### PR TITLE
refactor(vector): parameterize Index over an IndexSpec for multiple embedding stores

### DIFF
--- a/cmd/agentsview/embeddings.go
+++ b/cmd/agentsview/embeddings.go
@@ -9,8 +9,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"text/tabwriter"
@@ -119,6 +121,7 @@ func newEmbeddingsBuildCommand() *cobra.Command {
 }
 
 func newEmbeddingsListCommand() *cobra.Command {
+	var store string
 	cmd := &cobra.Command{
 		Use:          "list",
 		Short:        "List embedding generations",
@@ -126,16 +129,19 @@ func newEmbeddingsListCommand() *cobra.Command {
 		Args:         cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runEmbeddingsList(
-				cmd.Context(), cmd.OutOrStdout(), outputFormat(cmd) == "json",
+				cmd.Context(), cmd.OutOrStdout(), outputFormat(cmd) == "json", store,
 			)
 		},
 	}
 	registerFormatFlags(cmd.Flags())
+	cmd.Flags().StringVar(&store, "store", "",
+		"Embedding store to operate on (default: messages)")
 	return cmd
 }
 
 func newEmbeddingsActivateCommand() *cobra.Command {
 	var force bool
+	var store string
 	cmd := &cobra.Command{
 		Use:          "activate <id>",
 		Short:        "Activate an embedding generation",
@@ -147,17 +153,20 @@ func newEmbeddingsActivateCommand() *cobra.Command {
 				return err
 			}
 			return runEmbeddingsGenerationAction(
-				cmd.Context(), cmd.OutOrStdout(), id, force, false,
+				cmd.Context(), cmd.OutOrStdout(), id, force, false, store,
 			)
 		},
 	}
 	cmd.Flags().BoolVar(&force, "force", false,
 		"Activate even if the generation has incomplete coverage")
+	cmd.Flags().StringVar(&store, "store", "",
+		"Embedding store to operate on (default: messages)")
 	return cmd
 }
 
 func newEmbeddingsRetireCommand() *cobra.Command {
 	var force bool
+	var store string
 	cmd := &cobra.Command{
 		Use:          "retire <id>",
 		Short:        "Retire an embedding generation",
@@ -169,13 +178,35 @@ func newEmbeddingsRetireCommand() *cobra.Command {
 				return err
 			}
 			return runEmbeddingsGenerationAction(
-				cmd.Context(), cmd.OutOrStdout(), id, force, true,
+				cmd.Context(), cmd.OutOrStdout(), id, force, true, store,
 			)
 		},
 	}
 	cmd.Flags().BoolVar(&force, "force", false,
 		"Retire even if the generation is currently active")
+	cmd.Flags().StringVar(&store, "store", "",
+		"Embedding store to operate on (default: messages)")
 	return cmd
+}
+
+// vectorStoreSpec resolves an `--store` name against the registered
+// embedding stores. There is one registry entry per store; a PR adding a
+// new store registers its spec here and extends the daemon embeddings API
+// (which currently serves only the message store) alongside it.
+func vectorStoreSpec(name string) (vector.IndexSpec, error) {
+	specs := map[string]vector.IndexSpec{
+		vector.MessageIndexSpec().Name: vector.MessageIndexSpec(),
+	}
+	if name == "" {
+		name = vector.MessageIndexSpec().Name
+	}
+	spec, ok := specs[name]
+	if !ok {
+		names := slices.Sorted(maps.Keys(specs))
+		return vector.IndexSpec{}, fmt.Errorf(
+			"unknown embedding store %q (known stores: %s)", name, strings.Join(names, ", "))
+	}
+	return spec, nil
 }
 
 func parseGenerationID(raw string) (int64, error) {
@@ -516,14 +547,22 @@ func printBuildSummary(w io.Writer, result vector.BuildResult) {
 	}
 }
 
-// runEmbeddingsList loads config, gates on [vector] enabled, lists every
-// generation via the daemon or directly, and renders it as a table or JSON.
-func runEmbeddingsList(ctx context.Context, out io.Writer, jsonOutput bool) error {
+// runEmbeddingsList loads config, gates on [vector] enabled, resolves the
+// requested store, lists every generation via the daemon or directly, and
+// renders it as a table or JSON. Generation IDs are only unique within a
+// store, so every entry is stamped with the resolved store's name before
+// display, including entries fetched from the daemon (which does not send
+// one, since it currently only serves the message store).
+func runEmbeddingsList(ctx context.Context, out io.Writer, jsonOutput bool, store string) error {
 	cfg, err := config.LoadMinimal()
 	if err != nil {
 		return fmt.Errorf("loading config: %w", err)
 	}
 	if err := requireVectorEnabled(cfg); err != nil {
+		return err
+	}
+	spec, err := vectorStoreSpec(store)
+	if err != nil {
 		return err
 	}
 
@@ -538,10 +577,13 @@ func runEmbeddingsList(ctx context.Context, out io.Writer, jsonOutput bool) erro
 			return err
 		}
 	} else {
-		gens, err = directListGenerations(ctx, cfg)
+		gens, err = directListGenerations(ctx, cfg, spec)
 		if err != nil {
 			return err
 		}
+	}
+	for i := range gens {
+		gens[i].Store = spec.Name
 	}
 
 	if jsonOutput {
@@ -556,10 +598,12 @@ func runEmbeddingsList(ctx context.Context, out io.Writer, jsonOutput bool) erro
 	return nil
 }
 
-// directListGenerations opens vectors.db read-only and lists its
+// directListGenerations opens vectors.db read-only and lists spec's
 // generations, or returns an empty list without error when the index has
 // never been built.
