### PR TITLE
fix(parser): export hermes state sessions as JSONL

### DIFF
--- a/cmd/agentsview/session_export.go
+++ b/cmd/agentsview/session_export.go
@@ -4,10 +4,12 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -66,6 +68,26 @@ func newSessionExportCommand() *cobra.Command {
 				return fmt.Errorf(
 					"source file not found for session %s", id,
 				)
+			}
+			if rawID, ok := rawHermesSessionID(id); ok {
+				hermesPath, err := resolveHermesExportPath(
+					cmd.Context(), cfg, id, rawID, storedPath,
+				)
+				if err != nil {
+					return err
+				}
+				if dbPath, sessionID, ok :=
+					parser.SplitHermesStateVirtualPath(hermesPath); ok {
+					return parser.WriteHermesStateSessionJSONL(
+						cmd.OutOrStdout(), dbPath, sessionID,
+					)
+				}
+				if filepath.Base(hermesPath) == "state.db" {
+					return parser.WriteHermesStateSessionJSONL(
+						cmd.OutOrStdout(), hermesPath, rawID,
+					)
+				}
+				storedPath = hermesPath
 			}
 			// Aider stores many repo runs in one Markdown history file,
 			// with sessions keyed by a <history>#<idx> virtual path.
@@ -161,4 +183,53 @@ func rawAiderSessionID(sessionID string) (string, bool) {
 	_, rawID := parser.StripHostPrefix(sessionID)
 	rawID = strings.TrimPrefix(rawID, def.IDPrefix)
 	return rawID, rawID != ""
+}
+
+func rawHermesSessionID(sessionID string) (string, bool) {
+	_, rawID := parser.StripHostPrefix(sessionID)
+	def, ok := parser.AgentByPrefix(rawID)
+	if !ok || def.Type != parser.AgentHermes {
+		return "", false
+	}
+	rawID = strings.TrimPrefix(rawID, def.IDPrefix)
+	return rawID, rawID != ""
+}
+
+func resolveHermesExportPath(
+	ctx context.Context,
+	cfg config.Config,
+	fullID string,
+	rawID string,
+	storedPath string,
+) (string, error) {
+	provider, ok := parser.NewProvider(parser.AgentHermes, parser.ProviderConfig{
+		Roots: cfg.AgentDirs[parser.AgentHermes],
+	})
+	if !ok {
+		return storedPath, nil
+	}
+	source, found, err := provider.FindSource(ctx, parser.FindSourceRequest{
+		RawSessionID:       rawID,
+		FullSessionID:      fullID,
+		StoredFilePath:     storedPath,
+		FingerprintKey:     storedPath,
+		RequireFreshSource: true,
+		PreferStoredSource: true,
+	})
+	if err != nil {
+		return "", err
+	}
+	if !found {
+		return storedPath, nil
+	}
+	for _, candidate := range []string{
+		source.DisplayPath,
+		source.FingerprintKey,
+		source.Key,
+	} {
+		if candidate != "" {
+			return candidate, nil
+		}
+	}
+	return storedPath, nil
 }

--- a/cmd/agentsview/session_test.go
+++ b/cmd/agentsview/session_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -252,6 +253,122 @@ func TestSessionHelp_ShowsSubcommands(t *testing.T) {
 		"expected --format persistent flag in help")
 	assert.Contains(t, help, "--pg",
 		"expected --pg persistent flag in help")
