### PR TITLE
perf: reduce DuckDB push write amplification

### DIFF
--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -1653,6 +1653,68 @@ func (db *DB) ToolCallFingerprint(sessionID string) (string, error) {
 	return b.String(), rows.Err()
 }
 
+// ToolResultEventFingerprintWithTimestampNormalizer returns an exact ordered
+// fingerprint of persisted tool-result event fields. The optional timestamp
+// normalizer lets push backends compare SQLite text timestamps with target
+// stores that round or reformat timestamp values on insert.
+func (db *DB) ToolResultEventFingerprintWithTimestampNormalizer(
+	sessionID string,
+	normalizeTimestamp func(string) string,
+) (string, error) {
+	rows, err := db.getReader().Query(
+		`SELECT tool_call_message_ordinal, call_index, event_index,
+			COALESCE(tool_use_id, ''), COALESCE(agent_id, ''),
+			COALESCE(subagent_session_id, ''), source, status,
+			content, content_length, COALESCE(timestamp, '')
+		 FROM tool_result_events
+		 WHERE session_id = ?
+		 ORDER BY tool_call_message_ordinal ASC, call_index ASC, event_index ASC`,
+		sessionID,
+	)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+
+	var b strings.Builder
+	for rows.Next() {
+		var messageOrdinal, callIndex, eventIndex, contentLength int
+		var toolUseID, agentID, subagentSessionID string
+		var source, status, content, timestamp string
+		if err := rows.Scan(
+			&messageOrdinal, &callIndex, &eventIndex,
+			&toolUseID, &agentID, &subagentSessionID,
+			&source, &status, &content, &contentLength, &timestamp,
+		); err != nil {
+			return "", err
+		}
+		if normalizeTimestamp != nil {
+			timestamp = normalizeTimestamp(timestamp)
+		}
+		toolUseID = SanitizeUTF8(toolUseID)
+		agentID = SanitizeUTF8(agentID)
+		subagentSessionID = SanitizeUTF8(subagentSessionID)
+		source = SanitizeUTF8(source)
+		status = SanitizeUTF8(status)
+		content = SanitizeUTF8(content)
+		contentSum := sha256.Sum256([]byte(content))
+		fmt.Fprintf(
+			&b,
+			"%d|%d|%d|%d:%s|%d:%s|%d:%s|%d:%s|%d:%s|%d|%x|%d:%s;",
+			messageOrdinal, callIndex, eventIndex,
+			len(toolUseID), toolUseID,
+			len(agentID), agentID,
+			len(subagentSessionID), subagentSessionID,
+			len(source), source,
+			len(status), status,
+			contentLength,
+			contentSum,
+			len(timestamp), timestamp,
+		)
+	}
+	return b.String(), rows.Err()
+}
+
 // GetMessageByOrdinal returns a single message by session ID and ordinal.
 func (db *DB) GetMessageByOrdinal(
 	sessionID string, ordinal int,

--- a/internal/duckdb/checkpoint.go
+++ b/internal/duckdb/checkpoint.go
@@ -1,0 +1,56 @@
+package duckdb
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+const duckCheckpointMinFreeBytes int64 = 16 << 20
+
+type duckDBMaintenance interface {
+	checkpointAfterPush(context.Context, *sql.DB) error
+}
+
+type duckDBCheckpointMaintenance struct{}
+
+type duckDBSize struct {
+	blockSize  int64
+	freeBlocks int64
+}
+
+func (duckDBCheckpointMaintenance) checkpointAfterPush(
+	ctx context.Context, duck *sql.DB,
+) error {
+	size, err := readDuckDBSize(ctx, duck)
+	if err != nil {
+		return err
+	}
+	if !shouldCheckpointDuckDB(size) {
+		return nil
+	}
+	if _, err := duck.ExecContext(ctx, `CHECKPOINT`); err != nil {
+		return fmt.Errorf("checkpointing duckdb mirror: %w", err)
+	}
+	return nil
+}
+
+func readDuckDBSize(ctx context.Context, duck *sql.DB) (duckDBSize, error) {
+	var size duckDBSize
+	if err := duck.QueryRowContext(ctx, `
+		SELECT block_size, free_blocks
+		FROM pragma_database_size()
+		WHERE database_name = current_database()
+	`).Scan(&size.blockSize, &size.freeBlocks); err != nil {
+		return duckDBSize{}, fmt.Errorf("reading duckdb database size: %w", err)
+	}
+	return size, nil
+}
+
+func shouldCheckpointDuckDB(size duckDBSize) bool {
+	if size.blockSize <= 0 || size.freeBlocks <= 0 {
+		return false
+	}
+	blocksNeeded := (duckCheckpointMinFreeBytes + size.blockSize - 1) / size.blockSize
+	return size.freeBlocks >= blocksNeeded
+}

--- a/internal/duckdb/connect.go
+++ b/internal/duckdb/connect.go
@@ -235,6 +235,7 @@ func NewFromConfig(
 		excludeProjects: opts.ExcludeProjects,
 		connectionKind:  connectionKind,
 		quack:           quack,
+		maintenance:     duckDBCheckpointMaintenance{},
 	}, nil
 }
 

