### PR TITLE
fix(frontend): preserve calendar range picker selections

### DIFF
--- a/frontend/src/lib/components/shared/rangeSelection.test.ts
+++ b/frontend/src/lib/components/shared/rangeSelection.test.ts
@@ -94,17 +94,29 @@ describe("selectionFromWindow", () => {
     ).toEqual({ mode: "relative", days: 0 });
   });
 
+  it("reconstructs a pinned calendar week from its fixed bounds", () => {
+    expect(
+      selectionFromWindow({
+        isPinned: true,
+        windowDays: 0,
+        from: "2026-06-15",
+        to: "2026-06-21",
+        earliestSession: "2024-02-03T00:00:00Z",
+      }),
+    ).toEqual({ mode: "calendar", unit: "week", anchor: "2026-06-15" });
+  });
+
   it("shows any other pinned range as custom", () => {
     vi.setSystemTime(new Date("2026-04-25T12:00:00Z"));
     expect(
       selectionFromWindow({
         isPinned: true,
         windowDays: 0,
-        from: "2026-01-01",
+        from: "2026-01-02",
         to: "2026-01-31",
         earliestSession: "2024-02-03T00:00:00Z",
       }),
-    ).toEqual({ mode: "custom", from: "2026-01-01", to: "2026-01-31" });
+    ).toEqual({ mode: "custom", from: "2026-01-02", to: "2026-01-31" });
   });
 });
 
@@ -114,6 +126,14 @@ describe("selectionFromRange", () => {
     expect(selectionFromRange("2025-04-26", "2026-04-25")).toEqual({
       mode: "relative",
       days: 365,
+    });
+  });
+
+  it("reconstructs a calendar month from exact month bounds", () => {
+    expect(selectionFromRange("2026-02-01", "2026-02-28")).toEqual({
+      mode: "calendar",
+      unit: "month",
+      anchor: "2026-02-01",
     });
   });
 

--- a/frontend/src/lib/components/shared/rangeSelection.ts
+++ b/frontend/src/lib/components/shared/rangeSelection.ts
@@ -64,6 +64,9 @@ function parseLocal(date: string): Date {
 }
 
 function isValidLocalDate(date: string): boolean {
+  // RangeSelection uses app-internal canonical date-only strings, not
+  // localized display/input formats. Keep this strict so lexicographic range
+  // comparisons and local calendar math stay unambiguous.
   if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return false;
   const d = parseLocal(date);
   return !Number.isNaN(d.getTime()) && localDateStr(d) === date;

--- a/frontend/src/lib/components/shared/rangeSelection.ts
+++ b/frontend/src/lib/components/shared/rangeSelection.ts
@@ -63,6 +63,12 @@ function parseLocal(date: string): Date {
   return new Date(date + "T00:00:00");
 }
 
+function isValidLocalDate(date: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return false;
+  const d = parseLocal(date);
+  return !Number.isNaN(d.getTime()) && localDateStr(d) === date;
+}
+
 /**
  * The inclusive from/to bounds of a calendar period containing `anchor`.
  * Day is a single date; week is the Monday-Sunday ISO week; month is the
@@ -85,6 +91,30 @@ export function periodBounds(unit: CalendarUnit, anchor: string): DateRange {
   const first = new Date(d.getFullYear(), d.getMonth(), 1);
   const last = new Date(d.getFullYear(), d.getMonth() + 1, 0);
   return { from: localDateStr(first), to: localDateStr(last) };
+}
+
+function selectionFromCalendarRange(
+  from: string,
+  to: string,
+): CalendarSelection | null {
+  if (from > to || !isValidLocalDate(from) || !isValidLocalDate(to)) {
+    return null;
+  }
+  if (from === to) {
+    return { mode: "calendar", unit: "day", anchor: from };
+  }
+
+  const week = periodBounds("week", from);
+  if (week.from === from && week.to === to) {
+    return { mode: "calendar", unit: "week", anchor: from };
+  }
+
+  const month = periodBounds("month", from);
+  if (month.from === from && month.to === to) {
+    return { mode: "calendar", unit: "month", anchor: from };
+  }
+
+  return null;
 }
 
 /** Turn any selection into the concrete {from, to} the stores consume. */
@@ -122,6 +152,8 @@ export function selectionFromWindow(opts: {
   if (opts.from === all.from && opts.to === all.to) {
     return { mode: "relative", days: 0 };
   }
+  const calendar = selectionFromCalendarRange(opts.from, opts.to);
+  if (calendar) return calendar;
   return { mode: "custom", from: opts.from, to: opts.to };
 }
 
@@ -142,6 +174,8 @@ export function selectionFromRange(
       return { mode: "relative", days: preset.days };
     }
   }
+  const calendar = selectionFromCalendarRange(from, to);
+  if (calendar) return calendar;
   return { mode: "custom", from, to };
 }
 

--- a/frontend/src/lib/components/shared/rangeSelection.ts
+++ b/frontend/src/lib/components/shared/rangeSelection.ts
@@ -136,7 +136,8 @@ export function resolveRange(
  * Reconstruct the picker selection for stores that track a rolling-vs-pinned
  * window (analytics, usage). A non-pinned window is the rolling preset; a
  * pinned range that exactly matches the all-time bounds shows as the "All"
- * preset; anything else is a custom range.
+ * preset; exact calendar periods show as calendar selections; anything else
+ * is a custom range.
  */
 export function selectionFromWindow(opts: {
   isPinned: boolean;
@@ -160,8 +161,8 @@ export function selectionFromWindow(opts: {
 /**
  * Reconstruct a selection for stores that only persist a from/to span (trends,
  * insights). If the span exactly matches a relative preset's current bounds it
- * shows as that preset (so a default 1y range reads "Last year"); otherwise it
- * is a custom range.
+ * shows as that preset (so a default 1y range reads "Last year"). Exact
+ * calendar periods show as calendar selections; otherwise it is a custom range.
  */
 export function selectionFromRange(
   from: string,

--- a/frontend/src/lib/components/trends/TrendsPage.test.ts
+++ b/frontend/src/lib/components/trends/TrendsPage.test.ts
@@ -92,7 +92,7 @@ describe("TrendsPage", () => {
     window.history.replaceState(
       null,
       "",
-      "/trends?from=2024-01-01&to=2024-01-31",
+      "/trends?from=2024-01-02&to=2024-01-31",
     );
     component = mount(TrendsPage, { target: document.body });
     await flushPromises();


### PR DESCRIPTION
Fixes date-range picker reconstruction so pinned fixed ranges that exactly match calendar periods come back as calendar selections instead of falling through to custom. This preserves Calendar Day/Week/Month state for analytics, usage, trends, and insights after the stores persist only concrete from/to bounds.

The implementation adds one shared helper in `rangeSelection.ts` that validates local ISO date strings and recognizes exact day, ISO Monday-Sunday week, and full calendar month bounds before the custom fallback. Relative presets and all-time handling still take precedence where they already did. The remaining ambiguity is intentional: if a user-defined custom range exactly equals a canonical calendar period, the picker now shows the canonical Calendar selection because the stored `{from,to}` alone cannot preserve the original mode.

Tests cover pinned calendar-week reconstruction, exact-month reconstruction, and keep the Trends custom fixture on a noncanonical span so it continues to assert the actual custom path. Reviewers should start in `frontend/src/lib/components/shared/rangeSelection.ts`.