+}
+
+func TestSessionExportHermesStateDBScopesToSessionJSONL(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		filePath func(string) string
+	}{
+		{
+			name: "virtual state db path",
+			filePath: func(stateDB string) string {
+				return parser.HermesStateVirtualPath(stateDB, "child")
+			},
+		},
+		{
+			name: "legacy physical state db path",
+			filePath: func(stateDB string) string {
+				return stateDB
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dataDir := testDataDir(t)
+			stateRoot := t.TempDir()
+			stateDB := filepath.Join(stateRoot, "state.db")
+			writeHermesSessionExportStateDB(t, stateDB)
+			filePath := tc.filePath(stateDB)
+
+			database := dbtest.OpenTestDBAt(t, sessionsDBPath(dataDir))
+			require.NoError(t, database.UpsertSession(db.Session{
+				ID:               "hermes:child",
+				Project:          "hermes-discord",
+				Machine:          "m",
+				Agent:            string(parser.AgentHermes),
+				MessageCount:     1,
+				UserMessageCount: 1,
+				FilePath:         &filePath,
+			}))
+			require.NoError(t, database.Close())
+
+			out, err := executeCommand(newRootCommand(), "session", "export", "hermes:child")
+			require.NoError(t, err)
+			assert.NotContains(t, out, "SQLite format 3")
+			assert.Contains(t, out, `"role":"session_meta"`)
+			assert.Contains(t, out, `"role":"user"`)
+			assert.Contains(t, out, `"content":"state export question"`)
+			assert.NotContains(t, out, "\x00")
+		})
+	}
+}
+
+func writeHermesSessionExportStateDB(t *testing.T, stateDB string) {
+	t.Helper()
+	conn, err := sql.Open("sqlite3", stateDB)
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	_, err = conn.Exec(`
+		CREATE TABLE sessions (
+			id TEXT PRIMARY KEY,
+			source TEXT NOT NULL,
+			user_id TEXT,
+			model TEXT,
+			model_config TEXT,
+			system_prompt TEXT,
+			parent_session_id TEXT,
+			started_at REAL NOT NULL,
+			ended_at REAL,
+			end_reason TEXT,
+			message_count INTEGER DEFAULT 0,
+			tool_call_count INTEGER DEFAULT 0,
+			input_tokens INTEGER DEFAULT 0,
+			output_tokens INTEGER DEFAULT 0,
+			cache_read_tokens INTEGER DEFAULT 0,
+			cache_write_tokens INTEGER DEFAULT 0,
+			reasoning_tokens INTEGER DEFAULT 0,
+			billing_provider TEXT,
+			billing_base_url TEXT,
+			billing_mode TEXT,
+			estimated_cost_usd REAL,
+			actual_cost_usd REAL,
+			cost_status TEXT,
+			cost_source TEXT,
+			pricing_version TEXT,
+			title TEXT,
+			api_call_count INTEGER DEFAULT 0
+		);
+		CREATE TABLE messages (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			session_id TEXT NOT NULL,
+			role TEXT NOT NULL,
+			content TEXT,
+			tool_call_id TEXT,
+			tool_calls TEXT,
+			tool_name TEXT,
+			timestamp REAL NOT NULL,
+			token_count INTEGER,
+			finish_reason TEXT,
+			reasoning TEXT,
+			reasoning_content TEXT,
+			reasoning_details TEXT,
+			codex_reasoning_items TEXT,
+			codex_message_items TEXT
+		);
+		INSERT INTO sessions (
+			id, source, model, started_at, ended_at, message_count, title
+		) VALUES (
+			'child', 'discord', 'gpt-5.4', 1778767200.0, 1778767800.0, 1,
+			'Child Session'
+		);
+		INSERT INTO messages (
+			session_id, role, content, timestamp
+		) VALUES (
+			'child', 'user', 'state export question', 1778767210.0
+		);
+	`)
+	require.NoError(t, err)
 }
 
 // seedSession opens the SQLite DB at dataDir/sessions.db, inserts

--- a/internal/parser/hermes.go
+++ b/internal/parser/hermes.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"math"
 	"os"
@@ -550,6 +551,106 @@ func hermesStatePaths(root string) (stateDB, sessionsDir string, ok bool) {
 	return "", "", false
 }
 
