### PR TITLE
fix(parser): discover OMP sessions with a leading title slot

### DIFF
--- a/internal/parser/discovery.go
+++ b/internal/parser/discovery.go
@@ -868,9 +868,12 @@ func ResolveGeminiProject(
 }
 
 // IsPiSessionFile reads the first non-blank line of path and returns true
-// when the JSON type field equals "session". The scanner buffer grows up to
-// 64 MiB to match parser.maxLineSize. Leading blank lines are skipped to
-// match lineReader behavior.
+// when the JSON type field equals "session". OMP (Oh My Pi) v16.3+ prefixes
+// session files with a fixed-width rewritable {"type":"title",...} slot
+// line, so title lines before the session header are skipped, matching the
+// header scan in parsePiLikeSession. The scanner buffer grows up to 64 MiB
+// to match parser.maxLineSize. Leading blank lines are skipped to match
+// lineReader behavior.
 func IsPiSessionFile(path string) bool {
 	f, err := os.Open(path)
 	if err != nil {
@@ -884,7 +887,11 @@ func IsPiSessionFile(path string) bool {
 		if line == "" {
 			continue
 		}
-		return gjson.Get(line, "type").Str == "session"
+		typ := gjson.Get(line, "type").Str
+		if typ == "title" {
+			continue
+		}
+		return typ == "session"
 	}
 	return false
 }

--- a/internal/parser/discovery_test.go
+++ b/internal/parser/discovery_test.go
@@ -1435,6 +1435,29 @@ func TestIsPiSessionFile(t *testing.T) {
 			"expected false for non-session JSON")
 	})
 
