### PR TITLE
fix(usage): wire agent exclusions through usage filters

### DIFF
--- a/frontend/src/lib/components/filters/SessionActiveFilters.svelte
+++ b/frontend/src/lib/components/filters/SessionActiveFilters.svelte
@@ -16,6 +16,7 @@
     onClearProjects?: () => void;
     onRemoveModel?: (model: string) => void;
     onClearModels?: () => void;
+    onClearAgents?: () => void;
   }
 
   let {
@@ -25,6 +26,7 @@
     onClearProjects,
     onRemoveModel,
     onClearModels,
+    onClearAgents,
   }: Props = $props();
 
   const selectedAgents = $derived(
@@ -87,6 +89,7 @@
     });
     onClearProjects?.();
     onClearModels?.();
+    onClearAgents?.();
   }
 </script>
 

--- a/frontend/src/lib/components/filters/SessionActiveFilters.test.ts
+++ b/frontend/src/lib/components/filters/SessionActiveFilters.test.ts
@@ -1,0 +1,49 @@
+import {
+  afterEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vite-plus/test";
+import { flushSync, mount, unmount } from "svelte";
+import SessionActiveFilters from "./SessionActiveFilters.svelte";
+import { sessions } from "../../stores/sessions.svelte.js";
+
+let component: ReturnType<typeof mount> | undefined;
+
+afterEach(() => {
+  if (component) unmount(component);
+  component = undefined;
+  document.body.innerHTML = "";
+  sessions.filters.project = "";
+  vi.restoreAllMocks();
+});
+
+describe("SessionActiveFilters clear all", () => {
+  it("invokes every usage-level clear hook", () => {
+    vi.spyOn(sessions, "clearSessionFilters").mockImplementation(
+      () => {},
+    );
+    vi.spyOn(sessions, "load").mockResolvedValue();
+    sessions.filters.project = "alpha";
+    const onClearProjects = vi.fn();
+    const onClearModels = vi.fn();
+    const onClearAgents = vi.fn();
+
+    component = mount(SessionActiveFilters, {
+      target: document.body,
+      props: { onClearProjects, onClearModels, onClearAgents },
+    });
+    flushSync();
+
+    const clearAll =
+      document.querySelector<HTMLButtonElement>(".clear-all");
+    expect(clearAll).not.toBeNull();
+    clearAll?.click();
+    flushSync();
+
+    expect(onClearProjects).toHaveBeenCalledOnce();
+    expect(onClearModels).toHaveBeenCalledOnce();
+    expect(onClearAgents).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/lib/components/usage/AttributionPanel.test.ts
+++ b/frontend/src/lib/components/usage/AttributionPanel.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mount, tick, unmount } from "svelte";
+import type { UsageSummaryResponse } from "../../api/types/usage.js";
+
+const usageServiceMocks = vi.hoisted(() => ({
+  getApiV1UsageSummary: vi.fn().mockResolvedValue({}),
+  getApiV1UsageComparison: vi.fn().mockResolvedValue({}),
+  getApiV1UsagePairwiseComparison: vi.fn().mockResolvedValue({}),
+  getApiV1UsageTopSessions: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../../api/runtime.js", () => ({
+  configureGeneratedClient: vi.fn(),
+  callGenerated: vi.fn((request: () => Promise<unknown>) => request()),
+  isAbortError: vi.fn(() => false),
+}));
+
+vi.mock("../../api/generated/index", () => ({
+  UsageService: usageServiceMocks,
+}));
+
+import AttributionPanel from "./AttributionPanel.svelte";
+import { usage } from "../../stores/usage.svelte.js";
+
+function summaryWithAgents(agents: string[]): UsageSummaryResponse {
+  return {
+    from: "2024-01-01",
+    to: "2024-01-31",
+    totals: {
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheCreationTokens: 0,
+      cacheReadTokens: 0,
+      totalCost: 12,
+    },
+    daily: [],
+    projectTotals: [],
+    modelTotals: [],
+    agentTotals: agents.map((agent, i) => ({
+      agent,
+      inputTokens: 60 - i * 20,
+      outputTokens: 30 - i * 10,
+      cacheCreationTokens: 0,
+      cacheReadTokens: 0,
+      cost: 8 - i * 4,
+    })),
+    sessionCounts: { total: 2, byProject: {}, byAgent: {} },
+    cacheStats: {
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      uncachedInputTokens: 100,
+      outputTokens: 50,
+      hitRate: 0,
+      savingsVsUncached: 0,
+    },
+  };
+}
+
+describe("AttributionPanel agent exclusion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    usage.summary = summaryWithAgents(["claude", "codex"]);
+    usage.excludedAgents = "";
+    usage.toggles.attribution.groupBy = "agent";
+    usage.toggles.attribution.view = "list";
+  });
+
+  afterEach(() => {
+    usage.summary = null;
+    usage.excludedAgents = "";
+    usage.toggles.attribution.groupBy = "project";
+    document.body.innerHTML = "";
+  });
+
+  // Drives the real click path: panel click -> store toggle -> outgoing
+  // request. Fails without the baseParams excludeAgent wiring.
+  it("sends agent exclusions in usage queries after an attribution click", async () => {
+    const component = mount(AttributionPanel, { target: document.body });
+    await tick();
+
+    const rows = document.querySelectorAll<HTMLElement>(".list-row");
+    expect(rows.length).toBe(2);
+    rows[1]!.click(); // exclude "codex"
+
+    await vi.waitFor(() =>
+      expect(
+        usageServiceMocks.getApiV1UsageSummary,
+      ).toHaveBeenLastCalledWith(
+        expect.objectContaining({ excludeAgent: "codex" }),
+      ),
+    );
+    unmount(component);
+  });
+});

--- a/frontend/src/lib/components/usage/UsagePage.svelte
+++ b/frontend/src/lib/components/usage/UsagePage.svelte
@@ -48,6 +48,13 @@
     })),
   );
 
