### PR TITLE
perf(sync): stop re-parsing unchanged OpenCode SQLite containers on every periodic sync

### DIFF
--- a/internal/parser/opencode.go
+++ b/internal/parser/opencode.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/tidwall/gjson"
@@ -118,7 +119,7 @@ func parseOpenCodeDBSession(
 	}
 	defer db.Close()
 
-	projects, err := loadOpenCodeProjects(db)
+	projects, err := loadOpenCodeProjectsCached(db, dbPath)
 	if err != nil {
 		return nil, nil, fmt.Errorf(
 			"loading opencode projects: %w", err,
@@ -259,6 +260,55 @@ func loadOpenCodeProjects(
 		projects[p.id] = p.worktree
 	}
 	return projects, rows.Err()
+}
+
+type openCodeProjectsCacheEntry struct {
+	state    SQLiteContainerState
+	projects map[string]string
+}
+
+// openCodeProjectsCache memoizes the project table per shared SQLite DB,
+// keyed by the container's change-detection state. The engine parses each
+// session of a container through an independent provider instance, so
+// without this cache every parsed session re-queried the full project
+// table — the dominant per-session cost when re-verifying a changed
+// container. Entries hold only a handful of small maps (one per configured
+// container path) and are replaced in place.
+var (
+	openCodeProjectsCacheMu sync.Mutex
+	openCodeProjectsCache   = map[string]openCodeProjectsCacheEntry{}
+)
+
+// loadOpenCodeProjectsCached returns the project→worktree map for the
+// shared DB at dbPath, reusing the previous load while the container state
+// is unchanged. The state is captured before the query, so a write racing
+// the load can only make cached data newer than its key — the next capture
+// then mismatches and reloads. The returned map is shared and must be
+// treated as read-only.
+func loadOpenCodeProjectsCached(
+	db *sql.DB, dbPath string,
+) (map[string]string, error) {
+	state, ok := StatSQLiteContainerState(dbPath)
+	if !ok {
+		return loadOpenCodeProjects(db)
+	}
+	openCodeProjectsCacheMu.Lock()
+	entry, hit := openCodeProjectsCache[dbPath]
+	openCodeProjectsCacheMu.Unlock()
+	if hit && entry.state == state {
+		return entry.projects, nil
+	}
+	projects, err := loadOpenCodeProjects(db)
+	if err != nil {
+		return nil, err
+	}
+	openCodeProjectsCacheMu.Lock()
+	openCodeProjectsCache[dbPath] = openCodeProjectsCacheEntry{
+		state:    state,
+		projects: projects,
+	}
+	openCodeProjectsCacheMu.Unlock()
+	return projects, nil
 }
 
 // openCodeSessionRow is a row from the opencode session table.

--- a/internal/parser/opencode_provider.go
+++ b/internal/parser/opencode_provider.go
@@ -284,6 +284,11 @@ func (spec openCodeProviderSpec) parseSQLite(
 type openCodeFormatSource struct {
 	Root string
 	Path string
+	// MTimeNS carries the session's time_updated (already listed during
+	// SQLite discovery, scaled to nanoseconds) so Fingerprint does not
+	// reopen the shared DB once per session. Zero means unknown and makes
+	// Fingerprint fall back to querying the DB.
+	MTimeNS int64
 }
 
 type openCodeFormatSourceSet struct {
@@ -436,9 +441,13 @@ func (s openCodeFormatSourceSet) Fingerprint(
 	if !ok {
 		return SourceFingerprint{}, fmt.Errorf("%s source path unavailable", s.spec.agent)
 	}
-	mtime, err := s.spec.sourceMtime(path)
-	if err != nil {
-		return SourceFingerprint{}, err
+	mtime := sourceCarriedMTimeNS(source)
+	if mtime == 0 {
+		var err error
+		mtime, err = s.spec.sourceMtime(path)
+		if err != nil {
+			return SourceFingerprint{}, err
+		}
 	}
 	fingerprint := SourceFingerprint{
 		Key:     firstNonEmptyJSONLString(source.FingerprintKey, source.Key, path),
@@ -460,11 +469,29 @@ func (s openCodeFormatSourceSet) Fingerprint(
 		return SourceFingerprint{}, fmt.Errorf("stat %s: source is a directory", path)
 	}
 	fingerprint.Size = info.Size()
-	fingerprint.Hash, err = openCodeProviderStorageFingerprint(path)
-	if err != nil {
-		return SourceFingerprint{}, err
-	}
+	// No content hash: no engine freshness gate consumes it for this
+	// family (see providerFingerprintHashRequiredForFreshness), and the
+	// authoritative storage fingerprint is computed by Parse and compared
+	// post-parse by dropUnchangedSharedSQLiteResults. Computing it here
+	// re-read and re-hashed every message and part file of the session on
+	// every fingerprint call — the dominant cost of syncing streaming
+	// storage sessions — for a value nothing read.
 	return fingerprint, nil
+}
+
+// sourceCarriedMTimeNS returns the discovery-listed session mtime carried on
+// a SQLite-backed source, or zero when the source was built without one
+// (storage sessions, FindSource lookups).
+func sourceCarriedMTimeNS(source SourceRef) int64 {
+	switch src := source.Opaque.(type) {
+	case openCodeFormatSource:
+		return src.MTimeNS
+	case *openCodeFormatSource:
+		if src != nil {
+			return src.MTimeNS
+		}
+	}
+	return 0
 }
 
 func (s openCodeFormatSourceSet) pathFromSource(source SourceRef) (string, bool) {
@@ -514,7 +541,7 @@ func (s openCodeFormatSourceSet) sqliteSources(
 		// sourceRef, which reopens the same SQLite DB once per row via
 		// OpenCodeSQLiteSessionExists (O(n) opens for n sessions, and it would
 		// silently drop a row whose redundant probe failed).
-		source, ok := s.sqliteSourceRefFromMeta(root, meta.VirtualPath)
+		source, ok := s.sqliteSourceRefFromMeta(root, meta)
 		if !ok {
 			continue
 		}
@@ -527,13 +554,14 @@ func (s openCodeFormatSourceSet) sqliteSources(
 // from the SQLite DB at root. It validates the virtual path parses and that its
 // DB lives under root, but unlike sourceRef it skips the per-row
 // OpenCodeSQLiteSessionExists probe because the caller read the row from that
-// same DB moments earlier.
+// same DB moments earlier. The listed time_updated rides along so Fingerprint
+// does not reopen the DB per session.
 func (s openCodeFormatSourceSet) sqliteSourceRefFromMeta(
 	root string,
-	virtualPath string,
+	meta OpenCodeSessionMeta,
 ) (SourceRef, bool) {
 	root = filepath.Clean(root)
-	path := filepath.Clean(virtualPath)
+	path := filepath.Clean(meta.VirtualPath)
 	dbPath, _, ok := s.spec.parseVirtual(path)
 	if !ok {
 		return SourceRef{}, false
@@ -541,7 +569,12 @@ func (s openCodeFormatSourceSet) sqliteSourceRefFromMeta(
 	if _, under := relUnder(root, dbPath); !under {
 		return SourceRef{}, false
 	}
-	return s.newSourceRef(root, path, ""), true
+	ref := s.newSourceRef(root, path, "")
+	if src, ok := ref.Opaque.(openCodeFormatSource); ok {
+		src.MTimeNS = meta.FileMtime
+		ref.Opaque = src
+	}
+	return ref, true
 }
 
 func (s openCodeFormatSourceSet) sourcesForChangedPathInRoot(
@@ -765,47 +798,6 @@ func (s openCodeFormatSourceSet) isStorageSessionPath(
 		parts[1] == filepath.Base(src.SessionRoot) &&
 		strings.HasSuffix(parts[3], ".json") &&
 		(!requireExisting || IsRegularFile(path))
-}
-
-func openCodeProviderStorageFingerprint(sessionPath string) (string, error) {
-	raw, err := os.ReadFile(sessionPath)
-	if err != nil {
-		return "", err
-	}
-	var sf openCodeStorageSessionFile
-	if err := json.Unmarshal(raw, &sf); err != nil {
-		return "", fmt.Errorf(
-			"decoding opencode session file %s: %w",
-			sessionPath, err,
-		)
-	}
-	if sf.ID == "" {
-		return "", fmt.Errorf(
-			"opencode session file %s missing id",
-			sessionPath,
-		)
-	}
-	root := filepath.Dir(filepath.Dir(filepath.Dir(filepath.Dir(sessionPath))))
-	msgs, err := loadOpenCodeStorageMessages(root, sf.ID)
-	if err != nil {
-		return "", err
-	}
-	parts, err := loadOpenCodeStorageParts(root, msgs)
-	if err != nil {
-		return "", err
-	}
-	return buildOpenCodeSessionFingerprint(
-		openCodeSessionRow{
-			id:          sf.ID,
-			parentID:    sf.ParentID,
-			title:       sf.Title,
-			timeCreated: sf.Time.Created,
-			timeUpdated: sf.Time.Updated,
-		},
-		sf.Directory,
-		msgs,
-		parts,
-	), nil
 }
 
 func readOpenCodeProviderStorageSessionID(path string) string {

--- a/internal/parser/opencode_provider_test.go
+++ b/internal/parser/opencode_provider_test.go
@@ -80,7 +80,10 @@ func TestOpenCodeProviderStorageSourceMethods(t *testing.T) {
 	assert.Equal(t, sessionPath, fingerprint.Key)
 	assert.Positive(t, fingerprint.Size)
 	assert.Positive(t, fingerprint.MTimeNS)
-	assert.True(t, HasOpenCodeStorageFingerprint(fingerprint.Hash))
+	// Storage-mode Fingerprint is stat-only: the content fingerprint is
+	// computed by Parse, and hashing here would re-read every message and
+	// part file on each fingerprint call.
+	assert.Empty(t, fingerprint.Hash)
 
 	outcome, err := provider.Parse(context.Background(), ParseRequest{
 		Source:      found,
@@ -95,7 +98,9 @@ func TestOpenCodeProviderStorageSourceMethods(t *testing.T) {
 	assert.Equal(t, AgentOpenCode, result.Result.Session.Agent)
 	assert.Equal(t, "opencode_app", result.Result.Session.Project)
 	assert.Equal(t, "devbox", result.Result.Session.Machine)
-	assert.Equal(t, fingerprint.Hash, result.Result.Session.File.Hash)
+	assert.True(t,
+		HasOpenCodeStorageFingerprint(result.Result.Session.File.Hash),
+		"Parse must compute the storage content fingerprint itself")
 	assert.Len(t, result.Result.Messages, 1)
 
 	require.NoError(t, os.Remove(sessionPath), "remove storage session")
@@ -315,6 +320,41 @@ func TestOpenCodeProviderSQLiteDiscoversAllListedSessions(t *testing.T) {
 	for _, src := range discovered {
 		assert.Equal(t, src.DisplayPath, src.FingerprintKey)
 	}
+}
+
+// TestOpenCodeProviderSQLiteFingerprintUsesDiscoveryMeta pins that
+// fingerprinting a discovered SQLite-backed session reuses the time_updated
+// already listed during discovery instead of reopening the shared DB once per
+// session. Replacing the DB with unreadable bytes after discovery makes any
+// reopen fail, so a successful fingerprint proves the metadata was carried on
+// the source.
+func TestOpenCodeProviderSQLiteFingerprintUsesDiscoveryMeta(t *testing.T) {
+
+	root := t.TempDir()
+	dbPath, seeder, db := newTestDBAt(t, filepath.Join(root, "opencode.db"))
+	seeder.AddProject("prj_1", "/home/user/code/sqlite-app")
+	seeder.AddSession(
+		"ses_meta", "prj_1", "", "Meta", 1700000000000, 1700000010000,
+	)
+	require.NoError(t, db.Close())
+
+	provider, ok := NewProvider(AgentOpenCode, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	discovered, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, discovered, 1)
+
+	garbage := []byte("not a sqlite database")
+	require.NoError(t, os.WriteFile(dbPath, garbage, 0o644))
+
+	fp, err := provider.Fingerprint(context.Background(), discovered[0])
+	require.NoError(t, err,
+		"fingerprint must not reopen the SQLite DB for a discovered source")
+	assert.Equal(t, OpenCodeSQLiteVirtualPath(dbPath, "ses_meta"), fp.Key)
+	assert.Equal(t, int64(1700000010000000000), fp.MTimeNS,
+		"fingerprint mtime must be the discovered time_updated in ns")
+	assert.Equal(t, int64(len(garbage)), fp.Size,
+		"fingerprint size stays the shared container file size")
 }
 
 func TestOpenCodeProviderHybridDiscoveryFiltersSQLiteDuplicate(t *testing.T) {

--- a/internal/parser/opencode_storage_state.go
+++ b/internal/parser/opencode_storage_state.go
@@ -1,0 +1,98 @@
+// ABOUTME: Change-detection state for file-backed OpenCode storage sessions,
+// ABOUTME: built from the stat signature of every file the parser would read.
+package parser
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// StatOpenCodeStorageSessionState captures a change-detection state for a
+// file-backed OpenCode-format storage session: a digest over the name, size,
+// and nanosecond mtime of the session JSON and of every message and part
+// file its parse would read (the same .json filters as
+// loadOpenCodeStorageMessages and loadOpenCodeStorageParts). Two equal
+// states mean the parse inputs carry an identical stat signature, so a
+// session whose state matches a previously verified one can skip re-parsing.
+//
+// The signature is deliberately per-file rather than an aggregate max-mtime:
+// a composite max cannot see a child rewritten within one filesystem mtime
+// granule or with a restored timestamp, while a per-file (name, size,
+// mtimeNS) set narrows the blind spot to a same-size in-place rewrite that
+// also preserves the file's mtime. Callers that learn about a change out of
+// band (a watcher event naming a child file) must invalidate any trust in
+// the previous state rather than rely on the stat signature alone.
+//
+// ok is false when the session file is missing or a directory listing
+// fails, in which case the session must never be treated as unchanged.
+func StatOpenCodeStorageSessionState(sessionPath string) (string, bool) {
+	info, err := os.Stat(sessionPath)
+	if err != nil || !info.Mode().IsRegular() {
+		return "", false
+	}
+	h := sha256.New()
+	record := func(kind, name string, size, mtimeNS int64) {
+		fmt.Fprintf(h, "%s\x00%s\x00%d\x00%d\n", kind, name, size, mtimeNS)
+	}
+	record(
+		"session", filepath.Base(sessionPath),
+		info.Size(), info.ModTime().UnixNano(),
+	)
+
+	root := filepath.Dir(filepath.Dir(filepath.Dir(
+		filepath.Dir(sessionPath),
+	)))
+	sessionID := strings.TrimSuffix(
+		filepath.Base(sessionPath), filepath.Ext(sessionPath),
+	)
+	messageDir := filepath.Join(root, "storage", "message", sessionID)
+	msgEntries, err := os.ReadDir(messageDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Sprintf("%x", h.Sum(nil)), true
+		}
+		return "", false
+	}
+	for _, entry := range msgEntries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		msgInfo, err := entry.Info()
+		if err != nil {
+			return "", false
+		}
+		record(
+			"message", entry.Name(),
+			msgInfo.Size(), msgInfo.ModTime().UnixNano(),
+		)
+		messageID := strings.TrimSuffix(
+			entry.Name(), filepath.Ext(entry.Name()),
+		)
+		partDir := filepath.Join(root, "storage", "part", messageID)
+		partEntries, err := os.ReadDir(partDir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return "", false
+		}
+		for _, partEntry := range partEntries {
+			if partEntry.IsDir() ||
+				!strings.HasSuffix(partEntry.Name(), ".json") {
+				continue
+			}
+			partInfo, err := partEntry.Info()
+			if err != nil {
+				return "", false
+			}
+			record(
+				"part", messageID+"/"+partEntry.Name(),
+				partInfo.Size(), partInfo.ModTime().UnixNano(),
+			)
+		}
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), true
+}

--- a/internal/parser/opencode_storage_state_test.go
+++ b/internal/parser/opencode_storage_state_test.go
@@ -1,0 +1,111 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatOpenCodeStorageSessionState(t *testing.T) {
+	root := t.TempDir()
+	sessionPath := writeOpenCodeProviderStorageSession(
+		t, root, "session", "ses_state", "state-app", "State Session",
+	)
+
+	state, ok := StatOpenCodeStorageSessionState(sessionPath)
+	require.True(t, ok, "state capture must succeed")
+	require.NotEmpty(t, state)
+
+	again, ok := StatOpenCodeStorageSessionState(sessionPath)
+	require.True(t, ok)
+	assert.Equal(t, state, again, "untouched tree must produce equal states")
+
+	t.Run("added part changes state", func(t *testing.T) {
+		writeOpenCodeStorageFile(t, filepath.Join(
+			root, "storage", "part", "msg_1", "prt_2.json",
+		), map[string]any{
+			"id":        "prt_2",
+			"sessionID": "ses_state",
+			"messageID": "msg_1",
+			"type":      "text",
+			"text":      "appended part",
+			"time":      map[string]any{"created": int64(1700000001000)},
+		})
+		next, ok := StatOpenCodeStorageSessionState(sessionPath)
+		require.True(t, ok)
+		assert.NotEqual(t, state, next,
+			"a new part file must change the state")
+		state = next
+	})
+
+	t.Run("part mtime bump changes state", func(t *testing.T) {
+		partPath := filepath.Join(
+			root, "storage", "part", "msg_1", "prt_2.json",
+		)
+		bumped := time.Unix(1810000000, 123456789)
+		require.NoError(t, os.Chtimes(partPath, bumped, bumped))
+		next, ok := StatOpenCodeStorageSessionState(sessionPath)
+		require.True(t, ok)
+		assert.NotEqual(t, state, next,
+			"a part mtime change must change the state")
+		state = next
+	})
+
+	t.Run("size change with restored mtime changes state", func(t *testing.T) {
+		partPath := filepath.Join(
+			root, "storage", "part", "msg_1", "prt_2.json",
+		)
+		info, err := os.Stat(partPath)
+		require.NoError(t, err)
+		writeOpenCodeStorageFile(t, partPath, map[string]any{
+			"id":        "prt_2",
+			"sessionID": "ses_state",
+			"messageID": "msg_1",
+			"type":      "text",
+			"text":      "appended part grown longer",
+			"time":      map[string]any{"created": int64(1700000001000)},
+		})
+		require.NoError(t,
+			os.Chtimes(partPath, info.ModTime(), info.ModTime()))
+		next, ok := StatOpenCodeStorageSessionState(sessionPath)
+		require.True(t, ok)
+		assert.NotEqual(t, state, next,
+			"a size change must change the state even at a restored mtime")
+	})
+
+	t.Run("missing session file fails capture", func(t *testing.T) {
+		_, ok := StatOpenCodeStorageSessionState(
+			filepath.Join(root, "storage", "session", "global", "nope.json"),
+		)
+		assert.False(t, ok, "missing session file must never be trusted")
+	})
+}
+
+func TestStatOpenCodeStorageSessionStateWithoutMessages(t *testing.T) {
+	root := t.TempDir()
+	sessionPath := filepath.Join(
+		root, "storage", "session", "global", "ses_lonely.json",
+	)
+	writeOpenCodeStorageFile(t, sessionPath, map[string]any{
+		"id":        "ses_lonely",
+		"directory": "/home/user/code/lonely-app",
+		"title":     "Lonely",
+		"time": map[string]any{
+			"created": int64(1700000000000),
+			"updated": int64(1700000060000),
+		},
+	})
+
+	state, ok := StatOpenCodeStorageSessionState(sessionPath)
+	require.True(t, ok,
+		"a session without a message dir is valid and capturable")
+	require.NotEmpty(t, state)
+
+	again, ok := StatOpenCodeStorageSessionState(sessionPath)
+	require.True(t, ok)
+	assert.Equal(t, state, again)
+}

--- a/internal/parser/sqlite_container_state.go
+++ b/internal/parser/sqlite_container_state.go
@@ -1,0 +1,156 @@
+// ABOUTME: Change-detection state for shared SQLite container files, built
+// ABOUTME: on SQLite's own write markers rather than timestamp precision.
+package parser
+
+import (
+	"encoding/binary"
+	"os"
+)
+
+// SQLiteContainerState captures a shared SQLite container file's
+// change-detection state. Two equal states mean the container provably has
+// not changed between the two captures.
+//
+// "Provably" deliberately does not rest on timestamp equality. Filesystem
+// mtime granularity varies (ns on APFS/ext4, 1s on HFS+, 2s on FAT) and
+// timestamps round-trip through layers with different precisions, so
+// comparisons finer than one second are not meaningful; mtimes here are
+// truncated to whole seconds and act only as coarse extra signal. The real
+// precision comes from SQLite's own write markers, which advance on every
+// committed transaction regardless of any clock:
+//
+//   - the 32-bit file change counter at byte 24 of the database header
+//     (bumped per transaction in rollback-journal mode, and on every
+//     checkpoint in WAL mode), and
+//   - the WAL header's checkpoint sequence number and random salts, plus
+//     the WAL size: between WAL resets commits only append frames (the WAL
+//     grows), and every WAL reset re-randomizes the salts.
+//
+// A spurious mismatch merely costs one redundant re-read, while a wrong
+// match is what the write markers rule out.
+//
+// Both headers are read per the documented on-disk format, which SQLite
+// pledges to keep backwards compatible through 2050:
+//
+//	https://www.sqlite.org/fileformat2.html (database header
+//	#the_database_header, WAL format #wal_file_format; layouts
+//	unchanged since 3.0.0 and 3.7.0 respectively)
+//	https://www.sqlite.org/lts.html (long-term support and format
+//	stability pledge through 2050)
+type SQLiteContainerState struct {
+	DBSize          int64
+	DBMtimeSec      int64
+	DBChangeCounter uint32
+	// DBInode and DBDevice distinguish a replaced or restored container
+	// file (new inode) from in-place transaction writes, which the header
+	// markers alone cannot: a byte-identical copy carries the same size,
+	// counter, and salts. Zero on platforms without cheap file identity
+	// (Windows), where replacement detection degrades to the other
+	// markers. In-place byte surgery that preserves every marker and
+	// lands within the trusted mtime's second is explicitly out of
+	// scope — the same exposure class every mtime-based sync tool
+	// accepts.
+	DBInode  uint64
+	DBDevice uint64
+
+	WALSize     int64
+	WALMtimeSec int64
+	WALCkptSeq  uint32
+	WALSalt1    uint32
+	WALSalt2    uint32
+}
+
+// sqliteHeaderProbeSize covers the 100-byte SQLite database header; the
+// file change counter lives at bytes 24-27 (big-endian), per
+// https://www.sqlite.org/fileformat2.html#the_database_header.
+const sqliteHeaderProbeSize = 100
+
+// The documented WAL header magic values (byte order of the frame
+// checksums) and the only WAL format version ever published (stable since
+// SQLite 3.7.0), per https://www.sqlite.org/fileformat2.html#wal_file_format.
+// The salts and checkpoint sequence are only meaningful under this exact
+// format, so anything else fails closed to "never trusted".
+const (
+	sqliteWALMagicBE = 0x377f0683
+	sqliteWALMagicLE = 0x377f0682
+	sqliteWALVersion = 3007000
+)
+
+var sqliteHeaderMagic = []byte("SQLite format 3\x00")
+
+// StatSQLiteContainerState captures the current change-detection state of a
+// shared SQLite container. ok is false when the container is missing or its
+// headers cannot be read, in which case the container must never be treated
+// as unchanged.
+func StatSQLiteContainerState(dbPath string) (SQLiteContainerState, bool) {
+	info, err := os.Stat(dbPath)
+	if err != nil || !info.Mode().IsRegular() {
+		return SQLiteContainerState{}, false
+	}
+	state := SQLiteContainerState{
+		DBSize:     info.Size(),
+		DBMtimeSec: info.ModTime().Unix(),
+	}
+	state.DBInode, state.DBDevice = sourceFileIdentity(info)
+	counter, ok := readSQLiteChangeCounter(dbPath)
+	if !ok {
+		return SQLiteContainerState{}, false
+	}
+	state.DBChangeCounter = counter
+
+	walPath := dbPath + "-wal"
+	walInfo, err := os.Stat(walPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return state, true
+		}
+		return SQLiteContainerState{}, false
+	}
+	if !walInfo.Mode().IsRegular() ||
+		walInfo.Size() <= sqliteWALHeaderSize {
+		// A WAL at or under header size carries no transaction frames, so
+		// it is equivalent to an absent WAL: read-only SQLite clients can
+		// leave an empty WAL behind without implying any content change.
+		return state, true
+	}
+	header := make([]byte, sqliteWALHeaderSize)
+	f, err := os.Open(walPath)
+	if err != nil {
+		return SQLiteContainerState{}, false
+	}
+	defer f.Close()
+	if _, err := f.ReadAt(header, 0); err != nil {
+		return SQLiteContainerState{}, false
+	}
+	magic := binary.BigEndian.Uint32(header[0:4])
+	if magic != sqliteWALMagicBE && magic != sqliteWALMagicLE {
+		return SQLiteContainerState{}, false
+	}
+	if binary.BigEndian.Uint32(header[4:8]) != sqliteWALVersion {
+		return SQLiteContainerState{}, false
+	}
+	state.WALSize = walInfo.Size()
+	state.WALMtimeSec = walInfo.ModTime().Unix()
+	state.WALCkptSeq = binary.BigEndian.Uint32(header[12:16])
+	state.WALSalt1 = binary.BigEndian.Uint32(header[16:20])
+	state.WALSalt2 = binary.BigEndian.Uint32(header[20:24])
+	return state, true
+}
+
+func readSQLiteChangeCounter(dbPath string) (uint32, bool) {
+	f, err := os.Open(dbPath)
+	if err != nil {
+		return 0, false
+	}
+	defer f.Close()
+	header := make([]byte, sqliteHeaderProbeSize)
+	if _, err := f.ReadAt(header, 0); err != nil {
+		return 0, false
+	}
+	for i, b := range sqliteHeaderMagic {
+		if header[i] != b {
+			return 0, false
+		}
+	}
+	return binary.BigEndian.Uint32(header[24:28]), true
+}

--- a/internal/parser/sqlite_container_state.go
+++ b/internal/parser/sqlite_container_state.go
@@ -23,8 +23,15 @@ import (
 //     (bumped per transaction in rollback-journal mode, and on every
 //     checkpoint in WAL mode), and
 //   - the WAL header's checkpoint sequence number and random salts, plus
-//     the WAL size: between WAL resets commits only append frames (the WAL
-//     grows), and every WAL reset re-randomizes the salts.
+//     the WAL size: between WAL resets commits only append frames ("a WAL
+//     always grows from beginning toward the end", so the size advances),
+//     and frames are only ever overwritten after a reset, whose first
+//     write transaction rewrites the header with an incremented salt-1
+//     and re-randomized salt-2 — the salts are SQLite's own mechanism for
+//     invalidating stale frames. Every committed frame therefore either
+//     grows the WAL or lands behind changed salts; a state that compares
+//     equal cannot hide new frames short of a fresh WAL's two random
+//     salts colliding with the captured ones.
 //
 // A spurious mismatch merely costs one redundant re-read, while a wrong
 // match is what the write markers rule out.

--- a/internal/parser/sqlite_container_state_test.go
+++ b/internal/parser/sqlite_container_state_test.go
@@ -1,0 +1,182 @@
+package parser
+
+import (
+	"encoding/binary"
+	"os"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSQLiteContainerStateIgnoresSubSecondMtimeChanges pins the state's
+// timestamp contract: mtime participates at whole-second granularity only,
+// so sub-second timestamp instability (filesystems and stat round-trips
+// disagree below one second) can never make an unchanged container look
+// changed, while a change that crosses a second boundary still registers.
+// Content changes are detected by SQLite's own write markers regardless of
+// any timestamp.
+func TestSQLiteContainerStateIgnoresSubSecondMtimeChanges(t *testing.T) {
+	dbPath, _, db := newTestDB(t)
+	require.NoError(t, db.Close())
+
+	base := time.Unix(1700000000, 100*int64(time.Millisecond))
+	require.NoError(t, os.Chtimes(dbPath, base, base))
+	before, ok := StatSQLiteContainerState(dbPath)
+	require.True(t, ok, "state must be readable")
+
+	nudged := time.Unix(1700000000, 900*int64(time.Millisecond))
+	require.NoError(t, os.Chtimes(dbPath, nudged, nudged))
+	within, ok := StatSQLiteContainerState(dbPath)
+	require.True(t, ok, "state must be readable after sub-second nudge")
+	assert.Equal(t, before, within,
+		"a sub-second mtime change must not change the container state")
+
+	crossed := time.Unix(1700000001, 0)
+	require.NoError(t, os.Chtimes(dbPath, crossed, crossed))
+	afterSecond, ok := StatSQLiteContainerState(dbPath)
+	require.True(t, ok, "state must be readable after second boundary")
+	assert.NotEqual(t, before, afterSecond,
+		"an mtime change across a second boundary must change the state")
+}
+
+// TestSQLiteContainerStateRejectsNonSQLiteFiles pins that a file without a
+// SQLite header can never be captured, and therefore never trusted as an
+// unchanged container.
+func TestSQLiteContainerStateRejectsNonSQLiteFiles(t *testing.T) {
+	path := t.TempDir() + "/opencode.db"
+	require.NoError(t, os.WriteFile(
+		path, []byte("not a sqlite database, padded to header size........................................................."), 0o644,
+	))
+	_, ok := StatSQLiteContainerState(path)
+	assert.False(t, ok, "non-SQLite bytes must not produce a container state")
+}
+
+// TestSQLiteContainerStateDetectsFileReplacement pins that swapping the
+// container for a different file is visible even when every header marker
+// and the stat metadata coincide: a byte-identical copy at a new inode with
+// a restored mtime must still change the state. Without file identity, a
+// restored or replaced database landing in the same second with the same
+// size and change counter would be indistinguishable from the original.
+func TestSQLiteContainerStateDetectsFileReplacement(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file identity is unavailable on Windows")
+	}
+	dbPath, _, db := newTestDB(t)
+	require.NoError(t, db.Close())
+
+	before, ok := StatSQLiteContainerState(dbPath)
+	require.True(t, ok, "state must be readable before replacement")
+
+	raw, err := os.ReadFile(dbPath)
+	require.NoError(t, err, "read container bytes")
+	info, err := os.Stat(dbPath)
+	require.NoError(t, err, "stat container")
+	// Write the copy while the original still exists so the two files are
+	// guaranteed distinct inodes, then rename over the original. A
+	// remove-then-recreate at the same path can reuse the freed inode and
+	// make the replacement genuinely indistinguishable.
+	replacement := dbPath + ".replacement"
+	require.NoError(t, os.WriteFile(replacement, raw, 0o644),
+		"write replacement container with identical bytes")
+	require.NoError(t, os.Rename(replacement, dbPath),
+		"swap replacement over container")
+	require.NoError(t,
+		os.Chtimes(dbPath, info.ModTime(), info.ModTime()),
+		"restore container mtime")
+
+	after, ok := StatSQLiteContainerState(dbPath)
+	require.True(t, ok, "state must be readable after replacement")
+	assert.NotEqual(t, before, after,
+		"a replaced container file must change the state")
+}
+
+// TestSQLiteContainerStateRejectsUnknownWALFormat pins that the WAL fields
+// are only trusted when the WAL header carries the documented magic and
+// format version (3007000). The salts and checkpoint sequence are what make
+// the equality check sound; under any other format those bytes are opaque,
+// so the container must fail closed to "never trusted" instead.
+func TestSQLiteContainerStateRejectsUnknownWALFormat(t *testing.T) {
+	writeWAL := func(t *testing.T, dbPath string, magic, version uint32) {
+		t.Helper()
+		header := make([]byte, 40)
+		binary.BigEndian.PutUint32(header[0:4], magic)
+		binary.BigEndian.PutUint32(header[4:8], version)
+		binary.BigEndian.PutUint32(header[12:16], 7)  // checkpoint seq
+		binary.BigEndian.PutUint32(header[16:20], 11) // salt-1
+		binary.BigEndian.PutUint32(header[20:24], 13) // salt-2
+		require.NoError(t, os.WriteFile(dbPath+"-wal", header, 0o644))
+	}
+
+	t.Run("documented header is read", func(t *testing.T) {
+		dbPath, _, db := newTestDB(t)
+		require.NoError(t, db.Close())
+		writeWAL(t, dbPath, 0x377f0683, 3007000)
+		state, ok := StatSQLiteContainerState(dbPath)
+		require.True(t, ok, "documented WAL header must be readable")
+		assert.Equal(t, uint32(7), state.WALCkptSeq)
+		assert.Equal(t, uint32(11), state.WALSalt1)
+		assert.Equal(t, uint32(13), state.WALSalt2)
+	})
+
+	t.Run("wrong magic fails closed", func(t *testing.T) {
+		dbPath, _, db := newTestDB(t)
+		require.NoError(t, db.Close())
+		writeWAL(t, dbPath, 0xdeadbeef, 3007000)
+		_, ok := StatSQLiteContainerState(dbPath)
+		assert.False(t, ok,
+			"a WAL without the documented magic must never be trusted")
+	})
+
+	t.Run("unknown version fails closed", func(t *testing.T) {
+		dbPath, _, db := newTestDB(t)
+		require.NoError(t, db.Close())
+		writeWAL(t, dbPath, 0x377f0682, 3008000)
+		_, ok := StatSQLiteContainerState(dbPath)
+		assert.False(t, ok,
+			"an unknown WAL format version must never be trusted")
+	})
+}
+
+// TestOpenCodeProjectsCacheReusesUntilContainerChanges pins the
+// project-table cache used by SQLite session parsing: while the container
+// state is unchanged the previous load is served back, and any committed
+// write invalidates it. Without the cache every parsed session re-queried
+// the full project table, which dominated re-parse CPU on large archives.
+func TestOpenCodeProjectsCacheReusesUntilContainerChanges(t *testing.T) {
+	dbPath, seeder, db := newTestDB(t)
+	defer db.Close()
+	seeder.AddProject("prj_1", "/home/user/code/app-one")
+
+	first, err := loadOpenCodeProjectsCached(db, dbPath)
+	require.NoError(t, err)
+	assert.Equal(t,
+		map[string]string{"prj_1": "/home/user/code/app-one"}, first)
+
+	// Poison the cached copy to make hits observable: an unchanged
+	// container must serve the poisoned entry back, and a changed one must
+	// reload the real values from the DB.
+	openCodeProjectsCacheMu.Lock()
+	entry := openCodeProjectsCache[dbPath]
+	entry.projects = map[string]string{"prj_1": "cached-marker"}
+	openCodeProjectsCache[dbPath] = entry
+	openCodeProjectsCacheMu.Unlock()
+
+	second, err := loadOpenCodeProjectsCached(db, dbPath)
+	require.NoError(t, err)
+	assert.Equal(t, "cached-marker", second["prj_1"],
+		"an unchanged container must be served from the cache")
+
+	_, err = db.Exec(
+		"UPDATE project SET worktree = ? WHERE id = ?",
+		"/home/user/code/renamed", "prj_1",
+	)
+	require.NoError(t, err)
+
+	third, err := loadOpenCodeProjectsCached(db, dbPath)
+	require.NoError(t, err)
+	assert.Equal(t, "/home/user/code/renamed", third["prj_1"],
+		"a committed write must invalidate the cached projects")
+}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -3847,6 +3847,17 @@ func (e *Engine) processProviderFile(
 		return processResult{skip: true}, true
 	}
 
+	// Processing a file-backed storage session makes (or confirms) the
+	// storage copy as the archive's canonical content for its ID, so a
+	// same-ID SQLite row in this root's container is no longer backed by
+	// what its trusted membership verified. Drop it so a storage copy
+	// that appears and disappears entirely between full passes still
+	// forces the re-exposed row to re-verify (see
+	// dropTrustedSQLiteContainerSessionForStorage).
+	if sessionPath := e.openCodeStorageSessionPath(file); sessionPath != "" {
+		e.dropTrustedSQLiteContainerSessionForStorage(file.Agent, sessionPath)
+	}
+
 	// OpenCode-family file-backed storage gate: when the session's
 	// per-file stat signature matches the last verified pass, its parse
 	// inputs are unchanged, so skip before re-reading the whole message

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -150,6 +150,31 @@ type Engine struct {
 	// sessions don't rescan their whole history on every appended
 	// line. Close flushes and stops it.
 	signalSched *signalScheduler
+
+	// containerMu guards the OpenCode-family shared-SQLite freshness
+	// gate (see opencode_container_gate.go). trustedSQLiteContainers
+	// maps a container DB path to its state at the end of the last
+	// pass that verified every one of its sessions; containerPass is
+	// the bookkeeping for the pass currently running (nil outside
+	// passes). Both are in-memory only: a restart re-verifies once.
+	containerMu             gosync.Mutex
+	trustedSQLiteContainers map[string]parser.SQLiteContainerState
+	containerPass           *sqliteContainerPass
+
+	// storageTrustMu guards the per-session freshness gate for
+	// OpenCode-family file-backed storage sessions (see
+	// opencode_storage_gate.go). trustedStorageSessions maps a session
+	// JSON path to the stat signature captured before the last parse
+	// whose outcome the archive absorbed (results dropped as already
+	// stored, or confirmed written). storageTrustGens counts each
+	// session's invalidations and storageTrustEpoch counts full clears,
+	// so a promotion whose pre-parse snapshot predates an invalidation
+	// is discarded instead of resurrecting the invalidated trust. All
+	// in-memory only: a restart re-verifies once.
+	storageTrustMu         gosync.Mutex
+	trustedStorageSessions map[string]string
+	storageTrustGens       map[string]uint64
+	storageTrustEpoch      uint64
 }
 
 // PhaseStats returns the engine's phase counter. The values reflect only
@@ -543,6 +568,9 @@ func (e *Engine) SyncPathsContext(ctx context.Context, paths []string) {
 	if e.refuseWriteInForceParse("SyncPaths") {
 		return
 	}
+	// Capture container states before classifyPaths lists any session rows,
+	// matching the capture-before-discovery ordering of full syncs.
+	preContainerStates := e.captureSQLiteContainerStates()
 	files := e.classifyPaths(paths)
 	if len(files) == 0 {
 		return
@@ -564,11 +592,20 @@ func (e *Engine) SyncPathsContext(ctx context.Context, paths []string) {
 	e.resetS3CodexIndexCache()
 
 	e.anomalies.reset()
+	// Begin a container pass so an already-trusted, unchanged container
+	// still gates its fan-out (a spurious watcher event on the DB file
+	// costs nothing), but never promote from here: a changed-path pass is
+	// not guaranteed to cover a container's complete session set (a hybrid
+	// root can fan a single message path out to one SQLite-backed
+	// session), and promotion from a subset would be unsound. The next
+	// full sync re-verifies and re-trusts (see opencode_container_gate.go).
+	e.beginSQLiteContainerPass(files, preContainerStates)
 	results := e.startWorkers(ctx, files)
 	stats = e.collectAndBatch(
 		ctx, results, len(files), len(files), nil,
 		syncWriteDefault,
 	)
+	e.finishSQLiteContainerPass(true)
 	e.anomalies.applyTo(&stats)
 	e.persistSkipCache()
 
@@ -691,15 +728,19 @@ func (e *Engine) classifyProviderChangedPath(
 			continue
 		}
 		for _, watchRoot := range watchRoots {
-			storedSourcePaths, err := e.db.ListStoredSourcePathHints(
-				string(def.Type),
-				[]string{watchRoot},
-			)
-			if err != nil {
-				log.Printf(
-					"%s provider changed-path stored hints: %v",
-					def.Type, err,
+			var storedSourcePaths []string
+			if providerChangedPathWantsStoredHints(def.Type) {
+				var err error
+				storedSourcePaths, err = e.db.ListStoredSourcePathHints(
+					string(def.Type),
+					[]string{watchRoot},
 				)
+				if err != nil {
+					log.Printf(
+						"%s provider changed-path stored hints: %v",
+						def.Type, err,
+					)
+				}
 			}
 			sources, err := provider.SourcesForChangedPath(
 				ctx,
@@ -740,14 +781,22 @@ func (e *Engine) classifyProviderChangedPath(
 				}
 				seen[key] = struct{}{}
 				sourceCopy := source
-				files = append(files, parser.DiscoveredFile{
+				discovered := parser.DiscoveredFile{
 					Path:            sourcePath,
 					Project:         source.ProjectHint,
 					Agent:           agent,
 					ForceParse:      providerChangedPathForceParse(agent, sourcePath, path, eventKind, mode),
 					ProviderSource:  &sourceCopy,
 					ProviderProcess: mode == parser.ProviderMigrationProviderAuthoritative,
-				})
+				}
+				// A watcher event names a concrete change even when the
+				// session's stat signature cannot see it (a same-size,
+				// same-mtime child rewrite), so the storage gate must
+				// re-verify this session by content on the next pass.
+				if sessionPath := e.openCodeStorageSessionPath(discovered); sessionPath != "" {
+					e.invalidateOpenCodeStorageSession(sessionPath)
+				}
+				files = append(files, discovered)
 			}
 		}
 	}
@@ -805,10 +854,34 @@ func providerChangedPathForceParse(
 	}
 	if filepath.Clean(sourcePath) != filepath.Clean(eventPath) &&
 		!providerVirtualSourceBackedByEvent(sourcePath, eventPath) {
+		// OpenCode-family storage sessions resolve message/part events
+		// to their session JSON, whose fingerprint and stat signature
+		// span those same child files, and the classifier invalidates
+		// the session's storage-gate trust for every event. The normal
+		// freshness path therefore re-verifies by content, while a
+		// forced parse would bypass dropUnchangedSharedSQLiteResults
+		// and rewrite the whole session on every streamed append.
+		// Remove events keep the force so a deleted child still
+		// re-emits through the deletion path.
+		if eventKind != "remove" &&
+			isOpenCodeFormatStorageAgent(agent) &&
+			isOpenCodeFormatStoragePath(agent, sourcePath) {
+			return false
+		}
 		return true
 	}
 	return eventKind == "remove" &&
 		providerDeletedPhysicalSQLiteSource(agent, sourcePath)
+}
+
+// providerChangedPathWantsStoredHints reports whether an agent's
+// SourcesForChangedPath implementation reads
+// ChangedPathRequest.StoredSourcePaths. The OpenCode-family source sets
+// resolve changed paths purely from the on-disk layout, so the per-event
+// stored-hints lookup — a LIKE scan over every stored session row of the
+// agent — would be computed and discarded on every watcher event.
+func providerChangedPathWantsStoredHints(agent parser.AgentType) bool {
+	return !isOpenCodeFormatStorageAgent(agent)
 }
 
 func providerVirtualSourceBackedByEvent(sourcePath, eventPath string) bool {
@@ -1141,6 +1214,12 @@ func (e *Engine) resyncAllLocked(
 			Hint:   hint,
 		})
 	}
+
+	// Resync rebuilds the archive from scratch, so every shared-SQLite
+	// container and storage session must be re-verified against the
+	// fresh database.
+	e.clearTrustedSQLiteContainers()
+	e.clearTrustedOpenCodeStorageSessions()
 
 	origDB := e.db
 	origPath := origDB.Path()
@@ -1884,6 +1963,11 @@ func (e *Engine) syncAllLocked(
 		Detail: "Discovering sessions",
 	})
 
+	// Container states must be captured BEFORE discovery lists any session
+	// rows, so a promoted state can never be newer than the discovered
+	// session set (see captureSQLiteContainerStates).
+	preContainerStates := e.captureSQLiteContainerStates()
+
 	var all []parser.DiscoveredFile
 	counts := make(map[parser.AgentType]int)
 	providerFound, providerFailures := e.discoverProviderSources(ctx, scope)
@@ -1891,6 +1975,11 @@ func (e *Engine) syncAllLocked(
 		counts[file.Agent]++
 	}
 	all = append(all, providerFound...)
+
+	// Begin gate bookkeeping from the pre-filter discovery set: promotion
+	// needs a completion for every discovered session, so a cutoff-filtered
+	// pass must stay unpromotable (see opencode_container_gate.go).
+	e.beginSQLiteContainerPass(providerFound, preContainerStates)
 
 	quickSyncCutoff := !since.IsZero()
 	if quickSyncCutoff {
@@ -1971,6 +2060,11 @@ func (e *Engine) syncAllLocked(
 	for range providerFailures {
 		stats.RecordFailed()
 	}
+	// Discovery failures cannot be attributed to a provider here, so any
+	// failure conservatively blocks every container promotion this pass.
+	e.finishSQLiteContainerPass(
+		stats.Aborted || ctx.Err() != nil || providerFailures > 0,
+	)
 	stats.nonContainerDiscovered = nonContainerDiscovered
 	if verbose {
 		log.Printf(
@@ -3315,6 +3409,7 @@ func (e *Engine) collectAndBatch(
 				goto flush
 			}
 			stats.RecordFailed()
+			e.noteSQLiteContainerResult(r.path, false)
 			if r.cacheSkip && r.mtime != 0 && !r.noCacheSkip {
 				e.cacheSkip(r.skipCacheKey(), r.mtime, r.sourceFingerprint)
 			}
@@ -3326,6 +3421,7 @@ func (e *Engine) collectAndBatch(
 				e.cacheSkip(r.skipCacheKey(), r.mtime)
 			}
 			stats.RecordSkip()
+			e.noteSQLiteContainerResult(r.path, true)
 			progress.SessionsDone++
 			e.reportProgress(onProgress, progress)
 			continue
@@ -3349,6 +3445,7 @@ func (e *Engine) collectAndBatch(
 			); err != nil {
 				log.Printf("delete parser-excluded sessions: %v", err)
 				stats.RecordFailed()
+				e.noteSQLiteContainerResult(r.path, false)
 				continue
 			}
 			stats.parserExcludedIDs = append(
@@ -3364,6 +3461,7 @@ func (e *Engine) collectAndBatch(
 			if r.cacheSkip && !r.noCacheSkip {
 				e.cacheSkip(r.skipCacheKey(), r.mtime, r.sourceFingerprint)
 			}
+			e.noteSQLiteContainerResult(r.path, true)
 			progress.SessionsDone++
 			e.reportProgress(onProgress, progress)
 			continue
@@ -3381,6 +3479,16 @@ func (e *Engine) collectAndBatch(
 		// allow-list change must be able to pick them up again.
 		allowed, vetoed := e.splitResultsByCwdFilter(r.results)
 		stats.cwdFilteredSessions += vetoed
+		// A cwd-vetoed session parsed fine but was deliberately not
+		// persisted, and sessions parsed at DataVersionNeedsRetry are
+		// deferred work — neither is verified state, so their container
+		// must stay untrusted. The vetoed case matters because the gate
+		// must never hide a filtered session from a future allow-list
+		// change; such containers simply keep the pre-gate re-verify
+		// behavior.
+		e.noteSQLiteContainerResult(
+			r.path, vetoed == 0 && len(r.retrySessionIDs) == 0,
+		)
 		if vetoed > 0 && len(allowed) == 0 {
 			stats.cwdFilteredFiles++
 			progress.SessionsDone++
@@ -3402,11 +3510,14 @@ func (e *Engine) collectAndBatch(
 		} else {
 			for _, pr := range allowed {
 				pending = append(pending, pendingWrite{
-					sess:         pr.Session,
-					msgs:         pr.Messages,
-					usageEvents:  pr.UsageEvents,
-					needsRetry:   r.needsRetryForSession(pr.Session.ID),
-					forceReplace: r.forceReplace,
+					sess:              pr.Session,
+					msgs:              pr.Messages,
+					usageEvents:       pr.UsageEvents,
+					needsRetry:        r.needsRetryForSession(pr.Session.ID),
+					forceReplace:      r.forceReplace,
+					storageTrustPath:  r.storageTrustPath,
+					storageTrustState: r.storageTrustState,
+					storageTrustSnap:  r.storageTrustSnap,
 				})
 			}
 			// A Kiro SQLite store is discovered as one container source
@@ -3430,6 +3541,14 @@ func (e *Engine) collectAndBatch(
 			for range failedWrites {
 				stats.RecordFailed()
 			}
+			// Batch write failures cannot be attributed to individual
+			// sessions, so they block every container promotion this pass.
+			if failedWrites > 0 {
+				e.poisonSQLiteContainerPass()
+			}
+			e.promoteOpenCodeStorageTrustAfterWrite(
+				pending, writtenSessions, failedWrites, cwdFiltered,
+			)
 			stats.cwdFilteredSessions += cwdFiltered
 			progress.MessagesIndexed += writtenMessages
 			stats.messagesIndexed = progress.MessagesIndexed
@@ -3448,6 +3567,12 @@ flush:
 		for range failedWrites {
 			stats.RecordFailed()
 		}
+		if failedWrites > 0 {
+			e.poisonSQLiteContainerPass()
+		}
+		e.promoteOpenCodeStorageTrustAfterWrite(
+			pending, writtenSessions, failedWrites, cwdFiltered,
+		)
 		stats.cwdFilteredSessions += cwdFiltered
 		progress.MessagesIndexed += writtenMessages
 		stats.messagesIndexed = progress.MessagesIndexed
@@ -3546,6 +3671,14 @@ type processResult struct {
 	// suppressPresenceSweep marks an incomplete source result where
 	// missing stored sessions are expected rather than parser drift.
 	suppressPresenceSweep bool
+	// storageTrustPath/State/Snap carry an OpenCode-family storage
+	// session's pre-parse stat signature and invalidation snapshot to
+	// the write path, which promotes it once the session's batch is
+	// confirmed fully written (see opencode_storage_gate.go). Empty for
+	// everything else.
+	storageTrustPath  string
+	storageTrustState string
+	storageTrustSnap  storageTrustSnapshot
 }
 
 func (r processResult) needsRetryForSession(sessionID string) bool {
@@ -3700,6 +3833,26 @@ func (e *Engine) processProviderFile(
 	}
 	if file.ProviderSource != nil && !file.ProviderProcess && !usesProvider {
 		return processResult{}, false
+	}
+
+	// OpenCode-family shared-SQLite gate: when the whole container
+	// provably has not changed since the last fully verified pass, none
+	// of its sessions can have changed, so skip before paying for the
+	// per-session fingerprint (a DB open per source) and parse.
+	if e.sqliteContainerSourceFresh(file) {
+		return processResult{skip: true}, true
+	}
+
+	// OpenCode-family file-backed storage gate: when the session's
+	// per-file stat signature matches the last verified pass, its parse
+	// inputs are unchanged, so skip before re-reading the whole message
+	// and part tree (see opencode_storage_gate.go). The captured state
+	// also feeds the post-parse promotion below.
+	storageState, storageSnap, storageStateOK :=
+		e.openCodeStorageSessionGateState(file)
+	if storageStateOK &&
+		e.openCodeStorageSessionFresh(file.Path, storageState) {
+		return processResult{skip: true}, true
 	}
 
 	factory, ok := e.providerFactories[file.Agent]
@@ -3925,8 +4078,10 @@ func (e *Engine) processProviderFile(
 		}, true
 	}
 
+	parsedResults := parseOutcomeResults(outcome.Results)
+	parsedCount := len(parsedResults)
 	res := processResult{
-		results:               e.dropUnchangedSharedSQLiteResults(file, parseOutcomeResults(outcome.Results)),
+		results:               e.dropUnchangedSharedSQLiteResults(file, parsedResults),
 		excludedSessionIDs:    append([]string(nil), outcome.ExcludedSessionIDs...),
 		mtime:                 fingerprint.MTimeNS,
 		cacheSkip:             cacheSkip,
@@ -3959,6 +4114,12 @@ func (e *Engine) processProviderFile(
 		}
 	}
 	e.applyProviderFilePathPolicies(provider, file.Agent, &res)
+	if storageStateOK {
+		e.stageOpenCodeStorageTrust(
+			&res, file.Path, storageState, storageSnap,
+			parsedCount, outcome.ResultSetComplete,
+		)
+	}
 	return res, true
 }
 
@@ -5717,6 +5878,12 @@ type pendingWrite struct {
 	usageEvents  []parser.ParsedUsageEvent
 	needsRetry   bool
 	forceReplace bool
+	// storageTrustPath/State/Snap promote the session's OpenCode
+	// storage-gate trust after its batch is confirmed fully written.
+	// Empty for everything else.
+	storageTrustPath  string
+	storageTrustState string
+	storageTrustSnap  storageTrustSnapshot
 }
 
 func dataVersionForWrite(pw pendingWrite) int {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -153,12 +153,13 @@ type Engine struct {
 
 	// containerMu guards the OpenCode-family shared-SQLite freshness
 	// gate (see opencode_container_gate.go). trustedSQLiteContainers
-	// maps a container DB path to its state at the end of the last
-	// pass that verified every one of its sessions; containerPass is
-	// the bookkeeping for the pass currently running (nil outside
-	// passes). Both are in-memory only: a restart re-verifies once.
+	// maps a container DB path to its state and verified session-ID
+	// set at the end of the last pass that verified every one of its
+	// discovered sessions; containerPass is the bookkeeping for the
+	// pass currently running (nil outside passes). Both are in-memory
+	// only: a restart re-verifies once.
 	containerMu             gosync.Mutex
-	trustedSQLiteContainers map[string]parser.SQLiteContainerState
+	trustedSQLiteContainers map[string]trustedSQLiteContainer
 	containerPass           *sqliteContainerPass
 
 	// storageTrustMu guards the per-session freshness gate for

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -606,7 +606,7 @@ func (e *Engine) SyncPathsContext(ctx context.Context, paths []string) {
 		ctx, results, len(files), len(files), nil,
 		syncWriteDefault,
 	)
-	e.finishSQLiteContainerPass(true)
+	e.finishSQLiteContainerPass(true, false)
 	e.anomalies.applyTo(&stats)
 	e.persistSkipCache()
 
@@ -2063,8 +2063,11 @@ func (e *Engine) syncAllLocked(
 	}
 	// Discovery failures cannot be attributed to a provider here, so any
 	// failure conservatively blocks every container promotion this pass.
+	// Only unscoped passes discovered every root, so only they may drop
+	// trusted entries for containers that produced no sources.
 	e.finishSQLiteContainerPass(
 		stats.Aborted || ctx.Err() != nil || providerFailures > 0,
+		scope == nil,
 	)
 	stats.nonContainerDiscovered = nonContainerDiscovered
 	if verbose {

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -595,6 +595,446 @@ func TestSyncEngineOpenCodeSQLiteSameMtimeContentChangeUsesFingerprint(
 		"successful rewrite must bump local_modified_at for push windows")
 }
 
+// TestSyncEngineOpenCodeSQLiteUntouchedContainerSkipsReparse pins the
+// container-level freshness gate: when the shared opencode.db file is
+// completely untouched since the last verified sync, its sessions must be
+// counted as skipped (no per-session fingerprint, no parse) instead of
+// being re-parsed and dropped as unchanged after the fact.
+func TestSyncEngineOpenCodeSQLiteUntouchedContainerSkipsReparse(
+	t *testing.T,
+) {
+	env := setupSingleAgentTestEnv(t, parser.AgentOpenCode)
+	oc := createOpenCodeDB(t, env.opencodeDir)
+	oc.addProject(t, "proj", "/home/user/code/opencode-app")
+	seedOpenCodeSQLiteTextSession(
+		t, oc, "proj", "gated-one",
+		1779012000000, 1779012030000,
+		"first prompt", "first answer",
+	)
+	seedOpenCodeSQLiteTextSession(
+		t, oc, "proj", "gated-two",
+		1779012100000, 1779012130000,
+		"second prompt", "second answer",
+	)
+
+	stats := env.engine.SyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted, "first sync aborted: %+v", stats)
+	assert.Equal(t, 2, stats.Synced, "first sync writes both sessions")
+
+	stats = env.engine.SyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted, "second sync aborted: %+v", stats)
+	assert.Equal(t, 0, stats.Synced,
+		"untouched container must not re-emit sessions")
+	assert.Equal(t, 2, stats.Skipped,
+		"untouched container sessions must skip before parse")
+	assertMessageContent(
+		t, env.db, "opencode:gated-one",
+		"first prompt", "first answer",
+	)
+	assertMessageContent(
+		t, env.db, "opencode:gated-two",
+		"second prompt", "second answer",
+	)
+}
+
+// TestSyncEngineOpenCodeSQLiteStatIdenticalContentChangeStillReemits pins
+// the gate's safety boundary: file size and mtime equality alone must never
+// be trusted (mtime granularity differs across filesystems, and a rewrite
+// can land within one granularity unit). A content change that leaves the
+// container stat-identical — same size, mtime restored — still changes
+// SQLite's own write counters, so the sessions must be re-parsed and the
+// changed content re-emitted.
+func TestSyncEngineOpenCodeSQLiteStatIdenticalContentChangeStillReemits(
+	t *testing.T,
+) {
+	env := setupSingleAgentTestEnv(t, parser.AgentOpenCode)
+	oc := createOpenCodeDB(t, env.opencodeDir)
+	oc.addProject(t, "proj", "/home/user/code/opencode-app")
+	seedOpenCodeSQLiteTextSession(
+		t, oc, "proj", "stat-twin",
+		1779012000000, 1779012030000,
+		"original prompt", "original answer",
+	)
+
+	stats := env.engine.SyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted, "first sync aborted: %+v", stats)
+	assert.Equal(t, 1, stats.Synced, "first sync writes the session")
+
+	dbPath := filepath.Join(env.opencodeDir, "opencode.db")
+	before, err := os.Stat(dbPath)
+	require.NoError(t, err, "stat opencode.db")
+
+	time.Sleep(20 * time.Millisecond)
+	// Same-length replacement content keeps the SQLite file size stable, and
+	// the mtime is restored below, so only SQLite's internal change counter
+	// betrays the rewrite.
+	oc.replaceTextContent(
+		t, "stat-twin",
+		"replaced prompt", "replaced answer",
+		1779012000000,
+	)
+	after, err := os.Stat(dbPath)
+	require.NoError(t, err, "stat opencode.db after rewrite")
+	require.Equal(t, before.Size(), after.Size(),
+		"fixture must keep the container size stable for this test")
+	setFileMtime(t, dbPath, before.ModTime().UnixNano())
+
+	stats = env.engine.SyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted, "second sync aborted: %+v", stats)
+	assert.Equal(t, 1, stats.Synced,
+		"stat-identical content change must still be re-emitted")
+	assertMessageContent(
+		t, env.db, "opencode:stat-twin",
+		"replaced prompt", "replaced answer",
+	)
+}
+
+// TestSyncEngineOpenCodeSQLiteWALOnlyChangeStillReemits pins the gate's WAL
+// awareness: OpenCode runs its database in WAL mode, where a committed write
+// only appends frames to opencode.db-wal and leaves the main file's size,
+// mtime, and header change counter untouched until a checkpoint. A change
+// that lands only in the WAL must still be re-parsed and re-emitted.
+func TestSyncEngineOpenCodeSQLiteWALOnlyChangeStillReemits(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentOpenCode)
+	oc := createOpenCodeDB(t, env.opencodeDir)
+	oc.mustExec(t, "enable WAL", "PRAGMA journal_mode=WAL")
+	oc.addProject(t, "proj", "/home/user/code/opencode-app")
+	seedOpenCodeSQLiteTextSession(
+		t, oc, "proj", "wal-session",
+		1779012000000, 1779012030000,
+		"original prompt", "original answer",
+	)
+
+	stats := env.engine.SyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted, "first sync aborted: %+v", stats)
+	assert.Equal(t, 1, stats.Synced, "first sync writes the session")
+
+	dbPath := filepath.Join(env.opencodeDir, "opencode.db")
+	before, err := os.Stat(dbPath)
+	require.NoError(t, err, "stat opencode.db")
+
+	time.Sleep(20 * time.Millisecond)
+	oc.updateSessionTime(t, "wal-session", 1779015630000)
+	oc.replaceTextContent(
+		t, "wal-session",
+		"changed prompt", "changed answer",
+		1779015600000,
+	)
+	// The commit must have landed in the WAL only; a main-file change would
+	// mean this test no longer exercises the WAL-awareness of the gate.
+	after, err := os.Stat(dbPath)
+	require.NoError(t, err, "stat opencode.db after WAL write")
+	require.Equal(t, before.Size(), after.Size(),
+		"main DB file size must stay untouched by a WAL-mode commit")
+	require.Equal(t, before.ModTime(), after.ModTime(),
+		"main DB file mtime must stay untouched by a WAL-mode commit")
+
+	stats = env.engine.SyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted, "second sync aborted: %+v", stats)
+	assert.Equal(t, 1, stats.Synced,
+		"a WAL-only container change must still be re-emitted")
+	assertMessageContent(
+		t, env.db, "opencode:wal-session",
+		"changed prompt", "changed answer",
+	)
+}
+
+// TestSyncEngineOpenCodeSQLiteCwdFilteredContainerStaysUntrusted pins the
+// promotion invariant against the cwd allow-list: a session that parses but
+// is vetoed by the filter was deliberately not persisted, so its container
+// was not fully verified and must never be trusted. A later sync must
+// re-verify the container (no gate skips) instead of hiding the vetoed
+// session behind the trusted state.
+func TestSyncEngineOpenCodeSQLiteCwdFilteredContainerStaysUntrusted(
+	t *testing.T,
+) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	root := t.TempDir()
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentOpenCode: {root},
+		},
+		Machine:            "local",
+		IncludeCwdPrefixes: []string{"/home/user/code/keep-app"},
+	})
+	oc := createOpenCodeDB(t, root)
+	oc.addProject(t, "proj-keep", "/home/user/code/keep-app")
+	oc.addProject(t, "proj-drop", "/home/user/code/drop-app")
+	seedOpenCodeSQLiteTextSession(
+		t, oc, "proj-keep", "keep-session",
+		1779012000000, 1779012030000,
+		"keep prompt", "keep answer",
+	)
+	seedOpenCodeSQLiteTextSession(
+		t, oc, "proj-drop", "drop-session",
+		1779012100000, 1779012130000,
+		"drop prompt", "drop answer",
+	)
+
+	stats := engine.SyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted, "first sync aborted: %+v", stats)
+	assert.Equal(t, 1, stats.Synced, "only the allowed session is written")
+
+	stats = engine.SyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted, "second sync aborted: %+v", stats)
+	assert.Equal(t, 0, stats.Skipped,
+		"a container with cwd-vetoed sessions must not be gate-skipped")
+
+	kept, err := database.GetSessionFull(
+		context.Background(), "opencode:keep-session",
+	)
+	require.NoError(t, err)
+	assert.NotNil(t, kept, "allowed session must be archived")
+	dropped, err := database.GetSessionFull(
+		context.Background(), "opencode:drop-session",
+	)
+	require.NoError(t, err)
+	assert.Nil(t, dropped, "vetoed session must stay out of the archive")
+}
+
+// TestSyncEngineOpenCodeSQLiteCutoffPassMustNotTrustContainer guards the
+// gate's promotion rule: a cutoff-filtered pass discovers the container but
+// processes none of its sessions, so it has verified nothing and a later
+// full sync must still parse and write them.
+func TestSyncEngineOpenCodeSQLiteCutoffPassMustNotTrustContainer(
+	t *testing.T,
+) {
+	env := setupSingleAgentTestEnv(t, parser.AgentOpenCode)
+	oc := createOpenCodeDB(t, env.opencodeDir)
+	oc.addProject(t, "proj", "/home/user/code/opencode-app")
+	seedOpenCodeSQLiteTextSession(
+		t, oc, "proj", "filtered-session",
+		1779012000000, 1779012030000,
+		"first prompt", "first answer",
+	)
+
+	future := time.Now().Add(24 * time.Hour)
+	stats := env.engine.SyncAllSince(context.Background(), future, nil)
+	require.False(t, stats.Aborted, "cutoff sync aborted: %+v", stats)
+	assert.Equal(t, 0, stats.Synced, "future cutoff filters every source")
+
+	stats = env.engine.SyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted, "full sync aborted: %+v", stats)
+	assert.Equal(t, 1, stats.Synced,
+		"a cutoff-filtered pass must not mark the container verified")
+	assertMessageContent(
+		t, env.db, "opencode:filtered-session",
+		"first prompt", "first answer",
+	)
+}
+
+// TestSyncEngineOpenCodeStorageUntouchedSessionSkipsReparse pins the
+// per-session freshness gate for file-backed storage sessions: once a pass
+// has written (or verified) a session, an untouched session must skip
+// before fingerprinting and parsing on every later pass — including the
+// very next one after the write. The part file is made unreadable for the
+// gated pass, so any attempt to re-read the tree would surface as a
+// failure instead of a skip.
+func TestSyncEngineOpenCodeStorageUntouchedSessionSkipsReparse(
+	t *testing.T,
+) {
+	env := setupSingleAgentTestEnv(t, parser.AgentOpenCode)
+	storage := createOpenCodeStorageFixture(t, env.opencodeDir)
+	const sessionID = "oc-storage-gated"
+	storage.addSession(
+		t, "global", sessionID,
+		"/home/user/code/oc-app", "Storage Gated",
+		1704067200000, 1704067205000,
+	)
+	storage.addMessage(
+		t, sessionID, "msg-a1", "assistant",
+		1704067201000, nil,
+	)
+	partPath := storage.addTextPart(
+		t, sessionID, "msg-a1", "part-a1",
+		"gated storage reply", 1704067201000,
+	)
+
+	stats := env.engine.SyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted, "first sync aborted: %+v", stats)
+	assert.Equal(t, 1, stats.Synced, "first sync writes the session")
+
+	// The write pass itself promotes the session's stat signature, so
+	// the very next pass must already gate-skip it.
+	require.NoError(t, os.Chmod(partPath, 0o000), "make part unreadable")
+	t.Cleanup(func() {
+		_ = os.Chmod(partPath, 0o644)
+	})
+
+	stats = env.engine.SyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted, "gated sync aborted: %+v", stats)
+	assert.Equal(t, 0, stats.Failed,
+		"gated pass must not re-read message or part files")
+	assert.Equal(t, 1, stats.Skipped,
+		"verified-unchanged session must skip before parse")
+	assertMessageContent(
+		t, env.db, "opencode:"+sessionID, "gated storage reply",
+	)
+}
+
+// TestSyncEngineOpenCodeStorageAppendedMessageReemitsSession covers the
+// streaming case through the gate: a new message/part appended after the
+// session was trusted changes its stat signature, so the session re-parses
+// and re-emits exactly once, then settles back to skipping.
+func TestSyncEngineOpenCodeStorageAppendedMessageReemitsSession(
+	t *testing.T,
+) {
+	env := setupSingleAgentTestEnv(t, parser.AgentOpenCode)
+	storage := createOpenCodeStorageFixture(t, env.opencodeDir)
+	const sessionID = "oc-storage-append"
+	storage.addSession(
+		t, "global", sessionID,
+		"/home/user/code/oc-app", "Storage Append",
+		1704067200000, 1704067205000,
+	)
+	storage.addMessage(
+		t, sessionID, "msg-a1", "assistant",
+		1704067201000, nil,
+	)
+	storage.addTextPart(
+		t, sessionID, "msg-a1", "part-a1",
+		"first storage reply", 1704067201000,
+	)
+
+	stats := env.engine.SyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted, "first sync aborted: %+v", stats)
+	assert.Equal(t, 1, stats.Synced, "first sync writes the session")
+	stats = env.engine.SyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted, "second sync aborted: %+v", stats)
+	assert.Equal(t, 0, stats.Synced, "verification pass drops the unchanged session")
+
+	storage.addMessage(
+		t, sessionID, "msg-b1", "assistant",
+		1704067202000, nil,
+	)
+	storage.addTextPart(
+		t, sessionID, "msg-b1", "part-b1",
+		"second storage reply", 1704067202000,
+	)
+
+	stats = env.engine.SyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted, "append sync aborted: %+v", stats)
+	assert.Equal(t, 1, stats.Synced,
+		"appended message must re-emit the session")
+	assertMessageContent(
+		t, env.db, "opencode:"+sessionID,
+		"first storage reply", "second storage reply",
+	)
+}
+
+// TestSyncEngineOpenCodeStorageWatcherEventDoesNotRewriteUnchanged pins the
+// watcher path for file-backed storage sessions: a changed-path event that
+// resolves to a session whose parse output is already stored must not
+// rewrite it. Message/part events used to force-parse, which bypassed
+// dropUnchangedSharedSQLiteResults and rewrote the whole session (bumping
+// local_modified_at and amplifying remote pushes) on every streamed append
+// or spurious event re-fire.
+func TestSyncEngineOpenCodeStorageWatcherEventDoesNotRewriteUnchanged(
+	t *testing.T,
+) {
+	env := setupSingleAgentTestEnv(t, parser.AgentOpenCode)
+	storage := createOpenCodeStorageFixture(t, env.opencodeDir)
+	const sessionID = "oc-storage-watch-unchanged"
+	storage.addSession(
+		t, "global", sessionID,
+		"/home/user/code/oc-app", "Storage Watch",
+		1704067200000, 1704067205000,
+	)
+	storage.addMessage(
+		t, sessionID, "msg-a1", "assistant",
+		1704067201000, nil,
+	)
+	partPath := storage.addTextPart(
+		t, sessionID, "msg-a1", "part-a1",
+		"steady storage reply", 1704067201000,
+	)
+
+	stats := env.engine.SyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted, "first sync aborted: %+v", stats)
+	assert.Equal(t, 1, stats.Synced, "first sync writes the session")
+	fullID := "opencode:" + sessionID
+	before := openCodeLocalModifiedSnapshot(t, env.db, fullID)
+
+	env.engine.SyncPaths([]string{partPath})
+
+	after := openCodeLocalModifiedSnapshot(t, env.db, fullID)
+	assert.Equal(t, before[fullID], after[fullID],
+		"an event on an unchanged session must not rewrite it")
+	assertMessageContent(
+		t, env.db, fullID, "steady storage reply",
+	)
+
+	storage.addTextPart(
+		t, sessionID, "msg-a1", "part-a1",
+		"updated storage reply", 1704067203000,
+	)
+	env.engine.SyncPaths([]string{partPath})
+
+	assertMessageContent(
+		t, env.db, fullID, "updated storage reply",
+	)
+	final := openCodeLocalModifiedSnapshot(t, env.db, fullID)
+	assert.NotEqual(t, after[fullID], final[fullID],
+		"a real content change must rewrite the session")
+}
+
+// TestSyncEngineOpenCodeStorageStatIdenticalEventStillReemits pins the
+// gate's safety boundary on the watcher path: a child rewritten in place
+// with the same size and a restored mtime is invisible to the stat
+// signature, but the event names the change, so classification must
+// invalidate the session's trust and the next parse must re-emit the new
+// content.
+func TestSyncEngineOpenCodeStorageStatIdenticalEventStillReemits(
+	t *testing.T,
+) {
+	env := setupSingleAgentTestEnv(t, parser.AgentOpenCode)
+	storage := createOpenCodeStorageFixture(t, env.opencodeDir)
+	const sessionID = "oc-storage-stat-twin"
+	storage.addSession(
+		t, "global", sessionID,
+		"/home/user/code/oc-app", "Storage Stat Twin",
+		1704067200000, 1704067205000,
+	)
+	storage.addMessage(
+		t, sessionID, "msg-a1", "assistant",
+		1704067201000, nil,
+	)
+	partPath := storage.addTextPart(
+		t, sessionID, "msg-a1", "part-a1",
+		"stat twin reply AAAA", 1704067201000,
+	)
+
+	stats := env.engine.SyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted, "first sync aborted: %+v", stats)
+	assert.Equal(t, 1, stats.Synced, "first sync writes the session")
+	stats = env.engine.SyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted, "second sync aborted: %+v", stats)
+	assert.Equal(t, 0, stats.Synced, "verification pass drops the unchanged session")
+
+	beforeInfo, err := os.Stat(partPath)
+	require.NoError(t, err, "stat part before rewrite")
+	// Same-length replacement text keeps the part file size stable, and the
+	// mtime is restored below, so only the event says anything changed.
+	storage.addTextPart(
+		t, sessionID, "msg-a1", "part-a1",
+		"stat twin reply BBBB", 1704067201000,
+	)
+	afterInfo, err := os.Stat(partPath)
+	require.NoError(t, err, "stat part after rewrite")
+	require.Equal(t, beforeInfo.Size(), afterInfo.Size(),
+		"fixture must keep the part size stable for this test")
+	setFileMtime(t, partPath, beforeInfo.ModTime().UnixNano())
+
+	env.engine.SyncPaths([]string{partPath})
+
+	assertMessageContent(
+		t, env.db, "opencode:"+sessionID, "stat twin reply BBBB",
+	)
+}
+
 func TestSyncEngineOpenCodeSQLiteSameMtimeMetadataChangeUsesFingerprint(
 	t *testing.T,
 ) {

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -5431,6 +5431,84 @@ func TestOpenCodeHybridFullyShadowedContainerDropsStaleTrust(t *testing.T) {
 	)
 }
 
+// TestOpenCodeHybridWatcherShadowCycleDropsRowTrust pins the watcher-path
+// shadow/unshadow cycle: a storage JSON for a trusted SQLite row arrives
+// via a changed-path sync (which replaces the archived row but never
+// re-promotes containers) and disappears again before any full pass
+// observes the shadowed state. Processing the storage session must drop
+// the row's trusted membership, or the next full pass — container state
+// unchanged, membership still verified — would gate-skip the re-exposed
+// row forever and the archive would keep the interim storage copy.
+func TestOpenCodeHybridWatcherShadowCycleDropsRowTrust(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentOpenCode)
+	const sessionID = "oc-watcher-shadow"
+	sqlite := createOpenCodeDB(t, env.opencodeDir)
+	sqlite.addProject(t, "proj-1", "/home/user/code/app")
+	sqlite.addSession(t, sessionID, "proj-1", 1704067200000, 1704067299000)
+	sqlite.addMessage(t, "msg-q1", sessionID, "user", 1704067200000)
+	sqlite.addTextPart(
+		t, "part-q1", sessionID, "msg-q1",
+		"sqlite canonical question", 1704067200000,
+	)
+
+	// The verified pass trusts the container with the row's membership.
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1,
+		Synced:        1,
+	})
+
+	// A storage JSON for the same session arrives and is synced through
+	// the watcher's changed-path pass, replacing the archived row.
+	storage := createOpenCodeStorageFixture(t, env.opencodeDir)
+	sessionPath := storage.addSession(
+		t, "global", sessionID,
+		"/home/user/code/app", "Watcher Shadow",
+		1704067200000, 1704067205000,
+	)
+	storage.addMessage(
+		t, sessionID, "msg-s1", "assistant", 1704067201000, nil,
+	)
+	storage.addTextPart(
+		t, sessionID, "msg-s1", "part-s1",
+		"storage interim reply", 1704067201000,
+	)
+	storageMtime := time.UnixMilli(1704067205000)
+	require.NoError(t, filepath.WalkDir(
+		filepath.Join(env.opencodeDir, "storage"),
+		func(p string, _ fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			return os.Chtimes(p, storageMtime, storageMtime)
+		},
+	), "backdate storage tree")
+	env.engine.SyncPaths([]string{sessionPath})
+	assertMessageContent(
+		t, env.db, "opencode:"+sessionID, "storage interim reply",
+	)
+
+	// The storage copy disappears again without the watcher observing it
+	// and without any full pass having seen the shadowed state; the DB
+	// never changed.
+	require.NoError(t, os.Remove(sessionPath), "remove session json")
+	require.NoError(t, os.RemoveAll(filepath.Join(
+		env.opencodeDir, "storage", "message", sessionID,
+	)), "remove message dir")
+	require.NoError(t, os.RemoveAll(filepath.Join(
+		env.opencodeDir, "storage", "part", "msg-s1",
+	)), "remove part dir")
+
+	// The full pass must re-verify the re-exposed row: it is newer than
+	// the interim storage archive and takes the session back.
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1,
+		Synced:        1,
+	})
+	assertMessageContent(
+		t, env.db, "opencode:"+sessionID, "sqlite canonical question",
+	)
+}
+
 // TestFindSourceFileSkipsHybridRootMissingSession covers the
 // multi-root shadowing case: an early hybrid root with an
 // opencode.db that lacks the requested session must not shadow a

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -5347,6 +5347,90 @@ func TestOpenCodeHybridUnshadowedSQLiteSessionParsesAfterStorageRemoval(t *testi
 		"the session must now resolve to the SQLite source")
 }
 
