### PR TITLE
fix(parser): parse Codex custom tool calls

### DIFF
--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -268,10 +268,10 @@ func (b *codexSessionBuilder) handleResponseItem(
 	payload gjson.Result, ts time.Time,
 ) {
 	switch payload.Get("type").Str {
-	case "function_call":
+	case "function_call", "custom_tool_call":
 		b.handleFunctionCall(payload, ts)
 		return
-	case "function_call_output":
+	case "function_call_output", "custom_tool_call_output":
 		b.handleFunctionCallOutput(payload, ts)
 		return
 	}
@@ -533,9 +533,19 @@ func (b *codexSessionBuilder) handleFunctionCallOutput(
 		})
 	default:
 		if text := strings.TrimSpace(raw); text != "" {
+			source := "function_call_output"
+			status := ""
+			if payload.Get("type").Str == "custom_tool_call_output" {
+				source = "custom_tool_call_output"
+				status = payload.Get("status").Str
+				if status == "" {
+					status = "completed"
+				}
+			}
 			b.appendCallResultEvent(callID, ParsedToolResultEvent{
 				ToolUseID: callID,
-				Source:    "function_call_output",
+				Source:    source,
+				Status:    status,
 				Content:   text,
 				Timestamp: ts,
 			})
@@ -1806,9 +1816,9 @@ func codexIncrementalNeedsFullParse(line string) bool {
 
 	payload := gjson.Get(line, "payload")
 	switch payload.Get("type").Str {
-	case "function_call":
+	case "function_call", "custom_tool_call":
 		return isCodexWaitAgentCall(payload.Get("name").Str)
-	case "function_call_output":
+	case "function_call_output", "custom_tool_call_output":
 		output, raw := parseCodexFunctionOutput(payload)
 		return isCodexSubagentFunctionOutput(output) ||
 			strings.TrimSpace(raw) != ""

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -344,6 +344,58 @@ func TestParseCodexSession_FunctionCalls(t *testing.T) {
 		assert.Contains(t, msgs[1].ToolCalls[0].InputJSON, "Begin Patch")
 	})
 
+	t.Run("custom_tool_call apply_patch input and output", func(t *testing.T) {
+		call := `{"timestamp":"2026-07-08T03:20:43.339Z","type":"response_item","payload":{"type":"custom_tool_call","status":"completed","call_id":"call_abc","name":"apply_patch","input":"*** Begin Patch\n*** Add File: infra/scripts/with-resolved-images.sh\n+#!/bin/sh\n*** End Patch"}}`
+		patchEnd := `{"timestamp":"2026-07-08T03:20:43.356Z","type":"event_msg","payload":{"type":"patch_apply_end","call_id":"call_abc","stdout":"Success. Updated the following files:\nA infra/scripts/with-resolved-images.sh\n","stderr":"","success":true}}`
+		output := `{"timestamp":"2026-07-08T03:20:43.376Z","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"call_abc","output":"Exit code: 0\nWall time: 0 seconds\nOutput:\nSuccess. Updated the following files:\nA infra/scripts/with-resolved-images.sh\n"}}`
+		content := testjsonl.JoinJSONL(
+			testjsonl.CodexSessionMetaJSON("fc-custom-tool", "/tmp", "user", tsEarly),
+			testjsonl.CodexMsgJSON("user", "apply the patch", tsEarlyS1),
+			call,
+			patchEnd,
+			output,
+		)
+
+		_, msgs := runCodexParserTest(t, "test.jsonl", content, false)
+
+		require.Len(t, msgs, 2)
+		assert.Equal(t, RoleAssistant, msgs[1].Role)
+		assert.True(t, msgs[1].HasToolUse)
+		assertToolCalls(t, msgs[1].ToolCalls, []ParsedToolCall{{
+			ToolUseID: "call_abc",
+			ToolName:  "apply_patch",
+			Category:  "Edit",
+		}})
+		tc := msgs[1].ToolCalls[0]
+		assert.Contains(t, tc.InputJSON, "Begin Patch")
+		assertToolResultEvents(t, tc.ResultEvents, []ParsedToolResultEvent{{
+			ToolUseID: "call_abc",
+			Source:    "custom_tool_call_output",
+			Status:    "completed",
+			Content:   "Exit code: 0\nWall time: 0 seconds\nOutput:\nSuccess. Updated the following files:\nA infra/scripts/with-resolved-images.sh",
+		}})
+	})
+
+	t.Run("unsupported response_item subtype is ignored", func(t *testing.T) {
+		unsupported := `{"timestamp":"2026-07-08T03:20:43.339Z","type":"response_item","payload":{"type":"custom_tool_callish","call_id":"call_abc","name":"apply_patch","input":"*** Begin Patch\n*** End Patch"}}`
+		content := testjsonl.JoinJSONL(
+			testjsonl.CodexSessionMetaJSON("fc-unsupported-response-item", "/tmp", "user", tsEarly),
+			testjsonl.CodexMsgJSON("user", "apply the patch", tsEarlyS1),
+			unsupported,
+		)
+
+		_, msgs := runCodexParserTest(t, "test.jsonl", content, false)
+
+		require.Len(t, msgs, 1)
+		assert.False(t, msgs[0].HasToolUse)
+	})
+
+	t.Run("custom_tool_call_output requests full parse", func(t *testing.T) {
+		line := `{"timestamp":"2026-07-08T03:20:43.376Z","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"call_abc","output":"Exit code: 0\nWall time: 0 seconds\nOutput:\nSuccess."}}`
+
+		assert.True(t, codexIncrementalNeedsFullParse(line))
+	})
+
 	t.Run("write_stdin formats with session and chars", func(t *testing.T) {
 		content := loadFixture(t, "codex/fc_stdin.jsonl")
 		_, msgs := runCodexParserTest(t, "test.jsonl", content, false)


### PR DESCRIPTION
Codex exec transcripts can store edits as `custom_tool_call` response items, so AgentsView was missing `apply_patch` calls even though the raw JSONL showed file changes. The parser dropped those records before they became structured tool calls, which made the timeline, tool summary, API messages, and markdown export under-report what happened in the session.

This routes Codex custom call records through the existing function-call parser instead of adding a second tool-call implementation. The existing input helpers already understand `payload.input`, so the patch body can populate the same `InputJSON`, summary, category, and call-id fields as regular function calls. Matching `custom_tool_call_output` records are linked back to the parsed call as result events for this custom-output path, while the existing spawn and wait special cases for ordinary function-call output stay on their current behavior.

The regression uses the JSONL shape from the issue and checks that `apply_patch` appears as an Edit tool call with the raw patch text and linked output. Review should focus on the Codex response-item dispatch, the narrow custom-output attachment path, and the incremental full-parse trigger for custom output.

Fixes #1023