+// HermesStateVirtualPath identifies one Hermes session inside a state.db
+// archive.
+func HermesStateVirtualPath(stateDB, rawID string) string {
+	return VirtualSourcePath(stateDB, rawID)
+}
+
+// SplitHermesStateVirtualPath splits a Hermes state.db virtual source path.
+func SplitHermesStateVirtualPath(path string) (stateDB, rawID string, ok bool) {
+	return ParseVirtualSourcePathForBase(path, "state.db")
+}
+
+// WriteHermesStateSessionJSONL writes one Hermes state.db session as scoped
+// JSONL. It is used by `session export` for sessions whose persisted source is
+// the shared SQLite archive rather than a per-session transcript file.
+func WriteHermesStateSessionJSONL(w io.Writer, stateDB, rawID string) error {
+	if rawID == "" || !IsValidSessionID(rawID) {
+		return fmt.Errorf("invalid hermes session id: %q", rawID)
+	}
+	if _, err := os.Stat(stateDB); err != nil {
+		return err
+	}
+	conn, err := sql.Open("sqlite3", "file:"+sqliteURIPath(stateDB)+"?mode=ro")
+	if err != nil {
+		return fmt.Errorf("open hermes state db: %w", err)
+	}
+	defer conn.Close()
+
+	session, err := readHermesStateSession(conn, rawID)
+	if err != nil {
+		return err
+	}
+	messages, err := readHermesStateMessagesForSession(conn, rawID)
+	if err != nil {
+		return err
+	}
+
+	enc := json.NewEncoder(w)
+	meta := hermesStateExportLine{
+		Role:            "session_meta",
+		Platform:        session.source,
+		Model:           session.model,
+		ParentSessionID: session.parentSessionID,
+		Title:           session.title,
+		Timestamp:       hermesExportTimestamp(session.startedAt),
+	}
+	if err := enc.Encode(meta); err != nil {
+		return fmt.Errorf("write hermes session metadata: %w", err)
+	}
+	for _, message := range messages {
+		if err := enc.Encode(hermesStateMessageExportLine(message)); err != nil {
+			return fmt.Errorf("write hermes message: %w", err)
+		}
+	}
+	return nil
+}
+
+type hermesStateExportLine struct {
+	Role                string          `json:"role"`
+	Platform            string          `json:"platform,omitempty"`
+	Model               string          `json:"model,omitempty"`
+	ParentSessionID     string          `json:"parent_session_id,omitempty"`
+	Title               string          `json:"title,omitempty"`
+	Content             string          `json:"content,omitempty"`
+	ToolCallID          string          `json:"tool_call_id,omitempty"`
+	ToolCalls           json.RawMessage `json:"tool_calls,omitempty"`
+	Timestamp           string          `json:"timestamp,omitempty"`
+	FinishReason        string          `json:"finish_reason,omitempty"`
+	Reasoning           string          `json:"reasoning,omitempty"`
+	ReasoningContent    string          `json:"reasoning_content,omitempty"`
+	ReasoningDetails    string          `json:"reasoning_details,omitempty"`
+	CodexReasoningItems string          `json:"codex_reasoning_items,omitempty"`
+	CodexMessageItems   string          `json:"codex_message_items,omitempty"`
+}
+
+func hermesStateMessageExportLine(message hermesStateMessage) hermesStateExportLine {
+	line := hermesStateExportLine{
+		Role:                message.role,
+		Content:             message.content,
+		ToolCallID:          message.toolCallID,
+		Timestamp:           hermesExportTimestamp(message.timestamp),
+		FinishReason:        message.finishReason,
+		Reasoning:           message.reasoning,
+		ReasoningContent:    message.reasoningContent,
+		ReasoningDetails:    message.reasoningDetails,
+		CodexReasoningItems: message.codexReasoningItems,
+		CodexMessageItems:   message.codexMessageItems,
+	}
+	if message.toolCalls != "" && json.Valid([]byte(message.toolCalls)) {
+		line.ToolCalls = json.RawMessage(message.toolCalls)
+	}
+	return line
+}
+
+func hermesExportTimestamp(ts time.Time) string {
+	if ts.IsZero() {
+		return ""
+	}
+	return ts.Format(time.RFC3339Nano)
+}
+
 func (p *hermesProvider) parseStateDB(
 	stateDB, sessionsDir, project, machine string,
 ) ([]ParseResult, error) {
@@ -600,6 +701,46 @@ func (p *hermesProvider) parseStateDB(
 		return results[i].Session.ID < results[j].Session.ID
 	})
 	return results, nil
