### PR TITLE
fix(sync): drop unchanged opencode-family container sessions

### DIFF
--- a/internal/db/project_identity_test.go
+++ b/internal/db/project_identity_test.go
@@ -619,7 +619,8 @@ func TestProjectIdentityMapLegacyFallbackAcceptsWindowsDriveRoots(t *testing.T) 
 func TestProjectIdentityMapUnknownPersistedObservationUsesLegacyFallback(t *testing.T) {
 	d := testDB(t)
 	ctx := context.Background()
-	root := t.TempDir()
+	root := filepath.Join(t.TempDir(), "fallback")
+	require.NoError(t, os.MkdirAll(filepath.Join(root, ".git"), 0o755))
 
 	require.NoError(t, d.UpsertProjectIdentityObservation(ctx,
 		export.ProjectIdentityObservation{

--- a/internal/insight/generate_test.go
+++ b/internal/insight/generate_test.go
@@ -216,9 +216,9 @@ func createMockBinary(
 	bin = filepath.Join(dir, name)
 	var script string
 	if writeArgs {
-		script = fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$@\" > %s\ncat %s\nexit %d\n", shellQuote(argsFile), shellQuote(dataFile), exitCode)
+		script = fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$@\" > %s\nprintf '%%s' %s\nexit %d\n", shellQuote(argsFile), shellQuote(stdout), exitCode)
 	} else {
-		script = fmt.Sprintf("#!/bin/sh\ncat %s\nexit %d\n", shellQuote(dataFile), exitCode)
+		script = fmt.Sprintf("#!/bin/sh\nprintf '%%s' %s\nexit %d\n", shellQuote(stdout), exitCode)
 	}
 	require.NoError(t, os.WriteFile(bin, []byte(script), 0o755))
 	return bin, argsFile

--- a/internal/parser/devin_test.go
+++ b/internal/parser/devin_test.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"database/sql"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -331,16 +332,18 @@ func TestParseDevinSessionFinalMetricsTotalKeys(t *testing.T) {
 
 func TestParseDevinSessionTranscriptFallbacks(t *testing.T) {
 	const sessionID = "session-fallbacks"
+	worktree := filepath.Join(t.TempDir(), "fallback-app")
+	require.NoError(t, os.MkdirAll(filepath.Join(worktree, ".git"), 0o755))
 	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{
 		ID:                 sessionID,
 		Model:              "db-model",
 		CreatedAtMillis:    new(int64(0)),
-		WorkspaceJSON:      `[{"root_path":"/tmp/worktrees/fallback-app"}]`,
+		WorkspaceJSON:      fmt.Sprintf(`[{"root_path":%q}]`, worktree),
 		MetadataJSON:       `{"mode":"fallback"}`,
 		LastActivityMillis: nil,
-	}, `{
+	}, fmt.Sprintf(`{
 		"agent":{"model_name":""},
-		"workspace_dirs":[{"root_path":"/tmp/worktrees/fallback-app"}],
+		"workspace_dirs":[{"root_path":%q}],
 		"final_metrics":{
 			"output_tokens":0,
 			"context_tokens":0,
@@ -350,14 +353,14 @@ func TestParseDevinSessionTranscriptFallbacks(t *testing.T) {
 			{"step_id":"a","source":"user","createdAt":"2024-01-01T10:00:01Z","message":"hi from fallback"},
 			{"step_id":"b","source":"agent","updatedAt":"2024-01-01T10:00:05Z","message":[{"type":"text","text":"hello"}]}
 		]
-	}`)
+	}`, worktree))
 
 	sess, msgs, err := parseDevinSession(dbPath, sessionID, "local")
 	require.NoError(t, err)
 	require.Len(t, msgs, 2)
 	assert.Equal(t, "hi from fallback", sess.SessionName)
 	assert.Equal(t, "hi from fallback", sess.FirstMessage)
-	assert.Equal(t, "/tmp/worktrees/fallback-app", sess.Cwd)
+	assert.Equal(t, worktree, sess.Cwd)
 	assert.Equal(t, "fallback_app", sess.Project)
 	assert.Equal(t, "db-model", msgs[0].Model)
 	assert.Equal(t, "db-model", msgs[1].Model)
@@ -397,10 +400,12 @@ func TestParseDevinSessionAllowsMissingMetadataTimestamps(t *testing.T) {
 
 func TestParseDevinSessionEmptyTranscriptUsesDBMetadata(t *testing.T) {
 	const sessionID = "session-empty"
+	worktree := filepath.Join(t.TempDir(), "db-only-project")
+	require.NoError(t, os.MkdirAll(filepath.Join(worktree, ".git"), 0o755))
 	dbPath, _ := newDevinSessionFixture(t, devinSessionRow{
 		ID:                 sessionID,
 		Title:              "DB only session",
-		WorkingDirectory:   "/tmp/db-only-project",
+		WorkingDirectory:   worktree,
 		Model:              "db-only-model",
 		CreatedAtMillis:    new(int64(1704103200000)),
 		LastActivityMillis: new(int64(1704103209000)),
@@ -414,7 +419,7 @@ func TestParseDevinSessionEmptyTranscriptUsesDBMetadata(t *testing.T) {
 	require.NotNil(t, sess)
 	assert.Empty(t, msgs)
 	assert.Equal(t, "DB only session", sess.SessionName)
-	assert.Equal(t, "/tmp/db-only-project", sess.Cwd)
+	assert.Equal(t, worktree, sess.Cwd)
 	assert.Equal(t, "db_only_project", sess.Project)
 	assert.Equal(t, 0, sess.MessageCount)
 	assert.Equal(t, 0, sess.UserMessageCount)

--- a/internal/parser/opencode.go
+++ b/internal/parser/opencode.go
@@ -410,7 +410,7 @@ func buildOpenCodeSession(
 		)
 	}
 
-	return buildOpenCodeParsedSession(
+	sess, parsed, err := buildOpenCodeParsedSession(
 		s,
 		worktree,
 		dbPath+"#"+s.id,
@@ -419,6 +419,11 @@ func buildOpenCodeSession(
 		msgs,
 		parts,
 	)
+	if err != nil || sess == nil {
+		return sess, parsed, err
+	}
+	sess.File.Hash = buildOpenCodeStorageFingerprint(msgs, parts)
+	return sess, parsed, nil
 }
 
 func buildOpenCodeParsedSession(

--- a/internal/parser/opencode.go
+++ b/internal/parser/opencode.go
@@ -206,8 +206,17 @@ func parseOpenCodeStorageFile(
 	if err != nil || sess == nil {
 		return sess, parsed, err
 	}
-	sess.File.Hash = buildOpenCodeStorageFingerprint(
-		msgs, parts,
+	sess.File.Hash = buildOpenCodeSessionFingerprint(
+		openCodeSessionRow{
+			id:          sf.ID,
+			parentID:    sf.ParentID,
+			title:       sf.Title,
+			timeCreated: sf.Time.Created,
+			timeUpdated: sf.Time.Updated,
+		},
+		sf.Directory,
+		msgs,
+		parts,
 	)
 	return sess, parsed, nil
 }
@@ -316,7 +325,18 @@ type openCodePartRow struct {
 }
 
 type openCodeStorageFingerprint struct {
+	Session  *openCodeStorageFingerprintSession  `json:"session,omitempty"`
 	Messages []openCodeStorageFingerprintMessage `json:"messages"`
+}
+
+type openCodeStorageFingerprintSession struct {
+	ID          string `json:"id,omitempty"`
+	ProjectID   string `json:"project_id,omitempty"`
+	ParentID    string `json:"parent_id,omitempty"`
+	Title       string `json:"title,omitempty"`
+	Worktree    string `json:"worktree,omitempty"`
+	TimeCreated int64  `json:"time_created,omitempty"`
+	TimeUpdated int64  `json:"time_updated,omitempty"`
 }
 
 type openCodeStorageFingerprintMessage struct {
@@ -422,7 +442,9 @@ func buildOpenCodeSession(
 	if err != nil || sess == nil {
 		return sess, parsed, err
 	}
-	sess.File.Hash = buildOpenCodeStorageFingerprint(msgs, parts)
+	sess.File.Hash = buildOpenCodeSessionFingerprint(
+		s, worktree, msgs, parts,
+	)
 	return sess, parsed, nil
 }
 
@@ -982,6 +1004,12 @@ func OpenCodeStorageFingerprintMissing(
 	if !ok {
 		return false
 	}
+	if stored.Session != nil {
+		if current.Session == nil ||
+			*current.Session != *stored.Session {
+			return true
+		}
+	}
 
 	currentMsgs := make(map[string]openCodeStorageFingerprintMessage, len(current.Messages))
 	for _, msg := range current.Messages {
@@ -1016,7 +1044,37 @@ func buildOpenCodeStorageFingerprint(
 	msgs []openCodeMessageRow,
 	parts map[string][]openCodePartRow,
 ) string {
+	return buildOpenCodeStorageFingerprintWithSession(nil, msgs, parts)
+}
+
+func buildOpenCodeSessionFingerprint(
+	s openCodeSessionRow,
+	worktree string,
+	msgs []openCodeMessageRow,
+	parts map[string][]openCodePartRow,
+) string {
+	return buildOpenCodeStorageFingerprintWithSession(
+		&openCodeStorageFingerprintSession{
+			ID:          s.id,
+			ProjectID:   s.projectID,
+			ParentID:    s.parentID,
+			Title:       s.title,
+			Worktree:    worktree,
+			TimeCreated: s.timeCreated,
+			TimeUpdated: s.timeUpdated,
+		},
+		msgs,
+		parts,
+	)
+}
+
+func buildOpenCodeStorageFingerprintWithSession(
+	session *openCodeStorageFingerprintSession,
+	msgs []openCodeMessageRow,
+	parts map[string][]openCodePartRow,
+) string {
 	fp := openCodeStorageFingerprint{
+		Session: session,
 		Messages: make(
 			[]openCodeStorageFingerprintMessage,
 			0, len(msgs),

--- a/internal/parser/opencode_provider.go
+++ b/internal/parser/opencode_provider.go
@@ -768,9 +768,25 @@ func (s openCodeFormatSourceSet) isStorageSessionPath(
 }
 
 func openCodeProviderStorageFingerprint(sessionPath string) (string, error) {
+	raw, err := os.ReadFile(sessionPath)
+	if err != nil {
+		return "", err
+	}
+	var sf openCodeStorageSessionFile
+	if err := json.Unmarshal(raw, &sf); err != nil {
+		return "", fmt.Errorf(
+			"decoding opencode session file %s: %w",
+			sessionPath, err,
+		)
+	}
+	if sf.ID == "" {
+		return "", fmt.Errorf(
+			"opencode session file %s missing id",
+			sessionPath,
+		)
+	}
 	root := filepath.Dir(filepath.Dir(filepath.Dir(filepath.Dir(sessionPath))))
-	sessionID := strings.TrimSuffix(filepath.Base(sessionPath), filepath.Ext(sessionPath))
-	msgs, err := loadOpenCodeStorageMessages(root, sessionID)
+	msgs, err := loadOpenCodeStorageMessages(root, sf.ID)
 	if err != nil {
 		return "", err
 	}
@@ -778,7 +794,18 @@ func openCodeProviderStorageFingerprint(sessionPath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return buildOpenCodeStorageFingerprint(msgs, parts), nil
+	return buildOpenCodeSessionFingerprint(
+		openCodeSessionRow{
+			id:          sf.ID,
+			parentID:    sf.ParentID,
+			title:       sf.Title,
+			timeCreated: sf.Time.Created,
+			timeUpdated: sf.Time.Updated,
+		},
+		sf.Directory,
+		msgs,
+		parts,
+	), nil
 }
 
 func readOpenCodeProviderStorageSessionID(path string) string {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -3909,6 +3909,12 @@ func (e *Engine) dropUnchangedSharedSQLiteResults(
 		// Every aider run in a history file shares the file's content hash, so
 		// a same-mtime append/truncate is caught by the hash compare.
 		compareHash = true
+	case parser.AgentOpenCode, parser.AgentKilo, parser.AgentMiMoCode, parser.AgentIcodemate:
+		// OpenCode-family providers fan one shared container out to per-session
+		// results. The per-session mtime is the session's own updated time, and
+		// the hash compare uses the opencode storage fingerprint to catch
+		// same-mtime content changes.
+		compareHash = true
 	case parser.AgentZed, parser.AgentKiro:
 		// Zed and Kiro fan one container DB out to a session per row and have no
 		// per-row content hash, so unchanged rows are detected by mtime plus
@@ -7142,9 +7148,18 @@ func (e *Engine) shouldPreserveOpenCodeFormatArchive(
 	storedHash := derefString(stored.FileHash)
 	storedPath := derefString(stored.FilePath)
 	storedMtime := derefInt64(stored.FileMtime)
-	storedIsStorageArchive := hasOpenCodeFormatStorageFingerprint(
+	storedHasStorageFingerprint := hasOpenCodeFormatStorageFingerprint(
 		agent, storedHash,
-	) || isOpenCodeFormatStoragePath(agent, storedPath)
+	)
+	storedIsSQLiteVirtual := isOpenCodeFormatSQLiteVirtualPath(
+		agent, storedPath,
+	)
+	storedIsStorageArchive := isOpenCodeFormatStoragePath(
+		agent, storedPath,
+	) || (storedPath == "" && storedHasStorageFingerprint)
+	if storedIsSQLiteVirtual {
+		storedIsStorageArchive = false
+	}
 	if isOpenCodeFormatSQLiteVirtualPath(agent, path) &&
 		!storedIsStorageArchive {
 		return false
@@ -7160,7 +7175,7 @@ func (e *Engine) shouldPreserveOpenCodeFormatArchive(
 	// live child files in place, so we only preserve when the
 	// newly parsed transcript also looks incomplete relative
 	// to what is already archived.
-	if hasOpenCodeFormatStorageFingerprint(agent, storedHash) &&
+	if storedHasStorageFingerprint &&
 		hasOpenCodeFormatStorageFingerprint(agent, currentHash) &&
 		!parser.OpenCodeStorageFingerprintMissing(
 			storedHash, currentHash,

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -550,6 +550,58 @@ func TestSyncEngineOpenCodeSQLiteSameMtimeContentChangeUsesFingerprint(
 		"successful rewrite must bump local_modified_at for push windows")
 }
 
+func TestSyncEngineOpenCodeSQLiteSameMtimeMetadataChangeUsesFingerprint(
+	t *testing.T,
+) {
+	env := setupSingleAgentTestEnv(t, parser.AgentOpenCode)
+	oc := createOpenCodeDB(t, env.opencodeDir)
+	oc.addProject(t, "proj", "/home/user/code/original-app")
+	seedOpenCodeSQLiteTextSession(
+		t, oc, "proj", "same-mtime-metadata",
+		1779012000000, 1779012030000,
+		"stable prompt", "stable answer",
+	)
+
+	stats := env.engine.SyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted, "first sync aborted: %+v", stats)
+	assert.Equal(t, 1, stats.Synced, "first sync writes the SQLite session")
+	sessionID := "opencode:same-mtime-metadata"
+	before := openCodeStoredSession(t, env.db, sessionID)
+	require.NotNil(t, before.FileMtime, "file_mtime before rewrite")
+	require.NotNil(t, before.FileHash, "file_hash before rewrite")
+	require.NotNil(t, before.LocalModifiedAt,
+		"local_modified_at before rewrite")
+	assert.Equal(t, "/home/user/code/original-app", before.Cwd)
+	assert.Equal(t, "original_app", before.Project)
+
+	time.Sleep(20 * time.Millisecond)
+	oc.mustExec(t, "update project worktree",
+		"UPDATE project SET worktree = ? WHERE id = ?",
+		"/home/user/code/renamed-app", "proj",
+	)
+
+	stats = env.engine.SyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted, "second sync aborted: %+v", stats)
+	assert.Equal(t, 1, stats.Synced,
+		"same-mtime SQLite metadata changes must be rewritten")
+	assertMessageContent(
+		t, env.db, sessionID, "stable prompt", "stable answer",
+	)
+	after := openCodeStoredSession(t, env.db, sessionID)
+	require.NotNil(t, after.FileMtime, "file_mtime after rewrite")
+	require.NotNil(t, after.FileHash, "file_hash after rewrite")
+	require.NotNil(t, after.LocalModifiedAt,
+		"local_modified_at after rewrite")
+	assert.Equal(t, *before.FileMtime, *after.FileMtime,
+		"metadata-only rewrite keeps the OpenCode SQLite session mtime")
+	assert.NotEqual(t, *before.FileHash, *after.FileHash,
+		"changed SQLite metadata must change the storage fingerprint")
+	assert.Greater(t, *after.LocalModifiedAt, *before.LocalModifiedAt,
+		"successful rewrite must bump local_modified_at for push windows")
+	assert.Equal(t, "/home/user/code/renamed-app", after.Cwd)
+	assert.Equal(t, "renamed_app", after.Project)
+}
+
 func TestSyncEngineOpenCodeStorageSameMtimeContentChangeUsesFingerprint(
 	t *testing.T,
 ) {

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -284,6 +284,348 @@ func assignFocusedAgentDir(
 	}
 }
 
+type openCodeFamilySQLiteCase struct {
+	name   string
+	agent  parser.AgentType
+	dbName string
+	prefix string
+}
+
+func openCodeFamilySQLiteCases() []openCodeFamilySQLiteCase {
+	return []openCodeFamilySQLiteCase{
+		{
+			name: "opencode", agent: parser.AgentOpenCode,
+			dbName: "opencode.db", prefix: "opencode:",
+		},
+		{
+			name: "kilo", agent: parser.AgentKilo,
+			dbName: "kilo.db", prefix: "kilo:",
+		},
+		{
+			name: "mimocode", agent: parser.AgentMiMoCode,
+			dbName: "mimocode.db", prefix: "mimocode:",
+		},
+		{
+			name: "icodemate", agent: parser.AgentIcodemate,
+			dbName: "icodemate.db", prefix: "icodemate:",
+		},
+	}
+}
+
+func newOpenCodeFamilySQLiteTestEngine(
+	t *testing.T,
+	agent parser.AgentType,
+	root string,
+	database *db.DB,
+) *sync.Engine {
+	t.Helper()
+	return sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			agent: {root},
+		},
+		Machine: "local",
+	})
+}
+
+func seedOpenCodeSQLiteTextSession(
+	t *testing.T,
+	oc *openCodeTestDB,
+	projectID, sessionID string,
+	timeCreated, timeUpdated int64,
+	userContent, assistantContent string,
+) {
+	t.Helper()
+	oc.addSession(t, sessionID, projectID, timeCreated, timeUpdated)
+	userMessageID := sessionID + "-msg-user"
+	assistantMessageID := sessionID + "-msg-assistant"
+	oc.addMessage(t, userMessageID, sessionID, "user", timeCreated)
+	oc.addMessage(
+		t, assistantMessageID, sessionID, "assistant", timeCreated+1,
+	)
+	oc.addTextPart(
+		t, userMessageID+"-part", sessionID, userMessageID,
+		userContent, timeCreated,
+	)
+	oc.addTextPart(
+		t, assistantMessageID+"-part", sessionID,
+		assistantMessageID, assistantContent, timeCreated+1,
+	)
+}
+
+func openCodeLocalModifiedSnapshot(
+	t *testing.T,
+	database *db.DB,
+	sessionIDs ...string,
+) map[string]string {
+	t.Helper()
+	out := make(map[string]string, len(sessionIDs))
+	for _, sessionID := range sessionIDs {
+		sess, err := database.GetSessionFull(context.Background(), sessionID)
+		require.NoError(t, err, "GetSessionFull(%q)", sessionID)
+		require.NotNil(t, sess, "session %q not found", sessionID)
+		require.NotNil(t, sess.LocalModifiedAt,
+			"local_modified_at for %q", sessionID)
+		out[sessionID] = *sess.LocalModifiedAt
+	}
+	return out
+}
+
+func openCodeStoredSession(
+	t *testing.T,
+	database *db.DB,
+	sessionID string,
+) *db.Session {
+	t.Helper()
+	sess, err := database.GetSessionFull(context.Background(), sessionID)
+	require.NoError(t, err, "GetSessionFull(%q)", sessionID)
+	require.NotNil(t, sess, "session %q not found", sessionID)
+	return sess
+}
+
+func setFileMtime(t *testing.T, path string, mtimeNS int64) {
+	t.Helper()
+	ts := time.Unix(0, mtimeNS)
+	require.NoError(t, os.Chtimes(path, ts, ts), "chtimes %s", path)
+}
+
+func TestSyncEngineOpenCodeFamilySQLiteDropsUnchangedContainerSessions(
+	t *testing.T,
+) {
+	for _, tt := range openCodeFamilySQLiteCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			database := dbtest.OpenTestDB(t)
+			engine := newOpenCodeFamilySQLiteTestEngine(
+				t, tt.agent, root, database,
+			)
+			oc := createOpenCodeLikeDB(
+				t, filepath.Join(root, tt.dbName), tt.name,
+			)
+			oc.addProject(t, "proj", "/home/user/code/opencode-app")
+			seedOpenCodeSQLiteTextSession(
+				t, oc, "proj", "stable-one",
+				1779012000000, 1779012030000,
+				"first prompt", "first answer",
+			)
+			seedOpenCodeSQLiteTextSession(
+				t, oc, "proj", "stable-two",
+				1779012100000, 1779012130000,
+				"second prompt", "second answer",
+			)
+
+			stats := engine.SyncAll(context.Background(), nil)
+			require.False(t, stats.Aborted, "first sync aborted: %+v", stats)
+			assert.Equal(t, 2, stats.Synced, "first sync writes both sessions")
+
+			sessionIDs := []string{
+				tt.prefix + "stable-one",
+				tt.prefix + "stable-two",
+			}
+			before := openCodeLocalModifiedSnapshot(
+				t, database, sessionIDs...,
+			)
+
+			time.Sleep(20 * time.Millisecond)
+			stats = engine.SyncAll(context.Background(), nil)
+			require.False(t, stats.Aborted, "second sync aborted: %+v", stats)
+			assert.Equal(t, 0, stats.Synced,
+				"unchanged %s SQLite container sessions must be dropped", tt.name)
+
+			after := openCodeLocalModifiedSnapshot(
+				t, database, sessionIDs...,
+			)
+			assert.Equal(t, before, after,
+				"unchanged %s rows must not be rewritten", tt.name)
+		})
+	}
+}
+
+func TestSyncEngineOpenCodeSQLiteDropsOnlyUnchangedContainerRows(
+	t *testing.T,
+) {
+	env := setupSingleAgentTestEnv(t, parser.AgentOpenCode)
+	oc := createOpenCodeDB(t, env.opencodeDir)
+	oc.addProject(t, "proj", "/home/user/code/opencode-app")
+	seedOpenCodeSQLiteTextSession(
+		t, oc, "proj", "changed-session",
+		1779012000000, 1779012030000,
+		"original prompt", "original answer",
+	)
+	seedOpenCodeSQLiteTextSession(
+		t, oc, "proj", "stable-session",
+		1779012100000, 1779012130000,
+		"stable prompt", "stable answer",
+	)
+
+	stats := env.engine.SyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted, "first sync aborted: %+v", stats)
+	assert.Equal(t, 2, stats.Synced, "first sync writes both sessions")
+
+	changedID := "opencode:changed-session"
+	stableID := "opencode:stable-session"
+	before := openCodeLocalModifiedSnapshot(
+		t, env.db, changedID, stableID,
+	)
+
+	time.Sleep(20 * time.Millisecond)
+	oc.updateSessionTime(t, "changed-session", 1779015630000)
+	oc.replaceTextContent(
+		t, "changed-session",
+		"changed prompt", "changed answer",
+		1779015600000,
+	)
+
+	stats = env.engine.SyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted, "second sync aborted: %+v", stats)
+	assert.Equal(t, 1, stats.Synced,
+		"only the changed OpenCode SQLite row should be rewritten")
+	assertMessageContent(
+		t, env.db, changedID, "changed prompt", "changed answer",
+	)
+
+	after := openCodeLocalModifiedSnapshot(
+		t, env.db, changedID, stableID,
+	)
+	assert.NotEqual(t, before[changedID], after[changedID],
+		"changed row must be rewritten")
+	assert.Equal(t, before[stableID], after[stableID],
+		"unchanged sibling row must not be rewritten")
+	assertMessageContent(
+		t, env.db, stableID, "stable prompt", "stable answer",
+	)
+}
+
+func TestSyncEngineOpenCodeSQLiteSameMtimeContentChangeUsesFingerprint(
+	t *testing.T,
+) {
+	env := setupSingleAgentTestEnv(t, parser.AgentOpenCode)
+	oc := createOpenCodeDB(t, env.opencodeDir)
+	oc.addProject(t, "proj", "/home/user/code/opencode-app")
+	seedOpenCodeSQLiteTextSession(
+		t, oc, "proj", "same-mtime-sqlite",
+		1779012000000, 1779012030000,
+		"original prompt", "original answer",
+	)
+
+	stats := env.engine.SyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted, "first sync aborted: %+v", stats)
+	assert.Equal(t, 1, stats.Synced, "first sync writes the SQLite session")
+	sessionID := "opencode:same-mtime-sqlite"
+	assertMessageContent(
+		t, env.db, sessionID, "original prompt", "original answer",
+	)
+	before := openCodeStoredSession(t, env.db, sessionID)
+	require.NotNil(t, before.FileMtime, "file_mtime before rewrite")
+	require.NotNil(t, before.FileHash, "file_hash before rewrite")
+	require.NotNil(t, before.LocalModifiedAt,
+		"local_modified_at before rewrite")
+
+	time.Sleep(20 * time.Millisecond)
+	oc.replaceTextContent(
+		t, "same-mtime-sqlite",
+		"changed prompt with same session mtime",
+		"changed answer with same session mtime",
+		1779012000000,
+	)
+
+	stats = env.engine.SyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted, "second sync aborted: %+v", stats)
+	assert.Equal(t, 1, stats.Synced,
+		"same-mtime SQLite fingerprint changes must be rewritten")
+	assertMessageContent(
+		t, env.db, sessionID,
+		"changed prompt with same session mtime",
+		"changed answer with same session mtime",
+	)
+	after := openCodeStoredSession(t, env.db, sessionID)
+	require.NotNil(t, after.FileMtime, "file_mtime after rewrite")
+	require.NotNil(t, after.FileHash, "file_hash after rewrite")
+	require.NotNil(t, after.LocalModifiedAt,
+		"local_modified_at after rewrite")
+	assert.Equal(t, *before.FileMtime, *after.FileMtime,
+		"same-mtime rewrite keeps the OpenCode SQLite session mtime")
+	assert.NotEqual(t, *before.FileHash, *after.FileHash,
+		"changed SQLite child content must change the storage fingerprint")
+	assert.Greater(t, *after.LocalModifiedAt, *before.LocalModifiedAt,
+		"successful rewrite must bump local_modified_at for push windows")
+}
+
+func TestSyncEngineOpenCodeStorageSameMtimeContentChangeUsesFingerprint(
+	t *testing.T,
+) {
+	env := setupSingleAgentTestEnv(t, parser.AgentOpenCode)
+	storage := createOpenCodeStorageFixture(t, env.opencodeDir)
+	sessionPath := storage.addSession(
+		t, "proj", "same-mtime-hash",
+		"/home/user/code/opencode-app", "Hash Guard",
+		1779012000000, 1779012030000,
+	)
+	storage.addMessage(
+		t, "same-mtime-hash", "msg-user", "user",
+		1779012000000, nil,
+	)
+	userPartPath := storage.addTextPart(
+		t, "same-mtime-hash", "msg-user", "part-user",
+		"original prompt", 1779012000000,
+	)
+	storage.addMessage(
+		t, "same-mtime-hash", "msg-assistant", "assistant",
+		1779012000001, nil,
+	)
+	storage.addTextPart(
+		t, "same-mtime-hash", "msg-assistant", "part-assistant",
+		"original answer", 1779012000001,
+	)
+
+	stats := env.engine.SyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted, "first sync aborted: %+v", stats)
+	assert.Equal(t, 1, stats.Synced, "first sync writes the storage session")
+	sessionID := "opencode:same-mtime-hash"
+	assertMessageContent(
+		t, env.db, sessionID, "original prompt", "original answer",
+	)
+	before := openCodeStoredSession(t, env.db, sessionID)
+	require.NotNil(t, before.FileMtime, "file_mtime before rewrite")
+	require.NotNil(t, before.FileHash, "file_hash before rewrite")
+	require.NotNil(t, before.LocalModifiedAt,
+		"local_modified_at before rewrite")
+
+	time.Sleep(20 * time.Millisecond)
+	storage.addSession(
+		t, "proj", "same-mtime-hash",
+		"/home/user/code/opencode-app",
+		"Hash Guard with same-mtime metadata padding",
+		1779012000000, 1779012030000,
+	)
+	storage.addTextPart(
+		t, "same-mtime-hash", "msg-user", "part-user",
+		"changed prompt with different fingerprint",
+		1779012000000,
+	)
+	setFileMtime(t, sessionPath, *before.FileMtime)
+	setFileMtime(t, userPartPath, *before.FileMtime)
+
+	stats = env.engine.SyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted, "second sync aborted: %+v", stats)
+	assert.Equal(t, 1, stats.Synced,
+		"same-mtime storage fingerprint changes must be rewritten")
+	assertMessageContent(
+		t, env.db, sessionID,
+		"changed prompt with different fingerprint", "original answer",
+	)
+	after := openCodeStoredSession(t, env.db, sessionID)
+	require.NotNil(t, after.FileMtime, "file_mtime after rewrite")
+	require.NotNil(t, after.FileHash, "file_hash after rewrite")
+	require.NotNil(t, after.LocalModifiedAt,
+		"local_modified_at after rewrite")
+	assert.Equal(t, *before.FileMtime, *after.FileMtime,
+		"same-mtime rewrite keeps the OpenCode storage source mtime")
+	assert.NotEqual(t, *before.FileHash, *after.FileHash,
+		"changed child content must change the storage fingerprint")
+	assert.Greater(t, *after.LocalModifiedAt, *before.LocalModifiedAt,
+		"successful rewrite must bump local_modified_at for push windows")
+}
+
 func TestSyncEngineKiroSQLiteUpdatePaths(t *testing.T) {
 	env := setupSingleAgentTestEnv(t, parser.AgentKiro)
 	ks := createKiroSQLiteDB(t, env.kiroDir)


### PR DESCRIPTION
## What changed

- Drops unchanged OpenCode-family shared-container sessions after parse using session mtime, `file_hash`, and data version.
- Stores the OpenCode storage fingerprint on SQLite-backed OpenCode sessions too, so same-mtime content changes are still re-emitted.
- Adds regressions for unchanged containers, one changed row among unchanged siblings, and same-mtime content changes.
- Hardens a few test fixtures that depended on host temp paths, PATH coreutils, or global git signing.

## Why

OpenCode-format providers fan one SQLite or storage container into virtual per-session rows. Without the post-parse unchanged drop, stable sessions were rewritten on every full sync, bumping `local_modified_at` and amplifying remote push writes.

## Notes for reviewers

- The sync behavior change is in `dropUnchangedSharedSQLiteResults`.
- The fixture-hardening commit is separate from the sync fix.
