### PR TITLE
fix(docs): scrub screenshot fixtures and sidebar trees

### DIFF
--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -9,10 +9,13 @@ Generates screenshots for the docs site using Playwright inside Docker.
 - A sessions database at `~/.agentsview/sessions.db` (override with `SOURCE_DB`)
 - The screenshot extractor keeps approved public projects from the newest 60-day
   session window (override with `SCREENSHOT_HISTORY_DAYS`)
-- Optional local-only screenshot scrub terms via a line-separated
-  `~/.config/agentsview-docs/screenshot-blocked-terms.txt`, override the path
-  with `SCREENSHOT_BLOCKED_TERMS_FILE`, or append terms with
-  `SCREENSHOT_BLOCKED_TERMS`
+- Optional local-only screenshot scrub terms via line-separated files. The
+  extractor redacts the current `HOME` path to `~`. By default it also reads
+  both `~/.config/agentsview-docs/screenshot-blocked-terms.txt` and the
+  canonical private terms file at `~/.config/kenn/private-terms.txt` (or
+  `KENN_PRIVATE_TERMS_FILE`). Override the screenshot-specific path with
+  `SCREENSHOT_BLOCKED_TERMS_FILE`, or append terms with
+  `SCREENSHOT_BLOCKED_TERMS`.
 
 ## Run all screenshots
 
@@ -37,17 +40,17 @@ Any extra arguments are forwarded to `npx playwright test` inside the container.
 1. Assembles a Docker build context with the agentsview source, sessions
    database, and test files
 1. Builds a multi-stage Docker image:
-   - **Stage 1 (builder):** Compiles the agentsview Go binary with frontend
-     assets
-   - **Stage 2 (db):** Extracts a reduced database with screenshot-safe projects
-   - **Stage 3 (playwright):** Installs Playwright + Chromium + PostgreSQL,
-     copies binary and DB
+    - **Stage 1 (builder):** Compiles the agentsview Go binary with frontend
+      assets
+    - **Stage 2 (db):** Extracts a reduced database with screenshot-safe projects
+    - **Stage 3 (playwright):** Installs Playwright + Chromium + PostgreSQL,
+      copies binary and DB
 1. Runs the container, which:
-   - Starts PostgreSQL and pushes test data from two simulated machines
-   - Starts agentsview on port 8090 (SQLite mode, for most screenshots)
-   - Starts agentsview pg serve on port 8091 (PG mode, for machine label
-     screenshots)
-   - Executes the Playwright tests against both servers
+    - Starts PostgreSQL and pushes test data from two simulated machines
+    - Starts agentsview on port 8090 (SQLite mode, for most screenshots)
+    - Starts agentsview pg serve on port 8091 (PG mode, for machine label
+      screenshots)
+    - Executes the Playwright tests against both servers
 1. Screenshots are written to the mounted `/output` volume
    (`docs/assets/generated/screenshots/`)
 

--- a/docs/screenshots/extract-db.sh
+++ b/docs/screenshots/extract-db.sh
@@ -8,19 +8,38 @@ set -euo pipefail
 SOURCE="${1:-${SOURCE:-/data/source.db}}"
 OUTPUT="${2:-${OUTPUT:-/data/test-sessions.db}}"
 HISTORY_DAYS="${SCREENSHOT_HISTORY_DAYS:-60}"
-BLOCKED_TERMS_FILE="${SCREENSHOT_BLOCKED_TERMS_FILE:-$HOME/.config/agentsview-docs/screenshot-blocked-terms.txt}"
+DEFAULT_BLOCKED_TERMS_FILE="$HOME/.config/agentsview-docs/screenshot-blocked-terms.txt"
+BLOCKED_TERMS_FILE="${SCREENSHOT_BLOCKED_TERMS_FILE:-$DEFAULT_BLOCKED_TERMS_FILE}"
+PRIVATE_TERMS_FILE="${KENN_PRIVATE_TERMS_FILE:-$HOME/.config/kenn/private-terms.txt}"
+HOME_PATH="${HOME:-}"
 BLOCKED_TERMS="${SCREENSHOT_BLOCKED_TERMS:-}"
-BLOCKED_PATTERNS_SQL="$(mktemp "${TMPDIR:-/tmp}/agentsview-screenshot-blocked-patterns.XXXXXX.sql")"
+BLOCKED_PATTERNS_SQL="$(mktemp "${TMPDIR:-/tmp}/agentsview-screenshot-blocked-patterns.XXXXXX")"
 trap 'rm -f "$BLOCKED_PATTERNS_SQL"' EXIT
 
-if [ -f "$BLOCKED_TERMS_FILE" ]; then
-  FILE_BLOCKED_TERMS="$(<"$BLOCKED_TERMS_FILE")"
-  if [ -n "$BLOCKED_TERMS" ] && [ -n "$FILE_BLOCKED_TERMS" ]; then
-    BLOCKED_TERMS="$BLOCKED_TERMS"$'\n'"$FILE_BLOCKED_TERMS"
-  else
-    BLOCKED_TERMS="$BLOCKED_TERMS$FILE_BLOCKED_TERMS"
+append_blocked_terms() {
+  local terms="$1"
+  if [ -z "$terms" ]; then
+    return
   fi
-fi
+
+  if [ -n "$BLOCKED_TERMS" ]; then
+    BLOCKED_TERMS="$BLOCKED_TERMS"$'\n'"$terms"
+  else
+    BLOCKED_TERMS="$terms"
+  fi
+}
+
+append_blocked_terms_file() {
+  local terms_file="$1"
+  if [ ! -f "$terms_file" ]; then
+    return
+  fi
+
+  append_blocked_terms "$(<"$terms_file")"
+}
+
+append_blocked_terms_file "$BLOCKED_TERMS_FILE"
+append_blocked_terms_file "$PRIVATE_TERMS_FILE"
 
 if [[ ! "$HISTORY_DAYS" =~ ^[0-9]+$ ]] || [ "$HISTORY_DAYS" -lt 1 ]; then
   echo "Error: SCREENSHOT_HISTORY_DAYS must be a positive integer"
