### PR TITLE
fix(sync): reparse same-size same-mtime in-place Claude rewrites

### DIFF
--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -4495,6 +4495,11 @@ func (e *Engine) providerSingleSessionFresh(
 	if e.providerIncrementalIdentityChanged(lookupPath, info) {
 		return 0, false, true
 	}
+	if e.providerIncrementalContentChanged(
+		e.idPrefix+sessionID, lookupPath, info,
+	) {
+		return 0, false, true
+	}
 	sess, _ := e.db.GetSession(ctx, e.idPrefix+sessionID)
 	return info.ModTime().UnixNano(), sess != nil &&
 		sess.Project != "" &&
@@ -4512,6 +4517,37 @@ func (e *Engine) providerIncrementalIdentityChanged(
 	}
 	curInode, curDevice := getFileIdentity(info)
 	return e.db.FileIdentityChanged(lookupPath, curInode, curDevice)
+}
+
+// providerIncrementalContentChanged reports whether a single-session JSONL
+// source whose size, mtime, and file identity already match the stored row
+// nonetheless holds different bytes than were last parsed. It is the last
+// guard against a same-size, same-mtime, same-inode in-place rewrite: two
+// fast writes landing in one filesystem mtime granule (or a coarse-mtime
+// filesystem) leave every stat signal identical, so only the content hash
+// distinguishes a genuine rewrite from an unchanged file. The stored file_hash
+// covers the stored file_size byte range, which shouldSkipFile has already
+// confirmed equals the current size, so the on-disk prefix hash is directly
+// comparable. Rows without a stored hash (legacy or non-fingerprinted) fall
+// back to trusting the size/mtime/identity signals, preserving prior behavior.
+func (e *Engine) providerIncrementalContentChanged(
+	fullID, lookupPath string,
+	info os.FileInfo,
+) bool {
+	if e.pathRewriter != nil {
+		// Remote imports translate per-run temp paths; the stored hash is the
+		// remote source fingerprint and freshness is handled on that path.
+		return false
+	}
+	storedHash, ok := e.db.GetSessionFileHash(fullID)
+	if !ok || storedHash == "" {
+		return false
+	}
+	curHash, err := ComputeFileHashPrefix(lookupPath, info.Size())
+	if err != nil {
+		return false
+	}
+	return curHash != storedHash
 }
 
 func (e *Engine) providerSourceFreshBeforeFingerprint(
@@ -4818,7 +4854,12 @@ func (e *Engine) tryIncrementalJSONL(
 	// the next sync.
 	newOffset := inc.FileSize + consumed
 	var incHash string
-	if agent == parser.AgentCodex {
+	// Refresh the stored content fingerprint on the incremental path. Codex
+	// needs it for parse-diff's raced-skew detection; Claude needs it so
+	// providerSingleSessionFresh can compare the stored hash against the
+	// on-disk bytes and catch a same-size, same-mtime, same-inode in-place
+	// rewrite that the size/mtime/identity skip signals cannot see.
+	if agent == parser.AgentCodex || agent == parser.AgentClaude {
 		if hash, err := ComputeFileHashPrefix(file.Path, newOffset); err == nil {
 			incHash = hash
 		}
@@ -6453,7 +6494,11 @@ func shouldReplaceFullParseMessages(
 // session metadata without overwriting columns that are not
 // recomputed during incremental parsing (e.g. parent_session_id,
 // relationship_type). Codex refreshes file_hash because parse-diff
-// uses it as the transcript fingerprint for raced-skew detection.
+// uses it as the transcript fingerprint for raced-skew detection;
+// Claude refreshes it so providerSingleSessionFresh can use the
+// stored hash as a content fingerprint against same-size in-place
+// rewrites. Other agents pass an empty hash, which COALESCE leaves
+// untouched.
 func (e *Engine) writeIncremental(
 	inc *incrementalUpdate,
 ) error {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -4482,8 +4482,14 @@ func (e *Engine) providerSingleSessionFresh(
 	if e.pathRewriter != nil {
 		lookupPath = e.pathRewriter(path)
 	}
+	// statPath is the on-disk file the stat came from: lookupPath when it
+	// resolves (local sync, where lookupPath == path), otherwise the physical
+	// source path (remote sync rewrites path to a non-local logical key). The
+	// content guard below hashes statPath, so it must be the openable file.
+	statPath := lookupPath
 	info, err := os.Stat(lookupPath)
 	if err != nil {
+		statPath = path
 		info, err = os.Stat(path)
 		if err != nil {
 			return 0, false, false
@@ -4496,7 +4502,7 @@ func (e *Engine) providerSingleSessionFresh(
 		return 0, false, true
 	}
 	if e.providerIncrementalContentChanged(
-		e.idPrefix+sessionID, lookupPath, info,
+		e.idPrefix+sessionID, statPath, info,
 	) {
 		return 0, false, true
 	}
@@ -4525,25 +4531,30 @@ func (e *Engine) providerIncrementalIdentityChanged(
 // guard against a same-size, same-mtime, same-inode in-place rewrite: two
 // fast writes landing in one filesystem mtime granule (or a coarse-mtime
 // filesystem) leave every stat signal identical, so only the content hash
-// distinguishes a genuine rewrite from an unchanged file. The stored file_hash
-// covers the stored file_size byte range, which shouldSkipFile has already
-// confirmed equals the current size, so the on-disk prefix hash is directly
-// comparable. Rows without a stored hash (legacy or non-fingerprinted) fall
-// back to trusting the size/mtime/identity signals, preserving prior behavior.
+// distinguishes a genuine rewrite from an unchanged file.
+//
+// hashPath is the physical file the stat came from -- the local path for
+// local sources, the materialized download for remote (path-rewritten)
+// sources. The stored file_hash is computed over those same materialized
+// bytes on both the full-parse (hashJSONLSourceFile) and incremental
+// (ComputeFileHashPrefix) paths, so the on-disk prefix hash is directly
+// comparable regardless of the logical key the row is stored under. That is
+// also why this is the correct freshness signal for remote sync: every
+// re-download gets a fresh inode, so the inode net is disabled to avoid a
+// false-positive re-parse, but identical content still hashes equal here while
+// a genuine rewrite does not. shouldSkipFile has already confirmed the stored
+// file_size equals the current size, so the prefix hash covers the stored byte
+// range. Rows without a stored hash (legacy or non-fingerprinted) fall back to
+// trusting the size/mtime/identity signals, preserving prior behavior.
 func (e *Engine) providerIncrementalContentChanged(
-	fullID, lookupPath string,
+	fullID, hashPath string,
 	info os.FileInfo,
 ) bool {
-	if e.pathRewriter != nil {
-		// Remote imports translate per-run temp paths; the stored hash is the
-		// remote source fingerprint and freshness is handled on that path.
-		return false
-	}
 	storedHash, ok := e.db.GetSessionFileHash(fullID)
 	if !ok || storedHash == "" {
 		return false
 	}
-	curHash, err := ComputeFileHashPrefix(lookupPath, info.Size())
+	curHash, err := ComputeFileHashPrefix(hashPath, info.Size())
 	if err != nil {
 		return false
 	}

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -7579,14 +7579,21 @@ func TestIncrementalSync_ClaudeAppend(t *testing.T) {
 		assert.Equal(t, "inc-test", m.SessionID, "msgs[%d].SessionID = %q, want inc-test", i, m.SessionID)
 	}
 
-	// Metadata preserved (file_hash not cleared).
+	// file_hash is refreshed to the appended content's fingerprint (not
+	// cleared, not left on the pre-append snapshot) so the freshness gate can
+	// use it to detect a later same-size in-place rewrite.
 	updated, err := env.db.GetSessionFull(
 		context.Background(), "inc-test",
 	)
 	require.NoError(t, err, "GetSessionFull after incremental")
-	require.NotNil(t, updated.FileHash, "file_hash = nil, want %q (preserved)", origHash)
-	assert.Equal(t, origHash, *updated.FileHash,
-		"file_hash = %v, want %q (preserved)", updated.FileHash, origHash)
+	require.NotNil(t, updated.FileHash, "file_hash = nil, want appended-content hash")
+	require.NotEmpty(t, *updated.FileHash, "file_hash empty after incremental append")
+	assert.NotEqual(t, origHash, *updated.FileHash,
+		"file_hash = %q, want it refreshed away from the pre-append snapshot", origHash)
+	wantHash, err := sync.ComputeFileHash(path)
+	require.NoError(t, err, "hash appended file")
+	assert.Equal(t, wantHash, *updated.FileHash,
+		"file_hash does not match the appended file content")
 	assert.True(t, updated.HasTotalOutputTokens, "HasTotalOutputTokens = false, want true")
 	assert.True(t, updated.HasPeakContextTokens, "HasPeakContextTokens = false, want true")
 	assert.Equal(t, 200, updated.TotalOutputTokens, "TotalOutputTokens = %d, want 200", updated.TotalOutputTokens)
@@ -8091,6 +8098,70 @@ func TestIncrementalSync_ClaudeSameSizeInPlaceRewriteClearsStaleRows(t *testing.
 	msgs := fetchMessages(t, env.db, "same-size-in-place")
 	require.Len(t, msgs, 1)
 	assert.Contains(t, msgs[0].Content, "replacement")
+}
+
+// TestIncrementalSync_ClaudeSameSizeSameMtimeInPlaceRewriteUsesFullParse pins
+// the worst case for the stat-only fast-skip: a file rewritten in place (same
+// inode and device) with the same byte size and the same mtime. Two fast
+// successive writes landing in one filesystem mtime granule produce exactly
+// this state in the wild, and neither the size/mtime skip nor the inode net can
+// see the change. The engine must still detect the new content and full-parse
+// instead of serving the stale rows.
+func TestIncrementalSync_ClaudeSameSizeSameMtimeInPlaceRewriteUsesFullParse(
+	t *testing.T,
+) {
+	if runtime.GOOS == "windows" {
+		t.Skip("identity tracking is a no-op on Windows")
+	}
+	env := setupSingleAgentTestEnv(t, parser.AgentClaude)
+
+	original := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("first", tsZero),
+		testjsonl.ClaudeAssistantJSON("alpha", tsZeroS5),
+	)
+	path := env.writeClaudeSession(
+		t, "proj", "same-size-same-mtime-in-place.jsonl", original,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+	assertSessionMessageCount(t, env.db, "same-size-same-mtime-in-place", 2)
+
+	full, err := env.db.GetSessionFull(
+		context.Background(), "same-size-same-mtime-in-place",
+	)
+	require.NoError(t, err, "GetSessionFull")
+	require.NotNil(t, full.FileInode, "file_inode not populated after initial sync")
+	origInode := *full.FileInode
+	info, err := os.Stat(path)
+	require.NoError(t, err, "stat original")
+	originalMtime := info.ModTime()
+
+	replacement := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("third", tsZero),
+		testjsonl.ClaudeAssistantJSON("bravo", tsZeroS5),
+	)
+	require.Len(t, replacement, len(original), "replacement fixture must keep same byte size")
+
+	// Rewrite in place so the inode/device do not change, then restore the
+	// original mtime so size, mtime, inode, and device all match what the
+	// initial sync stored. Only the content differs.
+	require.NoError(t, os.WriteFile(path, []byte(replacement), 0o644), "in-place rewrite")
+	require.NoError(t, os.Chtimes(path, originalMtime, originalMtime), "restore mtime")
+
+	env.engine.SyncPaths([]string{path})
+
+	msgs := fetchMessages(t, env.db, "same-size-same-mtime-in-place")
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "third", msgs[0].Content)
+	assert.Equal(t, "bravo", msgs[1].Content)
+
+	full, err = env.db.GetSessionFull(
+		context.Background(), "same-size-same-mtime-in-place",
+	)
+	require.NoError(t, err, "GetSessionFull after replace")
+	require.NotNil(t, full.FileInode, "file_inode cleared after replace")
+	// The rewrite was in place, so the inode is unchanged: the fix must catch
+	// the content change through the stored hash, not the identity net.
+	assert.Equal(t, origInode, *full.FileInode)
 }
 
 // TestIncrementalSync_ClaudeMidStreamSplitFallsBackToFullParse covers

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -8059,6 +8059,124 @@ func TestIncrementalSync_ClaudePathRewriterIgnoresTempInodeChange(t *testing.T) 
 	})
 }
 
+// TestIncrementalSync_ClaudePathRewriterSameSizeSameMtimeRewrite covers the
+// remote (path-rewritten) equivalent of the same-size, same-mtime in-place
+// rewrite. A remote re-download always lands on a fresh inode, so the inode net
+// is disabled for path-rewritten sources; only the content hash can tell an
+// unchanged re-download from a rewrite that kept the same size and mtime. The
+// content guard hashes the materialized download, so an unchanged copy must
+// still skip while a genuine same-size same-mtime rewrite must full-parse.
+func TestIncrementalSync_ClaudePathRewriterSameSizeSameMtimeRewrite(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("identity tracking is a no-op on Windows")
+	}
+
+	original := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("first", tsZero),
+		testjsonl.ClaudeAssistantJSON("alpha", tsZeroS5),
+	)
+	changed := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("third", tsZero),
+		testjsonl.ClaudeAssistantJSON("bravo", tsZeroS5),
+	)
+	require.Len(t, changed, len(original), "fixtures must keep same byte size")
+
+	const remoteRoot = "/home/test/.claude/projects"
+	mkRewriter := func(roots ...string) func(string) string {
+		return func(p string) string {
+			for _, root := range roots {
+				rel, err := filepath.Rel(root, p)
+				if err == nil && !strings.HasPrefix(rel, "..") {
+					return "host:" + filepath.ToSlash(
+						filepath.Join(remoteRoot, rel),
+					)
+				}
+			}
+			return "host:" + filepath.ToSlash(p)
+		}
+	}
+
+	tests := []struct {
+		name          string
+		second        string
+		wantSynced    int
+		wantSkipped   int
+		wantUser      string
+		wantAssistant string
+	}{
+		{
+			name:          "unchanged re-download skips",
+			second:        original,
+			wantSynced:    0,
+			wantSkipped:   1,
+			wantUser:      "first",
+			wantAssistant: "alpha",
+		},
+		{
+			name:          "same-size same-mtime rewrite full-parses",
+			second:        changed,
+			wantSynced:    1,
+			wantSkipped:   0,
+			wantUser:      "third",
+			wantAssistant: "bravo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			database := dbtest.OpenTestDB(t)
+			firstRoot := t.TempDir()
+			secondRoot := t.TempDir()
+			rewriter := mkRewriter(firstRoot, secondRoot)
+
+			firstPath := filepath.Join(firstRoot, "proj", "remote-rewrite.jsonl")
+			dbtest.WriteTestFile(t, firstPath, []byte(original))
+			firstInfo, err := os.Stat(firstPath)
+			require.NoError(t, err, "stat first temp copy")
+			firstEngine := sync.NewEngine(database, sync.EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{
+					parser.AgentClaude: {firstRoot},
+				},
+				Machine:      "host",
+				IDPrefix:     "host~",
+				PathRewriter: rewriter,
+				Ephemeral:    true,
+			})
+			runSyncAndAssert(t, firstEngine, sync.SyncStats{
+				TotalSessions: 1, Synced: 1,
+			})
+
+			// Second temp copy: same byte size, same mtime, different inode.
+			// Only the content differs (or not, per the case).
+			secondPath := filepath.Join(secondRoot, "proj", "remote-rewrite.jsonl")
+			dbtest.WriteTestFile(t, secondPath, []byte(tt.second))
+			require.NoError(t,
+				os.Chtimes(secondPath, firstInfo.ModTime(), firstInfo.ModTime()),
+				"preserve remote mtime on second temp copy",
+			)
+			secondEngine := sync.NewEngine(database, sync.EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{
+					parser.AgentClaude: {secondRoot},
+				},
+				Machine:      "host",
+				IDPrefix:     "host~",
+				PathRewriter: rewriter,
+				Ephemeral:    true,
+			})
+			runSyncAndAssert(t, secondEngine, sync.SyncStats{
+				TotalSessions: 1,
+				Synced:        tt.wantSynced,
+				Skipped:       tt.wantSkipped,
+			})
+
+			msgs := fetchMessages(t, database, "host~remote-rewrite")
+			require.Len(t, msgs, 2)
+			assert.Equal(t, tt.wantUser, msgs[0].Content)
+			assert.Equal(t, tt.wantAssistant, msgs[1].Content)
+		})
+	}
+}
+
 func TestIncrementalSync_ClaudeSameSizeInPlaceRewriteClearsStaleRows(t *testing.T) {
 	env := setupSingleAgentTestEnv(t, parser.AgentClaude)
 


### PR DESCRIPTION
The single-session freshness fast path skips re-parsing a Claude JSONL source when its size, mtime, and file identity (inode/device) all match the stored row. A same-size, same-mtime, same-inode **in-place** rewrite matches all three signals, so the engine keeps the stale rows instead of re-parsing. This happens in the wild when two writes land in one filesystem mtime granule, or on a coarse-mtime filesystem. The inode net (#357) only catches atomic-rename replacements (the inode changes); it is blind to in-place rewrites. The same gap produced a nondeterministic CI flake in `TestIncrementalSync_ClaudeSameSizeFileReplaceUsesFullParse` on filesystems where the inode signal is unavailable and the check degrades to mtime alone.

Fix: a content-hash tie-breaker that runs **only** once size + mtime + identity already match — it compares the on-disk prefix hash (over the stored `file_size`, which `shouldSkipFile` has confirmed equals the current size) against the stored `file_hash`, and forces a full parse on mismatch. The common path stays cheap: a real append changes the size and returns before hashing, so the hash is paid only for sources that already look byte-for-byte unchanged — the same skip-path-hashing the codebase already uses for coarse-mtime sources (S3/Aider/Shelley). Rows without a stored hash fall back to the prior size/mtime/identity behavior. Claude's incremental path now refreshes `file_hash` (previously only Codex did), so the stored hash stays a valid current fingerprint.

Covers local **and** remote (path-rewritten) sync: for remote sources the physical materialized file is hashed (the logical rewritten key is not openable), and the stored hash is computed over those same materialized bytes on both the full-parse and incremental paths, so the comparison is directly comparable — an unchanged re-download still hashes equal and skips, while a genuine rewrite re-parses.

Tradeoff: the content hash is a recurring read on the freshness fast path for otherwise-unchanged Claude sessions, bounded by the sync cutoff window. It is the deliberate cost of closing a correctness gap (silently serving stale content) that stat signals cannot detect.

Where to look: `internal/sync/engine.go` — `providerIncrementalContentChanged` and the `statPath` capture in `providerSingleSessionFresh`, plus the Claude `file_hash` refresh in `tryIncrementalJSONL`/`writeIncremental`. Tests in `internal/sync/engine_integration_test.go` cover the local in-place rewrite, the remote path-rewritten rewrite, and the unchanged-remote-re-download skip.