### PR TITLE
perf(sync): release large backfill heaps after signal recompute

### DIFF
--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -237,9 +237,7 @@ func runServe(cfg config.Config, opts serveOptions) {
 		go idleTracker.Do(func() {
 			if err := database.BackfillSignals(
 				ctx,
-				func(bCtx context.Context, id string) error {
-					return engine.RecomputeSignals(bCtx, id)
-				},
+				engine.BackfillSignalComputer(),
 			); err != nil && ctx.Err() == nil {
 				log.Printf("signals backfill: %v", err)
 			}

--- a/internal/db/search_content_bench_test.go
+++ b/internal/db/search_content_bench_test.go
@@ -3,6 +3,8 @@ package db
 import (
 	"context"
 	"fmt"
+	"io"
+	"log"
 	"testing"
 )
 
@@ -42,6 +44,9 @@ const (
 // instead of filling with outside-run hits.
 func seedContentSearchBench(b *testing.B, d *DB) {
 	b.Helper()
+	origLog := log.Writer()
+	log.SetOutput(io.Discard)
+	b.Cleanup(func() { log.SetOutput(origLog) })
 	for i := range benchContentSessions {
 		sessionID := fmt.Sprintf("bench-search-%03d", i)
 		if err := d.UpsertSession(Session{

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -247,7 +247,7 @@ func NewEngine(
 	// Errors are logged inside recomputeSignalsFromDB and are
 	// non-fatal: the next write or flush retries.
 	recompute := func(sessionID string) {
-		_ = e.recomputeSignalsFromDB(
+		_, _ = e.recomputeSignalsFromDB(
 			context.Background(), sessionID,
 		)
 	}
@@ -5625,7 +5625,28 @@ func (e *Engine) RecomputeSignals(
 			"RecomputeSignals refused on report-only parse-diff engine",
 		)
 	}
-	return e.recomputeSignalsFromDB(ctx, sessionID)
+	_, err := e.recomputeSignalsFromDB(ctx, sessionID)
+	return err
+}
+
+// BackfillSignalComputer returns a signal recompute closure for archive
+// backfills that releases transient heap after enough loaded content has
+// crossed the threshold.
+func (e *Engine) BackfillSignalComputer() func(context.Context, string) error {
+	var release recomputeHeapReleaser
+	return func(ctx context.Context, sessionID string) error {
+		if e.refuseWriteInForceParse("BackfillSignalComputer") {
+			return errors.New(
+				"BackfillSignalComputer refused on report-only parse-diff engine",
+			)
+		}
+		heapBytes, err := e.recomputeSignalsFromDB(ctx, sessionID)
+		if err != nil {
+			return err
+		}
+		release.Account(heapBytes)
+		return nil
+	}
 }
 
 // recomputeSignalsFromDB loads a session's full message history
@@ -5635,15 +5656,15 @@ func (e *Engine) RecomputeSignals(
 // incremental writes).
 func (e *Engine) recomputeSignalsFromDB(
 	ctx context.Context, sessionID string,
-) error {
+) (int, error) {
 	sess, err := e.db.GetSessionFull(ctx, sessionID)
 	if err != nil {
-		return fmt.Errorf(
+		return 0, fmt.Errorf(
 			"loading session %s: %w", sessionID, err,
 		)
 	}
 	if sess == nil {
-		return nil
+		return 0, nil
 	}
 	msgs, err := e.db.GetAllMessages(ctx, sessionID)
 	if err != nil {
@@ -5651,11 +5672,12 @@ func (e *Engine) recomputeSignalsFromDB(
 			"signals: load messages %s: %v",
 			sessionID, err,
 		)
-		return fmt.Errorf(
+		return 0, fmt.Errorf(
 			"loading messages %s: %w", sessionID, err,
 		)
 	}
 	update, findings := computeSignalsAndSecrets(*sess, msgs)
+	heapBytes := recomputeHeapBytes(msgs, findings)
 	// Findings persist before the signals update: UpdateSessionSignals
 	// advances quality_signal_version, which BackfillSignals treats as
 	// proof the whole compute persisted. Writing it last keeps a
@@ -5665,7 +5687,7 @@ func (e *Engine) recomputeSignalsFromDB(
 		sessionID, findings, update.SecretLeakCount, update.SecretsRulesVersion,
 	); err != nil {
 		log.Printf("secrets: persist %s: %v", sessionID, err)
-		return fmt.Errorf("persisting findings %s: %w", sessionID, err)
+		return 0, fmt.Errorf("persisting findings %s: %w", sessionID, err)
 	}
 	if err := e.db.UpdateSessionSignals(
 		sessionID, update,
@@ -5673,11 +5695,11 @@ func (e *Engine) recomputeSignalsFromDB(
 		log.Printf(
 			"signals: update %s: %v", sessionID, err,
 		)
-		return fmt.Errorf(
+		return 0, fmt.Errorf(
 			"updating signals %s: %w", sessionID, err,
 		)
 	}
-	return nil
+	return heapBytes, nil
 }
 
 type pendingWrite struct {

--- a/internal/sync/parsediff_integration_test.go
+++ b/internal/sync/parsediff_integration_test.go
@@ -2255,6 +2255,14 @@ func TestParseDiffEngineRefusesWrites(t *testing.T) {
 			" WHERE id = ?", sessionID)
 	mutateDB(t, env,
 		"DELETE FROM secret_findings WHERE session_id = ?", sessionID)
+	require.Error(t, diffEngine.BackfillSignalComputer()(ctx, sessionID),
+		"BackfillSignalComputer on a report-only engine must error")
+	mutateDB(t, env,
+		"UPDATE sessions SET secret_leak_count = 0, "+
+			"secrets_rules_version = '', quality_signal_version = 0"+
+			" WHERE id = ?", sessionID)
+	mutateDB(t, env,
+		"DELETE FROM secret_findings WHERE session_id = ?", sessionID)
 	_, err = diffEngine.ScanSecrets(
 		ctx, sync.SecretScanInput{Backfill: true}, nil,
 	)

--- a/internal/sync/recompute_memory.go
+++ b/internal/sync/recompute_memory.go
@@ -1,0 +1,58 @@
+package sync
+
+import (
+	"runtime/debug"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+const recomputeHeapReleaseDefaultThreshold = 256 << 20
+
+var (
+	recomputeHeapReleaseThreshold = recomputeHeapReleaseDefaultThreshold
+	freeRecomputeHeap             = debug.FreeOSMemory
+)
+
+type recomputeHeapReleaser struct {
+	pendingBytes int
+}
+
+func (r *recomputeHeapReleaser) Account(heapBytes int) {
+	r.pendingBytes += heapBytes
+	if r.pendingBytes < recomputeHeapReleaseThreshold {
+		return
+	}
+	r.pendingBytes = 0
+	freeRecomputeHeap()
+}
+
+func recomputeHeapBytes(
+	msgs []db.Message, findings []db.SecretFinding,
+) int {
+	total := 0
+	for _, msg := range msgs {
+		total += len(msg.Content) + len(msg.ThinkingText) +
+			len(msg.Timestamp) + len(msg.Model) + len(msg.TokenUsage) +
+			len(msg.ClaudeMessageID) + len(msg.ClaudeRequestID) +
+			len(msg.SourceType) + len(msg.SourceSubtype) +
+			len(msg.SourceUUID) + len(msg.SourceParentUUID)
+		for _, tc := range msg.ToolCalls {
+			total += len(tc.ToolName) + len(tc.Category) +
+				len(tc.ToolUseID) + len(tc.InputJSON) +
+				len(tc.FilePath) + len(tc.SkillName) +
+				len(tc.ResultContent) + len(tc.SubagentSessionID)
+			for _, ev := range tc.ResultEvents {
+				total += len(ev.ToolUseID) + len(ev.AgentID) +
+					len(ev.SubagentSessionID) + len(ev.Source) +
+					len(ev.Status) + len(ev.Content) +
+					len(ev.Timestamp)
+			}
+		}
+	}
+	for _, finding := range findings {
+		total += len(finding.SessionID) + len(finding.RuleName) +
+			len(finding.Confidence) + len(finding.LocationKind) +
+			len(finding.RedactedMatch) + len(finding.RulesVersion)
+	}
+	return total
+}

--- a/internal/sync/recompute_memory_test.go
+++ b/internal/sync/recompute_memory_test.go
@@ -1,0 +1,156 @@
+package sync
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/db"
+)
+
+func TestRecomputeHeapBytesCountsLoadedText(t *testing.T) {
+	callIndex := 0
+	eventIndex := 1
+	msgs := []db.Message{{
+		SessionID: "s1",
+		Ordinal:   0,
+		Content:   "message",
+		ToolCalls: []db.ToolCall{{
+			ToolName:      "Bash",
+			Category:      "Bash",
+			ToolUseID:     "tool-1",
+			InputJSON:     `{"cmd":"echo"}`,
+			ResultContent: "legacy result",
+			ResultEvents: []db.ToolResultEvent{{
+				ToolUseID: "tool-1",
+				Status:    "completed",
+				Content:   "event result",
+			}},
+		}},
+	}}
+	findings := []db.SecretFinding{{
+		SessionID:      "s1",
+		RuleName:       "aws-access-key",
+		Confidence:     "definite",
+		LocationKind:   "tool_result_event",
+		MessageOrdinal: 0,
+		CallIndex:      &callIndex,
+		EventIndex:     &eventIndex,
+		RedactedMatch:  "AKIA************PLJM",
+		RulesVersion:   "v1",
+	}}
+
+	got := recomputeHeapBytes(msgs, findings)
+
+	assert.GreaterOrEqual(t, got, len("message")+len(`{"cmd":"echo"}`)+
+		len("legacy result")+len("event result")+
+		len("AKIA************PLJM"))
+}
+
+func TestBackfillSignalComputerReleasesAccumulatedHeap(t *testing.T) {
+	fx := newEngineFixture(t)
+	ctx := context.Background()
+	const id = "s1"
+	require.NoError(t, fx.db.UpsertSession(db.Session{
+		ID: id, Project: "proj", Machine: "m", Agent: "claude",
+		MessageCount: 1, UserMessageCount: 1,
+	}))
+	require.NoError(t, fx.db.ReplaceSessionMessages(id, []db.Message{{
+		SessionID: id,
+		Ordinal:   0,
+		Role:      "user",
+		Content:   strings.Repeat("x", 128),
+	}}))
+
+	oldThreshold := recomputeHeapReleaseThreshold
+	oldFree := freeRecomputeHeap
+	defer func() {
+		recomputeHeapReleaseThreshold = oldThreshold
+		freeRecomputeHeap = oldFree
+	}()
+	recomputeHeapReleaseThreshold = 1
+	var calls int
+	freeRecomputeHeap = func() {
+		calls++
+	}
+
+	compute := fx.engine.BackfillSignalComputer()
+	require.NoError(t, compute(ctx, id))
+
+	assert.Equal(t, 1, calls)
+}
+
+func TestRecomputeSignalsDoesNotReleaseHeapDirectly(t *testing.T) {
+	fx := newEngineFixture(t)
+	ctx := context.Background()
+	const id = "s1"
+	require.NoError(t, fx.db.UpsertSession(db.Session{
+		ID: id, Project: "proj", Machine: "m", Agent: "claude",
+		MessageCount: 1, UserMessageCount: 1,
+	}))
+	require.NoError(t, fx.db.ReplaceSessionMessages(id, []db.Message{{
+		SessionID: id,
+		Ordinal:   0,
+		Role:      "user",
+		Content:   strings.Repeat("x", 128),
+	}}))
+
+	oldThreshold := recomputeHeapReleaseThreshold
+	oldFree := freeRecomputeHeap
+	defer func() {
+		recomputeHeapReleaseThreshold = oldThreshold
+		freeRecomputeHeap = oldFree
+	}()
+	recomputeHeapReleaseThreshold = 1
+	var calls int
+	freeRecomputeHeap = func() {
+		calls++
+	}
+
+	require.NoError(t, fx.engine.RecomputeSignals(ctx, id))
+
+	assert.Zero(t, calls)
+}
+
+func TestRecomputeHeapReleaserSkipsSmallSessions(t *testing.T) {
+	oldThreshold := recomputeHeapReleaseThreshold
+	oldFree := freeRecomputeHeap
+	defer func() {
+		recomputeHeapReleaseThreshold = oldThreshold
+		freeRecomputeHeap = oldFree
+	}()
+	recomputeHeapReleaseThreshold = 128
+	var calls int
+	freeRecomputeHeap = func() {
+		calls++
+	}
+
+	var release recomputeHeapReleaser
+	release.Account(127)
+
+	assert.Zero(t, calls)
+}
+
+func TestRecomputeHeapReleaserAccumulatesBeforeRelease(t *testing.T) {
+	oldThreshold := recomputeHeapReleaseThreshold
+	oldFree := freeRecomputeHeap
+	defer func() {
+		recomputeHeapReleaseThreshold = oldThreshold
+		freeRecomputeHeap = oldFree
+	}()
+	recomputeHeapReleaseThreshold = 128
+	var calls int
+	freeRecomputeHeap = func() {
+		calls++
+	}
+
+	var release recomputeHeapReleaser
+	release.Account(64)
+	release.Account(63)
+	assert.Zero(t, calls)
+
+	release.Account(1)
+	assert.Equal(t, 1, calls)
+}


### PR DESCRIPTION
Large local archives can finish initial sync and then keep the backend daemon's heap inflated while the background signal and secret backfill walks archived sessions. That path loads each session's full messages, tool calls, and tool result event content, computes signals and secret findings, persists the derived rows, then moves on to the next session. With thousands of archived sessions, those per-session allocations can be dead while the runtime still holds the expanded heap.

This change adds a narrow memory-pressure release to the signal backfill compute path. The sync engine now estimates the loaded content bytes for each successful recompute and accumulates those bytes across the backfill walk. When the accumulated payload crosses a 256 MiB threshold, it calls the runtime memory release hook and resets the counter. Direct delayed signal recomputes keep their existing behavior and do not force a release.

The scope is intentionally small. This does not rewrite message storage APIs, stream secret scanning, change parser behavior, alter remote or artifact sync, or touch the frontend WebView cache work from #261. It also keeps the CPU loop from #1032 separate; that issue was fixed in v0.37.1, while this path addresses memory growth during archived signal backfill.

Focused coverage proves the byte accounting includes hydrated message, tool, result event, and finding payloads, the backfill closure releases after accumulated bytes cross the threshold, below-threshold recomputes do not release, and direct `RecomputeSignals` stays outside the forced-release path.

Closes #1022
