### PR TITLE
test(api): move generated-client tests out of generated output (#977)

### DIFF
--- a/frontend/src/lib/api/AnalyticsService.generated-client.test.ts
+++ b/frontend/src/lib/api/AnalyticsService.generated-client.test.ts
@@ -1,24 +1,24 @@
 import {
+  beforeEach,
   describe,
   expect,
   it,
   vi,
-  beforeEach,
 } from "vite-plus/test";
 
 const { request } = vi.hoisted(() => ({
   request: vi.fn(),
 }));
 
-vi.mock("../core/OpenAPI", () => ({
+vi.mock("./generated/core/OpenAPI", () => ({
   OpenAPI: {},
 }));
 
-vi.mock("../core/request", () => ({
+vi.mock("./generated/core/request", () => ({
   request,
 }));
 
-import { AnalyticsService } from "./AnalyticsService";
+import { AnalyticsService } from "./generated/services/AnalyticsService";
 
 describe("AnalyticsService signal sessions", () => {
   beforeEach(() => {


### PR DESCRIPTION
`frontend/src/lib/api/generated/services/AnalyticsService.test.ts` is a handwritten Vite test inside the generated client output tree. That placement conflicts with the generated-client contract in `docs/internal/huma-api-routes.md`: regeneration owns `frontend/src/lib/api/generated`, and the whole subtree is marked generated for GitHub.

This moves the test up to `frontend/src/lib/api/AnalyticsService.generated-client.test.ts`, keeping the existing request assertion intact while updating the relative import and mocks. The generated client stays committed and unchanged; this slice only makes the generated tree contain generated output again so the follow-up freshness gate can run without deleting handwritten tests.

Focused validation covers the relocated Vite test, frontend typecheck, the absence of tracked `.test.ts` files under `frontend/src/lib/api/generated`, and the relocated file's generated-file attribute.

Refs #977