+}
+
+func readHermesStateSession(
+	conn *sql.DB, rawID string,
+) (hermesStateSession, error) {
+	var ss hermesStateSession
+	var started, ended float64
+	err := conn.QueryRow(`
+		SELECT id, source, COALESCE(model, ''),
+			COALESCE(parent_session_id, ''), started_at,
+			COALESCE(ended_at, 0), COALESCE(message_count, 0),
+			COALESCE(input_tokens, 0), COALESCE(output_tokens, 0),
+			COALESCE(cache_read_tokens, 0),
+			COALESCE(cache_write_tokens, 0),
+			COALESCE(reasoning_tokens, 0),
+			estimated_cost_usd, actual_cost_usd,
+			COALESCE(cost_status, ''), COALESCE(cost_source, ''),
+			COALESCE(title, ''), COALESCE(api_call_count, 0)
+		FROM sessions
+		WHERE id = ?`, rawID).Scan(
+		&ss.id, &ss.source, &ss.model,
+		&ss.parentSessionID, &started, &ended,
+		&ss.messageCount, &ss.inputTokens, &ss.outputTokens,
+		&ss.cacheReadTokens, &ss.cacheWriteTokens,
+		&ss.reasoningTokens, &ss.estimatedCost, &ss.actualCost,
+		&ss.costStatus, &ss.costSource, &ss.title,
+		&ss.apiCallCount,
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return hermesStateSession{}, fmt.Errorf(
+				"hermes session %s not found in state db: %w",
+				rawID, err,
+			)
+		}
+		return hermesStateSession{}, fmt.Errorf("query hermes session %s: %w", rawID, err)
+	}
+	ss.startedAt = hermesUnixTime(started)
+	ss.endedAt = hermesUnixTime(ended)
+	return ss, nil
 }
 
 func readHermesStateSessions(
@@ -679,6 +820,44 @@ func readHermesStateMessages(
 		}
 		hm.timestamp = hermesUnixTime(ts)
 		out[sid] = append(out[sid], hm)
+	}
+	return out, rows.Err()
+}
+
+func readHermesStateMessagesForSession(
+	conn *sql.DB, rawID string,
+) ([]hermesStateMessage, error) {
+	rows, err := conn.Query(`
+		SELECT role, COALESCE(content, ''),
+			COALESCE(tool_call_id, ''), COALESCE(tool_calls, ''),
+			timestamp, COALESCE(finish_reason, ''),
+			COALESCE(reasoning, ''), COALESCE(reasoning_content, ''),
+			COALESCE(reasoning_details, ''),
+			COALESCE(codex_reasoning_items, ''),
+			COALESCE(codex_message_items, '')
+		FROM messages
+		WHERE session_id = ?
+		ORDER BY timestamp ASC, id ASC`, rawID)
+	if err != nil {
+		return nil, fmt.Errorf("query hermes messages for %s: %w", rawID, err)
+	}
+	defer rows.Close()
+
+	var out []hermesStateMessage
+	for rows.Next() {
+		var hm hermesStateMessage
+		var ts float64
+		if err := rows.Scan(
+			&hm.role, &hm.content, &hm.toolCallID,
+			&hm.toolCalls, &ts, &hm.finishReason,
+			&hm.reasoning, &hm.reasoningContent,
+			&hm.reasoningDetails, &hm.codexReasoningItems,
+			&hm.codexMessageItems,
+		); err != nil {
+			return nil, fmt.Errorf("scan hermes message for %s: %w", rawID, err)
+		}
+		hm.timestamp = hermesUnixTime(ts)
+		out = append(out, hm)
 	}
 	return out, rows.Err()
 }

--- a/internal/parser/hermes_provider.go
+++ b/internal/parser/hermes_provider.go
@@ -97,15 +97,19 @@ func (p *hermesProvider) Parse(
 			return ParseOutcome{}, err
 		}
 		// Mirror the legacy engine's stampHermesArchiveResults: every archive
-		// session's stored file identity is the state.db path with the
+		// session's stored file freshness is the state.db aggregate with the
 		// aggregate (state.db plus transcripts) size and mtime, so a
