### PR TITLE
feat(usage): show session context and token breakdown (#982)

### DIFF
--- a/cmd/agentsview/archive_query_backend.go
+++ b/cmd/agentsview/archive_query_backend.go
@@ -263,7 +263,7 @@ func (b localArchiveQueryBackend) SessionUsage(
 		engine.Close()
 	}
 
-	u, err := b.database.GetSessionUsage(ctx, resolvedID)
+	u, err := b.database.GetSessionUsage(ctx, resolvedID, true)
 	if err != nil {
 		return nil, tokenUseExitErr,
 			fmt.Errorf("querying session usage: %w", err)
@@ -282,7 +282,7 @@ func (b localArchiveQueryBackend) SessionUsage(
 				"warning: pricing refresh failed: %v\n", refErr)
 		} else if refreshed {
 			if u2, e := b.database.GetSessionUsage(
-				ctx, resolvedID,
+				ctx, resolvedID, true,
 			); e == nil && u2 != nil {
 				u = u2
 			}

--- a/cmd/agentsview/session_test.go
+++ b/cmd/agentsview/session_test.go
@@ -155,7 +155,8 @@ type remoteUsageSpec struct {
 
 // remoteUsageRequests records what the fake usage server observed.
 type remoteUsageRequests struct {
-	UsagePath string
+	UsagePath  string
+	UsageQuery string
 }
 
 // newRemoteUsageServer stands in for a remote agentsview server answering
@@ -195,6 +196,7 @@ func newRemoteUsageServer(
 			writeJSONResponse(w, detailJSON)
 		case usagePath:
 			reqs.UsagePath = r.URL.Path
+			reqs.UsageQuery = r.URL.RawQuery
 			if spec.usageDelay > 0 {
 				time.Sleep(spec.usageDelay)
 			}
@@ -1080,6 +1082,8 @@ func TestSessionUsage_ServerFlagUsesHTTP(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, out)
 	assert.Equal(t, "/api/v1/sessions/remote-session/usage", reqs.UsagePath)
+	assert.Equal(t, "breakdown=true", reqs.UsageQuery,
+		"remote CLI must request full breakdown rows")
 	assert.Equal(t, tokenUseExitOK, code)
 	assert.Equal(t, "remote-session", out.SessionID)
 	assert.Equal(t, "remote-project", out.Project)

--- a/cmd/agentsview/session_usage.go
+++ b/cmd/agentsview/session_usage.go
@@ -217,7 +217,7 @@ func storeSessionUsageData(
 		return nil, tokenUseExitNotFound, nil
 	}
 
-	u, err := store.GetSessionUsage(ctx, resolvedID)
+	u, err := store.GetSessionUsage(ctx, resolvedID, true)
 	if err != nil {
 		return nil, tokenUseExitErr,
 			fmt.Errorf("querying %s session usage: %w", storeName, err)

--- a/cmd/agentsview/session_usage.go
+++ b/cmd/agentsview/session_usage.go
@@ -144,8 +144,11 @@ func httpSessionUsageData(
 		}
 		return nil, tokenUseExitErr, err
 	}
+	// Request the full breakdown so the remote path matches the
+	// shape returned by the direct store paths.
 	endpoint := strings.TrimSuffix(baseURL, "/") +
-		"/api/v1/sessions/" + url.PathEscape(resolvedID) + "/usage"
+		"/api/v1/sessions/" + url.PathEscape(resolvedID) +
+		"/usage?breakdown=true"
 	req, err := http.NewRequestWithContext(
 		ctx, http.MethodGet, endpoint, nil,
 	)

--- a/cmd/agentsview/session_usage_test.go
+++ b/cmd/agentsview/session_usage_test.go
@@ -146,6 +146,7 @@ func TestSessionUsageJSONSchemaIncludesCostContract(t *testing.T) {
 		"session_id":          "codex:abc",
 		"agent":               "codex",
 		"project":             "my-project",
+		"breakdown":           nil,
 		"total_output_tokens": float64(123),
 		"peak_context_tokens": float64(456),
 		"has_token_data":      true,

--- a/cmd/agentsview/session_usage_test.go
+++ b/cmd/agentsview/session_usage_test.go
@@ -146,6 +146,7 @@ func TestSessionUsageJSONSchemaIncludesCostContract(t *testing.T) {
 		"session_id":          "codex:abc",
 		"agent":               "codex",
 		"project":             "my-project",
+		"breakdown_count":     float64(0),
 		"breakdown":           nil,
 		"total_output_tokens": float64(123),
 		"peak_context_tokens": float64(456),

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -157,6 +157,7 @@
   "session_breadcrumb_copied": "Copied!",
   "session_breadcrumb_estimated_session_cost": "Estimated session cost",
   "session_breadcrumb_usage_breakdown_title": "Session usage breakdown",
+  "session_breadcrumb_usage_breakdown_loading": "Loading usage...",
   "session_breadcrumb_usage_breakdown_steps": [
     {
       "declarations": [

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -558,6 +558,22 @@
   ],
   "analytics_tool_usage_trend_tooltip": "{date} | {total} total | {parts}",
   "analytics_tool_usage_empty": "No tool usage data",
+  "analytics_tool_usage_loading": "Loading tool usage...",
+  "analytics_tool_usage_top_tools": "Top tools",
+  "analytics_tool_usage_sessions": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "local countPlural = count: plural"
+      ],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "{countLabel} session",
+        "countPlural=other": "{countLabel} sessions"
+      }
+    }
+  ],
   "analytics_by_category": "By Category",
   "analytics_by_agent": "By Agent",
   "analytics_by_project": "By Project",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -156,6 +156,21 @@
   "session_breadcrumb_copy_session_id_value": "Copy session ID: {id}",
   "session_breadcrumb_copied": "Copied!",
   "session_breadcrumb_estimated_session_cost": "Estimated session cost",
+  "session_breadcrumb_usage_breakdown_title": "Session usage breakdown",
+  "session_breadcrumb_usage_breakdown_steps": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "local countPlural = count: plural"
+      ],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=one": "{countLabel} step",
+        "countPlural=other": "{countLabel} steps"
+      }
+    }
+  ],
   "session_breadcrumb_copy_link_to_session": "Copy link to session",
   "session_breadcrumb_show_session_analysis": "Show session analysis",
   "session_breadcrumb_hide_session_analysis": "Hide session analysis",

--- a/frontend/messages/ko.json
+++ b/frontend/messages/ko.json
@@ -153,6 +153,20 @@
   "session_breadcrumb_copy_session_id_value": "세션 ID 복사: {id}",
   "session_breadcrumb_copied": "복사됨!",
   "session_breadcrumb_estimated_session_cost": "예상 세션 비용",
+  "session_breadcrumb_usage_breakdown_title": "세션 사용량 상세",
+  "session_breadcrumb_usage_breakdown_steps": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "local countPlural = count: plural"
+      ],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=other": "{countLabel}개 단계"
+      }
+    }
+  ],
   "session_breadcrumb_copy_link_to_session": "세션 링크 복사",
   "session_breadcrumb_show_session_analysis": "세션 분석 표시",
   "session_breadcrumb_hide_session_analysis": "세션 분석 숨기기",

--- a/frontend/messages/ko.json
+++ b/frontend/messages/ko.json
@@ -154,6 +154,7 @@
   "session_breadcrumb_copied": "복사됨!",
   "session_breadcrumb_estimated_session_cost": "예상 세션 비용",
   "session_breadcrumb_usage_breakdown_title": "세션 사용량 상세",
+  "session_breadcrumb_usage_breakdown_loading": "사용량 불러오는 중...",
   "session_breadcrumb_usage_breakdown_steps": [
     {
       "declarations": [

--- a/frontend/messages/ko.json
+++ b/frontend/messages/ko.json
@@ -544,6 +544,21 @@
   ],
   "analytics_tool_usage_trend_tooltip": "{date} | 총 {total} | {parts}",
   "analytics_tool_usage_empty": "도구 사용 데이터 없음",
+  "analytics_tool_usage_loading": "도구 사용 데이터 불러오는 중...",
+  "analytics_tool_usage_top_tools": "상위 도구",
+  "analytics_tool_usage_sessions": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "local countPlural = count: plural"
+      ],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=other": "세션 {countLabel}개"
+      }
+    }
+  ],
   "analytics_by_category": "카테고리별",
   "analytics_by_agent": "에이전트별",
   "analytics_by_project": "프로젝트별",

--- a/frontend/messages/zh-CN.json
+++ b/frontend/messages/zh-CN.json
@@ -154,6 +154,7 @@
   "session_breadcrumb_copied": "已复制！",
   "session_breadcrumb_estimated_session_cost": "预估会话成本",
   "session_breadcrumb_usage_breakdown_title": "会话用量明细",
+  "session_breadcrumb_usage_breakdown_loading": "正在加载用量数据...",
   "session_breadcrumb_usage_breakdown_steps": [
     {
       "declarations": [

--- a/frontend/messages/zh-CN.json
+++ b/frontend/messages/zh-CN.json
@@ -153,6 +153,20 @@
   "session_breadcrumb_copy_session_id_value": "复制会话 ID：{id}",
   "session_breadcrumb_copied": "已复制！",
   "session_breadcrumb_estimated_session_cost": "预估会话成本",
+  "session_breadcrumb_usage_breakdown_title": "会话用量明细",
+  "session_breadcrumb_usage_breakdown_steps": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "local countPlural = count: plural"
+      ],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=other": "{countLabel} 个步骤"
+      }
+    }
+  ],
   "session_breadcrumb_copy_link_to_session": "复制会话链接",
   "session_breadcrumb_show_session_analysis": "显示会话分析",
   "session_breadcrumb_hide_session_analysis": "隐藏会话分析",

--- a/frontend/messages/zh-CN.json
+++ b/frontend/messages/zh-CN.json
@@ -544,6 +544,21 @@
   ],
   "analytics_tool_usage_trend_tooltip": "{date} | 总计 {total} | {parts}",
   "analytics_tool_usage_empty": "无 tool 使用数据",
+  "analytics_tool_usage_loading": "正在加载 tool 使用数据...",
+  "analytics_tool_usage_top_tools": "热门 Tool",
+  "analytics_tool_usage_sessions": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "local countPlural = count: plural"
+      ],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=other": "{countLabel} 个会话"
+      }
+    }
+  ],
   "analytics_by_category": "按类别",
   "analytics_by_agent": "按 Agent",
   "analytics_by_project": "按项目",

--- a/frontend/messages/zh-TW.json
+++ b/frontend/messages/zh-TW.json
@@ -544,6 +544,21 @@
   ],
   "analytics_tool_usage_trend_tooltip": "{date} | 總計 {total} | {parts}",
   "analytics_tool_usage_empty": "無 tool 使用數據",
+  "analytics_tool_usage_loading": "正在加載 tool 使用數據...",
+  "analytics_tool_usage_top_tools": "熱門 Tool",
+  "analytics_tool_usage_sessions": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "local countPlural = count: plural"
+      ],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=other": "{countLabel} 個會話"
+      }
+    }
+  ],
   "analytics_by_category": "按類別",
   "analytics_by_agent": "按 Agent",
   "analytics_by_project": "按項目",

--- a/frontend/messages/zh-TW.json
+++ b/frontend/messages/zh-TW.json
@@ -154,6 +154,7 @@
   "session_breadcrumb_copied": "已複製！",
   "session_breadcrumb_estimated_session_cost": "預估會話成本",
   "session_breadcrumb_usage_breakdown_title": "會話用量明細",
+  "session_breadcrumb_usage_breakdown_loading": "正在載入用量數據...",
   "session_breadcrumb_usage_breakdown_steps": [
     {
       "declarations": [

--- a/frontend/messages/zh-TW.json
+++ b/frontend/messages/zh-TW.json
@@ -153,6 +153,20 @@
   "session_breadcrumb_copy_session_id_value": "複製會話 ID：{id}",
   "session_breadcrumb_copied": "已複製！",
   "session_breadcrumb_estimated_session_cost": "預估會話成本",
+  "session_breadcrumb_usage_breakdown_title": "會話用量明細",
+  "session_breadcrumb_usage_breakdown_steps": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "local countPlural = count: plural"
+      ],
+      "selectors": ["countPlural"],
+      "match": {
+        "countPlural=other": "{countLabel} 個步驟"
+      }
+    }
+  ],
   "session_breadcrumb_copy_link_to_session": "複製會話連結",
   "session_breadcrumb_show_session_analysis": "顯示會話分析",
   "session_breadcrumb_hide_session_analysis": "隱藏會話分析",

--- a/frontend/src/lib/api/generated/index.ts
+++ b/frontend/src/lib/api/generated/index.ts
@@ -115,6 +115,7 @@ export type { DbToolCategoryCount } from './models/DbToolCategoryCount';
 export type { DbToolResultEvent } from './models/DbToolResultEvent';
 export type { DbToolsAnalyticsResponse } from './models/DbToolsAnalyticsResponse';
 export type { DbToolTrendEntry } from './models/DbToolTrendEntry';
+export type { DbToolUsageAnalysis } from './models/DbToolUsageAnalysis';
 export type { DbTopSession } from './models/DbTopSession';
 export type { DbTopSessionEntry } from './models/DbTopSessionEntry';
 export type { DbTopSessionsResponse } from './models/DbTopSessionsResponse';
@@ -181,6 +182,7 @@ export type { ServiceUsagePairwiseComparisonDelta } from './models/ServiceUsageP
 export type { ServiceUsagePairwiseComparisonResponse } from './models/ServiceUsagePairwiseComparisonResponse';
 export type { ServiceUsagePairwiseComparisonSide } from './models/ServiceUsagePairwiseComparisonSide';
 export type { SessionDirectoryResponse } from './models/SessionDirectoryResponse';
+export type { SessionUsageBreakdownResponse } from './models/SessionUsageBreakdownResponse';
 export type { SessionUsageResponse } from './models/SessionUsageResponse';
 export type { SetGithubConfigInputBody } from './models/SetGithubConfigInputBody';
 export type { SetGithubConfigResponse } from './models/SetGithubConfigResponse';

--- a/frontend/src/lib/api/generated/models/BatchDeleteInputBody.ts
+++ b/frontend/src/lib/api/generated/models/BatchDeleteInputBody.ts
@@ -6,6 +6,6 @@ export type BatchDeleteInputBody = {
   /**
    * Session IDs to soft-delete
    */
-  session_ids: any[] | null;
+  session_ids: Array<string>;
 };
 

--- a/frontend/src/lib/api/generated/models/BatchDeleteInputBody.ts
+++ b/frontend/src/lib/api/generated/models/BatchDeleteInputBody.ts
@@ -6,6 +6,6 @@ export type BatchDeleteInputBody = {
   /**
    * Session IDs to soft-delete
    */
-  session_ids: Array<string>;
+  session_ids: any[] | null;
 };
 

--- a/frontend/src/lib/api/generated/models/DbInsight.ts
+++ b/frontend/src/lib/api/generated/models/DbInsight.ts
@@ -23,3 +23,4 @@ export type DbInsight = {
   template_version?: string;
   type: string;
 };
+

--- a/frontend/src/lib/api/generated/models/DbToolUsageAnalysis.ts
+++ b/frontend/src/lib/api/generated/models/DbToolUsageAnalysis.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type DbToolUsageAnalysis = {
+  call_count: number;
+  category: string;
+  pct: number;
+  session_count: number;
+  tool_name: string;
+};
+

--- a/frontend/src/lib/api/generated/models/DbToolsAnalyticsResponse.ts
+++ b/frontend/src/lib/api/generated/models/DbToolsAnalyticsResponse.ts
@@ -5,6 +5,7 @@
 export type DbToolsAnalyticsResponse = {
   by_agent: any[] | null;
   by_category: any[] | null;
+  by_tool: any[] | null;
   total_calls: number;
   trend: any[] | null;
 };

--- a/frontend/src/lib/api/generated/models/GenerateInsightRequest.ts
+++ b/frontend/src/lib/api/generated/models/GenerateInsightRequest.ts
@@ -18,3 +18,4 @@ export type GenerateInsightRequest = {
   timezone?: string;
   type: string;
 };
+

--- a/frontend/src/lib/api/generated/models/SessionUsageBreakdownResponse.ts
+++ b/frontend/src/lib/api/generated/models/SessionUsageBreakdownResponse.ts
@@ -1,0 +1,19 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type SessionUsageBreakdownResponse = {
+  cache_creation_input_tokens: number;
+  cache_read_input_tokens: number;
+  cost_usd: number;
+  has_cost: boolean;
+  input_tokens: number;
+  label: string;
+  message_ordinal?: number;
+  model: string;
+  ordinal: number;
+  output_tokens: number;
+  source: string;
+  timestamp: string;
+};
+

