### PR TITLE
fix(release): provide sqlite3.h for sqlite-vec cgo builds on Linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,16 @@ jobs:
           COMMIT=${GITHUB_SHA::8}
           BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
+          # sqlite-vec's cgo bindings #include "sqlite3.h". The manylinux
+          # image has no SQLite headers, and AlmaLinux 8's sqlite-devel
+          # (3.26) is old enough that sqlite-vec would silently compile out
+          # its vtab_in support. Use the header of the exact amalgamation
+          # bundled and statically linked by mattn/go-sqlite3.
+          go mod download github.com/mattn/go-sqlite3
+          mkdir -p .sqlite-include
+          cp "$(go list -m -f '{{.Dir}}' github.com/mattn/go-sqlite3)/sqlite3-binding.h" .sqlite-include/sqlite3.h
+          export CGO_CFLAGS="-I${PWD}/.sqlite-include"
+
           mkdir -p dist
           LDFLAGS="-s -w -X main.version=v${VERSION} -X main.commit=${COMMIT} -X main.buildDate=${BUILD_DATE}"
           go build -tags fts5 -buildvcs=false -ldflags="$LDFLAGS" -trimpath \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,14 @@ WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 
+# sqlite-vec's cgo bindings (pulled in via go.kenn.io/kit/vector/sqlitevec)
+# #include "sqlite3.h", which this image does not ship. Compile them against
+# the header of the exact SQLite amalgamation that mattn/go-sqlite3 bundles
+# and statically links, so header and linked library always match.
+RUN mkdir -p /sqlite-include \
+    && cp "$(go list -m -f '{{.Dir}}' github.com/mattn/go-sqlite3)/sqlite3-binding.h" /sqlite-include/sqlite3.h
+ENV CGO_CFLAGS="-I/sqlite-include"
+
 COPY . ./
 COPY --from=frontend-build /src/frontend/dist ./internal/web/dist
 


### PR DESCRIPTION
The v0.37.0 Release and Docker workflows failed on both Linux build paths: the semantic search merge (#999) pulled in `github.com/asg017/sqlite-vec-go-bindings/cgo` (via `go.kenn.io/kit/vector/sqlitevec`), whose C sources `#include "sqlite3.h"`. GitHub's hosted ubuntu/macos/windows images provide SQLite headers, but the manylinux_2_28 release containers and the `golang:bookworm` Docker build stage do not, so `go build` died with `fatal error: sqlite3.h: No such file or directory`. That blocked the CLI release assets and the PyPI publish.

Instead of installing distro headers, both Linux build paths now compile sqlite-vec against the header of the exact SQLite amalgamation bundled and statically linked by mattn/go-sqlite3 (`sqlite3-binding.h`, currently 3.53.2), exposed via `CGO_CFLAGS`. This keeps the compile-time header and the linked library at the same version everywhere. It also avoids a silent behavior difference: manylinux_2_28 (AlmaLinux 8) ships SQLite 3.26 headers, and sqlite-vec compiles out its `sqlite3_vtab_in` support when built against headers older than 3.38, which would have made PyPI wheels behave differently from every other build.

Reviewers should look at the new header-staging step in `.github/workflows/release.yml` (build-linux) and the equivalent `RUN`/`ENV` pair in `Dockerfile`. macOS and Windows builds are unchanged; they already build against SDK/toolchain headers newer than 3.38.