-		// transcript-only change still refreshes the archive's freshness.
+		// transcript-only change still refreshes the archive's freshness. The
+		// persisted path itself stays virtual so per-session export never
+		// streams the whole shared SQLite archive.
 		size, mtime := hermesArchiveEffectiveFileInfo(path)
 		out := make([]ParseResultOutcome, 0, len(results))
 		for i := range results {
-			results[i].Session.File.Path = path
+			rawID := strings.TrimPrefix(results[i].Session.ID, string(AgentHermes)+":")
+			results[i].Session.File.Path = HermesStateVirtualPath(path, rawID)
 			results[i].Session.File.Size = size
 			results[i].Session.File.Mtime = mtime
+			results[i].Session.File.Hash = req.Fingerprint.Hash
 			out = append(out, ParseResultOutcome{
 				Result:      results[i],
 				DataVersion: DataVersionCurrent,
@@ -224,8 +228,27 @@ func (s hermesSourceSet) FindSource(
 		if path == "" {
 			continue
 		}
+		if _, storedRawID, ok := SplitHermesStateVirtualPath(path); ok &&
+			req.RawSessionID != "" && storedRawID != req.RawSessionID {
+			continue
+		}
 		for _, root := range s.roots {
 			if source, ok := s.sourceForPath(root, path); ok {
+				sourcePath, _ := s.pathFromSource(source)
+				if req.RawSessionID != "" &&
+					filepath.Base(sourcePath) == "state.db" {
+					found, err := hermesStateDBHasSession(sourcePath, req.RawSessionID)
+					switch {
+					case err != nil:
+						log.Printf(
+							"hermes: state db lookup failed for %s: %v; "+
+								"falling back to transcripts", sourcePath, err,
+						)
+						continue
+					case !found:
+						continue
+					}
+				}
 				return source, true, nil
 			}
 		}
@@ -357,6 +380,10 @@ func (s hermesSourceSet) sourceForChangedPath(
 	root = filepath.Clean(root)
 	path = filepath.Clean(path)
 	if stateDB, sessionsDir, ok := hermesStatePaths(root); ok {
+		if virtualDB, _, ok := SplitHermesStateVirtualPath(path); ok &&
+			samePath(virtualDB, stateDB) {
+			return hermesArchiveSourceRef(root, stateDB)
+		}
 		if samePath(path, stateDB) || hermesPathInTranscriptDir(sessionsDir, path) {
 			return hermesArchiveSourceRef(root, stateDB)
 		}

--- a/internal/parser/hermes_provider_test.go
+++ b/internal/parser/hermes_provider_test.go
@@ -2,8 +2,10 @@ package parser
 
 import (
 	"context"
+	"database/sql"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -416,7 +418,7 @@ func TestHermesProviderParseStateDB(t *testing.T) {
 	require.NoError(t, err)
 	transcriptInfo, err := os.Stat(transcriptPath)
 	require.NoError(t, err)
-	assert.Equal(t, stateDB, result.Result.Session.File.Path)
+	assert.Equal(t, HermesStateVirtualPath(stateDB, "child"), result.Result.Session.File.Path)
 	assert.Equal(
 		t,
 		stateInfo.Size()+transcriptInfo.Size(),
@@ -427,6 +429,43 @@ func TestHermesProviderParseStateDB(t *testing.T) {
 		max(stateInfo.ModTime().UnixNano(), transcriptInfo.ModTime().UnixNano()),
 		result.Result.Session.File.Mtime,
 	)
+}
+
+func TestWriteHermesStateSessionJSONLScopesStateDBExport(t *testing.T) {
+	root := t.TempDir()
+	createHermesStateDB(t, root)
+	stateDB := filepath.Join(root, "state.db")
+	conn, err := sql.Open("sqlite3", stateDB)
+	require.NoError(t, err)
+	_, err = conn.Exec(`
+		INSERT INTO messages (
+			session_id, role, content, tool_calls, timestamp
+		) VALUES (
+			'child', 'assistant', '',
+			'[{"id":"call_1","function":{"name":"read_file","arguments":"{\"path\":\"README.md\"}"}}]',
+			1778767220.0
+		);
+		INSERT INTO messages (
+			session_id, role, content, tool_call_id, timestamp
+		) VALUES (
+			'child', 'tool', 'file contents', 'call_1', 1778767230.0
+		);
+	`)
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	var buf strings.Builder
+	require.NoError(t, WriteHermesStateSessionJSONL(&buf, stateDB, "child"))
+
+	out := buf.String()
+	assert.NotContains(t, out, "SQLite format 3")
+	assert.Contains(t, out, `"role":"session_meta"`)
+	assert.Contains(t, out, `"role":"user"`)
+	assert.Contains(t, out, `"content":"state db only has one message"`)
+	assert.Contains(t, out, `"tool_calls":[{"id":"call_1"`)
+	assert.Contains(t, out, `"tool_call_id":"call_1"`)
+	assert.Contains(t, out, `"content":"file contents"`)
+	assert.NotContains(t, out, "\x00")
 }
 
 func TestHermesProviderFindSourceDoesNotReturnStateDBForMissingRawID(t *testing.T) {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -4703,11 +4703,11 @@ func (e *Engine) shouldSkipFile(
 
 // providerSourceUnchangedInDB reports whether a provider source's persisted
 // file metadata already matches its current fingerprint, so a reparse would be
-// a no-op. It compares the DB-stored file_size/file_mtime for the source's
-// path against the fingerprint and requires a current data_version, mirroring
-// shouldSkipByPath for the provider-authoritative runtime. A source with no
-// stored row, an empty key, or a non-fingerprint identity (no size, e.g. a
-// tombstone) never matches and therefore reparses.
+// a no-op. It compares DB-stored file_size/file_mtime for the source's path
+// against the fingerprint and requires a current data_version, mirroring
+// shouldSkipByPath for the provider-authoritative runtime. Hermes state.db
+// sources persist per-session virtual paths under the physical state.db key;
+// in that case every active stored hint under the source must be fresh.
 func (e *Engine) providerSourceUnchangedInDB(
 	source parser.SourceRef,
 	fingerprint parser.SourceFingerprint,
@@ -4722,6 +4722,36 @@ func (e *Engine) providerSourceUnchangedInDB(
 	if e.pathRewriter != nil {
 		lookupPath = e.pathRewriter(lookupPath)
 	}
+	if e.providerSourcePathUnchangedInDB(source.Provider, lookupPath, fingerprint) {
+		return true
+	}
+	if source.Provider != parser.AgentHermes {
+		return false
+	}
+
+	hints, err := e.db.ListStoredSourcePathHints(
+		string(source.Provider), []string{lookupPath},
+	)
+	if err != nil {
+		log.Printf("list provider source freshness hints: %v", err)
+		return false
+	}
+	if len(hints) == 0 {
+		return false
+	}
+	for _, hint := range hints {
+		if !e.providerSourcePathUnchangedInDB(source.Provider, hint, fingerprint) {
+			return false
+		}
+	}
+	return true
+}
+
+func (e *Engine) providerSourcePathUnchangedInDB(
+	agent parser.AgentType,
+	lookupPath string,
+	fingerprint parser.SourceFingerprint,
+) bool {
 	storedSize, storedMtime, ok := e.db.GetFileInfoByPath(lookupPath)
 	if !ok {
 		return false
@@ -4729,7 +4759,7 @@ func (e *Engine) providerSourceUnchangedInDB(
 	if storedSize != fingerprint.Size || storedMtime != fingerprint.MTimeNS {
 		return false
 	}
-	if !e.providerFingerprintHashMatchesDB(source.Provider, lookupPath, fingerprint) {
+	if !e.providerFingerprintHashMatchesDB(agent, lookupPath, fingerprint) {
 		return false
 	}
 	// A stale stored project (e.g. a generated roborev CI worktree name)

--- a/internal/sync/hermes_archive_test.go
+++ b/internal/sync/hermes_archive_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -155,9 +156,9 @@ func TestProcessFileHermesArchiveSkipCacheUsesAggregateMtime(t *testing.T) {
 }
 
 // TestProcessFileHermesArchivePersistsAggregateFingerprint confirms the
-// provider-authoritative processFile path stamps every archive session with the
-// state.db path and the aggregate size and mtime, and that a second pass skips
-// once the file info is persisted. This replaces the removed
+// provider-authoritative processFile path stamps every archive session with a
+// state.db virtual path and the aggregate size and mtime, and that a second
+// pass skips once the file info is persisted. This replaces the removed
 // processHermes-based assertions.
 func TestProcessFileHermesArchivePersistsAggregateFingerprint(t *testing.T) {
 	root := t.TempDir()
@@ -190,7 +191,8 @@ func TestProcessFileHermesArchivePersistsAggregateFingerprint(t *testing.T) {
 	require.NoError(t, res.err)
 	require.NotEmpty(t, res.results)
 	for _, result := range res.results {
-		assert.Equal(t, stateDB, result.Session.File.Path)
+		rawID := strings.TrimPrefix(result.Session.ID, "hermes:")
+		assert.Equal(t, parser.HermesStateVirtualPath(stateDB, rawID), result.Session.File.Path)
 		assert.Equal(t, wantSize, result.Session.File.Size)
 		assert.Equal(t, wantMtime, result.Session.File.Mtime)
 	}
@@ -207,7 +209,9 @@ func TestProcessFileHermesArchivePersistsAggregateFingerprint(t *testing.T) {
 	require.Equal(t, 0, failed)
 	require.NotZero(t, written)
 
-	storedSize, storedMtime, ok := database.GetFileInfoByPath(stateDB)
+	storedSize, storedMtime, ok := database.GetFileInfoByPath(
+		parser.HermesStateVirtualPath(stateDB, "child"),
+	)
 	require.True(t, ok)
 	assert.Equal(t, wantSize, storedSize)
 	assert.Equal(t, wantMtime, storedMtime)
@@ -215,8 +219,9 @@ func TestProcessFileHermesArchivePersistsAggregateFingerprint(t *testing.T) {
 
 // TestSyncPathsHermesArchiveTranscriptPersistsAggregateFingerprint confirms that
 // syncing a transcript path inside an archive routes through the provider, which
-// reparses the whole archive and persists the aggregate file info under the
-// state.db path. This replaces the removed syncSingleHermesArchive coverage.
+// reparses the whole archive and persists the aggregate file info under each
+// state.db virtual path. This replaces the removed syncSingleHermesArchive
+// coverage.
 func TestSyncPathsHermesArchiveTranscriptPersistsAggregateFingerprint(t *testing.T) {
 	root := t.TempDir()
 	stateDB := writeHermesArchiveStateDB(t, root)
@@ -242,7 +247,9 @@ func TestSyncPathsHermesArchiveTranscriptPersistsAggregateFingerprint(t *testing
 
 	engine.SyncPaths([]string{transcriptPath})
 
-	storedSize, storedMtime, found := database.GetFileInfoByPath(stateDB)
+	storedSize, storedMtime, found := database.GetFileInfoByPath(
+		parser.HermesStateVirtualPath(stateDB, "child"),
+	)
 	require.True(t, found)
 	assert.Equal(t, wantSize, storedSize)
 	assert.Equal(t, wantMtime, storedMtime)


### PR DESCRIPTION
Fixes #1047.

Hermes sessions sourced from `state.db` now export as scoped JSONL instead of copying the SQLite container. The previous behavior could return rc 0 with binary archive bytes for any state-backed Hermes session, and legacy rows that still point at a physical `state.db` would keep repeating that failure until the archive was rebuilt.

The parser now records state-backed sessions with per-session `state.db#session` source paths while preserving aggregate freshness for sync. Export resolves those virtual or legacy physical paths back through the Hermes provider and synthesizes JSONL from the requested row/messages, including tool calls and tool results. Wrong or stale state-db hints are skipped when they do not contain the requested raw session id.

Reviewers should look at `internal/parser/hermes.go`, `internal/parser/hermes_provider.go`, `cmd/agentsview/session_export.go`, and the Hermes-only freshness fallback in `internal/sync/engine.go`. The fallback is intentionally scoped so other multi-session providers keep their existing stale-row behavior.

<sup>generated by a clanker</sup>