--- a/frontend/src/lib/api/generated/models/SessionUsageResponse.ts
+++ b/frontend/src/lib/api/generated/models/SessionUsageResponse.ts
@@ -5,6 +5,7 @@
 export type SessionUsageResponse = {
   agent: string;
   ai_credits?: number;
+  breakdown: any[] | null;
   cost_usd: number;
   has_cost: boolean;
   has_token_data: boolean;

--- a/frontend/src/lib/api/generated/models/SessionUsageResponse.ts
+++ b/frontend/src/lib/api/generated/models/SessionUsageResponse.ts
@@ -6,6 +6,7 @@ export type SessionUsageResponse = {
   agent: string;
   ai_credits?: number;
   breakdown: any[] | null;
+  breakdown_count: number;
   cost_usd: number;
   has_cost: boolean;
   has_token_data: boolean;

--- a/frontend/src/lib/api/generated/services/SessionsService.ts
+++ b/frontend/src/lib/api/generated/services/SessionsService.ts
@@ -1188,17 +1188,25 @@ export class SessionsService {
    */
   public static getApiV1SessionsIdUsage({
     id,
+    breakdown,
   }: {
     /**
      * Session ID
      */
     id: string,
+    /**
+     * Include per-step breakdown rows
+     */
+    breakdown?: boolean,
   }): CancelablePromise<SessionUsageResponse> {
     return __request(OpenAPI, {
       method: 'GET',
       url: '/api/v1/sessions/{id}/usage',
       path: {
         'id': id,
+      },
+      query: {
+        'breakdown': breakdown,
       },
       errors: {
         400: `Bad Request`,

--- a/frontend/src/lib/api/types/analytics.ts
+++ b/frontend/src/lib/api/types/analytics.ts
@@ -166,6 +166,14 @@ export interface ToolAgentBreakdown {
   categories: ToolCategoryCount[];
 }
 
+export interface ToolUsageAnalysis {
+  tool_name: string;
+  category: string;
+  call_count: number;
+  session_count: number;
+  pct: number;
+}
+
 export interface ToolTrendEntry {
   date: string;
   by_category: Record<string, number>;
@@ -175,6 +183,7 @@ export interface ToolsAnalyticsResponse {
   total_calls: number;
   by_category: ToolCategoryCount[];
   by_agent: ToolAgentBreakdown[];
+  by_tool: ToolUsageAnalysis[];
   trend: ToolTrendEntry[];
 }
 

--- a/frontend/src/lib/components/analytics/ToolUsage.svelte
+++ b/frontend/src/lib/components/analytics/ToolUsage.svelte
@@ -29,6 +29,7 @@
   );
 
   const trendEntries = $derived(analytics.tools?.trend ?? []);
+  const toolRows = $derived(analytics.tools?.by_tool ?? []);
 
   const trendMax = $derived.by(() => {
     let max = 1;
@@ -134,8 +135,42 @@
         {m.shared_retry()}
       </button>
     </div>
+  {:else if analytics.loading.tools}
+    <div class="empty">{m.analytics_tool_usage_loading()}</div>
   {:else if categories.length > 0}
     <div class="sections">
+      {#if toolRows.length > 0}
+        <div class="section">
+          <h4 class="section-title">
+            {m.analytics_tool_usage_top_tools()}
+          </h4>
+          <div class="tool-table">
+            {#each toolRows.slice(0, 8) as tool}
+              <div class="tool-row">
+                <span
+                  class="tool-dot"
+                  style="background: {colorFor(tool.category)}"
+                ></span>
+                <span class="tool-name" title={tool.tool_name}>
+                  {tool.tool_name}
+                </span>
+                <span class="tool-category">{tool.category}</span>
+                <span class="tool-count">
+                  {tool.call_count.toLocaleString()}
+                </span>
+                <span class="tool-sessions">
+                  {m.analytics_tool_usage_sessions({
+                    count: tool.session_count,
+                    countLabel: tool.session_count.toLocaleString(),
+                  })}
+                </span>
+                <span class="tool-pct">{tool.pct}%</span>
+              </div>
+            {/each}
+          </div>
+        </div>
+      {/if}
+
       <div class="section">
         <h4 class="section-title">{m.analytics_by_category()}</h4>
         <div class="bar-list">
@@ -238,6 +273,70 @@
     text-transform: uppercase;
     letter-spacing: 0.05em;
     margin-bottom: 6px;
+  }
+
+  .tool-table {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 2px;
+  }
+
+  .tool-row {
+    display: grid;
+    grid-template-columns: 8px minmax(80px, 1fr) minmax(52px, 72px) 48px 72px 40px;
+    align-items: center;
+    gap: 8px;
+    min-height: 28px;
+    padding: 4px;
+    border-radius: var(--radius-sm);
+    color: var(--text-secondary);
+    font-size: 11px;
+  }
+
+  .tool-row:hover {
+    background: var(--bg-surface-hover);
+  }
+
+  .tool-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+  }
+
+  .tool-name {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--text-primary);
+    font-weight: 500;
+  }
+
+  .tool-category {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--text-muted);
+  }
+
+  .tool-count,
+  .tool-sessions,
+  .tool-pct {
+    text-align: right;
+    font-family: var(--font-mono);
+    color: var(--text-muted);
+  }
+
+  @media (max-width: 640px) {
+    .tool-row {
+      grid-template-columns: 8px minmax(0, 1fr) 44px 36px;
+    }
+
+    .tool-category,
+    .tool-sessions {
+      display: none;
+    }
   }
 
   .bar-list {

--- a/frontend/src/lib/components/analytics/ToolUsage.test.ts
+++ b/frontend/src/lib/components/analytics/ToolUsage.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+import {
+  afterEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { mount, tick, unmount } from "svelte";
+// @ts-ignore
+import ToolUsage from "./ToolUsage.svelte";
+import { analytics } from "../../stores/analytics.svelte.js";
+
+describe("ToolUsage", () => {
+  afterEach(() => {
+    analytics.tools = null;
+    // @ts-ignore
+    analytics.errors = {
+      ...analytics.errors,
+      tools: null,
+    };
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  it("renders ranked per-tool analysis rows", async () => {
+    analytics.tools = {
+      total_calls: 6,
+      by_category: [
+        { category: "Read", count: 3, pct: 50 },
+        { category: "Bash", count: 2, pct: 33.3 },
+      ],
+      by_agent: [],
+      by_tool: [
+        {
+          tool_name: "Read",
+          category: "Read",
+          call_count: 3,
+          session_count: 2,
+          pct: 50,
+        },
+        {
+          tool_name: "Bash",
+          category: "Bash",
+          call_count: 2,
+          session_count: 1,
+          pct: 33.3,
+        },
+      ],
+      trend: [
+        {
+          date: "2024-06-03",
+          by_category: { Read: 3, Bash: 2 },
+        },
+        {
+          date: "2024-06-10",
+          by_category: { Read: 1 },
+        },
+      ],
+    };
+
+    const component = mount(ToolUsage, { target: document.body });
+    await tick();
+
+    expect(document.body.textContent).toContain("Tool Usage");
+    expect(document.body.textContent).toContain("6 calls");
+    expect(document.body.textContent).toContain("Top tools");
+    expect(document.body.textContent).toContain("Read");
+    expect(document.body.textContent).toContain("3");
+    expect(document.body.textContent).toContain("2 sessions");
+    expect(document.body.textContent).toContain("50%");
+    expect(document.body.textContent).toContain("Bash");
+    expect(document.body.textContent).toContain("1 session");
+    expect(document.body.textContent).not.toContain("1 sessions");
+    expect(document.body.textContent).toContain("33.3%");
+    expect(document.body.textContent).toContain("By Category");
+    expect(document.body.textContent).toContain("Weekly Trend");
+
+    unmount(component);
+  });
+
+  it("renders loading state while the first fetch is in flight", async () => {
+    analytics.tools = null;
+    analytics.loading = { ...analytics.loading, tools: true };
+
+    const component = mount(ToolUsage, { target: document.body });
+    await tick();
+
+    expect(document.body.textContent).toContain("Loading tool usage...");
+    expect(document.body.textContent).not.toContain("No tool usage data");
+
+    analytics.loading = { ...analytics.loading, tools: false };
+    unmount(component);
+  });
+
+  it("renders empty state without tool rows", async () => {
+    analytics.tools = {
+      total_calls: 0,
+      by_category: [],
+      by_agent: [],
+      by_tool: [],
+      trend: [],
+    };
+
+    const component = mount(ToolUsage, { target: document.body });
+    await tick();
+
+    expect(document.body.textContent).toContain("No tool usage data");
+
+    unmount(component);
+  });
+});

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -790,9 +790,12 @@
         <details class="usage-breakdown" bind:open={usageBreakdownOpen}>
           <summary
             class="usage-breakdown-trigger"
-            title="Session usage breakdown"
+            title={m.session_breadcrumb_usage_breakdown_title()}
           >
-            {sessionUsageBreakdown.length} steps
+            {m.session_breadcrumb_usage_breakdown_steps({
+              count: sessionUsageBreakdown.length,
+              countLabel: sessionUsageBreakdown.length.toLocaleString(),
+            })}
           </summary>
           {#if usageBreakdownOpen}
             <div class="usage-breakdown-menu">

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -130,6 +130,7 @@
   });
 
   let sessionCost = $state<number | null>(null);
+  let sessionUsageBreakdownCount = $state(0);
   let sessionUsageBreakdown = $state<SessionUsageBreakdownEntry[]>([]);
   // Key of the last successful usage fetch. Cost depends on more
   // than output tokens (input/cache tokens and explicit usage-event
@@ -141,34 +142,48 @@
   let costFetchKey: string | null = null;
   let costSessionId: string | null = null;
   let costRequestSeq = 0;
+  let breakdownFetchKey: string | null = null;
+  let breakdownRequestSeq = 0;
+
+  function usageFetchKey(s: Session): string {
+    return [
+      s.id,
+      s.total_output_tokens ?? 0,
+      s.peak_context_tokens ?? 0,
+      s.has_total_output_tokens ?? "",
+      s.has_peak_context_tokens ?? "",
+      s.message_count ?? 0,
+      s.ended_at ?? "",
+    ].join("\n");
+  }
+
+  function resetUsageBreakdown() {
+    sessionUsageBreakdownCount = 0;
+    sessionUsageBreakdown = [];
+    usageBreakdownOpen = false;
+    usageBreakdownLoading = false;
+    breakdownFetchKey = null;
+    breakdownRequestSeq++;
+  }
+
   $effect(() => {
     if (!session) {
       sessionCost = null;
-      sessionUsageBreakdown = [];
-      usageBreakdownOpen = false;
+      resetUsageBreakdown();
       costFetchKey = null;
       costSessionId = null;
       costRequestSeq++;
       return;
     }
     const id = session.id;
-    const key = [
-      id,
-      session.total_output_tokens ?? 0,
-      session.peak_context_tokens ?? 0,
-      session.has_total_output_tokens ?? "",
-      session.has_peak_context_tokens ?? "",
-      session.message_count ?? 0,
-      session.ended_at ?? "",
-    ].join("\n");
+    const key = usageFetchKey(session);
     if (id !== costSessionId) {
       // Entering a different session invalidates both the displayed
       // cost and the fetch cache; the cached key must never satisfy
       // the early return below while another session's request is
       // still in flight.
       sessionCost = null;
-      sessionUsageBreakdown = [];
-      usageBreakdownOpen = false;
+      resetUsageBreakdown();
       costFetchKey = null;
     }
     if (key === costFetchKey) return;
@@ -180,25 +195,51 @@
         if (seq !== costRequestSeq) return;
         costFetchKey = key;
         sessionCost = res.has_cost ? res.cost_usd : null;
+        sessionUsageBreakdownCount = res.breakdown_count ?? 0;
+      })
+      .catch(() => {
+        if (seq !== costRequestSeq) return;
+        sessionUsageBreakdownCount = 0;
+        // Leave the fetch key unset so the next
+        // session refresh retries the lookup.
+      });
+  });
+
+  // Breakdown rows are fetched only when the menu opens; large
+  // sessions can have thousands of entries and the count-only
+  // /usage fetch above happens automatically on every session.
+  $effect(() => {
+    if (!usageBreakdownOpen || !session) return;
+    const id = session.id;
+    const key = usageFetchKey(session);
+    if (key === breakdownFetchKey) return;
+    const seq = ++breakdownRequestSeq;
+    usageBreakdownLoading = true;
+    configureGeneratedClient();
+    SessionsService.getApiV1SessionsIdUsage({ id, breakdown: true })
+      .then((res) => {
+        if (seq !== breakdownRequestSeq) return;
+        breakdownFetchKey = key;
+        usageBreakdownLoading = false;
         sessionUsageBreakdown = Array.isArray(res.breakdown)
           ? (res.breakdown as SessionUsageBreakdownEntry[])
           : [];
       })
       .catch(() => {
-        if (seq !== costRequestSeq) return;
+        if (seq !== breakdownRequestSeq) return;
+        usageBreakdownLoading = false;
         sessionUsageBreakdown = [];
-        // Leave the fetch key unset so the next
-        // session refresh retries the lookup.
+        // Leave the fetch key unset so reopening retries.
       });
   });
 
   let sessionCostLabel = $derived(
     sessionCost !== null ? formatCost(sessionCost) : null,
   );
-  // Menu rows render only while open; large sessions can have
-  // thousands of breakdown entries and the /usage fetch happens
-  // automatically, so the collapsed dropdown must stay DOM-free.
+  // Menu rows render only while open, so the collapsed dropdown
+  // stays DOM-free.
   let usageBreakdownOpen = $state(false);
+  let usageBreakdownLoading = $state(false);
 
   let sessionContextTokens = $derived(session?.peak_context_tokens ?? 0);
   let sessionOutputTokens = $derived(session?.total_output_tokens ?? 0);
@@ -786,19 +827,28 @@
           {sessionTokenSummary}
         </span>
       {/if}
-      {#if sessionUsageBreakdown.length > 0}
+      {#if sessionUsageBreakdownCount > 0}
         <details class="usage-breakdown" bind:open={usageBreakdownOpen}>
           <summary
             class="usage-breakdown-trigger"
             title={m.session_breadcrumb_usage_breakdown_title()}
           >
             {m.session_breadcrumb_usage_breakdown_steps({
-              count: sessionUsageBreakdown.length,
-              countLabel: sessionUsageBreakdown.length.toLocaleString(),
+              count: sessionUsageBreakdownCount,
+              countLabel: sessionUsageBreakdownCount.toLocaleString(),
             })}
           </summary>
           {#if usageBreakdownOpen}
             <div class="usage-breakdown-menu">
+              {#if usageBreakdownLoading}
+                <div class="usage-breakdown-status">
+                  {m.session_breadcrumb_usage_breakdown_loading()}
+                </div>
+              {:else if sessionUsageBreakdown.length === 0}
+                <div class="usage-breakdown-status">
+                  {m.session_breadcrumb_failed()}
+                </div>
+              {:else}
               {#each sessionUsageBreakdown as row (row.ordinal)}
                 <div class="usage-breakdown-row" title={formatBreakdownTitle(row)}>
                   <span class="usage-breakdown-label">
@@ -819,6 +869,7 @@
                   {/if}
                 </div>
               {/each}
+              {/if}
             </div>
           {/if}
         </details>
@@ -1238,6 +1289,12 @@
     background: var(--bg-primary);
     box-shadow: var(--shadow-lg);
     z-index: var(--z-popover);
+  }
+
+  .usage-breakdown-status {
+    padding: 5px 6px;
+    font-size: 11px;
+    color: var(--text-muted);
   }
 
   .usage-breakdown-row {

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -145,6 +145,7 @@
     if (!session) {
       sessionCost = null;
       sessionUsageBreakdown = [];
+      usageBreakdownOpen = false;
       costFetchKey = null;
       costSessionId = null;
       costRequestSeq++;
@@ -167,6 +168,7 @@
       // still in flight.
       sessionCost = null;
       sessionUsageBreakdown = [];
+      usageBreakdownOpen = false;
       costFetchKey = null;
     }
     if (key === costFetchKey) return;
@@ -193,7 +195,10 @@
   let sessionCostLabel = $derived(
     sessionCost !== null ? formatCost(sessionCost) : null,
   );
-  let sessionUsageBreakdownRows = $derived(sessionUsageBreakdown);
+  // Menu rows render only while open; large sessions can have
+  // thousands of breakdown entries and the /usage fetch happens
+  // automatically, so the collapsed dropdown must stay DOM-free.
+  let usageBreakdownOpen = $state(false);
 
   let sessionContextTokens = $derived(session?.peak_context_tokens ?? 0);
   let sessionOutputTokens = $derived(session?.total_output_tokens ?? 0);
@@ -781,36 +786,38 @@
           {sessionTokenSummary}
         </span>
       {/if}
-      {#if sessionUsageBreakdownRows.length > 0}
-        <details class="usage-breakdown">
+      {#if sessionUsageBreakdown.length > 0}
+        <details class="usage-breakdown" bind:open={usageBreakdownOpen}>
           <summary
             class="usage-breakdown-trigger"
             title="Session usage breakdown"
           >
             {sessionUsageBreakdown.length} steps
           </summary>
-          <div class="usage-breakdown-menu">
-            {#each sessionUsageBreakdownRows as row (row.ordinal)}
-              <div class="usage-breakdown-row" title={formatBreakdownTitle(row)}>
-                <span class="usage-breakdown-label">
-                  {row.label}
-                </span>
-                <span class="usage-breakdown-model">
-                  {row.model || row.source}
-                </span>
-                <span class="usage-breakdown-tokens">
-                  {formatBreakdownContext(row)} ctx
-                  <span aria-hidden="true">/</span>
-                  {formatTokenCount(row.output_tokens)} out
-                </span>
-                {#if row.has_cost}
-                  <span class="usage-breakdown-cost">
-                    {formatCost(row.cost_usd)}
+          {#if usageBreakdownOpen}
+            <div class="usage-breakdown-menu">
+              {#each sessionUsageBreakdown as row (row.ordinal)}
+                <div class="usage-breakdown-row" title={formatBreakdownTitle(row)}>
+                  <span class="usage-breakdown-label">
+                    {row.label}
                   </span>
-                {/if}
-              </div>
-            {/each}
-          </div>
+                  <span class="usage-breakdown-model">
+                    {row.model || row.source}
+                  </span>
+                  <span class="usage-breakdown-tokens">
+                    {formatBreakdownContext(row)} ctx
+                    <span aria-hidden="true">/</span>
+                    {formatTokenCount(row.output_tokens)} out
+                  </span>
+                  {#if row.has_cost}
+                    <span class="usage-breakdown-cost">
+                      {formatCost(row.cost_usd)}
+                    </span>
+                  {/if}
+                </div>
+              {/each}
+            </div>
+          {/if}
         </details>
       {/if}
       {#if sessionCostLabel}

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -81,6 +81,21 @@
     path: string;
   }
 
+  interface SessionUsageBreakdownEntry {
+    ordinal: number;
+    message_ordinal?: number;
+    source: string;
+    label: string;
+    timestamp: string;
+    model: string;
+    input_tokens: number;
+    output_tokens: number;
+    cache_creation_input_tokens: number;
+    cache_read_input_tokens: number;
+    cost_usd: number;
+    has_cost: boolean;
+  }
+
   onMount(() => {
     configureGeneratedClient();
     OpenersService.getApiV1Openers()
@@ -115,6 +130,7 @@
   });
 
   let sessionCost = $state<number | null>(null);
+  let sessionUsageBreakdown = $state<SessionUsageBreakdownEntry[]>([]);
   // Key of the last successful usage fetch. Cost depends on more
   // than output tokens (input/cache tokens and explicit usage-event
   // costs), so the key includes every cost-affecting field present
@@ -128,6 +144,7 @@
   $effect(() => {
     if (!session) {
       sessionCost = null;
+      sessionUsageBreakdown = [];
       costFetchKey = null;
       costSessionId = null;
       costRequestSeq++;
@@ -149,6 +166,7 @@
       // the early return below while another session's request is
       // still in flight.
       sessionCost = null;
+      sessionUsageBreakdown = [];
       costFetchKey = null;
     }
     if (key === costFetchKey) return;
@@ -160,8 +178,13 @@
         if (seq !== costRequestSeq) return;
         costFetchKey = key;
         sessionCost = res.has_cost ? res.cost_usd : null;
+        sessionUsageBreakdown = Array.isArray(res.breakdown)
+          ? (res.breakdown as SessionUsageBreakdownEntry[])
+          : [];
       })
       .catch(() => {
+        if (seq !== costRequestSeq) return;
+        sessionUsageBreakdown = [];
         // Leave the fetch key unset so the next
         // session refresh retries the lookup.
       });
@@ -170,6 +193,7 @@
   let sessionCostLabel = $derived(
     sessionCost !== null ? formatCost(sessionCost) : null,
   );
+  let sessionUsageBreakdownRows = $derived(sessionUsageBreakdown);
 
   let sessionContextTokens = $derived(session?.peak_context_tokens ?? 0);
   let sessionOutputTokens = $derived(session?.total_output_tokens ?? 0);
@@ -213,6 +237,30 @@
   function sessionDisplayId(id: string): string {
     const idx = id.indexOf(":");
     return idx >= 0 ? id.slice(idx + 1) : id;
+  }
+
+  function formatTokenCount(value: number): string {
+    return Math.max(0, value).toLocaleString();
+  }
+
+  function formatBreakdownContext(entry: SessionUsageBreakdownEntry): string {
+    const context =
+      entry.input_tokens +
+      entry.cache_creation_input_tokens +
+      entry.cache_read_input_tokens;
+    return formatTokenCount(context);
+  }
+
+  function formatBreakdownTitle(entry: SessionUsageBreakdownEntry): string {
+    const parts = [
+      entry.model || entry.source,
+      `${formatBreakdownContext(entry)} ctx`,
+      `${formatTokenCount(entry.output_tokens)} out`,
+    ];
+    if (entry.has_cost) {
+      parts.push(formatCost(entry.cost_usd));
+    }
+    return parts.filter(Boolean).join(" · ");
   }
 
   async function copySessionId(
@@ -733,6 +781,38 @@
           {sessionTokenSummary}
         </span>
       {/if}
+      {#if sessionUsageBreakdownRows.length > 0}
+        <details class="usage-breakdown">
+          <summary
+            class="usage-breakdown-trigger"
+            title="Session usage breakdown"
+          >
+            {sessionUsageBreakdown.length} steps
+          </summary>
+          <div class="usage-breakdown-menu">
+            {#each sessionUsageBreakdownRows as row (row.ordinal)}
+              <div class="usage-breakdown-row" title={formatBreakdownTitle(row)}>
+                <span class="usage-breakdown-label">
+                  {row.label}
+                </span>
+                <span class="usage-breakdown-model">
+                  {row.model || row.source}
+                </span>
+                <span class="usage-breakdown-tokens">
+                  {formatBreakdownContext(row)} ctx
+                  <span aria-hidden="true">/</span>
+                  {formatTokenCount(row.output_tokens)} out
+                </span>
+                {#if row.has_cost}
+                  <span class="usage-breakdown-cost">
+                    {formatCost(row.cost_usd)}
+                  </span>
+                {/if}
+              </div>
+            {/each}
+          </div>
+        </details>
+      {/if}
       {#if sessionCostLabel}
         <span class="cost-badge" title={m.session_breadcrumb_estimated_session_cost()}>
           {sessionCostLabel}
@@ -1107,6 +1187,92 @@
     flex-shrink: 0;
   }
 
+  .usage-breakdown {
+    position: relative;
+    flex-shrink: 0;
+  }
+
+  .usage-breakdown-trigger {
+    list-style: none;
+    font-size: 10px;
+    font-variant-numeric: tabular-nums;
+    color: var(--text-muted);
+    padding: 1px 5px;
+    border-radius: 4px;
+    background: var(--bg-tertiary);
+    white-space: nowrap;
+    cursor: pointer;
+  }
+
+  .usage-breakdown-trigger::-webkit-details-marker {
+    display: none;
+  }
+
+  .usage-breakdown[open] .usage-breakdown-trigger,
+  .usage-breakdown-trigger:hover {
+    color: var(--text-secondary);
+    background: var(--bg-surface-hover);
+  }
+
+  .usage-breakdown-menu {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    margin-top: 4px;
+    width: min(460px, calc(100vw - 24px));
+    max-height: 260px;
+    overflow: auto;
+    padding: 6px;
+    border: 1px solid var(--border-default);
+    border-radius: 6px;
+    background: var(--bg-primary);
+    box-shadow: var(--shadow-lg);
+    z-index: var(--z-popover);
+  }
+
+  .usage-breakdown-row {
+    display: grid;
+    grid-template-columns: minmax(62px, 0.85fr) minmax(90px, 1fr) max-content max-content;
+    gap: 8px;
+    align-items: center;
+    padding: 5px 6px;
+    border-radius: 4px;
+    font-size: 11px;
+    line-height: 1.25;
+    color: var(--text-secondary);
+  }
+
+  .usage-breakdown-row:hover {
+    background: var(--bg-surface-hover);
+  }
+
+  .usage-breakdown-label,
+  .usage-breakdown-model {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .usage-breakdown-label {
+    color: var(--text-primary);
+    font-weight: 500;
+  }
+
+  .usage-breakdown-model {
+    color: var(--text-muted);
+  }
+
+  .usage-breakdown-tokens,
+  .usage-breakdown-cost {
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+  }
+
+  .usage-breakdown-cost {
+    color: var(--text-muted);
+  }
+
   .model-badge {
     font-size: 10px;
     color: var(--text-muted);
@@ -1305,6 +1471,26 @@
       max-width: 110px;
       overflow: hidden;
       text-overflow: ellipsis;
+    }
+
+    .usage-breakdown-trigger {
+      font-size: 9px;
+      padding: 1px 4px;
+    }
+
+    .usage-breakdown-menu {
+      right: -54px;
+      width: min(360px, calc(100vw - 16px));
+    }
+
+    .usage-breakdown-row {
+      grid-template-columns: minmax(56px, 0.8fr) minmax(68px, 1fr) max-content;
+      gap: 6px;
+      font-size: 10px;
+    }
+
+    .usage-breakdown-cost {
+      display: none;
     }
 
     .session-id {

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
@@ -147,6 +147,16 @@ function makeUsage(
   };
 }
 
+async function openUsageBreakdown(): Promise<void> {
+  const details = document.querySelector<HTMLDetailsElement>(
+    ".usage-breakdown",
+  );
+  expect(details).not.toBeNull();
+  details!.open = true;
+  details!.dispatchEvent(new Event("toggle"));
+  await tick();
+}
+
 function makeAssistantMessage(model: string): Message {
   return {
     id: 1,
@@ -921,6 +931,10 @@ describe("SessionBreadcrumb", () => {
             ?.trim(),
         ).toBe("2 steps");
       });
+      expect(
+        document.querySelectorAll(".usage-breakdown-row"),
+      ).toHaveLength(0);
+      await openUsageBreakdown();
       const rows = Array.from(
         document.querySelectorAll(".usage-breakdown-row"),
       );
@@ -995,6 +1009,7 @@ describe("SessionBreadcrumb", () => {
             ?.trim(),
         ).toBe("8 steps");
       });
+      await openUsageBreakdown();
       expect(
         document.querySelectorAll(".usage-breakdown-row"),
       ).toHaveLength(8);
@@ -1046,6 +1061,7 @@ describe("SessionBreadcrumb", () => {
         const badge = document.querySelector(".cost-badge");
         expect(badge?.textContent?.trim()).toBe("$2.00");
       });
+      await openUsageBreakdown();
       expect(
         document.querySelector(".usage-breakdown-row")?.textContent,
       ).toContain("gpt-5.4");

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
@@ -108,7 +108,23 @@ interface SessionUsage {
   has_cost: boolean;
   models: string[];
   unpriced_models: string[];
+  breakdown: SessionUsageBreakdownEntry[];
   server_running: boolean;
+}
+
+interface SessionUsageBreakdownEntry {
+  ordinal: number;
+  message_ordinal?: number;
+  source: string;
+  label: string;
+  timestamp: string;
+  model: string;
+  input_tokens: number;
+  output_tokens: number;
+  cache_creation_input_tokens: number;
+  cache_read_input_tokens: number;
+  cost_usd: number;
+  has_cost: boolean;
 }
 
 function makeUsage(
@@ -125,6 +141,7 @@ function makeUsage(
     has_cost: false,
     models: [],
     unpriced_models: [],
+    breakdown: [],
     server_running: true,
     ...overrides,
   };
@@ -847,6 +864,144 @@ describe("SessionBreadcrumb", () => {
       unmount(component);
     });
 
+    it("renders the session usage breakdown from the usage response", async () => {
+      sessionsService.getApiV1SessionsIdUsage.mockResolvedValue(
+        makeUsage({
+          has_cost: true,
+          cost_usd: 0.022,
+          breakdown: [
+            {
+              ordinal: 1,
+              message_ordinal: 0,
+              source: "message",
+              label: "Prompt 1",
+              timestamp: "2026-02-20T12:30:00Z",
+              model: "claude-opus-4-6",
+              input_tokens: 1000,
+              output_tokens: 500,
+              cache_creation_input_tokens: 200,
+              cache_read_input_tokens: 300,
+              cost_usd: 0.017,
+              has_cost: true,
+            },
+            {
+              ordinal: 2,
+              source: "session",
+              label: "session",
+              timestamp: "2026-02-20T12:31:00Z",
+              model: "gpt-5.4",
+              input_tokens: 150,
+              output_tokens: 20,
+              cache_creation_input_tokens: 0,
+              cache_read_input_tokens: 0,
+              cost_usd: 0.005,
+              has_cost: true,
+            },
+          ],
+        }),
+      );
+
+      const component = mount(SessionBreadcrumb, {
+        target: document.body,
+        props: {
+          session: makeSession("claude", {
+            peak_context_tokens: 1500,
+            total_output_tokens: 520,
+            has_peak_context_tokens: true,
+            has_total_output_tokens: true,
+          }),
+          onBack: () => {},
+        },
+      });
+
+      await vi.waitFor(() => {
+        expect(
+          document.querySelector(".usage-breakdown-trigger")
+            ?.textContent
+            ?.trim(),
+        ).toBe("2 steps");
+      });
+      const rows = Array.from(
+        document.querySelectorAll(".usage-breakdown-row"),
+      );
+      expect(rows).toHaveLength(2);
+      const first = rows[0]!;
+      const second = rows[1]!;
+      expect(first.textContent).toContain("Prompt 1");
+      expect(first.textContent).toContain("claude-opus-4-6");
+      expect(first.textContent).toContain("1,500 ctx");
+      expect(first.textContent).toContain("500 out");
+      expect(second.textContent).toContain("session");
+      expect(second.textContent).toContain("gpt-5.4");
+
+      unmount(component);
+    });
+
+    it("renders no usage breakdown when the usage response has no rows", async () => {
+      sessionsService.getApiV1SessionsIdUsage.mockResolvedValue(
+        makeUsage({ breakdown: [] }),
+      );
+
+      const component = mount(SessionBreadcrumb, {
+        target: document.body,
+        props: {
+          session: makeSession("claude"),
+          onBack: () => {},
+        },
+      });
+
+      await flushPromises();
+      await vi.waitFor(() => {
+        expect(
+          sessionsService.getApiV1SessionsIdUsage,
+        ).toHaveBeenCalled();
+      });
+      expect(document.querySelector(".usage-breakdown")).toBeNull();
+
+      unmount(component);
+    });
+
+    it("renders every breakdown row in the scrollable menu", async () => {
+      sessionsService.getApiV1SessionsIdUsage.mockResolvedValue(
+        makeUsage({
+          breakdown: Array.from({ length: 8 }, (_, i) => ({
+            ordinal: i + 1,
+            source: "message",
+            label: `Prompt ${i + 1}`,
+            timestamp: "2026-02-20T12:30:00Z",
+            model: "claude-opus-4-6",
+            input_tokens: 100 + i,
+            output_tokens: 10 + i,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+            cost_usd: 0,
+            has_cost: false,
+          })),
+        }),
+      );
+
+      const component = mount(SessionBreadcrumb, {
+        target: document.body,
+        props: {
+          session: makeSession("claude"),
+          onBack: () => {},
+        },
+      });
+
+      await vi.waitFor(() => {
+        expect(
+          document.querySelector(".usage-breakdown-trigger")
+            ?.textContent
+            ?.trim(),
+        ).toBe("8 steps");
+      });
+      expect(
+        document.querySelectorAll(".usage-breakdown-row"),
+      ).toHaveLength(8);
+
+      unmount(component);
+    });
+
     it("ignores a stale usage response after switching sessions", async () => {
       const first = deferred<SessionUsage>();
       sessionsService.getApiV1SessionsIdUsage
@@ -856,6 +1011,21 @@ describe("SessionBreadcrumb", () => {
             session_id: "run:bbb",
             has_cost: true,
             cost_usd: 2,
+            breakdown: [
+              {
+                ordinal: 1,
+                source: "message",
+                label: "Prompt 1",
+                timestamp: "2026-02-20T12:31:00Z",
+                model: "gpt-5.4",
+                input_tokens: 10,
+                output_tokens: 2,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 0,
+                cost_usd: 2,
+                has_cost: true,
+              },
+            ],
           }),
         );
 
@@ -876,6 +1046,9 @@ describe("SessionBreadcrumb", () => {
         const badge = document.querySelector(".cost-badge");
         expect(badge?.textContent?.trim()).toBe("$2.00");
       });
+      expect(
+        document.querySelector(".usage-breakdown-row")?.textContent,
+      ).toContain("gpt-5.4");
 
       // The first session's response arrives late and must not
       // overwrite the newer session's cost.
@@ -884,12 +1057,30 @@ describe("SessionBreadcrumb", () => {
           session_id: "run:aaa",
           has_cost: true,
           cost_usd: 9.99,
+          breakdown: [
+            {
+              ordinal: 1,
+              source: "message",
+              label: "Prompt 1",
+              timestamp: "2026-02-20T12:30:00Z",
+              model: "stale-model",
+              input_tokens: 999,
+              output_tokens: 99,
+              cache_creation_input_tokens: 0,
+              cache_read_input_tokens: 0,
+              cost_usd: 9.99,
+              has_cost: true,
+            },
+          ],
         }),
       );
       await flushPromises();
       expect(
         document.querySelector(".cost-badge")?.textContent?.trim(),
       ).toBe("$2.00");
+      expect(
+        document.querySelector(".usage-breakdown-row")?.textContent,
+      ).not.toContain("stale-model");
 
       component.$destroy();
     });

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
@@ -108,6 +108,7 @@ interface SessionUsage {
   has_cost: boolean;
   models: string[];
   unpriced_models: string[];
+  breakdown_count: number;
   breakdown: SessionUsageBreakdownEntry[];
   server_running: boolean;
 }
@@ -141,6 +142,7 @@ function makeUsage(
     has_cost: false,
     models: [],
     unpriced_models: [],
+    breakdown_count: 0,
     breakdown: [],
     server_running: true,
     ...overrides,
@@ -154,6 +156,9 @@ async function openUsageBreakdown(): Promise<void> {
   expect(details).not.toBeNull();
   details!.open = true;
   details!.dispatchEvent(new Event("toggle"));
+  await tick();
+  // Opening triggers the lazy breakdown fetch; let it settle.
+  await Promise.resolve();
   await tick();
 }
 
@@ -874,41 +879,46 @@ describe("SessionBreadcrumb", () => {
       unmount(component);
     });
 
-    it("renders the session usage breakdown from the usage response", async () => {
-      sessionsService.getApiV1SessionsIdUsage.mockResolvedValue(
-        makeUsage({
+    it("renders the session usage breakdown lazily when the menu opens", async () => {
+      const rows: SessionUsageBreakdownEntry[] = [
+        {
+          ordinal: 1,
+          message_ordinal: 0,
+          source: "message",
+          label: "Prompt 1",
+          timestamp: "2026-02-20T12:30:00Z",
+          model: "claude-opus-4-6",
+          input_tokens: 1000,
+          output_tokens: 500,
+          cache_creation_input_tokens: 200,
+          cache_read_input_tokens: 300,
+          cost_usd: 0.017,
           has_cost: true,
-          cost_usd: 0.022,
-          breakdown: [
-            {
-              ordinal: 1,
-              message_ordinal: 0,
-              source: "message",
-              label: "Prompt 1",
-              timestamp: "2026-02-20T12:30:00Z",
-              model: "claude-opus-4-6",
-              input_tokens: 1000,
-              output_tokens: 500,
-              cache_creation_input_tokens: 200,
-              cache_read_input_tokens: 300,
-              cost_usd: 0.017,
+        },
+        {
+          ordinal: 2,
+          source: "session",
+          label: "session",
+          timestamp: "2026-02-20T12:31:00Z",
+          model: "gpt-5.4",
+          input_tokens: 150,
+          output_tokens: 20,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+          cost_usd: 0.005,
+          has_cost: true,
+        },
+      ];
+      sessionsService.getApiV1SessionsIdUsage.mockImplementation(
+        ({ breakdown }: { id: string; breakdown?: boolean }) =>
+          Promise.resolve(
+            makeUsage({
               has_cost: true,
-            },
-            {
-              ordinal: 2,
-              source: "session",
-              label: "session",
-              timestamp: "2026-02-20T12:31:00Z",
-              model: "gpt-5.4",
-              input_tokens: 150,
-              output_tokens: 20,
-              cache_creation_input_tokens: 0,
-              cache_read_input_tokens: 0,
-              cost_usd: 0.005,
-              has_cost: true,
-            },
-          ],
-        }),
+              cost_usd: 0.022,
+              breakdown_count: 2,
+              breakdown: breakdown ? rows : [],
+            }),
+          ),
       );
 
       const component = mount(SessionBreadcrumb, {
@@ -934,13 +944,26 @@ describe("SessionBreadcrumb", () => {
       expect(
         document.querySelectorAll(".usage-breakdown-row"),
       ).toHaveLength(0);
+      expect(
+        sessionsService.getApiV1SessionsIdUsage,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        sessionsService.getApiV1SessionsIdUsage,
+      ).toHaveBeenCalledWith({ id: "run:123456789abcdef" });
+
       await openUsageBreakdown();
-      const rows = Array.from(
+      expect(
+        sessionsService.getApiV1SessionsIdUsage,
+      ).toHaveBeenCalledWith({
+        id: "run:123456789abcdef",
+        breakdown: true,
+      });
+      const renderedRows = Array.from(
         document.querySelectorAll(".usage-breakdown-row"),
       );
-      expect(rows).toHaveLength(2);
-      const first = rows[0]!;
-      const second = rows[1]!;
+      expect(renderedRows).toHaveLength(2);
+      const first = renderedRows[0]!;
+      const second = renderedRows[1]!;
       expect(first.textContent).toContain("Prompt 1");
       expect(first.textContent).toContain("claude-opus-4-6");
       expect(first.textContent).toContain("1,500 ctx");
@@ -951,9 +974,9 @@ describe("SessionBreadcrumb", () => {
       unmount(component);
     });
 
-    it("renders no usage breakdown when the usage response has no rows", async () => {
+    it("renders no usage breakdown when the usage response counts no rows", async () => {
       sessionsService.getApiV1SessionsIdUsage.mockResolvedValue(
-        makeUsage({ breakdown: [] }),
+        makeUsage({ breakdown_count: 0 }),
       );
 
       const component = mount(SessionBreadcrumb, {
@@ -976,22 +999,28 @@ describe("SessionBreadcrumb", () => {
     });
 
     it("renders every breakdown row in the scrollable menu", async () => {
-      sessionsService.getApiV1SessionsIdUsage.mockResolvedValue(
-        makeUsage({
-          breakdown: Array.from({ length: 8 }, (_, i) => ({
-            ordinal: i + 1,
-            source: "message",
-            label: `Prompt ${i + 1}`,
-            timestamp: "2026-02-20T12:30:00Z",
-            model: "claude-opus-4-6",
-            input_tokens: 100 + i,
-            output_tokens: 10 + i,
-            cache_creation_input_tokens: 0,
-            cache_read_input_tokens: 0,
-            cost_usd: 0,
-            has_cost: false,
-          })),
-        }),
+      sessionsService.getApiV1SessionsIdUsage.mockImplementation(
+        ({ breakdown }: { id: string; breakdown?: boolean }) =>
+          Promise.resolve(
+            makeUsage({
+              breakdown_count: 8,
+              breakdown: breakdown
+                ? Array.from({ length: 8 }, (_, i) => ({
+                    ordinal: i + 1,
+                    source: "message",
+                    label: `Prompt ${i + 1}`,
+                    timestamp: "2026-02-20T12:30:00Z",
+                    model: "claude-opus-4-6",
+                    input_tokens: 100 + i,
+                    output_tokens: 10 + i,
+                    cache_creation_input_tokens: 0,
+                    cache_read_input_tokens: 0,
+                    cost_usd: 0,
+                    has_cost: false,
+                  }))
+                : [],
+            }),
+          ),
       );
 
       const component = mount(SessionBreadcrumb, {
@@ -1017,32 +1046,137 @@ describe("SessionBreadcrumb", () => {
       unmount(component);
     });
 
+    it("shows a loading placeholder until breakdown rows arrive", async () => {
+      const rowsFetch = deferred<SessionUsage>();
+      sessionsService.getApiV1SessionsIdUsage.mockImplementation(
+        ({ breakdown }: { id: string; breakdown?: boolean }) =>
+          breakdown
+            ? rowsFetch.promise
+            : Promise.resolve(makeUsage({ breakdown_count: 1 })),
+      );
+
+      const component = mount(SessionBreadcrumb, {
+        target: document.body,
+        props: {
+          session: makeSession("claude"),
+          onBack: () => {},
+        },
+      });
+
+      await vi.waitFor(() => {
+        expect(
+          document.querySelector(".usage-breakdown-trigger")
+            ?.textContent
+            ?.trim(),
+        ).toBe("1 step");
+      });
+      await openUsageBreakdown();
+      expect(
+        document.querySelector(".usage-breakdown-status")
+          ?.textContent
+          ?.trim(),
+      ).toBe("Loading usage...");
+      expect(
+        document.querySelectorAll(".usage-breakdown-row"),
+      ).toHaveLength(0);
+
+      rowsFetch.resolve(
+        makeUsage({
+          breakdown_count: 1,
+          breakdown: [
+            {
+              ordinal: 1,
+              source: "message",
+              label: "Prompt 1",
+              timestamp: "2026-02-20T12:30:00Z",
+              model: "claude-opus-4-6",
+              input_tokens: 100,
+              output_tokens: 10,
+              cache_creation_input_tokens: 0,
+              cache_read_input_tokens: 0,
+              cost_usd: 0,
+              has_cost: false,
+            },
+          ],
+        }),
+      );
+      await flushPromises();
+      expect(document.querySelector(".usage-breakdown-status")).toBeNull();
+      expect(
+        document.querySelectorAll(".usage-breakdown-row"),
+      ).toHaveLength(1);
+
+      unmount(component);
+    });
+
+    it("shows a failure placeholder when the breakdown fetch fails", async () => {
+      sessionsService.getApiV1SessionsIdUsage.mockImplementation(
+        ({ breakdown }: { id: string; breakdown?: boolean }) =>
+          breakdown
+            ? Promise.reject(new Error("boom"))
+            : Promise.resolve(makeUsage({ breakdown_count: 3 })),
+      );
+
+      const component = mount(SessionBreadcrumb, {
+        target: document.body,
+        props: {
+          session: makeSession("claude"),
+          onBack: () => {},
+        },
+      });
+
+      await vi.waitFor(() => {
+        expect(
+          document.querySelector(".usage-breakdown-trigger")
+            ?.textContent
+            ?.trim(),
+        ).toBe("3 steps");
+      });
+      await openUsageBreakdown();
+      expect(
+        document.querySelector(".usage-breakdown-status")
+          ?.textContent
+          ?.trim(),
+      ).toBe("Failed");
+      expect(
+        document.querySelectorAll(".usage-breakdown-row"),
+      ).toHaveLength(0);
+
+      unmount(component);
+    });
+
     it("ignores a stale usage response after switching sessions", async () => {
       const first = deferred<SessionUsage>();
-      sessionsService.getApiV1SessionsIdUsage
-        .mockReturnValueOnce(first.promise)
-        .mockResolvedValueOnce(
-          makeUsage({
-            session_id: "run:bbb",
-            has_cost: true,
-            cost_usd: 2,
-            breakdown: [
-              {
-                ordinal: 1,
-                source: "message",
-                label: "Prompt 1",
-                timestamp: "2026-02-20T12:31:00Z",
-                model: "gpt-5.4",
-                input_tokens: 10,
-                output_tokens: 2,
-                cache_creation_input_tokens: 0,
-                cache_read_input_tokens: 0,
-                cost_usd: 2,
-                has_cost: true,
-              },
-            ],
-          }),
-        );
+      sessionsService.getApiV1SessionsIdUsage.mockImplementation(
+        ({ id, breakdown }: { id: string; breakdown?: boolean }) => {
+          if (id === "run:aaa") return first.promise;
+          return Promise.resolve(
+            makeUsage({
+              session_id: "run:bbb",
+              has_cost: true,
+              cost_usd: 2,
+              breakdown_count: 1,
+              breakdown: breakdown
+                ? [
+                    {
+                      ordinal: 1,
+                      source: "message",
+                      label: "Prompt 1",
+                      timestamp: "2026-02-20T12:31:00Z",
+                      model: "gpt-5.4",
+                      input_tokens: 10,
+                      output_tokens: 2,
+                      cache_creation_input_tokens: 0,
+                      cache_read_input_tokens: 0,
+                      cost_usd: 2,
+                      has_cost: true,
+                    },
+                  ]
+                : [],
+            }),
+          );
+        },
+      );
 
       const component = createClassComponent({
         component: SessionBreadcrumb,
@@ -1067,27 +1201,13 @@ describe("SessionBreadcrumb", () => {
       ).toContain("gpt-5.4");
 
       // The first session's response arrives late and must not
-      // overwrite the newer session's cost.
+      // overwrite the newer session's cost or step count.
       first.resolve(
         makeUsage({
           session_id: "run:aaa",
           has_cost: true,
           cost_usd: 9.99,
-          breakdown: [
-            {
-              ordinal: 1,
-              source: "message",
-              label: "Prompt 1",
-              timestamp: "2026-02-20T12:30:00Z",
-              model: "stale-model",
-              input_tokens: 999,
-              output_tokens: 99,
-              cache_creation_input_tokens: 0,
-              cache_read_input_tokens: 0,
-              cost_usd: 9.99,
-              has_cost: true,
-            },
-          ],
+          breakdown_count: 42,
         }),
       );
       await flushPromises();
@@ -1095,8 +1215,13 @@ describe("SessionBreadcrumb", () => {
         document.querySelector(".cost-badge")?.textContent?.trim(),
       ).toBe("$2.00");
       expect(
+        document.querySelector(".usage-breakdown-trigger")
+          ?.textContent
+          ?.trim(),
+      ).toBe("1 step");
+      expect(
         document.querySelector(".usage-breakdown-row")?.textContent,
-      ).not.toContain("stale-model");
+      ).toContain("gpt-5.4");
 
       component.$destroy();
     });

--- a/frontend/src/lib/stores/analytics.test.ts
+++ b/frontend/src/lib/stores/analytics.test.ts
@@ -128,6 +128,7 @@ function makeTools(): ToolsAnalyticsResponse {
     total_calls: 0,
     by_category: [],
     by_agent: [],
+    by_tool: [],
     trend: [],
   };
 }

--- a/frontend/src/lib/utils/csv-export.test.ts
+++ b/frontend/src/lib/utils/csv-export.test.ts
@@ -111,6 +111,7 @@ describe("generateAnalyticsCSV", () => {
         { category: "Write", count: 40, pct: 40 },
       ],
       by_agent: [],
+      by_tool: [],
       trend: [],
     };
 
@@ -160,6 +161,7 @@ describe("generateAnalyticsCSV", () => {
         { category: "Read", count: 1, pct: 100 },
       ],
       by_agent: [],
+      by_tool: [],
       trend: [],
     };
 

--- a/internal/db/analytics.go
+++ b/internal/db/analytics.go
@@ -2595,6 +2595,15 @@ type ToolAgentBreakdown struct {
 	Categories []ToolCategoryCount `json:"categories"`
 }
 
+// ToolUsageAnalysis holds ranked usage for one concrete tool name.
+type ToolUsageAnalysis struct {
+	ToolName     string  `json:"tool_name"`
+	Category     string  `json:"category"`
+	CallCount    int     `json:"call_count"`
+	SessionCount int     `json:"session_count"`
+	Pct          float64 `json:"pct"`
+}
+
 // ToolTrendEntry holds tool call counts for one time bucket.
 type ToolTrendEntry struct {
 	Date  string         `json:"date"`
@@ -2606,7 +2615,19 @@ type ToolsAnalyticsResponse struct {
 	TotalCalls int                  `json:"total_calls"`
 	ByCategory []ToolCategoryCount  `json:"by_category"`
 	ByAgent    []ToolAgentBreakdown `json:"by_agent"`
+	ByTool     []ToolUsageAnalysis  `json:"by_tool"`
 	Trend      []ToolTrendEntry     `json:"trend"`
+}
+
+// ToolAnalyticsRow is a backend-neutral intermediate row used to
+// aggregate concrete tool usage after native stores apply their filters.
+type ToolAnalyticsRow struct {
+	SessionID string
+	ToolName  string
+	Category  string
+	Agent     string
+	Date      string
+	Count     int
 }
 
 // SkillAgentBreakdown holds skill usage for one agent.
@@ -2656,6 +2677,162 @@ type SkillAnalyticsRow struct {
 	Date       string
 	LastUsedAt string
 	Count      int
+}
+
+type toolUsageAccumulator struct {
+	toolName   string
+	category   string
+	callCount  int
+	sessionIDs map[string]struct{}
+}
+
+// BuildToolsAnalytics folds backend-neutral tool rows into the public
+// response shape. Tool names are trimmed and blank names are reported as
+// Unknown so legacy rows remain visible instead of disappearing.
+func BuildToolsAnalytics(rows []ToolAnalyticsRow) ToolsAnalyticsResponse {
+	resp := ToolsAnalyticsResponse{
+		ByCategory: []ToolCategoryCount{},
+		ByAgent:    []ToolAgentBreakdown{},
+		ByTool:     []ToolUsageAnalysis{},
+		Trend:      []ToolTrendEntry{},
+	}
+	if len(rows) == 0 {
+		return resp
+	}
+
+	catCounts := make(map[string]int)
+	agentCats := make(map[string]map[string]int)
+	trendBuckets := make(map[string]map[string]int)
+	toolCounts := make(map[string]*toolUsageAccumulator)
+
+	for _, row := range rows {
+		if row.Count <= 0 {
+			continue
+		}
+		catCounts[row.Category] += row.Count
+		resp.TotalCalls += row.Count
+
+		if agentCats[row.Agent] == nil {
+			agentCats[row.Agent] = make(map[string]int)
+		}
+		agentCats[row.Agent][row.Category] += row.Count
+
+		week := bucketDate(row.Date, "week")
+		if trendBuckets[week] == nil {
+			trendBuckets[week] = make(map[string]int)
+		}
+		trendBuckets[week][row.Category] += row.Count
+
+		name := strings.TrimSpace(row.ToolName)
+		if name == "" {
+			name = "Unknown"
+		}
+		key := row.Category + "\x00" + name
+		acc := toolCounts[key]
+		if acc == nil {
+			acc = &toolUsageAccumulator{
+				toolName:   name,
+				category:   row.Category,
+				sessionIDs: map[string]struct{}{},
+			}
+			toolCounts[key] = acc
+		}
+		acc.callCount += row.Count
+		if row.SessionID != "" {
+			acc.sessionIDs[row.SessionID] = struct{}{}
+		}
+	}
+
+	if resp.TotalCalls == 0 {
+		return resp
+	}
+
+	resp.ByCategory = make([]ToolCategoryCount, 0, len(catCounts))
+	for cat, count := range catCounts {
+		pct := math.Round(
+			float64(count)/float64(resp.TotalCalls)*1000,
+		) / 10
+		resp.ByCategory = append(resp.ByCategory,
+			ToolCategoryCount{
+				Category: cat, Count: count, Pct: pct,
+			})
+	}
+	sort.Slice(resp.ByCategory, func(i, j int) bool {
+		if resp.ByCategory[i].Count != resp.ByCategory[j].Count {
+			return resp.ByCategory[i].Count > resp.ByCategory[j].Count
+		}
+		return resp.ByCategory[i].Category < resp.ByCategory[j].Category
+	})
+
+	agentKeys := make([]string, 0, len(agentCats))
+	for agent := range agentCats {
+		agentKeys = append(agentKeys, agent)
+	}
+	sort.Strings(agentKeys)
+	resp.ByAgent = make([]ToolAgentBreakdown, 0, len(agentKeys))
+	for _, agent := range agentKeys {
+		cats := agentCats[agent]
+		total := 0
+		for _, c := range cats {
+			total += c
+		}
+		catList := make([]ToolCategoryCount, 0, len(cats))
+		for cat, count := range cats {
+			pct := math.Round(
+				float64(count)/float64(total)*1000,
+			) / 10
+			catList = append(catList, ToolCategoryCount{
+				Category: cat, Count: count, Pct: pct,
+			})
+		}
+		sort.Slice(catList, func(i, j int) bool {
+			if catList[i].Count != catList[j].Count {
+				return catList[i].Count > catList[j].Count
+			}
+			return catList[i].Category < catList[j].Category
+		})
+		resp.ByAgent = append(resp.ByAgent,
+			ToolAgentBreakdown{
+				Agent:      agent,
+				Total:      total,
+				Categories: catList,
+			})
+	}
+
+	resp.ByTool = make([]ToolUsageAnalysis, 0, len(toolCounts))
+	for _, acc := range toolCounts {
+		pct := math.Round(
+			float64(acc.callCount)/float64(resp.TotalCalls)*1000,
+		) / 10
+		resp.ByTool = append(resp.ByTool, ToolUsageAnalysis{
+			ToolName:     acc.toolName,
+			Category:     acc.category,
+			CallCount:    acc.callCount,
+			SessionCount: len(acc.sessionIDs),
+			Pct:          pct,
+		})
+	}
+	sort.Slice(resp.ByTool, func(i, j int) bool {
+		if resp.ByTool[i].CallCount != resp.ByTool[j].CallCount {
+			return resp.ByTool[i].CallCount > resp.ByTool[j].CallCount
+		}
+		if resp.ByTool[i].ToolName != resp.ByTool[j].ToolName {
+			return resp.ByTool[i].ToolName < resp.ByTool[j].ToolName
+		}
+		return resp.ByTool[i].Category < resp.ByTool[j].Category
+	})
+
+	resp.Trend = make([]ToolTrendEntry, 0, len(trendBuckets))
+	for week, cats := range trendBuckets {
+		resp.Trend = append(resp.Trend, ToolTrendEntry{
+			Date: week, ByCat: cats,
+		})
+	}
+	sort.Slice(resp.Trend, func(i, j int) bool {
+		return resp.Trend[i].Date < resp.Trend[j].Date
+	})
+
+	return resp
 }
 
 type skillUsageAccumulator struct {
@@ -2812,7 +2989,8 @@ func analyticsToolsQuery(
 	modelPred string,
 	includeMessageMeta bool,
 ) string {
-	query := `SELECT tc.session_id, tc.category, COUNT(*)`
+	query := `SELECT tc.session_id, tc.category,
+			TRIM(COALESCE(tc.tool_name, '')), COUNT(*)`
 	if includeMessageMeta {
 		query += `, COALESCE(m.timestamp, '')`
 	}
@@ -2830,7 +3008,8 @@ func analyticsToolsQuery(
 			AND ` + modelPred
 	}
 	query += `
-		GROUP BY tc.session_id, tc.category`
+		GROUP BY tc.session_id, tc.category,
+			TRIM(COALESCE(tc.tool_name, ''))`
 	if includeMessageMeta {
 		query += `, COALESCE(m.timestamp, '')`
 	}
@@ -2901,6 +3080,7 @@ func (db *DB) GetAnalyticsTools(
 	resp := ToolsAnalyticsResponse{
 		ByCategory: []ToolCategoryCount{},
 		ByAgent:    []ToolAgentBreakdown{},
+		ByTool:     []ToolUsageAnalysis{},
 		Trend:      []ToolTrendEntry{},
 	}
 
@@ -2909,13 +3089,7 @@ func (db *DB) GetAnalyticsTools(
 	}
 
 	// Query tool_calls for filtered sessions (chunked).
-	type toolRow struct {
-		sessionID string
-		category  string
-		count     int
-		date      string
-	}
-	var toolRows []toolRow
+	var toolRows []ToolAnalyticsRow
 
 	err = queryChunked(sessionIDs,
 		func(chunk []string) error {
@@ -2935,10 +3109,10 @@ func (db *DB) GetAnalyticsTools(
 			}
 			defer rows.Close()
 			for rows.Next() {
-				var sid, cat, ts string
+				var sid, cat, toolName, ts string
 				var count int
 				if err := rows.Scan(
-					&sid, &cat, &count, &ts,
+					&sid, &cat, &toolName, &count, &ts,
 				); err != nil {
 					return fmt.Errorf(
 						"scanning tool_call: %w", err,
@@ -2954,11 +3128,13 @@ func (db *DB) GetAnalyticsTools(
 				if !keep {
 					continue
 				}
-				toolRows = append(toolRows, toolRow{
-					sessionID: sid,
-					category:  cat,
-					count:     count,
-					date:      date,
+				toolRows = append(toolRows, ToolAnalyticsRow{
+					SessionID: sid,
+					Category:  cat,
+					ToolName:  toolName,
+					Agent:     info.agent,
+					Count:     count,
+					Date:      date,
 				})
 			}
 			return rows.Err()
@@ -2971,105 +3147,7 @@ func (db *DB) GetAnalyticsTools(
 		return resp, nil
 	}
 
-	// Aggregate in Go.
-	catCounts := make(map[string]int)
-	agentCats := make(map[string]map[string]int)    // agent → cat → count
-	trendBuckets := make(map[string]map[string]int) // week → cat → count
-
-	for _, tr := range toolRows {
-		info := sessionMap[tr.sessionID]
-		catCounts[tr.category] += tr.count
-
-		if agentCats[info.agent] == nil {
-			agentCats[info.agent] = make(map[string]int)
-		}
-		agentCats[info.agent][tr.category] += tr.count
-
-		week := bucketDate(tr.date, "week")
-		if trendBuckets[week] == nil {
-			trendBuckets[week] = make(map[string]int)
-		}
-		trendBuckets[week][tr.category] += tr.count
-	}
-
-	for _, count := range catCounts {
-		resp.TotalCalls += count
-	}
-
-	// Build ByCategory sorted by count desc.
-	resp.ByCategory = make(
-		[]ToolCategoryCount, 0, len(catCounts),
-	)
-	for cat, count := range catCounts {
-		pct := math.Round(
-			float64(count)/float64(resp.TotalCalls)*1000,
-		) / 10
-		resp.ByCategory = append(resp.ByCategory,
-			ToolCategoryCount{
-				Category: cat, Count: count, Pct: pct,
-			})
-	}
-	sort.Slice(resp.ByCategory, func(i, j int) bool {
-		if resp.ByCategory[i].Count != resp.ByCategory[j].Count {
-			return resp.ByCategory[i].Count > resp.ByCategory[j].Count
-		}
-		return resp.ByCategory[i].Category < resp.ByCategory[j].Category
-	})
-
-	// Build ByAgent sorted alphabetically.
-	agentKeys := make([]string, 0, len(agentCats))
-	for k := range agentCats {
-		agentKeys = append(agentKeys, k)
-	}
-	sort.Strings(agentKeys)
-	resp.ByAgent = make(
-		[]ToolAgentBreakdown, 0, len(agentKeys),
-	)
-	for _, agent := range agentKeys {
-		cats := agentCats[agent]
-		total := 0
-		for _, c := range cats {
-			total += c
-		}
-		catList := make(
-			[]ToolCategoryCount, 0, len(cats),
-		)
-		for cat, count := range cats {
-			pct := math.Round(
-				float64(count)/float64(total)*1000,
-			) / 10
-			catList = append(catList, ToolCategoryCount{
-				Category: cat, Count: count, Pct: pct,
-			})
-		}
-		sort.Slice(catList, func(i, j int) bool {
-			if catList[i].Count != catList[j].Count {
-				return catList[i].Count > catList[j].Count
-			}
-			return catList[i].Category < catList[j].Category
-		})
-		resp.ByAgent = append(resp.ByAgent,
-			ToolAgentBreakdown{
-				Agent:      agent,
-				Total:      total,
-				Categories: catList,
-			})
-	}
-
-	// Build Trend sorted by date.
-	resp.Trend = make(
-		[]ToolTrendEntry, 0, len(trendBuckets),
-	)
-	for week, cats := range trendBuckets {
-		resp.Trend = append(resp.Trend, ToolTrendEntry{
-			Date: week, ByCat: cats,
-		})
-	}
-	sort.Slice(resp.Trend, func(i, j int) bool {
-		return resp.Trend[i].Date < resp.Trend[j].Date
-	})
-
-	return resp, nil
+	return BuildToolsAnalytics(toolRows), nil
 }
 
 // ResolveSkillRowTime resolves the timestamp for a single skill call and

--- a/internal/db/analytics_test.go
+++ b/internal/db/analytics_test.go
@@ -2493,6 +2493,7 @@ func TestGetAnalyticsTools(t *testing.T) {
 		require.NoError(t, err, "GetAnalyticsTools")
 		assert.Equal(t, 0, resp.TotalCalls, "TotalCalls")
 		assert.Len(t, resp.ByCategory, 0, "len(ByCategory)")
+		assert.Len(t, resp.ByTool, 0, "len(ByTool)")
 	})
 
 	// Seed sessions with tool_calls.
@@ -2565,6 +2566,23 @@ func TestGetAnalyticsTools(t *testing.T) {
 		assert.Equal(t, 50.0, resp.ByCategory[0].Pct, "Read pct")
 	})
 
+	t.Run("ByToolAnalysis", func(t *testing.T) {
+		resp, err := d.GetAnalyticsTools(ctx, baseFilter())
+		require.NoError(t, err, "GetAnalyticsTools")
+		require.Len(t, resp.ByTool, 4, "len(ByTool)")
+
+		read := resp.ByTool[0]
+		assert.Equal(t, "Read", read.ToolName, "tool name")
+		assert.Equal(t, "Read", read.Category, "category")
+		assert.Equal(t, 3, read.CallCount, "call count")
+		assert.Equal(t, 2, read.SessionCount, "session count")
+		assert.Equal(t, 50.0, read.Pct, "pct")
+
+		assert.Equal(t, "Bash", resp.ByTool[1].ToolName, "tie sort")
+		assert.Equal(t, 1, resp.ByTool[1].SessionCount, "Bash sessions")
+		assert.Equal(t, 16.7, resp.ByTool[1].Pct, "Bash pct")
+	})
+
 	t.Run("ByAgent", func(t *testing.T) {
 		resp, err := d.GetAnalyticsTools(ctx, baseFilter())
 		require.NoError(t, err, "GetAnalyticsTools")
@@ -2597,6 +2615,10 @@ func TestGetAnalyticsTools(t *testing.T) {
 		resp, err := d.GetAnalyticsTools(ctx, f)
 		require.NoError(t, err, "GetAnalyticsTools")
 		assert.Equal(t, 4, resp.TotalCalls, "TotalCalls")
+		require.Len(t, resp.ByTool, 3, "len(ByTool)")
+		assert.Equal(t, "Read", resp.ByTool[0].ToolName, "first tool")
+		assert.Equal(t, 2, resp.ByTool[0].CallCount, "Read calls")
+		assert.Equal(t, 1, resp.ByTool[0].SessionCount, "Read sessions")
 	})
 
 	t.Run("EmptyDateRange", func(t *testing.T) {
@@ -2613,9 +2635,9 @@ func TestAnalyticsToolsToolCallsQueryAggregatesInSQL(t *testing.T) {
 	normalized := strings.Join(strings.Fields(strings.ToLower(q)), " ")
 
 	assert.Contains(t, normalized,
-		"select tc.session_id, tc.category, count(*)")
+		"select tc.session_id, tc.category, trim(coalesce(tc.tool_name, '')), count(*)")
 	assert.Contains(t, normalized,
-		"group by tc.session_id, tc.category")
+		"group by tc.session_id, tc.category, trim(coalesce(tc.tool_name, ''))")
 }
 
 func TestGetAnalyticsToolsModelFilterCountsOnlyMatchingToolCalls(
@@ -2662,6 +2684,14 @@ func TestGetAnalyticsToolsModelFilterCountsOnlyMatchingToolCalls(
 	assert.Equal(t, 1, catMap["Read"], "Read")
 	assert.Equal(t, 1, catMap["Bash"], "Bash")
 	assert.Zero(t, catMap["Grep"], "Grep")
+
+	toolMap := make(map[string]int)
+	for _, tool := range resp.ByTool {
+		toolMap[tool.ToolName] = tool.CallCount
+	}
+	assert.Equal(t, 1, toolMap["Read"], "Read tool")
+	assert.Equal(t, 1, toolMap["Bash"], "Bash tool")
+	assert.Zero(t, toolMap["Grep"], "Grep tool")
 }
 
 func TestGetAnalyticsToolsModelAndHourFilterCountsOnlyMatchingHourToolCalls(

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -87,7 +87,7 @@ type Store interface {
 	GetTopSessionsByCost(ctx context.Context, f UsageFilter, limit int) ([]TopSessionEntry, error)
 	GetUsageSessionCounts(ctx context.Context, f UsageFilter) (UsageSessionCounts, error)
 	GetUsageMatchingSessionCount(ctx context.Context, f UsageFilter) (int, error)
-	GetSessionUsage(ctx context.Context, sessionID string) (*SessionUsage, error)
+	GetSessionUsage(ctx context.Context, sessionID string, includeBreakdown bool) (*SessionUsage, error)
 
 	// Stars.
 	StarSession(sessionID string) (bool, error)

--- a/internal/db/store_contract_test.go
+++ b/internal/db/store_contract_test.go
@@ -561,7 +561,7 @@ func contractAnalyticsTrendsAndUsage(
 	require.Equal(t, 3, counts.Total)
 	require.Equal(t, 2, counts.ByProject["alpha"])
 
-	usage, err := store.GetSessionUsage(ctx, fixture.alphaID)
+	usage, err := store.GetSessionUsage(ctx, fixture.alphaID, true)
 	require.NoError(t, err)
 	require.NotNil(t, usage)
 	require.True(t, usage.HasTokenData)

--- a/internal/db/usage.go
+++ b/internal/db/usage.go
@@ -2317,17 +2317,33 @@ func (db *DB) GetTopSessionsByCost(
 // (usage_events.cost_usd). CostUSD is non-zero only when HasCost is
 // true; a partial total (some models unpriced) is never emitted.
 type SessionUsage struct {
-	SessionID         string   `json:"session_id"`
-	Agent             string   `json:"agent"`
-	Project           string   `json:"project"`
-	TotalOutputTokens int      `json:"total_output_tokens"`
-	PeakContextTokens int      `json:"peak_context_tokens"`
-	HasTokenData      bool     `json:"has_token_data"`
-	CostUSD           float64  `json:"cost_usd"`
-	HasCost           bool     `json:"has_cost"`
-	AICredits         float64  `json:"ai_credits,omitempty"`
-	Models            []string `json:"models"`
-	UnpricedModels    []string `json:"unpriced_models,omitempty"`
+	SessionID         string                       `json:"session_id"`
+	Agent             string                       `json:"agent"`
+	Project           string                       `json:"project"`
+	TotalOutputTokens int                          `json:"total_output_tokens"`
+	PeakContextTokens int                          `json:"peak_context_tokens"`
+	HasTokenData      bool                         `json:"has_token_data"`
+	CostUSD           float64                      `json:"cost_usd"`
+	HasCost           bool                         `json:"has_cost"`
+	AICredits         float64                      `json:"ai_credits,omitempty"`
+	Models            []string                     `json:"models"`
+	UnpricedModels    []string                     `json:"unpriced_models,omitempty"`
+	Breakdown         []SessionUsageBreakdownEntry `json:"breakdown"`
+}
+
+type SessionUsageBreakdownEntry struct {
+	Ordinal                  int     `json:"ordinal"`
+	MessageOrdinal           *int    `json:"message_ordinal,omitempty"`
+	Source                   string  `json:"source"`
+	Label                    string  `json:"label"`
+	Timestamp                string  `json:"timestamp"`
+	Model                    string  `json:"model"`
+	InputTokens              int     `json:"input_tokens"`
+	OutputTokens             int     `json:"output_tokens"`
+	CacheCreationInputTokens int     `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int     `json:"cache_read_input_tokens"`
+	CostUSD                  float64 `json:"cost_usd"`
+	HasCost                  bool    `json:"has_cost"`
 }
 
 // sessionRowCost computes one usage row's cost and reports whether
@@ -2369,6 +2385,55 @@ func sessionRowCost(
 	return cost, true, true
 }
 
+func sessionUsageBreakdownEntry(
+	r usageScanRow,
+	ordinal int,
+	cost float64,
+	priced bool,
+) SessionUsageBreakdownEntry {
+	var inTok, outTok, crTok, rdTok int
+	if r.usageSource == "message" {
+		inTok, outTok, crTok, rdTok =
+			clampedUsageTokenCounters(r.tokenJSON)
+	} else {
+		inTok, outTok, crTok, rdTok = usageEventRowTokens(
+			r.usageSource,
+			r.inputTokens, r.outputTokens,
+			r.cacheCreationInputTokens, r.cacheReadInputTokens)
+	}
+	entry := SessionUsageBreakdownEntry{
+		Ordinal:                  ordinal,
+		Source:                   r.usageSource,
+		Label:                    sessionUsageBreakdownLabel(r),
+		Timestamp:                r.ts,
+		Model:                    r.model,
+		InputTokens:              inTok,
+		OutputTokens:             outTok,
+		CacheCreationInputTokens: crTok,
+		CacheReadInputTokens:     rdTok,
+		CostUSD:                  cost,
+		HasCost:                  priced,
+	}
+	if r.messageOrdinal.Valid {
+		messageOrdinal := int(r.messageOrdinal.Int64)
+		entry.MessageOrdinal = &messageOrdinal
+	}
+	return entry
+}
+
+func sessionUsageBreakdownLabel(r usageScanRow) string {
+	if r.messageOrdinal.Valid {
+		if r.usageSource == "message" {
+			return fmt.Sprintf("Prompt %d", r.messageOrdinal.Int64+1)
+		}
+		return fmt.Sprintf("Step %d", r.messageOrdinal.Int64+1)
+	}
+	if r.usageSource != "" {
+		return r.usageSource
+	}
+	return "usage"
+}
+
 // GetSessionUsage returns one session's token totals and cost
 // estimate. It starts from GetSession (so metadata and session-level
 // token aggregates are reported even when there are no per-message
@@ -2396,7 +2461,9 @@ func (db *DB) GetSessionUsage(
 
 	query := usageRowSelect() + ` AND u.session_id = ?
 		ORDER BY u.ts ASC, u.session_id ASC,
-		COALESCE(u.message_ordinal, -1) ASC`
+		COALESCE(u.message_ordinal, -1) ASC,
+		u.usage_source ASC,
+		COALESCE(u.usage_dedup_key, '') ASC`
 	rows, err := db.getReader().QueryContext(ctx, query, sessionID)
 	if err != nil {
 		return nil, fmt.Errorf("querying session usage: %w", err)
@@ -2408,6 +2475,7 @@ func (db *DB) GetSessionUsage(
 	allPriced := true
 	modelsSet := make(map[string]struct{})
 	unpricedSet := make(map[string]struct{})
+	breakdown := make([]SessionUsageBreakdownEntry, 0)
 
 	seen := make(map[usageDedupToken]struct{})
 
@@ -2438,6 +2506,8 @@ func (db *DB) GetSessionUsage(
 			allPriced = false
 			unpricedSet[r.model] = struct{}{}
 		}
+		breakdown = append(breakdown, sessionUsageBreakdownEntry(
+			r, len(breakdown)+1, c, priced))
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterating session usage rows: %w", err)
@@ -2452,6 +2522,7 @@ func (db *DB) GetSessionUsage(
 		HasTokenData:      sess.HasTotalOutputTokens || sess.HasPeakContextTokens,
 		Models:            sortedSetKeys(modelsSet),
 		HasCost:           contributing && allPriced,
+		Breakdown:         breakdown,
 	}
 	if out.HasCost {
 		out.CostUSD = cost

--- a/internal/db/usage.go
+++ b/internal/db/usage.go
@@ -2328,6 +2328,7 @@ type SessionUsage struct {
 	AICredits         float64                      `json:"ai_credits,omitempty"`
 	Models            []string                     `json:"models"`
 	UnpricedModels    []string                     `json:"unpriced_models,omitempty"`
+	BreakdownCount    int                          `json:"breakdown_count"`
 	Breakdown         []SessionUsageBreakdownEntry `json:"breakdown"`
 }
 
@@ -2441,9 +2442,11 @@ func sessionUsageBreakdownLabel(r usageScanRow) string {
 // rows. Dedup is intra-session only; this reports the session's own
 // usage, which can diverge from the dashboard's cross-session
 // credited total for fork/subagent sessions. Returns (nil, nil) when
-// the session does not exist.
+// the session does not exist. BreakdownCount is always populated;
+// per-row Breakdown entries are built only when includeBreakdown is
+// true so callers that need just the totals avoid the row payload.
 func (db *DB) GetSessionUsage(
-	ctx context.Context, sessionID string,
+	ctx context.Context, sessionID string, includeBreakdown bool,
 ) (*SessionUsage, error) {
 	sess, err := db.GetSession(ctx, sessionID)
 	if err != nil {
@@ -2476,6 +2479,7 @@ func (db *DB) GetSessionUsage(
 	modelsSet := make(map[string]struct{})
 	unpricedSet := make(map[string]struct{})
 	breakdown := make([]SessionUsageBreakdownEntry, 0)
+	breakdownCount := 0
 
 	seen := make(map[usageDedupToken]struct{})
 
@@ -2506,8 +2510,11 @@ func (db *DB) GetSessionUsage(
 			allPriced = false
 			unpricedSet[r.model] = struct{}{}
 		}
-		breakdown = append(breakdown, sessionUsageBreakdownEntry(
-			r, len(breakdown)+1, c, priced))
+		breakdownCount++
+		if includeBreakdown {
+			breakdown = append(breakdown, sessionUsageBreakdownEntry(
+				r, breakdownCount, c, priced))
+		}
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterating session usage rows: %w", err)
@@ -2522,6 +2529,7 @@ func (db *DB) GetSessionUsage(
 		HasTokenData:      sess.HasTotalOutputTokens || sess.HasPeakContextTokens,
 		Models:            sortedSetKeys(modelsSet),
 		HasCost:           contributing && allPriced,
+		BreakdownCount:    breakdownCount,
 		Breakdown:         breakdown,
 	}
 	if out.HasCost {

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -3241,6 +3241,19 @@ func TestGetSessionUsage_PricedModel(t *testing.T) {
 		"PeakContextTokens want 1200")
 	assert.Equal(t, []string{"claude-opus-4-6"}, u.Models, "Models")
 	assert.Empty(t, u.UnpricedModels, "UnpricedModels")
+	require.Len(t, u.Breakdown, 1, "Breakdown")
+	entry := u.Breakdown[0]
+	assert.Equal(t, 1, entry.Ordinal, "Breakdown ordinal")
+	require.NotNil(t, entry.MessageOrdinal, "MessageOrdinal")
+	assert.Equal(t, 0, *entry.MessageOrdinal, "MessageOrdinal")
+	assert.Equal(t, "message", entry.Source, "Source")
+	assert.Equal(t, "Prompt 1", entry.Label, "Label")
+	assert.Equal(t, "2026-05-20T10:30:00Z", entry.Timestamp, "Timestamp")
+	assert.Equal(t, "claude-opus-4-6", entry.Model, "Model")
+	assert.Equal(t, 1000, entry.InputTokens, "InputTokens")
+	assert.Equal(t, 500, entry.OutputTokens, "OutputTokens")
+	assert.InDelta(t, 0.0175, entry.CostUSD, 1e-9, "entry CostUSD")
+	assert.True(t, entry.HasCost, "entry HasCost")
 }
 
 func TestGetSessionUsage_UnpricedModel(t *testing.T) {
@@ -3318,6 +3331,75 @@ func TestGetSessionUsage_ExplicitCostOnly(t *testing.T) {
 	assert.True(t, u.HasCost, "HasCost = false, want true (explicit cost)")
 	assert.InDelta(t, 0.02, u.CostUSD, 1e-9, "CostUSD")
 	assert.Equal(t, []string{"gpt-5.4"}, u.Models, "Models")
+	require.Len(t, u.Breakdown, 1, "Breakdown")
+	entry := u.Breakdown[0]
+	assert.Nil(t, entry.MessageOrdinal, "MessageOrdinal")
+	assert.Equal(t, "session", entry.Source, "Source")
+	assert.Equal(t, "session", entry.Label, "Label")
+	assert.Equal(t, 100, entry.InputTokens, "InputTokens")
+	assert.Equal(t, 50, entry.OutputTokens, "OutputTokens")
+	assert.True(t, entry.HasCost, "entry HasCost")
+	assert.InDelta(t, 0.02, entry.CostUSD, 1e-9, "entry CostUSD")
+}
+
+func TestGetSessionUsage_BreakdownOrderingAndBuckets(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	seedOpusPricing(t, d)
+	insertSession(t, d, "claude:s-breakdown", "proj", func(s *Session) {
+		s.Agent = "claude-code"
+		s.StartedAt = new("2026-05-20T10:00:00Z")
+		s.TotalOutputTokens = 650
+		s.PeakContextTokens = 1500
+		s.HasTotalOutputTokens = true
+		s.HasPeakContextTokens = true
+	})
+	insertMessages(t, d,
+		Message{
+			SessionID: "claude:s-breakdown", Ordinal: 1, Role: "assistant",
+			Timestamp: "2026-05-20T10:31:00Z", Model: "claude-opus-4-6",
+			TokenUsage: json.RawMessage(
+				`{"input_tokens":100,"output_tokens":50,` +
+					`"cache_creation_input_tokens":10,` +
+					`"cache_read_input_tokens":20}`),
+		},
+		Message{
+			SessionID: "claude:s-breakdown", Ordinal: 0, Role: "assistant",
+			Timestamp: "2026-05-20T10:30:00Z", Model: "claude-opus-4-6",
+			TokenUsage: json.RawMessage(
+				`{"input_tokens":200,"output_tokens":60,` +
+					`"cache_creation_input_tokens":0,` +
+					`"cache_read_input_tokens":40}`),
+		},
+	)
+
+	u, err := d.GetSessionUsage(ctx, "claude:s-breakdown")
+	requireNoError(t, err, "GetSessionUsage")
+	require.Len(t, u.Breakdown, 2, "Breakdown")
+	assert.Equal(t, 650, u.TotalOutputTokens, "TotalOutputTokens")
+	assert.Equal(t, 1500, u.PeakContextTokens, "PeakContextTokens")
+
+	first := u.Breakdown[0]
+	require.NotNil(t, first.MessageOrdinal, "first MessageOrdinal")
+	assert.Equal(t, 0, *first.MessageOrdinal, "first MessageOrdinal")
+	assert.Equal(t, "Prompt 1", first.Label, "first Label")
+	assert.Equal(t, 200, first.InputTokens, "first InputTokens")
+	assert.Equal(t, 60, first.OutputTokens, "first OutputTokens")
+	assert.Equal(t, 0, first.CacheCreationInputTokens, "first CacheCreationInputTokens")
+	assert.Equal(t, 40, first.CacheReadInputTokens, "first CacheReadInputTokens")
+
+	second := u.Breakdown[1]
+	require.NotNil(t, second.MessageOrdinal, "second MessageOrdinal")
+	assert.Equal(t, 1, *second.MessageOrdinal, "second MessageOrdinal")
+	assert.Equal(t, "Prompt 2", second.Label, "second Label")
+	assert.Equal(t, 100, second.InputTokens, "second InputTokens")
+	assert.Equal(t, 50, second.OutputTokens, "second OutputTokens")
+	assert.Equal(t, 10, second.CacheCreationInputTokens, "second CacheCreationInputTokens")
+	assert.Equal(t, 20, second.CacheReadInputTokens, "second CacheReadInputTokens")
+
+	breakdownCost := first.CostUSD + second.CostUSD
+	assert.InDelta(t, breakdownCost, u.CostUSD, 1e-9,
+		"breakdown cost should sum to total cost")
 }
 
 func TestGetSessionUsage_DedupesDuplicateClaudeRows(t *testing.T) {
@@ -3349,6 +3431,9 @@ func TestGetSessionUsage_DedupesDuplicateClaudeRows(t *testing.T) {
 	// One row priced at 1000*5/1e6 + 500*25/1e6 = 0.0175; deduped, not 0.035.
 	assert.InDelta(t, 0.0175, u.CostUSD, 1e-9, "CostUSD want 0.0175 (deduped)")
 	assert.True(t, u.HasCost, "HasCost = false, want true")
+	require.Len(t, u.Breakdown, 1, "Breakdown")
+	require.NotNil(t, u.Breakdown[0].MessageOrdinal, "MessageOrdinal")
+	assert.Equal(t, 0, *u.Breakdown[0].MessageOrdinal, "MessageOrdinal")
 }
 
 func TestGetSessionUsage_DedupesBySourceUUIDWhenClaudePairIncomplete(t *testing.T) {
@@ -3401,6 +3486,7 @@ func TestGetSessionUsage_NoTokenRowsKeepsMetadata(t *testing.T) {
 	assert.True(t, u.HasTokenData, "HasTokenData = false, want true")
 	assert.False(t, u.HasCost, "HasCost = true, want false (no cost rows)")
 	assert.NotNil(t, u.Models, "Models = nil, want non-nil empty slice")
+	assert.Empty(t, u.Breakdown, "Breakdown")
 }
 
 func TestGetSessionUsage_NotFound(t *testing.T) {

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -409,7 +409,7 @@ func TestUsageRowsHandleBlankMessageTimestampWithoutSessionStart(t *testing.T) {
 	assert.Equal(t, 100, daily.Totals.InputTokens)
 	assert.Equal(t, 50, daily.Totals.OutputTokens)
 
-	usage, err := d.GetSessionUsage(ctx, "blank-ts")
+	usage, err := d.GetSessionUsage(ctx, "blank-ts", true)
 	requireNoError(t, err, "GetSessionUsage")
 	require.NotNil(t, usage)
 	assert.Equal(t, []string{"claude-sonnet-4-20250514"}, usage.Models)
@@ -458,7 +458,7 @@ func TestUsagePreservesSessionSummaryUsageEventTokens(t *testing.T) {
 	assert.Equal(t, rawInput, daily.Totals.InputTokens, "daily input")
 	assert.Equal(t, rawOutput, daily.Totals.OutputTokens, "daily output")
 
-	usage, err := d.GetSessionUsage(ctx, "hermes:summary")
+	usage, err := d.GetSessionUsage(ctx, "hermes:summary", true)
 	requireNoError(t, err, "GetSessionUsage")
 	require.NotNil(t, usage, "session usage")
 	assert.Equal(t, rawOutput, usage.TotalOutputTokens, "session output total")
@@ -1227,7 +1227,7 @@ func TestUsageAggregationClampsMessageTokenJSON(t *testing.T) {
 	assert.InDelta(t, 20.0, result.Totals.TotalCost, 1e-9,
 		"TotalCost")
 
-	usage, err := d.GetSessionUsage(ctx, "sess1")
+	usage, err := d.GetSessionUsage(ctx, "sess1", true)
 	requireNoError(t, err, "GetSessionUsage")
 	require.NotNil(t, usage, "session usage")
 	require.True(t, usage.HasCost, "HasCost")
@@ -3230,7 +3230,7 @@ func TestGetSessionUsage_PricedModel(t *testing.T) {
 			`{"input_tokens":1000,"output_tokens":500}`),
 	})
 
-	u, err := d.GetSessionUsage(ctx, "claude:s1")
+	u, err := d.GetSessionUsage(ctx, "claude:s1", true)
 	requireNoError(t, err, "GetSessionUsage")
 	require.NotNil(t, u, "usage is nil")
 	require.True(t, u.HasCost, "HasCost = false, want true")
@@ -3272,7 +3272,7 @@ func TestGetSessionUsage_UnpricedModel(t *testing.T) {
 			`{"input_tokens":1000,"output_tokens":500}`),
 	})
 
-	u, err := d.GetSessionUsage(ctx, "claude:s2")
+	u, err := d.GetSessionUsage(ctx, "claude:s2", true)
 	requireNoError(t, err, "GetSessionUsage")
 	assert.False(t, u.HasCost, "HasCost = true, want false (unpriced)")
 	assert.Equal(t, 0.0, u.CostUSD, "CostUSD")
@@ -3303,7 +3303,7 @@ func TestGetSessionUsage_MixedPricedUnpriced(t *testing.T) {
 		},
 	)
 
-	u, err := d.GetSessionUsage(ctx, "claude:s3")
+	u, err := d.GetSessionUsage(ctx, "claude:s3", true)
 	requireNoError(t, err, "GetSessionUsage")
 	assert.False(t, u.HasCost, "HasCost = true, want false (mixed)")
 	assert.Equal(t, 0.0, u.CostUSD, "CostUSD")
@@ -3326,7 +3326,7 @@ func TestGetSessionUsage_ExplicitCostOnly(t *testing.T) {
 		OccurredAt: "2026-05-20T10:05:00Z", DedupKey: "session:hermes:s4",
 	}}), "ReplaceSessionUsageEvents")
 
-	u, err := d.GetSessionUsage(ctx, "hermes:s4")
+	u, err := d.GetSessionUsage(ctx, "hermes:s4", true)
 	requireNoError(t, err, "GetSessionUsage")
 	assert.True(t, u.HasCost, "HasCost = false, want true (explicit cost)")
 	assert.InDelta(t, 0.02, u.CostUSD, 1e-9, "CostUSD")
@@ -3373,7 +3373,7 @@ func TestGetSessionUsage_BreakdownOrderingAndBuckets(t *testing.T) {
 		},
 	)
 
-	u, err := d.GetSessionUsage(ctx, "claude:s-breakdown")
+	u, err := d.GetSessionUsage(ctx, "claude:s-breakdown", true)
 	requireNoError(t, err, "GetSessionUsage")
 	require.Len(t, u.Breakdown, 2, "Breakdown")
 	assert.Equal(t, 650, u.TotalOutputTokens, "TotalOutputTokens")
@@ -3426,7 +3426,7 @@ func TestGetSessionUsage_DedupesDuplicateClaudeRows(t *testing.T) {
 			TokenUsage: json.RawMessage(`{"input_tokens":1000,"output_tokens":500}`),
 		},
 	)
-	u, err := d.GetSessionUsage(ctx, "claude:s6")
+	u, err := d.GetSessionUsage(ctx, "claude:s6", true)
 	requireNoError(t, err, "GetSessionUsage")
 	// One row priced at 1000*5/1e6 + 500*25/1e6 = 0.0175; deduped, not 0.035.
 	assert.InDelta(t, 0.0175, u.CostUSD, 1e-9, "CostUSD want 0.0175 (deduped)")
@@ -3458,7 +3458,7 @@ func TestGetSessionUsage_DedupesBySourceUUIDWhenClaudePairIncomplete(t *testing.
 			TokenUsage: json.RawMessage(`{"input_tokens":1000,"output_tokens":500}`),
 		},
 	)
-	u, err := d.GetSessionUsage(ctx, "claude:s7")
+	u, err := d.GetSessionUsage(ctx, "claude:s7", true)
 	requireNoError(t, err, "GetSessionUsage")
 	assert.InDelta(t, 0.0175, u.CostUSD, 1e-9, "CostUSD want 0.0175 (deduped)")
 	assert.True(t, u.HasCost, "HasCost = false, want true")
@@ -3476,7 +3476,7 @@ func TestGetSessionUsage_NoTokenRowsKeepsMetadata(t *testing.T) {
 		s.HasPeakContextTokens = true
 	})
 
-	u, err := d.GetSessionUsage(ctx, "claude:s5")
+	u, err := d.GetSessionUsage(ctx, "claude:s5", true)
 	requireNoError(t, err, "GetSessionUsage")
 	require.NotNil(t, u, "usage is nil")
 	assert.Equal(t, 700, u.TotalOutputTokens,
@@ -3491,7 +3491,7 @@ func TestGetSessionUsage_NoTokenRowsKeepsMetadata(t *testing.T) {
 
 func TestGetSessionUsage_NotFound(t *testing.T) {
 	d := testDB(t)
-	u, err := d.GetSessionUsage(context.Background(), "nope:x")
+	u, err := d.GetSessionUsage(context.Background(), "nope:x", true)
 	requireNoError(t, err, "GetSessionUsage")
 	assert.Nil(t, u, "usage")
 }
@@ -3523,7 +3523,7 @@ func TestGetSessionUsage_AICreditsCapability(t *testing.T) {
 			`{"input_tokens":1000,"output_tokens":500}`),
 	})
 
-	u, err := d.GetSessionUsage(ctx, "ai-credit-agent:s1")
+	u, err := d.GetSessionUsage(ctx, "ai-credit-agent:s1", true)
 	requireNoError(t, err, "GetSessionUsage")
 	require.NotNil(t, u, "usage is nil")
 	assert.True(t, u.HasCost, "HasCost = false, want true")

--- a/internal/duckdb/analytics_usage.go
+++ b/internal/duckdb/analytics_usage.go
@@ -2,6 +2,7 @@ package duckdb
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"math"
 	"slices"
@@ -1798,24 +1799,15 @@ func (s *Store) GetAnalyticsTools(
 		ids = append(ids, r.id)
 	}
 	if len(ids) == 0 {
-		return db.ToolsAnalyticsResponse{}, nil
+		return db.BuildToolsAnalytics(nil), nil
 	}
-	cats := map[string]int{}
-	agents := map[string]map[string]int{}
-	trends := map[string]map[string]int{}
-	total := 0
-	type toolRow struct {
-		sessionID string
-		category  string
-		count     int
-		date      string
-	}
-	var toolRows []toolRow
+	var toolRows []db.ToolAnalyticsRow
 	err = duckQueryChunked(ids, func(chunk []string) error {
 		ph, args := duckInPlaceholders(chunk)
 		modelPred, modelArgs := duckAnalyticsCSVPredicate("m.model", f.Model)
 		args = append(args, modelArgs...)
-		query := `SELECT tc.session_id, tc.category, COUNT(*),
+		query := `SELECT tc.session_id, tc.category,
+				TRIM(COALESCE(tc.tool_name, '')), COUNT(*),
 				m.timestamp
 				FROM tool_calls tc
 				LEFT JOIN messages m
@@ -1827,17 +1819,18 @@ func (s *Store) GetAnalyticsTools(
 				AND ` + modelPred
 		}
 		query += `
-				GROUP BY tc.session_id, tc.category, m.timestamp`
+				GROUP BY tc.session_id, tc.category,
+					TRIM(COALESCE(tc.tool_name, '')), m.timestamp`
 		rows, qErr := s.queryContext(ctx, query, args...)
 		if qErr != nil {
 			return qErr
 		}
 		defer rows.Close()
 		for rows.Next() {
-			var sid, cat string
+			var sid, cat, toolName string
 			var ts any
 			var count int
-			if err := rows.Scan(&sid, &cat, &count, &ts); err != nil {
+			if err := rows.Scan(&sid, &cat, &toolName, &count, &ts); err != nil {
 				return err
 			}
 			r, ok := meta[sid]
@@ -1850,11 +1843,13 @@ func (s *Store) GetAnalyticsTools(
 			if !keep {
 				continue
 			}
-			toolRows = append(toolRows, toolRow{
-				sessionID: sid,
-				category:  cat,
-				count:     count,
-				date:      date,
+			toolRows = append(toolRows, db.ToolAnalyticsRow{
+				SessionID: sid,
+				Category:  cat,
+				ToolName:  toolName,
+				Agent:     r.agent,
+				Count:     count,
+				Date:      date,
 			})
 		}
 		return rows.Err()
@@ -1862,50 +1857,7 @@ func (s *Store) GetAnalyticsTools(
 	if err != nil {
 		return db.ToolsAnalyticsResponse{}, err
 	}
-	for _, tr := range toolRows {
-		r, ok := meta[tr.sessionID]
-		if !ok {
-			continue
-		}
-		total += tr.count
-		cats[tr.category] += tr.count
-		if agents[r.agent] == nil {
-			agents[r.agent] = map[string]int{}
-		}
-		agents[r.agent][tr.category] += tr.count
-		week := bucketAnalyticsDate(tr.date, "week")
-		if trends[week] == nil {
-			trends[week] = map[string]int{}
-		}
-		trends[week][tr.category] += tr.count
-	}
-	resp := db.ToolsAnalyticsResponse{TotalCalls: total}
-	for cat, count := range cats {
-		resp.ByCategory = append(resp.ByCategory, db.ToolCategoryCount{
-			Category: cat, Count: count, Pct: round1(float64(count) / float64(max(total, 1)) * 100),
-		})
-	}
-	sort.Slice(resp.ByCategory, func(i, j int) bool {
-		if resp.ByCategory[i].Count != resp.ByCategory[j].Count {
-			return resp.ByCategory[i].Count > resp.ByCategory[j].Count
-		}
-		return resp.ByCategory[i].Category < resp.ByCategory[j].Category
-	})
-	for _, agent := range sortedKeys(agents) {
-		breakdown := db.ToolAgentBreakdown{Agent: agent}
-		for cat, count := range agents[agent] {
-			breakdown.Total += count
-			breakdown.Categories = append(breakdown.Categories, db.ToolCategoryCount{Category: cat, Count: count})
-		}
-		for i := range breakdown.Categories {
-			breakdown.Categories[i].Pct = round1(float64(breakdown.Categories[i].Count) / float64(max(breakdown.Total, 1)) * 100)
-		}
-		resp.ByAgent = append(resp.ByAgent, breakdown)
-	}
-	for _, date := range sortedKeys(trends) {
-		resp.Trend = append(resp.Trend, db.ToolTrendEntry{Date: date, ByCat: trends[date]})
-	}
-	return resp, nil
+	return db.BuildToolsAnalytics(toolRows), nil
 }
 
 func (s *Store) GetAnalyticsSkills(
@@ -3511,6 +3463,20 @@ type duckUsageAggregateRow struct {
 	reportedCostRows int
 }
 
+type duckSessionUsageRow struct {
+	sessionID      string
+	messageOrdinal sql.NullInt64
+	source         string
+	ts             string
+	model          string
+	inputTok       int
+	outputTok      int
+	cacheCr        int
+	cacheRd        int
+	reasoningTok   int
+	costUSD        sql.NullFloat64
+}
+
 func duckUsageAggregateCost(
 	model string,
 	inputTok, outputTok, cacheCr, cacheRd int,
@@ -3547,6 +3513,73 @@ func duckUsageAggregateCost(
 		priced = true
 	}
 	return cost, readDelta + createDelta, priced, true
+}
+
+func duckSessionUsageRowCost(
+	r duckSessionUsageRow, pricing map[string]duckRates,
+) (float64, bool, bool) {
+	if r.costUSD.Valid {
+		return r.costUSD.Float64, true, true
+	}
+	if r.inputTok == 0 && r.outputTok == 0 && r.reasoningTok == 0 &&
+		r.cacheCr == 0 && r.cacheRd == 0 {
+		return 0, true, false
+	}
+	rates, priced := pricingpkg.Resolve(pricing, r.model)
+	if !priced {
+		return 0, false, true
+	}
+	// Reasoning is a breakdown of output, not additional billable
+	// output; reasoning-only rows bill at the output rate. Mirrors
+	// export.ModelRates.CostForTokens and the aggregate SQL fold.
+	billableOutput := r.outputTok
+	if billableOutput == 0 {
+		billableOutput = r.reasoningTok
+	}
+	cost := (float64(r.inputTok)*rates.input +
+		float64(billableOutput)*rates.output +
+		float64(r.cacheCr)*rates.cacheCreation +
+		float64(r.cacheRd)*rates.cacheRead) / 1_000_000
+	return cost, true, true
+}
+
+func duckSessionUsageBreakdownEntry(
+	r duckSessionUsageRow,
+	ordinal int,
+	cost float64,
+	priced bool,
+) db.SessionUsageBreakdownEntry {
+	entry := db.SessionUsageBreakdownEntry{
+		Ordinal:                  ordinal,
+		Source:                   r.source,
+		Label:                    duckSessionUsageBreakdownLabel(r),
+		Timestamp:                r.ts,
+		Model:                    r.model,
+		InputTokens:              r.inputTok,
+		OutputTokens:             r.outputTok,
+		CacheCreationInputTokens: r.cacheCr,
+		CacheReadInputTokens:     r.cacheRd,
+		CostUSD:                  cost,
+		HasCost:                  priced,
+	}
+	if r.messageOrdinal.Valid {
+		messageOrdinal := int(r.messageOrdinal.Int64)
+		entry.MessageOrdinal = &messageOrdinal
+	}
+	return entry
+}
+
+func duckSessionUsageBreakdownLabel(r duckSessionUsageRow) string {
+	if r.messageOrdinal.Valid {
+		if r.source == "message" {
+			return fmt.Sprintf("Prompt %d", r.messageOrdinal.Int64+1)
+		}
+		return fmt.Sprintf("Step %d", r.messageOrdinal.Int64+1)
+	}
+	if r.source != "" {
+		return r.source
+	}
+	return "usage"
 }
 
 func (s *Store) dailyUsageAggregateRows(
@@ -3847,6 +3880,42 @@ func (s *Store) sessionUsageAggregateRows(
 	return out, rows.Err()
 }
 
+func (s *Store) sessionUsageRows(
+	ctx context.Context, sessionID string,
+) ([]duckSessionUsageRow, error) {
+	cte, args := duckUsageCTE(db.UsageFilter{}, sessionID)
+	query := cte + `
+		SELECT session_id, message_ordinal, source, ts, model,
+			input_tokens_norm, output_tokens_norm,
+			cache_create_norm, cache_read_norm,
+			reasoning_tokens_norm, cost_usd
+		FROM usage_localized
+		ORDER BY ts ASC, session_id ASC,
+			COALESCE(message_ordinal, -1) ASC,
+			source ASC,
+			usage_dedup_key ASC`
+	rows, err := s.queryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("querying duckdb session usage rows: %w", err)
+	}
+	defer rows.Close()
+	var out []duckSessionUsageRow
+	for rows.Next() {
+		var r duckSessionUsageRow
+		var ts any
+		if err := rows.Scan(
+			&r.sessionID, &r.messageOrdinal, &r.source, &ts, &r.model,
+			&r.inputTok, &r.outputTok, &r.cacheCr, &r.cacheRd,
+			&r.reasoningTok, &r.costUSD,
+		); err != nil {
+			return nil, fmt.Errorf("scanning duckdb session usage row: %w", err)
+		}
+		r.ts = formatDBTime(ts)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
 func (s *Store) GetTopSessionsByCost(
 	ctx context.Context, f db.UsageFilter, limit int,
 ) ([]db.TopSessionEntry, error) {
@@ -4044,6 +4113,10 @@ func (s *Store) GetSessionUsage(
 	if err != nil {
 		return nil, err
 	}
+	breakdownRows, err := s.sessionUsageRows(ctx, sessionID)
+	if err != nil {
+		return nil, err
+	}
 	models := map[string]bool{}
 	unpriced := map[string]bool{}
 	totalCost := 0.0
@@ -4068,6 +4141,15 @@ func (s *Store) GetSessionUsage(
 			unpriced[r.model] = true
 		}
 	}
+	breakdown := make([]db.SessionUsageBreakdownEntry, 0, len(breakdownRows))
+	for _, r := range breakdownRows {
+		cost, priced, contributes := duckSessionUsageRowCost(r, pricing)
+		if !contributes {
+			continue
+		}
+		breakdown = append(breakdown, duckSessionUsageBreakdownEntry(
+			r, len(breakdown)+1, cost, priced))
+	}
 	out := &db.SessionUsage{
 		SessionID: sessionID, Agent: sess.Agent, Project: sess.Project,
 		TotalOutputTokens: sess.TotalOutputTokens,
@@ -4075,6 +4157,7 @@ func (s *Store) GetSessionUsage(
 		HasTokenData:      hasRows || sess.HasTotalOutputTokens || sess.HasPeakContextTokens,
 		Models:            sortedBoolKeys(models),
 		UnpricedModels:    sortedBoolKeys(unpriced),
+		Breakdown:         breakdown,
 	}
 	if len(unpriced) == 0 && hasRows {
 		out.HasCost = true

--- a/internal/duckdb/analytics_usage.go
+++ b/internal/duckdb/analytics_usage.go
@@ -3880,6 +3880,32 @@ func (s *Store) sessionUsageAggregateRows(
 	return out, rows.Err()
 }
 
+// sessionUsageRowCount counts the deduped usage rows that would
+// contribute breakdown entries, mirroring duckSessionUsageRowCost's
+// contributes rule (an explicit cost or any nonzero token counter)
+// without shipping the rows.
+func (s *Store) sessionUsageRowCount(
+	ctx context.Context, sessionID string,
+) (int, error) {
+	cte, args := duckUsageCTE(db.UsageFilter{}, sessionID)
+	query := cte + `
+		SELECT COUNT(*)
+		FROM usage_localized
+		WHERE cost_usd IS NOT NULL
+			OR input_tokens_norm != 0
+			OR output_tokens_norm != 0
+			OR cache_create_norm != 0
+			OR cache_read_norm != 0
+			OR reasoning_tokens_norm != 0`
+	var count int
+	if err := s.queryRowContext(ctx, query, args...).
+		Scan(&count); err != nil {
+		return 0, fmt.Errorf(
+			"counting duckdb session usage rows: %w", err)
+	}
+	return count, nil
+}
+
 func (s *Store) sessionUsageRows(
 	ctx context.Context, sessionID string,
 ) ([]duckSessionUsageRow, error) {
@@ -4098,7 +4124,7 @@ func (s *Store) GetUsageMatchingSessionCount(
 }
 
 func (s *Store) GetSessionUsage(
-	ctx context.Context, sessionID string,
+	ctx context.Context, sessionID string, includeBreakdown bool,
 ) (*db.SessionUsage, error) {
 	sess, err := s.GetSession(ctx, sessionID)
 	if err != nil || sess == nil {
@@ -4113,7 +4139,13 @@ func (s *Store) GetSessionUsage(
 	if err != nil {
 		return nil, err
 	}
-	breakdownRows, err := s.sessionUsageRows(ctx, sessionID)
+	var breakdownRows []duckSessionUsageRow
+	breakdownCount := 0
+	if includeBreakdown {
+		breakdownRows, err = s.sessionUsageRows(ctx, sessionID)
+	} else {
+		breakdownCount, err = s.sessionUsageRowCount(ctx, sessionID)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -4150,6 +4182,9 @@ func (s *Store) GetSessionUsage(
 		breakdown = append(breakdown, duckSessionUsageBreakdownEntry(
 			r, len(breakdown)+1, cost, priced))
 	}
+	if includeBreakdown {
+		breakdownCount = len(breakdown)
+	}
 	out := &db.SessionUsage{
 		SessionID: sessionID, Agent: sess.Agent, Project: sess.Project,
 		TotalOutputTokens: sess.TotalOutputTokens,
@@ -4157,6 +4192,7 @@ func (s *Store) GetSessionUsage(
 		HasTokenData:      hasRows || sess.HasTotalOutputTokens || sess.HasPeakContextTokens,
 		Models:            sortedBoolKeys(models),
 		UnpricedModels:    sortedBoolKeys(unpriced),
+		BreakdownCount:    breakdownCount,
 		Breakdown:         breakdown,
 	}
 	if len(unpriced) == 0 && hasRows {

--- a/internal/duckdb/analytics_usage_test.go
+++ b/internal/duckdb/analytics_usage_test.go
@@ -966,6 +966,14 @@ func assertDuckAnalyticsToolsModelFilterCountsOnlyMatchingToolCalls(
 	assert.Equal(t, 1, byCategory["Read"], "Read")
 	assert.Equal(t, 1, byCategory["Skill"], "Skill")
 	assert.Zero(t, byCategory["Grep"], "Grep")
+
+	byTool := map[string]int{}
+	for _, row := range resp.ByTool {
+		byTool[row.ToolName] = row.CallCount
+	}
+	assert.Equal(t, 1, byTool["Read"], "Read tool")
+	assert.Equal(t, 1, byTool["Skill"], "Skill tool")
+	assert.Zero(t, byTool["Grep"], "Grep tool")
 }
 
 func TestDuckAnalyticsToolsModelAndHourFilterCountsOnlyMatchingHourToolCalls(
@@ -1006,6 +1014,10 @@ func TestDuckAnalyticsToolsModelAndHourFilterCountsOnlyMatchingHourToolCalls(
 	require.Len(t, resp.ByCategory, 1, "len(ByCategory)")
 	assert.Equal(t, "Grep", resp.ByCategory[0].Category, "Category")
 	assert.Equal(t, 1, resp.ByCategory[0].Count, "Count")
+	require.Len(t, resp.ByTool, 1, "len(ByTool)")
+	assert.Equal(t, "Grep", resp.ByTool[0].ToolName, "ToolName")
+	assert.Equal(t, 1, resp.ByTool[0].CallCount, "CallCount")
+	assert.Equal(t, 1, resp.ByTool[0].SessionCount, "SessionCount")
 }
 
 func assertDuckAnalyticsSkillsModelFilterCountsOnlyMatchingSkillCalls(

--- a/internal/duckdb/store_contract_test.go
+++ b/internal/duckdb/store_contract_test.go
@@ -329,7 +329,7 @@ func duckContractAnalyticsTrendsAndUsage(
 	require.NoError(t, err)
 	require.Equal(t, 2, counts.Total)
 
-	sessionUsage, err := store.GetSessionUsage(ctx, fixture.alphaID)
+	sessionUsage, err := store.GetSessionUsage(ctx, fixture.alphaID, true)
 	require.NoError(t, err)
 	require.NotNil(t, sessionUsage)
 	require.True(t, sessionUsage.HasCost)

--- a/internal/duckdb/store_test.go
+++ b/internal/duckdb/store_test.go
@@ -788,7 +788,7 @@ func TestStoreAnalyticsUsageAndTrends(t *testing.T) {
 	assert.Equal(t, 2, counts.Total)
 	assert.Equal(t, 1, counts.ByProject["alpha"])
 
-	sessionUsage, err := store.GetSessionUsage(ctx, fixture.alphaID)
+	sessionUsage, err := store.GetSessionUsage(ctx, fixture.alphaID, true)
 	require.NoError(t, err)
 	require.NotNil(t, sessionUsage)
 	assert.True(t, sessionUsage.HasCost)
@@ -2191,7 +2191,7 @@ func TestUsageDedupesClaudeMessageIDs(t *testing.T) {
 	assert.Equal(t, 1, counts.ByProject["alpha"])
 	assert.NotContains(t, counts.ByProject, "beta")
 
-	sessionUsage, err := store.GetSessionUsage(ctx, "duck-usage-b")
+	sessionUsage, err := store.GetSessionUsage(ctx, "duck-usage-b", true)
 	require.NoError(t, err)
 	require.NotNil(t, sessionUsage)
 	assert.True(t, sessionUsage.HasCost)
@@ -2266,7 +2266,7 @@ func TestUsageDedupesSourceUUIDWhenClaudePairIncomplete(t *testing.T) {
 	assert.Equal(t, 1, counts.ByProject["alpha"])
 	assert.NotContains(t, counts.ByProject, "beta")
 
-	sessionUsage, err := store.GetSessionUsage(ctx, "duck-usage-source-b")
+	sessionUsage, err := store.GetSessionUsage(ctx, "duck-usage-source-b", true)
 	require.NoError(t, err)
 	require.NotNil(t, sessionUsage)
 	assert.True(t, sessionUsage.HasCost)
@@ -2330,7 +2330,7 @@ func TestUsagePreservesSessionSummaryUsageEventTokens(t *testing.T) {
 	wantCost := (float64(rawInput)*1 + float64(rawOutput)*2) / 1_000_000
 	assert.InDelta(t, wantCost, top[0].Cost, 0.000001)
 
-	sessionUsage, err := store.GetSessionUsage(ctx, sessionID)
+	sessionUsage, err := store.GetSessionUsage(ctx, sessionID, true)
 	require.NoError(t, err)
 	require.NotNil(t, sessionUsage)
 	assert.Equal(t, rawOutput, sessionUsage.TotalOutputTokens)
@@ -2392,7 +2392,7 @@ func TestDailyUsageCostsReasoningOnlyRows(t *testing.T) {
 	require.Len(t, top, 1)
 	assert.InDelta(t, wantCost, top[0].Cost, 0.000001)
 
-	sessionUsage, err := store.GetSessionUsage(ctx, sessionID)
+	sessionUsage, err := store.GetSessionUsage(ctx, sessionID, true)
 	require.NoError(t, err)
 	require.NotNil(t, sessionUsage)
 	assert.True(t, sessionUsage.HasCost)
@@ -2445,7 +2445,7 @@ func TestDailyUsageCostsMessageReasoningTokens(t *testing.T) {
 	assert.Zero(t, daily.Totals.OutputTokens)
 	assert.InDelta(t, 0.002, daily.Totals.TotalCost, 0.000001)
 
-	sessionUsage, err := store.GetSessionUsage(ctx, "duck-message-reasoning")
+	sessionUsage, err := store.GetSessionUsage(ctx, "duck-message-reasoning", true)
 	require.NoError(t, err)
 	require.NotNil(t, sessionUsage)
 	assert.True(t, sessionUsage.HasCost)
@@ -2517,7 +2517,7 @@ func TestDailyUsageCostsMixedOutputAndReasoningOnlyRows(t *testing.T) {
 	require.Len(t, top, 1)
 	assert.InDelta(t, wantCost, top[0].Cost, 0.000001)
 
-	sessionUsage, err := store.GetSessionUsage(ctx, sessionID)
+	sessionUsage, err := store.GetSessionUsage(ctx, sessionID, true)
 	require.NoError(t, err)
 	require.NotNil(t, sessionUsage)
 	assert.True(t, sessionUsage.HasCost)

--- a/internal/duckdb/store_test.go
+++ b/internal/duckdb/store_test.go
@@ -2197,6 +2197,19 @@ func TestUsageDedupesClaudeMessageIDs(t *testing.T) {
 	assert.True(t, sessionUsage.HasCost)
 	assert.InDelta(t, 0.000033, sessionUsage.CostUSD, 0.000001)
 	assert.Equal(t, []string{"claude-test"}, sessionUsage.Models)
+	require.Len(t, sessionUsage.Breakdown, 1)
+	entry := sessionUsage.Breakdown[0]
+	assert.Equal(t, 1, entry.Ordinal)
+	require.NotNil(t, entry.MessageOrdinal)
+	assert.Equal(t, 0, *entry.MessageOrdinal)
+	assert.Equal(t, "message", entry.Source)
+	assert.Equal(t, "Prompt 1", entry.Label)
+	assert.Equal(t, "2026-01-13T00:01:00Z", entry.Timestamp)
+	assert.Equal(t, "claude-test", entry.Model)
+	assert.Equal(t, 1, entry.InputTokens)
+	assert.Equal(t, 2, entry.OutputTokens)
+	assert.True(t, entry.HasCost)
+	assert.InDelta(t, 0.000033, entry.CostUSD, 0.000001)
 }
 
 func TestUsageDedupesSourceUUIDWhenClaudePairIncomplete(t *testing.T) {
@@ -2259,6 +2272,9 @@ func TestUsageDedupesSourceUUIDWhenClaudePairIncomplete(t *testing.T) {
 	assert.True(t, sessionUsage.HasCost)
 	assert.InDelta(t, 0.000033, sessionUsage.CostUSD, 0.000001)
 	assert.Equal(t, []string{"claude-test"}, sessionUsage.Models)
+	require.Len(t, sessionUsage.Breakdown, 1)
+	require.NotNil(t, sessionUsage.Breakdown[0].MessageOrdinal)
+	assert.Equal(t, 0, *sessionUsage.Breakdown[0].MessageOrdinal)
 }
 
 func TestUsagePreservesSessionSummaryUsageEventTokens(t *testing.T) {
@@ -2322,6 +2338,15 @@ func TestUsagePreservesSessionSummaryUsageEventTokens(t *testing.T) {
 	assert.True(t, sessionUsage.HasCost)
 	assert.InDelta(t, wantCost, sessionUsage.CostUSD, 0.000001)
 	assert.Equal(t, []string{"summary-model"}, sessionUsage.Models)
+	require.Len(t, sessionUsage.Breakdown, 1)
+	entry := sessionUsage.Breakdown[0]
+	assert.Equal(t, "session", entry.Source)
+	assert.Equal(t, "session", entry.Label)
+	assert.Nil(t, entry.MessageOrdinal)
+	assert.Equal(t, rawInput, entry.InputTokens)
+	assert.Equal(t, rawOutput, entry.OutputTokens)
+	assert.True(t, entry.HasCost)
+	assert.InDelta(t, wantCost, entry.CostUSD, 0.000001)
 }
 
 func TestDailyUsageCostsReasoningOnlyRows(t *testing.T) {
@@ -2372,6 +2397,15 @@ func TestDailyUsageCostsReasoningOnlyRows(t *testing.T) {
 	require.NotNil(t, sessionUsage)
 	assert.True(t, sessionUsage.HasCost)
 	assert.InDelta(t, wantCost, sessionUsage.CostUSD, 0.000001)
+	require.Len(t, sessionUsage.Breakdown, 1,
+		"reasoning-only rows must appear in the breakdown")
+	entry := sessionUsage.Breakdown[0]
+	assert.Equal(t, "provider", entry.Source)
+	assert.Zero(t, entry.OutputTokens,
+		"reasoning stays out of reported output tokens")
+	assert.True(t, entry.HasCost)
+	assert.InDelta(t, wantCost, entry.CostUSD, 0.000001,
+		"reasoning-only breakdown row bills at the output rate")
 }
 
 func TestDailyUsageCostsMessageReasoningTokens(t *testing.T) {
@@ -2416,6 +2450,15 @@ func TestDailyUsageCostsMessageReasoningTokens(t *testing.T) {
 	require.NotNil(t, sessionUsage)
 	assert.True(t, sessionUsage.HasCost)
 	assert.InDelta(t, 0.002, sessionUsage.CostUSD, 0.000001)
+	require.Len(t, sessionUsage.Breakdown, 1,
+		"reasoning-bearing message must appear in the breakdown")
+	entry := sessionUsage.Breakdown[0]
+	assert.Equal(t, "message", entry.Source)
+	assert.Equal(t, 1000, entry.InputTokens)
+	assert.Zero(t, entry.OutputTokens)
+	assert.True(t, entry.HasCost)
+	assert.InDelta(t, 0.002, entry.CostUSD, 0.000001,
+		"breakdown cost must include reasoning billed as output")
 }
 
 func TestDailyUsageCostsMixedOutputAndReasoningOnlyRows(t *testing.T) {
@@ -2479,6 +2522,15 @@ func TestDailyUsageCostsMixedOutputAndReasoningOnlyRows(t *testing.T) {
 	require.NotNil(t, sessionUsage)
 	assert.True(t, sessionUsage.HasCost)
 	assert.InDelta(t, wantCost, sessionUsage.CostUSD, 0.000001)
+	require.Len(t, sessionUsage.Breakdown, 2,
+		"both output and reasoning-only rows must appear in the breakdown")
+	breakdownCost := 0.0
+	for _, entry := range sessionUsage.Breakdown {
+		assert.True(t, entry.HasCost)
+		breakdownCost += entry.CostUSD
+	}
+	assert.InDelta(t, wantCost, breakdownCost, 0.000001,
+		"breakdown costs must sum to the session cost")
 }
 
 func TestUsageDedupPrefersInRangeDuplicate(t *testing.T) {

--- a/internal/insight/prompt.go
+++ b/internal/insight/prompt.go
@@ -158,7 +158,7 @@ func buildSessionPrompt(
 	if err != nil {
 		return "", fmt.Errorf("getting timing: %w", err)
 	}
-	usage, err := database.GetSessionUsage(ctx, req.SessionID)
+	usage, err := database.GetSessionUsage(ctx, req.SessionID, false)
 	if err != nil {
 		return "", fmt.Errorf("getting usage: %w", err)
 	}

--- a/internal/postgres/analytics.go
+++ b/internal/postgres/analytics.go
@@ -2122,6 +2122,7 @@ func (s *Store) GetAnalyticsTools(
 	resp := db.ToolsAnalyticsResponse{
 		ByCategory: []db.ToolCategoryCount{},
 		ByAgent:    []db.ToolAgentBreakdown{},
+		ByTool:     []db.ToolUsageAnalysis{},
 		Trend:      []db.ToolTrendEntry{},
 	}
 
@@ -2129,13 +2130,7 @@ func (s *Store) GetAnalyticsTools(
 		return resp, nil
 	}
 
-	type toolRow struct {
-		sessionID string
-		category  string
-		count     int
-		date      string
-	}
-	var toolRows []toolRow
+	var toolRows []db.ToolAnalyticsRow
 
 	err = pgQueryChunked(sessionIDs,
 		func(chunk []string) error {
@@ -2147,7 +2142,8 @@ func (s *Store) GetAnalyticsTools(
 			)
 			msgTSExpr := `COALESCE(TO_CHAR(m.timestamp AT TIME ZONE 'UTC', ` +
 				`'YYYY-MM-DD"T"HH24:MI:SS"Z"'), '')`
-			q := `SELECT tc.session_id, tc.category, COUNT(*),
+			q := `SELECT tc.session_id, tc.category,
+				TRIM(COALESCE(tc.tool_name, '')), COUNT(*),
 				` + msgTSExpr + `
 				FROM tool_calls tc
 				LEFT JOIN messages m
@@ -2155,7 +2151,8 @@ func (s *Store) GetAnalyticsTools(
 					AND m.ordinal = tc.message_ordinal`
 			q += `
 				WHERE ` + strings.Join(preds, " AND ") + `
-				GROUP BY tc.session_id, tc.category, ` + msgTSExpr
+				GROUP BY tc.session_id, tc.category,
+					TRIM(COALESCE(tc.tool_name, '')), ` + msgTSExpr
 			rows, qErr := s.pg.QueryContext(
 				ctx, q, chunkPB.args...,
 			)
@@ -2166,10 +2163,10 @@ func (s *Store) GetAnalyticsTools(
 			}
 			defer rows.Close()
 			for rows.Next() {
-				var sid, cat, ts string
+				var sid, cat, toolName, ts string
 				var count int
 				if err := rows.Scan(
-					&sid, &cat, &count, &ts,
+					&sid, &cat, &toolName, &count, &ts,
 				); err != nil {
 					return fmt.Errorf(
 						"scanning tool_call: %w", err,
@@ -2185,11 +2182,13 @@ func (s *Store) GetAnalyticsTools(
 				if !keep {
 					continue
 				}
-				toolRows = append(toolRows, toolRow{
-					sessionID: sid,
-					category:  cat,
-					count:     count,
-					date:      date,
+				toolRows = append(toolRows, db.ToolAnalyticsRow{
+					SessionID: sid,
+					Category:  cat,
+					ToolName:  toolName,
+					Agent:     info.agent,
+					Count:     count,
+					Date:      date,
 				})
 			}
 			return rows.Err()
@@ -2201,107 +2200,7 @@ func (s *Store) GetAnalyticsTools(
 	if len(toolRows) == 0 {
 		return resp, nil
 	}
-
-	catCounts := make(map[string]int)
-	agentCats := make(map[string]map[string]int)
-	trendBuckets := make(map[string]map[string]int)
-
-	for _, tr := range toolRows {
-		info := sessionMap[tr.sessionID]
-		catCounts[tr.category] += tr.count
-
-		if agentCats[info.agent] == nil {
-			agentCats[info.agent] = make(map[string]int)
-		}
-		agentCats[info.agent][tr.category] += tr.count
-
-		week := bucketDate(tr.date, "week")
-		if trendBuckets[week] == nil {
-			trendBuckets[week] = make(map[string]int)
-		}
-		trendBuckets[week][tr.category] += tr.count
-	}
-
-	for _, count := range catCounts {
-		resp.TotalCalls += count
-	}
-
-	resp.ByCategory = make(
-		[]db.ToolCategoryCount, 0, len(catCounts),
-	)
-	for cat, count := range catCounts {
-		pct := math.Round(
-			float64(count)/
-				float64(resp.TotalCalls)*1000,
-		) / 10
-		resp.ByCategory = append(resp.ByCategory,
-			db.ToolCategoryCount{
-				Category: cat, Count: count, Pct: pct,
-			})
-	}
-	sort.Slice(resp.ByCategory, func(i, j int) bool {
-		if resp.ByCategory[i].Count !=
-			resp.ByCategory[j].Count {
-			return resp.ByCategory[i].Count >
-				resp.ByCategory[j].Count
-		}
-		return resp.ByCategory[i].Category <
-			resp.ByCategory[j].Category
-	})
-
-	agentKeys := make([]string, 0, len(agentCats))
-	for k := range agentCats {
-		agentKeys = append(agentKeys, k)
-	}
-	sort.Strings(agentKeys)
-	resp.ByAgent = make(
-		[]db.ToolAgentBreakdown, 0, len(agentKeys),
-	)
-	for _, agent := range agentKeys {
-		cats := agentCats[agent]
-		total := 0
-		for _, c := range cats {
-			total += c
-		}
-		catList := make(
-			[]db.ToolCategoryCount, 0, len(cats),
-		)
-		for cat, count := range cats {
-			pct := math.Round(
-				float64(count)/float64(total)*1000,
-			) / 10
-			catList = append(catList, db.ToolCategoryCount{
-				Category: cat, Count: count, Pct: pct,
-			})
-		}
-		sort.Slice(catList, func(i, j int) bool {
-			if catList[i].Count != catList[j].Count {
-				return catList[i].Count > catList[j].Count
-			}
-			return catList[i].Category <
-				catList[j].Category
-		})
-		resp.ByAgent = append(resp.ByAgent,
-			db.ToolAgentBreakdown{
-				Agent:      agent,
-				Total:      total,
-				Categories: catList,
-			})
-	}
-
-	resp.Trend = make(
-		[]db.ToolTrendEntry, 0, len(trendBuckets),
-	)
-	for week, cats := range trendBuckets {
-		resp.Trend = append(resp.Trend, db.ToolTrendEntry{
-			Date: week, ByCat: cats,
-		})
-	}
-	sort.Slice(resp.Trend, func(i, j int) bool {
-		return resp.Trend[i].Date < resp.Trend[j].Date
-	})
-
-	return resp, nil
+	return db.BuildToolsAnalytics(toolRows), nil
 }
 
 // GetAnalyticsSkills returns skill usage analytics.

--- a/internal/postgres/analytics_model_pgtest_test.go
+++ b/internal/postgres/analytics_model_pgtest_test.go
@@ -437,6 +437,14 @@ func TestStoreGetAnalyticsToolsModelFilterCountsOnlyMatchingToolCalls(
 	assert.Equal(t, 1, catMap["Read"], "Read")
 	assert.Equal(t, 1, catMap["Bash"], "Bash")
 	assert.Zero(t, catMap["Grep"], "Grep")
+
+	toolMap := make(map[string]int)
+	for _, tool := range resp.ByTool {
+		toolMap[tool.ToolName] = tool.CallCount
+	}
+	assert.Equal(t, 1, toolMap["Read"], "Read tool")
+	assert.Equal(t, 1, toolMap["Bash"], "Bash tool")
+	assert.Zero(t, toolMap["Grep"], "Grep tool")
 }
 
 func TestStoreGetAnalyticsToolsModelAndHourFilterCountsOnlyMatchingHourToolCalls(
@@ -486,6 +494,10 @@ func TestStoreGetAnalyticsToolsModelAndHourFilterCountsOnlyMatchingHourToolCalls
 	require.Len(t, resp.ByCategory, 1, "len(ByCategory)")
 	assert.Equal(t, "Grep", resp.ByCategory[0].Category, "Category")
 	assert.Equal(t, 1, resp.ByCategory[0].Count, "Count")
+	require.Len(t, resp.ByTool, 1, "len(ByTool)")
+	assert.Equal(t, "Grep", resp.ByTool[0].ToolName, "ToolName")
+	assert.Equal(t, 1, resp.ByTool[0].CallCount, "CallCount")
+	assert.Equal(t, 1, resp.ByTool[0].SessionCount, "SessionCount")
 }
 
 func TestStoreGetAnalyticsSkillsModelFilterCountsOnlyMatchingSkillCalls(

--- a/internal/postgres/analytics_unit_test.go
+++ b/internal/postgres/analytics_unit_test.go
@@ -178,6 +178,11 @@ func (c *analyticsProbeConn) QueryContext(
 				},
 			}, nil
 		}
+		if !strings.Contains(normalized,
+			"trim(coalesce(tc.tool_name") {
+			return nil, errors.New(
+				"tool call query must project trimmed tool_name")
+		}
 		if !strings.Contains(normalized, "group by session_id, category") {
 			if !strings.Contains(normalized,
 				"group by tc.session_id, tc.category") {
@@ -185,33 +190,38 @@ func (c *analyticsProbeConn) QueryContext(
 					"tool call query must group by session_id, category")
 			}
 		}
+		if !strings.Contains(normalized,
+			"trim(coalesce(tc.tool_name") {
+			return nil, errors.New(
+				"tool call query must group by tool_name")
+		}
 		if strings.Contains(normalized, "to_char(m.timestamp") {
 			return &analyticsProbeRows{
 				columns: []string{
-					"session_id", "category", "count", "timestamp",
+					"session_id", "category", "tool_name", "count", "timestamp",
 				},
 				values: [][]driver.Value{
 					{
-						"s1", "Read", int64(2),
+						"s1", "Read", "Read", int64(2),
 						"2024-06-03T09:00:00Z",
 					},
 					{
-						"s1", "Bash", int64(1),
+						"s1", "Bash", "Bash", int64(1),
 						"2024-06-03T09:00:00Z",
 					},
 					{
-						"s2", "Read", int64(1),
+						"s2", "Read", "Read", int64(1),
 						"2024-06-04T09:00:00Z",
 					},
 				},
 			}, nil
 		}
 		return &analyticsProbeRows{
-			columns: []string{"session_id", "category", "count"},
+			columns: []string{"session_id", "category", "tool_name", "count"},
 			values: [][]driver.Value{
-				{"s1", "Read", int64(2)},
-				{"s1", "Bash", int64(1)},
-				{"s2", "Read", int64(1)},
+				{"s1", "Read", "Read", int64(2)},
+				{"s1", "Bash", "Bash", int64(1)},
+				{"s2", "Read", "Read", int64(1)},
 			},
 		}, nil
 	case strings.Contains(normalized, "from messages"):
@@ -272,6 +282,10 @@ func TestGetAnalyticsToolsAggregatesToolCallsInSQL(t *testing.T) {
 	require.NotEmpty(t, resp.ByCategory)
 	assert.Equal(t, "Read", resp.ByCategory[0].Category)
 	assert.Equal(t, 3, resp.ByCategory[0].Count)
+	require.NotEmpty(t, resp.ByTool)
+	assert.Equal(t, "Read", resp.ByTool[0].ToolName)
+	assert.Equal(t, 3, resp.ByTool[0].CallCount)
+	assert.Equal(t, 2, resp.ByTool[0].SessionCount)
 }
 
 func TestGetAnalyticsSkillsAggregatesToolCallsInSQL(t *testing.T) {

--- a/internal/postgres/usage.go
+++ b/internal/postgres/usage.go
@@ -997,6 +997,58 @@ func pgSessionRowCost(
 	return cost, true, true
 }
 
+func pgSessionUsageBreakdownEntry(
+	r pgUsageScanRow,
+	ordinal int,
+	cost float64,
+	priced bool,
+) db.SessionUsageBreakdownEntry {
+	var inTok, outTok, crTok, rdTok int
+	if r.usageSource == "message" {
+		usage := gjson.Parse(r.tokenJSON)
+		inTok = pgTokenJSONCount(usage, "input_tokens")
+		outTok = pgTokenJSONCount(usage, "output_tokens")
+		crTok = pgTokenJSONCount(usage, "cache_creation_input_tokens")
+		rdTok = pgTokenJSONCount(usage, "cache_read_input_tokens")
+	} else {
+		inTok, outTok, crTok, rdTok = pgUsageEventRowTokens(
+			r.usageSource,
+			r.inputTokens, r.outputTokens,
+			r.cacheCreationInputTokens, r.cacheReadInputTokens)
+	}
+	entry := db.SessionUsageBreakdownEntry{
+		Ordinal:                  ordinal,
+		Source:                   r.usageSource,
+		Label:                    pgSessionUsageBreakdownLabel(r),
+		Timestamp:                startedAtString(r.ts),
+		Model:                    r.model,
+		InputTokens:              inTok,
+		OutputTokens:             outTok,
+		CacheCreationInputTokens: crTok,
+		CacheReadInputTokens:     rdTok,
+		CostUSD:                  cost,
+		HasCost:                  priced,
+	}
+	if r.messageOrdinal.Valid {
+		messageOrdinal := int(r.messageOrdinal.Int64)
+		entry.MessageOrdinal = &messageOrdinal
+	}
+	return entry
+}
+
+func pgSessionUsageBreakdownLabel(r pgUsageScanRow) string {
+	if r.messageOrdinal.Valid {
+		if r.usageSource == "message" {
+			return fmt.Sprintf("Prompt %d", r.messageOrdinal.Int64+1)
+		}
+		return fmt.Sprintf("Step %d", r.messageOrdinal.Int64+1)
+	}
+	if r.usageSource != "" {
+		return r.usageSource
+	}
+	return "usage"
+}
+
 func usageDate(ts sql.NullTime, loc *time.Location) string {
 	if !ts.Valid {
 		return ""
@@ -1085,7 +1137,9 @@ func (s *Store) GetSessionUsage(
 	pb := &paramBuilder{}
 	query := pgUsageRowSelect() + " AND u.session_id = " +
 		pb.add(sessionID) + ` ORDER BY u.ts ASC, u.session_id ASC,
-		COALESCE(u.message_ordinal, -1) ASC`
+		COALESCE(u.message_ordinal, -1) ASC,
+		u.usage_source ASC,
+		COALESCE(u.usage_dedup_key, '') ASC`
 	rows, err := s.pg.QueryContext(ctx, query, pb.args...)
 	if err != nil {
 		return nil, fmt.Errorf("querying pg session usage: %w", err)
@@ -1097,6 +1151,7 @@ func (s *Store) GetSessionUsage(
 	allPriced := true
 	modelsSet := make(map[string]struct{})
 	unpricedSet := make(map[string]struct{})
+	breakdown := make([]db.SessionUsageBreakdownEntry, 0)
 
 	seen := make(map[pgUsageDedupToken]struct{})
 
@@ -1128,6 +1183,8 @@ func (s *Store) GetSessionUsage(
 			allPriced = false
 			unpricedSet[r.model] = struct{}{}
 		}
+		breakdown = append(breakdown, pgSessionUsageBreakdownEntry(
+			r, len(breakdown)+1, c, priced))
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterating pg session usage rows: %w", err)
@@ -1141,8 +1198,9 @@ func (s *Store) GetSessionUsage(
 		PeakContextTokens: sess.PeakContextTokens,
 		HasTokenData: sess.HasTotalOutputTokens ||
 			sess.HasPeakContextTokens,
-		Models:  sortedStringSetKeys(modelsSet),
-		HasCost: contributing && allPriced,
+		Models:    sortedStringSetKeys(modelsSet),
+		HasCost:   contributing && allPriced,
+		Breakdown: breakdown,
 	}
 	if out.HasCost {
 		out.CostUSD = cost

--- a/internal/postgres/usage.go
+++ b/internal/postgres/usage.go
@@ -1116,9 +1116,11 @@ WHERE id IN (` + strings.Join(placeholders, ",") + `)`
 }
 
 // GetSessionUsage returns one session's token totals and cost
-// estimate from the PostgreSQL session store.
+// estimate from the PostgreSQL session store. BreakdownCount is
+// always populated; per-row Breakdown entries are built only when
+// includeBreakdown is true.
 func (s *Store) GetSessionUsage(
-	ctx context.Context, sessionID string,
+	ctx context.Context, sessionID string, includeBreakdown bool,
 ) (*db.SessionUsage, error) {
 	sess, err := s.GetSession(ctx, sessionID)
 	if err != nil {
@@ -1152,6 +1154,7 @@ func (s *Store) GetSessionUsage(
 	modelsSet := make(map[string]struct{})
 	unpricedSet := make(map[string]struct{})
 	breakdown := make([]db.SessionUsageBreakdownEntry, 0)
+	breakdownCount := 0
 
 	seen := make(map[pgUsageDedupToken]struct{})
 
@@ -1183,8 +1186,11 @@ func (s *Store) GetSessionUsage(
 			allPriced = false
 			unpricedSet[r.model] = struct{}{}
 		}
-		breakdown = append(breakdown, pgSessionUsageBreakdownEntry(
-			r, len(breakdown)+1, c, priced))
+		breakdownCount++
+		if includeBreakdown {
+			breakdown = append(breakdown, pgSessionUsageBreakdownEntry(
+				r, breakdownCount, c, priced))
+		}
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterating pg session usage rows: %w", err)
@@ -1198,9 +1204,10 @@ func (s *Store) GetSessionUsage(
 		PeakContextTokens: sess.PeakContextTokens,
 		HasTokenData: sess.HasTotalOutputTokens ||
 			sess.HasPeakContextTokens,
-		Models:    sortedStringSetKeys(modelsSet),
-		HasCost:   contributing && allPriced,
-		Breakdown: breakdown,
+		Models:         sortedStringSetKeys(modelsSet),
+		HasCost:        contributing && allPriced,
+		BreakdownCount: breakdownCount,
+		Breakdown:      breakdown,
 	}
 	if out.HasCost {
 		out.CostUSD = cost

--- a/internal/postgres/usage_pgtest_test.go
+++ b/internal/postgres/usage_pgtest_test.go
@@ -230,6 +230,21 @@ func TestStoreGetSessionUsagePricedModel(t *testing.T) {
 	assert.InDelta(t, 0.01134, got.CostUSD, 1e-9)
 	assert.Equal(t, []string{"gpt-5.1"}, got.Models)
 	assert.Empty(t, got.UnpricedModels)
+	require.Len(t, got.Breakdown, 1, "Breakdown")
+	entry := got.Breakdown[0]
+	assert.Equal(t, 1, entry.Ordinal)
+	require.NotNil(t, entry.MessageOrdinal)
+	assert.Equal(t, 1, *entry.MessageOrdinal)
+	assert.Equal(t, "message", entry.Source)
+	assert.Equal(t, "Prompt 2", entry.Label)
+	assert.Equal(t, "2026-03-12T10:01:00Z", entry.Timestamp)
+	assert.Equal(t, "gpt-5.1", entry.Model)
+	assert.Equal(t, 1000, entry.InputTokens)
+	assert.Equal(t, 500, entry.OutputTokens)
+	assert.Equal(t, 200, entry.CacheCreationInputTokens)
+	assert.Equal(t, 300, entry.CacheReadInputTokens)
+	assert.True(t, entry.HasCost)
+	assert.InDelta(t, 0.01134, entry.CostUSD, 1e-9)
 }
 
 func TestStoreGetSessionUsageDedupesSourceUUIDWhenClaudePairIncomplete(t *testing.T) {
@@ -272,6 +287,9 @@ func TestStoreGetSessionUsageDedupesSourceUUIDWhenClaudePairIncomplete(t *testin
 	assert.True(t, got.HasCost)
 	assert.InDelta(t, 0.0175, got.CostUSD, 1e-9)
 	assert.Equal(t, []string{"claude-opus-4-6"}, got.Models)
+	require.Len(t, got.Breakdown, 1, "Breakdown")
+	require.NotNil(t, got.Breakdown[0].MessageOrdinal)
+	assert.Equal(t, 0, *got.Breakdown[0].MessageOrdinal)
 }
 
 func TestStoreGetSessionUsageNoTokenRowsKeepsMetadata(t *testing.T) {
@@ -299,6 +317,7 @@ func TestStoreGetSessionUsageNoTokenRowsKeepsMetadata(t *testing.T) {
 	assert.Zero(t, got.CostUSD)
 	assert.Empty(t, got.Models)
 	assert.Empty(t, got.UnpricedModels)
+	assert.Empty(t, got.Breakdown)
 }
 
 func TestStoreGetSessionUsageNotFound(t *testing.T) {
@@ -805,10 +824,10 @@ func TestPostgresUsagePreservesSessionSummaryUsageEventTokens(t *testing.T) {
 	require.NoError(t, err, "insert session")
 	_, err = store.DB().ExecContext(ctx, `
 		INSERT INTO usage_events (
-			session_id, source, model, input_tokens, output_tokens,
-			occurred_at, dedup_key
+			session_id, message_ordinal, source, model, input_tokens,
+			output_tokens, occurred_at, dedup_key
 		) VALUES (
-			'hermes-summary', 'session', 'gpt-5.4', $1, $2,
+			'hermes-summary', 0, 'session', 'gpt-5.4', $1, $2,
 			'2026-05-14T10:05:00Z'::timestamptz, 'session:hermes-summary'
 		)`, rawInput, rawOutput)
 	require.NoError(t, err, "insert usage event")
@@ -831,6 +850,16 @@ func TestPostgresUsagePreservesSessionSummaryUsageEventTokens(t *testing.T) {
 	require.True(t, usage.HasCost, "HasCost")
 	wantCost := (float64(rawInput)*1.0 + float64(rawOutput)*2.0) / 1_000_000
 	assert.InDelta(t, wantCost, usage.CostUSD, 1e-9, "session cost")
+	require.Len(t, usage.Breakdown, 1, "Breakdown")
+	entry := usage.Breakdown[0]
+	assert.Equal(t, "session", entry.Source)
+	assert.Equal(t, "Step 1", entry.Label)
+	require.NotNil(t, entry.MessageOrdinal)
+	assert.Equal(t, 0, *entry.MessageOrdinal)
+	assert.Equal(t, rawInput, entry.InputTokens)
+	assert.Equal(t, rawOutput, entry.OutputTokens)
+	assert.True(t, entry.HasCost)
+	assert.InDelta(t, wantCost, entry.CostUSD, 1e-9, "breakdown cost")
 }
 
 func TestPostgresUsageCostsMessageReasoningTokens(t *testing.T) {

--- a/internal/postgres/usage_pgtest_test.go
+++ b/internal/postgres/usage_pgtest_test.go
@@ -217,7 +217,7 @@ func TestStoreGetSessionUsagePricedModel(t *testing.T) {
 		)`)
 	require.NoError(t, err, "insert message")
 
-	got, err := store.GetSessionUsage(ctx, "codex:usage-priced")
+	got, err := store.GetSessionUsage(ctx, "codex:usage-priced", true)
 	require.NoError(t, err, "GetSessionUsage")
 	require.NotNil(t, got, "GetSessionUsage result")
 	assert.Equal(t, "codex:usage-priced", got.SessionID)
@@ -281,7 +281,7 @@ func TestStoreGetSessionUsageDedupesSourceUUIDWhenClaudePairIncomplete(t *testin
 			 'msg-1', '', 'source-1')`)
 	require.NoError(t, err, "insert messages")
 
-	got, err := store.GetSessionUsage(ctx, "claude:usage-source")
+	got, err := store.GetSessionUsage(ctx, "claude:usage-source", true)
 	require.NoError(t, err, "GetSessionUsage")
 	require.NotNil(t, got, "GetSessionUsage result")
 	assert.True(t, got.HasCost)
@@ -306,7 +306,7 @@ func TestStoreGetSessionUsageNoTokenRowsKeepsMetadata(t *testing.T) {
 		)`)
 	require.NoError(t, err, "insert session")
 
-	got, err := store.GetSessionUsage(ctx, "codex:usage-empty")
+	got, err := store.GetSessionUsage(ctx, "codex:usage-empty", true)
 	require.NoError(t, err, "GetSessionUsage")
 	require.NotNil(t, got, "GetSessionUsage result")
 	assert.Equal(t, "codex:usage-empty", got.SessionID)
@@ -323,7 +323,7 @@ func TestStoreGetSessionUsageNoTokenRowsKeepsMetadata(t *testing.T) {
 func TestStoreGetSessionUsageNotFound(t *testing.T) {
 	_, store := prepareUsageSchema(t, "agentsview_session_usage_missing_test")
 
-	got, err := store.GetSessionUsage(context.Background(), "missing")
+	got, err := store.GetSessionUsage(context.Background(), "missing", true)
 	require.NoError(t, err, "GetSessionUsage")
 	assert.Nil(t, got, "GetSessionUsage")
 }
@@ -842,7 +842,7 @@ func TestPostgresUsagePreservesSessionSummaryUsageEventTokens(t *testing.T) {
 	assert.Equal(t, rawInput, daily.Totals.InputTokens, "daily input")
 	assert.Equal(t, rawOutput, daily.Totals.OutputTokens, "daily output")
 
-	usage, err := store.GetSessionUsage(ctx, "hermes-summary")
+	usage, err := store.GetSessionUsage(ctx, "hermes-summary", true)
 	require.NoError(t, err, "GetSessionUsage")
 	require.NotNil(t, usage, "session usage")
 	assert.Equal(t, rawOutput, usage.TotalOutputTokens)
@@ -904,7 +904,7 @@ func TestPostgresUsageCostsMessageReasoningTokens(t *testing.T) {
 	assert.Zero(t, daily.Totals.OutputTokens)
 	assert.InDelta(t, 4.001, daily.Totals.TotalCost, 1e-12)
 
-	usage, err := store.GetSessionUsage(ctx, "pg-message-reasoning")
+	usage, err := store.GetSessionUsage(ctx, "pg-message-reasoning", true)
 	require.NoError(t, err, "GetSessionUsage")
 	require.NotNil(t, usage)
 	assert.True(t, usage.HasCost)
@@ -1068,7 +1068,7 @@ func TestStoreGetSessionUsage_CopilotAICreditsComputed(t *testing.T) {
 		)`)
 	require.NoError(t, err, "insert usage event")
 
-	u, err := store.GetSessionUsage(ctx, "copilot:s1")
+	u, err := store.GetSessionUsage(ctx, "copilot:s1", true)
 	require.NoError(t, err, "GetSessionUsage")
 	require.NotNil(t, u, "usage is nil")
 	assert.True(t, u.HasCost, "HasCost")
@@ -1098,7 +1098,7 @@ func TestStoreGetSessionUsage_CopilotNoAICreditsUnpriced(t *testing.T) {
 		)`)
 	require.NoError(t, err, "insert usage event")
 
-	u, err := store.GetSessionUsage(ctx, "copilot:s2")
+	u, err := store.GetSessionUsage(ctx, "copilot:s2", true)
 	require.NoError(t, err, "GetSessionUsage")
 	require.NotNil(t, u, "usage is nil")
 	assert.False(t, u.HasCost, "HasCost should be false")

--- a/internal/server/analytics_test.go
+++ b/internal/server/analytics_test.go
@@ -892,6 +892,10 @@ func TestAnalyticsTools(t *testing.T) {
 		resp := decode[db.ToolsAnalyticsResponse](t, w)
 		assert.Equal(t, stats.TotalToolCalls, resp.TotalCalls)
 		assert.NotEmpty(t, resp.ByCategory)
+		require.NotEmpty(t, resp.ByTool)
+		assert.NotEmpty(t, resp.ByTool[0].ToolName)
+		assert.NotZero(t, resp.ByTool[0].CallCount)
+		assert.NotZero(t, resp.ByTool[0].SessionCount)
 		assert.Len(t, resp.ByAgent, stats.Agents)
 	})
 

--- a/internal/server/huma_routes_sessions.go
+++ b/internal/server/huma_routes_sessions.go
@@ -368,8 +368,14 @@ type sessionUsageResponse struct {
 	AICredits         float64                         `json:"ai_credits,omitempty"`
 	Models            []string                        `json:"models"`
 	UnpricedModels    []string                        `json:"unpriced_models"`
+	BreakdownCount    int                             `json:"breakdown_count"`
 	Breakdown         []sessionUsageBreakdownResponse `json:"breakdown"`
 	ServerRunning     bool                            `json:"server_running"`
+}
+
+type sessionUsageInput struct {
+	ID        string `path:"id" required:"true" doc:"Session ID"`
+	Breakdown bool   `query:"breakdown" doc:"Include per-step breakdown rows"`
 }
 
 type sessionUsageBreakdownResponse struct {
@@ -439,6 +445,7 @@ func newSessionUsageHumaResponse(usage *db.SessionUsage) sessionUsageResponse {
 		AICredits:         usage.AICredits,
 		Models:            usage.Models,
 		UnpricedModels:    unpricedModels,
+		BreakdownCount:    usage.BreakdownCount,
 		Breakdown:         breakdown,
 		ServerRunning:     true,
 	}
@@ -446,9 +453,9 @@ func newSessionUsageHumaResponse(usage *db.SessionUsage) sessionUsageResponse {
 
 func (s *Server) humaSessionUsage(
 	ctx context.Context,
-	in *idPathInput,
+	in *sessionUsageInput,
 ) (*jsonOutput[sessionUsageResponse], error) {
-	usage, err := s.db.GetSessionUsage(ctx, in.ID)
+	usage, err := s.db.GetSessionUsage(ctx, in.ID, in.Breakdown)
 	if err != nil {
 		if handled := handleHumaContextError(err); handled != nil {
 			return nil, handled

--- a/internal/server/huma_routes_sessions.go
+++ b/internal/server/huma_routes_sessions.go
@@ -357,18 +357,34 @@ func (s *Server) humaSessionTiming(
 }
 
 type sessionUsageResponse struct {
-	SessionID         string   `json:"session_id"`
-	Agent             string   `json:"agent"`
-	Project           string   `json:"project"`
-	TotalOutputTokens int      `json:"total_output_tokens"`
-	PeakContextTokens int      `json:"peak_context_tokens"`
-	HasTokenData      bool     `json:"has_token_data"`
-	CostUSD           float64  `json:"cost_usd"`
-	HasCost           bool     `json:"has_cost"`
-	AICredits         float64  `json:"ai_credits,omitempty"`
-	Models            []string `json:"models"`
-	UnpricedModels    []string `json:"unpriced_models"`
-	ServerRunning     bool     `json:"server_running"`
+	SessionID         string                          `json:"session_id"`
+	Agent             string                          `json:"agent"`
+	Project           string                          `json:"project"`
+	TotalOutputTokens int                             `json:"total_output_tokens"`
+	PeakContextTokens int                             `json:"peak_context_tokens"`
+	HasTokenData      bool                            `json:"has_token_data"`
+	CostUSD           float64                         `json:"cost_usd"`
+	HasCost           bool                            `json:"has_cost"`
+	AICredits         float64                         `json:"ai_credits,omitempty"`
+	Models            []string                        `json:"models"`
+	UnpricedModels    []string                        `json:"unpriced_models"`
+	Breakdown         []sessionUsageBreakdownResponse `json:"breakdown"`
+	ServerRunning     bool                            `json:"server_running"`
+}
+
+type sessionUsageBreakdownResponse struct {
+	Ordinal                  int     `json:"ordinal"`
+	MessageOrdinal           *int    `json:"message_ordinal,omitempty"`
+	Source                   string  `json:"source"`
+	Label                    string  `json:"label"`
+	Timestamp                string  `json:"timestamp"`
+	Model                    string  `json:"model"`
+	InputTokens              int     `json:"input_tokens"`
+	OutputTokens             int     `json:"output_tokens"`
+	CacheCreationInputTokens int     `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int     `json:"cache_read_input_tokens"`
+	CostUSD                  float64 `json:"cost_usd"`
+	HasCost                  bool    `json:"has_cost"`
 }
 
 type sessionUsageErrorBody struct {
@@ -394,6 +410,23 @@ func newSessionUsageHumaResponse(usage *db.SessionUsage) sessionUsageResponse {
 	if unpricedModels == nil {
 		unpricedModels = []string{}
 	}
+	breakdown := make([]sessionUsageBreakdownResponse, 0, len(usage.Breakdown))
+	for _, entry := range usage.Breakdown {
+		breakdown = append(breakdown, sessionUsageBreakdownResponse{
+			Ordinal:                  entry.Ordinal,
+			MessageOrdinal:           entry.MessageOrdinal,
+			Source:                   entry.Source,
+			Label:                    entry.Label,
+			Timestamp:                entry.Timestamp,
+			Model:                    entry.Model,
+			InputTokens:              entry.InputTokens,
+			OutputTokens:             entry.OutputTokens,
+			CacheCreationInputTokens: entry.CacheCreationInputTokens,
+			CacheReadInputTokens:     entry.CacheReadInputTokens,
+			CostUSD:                  entry.CostUSD,
+			HasCost:                  entry.HasCost,
+		})
+	}
 	return sessionUsageResponse{
 		SessionID:         usage.SessionID,
 		Agent:             usage.Agent,
@@ -406,6 +439,7 @@ func newSessionUsageHumaResponse(usage *db.SessionUsage) sessionUsageResponse {
 		AICredits:         usage.AICredits,
 		Models:            usage.Models,
 		UnpricedModels:    unpricedModels,
+		Breakdown:         breakdown,
 		ServerRunning:     true,
 	}
 }

--- a/internal/server/insights_test.go
+++ b/internal/server/insights_test.go
@@ -1526,8 +1526,15 @@ func TestGenerateInsight_LogDropSummaryAndCompletion(t *testing.T) {
 			Agent:   "claude",
 		}, nil
 	}
+	// The 1ms-per-write client drains the buffered log backlog far
+	// slower on Windows, where time.Sleep rounds up to ~15ms timer
+	// granularity. This test protects drop reporting plus completion,
+	// not drain-deadline behavior (covered by the LogDrainTimeout
+	// tests), so give the drain a generous ceiling to keep the done
+	// event deterministic across platforms.
 	te := setupWithServerOpts(t, []server.Option{
 		server.WithGenerateStreamFunc(stubGen),
+		server.WithInsightLogDrainTimeouts(30*time.Second, time.Second),
 	})
 
 	req := httptest.NewRequest(
@@ -1550,7 +1557,7 @@ func TestGenerateInsight_LogDropSummaryAndCompletion(t *testing.T) {
 
 	select {
 	case <-done:
-	case <-time.After(8 * time.Second):
+	case <-time.After(40 * time.Second):
 		require.Fail(t, "timed out waiting for generate handler")
 	}
 

--- a/internal/server/session_usage_test.go
+++ b/internal/server/session_usage_test.go
@@ -38,6 +38,7 @@ func TestHandleSessionUsage_PricedSession(t *testing.T) {
 			)
 		})
 
+	// Without ?breakdown=true the response carries only the count.
 	w := te.get(t, "/api/v1/sessions/codex:usage-priced/usage")
 	assertStatus(t, w, http.StatusOK)
 
@@ -54,24 +55,34 @@ func TestHandleSessionUsage_PricedSession(t *testing.T) {
 		"has_cost":            true,
 		"models":              []any{"gpt-5.1"},
 		"unpriced_models":     []any{},
-		"breakdown": []any{
-			map[string]any{
-				"ordinal":                     float64(1),
-				"message_ordinal":             float64(1),
-				"source":                      "message",
-				"label":                       "Prompt 2",
-				"timestamp":                   tsSeed,
-				"model":                       "gpt-5.1",
-				"input_tokens":                float64(1000),
-				"output_tokens":               float64(500),
-				"cache_creation_input_tokens": float64(200),
-				"cache_read_input_tokens":     float64(300),
-				"cost_usd":                    0.01134,
-				"has_cost":                    true,
-			},
-		},
-		"server_running": true,
+		"breakdown_count":     float64(1),
+		"breakdown":           []any{},
+		"server_running":      true,
 	}, got)
+
+	w = te.get(t,
+		"/api/v1/sessions/codex:usage-priced/usage?breakdown=true")
+	assertStatus(t, w, http.StatusOK)
+
+	got = map[string]any{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, float64(1), got["breakdown_count"], "breakdown_count")
+	assert.Equal(t, []any{
+		map[string]any{
+			"ordinal":                     float64(1),
+			"message_ordinal":             float64(1),
+			"source":                      "message",
+			"label":                       "Prompt 2",
+			"timestamp":                   tsSeed,
+			"model":                       "gpt-5.1",
+			"input_tokens":                float64(1000),
+			"output_tokens":               float64(500),
+			"cache_creation_input_tokens": float64(200),
+			"cache_read_input_tokens":     float64(300),
+			"cost_usd":                    0.01134,
+			"has_cost":                    true,
+		},
+	}, got["breakdown"], "breakdown rows with ?breakdown=true")
 }
 
 func TestHandleSessionUsage_NoTokenOrCostData(t *testing.T) {
@@ -97,6 +108,7 @@ func TestHandleSessionUsage_NoTokenOrCostData(t *testing.T) {
 		"has_cost":            false,
 		"models":              []any{},
 		"unpriced_models":     []any{},
+		"breakdown_count":     float64(0),
 		"breakdown":           []any{},
 		"server_running":      true,
 	}, got)
@@ -146,7 +158,7 @@ func TestHandleSessionUsage_BreakdownOrderingAndDedup(t *testing.T) {
 	), "ReplaceSessionUsageEvents")
 
 	usage, err := te.db.GetSessionUsage(context.Background(),
-		"codex:usage-breakdown")
+		"codex:usage-breakdown", true)
 	require.NoError(t, err, "GetSessionUsage")
 	require.NotNil(t, usage, "usage is nil")
 	require.Len(t, usage.Breakdown, 2)

--- a/internal/server/session_usage_test.go
+++ b/internal/server/session_usage_test.go
@@ -1,6 +1,7 @@
 package server_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -53,7 +54,23 @@ func TestHandleSessionUsage_PricedSession(t *testing.T) {
 		"has_cost":            true,
 		"models":              []any{"gpt-5.1"},
 		"unpriced_models":     []any{},
-		"server_running":      true,
+		"breakdown": []any{
+			map[string]any{
+				"ordinal":                     float64(1),
+				"message_ordinal":             float64(1),
+				"source":                      "message",
+				"label":                       "Prompt 2",
+				"timestamp":                   tsSeed,
+				"model":                       "gpt-5.1",
+				"input_tokens":                float64(1000),
+				"output_tokens":               float64(500),
+				"cache_creation_input_tokens": float64(200),
+				"cache_read_input_tokens":     float64(300),
+				"cost_usd":                    0.01134,
+				"has_cost":                    true,
+			},
+		},
+		"server_running": true,
 	}, got)
 }
 
@@ -80,8 +97,74 @@ func TestHandleSessionUsage_NoTokenOrCostData(t *testing.T) {
 		"has_cost":            false,
 		"models":              []any{},
 		"unpriced_models":     []any{},
+		"breakdown":           []any{},
 		"server_running":      true,
 	}, got)
+}
+
+func TestHandleSessionUsage_BreakdownOrderingAndDedup(t *testing.T) {
+	te := setup(t)
+	seedSessionUsagePricing(t, te.db)
+	te.seedSession(t, "codex:usage-breakdown", "my-project", 3,
+		func(s *db.Session) {
+			s.Agent = "codex"
+			s.TotalOutputTokens = 1500
+			s.PeakContextTokens = 4000
+			s.HasTotalOutputTokens = true
+			s.HasPeakContextTokens = true
+		})
+	te.seedMessages(t, "codex:usage-breakdown", 3,
+		func(i int, m *db.Message) {
+			switch i {
+			case 0, 1:
+				m.Role = "assistant"
+				m.Model = "gpt-5.1"
+				m.ClaudeMessageID = "msg-dup"
+				m.ClaudeRequestID = "req-dup"
+				m.TokenUsage = json.RawMessage(
+					`{"input_tokens":1000,"output_tokens":500,` +
+						`"cache_creation_input_tokens":200,` +
+						`"cache_read_input_tokens":300}`,
+				)
+			}
+		})
+	ordinal := 1
+	require.NoError(t, te.db.ReplaceSessionUsageEvents(
+		"codex:usage-breakdown",
+		[]db.UsageEvent{{
+			SessionID:                "codex:usage-breakdown",
+			MessageOrdinal:           &ordinal,
+			Source:                   "step",
+			Model:                    "gpt-5.1",
+			InputTokens:              250,
+			OutputTokens:             125,
+			CacheCreationInputTokens: 50,
+			CacheReadInputTokens:     25,
+			OccurredAt:               "2026-05-20T10:40:00Z",
+			DedupKey:                 "step:1",
+		}},
+	), "ReplaceSessionUsageEvents")
+
+	usage, err := te.db.GetSessionUsage(context.Background(),
+		"codex:usage-breakdown")
+	require.NoError(t, err, "GetSessionUsage")
+	require.NotNil(t, usage, "usage is nil")
+	require.Len(t, usage.Breakdown, 2)
+	assert.Equal(t, 1, usage.Breakdown[0].Ordinal)
+	assert.Equal(t, "Prompt 1", usage.Breakdown[0].Label)
+	assert.Equal(t, "message", usage.Breakdown[0].Source)
+	assert.Equal(t, 1000, usage.Breakdown[0].InputTokens)
+	assert.Equal(t, 500, usage.Breakdown[0].OutputTokens)
+	assert.Equal(t, 200, usage.Breakdown[0].CacheCreationInputTokens)
+	assert.Equal(t, 300, usage.Breakdown[0].CacheReadInputTokens)
+	assert.Equal(t, 2, usage.Breakdown[1].Ordinal)
+	assert.Equal(t, "Step 2", usage.Breakdown[1].Label)
+	assert.Equal(t, "step", usage.Breakdown[1].Source)
+	assert.Equal(t, 250, usage.Breakdown[1].InputTokens)
+	assert.Equal(t, 125, usage.Breakdown[1].OutputTokens)
+	assert.Equal(t, 50, usage.Breakdown[1].CacheCreationInputTokens)
+	assert.Equal(t, 25, usage.Breakdown[1].CacheReadInputTokens)
+	assert.InDelta(t, 0.01416, usage.CostUSD, 1e-9)
 }
 
 func TestHandleSessionUsage_NotFound(t *testing.T) {


### PR DESCRIPTION
Session usage currently stops at aggregate token and cost totals. That is useful in the breadcrumb, but it does not show which prompts or steps consumed the context and token budget inside a session.

This extends the existing session usage path instead of adding a parallel endpoint. `GetSessionUsage` keeps computing the current totals, and it also returns ordered breakdown rows from the same deduplicated usage stream. The Huma response maps those rows into `/api/v1/sessions/{id}/usage`, the generated TypeScript client is refreshed, and the session-detail UI renders the breakdown while preserving the existing totals.

This is stacked on the tool usage analysis branch because both changes regenerate the committed frontend client. The generated output in this branch includes that API surface plus the new session usage breakdown field.

Depends on #988.

Closes #982
