### PR TITLE
feat(insights): analyze a single session

### DIFF
--- a/frontend/src/lib/api/generated/models/DbInsight.ts
+++ b/frontend/src/lib/api/generated/models/DbInsight.ts
@@ -23,4 +23,3 @@ export type DbInsight = {
   template_version?: string;
   type: string;
 };
-

--- a/frontend/src/lib/api/generated/models/GenerateInsightRequest.ts
+++ b/frontend/src/lib/api/generated/models/GenerateInsightRequest.ts
@@ -14,7 +14,7 @@ export type GenerateInsightRequest = {
   llm_opt_in?: boolean;
   project?: string;
   prompt?: string;
+  session_id?: string;
   timezone?: string;
   type: string;
 };
-

--- a/frontend/src/lib/api/types/insights.ts
+++ b/frontend/src/lib/api/types/insights.ts
@@ -62,6 +62,7 @@ export interface GenerateInsightRequest {
   date_from: string;
   date_to: string;
   project?: string;
+  session_id?: string;
   prompt?: string;
   agent?: AgentName;
   // IANA timezone the date range is expressed in, so the server's activity

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -9,6 +9,7 @@
     EllipsisVerticalIcon,
     FileTextIcon,
     FolderIcon,
+    LightbulbIcon,
     LinkIcon,
     SearchIcon,
     SquareTerminalIcon,
@@ -34,6 +35,7 @@
   import SignalPanel from "../content/SignalPanel.svelte";
   import { sessions } from "../../stores/sessions.svelte.js";
   import { router } from "../../stores/router.svelte.js";
+  import { insights } from "../../stores/insights.svelte.js";
   import {
     supportsResume,
     buildResumeCommand,
@@ -241,6 +243,12 @@
     copiedLinkTimer = setTimeout(() => {
       if (copiedLinkId === id) copiedLinkId = "";
     }, 1500);
+  }
+
+  function handleAgentAnalysis() {
+    if (!session) return;
+    insights.generateForSession(session);
+    router.navigate("insights");
   }
 
   function toggleMenu() {
@@ -761,6 +769,14 @@
           <ChartColumnIcon size="13" strokeWidth="2" aria-hidden="true" />
         </button>
         <button
+          class="insight-btn"
+          title={m.insights_page_agent_analysis()}
+          aria-label={m.insights_page_agent_analysis()}
+          onclick={handleAgentAnalysis}
+        >
+          <LightbulbIcon size="13" strokeWidth="2" aria-hidden="true" />
+        </button>
+        <button
           class="find-btn"
           class:find-btn--active={inSessionSearch.isOpen}
           title={m.session_breadcrumb_find_in_session_shortcut()}
@@ -1177,6 +1193,26 @@
   }
 
   .find-btn:hover {
+    background: var(--bg-surface-hover);
+    color: var(--accent-blue);
+  }
+
+  .insight-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    border: none;
+    border-radius: var(--radius-sm, 4px);
+    background: transparent;
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+    flex-shrink: 0;
+  }
+
+  .insight-btn:hover {
     background: var(--bg-surface-hover);
     color: var(--accent-blue);
   }

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
@@ -18,6 +18,17 @@ import {
 } from "../../api/generated/index";
 import { messages } from "../../stores/messages.svelte.js";
 import { setLocale } from "../../i18n/index.js";
