### PR TITLE
feat(parse-diff): classify incremental-append skew and recommend a resync baseline

### DIFF
--- a/cmd/agentsview/parse_diff.go
+++ b/cmd/agentsview/parse_diff.go
@@ -62,9 +62,11 @@ func newParseDiffCommand() *cobra.Command {
 			"Use it to vet parser changes against the real archive before\n" +
 			"bumping the data version, or to detect upstream format drift.\n" +
 			"Run it against a quiescent archive: sessions still being\n" +
-			"written, and sessions last written through the incremental\n" +
-			"append path, can show benign drift against a full re-parse. A\n" +
-			"freshly resynced archive gives the cleanest baseline.",
+			"written can show benign drift against a full re-parse and are\n" +
+			"classified as raced. Sessions last written through the\n" +
+			"incremental-append path are detected and classified as\n" +
+			"incremental_skew (both excluded from --fail-on-change); a\n" +
+			"freshly resynced archive still gives the cleanest baseline.",
 		GroupID:      groupData,
 		SilenceUsage: true,
 		Args:         cobra.NoArgs,
@@ -315,8 +317,26 @@ func renderParseDiffReport(
 	renderParseDiffParseErrors(w, r.Sessions)
 	renderParseDiffChanged(w, r.Sessions, verbose)
 	renderParseDiffRaced(w, r.Sessions, verbose)
+	renderParseDiffIncrementalSkew(w, r.Sessions, verbose)
 	if verbose {
 		renderParseDiffPendingResync(w, r.Sessions)
+	}
+
+	// Incremental-skew sessions are suppressed from --fail-on-change but
+	// still signal that the comparison basis is compromised for those
+	// rows. A full resync rewrites them through normalization, clears the
+	// marker, and restores full diff scrutiny -- so recommend it, mirroring
+	// the vacuous-resync warning above. Totals.IncrementalSkew is already
+	// in the JSON, so no new bool method is needed to gate the note.
+	if r.Totals.IncrementalSkew > 0 {
+		fmt.Fprintf(w,
+			"Note: %d session(s) were last written through the "+
+				"incremental-append path, so a full re-parse legitimately "+
+				"differs from the stored rows. They are classified "+
+				"incremental_skew and excluded from --fail-on-change. Run a "+
+				"full resync for a clean parse-diff baseline that restores "+
+				"drift detection on these sessions.\n\n",
+			r.Totals.IncrementalSkew)
 	}
 
 	fmt.Fprintf(w, "%d sessions changed, %d identical.\n",
@@ -397,6 +417,8 @@ func renderParseDiffSummary(w io.Writer, t sync.ParseDiffTotals) {
 		"(source not re-parsed: missing, remote, trashed, or not sampled)")
 	line("Raced", t.Raced,
 		"(source changed mid-run; inconclusive, not counted as drift)")
+	line("Incremental skew", t.IncrementalSkew,
+		"(last written incrementally; full re-parse differs, not counted as drift)")
 	line("Excluded by parser", t.ExcludedByParser,
 		"(parser intentionally drops these; sync would delete them)")
 	line("Parse errors", t.ParseErrors,
@@ -507,6 +529,54 @@ func renderParseDiffRaced(
 	}
 	tw.Flush()
 	if extra := len(raced) - len(shown); extra > 0 {
+		fmt.Fprintf(w, "  ... (%d more; use --verbose or --json)\n",
+			extra)
+	}
+	fmt.Fprintln(w)
+}
+
+// renderParseDiffIncrementalSkew lists sessions whose would-be change
+// was reclassified as incremental-append skew: the stored row was last
+// written through the incremental-append path, so a full re-parse
+// legitimately differs. These never trip --fail-on-change, but surfacing
+// them tells the operator the comparison basis is compromised for those
+// rows and a full resync gives a clean baseline. Compact by default;
+// verbose shows the masked field diffs.
+func renderParseDiffIncrementalSkew(
+	w io.Writer, sessions []sync.SessionDiff, verbose bool,
+) {
+	var skew []sync.SessionDiff
+	for _, s := range sessions {
+		if s.Class == sync.DiffIncrementalSkew {
+			skew = append(skew, s)
+		}
+	}
+	if len(skew) == 0 {
+		return
+	}
+	fmt.Fprintln(w,
+		"Incremental-skew sessions "+
+			"(last written incrementally; not counted as drift)")
+	if verbose {
+		for _, s := range skew {
+			renderParseDiffSessionVerbose(w, s)
+		}
+		fmt.Fprintln(w)
+		return
+	}
+	shown := skew
+	if len(shown) > parseDiffChangedCap {
+		shown = shown[:parseDiffChangedCap]
+	}
+	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+	for _, s := range shown {
+		fmt.Fprintf(tw, "  %s\t%s\t%s\n",
+			sanitizeTerminal(s.Agent),
+			sanitizeTerminal(shortID(s.SessionID)),
+			sanitizeTerminal(parseDiffFieldSummary(s.Fields)))
+	}
+	tw.Flush()
+	if extra := len(skew) - len(shown); extra > 0 {
 		fmt.Fprintf(w, "  ... (%d more; use --verbose or --json)\n",
 			extra)
 	}

--- a/cmd/agentsview/parse_diff_test.go
+++ b/cmd/agentsview/parse_diff_test.go
@@ -362,6 +362,18 @@ func changedSession(
 	}
 }
 
+// skewSession builds a DiffIncrementalSkew SessionDiff fixture.
+func skewSession(
+	agent, id string, fields ...sync.FieldDiff,
+) sync.SessionDiff {
+	return sync.SessionDiff{
+		SessionID: id,
+		Agent:     agent,
+		Class:     sync.DiffIncrementalSkew,
+		Fields:    fields,
+	}
+}
+
 func TestRenderParseDiffReport_ChangedSessions(t *testing.T) {
 	r := &sync.ParseDiffReport{
 		GeneratedAt:   "2026-06-12T00:00:00Z",
@@ -512,6 +524,112 @@ func TestRenderParseDiffReport_CapAndVerbose(t *testing.T) {
 			"first_message: old -> new (lengths 3 vs 3)")
 		assert.Contains(t, out,
 			"termination_status: completed -> (null) [informational]")
+	})
+}
+
+func TestRenderParseDiffReport_IncrementalSkewCapAndVerbose(t *testing.T) {
+	var sessions []sync.SessionDiff
+	for i := range parseDiffChangedCap + 5 {
+		sessions = append(sessions, skewSession(
+			"claude",
+			fmt.Sprintf("skew-%02d", i),
+			sync.FieldDiff{
+				Field:  sync.FieldFirstMessage,
+				Stored: "old",
+				Parsed: "new",
+			},
+		))
+	}
+	r := &sync.ParseDiffReport{
+		Totals: sync.ParseDiffTotals{
+			Examined:        len(sessions),
+			IncrementalSkew: len(sessions),
+		},
+		Sessions: sessions,
+	}
+
+	t.Run("capped", func(t *testing.T) {
+		var buf bytes.Buffer
+		renderParseDiffReport(&buf, r, "db", "all agents", false)
+		out := buf.String()
+
+		assert.Contains(t, out, "Incremental-skew sessions",
+			"the skew drill-down section must be present")
+		assert.Contains(t, out,
+			"... (5 more; use --verbose or --json)")
+		assert.Contains(t, out, "skew-00")
+		assert.Contains(t, out,
+			fmt.Sprintf("skew-%02d", parseDiffChangedCap-1))
+		assert.NotContains(t, out,
+			fmt.Sprintf("skew-%02d", parseDiffChangedCap),
+			"sessions past the cap must be elided")
+		assert.Contains(t, out, "Incremental skew",
+			"the summary must include the incremental-skew line")
+	})
+
+	t.Run("verbose", func(t *testing.T) {
+		var buf bytes.Buffer
+		renderParseDiffReport(&buf, r, "db", "all agents", true)
+		out := buf.String()
+
+		assert.NotContains(t, out, "more; use --verbose",
+			"verbose output is never capped")
+		assert.Contains(t, out,
+			fmt.Sprintf("skew-%02d", parseDiffChangedCap+4),
+			"verbose lists every skew session")
+		assert.Contains(t, out, "first_message: old -> new")
+	})
+}
+
+// TestRenderParseDiffReport_ResyncNote pins the resync-baseline
+// recommendation: the note appears only when the report carries
+// incremental-skew sessions, and is absent otherwise.
+func TestRenderParseDiffReport_ResyncNote(t *testing.T) {
+	t.Run("note present when incremental skew > 0", func(t *testing.T) {
+		r := &sync.ParseDiffReport{
+			Totals: sync.ParseDiffTotals{
+				Examined:        2,
+				Identical:       1,
+				IncrementalSkew: 1,
+			},
+			Sessions: []sync.SessionDiff{
+				skewSession("claude", "skew-1", sync.FieldDiff{
+					Field:  sync.FieldFirstMessage,
+					Stored: "a", Parsed: "b",
+				}),
+			},
+		}
+		var buf bytes.Buffer
+		renderParseDiffReport(&buf, r, "db", "all agents", false)
+		out := buf.String()
+		assert.Contains(t, out,
+			"1 session(s) were last written through the "+
+				"incremental-append path",
+			"the resync note must report the skew count")
+		assert.Contains(t, out, "Run a full resync",
+			"the resync note must recommend a resync")
+	})
+
+	t.Run("note absent without incremental skew", func(t *testing.T) {
+		r := &sync.ParseDiffReport{
+			Totals: sync.ParseDiffTotals{
+				Examined:  2,
+				Identical: 1,
+				Changed:   1,
+			},
+			FieldCounts: map[string]int{sync.FieldFirstMessage: 1},
+			Sessions: []sync.SessionDiff{
+				changedSession("claude", "chg-1", sync.FieldDiff{
+					Field:  sync.FieldFirstMessage,
+					Stored: "a", Parsed: "b",
+				}),
+			},
+		}
+		var buf bytes.Buffer
+		renderParseDiffReport(&buf, r, "db", "all agents", false)
+		out := buf.String()
+		assert.NotContains(t, out, "incremental-append path",
+			"the resync note must not appear without skew sessions")
 	})
 }
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1248,6 +1248,16 @@ func (db *DB) migrateColumns() error {
 			"ALTER TABLE sessions ADD COLUMN is_truncated INTEGER NOT NULL DEFAULT 0",
 		},
 		{
+			// Non-destructive column add: no dataVersion bump and no
+			// resync. The column defaults false and self-heals to true on
+			// the next incremental write of each row; a pre-migration
+			// archive simply reads false everywhere until then, which
+			// keeps parse-diff scrutiny conservative (drift is reported,
+			// never masked) rather than the reverse.
+			"sessions", "last_write_incremental",
+			"ALTER TABLE sessions ADD COLUMN last_write_incremental INTEGER NOT NULL DEFAULT 0",
+		},
+		{
 			"sessions", "file_inode",
 			"ALTER TABLE sessions ADD COLUMN file_inode INTEGER",
 		},

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -5602,6 +5602,65 @@ func TestUpdateSessionIncremental(t *testing.T) {
 	assert.Equal(t, "abc123", *got.FileHash, "FileHash")
 }
 
+// TestLastWriteIncrementalMarker pins the parse-diff detection signal:
+// the full-write path (UpsertSession) leaves last_write_incremental
+// false, an incremental append (WriteSessionIncremental) sets it true,
+// and a later full write of the same ID resets it to false. This is the
+// per-session ground truth parse-diff reads to classify incremental
+// skew, so its set/reset behavior across both write paths must hold.
+func TestLastWriteIncrementalMarker(t *testing.T) {
+	d := testDB(t)
+
+	base := Session{
+		ID:               "inc-marker",
+		Project:          "proj",
+		Machine:          "test",
+		Agent:            "claude",
+		FirstMessage:     new("hello"),
+		StartedAt:        new("2024-01-15T10:00:00Z"),
+		MessageCount:     1,
+		UserMessageCount: 1,
+		FilePath:         new("/tmp/sessions/inc-marker.jsonl"),
+		FileSize:         new(int64(512)),
+		FileMtime:        new(int64(100)),
+	}
+	requireNoError(t, d.UpsertSession(base), "initial full upsert")
+
+	got, err := d.GetSessionFull(context.Background(), "inc-marker")
+	requireNoError(t, err, "get after full upsert")
+	require.NotNil(t, got, "session after full upsert")
+	assert.False(t, got.LastWriteIncremental,
+		"full write path must leave last_write_incremental false")
+
+	requireNoError(t, d.WriteSessionIncremental(
+		"inc-marker",
+		[]Message{asstMsg("inc-marker", 1, "appended reply")},
+		IncrementalSessionUpdate{
+			MsgCount:     2,
+			UserMsgCount: 1,
+			FileSize:     1024,
+			FileMtime:    200,
+			NextOrdinal:  2,
+		},
+	), "incremental write")
+
+	got, err = d.GetSessionFull(context.Background(), "inc-marker")
+	requireNoError(t, err, "get after incremental write")
+	require.NotNil(t, got, "session after incremental write")
+	assert.True(t, got.LastWriteIncremental,
+		"incremental append must set last_write_incremental true")
+
+	// A subsequent full re-normalization of the same ID clears it: this
+	// is the self-heal a full resync relies on to restore parse-diff
+	// scrutiny.
+	requireNoError(t, d.UpsertSession(base), "second full upsert")
+	got, err = d.GetSessionFull(context.Background(), "inc-marker")
+	requireNoError(t, err, "get after second full upsert")
+	require.NotNil(t, got, "session after second full upsert")
+	assert.False(t, got.LastWriteIncremental,
+		"a full re-normalization must clear last_write_incremental")
+}
+
 func TestIncrementalWriteAtomicityRollsBackMessages(t *testing.T) {
 	d := testDB(t)
 	insertSession(t, d, "atomic-target", "proj")

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -5603,11 +5603,13 @@ func TestUpdateSessionIncremental(t *testing.T) {
 }
 
 // TestLastWriteIncrementalMarker pins the parse-diff detection signal:
-// the full-write path (UpsertSession) leaves last_write_incremental
+// a fresh full write (UpsertSession) leaves last_write_incremental
 // false, an incremental append (WriteSessionIncremental) sets it true,
-// and a later full write of the same ID resets it to false. This is the
-// per-session ground truth parse-diff reads to classify incremental
-// skew, so its set/reset behavior across both write paths must hold.
+// a bare UpsertSession afterward PRESERVES it (it rewrites only the
+// session row, not the still-incremental message rows), and only a full
+// message re-normalization (ReplaceSessionMessages) clears it. This is
+// the per-session ground truth parse-diff reads to classify incremental
+// skew, so its set/reset behavior across these write paths must hold.
 func TestLastWriteIncrementalMarker(t *testing.T) {
 	d := testDB(t)
 
@@ -5650,15 +5652,93 @@ func TestLastWriteIncrementalMarker(t *testing.T) {
 	assert.True(t, got.LastWriteIncremental,
 		"incremental append must set last_write_incremental true")
 
-	// A subsequent full re-normalization of the same ID clears it: this
-	// is the self-heal a full resync relies on to restore parse-diff
-	// scrutiny.
+	// A bare UpsertSession rewrites only the session row, not the message
+	// rows, so it must PRESERVE the marker: the stored messages are still
+	// the incrementally appended ones. Clearing here (as an earlier
+	// implementation did) would make parse-diff report that still-present
+	// benign skew as real drift after any routine append-only full-parse
+	// sync (Claude/Codex take ReplaceMessages=false).
 	requireNoError(t, d.UpsertSession(base), "second full upsert")
 	got, err = d.GetSessionFull(context.Background(), "inc-marker")
 	requireNoError(t, err, "get after second full upsert")
 	require.NotNil(t, got, "session after second full upsert")
+	assert.True(t, got.LastWriteIncremental,
+		"a bare session upsert must preserve the marker (messages not re-normalized)")
+
+	// A full message re-normalization clears it: this is the self-heal a
+	// full resync relies on to restore parse-diff scrutiny.
+	requireNoError(t, d.ReplaceSessionMessages(
+		"inc-marker",
+		[]Message{asstMsg("inc-marker", 1, "renormalized reply")},
+	), "full message replace")
+	got, err = d.GetSessionFull(context.Background(), "inc-marker")
+	requireNoError(t, err, "get after full message replace")
+	require.NotNil(t, got, "session after full message replace")
 	assert.False(t, got.LastWriteIncremental,
-		"a full re-normalization must clear last_write_incremental")
+		"a full message re-normalization must clear last_write_incremental")
+}
+
+// TestBatchWriteIncrementalMarkerReplaceMode pins the batch-path half of
+// the marker contract: the routine full-parse batch path takes
+// ReplaceMessages=false for append-only agents (Claude/Codex), where it
+// upserts the session row and appends new messages but does NOT rewrite
+// earlier incrementally written rows. That path must PRESERVE the marker;
+// only a ReplaceMessages=true batch, which deletes and reinserts every
+// row, may clear it. Without this, a single routine sync flips a benign
+// incremental_skew session into a spurious DiffChanged.
+func TestBatchWriteIncrementalMarkerReplaceMode(t *testing.T) {
+	d := testDB(t)
+
+	base := Session{
+		ID:               "batch-marker",
+		Project:          "proj",
+		Machine:          defaultMachine,
+		Agent:            "claude",
+		FirstMessage:     new("hello"),
+		StartedAt:        new("2024-01-15T10:00:00Z"),
+		MessageCount:     1,
+		UserMessageCount: 1,
+	}
+	requireNoError(t, d.UpsertSession(base), "initial upsert")
+	requireNoError(t, d.WriteSessionIncremental(
+		"batch-marker",
+		[]Message{asstMsg("batch-marker", 1, "appended reply")},
+		IncrementalSessionUpdate{MsgCount: 2, UserMsgCount: 1, NextOrdinal: 2},
+	), "incremental write")
+
+	got, err := d.GetSessionFull(context.Background(), "batch-marker")
+	requireNoError(t, err, "get after incremental write")
+	require.NotNil(t, got, "session after incremental write")
+	require.True(t, got.LastWriteIncremental, "marker set by incremental write")
+
+	// Append-only full-parse batch (ReplaceMessages=false): must preserve.
+	appendOnly := []Message{userMsg("batch-marker", 0, "hello"), asstMsg("batch-marker", 2, "next")}
+	_, err = d.WriteSessionBatch([]SessionBatchWrite{{
+		Session:         base,
+		Messages:        appendOnly,
+		DataVersion:     CurrentDataVersion(),
+		ReplaceMessages: false,
+	}})
+	requireNoError(t, err, "append-only batch write")
+	got, err = d.GetSessionFull(context.Background(), "batch-marker")
+	requireNoError(t, err, "get after append-only batch")
+	require.NotNil(t, got, "session after append-only batch")
+	assert.True(t, got.LastWriteIncremental,
+		"append-only batch (ReplaceMessages=false) must preserve the marker")
+
+	// Full-replace batch (ReplaceMessages=true): must clear.
+	_, err = d.WriteSessionBatch([]SessionBatchWrite{{
+		Session:         base,
+		Messages:        []Message{userMsg("batch-marker", 0, "hello")},
+		DataVersion:     CurrentDataVersion(),
+		ReplaceMessages: true,
+	}})
+	requireNoError(t, err, "full-replace batch write")
+	got, err = d.GetSessionFull(context.Background(), "batch-marker")
+	requireNoError(t, err, "get after full-replace batch")
+	require.NotNil(t, got, "session after full-replace batch")
+	assert.False(t, got.LastWriteIncremental,
+		"full-replace batch (ReplaceMessages=true) must clear the marker")
 }
 
 func TestIncrementalWriteAtomicityRollsBackMessages(t *testing.T) {

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -595,6 +595,11 @@ func (db *DB) ReplaceSessionMessages(
 	} else if err := replaceSessionMessagesTx(tx, sessionID, msgs); err != nil {
 		return err
 	}
+	// A full message replacement re-normalizes every row, so clear the
+	// incremental-append marker parse-diff reads (see resetIncrementalMarkerTx).
+	if err := resetIncrementalMarkerTx(tx, sessionID); err != nil {
+		return err
+	}
 	if err := updateSessionAutomationFromMessagesTx(tx, sessionID); err != nil {
 		return err
 	}
@@ -735,6 +740,11 @@ func (db *DB) ReplaceSessionContent(
 			return err
 		}
 	} else if err := replaceSessionMessagesTx(tx, sessionID, msgs); err != nil {
+		return err
+	}
+	// Every message row is now the full-parse shape, so this row is no
+	// longer incremental-append skew: clear the marker parse-diff reads.
+	if err := resetIncrementalMarkerTx(tx, sessionID); err != nil {
 		return err
 	}
 	if err := updateSessionAutomationFromMessagesTx(tx, sessionID); err != nil {

--- a/internal/db/orphaned.go
+++ b/internal/db/orphaned.go
@@ -630,7 +630,7 @@ func orphanSessionCols(ctx context.Context, tx *sql.Tx) string {
 		"runaway_tool_loop_count",
 		"cwd", "git_branch", "source_session_id",
 		"source_version", "transcript_fidelity", "parser_malformed_lines",
-		"is_truncated",
+		"is_truncated", "last_write_incremental",
 		"secret_leak_count", "secrets_rules_version",
 	} {
 		if oldDBHasColumn(ctx, tx, "sessions", c) {

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -59,6 +59,12 @@ CREATE TABLE IF NOT EXISTS sessions (
     transcript_fidelity TEXT NOT NULL DEFAULT '',
     parser_malformed_lines INTEGER NOT NULL DEFAULT 0,
     is_truncated INTEGER NOT NULL DEFAULT 0,
+    -- SQLite-only sync bookkeeping (like next_ordinal): TRUE when the
+    -- last write to this row went through the incremental-append path
+    -- rather than a full re-normalization. Consumed only by parse-diff
+    -- to suppress benign incremental-vs-full skew; deliberately not
+    -- mirrored to PG/DuckDB.
+    last_write_incremental INTEGER NOT NULL DEFAULT 0,
     deleted_at  TEXT,
     created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
     termination_status TEXT,

--- a/internal/db/session_batch.go
+++ b/internal/db/session_batch.go
@@ -346,6 +346,13 @@ func writeOneSessionBatchTx(
 		if err := restorePinsTx(tx, write.Session.ID, pins); err != nil {
 			return 0, err
 		}
+		// A full message replacement re-normalizes every row, so this row is
+		// no longer incremental-append skew. The append-only branch
+		// (ReplaceMessages=false) deliberately leaves the marker untouched so
+		// earlier incrementally written rows stay flagged for parse-diff.
+		if err := resetIncrementalMarkerTx(tx, write.Session.ID); err != nil {
+			return 0, err
+		}
 	}
 	if err := updateSessionAutomationFromMessagesTx(
 		tx, write.Session.ID,

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -115,6 +115,7 @@ const sessionFullCols = `id, project, machine, agent,
 	cwd, git_branch, source_session_id, source_version,
 	transcript_fidelity,
 	parser_malformed_lines, is_truncated,
+	last_write_incremental,
 	deleted_at, termination_status, file_path, file_size, file_mtime,
 	next_ordinal, last_entry_uuid,
 	file_inode, file_device,
@@ -328,11 +329,20 @@ type Session struct {
 	FileMtime         *int64  `json:"file_mtime,omitempty"`
 	NextOrdinal       int     `json:"-"`
 	LastEntryUUID     *string `json:"-"`
-	FileInode         *int64  `json:"file_inode,omitempty"`
-	FileDevice        *int64  `json:"file_device,omitempty"`
-	FileHash          *string `json:"file_hash,omitempty"`
-	LocalModifiedAt   *string `json:"local_modified_at,omitempty"`
-	CreatedAt         string  `json:"created_at"`
+	// LastWriteIncremental is SQLite-only sync bookkeeping (like
+	// NextOrdinal): true when the last write to this row went through
+	// the incremental-append path (updateSessionIncrementalTx) instead
+	// of a full re-normalization (upsertSessionArgs, which always resets
+	// it to false). It is consumed only by parse-diff to classify benign
+	// incremental-vs-full skew and is json:"-" so it never leaks through
+	// the HTTP session API. Deliberately not mirrored to PG/DuckDB: their
+	// push column lists omit the whole sync-bookkeeping cluster.
+	LastWriteIncremental bool    `json:"-"`
+	FileInode            *int64  `json:"file_inode,omitempty"`
+	FileDevice           *int64  `json:"file_device,omitempty"`
+	FileHash             *string `json:"file_hash,omitempty"`
+	LocalModifiedAt      *string `json:"local_modified_at,omitempty"`
+	CreatedAt            string  `json:"created_at"`
 }
 
 // SessionCursor is the opaque pagination token. EndedAt carries the
@@ -1054,6 +1064,7 @@ func (db *DB) GetSessionFull(
 		&s.SourceSessionID, &s.SourceVersion,
 		&s.TranscriptFidelity,
 		&s.ParserMalformedLines, &s.IsTruncated,
+		&s.LastWriteIncremental,
 		&s.DeletedAt, &s.TerminationStatus, &s.FilePath, &s.FileSize,
 		&s.FileMtime, &s.NextOrdinal, &s.LastEntryUUID,
 		&s.FileInode, &s.FileDevice,
@@ -1206,10 +1217,11 @@ const upsertSessionSQL = `
 			source_version, transcript_fidelity,
 			parser_malformed_lines,
 			is_truncated,
+			last_write_incremental,
 			file_path, file_size, file_mtime,
 			next_ordinal, last_entry_uuid,
 			file_inode, file_device, file_hash
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 			project = excluded.project,
 			machine = excluded.machine,
@@ -1237,6 +1249,9 @@ const upsertSessionSQL = `
 			transcript_fidelity = excluded.transcript_fidelity,
 			parser_malformed_lines = excluded.parser_malformed_lines,
 			is_truncated = excluded.is_truncated,
+			-- A full re-normalization always clears the incremental marker:
+			-- the excluded row carries the literal false from upsertSessionArgs.
+			last_write_incremental = excluded.last_write_incremental,
 			file_path = excluded.file_path,
 			file_size = excluded.file_size,
 			file_mtime = excluded.file_mtime,
@@ -1267,6 +1282,12 @@ func upsertSessionArgs(s Session) []any {
 		s.SourceVersion, s.TranscriptFidelity,
 		s.ParserMalformedLines,
 		s.IsTruncated,
+		// last_write_incremental is always false on the full-write path:
+		// this row was re-normalized, not incrementally appended. Passing
+		// the literal (rather than s.LastWriteIncremental) makes the reset
+		// structural, and the ON CONFLICT clause propagates it via
+		// excluded.last_write_incremental.
+		false,
 		s.FilePath, s.FileSize, s.FileMtime,
 		s.NextOrdinal, s.LastEntryUUID,
 		s.FileInode, s.FileDevice, s.FileHash,
@@ -1814,7 +1835,12 @@ func updateSessionIncrementalTx(
 			peak_context_tokens = ?,
 			has_total_output_tokens = ?,
 			has_peak_context_tokens = ?,
-			termination_status = NULL
+			termination_status = NULL,
+			-- Mark the row as last written by the incremental-append path.
+			-- The full-replace writer (upsertSessionArgs) resets this to
+			-- false; parse-diff reads it to classify benign
+			-- incremental-vs-full skew.
+			last_write_incremental = 1
 		WHERE id = ?`,
 		update.EndedAt, update.MsgCount, update.UserMsgCount,
 		update.FileSize, update.FileMtime,
@@ -3000,6 +3026,7 @@ func (db *DB) ListSessionsModifiedBetween(
 			&s.SourceSessionID, &s.SourceVersion,
 			&s.TranscriptFidelity,
 			&s.ParserMalformedLines, &s.IsTruncated,
+			&s.LastWriteIncremental,
 			&s.DeletedAt, &s.TerminationStatus, &s.FilePath, &s.FileSize,
 			&s.FileMtime, &s.NextOrdinal, &s.LastEntryUUID,
 			&s.FileInode, &s.FileDevice,

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -1249,9 +1249,15 @@ const upsertSessionSQL = `
 			transcript_fidelity = excluded.transcript_fidelity,
 			parser_malformed_lines = excluded.parser_malformed_lines,
 			is_truncated = excluded.is_truncated,
-			-- A full re-normalization always clears the incremental marker:
-			-- the excluded row carries the literal false from upsertSessionArgs.
-			last_write_incremental = excluded.last_write_incremental,
+			-- last_write_incremental is deliberately NOT touched on conflict.
+			-- A bare upsert rewrites only the session row, not the message
+			-- rows, so it is not a re-normalization: the append-only full-parse
+			-- path (Claude/Codex, ReplaceMessages=false) upserts the session and
+			-- appends new messages while leaving earlier incrementally written
+			-- rows in place. Clearing the marker here would make parse-diff
+			-- report that still-present benign skew as real drift. The marker is
+			-- reset only by a genuine full message replacement
+			-- (resetIncrementalMarkerTx), and seeded false on fresh INSERT.
 			file_path = excluded.file_path,
 			file_size = excluded.file_size,
 			file_mtime = excluded.file_mtime,
@@ -1282,11 +1288,10 @@ func upsertSessionArgs(s Session) []any {
 		s.SourceVersion, s.TranscriptFidelity,
 		s.ParserMalformedLines,
 		s.IsTruncated,
-		// last_write_incremental is always false on the full-write path:
-		// this row was re-normalized, not incrementally appended. Passing
-		// the literal (rather than s.LastWriteIncremental) makes the reset
-		// structural, and the ON CONFLICT clause propagates it via
-		// excluded.last_write_incremental.
+		// last_write_incremental is seeded false on fresh INSERT: a brand-new
+		// row starts fully normalized. On conflict the column is left as-is
+		// (see upsertSessionSQL) because a bare upsert does not re-normalize
+		// the stored messages; only a full message replacement clears it.
 		false,
 		s.FilePath, s.FileSize, s.FileMtime,
 		s.NextOrdinal, s.LastEntryUUID,
@@ -1889,6 +1894,27 @@ func (db *DB) UpdateSessionIncremental(
 	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("committing incremental update tx: %w", err)
+	}
+	return nil
+}
+
+// resetIncrementalMarkerTx clears last_write_incremental after a full
+// message re-normalization. It is the counterpart to the marker set in
+// updateSessionIncrementalTx: parse-diff reads the marker to suppress
+// benign incremental-append skew, so only a path that actually rewrites
+// every message row to the full-parse shape (ReplaceSessionContent,
+// ReplaceSessionMessages, the batch ReplaceMessages branch) may clear it.
+// A bare UpsertSession or an append-only write must not, or the
+// suppression self-heals prematurely and still-present skew reappears as
+// spurious drift.
+func resetIncrementalMarkerTx(tx *sql.Tx, sessionID string) error {
+	if _, err := tx.Exec(
+		`UPDATE sessions SET last_write_incremental = 0 WHERE id = ?`,
+		sessionID,
+	); err != nil {
+		return fmt.Errorf(
+			"resetting incremental marker for %s: %w", sessionID, err,
+		)
 	}
 	return nil
 }

--- a/internal/sync/parsediff.go
+++ b/internal/sync/parsediff.go
@@ -738,19 +738,28 @@ func (e *Engine) parseDiffCollectFile(
 
 		// Incremental-append skew: the stored row was last written by the
 		// incremental-append path (last_write_incremental), so a full
-		// re-parse legitimately differs on the fields that path leaves
-		// frozen or recomputes. Only meaningful when there is a real change
-		// to reclassify, and only when the session was actually compared (a
-		// nil stored row cannot carry the flag). Ranked below raced -- if
-		// the source also demonstrably moved past its snapshot, the mtime
-		// race is the stronger, directly provable diagnosis -- so this is
-		// gated on !raced. Unlike the raced guard this needs no
-		// agent/source reliability check: the flag is per-session ground
-		// truth recorded by the exact write path being diagnosed, so it
-		// generalizes to whatever provider took the incremental path rather
-		// than a hardcoded agent list.
+		// re-parse legitimately differs on the ordinal-shape / per-message
+		// metadata surface. Only meaningful when there is a real change to
+		// reclassify, and only when the session was actually compared (a nil
+		// stored row cannot carry the flag). Ranked below raced -- if the
+		// source also demonstrably moved past its snapshot, the mtime race
+		// is the stronger, directly provable diagnosis -- so this is gated
+		// on !raced. Unlike the raced guard this needs no agent/source
+		// reliability check: the flag is per-session ground truth recorded
+		// by the exact write path being diagnosed, so it generalizes to
+		// whatever provider took the incremental path rather than a
+		// hardcoded agent list.
+		//
+		// The reclassification is confined to the incremental-artifact
+		// fields (diffsConfinedToIncrementalArtifacts): a marker alone is
+		// not enough, because it is session-level while a regression is
+		// field-level. A non-informational diff outside that allow-list
+		// (first_message, message_content, usage totals, tool_calls, ...) is
+		// genuine parser drift that must stay DiffChanged even on an
+		// incrementally written row, so the marker cannot mask it.
 		incrementalSkew := realDiffs > 0 && compare && !raced &&
-			stored != nil && stored.LastWriteIncremental
+			stored != nil && stored.LastWriteIncremental &&
+			diffsConfinedToIncrementalArtifacts(fields)
 
 		class, reason := classifyParseDiffSession(
 			pw.needsRetry,

--- a/internal/sync/parsediff.go
+++ b/internal/sync/parsediff.go
@@ -180,13 +180,14 @@ func (e *Engine) ParseDiff(ctx context.Context, opts ParseDiffOptions) (*ParseDi
 		report, storedSessions, resolvedSet,
 		len(opts.Agents) == 0, cutPaths, visited,
 	)
-	// Raced sessions were compared against a fresh parse just like the
-	// others, so they count toward Examined; they are simply not counted
-	// as drift. Keeping them in Examined also keeps VacuousResync honest:
-	// a run with comparable (raced) sessions is not "all pending resync".
+	// Raced and incremental-skew sessions were compared against a fresh
+	// parse just like the others, so they count toward Examined; they are
+	// simply not counted as drift. Keeping them in Examined also keeps
+	// VacuousResync honest: a run with comparable (raced or skew) sessions
+	// is not "all pending resync".
 	report.Totals.Examined = report.Totals.Identical +
 		report.Totals.Changed + report.Totals.PendingResync +
-		report.Totals.Raced
+		report.Totals.Raced + report.Totals.IncrementalSkew
 
 	sort.Slice(report.Sessions, func(i, j int) bool {
 		a, b := report.Sessions[i], report.Sessions[j]
@@ -735,6 +736,22 @@ func (e *Engine) parseDiffCollectFile(
 			}
 		}
 
+		// Incremental-append skew: the stored row was last written by the
+		// incremental-append path (last_write_incremental), so a full
+		// re-parse legitimately differs on the fields that path leaves
+		// frozen or recomputes. Only meaningful when there is a real change
+		// to reclassify, and only when the session was actually compared (a
+		// nil stored row cannot carry the flag). Ranked below raced -- if
+		// the source also demonstrably moved past its snapshot, the mtime
+		// race is the stronger, directly provable diagnosis -- so this is
+		// gated on !raced. Unlike the raced guard this needs no
+		// agent/source reliability check: the flag is per-session ground
+		// truth recorded by the exact write path being diagnosed, so it
+		// generalizes to whatever provider took the incremental path rather
+		// than a hardcoded agent list.
+		incrementalSkew := realDiffs > 0 && compare && !raced &&
+			stored != nil && stored.LastWriteIncremental
+
 		class, reason := classifyParseDiffSession(
 			pw.needsRetry,
 			ok,
@@ -743,6 +760,7 @@ func (e *Engine) parseDiffCollectFile(
 			stored != nil && stored.DataVersion < db.CurrentDataVersion(),
 			realDiffs,
 			raced,
+			incrementalSkew,
 		)
 
 		entry := SessionDiff{
@@ -786,6 +804,13 @@ func (e *Engine) parseDiffCollectFile(
 			// FieldCounts and from HasFailures so --fail-on-change stays
 			// trustworthy.
 			report.Totals.Raced++
+			report.Sessions = append(report.Sessions, entry)
+		case DiffIncrementalSkew:
+			// Inconclusive (incremental-vs-full skew): listed for
+			// visibility with its field diffs attached for drill-down, but
+			// excluded from FieldCounts and from HasFailures so
+			// --fail-on-change stays trustworthy, exactly like DiffRaced.
+			report.Totals.IncrementalSkew++
 			report.Sessions = append(report.Sessions, entry)
 		case DiffSkipped:
 			// A re-parsed but trashed session: counted with the rest

--- a/internal/sync/parsediff_compare.go
+++ b/internal/sync/parsediff_compare.go
@@ -365,6 +365,51 @@ func usesIncrementalAppend(agent string) bool {
 		agent == string(parser.AgentCodex)
 }
 
+// incrementalArtifactField reports whether a non-informational diff on
+// the named field can be a legitimate incremental-append-vs-full-reparse
+// artifact rather than parser drift. The incremental-append path appends
+// already-normalized message rows and recomputes the session aggregates
+// to absolute values, so per-message content/tokens/models/tool_calls,
+// the head-derived first_message/started_at, and the recomputed
+// aggregates all stay byte-stable against a full re-parse -- a difference
+// there is genuine drift the marker must not mask. Only the ordinal-shape
+// / per-message metadata surface (role/timestamp/flags/source ids, i.e.
+// FieldMessageMetadata) can legitimately reshape when a whole-file
+// re-parse aligns records differently than the tail parse did.
+//
+// Empirically -- parse-diff over the real archive -- even that surface
+// does not materialize for quiescent, current-version incremental rows
+// (0 skew, 0 changed across the Claude/Codex corpus; the only observed
+// per-message metadata drift was on a live-write raced session, which
+// outranks skew). So this allow-list is a deliberately conservative
+// safety net, not a routinely hit path: the session fields the
+// incremental path actually freezes are already marked Informational
+// (termination_status, session_name, cwd, ...) and never reach here.
+func incrementalArtifactField(field string) bool {
+	return field == FieldMessageMetadata
+}
+
+// diffsConfinedToIncrementalArtifacts reports whether every
+// non-informational diff is on the incremental-artifact allow-list, the
+// precondition for reclassifying a row last written incrementally as
+// benign incremental_skew. A single non-informational diff outside the
+// allow-list (first_message, message_content, usage totals, tool_calls,
+// aggregates, ...) is genuine parser drift the marker must not suppress,
+// so the caller keeps the session DiffChanged. Informational diffs (the
+// frozen session fields) are ignored: they never make a session change in
+// the first place.
+func diffsConfinedToIncrementalArtifacts(fields []FieldDiff) bool {
+	for _, f := range fields {
+		if f.Informational {
+			continue
+		}
+		if !incrementalArtifactField(f.Field) {
+			return false
+		}
+	}
+	return true
+}
+
 // tokenAggregateDiffers compares a session token aggregate as a
 // (value, has-flag) unit. A coverage-flag flip is a real difference
 // even when the numeric values match; values are only meaningful
@@ -1206,11 +1251,14 @@ func compareUsageEvents(
 //     than parser drift. Only meaningful when realDiffs > 0; an
 //     unchanged session is identical regardless of a mid-run write.
 //   - incrementalSkew: the stored row was last written through the
-//     incremental-append path, so a full re-parse legitimately differs on
-//     the fields that path leaves frozen or recomputes. Also only
-//     meaningful when realDiffs > 0. It sits below raced: when both apply,
-//     raced wins because the advanced mtime is the stronger, directly
-//     provable diagnosis.
+//     incremental-append path AND every non-informational diff is confined
+//     to the incremental-artifact allow-list (the caller folds
+//     diffsConfinedToIncrementalArtifacts into this flag), so a full
+//     re-parse legitimately differs only on the ordinal-shape surface. A
+//     regression on any other field keeps the session DiffChanged. Also
+//     only meaningful when realDiffs > 0. It sits below raced: when both
+//     apply, raced wins because the advanced mtime is the stronger,
+//     directly provable diagnosis.
 func classifyParseDiffSession(
 	needsRetry, prepared, hasStored, storedTrashed,
 	pendingResync bool,

--- a/internal/sync/parsediff_compare.go
+++ b/internal/sync/parsediff_compare.go
@@ -1205,11 +1205,17 @@ func compareUsageEvents(
 //     would-be change is a torn comparison against live content rather
 //     than parser drift. Only meaningful when realDiffs > 0; an
 //     unchanged session is identical regardless of a mid-run write.
+//   - incrementalSkew: the stored row was last written through the
+//     incremental-append path, so a full re-parse legitimately differs on
+//     the fields that path leaves frozen or recomputes. Also only
+//     meaningful when realDiffs > 0. It sits below raced: when both apply,
+//     raced wins because the advanced mtime is the stronger, directly
+//     provable diagnosis.
 func classifyParseDiffSession(
 	needsRetry, prepared, hasStored, storedTrashed,
 	pendingResync bool,
 	realDiffs int,
-	raced bool,
+	raced, incrementalSkew bool,
 ) (DiffClass, string) {
 	switch {
 	case needsRetry:
@@ -1232,6 +1238,12 @@ func classifyParseDiffSession(
 		// A change against a source the daemon (or an active session)
 		// rewrote after the snapshot: inconclusive, not parser drift.
 		return DiffRaced, "source file changed after snapshot (live-write skew)"
+	case realDiffs > 0 && incrementalSkew:
+		// A change against a row last written incrementally: a full
+		// re-parse legitimately diverges from the frozen/incremental
+		// state, so this is comparison-basis skew, not parser drift.
+		return DiffIncrementalSkew,
+			"stored row last written incrementally (incremental-append skew)"
 	case realDiffs > 0:
 		return DiffChanged, ""
 	default:

--- a/internal/sync/parsediff_compare_test.go
+++ b/internal/sync/parsediff_compare_test.go
@@ -1607,6 +1607,78 @@ func TestParseDiffClassifyPrecedence(t *testing.T) {
 	}
 }
 
+func TestDiffsConfinedToIncrementalArtifacts(t *testing.T) {
+	tests := []struct {
+		name   string
+		fields []FieldDiff
+		want   bool
+	}{
+		{
+			name: "message_metadata alone is an incremental artifact",
+			fields: []FieldDiff{
+				{Field: FieldMessageMetadata},
+			},
+			want: true,
+		},
+		{
+			name: "informational session fields are ignored",
+			fields: []FieldDiff{
+				{Field: FieldTerminationStatus, Informational: true},
+				{Field: FieldSessionName, Informational: true},
+				{Field: FieldMessageMetadata},
+			},
+			want: true,
+		},
+		{
+			name:   "no diffs are vacuously confined",
+			fields: nil,
+			want:   true,
+		},
+		{
+			name: "first_message drift is not an artifact",
+			fields: []FieldDiff{
+				{Field: FieldFirstMessage},
+			},
+			want: false,
+		},
+		{
+			name: "message_content drift is not an artifact",
+			fields: []FieldDiff{
+				{Field: FieldMessageContent},
+			},
+			want: false,
+		},
+		{
+			name: "usage totals drift is not an artifact",
+			fields: []FieldDiff{
+				{Field: FieldTotalOutputTokens},
+			},
+			want: false,
+		},
+		{
+			name: "an artifact mixed with a non-artifact is not confined",
+			fields: []FieldDiff{
+				{Field: FieldMessageMetadata},
+				{Field: FieldFirstMessage},
+			},
+			want: false,
+		},
+		{
+			name: "tool_calls drift is not an artifact",
+			fields: []FieldDiff{
+				{Field: FieldToolCalls},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want,
+				diffsConfinedToIncrementalArtifacts(tt.fields))
+		})
+	}
+}
+
 // TestParseDiffSourceRaced pins the conservative mtime-skew verdict: a
 // source that moved past the snapshot mtime (or whose mtime cannot be
 // resolved) is raced; one that is demonstrably at or before the snapshot

--- a/internal/sync/parsediff_compare_test.go
+++ b/internal/sync/parsediff_compare_test.go
@@ -1495,22 +1495,23 @@ func pdFetchStored(t *testing.T, d *db.DB, id string) *db.Session {
 
 func TestParseDiffClassifyPrecedence(t *testing.T) {
 	tests := []struct {
-		name          string
-		needsRetry    bool
-		prepared      bool
-		hasStored     bool
-		storedTrashed bool
-		pendingResync bool
-		realDiffs     int
-		raced         bool
-		wantClass     DiffClass
-		wantReason    string
+		name            string
+		needsRetry      bool
+		prepared        bool
+		hasStored       bool
+		storedTrashed   bool
+		pendingResync   bool
+		realDiffs       int
+		raced           bool
+		incrementalSkew bool
+		wantClass       DiffClass
+		wantReason      string
 	}{
 		{
 			name:       "needs retry wins over everything",
 			needsRetry: true, prepared: false, hasStored: true,
 			storedTrashed: true, pendingResync: true, realDiffs: 3,
-			raced:      true,
+			raced: true, incrementalSkew: true,
 			wantClass:  DiffNeedsRetry,
 			wantReason: "transient low-fidelity parse; differences expected",
 		},
@@ -1545,10 +1546,31 @@ func TestParseDiffClassifyPrecedence(t *testing.T) {
 			wantClass: DiffPendingResync,
 		},
 		{
+			name:     "pending resync wins over incremental skew",
+			prepared: true, hasStored: true, pendingResync: true,
+			realDiffs: 2, incrementalSkew: true,
+			wantClass: DiffPendingResync,
+		},
+		{
 			name:     "raced wins over changed when source moved",
 			prepared: true, hasStored: true, realDiffs: 1, raced: true,
 			wantClass:  DiffRaced,
 			wantReason: "source file changed after snapshot (live-write skew)",
+		},
+		{
+			name:     "raced wins over incremental skew when both apply",
+			prepared: true, hasStored: true, realDiffs: 1,
+			raced: true, incrementalSkew: true,
+			wantClass:  DiffRaced,
+			wantReason: "source file changed after snapshot (live-write skew)",
+		},
+		{
+			name:     "incremental skew wins over changed",
+			prepared: true, hasStored: true, realDiffs: 1,
+			incrementalSkew: true,
+			wantClass:       DiffIncrementalSkew,
+			wantReason: "stored row last written incrementally " +
+				"(incremental-append skew)",
 		},
 		{
 			name:     "real diffs mean changed",
@@ -1561,6 +1583,12 @@ func TestParseDiffClassifyPrecedence(t *testing.T) {
 			wantClass: DiffIdentical,
 		},
 		{
+			name:     "incremental skew flag is inert without a real diff",
+			prepared: true, hasStored: true, realDiffs: 0,
+			incrementalSkew: true,
+			wantClass:       DiffIdentical,
+		},
+		{
 			name:     "no real diffs mean identical",
 			prepared: true, hasStored: true, realDiffs: 0,
 			wantClass: DiffIdentical,
@@ -1571,7 +1599,7 @@ func TestParseDiffClassifyPrecedence(t *testing.T) {
 			class, reason := classifyParseDiffSession(
 				tt.needsRetry, tt.prepared, tt.hasStored,
 				tt.storedTrashed, tt.pendingResync, tt.realDiffs,
-				tt.raced,
+				tt.raced, tt.incrementalSkew,
 			)
 			assert.Equal(t, tt.wantClass, class)
 			assert.Equal(t, tt.wantReason, reason)
@@ -2143,8 +2171,19 @@ func TestParseDiffReportHasFailures(t *testing.T) {
 			totals: ParseDiffTotals{Examined: 3, Identical: 2, Raced: 1},
 		},
 		{
+			name: "incremental-skew sessions alone do not fail",
+			totals: ParseDiffTotals{
+				Examined: 3, Identical: 2, IncrementalSkew: 1,
+			},
+		},
+		{
 			name:   "a real change still fails alongside raced sessions",
 			totals: ParseDiffTotals{Changed: 1, Raced: 2},
+			want:   true,
+		},
+		{
+			name:   "a real change still fails alongside incremental-skew",
+			totals: ParseDiffTotals{Changed: 1, IncrementalSkew: 2},
 			want:   true,
 		},
 	}

--- a/internal/sync/parsediff_integration_test.go
+++ b/internal/sync/parsediff_integration_test.go
@@ -1361,11 +1361,14 @@ func TestParseDiffIncrementalAppendSkewNotCountedAsChange(t *testing.T) {
 	require.True(t, afterAppend.LastWriteIncremental,
 		"the incremental append must set the marker via real code")
 
-	// Seed a real (non-informational) first_message drift on both
-	// sessions so a re-parse detects a change for each.
+	// Seed drift on both sessions. The incrementally written pd-skew gets a
+	// per-message metadata (timestamp) diff -- the ordinal-shape surface a
+	// full re-parse can legitimately reshape, so the marker may suppress it.
+	// The full-write control pd-full gets a first_message diff so a re-parse
+	// detects a change there too.
 	mutateDB(t, env,
-		"UPDATE sessions SET first_message = ? WHERE id = ?",
-		"drifted first message", "pd-skew")
+		"UPDATE messages SET timestamp = ? WHERE session_id = ? AND ordinal = 0",
+		"2020-01-01T00:00:00Z", "pd-skew")
 	mutateDB(t, env,
 		"UPDATE sessions SET first_message = ? WHERE id = ?",
 		"drifted first message", "pd-full")
@@ -1376,7 +1379,7 @@ func TestParseDiffIncrementalAppendSkewNotCountedAsChange(t *testing.T) {
 		Examined: 2, Changed: 1, IncrementalSkew: 1,
 	}, report.Totals, "totals")
 	// Only the full-write session's drift contributes to FieldCounts; the
-	// incrementally written session's drift is suppressed.
+	// incrementally written session's metadata drift is suppressed.
 	assert.Equal(t, map[string]int{sync.FieldFirstMessage: 1},
 		report.FieldCounts,
 		"only the full-write change contributes to FieldCounts")
@@ -1388,7 +1391,7 @@ func TestParseDiffIncrementalAppendSkewNotCountedAsChange(t *testing.T) {
 	// The would-be change is attached for drill-down even though it is
 	// not counted, so an operator can see what the skew suppressed.
 	assert.Contains(t, sessionDiffFieldNames(skew, true),
-		sync.FieldFirstMessage,
+		sync.FieldMessageMetadata,
 		"skew field diff attached for drill-down")
 
 	changed := findSessionDiff(report, "pd-full")
@@ -1417,9 +1420,11 @@ func TestParseDiffIncrementalAppendSkewAloneDoesNotFail(t *testing.T) {
 
 	appendClaudeLineAndSyncIncremental(t, env, path,
 		claudeAppendedAssistantLine("appended reply", "2024-01-01T10:00:10Z"))
+	// A per-message metadata (timestamp) diff is the incremental-artifact
+	// surface the marker may suppress.
 	mutateDB(t, env,
-		"UPDATE sessions SET first_message = ? WHERE id = ?",
-		"drifted first message", "pd-solo-skew")
+		"UPDATE messages SET timestamp = ? WHERE session_id = ? AND ordinal = 0",
+		"2020-01-01T00:00:00Z", "pd-solo-skew")
 
 	report := runParseDiff(t, env, sync.ParseDiffOptions{})
 	assert.Equal(t, sync.ParseDiffTotals{
@@ -1429,6 +1434,50 @@ func TestParseDiffIncrementalAppendSkewAloneDoesNotFail(t *testing.T) {
 		"skew field diffs must be excluded from FieldCounts")
 	assert.False(t, report.HasFailures(),
 		"a skew session alone must not trip --fail-on-change")
+}
+
+// TestParseDiffIncrementalMarkerDoesNotMaskNonArtifactDrift is the direct
+// regression guard for the narrowing: an incrementally written session
+// (marker set) whose drift lands on a field OUTSIDE the incremental-artifact
+// allow-list -- here first_message, which is head-derived and byte-stable
+// across appends -- must stay a genuine DiffChanged and trip
+// --fail-on-change. The marker is session-level; a regression is
+// field-level, so the marker alone must not suppress it.
+func TestParseDiffIncrementalMarkerDoesNotMaskNonArtifactDrift(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentClaude)
+
+	path := env.writeClaudeSession(t, "test-proj", "pd-nomask.jsonl",
+		parseDiffClaudeContent("nomask prompt", "nomask reply"))
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1, Synced: 1,
+	})
+	appendClaudeLineAndSyncIncremental(t, env, path,
+		claudeAppendedAssistantLine("appended reply", "2024-01-01T10:00:10Z"))
+
+	marked, err := env.db.GetSessionFull(context.Background(), "pd-nomask")
+	require.NoError(t, err, "GetSessionFull after append")
+	require.NotNil(t, marked, "session after append")
+	require.True(t, marked.LastWriteIncremental,
+		"the incremental append must set the marker via real code")
+
+	// first_message is not an incremental artifact: a diff there is genuine
+	// parser drift the marker must not mask.
+	mutateDB(t, env,
+		"UPDATE sessions SET first_message = ? WHERE id = ?",
+		"drifted first message", "pd-nomask")
+
+	report := runParseDiff(t, env, sync.ParseDiffOptions{})
+	assert.Equal(t, sync.ParseDiffTotals{
+		Examined: 1, Changed: 1,
+	}, report.Totals, "a non-artifact diff on a marked row must stay changed")
+	changed := findSessionDiff(report, "pd-nomask")
+	require.NotNil(t, changed, "session not listed")
+	assert.Equal(t, sync.DiffChanged, changed.Class,
+		"marker must not reclassify a first_message regression as skew")
+	assert.Equal(t, map[string]int{sync.FieldFirstMessage: 1},
+		report.FieldCounts, "the regression must contribute to FieldCounts")
+	assert.True(t, report.HasFailures(),
+		"a non-artifact regression on a marked row must trip --fail-on-change")
 }
 
 // TestParseDiffFullResyncClearsIncrementalSkew proves the resync-baseline
@@ -1446,10 +1495,11 @@ func TestParseDiffFullResyncClearsIncrementalSkew(t *testing.T) {
 	appendClaudeLineAndSyncIncremental(t, env, path,
 		claudeAppendedAssistantLine("appended reply", "2024-01-01T10:00:10Z"))
 
-	// Precondition: the incrementally written session is classified skew.
+	// Precondition: the incrementally written session, drifting on the
+	// per-message metadata (timestamp) artifact surface, is classified skew.
 	mutateDB(t, env,
-		"UPDATE sessions SET first_message = ? WHERE id = ?",
-		"drifted first message", "pd-heal")
+		"UPDATE messages SET timestamp = ? WHERE session_id = ? AND ordinal = 0",
+		"2020-01-01T00:00:00Z", "pd-heal")
 	report := runParseDiff(t, env, sync.ParseDiffOptions{})
 	skew := findSessionDiff(report, "pd-heal")
 	require.NotNil(t, skew, "skew session not listed pre-resync")
@@ -1469,8 +1519,8 @@ func TestParseDiffFullResyncClearsIncrementalSkew(t *testing.T) {
 		"a full resync must clear the incremental marker")
 
 	mutateDB(t, env,
-		"UPDATE sessions SET first_message = ? WHERE id = ?",
-		"drifted first message", "pd-heal")
+		"UPDATE messages SET timestamp = ? WHERE session_id = ? AND ordinal = 0",
+		"2020-01-01T00:00:00Z", "pd-heal")
 	report = runParseDiff(t, env, sync.ParseDiffOptions{})
 	changed := findSessionDiff(report, "pd-heal")
 	require.NotNil(t, changed, "session not listed post-resync")
@@ -1536,9 +1586,11 @@ func TestParseDiffRacedWinsOverIncrementalSkew(t *testing.T) {
 	appendClaudeLineAndSyncIncremental(t, env, path,
 		claudeAppendedAssistantLine("appended reply", "2024-01-01T10:00:10Z"))
 
+	// Seed a per-message metadata (timestamp) diff -- an incremental-artifact
+	// field, so this session would otherwise classify skew; raced must win.
 	mutateDB(t, env,
-		"UPDATE sessions SET first_message = ? WHERE id = ?",
-		"drifted first message", "pd-both")
+		"UPDATE messages SET timestamp = ? WHERE session_id = ? AND ordinal = 0",
+		"2020-01-01T00:00:00Z", "pd-both")
 
 	// Advance the source mtime past the snapshot so the session is BOTH
 	// raced and incrementally written.

--- a/internal/sync/parsediff_integration_test.go
+++ b/internal/sync/parsediff_integration_test.go
@@ -1304,6 +1304,260 @@ func TestParseDiffRacedDoesNotMaskCleanRun(t *testing.T) {
 	assert.False(t, report.HasFailures(), "clean run")
 }
 
+// claudeAppendedAssistantLine renders one raw assistant JSONL line that
+// can be appended to a Claude session source and picked up by an
+// incremental sync.
+func claudeAppendedAssistantLine(text, ts string) string {
+	return testjsonl.ClaudeAssistantJSON(
+		[]map[string]any{{"type": "text", "text": text}}, ts,
+	) + "\n"
+}
+
+// appendClaudeLineAndSyncIncremental appends one raw JSONL line to a
+// Claude session source and drives a real incremental sync of it,
+// exercising the production incremental-append path (writeIncremental ->
+// WriteSessionIncremental) that sets last_write_incremental. Using the
+// real write path rather than a mutateDB-simulated flag is the point of
+// these tests: it proves the detection signal is wired end to end.
+func appendClaudeLineAndSyncIncremental(
+	t *testing.T, env *testEnv, path, line string,
+) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err, "open for append")
+	_, err = f.WriteString(line)
+	require.NoError(t, err, "append line")
+	require.NoError(t, f.Close(), "close after append")
+	env.engine.SyncPaths([]string{path})
+}
+
+// TestParseDiffIncrementalAppendSkewNotCountedAsChange proves the core
+// contract: a session last written through the real incremental-append
+// path is classified DiffIncrementalSkew (not DiffChanged), excluded from
+// FieldCounts and HasFailures, but still counted in Examined and listed
+// for drill-down. A control session written only through the full path
+// still classifies as a genuine change, so the marker never masks drift
+// on a session that was not actually written incrementally.
+func TestParseDiffIncrementalAppendSkewNotCountedAsChange(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentClaude)
+
+	skewPath := env.writeClaudeSession(t, "test-proj", "pd-skew.jsonl",
+		parseDiffClaudeContent("skew prompt", "skew reply"))
+	env.writeClaudeSession(t, "test-proj", "pd-full.jsonl",
+		parseDiffClaudeContent("full prompt", "full reply"))
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 2, Synced: 2,
+	})
+
+	appendClaudeLineAndSyncIncremental(t, env, skewPath,
+		claudeAppendedAssistantLine("appended reply", "2024-01-01T10:00:10Z"))
+
+	// Assert the marker was set by real production code, not simulated.
+	afterAppend, err := env.db.GetSessionFull(
+		context.Background(), "pd-skew",
+	)
+	require.NoError(t, err, "GetSessionFull after append")
+	require.NotNil(t, afterAppend, "session after append")
+	require.True(t, afterAppend.LastWriteIncremental,
+		"the incremental append must set the marker via real code")
+
+	// Seed a real (non-informational) first_message drift on both
+	// sessions so a re-parse detects a change for each.
+	mutateDB(t, env,
+		"UPDATE sessions SET first_message = ? WHERE id = ?",
+		"drifted first message", "pd-skew")
+	mutateDB(t, env,
+		"UPDATE sessions SET first_message = ? WHERE id = ?",
+		"drifted first message", "pd-full")
+
+	report := runParseDiff(t, env, sync.ParseDiffOptions{})
+
+	assert.Equal(t, sync.ParseDiffTotals{
+		Examined: 2, Changed: 1, IncrementalSkew: 1,
+	}, report.Totals, "totals")
+	// Only the full-write session's drift contributes to FieldCounts; the
+	// incrementally written session's drift is suppressed.
+	assert.Equal(t, map[string]int{sync.FieldFirstMessage: 1},
+		report.FieldCounts,
+		"only the full-write change contributes to FieldCounts")
+
+	skew := findSessionDiff(report, "pd-skew")
+	require.NotNil(t, skew, "skew session not listed")
+	assert.Equal(t, sync.DiffIncrementalSkew, skew.Class, "skew class")
+	assert.NotEmpty(t, skew.Reason, "skew reason")
+	// The would-be change is attached for drill-down even though it is
+	// not counted, so an operator can see what the skew suppressed.
+	assert.Contains(t, sessionDiffFieldNames(skew, true),
+		sync.FieldFirstMessage,
+		"skew field diff attached for drill-down")
+
+	changed := findSessionDiff(report, "pd-full")
+	require.NotNil(t, changed, "full session not listed")
+	assert.Equal(t, sync.DiffChanged, changed.Class,
+		"full-write drift stays changed, never masked as skew")
+	assert.Contains(t, sessionDiffFieldNames(changed, false),
+		sync.FieldFirstMessage, "control change field")
+
+	// The run fails because of the full-write change, not the skew one.
+	assert.True(t, report.HasFailures(),
+		"the full-write change must still trip --fail-on-change")
+}
+
+// TestParseDiffIncrementalAppendSkewAloneDoesNotFail isolates the gate
+// contract: a run whose only drift is on an incrementally written session
+// classifies incremental_skew and must NOT trip --fail-on-change.
+func TestParseDiffIncrementalAppendSkewAloneDoesNotFail(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentClaude)
+
+	path := env.writeClaudeSession(t, "test-proj", "pd-solo-skew.jsonl",
+		parseDiffClaudeContent("solo prompt", "solo reply"))
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1, Synced: 1,
+	})
+
+	appendClaudeLineAndSyncIncremental(t, env, path,
+		claudeAppendedAssistantLine("appended reply", "2024-01-01T10:00:10Z"))
+	mutateDB(t, env,
+		"UPDATE sessions SET first_message = ? WHERE id = ?",
+		"drifted first message", "pd-solo-skew")
+
+	report := runParseDiff(t, env, sync.ParseDiffOptions{})
+	assert.Equal(t, sync.ParseDiffTotals{
+		Examined: 1, IncrementalSkew: 1,
+	}, report.Totals, "totals")
+	assert.Empty(t, report.FieldCounts,
+		"skew field diffs must be excluded from FieldCounts")
+	assert.False(t, report.HasFailures(),
+		"a skew session alone must not trip --fail-on-change")
+}
+
+// TestParseDiffFullResyncClearsIncrementalSkew proves the resync-baseline
+// self-heal: an incrementally written session classifies incremental_skew,
+// but after a full resync rewrites it through normalization (clearing the
+// marker) the same seeded drift classifies as a genuine DiffChanged again.
+func TestParseDiffFullResyncClearsIncrementalSkew(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentClaude)
+
+	path := env.writeClaudeSession(t, "test-proj", "pd-heal.jsonl",
+		parseDiffClaudeContent("heal prompt", "heal reply"))
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1, Synced: 1,
+	})
+	appendClaudeLineAndSyncIncremental(t, env, path,
+		claudeAppendedAssistantLine("appended reply", "2024-01-01T10:00:10Z"))
+
+	// Precondition: the incrementally written session is classified skew.
+	mutateDB(t, env,
+		"UPDATE sessions SET first_message = ? WHERE id = ?",
+		"drifted first message", "pd-heal")
+	report := runParseDiff(t, env, sync.ParseDiffOptions{})
+	skew := findSessionDiff(report, "pd-heal")
+	require.NotNil(t, skew, "skew session not listed pre-resync")
+	require.Equal(t, sync.DiffIncrementalSkew, skew.Class,
+		"skew class pre-resync")
+
+	// A full resync rewrites every row through normalization, clearing the
+	// marker. Re-seed the same drift afterward (the resync overwrote it),
+	// then confirm the session is now a genuine DiffChanged: the skew
+	// suppression self-heals once the comparison basis is rebuilt.
+	stats := env.engine.ResyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted, "resync aborted")
+	healed, err := env.db.GetSessionFull(context.Background(), "pd-heal")
+	require.NoError(t, err, "GetSessionFull after resync")
+	require.NotNil(t, healed, "session after resync")
+	require.False(t, healed.LastWriteIncremental,
+		"a full resync must clear the incremental marker")
+
+	mutateDB(t, env,
+		"UPDATE sessions SET first_message = ? WHERE id = ?",
+		"drifted first message", "pd-heal")
+	report = runParseDiff(t, env, sync.ParseDiffOptions{})
+	changed := findSessionDiff(report, "pd-heal")
+	require.NotNil(t, changed, "session not listed post-resync")
+	assert.Equal(t, sync.DiffChanged, changed.Class,
+		"a full resync clears the marker, restoring drift detection")
+	assert.True(t, report.HasFailures(),
+		"post-resync drift must trip --fail-on-change again")
+}
+
+// TestParseDiffIncrementalSkewNeverSetForDBBackedProviders proves the
+// marker is driven by the write path, not the agent: a DB-backed provider
+// (Kiro) always writes through the full path, so its rows never carry the
+// incremental marker and seeded drift stays a genuine DiffChanged.
+func TestParseDiffIncrementalSkewNeverSetForDBBackedProviders(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentKiro)
+	ks := createKiroSQLiteDB(t, env.kiroDir)
+	payload := readKiroSQLiteFixture(t, "standard_payload.json")
+	ks.addSession(
+		t, "/home/user/code/kiro-app", "kiro-db",
+		payload, 1779012000000, 1779012030000,
+	)
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1, Synced: 1,
+	})
+
+	stored, err := env.db.GetSessionFull(
+		context.Background(), "kiro:kiro-db",
+	)
+	require.NoError(t, err, "GetSessionFull kiro")
+	require.NotNil(t, stored, "kiro session")
+	require.False(t, stored.LastWriteIncremental,
+		"DB-backed providers must never set the incremental marker")
+
+	mutateDB(t, env,
+		"UPDATE sessions SET first_message = ? WHERE id = ?",
+		"drifted first message", "kiro:kiro-db")
+
+	report := runParseDiff(t, env, sync.ParseDiffOptions{
+		Agents: []parser.AgentType{parser.AgentKiro},
+	})
+	assert.Zero(t, report.Totals.IncrementalSkew,
+		"DB-backed drift must never classify as incremental skew")
+	changed := findSessionDiff(report, "kiro:kiro-db")
+	require.NotNil(t, changed, "kiro session not listed")
+	assert.Equal(t, sync.DiffChanged, changed.Class,
+		"DB-backed drift stays changed, never skew")
+	assert.True(t, report.HasFailures(),
+		"DB-backed drift must trip --fail-on-change")
+}
+
+// TestParseDiffRacedWinsOverIncrementalSkew pins the precedence: when a
+// source both advanced past its snapshot mtime (raced) and was last
+// written incrementally (skew), raced wins because the advanced mtime is
+// the stronger, directly provable diagnosis.
+func TestParseDiffRacedWinsOverIncrementalSkew(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentClaude)
+
+	path := env.writeClaudeSession(t, "test-proj", "pd-both.jsonl",
+		parseDiffClaudeContent("both prompt", "both reply"))
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1, Synced: 1,
+	})
+	appendClaudeLineAndSyncIncremental(t, env, path,
+		claudeAppendedAssistantLine("appended reply", "2024-01-01T10:00:10Z"))
+
+	mutateDB(t, env,
+		"UPDATE sessions SET first_message = ? WHERE id = ?",
+		"drifted first message", "pd-both")
+
+	// Advance the source mtime past the snapshot so the session is BOTH
+	// raced and incrementally written.
+	future := time.Now().Add(48 * time.Hour)
+	require.NoError(t, os.Chtimes(path, future, future),
+		"advance source mtime")
+
+	report := runParseDiff(t, env, sync.ParseDiffOptions{})
+	assert.Equal(t, sync.ParseDiffTotals{
+		Examined: 1, Raced: 1,
+	}, report.Totals, "raced wins over incremental skew")
+	both := findSessionDiff(report, "pd-both")
+	require.NotNil(t, both, "session not listed")
+	assert.Equal(t, sync.DiffRaced, both.Class,
+		"raced takes precedence over incremental skew")
+	assert.False(t, report.HasFailures(),
+		"a raced/skew session must not trip --fail-on-change")
+}
+
 // TestParseDiffDBBackedSourceNotMaskedAsRaced pins the reliability gate for
 // composite, DB-backed sources. Many Kiro sessions share ONE data.sqlite3, and
 // the live mtime the skew guard could observe (a composite db stat or per-row

--- a/internal/sync/parsediff_report.go
+++ b/internal/sync/parsediff_report.go
@@ -54,6 +54,26 @@ const (
 	// compare path only; the presence sweep (a stored ID a clean parse no
 	// longer emits) is a separate signal and is not yet skew-guarded.
 	DiffRaced DiffClass = "raced"
+	// DiffIncrementalSkew: the comparison detected a non-informational
+	// change, but the stored row was last written through the
+	// incremental-append path (sessions.last_write_incremental) rather
+	// than a full re-normalization. Claude and Codex append new JSONL
+	// tails without rewriting the whole session, so a fresh full re-parse
+	// legitimately differs on fields the incremental path leaves frozen
+	// or recomputes differently (message_metadata, ordinal-set shape),
+	// even at the current data_version and without a pending resync. The
+	// change is therefore comparison-basis skew, not parser drift, and is
+	// inconclusive. Like DiffRaced it is reported for drill-down but never
+	// counted as a failure: --fail-on-change must not trip on it. The
+	// tradeoff mirrors DiffRaced's -- this is a session-level suppression,
+	// so a genuine regression on an incrementally-written session is also
+	// masked until that row is fully resynced (which clears the marker and
+	// restores full scrutiny). A full resync gives the clean baseline; see
+	// the resync recommendation in the CLI report. Precedence is below
+	// DiffRaced: when a source both advanced past its snapshot mtime and
+	// was last written incrementally, raced wins because the advanced
+	// mtime is the stronger, directly-provable diagnosis.
+	DiffIncrementalSkew DiffClass = "incremental_skew"
 )
 
 // Compared-field names. Used as FieldDiff.Field values and
@@ -161,6 +181,13 @@ type ParseDiffTotals struct {
 	// because the on-disk source advanced past the snapshot mtime. They
 	// are inconclusive (live-write skew), so HasFailures excludes them.
 	Raced int `json:"raced"`
+	// IncrementalSkew counts sessions whose would-be change was
+	// reclassified because the stored row was last written through the
+	// incremental-append path (last_write_incremental), so a full re-parse
+	// legitimately differs. They are inconclusive comparison-basis skew,
+	// not parser drift, so HasFailures excludes them; they are still part
+	// of Examined because they were compared, exactly like Raced.
+	IncrementalSkew int `json:"incremental_skew"`
 	// InformationalOnly counts sessions classified identical whose only
 	// diffs are informational. Included in Identical.
 	InformationalOnly int `json:"informational_only"`

--- a/internal/sync/parsediff_report.go
+++ b/internal/sync/parsediff_report.go
@@ -55,20 +55,27 @@ const (
 	// longer emits) is a separate signal and is not yet skew-guarded.
 	DiffRaced DiffClass = "raced"
 	// DiffIncrementalSkew: the comparison detected a non-informational
-	// change, but the stored row was last written through the
+	// change, the stored row was last written through the
 	// incremental-append path (sessions.last_write_incremental) rather
-	// than a full re-normalization. Claude and Codex append new JSONL
-	// tails without rewriting the whole session, so a fresh full re-parse
-	// legitimately differs on fields the incremental path leaves frozen
-	// or recomputes differently (message_metadata, ordinal-set shape),
-	// even at the current data_version and without a pending resync. The
-	// change is therefore comparison-basis skew, not parser drift, and is
-	// inconclusive. Like DiffRaced it is reported for drill-down but never
-	// counted as a failure: --fail-on-change must not trip on it. The
-	// tradeoff mirrors DiffRaced's -- this is a session-level suppression,
-	// so a genuine regression on an incrementally-written session is also
-	// masked until that row is fully resynced (which clears the marker and
-	// restores full scrutiny). A full resync gives the clean baseline; see
+	// than a full re-normalization, AND every non-informational diff is
+	// confined to the incremental-artifact allow-list
+	// (diffsConfinedToIncrementalArtifacts). Claude and Codex append new
+	// JSONL tails without rewriting the whole session, so a fresh full
+	// re-parse can legitimately differ on the ordinal-shape / per-message
+	// metadata surface (message_metadata) even at the current data_version
+	// and without a pending resync. That change is comparison-basis skew,
+	// not parser drift, and is inconclusive: like DiffRaced it is reported
+	// for drill-down but never counted as a failure.
+	//
+	// The confinement is what keeps the marker from masking real
+	// regressions: the marker is session-level, but a regression is
+	// field-level, so a non-informational diff on any other field
+	// (first_message, message_content, usage totals, tool_calls, the
+	// recomputed aggregates, ...) keeps the session DiffChanged and trips
+	// --fail-on-change even on an incrementally-written row. The frozen
+	// session fields the incremental path owns (termination_status,
+	// session_name, cwd, ...) are already marked informational and never
+	// reach this test. A full resync still gives the cleanest baseline; see
 	// the resync recommendation in the CLI report. Precedence is below
 	// DiffRaced: when a source both advanced past its snapshot mtime and
 	// was last written incrementally, raced wins because the advanced


### PR DESCRIPTION
parse-diff v2 follow-up (after #805 sub-items 1+4 and #949 sub-item 3), addressing incremental-append skew.

`parse-diff` compares stored session rows against a fresh full re-parse. Sessions last written through the incremental JSONL append path (Claude/Codex) are not rewritten through full normalization, so a fresh full re-parse can legitimately differ on the per-message metadata / ordinal-set shape even at the current data_version and without a pending resync. Those sessions were reported as changed — noise that makes `--fail-on-change` untrustworthy in CI against a non-resynced archive.

This adds a SQLite-only `sessions.last_write_incremental` marker, set inside the single incremental-update seam. It is reset to false only by a genuine full message re-normalization (`ReplaceSessionContent`, `ReplaceSessionMessages`, and the batch `ReplaceMessages` branch) via a shared `resetIncrementalMarkerTx`, and seeded false on fresh INSERT — not on a bare `UpsertSession`. That distinction matters: the routine full-parse batch path takes `ReplaceMessages=false` for the append-only agents, upserting the session row while appending only new messages and leaving earlier incrementally written rows in place, so clearing the marker on every upsert would have made a single routine sync report still-present benign skew as real drift. The marker is therefore per-session ground truth (not inferred) and self-heals on the next full resync.

A new `DiffIncrementalSkew` class — mirroring `DiffRaced` — reclassifies a would-be change on such a row: it is listed for drill-down but excluded from failure counting, while still counting toward Examined. Precedence is raced > incremental-skew > changed. The CLI additionally prints a resync-baseline recommendation whenever skew is present.

The reclassification is confined to the incremental-artifact surface, not applied session-wide. Because the marker is session-level while a regression is field-level, the marker only reclassifies when every non-informational diff is on an allow-list holding just the ordinal-shape / per-message metadata field (`message_metadata`, via `diffsConfinedToIncrementalArtifacts`). A non-informational diff on any other field — head-derived `first_message`/`started_at`, message content, usage totals, tool_calls, or the recomputed aggregates, all of which both write paths normalize identically — keeps the session `DiffChanged` and still trips `--fail-on-change`. The session fields the incremental path actually freezes (`termination_status`, `session_name`, `cwd`, …) are already marked informational and never reach this test. Characterized against the real archive: `parse-diff` over the full Claude/Codex corpus shows 0 changed and 0 skew for quiescent current-version rows; the only per-message metadata drift observed was on a live-write raced session, which already outranks skew. The class is thus a conservative safety net for the one surface a whole-file re-parse can legitimately reshape, without masking regressions elsewhere.

Backend note: the marker is SQLite-only by design, like `next_ordinal`/`last_entry_uuid`/`file_hash`. parse-diff opens the local SQLite archive directly and is never reachable through the PostgreSQL/DuckDB read paths; the column is `json:"-"` and the push paths use explicit column lists that already omit the sync-bookkeeping cluster. The migration is a non-destructive ADD COLUMN with no dataVersion bump.

Where to look: `internal/db/sessions.go` / `messages.go` / `session_batch.go` (set, scan, and the full-rewrite-only reset), `internal/sync/parsediff_compare.go` and `parsediff.go` (classify, compute, and artifact confinement), `internal/sync/parsediff_report.go` (the class), `cmd/agentsview/parse_diff.go` (render + resync note).
