### PR TITLE
refactor(usage): derive unsupported usage from agent capabilities

### DIFF
--- a/cmd/agentsview/usage.go
+++ b/cmd/agentsview/usage.go
@@ -193,16 +193,20 @@ func runUsageDaily(cfg UsageDailyConfig) {
 }
 
 // noTokenDataNote returns a one-line stderr note for a zero usage result when
-// the user has filtered to a Copilot agent whose records do not include token
-// or cost data that agentsview can total. It returns "" when the filter is not
-// a Copilot agent or real token/cost data exists. This is an agent-property
-// statement (issue #349) shown in response to an explicit --agent the user
-// typed, so it needs no session-presence check; it is appropriate even for an
-// empty window.
+// the user has filtered to agents that do not record per-message token usage.
+// Current Copilot agents keep the Copilot-specific wording; other no-token
+// agents fall back to a generic note. It returns "" when the filter does not
+// select only no-token-data agents or real token/cost data exists. This is an
+// agent-property statement (issue #349) shown in response to an explicit
+// --agent the user typed, so it needs no session-presence check; it is
+// appropriate even for an empty window.
 func noTokenDataNote(agent string, totals db.UsageTotals) string {
 	if !parser.AgentFilterLacksPerMessageTokenData(agent) ||
 		!db.NoTokenData(totals) {
 		return ""
+	}
+	if !parser.AgentFilterUsesAICredits(agent) {
+		return "note: matching sessions do not record per-message token usage."
 	}
 	return "note: these GitHub Copilot records do not include token " +
 		"or cost data that agentsview can total."

--- a/cmd/agentsview/usage.go
+++ b/cmd/agentsview/usage.go
@@ -17,6 +17,7 @@ import (
 
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/pricing"
 	"go.kenn.io/agentsview/internal/sync"
 )
@@ -199,7 +200,8 @@ func runUsageDaily(cfg UsageDailyConfig) {
 // typed, so it needs no session-presence check; it is appropriate even for an
 // empty window.
 func noTokenDataNote(agent string, totals db.UsageTotals) string {
-	if !db.IsCopilotAgentFilter(agent) || !db.NoTokenData(totals) {
+	if !parser.AgentFilterLacksPerMessageTokenData(agent) ||
+		!db.NoTokenData(totals) {
 		return ""
 	}
 	return "note: these GitHub Copilot records do not include token " +

--- a/cmd/agentsview/usage.go
+++ b/cmd/agentsview/usage.go
@@ -19,6 +19,7 @@ import (
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/pricing"
+	"go.kenn.io/agentsview/internal/service"
 	"go.kenn.io/agentsview/internal/sync"
 )
 
@@ -194,9 +195,11 @@ func runUsageDaily(cfg UsageDailyConfig) {
 
 // noTokenDataNote returns a one-line stderr note for a zero usage result when
 // the user has filtered to agents that do not record per-message token usage.
-// Current Copilot agents keep the Copilot-specific wording; other no-token
-// agents fall back to a generic note. It returns "" when the filter does not
-// select only no-token-data agents or real token/cost data exists. This is an
+// The wording follows the service's unsupported-usage kind for the same
+// filter, so the CLI and the dashboard cannot drift: all-Copilot filters keep
+// the Copilot-specific wording and every other no-token filter gets the
+// generic note. It returns "" when the filter does not select only
+// no-token-data agents or real token/cost data exists. This is an
 // agent-property statement (issue #349) shown in response to an explicit
 // --agent the user typed, so it needs no session-presence check; it is
 // appropriate even for an empty window.
@@ -205,11 +208,12 @@ func noTokenDataNote(agent string, totals db.UsageTotals) string {
 		!db.NoTokenData(totals) {
 		return ""
 	}
-	if !parser.AgentFilterUsesAICredits(agent) {
-		return "note: matching sessions do not record per-message token usage."
+	if service.UnsupportedUsageKindForAgentFilter(agent) ==
+		service.UnsupportedUsageKindCopilotNoTokenData {
+		return "note: these GitHub Copilot records do not include token " +
+			"or cost data that agentsview can total."
 	}
-	return "note: these GitHub Copilot records do not include token " +
-		"or cost data that agentsview can total."
+	return "note: matching sessions do not record per-message token usage."
 }
 
 type UsageStatuslineConfig struct {

--- a/cmd/agentsview/usage_test.go
+++ b/cmd/agentsview/usage_test.go
@@ -1231,13 +1231,23 @@ func TestRunUsageDailyNoHintWhenDataPresent(t *testing.T) {
 }
 
 func TestNoTokenDataNote(t *testing.T) {
-	parsertest.StubAgentDefs(t, parser.AgentDef{
-		Type:        parser.AgentType("no-token-agent"),
-		DisplayName: "No Token Agent",
-		Usage: parser.UsageCapabilities{
-			NoPerMessageTokenData: true,
+	parsertest.StubAgentDefs(t,
+		parser.AgentDef{
+			Type:        parser.AgentType("no-token-agent"),
+			DisplayName: "No Token Agent",
+			Usage: parser.UsageCapabilities{
+				NoPerMessageTokenData: true,
+			},
 		},
-	})
+		parser.AgentDef{
+			Type:        parser.AgentType("credit-note-agent"),
+			DisplayName: "Credit Note Agent",
+			Usage: parser.UsageCapabilities{
+				NoPerMessageTokenData: true,
+				AICreditsDenominated:  true,
+			},
+		},
+	)
 
 	zero := db.UsageTotals{}
 	withData := db.UsageTotals{OutputTokens: 5}
@@ -1257,6 +1267,7 @@ func TestNoTokenDataNote(t *testing.T) {
 		{"vscode-copilot with zero totals", "vscode-copilot", zero, copilotNote},
 		{"all-copilot CSV filter", "copilot,vscode-copilot", zero, copilotNote},
 		{"non-copilot no-token agent", "no-token-agent", zero, genericNote},
+		{"non-copilot ai-credit agent", "credit-note-agent", zero, genericNote},
 		{"mixed CSV filter", "copilot,claude", zero, ""},
 	}
 	for _, tc := range cases {

--- a/cmd/agentsview/usage_test.go
+++ b/cmd/agentsview/usage_test.go
@@ -19,6 +19,7 @@ import (
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/dbtest"
 	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/parsertest"
 	"go.kenn.io/agentsview/internal/pricing"
 )
 
@@ -1230,13 +1231,13 @@ func TestRunUsageDailyNoHintWhenDataPresent(t *testing.T) {
 }
 
 func TestNoTokenDataNote(t *testing.T) {
-	defer withUsageParserAgentDefs(t, parser.AgentDef{
+	parsertest.StubAgentDefs(t, parser.AgentDef{
 		Type:        parser.AgentType("no-token-agent"),
 		DisplayName: "No Token Agent",
 		Usage: parser.UsageCapabilities{
 			NoPerMessageTokenData: true,
 		},
-	})()
+	})
 
 	zero := db.UsageTotals{}
 	withData := db.UsageTotals{OutputTokens: 5}
@@ -1263,14 +1264,5 @@ func TestNoTokenDataNote(t *testing.T) {
 			assert.Equal(t, tc.want,
 				noTokenDataNote(tc.agent, tc.totals))
 		})
-	}
-}
-
-func withUsageParserAgentDefs(t *testing.T, defs ...parser.AgentDef) func() {
-	t.Helper()
-	orig := append([]parser.AgentDef(nil), parser.Registry...)
-	parser.Registry = append(parser.Registry, defs...)
-	return func() {
-		parser.Registry = orig
 	}
 }

--- a/cmd/agentsview/usage_test.go
+++ b/cmd/agentsview/usage_test.go
@@ -18,6 +18,7 @@ import (
 	"go.kenn.io/agentsview/internal/cursorusage"
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/pricing"
 )
 
@@ -1229,10 +1230,19 @@ func TestRunUsageDailyNoHintWhenDataPresent(t *testing.T) {
 }
 
 func TestNoTokenDataNote(t *testing.T) {
+	defer withUsageParserAgentDefs(t, parser.AgentDef{
+		Type:        parser.AgentType("no-token-agent"),
+		DisplayName: "No Token Agent",
+		Usage: parser.UsageCapabilities{
+			NoPerMessageTokenData: true,
+		},
+	})()
+
 	zero := db.UsageTotals{}
 	withData := db.UsageTotals{OutputTokens: 5}
 	copilotNote := "note: these GitHub Copilot records do not include token " +
 		"or cost data that agentsview can total."
+	genericNote := "note: matching sessions do not record per-message token usage."
 	cases := []struct {
 		name   string
 		agent  string
@@ -1245,6 +1255,7 @@ func TestNoTokenDataNote(t *testing.T) {
 		{"copilot with zero totals", "copilot", zero, copilotNote},
 		{"vscode-copilot with zero totals", "vscode-copilot", zero, copilotNote},
 		{"all-copilot CSV filter", "copilot,vscode-copilot", zero, copilotNote},
+		{"non-copilot no-token agent", "no-token-agent", zero, genericNote},
 		{"mixed CSV filter", "copilot,claude", zero, ""},
 	}
 	for _, tc := range cases {
@@ -1252,5 +1263,14 @@ func TestNoTokenDataNote(t *testing.T) {
 			assert.Equal(t, tc.want,
 				noTokenDataNote(tc.agent, tc.totals))
 		})
+	}
+}
+
+func withUsageParserAgentDefs(t *testing.T, defs ...parser.AgentDef) func() {
+	t.Helper()
+	orig := append([]parser.AgentDef(nil), parser.Registry...)
+	parser.Registry = append(parser.Registry, defs...)
+	return func() {
+		parser.Registry = orig
 	}
 }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -720,7 +720,7 @@
   "usage_summary_total_cost": "Total Cost",
   "usage_summary_copilot_ai_credits": "Copilot AI Credits",
   "usage_summary_unsupported_copilot_no_token_data": "Copilot sessions matched this range, but Copilot does not record per-message token usage.",
-  "usage_summary_unsupported_generic": "Some matching sessions do not expose token usage data.",
+  "usage_summary_unsupported_generic": "Matching sessions do not expose token usage data.",
   "usage_summary_input_tokens": "Input Tokens",
   "usage_summary_daily_burn": "Daily Burn",
   "usage_summary_peak_day": "Peak Day",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -720,6 +720,7 @@
   "usage_summary_total_cost": "Total Cost",
   "usage_summary_copilot_ai_credits": "Copilot AI Credits",
   "usage_summary_unsupported_copilot_no_token_data": "Copilot sessions matched this range, but Copilot does not record per-message token usage.",
+  "usage_summary_unsupported_generic": "Some matching sessions do not expose token usage data.",
   "usage_summary_input_tokens": "Input Tokens",
   "usage_summary_daily_burn": "Daily Burn",
   "usage_summary_peak_day": "Peak Day",

--- a/frontend/messages/zh-CN.json
+++ b/frontend/messages/zh-CN.json
@@ -1603,7 +1603,7 @@
   "usage_pairwise_cost_per_session": "每会话成本",
   "usage_pairwise_total_tokens": "总 Token",
   "usage_pairwise_tokens_per_session": "每会话 Token",
-  "usage_summary_unsupported_generic": "部分匹配会话未提供 token 用量数据。",
+  "usage_summary_unsupported_generic": "匹配会话未提供 token 用量数据。",
   "usage_copilot_credits": "Copilot AI 积分",
   "usage_input_tokens": "输入 Token",
   "usage_cached_suffix": "+{tokens} 已缓存",

--- a/frontend/messages/zh-CN.json
+++ b/frontend/messages/zh-CN.json
@@ -1603,6 +1603,7 @@
   "usage_pairwise_cost_per_session": "每会话成本",
   "usage_pairwise_total_tokens": "总 Token",
   "usage_pairwise_tokens_per_session": "每会话 Token",
+  "usage_summary_unsupported_generic": "部分匹配会话未提供 token 用量数据。",
   "usage_copilot_credits": "Copilot AI 积分",
   "usage_input_tokens": "输入 Token",
   "usage_cached_suffix": "+{tokens} 已缓存",

--- a/frontend/messages/zh-TW.json
+++ b/frontend/messages/zh-TW.json
@@ -1603,6 +1603,7 @@
   "usage_pairwise_cost_per_session": "每會話成本",
   "usage_pairwise_total_tokens": "總 Token",
   "usage_pairwise_tokens_per_session": "每會話 Token",
+  "usage_summary_unsupported_generic": "部分匹配工作階段未提供 token 用量資料。",
   "usage_copilot_credits": "Copilot AI 積分",
   "usage_input_tokens": "輸入 Token",
   "usage_cached_suffix": "+{tokens} 已緩存",

--- a/frontend/messages/zh-TW.json
+++ b/frontend/messages/zh-TW.json
@@ -1603,7 +1603,7 @@
   "usage_pairwise_cost_per_session": "每會話成本",
   "usage_pairwise_total_tokens": "總 Token",
   "usage_pairwise_tokens_per_session": "每會話 Token",
-  "usage_summary_unsupported_generic": "部分匹配工作階段未提供 token 用量資料。",
+  "usage_summary_unsupported_generic": "匹配工作階段未提供 token 用量資料。",
   "usage_copilot_credits": "Copilot AI 積分",
   "usage_input_tokens": "輸入 Token",
   "usage_cached_suffix": "+{tokens} 已緩存",

--- a/frontend/src/lib/components/usage/UsagePage.svelte
+++ b/frontend/src/lib/components/usage/UsagePage.svelte
@@ -127,6 +127,9 @@
     if (kind === "copilot-no-token-data") {
       return m.usage_summary_unsupported_copilot_no_token_data();
     }
+    if (kind) {
+      return m.usage_summary_unsupported_generic();
+    }
     return "";
   });
   const sessionUrlParams = $derived(

--- a/frontend/src/lib/components/usage/UsagePage.test.ts
+++ b/frontend/src/lib/components/usage/UsagePage.test.ts
@@ -132,7 +132,7 @@ describe("UsagePage refresh behavior", () => {
     await flushEffects();
 
     expect(document.body.textContent).toContain(
-      "Some matching sessions do not expose token usage data",
+      "Matching sessions do not expose token usage data",
     );
     expect(document.body.textContent).not.toContain(
       "Copilot sessions matched this range",

--- a/frontend/src/lib/components/usage/UsagePage.test.ts
+++ b/frontend/src/lib/components/usage/UsagePage.test.ts
@@ -114,6 +114,31 @@ describe("UsagePage refresh behavior", () => {
     );
   });
 
+  it("renders a generic unsupported usage note for unknown kinds", async () => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        disconnect() {}
+      },
+    );
+    vi.spyOn(usage, "fetchAll").mockResolvedValue();
+
+    router.route = "usage";
+    router.params = {};
+    usage.summary = usageSummaryWithUnsupported("future-no-token-data");
+
+    component = mount(UsagePage, { target: document.body });
+    await flushEffects();
+
+    expect(document.body.textContent).toContain(
+      "Some matching sessions do not expose token usage data",
+    );
+    expect(document.body.textContent).not.toContain(
+      "Copilot sessions matched this range",
+    );
+  });
+
   it("does not auto-refresh usage scans from SSE updates", () => {
     expect(source).not.toContain("subscribeDebounced");
     expect(source).not.toContain("REFRESH_MS");

--- a/internal/db/usage.go
+++ b/internal/db/usage.go
@@ -11,33 +11,9 @@ import (
 	"strings"
 	"time"
 
+	"go.kenn.io/agentsview/internal/parser"
 	pricingpkg "go.kenn.io/agentsview/internal/pricing"
 )
-
-func IsCopilotAgent(agent string) bool {
-	return agent == "copilot" || agent == "vscode-copilot" || agent == "visualstudio-copilot"
-}
-
-// IsCopilotAgentFilter reports whether a (possibly comma-separated) agent
-// filter selects only Copilot agents — every non-empty entry is a Copilot
-// agent and there is at least one. The Usage agent filter supports
-// comma-separated lists (e.g. "copilot,vscode-copilot"), so the no-token-data
-// hint must treat such a list as Copilot rather than exact-matching the raw
-// string.
-func IsCopilotAgentFilter(agentFilter string) bool {
-	matched := false
-	for part := range strings.SplitSeq(agentFilter, ",") {
-		part = strings.TrimSpace(part)
-		if part == "" {
-			continue
-		}
-		if !IsCopilotAgent(part) {
-			return false
-		}
-		matched = true
-	}
-	return matched
-}
 
 // NoTokenData reports whether a daily-usage total carries neither token
 // data nor cost: every token counter, the cost total, and any Copilot AI
@@ -1855,7 +1831,7 @@ func (db *DB) GetDailyUsage(
 
 		var copilotCost float64
 		for key, b := range accum {
-			if IsCopilotAgent(key.agent) {
+			if parser.AgentNameUsesAICredits(key.agent) {
 				copilotCost += b.cost
 			}
 		}
@@ -2031,7 +2007,7 @@ func (db *DB) GetDailyUsage(
 	var copilotCost float64
 	for _, d := range daily {
 		for _, ab := range d.AgentBreakdowns {
-			if IsCopilotAgent(ab.Agent) {
+			if parser.AgentNameUsesAICredits(ab.Agent) {
 				copilotCost += ab.Cost
 			}
 		}
@@ -2345,7 +2321,7 @@ func (db *DB) GetSessionUsage(
 	if out.HasCost {
 		out.CostUSD = cost
 	}
-	if IsCopilotAgent(sess.Agent) && out.HasCost {
+	if parser.AgentNameUsesAICredits(sess.Agent) && out.HasCost {
 		out.AICredits = cost / 0.01
 	}
 	if len(unpricedSet) > 0 {

--- a/internal/db/usage.go
+++ b/internal/db/usage.go
@@ -15,6 +15,22 @@ import (
 	pricingpkg "go.kenn.io/agentsview/internal/pricing"
 )
 
+// aiCreditUSD is the USD value of one AI credit for agents whose cost
+// is denominated in AI credits (the AICreditsDenominated capability).
+const aiCreditUSD = 0.01
+
+// AICreditsFromCost converts a USD cost into AI credits when the
+// agent's cost is denominated in AI credits, and returns 0 otherwise.
+// It is the single home of the credit conversion shared by the SQLite,
+// PostgreSQL, and DuckDB usage paths; a per-agent credit rate would
+// slot in here rather than at each accumulation site.
+func AICreditsFromCost(agent string, costUSD float64) float64 {
+	if costUSD == 0 || !parser.AgentNameUsesAICredits(agent) {
+		return 0
+	}
+	return costUSD / aiCreditUSD
+}
+
 // NoTokenData reports whether a daily-usage total carries neither token
 // data nor cost: every token counter, the cost total, and any Copilot AI
 // credits are zero. It distinguishes a window whose sessions simply do not
@@ -1829,14 +1845,12 @@ func (db *DB) GetDailyUsage(
 		}
 		totals.CacheSavings = totalSavings
 
-		var aiCreditCost float64
+		var aiCredits float64
 		for key, b := range accum {
-			if parser.AgentNameUsesAICredits(key.agent) {
-				aiCreditCost += b.cost
-			}
+			aiCredits += AICreditsFromCost(key.agent, b.cost)
 		}
-		if aiCreditCost > 0 {
-			totals.CopilotAICredits = aiCreditCost / 0.01
+		if aiCredits > 0 {
+			totals.CopilotAICredits = aiCredits
 		}
 		var sessionCounts UsageSessionCounts
 		if seenSessions != nil {
@@ -2004,16 +2018,14 @@ func (db *DB) GetDailyUsage(
 
 	totals.CacheSavings = totalSavings
 
-	var aiCreditCost float64
+	var aiCredits float64
 	for _, d := range daily {
 		for _, ab := range d.AgentBreakdowns {
-			if parser.AgentNameUsesAICredits(ab.Agent) {
-				aiCreditCost += ab.Cost
-			}
+			aiCredits += AICreditsFromCost(ab.Agent, ab.Cost)
 		}
 	}
-	if aiCreditCost > 0 {
-		totals.CopilotAICredits = aiCreditCost / 0.01
+	if aiCredits > 0 {
+		totals.CopilotAICredits = aiCredits
 	}
 
 	var sessionCounts UsageSessionCounts
@@ -2320,9 +2332,7 @@ func (db *DB) GetSessionUsage(
 	}
 	if out.HasCost {
 		out.CostUSD = cost
-	}
-	if parser.AgentNameUsesAICredits(sess.Agent) && out.HasCost {
-		out.AICredits = cost / 0.01
+		out.AICredits = AICreditsFromCost(sess.Agent, cost)
 	}
 	if len(unpricedSet) > 0 {
 		out.UnpricedModels = sortedSetKeys(unpricedSet)

--- a/internal/db/usage.go
+++ b/internal/db/usage.go
@@ -1829,14 +1829,14 @@ func (db *DB) GetDailyUsage(
 		}
 		totals.CacheSavings = totalSavings
 
-		var copilotCost float64
+		var aiCreditCost float64
 		for key, b := range accum {
 			if parser.AgentNameUsesAICredits(key.agent) {
-				copilotCost += b.cost
+				aiCreditCost += b.cost
 			}
 		}
-		if copilotCost > 0 {
-			totals.CopilotAICredits = copilotCost / 0.01
+		if aiCreditCost > 0 {
+			totals.CopilotAICredits = aiCreditCost / 0.01
 		}
 		var sessionCounts UsageSessionCounts
 		if seenSessions != nil {
@@ -2004,16 +2004,16 @@ func (db *DB) GetDailyUsage(
 
 	totals.CacheSavings = totalSavings
 
-	var copilotCost float64
+	var aiCreditCost float64
 	for _, d := range daily {
 		for _, ab := range d.AgentBreakdowns {
 			if parser.AgentNameUsesAICredits(ab.Agent) {
-				copilotCost += ab.Cost
+				aiCreditCost += ab.Cost
 			}
 		}
 	}
-	if copilotCost > 0 {
-		totals.CopilotAICredits = copilotCost / 0.01
+	if aiCreditCost > 0 {
+		totals.CopilotAICredits = aiCreditCost / 0.01
 	}
 
 	var sessionCounts UsageSessionCounts

--- a/internal/db/usage_no_token_data_test.go
+++ b/internal/db/usage_no_token_data_test.go
@@ -26,26 +26,3 @@ func TestNoTokenData(t *testing.T) {
 		})
 	}
 }
-
-func TestIsCopilotAgentFilter(t *testing.T) {
-	cases := []struct {
-		name   string
-		filter string
-		want   bool
-	}{
-		{"empty", "", false},
-		{"single copilot", "copilot", true},
-		{"vscode copilot", "vscode-copilot", true},
-		{"all-copilot CSV", "copilot,vscode-copilot,visualstudio-copilot", true},
-		{"CSV with spaces", " copilot , vscode-copilot ", true},
-		{"mixed CSV", "copilot,claude", false},
-		{"single non-copilot", "claude", false},
-		{"trailing comma", "copilot,", true},
-		{"only commas", ",", false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, IsCopilotAgentFilter(tc.filter))
-		})
-	}
-}

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -17,6 +17,7 @@ import (
 
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/parsertest"
 )
 
 var (
@@ -3317,13 +3318,13 @@ func TestGetSessionUsage_NotFound(t *testing.T) {
 }
 
 func TestGetSessionUsage_AICreditsCapability(t *testing.T) {
-	defer withParserAgentDefs(t, parser.AgentDef{
+	parsertest.StubAgentDefs(t, parser.AgentDef{
 		Type:        parser.AgentType("ai-credit-agent"),
 		DisplayName: "AI Credit Agent",
 		Usage: parser.UsageCapabilities{
 			AICreditsDenominated: true,
 		},
-	})()
+	})
 
 	d := testDB(t)
 	ctx := context.Background()
@@ -3354,13 +3355,13 @@ func TestGetSessionUsage_AICreditsCapability(t *testing.T) {
 // TestGetDailyUsage_CopilotAICredits verifies AI credits are computed from
 // agents with the parser AI-credit capability: costUSD / 0.01.
 func TestGetDailyUsage_CopilotAICredits(t *testing.T) {
-	defer withParserAgentDefs(t, parser.AgentDef{
+	parsertest.StubAgentDefs(t, parser.AgentDef{
 		Type:        parser.AgentType("ai-credit-agent"),
 		DisplayName: "AI Credit Agent",
 		Usage: parser.UsageCapabilities{
 			AICreditsDenominated: true,
 		},
-	})()
+	})
 
 	d := testDB(t)
 	ctx := context.Background()
@@ -3457,14 +3458,5 @@ func TestGetDailyUsage_CopilotAICredits(t *testing.T) {
 			assert.InDelta(t, wantCredits, result.Totals.CopilotAICredits,
 				1e-6, "CopilotAICredits")
 		})
-	}
-}
-
-func withParserAgentDefs(t *testing.T, defs ...parser.AgentDef) func() {
-	t.Helper()
-	orig := append([]parser.AgentDef(nil), parser.Registry...)
-	parser.Registry = append(parser.Registry, defs...)
-	return func() {
-		parser.Registry = orig
 	}
 }

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -3460,3 +3460,23 @@ func TestGetDailyUsage_CopilotAICredits(t *testing.T) {
 		})
 	}
 }
+
+func TestAICreditsFromCost(t *testing.T) {
+	cases := []struct {
+		name  string
+		agent string
+		cost  float64
+		want  float64
+	}{
+		{"copilot converts at a cent per credit", "copilot", 0.42, 42},
+		{"zero cost yields zero credits", "copilot", 0, 0},
+		{"non-credit agent yields zero", "claude", 3.5, 0},
+		{"unknown agent yields zero", "unknown-agent", 3.5, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.InDelta(t, tc.want,
+				AICreditsFromCost(tc.agent, tc.cost), 1e-9)
+		})
+	}
+}

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/parser"
 )
 
 var (
@@ -3315,9 +3316,52 @@ func TestGetSessionUsage_NotFound(t *testing.T) {
 	assert.Nil(t, u, "usage")
 }
 
-// TestGetDailyUsage_CopilotAICredits verifies AI credits are computed only
-// from priced Copilot usage: costUSD / 0.01.
+func TestGetSessionUsage_AICreditsCapability(t *testing.T) {
+	defer withParserAgentDefs(t, parser.AgentDef{
+		Type:        parser.AgentType("ai-credit-agent"),
+		DisplayName: "AI Credit Agent",
+		Usage: parser.UsageCapabilities{
+			AICreditsDenominated: true,
+		},
+	})()
+
+	d := testDB(t)
+	ctx := context.Background()
+	seedOpusPricing(t, d)
+
+	insertSession(t, d, "ai-credit-agent:s1", "proj", func(s *Session) {
+		s.Agent = "ai-credit-agent"
+		s.StartedAt = new("2026-05-20T10:00:00Z")
+	})
+	insertMessages(t, d, Message{
+		SessionID: "ai-credit-agent:s1",
+		Ordinal:   0,
+		Role:      "assistant",
+		Timestamp: "2026-05-20T10:30:00Z",
+		Model:     "claude-opus-4-6",
+		TokenUsage: json.RawMessage(
+			`{"input_tokens":1000,"output_tokens":500}`),
+	})
+
+	u, err := d.GetSessionUsage(ctx, "ai-credit-agent:s1")
+	requireNoError(t, err, "GetSessionUsage")
+	require.NotNil(t, u, "usage is nil")
+	assert.True(t, u.HasCost, "HasCost = false, want true")
+	assert.InDelta(t, 0.0175, u.CostUSD, 1e-9, "CostUSD")
+	assert.InDelta(t, 1.75, u.AICredits, 1e-9, "AICredits")
+}
+
+// TestGetDailyUsage_CopilotAICredits verifies AI credits are computed from
+// agents with the parser AI-credit capability: costUSD / 0.01.
 func TestGetDailyUsage_CopilotAICredits(t *testing.T) {
+	defer withParserAgentDefs(t, parser.AgentDef{
+		Type:        parser.AgentType("ai-credit-agent"),
+		DisplayName: "AI Credit Agent",
+		Usage: parser.UsageCapabilities{
+			AICreditsDenominated: true,
+		},
+	})()
+
 	d := testDB(t)
 	ctx := context.Background()
 
@@ -3351,6 +3395,15 @@ func TestGetDailyUsage_CopilotAICredits(t *testing.T) {
 			name:        "copilot credits computed",
 			sessionID:   "copilot:aicredits",
 			agent:       "copilot",
+			model:       "gpt-4",
+			inputRate:   15.0,
+			outputRate:  60.0,
+			wantCredits: true,
+		},
+		{
+			name:        "non copilot capability credits computed",
+			sessionID:   "ai-credit-agent:aicredits",
+			agent:       "ai-credit-agent",
 			model:       "gpt-4",
 			inputRate:   15.0,
 			outputRate:  60.0,
@@ -3404,5 +3457,14 @@ func TestGetDailyUsage_CopilotAICredits(t *testing.T) {
 			assert.InDelta(t, wantCredits, result.Totals.CopilotAICredits,
 				1e-6, "CopilotAICredits")
 		})
+	}
+}
+
+func withParserAgentDefs(t *testing.T, defs ...parser.AgentDef) func() {
+	t.Helper()
+	orig := append([]parser.AgentDef(nil), parser.Registry...)
+	parser.Registry = append(parser.Registry, defs...)
+	return func() {
+		parser.Registry = orig
 	}
 }

--- a/internal/duckdb/analytics_usage.go
+++ b/internal/duckdb/analytics_usage.go
@@ -3625,14 +3625,14 @@ func (s *Store) GetDailyUsage(
 	result.Totals.CacheSavings = roundCost(totalSavings)
 	result.Totals.TotalCost = roundCost(result.Totals.TotalCost)
 
-	var copilotCost float64
+	var aiCreditCost float64
 	for key, b := range accum {
 		if parser.AgentNameUsesAICredits(key.agent) {
-			copilotCost += b.cost
+			aiCreditCost += b.cost
 		}
 	}
-	if copilotCost > 0 {
-		result.Totals.CopilotAICredits = copilotCost / 0.01
+	if aiCreditCost > 0 {
+		result.Totals.CopilotAICredits = aiCreditCost / 0.01
 	}
 
 	if result.Daily == nil {

--- a/internal/duckdb/analytics_usage.go
+++ b/internal/duckdb/analytics_usage.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
 	pricingpkg "go.kenn.io/agentsview/internal/pricing"
 	"go.kenn.io/agentsview/internal/signals"
 )
@@ -3626,7 +3627,7 @@ func (s *Store) GetDailyUsage(
 
 	var copilotCost float64
 	for key, b := range accum {
-		if db.IsCopilotAgent(key.agent) {
+		if parser.AgentNameUsesAICredits(key.agent) {
 			copilotCost += b.cost
 		}
 	}
@@ -3958,7 +3959,8 @@ func (s *Store) GetSessionUsage(
 		out.HasCost = true
 		out.CostUSD = roundCost(totalCost)
 	}
-	if db.IsCopilotAgent(sess.Agent) && out.HasCost && out.CostUSD > 0 {
+	if parser.AgentNameUsesAICredits(sess.Agent) &&
+		out.HasCost && out.CostUSD > 0 {
 		out.AICredits = out.CostUSD / 0.01
 	}
 	return out, nil

--- a/internal/duckdb/analytics_usage.go
+++ b/internal/duckdb/analytics_usage.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"go.kenn.io/agentsview/internal/db"
-	"go.kenn.io/agentsview/internal/parser"
 	pricingpkg "go.kenn.io/agentsview/internal/pricing"
 	"go.kenn.io/agentsview/internal/signals"
 )
@@ -3625,14 +3624,12 @@ func (s *Store) GetDailyUsage(
 	result.Totals.CacheSavings = roundCost(totalSavings)
 	result.Totals.TotalCost = roundCost(result.Totals.TotalCost)
 
-	var aiCreditCost float64
+	var aiCredits float64
 	for key, b := range accum {
-		if parser.AgentNameUsesAICredits(key.agent) {
-			aiCreditCost += b.cost
-		}
+		aiCredits += db.AICreditsFromCost(key.agent, b.cost)
 	}
-	if aiCreditCost > 0 {
-		result.Totals.CopilotAICredits = aiCreditCost / 0.01
+	if aiCredits > 0 {
+		result.Totals.CopilotAICredits = aiCredits
 	}
 
 	if result.Daily == nil {
@@ -3958,10 +3955,7 @@ func (s *Store) GetSessionUsage(
 	if len(unpriced) == 0 && hasRows {
 		out.HasCost = true
 		out.CostUSD = roundCost(totalCost)
-	}
-	if parser.AgentNameUsesAICredits(sess.Agent) &&
-		out.HasCost && out.CostUSD > 0 {
-		out.AICredits = out.CostUSD / 0.01
+		out.AICredits = db.AICreditsFromCost(sess.Agent, out.CostUSD)
 	}
 	return out, nil
 }

--- a/internal/parser/capabilities_ext_test.go
+++ b/internal/parser/capabilities_ext_test.go
@@ -27,7 +27,10 @@ func TestAgentUsageCapabilityHelpersFailClosedAndDiverge(t *testing.T) {
 		},
 	)
 
-	assert.True(t, parser.AgentNameLacksPerMessageTokenData(" no-token-only "))
+	// Names match registry types exactly; only the CSV filter parser
+	// trims, so a padded name fails closed at the name level.
+	assert.False(t, parser.AgentNameLacksPerMessageTokenData(" no-token-only "))
+	assert.True(t, parser.AgentNameLacksPerMessageTokenData("no-token-only"))
 	assert.False(t, parser.AgentNameUsesAICredits("no-token-only"))
 	assert.False(t, parser.AgentNameLacksPerMessageTokenData("ai-credit-only"))
 	assert.True(t, parser.AgentNameUsesAICredits("ai-credit-only"))
@@ -43,9 +46,4 @@ func TestAgentUsageCapabilityHelpersFailClosedAndDiverge(t *testing.T) {
 	assert.False(t, parser.AgentFilterLacksPerMessageTokenData(","))
 	assert.False(t, parser.AgentFilterLacksPerMessageTokenData("copilot,claude"))
 	assert.False(t, parser.AgentFilterLacksPerMessageTokenData("unknown-agent"))
-	assert.True(t, parser.AgentFilterUsesAICredits("copilot, ai-credit-only"))
-	assert.False(t, parser.AgentFilterUsesAICredits(""))
-	assert.False(t, parser.AgentFilterUsesAICredits("no-token-only"))
-	assert.False(t, parser.AgentFilterUsesAICredits("copilot,claude"))
-	assert.False(t, parser.AgentFilterUsesAICredits("unknown-agent"))
 }

--- a/internal/parser/capabilities_ext_test.go
+++ b/internal/parser/capabilities_ext_test.go
@@ -1,0 +1,51 @@
+package parser_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/parsertest"
+)
+
+func TestAgentUsageCapabilityHelpersFailClosedAndDiverge(t *testing.T) {
+	parsertest.StubAgentDefs(t,
+		parser.AgentDef{
+			Type:        parser.AgentType("no-token-only"),
+			DisplayName: "No Token Only",
+			Usage: parser.UsageCapabilities{
+				NoPerMessageTokenData: true,
+			},
+		},
+		parser.AgentDef{
+			Type:        parser.AgentType("ai-credit-only"),
+			DisplayName: "AI Credit Only",
+			Usage: parser.UsageCapabilities{
+				AICreditsDenominated: true,
+			},
+		},
+	)
+
+	assert.True(t, parser.AgentNameLacksPerMessageTokenData(" no-token-only "))
+	assert.False(t, parser.AgentNameUsesAICredits("no-token-only"))
+	assert.False(t, parser.AgentNameLacksPerMessageTokenData("ai-credit-only"))
+	assert.True(t, parser.AgentNameUsesAICredits("ai-credit-only"))
+	assert.False(t, parser.AgentNameLacksPerMessageTokenData(""))
+	assert.False(t, parser.AgentNameUsesAICredits(""))
+	assert.False(t, parser.AgentNameLacksPerMessageTokenData("unknown-agent"))
+	assert.False(t, parser.AgentNameUsesAICredits("unknown-agent"))
+
+	assert.True(t, parser.AgentFilterLacksPerMessageTokenData(
+		"copilot, vscode-copilot,no-token-only,",
+	))
+	assert.False(t, parser.AgentFilterLacksPerMessageTokenData(""))
+	assert.False(t, parser.AgentFilterLacksPerMessageTokenData(","))
+	assert.False(t, parser.AgentFilterLacksPerMessageTokenData("copilot,claude"))
+	assert.False(t, parser.AgentFilterLacksPerMessageTokenData("unknown-agent"))
+	assert.True(t, parser.AgentFilterUsesAICredits("copilot, ai-credit-only"))
+	assert.False(t, parser.AgentFilterUsesAICredits(""))
+	assert.False(t, parser.AgentFilterUsesAICredits("no-token-only"))
+	assert.False(t, parser.AgentFilterUsesAICredits("copilot,claude"))
+	assert.False(t, parser.AgentFilterUsesAICredits("unknown-agent"))
+}

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -668,13 +668,21 @@ func AgentNameUsesAICredits(agent string) bool {
 }
 
 func AgentFilterLacksPerMessageTokenData(agentFilter string) bool {
+	return agentFilterMatches(agentFilter, AgentNameLacksPerMessageTokenData)
+}
+
+func AgentFilterUsesAICredits(agentFilter string) bool {
+	return agentFilterMatches(agentFilter, AgentNameUsesAICredits)
+}
+
+func agentFilterMatches(agentFilter string, match func(string) bool) bool {
 	matched := false
 	for part := range strings.SplitSeq(agentFilter, ",") {
 		part = strings.TrimSpace(part)
 		if part == "" {
 			continue
 		}
-		if !AgentNameLacksPerMessageTokenData(part) {
+		if !match(part) {
 			return false
 		}
 		matched = true

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -641,38 +641,27 @@ func AgentByType(t AgentType) (AgentDef, bool) {
 	return AgentDef{}, false
 }
 
-func AgentLacksPerMessageTokenData(t AgentType) bool {
-	def, ok := AgentByType(t)
+// AgentNameLacksPerMessageTokenData reports whether the named agent
+// records no per-message token data. Names match registry types
+// exactly and unknown names fail closed; CSV filter parsing trims its
+// parts before calling.
+func AgentNameLacksPerMessageTokenData(agent string) bool {
+	def, ok := AgentByType(AgentType(agent))
 	return ok && def.Usage.NoPerMessageTokenData
 }
 
-func AgentUsesAICredits(t AgentType) bool {
-	def, ok := AgentByType(t)
+// AgentNameUsesAICredits reports whether the named agent's cost is
+// denominated in AI credits rather than USD.
+func AgentNameUsesAICredits(agent string) bool {
+	def, ok := AgentByType(AgentType(agent))
 	return ok && def.Usage.AICreditsDenominated
 }
 
-func AgentNameLacksPerMessageTokenData(agent string) bool {
-	agent = strings.TrimSpace(agent)
-	if agent == "" {
-		return false
-	}
-	return AgentLacksPerMessageTokenData(AgentType(agent))
-}
-
-func AgentNameUsesAICredits(agent string) bool {
-	agent = strings.TrimSpace(agent)
-	if agent == "" {
-		return false
-	}
-	return AgentUsesAICredits(AgentType(agent))
-}
-
+// AgentFilterLacksPerMessageTokenData reports whether a (possibly
+// comma-separated) agent filter selects only agents without
+// per-message token data, with at least one entry.
 func AgentFilterLacksPerMessageTokenData(agentFilter string) bool {
 	return agentFilterMatches(agentFilter, AgentNameLacksPerMessageTokenData)
-}
-
-func AgentFilterUsesAICredits(agentFilter string) bool {
-	return agentFilterMatches(agentFilter, AgentNameUsesAICredits)
 }
 
 func agentFilterMatches(agentFilter string, match func(string) bool) bool {
@@ -704,9 +693,10 @@ func AgentIsCopilot(t AgentType) bool {
 }
 
 // AgentNameIsCopilot reports whether the agent name identifies a
-// Copilot-family agent.
+// Copilot-family agent. Names match exactly, like the capability
+// helpers above.
 func AgentNameIsCopilot(agent string) bool {
-	return AgentIsCopilot(AgentType(strings.TrimSpace(agent)))
+	return AgentIsCopilot(AgentType(agent))
 }
 
 // AgentFilterIsCopilot reports whether a (possibly comma-separated)

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -690,6 +690,32 @@ func agentFilterMatches(agentFilter string, match func(string) bool) bool {
 	return matched
 }
 
+// AgentIsCopilot reports whether t is one of the GitHub Copilot
+// family agents. Copilot-specific user-facing wording keys on this
+// identity; the usage capabilities above intentionally do not imply
+// it, so a future agent can adopt NoPerMessageTokenData or
+// AICreditsDenominated without inheriting Copilot messaging.
+func AgentIsCopilot(t AgentType) bool {
+	switch t {
+	case AgentCopilot, AgentVSCodeCopilot, AgentVSCopilot:
+		return true
+	}
+	return false
+}
+
+// AgentNameIsCopilot reports whether the agent name identifies a
+// Copilot-family agent.
+func AgentNameIsCopilot(agent string) bool {
+	return AgentIsCopilot(AgentType(strings.TrimSpace(agent)))
+}
+
+// AgentFilterIsCopilot reports whether a (possibly comma-separated)
+// agent filter selects only Copilot-family agents, with at least one
+// entry.
+func AgentFilterIsCopilot(agentFilter string) bool {
+	return agentFilterMatches(agentFilter, AgentNameIsCopilot)
+}
+
 // StripHostPrefix splits a remote session ID into its host
 // and raw ID parts. Remote IDs use the form "host~rawID"
 // where the "~" separator avoids conflict with both agent

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -70,6 +70,7 @@ type AgentDef struct {
 	WatchSubdirs      []string // subdirs to watch (nil = watch root)
 	ShallowWatch      bool     // true = watch root only, rely on periodic sync for subdirs
 	FileBased         bool     // false for DB-backed agents
+	Usage             UsageCapabilities
 
 	// WatchRootsFunc resolves the directories to watch for live
 	// updates under a configured root, for agents whose watch
@@ -84,6 +85,11 @@ type AgentDef struct {
 	// live outside the session tree, such as Codex's
 	// session_index.jsonl. Nil for agents with no such files.
 	ShallowWatchRootsFunc func(string) []string
+}
+
+type UsageCapabilities struct {
+	NoPerMessageTokenData bool
+	AICreditsDenominated  bool
 }
 
 // Registry lists all supported agents. Order is stable and
@@ -141,6 +147,10 @@ var Registry = []AgentDef{
 		IDPrefix:     "copilot:",
 		WatchSubdirs: []string{"session-state"},
 		FileBased:    true,
+		Usage: UsageCapabilities{
+			NoPerMessageTokenData: true,
+			AICreditsDenominated:  true,
+		},
 	},
 	{
 		Type:         AgentGemini,
@@ -268,6 +278,10 @@ var Registry = []AgentDef{
 			"globalStorage",
 		},
 		FileBased: true,
+		Usage: UsageCapabilities{
+			NoPerMessageTokenData: true,
+			AICreditsDenominated:  true,
+		},
 	},
 	{
 		Type:        AgentVSCopilot,
@@ -284,6 +298,10 @@ var Registry = []AgentDef{
 		},
 		IDPrefix:  "visualstudio-copilot:",
 		FileBased: true,
+		Usage: UsageCapabilities{
+			NoPerMessageTokenData: true,
+			AICreditsDenominated:  true,
+		},
 	},
 	{
 		Type:        AgentPi,
@@ -621,6 +639,47 @@ func AgentByType(t AgentType) (AgentDef, bool) {
 		}
 	}
 	return AgentDef{}, false
+}
+
+func AgentLacksPerMessageTokenData(t AgentType) bool {
+	def, ok := AgentByType(t)
+	return ok && def.Usage.NoPerMessageTokenData
+}
+
+func AgentUsesAICredits(t AgentType) bool {
+	def, ok := AgentByType(t)
+	return ok && def.Usage.AICreditsDenominated
+}
+
+func AgentNameLacksPerMessageTokenData(agent string) bool {
+	agent = strings.TrimSpace(agent)
+	if agent == "" {
+		return false
+	}
+	return AgentLacksPerMessageTokenData(AgentType(agent))
+}
+
+func AgentNameUsesAICredits(agent string) bool {
+	agent = strings.TrimSpace(agent)
+	if agent == "" {
+		return false
+	}
+	return AgentUsesAICredits(AgentType(agent))
+}
+
+func AgentFilterLacksPerMessageTokenData(agentFilter string) bool {
+	matched := false
+	for part := range strings.SplitSeq(agentFilter, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		if !AgentNameLacksPerMessageTokenData(part) {
+			return false
+		}
+		matched = true
+	}
+	return matched
 }
 
 // StripHostPrefix splits a remote session ID into its host

--- a/internal/parser/types_test.go
+++ b/internal/parser/types_test.go
@@ -232,6 +232,11 @@ func TestUsageCapabilityConsumersRouteThroughParser(t *testing.T) {
 			path:     "../service/direct.go",
 			required: "parser.AgentFilterLacksPerMessageTokenData",
 		},
+		{
+			name:     "cli unsupported usage",
+			path:     "../../cmd/agentsview/usage.go",
+			required: "parser.AgentFilterLacksPerMessageTokenData",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/parser/types_test.go
+++ b/internal/parser/types_test.go
@@ -169,6 +169,48 @@ func TestAgentUsageCapabilities(t *testing.T) {
 	}
 }
 
+func TestAgentCopilotIdentity(t *testing.T) {
+	tests := []struct {
+		name  string
+		agent AgentType
+		want  bool
+	}{
+		{"copilot", AgentCopilot, true},
+		{"vscode copilot", AgentVSCodeCopilot, true},
+		{"visual studio copilot", AgentVSCopilot, true},
+		{"claude", AgentClaude, false},
+		{"unknown", AgentType("unknown-agent"), false},
+		{"empty", AgentType(""), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, AgentIsCopilot(tc.agent))
+			assert.Equal(t, tc.want, AgentNameIsCopilot(string(tc.agent)))
+		})
+	}
+}
+
+func TestAgentFilterIsCopilot(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter string
+		want   bool
+	}{
+		{"empty", "", false},
+		{"single copilot", "copilot", true},
+		{"all-copilot CSV with spaces", " copilot , visualstudio-copilot ", true},
+		{"trailing comma", "copilot,vscode-copilot,", true},
+		{"mixed CSV", "copilot,claude", false},
+		{"only commas", ",", false},
+		{"single non-copilot", "claude", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, AgentFilterIsCopilot(tc.filter))
+		})
+	}
+}
+
 func TestAgentByType(t *testing.T) {
 	tests := []struct {
 		input AgentType

--- a/internal/parser/types_test.go
+++ b/internal/parser/types_test.go
@@ -211,64 +211,6 @@ func TestAgentUsageCapabilityHelpersFailClosedAndDiverge(t *testing.T) {
 	assert.False(t, AgentFilterUsesAICredits("unknown-agent"))
 }
 
-func TestUsageCapabilityConsumersRouteThroughParser(t *testing.T) {
-	tests := []struct {
-		name     string
-		path     string
-		required []string
-	}{
-		{
-			name: "sqlite ai credits",
-			path: "../db/usage.go",
-			required: []string{
-				"parser.AgentNameUsesAICredits",
-			},
-		},
-		{
-			name: "postgres ai credits",
-			path: "../postgres/usage.go",
-			required: []string{
-				"parser.AgentNameUsesAICredits",
-			},
-		},
-		{
-			name: "duckdb ai credits",
-			path: "../duckdb/analytics_usage.go",
-			required: []string{
-				"parser.AgentNameUsesAICredits",
-			},
-		},
-		{
-			name: "service unsupported usage",
-			path: "../service/direct.go",
-			required: []string{
-				"parser.AgentFilterLacksPerMessageTokenData",
-				"parser.AgentFilterUsesAICredits",
-			},
-		},
-		{
-			name: "cli unsupported usage",
-			path: "../../cmd/agentsview/usage.go",
-			required: []string{
-				"parser.AgentFilterLacksPerMessageTokenData",
-				"parser.AgentFilterUsesAICredits",
-			},
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			src, err := os.ReadFile(tc.path)
-			require.NoError(t, err)
-			text := string(src)
-			for _, required := range tc.required {
-				assert.Contains(t, text, required)
-			}
-			assert.NotContains(t, text, "IsCopilotAgent")
-			assert.NotContains(t, text, "IsCopilotAgentFilter")
-		})
-	}
-}
-
 func withTestAgentDefs(t *testing.T, defs ...AgentDef) func() {
 	t.Helper()
 	orig := slices.Clone(Registry)

--- a/internal/parser/types_test.go
+++ b/internal/parser/types_test.go
@@ -169,57 +169,6 @@ func TestAgentUsageCapabilities(t *testing.T) {
 	}
 }
 
-func TestAgentUsageCapabilityHelpersFailClosedAndDiverge(t *testing.T) {
-	restore := withTestAgentDefs(t,
-		AgentDef{
-			Type:        AgentType("no-token-only"),
-			DisplayName: "No Token Only",
-			Usage: UsageCapabilities{
-				NoPerMessageTokenData: true,
-			},
-		},
-		AgentDef{
-			Type:        AgentType("ai-credit-only"),
-			DisplayName: "AI Credit Only",
-			Usage: UsageCapabilities{
-				AICreditsDenominated: true,
-			},
-		},
-	)
-	defer restore()
-
-	assert.True(t, AgentNameLacksPerMessageTokenData(" no-token-only "))
-	assert.False(t, AgentNameUsesAICredits("no-token-only"))
-	assert.False(t, AgentNameLacksPerMessageTokenData("ai-credit-only"))
-	assert.True(t, AgentNameUsesAICredits("ai-credit-only"))
-	assert.False(t, AgentNameLacksPerMessageTokenData(""))
-	assert.False(t, AgentNameUsesAICredits(""))
-	assert.False(t, AgentNameLacksPerMessageTokenData("unknown-agent"))
-	assert.False(t, AgentNameUsesAICredits("unknown-agent"))
-
-	assert.True(t, AgentFilterLacksPerMessageTokenData(
-		"copilot, vscode-copilot,no-token-only,",
-	))
-	assert.False(t, AgentFilterLacksPerMessageTokenData(""))
-	assert.False(t, AgentFilterLacksPerMessageTokenData(","))
-	assert.False(t, AgentFilterLacksPerMessageTokenData("copilot,claude"))
-	assert.False(t, AgentFilterLacksPerMessageTokenData("unknown-agent"))
-	assert.True(t, AgentFilterUsesAICredits("copilot, ai-credit-only"))
-	assert.False(t, AgentFilterUsesAICredits(""))
-	assert.False(t, AgentFilterUsesAICredits("no-token-only"))
-	assert.False(t, AgentFilterUsesAICredits("copilot,claude"))
-	assert.False(t, AgentFilterUsesAICredits("unknown-agent"))
-}
-
-func withTestAgentDefs(t *testing.T, defs ...AgentDef) func() {
-	t.Helper()
-	orig := slices.Clone(Registry)
-	Registry = append(Registry, defs...)
-	return func() {
-		Registry = orig
-	}
-}
-
 func TestAgentByType(t *testing.T) {
 	tests := []struct {
 		input AgentType

--- a/internal/parser/types_test.go
+++ b/internal/parser/types_test.go
@@ -204,38 +204,55 @@ func TestAgentUsageCapabilityHelpersFailClosedAndDiverge(t *testing.T) {
 	assert.False(t, AgentFilterLacksPerMessageTokenData(","))
 	assert.False(t, AgentFilterLacksPerMessageTokenData("copilot,claude"))
 	assert.False(t, AgentFilterLacksPerMessageTokenData("unknown-agent"))
+	assert.True(t, AgentFilterUsesAICredits("copilot, ai-credit-only"))
+	assert.False(t, AgentFilterUsesAICredits(""))
+	assert.False(t, AgentFilterUsesAICredits("no-token-only"))
+	assert.False(t, AgentFilterUsesAICredits("copilot,claude"))
+	assert.False(t, AgentFilterUsesAICredits("unknown-agent"))
 }
 
 func TestUsageCapabilityConsumersRouteThroughParser(t *testing.T) {
 	tests := []struct {
 		name     string
 		path     string
-		required string
+		required []string
 	}{
 		{
-			name:     "sqlite ai credits",
-			path:     "../db/usage.go",
-			required: "parser.AgentNameUsesAICredits",
+			name: "sqlite ai credits",
+			path: "../db/usage.go",
+			required: []string{
+				"parser.AgentNameUsesAICredits",
+			},
 		},
 		{
-			name:     "postgres ai credits",
-			path:     "../postgres/usage.go",
-			required: "parser.AgentNameUsesAICredits",
+			name: "postgres ai credits",
+			path: "../postgres/usage.go",
+			required: []string{
+				"parser.AgentNameUsesAICredits",
+			},
 		},
 		{
-			name:     "duckdb ai credits",
-			path:     "../duckdb/analytics_usage.go",
-			required: "parser.AgentNameUsesAICredits",
+			name: "duckdb ai credits",
+			path: "../duckdb/analytics_usage.go",
+			required: []string{
+				"parser.AgentNameUsesAICredits",
+			},
 		},
 		{
-			name:     "service unsupported usage",
-			path:     "../service/direct.go",
-			required: "parser.AgentFilterLacksPerMessageTokenData",
+			name: "service unsupported usage",
+			path: "../service/direct.go",
+			required: []string{
+				"parser.AgentFilterLacksPerMessageTokenData",
+				"parser.AgentFilterUsesAICredits",
+			},
 		},
 		{
-			name:     "cli unsupported usage",
-			path:     "../../cmd/agentsview/usage.go",
-			required: "parser.AgentFilterLacksPerMessageTokenData",
+			name: "cli unsupported usage",
+			path: "../../cmd/agentsview/usage.go",
+			required: []string{
+				"parser.AgentFilterLacksPerMessageTokenData",
+				"parser.AgentFilterUsesAICredits",
+			},
 		},
 	}
 	for _, tc := range tests {
@@ -243,7 +260,9 @@ func TestUsageCapabilityConsumersRouteThroughParser(t *testing.T) {
 			src, err := os.ReadFile(tc.path)
 			require.NoError(t, err)
 			text := string(src)
-			assert.Contains(t, text, tc.required)
+			for _, required := range tc.required {
+				assert.Contains(t, text, required)
+			}
 			assert.NotContains(t, text, "IsCopilotAgent")
 			assert.NotContains(t, text, "IsCopilotAgentFilter")
 		})

--- a/internal/parser/types_test.go
+++ b/internal/parser/types_test.go
@@ -129,6 +129,131 @@ func TestInferTokenPresence(t *testing.T) {
 	}
 }
 
+func TestAgentUsageCapabilities(t *testing.T) {
+	tests := []struct {
+		name        string
+		agent       AgentType
+		wantNoToken bool
+		wantCredits bool
+	}{
+		{
+			name:        "copilot",
+			agent:       AgentCopilot,
+			wantNoToken: true,
+			wantCredits: true,
+		},
+		{
+			name:        "vscode copilot",
+			agent:       AgentVSCodeCopilot,
+			wantNoToken: true,
+			wantCredits: true,
+		},
+		{
+			name:        "visual studio copilot",
+			agent:       AgentVSCopilot,
+			wantNoToken: true,
+			wantCredits: true,
+		},
+		{
+			name:  "claude",
+			agent: AgentClaude,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.wantNoToken,
+				AgentLacksPerMessageTokenData(tc.agent))
+			assert.Equal(t, tc.wantCredits,
+				AgentUsesAICredits(tc.agent))
+		})
+	}
+}
+
+func TestAgentUsageCapabilityHelpersFailClosedAndDiverge(t *testing.T) {
+	restore := withTestAgentDefs(t,
+		AgentDef{
+			Type:        AgentType("no-token-only"),
+			DisplayName: "No Token Only",
+			Usage: UsageCapabilities{
+				NoPerMessageTokenData: true,
+			},
+		},
+		AgentDef{
+			Type:        AgentType("ai-credit-only"),
+			DisplayName: "AI Credit Only",
+			Usage: UsageCapabilities{
+				AICreditsDenominated: true,
+			},
+		},
+	)
+	defer restore()
+
+	assert.True(t, AgentNameLacksPerMessageTokenData(" no-token-only "))
+	assert.False(t, AgentNameUsesAICredits("no-token-only"))
+	assert.False(t, AgentNameLacksPerMessageTokenData("ai-credit-only"))
+	assert.True(t, AgentNameUsesAICredits("ai-credit-only"))
+	assert.False(t, AgentNameLacksPerMessageTokenData(""))
+	assert.False(t, AgentNameUsesAICredits(""))
+	assert.False(t, AgentNameLacksPerMessageTokenData("unknown-agent"))
+	assert.False(t, AgentNameUsesAICredits("unknown-agent"))
+
+	assert.True(t, AgentFilterLacksPerMessageTokenData(
+		"copilot, vscode-copilot,no-token-only,",
+	))
+	assert.False(t, AgentFilterLacksPerMessageTokenData(""))
+	assert.False(t, AgentFilterLacksPerMessageTokenData(","))
+	assert.False(t, AgentFilterLacksPerMessageTokenData("copilot,claude"))
+	assert.False(t, AgentFilterLacksPerMessageTokenData("unknown-agent"))
+}
+
+func TestUsageCapabilityConsumersRouteThroughParser(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		required string
+	}{
+		{
+			name:     "sqlite ai credits",
+			path:     "../db/usage.go",
+			required: "parser.AgentNameUsesAICredits",
+		},
+		{
+			name:     "postgres ai credits",
+			path:     "../postgres/usage.go",
+			required: "parser.AgentNameUsesAICredits",
+		},
+		{
+			name:     "duckdb ai credits",
+			path:     "../duckdb/analytics_usage.go",
+			required: "parser.AgentNameUsesAICredits",
+		},
+		{
+			name:     "service unsupported usage",
+			path:     "../service/direct.go",
+			required: "parser.AgentFilterLacksPerMessageTokenData",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			src, err := os.ReadFile(tc.path)
+			require.NoError(t, err)
+			text := string(src)
+			assert.Contains(t, text, tc.required)
+			assert.NotContains(t, text, "IsCopilotAgent")
+			assert.NotContains(t, text, "IsCopilotAgentFilter")
+		})
+	}
+}
+
+func withTestAgentDefs(t *testing.T, defs ...AgentDef) func() {
+	t.Helper()
+	orig := slices.Clone(Registry)
+	Registry = append(Registry, defs...)
+	return func() {
+		Registry = orig
+	}
+}
+
 func TestAgentByType(t *testing.T) {
 	tests := []struct {
 		input AgentType

--- a/internal/parser/types_test.go
+++ b/internal/parser/types_test.go
@@ -162,9 +162,9 @@ func TestAgentUsageCapabilities(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.wantNoToken,
-				AgentLacksPerMessageTokenData(tc.agent))
+				AgentNameLacksPerMessageTokenData(string(tc.agent)))
 			assert.Equal(t, tc.wantCredits,
-				AgentUsesAICredits(tc.agent))
+				AgentNameUsesAICredits(string(tc.agent)))
 		})
 	}
 }

--- a/internal/parsertest/parsertest.go
+++ b/internal/parsertest/parsertest.go
@@ -1,0 +1,23 @@
+// Package parsertest provides shared test helpers for stubbing
+// agent definitions in the parser registry across test packages.
+package parsertest
+
+import (
+	"slices"
+	"testing"
+
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+// StubAgentDefs appends defs to the parser registry for the duration
+// of the test and restores the original registry on cleanup. The
+// registry is a package-level variable, so tests that stub it must not
+// run in parallel with tests that read it.
+func StubAgentDefs(t testing.TB, defs ...parser.AgentDef) {
+	t.Helper()
+	orig := slices.Clone(parser.Registry)
+	parser.Registry = append(parser.Registry, defs...)
+	t.Cleanup(func() {
+		parser.Registry = orig
+	})
+}

--- a/internal/postgres/usage.go
+++ b/internal/postgres/usage.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/tidwall/gjson"
 	"go.kenn.io/agentsview/internal/db"
-	"go.kenn.io/agentsview/internal/parser"
 )
 
 const pgUsageMessageEligibility = `
@@ -1129,9 +1128,7 @@ func (s *Store) GetSessionUsage(
 	}
 	if out.HasCost {
 		out.CostUSD = cost
-	}
-	if parser.AgentNameUsesAICredits(sess.Agent) && out.HasCost {
-		out.AICredits = cost / 0.01
+		out.AICredits = db.AICreditsFromCost(sess.Agent, cost)
 	}
 	if len(unpricedSet) > 0 {
 		out.UnpricedModels = sortedStringSetKeys(unpricedSet)
@@ -1356,14 +1353,12 @@ func (s *Store) GetDailyUsage(
 		}
 		totals.CacheSavings = totalSavings
 
-		var aiCreditCost float64
+		var aiCredits float64
 		for key, b := range accum {
-			if parser.AgentNameUsesAICredits(key.agent) {
-				aiCreditCost += b.cost
-			}
+			aiCredits += db.AICreditsFromCost(key.agent, b.cost)
 		}
-		if aiCreditCost > 0 {
-			totals.CopilotAICredits = aiCreditCost / 0.01
+		if aiCredits > 0 {
+			totals.CopilotAICredits = aiCredits
 		}
 
 		var sessionCounts db.UsageSessionCounts
@@ -1517,16 +1512,14 @@ func (s *Store) GetDailyUsage(
 	}
 	totals.CacheSavings = totalSavings
 
-	var aiCreditCost float64
+	var aiCredits float64
 	for _, d := range daily {
 		for _, ab := range d.AgentBreakdowns {
-			if parser.AgentNameUsesAICredits(ab.Agent) {
-				aiCreditCost += ab.Cost
-			}
+			aiCredits += db.AICreditsFromCost(ab.Agent, ab.Cost)
 		}
 	}
-	if aiCreditCost > 0 {
-		totals.CopilotAICredits = aiCreditCost / 0.01
+	if aiCredits > 0 {
+		totals.CopilotAICredits = aiCredits
 	}
 
 	var sessionCounts db.UsageSessionCounts

--- a/internal/postgres/usage.go
+++ b/internal/postgres/usage.go
@@ -1356,14 +1356,14 @@ func (s *Store) GetDailyUsage(
 		}
 		totals.CacheSavings = totalSavings
 
-		var copilotCost float64
+		var aiCreditCost float64
 		for key, b := range accum {
 			if parser.AgentNameUsesAICredits(key.agent) {
-				copilotCost += b.cost
+				aiCreditCost += b.cost
 			}
 		}
-		if copilotCost > 0 {
-			totals.CopilotAICredits = copilotCost / 0.01
+		if aiCreditCost > 0 {
+			totals.CopilotAICredits = aiCreditCost / 0.01
 		}
 
 		var sessionCounts db.UsageSessionCounts
@@ -1517,16 +1517,16 @@ func (s *Store) GetDailyUsage(
 	}
 	totals.CacheSavings = totalSavings
 
-	var copilotCost float64
+	var aiCreditCost float64
 	for _, d := range daily {
 		for _, ab := range d.AgentBreakdowns {
 			if parser.AgentNameUsesAICredits(ab.Agent) {
-				copilotCost += ab.Cost
+				aiCreditCost += ab.Cost
 			}
 		}
 	}
-	if copilotCost > 0 {
-		totals.CopilotAICredits = copilotCost / 0.01
+	if aiCreditCost > 0 {
+		totals.CopilotAICredits = aiCreditCost / 0.01
 	}
 
 	var sessionCounts db.UsageSessionCounts

--- a/internal/postgres/usage.go
+++ b/internal/postgres/usage.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/tidwall/gjson"
 	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
 )
 
 const pgUsageMessageEligibility = `
@@ -1129,7 +1130,7 @@ func (s *Store) GetSessionUsage(
 	if out.HasCost {
 		out.CostUSD = cost
 	}
-	if db.IsCopilotAgent(sess.Agent) && out.HasCost {
+	if parser.AgentNameUsesAICredits(sess.Agent) && out.HasCost {
 		out.AICredits = cost / 0.01
 	}
 	if len(unpricedSet) > 0 {
@@ -1357,7 +1358,7 @@ func (s *Store) GetDailyUsage(
 
 		var copilotCost float64
 		for key, b := range accum {
-			if db.IsCopilotAgent(key.agent) {
+			if parser.AgentNameUsesAICredits(key.agent) {
 				copilotCost += b.cost
 			}
 		}
@@ -1519,7 +1520,7 @@ func (s *Store) GetDailyUsage(
 	var copilotCost float64
 	for _, d := range daily {
 		for _, ab := range d.AgentBreakdowns {
-			if db.IsCopilotAgent(ab.Agent) {
+			if parser.AgentNameUsesAICredits(ab.Agent) {
 				copilotCost += ab.Cost
 			}
 		}

--- a/internal/server/usage_internal_test.go
+++ b/internal/server/usage_internal_test.go
@@ -266,6 +266,47 @@ func TestUsageSummarySetsUnsupportedUsageFromAgentCapability(t *testing.T) {
 	assertUsageQueryCalls(t, spy, 1, 0, 1)
 }
 
+// TestUsageSummaryKeepsGenericKindForNonCopilotAICreditAgent pins the
+// Copilot-branded kind to Copilot identity: an agent that shares both of
+// Copilot's usage capabilities must still surface the generic kind.
+func TestUsageSummaryKeepsGenericKindForNonCopilotAICreditAgent(t *testing.T) {
+	parsertest.StubAgentDefs(t, parser.AgentDef{
+		Type:        parser.AgentType("credit-note-agent"),
+		DisplayName: "Credit Note Agent",
+		Usage: parser.UsageCapabilities{
+			NoPerMessageTokenData: true,
+			AICreditsDenominated:  true,
+		},
+	})
+
+	spy := &usageSummaryCountsSpy{
+		matchingSessionCount: 1,
+		result: db.DailyUsageResult{
+			Daily:  []db.DailyUsageEntry{{Date: "2024-06-01"}},
+			Totals: db.UsageTotals{},
+			SessionCounts: db.UsageSessionCounts{
+				Total:     0,
+				ByProject: map[string]int{},
+				ByAgent:   map[string]int{},
+			},
+		},
+	}
+	s := newRoutedTestServerWithStore(t, spy)
+
+	w := serveGet(t, s,
+		"/api/v1/usage/summary?"+oneDayUsageRange+"&agent=credit-note-agent")
+	assertRecorderStatus(t, w, http.StatusOK)
+
+	var resp UsageSummaryResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.NotNil(t, resp.UnsupportedUsage)
+	assert.Equal(t,
+		service.UnsupportedUsageKindNoTokenData,
+		resp.UnsupportedUsage.Kind,
+	)
+	assertUsageQueryCalls(t, spy, 1, 0, 1)
+}
+
 func TestUsageSummarySkipsUnsupportedUsageForMixedAgentFilters(t *testing.T) {
 	spy := &usageSummaryCountsSpy{
 		matchingSessionCount: 2,

--- a/internal/server/usage_internal_test.go
+++ b/internal/server/usage_internal_test.go
@@ -12,6 +12,7 @@ import (
 
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/parsertest"
 	"go.kenn.io/agentsview/internal/service"
 )
 
@@ -229,13 +230,13 @@ func TestUsageSummarySetsUnsupportedUsageForCopilotNoTokenData(t *testing.T) {
 }
 
 func TestUsageSummarySetsUnsupportedUsageFromAgentCapability(t *testing.T) {
-	defer withServerParserAgentDefs(t, parser.AgentDef{
+	parsertest.StubAgentDefs(t, parser.AgentDef{
 		Type:        parser.AgentType("no-token-agent"),
 		DisplayName: "No Token Agent",
 		Usage: parser.UsageCapabilities{
 			NoPerMessageTokenData: true,
 		},
-	})()
+	})
 
 	spy := &usageSummaryCountsSpy{
 		matchingSessionCount: 1,
@@ -326,13 +327,4 @@ func TestUsagePairwiseComparisonOpenAPIRequiresSideParams(t *testing.T) {
 	assert.True(t, required["left_value"])
 	assert.True(t, required["right_dimension"])
 	assert.True(t, required["right_value"])
-}
-
-func withServerParserAgentDefs(t *testing.T, defs ...parser.AgentDef) func() {
-	t.Helper()
-	orig := append([]parser.AgentDef(nil), parser.Registry...)
-	parser.Registry = append(parser.Registry, defs...)
-	return func() {
-		parser.Registry = orig
-	}
 }

--- a/internal/server/usage_internal_test.go
+++ b/internal/server/usage_internal_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/service"
 )
 
@@ -227,6 +228,43 @@ func TestUsageSummarySetsUnsupportedUsageForCopilotNoTokenData(t *testing.T) {
 	assertUsageQueryCalls(t, spy, 1, 0, 1)
 }
 
+func TestUsageSummarySetsUnsupportedUsageFromAgentCapability(t *testing.T) {
+	defer withServerParserAgentDefs(t, parser.AgentDef{
+		Type:        parser.AgentType("no-token-agent"),
+		DisplayName: "No Token Agent",
+		Usage: parser.UsageCapabilities{
+			NoPerMessageTokenData: true,
+		},
+	})()
+
+	spy := &usageSummaryCountsSpy{
+		matchingSessionCount: 1,
+		result: db.DailyUsageResult{
+			Daily:  []db.DailyUsageEntry{{Date: "2024-06-01"}},
+			Totals: db.UsageTotals{},
+			SessionCounts: db.UsageSessionCounts{
+				Total:     0,
+				ByProject: map[string]int{},
+				ByAgent:   map[string]int{},
+			},
+		},
+	}
+	s := newRoutedTestServerWithStore(t, spy)
+
+	w := serveGet(t, s,
+		"/api/v1/usage/summary?"+oneDayUsageRange+"&agent=no-token-agent")
+	assertRecorderStatus(t, w, http.StatusOK)
+
+	var resp UsageSummaryResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.NotNil(t, resp.UnsupportedUsage)
+	assert.Equal(t,
+		service.UnsupportedUsageKindCopilotNoTokenData,
+		resp.UnsupportedUsage.Kind,
+	)
+	assertUsageQueryCalls(t, spy, 1, 0, 1)
+}
+
 func TestUsageSummarySkipsUnsupportedUsageForMixedAgentFilters(t *testing.T) {
 	spy := &usageSummaryCountsSpy{
 		matchingSessionCount: 2,
@@ -288,4 +326,13 @@ func TestUsagePairwiseComparisonOpenAPIRequiresSideParams(t *testing.T) {
 	assert.True(t, required["left_value"])
 	assert.True(t, required["right_dimension"])
 	assert.True(t, required["right_value"])
+}
+
+func withServerParserAgentDefs(t *testing.T, defs ...parser.AgentDef) func() {
+	t.Helper()
+	orig := append([]parser.AgentDef(nil), parser.Registry...)
+	parser.Registry = append(parser.Registry, defs...)
+	return func() {
+		parser.Registry = orig
+	}
 }

--- a/internal/server/usage_internal_test.go
+++ b/internal/server/usage_internal_test.go
@@ -259,7 +259,7 @@ func TestUsageSummarySetsUnsupportedUsageFromAgentCapability(t *testing.T) {
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	require.NotNil(t, resp.UnsupportedUsage)
 	assert.Equal(t,
-		service.UnsupportedUsageKindCopilotNoTokenData,
+		service.UnsupportedUsageKindNoTokenData,
 		resp.UnsupportedUsage.Kind,
 	)
 	assertUsageQueryCalls(t, spy, 1, 0, 1)

--- a/internal/service/direct.go
+++ b/internal/service/direct.go
@@ -593,8 +593,12 @@ func (b *directBackend) UsageSummary(
 			return nil, err
 		}
 		if matchingSessions > 0 {
+			kind := UnsupportedUsageKindNoTokenData
+			if parser.AgentFilterUsesAICredits(f.Agent) {
+				kind = UnsupportedUsageKindCopilotNoTokenData
+			}
 			summary.UnsupportedUsage = &UnsupportedUsage{
-				Kind: UnsupportedUsageKindCopilotNoTokenData,
+				Kind: kind,
 			}
 		}
 	}

--- a/internal/service/direct.go
+++ b/internal/service/direct.go
@@ -593,12 +593,8 @@ func (b *directBackend) UsageSummary(
 			return nil, err
 		}
 		if matchingSessions > 0 {
-			kind := UnsupportedUsageKindNoTokenData
-			if parser.AgentFilterUsesAICredits(f.Agent) {
-				kind = UnsupportedUsageKindCopilotNoTokenData
-			}
 			summary.UnsupportedUsage = &UnsupportedUsage{
-				Kind: kind,
+				Kind: UnsupportedUsageKindForAgentFilter(f.Agent),
 			}
 		}
 	}

--- a/internal/service/direct.go
+++ b/internal/service/direct.go
@@ -586,7 +586,8 @@ func (b *directBackend) UsageSummary(
 		return nil, err
 	}
 	summary := buildUsageSummary(f, result)
-	if db.IsCopilotAgentFilter(f.Agent) && db.NoTokenData(result.Totals) {
+	if parser.AgentFilterLacksPerMessageTokenData(f.Agent) &&
+		db.NoTokenData(result.Totals) {
 		matchingSessions, err := b.db.GetUsageMatchingSessionCount(ctx, f)
 		if err != nil {
 			return nil, err

--- a/internal/service/usage.go
+++ b/internal/service/usage.go
@@ -163,6 +163,7 @@ type CacheStats struct {
 	SavingsVsUncached   float64 `json:"savingsVsUncached"`
 }
 
+const UnsupportedUsageKindNoTokenData = "no-token-data"
 const UnsupportedUsageKindCopilotNoTokenData = "copilot-no-token-data"
 
 type UnsupportedUsage struct {

--- a/internal/service/usage.go
+++ b/internal/service/usage.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/timeutil"
 )
 
@@ -165,6 +166,20 @@ type CacheStats struct {
 
 const UnsupportedUsageKindNoTokenData = "no-token-data"
 const UnsupportedUsageKindCopilotNoTokenData = "copilot-no-token-data"
+
+// UnsupportedUsageKindForAgentFilter returns the unsupported-usage
+// kind for an agent filter whose agents record no per-message token
+// data: the Copilot-specific kind when the filter selects only
+// Copilot-family agents, and the generic kind otherwise. Copilot
+// branding keys on agent identity, not on the AI-credits capability,
+// so another credits-denominated agent degrades to the generic kind
+// instead of being described as Copilot.
+func UnsupportedUsageKindForAgentFilter(agentFilter string) string {
+	if parser.AgentFilterIsCopilot(agentFilter) {
+		return UnsupportedUsageKindCopilotNoTokenData
+	}
+	return UnsupportedUsageKindNoTokenData
+}
 
 type UnsupportedUsage struct {
 	Kind string `json:"kind"`

--- a/internal/service/usage_internal_test.go
+++ b/internal/service/usage_internal_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/parsertest"
 )
 
 func TestComputeCacheStats_SavingsPassThrough(t *testing.T) {
@@ -61,4 +63,52 @@ func TestComputeCacheStats_UncachedPassesInputThrough(t *testing.T) {
 	assert.Equal(t, 100, cs.UncachedInputTokens)
 	assert.Equal(t, 200, cs.CacheReadTokens)
 	assert.Equal(t, 50, cs.CacheCreationTokens)
+}
+
+// TestUnsupportedUsageKindForAgentFilter pins Copilot branding to Copilot
+// identity: an agent that merely shares Copilot's capabilities (no token
+// data, AI-credits denominated) must degrade to the generic kind, not be
+// described as Copilot. No t.Parallel: it stubs the parser registry.
+func TestUnsupportedUsageKindForAgentFilter(t *testing.T) {
+	parsertest.StubAgentDefs(t, parser.AgentDef{
+		Type:        parser.AgentType("credit-note-agent"),
+		DisplayName: "Credit Note Agent",
+		Usage: parser.UsageCapabilities{
+			NoPerMessageTokenData: true,
+			AICreditsDenominated:  true,
+		},
+	})
+
+	cases := []struct {
+		name   string
+		filter string
+		want   string
+	}{
+		{
+			name:   "all-copilot filter",
+			filter: "copilot,vscode-copilot",
+			want:   UnsupportedUsageKindCopilotNoTokenData,
+		},
+		{
+			name:   "non-copilot agent with copilot capabilities",
+			filter: "credit-note-agent",
+			want:   UnsupportedUsageKindNoTokenData,
+		},
+		{
+			name:   "copilot mixed with non-copilot",
+			filter: "copilot,credit-note-agent",
+			want:   UnsupportedUsageKindNoTokenData,
+		},
+		{
+			name:   "empty filter",
+			filter: "",
+			want:   UnsupportedUsageKindNoTokenData,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want,
+				UnsupportedUsageKindForAgentFilter(tc.filter))
+		})
+	}
 }


### PR DESCRIPTION
The follow-up from PR #947 is that the no-token-data usage hint and Copilot AI-credit accounting both depend on Copilot name matching in `internal/db/usage.go`. That helper now carries two separate meanings: whether an agent records per-message token data, and whether its cost is denominated in Copilot-style AI credits. Wes called out that a future Copilot variant or another no-token-data agent would have to remember this storage-layer helper, while the deeper home is capability metadata on the agent registry.

This moves the usage semantics onto `internal/parser/types.go`, with separate capability flags for agents that do not record per-message token data and agents whose cost should be surfaced as AI credits. The CLI no-token-data note and dashboard unsupported-usage trigger now ask the parser capability surface whether the selected filter contains only no-token-data agents, while the SQLite, PostgreSQL, and DuckDB accounting paths ask the distinct AI-credit capability before converting cost. Current behavior for Copilot, VS Code Copilot, and Visual Studio Copilot is preserved, but future agents can opt into one capability without inheriting the other.

The dashboard also gets a generic localized fallback for unknown `unsupportedUsage.kind` values across English, Simplified Chinese, and Traditional Chinese. The existing `copilot-no-token-data` copy stays scoped to Copilot-family filters, while other no-token agents now fall back to generic messaging instead of inheriting Copilot-specific wording, and future backend kinds still degrade visibly instead of rendering nothing. Scope stays limited to the ownership and fallback issues from https://github.com/kenn-io/agentsview/pull/947#issuecomment-4869656623.
