### PR TITLE
ci(docker): add stable tag for tagged image releases

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,6 +60,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ steps.vars.outputs.image }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=stable,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=semver,pattern={{version}}
           labels: |
             org.opencontainers.image.title=agentsview


### PR DESCRIPTION
Anyone who wants to pin a deployment to "the latest released version" instead of tracking `main` commit-by-commit currently has nowhere to point. The Docker publishing workflow only produces `latest`, which moves on every push to `main` and can include unreleased work between tags, and exact semver tags like `v1.4.2`, which never move and require manually bumping the pin on every release. There is no tag whose meaning is "most recent tagged release," so `docker-compose.prod.yaml` and other consumers wanting release-only stability are stuck choosing between a moving branch build and hand-maintained version pins.

This change adds a single additive `stable` tag to `.github/workflows/docker.yml`'s existing `docker/metadata-action` configuration, enabled only when the workflow runs from a version tag push, the same trigger that already produces the semver tag. `latest` keeps its current behavior and continues to track `main` on every push; the new `stable` tag simply moves to point at whichever tagged release was published most recently. Nothing else in the workflow, the Dockerfile, or the build/push steps changes. `docker-compose.prod.yaml` is intentionally left on `latest`, so the documented default deployment path is unaffected; `stable` is an additive option for consumers who want to track releases rather than `main`.

The workflow YAML was validated for syntax locally, but actually publishing a `stable` tag to `ghcr.io/kenn-io/agentsview` on a real tag push can only be verified by the Docker workflow itself, so CI on this PR and on the next tagged release is the authoritative proof that the tag publishes as intended.

Fixes #923