+// TestOpenCodeHybridFullyShadowedContainerDropsStaleTrust pins the
+// shadow-then-unshadow cycle with no other rows: a verified SQLite-only
+// session gets shadowed by a later storage JSON, so the next full sync
+// discovers no SQLite sources at all for the container. That pass must
+// drop the container's trusted entry — otherwise the stale session set
+// still matches once the storage JSON is removed again (the DB never
+// changed), and the re-exposed row is gate-skipped instead of parsed.
+func TestOpenCodeHybridFullyShadowedContainerDropsStaleTrust(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentOpenCode)
+	const sessionID = "oc-reshadow"
+	sqlite := createOpenCodeDB(t, env.opencodeDir)
+	sqlite.addProject(t, "proj-1", "/home/user/code/app")
+	sqlite.addSession(t, sessionID, "proj-1", 1704067200000, 1704067299000)
+	sqlite.addMessage(t, "msg-q1", sessionID, "user", 1704067200000)
+	sqlite.addTextPart(
+		t, "part-q1", sessionID, "msg-q1",
+		"sqlite canonical question", 1704067200000,
+	)
+
+	// The verified pass sees only the SQLite row and trusts the container.
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1,
+		Synced:        1,
+	})
+	assertMessageContent(
+		t, env.db, "opencode:"+sessionID, "sqlite canonical question",
+	)
+
+	// A storage JSON appears for the same session and shadows the row;
+	// this full sync discovers no SQLite sources for the container.
+	storage := createOpenCodeStorageFixture(t, env.opencodeDir)
+	sessionPath := storage.addSession(
+		t, "global", sessionID,
+		"/home/user/code/app", "Reshadow",
+		1704067200000, 1704067205000,
+	)
+	storage.addMessage(
+		t, sessionID, "msg-s1", "assistant", 1704067201000, nil,
+	)
+	storage.addTextPart(
+		t, sessionID, "msg-s1", "part-s1",
+		"storage interim reply", 1704067201000,
+	)
+	// Backdate the storage tree so the SQLite copy stays comparably newer
+	// (the archived session mtime is a composite over files and dirs).
+	storageMtime := time.UnixMilli(1704067205000)
+	require.NoError(t, filepath.WalkDir(
+		filepath.Join(env.opencodeDir, "storage"),
+		func(p string, _ fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			return os.Chtimes(p, storageMtime, storageMtime)
+		},
+	), "backdate storage tree")
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1,
+		Synced:        1,
+	})
+	assertMessageContent(
+		t, env.db, "opencode:"+sessionID, "storage interim reply",
+	)
+
+	// The storage copy disappears again; the DB never changed, so a stale
+	// trusted entry from the first pass would still match and gate-skip
+	// the re-exposed, newer row.
+	require.NoError(t, os.Remove(sessionPath), "remove session json")
+	require.NoError(t, os.RemoveAll(filepath.Join(
+		env.opencodeDir, "storage", "message", sessionID,
+	)), "remove message dir")
+	require.NoError(t, os.RemoveAll(filepath.Join(
+		env.opencodeDir, "storage", "part", "msg-s1",
+	)), "remove part dir")
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 1,
+		Synced:        1,
+	})
+	assertMessageContent(
+		t, env.db, "opencode:"+sessionID, "sqlite canonical question",
+	)
+}
+
 // TestFindSourceFileSkipsHybridRootMissingSession covers the
 // multi-root shadowing case: an early hybrid root with an
 // opencode.db that lacks the requested session must not shadow a

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -5250,6 +5251,100 @@ func TestOpenCodeHybridRootSyncsSQLiteSessions(t *testing.T) {
 		t, env.db, "opencode:"+duplicateID,
 		"canonical storage reply",
 	)
