### PR TITLE
feat(parser): add Devin CLI session support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ On first run, agentsview discovers sessions from every supported agent on your
 machine, syncs them into a local SQLite database, and serves a web UI at
 `http://127.0.0.1:8080`.
 
+For Devin CLI, point `DEVIN_DIR` or `devin_dirs` at the local root that contains
+`cli/` — for example `~/Library/Application Support/devin` on macOS,
+`~/.local/share/devin` on Linux, or a redacted path like
+`.../Application Support/devin`. AgentsView reads session data under
+`<root>/cli/...` and intentionally ignores copied config or OAuth paths. Do not
+paste tokens, OAuth files, or other secrets into bug reports.
+
 Claude and Codex sources can also be configured as `s3://` roots, so a central
 AgentsView instance can read sessions that other machines push to S3-compatible
 object storage. Add those roots to `claude_project_dirs` or
@@ -301,6 +308,7 @@ thread JSON files.
 | Claude Cowork         | `~/Library/Application Support/Claude/local-agent-mode-sessions/` (macOS)                                                                                               |
 | Codex                 | `~/.codex/sessions/`                                                                                                                                                    |
 | Copilot CLI           | `~/.copilot/`                                                                                                                                                           |
+| Devin CLI             | `~/.local/share/devin/` (Linux), `~/Library/Application Support/devin/` (macOS); point `DEVIN_DIR` / `devin_dirs` at the root that contains `cli/`                      |
 | Cortex Code           | `~/.snowflake/cortex/conversations/`                                                                                                                                    |
 | Cursor                | `~/.cursor/projects/`                                                                                                                                                   |
 | DeepSeek TUI          | `~/.codewhale/sessions/`, `~/.deepseek/sessions/`                                                                                                                       |

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -1030,12 +1030,16 @@ func collectWatchRoots(cfg config.Config) (roots []watchRoot, unwatchedDirs []st
 		})
 	}
 	for _, def := range parser.Registry {
-		if !def.FileBased {
-			continue
-		}
 		for _, d := range cfg.ResolveDirs(def.Type) {
+			_, hasProvider := parser.ProviderFactoryByType(def.Type)
 			if providerWatched, providerUnwatched := collectProviderWatchRoots(def, d, addRoot); providerWatched {
 				unwatchedDirs = append(unwatchedDirs, providerUnwatched...)
+				continue
+			}
+			if !def.FileBased {
+				if hasProvider {
+					unwatchedDirs = append(unwatchedDirs, d)
+				}
 				continue
 			}
 			fallbackUnwatched := collectLegacyWatchRoots(def, d, addRoot)

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -758,6 +758,44 @@ func TestCollectWatchRootsUsesAntigravityCLIHistoryRoot(t *testing.T) {
 	assert.False(t, brain.shallow)
 }
 
+func TestCollectWatchRootsIncludesDevinProviderRootsForNonFileAgent(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "cli", "transcripts"), 0o755))
+	writeTestFile(t, filepath.Join(root, "cli", "sessions.db"), []byte("sqlite"))
+
+	cfg := config.Config{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentDevin: {root},
+		},
+	}
+
+	roots, unwatchedDirs := collectWatchRoots(cfg)
+
+	require.Empty(t, unwatchedDirs)
+	cliRoot, ok := findCollectedWatchRoot(roots, filepath.Join(root, "cli"))
+	require.True(t, ok, "devin cli root not collected")
+	assert.True(t, cliRoot.shallow)
+	assert.Equal(t, []string{root}, cliRoot.dirs)
+	transcriptsRoot, ok := findCollectedWatchRoot(roots, filepath.Join(root, "cli", "transcripts"))
+	require.True(t, ok, "devin transcripts root not collected")
+	assert.True(t, transcriptsRoot.shallow)
+	assert.Equal(t, []string{root}, transcriptsRoot.dirs)
+}
+
+func TestCollectWatchRootsMarksDevinRootUnwatchedWhenProviderPathsMissing(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.Config{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentDevin: {root},
+		},
+	}
+
+	roots, unwatchedDirs := collectWatchRoots(cfg)
+
+	assert.Empty(t, roots)
+	assert.Equal(t, []string{root}, unwatchedDirs)
+}
+
 func TestMissingWatchRootCoverageDoesNotTreatShallowAncestorAsRecursive(t *testing.T) {
 	root := filepath.Clean(filepath.Join(t.TempDir(), "state"))
 	shallowRoots := []watchRoot{{root: root, shallow: true}}

--- a/cmd/agentsview/parse_diff.go
+++ b/cmd/agentsview/parse_diff.go
@@ -242,8 +242,7 @@ func parseDiffAgentTypes(names []string) ([]parser.AgentType, error) {
 		}
 		if !parseDiffAgentSupported(def) {
 			return nil, fmt.Errorf(
-				"agent %q is not supported by parse-diff "+
-					"(no on-disk source to re-parse)",
+				"agent %q is not supported by parse-diff",
 				raw,
 			)
 		}
@@ -270,9 +269,9 @@ func parseDiffAgentSupported(def parser.AgentDef) bool {
 	// A provider-authoritative agent with a registered factory has a
 	// Discover()/Parse() parse-diff can re-parse, whether it reads literal
 	// per-session files or a shared SQLite store it fans out per session
-	// (Kiro, OpenCode, Forge, Piebald, Warp). FileBased is not consulted:
-	// import-only agents are already excluded because they are not
-	// provider-authoritative.
+	// (Kiro, OpenCode, Forge, Devin, Piebald, Warp). FileBased is not
+	// consulted: import-only agents are already excluded because they are
+	// not provider-authoritative.
 	switch parser.ProviderMigrationModes()[def.Type] {
 	case parser.ProviderMigrationProviderAuthoritative:
 		_, ok := parser.ProviderFactoryByType(def.Type)

--- a/cmd/agentsview/parse_diff_test.go
+++ b/cmd/agentsview/parse_diff_test.go
@@ -60,7 +60,7 @@ func TestParseDiff_UnknownAgentListsSupported(t *testing.T) {
 	}
 	// The DB-backed provider-authoritative agents are re-parseable through
 	// their providers, so they appear in the supported list too.
-	for _, want := range []string{"forge", "piebald", "warp"} {
+	for _, want := range []string{"forge", "devin", "piebald", "warp"} {
 		assert.Contains(t, err.Error(), want,
 			"error should list supported DB-backed agent %q", want)
 	}
@@ -90,8 +90,7 @@ func TestParseDiff_RejectsAgentsWithoutOnDiskSource(t *testing.T) {
 				"parse-diff", "--agent", tc.agent)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), fmt.Sprintf(
-				"agent %q is not supported by parse-diff "+
-					"(no on-disk source to re-parse)", tc.agent))
+				"agent %q is not supported by parse-diff", tc.agent))
 		})
 	}
 }