+	t.Run("OMPTitleSlotBeforeSession", func(t *testing.T) {
+		// OMP (Oh My Pi) v16.3+ writes a fixed-width rewritable title slot
+		// as the first line; the session header is on the second line.
+		f, err := os.CreateTemp(t.TempDir(), "omp-*.jsonl")
+		require.NoError(t, err)
+		_, _ = f.WriteString(
+			`{"type":"title","v":1,"title":"","updatedAt":"2026-07-02T09:48:32.328Z","pad":"      "}` + "\n" +
+				`{"type":"session","version":3,"id":"abc","timestamp":"2026-07-02T09:48:32.328Z","cwd":"/repos/x"}` + "\n")
+		f.Close()
+		assert.True(t, IsPiSessionFile(f.Name()),
+			"expected true for OMP file with title slot before session header")
+	})
+
+	t.Run("OMPTitleSlotWithoutSession", func(t *testing.T) {
+		f, err := os.CreateTemp(t.TempDir(), "omp-*.jsonl")
+		require.NoError(t, err)
+		_, _ = f.WriteString(
+			`{"type":"title","v":1,"title":"orphan","updatedAt":"2026-07-02T09:48:32.328Z","pad":" "}` + "\n")
+		f.Close()
+		assert.False(t, IsPiSessionFile(f.Name()),
+			"expected false for title slot with no session header")
+	})
+
 	t.Run("EmptyFile", func(t *testing.T) {
 		f, err := os.CreateTemp(t.TempDir(), "pi-*.jsonl")
 		require.NoError(t, err)

--- a/internal/parser/pi.go
+++ b/internal/parser/pi.go
@@ -39,8 +39,11 @@ func parsePiLikeSession(
 
 	// --- Parse session header (first non-whitespace line) ---
 	// Skip whitespace-only lines to stay consistent with
-	// IsPiSessionFile in discovery.go which uses TrimSpace.
-	var headerLine string
+	// IsPiSessionFile in discovery.go which uses TrimSpace. OMP (Oh My Pi)
+	// v16.3+ prefixes the header with a fixed-width rewritable
+	// {"type":"title",...} slot line holding the current session title;
+	// skip it too (matching IsPiSessionFile) and keep its title.
+	var headerLine, slotTitle string
 	for {
 		line, ok := lr.next()
 		if !ok {
@@ -48,10 +51,15 @@ func parsePiLikeSession(
 				"not a pi session: missing session header in %s", path,
 			)
 		}
-		if strings.TrimSpace(line) != "" {
-			headerLine = line
-			break
+		if strings.TrimSpace(line) == "" {
+			continue
 		}
+		if gjson.Get(line, "type").Str == "title" {
+			slotTitle = gjson.Get(line, "title").Str
+			continue
+		}
+		headerLine = line
+		break
 	}
 
 	if !gjson.Valid(headerLine) {
@@ -68,6 +76,7 @@ func parsePiLikeSession(
 
 	sessionID := gjson.Get(headerLine, "id").Str
 	cwd := gjson.Get(headerLine, "cwd").Str
+	headerTitle := gjson.Get(headerLine, "title").Str
 	headerTimestamp := parseTimestamp(gjson.Get(headerLine, "timestamp").Str)
 
 	// If project was not passed in, derive from cwd.
@@ -239,6 +248,15 @@ func parsePiLikeSession(
 
 	if err := lr.Err(); err != nil {
 		return nil, nil, fmt.Errorf("reading pi %s: %w", path, err)
+	}
+
+	// Session name precedence: the OMP title slot is rewritten in place
+	// and always holds the current title, so it outranks session_info
+	// renames; the header title is the initial auto-generated fallback.
+	if slotTitle != "" {
+		sessionName = slotTitle
+	} else if sessionName == "" {
+		sessionName = headerTitle
 	}
 
 	// V1 fallback: derive session ID from filename.

--- a/internal/parser/pi_provider_test.go
+++ b/internal/parser/pi_provider_test.go
@@ -63,6 +63,41 @@ func TestOMPProviderSourceMethods(t *testing.T) {
 	assert.Equal(t, sourcePath, changed[0].DisplayPath)
 }
 
+// TestOMPProviderDiscoversTitleSlotSession reproduces issue #959: OMP
+// v16.3+ writes a fixed-width title slot line before the session header,
+// so discovery must look past it instead of only sniffing the first line.
+func TestOMPProviderDiscoversTitleSlotSession(t *testing.T) {
+	root := t.TempDir()
+	sourcePath := filepath.Join(root, "-repos-x", "2026-07-02T09-48-32-328Z_omp-slot.jsonl")
+	writeSourceFile(t, sourcePath, strings.Join([]string{
+		`{"type":"title","v":1,"title":"Fix the widget","source":"auto","updatedAt":"2026-07-02T09:50:00.000Z","pad":"   "}`,
+		`{"type":"session","version":3,"id":"omp-slot","timestamp":"2026-07-02T09:48:32.328Z","cwd":"/repos/x"}`,
+		`{"type":"message","id":"msg-1","parentId":null,"timestamp":"2026-07-02T09:48:44.939Z","message":{"role":"user","content":[{"type":"text","text":"just response ok"}]}}`,
+		"",
+	}, "\n"))
+
+	provider, ok := NewProvider(AgentOMP, ProviderConfig{
+		Roots:   []string{root},
+		Machine: "devbox",
+	})
+	require.True(t, ok)
+
+	discovered, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, discovered, 1,
+		"OMP session with leading title slot must be discovered")
+	assert.Equal(t, sourcePath, discovered[0].DisplayPath)
+
+	outcome, err := provider.Parse(context.Background(), ParseRequest{
+		Source: discovered[0],
+	})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	sess := outcome.Results[0].Result.Session
+	assert.Equal(t, "omp:omp-slot", sess.ID)
+	assert.Equal(t, "Fix the widget", sess.SessionName)
+}
+
 func TestPiProviderSourceMethods(t *testing.T) {
 	root := t.TempDir()
 	sourcePath := filepath.Join(root, "encoded-cwd", "session-123.jsonl")

--- a/internal/parser/pi_test.go
+++ b/internal/parser/pi_test.go
@@ -125,6 +125,76 @@ func TestPiProviderParsesSessionInfoLastNameWins(t *testing.T) {
 	assert.Equal(t, "Final name", sess.SessionName)
 }
 
+// TestPiProviderParsesOMPTitleSlot verifies that OMP's fixed-width title
+// slot line before the session header is skipped and its title becomes the
+// session name (issue #959: OMP v16.3+ session files start with the slot,
+// not the session header).
+func TestPiProviderParsesOMPTitleSlot(t *testing.T) {
+	content := strings.Join([]string{
+		`{"type":"title","v":1,"title":"Build Bloom filter research artifact","source":"auto","updatedAt":"2026-07-03T06:32:44.479Z","pad":"    "}`,
+		`{"type":"session","version":3,"id":"omp-sess","timestamp":"2026-07-03T06:30:58.508Z","cwd":"/Users/alice/code/my-project","title":"Follow PROJECT.md instructions","titleSource":"auto"}`,
+		`{"type":"model_change","id":"mc-1","parentId":null,"timestamp":"2026-07-03T06:30:58.610Z","model":"anthropic/claude-opus-4-8"}`,
+		`{"type":"thinking_level_change","id":"tl-1","parentId":"mc-1","timestamp":"2026-07-03T06:30:58.611Z","thinkingLevel":"high"}`,
+		`{"type":"message","id":"msg-1","parentId":"tl-1","timestamp":"2026-07-03T06:31:00.000Z","message":{"role":"user","content":[{"type":"text","text":"hello"}]}}`,
+		`{"type":"message","id":"msg-2","parentId":"msg-1","timestamp":"2026-07-03T06:31:05.000Z","message":{"role":"assistant","content":[{"type":"text","text":"hi"}],"model":"claude-opus-4-8","usage":{"input":2,"output":4}}}`,
+		"",
+	}, "\n")
+
+	sess, msgs := runPiParserTest(t, content)
+
+	assert.Equal(t, "pi:omp-sess", sess.ID)
+	assert.Equal(t, "/Users/alice/code/my-project", sess.Cwd)
+	assert.Equal(t, "Build Bloom filter research artifact", sess.SessionName,
+		"title slot title should become the session name")
+	assert.Equal(t, 2, sess.MessageCount,
+		"the title slot must not count as a message")
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "hello", sess.FirstMessage)
+}
+
+// TestPiProviderParsesOMPHeaderTitleFallback verifies that when the title
+// slot is empty (session not yet titled) the header's auto-generated title
+// is used instead.
+func TestPiProviderParsesOMPHeaderTitleFallback(t *testing.T) {
+	content := strings.Join([]string{
+		`{"type":"title","v":1,"title":"","updatedAt":"2026-07-03T06:30:58.508Z","pad":"    "}`,
+		`{"type":"session","version":3,"id":"omp-sess","timestamp":"2026-07-03T06:30:58.508Z","cwd":"/Users/alice/code/my-project","title":"Header auto title","titleSource":"auto"}`,
+		`{"type":"message","id":"msg-1","parentId":null,"timestamp":"2026-07-03T06:31:00.000Z","message":{"role":"user","content":"hello"}}`,
+		"",
+	}, "\n")
+
+	sess, _ := runPiParserTest(t, content)
+
+	assert.Equal(t, "Header auto title", sess.SessionName)
+}
+
+// TestPiProviderParsesOMPTitleSlotWinsOverSessionInfo pins the title
+// precedence: the slot is rewritten in place and always holds the current
+// title, so it outranks session_info renames and the header title.
+func TestPiProviderParsesOMPTitleSlotWinsOverSessionInfo(t *testing.T) {
+	content := strings.Join([]string{
+		`{"type":"title","v":1,"title":"Slot title","source":"user","updatedAt":"2026-07-03T06:32:00.000Z","pad":" "}`,
+		`{"type":"session","version":3,"id":"omp-sess","timestamp":"2026-07-03T06:30:58.508Z","cwd":"/Users/alice/code/my-project","title":"Header title"}`,
+		`{"type":"session_info","id":"info-1","parentId":null,"timestamp":"2026-07-03T06:31:00.000Z","name":"Info name"}`,
+		`{"type":"message","id":"msg-1","parentId":"info-1","timestamp":"2026-07-03T06:31:01.000Z","message":{"role":"user","content":"hello"}}`,
+		"",
+	}, "\n")
+
+	sess, _ := runPiParserTest(t, content)
+
+	assert.Equal(t, "Slot title", sess.SessionName)
+}
+
+// TestPiProviderParsesOMPTitleSlotWithoutHeader verifies that a file with
+// only a title slot and no session header is still rejected.
+func TestPiProviderParsesOMPTitleSlotWithoutHeader(t *testing.T) {
+	path := createTestFile(t, "pi-session.jsonl",
+		`{"type":"title","v":1,"title":"orphan","updatedAt":"2026-07-03T06:30:58.508Z","pad":" "}`+"\n")
+	_, _, err := parsePiTestSession(t, path, "my_project", "local")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a pi session")
+}
+
 // TestPiProviderParsesUserMessages verifies user message content and ordinals
 // (PRSR-02, PRSR-01).
 func TestPiProviderParsesUserMessages(t *testing.T) {


### PR DESCRIPTION
Fixes #959

## What

OMP (Oh My Pi) v16.3+ writes a fixed-width, rewritable `{"type":"title",...}` slot as the first line of each session file — exactly 256 UTF-8 bytes including newline, space-padded via its `pad` field — so the current title can be updated in place without shifting the rest of the file ([`session-title-slot.ts`](https://github.com/can1357/oh-my-pi/blob/master/packages/coding-agent/src/session/session-title-slot.ts)). The `{"type":"session",...}` header now sits on the second line.

`IsPiSessionFile` sniffed only the first non-blank line for a session header, so discovery rejected every OMP session. `parsePiLikeSession` made the same first-line assumption one layer deeper and would have refused to parse them regardless.

## Changes

- `IsPiSessionFile` skips `"title"`-typed lines before deciding, staying in sync with the parser's header scan (the two are documented to match).
- `parsePiLikeSession` skips the slot in its header scan and keeps its title. Session name precedence: slot title (rewritten in place, always current) > `session_info` renames (pi lineage, which has no slot) > v3 header `title` (the initial auto-generated title).
- Plain pi files without the slot behave exactly as before, and a title-slot-only file with no session header is still rejected.

## Where to look

- `internal/parser/discovery.go` — the sniff loop
- `internal/parser/pi.go` — header scan and name precedence

## Limitations / follow-ups

- OMP records branch lineage as `parentSession` (a session ID) where pi uses `branchedFrom` (a file path), so `ParentSessionID` stays empty for branched OMP sessions; left for a follow-up.
- Other OMP-specific entry types (`title_change`, `custom`, `custom_message`, the `fileMention` message role) continue to fall through the existing skip-silently paths.