--- a/internal/duckdb/push.go
+++ b/internal/duckdb/push.go
@@ -316,42 +316,45 @@ func (s *Sync) replaceSessionDependents(
 func (s *Sync) deleteHardDeletedMirrorSessions(
 	ctx context.Context, tx *sql.Tx, localSessions []db.Session,
 	machine string, projects, excludeProjects []string,
-) ([]string, error) {
+) ([]string, map[string]bool, error) {
 	localIDs := make(map[string]bool, len(localSessions))
 	for _, sess := range localSessions {
 		localIDs[sess.ID] = true
 	}
+	mirrorIDs := make(map[string]bool)
 	rows, err := tx.QueryContext(ctx,
 		`SELECT id, project FROM sessions WHERE machine = ?`,
 		machine,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("listing duckdb sessions for deletion reconciliation: %w", err)
+		return nil, nil, fmt.Errorf("listing duckdb sessions for deletion reconciliation: %w", err)
 	}
 	defer rows.Close()
 	var stale []string
 	for rows.Next() {
 		var id, project string
 		if err := rows.Scan(&id, &project); err != nil {
-			return nil, fmt.Errorf("scanning duckdb session for deletion reconciliation: %w", err)
+			return nil, nil, fmt.Errorf("scanning duckdb session for deletion reconciliation: %w", err)
 		}
+		mirrorIDs[id] = true
 		if !projectInSyncScope(project, projects, excludeProjects) {
 			continue
 		}
 		if !localIDs[id] {
 			stale = append(stale, id)
+			delete(mirrorIDs, id)
 		}
 	}
 	if err := rows.Err(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	sort.Strings(stale)
 	for _, id := range stale {
 		if err := s.deleteMirrorSession(ctx, tx, id); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
-	return stale, nil
+	return stale, mirrorIDs, nil
 }
 
 func (s *Sync) deleteMirrorSession(

--- a/internal/duckdb/push.go
+++ b/internal/duckdb/push.go
@@ -221,20 +221,66 @@ func (s *Sync) replaceStarredSessions(
 }
 
 func (s *Sync) pushSession(
-	ctx context.Context, exec duckMutationExecutor, sess db.Session,
+	ctx context.Context,
+	exec duckMutationExecutor,
+	target duckQueryer,
+	sess db.Session,
+	full bool,
 ) (int, error) {
 	if err := s.upsertSession(ctx, exec, sess); err != nil {
-		return 0, err
-	}
-	if err := s.replaceSessionDependents(ctx, exec, sess.ID); err != nil {
-		return 0, err
-	}
-	if err := s.replaceUsageEvents(ctx, exec, sess.ID); err != nil {
 		return 0, err
 	}
 	msgs, err := s.local.GetAllMessages(ctx, sess.ID)
 	if err != nil {
 		return 0, fmt.Errorf("reading local messages for %s: %w", sess.ID, err)
+	}
+
+	if !full {
+		action, err := s.duckMessagePushAction(ctx, target, sess.ID, msgs)
+		if err != nil {
+			return 0, err
+		}
+		switch action.kind {
+		case duckMessagePushSkip:
+			if err := s.replaceSessionSecretFindings(ctx, exec, sess.ID); err != nil {
+				return 0, err
+			}
+			return 0, nil
+		case duckMessagePushAppend:
+			suffix := messagesAfterDuckOrdinal(msgs, action.maxOrdinal)
+			if len(suffix) == 0 {
+				return 0, fmt.Errorf(
+					"duckdb append %s: no local suffix after ordinal %d",
+					sess.ID, action.maxOrdinal,
+				)
+			}
+			if err := s.replaceUsageEvents(ctx, exec, sess.ID); err != nil {
+				return 0, err
+			}
+			if err := insertMessages(ctx, exec, suffix); err != nil {
+				return 0, err
+			}
+			if err := insertToolCalls(ctx, exec, suffix); err != nil {
+				return 0, err
+			}
+			if err := insertToolResultEvents(ctx, exec, suffix); err != nil {
+				return 0, err
+			}
+			if err := s.replaceSessionSecretFindings(ctx, exec, sess.ID); err != nil {
+				return 0, err
+			}
+			return len(suffix), nil
+		case duckMessagePushReplace:
+		default:
+			return 0, fmt.Errorf("unknown duckdb message push action %d", action.kind)
+		}
+	}
+
+	if err := s.replaceSessionDependents(ctx, exec, sess.ID); err != nil {
+		return 0, err
+	}
+	if err := s.replaceUsageEvents(ctx, exec, sess.ID); err != nil {
+		return 0, err
 	}
 	if err := insertMessages(ctx, exec, msgs); err != nil {
 		return 0, err
@@ -1364,6 +1410,18 @@ func (s *Sync) replaceSecretFindings(
 		}
 	}
 	return nil
+}
+
+func (s *Sync) replaceSessionSecretFindings(
+	ctx context.Context, exec duckMutationExecutor, sessionID string,
+) error {
+	if err := s.execMutation(ctx, exec,
+		`DELETE FROM secret_findings WHERE session_id = ?`,
+		sessionID,
+	); err != nil {
+		return fmt.Errorf("clearing duckdb secret_findings for %s: %w", sessionID, err)
+	}
+	return s.replaceSecretFindings(ctx, exec, sessionID)
 }
 
 func (s *Sync) replacePinnedMessages(

--- a/internal/duckdb/push.go
+++ b/internal/duckdb/push.go
@@ -245,6 +245,9 @@ func (s *Sync) pushSession(
 			if err := s.replaceSessionSecretFindings(ctx, exec, sess.ID); err != nil {
 				return 0, err
 			}
+			if err := s.replaceSessionPinnedMessages(ctx, exec, sess.ID); err != nil {
+				return 0, err
+			}
 			return 0, nil
 		case duckMessagePushAppend:
 			suffix := messagesAfterDuckOrdinal(msgs, action.maxOrdinal)
@@ -267,6 +270,9 @@ func (s *Sync) pushSession(
 				return 0, err
 			}
 			if err := s.replaceSessionSecretFindings(ctx, exec, sess.ID); err != nil {
+				return 0, err
+			}
+			if err := s.replaceSessionPinnedMessages(ctx, exec, sess.ID); err != nil {
 				return 0, err
 			}
 			return len(suffix), nil
@@ -1427,6 +1433,18 @@ func (s *Sync) replaceSessionSecretFindings(
 	return s.replaceSecretFindings(ctx, exec, sessionID)
 }
 
+func (s *Sync) replaceSessionPinnedMessages(
+	ctx context.Context, exec duckMutationExecutor, sessionID string,
+) error {
+	if err := s.execMutation(ctx, exec,
+		`DELETE FROM pinned_messages WHERE session_id = ?`,
+		sessionID,
+	); err != nil {
+		return fmt.Errorf("clearing duckdb pinned_messages for %s: %w", sessionID, err)
+	}
+	return s.replacePinnedMessages(ctx, exec, sessionID)
+}
+
 func (s *Sync) replacePinnedMessages(
 	ctx context.Context, exec duckMutationExecutor, sessionID string,
 ) error {
@@ -1471,12 +1489,7 @@ func (s *Sync) replaceScopedPinnedMessages(
 	ctx context.Context, tx *sql.Tx, sessions []db.Session,
 ) error {
 	for _, sess := range sessions {
-		if err := s.execMutation(ctx, tx,
-			`DELETE FROM pinned_messages WHERE session_id = ?`, sess.ID,
-		); err != nil {
-			return fmt.Errorf("clearing duckdb pinned_messages for %s: %w", sess.ID, err)
-		}
-		if err := s.replacePinnedMessages(ctx, tx, sess.ID); err != nil {
+		if err := s.replaceSessionPinnedMessages(ctx, tx, sess.ID); err != nil {
 			return err
 		}
 	}

--- a/internal/duckdb/push_fingerprint.go
+++ b/internal/duckdb/push_fingerprint.go
@@ -31,6 +31,7 @@ type duckMessageFingerprint struct {
 	Min           int64
 	MinOrdinal    int
 	MaxOrdinal    int
+	MessageIDFP   string
 	ContentHashFP string
 	RoleTimeFP    string
 	FlagsFP       string
@@ -124,6 +125,7 @@ func duckMessageFingerprintsMatch(
 		localFP.Min != targetFP.Min ||
 		localFP.MinOrdinal != targetFP.MinOrdinal ||
 		localFP.MaxOrdinal != targetFP.MaxOrdinal ||
+		localFP.MessageIDFP != targetFP.MessageIDFP ||
 		localFP.ContentHashFP != targetFP.ContentHashFP ||
 		localFP.RoleTimeFP != targetFP.RoleTimeFP ||
 		localFP.FlagsFP != targetFP.FlagsFP ||
@@ -177,7 +179,7 @@ func duckMessageFingerprintForSession(
 func duckStoredMessageFingerprint(
 	ctx context.Context, q duckQueryer, sessionID string, maxOrdinal *int,
 ) (duckMessageFingerprint, error) {
-	query := `SELECT ordinal, role, content, thinking_text, timestamp,
+	query := `SELECT id, ordinal, role, content, thinking_text, timestamp,
 			has_thinking, has_tool_use, content_length, is_system,
 			model, token_usage, context_tokens, output_tokens,
 			has_context_tokens, has_output_tokens, claude_message_id,
@@ -199,6 +201,7 @@ func duckStoredMessageFingerprint(
 	defer rows.Close()
 
 	fp := duckMessageFingerprint{MinOrdinal: -1, MaxOrdinal: -1}
+	var messageIDs strings.Builder
 	var systemOrdinals strings.Builder
 	var contentHash strings.Builder
 	var roleTime strings.Builder
@@ -206,6 +209,7 @@ func duckStoredMessageFingerprint(
 	var token strings.Builder
 	for rows.Next() {
 		var ordinal, contentLength, contextTokens, outputTokens int
+		var id int64
 		var role, content, thinkingText, model, tokenUsage string
 		var claudeMsgID, claudeReqID string
 		var srcType, srcSubtype, srcUUID, srcParentUUID string
@@ -214,7 +218,7 @@ func duckStoredMessageFingerprint(
 		var hasContextTokens, hasOutputTokens bool
 		var isSidechain, isCompactBoundary bool
 		if err := rows.Scan(
-			&ordinal, &role, &content, &thinkingText, &timestamp,
+			&id, &ordinal, &role, &content, &thinkingText, &timestamp,
 			&hasThinking, &hasToolUse, &contentLength, &isSystem,
 			&model, &tokenUsage, &contextTokens, &outputTokens,
 			&hasContextTokens, &hasOutputTokens, &claudeMsgID,
@@ -236,6 +240,7 @@ func duckStoredMessageFingerprint(
 		}
 		fp.Count++
 		fp.Sum += int64(contentLength)
+		fmt.Fprintf(&messageIDs, "%d|%d;", ordinal, id)
 		if isSystem {
 			if systemOrdinals.Len() > 0 {
 				systemOrdinals.WriteByte(',')
@@ -292,6 +297,7 @@ func duckStoredMessageFingerprint(
 	if err := rows.Err(); err != nil {
 		return duckMessageFingerprint{}, err
 	}
+	fp.MessageIDFP = messageIDs.String()
 	fp.SystemFP = systemOrdinals.String()
 	fp.ContentHashFP = contentHash.String()
 	fp.RoleTimeFP = roleTime.String()

--- a/internal/duckdb/push_fingerprint.go
+++ b/internal/duckdb/push_fingerprint.go
@@ -209,7 +209,7 @@ func duckStoredMessageFingerprint(
 	var token strings.Builder
 	for rows.Next() {
 		var ordinal, contentLength, contextTokens, outputTokens int
-		var id int64
+		var id sql.NullInt64
 		var role, content, thinkingText, model, tokenUsage string
 		var claudeMsgID, claudeReqID string
 		var srcType, srcSubtype, srcUUID, srcParentUUID string
@@ -240,7 +240,7 @@ func duckStoredMessageFingerprint(
 		}
 		fp.Count++
 		fp.Sum += int64(contentLength)
-		fmt.Fprintf(&messageIDs, "%d|%d;", ordinal, id)
+		fmt.Fprintf(&messageIDs, "%d|%t|%d;", ordinal, id.Valid, id.Int64)
 		if isSystem {
 			if systemOrdinals.Len() > 0 {
 				systemOrdinals.WriteByte(',')

--- a/internal/duckdb/push_fingerprint.go
+++ b/internal/duckdb/push_fingerprint.go
@@ -1,0 +1,525 @@
+package duckdb
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+type duckMessagePushKind int
+
+const (
+	duckMessagePushReplace duckMessagePushKind = iota
+	duckMessagePushSkip
+	duckMessagePushAppend
+)
+
+type duckMessagePushAction struct {
+	kind       duckMessagePushKind
+	maxOrdinal int
+}
+
+type duckMessageFingerprint struct {
+	Count         int
+	Sum           int64
+	Max           int64
+	Min           int64
+	MinOrdinal    int
+	MaxOrdinal    int
+	ContentHashFP string
+	RoleTimeFP    string
+	FlagsFP       string
+	SystemFP      string
+	TokenFP       string
+	ToolCallCount int
+	ToolCallSum   int64
+	ToolCallFP    string
+	ToolResultFP  string
+	UsageEventFP  string
+}
+
+type duckQueryer interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+}
+
+type syncDuckQueryer struct {
+	sync *Sync
+}
+
+func (q syncDuckQueryer) QueryContext(
+	ctx context.Context, query string, args ...any,
+) (*sql.Rows, error) {
+	return queryDuckDBContext(
+		ctx, q.sync.duck, q.sync.connectionKind, q.sync.quack, query, args...,
+	)
+}
+
+func (s *Sync) targetQueryer() duckQueryer {
+	return syncDuckQueryer{sync: s}
+}
+
+func (s *Sync) duckMessagePushAction(
+	ctx context.Context, q duckQueryer, sessionID string, msgs []db.Message,
+) (duckMessagePushAction, error) {
+	localCount := len(msgs)
+	targetFP, err := duckMessageFingerprintForSession(ctx, q, sessionID, nil)
+	if err != nil {
+		return duckMessagePushAction{}, fmt.Errorf(
+			"reading duckdb message fingerprint %s: %w", sessionID, err,
+		)
+	}
+	if localCount == 0 {
+		return duckMessagePushAction{kind: duckMessagePushReplace}, nil
+	}
+	if targetFP.Count == localCount && targetFP.Count > 0 {
+		localFP, err := duckMessageFingerprintForSession(
+			ctx, s.local.Reader(), sessionID, nil,
+		)
+		if err != nil {
+			return duckMessagePushAction{}, fmt.Errorf(
+				"reading local message fingerprint %s: %w", sessionID, err,
+			)
+		}
+		if duckMessageFingerprintsMatch(localFP, targetFP, true) {
+			return duckMessagePushAction{kind: duckMessagePushSkip}, nil
+		}
+		return duckMessagePushAction{kind: duckMessagePushReplace}, nil
+	}
+	if targetFP.Count <= 0 || targetFP.Count >= localCount {
+		return duckMessagePushAction{kind: duckMessagePushReplace}, nil
+	}
+
+	maxOrdinal := targetFP.MaxOrdinal
+	localPrefixFP, err := duckMessageFingerprintForSession(
+		ctx, s.local.Reader(), sessionID, &maxOrdinal,
+	)
+	if err != nil {
+		return duckMessagePushAction{}, fmt.Errorf(
+			"reading local prefix fingerprint %s: %w", sessionID, err,
+		)
+	}
+	if localPrefixFP.Count != targetFP.Count {
+		return duckMessagePushAction{kind: duckMessagePushReplace}, nil
+	}
+	if duckMessageFingerprintsMatch(localPrefixFP, targetFP, false) {
+		return duckMessagePushAction{
+			kind:       duckMessagePushAppend,
+			maxOrdinal: targetFP.MaxOrdinal,
+		}, nil
+	}
+	return duckMessagePushAction{kind: duckMessagePushReplace}, nil
+}
+
+func duckMessageFingerprintsMatch(
+	localFP, targetFP duckMessageFingerprint, includeUsage bool,
+) bool {
+	if localFP.Count != targetFP.Count ||
+		localFP.Sum != targetFP.Sum ||
+		localFP.Max != targetFP.Max ||
+		localFP.Min != targetFP.Min ||
+		localFP.MinOrdinal != targetFP.MinOrdinal ||
+		localFP.MaxOrdinal != targetFP.MaxOrdinal ||
+		localFP.ContentHashFP != targetFP.ContentHashFP ||
+		localFP.RoleTimeFP != targetFP.RoleTimeFP ||
+		localFP.FlagsFP != targetFP.FlagsFP ||
+		localFP.SystemFP != targetFP.SystemFP ||
+		localFP.TokenFP != targetFP.TokenFP ||
+		localFP.ToolCallCount != targetFP.ToolCallCount ||
+		localFP.ToolCallSum != targetFP.ToolCallSum ||
+		localFP.ToolCallFP != targetFP.ToolCallFP ||
+		localFP.ToolResultFP != targetFP.ToolResultFP {
+		return false
+	}
+	return !includeUsage || localFP.UsageEventFP == targetFP.UsageEventFP
+}
+
+func duckMessageFingerprintForSession(
+	ctx context.Context,
+	q duckQueryer,
+	sessionID string,
+	maxOrdinal *int,
+) (duckMessageFingerprint, error) {
+	fp, err := duckStoredMessageFingerprint(ctx, q, sessionID, maxOrdinal)
+	if err != nil {
+		return duckMessageFingerprint{}, err
+	}
+	toolCount, toolSum, toolFP, err := duckStoredToolCallFingerprint(
+		ctx, q, sessionID, maxOrdinal,
+	)
+	if err != nil {
+		return duckMessageFingerprint{}, err
+	}
+	fp.ToolCallCount = toolCount
+	fp.ToolCallSum = toolSum
+	fp.ToolCallFP = toolFP
+	resultFP, err := duckStoredToolResultEventFingerprint(
+		ctx, q, sessionID, maxOrdinal,
+	)
+	if err != nil {
+		return duckMessageFingerprint{}, err
+	}
+	fp.ToolResultFP = resultFP
+	if maxOrdinal == nil {
+		usageFP, err := duckStoredUsageEventFingerprint(ctx, q, sessionID)
+		if err != nil {
+			return duckMessageFingerprint{}, err
+		}
+		fp.UsageEventFP = usageFP
+	}
+	return fp, nil
+}
+
+func duckStoredMessageFingerprint(
+	ctx context.Context, q duckQueryer, sessionID string, maxOrdinal *int,
+) (duckMessageFingerprint, error) {
+	query := `SELECT ordinal, role, content, thinking_text, timestamp,
+			has_thinking, has_tool_use, content_length, is_system,
+			model, token_usage, context_tokens, output_tokens,
+			has_context_tokens, has_output_tokens, claude_message_id,
+			claude_request_id, source_type, source_subtype, source_uuid,
+			source_parent_uuid, is_sidechain, is_compact_boundary
+		FROM messages
+		WHERE session_id = ?`
+	args := []any{sessionID}
+	if maxOrdinal != nil {
+		query += ` AND ordinal <= ?`
+		args = append(args, *maxOrdinal)
+	}
+	query += ` ORDER BY ordinal ASC`
+
+	rows, err := q.QueryContext(ctx, query, args...)
+	if err != nil {
+		return duckMessageFingerprint{}, err
+	}
+	defer rows.Close()
+
+	fp := duckMessageFingerprint{MinOrdinal: -1, MaxOrdinal: -1}
+	var systemOrdinals strings.Builder
+	var contentHash strings.Builder
+	var roleTime strings.Builder
+	var flags strings.Builder
+	var token strings.Builder
+	for rows.Next() {
+		var ordinal, contentLength, contextTokens, outputTokens int
+		var role, content, thinkingText, model, tokenUsage string
+		var claudeMsgID, claudeReqID string
+		var srcType, srcSubtype, srcUUID, srcParentUUID string
+		var timestamp any
+		var hasThinking, hasToolUse, isSystem bool
+		var hasContextTokens, hasOutputTokens bool
+		var isSidechain, isCompactBoundary bool
+		if err := rows.Scan(
+			&ordinal, &role, &content, &thinkingText, &timestamp,
+			&hasThinking, &hasToolUse, &contentLength, &isSystem,
+			&model, &tokenUsage, &contextTokens, &outputTokens,
+			&hasContextTokens, &hasOutputTokens, &claudeMsgID,
+			&claudeReqID, &srcType, &srcSubtype, &srcUUID,
+			&srcParentUUID, &isSidechain, &isCompactBoundary,
+		); err != nil {
+			return duckMessageFingerprint{}, err
+		}
+		if fp.Count == 0 {
+			fp.Min = int64(contentLength)
+			fp.Max = int64(contentLength)
+			fp.MinOrdinal = ordinal
+			fp.MaxOrdinal = ordinal
+		} else {
+			fp.Min = min(fp.Min, int64(contentLength))
+			fp.Max = max(fp.Max, int64(contentLength))
+			fp.MinOrdinal = min(fp.MinOrdinal, ordinal)
+			fp.MaxOrdinal = max(fp.MaxOrdinal, ordinal)
+		}
+		fp.Count++
+		fp.Sum += int64(contentLength)
+		if isSystem {
+			if systemOrdinals.Len() > 0 {
+				systemOrdinals.WriteByte(',')
+			}
+			fmt.Fprintf(&systemOrdinals, "%d", ordinal)
+		}
+
+		content = db.SanitizeUTF8(content)
+		contentSum := sha256.Sum256([]byte(content))
+		fmt.Fprintf(
+			&contentHash, "%d|%d|%x;",
+			ordinal, contentLength, contentSum,
+		)
+
+		role = db.SanitizeUTF8(role)
+		timestampText := duckFingerprintTime(timestamp)
+		fmt.Fprintf(
+			&roleTime, "%d|%d:%s|%d:%s;",
+			ordinal, len(role), role, len(timestampText), timestampText,
+		)
+
+		thinkingText = db.SanitizeUTF8(thinkingText)
+		thinkingSum := sha256.Sum256([]byte(thinkingText))
+		fmt.Fprintf(
+			&flags, "%d|%t|%t|%t|%x;",
+			ordinal, isSystem, hasThinking, hasToolUse, thinkingSum,
+		)
+
+		model = db.SanitizeUTF8(model)
+		tokenUsage = db.SanitizeUTF8(tokenUsage)
+		claudeMsgID = db.SanitizeUTF8(claudeMsgID)
+		claudeReqID = db.SanitizeUTF8(claudeReqID)
+		srcType = db.SanitizeUTF8(srcType)
+		srcSubtype = db.SanitizeUTF8(srcSubtype)
+		srcUUID = db.SanitizeUTF8(srcUUID)
+		srcParentUUID = db.SanitizeUTF8(srcParentUUID)
+		fmt.Fprintf(
+			&token,
+			"%d|%d:%s|%d:%s|%d|%d|%t|%t|%s|%s|"+
+				"%d:%s|%d:%s|%d:%s|%d:%s|%t|%t;",
+			ordinal,
+			len(model), model,
+			len(tokenUsage), tokenUsage,
+			contextTokens, outputTokens,
+			hasContextTokens, hasOutputTokens,
+			claudeMsgID, claudeReqID,
+			len(srcType), srcType,
+			len(srcSubtype), srcSubtype,
+			len(srcUUID), srcUUID,
+			len(srcParentUUID), srcParentUUID,
+			isSidechain, isCompactBoundary,
+		)
+	}
+	if err := rows.Err(); err != nil {
+		return duckMessageFingerprint{}, err
+	}
+	fp.SystemFP = systemOrdinals.String()
+	fp.ContentHashFP = contentHash.String()
+	fp.RoleTimeFP = roleTime.String()
+	fp.FlagsFP = flags.String()
+	fp.TokenFP = token.String()
+	return fp, nil
+}
+
+func duckStoredToolCallFingerprint(
+	ctx context.Context, q duckQueryer, sessionID string, maxOrdinal *int,
+) (int, int64, string, error) {
+	query := `SELECT m.ordinal, tc.call_index, tc.tool_name, tc.category,
+			COALESCE(tc.tool_use_id, ''), COALESCE(tc.input_json, ''),
+			COALESCE(tc.skill_name, ''), COALESCE(tc.subagent_session_id, ''),
+			COALESCE(tc.result_content_length, 0),
+			COALESCE(tc.result_content, ''), COALESCE(tc.file_path, '')
+		FROM tool_calls tc
+		JOIN messages m ON m.session_id = tc.session_id
+			AND m.id = tc.message_id
+		WHERE tc.session_id = ?`
+	args := []any{sessionID}
+	if maxOrdinal != nil {
+		query += ` AND m.ordinal <= ?`
+		args = append(args, *maxOrdinal)
+	}
+	query += ` ORDER BY m.ordinal ASC, tc.call_index ASC`
+
+	rows, err := q.QueryContext(ctx, query, args...)
+	if err != nil {
+		return 0, 0, "", err
+	}
+	defer rows.Close()
+
+	count := 0
+	var sum int64
+	var b strings.Builder
+	for rows.Next() {
+		var messageOrdinal, callIndex, resultContentLength int
+		var toolName, category, toolUseID, inputJSON string
+		var skillName, subagentSessionID, resultContent, filePath string
+		if err := rows.Scan(
+			&messageOrdinal, &callIndex, &toolName, &category,
+			&toolUseID, &inputJSON, &skillName, &subagentSessionID,
+			&resultContentLength, &resultContent, &filePath,
+		); err != nil {
+			return 0, 0, "", err
+		}
+		count++
+		sum += int64(resultContentLength)
+		toolName = db.SanitizeUTF8(toolName)
+		category = db.SanitizeUTF8(category)
+		toolUseID = db.SanitizeUTF8(toolUseID)
+		inputJSON = db.SanitizeUTF8(inputJSON)
+		skillName = db.SanitizeUTF8(skillName)
+		subagentSessionID = db.SanitizeUTF8(subagentSessionID)
+		resultContent = db.SanitizeUTF8(resultContent)
+		filePath = db.SanitizeUTF8(filePath)
+		fmt.Fprintf(
+			&b,
+			"%d|%d|%d:%s|%d:%s|%d:%s|%d:%s|%d:%s|%d:%s|%d|%d:%s|%d:%s;",
+			messageOrdinal, callIndex,
+			len(toolName), toolName,
+			len(category), category,
+			len(toolUseID), toolUseID,
+			len(inputJSON), inputJSON,
+			len(skillName), skillName,
+			len(subagentSessionID), subagentSessionID,
+			resultContentLength,
+			len(resultContent), resultContent,
+			len(filePath), filePath,
+		)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, 0, "", err
+	}
+	return count, sum, b.String(), nil
+}
+
+func duckStoredToolResultEventFingerprint(
+	ctx context.Context, q duckQueryer, sessionID string, maxOrdinal *int,
+) (string, error) {
+	query := `SELECT tool_call_message_ordinal, call_index, event_index,
+			COALESCE(tool_use_id, ''), COALESCE(agent_id, ''),
+			COALESCE(subagent_session_id, ''), source, status,
+			content, content_length, timestamp
+		FROM tool_result_events
+		WHERE session_id = ?`
+	args := []any{sessionID}
+	if maxOrdinal != nil {
+		query += ` AND tool_call_message_ordinal <= ?`
+		args = append(args, *maxOrdinal)
+	}
+	query += ` ORDER BY tool_call_message_ordinal ASC, call_index ASC, event_index ASC`
+
+	rows, err := q.QueryContext(ctx, query, args...)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+
+	var b strings.Builder
+	for rows.Next() {
+		var messageOrdinal, callIndex, eventIndex, contentLength int
+		var toolUseID, agentID, subagentSessionID string
+		var source, status, content string
+		var timestamp any
+		if err := rows.Scan(
+			&messageOrdinal, &callIndex, &eventIndex,
+			&toolUseID, &agentID, &subagentSessionID,
+			&source, &status, &content, &contentLength, &timestamp,
+		); err != nil {
+			return "", err
+		}
+		toolUseID = db.SanitizeUTF8(toolUseID)
+		agentID = db.SanitizeUTF8(agentID)
+		subagentSessionID = db.SanitizeUTF8(subagentSessionID)
+		source = db.SanitizeUTF8(source)
+		status = db.SanitizeUTF8(status)
+		content = db.SanitizeUTF8(content)
+		contentSum := sha256.Sum256([]byte(content))
+		timestampText := duckFingerprintTime(timestamp)
+		fmt.Fprintf(
+			&b,
+			"%d|%d|%d|%d:%s|%d:%s|%d:%s|%d:%s|%d:%s|%d|%x|%d:%s;",
+			messageOrdinal, callIndex, eventIndex,
+			len(toolUseID), toolUseID,
+			len(agentID), agentID,
+			len(subagentSessionID), subagentSessionID,
+			len(source), source,
+			len(status), status,
+			contentLength,
+			contentSum,
+			len(timestampText), timestampText,
+		)
+	}
+	return b.String(), rows.Err()
+}
+
+func duckStoredUsageEventFingerprint(
+	ctx context.Context, q duckQueryer, sessionID string,
+) (string, error) {
+	rows, err := q.QueryContext(ctx, `
+		SELECT message_ordinal, source, model,
+			input_tokens, output_tokens,
+			cache_creation_input_tokens, cache_read_input_tokens,
+			reasoning_tokens, cost_usd, cost_status, cost_source,
+			occurred_at, dedup_key
+		FROM usage_events
+		WHERE session_id = ?
+		ORDER BY COALESCE(CAST(occurred_at AS TEXT), ''), id`,
+		sessionID,
+	)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+
+	var b strings.Builder
+	for rows.Next() {
+		var ordinal sql.NullInt64
+		var source, model, costStatus, costSource string
+		var inputTokens, outputTokens int
+		var cacheCreationInputTokens, cacheReadInputTokens int
+		var reasoningTokens int
+		var cost sql.NullFloat64
+		var occurredAt any
+		var dedupKey sql.NullString
+		if err := rows.Scan(
+			&ordinal, &source, &model,
+			&inputTokens, &outputTokens,
+			&cacheCreationInputTokens, &cacheReadInputTokens,
+			&reasoningTokens, &cost, &costStatus, &costSource,
+			&occurredAt, &dedupKey,
+		); err != nil {
+			return "", err
+		}
+		occurred := duckFingerprintTime(occurredAt)
+		source = db.SanitizeUTF8(source)
+		model = db.SanitizeUTF8(model)
+		costStatus = db.SanitizeUTF8(costStatus)
+		costSource = db.SanitizeUTF8(costSource)
+		dedupKey.String = db.SanitizeUTF8(dedupKey.String)
+		fmt.Fprintf(
+			&b,
+			"%t|%d|%d:%s|%d:%s|%d|%d|%d|%d|%d|%t|%g|%d:%s|%d:%s|%d:%s|%d:%s;",
+			ordinal.Valid,
+			ordinal.Int64,
+			len(source), source,
+			len(model), model,
+			inputTokens,
+			outputTokens,
+			cacheCreationInputTokens,
+			cacheReadInputTokens,
+			reasoningTokens,
+			cost.Valid,
+			cost.Float64,
+			len(costStatus), costStatus,
+			len(costSource), costSource,
+			len(occurred), occurred,
+			len(dedupKey.String), dedupKey.String,
+		)
+	}
+	return b.String(), rows.Err()
+}
+
+func duckFingerprintTime(value any) string {
+	switch v := value.(type) {
+	case nil:
+		return ""
+	case time.Time:
+		return v.UTC().Format(time.RFC3339Nano)
+	case string:
+		if t, ok := parseTimestamp(v); ok {
+			return t.UTC().Format(time.RFC3339Nano)
+		}
+		return v
+	case []byte:
+		return duckFingerprintTime(string(v))
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+func messagesAfterDuckOrdinal(msgs []db.Message, maxOrdinal int) []db.Message {
+	for i, msg := range msgs {
+		if msg.Ordinal > maxOrdinal {
+			return msgs[i:]
+		}
+	}
+	return nil
+}

--- a/internal/duckdb/quack_smoke_duckdbtest_test.go
+++ b/internal/duckdb/quack_smoke_duckdbtest_test.go
@@ -518,6 +518,9 @@ func TestQuackClientSyncPushWritesThroughAttachment(t *testing.T) {
 	require.NoError(t, err, "push through Quack")
 	assert.Equal(t, 2, result.SessionsPushed)
 	assert.Equal(t, 3, result.MessagesPushed)
+	watermark, err := local.GetSyncState(syncer.syncStateKey(lastPushStateKey))
+	require.NoError(t, err, "read Quack push watermark")
+	assert.NotEmpty(t, watermark, "successful Quack push must advance watermark")
 
 	status, err := syncer.Status(ctx)
 	require.NoError(t, err, "read Quack-backed sync status")

--- a/internal/duckdb/sync.go
+++ b/internal/duckdb/sync.go
@@ -270,13 +270,11 @@ func (s *Sync) Push(
 	if err != nil {
 		return result, fmt.Errorf("listing local sessions: %w", err)
 	}
-	result.Diagnostics.LocalSessions = countPushSessions(allLocalSessions)
-	sessionFingerprints, err := s.sessionFingerprints(ctx, sessions)
-	if err != nil {
-		return result, err
+	allLocalSessionByID := make(map[string]db.Session, len(allLocalSessions))
+	for _, sess := range allLocalSessions {
+		allLocalSessionByID[sess.ID] = sess
 	}
-	candidateSessions := append([]db.Session(nil), sessions...)
-	result.Diagnostics.CandidateSessions = countPushSessions(candidateSessions)
+	result.Diagnostics.LocalSessions = countPushSessions(allLocalSessions)
 	priorFingerprints := map[string]string{}
 	if !full {
 		priorFingerprints, err = readSyncFingerprintsWithKey(
@@ -305,7 +303,20 @@ func (s *Sync) Push(
 	}
 	result.Diagnostics.DeletedStaleSessions = len(staleIDs)
 	if !full {
-		pruneMissingMirrorFingerprints(priorFingerprints, mirrorSessionIDs)
+		missingMirrorIDs := pruneMissingMirrorFingerprints(
+			priorFingerprints, mirrorSessionIDs,
+		)
+		sessions = appendMissingMirrorRepairCandidates(
+			sessions, sessionByID, allLocalSessionByID, missingMirrorIDs,
+		)
+	}
+	sessionFingerprints, err := s.sessionFingerprints(ctx, sessions)
+	if err != nil {
+		return result, err
+	}
+	candidateSessions := append([]db.Session(nil), sessions...)
+	result.Diagnostics.CandidateSessions = countPushSessions(candidateSessions)
+	if !full {
 		sessions = filterUnchangedSessions(sessions, priorFingerprints, sessionFingerprints)
 		result.Diagnostics.SkippedUnchangedSessions = skippedPushSessions(
 			candidateSessions, sessions,
@@ -884,12 +895,36 @@ func filterUnchangedSessions(
 func pruneMissingMirrorFingerprints(
 	priorFingerprints map[string]string,
 	mirrorSessionIDs map[string]bool,
-) {
+) []string {
+	var missing []string
 	for id := range priorFingerprints {
 		if !mirrorSessionIDs[id] {
 			delete(priorFingerprints, id)
+			missing = append(missing, id)
 		}
 	}
+	sort.Strings(missing)
+	return missing
+}
+
+func appendMissingMirrorRepairCandidates(
+	sessions []db.Session,
+	sessionByID map[string]db.Session,
+	allLocalSessionByID map[string]db.Session,
+	missingMirrorIDs []string,
+) []db.Session {
+	for _, id := range missingMirrorIDs {
+		sess, ok := allLocalSessionByID[id]
+		if !ok {
+			continue
+		}
+		if _, ok := sessionByID[id]; ok {
+			continue
+		}
+		sessionByID[id] = sess
+		sessions = append(sessions, sess)
+	}
+	return sessions
 }
 
 func previousLocalSyncTimestamp(value string) (string, error) {

--- a/internal/duckdb/sync.go
+++ b/internal/duckdb/sync.go
@@ -286,19 +286,13 @@ func (s *Sync) Push(
 		if err != nil {
 			return result, err
 		}
-		sessions = filterUnchangedSessions(sessions, priorFingerprints, sessionFingerprints)
-		result.Diagnostics.SkippedUnchangedSessions = skippedPushSessions(
-			candidateSessions, sessions,
-		)
 	}
-	sort.Slice(sessions, func(i, j int) bool {
-		return sessions[i].ID < sessions[j].ID
-	})
 
 	var staleIDs []string
+	var mirrorSessionIDs map[string]bool
 	err = s.withDuckTx(ctx, "delete hard-deleted sessions", func(tx *sql.Tx) error {
 		var txErr error
-		staleIDs, txErr = s.deleteHardDeletedMirrorSessions(
+		staleIDs, mirrorSessionIDs, txErr = s.deleteHardDeletedMirrorSessions(
 			ctx, tx, allLocalSessions, s.machine, s.projects, s.excludeProjects,
 		)
 		return txErr
@@ -310,6 +304,16 @@ func (s *Sync) Push(
 		delete(priorFingerprints, id)
 	}
 	result.Diagnostics.DeletedStaleSessions = len(staleIDs)
+	if !full {
+		pruneMissingMirrorFingerprints(priorFingerprints, mirrorSessionIDs)
+		sessions = filterUnchangedSessions(sessions, priorFingerprints, sessionFingerprints)
+		result.Diagnostics.SkippedUnchangedSessions = skippedPushSessions(
+			candidateSessions, sessions,
+		)
+	}
+	sort.Slice(sessions, func(i, j int) bool {
+		return sessions[i].ID < sessions[j].ID
+	})
 
 	pushed := make([]db.Session, 0, len(sessions))
 	for start := 0; start < len(sessions); start += duckSessionPushBatchSize {
@@ -875,6 +879,17 @@ func filterUnchangedSessions(
 		out = append(out, sess)
 	}
 	return out
+}
+
+func pruneMissingMirrorFingerprints(
+	priorFingerprints map[string]string,
+	mirrorSessionIDs map[string]bool,
+) {
+	for id := range priorFingerprints {
+		if !mirrorSessionIDs[id] {
+			delete(priorFingerprints, id)
+		}
+	}
 }
 
 func previousLocalSyncTimestamp(value string) (string, error) {

--- a/internal/duckdb/sync.go
+++ b/internal/duckdb/sync.go
@@ -345,10 +345,8 @@ func (s *Sync) Push(
 		)
 	}
 	if len(pushed) > 0 || len(staleIDs) > 0 {
-		if s.maintenance != nil {
-			if err := s.maintenance.checkpointAfterPush(ctx, s.duck); err != nil {
-				return result, err
-			}
+		if err := s.checkpointAfterMutatingPush(ctx); err != nil {
+			return result, err
 		}
 	}
 	if full && s.isFiltered() {
@@ -368,6 +366,15 @@ func (s *Sync) Push(
 	}
 	result.Duration = time.Since(start)
 	return result, nil
+}
+
+func (s *Sync) checkpointAfterMutatingPush(ctx context.Context) error {
+	// CHECKPOINT is local-file maintenance. Quack targets route storage work
+	// through a remote server, so running it on the client handle is wrong.
+	if s.connectionKind == duckDBQuackClientConnection || s.maintenance == nil {
+		return nil
+	}
+	return s.maintenance.checkpointAfterPush(ctx, s.duck)
 }
 
 func (s *Sync) withDuckTx(

--- a/internal/duckdb/sync.go
+++ b/internal/duckdb/sync.go
@@ -38,6 +38,7 @@ type Sync struct {
 	excludeProjects []string
 	connectionKind  duckDBConnectionKind
 	quack           *quackClient
+	maintenance     duckDBMaintenance
 
 	closeOnce sync.Once
 	closeErr  error
@@ -120,6 +121,7 @@ func New(
 		syncStateScope:  opts.SyncStateTarget,
 		projects:        opts.Projects,
 		excludeProjects: opts.ExcludeProjects,
+		maintenance:     duckDBCheckpointMaintenance{},
 	}, nil
 }
 
@@ -312,9 +314,9 @@ func (s *Sync) Push(
 	pushed := make([]db.Session, 0, len(sessions))
 	for start := 0; start < len(sessions); start += duckSessionPushBatchSize {
 		end := min(start+duckSessionPushBatchSize, len(sessions))
-		if err := s.pushSessionBatch(
+		if err := s.pushSessionBatchForMode(
 			ctx, sessions[start:end], start, len(sessions),
-			&result, &pushed, onProgress,
+			&result, &pushed, onProgress, full,
 		); err != nil {
 			return result, err
 		}
@@ -341,6 +343,13 @@ func (s *Sync) Push(
 			"duckdbsync: skipping curation refresh after %d session push errors",
 			result.Errors,
 		)
+	}
+	if len(pushed) > 0 || len(staleIDs) > 0 {
+		if s.maintenance != nil {
+			if err := s.maintenance.checkpointAfterPush(ctx, s.duck); err != nil {
+				return result, err
+			}
+		}
 	}
 	if full && s.isFiltered() {
 		// Clear the global watermark so the next unfiltered push
@@ -391,9 +400,30 @@ func (s *Sync) pushSessionBatch(
 	pushed *[]db.Session,
 	onProgress func(PushProgress),
 ) error {
+	return s.pushSessionBatchForMode(
+		ctx, sessions, offset, total, result, pushed, onProgress, false,
+	)
+}
+
+func (s *Sync) pushSessionBatchForMode(
+	ctx context.Context,
+	sessions []db.Session,
+	offset int,
+	total int,
+	result *PushResult,
+	pushed *[]db.Session,
+	onProgress func(PushProgress),
+	full bool,
+) error {
 	return pushSessionBatchWith(
 		ctx, sessions, offset, total, result, pushed, onProgress,
-		s.tryPushSessionBatch, s.pushSingleSession, waitAfterRemoteMutationTimeout,
+		func(ctx context.Context, sessions []db.Session) ([]int, error) {
+			return s.tryPushSessionBatch(ctx, sessions, full)
+		},
+		func(ctx context.Context, sess db.Session) (int, error) {
+			return s.pushSingleSession(ctx, sess, full)
+		},
+		waitAfterRemoteMutationTimeout,
 	)
 }
 
@@ -541,10 +571,10 @@ func reportDuckPushProgress(
 }
 
 func (s *Sync) tryPushSessionBatch(
-	ctx context.Context, sessions []db.Session,
+	ctx context.Context, sessions []db.Session, full bool,
 ) ([]int, error) {
 	if s.connectionKind == duckDBQuackClientConnection {
-		return s.tryPushRemoteSessionBatch(ctx, sessions)
+		return s.tryPushRemoteSessionBatch(ctx, sessions, full)
 	}
 	tx, err := s.duck.BeginTx(ctx, nil)
 	if err != nil {
@@ -554,7 +584,7 @@ func (s *Sync) tryPushSessionBatch(
 	messagesBySession := make([]int, len(sessions))
 
 	for i, sess := range sessions {
-		messages, err := s.pushSession(ctx, tx, sess)
+		messages, err := s.pushSession(ctx, tx, tx, sess, full)
 		if err != nil {
 			return nil, fmt.Errorf("pushing duckdb session %s: %w", sess.ID, err)
 		}
@@ -567,7 +597,7 @@ func (s *Sync) tryPushSessionBatch(
 }
 
 func (s *Sync) tryPushRemoteSessionBatch(
-	ctx context.Context, sessions []db.Session,
+	ctx context.Context, sessions []db.Session, full bool,
 ) ([]int, error) {
 	const batchLabel = "duckdb remote session batch"
 
@@ -576,7 +606,9 @@ func (s *Sync) tryPushRemoteSessionBatch(
 
 	for i, sess := range sessions {
 		sessionBatch := &duckRemoteMutationBatch{}
-		messages, err := s.pushSession(ctx, sessionBatch, sess)
+		messages, err := s.pushSession(
+			ctx, sessionBatch, s.targetQueryer(), sess, full,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("pushing duckdb remote session %s: %w", sess.ID, err)
 		}
@@ -612,16 +644,18 @@ func (s *Sync) tryPushRemoteSessionBatch(
 	return messagesBySession, nil
 }
 
-func (s *Sync) pushSingleSession(ctx context.Context, sess db.Session) (int, error) {
+func (s *Sync) pushSingleSession(
+	ctx context.Context, sess db.Session, full bool,
+) (int, error) {
 	if s.connectionKind == duckDBQuackClientConnection {
-		return s.pushSingleRemoteSession(ctx, sess)
+		return s.pushSingleRemoteSession(ctx, sess, full)
 	}
 	tx, err := s.duck.BeginTx(ctx, nil)
 	if err != nil {
 		return 0, fmt.Errorf("begin duckdb session tx %s: %w", sess.ID, err)
 	}
 	defer func() { _ = tx.Rollback() }()
-	messages, err := s.pushSession(ctx, tx, sess)
+	messages, err := s.pushSession(ctx, tx, tx, sess, full)
 	if err != nil {
 		return 0, err
 	}
@@ -631,9 +665,11 @@ func (s *Sync) pushSingleSession(ctx context.Context, sess db.Session) (int, err
 	return messages, nil
 }
 
-func (s *Sync) pushSingleRemoteSession(ctx context.Context, sess db.Session) (int, error) {
+func (s *Sync) pushSingleRemoteSession(
+	ctx context.Context, sess db.Session, full bool,
+) (int, error) {
 	batch := &duckRemoteMutationBatch{}
-	messages, err := s.pushSession(ctx, batch, sess)
+	messages, err := s.pushSession(ctx, batch, s.targetQueryer(), sess, full)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/duckdb/sync_fastpath_test.go
+++ b/internal/duckdb/sync_fastpath_test.go
@@ -392,6 +392,36 @@ func TestSyncCheckpointFailureAfterHardDeleteDoesNotKeepStaleFingerprint(t *test
 	assert.NotContains(t, fingerprints, fixture.betaID)
 }
 
+func TestSyncMissingMirrorRowWithUnchangedLocalSessionIsRepaired(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	fixture := seedDuckDBSyncFixture(t, local)
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+	policy := &checkpointSpy{}
+	syncer.maintenance = policy
+
+	first, err := syncer.Push(ctx, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, first.SessionsPushed)
+	assert.Equal(t, 1, policy.calls)
+	require.NoError(t, syncer.withDuckTx(ctx, "test delete mirror session", func(tx *sql.Tx) error {
+		return syncer.deleteMirrorSession(ctx, tx, fixture.betaID)
+	}))
+	assertDuckDBCountWhere(t, syncer.DB(), "sessions", "id = ?", fixture.betaID, 0)
+
+	second, err := syncer.Push(ctx, false, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, second.SessionsPushed)
+	assert.Equal(t, 1, second.MessagesPushed)
+	assert.Equal(t, 2, policy.calls)
+	assertDuckDBCountWhere(t, syncer.DB(), "sessions", "id = ?", fixture.betaID, 1)
+	assertDuckDBCountWhere(t, syncer.DB(), "messages", "session_id = ?", fixture.betaID, 1)
+	fingerprints, err := readSyncFingerprintsWithKey(local, lastPushBoundaryStateKey)
+	require.NoError(t, err)
+	assert.Contains(t, fingerprints, fixture.betaID)
+}
+
 func TestSyncCheckpointPolicySkipsRemoteQuackTargets(t *testing.T) {
 	ctx := context.Background()
 	local := newLocalDB(t)

--- a/internal/duckdb/sync_fastpath_test.go
+++ b/internal/duckdb/sync_fastpath_test.go
@@ -145,6 +145,47 @@ func TestSyncIncrementalHistoricalMessageChangeFallsBackToRewrite(t *testing.T) 
 	)
 }
 
+func TestSyncIncrementalMessageIDChangeFallsBackToRewrite(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	fixture := seedDuckDBSyncFixture(t, local)
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+
+	first, err := syncer.Push(ctx, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, first.SessionsPushed)
+	rowIDBefore := duckMessageRowID(t, syncer.DB(), fixture.alphaID, 0)
+	localBefore, err := local.GetAllMessages(ctx, fixture.alphaID)
+	require.NoError(t, err)
+	require.Len(t, localBefore, 2)
+	require.Equal(t,
+		localBefore[0].ID,
+		duckMessageID(t, syncer.DB(), fixture.alphaID, 0),
+	)
+
+	time.Sleep(time.Millisecond)
+	localAfter := rewriteLocalMessagesPreservingContent(t, local, fixture.alphaID)
+	require.Len(t, localAfter, 2)
+	require.NotEqual(t, localBefore[0].ID, localAfter[0].ID)
+	second, err := syncer.Push(ctx, false, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, second.SessionsPushed)
+	assert.Equal(t, len(localAfter), second.MessagesPushed)
+	assert.NotEqual(t,
+		rowIDBefore,
+		duckMessageRowID(t, syncer.DB(), fixture.alphaID, 0),
+		"local message id changes must refresh DuckDB message rows",
+	)
+	assert.Equal(t,
+		localAfter[0].ID,
+		duckMessageID(t, syncer.DB(), fixture.alphaID, 0),
+	)
+	assert.Equal(t, 1, duckPinnedMessageMirrorJoinCount(
+		t, syncer.DB(), fixture.alphaID,
+	), "curation refresh must point pins at mirrored messages")
+}
+
 func TestSyncIncrementalToolResultEventChangeUpdatesMirror(t *testing.T) {
 	ctx := context.Background()
 	local := newLocalDB(t)
@@ -329,6 +370,31 @@ func appendLocalMessage(
 	require.NoError(t, err)
 }
 
+func rewriteLocalMessagesPreservingContent(
+	t *testing.T, local *db.DB, sessionID string,
+) []db.Message {
+	t.Helper()
+	ctx := context.Background()
+	sess, err := local.GetSession(ctx, sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	msgs, err := local.GetAllMessages(ctx, sessionID)
+	require.NoError(t, err)
+	modifiedAt := syncNow()
+	sess.LocalModifiedAt = &modifiedAt
+	sess.MessageCount = len(msgs)
+	_, err = local.WriteSessionBatchAtomic([]db.SessionBatchWrite{{
+		Session:         *sess,
+		Messages:        msgs,
+		DataVersion:     1,
+		ReplaceMessages: true,
+	}})
+	require.NoError(t, err)
+	rewritten, err := local.GetAllMessages(ctx, sessionID)
+	require.NoError(t, err)
+	return rewritten
+}
+
 func writeToolResultStatusSession(
 	t *testing.T, local *db.DB, sessionID, status string,
 ) {
@@ -453,6 +519,35 @@ func duckMessageRowID(
 		sessionID, ordinal,
 	).Scan(&rowID))
 	return rowID
+}
+
+func duckMessageID(
+	t *testing.T, conn *sql.DB, sessionID string, ordinal int,
+) int64 {
+	t.Helper()
+	var id int64
+	require.NoError(t, conn.QueryRow(
+		`SELECT id FROM messages WHERE session_id = ? AND ordinal = ?`,
+		sessionID, ordinal,
+	).Scan(&id))
+	return id
+}
+
+func duckPinnedMessageMirrorJoinCount(
+	t *testing.T, conn *sql.DB, sessionID string,
+) int {
+	t.Helper()
+	var count int
+	require.NoError(t, conn.QueryRow(`
+		SELECT COUNT(*)
+		FROM pinned_messages p
+		JOIN messages m
+			ON m.session_id = p.session_id
+			AND m.id = p.message_id
+		WHERE p.session_id = ?`,
+		sessionID,
+	).Scan(&count))
+	return count
 }
 
 type checkpointSpy struct {

--- a/internal/duckdb/sync_fastpath_test.go
+++ b/internal/duckdb/sync_fastpath_test.go
@@ -186,6 +186,38 @@ func TestSyncIncrementalMessageIDChangeFallsBackToRewrite(t *testing.T) {
 	), "curation refresh must point pins at mirrored messages")
 }
 
+func TestSyncIncrementalNullMirrorMessageIDFallsBackToRewrite(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	fixture := seedDuckDBSyncFixture(t, local)
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+
+	first, err := syncer.Push(ctx, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, first.SessionsPushed)
+	localMessages, err := local.GetAllMessages(ctx, fixture.betaID)
+	require.NoError(t, err)
+	require.Len(t, localMessages, 1)
+	_, err = syncer.DB().ExecContext(ctx,
+		`UPDATE messages SET id = NULL WHERE session_id = ? AND ordinal = ?`,
+		fixture.betaID, 0,
+	)
+	require.NoError(t, err)
+
+	time.Sleep(time.Millisecond)
+	renameSessionOnly(t, local, fixture.betaID, "beta null id repair")
+	second, err := syncer.Push(ctx, false, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, second.SessionsPushed)
+	assert.Equal(t, 1, second.MessagesPushed)
+	assert.Equal(t,
+		localMessages[0].ID,
+		duckMessageID(t, syncer.DB(), fixture.betaID, 0),
+		"NULL mirrored message ids must force a repair rewrite",
+	)
+}
+
 func TestSyncIncrementalToolResultEventChangeUpdatesMirror(t *testing.T) {
 	ctx := context.Background()
 	local := newLocalDB(t)

--- a/internal/duckdb/sync_fastpath_test.go
+++ b/internal/duckdb/sync_fastpath_test.go
@@ -352,6 +352,46 @@ func TestSyncCheckpointFailureDoesNotAdvanceWatermark(t *testing.T) {
 	assert.Empty(t, watermark)
 }
 
+func TestSyncCheckpointFailureAfterHardDeleteDoesNotKeepStaleFingerprint(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	fixture := seedDuckDBSyncFixture(t, local)
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+
+	first, err := syncer.Push(ctx, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, first.SessionsPushed)
+	firstWatermark, err := local.GetSyncState(lastPushStateKey)
+	require.NoError(t, err)
+	fingerprints, err := readSyncFingerprintsWithKey(local, lastPushBoundaryStateKey)
+	require.NoError(t, err)
+	require.Contains(t, fingerprints, fixture.betaID)
+
+	require.NoError(t, local.SoftDeleteSession(fixture.betaID))
+	deleted, err := local.DeleteSessionIfTrashed(fixture.betaID)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, deleted)
+	policy := &checkpointSpy{err: errors.New("checkpoint failed")}
+	syncer.maintenance = policy
+
+	_, err = syncer.Push(ctx, false, nil)
+	require.ErrorContains(t, err, "checkpoint failed")
+	assert.Equal(t, 1, policy.calls)
+	assertDuckDBCountWhere(t, syncer.DB(), "sessions", "id = ?", fixture.betaID, 0)
+	watermarkAfterFailure, err := local.GetSyncState(lastPushStateKey)
+	require.NoError(t, err)
+	assert.Equal(t, firstWatermark, watermarkAfterFailure)
+
+	policy.err = nil
+	retry, err := syncer.Push(ctx, false, nil)
+	require.NoError(t, err)
+	assert.Zero(t, retry.SessionsPushed)
+	assert.Equal(t, 1, policy.calls, "retry should only repair local sync state")
+	fingerprints, err = readSyncFingerprintsWithKey(local, lastPushBoundaryStateKey)
+	require.NoError(t, err)
+	assert.NotContains(t, fingerprints, fixture.betaID)
+}
+
 func TestSyncCheckpointPolicySkipsRemoteQuackTargets(t *testing.T) {
 	ctx := context.Background()
 	local := newLocalDB(t)

--- a/internal/duckdb/sync_fastpath_test.go
+++ b/internal/duckdb/sync_fastpath_test.go
@@ -424,13 +424,11 @@ func rewriteLocalMessagesPreservingContent(
 	require.NotNil(t, sess)
 	msgs, err := local.GetAllMessages(ctx, sessionID)
 	require.NoError(t, err)
-	modifiedAt := time.Now().UTC().Format(localSyncTimestampLayout)
-	sess.LocalModifiedAt = &modifiedAt
 	sess.MessageCount = len(msgs)
 	_, err = local.WriteSessionBatchAtomic([]db.SessionBatchWrite{{
 		Session:         *sess,
 		Messages:        msgs,
-		DataVersion:     1,
+		DataVersion:     1, // stamps local_modified_at for Push(false) selection
 		ReplaceMessages: true,
 	}})
 	require.NoError(t, err)
@@ -499,12 +497,10 @@ func writeFastPathLifecycleSession(
 		sessionID, "alpha", "lifecycle first",
 		"2026-01-21T00:00:00.000Z", len(messages),
 	)
-	modifiedAt := time.Now().UTC().Format(localSyncTimestampLayout)
-	sess.LocalModifiedAt = &modifiedAt
 	write := db.SessionBatchWrite{
 		Session:         sess,
 		Messages:        messages,
-		DataVersion:     1,
+		DataVersion:     1, // stamps local_modified_at for Push(false) selection
 		ReplaceMessages: true,
 	}
 	if usageInputTokens > 0 {

--- a/internal/duckdb/sync_fastpath_test.go
+++ b/internal/duckdb/sync_fastpath_test.go
@@ -218,6 +218,67 @@ func TestSyncIncrementalNullMirrorMessageIDFallsBackToRewrite(t *testing.T) {
 	)
 }
 
+func TestPushSessionSkipFastPathRefreshesPinnedMessages(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	fixture := seedDuckDBSyncFixture(t, local)
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+
+	first, err := syncer.Push(ctx, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, first.SessionsPushed)
+	msgs, err := local.GetAllMessages(ctx, fixture.alphaID)
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+	note := "skip fast path pin"
+	_, err = local.PinMessage(fixture.alphaID, msgs[0].ID, &note)
+	require.NoError(t, err)
+	sess, err := local.GetSession(ctx, fixture.alphaID)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	pushedMessages, err := syncer.pushSingleSession(ctx, *sess, false)
+	require.NoError(t, err)
+
+	assert.Zero(t, pushedMessages)
+	assert.Equal(t, note, duckPinnedMessageNote(
+		t, syncer.DB(), fixture.alphaID, msgs[0].ID,
+	))
+}
+
+func TestPushSessionAppendFastPathRefreshesPinnedMessages(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	fixture := seedDuckDBSyncFixture(t, local)
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+
+	first, err := syncer.Push(ctx, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, first.SessionsPushed)
+	msgs, err := local.GetAllMessages(ctx, fixture.alphaID)
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+	note := "append fast path pin"
+	_, err = local.PinMessage(fixture.alphaID, msgs[0].ID, &note)
+	require.NoError(t, err)
+	appendLocalMessage(t, local, fixture.alphaID, 3, syncMessage(
+		fixture.alphaID, 2, "assistant", "append after pin",
+		time.Now().UTC().Format(localSyncTimestampLayout),
+	))
+	sess, err := local.GetSession(ctx, fixture.alphaID)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	pushedMessages, err := syncer.pushSingleSession(ctx, *sess, false)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, pushedMessages)
+	assert.Equal(t, note, duckPinnedMessageNote(
+		t, syncer.DB(), fixture.alphaID, msgs[0].ID,
+	))
+	assertDuckDBCountWhere(t, syncer.DB(), "messages", "session_id = ?", fixture.alphaID, 3)
+}
+
 func TestSyncIncrementalToolResultEventChangeUpdatesMirror(t *testing.T) {
 	ctx := context.Background()
 	local := newLocalDB(t)
@@ -654,6 +715,18 @@ func duckPinnedMessageMirrorJoinCount(
 		sessionID,
 	).Scan(&count))
 	return count
+}
+
+func duckPinnedMessageNote(
+	t *testing.T, conn *sql.DB, sessionID string, messageID int64,
+) string {
+	t.Helper()
+	var note string
+	require.NoError(t, conn.QueryRow(
+		`SELECT note FROM pinned_messages WHERE session_id = ? AND message_id = ?`,
+		sessionID, messageID,
+	).Scan(&note))
+	return note
 }
 
 type checkpointSpy struct {

--- a/internal/duckdb/sync_fastpath_test.go
+++ b/internal/duckdb/sync_fastpath_test.go
@@ -1,0 +1,466 @@
+//go:build !(windows && arm64)
+
+package duckdb
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"go.kenn.io/agentsview/internal/db"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSyncIncrementalMetadataChangeSkipsMessageRewrite(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	fixture := seedDuckDBSyncFixture(t, local)
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+
+	first, err := syncer.Push(ctx, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, first.SessionsPushed)
+	rowIDBefore := duckMessageRowID(t, syncer.DB(), fixture.betaID, 0)
+
+	time.Sleep(time.Millisecond)
+	renameSessionOnly(t, local, fixture.betaID, "beta renamed")
+	second, err := syncer.Push(ctx, false, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, second.SessionsPushed)
+	assert.Equal(t, 0, second.MessagesPushed)
+	assert.Equal(t,
+		rowIDBefore,
+		duckMessageRowID(t, syncer.DB(), fixture.betaID, 0),
+		"metadata-only session pushes must not delete and recreate messages",
+	)
+}
+
+func TestSyncIncrementalAppendsOnlyNewSuffixMessages(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	const sessionID = "duck-sync-append"
+	_, err := local.WriteSessionBatchAtomic([]db.SessionBatchWrite{{
+		Session: syncSession(
+			sessionID, "alpha", "append first",
+			"2026-01-19T00:00:00.000Z", 2,
+		),
+		Messages: []db.Message{
+			syncMessage(sessionID, 0, "user", "append first", "2026-01-19T00:00:00.000Z"),
+			syncMessage(sessionID, 1, "assistant", "append reply", "2026-01-19T00:01:00.000Z"),
+		},
+		UsageEvents: []db.UsageEvent{{
+			Source:       "hermes",
+			Model:        "claude-test",
+			InputTokens:  1,
+			OutputTokens: 2,
+			OccurredAt:   "2026-01-19T00:02:00.000Z",
+			DedupKey:     "append-usage",
+		}},
+		DataVersion:     1,
+		ReplaceMessages: true,
+	}})
+	require.NoError(t, err)
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+
+	first, err := syncer.Push(ctx, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, first.SessionsPushed)
+	prefixRowID := duckMessageRowID(t, syncer.DB(), sessionID, 0)
+
+	time.Sleep(time.Millisecond)
+	appendLocalMessage(t, local, sessionID, 2, syncMessage(
+		sessionID, 2, "assistant", "append suffix",
+		time.Now().UTC().Format(localSyncTimestampLayout),
+		db.ToolCall{
+			ToolName:  "read",
+			Category:  "filesystem",
+			ToolUseID: "append-tool",
+			InputJSON: `{"path":"append.txt"}`,
+			ResultEvents: []db.ToolResultEvent{{
+				Source:        "tool",
+				Status:        "complete",
+				Content:       "append result",
+				ContentLength: len("append result"),
+				Timestamp:     time.Now().UTC().Format(localSyncTimestampLayout),
+				EventIndex:    0,
+			}},
+		},
+	), db.UsageEvent{
+		Source:       "hermes",
+		Model:        "claude-test",
+		InputTokens:  42,
+		OutputTokens: 2,
+		OccurredAt:   "2026-01-19T00:02:00.000Z",
+		DedupKey:     "append-usage",
+	})
+	second, err := syncer.Push(ctx, false, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, second.SessionsPushed)
+	assert.Equal(t, 1, second.MessagesPushed)
+	assert.Equal(t,
+		prefixRowID,
+		duckMessageRowID(t, syncer.DB(), sessionID, 0),
+		"suffix-only growth must preserve already mirrored prefix rows",
+	)
+	assertDuckDBCountWhere(t, syncer.DB(), "messages", "session_id = ?", sessionID, 3)
+	assertDuckDBCountWhere(t, syncer.DB(), "tool_calls", "session_id = ?", sessionID, 1)
+	assertDuckDBCountWhere(t, syncer.DB(), "tool_result_events", "session_id = ?", sessionID, 1)
+	var inputTokens int
+	require.NoError(t, syncer.DB().QueryRowContext(ctx,
+		`SELECT input_tokens FROM usage_events WHERE session_id = ? AND dedup_key = ?`,
+		sessionID, "append-usage",
+	).Scan(&inputTokens))
+	assert.Equal(t, 42, inputTokens)
+}
+
+func TestSyncIncrementalHistoricalMessageChangeFallsBackToRewrite(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	fixture := seedDuckDBSyncFixture(t, local)
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+
+	first, err := syncer.Push(ctx, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, first.SessionsPushed)
+	rowIDBefore := duckMessageRowID(t, syncer.DB(), fixture.alphaID, 0)
+
+	time.Sleep(time.Millisecond)
+	modifiedAt := time.Now().UTC().Format(localSyncTimestampLayout)
+	updateSession(t, local, fixture.alphaID, "alpha historical edit", modifiedAt)
+	second, err := syncer.Push(ctx, false, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, second.SessionsPushed)
+	assert.Equal(t, 1, second.MessagesPushed)
+	assert.NotEqual(t,
+		rowIDBefore,
+		duckMessageRowID(t, syncer.DB(), fixture.alphaID, 0),
+		"historical content changes must fall back to a full dependent rewrite",
+	)
+}
+
+func TestSyncIncrementalToolResultEventChangeUpdatesMirror(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	const sessionID = "duck-sync-result-event"
+	writeToolResultStatusSession(t, local, sessionID, "in_progress")
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+
+	first, err := syncer.Push(ctx, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, first.SessionsPushed)
+
+	time.Sleep(time.Millisecond)
+	writeToolResultStatusSession(t, local, sessionID, "complete")
+	second, err := syncer.Push(ctx, false, nil)
+	require.NoError(t, err)
+
+	var status string
+	require.NoError(t, syncer.DB().QueryRowContext(ctx,
+		`SELECT status FROM tool_result_events WHERE session_id = ?`,
+		sessionID,
+	).Scan(&status))
+	assert.Equal(t, 1, second.SessionsPushed)
+	assert.Equal(t, "complete", status)
+}
+
+func TestSyncIncrementalFastPathLifecycle(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	const sessionID = "duck-sync-fastpath-lifecycle"
+	writeFastPathLifecycleSession(t, local, sessionID, "in_progress", false, 0, syncNow())
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+
+	first, err := syncer.Push(ctx, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, first.SessionsPushed)
+	require.Equal(t, 2, first.MessagesPushed)
+	row0 := duckMessageRowID(t, syncer.DB(), sessionID, 0)
+	row1 := duckMessageRowID(t, syncer.DB(), sessionID, 1)
+
+	noOp, err := syncer.Push(ctx, false, nil)
+	require.NoError(t, err)
+	assert.Zero(t, noOp.SessionsPushed)
+	assert.Equal(t, row0, duckMessageRowID(t, syncer.DB(), sessionID, 0))
+	assert.Equal(t, row1, duckMessageRowID(t, syncer.DB(), sessionID, 1))
+
+	time.Sleep(time.Millisecond)
+	renameSessionOnly(t, local, sessionID, "renamed lifecycle")
+	metadataOnly, err := syncer.Push(ctx, false, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, metadataOnly.SessionsPushed)
+	assert.Zero(t, metadataOnly.MessagesPushed)
+	assert.Equal(t, row0, duckMessageRowID(t, syncer.DB(), sessionID, 0))
+	assert.Equal(t, row1, duckMessageRowID(t, syncer.DB(), sessionID, 1))
+
+	time.Sleep(time.Millisecond)
+	appendLocalMessage(t, local, sessionID, 3, lifecycleSuffixMessage(sessionID), db.UsageEvent{
+		Source:       "hermes",
+		Model:        "claude-test",
+		InputTokens:  42,
+		OutputTokens: 7,
+		OccurredAt:   "2026-01-21T00:03:00.000Z",
+		DedupKey:     "lifecycle-usage",
+	})
+	appended, err := syncer.Push(ctx, false, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, appended.SessionsPushed)
+	assert.Equal(t, 1, appended.MessagesPushed)
+	assert.Equal(t, row0, duckMessageRowID(t, syncer.DB(), sessionID, 0))
+	assert.Equal(t, row1, duckMessageRowID(t, syncer.DB(), sessionID, 1))
+	assertDuckDBCountWhere(t, syncer.DB(), "messages", "session_id = ?", sessionID, 3)
+	var inputTokens int
+	require.NoError(t, syncer.DB().QueryRowContext(ctx,
+		`SELECT input_tokens FROM usage_events WHERE session_id = ? AND dedup_key = ?`,
+		sessionID, "lifecycle-usage",
+	).Scan(&inputTokens))
+	assert.Equal(t, 42, inputTokens)
+
+	time.Sleep(time.Millisecond)
+	writeFastPathLifecycleSession(t, local, sessionID, "complete", true, 99, syncNow())
+	resultOnly, err := syncer.Push(ctx, false, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, resultOnly.SessionsPushed)
+	assert.Equal(t, 3, resultOnly.MessagesPushed)
+	assert.NotEqual(t, row1, duckMessageRowID(t, syncer.DB(), sessionID, 1))
+	var status string
+	require.NoError(t, syncer.DB().QueryRowContext(ctx,
+		`SELECT status FROM tool_result_events WHERE session_id = ?`,
+		sessionID,
+	).Scan(&status))
+	assert.Equal(t, "complete", status)
+	require.NoError(t, syncer.DB().QueryRowContext(ctx,
+		`SELECT input_tokens FROM usage_events WHERE session_id = ? AND dedup_key = ?`,
+		sessionID, "lifecycle-usage",
+	).Scan(&inputTokens))
+	assert.Equal(t, 99, inputTokens)
+}
+
+func TestSyncCheckpointPolicyRunsOnlyAfterMutatingPush(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	seedDuckDBSyncFixture(t, local)
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+	policy := &checkpointSpy{}
+	syncer.maintenance = policy
+
+	first, err := syncer.Push(ctx, true, nil)
+	require.NoError(t, err)
+	require.Equal(t, 2, first.SessionsPushed)
+	assert.Equal(t, 1, policy.calls)
+
+	second, err := syncer.Push(ctx, false, nil)
+	require.NoError(t, err)
+	require.Zero(t, second.SessionsPushed)
+	assert.Equal(t, 1, policy.calls, "no-op push must not checkpoint")
+}
+
+func TestSyncCheckpointFailureDoesNotAdvanceWatermark(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	seedDuckDBSyncFixture(t, local)
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+	policy := &checkpointSpy{err: errors.New("checkpoint failed")}
+	syncer.maintenance = policy
+
+	_, err := syncer.Push(ctx, true, nil)
+	require.ErrorContains(t, err, "checkpoint failed")
+	assert.Equal(t, 1, policy.calls)
+	assertDuckDBCount(t, syncer.DB(), "sessions", 2)
+
+	watermark, err := local.GetSyncState(lastPushStateKey)
+	require.NoError(t, err)
+	assert.Empty(t, watermark)
+}
+
+func TestDuckCheckpointDecisionRequiresFreeBlockThreshold(t *testing.T) {
+	assert.False(t, shouldCheckpointDuckDB(duckDBSize{
+		blockSize:  duckCheckpointMinFreeBytes,
+		freeBlocks: 0,
+	}))
+	assert.False(t, shouldCheckpointDuckDB(duckDBSize{
+		blockSize:  duckCheckpointMinFreeBytes - 1,
+		freeBlocks: 1,
+	}))
+	assert.True(t, shouldCheckpointDuckDB(duckDBSize{
+		blockSize:  duckCheckpointMinFreeBytes,
+		freeBlocks: 1,
+	}))
+}
+
+func renameSessionOnly(t *testing.T, local *db.DB, sessionID, displayName string) {
+	t.Helper()
+	ctx := context.Background()
+	sess, err := local.GetSession(ctx, sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	sess.DisplayName = &displayName
+	modifiedAt := time.Now().UTC().Format(localSyncTimestampLayout)
+	sess.LocalModifiedAt = &modifiedAt
+	_, err = local.WriteSessionBatchAtomic([]db.SessionBatchWrite{{
+		Session: *sess,
+	}})
+	require.NoError(t, err)
+}
+
+func appendLocalMessage(
+	t *testing.T, local *db.DB, sessionID string, newCount int, msg db.Message,
+	usageEvents ...db.UsageEvent,
+) {
+	t.Helper()
+	ctx := context.Background()
+	sess, err := local.GetSession(ctx, sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	modifiedAt := time.Now().UTC().Format(localSyncTimestampLayout)
+	sess.LocalModifiedAt = &modifiedAt
+	sess.MessageCount = newCount
+	_, err = local.WriteSessionBatchAtomic([]db.SessionBatchWrite{{
+		Session:     *sess,
+		Messages:    []db.Message{msg},
+		UsageEvents: usageEvents,
+	}})
+	require.NoError(t, err)
+}
+
+func writeToolResultStatusSession(
+	t *testing.T, local *db.DB, sessionID, status string,
+) {
+	t.Helper()
+	modifiedAt := time.Now().UTC().Format(localSyncTimestampLayout)
+	msg := syncMessage(
+		sessionID, 0, "assistant", "tool result event",
+		"2026-01-20T00:00:00.000Z",
+		db.ToolCall{
+			ToolName:  "read",
+			Category:  "filesystem",
+			ToolUseID: "result-event-tool",
+			InputJSON: `{"path":"event.txt"}`,
+			ResultEvents: []db.ToolResultEvent{{
+				Source:        "tool",
+				Status:        status,
+				Content:       "event result",
+				ContentLength: len("event result"),
+				Timestamp:     "2026-01-20T00:00:30.000Z",
+				EventIndex:    0,
+			}},
+		},
+	)
+	sess := syncSession(
+		sessionID, "alpha", "tool result event",
+		"2026-01-20T00:00:00.000Z", 1,
+	)
+	sess.LocalModifiedAt = &modifiedAt
+	_, err := local.WriteSessionBatchAtomic([]db.SessionBatchWrite{{
+		Session:         sess,
+		Messages:        []db.Message{msg},
+		DataVersion:     1,
+		ReplaceMessages: true,
+	}})
+	require.NoError(t, err)
+}
+
+func writeFastPathLifecycleSession(
+	t *testing.T,
+	local *db.DB,
+	sessionID string,
+	resultStatus string,
+	includeSuffix bool,
+	usageInputTokens int,
+	modifiedAt string,
+) {
+	t.Helper()
+	messages := []db.Message{
+		syncMessage(
+			sessionID, 0, "user", "lifecycle first",
+			"2026-01-21T00:00:00.000Z",
+		),
+		lifecycleToolMessage(sessionID, resultStatus),
+	}
+	if includeSuffix {
+		messages = append(messages, lifecycleSuffixMessage(sessionID))
+	}
+	sess := syncSession(
+		sessionID, "alpha", "lifecycle first",
+		"2026-01-21T00:00:00.000Z", len(messages),
+	)
+	sess.LocalModifiedAt = &modifiedAt
+	write := db.SessionBatchWrite{
+		Session:         sess,
+		Messages:        messages,
+		DataVersion:     1,
+		ReplaceMessages: true,
+	}
+	if usageInputTokens > 0 {
+		write.UsageEvents = []db.UsageEvent{{
+			Source:       "hermes",
+			Model:        "claude-test",
+			InputTokens:  usageInputTokens,
+			OutputTokens: 7,
+			OccurredAt:   "2026-01-21T00:03:00.000Z",
+			DedupKey:     "lifecycle-usage",
+		}}
+	}
+	_, err := local.WriteSessionBatchAtomic([]db.SessionBatchWrite{write})
+	require.NoError(t, err)
+}
+
+func lifecycleToolMessage(sessionID, resultStatus string) db.Message {
+	return syncMessage(
+		sessionID, 1, "assistant", "lifecycle tool",
+		"2026-01-21T00:01:00.000Z",
+		db.ToolCall{
+			ToolName:  "read",
+			Category:  "filesystem",
+			ToolUseID: "lifecycle-tool",
+			InputJSON: `{"path":"lifecycle.txt"}`,
+			ResultEvents: []db.ToolResultEvent{{
+				Source:        "tool",
+				Status:        resultStatus,
+				Content:       "lifecycle result",
+				ContentLength: len("lifecycle result"),
+				Timestamp:     "2026-01-21T00:01:30.000Z",
+				EventIndex:    0,
+			}},
+		},
+	)
+}
+
+func lifecycleSuffixMessage(sessionID string) db.Message {
+	return syncMessage(
+		sessionID, 2, "assistant", "lifecycle suffix",
+		"2026-01-21T00:02:00.000Z",
+	)
+}
+
+func syncNow() string {
+	return time.Now().UTC().Format(localSyncTimestampLayout)
+}
+
+func duckMessageRowID(
+	t *testing.T, conn *sql.DB, sessionID string, ordinal int,
+) int64 {
+	t.Helper()
+	var rowID int64
+	require.NoError(t, conn.QueryRow(
+		`SELECT rowid FROM messages WHERE session_id = ? AND ordinal = ?`,
+		sessionID, ordinal,
+	).Scan(&rowID))
+	return rowID
+}
+
+type checkpointSpy struct {
+	calls int
+	err   error
+}
+
+func (s *checkpointSpy) checkpointAfterPush(context.Context, *sql.DB) error {
+	s.calls++
+	return s.err
+}

--- a/internal/duckdb/sync_fastpath_test.go
+++ b/internal/duckdb/sync_fastpath_test.go
@@ -424,6 +424,8 @@ func rewriteLocalMessagesPreservingContent(
 	require.NotNil(t, sess)
 	msgs, err := local.GetAllMessages(ctx, sessionID)
 	require.NoError(t, err)
+	modifiedAt := time.Now().UTC().Format(localSyncTimestampLayout)
+	sess.LocalModifiedAt = &modifiedAt
 	sess.MessageCount = len(msgs)
 	_, err = local.WriteSessionBatchAtomic([]db.SessionBatchWrite{{
 		Session:         *sess,
@@ -497,6 +499,8 @@ func writeFastPathLifecycleSession(
 		sessionID, "alpha", "lifecycle first",
 		"2026-01-21T00:00:00.000Z", len(messages),
 	)
+	modifiedAt := time.Now().UTC().Format(localSyncTimestampLayout)
+	sess.LocalModifiedAt = &modifiedAt
 	write := db.SessionBatchWrite{
 		Session:         sess,
 		Messages:        messages,

--- a/internal/duckdb/sync_fastpath_test.go
+++ b/internal/duckdb/sync_fastpath_test.go
@@ -215,7 +215,7 @@ func TestSyncIncrementalFastPathLifecycle(t *testing.T) {
 	ctx := context.Background()
 	local := newLocalDB(t)
 	const sessionID = "duck-sync-fastpath-lifecycle"
-	writeFastPathLifecycleSession(t, local, sessionID, "in_progress", false, 0, syncNow())
+	writeFastPathLifecycleSession(t, local, sessionID, "in_progress", false, 0)
 	syncer := newInMemoryTestSync(t, local, SyncOptions{})
 
 	first, err := syncer.Push(ctx, true, nil)
@@ -264,7 +264,7 @@ func TestSyncIncrementalFastPathLifecycle(t *testing.T) {
 	assert.Equal(t, 42, inputTokens)
 
 	time.Sleep(time.Millisecond)
-	writeFastPathLifecycleSession(t, local, sessionID, "complete", true, 99, syncNow())
+	writeFastPathLifecycleSession(t, local, sessionID, "complete", true, 99)
 	resultOnly, err := syncer.Push(ctx, false, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, resultOnly.SessionsPushed)
@@ -318,6 +318,18 @@ func TestSyncCheckpointFailureDoesNotAdvanceWatermark(t *testing.T) {
 	watermark, err := local.GetSyncState(lastPushStateKey)
 	require.NoError(t, err)
 	assert.Empty(t, watermark)
+}
+
+func TestSyncCheckpointPolicySkipsRemoteQuackTargets(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+	policy := &checkpointSpy{err: errors.New("checkpoint should not run")}
+	syncer.connectionKind = duckDBQuackClientConnection
+	syncer.maintenance = policy
+
+	require.NoError(t, syncer.checkpointAfterMutatingPush(ctx))
+	assert.Zero(t, policy.calls)
 }
 
 func TestDuckCheckpointDecisionRequiresFreeBlockThreshold(t *testing.T) {
@@ -380,8 +392,6 @@ func rewriteLocalMessagesPreservingContent(
 	require.NotNil(t, sess)
 	msgs, err := local.GetAllMessages(ctx, sessionID)
 	require.NoError(t, err)
-	modifiedAt := syncNow()
-	sess.LocalModifiedAt = &modifiedAt
 	sess.MessageCount = len(msgs)
 	_, err = local.WriteSessionBatchAtomic([]db.SessionBatchWrite{{
 		Session:         *sess,
@@ -439,7 +449,6 @@ func writeFastPathLifecycleSession(
 	resultStatus string,
 	includeSuffix bool,
 	usageInputTokens int,
-	modifiedAt string,
 ) {
 	t.Helper()
 	messages := []db.Message{
@@ -456,7 +465,6 @@ func writeFastPathLifecycleSession(
 		sessionID, "alpha", "lifecycle first",
 		"2026-01-21T00:00:00.000Z", len(messages),
 	)
-	sess.LocalModifiedAt = &modifiedAt
 	write := db.SessionBatchWrite{
 		Session:         sess,
 		Messages:        messages,
@@ -503,10 +511,6 @@ func lifecycleSuffixMessage(sessionID string) db.Message {
 		sessionID, 2, "assistant", "lifecycle suffix",
 		"2026-01-21T00:02:00.000Z",
 	)
-}
-
-func syncNow() string {
-	return time.Now().UTC().Format(localSyncTimestampLayout)
 }
 
 func duckMessageRowID(

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -1906,6 +1906,14 @@ func (s *Sync) pushMessages(
 				"computing local tool_call fingerprint: %w", err,
 			)
 		}
+		localFP.ToolResultFP, err = localToolResultEventPGFingerprint(
+			s.local, sessionID,
+		)
+		if err != nil {
+			return 0, fmt.Errorf(
+				"computing local tool_result_event fingerprint: %w", err,
+			)
+		}
 		localFP.TokenFP, err = s.local.MessageTokenFingerprint(sessionID)
 		if err != nil {
 			return 0, fmt.Errorf(
@@ -1970,6 +1978,13 @@ func (s *Sync) pushMessages(
 					err,
 				)
 			}
+			pgResultFP, err := pgToolResultEventFingerprint(ctx, tx, sessionID)
+			if err != nil {
+				return 0, fmt.Errorf(
+					"computing pg tool_result_event fingerprint: %w",
+					err,
+				)
+			}
 			pgUsageFP, err := pgUsageEventFingerprint(ctx, tx, sessionID)
 			if err != nil {
 				return 0, fmt.Errorf(
@@ -1988,6 +2003,7 @@ func (s *Sync) pushMessages(
 				localFP.ToolCallCount == pgToolAgg.Count &&
 				localFP.ToolCallSum == pgToolAgg.Sum &&
 				localFP.ToolCallFP == pgTCFP &&
+				localFP.ToolResultFP == pgResultFP &&
 				localFP.TokenFP == pgTokenFP &&
 				localFP.UsageEventFP == pgUsageFP {
 				return 0, nil

--- a/internal/postgres/push_fingerprint.go
+++ b/internal/postgres/push_fingerprint.go
@@ -34,6 +34,7 @@ type pushMessageComparison struct {
 	MessageTokenFingerprint map[string]string
 	ToolCallAggregates      map[string]pushToolCallAggregate
 	ToolCallFingerprint     map[string]string
+	ToolResultFingerprint   map[string]string
 	UsageEventFingerprint   map[string]string
 }
 
@@ -48,6 +49,7 @@ type pushLocalMessageFingerprint struct {
 	ToolCallCount int
 	ToolCallSum   int64
 	ToolCallFP    string
+	ToolResultFP  string
 	TokenFP       string
 	UsageEventFP  string
 }
@@ -78,6 +80,7 @@ func readPushSessionMessageComparisons(
 		MessageTokenFingerprint: make(map[string]string, len(sessionIDs)),
 		ToolCallAggregates:      make(map[string]pushToolCallAggregate, len(sessionIDs)),
 		ToolCallFingerprint:     make(map[string]string, len(sessionIDs)),
+		ToolResultFingerprint:   make(map[string]string, len(sessionIDs)),
 		UsageEventFingerprint:   make(map[string]string, len(sessionIDs)),
 	}
 
@@ -120,6 +123,11 @@ func readPushSessionMessageComparisons(
 		}
 		if err := loadPushToolCallFingerprints(
 			ctx, tx, chunk, comparisons.ToolCallFingerprint,
+		); err != nil {
+			return nil, err
+		}
+		if err := loadPushToolResultEventFingerprints(
+			ctx, tx, chunk, comparisons.ToolResultFingerprint,
 		); err != nil {
 			return nil, err
 		}
@@ -590,6 +598,146 @@ func loadPushUsageEventFingerprints(
 	return nil
 }
 
+func loadPushToolResultEventFingerprints(
+	ctx context.Context,
+	tx *sql.Tx,
+	sessionIDs []string,
+	out map[string]string,
+) error {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT session_id, tool_call_message_ordinal, call_index, event_index,
+			COALESCE(tool_use_id, ''), COALESCE(agent_id, ''),
+			COALESCE(subagent_session_id, ''), source, status,
+			content, content_length, timestamp
+		 FROM tool_result_events
+		WHERE session_id = ANY($1)
+		ORDER BY session_id, tool_call_message_ordinal ASC, call_index ASC, event_index ASC
+	`, sessionIDs)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	builders := make(map[string]*strings.Builder, len(sessionIDs))
+	for rows.Next() {
+		var sessionID string
+		var messageOrdinal, callIndex, eventIndex, contentLength int
+		var toolUseID, agentID, subagentSessionID string
+		var source, status, content string
+		var timestamp sql.NullTime
+		if err := rows.Scan(
+			&sessionID, &messageOrdinal, &callIndex, &eventIndex,
+			&toolUseID, &agentID, &subagentSessionID,
+			&source, &status, &content, &contentLength, &timestamp,
+		); err != nil {
+			return err
+		}
+		b := builders[sessionID]
+		if b == nil {
+			b = &strings.Builder{}
+			builders[sessionID] = b
+		}
+		timestampText := ""
+		if timestamp.Valid {
+			timestampText = FormatISO8601(timestamp.Time)
+		}
+		toolUseID = db.SanitizeUTF8(toolUseID)
+		agentID = db.SanitizeUTF8(agentID)
+		subagentSessionID = db.SanitizeUTF8(subagentSessionID)
+		source = db.SanitizeUTF8(source)
+		status = db.SanitizeUTF8(status)
+		content = db.SanitizeUTF8(content)
+		contentSum := sha256.Sum256([]byte(content))
+		fmt.Fprintf(
+			b,
+			"%d|%d|%d|%d:%s|%d:%s|%d:%s|%d:%s|%d:%s|%d|%x|%d:%s;",
+			messageOrdinal, callIndex, eventIndex,
+			len(toolUseID), toolUseID,
+			len(agentID), agentID,
+			len(subagentSessionID), subagentSessionID,
+			len(source), source,
+			len(status), status,
+			contentLength,
+			contentSum,
+			len(timestampText), timestampText,
+		)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	for sessionID, b := range builders {
+		out[sessionID] = b.String()
+	}
+	return nil
+}
+
+func localToolResultEventPGFingerprint(
+	local *db.DB, sessionID string,
+) (string, error) {
+	return local.ToolResultEventFingerprintWithTimestampNormalizer(
+		sessionID,
+		pgPushTimestampFingerprintText,
+	)
+}
+
+func pgToolResultEventFingerprint(
+	ctx context.Context, tx *sql.Tx, sessionID string,
+) (string, error) {
+	rows, err := tx.QueryContext(ctx,
+		`SELECT tool_call_message_ordinal, call_index, event_index,
+			COALESCE(tool_use_id, ''), COALESCE(agent_id, ''),
+			COALESCE(subagent_session_id, ''), source, status,
+			content, content_length, timestamp
+		 FROM tool_result_events
+		 WHERE session_id = $1
+		 ORDER BY tool_call_message_ordinal ASC, call_index ASC, event_index ASC`,
+		sessionID,
+	)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+
+	var b strings.Builder
+	for rows.Next() {
+		var messageOrdinal, callIndex, eventIndex, contentLength int
+		var toolUseID, agentID, subagentSessionID string
+		var source, status, content string
+		var timestamp sql.NullTime
+		if err := rows.Scan(
+			&messageOrdinal, &callIndex, &eventIndex,
+			&toolUseID, &agentID, &subagentSessionID,
+			&source, &status, &content, &contentLength, &timestamp,
+		); err != nil {
+			return "", err
+		}
+		timestampText := ""
+		if timestamp.Valid {
+			timestampText = FormatISO8601(timestamp.Time)
+		}
+		toolUseID = db.SanitizeUTF8(toolUseID)
+		agentID = db.SanitizeUTF8(agentID)
+		subagentSessionID = db.SanitizeUTF8(subagentSessionID)
+		source = db.SanitizeUTF8(source)
+		status = db.SanitizeUTF8(status)
+		content = db.SanitizeUTF8(content)
+		contentSum := sha256.Sum256([]byte(content))
+		fmt.Fprintf(&b,
+			"%d|%d|%d|%d:%s|%d:%s|%d:%s|%d:%s|%d:%s|%d|%x|%d:%s;",
+			messageOrdinal, callIndex, eventIndex,
+			len(toolUseID), toolUseID,
+			len(agentID), agentID,
+			len(subagentSessionID), subagentSessionID,
+			len(source), source,
+			len(status), status,
+			contentLength,
+			contentSum,
+			len(timestampText), timestampText,
+		)
+	}
+	return b.String(), rows.Err()
+}
+
 func shouldSkipSessionMessages(
 	sessionID string,
 	localCount int,
@@ -615,6 +763,7 @@ func shouldSkipSessionMessages(
 		localFP.ToolCallCount == comparisons.ToolCallAggregates[sessionID].Count &&
 		localFP.ToolCallSum == comparisons.ToolCallAggregates[sessionID].Sum &&
 		localFP.ToolCallFP == comparisons.ToolCallFingerprint[sessionID] &&
+		localFP.ToolResultFP == comparisons.ToolResultFingerprint[sessionID] &&
 		localFP.TokenFP == comparisons.MessageTokenFingerprint[sessionID] &&
 		localFP.UsageEventFP == comparisons.UsageEventFingerprint[sessionID]
 }

--- a/internal/postgres/push_fingerprint_test.go
+++ b/internal/postgres/push_fingerprint_test.go
@@ -22,6 +22,7 @@ func TestReadPushSessionMessageComparisonsNoSessions(t *testing.T) {
 	assert.Empty(t, comparisons.MessageTokenFingerprint)
 	assert.Empty(t, comparisons.ToolCallAggregates)
 	assert.Empty(t, comparisons.ToolCallFingerprint)
+	assert.Empty(t, comparisons.ToolResultFingerprint)
 	assert.Empty(t, comparisons.UsageEventFingerprint)
 }
 
@@ -37,6 +38,7 @@ func TestShouldSkipSessionMessagesGuardsCountAndNilMaps(t *testing.T) {
 		MessageTokenFingerprint: map[string]string{"sess": ""},
 		ToolCallAggregates:      map[string]pushToolCallAggregate{"sess": {}},
 		ToolCallFingerprint:     map[string]string{"sess": ""},
+		ToolResultFingerprint:   map[string]string{"sess": ""},
 		UsageEventFingerprint:   map[string]string{"sess": ""},
 	}
 	localFP := pushLocalMessageFingerprint{Sum: 1, Max: 1, Min: 1}

--- a/internal/postgres/push_test.go
+++ b/internal/postgres/push_test.go
@@ -1526,6 +1526,9 @@ func TestShouldSkipSessionMessagesInBatchedPush(t *testing.T) {
 		ToolCallFingerprint: map[string]string{
 			sessionID: "toolcalls",
 		},
+		ToolResultFingerprint: map[string]string{
+			sessionID: "results",
+		},
 		UsageEventFingerprint: map[string]string{
 			sessionID: "usage",
 		},
@@ -1541,6 +1544,7 @@ func TestShouldSkipSessionMessagesInBatchedPush(t *testing.T) {
 		ToolCallCount: 1,
 		ToolCallSum:   99,
 		ToolCallFP:    "toolcalls",
+		ToolResultFP:  "results",
 		TokenFP:       "tokens",
 		UsageEventFP:  "usage",
 	}
@@ -1554,6 +1558,12 @@ func TestShouldSkipSessionMessagesInBatchedPush(t *testing.T) {
 	assert.False(t, shouldSkipSessionMessages(
 		sessionID, 2, changedFP, false, baseComparisons,
 	), "tool-call sum mismatch should force push")
+
+	changedFP = unchangedFP
+	changedFP.ToolResultFP = "changed-results"
+	assert.False(t, shouldSkipSessionMessages(
+		sessionID, 2, changedFP, false, baseComparisons,
+	), "tool-result event mismatch should force push")
 
 	assert.False(t, shouldSkipSessionMessages(
 		sessionID, 2, unchangedFP, true, baseComparisons,


### PR DESCRIPTION
DuckDB mirror pushes now avoid rewriting session dependents when the target already matches local message, tool, result-event, and usage fingerprints. Suffix-only active-session growth appends just the new messages and dependent rows, while historical or dependent-row mismatches still fall back to a full replacement.

The skip and append fast paths refresh per-session pinned messages and secret findings in the same mutation transaction, so a later partial push failure cannot leave those dependent rows stale while persisting fresh fingerprints.

Incremental DuckDB pushes also repair cached fingerprints whose mirror rows are missing by re-adding the unchanged local session to the push candidates before skip filtering. That keeps retry and partial-failure cleanup from advancing the watermark while the mirror is still missing a session.

The DuckDB backend runs threshold-gated checkpoint maintenance after committed mutating pushes, before local watermark advancement. PostgreSQL skip fingerprints now include tool-result events so both push backends agree on stale event detection.

The main review points are `internal/duckdb/sync.go`, `internal/duckdb/push.go`, `internal/duckdb/push_fingerprint.go`, `internal/duckdb/checkpoint.go`, and the lifecycle coverage in `internal/duckdb/sync_fastpath_test.go`. Checkpointing is intentionally partial reclamation; large historical rewrites may still require full-copy compaction outside the normal push path.
