### PR TITLE
feat(cli): render session search results as an aligned table

### DIFF
--- a/cmd/agentsview/session_search.go
+++ b/cmd/agentsview/session_search.go
@@ -6,11 +6,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
+	"github.com/mattn/go-runewidth"
 	"github.com/spf13/cobra"
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/service"
+	"golang.org/x/term"
 )
 
 func newSessionSearchCommand() *cobra.Command {
@@ -88,7 +91,7 @@ func newSessionSearchCommand() *cobra.Command {
 			if outputFormat(cmd) == "json" {
 				return json.NewEncoder(cmd.OutOrStdout()).Encode(res)
 			}
-			return printContentMatchesHuman(cmd.OutOrStdout(), res)
+			return printContentSearchResult(cmd.OutOrStdout(), res, contextN)
 		},
 	}
 	flags := cmd.Flags()
@@ -186,6 +189,186 @@ func resolveContentSearchMode(
 		}
 	}
 	return mode, nil
+}
+
+// printContentSearchResult renders a content search result for humans.
+// Flat results (no --context) render as an aligned table sized to the
+// terminal; --context requests keep the record-style output because
+// per-match context lines cannot live inside table rows.
+func printContentSearchResult(
+	w io.Writer, res *service.ContentSearchResult, contextN int,
+) error {
+	if contextN > 0 {
+		return printContentMatchesHuman(w, res)
+	}
+	return printContentMatchesTable(w, res, contentTerminalWidth(w))
+}
+
+// contentTerminalWidth reports the terminal width of w, or 0 when w is not
+// an interactive terminal (pipes, files, tests). Follows the flagHelpWidth
+// pattern: 0 tells the table renderer to print snippets untruncated.
+func contentTerminalWidth(w io.Writer) int {
+	f, ok := w.(*os.File)
+	if !ok {
+		return 0
+	}
+	fd := int(f.Fd())
+	if !term.IsTerminal(fd) {
+		return 0
+	}
+	width, _, err := term.GetSize(fd)
+	if err != nil || width <= 0 {
+		return 0
+	}
+	return width
+}
+
+// contentLocationMaxWidth caps the LOCATION column so a huge tool name
+// cannot starve the snippet column.
+const contentLocationMaxWidth = 48
+
+// contentProjectMaxWidth caps the PROJECT column so an oversized project
+// name cannot starve the snippet column.
+const contentProjectMaxWidth = 32
+
+// truncCell collapses whitespace and truncates s to at most max terminal
+// display cells, ellipsizing when it cut anything. A max of 0 disables
+// truncation (non-TTY output keeps full values). The display-cell
+// counterpart of truncName for the search table, where full-width runes
+// must not break column alignment.
+func truncCell(s string, max int) string {
+	s = collapseWhitespace(s)
+	if max <= 0 || runewidth.StringWidth(s) <= max {
+		return s
+	}
+	return runewidth.Truncate(s, max, "…")
+}
+
+// contentSnippetMinWidth keeps the snippet readable on narrow terminals;
+// below this the row is allowed to wrap instead of the snippet vanishing.
+const contentSnippetMinWidth = 40
+
+// contentColumnGap is the number of spaces between table columns.
+const contentColumnGap = 2
+
+// contentSnippetBudget returns the rune budget for the trailing SNIPPET
+// column: the terminal width minus the earlier columns and their gaps,
+// floored at contentSnippetMinWidth. A termWidth of 0 (unknown terminal)
+// returns 0, meaning untruncated.
+func contentSnippetBudget(termWidth int, otherWidths []int) int {
+	if termWidth <= 0 {
+		return 0
+	}
+	remaining := termWidth
+	for _, w := range otherWidths {
+		remaining -= w + contentColumnGap
+	}
+	if remaining < contentSnippetMinWidth {
+		return contentSnippetMinWidth
+	}
+	return remaining
+}
+
+// printContentMatchesTable writes one aligned row per match under a header
+// line: ID, MATCH (ordinal/range plus "sub" marker), SCORE (only when any
+// match is scored), PROJECT (capped), LOCATION (capped), and SNIPPET. The snippet
+// expands to fill the remaining terminal width when termWidth is known and
+// prints untruncated when it is 0. Every cell is terminal-sanitized.
+func printContentMatchesTable(
+	w io.Writer, res *service.ContentSearchResult, termWidth int,
+) error {
+	if len(res.Matches) == 0 {
+		fmt.Fprintln(w, "(no matches)")
+		return nil
+	}
+	hasScore := false
+	for _, m := range res.Matches {
+		if m.Score != nil {
+			hasScore = true
+			break
+		}
+	}
+	headers := []string{"ID", "MATCH"}
+	if hasScore {
+		headers = append(headers, "SCORE")
+	}
+	headers = append(headers, "PROJECT", "LOCATION", "SNIPPET")
+
+	// Column caps only apply when a real terminal width constrains the
+	// row; piped output keeps full values, like the untruncated snippet.
+	projectCap, locationCap := 0, 0
+	if termWidth > 0 {
+		projectCap = contentProjectMaxWidth
+		locationCap = contentLocationMaxWidth
+	}
+
+	rows := make([][]string, 0, len(res.Matches))
+	for _, m := range res.Matches {
+		loc := m.Location
+		if m.ToolName != "" {
+			loc += ":" + m.ToolName
+		}
+		match := formatMatchOrdinal(m)
+		if m.Subordinate {
+			match += " sub"
+		}
+		cells := []string{sanitizeTerminal(m.SessionID), match}
+		if hasScore {
+			score := emDash
+			if m.Score != nil {
+				score = fmt.Sprintf("%.2f", *m.Score)
+			}
+			cells = append(cells, score)
+		}
+		cells = append(cells,
+			truncCell(sanitizeTerminal(orEmDash(m.Project)), projectCap),
+			truncCell(sanitizeTerminal(loc), locationCap),
+			sanitizeTerminal(collapseWhitespace(m.Snippet)),
+		)
+		rows = append(rows, cells)
+	}
+
+	// Size every column but the trailing snippet from the data, then give
+	// the snippet whatever terminal width remains. All sizing, padding,
+	// and truncation use terminal display cells (runewidth), not rune
+	// counts, so full-width CJK runes and emoji stay aligned.
+	widths := make([]int, len(headers)-1)
+	for i := range widths {
+		widths[i] = runewidth.StringWidth(headers[i])
+		for _, cells := range rows {
+			if n := runewidth.StringWidth(cells[i]); n > widths[i] {
+				widths[i] = n
+			}
+		}
+	}
+	budget := contentSnippetBudget(termWidth, widths)
+	gap := strings.Repeat(" ", contentColumnGap)
+
+	printRow := func(cells []string) {
+		var b strings.Builder
+		for i, w := range widths {
+			b.WriteString(cells[i])
+			b.WriteString(strings.Repeat(" ",
+				w-runewidth.StringWidth(cells[i])))
+			b.WriteString(gap)
+		}
+		snippet := cells[len(cells)-1]
+		// Truncate only when the snippet actually overflows the budget;
+		// an exact fit prints unmodified.
+		if budget > 0 && runewidth.StringWidth(snippet) > budget {
+			snippet = runewidth.Truncate(snippet, budget, "…")
+		}
+		b.WriteString(snippet)
+		fmt.Fprintln(w, b.String())
+	}
+	printRow(headers)
+	for _, cells := range rows {
+		printRow(cells)
+	}
+	if res.NextCursor != 0 {
+		fmt.Fprintf(w, "\nMore results: --cursor %d\n", res.NextCursor)
+	}
+	return nil
 }
 
 // printContentMatchesHuman writes one line per match, terminal-sanitized.

