### PR TITLE
fix(sync): honor shutdown signal during watcher-driven syncs

### DIFF
--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -227,6 +227,20 @@ func runServe(cfg config.Config, opts serveOptions) {
 			return
 		}
 
+		// The initial sync can leave hundreds of MB in the WAL, and
+		// SQLite checkpoints the whole log — not cancellable — when the
+		// final connection closes. A SIGTERM landing shortly after
+		// startup would spend the service manager's stop timeout inside
+		// that close and get escalated to SIGKILL, so truncate the WAL
+		// now at a controlled moment. Persistent readers just leave it
+		// for the periodic checkpoint loop.
+		if err := database.CheckpointWALTruncateWithRetry(
+			ctx,
+		); err != nil && !errors.Is(err, db.ErrWALCheckpointBusy) &&
+			ctx.Err() == nil {
+			log.Printf("post-sync wal checkpoint: %v", err)
+		}
+
 		// Backfill runs in the background. On a large DB (e.g.
 		// after copying tens of thousands of orphaned sessions
 		// during a resync), walking every row to recompute
@@ -353,13 +367,18 @@ func runServe(cfg config.Config, opts serveOptions) {
 		stopWatcher, unwatchedDirs := startFileWatcher(
 			cfg, engine, func(paths []string) {
 				idleTracker.Do(func() {
-					engine.SyncPaths(paths)
+					// The serve ctx must reach watcher-driven syncs:
+					// stopWatcher waits for the in-flight callback, so
+					// a sync that ignored SIGTERM would hold shutdown
+					// open until the service manager escalates to
+					// SIGKILL.
+					engine.SyncPathsContext(ctx, paths)
 				})
 			},
 		)
 		defer stopWatcher()
 		if len(unwatchedDirs) > 0 {
-			go startUnwatchedPoll(engine, unwatchedDirs, idleTracker)
+			go startUnwatchedPoll(ctx, engine, unwatchedDirs, idleTracker)
 		}
 	}
 
@@ -1411,20 +1430,28 @@ type unwatchedPollSyncer interface {
 }
 
 func startUnwatchedPoll(
+	ctx context.Context,
 	engine unwatchedPollSyncer,
 	roots []string,
 	idleTracker *server.IdleTracker,
 ) {
 	ticker := time.NewTicker(unwatchedPollInterval)
 	defer ticker.Stop()
-	for range ticker.C {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
 		log.Println("Polling unwatched directories...")
 		idleTracker.Do(func() {
-			pollUnwatchedRootsOnce(engine, roots)
+			pollUnwatchedRootsOnce(ctx, engine, roots)
 		})
 	}
 }
 