+  const agentItems = $derived(
+    sessions.agents.map((a) => ({
+      name: a.name,
+      count: a.session_count,
+    })),
+  );
+
   const earliestSession = $derived(sync.stats?.earliest_session ?? null);
 
   const rangeSelection = $derived(
@@ -169,7 +176,7 @@
   // apply params that are actually present in the URL.
   const USAGE_FILTER_KEYS = new Set([
     "from", "to", "window_days",
-    "model", "exclude_model",
+    "model", "exclude_model", "exclude_agent",
   ]);
   const SESSION_FILTER_KEYS = new Set([
     "project", "machine", "agent",
@@ -297,6 +304,11 @@
         usage.excludedProjects = newExProject;
         changed = true;
       }
+      const newExAgent = params["exclude_agent"] ?? "";
+      if (newExAgent !== usage.excludedAgents) {
+        usage.excludedAgents = newExAgent;
+        changed = true;
+      }
       if (usage.excludedModels) {
         usage.excludedModels = "";
         changed = true;
@@ -354,6 +366,9 @@
 
   onMount(() => {
     mounted = true;
+    // The Agent dropdown reads sessions.agents, which is otherwise loaded
+    // lazily by the sidebar filter control; a direct /usage visit needs it too.
+    sessions.loadAgents();
     // SSE events only flag new data; RefreshControl owns the periodic refresh
     // and the manual button. The initial and filter-change fetches run from the
     // effects above once URL/filter state is hydrated.
@@ -402,6 +417,16 @@
       />
 
       <FilterDropdown
+        label={m.analytics_col_agent()}
+        items={agentItems}
+        excludedCsv={usage.excludedAgents}
+        onToggle={(name) => usage.toggleAgent(name)}
+        onSelectAll={() => usage.selectAllAgents()}
+        onDeselectAll={() =>
+          usage.deselectAllAgents(agentItems.map((a) => a.name))}
+      />
+
+      <FilterDropdown
         label={m.usage_model()}
         items={modelItems}
         excludedCsv={usage.selectedModels}
@@ -426,6 +451,7 @@
   <SessionActiveFilters
     modelFilters={selectedModels}
     onClearProjects={() => usage.selectAllProjects()}
+    onClearAgents={() => usage.selectAllAgents()}
     onRemoveModel={(model) => usage.toggleModel(model)}
     onClearModels={() => usage.selectAllModels()}
   />

--- a/frontend/src/lib/components/usage/UsagePage.test.ts
+++ b/frontend/src/lib/components/usage/UsagePage.test.ts
@@ -92,6 +92,27 @@ describe("UsagePage refresh behavior", () => {
     );
   });
 
+  it("loads agent metadata on mount for the Agent dropdown", async () => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        disconnect() {}
+      },
+    );
+    vi.spyOn(usage, "fetchAll").mockResolvedValue();
+    const loadAgents = vi.spyOn(sessions, "loadAgents")
+      .mockResolvedValue();
+
+    router.route = "usage";
+    router.params = {};
+
+    component = mount(UsagePage, { target: document.body });
+    await flushEffects();
+
+    expect(loadAgents).toHaveBeenCalled();
+  });
+
   it("keeps the note hidden without an unsupported usage signal", async () => {
     vi.stubGlobal(
       "ResizeObserver",

--- a/frontend/src/lib/stores/usage.svelte.ts
+++ b/frontend/src/lib/stores/usage.svelte.ts
@@ -283,6 +283,9 @@ class UsageStore {
     } else if (this.excludedProjects) {
       p.excludeProject = this.excludedProjects;
     }
+    if (this.excludedAgents) {
+      p.excludeAgent = this.excludedAgents;
+    }
     if (this.selectedModels) {
       p.model = this.selectedModels;
     }
@@ -506,7 +509,11 @@ class UsageStore {
   }
 
   get hasActiveFilters(): boolean {
-    return this.excludedProjects !== "" || this.selectedModels !== "";
+    return (
+      this.excludedProjects !== "" ||
+      this.excludedAgents !== "" ||
+      this.selectedModels !== ""
+    );
   }
 
   get isQuerying(): boolean {
@@ -913,6 +920,9 @@ export function buildUsageUrlParams(
   }
   if (state.excludedProjects) {
     params["exclude_project"] = state.excludedProjects;
+  }
+  if (state.excludedAgents) {
+    params["exclude_agent"] = state.excludedAgents;
   }
   return params;
 }

--- a/frontend/src/lib/stores/usage.test.ts
+++ b/frontend/src/lib/stores/usage.test.ts
@@ -518,6 +518,28 @@ describe("UsageStore session filter params", () => {
     );
   });
 
+  it("passes exclusion filters to usage endpoints", async () => {
+    const { usage } = await loadStore();
+
+    usage.excludedProjects = "proj-a,proj-b";
+    usage.excludedAgents = "codex";
+
+    await usage.fetchAll();
+
+    expect(usageServiceMocks.getApiV1UsageSummary).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        excludeProject: "proj-a,proj-b",
+        excludeAgent: "codex",
+      }),
+    );
+    expect(usageServiceMocks.getApiV1UsageTopSessions).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        excludeProject: "proj-a,proj-b",
+        excludeAgent: "codex",
+      }),
+    );
+  });
+
   it("stores pairwise comparison data from the generated API", async () => {
     const { usage } = await loadStore();
 
@@ -1284,6 +1306,7 @@ describe("buildUsageUrlParams", () => {
     });
     expect(params).toEqual({
       exclude_project: "p1",
+      exclude_agent: "a1",
       model: "m2",
     });
   });


### PR DESCRIPTION
Fixes the pre-existing silent no-op where clicking an agent in Usage attribution updated local exclusion state, but the next usage requests did not send `excludeAgent`. The store now includes agent exclusions in the shared request params and counts them in `hasActiveFilters`, so the API sees the same filter state the UI shows.

The Usage toolbar also gets the Agent dropdown next to Project and Model. It uses the existing dropdown pattern, which makes agent exclusions visible and reversible without relying on attribution-row clicks. This stays scoped to Usage agent filtering and does not depend on the branch-dimension work.

![Agent dropdown on the usage toolbar (synthetic data)](https://github.com/prateek/agentsview/blob/fb53a1c2cb5847c29be289c5edec2899578dde4f/972-agent-dropdown.png?raw=true)

Reviewers should start with `frontend/src/lib/stores/usage.svelte.ts`; `UsagePage.svelte` is the toolbar wiring, and the added component/store tests cover the request params plus the attribution-click path.

Fixes #976.