### PR TITLE
docs: add 0.36.1 release notes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,69 @@ title: Changelog
 description: Release history for AgentsView
 ---
 
+## 0.36.1
+<small>2026-07-03</small>
+
+**New features**
+
+- Add **Devin CLI session support**. AgentsView now discovers Devin CLI roots,
+  reads local session data from the `cli/` subtree, parses Devin messages and
+  tool activity, includes Devin in supported-agent metadata, and documents the
+  safe root to share when filing bug reports.
+- Extend **`parse-diff` diagnostics** for sessions last written through the
+  incremental-append path. These rows are now classified as
+  `incremental_skew`, excluded from `--fail-on-change`, and accompanied by
+  guidance to run a full resync for a clean parser-drift baseline.
+- Report **Antigravity `gen_metadata` without usage anomalies** in sync
+  summaries, so operators can spot Antigravity records that contain generation
+  metadata but did not produce normalized usage totals.
+
+**Improvements**
+
+- Show clearer **startup and resync state** while AgentsView initializes.
+  Background startup now publishes the daemon PID, elapsed time, current phase,
+  progress detail, and log path for `agentsview serve status`, while full
+  resyncs print durable phase and completion lines.
+- Improve **remote sync configuration and error reporting**. HTTP remote sync
+  now validates configured hosts more directly, keeps ad hoc HTTP remotes
+  unsupported, and maps common failures such as token rejection, missing remote
+  endpoints, connection refusal, DNS failures, and timeouts to actionable
+  messages.
+- Refresh **frontend controls and dialogs** by migrating the Svelte UI to the
+  shared `@kenn-io/kit-ui` components, making filters, range pickers, dialogs,
+  settings controls, copy buttons, refresh controls, and related interaction
+  states more consistent across pages.
+
+**Bug fixes**
+
+- Discover **OhMyPi sessions with a leading title slot**, matching the current
+  OMP/Pi-style transcript shape instead of skipping those files.
+- Reparse **in-place Claude rewrites** even when the source file size and mtime
+  are unchanged, so same-length edits no longer leave stale stored messages.
+- Fix **data-version resync completion** so preserved orphaned sessions and
+  sessions copied through an aborted-resync fallback still receive the
+  backfills they need instead of being treated as fully rewritten.
+- Scope **PostgreSQL session-alias backfill markers per push target**, so one
+  PostgreSQL destination cannot incorrectly satisfy or block the required full
+  alias backfill for another target.
+
+**Acknowledgements**
+
+- Thanks to [Aaron Florey](https://github.com/aaronflorey) for Devin CLI
+  session discovery and parsing.
+- Thanks to [Matthew Jacobs](https://github.com/mjacobs) for `parse-diff`
+  incremental-skew diagnostics, OMP leading-title discovery, Antigravity
+  `gen_metadata` anomaly reporting, and the same-size same-mtime Claude rewrite
+  fix.
+- Thanks to [Wes McKinney](https://github.com/wesm) for startup transparency,
+  resync consistency fixes, and remote sync configuration and error reporting.
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for the
+  frontend migration to shared UI controls and dialogs.
+- Thanks to [Rod Boev](https://github.com/rodboev) for scoping PostgreSQL
+  session-alias backfill markers by target.
+
+---
+
 ## 0.36.0
 <small>2026-07-02</small>
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -708,6 +708,21 @@ are skipped because there is no source file to re-parse. Provider-backed stores
 with authoritative local sources, including Warp, Forge, Piebald, and Devin, are
 covered alongside normal file-backed agents.
 
+The report distinguishes parser drift from comparison-basis skew:
+
+- `raced` means the source changed while `parse-diff` was running. It is
+  reported for review but does not fail `--fail-on-change`.
+- `incremental_skew` means the stored row was last written by an
+  incremental-append sync, so a fresh full re-parse can legitimately differ on
+  append-path metadata. It is also reported but excluded from
+  `--fail-on-change`.
+- `pending_resync` means the stored data version is behind the running binary;
+  the next data-version resync rewrites those rows.
+
+If the report includes `incremental_skew`, run a full resync before treating the
+archive as a clean parser-drift baseline. A full resync rewrites those rows
+through the normalization path and restores strict `parse-diff` scrutiny.
+
 ______________________________________________________________________
 
 ### `agentsview import`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -129,6 +129,13 @@ per-host `token` is required and must match the remote daemon's `auth_token`.
 Do not reuse the collector daemon's own `auth_token` for untrusted remote
 endpoints.
 
+Each `remote_hosts.host` value must be unique. A configured HTTP host can be
+selected later with `agentsview sync --host <name>`, but ad hoc HTTP remotes are
+not supported; without a matching configured host, `--host` remains an SSH
+remote sync. HTTP failures are summarized with actionable messages for common
+cases such as token rejection, missing remote archive endpoints, connection
+refusal, DNS failures, and timeouts.
+
 The remote daemon must also listen on an interface the collector can reach.
 The server binds `127.0.0.1` by default, so set `host` in the remote
 machine's config.toml (requires `require_auth = true`) or start it with
@@ -628,7 +635,13 @@ full-text search indexes on message content.
 | `skipped_files`      | Cache of non-interactive session files                                       |
 | `messages_fts`       | FTS5 virtual table for full-text search                                      |
 
-The database is automatically migrated on startup when the schema changes.
+The database is automatically migrated on startup when the schema changes. When
+the stored data version is stale, AgentsView preserves the existing database and
+runs a full resync into a fresh temporary database. The resync then copies
+preserved/orphaned session data from the previous database before swapping
+atomically. If the full resync aborts, AgentsView falls back to an incremental
+sync and leaves the data-version marker stale so a later startup can retry the
+full rewrite.
 
 ## Sync Behavior
 
@@ -651,6 +664,20 @@ that metadata shows a parse may be needed.
 
 Files that fail to parse or contain no interactive content are cached in the
 `skipped_files` table and skipped on subsequent syncs until their mtime changes.
+
+Sync summaries include a `Parser anomalies (this run)` section whenever the
+current run observes parser or sanitizer anomalies. The section can include
+malformed-line counts, unrecognized Antigravity schema sessions,
+sanitized-field counts, and Antigravity `gen_metadata without usage` counts. A
+`gen_metadata without usage` entry means Antigravity supplied generation
+metadata for one or more records, but AgentsView could not derive normalized
+usage totals from those records during that sync.
+
+When a data-version resync runs, startup output prints durable phase and
+completion lines for the resync steps. Background daemons also publish startup
+state while they hold the start lock, so `agentsview serve status` can show the
+starting PID, elapsed time, current phase, progress detail, and log path before
+the HTTP server is ready.
 
 ### Large Watch Trees
 

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -100,6 +100,14 @@ The HTTP transport is intended for private networking such as Tailscale or an
 equivalent restricted overlay. Do not expose raw archive endpoints directly to
 the public internet.
 
+HTTP remote sync failures are summarized without echoing remote-controlled URLs
+or response bodies. Common summaries point at the specific fix: a rejected token
+means the collector's per-host `token` does not match the remote daemon's
+`auth_token`; a missing endpoint means the remote host needs a newer
+AgentsView; connection refusal usually means the daemon is not running, is still
+bound to loopback, or the URL port is wrong; DNS and timeout messages point back
+to the configured `url`.
+
 For always-available fleet nodes launched with `agentsview serve --background`,
 set:
 


### PR DESCRIPTION
The 0.36.1 tag is cut, but the public release history still stops at 0.36.0 and operators would otherwise need to read implementation PRs to understand the new sync diagnostics and remote sync failure modes.

This updates the changelog with contributor acknowledgements and extends the command, configuration, and remote-access docs for `parse-diff` `incremental_skew`, startup and resync status, Antigravity `gen_metadata` anomaly summaries, and HTTP remote sync troubleshooting.

The docs intentionally avoid promising new workflows beyond the observed CLI and status surfaces. No screenshots were regenerated because the release UI work was component consistency rather than a new screenshot-led flow. Reviewers should focus on the changelog wording and the diagnostic names in the reference pages, since those terms are the CLI surface users will search for.