### PR TITLE
fix(config): apply port from config.toml to Config struct

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -667,6 +667,7 @@ func (c *Config) applyConfigTOML(data string) error {
 		CursorAdminEmail               string                     `toml:"cursor_admin_email"`
 		CursorAdminUserID              string                     `toml:"cursor_admin_user_id"`
 		Host                           string                     `toml:"host"`
+		Port                           int                        `toml:"port"`
 		PublicURL                      string                     `toml:"public_url"`
 		PublicOrigins                  []string                   `toml:"public_origins"`
 		Proxy                          ProxyConfig                `toml:"proxy"`
@@ -712,6 +713,9 @@ func (c *Config) applyConfigTOML(data string) error {
 	}
 	if file.Host != "" {
 		c.Host = file.Host
+	}
+	if file.Port != 0 {
+		c.Port = file.Port
 	}
 	if file.PublicURL != "" {
 		c.PublicURL = file.PublicURL

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -424,6 +424,26 @@ func TestLoad_HostFlagOverridesConfigFile(t *testing.T) {
 	assert.True(t, cfg.HostExplicit)
 }
 
+func TestLoad_PortFromConfigFile(t *testing.T) {
+	cfg := loadMinimalWithConfig(t, map[string]any{
+		"port": 7357,
+	})
+
+	assert.Equal(t, 7357, cfg.Port)
+}
+
+func TestLoad_PortFlagOverridesConfigFile(t *testing.T) {
+	tmp := setupTestEnv(t)
+	writeConfig(t, tmp, map[string]any{
+		"port": 7357,
+	})
+
+	cfg, err := loadConfigFromFlags(t, "-port", "9090")
+	require.NoError(t, err)
+
+	assert.Equal(t, 9090, cfg.Port)
+}
+
 func TestLoad_PublicOriginsFromConfigFile(t *testing.T) {
 	cfg := loadMinimalWithConfig(t, map[string]any{
 		"public_origins": []string{


### PR DESCRIPTION
The applyConfigTOML function TOML parsing struct was missing the Port field, causing "port = 19090" in config.toml to be silently ignored. The field was parsed by the TOML decoder but never applied to the Config.

Add the Port field to the parsing struct and apply it when non-zero.