### PR TITLE
feat(parser): prefer agy-reader trajectory sidecars for Antigravity IDE sessions

### DIFF
--- a/internal/parser/antigravity.go
+++ b/internal/parser/antigravity.go
@@ -100,17 +100,15 @@ func (p *antigravityProvider) parseSession(
 	// schema cannot be read.
 	sourceVersion := antigravitySourceVersion(db)
 
-	dbResult, err := loadAntigravityStepsWithRawCount(db)
-	if err != nil {
-		return nil, nil, nil, err
-	}
+	dbResult, dbErr := loadAntigravityStepsWithRawCount(db)
 	messages := dbResult.messages
 	// gen_metadata token usage describes the session's actual
 	// consumption no matter which transcript source wins below. The
 	// trajectory sidecar also extracts generatorMetadata usage, but the
 	// .db gen_metadata events win and sidecar events only fill the gap
-	// (missing gen_metadata table) so the same generation is never
-	// counted twice -- mirroring the CLI path's merge behavior.
+	// (unreadable steps or missing gen_metadata table) so the same
+	// generation is never counted twice -- mirroring the CLI path's
+	// merge behavior.
 	usageEvents := dbResult.usageEvents
 	hasGenMetadata := dbResult.hasGenMetadata
 	// TranscriptFidelity is left empty (treated as full) for the heuristic
@@ -125,22 +123,29 @@ func (p *antigravityProvider) parseSession(
 	// at least as many steps as the raw DB decode, so a sidecar lagging
 	// behind a live session loses until agy-reader catches up. When the
 	// sidecar is absent, malformed, or fails the coverage gate the parser
-	// falls back to the heuristic decode exactly as before.
+	// falls back to the heuristic decode exactly as before. A step-load
+	// failure is a fallback condition, not a parse failure (mirroring the
+	// CLI flow): the DB then offers no coverage signal and a readable
+	// sidecar can still rescue the session; without one the original
+	// step-load error is returned below.
 	sidecarPath := strings.TrimSuffix(path, ".db") + ".trajectory.json"
 	tRes, tErr := parseAntigravityCLITrajectory(sidecarPath)
 	sidecarOK := tErr == nil &&
 		hasDisplayableAntigravityCLITrajectoryMessage(tRes.messages)
-	sidecarCovers := dbResult.rawStepCount == 0 ||
+	sidecarCovers := dbErr != nil || dbResult.rawStepCount == 0 ||
 		tRes.rawSteps >= dbResult.rawStepCount
-	if sidecarOK && sidecarCovers {
+	switch {
+	case sidecarOK && sidecarCovers:
 		messages = tRes.messages
 		transcriptFidelity = TranscriptFidelityFull
+	case dbErr != nil:
+		return nil, nil, nil, dbErr
 	}
 	// Coverage gates usage just like the transcript: a lagging sidecar
 	// carries only the generations it has seen, so persisting those would
 	// underreport totals on a row that looks current. sidecarCovers stays
-	// true when the DB offers no coverage signal (zero rows), so gap-fill
-	// still applies there.
+	// true when the DB offers no coverage signal (unreadable steps or zero
+	// rows), so gap-fill still applies there.
 	if len(usageEvents) == 0 && tErr == nil && sidecarCovers {
 		usageEvents = tRes.usageEvents
 	}

--- a/internal/parser/antigravity.go
+++ b/internal/parser/antigravity.go
@@ -166,6 +166,14 @@ func (p *antigravityProvider) parseSession(
 			// every subsequent sync re-parses until the DB reads
 			// cleanly and the real coverage gate re-decides.
 			status.NeedsRetry = true
+			// Rescue-only usage merge: the independent gen_metadata
+			// load has no decoded step to anchor timestamps to, so its
+			// events would collapse onto sessions.started_at in daily
+			// analytics. Borrow per-generation timing from the sidecar
+			// while the DB token counts stay authoritative. The row is
+			// already NeedsRetry, so a later clean parse re-derives
+			// everything; the merge just keeps analytics sane meanwhile.
+			mergeAntigravityRescueUsageTiming(usageEvents, tRes.usageEvents)
 		}
 	case dbErr != nil:
 		// Fail closed, deliberately. The sync engine unconditionally
@@ -387,6 +395,33 @@ func loadAntigravityGenMetadataUsage(
 		r.appendGenMetadataUsage(data, ParsedMessage{}, false)
 	}
 	return r.usageEvents, hasGenMetadata
+}
+
+// mergeAntigravityRescueUsageTiming copies per-generation timing (and
+// missing model attribution) from sidecar usage events onto DB
+// gen_metadata events, matched by ordinal position: gen_metadata is
+// loaded ORDER BY idx and the sidecar's generatorMetadata events are in
+// trajectory order, so both describe the same generation sequence. The
+// DB token counts stay authoritative. DB events beyond the sidecar's
+// count keep an empty OccurredAt -- timestamps are never invented --
+// and sidecar events beyond the DB's count are ignored (the DB is
+// ground truth for which generations happened). Rescue-path only:
+// normal parses over a readable DB anchor events to decoded steps and
+// must not pass through here.
+func mergeAntigravityRescueUsageTiming(
+	dbEvents, sidecarEvents []ParsedUsageEvent,
+) {
+	for i := range dbEvents {
+		if i >= len(sidecarEvents) {
+			return
+		}
+		if dbEvents[i].OccurredAt == "" {
+			dbEvents[i].OccurredAt = sidecarEvents[i].OccurredAt
+		}
+		if dbEvents[i].Model == "" {
+			dbEvents[i].Model = sidecarEvents[i].Model
+		}
+	}
 }
 
 func loadAntigravityStepsWithRawCount(

--- a/internal/parser/antigravity.go
+++ b/internal/parser/antigravity.go
@@ -66,19 +66,32 @@ func antigravityIDECompanionPaths(path string) []string {
 	)...)
 }
 
+// antigravityParseStatus carries sync-relevant IDE parser metadata that
+// is not part of the canonical session/message shape, mirroring the CLI
+// path's AntigravityCLIParseStatus.
+type antigravityParseStatus struct {
+	// NeedsRetry is true when the sidecar rescued the transcript while
+	// the steps query was failing: coverage is unprovable without a
+	// readable DB, so the row must stay stale (data_version-1) and every
+	// subsequent sync re-parses until the DB reads cleanly and the real
+	// coverage gate re-decides.
+	NeedsRetry bool
+}
+
 // parseSession parses one IDE session DB. It is owned by the
 // antigravityProvider; the package-level ParseAntigravitySession
 // entrypoint was folded onto the provider.
 func (p *antigravityProvider) parseSession(
 	path, project, machine string,
-) (*ParsedSession, []ParsedMessage, []ParsedUsageEvent, error) {
+) (*ParsedSession, []ParsedMessage, []ParsedUsageEvent, antigravityParseStatus, error) {
+	var status antigravityParseStatus
 	info, err := os.Stat(path)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("stat %s: %w", path, err)
+		return nil, nil, nil, status, fmt.Errorf("stat %s: %w", path, err)
 	}
 	id := strings.TrimSuffix(filepath.Base(path), ".db")
 	if !IsValidSessionID(id) {
-		return nil, nil, nil, fmt.Errorf(
+		return nil, nil, nil, status, fmt.Errorf(
 			"invalid Antigravity IDE session filename: %s", path,
 		)
 	}
@@ -89,7 +102,7 @@ func (p *antigravityProvider) parseSession(
 	dsn := "file:" + sqliteURIPath(path) + "?mode=ro&immutable=0"
 	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf(
+		return nil, nil, nil, status, fmt.Errorf(
 			"open antigravity db %s: %w", path, err,
 		)
 	}
@@ -145,6 +158,15 @@ func (p *antigravityProvider) parseSession(
 	case sidecarOK && sidecarCovers:
 		messages = tRes.messages
 		transcriptFidelity = TranscriptFidelityFull
+		if dbErr != nil {
+			// The rescue persists the best-available sidecar content,
+			// but with the steps query failing there is no DB step
+			// count to prove the sidecar actually covers the session
+			// (it may lag a live session). Leave the row stale so
+			// every subsequent sync re-parses until the DB reads
+			// cleanly and the real coverage gate re-decides.
+			status.NeedsRetry = true
+		}
 	case dbErr != nil:
 		// Fail closed, deliberately. The sync engine unconditionally
 		// full-replaces stored Antigravity messages on any successful
@@ -156,7 +178,7 @@ func (p *antigravityProvider) parseSession(
 		// error preserves the stored session instead. Degraded-persist
 		// requires engine-level clobber protection first; that
 		// enhancement is tracked separately.
-		return nil, nil, nil, dbErr
+		return nil, nil, nil, status, dbErr
 	}
 	// Coverage gates usage just like the transcript: a lagging sidecar
 	// carries only the generations it has seen, so persisting those would
@@ -254,9 +276,9 @@ func (p *antigravityProvider) parseSession(
 		// Usage events still flow for message-less parses (e.g. an
 		// undecodable DB with gen_metadata) so daily usage analytics
 		// match the event-derived session totals stamped above.
-		return sess, nil, usageEvents, nil
+		return sess, nil, usageEvents, status, nil
 	}
-	return sess, messages, usageEvents, nil
+	return sess, messages, usageEvents, status, nil
 }
 
 type antigravityStepLoadResult struct {

--- a/internal/parser/antigravity.go
+++ b/internal/parser/antigravity.go
@@ -131,21 +131,32 @@ func (p *antigravityProvider) parseSession(
 	// behind a live session loses until agy-reader catches up. When the
 	// sidecar is absent, malformed, or fails the coverage gate the parser
 	// falls back to the heuristic decode exactly as before. A step-load
-	// failure is a fallback condition, not a parse failure (mirroring the
-	// CLI flow): the DB then offers no coverage signal and a readable
-	// sidecar can still rescue the session; without one the parser
-	// degrades to whatever is recoverable (brain artifacts, gen_metadata
-	// or sidecar usage) and returns the original step-load error only
-	// when nothing at all is recoverable.
+	// failure is a fallback condition only when a covering displayable
+	// sidecar can rescue the session with a full transcript (the DB then
+	// offers no coverage signal); without one the original step-load
+	// error is returned.
 	sidecarPath := strings.TrimSuffix(path, ".db") + ".trajectory.json"
 	tRes, tErr := parseAntigravityCLITrajectory(sidecarPath)
 	sidecarOK := tErr == nil &&
 		hasDisplayableAntigravityCLITrajectoryMessage(tRes.messages)
 	sidecarCovers := dbErr != nil || dbResult.rawStepCount == 0 ||
 		tRes.rawSteps >= dbResult.rawStepCount
-	if sidecarOK && sidecarCovers {
+	switch {
+	case sidecarOK && sidecarCovers:
 		messages = tRes.messages
 		transcriptFidelity = TranscriptFidelityFull
+	case dbErr != nil:
+		// Fail closed, deliberately. The sync engine unconditionally
+		// full-replaces stored Antigravity messages on any successful
+		// parse (shouldReplaceFullParseMessages plus this provider's
+		// unconditional ForceReplace), so persisting a degraded
+		// usage-only or brain-only row here would clobber a previously
+		// stored full transcript whenever the steps query fails
+		// transiently (e.g. during live IDE writes). Surfacing the
+		// error preserves the stored session instead. Degraded-persist
+		// requires engine-level clobber protection first; that
+		// enhancement is tracked separately.
+		return nil, nil, nil, dbErr
 	}
 	// Coverage gates usage just like the transcript: a lagging sidecar
 	// carries only the generations it has seen, so persisting those would
@@ -161,17 +172,6 @@ func (p *antigravityProvider) parseSession(
 			filepath.Join(root, "brain", id),
 		)...,
 	)
-
-	// The step-load error surfaces only when nothing was recoverable: no
-	// rescuing sidecar transcript, no brain artifacts, and no usage from
-	// gen_metadata or the sidecar. Anything else is persisted as a
-	// degraded session (fidelity stays empty, no fabricated transcript);
-	// the sidecar, brain artifacts, and DB files are all fingerprinted
-	// companions, so a later change to any of them re-parses the session.
-	if dbErr != nil && (!sidecarOK || !sidecarCovers) &&
-		len(messages) == 0 && len(usageEvents) == 0 {
-		return nil, nil, nil, dbErr
-	}
 
 	sort.SliceStable(messages, func(i, j int) bool {
 		return messages[i].Timestamp.Before(messages[j].Timestamp)

--- a/internal/parser/antigravity.go
+++ b/internal/parser/antigravity.go
@@ -397,30 +397,56 @@ func loadAntigravityGenMetadataUsage(
 	return r.usageEvents, hasGenMetadata
 }
 
+// antigravityUsageEventIsZeroToken mirrors the sidecar parser's
+// empty-usage skip (parseAntigravityCLITrajectory drops generations
+// where input, output, AND cacheRead are all zero -- the marker of a
+// failed/retried generation). The rescue merge below applies the same
+// predicate to the DB side so the two event sequences align by
+// construction.
+func antigravityUsageEventIsZeroToken(ev ParsedUsageEvent) bool {
+	return ev.InputTokens == 0 && ev.OutputTokens == 0 &&
+		ev.CacheReadInputTokens == 0
+}
+
 // mergeAntigravityRescueUsageTiming copies per-generation timing (and
 // missing model attribution) from sidecar usage events onto DB
 // gen_metadata events, matched by ordinal position: gen_metadata is
 // loaded ORDER BY idx and the sidecar's generatorMetadata events are in
 // trajectory order, so both describe the same generation sequence. The
-// DB token counts stay authoritative. DB events beyond the sidecar's
-// count keep an empty OccurredAt -- timestamps are never invented --
-// and sidecar events beyond the DB's count are ignored (the DB is
-// ground truth for which generations happened). Rescue-path only:
+// DB token counts stay authoritative.
+//
+// Zero-token DB events are skipped WITHOUT consuming a sidecar event:
+// the sidecar parser never emits an event for an empty/retried
+// generation (see antigravityUsageEventIsZeroToken), so a zero-token DB
+// event has no sidecar counterpart and pairing it would shift every
+// later match onto the wrong timestamp. Those events stay in the output
+// untouched, in their original order -- they are still ground-truth
+// generation records -- just timestamp-less. With that filter the
+// sequences align by construction and any divergence is suffix-only (a
+// lagging sidecar), which prefix matching handles: DB events beyond the
+// sidecar's count keep an empty OccurredAt (timestamps are never
+// invented) and sidecar events beyond the DB's count are ignored (the
+// DB is ground truth for which generations happened). Rescue-path only:
 // normal parses over a readable DB anchor events to decoded steps and
 // must not pass through here.
 func mergeAntigravityRescueUsageTiming(
 	dbEvents, sidecarEvents []ParsedUsageEvent,
 ) {
+	j := 0
 	for i := range dbEvents {
-		if i >= len(sidecarEvents) {
+		if antigravityUsageEventIsZeroToken(dbEvents[i]) {
+			continue
+		}
+		if j >= len(sidecarEvents) {
 			return
 		}
 		if dbEvents[i].OccurredAt == "" {
-			dbEvents[i].OccurredAt = sidecarEvents[i].OccurredAt
+			dbEvents[i].OccurredAt = sidecarEvents[j].OccurredAt
 		}
 		if dbEvents[i].Model == "" {
-			dbEvents[i].Model = sidecarEvents[i].Model
+			dbEvents[i].Model = sidecarEvents[j].Model
 		}
+		j++
 	}
 }
 

--- a/internal/parser/antigravity.go
+++ b/internal/parser/antigravity.go
@@ -66,32 +66,19 @@ func antigravityIDECompanionPaths(path string) []string {
 	)...)
 }
 
-// antigravityParseStatus carries sync-relevant IDE parser metadata that
-// is not part of the canonical session/message shape, mirroring the CLI
-// path's AntigravityCLIParseStatus.
-type antigravityParseStatus struct {
-	// NeedsRetry is true when the sidecar rescued the transcript while
-	// the steps query was failing: coverage is unprovable without a
-	// readable DB, so the row must stay stale (data_version-1) and every
-	// subsequent sync re-parses until the DB reads cleanly and the real
-	// coverage gate re-decides.
-	NeedsRetry bool
-}
-
 // parseSession parses one IDE session DB. It is owned by the
 // antigravityProvider; the package-level ParseAntigravitySession
 // entrypoint was folded onto the provider.
 func (p *antigravityProvider) parseSession(
 	path, project, machine string,
-) (*ParsedSession, []ParsedMessage, []ParsedUsageEvent, antigravityParseStatus, error) {
-	var status antigravityParseStatus
+) (*ParsedSession, []ParsedMessage, []ParsedUsageEvent, error) {
 	info, err := os.Stat(path)
 	if err != nil {
-		return nil, nil, nil, status, fmt.Errorf("stat %s: %w", path, err)
+		return nil, nil, nil, fmt.Errorf("stat %s: %w", path, err)
 	}
 	id := strings.TrimSuffix(filepath.Base(path), ".db")
 	if !IsValidSessionID(id) {
-		return nil, nil, nil, status, fmt.Errorf(
+		return nil, nil, nil, fmt.Errorf(
 			"invalid Antigravity IDE session filename: %s", path,
 		)
 	}
@@ -102,7 +89,7 @@ func (p *antigravityProvider) parseSession(
 	dsn := "file:" + sqliteURIPath(path) + "?mode=ro&immutable=0"
 	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {
-		return nil, nil, nil, status, fmt.Errorf(
+		return nil, nil, nil, fmt.Errorf(
 			"open antigravity db %s: %w", path, err,
 		)
 	}
@@ -113,24 +100,31 @@ func (p *antigravityProvider) parseSession(
 	// schema cannot be read.
 	sourceVersion := antigravitySourceVersion(db)
 
-	dbResult, dbErr := loadAntigravityStepsWithRawCount(db)
+	dbResult, err := loadAntigravityStepsWithRawCount(db)
+	if err != nil {
+		// Fail closed on an unreadable steps table, deliberately: a
+		// covering sidecar cannot rescue an unreadable DB because
+		// coverage is unprovable without the DB's raw step count (a
+		// displayable sidecar may lag a live session), and this
+		// provider force-replaces on success (the engine's
+		// shouldReplaceFullParseMessages plus the unconditional
+		// ForceReplace outcome), so any rescue would risk overwriting a
+		// previously complete stored transcript with a stale sidecar
+		// (roborev jobs 1982 and 2112, both high). Safe rescue needs
+		// engine-level no-clobber support, tracked separately. The
+		// parse error preserves stored data and the engine retries
+		// failed files.
+		return nil, nil, nil, err
+	}
 	messages := dbResult.messages
 	// gen_metadata token usage describes the session's actual
 	// consumption no matter which transcript source wins below. The
 	// trajectory sidecar also extracts generatorMetadata usage, but the
 	// .db gen_metadata events win and sidecar events only fill the gap
-	// (unreadable steps or missing gen_metadata table) so the same
-	// generation is never counted twice -- mirroring the CLI path's
-	// merge behavior.
+	// (missing gen_metadata table) so the same generation is never
+	// counted twice -- mirroring the CLI path's merge behavior.
 	usageEvents := dbResult.usageEvents
 	hasGenMetadata := dbResult.hasGenMetadata
-	if dbErr != nil {
-		// The steps query failed before gen_metadata was read, so the
-		// result above carries no usage. Load gen_metadata independently:
-		// it is still the DB's ground-truth consumption and must win over
-		// sidecar gap-fill even when the sidecar rescues the transcript.
-		usageEvents, hasGenMetadata = loadAntigravityGenMetadataUsage(db)
-	}
 	// TranscriptFidelity is left empty (treated as full) for the heuristic
 	// decode, matching prior IDE behavior; a covering sidecar sets it to
 	// TranscriptFidelityFull explicitly below.
@@ -143,56 +137,22 @@ func (p *antigravityProvider) parseSession(
 	// at least as many steps as the raw DB decode, so a sidecar lagging
 	// behind a live session loses until agy-reader catches up. When the
 	// sidecar is absent, malformed, or fails the coverage gate the parser
-	// falls back to the heuristic decode exactly as before. A step-load
-	// failure is a fallback condition only when a covering displayable
-	// sidecar can rescue the session with a full transcript (the DB then
-	// offers no coverage signal); without one the original step-load
-	// error is returned.
+	// falls back to the heuristic decode exactly as before.
 	sidecarPath := strings.TrimSuffix(path, ".db") + ".trajectory.json"
 	tRes, tErr := parseAntigravityCLITrajectory(sidecarPath)
 	sidecarOK := tErr == nil &&
 		hasDisplayableAntigravityCLITrajectoryMessage(tRes.messages)
-	sidecarCovers := dbErr != nil || dbResult.rawStepCount == 0 ||
+	sidecarCovers := dbResult.rawStepCount == 0 ||
 		tRes.rawSteps >= dbResult.rawStepCount
-	switch {
-	case sidecarOK && sidecarCovers:
+	if sidecarOK && sidecarCovers {
 		messages = tRes.messages
 		transcriptFidelity = TranscriptFidelityFull
-		if dbErr != nil {
-			// The rescue persists the best-available sidecar content,
-			// but with the steps query failing there is no DB step
-			// count to prove the sidecar actually covers the session
-			// (it may lag a live session). Leave the row stale so
-			// every subsequent sync re-parses until the DB reads
-			// cleanly and the real coverage gate re-decides.
-			status.NeedsRetry = true
-			// Rescue-only usage merge: the independent gen_metadata
-			// load has no decoded step to anchor timestamps to, so its
-			// events would collapse onto sessions.started_at in daily
-			// analytics. Borrow per-generation timing from the sidecar
-			// while the DB token counts stay authoritative. The row is
-			// already NeedsRetry, so a later clean parse re-derives
-			// everything; the merge just keeps analytics sane meanwhile.
-			mergeAntigravityRescueUsageTiming(usageEvents, tRes.usageEvents)
-		}
-	case dbErr != nil:
-		// Fail closed, deliberately. The sync engine unconditionally
-		// full-replaces stored Antigravity messages on any successful
-		// parse (shouldReplaceFullParseMessages plus this provider's
-		// unconditional ForceReplace), so persisting a degraded
-		// usage-only or brain-only row here would clobber a previously
-		// stored full transcript whenever the steps query fails
-		// transiently (e.g. during live IDE writes). Surfacing the
-		// error preserves the stored session instead. Degraded-persist
-		// requires engine-level clobber protection first; that
-		// enhancement is tracked separately.
-		return nil, nil, nil, status, dbErr
 	}
 	// Coverage gates usage just like the transcript: a lagging sidecar
 	// carries only the generations it has seen, so persisting those would
 	// underreport totals on a row that looks current. sidecarCovers stays
-	// true when the DB offers no coverage signal (unreadable steps or zero
-	// rows), so gap-fill still applies there.
+	// true when the DB offers no coverage signal (zero rows), so gap-fill
+	// still applies there.
 	if len(usageEvents) == 0 && tErr == nil && sidecarCovers {
 		usageEvents = tRes.usageEvents
 	}
@@ -284,9 +244,9 @@ func (p *antigravityProvider) parseSession(
 		// Usage events still flow for message-less parses (e.g. an
 		// undecodable DB with gen_metadata) so daily usage analytics
 		// match the event-derived session totals stamped above.
-		return sess, nil, usageEvents, status, nil
+		return sess, nil, usageEvents, nil
 	}
-	return sess, messages, usageEvents, status, nil
+	return sess, messages, usageEvents, nil
 }
 
 type antigravityStepLoadResult struct {
@@ -360,93 +320,6 @@ func roleForAntigravityStepKind(kind antigravityStepKind) RoleType {
 		return RoleAssistant
 	default:
 		return RoleAssistant
-	}
-}
-
-// loadAntigravityGenMetadataUsage loads usage events directly from the
-// gen_metadata table for the IDE sidecar-rescue path: when the steps
-// query fails, loadAntigravityStepsWithRawCount returns before it ever
-// reads gen_metadata, yet gen_metadata is the session's ground-truth
-// consumption and must stay primary ahead of sidecar gap-fill no matter
-// which transcript source wins. Events decoded here carry no message
-// attribution, model-from-message, or timestamp (there is no decoded
-// step to anchor them), so they bucket at session start in daily usage.
-// The second return reports whether the table carried rows at all, so
-// GenMetadataWithoutUsage keeps its meaning in the rescue path.
-func loadAntigravityGenMetadataUsage(
-	db *sql.DB,
-) ([]ParsedUsageEvent, bool) {
-	rows, err := db.Query("SELECT idx, data FROM gen_metadata ORDER BY idx")
-	if err != nil {
-		return nil, false
-	}
-	defer rows.Close()
-	var r antigravityStepLoadResult
-	hasGenMetadata := false
-	for rows.Next() {
-		var idx int
-		var data []byte
-		if err := rows.Scan(&idx, &data); err != nil {
-			continue
-		}
-		hasGenMetadata = true
-		// decoded=false: no step message exists to attach counts to; the
-		// event alone carries the usage, same as an undecodable step row.
-		r.appendGenMetadataUsage(data, ParsedMessage{}, false)
-	}
-	return r.usageEvents, hasGenMetadata
-}
-
-// antigravityUsageEventIsZeroToken mirrors the sidecar parser's
-// empty-usage skip (parseAntigravityCLITrajectory drops generations
-// where input, output, AND cacheRead are all zero -- the marker of a
-// failed/retried generation). The rescue merge below applies the same
-// predicate to the DB side so the two event sequences align by
-// construction.
-func antigravityUsageEventIsZeroToken(ev ParsedUsageEvent) bool {
-	return ev.InputTokens == 0 && ev.OutputTokens == 0 &&
-		ev.CacheReadInputTokens == 0
-}
-
-// mergeAntigravityRescueUsageTiming copies per-generation timing (and
-// missing model attribution) from sidecar usage events onto DB
-// gen_metadata events, matched by ordinal position: gen_metadata is
-// loaded ORDER BY idx and the sidecar's generatorMetadata events are in
-// trajectory order, so both describe the same generation sequence. The
-// DB token counts stay authoritative.
-//
-// Zero-token DB events are skipped WITHOUT consuming a sidecar event:
-// the sidecar parser never emits an event for an empty/retried
-// generation (see antigravityUsageEventIsZeroToken), so a zero-token DB
-// event has no sidecar counterpart and pairing it would shift every
-// later match onto the wrong timestamp. Those events stay in the output
-// untouched, in their original order -- they are still ground-truth
-// generation records -- just timestamp-less. With that filter the
-// sequences align by construction and any divergence is suffix-only (a
-// lagging sidecar), which prefix matching handles: DB events beyond the
-// sidecar's count keep an empty OccurredAt (timestamps are never
-// invented) and sidecar events beyond the DB's count are ignored (the
-// DB is ground truth for which generations happened). Rescue-path only:
-// normal parses over a readable DB anchor events to decoded steps and
-// must not pass through here.
-func mergeAntigravityRescueUsageTiming(
-	dbEvents, sidecarEvents []ParsedUsageEvent,
-) {
-	j := 0
-	for i := range dbEvents {
-		if antigravityUsageEventIsZeroToken(dbEvents[i]) {
-			continue
-		}
-		if j >= len(sidecarEvents) {
-			return
-		}
-		if dbEvents[i].OccurredAt == "" {
-			dbEvents[i].OccurredAt = sidecarEvents[j].OccurredAt
-		}
-		if dbEvents[i].Model == "" {
-			dbEvents[i].Model = sidecarEvents[j].Model
-		}
-		j++
 	}
 }
 

--- a/internal/parser/antigravity.go
+++ b/internal/parser/antigravity.go
@@ -133,20 +133,19 @@ func (p *antigravityProvider) parseSession(
 	// falls back to the heuristic decode exactly as before. A step-load
 	// failure is a fallback condition, not a parse failure (mirroring the
 	// CLI flow): the DB then offers no coverage signal and a readable
-	// sidecar can still rescue the session; without one the original
-	// step-load error is returned below.
+	// sidecar can still rescue the session; without one the parser
+	// degrades to whatever is recoverable (brain artifacts, gen_metadata
+	// or sidecar usage) and returns the original step-load error only
+	// when nothing at all is recoverable.
 	sidecarPath := strings.TrimSuffix(path, ".db") + ".trajectory.json"
 	tRes, tErr := parseAntigravityCLITrajectory(sidecarPath)
 	sidecarOK := tErr == nil &&
 		hasDisplayableAntigravityCLITrajectoryMessage(tRes.messages)
 	sidecarCovers := dbErr != nil || dbResult.rawStepCount == 0 ||
 		tRes.rawSteps >= dbResult.rawStepCount
-	switch {
-	case sidecarOK && sidecarCovers:
+	if sidecarOK && sidecarCovers {
 		messages = tRes.messages
 		transcriptFidelity = TranscriptFidelityFull
-	case dbErr != nil:
-		return nil, nil, nil, dbErr
 	}
 	// Coverage gates usage just like the transcript: a lagging sidecar
 	// carries only the generations it has seen, so persisting those would
@@ -162,6 +161,17 @@ func (p *antigravityProvider) parseSession(
 			filepath.Join(root, "brain", id),
 		)...,
 	)
+
+	// The step-load error surfaces only when nothing was recoverable: no
+	// rescuing sidecar transcript, no brain artifacts, and no usage from
+	// gen_metadata or the sidecar. Anything else is persisted as a
+	// degraded session (fidelity stays empty, no fabricated transcript);
+	// the sidecar, brain artifacts, and DB files are all fingerprinted
+	// companions, so a later change to any of them re-parses the session.
+	if dbErr != nil && !(sidecarOK && sidecarCovers) &&
+		len(messages) == 0 && len(usageEvents) == 0 {
+		return nil, nil, nil, dbErr
+	}
 
 	sort.SliceStable(messages, func(i, j int) bool {
 		return messages[i].Timestamp.Before(messages[j].Timestamp)

--- a/internal/parser/antigravity.go
+++ b/internal/parser/antigravity.go
@@ -111,6 +111,13 @@ func (p *antigravityProvider) parseSession(
 	// merge behavior.
 	usageEvents := dbResult.usageEvents
 	hasGenMetadata := dbResult.hasGenMetadata
+	if dbErr != nil {
+		// The steps query failed before gen_metadata was read, so the
+		// result above carries no usage. Load gen_metadata independently:
+		// it is still the DB's ground-truth consumption and must win over
+		// sidecar gap-fill even when the sidecar rescues the transcript.
+		usageEvents, hasGenMetadata = loadAntigravityGenMetadataUsage(db)
+	}
 	// TranscriptFidelity is left empty (treated as full) for the heuristic
 	// decode, matching prior IDE behavior; a covering sidecar sets it to
 	// TranscriptFidelityFull explicitly below.
@@ -314,6 +321,40 @@ func roleForAntigravityStepKind(kind antigravityStepKind) RoleType {
 	default:
 		return RoleAssistant
 	}
+}
+
+// loadAntigravityGenMetadataUsage loads usage events directly from the
+// gen_metadata table for the IDE sidecar-rescue path: when the steps
+// query fails, loadAntigravityStepsWithRawCount returns before it ever
+// reads gen_metadata, yet gen_metadata is the session's ground-truth
+// consumption and must stay primary ahead of sidecar gap-fill no matter
+// which transcript source wins. Events decoded here carry no message
+// attribution, model-from-message, or timestamp (there is no decoded
+// step to anchor them), so they bucket at session start in daily usage.
+// The second return reports whether the table carried rows at all, so
+// GenMetadataWithoutUsage keeps its meaning in the rescue path.
+func loadAntigravityGenMetadataUsage(
+	db *sql.DB,
+) ([]ParsedUsageEvent, bool) {
+	rows, err := db.Query("SELECT idx, data FROM gen_metadata ORDER BY idx")
+	if err != nil {
+		return nil, false
+	}
+	defer rows.Close()
+	var r antigravityStepLoadResult
+	hasGenMetadata := false
+	for rows.Next() {
+		var idx int
+		var data []byte
+		if err := rows.Scan(&idx, &data); err != nil {
+			continue
+		}
+		hasGenMetadata = true
+		// decoded=false: no step message exists to attach counts to; the
+		// event alone carries the usage, same as an undecodable step row.
+		r.appendGenMetadataUsage(data, ParsedMessage{}, false)
+	}
+	return r.usageEvents, hasGenMetadata
 }
 
 func loadAntigravityStepsWithRawCount(

--- a/internal/parser/antigravity.go
+++ b/internal/parser/antigravity.go
@@ -55,6 +55,11 @@ func antigravityIDECompanionPaths(path string) []string {
 		path + "-wal",
 		path + "-shm",
 		filepath.Join(root, "annotations", id+".pbtxt"),
+		// The agy-reader trajectory sidecar is a transcript source for
+		// IDE sessions too (see parseSession), so a sidecar write must
+		// change the fingerprint even when the database files themselves
+		// are untouched.
+		strings.TrimSuffix(path, ".db") + ".trajectory.json",
 	}
 	return append(companions, antigravityBrainCompanions(
 		filepath.Join(root, "brain", id),
@@ -95,10 +100,51 @@ func (p *antigravityProvider) parseSession(
 	// schema cannot be read.
 	sourceVersion := antigravitySourceVersion(db)
 
-	messages, usageEvents, hasGenMetadata, err := loadAntigravitySteps(db)
+	dbResult, err := loadAntigravityStepsWithRawCount(db)
 	if err != nil {
 		return nil, nil, nil, err
 	}
+	messages := dbResult.messages
+	// gen_metadata token usage describes the session's actual
+	// consumption no matter which transcript source wins below. The
+	// trajectory sidecar also extracts generatorMetadata usage, but the
+	// .db gen_metadata events win and sidecar events only fill the gap
+	// (missing gen_metadata table) so the same generation is never
+	// counted twice -- mirroring the CLI path's merge behavior.
+	usageEvents := dbResult.usageEvents
+	hasGenMetadata := dbResult.hasGenMetadata
+	// TranscriptFidelity is left empty (treated as full) for the heuristic
+	// decode, matching prior IDE behavior; a covering sidecar sets it to
+	// TranscriptFidelityFull explicitly below.
+	transcriptFidelity := ""
+
+	// Prefer the agy-reader trajectory sidecar: it is the daemon's own
+	// decode, with structured tool calls/results and thinking, where the
+	// heuristic DB decode only recovers loose strings. Selection is
+	// content-based, not mtime-based: the sidecar wins only when it covers
+	// at least as many steps as the raw DB decode, so a sidecar lagging
+	// behind a live session loses until agy-reader catches up. When the
+	// sidecar is absent, malformed, or fails the coverage gate the parser
+	// falls back to the heuristic decode exactly as before.
+	sidecarPath := strings.TrimSuffix(path, ".db") + ".trajectory.json"
+	tRes, tErr := parseAntigravityCLITrajectory(sidecarPath)
+	sidecarOK := tErr == nil &&
+		hasDisplayableAntigravityCLITrajectoryMessage(tRes.messages)
+	sidecarCovers := dbResult.rawStepCount == 0 ||
+		tRes.rawSteps >= dbResult.rawStepCount
+	if sidecarOK && sidecarCovers {
+		messages = tRes.messages
+		transcriptFidelity = TranscriptFidelityFull
+	}
+	// Coverage gates usage just like the transcript: a lagging sidecar
+	// carries only the generations it has seen, so persisting those would
+	// underreport totals on a row that looks current. sidecarCovers stays
+	// true when the DB offers no coverage signal (zero rows), so gap-fill
+	// still applies there.
+	if len(usageEvents) == 0 && tErr == nil && sidecarCovers {
+		usageEvents = tRes.usageEvents
+	}
+
 	messages = append(messages,
 		collectAntigravityBrainMessages(
 			filepath.Join(root, "brain", id),
@@ -157,16 +203,17 @@ func (p *antigravityProvider) parseSession(
 	}
 
 	sess := &ParsedSession{
-		ID:               antigravityIDPrefix + id,
-		Project:          project,
-		Machine:          machine,
-		Agent:            AgentAntigravity,
-		FirstMessage:     firstMessage,
-		StartedAt:        startedAt,
-		EndedAt:          endedAt,
-		MessageCount:     len(messages),
-		UserMessageCount: userCount,
-		SourceVersion:    sourceVersion,
+		ID:                 antigravityIDPrefix + id,
+		Project:            project,
+		Machine:            machine,
+		Agent:              AgentAntigravity,
+		FirstMessage:       firstMessage,
+		StartedAt:          startedAt,
+		EndedAt:            endedAt,
+		MessageCount:       len(messages),
+		UserMessageCount:   userCount,
+		SourceVersion:      sourceVersion,
+		TranscriptFidelity: transcriptFidelity,
 		File: FileInfo{
 			Path:  path,
 			Size:  size,
@@ -188,16 +235,6 @@ func (p *antigravityProvider) parseSession(
 		return sess, nil, usageEvents, nil
 	}
 	return sess, messages, usageEvents, nil
-}
-
-func loadAntigravitySteps(
-	db *sql.DB,
-) ([]ParsedMessage, []ParsedUsageEvent, bool, error) {
-	result, err := loadAntigravityStepsWithRawCount(db)
-	if err != nil {
-		return nil, nil, false, err
-	}
-	return result.messages, result.usageEvents, result.hasGenMetadata, nil
 }
 
 type antigravityStepLoadResult struct {

--- a/internal/parser/antigravity.go
+++ b/internal/parser/antigravity.go
@@ -168,7 +168,7 @@ func (p *antigravityProvider) parseSession(
 	// degraded session (fidelity stays empty, no fabricated transcript);
 	// the sidecar, brain artifacts, and DB files are all fingerprinted
 	// companions, so a later change to any of them re-parses the session.
-	if dbErr != nil && !(sidecarOK && sidecarCovers) &&
+	if dbErr != nil && (!sidecarOK || !sidecarCovers) &&
 		len(messages) == 0 && len(usageEvents) == 0 {
 		return nil, nil, nil, dbErr
 	}

--- a/internal/parser/antigravity_provider.go
+++ b/internal/parser/antigravity_provider.go
@@ -223,7 +223,7 @@ func (s antigravitySourceSet) WatchPlan(context.Context) (WatchPlan, error) {
 			WatchRoot{
 				Path:         filepath.Join(root, "conversations"),
 				Recursive:    false,
-				IncludeGlobs: []string{"*.db", "*.db-*"},
+				IncludeGlobs: []string{"*.db", "*.db-*", "*.trajectory.json"},
 				DebounceKey:  string(AgentAntigravity) + ":conversations:" + root,
 			},
 		)
@@ -354,6 +354,12 @@ func (s antigravitySourceSet) sourceForChangedPath(root, path string) (SourceRef
 	if dbPath, id, ok := antigravityConversationDBForPath(root, path); ok {
 		return s.newSourceRef(root, dbPath, id), true
 	}
+	if id, ok := antigravityIDETrajectoryID(root, path); ok {
+		dbPath := filepath.Join(root, "conversations", id+".db")
+		if IsRegularFile(dbPath) {
+			return s.newSourceRef(root, dbPath, id), true
+		}
+	}
 	if id, ok := antigravityAnnotationID(root, path); ok {
 		dbPath := filepath.Join(root, "conversations", id+".db")
 		if IsRegularFile(dbPath) {
@@ -420,6 +426,24 @@ func antigravityConversationDBForPath(root, path string) (string, string, bool) 
 	return filepath.Join(root, "conversations", id+".db"), id, true
 }
 
+// antigravityIDETrajectoryID reports whether path is a
+// conversations/<id>.trajectory.json agy-reader sidecar under root and,
+// if so, returns the session id so a sidecar write routes back to its
+// .db source for re-sync.
+func antigravityIDETrajectoryID(root, path string) (string, bool) {
+	rel, ok := relUnder(filepath.Clean(root), filepath.Clean(path))
+	if !ok {
+		return "", false
+	}
+	parts := strings.Split(rel, string(filepath.Separator))
+	if len(parts) != 2 || parts[0] != "conversations" ||
+		!strings.HasSuffix(parts[1], ".trajectory.json") {
+		return "", false
+	}
+	id := strings.TrimSuffix(parts[1], ".trajectory.json")
+	return id, IsValidSessionID(id)
+}
+
 func antigravityAnnotationID(root, path string) (string, bool) {
 	rel, ok := relUnder(filepath.Clean(root), filepath.Clean(path))
 	if !ok {
@@ -463,9 +487,12 @@ func antigravityProviderCapabilities() Capabilities {
 		Source: source,
 		Content: ContentCapabilities{
 			FirstMessage:         CapabilitySupported,
+			Thinking:             CapabilitySupported,
 			ToolCalls:            CapabilitySupported,
+			ToolResults:          CapabilitySupported,
 			PerMessageTokenUsage: CapabilitySupported,
 			AggregateUsageEvents: CapabilitySupported,
+			Model:                CapabilitySupported,
 		},
 	}
 }

--- a/internal/parser/antigravity_provider.go
+++ b/internal/parser/antigravity_provider.go
@@ -96,7 +96,7 @@ func (p *antigravityProvider) Parse(
 		return ParseOutcome{}, fmt.Errorf("stat %s: %w", src.Path, err)
 	}
 	machine := firstNonEmptyJSONLString(req.Machine, p.Config.Machine)
-	sess, msgs, usageEvents, err := p.parseSession(
+	sess, msgs, usageEvents, status, err := p.parseSession(
 		src.Path,
 		req.Source.ProjectHint,
 		machine,
@@ -114,15 +114,20 @@ func (p *antigravityProvider) Parse(
 	if req.Fingerprint.Hash != "" {
 		sess.File.Hash = req.Fingerprint.Hash
 	}
+	result := ParseResultOutcome{
+		Result: ParseResult{
+			Session:     *sess,
+			Messages:    msgs,
+			UsageEvents: usageEvents,
+		},
+		DataVersion: DataVersionCurrent,
+	}
+	if status.NeedsRetry {
+		result.DataVersion = DataVersionNeedsRetry
+		result.RetryReason = "antigravity ide sidecar rescue pending readable steps"
+	}
 	return ParseOutcome{
-		Results: []ParseResultOutcome{{
-			Result: ParseResult{
-				Session:     *sess,
-				Messages:    msgs,
-				UsageEvents: usageEvents,
-			},
-			DataVersion: DataVersionCurrent,
-		}},
+		Results:           []ParseResultOutcome{result},
 		ResultSetComplete: true,
 		ForceReplace:      true,
 	}, nil

--- a/internal/parser/antigravity_provider.go
+++ b/internal/parser/antigravity_provider.go
@@ -96,7 +96,7 @@ func (p *antigravityProvider) Parse(
 		return ParseOutcome{}, fmt.Errorf("stat %s: %w", src.Path, err)
 	}
 	machine := firstNonEmptyJSONLString(req.Machine, p.Config.Machine)
-	sess, msgs, usageEvents, status, err := p.parseSession(
+	sess, msgs, usageEvents, err := p.parseSession(
 		src.Path,
 		req.Source.ProjectHint,
 		machine,
@@ -114,20 +114,15 @@ func (p *antigravityProvider) Parse(
 	if req.Fingerprint.Hash != "" {
 		sess.File.Hash = req.Fingerprint.Hash
 	}
-	result := ParseResultOutcome{
-		Result: ParseResult{
-			Session:     *sess,
-			Messages:    msgs,
-			UsageEvents: usageEvents,
-		},
-		DataVersion: DataVersionCurrent,
-	}
-	if status.NeedsRetry {
-		result.DataVersion = DataVersionNeedsRetry
-		result.RetryReason = "antigravity ide sidecar rescue pending readable steps"
-	}
 	return ParseOutcome{
-		Results:           []ParseResultOutcome{result},
+		Results: []ParseResultOutcome{{
+			Result: ParseResult{
+				Session:     *sess,
+				Messages:    msgs,
+				UsageEvents: usageEvents,
+			},
+			DataVersion: DataVersionCurrent,
+		}},
 		ResultSetComplete: true,
 		ForceReplace:      true,
 	}, nil

--- a/internal/parser/antigravity_provider_test.go
+++ b/internal/parser/antigravity_provider_test.go
@@ -795,3 +795,97 @@ func TestAntigravityCLIDiscoverBuildsProjectMapOncePerRoot(t *testing.T) {
 	assert.Equal(t, 1, calls,
 		"history.jsonl project map should be built once per root, not per source")
 }
+
+// TestAntigravityProviderRoutesTrajectorySidecar verifies the IDE
+// provider watches for and routes a conversations/<id>.trajectory.json
+// sidecar write back to its .db source, and that a sidecar change moves
+// the composite fingerprint so the session re-syncs.
+func TestAntigravityProviderRoutesTrajectorySidecar(t *testing.T) {
+	root := t.TempDir()
+	id := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	dbPath := filepath.Join(root, "conversations", id+".db")
+	writeAntigravityIDEProviderFixture(t, root, id)
+
+	provider, ok := NewProvider(AgentAntigravity, ProviderConfig{
+		Roots:   []string{root},
+		Machine: "devbox",
+	})
+	require.True(t, ok)
+
+	plan, err := provider.WatchPlan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, plan.Roots, 3)
+	assert.Equal(t, filepath.Join(root, "conversations"), plan.Roots[2].Path)
+	assert.Contains(t, plan.Roots[2].IncludeGlobs, "*.trajectory.json",
+		"conversations watch must include the trajectory sidecar")
+
+	sidecarPath := filepath.Join(root, "conversations", id+".trajectory.json")
+	changed, err := provider.SourcesForChangedPath(
+		context.Background(),
+		ChangedPathRequest{Path: sidecarPath, EventKind: "write"},
+	)
+	require.NoError(t, err)
+	require.Len(t, changed, 1)
+	assert.Equal(t, dbPath, changed[0].DisplayPath,
+		"a sidecar write must route to its .db source")
+
+	// A sidecar with no matching .db must not route to a phantom source.
+	orphan := filepath.Join(root, "conversations",
+		"ffffffff-ffff-ffff-ffff-ffffffffffff.trajectory.json")
+	mustWrite(t, orphan, []byte("{}"))
+	changed, err = provider.SourcesForChangedPath(
+		context.Background(),
+		ChangedPathRequest{Path: orphan, EventKind: "write"},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, changed)
+}
+
+// TestAntigravityProviderFingerprintTracksTrajectorySidecar verifies the
+// composite fingerprint changes when the agy-reader sidecar appears or
+// is updated, so a sidecar-only change triggers a re-sync.
+func TestAntigravityProviderFingerprintTracksTrajectorySidecar(t *testing.T) {
+	root := t.TempDir()
+	id := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	writeAntigravityIDEProviderFixture(t, root, id)
+
+	provider, ok := NewProvider(AgentAntigravity, ProviderConfig{
+		Roots:   []string{root},
+		Machine: "devbox",
+	})
+	require.True(t, ok)
+	source, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
+		RawSessionID: id,
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	before, err := provider.Fingerprint(context.Background(), source)
+	require.NoError(t, err)
+
+	sidecarPath := filepath.Join(root, "conversations", id+".trajectory.json")
+	mustWrite(t, sidecarPath, []byte(`{"steps":[]}`))
+	afterCreate, err := provider.Fingerprint(context.Background(), source)
+	require.NoError(t, err)
+	assert.NotEqual(t, before.Hash, afterCreate.Hash,
+		"sidecar creation must change the fingerprint")
+
+	mustWrite(t, sidecarPath, []byte(`{"steps":[{"type":"CORTEX_STEP_TYPE_USER_INPUT"}]}`))
+	afterUpdate, err := provider.Fingerprint(context.Background(), source)
+	require.NoError(t, err)
+	assert.NotEqual(t, afterCreate.Hash, afterUpdate.Hash,
+		"sidecar update must change the fingerprint")
+}
+
+// TestAntigravityProviderCapabilitiesAdvertiseSidecarContent guards that
+// the IDE provider advertises the richer content the trajectory sidecar
+// makes available, matching the CLI provider.
+func TestAntigravityProviderCapabilitiesAdvertiseSidecarContent(t *testing.T) {
+	factory, ok := ProviderFactoryByType(AgentAntigravity)
+	require.True(t, ok)
+	caps := factory.Capabilities()
+	assert.Equal(t, CapabilitySupported, caps.Content.Thinking)
+	assert.Equal(t, CapabilitySupported, caps.Content.ToolResults)
+	assert.Equal(t, CapabilitySupported, caps.Content.Model)
+	assert.Equal(t, CapabilitySupported, caps.Content.ToolCalls)
+}

--- a/internal/parser/antigravity_provider_test.go
+++ b/internal/parser/antigravity_provider_test.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"context"
+	"database/sql"
 	"os"
 	"path/filepath"
 	"strings"
@@ -888,4 +889,66 @@ func TestAntigravityProviderCapabilitiesAdvertiseSidecarContent(t *testing.T) {
 	assert.Equal(t, CapabilitySupported, caps.Content.ToolResults)
 	assert.Equal(t, CapabilitySupported, caps.Content.Model)
 	assert.Equal(t, CapabilitySupported, caps.Content.ToolCalls)
+}
+
+// TestAntigravityProviderParseRetryOnSidecarRescue verifies the IDE
+// provider stamps DataVersionNeedsRetry when the sidecar rescues a .db
+// whose steps query fails (coverage unprovable), and DataVersionCurrent
+// for a normal covering-sidecar win over a readable DB.
+func TestAntigravityProviderParseRetryOnSidecarRescue(t *testing.T) {
+	parseOne := func(t *testing.T, root, id string) ParseResultOutcome {
+		t.Helper()
+		provider, ok := NewProvider(AgentAntigravity, ProviderConfig{
+			Roots:   []string{root},
+			Machine: "devbox",
+		})
+		require.True(t, ok)
+		source, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
+			RawSessionID: id,
+		})
+		require.NoError(t, err)
+		require.True(t, ok)
+		outcome, err := provider.Parse(context.Background(), ParseRequest{
+			Source: source,
+		})
+		require.NoError(t, err)
+		require.True(t, outcome.ResultSetComplete)
+		require.True(t, outcome.ForceReplace)
+		require.Len(t, outcome.Results, 1)
+		return outcome.Results[0]
+	}
+
+	t.Run("rescue with unreadable steps needs retry", func(t *testing.T) {
+		root := t.TempDir()
+		id := "4b4b4b4b-5c5c-6d6d-7e7e-8f8f8f8f8f8f"
+		mustMkdir(t, filepath.Join(root, "conversations"))
+		dbPath := filepath.Join(root, "conversations", id+".db")
+		db, err := sql.Open("sqlite3", dbPath)
+		require.NoError(t, err)
+		mustExec(t, db, `CREATE TABLE trajectory_meta (
+			trajectory_id text, PRIMARY KEY (trajectory_id))`)
+		require.NoError(t, db.Close())
+		writeAntigravityTestSidecar(t, root, id, 2)
+
+		result := parseOne(t, root, id)
+		assert.Equal(t, DataVersionNeedsRetry, result.DataVersion)
+		assert.NotEmpty(t, result.RetryReason)
+		assert.Equal(t, "antigravity:"+id, result.Result.Session.ID)
+		assert.NotEmpty(t, result.Result.Messages)
+	})
+
+	t.Run("covering sidecar over readable db is current", func(t *testing.T) {
+		root := t.TempDir()
+		id := "5b5b5b5b-6c6c-7d7d-8e8e-9f9f9f9f9f9f"
+		mustMkdir(t, filepath.Join(root, "conversations"))
+		dbPath := filepath.Join(root, "conversations", id+".db")
+		createAntigravityTestDB(t, dbPath) // 2 raw steps
+		writeAntigravityTestSidecar(t, root, id, 2)
+
+		result := parseOne(t, root, id)
+		assert.Equal(t, DataVersionCurrent, result.DataVersion)
+		assert.Empty(t, result.RetryReason)
+		assert.Equal(t, TranscriptFidelityFull,
+			result.Result.Session.TranscriptFidelity)
+	})
 }

--- a/internal/parser/antigravity_provider_test.go
+++ b/internal/parser/antigravity_provider_test.go
@@ -2,7 +2,6 @@ package parser
 
 import (
 	"context"
-	"database/sql"
 	"os"
 	"path/filepath"
 	"strings"
@@ -889,66 +888,4 @@ func TestAntigravityProviderCapabilitiesAdvertiseSidecarContent(t *testing.T) {
 	assert.Equal(t, CapabilitySupported, caps.Content.ToolResults)
 	assert.Equal(t, CapabilitySupported, caps.Content.Model)
 	assert.Equal(t, CapabilitySupported, caps.Content.ToolCalls)
-}
-
-// TestAntigravityProviderParseRetryOnSidecarRescue verifies the IDE
-// provider stamps DataVersionNeedsRetry when the sidecar rescues a .db
-// whose steps query fails (coverage unprovable), and DataVersionCurrent
-// for a normal covering-sidecar win over a readable DB.
-func TestAntigravityProviderParseRetryOnSidecarRescue(t *testing.T) {
-	parseOne := func(t *testing.T, root, id string) ParseResultOutcome {
-		t.Helper()
-		provider, ok := NewProvider(AgentAntigravity, ProviderConfig{
-			Roots:   []string{root},
-			Machine: "devbox",
-		})
-		require.True(t, ok)
-		source, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
-			RawSessionID: id,
-		})
-		require.NoError(t, err)
-		require.True(t, ok)
-		outcome, err := provider.Parse(context.Background(), ParseRequest{
-			Source: source,
-		})
-		require.NoError(t, err)
-		require.True(t, outcome.ResultSetComplete)
-		require.True(t, outcome.ForceReplace)
-		require.Len(t, outcome.Results, 1)
-		return outcome.Results[0]
-	}
-
-	t.Run("rescue with unreadable steps needs retry", func(t *testing.T) {
-		root := t.TempDir()
-		id := "4b4b4b4b-5c5c-6d6d-7e7e-8f8f8f8f8f8f"
-		mustMkdir(t, filepath.Join(root, "conversations"))
-		dbPath := filepath.Join(root, "conversations", id+".db")
-		db, err := sql.Open("sqlite3", dbPath)
-		require.NoError(t, err)
-		mustExec(t, db, `CREATE TABLE trajectory_meta (
-			trajectory_id text, PRIMARY KEY (trajectory_id))`)
-		require.NoError(t, db.Close())
-		writeAntigravityTestSidecar(t, root, id, 2)
-
-		result := parseOne(t, root, id)
-		assert.Equal(t, DataVersionNeedsRetry, result.DataVersion)
-		assert.NotEmpty(t, result.RetryReason)
-		assert.Equal(t, "antigravity:"+id, result.Result.Session.ID)
-		assert.NotEmpty(t, result.Result.Messages)
-	})
-
-	t.Run("covering sidecar over readable db is current", func(t *testing.T) {
-		root := t.TempDir()
-		id := "5b5b5b5b-6c6c-7d7d-8e8e-9f9f9f9f9f9f"
-		mustMkdir(t, filepath.Join(root, "conversations"))
-		dbPath := filepath.Join(root, "conversations", id+".db")
-		createAntigravityTestDB(t, dbPath) // 2 raw steps
-		writeAntigravityTestSidecar(t, root, id, 2)
-
-		result := parseOne(t, root, id)
-		assert.Equal(t, DataVersionCurrent, result.DataVersion)
-		assert.Empty(t, result.RetryReason)
-		assert.Equal(t, TranscriptFidelityFull,
-			result.Result.Session.TranscriptFidelity)
-	})
 }

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -4080,4 +4080,31 @@ func TestAntigravityIDEUnreadableStepsFailsClosed(t *testing.T) {
 		assert.Empty(t, msgs)
 		assert.Empty(t, usageEvents)
 	})
+
+	t.Run("gen_metadata usage does not persist a degraded row", func(t *testing.T) {
+		root := t.TempDir()
+		id := "4b4b4b4b-5c5c-6d6d-7e7e-8f8f8f8f8f8f"
+		dbPath := makeNoStepsDB(t, root, id)
+		// Readable gen_metadata with decodable usage, no sidecar: the
+		// usage alone must not persist a degraded row either.
+		db, err := sql.Open("sqlite3", dbPath)
+		require.NoError(t, err)
+		mustExec(t, db, `CREATE TABLE gen_metadata (
+			idx integer, data blob, size integer, PRIMARY KEY (idx))`)
+		genData := createAntigravityMockGenMetadata(t, 2400, 180, 0, "Test Gemini 3.5")
+		mustExec(t, db,
+			`INSERT INTO gen_metadata (idx, data, size) VALUES (1, ?, ?)`,
+			genData, len(genData))
+		require.NoError(t, db.Close())
+
+		sess, msgs, usageEvents, err := parseAntigravityTestSession(
+			t, dbPath, "", "test-machine",
+		)
+		require.Error(t, err,
+			"gen_metadata usage alone must not persist a degraded row")
+		assert.Contains(t, err.Error(), "steps")
+		assert.Nil(t, sess)
+		assert.Empty(t, msgs)
+		assert.Empty(t, usageEvents)
+	})
 }

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -61,25 +61,13 @@ func findAntigravityTestSourceFile(t *testing.T, root, id string) string {
 	return newAntigravityTestProvider(t, root).sources.findSourceFile(root, id)
 }
 
-// parseAntigravityTestSessionWithStatus parses an IDE session DB through the
-// provider-owned parse method, surfacing the sync-relevant parse status.
-func parseAntigravityTestSessionWithStatus(
-	t *testing.T, path, project, machine string,
-) (*ParsedSession, []ParsedMessage, []ParsedUsageEvent, antigravityParseStatus, error) {
-	t.Helper()
-	return newAntigravityTestProvider(t).parseSession(path, project, machine)
-}
-
-// parseAntigravityTestSession is the no-status convenience wrapper,
-// replacing the removed package-level ParseAntigravitySession.
+// parseAntigravityTestSession parses an IDE session DB through the provider-owned
+// parse method, replacing the removed package-level ParseAntigravitySession.
 func parseAntigravityTestSession(
 	t *testing.T, path, project, machine string,
 ) (*ParsedSession, []ParsedMessage, []ParsedUsageEvent, error) {
 	t.Helper()
-	sess, msgs, events, _, err := parseAntigravityTestSessionWithStatus(
-		t, path, project, machine,
-	)
-	return sess, msgs, events, err
+	return newAntigravityTestProvider(t).parseSession(path, project, machine)
 }
 
 // discoverAntigravityCLITestSessions discovers CLI sessions under root through
@@ -3659,12 +3647,8 @@ func TestAntigravityIDEPrefersSidecarWithCoverage(t *testing.T) {
 	createAntigravityTestDB(t, dbPath) // 2 raw steps
 	writeAntigravityTestSidecar(t, root, id, 2)
 
-	sess, msgs, _, status, err := parseAntigravityTestSessionWithStatus(
-		t, dbPath, "", "test-machine",
-	)
+	sess, msgs, _, err := parseAntigravityTestSession(t, dbPath, "", "test-machine")
 	require.NoError(t, err)
-	assert.False(t, status.NeedsRetry,
-		"a readable DB proves coverage; no retry needed")
 
 	// Structured sidecar transcript wins over the heuristic decode.
 	require.Len(t, msgs, 2)
@@ -3867,46 +3851,6 @@ func TestAntigravityIDENonCoveringSidecarUsageRejected(t *testing.T) {
 		"non-covering sidecar usage must be rejected like its transcript")
 }
 
-// TestAntigravityIDECoveringSidecarRescuesUnreadableSteps verifies that a
-// step-load failure is a fallback condition, not a parse failure: a .db
-// with a readable schema but no steps table is rescued by a covering
-// sidecar, mirroring the CLI flow.
-func TestAntigravityIDECoveringSidecarRescuesUnreadableSteps(t *testing.T) {
-	root := t.TempDir()
-	id := "8a8a8a8a-9b9b-acac-bdbd-cececececece"
-	mustMkdir(t, filepath.Join(root, "conversations"))
-
-	// Readable schema, but loadAntigravityStepsWithRawCount's
-	// `SELECT ... FROM steps` fails: no steps table.
-	dbPath := filepath.Join(root, "conversations", id+".db")
-	db, err := sql.Open("sqlite3", dbPath)
-	require.NoError(t, err)
-	mustExec(t, db, `CREATE TABLE trajectory_meta (
-		trajectory_id text, PRIMARY KEY (trajectory_id))`)
-	require.NoError(t, db.Close())
-
-	writeAntigravityTestSidecar(t, root, id, 2)
-
-	sess, msgs, _, status, err := parseAntigravityTestSessionWithStatus(
-		t, dbPath, "", "test-machine",
-	)
-	require.NoError(t, err,
-		"covering sidecar must rescue a .db with unreadable steps")
-	assert.True(t, status.NeedsRetry,
-		"rescue without a readable DB cannot prove coverage; row must stay stale")
-
-	require.Len(t, msgs, 2)
-	assert.Equal(t, "sidecar prompt", msgs[0].Content)
-	assert.Equal(t, "sidecar assistant reply", msgs[1].Content)
-	assert.Equal(t, TranscriptFidelityFull, sess.TranscriptFidelity)
-	// The schema fingerprint is computed before step loading, so the
-	// rescued session still carries the agy-schema marker.
-	assert.True(t,
-		strings.HasPrefix(sess.SourceVersion, antigravitySchemaUnknownPrefix),
-		"readable schema must still yield an agy-schema marker, got %q",
-		sess.SourceVersion)
-}
-
 // TestAntigravityIDEUnreadableStepsWithoutSidecarStillFails verifies the
 // step-load error is still surfaced when no sidecar can rescue the
 // session, preserving prior behavior.
@@ -3928,191 +3872,14 @@ func TestAntigravityIDEUnreadableStepsWithoutSidecarStillFails(t *testing.T) {
 	assert.Contains(t, err.Error(), "steps")
 }
 
-// TestAntigravityIDESidecarRescueKeepsGenMetadataUsage verifies that
-// when the steps query fails but gen_metadata is still readable, the
-// sidecar rescue keeps the DB's gen_metadata usage as primary: the
-// covering sidecar wins the transcript, but usage events come from
-// gen_metadata (ground-truth consumption), not sidecar gap-fill, and
-// GenMetadataWithoutUsage semantics stay intact.
-func TestAntigravityIDESidecarRescueKeepsGenMetadataUsage(t *testing.T) {
-	makeDB := func(t *testing.T, root, id string, genData []byte) string {
-		t.Helper()
-		mustMkdir(t, filepath.Join(root, "conversations"))
-		dbPath := filepath.Join(root, "conversations", id+".db")
-		db, err := sql.Open("sqlite3", dbPath)
-		require.NoError(t, err)
-		// Readable schema and gen_metadata, but NO steps table: the
-		// steps query fails before the shared loader reads gen_metadata.
-		mustExec(t, db, `CREATE TABLE trajectory_meta (
-			trajectory_id text, PRIMARY KEY (trajectory_id))`)
-		mustExec(t, db, `CREATE TABLE gen_metadata (
-			idx integer, data blob, size integer, PRIMARY KEY (idx))`)
-		mustExec(t, db,
-			`INSERT INTO gen_metadata (idx, data, size) VALUES (1, ?, ?)`,
-			genData, len(genData))
-		require.NoError(t, db.Close())
-		return dbPath
-	}
-
-	t.Run("gen_metadata usage wins over sidecar gap-fill", func(t *testing.T) {
-		root := t.TempDir()
-		id := "abababab-cdcd-efef-abab-cdcdcdcdcdcd"
-		genData := createAntigravityMockGenMetadata(t, 2400, 180, 0, "Test Gemini 3.5")
-		dbPath := makeDB(t, root, id, genData)
-
-		// Covering sidecar whose generatorMetadata carries DIFFERENT
-		// numbers; the DB gen_metadata event must still win.
-		genJSON := `[{
-			"stepIndices": [1],
-			"chatModel": {
-				"model": "MODEL_PLACEHOLDER_M20",
-				"usage": {"inputTokens": "9999", "outputTokens": "888"}
-			}
-		}]`
-		writeAntigravityTestSidecarWithGenMetadata(t, root, id, 2, genJSON)
-
-		sess, msgs, usageEvents, err := parseAntigravityTestSession(
-			t, dbPath, "", "test-machine",
-		)
-		require.NoError(t, err,
-			"covering sidecar must rescue a .db with unreadable steps")
-
-		require.Len(t, msgs, 2)
-		assert.Equal(t, "sidecar prompt", msgs[0].Content)
-		assert.Equal(t, TranscriptFidelityFull, sess.TranscriptFidelity)
-
-		require.Len(t, usageEvents, 1)
-		assert.Equal(t, "generation", usageEvents[0].Source,
-			"usage must come from the DB gen_metadata, not the sidecar")
-		assert.Equal(t, "Test Gemini 3.5", usageEvents[0].Model)
-		assert.Equal(t, 2400, usageEvents[0].InputTokens)
-		assert.Equal(t, 180, usageEvents[0].OutputTokens)
-		assert.Equal(t, sess.ID, usageEvents[0].SessionID)
-		// The rescue merge borrows the sidecar's per-generation timing
-		// (the planner step's createdAt) while the DB counts stay
-		// authoritative, so daily analytics do not collapse the
-		// generation onto sessions.started_at.
-		assert.Equal(t, "2026-06-10T20:41:00Z", usageEvents[0].OccurredAt)
-		assert.False(t, sess.GenMetadataWithoutUsage,
-			"decoded gen_metadata usage must clear the flag")
-
-		assert.Equal(t, 180, sess.TotalOutputTokens)
-		assert.Equal(t, 2400, sess.PeakContextTokens)
-	})
-
-	t.Run("db events beyond sidecar count stay timestamp-less", func(t *testing.T) {
-		root := t.TempDir()
-		id := "cbcbcbcb-eded-afaf-cbcb-edededededed"
-		genData := createAntigravityMockGenMetadata(t, 2400, 180, 0, "Test Gemini 3.5")
-		dbPath := makeDB(t, root, id, genData)
-		// Second gen_metadata row: the DB carries more generations than
-		// the sidecar reports. Timestamps must never be invented for
-		// the surplus event.
-		genData2 := createAntigravityMockGenMetadata(t, 500, 40, 0, "Test Gemini 3.5")
-		db, err := sql.Open("sqlite3", dbPath)
-		require.NoError(t, err)
-		mustExec(t, db,
-			`INSERT INTO gen_metadata (idx, data, size) VALUES (2, ?, ?)`,
-			genData2, len(genData2))
-		require.NoError(t, db.Close())
-
-		genJSON := `[{
-			"stepIndices": [1],
-			"chatModel": {
-				"model": "MODEL_PLACEHOLDER_M20",
-				"usage": {"inputTokens": "9999", "outputTokens": "888"}
-			}
-		}]`
-		writeAntigravityTestSidecarWithGenMetadata(t, root, id, 2, genJSON)
-
-		_, _, usageEvents, err := parseAntigravityTestSession(
-			t, dbPath, "", "test-machine",
-		)
-		require.NoError(t, err)
-		require.Len(t, usageEvents, 2,
-			"both DB gen_metadata events must survive the merge")
-		assert.Equal(t, "generation", usageEvents[0].Source)
-		assert.Equal(t, 2400, usageEvents[0].InputTokens)
-		assert.Equal(t, "2026-06-10T20:41:00Z", usageEvents[0].OccurredAt,
-			"first event pairs with the sidecar generation by position")
-		assert.Equal(t, "generation", usageEvents[1].Source)
-		assert.Equal(t, 500, usageEvents[1].InputTokens)
-		assert.Empty(t, usageEvents[1].OccurredAt,
-			"surplus DB event must stay bare; timestamps are never invented")
-	})
-
-	t.Run("zero-token generation does not shift timestamp pairing", func(t *testing.T) {
-		root := t.TempDir()
-		id := "dcdcdcdc-fefe-abab-dcdc-fefefefefefe"
-		// An empty/retried generation BEFORE the successful one: the DB
-		// loader still emits a zero-token event for it, but the sidecar
-		// drops empty-usage generations, so naive positional pairing
-		// would hand the successful generation's timestamp to the
-		// zero-token event.
-		genDataEmpty := createAntigravityMockGenMetadata(t, 0, 0, 0, "Test Gemini 3.5")
-		dbPath := makeDB(t, root, id, genDataEmpty)
-		genDataReal := createAntigravityMockGenMetadata(t, 2400, 180, 0, "Test Gemini 3.5")
-		db, err := sql.Open("sqlite3", dbPath)
-		require.NoError(t, err)
-		mustExec(t, db,
-			`INSERT INTO gen_metadata (idx, data, size) VALUES (2, ?, ?)`,
-			genDataReal, len(genDataReal))
-		require.NoError(t, db.Close())
-
-		// Sidecar carries ONLY the successful generation.
-		genJSON := `[{
-			"stepIndices": [1],
-			"chatModel": {
-				"model": "MODEL_PLACEHOLDER_M20",
-				"usage": {"inputTokens": "9999", "outputTokens": "888"}
-			}
-		}]`
-		writeAntigravityTestSidecarWithGenMetadata(t, root, id, 2, genJSON)
-
-		_, _, usageEvents, err := parseAntigravityTestSession(
-			t, dbPath, "", "test-machine",
-		)
-		require.NoError(t, err)
-		require.Len(t, usageEvents, 2,
-			"zero-token DB events remain in the output")
-		assert.Equal(t, 0, usageEvents[0].InputTokens)
-		assert.Equal(t, 0, usageEvents[0].OutputTokens)
-		assert.Empty(t, usageEvents[0].OccurredAt,
-			"zero-token event must not inherit the successful generation's timestamp")
-		assert.Equal(t, 2400, usageEvents[1].InputTokens)
-		assert.Equal(t, 180, usageEvents[1].OutputTokens)
-		assert.Equal(t, "2026-06-10T20:41:00Z", usageEvents[1].OccurredAt,
-			"successful generation pairs with the sidecar event despite the earlier zero-token row")
-	})
-
-	t.Run("undecodable gen_metadata keeps flag semantics", func(t *testing.T) {
-		root := t.TempDir()
-		id := "babababa-dcdc-fefe-baba-dcdcdcdcdcdc"
-		// Garbage gen_metadata: rows exist but decode into zero usage.
-		dbPath := makeDB(t, root, id, []byte{0xff, 0xff, 0xff})
-
-		// Covering sidecar without generatorMetadata: nothing gap-fills.
-		writeAntigravityTestSidecar(t, root, id, 2)
-
-		sess, msgs, usageEvents, err := parseAntigravityTestSession(
-			t, dbPath, "", "test-machine",
-		)
-		require.NoError(t, err)
-		require.NotEmpty(t, msgs)
-		assert.Equal(t, TranscriptFidelityFull, sess.TranscriptFidelity)
-		assert.Empty(t, usageEvents)
-		assert.True(t, sess.GenMetadataWithoutUsage,
-			"gen_metadata rows that decode to no usage must flag the session")
-	})
-}
-
 // TestAntigravityIDEUnreadableStepsFailsClosed verifies that a
-// step-load failure without a rescuing (covering, displayable) sidecar
-// transcript surfaces the error even when partial data exists: the sync
-// engine unconditionally full-replaces stored Antigravity messages on
-// any successful parse, so persisting a degraded usage-only or
-// brain-only row would clobber a previously stored full transcript
-// whenever the steps query fails transiently.
+// step-load failure always surfaces the error, no matter what other
+// data exists -- including a covering displayable sidecar: coverage is
+// unprovable without the DB's step count, and the sync engine
+// unconditionally full-replaces stored Antigravity messages on any
+// successful parse, so persisting sidecar, usage-only, or brain-only
+// content would clobber a previously stored full transcript whenever
+// the steps query fails transiently.
 func TestAntigravityIDEUnreadableStepsFailsClosed(t *testing.T) {
 	makeNoStepsDB := func(t *testing.T, root, id string) string {
 		t.Helper()
@@ -4125,6 +3892,28 @@ func TestAntigravityIDEUnreadableStepsFailsClosed(t *testing.T) {
 		require.NoError(t, db.Close())
 		return dbPath
 	}
+
+	t.Run("covering displayable sidecar does not rescue", func(t *testing.T) {
+		root := t.TempDir()
+		id := "8a8a8a8a-9b9b-acac-bdbd-cececececece"
+		dbPath := makeNoStepsDB(t, root, id)
+		// A displayable sidecar that would win over a readable DB. With
+		// the steps query failing, coverage is unprovable (the sidecar
+		// may lag a live session) and this provider force-replaces on
+		// success, so a rescue could overwrite a previously complete
+		// stored transcript. The parse must fail instead.
+		writeAntigravityTestSidecar(t, root, id, 2)
+
+		sess, msgs, usageEvents, err := parseAntigravityTestSession(
+			t, dbPath, "", "test-machine",
+		)
+		require.Error(t, err,
+			"a covering displayable sidecar must not rescue an unreadable DB")
+		assert.Contains(t, err.Error(), "steps")
+		assert.Nil(t, sess)
+		assert.Empty(t, msgs)
+		assert.Empty(t, usageEvents)
+	})
 
 	t.Run("usage-only sidecar does not persist a degraded row", func(t *testing.T) {
 		root := t.TempDir()

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -3988,11 +3988,57 @@ func TestAntigravityIDESidecarRescueKeepsGenMetadataUsage(t *testing.T) {
 		assert.Equal(t, 2400, usageEvents[0].InputTokens)
 		assert.Equal(t, 180, usageEvents[0].OutputTokens)
 		assert.Equal(t, sess.ID, usageEvents[0].SessionID)
+		// The rescue merge borrows the sidecar's per-generation timing
+		// (the planner step's createdAt) while the DB counts stay
+		// authoritative, so daily analytics do not collapse the
+		// generation onto sessions.started_at.
+		assert.Equal(t, "2026-06-10T20:41:00Z", usageEvents[0].OccurredAt)
 		assert.False(t, sess.GenMetadataWithoutUsage,
 			"decoded gen_metadata usage must clear the flag")
 
 		assert.Equal(t, 180, sess.TotalOutputTokens)
 		assert.Equal(t, 2400, sess.PeakContextTokens)
+	})
+
+	t.Run("db events beyond sidecar count stay timestamp-less", func(t *testing.T) {
+		root := t.TempDir()
+		id := "cbcbcbcb-eded-afaf-cbcb-edededededed"
+		genData := createAntigravityMockGenMetadata(t, 2400, 180, 0, "Test Gemini 3.5")
+		dbPath := makeDB(t, root, id, genData)
+		// Second gen_metadata row: the DB carries more generations than
+		// the sidecar reports. Timestamps must never be invented for
+		// the surplus event.
+		genData2 := createAntigravityMockGenMetadata(t, 500, 40, 0, "Test Gemini 3.5")
+		db, err := sql.Open("sqlite3", dbPath)
+		require.NoError(t, err)
+		mustExec(t, db,
+			`INSERT INTO gen_metadata (idx, data, size) VALUES (2, ?, ?)`,
+			genData2, len(genData2))
+		require.NoError(t, db.Close())
+
+		genJSON := `[{
+			"stepIndices": [1],
+			"chatModel": {
+				"model": "MODEL_PLACEHOLDER_M20",
+				"usage": {"inputTokens": "9999", "outputTokens": "888"}
+			}
+		}]`
+		writeAntigravityTestSidecarWithGenMetadata(t, root, id, 2, genJSON)
+
+		_, _, usageEvents, err := parseAntigravityTestSession(
+			t, dbPath, "", "test-machine",
+		)
+		require.NoError(t, err)
+		require.Len(t, usageEvents, 2,
+			"both DB gen_metadata events must survive the merge")
+		assert.Equal(t, "generation", usageEvents[0].Source)
+		assert.Equal(t, 2400, usageEvents[0].InputTokens)
+		assert.Equal(t, "2026-06-10T20:41:00Z", usageEvents[0].OccurredAt,
+			"first event pairs with the sidecar generation by position")
+		assert.Equal(t, "generation", usageEvents[1].Source)
+		assert.Equal(t, 500, usageEvents[1].InputTokens)
+		assert.Empty(t, usageEvents[1].OccurredAt,
+			"surplus DB event must stay bare; timestamps are never invented")
 	})
 
 	t.Run("undecodable gen_metadata keeps flag semantics", func(t *testing.T) {

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -3850,3 +3850,60 @@ func TestAntigravityIDENonCoveringSidecarUsageRejected(t *testing.T) {
 	assert.Empty(t, usageEvents,
 		"non-covering sidecar usage must be rejected like its transcript")
 }
+
+// TestAntigravityIDECoveringSidecarRescuesUnreadableSteps verifies that a
+// step-load failure is a fallback condition, not a parse failure: a .db
+// with a readable schema but no steps table is rescued by a covering
+// sidecar, mirroring the CLI flow.
+func TestAntigravityIDECoveringSidecarRescuesUnreadableSteps(t *testing.T) {
+	root := t.TempDir()
+	id := "8a8a8a8a-9b9b-acac-bdbd-cececececece"
+	mustMkdir(t, filepath.Join(root, "conversations"))
+
+	// Readable schema, but loadAntigravityStepsWithRawCount's
+	// `SELECT ... FROM steps` fails: no steps table.
+	dbPath := filepath.Join(root, "conversations", id+".db")
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	mustExec(t, db, `CREATE TABLE trajectory_meta (
+		trajectory_id text, PRIMARY KEY (trajectory_id))`)
+	require.NoError(t, db.Close())
+
+	writeAntigravityTestSidecar(t, root, id, 2)
+
+	sess, msgs, _, err := parseAntigravityTestSession(t, dbPath, "", "test-machine")
+	require.NoError(t, err,
+		"covering sidecar must rescue a .db with unreadable steps")
+
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "sidecar prompt", msgs[0].Content)
+	assert.Equal(t, "sidecar assistant reply", msgs[1].Content)
+	assert.Equal(t, TranscriptFidelityFull, sess.TranscriptFidelity)
+	// The schema fingerprint is computed before step loading, so the
+	// rescued session still carries the agy-schema marker.
+	assert.True(t,
+		strings.HasPrefix(sess.SourceVersion, antigravitySchemaUnknownPrefix),
+		"readable schema must still yield an agy-schema marker, got %q",
+		sess.SourceVersion)
+}
+
+// TestAntigravityIDEUnreadableStepsWithoutSidecarStillFails verifies the
+// step-load error is still surfaced when no sidecar can rescue the
+// session, preserving prior behavior.
+func TestAntigravityIDEUnreadableStepsWithoutSidecarStillFails(t *testing.T) {
+	root := t.TempDir()
+	id := "9a9a9a9a-abab-bcbc-cdcd-dededededede"
+	mustMkdir(t, filepath.Join(root, "conversations"))
+
+	dbPath := filepath.Join(root, "conversations", id+".db")
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	mustExec(t, db, `CREATE TABLE trajectory_meta (
+		trajectory_id text, PRIMARY KEY (trajectory_id))`)
+	require.NoError(t, db.Close())
+
+	_, _, _, err = parseAntigravityTestSession(t, dbPath, "", "test-machine")
+	require.Error(t, err,
+		"unreadable steps without a rescuing sidecar must fail the parse")
+	assert.Contains(t, err.Error(), "steps")
+}

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -3995,3 +3995,104 @@ func TestAntigravityIDESidecarRescueKeepsGenMetadataUsage(t *testing.T) {
 			"gen_metadata rows that decode to no usage must flag the session")
 	})
 }
+
+// TestAntigravityIDEUnreadableStepsDegradesToRecoverableData verifies
+// that a step-load failure without a rescuing sidecar transcript does
+// not drop data that is still recoverable: usage-only sidecars, DB
+// gen_metadata, and brain artifacts all persist a degraded session, and
+// the step-load error surfaces only when nothing is recoverable.
+func TestAntigravityIDEUnreadableStepsDegradesToRecoverableData(t *testing.T) {
+	makeNoStepsDB := func(t *testing.T, root, id string, genData []byte) string {
+		t.Helper()
+		mustMkdir(t, filepath.Join(root, "conversations"))
+		dbPath := filepath.Join(root, "conversations", id+".db")
+		db, err := sql.Open("sqlite3", dbPath)
+		require.NoError(t, err)
+		mustExec(t, db, `CREATE TABLE trajectory_meta (
+			trajectory_id text, PRIMARY KEY (trajectory_id))`)
+		if genData != nil {
+			mustExec(t, db, `CREATE TABLE gen_metadata (
+				idx integer, data blob, size integer, PRIMARY KEY (idx))`)
+			mustExec(t, db,
+				`INSERT INTO gen_metadata (idx, data, size) VALUES (1, ?, ?)`,
+				genData, len(genData))
+		}
+		require.NoError(t, db.Close())
+		return dbPath
+	}
+
+	genJSON := `[{
+		"stepIndices": [1],
+		"chatModel": {
+			"model": "MODEL_PLACEHOLDER_M20",
+			"usage": {"inputTokens": "1500", "outputTokens": "77"}
+		}
+	}]`
+
+	t.Run("usage-only sidecar persists with sidecar usage", func(t *testing.T) {
+		root := t.TempDir()
+		id := "1b1b1b1b-2c2c-3d3d-4e4e-5f5f5f5f5f5f"
+		dbPath := makeNoStepsDB(t, root, id, nil)
+		// Sidecar with zero steps: no displayable transcript, only
+		// generatorMetadata usage.
+		writeAntigravityTestSidecarWithGenMetadata(t, root, id, 0, genJSON)
+
+		sess, msgs, usageEvents, err := parseAntigravityTestSession(
+			t, dbPath, "", "test-machine",
+		)
+		require.NoError(t, err,
+			"recoverable sidecar usage must persist a degraded session")
+		assert.Empty(t, msgs, "no transcript is fabricated")
+		assert.Equal(t, "", sess.TranscriptFidelity)
+		assert.Equal(t, 0, sess.MessageCount)
+		assert.Equal(t, 0, sess.UserMessageCount)
+		assert.Empty(t, sess.FirstMessage)
+		require.Len(t, usageEvents, 1)
+		assert.Equal(t, "sidecar", usageEvents[0].Source)
+		assert.Equal(t, 1500, usageEvents[0].InputTokens)
+		assert.Equal(t, 77, usageEvents[0].OutputTokens)
+		assert.Equal(t, sess.ID, usageEvents[0].SessionID)
+	})
+
+	t.Run("gen_metadata usage stays primary over usage-only sidecar", func(t *testing.T) {
+		root := t.TempDir()
+		id := "2b2b2b2b-3c3c-4d4d-5e5e-6f6f6f6f6f6f"
+		genData := createAntigravityMockGenMetadata(t, 2400, 180, 0, "Test Gemini 3.5")
+		dbPath := makeNoStepsDB(t, root, id, genData)
+		writeAntigravityTestSidecarWithGenMetadata(t, root, id, 0, genJSON)
+
+		sess, msgs, usageEvents, err := parseAntigravityTestSession(
+			t, dbPath, "", "test-machine",
+		)
+		require.NoError(t, err)
+		assert.Empty(t, msgs)
+		require.Len(t, usageEvents, 1)
+		assert.Equal(t, "generation", usageEvents[0].Source,
+			"DB gen_metadata must win over sidecar usage")
+		assert.Equal(t, 2400, usageEvents[0].InputTokens)
+		assert.Equal(t, 180, usageEvents[0].OutputTokens)
+		assert.False(t, sess.GenMetadataWithoutUsage)
+	})
+
+	t.Run("brain artifacts persist without any sidecar", func(t *testing.T) {
+		root := t.TempDir()
+		id := "3b3b3b3b-4c4c-5d5d-6e6e-7f7f7f7f7f7f"
+		dbPath := makeNoStepsDB(t, root, id, nil)
+		mustMkdir(t, filepath.Join(root, "brain", id))
+		mustWrite(t, filepath.Join(root, "brain", id, "plan.md"),
+			[]byte("# Recovered plan"))
+
+		sess, msgs, usageEvents, err := parseAntigravityTestSession(
+			t, dbPath, "", "test-machine",
+		)
+		require.NoError(t, err,
+			"brain artifacts must persist a degraded session")
+		require.Len(t, msgs, 1)
+		assert.Equal(t, RoleAssistant, msgs[0].Role)
+		assert.Contains(t, msgs[0].Content, "Recovered plan")
+		assert.Equal(t, "", sess.TranscriptFidelity)
+		assert.Equal(t, 1, sess.MessageCount)
+		assert.Equal(t, 0, sess.UserMessageCount)
+		assert.Empty(t, usageEvents)
+	})
+}

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -4041,6 +4041,50 @@ func TestAntigravityIDESidecarRescueKeepsGenMetadataUsage(t *testing.T) {
 			"surplus DB event must stay bare; timestamps are never invented")
 	})
 
+	t.Run("zero-token generation does not shift timestamp pairing", func(t *testing.T) {
+		root := t.TempDir()
+		id := "dcdcdcdc-fefe-abab-dcdc-fefefefefefe"
+		// An empty/retried generation BEFORE the successful one: the DB
+		// loader still emits a zero-token event for it, but the sidecar
+		// drops empty-usage generations, so naive positional pairing
+		// would hand the successful generation's timestamp to the
+		// zero-token event.
+		genDataEmpty := createAntigravityMockGenMetadata(t, 0, 0, 0, "Test Gemini 3.5")
+		dbPath := makeDB(t, root, id, genDataEmpty)
+		genDataReal := createAntigravityMockGenMetadata(t, 2400, 180, 0, "Test Gemini 3.5")
+		db, err := sql.Open("sqlite3", dbPath)
+		require.NoError(t, err)
+		mustExec(t, db,
+			`INSERT INTO gen_metadata (idx, data, size) VALUES (2, ?, ?)`,
+			genDataReal, len(genDataReal))
+		require.NoError(t, db.Close())
+
+		// Sidecar carries ONLY the successful generation.
+		genJSON := `[{
+			"stepIndices": [1],
+			"chatModel": {
+				"model": "MODEL_PLACEHOLDER_M20",
+				"usage": {"inputTokens": "9999", "outputTokens": "888"}
+			}
+		}]`
+		writeAntigravityTestSidecarWithGenMetadata(t, root, id, 2, genJSON)
+
+		_, _, usageEvents, err := parseAntigravityTestSession(
+			t, dbPath, "", "test-machine",
+		)
+		require.NoError(t, err)
+		require.Len(t, usageEvents, 2,
+			"zero-token DB events remain in the output")
+		assert.Equal(t, 0, usageEvents[0].InputTokens)
+		assert.Equal(t, 0, usageEvents[0].OutputTokens)
+		assert.Empty(t, usageEvents[0].OccurredAt,
+			"zero-token event must not inherit the successful generation's timestamp")
+		assert.Equal(t, 2400, usageEvents[1].InputTokens)
+		assert.Equal(t, 180, usageEvents[1].OutputTokens)
+		assert.Equal(t, "2026-06-10T20:41:00Z", usageEvents[1].OccurredAt,
+			"successful generation pairs with the sidecar event despite the earlier zero-token row")
+	})
+
 	t.Run("undecodable gen_metadata keeps flag semantics", func(t *testing.T) {
 		root := t.TempDir()
 		id := "babababa-dcdc-fefe-baba-dcdcdcdcdcdc"

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -3907,3 +3907,91 @@ func TestAntigravityIDEUnreadableStepsWithoutSidecarStillFails(t *testing.T) {
 		"unreadable steps without a rescuing sidecar must fail the parse")
 	assert.Contains(t, err.Error(), "steps")
 }
+
+// TestAntigravityIDESidecarRescueKeepsGenMetadataUsage verifies that
+// when the steps query fails but gen_metadata is still readable, the
+// sidecar rescue keeps the DB's gen_metadata usage as primary: the
+// covering sidecar wins the transcript, but usage events come from
+// gen_metadata (ground-truth consumption), not sidecar gap-fill, and
+// GenMetadataWithoutUsage semantics stay intact.
+func TestAntigravityIDESidecarRescueKeepsGenMetadataUsage(t *testing.T) {
+	makeDB := func(t *testing.T, root, id string, genData []byte) string {
+		t.Helper()
+		mustMkdir(t, filepath.Join(root, "conversations"))
+		dbPath := filepath.Join(root, "conversations", id+".db")
+		db, err := sql.Open("sqlite3", dbPath)
+		require.NoError(t, err)
+		// Readable schema and gen_metadata, but NO steps table: the
+		// steps query fails before the shared loader reads gen_metadata.
+		mustExec(t, db, `CREATE TABLE trajectory_meta (
+			trajectory_id text, PRIMARY KEY (trajectory_id))`)
+		mustExec(t, db, `CREATE TABLE gen_metadata (
+			idx integer, data blob, size integer, PRIMARY KEY (idx))`)
+		mustExec(t, db,
+			`INSERT INTO gen_metadata (idx, data, size) VALUES (1, ?, ?)`,
+			genData, len(genData))
+		require.NoError(t, db.Close())
+		return dbPath
+	}
+
+	t.Run("gen_metadata usage wins over sidecar gap-fill", func(t *testing.T) {
+		root := t.TempDir()
+		id := "abababab-cdcd-efef-abab-cdcdcdcdcdcd"
+		genData := createAntigravityMockGenMetadata(t, 2400, 180, 0, "Test Gemini 3.5")
+		dbPath := makeDB(t, root, id, genData)
+
+		// Covering sidecar whose generatorMetadata carries DIFFERENT
+		// numbers; the DB gen_metadata event must still win.
+		genJSON := `[{
+			"stepIndices": [1],
+			"chatModel": {
+				"model": "MODEL_PLACEHOLDER_M20",
+				"usage": {"inputTokens": "9999", "outputTokens": "888"}
+			}
+		}]`
+		writeAntigravityTestSidecarWithGenMetadata(t, root, id, 2, genJSON)
+
+		sess, msgs, usageEvents, err := parseAntigravityTestSession(
+			t, dbPath, "", "test-machine",
+		)
+		require.NoError(t, err,
+			"covering sidecar must rescue a .db with unreadable steps")
+
+		require.Len(t, msgs, 2)
+		assert.Equal(t, "sidecar prompt", msgs[0].Content)
+		assert.Equal(t, TranscriptFidelityFull, sess.TranscriptFidelity)
+
+		require.Len(t, usageEvents, 1)
+		assert.Equal(t, "generation", usageEvents[0].Source,
+			"usage must come from the DB gen_metadata, not the sidecar")
+		assert.Equal(t, "Test Gemini 3.5", usageEvents[0].Model)
+		assert.Equal(t, 2400, usageEvents[0].InputTokens)
+		assert.Equal(t, 180, usageEvents[0].OutputTokens)
+		assert.Equal(t, sess.ID, usageEvents[0].SessionID)
+		assert.False(t, sess.GenMetadataWithoutUsage,
+			"decoded gen_metadata usage must clear the flag")
+
+		assert.Equal(t, 180, sess.TotalOutputTokens)
+		assert.Equal(t, 2400, sess.PeakContextTokens)
+	})
+
+	t.Run("undecodable gen_metadata keeps flag semantics", func(t *testing.T) {
+		root := t.TempDir()
+		id := "babababa-dcdc-fefe-baba-dcdcdcdcdcdc"
+		// Garbage gen_metadata: rows exist but decode into zero usage.
+		dbPath := makeDB(t, root, id, []byte{0xff, 0xff, 0xff})
+
+		// Covering sidecar without generatorMetadata: nothing gap-fills.
+		writeAntigravityTestSidecar(t, root, id, 2)
+
+		sess, msgs, usageEvents, err := parseAntigravityTestSession(
+			t, dbPath, "", "test-machine",
+		)
+		require.NoError(t, err)
+		require.NotEmpty(t, msgs)
+		assert.Equal(t, TranscriptFidelityFull, sess.TranscriptFidelity)
+		assert.Empty(t, usageEvents)
+		assert.True(t, sess.GenMetadataWithoutUsage,
+			"gen_metadata rows that decode to no usage must flag the session")
+	})
+}

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -3628,3 +3628,225 @@ func TestAntigravityCLITranscriptFidelity(t *testing.T) {
 		assert.Equal(t, TranscriptFidelitySummary, sess.TranscriptFidelity)
 	})
 }
+
+// ---- IDE trajectory sidecar (agy-reader) ----------------------
+//
+// The IDE parser mirrors the CLI sidecar-wins path: when a
+// conversations/<uuid>.trajectory.json sidecar covers the raw .db step
+// count it replaces the heuristic decode and marks the transcript full;
+// otherwise the heuristic decode stands exactly as before. These tests
+// reuse the CLI sidecar fixtures (writeAntigravityTestSidecar) since the
+// sidecar format and on-disk location are identical.
+
+func TestAntigravityIDEPrefersSidecarWithCoverage(t *testing.T) {
+	root := t.TempDir()
+	id := "1a1a1a1a-2b2b-3c3c-4d4d-5e5e5e5e5e5e"
+	mustMkdir(t, filepath.Join(root, "conversations"))
+
+	dbPath := filepath.Join(root, "conversations", id+".db")
+	createAntigravityTestDB(t, dbPath) // 2 raw steps
+	writeAntigravityTestSidecar(t, root, id, 2)
+
+	sess, msgs, _, err := parseAntigravityTestSession(t, dbPath, "", "test-machine")
+	require.NoError(t, err)
+
+	// Structured sidecar transcript wins over the heuristic decode.
+	require.Len(t, msgs, 2)
+	assert.Equal(t, RoleUser, msgs[0].Role)
+	assert.Equal(t, "sidecar prompt", msgs[0].Content)
+	assert.Equal(t, RoleAssistant, msgs[1].Role)
+	assert.Equal(t, "sidecar assistant reply", msgs[1].Content)
+	assert.True(t, msgs[1].HasThinking)
+	require.Len(t, msgs[1].ToolCalls, 1)
+	assert.Equal(t, "tc-1", msgs[1].ToolCalls[0].ToolUseID)
+	assert.Equal(t, "sidecar prompt", sess.FirstMessage)
+	assert.Equal(t, TranscriptFidelityFull, sess.TranscriptFidelity)
+}
+
+func TestAntigravityIDEHeuristicFallbackWhenSidecarMissing(t *testing.T) {
+	root := t.TempDir()
+	id := "2a2a2a2a-3b3b-4c4c-5d5d-6e6e6e6e6e6e"
+	mustMkdir(t, filepath.Join(root, "conversations"))
+
+	dbPath := filepath.Join(root, "conversations", id+".db")
+	createAntigravityTestDB(t, dbPath) // 2 raw steps, no sidecar
+
+	sess, msgs, _, err := parseAntigravityTestSession(t, dbPath, "", "test-machine")
+	require.NoError(t, err)
+
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "user prompt text goes here", msgs[0].Content)
+	assert.Contains(t, msgs[1].Content, "assistant reply content body")
+	// Fidelity unchanged from prior IDE behavior: empty (treated as full).
+	assert.Equal(t, "", sess.TranscriptFidelity)
+}
+
+func TestAntigravityIDEKeepsDBDecodeWhenSidecarLags(t *testing.T) {
+	root := t.TempDir()
+	id := "3a3a3a3a-4b4b-5c5c-6d6d-7e7e7e7e7e7e"
+	mustMkdir(t, filepath.Join(root, "conversations"))
+
+	dbPath := filepath.Join(root, "conversations", id+".db")
+	createAntigravityTestDB(t, dbPath) // 2 raw steps
+	// Sidecar covers only 1 of 2 steps: a live session agy-reader has
+	// not caught up with yet. The fuller heuristic decode must win.
+	writeAntigravityTestSidecar(t, root, id, 1)
+
+	sess, msgs, _, err := parseAntigravityTestSession(t, dbPath, "", "test-machine")
+	require.NoError(t, err)
+
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "user prompt text goes here", msgs[0].Content)
+	assert.Contains(t, msgs[1].Content, "assistant reply content body")
+	assert.Equal(t, "", sess.TranscriptFidelity)
+}
+
+func TestAntigravityIDEMalformedSidecarFallsBack(t *testing.T) {
+	root := t.TempDir()
+	id := "4a4a4a4a-5b5b-6c6c-7d7d-8e8e8e8e8e8e"
+	mustMkdir(t, filepath.Join(root, "conversations"))
+
+	dbPath := filepath.Join(root, "conversations", id+".db")
+	createAntigravityTestDB(t, dbPath) // 2 raw steps
+	mustWrite(t,
+		filepath.Join(root, "conversations", id+".trajectory.json"),
+		[]byte(`{not valid json`))
+
+	sess, msgs, _, err := parseAntigravityTestSession(t, dbPath, "", "test-machine")
+	require.NoError(t, err)
+
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "user prompt text goes here", msgs[0].Content)
+	assert.Contains(t, msgs[1].Content, "assistant reply content body")
+	assert.Equal(t, "", sess.TranscriptFidelity)
+}
+
+// TestAntigravityIDESidecarWinsKeepsGenMetadataUsage verifies the
+// gen_metadata-wins merge: a covering sidecar replaces the transcript,
+// but usage still comes from the .db gen_metadata (source "generation")
+// rather than being double counted from the sidecar.
+func TestAntigravityIDESidecarWinsKeepsGenMetadataUsage(t *testing.T) {
+	root := t.TempDir()
+	id := "5a5a5a5a-6b6b-7c7c-8d8d-9e9e9e9e9e9e"
+	mustMkdir(t, filepath.Join(root, "conversations"))
+
+	dbPath := filepath.Join(root, "conversations", id+".db")
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	createAntigravityStepTables(t, db)
+	mustExec(t, db, `CREATE TABLE gen_metadata (idx integer, data blob, size integer, PRIMARY KEY (idx))`)
+	tsEarly := encodePB([]pbField{{num: 1, wire: pbWireVarint, varint: 1779000000}})
+	userPayload := encodePB([]pbField{
+		{num: 5, wire: pbWireBytes, bytes: tsEarly},
+		{num: 17, wire: pbWireBytes, bytes: []byte("db user prompt that is long enough")},
+	})
+	tsLate := encodePB([]pbField{{num: 1, wire: pbWireVarint, varint: 1779000100}})
+	asstPayload := encodePB([]pbField{
+		{num: 5, wire: pbWireBytes, bytes: tsLate},
+		{num: 17, wire: pbWireBytes, bytes: []byte("db assistant reply that is long enough")},
+	})
+	mustExec(t, db, `INSERT INTO steps (idx, step_type, step_payload) VALUES (0, 14, ?)`, userPayload)
+	mustExec(t, db, `INSERT INTO steps (idx, step_type, step_payload) VALUES (1, 17, ?)`, asstPayload)
+	genData := createAntigravityMockGenMetadata(t, 2400, 180, 0, "Test Gemini 3.5")
+	mustExec(t, db, `INSERT INTO gen_metadata (idx, data, size) VALUES (1, ?, ?)`, genData, len(genData))
+	require.NoError(t, db.Close())
+
+	// Covering sidecar with DIFFERENT generatorMetadata usage; the .db
+	// gen_metadata event must still win so the generation is counted once.
+	genJSON := `[{
+		"stepIndices": [1],
+		"chatModel": {
+			"model": "MODEL_PLACEHOLDER_M20",
+			"usage": {"inputTokens": "9999", "outputTokens": "888"}
+		}
+	}]`
+	writeAntigravityTestSidecarWithGenMetadata(t, root, id, 2, genJSON)
+
+	sess, msgs, usageEvents, err := parseAntigravityTestSession(t, dbPath, "", "test-machine")
+	require.NoError(t, err)
+
+	// Sidecar transcript wins.
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "sidecar prompt", msgs[0].Content)
+	assert.Equal(t, TranscriptFidelityFull, sess.TranscriptFidelity)
+
+	// Exactly one usage event, from the .db gen_metadata (not the sidecar).
+	require.Len(t, usageEvents, 1)
+	assert.Equal(t, "generation", usageEvents[0].Source)
+	assert.Equal(t, 2400, usageEvents[0].InputTokens)
+	assert.Equal(t, 180, usageEvents[0].OutputTokens)
+	assert.Equal(t, sess.ID, usageEvents[0].SessionID)
+}
+
+// TestAntigravityIDEWithoutGenMetadataGetsSidecarUsage verifies the
+// gap-fill: when the .db has no gen_metadata, a covering sidecar's
+// generatorMetadata supplies usage events (source "sidecar").
+func TestAntigravityIDEWithoutGenMetadataGetsSidecarUsage(t *testing.T) {
+	root := t.TempDir()
+	id := "6a6a6a6a-7b7b-8c8c-9d9d-aeaeaeaeaeae"
+	mustMkdir(t, filepath.Join(root, "conversations"))
+
+	dbPath := filepath.Join(root, "conversations", id+".db")
+	createAntigravityTestDB(t, dbPath) // 2 raw steps, no gen_metadata table
+
+	genJSON := `[{
+		"stepIndices": [1],
+		"chatModel": {
+			"model": "MODEL_PLACEHOLDER_M20",
+			"usage": {
+				"inputTokens": "1500",
+				"outputTokens": "77",
+				"thinkingOutputTokens": "20",
+				"cacheReadTokens": "300"
+			}
+		}
+	}]`
+	writeAntigravityTestSidecarWithGenMetadata(t, root, id, 2, genJSON)
+
+	sess, msgs, usageEvents, err := parseAntigravityTestSession(t, dbPath, "", "test-machine")
+	require.NoError(t, err)
+	require.NotEmpty(t, msgs)
+	assert.Equal(t, "sidecar prompt", msgs[0].Content)
+	assert.Equal(t, TranscriptFidelityFull, sess.TranscriptFidelity)
+
+	require.Len(t, usageEvents, 1)
+	assert.Equal(t, "sidecar", usageEvents[0].Source)
+	assert.Equal(t, "MODEL_PLACEHOLDER_M20", usageEvents[0].Model)
+	assert.Equal(t, 1500, usageEvents[0].InputTokens)
+	assert.Equal(t, 77, usageEvents[0].OutputTokens)
+	assert.Equal(t, 20, usageEvents[0].ReasoningTokens)
+	assert.Equal(t, 300, usageEvents[0].CacheReadInputTokens)
+	assert.Equal(t, sess.ID, usageEvents[0].SessionID)
+}
+
+// TestAntigravityIDENonCoveringSidecarUsageRejected verifies that a
+// lagging sidecar loses both the transcript and its usage: the usage
+// gap-fill is gated on the same coverage check as the transcript.
+func TestAntigravityIDENonCoveringSidecarUsageRejected(t *testing.T) {
+	root := t.TempDir()
+	id := "7a7a7a7a-8b8b-9c9c-adad-bebebebebebe"
+	mustMkdir(t, filepath.Join(root, "conversations"))
+
+	dbPath := filepath.Join(root, "conversations", id+".db")
+	createAntigravityTestDB(t, dbPath) // 2 raw steps, no gen_metadata table
+
+	genJSON := `[{
+		"stepIndices": [1],
+		"chatModel": {
+			"model": "MODEL_PLACEHOLDER_M20",
+			"usage": {"inputTokens": "1500", "outputTokens": "77"}
+		}
+	}]`
+	// Sidecar covers only 1 of 2 raw steps.
+	writeAntigravityTestSidecarWithGenMetadata(t, root, id, 1, genJSON)
+
+	sess, msgs, usageEvents, err := parseAntigravityTestSession(t, dbPath, "", "test-machine")
+	require.NoError(t, err)
+
+	// Heuristic decode wins; sidecar usage rejected like its transcript.
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "user prompt text goes here", msgs[0].Content)
+	assert.Equal(t, "", sess.TranscriptFidelity)
+	assert.Empty(t, usageEvents,
+		"non-covering sidecar usage must be rejected like its transcript")
+}

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -61,13 +61,25 @@ func findAntigravityTestSourceFile(t *testing.T, root, id string) string {
 	return newAntigravityTestProvider(t, root).sources.findSourceFile(root, id)
 }
 
-// parseAntigravityTestSession parses an IDE session DB through the provider-owned
-// parse method, replacing the removed package-level ParseAntigravitySession.
+// parseAntigravityTestSessionWithStatus parses an IDE session DB through the
+// provider-owned parse method, surfacing the sync-relevant parse status.
+func parseAntigravityTestSessionWithStatus(
+	t *testing.T, path, project, machine string,
+) (*ParsedSession, []ParsedMessage, []ParsedUsageEvent, antigravityParseStatus, error) {
+	t.Helper()
+	return newAntigravityTestProvider(t).parseSession(path, project, machine)
+}
+
+// parseAntigravityTestSession is the no-status convenience wrapper,
+// replacing the removed package-level ParseAntigravitySession.
 func parseAntigravityTestSession(
 	t *testing.T, path, project, machine string,
 ) (*ParsedSession, []ParsedMessage, []ParsedUsageEvent, error) {
 	t.Helper()
-	return newAntigravityTestProvider(t).parseSession(path, project, machine)
+	sess, msgs, events, _, err := parseAntigravityTestSessionWithStatus(
+		t, path, project, machine,
+	)
+	return sess, msgs, events, err
 }
 
 // discoverAntigravityCLITestSessions discovers CLI sessions under root through
@@ -3647,8 +3659,12 @@ func TestAntigravityIDEPrefersSidecarWithCoverage(t *testing.T) {
 	createAntigravityTestDB(t, dbPath) // 2 raw steps
 	writeAntigravityTestSidecar(t, root, id, 2)
 
-	sess, msgs, _, err := parseAntigravityTestSession(t, dbPath, "", "test-machine")
+	sess, msgs, _, status, err := parseAntigravityTestSessionWithStatus(
+		t, dbPath, "", "test-machine",
+	)
 	require.NoError(t, err)
+	assert.False(t, status.NeedsRetry,
+		"a readable DB proves coverage; no retry needed")
 
 	// Structured sidecar transcript wins over the heuristic decode.
 	require.Len(t, msgs, 2)
@@ -3871,9 +3887,13 @@ func TestAntigravityIDECoveringSidecarRescuesUnreadableSteps(t *testing.T) {
 
 	writeAntigravityTestSidecar(t, root, id, 2)
 
-	sess, msgs, _, err := parseAntigravityTestSession(t, dbPath, "", "test-machine")
+	sess, msgs, _, status, err := parseAntigravityTestSessionWithStatus(
+		t, dbPath, "", "test-machine",
+	)
 	require.NoError(t, err,
 		"covering sidecar must rescue a .db with unreadable steps")
+	assert.True(t, status.NeedsRetry,
+		"rescue without a readable DB cannot prove coverage; row must stay stale")
 
 	require.Len(t, msgs, 2)
 	assert.Equal(t, "sidecar prompt", msgs[0].Content)

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -3996,13 +3996,15 @@ func TestAntigravityIDESidecarRescueKeepsGenMetadataUsage(t *testing.T) {
 	})
 }
 
-// TestAntigravityIDEUnreadableStepsDegradesToRecoverableData verifies
-// that a step-load failure without a rescuing sidecar transcript does
-// not drop data that is still recoverable: usage-only sidecars, DB
-// gen_metadata, and brain artifacts all persist a degraded session, and
-// the step-load error surfaces only when nothing is recoverable.
-func TestAntigravityIDEUnreadableStepsDegradesToRecoverableData(t *testing.T) {
-	makeNoStepsDB := func(t *testing.T, root, id string, genData []byte) string {
+// TestAntigravityIDEUnreadableStepsFailsClosed verifies that a
+// step-load failure without a rescuing (covering, displayable) sidecar
+// transcript surfaces the error even when partial data exists: the sync
+// engine unconditionally full-replaces stored Antigravity messages on
+// any successful parse, so persisting a degraded usage-only or
+// brain-only row would clobber a previously stored full transcript
+// whenever the steps query fails transiently.
+func TestAntigravityIDEUnreadableStepsFailsClosed(t *testing.T) {
+	makeNoStepsDB := func(t *testing.T, root, id string) string {
 		t.Helper()
 		mustMkdir(t, filepath.Join(root, "conversations"))
 		dbPath := filepath.Join(root, "conversations", id+".db")
@@ -4010,74 +4012,40 @@ func TestAntigravityIDEUnreadableStepsDegradesToRecoverableData(t *testing.T) {
 		require.NoError(t, err)
 		mustExec(t, db, `CREATE TABLE trajectory_meta (
 			trajectory_id text, PRIMARY KEY (trajectory_id))`)
-		if genData != nil {
-			mustExec(t, db, `CREATE TABLE gen_metadata (
-				idx integer, data blob, size integer, PRIMARY KEY (idx))`)
-			mustExec(t, db,
-				`INSERT INTO gen_metadata (idx, data, size) VALUES (1, ?, ?)`,
-				genData, len(genData))
-		}
 		require.NoError(t, db.Close())
 		return dbPath
 	}
 
-	genJSON := `[{
-		"stepIndices": [1],
-		"chatModel": {
-			"model": "MODEL_PLACEHOLDER_M20",
-			"usage": {"inputTokens": "1500", "outputTokens": "77"}
-		}
-	}]`
-
-	t.Run("usage-only sidecar persists with sidecar usage", func(t *testing.T) {
+	t.Run("usage-only sidecar does not persist a degraded row", func(t *testing.T) {
 		root := t.TempDir()
 		id := "1b1b1b1b-2c2c-3d3d-4e4e-5f5f5f5f5f5f"
-		dbPath := makeNoStepsDB(t, root, id, nil)
+		dbPath := makeNoStepsDB(t, root, id)
 		// Sidecar with zero steps: no displayable transcript, only
-		// generatorMetadata usage.
+		// generatorMetadata usage. It must NOT rescue the parse.
+		genJSON := `[{
+			"stepIndices": [1],
+			"chatModel": {
+				"model": "MODEL_PLACEHOLDER_M20",
+				"usage": {"inputTokens": "1500", "outputTokens": "77"}
+			}
+		}]`
 		writeAntigravityTestSidecarWithGenMetadata(t, root, id, 0, genJSON)
 
 		sess, msgs, usageEvents, err := parseAntigravityTestSession(
 			t, dbPath, "", "test-machine",
 		)
-		require.NoError(t, err,
-			"recoverable sidecar usage must persist a degraded session")
-		assert.Empty(t, msgs, "no transcript is fabricated")
-		assert.Equal(t, "", sess.TranscriptFidelity)
-		assert.Equal(t, 0, sess.MessageCount)
-		assert.Equal(t, 0, sess.UserMessageCount)
-		assert.Empty(t, sess.FirstMessage)
-		require.Len(t, usageEvents, 1)
-		assert.Equal(t, "sidecar", usageEvents[0].Source)
-		assert.Equal(t, 1500, usageEvents[0].InputTokens)
-		assert.Equal(t, 77, usageEvents[0].OutputTokens)
-		assert.Equal(t, sess.ID, usageEvents[0].SessionID)
-	})
-
-	t.Run("gen_metadata usage stays primary over usage-only sidecar", func(t *testing.T) {
-		root := t.TempDir()
-		id := "2b2b2b2b-3c3c-4d4d-5e5e-6f6f6f6f6f6f"
-		genData := createAntigravityMockGenMetadata(t, 2400, 180, 0, "Test Gemini 3.5")
-		dbPath := makeNoStepsDB(t, root, id, genData)
-		writeAntigravityTestSidecarWithGenMetadata(t, root, id, 0, genJSON)
-
-		sess, msgs, usageEvents, err := parseAntigravityTestSession(
-			t, dbPath, "", "test-machine",
-		)
-		require.NoError(t, err)
+		require.Error(t, err,
+			"usage-only sidecar must not persist a degraded row")
+		assert.Contains(t, err.Error(), "steps")
+		assert.Nil(t, sess)
 		assert.Empty(t, msgs)
-		require.Len(t, usageEvents, 1)
-		assert.Equal(t, "generation", usageEvents[0].Source,
-			"DB gen_metadata must win over sidecar usage")
-		assert.Equal(t, 2400, usageEvents[0].InputTokens)
-		assert.Equal(t, 180, usageEvents[0].OutputTokens)
-		assert.False(t, sess.GenMetadataWithoutUsage)
+		assert.Empty(t, usageEvents)
 	})
 
-	t.Run("brain artifacts persist without any sidecar", func(t *testing.T) {
+	t.Run("brain artifacts do not persist a degraded row", func(t *testing.T) {
 		root := t.TempDir()
 		id := "3b3b3b3b-4c4c-5d5d-6e6e-7f7f7f7f7f7f"
-		dbPath := makeNoStepsDB(t, root, id, nil)
+		dbPath := makeNoStepsDB(t, root, id)
 		mustMkdir(t, filepath.Join(root, "brain", id))
 		mustWrite(t, filepath.Join(root, "brain", id, "plan.md"),
 			[]byte("# Recovered plan"))
@@ -4085,14 +4053,11 @@ func TestAntigravityIDEUnreadableStepsDegradesToRecoverableData(t *testing.T) {
 		sess, msgs, usageEvents, err := parseAntigravityTestSession(
 			t, dbPath, "", "test-machine",
 		)
-		require.NoError(t, err,
-			"brain artifacts must persist a degraded session")
-		require.Len(t, msgs, 1)
-		assert.Equal(t, RoleAssistant, msgs[0].Role)
-		assert.Contains(t, msgs[0].Content, "Recovered plan")
-		assert.Equal(t, "", sess.TranscriptFidelity)
-		assert.Equal(t, 1, sess.MessageCount)
-		assert.Equal(t, 0, sess.UserMessageCount)
+		require.Error(t, err,
+			"brain-only data must not persist a degraded row")
+		assert.Contains(t, err.Error(), "steps")
+		assert.Nil(t, sess)
+		assert.Empty(t, msgs)
 		assert.Empty(t, usageEvents)
 	})
 }


### PR DESCRIPTION
Antigravity IDE (Antigravity 2.0) stores conversations in a binary `.db` whose steps the parser could previously only decode heuristically — thinking, tool-use, and per-step model attribution were largely invisible. [agy-reader](https://github.com/mjacobs/agy-reader) can export a structured `<id>.trajectory.json` sidecar next to each `.db` by asking the running IDE's language-server daemon for the real transcript. This PR teaches the Antigravity IDE parser to prefer that sidecar when present.

How it works:

- When a `.trajectory.json` sidecar exists alongside the `.db` and its step count covers the raw step count read from the `.db`, the parser takes the sidecar transcript (reusing the existing Antigravity CLI trajectory parsing path) and promotes the session to `transcript_fidelity=full`. A lagging or malformed sidecar loses to the heuristic decode — coverage is the gate, so a stale sidecar can never hide newer steps.
- The sidecar joins the session's fingerprint companion set, so sidecar creation or updates trigger a re-parse, and archives synced before this change upgrade in place on the next sync. The watcher routes sidecar file events back to the owning `.db`.
- Usage merging is gated on the same coverage check as the transcript, and gen_metadata usage remains primary where it decodes.
- If the `.db` steps table is unreadable, the parser fails closed (parse error, no partial persist) rather than trusting the sidecar alone: Antigravity force-replaces messages on every successful parse, so persisting a sidecar-only result could clobber a previously stored fuller transcript. Lifting that restriction needs engine-level no-clobber support and is deliberately out of scope here.
- Without a sidecar, behavior is unchanged; nothing here requires agy-reader.

On real archives the difference is substantial: the same five IDE sessions that heuristic decoding rendered as 421 fragmentary messages parse to 244 real messages with thinking, tool-use, and model attribution, all at full fidelity.

Reviewers should look at `parseIDESession`/the sidecar-wins branch in `internal/parser/antigravity.go` (coverage gate, fail-closed path) and the companion/watcher wiring in `internal/parser/antigravity_provider.go`.

A known limitation: usage events synthesized from gen_metadata rows on heuristically-undecodable steps still lack timestamps/model when the sidecar wins; borrowing those from the sidecar is deferred to a follow-up to keep this PR to the stable core.