### PR TITLE
fix(postgres): scope alias backfill marker per target

### DIFF
--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -70,6 +70,7 @@ func (s *Sync) Push(
 	start := time.Now()
 	var result PushResult
 	state := s.effectiveSyncState()
+	aliasBackfillState := s.aliasBackfillSyncStateOrDefault()
 
 	if err := CheckDataVersionCompat(ctx, s.pg); err != nil {
 		return result, err
@@ -132,9 +133,12 @@ func (s *Sync) Push(
 	legacyMarkerMachines := pushMarkerLegacyMachines(
 		markerMachine, markerMachineAliases,
 	)
+	// Keep the backfill marker scoped to target only; all other push
+	// state remains scoped by full effective sync state (including filter
+	// fingerprint when present).
 	aliasBackfillNeeded := false
 	full, aliasBackfillNeeded, err = applySessionAliasBackfillRequirement(
-		state, full,
+		aliasBackfillState, full,
 	)
 	if err != nil {
 		return result, err
@@ -339,7 +343,7 @@ func (s *Sync) Push(
 			return result, err
 		}
 		if err := completeSessionAliasBackfill(
-			state, aliasBackfillNeeded, result,
+			aliasBackfillState, aliasBackfillNeeded, result,
 		); err != nil {
 			return result, err
 		}
@@ -443,7 +447,7 @@ func (s *Sync) Push(
 		return result, err
 	}
 	if err := completeSessionAliasBackfill(
-		state, aliasBackfillNeeded, result,
+		aliasBackfillState, aliasBackfillNeeded, result,
 	); err != nil {
 		return result, err
 	}

--- a/internal/postgres/push_test.go
+++ b/internal/postgres/push_test.go
@@ -194,6 +194,115 @@ func TestCompleteSessionAliasBackfillMarksDoneUnlessErrors(t *testing.T) {
 	}
 }
 
+func TestSessionAliasBackfillRequirementUsesSyncAliasStateAcrossFilters(t *testing.T) {
+	filterScopeA := pushSyncStateScope(
+		"work",
+		[]string{"alpha"},
+		nil,
+	)
+	filterScopeB := pushSyncStateScope(
+		"work",
+		[]string{"beta"},
+		nil,
+	)
+
+	store := &syncStateStoreStub{}
+	syncA := &Sync{
+		syncState:          newScopedSyncStateStore(store, filterScopeA, false),
+		aliasBackfillState: newScopedSyncStateStore(store, "work", false),
+	}
+	syncB := &Sync{
+		syncState:          newScopedSyncStateStore(store, filterScopeB, false),
+		aliasBackfillState: newScopedSyncStateStore(store, "work", false),
+	}
+
+	full, needed, err := applySessionAliasBackfillRequirement(
+		syncA.aliasBackfillSyncStateOrDefault(), false,
+	)
+	require.NoError(t, err)
+	assert.True(t, full)
+	assert.True(t, needed)
+
+	require.NoError(t, completeSessionAliasBackfill(
+		syncA.aliasBackfillSyncStateOrDefault(),
+		true,
+		PushResult{},
+	))
+
+	full, needed, err = applySessionAliasBackfillRequirement(
+		syncB.aliasBackfillSyncStateOrDefault(), false,
+	)
+	require.NoError(t, err)
+	assert.False(t, full, "head behavior: target scope keeps marker across filters")
+	assert.False(t, needed, "head behavior: marker should not re-arm full push")
+	assert.Empty(t, store.values[sessionAliasBackfillStateKey+":"+filterScopeA])
+	assert.Empty(t, store.values[sessionAliasBackfillStateKey+":"+filterScopeB])
+	assert.Equal(t, "1", store.values[sessionAliasBackfillStateKey+":work"])
+}
+
+func TestSessionAliasBackfillStateFallsBackToEffectiveScope(t *testing.T) {
+	store := &syncStateStoreStub{}
+	scope := pushSyncStateScope("work", []string{"alpha"}, nil)
+	syncer := &Sync{
+		syncState: newScopedSyncStateStore(store, scope, false),
+	}
+
+	require.NoError(t, markSessionAliasBackfillDone(
+		syncer.aliasBackfillSyncStateOrDefault(),
+	))
+	assert.Equal(t, "1", store.values[sessionAliasBackfillStateKey+":"+scope])
+}
+
+func TestSessionAliasBackfillKeysStayFilteredForPushState(t *testing.T) {
+	filterScopeA := pushSyncStateScope("work", []string{"alpha"}, nil)
+	filterScopeB := pushSyncStateScope("work", []string{"beta"}, nil)
+	store := &syncStateStoreStub{}
+	syncA := &Sync{
+		syncState:          newScopedSyncStateStore(store, filterScopeA, false),
+		aliasBackfillState: newScopedSyncStateStore(store, "work", false),
+	}
+
+	require.NoError(t, syncA.effectiveSyncState().SetSyncState(
+		"last_push_at", "2026-03-11T12:00:00.000Z",
+	))
+	require.NoError(t, syncA.effectiveSyncState().SetSyncState(
+		lastPushBoundaryStateKey, `{"cutoff":"2026-03-11T12:00:00.000Z"}`,
+	))
+	require.NoError(t, syncA.effectiveSyncState().SetSyncState(
+		lastPushTargetFingerprintKey, "fp-1",
+	))
+	require.NoError(t, markSessionAliasBackfillDone(
+		syncA.aliasBackfillSyncStateOrDefault(),
+	))
+
+	assert.Equal(
+		t,
+		"2026-03-11T12:00:00.000Z",
+		store.values["last_push_at:"+filterScopeA],
+	)
+	assert.Equal(
+		t,
+		`{"cutoff":"2026-03-11T12:00:00.000Z"}`,
+		store.values[lastPushBoundaryStateKey+":"+filterScopeA],
+	)
+	assert.Equal(
+		t,
+		"fp-1",
+		store.values[lastPushTargetFingerprintKey+":"+filterScopeA],
+	)
+	assert.Empty(t, store.values["last_push_at:"+filterScopeB])
+	assert.Empty(t, store.values[lastPushBoundaryStateKey+":"+filterScopeB])
+	assert.Empty(t, store.values[lastPushTargetFingerprintKey+":"+filterScopeB])
+	assert.Empty(t, store.values[sessionAliasBackfillStateKey+":"+filterScopeA])
+	assert.Empty(t, store.values[sessionAliasBackfillStateKey+":"+filterScopeB])
+	assert.Equal(
+		t,
+		"1",
+		store.values[sessionAliasBackfillStateKey+":work"],
+	)
+	assert.Empty(t, store.values["last_push_at:work"])
+}
+
 func TestReadPushBoundaryStateValidity(t *testing.T) {
 	const cutoff = "2026-03-11T12:34:56.123Z"
 

--- a/internal/postgres/push_test.go
+++ b/internal/postgres/push_test.go
@@ -82,6 +82,144 @@ func (s *syncStateStoreStub) GetOrCreateSyncState(
 	return defaultValue, nil
 }
 
+type pushAliasRoutingDriver struct{}
+
+type pushAliasRoutingConn struct{}
+
+type pushAliasRoutingTx struct{}
+
+type pushAliasRoutingRows struct {
+	columns []string
+	values  [][]driver.Value
+	next    int
+}
+
+var pushAliasRoutingRegisterOnce sync.Once
+
+func newPushAliasRoutingDB(t *testing.T) *sql.DB {
+	t.Helper()
+	pushAliasRoutingRegisterOnce.Do(func() {
+		sql.Register("agentsview_push_alias_routing", pushAliasRoutingDriver{})
+	})
+
+	pg, err := sql.Open("agentsview_push_alias_routing", t.Name())
+	require.NoError(t, err, "open push-alias-routing db")
+	t.Cleanup(func() { _ = pg.Close() })
+	return pg
+}
+
+func (pushAliasRoutingDriver) Open(string) (driver.Conn, error) {
+	return &pushAliasRoutingConn{}, nil
+}
+
+func (c *pushAliasRoutingConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("prepare not implemented")
+}
+
+func (c *pushAliasRoutingConn) Close() error { return nil }
+
+func (c *pushAliasRoutingConn) Begin() (driver.Tx, error) {
+	return c.BeginTx(context.Background(), driver.TxOptions{})
+}
+
+func (c *pushAliasRoutingConn) BeginTx(
+	context.Context, driver.TxOptions,
+) (driver.Tx, error) {
+	return pushAliasRoutingTx{}, nil
+}
+
+func (c *pushAliasRoutingConn) CheckNamedValue(
+	*driver.NamedValue,
+) error {
+	return nil
+}
+
+func (c *pushAliasRoutingConn) ExecContext(
+	_ context.Context, query string, _ []driver.NamedValue,
+) (driver.Result, error) {
+	normalized := strings.ToLower(query)
+	switch {
+	case strings.Contains(normalized, "insert into model_pricing"):
+		return driver.RowsAffected(1), nil
+	case strings.Contains(normalized, "insert into sync_metadata"):
+		return driver.RowsAffected(1), nil
+	default:
+		return driver.RowsAffected(1), nil
+	}
+}
+
+func (c *pushAliasRoutingConn) QueryContext(
+	_ context.Context, query string, _ []driver.NamedValue,
+) (driver.Rows, error) {
+	normalized := strings.ToLower(query)
+	switch {
+	case strings.Contains(normalized, "select coalesce(max(data_version), 0) from sessions"):
+		return &pushAliasRoutingRows{
+			columns: []string{"coalesce"},
+			values:  [][]driver.Value{{0}},
+		}, nil
+	case strings.Contains(normalized, "from information_schema.tables"):
+		return &pushAliasRoutingRows{
+			columns: []string{"exists"},
+			values:  [][]driver.Value{{1}},
+		}, nil
+	case strings.Contains(normalized, "from pg_indexes"):
+		return &pushAliasRoutingRows{
+			columns: []string{"exists"},
+			values:  [][]driver.Value{{1}},
+		}, nil
+	case strings.Contains(normalized, "select exists ("):
+		return &pushAliasRoutingRows{
+			columns: []string{"exists"},
+			values:  [][]driver.Value{{false}},
+		}, nil
+	case strings.Contains(normalized, "select value from sync_metadata where key = $1"):
+		return &pushAliasRoutingRows{
+			columns: []string{"value"},
+		}, nil
+	case strings.Contains(normalized, "limit 0"):
+		return &pushAliasRoutingRows{
+			columns: []string{"probe"},
+		}, nil
+	case strings.Contains(normalized, "select model_pattern, input_per_mtok"):
+		return &pushAliasRoutingRows{
+			columns: []string{
+				"model_pattern",
+				"input_per_mtok",
+				"output_per_mtok",
+				"cache_creation_per_mtok",
+				"cache_read_per_mtok",
+				"updated_at",
+			},
+		}, nil
+	case strings.Contains(normalized, "select id from excluded_sessions"):
+		return &pushAliasRoutingRows{
+			columns: []string{"id"},
+		}, nil
+	default:
+		return &pushAliasRoutingRows{
+			columns: []string{"probe"},
+		}, nil
+	}
+}
+
+func (pushAliasRoutingTx) Commit() error { return nil }
+
+func (pushAliasRoutingTx) Rollback() error { return nil }
+
+func (r *pushAliasRoutingRows) Columns() []string { return r.columns }
+
+func (r *pushAliasRoutingRows) Close() error { return nil }
+
+func (r *pushAliasRoutingRows) Next(dest []driver.Value) error {
+	if r.next >= len(r.values) {
+		return io.EOF
+	}
+	copy(dest, r.values[r.next])
+	r.next++
+	return nil
+}
+
 func TestPushMarkerIDReturnsInsertWinner(t *testing.T) {
 	local, err := db.Open(filepath.Join(t.TempDir(), "local.db"))
 	require.NoError(t, err, "db.Open")
@@ -238,6 +376,68 @@ func TestSessionAliasBackfillRequirementUsesSyncAliasStateAcrossFilters(t *testi
 	assert.Empty(t, store.values[sessionAliasBackfillStateKey+":"+filterScopeA])
 	assert.Empty(t, store.values[sessionAliasBackfillStateKey+":"+filterScopeB])
 	assert.Equal(t, "1", store.values[sessionAliasBackfillStateKey+":work"])
+}
+
+func TestPushUsesTargetScopedAliasBackfillStateAcrossFilters(t *testing.T) {
+	filterScopeA := pushSyncStateScope("work", []string{"alpha"}, nil)
+	filterScopeB := pushSyncStateScope("work", []string{"beta"}, nil)
+	local := testDB(t)
+	pg := newPushAliasRoutingDB(t)
+	ctx := context.Background()
+
+	syncA := &Sync{
+		pg:                 pg,
+		local:              local,
+		syncState:          newScopedSyncStateStore(local, filterScopeA, false),
+		aliasBackfillState: newScopedSyncStateStore(local, "work", false),
+		machine:            "push-machine",
+		schema:             "agentsview",
+		targetFingerprint:  "target-fp",
+		syncStateTarget:    filterScopeA,
+		projects:           []string{"alpha"},
+		schemaDone:         true,
+	}
+	syncB := &Sync{
+		pg:                 pg,
+		local:              local,
+		syncState:          newScopedSyncStateStore(local, filterScopeB, false),
+		aliasBackfillState: newScopedSyncStateStore(local, "work", false),
+		machine:            "push-machine",
+		schema:             "agentsview",
+		targetFingerprint:  "target-fp",
+		syncStateTarget:    filterScopeB,
+		projects:           []string{"beta"},
+		schemaDone:         true,
+	}
+
+	_, err := syncA.Push(ctx, false, nil)
+	require.NoError(t, err)
+	_, err = syncB.Push(ctx, false, nil)
+	require.NoError(t, err)
+
+	targetMarker, err := local.GetSyncState(
+		sessionAliasBackfillStateKey + ":work",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "1", targetMarker)
+
+	filterMarkerB, err := local.GetSyncState(
+		sessionAliasBackfillStateKey + ":" + filterScopeB,
+	)
+	require.NoError(t, err)
+	assert.Empty(t, filterMarkerB)
+
+	filteredLastPushA, err := local.GetSyncState("last_push_at:" + filterScopeA)
+	require.NoError(t, err)
+	assert.NotEmpty(t, filteredLastPushA)
+
+	filteredLastPushB, err := local.GetSyncState("last_push_at:" + filterScopeB)
+	require.NoError(t, err)
+	assert.NotEmpty(t, filteredLastPushB)
+
+	unscopedLastPush, err := local.GetSyncState("last_push_at:work")
+	require.NoError(t, err)
+	assert.Empty(t, unscopedLastPush)
 }
 
 func TestSessionAliasBackfillStateFallsBackToEffectiveScope(t *testing.T) {

--- a/internal/postgres/sync.go
+++ b/internal/postgres/sync.go
@@ -149,6 +149,7 @@ type Sync struct {
 	pg                     *sql.DB
 	local                  *db.DB
 	syncState              syncStateStore
+	aliasBackfillState     syncStateStore
 	machine                string
 	schema                 string
 	targetFingerprint      string
@@ -171,6 +172,13 @@ func (s *Sync) effectiveSyncState() syncStateStore {
 		return s.syncState
 	}
 	return s.local
+}
+
+func (s *Sync) aliasBackfillSyncStateOrDefault() syncStateStore {
+	if s.aliasBackfillState != nil {
+		return s.aliasBackfillState
+	}
+	return s.effectiveSyncState()
 }
 
 // SyncOptions holds optional configuration for a Sync instance.
@@ -239,6 +247,7 @@ func New(
 		opts.Projects,
 		opts.ExcludeProjects,
 	)
+	aliasBackfillStateScope := opts.SyncStateTarget
 	migrateLegacySyncState := opts.MigrateLegacySyncState &&
 		!hasProjectFilter(opts.Projects, opts.ExcludeProjects)
 
@@ -249,6 +258,11 @@ func New(
 			local,
 			syncStateScope,
 			migrateLegacySyncState,
+		),
+		aliasBackfillState: newScopedSyncStateStore(
+			local,
+			aliasBackfillStateScope,
+			false,
 		),
 		machine:                machine,
 		schema:                 schema,


### PR DESCRIPTION
Filtered PostgreSQL pushes can still fall back to repeated full sweeps after the project filter set changes, because the one-time session-alias backfill marker is stored in the same project-filtered sync-state scope as the incremental push watermarks. The filtered scope is correct for `last_push_at`, target fingerprints, and boundary fingerprints, but it is the wrong scope for a migration marker that only needs to complete once per PG target.

This moves the alias-backfill marker onto target-scoped sync state while leaving the ordinary filtered push state in the existing project-filtered store. Changing `--projects` or `--exclude-projects` will no longer re-arm the alias-backfill full-push gate after the same target has already completed it, but different filter sets will still keep their own incremental watermarks and reset behavior exactly as before.

The change stays entirely inside `internal/postgres`, and it keeps the current one-time marker model rather than widening the fix into per-session tracking. One bounded limitation remains: the first filtered push that sets the target-scoped marker only backfills sessions inside that filter. Sessions outside that filtered run keep their old alias state until a later push includes them or they change locally, so this narrows the repeated full-push bug without claiming full per-session coverage.

This follows the narrowed analysis in [#939](https://github.com/kenn-io/agentsview/issues/939) from leejuhanKr and the split left by merged sibling [#940](https://github.com/kenn-io/agentsview/pull/940).

Closes #939