+import { router } from "../../stores/router.svelte.js";
+
+const { generateForSession } = vi.hoisted(() => ({
+  generateForSession: vi.fn(),
+}));
+
+vi.mock("../../stores/insights.svelte.js", () => ({
+  insights: {
+    generateForSession,
+  },
+}));
 
 vi.mock("../../api/client.js", () => ({
   listOpeners: vi.fn().mockResolvedValue({ openers: [] }),
@@ -155,6 +166,7 @@ async function flushPromises() {
 }
 
 beforeEach(() => {
+  generateForSession.mockReset();
   openersService.getApiV1Openers
     .mockReset()
     .mockResolvedValue({ openers: [] });
@@ -415,6 +427,30 @@ describe("SessionBreadcrumb", () => {
       "2.4k ctx / 180 out",
     );
 
+    unmount(component);
+  });
+
+  it("starts single-session agent analysis from the top bar", async () => {
+    const navigateSpy = vi.spyOn(router, "navigate");
+    const session = makeSession("claude");
+    const component = mount(SessionBreadcrumb, {
+      target: document.body,
+      props: {
+        session,
+        onBack: () => {},
+      },
+    });
+
+    await tick();
+    const button = document.querySelector<HTMLButtonElement>(".insight-btn");
+    expect(button).toBeTruthy();
+
+    button!.click();
+
+    expect(generateForSession).toHaveBeenCalledWith(session);
+    expect(navigateSpy).toHaveBeenCalledWith("insights");
+
+    navigateSpy.mockRestore();
     unmount(component);
   });
 

--- a/frontend/src/lib/stores/insights.svelte.ts
+++ b/frontend/src/lib/stores/insights.svelte.ts
@@ -6,6 +6,7 @@ import type {
   CannedInsightKind,
   AutomatedScope,
   InsightGenerationFilters,
+  Session,
 } from "../api/types.js";
 import {
   ApiError as GeneratedApiError,
@@ -29,6 +30,7 @@ export interface InsightTask {
   kind?: CannedInsightKind;
   promptText: string;
   automatedScope: AutomatedScope;
+  sessionId?: string;
   sessionFilters?: InsightGenerationFilters;
   status: "generating" | "done" | "error";
   phase: string;
@@ -48,6 +50,7 @@ interface GenerationSnapshot {
   kind?: CannedInsightKind;
   promptText: string;
   automatedScope: AutomatedScope;
+  sessionId?: string;
   sessionFilters?: InsightGenerationFilters;
 }
 
@@ -174,10 +177,34 @@ class InsightsStore {
         : undefined,
       promptText: this.promptText,
       automatedScope: this.automatedScope,
+      sessionId: undefined,
       sessionFilters: this.sessionFilters
         ? { ...this.sessionFilters }
         : undefined,
     });
+  }
+
+  generateForSession(session: Session) {
+    const date = sessionInsightDate(session);
+    this.type = "agent_analysis";
+    this.dateFrom = date;
+    this.dateTo = date;
+    this.project = session.project || "";
+    this.automatedScope = "human";
+    this.#startGeneration(
+      {
+        type: "agent_analysis",
+        dateFrom: date,
+        dateTo: date,
+        project: session.project || "",
+        agent: this.agent,
+        promptText: this.promptText,
+        automatedScope: "human",
+        sessionId: session.id,
+      },
+      undefined,
+      true,
+    );
   }
 
   retryTask(clientId: string) {
@@ -193,6 +220,7 @@ class InsightsStore {
         kind: task.kind,
         promptText: task.promptText,
         automatedScope: task.automatedScope,
+        sessionId: task.sessionId,
         sessionFilters: task.sessionFilters
           ? { ...task.sessionFilters }
           : undefined,
@@ -217,6 +245,7 @@ class InsightsStore {
       kind: snap.kind,
       promptText: snap.promptText,
       automatedScope: snap.automatedScope,
+      sessionId: snap.sessionId,
       sessionFilters: snap.sessionFilters
         ? { ...snap.sessionFilters }
         : undefined,
@@ -245,6 +274,7 @@ class InsightsStore {
         date_to: snap.dateTo,
         project: snap.project || undefined,
         prompt: snap.promptText || undefined,
+        session_id: snap.sessionId,
         timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
         agent: snap.agent,
         kind: snap.kind,
@@ -359,3 +389,11 @@ class InsightsStore {
 }
 
 export const insights = new InsightsStore();
+
+function sessionInsightDate(session: Session): string {
+  const ts =
+    session.started_at ||
+    session.ended_at ||
+    session.created_at;
+  return ts.slice(0, 10);
+}

--- a/frontend/src/lib/stores/insights.test.ts
+++ b/frontend/src/lib/stores/insights.test.ts
@@ -6,7 +6,7 @@ import {
   beforeEach,
 } from "vite-plus/test";
 import { insights } from "./insights.svelte.js";
-import type { Insight } from "../api/types.js";
+import type { Insight, Session } from "../api/types.js";
 
 const api = vi.hoisted(() => {
   class MockApiError extends Error {
@@ -59,6 +59,25 @@ function makeInsight(
     prompt: null,
     content: "# Summary\nThings happened.",
     created_at: "2025-01-15T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "run:session-1",
+    project: "proj-a",
+    machine: "local",
+    agent: "claude",
+    first_message: "hello",
+    started_at: "2026-07-05T14:30:00Z",
+    ended_at: "2026-07-05T14:45:00Z",
+    message_count: 2,
+    user_message_count: 1,
+    total_output_tokens: 0,
+    peak_context_tokens: 0,
+    is_automated: false,
+    created_at: "2026-07-05T14:30:00Z",
     ...overrides,
   };
 }
@@ -338,6 +357,28 @@ describe("generate (multi-task)", () => {
       expect.any(Function),
       expect.any(Function),
     );
+  });
+
+  it("generates agent analysis for a single session", () => {
+    vi.mocked(api.generateInsight).mockReturnValueOnce({
+      abort: vi.fn(),
+      done: Promise.resolve(makeInsight({ id: 32 })),
+    });
+
+    insights.generateForSession(makeSession());
+
+    expect(api.generateInsight).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "agent_analysis",
+        date_from: "2026-07-05",
+        date_to: "2026-07-05",
+        project: "proj-a",
+        session_id: "run:session-1",
+      }),
+      expect.any(Function),
+      expect.any(Function),
+    );
+    expect(insights.selectedTaskId).toBe(insights.tasks[0]?.clientId);
   });
 
   it("sends dashboard session filters for canned recommendations", async () => {

--- a/internal/insight/prompt.go
+++ b/internal/insight/prompt.go
@@ -17,6 +17,7 @@ type GenerateRequest struct {
 	DateTo         string
 	Project        string
 	Prompt         string
+	SessionID      string
 	AutomatedScope string
 	Summary        *RangeSummary // non-nil only for multi-day ranges
 }
@@ -28,6 +29,9 @@ func BuildPrompt(
 	database db.Store,
 	req GenerateRequest,
 ) (string, error) {
+	if req.SessionID != "" {
+		return buildSessionPrompt(ctx, database, req)
+	}
 	automatedScope := req.AutomatedScope
 	if automatedScope == "" {
 		automatedScope = "human"
@@ -131,6 +135,85 @@ func BuildPrompt(
 		b.WriteString("\n")
 	}
 
+	return b.String(), nil
+}
+
+func buildSessionPrompt(
+	ctx context.Context,
+	database db.Store,
+	req GenerateRequest,
+) (string, error) {
+	sess, err := database.GetSession(ctx, req.SessionID)
+	if err != nil {
+		return "", fmt.Errorf("getting session: %w", err)
+	}
+	if sess == nil {
+		return "", fmt.Errorf("session not found: %s", req.SessionID)
+	}
+	msgs, err := database.GetAllMessages(ctx, req.SessionID)
+	if err != nil {
+		return "", fmt.Errorf("getting messages: %w", err)
+	}
+	timing, err := database.GetSessionTiming(ctx, req.SessionID)
+	if err != nil {
+		return "", fmt.Errorf("getting timing: %w", err)
+	}
+	usage, err := database.GetSessionUsage(ctx, req.SessionID)
+	if err != nil {
+		return "", fmt.Errorf("getting usage: %w", err)
+	}
+
+	var b strings.Builder
+	writeSystemInstruction(&b, req.Type)
+	fmt.Fprintf(&b, "\n## Session: %s\n\n", req.SessionID)
+	fmt.Fprintf(&b, "- Project: %s\n", sess.Project)
+	fmt.Fprintf(&b, "- Agent: %s\n", sess.Agent)
+	if sess.StartedAt != nil {
+		fmt.Fprintf(&b, "- Started: %s\n", *sess.StartedAt)
+	}
+	if sess.EndedAt != nil {
+		fmt.Fprintf(&b, "- Ended: %s\n", *sess.EndedAt)
+	}
+	fmt.Fprintf(&b, "- Messages: %d\n", sess.MessageCount)
+	if usage != nil && usage.HasTokenData {
+		fmt.Fprintf(&b, "- Output tokens: %d\n", usage.TotalOutputTokens)
+		fmt.Fprintf(&b, "- Peak context tokens: %d\n", usage.PeakContextTokens)
+	}
+	if usage != nil && usage.HasCost {
+		fmt.Fprintf(&b, "- Cost: $%.4f\n", usage.CostUSD)
+	}
+	if timing != nil {
+		fmt.Fprintf(&b, "- Duration: %.1fs\n", float64(timing.TotalDurationMs)/1000)
+		fmt.Fprintf(&b, "- Tool calls: %d\n", timing.ToolCallCount)
+	}
+
+	b.WriteString("\n## Messages\n\n")
+	if len(msgs) == 0 {
+		b.WriteString("No messages found for this session.\n")
+	} else {
+		for _, m := range msgs {
+			if m.IsSystem {
+				continue
+			}
+			fmt.Fprintf(&b, "### Message %d: %s\n", m.Ordinal, m.Role)
+			if m.Timestamp != "" {
+				fmt.Fprintf(&b, "- Timestamp: %s\n", m.Timestamp)
+			}
+			if m.Model != "" {
+				fmt.Fprintf(&b, "- Model: %s\n", m.Model)
+			}
+			if hasContext, hasOutput := m.TokenPresence(); hasContext || hasOutput {
+				fmt.Fprintf(&b, "- Context tokens: %d\n", m.ContextTokens)
+				fmt.Fprintf(&b, "- Output tokens: %d\n", m.OutputTokens)
+			}
+			fmt.Fprintf(&b, "\n%s\n\n", truncateString(m.Content, 800))
+		}
+	}
+	if req.Prompt != "" {
+		b.WriteString("## User Query\n\n")
+		b.WriteString(req.Prompt)
+		b.WriteString("\n")
+	}
 	return b.String(), nil
 }
 

--- a/internal/insight/prompt_test.go
+++ b/internal/insight/prompt_test.go
@@ -100,6 +100,45 @@ func TestBuildPrompt(t *testing.T) {
 			wantContains: []string{"analyzing AI agent"},
 		},
 		{
+			name: "single session analysis",
+			req: GenerateRequest{
+				Type:      "agent_analysis",
+				DateFrom:  "2025-01-15",
+				DateTo:    "2025-01-15",
+				SessionID: "s1",
+			},
+			seed: func(t *testing.T, d *db.DB) {
+				dbtest.SeedSession(t, d, "s1", "my-app", func(s *db.Session) {
+					s.Agent = "claude"
+					s.MessageCount = 2
+					s.StartedAt = new("2025-01-15T10:00:00Z")
+					s.EndedAt = new("2025-01-15T10:10:00Z")
+				})
+				dbtest.SeedMessages(t, d,
+					db.Message{
+						SessionID: "s1",
+						Ordinal:   1,
+						Role:      "user",
+						Content:   "Review the flaky test setup",
+						Timestamp: "2025-01-15T10:00:01Z",
+					},
+					db.Message{
+						SessionID: "s1",
+						Ordinal:   2,
+						Role:      "assistant",
+						Content:   "I found two retry loops in the test harness",
+						Timestamp: "2025-01-15T10:00:10Z",
+					},
+				)
+			},
+			wantContains: []string{
+				"## Session: s1",
+				"Review the flaky test setup",
+				"retry loops",
+			},
+			wantNot: []string{"## Sessions"},
+		},
+		{
 			name: "truncation",
 			req: GenerateRequest{
 				Type:     "daily_activity",

--- a/internal/server/huma_routes_insights.go
+++ b/internal/server/huma_routes_insights.go
@@ -198,13 +198,13 @@ func (s *Server) humaGenerateInsight(
 			"insight generation is not available in read-only mode")
 	}
 	req := in.Body
-	if req.SessionID != "" && req.Type != "agent_analysis" {
-		return nil, apiError(http.StatusBadRequest,
-			"session_id is only supported for agent_analysis")
-	}
 	if !validInsightTypes[req.Type] {
 		return nil, apiError(http.StatusBadRequest,
 			"invalid type: must be daily_activity, agent_analysis, or llm_canned")
+	}
+	if req.SessionID != "" && req.Type != "agent_analysis" {
+		return nil, apiError(http.StatusBadRequest,
+			"session_id is only supported for agent_analysis")
 	}
 	if req.Type == insight.CannedType {
 		return s.humaGenerateCannedInsight(req)

--- a/internal/server/huma_routes_insights.go
+++ b/internal/server/huma_routes_insights.go
@@ -205,6 +205,31 @@ func (s *Server) humaGenerateInsight(
 	if req.Type == insight.CannedType {
 		return s.humaGenerateCannedInsight(req)
 	}
+	if req.SessionID != "" {
+		if req.Type != "agent_analysis" {
+			return nil, apiError(http.StatusBadRequest,
+				"session_id is only supported for agent_analysis")
+		}
+		session, err := s.db.GetSession(ctx, req.SessionID)
+		if err != nil {
+			return nil, serverError(err)
+		}
+		if session == nil {
+			return nil, apiError(http.StatusNotFound, "session not found")
+		}
+		date := insightSessionDate(session)
+		if date == "" {
+			return nil, apiError(http.StatusBadRequest,
+				"session has no usable timestamp")
+		}
+		if req.DateFrom == "" {
+			req.DateFrom = date
+		}
+		if req.DateTo == "" {
+			req.DateTo = date
+		}
+		req.Project = session.Project
+	}
 	if !timeutil.IsValidDate(req.DateFrom) {
 		return nil, apiError(http.StatusBadRequest,
 			"invalid date_from: use YYYY-MM-DD")
@@ -253,6 +278,7 @@ func (s *Server) humaGenerateInsight(
 			DateTo:         req.DateTo,
 			Project:        req.Project,
 			Prompt:         req.Prompt,
+			SessionID:      req.SessionID,
 			AutomatedScope: req.AutomatedScope,
 		}
 		// Attach the activity summary for any valid range, single day
@@ -431,6 +457,29 @@ func (s *Server) humaGenerateInsight(
 		}
 		sendJSON("done", saved)
 	}}, nil
+}
+
+func insightSessionDate(session *db.Session) string {
+	if session == nil {
+		return ""
+	}
+	for _, ts := range []string{
+		insightStringValue(session.StartedAt),
+		insightStringValue(session.EndedAt),
+		session.CreatedAt,
+	} {
+		if len(ts) >= len("2006-01-02") {
+			return ts[:10]
+		}
+	}
+	return ""
+}
+
+func insightStringValue(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
 }
 
 // activityRangeSummary resolves the requested range into an activity report and

--- a/internal/server/huma_routes_insights.go
+++ b/internal/server/huma_routes_insights.go
@@ -198,6 +198,10 @@ func (s *Server) humaGenerateInsight(
 			"insight generation is not available in read-only mode")
 	}
 	req := in.Body
+	if req.SessionID != "" && req.Type != "agent_analysis" {
+		return nil, apiError(http.StatusBadRequest,
+			"session_id is only supported for agent_analysis")
+	}
 	if !validInsightTypes[req.Type] {
 		return nil, apiError(http.StatusBadRequest,
 			"invalid type: must be daily_activity, agent_analysis, or llm_canned")
@@ -206,10 +210,6 @@ func (s *Server) humaGenerateInsight(
 		return s.humaGenerateCannedInsight(req)
 	}
 	if req.SessionID != "" {
-		if req.Type != "agent_analysis" {
-			return nil, apiError(http.StatusBadRequest,
-				"session_id is only supported for agent_analysis")
-		}
 		session, err := s.db.GetSession(ctx, req.SessionID)
 		if err != nil {
 			return nil, serverError(err)

--- a/internal/server/huma_routes_insights.go
+++ b/internal/server/huma_routes_insights.go
@@ -218,14 +218,10 @@ func (s *Server) humaGenerateInsight(
 			return nil, apiError(http.StatusNotFound, "session not found")
 		}
 		date := insightSessionDate(session)
-		if date == "" {
-			return nil, apiError(http.StatusBadRequest,
-				"session has no usable timestamp")
-		}
-		if req.DateFrom == "" {
+		if req.DateFrom == "" && date != "" {
 			req.DateFrom = date
 		}
-		if req.DateTo == "" {
+		if req.DateTo == "" && date != "" {
 			req.DateTo = date
 		}
 		req.Project = session.Project

--- a/internal/server/insights.go
+++ b/internal/server/insights.go
@@ -28,6 +28,7 @@ type generateInsightRequest struct {
 	DateTo         string                        `json:"date_to"`
 	Project        string                        `json:"project,omitempty"`
 	Prompt         string                        `json:"prompt,omitempty"`
+	SessionID      string                        `json:"session_id,omitempty"`
 	Agent          string                        `json:"agent,omitempty"`
 	Kind           string                        `json:"kind,omitempty"`
 	LLMOptIn       bool                          `json:"llm_opt_in,omitempty"`

--- a/internal/server/insights_test.go
+++ b/internal/server/insights_test.go
@@ -411,6 +411,15 @@ func TestGenerateInsight_SingleSessionUsesSessionPrompt(t *testing.T) {
 	assert.Equal(t, "my-app", *saved.Project)
 }
 
+func TestGenerateInsight_SingleSessionMissingSession(t *testing.T) {
+	te := setup(t)
+
+	w := te.post(t, "/api/v1/insights/generate",
+		`{"type":"agent_analysis","session_id":"missing","date_from":"","date_to":""}`)
+	assertStatus(t, w, http.StatusNotFound)
+	assertBodyContains(t, w, "session not found")
+}
+
 func TestGenerateInsight_PersistsWithReadOnlyStore(t *testing.T) {
 	dir := tempDirWithRetryCleanup(t)
 	dbPath := filepath.Join(dir, "test.db")

--- a/internal/server/insights_test.go
+++ b/internal/server/insights_test.go
@@ -368,6 +368,45 @@ func TestGenerateInsight_DefaultAgent(t *testing.T) {
 	assertBodyContains(t, w, "stub: no CLI")
 }
 
+func TestGenerateInsight_SessionValidation(t *testing.T) {
+	te := setup(t)
+
+	w := te.post(t, "/api/v1/insights/generate",
+		`{"type":"daily_activity","session_id":"missing","date_from":"2025-01-15","date_to":"2025-01-15"}`)
+	assertStatus(t, w, http.StatusBadRequest)
+	assertBodyContains(t, w, "session_id is only supported for agent_analysis")
+}
+
+func TestGenerateInsight_SingleSessionUsesSessionPrompt(t *testing.T) {
+	te := setupWithServerOpts(t, []server.Option{
+		server.WithGenerateFunc(func(
+			_ context.Context, agent, prompt string,
+		) (insight.Result, error) {
+			assert.Equal(t, "claude", agent)
+			assert.Contains(t, prompt, "## Session: session-1")
+			return insight.Result{
+				Agent:   "claude",
+				Content: "single-session analysis",
+			}, nil
+		}),
+	})
+	te.seedSession(t, "session-1", "my-app", 2)
+
+	w := te.post(t, "/api/v1/insights/generate",
+		`{"type":"agent_analysis","session_id":"session-1","date_from":"","date_to":""}`)
+	assertStatus(t, w, http.StatusOK)
+
+	events := parseSSE(w.Body.String())
+	require.NotEmpty(t, events)
+	require.Equal(t, "done", events[len(events)-1].Event)
+
+	var saved db.Insight
+	require.NoError(t, json.Unmarshal([]byte(events[len(events)-1].Data), &saved))
+	assert.Equal(t, "2025-01-15", saved.DateFrom)
+	assert.Equal(t, "2025-01-15", saved.DateTo)
+	assert.Equal(t, "my-app", *saved.Project)
+}
+
 func TestGenerateInsight_PersistsWithReadOnlyStore(t *testing.T) {
 	dir := tempDirWithRetryCleanup(t)
 	dbPath := filepath.Join(dir, "test.db")

--- a/internal/server/insights_test.go
+++ b/internal/server/insights_test.go
@@ -371,10 +371,14 @@ func TestGenerateInsight_DefaultAgent(t *testing.T) {
 func TestGenerateInsight_SessionValidation(t *testing.T) {
 	te := setup(t)
 
-	w := te.post(t, "/api/v1/insights/generate",
-		`{"type":"daily_activity","session_id":"missing","date_from":"2025-01-15","date_to":"2025-01-15"}`)
-	assertStatus(t, w, http.StatusBadRequest)
-	assertBodyContains(t, w, "session_id is only supported for agent_analysis")
+	for _, body := range []string{
+		`{"type":"daily_activity","session_id":"missing","date_from":"2025-01-15","date_to":"2025-01-15"}`,
+		`{"type":"llm_canned","kind":"prompt_maturity_review","llm_opt_in":true,"session_id":"missing","date_from":"2025-01-15","date_to":"2025-01-15"}`,
+	} {
+		w := te.post(t, "/api/v1/insights/generate", body)
+		assertStatus(t, w, http.StatusBadRequest)
+		assertBodyContains(t, w, "session_id is only supported for agent_analysis")
+	}
 }
 
 func TestGenerateInsight_SingleSessionUsesSessionPrompt(t *testing.T) {


### PR DESCRIPTION
The insights generator can analyze agent activity, but the request path is date-window scoped, so starting from a single session still asks the backend for a sessions-list prompt. That makes the top-bar workflow in #445 impossible without manually narrowing dates and still getting surrounding sessions in the prompt.

This adds a session-scoped path to the existing insights generation flow instead of creating a parallel endpoint. The session breadcrumb starts an `agent_analysis` task with the current session id, the server validates that session scope only applies to agent analysis, and the prompt builder switches to a single-session branch that reads the session, messages, timing, and usage through the existing store interface.

The storage shape stays unchanged for this pass. The PR keeps the generated insight pipeline, SSE stream, task handling, and ordinary date-range analysis intact, and limits the new behavior to the missing session scope.

Closes #445
