### PR TITLE
feat(parser): add Qoder session support

### DIFF
--- a/frontend/src/lib/components/settings/AgentDirSettings.svelte
+++ b/frontend/src/lib/components/settings/AgentDirSettings.svelte
@@ -23,6 +23,7 @@
     zed: "Zed",
     kimi: "Kimi",
     workbuddy: "WorkBuddy",
+    qoder: "Qoder",
     piebald: "Piebald",
     antigravity: "Antigravity",
     "antigravity-cli": "Antigravity CLI",

--- a/frontend/src/lib/utils/agents.test.ts
+++ b/frontend/src/lib/utils/agents.test.ts
@@ -38,6 +38,7 @@ describe("KNOWN_AGENTS", () => {
       "kiro-ide",
       "cortex",
       "workbuddy",
+      "qoder",
       "piebald",
       "antigravity",
       "antigravity-cli",
@@ -170,6 +171,7 @@ describe("agentLabel", () => {
     expect(agentLabel("qwen")).toBe("Qwen Code");
     expect(agentLabel("qwenpaw")).toBe("QwenPaw");
     expect(agentLabel("deepseek-tui")).toBe("DeepSeek TUI");
+    expect(agentLabel("qoder")).toBe("Qoder");
   });
 
   it("capitalizes simple agent names", () => {

--- a/frontend/src/lib/utils/agents.ts
+++ b/frontend/src/lib/utils/agents.ts
@@ -53,6 +53,7 @@ export const KNOWN_AGENTS: readonly AgentMeta[] = [
   { name: "kiro-ide", color: "var(--accent-lime)", label: "Kiro IDE" },
   { name: "cortex", color: "var(--accent-cyan)", label: "Cortex Code" },
   { name: "workbuddy", color: "var(--accent-violet)", label: "WorkBuddy" },
+  { name: "qoder", color: "var(--accent-cyan)", label: "Qoder" },
   { name: "piebald", color: "var(--accent-orange)", label: "Piebald" },
   {
     name: "antigravity",

--- a/internal/parser/provider.go
+++ b/internal/parser/provider.go
@@ -474,6 +474,8 @@ func providerFactoryForDef(def AgentDef) ProviderFactory {
 		return newQwenProviderFactory(def)
 	case AgentQwenPaw:
 		return newQwenPawProviderFactory(def)
+	case AgentQoder:
+		return newQoderProviderFactory(def)
 	case AgentReasonix:
 		return newReasonixProviderFactory(def)
 	case AgentShelley:

--- a/internal/parser/provider_migration.go
+++ b/internal/parser/provider_migration.go
@@ -57,6 +57,7 @@ var providerMigrationModes = map[AgentType]ProviderMigrationMode{
 	AgentZed:            ProviderMigrationProviderAuthoritative,
 	AgentQwenPaw:        ProviderMigrationProviderAuthoritative,
 	AgentGptme:          ProviderMigrationProviderAuthoritative,
+	AgentQoder:          ProviderMigrationProviderAuthoritative,
 	AgentShelley:        ProviderMigrationProviderAuthoritative,
 	AgentAider:          ProviderMigrationProviderAuthoritative,
 	AgentOMP:            ProviderMigrationProviderAuthoritative,

--- a/internal/parser/qoder.go
+++ b/internal/parser/qoder.go
@@ -1,0 +1,257 @@
+package parser
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const qoderIDPrefix = "qoder:"
+
+type qoderSessionMeta struct {
+	Title           string `json:"title"`
+	ParentSessionID string `json:"parent_session_id"`
+	ForkFrom        string `json:"fork_from"`
+	WorkingDir      string `json:"working_dir"`
+}
+
+func DiscoverQoderSessions(projectsDir string) []DiscoveredFile {
+	if projectsDir == "" {
+		return nil
+	}
+	projects, err := os.ReadDir(projectsDir)
+	if err != nil {
+		return nil
+	}
+
+	var files []DiscoveredFile
+	for _, projectEntry := range projects {
+		if !isDirOrSymlink(projectEntry, projectsDir) {
+			continue
+		}
+		projectDir := filepath.Join(projectsDir, projectEntry.Name())
+		project := DecodeQoderProjectDir(projectEntry.Name())
+		entries, err := os.ReadDir(projectDir)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			name := entry.Name()
+			if !entry.IsDir() && strings.HasSuffix(name, ".jsonl") {
+				stem := strings.TrimSuffix(name, ".jsonl")
+				if strings.HasPrefix(stem, "agent-") ||
+					!IsValidSessionID(stem) {
+					continue
+				}
+				files = append(files, DiscoveredFile{
+					Path:    filepath.Join(projectDir, name),
+					Project: project,
+					Agent:   AgentQoder,
+				})
+				continue
+			}
+			if !isDirOrSymlink(entry, projectDir) || !IsValidSessionID(name) {
+				continue
+			}
+			subagentsDir := filepath.Join(projectDir, name, "subagents")
+			subagents, err := os.ReadDir(subagentsDir)
+			if err != nil {
+				continue
+			}
+			for _, sub := range subagents {
+				if sub.IsDir() || !strings.HasSuffix(sub.Name(), ".jsonl") {
+					continue
+				}
+				stem := strings.TrimSuffix(sub.Name(), ".jsonl")
+				if !strings.HasPrefix(stem, "agent-") ||
+					!IsValidSessionID(stem) {
+					continue
+				}
+				files = append(files, DiscoveredFile{
+					Path:    filepath.Join(subagentsDir, sub.Name()),
+					Project: project,
+					Agent:   AgentQoder,
+				})
+			}
+		}
+	}
+
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Path < files[j].Path
+	})
+	return files
+}
+
+func FindQoderSourceFile(projectsDir, rawID string) string {
+	if projectsDir == "" {
+		return ""
+	}
+	rawID = strings.TrimPrefix(rawID, qoderIDPrefix)
+	sessionID, subagentID, hasSubagent := strings.Cut(rawID, ":subagent:")
+	if !IsValidSessionID(sessionID) {
+		return ""
+	}
+	if hasSubagent &&
+		(!strings.HasPrefix(subagentID, "agent-") || !IsValidSessionID(subagentID)) {
+		return ""
+	}
+
+	projects, err := os.ReadDir(projectsDir)
+	if err != nil {
+		return ""
+	}
+	for _, projectEntry := range projects {
+		if !isDirOrSymlink(projectEntry, projectsDir) {
+			continue
+		}
+		projectDir := filepath.Join(projectsDir, projectEntry.Name())
+		candidate := filepath.Join(projectDir, sessionID+".jsonl")
+		if hasSubagent {
+			candidate = filepath.Join(projectDir, sessionID, "subagents", subagentID+".jsonl")
+		}
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+	}
+	return ""
+}
+
+func ParseQoderSession(path, project, machine string) ([]ParseResult, error) {
+	results, _, err := ParseQoderSessionWithExclusions(path, project, machine)
+	return results, err
+}
+
+func ParseQoderSessionWithExclusions(
+	path, project, machine string,
+) ([]ParseResult, []string, error) {
+	results, excluded, err := claudeParseWithExclusions(
+		path, project, machine,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("qoder parse %s: %w", path, err)
+	}
+
+	meta := readQoderSessionMeta(path)
+	parentID, subagentID, isSubagent := qoderPathIDs(path, project)
+	fileStem := strings.TrimSuffix(filepath.Base(path), ".jsonl")
+	for i := range results {
+		retagQoderResult(&results[i], fileStem, parentID, subagentID, isSubagent)
+		if !isSubagent {
+			applyQoderMeta(&results[i].Session, meta)
+		}
+	}
+	for i := range excluded {
+		excluded[i] = qoderPrefixID(excluded[i])
+	}
+	InferRelationshipTypes(results)
+	return results, excluded, nil
+}
+
+func DecodeQoderProjectDir(encoded string) string {
+	if !strings.HasPrefix(encoded, "-") {
+		return NormalizeName(encoded)
+	}
+	parts := strings.Split(encoded, "-")
+	for i := len(parts) - 1; i >= 0; i-- {
+		if parts[i] != "" {
+			return NormalizeName(parts[i])
+		}
+	}
+	return NormalizeName(encoded)
+}
+
+func retagQoderResult(
+	result *ParseResult,
+	fileStem, parentID, subagentID string,
+	isSubagent bool,
+) {
+	rawID := strings.TrimPrefix(result.Session.ID, qoderIDPrefix)
+	if isSubagent {
+		suffix := strings.TrimPrefix(rawID, fileStem)
+		result.Session.ID = qoderSubagentID(parentID, subagentID+suffix)
+		result.Session.ParentSessionID = qoderPrefixID(parentID)
+		result.Session.RelationshipType = RelSubagent
+	} else {
+		result.Session.ID = qoderPrefixID(rawID)
+		result.Session.ParentSessionID = qoderPrefixMaybe(result.Session.ParentSessionID)
+	}
+	result.Session.Agent = AgentQoder
+	retagQoderToolCalls(result.Messages, result.Session.ID)
+}
+
+func retagQoderToolCalls(messages []ParsedMessage, sessionID string) {
+	for i := range messages {
+		for j := range messages[i].ToolCalls {
+			subagentID := messages[i].ToolCalls[j].SubagentSessionID
+			if strings.HasPrefix(subagentID, "agent-") {
+				messages[i].ToolCalls[j].SubagentSessionID =
+					sessionID + ":subagent:" + subagentID
+			}
+		}
+	}
+}
+
+func applyQoderMeta(sess *ParsedSession, meta qoderSessionMeta) {
+	if meta.Title != "" {
+		sess.SessionName = meta.Title
+	}
+	if sess.Cwd == "" && meta.WorkingDir != "" {
+		sess.Cwd = meta.WorkingDir
+	}
+	if sess.ParentSessionID == "" {
+		switch {
+		case meta.ForkFrom != "":
+			sess.ParentSessionID = qoderPrefixID(meta.ForkFrom)
+			sess.RelationshipType = RelFork
+		case meta.ParentSessionID != "":
+			sess.ParentSessionID = qoderPrefixID(meta.ParentSessionID)
+		}
+	}
+}
+
+func readQoderSessionMeta(path string) qoderSessionMeta {
+	metaPath := strings.TrimSuffix(path, ".jsonl") + "-session.json"
+	data, err := os.ReadFile(metaPath)
+	if err != nil {
+		return qoderSessionMeta{}
+	}
+	var meta qoderSessionMeta
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return qoderSessionMeta{}
+	}
+	return meta
+}
+
+func qoderPathIDs(path, _ string) (parentID, subagentID string, isSubagent bool) {
+	if filepath.Base(filepath.Dir(path)) != "subagents" {
+		return "", "", false
+	}
+	parent := filepath.Base(filepath.Dir(filepath.Dir(path)))
+	if !IsValidSessionID(parent) {
+		return "", "", false
+	}
+	stem := strings.TrimSuffix(filepath.Base(path), ".jsonl")
+	if !strings.HasPrefix(stem, "agent-") || !IsValidSessionID(stem) {
+		return "", "", false
+	}
+	return parent, stem, true
+}
+
+func qoderPrefixID(id string) string {
+	id = strings.TrimPrefix(id, qoderIDPrefix)
+	return qoderIDPrefix + id
+}
+
+func qoderPrefixMaybe(id string) string {
+	if id == "" {
+		return ""
+	}
+	return qoderPrefixID(id)
+}
+
+func qoderSubagentID(parentID, subagentID string) string {
+	return qoderPrefixID(parentID) + ":subagent:" + subagentID
+}

--- a/internal/parser/qoder.go
+++ b/internal/parser/qoder.go
@@ -224,12 +224,16 @@ func applyQoderMeta(sess *ParsedSession, meta qoderSessionMeta) {
 	if sess.Cwd == "" && meta.WorkingDir != "" {
 		sess.Cwd = meta.WorkingDir
 	}
-	if meta.ForkFrom != "" {
+	if meta.ForkFrom != "" && !hasParserDiscoveredForkParent(sess) {
 		sess.ParentSessionID = qoderPrefixID(meta.ForkFrom)
 		sess.RelationshipType = RelFork
 	} else if sess.ParentSessionID == "" && meta.ParentSessionID != "" {
 		sess.ParentSessionID = qoderPrefixID(meta.ParentSessionID)
 	}
+}
+
+func hasParserDiscoveredForkParent(sess *ParsedSession) bool {
+	return sess.RelationshipType == RelFork && sess.ParentSessionID != ""
 }
 
 func readQoderSessionMeta(path string) qoderSessionMeta {

--- a/internal/parser/qoder.go
+++ b/internal/parser/qoder.go
@@ -144,7 +144,9 @@ func ParseQoderSessionWithExclusions(
 		}
 	}
 	for i := range excluded {
-		excluded[i] = qoderPrefixID(excluded[i])
+		excluded[i] = qoderExcludedID(
+			excluded[i], fileStem, parentID, subagentID, isSubagent,
+		)
 	}
 	InferRelationshipTypes(results)
 	return results, excluded, nil
@@ -254,4 +256,16 @@ func qoderPrefixMaybe(id string) string {
 
 func qoderSubagentID(parentID, subagentID string) string {
 	return qoderPrefixID(parentID) + ":subagent:" + subagentID
+}
+
+func qoderExcludedID(
+	id, fileStem, parentID, subagentID string,
+	isSubagent bool,
+) string {
+	rawID := strings.TrimPrefix(id, qoderIDPrefix)
+	if isSubagent {
+		suffix := strings.TrimPrefix(rawID, fileStem)
+		return qoderSubagentID(parentID, subagentID+suffix)
+	}
+	return qoderPrefixID(rawID)
 }

--- a/internal/parser/qoder.go
+++ b/internal/parser/qoder.go
@@ -181,7 +181,11 @@ func retagQoderResult(
 		result.Session.ParentSessionID = qoderPrefixMaybe(result.Session.ParentSessionID)
 	}
 	result.Session.Agent = AgentQoder
-	retagQoderToolCalls(result.Messages, result.Session.ID)
+	toolCallParentID := result.Session.ID
+	if !isSubagent {
+		toolCallParentID = qoderPrefixID(fileStem)
+	}
+	retagQoderToolCalls(result.Messages, toolCallParentID)
 }
 
 func retagQoderToolCalls(messages []ParsedMessage, sessionID string) {

--- a/internal/parser/qoder.go
+++ b/internal/parser/qoder.go
@@ -157,7 +157,7 @@ func DecodeQoderProjectDir(encoded string) string {
 		return NormalizeName(encoded)
 	}
 	parts := strings.Split(encoded, "-")
-	for i := len(parts) - 2; i >= 0; i-- {
+	for i := 0; i < len(parts)-1; i++ {
 		if isQoderProjectParentDir(parts[i]) {
 			project := strings.Join(parts[i+1:], "-")
 			if project != "" {

--- a/internal/parser/qoder.go
+++ b/internal/parser/qoder.go
@@ -207,14 +207,11 @@ func applyQoderMeta(sess *ParsedSession, meta qoderSessionMeta) {
 	if sess.Cwd == "" && meta.WorkingDir != "" {
 		sess.Cwd = meta.WorkingDir
 	}
-	if sess.ParentSessionID == "" {
-		switch {
-		case meta.ForkFrom != "":
-			sess.ParentSessionID = qoderPrefixID(meta.ForkFrom)
-			sess.RelationshipType = RelFork
-		case meta.ParentSessionID != "":
-			sess.ParentSessionID = qoderPrefixID(meta.ParentSessionID)
-		}
+	if meta.ForkFrom != "" {
+		sess.ParentSessionID = qoderPrefixID(meta.ForkFrom)
+		sess.RelationshipType = RelFork
+	} else if sess.ParentSessionID == "" && meta.ParentSessionID != "" {
+		sess.ParentSessionID = qoderPrefixID(meta.ParentSessionID)
 	}
 }
 

--- a/internal/parser/qoder.go
+++ b/internal/parser/qoder.go
@@ -157,12 +157,29 @@ func DecodeQoderProjectDir(encoded string) string {
 		return NormalizeName(encoded)
 	}
 	parts := strings.Split(encoded, "-")
+	for i := len(parts) - 2; i >= 0; i-- {
+		if isQoderProjectParentDir(parts[i]) {
+			project := strings.Join(parts[i+1:], "-")
+			if project != "" {
+				return NormalizeName(project)
+			}
+		}
+	}
 	for i := len(parts) - 1; i >= 0; i-- {
 		if parts[i] != "" {
 			return NormalizeName(parts[i])
 		}
 	}
 	return NormalizeName(encoded)
+}
+
+func isQoderProjectParentDir(part string) bool {
+	switch strings.ToLower(part) {
+	case "code", "coding", "dev", "development", "projects", "repos", "src", "work", "workspace":
+		return true
+	default:
+		return false
+	}
 }
 
 func retagQoderResult(

--- a/internal/parser/qoder_provider.go
+++ b/internal/parser/qoder_provider.go
@@ -24,6 +24,7 @@ func newQoderSourceSet(roots []string) JSONLSourceSet {
 		WithSessionIDFromPath(qoderSessionIDFromPath),
 		WithLookupIDValid(isQoderLookupID),
 		WithParseFile(qoderParseFile),
+		WithForceReplace(),
 		WithCompanionFiles(qoderCompanionFiles),
 	)
 }
@@ -127,6 +128,7 @@ func qoderProviderCapabilities() Capabilities {
 	source := jsonlFileProviderSourceCapabilities()
 	source.MultiSessionSource = CapabilitySupported
 	source.ExcludedSessions = CapabilitySupported
+	source.ForceReplaceOnParse = CapabilitySupported
 	return Capabilities{
 		Source: source,
 		Content: ContentCapabilities{

--- a/internal/parser/qoder_provider.go
+++ b/internal/parser/qoder_provider.go
@@ -1,0 +1,140 @@
+package parser
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+)
+
+func newQoderProviderFactory(def AgentDef) ProviderFactory {
+	return NewSourceSetFactory(
+		def,
+		qoderProviderCapabilities(),
+		func(cfg ProviderConfig) SourceSet { return newQoderSourceSet(cfg.Roots) },
+	)
+}
+
+func newQoderSourceSet(roots []string) JSONLSourceSet {
+	return NewJSONLSourceSet(AgentQoder, roots,
+		WithRecursive(),
+		WithSymlinkFollowing(),
+		WithContentHashing(),
+		WithIncludePath(isQoderSourcePath),
+		WithProjectHint(qoderProjectHintFromPath),
+		WithSessionIDFromPath(qoderSessionIDFromPath),
+		WithLookupIDValid(isQoderLookupID),
+		WithParseFile(qoderParseFile),
+		WithCompanionFiles(qoderCompanionFiles),
+	)
+}
+
+func qoderParseFile(
+	_ context.Context, path string, req ParseRequest,
+) ([]ParseResult, []string, error) {
+	results, excluded, err := ParseQoderSessionWithExclusions(
+		path, req.Source.ProjectHint, req.Machine,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	if req.Fingerprint.Hash != "" {
+		for i := range results {
+			results[i].Session.File.Hash = req.Fingerprint.Hash
+		}
+	}
+	return results, excluded, nil
+}
+
+func isQoderSourcePath(root, path string) bool {
+	parts, ok := qoderPathParts(root, path)
+	if !ok {
+		return false
+	}
+	switch len(parts) {
+	case 2:
+		stem, ok := strings.CutSuffix(parts[1], ".jsonl")
+		return ok &&
+			!strings.HasPrefix(stem, "agent-") &&
+			IsValidSessionID(stem)
+	case 4:
+		stem, ok := strings.CutSuffix(parts[3], ".jsonl")
+		return ok &&
+			IsValidSessionID(parts[1]) &&
+			parts[2] == "subagents" &&
+			strings.HasPrefix(stem, "agent-") &&
+			IsValidSessionID(stem)
+	default:
+		return false
+	}
+}
+
+func qoderProjectHintFromPath(root, path string) string {
+	parts, ok := qoderPathParts(root, path)
+	if !ok || len(parts) < 2 {
+		return ""
+	}
+	return DecodeQoderProjectDir(parts[0])
+}
+
+func qoderSessionIDFromPath(root, path string) string {
+	if !isQoderSourcePath(root, path) {
+		return ""
+	}
+	parts, _ := qoderPathParts(root, path)
+	stem := strings.TrimSuffix(filepath.Base(path), ".jsonl")
+	if len(parts) == 4 {
+		return parts[1] + ":subagent:" + stem
+	}
+	return stem
+}
+
+func isQoderLookupID(rawID string) bool {
+	if rawID == "" {
+		return false
+	}
+	sessionID, subagentID, hasSubagent := strings.Cut(rawID, ":subagent:")
+	if !IsValidSessionID(sessionID) {
+		return false
+	}
+	return !hasSubagent ||
+		strings.HasPrefix(subagentID, "agent-") &&
+			IsValidSessionID(subagentID)
+}
+
+func qoderPathParts(root, path string) ([]string, bool) {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return nil, false
+	}
+	parts := strings.Split(rel, string(filepath.Separator))
+	for _, part := range parts {
+		if part == "" || part == "." || part == ".." {
+			return nil, false
+		}
+	}
+	return parts, true
+}
+
+func qoderCompanionFiles(path string) []string {
+	if strings.HasSuffix(path, ".jsonl") {
+		return []string{strings.TrimSuffix(path, ".jsonl") + "-session.json"}
+	}
+	return nil
+}
+
+func qoderProviderCapabilities() Capabilities {
+	return Capabilities{
+		Source: jsonlFileProviderSourceCapabilities(),
+		Content: ContentCapabilities{
+			FirstMessage:         CapabilitySupported,
+			Cwd:                  CapabilitySupported,
+			Relationships:        CapabilitySupported,
+			Subagents:            CapabilitySupported,
+			ToolCalls:            CapabilitySupported,
+			ToolResults:          CapabilitySupported,
+			PerMessageTokenUsage: CapabilitySupported,
+			MalformedLineCount:   CapabilitySupported,
+			Model:                CapabilitySupported,
+		},
+	}
+}

--- a/internal/parser/qoder_provider.go
+++ b/internal/parser/qoder_provider.go
@@ -124,8 +124,11 @@ func qoderCompanionFiles(path string) []string {
 }
 
 func qoderProviderCapabilities() Capabilities {
+	source := jsonlFileProviderSourceCapabilities()
+	source.MultiSessionSource = CapabilitySupported
+	source.ExcludedSessions = CapabilitySupported
 	return Capabilities{
-		Source: jsonlFileProviderSourceCapabilities(),
+		Source: source,
 		Content: ContentCapabilities{
 			FirstMessage:         CapabilitySupported,
 			Cwd:                  CapabilitySupported,

--- a/internal/parser/qoder_provider.go
+++ b/internal/parser/qoder_provider.go
@@ -38,8 +38,14 @@ func qoderParseFile(
 	if err != nil {
 		return nil, nil, err
 	}
-	if req.Fingerprint.Hash != "" {
-		for i := range results {
+	for i := range results {
+		if req.Fingerprint.Size > 0 {
+			results[i].Session.File.Size = req.Fingerprint.Size
+		}
+		if req.Fingerprint.MTimeNS > 0 {
+			results[i].Session.File.Mtime = req.Fingerprint.MTimeNS
+		}
+		if req.Fingerprint.Hash != "" {
 			results[i].Session.File.Hash = req.Fingerprint.Hash
 		}
 	}

--- a/internal/parser/qoder_provider.go
+++ b/internal/parser/qoder_provider.go
@@ -116,8 +116,9 @@ func qoderPathParts(root, path string) ([]string, bool) {
 }
 
 func qoderCompanionFiles(path string) []string {
-	if strings.HasSuffix(path, ".jsonl") {
-		return []string{strings.TrimSuffix(path, ".jsonl") + "-session.json"}
+	stem, ok := strings.CutSuffix(path, ".jsonl")
+	if ok {
+		return []string{stem + "-session.json"}
 	}
 	return nil
 }

--- a/internal/parser/qoder_test.go
+++ b/internal/parser/qoder_test.go
@@ -89,18 +89,34 @@ func TestParseQoderSessionSidecarMetadata(t *testing.T) {
 	assert.Equal(t, RelFork, sess.RelationshipType)
 }
 
-func TestQoderSidecarForkFromOverridesInferredParent(t *testing.T) {
-	sess := ParsedSession{
-		ParentSessionID:  "qoder:22222222-2222-4222-8222-222222222222",
-		RelationshipType: RelContinuation,
-	}
+func TestQoderSidecarForkFromPreservesParserForkParent(t *testing.T) {
+	t.Run("promotes continuation parent", func(t *testing.T) {
+		sess := ParsedSession{
+			ParentSessionID:  "qoder:22222222-2222-4222-8222-222222222222",
+			RelationshipType: RelContinuation,
+		}
 
-	applyQoderMeta(&sess, qoderSessionMeta{
-		ForkFrom: "11111111-1111-4111-8111-111111111111",
+		applyQoderMeta(&sess, qoderSessionMeta{
+			ForkFrom: "11111111-1111-4111-8111-111111111111",
+		})
+
+		assert.Equal(t, "qoder:11111111-1111-4111-8111-111111111111", sess.ParentSessionID)
+		assert.Equal(t, RelFork, sess.RelationshipType)
 	})
 
-	assert.Equal(t, "qoder:11111111-1111-4111-8111-111111111111", sess.ParentSessionID)
-	assert.Equal(t, RelFork, sess.RelationshipType)
+	t.Run("keeps parser fork parent", func(t *testing.T) {
+		sess := ParsedSession{
+			ParentSessionID:  "qoder:22222222-2222-4222-8222-222222222222",
+			RelationshipType: RelFork,
+		}
+
+		applyQoderMeta(&sess, qoderSessionMeta{
+			ForkFrom: "11111111-1111-4111-8111-111111111111",
+		})
+
+		assert.Equal(t, "qoder:22222222-2222-4222-8222-222222222222", sess.ParentSessionID)
+		assert.Equal(t, RelFork, sess.RelationshipType)
+	})
 }
 
 func TestQoderProviderParseStampsCompositeFingerprint(t *testing.T) {
@@ -227,10 +243,16 @@ func TestParseQoderForkedSessionRetagsToolCallSubagentIDsToFileStem(t *testing.T
 {"type":"user","uuid":"fork-r1","parentUuid":"fork-a1","timestamp":"2026-06-04T09:48:02.000Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_fork","content":"done"}]},"toolUseResult":{"status":"completed","agentId":"123"},"sessionId":"11111111-1111-4111-8111-111111111111"}
 `
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	require.NoError(t, os.WriteFile(
+		strings.TrimSuffix(path, ".jsonl")+"-session.json",
+		[]byte(`{"fork_from":"22222222-2222-4222-8222-222222222222"}`),
+		0o644,
+	))
 
 	results, err := ParseQoderSession(path, "proj", "local")
 	require.NoError(t, err)
 	require.Len(t, results, 2)
+	assert.Equal(t, "qoder:22222222-2222-4222-8222-222222222222", results[0].Session.ParentSessionID)
 	var fork *ParseResult
 	for i := range results {
 		if results[i].Session.RelationshipType == RelFork {
@@ -239,6 +261,7 @@ func TestParseQoderForkedSessionRetagsToolCallSubagentIDsToFileStem(t *testing.T
 	}
 	require.NotNil(t, fork)
 	assert.NotEqual(t, qoderPrefixID(fileStem), fork.Session.ID)
+	assert.Equal(t, qoderPrefixID(fileStem), fork.Session.ParentSessionID)
 	var calls []ParsedToolCall
 	for _, msg := range fork.Messages {
 		calls = append(calls, msg.ToolCalls...)

--- a/internal/parser/qoder_test.go
+++ b/internal/parser/qoder_test.go
@@ -31,6 +31,7 @@ func TestQoderRegistry(t *testing.T) {
 	assert.Equal(t, CapabilitySupported, caps.Source.FindSource)
 	assert.Equal(t, CapabilitySupported, caps.Source.MultiSessionSource)
 	assert.Equal(t, CapabilitySupported, caps.Source.ExcludedSessions)
+	assert.Equal(t, CapabilitySupported, caps.Source.ForceReplaceOnParse)
 	assert.Equal(t, CapabilitySupported, caps.Content.Subagents)
 	provider, ok := NewProvider(AgentQoder, ProviderConfig{Roots: []string{t.TempDir()}})
 	require.True(t, ok)

--- a/internal/parser/qoder_test.go
+++ b/internal/parser/qoder_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -28,6 +29,8 @@ func TestQoderRegistry(t *testing.T) {
 	assert.Equal(t, CapabilitySupported, caps.Source.DiscoverSources)
 	assert.Equal(t, CapabilitySupported, caps.Source.ClassifyChangedPath)
 	assert.Equal(t, CapabilitySupported, caps.Source.FindSource)
+	assert.Equal(t, CapabilitySupported, caps.Source.MultiSessionSource)
+	assert.Equal(t, CapabilitySupported, caps.Source.ExcludedSessions)
 	assert.Equal(t, CapabilitySupported, caps.Content.Subagents)
 	provider, ok := NewProvider(AgentQoder, ProviderConfig{Roots: []string{t.TempDir()}})
 	require.True(t, ok)
@@ -100,6 +103,39 @@ func TestParseQoderSubagentSession(t *testing.T) {
 	assert.Equal(t, "qoder:11111111-1111-4111-8111-111111111111", sess.ParentSessionID)
 	assert.Equal(t, RelSubagent, sess.RelationshipType)
 	assert.Equal(t, AgentQoder, sess.Agent)
+}
+
+func TestParseQoderSubagentExclusionIDs(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "proj", "11111111-1111-4111-8111-111111111111", "subagents", "agent-123.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	content := `{"type":"user","uuid":"u1","timestamp":"2026-06-04T09:47:27.966Z","message":{"role":"user","content":"/usage"},"sessionId":"agent-123"}
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	results, excluded, err := ParseQoderSessionWithExclusions(path, "proj", "local")
+	require.NoError(t, err)
+	assert.Empty(t, results)
+	assert.Equal(t, []string{
+		"qoder:11111111-1111-4111-8111-111111111111:subagent:agent-123",
+	}, excluded)
+
+	provider, ok := NewProvider(AgentQoder, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	source, found, err := provider.FindSource(context.Background(), FindSourceRequest{
+		RawSessionID: "11111111-1111-4111-8111-111111111111:subagent:agent-123",
+	})
+	require.NoError(t, err)
+	require.True(t, found)
+	outcome, err := provider.Parse(context.Background(), ParseRequest{
+		Source:  source,
+		Machine: "local",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, outcome.Results)
+	assert.Equal(t, []string{
+		"qoder:11111111-1111-4111-8111-111111111111:subagent:agent-123",
+	}, outcome.ExcludedSessionIDs)
 }
 
 func TestParseQoderSessionRetagsToolCallSubagentIDs(t *testing.T) {

--- a/internal/parser/qoder_test.go
+++ b/internal/parser/qoder_test.go
@@ -314,6 +314,8 @@ func TestDecodeQoderProjectDir(t *testing.T) {
 		{"-Users-foo-myproject", "myproject"},
 		{"-home-user-work-coding", "coding"},
 		{"-Users-alice-code-sample-project", "sample_project"},
+		{"-Users-alice-code-dev-tools", "dev_tools"},
+		{"-home-alice-projects-work-app", "work_app"},
 		{"-home-alice-projects-agent-ui", "agent_ui"},
 		{"plain-name", "plain_name"},
 		{"", ""},

--- a/internal/parser/qoder_test.go
+++ b/internal/parser/qoder_test.go
@@ -89,6 +89,55 @@ func TestParseQoderSessionSidecarMetadata(t *testing.T) {
 	assert.Equal(t, RelFork, sess.RelationshipType)
 }
 
+func TestQoderSidecarForkFromOverridesInferredParent(t *testing.T) {
+	sess := ParsedSession{
+		ParentSessionID:  "qoder:22222222-2222-4222-8222-222222222222",
+		RelationshipType: RelContinuation,
+	}
+
+	applyQoderMeta(&sess, qoderSessionMeta{
+		ForkFrom: "11111111-1111-4111-8111-111111111111",
+	})
+
+	assert.Equal(t, "qoder:11111111-1111-4111-8111-111111111111", sess.ParentSessionID)
+	assert.Equal(t, RelFork, sess.RelationshipType)
+}
+
+func TestQoderProviderParseStampsCompositeFingerprint(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "-Users-alice-project", "11111111-1111-4111-8111-111111111111.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(`{"type":"user","uuid":"u1","timestamp":"2026-06-04T09:47:27.966Z","message":{"role":"user","content":"hello"},"sessionId":"11111111-1111-4111-8111-111111111111"}
+`), 0o644))
+	require.NoError(t, os.WriteFile(
+		strings.TrimSuffix(path, ".jsonl")+"-session.json",
+		[]byte(`{"title":"Composite fingerprint"}`),
+		0o644,
+	))
+
+	provider, ok := NewProvider(AgentQoder, ProviderConfig{
+		Roots:   []string{root},
+		Machine: "local",
+	})
+	require.True(t, ok)
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	fingerprint, err := provider.Fingerprint(context.Background(), sources[0])
+	require.NoError(t, err)
+
+	outcome, err := provider.Parse(context.Background(), ParseRequest{
+		Source:      sources[0],
+		Fingerprint: fingerprint,
+	})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	file := outcome.Results[0].Result.Session.File
+	assert.Equal(t, fingerprint.Size, file.Size)
+	assert.Equal(t, fingerprint.MTimeNS, file.Mtime)
+	assert.Equal(t, fingerprint.Hash, file.Hash)
+}
+
 func TestParseQoderSubagentSession(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "proj", "11111111-1111-4111-8111-111111111111", "subagents", "agent-123.jsonl")
 	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))

--- a/internal/parser/qoder_test.go
+++ b/internal/parser/qoder_test.go
@@ -158,6 +158,45 @@ func TestParseQoderSessionRetagsToolCallSubagentIDs(t *testing.T) {
 	assert.Equal(t, "qoder:11111111-1111-4111-8111-111111111111:subagent:agent-123", calls[0].SubagentSessionID)
 }
 
+func TestParseQoderForkedSessionRetagsToolCallSubagentIDsToFileStem(t *testing.T) {
+	fileStem := "11111111-1111-4111-8111-111111111111"
+	path := filepath.Join(t.TempDir(), "proj", fileStem+".jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	content := `{"type":"user","uuid":"root","timestamp":"2026-06-04T09:47:20.000Z","message":{"role":"user","content":"start"},"sessionId":"11111111-1111-4111-8111-111111111111"}
+{"type":"assistant","uuid":"split","parentUuid":"root","timestamp":"2026-06-04T09:47:21.000Z","message":{"role":"assistant","content":[{"type":"text","text":"ok"}]},"sessionId":"11111111-1111-4111-8111-111111111111"}
+{"type":"user","uuid":"main-u1","parentUuid":"split","timestamp":"2026-06-04T09:47:22.000Z","message":{"role":"user","content":"main 1"},"sessionId":"11111111-1111-4111-8111-111111111111"}
+{"type":"assistant","uuid":"main-a1","parentUuid":"main-u1","timestamp":"2026-06-04T09:47:23.000Z","message":{"role":"assistant","content":[{"type":"text","text":"main answer 1"}]},"sessionId":"11111111-1111-4111-8111-111111111111"}
+{"type":"user","uuid":"main-u2","parentUuid":"main-a1","timestamp":"2026-06-04T09:47:24.000Z","message":{"role":"user","content":"main 2"},"sessionId":"11111111-1111-4111-8111-111111111111"}
+{"type":"assistant","uuid":"main-a2","parentUuid":"main-u2","timestamp":"2026-06-04T09:47:25.000Z","message":{"role":"assistant","content":[{"type":"text","text":"main answer 2"}]},"sessionId":"11111111-1111-4111-8111-111111111111"}
+{"type":"user","uuid":"main-u3","parentUuid":"main-a2","timestamp":"2026-06-04T09:47:26.000Z","message":{"role":"user","content":"main 3"},"sessionId":"11111111-1111-4111-8111-111111111111"}
+{"type":"assistant","uuid":"main-a3","parentUuid":"main-u3","timestamp":"2026-06-04T09:47:27.000Z","message":{"role":"assistant","content":[{"type":"text","text":"main answer 3"}]},"sessionId":"11111111-1111-4111-8111-111111111111"}
+{"type":"user","uuid":"main-u4","parentUuid":"main-a3","timestamp":"2026-06-04T09:47:28.000Z","message":{"role":"user","content":"main 4"},"sessionId":"11111111-1111-4111-8111-111111111111"}
+{"type":"assistant","uuid":"main-a4","parentUuid":"main-u4","timestamp":"2026-06-04T09:47:29.000Z","message":{"role":"assistant","content":[{"type":"text","text":"main answer 4"}]},"sessionId":"11111111-1111-4111-8111-111111111111"}
+{"type":"user","uuid":"fork-u1","parentUuid":"split","timestamp":"2026-06-04T09:48:00.000Z","message":{"role":"user","content":"fork delegate"},"sessionId":"11111111-1111-4111-8111-111111111111"}
+{"type":"assistant","uuid":"fork-a1","parentUuid":"fork-u1","timestamp":"2026-06-04T09:48:01.000Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_fork","name":"Agent","input":{"description":"do fork work","prompt":"x"}}]},"sessionId":"11111111-1111-4111-8111-111111111111"}
+{"type":"user","uuid":"fork-r1","parentUuid":"fork-a1","timestamp":"2026-06-04T09:48:02.000Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_fork","content":"done"}]},"toolUseResult":{"status":"completed","agentId":"123"},"sessionId":"11111111-1111-4111-8111-111111111111"}
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	results, err := ParseQoderSession(path, "proj", "local")
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	var fork *ParseResult
+	for i := range results {
+		if results[i].Session.RelationshipType == RelFork {
+			fork = &results[i]
+		}
+	}
+	require.NotNil(t, fork)
+	assert.NotEqual(t, qoderPrefixID(fileStem), fork.Session.ID)
+	var calls []ParsedToolCall
+	for _, msg := range fork.Messages {
+		calls = append(calls, msg.ToolCalls...)
+	}
+	require.Len(t, calls, 1)
+	assert.Equal(t, "qoder:"+fileStem+":subagent:agent-123", calls[0].SubagentSessionID)
+}
+
 func TestDiscoverQoderSessions(t *testing.T) {
 	root := t.TempDir()
 	mainPath := filepath.Join(root, "-Users-alice-project", "11111111-1111-4111-8111-111111111111.jsonl")

--- a/internal/parser/qoder_test.go
+++ b/internal/parser/qoder_test.go
@@ -290,6 +290,8 @@ func TestDecodeQoderProjectDir(t *testing.T) {
 	}{
 		{"-Users-foo-myproject", "myproject"},
 		{"-home-user-work-coding", "coding"},
+		{"-Users-alice-code-sample-project", "sample_project"},
+		{"-home-alice-projects-agent-ui", "agent_ui"},
 		{"plain-name", "plain_name"},
 		{"", ""},
 	}

--- a/internal/parser/qoder_test.go
+++ b/internal/parser/qoder_test.go
@@ -1,0 +1,176 @@
+package parser
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQoderRegistry(t *testing.T) {
+	def, ok := AgentByType(AgentQoder)
+	require.True(t, ok, "AgentQoder missing from Registry")
+	assert.Equal(t, "Qoder", def.DisplayName)
+	assert.Equal(t, "QODER_PROJECTS_DIR", def.EnvVar)
+	assert.Equal(t, "qoder_project_dirs", def.ConfigKey)
+	assert.Equal(t, qoderIDPrefix, def.IDPrefix)
+	assert.True(t, def.FileBased)
+	assert.False(t, def.ShallowWatch)
+	assert.Equal(t, []string{".qoder/projects", ".qoderwork/projects"}, def.DefaultDirs)
+	factory, ok := ProviderFactoryByType(AgentQoder)
+	require.True(t, ok, "AgentQoder provider missing")
+	assert.Equal(t, AgentQoder, factory.Definition().Type)
+	caps := factory.Capabilities()
+	assert.Equal(t, CapabilitySupported, caps.Source.DiscoverSources)
+	assert.Equal(t, CapabilitySupported, caps.Source.ClassifyChangedPath)
+	assert.Equal(t, CapabilitySupported, caps.Source.FindSource)
+	assert.Equal(t, CapabilitySupported, caps.Content.Subagents)
+	provider, ok := NewProvider(AgentQoder, ProviderConfig{Roots: []string{t.TempDir()}})
+	require.True(t, ok)
+	require.NotNil(t, provider)
+}
+
+func TestParseQoderSession(t *testing.T) {
+	root := t.TempDir()
+	cwd := filepath.Join(root, "code", "sample-project")
+	require.NoError(t, os.MkdirAll(cwd, 0o755))
+	path := filepath.Join(root, "-Users-alice-sample-project", "11111111-1111-4111-8111-111111111111.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	content := fmt.Sprintf(`{"type":"user","uuid":"u1","timestamp":"2026-06-04T09:47:27.966Z","message":{"role":"user","content":"help me"},"cwd":%q,"sessionId":"11111111-1111-4111-8111-111111111111","version":"1.0.8"}
+{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2026-06-04T09:47:32.116Z","message":{"id":"msg_1","type":"message","role":"assistant","model":"auto","stop_reason":"end_turn","usage":{"input_tokens":100,"cache_creation_input_tokens":7,"cache_read_input_tokens":50,"output_tokens":30},"content":[{"type":"text","text":"done"}]},"sessionId":"11111111-1111-4111-8111-111111111111"}
+{"type":"user","uuid":"u2","parentUuid":"a1","timestamp":"2026-06-04T09:47:39.020Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"}]},"sessionId":"11111111-1111-4111-8111-111111111111"}
+`, cwd)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	results, err := ParseQoderSession(path, "sample-project", "local")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	sess := results[0].Session
+	assert.Equal(t, "qoder:11111111-1111-4111-8111-111111111111", sess.ID)
+	assert.Equal(t, AgentQoder, sess.Agent)
+	assert.Equal(t, "sample-project", sess.Project)
+	assert.Equal(t, cwd, sess.Cwd)
+	assert.Equal(t, "help me", sess.FirstMessage)
+	assert.True(t, sess.HasTotalOutputTokens)
+	assert.Equal(t, 30, sess.TotalOutputTokens)
+	assert.True(t, sess.HasPeakContextTokens)
+	assert.Equal(t, 157, sess.PeakContextTokens)
+	require.Len(t, results[0].Messages, 3)
+	assert.Equal(t, 157, results[0].Messages[1].ContextTokens)
+	assert.Equal(t, 30, results[0].Messages[1].OutputTokens)
+}
+
+func TestParseQoderSessionSidecarMetadata(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "proj", "22222222-2222-4222-8222-222222222222.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(`{"type":"user","uuid":"u1","timestamp":"2026-06-04T09:47:27.966Z","message":{"role":"user","content":"fork"}}
+`), 0o644))
+	require.NoError(t, os.WriteFile(
+		strings.TrimSuffix(path, ".jsonl")+"-session.json",
+		[]byte(`{"title":"Forked work","working_dir":"/tmp/qoder","fork_from":"11111111-1111-4111-8111-111111111111"}`),
+		0o644,
+	))
+
+	results, err := ParseQoderSession(path, "proj", "local")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	sess := results[0].Session
+	assert.Equal(t, "Forked work", sess.SessionName)
+	assert.Equal(t, "/tmp/qoder", sess.Cwd)
+	assert.Equal(t, "qoder:11111111-1111-4111-8111-111111111111", sess.ParentSessionID)
+	assert.Equal(t, RelFork, sess.RelationshipType)
+}
+
+func TestParseQoderSubagentSession(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "proj", "11111111-1111-4111-8111-111111111111", "subagents", "agent-123.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	content := `{"agentId":"123","type":"user","uuid":"u1","timestamp":"2026-06-04T09:47:27.966Z","message":{"role":"user","content":[{"type":"text","text":"sub task"}]},"sessionId":"child-session"}
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	results, err := ParseQoderSession(path, "proj", "local")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	sess := results[0].Session
+	assert.Equal(t, "qoder:11111111-1111-4111-8111-111111111111:subagent:agent-123", sess.ID)
+	assert.Equal(t, "qoder:11111111-1111-4111-8111-111111111111", sess.ParentSessionID)
+	assert.Equal(t, RelSubagent, sess.RelationshipType)
+	assert.Equal(t, AgentQoder, sess.Agent)
+}
+
+func TestParseQoderSessionRetagsToolCallSubagentIDs(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "proj", "11111111-1111-4111-8111-111111111111.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	content := `{"type":"user","uuid":"u1","timestamp":"2026-06-04T09:47:27.966Z","message":{"role":"user","content":"delegate"},"sessionId":"11111111-1111-4111-8111-111111111111"}
+{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2026-06-04T09:47:32.116Z","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_1","name":"Agent","input":{"description":"do it","prompt":"x"}}]},"sessionId":"11111111-1111-4111-8111-111111111111"}
+{"type":"user","uuid":"u2","parentUuid":"a1","timestamp":"2026-06-04T09:47:39.020Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"done"}]},"toolUseResult":{"status":"completed","agentId":"123"}}
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	results, err := ParseQoderSession(path, "proj", "local")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	var calls []ParsedToolCall
+	for _, msg := range results[0].Messages {
+		calls = append(calls, msg.ToolCalls...)
+	}
+	require.Len(t, calls, 1)
+	assert.Equal(t, "qoder:11111111-1111-4111-8111-111111111111:subagent:agent-123", calls[0].SubagentSessionID)
+}
+
+func TestDiscoverQoderSessions(t *testing.T) {
+	root := t.TempDir()
+	mainPath := filepath.Join(root, "-Users-alice-project", "11111111-1111-4111-8111-111111111111.jsonl")
+	sidecarPath := filepath.Join(root, "-Users-alice-project", "11111111-1111-4111-8111-111111111111-session.json")
+	statsPath := filepath.Join(root, "ai-stats", "usage.json")
+	rootAgentPath := filepath.Join(root, "-Users-alice-project", "agent-123.jsonl")
+	subPath := filepath.Join(root, "-Users-alice-project", "11111111-1111-4111-8111-111111111111", "subagents", "agent-123.jsonl")
+	for _, path := range []string{mainPath, sidecarPath, statsPath, rootAgentPath, subPath} {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o644))
+	}
+
+	files := DiscoverQoderSessions(root)
+	require.Len(t, files, 2)
+	assert.Equal(t, mainPath, files[0].Path)
+	assert.Equal(t, "project", files[0].Project)
+	assert.Equal(t, AgentQoder, files[0].Agent)
+	assert.Equal(t, subPath, files[1].Path)
+	assert.Equal(t, "project", files[1].Project)
+	assert.Equal(t, AgentQoder, files[1].Agent)
+}
+
+func TestFindQoderSourceFile(t *testing.T) {
+	root := t.TempDir()
+	mainPath := filepath.Join(root, "proj", "11111111-1111-4111-8111-111111111111.jsonl")
+	subPath := filepath.Join(root, "proj", "11111111-1111-4111-8111-111111111111", "subagents", "agent-123.jsonl")
+	for _, path := range []string{mainPath, subPath} {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o644))
+	}
+
+	assert.Equal(t, mainPath, FindQoderSourceFile(root, "qoder:11111111-1111-4111-8111-111111111111"))
+	assert.Equal(t, subPath, FindQoderSourceFile(root, "qoder:11111111-1111-4111-8111-111111111111:subagent:agent-123"))
+	assert.Empty(t, FindQoderSourceFile(root, "qoder:11111111-1111-4111-8111-111111111111:subagent:../agent-123"))
+}
+
+func TestDecodeQoderProjectDir(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{"-Users-foo-myproject", "myproject"},
+		{"-home-user-work-coding", "coding"},
+		{"plain-name", "plain_name"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, DecodeQoderProjectDir(tt.name))
+		})
+	}
+}

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -52,6 +52,7 @@ const (
 	AgentZed            AgentType = "zed"
 	AgentQwenPaw        AgentType = "qwenpaw"
 	AgentGptme          AgentType = "gptme"
+	AgentQoder          AgentType = "qoder"
 	AgentShelley        AgentType = "shelley"
 	AgentAider          AgentType = "aider"
 	AgentReasonix       AgentType = "reasonix"
@@ -565,6 +566,18 @@ var Registry = []AgentDef{
 		DefaultDirs: []string{".local/share/gptme/logs"},
 		IDPrefix:    "gptme:",
 		FileBased:   true,
+	},
+	{
+		Type:        AgentQoder,
+		DisplayName: "Qoder",
+		EnvVar:      "QODER_PROJECTS_DIR",
+		ConfigKey:   "qoder_project_dirs",
+		DefaultDirs: []string{
+			".qoder/projects",
+			".qoderwork/projects",
+		},
+		IDPrefix:  "qoder:",
+		FileBased: true,
 	},
 	{
 		// Shelley (exe.dev) stores all conversations in a single

--- a/internal/parser/types_test.go
+++ b/internal/parser/types_test.go
@@ -367,6 +367,12 @@ func TestAgentByPrefix(t *testing.T) {
 			true,
 		},
 		{
+			"qoder prefix",
+			"qoder:sess-id",
+			AgentQoder,
+			true,
+		},
+		{
 			"remote deepseek tui prefix",
 			"devbox~deepseek-tui:sess-id",
 			AgentDeepSeekTUI,
@@ -445,6 +451,7 @@ func TestRegistryCompleteness(t *testing.T) {
 		AgentWorkBuddy,
 		AgentZencoder,
 		AgentGptme,
+		AgentQoder,
 		AgentQwenPaw,
 		AgentShelley,
 		AgentVibe,

--- a/internal/ssh/resolve.go
+++ b/internal/ssh/resolve.go
@@ -73,6 +73,24 @@ func buildAiderResolveSnippet(envVar string) string {
 // the remote are skipped.
 func buildResolveScript() string {
 	var b strings.Builder
+	b.WriteString(
+		"av_emit_dir() { " +
+			"if [ -n \"$1\" ]; then eval \"dir=\\${$1:-}\"; else dir=\"\"; fi; " +
+			"[ -n \"$dir\" ] || dir=\"$2\"; " +
+			"[ -d \"$dir\" ] && printf '%s\\000' \"$3:$dir\"; " +
+			"}\n" +
+			"av_emit_rooted_dir() { " +
+			"if [ -n \"$1\" ]; then eval \"dir=\\${$1:-}\"; else dir=\"\"; fi; " +
+			"if [ -n \"$2\" ]; then eval \"root=\\${$2:-}\"; else root=\"\"; fi; " +
+			"[ -z \"$dir\" ] && [ -n \"$root\" ] && dir=\"$root$3\"; " +
+			"[ -n \"$dir\" ] || dir=\"$4\"; " +
+			"[ -d \"$dir\" ] && printf '%s\\000' \"$5:$dir\"; " +
+			"}\n" +
+			"av_emit_codex_index() { " +
+			"idx=\"${dir%/*}/" + parser.CodexSessionIndexFilename + "\"; " +
+			"[ -f \"$idx\" ] && printf '%s\\000' \"" + resolveFilePrefix + ":$idx\"; " +
+			"}\n",
+	)
 	for _, def := range parser.Registry {
 		if !resolveAgentHasOnDiskSource(def) {
 			continue
@@ -98,37 +116,19 @@ func buildResolveScript() string {
 			defaultDir := "$HOME/" + rel
 			if def.DefaultRootEnvVar != "" {
 				rootTail := remoteDefaultRootTail(rel)
-				fmt.Fprintf(&b, "dir=\"")
-				if def.EnvVar != "" {
-					fmt.Fprintf(&b, "${%s:-}", def.EnvVar)
-				}
-				fmt.Fprintf(&b, "\"; ")
-				fmt.Fprintf(&b, "root=\"${%s:-}\"; ", def.DefaultRootEnvVar)
+				rootSuffix := ""
 				if rootTail != "" {
-					fmt.Fprintf(&b,
-						"[ -z \"$dir\" ] && [ -n \"$root\" ] && dir=\"$root/%s\"; ",
-						rootTail,
-					)
-				} else {
-					fmt.Fprintf(&b,
-						"[ -z \"$dir\" ] && [ -n \"$root\" ] && dir=\"$root\"; ",
-					)
+					rootSuffix = "/" + rootTail
 				}
 				fmt.Fprintf(&b,
-					"[ -n \"$dir\" ] || dir=\"%s\"; [ -d \"$dir\" ] && "+
-						"printf '%%s\\000' \"%s:$dir\"\n",
+					"av_emit_rooted_dir \"%s\" \"%s\" \"%s\" \"%s\" %s\n",
+					def.EnvVar, def.DefaultRootEnvVar, rootSuffix,
 					defaultDir, string(def.Type),
 				)
 			} else {
-				dirExpr := defaultDir
-				if def.EnvVar != "" {
-					// env var overrides default
-					dirExpr = fmt.Sprintf("${%s:-%s}", def.EnvVar, defaultDir)
-				}
 				fmt.Fprintf(&b,
-					"dir=\"%s\"; [ -d \"$dir\" ] && "+
-						"printf '%%s\\000' \"%s:$dir\"\n",
-					dirExpr, string(def.Type),
+					"av_emit_dir \"%s\" \"%s\" %s\n",
+					def.EnvVar, defaultDir, string(def.Type),
 				)
 			}
 			// Codex stores renameable session titles in
@@ -136,13 +136,7 @@ func buildResolveScript() string {
 			// sessions/ and archived_sessions/. Emit it so renames
 			// import on remote hosts too. ${dir%/*} is the parent.
 			if def.Type == parser.AgentCodex {
-				fmt.Fprintf(&b,
-					"idx=\"${dir%%/*}/%s\"; "+
-						"[ -f \"$idx\" ] && "+
-						"printf '%%s\\000' \"%s:$idx\"\n",
-					parser.CodexSessionIndexFilename,
-					resolveFilePrefix,
-				)
+				b.WriteString("av_emit_codex_index\n")
 			}
 		}
 	}

--- a/internal/ssh/resolve.go
+++ b/internal/ssh/resolve.go
@@ -75,13 +75,13 @@ func buildResolveScript() string {
 	var b strings.Builder
 	b.WriteString(
 		"av_emit_dir() { " +
-			"if [ -n \"$1\" ]; then eval \"dir=\\${$1:-}\"; else dir=\"\"; fi; " +
+			"dir=\"$1\"; " +
 			"[ -n \"$dir\" ] || dir=\"$2\"; " +
 			"[ -d \"$dir\" ] && printf '%s\\000' \"$3:$dir\"; " +
 			"}\n" +
 			"av_emit_rooted_dir() { " +
-			"if [ -n \"$1\" ]; then eval \"dir=\\${$1:-}\"; else dir=\"\"; fi; " +
-			"if [ -n \"$2\" ]; then eval \"root=\\${$2:-}\"; else root=\"\"; fi; " +
+			"dir=\"$1\"; " +
+			"root=\"$2\"; " +
 			"[ -z \"$dir\" ] && [ -n \"$root\" ] && dir=\"$root$3\"; " +
 			"[ -n \"$dir\" ] || dir=\"$4\"; " +
 			"[ -d \"$dir\" ] && printf '%s\\000' \"$5:$dir\"; " +
@@ -122,13 +122,15 @@ func buildResolveScript() string {
 				}
 				fmt.Fprintf(&b,
 					"av_emit_rooted_dir \"%s\" \"%s\" \"%s\" \"%s\" %s\n",
-					def.EnvVar, def.DefaultRootEnvVar, rootSuffix,
-					defaultDir, string(def.Type),
+					remoteEnvExpansion(def.EnvVar),
+					remoteEnvExpansion(def.DefaultRootEnvVar),
+					rootSuffix, defaultDir, string(def.Type),
 				)
 			} else {
 				fmt.Fprintf(&b,
 					"av_emit_dir \"%s\" \"%s\" %s\n",
-					def.EnvVar, defaultDir, string(def.Type),
+					remoteEnvExpansion(def.EnvVar), defaultDir,
+					string(def.Type),
 				)
 			}
 			// Codex stores renameable session titles in
@@ -144,6 +146,13 @@ func buildResolveScript() string {
 	// path doesn't exist, which would make sh exit non-zero.
 	b.WriteString("true\n")
 	return b.String()
+}
+
+func remoteEnvExpansion(envVar string) string {
+	if envVar == "" {
+		return ""
+	}
+	return "${" + envVar + ":-}"
 }
 
 // BuildResolveScriptForTest exposes the SSH resolver script to

--- a/internal/ssh/resolve_test.go
+++ b/internal/ssh/resolve_test.go
@@ -58,7 +58,7 @@ func TestResolveScriptExcludesDevinProviderRoot(t *testing.T) {
 
 func TestResolveScriptHonorsClaudeConfigDirRoot(t *testing.T) {
 	home := t.TempDir()
-	root := filepath.Join(home, ".claude-personal")
+	root := filepath.Join(home, "claude personal")
 	projectsDir := filepath.Join(root, "projects")
 	require.NoError(t, os.MkdirAll(projectsDir, 0o755), "mkdir projects")
 
@@ -74,6 +74,25 @@ func TestResolveScriptHonorsClaudeConfigDirRoot(t *testing.T) {
 	dirs, _ := parseResolvedDirs(string(out))
 	assert.Contains(t, dirs[parser.AgentClaude], root+"/projects")
 	assert.NotContains(t, dirs[parser.AgentClaude], home+"/.claude/projects")
+}
+
+func TestResolveScriptTreatsEnvValuesAsData(t *testing.T) {
+	home := t.TempDir()
+	projectsDir := filepath.Join(home, "config root", "projects")
+	require.NoError(t, os.MkdirAll(projectsDir, 0o755), "mkdir projects")
+
+	script := buildResolveScript()
+	require.NotContains(t, script, "eval")
+	cmd := exec.Command("sh", "-c", script)
+	cmd.Env = []string{
+		"HOME=" + home,
+		"CLAUDE_PROJECTS_DIR=" + projectsDir,
+	}
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "resolve script failed: output: %s", out)
+
+	dirs, _ := parseResolvedDirs(string(out))
+	assert.Contains(t, dirs[parser.AgentClaude], projectsDir)
 }
 
 func TestResolveScriptExitsZero(t *testing.T) {

--- a/internal/ssh/resolve_test.go
+++ b/internal/ssh/resolve_test.go
@@ -22,18 +22,23 @@ func TestBuildResolveScript(t *testing.T) {
 
 	// Only file-backed provider-authoritative agents belong in the resolver.
 	for _, def := range parser.Registry {
-		marker := "\"" + string(def.Type) + ":"
 		want := def.FileBased &&
 			parser.ProviderMigrationModes()[def.Type] ==
 				parser.ProviderMigrationProviderAuthoritative
 		if want {
-			assert.Contains(t, script, marker,
+			assert.True(t, resolveScriptMentionsAgent(script, def.Type),
 				"file-backed provider-authoritative agent %s missing from script", def.Type)
 			continue
 		}
-		assert.NotContains(t, script, marker,
+		assert.False(t, resolveScriptMentionsAgent(script, def.Type),
 			"unsupported agent %s must stay out of the SSH resolver", def.Type)
 	}
+}
+
+func resolveScriptMentionsAgent(script string, agent parser.AgentType) bool {
+	name := string(agent)
+	return strings.Contains(script, "\""+name+":") ||
+		strings.Contains(script, " "+name+"\n")
 }
 
 func TestResolveScriptExcludesDevinProviderRoot(t *testing.T) {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -8197,6 +8197,18 @@ func (e *Engine) SyncSingleSessionContext(
 				file.Project = workspace
 			}
 		}
+	case parser.AgentQoder:
+		for _, qoderDir := range e.agentDirs[parser.AgentQoder] {
+			rel, ok := isUnder(qoderDir, path)
+			if !ok {
+				continue
+			}
+			parts := strings.Split(rel, string(filepath.Separator))
+			if len(parts) == 2 || len(parts) == 4 && parts[2] == "subagents" {
+				file.Project = parser.DecodeQoderProjectDir(parts[0])
+				break
+			}
+		}
 	case parser.AgentReasonix:
 		if classified, ok := e.classifyReasonixPath(path); ok {
 			file.Project = classified.Project

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -4178,7 +4178,12 @@ func providerProcessCacheKeyWithHash(
 }
 
 func providerFingerprintHashRequiredForFreshness(agent parser.AgentType) bool {
-	return agent == parser.AgentDevin
+	switch agent {
+	case parser.AgentDevin, parser.AgentQoder:
+		return true
+	default:
+		return false
+	}
 }
 
 func (e *Engine) providerSkipCacheEntryFreshInDB(

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -7808,6 +7808,10 @@ func providerSourcePathNeedsFingerprint(path string) bool {
 	return path != "" && parser.ResolveSourceFilePath(path) != path
 }
 
+func providerSourceMtimeNeedsFingerprint(agent parser.AgentType) bool {
+	return agent == parser.AgentQoder
+}
+
 // providerSessionIsFork reports whether the session ID addresses a fork child
 // whose base differs from the resolved source session. Only Piebald uses the
 // "<chat>-<row>" fork-ID shape among the DB-backed providers.
@@ -7894,7 +7898,8 @@ func (e *Engine) SourceMtime(sessionID string) int64 {
 		return 0
 	}
 	if e.isProviderAuthoritative(def.Type) &&
-		providerSourcePathNeedsFingerprint(path) {
+		(providerSourcePathNeedsFingerprint(path) ||
+			providerSourceMtimeNeedsFingerprint(def.Type)) {
 		if mtime := e.providerSessionSourceMtime(
 			context.Background(), def, sessionID, rawSessionID, path,
 		); mtime != 0 {

--- a/internal/sync/qoder_test.go
+++ b/internal/sync/qoder_test.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -78,4 +79,44 @@ func TestEngineClassifyQoderProjectNamedSubagentsAsMainSession(t *testing.T) {
 	assert.Equal(t, path, got.Path)
 	assert.Equal(t, "subagents", got.Project)
 	assert.Equal(t, parser.AgentQoder, got.Agent)
+}
+
+func TestEngineSyncQoderSameMessageIDAppendForceReplaces(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentQoder: {root},
+		},
+		Machine: "local",
+	})
+
+	rawID := "11111111-1111-4111-8111-111111111111"
+	sessionID := "qoder:" + rawID
+	path := filepath.Join(root, "-Users-alice-project", rawID+".jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	initial := `{"type":"user","uuid":"u1","timestamp":"2026-06-04T09:47:20.000Z","message":{"role":"user","content":"hello"},"sessionId":"11111111-1111-4111-8111-111111111111"}
+{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2026-06-04T09:47:21.000Z","message":{"id":"msg_split","role":"assistant","model":"auto","stop_reason":"tool_use","content":[{"type":"text","text":"Hello"}]},"sessionId":"11111111-1111-4111-8111-111111111111"}
+`
+	require.NoError(t, os.WriteFile(path, []byte(initial), 0o644))
+
+	engine.SyncAll(context.Background(), nil)
+	msgs, err := database.GetAllMessages(context.Background(), sessionID)
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "Hello", msgs[1].Content)
+
+	appended := `{"type":"assistant","uuid":"a2","parentUuid":"a1","timestamp":"2026-06-04T09:47:22.000Z","message":{"id":"msg_split","role":"assistant","model":"auto","stop_reason":"end_turn","content":[{"type":"text","text":"Hello world"}]},"sessionId":"11111111-1111-4111-8111-111111111111"}
+`
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, writeErr := f.WriteString(appended)
+	require.NoError(t, writeErr)
+	require.NoError(t, f.Close())
+
+	engine.SyncPaths([]string{path})
+	msgs, err = database.GetAllMessages(context.Background(), sessionID)
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "Hello world", msgs[1].Content)
 }

--- a/internal/sync/qoder_test.go
+++ b/internal/sync/qoder_test.go
@@ -203,6 +203,36 @@ func TestProcessFileQoderSameSizeSameMtimeSidecarRewriteReparses(t *testing.T) {
 	}
 }
 
+func TestSourceMtimeQoderIncludesSidecarMtime(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentQoder: {root},
+		},
+		Machine: "local",
+	})
+
+	rawID := "11111111-1111-4111-8111-111111111111"
+	path := filepath.Join(root, "-Users-alice-project", rawID+".jsonl")
+	sidecarPath := strings.TrimSuffix(path, ".jsonl") + "-session.json"
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(`{"type":"user","uuid":"u1","timestamp":"2026-06-04T09:47:27.966Z","message":{"role":"user","content":"hello"},"sessionId":"11111111-1111-4111-8111-111111111111"}
+`), 0o644))
+	require.NoError(t, os.WriteFile(
+		sidecarPath,
+		[]byte(`{"title":"Sidecar title","working_dir":"/tmp/qoder"}`),
+		0o644,
+	))
+
+	transcriptTime := time.Date(2026, time.June, 4, 10, 0, 0, 0, time.UTC)
+	sidecarTime := transcriptTime.Add(5 * time.Minute)
+	require.NoError(t, os.Chtimes(path, transcriptTime, transcriptTime))
+	require.NoError(t, os.Chtimes(sidecarPath, sidecarTime, sidecarTime))
+
+	assert.Equal(t, sidecarTime.UnixNano(), engine.SourceMtime("qoder:"+rawID))
+}
+
 func writeProcessQoderResult(
 	t *testing.T,
 	engine *Engine,

--- a/internal/sync/qoder_test.go
+++ b/internal/sync/qoder_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -119,4 +121,104 @@ func TestEngineSyncQoderSameMessageIDAppendForceReplaces(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, msgs, 2)
 	assert.Equal(t, "Hello world", msgs[1].Content)
+}
+
+func TestProcessFileQoderSameSizeSameMtimeSidecarRewriteReparses(t *testing.T) {
+	tests := []struct {
+		name      string
+		seedCache bool
+		freshSync bool
+	}{
+		{name: "skip cache", seedCache: true},
+		{name: "db freshness", freshSync: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			database := openTestDB(t)
+			root := t.TempDir()
+			engine := NewEngine(database, EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{
+					parser.AgentQoder: {root},
+				},
+				Machine: "local",
+			})
+
+			rawID := "11111111-1111-4111-8111-111111111111"
+			path := filepath.Join(root, "-Users-alice-project", rawID+".jsonl")
+			sidecarPath := strings.TrimSuffix(path, ".jsonl") + "-session.json"
+			require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+			require.NoError(t, os.WriteFile(path, []byte(`{"type":"user","uuid":"u1","timestamp":"2026-06-04T09:47:27.966Z","message":{"role":"user","content":"hello"},"sessionId":"11111111-1111-4111-8111-111111111111"}
+`), 0o644))
+			initialSidecar := []byte(`{"title":"Initial title","working_dir":"/tmp/qoder-a"}`)
+			changedSidecar := []byte(`{"title":"Changed title","working_dir":"/tmp/qoder-a"}`)
+			require.Len(t, changedSidecar, len(initialSidecar),
+				"test must keep size stable so hash is the only freshness signal")
+			require.NoError(t, os.WriteFile(sidecarPath, initialSidecar, 0o644))
+			initialTime := time.Date(2026, time.June, 4, 10, 0, 0, 0, time.UTC)
+			require.NoError(t, os.Chtimes(path, initialTime, initialTime))
+			require.NoError(t, os.Chtimes(sidecarPath, initialTime, initialTime))
+
+			file := parser.DiscoveredFile{
+				Path:            path,
+				Agent:           parser.AgentQoder,
+				ProviderProcess: true,
+			}
+			first := engine.processFile(context.Background(), file)
+			require.NoError(t, first.err)
+			require.Len(t, first.results, 1)
+			initialMtime := first.results[0].Session.File.Mtime
+			initialHash := first.results[0].Session.File.Hash
+			require.Equal(t, initialTime.UnixNano(), initialMtime)
+			require.NotEmpty(t, initialHash)
+			require.Contains(t, first.cacheKey, "?source_hash="+initialHash)
+			writeProcessQoderResult(t, engine, first)
+
+			require.NoError(t, os.WriteFile(sidecarPath, changedSidecar, 0o644))
+			require.NoError(t, os.Chtimes(sidecarPath, initialTime, initialTime))
+
+			if tt.seedCache {
+				engine.cacheSkip(first.cacheKey, initialMtime)
+			}
+			if tt.freshSync {
+				engine = NewEngine(database, EngineConfig{
+					AgentDirs: map[parser.AgentType][]string{
+						parser.AgentQoder: {root},
+					},
+					Machine: "local",
+				})
+			}
+
+			second := engine.processFile(context.Background(), file)
+			require.NoError(t, second.err)
+			assert.False(t, second.skip)
+			require.Len(t, second.results, 1)
+			assert.Equal(t, "Changed title", second.results[0].Session.SessionName)
+			assert.Equal(t, "/tmp/qoder-a", second.results[0].Session.Cwd)
+			changedHash := second.results[0].Session.File.Hash
+			require.NotEmpty(t, changedHash)
+			require.NotEqual(t, initialHash, changedHash)
+			require.Contains(t, second.cacheKey, "?source_hash="+changedHash)
+		})
+	}
+}
+
+func writeProcessQoderResult(
+	t *testing.T,
+	engine *Engine,
+	result processResult,
+) {
+	t.Helper()
+	written, _, failed := engine.writeBatch(
+		[]pendingWrite{{
+			sess:         result.results[0].Session,
+			msgs:         result.results[0].Messages,
+			usageEvents:  result.results[0].UsageEvents,
+			forceReplace: result.forceReplace,
+		}},
+		syncWriteDefault,
+		false,
+	)
+	require.Equal(t, 0, failed)
+	require.Equal(t, 1, written)
 }

--- a/internal/sync/qoder_test.go
+++ b/internal/sync/qoder_test.go
@@ -1,0 +1,81 @@
+package sync
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+func TestEngineClassifyQoderPaths(t *testing.T) {
+	db := openTestDB(t)
+	root := t.TempDir()
+	engine := NewEngine(db, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentQoder: {root},
+		},
+		Machine: "local",
+	})
+
+	mainPath := filepath.Join(root, "-Users-alice-project", "11111111-1111-4111-8111-111111111111.jsonl")
+	subPath := filepath.Join(root, "-Users-alice-project", "11111111-1111-4111-8111-111111111111", "subagents", "agent-123.jsonl")
+	sidecarPath := filepath.Join(root, "-Users-alice-project", "11111111-1111-4111-8111-111111111111-session.json")
+	statsPath := filepath.Join(root, "ai-stats", "usage.json")
+	rootAgentPath := filepath.Join(root, "-Users-alice-project", "agent-123.jsonl")
+	nestedPath := filepath.Join(root, "-Users-alice-project", "notes", "stray.jsonl")
+	for _, path := range []string{mainPath, subPath, sidecarPath, statsPath, rootAgentPath, nestedPath} {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o644))
+	}
+
+	files := engine.classifyPaths([]string{mainPath})
+	require.Len(t, files, 1, "main path did not classify")
+	got := files[0]
+	assert.Equal(t, mainPath, got.Path)
+	assert.Equal(t, "project", got.Project)
+	assert.Equal(t, parser.AgentQoder, got.Agent)
+
+	files = engine.classifyPaths([]string{subPath})
+	require.Len(t, files, 1, "subagent path did not classify")
+	got = files[0]
+	assert.Equal(t, subPath, got.Path)
+	assert.Equal(t, "project", got.Project)
+	assert.Equal(t, parser.AgentQoder, got.Agent)
+
+	files = engine.classifyPaths([]string{sidecarPath})
+	require.Len(t, files, 1, "sidecar path did not map to transcript")
+	got = files[0]
+	assert.Equal(t, mainPath, got.Path)
+	assert.Equal(t, "project", got.Project)
+	assert.Equal(t, parser.AgentQoder, got.Agent)
+
+	for _, path := range []string{statsPath, rootAgentPath, nestedPath} {
+		files = engine.classifyPaths([]string{path})
+		assert.Emptyf(t, files, "%s classified as %+v", path, files)
+	}
+}
+
+func TestEngineClassifyQoderProjectNamedSubagentsAsMainSession(t *testing.T) {
+	db := openTestDB(t)
+	root := t.TempDir()
+	engine := NewEngine(db, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentQoder: {root},
+		},
+		Machine: "local",
+	})
+
+	path := filepath.Join(root, "subagents", "11111111-1111-4111-8111-111111111111.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o644))
+
+	files := engine.classifyPaths([]string{path})
+	require.Len(t, files, 1, "path did not classify")
+	got := files[0]
+	assert.Equal(t, path, got.Path)
+	assert.Equal(t, "subagents", got.Project)
+	assert.Equal(t, parser.AgentQoder, got.Agent)
+}


### PR DESCRIPTION
AgentsView now reads Qoder and QoderWork transcripts from `~/.qoder/projects/` and `~/.qoderwork/projects/`. The files in #1011 use Claude-style JSONL, so the provider runs them through the existing Claude parser and retags the parsed sessions as Qoder instead of carrying a separate parser.

The provider discovers main transcripts and `subagents/agent-*.jsonl` files, applies `*-session.json` title, cwd, and fork metadata, force-replaces Qoder parses so Claude-style streamed chunks update stored rows, and keeps subagent links stable across forked rows. Sync path classification and the frontend agent label are wired up so configured Qoder directories behave like the other file-backed agents.

QoderCLI stays out of scope because #1011 describes only `ai-stats/` there, with no transcript files to import. #1000 is covered by this Qoder and QoderWork support; #1011 has the concrete layout and samples used here.

Reviewer entry points are `internal/parser/qoder*.go` for discovery and retagging, `internal/sync/qoder_test.go` for sync behavior, and `frontend/src/lib/utils/agents.ts` for the display label.

Closes #1011