### PR TITLE
feat(parser): add ZCode SQLite sync support (#1003)

### DIFF
--- a/internal/parser/provider.go
+++ b/internal/parser/provider.go
@@ -484,6 +484,8 @@ func providerFactoryForDef(def AgentDef) ProviderFactory {
 		return newVSCodeCopilotProviderFactory(def)
 	case AgentVibe:
 		return newVibeProviderFactory(def)
+	case AgentZCode:
+		return newZcodeProviderFactory(def)
 	case AgentWarp:
 		return newWarpProviderFactory(def)
 	case AgentWorkBuddy:

--- a/internal/parser/provider_migration.go
+++ b/internal/parser/provider_migration.go
@@ -51,6 +51,7 @@ var providerMigrationModes = map[AgentType]ProviderMigrationMode{
 	AgentPiebald:        ProviderMigrationProviderAuthoritative,
 	AgentWarp:           ProviderMigrationProviderAuthoritative,
 	AgentPositron:       ProviderMigrationProviderAuthoritative,
+	AgentZCode:          ProviderMigrationProviderAuthoritative,
 	AgentAntigravity:    ProviderMigrationProviderAuthoritative,
 	AgentAntigravityCLI: ProviderMigrationProviderAuthoritative,
 	AgentVibe:           ProviderMigrationProviderAuthoritative,

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -46,6 +46,7 @@ const (
 	AgentPiebald        AgentType = "piebald"
 	AgentWarp           AgentType = "warp"
 	AgentPositron       AgentType = "positron"
+	AgentZCode          AgentType = "zcode"
 	AgentAntigravity    AgentType = "antigravity"
 	AgentAntigravityCLI AgentType = "antigravity-cli"
 	AgentVibe           AgentType = "vibe"
@@ -509,6 +510,21 @@ var Registry = []AgentDef{
 		IDPrefix:     "positron:",
 		WatchSubdirs: []string{"workspaceStorage"},
 		FileBased:    true,
+	},
+	{
+		Type:        AgentZCode,
+		DisplayName: "ZCode",
+		EnvVar:      "ZCODE_DIR",
+		ConfigKey:   "zcode_dirs",
+		DefaultDirs: []string{
+			".zcode/cli/db",
+			".zcode/cli",
+		},
+		IDPrefix:  "zcode:",
+		FileBased: false,
+		Usage: UsageCapabilities{
+			NoPerMessageTokenData: true,
+		},
 	},
 	{
 		Type:         AgentZed,

--- a/internal/parser/types_test.go
+++ b/internal/parser/types_test.go
@@ -437,6 +437,7 @@ func TestRegistryCompleteness(t *testing.T) {
 		AgentPiebald,
 		AgentWarp,
 		AgentPositron,
+		AgentZCode,
 		AgentZed,
 		AgentAntigravity,
 		AgentAntigravityCLI,
@@ -584,6 +585,17 @@ func TestZedRegistryEntry(t *testing.T) {
 	assert.Equal(t, "ZED_DIR", def.EnvVar)
 	assert.Equal(t, "zed_dirs", def.ConfigKey)
 	assert.Equal(t, "zed:", def.IDPrefix)
+}
+
+func TestZCodeRegistryEntry(t *testing.T) {
+	def, ok := AgentByType(AgentZCode)
+	require.True(t, ok, "AgentZCode missing from Registry")
+	require.False(t, def.FileBased, "ZCode FileBased")
+	assert.Equal(t, "ZCODE_DIR", def.EnvVar)
+	assert.Equal(t, "zcode_dirs", def.ConfigKey)
+	assert.Equal(t, []string{".zcode/cli/db", ".zcode/cli"}, def.DefaultDirs)
+	assert.Equal(t, "zcode:", def.IDPrefix)
+	assert.True(t, def.Usage.NoPerMessageTokenData)
 }
 
 func TestShelleyRegistryEntry(t *testing.T) {

--- a/internal/parser/zcode.go
+++ b/internal/parser/zcode.go
@@ -1,0 +1,565 @@
+package parser
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const ZCodeDBName = "db.sqlite"
+
+const zcodeDBName = ZCodeDBName
+
+type zcodeProviderFactory struct {
+	def AgentDef
+}
+
+func newZcodeProviderFactory(def AgentDef) ProviderFactory {
+	return zcodeProviderFactory{def: cloneAgentDef(def)}
+}
+
+func (f zcodeProviderFactory) Definition() AgentDef {
+	return cloneAgentDef(f.def)
+}
+
+func (f zcodeProviderFactory) Capabilities() Capabilities {
+	return zcodeProviderCapabilities()
+}
+
+func (f zcodeProviderFactory) NewProvider(cfg ProviderConfig) Provider {
+	cfg = cfg.Clone()
+	cfg.Roots = normalizeZCodeRoots(cfg.Roots)
+	spec := zcodeProviderSpec()
+	return &dbBackedProvider{
+		ProviderBase: ProviderBase{
+			Def:    cloneAgentDef(f.def),
+			Caps:   spec.caps,
+			Config: cfg,
+		},
+		spec:    spec,
+		sources: newDBBackedSourceSet(spec, cfg.Roots),
+	}
+}
+
+func zcodeProviderCapabilities() Capabilities {
+	return Capabilities{
+		Source: dbBackedSourceCapabilities(CapabilityNotApplicable),
+		Content: ContentCapabilities{
+			FirstMessage:         CapabilitySupported,
+			SessionName:          CapabilitySupported,
+			Cwd:                  CapabilitySupported,
+			AggregateUsageEvents: CapabilitySupported,
+		},
+	}
+}
+
+func zcodeProviderSpec() dbBackedProviderSpec {
+	return dbBackedProviderSpec{
+		agent:  AgentZCode,
+		dbName: zcodeDBName,
+		findDB: zcodeDBPath,
+		listMeta: func(dbPath string) ([]dbBackedSessionMeta, error) {
+			return listZCodeSessionMeta(dbPath)
+		},
+		parse: func(dbPath, sessionID, machine string) ([]ParseResult, error) {
+			result, err := parseZCodeSession(dbPath, sessionID, machine)
+			if err != nil || result == nil {
+				return nil, err
+			}
+			return []ParseResult{*result}, nil
+		},
+		caps: zcodeProviderCapabilities(),
+	}
+}
+
+func normalizeZCodeRoots(roots []string) []string {
+	cleaned := cleanJSONLRoots(roots)
+	out := make([]string, 0, len(cleaned))
+	seen := make(map[string]struct{}, len(cleaned))
+	for _, root := range cleaned {
+		normalized := normalizeZCodeRoot(root)
+		if normalized == "" {
+			continue
+		}
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		out = append(out, normalized)
+	}
+	return out
+}
+
+func normalizeZCodeRoot(root string) string {
+	root = filepath.Clean(root)
+	if root == "" || root == "." {
+		return ""
+	}
+	if filepath.Base(root) == "db" {
+		return root
+	}
+	return filepath.Join(root, "db")
+}
+
+func zcodeDBPath(dir string) string {
+	if dir == "" {
+		return ""
+	}
+	path := filepath.Join(dir, zcodeDBName)
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return ""
+	}
+	return path
+}
+
+func zcodeVirtualPathParts(path string) (string, string, bool) {
+	return ParseVirtualSourcePathForBase(path, zcodeDBName)
+}
+
+func ZCodeSQLiteVirtualPath(dbPath, sessionID string) string {
+	return VirtualSourcePath(dbPath, sessionID)
+}
+
+func ZCodeSQLiteSourceMtime(path string) (int64, error) {
+	dbPath, sessionID, ok := zcodeVirtualPathParts(path)
+	if !ok {
+		return 0, fmt.Errorf("not a zcode sqlite virtual path: %s", path)
+	}
+	db, err := openZCodeDB(dbPath)
+	if err != nil {
+		return 0, err
+	}
+	defer db.Close()
+
+	row, err := loadZCodeSessionRow(db, sessionID)
+	if err != nil {
+		return 0, err
+	}
+	return zcodeSessionFileMtime(dbPath, db, row), nil
+}
+
+func listZCodeSessionMeta(dbPath string) ([]dbBackedSessionMeta, error) {
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		return nil, nil
+	}
+	db, err := openZCodeDB(dbPath)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+
+	rows, err := db.Query(`
+		SELECT id,
+		       project_id,
+		       workspace_id,
+		       COALESCE(directory, ''),
+		       COALESCE(title, ''),
+		       COALESCE(time_created, ''),
+		       COALESCE(time_updated, '')
+		  FROM session
+		 ORDER BY COALESCE(time_updated, time_created), id
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("listing zcode sessions: %w", err)
+	}
+	defer rows.Close()
+
+	var metas []dbBackedSessionMeta
+	for rows.Next() {
+		row, err := scanZCodeSessionRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		if row.id == "" {
+			continue
+		}
+		metas = append(metas, dbBackedSessionMeta{
+			SessionID:   row.id,
+			VirtualPath: ZCodeSQLiteVirtualPath(dbPath, row.id),
+			FileMtime:   zcodeSessionFileMtime(dbPath, db, row),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	sort.Slice(metas, func(i, j int) bool {
+		return metas[i].SessionID < metas[j].SessionID
+	})
+	return metas, nil
+}
+
+func parseZCodeSession(dbPath, sessionID, machine string) (*ParseResult, error) {
+	db, err := openZCodeDB(dbPath)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+
+	row, err := loadZCodeSessionRow(db, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	result, err := buildZCodeParseResult(dbPath, machine, row, db)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func openZCodeDB(dbPath string) (*sql.DB, error) {
+	dsn := "file:" + sqliteURIPath(dbPath) + "?mode=ro&immutable=0&_busy_timeout=3000"
+	db, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		return nil, fmt.Errorf("opening zcode db %s: %w", dbPath, err)
+	}
+	return db, nil
+}
+
+type zcodeSessionRow struct {
+	id          string
+	projectID   sql.NullString
+	workspaceID sql.NullString
+	directory   sql.NullString
+	title       sql.NullString
+	timeCreated sql.NullString
+	timeUpdated sql.NullString
+}
+
+type zcodeUsageRow struct {
+	sessionID                string
+	turnID                   sql.NullString
+	providerID               sql.NullString
+	modelID                  sql.NullString
+	status                   sql.NullString
+	inputTokens              sql.NullInt64
+	outputTokens             sql.NullInt64
+	reasoningTokens          sql.NullInt64
+	cacheCreationInputTokens sql.NullInt64
+	cacheReadInputTokens     sql.NullInt64
+	computedTotalTokens      sql.NullInt64
+	startedAt                sql.NullString
+	completedAt              sql.NullString
+	durationMS               sql.NullInt64
+	toolCallCount            sql.NullInt64
+}
+
+func loadZCodeSessionRow(db *sql.DB, sessionID string) (zcodeSessionRow, error) {
+	row := db.QueryRow(`
+		SELECT id,
+		       project_id,
+		       workspace_id,
+		       COALESCE(directory, ''),
+		       COALESCE(title, ''),
+		       COALESCE(time_created, ''),
+		       COALESCE(time_updated, '')
+		  FROM session
+		 WHERE id = ?
+	`, sessionID)
+
+	var out zcodeSessionRow
+	err := row.Scan(
+		&out.id, &out.projectID, &out.workspaceID,
+		&out.directory, &out.title, &out.timeCreated, &out.timeUpdated,
+	)
+	if err != nil {
+		return zcodeSessionRow{}, fmt.Errorf("loading zcode session %s: %w", sessionID, err)
+	}
+	return out, nil
+}
+
+func scanZCodeSessionRow(rows *sql.Rows) (zcodeSessionRow, error) {
+	var out zcodeSessionRow
+	if err := rows.Scan(
+		&out.id, &out.projectID, &out.workspaceID,
+		&out.directory, &out.title, &out.timeCreated, &out.timeUpdated,
+	); err != nil {
+		return zcodeSessionRow{}, fmt.Errorf("scanning zcode session meta: %w", err)
+	}
+	return out, nil
+}
+
+func buildZCodeParseResult(
+	dbPath, machine string,
+	row zcodeSessionRow,
+	db *sql.DB,
+) (ParseResult, error) {
+	startedAt := zcodeParseTime(row.timeCreated.String)
+	endedAt := zcodeParseTime(row.timeUpdated.String)
+	if startedAt.IsZero() {
+		startedAt = endedAt
+	}
+	if endedAt.IsZero() {
+		endedAt = startedAt
+	}
+
+	directory := row.directory.String
+	project := ExtractProjectFromCwd(directory)
+	if project == "" {
+		switch {
+		case row.projectID.Valid:
+			project = "project-" + strings.TrimSpace(row.projectID.String)
+		case row.workspaceID.Valid:
+			project = "workspace-" + strings.TrimSpace(row.workspaceID.String)
+		default:
+			project = "unknown"
+		}
+	}
+
+	title := strings.TrimSpace(row.title.String)
+	firstMessage := title
+	if firstMessage != "" {
+		firstMessage = truncate(strings.ReplaceAll(firstMessage, "\n", " "), 300)
+	}
+
+	sess := ParsedSession{
+		ID:           "zcode:" + row.id,
+		Project:      project,
+		Machine:      machine,
+		Agent:        AgentZCode,
+		Cwd:          directory,
+		FirstMessage: firstMessage,
+		SessionName:  title,
+		StartedAt:    startedAt,
+		EndedAt:      endedAt,
+		MessageCount: 0,
+		File: FileInfo{
+			Path: ZCodeSQLiteVirtualPath(dbPath, row.id),
+		},
+	}
+	if info, err := os.Stat(dbPath); err == nil {
+		sess.File.Size = info.Size()
+	}
+	sess.File.Mtime = zcodeSessionFileMtime(dbPath, db, row)
+
+	usageEvents, err := listZCodeUsageEvents(db, row.id, startedAt, endedAt)
+	if err != nil {
+		return ParseResult{}, err
+	}
+	applyUsageEventTokenTotals(&sess, usageEvents)
+
+	return ParseResult{
+		Session:     sess,
+		UsageEvents: usageEvents,
+	}, nil
+}
+
+func listZCodeUsageEvents(
+	db *sql.DB,
+	sessionID string,
+	startedAt, endedAt time.Time,
+) ([]ParsedUsageEvent, error) {
+	rows, err := db.Query(`
+		SELECT session_id,
+		       CAST(turn_id AS TEXT),
+		       provider_id,
+		       COALESCE(model_id, ''),
+		       COALESCE(status, ''),
+		       COALESCE(input_tokens, 0),
+		       COALESCE(output_tokens, 0),
+		       COALESCE(reasoning_tokens, 0),
+		       COALESCE(cache_creation_input_tokens, 0),
+		       COALESCE(cache_read_input_tokens, 0),
+		       COALESCE(computed_total_tokens, 0),
+		       COALESCE(started_at, ''),
+		       COALESCE(completed_at, ''),
+		       COALESCE(duration_ms, 0),
+		       COALESCE(tool_call_count, 0)
+		  FROM model_usage
+		 WHERE session_id = ?
+		 ORDER BY
+		       COALESCE(turn_id, -1),
+		       COALESCE(started_at, ''),
+		       COALESCE(completed_at, ''),
+		       COALESCE(provider_id, -1),
+		       COALESCE(model_id, ''),
+		       COALESCE(status, ''),
+		       COALESCE(input_tokens, 0),
+		       COALESCE(output_tokens, 0),
+		       COALESCE(reasoning_tokens, 0),
+		       COALESCE(cache_creation_input_tokens, 0),
+		       COALESCE(cache_read_input_tokens, 0),
+		       COALESCE(computed_total_tokens, 0),
+		       COALESCE(duration_ms, 0),
+		       COALESCE(tool_call_count, 0)
+	`, sessionID)
+	if err != nil {
+		if strings.Contains(err.Error(), "no such table: model_usage") {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("listing zcode usage rows for %s: %w", sessionID, err)
+	}
+	defer rows.Close()
+
+	var events []ParsedUsageEvent
+	for rows.Next() {
+		row, err := scanZCodeUsageRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		if row.sessionID == "" {
+			continue
+		}
+		fullSessionID := "zcode:" + row.sessionID
+		ev := ParsedUsageEvent{
+			SessionID:                fullSessionID,
+			Source:                   "session",
+			Model:                    row.modelID.String,
+			InputTokens:              int(row.inputTokens.Int64),
+			OutputTokens:             int(row.outputTokens.Int64),
+			CacheCreationInputTokens: int(row.cacheCreationInputTokens.Int64),
+			CacheReadInputTokens:     int(row.cacheReadInputTokens.Int64),
+			ReasoningTokens:          int(row.reasoningTokens.Int64),
+			OccurredAt:               timeString(zcodeUsageTime(row.completedAt.String), zcodeUsageTime(row.startedAt.String)),
+			DedupKey:                 zcodeUsageDedupKey(fullSessionID, row),
+		}
+		if row.turnID.Valid {
+			if parsed, err := strconv.Atoi(strings.TrimSpace(row.turnID.String)); err == nil {
+				ev.MessageOrdinal = &parsed
+			}
+		}
+		if ev.OccurredAt == "" {
+			ev.OccurredAt = timeString(endedAt, startedAt)
+		}
+		events = append(events, ev)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return events, nil
+}
+
+func scanZCodeUsageRow(rows *sql.Rows) (zcodeUsageRow, error) {
+	var out zcodeUsageRow
+	if err := rows.Scan(
+		&out.sessionID, &out.turnID, &out.providerID,
+		&out.modelID, &out.status, &out.inputTokens, &out.outputTokens,
+		&out.reasoningTokens, &out.cacheCreationInputTokens,
+		&out.cacheReadInputTokens, &out.computedTotalTokens,
+		&out.startedAt, &out.completedAt, &out.durationMS,
+		&out.toolCallCount,
+	); err != nil {
+		return zcodeUsageRow{}, fmt.Errorf("scanning zcode usage row: %w", err)
+	}
+	return out, nil
+}
+
+func zcodeUsageDedupKey(fullSessionID string, row zcodeUsageRow) string {
+	parts := []string{
+		"session:" + fullSessionID,
+		"turn=" + row.turnID.String,
+		"provider=" + row.providerID.String,
+		"model=" + row.modelID.String,
+		"status=" + row.status.String,
+		"started_at=" + row.startedAt.String,
+		"completed_at=" + row.completedAt.String,
+		"duration_ms=" + zcodeNullInt64String(row.durationMS),
+		"tool_call_count=" + zcodeNullInt64String(row.toolCallCount),
+		"input_tokens=" + zcodeNullInt64String(row.inputTokens),
+		"output_tokens=" + zcodeNullInt64String(row.outputTokens),
+		"reasoning_tokens=" + zcodeNullInt64String(row.reasoningTokens),
+		"cache_creation_input_tokens=" + zcodeNullInt64String(row.cacheCreationInputTokens),
+		"cache_read_input_tokens=" + zcodeNullInt64String(row.cacheReadInputTokens),
+		"computed_total_tokens=" + zcodeNullInt64String(row.computedTotalTokens),
+	}
+	return strings.Join(parts, "|")
+}
+
+func zcodeNullInt64String(v sql.NullInt64) string {
+	if !v.Valid {
+		return ""
+	}
+	return strconv.FormatInt(v.Int64, 10)
+}
+
+func zcodeParseTime(raw string) time.Time {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}
+	}
+	if ts := parseTimestamp(raw); !ts.IsZero() {
+		return ts
+	}
+	if n, err := strconv.ParseInt(raw, 10, 64); err == nil {
+		switch {
+		case n >= 1_000_000_000_000_000_000:
+			return time.Unix(0, n).UTC()
+		case n >= 1_000_000_000_000:
+			return time.UnixMilli(n).UTC()
+		case n >= 1_000_000_000:
+			return time.Unix(n, 0).UTC()
+		default:
+			return time.Unix(n, 0).UTC()
+		}
+	}
+	return time.Time{}
+}
+
+func zcodeUsageTime(raw string) time.Time {
+	return zcodeParseTime(raw)
+}
+
+func zcodeSessionFileMtime(dbPath string, db *sql.DB, row zcodeSessionRow) int64 {
+	maxMtime := zcodeTimeUnixNano(zcodeRowUpdatedAt(row))
+	if usageMtime, err := zcodeMaxUsageMtime(db, row.id); err == nil {
+		maxMtime = max(maxMtime, usageMtime)
+	}
+	for _, path := range []string{dbPath, dbPath + "-wal", dbPath + "-shm"} {
+		if info, err := os.Stat(path); err == nil {
+			maxMtime = max(maxMtime, info.ModTime().UnixNano())
+		}
+	}
+	return maxMtime
+}
+
+func zcodeMaxUsageMtime(db *sql.DB, sessionID string) (int64, error) {
+	rows, err := db.Query(`
+		SELECT CAST(COALESCE(completed_at, '') AS TEXT),
+		       CAST(COALESCE(started_at, '') AS TEXT)
+		  FROM model_usage
+		 WHERE session_id = ?
+	`, sessionID)
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "no such table: model_usage") {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("listing zcode usage mtimes: %w", err)
+	}
+	defer rows.Close()
+
+	var maxMtime int64
+	for rows.Next() {
+		var completedAt, startedAt string
+		if err := rows.Scan(&completedAt, &startedAt); err != nil {
+			return 0, fmt.Errorf("scanning zcode usage mtime: %w", err)
+		}
+		maxMtime = max(maxMtime, zcodeTimeUnixNano(zcodeUsageTime(completedAt)))
+		maxMtime = max(maxMtime, zcodeTimeUnixNano(zcodeUsageTime(startedAt)))
+	}
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+	return maxMtime, nil
+}
+
+func zcodeTimeUnixNano(ts time.Time) int64 {
+	if ts.IsZero() {
+		return 0
+	}
+	return ts.UnixNano()
+}
+
+func zcodeRowUpdatedAt(row zcodeSessionRow) time.Time {
+	if ts := zcodeParseTime(row.timeUpdated.String); !ts.IsZero() {
+		return ts
+	}
+	if ts := zcodeParseTime(row.timeCreated.String); !ts.IsZero() {
+		return ts
+	}
+	return time.Time{}
+}

--- a/internal/parser/zcode_test.go
+++ b/internal/parser/zcode_test.go
@@ -1,0 +1,525 @@
+package parser
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const zcodeTestSchema = `
+	CREATE TABLE session (
+		id TEXT PRIMARY KEY NOT NULL,
+		project_id TEXT,
+		workspace_id TEXT,
+		directory TEXT,
+		title TEXT,
+		time_created INTEGER,
+		time_updated INTEGER
+	);
+	CREATE TABLE model_usage (
+		session_id TEXT NOT NULL,
+		turn_id TEXT,
+		provider_id TEXT,
+		model_id TEXT,
+		status TEXT,
+		input_tokens INTEGER,
+		output_tokens INTEGER,
+		reasoning_tokens INTEGER,
+		cache_creation_input_tokens INTEGER,
+		cache_read_input_tokens INTEGER,
+		computed_total_tokens INTEGER,
+		started_at INTEGER,
+		completed_at INTEGER,
+		duration_ms INTEGER,
+		tool_call_count INTEGER
+	);
+`
+
+type zcodeTestFixture struct {
+	Root     string
+	CLIRoot  string
+	DBDir    string
+	DBPath   string
+	database *sql.DB
+}
+
+func newZCodeTestFixture(t *testing.T) *zcodeTestFixture {
+	t.Helper()
+	root := t.TempDir()
+	cliRoot := filepath.Join(root, ".zcode", "cli")
+	dbDir := filepath.Join(cliRoot, "db")
+	require.NoError(t, os.MkdirAll(dbDir, 0o755))
+	dbPath := filepath.Join(dbDir, zcodeDBName)
+
+	database, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = database.Close() })
+	_, err = database.Exec(zcodeTestSchema)
+	require.NoError(t, err)
+
+	return &zcodeTestFixture{
+		Root:     root,
+		CLIRoot:  cliRoot,
+		DBDir:    dbDir,
+		DBPath:   dbPath,
+		database: database,
+	}
+}
+
+func (f *zcodeTestFixture) insertSession(
+	t *testing.T,
+	id, directory, title string,
+	createdAt, updatedAt any,
+	projectID, workspaceID string,
+) {
+	t.Helper()
+	_, err := f.database.Exec(`
+		INSERT INTO session (
+			id, project_id, workspace_id, directory, title,
+			time_created, time_updated
+		) VALUES (?, ?, ?, ?, ?, ?, ?)
+	`, id, nullableZCodeString(projectID), nullableZCodeString(workspaceID), directory, title, createdAt, updatedAt)
+	require.NoError(t, err)
+}
+
+func (f *zcodeTestFixture) insertUsage(
+	t *testing.T,
+	sessionID string,
+	turnID string,
+	providerID string,
+	modelID, status string,
+	inputTokens, outputTokens, reasoningTokens,
+	cacheCreationTokens, cacheReadTokens, computedTotalTokens int64,
+	startedAt, completedAt string,
+	durationMS, toolCallCount int64,
+) {
+	t.Helper()
+	_, err := f.database.Exec(`
+		INSERT INTO model_usage (
+			session_id, turn_id, provider_id, model_id, status,
+			input_tokens, output_tokens, reasoning_tokens,
+			cache_creation_input_tokens, cache_read_input_tokens,
+			computed_total_tokens, started_at, completed_at,
+			duration_ms, tool_call_count
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, sessionID, nullableZCodeString(turnID), nullableZCodeString(providerID), modelID, status,
+		inputTokens, outputTokens, reasoningTokens,
+		cacheCreationTokens, cacheReadTokens, computedTotalTokens,
+		startedAt, completedAt, durationMS, toolCallCount)
+	require.NoError(t, err)
+}
+
+func TestZCodeParsesReportedIntegerTimestamps(t *testing.T) {
+	fixture := newZCodeTestFixture(t)
+	fixture.insertSession(
+		t,
+		"session-ms",
+		"/Users/alice/code/ms-app",
+		"Integer timestamps",
+		int64(1783352401000),
+		int64(1783352700000),
+		"",
+		"",
+	)
+	oldDBMtime := time.Date(2026, 7, 6, 13, 0, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(fixture.DBPath, oldDBMtime, oldDBMtime))
+
+	provider, ok := NewProvider(AgentZCode, ProviderConfig{
+		Roots:   []string{fixture.CLIRoot},
+		Machine: "devbox",
+	})
+	require.True(t, ok)
+
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+
+	outcome, err := provider.Parse(context.Background(), ParseRequest{
+		Source:  sources[0],
+		Machine: "devbox",
+	})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	assert.Equal(t, int64(1783352401000000000), outcome.Results[0].Result.Session.StartedAt.UnixNano())
+	assert.Equal(t, int64(1783352700000000000), outcome.Results[0].Result.Session.EndedAt.UnixNano())
+	assert.Equal(t, int64(1783352700000000000), outcome.Results[0].Result.Session.File.Mtime)
+}
+
+func TestZCodeProviderSourceMethodsAndParse(t *testing.T) {
+	fixture := newZCodeTestFixture(t)
+	fixture.insertSession(
+		t,
+		"session-001",
+		"/Users/alice/code/acme-app",
+		"Acme session",
+		"2026-07-06T13:00:01Z",
+		"2026-07-06T13:05:00Z",
+		"project-7",
+		"workspace-19",
+	)
+	fixture.insertUsage(
+		t,
+		"session-001",
+		"1",
+		"builtin:bigmodel-coding-plan",
+		"claude-sonnet-4-6",
+		"done",
+		1000, 200, 40, 50, 25, 1315,
+		"2026-07-06T13:00:02Z",
+		"2026-07-06T13:00:03Z",
+		1000,
+		2,
+	)
+	fixture.insertUsage(
+		t,
+		"session-001",
+		"2",
+		"builtin:bigmodel-coding-plan",
+		"claude-sonnet-4-6",
+		"done",
+		800, 75, 5, 10, 0, 890,
+		"2026-07-06T13:04:00Z",
+		"2026-07-06T13:05:00Z",
+		600,
+		0,
+	)
+
+	provider, ok := NewProvider(AgentZCode, ProviderConfig{
+		Roots: []string{
+			fixture.CLIRoot,
+			fixture.DBDir,
+		},
+		Machine: "devbox",
+	})
+	require.True(t, ok)
+
+	plan, err := provider.WatchPlan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, plan.Roots, 1)
+	assert.Equal(t, fixture.DBDir, plan.Roots[0].Path)
+	assert.Contains(t, plan.Roots[0].IncludeGlobs, zcodeDBName)
+	assert.Contains(t, plan.Roots[0].IncludeGlobs, zcodeDBName+"-*")
+
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	source := sources[0]
+	assert.Equal(t, AgentZCode, source.Provider)
+	assert.Equal(t, fixture.DBPath+"#session-001", source.DisplayPath)
+
+	fingerprint, err := provider.Fingerprint(context.Background(), source)
+	require.NoError(t, err)
+	assert.Equal(t, fixture.DBPath+"#session-001", fingerprint.Key)
+	assert.NotZero(t, fingerprint.MTimeNS)
+
+	foundSource, found, err := provider.FindSource(context.Background(), FindSourceRequest{
+		RawSessionID:  "session-001",
+		FullSessionID: "zcode:session-001",
+	})
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, source.DisplayPath, foundSource.DisplayPath)
+
+	outcome, err := provider.Parse(context.Background(), ParseRequest{
+		Source:      foundSource,
+		Fingerprint: fingerprint,
+		Machine:     "devbox",
+	})
+	require.NoError(t, err)
+	require.True(t, outcome.ResultSetComplete)
+	require.True(t, outcome.ForceReplace)
+	require.Len(t, outcome.Results, 1)
+
+	result := outcome.Results[0]
+	sess := result.Result.Session
+	assert.Equal(t, "zcode:session-001", sess.ID)
+	assert.Equal(t, AgentZCode, sess.Agent)
+	assert.Equal(t, "devbox", sess.Machine)
+	assert.Equal(t, "acme_app", sess.Project)
+	assert.Equal(t, "/Users/alice/code/acme-app", sess.Cwd)
+	assert.Equal(t, "Acme session", sess.SessionName)
+	assert.Equal(t, "Acme session", sess.FirstMessage)
+	assert.Equal(t, 0, sess.MessageCount)
+	assert.Equal(t, 0, sess.UserMessageCount)
+	assert.Equal(t, fixture.DBPath+"#session-001", sess.File.Path)
+	assert.NotZero(t, sess.File.Size)
+	assert.Equal(t, 2, len(result.Result.UsageEvents))
+	assert.Equal(t, 275, sess.TotalOutputTokens)
+	assert.True(t, sess.HasTotalOutputTokens)
+	assert.Equal(t, 1075, sess.PeakContextTokens)
+	assert.True(t, sess.HasPeakContextTokens)
+
+	first := result.Result.UsageEvents[0]
+	second := result.Result.UsageEvents[1]
+	require.NotNil(t, first.MessageOrdinal)
+	require.NotNil(t, second.MessageOrdinal)
+	assert.Equal(t, 1, *first.MessageOrdinal)
+	assert.Equal(t, 2, *second.MessageOrdinal)
+	assert.Equal(t, "zcode:session-001", first.SessionID)
+	assert.Equal(t, "session", first.Source)
+	assert.Equal(t, "claude-sonnet-4-6", first.Model)
+	assert.Equal(t, 1000, first.InputTokens)
+	assert.Equal(t, 200, first.OutputTokens)
+	assert.Equal(t, 40, first.ReasoningTokens)
+	assert.Equal(t, 50, first.CacheCreationInputTokens)
+	assert.Equal(t, 25, first.CacheReadInputTokens)
+	assert.Equal(t, "zcode:session-001", second.SessionID)
+	assert.NotEqual(t, first.DedupKey, second.DedupKey)
+	assert.Contains(t, first.DedupKey, "session:zcode:session-001")
+	assert.Contains(t, first.DedupKey, "turn=1")
+	assert.Contains(t, first.DedupKey, "provider=builtin:bigmodel-coding-plan")
+	assert.Contains(t, first.DedupKey, "model=claude-sonnet-4-6")
+	assert.Contains(t, first.DedupKey, "input_tokens=1000")
+}
+
+func TestZCodeUsageEventMapping(t *testing.T) {
+	fixture := newZCodeTestFixture(t)
+	fixture.insertSession(
+		t,
+		"session-usage",
+		"/Users/alice/code/acme-app",
+		"Usage session",
+		"2026-07-06T13:00:01Z",
+		"2026-07-06T13:05:00Z",
+		"",
+		"",
+	)
+	fixture.insertUsage(
+		t,
+		"session-usage",
+		"turn-alpha",
+		"builtin:bigmodel-coding-plan",
+		"claude-sonnet-4-6",
+		"done",
+		1000, 200, 40, 50, 25, 1315,
+		"2026-07-06T13:00:02Z",
+		"2026-07-06T13:00:03Z",
+		1000,
+		2,
+	)
+
+	provider, ok := NewProvider(AgentZCode, ProviderConfig{
+		Roots:   []string{fixture.CLIRoot},
+		Machine: "devbox",
+	})
+	require.True(t, ok)
+
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+
+	outcome, err := provider.Parse(context.Background(), ParseRequest{
+		Source:      sources[0],
+		Fingerprint: SourceFingerprint{Key: fixture.DBPath + "#session-usage"},
+		Machine:     "devbox",
+	})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+
+	result := outcome.Results[0]
+	require.Len(t, result.Result.UsageEvents, 1)
+	event := result.Result.UsageEvents[0]
+	assert.Equal(t, "zcode:session-usage", event.SessionID)
+	assert.Nil(t, event.MessageOrdinal)
+	assert.Equal(t, "claude-sonnet-4-6", event.Model)
+	assert.Equal(t, 1000, event.InputTokens)
+	assert.Equal(t, 200, event.OutputTokens)
+	assert.Equal(t, 40, event.ReasoningTokens)
+	assert.Equal(t, 50, event.CacheCreationInputTokens)
+	assert.Equal(t, 25, event.CacheReadInputTokens)
+	assert.Contains(t, event.DedupKey, "session:zcode:session-usage")
+	assert.Contains(t, event.DedupKey, "turn=turn-alpha")
+	assert.Contains(t, event.DedupKey, "provider=builtin:bigmodel-coding-plan")
+	assert.Contains(t, event.DedupKey, "model=claude-sonnet-4-6")
+}
+
+func TestZCodeFingerprintTracksUsageMtime(t *testing.T) {
+	fixture := newZCodeTestFixture(t)
+	fixture.insertSession(
+		t,
+		"session-usage-mtime",
+		"/Users/alice/code/acme-app",
+		"Usage mtime",
+		"2026-07-06T13:00:01Z",
+		"2026-07-06T13:01:00Z",
+		"",
+		"",
+	)
+	fixture.insertUsage(
+		t,
+		"session-usage-mtime",
+		"turn-alpha",
+		"builtin:bigmodel-coding-plan",
+		"claude-sonnet-4-6",
+		"done",
+		1000, 200, 40, 50, 25, 1315,
+		"2026-07-06T13:09:00Z",
+		"2026-07-06T13:10:00Z",
+		1000,
+		2,
+	)
+	oldDBMtime := time.Date(2026, 7, 6, 13, 0, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(fixture.DBPath, oldDBMtime, oldDBMtime))
+
+	provider, ok := NewProvider(AgentZCode, ProviderConfig{
+		Roots:   []string{fixture.CLIRoot},
+		Machine: "devbox",
+	})
+	require.True(t, ok)
+
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+
+	fingerprint, err := provider.Fingerprint(context.Background(), sources[0])
+	require.NoError(t, err)
+	expected := time.Date(2026, 7, 6, 13, 10, 0, 0, time.UTC).UnixNano()
+	assert.Equal(t, expected, fingerprint.MTimeNS)
+}
+
+func TestZCodeFingerprintTracksDBMtimeForUsageOnlyChanges(t *testing.T) {
+	fixture := newZCodeTestFixture(t)
+	fixture.insertSession(
+		t,
+		"session-db-mtime",
+		"/Users/alice/code/acme-app",
+		"DB mtime",
+		"2026-07-06T13:00:01Z",
+		"2026-07-06T13:10:00Z",
+		"",
+		"",
+	)
+	fixture.insertUsage(
+		t,
+		"session-db-mtime",
+		"turn-alpha",
+		"builtin:bigmodel-coding-plan",
+		"claude-sonnet-4-6",
+		"done",
+		1000, 200, 40, 50, 25, 1315,
+		"2026-07-06T13:04:00Z",
+		"2026-07-06T13:05:00Z",
+		1000,
+		2,
+	)
+	dbMtime := time.Date(2026, 7, 6, 13, 20, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(fixture.DBPath, dbMtime, dbMtime))
+
+	provider, ok := NewProvider(AgentZCode, ProviderConfig{
+		Roots:   []string{fixture.CLIRoot},
+		Machine: "devbox",
+	})
+	require.True(t, ok)
+
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+
+	fingerprint, err := provider.Fingerprint(context.Background(), sources[0])
+	require.NoError(t, err)
+	assert.Equal(t, dbMtime.UnixNano(), fingerprint.MTimeNS)
+}
+
+func TestZCodeFallsBackToDBMtimeWhenTimestampsAreMissing(t *testing.T) {
+	fixture := newZCodeTestFixture(t)
+	fixture.insertSession(
+		t,
+		"session-no-timestamps",
+		"/Users/alice/code/acme-app",
+		"No timestamps",
+		nil,
+		nil,
+		"",
+		"",
+	)
+	dbMtime := time.Date(2026, 7, 6, 13, 20, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(fixture.DBPath, dbMtime, dbMtime))
+
+	provider, ok := NewProvider(AgentZCode, ProviderConfig{
+		Roots:   []string{fixture.CLIRoot},
+		Machine: "devbox",
+	})
+	require.True(t, ok)
+
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+
+	outcome, err := provider.Parse(context.Background(), ParseRequest{
+		Source:  sources[0],
+		Machine: "devbox",
+	})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	assert.Equal(t, dbMtime.UnixNano(), outcome.Results[0].Result.Session.File.Mtime)
+}
+
+func TestZCodeParsesSessionWhenUsageTableIsMissing(t *testing.T) {
+	fixture := newZCodeTestFixture(t)
+	_, err := fixture.database.Exec(`DROP TABLE model_usage`)
+	require.NoError(t, err)
+	fixture.insertSession(
+		t,
+		"session-no-usage-table",
+		"/Users/alice/code/acme-app",
+		"No usage table",
+		"2026-07-06T13:00:01Z",
+		"2026-07-06T13:05:00Z",
+		"",
+		"",
+	)
+
+	provider, ok := NewProvider(AgentZCode, ProviderConfig{
+		Roots:   []string{fixture.CLIRoot},
+		Machine: "devbox",
+	})
+	require.True(t, ok)
+
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+
+	outcome, err := provider.Parse(context.Background(), ParseRequest{
+		Source:  sources[0],
+		Machine: "devbox",
+	})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+
+	result := outcome.Results[0].Result
+	assert.Equal(t, "zcode:session-no-usage-table", result.Session.ID)
+	assert.Equal(t, 0, result.Session.MessageCount)
+	assert.Empty(t, result.UsageEvents)
+	assert.False(t, result.Session.HasTotalOutputTokens)
+	assert.False(t, result.Session.HasPeakContextTokens)
+}
+
+func TestZCodeProviderRootWithoutDB(t *testing.T) {
+	root := t.TempDir()
+	cliRoot := filepath.Join(root, ".zcode", "cli")
+	require.NoError(t, os.MkdirAll(cliRoot, 0o755))
+
+	provider, ok := NewProvider(AgentZCode, ProviderConfig{
+		Roots:   []string{cliRoot},
+		Machine: "devbox",
+	})
+	require.True(t, ok)
+
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, sources)
+}
+
+func nullableZCodeString(v string) any {
+	if v == "" {
+		return nil
+	}
+	return v
+}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -841,6 +841,8 @@ func providerDeletedPhysicalSQLiteSource(
 	switch agent {
 	case parser.AgentZed:
 		return filepath.Base(path) == "threads.db"
+	case parser.AgentZCode:
+		return filepath.Base(path) == parser.ZCodeDBName
 	case parser.AgentShelley:
 		return filepath.Base(path) == shelleyDBFile
 	default:
@@ -1979,7 +1981,7 @@ func (e *Engine) syncAllLocked(
 	// through the provider facade in the file-sync phase above, so no
 	// dedicated DB-backed sync pass is needed here.
 
-	// Sync Warp, Forge, and Piebald sessions. These are provider-authoritative
+	// Sync Warp, Forge, Piebald, and ZCode sessions. These are provider-authoritative
 	// DB-backed providers: a shared SQLite DB hosts every session, so the
 	// provider facade enumerates sources and parses only the changed ones.
 	if scope.includesAny(e.agentDirs[parser.AgentWarp]) {
@@ -2009,9 +2011,18 @@ func (e *Engine) syncAllLocked(
 			return stats
 		}
 	}
+	if scope.includesAny(e.agentDirs[parser.AgentZCode]) {
+		if e.syncProviderDBBackedAgent(
+			ctx, parser.AgentZCode, "zcode",
+			writeMode, verbose, scope, &stats, advanceDBProgress,
+		) {
+			stats.Aborted = true
+			return stats
+		}
+	}
 
 	// Link subagent child sessions to their parents after all DB-backed
-	// agent writes (including provider-authoritative Forge and Piebald).
+	// agent writes (including provider-authoritative Forge, Piebald, and ZCode).
 	// LinkSubagentSessions is idempotent — its WHERE filter and partial index
 	// make it a cheap no-op when nothing new was written — so no guard is
 	// needed.
@@ -2135,7 +2146,7 @@ func (e *Engine) discoverProviderSources(
 			_, ok := forceParseSources[filepath.Clean(sourcePath)]
 			return ok
 		}
-		// Forge, Piebald, and Warp are DB-backed providers: a shared SQLite
+		// Forge, Piebald, Warp, and ZCode are DB-backed providers: a shared SQLite
 		// DB hosts every session. Full-sync change detection and counting
 		// run through their dedicated provider-driven DB sync phase
 		// (syncProviderDBBacked), not the per-source discovery list, so a
@@ -2991,6 +3002,7 @@ func (e *Engine) countDBBackedSessions(
 		parser.AgentWarp,
 		parser.AgentForge,
 		parser.AgentPiebald,
+		parser.AgentZCode,
 	} {
 		total += e.countDBBackedProgressTotal(agent, scope)
 	}
@@ -3640,7 +3652,7 @@ func (e *Engine) processProviderFile(
 		return processResult{err: err}, true
 	}
 	if !found {
-		// A forced parse on a deleted shared SQLite database (Zed, Shelley)
+		// A forced parse on a deleted shared SQLite database (Zed, ZCode, Shelley)
 		// resolves to no source because the physical file is gone. Mirror the
 		// legacy deleted-source handling: complete the source as an empty
 		// force-replace so the engine retires every session that lived in the
@@ -4202,7 +4214,7 @@ func (e *Engine) providerSkipCacheEntryFreshInDB(
 
 func processFileUsesProvider(agent parser.AgentType) bool {
 	switch agent {
-	case parser.AgentForge, parser.AgentPiebald, parser.AgentWarp:
+	case parser.AgentForge, parser.AgentPiebald, parser.AgentWarp, parser.AgentZCode:
 		return true
 	default:
 		return false
@@ -4246,7 +4258,7 @@ func (e *Engine) shouldSkipProviderSource(
 
 func providerSourceSupportsPersistedFreshness(agent parser.AgentType) bool {
 	switch agent {
-	case parser.AgentForge, parser.AgentWarp:
+	case parser.AgentForge, parser.AgentWarp, parser.AgentZCode:
 		return true
 	default:
 		return false
@@ -4288,6 +4300,14 @@ func (e *Engine) shouldCacheSkip(
 			return false
 		}
 		if _, _, ok := parser.ParseVirtualSourcePathForBase(file.Path, "threads.db"); ok {
+			return false
+		}
+	}
+	if file.Agent == parser.AgentZCode {
+		if filepath.Base(file.Path) == parser.ZCodeDBName {
+			return false
+		}
+		if _, _, ok := parser.ParseVirtualSourcePathForBase(file.Path, parser.ZCodeDBName); ok {
 			return false
 		}
 	}
@@ -7609,7 +7629,7 @@ func (e *Engine) FindSourceFile(sessionID string) string {
 	}
 	rawSessionID := strings.TrimPrefix(rawID, def.IDPrefix)
 	if !def.FileBased {
-		// Forge, Piebald, and Warp are DB-backed providers that own
+		// Forge, Piebald, Warp, and ZCode are DB-backed providers that own
 		// discovery and source lookup through the provider facade. Their
 		// virtual <db>#<sessionID> path is resolved by findProviderSourceFile
 		// below. Non-provider, non-file-based agents (e.g. remote imports)
@@ -7872,7 +7892,7 @@ func (e *Engine) SourceMtime(sessionID string) int64 {
 	}
 	rawSessionID := strings.TrimPrefix(rawID, def.IDPrefix)
 	if !def.FileBased {
-		// Forge, Piebald, and Warp are DB-backed providers: their
+		// Forge, Piebald, Warp, and ZCode are DB-backed providers: their
 		// per-session source mtime comes from the provider fingerprint
 		// (which mirrors the legacy List*SessionMeta last-modified value).
 		// Non-provider, non-file-based agents have no local source.
@@ -8070,7 +8090,7 @@ func (e *Engine) SyncSingleSessionContext(
 		return fmt.Errorf("unknown agent for session %s", sessionID)
 	}
 	if !def.FileBased {
-		// Forge, Piebald, and Warp are DB-backed providers: re-sync routes
+		// Forge, Piebald, Warp, and ZCode are DB-backed providers: re-sync routes
 		// through FindSourceFile (resolving the virtual <db>#<sessionID>
 		// path) plus the provider-aware processFile path below, mirroring
 		// the file-based agents. Other non-file-based agents use the

--- a/internal/sync/provider_process_test.go
+++ b/internal/sync/provider_process_test.go
@@ -277,12 +277,44 @@ func TestProcessFileProviderWarpVirtualSource(t *testing.T) {
 	assert.NotEmpty(t, res.results[0].Messages)
 }
 
+func TestProcessFileProviderZCodeVirtualSource(t *testing.T) {
+	root := t.TempDir()
+	dbPath := writeProcessProviderZCodeDB(t, filepath.Join(root, ".zcode", "cli"))
+	engine := NewEngine(openTestDB(t), EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentZCode: {filepath.Join(root, ".zcode", "cli")},
+		},
+		Machine: "devbox",
+	})
+
+	files := engine.classifyProviderChangedPath(dbPath)
+	require.Len(t, files, 1)
+	assert.Equal(t, dbPath+"#session-001", files[0].Path)
+	assert.Equal(t, parser.AgentZCode, files[0].Agent)
+	assert.False(t, files[0].ForceParse)
+
+	res := engine.processFile(context.Background(), files[0])
+
+	require.NoError(t, res.err)
+	require.Len(t, res.results, 1)
+	assert.True(t, res.forceReplace)
+	assert.NotZero(t, res.mtime)
+	assert.Equal(t, "zcode:session-001", res.results[0].Session.ID)
+	assert.Equal(t, parser.AgentZCode, res.results[0].Session.Agent)
+	assert.Equal(t, "devbox", res.results[0].Session.Machine)
+	assert.Empty(t, res.results[0].Messages)
+	require.Len(t, res.results[0].UsageEvents, 1)
+	assert.Equal(t, 1, res.results[0].UsageEvents[0].InputTokens)
+	assert.Equal(t, 2, res.results[0].UsageEvents[0].OutputTokens)
+}
+
 func TestProcessFileUsesProviderDBBackedFamily(t *testing.T) {
 
 	for _, agent := range []parser.AgentType{
 		parser.AgentForge,
 		parser.AgentPiebald,
 		parser.AgentWarp,
+		parser.AgentZCode,
 	} {
 		assert.True(t, processFileUsesProvider(agent), agent)
 	}
@@ -1366,6 +1398,65 @@ func seedProcessProviderWarpConversation(t *testing.T, database *sql.DB) {
 		`"Completed"`,
 		"auto-genius",
 	)
+}
+
+func writeProcessProviderZCodeDB(t *testing.T, cliRoot string) string {
+	t.Helper()
+	dbDir := filepath.Join(cliRoot, "db")
+	require.NoError(t, os.MkdirAll(dbDir, 0o755))
+	dbPath := filepath.Join(dbDir, "db.sqlite")
+	database, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = database.Close() })
+	mustExecProcessProviderSQL(t, database, `
+		CREATE TABLE session (
+			id TEXT PRIMARY KEY NOT NULL,
+			project_id TEXT,
+			workspace_id TEXT,
+			directory TEXT,
+			title TEXT,
+			time_created TEXT,
+			time_updated TEXT
+		);
+		CREATE TABLE model_usage (
+			session_id TEXT NOT NULL,
+			turn_id TEXT,
+			provider_id TEXT,
+			model_id TEXT,
+			status TEXT,
+			input_tokens INTEGER,
+			output_tokens INTEGER,
+			reasoning_tokens INTEGER,
+			cache_creation_input_tokens INTEGER,
+			cache_read_input_tokens INTEGER,
+			computed_total_tokens INTEGER,
+			started_at TEXT,
+			completed_at TEXT,
+			duration_ms INTEGER,
+			tool_call_count INTEGER
+		);
+	`)
+	mustExecProcessProviderSQL(t, database,
+		`INSERT INTO session (
+			id, project_id, workspace_id, directory, title,
+			time_created, time_updated
+		) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"session-001", "project-7", "workspace-19", "/Users/alice/code/acme-app",
+		"Acme session", "2026-07-06T13:00:01Z", "2026-07-06T13:05:00Z",
+	)
+	mustExecProcessProviderSQL(t, database,
+		`INSERT INTO model_usage (
+			session_id, turn_id, provider_id, model_id, status,
+			input_tokens, output_tokens, reasoning_tokens,
+			cache_creation_input_tokens, cache_read_input_tokens,
+			computed_total_tokens, started_at, completed_at,
+			duration_ms, tool_call_count
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"session-001", "1", "builtin:bigmodel-coding-plan", "claude-sonnet-4-6", "done",
+		int64(1), int64(2), int64(0), int64(0), int64(0), int64(3),
+		"2026-07-06T13:00:02Z", "2026-07-06T13:00:03Z", int64(1000), int64(1),
+	)
+	return dbPath
 }
 
 func mustExecProcessProviderSQL(

--- a/internal/sync/zcode_integration_test.go
+++ b/internal/sync/zcode_integration_test.go
@@ -1,0 +1,58 @@
+package sync
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+func TestSyncZCode(t *testing.T) {
+	root := t.TempDir()
+	dbPath := writeProcessProviderZCodeDB(t, filepath.Join(root, ".zcode", "cli"))
+	database := openTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentZCode: {filepath.Join(root, ".zcode", "cli")},
+		},
+		Machine: "devbox",
+	})
+
+	runSyncAndAssert(t, engine, SyncStats{TotalSessions: 1, Synced: 1, Skipped: 0})
+
+	sess, err := database.GetSession(context.Background(), "zcode:session-001")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, 0, sess.MessageCount)
+	assert.Equal(t, "acme_app", sess.Project)
+	assert.Equal(t, dbPath+"#session-001", database.GetSessionFilePath("zcode:session-001"))
+	_, storedMtime, ok := database.GetSessionFileInfo("zcode:session-001")
+	require.True(t, ok)
+	assert.Equal(t, engine.SourceMtime("zcode:session-001"), storedMtime)
+
+	events, err := database.GetUsageEvents(context.Background(), "zcode:session-001")
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.Equal(t, "claude-sonnet-4-6", events[0].Model)
+	assert.Equal(t, 1, events[0].InputTokens)
+	assert.Equal(t, 2, events[0].OutputTokens)
+	assert.Contains(t, events[0].DedupKey, "session:zcode:session-001")
+	assert.Contains(t, events[0].DedupKey, "turn=1")
+	assert.Contains(t, events[0].DedupKey, "model=claude-sonnet-4-6")
+
+	runSyncAndAssert(t, engine, SyncStats{TotalSessions: 0, Synced: 0, Skipped: 0})
+}
+
+func runSyncAndAssert(t *testing.T, engine *Engine, want SyncStats) SyncStats {
+	t.Helper()
+	stats := engine.SyncAll(context.Background(), nil)
+	diff := cmp.Diff(want, stats, cmpopts.IgnoreUnexported(SyncStats{}))
+	require.Empty(t, diff, "SyncAll() mismatch (-want +got):\n%s", diff)
+	return stats
+}


### PR DESCRIPTION
ZCode sessions were invisible because agentsview did not have an agent type, provider, parser, or sync route for the SQLite database reported in #1003.

This adds `AgentZCode` on the existing DB-backed provider path. The provider resolves either `.zcode/cli/db` or `.zcode/cli` to `db.sqlite`, reads the reported `session` and `model_usage` tables, and emits metadata-only sessions plus usage events. Freshness uses the same effective mtime for provider fingerprints and stored session file info, combining session timestamps, usage timestamps, and the SQLite DB/WAL/SHM mtimes so usage-only updates stay visible.

This covers metadata and usage from the issue's reported schema. Live ZCode compatibility and transcript-message storage need a sample DB, local install, or upstream schema source.

Closes #1003