--- a/cmd/agentsview/session_search_test.go
+++ b/cmd/agentsview/session_search_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mattn/go-runewidth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/db"
@@ -357,4 +358,306 @@ func TestPrintContentMatchesHumanRendersUnitRangeAndSubMarker(t *testing.T) {
 	assert.Contains(t, lines[2], "#5", "single-ordinal hit keeps the plain form")
 	assert.NotContains(t, lines[2], "@", "no anchor marker for single-ordinal hits")
 	assert.NotContains(t, lines[2], " sub", "no subordinate marker for top-level hits")
+}
+
+// TestPrintContentMatchesTableBasic pins the flat (no --context) human
+// rendering: a header row, one aligned row per match, the full session ID,
+// the fused location:tool column, and an untruncated snippet when no
+// terminal width is known (termWidth 0 — pipes, files, tests).
+func TestPrintContentMatchesTableBasic(t *testing.T) {
+	longSnippet := strings.Repeat("s", 300)
+	res := &service.ContentSearchResult{
+		Matches: []db.ContentMatch{
+			{
+				SessionID: "fc9367d6-38f7-4d18-863d-118dec238bd0",
+				Project:   "yas", Location: "tool_result", ToolName: "Bash",
+				Ordinal: 12, Snippet: longSnippet,
+			},
+			{
+				SessionID: "sess2", Project: "proj2", Location: "message",
+				Ordinal: 3, Snippet: "line one\nline two",
+			},
+		},
+	}
+	var buf bytes.Buffer
+	require.NoError(t, printContentMatchesTable(&buf, res, 0))
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	require.Len(t, lines, 3)
+
+	header, row1, row2 := lines[0], lines[1], lines[2]
+	for _, col := range []string{"ID", "MATCH", "PROJECT", "LOCATION", "SNIPPET"} {
+		assert.Contains(t, header, col)
+	}
+	assert.NotContains(t, header, "SCORE",
+		"SCORE column omitted when no match is scored")
+
+	assert.Contains(t, row1, "fc9367d6-38f7-4d18-863d-118dec238bd0")
+	assert.Contains(t, row1, "#12")
+	assert.Contains(t, row1, "tool_result:Bash")
+	assert.Contains(t, row1, longSnippet, "snippet untruncated at width 0")
+	assert.Contains(t, row2, "line one line two",
+		"newlines collapsed to keep one row per match")
+
+	// Columns align: each header label starts at the same rune offset as
+	// the corresponding cell in every row.
+	idIdx := strings.Index(header, "ID")
+	matchIdx := strings.Index(header, "MATCH")
+	assert.Equal(t, idIdx, strings.Index(row1, "fc9367d6"))
+	assert.Equal(t, matchIdx, strings.Index(row1, "#12"))
+	assert.Equal(t, matchIdx, strings.Index(row2, "#3"))
+}
+
+// TestPrintContentMatchesTableScoreColumn pins the conditional SCORE
+// column: present when any match carries a score, with an em dash for
+// unscored rows.
+func TestPrintContentMatchesTableScoreColumn(t *testing.T) {
+	score := 0.834
+	res := &service.ContentSearchResult{
+		Matches: []db.ContentMatch{
+			{SessionID: "s1", Project: "p", Location: "message",
+				Ordinal: 3, Snippet: "hit", Score: &score},
+			{SessionID: "s2", Project: "p", Location: "message",
+				Ordinal: 1, Snippet: "hit"},
+		},
+	}
+	var buf bytes.Buffer
+	require.NoError(t, printContentMatchesTable(&buf, res, 0))
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	require.Len(t, lines, 3)
+	assert.Contains(t, lines[0], "SCORE")
+	assert.Contains(t, lines[1], "0.83")
+	assert.Contains(t, lines[2], emDash, "unscored row shows an em dash")
+}
+
+// TestPrintContentMatchesTableRangeAndSub pins the MATCH column for
+// run-grouped hits: "#<start>-<end> @<anchor>" plus a "sub" marker for
+// subordinate units.
+func TestPrintContentMatchesTableRangeAndSub(t *testing.T) {
+	res := &service.ContentSearchResult{
+		Matches: []db.ContentMatch{
+			{
+				SessionID: "s1", Project: "p", Location: "message",
+				Ordinal: 19, OrdinalRange: [2]int{12, 40},
+				Subordinate: true, Snippet: "ranged",
+			},
+		},
+	}
+	var buf bytes.Buffer
+	require.NoError(t, printContentMatchesTable(&buf, res, 0))
+	assert.Contains(t, buf.String(), "#12-40 @19 sub")
+}
+
+// TestPrintContentMatchesTableSnippetFillsWidth pins TTY behavior: the
+// snippet expands to the remaining terminal width and is ellipsized there,
+// so no row exceeds the terminal width.
+func TestPrintContentMatchesTableSnippetFillsWidth(t *testing.T) {
+	res := &service.ContentSearchResult{
+		Matches: []db.ContentMatch{
+			{SessionID: "s1", Project: "p", Location: "message",
+				Ordinal: 1, Snippet: strings.Repeat("x", 500)},
+		},
+	}
+	const width = 100
+	var buf bytes.Buffer
+	require.NoError(t, printContentMatchesTable(&buf, res, width))
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	require.Len(t, lines, 2)
+	row := lines[1]
+	assert.LessOrEqual(t, len([]rune(row)), width)
+	assert.True(t, strings.HasSuffix(row, "…"), "truncated snippet gains an ellipsis")
+}
+
+// TestPrintContentMatchesTableLocationCap pins the LOCATION cap: on a
+// TTY a huge tool name cannot starve the snippet column, while non-TTY
+// output (termWidth 0) keeps the full value, matching the untruncated
+// snippet policy for pipes.
+func TestPrintContentMatchesTableLocationCap(t *testing.T) {
+	res := &service.ContentSearchResult{
+		Matches: []db.ContentMatch{
+			{SessionID: "s1", Project: "p", Location: "tool_result",
+				ToolName: strings.Repeat("t", 200), Ordinal: 1, Snippet: "hit"},
+		},
+	}
+	loc := "tool_result:" + strings.Repeat("t", 200)
+
+	var buf bytes.Buffer
+	require.NoError(t, printContentMatchesTable(&buf, res, 200))
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	require.Len(t, lines, 2)
+	assert.NotContains(t, lines[1], loc, "location is capped on a TTY")
+	assert.Contains(t, lines[1], "…")
+	assert.Contains(t, lines[1], "hit", "snippet survives a huge tool name")
+
+	buf.Reset()
+	require.NoError(t, printContentMatchesTable(&buf, res, 0))
+	lines = strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	require.Len(t, lines, 2)
+	assert.Contains(t, lines[1], loc, "piped output keeps the full location")
+}
+
+// TestPrintContentMatchesTableEmptyAndCursor pins the unchanged empty
+// message and pagination footer around the table.
+func TestPrintContentMatchesTableEmptyAndCursor(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, printContentMatchesTable(
+		&buf, &service.ContentSearchResult{}, 0))
+	assert.Equal(t, "(no matches)\n", buf.String())
+
+	buf.Reset()
+	res := &service.ContentSearchResult{
+		Matches: []db.ContentMatch{
+			{SessionID: "s1", Project: "p", Location: "message",
+				Ordinal: 1, Snippet: "hit"},
+		},
+		NextCursor: 7,
+	}
+	require.NoError(t, printContentMatchesTable(&buf, res, 0))
+	assert.Contains(t, buf.String(), "More results: --cursor 7")
+}
+
+// TestContentSnippetBudget pins the snippet width computation: 0 means
+// unknown terminal (untruncated), otherwise the remaining width after the
+// fixed columns with a readability floor on narrow terminals.
+func TestContentSnippetBudget(t *testing.T) {
+	tests := []struct {
+		name        string
+		termWidth   int
+		otherWidths []int
+		want        int
+	}{
+		{"unknown terminal", 0, []int{10, 5}, 0},
+		{"wide terminal", 200, []int{36, 5, 4, 10}, 200 - (36 + 2) - (5 + 2) - (4 + 2) - (10 + 2)},
+		{"narrow terminal floors", 60, []int{36, 5, 4, 10}, contentSnippetMinWidth},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, contentSnippetBudget(tt.termWidth, tt.otherWidths))
+		})
+	}
+}
+
+// TestPrintContentSearchResultPicksRenderer pins the dispatch: --context
+// requests keep the record-style output (context lines cannot live in
+// table rows), while flat results render as a table.
+func TestPrintContentSearchResultPicksRenderer(t *testing.T) {
+	res := &service.ContentSearchResult{
+		Matches: []db.ContentMatch{
+			{
+				SessionID: "s1", Project: "p", Location: "message",
+				Ordinal: 5, Snippet: "the match",
+				ContextBefore: []db.Message{{Role: "user", Content: "before"}},
+			},
+		},
+	}
+	var buf bytes.Buffer
+	require.NoError(t, printContentSearchResult(&buf, res, 1))
+	assert.Contains(t, buf.String(), "  user: before",
+		"context mode keeps record-style output")
+	assert.NotContains(t, buf.String(), "SNIPPET")
+
+	buf.Reset()
+	require.NoError(t, printContentSearchResult(&buf, res, 0))
+	assert.Contains(t, buf.String(), "SNIPPET", "flat mode renders the table")
+}
+
+// TestPrintContentMatchesTableSnippetExactFit pins the truncation boundary:
+// a snippet that exactly fits the remaining width prints unmodified, with
+// no rune dropped and no ellipsis.
+func TestPrintContentMatchesTableSnippetExactFit(t *testing.T) {
+	const width = 100
+	// Fixed columns for this row: ID "s1" (header "ID" wins, 2) + MATCH
+	// "#1"/"MATCH" (5) + PROJECT "p"/"PROJECT" (7) + LOCATION
+	// "message"/"LOCATION" (8), each followed by a 2-space gap = 30 used,
+	// leaving a 70-rune snippet budget.
+	snippet := strings.Repeat("x", 70)
+	res := &service.ContentSearchResult{
+		Matches: []db.ContentMatch{
+			{SessionID: "s1", Project: "p", Location: "message",
+				Ordinal: 1, Snippet: snippet},
+		},
+	}
+	var buf bytes.Buffer
+	require.NoError(t, printContentMatchesTable(&buf, res, width))
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	require.Len(t, lines, 2)
+	assert.True(t, strings.HasSuffix(lines[1], snippet),
+		"exact-fit snippet prints unmodified")
+	assert.Equal(t, width, len([]rune(lines[1])))
+}
+
+// TestPrintContentMatchesTableProjectCap pins the PROJECT cap: on a TTY
+// an oversized or multi-line project name is collapsed and truncated so
+// it cannot starve the snippet column, while non-TTY output keeps the
+// full (whitespace-collapsed) value.
+func TestPrintContentMatchesTableProjectCap(t *testing.T) {
+	res := &service.ContentSearchResult{
+		Matches: []db.ContentMatch{
+			{SessionID: "s1", Project: strings.Repeat("p", 200) + "\nq",
+				Location: "message", Ordinal: 1, Snippet: "hit"},
+		},
+	}
+	var buf bytes.Buffer
+	require.NoError(t, printContentMatchesTable(&buf, res, 200))
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	require.Len(t, lines, 2)
+	assert.NotContains(t, lines[1], strings.Repeat("p", 200), "project is capped")
+	assert.NotContains(t, lines[1], "\nq", "project whitespace collapsed")
+	assert.Contains(t, lines[1], "…")
+	assert.Contains(t, lines[1], "hit", "snippet survives a huge project name")
+	assert.LessOrEqual(t,
+		strings.Index(lines[1], "hit"), 100,
+		"fixed columns stay bounded ahead of the snippet")
+
+	buf.Reset()
+	require.NoError(t, printContentMatchesTable(&buf, res, 0))
+	lines = strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	require.Len(t, lines, 2)
+	assert.Contains(t, lines[1], strings.Repeat("p", 200)+" q",
+		"piped output keeps the full collapsed project")
+}
+
+// TestPrintContentMatchesTableWideRunesAlign pins display-width alignment:
+// a project of full-width CJK runes occupies more terminal cells than its
+// rune count, and the following column must still start at the same
+// display column in every row.
+func TestPrintContentMatchesTableWideRunesAlign(t *testing.T) {
+	res := &service.ContentSearchResult{
+		Matches: []db.ContentMatch{
+			{SessionID: "s1", Project: "日本語", Location: "message",
+				Ordinal: 1, Snippet: "hit"},
+			{SessionID: "s2", Project: "ascii", Location: "message",
+				Ordinal: 2, Snippet: "hit"},
+		},
+	}
+	var buf bytes.Buffer
+	require.NoError(t, printContentMatchesTable(&buf, res, 0))
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	require.Len(t, lines, 3)
+	col := func(line string) int {
+		i := strings.Index(line, "message")
+		require.GreaterOrEqual(t, i, 0)
+		return runewidth.StringWidth(line[:i])
+	}
+	assert.Equal(t, col(lines[1]), col(lines[2]),
+		"LOCATION starts at the same display column despite wide runes")
+}
+
+// TestPrintContentMatchesTableWideSnippetBudget pins display-width
+// truncation: a snippet of full-width runes must be cut so the whole row
+// fits the terminal in display cells, not rune count.
+func TestPrintContentMatchesTableWideSnippetBudget(t *testing.T) {
+	res := &service.ContentSearchResult{
+		Matches: []db.ContentMatch{
+			{SessionID: "s1", Project: "p", Location: "message",
+				Ordinal: 1, Snippet: strings.Repeat("界", 200)},
+		},
+	}
+	const width = 100
+	var buf bytes.Buffer
+	require.NoError(t, printContentMatchesTable(&buf, res, width))
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	require.Len(t, lines, 2)
+	assert.LessOrEqual(t, runewidth.StringWidth(lines[1]), width,
+		"row fits the terminal in display cells")
+	assert.True(t, strings.HasSuffix(lines[1], "…"))
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/klauspost/compress v1.19.0
+	github.com/mattn/go-runewidth v0.0.23
 	github.com/mattn/go-sqlite3 v1.14.47
 	github.com/minio/minio-go/v7 v7.2.1
 	github.com/modelcontextprotocol/go-sdk v1.6.1
@@ -42,6 +43,7 @@ require (
 	github.com/asg017/sqlite-vec-go-bindings v0.1.6 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK3
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=
+github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=
@@ -136,6 +138,8 @@ github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8S
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mattn/go-isatty v0.0.21 h1:xYae+lCNBP7QuW4PUnNG61ffM4hVIfm+zUzDuSzYLGs=
 github.com/mattn/go-isatty v0.0.21/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
+github.com/mattn/go-runewidth v0.0.23 h1:7ykA0T0jkPpzSvMS5i9uoNn2Xy3R383f9HDx3RybWcw=
+github.com/mattn/go-runewidth v0.0.23/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/mattn/go-sqlite3 v1.14.47 h1:jOBI62gS7nKeZv+as1oGEy0+1qISgXwH/QBlR6KbfIo=
 github.com/mattn/go-sqlite3 v1.14.47/go.mod h1:6JTjA44L93a0QCyJef5YvlPoKXntQPjzWv5gtm9sB6w=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=


### PR DESCRIPTION
`session search` human output printed two lines per match (a metadata line plus an indented snippet), which was hard to scan. Flat results now render as one aligned row per match — ID, MATCH, SCORE (only for semantic/hybrid), PROJECT, LOCATION, SNIPPET — in the same hand-rolled style as the `session list` table, with no new rendering dependency.

**Before:**

<img width="4660" height="936" alt="before" src="https://github.com/user-attachments/assets/67b74c18-8075-4d3f-baf9-40eab0ab6af8" />


**After:**

<img width="4860" height="736" alt="after" src="https://github.com/user-attachments/assets/243ff748-c9b6-4230-a557-607f35d1c06e" />


On a TTY the snippet column expands to fill the remaining terminal width (floored at 40 cells on narrow terminals); PROJECT and LOCATION are capped so oversized values cannot starve it. Piped/non-TTY output prints all values untruncated so grep workflows keep working, and `--json` is unchanged. `--context` requests keep the record-style output, since context lines cannot live inside table rows.

Sizing, padding, and truncation are done in terminal display cells via `go-runewidth` (promoted from an existing indirect dependency), so full-width CJK and emoji content stays aligned.

Limitations: the row identifies the match, not the session — surfacing session names alongside matches is left for a follow-up. Reviewers should look at `cmd/agentsview/session_search.go`: the new `printContentMatchesTable` and its dispatch; the record-style printer is untouched apart from being demoted to the `--context` path.
