### PR TITLE
[codex] Prevent OpenCode WAL watcher feedback loop

### DIFF
--- a/internal/parser/antigravity.go
+++ b/internal/parser/antigravity.go
@@ -81,7 +81,7 @@ func (p *antigravityProvider) parseSession(
 
 	// Open read-only; SQLite session files have WAL/SHM
 	// sidecars that the driver expects in the same dir.
-	dsn := "file:" + path + "?mode=ro&immutable=0"
+	dsn := "file:" + sqliteURIPath(path) + "?mode=ro&immutable=0"
 	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf(

--- a/internal/parser/antigravity_cli.go
+++ b/internal/parser/antigravity_cli.go
@@ -310,7 +310,7 @@ func (p *antigravityCLIProvider) parseSessionWithStatus(
 func loadAntigravityCLIDBSteps(
 	path string,
 ) (antigravityStepLoadResult, error) {
-	dsn := "file:" + path + "?mode=ro&immutable=0"
+	dsn := "file:" + sqliteURIPath(path) + "?mode=ro&immutable=0"
 	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {
 		return antigravityStepLoadResult{}, fmt.Errorf(

--- a/internal/parser/hermes.go
+++ b/internal/parser/hermes.go
@@ -553,7 +553,7 @@ func hermesStatePaths(root string) (stateDB, sessionsDir string, ok bool) {
 func (p *hermesProvider) parseStateDB(
 	stateDB, sessionsDir, project, machine string,
 ) ([]ParseResult, error) {
-	conn, err := sql.Open("sqlite3", "file:"+stateDB+"?mode=ro")
+	conn, err := sql.Open("sqlite3", "file:"+sqliteURIPath(stateDB)+"?mode=ro")
 	if err != nil {
 		return nil, fmt.Errorf("open hermes state db: %w", err)
 	}

--- a/internal/parser/hermes_provider.go
+++ b/internal/parser/hermes_provider.go
@@ -268,7 +268,7 @@ func (s hermesSourceSet) FindSource(
 }
 
 func hermesStateDBHasSession(stateDB string, rawID string) (bool, error) {
-	conn, err := sql.Open("sqlite3", "file:"+stateDB+"?mode=ro")
+	conn, err := sql.Open("sqlite3", "file:"+sqliteURIPath(stateDB)+"?mode=ro")
 	if err != nil {
 		return false, fmt.Errorf("open hermes state db: %w", err)
 	}

--- a/internal/parser/opencode.go
+++ b/internal/parser/opencode.go
@@ -213,8 +213,8 @@ func parseOpenCodeStorageFile(
 }
 
 func openOpenCodeDB(dbPath string) (*sql.DB, error) {
-	dsn := dbPath +
-		"?mode=ro&_journal_mode=WAL&_busy_timeout=3000"
+	dsn := "file:" + dbPath +
+		"?mode=ro&_busy_timeout=3000"
 	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {
 		return nil, fmt.Errorf(

--- a/internal/parser/opencode.go
+++ b/internal/parser/opencode.go
@@ -213,7 +213,7 @@ func parseOpenCodeStorageFile(
 }
 
 func openOpenCodeDB(dbPath string) (*sql.DB, error) {
-	dsn := "file:" + dbPath +
+	dsn := "file:" + sqliteURIPath(dbPath) +
 		"?mode=ro&_busy_timeout=3000"
 	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {

--- a/internal/parser/opencode_provider.go
+++ b/internal/parser/opencode_provider.go
@@ -12,6 +12,13 @@ import (
 
 var _ Provider = (*openCodeFormatProvider)(nil)
 
+// A SQLite WAL begins with a 32-byte header. Bytes beyond the header are
+// transaction frames, so a larger WAL can contain source changes worth
+// syncing. Read-only SQLite connections may create an empty WAL and its SHM
+// index simply by opening a quiet WAL-mode database; those sidecars must not
+// make the watcher trigger itself.
+const sqliteWALHeaderSize = int64(32)
+
 type openCodeFormatProviderFactory struct {
 	def  AgentDef
 	spec openCodeProviderSpec
@@ -350,7 +357,7 @@ func (s openCodeFormatSourceSet) WatchPlan(context.Context) (WatchPlan, error) {
 				IncludeGlobs: []string{
 					"*.json",
 					s.spec.dbName,
-					s.spec.dbName + "-*",
+					s.spec.dbName + "-wal",
 				},
 				DebounceKey: string(s.spec.agent) + ":opencode:" + watchRoot,
 			})
@@ -545,8 +552,27 @@ func (s openCodeFormatSourceSet) sourcesForChangedPathInRoot(
 	if !ok {
 		return nil, false, nil
 	}
-	base := filepath.Base(rel)
-	if rel == s.spec.dbName || strings.HasPrefix(base, s.spec.dbName+"-") {
+	isSQLiteChange := true
+	switch rel {
+	case s.spec.dbName + "-shm":
+		// SHM is only SQLite's WAL index. WAL frames (or the checkpointed main
+		// database) carry the source changes, so SHM events are redundant.
+		return nil, true, nil
+	case s.spec.dbName + "-wal":
+		// A read-only connection can create an empty WAL while inspecting a
+		// quiet database. Ignore it, as well as WAL removal after a checkpoint;
+		// the corresponding main-database write is watched separately.
+		if !sqliteWALHasFrames(path) {
+			return nil, true, nil
+		}
+	case s.spec.dbName:
+		// The main database and WALs with transaction frames both fan out to
+		// the logical sessions stored in this shared SQLite container.
+	default:
+		isSQLiteChange = false
+	}
+
+	if isSQLiteChange {
 		dbPath := filepath.Join(root, s.spec.dbName)
 		if !IsRegularFile(dbPath) {
 			return nil, true, nil
@@ -638,6 +664,12 @@ func (s openCodeFormatSourceSet) sourcesForChangedPathInRoot(
 		return []SourceRef{source}, true, nil
 	}
 	return nil, false, nil
+}
+
+func sqliteWALHasFrames(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.Mode().IsRegular() &&
+		info.Size() > sqliteWALHeaderSize
 }
 
 func (s openCodeFormatSourceSet) sourceForRawID(root, sessionID string) (SourceRef, bool) {

--- a/internal/parser/opencode_provider.go
+++ b/internal/parser/opencode_provider.go
@@ -668,8 +668,10 @@ func (s openCodeFormatSourceSet) sourcesForChangedPathInRoot(
 
 func sqliteWALHasFrames(path string) bool {
 	info, err := os.Stat(path)
-	return err == nil && info.Mode().IsRegular() &&
-		info.Size() > sqliteWALHeaderSize
+	if err != nil || info == nil {
+		return false
+	}
+	return info.Mode().IsRegular() && info.Size() > sqliteWALHeaderSize
 }
 
 func (s openCodeFormatSourceSet) sourceForRawID(root, sessionID string) (SourceRef, bool) {

--- a/internal/parser/opencode_provider.go
+++ b/internal/parser/opencode_provider.go
@@ -3,7 +3,9 @@ package parser
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
@@ -668,7 +670,13 @@ func (s openCodeFormatSourceSet) sourcesForChangedPathInRoot(
 
 func sqliteWALHasFrames(path string) bool {
 	info, err := os.Stat(path)
-	if err != nil || info == nil {
+	if err != nil {
+		// Only a missing WAL is a definitive no-op. Other stat failures fail
+		// open so a real update is synced instead of silently dropped; at
+		// worst that costs one redundant sync.
+		return !errors.Is(err, fs.ErrNotExist)
+	}
+	if info == nil {
 		return false
 	}
 	return info.Mode().IsRegular() && info.Size() > sqliteWALHeaderSize

--- a/internal/parser/opencode_provider_test.go
+++ b/internal/parser/opencode_provider_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -230,6 +231,27 @@ func TestOpenCodeProviderIgnoresNonDataSQLiteSidecars(t *testing.T) {
 			assert.Empty(t, changed)
 		})
 	}
+}
+
+func TestSQLiteWALHasFramesFailsOpenOnStatError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory-permission stat failures are not portable to Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+
+	locked := filepath.Join(t.TempDir(), "locked")
+	require.NoError(t, os.Mkdir(locked, 0o700))
+	walPath := filepath.Join(locked, "opencode.db-wal")
+	require.NoError(t, os.WriteFile(walPath, make([]byte, 64), 0o600))
+	require.NoError(t, os.Chmod(locked, 0o000))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chmod(locked, 0o700))
+	})
+
+	assert.True(t, sqliteWALHasFrames(walPath),
+		"stat errors other than not-exist must fail open so real WAL updates are not dropped")
 }
 
 func TestOpenCodeProviderReadsLiveSQLiteWAL(t *testing.T) {

--- a/internal/parser/opencode_provider_test.go
+++ b/internal/parser/opencode_provider_test.go
@@ -130,20 +130,21 @@ func TestOpenCodeProviderSQLiteSourceMethods(t *testing.T) {
 	require.Len(t, plan.Roots, 1)
 	assert.Equal(t, root, plan.Roots[0].Path)
 	assert.True(t, plan.Roots[0].Recursive)
+	assert.Equal(t, []string{
+		"*.json", "opencode.db", "opencode.db-wal",
+	}, plan.Roots[0].IncludeGlobs)
 
 	discovered, err := provider.Discover(context.Background())
 	require.NoError(t, err)
 	requireSourcePathsMatch(t, discovered, fixture.AllVirtualPaths)
 	requireContainsSourcePath(t, discovered, virtualPath)
 
-	for _, path := range []string{dbPath, dbPath + "-wal"} {
-		changed, err := provider.SourcesForChangedPath(
-			context.Background(),
-			ChangedPathRequest{Path: path, EventKind: "write", WatchRoot: root},
-		)
-		require.NoError(t, err)
-		requireSourcePathsMatch(t, changed, fixture.AllVirtualPaths)
-	}
+	changed, err := provider.SourcesForChangedPath(
+		context.Background(),
+		ChangedPathRequest{Path: dbPath, EventKind: "write", WatchRoot: root},
+	)
+	require.NoError(t, err)
+	requireSourcePathsMatch(t, changed, fixture.AllVirtualPaths)
 
 	found, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
 		FullSessionID: "host~opencode:" + fixture.TargetSessionID,
@@ -182,6 +183,95 @@ func TestOpenCodeProviderSQLiteSourceMethods(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.Empty(t, removed, "removed sqlite DBs have no stateless virtual source list")
+}
+
+func TestOpenCodeProviderIgnoresNonDataSQLiteSidecars(t *testing.T) {
+	tests := []struct {
+		name      string
+		suffix    string
+		create    bool
+		size      int
+		remove    bool
+		eventKind string
+	}{
+		{name: "missing WAL", suffix: "-wal", eventKind: "remove"},
+		{name: "empty WAL", suffix: "-wal", create: true, eventKind: "write"},
+		{name: "partial WAL", suffix: "-wal", create: true, size: 3, eventKind: "write"},
+		{name: "header-only WAL", suffix: "-wal", create: true, size: 32, eventKind: "write"},
+		{name: "removed WAL", suffix: "-wal", create: true, size: 64, remove: true, eventKind: "remove"},
+		{name: "SHM", suffix: "-shm", create: true, size: 32 * 1024, eventKind: "write"},
+		{name: "unknown sidecar", suffix: "-backup", create: true, size: 64, eventKind: "write"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := openCodeSQLiteProviderReadFixture(t)
+			path := fixture.DBPath + tc.suffix
+			if tc.create {
+				require.NoError(t, os.WriteFile(path, make([]byte, tc.size), 0o600))
+			}
+			if tc.remove {
+				require.NoError(t, os.Remove(path))
+			}
+
+			provider, ok := NewProvider(AgentOpenCode, ProviderConfig{
+				Roots: []string{fixture.Root},
+			})
+			require.True(t, ok)
+			changed, err := provider.SourcesForChangedPath(
+				context.Background(),
+				ChangedPathRequest{
+					Path:      path,
+					EventKind: tc.eventKind,
+					WatchRoot: fixture.Root,
+				},
+			)
+			require.NoError(t, err)
+			assert.Empty(t, changed)
+		})
+	}
+}
+
+func TestOpenCodeProviderReadsLiveSQLiteWAL(t *testing.T) {
+	dbPath, seeder, writer := newTestDB(t)
+	defer writer.Close()
+
+	var journalMode string
+	require.NoError(t, writer.QueryRow("PRAGMA journal_mode=WAL").Scan(&journalMode))
+	require.Equal(t, "wal", journalMode)
+	_, err := writer.Exec("PRAGMA wal_autocheckpoint=0")
+	require.NoError(t, err)
+	seedStandardSession(t, seeder)
+
+	walPath := dbPath + "-wal"
+	walInfo, err := os.Stat(walPath)
+	require.NoError(t, err)
+	require.Greater(t, walInfo.Size(), sqliteWALHeaderSize)
+
+	provider, ok := NewProvider(AgentOpenCode, ProviderConfig{
+		Roots:   []string{filepath.Dir(dbPath)},
+		Machine: "devbox",
+	})
+	require.True(t, ok)
+	changed, err := provider.SourcesForChangedPath(
+		context.Background(),
+		ChangedPathRequest{
+			Path:      walPath,
+			EventKind: "write",
+			WatchRoot: filepath.Dir(dbPath),
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, changed, 1)
+
+	outcome, err := provider.Parse(context.Background(), ParseRequest{
+		Source: changed[0],
+	})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	assert.Equal(t, "opencode:ses_abc", outcome.Results[0].Result.Session.ID)
+	assert.Equal(t, "Sure, I can help with Go.",
+		outcome.Results[0].Result.Messages[1].Content)
 }
 
 // TestOpenCodeProviderSQLiteDiscoversAllListedSessions guards the refactor that

--- a/internal/parser/opencode_test.go
+++ b/internal/parser/opencode_test.go
@@ -259,6 +259,23 @@ func TestParseOpenCodeDB_StandardSession(t *testing.T) {
 	assertEq(t, "msg[1].Content", s.Messages[1].Content, "Sure, I can help with Go.")
 }
 
+func TestOpenOpenCodeDBDoesNotForceWALMode(t *testing.T) {
+	dbPath, _, writer := newTestDB(t)
+	require.NoError(t, writer.Close())
+
+	reader, err := openOpenCodeDB(dbPath)
+	require.NoError(t, err)
+	defer reader.Close()
+	_, err = reader.Exec("CREATE TABLE must_stay_read_only (id INTEGER)")
+	require.Error(t, err, "OpenCode source databases must stay read-only")
+
+	var journalMode string
+	require.NoError(t, reader.QueryRow("PRAGMA journal_mode").Scan(&journalMode))
+	assert.Equal(t, "delete", journalMode)
+	assert.NoFileExists(t, dbPath+"-wal")
+	assert.NoFileExists(t, dbPath+"-shm")
+}
+
 func TestParseOpenCodeFile_StorageSession(t *testing.T) {
 	root := t.TempDir()
 	sessionPath := filepath.Join(

--- a/internal/parser/piebald.go
+++ b/internal/parser/piebald.go
@@ -94,7 +94,7 @@ func parsePiebaldSessionResults(dbPath, chatID, machine string) ([]ParseResult, 
 }
 
 func openPiebaldDB(dbPath string) (*sql.DB, error) {
-	dsn := "file:" + dbPath + "?mode=ro&_busy_timeout=3000"
+	dsn := "file:" + sqliteURIPath(dbPath) + "?mode=ro&_busy_timeout=3000"
 	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("opening piebald db %s: %w", dbPath, err)

--- a/internal/parser/sqlite_dsn.go
+++ b/internal/parser/sqlite_dsn.go
@@ -1,0 +1,16 @@
+package parser
+
+import "strings"
+
+// sqliteURIPath escapes a filesystem path for use in a SQLite file: URI.
+// SQLite percent-decodes URI paths and stops parsing them at '?' or '#',
+// and go-sqlite3 splits its driver parameters at the first '?', so these
+// characters in a real path would open the wrong file or silently drop
+// options such as mode=ro.
+func sqliteURIPath(path string) string {
+	return strings.NewReplacer(
+		"%", "%25",
+		"?", "%3F",
+		"#", "%23",
+	).Replace(path)
+}

--- a/internal/parser/sqlite_dsn_test.go
+++ b/internal/parser/sqlite_dsn_test.go
@@ -1,0 +1,60 @@
+package parser
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSQLiteURIPath(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "plain", in: "/data/opencode.db", want: "/data/opencode.db"},
+		{name: "hash", in: "/data/pro#ject/x.db", want: "/data/pro%23ject/x.db"},
+		{name: "question mark", in: "/data/a?b/x.db", want: "/data/a%3Fb/x.db"},
+		{name: "percent", in: "/data/100%/x.db", want: "/data/100%25/x.db"},
+		{
+			name: "percent sequence stays literal",
+			in:   "/data/a%3Fb/x.db",
+			want: "/data/a%253Fb/x.db",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, sqliteURIPath(tc.in))
+		})
+	}
+}
+
+func TestOpenSQLiteWithSpecialCharPath(t *testing.T) {
+	// '#' would end the URI path (dropping mode=ro into the fragment) and
+	// '%41' would percent-decode to 'A' if the path were not escaped.
+	dir := filepath.Join(t.TempDir(), "pro#ject %41")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	dbPath := filepath.Join(dir, "opencode.db")
+
+	writer, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = writer.Exec("CREATE TABLE t (x INTEGER); INSERT INTO t VALUES (1)")
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	db, err := openOpenCodeDB(dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	var n int
+	require.NoError(t, db.QueryRow("SELECT count(*) FROM t").Scan(&n))
+	assert.Equal(t, 1, n)
+
+	_, err = db.Exec("INSERT INTO t VALUES (2)")
+	require.Error(t, err, "mode=ro must survive special characters in the path")
+}

--- a/internal/parser/zed.go
+++ b/internal/parser/zed.go
@@ -154,7 +154,7 @@ func OpenZedDB(dbPath string) (*sql.DB, error) {
 }
 
 func openZedDB(dbPath string) (*sql.DB, error) {
-	dsn := "file:" + dbPath + "?mode=ro&immutable=0&_busy_timeout=3000"
+	dsn := "file:" + sqliteURIPath(dbPath) + "?mode=ro&immutable=0&_busy_timeout=3000"
 	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("opening zed db %s: %w", dbPath, err)

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -3158,9 +3158,11 @@ func TestEngine_ClassifyPathsOpenCodeSQLiteWALFile(
 	})
 
 	dbPath := filepath.Join(opencodeDir, "opencode.db")
-	seedOpenCodeSQLiteSession(t, dbPath, "ses_wal")
+	seedOpenCodeSQLiteWALSession(t, dbPath, "ses_wal")
 	walPath := filepath.Join(opencodeDir, "opencode.db-wal")
-	require.NoError(t, os.WriteFile(walPath, []byte("wal"), 0o644), "WriteFile(%q)", walPath)
+	walInfo, err := os.Stat(walPath)
+	require.NoError(t, err, "Stat(%q)", walPath)
+	require.Greater(t, walInfo.Size(), int64(32), "WAL must contain transaction frames")
 
 	files := engine.classifyPaths([]string{walPath})
 	require.Len(t, files, 1)
@@ -3171,9 +3173,11 @@ func TestEngine_ClassifyPathsOpenCodeSQLiteWALFile(
 	assert.Equal(t, parser.AgentOpenCode, files[0].Agent)
 }
 
-// seedOpenCodeSQLiteSession creates a minimal OpenCode-shaped SQLite database
-// with a single session row so changed-path classification can enumerate it.
-func seedOpenCodeSQLiteSession(t *testing.T, dbPath, sessionID string) {
+// seedOpenCodeSQLiteWALSession creates a minimal OpenCode-shaped SQLite
+// database and keeps its writer open with the session commit held in the WAL.
+// This exercises the same uncheckpointed state produced by a live OpenCode
+// process rather than using a synthetic sidecar that SQLite cannot read.
+func seedOpenCodeSQLiteWALSession(t *testing.T, dbPath, sessionID string) {
 	t.Helper()
 	d, err := sql.Open("sqlite3", dbPath)
 	require.NoError(t, err, "open opencode db")
@@ -3203,6 +3207,11 @@ func seedOpenCodeSQLiteSession(t *testing.T, dbPath, sessionID string) {
 		);
 	`)
 	require.NoError(t, err, "create opencode schema")
+	var journalMode string
+	require.NoError(t, d.QueryRow("PRAGMA journal_mode=WAL").Scan(&journalMode))
+	require.Equal(t, "wal", journalMode)
+	_, err = d.Exec("PRAGMA wal_autocheckpoint=0")
+	require.NoError(t, err, "disable WAL autocheckpoint")
 	_, err = d.Exec(
 		"INSERT INTO project (id, worktree) VALUES ('prj_1', '/home/user/code/app')",
 	)


### PR DESCRIPTION
Closes #955.

OpenCode-family SQLite readers now use a real read-only file URI and no longer request a journal-mode change while inspecting source databases. Changed-path classification ignores WAL-index (`-shm`) events and empty, header-only, removed, or otherwise non-data WAL lifecycle events, while retaining main-database and data-bearing WAL updates.

This prevents AgentsView's own read connections from recursively fanning one sidecar event out to every SQLite-backed OpenCode session. Checkpointed WAL removal relies on the corresponding main-database write, and live uncheckpointed WAL frames remain visible to the parser.

The provider watch plan now declares only the main database and WAL data file. Regression coverage uses a real writer-held WAL to verify that committed frames are classified and readable, while transient sidecars remain bounded no-ops.
