### PR TITLE
fix(sync): skip local git discovery for foreign-machine sessions

### DIFF
--- a/internal/db/project_identity.go
+++ b/internal/db/project_identity.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"sort"
 	"strings"
@@ -623,6 +624,12 @@ func legacyProjectIdentityRoots(cwd, filePath string) []string {
 
 func discoverLegacyLocalGitIdentity(root string) (string, map[string]string) {
 	if !filepath.IsAbs(root) {
+		return "", nil
+	}
+	// Skip macOS automounter namespaces: probing them wakes
+	// automountd/opendirectoryd for paths that virtually never exist
+	// locally (see export.IsAutomountNamespacePath).
+	if export.IsAutomountNamespacePath(runtime.GOOS, filepath.Clean(root)) {
 		return "", nil
 	}
 	resolved, err := filepath.EvalSymlinks(filepath.Clean(root))

--- a/internal/export/project_identity.go
+++ b/internal/export/project_identity.go
@@ -162,12 +162,15 @@ func NormalizeRootPath(raw string) (normalized string, ok bool, err error) {
 		return "", false, nil
 	}
 	cleaned := filepath.Clean(raw)
-	resolved, err := filepath.EvalSymlinks(cleaned)
-	if err != nil && !os.IsNotExist(err) {
-		return "", false, err
-	}
-	if err != nil {
-		resolved = cleaned
+	resolved := cleaned
+	if !IsAutomountNamespacePath(runtime.GOOS, cleaned) {
+		resolved, err = filepath.EvalSymlinks(cleaned)
+		if err != nil && !os.IsNotExist(err) {
+			return "", false, err
+		}
+		if err != nil {
+			resolved = cleaned
+		}
 	}
 	abs, err := filepath.Abs(resolved)
 	if err != nil {
@@ -357,7 +360,31 @@ func normalizeWindowsDriveRootPath(raw string) string {
 	return drive + rest
 }
 
+// IsAutomountNamespacePath reports whether p lies inside a macOS
+// automounter namespace (/home, /net, /Network/Servers). On darwin, merely
+// stat'ing such a path wakes automountd, which resolves the map through
+// opendirectoryd, and negative results are not cached — an archive holding
+// many /home/... roots from sessions synced off Linux machines turns every
+// resolution sweep into a sustained syscall storm. Callers skip filesystem
+// resolution for these paths and use the cleaned path directly, which is
+// exactly what the (virtually always failing) EvalSymlinks fallback would
+// have produced. goos is a parameter so the predicate is testable off-darwin.
+func IsAutomountNamespacePath(goos, p string) bool {
+	if goos != "darwin" {
+		return false
+	}
+	for _, ns := range [...]string{"/home", "/net", "/Network/Servers"} {
+		if p == ns || strings.HasPrefix(p, ns+"/") {
+			return true
+		}
+	}
+	return false
+}
+
 func resolveStoredRootPath(cleaned string) (string, bool) {
+	if IsAutomountNamespacePath(runtime.GOOS, cleaned) {
+		return "", false
+	}
 	resolved, err := filepath.EvalSymlinks(filepath.FromSlash(cleaned))
 	if err != nil {
 		return "", false

--- a/internal/export/project_identity_test.go
+++ b/internal/export/project_identity_test.go
@@ -320,3 +320,46 @@ func sha256Hex(s string) string {
 	sum := sha256.Sum256([]byte(s))
 	return hex.EncodeToString(sum[:])
 }
+
+func TestIsAutomountNamespacePath(t *testing.T) {
+	tests := []struct {
+		name string
+		goos string
+		path string
+		want bool
+	}{
+		{"darwin home root", "darwin", "/home", true},
+		{"darwin home child", "darwin", "/home/user/repo", true},
+		{"darwin net child", "darwin", "/net/host/share", true},
+		{"darwin network servers", "darwin", "/Network/Servers/x", true},
+		{"darwin prefix collision homework", "darwin", "/homework/repo", false},
+		{"darwin prefix collision netdata", "darwin", "/netdata", false},
+		{"darwin regular path", "darwin", "/Users/user/repo", false},
+		{"linux home is real", "linux", "/home/user/repo", false},
+		{"windows never matches", "windows", "/home/user", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsAutomountNamespacePath(tt.goos, tt.path))
+		})
+	}
+}
+
+// TestNormalizeStoredRootPathSkipsAutomountNamespace pins that on macOS a
+// stored /home/... root path normalizes to its cleaned form without touching
+// the filesystem: resolving it through the automounter is both futile (the
+// path names a directory on another machine) and expensive (each probe wakes
+// automountd/opendirectoryd, and negative results are not cached).
+func TestNormalizeStoredRootPathSkipsAutomountNamespace(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("automount namespaces are a darwin-only concern")
+	}
+	got, ok := NormalizeStoredRootPath("/home/user/work/repo")
+	require.True(t, ok)
+	assert.Equal(t, "/home/user/work/repo", got)
+
+	normalized, ok, err := NormalizeRootPath("/home/user/work/repo")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "/home/user/work/repo", normalized)
+}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -6662,7 +6662,13 @@ func (e *Engine) cachedProjectIdentity(machine, rootPath string) projectIdentity
 		return cached
 	}
 	identity := projectIdentityCacheEntry{rootPath: rootPath}
-	if e.idPrefix == "" && e.pathRewriter == nil {
+	// Only probe the local filesystem for sessions recorded on this
+	// machine: another machine's cwd (e.g. /home/... from a synced Linux
+	// host) is meaningless here, and on macOS merely stat'ing such paths
+	// wakes the /home automounter — with tens of thousands of remote
+	// sessions and a one-minute cache TTL that becomes a sustained
+	// automountd/opendirectoryd CPU storm.
+	if e.idPrefix == "" && e.pathRewriter == nil && machine == e.machine {
 		if gitRoot, remotes := discoverLocalGitIdentity(rootPath); gitRoot != "" {
 			identity.rootPath = gitRoot
 			if name, raw, ok := export.SelectRemote(remotes); ok {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -6732,6 +6732,12 @@ func discoverLocalGitIdentity(cwd string) (string, map[string]string) {
 	if !safeLocalAbsolutePath(cwd) {
 		return "", nil
 	}
+	// Skip macOS automounter namespaces: probing them wakes
+	// automountd/opendirectoryd for paths that virtually never exist
+	// locally (see export.IsAutomountNamespacePath).
+	if export.IsAutomountNamespacePath(runtime.GOOS, filepath.Clean(cwd)) {
+		return "", nil
+	}
 	resolved, err := filepath.EvalSymlinks(filepath.Clean(cwd))
 	if err != nil {
 		return "", nil

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -1091,6 +1091,46 @@ func TestProjectIdentityObservationCachesLocalGitDiscovery(t *testing.T) {
 	assert.Equal(t, "github.com/acme/cache", observations[0].NormalizedRemote)
 }
 
+// TestProjectIdentityObservationSkipsDiscoveryForRemoteMachine pins that
+// local git discovery never probes the filesystem for a session recorded on
+// another machine: the cwd names a path on that machine, so resolving it
+// locally is wrong (and on macOS, stat'ing a remote /home/... cwd wakes the
+// automounter — see cachedProjectIdentity). The cwd here is a real local git
+// repo, so if discovery ran anyway the observation would carry its remote.
+func TestProjectIdentityObservationSkipsDiscoveryForRemoteMachine(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(root, ".git"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, ".git", "config"),
+		[]byte("[remote \"origin\"]\n\turl = https://github.com/acme/remote.git\n"),
+		0o644,
+	))
+	cwd := filepath.Join(root, "subdir")
+	require.NoError(t, os.Mkdir(cwd, 0o755))
+	e := NewEngine(database, EngineConfig{Machine: "laptop"})
+	ctx := context.Background()
+
+	require.NoError(t, e.writeProjectIdentityObservation(ctx, db.Session{
+		ID:        "identity-remote-machine",
+		Project:   "remote-proj",
+		Machine:   "remote-linux",
+		Agent:     "codex",
+		Cwd:       cwd,
+		StartedAt: strPtr(time.Now().UTC().Format(time.RFC3339Nano)),
+	}))
+
+	observations, err := database.ListProjectIdentityObservations(
+		ctx, []string{"remote-proj"},
+	)
+	require.NoError(t, err)
+	require.Len(t, observations, 1)
+	assert.Empty(t, observations[0].GitRemote,
+		"foreign-machine cwd must not be probed for a local git identity")
+	assert.Equal(t, cwd, observations[0].RootPath,
+		"root path must stay the raw cwd, not a locally resolved git root")
+}
+
 func TestProjectIdentitySafeLocalAbsolutePathHandlesWindowsDriveRootsByOS(t *testing.T) {
 	wantWindowsDriveLocal := runtime.GOOS == "windows"
 	assert.Equal(t, wantWindowsDriveLocal, safeLocalAbsolutePath(`C:\repo`))


### PR DESCRIPTION
Fixes a sustained automountd/opendirectoryd CPU storm on macOS caused by project-identity code probing the local filesystem with paths that belong to other machines. On darwin, `/home` (and `/net`, `/Network/Servers`) are automounter triggers: merely stat'ing a path under them wakes `automountd`, which resolves the map through `opendirectoryd`, and negative results are not cached. An archive holding tens of thousands of sessions synced from a remote Linux machine (thousands of distinct `/home/...` cwds and stored root paths) turned routine work into a continuous syscall storm — measured live as automountd pinned at ~100% and opendirectoryd at 1.3–3.6 cores, dropping to exactly zero with the daemon stopped; `fs_usage` showed agentsview threads issuing `lstat64`/`readlink` on `/home` at ~1,500 calls/sec.

Two probe paths are fixed:

1. **Sync-side discovery** (`cachedProjectIdentity` → `discoverLocalGitIdentity`): ran `filepath.EvalSymlinks` plus a git-root walk on every session's cwd, including foreign-machine sessions, on every identity-cache miss (one-minute TTL). Now gated on the observation's machine matching the engine's own machine identity, next to the existing `idPrefix`/`pathRewriter` remote-import gate. Foreign-machine observations keep their raw cwd with no git enrichment, which is what they should have carried all along.

2. **Read-side resolution** (`export.NormalizeRootPath`, `export.NormalizeStoredRootPath`, and the legacy discovery in `db.BuildProjectIdentityMap`): every activity/usage/export request rebuilds the project-identity map, and each stored `/home/...` root was re-resolved through `EvalSymlinks` per request. A new `export.IsAutomountNamespacePath` predicate skips filesystem resolution for macOS automounter namespaces in all three places (plus the sync-side discovery, for local sessions with such cwds). On darwin these resolutions always failed and fell back to the cleaned path, so skipping them produces identical identity keys minus the syscalls; other platforms are unaffected.

With both fixes deployed on the same archive under identical daemon + embedding load, automountd and opendirectoryd burn dropped to zero (0.00s and 0.13s CPU over a 2-minute sample, from ~1.75 and ~3.3 cores).

Rows already written with locally resolved roots for foreign sessions are left as-is; they age out through normal observation upserts.

Supersedes #1007.

🤖 Generated with [Claude Code](https://claude.com/claude-code)