@@ -49,6 +68,13 @@ mkdir -p "$(dirname "$OUTPUT")"
 rm -f "$OUTPUT"
 
 {
+  echo "CREATE TEMP TABLE screenshot_redactions(from_text TEXT PRIMARY KEY, to_text TEXT NOT NULL);"
+  if [ -n "$HOME_PATH" ] && [ "$HOME_PATH" != "/" ]; then
+    home_sql="${HOME_PATH//\'/\'\'}"
+    printf "INSERT OR IGNORE INTO screenshot_redactions(from_text, to_text) VALUES ('%s', '~');\n" \
+      "$home_sql"
+  fi
+
   echo "CREATE TEMP TABLE screenshot_blocked_patterns(pattern TEXT PRIMARY KEY);"
   while IFS= read -r term || [ -n "$term" ]; do
     trimmed="$(printf '%s' "$term" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
@@ -101,27 +127,20 @@ INSERT INTO screenshot_projects(name) VALUES
   ('roborev'),
   ('roborev_docs');
 
+CREATE TEMP TABLE screenshot_safe_sessions(id TEXT PRIMARY KEY);
+CREATE TEMP TABLE screenshot_root_sessions(id TEXT PRIMARY KEY);
 CREATE TEMP TABLE screenshot_sessions(id TEXT PRIMARY KEY);
 CREATE TEMP TABLE screenshot_bounds(
   cutoff_session_at TEXT,
   newest_session_at TEXT
 );
-INSERT INTO screenshot_bounds(cutoff_session_at, newest_session_at)
-SELECT
-  datetime(max(session_at), printf('-%d days', @history_days)),
-  max(session_at)
-FROM (
-  SELECT datetime(COALESCE(NULLIF(s.started_at, ''), s.created_at)) AS session_at
-  FROM sessions s
-  WHERE s.project IN (SELECT name FROM screenshot_projects)
-);
 
-INSERT INTO screenshot_sessions(id)
+INSERT INTO screenshot_safe_sessions(id)
 SELECT id
 FROM sessions s
-CROSS JOIN screenshot_bounds b
 WHERE s.project IN (SELECT name FROM screenshot_projects)
-  AND datetime(COALESCE(NULLIF(s.started_at, ''), s.created_at)) >= b.cutoff_session_at
+  AND s.message_count > 0
+  AND s.deleted_at IS NULL
   AND NOT EXISTS (
     SELECT 1
     FROM screenshot_blocked_patterns p
@@ -164,6 +183,63 @@ WHERE s.project IN (SELECT name FROM screenshot_projects)
     WHERE tre.session_id = s.id
   );
 
+INSERT INTO screenshot_bounds(cutoff_session_at, newest_session_at)
+SELECT
+  datetime(max(session_at), printf('-%d days', @history_days)),
+  max(session_at)
+FROM (
+  SELECT datetime(COALESCE(NULLIF(s.started_at, ''), s.created_at)) AS session_at
+  FROM sessions s
+  JOIN screenshot_safe_sessions safe ON safe.id = s.id
+  WHERE COALESCE(s.parent_session_id, '') = ''
+    AND s.relationship_type NOT IN ('subagent', 'fork', 'continuation')
+);
+
+INSERT INTO screenshot_root_sessions(id)
+SELECT s.id
+FROM sessions s
+JOIN screenshot_safe_sessions safe ON safe.id = s.id
+CROSS JOIN screenshot_bounds b
+WHERE COALESCE(s.parent_session_id, '') = ''
+  AND s.relationship_type NOT IN ('subagent', 'fork', 'continuation')
+  AND datetime(COALESCE(NULLIF(s.started_at, ''), s.created_at)) >= b.cutoff_session_at;
+
+WITH RECURSIVE screenshot_tree(id) AS (
+  SELECT id FROM screenshot_root_sessions
+  UNION
+  SELECT child.id
+  FROM sessions child
+  JOIN screenshot_tree parent ON child.parent_session_id = parent.id
+  JOIN screenshot_safe_sessions safe ON safe.id = child.id
+)
+INSERT INTO screenshot_sessions(id)
+SELECT id FROM screenshot_tree;
+
+-- Thinking-block screenshots navigate directly to one rich session because
+-- thinking messages are rare and often older than the recent sidebar window.
+-- Prefer a human root for this direct navigation fixture, while keeping
+-- automated sessions available for usage/activity categorization screenshots.
+INSERT OR IGNORE INTO screenshot_sessions(id)
+SELECT s.id
+FROM sessions s
+JOIN screenshot_safe_sessions safe ON safe.id = s.id
+WHERE COALESCE(s.parent_session_id, '') = ''
+  AND s.relationship_type NOT IN ('subagent', 'fork', 'continuation')
+  AND COALESCE(s.is_automated, 0) = 0
+  AND EXISTS (
+    SELECT 1
+    FROM messages m
+    WHERE m.session_id = s.id
+      AND COALESCE(m.thinking_text, '') != ''
+  )
+ORDER BY (
+  SELECT COUNT(*)
+  FROM messages m
+  WHERE m.session_id = s.id
+    AND COALESCE(m.thinking_text, '') != ''
+) DESC, s.id
+LIMIT 1;
+
 -- Drop FTS5 sync triggers before the bulk delete. Each
 -- DELETE FROM messages otherwise fires messages_ad which
 -- runs an FTS5 'delete' command, and that trips
@@ -204,6 +280,29 @@ DELETE FROM messages WHERE session_id IN (
 );
 DELETE FROM sessions
 WHERE id NOT IN (SELECT id FROM screenshot_sessions);
+
+UPDATE sessions
+SET first_message = replace(first_message, r.from_text, r.to_text),
+    display_name = replace(display_name, r.from_text, r.to_text),
+    session_name = replace(session_name, r.from_text, r.to_text),
+    cwd = replace(cwd, r.from_text, r.to_text),
+    file_path = replace(file_path, r.from_text, r.to_text)
+FROM screenshot_redactions r;
+
+UPDATE messages
+SET content = replace(content, r.from_text, r.to_text),
+    thinking_text = replace(thinking_text, r.from_text, r.to_text)
+FROM screenshot_redactions r;
+
+UPDATE tool_calls
+SET file_path = replace(file_path, r.from_text, r.to_text),
+    input_json = replace(input_json, r.from_text, r.to_text),
+    result_content = replace(result_content, r.from_text, r.to_text)
+FROM screenshot_redactions r;
+
+UPDATE tool_result_events
+SET content = replace(content, r.from_text, r.to_text)
+FROM screenshot_redactions r;
 
 -- Rebuild FTS index from the surviving messages.
 INSERT INTO messages_fts(messages_fts) VALUES('rebuild');

--- a/internal/db/filter_test.go
+++ b/internal/db/filter_test.go
@@ -1214,6 +1214,47 @@ func TestSidebarSessionIndexIncludesChildrenForMatchingRoot(t *testing.T) {
 	requireSidebarIndexIDs(t, index.Sessions, []string{"root", "sub", "fork"})
 }
 
+func TestSidebarSessionIndexPagedExcludesAutomatedDescendants(t *testing.T) {
+	d := testDB(t)
+
+	rootID := "root"
+	insertSession(t, d, rootID, "proj", func(s *Session) {
+		s.EndedAt = new("2024-01-03T00:00:00Z")
+		s.MessageCount = 10
+		s.UserMessageCount = 5
+	})
+	insertSession(t, d, "human-child", "proj", func(s *Session) {
+		s.EndedAt = new("2024-01-02T00:00:00Z")
+		s.MessageCount = 2
+		s.UserMessageCount = 1
+		s.ParentSessionID = &rootID
+		s.RelationshipType = "subagent"
+	})
+	insertSession(t, d, "automated-child", "proj", func(s *Session) {
+		fm := "You are a code reviewer. Review the code."
+		s.FirstMessage = &fm
+		s.EndedAt = new("2024-01-01T00:00:00Z")
+		s.MessageCount = 3
+		s.UserMessageCount = 1
+		s.ParentSessionID = &rootID
+		s.RelationshipType = "subagent"
+	})
+
+	index, err := d.GetSidebarSessionIndex(context.Background(), SessionFilter{
+		ExcludeAutomated: true,
+		Limit:            1,
+	})
+	requireNoError(t, err, "GetSidebarSessionIndex")
+	requireSidebarIndexIDs(t, index.Sessions, []string{"root", "human-child"})
+
+	index, err = d.GetSidebarSessionIndex(context.Background(), SessionFilter{
+		ExcludeAutomated: false,
+		Limit:            1,
+	})
+	requireNoError(t, err, "GetSidebarSessionIndex")
+	requireSidebarIndexIDs(t, index.Sessions, []string{"root", "human-child", "automated-child"})
+}
+
 func TestSidebarSessionIndexStarredIncludesStarredDescendantRoot(t *testing.T) {
 	d := testDB(t)
 

--- a/internal/db/query_dialect.go
+++ b/internal/db/query_dialect.go
@@ -453,6 +453,11 @@ func buildSessionFilterWithBuilder(
 	rootMatchParts = append(rootMatchParts,
 		BuildCanonicalRootWhere(b.dialect, "root_session", f.IncludeOrphans))
 	rootMatch := strings.Join(rootMatchParts, " AND ")
+	childAutomationPred := automationScopePredicate(f, b.dialect, "s")
+	childAutomationWhere := ""
+	if childAutomationPred != "" {
+		childAutomationWhere = " AND " + childAutomationPred
+	}
 
 	cte := "WITH RECURSIVE tree(id) AS (" +
 		"SELECT root_session.id FROM sessions root_session" +
@@ -463,9 +468,27 @@ func buildSessionFilterWithBuilder(
 		"SELECT s.id FROM sessions s" +
 		" JOIN tree t ON s.parent_session_id = t.id" +
 		" WHERE s.message_count > 0 AND s.deleted_at IS NULL" +
+		childAutomationWhere +
 		") SELECT id FROM tree"
 
 	return baseWhere + " AND " + q("id") + " IN (" + cte + ")"
+}
+
+func automationScopePredicate(
+	f SessionFilter, dialect QueryDialect, sessionAlias string,
+) string {
+	col := "is_automated"
+	if sessionAlias != "" {
+		col = sessionAlias + "." + col
+	}
+	switch normalizeAutomatedScope(f.AutomatedScope, f.ExcludeAutomated) {
+	case "human":
+		return col + " = " + dialect.falseLiteral
+	case "automated":
+		return col + " = " + dialect.trueLiteral
+	default:
+		return ""
+	}
 }
 
 func sessionFilterPredicates(

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -789,6 +789,11 @@ func (db *DB) getSidebarSessionIndexPage(
 	rootFilter.IncludeChildren = false
 	rootWhere, rootArgs := buildSessionBaseFilter(rootFilter)
 	canonicalRootWhere := buildCanonicalRootWhere(f.IncludeOrphans)
+	childAutomationPred := automationScopePredicate(f, SQLiteQueryDialect(), "s")
+	childAutomationWhere := ""
+	if childAutomationPred != "" {
+		childAutomationWhere = " AND " + childAutomationPred
+	}
 
 	var total int
 	var cur SessionCursor
@@ -817,6 +822,7 @@ func (db *DB) getSidebarSessionIndexPage(
 					JOIN tree t ON s.parent_session_id = t.id
 					WHERE s.message_count > 0
 					  AND s.deleted_at IS NULL
+					  ` + childAutomationWhere + `
 				),
 				eligible_roots(id) AS (
 					SELECT DISTINCT t.root_id
@@ -864,6 +870,7 @@ func (db *DB) getSidebarSessionIndexPage(
 			JOIN tree t ON s.parent_session_id = t.id
 			WHERE s.message_count > 0
 			  AND s.deleted_at IS NULL
+			  ` + childAutomationWhere + `
 		)
 		` + sidebarStarredRootCTE(f.Starred) + `,
 		root_activity(id, activity) AS (
@@ -945,6 +952,7 @@ func (db *DB) getSidebarSessionIndexPage(
 			JOIN tree t ON s.parent_session_id = t.id
 			WHERE s.message_count > 0
 			  AND s.deleted_at IS NULL
+			  ` + childAutomationWhere + `
 		),
 		ranked_tree(id, ord) AS (
 			SELECT id, MIN(ord) AS ord

--- a/internal/postgres/sessions.go
+++ b/internal/postgres/sessions.go
@@ -553,6 +553,14 @@ func (s *Store) getSidebarSessionIndexPage(
 	rootFilter.Starred = false
 	rootWhere, rootArgs := buildPGSessionBaseFilter(rootFilter)
 	canonicalRootWhere := db.BuildCanonicalRootWhere(db.PostgresQueryDialect(), "sessions", f.IncludeOrphans)
+	childAutomationPred := pgAutomatedScopePredicate(
+		normalizePGAutomatedScope(f.AutomatedScope, f.ExcludeAutomated),
+		"s.is_automated",
+	)
+	childAutomationWhere := ""
+	if childAutomationPred != "" {
+		childAutomationWhere = " AND " + childAutomationPred
+	}
 
 	var total int
 	var cur db.SessionCursor
@@ -581,6 +589,7 @@ func (s *Store) getSidebarSessionIndexPage(
 					JOIN tree t ON s.parent_session_id = t.id
 					WHERE s.message_count > 0
 					  AND s.deleted_at IS NULL
+					  ` + childAutomationWhere + `
 				),
 				eligible_roots(id) AS (
 					SELECT DISTINCT t.root_id
@@ -630,6 +639,7 @@ func (s *Store) getSidebarSessionIndexPage(
 			JOIN tree t ON s.parent_session_id = t.id
 			WHERE s.message_count > 0
 			  AND s.deleted_at IS NULL
+			  ` + childAutomationWhere + `
 		)
 		` + pgSidebarStarredRootCTE(f.Starred) + `,
 		root_activity(id, activity) AS (
@@ -718,6 +728,7 @@ func (s *Store) getSidebarSessionIndexPage(
 			JOIN tree t ON s.parent_session_id = t.id
 			WHERE s.message_count > 0
 			  AND s.deleted_at IS NULL
+			  ` + childAutomationWhere + `
 		),
 		ranked_tree(id, ord) AS (
 			SELECT id, MIN(ord) AS ord

--- a/internal/postgres/store_test.go
+++ b/internal/postgres/store_test.go
@@ -497,6 +497,56 @@ func TestStoreGetSidebarSessionIndexIncludesChildrenForMatchingRoot(
 	)
 }
 
+func TestStoreGetSidebarSessionIndexPagedExcludesAutomatedDescendants(
+	t *testing.T,
+) {
+	pgURL := testPGURL(t)
+	store := ensureSidebarIndexStoreSchema(t, pgURL)
+	defer store.Close()
+
+	rootID := "root"
+	insertSidebarIndexSession(t, store, rootID, func(
+		s *sidebarIndexSessionSeed,
+	) {
+		s.endedAt = "2024-01-03T00:00:00Z"
+		s.userMessageCount = 5
+	})
+	insertSidebarIndexSession(t, store, "human-child", func(
+		s *sidebarIndexSessionSeed,
+	) {
+		s.endedAt = "2024-01-02T00:00:00Z"
+		s.parentSessionID = &rootID
+		s.relationshipType = "subagent"
+		s.userMessageCount = 1
+	})
+	insertSidebarIndexSession(t, store, "automated-child", func(
+		s *sidebarIndexSessionSeed,
+	) {
+		s.firstMessage = "You are a code reviewer. Review the code."
+		s.endedAt = "2024-01-01T00:00:00Z"
+		s.parentSessionID = &rootID
+		s.relationshipType = "subagent"
+		s.userMessageCount = 1
+		s.isAutomated = true
+	})
+
+	index, err := store.GetSidebarSessionIndex(
+		context.Background(),
+		db.SessionFilter{ExcludeAutomated: true, Limit: 1},
+	)
+	require.NoError(t, err, "GetSidebarSessionIndex exclude automated")
+	requireSidebarIndexIDs(t, index.Sessions, []string{"root", "human-child"})
+
+	index, err = store.GetSidebarSessionIndex(
+		context.Background(),
+		db.SessionFilter{ExcludeAutomated: false, Limit: 1},
+	)
+	require.NoError(t, err, "GetSidebarSessionIndex include automated")
+	requireSidebarIndexIDs(
+		t, index.Sessions, []string{"root", "human-child", "automated-child"},
+	)
+}
+
 func TestStoreGetSidebarSessionIndexPaginatesContinuationsAsDescendants(
 	t *testing.T,
 ) {

--- a/scripts/extract_db_test.go
+++ b/scripts/extract_db_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,8 +47,9 @@ func TestExtractDBBlocksTermsAcrossCoveredColumns(t *testing.T) {
 	insertSession := func(id, branch, firstMsg string) {
 		_, err := conn.Exec(
 			`INSERT INTO sessions
-			   (id, project, created_at, started_at, git_branch, first_message)
-			 VALUES (?, 'agentsview', ?, '', ?, ?)`,
+			   (id, project, created_at, started_at, message_count,
+			    user_message_count, git_branch, first_message)
+			 VALUES (?, 'agentsview', ?, '', 1, 1, ?, ?)`,
 			id, ts, branch, firstMsg,
 		)
 		require.NoError(t, err)
@@ -77,21 +79,21 @@ func TestExtractDBBlocksTermsAcrossCoveredColumns(t *testing.T) {
 
 	// Term hidden in message content.
 	insertSession("s_msg", "main", "ordinary prompt")
-	insertMessage(2, "s_msg", "today I integrated with ghosthub")
+	insertMessage(2, "s_msg", "today I integrated with blocklist-demo-service")
 
 	// Term hidden in git_branch (newly covered column).
-	insertSession("s_branch", "feat/ghosthub-sync", "branch work")
+	insertSession("s_branch", "feat/blocklist-demo-service-sync", "branch work")
 	insertMessage(3, "s_branch", "clean message body")
 
 	// Term hidden in a tool call's file_path (newly covered column).
 	insertSession("s_tcpath", "main", "file edits")
 	insertMessage(4, "s_tcpath", "clean message body")
-	insertToolCall("s_tcpath", "/Users/dev/code/ghosthub/main.go", "", `{"a":1}`)
+	insertToolCall("s_tcpath", "/Users/dev/code/blocklist-demo-service/main.go", "", `{"a":1}`)
 
 	// Term hidden in a tool call's skill_name (newly covered column).
 	insertSession("s_skill", "main", "skill run")
 	insertMessage(5, "s_skill", "clean message body")
-	insertToolCall("s_skill", "/tmp/clean.go", "ghosthub-deploy", `{"b":2}`)
+	insertToolCall("s_skill", "/tmp/clean.go", "blocklist-demo-service-deploy", `{"b":2}`)
 
 	// Flush the WAL so the sqlite3 CLI sees every committed row.
 	_, err = conn.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
@@ -103,7 +105,7 @@ func TestExtractDBBlocksTermsAcrossCoveredColumns(t *testing.T) {
 	cmd := exec.Command("bash", scriptPath, srcPath, outPath)
 	cmd.Env = append(
 		os.Environ(),
-		"SCREENSHOT_BLOCKED_TERMS=ghosthub",
+		"SCREENSHOT_BLOCKED_TERMS=blocklist-demo-service",
 		// Pin the file source to a path that does not exist so the test is
 		// hermetic and ignores any real blocked-terms file on the host.
 		"SCREENSHOT_BLOCKED_TERMS_FILE="+filepath.Join(tempDir, "absent.txt"),
@@ -132,6 +134,386 @@ func TestExtractDBBlocksTermsAcrossCoveredColumns(t *testing.T) {
 			"all be dropped")
 }
 
+// TestExtractDBUsesPrivateTermsFileByDefault protects the default screenshot
+// scrub path. The screenshot runner should pick up the canonical private terms
+// file without requiring SCREENSHOT_BLOCKED_TERMS_FILE for every local run.
+func TestExtractDBUsesPrivateTermsFileByDefault(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 CLI not available")
+	}
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+
+	tempDir := t.TempDir()
+	srcPath := filepath.Join(tempDir, "source.db")
+	d, err := avdb.Open(srcPath)
+	require.NoError(t, err)
+	require.NoError(t, d.Close())
+
+	conn, err := sql.Open("sqlite3", srcPath)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	const ts = "2026-06-01T12:00:00.000Z"
+	seed := func(id, content string) {
+		_, err := conn.Exec(
+			`INSERT INTO sessions
+			   (id, project, created_at, started_at, message_count,
+			    user_message_count)
+			 VALUES (?, 'agentsview', ?, '', 1, 1)`,
+			id, ts,
+		)
+		require.NoError(t, err)
+		_, err = conn.Exec(
+			`INSERT INTO messages (session_id, ordinal, role, content)
+			 VALUES (?, 0, 'user', ?)`,
+			id, content,
+		)
+		require.NoError(t, err)
+	}
+	seed("s_keep", "ordinary screenshot-safe notes")
+	seed("s_drop", "mentions blocklist-demo-service in the transcript")
+
+	_, err = conn.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	privateTermsDir := filepath.Join(tempDir, ".config", "kenn")
+	require.NoError(t, os.MkdirAll(privateTermsDir, 0o700))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(privateTermsDir, "private-terms.txt"),
+		[]byte("blocklist-demo-service\n"),
+		0o600,
+	))
+
+	outPath := filepath.Join(tempDir, "out.db")
+	scriptPath := filepath.Join("..", "docs", "screenshots", "extract-db.sh")
+	cmd := exec.Command("bash", scriptPath, srcPath, outPath)
+	cmd.Env = filteredEnv(
+		"SCREENSHOT_BLOCKED_TERMS_FILE",
+		"KENN_PRIVATE_TERMS_FILE",
+	)
+	cmd.Env = append(
+		cmd.Env,
+		"HOME="+tempDir,
+		"SCREENSHOT_BLOCKED_TERMS=",
+	)
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "extract-db.sh failed: %s", out)
+
+	outConn, err := sql.Open("sqlite3", outPath)
+	require.NoError(t, err)
+	defer outConn.Close()
+	rows, err := outConn.Query("SELECT id FROM sessions ORDER BY id")
+	require.NoError(t, err)
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		require.NoError(t, rows.Scan(&id))
+		ids = append(ids, id)
+	}
+	require.NoError(t, rows.Err())
+
+	assert.Equal(t, []string{"s_keep"}, ids)
+}
+
+func TestExtractDBRedactsHomePathByDefault(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 CLI not available")
+	}
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+
+	tempDir := t.TempDir()
+	srcPath := filepath.Join(tempDir, "source.db")
+	d, err := avdb.Open(srcPath)
+	require.NoError(t, err)
+	require.NoError(t, d.Close())
+
+	conn, err := sql.Open("sqlite3", srcPath)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	homePath := filepath.Join(tempDir, "home", "local-user")
+	require.NoError(t, os.MkdirAll(homePath, 0o700))
+
+	const ts = "2026-06-01T12:00:00.000Z"
+	seed := func(id, firstMessage, content string) {
+		_, err := conn.Exec(
+			`INSERT INTO sessions
+			   (id, project, created_at, started_at, message_count,
+			    user_message_count, first_message)
+			 VALUES (?, 'agentsview', ?, '', 1, 1, ?)`,
+			id, ts, firstMessage,
+		)
+		require.NoError(t, err)
+		_, err = conn.Exec(
+			`INSERT INTO messages (session_id, ordinal, role, content)
+			 VALUES (?, 0, 'user', ?)`,
+			id, content,
+		)
+		require.NoError(t, err)
+	}
+	seed("s_keep", "ordinary screenshot-safe notes", "clean transcript")
+	seed(
+		"s_redact",
+		"Review work under "+filepath.Join(homePath, "code", "project-a"),
+		"Inspect "+filepath.Join(homePath, "code", "project-a", "main.go"),
+	)
+
+	_, err = conn.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	outPath := filepath.Join(tempDir, "out.db")
+	scriptPath := filepath.Join("..", "docs", "screenshots", "extract-db.sh")
+	cmd := exec.Command("bash", scriptPath, srcPath, outPath)
+	cmd.Env = append(
+		filteredEnv(
+			"SCREENSHOT_BLOCKED_TERMS_FILE",
+			"KENN_PRIVATE_TERMS_FILE",
+		),
+		"HOME="+homePath,
+		"SCREENSHOT_BLOCKED_TERMS=",
+		"SCREENSHOT_BLOCKED_TERMS_FILE="+filepath.Join(tempDir, "absent.txt"),
+		"KENN_PRIVATE_TERMS_FILE="+filepath.Join(tempDir, "absent-private.txt"),
+	)
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "extract-db.sh failed: %s", out)
+
+	outConn, err := sql.Open("sqlite3", outPath)
+	require.NoError(t, err)
+	defer outConn.Close()
+	rows, err := outConn.Query("SELECT id FROM sessions ORDER BY id")
+	require.NoError(t, err)
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		require.NoError(t, rows.Scan(&id))
+		ids = append(ids, id)
+	}
+	require.NoError(t, rows.Err())
+
+	assert.Equal(t, []string{"s_keep", "s_redact"}, ids)
+
+	var firstMessage, content string
+	require.NoError(t, outConn.QueryRow(
+		`SELECT s.first_message, m.content
+		 FROM sessions s
+		 JOIN messages m ON m.session_id = s.id
+		 WHERE s.id = 's_redact'`,
+	).Scan(&firstMessage, &content))
+	assert.Equal(t, "Review work under ~/code/project-a", firstMessage)
+	assert.Equal(t, "Inspect ~/code/project-a/main.go", content)
+	assert.NotContains(t, firstMessage, homePath)
+	assert.NotContains(t, content, homePath)
+}
+
+func TestExtractDBUsesPrivateTermsFileWithScreenshotFileOverride(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 CLI not available")
+	}
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+
+	tempDir := t.TempDir()
+	srcPath := filepath.Join(tempDir, "source.db")
+	d, err := avdb.Open(srcPath)
+	require.NoError(t, err)
+	require.NoError(t, d.Close())
+
+	conn, err := sql.Open("sqlite3", srcPath)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	const ts = "2026-06-01T12:00:00.000Z"
+	seed := func(id, content string) {
+		_, err := conn.Exec(
+			`INSERT INTO sessions
+			   (id, project, created_at, started_at, message_count,
+			    user_message_count)
+			 VALUES (?, 'agentsview', ?, '', 1, 1)`,
+			id, ts,
+		)
+		require.NoError(t, err)
+		_, err = conn.Exec(
+			`INSERT INTO messages (session_id, ordinal, role, content)
+			 VALUES (?, 0, 'user', ?)`,
+			id, content,
+		)
+		require.NoError(t, err)
+	}
+	seed("s_keep", "ordinary screenshot-safe notes")
+	seed("s_drop_private", "mentions private-only-demo in the transcript")
+	seed("s_drop_screenshot", "mentions screenshot-only-demo in the transcript")
+
+	_, err = conn.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	privateTerms := filepath.Join(tempDir, "private-terms.txt")
+	require.NoError(t, os.WriteFile(privateTerms, []byte("private-only-demo\n"), 0o600))
+	screenshotTerms := filepath.Join(tempDir, "screenshot-terms.txt")
+	require.NoError(t, os.WriteFile(screenshotTerms, []byte("screenshot-only-demo\n"), 0o600))
+
+	outPath := filepath.Join(tempDir, "out.db")
+	scriptPath := filepath.Join("..", "docs", "screenshots", "extract-db.sh")
+	cmd := exec.Command("bash", scriptPath, srcPath, outPath)
+	cmd.Env = append(
+		filteredEnv("KENN_PRIVATE_TERMS_FILE"),
+		"SCREENSHOT_BLOCKED_TERMS=",
+		"SCREENSHOT_BLOCKED_TERMS_FILE="+screenshotTerms,
+		"KENN_PRIVATE_TERMS_FILE="+privateTerms,
+	)
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "extract-db.sh failed: %s", out)
+
+	outConn, err := sql.Open("sqlite3", outPath)
+	require.NoError(t, err)
+	defer outConn.Close()
+	rows, err := outConn.Query("SELECT id FROM sessions ORDER BY id")
+	require.NoError(t, err)
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		require.NoError(t, rows.Scan(&id))
+		ids = append(ids, id)
+	}
+	require.NoError(t, rows.Err())
+
+	assert.Equal(t, []string{"s_keep"}, ids)
+}
+
+// TestExtractDBKeepsOnlyRootTrees exercises the screenshot fixture's sidebar
+// hygiene end to end. Child sessions only survive when their parent tree is
+// exported, old descendants of an exported root stay available, and automated
+// sessions remain in the fixture so the app can classify/filter them itself.
+func TestExtractDBKeepsOnlyRootTrees(t *testing.T) {
+	if _, err := exec.LookPath("sqlite3"); err != nil {
+		t.Skip("sqlite3 CLI not available")
+	}
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+
+	tempDir := t.TempDir()
+	srcPath := filepath.Join(tempDir, "source.db")
+	d, err := avdb.Open(srcPath)
+	require.NoError(t, err)
+	require.NoError(t, d.Close())
+
+	conn, err := sql.Open("sqlite3", srcPath)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	insertSession := func(
+		id, parentID, relationship, createdAt string,
+		automated, messageCount, userMessageCount int,
+	) {
+		_, err := conn.Exec(
+			`INSERT INTO sessions
+			   (id, project, created_at, started_at, message_count,
+			    user_message_count, parent_session_id, relationship_type,
+			    is_automated, first_message)
+			 VALUES (?, 'agentsview', ?, '', ?, ?, NULLIF(?, ''), ?, ?, ?)`,
+			id, createdAt, messageCount, userMessageCount,
+			parentID, relationship, automated, id+" prompt",
+		)
+		require.NoError(t, err)
+		_, err = conn.Exec(
+			`INSERT INTO messages (session_id, ordinal, role, content)
+			 VALUES (?, 0, 'user', ?)`,
+			id, id+" message",
+		)
+		require.NoError(t, err)
+	}
+
+	const recent = "2026-06-01T12:00:00.000Z"
+	const old = "2026-01-01T12:00:00.000Z"
+	insertSession("root_keep", "", "", recent, 0, 3, 2)
+	insertSession("child_keep", "root_keep", "subagent", recent, 0, 1, 1)
+	insertSession("old_child_keep", "root_keep", "subagent", old, 0, 1, 1)
+	insertSession("automated_root_keep", "", "", recent, 1, 1, 1)
+	insertSession("automated_child_keep", "root_keep", "subagent", recent, 1, 1, 1)
+	insertSession("child_of_automated_root_keep", "automated_root_keep", "subagent", recent, 0, 1, 1)
+	insertSession("orphan_subagent_drop", "missing_parent", "subagent", recent, 0, 1, 1)
+	insertSession("orphan_fork_drop", "missing_parent", "fork", recent, 0, 1, 1)
+	insertSession("old_root_drop", "", "", old, 0, 3, 2)
+	insertSession("old_thinking_keep", "", "", old, 0, 3, 2)
+	insertSession("automated_thinking_keep", "", "", recent, 1, 1, 1)
+	_, err = conn.Exec(
+		`UPDATE messages
+		 SET thinking_text = 'private reasoning', has_thinking = 1
+		 WHERE session_id IN ('old_thinking_keep', 'automated_thinking_keep')`,
+	)
+	require.NoError(t, err)
+
+	_, err = conn.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	outPath := filepath.Join(tempDir, "out.db")
+	scriptPath := filepath.Join("..", "docs", "screenshots", "extract-db.sh")
+	cmd := exec.Command("bash", scriptPath, srcPath, outPath)
+	cmd.Env = append(
+		os.Environ(),
+		"SCREENSHOT_BLOCKED_TERMS=",
+		"SCREENSHOT_BLOCKED_TERMS_FILE="+filepath.Join(tempDir, "absent.txt"),
+	)
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "extract-db.sh failed: %s", out)
+
+	outConn, err := sql.Open("sqlite3", outPath)
+	require.NoError(t, err)
+	defer outConn.Close()
+
+	rows, err := outConn.Query("SELECT id FROM sessions ORDER BY id")
+	require.NoError(t, err)
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		require.NoError(t, rows.Scan(&id))
+		ids = append(ids, id)
+	}
+	require.NoError(t, rows.Err())
+
+	assert.Equal(t, []string{
+		"automated_child_keep",
+		"automated_root_keep",
+		"automated_thinking_keep",
+		"child_keep",
+		"child_of_automated_root_keep",
+		"old_child_keep",
+		"old_thinking_keep",
+		"root_keep",
+	}, ids)
+
+	var automatedCount int
+	require.NoError(t, outConn.QueryRow(
+		"SELECT COUNT(*) FROM sessions WHERE is_automated = 1",
+	).Scan(&automatedCount))
+	assert.Equal(t, 3, automatedCount)
+
+	var orphanChildCount int
+	require.NoError(t, outConn.QueryRow(
+		`SELECT COUNT(*)
+		 FROM sessions child
+		 WHERE child.relationship_type IN ('subagent', 'fork', 'continuation')
+		   AND NOT EXISTS (
+		     SELECT 1 FROM sessions parent
+		     WHERE parent.id = child.parent_session_id
+		   )`,
+	).Scan(&orphanChildCount))
+	assert.Zero(t, orphanChildCount)
+}
+
 // TestExtractDBTermsFileSkipsCommentsAndBlanks pins the terms-file format:
 // comment lines (leading '#') and blank lines are ignored. A bare '#' must
 // not become the pattern '%#%', which would match nearly every transcript and
@@ -157,8 +539,10 @@ func TestExtractDBTermsFileSkipsCommentsAndBlanks(t *testing.T) {
 	const ts = "2026-06-01T12:00:00.000Z"
 	seed := func(id, content string) {
 		_, err := conn.Exec(
-			`INSERT INTO sessions (id, project, created_at, started_at)
-			 VALUES (?, 'agentsview', ?, '')`,
+			`INSERT INTO sessions
+			   (id, project, created_at, started_at, message_count,
+			    user_message_count)
+			 VALUES (?, 'agentsview', ?, '', 1, 1)`,
 			id, ts,
 		)
 		require.NoError(t, err)
@@ -174,7 +558,7 @@ func TestExtractDBTermsFileSkipsCommentsAndBlanks(t *testing.T) {
 	// would be dropped.
 	seed("s_keep", "## Heading\nordinary notes, nothing blocked here")
 	// Session referencing the one real blocked term.
-	seed("s_drop", "spent the day on ghosthub internals")
+	seed("s_drop", "spent the day on blocklist-demo-service internals")
 
 	_, err = conn.Exec("PRAGMA wal_checkpoint(TRUNCATE)")
 	require.NoError(t, err)
@@ -186,7 +570,7 @@ func TestExtractDBTermsFileSkipsCommentsAndBlanks(t *testing.T) {
 			"#\n"+
 			"   # indented comment, ignored\n"+
 			"\n"+
-			"ghosthub\n",
+			"blocklist-demo-service\n",
 	), 0o600))
 
 	outPath := filepath.Join(tempDir, "out.db")
@@ -217,4 +601,26 @@ func TestExtractDBTermsFileSkipsCommentsAndBlanks(t *testing.T) {
 	assert.Equal(t, []string{"s_keep"}, ids,
 		"comment and blank lines must be skipped: the clean session containing "+
 			"'#' must survive and only the real term may drop a session")
+}
+
+func filteredEnv(dropKeys ...string) []string {
+	drops := make(map[string]struct{}, len(dropKeys))
+	for _, key := range dropKeys {
+		drops[key] = struct{}{}
+	}
+
+	env := os.Environ()
+	filtered := make([]string, 0, len(env))
+	for _, entry := range env {
+		key, _, ok := strings.Cut(entry, "=")
+		if !ok {
+			filtered = append(filtered, entry)
+			continue
+		}
+		if _, drop := drops[key]; drop {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
 }


### PR DESCRIPTION
The screenshot fixture now preserves automated sessions for activity and usage categorization while keeping default sidebar captures aligned with the app's interactive-session view. Extraction reads the screenshot-specific blocklist plus the canonical private-terms file, redacts the local home path in surviving fixture rows, and keeps only rooted child trees so orphan child sessions cannot appear as top-level screenshots.

The sidebar tree queries now apply the automation scope to recursive descendants in both SQLite and PostgreSQL. That prevents automated subagent/fork/continuation rows from re-entering the default paged sidebar under an otherwise interactive root, while `include_automated=true` still exposes automated rows for views that need them.

Reviewers should look at the screenshot extractor, the shared SQLite filter builder, and the PostgreSQL sidebar tree query. The generated screenshots were regenerated locally from the scrubbed fixture for docs inspection before updating the generated-assets branch.
