### PR TITLE
fix(cli): report hidden session list defaults

### DIFF
--- a/cmd/agentsview/session_list.go
+++ b/cmd/agentsview/session_list.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -116,6 +117,14 @@ func newSessionListCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			notice, err := sessionListDefaultExclusionNotice(
+				cmd.Context(), svc, f, list.Total)
+			if err != nil {
+				return err
+			}
+			if notice != "" {
+				fmt.Fprintln(cmd.ErrOrStderr(), notice)
+			}
 			if outputFormat(cmd) == "json" {
 				return json.NewEncoder(cmd.OutOrStdout()).Encode(list)
 			}
@@ -186,6 +195,89 @@ func newSessionListCommand() *cobra.Command {
 		"Alias for --resume")
 
 	return cmd
+}
+
+func sessionListDefaultExclusionNotice(
+	ctx context.Context,
+	svc service.SessionService,
+	f service.ListFilter,
+	visibleTotal int,
+) (string, error) {
+	if f.Cursor != "" || (f.IncludeOneShot && f.IncludeAutomated) {
+		return "", nil
+	}
+
+	hiddenOneShot := 0
+	if !f.IncludeOneShot {
+		withOneShot := sessionListCountFilter(f)
+		withOneShot.IncludeOneShot = true
+		withOneShot.IncludeAutomated = f.IncludeAutomated
+		list, err := svc.List(ctx, withOneShot)
+		if err != nil {
+			return "", fmt.Errorf(
+				"counting one-shot session exclusions: %w", err)
+		}
+		hiddenOneShot = hiddenSessionCount(list.Total, visibleTotal)
+	}
+
+	hiddenAutomated := 0
+	if !f.IncludeAutomated {
+		withAutomated := sessionListCountFilter(f)
+		withAutomated.IncludeOneShot = f.IncludeOneShot
+		withAutomated.IncludeAutomated = true
+		list, err := svc.List(ctx, withAutomated)
+		if err != nil {
+			return "", fmt.Errorf(
+				"counting automated session exclusions: %w", err)
+		}
+		hiddenAutomated = hiddenSessionCount(list.Total, visibleTotal)
+	}
+
+	hiddenTotal := hiddenOneShot + hiddenAutomated
+	if hiddenTotal == 0 {
+		return "", nil
+	}
+
+	var hiddenParts []string
+	var flagParts []string
+	if hiddenOneShot > 0 {
+		hiddenParts = append(hiddenParts,
+			fmt.Sprintf("%d one-shot", hiddenOneShot))
+		flagParts = append(flagParts, "--include-one-shot")
+	}
+	if hiddenAutomated > 0 {
+		hiddenParts = append(hiddenParts,
+			fmt.Sprintf("%d automated", hiddenAutomated))
+		flagParts = append(flagParts, "--include-automated")
+	}
+
+	return fmt.Sprintf(
+		"Excluded %d %s by default: %s. Use %s to include them.",
+		hiddenTotal,
+		pluralSession(hiddenTotal),
+		strings.Join(hiddenParts, ", "),
+		strings.Join(flagParts, " and/or "),
+	), nil
+}
+
+func sessionListCountFilter(f service.ListFilter) service.ListFilter {
+	f.Cursor = ""
+	f.Limit = 1
+	return f
+}
+
+func hiddenSessionCount(expandedTotal, visibleTotal int) int {
+	if expandedTotal <= visibleTotal {
+		return 0
+	}
+	return expandedTotal - visibleTotal
+}
+
+func pluralSession(n int) string {
+	if n == 1 {
+		return "session"
+	}
+	return "sessions"
 }
 
 // sessionNameWidth caps the NAME column so a long first message can't

--- a/cmd/agentsview/session_list_test.go
+++ b/cmd/agentsview/session_list_test.go
@@ -3,11 +3,13 @@
 package main
 
 import (
+	"bytes"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/db"
 )
 
 // TestSessionListSinceMutuallyExclusiveWithActiveSince verifies the error is
@@ -82,6 +84,47 @@ func TestSessionListResumeRespectsExplicitSince(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"within-since"}, sessionListIDs(t, out))
+}
+
+func TestSessionListReportsDefaultExclusionsOnStderr(t *testing.T) {
+	dataDir := newAgentDataDir(t)
+	seedSessionsWithOpts(t, dataDir,
+		sessionSeed{id: "included", project: "proj"},
+		sessionSeed{
+			id:      "one-shot",
+			project: "proj",
+			mut: func(s *db.Session) {
+				s.UserMessageCount = 1
+			},
+		},
+		sessionSeed{
+			id:      "automated",
+			project: "proj",
+			mut: func(s *db.Session) {
+				msg := "You are a code reviewer. Review this change."
+				s.FirstMessage = &msg
+				s.UserMessageCount = 1
+			},
+		},
+	)
+
+	root := newRootCommand()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs([]string{"session", "list", "--format", "json"})
+
+	_, err := root.ExecuteC()
+	require.NoError(t, err)
+	got := decodeCLIJSON[cliSessionList](t, stdout.String())
+	require.Equal(t, 1, got.Total)
+	require.Len(t, got.Sessions, 1)
+	assert.Equal(t, "included", got.Sessions[0]["id"])
+	assert.Contains(t, stderr.String(), "Excluded 2 sessions by default")
+	assert.Contains(t, stderr.String(), "1 one-shot")
+	assert.Contains(t, stderr.String(), "1 automated")
+	assert.Contains(t, stderr.String(), "--include-one-shot")
+	assert.Contains(t, stderr.String(), "--include-automated")
 }
 
 // TestResolveSinceFlag_ResolvesRelativeWindow is a fast unit test of the


### PR DESCRIPTION
Refs #1048.

`session list` can look like it silently under-enumerated a large archive because its default one-shot and automated filters are applied before the JSON total is returned. This keeps stdout unchanged and emits a stderr advisory with the hidden one-shot and automated counts, so piped JSON remains parseable while users still get an explanation for missing rows.

The listing filters themselves do not change; callers still opt into full enumeration with `--include-one-shot` and `--include-automated`.

<sup>generated by a clanker</sup>