@@ -130,8 +129,8 @@ func TestParseDiffAgentTypes(t *testing.T) {
 		},
 		{
 			name: "db-backed provider-authoritative agents",
-			in:   []string{"forge", "piebald", "warp"},
-			want: []string{"forge", "piebald", "warp"},
+			in:   []string{"forge", "devin", "piebald", "warp"},
+			want: []string{"forge", "devin", "piebald", "warp"},
 		},
 		{
 			name: "trims and lowercases",
@@ -151,7 +150,7 @@ func TestParseDiffAgentTypes(t *testing.T) {
 		{
 			name:    "import-only agent",
 			in:      []string{"claude-ai"},
-			wantErr: "no on-disk source to re-parse",
+			wantErr: "is not supported by parse-diff",
 		},
 	}
 	for _, tc := range tests {
@@ -183,15 +182,22 @@ func TestParseDiffSupportedAgentsIncludesProviderAuthoritativeAgents(t *testing.
 	// current provider-authoritative agent and stays correct as the migration
 	// manifest changes, rather than a hand-maintained subset. FileBased is not
 	// part of the gate: DB-backed provider-authoritative agents
-	// (Forge/Piebald/Warp) are re-parseable through their providers too.
+	// (Forge/Devin/Piebald/Warp) are re-parseable through their providers too.
 	checked := 0
 	for _, def := range parser.Registry {
 		if modes[def.Type] != parser.ProviderMigrationProviderAuthoritative {
 			continue
 		}
+		if _, ok := parser.ProviderFactoryByType(def.Type); !ok {
+			assert.False(t, parseDiffAgentSupported(def),
+				"parse-diff must exclude %s without a provider factory", def.Type)
+			assert.NotContains(t, supported, string(def.Type),
+				"parse-diff supported list must exclude %s without a provider factory", def.Type)
+			continue
+		}
 		checked++
 		assert.True(t, parseDiffAgentSupported(def),
-			"parse-diff support must include provider-authoritative %s", def.Type)
+			"parse-diff support must include %s", def.Type)
 		assert.Contains(t, supported, string(def.Type),
 			"parse-diff supported list must include %s", def.Type)
 	}
@@ -202,7 +208,8 @@ func TestParseDiffSupportedAgentsIncludesProviderAuthoritativeAgents(t *testing.
 	// regression that re-adds a FileBased gate to the parse-diff support
 	// check is caught by name, not just by the registry-wide sweep above.
 	for _, agent := range []parser.AgentType{
-		parser.AgentForge, parser.AgentPiebald, parser.AgentWarp,
+		parser.AgentForge, parser.AgentDevin,
+		parser.AgentPiebald, parser.AgentWarp,
 	} {
 		def, ok := parser.AgentByType(agent)
 		require.True(t, ok, "agent %s", agent)

--- a/cmd/agentsview/token_use.go
+++ b/cmd/agentsview/token_use.go
@@ -42,11 +42,11 @@ const (
 //     in SQL; suffix matches come back in most-recent order. If
 //     multiple suffix matches exist without an exact row, the
 //     most recent wins and an ambiguity warning is emitted.
-//  3. Canonical disk probe: when input begins with a registered
-//     agent prefix, strip the prefix and ask that agent's disk source
-//     lookup so a truly canonical-but-unsynced ID on disk still resolves.
-//  4. Raw disk probe: ask every file-based agent's disk source lookup
-//     with the raw input; the first hit yields "<prefix><input>".
+//  3. Canonical provider probe: when input begins with a registered
+//     agent prefix, strip the prefix and ask that agent's source lookup
+//     so a truly canonical-but-unsynced ID still resolves.
+//  4. Raw provider probe: ask every file-backed agent plus Devin for a
+//     raw-ID source lookup; the first hit yields "<prefix><input>".
 //  5. No match anywhere: returned unchanged with known=false.
 //
 // known reports whether resolution found evidence for the ID.
@@ -88,7 +88,7 @@ func resolveRawSessionID(
 	// before resolving the source (which rejects IDs with
 	// colons via IsValidSessionID).
 	for _, def := range parser.Registry {
-		if def.IDPrefix == "" || !def.FileBased ||
+		if def.IDPrefix == "" ||
 			!agentHasDiskSourceLookup(def) {
 			continue
 		}
@@ -109,7 +109,7 @@ func resolveRawSessionID(
 	// colon-bearing raw IDs (Kimi, OpenClaw, Kiro IDE) may
 	// match.
 	for _, def := range parser.Registry {
-		if !def.FileBased || !agentHasDiskSourceLookup(def) {
+		if !agentHasDiskSourceLookup(def) {
 			continue
 		}
 		for _, dir := range agentDirs[def.Type] {
@@ -122,10 +122,13 @@ func resolveRawSessionID(
 	return input, false
 }
 
-// agentHasDiskSourceLookup reports whether a session source can be located on
-// disk by raw ID for the agent, via its provider-authoritative provider's
-// FindSource.
+// agentHasDiskSourceLookup reports whether a session source can be located by
+// raw ID via the provider facade's FindSource path. This covers file-backed
+// agents plus Devin's provider-owned virtual session paths.
 func agentHasDiskSourceLookup(def parser.AgentDef) bool {
+	if !def.FileBased && def.Type != parser.AgentDevin {
+		return false
+	}
 	if parser.ProviderMigrationModes()[def.Type] !=
 		parser.ProviderMigrationProviderAuthoritative {
 		return false

--- a/cmd/agentsview/token_use_test.go
+++ b/cmd/agentsview/token_use_test.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"os"
 	"path/filepath"
 	"testing"
 
+	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/db"
@@ -278,6 +280,49 @@ func TestResolveSessionID_ProviderAuthoritativeCursorOnDiskNotInDB(t *testing.T)
 	assert.True(t, known, "canonical provider disk probe")
 }
 
+func TestResolveSessionID_DevinCanonicalID_OnDiskNotInDB(t *testing.T) {
+	d := newTestDB(t)
+	ctx := context.Background()
+
+	root := t.TempDir()
+	cliDir := filepath.Join(root, "cli")
+	transcriptsDir := filepath.Join(cliDir, "transcripts")
+	require.NoError(t, os.MkdirAll(transcriptsDir, 0o755))
+	dbPath := filepath.Join(cliDir, "sessions.db")
+	devinDB, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, devinDB.Close()) })
+	_, err = devinDB.Exec(`
+		CREATE TABLE sessions (
+			id TEXT PRIMARY KEY,
+			title TEXT,
+			working_directory TEXT,
+			model TEXT,
+			created_at INTEGER,
+			last_activity_at INTEGER,
+			hidden INTEGER NOT NULL DEFAULT 0
+		);
+		INSERT INTO sessions
+			(id, title, working_directory, model, created_at, last_activity_at, hidden)
+		VALUES
+			('session-123', 'Devin session', '/cwd/devin', 'devin-1', 1700000000000, 1700000001000, 0);
+	`)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(transcriptsDir, "session-123.json"),
+		[]byte(`{"messages":[]}`+"\n"),
+		0o644,
+	))
+
+	agentDirs := map[parser.AgentType][]string{
+		parser.AgentDevin: {root},
+	}
+	got, known := resolveRawSessionID(ctx, d, agentDirs, "devin:session-123")
+	assert.Equal(t, "devin:session-123", got)
+	assert.True(t, known,
+		"provider-backed Devin IDs should resolve via FindSource even though FileBased is false")
+}
+
 func TestResolveSessionID_RawOpenClawCollidesWithCodexPrefix(t *testing.T) {
 	d := newTestDB(t)
 	ctx := context.Background()
@@ -320,7 +365,7 @@ func TestResolveSessionID_UnderscoreID_NoFalseMatch(t *testing.T) {
 	assert.True(t, known)
 }
 
-func TestAgentHasDiskSourceLookupIncludesProviderAuthoritativeAgents(t *testing.T) {
+func TestAgentHasDiskSourceLookupIncludesFileBackedAgentsAndDevin(t *testing.T) {
 	for _, agent := range []parser.AgentType{
 		parser.AgentGptme,
 		parser.AgentPi,
@@ -331,6 +376,7 @@ func TestAgentHasDiskSourceLookupIncludesProviderAuthoritativeAgents(t *testing.
 		parser.AgentQwenPaw,
 		parser.AgentOpenHands,
 		parser.AgentCursor,
+		parser.AgentDevin,
 		parser.AgentVibe,
 		parser.AgentClaude,
 		parser.AgentCowork,
@@ -339,8 +385,12 @@ func TestAgentHasDiskSourceLookupIncludesProviderAuthoritativeAgents(t *testing.
 		def, ok := parser.AgentByType(agent)
 		require.True(t, ok, "agent %s", agent)
 		assert.True(t, agentHasDiskSourceLookup(def),
-			"token-use disk probe must include provider-authoritative %s", agent)
+			"token-use source probe must include %s", agent)
 	}
+	warpDef, ok := parser.AgentByType(parser.AgentWarp)
+	require.True(t, ok, "agent %s", parser.AgentWarp)
+	assert.False(t, agentHasDiskSourceLookup(warpDef),
+		"token-use source probe must exclude non-Devin non-file-backed agents")
 }
 
 func TestUsageExitCode_TokenData(t *testing.T) {

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -705,7 +705,7 @@ agentsview parse-diff --json > parser-report.json
 `parse-diff` is intended for parser development and release QA. Run it against a
 quiescent, freshly synced archive for the clearest signal. Import-only sources
 are skipped because there is no source file to re-parse. Provider-backed stores
-with authoritative local sources, including Warp, Forge, and Piebald, are
+with authoritative local sources, including Warp, Forge, Piebald, and Devin, are
 covered alongside normal file-backed agents.
 
 ______________________________________________________________________

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -186,6 +186,7 @@ can still be parsed.
 | Codex                 | `~/.codex/sessions/` and `~/.codex/archived_sessions/`                           | JSONL per session                                                                                                               |
 | Command Code          | `~/.commandcode/projects/`                                                       | JSONL per session, optional `.meta.json` sidecar                                                                                |
 | Copilot CLI           | `~/.copilot/`                                                                    | JSONL per session under `session-state/`                                                                                        |
+| Devin CLI             | `~/.local/share/devin/` (Linux), `~/Library/Application Support/devin/` (macOS)             | Local CLI data rooted at the directory that contains `cli/`; session data is discovered under `<root>/cli/...`                 |
 | Cortex Code           | `~/.snowflake/cortex/conversations/`                                             | JSON / JSONL per session                                                                                                        |
 | Cursor                | `~/.cursor/projects/`                                                            | JSONL or plain-text transcripts                                                                                                 |
 | DeepSeek TUI          | `~/.codewhale/sessions/` and `~/.deepseek/sessions/`                             | JSON per session                                                                                                                |
@@ -271,6 +272,19 @@ log reports how many directories are watched this way:
 ```
 Watching 74 directories for changes (2 shallow) (76ms)
 ```
+
+**Devin CLI root:** Point `DEVIN_DIR` or `devin_dirs` at the local root that
+contains Devin's `cli/` directory, not at copied config or OAuth files. The
+default roots are `~/Library/Application Support/devin` on macOS and
+`~/.local/share/devin` on Linux, and AgentsView discovers session data under
+`<root>/cli/...`. When sharing a path publicly, redact parent directories and
+keep only the relevant tail, for example `.../Application Support/devin` or
+`.../.local/share/devin`.
+
+AgentsView intentionally ignores copied config/OAuth locations because those
+paths are not the session archive source and may contain sensitive account
+material. When filing bugs, share only the redacted local-share root and
+directory shape, never pasted tokens, OAuth files, or other secrets.
 
 **OpenCode storage backend:** As of 0.24.0, AgentsView reads both of OpenCode's
 layouts. If a `storage/session/` directory exists under the OpenCode root,
@@ -383,6 +397,7 @@ export COWORK_DIR=~/custom/cowork
 export CODEX_SESSIONS_DIR=~/custom/codex
 export COMMANDCODE_PROJECTS_DIR=~/custom/commandcode
 export COPILOT_DIR=~/custom/copilot
+export DEVIN_DIR=~/Library/Application\ Support/devin
 export CORTEX_DIR=~/custom/cortex
 export CURSOR_PROJECTS_DIR=~/custom/cursor
 export DEEPSEEK_TUI_SESSIONS_DIR=~/custom/deepseek/sessions
@@ -435,7 +450,7 @@ codex_sessions_dirs = [
 
 The corresponding fields are `aider_dirs`, `amp_dirs`, `antigravity_dirs`,
 `antigravity_cli_dirs`, `claude_project_dirs`, `openclaude_project_dirs`,
-`cowork_dirs`,
+`cowork_dirs`, `devin_dirs`,
 `codex_sessions_dirs`, `commandcode_project_dirs`, `copilot_dirs`,
 `cortex_dirs`, `cursor_project_dirs`, `deepseek_tui_sessions_dirs`,
 `forge_dirs`, `gemini_dirs`, `gptme_dirs`, `hermes_sessions_dirs`, `iflow_dirs`,

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1139,7 +1139,7 @@ Settings are organized into sections:
 |---------|----------------------|
 | Language | Interface language (English or Simplified Chinese) |
 | Appearance | Theme (light/dark), high-contrast mode, message layout, text size, block visibility, desktop zoom level |
-| Agent Directories | Custom paths for each agent's session files |
+| Agent Directories | Custom paths for each agent's session files. For Devin CLI, point at the local root that contains `cli/` (for example a redacted `.../Application Support/devin` path), not copied config or OAuth files. |
 | Terminal | Default terminal emulator for session resume |
 | Worktree Mappings | Map worktree paths back to their main project (see [Worktree Project Mappings](/configuration/#worktree-project-mappings)) |
 | GitHub | Personal access token for Gist publishing |

--- a/frontend/src/lib/utils/agents.test.ts
+++ b/frontend/src/lib/utils/agents.test.ts
@@ -14,6 +14,7 @@ describe("KNOWN_AGENTS", () => {
       "cowork",
       "codex",
       "copilot",
+      "devin",
       "gemini",
       "opencode",
       "openhands",
@@ -61,6 +62,9 @@ describe("agentColor", () => {
     );
     expect(agentColor("copilot")).toBe(
       "var(--accent-amber)",
+    );
+    expect(agentColor("devin")).toBe(
+      "var(--accent-red)",
     );
     expect(agentColor("gemini")).toBe(
       "var(--accent-rose)",
@@ -156,6 +160,7 @@ describe("agentLabel", () => {
       "Visual Studio Copilot",
     );
     expect(agentLabel("openhands")).toBe("OpenHands");
+    expect(agentLabel("devin")).toBe("Devin");
     expect(agentLabel("openclaw")).toBe("OpenClaw");
     expect(agentLabel("qclaw")).toBe("QClaw");
     expect(agentLabel("iflow")).toBe("iFlow");

--- a/frontend/src/lib/utils/agents.ts
+++ b/frontend/src/lib/utils/agents.ts
@@ -9,6 +9,7 @@ export const KNOWN_AGENTS: readonly AgentMeta[] = [
   { name: "cowork", color: "var(--accent-sky)", label: "Claude Cowork" },
   { name: "codex", color: "var(--accent-green)" },
   { name: "copilot", color: "var(--accent-amber)" },
+  { name: "devin", color: "var(--accent-red)", label: "Devin" },
   { name: "gemini", color: "var(--accent-rose)" },
   { name: "opencode", color: "var(--accent-purple)" },
   { name: "openhands", color: "var(--accent-teal)", label: "OpenHands" },

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -283,6 +283,17 @@ func TestDefault_SkipsAiderUntilConfigured(t *testing.T) {
 	assert.False(t, cfg.IsUserConfigured(parser.AgentAider))
 }
 
+func TestDefault_IncludesDevinLocalShareRoots(t *testing.T) {
+	cfg, err := Default()
+	require.NoError(t, err)
+
+	dirs := cfg.ResolveDirs(parser.AgentDevin)
+	require.Len(t, dirs, 2)
+	assert.True(t, strings.HasSuffix(dirs[0], filepath.Join("Library", "Application Support", "devin")), "dirs[0] = %q", dirs[0])
+	assert.True(t, strings.HasSuffix(dirs[1], filepath.Join(".local", "share", "devin")), "dirs[1] = %q", dirs[1])
+	assert.False(t, cfg.IsUserConfigured(parser.AgentDevin))
+}
+
 func TestLoadEnv_OverridesDataDir(t *testing.T) {
 	custom := setupTestEnv(t)
 
@@ -748,6 +759,46 @@ func TestResolveDirs_ClaudeConfigDirRootEnvVar(t *testing.T) {
 		assert.Equal(t, []string{"/from/config"},
 			cfg.ResolveDirs(parser.AgentClaude))
 		assert.True(t, cfg.IsUserConfigured(parser.AgentClaude))
+	})
+}
+
+func TestResolveDirs_DevinPrecedenceAndMergeRules(t *testing.T) {
+	t.Run("config overrides defaults", func(t *testing.T) {
+		cfg := loadMinimalWithConfig(t, map[string]any{
+			"devin_dirs": []string{"/from/config/devin"},
+		})
+
+		assert.Equal(t, []string{"/from/config/devin"},
+			cfg.ResolveDirs(parser.AgentDevin))
+		assert.True(t, cfg.IsUserConfigured(parser.AgentDevin))
+	})
+
+	t.Run("env overrides config", func(t *testing.T) {
+		f := newConfigFixture(t)
+		f.WriteTOML(t, map[string]any{
+			"devin_dirs": []string{"/from/config/devin"},
+		})
+		t.Setenv("DEVIN_DIR", "/from/env/devin")
+
+		cfg := f.LoadMinimal(t)
+
+		assert.Equal(t, []string{"/from/env/devin"},
+			cfg.ResolveDirs(parser.AgentDevin))
+		assert.True(t, cfg.IsUserConfigured(parser.AgentDevin))
+	})
+
+	t.Run("config file still applies when env unset", func(t *testing.T) {
+		f := newConfigFixture(t)
+		f.WriteTOML(t, map[string]any{
+			"devin_dirs": []string{"/from/config/devin", "/second/config/devin"},
+		})
+		t.Setenv("DEVIN_DIR", "")
+
+		cfg := f.LoadMinimal(t)
+
+		assert.Equal(t, []string{"/from/config/devin", "/second/config/devin"},
+			cfg.ResolveDirs(parser.AgentDevin))
+		assert.True(t, cfg.IsUserConfigured(parser.AgentDevin))
 	})
 }
 

--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -23,8 +23,8 @@ const rootSessionFilter = `message_count > 0
 	AND relationship_type NOT IN ('subagent', 'fork')
 	AND deleted_at IS NULL`
 
-func nonFileAgentPlaceholders() string {
-	agents := parser.NonFileBackedAgents()
+func nonSourceBackedAgentPlaceholders() string {
+	agents := nonSourceBackedAgents()
 	placeholders := make([]string, len(agents))
 	for i := range agents {
 		placeholders[i] = "?"
@@ -32,8 +32,8 @@ func nonFileAgentPlaceholders() string {
 	return strings.Join(placeholders, ", ")
 }
 
-func nonFileAgentArgs() []any {
-	agents := parser.NonFileBackedAgents()
+func nonSourceBackedAgentArgs() []any {
+	agents := nonSourceBackedAgents()
 	args := make([]any, len(agents))
 	for i, a := range agents {
 		args[i] = string(a)
@@ -41,19 +41,29 @@ func nonFileAgentArgs() []any {
 	return args
 }
 
-// FileBackedSessionCount returns the number of root sessions
-// synced from files (excludes non-file-backed agents like
-// OpenCode and Claude.ai). Used by ResyncAll to decide
-// whether empty file discovery should abort the swap.
+func nonSourceBackedAgents() []parser.AgentType {
+	var agents []parser.AgentType
+	for _, def := range parser.Registry {
+		if def.FileBased || def.Type == parser.AgentDevin {
+			continue
+		}
+		agents = append(agents, def.Type)
+	}
+	return agents
+}
+
+// FileBackedSessionCount returns the number of root sessions protected by local
+// resync discovery. This includes literal file-backed sessions plus Devin's
+// provider-backed local CLI archive sessions.
 func (db *DB) FileBackedSessionCount(
 	ctx context.Context,
 ) (int, error) {
 	var count int
 	err := db.getReader().QueryRowContext(ctx,
 		`SELECT COUNT(*) FROM sessions
-		 WHERE agent NOT IN (`+nonFileAgentPlaceholders()+`)
+		 WHERE agent NOT IN (`+nonSourceBackedAgentPlaceholders()+`)
 		 AND `+rootSessionFilter,
-		nonFileAgentArgs()...,
+		nonSourceBackedAgentArgs()...,
 	).Scan(&count)
 	if err != nil {
 		return 0, fmt.Errorf(

--- a/internal/db/stats_test.go
+++ b/internal/db/stats_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFileBackedSessionCount_ExcludesNonFileAgents(
+func TestFileBackedSessionCount_ExcludesNonDevinNonFileBackedAgents(
 	t *testing.T,
 ) {
 	d := testDB(t)
@@ -18,15 +18,20 @@ func TestFileBackedSessionCount_ExcludesNonFileAgents(
 	insertSession(t, d, "claude-ai:test-1", "claude.ai",
 		func(s *Session) { s.Agent = "claude-ai" })
 
-	// Insert a warp session (non-file-backed).
+	// Insert a warp session (non-Devin, non-file-backed).
 	insertSession(t, d, "warp:test-1", "myproject",
 		func(s *Session) { s.Agent = "warp" })
+
+	// Insert a devin session (provider-backed local source; FileBased=false but
+	// still protected by resync counting).
+	insertSession(t, d, "devin:test-1", "myproject",
+		func(s *Session) { s.Agent = "devin" })
 
 	// Insert a claude session (file-backed).
 	insertSession(t, d, "test-file-session", "myproject")
 
 	count, err := d.FileBackedSessionCount(ctx)
 	require.NoError(t, err, "FileBackedSessionCount")
-	assert.Equal(t, 1, count,
-		"FileBackedSessionCount should be 1 (only claude session)")
+	assert.Equal(t, 2, count,
+		"FileBackedSessionCount should include claude plus devin, but exclude other non-file-backed agents")
 }

--- a/internal/parser/content.go
+++ b/internal/parser/content.go
@@ -55,47 +55,13 @@ func ExtractTextContent(
 			// some tools populate only "arguments", so fall back to
 			// it when "input" is missing or empty.
 			hasToolUse = true
-			name := block.Get("name").Str
-			if name != "" {
-				input := block.Get("input")
-				if input.Raw == "" || input.Raw == "{}" {
-					if args := block.Get("arguments"); args.Exists() {
-						input = args
-					}
-				}
-				tc := ParsedToolCall{
-					ToolUseID: block.Get("id").Str,
-					ToolName:  name,
-					Category:  NormalizeToolCategory(name),
-					InputJSON: input.Raw,
-				}
-				switch name {
-				case "Skill":
-					tc.SkillName = input.Get("skill").Str
-				case "skill":
-					tc.SkillName = input.Get("skill").Str
-					if tc.SkillName == "" {
-						tc.SkillName = input.Get("name").Str
-					}
-				default:
-					tc.SkillName = inferToolSkillName(
-						name,
-						tc.InputJSON,
-					)
-				}
+			if tc, ok := parseToolCall(block); ok {
 				toolCalls = append(toolCalls, tc)
 			}
 			parts = append(parts, formatToolUse(block))
 		case "tool_result":
-			tuid := block.Get("tool_use_id").Str
-			if tuid != "" {
-				rc := block.Get("content")
-				cl := toolResultContentLength(rc)
-				toolResults = append(toolResults, ParsedToolResult{
-					ToolUseID:     tuid,
-					ContentLength: cl,
-					ContentRaw:    rc.Raw,
-				})
+			if tr, ok := parseToolResult(block); ok {
+				toolResults = append(toolResults, tr)
 			}
 		}
 		return true
@@ -104,6 +70,55 @@ func ExtractTextContent(
 	return strings.Join(parts, "\n"),
 		strings.Join(thinkingParts, "\n\n"),
 		hasThinking, hasToolUse, toolCalls, toolResults
+}
+
+func parseToolCall(block gjson.Result) (ParsedToolCall, bool) {
+	name := block.Get("name").Str
+	if name == "" {
+		return ParsedToolCall{}, false
+	}
+	input := toolCallInput(block)
+	tc := ParsedToolCall{
+		ToolUseID: block.Get("id").Str,
+		ToolName:  name,
+		Category:  NormalizeToolCategory(name),
+		InputJSON: input.Raw,
+	}
+	switch name {
+	case "Skill":
+		tc.SkillName = input.Get("skill").Str
+	case "skill":
+		tc.SkillName = input.Get("skill").Str
+		if tc.SkillName == "" {
+			tc.SkillName = input.Get("name").Str
+		}
+	default:
+		tc.SkillName = inferToolSkillName(name, tc.InputJSON)
+	}
+	return tc, true
+}
+
+func toolCallInput(block gjson.Result) gjson.Result {
+	input := block.Get("input")
+	if input.Raw == "" || input.Raw == "{}" {
+		if args := block.Get("arguments"); args.Exists() {
+			input = args
+		}
+	}
+	return input
+}
+
+func parseToolResult(block gjson.Result) (ParsedToolResult, bool) {
+	tuid := block.Get("tool_use_id").Str
+	if tuid == "" {
+		return ParsedToolResult{}, false
+	}
+	rc := block.Get("content")
+	return ParsedToolResult{
+		ToolUseID:     tuid,
+		ContentLength: toolResultContentLength(rc),
+		ContentRaw:    rc.Raw,
+	}, true
 }
 
 func toolResultContentLength(content gjson.Result) int {

--- a/internal/parser/db_backed_provider.go
+++ b/internal/parser/db_backed_provider.go
@@ -447,15 +447,7 @@ func (s dbBackedSource) virtualPath() string {
 }
 
 func parseDBBackedVirtualPath(path string) (string, string, bool) {
-	idx := strings.LastIndex(path, "#")
-	if idx < 0 {
-		return "", "", false
-	}
-	dbPath, sessionID := path[:idx], path[idx+1:]
-	if dbPath == "" || sessionID == "" {
-		return "", "", false
-	}
-	return dbPath, sessionID, true
+	return ParseVirtualSourcePath(path)
 }
 
 func newForgeProviderFactory(def AgentDef) ProviderFactory {

--- a/internal/parser/devin.go
+++ b/internal/parser/devin.go
@@ -1,0 +1,911 @@
+package parser
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/tidwall/gjson"
+)
+
+const devinDBFilename = "sessions.db"
+
+// DevinSessionMeta is lightweight metadata for a Devin session row.
+type DevinSessionMeta struct {
+	RawSessionID string
+	VirtualPath  string
+	Title        string
+	CWD          string
+	Model        string
+	CreatedAt    time.Time
+	LastActivity time.Time
+	UpdatedAt    time.Time
+	FileMtime    int64
+}
+
+// devinDBPath returns <root>/cli/sessions.db when present.
+func devinDBPath(root string) string {
+	if root == "" {
+		return ""
+	}
+	path := filepath.Join(root, "cli", devinDBFilename)
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return ""
+	}
+	return path
+}
+
+// ListDevinSessionMeta returns lightweight metadata for all non-hidden Devin
+// sessions without parsing transcripts.
+func ListDevinSessionMeta(dbPath string) ([]DevinSessionMeta, error) {
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		return nil, nil
+	}
+
+	db, err := openDevinDB(dbPath)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+
+	rows, err := db.Query(`
+		SELECT id,
+		       COALESCE(title, ''),
+		       COALESCE(working_directory, ''),
+		       COALESCE(model, ''),
+		       COALESCE(created_at, 0),
+		       last_activity_at,
+		       COALESCE(last_activity_at, created_at)
+		  FROM sessions
+		 WHERE COALESCE(hidden, 0) <> 1
+		 ORDER BY COALESCE(last_activity_at, created_at) DESC, id DESC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("listing devin sessions: %w", err)
+	}
+	defer rows.Close()
+
+	var metas []DevinSessionMeta
+	for rows.Next() {
+		var meta DevinSessionMeta
+		var createdAtMS int64
+		var lastActivityMS sql.NullInt64
+		var updatedAtMS int64
+		if err := rows.Scan(
+			&meta.RawSessionID,
+			&meta.Title,
+			&meta.CWD,
+			&meta.Model,
+			&createdAtMS,
+			&lastActivityMS,
+			&updatedAtMS,
+		); err != nil {
+			return nil, fmt.Errorf("scanning devin session meta: %w", err)
+		}
+		meta.VirtualPath = VirtualSourcePath(dbPath, meta.RawSessionID)
+		meta.CreatedAt = devinUnixMilli(createdAtMS)
+		if lastActivityMS.Valid {
+			meta.LastActivity = devinUnixMilli(lastActivityMS.Int64)
+		}
+		meta.UpdatedAt = devinUnixMilli(updatedAtMS)
+		meta.FileMtime = updatedAtMS * 1_000_000
+		metas = append(metas, meta)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating devin sessions: %w", err)
+	}
+	return metas, nil
+}
+
+func openDevinDB(dbPath string) (*sql.DB, error) {
+	dsn := "file:" + dbPath + "?mode=ro&_busy_timeout=3000"
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("opening devin db %s: %w", dbPath, err)
+	}
+	return db, nil
+}
+
+func getDevinSessionMeta(
+	dbPath, rawSessionID string,
+) (*DevinSessionMeta, error) {
+	db, err := openDevinDB(dbPath)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+
+	var meta DevinSessionMeta
+	var createdAtMS int64
+	var lastActivityMS sql.NullInt64
+	var updatedAtMS int64
+	err = db.QueryRow(`
+		SELECT id,
+		       COALESCE(title, ''),
+		       COALESCE(working_directory, ''),
+		       COALESCE(model, ''),
+		       COALESCE(created_at, 0),
+		       last_activity_at,
+		       COALESCE(last_activity_at, created_at)
+		  FROM sessions
+		 WHERE COALESCE(hidden, 0) <> 1
+		   AND id = ?
+	`, rawSessionID).Scan(
+		&meta.RawSessionID,
+		&meta.Title,
+		&meta.CWD,
+		&meta.Model,
+		&createdAtMS,
+		&lastActivityMS,
+		&updatedAtMS,
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("loading devin session meta: %w", err)
+	}
+
+	meta.VirtualPath = VirtualSourcePath(dbPath, meta.RawSessionID)
+	meta.CreatedAt = devinUnixMilli(createdAtMS)
+	if lastActivityMS.Valid {
+		meta.LastActivity = devinUnixMilli(lastActivityMS.Int64)
+	}
+	meta.UpdatedAt = devinUnixMilli(updatedAtMS)
+	meta.FileMtime = updatedAtMS * 1_000_000
+	return &meta, nil
+}
+
+func devinUnixMilli(ms int64) time.Time {
+	if ms <= 0 {
+		return time.Time{}
+	}
+	return time.UnixMilli(ms).UTC()
+}
+
+type devinTranscriptError struct {
+	op    string
+	cause error
+}
+
+func (e *devinTranscriptError) Error() string {
+	msg := fmt.Sprintf(
+		"%s devin transcript %s for session %s",
+		e.op,
+		devinRedactedTranscriptPath(),
+		devinRedactedSessionID(),
+	)
+	if e.cause != nil {
+		return msg + ": " + e.cause.Error()
+	}
+	return msg
+}
+
+func (e *devinTranscriptError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+func newDevinTranscriptError(op string, cause error) error {
+	return &devinTranscriptError{op: op, cause: cause}
+}
+
+func devinRedactedTranscriptPath() string {
+	return filepath.Join("cli", "transcripts", "<redacted-session-id>.json")
+}
+
+func devinRedactedSessionID() string {
+	return "<redacted-session-id>"
+}
+
+func parseDevinSession(dbPath, rawSessionID, machine string) (*ParsedSession, []ParsedMessage, error) {
+	meta, err := getDevinSessionMeta(dbPath, rawSessionID)
+	if err != nil {
+		return nil, nil, err
+	}
+	if meta == nil {
+		return nil, nil, sql.ErrNoRows
+	}
+
+	transcriptPath := filepath.Join(filepath.Dir(dbPath), "transcripts", rawSessionID+".json")
+	info, err := os.Stat(transcriptPath)
+	transcriptPresent := err == nil
+	if err != nil && !os.IsNotExist(err) {
+		return nil, nil, newDevinTranscriptError("stat", err)
+	}
+	if !transcriptPresent {
+		fallbackErr := newDevinTranscriptError("missing", nil)
+		sess, msgs, ok, err := parseDevinSessionFromMessageNodes(dbPath, rawSessionID, machine, meta)
+		if err == nil && ok {
+			return sess, msgs, nil
+		}
+		if err != nil {
+			return nil, nil, fallbackErr
+		}
+		return nil, nil, fallbackErr
+	}
+
+	data, err := os.ReadFile(transcriptPath)
+	if err != nil {
+		return nil, nil, newDevinTranscriptError("read", err)
+	}
+	if !gjson.ValidBytes(data) {
+		return nil, nil, newDevinTranscriptError("invalid", nil)
+	}
+
+	root := gjson.ParseBytes(data)
+	steps := root.Get("steps")
+	if !steps.IsArray() {
+		return nil, nil, newDevinTranscriptError("missing steps array in", nil)
+	}
+
+	model := firstNonEmpty(root.Get("agent.model_name").Str, metaValue(meta, func(m *DevinSessionMeta) string { return m.Model }))
+	cwd := firstNonEmpty(
+		metaValue(meta, func(m *DevinSessionMeta) string { return m.CWD }),
+		devinTranscriptCWD(root),
+	)
+
+	var (
+		messages      []ParsedMessage
+		firstMessage  string
+		firstStepAt   time.Time
+		lastStepAt    time.Time
+		rootStartedAt = parseTimestamp(root.Get("created_at").Str)
+		rootEndedAt   = parseTimestamp(root.Get("updated_at").Str)
+		userMsgCount  int
+		stepOrdinal   int
+	)
+
+	steps.ForEach(func(_, step gjson.Result) bool {
+		msg, ok := parseDevinStep(step, stepOrdinal, model)
+		stepOrdinal++
+		if !ok {
+			return true
+		}
+		messages = append(messages, msg)
+		if firstStepAt.IsZero() && !msg.Timestamp.IsZero() {
+			firstStepAt = msg.Timestamp
+		}
+		if msg.Timestamp.After(lastStepAt) {
+			lastStepAt = msg.Timestamp
+		}
+		if msg.Role == RoleUser && strings.TrimSpace(msg.Content) != "" {
+			userMsgCount++
+			if firstMessage == "" {
+				firstMessage = truncate(strings.ReplaceAll(msg.Content, "\n", " "), 300)
+			}
+		}
+		return true
+	})
+
+	startedAt := firstNonZeroTime(
+		metaTime(meta, func(m *DevinSessionMeta) time.Time { return m.CreatedAt }),
+		rootStartedAt,
+		firstStepAt,
+	)
+	endedAt := firstNonZeroTime(
+		metaTime(meta, func(m *DevinSessionMeta) time.Time { return m.LastActivity }),
+		lastStepAt,
+		rootEndedAt,
+		startedAt,
+	)
+
+	fileInfo := devinBaseFileInfo(dbPath, rawSessionID)
+	if transcriptPresent {
+		fileInfo.Size = info.Size()
+		fileInfo.Mtime = info.ModTime().UnixNano()
+	}
+	devinApplyFileInfoTimes(&fileInfo, meta, endedAt)
+
+	sess := buildDevinParsedSession(meta, rawSessionID, machine, cwd, firstMessage, startedAt, endedAt, userMsgCount, messages, fileInfo)
+	accumulateMessageTokenUsage(sess, messages)
+	applyDevinFinalMetrics(sess, root.Get("final_metrics"))
+	return sess, messages, nil
+}
+
+func parseDevinSessionFromMessageNodes(
+	dbPath, rawSessionID, machine string,
+	meta *DevinSessionMeta,
+) (*ParsedSession, []ParsedMessage, bool, error) {
+	rows, err := listDevinMessageNodes(dbPath, rawSessionID)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	if len(rows) == 0 {
+		return nil, nil, false, nil
+	}
+
+	model := metaValue(meta, func(m *DevinSessionMeta) string { return m.Model })
+	cwd := metaValue(meta, func(m *DevinSessionMeta) string { return m.CWD })
+
+	var (
+		messages     []ParsedMessage
+		firstMessage string
+		firstStepAt  time.Time
+		lastStepAt   time.Time
+		userMsgCount int
+	)
+	for _, row := range rows {
+		msg, ok, err := parseDevinDBMessageNode(row, len(messages), model)
+		if err != nil {
+			return nil, nil, false, err
+		}
+		if !ok {
+			continue
+		}
+		messages = append(messages, msg)
+		if firstStepAt.IsZero() && !msg.Timestamp.IsZero() {
+			firstStepAt = msg.Timestamp
+		}
+		if msg.Timestamp.After(lastStepAt) {
+			lastStepAt = msg.Timestamp
+		}
+		if msg.Role == RoleUser && !msg.IsSystem && strings.TrimSpace(msg.Content) != "" {
+			userMsgCount++
+			if firstMessage == "" {
+				firstMessage = truncate(strings.ReplaceAll(msg.Content, "\n", " "), 300)
+			}
+		}
+	}
+	if len(messages) == 0 {
+		return nil, nil, false, nil
+	}
+
+	startedAt := firstNonZeroTime(
+		metaTime(meta, func(m *DevinSessionMeta) time.Time { return m.CreatedAt }),
+		firstStepAt,
+	)
+	endedAt := firstNonZeroTime(
+		metaTime(meta, func(m *DevinSessionMeta) time.Time { return m.LastActivity }),
+		lastStepAt,
+		startedAt,
+	)
+
+	fileInfo := devinBaseFileInfo(dbPath, rawSessionID)
+	devinApplyFileInfoTimes(&fileInfo, meta, endedAt)
+	sess := buildDevinParsedSession(meta, rawSessionID, machine, cwd, firstMessage, startedAt, endedAt, userMsgCount, messages, fileInfo)
+	return sess, messages, true, nil
+}
+
+type devinMessageNodeRow struct {
+	RowID        int64
+	NodeID       int64
+	ParentNodeID sql.NullInt64
+	ChatMessage  string
+	CreatedAtMS  int64
+}
+
+func listDevinMessageNodes(dbPath, rawSessionID string) ([]devinMessageNodeRow, error) {
+	db, err := openDevinDB(dbPath)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+
+	rows, err := db.Query(`
+		SELECT row_id,
+		       node_id,
+		       parent_node_id,
+		       chat_message,
+		       created_at
+		  FROM message_nodes
+		 WHERE session_id = ?
+		 ORDER BY created_at ASC, row_id ASC
+	`, rawSessionID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var nodes []devinMessageNodeRow
+	for rows.Next() {
+		var row devinMessageNodeRow
+		if err := rows.Scan(&row.RowID, &row.NodeID, &row.ParentNodeID, &row.ChatMessage, &row.CreatedAtMS); err != nil {
+			return nil, err
+		}
+		nodes = append(nodes, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return nodes, nil
+}
+
+func parseDevinDBMessageNode(
+	row devinMessageNodeRow,
+	ordinal int,
+	model string,
+) (ParsedMessage, bool, error) {
+	if !gjson.Valid(row.ChatMessage) {
+		return ParsedMessage{}, false, errors.New("invalid devin message_nodes chat_message")
+	}
+	root := gjson.Parse(row.ChatMessage)
+	role, isSystem, ok := devinDBRole(root.Get("role").Str)
+	if !ok {
+		return ParsedMessage{}, false, nil
+	}
+
+	content, thinking, hasThinking, hasToolUse, toolCalls, toolResults := ExtractTextContent(root.Get("content"))
+	topThinking := strings.TrimSpace(root.Get("thinking").Str)
+	if topThinking != "" && topThinking != thinking {
+		thinking = joinNonEmpty(thinking, topThinking)
+		content = joinNonEmpty(content, "[Thinking]\n"+topThinking+"\n[/Thinking]")
+		hasThinking = true
+	}
+
+	topLevelToolCalls, topLevelToolText := parseDevinDBToolCalls(root.Get("tool_calls"))
+	if len(topLevelToolCalls) > 0 {
+		toolCalls = append(toolCalls, topLevelToolCalls...)
+		hasToolUse = true
+		content = joinNonEmpty(content, topLevelToolText)
+	}
+
+	if role == RoleTool {
+		if toolResult, ok := parseDevinDBToolResult(root.Get("tool_call_id"), root.Get("content")); ok {
+			toolResults = append(toolResults, toolResult)
+		}
+	}
+
+	if strings.TrimSpace(content) == "" && len(toolCalls) == 0 && len(toolResults) == 0 {
+		return ParsedMessage{}, false, nil
+	}
+
+	msg := ParsedMessage{
+		Ordinal:       ordinal,
+		Role:          role,
+		Content:       content,
+		ThinkingText:  thinking,
+		Timestamp:     devinUnixMilli(row.CreatedAtMS),
+		HasThinking:   hasThinking,
+		HasToolUse:    hasToolUse || len(toolCalls) > 0,
+		IsSystem:      isSystem,
+		ContentLength: len(content),
+		ToolCalls:     toolCalls,
+		ToolResults:   toolResults,
+		Model:         model,
+		SourceUUID:    fmt.Sprintf("%d", row.NodeID),
+	}
+	if row.ParentNodeID.Valid {
+		msg.SourceParentUUID = fmt.Sprintf("%d", row.ParentNodeID.Int64)
+	}
+	return msg, true, nil
+}
+
+func parseDevinDBToolCalls(toolCalls gjson.Result) ([]ParsedToolCall, string) {
+	if !toolCalls.IsArray() {
+		return nil, ""
+	}
+	var (
+		parsed []ParsedToolCall
+		parts  []string
+	)
+	toolCalls.ForEach(func(_, tc gjson.Result) bool {
+		parsedCall, ok := parseDevinDBToolCall(tc)
+		if ok {
+			parsed = append(parsed, parsedCall)
+			if text := formatDevinDBToolCall(parsedCall); text != "" {
+				parts = append(parts, text)
+			}
+		}
+		return true
+	})
+	return parsed, strings.Join(parts, "\n")
+}
+
+func parseDevinDBToolCall(tc gjson.Result) (ParsedToolCall, bool) {
+	if parsed, ok := parseToolCall(tc); ok {
+		return parsed, true
+	}
+	name := firstNonEmpty(tc.Get("function.name").Str, tc.Get("name").Str)
+	if name == "" {
+		return ParsedToolCall{}, false
+	}
+	input := tc.Get("function.arguments")
+	inputJSON := input.Raw
+	if input.Type == gjson.String {
+		inputJSON = input.Str
+	}
+	if inputJSON == "" {
+		input = toolCallInput(tc)
+		inputJSON = input.Raw
+	}
+	return ParsedToolCall{
+		ToolUseID: tc.Get("id").Str,
+		ToolName:  name,
+		Category:  NormalizeToolCategory(name),
+		InputJSON: inputJSON,
+	}, true
+}
+
+func formatDevinDBToolCall(tc ParsedToolCall) string {
+	block := map[string]any{"name": tc.ToolName}
+	if strings.TrimSpace(tc.InputJSON) != "" {
+		var input any
+		if json.Unmarshal([]byte(tc.InputJSON), &input) == nil {
+			block["input"] = input
+		}
+	}
+	if raw, err := json.Marshal(block); err == nil {
+		return strings.TrimSpace(formatToolUse(gjson.ParseBytes(raw)))
+	}
+	return ""
+}
+
+func parseDevinDBToolResult(toolCallID, content gjson.Result) (ParsedToolResult, bool) {
+	id := strings.TrimSpace(toolCallID.Str)
+	if id == "" {
+		return ParsedToolResult{}, false
+	}
+	return ParsedToolResult{
+		ToolUseID:     id,
+		ContentLength: toolResultContentLength(content),
+		ContentRaw:    content.Raw,
+	}, true
+}
+
+func devinDBRole(role string) (RoleType, bool, bool) {
+	switch role {
+	case "user":
+		return RoleUser, false, true
+	case "assistant", "agent":
+		return RoleAssistant, false, true
+	case "system":
+		return RoleSystem, true, true
+	case "tool":
+		return RoleTool, false, true
+	default:
+		return "", false, false
+	}
+}
+
+func devinBaseFileInfo(dbPath, rawSessionID string) FileInfo {
+	return FileInfo{Path: VirtualSourcePath(dbPath, rawSessionID)}
+}
+
+func devinApplyFileInfoTimes(fileInfo *FileInfo, meta *DevinSessionMeta, endedAt time.Time) {
+	if fileInfo == nil {
+		return
+	}
+	if meta != nil && meta.FileMtime > 0 && meta.FileMtime > fileInfo.Mtime {
+		fileInfo.Mtime = meta.FileMtime
+	}
+	if !endedAt.IsZero() && endedAt.UnixNano() > fileInfo.Mtime {
+		fileInfo.Mtime = endedAt.UnixNano()
+	}
+}
+
+func buildDevinParsedSession(
+	meta *DevinSessionMeta,
+	rawSessionID, machine, cwd, firstMessage string,
+	startedAt, endedAt time.Time,
+	userMsgCount int,
+	messages []ParsedMessage,
+	fileInfo FileInfo,
+) *ParsedSession {
+	sessionName := firstNonEmpty(
+		metaValue(meta, func(m *DevinSessionMeta) string { return m.Title }),
+		firstMessage,
+	)
+	return &ParsedSession{
+		ID:               "devin:" + rawSessionID,
+		Project:          ExtractProjectFromCwd(cwd),
+		Machine:          machine,
+		Agent:            AgentDevin,
+		Cwd:              cwd,
+		SourceSessionID:  rawSessionID,
+		SessionName:      sessionName,
+		FirstMessage:     firstMessage,
+		StartedAt:        startedAt,
+		EndedAt:          endedAt,
+		MessageCount:     len(messages),
+		UserMessageCount: userMsgCount,
+		File:             fileInfo,
+	}
+}
+
+func metaValue[T any](meta *DevinSessionMeta, fn func(*DevinSessionMeta) T) T {
+	var zero T
+	if meta == nil {
+		return zero
+	}
+	return fn(meta)
+}
+
+func metaTime(meta *DevinSessionMeta, fn func(*DevinSessionMeta) time.Time) time.Time {
+	if meta == nil {
+		return time.Time{}
+	}
+	return fn(meta)
+}
+
+func firstNonZeroTime(times ...time.Time) time.Time {
+	for _, ts := range times {
+		if !ts.IsZero() {
+			return ts
+		}
+	}
+	return time.Time{}
+}
+
+func devinTranscriptCWD(root gjson.Result) string {
+	if cwd := firstNonEmpty(
+		root.Get("working_directory").Str,
+		root.Get("cwd").Str,
+		root.Get("agent.working_directory").Str,
+		root.Get("agent.cwd").Str,
+	); cwd != "" {
+		return cwd
+	}
+
+	workspaceDirs := root.Get("workspace_dirs")
+	if !workspaceDirs.IsArray() {
+		return ""
+	}
+	first := workspaceDirs.Array()
+	if len(first) == 0 {
+		return ""
+	}
+	return firstNonEmpty(first[0].Str, first[0].Get("root_path").Str, first[0].Get("path").Str)
+}
+
+func applyDevinFinalMetrics(sess *ParsedSession, metrics gjson.Result) {
+	if !metrics.Exists() || metrics.Type != gjson.JSON {
+		return
+	}
+
+	if output, ok := firstPositiveGJSONInt(metrics,
+		"output_tokens", "total_completion_tokens"); ok {
+		sess.TotalOutputTokens = output
+		sess.HasTotalOutputTokens = true
+	}
+
+	if !sess.HasPeakContextTokens {
+		context := 0
+		hasContext := false
+		for _, key := range []string{
+			"input_tokens",
+			"cache_creation_input_tokens",
+			"cache_read_input_tokens",
+		} {
+			if value, ok := positiveGJSONInt(metrics.Get(key)); ok {
+				hasContext = true
+				context += value
+			}
+		}
+		if !hasContext {
+			if value, ok := positiveGJSONInt(metrics.Get("total_prompt_tokens")); ok {
+				hasContext = true
+				context = value
+			}
+		}
+		if !hasContext {
+			if value, ok := positiveGJSONInt(metrics.Get("total_cached_tokens")); ok {
+				hasContext = true
+				context = value
+			}
+		}
+		if !hasContext {
+			if value, ok := positiveGJSONInt(metrics.Get("context_tokens")); ok {
+				hasContext = true
+				context = value
+			}
+		}
+		if hasContext {
+			sess.PeakContextTokens = context
+			sess.HasPeakContextTokens = true
+		}
+	}
+	sess.aggregateTokenPresenceKnown =
+		sess.HasTotalOutputTokens || sess.HasPeakContextTokens
+}
+
+func firstPositiveGJSONInt(root gjson.Result, keys ...string) (int, bool) {
+	for _, key := range keys {
+		if value, ok := positiveGJSONInt(root.Get(key)); ok {
+			return value, true
+		}
+	}
+	return 0, false
+}
+
+func positiveGJSONInt(value gjson.Result) (int, bool) {
+	if !value.Exists() {
+		return 0, false
+	}
+	if n := int(value.Int()); n > 0 {
+		return n, true
+	}
+	return 0, false
+}
+
+func parseDevinStep(step gjson.Result, ordinal int, model string) (ParsedMessage, bool) {
+	role, isSystem, ok := devinRoleForSource(step.Get("source").Str)
+	if !ok {
+		return ParsedMessage{}, false
+	}
+
+	content, thinking, hasThinking, hasToolUse, toolCalls, toolResults :=
+		ExtractTextContent(step.Get("message"))
+	topLevelToolText, topLevelToolCalls := formatTopLevelToolUses(step.Get("tool_use"))
+	if topLevelToolText != "" {
+		content = joinNonEmpty(content, topLevelToolText)
+		hasToolUse = true
+	}
+	toolCalls = append(toolCalls, topLevelToolCalls...)
+	toolResults = append(toolResults, extractTopLevelToolResults(step.Get("tool_result"))...)
+
+	if strings.TrimSpace(content) == "" && len(toolCalls) == 0 && len(toolResults) == 0 {
+		return ParsedMessage{}, false
+	}
+	if role != RoleUser && strings.TrimSpace(content) == "" && len(toolCalls) == 0 && len(toolResults) > 0 {
+		role = RoleTool
+		isSystem = false
+	}
+	tokenUsage, contextTokens, outputTokens, hasContextTokens, hasOutputTokens :=
+		devinTokenUsageFromMetrics(step.Get("metrics"))
+	messageModel := firstNonEmpty(
+		step.Get("extra.generation_model").Str,
+		step.Get("model_name").Str,
+		model,
+	)
+
+	return ParsedMessage{
+		Ordinal:          ordinal,
+		Role:             role,
+		Content:          content,
+		ThinkingText:     thinking,
+		Timestamp:        devinStepTimestamp(step),
+		HasThinking:      hasThinking,
+		HasToolUse:       hasToolUse || len(toolCalls) > 0,
+		IsSystem:         isSystem,
+		ContentLength:    len(content),
+		ToolCalls:        toolCalls,
+		ToolResults:      toolResults,
+		Model:            messageModel,
+		TokenUsage:       tokenUsage,
+		ContextTokens:    contextTokens,
+		OutputTokens:     outputTokens,
+		HasContextTokens: hasContextTokens,
+		HasOutputTokens:  hasOutputTokens,
+		SourceUUID:       devinStepID(step.Get("step_id")),
+	}, true
+}
+
+func devinTokenUsageFromMetrics(metrics gjson.Result) (
+	json.RawMessage, int, int, bool, bool,
+) {
+	if !metrics.Exists() || metrics.Type != gjson.JSON {
+		return nil, 0, 0, false, false
+	}
+
+	prompt, hasPrompt := nonNegativeGJSONInt(metrics.Get("prompt_tokens"))
+	completion, hasCompletion := nonNegativeGJSONInt(metrics.Get("completion_tokens"))
+	cached, hasCached := nonNegativeGJSONInt(metrics.Get("cached_tokens"))
+	if !hasPrompt && !hasCompletion && !hasCached {
+		return nil, 0, 0, false, false
+	}
+
+	input := prompt
+	if hasPrompt && hasCached {
+		input -= cached
+	}
+	if input < 0 {
+		input = 0
+	}
+
+	payload := make(map[string]int, 3)
+	if hasPrompt {
+		payload["input_tokens"] = input
+	}
+	if hasCompletion {
+		payload["output_tokens"] = completion
+	}
+	if hasCached {
+		payload["cache_read_input_tokens"] = cached
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return nil, 0, 0, false, false
+	}
+
+	context := input + cached
+	return raw, context, completion, hasPrompt || hasCached, hasCompletion
+}
+
+func nonNegativeGJSONInt(value gjson.Result) (int, bool) {
+	if !value.Exists() {
+		return 0, false
+	}
+	n := int(value.Int())
+	if n < 0 {
+		return 0, true
+	}
+	return n, true
+}
+
+func devinStepID(stepID gjson.Result) string {
+	switch stepID.Type {
+	case gjson.String:
+		return stepID.Str
+	case gjson.Number, gjson.True, gjson.False, gjson.JSON:
+		return stepID.Raw
+	default:
+		return ""
+	}
+}
+
+func formatTopLevelToolUses(toolUses gjson.Result) (string, []ParsedToolCall) {
+	if !toolUses.IsArray() {
+		return "", nil
+	}
+	var (
+		parts []string
+		calls []ParsedToolCall
+	)
+	toolUses.ForEach(func(_, toolUse gjson.Result) bool {
+		if text := strings.TrimSpace(formatToolUse(toolUse)); text != "" {
+			parts = append(parts, text)
+		}
+		if tc, ok := parseToolCall(toolUse); ok {
+			calls = append(calls, tc)
+		}
+		return true
+	})
+	return strings.Join(parts, "\n"), calls
+}
+
+func extractTopLevelToolResults(toolResults gjson.Result) []ParsedToolResult {
+	if !toolResults.IsArray() {
+		return nil
+	}
+	var parsed []ParsedToolResult
+	toolResults.ForEach(func(_, toolResult gjson.Result) bool {
+		if tr, ok := parseToolResult(toolResult); ok {
+			parsed = append(parsed, tr)
+		}
+		return true
+	})
+	return parsed
+}
+
+func devinRoleForSource(source string) (RoleType, bool, bool) {
+	switch source {
+	case "user":
+		return RoleUser, false, true
+	case "agent":
+		return RoleAssistant, false, true
+	case "system":
+		return RoleSystem, true, true
+	default:
+		return "", false, false
+	}
+}
+
+func devinStepTimestamp(step gjson.Result) time.Time {
+	return parseTimestamp(firstNonEmpty(
+		step.Get("timestamp").Str,
+		step.Get("created_at").Str,
+		step.Get("createdAt").Str,
+		step.Get("updated_at").Str,
+		step.Get("updatedAt").Str,
+	))
+}
+
+func joinNonEmpty(parts ...string) string {
+	filtered := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if strings.TrimSpace(part) != "" {
+			filtered = append(filtered, part)
+		}
+	}
+	return strings.Join(filtered, "\n")
+}

--- a/internal/parser/devin.go
+++ b/internal/parser/devin.go
@@ -62,10 +62,10 @@ func ListDevinSessionMeta(dbPath string) ([]DevinSessionMeta, error) {
 		       COALESCE(model, ''),
 		       COALESCE(created_at, 0),
 		       last_activity_at,
-		       COALESCE(last_activity_at, created_at)
+		       COALESCE(last_activity_at, created_at, 0)
 		  FROM sessions
 		 WHERE COALESCE(hidden, 0) <> 1
-		 ORDER BY COALESCE(last_activity_at, created_at) DESC, id DESC
+		 ORDER BY COALESCE(last_activity_at, created_at, 0) DESC, id DESC
 	`)
 	if err != nil {
 		return nil, fmt.Errorf("listing devin sessions: %w", err)
@@ -133,7 +133,7 @@ func getDevinSessionMeta(
 		       COALESCE(model, ''),
 		       COALESCE(created_at, 0),
 		       last_activity_at,
-		       COALESCE(last_activity_at, created_at)
+		       COALESCE(last_activity_at, created_at, 0)
 		  FROM sessions
 		 WHERE COALESCE(hidden, 0) <> 1
 		   AND id = ?
@@ -183,7 +183,7 @@ func (e *devinTranscriptError) Error() string {
 		devinRedactedSessionID(),
 	)
 	if e.cause != nil {
-		return msg + ": " + e.cause.Error()
+		return msg + ": " + devinTranscriptCauseMessage(e.cause)
 	}
 	return msg
 }
@@ -197,6 +197,20 @@ func (e *devinTranscriptError) Unwrap() error {
 
 func newDevinTranscriptError(op string, cause error) error {
 	return &devinTranscriptError{op: op, cause: cause}
+}
+
+func devinTranscriptCauseMessage(cause error) string {
+	var pathErr *os.PathError
+	if errors.As(cause, &pathErr) {
+		if pathErr.Op != "" && pathErr.Err != nil {
+			return pathErr.Op + ": " + pathErr.Err.Error()
+		}
+		if pathErr.Err != nil {
+			return pathErr.Err.Error()
+		}
+		return pathErr.Op
+	}
+	return cause.Error()
 }
 
 func devinRedactedTranscriptPath() string {

--- a/internal/parser/devin.go
+++ b/internal/parser/devin.go
@@ -105,7 +105,7 @@ func ListDevinSessionMeta(dbPath string) ([]DevinSessionMeta, error) {
 }
 
 func openDevinDB(dbPath string) (*sql.DB, error) {
-	dsn := "file:" + dbPath + "?mode=ro&_busy_timeout=3000"
+	dsn := "file:" + sqliteURIPath(dbPath) + "?mode=ro&_busy_timeout=3000"
 	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("opening devin db %s: %w", dbPath, err)

--- a/internal/parser/devin.go
+++ b/internal/parser/devin.go
@@ -218,11 +218,10 @@ func parseDevinSession(dbPath, rawSessionID, machine string) (*ParsedSession, []
 
 	transcriptPath := filepath.Join(filepath.Dir(dbPath), "transcripts", rawSessionID+".json")
 	info, err := os.Stat(transcriptPath)
-	transcriptPresent := err == nil
-	if err != nil && !os.IsNotExist(err) {
-		return nil, nil, newDevinTranscriptError("stat", err)
-	}
-	if !transcriptPresent {
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return nil, nil, newDevinTranscriptError("stat", err)
+		}
 		fallbackErr := newDevinTranscriptError("missing", nil)
 		sess, msgs, ok, err := parseDevinSessionFromMessageNodes(dbPath, rawSessionID, machine, meta)
 		if err == nil && ok {
@@ -300,10 +299,8 @@ func parseDevinSession(dbPath, rawSessionID, machine string) (*ParsedSession, []
 	)
 
 	fileInfo := devinBaseFileInfo(dbPath, rawSessionID)
-	if transcriptPresent {
-		fileInfo.Size = info.Size()
-		fileInfo.Mtime = info.ModTime().UnixNano()
-	}
+	fileInfo.Size = info.Size()
+	fileInfo.Mtime = info.ModTime().UnixNano()
 	devinApplyFileInfoTimes(&fileInfo, meta, endedAt)
 
 	sess := buildDevinParsedSession(meta, rawSessionID, machine, cwd, firstMessage, startedAt, endedAt, userMsgCount, messages, fileInfo)

--- a/internal/parser/devin_provider.go
+++ b/internal/parser/devin_provider.go
@@ -329,7 +329,7 @@ func (s devinSourceSet) Fingerprint(
 		return SourceFingerprint{}, newDevinTranscriptError("stat", err)
 	}
 	fingerprint.MTimeNS = maxDevinFingerprintMTime(meta, dbInfo, transcriptInfo)
-	hash, err := devinFingerprintHash(meta, transcriptPath, transcriptInfo)
+	hash, err := devinFingerprintHash(meta, src.DBPath, transcriptPath, transcriptInfo)
 	if err != nil {
 		return SourceFingerprint{}, err
 	}
@@ -370,23 +370,28 @@ func maxDevinFingerprintMTime(
 
 func devinFingerprintHash(
 	meta *DevinSessionMeta,
+	dbPath string,
 	transcriptPath string,
 	transcriptInfo os.FileInfo,
 ) (string, error) {
 	h := sha256.New()
 	if _, err := fmt.Fprintf(
 		h,
-		"session\x00%s\x00created\x00%d\x00last_activity\x00%d\x00updated\x00%d\x00title\x00%s\x00model\x00%s\x00",
+		"session\x00%s\x00created\x00%d\x00last_activity\x00%d\x00updated\x00%d\x00title\x00%s\x00cwd\x00%s\x00model\x00%s\x00",
 		meta.RawSessionID,
 		meta.CreatedAt.UnixMilli(),
 		meta.LastActivity.UnixMilli(),
 		meta.UpdatedAt.UnixMilli(),
 		meta.Title,
+		meta.CWD,
 		meta.Model,
 	); err != nil {
 		return "", err
 	}
 	if transcriptInfo == nil {
+		if err := devinAppendMessageNodesFingerprint(h, dbPath, meta.RawSessionID); err != nil {
+			return "", err
+		}
 		return fmt.Sprintf("%x", h.Sum(nil)), nil
 	}
 	if _, err := fmt.Fprintf(
@@ -406,6 +411,43 @@ func devinFingerprintHash(
 		return "", newDevinTranscriptError("hash", err)
 	}
 	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}
+
+func devinAppendMessageNodesFingerprint(h io.Writer, dbPath, rawSessionID string) error {
+	nodes, err := listDevinMessageNodes(dbPath, rawSessionID)
+	if err != nil {
+		return err
+	}
+	var maxCreatedAtMS int64
+	for _, node := range nodes {
+		if node.CreatedAtMS > maxCreatedAtMS {
+			maxCreatedAtMS = node.CreatedAtMS
+		}
+	}
+	if _, err := fmt.Fprintf(h, "message_nodes\x00count\x00%d\x00max_created\x00%d\x00", len(nodes), maxCreatedAtMS); err != nil {
+		return err
+	}
+	for _, node := range nodes {
+		if _, err := fmt.Fprintf(
+			h,
+			"row\x00%d\x00node\x00%d\x00parent_valid\x00%t\x00parent\x00%d\x00created\x00%d\x00chat_len\x00%d\x00",
+			node.RowID,
+			node.NodeID,
+			node.ParentNodeID.Valid,
+			node.ParentNodeID.Int64,
+			node.CreatedAtMS,
+			len(node.ChatMessage),
+		); err != nil {
+			return err
+		}
+		if _, err := io.WriteString(h, node.ChatMessage); err != nil {
+			return err
+		}
+		if _, err := io.WriteString(h, "\x00"); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (s devinSourceSet) sourceFromRef(source SourceRef) (devinSource, bool) {

--- a/internal/parser/devin_provider.go
+++ b/internal/parser/devin_provider.go
@@ -106,17 +106,7 @@ func (p *devinProvider) Parse(
 	}
 	var transcriptErr *devinTranscriptError
 	if errors.As(err, &transcriptErr) {
-		sourceKey := firstNonEmptyJSONLString(req.Source.FingerprintKey, req.Source.Key, src.virtualPath())
-		return ParseOutcome{
-			SourceErrors: []SourceError{{
-				SourceKey:   sourceKey,
-				DisplayPath: devinRedactedTranscriptPath(),
-				SessionID:   "devin:" + src.SessionID,
-				Err:         transcriptErr,
-				Retryable:   true,
-			}},
-			ResultSetComplete: true,
-		}, nil
+		return ParseOutcome{}, transcriptErr
 	}
 	if err != nil {
 		return ParseOutcome{}, err
@@ -171,7 +161,7 @@ func (s devinSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
 			return nil, err
 		}
 		for _, meta := range metas {
-			addJSONLSource(s.newSourceRef(root, dbPath, meta.RawSessionID), &sources, seen)
+			addJSONLSource(s.newSourceRefWithMTime(root, dbPath, meta.RawSessionID, meta.FileMtime), &sources, seen)
 		}
 	}
 	sortJSONLSources(sources)
@@ -222,7 +212,7 @@ func (s devinSourceSet) SourcesForChangedPath(
 			sources := make([]SourceRef, 0, len(metas))
 			seen := make(map[string]struct{}, len(metas))
 			for _, meta := range metas {
-				addJSONLSource(s.newSourceRef(root, dbPath, meta.RawSessionID), &sources, seen)
+				addJSONLSource(s.newSourceRefWithMTime(root, dbPath, meta.RawSessionID, meta.FileMtime), &sources, seen)
 			}
 			for _, path := range req.StoredSourcePaths {
 				ref, ok := s.sourceRef(root, path, true)
@@ -503,7 +493,7 @@ func (s devinSourceSet) findByRawSessionID(root, rawID string, requireFresh bool
 	if meta == nil {
 		return SourceRef{}, false, nil
 	}
-	ref := s.newSourceRef(root, dbPath, rawID)
+	ref := s.newSourceRefWithMTime(root, dbPath, rawID, meta.FileMtime)
 	if requireFresh {
 		fresh, err := s.sourceExists(ref.Opaque.(devinSource))
 		if err != nil {
@@ -517,12 +507,17 @@ func (s devinSourceSet) findByRawSessionID(root, rawID string, requireFresh bool
 }
 
 func (s devinSourceSet) newSourceRef(root, dbPath, sessionID string) SourceRef {
+	return s.newSourceRefWithMTime(root, dbPath, sessionID, 0)
+}
+
+func (s devinSourceSet) newSourceRefWithMTime(root, dbPath, sessionID string, mtimeNS int64) SourceRef {
 	virtualPath := VirtualSourcePath(dbPath, sessionID)
 	return SourceRef{
-		Provider:       AgentDevin,
-		Key:            virtualPath,
-		DisplayPath:    virtualPath,
-		FingerprintKey: virtualPath,
+		Provider:         AgentDevin,
+		Key:              virtualPath,
+		DisplayPath:      virtualPath,
+		FingerprintKey:   virtualPath,
+		DiscoveryMTimeNS: mtimeNS,
 		Opaque: devinSource{
 			Root:      root,
 			DBPath:    dbPath,

--- a/internal/parser/devin_provider.go
+++ b/internal/parser/devin_provider.go
@@ -1,0 +1,552 @@
+package parser
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func newDevinProviderFactory(def AgentDef) ProviderFactory {
+	return devinProviderFactory{def: cloneAgentDef(def)}
+}
+
+type devinProviderFactory struct {
+	def AgentDef
+}
+
+func (f devinProviderFactory) Definition() AgentDef {
+	return cloneAgentDef(f.def)
+}
+
+func (f devinProviderFactory) Capabilities() Capabilities {
+	return devinProviderCapabilities()
+}
+
+func (f devinProviderFactory) NewProvider(cfg ProviderConfig) Provider {
+	cfg = cfg.Clone()
+	return &devinProvider{
+		ProviderBase: ProviderBase{
+			Def:    cloneAgentDef(f.def),
+			Caps:   devinProviderCapabilities(),
+			Config: cfg,
+		},
+		sources: newDevinSourceSet(cfg.Roots),
+	}
+}
+
+type devinProvider struct {
+	ProviderBase
+	sources devinSourceSet
+}
+
+func (p *devinProvider) Discover(ctx context.Context) ([]SourceRef, error) {
+	return p.sources.Discover(ctx)
+}
+
+func (p *devinProvider) WatchPlan(ctx context.Context) (WatchPlan, error) {
+	return p.sources.WatchPlan(ctx)
+}
+
+func (p *devinProvider) SourcesForChangedPath(
+	ctx context.Context,
+	req ChangedPathRequest,
+) ([]SourceRef, error) {
+	return p.sources.SourcesForChangedPath(ctx, req)
+}
+
+func (p *devinProvider) FindSource(
+	ctx context.Context,
+	req FindSourceRequest,
+) (SourceRef, bool, error) {
+	req = ProviderFindRequestWithRawSessionID(p.Def, req)
+	return p.sources.FindSource(ctx, req)
+}
+
+func (p *devinProvider) Fingerprint(
+	ctx context.Context,
+	source SourceRef,
+) (SourceFingerprint, error) {
+	return p.sources.Fingerprint(ctx, source)
+}
+
+func (p *devinProvider) Parse(
+	ctx context.Context,
+	req ParseRequest,
+) (ParseOutcome, error) {
+	if err := ctx.Err(); err != nil {
+		return ParseOutcome{}, err
+	}
+	src, ok := p.sources.sourceFromRef(req.Source)
+	if !ok {
+		return ParseOutcome{}, fmt.Errorf("%s source path unavailable", AgentDevin)
+	}
+	if _, err := os.Stat(src.DBPath); err != nil {
+		if os.IsNotExist(err) {
+			return ParseOutcome{
+				ResultSetComplete: true,
+				SkipReason:        SkipNoSession,
+			}, nil
+		}
+		return ParseOutcome{}, fmt.Errorf("stat %s: %w", src.DBPath, err)
+	}
+	machine := firstNonEmptyJSONLString(req.Machine, p.Config.Machine)
+	sess, msgs, err := parseDevinSession(src.DBPath, src.SessionID, machine)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ParseOutcome{
+			ResultSetComplete: true,
+			ForceReplace:      true,
+			SkipReason:        SkipNoSession,
+		}, nil
+	}
+	var transcriptErr *devinTranscriptError
+	if errors.As(err, &transcriptErr) {
+		sourceKey := firstNonEmptyJSONLString(req.Source.FingerprintKey, req.Source.Key, src.virtualPath())
+		return ParseOutcome{
+			SourceErrors: []SourceError{{
+				SourceKey:   sourceKey,
+				DisplayPath: devinRedactedTranscriptPath(),
+				SessionID:   "devin:" + src.SessionID,
+				Err:         transcriptErr,
+				Retryable:   true,
+			}},
+			ResultSetComplete: true,
+		}, nil
+	}
+	if err != nil {
+		return ParseOutcome{}, err
+	}
+	if sess == nil {
+		return ParseOutcome{
+			ResultSetComplete: true,
+			ForceReplace:      true,
+			SkipReason:        SkipNoSession,
+		}, nil
+	}
+	if req.Fingerprint.Hash != "" {
+		sess.File.Hash = req.Fingerprint.Hash
+	}
+	return ParseOutcome{
+		Results: []ParseResultOutcome{{
+			Result:      ParseResult{Session: *sess, Messages: msgs},
+			DataVersion: DataVersionCurrent,
+		}},
+		ResultSetComplete: true,
+		ForceReplace:      true,
+	}, nil
+}
+
+type devinSource struct {
+	Root      string
+	DBPath    string
+	SessionID string
+}
+
+type devinSourceSet struct {
+	roots []string
+}
+
+func newDevinSourceSet(roots []string) devinSourceSet {
+	return devinSourceSet{roots: cleanJSONLRoots(roots)}
+}
+
+func (s devinSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
+	var sources []SourceRef
+	seen := make(map[string]struct{})
+	for _, root := range s.roots {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		dbPath := devinDBPath(root)
+		if dbPath == "" {
+			continue
+		}
+		metas, err := ListDevinSessionMeta(dbPath)
+		if err != nil {
+			return nil, err
+		}
+		for _, meta := range metas {
+			addJSONLSource(s.newSourceRef(root, dbPath, meta.RawSessionID), &sources, seen)
+		}
+	}
+	sortJSONLSources(sources)
+	return sources, nil
+}
+
+func (s devinSourceSet) WatchPlan(context.Context) (WatchPlan, error) {
+	roots := make([]WatchRoot, 0, len(s.roots)*2)
+	for _, root := range s.roots {
+		cliRoot := filepath.Join(root, "cli")
+		roots = append(roots,
+			WatchRoot{
+				Path:         cliRoot,
+				Recursive:    false,
+				IncludeGlobs: []string{devinDBFilename, devinDBFilename + "-*"},
+				DebounceKey:  string(AgentDevin) + ":db:" + root,
+			},
+			WatchRoot{
+				Path:         filepath.Join(cliRoot, "transcripts"),
+				Recursive:    false,
+				IncludeGlobs: []string{"*.json"},
+				DebounceKey:  string(AgentDevin) + ":transcripts:" + root,
+			},
+		)
+	}
+	return WatchPlan{Roots: roots}, nil
+}
+
+func (s devinSourceSet) SourcesForChangedPath(
+	ctx context.Context,
+	req ChangedPathRequest,
+) ([]SourceRef, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	for _, root := range s.roots {
+		if req.WatchRoot != "" && !samePath(req.WatchRoot, filepath.Join(root, "cli")) && !samePath(req.WatchRoot, filepath.Join(root, "cli", "transcripts")) {
+			continue
+		}
+		if ref, ok := s.sourceRef(root, req.Path, true); ok {
+			return []SourceRef{ref}, nil
+		}
+		if dbPath, ok := s.dbPathForEvent(root, req.Path); ok {
+			metas, err := ListDevinSessionMeta(dbPath)
+			if err != nil {
+				return nil, err
+			}
+			sources := make([]SourceRef, 0, len(metas))
+			seen := make(map[string]struct{}, len(metas))
+			for _, meta := range metas {
+				addJSONLSource(s.newSourceRef(root, dbPath, meta.RawSessionID), &sources, seen)
+			}
+			for _, path := range req.StoredSourcePaths {
+				ref, ok := s.sourceRef(root, path, true)
+				if !ok {
+					continue
+				}
+				src := ref.Opaque.(devinSource)
+				if !samePath(src.DBPath, dbPath) {
+					continue
+				}
+				addJSONLSource(ref, &sources, seen)
+			}
+			sortJSONLSources(sources)
+			return sources, nil
+		}
+		if sessionID, ok := s.transcriptSessionIDForEvent(root, req.Path); ok {
+			if ref, ok, err := s.findByRawSessionID(root, sessionID, false); err != nil {
+				return nil, err
+			} else if ok {
+				return []SourceRef{ref}, nil
+			}
+			for _, path := range req.StoredSourcePaths {
+				ref, ok := s.sourceRef(root, path, true)
+				if !ok {
+					continue
+				}
+				src := ref.Opaque.(devinSource)
+				if src.SessionID == sessionID {
+					return []SourceRef{ref}, nil
+				}
+			}
+		}
+	}
+	return nil, nil
+}
+
+func (s devinSourceSet) FindSource(
+	ctx context.Context,
+	req FindSourceRequest,
+) (SourceRef, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return SourceRef{}, false, err
+	}
+	for _, path := range []string{req.StoredFilePath, req.FingerprintKey} {
+		if path == "" {
+			continue
+		}
+		for _, root := range s.roots {
+			ref, ok := s.sourceRef(root, path, true)
+			if !ok {
+				continue
+			}
+			src := ref.Opaque.(devinSource)
+			if req.RawSessionID != "" && src.SessionID != req.RawSessionID {
+				continue
+			}
+			if req.RequireFreshSource {
+				fresh, err := s.sourceExists(src)
+				if err != nil {
+					return SourceRef{}, false, err
+				}
+				if !fresh {
+					continue
+				}
+			}
+			return ref, true, nil
+		}
+	}
+	if req.RawSessionID == "" {
+		return SourceRef{}, false, nil
+	}
+	for _, root := range s.roots {
+		ref, ok, err := s.findByRawSessionID(root, req.RawSessionID, req.RequireFreshSource)
+		if err != nil {
+			return SourceRef{}, false, err
+		}
+		if ok {
+			return ref, true, nil
+		}
+	}
+	return SourceRef{}, false, nil
+}
+
+func (s devinSourceSet) Fingerprint(
+	ctx context.Context,
+	source SourceRef,
+) (SourceFingerprint, error) {
+	if err := ctx.Err(); err != nil {
+		return SourceFingerprint{}, err
+	}
+	src, ok := s.sourceFromRef(source)
+	if !ok {
+		return SourceFingerprint{}, fmt.Errorf("%s source path unavailable", AgentDevin)
+	}
+	key := firstNonEmptyJSONLString(source.FingerprintKey, source.Key, src.virtualPath())
+	dbInfo, err := os.Stat(src.DBPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return SourceFingerprint{Key: key}, nil
+		}
+		return SourceFingerprint{}, fmt.Errorf("stat %s: %w", src.DBPath, err)
+	}
+	meta, err := getDevinSessionMeta(src.DBPath, src.SessionID)
+	if err != nil {
+		return SourceFingerprint{}, err
+	}
+	if meta == nil {
+		return SourceFingerprint{Key: key}, nil
+	}
+	fingerprint := SourceFingerprint{Key: key}
+	transcriptPath := filepath.Join(filepath.Dir(src.DBPath), "transcripts", src.SessionID+".json")
+	transcriptInfo, err := os.Stat(transcriptPath)
+	if err != nil && !os.IsNotExist(err) {
+		return SourceFingerprint{}, newDevinTranscriptError("stat", err)
+	}
+	fingerprint.MTimeNS = maxDevinFingerprintMTime(meta, dbInfo, transcriptInfo)
+	hash, err := devinFingerprintHash(meta, transcriptPath, transcriptInfo)
+	if err != nil {
+		return SourceFingerprint{}, err
+	}
+	fingerprint.Hash = hash
+	if transcriptInfo != nil {
+		fingerprint.Size = transcriptInfo.Size()
+	}
+	return fingerprint, nil
+}
+
+func maxDevinFingerprintMTime(
+	meta *DevinSessionMeta,
+	dbInfo os.FileInfo,
+	transcriptInfo os.FileInfo,
+) int64 {
+	var mtime int64
+	if meta != nil {
+		mtime = meta.FileMtime
+		if created := meta.CreatedAt.UnixNano(); created > mtime {
+			mtime = created
+		}
+		if lastActivity := meta.LastActivity.UnixNano(); lastActivity > mtime {
+			mtime = lastActivity
+		}
+	}
+	if dbInfo != nil {
+		if dbMTime := dbInfo.ModTime().UnixNano(); dbMTime > mtime {
+			mtime = dbMTime
+		}
+	}
+	if transcriptInfo != nil {
+		if transcriptMTime := transcriptInfo.ModTime().UnixNano(); transcriptMTime > mtime {
+			mtime = transcriptMTime
+		}
+	}
+	return mtime
+}
+
+func devinFingerprintHash(
+	meta *DevinSessionMeta,
+	transcriptPath string,
+	transcriptInfo os.FileInfo,
+) (string, error) {
+	h := sha256.New()
+	if _, err := fmt.Fprintf(
+		h,
+		"session\x00%s\x00created\x00%d\x00last_activity\x00%d\x00updated\x00%d\x00title\x00%s\x00model\x00%s\x00",
+		meta.RawSessionID,
+		meta.CreatedAt.UnixMilli(),
+		meta.LastActivity.UnixMilli(),
+		meta.UpdatedAt.UnixMilli(),
+		meta.Title,
+		meta.Model,
+	); err != nil {
+		return "", err
+	}
+	if transcriptInfo == nil {
+		return fmt.Sprintf("%x", h.Sum(nil)), nil
+	}
+	if _, err := fmt.Fprintf(
+		h,
+		"transcript_size\x00%d\x00transcript_mtime\x00%d\x00",
+		transcriptInfo.Size(),
+		transcriptInfo.ModTime().UnixNano(),
+	); err != nil {
+		return "", err
+	}
+	f, err := os.Open(transcriptPath)
+	if err != nil {
+		return "", newDevinTranscriptError("open", err)
+	}
+	defer f.Close()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", newDevinTranscriptError("hash", err)
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}
+
+func (s devinSourceSet) sourceFromRef(source SourceRef) (devinSource, bool) {
+	switch src := source.Opaque.(type) {
+	case devinSource:
+		return src, src.DBPath != "" && src.SessionID != ""
+	case *devinSource:
+		if src != nil && src.DBPath != "" && src.SessionID != "" {
+			return *src, true
+		}
+	}
+	for _, candidate := range []string{source.DisplayPath, source.FingerprintKey, source.Key} {
+		for _, root := range s.roots {
+			if ref, ok := s.sourceRef(root, candidate, true); ok {
+				return ref.Opaque.(devinSource), true
+			}
+		}
+	}
+	return devinSource{}, false
+}
+
+func (s devinSourceSet) sourceRef(root, path string, allowMissing bool) (SourceRef, bool) {
+	root = filepath.Clean(root)
+	path = filepath.Clean(path)
+	dbPath, sessionID, ok := ParseVirtualSourcePathForBase(path, devinDBFilename)
+	if !ok || sessionID == "" {
+		return SourceRef{}, false
+	}
+	if !samePath(dbPath, filepath.Join(root, "cli", devinDBFilename)) {
+		return SourceRef{}, false
+	}
+	if !allowMissing && !IsRegularFile(dbPath) {
+		return SourceRef{}, false
+	}
+	return s.newSourceRef(root, dbPath, sessionID), true
+}
+
+func (s devinSourceSet) dbPathForEvent(root, path string) (string, bool) {
+	root = filepath.Clean(root)
+	path = filepath.Clean(path)
+	cliRoot := filepath.Join(root, "cli")
+	rel, ok := relUnder(cliRoot, path)
+	if !ok || strings.Contains(rel, string(filepath.Separator)) {
+		return "", false
+	}
+	if rel == devinDBFilename || rel == devinDBFilename+"-wal" || rel == devinDBFilename+"-shm" {
+		return filepath.Join(cliRoot, devinDBFilename), true
+	}
+	return "", false
+}
+
+func (s devinSourceSet) transcriptSessionIDForEvent(root, path string) (string, bool) {
+	root = filepath.Clean(root)
+	path = filepath.Clean(path)
+	rel, ok := relUnder(filepath.Join(root, "cli", "transcripts"), path)
+	if !ok || strings.Contains(rel, string(filepath.Separator)) || filepath.Ext(rel) != ".json" {
+		return "", false
+	}
+	return strings.TrimSuffix(rel, ".json"), true
+}
+
+func (s devinSourceSet) sourceExists(src devinSource) (bool, error) {
+	if !IsRegularFile(src.DBPath) {
+		return false, nil
+	}
+	meta, err := getDevinSessionMeta(src.DBPath, src.SessionID)
+	if err != nil {
+		return false, err
+	}
+	return meta != nil, nil
+}
+
+func (s devinSourceSet) findByRawSessionID(root, rawID string, requireFresh bool) (SourceRef, bool, error) {
+	if root == "" || rawID == "" {
+		return SourceRef{}, false, nil
+	}
+	dbPath := devinDBPath(root)
+	if dbPath == "" {
+		return SourceRef{}, false, nil
+	}
+	meta, err := getDevinSessionMeta(dbPath, rawID)
+	if err != nil {
+		return SourceRef{}, false, err
+	}
+	if meta == nil {
+		return SourceRef{}, false, nil
+	}
+	ref := s.newSourceRef(root, dbPath, rawID)
+	if requireFresh {
+		fresh, err := s.sourceExists(ref.Opaque.(devinSource))
+		if err != nil {
+			return SourceRef{}, false, err
+		}
+		if !fresh {
+			return SourceRef{}, false, nil
+		}
+	}
+	return ref, true, nil
+}
+
+func (s devinSourceSet) newSourceRef(root, dbPath, sessionID string) SourceRef {
+	virtualPath := VirtualSourcePath(dbPath, sessionID)
+	return SourceRef{
+		Provider:       AgentDevin,
+		Key:            virtualPath,
+		DisplayPath:    virtualPath,
+		FingerprintKey: virtualPath,
+		Opaque: devinSource{
+			Root:      root,
+			DBPath:    dbPath,
+			SessionID: sessionID,
+		},
+	}
+}
+
+func (s devinSource) virtualPath() string {
+	return VirtualSourcePath(s.DBPath, s.SessionID)
+}
+
+func devinProviderCapabilities() Capabilities {
+	return Capabilities{
+		Source: dbBackedSourceCapabilities(CapabilityNotApplicable),
+		Content: ContentCapabilities{
+			FirstMessage:         CapabilitySupported,
+			SessionName:          CapabilitySupported,
+			Cwd:                  CapabilitySupported,
+			Thinking:             CapabilitySupported,
+			ToolCalls:            CapabilitySupported,
+			ToolResults:          CapabilitySupported,
+			PerMessageTokenUsage: CapabilitySupported,
+			Model:                CapabilitySupported,
+		},
+	}
+}

--- a/internal/parser/devin_provider_test.go
+++ b/internal/parser/devin_provider_test.go
@@ -1,0 +1,618 @@
+package parser
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func assertDevinErrorRedacted(t *testing.T, err error, secretFragments ...string) {
+	t.Helper()
+	require.Error(t, err)
+	for _, fragment := range secretFragments {
+		assert.NotContains(t, err.Error(), fragment)
+	}
+}
+
+func TestDevinProviderCapabilities(t *testing.T) {
+	caps := devinProviderCapabilities()
+	assert.Equal(t, CapabilitySupported, caps.Content.PerMessageTokenUsage)
+	assert.Equal(t, CapabilityUnsupported, caps.Content.AggregateUsageEvents)
+}
+
+func TestDevinProviderDiscoverFindParse(t *testing.T) {
+	const sessionID = "session-123"
+	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{
+		ID:                 sessionID,
+		Title:              "DB title wins",
+		WorkingDirectory:   "/Users/alice/code/my-app",
+		Model:              "db-model",
+		CreatedAtMillis:    new(int64(1704103199000)),
+		LastActivityMillis: new(int64(1704103265000)),
+	}, `{
+		"agent":{"model_name":"devin-1"},
+		"steps":[
+			{"step_id":"step-1","source":"user","timestamp":"2024-01-01T10:00:01Z","message":"Fix the login bug"},
+			{"step_id":"step-2","source":"agent","timestamp":"2024-01-01T10:00:05Z","message":[{"type":"text","text":"Inspecting files."}]}
+		]
+	}`)
+	root := filepath.Dir(filepath.Dir(dbPath))
+	virtualPath := VirtualSourcePath(dbPath, sessionID)
+
+	provider, ok := NewProvider(AgentDevin, ProviderConfig{Roots: []string{root}, Machine: "devbox"})
+	require.True(t, ok)
+
+	plan, err := provider.WatchPlan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, plan.Roots, 2)
+	assert.Equal(t, filepath.Join(root, "cli"), plan.Roots[0].Path)
+	assert.False(t, plan.Roots[0].Recursive)
+	assert.ElementsMatch(t,
+		[]string{devinDBFilename, devinDBFilename + "-*"},
+		plan.Roots[0].IncludeGlobs,
+	)
+	assert.Equal(t, filepath.Join(root, "cli", "transcripts"), plan.Roots[1].Path)
+	assert.False(t, plan.Roots[1].Recursive)
+	assert.Equal(t, []string{"*.json"}, plan.Roots[1].IncludeGlobs)
+
+	discovered, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, discovered, 1)
+	assert.Equal(t, virtualPath, discovered[0].Key)
+	assert.Equal(t, virtualPath, discovered[0].DisplayPath)
+	assert.Equal(t, virtualPath, discovered[0].FingerprintKey)
+
+	changed, err := provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{
+		Path:      filepath.Join(root, "cli", "transcripts", sessionID+".json"),
+		EventKind: "write",
+		WatchRoot: filepath.Join(root, "cli", "transcripts"),
+	})
+	require.NoError(t, err)
+	require.Len(t, changed, 1)
+	assert.Equal(t, virtualPath, changed[0].DisplayPath)
+
+	fullIDSource, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
+		FullSessionID: "host~devin:" + sessionID,
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, virtualPath, fullIDSource.DisplayPath)
+
+	storedSource, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
+		StoredFilePath: virtualPath,
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, virtualPath, storedSource.DisplayPath)
+
+	fingerprint, err := provider.Fingerprint(context.Background(), storedSource)
+	require.NoError(t, err)
+	assert.Equal(t, virtualPath, fingerprint.Key)
+	assert.NotZero(t, fingerprint.MTimeNS)
+
+	outcome, err := provider.Parse(context.Background(), ParseRequest{Source: storedSource})
+	require.NoError(t, err)
+	require.True(t, outcome.ResultSetComplete)
+	require.True(t, outcome.ForceReplace)
+	require.Len(t, outcome.Results, 1)
+	result := outcome.Results[0]
+	assert.Equal(t, DataVersionCurrent, result.DataVersion)
+	assert.Equal(t, "devin:"+sessionID, result.Result.Session.ID)
+	assert.Equal(t, virtualPath, result.Result.Session.File.Path)
+	assert.Equal(t, "devbox", result.Result.Session.Machine)
+	assert.Len(t, result.Result.Messages, 2)
+}
+
+func TestDevinProviderDBEventsFanOutAndPreserveTombstones(t *testing.T) {
+	const liveSessionID = "session-live"
+	fixture := newDevinTestFixture(t,
+		devinSessionRow{ID: liveSessionID, Title: "Live", WorkingDirectory: "/tmp/live", Model: "db-model", CreatedAtMillis: new(int64(1704103199000)), LastActivityMillis: new(int64(1704103265000))},
+		devinSessionRow{ID: "session-deleted", Title: "Deleted", WorkingDirectory: "/tmp/deleted", Model: "db-model", CreatedAtMillis: new(int64(1704103199000)), LastActivityMillis: new(int64(1704103264000))},
+	)
+	fixture.writeTranscript(t, liveSessionID, `{"steps":[]}`)
+	root := fixture.Root
+	liveVirtualPath := fixture.sessionVirtualPath(liveSessionID)
+	deletedVirtualPath := fixture.sessionVirtualPath("session-deleted")
+	dbPath := fixture.DBPath
+	execDevinTestSQL(t, dbPath, `DELETE FROM sessions WHERE id = 'session-deleted'`)
+
+	provider, ok := NewProvider(AgentDevin, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	for _, changedPath := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
+		changed, err := provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{
+			Path:              changedPath,
+			EventKind:         "write",
+			WatchRoot:         filepath.Join(root, "cli"),
+			StoredSourcePaths: []string{deletedVirtualPath},
+		})
+		require.NoError(t, err)
+		require.Len(t, changed, 2, changedPath)
+		assert.ElementsMatch(t,
+			[]string{liveVirtualPath, deletedVirtualPath},
+			[]string{changed[0].DisplayPath, changed[1].DisplayPath},
+		)
+	}
+}
+
+func TestDevinProviderTranscriptEventsTargetLiveOrStoredSession(t *testing.T) {
+	const liveSessionID = "session-live"
+	fixture := newDevinTestFixture(t,
+		devinSessionRow{ID: liveSessionID, Title: "Live", WorkingDirectory: "/tmp/live", Model: "db-model", CreatedAtMillis: new(int64(1704103199000)), LastActivityMillis: new(int64(1704103265000))},
+		devinSessionRow{ID: "session-deleted", Title: "Deleted", WorkingDirectory: "/tmp/deleted", Model: "db-model", CreatedAtMillis: new(int64(1704103199000)), LastActivityMillis: new(int64(1704103264000))},
+	)
+	fixture.writeTranscript(t, liveSessionID, `{"steps":[]}`)
+	root := fixture.Root
+	liveVirtualPath := fixture.sessionVirtualPath(liveSessionID)
+	deletedVirtualPath := fixture.sessionVirtualPath("session-deleted")
+	dbPath := fixture.DBPath
+	execDevinTestSQL(t, dbPath, `DELETE FROM sessions WHERE id = 'session-deleted'`)
+
+	provider, ok := NewProvider(AgentDevin, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	liveChanged, err := provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{
+		Path:      filepath.Join(root, "cli", "transcripts", liveSessionID+".json"),
+		EventKind: "write",
+		WatchRoot: filepath.Join(root, "cli", "transcripts"),
+	})
+	require.NoError(t, err)
+	require.Len(t, liveChanged, 1)
+	assert.Equal(t, liveVirtualPath, liveChanged[0].DisplayPath)
+
+	deletedChanged, err := provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{
+		Path:              filepath.Join(root, "cli", "transcripts", "session-deleted.json"),
+		EventKind:         "write",
+		WatchRoot:         filepath.Join(root, "cli", "transcripts"),
+		StoredSourcePaths: []string{deletedVirtualPath},
+	})
+	require.NoError(t, err)
+	require.Len(t, deletedChanged, 1)
+	assert.Equal(t, deletedVirtualPath, deletedChanged[0].DisplayPath)
+}
+
+func TestDevinProviderRejectsUnrelatedChangedPaths(t *testing.T) {
+	const sessionID = "session-123"
+	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "Title", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAtMillis: new(int64(1704103199000)), LastActivityMillis: new(int64(1704103265000))}, `{"steps":[]}`)
+	root := filepath.Dir(filepath.Dir(dbPath))
+
+	provider, ok := NewProvider(AgentDevin, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	for _, req := range []ChangedPathRequest{
+		{
+			Path:      filepath.Join(root, "cli", "sessions.db-backup"),
+			EventKind: "write",
+			WatchRoot: filepath.Join(root, "cli"),
+		},
+		{
+			Path:      filepath.Join(root, "cli", "transcripts", sessionID+".txt"),
+			EventKind: "write",
+			WatchRoot: filepath.Join(root, "cli", "transcripts"),
+		},
+		{
+			Path:      filepath.Join(root, "cli", "nested", devinDBFilename),
+			EventKind: "write",
+			WatchRoot: filepath.Join(root, "cli"),
+		},
+		{
+			Path:      filepath.Join(root, "other", "sessions.db"),
+			EventKind: "write",
+			WatchRoot: filepath.Join(root, "other"),
+		},
+	} {
+		changed, err := provider.SourcesForChangedPath(context.Background(), req)
+		require.NoError(t, err)
+		assert.Empty(t, changed, "%+v", req)
+	}
+}
+
+func TestDevinProviderMissingTranscriptUsesMessageNodeFallback(t *testing.T) {
+	const sessionID = "session-db-only"
+	fixture := newDevinTestFixture(t,
+		devinSessionRow{ID: sessionID, Title: "DB only session", WorkingDirectory: "/tmp/db-only-project", Model: "db-only-model", CreatedAtMillis: new(int64(1704103200000)), LastActivityMillis: new(int64(1704103209000))},
+	)
+	root := fixture.Root
+	fixture.insertMessageNodes(t,
+		devinSyntheticMessageNodeRow{SessionID: sessionID, NodeID: 1, ChatMessage: `{"role":"user","content":"fallback user"}`, CreatedAtMillis: 1704103201000},
+		devinSyntheticMessageNodeRow{SessionID: sessionID, NodeID: 2, ChatMessage: `{"role":"assistant","content":"fallback assistant"}`, CreatedAtMillis: 1704103205000},
+	)
+
+	provider, ok := NewProvider(AgentDevin, ProviderConfig{Roots: []string{root}, Machine: "devbox"})
+	require.True(t, ok)
+
+	source, ok, err := provider.FindSource(context.Background(), FindSourceRequest{RawSessionID: sessionID})
+	require.NoError(t, err)
+	require.True(t, ok)
+	outcome, err := provider.Parse(context.Background(), ParseRequest{Source: source})
+	require.NoError(t, err)
+	assert.True(t, outcome.ResultSetComplete)
+	assert.True(t, outcome.ForceReplace)
+	require.Len(t, outcome.Results, 1)
+	assert.Empty(t, outcome.SourceErrors)
+	assert.Equal(t, "devin:"+sessionID, outcome.Results[0].Result.Session.ID)
+	assert.Len(t, outcome.Results[0].Result.Messages, 2)
+	assert.Equal(t, "fallback user", outcome.Results[0].Result.Messages[0].Content)
+}
+
+func TestDevinProviderMissingTranscriptWithoutDBMessagesReturnsRetryableSourceError(t *testing.T) {
+	const sessionID = "session-db-only-empty"
+	fixture := newDevinTestFixture(t,
+		devinSessionRow{ID: sessionID, Title: "DB only session", WorkingDirectory: "/tmp/db-only-project", Model: "db-only-model", CreatedAtMillis: new(int64(1704103200000)), LastActivityMillis: new(int64(1704103209000))},
+	)
+	root := fixture.Root
+
+	provider, ok := NewProvider(AgentDevin, ProviderConfig{Roots: []string{root}, Machine: "devbox"})
+	require.True(t, ok)
+
+	source, ok, err := provider.FindSource(context.Background(), FindSourceRequest{RawSessionID: sessionID})
+	require.NoError(t, err)
+	require.True(t, ok)
+	outcome, err := provider.Parse(context.Background(), ParseRequest{Source: source})
+	require.NoError(t, err)
+	assert.True(t, outcome.ResultSetComplete)
+	assert.False(t, outcome.ForceReplace)
+	assert.Empty(t, outcome.Results)
+	require.Len(t, outcome.SourceErrors, 1)
+	assert.Equal(t, source.FingerprintKey, outcome.SourceErrors[0].SourceKey)
+	assert.Equal(t, devinRedactedTranscriptPath(), outcome.SourceErrors[0].DisplayPath)
+	assert.Equal(t, "devin:"+sessionID, outcome.SourceErrors[0].SessionID)
+	assert.True(t, outcome.SourceErrors[0].Retryable)
+	assert.ErrorContains(t, outcome.SourceErrors[0].Err, "missing devin transcript")
+}
+
+func TestDevinProviderCompositeFingerprintStableAndRedacted(t *testing.T) {
+	const sessionID = "session-fingerprint"
+	dbPath, transcriptPath := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "Stable title", WorkingDirectory: "/Users/alice/.config/devin/project", Model: "db-model", CreatedAtMillis: new(int64(1704103200000)), LastActivityMillis: new(int64(1704103209000)), MetadataJSON: `{"token_hint":"redacted"}`}, `{"token":"secret-token-123","steps":[{"step_id":"step-1","source":"user","message":"hello"}]}`)
+	root := filepath.Dir(filepath.Dir(dbPath))
+	virtualPath := VirtualSourcePath(dbPath, sessionID)
+
+	provider, ok := NewProvider(AgentDevin, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	source, ok, err := provider.FindSource(context.Background(), FindSourceRequest{RawSessionID: sessionID})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	first, err := provider.Fingerprint(context.Background(), source)
+	require.NoError(t, err)
+	second, err := provider.Fingerprint(context.Background(), source)
+	require.NoError(t, err)
+
+	assert.Equal(t, first, second)
+	assert.Equal(t, virtualPath, first.Key)
+	assert.NotZero(t, first.MTimeNS)
+	assert.NotEmpty(t, first.Hash)
+	assert.NotContains(t, first.Hash, "secret-token-123")
+	assert.NotContains(t, first.Hash, "/Users/alice/.config/devin/project")
+	assert.NotContains(t, first.Key, transcriptPath)
+}
+
+func TestDevinProviderFingerprintChangesWhenTranscriptChangesWithoutDBMetadataChange(t *testing.T) {
+	const sessionID = "session-transcript-change"
+	dbPath, transcriptPath := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "Transcript change", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAtMillis: new(int64(1704103200000)), LastActivityMillis: new(int64(1704103209000))}, `{"steps":[{"step_id":"step-1","source":"user","message":"alpha"}]}`)
+	root := filepath.Dir(filepath.Dir(dbPath))
+
+	provider, ok := NewProvider(AgentDevin, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	source, ok, err := provider.FindSource(context.Background(), FindSourceRequest{RawSessionID: sessionID})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	before, err := provider.Fingerprint(context.Background(), source)
+	require.NoError(t, err)
+	transcriptInfo, err := os.Stat(transcriptPath)
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(transcriptPath, []byte(`{"steps":[{"step_id":"step-1","source":"user","message":"omega"}]}`), 0o644))
+	require.NoError(t, os.Chtimes(transcriptPath, transcriptInfo.ModTime(), transcriptInfo.ModTime()))
+
+	after, err := provider.Fingerprint(context.Background(), source)
+	require.NoError(t, err)
+
+	assert.Equal(t, before.Key, after.Key)
+	assert.Equal(t, before.MTimeNS, after.MTimeNS)
+	assert.NotEqual(t, before.Hash, after.Hash)
+}
+
+func TestDevinProviderFingerprintChangesWhenLastActivityChanges(t *testing.T) {
+	const sessionID = "session-last-activity"
+	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "DB change", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAtMillis: new(int64(1704103200000)), LastActivityMillis: new(int64(1704103209000))}, `{"steps":[]}`)
+	root := filepath.Dir(filepath.Dir(dbPath))
+
+	provider, ok := NewProvider(AgentDevin, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	source, ok, err := provider.FindSource(context.Background(), FindSourceRequest{RawSessionID: sessionID})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	before, err := provider.Fingerprint(context.Background(), source)
+	require.NoError(t, err)
+
+	execDevinTestSQL(t, dbPath, `UPDATE sessions SET last_activity_at = 1704103215000 WHERE id = 'session-last-activity'`)
+
+	after, err := provider.Fingerprint(context.Background(), source)
+	require.NoError(t, err)
+
+	assert.Equal(t, before.Key, after.Key)
+	assert.Greater(t, after.MTimeNS, before.MTimeNS)
+	assert.NotEqual(t, before.Hash, after.Hash)
+}
+
+func TestDevinProviderFingerprintWithoutTranscriptUsesDBFreshnessOnly(t *testing.T) {
+	const sessionID = "session-missing-transcript"
+	dbPath, transcriptPath := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "DB only session", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAtMillis: new(int64(1704103200000)), LastActivityMillis: new(int64(1704103209000))}, `{"steps":[]}`)
+	root := filepath.Dir(filepath.Dir(dbPath))
+	virtualPath := VirtualSourcePath(dbPath, sessionID)
+	require.NoError(t, os.Remove(transcriptPath))
+
+	provider, ok := NewProvider(AgentDevin, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	source, ok, err := provider.FindSource(context.Background(), FindSourceRequest{RawSessionID: sessionID})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	fingerprint, err := provider.Fingerprint(context.Background(), source)
+	require.NoError(t, err)
+
+	assert.Equal(t, virtualPath, fingerprint.Key)
+	assert.NotZero(t, fingerprint.MTimeNS)
+	assert.Zero(t, fingerprint.Size)
+	assert.NotEmpty(t, fingerprint.Hash)
+	assert.NotContains(t, fingerprint.Hash, transcriptPath)
+}
+
+func TestDevinProviderRejectsInvalidStoredVirtualPaths(t *testing.T) {
+	const sessionID = "session-123"
+	fixture := newDevinTestFixture(t,
+		devinSessionRow{ID: sessionID, Title: "Title", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAtMillis: new(int64(1704103199000)), LastActivityMillis: new(int64(1704103265000))},
+		devinSessionRow{ID: "session-999", Title: "Other", WorkingDirectory: "/tmp/other", Model: "db-model", CreatedAtMillis: new(int64(1704103199000)), LastActivityMillis: new(int64(1704103265000))},
+	)
+	fixture.writeTranscript(t, sessionID, `{"steps":[]}`)
+	root := fixture.Root
+	virtualPath := fixture.sessionVirtualPath(sessionID)
+	otherPath := fixture.sessionVirtualPath("session-999")
+	dbPath := fixture.DBPath
+
+	provider, ok := NewProvider(AgentDevin, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	for _, path := range []string{
+		dbPath + "#",
+		filepath.Join(root, "cli", "other.db") + "#" + sessionID,
+		filepath.Join(root, devinDBFilename) + "#" + sessionID,
+		filepath.Join(root, "cli", "nested", devinDBFilename) + "#" + sessionID,
+	} {
+		_, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
+			StoredFilePath:     path,
+			RequireFreshSource: true,
+		})
+		require.NoError(t, err)
+		assert.False(t, ok, "stored path %q", path)
+	}
+
+	source, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
+		RawSessionID:       sessionID,
+		StoredFilePath:     otherPath,
+		RequireFreshSource: true,
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, virtualPath, source.DisplayPath)
+}
+
+func TestDevinProviderDedupesDuplicateRoots(t *testing.T) {
+	const sessionID = "session-123"
+	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "Title", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAtMillis: new(int64(1704103199000)), LastActivityMillis: new(int64(1704103265000))}, `{"steps":[]}`)
+	root := filepath.Dir(filepath.Dir(dbPath))
+
+	provider, ok := NewProvider(AgentDevin, ProviderConfig{Roots: []string{root, root, filepath.Join(root, ".")}})
+	require.True(t, ok)
+
+	discovered, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, discovered, 1)
+}
+
+func TestDevinProviderDeletedRowFingerprintsTombstoneAndSkips(t *testing.T) {
+	const sessionID = "session-123"
+	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "Title", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAtMillis: new(int64(1704103199000)), LastActivityMillis: new(int64(1704103265000))}, `{"steps":[]}`)
+	root := filepath.Dir(filepath.Dir(dbPath))
+	virtualPath := VirtualSourcePath(dbPath, sessionID)
+
+	provider, ok := NewProvider(AgentDevin, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	source, ok, err := provider.FindSource(context.Background(), FindSourceRequest{RawSessionID: sessionID})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, virtualPath, source.DisplayPath)
+	execDevinTestSQL(t, dbPath, `DELETE FROM sessions WHERE id = 'session-123'`)
+
+	changed, err := provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{
+		Path:              dbPath,
+		EventKind:         "write",
+		WatchRoot:         filepath.Join(root, "cli"),
+		StoredSourcePaths: []string{virtualPath},
+	})
+	require.NoError(t, err)
+	require.Len(t, changed, 1)
+
+	fingerprint, err := provider.Fingerprint(context.Background(), changed[0])
+	require.NoError(t, err)
+	assert.Equal(t, SourceFingerprint{Key: virtualPath}, fingerprint)
+
+	outcome, err := provider.Parse(context.Background(), ParseRequest{Source: changed[0]})
+	require.NoError(t, err)
+	assert.True(t, outcome.ResultSetComplete)
+	assert.True(t, outcome.ForceReplace)
+	assert.Equal(t, SkipNoSession, outcome.SkipReason)
+	assert.Empty(t, outcome.Results)
+}
+
+func TestDevinProviderHiddenRowFingerprintsTombstoneAndSkips(t *testing.T) {
+	const sessionID = "session-hidden"
+	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "Title", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAtMillis: new(int64(1704103199000)), LastActivityMillis: new(int64(1704103265000)), Hidden: false}, `{"steps":[]}`)
+	root := filepath.Dir(filepath.Dir(dbPath))
+	virtualPath := VirtualSourcePath(dbPath, sessionID)
+
+	provider, ok := NewProvider(AgentDevin, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	source, ok, err := provider.FindSource(context.Background(), FindSourceRequest{RawSessionID: sessionID})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, virtualPath, source.DisplayPath)
+	execDevinTestSQL(t, dbPath, `UPDATE sessions SET hidden = 1 WHERE id = 'session-hidden'`)
+
+	changed, err := provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{
+		Path:              dbPath,
+		EventKind:         "write",
+		WatchRoot:         filepath.Join(root, "cli"),
+		StoredSourcePaths: []string{virtualPath},
+	})
+	require.NoError(t, err)
+	require.Len(t, changed, 1)
+
+	fingerprint, err := provider.Fingerprint(context.Background(), changed[0])
+	require.NoError(t, err)
+	assert.Equal(t, SourceFingerprint{Key: virtualPath}, fingerprint)
+
+	outcome, err := provider.Parse(context.Background(), ParseRequest{Source: changed[0]})
+	require.NoError(t, err)
+	assert.True(t, outcome.ResultSetComplete)
+	assert.True(t, outcome.ForceReplace)
+	assert.Equal(t, SkipNoSession, outcome.SkipReason)
+	assert.Empty(t, outcome.Results)
+}
+
+func TestDevinProviderCorruptTranscriptReturnsRetryableSourceError(t *testing.T) {
+	const sessionID = "session-corrupt"
+	dbPath, transcriptPath := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "Corrupt transcript", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAtMillis: new(int64(1704103199000)), LastActivityMillis: new(int64(1704103265000))}, `{"steps":[]}`)
+	root := filepath.Dir(filepath.Dir(dbPath))
+	require.NoError(t, os.WriteFile(transcriptPath, []byte(`{"secret":"token-123","steps":[`), 0o644))
+
+	provider, ok := NewProvider(AgentDevin, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	source, ok, err := provider.FindSource(context.Background(), FindSourceRequest{RawSessionID: sessionID})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	outcome, err := provider.Parse(context.Background(), ParseRequest{Source: source})
+	require.NoError(t, err)
+	assert.True(t, outcome.ResultSetComplete)
+	assert.False(t, outcome.ForceReplace)
+	assert.Empty(t, outcome.Results)
+	require.Len(t, outcome.SourceErrors, 1)
+	sourceErr := outcome.SourceErrors[0]
+	assert.True(t, sourceErr.Retryable)
+	assert.Equal(t, devinRedactedTranscriptPath(), sourceErr.DisplayPath)
+	assert.ErrorContains(t, sourceErr.Err, "invalid devin transcript")
+	assert.NotContains(t, sourceErr.Err.Error(), transcriptPath)
+	assert.NotContains(t, sourceErr.Err.Error(), sessionID)
+	assert.NotContains(t, sourceErr.Err.Error(), "token-123")
+}
+
+func TestDevinProviderIgnoresCredentialPathsAndRedactsSecretBearingErrors(t *testing.T) {
+	const (
+		sessionID      = "session-privacy"
+		secretSentinel = "oauth-token-SYNTHETIC-SECRET-SENTINEL"
+	)
+	fixture := newDevinTestFixture(t,
+		devinSessionRow{ID: sessionID, Title: "Privacy", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAtMillis: new(int64(1704103199000)), LastActivityMillis: new(int64(1704103265000))},
+	)
+	transcriptPath := fixture.writeTranscript(t, sessionID, `{"api_key":"oauth-token-SYNTHETIC-SECRET-SENTINEL","steps":[`)
+
+	secretRoot := filepath.Join(t.TempDir(), secretSentinel, "config", "mcp", "oauth", "devin-root")
+	require.NoError(t, os.MkdirAll(filepath.Dir(secretRoot), 0o755))
+	require.NoError(t, os.Rename(fixture.Root, secretRoot))
+
+	dbPath := filepath.Join(secretRoot, "cli", devinDBFilename)
+	provider, ok := NewProvider(AgentDevin, ProviderConfig{Roots: []string{secretRoot}})
+	require.True(t, ok)
+
+	for _, req := range []ChangedPathRequest{
+		{
+			Path:      filepath.Join(secretRoot, "cli", "config.json"),
+			EventKind: "write",
+			WatchRoot: filepath.Join(secretRoot, "cli"),
+		},
+		{
+			Path:      filepath.Join(secretRoot, "cli", "mcp", "oauth", "credentials.db"),
+			EventKind: "write",
+			WatchRoot: filepath.Join(secretRoot, "cli"),
+		},
+		{
+			Path:      filepath.Join(secretRoot, "cli", "mcp", "oauth", "token-cache.json"),
+			EventKind: "write",
+			WatchRoot: filepath.Join(secretRoot, "cli"),
+		},
+	} {
+		changed, err := provider.SourcesForChangedPath(context.Background(), req)
+		require.NoError(t, err)
+		assert.Empty(t, changed, "%+v", req)
+	}
+
+	source, ok, err := provider.FindSource(context.Background(), FindSourceRequest{RawSessionID: sessionID})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, VirtualSourcePath(dbPath, sessionID), source.DisplayPath)
+
+	outcome, err := provider.Parse(context.Background(), ParseRequest{Source: source})
+	require.NoError(t, err)
+	require.Len(t, outcome.SourceErrors, 1)
+	sourceErr := outcome.SourceErrors[0]
+	assert.True(t, sourceErr.Retryable)
+	assert.Equal(t, devinRedactedTranscriptPath(), sourceErr.DisplayPath)
+	assert.ErrorContains(t, sourceErr.Err, "invalid devin transcript")
+	assertDevinErrorRedacted(t, sourceErr.Err,
+		secretSentinel,
+		"mcp/oauth",
+		"config",
+		"api_key",
+		transcriptPath,
+	)
+}
+
+func TestDevinProviderMissingDBSkipsAndPreservesSessions(t *testing.T) {
+	const sessionID = "session-123"
+	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "Title", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAtMillis: new(int64(1704103199000)), LastActivityMillis: new(int64(1704103265000))}, `{"steps":[]}`)
+	root := filepath.Dir(filepath.Dir(dbPath))
+	virtualPath := VirtualSourcePath(dbPath, sessionID)
+
+	provider, ok := NewProvider(AgentDevin, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	source, ok, err := provider.FindSource(context.Background(), FindSourceRequest{StoredFilePath: virtualPath})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	require.NoError(t, os.Remove(dbPath))
+	changed, err := provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{
+		Path:              dbPath,
+		EventKind:         "remove",
+		WatchRoot:         filepath.Join(root, "cli"),
+		StoredSourcePaths: []string{virtualPath},
+	})
+	require.NoError(t, err)
+	require.Len(t, changed, 1)
+
+	fingerprint, err := provider.Fingerprint(context.Background(), source)
+	require.NoError(t, err)
+	assert.Equal(t, SourceFingerprint{Key: virtualPath}, fingerprint)
+
+	outcome, err := provider.Parse(context.Background(), ParseRequest{Source: changed[0]})
+	require.NoError(t, err)
+	assert.True(t, outcome.ResultSetComplete)
+	assert.False(t, outcome.ForceReplace)
+	assert.Equal(t, SkipNoSession, outcome.SkipReason)
+	assert.Empty(t, outcome.Results)
+}

--- a/internal/parser/devin_provider_test.go
+++ b/internal/parser/devin_provider_test.go
@@ -342,6 +342,30 @@ func TestDevinProviderFingerprintChangesWhenLastActivityChanges(t *testing.T) {
 	assert.NotEqual(t, before.Hash, after.Hash)
 }
 
+func TestDevinProviderFingerprintChangesWhenWorkingDirectoryChanges(t *testing.T) {
+	const sessionID = "session-cwd-change"
+	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "CWD change", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAtMillis: new(int64(1704103200000)), LastActivityMillis: new(int64(1704103209000))}, `{"steps":[]}`)
+	root := filepath.Dir(filepath.Dir(dbPath))
+
+	provider, ok := NewProvider(AgentDevin, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	source, ok, err := provider.FindSource(context.Background(), FindSourceRequest{RawSessionID: sessionID})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	before, err := provider.Fingerprint(context.Background(), source)
+	require.NoError(t, err)
+
+	execDevinTestSQL(t, dbPath, `UPDATE sessions SET working_directory = '/tmp/renamed-app' WHERE id = 'session-cwd-change'`)
+
+	after, err := provider.Fingerprint(context.Background(), source)
+	require.NoError(t, err)
+
+	assert.Equal(t, before.Key, after.Key)
+	assert.NotEqual(t, before.Hash, after.Hash)
+}
+
 func TestDevinProviderFingerprintWithoutTranscriptUsesDBFreshnessOnly(t *testing.T) {
 	const sessionID = "session-missing-transcript"
 	dbPath, transcriptPath := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "DB only session", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAtMillis: new(int64(1704103200000)), LastActivityMillis: new(int64(1704103209000))}, `{"steps":[]}`)
@@ -364,6 +388,34 @@ func TestDevinProviderFingerprintWithoutTranscriptUsesDBFreshnessOnly(t *testing
 	assert.Zero(t, fingerprint.Size)
 	assert.NotEmpty(t, fingerprint.Hash)
 	assert.NotContains(t, fingerprint.Hash, transcriptPath)
+}
+
+func TestDevinProviderFingerprintWithoutTranscriptChangesWhenMessageNodesChange(t *testing.T) {
+	const sessionID = "session-message-node-change"
+	fixture := newDevinTestFixture(t,
+		devinSessionRow{ID: sessionID, Title: "DB messages", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAtMillis: new(int64(1704103200000)), LastActivityMillis: new(int64(1704103209000))},
+	)
+	fixture.insertMessageNodes(t,
+		devinSyntheticMessageNodeRow{SessionID: sessionID, NodeID: 1, ChatMessage: `{"role":"user","content":"alpha"}`, CreatedAtMillis: 1704103201000},
+	)
+
+	provider, ok := NewProvider(AgentDevin, ProviderConfig{Roots: []string{fixture.Root}})
+	require.True(t, ok)
+
+	source, ok, err := provider.FindSource(context.Background(), FindSourceRequest{RawSessionID: sessionID})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	before, err := provider.Fingerprint(context.Background(), source)
+	require.NoError(t, err)
+
+	execDevinTestSQL(t, fixture.DBPath, `UPDATE message_nodes SET chat_message = '{"role":"user","content":"omega"}' WHERE session_id = 'session-message-node-change'`)
+
+	after, err := provider.Fingerprint(context.Background(), source)
+	require.NoError(t, err)
+
+	assert.Equal(t, before.Key, after.Key)
+	assert.NotEqual(t, before.Hash, after.Hash)
 }
 
 func TestDevinProviderRejectsInvalidStoredVirtualPaths(t *testing.T) {

--- a/internal/parser/devin_provider_test.go
+++ b/internal/parser/devin_provider_test.go
@@ -65,6 +65,7 @@ func TestDevinProviderDiscoverFindParse(t *testing.T) {
 	assert.Equal(t, virtualPath, discovered[0].Key)
 	assert.Equal(t, virtualPath, discovered[0].DisplayPath)
 	assert.Equal(t, virtualPath, discovered[0].FingerprintKey)
+	assert.Equal(t, int64(1704103265000000000), discovered[0].DiscoveryMTimeNS)
 
 	changed, err := provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{
 		Path:      filepath.Join(root, "cli", "transcripts", sessionID+".json"),
@@ -239,7 +240,7 @@ func TestDevinProviderMissingTranscriptUsesMessageNodeFallback(t *testing.T) {
 	assert.Equal(t, "fallback user", outcome.Results[0].Result.Messages[0].Content)
 }
 
-func TestDevinProviderMissingTranscriptWithoutDBMessagesReturnsRetryableSourceError(t *testing.T) {
+func TestDevinProviderMissingTranscriptWithoutDBMessagesReturnsProviderError(t *testing.T) {
 	const sessionID = "session-db-only-empty"
 	fixture := newDevinTestFixture(t,
 		devinSessionRow{ID: sessionID, Title: "DB only session", WorkingDirectory: "/tmp/db-only-project", Model: "db-only-model", CreatedAtMillis: new(int64(1704103200000)), LastActivityMillis: new(int64(1704103209000))},
@@ -253,16 +254,12 @@ func TestDevinProviderMissingTranscriptWithoutDBMessagesReturnsRetryableSourceEr
 	require.NoError(t, err)
 	require.True(t, ok)
 	outcome, err := provider.Parse(context.Background(), ParseRequest{Source: source})
-	require.NoError(t, err)
-	assert.True(t, outcome.ResultSetComplete)
-	assert.False(t, outcome.ForceReplace)
+	require.Error(t, err)
 	assert.Empty(t, outcome.Results)
-	require.Len(t, outcome.SourceErrors, 1)
-	assert.Equal(t, source.FingerprintKey, outcome.SourceErrors[0].SourceKey)
-	assert.Equal(t, devinRedactedTranscriptPath(), outcome.SourceErrors[0].DisplayPath)
-	assert.Equal(t, "devin:"+sessionID, outcome.SourceErrors[0].SessionID)
-	assert.True(t, outcome.SourceErrors[0].Retryable)
-	assert.ErrorContains(t, outcome.SourceErrors[0].Err, "missing devin transcript")
+	assert.Empty(t, outcome.SourceErrors)
+	assert.ErrorContains(t, err, "missing devin transcript")
+	assert.NotContains(t, err.Error(), source.DisplayPath)
+	assert.NotContains(t, err.Error(), sessionID)
 }
 
 func TestDevinProviderCompositeFingerprintStableAndRedacted(t *testing.T) {
@@ -493,7 +490,7 @@ func TestDevinProviderHiddenRowFingerprintsTombstoneAndSkips(t *testing.T) {
 	assert.Empty(t, outcome.Results)
 }
 
-func TestDevinProviderCorruptTranscriptReturnsRetryableSourceError(t *testing.T) {
+func TestDevinProviderCorruptTranscriptReturnsProviderError(t *testing.T) {
 	const sessionID = "session-corrupt"
 	dbPath, transcriptPath := newDevinSessionFixture(t, devinSessionRow{ID: sessionID, Title: "Corrupt transcript", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAtMillis: new(int64(1704103199000)), LastActivityMillis: new(int64(1704103265000))}, `{"steps":[]}`)
 	root := filepath.Dir(filepath.Dir(dbPath))
@@ -507,18 +504,13 @@ func TestDevinProviderCorruptTranscriptReturnsRetryableSourceError(t *testing.T)
 	require.True(t, ok)
 
 	outcome, err := provider.Parse(context.Background(), ParseRequest{Source: source})
-	require.NoError(t, err)
-	assert.True(t, outcome.ResultSetComplete)
-	assert.False(t, outcome.ForceReplace)
 	assert.Empty(t, outcome.Results)
-	require.Len(t, outcome.SourceErrors, 1)
-	sourceErr := outcome.SourceErrors[0]
-	assert.True(t, sourceErr.Retryable)
-	assert.Equal(t, devinRedactedTranscriptPath(), sourceErr.DisplayPath)
-	assert.ErrorContains(t, sourceErr.Err, "invalid devin transcript")
-	assert.NotContains(t, sourceErr.Err.Error(), transcriptPath)
-	assert.NotContains(t, sourceErr.Err.Error(), sessionID)
-	assert.NotContains(t, sourceErr.Err.Error(), "token-123")
+	assert.Empty(t, outcome.SourceErrors)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "invalid devin transcript")
+	assert.NotContains(t, err.Error(), transcriptPath)
+	assert.NotContains(t, err.Error(), sessionID)
+	assert.NotContains(t, err.Error(), "token-123")
 }
 
 func TestDevinProviderIgnoresCredentialPathsAndRedactsSecretBearingErrors(t *testing.T) {
@@ -567,13 +559,11 @@ func TestDevinProviderIgnoresCredentialPathsAndRedactsSecretBearingErrors(t *tes
 	assert.Equal(t, VirtualSourcePath(dbPath, sessionID), source.DisplayPath)
 
 	outcome, err := provider.Parse(context.Background(), ParseRequest{Source: source})
-	require.NoError(t, err)
-	require.Len(t, outcome.SourceErrors, 1)
-	sourceErr := outcome.SourceErrors[0]
-	assert.True(t, sourceErr.Retryable)
-	assert.Equal(t, devinRedactedTranscriptPath(), sourceErr.DisplayPath)
-	assert.ErrorContains(t, sourceErr.Err, "invalid devin transcript")
-	assertDevinErrorRedacted(t, sourceErr.Err,
+	assert.Empty(t, outcome.Results)
+	assert.Empty(t, outcome.SourceErrors)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "invalid devin transcript")
+	assertDevinErrorRedacted(t, err,
 		secretSentinel,
 		"mcp/oauth",
 		"config",

--- a/internal/parser/devin_test.go
+++ b/internal/parser/devin_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"database/sql"
 	"os"
 	"path/filepath"
 	"testing"
@@ -106,6 +107,29 @@ func TestOpenDevinDBUsesReadOnlyMode(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"session-readonly"}, devinMetaIDs(metas))
 	assert.NotEmpty(t, journalMode)
+}
+
+func TestOpenDevinDBWithSpecialCharPath(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "pro#ject %41")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	dbPath := filepath.Join(dir, devinDBFilename)
+
+	writer, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = writer.Exec("CREATE TABLE sessions (id TEXT); INSERT INTO sessions VALUES ('session-1')")
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	db, err := openDevinDB(dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	var count int
+	require.NoError(t, db.QueryRow("SELECT count(*) FROM sessions").Scan(&count))
+	assert.Equal(t, 1, count)
+
+	_, err = db.Exec("INSERT INTO sessions VALUES ('session-2')")
+	require.Error(t, err, "mode=ro must survive special characters in the path")
 }
 
 func TestParseDevinSession(t *testing.T) {

--- a/internal/parser/devin_test.go
+++ b/internal/parser/devin_test.go
@@ -1,0 +1,534 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestDevinDBPath(t *testing.T) {
+	root := t.TempDir()
+	cliDir := filepath.Join(root, "cli")
+	require.NoError(t, os.MkdirAll(cliDir, 0o755))
+	dbPath := filepath.Join(cliDir, devinDBFilename)
+	require.NoError(t, os.WriteFile(dbPath, []byte("synthetic"), 0o644))
+
+	assert.Equal(t, dbPath, devinDBPath(root))
+	assert.Empty(t, devinDBPath(filepath.Join(root, "missing")))
+	assert.Empty(t, devinDBPath(""))
+
+	require.NoError(t, os.Remove(dbPath))
+	require.NoError(t, os.Mkdir(dbPath, 0o755))
+	assert.Empty(t, devinDBPath(root))
+}
+
+func TestListDevinSessionMeta(t *testing.T) {
+	fixture := newDevinTestFixture(t,
+		devinSessionRow{ID: "session-hidden", Title: "Hidden", WorkingDirectory: "/cwd/hidden", Model: "model-hidden", CreatedAtMillis: new(int64(1_700_000_010_000)), LastActivityMillis: new(int64(1_700_000_090_000)), Hidden: true},
+		devinSessionRow{ID: "session-fallback", Title: "Fallback title", WorkingDirectory: "/cwd/fallback", Model: "model-fallback", CreatedAtMillis: new(int64(1_700_000_020_000))},
+		devinSessionRow{ID: "session-active", Title: "Active title", WorkingDirectory: "/cwd/active", Model: "model-active", CreatedAtMillis: new(int64(1_700_000_030_000)), LastActivityMillis: new(int64(1_700_000_080_000))},
+		devinSessionRow{ID: "session-newest", Title: "Newest title", WorkingDirectory: "/cwd/newest", Model: "model-newest", CreatedAtMillis: new(int64(1_700_000_040_000)), LastActivityMillis: new(int64(1_700_000_095_000))},
+	)
+
+	metas, err := ListDevinSessionMeta(fixture.DBPath)
+	require.NoError(t, err)
+	require.Len(t, metas, 3)
+
+	assert.Equal(t, []string{"session-newest", "session-active", "session-fallback"}, devinMetaIDs(metas))
+
+	assert.Equal(t, fixture.sessionVirtualPath("session-newest"), metas[0].VirtualPath)
+	assert.Equal(t, "Newest title", metas[0].Title)
+	assert.Equal(t, "/cwd/newest", metas[0].CWD)
+	assert.Equal(t, "model-newest", metas[0].Model)
+	assert.Equal(t, time.UnixMilli(1_700_000_095_000).UTC(), metas[0].UpdatedAt)
+	assert.Equal(t, int64(1_700_000_095_000_000_000), metas[0].FileMtime)
+
+	assert.Equal(t, time.UnixMilli(1_700_000_020_000).UTC(), metas[2].UpdatedAt)
+	assert.Equal(t, int64(1_700_000_020_000_000_000), metas[2].FileMtime)
+
+	for _, meta := range metas {
+		assert.NotEqual(t, "session-hidden", meta.RawSessionID)
+	}
+}
+
+func TestListDevinSessionMetaMissingDB(t *testing.T) {
+	metas, err := ListDevinSessionMeta(filepath.Join(t.TempDir(), "cli", devinDBFilename))
+	require.NoError(t, err)
+	assert.Nil(t, metas)
+}
+
+func TestListDevinSessionMetaMalformedSchema(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), devinDBFilename)
+	initDevinTestDB(t, dbPath)
+	execDevinTestSQL(t, dbPath, `
+		CREATE TABLE sessions (
+			id TEXT PRIMARY KEY,
+			payload TEXT
+		);
+	`)
+	execDevinTestSQL(t, dbPath, `INSERT INTO sessions (id, payload) VALUES ('secret-session', 'top-secret-row-content')`)
+
+	metas, err := ListDevinSessionMeta(dbPath)
+	assert.Nil(t, metas)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "listing devin sessions")
+	assert.NotContains(t, err.Error(), "top-secret-row-content")
+	assert.NotContains(t, err.Error(), "secret-session")
+}
+
+func TestOpenDevinDBUsesReadOnlyMode(t *testing.T) {
+	fixture := newDevinTestFixture(t,
+		devinSessionRow{ID: "session-readonly", Title: "Read only", WorkingDirectory: "/tmp/readonly", Model: "db-model", CreatedAtMillis: new(int64(1704103199000)), LastActivityMillis: new(int64(1704103265000))},
+	)
+
+	db, err := openDevinDB(fixture.DBPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	var journalMode string
+	require.NoError(t, db.QueryRow(`PRAGMA journal_mode`).Scan(&journalMode))
+
+	_, err = db.Exec(`INSERT INTO sessions (id) VALUES ('write-should-fail')`)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "readonly")
+	assert.ErrorContains(t, err, "attempt to write")
+
+	var count int
+	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM sessions`).Scan(&count))
+	assert.Equal(t, 1, count)
+
+	metas, err := ListDevinSessionMeta(fixture.DBPath)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"session-readonly"}, devinMetaIDs(metas))
+	assert.NotEmpty(t, journalMode)
+}
+
+func TestParseDevinSession(t *testing.T) {
+	const sessionID = "session-123"
+	dbPath, transcriptPath := newDevinSessionFixture(t, devinSessionRow{
+		ID:                 sessionID,
+		Title:              "DB title wins",
+		WorkingDirectory:   "/Users/alice/code/my-app",
+		Model:              "db-model",
+		CreatedAtMillis:    new(int64(1704103199000)),
+		LastActivityMillis: new(int64(1704103265000)),
+		WorkspaceJSON:      `{"root_path":"/Users/alice/code/my-app"}`,
+		MetadataJSON:       `{"source":"synthetic"}`,
+	}, `{
+		"title":"Transcript title loses",
+		"cwd":"/Users/alice/code/transcript-cwd",
+		"created_at":"2024-01-01T10:00:00Z",
+		"updated_at":"2024-01-01T10:01:05Z",
+		"agent":{"model_name":"devin-1"},
+		"final_metrics":{
+			"output_tokens":222,
+			"input_tokens":100,
+			"cache_read_input_tokens":300,
+			"cost_usd":99,
+			"mystery_tokens":444
+		},
+		"steps":[
+			{"step_id":100,"source":"system","timestamp":"2024-01-01T10:00:00Z","message":"Session booted"},
+			{"step_id":"step-1","source":"user","timestamp":"2024-01-01T10:00:01Z","message":"Fix the login bug"},
+			{"step_id":"step-skip","source":"user","timestamp":"2024-01-01T10:00:02Z","message":[{"type":"text","text":""},{"type":"unknown","value":"ignored"}]},
+			{"step_id":"step-3","source":"agent","timestamp":"2024-01-01T10:00:05Z","message":[{"type":"thinking","thinking":"Check auth flow"},{"type":"text","text":"Inspecting files."},{"type":"tool_use","id":"tool-msg","name":"read_file","input":{"file_path":"README.md"}}],"tool_use":[{"id":"tool-top-1","name":"shell_command","input":{"command":"ls -la"}},{"id":"tool-top-2","name":"edit_file","input":{"path":"main.go"}}]},
+			{"step_id":"step-4","source":"user","timestamp":"2024-01-01T10:01:00Z","tool_result":[{"tool_use_id":"tool-top-1","content":"file1\nfile2"}]},
+			{"step_id":"step-5","source":"agent","timestamp":"2024-01-01T10:01:05Z","message":[{"type":"unknown","value":"ignored"}],"tool_result":[{"tool_use_id":"tool-top-2","content":[{"type":"text","text":"patch applied"}]}]}
+		]
+	}`)
+
+	sess, msgs, err := parseDevinSession(dbPath, sessionID, "local")
+	require.NoError(t, err)
+	assertSessionMeta(t, sess, "devin:"+sessionID, "my_app", AgentDevin)
+	require.Len(t, msgs, 5)
+	assert.Equal(t, VirtualSourcePath(dbPath, sessionID), sess.File.Path)
+	assert.Equal(t, transcriptPath, filepath.Join(filepath.Dir(dbPath), "transcripts", sessionID+".json"))
+	assert.Equal(t, "DB title wins", sess.SessionName)
+	assert.Equal(t, "/Users/alice/code/my-app", sess.Cwd)
+	assert.Equal(t, "Fix the login bug", sess.FirstMessage)
+	assert.Equal(t, 1, sess.UserMessageCount)
+	assertTimestamp(t, sess.StartedAt, time.UnixMilli(1_704_103_199_000).UTC())
+	assertTimestamp(t, sess.EndedAt, time.UnixMilli(1_704_103_265_000).UTC())
+	assert.True(t, sess.HasTotalOutputTokens)
+	assert.Equal(t, 222, sess.TotalOutputTokens)
+	assert.True(t, sess.HasPeakContextTokens)
+	assert.Equal(t, 400, sess.PeakContextTokens)
+	hasTotal, hasPeak := sess.AggregateTokenPresence()
+	assert.True(t, hasTotal)
+	assert.True(t, hasPeak)
+
+	assert.Equal(t, 0, msgs[0].Ordinal)
+	assert.Equal(t, 1, msgs[1].Ordinal)
+	assert.Equal(t, 3, msgs[2].Ordinal)
+	assert.Equal(t, 4, msgs[3].Ordinal)
+	assert.Equal(t, 5, msgs[4].Ordinal)
+
+	assert.Equal(t, RoleSystem, msgs[0].Role)
+	assert.True(t, msgs[0].IsSystem)
+	assert.Equal(t, "100", msgs[0].SourceUUID)
+
+	assert.Equal(t, RoleUser, msgs[1].Role)
+	assert.False(t, msgs[1].IsSystem)
+	assert.Equal(t, "Fix the login bug", msgs[1].Content)
+
+	assistant := msgs[2]
+	assert.Equal(t, RoleAssistant, assistant.Role)
+	assert.Equal(t, "devin-1", assistant.Model)
+	assert.True(t, assistant.HasThinking)
+	assert.True(t, assistant.HasToolUse)
+	assert.Equal(t, "Check auth flow", assistant.ThinkingText)
+	assert.Contains(t, assistant.Content, "[Thinking]\nCheck auth flow\n[/Thinking]")
+	assert.Contains(t, assistant.Content, "Inspecting files.")
+	assert.Contains(t, assistant.Content, "[Read: README.md]")
+	assert.Contains(t, assistant.Content, "[Bash]\n$ ls -la")
+	assert.Contains(t, assistant.Content, "[Edit: main.go]")
+	require.Len(t, assistant.ToolCalls, 3)
+	assert.Equal(t, ParsedToolCall{ToolUseID: "tool-msg", ToolName: "read_file", Category: "Read", InputJSON: `{"file_path":"README.md"}`}, assistant.ToolCalls[0])
+	assert.Equal(t, ParsedToolCall{ToolUseID: "tool-top-1", ToolName: "shell_command", Category: "Bash", InputJSON: `{"command":"ls -la"}`}, assistant.ToolCalls[1])
+	assert.Equal(t, ParsedToolCall{ToolUseID: "tool-top-2", ToolName: "edit_file", Category: "Edit", InputJSON: `{"path":"main.go"}`}, assistant.ToolCalls[2])
+
+	carrier := msgs[3]
+	assert.Equal(t, RoleUser, carrier.Role)
+	assert.Empty(t, carrier.Content)
+	require.Len(t, carrier.ToolResults, 1)
+	assert.Equal(t, ParsedToolResult{ToolUseID: "tool-top-1", ContentLength: len("file1\nfile2"), ContentRaw: `"file1\nfile2"`}, carrier.ToolResults[0])
+
+	standalone := msgs[4]
+	assert.Equal(t, RoleTool, standalone.Role)
+	assert.Empty(t, standalone.Content)
+	require.Len(t, standalone.ToolResults, 1)
+	assert.Equal(t, ParsedToolResult{ToolUseID: "tool-top-2", ContentLength: len("patch applied"), ContentRaw: `[{"type":"text","text":"patch applied"}]`}, standalone.ToolResults[0])
+}
+
+func TestParseDevinSessionStepMetricsPopulateTokenUsage(t *testing.T) {
+	const sessionID = "session-step-metrics"
+	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{
+		ID:                 sessionID,
+		Title:              "Step metrics",
+		WorkingDirectory:   "/tmp/devin-pricing",
+		Model:              "adaptive",
+		CreatedAtMillis:    new(int64(1704103199000)),
+		LastActivityMillis: new(int64(1704103265000)),
+	}, `{
+		"agent":{"model_name":"Adaptive"},
+		"final_metrics":{
+			"total_completion_tokens":15,
+			"total_prompt_tokens":300,
+			"total_cached_tokens":20
+		},
+		"steps":[
+			{"step_id":"u1","source":"user","timestamp":"2024-01-01T10:00:01Z","message":"price this"},
+			{"step_id":"a1","source":"agent","timestamp":"2024-01-01T10:00:02Z","model_name":"Adaptive","extra":{"generation_model":"glm-5-2"},"metrics":{"prompt_tokens":100,"completion_tokens":10,"cached_tokens":20},"message":"first answer"},
+			{"step_id":"a2","source":"agent","timestamp":"2024-01-01T10:00:03Z","model_name":"Adaptive","extra":{"generation_model":"kimi-k2-7"},"metrics":{"prompt_tokens":80,"completion_tokens":5,"cached_tokens":0},"message":"second answer"}
+		]
+	}`)
+
+	sess, msgs, err := parseDevinSession(dbPath, sessionID, "local")
+	require.NoError(t, err)
+	require.Len(t, msgs, 3)
+
+	first := msgs[1]
+	assert.Equal(t, "glm-5-2", first.Model)
+	assert.True(t, first.HasContextTokens)
+	assert.True(t, first.HasOutputTokens)
+	assert.Equal(t, 100, first.ContextTokens)
+	assert.Equal(t, 10, first.OutputTokens)
+	require.NotEmpty(t, first.TokenUsage)
+	assert.Equal(t, int64(80), gjson.GetBytes(first.TokenUsage, "input_tokens").Int())
+	assert.Equal(t, int64(10), gjson.GetBytes(first.TokenUsage, "output_tokens").Int())
+	assert.Equal(t, int64(20), gjson.GetBytes(first.TokenUsage, "cache_read_input_tokens").Int())
+
+	second := msgs[2]
+	assert.Equal(t, "kimi-k2-7", second.Model)
+	assert.Equal(t, 80, second.ContextTokens)
+	assert.Equal(t, 5, second.OutputTokens)
+	require.NotEmpty(t, second.TokenUsage)
+	assert.Equal(t, int64(80), gjson.GetBytes(second.TokenUsage, "input_tokens").Int())
+	assert.Equal(t, int64(5), gjson.GetBytes(second.TokenUsage, "output_tokens").Int())
+	assert.Equal(t, int64(0), gjson.GetBytes(second.TokenUsage, "cache_read_input_tokens").Int())
+
+	assert.True(t, sess.HasTotalOutputTokens)
+	assert.Equal(t, 15, sess.TotalOutputTokens)
+	assert.True(t, sess.HasPeakContextTokens)
+	assert.Equal(t, 100, sess.PeakContextTokens)
+}
+
+func TestParseDevinSessionFinalMetricsTotalKeys(t *testing.T) {
+	const sessionID = "session-final-total-metrics"
+	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{
+		ID:                 sessionID,
+		Title:              "Final metrics",
+		WorkingDirectory:   "/tmp/devin-final-metrics",
+		Model:              "glm-5-2",
+		CreatedAtMillis:    new(int64(1704103199000)),
+		LastActivityMillis: new(int64(1704103265000)),
+	}, `{
+		"agent":{"model_name":"Adaptive"},
+		"final_metrics":{
+			"total_completion_tokens":15,
+			"total_prompt_tokens":300,
+			"total_cached_tokens":20
+		},
+		"steps":[
+			{"step_id":"u1","source":"user","timestamp":"2024-01-01T10:00:01Z","message":"summarize"},
+			{"step_id":"a1","source":"agent","timestamp":"2024-01-01T10:00:02Z","message":"done"}
+		]
+	}`)
+
+	sess, msgs, err := parseDevinSession(dbPath, sessionID, "local")
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+	assert.Empty(t, msgs[1].TokenUsage)
+	assert.True(t, sess.HasTotalOutputTokens)
+	assert.Equal(t, 15, sess.TotalOutputTokens)
+	assert.True(t, sess.HasPeakContextTokens)
+	assert.Equal(t, 300, sess.PeakContextTokens)
+}
+
+func TestParseDevinSessionTranscriptFallbacks(t *testing.T) {
+	const sessionID = "session-fallbacks"
+	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{
+		ID:                 sessionID,
+		Model:              "db-model",
+		CreatedAtMillis:    new(int64(0)),
+		WorkspaceJSON:      `[{"root_path":"/tmp/worktrees/fallback-app"}]`,
+		MetadataJSON:       `{"mode":"fallback"}`,
+		LastActivityMillis: nil,
+	}, `{
+		"agent":{"model_name":""},
+		"workspace_dirs":[{"root_path":"/tmp/worktrees/fallback-app"}],
+		"final_metrics":{
+			"output_tokens":0,
+			"context_tokens":0,
+			"total_cost_usd":123
+		},
+		"steps":[
+			{"step_id":"a","source":"user","createdAt":"2024-01-01T10:00:01Z","message":"hi from fallback"},
+			{"step_id":"b","source":"agent","updatedAt":"2024-01-01T10:00:05Z","message":[{"type":"text","text":"hello"}]}
+		]
+	}`)
+
+	sess, msgs, err := parseDevinSession(dbPath, sessionID, "local")
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "hi from fallback", sess.SessionName)
+	assert.Equal(t, "hi from fallback", sess.FirstMessage)
+	assert.Equal(t, "/tmp/worktrees/fallback-app", sess.Cwd)
+	assert.Equal(t, "fallback_app", sess.Project)
+	assert.Equal(t, "db-model", msgs[0].Model)
+	assert.Equal(t, "db-model", msgs[1].Model)
+	assertTimestamp(t, msgs[0].Timestamp, parseTimestamp(tsEarlyS1))
+	assertTimestamp(t, msgs[1].Timestamp, parseTimestamp(tsEarlyS5))
+	assertTimestamp(t, sess.StartedAt, parseTimestamp(tsEarlyS1))
+	assertTimestamp(t, sess.EndedAt, parseTimestamp(tsEarlyS5))
+	hasTotal, hasPeak := sess.AggregateTokenPresence()
+	assert.False(t, hasTotal)
+	assert.False(t, hasPeak)
+	assert.False(t, sess.HasTotalOutputTokens)
+	assert.False(t, sess.HasPeakContextTokens)
+}
+
+func TestParseDevinSessionEmptyTranscriptUsesDBMetadata(t *testing.T) {
+	const sessionID = "session-empty"
+	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{
+		ID:                 sessionID,
+		Title:              "DB only session",
+		WorkingDirectory:   "/tmp/db-only-project",
+		Model:              "db-only-model",
+		CreatedAtMillis:    new(int64(1704103200000)),
+		LastActivityMillis: new(int64(1704103209000)),
+	}, `{
+		"agent":{"model_name":"transcript-model"},
+		"steps":[]
+	}`)
+
+	sess, msgs, err := parseDevinSession(dbPath, sessionID, "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Empty(t, msgs)
+	assert.Equal(t, "DB only session", sess.SessionName)
+	assert.Equal(t, "/tmp/db-only-project", sess.Cwd)
+	assert.Equal(t, "db_only_project", sess.Project)
+	assert.Equal(t, 0, sess.MessageCount)
+	assert.Equal(t, 0, sess.UserMessageCount)
+	assertTimestamp(t, sess.StartedAt, time.UnixMilli(1_704_103_200_000).UTC())
+	assertTimestamp(t, sess.EndedAt, time.UnixMilli(1_704_103_209_000).UTC())
+}
+
+func TestParseDevinSessionMissingTranscriptFallsBackToMessageNodes(t *testing.T) {
+	const sessionID = "session-db-only"
+	fixture := newDevinTestFixture(t, devinSessionRow{
+		ID:                 sessionID,
+		Title:              "DB only session",
+		WorkingDirectory:   "/tmp/db-only-project",
+		Model:              "db-only-model",
+		CreatedAtMillis:    new(int64(1704103200000)),
+		LastActivityMillis: new(int64(1704103209000)),
+	})
+	fixture.insertMessageNodes(t,
+		devinSyntheticMessageNodeRow{SessionID: sessionID, NodeID: 1, ChatMessage: `{"role":"user","content":"Recover from SQLite fallback"}`, CreatedAtMillis: 1704103201000},
+		devinSyntheticMessageNodeRow{SessionID: sessionID, NodeID: 2, ChatMessage: `{"role":"assistant","content":"I'll use the database transcript fallback.","thinking":"checking message_nodes","tool_calls":[{"id":"call-1","function":{"name":"read_file","arguments":"{\"file_path\":\"main.go\"}"}}]}`, CreatedAtMillis: 1704103205000},
+		devinSyntheticMessageNodeRow{SessionID: sessionID, NodeID: 3, ChatMessage: `{"role":"tool","content":"package main\n","tool_call_id":"call-1"}`, CreatedAtMillis: 1704103207000},
+	)
+
+	sess, msgs, err := parseDevinSession(fixture.DBPath, sessionID, "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Len(t, msgs, 3)
+	assert.Equal(t, "DB only session", sess.SessionName)
+	assert.Equal(t, "Recover from SQLite fallback", sess.FirstMessage)
+	assert.Equal(t, 1, sess.UserMessageCount)
+	assert.Equal(t, 3, sess.MessageCount)
+	assert.Equal(t, "db-only-model", msgs[0].Model)
+	assert.Equal(t, RoleUser, msgs[0].Role)
+	assert.Equal(t, "Recover from SQLite fallback", msgs[0].Content)
+	assert.Equal(t, RoleAssistant, msgs[1].Role)
+	assert.True(t, msgs[1].HasThinking)
+	assert.True(t, msgs[1].HasToolUse)
+	assert.Contains(t, msgs[1].Content, "[Thinking]\nchecking message_nodes\n[/Thinking]")
+	assert.Contains(t, msgs[1].Content, "[Read: main.go]")
+	require.Len(t, msgs[1].ToolCalls, 1)
+	assert.Equal(t, ParsedToolCall{ToolUseID: "call-1", ToolName: "read_file", Category: "Read", InputJSON: `{"file_path":"main.go"}`}, msgs[1].ToolCalls[0])
+	assert.Equal(t, RoleTool, msgs[2].Role)
+	require.Len(t, msgs[2].ToolResults, 1)
+	assert.Equal(t, ParsedToolResult{ToolUseID: "call-1", ContentLength: len("package main\n"), ContentRaw: `"package main\n"`}, msgs[2].ToolResults[0])
+}
+
+func TestParseDevinSessionTranscriptStillWinsOverMessageNodes(t *testing.T) {
+	const sessionID = "session-transcript-wins"
+	fixture := newDevinTestFixture(t, devinSessionRow{
+		ID:                 sessionID,
+		Title:              "Transcript wins",
+		WorkingDirectory:   "/tmp/transcript-wins",
+		Model:              "db-model",
+		CreatedAtMillis:    new(int64(1704103200000)),
+		LastActivityMillis: new(int64(1704103209000)),
+	})
+	fixture.writeTranscript(t, sessionID, `{
+		"agent":{"model_name":"transcript-model"},
+		"steps":[
+			{"step_id":"step-1","source":"user","timestamp":"2024-01-01T10:00:01Z","message":"Use transcript"},
+			{"step_id":"step-2","source":"agent","timestamp":"2024-01-01T10:00:05Z","message":"Transcript answer"}
+		]
+	}`)
+	fixture.insertMessageNodes(t,
+		devinSyntheticMessageNodeRow{SessionID: sessionID, NodeID: 1, ChatMessage: `{"role":"user","content":"Use fallback instead"}`, CreatedAtMillis: 1704103201000},
+		devinSyntheticMessageNodeRow{SessionID: sessionID, NodeID: 2, ChatMessage: `{"role":"assistant","content":"Fallback answer"}`, CreatedAtMillis: 1704103205000},
+	)
+
+	sess, msgs, err := parseDevinSession(fixture.DBPath, sessionID, "local")
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "Use transcript", sess.FirstMessage)
+	assert.Equal(t, "transcript-model", msgs[0].Model)
+	assert.Equal(t, "Use transcript", msgs[0].Content)
+	assert.Equal(t, "Transcript answer", msgs[1].Content)
+}
+
+func TestParseDevinSessionMissingTranscriptWithoutDBMessagesReturnsRedactedError(t *testing.T) {
+	const sessionID = "session-db-only-empty"
+	fixture := newDevinTestFixture(t, devinSessionRow{
+		ID:                 sessionID,
+		Title:              "DB only session",
+		WorkingDirectory:   "/tmp/db-only-project",
+		Model:              "db-only-model",
+		CreatedAtMillis:    new(int64(1704103200000)),
+		LastActivityMillis: new(int64(1704103209000)),
+	})
+
+	sess, msgs, err := parseDevinSession(fixture.DBPath, sessionID, "local")
+	require.Nil(t, sess)
+	assert.Nil(t, msgs)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "missing devin transcript")
+	assert.ErrorContains(t, err, devinRedactedTranscriptPath())
+	assert.ErrorContains(t, err, devinRedactedSessionID())
+	assert.NotContains(t, err.Error(), sessionID)
+}
+
+func TestParseDevinSessionFallbackErrorsStayRedacted(t *testing.T) {
+	const (
+		sessionID      = "secret-session"
+		secretSentinel = "oauth-token-SYNTHETIC-SECRET-SENTINEL"
+	)
+	fixture := newDevinTestFixture(t, devinSessionRow{
+		ID:                 sessionID,
+		Title:              "DB only session",
+		WorkingDirectory:   "/tmp/db-only-project",
+		Model:              "db-only-model",
+		CreatedAtMillis:    new(int64(1704103200000)),
+		LastActivityMillis: new(int64(1704103209000)),
+	})
+	fixture.insertMessageNodes(t,
+		devinSyntheticMessageNodeRow{SessionID: sessionID, NodeID: 1, ChatMessage: `{"content":"` + secretSentinel, CreatedAtMillis: 1704103201000},
+	)
+
+	sess, msgs, err := parseDevinSession(fixture.DBPath, sessionID, "local")
+	require.Nil(t, sess)
+	assert.Nil(t, msgs)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "missing devin transcript")
+	assert.ErrorContains(t, err, devinRedactedTranscriptPath())
+	assert.ErrorContains(t, err, devinRedactedSessionID())
+	assert.NotContains(t, err.Error(), sessionID)
+	assert.NotContains(t, err.Error(), secretSentinel)
+}
+
+func TestParseDevinSessionCorruptTranscriptReturnsRedactedError(t *testing.T) {
+	const sessionID = "secret-session"
+	dbPath, transcriptPath := newDevinSessionFixture(t, devinSessionRow{
+		ID:                 sessionID,
+		Title:              "Corrupt transcript",
+		WorkingDirectory:   "/tmp/app",
+		Model:              "db-model",
+		CreatedAtMillis:    new(int64(1704103199000)),
+		LastActivityMillis: new(int64(1704103265000)),
+	}, `{"steps":[]}`)
+	require.NoError(t, os.WriteFile(transcriptPath, []byte(`{"apiKey":"secret-value","steps":[`), 0o644))
+
+	sess, msgs, err := parseDevinSession(dbPath, sessionID, "local")
+	require.Nil(t, sess)
+	assert.Nil(t, msgs)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "invalid devin transcript")
+	assert.ErrorContains(t, err, devinRedactedTranscriptPath())
+	assert.ErrorContains(t, err, devinRedactedSessionID())
+	assert.NotContains(t, err.Error(), transcriptPath)
+	assert.NotContains(t, err.Error(), sessionID)
+	assert.NotContains(t, err.Error(), "secret-value")
+}
+
+func TestParseDevinSessionRedactsCredentialPathsAndTokenLikeValues(t *testing.T) {
+	const (
+		sessionID      = "session-privacy"
+		secretSentinel = "oauth-token-SYNTHETIC-SECRET-SENTINEL"
+	)
+	fixture := newDevinTestFixture(t,
+		devinSessionRow{ID: sessionID, Title: "Privacy", WorkingDirectory: "/tmp/app", Model: "db-model", CreatedAtMillis: new(int64(1704103199000)), LastActivityMillis: new(int64(1704103265000))},
+	)
+	transcriptPath := fixture.writeTranscript(t, sessionID, `{"access_token":"oauth-token-SYNTHETIC-SECRET-SENTINEL","steps":[`)
+
+	secretRoot := filepath.Join(t.TempDir(), secretSentinel, "config", "mcp", "oauth", "devin-root")
+	require.NoError(t, os.MkdirAll(filepath.Dir(secretRoot), 0o755))
+	require.NoError(t, os.Rename(fixture.Root, secretRoot))
+	dbPath := filepath.Join(secretRoot, "cli", devinDBFilename)
+
+	sess, msgs, err := parseDevinSession(dbPath, sessionID, "local")
+	require.Nil(t, sess)
+	assert.Nil(t, msgs)
+	assert.ErrorContains(t, err, "invalid devin transcript")
+	assert.ErrorContains(t, err, devinRedactedTranscriptPath())
+	assert.ErrorContains(t, err, devinRedactedSessionID())
+	assertDevinErrorRedacted(t, err,
+		secretSentinel,
+		"mcp/oauth",
+		"config",
+		"access_token",
+		transcriptPath,
+	)
+}

--- a/internal/parser/devin_test.go
+++ b/internal/parser/devin_test.go
@@ -57,6 +57,21 @@ func TestListDevinSessionMeta(t *testing.T) {
 	}
 }
 
+func TestListDevinSessionMetaAllowsMissingTimestamps(t *testing.T) {
+	fixture := newDevinTestFixture(t,
+		devinSessionRow{ID: "session-missing-times", Title: "Partial row", WorkingDirectory: "/cwd/partial", Model: "model-partial"},
+	)
+
+	metas, err := ListDevinSessionMeta(fixture.DBPath)
+	require.NoError(t, err)
+	require.Len(t, metas, 1)
+
+	assert.Equal(t, "session-missing-times", metas[0].RawSessionID)
+	assert.True(t, metas[0].CreatedAt.IsZero())
+	assert.True(t, metas[0].UpdatedAt.IsZero())
+	assert.Zero(t, metas[0].FileMtime)
+}
+
 func TestListDevinSessionMetaMissingDB(t *testing.T) {
 	metas, err := ListDevinSessionMeta(filepath.Join(t.TempDir(), "cli", devinDBFilename))
 	require.NoError(t, err)
@@ -357,6 +372,29 @@ func TestParseDevinSessionTranscriptFallbacks(t *testing.T) {
 	assert.False(t, sess.HasPeakContextTokens)
 }
 
+func TestParseDevinSessionAllowsMissingMetadataTimestamps(t *testing.T) {
+	const sessionID = "session-missing-times"
+	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{
+		ID:               sessionID,
+		Title:            "Partial metadata",
+		WorkingDirectory: "/tmp/partial",
+		Model:            "db-model",
+	}, `{
+		"steps":[
+			{"step_id":"step-1","source":"user","message":"hello"}
+		]
+	}`)
+
+	sess, msgs, err := parseDevinSession(dbPath, sessionID, "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	require.Len(t, msgs, 1)
+
+	assert.Equal(t, "devin:"+sessionID, sess.ID)
+	assert.True(t, sess.StartedAt.IsZero())
+	assert.True(t, sess.EndedAt.IsZero())
+}
+
 func TestParseDevinSessionEmptyTranscriptUsesDBMetadata(t *testing.T) {
 	const sessionID = "session-empty"
 	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{
@@ -525,6 +563,25 @@ func TestParseDevinSessionCorruptTranscriptReturnsRedactedError(t *testing.T) {
 	assert.NotContains(t, err.Error(), transcriptPath)
 	assert.NotContains(t, err.Error(), sessionID)
 	assert.NotContains(t, err.Error(), "secret-value")
+}
+
+func TestDevinTranscriptPathErrorStaysRedacted(t *testing.T) {
+	const sessionID = "secret-session-id"
+	secretPath := filepath.Join(t.TempDir(), "cli", "transcripts", sessionID+".json")
+
+	err := newDevinTranscriptError("read", &os.PathError{
+		Op:   "open",
+		Path: secretPath,
+		Err:  os.ErrPermission,
+	})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "read devin transcript")
+	assert.ErrorContains(t, err, devinRedactedTranscriptPath())
+	assert.ErrorContains(t, err, devinRedactedSessionID())
+	assert.ErrorContains(t, err, "permission denied")
+	assert.NotContains(t, err.Error(), secretPath)
+	assert.NotContains(t, err.Error(), sessionID)
 }
 
 func TestParseDevinSessionRedactsCredentialPathsAndTokenLikeValues(t *testing.T) {

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -203,6 +203,11 @@ func TestExtractTextContent(t *testing.T) {
 			`[]`,
 			"", false, false, nil,
 		},
+		{
+			"unknown and empty blocks ignored",
+			`[{"type":"unknown","value":"x"},{"type":"text","text":""},{"type":"thinking","thinking":""}]`,
+			"", false, false, nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/parser/provider.go
+++ b/internal/parser/provider.go
@@ -432,6 +432,8 @@ func providerFactoryForDef(def AgentDef) ProviderFactory {
 		return newDeepSeekTUIProviderFactory(def)
 	case AgentForge:
 		return newForgeProviderFactory(def)
+	case AgentDevin:
+		return newDevinProviderFactory(def)
 	case AgentHermes:
 		return newHermesProviderFactory(def)
 	case AgentIflow:

--- a/internal/parser/provider_migration.go
+++ b/internal/parser/provider_migration.go
@@ -47,6 +47,7 @@ var providerMigrationModes = map[AgentType]ProviderMigrationMode{
 	AgentHermes:         ProviderMigrationProviderAuthoritative,
 	AgentWorkBuddy:      ProviderMigrationProviderAuthoritative,
 	AgentForge:          ProviderMigrationProviderAuthoritative,
+	AgentDevin:          ProviderMigrationProviderAuthoritative,
 	AgentPiebald:        ProviderMigrationProviderAuthoritative,
 	AgentWarp:           ProviderMigrationProviderAuthoritative,
 	AgentPositron:       ProviderMigrationProviderAuthoritative,

--- a/internal/parser/provider_test.go
+++ b/internal/parser/provider_test.go
@@ -168,6 +168,19 @@ func TestProviderFactoryLookupRejectsMissingAgent(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestProviderFactoryByTypeDevin(t *testing.T) {
+	factory, ok := ProviderFactoryByType(AgentDevin)
+	require.True(t, ok)
+	assert.Equal(t, AgentDevin, factory.Definition().Type)
+
+	provider := factory.NewProvider(ProviderConfig{
+		Roots:   []string{"/tmp/devin"},
+		Machine: "devbox",
+	})
+	require.NotNil(t, provider)
+	assert.Equal(t, AgentDevin, provider.Definition().Type)
+}
+
 func TestProviderMigrationModesCoverRegistry(t *testing.T) {
 	err := ValidateProviderMigrationModes(
 		ProviderFactories(),

--- a/internal/parser/taxonomy.go
+++ b/internal/parser/taxonomy.go
@@ -29,6 +29,8 @@ func NormalizeToolCategory(rawName string) string {
 	case "shell_command", "exec_command",
 		"write_stdin", "shell":
 		return "Bash"
+	case "list_files":
+		return "Read"
 	case "apply_patch":
 		return "Edit"
 	case "spawn_agent":

--- a/internal/parser/taxonomy_test.go
+++ b/internal/parser/taxonomy_test.go
@@ -26,6 +26,7 @@ func TestNormalizeToolCategory(t *testing.T) {
 		// Codex tools
 		{"shell_command", "Bash"},
 		{"exec_command", "Bash"},
+		{"list_files", "Read"},
 		{"apply_patch", "Edit"},
 		{"write_stdin", "Bash"},
 		{"shell", "Bash"},

--- a/internal/parser/test_helpers_test.go
+++ b/internal/parser/test_helpers_test.go
@@ -2,16 +2,228 @@ package parser
 
 import (
 	"bytes"
+	"database/sql"
 	"fmt"
 	"io"
 	"log"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+const devinSyntheticSessionsSchema = `
+CREATE TABLE sessions (
+	id TEXT PRIMARY KEY,
+	title TEXT,
+	working_directory TEXT,
+	model TEXT,
+	created_at INTEGER,
+	last_activity_at INTEGER,
+	workspace_json TEXT,
+	metadata_json TEXT,
+	hidden INTEGER NOT NULL DEFAULT 0
+);
+`
+
+const devinSyntheticMessageNodesSchema = `
+CREATE TABLE message_nodes (
+	row_id INTEGER PRIMARY KEY AUTOINCREMENT,
+	session_id TEXT NOT NULL,
+	node_id INTEGER NOT NULL,
+	parent_node_id INTEGER,
+	chat_message TEXT NOT NULL,
+	created_at INTEGER NOT NULL,
+	metadata TEXT
+);
+`
+
+type devinSessionRow struct {
+	ID                 string
+	Title              string
+	WorkingDirectory   string
+	Model              string
+	CreatedAtMillis    *int64
+	LastActivityMillis *int64
+	WorkspaceJSON      string
+	MetadataJSON       string
+	Hidden             bool
+}
+
+type devinTestFixture struct {
+	Root           string
+	CLIDir         string
+	TranscriptsDir string
+	DBPath         string
+}
+
+type devinSyntheticMessageNodeRow struct {
+	SessionID       string
+	NodeID          int64
+	ParentNodeID    *int64
+	ChatMessage     string
+	CreatedAtMillis int64
+	MetadataJSON    string
+}
+
+func newDevinTestFixture(t *testing.T, rows ...devinSessionRow) *devinTestFixture {
+	t.Helper()
+
+	root := t.TempDir()
+	cliDir := filepath.Join(root, "cli")
+	transcriptsDir := filepath.Join(cliDir, "transcripts")
+	require.NoError(t, os.MkdirAll(transcriptsDir, 0o755))
+
+	fixture := &devinTestFixture{
+		Root:           root,
+		CLIDir:         cliDir,
+		TranscriptsDir: transcriptsDir,
+		DBPath:         filepath.Join(cliDir, devinDBFilename),
+	}
+
+	initDevinTestDB(t, fixture.DBPath)
+	execDevinTestSQL(t, fixture.DBPath, devinSyntheticSessionsSchema)
+	execDevinTestSQL(t, fixture.DBPath, devinSyntheticMessageNodesSchema)
+	for _, row := range rows {
+		insertDevinSessionRow(t, fixture.DBPath, row)
+	}
+
+	return fixture
+}
+
+func initDevinTestDB(t *testing.T, dbPath string) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+}
+
+func insertDevinSessionRow(t *testing.T, dbPath string, row devinSessionRow) {
+	t.Helper()
+
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	_, err = db.Exec(`
+		INSERT INTO sessions (
+			id,
+			title,
+			working_directory,
+			model,
+			created_at,
+			last_activity_at,
+			workspace_json,
+			metadata_json,
+			hidden
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`,
+		row.ID,
+		row.Title,
+		row.WorkingDirectory,
+		row.Model,
+		devinNullableMillis(row.CreatedAtMillis),
+		devinNullableMillis(row.LastActivityMillis),
+		devinNullableString(row.WorkspaceJSON),
+		devinNullableString(row.MetadataJSON),
+		row.Hidden,
+	)
+	require.NoError(t, err)
+}
+
+func devinNullableMillis(ms *int64) any {
+	if ms == nil {
+		return nil
+	}
+	return *ms
+}
+
+func devinNullableString(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
+}
+
+func (f *devinTestFixture) writeTranscript(t *testing.T, sessionID, transcript string) string {
+	t.Helper()
+	transcriptPath := filepath.Join(f.TranscriptsDir, sessionID+".json")
+	require.NoError(t, os.WriteFile(transcriptPath, []byte(transcript), 0o644))
+	return transcriptPath
+}
+
+func (f *devinTestFixture) sessionVirtualPath(sessionID string) string {
+	return VirtualSourcePath(f.DBPath, sessionID)
+}
+
+func (f *devinTestFixture) insertMessageNodes(t *testing.T, rows ...devinSyntheticMessageNodeRow) {
+	t.Helper()
+	for _, row := range rows {
+		insertDevinMessageNodeRow(t, f.DBPath, row)
+	}
+}
+
+func newDevinSessionFixture(t *testing.T, row devinSessionRow, transcript string) (string, string) {
+	t.Helper()
+	fixture := newDevinTestFixture(t, row)
+	return fixture.DBPath, fixture.writeTranscript(t, row.ID, transcript)
+}
+
+func execDevinTestSQL(t *testing.T, dbPath, query string) {
+	t.Helper()
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+	_, err = db.Exec(query)
+	require.NoError(t, err)
+}
+
+func insertDevinMessageNodeRow(t *testing.T, dbPath string, row devinSyntheticMessageNodeRow) {
+	t.Helper()
+
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+
+	_, err = db.Exec(`
+		INSERT INTO message_nodes (
+			session_id,
+			node_id,
+			parent_node_id,
+			chat_message,
+			created_at,
+			metadata
+		) VALUES (?, ?, ?, ?, ?, ?)
+	`,
+		row.SessionID,
+		row.NodeID,
+		devinNullableInt64(row.ParentNodeID),
+		row.ChatMessage,
+		row.CreatedAtMillis,
+		devinNullableString(row.MetadataJSON),
+	)
+	require.NoError(t, err)
+}
+
+func devinNullableInt64(value *int64) any {
+	if value == nil {
+		return nil
+	}
+	return *value
+}
+
+func devinMetaIDs(metas []DevinSessionMeta) []string {
+	ids := make([]string, 0, len(metas))
+	for _, meta := range metas {
+		ids = append(ids, meta.RawSessionID)
+	}
+	return ids
+}
 
 // parseChatGPTExport parses a ChatGPT export through the ChatGPT import-only
 // provider. It is the test harness replacement for the former

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -42,6 +42,7 @@ const (
 	AgentHermes         AgentType = "hermes"
 	AgentWorkBuddy      AgentType = "workbuddy"
 	AgentForge          AgentType = "forge"
+	AgentDevin          AgentType = "devin"
 	AgentPiebald        AgentType = "piebald"
 	AgentWarp           AgentType = "warp"
 	AgentPositron       AgentType = "positron"
@@ -459,6 +460,18 @@ var Registry = []AgentDef{
 		DefaultDirs: []string{".forge"},
 		IDPrefix:    "forge:",
 		FileBased:   false,
+	},
+	{
+		Type:        AgentDevin,
+		DisplayName: "Devin",
+		EnvVar:      "DEVIN_DIR",
+		ConfigKey:   "devin_dirs",
+		DefaultDirs: []string{
+			"Library/Application Support/devin",
+			".local/share/devin",
+		},
+		IDPrefix:  "devin:",
+		FileBased: false,
 	},
 	{
 		Type:        AgentPiebald,

--- a/internal/parser/types_test.go
+++ b/internal/parser/types_test.go
@@ -229,6 +229,7 @@ func TestAgentByType(t *testing.T) {
 		{AgentVSCodeCopilot, true},
 		{AgentPi, true},
 		{AgentOMP, true},
+		{AgentDevin, true},
 		{AgentDeepSeekTUI, true},
 		{"unknown", false},
 	}
@@ -333,6 +334,12 @@ func TestAgentByPrefix(t *testing.T) {
 			true,
 		},
 		{
+			"devin prefix",
+			"devin:session-id",
+			AgentDevin,
+			true,
+		},
+		{
 			"zed prefix",
 			"zed:sess-id",
 			AgentZed,
@@ -426,6 +433,7 @@ func TestRegistryCompleteness(t *testing.T) {
 		AgentCortex,
 		AgentHermes,
 		AgentForge,
+		AgentDevin,
 		AgentPiebald,
 		AgentWarp,
 		AgentPositron,
@@ -651,6 +659,20 @@ func TestCommandCodeRegistryEntry(t *testing.T) {
 	require.True(t, def.FileBased, "Command Code FileBased")
 	assert.Equal(t, []string{".commandcode/projects"}, def.DefaultDirs)
 	assert.Equal(t, "commandcode:", def.IDPrefix)
+}
+
+func TestDevinRegistryEntry(t *testing.T) {
+	def, ok := AgentByType(AgentDevin)
+	require.True(t, ok, "AgentDevin missing from Registry")
+	require.False(t, def.FileBased, "Devin FileBased")
+	assert.Equal(t, "Devin", def.DisplayName)
+	assert.Equal(t, "DEVIN_DIR", def.EnvVar)
+	assert.Equal(t, "devin_dirs", def.ConfigKey)
+	assert.Equal(t, []string{
+		"Library/Application Support/devin",
+		".local/share/devin",
+	}, def.DefaultDirs)
+	assert.Equal(t, "devin:", def.IDPrefix)
 }
 
 func TestDeepSeekTUIRegistryEntry(t *testing.T) {
@@ -1044,6 +1066,12 @@ func TestAgentByPrefixRemote(t *testing.T) {
 			"remote copilot",
 			"server2~copilot:sess-id",
 			AgentCopilot,
+			true,
+		},
+		{
+			"remote devin",
+			"devbox1~devin:session-id",
+			AgentDevin,
 			true,
 		},
 		{

--- a/internal/remotesync/resolve_test.go
+++ b/internal/remotesync/resolve_test.go
@@ -20,10 +20,14 @@ func TestResolveTargetsFiltersAndIncludesSpecialFiles(t *testing.T) {
 	claudeDir := filepath.Join(root, "claude")
 	missingDir := filepath.Join(root, "missing")
 	codexDir := filepath.Join(root, ".codex", "sessions")
+	devinDir := filepath.Join(root, "devin")
+	warpDir := filepath.Join(root, "warp")
 	aiderRoot := filepath.Join(root, "code")
 	aiderHistory := filepath.Join(aiderRoot, "repo", parser.AiderHistoryFileName())
 	require.NoError(t, os.MkdirAll(claudeDir, 0o755))
 	require.NoError(t, os.MkdirAll(codexDir, 0o755))
+	require.NoError(t, os.MkdirAll(devinDir, 0o755))
+	require.NoError(t, os.MkdirAll(warpDir, 0o755))
 	require.NoError(t, os.MkdirAll(filepath.Dir(aiderHistory), 0o755))
 	require.NoError(t, os.WriteFile(aiderHistory, []byte("# aider\n"), 0o644))
 	codexIndex := filepath.Join(root, ".codex", parser.CodexSessionIndexFilename)
@@ -33,6 +37,8 @@ func TestResolveTargetsFiltersAndIncludesSpecialFiles(t *testing.T) {
 		AgentDirs: map[parser.AgentType][]string{
 			parser.AgentClaude: {claudeDir, missingDir},
 			parser.AgentCodex:  {codexDir},
+			parser.AgentDevin:  {devinDir},
+			parser.AgentWarp:   {warpDir},
 			parser.AgentAider:  {aiderRoot},
 			parser.AgentZed:    {filepath.Join(root, "zed")},
 		},
@@ -40,6 +46,8 @@ func TestResolveTargetsFiltersAndIncludesSpecialFiles(t *testing.T) {
 
 	assert.Equal(t, []string{claudeDir}, targets.Dirs[parser.AgentClaude])
 	assert.Equal(t, []string{codexDir}, targets.Dirs[parser.AgentCodex])
+	assert.NotContains(t, targets.Dirs, parser.AgentDevin)
+	assert.NotContains(t, targets.Dirs, parser.AgentWarp)
 	assert.Equal(t, []string{aiderHistory}, targets.Dirs[parser.AgentAider])
 	assert.NotContains(t, targets.Dirs, parser.AgentZed)
 	assert.Contains(t, targets.ExtraFiles, codexIndex)
@@ -110,17 +118,19 @@ func TestResolveTargetsMatchesSSHResolverForRepresentativeHome(t *testing.T) {
 	home := t.TempDir()
 	claudeDir := filepath.Join(home, ".claude", "projects")
 	codexDir := filepath.Join(home, ".codex", "sessions")
+	devinDir := filepath.Join(home, ".local", "share", "devin")
 	aiderRoot := filepath.Join(home, "code")
 	aiderHistory := filepath.Join(aiderRoot, "repo", parser.AiderHistoryFileName())
 	require.NoError(t, os.MkdirAll(claudeDir, 0o755))
 	require.NoError(t, os.MkdirAll(codexDir, 0o755))
+	require.NoError(t, os.MkdirAll(devinDir, 0o755))
 	require.NoError(t, os.MkdirAll(filepath.Dir(aiderHistory), 0o755))
 	require.NoError(t, os.WriteFile(aiderHistory, []byte("# aider\n"), 0o644))
 	codexIndex := filepath.Join(home, ".codex", parser.CodexSessionIndexFilename)
 	require.NoError(t, os.WriteFile(codexIndex, []byte("{}\n"), 0o644))
 
 	cmd := exec.Command("sh", "-c", ssh.BuildResolveScriptForTest())
-	cmd.Env = []string{"HOME=" + home, "AIDER_DIR=" + aiderRoot}
+	cmd.Env = []string{"HOME=" + home, "AIDER_DIR=" + aiderRoot, "DEVIN_DIR=" + devinDir}
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "ssh resolver output: %s", out)
 	sshDirs, sshExtra := ssh.ParseResolvedTargetsForTest(string(out))
@@ -129,11 +139,14 @@ func TestResolveTargetsMatchesSSHResolverForRepresentativeHome(t *testing.T) {
 		AgentDirs: map[parser.AgentType][]string{
 			parser.AgentClaude: {claudeDir},
 			parser.AgentCodex:  {codexDir},
+			parser.AgentDevin:  {devinDir},
 			parser.AgentAider:  {aiderRoot},
 		},
 	})
 	assert.ElementsMatch(t, sshDirs[parser.AgentClaude], goTargets.Dirs[parser.AgentClaude])
 	assert.ElementsMatch(t, sshDirs[parser.AgentCodex], goTargets.Dirs[parser.AgentCodex])
+	assert.NotContains(t, sshDirs, parser.AgentDevin)
+	assert.NotContains(t, goTargets.Dirs, parser.AgentDevin)
 	assert.ElementsMatch(t, sshDirs[parser.AgentAider], goTargets.Dirs[parser.AgentAider])
 	assert.ElementsMatch(t, sshExtra, goTargets.ExtraFiles)
 }

--- a/internal/ssh/resolve.go
+++ b/internal/ssh/resolve.go
@@ -67,10 +67,10 @@ func buildAiderResolveSnippet(envVar string) string {
 // "agentType:path\n" per agent target, plus "@file:path\n" lines for sibling
 // metadata files such as Codex's session_index.jsonl.
 //
-// Only includes file-based agents that have on-disk sources to resolve via
-// their provider facade. For each agent with an EnvVar, the script checks the
-// env var first and falls back to the default dir. Dirs (and files) that don't
-// exist on the remote are skipped.
+// Only includes file-backed agents whose local sources are resolved via their
+// provider facade. For each agent with an EnvVar, the script checks the env var
+// first and falls back to the default dir. Dirs (and files) that don't exist on
+// the remote are skipped.
 func buildResolveScript() string {
 	var b strings.Builder
 	for _, def := range parser.Registry {
@@ -166,10 +166,8 @@ func remoteDefaultRootTail(rel string) string {
 	return ""
 }
 
-// resolveAgentHasOnDiskSource reports whether a file-based agent has
-// on-disk sources the resolve script should probe via its provider facade.
-// Provider-authoritative agents have a configurable directory, so they must
-// stay in the remote resolve set.
+// resolveAgentHasOnDiskSource reports whether a file-backed agent has local
+// sources the resolve script should probe via the provider facade.
 func resolveAgentHasOnDiskSource(def parser.AgentDef) bool {
 	if !def.FileBased {
 		return false

--- a/internal/ssh/resolve_test.go
+++ b/internal/ssh/resolve_test.go
@@ -20,28 +20,35 @@ func TestBuildResolveScript(t *testing.T) {
 	assert.Contains(t, script, "CLAUDE_PROJECTS_DIR")
 	assert.Contains(t, script, "CLAUDE_CONFIG_DIR")
 
-	// Non-file-based agents must not appear.
+	// Only file-backed provider-authoritative agents belong in the resolver.
 	for _, def := range parser.Registry {
-		if def.FileBased {
+		marker := "\"" + string(def.Type) + ":"
+		want := def.FileBased &&
+			parser.ProviderMigrationModes()[def.Type] ==
+				parser.ProviderMigrationProviderAuthoritative
+		if want {
+			assert.Contains(t, script, marker,
+				"file-backed provider-authoritative agent %s missing from script", def.Type)
 			continue
 		}
-		marker := "\"" + string(def.Type) + ":"
 		assert.NotContains(t, script, marker,
-			"non-file-based agent %s in script", def.Type)
+			"unsupported agent %s must stay out of the SSH resolver", def.Type)
 	}
+}
 
-	// Every file-based, provider-authoritative agent has on-disk source
-	// roots that SSH sync must transfer, so it must appear in the script.
-	for _, def := range parser.Registry {
-		if !def.FileBased ||
-			parser.ProviderMigrationModes()[def.Type] !=
-				parser.ProviderMigrationProviderAuthoritative {
-			continue
-		}
-		marker := "\"" + string(def.Type) + ":"
-		assert.Contains(t, script, marker,
-			"provider-authoritative agent %s missing from script", def.Type)
-	}
+func TestResolveScriptExcludesDevinProviderRoot(t *testing.T) {
+	home := t.TempDir()
+	devinRoot := filepath.Join(home, ".local", "share", "devin")
+	require.NoError(t, os.MkdirAll(devinRoot, 0o755))
+
+	script := buildResolveScript()
+	cmd := exec.Command("sh", "-c", script)
+	cmd.Env = []string{"HOME=" + home, "DEVIN_DIR=" + devinRoot}
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "resolve script failed: output: %s", out)
+
+	dirs, _ := parseResolvedDirs(string(out))
+	assert.NotContains(t, dirs, parser.AgentDevin)
 }
 
 func TestResolveScriptHonorsClaudeConfigDirRoot(t *testing.T) {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -3796,6 +3796,7 @@ func (e *Engine) processProviderFile(
 			noCacheSkip: true,
 		}, true
 	}
+	applyProviderFingerprintFileInfo(file.Agent, fingerprint, outcome.Results)
 	cleanCache := providerOutcomeAllowsCleanSkipCache(outcome)
 	if outcome.SkipReason != parser.SkipNone {
 		excludedSessionIDs := append([]string(nil), outcome.ExcludedSessionIDs...)
@@ -7349,17 +7350,19 @@ func (e *Engine) findProviderSourceFile(
 	return providerDiscoveredPath(source)
 }
 
-// providerSourceMtime resolves the source-backed mtime for a DB-backed
-// provider session through the provider facade. The provider fingerprint
-// mirrors the legacy List*SessionMeta last-modified value. Piebald fork IDs
-// (piebald:<chat>-<row>) resolve to their base chat source, so a fork is
-// confirmed by parsing the chat and checking the requested session ID is
-// actually produced before returning the chat mtime.
-func (e *Engine) providerDBSourceMtime(
+// providerSessionSourceMtime resolves a session's authoritative source-backed
+// mtime through the provider facade. It is used for sessions whose stored
+// file_path is provider-owned (for example a virtual <db>#<sessionID> path), so
+// SourceMtime stays on the same composite fingerprint basis sync uses for DB
+// freshness checks. Piebald fork IDs (piebald:<chat>-<row>) resolve to their
+// base chat source, so a fork is confirmed by parsing the chat and checking the
+// requested session ID is actually produced before returning the chat mtime.
+func (e *Engine) providerSessionSourceMtime(
 	ctx context.Context,
 	def parser.AgentDef,
 	sessionID string,
 	rawSessionID string,
+	storedPath string,
 ) int64 {
 	factory, ok := e.providerFactories[def.Type]
 	if !ok || factory == nil {
@@ -7370,8 +7373,12 @@ func (e *Engine) providerDBSourceMtime(
 		Machine: e.machine,
 	})
 	source, found, err := provider.FindSource(ctx, parser.FindSourceRequest{
-		RawSessionID:  rawSessionID,
-		FullSessionID: sessionID,
+		RawSessionID:       rawSessionID,
+		FullSessionID:      sessionID,
+		StoredFilePath:     storedPath,
+		FingerprintKey:     storedPath,
+		RequireFreshSource: true,
+		PreferStoredSource: true,
 	})
 	if err != nil {
 		log.Printf("%s provider source mtime lookup: %v", def.Type, err)
@@ -7400,6 +7407,10 @@ func (e *Engine) providerDBSourceMtime(
 		}
 	}
 	return fingerprint.MTimeNS
+}
+
+func providerSourcePathNeedsFingerprint(path string) bool {
+	return path != "" && parser.ResolveSourceFilePath(path) != path
 }
 
 // providerSessionIsFork reports whether the session ID addresses a fork child
@@ -7476,8 +7487,8 @@ func (e *Engine) SourceMtime(sessionID string) int64 {
 		// (which mirrors the legacy List*SessionMeta last-modified value).
 		// Non-provider, non-file-based agents have no local source.
 		if e.isProviderAuthoritative(def.Type) {
-			return e.providerDBSourceMtime(
-				context.Background(), def, sessionID, rawSessionID,
+			return e.providerSessionSourceMtime(
+				context.Background(), def, sessionID, rawSessionID, "",
 			)
 		}
 		return 0
@@ -7486,6 +7497,14 @@ func (e *Engine) SourceMtime(sessionID string) int64 {
 	path := e.FindSourceFile(sessionID)
 	if path == "" {
 		return 0
+	}
+	if e.isProviderAuthoritative(def.Type) &&
+		providerSourcePathNeedsFingerprint(path) {
+		if mtime := e.providerSessionSourceMtime(
+			context.Background(), def, sessionID, rawSessionID, path,
+		); mtime != 0 {
+			return mtime
+		}
 	}
 	if isS3SourcePath(path) {
 		stat := statS3Object
@@ -7596,6 +7615,27 @@ func (e *Engine) SourceMtime(sessionID string) int64 {
 		return 0
 	}
 	return info.ModTime().UnixNano()
+}
+
+func applyProviderFingerprintFileInfo(
+	agent parser.AgentType,
+	fingerprint parser.SourceFingerprint,
+	results []parser.ParseResultOutcome,
+) {
+	if agent != parser.AgentDevin {
+		return
+	}
+	for i := range results {
+		if fingerprint.Size != 0 {
+			results[i].Result.Session.File.Size = fingerprint.Size
+		}
+		if fingerprint.MTimeNS != 0 {
+			results[i].Result.Session.File.Mtime = fingerprint.MTimeNS
+		}
+		if fingerprint.Hash != "" {
+			results[i].Result.Session.File.Hash = fingerprint.Hash
+		}
+	}
 }
 
 // SyncSingleSession re-syncs a single session by its ID and

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -3692,7 +3692,9 @@ func (e *Engine) processProviderFile(
 			// self-healing (e.g. a parser data-version bump or generated
 			// roborev CI worktree project): clear the entry and fall through
 			// to a full reparse, mirroring the legacy process arm.
-			if e.pathNeedsCachedSkipBypass(file.Path) {
+			if !e.providerSkipCacheEntryFreshInDB(file, source, fingerprint) {
+				e.clearSkip(cacheKey)
+			} else if e.pathNeedsCachedSkipBypass(file.Path) {
 				e.clearSkip(cacheKey)
 			} else {
 				return processResult{
@@ -4150,6 +4152,25 @@ func providerProcessCacheKeyWithHash(
 
 func providerFingerprintHashRequiredForFreshness(agent parser.AgentType) bool {
 	return agent == parser.AgentDevin
+}
+
+func (e *Engine) providerSkipCacheEntryFreshInDB(
+	file parser.DiscoveredFile,
+	source parser.SourceRef,
+	fingerprint parser.SourceFingerprint,
+) bool {
+	agent := file.Agent
+	if agent == "" {
+		agent = source.Provider
+	}
+	if fingerprint.Hash == "" || !providerFingerprintHashRequiredForFreshness(agent) {
+		return true
+	}
+	lookupPath := providerSkipLookupPath(file, source, fingerprint)
+	if e.pathRewriter != nil {
+		lookupPath = e.pathRewriter(lookupPath)
+	}
+	return e.providerFingerprintHashMatchesDB(agent, lookupPath, fingerprint)
 }
 
 func processFileUsesProvider(agent parser.AgentType) bool {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -4122,10 +4122,34 @@ func providerProcessCacheKey(
 	source parser.SourceRef,
 	fingerprint parser.SourceFingerprint,
 ) string {
+	agent := file.Agent
+	if agent == "" {
+		agent = source.Provider
+	}
+	key := ""
 	if key := plannedSkipKey(source, fingerprint); key != "" {
+		return providerProcessCacheKeyWithHash(key, agent, fingerprint)
+	}
+	key = file.Path
+	return providerProcessCacheKeyWithHash(key, agent, fingerprint)
+}
+
+func providerProcessCacheKeyWithHash(
+	key string,
+	agent parser.AgentType,
+	fingerprint parser.SourceFingerprint,
+) string {
+	if key == "" {
+		return ""
+	}
+	if fingerprint.Hash == "" || !providerFingerprintHashRequiredForFreshness(agent) {
 		return key
 	}
-	return file.Path
+	return key + "?source_hash=" + fingerprint.Hash
+}
+
+func providerFingerprintHashRequiredForFreshness(agent parser.AgentType) bool {
+	return agent == parser.AgentDevin
 }
 
 func processFileUsesProvider(agent parser.AgentType) bool {
@@ -4164,6 +4188,9 @@ func (e *Engine) shouldSkipProviderSource(
 		return false
 	}
 	if storedMtime != fingerprint.MTimeNS {
+		return false
+	}
+	if !e.providerFingerprintHashMatchesDB(agent, lookupPath, fingerprint) {
 		return false
 	}
 	return e.db.GetDataVersionByPath(lookupPath) >= db.CurrentDataVersion()
@@ -4380,6 +4407,9 @@ func (e *Engine) providerSourceUnchangedInDB(
 	if storedSize != fingerprint.Size || storedMtime != fingerprint.MTimeNS {
 		return false
 	}
+	if !e.providerFingerprintHashMatchesDB(source.Provider, lookupPath, fingerprint) {
+		return false
+	}
 	// A stale stored project (e.g. a generated roborev CI worktree name)
 	// must defeat the unchanged-source skip so the corrected project is
 	// reparsed, mirroring shouldSkipCodexFingerprint and the in-memory
@@ -4389,6 +4419,18 @@ func (e *Engine) providerSourceUnchangedInDB(
 		return false
 	}
 	return e.db.GetDataVersionByPath(lookupPath) >= db.CurrentDataVersion()
+}
+
+func (e *Engine) providerFingerprintHashMatchesDB(
+	agent parser.AgentType,
+	lookupPath string,
+	fingerprint parser.SourceFingerprint,
+) bool {
+	if fingerprint.Hash == "" || !providerFingerprintHashRequiredForFreshness(agent) {
+		return true
+	}
+	storedHash, ok := e.db.GetFileHashByPath(lookupPath)
+	return ok && storedHash == fingerprint.Hash
 }
 
 // shouldSkipByPath checks file size and mtime against what is

--- a/internal/sync/parsediff.go
+++ b/internal/sync/parsediff.go
@@ -400,13 +400,14 @@ func parseDiffSourceKey(path string) string {
 
 // perSessionDBVirtualSourceBases lists the shared-SQLite database filenames
 // whose providers discover one virtual source per session (opencode.db#id,
-// warp.sqlite#id, ...). parse-diff keys these by their full virtual path, so a
+// sessions.db#id, warp.sqlite#id, ...). parse-diff keys these by their full
+// virtual path, so a
 // --limit sample or a per-session parse failure stays scoped to the single
 // session it names instead of fanning out across every sibling row in the same
 // physical database. Contrast Kiro/Zed/Shelley, whose providers discover the
 // database as one source; those key by the stripped database path.
 var perSessionDBVirtualSourceBases = []string{
-	"opencode.db", "kilo.db", "mimocode.db",
+	"opencode.db", "kilo.db", "mimocode.db", "sessions.db",
 	parser.WarpDBFilename, parser.ForgeDBFilename, parser.PiebaldDBFilename,
 }
 

--- a/internal/sync/parsediff.go
+++ b/internal/sync/parsediff.go
@@ -18,8 +18,8 @@ type ParseDiffOptions struct {
 	// agent whose registered factory can Discover() and re-parse a source.
 	// That includes shared-SQLite DB-backed providers that fan a database
 	// out to one virtual source per session (Kiro, OpenCode, Forge,
-	// Piebald, Warp). Only import-only agents, which have no source to
-	// re-parse, are rejected with an error.
+	// Devin, Piebald, Warp). Only import-only agents, which have no
+	// source to re-parse, are rejected with an error.
 	Agents []parser.AgentType
 	// Limit caps the number of source files parsed, newest mtime first
 	// across all agents. 0 means no limit.
@@ -205,8 +205,8 @@ func (e *Engine) ParseDiff(ctx context.Context, opts ParseDiffOptions) (*ParseDi
 	return report, nil
 }
 
-// parseDiffProviderSources discovers an agent's on-disk sources through
-// the provider facade. It is scoped to a single agent type so parse-diff
+// parseDiffProviderSources discovers an agent's sources through the provider
+// facade. It is scoped to a single agent type so parse-diff
 // respects the requested agent set.
 func (e *Engine) parseDiffProviderSources(
 	ctx context.Context,
@@ -272,12 +272,13 @@ func (e *Engine) parseDiffAgentDiscoverable(def parser.AgentDef) bool {
 	// A provider-authoritative agent with a registered factory exposes a
 	// working Discover()/Parse() the report-only run can re-parse, whether it
 	// reads literal per-session files (Claude, Codex) or a shared SQLite store
-	// its provider fans out to one virtual source per session (Kiro, OpenCode,
-	// and the DB-backed Forge/Piebald/Warp providers). FileBased is not
-	// consulted here: it distinguishes literal-file agents from DB-backed ones
-	// for the watcher and sync paths, but both kinds satisfy the same provider
-	// Discover() contract parse-diff needs. Import-only agents are not
-	// provider-authoritative, so the switch still rejects them.
+	// its provider fans out to one virtual source per session (Kiro,
+	// OpenCode, and the DB-backed Forge/Devin/Piebald/Warp providers).
+	// FileBased is not consulted here: it distinguishes literal-file agents
+	// from DB-backed ones for the watcher and sync paths, but both kinds
+	// satisfy the same provider Discover() contract parse-diff needs.
+	// Import-only agents are not provider-authoritative, so the switch still
+	// rejects them.
 	switch e.providerMigrationModes[def.Type] {
 	case parser.ProviderMigrationProviderAuthoritative:
 		factory, ok := e.providerFactories[def.Type]
@@ -289,7 +290,7 @@ func (e *Engine) parseDiffAgentDiscoverable(def parser.AgentDef) bool {
 
 // resolveParseDiffAgents validates the requested agent set against
 // the registry and returns the matching defs in registry order. Only
-// file-based agents with an on-disk source can be re-parsed.
+// agents with parse-diff support can be re-parsed.
 func (e *Engine) resolveParseDiffAgents(
 	requested []parser.AgentType,
 ) ([]parser.AgentDef, error) {
@@ -316,7 +317,7 @@ func (e *Engine) resolveParseDiffAgents(
 		}
 		if _, known := parser.AgentByType(t); known {
 			return nil, fmt.Errorf(
-				"agent %q has no on-disk source to re-parse; "+
+				"agent %q is not supported by parse-diff; "+
 					"supported agents: %s", t, supported,
 			)
 		}
@@ -425,6 +426,9 @@ func isPerSessionDBVirtualSource(path string) bool {
 // Copilot appends to its shared trace file, and the "#runIdx" suffix aider
 // appends to its shared history file.
 func stripVirtualSourceSuffix(path string) string {
+	if dbPath, _, ok := parser.ParseVirtualSourcePath(path); ok {
+		return dbPath
+	}
 	if tracePath, _, ok := parser.SplitVisualStudioCopilotVirtualPath(path); ok {
 		return tracePath
 	}
@@ -468,10 +472,12 @@ func stripVirtualSourceSuffix(path string) string {
 // it fails CLOSED rather than risk masking genuine parser drift:
 //
 //   - Virtual-path sources (Aider "#runIdx", Kiro/Zed/OpenCode/Kilo/MiMoCode
-//     "#rawID", Shelley, Forge/Piebald/Warp "#sessionID", Visual Studio Copilot
-//     "#conversationID"). Many sessions fan out of ONE physical source, so the
-//     source mtime is NOT a per-session signal. A shared DB's rows can carry
-//     advanced updated_at values, and Aider's File.Mtime is the whole
+//     "#rawID", Shelley, Forge/Devin/Piebald/Warp "#sessionID", Visual
+//     Studio Copilot "#conversationID"). Many sessions fan out of ONE
+//     physical source, so the source mtime is NOT a per-session signal. A
+//     shared DB's rows can carry advanced updated_at values, Devin's
+//     authoritative mtime is a provider-composite across DB metadata and
+//     transcript state, and Aider's File.Mtime is the whole
 //     .aider.chat.history.md file's mtime shared by every run in it --
 //     appending a new run bumps it for all runs -- so a newer mtime does not
 //     mean THIS session's parsed content was torn. Including them would mask
@@ -978,15 +984,16 @@ func (e *Engine) parseDiffSweepStored(
 			reason = "remote session"
 		case s.DeletedAt != nil:
 			reason = "trashed"
-		case defOK && !def.FileBased &&
+		case defOK && !eParseDiffAgentHasProviderSource(def) &&
 			def.EnvVar == "" && def.ConfigKey == "":
 			reason = "import-only agent"
 		case defOK && !def.FileBased && !e.parseDiffAgentDiscoverable(def):
 			// A DB-backed agent parse-diff cannot re-parse (no provider
 			// factory). Provider-authoritative DB-backed agents
-			// (Forge/Piebald/Warp) are discoverable, so they fall through
-			// to the source-based reasons below (not sampled / source
-			// missing / not discovered) just like literal-file agents.
+			// (Forge/Devin/Piebald/Warp) are discoverable, so they fall
+			// through to the source-based reasons below (not sampled /
+			// source missing / not discovered) just like literal-file
+			// agents.
 			reason = "database-backed agent"
 		case s.FilePath == nil || *s.FilePath == "":
 			reason = "source missing"
@@ -1012,6 +1019,16 @@ func (e *Engine) parseDiffSweepStored(
 			StoredDataVersion: s.DataVersion,
 		})
 		report.Totals.Skipped++
+	}
+}
+
+func eParseDiffAgentHasProviderSource(def parser.AgentDef) bool {
+	switch parser.ProviderMigrationModes()[def.Type] {
+	case parser.ProviderMigrationProviderAuthoritative:
+		_, ok := parser.ProviderFactoryByType(def.Type)
+		return ok
+	default:
+		return false
 	}
 }
 

--- a/internal/sync/parsediff_compare_test.go
+++ b/internal/sync/parsediff_compare_test.go
@@ -2173,6 +2173,29 @@ func TestParseDiffProviderVirtualSQLiteLimitUsesExactSource(t *testing.T) {
 	}
 }
 
+func TestParseDiffDevinVirtualSQLiteLimitUsesExactSource(t *testing.T) {
+	dbPath := filepath.Join("/tmp", "devin", "cli", "sessions.db")
+	firstPath := parser.VirtualSourcePath(dbPath, "ses_one")
+	secondPath := parser.VirtualSourcePath(dbPath, "ses_two")
+	_, cutPaths, limited := sortAndLimitParseDiffFiles(
+		[]parser.DiscoveredFile{
+			{Path: firstPath, Agent: parser.AgentDevin},
+			{Path: secondPath, Agent: parser.AgentDevin},
+		},
+		1,
+	)
+
+	require.True(t, limited)
+	assert.Len(t, cutPaths, 1)
+	assert.False(t, cutPaths[dbPath])
+	for path := range cutPaths {
+		assert.True(t,
+			path == firstPath || path == secondPath,
+			"cut path %q must be one exact Devin virtual source", path,
+		)
+	}
+}
+
 // TestParseDiffDBBackedLimitOrdersByDiscoveryMtime pins the ordering fix at the
 // sorter boundary: two DB-backed virtual sources whose paths sort in the
 // opposite order to their per-session mtimes. Before the fix both stat to 0 and

--- a/internal/sync/parsediff_integration_test.go
+++ b/internal/sync/parsediff_integration_test.go
@@ -810,14 +810,15 @@ func TestParseDiffAgentScope(t *testing.T) {
 	assert.Equal(t, []string{"codex"}, report.Agents,
 		"report.Agents must reflect the scoped run")
 
-	// Database-backed agents have no on-disk source to re-parse.
+	// Import-only agents are outside parse-diff support.
 	_, err = engine.ParseDiff(
 		context.Background(), sync.ParseDiffOptions{
 			Agents: []parser.AgentType{parser.AgentClaudeAI},
 		},
 	)
 	require.Error(t, err,
-		"ParseDiff must reject database-backed agents")
+		"ParseDiff must reject import-only agents")
+	assert.ErrorContains(t, err, "is not supported by parse-diff")
 }
 
 func TestParseDiffCoversProviderAuthoritativePiFamily(t *testing.T) {

--- a/internal/sync/parsediff_provider_test.go
+++ b/internal/sync/parsediff_provider_test.go
@@ -54,7 +54,7 @@ func TestParseDiffDiscoversProviderSources(t *testing.T) {
 	}
 }
 
-func TestParseDiffProviderAuthoritativeAgentsAreDiscoverable(t *testing.T) {
+func TestParseDiffSupportedAgentsAreDiscoverable(t *testing.T) {
 	engine := NewDiffEngine(dbtest.OpenTestDB(t), EngineConfig{})
 	for _, agent := range []parser.AgentType{
 		parser.AgentGptme,
@@ -66,6 +66,7 @@ func TestParseDiffProviderAuthoritativeAgentsAreDiscoverable(t *testing.T) {
 		parser.AgentQwenPaw,
 		parser.AgentOpenHands,
 		parser.AgentCursor,
+		parser.AgentDevin,
 		parser.AgentVibe,
 		parser.AgentClaude,
 		parser.AgentCowork,
@@ -79,7 +80,7 @@ func TestParseDiffProviderAuthoritativeAgentsAreDiscoverable(t *testing.T) {
 		def, ok := parser.AgentByType(agent)
 		require.True(t, ok, "agent %s", agent)
 		assert.True(t, engine.parseDiffAgentDiscoverable(def),
-			"parse-diff engine must include provider-authoritative %s", agent)
+			"parse-diff engine must include %s", agent)
 	}
 }
 
@@ -91,6 +92,7 @@ func TestParseDiffDBBackedAgentsAreDiscoverable(t *testing.T) {
 	engine := NewDiffEngine(dbtest.OpenTestDB(t), EngineConfig{})
 	for _, agent := range []parser.AgentType{
 		parser.AgentForge,
+		parser.AgentDevin,
 		parser.AgentPiebald,
 		parser.AgentWarp,
 	} {
@@ -287,6 +289,17 @@ func TestParseDiffProviderSourcesThreadsS3Metadata(t *testing.T) {
 	assert.Equal(t, int64(1779012030000)*1_000_000, f.SourceMtime)
 	assert.Equal(t, "s3-fingerprint", f.SourceFingerprint)
 	assert.Equal(t, "myproj", f.Project)
+}
+
+func TestParseDiffSourceReliableForRacedDevinVirtualPath(t *testing.T) {
+	engine := NewDiffEngine(dbtest.OpenTestDB(t), EngineConfig{})
+	assert.False(
+		t,
+		engine.parseDiffSourceReliableForRaced(
+			parser.AgentDevin,
+			filepath.Join("/tmp", "devin", "cli", "sessions.db")+"#session-001",
+		),
+	)
 }
 
 type s3ParseDiffProviderFactory struct {

--- a/internal/sync/provider_process_test.go
+++ b/internal/sync/provider_process_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/dbtest"
 	"go.kenn.io/agentsview/internal/parser"
 )
@@ -554,6 +555,165 @@ func TestSyncSingleSessionProviderAuthoritativeBypassesProviderSkipCache(t *test
 	assert.False(t, cached)
 }
 
+func TestProcessFileProviderDevinSkipsStoredFreshSource(t *testing.T) {
+	root := t.TempDir()
+	dbPath, transcriptPath := writeProcessProviderDevinFixture(
+		t,
+		root,
+		"session-001",
+		"Initial reply",
+		1700000000000,
+		1700000005000,
+	)
+	virtualPath := parser.VirtualSourcePath(dbPath, "session-001")
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentDevin: {root},
+		},
+		Machine: "devbox",
+	})
+
+	first := engine.processFile(context.Background(), parser.DiscoveredFile{
+		Path:  virtualPath,
+		Agent: parser.AgentDevin,
+	})
+	require.NoError(t, first.err)
+	require.Len(t, first.results, 1)
+	require.Equal(t, virtualPath, engine.FindSourceFile("devin:session-001"))
+	storedMtime := first.results[0].Session.File.Mtime
+	require.NotZero(t, storedMtime)
+	assert.GreaterOrEqual(t, storedMtime, transcriptProcessProviderMtime(t, transcriptPath))
+
+	written, _, failed := engine.writeBatch(
+		[]pendingWrite{{
+			sess:         first.results[0].Session,
+			msgs:         first.results[0].Messages,
+			usageEvents:  first.results[0].UsageEvents,
+			forceReplace: first.forceReplace,
+		}},
+		syncWriteDefault,
+		false,
+	)
+	require.Equal(t, 0, failed)
+	require.Equal(t, 1, written)
+
+	_, dbStoredMtime, ok := database.GetSessionFileInfo("devin:session-001")
+	require.True(t, ok)
+	assert.Equal(t, storedMtime, dbStoredMtime)
+	assert.Equal(t, storedMtime, engine.SourceMtime("devin:session-001"))
+
+	second := engine.processFile(context.Background(), parser.DiscoveredFile{
+		Path:  virtualPath,
+		Agent: parser.AgentDevin,
+	})
+
+	require.NoError(t, second.err)
+	assert.True(t, second.skip)
+	assert.True(t, second.cacheSkip)
+	assert.Equal(t, storedMtime, second.mtime)
+	assert.Empty(t, second.results)
+}
+
+func TestProcessFileProviderDevinReparsesTranscriptOnlyChange(t *testing.T) {
+	root := t.TempDir()
+	dbPath, transcriptPath := writeProcessProviderDevinFixture(
+		t,
+		root,
+		"session-002",
+		"Initial reply",
+		1700000000000,
+		1700000005000,
+	)
+	virtualPath := parser.VirtualSourcePath(dbPath, "session-002")
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentDevin: {root},
+		},
+		Machine: "devbox",
+	})
+
+	first := engine.processFile(context.Background(), parser.DiscoveredFile{
+		Path:  virtualPath,
+		Agent: parser.AgentDevin,
+	})
+	require.NoError(t, first.err)
+	require.Len(t, first.results, 1)
+	written, _, failed := engine.writeBatch(
+		[]pendingWrite{{
+			sess:         first.results[0].Session,
+			msgs:         first.results[0].Messages,
+			usageEvents:  first.results[0].UsageEvents,
+			forceReplace: first.forceReplace,
+		}},
+		syncWriteDefault,
+		false,
+	)
+	require.Equal(t, 0, failed)
+	require.Equal(t, 1, written)
+	before := engine.SourceMtime("devin:session-002")
+
+	future := time.Now().Add(2 * time.Second)
+	writeProcessProviderDevinTranscript(t, transcriptPath, "Updated reply")
+	require.NoError(t, os.Chtimes(transcriptPath, future, future))
+
+	after := engine.SourceMtime("devin:session-002")
+	assert.Greater(t, after, before)
+
+	second := engine.processFile(context.Background(), parser.DiscoveredFile{
+		Path:  virtualPath,
+		Agent: parser.AgentDevin,
+	})
+	require.NoError(t, second.err)
+	assert.False(t, second.skip)
+	require.Len(t, second.results, 1)
+	assert.Greater(t, second.results[0].Session.File.Mtime, first.results[0].Session.File.Mtime)
+	assert.Equal(t, "Updated reply", second.results[0].Messages[1].Content)
+}
+
+func TestSyncAllProviderDevinMissingDBPreservesArchive(t *testing.T) {
+	root := t.TempDir()
+	dbPath, _ := writeProcessProviderDevinFixture(
+		t,
+		root,
+		"session-003",
+		"Archived reply",
+		1700000000000,
+		1700000005000,
+	)
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentDevin: {root},
+		},
+		Machine: "devbox",
+	})
+
+	stats := engine.SyncAll(context.Background(), nil)
+	require.Equal(t, 1, stats.Synced)
+	assertProviderProcessMessageContent(
+		t,
+		database,
+		"devin:session-003",
+		"Ship it",
+		"Archived reply",
+	)
+
+	require.NoError(t, os.Remove(dbPath))
+	stats = engine.SyncAll(context.Background(), nil)
+	assert.Equal(t, 0, stats.Synced)
+	assertProviderProcessMessageContent(
+		t,
+		database,
+		"devin:session-003",
+		"Ship it",
+		"Archived reply",
+	)
+	assert.Empty(t, engine.FindSourceFile("devin:session-003"))
+	assert.Zero(t, engine.SourceMtime("devin:session-003"))
+}
+
 func writeProcessProviderForgeDB(t *testing.T, root string) string {
 	t.Helper()
 	dbPath := filepath.Join(root, ".forge.db")
@@ -589,6 +749,100 @@ func writeProcessProviderForgeDB(t *testing.T, root string) string {
 	)
 	require.NoError(t, err)
 	return dbPath
+}
+
+func writeProcessProviderDevinFixture(
+	t *testing.T,
+	root string,
+	sessionID string,
+	assistantReply string,
+	createdAtMS int64,
+	lastActivityAtMS int64,
+) (string, string) {
+	t.Helper()
+	cliDir := filepath.Join(root, "cli")
+	transcriptsDir := filepath.Join(cliDir, "transcripts")
+	require.NoError(t, os.MkdirAll(transcriptsDir, 0o755))
+	dbPath := filepath.Join(cliDir, "sessions.db")
+	database, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = database.Close() })
+	_, err = database.Exec(`
+		CREATE TABLE sessions (
+			id TEXT PRIMARY KEY,
+			title TEXT,
+			working_directory TEXT,
+			model TEXT,
+			created_at INTEGER,
+			last_activity_at INTEGER,
+			hidden INTEGER NOT NULL DEFAULT 0
+		);
+	`)
+	require.NoError(t, err)
+	_, err = database.Exec(
+		`INSERT INTO sessions
+			(id, title, working_directory, model, created_at, last_activity_at, hidden)
+		 VALUES (?, ?, ?, ?, ?, ?, 0)`,
+		sessionID,
+		"Devin fixture",
+		"/Users/devbox/src/agentsview",
+		"devin-1",
+		createdAtMS,
+		lastActivityAtMS,
+	)
+	require.NoError(t, err)
+	transcriptPath := filepath.Join(transcriptsDir, sessionID+".json")
+	writeProcessProviderDevinTranscript(t, transcriptPath, assistantReply)
+	return dbPath, transcriptPath
+}
+
+func writeProcessProviderDevinTranscript(
+	t *testing.T,
+	transcriptPath string,
+	assistantReply string,
+) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(transcriptPath, []byte(`{
+		"created_at":"2024-01-01T00:00:00Z",
+		"updated_at":"2024-01-01T00:00:05Z",
+		"agent":{"model_name":"devin-1"},
+		"steps":[
+			{
+				"step_id":"step-user",
+				"source":"user",
+				"timestamp":"2024-01-01T00:00:01Z",
+				"message":"Ship it"
+			},
+			{
+				"step_id":"step-agent",
+				"source":"agent",
+				"timestamp":"2024-01-01T00:00:05Z",
+				"message":"`+assistantReply+`"
+			}
+		]
+	}`), 0o644))
+}
+
+func transcriptProcessProviderMtime(t *testing.T, transcriptPath string) int64 {
+	t.Helper()
+	info, err := os.Stat(transcriptPath)
+	require.NoError(t, err)
+	return info.ModTime().UnixNano()
+}
+
+func assertProviderProcessMessageContent(
+	t *testing.T,
+	database *db.DB,
+	sessionID string,
+	want ...string,
+) {
+	t.Helper()
+	msgs, err := database.GetAllMessages(context.Background(), sessionID)
+	require.NoError(t, err)
+	require.Len(t, msgs, len(want))
+	for i, content := range want {
+		assert.Equal(t, content, msgs[i].Content)
+	}
 }
 
 func newProcessFixtureEngine(

--- a/internal/sync/provider_process_test.go
+++ b/internal/sync/provider_process_test.go
@@ -764,6 +764,71 @@ func TestProcessFileProviderDevinSameSizeSameMtimeTranscriptRewriteReparses(t *t
 	}
 }
 
+func TestProcessFileProviderDevinRepeatedHashRewriteIgnoresStaleHashedCache(t *testing.T) {
+	root := t.TempDir()
+	dbPath, transcriptPath := writeProcessProviderDevinFixture(
+		t,
+		root,
+		"session-repeated-hash",
+		"Initial reply",
+		1700000000000,
+		1700000005000,
+	)
+	virtualPath := parser.VirtualSourcePath(dbPath, "session-repeated-hash")
+	file := parser.DiscoveredFile{
+		Path:  virtualPath,
+		Agent: parser.AgentDevin,
+	}
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentDevin: {root},
+		},
+		Machine: "devbox",
+	})
+
+	first := engine.processFile(context.Background(), file)
+	require.NoError(t, first.err)
+	require.Len(t, first.results, 1)
+	require.Len(t, first.results[0].Messages, 2)
+	assert.Equal(t, "Initial reply", first.results[0].Messages[1].Content)
+	initialMtime := first.results[0].Session.File.Mtime
+	initialHash := first.results[0].Session.File.Hash
+	require.NotZero(t, initialMtime)
+	require.NotEmpty(t, initialHash)
+	require.Contains(t, first.cacheKey, "?source_hash="+initialHash)
+	writeProcessProviderDevinResult(t, engine, first)
+
+	engine.cacheSkip(first.cacheKey, initialMtime)
+
+	writeProcessProviderDevinTranscript(t, transcriptPath, "Changed reply")
+	initialTime := time.Unix(0, initialMtime)
+	require.NoError(t, os.Chtimes(transcriptPath, initialTime, initialTime))
+	second := engine.processFile(context.Background(), file)
+	require.NoError(t, second.err)
+	assert.False(t, second.skip)
+	require.Len(t, second.results, 1)
+	require.Len(t, second.results[0].Messages, 2)
+	assert.Equal(t, "Changed reply", second.results[0].Messages[1].Content)
+	changedHash := second.results[0].Session.File.Hash
+	require.NotEmpty(t, changedHash)
+	require.NotEqual(t, initialHash, changedHash)
+	require.Contains(t, second.cacheKey, "?source_hash="+changedHash)
+	writeProcessProviderDevinResult(t, engine, second)
+	engine.clearSkip(second.cacheKey)
+
+	writeProcessProviderDevinTranscript(t, transcriptPath, "Initial reply")
+	require.NoError(t, os.Chtimes(transcriptPath, initialTime, initialTime))
+
+	third := engine.processFile(context.Background(), file)
+	require.NoError(t, third.err)
+	assert.False(t, third.skip)
+	require.Len(t, third.results, 1)
+	require.Len(t, third.results[0].Messages, 2)
+	assert.Equal(t, "Initial reply", third.results[0].Messages[1].Content)
+	assert.Equal(t, initialHash, third.results[0].Session.File.Hash)
+}
+
 func TestSyncAllProviderDevinMissingDBPreservesArchive(t *testing.T) {
 	root := t.TempDir()
 	dbPath, _ := writeProcessProviderDevinFixture(
@@ -841,6 +906,27 @@ func writeProcessProviderForgeDB(t *testing.T, root string) string {
 	)
 	require.NoError(t, err)
 	return dbPath
+}
+
+func writeProcessProviderDevinResult(
+	t *testing.T,
+	engine *Engine,
+	result processResult,
+) {
+	t.Helper()
+	require.Len(t, result.results, 1)
+	written, _, failed := engine.writeBatch(
+		[]pendingWrite{{
+			sess:         result.results[0].Session,
+			msgs:         result.results[0].Messages,
+			usageEvents:  result.results[0].UsageEvents,
+			forceReplace: result.forceReplace,
+		}},
+		syncWriteDefault,
+		false,
+	)
+	require.Equal(t, 0, failed)
+	require.Equal(t, 1, written)
 }
 
 func writeProcessProviderDevinFixture(

--- a/internal/sync/provider_process_test.go
+++ b/internal/sync/provider_process_test.go
@@ -672,6 +672,98 @@ func TestProcessFileProviderDevinReparsesTranscriptOnlyChange(t *testing.T) {
 	assert.Equal(t, "Updated reply", second.results[0].Messages[1].Content)
 }
 
+func TestProcessFileProviderDevinSameSizeSameMtimeTranscriptRewriteReparses(t *testing.T) {
+	tests := []struct {
+		name      string
+		seedCache bool
+		freshSync bool
+	}{
+		{name: "skip cache", seedCache: true},
+		{name: "db freshness", freshSync: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			dbPath, transcriptPath := writeProcessProviderDevinFixture(
+				t,
+				root,
+				"session-same-mtime",
+				"Initial reply",
+				1700000000000,
+				1700000005000,
+			)
+			virtualPath := parser.VirtualSourcePath(dbPath, "session-same-mtime")
+			database := dbtest.OpenTestDB(t)
+			engine := NewEngine(database, EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{
+					parser.AgentDevin: {root},
+				},
+				Machine: "devbox",
+			})
+
+			first := engine.processFile(context.Background(), parser.DiscoveredFile{
+				Path:  virtualPath,
+				Agent: parser.AgentDevin,
+			})
+			require.NoError(t, first.err)
+			require.Len(t, first.results, 1)
+			require.Len(t, first.results[0].Messages, 2)
+			assert.Equal(t, "Initial reply", first.results[0].Messages[1].Content)
+			initialMtime := first.results[0].Session.File.Mtime
+			initialHash := first.results[0].Session.File.Hash
+			require.NotZero(t, initialMtime)
+			require.NotEmpty(t, initialHash)
+
+			written, _, failed := engine.writeBatch(
+				[]pendingWrite{{
+					sess:         first.results[0].Session,
+					msgs:         first.results[0].Messages,
+					usageEvents:  first.results[0].UsageEvents,
+					forceReplace: first.forceReplace,
+				}},
+				syncWriteDefault,
+				false,
+			)
+			require.Equal(t, 0, failed)
+			require.Equal(t, 1, written)
+
+			infoBefore, err := os.Stat(transcriptPath)
+			require.NoError(t, err)
+			writeProcessProviderDevinTranscript(t, transcriptPath, "Changed reply")
+			initialTime := time.Unix(0, initialMtime)
+			require.NoError(t, os.Chtimes(transcriptPath, initialTime, initialTime))
+			infoAfter, err := os.Stat(transcriptPath)
+			require.NoError(t, err)
+			require.Equal(t, infoBefore.Size(), infoAfter.Size(),
+				"test must keep size stable so hash is the only freshness signal")
+
+			if tt.seedCache {
+				engine.cacheSkip(virtualPath, initialMtime)
+			}
+			if tt.freshSync {
+				engine = NewEngine(database, EngineConfig{
+					AgentDirs: map[parser.AgentType][]string{
+						parser.AgentDevin: {root},
+					},
+					Machine: "devbox",
+				})
+			}
+
+			second := engine.processFile(context.Background(), parser.DiscoveredFile{
+				Path:  virtualPath,
+				Agent: parser.AgentDevin,
+			})
+			require.NoError(t, second.err)
+			assert.False(t, second.skip)
+			require.Len(t, second.results, 1)
+			require.Len(t, second.results[0].Messages, 2)
+			assert.Equal(t, "Changed reply", second.results[0].Messages[1].Content)
+			assert.NotEqual(t, initialHash, second.results[0].Session.File.Hash)
+		})
+	}
+}
+
 func TestSyncAllProviderDevinMissingDBPreservesArchive(t *testing.T) {
 	root := t.TempDir()
 	dbPath, _ := writeProcessProviderDevinFixture(

--- a/internal/sync/provider_process_test.go
+++ b/internal/sync/provider_process_test.go
@@ -944,7 +944,6 @@ func writeProcessProviderDevinFixture(
 	dbPath := filepath.Join(cliDir, "sessions.db")
 	database, err := sql.Open("sqlite3", dbPath)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = database.Close() })
 	_, err = database.Exec(`
 		CREATE TABLE sessions (
 			id TEXT PRIMARY KEY,
@@ -969,6 +968,7 @@ func writeProcessProviderDevinFixture(
 		lastActivityAtMS,
 	)
 	require.NoError(t, err)
+	require.NoError(t, database.Close())
 	transcriptPath := filepath.Join(transcriptsDir, sessionID+".json")
 	writeProcessProviderDevinTranscript(t, transcriptPath, assistantReply)
 	return dbPath, transcriptPath


### PR DESCRIPTION
## Add Devin CLI as a supported local session source.

This teaches AgentsView to discover Devin roots from the local-share directory, parse session metadata from cli/sessions.db, read transcript content from cli/transcripts, and surface Devin sessions in the UI and settings docs. Devin is integrated through the provider facade because its session identity, freshness, and watch behavior come from a composite DB-plus-transcript source rather than a single transcript file.

The parser now handles Devin transcript messages, tool calls/results, token usage, privacy-safe error reporting, and fallback parsing from message_nodes when transcript JSON is missing. Sync and watcher integration were updated so Devin sessions use provider-owned virtual source paths, composite freshness, and provider watch plans without widening remote sync or other non-Devin behavior.

Reviewers should focus on:
- internal/parser/devin.go
- internal/parser/devin_provider.go
- internal/sync/engine.go
- cmd/agentsview/main.go

We intentionally narrow earlier provider-wide fallout so SSH remote sync, parse-diff, token-use probing, and resync safety counting stay scoped to existing behavior, with Devin as the only new non-file-backed exception.