### PR TITLE
feat(sync): surface Antigravity gen_metadata-without-usage anomaly counter

### DIFF
--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -849,6 +849,19 @@ func formatAnomalySummary(a sync.AnomalyStats) string {
 			)
 		}
 	}
+	if a.GenMetadataWithoutUsageTotal > 0 {
+		fmt.Fprintf(&b,
+			"  gen_metadata without usage: %d total\n",
+			a.GenMetadataWithoutUsageTotal,
+		)
+		for _, agent := range slices.Sorted(
+			maps.Keys(a.GenMetadataWithoutUsageByAgent),
+		) {
+			fmt.Fprintf(&b,
+				"    %s: %d\n", agent, a.GenMetadataWithoutUsageByAgent[agent],
+			)
+		}
+	}
 	if !a.Sanitize.IsZero() {
 		fmt.Fprintf(&b,
 			"  sanitized fields: %d total\n", a.Sanitize.Total(),

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -936,6 +936,52 @@ func TestFormatAnomalySummary(t *testing.T) {
 			},
 			wantOmit: []string{"malformed lines", "sanitized fields"},
 		},
+		{
+			name: "gen_metadata without usage only",
+			anomalies: agentsync.AnomalyStats{
+				GenMetadataWithoutUsageByAgent: map[string]int{
+					"antigravity": 1, "antigravity-cli": 2,
+				},
+				GenMetadataWithoutUsageTotal: 3,
+			},
+			wantContain: []string{
+				"Parser anomalies (this run):",
+				"gen_metadata without usage: 3 total",
+				"antigravity: 1",
+				"antigravity-cli: 2",
+			},
+			wantOmit: []string{
+				"malformed lines",
+				"unrecognized schema sessions",
+				"sanitized fields",
+			},
+		},
+		{
+			name: "all sections present",
+			anomalies: agentsync.AnomalyStats{
+				MalformedLinesByAgent:          map[string]int{"gemini": 7},
+				MalformedLinesTotal:            7,
+				UnknownSchemaSessionsByAgent:   map[string]int{"antigravity": 2},
+				UnknownSchemaSessionsTotal:     2,
+				GenMetadataWithoutUsageByAgent: map[string]int{"antigravity-cli": 3},
+				GenMetadataWithoutUsageTotal:   3,
+				Sanitize: agentsync.SanitizeStats{
+					TokensClamped:     4,
+					TimestampsBlanked: 1,
+				},
+			},
+			wantContain: []string{
+				"malformed lines: 7 total",
+				"gemini: 7",
+				"unrecognized schema sessions: 2 total",
+				"antigravity: 2",
+				"gen_metadata without usage: 3 total",
+				"antigravity-cli: 3",
+				"sanitized fields: 5 total",
+				"tokens clamped: 4",
+				"timestamps blanked: 1",
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/parser/antigravity.go
+++ b/internal/parser/antigravity.go
@@ -95,7 +95,7 @@ func (p *antigravityProvider) parseSession(
 	// schema cannot be read.
 	sourceVersion := antigravitySourceVersion(db)
 
-	messages, usageEvents, err := loadAntigravitySteps(db)
+	messages, usageEvents, hasGenMetadata, err := loadAntigravitySteps(db)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -175,6 +175,9 @@ func (p *antigravityProvider) parseSession(
 	}
 	accumulateMessageTokenUsage(sess, messages)
 	applyUsageEventTokenTotals(sess, usageEvents)
+	// gen_metadata rows with zero decoded usage events flag a possible
+	// token-block wire-format change. Derived from the final usageEvents.
+	sess.GenMetadataWithoutUsage = hasGenMetadata && len(usageEvents) == 0
 	for i := range usageEvents {
 		usageEvents[i].SessionID = sess.ID
 	}
@@ -187,18 +190,25 @@ func (p *antigravityProvider) parseSession(
 	return sess, messages, usageEvents, nil
 }
 
-func loadAntigravitySteps(db *sql.DB) ([]ParsedMessage, []ParsedUsageEvent, error) {
+func loadAntigravitySteps(
+	db *sql.DB,
+) ([]ParsedMessage, []ParsedUsageEvent, bool, error) {
 	result, err := loadAntigravityStepsWithRawCount(db)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, false, err
 	}
-	return result.messages, result.usageEvents, nil
+	return result.messages, result.usageEvents, result.hasGenMetadata, nil
 }
 
 type antigravityStepLoadResult struct {
 	messages     []ParsedMessage
 	usageEvents  []ParsedUsageEvent
 	rawStepCount int
+	// hasGenMetadata reports whether the steps DB carried a non-empty
+	// gen_metadata table. Paired with an empty usageEvents slice it flags a
+	// session whose gen_metadata rows failed to decode into usage -- an early
+	// warning that a newer agy build changed the token-block wire format.
+	hasGenMetadata bool
 	// sourceVersion is the schema-fingerprint label of the .db, set by the
 	// CLI loader while the DB is open. The IDE path computes it directly
 	// from its own handle via antigravitySourceVersion, so both classify
@@ -291,6 +301,7 @@ func loadAntigravityStepsWithRawCount(
 	}
 
 	var result antigravityStepLoadResult
+	result.hasGenMetadata = len(genMeta) > 0
 	for rows.Next() {
 		var (
 			idx      int

--- a/internal/parser/antigravity_cli.go
+++ b/internal/parser/antigravity_cli.go
@@ -105,6 +105,10 @@ func (p *antigravityCLIProvider) parseSessionWithStatus(
 	var messages []ParsedMessage
 	var usageEvents []ParsedUsageEvent
 	var hasTrajectory bool
+	// hasGenMetadata records whether the .db source carried gen_metadata
+	// rows. Combined with the FINAL usageEvents (after the sidecar gap-fill
+	// below) it flags a gen_metadata table that decoded into zero usage.
+	var hasGenMetadata bool
 	transcriptFidelity := TranscriptFidelitySummary
 	// sourceVersion is the schema-fingerprint label of the .db source; it
 	// stays empty for legacy .pb and sidecar-only sessions where no schema
@@ -113,6 +117,7 @@ func (p *antigravityCLIProvider) parseSessionWithStatus(
 	if ext == ".db" {
 		dbResult, dbErr := loadAntigravityCLIDBSteps(path)
 		sourceVersion = dbResult.sourceVersion
+		hasGenMetadata = dbResult.hasGenMetadata
 		// gen_metadata token usage describes the session's actual
 		// consumption no matter which transcript source wins below.
 		// The sidecar also extracts generatorMetadata usage, but
@@ -295,6 +300,10 @@ func (p *antigravityCLIProvider) parseSessionWithStatus(
 	}
 	accumulateMessageTokenUsage(sess, messages)
 	applyUsageEventTokenTotals(sess, usageEvents)
+	// Flag gen_metadata that decoded into zero usage. Computed from the FINAL
+	// usageEvents, so a session whose gen_metadata failed to decode but whose
+	// trajectory sidecar supplied usage via the gap-fill above is not flagged.
+	sess.GenMetadataWithoutUsage = hasGenMetadata && len(usageEvents) == 0
 	for i := range usageEvents {
 		usageEvents[i].SessionID = sess.ID
 	}

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -2839,6 +2839,184 @@ func TestAntigravityCLIZeroMessageKeepsUsageEvents(t *testing.T) {
 	assert.Equal(t, 3000, sess.PeakContextTokens)
 }
 
+// undecodableAntigravityGenMetadata builds a gen_metadata blob whose token
+// block is rejected by the heuristic (field 2 exceeds the plausibility cap),
+// so it decodes into no usage event even though the row is present.
+func undecodableAntigravityGenMetadata() []byte {
+	return encodePB([]pbField{
+		{num: 1, wire: pbWireVarint, varint: 1371},
+		{num: 2, wire: pbWireVarint, varint: 679261000}, // implausible input
+		{num: 3, wire: pbWireVarint, varint: 100},
+	})
+}
+
+// TestAntigravityGenMetadataWithoutUsageFlag exercises the IDE parser's
+// GenMetadataWithoutUsage flag: it is set only when the steps DB carried
+// gen_metadata rows that decoded into zero usage events. An absent or empty
+// gen_metadata table, or rows that decode into usage, leave it false.
+func TestAntigravityGenMetadataWithoutUsageFlag(t *testing.T) {
+	decodableStep := func(t *testing.T, db *sql.DB) {
+		t.Helper()
+		ts := encodePB([]pbField{{num: 1, wire: pbWireVarint, varint: 1779000100}})
+		asstPayload := encodePB([]pbField{
+			{num: 5, wire: pbWireBytes, bytes: ts},
+			{num: 17, wire: pbWireBytes, bytes: []byte("assistant response body goes here and is long")},
+		})
+		mustExec(t, db,
+			`INSERT INTO steps (idx, step_type, step_payload) VALUES (0, 17, ?)`,
+			asstPayload)
+	}
+	tests := []struct {
+		name     string
+		setupDB  func(t *testing.T, db *sql.DB)
+		wantFlag bool
+	}{
+		{
+			name: "no gen_metadata table",
+			setupDB: func(t *testing.T, db *sql.DB) {
+				createAntigravityStepTables(t, db)
+				decodableStep(t, db)
+			},
+			wantFlag: false,
+		},
+		{
+			name: "empty gen_metadata table",
+			setupDB: func(t *testing.T, db *sql.DB) {
+				createAntigravityStepTables(t, db)
+				mustExec(t, db, `CREATE TABLE gen_metadata (idx integer, data blob, size integer, PRIMARY KEY (idx))`)
+				decodableStep(t, db)
+			},
+			wantFlag: false,
+		},
+		{
+			name: "gen_metadata rows decode to usage",
+			setupDB: func(t *testing.T, db *sql.DB) {
+				createAntigravityStepTables(t, db)
+				mustExec(t, db, `CREATE TABLE gen_metadata (idx integer, data blob, size integer, PRIMARY KEY (idx))`)
+				decodableStep(t, db)
+				genData := createAntigravityMockGenMetadata(t, 2400, 180, 0, "Test Gemini 3.5")
+				mustExec(t, db, `INSERT INTO gen_metadata (idx, data, size) VALUES (0, ?, ?)`, genData, len(genData))
+			},
+			wantFlag: false,
+		},
+		{
+			name: "gen_metadata rows all undecodable",
+			setupDB: func(t *testing.T, db *sql.DB) {
+				createAntigravityStepTables(t, db)
+				mustExec(t, db, `CREATE TABLE gen_metadata (idx integer, data blob, size integer, PRIMARY KEY (idx))`)
+				decodableStep(t, db)
+				blob := undecodableAntigravityGenMetadata()
+				mustExec(t, db, `INSERT INTO gen_metadata (idx, data, size) VALUES (0, ?, ?)`, blob, len(blob))
+			},
+			wantFlag: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			id := "55555555-6666-7777-8888-abababababab"
+			mustMkdir(t, filepath.Join(root, "conversations"))
+			dbPath := filepath.Join(root, "conversations", id+".db")
+			db, err := sql.Open("sqlite3", dbPath)
+			require.NoError(t, err)
+			tt.setupDB(t, db)
+			require.NoError(t, db.Close())
+
+			sess, _, usageEvents, err := parseAntigravityTestSession(t,
+				dbPath, "test-project", "test-machine")
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantFlag, sess.GenMetadataWithoutUsage)
+			if tt.wantFlag {
+				assert.Empty(t, usageEvents,
+					"flag implies zero decoded usage events")
+			}
+		})
+	}
+}
+
+// TestAntigravityCLIGenMetadataWithoutUsageFlag covers the CLI parser's
+// critical timing: the flag is computed from the FINAL usageEvents, after the
+// trajectory-sidecar gap-fill. A session whose gen_metadata failed to decode
+// but whose sidecar supplied usage is NOT flagged; a session with neither
+// source of usage is.
+func TestAntigravityCLIGenMetadataWithoutUsageFlag(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T, root, id, dbPath string)
+		wantFlag bool
+		wantUsed bool // usage events expected on the parse result
+	}{
+		{
+			name: "undecodable gen_metadata rescued by sidecar usage",
+			setup: func(t *testing.T, root, id, dbPath string) {
+				db, err := sql.Open("sqlite3", dbPath)
+				require.NoError(t, err)
+				createAntigravityStepTables(t, db)
+				mustExec(t, db, `CREATE TABLE gen_metadata (idx integer, data blob, size integer, PRIMARY KEY (idx))`)
+				for i := range 2 {
+					mustExec(t, db,
+						`INSERT INTO steps (idx, step_type, step_payload) VALUES (?, ?, ?)`,
+						i, 99, []byte{0xff, 0xff, 0xff})
+				}
+				blob := undecodableAntigravityGenMetadata()
+				mustExec(t, db, `INSERT INTO gen_metadata (idx, data, size) VALUES (1, ?, ?)`, blob, len(blob))
+				require.NoError(t, db.Close())
+				// Covering sidecar carries generatorMetadata usage that fills
+				// the gap left by the undecodable gen_metadata.
+				genJSON := `[{
+					"stepIndices": [1],
+					"chatModel": {
+						"model": "MODEL_PLACEHOLDER_M20",
+						"usage": {"inputTokens": "1500", "outputTokens": "77"}
+					}
+				}]`
+				writeAntigravityTestSidecarWithGenMetadata(t, root, id, 2, genJSON)
+			},
+			wantFlag: false,
+			wantUsed: true,
+		},
+		{
+			name: "undecodable gen_metadata and no sidecar usage",
+			setup: func(t *testing.T, root, id, dbPath string) {
+				db, err := sql.Open("sqlite3", dbPath)
+				require.NoError(t, err)
+				createAntigravityStepTables(t, db)
+				mustExec(t, db, `CREATE TABLE gen_metadata (idx integer, data blob, size integer, PRIMARY KEY (idx))`)
+				mustExec(t, db,
+					`INSERT INTO steps (idx, step_type, step_payload) VALUES (0, 99, ?)`,
+					[]byte{0xff, 0xff, 0xff})
+				blob := undecodableAntigravityGenMetadata()
+				mustExec(t, db, `INSERT INTO gen_metadata (idx, data, size) VALUES (0, ?, ?)`, blob, len(blob))
+				require.NoError(t, db.Close())
+				// No sidecar written: nothing fills the usage gap.
+			},
+			wantFlag: true,
+			wantUsed: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			id := "00000000-1111-2222-3333-cdcdcdcdcdcd"
+			mustMkdir(t, filepath.Join(root, "conversations"))
+			dbPath := filepath.Join(root, "conversations", id+".db")
+			tt.setup(t, root, id, dbPath)
+
+			sess, _, usageEvents, _, err := parseAntigravityCLITestSessionWithStatus(t,
+				dbPath, "", "test-machine")
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantFlag, sess.GenMetadataWithoutUsage)
+			if tt.wantUsed {
+				assert.NotEmpty(t, usageEvents,
+					"sidecar gap-fill should supply usage events")
+			} else {
+				assert.Empty(t, usageEvents,
+					"flag implies zero decoded usage events")
+			}
+		})
+	}
+}
+
 func TestAntigravityTokenUsageDynamicField(t *testing.T) {
 	root := t.TempDir()
 	id := "55555555-6666-7777-8888-999999999998"

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -802,15 +802,21 @@ type ParsedSession struct {
 	// decode. Empty means full (parser did not classify). Currently set
 	// only by the Antigravity CLI parser.
 	TranscriptFidelity string
-	MalformedLines     int
-	IsTruncated        bool
-	FirstMessage       string
-	SessionName        string
-	StartedAt          time.Time
-	EndedAt            time.Time
-	MessageCount       int
-	UserMessageCount   int
-	File               FileInfo
+	// GenMetadataWithoutUsage reports whether this Antigravity session's steps
+	// table carried gen_metadata rows but none decoded into a usage event --
+	// an early warning that a newer agy build changed the gen_metadata wire
+	// format the token-block heuristic depends on. Set by both Antigravity
+	// parsers; false for every other agent.
+	GenMetadataWithoutUsage bool
+	MalformedLines          int
+	IsTruncated             bool
+	FirstMessage            string
+	SessionName             string
+	StartedAt               time.Time
+	EndedAt                 time.Time
+	MessageCount            int
+	UserMessageCount        int
+	File                    FileInfo
 
 	// TerminationStatus describes how the session appears to have
 	// ended. Empty string = unknown (parser did not classify, or

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -5672,6 +5672,14 @@ func (e *Engine) prepareSessionWrite(
 	if parser.DecodeConfidence(s.Agent, s.SourceVersion) == parser.DecodeConfidenceLow {
 		e.anomalies.recordUnknownSchemaSession(s.Agent)
 	}
+	// An Antigravity session whose gen_metadata table carried rows but decoded
+	// into zero usage events warns that a newer agy build may have changed the
+	// gen_metadata wire format the token-block heuristic depends on. The flag
+	// is set by the parsers from the final usageEvents, so a sidecar-rescued
+	// session is not counted here.
+	if pw.sess.GenMetadataWithoutUsage {
+		e.anomalies.recordGenMetadataWithoutUsageSession(s.Agent)
+	}
 
 	// A per-row token clamp must not leave an inflated value stranded in a
 	// row-derived session total while the row that produced it was clamped.

--- a/internal/sync/progress.go
+++ b/internal/sync/progress.go
@@ -102,6 +102,16 @@ type AnomalyStats struct {
 	// UnknownSchemaSessionsTotal is the grand total across all agents.
 	UnknownSchemaSessionsTotal int `json:"unknown_schema_sessions_total,omitempty"`
 
+	// GenMetadataWithoutUsageByAgent maps an agent type to the number of
+	// Antigravity sessions written this run that carried gen_metadata rows
+	// but decoded into zero usage events -- an early warning that a newer agy
+	// build changed the gen_metadata wire format the token-block heuristic
+	// depends on. Like the unknown-schema counter this counts whole SESSIONS.
+	// Only non-zero agents are present.
+	GenMetadataWithoutUsageByAgent map[string]int `json:"gen_metadata_without_usage_by_agent,omitempty"`
+	// GenMetadataWithoutUsageTotal is the grand total across all agents.
+	GenMetadataWithoutUsageTotal int `json:"gen_metadata_without_usage_total,omitempty"`
+
 	// Sanitize aggregates the central validation/sanitization fix counts
 	// across every session, message, and usage event written this run.
 	Sanitize SanitizeStats `json:"sanitize,omitzero"`
@@ -135,6 +145,7 @@ func (s SanitizeStats) IsZero() bool {
 func (a AnomalyStats) IsZero() bool {
 	return a.MalformedLinesTotal == 0 &&
 		a.UnknownSchemaSessionsTotal == 0 &&
+		a.GenMetadataWithoutUsageTotal == 0 &&
 		a.Sanitize.IsZero()
 }
 
@@ -166,6 +177,20 @@ func (a *AnomalyStats) RecordUnknownSchemaSessions(agent string, n int) {
 	a.UnknownSchemaSessionsTotal += n
 }
 
+// RecordGenMetadataWithoutUsage attributes n gen_metadata-without-usage
+// sessions to the given agent and updates the grand total. A non-positive
+// count is ignored so clean agents do not appear in the per-agent breakdown.
+func (a *AnomalyStats) RecordGenMetadataWithoutUsage(agent string, n int) {
+	if n <= 0 {
+		return
+	}
+	if a.GenMetadataWithoutUsageByAgent == nil {
+		a.GenMetadataWithoutUsageByAgent = make(map[string]int)
+	}
+	a.GenMetadataWithoutUsageByAgent[agent] += n
+	a.GenMetadataWithoutUsageTotal += n
+}
+
 // addSanitize accumulates the per-category counts from one
 // validateAndSanitize pass into the aggregate.
 func (a *AnomalyStats) addSanitize(v validationStats) {
@@ -183,6 +208,9 @@ func (a *AnomalyStats) merge(o AnomalyStats) {
 	}
 	for agent, n := range o.UnknownSchemaSessionsByAgent {
 		a.RecordUnknownSchemaSessions(agent, n)
+	}
+	for agent, n := range o.GenMetadataWithoutUsageByAgent {
+		a.RecordGenMetadataWithoutUsage(agent, n)
 	}
 	a.Sanitize.ControlCharsStripped += o.Sanitize.ControlCharsStripped
 	a.Sanitize.ModelClamped += o.Sanitize.ModelClamped
@@ -248,6 +276,16 @@ func (a *anomalyAccumulator) recordMalformedLines(
 func (a *anomalyAccumulator) recordUnknownSchemaSession(agent string) {
 	a.mu.Lock()
 	a.stats.RecordUnknownSchemaSessions(agent, 1)
+	a.mu.Unlock()
+}
+
+// recordGenMetadataWithoutUsageSession attributes one
+// gen_metadata-without-usage session to the given agent. Like the
+// unknown-schema counter it counts whole sessions, so a source that forks
+// into several sessions records each fork.
+func (a *anomalyAccumulator) recordGenMetadataWithoutUsageSession(agent string) {
+	a.mu.Lock()
+	a.stats.RecordGenMetadataWithoutUsage(agent, 1)
 	a.mu.Unlock()
 }
 

--- a/internal/sync/progress_test.go
+++ b/internal/sync/progress_test.go
@@ -182,6 +182,86 @@ func TestAnomalyAccumulator_RecordUnknownSchemaSession(t *testing.T) {
 	assert.Nil(t, next.Anomalies.UnknownSchemaSessionsByAgent)
 }
 
+func TestAnomalyStats_RecordGenMetadataWithoutUsage(t *testing.T) {
+	tests := []struct {
+		name    string
+		records []struct {
+			agent string
+			n     int
+		}
+		wantByAgent map[string]int
+		wantTotal   int
+	}{
+		{
+			name:        "clean run records nothing",
+			wantByAgent: nil,
+			wantTotal:   0,
+		},
+		{
+			name: "zero and negative counts are ignored",
+			records: []struct {
+				agent string
+				n     int
+			}{
+				{"antigravity", 0},
+				{"antigravity-cli", -2},
+			},
+			wantByAgent: nil,
+			wantTotal:   0,
+		},
+		{
+			name: "per-agent breakdown plus grand total",
+			records: []struct {
+				agent string
+				n     int
+			}{
+				{"antigravity", 1},
+				{"antigravity-cli", 2},
+				{"antigravity", 1},
+			},
+			wantByAgent: map[string]int{"antigravity": 2, "antigravity-cli": 2},
+			wantTotal:   4,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var a AnomalyStats
+			for _, r := range tt.records {
+				a.RecordGenMetadataWithoutUsage(r.agent, r.n)
+			}
+			assert.Equal(t, tt.wantByAgent, a.GenMetadataWithoutUsageByAgent)
+			assert.Equal(t, tt.wantTotal, a.GenMetadataWithoutUsageTotal)
+		})
+	}
+}
+
+// TestAnomalyAccumulator_RecordGenMetadataWithoutUsageSession verifies
+// whole-session accumulation per agent (no per-source dedup) and that a
+// reset clears it.
+func TestAnomalyAccumulator_RecordGenMetadataWithoutUsageSession(t *testing.T) {
+	var acc anomalyAccumulator
+	acc.reset()
+
+	acc.recordGenMetadataWithoutUsageSession("antigravity")
+	acc.recordGenMetadataWithoutUsageSession("antigravity")
+	acc.recordGenMetadataWithoutUsageSession("antigravity-cli")
+
+	var stats SyncStats
+	acc.applyTo(&stats)
+	assert.Equal(t, 3, stats.Anomalies.GenMetadataWithoutUsageTotal)
+	assert.Equal(t, map[string]int{"antigravity": 2, "antigravity-cli": 1},
+		stats.Anomalies.GenMetadataWithoutUsageByAgent)
+	assert.False(t, stats.Anomalies.IsZero())
+
+	// A fresh run starts from zero.
+	acc.reset()
+	var next SyncStats
+	acc.applyTo(&next)
+	assert.True(t, next.Anomalies.IsZero())
+	assert.Zero(t, next.Anomalies.GenMetadataWithoutUsageTotal)
+	assert.Nil(t, next.Anomalies.GenMetadataWithoutUsageByAgent)
+}
+
 func TestAnomalyAccumulator_Aggregate(t *testing.T) {
 	var acc anomalyAccumulator
 	acc.reset()
@@ -267,6 +347,11 @@ func TestAnomalyStats_IsZero(t *testing.T) {
 		{
 			name: "unknown schema only",
 			a:    AnomalyStats{UnknownSchemaSessionsTotal: 1},
+			want: false,
+		},
+		{
+			name: "gen_metadata without usage only",
+			a:    AnomalyStats{GenMetadataWithoutUsageTotal: 1},
 			want: false,
 		},
 		{


### PR DESCRIPTION
Extends the per-agent parser-anomaly counters (#866, #948) with a new signal: Antigravity sessions that carried `gen_metadata` rows but decoded into zero usage events. That combination is an early warning that a newer Antigravity build changed the gen_metadata token-block wire format the decode heuristic depends on — today it fails silently, and the session simply shows no usage.

The signal is set by both Antigravity parsers (IDE and CLI) as a transient flag on `ParsedSession`, computed from the *final* usageEvents so a CLI session whose gen_metadata failed to decode but whose trajectory sidecar supplied usage is correctly not flagged. It is recorded per agent at the existing `prepareSessionWrite` seam and rendered in the CLI sync summary next to the malformed-lines and unrecognized-schema counters, mirroring the #953 `UnknownSchemaSessionsByAgent` counter.

Deliberately schema-free: the flag never becomes a persisted column, so there is no migration and nothing flows to PostgreSQL/DuckDB — `AnomalyStats` is consumed only by the CLI summary printers.

Where to look: `internal/parser/antigravity.go` and `antigravity_cli.go` (detection and the sidecar-rescue correctness point), `internal/sync/progress.go` (`AnomalyStats`), `internal/sync/engine.go` (recording seam), `cmd/agentsview/main.go` (render).