### PR TITLE
fix(parser): populate SkillName in OpenCode tool-call extraction

### DIFF
--- a/internal/parser/opencode.go
+++ b/internal/parser/opencode.go
@@ -816,15 +816,18 @@ func extractOpenCodeToolCall(data, cwd string) ParsedToolCall {
 	}
 }
 
-// inferOpenCodeSkillName infers a skill name for a non-"skill"
-// OpenCode tool call by trying the Cursor-style read-file
-// heuristic first, then the Codex-style shell read-command
-// heuristic, resolving relative SKILL.md paths against the
-// session's project worktree when the tool call itself carries no
-// working-directory hint.
 func inferOpenCodeSkillName(toolName, inputJSON, cwd string) string {
-	if name := inferCursorSkillName(toolName, inputJSON); name != "" {
-		return name
+	if isCursorSkillReadTool(toolName) {
+		// OpenCode's read-tool input carries no cwd/workdir key, so
+		// inferSkillNameFromJSONPaths can't resolve relative SKILL.md
+		// paths and falls back to the parent directory name. Try the
+		// file_path directly against the session worktree first.
+		if fp := gjson.Get(inputJSON, "file_path").Str; fp != "" && cwd != "" {
+			if name := skillNameFromPath(fp, cwd); name != "" {
+				return name
+			}
+		}
+		return inferSkillNameFromJSONPaths(inputJSON)
 	}
 	return inferCodexSkillNameWithBase(toolName, inputJSON, cwd)
 }

--- a/internal/parser/opencode.go
+++ b/internal/parser/opencode.go
@@ -494,7 +494,7 @@ func buildOpenCodeParsedSession(
 		})
 
 		pm := buildOpenCodeMessage(
-			ordinal, role, m.timeCreated, msgParts,
+			ordinal, role, m.timeCreated, msgParts, worktree,
 		)
 		applyOpenCodeTokenUsage(&pm, md, m.data, msgParts)
 		if strings.TrimSpace(pm.Content) == "" &&
