### PR TITLE
fix(sync): skip local git discovery for foreign-machine sessions

### DIFF
--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -6662,7 +6662,13 @@ func (e *Engine) cachedProjectIdentity(machine, rootPath string) projectIdentity
 		return cached
 	}
 	identity := projectIdentityCacheEntry{rootPath: rootPath}
-	if e.idPrefix == "" && e.pathRewriter == nil {
+	// Only probe the local filesystem for sessions recorded on this
+	// machine: another machine's cwd (e.g. /home/... from a synced Linux
+	// host) is meaningless here, and on macOS merely stat'ing such paths
+	// wakes the /home automounter — with tens of thousands of remote
+	// sessions and a one-minute cache TTL that becomes a sustained
+	// automountd/opendirectoryd CPU storm.
+	if e.idPrefix == "" && e.pathRewriter == nil && machine == e.machine {
 		if gitRoot, remotes := discoverLocalGitIdentity(rootPath); gitRoot != "" {
 			identity.rootPath = gitRoot
 			if name, raw, ok := export.SelectRemote(remotes); ok {

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -1091,6 +1091,46 @@ func TestProjectIdentityObservationCachesLocalGitDiscovery(t *testing.T) {
 	assert.Equal(t, "github.com/acme/cache", observations[0].NormalizedRemote)
 }
 
+// TestProjectIdentityObservationSkipsDiscoveryForRemoteMachine pins that
+// local git discovery never probes the filesystem for a session recorded on
+// another machine: the cwd names a path on that machine, so resolving it
+// locally is wrong (and on macOS, stat'ing a remote /home/... cwd wakes the
+// automounter — see cachedProjectIdentity). The cwd here is a real local git
+// repo, so if discovery ran anyway the observation would carry its remote.
+func TestProjectIdentityObservationSkipsDiscoveryForRemoteMachine(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(root, ".git"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, ".git", "config"),
+		[]byte("[remote \"origin\"]\n\turl = https://github.com/acme/remote.git\n"),
+		0o644,
+	))
+	cwd := filepath.Join(root, "subdir")
+	require.NoError(t, os.Mkdir(cwd, 0o755))
+	e := NewEngine(database, EngineConfig{Machine: "laptop"})
+	ctx := context.Background()
+
+	require.NoError(t, e.writeProjectIdentityObservation(ctx, db.Session{
+		ID:        "identity-remote-machine",
+		Project:   "remote-proj",
+		Machine:   "home-nuc",
+		Agent:     "codex",
+		Cwd:       cwd,
+		StartedAt: strPtr(time.Now().UTC().Format(time.RFC3339Nano)),
+	}))
+
+	observations, err := database.ListProjectIdentityObservations(
+		ctx, []string{"remote-proj"},
+	)
+	require.NoError(t, err)
+	require.Len(t, observations, 1)
+	assert.Empty(t, observations[0].GitRemote,
+		"foreign-machine cwd must not be probed for a local git identity")
+	assert.Equal(t, cwd, observations[0].RootPath,
+		"root path must stay the raw cwd, not a locally resolved git root")
+}
+
 func TestProjectIdentitySafeLocalAbsolutePathHandlesWindowsDriveRootsByOS(t *testing.T) {
 	wantWindowsDriveLocal := runtime.GOOS == "windows"
 	assert.Equal(t, wantWindowsDriveLocal, safeLocalAbsolutePath(`C:\repo`))


### PR DESCRIPTION
The sync engine's project-identity discovery (`cachedProjectIdentity` → `discoverLocalGitIdentity`) ran `filepath.EvalSymlinks` plus a git-root walk on every session's `cwd`, including sessions recorded on other machines. A remote machine's cwd names a path on that machine, so probing it on the local filesystem is wrong on any OS.

On macOS it is also expensive: `/home` is an automounter trigger, so merely stat'ing a synced Linux session's `/home/...` cwd wakes `automountd`, which resolves the auto_home map through `opendirectoryd`, and negative results are not cached. On an archive with tens of thousands of sessions synced from a remote Linux machine (thousands of distinct `/home/...` cwds) and a one-minute identity-cache TTL, any sustained session-write activity produced a continuous syscall storm — measured live as automountd pinned at ~100% and opendirectoryd at 1.3–3.6 cores, dropping to exactly zero when the daemon stopped. `fs_usage` showed four agentsview threads issuing `lstat64`/`readlink` on `/home` at roughly 1,500 calls/sec.

The fix gates discovery on the observation's machine matching the engine's own machine identity, next to the existing `idPrefix`/`pathRewriter` remote-import gate. Foreign-machine observations keep their raw cwd as the root path with no git enrichment, which is what they should have carried all along. With the fix deployed on the same archive, automountd fell from ~175% CPU to ~10% and opendirectoryd from multi-core to ~22% under identical daemon load.

Rows already written with locally resolved roots for foreign sessions are left as-is; they age out through normal observation upserts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)