### PR TITLE
docs: add 0.36.0 release notes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,101 @@ title: Changelog
 description: Release history for AgentsView
 ---
 
+## 0.36.0
+<small>2026-07-02</small>
+
+**New features**
+
+- Add **pairwise usage cost comparisons** to the Usage page and usage API. The
+  new comparison panel can compare any two project or model slices in the
+  current date/filter window and reports backend-computed cost, session count,
+  total tokens, cost per session, tokens per session, absolute deltas, and
+  percent deltas. The REST surface is
+  `GET /api/v1/usage/pairwise-comparison`.
+- Show **parser malformed-line badges** on session detail pages when a parser
+  preserved a session but skipped malformed source lines. The badge uses the
+  persisted `parser_malformed_lines` count already produced by parser/sync
+  validation, so users can spot partially recovered transcripts without opening
+  CLI sync logs.
+- Add **Traditional Chinese (`zh-TW`) localization** across the Svelte frontend
+  and register it as a supported locale alongside English and Simplified
+  Chinese.
+- Support **forking Claude sessions from a selected message**. Claude message
+  headers now expose a fork action that renders the transcript through the
+  selected ordinal into a temporary prompt and launches `claude` from the
+  session working directory, or returns a copyable command when launch is not
+  available.
+- Add **branch metadata and filter support** for session queries. The new
+  `GET /api/v1/branches` endpoint returns distinct `(project, branch)` pairs
+  with opaque filter tokens, and session, search, analytics, activity, and usage
+  endpoints accept those tokens as `git_branch`. Project-scoped tokens keep
+  same-named branches in different repositories distinct and preserve empty
+  branch values.
+- Flag **Antigravity sessions decoded from unrecognized schemas**. Antigravity
+  IDE and CLI parsers now fingerprint SQLite schemas into `source_version`;
+  unknown fingerprints get an `agy-schema:<prefix>` marker, session details
+  expose `decode_confidence: "low"`, sync summaries count the affected
+  sessions, `doctor sync` reports them, and the UI shows an **Unverified
+  schema** badge.
+
+**Improvements**
+
+- Improve **Cursor attribution in stats** so `agentsview stats` and the stats
+  service read the host-local Cursor attribution database with parity between
+  direct and daemon-backed execution. Cursor attribution remains machine-local
+  and reports unsupported project filters explicitly.
+- Extend **`parse-diff` coverage** to DB-backed Warp, Forge, and Piebald
+  sessions by allowing provider-authoritative sources, not only file-backed
+  parsers.
+- Reduce **daemon sync CPU usage while sessions are actively streaming** by
+  avoiding repeated skip-check work on hot files that are still being written.
+- Improve **unsupported usage reporting** from agent capabilities. Agents now
+  advertise whether they lack per-message token data and whether their costs are
+  denominated as Copilot AI Credits separately, so Copilot-family filters keep
+  Copilot-specific wording while other no-token agents get generic guidance.
+
+**Bug fixes**
+
+- Fix **DuckDB push schema setup through Quack** so remote Quack-backed pushes
+  initialize and validate the DuckDB schema correctly.
+- Fix **Visual Studio 2026 Copilot session parsing** for the current trace
+  layout while preserving the existing Visual Studio Copilot agent identity and
+  discovery paths.
+- Surface **unsupported Copilot usage filters** correctly in the Usage page and
+  API instead of showing an empty report without the Copilot no-token-data note.
+- Backfill **worktree mappings** for sessions that have empty working-directory
+  rows but can be matched from sibling sessions under the same mapping.
+- Prevent **OpenCode WAL watcher feedback loops** by reading OpenCode-family
+  SQLite databases through read-only file URIs, ignoring transient `-shm`
+  events, and only treating main database or data-bearing WAL changes as
+  meaningful.
+- Remove **outdated Copilot billing wording** from CLI usage output. The note
+  now says Copilot records do not include token or cost data AgentsView can
+  total, rather than referring to old billing terminology.
+
+**Acknowledgements**
+
+- Thanks to [Rod Boev](https://github.com/rodboev) for pairwise usage
+  comparisons, Cursor attribution parity, Claude message-point session forking,
+  worktree-mapping backfills, unsupported usage capability metadata, and usage
+  filter fixes.
+- Thanks to [Matthew Jacobs](https://github.com/mjacobs) for parser
+  malformed-line badges, Antigravity schema-confidence reporting,
+  provider-backed `parse-diff` coverage, the Copilot CLI wording fix, and MCP
+  schema documentation.
+- Thanks to [Linus](https://github.com/Playgrand-by-linus) for the Traditional
+  Chinese (`zh-TW`) localization.
+- Thanks to [Prateek Rungta](https://github.com/prateek) for the project-scoped
+  branch filter foundation.
+- Thanks to [Phillip Cloud](https://github.com/cpcloud) for the DuckDB/Quack
+  schema setup fix.
+- Thanks to [Trent Nelson](https://github.com/tpn) for preventing OpenCode WAL
+  watcher feedback loops.
+- Thanks to [Wes McKinney](https://github.com/wesm) for daemon sync CPU
+  reduction, Windows test-suite fixture reuse, and release documentation.
+
+---
+
 ## 0.35.2
 <small>2026-06-30</small>
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -53,8 +53,12 @@ description: Release history for AgentsView
   avoiding repeated skip-check work on hot files that are still being written.
 - Improve **unsupported usage reporting** from agent capabilities. Agents now
   advertise whether they lack per-message token data and whether their costs are
-  denominated as Copilot AI Credits separately, so Copilot-family filters keep
+  denominated in AI credits (surfaced as "Copilot AI Credits" for Copilot
+  agents) as separate capabilities, so Copilot-family filters keep
   Copilot-specific wording while other no-token agents get generic guidance.
+- Publish a **`stable` Docker image tag** on tagged releases. `stable` always
+  points at the most recent tagged release, while `latest` continues to track
+  `main` and exact version tags remain immutable.
 
 **Bug fixes**
 
@@ -79,8 +83,9 @@ description: Release history for AgentsView
 
 - Thanks to [Rod Boev](https://github.com/rodboev) for pairwise usage
   comparisons, Cursor attribution parity, Claude message-point session forking,
-  worktree-mapping backfills, unsupported usage capability metadata, and usage
-  filter fixes.
+  worktree-mapping backfills, unsupported usage capability metadata, usage
+  filter fixes, Visual Studio 2026 Copilot session parsing, and the `stable`
+  Docker image tag.
 - Thanks to [Matthew Jacobs](https://github.com/mjacobs) for parser
   malformed-line badges, Antigravity schema-confidence reporting,
   provider-backed `parse-diff` coverage, the Copilot CLI wording fix, and MCP

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -668,6 +668,8 @@ The report includes:
 - leftover resync temp files
 - configured/default agent roots and whether each exists
 - recent debug lines mentioning sync, data versions, warnings, or failures
+- Antigravity CLI summary-mode counts and Antigravity sessions decoded from
+  unrecognized `agy-schema:` fingerprints
 - a likely-cause summary when startup sync behavior looks abnormal
 
 ______________________________________________________________________
@@ -702,8 +704,9 @@ agentsview parse-diff --json > parser-report.json
 
 `parse-diff` is intended for parser development and release QA. Run it against a
 quiescent, freshly synced archive for the clearest signal. Import-only sources
-and non-file-backed agents are skipped because there is no source file to
-re-parse.
+are skipped because there is no source file to re-parse. Provider-backed stores
+with authoritative local sources, including Warp, Forge, and Piebald, are
+covered alongside normal file-backed agents.
 
 ______________________________________________________________________
 

--- a/docs/session-api.md
+++ b/docs/session-api.md
@@ -170,7 +170,7 @@ agentsview session get <id> [--format json]
   "outcome": "completed",
   "health_score_basis": ["..."],
   "health_penalties": {"tool_retries": 5},
-  "parser_malformed_lines": 0,
+  "parser_malformed_lines": 3,
   "secret_leak_count": 0
 }
 ```
@@ -179,9 +179,10 @@ agentsview session get <id> [--format json]
 `health_score` is non-null. Both HTTP and CLI surfaces return them.
 
 `git_branch` is the branch captured at sync time when the parser or
-source metadata exposes it. `parser_malformed_lines` is non-zero
-when a parser recovered a session after skipping malformed source
-lines. Antigravity detail responses may also include
+source metadata exposes it; sessions with no recorded branch omit
+the field. `parser_malformed_lines` counts the malformed source
+lines a parser skipped while still recovering the session and is
+omitted when zero. Antigravity detail responses may also include
 `decode_confidence`; the value `low` means the session came from an
 unrecognized Antigravity schema fingerprint and was decoded
 heuristically.
@@ -377,9 +378,11 @@ Response:
 ```
 
 `command_only: true` returns the command without launching a
-terminal. Read-only local mode can still return commands, but
-remote sessions and read-only remote serving cannot launch local
-programs.
+terminal. When a launch is attempted but fails, the response still
+includes the command with `launched: false` and an `error` code of
+`no_terminal_found` or `launch_failed`. Read-only local mode can
+still return commands, but remote sessions and read-only remote
+serving cannot launch local programs.
 
 For Claude Code sessions, setting `fork_session: true` without
 `from_ordinal` appends Claude's native `--fork-session` flag to the

--- a/docs/session-api.md
+++ b/docs/session-api.md
@@ -108,6 +108,39 @@ use local SQLite unless `--pg` is supplied.
 | `--server-token-file <path>` | Bearer token file for an explicit `--server` URL. |
 | `--pg`                       | Read from configured PostgreSQL instead of SQLite. |
 
+## Shared metadata endpoints
+
+The web UI and generated API clients use shared metadata endpoints
+for filter options:
+
+```http
+GET /api/v1/projects
+GET /api/v1/machines
+GET /api/v1/branches
+GET /api/v1/agents
+```
+
+`GET /api/v1/branches` returns distinct `(project, branch)` pairs
+plus an opaque `token` field:
+
+```json
+{
+  "branches": [
+    {
+      "project": "myapp",
+      "branch": "main",
+      "token": "..."
+    }
+  ]
+}
+```
+
+Pass the returned token back as the `git_branch` query parameter on
+branch-aware endpoints. Treat it as opaque and URL-encode it in
+manual HTTP calls. The token is scoped by both project and branch,
+so `app-a/main` and `app-b/main` remain distinct, and an empty
+branch remains distinct from a literal `unknown` branch.
+
 ## Commands
 
 ### `agentsview session get`
@@ -127,6 +160,7 @@ agentsview session get <id> [--format json]
   "agent": "claude",
   "first_message": "...",
   "display_name": "...",
+  "git_branch": "main",
   "started_at": "2026-04-18T12:00:00Z",
   "ended_at": "2026-04-18T13:00:00Z",
   "message_count": 42,
@@ -136,12 +170,21 @@ agentsview session get <id> [--format json]
   "outcome": "completed",
   "health_score_basis": ["..."],
   "health_penalties": {"tool_retries": 5},
+  "parser_malformed_lines": 0,
   "secret_leak_count": 0
 }
 ```
 
 `health_score_basis` and `health_penalties` are populated when
 `health_score` is non-null. Both HTTP and CLI surfaces return them.
+
+`git_branch` is the branch captured at sync time when the parser or
+source metadata exposes it. `parser_malformed_lines` is non-zero
+when a parser recovered a session after skipping malformed source
+lines. Antigravity detail responses may also include
+`decode_confidence`; the value `low` means the session came from an
+unrecognized Antigravity schema fingerprint and was decoded
+heuristically.
 
 `secret_leak_count` (added in 0.30.0) counts definite-tier
 findings from [secret scanning](#secret-scanning) and is stamped
@@ -176,6 +219,7 @@ One-shot and automated sessions are excluded by default. Use the
 | `--project`           | `project`           | string                            |
 | `--exclude-project`   | `exclude_project`   | string                            |
 | `--machine`           | `machine`           | string                            |
+| —                     | `git_branch`        | opaque token from `GET /api/v1/branches` |
 | `--agent`             | `agent`             | string                            |
 | `--date`              | `date`              | `YYYY-MM-DD`                      |
 | `--date-from`         | `date_from`         | `YYYY-MM-DD`                      |
@@ -296,6 +340,55 @@ agentsview session tool-calls <id>
 
 `input_json` is a string — usually a serialized JSON object but may
 be a plain string (e.g. `"echo hello world"` from Codex).
+
+---
+
+### `POST /api/v1/sessions/{id}/resume`
+
+Resume a local session in its native agent, or return the command
+that would be launched. This is an HTTP-only surface used by the
+web UI's resume menu.
+
+```http
+POST /api/v1/sessions/{id}/resume
+```
+
+Request body:
+
+```json
+{
+  "skip_permissions": false,
+  "fork_session": false,
+  "from_ordinal": 17,
+  "command_only": false,
+  "opener_id": ""
+}
+```
+
+Response:
+
+```json
+{
+  "launched": true,
+  "terminal": "Terminal",
+  "command": "cd /repo && claude --resume abc-123",
+  "cwd": "/repo"
+}
+```
+
+`command_only: true` returns the command without launching a
+terminal. Read-only local mode can still return commands, but
+remote sessions and read-only remote serving cannot launch local
+programs.
+
+For Claude Code sessions, setting `fork_session: true` without
+`from_ordinal` appends Claude's native `--fork-session` flag to the
+normal resume command. Setting both `fork_session: true` and
+`from_ordinal` creates a message-point fork: AgentsView renders the
+transcript through that message ordinal into a temporary prompt and
+runs `claude < prompt` from the resolved session working directory.
+Message-point forks are Claude-only, require `fork_session`, reject
+`opener_id`, and return `404` when the ordinal is not present.
 
 ---
 
@@ -445,6 +538,7 @@ default; opt back in with `--include-one-shot`,
 | `--project`           | `project`           | string                                                 |
 | `--exclude-project`   | `exclude_project`   | string                                                 |
 | `--machine`           | `machine`           | string                                                 |
+| —                     | `git_branch`        | opaque token from `GET /api/v1/branches`               |
 | `--agent`             | `agent`             | string                                                 |
 | `--date`              | `date`              | `YYYY-MM-DD`                                           |
 | `--date-from`         | `date_from`         | `YYYY-MM-DD`                                           |
@@ -599,6 +693,7 @@ are also included by default and can be filtered with the
 | `timezone` | IANA timezone name; default `UTC` |
 | `bucket` | Optional bucket override: `5m`, `15m`, `1h`, `1d`, or `1w` |
 | `project` | Filter by project |
+| `git_branch` | Filter by opaque branch token from `GET /api/v1/branches` |
 | `agent` | Filter by agent |
 | `machine` | Filter by machine |
 | `automation` | `all`, `interactive`, or `automated`; default `all` |

--- a/docs/token-usage.md
+++ b/docs/token-usage.md
@@ -49,6 +49,16 @@ invocation, it's also dramatically faster on large histories
     do not expose token usage. Warp records session-level totals, but
     those totals are not yet folded into the per-message cost report.
 
+When an agent filter selects only agents that do not expose
+per-message token rows, AgentsView reports that as an unsupported
+usage state instead of silently showing an empty chart. Copilot-family
+filters (`copilot`, `vscode-copilot`, and `visualstudio-copilot`) keep
+Copilot-specific wording; any other no-token agent falls back to a
+generic "matching sessions do not expose token usage data" message.
+Copilot AI-credit conversion is tracked separately from this
+no-token-data capability, so future agents can opt into either
+behavior independently.
+
 ### Cursor Admin Usage Events
 
 Cursor has two usage sources in AgentsView:
@@ -171,6 +181,34 @@ outliers and the remaining breakdown tells you where the
 smaller spend is going.
 
 ![Cost attribution treemap](/assets/generated/screenshots/usage-attribution.png)
+
+### Pairwise Cost Comparison
+
+The Usage page also includes **Comparative Cost Analysis** for
+side-by-side cost checks. Pick a dimension (**Project** or
+**Model**) and value for the left side, then pick the same or a
+different dimension and value for the right side. The comparison
+uses the page's active date range and shared filters, then asks the
+backend to compute both slices.
+
+The result table shows total cost, session count, cost per session,
+total tokens, tokens per session, input tokens, output tokens, the
+absolute delta from left to right, and the percent delta when a
+ratio can be computed. It is useful for questions such as "how much
+more expensive was project A than project B this week?" or "how do
+two models compare after normalizing by session count?"
+
+The same comparison is available over REST:
+
+```http
+GET /api/v1/usage/pairwise-comparison
+```
+
+Pass the normal usage filters plus `left_dimension`, `left_value`,
+`right_dimension`, and `right_value`. Supported dimensions are
+`project` and `model`. Branch-scoped comparisons use the shared
+`git_branch` usage filter with an opaque token from
+`GET /api/v1/branches`.
 
 ### Top Sessions by Cost
 

--- a/docs/token-usage.md
+++ b/docs/token-usage.md
@@ -55,9 +55,10 @@ usage state instead of silently showing an empty chart. Copilot-family
 filters (`copilot`, `vscode-copilot`, and `visualstudio-copilot`) keep
 Copilot-specific wording; any other no-token agent falls back to a
 generic "matching sessions do not expose token usage data" message.
-Copilot AI-credit conversion is tracked separately from this
-no-token-data capability, so future agents can opt into either
-behavior independently.
+AI-credit cost denomination (surfaced as "Copilot AI Credits" for
+Copilot agents) is tracked as a separate capability from
+no-token-data, so future agents can opt into either behavior
+independently.
 
 ### Cursor Admin Usage Events
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -561,8 +561,8 @@ copy it to the clipboard for sharing or lookup. Click the grade
 badge to toggle the signal panel.
 
 If a parser skipped malformed source lines while still recovering
-the session, the header shows a **Malformed lines** badge with the
-persisted `parser_malformed_lines` count. For Antigravity IDE and
+the session, the header shows a malformed-lines badge with the
+persisted count (for example "3 malformed lines"). For Antigravity IDE and
 CLI sessions decoded from an unrecognized SQLite schema fingerprint,
 the header also shows **Unverified schema**. That badge means the
 session was decoded heuristically from a newer schema and may be

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -560,6 +560,14 @@ health grade badge, and a copyable **Session ID**. Click the ID to
 copy it to the clipboard for sharing or lookup. Click the grade
 badge to toggle the signal panel.
 
+If a parser skipped malformed source lines while still recovering
+the session, the header shows a **Malformed lines** badge with the
+persisted `parser_malformed_lines` count. For Antigravity IDE and
+CLI sessions decoded from an unrecognized SQLite schema fingerprint,
+the header also shows **Unverified schema**. That badge means the
+session was decoded heuristically from a newer schema and may be
+incomplete.
+
 ### Message Layouts
 
 Four layouts control how messages are rendered. Cycle between
@@ -598,6 +606,15 @@ The header shows the role label, timestamp, and a **copy
 button** that appears on hover. Click it to copy the full
 message content to the clipboard — a checkmark confirms the
 copy for 1.5 seconds.
+
+Claude Code sessions also show a fork action on each message header
+when the local server can launch or return a command. Clicking it
+starts a new Claude run from the selected point by rendering the
+transcript through that message ordinal into a temporary prompt,
+starting `claude` in the session working directory, and removing the
+temporary prompt after launch. In read-only local mode the action
+copies the command instead of launching it; remote sessions cannot be
+forked from the browser.
 
 ### Thinking Blocks
 


### PR DESCRIPTION
The 0.36.0 tag is cut, but the public docs still describe 0.35.2 as the newest release and do not explain the user-facing surfaces added alongside the mostly internal parser, usage, and sync work. This updates the release notes and the relevant docs pages so users can understand what changed without reading implementation PRs.

The release documentation calls out the narrow visible UI changes, the new API contracts for pairwise usage comparisons and branch tokens, and the parser-quality signals that now appear in session details and diagnostics. It also keeps contributor acknowledgements tied to the implementation history so the release page reflects who shipped the work.

Most of this release is backend and observability work, so the docs avoid promising new screenshot-led workflows where the product surface is intentionally small.