### PR TITLE
docs: document 0.37.4 remote sync

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,35 @@ title: Changelog
 description: Release history for AgentsView
 ---
 
+## 0.37.4
+<small>2026-07-09</small>
+
+**New features**
+
+- Add **incremental HTTP remote sync** backed by a persistent per-host mirror.
+  After the initial archive download, the collector compares a remote manifest
+  with its mirror and requests only changed files when fewer than half of the
+  manifest files need fetching. Deleted remote files are removed from the
+  mirror without deleting sessions already stored in the local archive.
+
+**Improvements**
+
+- Include **GPT-5.6 model pricing** for the base alias and the Sol, Terra, and
+  Luna variants in the embedded fallback catalog, so fresh installs and offline
+  usage reports can estimate their costs without a network fetch.
+- Explain **default `session list` exclusions** on stderr when one-shot or
+  automated sessions are hidden, including the number in each category and the
+  flags that include them. Structured stdout remains unchanged for scripts.
+
+**Acknowledgements**
+
+- Thanks to [Wes McKinney](https://github.com/wesm) for incremental HTTP remote
+  sync, GPT-5.6 fallback pricing, and release documentation.
+- Thanks to [Marius van Niekerk](https://github.com/mariusvniekerk) for making
+  the `session list` default exclusions visible.
+
+---
+
 ## 0.37.3
 <small>2026-07-09</small>
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -184,8 +184,8 @@ token = "remote-token"
 With hosts configured, `agentsview sync` (no `--host`) runs the local sync
 first, then syncs each configured host in the order declared using its
 configured transport. `--full` applies to every host; for HTTP hosts it
-re-downloads the full archive and bypasses the remote skip cache, though
-already-stored, current sessions are still skipped (see
+re-downloads the full archive into the persistent mirror and bypasses the
+remote path/mtime skip cache (see
 [Incremental Sync](/remote-access/#incremental-sync)). A failing host is
 reported on stderr and skipped so the remaining hosts still run; the command
 exits non-zero if any host failed.
@@ -846,6 +846,11 @@ exceptions: they stream raw bytes and NDJSON respectively, so they reject
 `--format`/`--json`. Use `--server <url>` to target an explicit running daemon,
 `AGENTSVIEW_SERVER_TOKEN` or `--server-token-file <path>` when that daemon
 requires auth, or `--pg` to read from configured PostgreSQL.
+
+`agentsview session list` excludes one-shot and automated sessions by default.
+When that hides matching sessions on the first page, it reports the counts and
+the corresponding `--include-one-shot` or `--include-automated` flags on stderr.
+Stdout, including `--format json`, keeps its existing shape for pipelines.
 
 `AGENTSVIEW_PG_URL`, a legacy `[pg].url`, or the effective default target from
 `default_pg` plus `[pg.NAME]` are sync configuration only; they do not change

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -123,21 +123,30 @@ host = "devbox1"
 transport = "http"
 url = "http://devbox1.tailnet.ts.net:8080"
 token = "remote-token"
+interval = "5m" # optional; zero or omitted means manual sync only
 ```
 
 HTTP remote sync calls the remote daemon's archive endpoints and always uses a
 bearer token, even when the rest of that daemon has `require_auth = false`. The
 per-host `token` is required and must match the remote daemon's `auth_token`.
 Do not reuse the collector daemon's own `auth_token` for untrusted remote
-endpoints. HTTP transfers are incremental after the first sync; see
+endpoints. HTTP transfers use a persistent per-host mirror and request file
+deltas when fewer than half of the manifest files need fetching; see
 [Remote Access — Incremental Sync](/remote-access/#incremental-sync).
 
-Each `remote_hosts.host` value must be unique. A configured HTTP host can be
-selected later with `agentsview sync --host <name>`, but ad hoc HTTP remotes are
-not supported; without a matching configured host, `--host` remains an SSH
-remote sync. HTTP failures are summarized with actionable messages for common
-cases such as token rejection, missing remote archive endpoints, connection
-refusal, DNS failures, and timeouts.
+Each `remote_hosts.host` value must be unique and stable. It namespaces imported
+session IDs, the database skip cache, and the persistent mirror; changing it for
+the same machine can duplicate sessions, while reusing it for another machine
+can reuse stale state. A configured HTTP host can be selected later with
+`agentsview sync --host <name>`, but ad hoc HTTP remotes are not supported;
+without a matching configured host, `--host` remains an SSH remote sync. HTTP
+failures are summarized with actionable messages for common cases such as token
+rejection, missing remote archive endpoints, connection refusal, DNS failures,
+and timeouts.
+
+Set `interval` to a positive duration such as `"5m"` to have a running
+collector daemon sync that host periodically. Zero or omitted disables the
+per-host schedule; manual `agentsview sync` still includes the host.
 
 The remote daemon must also listen on an interface the collector can reach.
 The server binds `127.0.0.1` by default, so set `host` in the remote

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -81,7 +81,14 @@ host = "devbox1"
 transport = "http"
 url = "http://devbox1.tailnet.ts.net:8080"
 token = "remote-token"
+interval = "5m" # optional: sync periodically while the collector daemon runs
 ```
+
+Treat `host` as the remote machine's stable, unique identity. AgentsView uses
+it to namespace imported session IDs, the database skip cache, and the mirror
+directory. Changing it creates a new namespace and can duplicate sessions from
+the same machine; reusing it for a different machine can reuse stale cached
+state. Changing only `url` is fine when the same logical machine moves.
 
 The daemon on the remote machine must bind a non-loopback interface (set
 `host = "0.0.0.0"` with `require_auth = true` in its config.toml) or every
@@ -119,34 +126,131 @@ That setting controls detached background daemons only. Supervised daemons run
 under systemd, launchd, Docker, or a foreground shell never create the idle
 tracker and already stay alive until their supervisor stops them.
 
+Run `agentsview sync` on the collector to sync local sessions and every
+configured host. Set `interval` on a `[[remote_hosts]]` entry when a running
+collector daemon should sync that host periodically; omit it or set it to `0s`
+for manual sync only. See [`agentsview sync`](/commands/#agentsview-sync) for
+single-host selection and failure behavior.
+
 ## Incremental Sync
 
-HTTP remote sync is incremental. The first sync downloads the full session
-archive and stores a byte-for-byte mirror under
-`<data_dir>/remote-mirrors/<host>-<hash>/`; subsequent syncs fetch a file
-manifest, diff it against the mirror, and download only files that changed
-on the remote. Archives are gzip-compressed in transit.
+Starting in 0.37.4, HTTP remote sync keeps a persistent mirror of each remote
+machine's syncable source files under:
 
-The mirror is a disposable transfer cache: deleting it is always safe and
-just makes the next sync download everything again. Sessions already
-imported into the database are never removed, even when their source files
-disappear from the remote.
+```text
+<data_dir>/remote-mirrors/<sanitized-host>-<hash>/
+```
 
-Agents whose exports are sanitized per transfer (Windsurf state databases)
-cannot be described by the manifest, so their files are downloaded as a
-separate small full archive on every sync. The rest of the host's corpus
-stays incremental.
+For the default data directory, that parent is
+`~/.agentsview/remote-mirrors/`. The readable host component is followed by a
+hash so names that sanitize to the same directory name do not collide. A lock
+file next to each mirror serializes concurrent syncs of that host from the same
+data directory.
 
-When the remote daemon predates the manifest endpoint, sync automatically
-falls back to the full-archive download and reports that incremental sync
-is unavailable, so mixed versions keep working.
+The mirror adds an on-disk copy of the remote session sources to the collector,
+in addition to the indexed database. Budget roughly the size of each remote
+host's syncable source corpus for it. Incremental transfer applies only to the
+HTTP transport; SSH remote sync continues to copy a full session tree on each
+run.
 
-Incremental transfer applies to the HTTP transport only; SSH remote sync
-still copies the full session tree on every run. `agentsview sync --full`
-re-downloads the full archive into the mirror — the escape hatch for a
-stale or corrupted mirror, which the size/mtime diff cannot detect — and
-bypasses the remote skip cache. Sessions already stored and current in
-the local database are still skipped by the normal freshness checks.
+### How A Sync Works
+
+1. The collector asks the remote daemon for its resolved agent roots. The
+   remote controls this allowlist; the collector cannot name arbitrary roots.
+2. The collector locks the host mirror and requests a gzip-compressed manifest
+   of regular, non-symlink files. Each entry carries its absolute remote path,
+   size, and modification time.
+3. The collector walks the mirror and compares file size and modification time
+   at microsecond precision. It schedules missing or changed files for fetch
+   and removes mirror files that disappeared from the manifest.
+4. When fewer than half of the manifest's files need fetching, the collector
+   requests only that delta. At half or more, it requests a full archive instead
+   of sending a large file list. The current collector advertises gzip support
+   for both archive modes.
+5. The archive is extracted into the mirror with remote modification times
+   preserved. AgentsView then imports from the complete mirror, so parsers that
+   read sibling files behave the same way they do against a full source tree.
+   The separate database skip cache avoids unnecessary parsing of unchanged
+   sessions during normal syncs.
+
+If no directory-scoped files changed, the collector skips the archive request
+and imports directly from the existing mirror. Files that disappear remotely
+are deleted from the mirror, but remote import is intentionally non-destructive:
+sessions already stored in the AgentsView database remain available.
+
+Windsurf is a special case. Its state database is sanitized into a curated
+export for every transfer, so the raw tree cannot safely participate in the
+manifest. AgentsView fetches that small export as a separate full archive on
+each sync while the rest of the host remains eligible for delta transfer. The
+Windsurf content in the mirror is the sanitized export, not a byte-for-byte copy
+of the remote state database.
+
+### When AgentsView Downloads A Full Archive
+
+A full HTTP transfer occurs in these cases:
+
+- the per-host mirror is new or was removed
+- `agentsview sync --full` is used
+- at least half of the manifest files are missing or changed
+- a collector data-version resync forces its configured remote syncs full
+- a delta request is rejected after a manifest succeeded; the collector retries
+  once with a full archive
+- the remote daemon does not support manifests, in which case the collector
+  uses the legacy full-transfer path on every sync
+
+Windsurf's curated export is also fetched in full on every sync, independently
+of the directory-scoped archive decision.
+
+`--full` refreshes the mirror bytes and bypasses the persistent remote
+path/mtime skip cache during import. It does not delete the local database or
+turn remote sync into a destructive reconciliation.
+
+### Compatibility And Recovery
+
+A 0.37.4 collector works with older remote daemons. A missing manifest route —
+including an old daemon's HTML app shell answering that route — makes the
+collector report that incremental sync is unavailable and use the legacy
+full-archive flow. That flow extracts to a temporary directory and does not
+create or update the persistent mirror. Older collectors also continue to use
+the full-archive endpoint on a 0.37.4 remote.
+
+The normal mirror comparison detects interrupted extraction when the resulting
+file size or modification time differs from the manifest, and the next sync
+fetches that file again. It also repairs file-versus-directory conflicts left by
+an interrupted extraction.
+
+The comparison does not hash file content. A remote rewrite that preserves both
+size and modification time, or local mirror corruption with the same metadata,
+can therefore look unchanged. Run a full sync to refresh the bytes:
+
+```bash
+# Refresh local sessions and every configured remote.
+agentsview sync --full
+
+# Refresh one configured host through the local daemon.
+agentsview sync --host devbox1 --full
+```
+
+The second form requires `devbox1` to match a configured `[[remote_hosts]]`
+entry; otherwise `--host` is an ad hoc SSH sync.
+
+The mirror is a disposable transfer cache. When no sync is running, deleting a
+host's mirror directory is safe and makes the next compatible sync bootstrap it
+again. Leave the adjacent `.lock` file in place. Removing mirror files never
+removes imported sessions from the database.
+
+### Transfer Safety
+
+The remote daemon recomputes its allowed sync targets for each request and
+rejects paths outside them. Manifest walks omit symlinks and special files;
+delta requests must either match an allowed extra file exactly or use an
+absolute path in the same POSIX, drive-letter, or UNC dialect as the allowed
+root. Symlinked roots or intermediate components are refused. Mirror deletions
+and type-conflict cleanup are separately confined to the per-host mirror root.
+
+These checks limit what authenticated sync requests can read, but they do not
+replace network isolation or bearer-token security. Keep the daemon on a
+private network and protect its `auth_token` as described above.
 
 ## SSE Endpoints
 

--- a/docs/session-api.md
+++ b/docs/session-api.md
@@ -212,8 +212,13 @@ agentsview session list [flags]
 }
 ```
 
-One-shot and automated sessions are excluded by default. Use the
-`--include-*` flags to opt back in.
+One-shot and automated sessions are excluded by default. When the first CLI
+page hides any, `session list` writes an advisory to stderr with the hidden
+count for each category and the `--include-one-shot` or `--include-automated`
+flag that reveals it. Human and JSON stdout are unchanged, so redirecting or
+piping structured output remains safe. The JSON `total` continues to describe
+the filtered result, not the excluded sessions. Use the `--include-*` flags to
+opt back in.
 
 | Flag                  | HTTP param          | Notes                             |
 |-----------------------|---------------------|-----------------------------------|

--- a/docs/zensical-docs.sh
+++ b/docs/zensical-docs.sh
@@ -78,10 +78,12 @@ tmp_config_base=""
     --exclude './screenshots/README.md' \
     --exclude './screenshots/entrypoint.sh' \
     --exclude './screenshots/extract-db.sh' \
+    --exclude './screenshots/node_modules' \
     --exclude './screenshots/package-lock.json' \
     --exclude './screenshots/package.json' \
     --exclude './screenshots/playwright.config.ts' \
     --exclude './screenshots/run.sh' \
+    --exclude './screenshots/test-results' \
     --exclude './screenshots/tests/*' \
     --exclude './screenshots/update-generated-assets-branch.sh' \
     --exclude './README.md' \

--- a/scripts/docs_assets_test.go
+++ b/scripts/docs_assets_test.go
@@ -257,6 +257,75 @@ func TestBuiltSiteCheckRejectsSvgUsePlainHref(t *testing.T) {
 	}
 }
 
+func TestZensicalDocsBuildExcludesScreenshotToolchain(t *testing.T) {
+	tempDir := t.TempDir()
+	repo := filepath.Join(tempDir, "repo")
+	docsDir := filepath.Join(repo, "docs")
+	require.NoError(t, os.MkdirAll(docsDir, 0o755))
+
+	scriptPath := installScript(t, repo,
+		filepath.Join("docs", "zensical-docs.sh"))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(docsDir, "zensical.toml"),
+		[]byte("[project]\ndocs_dir = \"docs\"\nsite_dir = \"site\"\n"),
+		0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(docsDir, "index.md"),
+		[]byte("---\ntitle: Home\ndescription: Home page\n---\n"),
+		0o644,
+	))
+
+	toolchainFile := filepath.Join(
+		docsDir, "screenshots", "node_modules", "playwright-core",
+		"trace-viewer.html",
+	)
+	require.NoError(t, os.MkdirAll(filepath.Dir(toolchainFile), 0o755))
+	require.NoError(t, os.WriteFile(
+		toolchainFile, []byte("private screenshot toolchain\n"), 0o644,
+	))
+	testResultFile := filepath.Join(
+		docsDir, "screenshots", "test-results", "trace.zip",
+	)
+	require.NoError(t, os.MkdirAll(filepath.Dir(testResultFile), 0o755))
+	require.NoError(t, os.WriteFile(
+		testResultFile, []byte("private test trace\n"), 0o644,
+	))
+	publicScreenshot := filepath.Join(
+		docsDir, "assets", "generated", "screenshots", "dashboard.png",
+	)
+	require.NoError(t, os.MkdirAll(filepath.Dir(publicScreenshot), 0o755))
+	require.NoError(t, os.WriteFile(
+		publicScreenshot, []byte("public screenshot\n"), 0o644,
+	))
+
+	fakeZensical := filepath.Join(docsDir, ".venv", "bin", "zensical")
+	require.NoError(t, os.MkdirAll(filepath.Dir(fakeZensical), 0o755))
+	require.NoError(t, os.WriteFile(fakeZensical, []byte(`#!/usr/bin/env bash
+set -euo pipefail
+public_docs="$(find . -maxdepth 1 -type d -name 'zensical-public-docs.*' -print -quit)"
+mkdir -p site
+cp -R "$public_docs"/. site/
+`), 0o755))
+
+	cmd := exec.Command("bash", scriptPath, "build")
+	cmd.Dir = docsDir
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(output))
+	assert.FileExists(t, filepath.Join(docsDir, "site", "index.md"))
+	assert.FileExists(t, filepath.Join(
+		docsDir, "site", "assets", "generated", "screenshots",
+		"dashboard.png",
+	))
+	assert.NoFileExists(t, filepath.Join(
+		docsDir, "site", "screenshots", "node_modules", "playwright-core",
+		"trace-viewer.html",
+	))
+	assert.NoFileExists(t, filepath.Join(
+		docsDir, "site", "screenshots", "test-results", "trace.zip",
+	))
+}
+
 func installScript(t *testing.T, repo, scriptRel string) string {
 	t.Helper()
 	script, err := os.ReadFile(filepath.Join("..", scriptRel))


### PR DESCRIPTION
0.37.4 changes HTTP remote sync from repeated whole-corpus transfers to a persistent mirror. The existing brief note did not give operators enough context to size storage, understand full-download fallbacks, preserve host identity, or recover stale mirrors.

This documents the transfer lifecycle, threshold, fallback and compatibility behavior, the Windsurf exception, deletion semantics, and security boundaries. It also adds release notes for HTTP sync, GPT-5.6 pricing, and CLI exclusions while recording the stderr behavior without changing JSON contracts.

The docs staging wrapper now excludes local Playwright dependencies and test outputs while retaining generated public screenshots, preventing local toolchain HTML from entering published output.

The current v0.37.4 tag still points at the pre-GPT-5.6 pricing snapshot. Release assembly needs the pending pricing refresh before published binaries match that changelog line.