+}
+
+// TestOpenCodeHybridUnshadowedSQLiteSessionParsesAfterStorageRemoval pins
+// the container gate against hybrid shadow removal: a SQLite row hidden by
+// a same-ID storage JSON during the verified pass becomes discoverable when
+// the storage copy is deleted, while the DB — and so its trusted state — is
+// untouched. The newly exposed row must be parsed and take over the
+// session, not gate-skipped as part of an unchanged container.
+func TestOpenCodeHybridUnshadowedSQLiteSessionParsesAfterStorageRemoval(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentOpenCode)
+	storage := createOpenCodeStorageFixture(t, env.opencodeDir)
+	const sessionID = "oc-unshadow"
+	sessionPath := storage.addSession(
+		t, "global", sessionID,
+		"/home/user/code/app", "Unshadow",
+		1704067200000, 1704067205000,
+	)
+	storage.addMessage(
+		t, sessionID, "msg-s1", "assistant", 1704067201000, nil,
+	)
+	storage.addTextPart(
+		t, sessionID, "msg-s1", "part-s1",
+		"storage canonical reply", 1704067201000,
+	)
+	// The archived storage session's mtime is a composite over the storage
+	// tree's files and directories; backdate the whole tree so the SQLite
+	// copy's updated time is comparably newer.
+	storageMtime := time.UnixMilli(1704067205000)
+	require.NoError(t, filepath.WalkDir(
+		filepath.Join(env.opencodeDir, "storage"),
+		func(p string, _ fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			return os.Chtimes(p, storageMtime, storageMtime)
+		},
+	), "backdate storage tree")
+
+	// The SQLite copy is newer than the storage copy from the start, so
+	// once exposed it must supersede the preserved storage archive; while
+	// the storage JSON exists, the same-ID shadow keeps the row out of
+	// discovery regardless of recency.
+	sqlite := createOpenCodeDB(t, env.opencodeDir)
+	sqlite.addProject(t, "proj-1", "/home/user/code/app")
+	sqlite.addSession(t, sessionID, "proj-1", 1704067200000, 1704067299000)
+	sqlite.addMessage(t, "msg-q1", sessionID, "user", 1704067200000)
+	sqlite.addTextPart(
+		t, "part-q1", sessionID, "msg-q1",
+		"sqlite only question", 1704067200000,
+	)
+	// A second, unshadowed row makes the verified pass discover the
+	// container at all — a fully shadowed container is never promoted, so
+	// only this row's presence puts the container's trust on the line.
+	const otherID = "oc-unshadow-other"
+	sqlite.addSession(t, otherID, "proj-1", 1704067200000, 1704067205000)
+	sqlite.addMessage(t, "msg-o1", otherID, "user", 1704067200000)
+	sqlite.addTextPart(
+		t, "part-o1", otherID, "msg-o1",
+		"other sqlite question", 1704067200000,
+	)
+
+	// The verified pass sees the storage copy and the unshadowed SQLite
+	// row; the shadowed row stays out of discovery, and the container is
+	// promoted to trusted with only the unshadowed row verified.
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 2,
+		Synced:        2,
+	})
+	assertMessageContent(
+		t, env.db, "opencode:"+sessionID, "storage canonical reply",
+	)
+
+	// Removing the storage copy exposes the SQLite row without touching
+	// the DB, so the container still matches its trusted state.
+	require.NoError(t, os.Remove(sessionPath), "remove session json")
+	require.NoError(t, os.RemoveAll(filepath.Join(
+		env.opencodeDir, "storage", "message", sessionID,
+	)), "remove message dir")
+	require.NoError(t, os.RemoveAll(filepath.Join(
+		env.opencodeDir, "storage", "part", "msg-s1",
+	)), "remove part dir")
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 2,
+		Synced:        1,
+		Skipped:       1,
+	})
+	assertMessageContent(
+		t, env.db, "opencode:"+sessionID, "sqlite only question",
+	)
+	virtualPath := parser.OpenCodeSQLiteVirtualPath(sqlite.path, sessionID)
+	assert.Equal(t, virtualPath,
+		env.engine.FindSourceFile("opencode:"+sessionID),
+		"the session must now resolve to the SQLite source")
 }
 
 // TestFindSourceFileSkipsHybridRootMissingSession covers the