@@ -690,6 +690,7 @@ func buildOpenCodeMessage(
 	role RoleType,
 	timeCreatedMs int64,
 	parts []openCodePartRow,
+	cwd string,
 ) ParsedMessage {
 	var (
 		texts       []string
@@ -708,7 +709,7 @@ func buildOpenCodeMessage(
 			}
 		case "tool":
 			hasToolUse = true
-			tc := extractOpenCodeToolCall(p.data)
+			tc := extractOpenCodeToolCall(p.data, cwd)
 			if tc.ToolName != "" {
 				toolCalls = append(toolCalls, tc)
 			}
@@ -779,7 +780,7 @@ type openCodeToolState struct {
 	Input json.RawMessage `json:"input"`
 }
 
-func extractOpenCodeToolCall(data string) ParsedToolCall {
+func extractOpenCodeToolCall(data, cwd string) ParsedToolCall {
 	var d openCodeToolData
 	if err := json.Unmarshal([]byte(data), &d); err != nil {
 		return ParsedToolCall{}
@@ -795,12 +796,37 @@ func extractOpenCodeToolCall(data string) ParsedToolCall {
 		}
 	}
 
+	var skillName string
+	switch d.ToolName {
+	case "skill":
+		skillName = gjson.Get(inputJSON, "skill").Str
+		if skillName == "" {
+			skillName = gjson.Get(inputJSON, "name").Str
+		}
+	default:
+		skillName = inferOpenCodeSkillName(d.ToolName, inputJSON, cwd)
+	}
+
 	return ParsedToolCall{
 		ToolUseID: d.CallID,
 		ToolName:  d.ToolName,
 		Category:  NormalizeToolCategory(d.ToolName),
 		InputJSON: inputJSON,
+		SkillName: skillName,
 	}
+}
+
+// inferOpenCodeSkillName infers a skill name for a non-"skill"
+// OpenCode tool call by trying the Cursor-style read-file
+// heuristic first, then the Codex-style shell read-command
+// heuristic, resolving relative SKILL.md paths against the
+// session's project worktree when the tool call itself carries no
+// working-directory hint.
+func inferOpenCodeSkillName(toolName, inputJSON, cwd string) string {
+	if name := inferCursorSkillName(toolName, inputJSON); name != "" {
+		return name
+	}
+	return inferCodexSkillNameWithBase(toolName, inputJSON, cwd)
 }
 
 type openCodeStorageTime struct {

--- a/internal/parser/opencode_test.go
+++ b/internal/parser/opencode_test.go
@@ -837,6 +837,104 @@ func TestParseOpenCodeDB_ToolParts(t *testing.T) {
 	}})
 }
 
+// TestParseOpenCodeDB_SkillTool verifies that a "skill" tool part
+// populates ParsedToolCall.SkillName straight from the tool's own
+// input, without going through the read-file/shell-command
+// inference heuristics. Before this fix extractOpenCodeToolCall
+// never set SkillName at all (#1040).
+func TestParseOpenCodeDB_SkillTool(t *testing.T) {
+	dbPath, seeder, db := newTestDB(t)
+	defer db.Close()
+
+	seeder.AddProject("prj_1", "/tmp/proj")
+	seeder.AddSession("ses_skill", "prj_1", "", "", 1700000000000, 1700000030000)
+
+	seeder.AddMessage("msg_u", "ses_skill", 1700000000000, 1700000000000, `{"role":"user"}`)
+	seeder.AddPart("prt_u", "msg_u", "ses_skill", 1700000000000, 1700000000000, `{"type":"text","text":"use the doc-writer skill"}`)
+
+	seeder.AddMessage("msg_a", "ses_skill", 1700000010000, 1700000010000, `{"role":"assistant"}`)
+	seeder.AddPart("prt_t", "msg_a", "ses_skill", 1700000010000, 1700000010000,
+		`{"type":"tool","tool":"skill","callID":"call_skill","state":{"input":{"name":"doc-writer"}}}`)
+
+	sessions, err := parseOpenCodeAll(dbPath, "m")
+	require.NoError(t, err, "ParseOpenCodeDB")
+	require.Len(t, sessions, 1, "sessions len")
+
+	msgs := sessions[0].Messages
+	require.Len(t, msgs, 2, "messages len")
+
+	ast := msgs[1]
+	require.Len(t, ast.ToolCalls, 1, "tool calls len")
+	assertEq(t, "SkillName", ast.ToolCalls[0].SkillName, "doc-writer")
+}
+
+// TestParseOpenCodeDB_SkillNameFromReadTool verifies that a
+// "read" tool part whose input points at a real on-disk SKILL.md
+// infers the skill name from the file's frontmatter, matching the
+// Cursor/Codex read-file heuristic shared via inferOpenCodeSkillName.
+func TestParseOpenCodeDB_SkillNameFromReadTool(t *testing.T) {
+	path := writeTestSkill(t, "foo", "foo")
+
+	dbPath, seeder, db := newTestDB(t)
+	defer db.Close()
+
+	seeder.AddProject("prj_1", "/tmp/proj")
+	seeder.AddSession("ses_read", "prj_1", "", "", 1700000000000, 1700000030000)
+
+	seeder.AddMessage("msg_u", "ses_read", 1700000000000, 1700000000000, `{"role":"user"}`)
+	seeder.AddPart("prt_u", "msg_u", "ses_read", 1700000000000, 1700000000000, `{"type":"text","text":"read the skill file"}`)
+
+	seeder.AddMessage("msg_a", "ses_read", 1700000010000, 1700000010000, `{"role":"assistant"}`)
+	seeder.AddPart("prt_t", "msg_a", "ses_read", 1700000010000, 1700000010000,
+		`{"type":"tool","tool":"read","callID":"call_read","state":{"input":{"file_path":`+
+			quoteJSON(t, path)+`}}}`)
+
+	sessions, err := parseOpenCodeAll(dbPath, "m")
+	require.NoError(t, err, "ParseOpenCodeDB")
+	require.Len(t, sessions, 1, "sessions len")
+
+	msgs := sessions[0].Messages
+	require.Len(t, msgs, 2, "messages len")
+
+	ast := msgs[1]
+	require.Len(t, ast.ToolCalls, 1, "tool calls len")
+	assertEq(t, "SkillName", ast.ToolCalls[0].SkillName, "foo")
+}
+
+// TestParseOpenCodeDB_SkillNameFromShellCommandRelativePath
+// verifies that a "bash" tool part running a relative-path
+// SKILL.md read is resolved against the session's project
+// worktree (threaded through buildOpenCodeMessage), matching the
+// Codex shell-command heuristic.
+func TestParseOpenCodeDB_SkillNameFromShellCommandRelativePath(t *testing.T) {
+	path := writeTestSkill(t, "foo", "foo")
+	worktree := filepath.Dir(filepath.Dir(filepath.Dir(path)))
+
+	dbPath, seeder, db := newTestDB(t)
+	defer db.Close()
+
+	seeder.AddProject("prj_1", worktree)
+	seeder.AddSession("ses_bash", "prj_1", "", "", 1700000000000, 1700000030000)
+
+	seeder.AddMessage("msg_u", "ses_bash", 1700000000000, 1700000000000, `{"role":"user"}`)
+	seeder.AddPart("prt_u", "msg_u", "ses_bash", 1700000000000, 1700000000000, `{"type":"text","text":"cat the skill file"}`)
+
+	seeder.AddMessage("msg_a", "ses_bash", 1700000010000, 1700000010000, `{"role":"assistant"}`)
+	seeder.AddPart("prt_t", "msg_a", "ses_bash", 1700000010000, 1700000010000,
+		`{"type":"tool","tool":"bash","callID":"call_bash","state":{"input":{"command":"cat skills/foo/SKILL.md"}}}`)
+
+	sessions, err := parseOpenCodeAll(dbPath, "m")
+	require.NoError(t, err, "ParseOpenCodeDB")
+	require.Len(t, sessions, 1, "sessions len")
+
+	msgs := sessions[0].Messages
+	require.Len(t, msgs, 2, "messages len")
+
+	ast := msgs[1]
+	require.Len(t, ast.ToolCalls, 1, "tool calls len")
+	assertEq(t, "SkillName", ast.ToolCalls[0].SkillName, "foo")
+}
+
 func TestParseOpenCodeDB_EmptySession(t *testing.T) {
 	dbPath, seeder, db := newTestDB(t)
 	defer db.Close()

--- a/internal/parser/opencode_test.go
+++ b/internal/parser/opencode_test.go
@@ -901,6 +901,41 @@ func TestParseOpenCodeDB_SkillNameFromReadTool(t *testing.T) {
 	assertEq(t, "SkillName", ast.ToolCalls[0].SkillName, "foo")
 }
 
+// TestParseOpenCodeDB_SkillNameFromReadToolRelativePath verifies
+// that a read tool with a relative SKILL.md path resolves against
+// the session worktree and reads frontmatter instead of falling
+// back to the parent directory name.
+func TestParseOpenCodeDB_SkillNameFromReadToolRelativePath(t *testing.T) {
+	// Frontmatter name intentionally differs from the folder name
+	// ("renamed") to prove we read frontmatter, not the directory.
+	path := writeTestSkill(t, "renamed", "actual-skill")
+	worktree := filepath.Dir(filepath.Dir(filepath.Dir(path)))
+
+	dbPath, seeder, db := newTestDB(t)
+	defer db.Close()
+
+	seeder.AddProject("prj_1", worktree)
+	seeder.AddSession("ses_rel", "prj_1", "", "", 1700000000000, 1700000030000)
+
+	seeder.AddMessage("msg_u", "ses_rel", 1700000000000, 1700000000000, `{"role":"user"}`)
+	seeder.AddPart("prt_u", "msg_u", "ses_rel", 1700000000000, 1700000000000, `{"type":"text","text":"read the skill"}`)
+
+	seeder.AddMessage("msg_a", "ses_rel", 1700000010000, 1700000010000, `{"role":"assistant"}`)
+	seeder.AddPart("prt_t", "msg_a", "ses_rel", 1700000010000, 1700000010000,
+		`{"type":"tool","tool":"read","callID":"call_read","state":{"input":{"file_path":"skills/renamed/SKILL.md"}}}`)
+
+	sessions, err := parseOpenCodeAll(dbPath, "m")
+	require.NoError(t, err, "ParseOpenCodeDB")
+	require.Len(t, sessions, 1, "sessions len")
+
+	msgs := sessions[0].Messages
+	require.Len(t, msgs, 2, "messages len")
+
+	ast := msgs[1]
+	require.Len(t, ast.ToolCalls, 1, "tool calls len")
+	assertEq(t, "SkillName", ast.ToolCalls[0].SkillName, "actual-skill")
+}
+
 // TestParseOpenCodeDB_SkillNameFromShellCommandRelativePath
 // verifies that a "bash" tool part running a relative-path
 // SKILL.md read is resolved against the session's project


### PR DESCRIPTION
Top Skills analytics is empty for OpenCode sessions because `extractOpenCodeToolCall` never populates `ParsedToolCall.SkillName`. Every other parser attributes a skill name, either directly for a dedicated skill-invocation tool call (Claude content blocks, Forge) or through the shared read-file/shell-command heuristic in `skill_inference.go` (Cursor, Kimi, Codex, and Claude's fallback arm), but the OpenCode parser runs neither path.

This adds both paths to `extractOpenCodeToolCall`. When the tool name is literally `skill` (OpenCode's dedicated skill tool, whose input carries the skill name under `name`), the skill name is read directly from the input JSON, mirroring the two-key lookup order Claude's content parser already uses. For every other tool call, a small local helper runs the same read-file/shell-command heuristic `inferToolSkillName` runs elsewhere, since OpenCode's `read` and `bash` tool names already match the heuristic's matchers. The shell-command branch takes the session's working directory as its fallback base, the same way the Codex parser threads its session cwd, so relative `SKILL.md` paths resolve against the session's project worktree.

Nothing outside `internal/parser/opencode.go` changes. The shared heuristic functions and every other parser are untouched, and there's no schema change: `SkillName` is derived at parse time, so re-syncing an existing OpenCode session picks up attribution on the next parse.

Fixes #1040