-func pollUnwatchedRootsOnce(engine unwatchedPollSyncer, roots []string) {
-	engine.SyncRootsSince(context.Background(), roots, time.Time{}, nil)
+func pollUnwatchedRootsOnce(
+	ctx context.Context, engine unwatchedPollSyncer, roots []string,
+) {
+	engine.SyncRootsSince(ctx, roots, time.Time{}, nil)
 }

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -241,8 +241,8 @@ func TestPollUnwatchedRootsOnceUsesScopedFullSync(t *testing.T) {
 	fake := &fakeUnwatchedPollSyncer{}
 	roots := []string{"/tmp/claude", "/tmp/codex"}
 
-	pollUnwatchedRootsOnce(fake, roots)
-	pollUnwatchedRootsOnce(fake, roots)
+	pollUnwatchedRootsOnce(t.Context(), fake, roots)
+	pollUnwatchedRootsOnce(t.Context(), fake, roots)
 
 	require.Equal(t, 2, fake.calls)
 	assert.Equal(t, roots, fake.callRoots[0])

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -531,6 +531,15 @@ func (r processResult) skipCacheKey(path string) string {
 // Paths that don't match known session file patterns are
 // silently ignored.
 func (e *Engine) SyncPaths(paths []string) {
+	e.SyncPathsContext(context.Background(), paths)
+}
+
+// SyncPathsContext is SyncPaths with caller-controlled cancellation. The
+// file watcher threads the serve shutdown context through here: its stop
+// path waits for the in-flight onChange callback, so a watcher-driven sync
+// that ignored SIGTERM would hold shutdown until a service manager's kill
+// timeout instead of aborting between files like every other sync path.
+func (e *Engine) SyncPathsContext(ctx context.Context, paths []string) {
 	if e.refuseWriteInForceParse("SyncPaths") {
 		return
 	}
@@ -555,9 +564,9 @@ func (e *Engine) SyncPaths(paths []string) {
 	e.resetS3CodexIndexCache()
 
 	e.anomalies.reset()
-	results := e.startWorkers(context.Background(), files)
+	results := e.startWorkers(ctx, files)
 	stats = e.collectAndBatch(
-		context.Background(), results, len(files), len(files), nil,
+		ctx, results, len(files), len(files), nil,
 		syncWriteDefault,
 	)
 	e.anomalies.applyTo(&stats)

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -391,6 +391,48 @@ func setFileMtime(t *testing.T, path string, mtimeNS int64) {
 	require.NoError(t, os.Chtimes(path, ts, ts), "chtimes %s", path)
 }
 
+// TestSyncPathsContextCancelledAbortsWithoutWriting pins shutdown
+// responsiveness for watcher-driven syncs: SyncPathsContext must honor its
+// context and abort before writing, instead of running the sync to
+// completion while Watcher.Stop (and therefore SIGTERM shutdown) waits on
+// it. The same paths sync fine once the context is live again.
+func TestSyncPathsContextCancelledAbortsWithoutWriting(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentOpenCode)
+	storage := createOpenCodeStorageFixture(t, env.opencodeDir)
+	const sessionID = "oc-cancelled-sync"
+	sessionPath := storage.addSession(
+		t, "global", sessionID,
+		"/home/user/code/oc-app", "Cancelled Sync",
+		1704067200000, 1704067205000,
+	)
+	storage.addMessage(
+		t, sessionID, "msg-a1", "assistant",
+		1704067201000, nil,
+	)
+	storage.addTextPart(
+		t, sessionID, "msg-a1", "part-a1",
+		"cancelled sync reply", 1704067201000,
+	)
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	env.engine.SyncPathsContext(cancelled, []string{sessionPath})
+
+	sess, err := env.db.GetSessionFull(
+		context.Background(), "opencode:"+sessionID,
+	)
+	require.NoError(t, err, "GetSessionFull after cancelled sync")
+	assert.Nil(t, sess,
+		"a cancelled watcher sync must not write the session")
+
+	env.engine.SyncPathsContext(
+		context.Background(), []string{sessionPath},
+	)
+	assertMessageContent(
+		t, env.db, "opencode:"+sessionID, "cancelled sync reply",
+	)
+}
+
 func TestSyncEngineOpenCodeFamilySQLiteDropsUnchangedContainerSessions(
 	t *testing.T,
 ) {

--- a/internal/sync/watcher.go
+++ b/internal/sync/watcher.go
@@ -158,6 +158,18 @@ func (w *Watcher) loop() {
 	defer ticker.Stop()
 
 	for {
+		// The select below picks randomly among ready cases, so a
+		// continuous event or ticker stream can keep winning over a
+		// closed stop channel — each round running another flush and
+		// its onChange sync — and starve Stop past a service
+		// manager's kill timeout. Check stop first so Stop() returns
+		// after at most the callback already in flight; pending
+		// changes are picked up by the next startup sync.
+		select {
+		case <-w.stop:
+			return
+		default:
+		}
 		select {
 		case <-w.stop:
 			return

--- a/internal/sync/watcher_test.go
+++ b/internal/sync/watcher_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -51,6 +52,71 @@ func pollUntil(t *testing.T, condition func() bool) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatal("pollUntil: condition not met within deadline")
+}
+
+// TestWatcherStopPreemptsPendingFlushes pins the loop's stop priority: once
+// Stop is signalled, the loop must exit after at most the in-flight
+// onChange callback, even with more pending changes and ticker fires ready.
+// Without the priority check the loop's select picks randomly among ready
+// cases, so a continuous event stream could keep winning over the closed
+// stop channel — each round running another long onChange sync — and starve
+// Stop past a service manager's kill timeout.
+func TestWatcherStopPreemptsPendingFlushes(t *testing.T) {
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	var calls atomic.Int32
+	w, dir := startTestWatcherNoCleanup(t, func([]string) {
+		calls.Add(1)
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		<-release
+	}, 10*time.Millisecond)
+
+	require.NoError(t,
+		os.WriteFile(filepath.Join(dir, "a.jsonl"), []byte("a"), 0o644))
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for onChange to start")
+	}
+
+	// Plant a pending change that is already older than the debounce
+	// while the first flush is blocked inside onChange. The ticker keeps
+	// firing during the block, so the moment the loop resumes it has a
+	// ready ticker case whose flush would deliver this entry.
+	w.mu.Lock()
+	w.pending[filepath.Join(dir, "b.jsonl")] =
+		time.Now().Add(-time.Second)
+	w.mu.Unlock()
+
+	stopped := make(chan struct{})
+	go func() {
+		w.Stop()
+		close(stopped)
+	}()
+	// Wait for Stop to close the stop channel before releasing the
+	// in-flight callback, so the loop's next iteration must observe it.
+	select {
+	case <-w.stop:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Stop to signal the loop")
+	}
+	// Keep the callback blocked past a debounce interval so the ticker
+	// fires and buffers a tick while the loop is busy. At resume both
+	// the closed stop channel and the tick are ready — exactly the race
+	// the stop-priority check must win every time.
+	time.Sleep(5 * w.debounce)
+	close(release)
+
+	select {
+	case <-stopped:
+	case <-time.After(5 * time.Second):
+		t.Fatal("watcher Stop did not return after the in-flight flush")
+	}
+	assert.Equal(t, int32(1), calls.Load(),
+		"pending changes must not flush once stop is signalled")
 }
 
 func TestWatcherCallsOnChange(t *testing.T) {


### PR DESCRIPTION
Addresses the shutdown half of #1022: systemd sent SIGTERM, the daemon kept syncing past the stop timeout, and the service manager escalated to SIGKILL.

## What changed

- **Watcher-driven syncs now honor the run context.** The fsnotify callback and the unwatched-roots poll previously called `SyncPaths`, which ran the worker pool under `context.Background()` — a SIGTERM mid-sync had to wait out the whole pass (minutes on large opencode storage trees). `SyncPathsContext` threads the signal context into `startWorkers` and `collectAndBatch`, so an in-flight sync aborts at the next file boundary without writing partial batches. `SyncPaths` remains as a `context.Background()` wrapper for callers without a lifecycle context.
- **The watcher loop checks stop before other work.** Go's `select` picks randomly among ready cases, so a continuous event or ticker stream could keep winning over the closed stop channel, each round running another flush and its onChange sync. A stop pre-check makes `Stop()` return after at most the callback already in flight; pending changes are picked up by the next startup sync.
- **The unwatched-roots poll exits on context cancellation** instead of sleeping through its next tick.
- **A WAL truncate checkpoint runs after the initial sync**, so a large initial pass no longer leaves the WAL to be checkpointed on the final connection close — previously that full checkpoint ran during shutdown and added to the stall.

## Where to look

- `internal/sync/engine.go` — `SyncPathsContext` and context threading.
- `internal/sync/watcher.go` — stop-priority check in the loop.
- `cmd/agentsview/main.go` — watcher callback, poll loop, and post-sync checkpoint wiring.

## Limitations

Cancellation is checked at file boundaries; a single very large file still parses to completion before the abort takes effect.