### PR TITLE
docs: add 0.37.3 release notes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,23 @@ title: Changelog
 description: Release history for AgentsView
 ---
 
+## 0.37.3
+<small>2026-07-09</small>
+
+**Bug fixes**
+
+- Restore **optimized SQLite builds for Linux release binaries and Docker
+  images** by preserving Go's default `-O2 -g` cgo flags when overriding
+  `CGO_CFLAGS`, improving full-text search and query performance in those
+  artifacts.
+
+**Acknowledgements**
+
+- Thanks to [Wes McKinney](https://github.com/wesm) for restoring optimized
+  release and Docker SQLite builds.
+
+---
+
 ## 0.37.2
 <small>2026-07-08</small>
 


### PR DESCRIPTION
The 0.37.3 release restores optimized SQLite compilation in the Linux release and Docker build paths, so the public changelog needs to show that patch as the current release rather than leaving 0.37.2 at the top.

This keeps the entry scoped to the user-visible consequence of the patch: release artifacts and container images no longer ship with the SQLite amalgamation built without Go's default optimization flags. The acknowledgement follows the existing changelog convention and credits the merged PR author.