-func directListGenerations(ctx context.Context, cfg config.Config) ([]vector.GenerationInfo, error) {
+func directListGenerations(
+	ctx context.Context, cfg config.Config, spec vector.IndexSpec,
+) ([]vector.GenerationInfo, error) {
 	path := cfg.Vector.ResolvedDBPath(cfg.DataDir)
 	if _, err := os.Stat(path); err != nil {
 		if os.IsNotExist(err) {
@@ -567,7 +611,7 @@ func directListGenerations(ctx context.Context, cfg config.Config) ([]vector.Gen
 		}
 		return nil, err
 	}
-	ix, err := vector.Open(ctx, path, true, cfg.Vector.Embeddings.MaxInputChars)
+	ix, err := vector.OpenSpec(ctx, path, spec, true, cfg.Vector.Embeddings.MaxInputChars)
 	if err != nil {
 		return nil, fmt.Errorf("opening vectors.db: %w", err)
 	}
@@ -579,10 +623,10 @@ func directListGenerations(ctx context.Context, cfg config.Config) ([]vector.Gen
 // table, truncating each fingerprint to fingerprintDisplayLen characters.
 func printGenerationsTable(out io.Writer, gens []vector.GenerationInfo) {
 	tw := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
-	fmt.Fprintln(tw, "ID\tSTATE\tMODEL\tDIM\tEMBEDDED\tMISSING\tFINGERPRINT")
+	fmt.Fprintln(tw, "STORE\tID\tSTATE\tMODEL\tDIM\tEMBEDDED\tMISSING\tFINGERPRINT")
 	for _, g := range gens {
-		fmt.Fprintf(tw, "%d\t%s\t%s\t%d\t%d\t%d\t%s\n",
-			g.ID, g.State, g.Model, g.Dimension, g.Embedded, g.Missing,
+		fmt.Fprintf(tw, "%s\t%d\t%s\t%s\t%d\t%d\t%d\t%s\n",
+			g.Store, g.ID, g.State, g.Model, g.Dimension, g.Embedded, g.Missing,
 			truncateFingerprint(g.Fingerprint))
 	}
 	_ = tw.Flush()
@@ -596,18 +640,24 @@ func truncateFingerprint(fp string) string {
 }
 
 // runEmbeddingsGenerationAction implements both `activate <id>` and
-// `retire <id>`: it loads config, gates on [vector] enabled, and dispatches
-// the requested action to the daemon or directly. A 409/refusal error's
-// message is returned verbatim (no extra wrapping) so it displays exactly
-// as the manager phrased it.
+// `retire <id>`: it loads config, gates on [vector] enabled, resolves the
+// requested store, and dispatches the requested action to the daemon or
+// directly. A 409/refusal error's message is returned verbatim (no extra
+// wrapping) so it displays exactly as the manager phrased it. The daemon
+// only serves the message store, so the daemon path needs no request
+// change beyond resolving (and thereby validating) the --store name.
 func runEmbeddingsGenerationAction(
-	ctx context.Context, out io.Writer, id int64, force, retire bool,
+	ctx context.Context, out io.Writer, id int64, force, retire bool, store string,
 ) error {
 	cfg, err := config.LoadMinimal()
 	if err != nil {
 		return fmt.Errorf("loading config: %w", err)
 	}
 	if err := requireVectorEnabled(cfg); err != nil {
+		return err
+	}
+	spec, err := vectorStoreSpec(store)
+	if err != nil {
 		return err
 	}
 
@@ -624,7 +674,7 @@ func runEmbeddingsGenerationAction(
 		if err != nil {
 			return err
 		}
-	} else if err := directGenerationAction(ctx, cfg, id, force, retire); err != nil {
+	} else if err := directGenerationAction(ctx, cfg, spec, id, force, retire); err != nil {
 		return err
 	}
 
@@ -637,9 +687,10 @@ func runEmbeddingsGenerationAction(
 }
 
 // directGenerationAction acquires the vectors write lock and applies the
-// activate/retire state change directly against vectors.db.
+// activate/retire state change directly against vectors.db, scoped to spec's
+// store.
 func directGenerationAction(
-	ctx context.Context, cfg config.Config, id int64, force, retire bool,
+	ctx context.Context, cfg config.Config, spec vector.IndexSpec, id int64, force, retire bool,
 ) error {
 	lock, err := tryAcquireNamedLock(cfg.DataDir, vectorsWriteLockFile)
 	if err != nil {
@@ -647,8 +698,8 @@ func directGenerationAction(
 	}
 	defer lock.Close()
 
-	ix, err := vector.Open(
-		ctx, cfg.Vector.ResolvedDBPath(cfg.DataDir), false, cfg.Vector.Embeddings.MaxInputChars,
+	ix, err := vector.OpenSpec(
+		ctx, cfg.Vector.ResolvedDBPath(cfg.DataDir), spec, false, cfg.Vector.Embeddings.MaxInputChars,
 	)
 	if err != nil {
 		return fmt.Errorf("opening vectors.db: %w", err)

--- a/cmd/agentsview/embeddings_test.go
+++ b/cmd/agentsview/embeddings_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -202,6 +203,7 @@ func TestEmbeddingsListRendersTable(t *testing.T) {
 
 	lines := strings.Split(strings.TrimSpace(out.String()), "\n")
 	require.Len(t, lines, 2, "expected a header line and one generation row, got: %q", out.String())
+	assert.Contains(t, lines[0], "STORE")
 	assert.Contains(t, lines[0], "ID")
 	assert.Contains(t, lines[0], "STATE")
 	assert.Contains(t, lines[0], "MODEL")
@@ -210,10 +212,46 @@ func TestEmbeddingsListRendersTable(t *testing.T) {
 	assert.Contains(t, lines[0], "MISSING")
 	assert.Contains(t, lines[0], "FINGERPRINT")
 
+	assert.Contains(t, lines[1], "messages")
 	assert.Contains(t, lines[1], "active")
 	assert.Contains(t, lines[1], "test-model")
 	assert.Contains(t, lines[1], truncateFingerprint(fp))
 	assert.NotContains(t, lines[1], fp, "fingerprint column must be truncated to 12 chars")
+}
+
+// TestEmbeddingsUnknownStoreFails asserts an unrecognized --store value
+// fails fast with the known-stores list, before any config-driven daemon
+// detection or vectors.db access.
+func TestEmbeddingsUnknownStoreFails(t *testing.T) {
+	dataDir := testDataDir(t)
+	writeEmbeddingsTestConfig(t, dataDir, "http://127.0.0.1:1")
+
+	err := runEmbeddingsList(context.Background(), io.Discard, false, "bogus")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unknown embedding store "bogus"`)
+	assert.Contains(t, err.Error(), "messages")
+}
+
+// TestEmbeddingsListShowsStoreColumn asserts `embeddings list --store
+// messages` renders the STORE column stamped with the resolved store name.
+func TestEmbeddingsListShowsStoreColumn(t *testing.T) {
+	dataDir := testDataDir(t)
+	writeEmbeddingsTestConfig(t, dataDir, "http://127.0.0.1:1")
+
+	cfg, err := config.LoadMinimal()
+	require.NoError(t, err)
+	ctx := context.Background()
+	ix, err := vector.Open(ctx, cfg.Vector.ResolvedDBPath(cfg.DataDir), false,
+		cfg.Vector.Embeddings.MaxInputChars)
+	require.NoError(t, err)
+	_, err = ix.EnsureGeneration(ctx, vectorGeneration(cfg.Vector.Embeddings), sqlitevec.StateActive)
+	require.NoError(t, err)
+	require.NoError(t, ix.Close())
+
+	var buf bytes.Buffer
+	require.NoError(t, runEmbeddingsList(context.Background(), &buf, false, "messages"))
+	assert.Contains(t, buf.String(), "STORE")
+	assert.Contains(t, buf.String(), "messages")
 }
 
 // TestEmbeddingsListJSONFormat asserts `embeddings list --format json`
@@ -245,6 +283,7 @@ func TestEmbeddingsListJSONFormat(t *testing.T) {
 	require.NoError(t, json.Unmarshal(out.Bytes(), &body))
 	require.Len(t, body.Generations, 1)
 	assert.Equal(t, "active", body.Generations[0].State)
+	assert.Equal(t, "messages", body.Generations[0].Store)
 }
 
 // TestEmbeddingsListEmptyIndexReturnsNoRows asserts `embeddings list`
@@ -902,7 +941,7 @@ func TestDirectListGenerationsVersionMismatchSurfacesRebuildRequired(t *testing.
 	require.NoError(t, err)
 	require.NoError(t, raw.Close())
 
-	_, err = directListGenerations(context.Background(), cfg)
+	_, err = directListGenerations(context.Background(), cfg, vector.MessageIndexSpec())
 	require.Error(t, err)
 	assert.ErrorIs(t, err, vector.ErrMirrorVersionMismatch,
 		"a stale-shape vectors.db must not be listed as if it were current")

--- a/docs/semantic-search-internals.md
+++ b/docs/semantic-search-internals.md
@@ -26,6 +26,18 @@ Tables inside the archive DB were rejected: that would tie vector writes to the
 archive's write path and lock, and complicate the resync-swap story with
 special-casing during the swap instead of a plain re-scan afterward.
 
+### Embedding stores and `IndexSpec`
+
+`vectors.db` can host more than one embedding store. Each store is bound by
+an `IndexSpec` (internal/vector): its documents table, its own key/value
+metadata table, and a table prefix for the kit-managed generation
+bookkeeping. Schema-version resets, metadata (watermarks, scope, generation
+model names), and generation lifecycles are all scoped per store, so
+resetting or rebuilding one store never touches another. The conversation
+message store described in this document is the spec returned by
+`MessageIndexSpec()`; `embeddings list/activate/retire` accept `--store`
+(default `messages`) because generation IDs are only unique within a store.
+
 ## Unit model: user documents and runs
 
 The index does not embed every message individually. The embeddable universe —

--- a/internal/vector/build.go
+++ b/internal/vector/build.go
@@ -20,10 +20,6 @@ import (
 // the completed (or aborted) run. Tests lower it to 0 for determinism.
 var progressInterval = 2 * time.Second
 
-// chunksTable is the kit-managed table mapping each embedded chunk to its
-// vec0 row, scoped by generation ordinal and doc_key.
-const chunksTable = vectorsPrefix + "_chunks"
-
 // BuildOptions configures one Build pass.
 type BuildOptions struct {
 	// FullRebuild forces every document to be re-embedded under the target
@@ -35,11 +31,11 @@ type BuildOptions struct {
 	// IncludeAutomated controls whether automated sessions' units are
 	// scanned into the mirror at all (see UnitSource.ScanEmbeddableUnits).
 	// It is part of the mirror's identity: Build compares it against the
-	// scope the mirror was last refreshed under (vector_meta) and forces a
-	// full reconciliation scan on any change, so now-out-of-scope rows (and
-	// their vectors) are removed and newly-in-scope sessions older than the
-	// refresh watermark are picked up. It does not force a re-embed of
-	// documents that stay in scope.
+	// scope the mirror was last refreshed under (the metadata table) and
+	// forces a full reconciliation scan on any change, so now-out-of-scope
+	// rows (and their vectors) are removed and newly-in-scope sessions older
+	// than the refresh watermark are picked up. It does not force a re-embed
+	// of documents that stay in scope.
 	IncludeAutomated bool
 	// BatchSize is the encode batch size (config batch_size).
 	BatchSize int
@@ -76,7 +72,7 @@ type BuildResult struct {
 // config: Model, Dimensions, and the fingerprinted Params — max_input_chars,
 // doc_unit_scheme, and chunk_overlap_chars; see vectorGeneration in
 // cmd/agentsview/embeddings.go). It
-// refreshes the vector_messages mirror, resolves which generation to fill
+// refreshes the mirror, resolves which generation to fill
 // (top-up the active one, start a new building generation, or reset and
 // refill the active one for FullRebuild), fills pending documents, and
 // auto-activates a building generation once it fully covers the mirror.
@@ -255,7 +251,7 @@ func (ix *Index) resolveBuildTarget(
 // scratch or a future kit API adds reclamation.
 func (ix *Index) retireAbandonedBuildingGenerations(ctx context.Context, keep string) error {
 	if _, err := ix.db.ExecContext(ctx,
-		`UPDATE `+generationsTable+` SET state = ? WHERE state = ? AND gen_key != ?`,
+		`UPDATE `+ix.spec.generationsTable()+` SET state = ? WHERE state = ? AND gen_key != ?`,
 		string(sqlitevec.StateRetired), string(sqlitevec.StateBuilding), keep,
 	); err != nil {
 		return fmt.Errorf("retire abandoned building generations: %w", err)
@@ -268,7 +264,7 @@ func (ix *Index) retireAbandonedBuildingGenerations(ctx context.Context, keep st
 func (ix *Index) generationExists(ctx context.Context, fp string) (bool, error) {
 	var ordinal int64
 	err := ix.db.QueryRowContext(ctx,
-		`SELECT ordinal FROM `+generationsTable+` WHERE gen_key = ?`, fp,
+		`SELECT ordinal FROM `+ix.spec.generationsTable()+` WHERE gen_key = ?`, fp,
 	).Scan(&ordinal)
 	if err == sql.ErrNoRows {
 		return false, nil
@@ -296,8 +292,8 @@ func (ix *Index) countPending(ctx context.Context, fp string) (int64, error) {
 		return 0, err
 	}
 	rows, err := ix.db.QueryContext(ctx, `
-SELECT content FROM vector_messages d WHERE NOT EXISTS (
-    SELECT 1 FROM `+stampsTable+` s WHERE s.ordinal = ? AND s.doc_key = d.doc_key
+SELECT content FROM `+ix.spec.DocsTable+` d WHERE NOT EXISTS (
+    SELECT 1 FROM `+ix.spec.stampsTable()+` s WHERE s.ordinal = ? AND s.doc_key = d.doc_key
       AND s.revision = d.content_hash)`,
 		ordinal,
 	)
@@ -325,7 +321,7 @@ SELECT content FROM vector_messages d WHERE NOT EXISTS (
 func (ix *Index) ordinalForFingerprint(ctx context.Context, fp string) (int64, error) {
 	var ordinal int64
 	if err := ix.db.QueryRowContext(ctx,
-		`SELECT ordinal FROM `+generationsTable+` WHERE gen_key = ?`, fp,
+		`SELECT ordinal FROM `+ix.spec.generationsTable()+` WHERE gen_key = ?`, fp,
 	).Scan(&ordinal); err != nil {
 		return 0, fmt.Errorf("lookup generation ordinal for fingerprint %s: %w", fp, err)
 	}
@@ -345,19 +341,19 @@ func (ix *Index) resetGeneration(ctx context.Context, fp string) error {
 
 	var ordinal int64
 	if err := tx.QueryRowContext(ctx,
-		`SELECT ordinal FROM `+generationsTable+` WHERE gen_key = ?`, fp,
+		`SELECT ordinal FROM `+ix.spec.generationsTable()+` WHERE gen_key = ?`, fp,
 	).Scan(&ordinal); err != nil {
 		return fmt.Errorf("lookup generation ordinal for fingerprint %s: %w", fp, err)
 	}
 
-	vecTable := fmt.Sprintf("%s_v%d", vectorsPrefix, ordinal)
+	vecTable := fmt.Sprintf("%s_v%d", ix.spec.VectorsPrefix, ordinal)
 	if _, err := tx.ExecContext(ctx, `DELETE FROM `+vecTable); err != nil {
 		return fmt.Errorf("clearing vec0 table: %w", err)
 	}
-	if _, err := tx.ExecContext(ctx, `DELETE FROM `+chunksTable+` WHERE ordinal = ?`, ordinal); err != nil {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM `+ix.spec.chunksTable()+` WHERE ordinal = ?`, ordinal); err != nil {
 		return fmt.Errorf("clearing chunk map: %w", err)
 	}
-	if _, err := tx.ExecContext(ctx, `DELETE FROM `+stampsTable+` WHERE ordinal = ?`, ordinal); err != nil {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM `+ix.spec.stampsTable()+` WHERE ordinal = ?`, ordinal); err != nil {
 		return fmt.Errorf("clearing stamps: %w", err)
 	}
 
@@ -404,13 +400,13 @@ func (ix *Index) activateGeneration(ctx context.Context, target string) error {
 	defer func() { _ = tx.Rollback() }()
 
 	if _, err := tx.ExecContext(ctx,
-		`UPDATE `+generationsTable+` SET state = ? WHERE state = ? AND gen_key != ?`,
+		`UPDATE `+ix.spec.generationsTable()+` SET state = ? WHERE state = ? AND gen_key != ?`,
 		string(sqlitevec.StateRetired), string(sqlitevec.StateActive), target,
 	); err != nil {
 		return fmt.Errorf("retire old active generation: %w", err)
 	}
 	if _, err := tx.ExecContext(ctx,
-		`UPDATE `+generationsTable+` SET state = ? WHERE gen_key = ?`,
+		`UPDATE `+ix.spec.generationsTable()+` SET state = ? WHERE gen_key = ?`,
 		string(sqlitevec.StateActive), target,
 	); err != nil {
 		return fmt.Errorf("activate generation: %w", err)

--- a/internal/vector/index.go
+++ b/internal/vector/index.go
@@ -150,6 +150,10 @@ type GenerationInfo struct {
 	Fingerprint string `json:"fingerprint"`
 	Embedded    int64  `json:"embedded"` // stamped docs
 	Missing     int64  `json:"missing"`  // mirror docs not stamped
+	// Store names the embedding store this generation belongs to (e.g.
+	// "messages"). Populated by the CLI after fetching, not by the daemon
+	// API, since generation IDs are only unique within a store.
+	Store string `json:"store,omitempty"`
 }
 
 // ChunkOverlap derives the SplitOptions.Overlap rune count from

--- a/internal/vector/index.go
+++ b/internal/vector/index.go
@@ -261,13 +261,17 @@ func prepareMirrorSchema(ctx context.Context, db *sql.DB, spec IndexSpec, readOn
 // of the versioned mirror: the mirror's own tables, plus any kit-owned
 // spec.VectorsPrefix* table (the generations and stamps bookkeeping tables
 // and one vec0 table per embedding generation, including retired or
-// abandoned ones left behind by a prior build).
+// abandoned ones left behind by a prior build). The prefix is matched
+// literally via substr, not LIKE: LIKE would treat "_" in a prefix such as
+// "message_vectors" as a single-character wildcard, letting one store's
+// schema-version reset match — and drop — another store's tables whose
+// names differ only at wildcard positions.
 func mirrorStateTableNames(ctx context.Context, db *sql.DB, spec IndexSpec) ([]string, error) {
 	rows, err := db.QueryContext(ctx, `
 SELECT name FROM sqlite_master
  WHERE type = 'table'
-   AND (name IN (?, ?) OR name LIKE ?)`,
-		spec.DocsTable, spec.MetaTable, spec.VectorsPrefix+"%")
+   AND (name IN (?, ?) OR substr(name, 1, ?) = ?)`,
+		spec.DocsTable, spec.MetaTable, len(spec.VectorsPrefix), spec.VectorsPrefix)
 	if err != nil {
 		return nil, fmt.Errorf("listing mirror tables: %w", err)
 	}

--- a/internal/vector/index.go
+++ b/internal/vector/index.go
@@ -19,38 +19,14 @@ import (
 // to register the same SQL functions twice.
 var registerVecOnce sync.Once
 
-// vectorsPrefix names the vec0/bookkeeping tables kit's sqlitevec store
-// manages for our documents table (message_vectors_generations,
-// message_vectors_chunks, message_vectors_stamps, message_vectors_v<N>).
-const vectorsPrefix = "message_vectors"
-
-// vectorSchema binds kit's sqlitevec store to our vector_messages mirror
-// table.
-var vectorSchema = sqlitevec.Schema{
-	DocsTable:      "vector_messages",
-	IDColumn:       "doc_key",
-	ContentColumn:  "content",
-	EmbedGenColumn: "embed_gen",
-	RevisionColumn: "content_hash",
-	VectorsPrefix:  vectorsPrefix,
-}
-
-// generationsTable is the kit-managed table holding one row per embedding
-// generation (ordinal, gen_key, fingerprint, dimension, state).
-const generationsTable = vectorsPrefix + "_generations"
-
-// stampsTable is the kit-managed table recording which documents are
-// embedded under which generation ordinal.
-const stampsTable = vectorsPrefix + "_stamps"
-
-// mirrorDDL creates agentsview's mirror of embeddable message content plus
-// a small key/value table for metadata kit's store does not track (the
+// messageMirrorDDL creates agentsview's mirror of embeddable message content
+// plus a small key/value table for metadata kit's store does not track (the
 // display model name for a generation). ordinal is the unit's first
 // (start) ordinal; ordinal_end is its last member's ordinal, equal to
 // ordinal for single-message (user) documents. subordinate and offsets
 // default to the "no run grouping yet" shape so a row inserted without
 // them (see mirror.go) is still valid.
-const mirrorDDL = `
+const messageMirrorDDL = `
 CREATE TABLE IF NOT EXISTS vector_messages (
     doc_key      TEXT PRIMARY KEY,
     session_id   TEXT NOT NULL,
@@ -70,23 +46,72 @@ CREATE TABLE IF NOT EXISTS vector_meta (
 );
 `
 
-// mirrorSchemaVersion is the current vectors.db mirror schema generation,
-// stamped into vector_meta under mirrorSchemaVersionKey. It covers both the
-// mirror's DDL shape (mirrorDDL's column set) AND its document-identity
-// scheme (what one vector_messages row means); bump it whenever either
-// changes in a way old rows cannot simply be read as-is. Open resets
-// vectors.db on the write path, and flags ErrMirrorVersionMismatch on the
-// read path, whenever the stamped value differs (or is absent while any
-// mirror state already exists).
+// mirrorSchemaVersionKey is the metadata-table key holding a spec's
+// MirrorSchemaVersion.
+const mirrorSchemaVersionKey = "mirror_schema_version"
+
+// IndexSpec binds an Index to one embedding store inside vectors.db. Every
+// table the Index touches derives from the spec — DocsTable and MetaTable
+// are the store's own tables, and every kit-managed table starts with
+// VectorsPrefix — so two stores can share one database file without reading
+// or resetting each other's state. Table names and prefixes of distinct
+// specs must not overlap: no spec's VectorsPrefix may be a prefix of
+// another spec's table names, since mirrorStateTableNames matches by these
+// names when a schema-version mismatch resets the store.
+type IndexSpec struct {
+	// Name identifies the store for CLI selection and display ("messages").
+	Name string
+	// DocsTable is the store's mirror documents table.
+	DocsTable string
+	// MetaTable is the store's own key/value metadata table (schema
+	// version, refresh watermark, scope, generation model names). Each
+	// store has its own so a reset of one store never clears another's
+	// metadata.
+	MetaTable string
+	// VectorsPrefix names the kit-managed bookkeeping tables
+	// (<prefix>_generations, _stamps, _chunks, _v<N>).
+	VectorsPrefix string
+	// MirrorDDL creates DocsTable, its indexes, and MetaTable
+	// (CREATE ... IF NOT EXISTS).
+	MirrorDDL string
+	// MirrorSchemaVersion versions the mirror's DDL shape and its
+	// document-identity scheme; see prepareMirrorSchema.
+	MirrorSchemaVersion string
+}
+
+func (s IndexSpec) schema() sqlitevec.Schema {
+	return sqlitevec.Schema{
+		DocsTable:      s.DocsTable,
+		IDColumn:       "doc_key",
+		ContentColumn:  "content",
+		EmbedGenColumn: "embed_gen",
+		RevisionColumn: "content_hash",
+		VectorsPrefix:  s.VectorsPrefix,
+	}
+}
+
+func (s IndexSpec) generationsTable() string { return s.VectorsPrefix + "_generations" }
+func (s IndexSpec) stampsTable() string      { return s.VectorsPrefix + "_stamps" }
+func (s IndexSpec) chunksTable() string      { return s.VectorsPrefix + "_chunks" }
+
+// MessageIndexSpec is the conversation-message embedding store. Its table
+// names, metadata keys, and schema version predate IndexSpec and must stay
+// byte-identical so existing vectors.db files open without a reset.
 //
 // History: "2" added the ordinal_end/subordinate/offsets columns but still
 // held one row per message; "3" switched document identity to run-grouped
 // units (one row per user message or per run of contiguous assistant
 // messages) with no DDL change.
-const mirrorSchemaVersion = "3"
-
-// mirrorSchemaVersionKey is the vector_meta key holding mirrorSchemaVersion.
-const mirrorSchemaVersionKey = "mirror_schema_version"
+func MessageIndexSpec() IndexSpec {
+	return IndexSpec{
+		Name:                "messages",
+		DocsTable:           "vector_messages",
+		MetaTable:           "vector_meta",
+		VectorsPrefix:       "message_vectors",
+		MirrorDDL:           messageMirrorDDL,
+		MirrorSchemaVersion: "3",
+	}
+}
 
 // ErrMirrorVersionMismatch reports a vectors.db written by a different
 // mirror schema version than this binary expects. Write-path Open calls
@@ -99,15 +124,16 @@ var ErrMirrorVersionMismatch = errors.New(
 
 // Index wraps vectors.db: agentsview's mirror of embeddable message content
 // plus kit's sqlitevec store, which owns the generation and vec0 tables
-// derived from vectorsPrefix.
+// derived from spec's VectorsPrefix.
 type Index struct {
 	db       *sql.DB
 	store    *sqlitevec.Store[string, string]
+	spec     IndexSpec
 	split    kitvec.SplitOptions
 	readOnly bool
 
 	// versionMismatch records a read-path Open's version-gate finding: the
-	// mirror was written by a different mirrorSchemaVersion. Write-path
+	// mirror was written by a different spec.MirrorSchemaVersion. Write-path
 	// Opens always resolve the mismatch themselves (reset and restamp), so
 	// this is only ever true on a read-only Index. Search checks it before
 	// touching any table.
@@ -115,7 +141,7 @@ type Index struct {
 }
 
 // GenerationInfo describes one embedding generation and its coverage of the
-// current vector_messages mirror, for CLI and status display.
+// current mirror, for CLI and status display.
 type GenerationInfo struct {
 	ID          int64  `json:"id"` // generations-table ordinal, CLI-facing
 	State       string `json:"state"`
@@ -135,14 +161,22 @@ func ChunkOverlap(maxInputChars int) int {
 	return maxInputChars * 15 / 100
 }
 
-// Open opens (creating when rw) vectors.db and the kit sqlitevec store atop
-// it. maxInputChars bounds the rune length of a single embedding request via
-// SplitOptions{MaxRunes: maxInputChars, Overlap: ChunkOverlap(maxInputChars)}.
-//
-// When readOnly is true the file must already exist; Open never creates or
-// migrates schema in that mode, matching internal/db.OpenReadOnly's
-// cold-CLI-read contract.
+// Open opens the message-store index; see OpenSpec.
 func Open(ctx context.Context, path string, readOnly bool, maxInputChars int) (*Index, error) {
+	return OpenSpec(ctx, path, MessageIndexSpec(), readOnly, maxInputChars)
+}
+
+// OpenSpec opens (creating when rw) vectors.db and the kit sqlitevec store
+// atop it, bound to spec's store. maxInputChars bounds the rune length of a
+// single embedding request via SplitOptions{MaxRunes: maxInputChars,
+// Overlap: ChunkOverlap(maxInputChars)}.
+//
+// When readOnly is true the file must already exist; OpenSpec never creates
+// or migrates schema in that mode, matching internal/db.OpenReadOnly's
+// cold-CLI-read contract.
+func OpenSpec(
+	ctx context.Context, path string, spec IndexSpec, readOnly bool, maxInputChars int,
+) (*Index, error) {
 	registerVecOnce.Do(sqlitevec.Register)
 
 	if readOnly {
@@ -162,13 +196,13 @@ func Open(ctx context.Context, path string, readOnly bool, maxInputChars int) (*
 		return nil, fmt.Errorf("opening vectors.db: %w", err)
 	}
 
-	versionMismatch, err := prepareMirrorSchema(ctx, db, readOnly)
+	versionMismatch, err := prepareMirrorSchema(ctx, db, spec, readOnly)
 	if err != nil {
 		db.Close()
 		return nil, err
 	}
 
-	store, err := sqlitevec.New[string, string](ctx, db, vectorSchema)
+	store, err := sqlitevec.New[string, string](ctx, db, spec.schema())
 	if err != nil {
 		db.Close()
 		return nil, fmt.Errorf("opening vector store: %w", err)
@@ -178,6 +212,7 @@ func Open(ctx context.Context, path string, readOnly bool, maxInputChars int) (*
 	return &Index{
 		db:              db,
 		store:           store,
+		spec:            spec,
 		split:           kitvec.SplitOptions{MaxRunes: maxInputChars, Overlap: overlap},
 		readOnly:        readOnly,
 		versionMismatch: versionMismatch,
@@ -185,7 +220,7 @@ func Open(ctx context.Context, path string, readOnly bool, maxInputChars int) (*
 }
 
 // prepareMirrorSchema checks vectors.db's stamped mirror_schema_version
-// against mirrorSchemaVersion and, on the write path, brings the schema
+// against spec.MirrorSchemaVersion and, on the write path, brings the schema
 // current. On a mismatch — including the version key being absent while any
 // mirror-state table already exists — the write path drops every such table
 // and recreates the current schema from scratch: vectors.db is disposable by
@@ -195,8 +230,8 @@ func Open(ctx context.Context, path string, readOnly bool, maxInputChars int) (*
 // any table, leaving stale rows exactly as they are; the caller (Search)
 // then fails closed with ErrMirrorVersionMismatch instead of risking a
 // misread of old-shaped rows.
-func prepareMirrorSchema(ctx context.Context, db *sql.DB, readOnly bool) (mismatch bool, err error) {
-	mismatch, tables, err := mirrorVersionMismatch(ctx, db)
+func prepareMirrorSchema(ctx context.Context, db *sql.DB, spec IndexSpec, readOnly bool) (mismatch bool, err error) {
+	mismatch, tables, err := mirrorVersionMismatch(ctx, db, spec)
 	if err != nil {
 		return false, err
 	}
@@ -209,10 +244,10 @@ func prepareMirrorSchema(ctx context.Context, db *sql.DB, readOnly bool) (mismat
 			return false, err
 		}
 	}
-	if _, err := db.ExecContext(ctx, mirrorDDL); err != nil {
+	if _, err := db.ExecContext(ctx, spec.MirrorDDL); err != nil {
 		return false, fmt.Errorf("creating vectors.db schema: %w", err)
 	}
-	if err := stampMirrorSchemaVersion(ctx, db); err != nil {
+	if err := stampMirrorSchemaVersion(ctx, db, spec); err != nil {
 		return false, err
 	}
 	return false, nil
@@ -220,15 +255,15 @@ func prepareMirrorSchema(ctx context.Context, db *sql.DB, readOnly bool) (mismat
 
 // mirrorStateTableNames lists the sqlite_master table names considered part
 // of the versioned mirror: the mirror's own tables, plus any kit-owned
-// message_vectors* table (the generations and stamps bookkeeping tables and
-// one vec0 table per embedding generation, including retired or abandoned
-// ones left behind by a prior build).
-func mirrorStateTableNames(ctx context.Context, db *sql.DB) ([]string, error) {
+// spec.VectorsPrefix* table (the generations and stamps bookkeeping tables
+// and one vec0 table per embedding generation, including retired or
+// abandoned ones left behind by a prior build).
+func mirrorStateTableNames(ctx context.Context, db *sql.DB, spec IndexSpec) ([]string, error) {
 	rows, err := db.QueryContext(ctx, `
 SELECT name FROM sqlite_master
  WHERE type = 'table'
-   AND (name IN ('vector_messages', 'vector_meta') OR name LIKE ?)`,
-		vectorsPrefix+"%")
+   AND (name IN (?, ?) OR name LIKE ?)`,
+		spec.DocsTable, spec.MetaTable, spec.VectorsPrefix+"%")
 	if err != nil {
 		return nil, fmt.Errorf("listing mirror tables: %w", err)
 	}
@@ -249,28 +284,28 @@ SELECT name FROM sqlite_master
 }
 
 // mirrorVersionMismatch reports whether vectors.db's stamped
-// mirror_schema_version differs from mirrorSchemaVersion. An empty/fresh
-// database (no mirror-state table at all) is never a mismatch — there is
-// nothing yet to be incompatible with. Otherwise, a version key that is
-// absent, or holds a different value, while any mirror-state table already
-// exists is a mismatch: that table predates versioning entirely, or was
-// stamped by a different scheme. tables is always returned so a write-path
-// caller can drop exactly the set that was inspected.
-func mirrorVersionMismatch(ctx context.Context, db *sql.DB) (mismatch bool, tables []string, err error) {
-	tables, err = mirrorStateTableNames(ctx, db)
+// mirror_schema_version differs from spec.MirrorSchemaVersion. An
+// empty/fresh database (no mirror-state table at all) is never a mismatch —
+// there is nothing yet to be incompatible with. Otherwise, a version key
+// that is absent, or holds a different value, while any mirror-state table
+// already exists is a mismatch: that table predates versioning entirely, or
+// was stamped by a different scheme. tables is always returned so a
+// write-path caller can drop exactly the set that was inspected.
+func mirrorVersionMismatch(ctx context.Context, db *sql.DB, spec IndexSpec) (mismatch bool, tables []string, err error) {
+	tables, err = mirrorStateTableNames(ctx, db, spec)
 	if err != nil {
 		return false, nil, err
 	}
 	if len(tables) == 0 {
 		return false, tables, nil
 	}
-	if !slices.Contains(tables, "vector_meta") {
+	if !slices.Contains(tables, spec.MetaTable) {
 		return true, tables, nil
 	}
 
 	var stamped string
 	err = db.QueryRowContext(ctx,
-		`SELECT value FROM vector_meta WHERE key = ?`, mirrorSchemaVersionKey,
+		`SELECT value FROM `+spec.MetaTable+` WHERE key = ?`, mirrorSchemaVersionKey,
 	).Scan(&stamped)
 	if err == sql.ErrNoRows {
 		return true, tables, nil
@@ -278,11 +313,11 @@ func mirrorVersionMismatch(ctx context.Context, db *sql.DB) (mismatch bool, tabl
 	if err != nil {
 		return false, nil, fmt.Errorf("reading mirror schema version: %w", err)
 	}
-	return stamped != mirrorSchemaVersion, tables, nil
+	return stamped != spec.MirrorSchemaVersion, tables, nil
 }
 
 // dropMirrorTables drops every named table, resetting vectors.db's mirror
-// state ahead of a fresh mirrorDDL + stampMirrorSchemaVersion. Table names
+// state ahead of a fresh MirrorDDL + stampMirrorSchemaVersion. Table names
 // come from sqlite_master (mirrorStateTableNames), not caller input, so
 // building the DROP statement by concatenation is safe; SQL does not allow
 // binding identifiers as query parameters.
@@ -295,13 +330,13 @@ func dropMirrorTables(ctx context.Context, db *sql.DB, tables []string) error {
 	return nil
 }
 
-// stampMirrorSchemaVersion records mirrorSchemaVersion into vector_meta,
-// overwriting any prior value.
-func stampMirrorSchemaVersion(ctx context.Context, db *sql.DB) error {
+// stampMirrorSchemaVersion records spec.MirrorSchemaVersion into
+// spec.MetaTable, overwriting any prior value.
+func stampMirrorSchemaVersion(ctx context.Context, db *sql.DB, spec IndexSpec) error {
 	if _, err := db.ExecContext(ctx, `
-INSERT INTO vector_meta (key, value) VALUES (?, ?)
+INSERT INTO `+spec.MetaTable+` (key, value) VALUES (?, ?)
 ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
-		mirrorSchemaVersionKey, mirrorSchemaVersion,
+		mirrorSchemaVersionKey, spec.MirrorSchemaVersion,
 	); err != nil {
 		return fmt.Errorf("stamping mirror schema version: %w", err)
 	}
@@ -322,11 +357,39 @@ func (ix *Index) requireWritable() error {
 	return nil
 }
 
+// metaGet reads one key from the spec's metadata table; ok is false when
+// the key is absent.
+func (ix *Index) metaGet(ctx context.Context, key string) (value string, ok bool, err error) {
+	err = ix.db.QueryRowContext(ctx,
+		`SELECT value FROM `+ix.spec.MetaTable+` WHERE key = ?`, key,
+	).Scan(&value)
+	if err == sql.ErrNoRows {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("reading %s key %s: %w", ix.spec.MetaTable, key, err)
+	}
+	return value, true, nil
+}
+
+// metaSet upserts one key into the spec's metadata table.
+func (ix *Index) metaSet(ctx context.Context, key, value string) error {
+	if _, err := ix.db.ExecContext(ctx, `
+INSERT INTO `+ix.spec.MetaTable+` (key, value) VALUES (?, ?)
+ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+		key, value,
+	); err != nil {
+		return fmt.Errorf("writing %s key %s: %w", ix.spec.MetaTable, key, err)
+	}
+	return nil
+}
+
 // EnsureGeneration registers gen (a model + dimension configuration) with
 // kit's store under its own fingerprint as the gen_key, creating its vec0
-// table on first use, and records the model's display name in vector_meta
-// so Generations can show it (kit's store persists only the fingerprint).
-// Calling it again for the same fingerprint updates only the state.
+// table on first use, and records the model's display name in the spec's
+// metadata table so Generations can show it (kit's store persists only the
+// fingerprint). Calling it again for the same fingerprint updates only the
+// state.
 func (ix *Index) EnsureGeneration(
 	ctx context.Context, gen kitvec.Generation, state sqlitevec.State,
 ) (string, error) {
@@ -337,10 +400,7 @@ func (ix *Index) EnsureGeneration(
 	if err := ix.store.EnsureGeneration(ctx, fingerprint, gen, state); err != nil {
 		return "", fmt.Errorf("ensure generation: %w", err)
 	}
-	if _, err := ix.db.ExecContext(ctx, `
-INSERT INTO vector_meta (key, value) VALUES (?, ?)
-ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
-		"gen_model:"+fingerprint, gen.Model); err != nil {
+	if err := ix.metaSet(ctx, "gen_model:"+fingerprint, gen.Model); err != nil {
 		return "", fmt.Errorf("record generation model: %w", err)
 	}
 	return fingerprint, nil
@@ -353,7 +413,7 @@ func (ix *Index) SetStateByID(ctx context.Context, id int64, state sqlitevec.Sta
 		return err
 	}
 	res, err := ix.db.ExecContext(ctx,
-		`UPDATE `+generationsTable+` SET state = ? WHERE ordinal = ?`, string(state), id)
+		`UPDATE `+ix.spec.generationsTable()+` SET state = ? WHERE ordinal = ?`, string(state), id)
 	if err != nil {
 		return fmt.Errorf("set generation state: %w", err)
 	}
@@ -380,7 +440,7 @@ func (ix *Index) BuildingFingerprint(ctx context.Context) (string, bool, error) 
 func (ix *Index) fingerprintByState(ctx context.Context, state string) (string, bool, error) {
 	var fingerprint string
 	err := ix.db.QueryRowContext(ctx,
-		`SELECT gen_key FROM `+generationsTable+` WHERE state = ? ORDER BY ordinal LIMIT 1`,
+		`SELECT gen_key FROM `+ix.spec.generationsTable()+` WHERE state = ? ORDER BY ordinal LIMIT 1`,
 		state).Scan(&fingerprint)
 	if err == sql.ErrNoRows {
 		return "", false, nil
@@ -392,33 +452,34 @@ func (ix *Index) fingerprintByState(ctx context.Context, state string) (string, 
 }
 
 // generationCoverageQuery is the exact join agentsview uses to report each
-// generation's coverage of the current vector_messages mirror: Embedded
-// counts stamps for that generation ordinal whose revision still matches
-// the mirror row's current content_hash, Missing counts mirror documents
-// with no such matching-revision stamp. A stamp whose revision no longer
-// matches (the mirror row's content changed since it was embedded) counts
-// as Missing rather than Embedded, since kit's store treats it as pending
-// re-embed.
-const generationCoverageQuery = `
+// generation's coverage of the current mirror: Embedded counts stamps for
+// that generation ordinal whose revision still matches the mirror row's
+// current content_hash, Missing counts mirror documents with no such
+// matching-revision stamp. A stamp whose revision no longer matches (the
+// mirror row's content changed since it was embedded) counts as Missing
+// rather than Embedded, since kit's store treats it as pending re-embed.
+func (ix *Index) generationCoverageQuery() string {
+	return `
 SELECT g.ordinal, g.gen_key, g.fingerprint, g.dimension, g.state,
-       (SELECT COUNT(*) FROM ` + stampsTable + ` s WHERE s.ordinal = g.ordinal
-          AND EXISTS (SELECT 1 FROM vector_messages d
+       (SELECT COUNT(*) FROM ` + ix.spec.stampsTable() + ` s WHERE s.ordinal = g.ordinal
+          AND EXISTS (SELECT 1 FROM ` + ix.spec.DocsTable + ` d
                       WHERE s.doc_key = d.doc_key AND s.revision = d.content_hash)),
-       (SELECT COUNT(*) FROM vector_messages d WHERE NOT EXISTS
-          (SELECT 1 FROM ` + stampsTable + ` s
+       (SELECT COUNT(*) FROM ` + ix.spec.DocsTable + ` d WHERE NOT EXISTS
+          (SELECT 1 FROM ` + ix.spec.stampsTable() + ` s
            WHERE s.ordinal = g.ordinal AND s.doc_key = d.doc_key AND s.revision = d.content_hash))
-FROM ` + generationsTable + ` g`
+FROM ` + ix.spec.generationsTable() + ` g`
+}
 
 // Generations returns every generation with its coverage counts against the
-// current vector_messages mirror, ordered by ordinal. Like Search and
-// StaleActive it fails closed with ErrMirrorVersionMismatch on a read-only
-// Index over a mismatched mirror, rather than reporting coverage counts
-// computed over stale-shape rows.
+// current mirror, ordered by ordinal. Like Search and StaleActive it fails
+// closed with ErrMirrorVersionMismatch on a read-only Index over a
+// mismatched mirror, rather than reporting coverage counts computed over
+// stale-shape rows.
 func (ix *Index) Generations(ctx context.Context) ([]GenerationInfo, error) {
 	if ix.versionMismatch {
 		return nil, ErrMirrorVersionMismatch
 	}
-	rows, err := ix.db.QueryContext(ctx, generationCoverageQuery+` ORDER BY g.ordinal`)
+	rows, err := ix.db.QueryContext(ctx, ix.generationCoverageQuery()+` ORDER BY g.ordinal`)
 	if err != nil {
 		return nil, fmt.Errorf("list generations: %w", err)
 	}
@@ -447,7 +508,7 @@ var ErrGenerationNotFound = errors.New("generation not found")
 // GenerationByID returns the single generation identified by its
 // generations-table ordinal.
 func (ix *Index) GenerationByID(ctx context.Context, id int64) (GenerationInfo, error) {
-	row := ix.db.QueryRowContext(ctx, generationCoverageQuery+` WHERE g.ordinal = ?`, id)
+	row := ix.db.QueryRowContext(ctx, ix.generationCoverageQuery()+` WHERE g.ordinal = ?`, id)
 	info, err := ix.scanGenerationInfo(ctx, row)
 	if err == sql.ErrNoRows {
 		return GenerationInfo{}, fmt.Errorf("generation %d: %w", id, ErrGenerationNotFound)
@@ -479,12 +540,10 @@ func (ix *Index) scanGenerationInfo(ctx context.Context, src genInfoScanner) (Ge
 		return GenerationInfo{}, fmt.Errorf("scan generation: %w", err)
 	}
 
-	var model sql.NullString
-	err := ix.db.QueryRowContext(ctx,
-		`SELECT value FROM vector_meta WHERE key = ?`, "gen_model:"+info.Fingerprint).Scan(&model)
-	if err != nil && err != sql.ErrNoRows {
+	model, _, err := ix.metaGet(ctx, "gen_model:"+info.Fingerprint)
+	if err != nil {
 		return GenerationInfo{}, fmt.Errorf("lookup generation model: %w", err)
 	}
-	info.Model = model.String
+	info.Model = model
 	return info, nil
 }

--- a/internal/vector/index_test.go
+++ b/internal/vector/index_test.go
@@ -311,16 +311,17 @@ INSERT INTO vector_meta (key, value) VALUES (?, ?), (?, ?)`,
 		refreshWatermarkKey, "2024-01-01T00:00:00Z",
 		scopeIncludeAutomatedKey, "true")
 	require.NoError(t, err)
-	_, err = raw.ExecContext(ctx, `CREATE TABLE `+generationsTable+` (ordinal INTEGER)`)
+	spec := MessageIndexSpec()
+	_, err = raw.ExecContext(ctx, `CREATE TABLE `+spec.generationsTable()+` (ordinal INTEGER)`)
 	require.NoError(t, err)
 	// Kit's other bookkeeping tables and indexes, by their real names so a
 	// read-only Open's CREATE ... IF NOT EXISTS statements all no-op.
 	_, err = raw.ExecContext(ctx, `
-CREATE TABLE `+chunksTable+` (ordinal INTEGER, doc_key, vec_rowid INTEGER);
-CREATE INDEX `+vectorsPrefix+`_chunks_by_vector ON `+chunksTable+` (ordinal, vec_rowid);
-CREATE INDEX `+vectorsPrefix+`_chunks_by_doc ON `+chunksTable+` (doc_key, ordinal, vec_rowid);
-CREATE TABLE `+stampsTable+` (ordinal INTEGER, doc_key, revision);
-CREATE INDEX `+vectorsPrefix+`_stamps_by_doc_revision ON `+stampsTable+` (doc_key, revision);`)
+CREATE TABLE `+spec.chunksTable()+` (ordinal INTEGER, doc_key, vec_rowid INTEGER);
+CREATE INDEX `+spec.VectorsPrefix+`_chunks_by_vector ON `+spec.chunksTable()+` (ordinal, vec_rowid);
+CREATE INDEX `+spec.VectorsPrefix+`_chunks_by_doc ON `+spec.chunksTable()+` (doc_key, ordinal, vec_rowid);
+CREATE TABLE `+spec.stampsTable()+` (ordinal INTEGER, doc_key, revision);
+CREATE INDEX `+spec.VectorsPrefix+`_stamps_by_doc_revision ON `+spec.stampsTable()+` (doc_key, revision);`)
 	require.NoError(t, err)
 	_, err = raw.ExecContext(ctx, `CREATE TABLE message_vectors_gen7 (id INTEGER)`)
 	require.NoError(t, err)
@@ -368,7 +369,7 @@ func TestMirrorSchemaVersionFreshDBStampsVersionNothingDropped(t *testing.T) {
 	require.NoError(t, ix.db.QueryRowContext(ctx,
 		`SELECT value FROM vector_meta WHERE key = ?`, mirrorSchemaVersionKey,
 	).Scan(&version))
-	assert.Equal(t, mirrorSchemaVersion, version)
+	assert.Equal(t, MessageIndexSpec().MirrorSchemaVersion, version)
 
 	var metaCount int
 	require.NoError(t, ix.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM vector_meta`).Scan(&metaCount))
@@ -447,7 +448,7 @@ VALUES (?, ?, ?, ?, ?, ?)`,
 	require.NoError(t, ix.db.QueryRowContext(ctx,
 		`SELECT value FROM vector_meta WHERE key = ?`, mirrorSchemaVersionKey,
 	).Scan(&version))
-	assert.Equal(t, mirrorSchemaVersion, version)
+	assert.Equal(t, MessageIndexSpec().MirrorSchemaVersion, version)
 
 	err = ix.db.QueryRowContext(ctx,
 		`SELECT name FROM sqlite_master WHERE name = 'message_vectors_gen7'`).Scan(new(string))
@@ -455,7 +456,7 @@ VALUES (?, ?, ?, ?, ?, ?)`,
 
 	var genCount int
 	require.NoError(t, ix.db.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM `+generationsTable).Scan(&genCount))
+		`SELECT COUNT(*) FROM `+MessageIndexSpec().generationsTable()).Scan(&genCount))
 	assert.Zero(t, genCount, "kit must have recreated its generations table fresh, not kept the fake row")
 }
 
@@ -482,7 +483,7 @@ func TestMirrorSchemaVersionV2StampResetsWritePath(t *testing.T) {
 	require.NoError(t, ix.db.QueryRowContext(ctx,
 		`SELECT value FROM vector_meta WHERE key = ?`, mirrorSchemaVersionKey,
 	).Scan(&version))
-	assert.Equal(t, mirrorSchemaVersion, version)
+	assert.Equal(t, MessageIndexSpec().MirrorSchemaVersion, version)
 }
 
 // TestMirrorSchemaVersionV2StampReadOnlyReturnsSentinel covers the read path

--- a/internal/vector/mirror.go
+++ b/internal/vector/mirror.go
@@ -13,12 +13,12 @@ import (
 	"go.kenn.io/agentsview/internal/db"
 )
 
-// refreshWatermarkKey is the vector_meta key holding the RFC3339 ended_at
-// high-water mark of the most recent Refresh scan, used to restrict the
-// next incremental (full=false) scan to newer sessions.
+// refreshWatermarkKey is the metadata-table key holding the RFC3339
+// ended_at high-water mark of the most recent Refresh scan, used to
+// restrict the next incremental (full=false) scan to newer sessions.
 const refreshWatermarkKey = "refresh_watermark"
 
-// scopeIncludeAutomatedKey is the vector_meta key holding the
+// scopeIncludeAutomatedKey is the metadata-table key holding the
 // include-automated scope ("true"/"false") the mirror was last refreshed
 // under. Build compares it against the requested scope on every call: the
 // scope is part of the mirror's identity, not the embedding fingerprint, so
@@ -144,12 +144,12 @@ func contentHash(content string) string {
 	return hex.EncodeToString(sum[:])
 }
 
-// Refresh reconciles the vector_messages mirror against src. full=true
-// scans the entire archive (since="") and additionally deletes mirror rows
-// (and their vectors, via store.DeleteVectors) whose identity was not seen
-// in the scan; full=false scans only sessions newer than the stored
-// watermark (vector_meta key "refresh_watermark") and only upserts,
-// leaving that reconciliation to a subsequent full refresh. includeAutomated
+// Refresh reconciles the mirror against src. full=true scans the entire
+// archive (since="") and additionally deletes mirror rows (and their
+// vectors, via store.DeleteVectors) whose identity was not seen in the
+// scan; full=false scans only sessions newer than the stored watermark
+// (metadata-table key "refresh_watermark") and only upserts, leaving that
+// reconciliation to a subsequent full refresh. includeAutomated
 // is passed through to src.ScanEmbeddableUnits: false excludes automated
 // sessions from the scan entirely, so their mirror rows are absent (and, in
 // full mode, reconciled away) rather than merely unembedded. Either mode
@@ -215,7 +215,7 @@ func (ix *Index) Refresh(
 	// seen too, so reconcileDeletions would otherwise also treat its (still
 	// present, sentinel-parked) row as a vanished identity and delete it a
 	// second time. Resolving evictions first means the row is gone by the
-	// time reconcileDeletions scans vector_messages, so it is never counted
+	// time reconcileDeletions scans the mirror, so it is never counted
 	// there. finalizeEvictions also guards against re-deleting an
 	// already-absent key on its own (see its doc comment), so this ordering
 	// and that guard together make Refresh's accounting robust regardless
@@ -260,7 +260,7 @@ func (ix *Index) upsertMirrorRow(
 
 	var existingHash sql.NullString
 	err = ix.db.QueryRowContext(ctx,
-		`SELECT content_hash FROM vector_messages WHERE doc_key = ?`, key,
+		`SELECT content_hash FROM `+ix.spec.DocsTable+` WHERE doc_key = ?`, key,
 	).Scan(&existingHash)
 	if err != nil && err != sql.ErrNoRows {
 		return false, evicted, fmt.Errorf("reading existing content hash: %w", err)
@@ -275,7 +275,7 @@ func (ix *Index) upsertMirrorRow(
 	}
 
 	if _, err := ix.db.ExecContext(ctx, `
-INSERT INTO vector_messages (doc_key, session_id, source_uuid, ordinal, ordinal_end,
+INSERT INTO `+ix.spec.DocsTable+` (doc_key, session_id, source_uuid, ordinal, ordinal_end,
     subordinate, offsets, content, content_hash)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(doc_key) DO UPDATE SET
@@ -341,7 +341,7 @@ func marshalOffsets(offsets []db.UnitOffset) (string, error) {
 func (ix *Index) parkingFloor(ctx context.Context) (int, error) {
 	var floor sql.NullInt64
 	if err := ix.db.QueryRowContext(ctx,
-		`SELECT MIN(ordinal) FROM vector_messages WHERE ordinal < 0`,
+		`SELECT MIN(ordinal) FROM `+ix.spec.DocsTable+` WHERE ordinal < 0`,
 	).Scan(&floor); err != nil {
 		return 0, fmt.Errorf("reading parked-ordinal floor: %w", err)
 	}
@@ -355,7 +355,7 @@ func (ix *Index) evictSlotOccupant(
 	ctx context.Context, key, sessionID string, ordinal int, sentinel *int,
 ) ([]string, error) {
 	rows, err := ix.db.QueryContext(ctx,
-		`SELECT doc_key FROM vector_messages
+		`SELECT doc_key FROM `+ix.spec.DocsTable+`
 		 WHERE session_id = ? AND ordinal = ? AND doc_key != ?`,
 		sessionID, ordinal, key)
 	if err != nil {
@@ -379,7 +379,7 @@ func (ix *Index) evictSlotOccupant(
 	for _, k := range evictKeys {
 		*sentinel--
 		if _, err := ix.db.ExecContext(ctx,
-			`UPDATE vector_messages SET ordinal = ? WHERE doc_key = ?`, *sentinel, k,
+			`UPDATE `+ix.spec.DocsTable+` SET ordinal = ? WHERE doc_key = ?`, *sentinel, k,
 		); err != nil {
 			return nil, fmt.Errorf("evicting slot occupant %s: %w", k, err)
 		}
@@ -399,7 +399,7 @@ func (ix *Index) evictSlotOccupant(
 // in the same scan — it merely shifted position and keeps its row and
 // embeddings untouched.
 //
-// A key already absent from vector_messages entirely (ok is false below) is
+// A key already absent from the mirror entirely (ok is false below) is
 // skipped rather than deleted again: Refresh runs finalizeEvictions before
 // full-mode reconcileDeletions specifically so this case shouldn't arise
 // within one call, but the guard makes the accounting correct regardless of
@@ -432,7 +432,7 @@ func (ix *Index) finalizeEvictions(ctx context.Context, evicted map[string]struc
 			return deleted, fmt.Errorf("deleting evicted vectors for %s: %w", key, err)
 		}
 		if _, err := ix.db.ExecContext(ctx,
-			`DELETE FROM vector_messages WHERE doc_key = ?`, key,
+			`DELETE FROM `+ix.spec.DocsTable+` WHERE doc_key = ?`, key,
 		); err != nil {
 			return deleted, fmt.Errorf("deleting evicted mirror row %s: %w", key, err)
 		}
@@ -442,7 +442,7 @@ func (ix *Index) finalizeEvictions(ctx context.Context, evicted map[string]struc
 }
 
 // currentOrdinals returns the current ordinal of each of keys that is still
-// present in vector_messages; a key absent from the result was somehow
+// present in the mirror; a key absent from the result was somehow
 // already removed from the mirror. keys is queried in maxSQLVars-sized
 // chunks: a large eviction batch in a single Refresh scan can otherwise
 // exceed SQLite's bind-variable limit.
@@ -451,7 +451,7 @@ func (ix *Index) currentOrdinals(ctx context.Context, keys []string) (map[string
 	err := chunkKeys(keys, func(chunk []string) error {
 		placeholders, args := inPlaceholders(chunk)
 		rows, err := ix.db.QueryContext(ctx,
-			`SELECT doc_key, ordinal FROM vector_messages WHERE doc_key IN `+placeholders, args...)
+			`SELECT doc_key, ordinal FROM `+ix.spec.DocsTable+` WHERE doc_key IN `+placeholders, args...)
 		if err != nil {
 			return fmt.Errorf("checking evicted doc_key ordinals: %w", err)
 		}
@@ -481,7 +481,7 @@ func (ix *Index) currentOrdinals(ctx context.Context, keys []string) (map[string
 func (ix *Index) reconcileDeletions(
 	ctx context.Context, seen map[string]struct{},
 ) (int, error) {
-	rows, err := ix.db.QueryContext(ctx, `SELECT doc_key FROM vector_messages`)
+	rows, err := ix.db.QueryContext(ctx, `SELECT doc_key FROM `+ix.spec.DocsTable)
 	if err != nil {
 		return 0, fmt.Errorf("listing mirror doc_keys: %w", err)
 	}
@@ -507,7 +507,7 @@ func (ix *Index) reconcileDeletions(
 			return 0, fmt.Errorf("deleting vectors for %s: %w", key, err)
 		}
 		if _, err := ix.db.ExecContext(ctx,
-			`DELETE FROM vector_messages WHERE doc_key = ?`, key,
+			`DELETE FROM `+ix.spec.DocsTable+` WHERE doc_key = ?`, key,
 		); err != nil {
 			return 0, fmt.Errorf("deleting mirror row %s: %w", key, err)
 		}
@@ -518,44 +518,25 @@ func (ix *Index) reconcileDeletions(
 // refreshWatermark reads the stored refresh watermark, returning "" when
 // none has been recorded yet.
 func (ix *Index) refreshWatermark(ctx context.Context) (string, error) {
-	var value string
-	err := ix.db.QueryRowContext(ctx,
-		`SELECT value FROM vector_meta WHERE key = ?`, refreshWatermarkKey,
-	).Scan(&value)
-	if err == sql.ErrNoRows {
-		return "", nil
-	}
-	if err != nil {
-		return "", fmt.Errorf("reading refresh watermark: %w", err)
-	}
-	return value, nil
+	value, _, err := ix.metaGet(ctx, refreshWatermarkKey)
+	return value, err
 }
 
 // setRefreshWatermark advances the stored refresh watermark to value.
 func (ix *Index) setRefreshWatermark(ctx context.Context, value string) error {
-	if _, err := ix.db.ExecContext(ctx, `
-INSERT INTO vector_meta (key, value) VALUES (?, ?)
-ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
-		refreshWatermarkKey, value,
-	); err != nil {
-		return fmt.Errorf("advancing refresh watermark: %w", err)
-	}
-	return nil
+	return ix.metaSet(ctx, refreshWatermarkKey, value)
 }
 
 // storedIncludeAutomatedScope reads the include-automated scope the mirror
 // was last refreshed under. ok is false when no scope has ever been stored
 // (the mirror's first build), in which case value is meaningless.
 func (ix *Index) storedIncludeAutomatedScope(ctx context.Context) (value, ok bool, err error) {
-	var raw string
-	err = ix.db.QueryRowContext(ctx,
-		`SELECT value FROM vector_meta WHERE key = ?`, scopeIncludeAutomatedKey,
-	).Scan(&raw)
-	if err == sql.ErrNoRows {
-		return false, false, nil
-	}
+	raw, ok, err := ix.metaGet(ctx, scopeIncludeAutomatedKey)
 	if err != nil {
 		return false, false, fmt.Errorf("reading stored include-automated scope: %w", err)
+	}
+	if !ok {
+		return false, false, nil
 	}
 	parsed, err := strconv.ParseBool(raw)
 	if err != nil {
@@ -567,12 +548,5 @@ func (ix *Index) storedIncludeAutomatedScope(ctx context.Context) (value, ok boo
 // setIncludeAutomatedScope records value as the include-automated scope the
 // mirror was most recently refreshed under.
 func (ix *Index) setIncludeAutomatedScope(ctx context.Context, value bool) error {
-	if _, err := ix.db.ExecContext(ctx, `
-INSERT INTO vector_meta (key, value) VALUES (?, ?)
-ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
-		scopeIncludeAutomatedKey, strconv.FormatBool(value),
-	); err != nil {
-		return fmt.Errorf("storing include-automated scope: %w", err)
-	}
-	return nil
+	return ix.metaSet(ctx, scopeIncludeAutomatedKey, strconv.FormatBool(value))
 }

--- a/internal/vector/search.go
+++ b/internal/vector/search.go
@@ -40,7 +40,7 @@ var ErrNoActiveGeneration = errors.New("no active embedding generation")
 // generation is queryable yet.
 type BuildingError struct {
 	// Percent is the building generation's coverage of the current
-	// vector_messages mirror, 0-100.
+	// mirror, 0-100.
 	Percent int
 }
 
@@ -139,9 +139,8 @@ func (ix *Index) noActiveGenerationError(ctx context.Context) error {
 	return &BuildingError{Percent: percent}
 }
 
-// buildingPercent reports fingerprint's coverage of the current
-// vector_messages mirror as a 0-100 percentage, guarding the
-// divide-by-zero case of an empty mirror.
+// buildingPercent reports fingerprint's coverage of the current mirror as a
+// 0-100 percentage, guarding the divide-by-zero case of an empty mirror.
 func (ix *Index) buildingPercent(ctx context.Context, fingerprint string) (int, error) {
 	ordinal, err := ix.ordinalForFingerprint(ctx, fingerprint)
 	if err != nil {
@@ -158,8 +157,8 @@ func (ix *Index) buildingPercent(ctx context.Context, fingerprint string) (int, 
 	return int(info.Embedded * 100 / total), nil
 }
 
-// mirrorDoc is the subset of a vector_messages row Search needs to hydrate a
-// kit hit into an agentsview Hit. offsets is empty for user documents.
+// mirrorDoc is the subset of a mirror row Search needs to hydrate a kit hit
+// into an agentsview Hit. offsets is empty for user documents.
 type mirrorDoc struct {
 	sessionID   string
 	ordinal     int
@@ -295,7 +294,7 @@ func anchorMemberIndex(offsets []db.UnitOffset, start, end int) int {
 }
 
 // lookupMirrorDocs reads each of docKeys' mirror rows (session_id, ordinal
-// range, subordinate flag, member offsets, content) from vector_messages,
+// range, subordinate flag, member offsets, content) from the mirror table,
 // keyed by doc_key, in maxSQLVars-sized chunks: a deep semantic overfetch
 // (large limit * over-fetch factor) can carry thousands of doc keys, well
 // past what a single IN (...) clause can bind. A key with no matching row is
@@ -308,7 +307,7 @@ func (ix *Index) lookupMirrorDocs(ctx context.Context, docKeys []string) (map[st
 		placeholders, args := inPlaceholders(chunk)
 		rows, err := ix.db.QueryContext(ctx, `
 SELECT doc_key, session_id, ordinal, ordinal_end, subordinate, offsets, content
-  FROM vector_messages
+  FROM `+ix.spec.DocsTable+`
  WHERE ordinal >= 0 AND doc_key IN `+placeholders, args...)
 		if err != nil {
 			return fmt.Errorf("look up search hit documents: %w", err)
@@ -363,8 +362,8 @@ func truncateRunes(s string, maxRunes int) string {
 	return string(runes[:maxRunes]) + "…"
 }
 
-// ResolveMessageUnits maps each ref to the vector_messages unit containing
-// it, returning a slice parallel to refs; a ref with no containing unit (its
+// ResolveMessageUnits maps each ref to the mirror unit containing it,
+// returning a slice parallel to refs; a ref with no containing unit (its
 // message lies outside the embeddable universe, or in a gap between units)
 // yields a zero UnitRef. Each ref is a point lookup on the retained unique
 // (session_id, ordinal) index — greatest unit ordinal <= ref ordinal, then a
@@ -390,7 +389,7 @@ func (ix *Index) ResolveMessageUnits(
 
 	stmt, err := ix.db.PrepareContext(ctx, `
 SELECT doc_key, ordinal, ordinal_end, subordinate
-  FROM vector_messages
+  FROM `+ix.spec.DocsTable+`
  WHERE session_id = ? AND ordinal >= 0 AND ordinal <= ?
  ORDER BY ordinal DESC LIMIT 1`)
 	if err != nil {

--- a/internal/vector/spec_test.go
+++ b/internal/vector/spec_test.go
@@ -105,6 +105,31 @@ func TestSpecResetLeavesOtherStoreIntact(t *testing.T) {
 	assert.Equal(t, "model-aux", auxGens[0].Model)
 }
 
+// The reset's prefix match must be literal, not LIKE: "_" in a prefix such
+// as "message_vectors" is a single-character LIKE wildcard, so a wildcard
+// match would drop a table like "messageXvectors_generations" (X at the
+// wildcard position) that belongs to no store owned by the spec.
+func TestSpecResetPrefixMatchIsLiteral(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vectors.db")
+	ctx := context.Background()
+
+	msg := openSpecT(t, path, MessageIndexSpec(), false)
+	_, err := msg.db.ExecContext(ctx,
+		`CREATE TABLE "messageXvectors_generations" (id INTEGER PRIMARY KEY)`)
+	require.NoError(t, err)
+	require.NoError(t, msg.Close())
+
+	stale := MessageIndexSpec()
+	stale.MirrorSchemaVersion = "999"
+	msg = openSpecT(t, path, stale, false)
+
+	var n int
+	require.NoError(t, msg.db.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM sqlite_master
+ WHERE type = 'table' AND name = 'messageXvectors_generations'`).Scan(&n))
+	assert.Equal(t, 1, n, "wildcard-position decoy table must survive a message-store reset")
+}
+
 // The read path fails closed per store: a version mismatch on one store
 // must not affect reads on the other.
 func TestSpecReadPathMismatchIsPerStore(t *testing.T) {

--- a/internal/vector/spec_test.go
+++ b/internal/vector/spec_test.go
@@ -1,0 +1,130 @@
+package vector
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	kitvec "go.kenn.io/kit/vector"
+	"go.kenn.io/kit/vector/sqlitevec"
+)
+
+// auxSpec is a second, minimal store used to prove two IndexSpecs can share
+// one vectors.db without touching each other's state.
+func auxSpec() IndexSpec {
+	return IndexSpec{
+		Name:          "aux",
+		DocsTable:     "vector_aux_docs",
+		MetaTable:     "vector_aux_meta",
+		VectorsPrefix: "aux_vectors",
+		MirrorDDL: `
+CREATE TABLE IF NOT EXISTS vector_aux_docs (
+    doc_key      TEXT PRIMARY KEY,
+    content      TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    embed_gen    TEXT
+);
+CREATE TABLE IF NOT EXISTS vector_aux_meta (
+    key TEXT PRIMARY KEY, value TEXT NOT NULL
+);
+`,
+		MirrorSchemaVersion: "1",
+	}
+}
+
+func openSpecT(t *testing.T, path string, spec IndexSpec, readOnly bool) *Index {
+	t.Helper()
+	ix, err := OpenSpec(context.Background(), path, spec, readOnly, 8192)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ix.Close() })
+	return ix
+}
+
+func testGen(model string) kitvec.Generation {
+	return kitvec.Generation{Model: model, Dimensions: 4, Params: map[string]string{"p": "1"}}
+}
+
+// Two stores in one vectors.db: generations and metadata stay disjoint.
+func TestSpecCoexistenceGenerationsAndMetaAreDisjoint(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vectors.db")
+	ctx := context.Background()
+
+	msg := openSpecT(t, path, MessageIndexSpec(), false)
+	aux := openSpecT(t, path, auxSpec(), false)
+
+	_, err := msg.EnsureGeneration(ctx, testGen("model-msg"), sqlitevec.StateActive)
+	require.NoError(t, err)
+	_, err = aux.EnsureGeneration(ctx, testGen("model-aux"), sqlitevec.StateActive)
+	require.NoError(t, err)
+
+	msgGens, err := msg.Generations(ctx)
+	require.NoError(t, err)
+	auxGens, err := aux.Generations(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, msgGens, 1)
+	require.Len(t, auxGens, 1)
+	assert.Equal(t, "model-msg", msgGens[0].Model)
+	assert.Equal(t, "model-aux", auxGens[0].Model)
+
+	// gen_model metadata landed in each store's own meta table.
+	_, ok, err := aux.metaGet(ctx, "gen_model:"+msgGens[0].Fingerprint)
+	require.NoError(t, err)
+	assert.False(t, ok, "message-store gen_model key leaked into aux meta table")
+}
+
+// A schema-version reset of one store must leave the other store's tables,
+// metadata, and generations intact.
+func TestSpecResetLeavesOtherStoreIntact(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vectors.db")
+	ctx := context.Background()
+
+	msg := openSpecT(t, path, MessageIndexSpec(), false)
+	aux := openSpecT(t, path, auxSpec(), false)
+	_, err := msg.EnsureGeneration(ctx, testGen("model-msg"), sqlitevec.StateActive)
+	require.NoError(t, err)
+	_, err = aux.EnsureGeneration(ctx, testGen("model-aux"), sqlitevec.StateActive)
+	require.NoError(t, err)
+	require.NoError(t, msg.Close())
+
+	// Re-open the message store as if built by an older schema version:
+	// the write path must drop and recreate ONLY message-store tables.
+	stale := MessageIndexSpec()
+	stale.MirrorSchemaVersion = "999"
+	msg = openSpecT(t, path, stale, false)
+
+	msgGens, err := msg.Generations(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, msgGens, "message store should have been reset")
+
+	auxGens, err := aux.Generations(ctx)
+	require.NoError(t, err)
+	require.Len(t, auxGens, 1, "aux store must survive the message-store reset")
+	assert.Equal(t, "model-aux", auxGens[0].Model)
+}
+
+// The read path fails closed per store: a version mismatch on one store
+// must not affect reads on the other.
+func TestSpecReadPathMismatchIsPerStore(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vectors.db")
+	ctx := context.Background()
+
+	msg := openSpecT(t, path, MessageIndexSpec(), false)
+	aux := openSpecT(t, path, auxSpec(), false)
+	_, err := aux.EnsureGeneration(ctx, testGen("model-aux"), sqlitevec.StateActive)
+	require.NoError(t, err)
+	require.NoError(t, msg.Close())
+
+	stale := MessageIndexSpec()
+	stale.MirrorSchemaVersion = "999"
+	msgRO := openSpecT(t, path, stale, true)
+
+	_, err = msgRO.Generations(ctx)
+	assert.ErrorIs(t, err, ErrMirrorVersionMismatch)
+
+	auxGens, err := aux.Generations(ctx)
+	require.NoError(t, err)
+	assert.Len(t, auxGens, 1)
+}


### PR DESCRIPTION
The vector machinery landed in #999 bound to package-level singletons naming one store's tables (`vector_messages`, `vector_meta`, the `message_vectors` prefix, mirror schema version, and shared metadata keys). Any second embedding store added to `vectors.db` would collide with the first: the schema-version reset path drops every table it considers mirror state, the metadata keys (watermark, scope, `gen_model:*`) live in one shared table, and generation IDs are only unique within one store's generations table.

This refactor makes each store's identity explicit. An `IndexSpec` carries the store's docs table, its own key/value metadata table, the kit bookkeeping prefix, its mirror DDL, and its schema version; `Index` binds to exactly one spec. Schema-version drop/reset now touches only spec-owned tables, and all metadata reads/writes go through per-spec `metaGet`/`metaSet`. The message store is the canned `MessageIndexSpec()`, with every table name, metadata key, and version literal byte-identical to before — an existing `vectors.db` opens with no reset and no re-embed. `Open` keeps its signature and delegates to `OpenSpec`, so the scheduler and search paths are untouched.

Because generation IDs are per-store, `embeddings list/activate/retire` gain a `--store` selector (default `messages`, the only registered store); `list` output and JSON now carry the store name. `embeddings build` stays unqualified until a second buildable store exists — `vectorStoreSpec` in `cmd/agentsview/embeddings.go` is the single registration point.

One known limitation, documented on `IndexSpec`: pairwise disjointness of spec table names/prefixes is a contract, not yet a runtime guard. Enforcement belongs with the registration of a second store, where a violation could first occur.

Where to look: `IndexSpec` and `prepareMirrorSchema` in `internal/vector/index.go` for the ownership boundaries, and `internal/vector/spec_test.go` for the isolation contract (two stores sharing one `vectors.db`; a schema reset of one leaves the other's tables, metadata, and generations intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)