### PR TITLE
build: silence macOS cgo and rolldown build warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,10 +72,13 @@ jobs:
           # (3.26) is old enough that sqlite-vec would silently compile out
           # its vtab_in support. Use the header of the exact amalgamation
           # bundled and statically linked by mattn/go-sqlite3.
+          # "-O2 -g" restates Go's built-in default, which setting
+          # CGO_CFLAGS would otherwise replace, leaving the SQLite
+          # amalgamation unoptimized (2-3x slower queries).
           go mod download github.com/mattn/go-sqlite3
           mkdir -p .sqlite-include
           cp "$(go list -m -f '{{.Dir}}' github.com/mattn/go-sqlite3)/sqlite3-binding.h" .sqlite-include/sqlite3.h
-          export CGO_CFLAGS="-I${PWD}/.sqlite-include"
+          export CGO_CFLAGS="-O2 -g -I${PWD}/.sqlite-include"
 
           mkdir -p dist
           LDFLAGS="-s -w -X main.version=v${VERSION} -X main.commit=${COMMIT} -X main.buildDate=${BUILD_DATE}"

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ internal/web/dist/*
 
 # Test/build artifacts
 /dist/
+/.sqlite-include/
 *.out
 coverage.out
 *.test

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,12 @@ RUN go mod download
 # #include "sqlite3.h", which this image does not ship. Compile them against
 # the header of the exact SQLite amalgamation that mattn/go-sqlite3 bundles
 # and statically links, so header and linked library always match.
+# "-O2 -g" restates Go's built-in default, which setting CGO_CFLAGS would
+# otherwise replace, leaving the SQLite amalgamation unoptimized (2-3x
+# slower queries).
 RUN mkdir -p /sqlite-include \
     && cp "$(go list -m -f '{{.Dir}}' github.com/mattn/go-sqlite3)/sqlite3-binding.h" /sqlite-include/sqlite3.h
-ENV CGO_CFLAGS="-I/sqlite-include"
+ENV CGO_CFLAGS="-O2 -g -I/sqlite-include"
 
 COPY . ./
 COPY --from=frontend-build /src/frontend/dist ./internal/web/dist

--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,22 @@ GOLANGCI_LINT_VERSION ?= v2.11.4
 CUSTOM_GCL := ./custom-gcl
 PRICING_SNAPSHOT_FILE := internal/pricing/snapshot/litellm_snapshot.json.gz
 
+# sqlite-vec's cgo bindings #include "sqlite3.h". Without an override the
+# compiler falls back to the system header (the macOS SDK one marks
+# sqlite3_auto_extension deprecated, warning on every build) which can also
+# drift from the amalgamation mattn/go-sqlite3 statically links. Compile
+# against the bundled amalgamation's own header instead, mirroring the
+# Linux release workflow in .github/workflows/release.yml.
+SQLITE_INCLUDE_DIR := .sqlite-include
+export CGO_CFLAGS += -I$(CURDIR)/$(SQLITE_INCLUDE_DIR)
+
 GOPATH_FIRST := $(shell go env GOPATH | cut -d: -f1)
 AIR_BIN := $(shell if command -v air >/dev/null 2>&1; then command -v air; \
 	elif [ -n "$$(go env GOBIN)" ] && [ -x "$$(go env GOBIN)/air" ]; then printf "%s" "$$(go env GOBIN)/air"; \
 	elif [ -x "$(GOPATH_FIRST)/bin/air" ]; then printf "%s" "$(GOPATH_FIRST)/bin/air"; \
 	fi)
 
-.PHONY: build build-release install frontend frontend-dev dev check-air air-install desktop-dev desktop-build desktop-macos-app desktop-macos-dmg desktop-windows-installer desktop-linux-appimage desktop-app docs-install docs-build docs-serve docs-check docs-screenshots docs-assets-branch docs-generated-assets-branch docs-deploy-staging docs-deploy test test-short bench-backends bench-gate bench-gate-config test-postgres test-postgres-ci test-s3 postgres-up postgres-down test-ssh test-ssh-ci ssh-up ssh-down e2e e2e-duckdb vet lint lint-ci lint-golangci lint-golangci-ci nilaway nilaway-golangci-build lint-tools tidy clean release release-darwin-arm64 release-darwin-amd64 release-linux-amd64 install-hooks ensure-embed-dir pricing-snapshot dev-snapshot help
+.PHONY: build build-release install frontend frontend-dev dev check-air air-install desktop-dev desktop-build desktop-macos-app desktop-macos-dmg desktop-windows-installer desktop-linux-appimage desktop-app docs-install docs-build docs-serve docs-check docs-screenshots docs-assets-branch docs-generated-assets-branch docs-deploy-staging docs-deploy test test-short bench-backends bench-gate bench-gate-config test-postgres test-postgres-ci test-s3 postgres-up postgres-down test-ssh test-ssh-ci ssh-up ssh-down e2e e2e-duckdb vet lint lint-ci lint-golangci lint-golangci-ci nilaway nilaway-golangci-build lint-tools tidy clean release release-darwin-arm64 release-darwin-amd64 release-linux-amd64 install-hooks ensure-embed-dir pricing-snapshot sqlite-vec-header dev-snapshot help
 
 # Ensure go:embed has at least one file (no-op if frontend is built)
 ensure-embed-dir:
@@ -30,9 +39,19 @@ ensure-embed-dir:
 			'keep embed dir for generated frontend assets' \
 			> internal/web/dist/.keep
 
+# Copy the go-sqlite3 amalgamation header where CGO_CFLAGS points.
+# Chained from pricing-snapshot so every Go-compiling target stages it
+# without lengthening each prerequisite list.
+sqlite-vec-header:
+	@go mod download github.com/mattn/go-sqlite3
+	@mkdir -p $(SQLITE_INCLUDE_DIR)
+	@install -m 0644 \
+		"$$(go list -m -f '{{.Dir}}' github.com/mattn/go-sqlite3)/sqlite3-binding.h" \
+		$(SQLITE_INCLUDE_DIR)/sqlite3.h
+
 # Restore the generated LiteLLM fallback snapshot from its artifact branch.
 # Pinned ref, SHA256, and branch are compiled into the snapshot tool.
-pricing-snapshot:
+pricing-snapshot: sqlite-vec-header
 	go run ./internal/pricing/cmd/litellm-snapshot -restore
 
 # Build the binary (debug, with embedded pricing snapshot and frontend)
@@ -421,7 +440,7 @@ tidy: pricing-snapshot
 clean:
 	rm -f agentsview agentsv
 	rm -f $(PRICING_SNAPSHOT_FILE)
-	rm -rf internal/web/dist dist/ tmp/
+	rm -rf internal/web/dist dist/ tmp/ $(SQLITE_INCLUDE_DIR)
 	mkdir -p internal/web/dist
 	printf '%s\n' \
 		'keep embed dir for generated frontend assets' \

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,12 @@ PRICING_SNAPSHOT_FILE := internal/pricing/snapshot/litellm_snapshot.json.gz
 # drift from the amalgamation mattn/go-sqlite3 statically links. Compile
 # against the bundled amalgamation's own header instead, mirroring the
 # Linux release workflow in .github/workflows/release.yml.
+# Setting CGO_CFLAGS replaces Go's built-in default of "-O2 -g", so restate
+# it explicitly or the SQLite amalgamation compiles unoptimized (2-3x slower
+# queries, caught by the bench gate). Caller-provided flags stay last so
+# they can still override.
 SQLITE_INCLUDE_DIR := .sqlite-include
-export CGO_CFLAGS += -I$(CURDIR)/$(SQLITE_INCLUDE_DIR)
+export CGO_CFLAGS := -O2 -g -I$(CURDIR)/$(SQLITE_INCLUDE_DIR) $(CGO_CFLAGS)
 
 GOPATH_FIRST := $(shell go env GOPATH | cut -d: -f1)
 AIR_BIN := $(shell if command -v air >/dev/null 2>&1; then command -v air; \

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -121,6 +121,18 @@ export default defineConfig({
   build: {
     outDir: "dist",
     emptyOutDir: true,
+    // The SPA is served from the local embedded Go binary, so chunk size
+    // carries no network cost. Heavy libraries (mermaid, shiki, katex,
+    // cytoscape) are already lazy chunks; the main entry sits just above
+    // the default 500 kB threshold.
+    chunkSizeWarningLimit: 1200,
+    rolldownOptions: {
+      checks: {
+        // Plugin time is dominated by vite-plus's internal vitest-resolver
+        // plugin, which we cannot act on from this config.
+        pluginTimings: false,
+      },
+    },
   },
   test: {
     environment: "jsdom",


### PR DESCRIPTION
Cleans up three warnings that appeared on every local macOS `make build`/`make install`, and fixes a pre-existing cgo optimization bug the first attempt surfaced.

**cgo deprecation warnings.** sqlite-vec's cgo bindings `#include "sqlite3.h"` and were picking up the macOS SDK header, which marks `sqlite3_auto_extension`/`sqlite3_cancel_auto_extension` deprecated and can drift from the amalgamation mattn/go-sqlite3 statically links. The Makefile now stages the bundled amalgamation's own header (`sqlite3-binding.h`) into a gitignored `.sqlite-include/` and exports `CGO_CFLAGS=-O2 -g -I...` globally — the same workaround the Linux release workflow and Dockerfile already use. The staging target is chained from `pricing-snapshot`, which every Go-compiling target already depends on. Since this changes the Go build cache key, the first build after this recompiles the cgo packages once.

**Missing `-O2 -g` in every existing `CGO_CFLAGS` override.** Setting the `CGO_CFLAGS` environment variable replaces Go's built-in default of `-O2 -g` rather than appending to it, so the SQLite amalgamation compiles unoptimized (the bench gate caught this on the first commit: FTS and substring search 2.6-2.8x slower). The Makefile export restates `-O2 -g`, and the same latent bug is fixed in `.github/workflows/release.yml` and the `Dockerfile`, which have been building release/container binaries with an unoptimized SQLite since the sqlite-vec header workaround landed.

**PLUGIN_TIMINGS.** This rolldown check is dominated (~80%) by vite-plus's internal `vitest-resolver` plugin, which isn't actionable from this config, so `checks.pluginTimings` is disabled in `vite.config.ts`.

**Chunk-size warning.** Heavy libraries (mermaid, shiki, katex, cytoscape) are already lazy chunks; the trigger is the 1.03 MB main entry (285 kB gzipped). The SPA is served from the local embedded Go binary, so chunk size has no network cost — `chunkSizeWarningLimit` is raised to 1200 instead of restructuring, keeping a tripwire if the entry grows further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)