--- a/internal/sync/opencode_container_gate.go
+++ b/internal/sync/opencode_container_gate.go
@@ -31,19 +31,18 @@ var openCodeFamilySQLiteAgents = []parser.AgentType{
 	parser.AgentIcodemate,
 }
 
-// sqliteContainerPathForFile maps a discovered file to its shared SQLite
-// container path, or "" when the file is not an OpenCode-family SQLite
-// virtual source (storage-mode JSON sessions included).
-func sqliteContainerPathForFile(file parser.DiscoveredFile) string {
+// sqliteContainerSourceForFile maps a discovered file to its shared SQLite
+// container path and session ID, or ok=false when the file is not an
+// OpenCode-family SQLite virtual source (storage-mode JSON sessions
+// included).
+func sqliteContainerSourceForFile(
+	file parser.DiscoveredFile,
+) (dbPath, sessionID string, ok bool) {
 	dbName := openCodeFormatDBName(file.Agent)
 	if dbName == "" {
-		return ""
+		return "", "", false
 	}
-	dbPath, _, ok := parser.ParseVirtualSourcePathForBase(file.Path, dbName)
-	if !ok {
-		return ""
-	}
-	return dbPath
+	return parser.ParseVirtualSourcePathForBase(file.Path, dbName)
 }
 
 // sqliteContainerPathForResultPath maps a processed result path back to its
@@ -61,14 +60,28 @@ func sqliteContainerPathForResultPath(path string) string {
 	return ""
 }
 
+// trustedSQLiteContainer is a container's state at the end of the last pass
+// that verified every one of its discovered sessions, together with exactly
+// which session IDs that pass discovered. The set matters in hybrid roots:
+// discovery drops SQLite rows shadowed by a same-ID storage JSON, so the
+// discoverable row set can grow — a storage JSON removed while the DB is
+// untouched exposes its row — without the container state changing. A
+// source may therefore gate-skip only when its session ID was part of the
+// verified set; a newly exposed row misses the set and parses.
+type trustedSQLiteContainer struct {
+	state    parser.SQLiteContainerState
+	sessions map[string]struct{}
+}
+
 // sqliteContainerPass tracks one sync pass's view of every OpenCode-family
-// SQLite container it discovered. captured is written once before workers
-// start and is read-only afterwards; completed and failed are touched only
-// by the single collectAndBatch goroutine, so no locking is needed during
-// the pass.
+// SQLite container it discovered. captured and sessions are written once
+// before workers start and are read-only afterwards; completed and failed
+// are touched only by the single collectAndBatch goroutine, so no locking
+// is needed during the pass.
 type sqliteContainerPass struct {
 	captured   map[string]parser.SQLiteContainerState
 	discovered map[string]int
+	sessions   map[string]map[string]struct{}
 	completed  map[string]int
 	failed     map[string]bool
 	poisoned   bool
@@ -130,19 +143,24 @@ func (e *Engine) beginSQLiteContainerPass(
 	}
 	var pass *sqliteContainerPass
 	for _, file := range files {
-		dbPath := sqliteContainerPathForFile(file)
-		if dbPath == "" {
+		dbPath, sessionID, ok := sqliteContainerSourceForFile(file)
+		if !ok {
 			continue
 		}
 		if pass == nil {
 			pass = &sqliteContainerPass{
 				captured:   make(map[string]parser.SQLiteContainerState),
 				discovered: make(map[string]int),
+				sessions:   make(map[string]map[string]struct{}),
 				completed:  make(map[string]int),
 				failed:     make(map[string]bool),
 			}
 		}
 		pass.discovered[dbPath]++
+		if pass.sessions[dbPath] == nil {
+			pass.sessions[dbPath] = make(map[string]struct{})
+		}
+		pass.sessions[dbPath][sessionID] = struct{}{}
 		if _, seen := pass.captured[dbPath]; seen || pass.failed[dbPath] {
 			continue
 		}
@@ -168,14 +186,18 @@ func (e *Engine) beginSQLiteContainerPass(
 }
 
 // sqliteContainerSourceFresh reports whether a discovered file belongs to a
-// container whose current state matches the last fully verified state, in
-// which case the session is unchanged and skips before fingerprinting.
+// container whose current state matches the last fully verified state AND
+// whose session ID was part of that verified pass, in which case the
+// session is unchanged and skips before fingerprinting. The membership
+// check covers hybrid roots, where the discoverable row set can grow (a
+// removed storage JSON stops shadowing its same-ID row) without the
+// container state changing; such a row was never verified and must parse.
 func (e *Engine) sqliteContainerSourceFresh(file parser.DiscoveredFile) bool {
 	if e.forceParse || file.ForceParse {
 		return false
 	}
-	dbPath := sqliteContainerPathForFile(file)
-	if dbPath == "" {
+	dbPath, sessionID, ok := sqliteContainerSourceForFile(file)
+	if !ok {
 		return false
 	}
 	e.containerMu.Lock()
@@ -188,7 +210,11 @@ func (e *Engine) sqliteContainerSourceFresh(file parser.DiscoveredFile) bool {
 		return false
 	}
 	trusted, ok := e.trustedSQLiteContainers[dbPath]
-	return ok && current == trusted
+	if !ok || current != trusted.state {
+		return false
+	}
+	_, verified := trusted.sessions[sessionID]
+	return verified
 }
 
 // noteSQLiteContainerResult records a processed file's outcome for
@@ -246,9 +272,12 @@ func (e *Engine) finishSQLiteContainerPass(incomplete bool) {
 		}
 		if e.trustedSQLiteContainers == nil {
 			e.trustedSQLiteContainers =
-				make(map[string]parser.SQLiteContainerState)
+				make(map[string]trustedSQLiteContainer)
 		}
-		e.trustedSQLiteContainers[dbPath] = state
+		e.trustedSQLiteContainers[dbPath] = trustedSQLiteContainer{
+			state:    state,
+			sessions: pass.sessions[dbPath],
+		}
 	}
 }
 

--- a/internal/sync/opencode_container_gate.go
+++ b/internal/sync/opencode_container_gate.go
@@ -255,12 +255,31 @@ func (e *Engine) poisonSQLiteContainerPass() {
 // without errors, retries, or write failures. incomplete marks passes that
 // must never promote (aborted, cancelled, or discovery failures whose
 // provider cannot be attributed).
-func (e *Engine) finishSQLiteContainerPass(incomplete bool) {
+//
+// fullDiscovery marks passes whose discovery covered every configured
+// root (full syncs, as opposed to changed-path or scoped-root passes).
+// Such a pass is authoritative for which rows are discoverable, so a
+// trusted container it discovered no sources for — fully shadowed by
+// storage JSONs, or gone — loses its trusted entry: the entry's session
+// set is no longer being maintained, and stale membership would otherwise
+// gate-skip a row re-exposed later by a storage removal that leaves the
+// DB untouched.
+func (e *Engine) finishSQLiteContainerPass(incomplete, fullDiscovery bool) {
 	e.containerMu.Lock()
 	defer e.containerMu.Unlock()
 	pass := e.containerPass
 	e.containerPass = nil
-	if pass == nil || pass.poisoned || incomplete {
+	if incomplete {
+		return
+	}
+	if fullDiscovery {
+		for dbPath := range e.trustedSQLiteContainers {
+			if pass == nil || pass.discovered[dbPath] == 0 {
+				delete(e.trustedSQLiteContainers, dbPath)
+			}
+		}
+	}
+	if pass == nil || pass.poisoned {
 		return
 	}
 	for dbPath, state := range pass.captured {

--- a/internal/sync/opencode_container_gate.go
+++ b/internal/sync/opencode_container_gate.go
@@ -1,0 +1,263 @@
+// ABOUTME: Container-level freshness gate for OpenCode-family shared
+// ABOUTME: SQLite databases, skipping per-session re-parse on idle syncs.
+package sync
+
+import (
+	"path/filepath"
+	"strings"
+
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+// The OpenCode-family providers fan one shared SQLite database into one
+// virtual source per session row. Per-session freshness cannot be decided
+// before parsing (a message or part row can change without bumping the
+// session's time_updated, which is why dropUnchangedSharedSQLiteResults
+// compares content fingerprints after the parse), so a periodic sync of an
+// untouched archive used to re-open and re-parse every session on every
+// pass. The gate restores an O(1) answer for the common idle case: when the
+// container file provably has not changed since a pass that verified every
+// one of its sessions — as decided by parser.SQLiteContainerState, which
+// rests on SQLite's own write markers rather than timestamp precision —
+// none of its sessions can have changed either, and they all skip before
+// fingerprinting.
+
+// openCodeFamilySQLiteAgents lists the agents whose sessions live in a
+// shared OpenCode-format SQLite container.
+var openCodeFamilySQLiteAgents = []parser.AgentType{
+	parser.AgentOpenCode,
+	parser.AgentKilo,
+	parser.AgentMiMoCode,
+	parser.AgentIcodemate,
+}
+
+// sqliteContainerPathForFile maps a discovered file to its shared SQLite
+// container path, or "" when the file is not an OpenCode-family SQLite
+// virtual source (storage-mode JSON sessions included).
+func sqliteContainerPathForFile(file parser.DiscoveredFile) string {
+	dbName := openCodeFormatDBName(file.Agent)
+	if dbName == "" {
+		return ""
+	}
+	dbPath, _, ok := parser.ParseVirtualSourcePathForBase(file.Path, dbName)
+	if !ok {
+		return ""
+	}
+	return dbPath
+}
+
+// sqliteContainerPathForResultPath maps a processed result path back to its
+// container. Result paths arrive without an agent, so every family DB name
+// is tried.
+func sqliteContainerPathForResultPath(path string) string {
+	for _, agent := range openCodeFamilySQLiteAgents {
+		dbPath, _, ok := parser.ParseVirtualSourcePathForBase(
+			path, openCodeFormatDBName(agent),
+		)
+		if ok {
+			return dbPath
+		}
+	}
+	return ""
+}
+
+// sqliteContainerPass tracks one sync pass's view of every OpenCode-family
+// SQLite container it discovered. captured is written once before workers
+// start and is read-only afterwards; completed and failed are touched only
+// by the single collectAndBatch goroutine, so no locking is needed during
+// the pass.
+type sqliteContainerPass struct {
+	captured   map[string]parser.SQLiteContainerState
+	discovered map[string]int
+	completed  map[string]int
+	failed     map[string]bool
+	poisoned   bool
+}
+
+// captureSQLiteContainerStates snapshots every configured OpenCode-family
+// SQLite container's state. It must run BEFORE discovery lists any session
+// rows: promotion may only trust a state that is at least as old as the
+// discovered session set, otherwise a session written between the listing
+// and a later capture would be promoted away and gate-skipped without ever
+// being parsed. Containers whose state cannot be read are simply absent
+// from the map and never promoted.
+func (e *Engine) captureSQLiteContainerStates() map[string]parser.SQLiteContainerState {
+	if e.forceParse {
+		return nil
+	}
+	states := make(map[string]parser.SQLiteContainerState)
+	for _, agent := range openCodeFamilySQLiteAgents {
+		for _, dir := range e.agentDirs[agent] {
+			if dir == "" || strings.HasPrefix(dir, "s3://") {
+				continue
+			}
+			src := resolveOpenCodeFormatSource(agent, filepath.Clean(dir))
+			if src.DBPath == "" {
+				continue
+			}
+			if state, ok := parser.StatSQLiteContainerState(src.DBPath); ok {
+				states[src.DBPath] = state
+			}
+		}
+	}
+	return states
+}
+
+// beginSQLiteContainerPass starts a pass's gate bookkeeping from the
+// discovered files and the pre-discovery container captures. files must be
+// the pre-filter discovery set: promotion requires seeing a completion for
+// every discovered session, so an mtime-cutoff or scope filter that drops
+// sessions from processing keeps the container untrusted. A discovered
+// container with no pre-discovery capture is marked failed and can neither
+// gate-skip nor be promoted this pass.
+//
+// It runs AFTER discovery, so each captured container is re-stat'ed here
+// and compared against its pre-discovery capture. A mismatch means the
+// container changed inside the capture-discovery window: the discovered
+// session set may already include that change, so gating against the
+// pre-discovery state would skip it while it still matches the trusted
+// state. Such containers are failed for the pass — no skips, no promotion
+// — and the next pass re-verifies them by content.
+func (e *Engine) beginSQLiteContainerPass(
+	files []parser.DiscoveredFile,
+	preStates map[string]parser.SQLiteContainerState,
+) {
+	if e.forceParse {
+		e.containerMu.Lock()
+		e.containerPass = nil
+		e.containerMu.Unlock()
+		return
+	}
+	var pass *sqliteContainerPass
+	for _, file := range files {
+		dbPath := sqliteContainerPathForFile(file)
+		if dbPath == "" {
+			continue
+		}
+		if pass == nil {
+			pass = &sqliteContainerPass{
+				captured:   make(map[string]parser.SQLiteContainerState),
+				discovered: make(map[string]int),
+				completed:  make(map[string]int),
+				failed:     make(map[string]bool),
+			}
+		}
+		pass.discovered[dbPath]++
+		if _, seen := pass.captured[dbPath]; seen || pass.failed[dbPath] {
+			continue
+		}
+		if state, ok := preStates[dbPath]; ok {
+			pass.captured[dbPath] = state
+		} else {
+			pass.failed[dbPath] = true
+		}
+	}
+	if pass != nil {
+		for dbPath, pre := range pass.captured {
+			if post, ok := parser.StatSQLiteContainerState(dbPath); ok &&
+				post == pre {
+				continue
+			}
+			delete(pass.captured, dbPath)
+			pass.failed[dbPath] = true
+		}
+	}
+	e.containerMu.Lock()
+	e.containerPass = pass
+	e.containerMu.Unlock()
+}
+
+// sqliteContainerSourceFresh reports whether a discovered file belongs to a
+// container whose current state matches the last fully verified state, in
+// which case the session is unchanged and skips before fingerprinting.
+func (e *Engine) sqliteContainerSourceFresh(file parser.DiscoveredFile) bool {
+	if e.forceParse || file.ForceParse {
+		return false
+	}
+	dbPath := sqliteContainerPathForFile(file)
+	if dbPath == "" {
+		return false
+	}
+	e.containerMu.Lock()
+	defer e.containerMu.Unlock()
+	if e.containerPass == nil {
+		return false
+	}
+	current, ok := e.containerPass.captured[dbPath]
+	if !ok {
+		return false
+	}
+	trusted, ok := e.trustedSQLiteContainers[dbPath]
+	return ok && current == trusted
+}
+
+// noteSQLiteContainerResult records a processed file's outcome for
+// promotion bookkeeping. Skips count as completions: a skipped session was
+// either gate-skipped against an already-trusted state or individually
+// verified fresh.
+func (e *Engine) noteSQLiteContainerResult(path string, ok bool) {
+	e.containerMu.Lock()
+	defer e.containerMu.Unlock()
+	pass := e.containerPass
+	if pass == nil {
+		return
+	}
+	dbPath := sqliteContainerPathForResultPath(path)
+	if dbPath == "" {
+		return
+	}
+	if ok {
+		pass.completed[dbPath]++
+	} else {
+		pass.failed[dbPath] = true
+	}
+}
+
+// poisonSQLiteContainerPass blocks every promotion for the current pass.
+// Used when a batched DB write fails, because batch failures cannot be
+// attributed to individual sessions.
+func (e *Engine) poisonSQLiteContainerPass() {
+	e.containerMu.Lock()
+	defer e.containerMu.Unlock()
+	if e.containerPass != nil {
+		e.containerPass.poisoned = true
+	}
+}
+
+// finishSQLiteContainerPass promotes the pass's captured container states
+// to trusted for every container whose discovered sessions all completed
+// without errors, retries, or write failures. incomplete marks passes that
+// must never promote (aborted, cancelled, or discovery failures whose
+// provider cannot be attributed).
+func (e *Engine) finishSQLiteContainerPass(incomplete bool) {
+	e.containerMu.Lock()
+	defer e.containerMu.Unlock()
+	pass := e.containerPass
+	e.containerPass = nil
+	if pass == nil || pass.poisoned || incomplete {
+		return
+	}
+	for dbPath, state := range pass.captured {
+		if pass.failed[dbPath] {
+			continue
+		}
+		if pass.completed[dbPath] != pass.discovered[dbPath] {
+			continue
+		}
+		if e.trustedSQLiteContainers == nil {
+			e.trustedSQLiteContainers =
+				make(map[string]parser.SQLiteContainerState)
+		}
+		e.trustedSQLiteContainers[dbPath] = state
+	}
+}
+
+// clearTrustedSQLiteContainers drops every trusted container state. Called
+// by resync, which rebuilds the archive from scratch and must re-verify
+// every session against it.
+func (e *Engine) clearTrustedSQLiteContainers() {
+	e.containerMu.Lock()
+	defer e.containerMu.Unlock()
+	e.trustedSQLiteContainers = nil
+	e.containerPass = nil
+}

--- a/internal/sync/opencode_container_gate.go
+++ b/internal/sync/opencode_container_gate.go
@@ -300,6 +300,38 @@ func (e *Engine) finishSQLiteContainerPass(incomplete, fullDiscovery bool) {
 	}
 }
 
+// dropTrustedSQLiteContainerSessionForStorage removes a processed storage
+// session's ID from its root's trusted container membership. From the
+// moment a file-backed storage session is processed, the archive's
+// canonical copy for that ID is the storage one, so a same-ID SQLite row —
+// even under an unchanged container state — no longer matches what its
+// membership verified. Without this, a storage JSON that arrives and
+// disappears entirely between full passes (both legs via watcher
+// changed-path syncs, which never re-promote containers) would leave the
+// stale membership in place, and the re-exposed row would gate-skip
+// forever while the archive kept the interim storage copy. The next fully
+// verified pass re-adds the ID once the row is actually re-verified.
+func (e *Engine) dropTrustedSQLiteContainerSessionForStorage(
+	agent parser.AgentType, sessionPath string,
+) {
+	// sessionPath is root/storage/<sessionSubdir>/<project>/<id>.json,
+	// mirroring the root derivation in StatOpenCodeStorageSessionState.
+	sessionID := strings.TrimSuffix(filepath.Base(sessionPath), ".json")
+	if sessionID == "" {
+		return
+	}
+	root := filepath.Dir(filepath.Dir(filepath.Dir(filepath.Dir(sessionPath))))
+	src := resolveOpenCodeFormatSource(agent, root)
+	if src.DBPath == "" {
+		return
+	}
+	e.containerMu.Lock()
+	defer e.containerMu.Unlock()
+	if trusted, ok := e.trustedSQLiteContainers[src.DBPath]; ok {
+		delete(trusted.sessions, sessionID)
+	}
+}
+
 // clearTrustedSQLiteContainers drops every trusted container state. Called
 // by resync, which rebuilds the archive from scratch and must re-verify
 // every session against it.

--- a/internal/sync/opencode_container_gate_internal_test.go
+++ b/internal/sync/opencode_container_gate_internal_test.go
@@ -1,0 +1,110 @@
+package sync
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+// newContainerTestDB creates a real SQLite file named like an OpenCode
+// container, so the pass's post-discovery recapture has something to stat.
+func newContainerTestDB(t *testing.T) (string, *sql.DB) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "opencode.db")
+	conn, err := sql.Open("sqlite3", path)
+	require.NoError(t, err, "open container db")
+	t.Cleanup(func() { _ = conn.Close() })
+	_, err = conn.Exec("CREATE TABLE session (id TEXT PRIMARY KEY)")
+	require.NoError(t, err, "create session table")
+	return path, conn
+}
+
+// TestSQLiteContainerPassPromotesOnlyPreDiscoveryCaptures pins the gate's
+// ordering invariant: the state promoted to trusted must have been captured
+// BEFORE discovery listed the container's sessions. Discovery reads the
+// session rows first, so a state captured afterwards can be newer than the
+// discovered set — a session written in between would then be gate-skipped
+// forever without ever being parsed. Containers with no pre-discovery
+// capture must therefore never be promoted, and promoted states must be
+// exactly the pre-discovery ones.
+func TestSQLiteContainerPassPromotesOnlyPreDiscoveryCaptures(t *testing.T) {
+	t.Run("missing pre-discovery capture blocks promotion", func(t *testing.T) {
+		e := &Engine{}
+		files := []parser.DiscoveredFile{
+			{Agent: parser.AgentOpenCode, Path: "/data/opencode.db#ses-1"},
+			{Agent: parser.AgentOpenCode, Path: "/data/opencode.db#ses-2"},
+		}
+		e.beginSQLiteContainerPass(
+			files, map[string]parser.SQLiteContainerState{},
+		)
+		e.noteSQLiteContainerResult("/data/opencode.db#ses-1", true)
+		e.noteSQLiteContainerResult("/data/opencode.db#ses-2", true)
+		e.finishSQLiteContainerPass(false)
+		assert.Empty(t, e.trustedSQLiteContainers,
+			"a container without a pre-discovery capture must not be trusted")
+	})
+
+	t.Run("promoted state is the pre-discovery capture", func(t *testing.T) {
+		e := &Engine{}
+		dbPath, _ := newContainerTestDB(t)
+		pre, ok := parser.StatSQLiteContainerState(dbPath)
+		require.True(t, ok, "container state must be readable")
+		files := []parser.DiscoveredFile{
+			{Agent: parser.AgentOpenCode, Path: dbPath + "#ses-1"},
+			{Agent: parser.AgentOpenCode, Path: dbPath + "#ses-2"},
+		}
+		e.beginSQLiteContainerPass(
+			files,
+			map[string]parser.SQLiteContainerState{dbPath: pre},
+		)
+		e.noteSQLiteContainerResult(dbPath+"#ses-1", true)
+		e.noteSQLiteContainerResult(dbPath+"#ses-2", true)
+		e.finishSQLiteContainerPass(false)
+		require.Contains(t, e.trustedSQLiteContainers, dbPath)
+		assert.Equal(t, pre, e.trustedSQLiteContainers[dbPath],
+			"trusted state must be exactly the pre-discovery capture")
+	})
+}
+
+// TestSQLiteContainerPassFailsOnCaptureDiscoveryMismatch pins the pass's
+// recapture check: a container that changed between the pre-discovery
+// capture and pass begin must neither gate-skip nor be promoted. The
+// discovered session set may already include the change, so gating against
+// the pre-discovery state — which still matches the trusted state — would
+// skip the changed sessions for the whole pass.
+func TestSQLiteContainerPassFailsOnCaptureDiscoveryMismatch(t *testing.T) {
+	e := &Engine{}
+	dbPath, conn := newContainerTestDB(t)
+	pre, ok := parser.StatSQLiteContainerState(dbPath)
+	require.True(t, ok, "container state must be readable")
+	// The container is trusted at the pre-discovery state, as after a
+	// fully verified idle pass.
+	e.trustedSQLiteContainers = map[string]parser.SQLiteContainerState{
+		dbPath: pre,
+	}
+
+	// The container changes inside the capture-discovery window.
+	_, err := conn.Exec("INSERT INTO session (id) VALUES ('ses-1')")
+	require.NoError(t, err, "write session inside the window")
+
+	file := parser.DiscoveredFile{
+		Agent: parser.AgentOpenCode, Path: dbPath + "#ses-1",
+	}
+	e.beginSQLiteContainerPass(
+		[]parser.DiscoveredFile{file},
+		map[string]parser.SQLiteContainerState{dbPath: pre},
+	)
+
+	assert.False(t, e.sqliteContainerSourceFresh(file),
+		"a mismatched container must not gate-skip its sessions")
+
+	e.noteSQLiteContainerResult(file.Path, true)
+	e.finishSQLiteContainerPass(false)
+	assert.Equal(t, pre, e.trustedSQLiteContainers[dbPath],
+		"a mismatched container must not be promoted past its trusted state")
+}

--- a/internal/sync/opencode_container_gate_internal_test.go
+++ b/internal/sync/opencode_container_gate_internal_test.go
@@ -66,8 +66,13 @@ func TestSQLiteContainerPassPromotesOnlyPreDiscoveryCaptures(t *testing.T) {
 		e.noteSQLiteContainerResult(dbPath+"#ses-2", true)
 		e.finishSQLiteContainerPass(false)
 		require.Contains(t, e.trustedSQLiteContainers, dbPath)
-		assert.Equal(t, pre, e.trustedSQLiteContainers[dbPath],
+		trusted := e.trustedSQLiteContainers[dbPath]
+		assert.Equal(t, pre, trusted.state,
 			"trusted state must be exactly the pre-discovery capture")
+		assert.Equal(t,
+			map[string]struct{}{"ses-1": {}, "ses-2": {}},
+			trusted.sessions,
+			"trusted set must be exactly the verified session IDs")
 	})
 }
 
@@ -84,8 +89,8 @@ func TestSQLiteContainerPassFailsOnCaptureDiscoveryMismatch(t *testing.T) {
 	require.True(t, ok, "container state must be readable")
 	// The container is trusted at the pre-discovery state, as after a
 	// fully verified idle pass.
-	e.trustedSQLiteContainers = map[string]parser.SQLiteContainerState{
-		dbPath: pre,
+	e.trustedSQLiteContainers = map[string]trustedSQLiteContainer{
+		dbPath: {state: pre, sessions: map[string]struct{}{"ses-1": {}}},
 	}
 
 	// The container changes inside the capture-discovery window.
@@ -105,6 +110,47 @@ func TestSQLiteContainerPassFailsOnCaptureDiscoveryMismatch(t *testing.T) {
 
 	e.noteSQLiteContainerResult(file.Path, true)
 	e.finishSQLiteContainerPass(false)
-	assert.Equal(t, pre, e.trustedSQLiteContainers[dbPath],
+	assert.Equal(t, pre, e.trustedSQLiteContainers[dbPath].state,
 		"a mismatched container must not be promoted past its trusted state")
+}
+
+// TestSQLiteContainerGateParsesNewlyUnshadowedSession pins the hybrid-root
+// invariant: hybrid discovery drops SQLite rows shadowed by a same-ID
+// storage JSON, so the discoverable row set can grow — a storage JSON
+// removed while the DB is untouched exposes its row — without the container
+// state changing. Trust therefore records which session IDs the verified
+// pass discovered, and only those may gate-skip; a newly exposed row was
+// never verified against the archive and must parse.
+func TestSQLiteContainerGateParsesNewlyUnshadowedSession(t *testing.T) {
+	e := &Engine{}
+	dbPath, _ := newContainerTestDB(t)
+	state, ok := parser.StatSQLiteContainerState(dbPath)
+	require.True(t, ok, "container state must be readable")
+
+	// A fully verified pass discovered only ses-1; ses-2's row was
+	// shadowed by its storage JSON at the time.
+	verified := parser.DiscoveredFile{
+		Agent: parser.AgentOpenCode, Path: dbPath + "#ses-1",
+	}
+	e.beginSQLiteContainerPass(
+		[]parser.DiscoveredFile{verified},
+		map[string]parser.SQLiteContainerState{dbPath: state},
+	)
+	e.noteSQLiteContainerResult(verified.Path, true)
+	e.finishSQLiteContainerPass(false)
+	require.Contains(t, e.trustedSQLiteContainers, dbPath)
+
+	// The storage JSON is removed; the DB is untouched. The next pass
+	// discovers ses-2's row for the first time.
+	exposed := parser.DiscoveredFile{
+		Agent: parser.AgentOpenCode, Path: dbPath + "#ses-2",
+	}
+	e.beginSQLiteContainerPass(
+		[]parser.DiscoveredFile{verified, exposed},
+		map[string]parser.SQLiteContainerState{dbPath: state},
+	)
+	assert.True(t, e.sqliteContainerSourceFresh(verified),
+		"the verified session must still gate-skip")
+	assert.False(t, e.sqliteContainerSourceFresh(exposed),
+		"a newly exposed row must parse despite the unchanged container")
 }

--- a/internal/sync/opencode_container_gate_internal_test.go
+++ b/internal/sync/opencode_container_gate_internal_test.go
@@ -44,7 +44,7 @@ func TestSQLiteContainerPassPromotesOnlyPreDiscoveryCaptures(t *testing.T) {
 		)
 		e.noteSQLiteContainerResult("/data/opencode.db#ses-1", true)
 		e.noteSQLiteContainerResult("/data/opencode.db#ses-2", true)
-		e.finishSQLiteContainerPass(false)
+		e.finishSQLiteContainerPass(false, true)
 		assert.Empty(t, e.trustedSQLiteContainers,
 			"a container without a pre-discovery capture must not be trusted")
 	})
@@ -64,7 +64,7 @@ func TestSQLiteContainerPassPromotesOnlyPreDiscoveryCaptures(t *testing.T) {
 		)
 		e.noteSQLiteContainerResult(dbPath+"#ses-1", true)
 		e.noteSQLiteContainerResult(dbPath+"#ses-2", true)
-		e.finishSQLiteContainerPass(false)
+		e.finishSQLiteContainerPass(false, true)
 		require.Contains(t, e.trustedSQLiteContainers, dbPath)
 		trusted := e.trustedSQLiteContainers[dbPath]
 		assert.Equal(t, pre, trusted.state,
@@ -109,7 +109,7 @@ func TestSQLiteContainerPassFailsOnCaptureDiscoveryMismatch(t *testing.T) {
 		"a mismatched container must not gate-skip its sessions")
 
 	e.noteSQLiteContainerResult(file.Path, true)
-	e.finishSQLiteContainerPass(false)
+	e.finishSQLiteContainerPass(false, true)
 	assert.Equal(t, pre, e.trustedSQLiteContainers[dbPath].state,
 		"a mismatched container must not be promoted past its trusted state")
 }
@@ -137,7 +137,7 @@ func TestSQLiteContainerGateParsesNewlyUnshadowedSession(t *testing.T) {
 		map[string]parser.SQLiteContainerState{dbPath: state},
 	)
 	e.noteSQLiteContainerResult(verified.Path, true)
-	e.finishSQLiteContainerPass(false)
+	e.finishSQLiteContainerPass(false, true)
 	require.Contains(t, e.trustedSQLiteContainers, dbPath)
 
 	// The storage JSON is removed; the DB is untouched. The next pass
@@ -153,4 +153,49 @@ func TestSQLiteContainerGateParsesNewlyUnshadowedSession(t *testing.T) {
 		"the verified session must still gate-skip")
 	assert.False(t, e.sqliteContainerSourceFresh(exposed),
 		"a newly exposed row must parse despite the unchanged container")
+}
+
+// TestSQLiteContainerFullPassDropsUndiscoveredTrust pins the stale-trust
+// cleanup: a complete full-discovery pass that finds no sources for a
+// trusted container (fully shadowed by storage JSONs, or gone) must drop
+// its trusted entry — the session set is no longer being maintained, and
+// stale membership would gate-skip a row re-exposed by a later storage
+// removal that leaves the DB untouched. Scoped and incomplete passes see
+// only a subset of roots, so absence there proves nothing and the entry
+// must survive.
+func TestSQLiteContainerFullPassDropsUndiscoveredTrust(t *testing.T) {
+	trusted := func() map[string]trustedSQLiteContainer {
+		return map[string]trustedSQLiteContainer{
+			"/data/opencode.db": {
+				sessions: map[string]struct{}{"ses-1": {}},
+			},
+		}
+	}
+
+	t.Run("full pass drops the undiscovered container", func(t *testing.T) {
+		e := &Engine{}
+		e.trustedSQLiteContainers = trusted()
+		e.beginSQLiteContainerPass(nil, nil)
+		e.finishSQLiteContainerPass(false, true)
+		assert.Empty(t, e.trustedSQLiteContainers,
+			"a full pass with no discovered sources must drop the trust")
+	})
+
+	t.Run("scoped pass keeps the entry", func(t *testing.T) {
+		e := &Engine{}
+		e.trustedSQLiteContainers = trusted()
+		e.beginSQLiteContainerPass(nil, nil)
+		e.finishSQLiteContainerPass(false, false)
+		assert.Contains(t, e.trustedSQLiteContainers, "/data/opencode.db",
+			"a scoped pass must not drop trust for out-of-scope containers")
+	})
+
+	t.Run("incomplete pass keeps the entry", func(t *testing.T) {
+		e := &Engine{}
+		e.trustedSQLiteContainers = trusted()
+		e.beginSQLiteContainerPass(nil, nil)
+		e.finishSQLiteContainerPass(true, true)
+		assert.Contains(t, e.trustedSQLiteContainers, "/data/opencode.db",
+			"an incomplete pass must not drop any trust")
+	})
 }

--- a/internal/sync/opencode_storage_gate.go
+++ b/internal/sync/opencode_storage_gate.go
@@ -1,0 +1,256 @@
+// ABOUTME: Per-session freshness gate for OpenCode-family file-backed
+// ABOUTME: storage sessions, skipping re-parse when the tree is unchanged.
+package sync
+
+import (
+	"path/filepath"
+	"strings"
+
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+// File-backed OpenCode-format sessions fan one session JSON plus its
+// message and part files into a single source whose parse re-reads the
+// whole tree. They are deliberately excluded from the mtime-keyed skip
+// cache (see shouldCacheSkip): the cache keys on a composite max-mtime,
+// which cannot see a child rewritten within one filesystem mtime granule
+// or with a restored timestamp. The consequence was that every full sync
+// and unwatched-root poll re-read and re-parsed every storage session of
+// an idle archive, and every watcher event on a streaming session
+// re-parsed its entire history.
+//
+// The gate restores a cheap answer for the unchanged case using
+// parser.StatOpenCodeStorageSessionState, a per-file (name, size, mtimeNS)
+// signature over exactly the files the parse would read. A session is
+// skipped before fingerprinting only when its current signature equals one
+// captured before a parse whose outcome the archive then absorbed: either
+// every parsed result was dropped as already stored, or the results were
+// confirmed fully written by the batch write path. The remaining blind
+// spot — an in-place child rewrite preserving both size and mtime — is
+// covered on the watcher path by invalidating trust for a session whenever
+// a changed-path event resolves to it, so an event-signaled change always
+// re-verifies by content. Trust is in-memory only: a restart re-verifies
+// every session once, mirroring the shared-SQLite container gate.
+
+// openCodeStorageSessionPath returns the discovered file's path when it is
+// a file-backed OpenCode-format storage session JSON under a storage-mode
+// root of its agent, or "" otherwise (SQLite containers and virtual rows
+// included). The root-mode walk mirrors shouldCacheSkip, which excludes
+// these same paths from the mtime skip cache.
+func (e *Engine) openCodeStorageSessionPath(file parser.DiscoveredFile) string {
+	if !isOpenCodeFormatStorageAgent(file.Agent) {
+		return ""
+	}
+	if filepath.Base(file.Path) == openCodeFormatDBName(file.Agent) {
+		return ""
+	}
+	if isOpenCodeFormatSQLiteVirtualPath(file.Agent, file.Path) {
+		return ""
+	}
+	for _, dir := range e.agentDirs[file.Agent] {
+		if dir == "" {
+			continue
+		}
+		src := resolveOpenCodeFormatSource(file.Agent, dir)
+		if src.Mode != parser.OpenCodeSourceStorage {
+			continue
+		}
+		rel, ok := isUnder(dir, file.Path)
+		if !ok {
+			continue
+		}
+		rel = filepath.ToSlash(rel)
+		sessionPrefix := "storage/" + filepath.Base(src.SessionRoot) + "/"
+		if strings.HasPrefix(rel, sessionPrefix) {
+			return file.Path
+		}
+		return ""
+	}
+	return ""
+}
+
+// storageTrustSnapshot marks a point in a session's invalidation history:
+// the trust epoch and the session's invalidation generation at capture
+// time. A promotion carries the snapshot taken before its parse; if either
+// counter has moved by promotion time, an invalidation landed after the
+// capture and the promotion is discarded rather than resurrecting trust
+// the invalidation just revoked.
+type storageTrustSnapshot struct {
+	epoch uint64
+	gen   uint64
+}
+
+// storageTrustSnapshotFor records the session's current invalidation
+// coordinates. It must be taken before the stat signature is captured:
+// an invalidation arriving after the snapshot then reliably blocks the
+// promotion, even when the change it signals is invisible to the stat
+// signature (a same-size, same-mtime child rewrite).
+func (e *Engine) storageTrustSnapshotFor(path string) storageTrustSnapshot {
+	e.storageTrustMu.Lock()
+	defer e.storageTrustMu.Unlock()
+	return storageTrustSnapshot{
+		epoch: e.storageTrustEpoch,
+		gen:   e.storageTrustGens[path],
+	}
+}
+
+// openCodeStorageSessionGateState captures the session's current stat
+// signature for the gate, along with the invalidation snapshot that any
+// later promotion of this capture must present. It returns ok=false when
+// the file is not a gateable storage session, this run force-parses, or
+// the signature cannot be captured; such sessions never skip and never
+// promote.
+func (e *Engine) openCodeStorageSessionGateState(
+	file parser.DiscoveredFile,
+) (string, storageTrustSnapshot, bool) {
+	if e.forceParse || file.ForceParse {
+		return "", storageTrustSnapshot{}, false
+	}
+	sessionPath := e.openCodeStorageSessionPath(file)
+	if sessionPath == "" {
+		return "", storageTrustSnapshot{}, false
+	}
+	snap := e.storageTrustSnapshotFor(sessionPath)
+	state, ok := parser.StatOpenCodeStorageSessionState(sessionPath)
+	if !ok {
+		return "", storageTrustSnapshot{}, false
+	}
+	return state, snap, true
+}
+
+// openCodeStorageSessionFresh reports whether the session's captured stat
+// signature matches the last verified one, in which case its parse inputs
+// are unchanged and it skips before fingerprinting.
+func (e *Engine) openCodeStorageSessionFresh(path, state string) bool {
+	if state == "" {
+		return false
+	}
+	e.storageTrustMu.Lock()
+	defer e.storageTrustMu.Unlock()
+	trusted, ok := e.trustedStorageSessions[path]
+	return ok && trusted == state
+}
+
+// promoteOpenCodeStorageSession records a stat signature that was captured
+// before a parse whose outcome the archive has since absorbed (results
+// dropped as already stored, or confirmed written). The
+// capture-before-parse ordering makes overlapping writes safe: a write
+// landing between capture and parse leaves the parsed content newer than
+// the signature, so the next capture mismatches and re-verifies. The
+// snapshot check covers the writes that ordering cannot: an invalidation
+// landing between capture and promotion (a watcher event classified while
+// a full sync was mid-pass) bumps the session's generation, so the stale
+// promotion is dropped and the next pass re-verifies by content.
+func (e *Engine) promoteOpenCodeStorageSession(
+	path, state string, snap storageTrustSnapshot,
+) {
+	if path == "" || state == "" {
+		return
+	}
+	e.storageTrustMu.Lock()
+	defer e.storageTrustMu.Unlock()
+	if snap.epoch != e.storageTrustEpoch || snap.gen != e.storageTrustGens[path] {
+		return
+	}
+	if e.trustedStorageSessions == nil {
+		e.trustedStorageSessions = make(map[string]string)
+	}
+	e.trustedStorageSessions[path] = state
+}
+
+// stageOpenCodeStorageTrust decides what a finished parse means for the
+// session's gate trust. A complete result set with no exclusions or
+// deferred retries either re-verified the session (every result dropped as
+// already stored — promote immediately) or produced content headed for the
+// write batch (stage the state on the result; the write path promotes it
+// once the batch is confirmed fully written). Anything else — retries,
+// exclusions, policy-suppressed results — invalidates so the next pass
+// re-verifies by content.
+func (e *Engine) stageOpenCodeStorageTrust(
+	res *processResult,
+	path, state string,
+	snap storageTrustSnapshot,
+	parsedCount int,
+	resultSetComplete bool,
+) {
+	clean := resultSetComplete &&
+		parsedCount > 0 &&
+		len(res.excludedSessionIDs) == 0 &&
+		res.retrySessionIDs == nil
+	if clean && len(res.results) == 0 {
+		e.promoteOpenCodeStorageSession(path, state, snap)
+		return
+	}
+	e.dropOpenCodeStorageTrust(path)
+	if clean {
+		res.storageTrustPath = path
+		res.storageTrustState = state
+		res.storageTrustSnap = snap
+	}
+}
+
+// promoteOpenCodeStorageTrustAfterWrite promotes the staged trust of every
+// session in a written batch, but only when the batch verifiably persisted
+// all of it: any failed, cwd-vetoed, or otherwise unwritten session leaves
+// the whole batch unpromoted (write failures are not attributable to
+// individual sessions), so those sessions re-verify on the next pass.
+func (e *Engine) promoteOpenCodeStorageTrustAfterWrite(
+	batch []pendingWrite,
+	writtenSessions, failedWrites, cwdFiltered int,
+) {
+	if failedWrites > 0 || cwdFiltered > 0 ||
+		writtenSessions != len(batch) {
+		return
+	}
+	for _, pw := range batch {
+		e.promoteOpenCodeStorageSession(
+			pw.storageTrustPath, pw.storageTrustState, pw.storageTrustSnap,
+		)
+	}
+}
+
+// dropOpenCodeStorageTrust removes the session's trusted signature without
+// bumping its invalidation generation. Used by the pass that owns the
+// session's staged promotion (results in flight to the write batch, or an
+// unclean parse), so the drop does not veto that same pass's promotion.
+func (e *Engine) dropOpenCodeStorageTrust(path string) {
+	if path == "" {
+		return
+	}
+	e.storageTrustMu.Lock()
+	defer e.storageTrustMu.Unlock()
+	delete(e.trustedStorageSessions, path)
+}
+
+// invalidateOpenCodeStorageSession drops trust for one session and bumps
+// its invalidation generation. Called when a watcher changed-path event
+// resolves to the session: the event says something changed even if the
+// stat signature cannot see it, so the next pass must re-verify by
+// content. The generation bump extends that guarantee across a
+// concurrently running pass — a promotion captured before the event
+// presents a stale snapshot and is discarded, so it cannot restore the
+// trust this invalidation revoked.
+func (e *Engine) invalidateOpenCodeStorageSession(path string) {
+	if path == "" {
+		return
+	}
+	e.storageTrustMu.Lock()
+	defer e.storageTrustMu.Unlock()
+	delete(e.trustedStorageSessions, path)
+	if e.storageTrustGens == nil {
+		e.storageTrustGens = make(map[string]uint64)
+	}
+	e.storageTrustGens[path]++
+}
+
+// clearTrustedOpenCodeStorageSessions drops every trusted session state
+// and starts a new trust epoch, so promotions staged before the clear are
+// discarded. Called by resync, which rebuilds the archive from scratch and
+// must re-verify every session against it.
+func (e *Engine) clearTrustedOpenCodeStorageSessions() {
+	e.storageTrustMu.Lock()
+	defer e.storageTrustMu.Unlock()
+	e.trustedStorageSessions = nil
+	e.storageTrustGens = nil
+	e.storageTrustEpoch++
+}

--- a/internal/sync/opencode_storage_gate_internal_test.go
+++ b/internal/sync/opencode_storage_gate_internal_test.go
@@ -1,0 +1,68 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestOpenCodeStorageInvalidationVetoesStalePromotion pins the gate's
+// snapshot invariant: an invalidation landing between a pass's pre-parse
+// capture and its post-write promotion must win. Watcher changed-path
+// classification runs outside syncMu, so it can invalidate a session while
+// a full sync is mid-pass; without the veto the pass's promotion would
+// restore the pre-event signature and a same-size, same-mtime rewrite —
+// the exact case the event invalidation exists to catch — would be skipped
+// on every later pass.
+func TestOpenCodeStorageInvalidationVetoesStalePromotion(t *testing.T) {
+	const path = "/data/storage/session/proj/ses_1.json"
+	const state = "sig-before-event"
+
+	t.Run("invalidation after capture blocks promotion", func(t *testing.T) {
+		e := &Engine{}
+		snap := e.storageTrustSnapshotFor(path)
+		e.invalidateOpenCodeStorageSession(path)
+		e.promoteOpenCodeStorageSession(path, state, snap)
+		assert.False(t, e.openCodeStorageSessionFresh(path, state),
+			"a promotion captured before the invalidation must be discarded")
+	})
+
+	t.Run("clear after capture blocks promotion", func(t *testing.T) {
+		e := &Engine{}
+		snap := e.storageTrustSnapshotFor(path)
+		e.clearTrustedOpenCodeStorageSessions()
+		e.promoteOpenCodeStorageSession(path, state, snap)
+		assert.False(t, e.openCodeStorageSessionFresh(path, state),
+			"a promotion captured before a resync clear must be discarded")
+	})
+
+	t.Run("undisturbed capture promotes", func(t *testing.T) {
+		e := &Engine{}
+		snap := e.storageTrustSnapshotFor(path)
+		e.promoteOpenCodeStorageSession(path, state, snap)
+		assert.True(t, e.openCodeStorageSessionFresh(path, state),
+			"a promotion with no intervening invalidation must land")
+	})
+
+	t.Run("own pass's in-flight drop does not veto", func(t *testing.T) {
+		e := &Engine{}
+		snap := e.storageTrustSnapshotFor(path)
+		// stageOpenCodeStorageTrust drops trust while staged results are
+		// in flight to the write batch; that drop belongs to the same
+		// pass and must not block the pass's own promotion.
+		e.dropOpenCodeStorageTrust(path)
+		e.promoteOpenCodeStorageSession(path, state, snap)
+		assert.True(t, e.openCodeStorageSessionFresh(path, state),
+			"the staging drop must not veto the same pass's promotion")
+	})
+
+	t.Run("invalidation bumps only its own session", func(t *testing.T) {
+		e := &Engine{}
+		const other = "/data/storage/session/proj/ses_2.json"
+		snap := e.storageTrustSnapshotFor(path)
+		e.invalidateOpenCodeStorageSession(other)
+		e.promoteOpenCodeStorageSession(path, state, snap)
+		assert.True(t, e.openCodeStorageSessionFresh(path, state),
+			"an unrelated session's invalidation must not veto this promotion")
+	})
+}


### PR DESCRIPTION
Fixes #1032.

## Problem

On an archive with ~4800 OpenCode sessions, every periodic sync — including the 2-minute unwatched-directory poll that kicks in when the watcher degrades (inotify budget on Linux) — burned 30+ seconds of CPU on a completely idle machine. A CPU profile of the steady-state pass put 42% in per-session `Fingerprint` calls (each one opening the shared SQLite DB to read a single `time_updated`) and 45% in re-parsing every session, a third of which was re-loading the full `project` table once per session. #1015 already stopped the resulting DB rewrites, but only after the parse, so the CPU cost remained.

The underlying constraint is that per-session freshness for OpenCode-family containers genuinely cannot be decided before parsing: a message or part row can change without bumping the session's `time_updated`, which is why #1015 compares content fingerprints post-parse. Any fix has to preserve that contract.

## What this does

- **Container-level freshness gate** (`internal/sync/opencode_container_gate.go`): when the shared container (`opencode.db` + `-wal`) provably has not changed since a pass that verified every one of its sessions, none of its sessions can have changed, and they all skip before fingerprinting. "Provably" does not rest on timestamp equality — filesystem mtime granularity ranges from ns to 2s, so comparisons finer than one second are not meaningful and mtimes participate only truncated to whole seconds. The decision rests on SQLite's own write markers: the header change counter, and the WAL's size, checkpoint sequence, and random salts, which advance on every commit regardless of any clock. Regression tests pin the two boundaries that matter: a stat-identical content rewrite (same size, restored mtime) is still re-emitted, and a WAL-only commit — OpenCode's normal write path, which leaves the main file's stat and change counter untouched — still invalidates the gate.
- Containers are trusted only after a pass with a clean completion for every discovered session; cutoff-filtered, scoped, aborted, watcher-subset, or partially failed passes never promote, and trust is in-memory only so a restart re-verifies once.
- **Fingerprint stops re-opening the DB per session**: discovery already lists `time_updated` for every row in one query, so it now rides on the `SourceRef`.
- **Project table memoized per container state**: each parsed session used to re-query the full `project` table; the map is now cached keyed by the same container state, removing ~13s of CPU per changed-container pass on the test dataset.

Warm sync of the 4794-session reproduction dropped from 5.9s (main) / 11.9s (v0.36.1, as reported) to ~50ms; editing one session re-emits exactly that session and the next poll gates again.

## Limitations and where to look

- A genuinely changed container still re-verifies all of its sessions — that is #1015's content-fingerprint contract, deliberately untouched. Profiling shows the remaining cost there is per-session SQLite connection setup (each parse opens its own handle); sharing a pooled handle per container is a follow-up because it changes provider lifecycle and file-lock behavior on Windows.
- Storage-mode OpenCode roots (per-session JSON files) have no single container file to gate and keep the existing behavior.
- Reviewers should look hardest at the promotion bookkeeping in `collectAndBatch`/`syncAllLocked` (when a pass may re-trust a container) and at `parser.SQLiteContainerState` (what "unchanged" means).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<sup>generated by a clanker</sup>

## Stacked: the same fix for file-backed storage sessions (sustained CPU in #1022)

Two further commits extend the gate to storage-mode roots (`storage/session/*.json` plus message/part trees), which the section above deliberately left out. Storage sessions had no pre-parse freshness gate at all — they are excluded from the mtime skip cache because a composite max-mtime can hide a child rewritten within one mtime granule — so every full sync and unwatched-root poll re-read and re-parsed every storage session, and every watcher event on a streaming session force-parsed and rewrote its entire history. That is the constant 150-180% CPU reported in #1022.

- **Per-session storage gate** (`internal/sync/opencode_storage_gate.go`, `internal/parser/opencode_storage_state.go`): a session skips before fingerprinting when its per-file (name, size, mtimeNS) signature over exactly the files the parse would read matches one captured before a parse whose outcome the archive absorbed — every result dropped as already stored, or the results confirmed fully written by the batch write path (batches with any failure or veto promote nothing). Trust is in-memory only and cleared on resync, mirroring the container gate.
- **Watcher message/part events no longer force-parse** (removes still do): the classifier instead invalidates the resolved session's trust, so an event-signaled change re-verifies by content even when it is stat-identical — that boundary is pinned by a regression test — while unchanged re-fires are filtered by `dropUnchangedSharedSQLiteResults` instead of rewriting the session and bumping `local_modified_at` on every streamed append.
- **Storage-mode `Fingerprint` is stat-only now**: its content hash re-read and re-hashed every message and part file per call, and no engine freshness gate consumes it; `Parse` computes the authoritative storage fingerprint.
- **The per-event `ListStoredSourcePathHints` query is skipped** for this family: its `SourcesForChangedPath` never reads stored hints, so the LIKE scan over every stored session row was computed and discarded on every watcher event.

Remaining limitation, deliberate: a poll (no watcher event) cannot see an in-place child rewrite that preserves both size and mtime; unlike SQLite there are no write markers in plain JSON trees. A restart re-verifies everything once.
