### PR TITLE
feat(postgres): pgvector-backed semantic and hybrid search

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:18-alpine
+        image: pgvector/pgvector:pg18
         env:
           POSTGRES_USER: agentsview_test
           POSTGRES_PASSWORD: agentsview_test_password

--- a/cmd/agentsview/archive_write_backend.go
+++ b/cmd/agentsview/archive_write_backend.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log"
+	"os"
 	"path/filepath"
+	stdsync "sync"
 	"time"
 
 	"go.kenn.io/agentsview/internal/config"
@@ -94,6 +97,72 @@ type daemonArchiveWriteBackend struct {
 	tr     transport
 }
 
+// daemonPushHeartbeatInterval bounds how often the daemon-delegated push
+// prints an elapsed-time line while waiting. A package var so tests can
+// shrink it.
+var daemonPushHeartbeatInterval = 30 * time.Second
+
+// startDaemonPushHeartbeat announces that the push runs inside the daemon
+// and then prints an elapsed-time line every interval until the returned
+// stop func is called. The daemon streams per-session progress once its
+// push loop starts, but the phases before it — the daemon-side local sync
+// and the remote schema migration — produce no progress events, so without
+// a heartbeat a long first push would look hung until the first session
+// lands. The caller stops the heartbeat on the first streamed progress
+// event; stop is idempotent-unsafe, so wrap it (see daemonPushProgress).
+func startDaemonPushHeartbeat(label string) func() {
+	return startDaemonPushHeartbeatTo(os.Stdout, label)
+}
+
+func startDaemonPushHeartbeatTo(w io.Writer, label string) func() {
+	fmt.Fprintf(w, "Pushing to %s via the local daemon...\n", label)
+	start := time.Now()
+	done := make(chan struct{})
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		ticker := time.NewTicker(daemonPushHeartbeatInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				fmt.Fprintf(w,
+					"still pushing to %s via the daemon (%s elapsed)\n",
+					label, time.Since(start).Round(time.Second),
+				)
+			}
+		}
+	}()
+	return func() {
+		close(done)
+		<-finished
+	}
+}
+
+// daemonPushProgress pairs a running heartbeat with a streamed-progress
+// renderer: the heartbeat covers the daemon-side phases that emit no
+// progress events (local sync, schema migration), and the first streamed
+// event silences it for good so heartbeat lines never interleave with the
+// in-place progress line. The returned finish func stops the heartbeat (if
+// no event ever arrived) and clears the in-place line.
+func daemonPushProgress[P any](
+	label string, render func(P),
+) (onProgress func(P), finish func()) {
+	stop := startDaemonPushHeartbeat(label)
+	var once stdsync.Once
+	stopHeartbeat := func() { once.Do(stop) }
+	onProgress = func(p P) {
+		stopHeartbeat()
+		render(p)
+	}
+	return onProgress, func() {
+		stopHeartbeat()
+		fmt.Print("\r\033[K")
+	}
+}
+
 func (b daemonArchiveWriteBackend) PGPush(
 	ctx context.Context,
 	target pgTargetSelection,
@@ -101,6 +170,10 @@ func (b daemonArchiveWriteBackend) PGPush(
 	projects []string,
 	excludeProjects []string,
 ) (postgres.PushResult, error) {
+	onProgress, finish := daemonPushProgress(
+		"PostgreSQL", newPGPushProgressPrinter(),
+	)
+	defer finish()
 	return postDaemonPush[postgres.PushResult](
 		ctx, b.tr, b.appCfg.AuthToken, "/api/v1/push/pg",
 		daemonPushRequest{
@@ -110,7 +183,9 @@ func (b daemonArchiveWriteBackend) PGPush(
 			PG:                     &target.PG,
 			SyncStateTarget:        target.SyncStateTarget,
 			MigrateLegacySyncState: target.MigrateLegacySyncState,
+			NoVectors:              cfg.NoVectors,
 		},
+		onProgress,
 	)
 }
 
@@ -210,6 +285,15 @@ func (b daemonArchiveWriteBackend) duckDBPush(
 	if syncStateTarget == "" {
 		syncStateTarget = duckdbsync.SyncStateTargetForConfig(duckCfg)
 	}
+	onProgress, finish := daemonPushProgress(
+		"DuckDB", func(p duckdbsync.PushProgress) {
+			fmt.Printf(
+				"\rPushing... %d/%d sessions, %d messages\x1b[K",
+				p.SessionsDone, p.SessionsTotal, p.MessagesDone,
+			)
+		},
+	)
+	defer finish()
 	return postDaemonPush[duckdbsync.PushResult](
 		ctx, b.tr, b.appCfg.AuthToken, "/api/v1/push/duckdb",
 		daemonPushRequest{
@@ -219,6 +303,7 @@ func (b daemonArchiveWriteBackend) duckDBPush(
 			DuckDB:          &duckCfg,
 			SyncStateTarget: syncStateTarget,
 		},
+		onProgress,
 	)
 }
 
@@ -327,7 +412,10 @@ func (b *localArchiveWriteBackend) PGPush(
 	ps, err := postgres.New(
 		target.PG.URL, target.PG.Schema, b.database,
 		target.PG.MachineName, target.PG.AllowInsecure,
-		target.syncOptions(projects, excludeProjects),
+		target.syncOptions(
+			projects, excludeProjects,
+			pgVectorPushSource(b.appCfg, target, cfg),
+		),
 	)
 	if err != nil {
 		return postgres.PushResult{}, err
@@ -348,11 +436,7 @@ func (b *localArchiveWriteBackend) PGPush(
 		time.Since(schemaStart).Round(time.Millisecond),
 	)
 	fmt.Println("Starting PostgreSQL push...")
-	result, err := ps.Push(ctx, forceFull,
-		func(p postgres.PushProgress) {
-			printPGPushProgress(p)
-		},
-	)
+	result, err := ps.Push(ctx, forceFull, newPGPushProgressPrinter())
 	fmt.Print("\r\033[K")
 	if err != nil {
 		return postgres.PushResult{}, err
@@ -432,7 +516,7 @@ func (b *localArchiveWriteBackend) duckDBPush(
 	result, err := syncer.Push(ctx, forceFull,
 		func(p duckdbsync.PushProgress) {
 			fmt.Printf(
-				"\rPushing... %d/%d sessions, %d messages",
+				"\rPushing... %d/%d sessions, %d messages\x1b[K",
 				p.SessionsDone, p.SessionsTotal, p.MessagesDone,
 			)
 		},
@@ -577,7 +661,10 @@ func (b *localArchiveWriteBackend) PGPushWatch(
 			s, cErr := postgres.New(
 				target.PG.URL, target.PG.Schema, b.database,
 				target.PG.MachineName, target.PG.AllowInsecure,
-				target.syncOptions(projects, exclude),
+				target.syncOptions(
+					projects, exclude,
+					pgVectorPushSource(b.appCfg, target, cfg),
+				),
 			)
 			if cErr != nil {
 				return nil, cErr

--- a/cmd/agentsview/archive_write_backend.go
+++ b/cmd/agentsview/archive_write_backend.go
@@ -409,13 +409,12 @@ func (b *localArchiveWriteBackend) PGPush(
 	fmt.Println("Connecting to PostgreSQL...")
 	connectStart := time.Now()
 	applyClassifierConfig(b.appCfg)
+	vectorSource := pgVectorPushSource(b.appCfg, target, cfg)
+	defer closeVectorPushSource(vectorSource)
 	ps, err := postgres.New(
 		target.PG.URL, target.PG.Schema, b.database,
 		target.PG.MachineName, target.PG.AllowInsecure,
-		target.syncOptions(
-			projects, excludeProjects,
-			pgVectorPushSource(b.appCfg, target, cfg),
-		),
+		target.syncOptions(projects, excludeProjects, vectorSource),
 	)
 	if err != nil {
 		return postgres.PushResult{}, err
@@ -647,6 +646,14 @@ func (b *localArchiveWriteBackend) PGPushWatch(
 		return err
 	}
 
+	// One vectors.db adapter for the watch loop's lifetime: connect runs on
+	// every reconnect, and a fresh source per reconnect would leak the
+	// previous one's memoized read-only handle (postgres.Sync never closes
+	// its source). The adapter is designed for reuse — it reopens lazily
+	// after transient failures.
+	vectorSource := pgVectorPushSource(b.appCfg, target, cfg)
+	defer closeVectorPushSource(vectorSource)
+
 	pusher := &pgPusher{
 		localSync: func(c context.Context) error {
 			engine.SyncAll(c, nil)
@@ -661,10 +668,7 @@ func (b *localArchiveWriteBackend) PGPushWatch(
 			s, cErr := postgres.New(
 				target.PG.URL, target.PG.Schema, b.database,
 				target.PG.MachineName, target.PG.AllowInsecure,
-				target.syncOptions(
-					projects, exclude,
-					pgVectorPushSource(b.appCfg, target, cfg),
-				),
+				target.syncOptions(projects, exclude, vectorSource),
 			)
 			if cErr != nil {
 				return nil, cErr

--- a/cmd/agentsview/archive_write_backend_test.go
+++ b/cmd/agentsview/archive_write_backend_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"path/filepath"
+	"strings"
+	stdsync "sync"
 	"testing"
 	"time"
 
@@ -11,8 +14,76 @@ import (
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/postgres"
 	syncpkg "go.kenn.io/agentsview/internal/sync"
 )
+
+// TestDaemonPushHeartbeat pins the daemon-delegated push's client-side
+// output: an immediate delegation announcement, elapsed-time heartbeats
+// while the blocking POST is in flight, and silence after stop.
+func TestDaemonPushHeartbeat(t *testing.T) {
+	orig := daemonPushHeartbeatInterval
+	daemonPushHeartbeatInterval = 5 * time.Millisecond
+	t.Cleanup(func() { daemonPushHeartbeatInterval = orig })
+
+	var out syncBuffer
+	stop := startDaemonPushHeartbeatTo(&out, "PostgreSQL")
+	assert.Contains(t, out.String(),
+		"Pushing to PostgreSQL via the local daemon")
+
+	require.Eventually(t, func() bool {
+		return strings.Contains(out.String(),
+			"still pushing to PostgreSQL via the daemon")
+	}, time.Second, time.Millisecond, "heartbeat line must appear")
+
+	stop()
+	settled := out.String()
+	time.Sleep(20 * time.Millisecond)
+	assert.Equal(t, settled, out.String(), "no output after stop")
+}
+
+// TestDaemonPushProgressSilencesHeartbeat pins that the first streamed
+// progress event stops the elapsed-time heartbeat for good: once the daemon
+// starts reporting real progress, heartbeat lines must not interleave with
+// the in-place progress line.
+func TestDaemonPushProgressSilencesHeartbeat(t *testing.T) {
+	orig := daemonPushHeartbeatInterval
+	daemonPushHeartbeatInterval = 50 * time.Millisecond
+	t.Cleanup(func() { daemonPushHeartbeatInterval = orig })
+
+	out := captureStdout(t, func() {
+		onProgress, finish := daemonPushProgress(
+			"PostgreSQL", newPGPushProgressPrinter(),
+		)
+		onProgress(postgres.PushProgress{SessionsDone: 1, SessionsTotal: 2})
+		time.Sleep(150 * time.Millisecond)
+		finish()
+	})
+
+	assert.Contains(t, out, "Pushing to PostgreSQL via the local daemon")
+	assert.Contains(t, out, "Pushing... 1/2 sessions")
+	assert.NotContains(t, out, "still pushing",
+		"heartbeat must stay silent after the first progress event")
+}
+
+// syncBuffer is a mutex-guarded bytes.Buffer: the heartbeat goroutine writes
+// while the test reads.
+type syncBuffer struct {
+	mu  stdsync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
 
 func TestLocalArchiveWriteBackendPGPushStopsAfterCanceledLocalSync(t *testing.T) {
 	testLocalArchivePushStopsAfterCanceledSync(t,

--- a/cmd/agentsview/cli.go
+++ b/cmd/agentsview/cli.go
@@ -569,6 +569,7 @@ func newPGCommand() *cobra.Command {
 	cmd.AddCommand(newPGPushCommand())
 	cmd.AddCommand(newPGStatusCommand())
 	cmd.AddCommand(newPGServeCommand())
+	cmd.AddCommand(newPGVectorsCommand())
 	cmd.AddCommand(newPGServiceCommand())
 	return cmd
 }
@@ -617,6 +618,7 @@ func newPGPushCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&cfg.Watch, "watch", false, "Run continuously, pushing on change plus a periodic floor")
 	cmd.Flags().DurationVar(&cfg.Debounce, "debounce", defaultWatchDebounce, "Coalesce window after a change before pushing (--watch only)")
 	cmd.Flags().DurationVar(&cfg.Interval, "interval", defaultWatchInterval, "Periodic floor push interval (--watch only)")
+	cmd.Flags().BoolVar(&cfg.NoVectors, "no-vectors", false, "Skip pushing semantic-search vectors")
 	return cmd
 }
 

--- a/cmd/agentsview/daemon_push.go
+++ b/cmd/agentsview/daemon_push.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -21,14 +22,23 @@ type daemonPushRequest struct {
 	DuckDB                 *config.DuckDBConfig `json:"duckdb,omitempty"`
 	SyncStateTarget        string               `json:"sync_state_target,omitempty"`
 	MigrateLegacySyncState bool                 `json:"migrate_legacy_sync_state,omitempty"`
+	// NoVectors mirrors the CLI --no-vectors flag into the daemon: it has no
+	// per-invocation flag of its own, so the gate must travel in the request.
+	NoVectors bool `json:"no_vectors,omitempty"`
 }
 
-func postDaemonPush[T any](
+// postDaemonPush delegates a push to the local daemon. It negotiates an SSE
+// response so the daemon can stream per-phase progress while the push runs;
+// each progress event is decoded as P and handed to onProgress (which may be
+// nil). A plain JSON response — the daemon streams only when it can flush —
+// is decoded directly as the result T.
+func postDaemonPush[T, P any](
 	ctx context.Context,
 	tr transport,
 	authToken string,
 	path string,
 	body daemonPushRequest,
+	onProgress func(P),
 ) (T, error) {
 	var zero T
 	data, err := json.Marshal(body)
@@ -43,6 +53,7 @@ func postDaemonPush[T any](
 		return zero, err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/event-stream")
 	req.Header.Set("Origin", tr.URL)
 	if authToken != "" {
 		req.Header.Set("Authorization", "Bearer "+authToken)
@@ -54,20 +65,112 @@ func postDaemonPush[T any](
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		msg, _ := io.ReadAll(resp.Body)
-		var apiErr struct {
-			Error string `json:"error"`
-		}
-		if err := json.Unmarshal(msg, &apiErr); err == nil &&
-			apiErr.Error != "" {
-			return zero, errors.New(apiErr.Error)
-		}
-		return zero, fmt.Errorf(
-			"HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(msg)),
-		)
+		return zero, daemonPushError(resp.StatusCode, msg)
+	}
+	if strings.HasPrefix(
+		resp.Header.Get("Content-Type"), "text/event-stream",
+	) {
+		return parseDaemonPushSSE[T](resp.Body, onProgress)
 	}
 	var out T
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		return zero, err
 	}
 	return out, nil
+}
+
+// daemonPushError renders a non-200 daemon response, preferring the API's
+// {"error": ...} body over the raw payload.
+func daemonPushError(status int, body []byte) error {
+	var apiErr struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(body, &apiErr); err == nil && apiErr.Error != "" {
+		return errors.New(apiErr.Error)
+	}
+	return fmt.Errorf("HTTP %d: %s", status, strings.TrimSpace(string(body)))
+}
+
+// parseDaemonPushSSE consumes the daemon push event stream: "progress" events
+// decode as P and feed onProgress, a "done" event decodes as the result T,
+// and an "error" event (an {"error": ...} body) fails the push. A stream that
+// ends without a done event is an error — the daemon died mid-push.
+func parseDaemonPushSSE[T, P any](
+	r io.Reader, onProgress func(P),
+) (T, error) {
+	var zero T
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 10*1024*1024)
+	var event string
+	var data strings.Builder
+	var done bool
+	var result T
+	var pushErr error
+	dispatch := func() error {
+		if data.Len() == 0 {
+			return nil
+		}
+		switch event {
+		case "done":
+			if err := json.Unmarshal([]byte(data.String()), &result); err != nil {
+				return fmt.Errorf("decoding daemon push result: %w", err)
+			}
+			done = true
+		case "progress":
+			if onProgress == nil {
+				return nil
+			}
+			var p P
+			if err := json.Unmarshal([]byte(data.String()), &p); err != nil {
+				return fmt.Errorf("decoding daemon push progress: %w", err)
+			}
+			onProgress(p)
+		default:
+			var apiErr struct {
+				Error string `json:"error"`
+			}
+			raw := data.String()
+			if err := json.Unmarshal([]byte(raw), &apiErr); err == nil &&
+				apiErr.Error != "" {
+				pushErr = errors.New(apiErr.Error)
+			} else {
+				pushErr = fmt.Errorf("daemon push error: %s", raw)
+			}
+		}
+		return nil
+	}
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			if err := dispatch(); err != nil {
+				return zero, err
+			}
+			event = ""
+			data.Reset()
+			continue
+		}
+		if value, ok := strings.CutPrefix(line, "event: "); ok {
+			event = value
+			continue
+		}
+		if value, ok := strings.CutPrefix(line, "data: "); ok {
+			if data.Len() > 0 {
+				data.WriteByte('\n')
+			}
+			data.WriteString(value)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return zero, err
+	}
+	if err := dispatch(); err != nil {
+		return zero, err
+	}
+	if pushErr != nil {
+		return zero, pushErr
+	}
+	if !done {
+		return zero, errors.New("daemon push response missing done event")
+	}
+	return result, nil
 }

--- a/cmd/agentsview/daemon_push_test.go
+++ b/cmd/agentsview/daemon_push_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/postgres"
+)
+
+func TestParseDaemonPushSSE(t *testing.T) {
+	stream := func(events ...string) string {
+		return strings.Join(events, "")
+	}
+	progressEvent := `event: progress` + "\n" +
+		`data: {"SessionsDone":3,"SessionsTotal":10}` + "\n\n"
+	doneEvent := `event: done` + "\n" +
+		`data: {"SessionsPushed":10,"MessagesPushed":42}` + "\n\n"
+
+	t.Run("progress then done", func(t *testing.T) {
+		var progress []postgres.PushProgress
+		result, err := parseDaemonPushSSE[postgres.PushResult](
+			strings.NewReader(stream(progressEvent, doneEvent)),
+			func(p postgres.PushProgress) { progress = append(progress, p) },
+		)
+		require.NoError(t, err)
+		assert.Equal(t, 10, result.SessionsPushed)
+		assert.Equal(t, 42, result.MessagesPushed)
+		require.Len(t, progress, 1)
+		assert.Equal(t, 3, progress[0].SessionsDone)
+		assert.Equal(t, 10, progress[0].SessionsTotal)
+	})
+
+	t.Run("nil onProgress is safe", func(t *testing.T) {
+		result, err := parseDaemonPushSSE[postgres.PushResult, postgres.PushProgress](
+			strings.NewReader(stream(progressEvent, doneEvent)), nil,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, 10, result.SessionsPushed)
+	})
+
+	t.Run("error event fails the push", func(t *testing.T) {
+		errEvent := "event: error\n" + `data: {"error":"schema: boom"}` + "\n\n"
+		_, err := parseDaemonPushSSE[postgres.PushResult, postgres.PushProgress](
+			strings.NewReader(stream(progressEvent, errEvent)), nil,
+		)
+		require.Error(t, err)
+		assert.Equal(t, "schema: boom", err.Error())
+	})
+
+	t.Run("stream without done event fails", func(t *testing.T) {
+		_, err := parseDaemonPushSSE[postgres.PushResult, postgres.PushProgress](
+			strings.NewReader(stream(progressEvent)), nil,
+		)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing done event")
+	})
+}
+
+// TestPostDaemonPushConsumesSSE pins the daemon-delegated push end to end
+// against a stub daemon that streams SSE: progress events reach the callback
+// and the done event becomes the returned result.
+func TestPostDaemonPushConsumesSSE(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, "/api/v1/push/pg", r.URL.Path)
+			require.Contains(t, r.Header.Get("Accept"), "text/event-stream")
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = w.Write([]byte(
+				"event: progress\ndata: {\"SessionsDone\":1,\"SessionsTotal\":2}\n\n" +
+					"event: done\ndata: {\"SessionsPushed\":2}\n\n"))
+		}))
+	t.Cleanup(ts.Close)
+
+	var progress []postgres.PushProgress
+	result, err := postDaemonPush[postgres.PushResult](
+		context.Background(), transport{URL: ts.URL}, "", "/api/v1/push/pg",
+		daemonPushRequest{},
+		func(p postgres.PushProgress) { progress = append(progress, p) },
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.SessionsPushed)
+	require.Len(t, progress, 1)
+	assert.Equal(t, 1, progress[0].SessionsDone)
+}
+
+// TestPostDaemonPushJSONFallback pins compatibility with a daemon that
+// answers with a plain JSON body instead of an event stream.
+func TestPostDaemonPushJSONFallback(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"SessionsPushed":7}`))
+		}))
+	t.Cleanup(ts.Close)
+
+	result, err := postDaemonPush[postgres.PushResult, postgres.PushProgress](
+		context.Background(), transport{URL: ts.URL}, "", "/api/v1/push/pg",
+		daemonPushRequest{}, nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 7, result.SessionsPushed)
+}

--- a/cmd/agentsview/embed_scheduler.go
+++ b/cmd/agentsview/embed_scheduler.go
@@ -379,7 +379,17 @@ func setupVectorServing(
 				"disabling vector serving for this run",
 			vectorsWriteLockRetryTimeout,
 		)
-		return vectorServing{}, nil
+		// The 501s this leaves behind must say why and how to recover: the
+		// generic "embeddings manager not available" reads like a missing
+		// feature, when the actual fix is restarting the daemon once the
+		// lock-holding process (typically a direct build) exits.
+		return vectorServing{ServerOpts: []server.Option{
+			server.WithEmbeddingsUnavailableReason(
+				"vector serving is disabled for this daemon run: another " +
+					"process (typically a direct 'agentsview embeddings build') " +
+					"held vectors.write.lock at startup; wait for it to finish, " +
+					"then restart the daemon"),
+		}}, nil
 	}
 
 	ix, err := vector.Open(

--- a/cmd/agentsview/embed_scheduler_test.go
+++ b/cmd/agentsview/embed_scheduler_test.go
@@ -652,9 +652,15 @@ func TestSetupVectorServingDisablesWhenWriteLockHeld(t *testing.T) {
 	require.NoError(t, err, "a held lock must degrade, not fail, daemon startup")
 	assert.Nil(t, vs.Scheduler)
 	assert.Nil(t, vs.Close)
-	assert.Empty(t, vs.ServerOpts)
 	assert.Contains(t, logBuf.String(), "vectors.write.lock")
 	assert.Contains(t, logBuf.String(), "disabling vector serving")
+
+	// The degraded run still carries one server option: the unavailability
+	// reason, so the embeddings routes' 501s explain the lock conflict and
+	// the restart remedy instead of the generic "manager not available"
+	// (the reason-to-501 threading itself is pinned in internal/server's
+	// TestEmbeddingsUnavailableReasonReplacesGeneric501).
+	assert.Len(t, vs.ServerOpts, 1)
 }
 
 // TestSetupVectorServingAcquiresAndReleasesWriteLock asserts a free

--- a/cmd/agentsview/embeddings.go
+++ b/cmd/agentsview/embeddings.go
@@ -441,6 +441,7 @@ func runDirectBuild(
 
 	ticker := time.NewTicker(directBuildProgressInterval)
 	defer ticker.Stop()
+	var progress buildProgressPrinter
 	for {
 		select {
 		case res := <-resultCh:
@@ -456,7 +457,7 @@ func runDirectBuild(
 			return nil
 		case <-ticker.C:
 			if status := m.Status(); status.Running {
-				printBuildProgress(out, status.Done, status.Total)
+				progress.print(out, status.Phase, status.Done, status.Total)
 			}
 		}
 	}
@@ -497,6 +498,7 @@ func buildViaDaemon(
 func pollDaemonBuildStatus(
 	ctx context.Context, out io.Writer, client embeddingsDaemonClient,
 ) error {
+	var progress buildProgressPrinter
 	for {
 		status, err := client.status(ctx)
 		if err != nil {
@@ -505,7 +507,7 @@ func pollDaemonBuildStatus(
 		if !status.Running {
 			return finalizeBuildStatus(out, status)
 		}
-		printBuildProgress(out, status.Done, status.Total)
+		progress.print(out, status.Phase, status.Done, status.Total)
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -527,8 +529,37 @@ func finalizeBuildStatus(out io.Writer, status vector.BuildStatus) error {
 	return nil
 }
 
-// printBuildProgress writes one progress line for either build path.
-func printBuildProgress(w io.Writer, done, total int64) {
+// buildProgressPrinter deduplicates the per-poll progress lines: both build
+// paths poll on a fixed interval and the status often has not moved between
+// polls, which used to print the same line dozens of times (worst during the
+// scan phase, where every poll rendered an identical "0/0 chunks").
+type buildProgressPrinter struct {
+	printed   bool
+	lastPhase string
+	lastDone  int64
+	lastTotal int64
+}
+
+func (p *buildProgressPrinter) print(w io.Writer, phase string, done, total int64) {
+	if p.printed && phase == p.lastPhase && done == p.lastDone && total == p.lastTotal {
+		return
+	}
+	p.printed = true
+	p.lastPhase, p.lastDone, p.lastTotal = phase, done, total
+	printBuildProgress(w, phase, done, total)
+}
+
+// printBuildProgress writes one progress line for either build path. Before
+// the embedding fill starts, the build scans the archive to reconcile the
+// mirror and chunk totals are not known yet; printing the chunk counters
+// there would render a misleading "0/0 chunks" for the whole scan, so any
+// non-embedding report without a total prints the scan line instead (an
+// empty phase covers daemons predating the scanning phase report).
+func printBuildProgress(w io.Writer, phase string, done, total int64) {
+	if phase != "embedding" && total == 0 {
+		fmt.Fprintln(w, "progress: scanning archive for changed documents...")
+		return
+	}
 	pct := 0.0
 	if total > 0 {
 		pct = float64(done) / float64(total) * 100

--- a/cmd/agentsview/embeddings_test.go
+++ b/cmd/agentsview/embeddings_test.go
@@ -359,9 +359,78 @@ func TestEmbeddingsBuildDirectPrintsProgress(t *testing.T) {
 	cmd.SetArgs(nil)
 	require.NoError(t, cmd.Execute())
 
-	assert.Regexp(t, `progress: \d+/\d+ chunks \(\d+\.\d%\)`, out.String(),
+	// The scan-phase line is the deterministic progress signal here: the
+	// build reports "scanning" until the stub's first (deliberately slow)
+	// encode call reports chunk counters, and the poll ticker fires many
+	// times inside that window. A chunk-counter line may or may not appear
+	// depending on how quickly the build finishes after that first report.
+	assert.Contains(t, out.String(),
+		"progress: scanning archive for changed documents...",
 		"a running build must print at least one progress line")
 	assert.Contains(t, out.String(), "Embedded 2 documents (2 chunks), skipped 0, stale 0")
+}
+
+// TestPrintBuildProgressPhases pins per-phase progress rendering: the scan
+// phase (and an empty phase from a daemon predating the scanning report)
+// prints the scan line instead of a misleading "0/0 chunks", while the
+// embedding phase prints chunk counters.
+func TestPrintBuildProgressPhases(t *testing.T) {
+	tests := []struct {
+		name  string
+		phase string
+		done  int64
+		total int64
+		want  string
+	}{
+		{
+			name: "scanning phase", phase: "scanning",
+			want: "progress: scanning archive for changed documents...\n",
+		},
+		{
+			name: "empty phase without totals treated as scanning", phase: "",
+			want: "progress: scanning archive for changed documents...\n",
+		},
+		{
+			name: "embedding phase with zero chunks", phase: "embedding",
+			want: "progress: 0/0 chunks (0.0%)\n",
+		},
+		{
+			name: "embedding phase with counters", phase: "embedding",
+			done: 587, total: 6004,
+			want: "progress: 587/6004 chunks (9.8%)\n",
+		},
+		{
+			name: "totals without phase still print counters", phase: "",
+			done: 1, total: 4,
+			want: "progress: 1/4 chunks (25.0%)\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			printBuildProgress(&out, tt.phase, tt.done, tt.total)
+			assert.Equal(t, tt.want, out.String())
+		})
+	}
+}
+
+// TestBuildProgressPrinterDeduplicates pins that unchanged status between
+// polls prints nothing: a long scan renders one scan line, not one per poll,
+// and a stalled chunk counter is not repeated.
+func TestBuildProgressPrinterDeduplicates(t *testing.T) {
+	var out bytes.Buffer
+	var p buildProgressPrinter
+	p.print(&out, "scanning", 0, 0)
+	p.print(&out, "scanning", 0, 0)
+	p.print(&out, "scanning", 0, 0)
+	p.print(&out, "embedding", 10, 40)
+	p.print(&out, "embedding", 10, 40)
+	p.print(&out, "embedding", 17, 40)
+	assert.Equal(t,
+		"progress: scanning archive for changed documents...\n"+
+			"progress: 10/40 chunks (25.0%)\n"+
+			"progress: 17/40 chunks (42.5%)\n",
+		out.String())
 }
 
 // TestEmbeddingsBuildDirectConcurrentFlockFails asserts a second direct

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -298,6 +298,9 @@ func runServe(cfg config.Config, opts serveOptions) {
 		server.WithPprof(opts.Pprof),
 	}
 	srvOpts = append(srvOpts, vectorServe.ServerOpts...)
+	if src := newVectorPushSource(cfg); src != nil {
+		srvOpts = append(srvOpts, server.WithVectorPushSource(src))
+	}
 	srv := server.New(cfg, database, engine, srvOpts...)
 
 	startupProgress.SetPhase("starting HTTP server")

--- a/cmd/agentsview/pg.go
+++ b/cmd/agentsview/pg.go
@@ -28,6 +28,7 @@ type PGPushConfig struct {
 	Watch           bool
 	Debounce        time.Duration
 	Interval        time.Duration
+	NoVectors       bool
 }
 
 type PGStatusConfig struct {
@@ -57,13 +58,29 @@ func (s pgTargetSelection) label() string {
 
 func (s pgTargetSelection) syncOptions(
 	projects, excludeProjects []string,
+	vectorSource postgres.VectorPushSource,
 ) postgres.SyncOptions {
 	return postgres.SyncOptions{
 		Projects:               projects,
 		ExcludeProjects:        excludeProjects,
 		SyncStateTarget:        s.SyncStateTarget,
 		MigrateLegacySyncState: s.MigrateLegacySyncState,
+		VectorSource:           vectorSource,
 	}
+}
+
+// pgVectorPushSource returns the vectors.db push source to attach for this
+// target, or nil when the vector push phase is gated off: the target opts out
+// via push_vectors=false, the caller passed --no-vectors, or [vector] is
+// disabled (newVectorPushSource itself returns nil then). A nil source leaves
+// postgres.Sync's vector phase skipped.
+func pgVectorPushSource(
+	appCfg config.Config, target pgTargetSelection, cfg PGPushConfig,
+) postgres.VectorPushSource {
+	if !target.PG.PushVectorsEnabled() || cfg.NoVectors {
+		return nil
+	}
+	return newVectorPushSource(appCfg)
 }
 
 func runPGPush(
@@ -167,17 +184,72 @@ func runPGPushTarget(
 	return nil
 }
 
-func printPGPushProgress(p postgres.PushProgress) {
+// pgPushProgressStage buckets progress reports into the display stages that
+// each own one progress line: daemon-side setup, fingerprinting, the session
+// push, and the vector push.
+func pgPushProgressStage(p postgres.PushProgress) string {
+	switch {
+	case p.Phase == "preparing" && p.SessionsTotal == 0:
+		return "setup"
+	case p.Phase == "preparing":
+		return "fingerprints"
+	case p.Phase == "vectors":
+		return "vectors"
+	default:
+		return "sessions"
+	}
+}
+
+// newPGPushProgressPrinter returns a progress renderer that updates the
+// current stage's line in place and finishes it with a newline when the push
+// moves to the next stage, so each completed stage stays in the scrollback
+// instead of being overwritten by the next one. Every render carries the
+// elapsed time since the printer was created (push start), so long stages
+// show how long the push has been running. Renders end with an
+// erase-to-end-of-line so a shorter render fully replaces a longer one
+// instead of leaving its tail behind.
+func newPGPushProgressPrinter() func(postgres.PushProgress) {
+	lastStage := ""
+	start := time.Now()
+	return func(p postgres.PushProgress) {
+		stage := pgPushProgressStage(p)
+		if lastStage != "" && stage != lastStage {
+			fmt.Println()
+		}
+		lastStage = stage
+		fmt.Printf("\r%s (%s elapsed)\x1b[K",
+			pgPushProgressLine(p), time.Since(start).Round(time.Second))
+	}
+}
+
+// pgPushProgressLine renders one progress report as the visible line text for
+// its stage; newPGPushProgressPrinter owns the in-place terminal handling.
+func pgPushProgressLine(p postgres.PushProgress) string {
+	if p.Phase == "preparing" {
+		if p.SessionsTotal == 0 {
+			return "Preparing push (sync state, metadata, fingerprints)..."
+		}
+		return fmt.Sprintf(
+			"Preparing... %d/%d sessions fingerprinted",
+			p.SessionsDone, p.SessionsTotal,
+		)
+	}
+	if p.Phase == "vectors" {
+		return fmt.Sprintf(
+			"Pushing vectors... %d/%d sessions scanned, %d chunks",
+			p.VectorSessionsDone, p.VectorSessionsTotal,
+			p.VectorChunksPushed,
+		)
+	}
 	if p.SkippedConflicts > 0 {
-		fmt.Printf(
-			"\rPushing... %d/%d sessions, %d messages, %d ownership conflicts skipped",
+		return fmt.Sprintf(
+			"Pushing... %d/%d sessions, %d messages, %d ownership conflicts skipped",
 			p.SessionsDone, p.SessionsTotal,
 			p.MessagesDone, p.SkippedConflicts,
 		)
-		return
 	}
-	fmt.Printf(
-		"\rPushing... %d/%d sessions, %d messages",
+	return fmt.Sprintf(
+		"Pushing... %d/%d sessions, %d messages",
 		p.SessionsDone, p.SessionsTotal,
 		p.MessagesDone,
 	)
@@ -204,6 +276,7 @@ func writePGPushSummary(w io.Writer, result postgres.PushResult) {
 			"Warning: skipped %d session(s) owned by another PostgreSQL push marker\n",
 			result.SkippedConflicts,
 		)
+		writePGVectorPushSummary(w, result.Vectors)
 		return
 	}
 	fmt.Fprintf(
@@ -214,6 +287,40 @@ func writePGPushSummary(w io.Writer, result postgres.PushResult) {
 		errSuffix,
 		dur,
 	)
+	writePGVectorPushSummary(w, result.Vectors)
+}
+
+// writePGVectorPushSummary prints the vector push phase outcome: a skip
+// reason when the phase did not run, otherwise per-session and per-doc
+// counters. An ownership conflict count is surfaced separately, analogous to
+// the session-level SkippedConflicts warning, since those sessions were left
+// untouched on PG because another machine's marker owns them.
+func writePGVectorPushSummary(w io.Writer, v postgres.VectorPushResult) {
+	if v.Skipped {
+		if v.SkippedReason != "" {
+			fmt.Fprintf(w, "Vectors: skipped (%s)\n", v.SkippedReason)
+		}
+		return
+	}
+	fmt.Fprintf(
+		w,
+		"Vectors: %d session(s) pushed, %d unchanged, %d docs, %d chunks\n",
+		v.SessionsPushed, v.SessionsUnchanged, v.DocsPushed, v.ChunksPushed,
+	)
+	if v.Conflicts > 0 {
+		fmt.Fprintf(
+			w,
+			"Warning: skipped %d vector session(s) owned by another PostgreSQL push marker\n",
+			v.Conflicts,
+		)
+	}
+	if v.SessionsDeferred > 0 {
+		fmt.Fprintf(
+			w,
+			"Warning: deferred vectors for %d session(s) whose session push failed; the next successful push sends them\n",
+			v.SessionsDeferred,
+		)
+	}
 }
 
 func runPGStatus(targetName string, cfg PGStatusConfig) error {
@@ -416,6 +523,9 @@ func runPGServe(appCfg config.Config, basePath string) {
 	if err := postgres.CheckDataVersionCompat(
 		ctx, store.DB(),
 	); err != nil {
+		fatal("pg serve: %v", err)
+	}
+	if err := wirePGVectorSearch(ctx, appCfg, store, "pg serve"); err != nil {
 		fatal("pg serve: %v", err)
 	}
 	if err := store.DetectInsightGenerationAvailability(

--- a/cmd/agentsview/pg_test.go
+++ b/cmd/agentsview/pg_test.go
@@ -395,6 +395,82 @@ func TestWritePGPushSummaryIncludesSkippedConflicts(t *testing.T) {
 		"Warning: skipped 2 session(s) owned by another PostgreSQL push marker")
 }
 
+func TestWritePGPushSummaryVectorPhase(t *testing.T) {
+	tests := []struct {
+		name        string
+		vectors     postgres.VectorPushResult
+		wantContain []string
+		wantAbsent  []string
+	}{
+		{
+			name: "counters",
+			vectors: postgres.VectorPushResult{
+				SessionsPushed:    2,
+				SessionsUnchanged: 5,
+				DocsPushed:        7,
+				ChunksPushed:      9,
+			},
+			wantContain: []string{
+				"Vectors: 2 session(s) pushed, 5 unchanged, 7 docs, 9 chunks",
+			},
+			wantAbsent: []string{"skipped", "Warning: skipped"},
+		},
+		{
+			name: "skipped with reason",
+			vectors: postgres.VectorPushResult{
+				Skipped:       true,
+				SkippedReason: "pgvector extension unavailable",
+			},
+			wantContain: []string{"Vectors: skipped (pgvector extension unavailable)"},
+		},
+		{
+			name:       "skipped without reason prints nothing",
+			vectors:    postgres.VectorPushResult{Skipped: true},
+			wantAbsent: []string{"Vectors:"},
+		},
+		{
+			name: "conflicts warning",
+			vectors: postgres.VectorPushResult{
+				SessionsPushed: 1,
+				Conflicts:      3,
+			},
+			wantContain: []string{
+				"Vectors: 1 session(s) pushed, 0 unchanged, 0 docs, 0 chunks",
+				"Warning: skipped 3 vector session(s) owned by another PostgreSQL push marker",
+			},
+		},
+		{
+			name: "deferred warning",
+			vectors: postgres.VectorPushResult{
+				SessionsPushed:   1,
+				SessionsDeferred: 2,
+			},
+			wantContain: []string{
+				"Vectors: 1 session(s) pushed, 0 unchanged, 0 docs, 0 chunks",
+				"Warning: deferred vectors for 2 session(s) whose session push failed; the next successful push sends them",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			writePGPushSummary(&out, postgres.PushResult{
+				SessionsPushed: 1,
+				MessagesPushed: 1,
+				Duration:       time.Second,
+				Vectors:        tt.vectors,
+			})
+			got := out.String()
+			for _, want := range tt.wantContain {
+				assert.Contains(t, got, want)
+			}
+			for _, absent := range tt.wantAbsent {
+				assert.NotContains(t, got, absent)
+			}
+		})
+	}
+}
+
 func TestWritePGPushSummaryReportsErrorCount(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -463,5 +539,55 @@ func TestWritePGPushSummaryReportsErrorCount(t *testing.T) {
 				assert.NotContains(t, got, absent)
 			}
 		})
+	}
+}
+
+// TestPGPushProgressPrinterKeepsCompletedStages pins the stage-aware
+// renderer: reports within a stage rerender one line in place, and a stage
+// transition finishes the line with a newline so completed stages stay in
+// the scrollback instead of being overwritten by the next stage.
+func TestPGPushProgressPrinterKeepsCompletedStages(t *testing.T) {
+	out := captureStdout(t, func() {
+		print := newPGPushProgressPrinter()
+		print(postgres.PushProgress{Phase: "preparing"})
+		print(postgres.PushProgress{Phase: "preparing"})
+		print(postgres.PushProgress{
+			Phase: "preparing", SessionsDone: 500, SessionsTotal: 1000,
+		})
+		print(postgres.PushProgress{
+			Phase: "preparing", SessionsDone: 1000, SessionsTotal: 1000,
+		})
+		print(postgres.PushProgress{
+			SessionsDone: 1, SessionsTotal: 9, MessagesDone: 5,
+		})
+		print(postgres.PushProgress{
+			Phase: "vectors", VectorSessionsDone: 1,
+			VectorSessionsTotal: 2, VectorChunksPushed: 3,
+		})
+	})
+
+	lines := strings.Split(out, "\n")
+	require.Len(t, lines, 4, "one line per stage: %q", out)
+
+	// Within a line, in-place rerenders are separated by carriage returns;
+	// the text a terminal leaves visible is the segment after the last one.
+	// Every render carries a wall-clock elapsed suffix, so assert on the
+	// stable prefix and the suffix shape rather than the exact duration.
+	visible := func(line string) string {
+		parts := strings.Split(line, "\r")
+		return strings.TrimSuffix(parts[len(parts)-1], "\x1b[K")
+	}
+	wantPrefixes := []string{
+		"Preparing push (sync state, metadata, fingerprints)...",
+		"Preparing... 1000/1000 sessions fingerprinted",
+		"Pushing... 1/9 sessions, 5 messages",
+		"Pushing vectors... 1/2 sessions scanned, 3 chunks",
+	}
+	for i, want := range wantPrefixes {
+		got := visible(lines[i])
+		assert.True(t, strings.HasPrefix(got, want),
+			"line %d: %q must start with %q", i, got, want)
+		assert.Regexp(t, ` \([0-9a-z.]+ elapsed\)$`, got,
+			"line %d must end with an elapsed suffix", i)
 	}
 }

--- a/cmd/agentsview/pg_vector_search.go
+++ b/cmd/agentsview/pg_vector_search.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	kitvec "go.kenn.io/kit/vector"
+
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/postgres"
+)
+
+// resolvePGServeVectorState classifies the startup gate into (wire, reason).
+// It is the pure core of wirePGVectorSearch, split out so the decision
+// logic is unit-testable without a PostgreSQL connection.
+//
+// Cases:
+//   - vector disabled: (false, "") — a plain 501 with no custom reason.
+//   - enabled and the local config's fingerprint matches a PG generation:
+//     (true, "") — the caller wires the searcher.
+//   - enabled but no PG generation matches: (false, <reason>) — the caller
+//     records the reason so the search endpoint can explain the miss.
+//
+// foundFPs is the comma-joined list of fingerprints PG does have, surfaced so
+// an operator can see whether it is a "wrong config" or "never pushed" miss.
+func resolvePGServeVectorState(
+	vectorEnabled, genFound bool, wantFP, foundFPs string,
+) (bool, string) {
+	if !vectorEnabled {
+		return false, ""
+	}
+	if genFound {
+		return true, ""
+	}
+	reason := fmt.Sprintf(
+		"semantic search: PG has no embedding generation matching fingerprint "+
+			"%s (present: %s); run 'agentsview pg push' from a machine with a "+
+			"matching [vector.embeddings] config",
+		wantFP, foundFPs)
+	return false, reason
+}
+
+// wirePGVectorSearch attaches PG-backed semantic search to store when the
+// local [vector.embeddings] config's fingerprint matches a generation already
+// pushed to PostgreSQL. It is the shared startup gate for every PG read
+// surface: `pg serve` (which treats the returned error as fatal) and the CLI
+// direct-read path via wirePGReadVectorSearch (which warns and degrades).
+// label prefixes the log lines with the calling surface ("pg serve",
+// "pg read").
+//
+// A miss is never an error: a missing pgvector table, a fingerprint mismatch,
+// or an unbuilt query encoder each leave semantic search unavailable (a
+// recorded reason surfaced through db.ErrSemanticUnavailable) rather than
+// failing construction. It returns an error only for a genuinely unexpected
+// query failure; the caller decides whether that is fatal.
+//
+// No per-query staleness gate is needed here: a PG generation is keyed by its
+// immutable fingerprint, so a startup match cannot go stale while the process
+// runs. Changing the local embeddings config changes the fingerprint, which
+// requires restarting the serve (or re-running the CLI command), and that
+// restart re-runs this gate.
+func wirePGVectorSearch(
+	ctx context.Context, appCfg config.Config, store *postgres.Store, label string,
+) error {
+	if !appCfg.Vector.Enabled {
+		return nil
+	}
+	gen := vectorGeneration(appCfg.Vector.Embeddings)
+	wantFP := gen.Fingerprint()
+	genID, dim, ok, err := postgres.LookupVectorGeneration(ctx, store.DB(), wantFP)
+	if err != nil {
+		return fmt.Errorf("looking up PG vector generation: %w", err)
+	}
+	if !ok {
+		present, err := postgres.ListVectorGenerationFingerprints(ctx, store.DB())
+		if err != nil {
+			log.Printf("%s: listing vector generations: %v", label, err)
+		}
+		_, reason := resolvePGServeVectorState(
+			true, false, wantFP, strings.Join(present, ", "))
+		store.SetSemanticUnavailableReason(reason)
+		log.Printf("%s: %s", label, reason)
+		return nil
+	}
+
+	// A generation row without its chunk table (a push interrupted between
+	// registering the generation and creating the table) must degrade like a
+	// fingerprint miss, not fail every query with a missing-relation error.
+	tableOK, err := postgres.VectorChunkTableExists(ctx, store.DB(), genID)
+	if err != nil {
+		return fmt.Errorf("probing PG vector chunk table: %w", err)
+	}
+	if !tableOK {
+		reason := fmt.Sprintf(
+			"semantic search: PG generation %d matches fingerprint %s but its "+
+				"chunk table is missing (interrupted push?); re-run "+
+				"'agentsview pg push' from a machine with a matching "+
+				"[vector.embeddings] config", genID, wantFP)
+		store.SetSemanticUnavailableReason(reason)
+		log.Printf("%s: %s", label, reason)
+		return nil
+	}
+
+	enc, err := newVectorEncoder(appCfg.Vector.Embeddings, "")
+	if err != nil {
+		return fmt.Errorf("building query encoder: %w", err)
+	}
+	encodeQuery := func(ctx context.Context, text string) ([]float32, error) {
+		vecs, err := kitvec.EncodeBatched(ctx, enc,
+			[]kitvec.Chunk{{Index: 0, Text: text}}, kitvec.BatchOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return vecs[0], nil
+	}
+	store.SetVectorSearcher(postgres.NewVectorSearcher(
+		store.DB(), genID, dim, appCfg.Vector.Embeddings.MaxInputChars, encodeQuery))
+	log.Printf("%s: semantic search enabled (generation %d, model %s)",
+		label, genID, gen.Model)
+	return nil
+}
+
+// wirePGReadVectorSearchFn is newPGReadService's seam for the vector wiring
+// call, overridable in tests that inject fake stores through openPGReadStore.
+var wirePGReadVectorSearchFn = wirePGReadVectorSearch
+
+// wirePGReadVectorSearch runs the shared PG vector gate for the CLI
+// direct-read path (`session search --pg --semantic|--hybrid`, `mcp --pg`).
+// It mirrors installDirectVectorSearcher's error semantics on the SQLite
+// direct path: wiring failures never fail service construction — every --pg
+// read command shares this constructor, so a vector-side failure must not
+// break unrelated reads. A genuine query failure is logged as a warning and
+// the command continues with semantic search returning
+// db.ErrSemanticUnavailable; a fingerprint miss records its reason inside
+// wirePGVectorSearch. Stores that are not *postgres.Store (test fakes
+// injected via openPGReadStore) are left untouched.
+func wirePGReadVectorSearch(cfg config.Config, store db.Store) {
+	pgStore, ok := store.(*postgres.Store)
+	if !ok {
+		return
+	}
+	if err := wirePGVectorSearch(
+		context.Background(), cfg, pgStore, "pg read",
+	); err != nil {
+		log.Printf(
+			"warning: wiring PG semantic search: %v; "+
+				"continuing without semantic search", err,
+		)
+	}
+}

--- a/cmd/agentsview/pg_vector_search_test.go
+++ b/cmd/agentsview/pg_vector_search_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/dbtest"
+)
+
+func TestResolvePGServeVectorState(t *testing.T) {
+	tests := []struct {
+		name         string
+		enabled      bool
+		found        bool
+		wantFP       string
+		foundFPs     string
+		expectWire   bool
+		expectReason string
+	}{
+		{
+			name:         "vector disabled yields plain unavailable",
+			enabled:      false,
+			found:        false,
+			wantFP:       "abc123",
+			foundFPs:     "def456",
+			expectWire:   false,
+			expectReason: "",
+		},
+		{
+			name:         "enabled and generation found wires searcher",
+			enabled:      true,
+			found:        true,
+			wantFP:       "abc123",
+			foundFPs:     "abc123",
+			expectWire:   true,
+			expectReason: "",
+		},
+		{
+			name:       "enabled but no matching generation",
+			enabled:    true,
+			found:      false,
+			wantFP:     "abc123",
+			foundFPs:   "def456, ghi789",
+			expectWire: false,
+			expectReason: "semantic search: PG has no embedding generation matching " +
+				"fingerprint abc123 (present: def456, ghi789); run 'agentsview pg push' " +
+				"from a machine with a matching [vector.embeddings] config",
+		},
+		{
+			name:       "enabled but PG has no generations at all",
+			enabled:    true,
+			found:      false,
+			wantFP:     "abc123",
+			foundFPs:   "",
+			expectWire: false,
+			expectReason: "semantic search: PG has no embedding generation matching " +
+				"fingerprint abc123 (present: ); run 'agentsview pg push' " +
+				"from a machine with a matching [vector.embeddings] config",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wire, reason := resolvePGServeVectorState(
+				tt.enabled, tt.found, tt.wantFP, tt.foundFPs)
+			assert.Equal(t, tt.expectWire, wire)
+			assert.Equal(t, tt.expectReason, reason)
+		})
+	}
+}
+
+// TestNewPGReadServiceRunsVectorWiring proves the CLI direct-read constructor
+// (shared by `session search --pg` and `mcp --pg`) runs the PG vector gate on
+// the store it opened, with the caller's config — the parity counterpart of
+// the SQLite direct path's installDirectVectorSearcher call. Dropping the
+// wiring call from newPGReadService, or passing it a different store or
+// config, fails this test.
+func TestNewPGReadServiceRunsVectorWiring(t *testing.T) {
+	fakeStore := dbtest.OpenTestDBAt(t, filepath.Join(t.TempDir(), "pg.db"))
+	stubPGReadStore(t, fakeStore)
+
+	var gotCfg config.Config
+	var gotStore db.Store
+	calls := 0
+	orig := wirePGReadVectorSearchFn
+	wirePGReadVectorSearchFn = func(cfg config.Config, store db.Store) {
+		calls++
+		gotCfg = cfg
+		gotStore = store
+	}
+	t.Cleanup(func() { wirePGReadVectorSearchFn = orig })
+
+	cfg := config.Config{}
+	cfg.Vector.Enabled = true
+	svc, cleanup, err := newPGReadService(cfg, config.PGConfig{
+		URL:    "postgres://example.test/agentsview",
+		Schema: "agentsview",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, svc)
+	t.Cleanup(cleanup)
+
+	require.Equal(t, 1, calls, "vector wiring must run exactly once per service")
+	assert.Same(t, db.Store(fakeStore), gotStore,
+		"wiring must target the store the service serves reads from")
+	assert.True(t, gotCfg.Vector.Enabled,
+		"wiring must see the caller's vector config")
+}
+
+// TestWirePGReadVectorSearchIgnoresNonPGStore covers the CLI wiring guard for
+// stores that are not *postgres.Store: tests stub openPGReadStore with a
+// SQLite-backed fake, so the guard must leave such stores untouched instead
+// of panicking on the type assertion.
+func TestWirePGReadVectorSearchIgnoresNonPGStore(t *testing.T) {
+	fakeStore := dbtest.OpenTestDBAt(t, filepath.Join(t.TempDir(), "pg.db"))
+	cfg := config.Config{}
+	cfg.Vector.Enabled = true
+
+	require.NotPanics(t, func() {
+		wirePGReadVectorSearch(cfg, fakeStore)
+	})
+}

--- a/cmd/agentsview/pg_vectors.go
+++ b/cmd/agentsview/pg_vectors.go
@@ -1,0 +1,171 @@
+// ABOUTME: `pg vectors` command group — list and drop PostgreSQL semantic
+// ABOUTME: search vector generations for maintenance and cleanup.
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/postgres"
+)
+
+func newPGVectorsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "vectors",
+		Short:        "Inspect and drop PostgreSQL vector generations",
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(newPGVectorsListCommand())
+	cmd.AddCommand(newPGVectorsDropCommand())
+	return cmd
+}
+
+func newPGVectorsListCommand() *cobra.Command {
+	var targetName string
+	cmd := &cobra.Command{
+		Use:          "list",
+		Short:        "List PostgreSQL vector generations",
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := runPGVectorsList(cmd.OutOrStdout(), targetName); err != nil {
+				return fmt.Errorf("pg vectors list: %w", err)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "",
+		"PG target name (default: the default configured target)")
+	return cmd
+}
+
+func newPGVectorsDropCommand() *cobra.Command {
+	var targetName string
+	var yes bool
+	cmd := &cobra.Command{
+		Use:          "drop <id>",
+		Short:        "Drop a PostgreSQL vector generation and its embeddings",
+		SilenceUsage: true,
+		Args:         cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id, err := parseGenerationID(args[0])
+			if err != nil {
+				return err
+			}
+			if err := runPGVectorsDrop(
+				cmd.InOrStdin(), cmd.OutOrStdout(), targetName, id, yes,
+			); err != nil {
+				return fmt.Errorf("pg vectors drop: %w", err)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "",
+		"PG target name (default: the default configured target)")
+	cmd.Flags().BoolVar(&yes, "yes", false, "Skip confirmation prompt")
+	return cmd
+}
+
+// openPGVectorTarget resolves a single PG target the same way `pg status` does
+// (resolvePGTargetSelections + postgres.Open, no --all), opening a connection
+// to it. The returned cleanup closes the pool.
+func openPGVectorTarget(targetName string) (*sql.DB, func(), error) {
+	appCfg, err := config.LoadMinimal()
+	if err != nil {
+		return nil, nil, fmt.Errorf("loading config: %w", err)
+	}
+	if err := os.MkdirAll(appCfg.DataDir, 0o755); err != nil {
+		return nil, nil, fmt.Errorf("creating data dir: %w", err)
+	}
+	setupLogFile(appCfg.DataDir)
+
+	targets, err := resolvePGTargetSelections(appCfg, targetName, false)
+	if err != nil {
+		return nil, nil, err
+	}
+	target, err := resolvePGTargetConfig(appCfg, targets[0])
+	if err != nil {
+		return nil, nil, err
+	}
+	if target.PG.URL == "" {
+		return nil, nil, fmt.Errorf("url not configured")
+	}
+	applyClassifierConfig(appCfg)
+	pg, err := postgres.Open(
+		target.PG.URL, target.PG.Schema, target.PG.AllowInsecure,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	return pg, func() { _ = pg.Close() }, nil
+}
+
+func runPGVectorsList(out io.Writer, targetName string) error {
+	pg, cleanup, err := openPGVectorTarget(targetName)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	gens, err := postgres.ListVectorGenerations(context.Background(), pg)
+	if err != nil {
+		return err
+	}
+	printPGVectorGenerations(out, gens)
+	return nil
+}
+
+// printPGVectorGenerations renders generations as a tabwriter table, matching
+// the column layout of the other CLI list commands. An empty set prints just
+// the header row.
+func printPGVectorGenerations(out io.Writer, gens []postgres.VectorGenerationRow) {
+	tw := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
+	fmt.Fprintln(tw, "ID\tMODEL\tDIM\tDOCS\tCHUNKS\tMACHINES\tCREATED")
+	for _, g := range gens {
+		machines := strings.Join(g.Machines, ",")
+		if machines == "" {
+			machines = "-"
+		}
+		fmt.Fprintf(tw, "%d\t%s\t%d\t%d\t%d\t%s\t%s\n",
+			g.ID, g.Model, g.Dimension, g.Docs, g.Chunks,
+			machines, g.CreatedAt.UTC().Format(time.RFC3339))
+	}
+	_ = tw.Flush()
+}
+
+func runPGVectorsDrop(
+	in io.Reader, out io.Writer, targetName string, id int64, yes bool,
+) error {
+	pg, cleanup, err := openPGVectorTarget(targetName)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	if !yes {
+		msg := fmt.Sprintf(
+			"Drop vector generation %d and all of its embeddings?", id)
+		if !confirm(in, out, msg) {
+			fmt.Fprintln(out, "Aborted.")
+			return nil
+		}
+	}
+	if err := postgres.DropVectorGeneration(context.Background(), pg, id); err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "Dropped vector generation %d.\n", id)
+	return nil
+}

--- a/cmd/agentsview/transport.go
+++ b/cmd/agentsview/transport.go
@@ -490,7 +490,10 @@ func directIncompatibleDaemonError(tr transport) error {
 // newPGReadService builds a read-only SessionService over the
 // configured PostgreSQL sync store. It shares the same store
 // construction path as pg serve, but leaves schema repair/migration
-// to pg push/serve because CLI read commands never mutate PG.
+// to pg push/serve because CLI read commands never mutate PG. Like
+// pg serve, it runs the PG vector gate so `session search --pg
+// --semantic|--hybrid` and `mcp --pg` get the same semantic search
+// the SQLite direct path wires via installDirectVectorSearcher.
 func newPGReadService(
 	cfg config.Config, pgCfg config.PGConfig,
 ) (service.SessionService, func(), error) {
@@ -506,5 +509,6 @@ func newPGReadService(
 			priced.SetCustomPricing(cfg.CustomModelPricing)
 		}
 	}
+	wirePGReadVectorSearchFn(cfg, store)
 	return service.NewReadOnlyBackend(store), cleanup, nil
 }

--- a/cmd/agentsview/vector_push_source.go
+++ b/cmd/agentsview/vector_push_source.go
@@ -5,6 +5,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
+	"log"
 	"os"
 	"sync"
 
@@ -23,10 +25,10 @@ import (
 // snapshotted ordinal, so a build that activates mid-push cannot pair this
 // generation's fingerprint with a newer generation's docs; the next Generation
 // call refreshes the snapshot, keeping successive daemon pushes current. The
-// read-only handle stays open for the adapter's lifetime — the CLI path is
-// short-lived and the daemon reuses one adapter until process exit; Close
-// releases it explicitly (tests need that on Windows, where an open sqlite
-// file cannot be deleted).
+// read-only handle stays open for the adapter's lifetime; the creator owns
+// that lifetime and must release it via closeVectorPushSource — per push in
+// PGPush, at loop exit in the watch path (which reuses one adapter across
+// reconnects) — since postgres.Sync never closes its source.
 type vectorPushSource struct {
 	cfg config.Config
 
@@ -47,6 +49,22 @@ func newVectorPushSource(appCfg config.Config) postgres.VectorPushSource {
 		return nil
 	}
 	return &vectorPushSource{cfg: appCfg}
+}
+
+// closeVectorPushSource releases a push source's memoized read-only
+// vectors.db handle. postgres.Sync never closes its source — the creator
+// owns the handle's lifetime — so every call site that builds a source must
+// close it when the push (or watch loop) is done, or repeated pushes leak
+// one SQLite handle each. Safe on a nil source and on sources holding no
+// handle.
+func closeVectorPushSource(src postgres.VectorPushSource) {
+	c, ok := src.(io.Closer)
+	if !ok {
+		return
+	}
+	if err := c.Close(); err != nil {
+		log.Printf("closing vectors.db push source: %v", err)
+	}
 }
 
 // openIndex opens vectors.db read-only and memoizes only a successful open. A

--- a/cmd/agentsview/vector_push_source.go
+++ b/cmd/agentsview/vector_push_source.go
@@ -1,0 +1,231 @@
+// ABOUTME: pg push adapter exposing the local vectors.db active generation
+// ABOUTME: to internal/postgres as a lazily-opened read-only VectorPushSource.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/postgres"
+	"go.kenn.io/agentsview/internal/vector"
+)
+
+// vectorPushSource adapts a read-only vector.Index to
+// postgres.VectorPushSource, opening vectors.db lazily so a pg push whose
+// target has vectors disabled never touches the file. Only a successful open is
+// memoized so the three interface methods of one push share one connection; a
+// missing file or open failure is never cached, so a daemon push that starts
+// before embeddings exist picks up a build that lands afterward. Generation
+// snapshots the active generation and SessionDocHashes/SessionDocs read the
+// snapshotted ordinal, so a build that activates mid-push cannot pair this
+// generation's fingerprint with a newer generation's docs; the next Generation
+// call refreshes the snapshot, keeping successive daemon pushes current. The
+// read-only handle stays open for the adapter's lifetime — the CLI path is
+// short-lived and the daemon reuses one adapter until process exit; Close
+// releases it explicitly (tests need that on Windows, where an open sqlite
+// file cannot be deleted).
+type vectorPushSource struct {
+	cfg config.Config
+
+	mu sync.Mutex
+	ix *vector.Index
+
+	// snap/snapOK hold the active generation captured by the most recent
+	// Generation call; SessionDocHashes and SessionDocs read snap.Ordinal.
+	snap   vector.ActiveExport
+	snapOK bool
+}
+
+// newVectorPushSource returns a lazy vectors.db push adapter, or nil when
+// [vector] is disabled: there is then no vectors.db to open and nothing to
+// push, and a nil source leaves postgres.Sync's vector phase skipped.
+func newVectorPushSource(appCfg config.Config) postgres.VectorPushSource {
+	if !appCfg.Vector.Enabled {
+		return nil
+	}
+	return &vectorPushSource{cfg: appCfg}
+}
+
+// openIndex opens vectors.db read-only and memoizes only a successful open. A
+// missing file (no build yet) and any open failure are NOT cached, so a later
+// call — a daemon push that starts before embeddings exist — reopens and picks
+// up a build that lands afterward. A nil index without error means the file is
+// absent ("nothing to push"); the pointer's own nil checks gate every
+// dereference.
+func (s *vectorPushSource) openIndex(ctx context.Context) (*vector.Index, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.ix != nil {
+		return s.ix, nil
+	}
+	path := s.cfg.Vector.ResolvedDBPath(s.cfg.DataDir)
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("stat vectors.db: %w", err)
+	}
+	ix, err := vector.Open(ctx, path, true, s.cfg.Vector.Embeddings.MaxInputChars)
+	if err != nil {
+		return nil, fmt.Errorf("opening vectors.db: %w", err)
+	}
+	s.ix = ix
+	return ix, nil
+}
+
+// Close releases the memoized read-only vectors.db handle, if one was opened.
+// Safe to call multiple times; a later interface call reopens the file via
+// openIndex's uncached-miss path.
+func (s *vectorPushSource) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.ix == nil {
+		return nil
+	}
+	err := s.ix.Close()
+	s.ix = nil
+	return err
+}
+
+// setSnapshot records the active generation captured by Generation.
+func (s *vectorPushSource) setSnapshot(exp vector.ActiveExport, ok bool) {
+	s.mu.Lock()
+	s.snap, s.snapOK = exp, ok
+	s.mu.Unlock()
+}
+
+// snapshot returns the active generation captured by the most recent
+// Generation call, and whether one is set.
+func (s *vectorPushSource) snapshot() (vector.ActiveExport, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.snap, s.snapOK
+}
+
+// Generation implements postgres.VectorPushSource and snapshots the active
+// generation for the rest of the push. Contract: Generation must be called
+// before SessionDocHashes and SessionDocs, which read the snapshotted ordinal;
+// the postgres push (pushVectors) calls Generation once first, then again as
+// the pre-eviction safety re-check. Snapshotting here means a build that
+// activates mid-push cannot mix this generation's fingerprint with a newer
+// generation's docs, while the next Generation call refreshes the snapshot so
+// successive pushes stay current.
+//
+// A generation with missing embeddings is refused with an error wrapping
+// postgres.ErrVectorSourceNotReady rather than exported: the mirror only
+// changes during builds, so missing coverage means a build is rewriting the
+// generation right now (a same-fingerprint full rebuild clears and refills it
+// in place) or one was interrupted. Exporting that partial view would evict
+// or overwrite valid PG vectors; the push after the build completes sends
+// everything that changed.
+func (s *vectorPushSource) Generation(
+	ctx context.Context,
+) (postgres.VectorGenerationInfo, bool, error) {
+	ix, err := s.openIndex(ctx)
+	if err != nil || ix == nil {
+		s.setSnapshot(vector.ActiveExport{}, false)
+		return postgres.VectorGenerationInfo{}, false, err
+	}
+	exp, ok, err := ix.ActiveExport(ctx)
+	if err != nil {
+		s.setSnapshot(vector.ActiveExport{}, false)
+		return postgres.VectorGenerationInfo{}, false,
+			fmt.Errorf("reading active generation: %w", err)
+	}
+	if !ok {
+		s.setSnapshot(vector.ActiveExport{}, false)
+		return postgres.VectorGenerationInfo{}, false, nil
+	}
+	info, err := ix.GenerationByID(ctx, exp.Ordinal)
+	if err != nil {
+		s.setSnapshot(vector.ActiveExport{}, false)
+		return postgres.VectorGenerationInfo{}, false,
+			fmt.Errorf("reading active generation coverage: %w", err)
+	}
+	if info.Missing > 0 {
+		s.setSnapshot(vector.ActiveExport{}, false)
+		return postgres.VectorGenerationInfo{}, false, fmt.Errorf(
+			"%w: %d document(s) pending",
+			postgres.ErrVectorSourceNotReady, info.Missing)
+	}
+	s.setSnapshot(exp, true)
+	return postgres.VectorGenerationInfo{
+		Fingerprint: exp.Fingerprint,
+		Model:       exp.Model,
+		Dimension:   exp.Dimension,
+	}, true, nil
+}
+
+// SessionDocHashes implements postgres.VectorPushSource, reading the ordinal
+// snapshotted by Generation. An absent file or no active snapshot yields an
+// empty (non-nil) map: no local sessions, so the push evicts any PG state this
+// pusher previously owned.
+func (s *vectorPushSource) SessionDocHashes(
+	ctx context.Context,
+) (map[string]string, error) {
+	ix, err := s.openIndex(ctx)
+	if err != nil {
+		return nil, err
+	}
+	exp, ok := s.snapshot()
+	if ix == nil || !ok {
+		return map[string]string{}, nil
+	}
+	return ix.SessionEmbeddedDocHashes(ctx, exp.Ordinal)
+}
+
+// SessionDocs implements postgres.VectorPushSource, exporting one session's
+// docs at the ordinal snapshotted by Generation and mapping each mirror doc and
+// its chunk vectors field-by-field onto the push types. The returned hash is
+// the aggregate of exactly the exported doc set, computed inside the export's
+// own read snapshot; the push defers the session when it no longer matches the
+// delta-scan hash.
+func (s *vectorPushSource) SessionDocs(
+	ctx context.Context, sessionID string,
+) ([]postgres.VectorPushDoc, string, error) {
+	ix, err := s.openIndex(ctx)
+	if err != nil {
+		return nil, "", err
+	}
+	exp, ok := s.snapshot()
+	if ix == nil || !ok {
+		return nil, "", nil
+	}
+	docs, aggHash, err := ix.ExportSessionDocs(ctx, exp.Ordinal, sessionID)
+	if err != nil {
+		return nil, "", err
+	}
+	return convertVectorPushDocs(docs), aggHash, nil
+}
+
+// convertVectorPushDocs copies exported mirror docs onto the backend-agnostic
+// push types. It is a mechanical field-by-field copy, isolated here so the
+// mapping is testable against the raw export API.
+func convertVectorPushDocs(docs []vector.ExportDoc) []postgres.VectorPushDoc {
+	out := make([]postgres.VectorPushDoc, len(docs))
+	for i, d := range docs {
+		chunks := make([]postgres.VectorPushChunk, len(d.Chunks))
+		for j, c := range d.Chunks {
+			chunks[j] = postgres.VectorPushChunk{
+				ChunkIndex: c.ChunkIndex,
+				Embedding:  c.Embedding,
+			}
+		}
+		out[i] = postgres.VectorPushDoc{
+			DocKey:      d.DocKey,
+			SessionID:   d.SessionID,
+			SourceUUID:  d.SourceUUID,
+			Ordinal:     d.Ordinal,
+			OrdinalEnd:  d.OrdinalEnd,
+			Subordinate: d.Subordinate,
+			OffsetsJSON: d.OffsetsJSON,
+			Content:     d.Content,
+			ContentHash: d.ContentHash,
+			Chunks:      chunks,
+		}
+	}
+	return out
+}

--- a/cmd/agentsview/vector_push_source_test.go
+++ b/cmd/agentsview/vector_push_source_test.go
@@ -1,0 +1,252 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	kitvec "go.kenn.io/kit/vector"
+
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/postgres"
+	"go.kenn.io/agentsview/internal/vector"
+)
+
+// enabledVectorConfig returns a minimal Config with [vector] enabled and a
+// fresh DataDir, so the push source resolves a vectors.db path under a temp
+// dir that no other test touches.
+func enabledVectorConfig(t *testing.T) config.Config {
+	t.Helper()
+	return config.Config{
+		DataDir: t.TempDir(),
+		Vector: config.VectorConfig{
+			Enabled: true,
+			Embeddings: config.VectorEmbeddingsConfig{
+				Model:         "fake-model",
+				Dimension:     4,
+				MaxInputChars: 8192,
+			},
+		},
+	}
+}
+
+// fakePushUnitSource is a vector.UnitSource that replays a fixed slice of
+// units, enough to build a tiny active generation for the round-trip test.
+type fakePushUnitSource struct {
+	units []db.EmbeddableUnit
+}
+
+func (f fakePushUnitSource) ScanEmbeddableUnits(
+	_ context.Context, _ string, _ bool, fn func(db.EmbeddableUnit) error,
+) (string, error) {
+	for _, u := range f.units {
+		if err := fn(u); err != nil {
+			return "", err
+		}
+	}
+	return "2024-01-01T00:00:03Z", nil
+}
+
+// fakePushEncoder returns a deterministic 4-dimensional encoder matching the
+// gen dimension the round-trip test builds with.
+func fakePushEncoder() kitvec.EncodeFunc {
+	return func(_ context.Context, texts []string) ([][]float32, error) {
+		out := make([][]float32, len(texts))
+		for i := range texts {
+			out[i] = []float32{1, 0, 0, 0}
+		}
+		return out, nil
+	}
+}
+
+// testPushUnitSource returns the fixed unit set the push-source tests build
+// their vectors.db from: two sessions, three documents.
+func testPushUnitSource() fakePushUnitSource {
+	return fakePushUnitSource{units: []db.EmbeddableUnit{
+		{SessionID: "session-1", Kind: "user", SourceUUID: "u1", Content: "hello"},
+		{
+			SessionID: "session-1", Kind: "run", SourceUUID: "a1",
+			Ordinal: 1, OrdinalEnd: 2, Content: "first\n\nsecond",
+			Offsets: []db.UnitOffset{{Ordinal: 1}, {Ordinal: 2, RuneStart: 7, ByteStart: 7}},
+		},
+		{SessionID: "session-2", Kind: "user", SourceUUID: "u2", Content: "world"},
+	}}
+}
+
+// buildTestVectorsDB opens a read-write index at cfg's resolved vectors.db
+// path, builds and activates one generation over two sessions, then closes
+// it so the push source can reopen the file read-only.
+func buildTestVectorsDB(t *testing.T, cfg config.Config) {
+	t.Helper()
+	ctx := context.Background()
+	ix, err := vector.Open(
+		ctx, cfg.Vector.ResolvedDBPath(cfg.DataDir), false,
+		cfg.Vector.Embeddings.MaxInputChars,
+	)
+	require.NoError(t, err)
+	defer ix.Close()
+
+	gen := kitvec.Generation{Model: "fake-model", Dimensions: 4}
+	result, err := ix.Build(
+		ctx, testPushUnitSource(), fakePushEncoder(), gen, vector.BuildOptions{},
+	)
+	require.NoError(t, err)
+	require.True(t, result.Activated)
+}
+
+// closePushSource registers a cleanup that closes the adapter's vectors.db
+// handle. Required on Windows, where TempDir removal fails while the sqlite
+// file is still open.
+func closePushSource(t *testing.T, src postgres.VectorPushSource) {
+	t.Helper()
+	t.Cleanup(func() {
+		require.NoError(t, src.(*vectorPushSource).Close())
+	})
+}
+
+func TestNewVectorPushSourceDisabled(t *testing.T) {
+	cfg := config.Config{} // [vector] disabled
+	assert.Nil(t, newVectorPushSource(cfg))
+}
+
+func TestVectorPushSourceMissingFile(t *testing.T) {
+	cfg := enabledVectorConfig(t)
+	src := newVectorPushSource(cfg)
+	require.NotNil(t, src)
+	closePushSource(t, src)
+
+	_, ok, err := src.Generation(context.Background())
+	require.NoError(t, err)
+	assert.False(t, ok) // no vectors.db yet -> nothing to push, not an error
+}
+
+// TestVectorPushSourceMissingFileThenBuilt pins that a missing vectors.db is
+// not memoized: the SAME adapter reports "nothing to push" before any build and
+// then picks up a generation built at the same path afterward, as a daemon push
+// that starts before embeddings exist must.
+func TestVectorPushSourceMissingFileThenBuilt(t *testing.T) {
+	ctx := context.Background()
+	cfg := enabledVectorConfig(t)
+	src := newVectorPushSource(cfg)
+	require.NotNil(t, src)
+	closePushSource(t, src)
+
+	_, ok, err := src.Generation(ctx)
+	require.NoError(t, err)
+	require.False(t, ok, "no vectors.db yet -> nothing to push")
+
+	buildTestVectorsDB(t, cfg)
+
+	gen, ok, err := src.Generation(ctx)
+	require.NoError(t, err)
+	require.True(t, ok, "same adapter must pick up a later build")
+	assert.Equal(t, "fake-model", gen.Model)
+
+	hashes, err := src.SessionDocHashes(ctx)
+	require.NoError(t, err)
+	assert.Len(t, hashes, 2)
+}
+
+// TestVectorPushSourceNotReadyDuringRebuild pins the partial-coverage gate: a
+// full rebuild clears the active generation's stamps in place before
+// re-embedding, so an aborted (or still running) rebuild leaves the active
+// generation with missing embeddings. Exporting that view would evict valid
+// PG vectors, so Generation must refuse with ErrVectorSourceNotReady until a
+// build completes.
+func TestVectorPushSourceNotReadyDuringRebuild(t *testing.T) {
+	ctx := context.Background()
+	cfg := enabledVectorConfig(t)
+	buildTestVectorsDB(t, cfg)
+
+	// Start a full rebuild whose encoder fails: resetGeneration has already
+	// cleared the active generation's stamps, so coverage is now partial —
+	// exactly the state a concurrent push would observe mid-rebuild.
+	ix, err := vector.Open(
+		ctx, cfg.Vector.ResolvedDBPath(cfg.DataDir), false,
+		cfg.Vector.Embeddings.MaxInputChars,
+	)
+	require.NoError(t, err)
+	failingEncoder := func(_ context.Context, _ []string) ([][]float32, error) {
+		return nil, errors.New("embeddings endpoint down")
+	}
+	_, err = ix.Build(ctx, testPushUnitSource(), failingEncoder,
+		kitvec.Generation{Model: "fake-model", Dimensions: 4},
+		vector.BuildOptions{FullRebuild: true},
+	)
+	require.Error(t, err, "rebuild must abort on encoder failure")
+	require.NoError(t, ix.Close())
+
+	src := newVectorPushSource(cfg)
+	require.NotNil(t, src)
+	closePushSource(t, src)
+
+	_, ok, err := src.Generation(ctx)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, postgres.ErrVectorSourceNotReady)
+	assert.False(t, ok)
+}
+
+func TestVectorPushSourceRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	cfg := enabledVectorConfig(t)
+	buildTestVectorsDB(t, cfg)
+
+	src := newVectorPushSource(cfg)
+	require.NotNil(t, src)
+	closePushSource(t, src)
+
+	gen, ok, err := src.Generation(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.NotEmpty(t, gen.Fingerprint)
+	assert.Equal(t, "fake-model", gen.Model)
+	assert.Equal(t, 4, gen.Dimension)
+
+	hashes, err := src.SessionDocHashes(ctx)
+	require.NoError(t, err)
+	require.Len(t, hashes, 2)
+	assert.Contains(t, hashes, "session-1")
+	assert.Contains(t, hashes, "session-2")
+
+	// Cross-check the adapter's mapping against the raw export API: every
+	// VectorPushDoc field must mirror its ExportDoc source exactly.
+	ix, err := vector.Open(
+		ctx, cfg.Vector.ResolvedDBPath(cfg.DataDir), true,
+		cfg.Vector.Embeddings.MaxInputChars,
+	)
+	require.NoError(t, err)
+	defer ix.Close()
+	exp, ok, err := ix.ActiveExport(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	want, wantHash, err := ix.ExportSessionDocs(ctx, exp.Ordinal, "session-1")
+	require.NoError(t, err)
+	require.NotEmpty(t, want)
+	assert.Equal(t, hashes["session-1"], wantHash,
+		"export hash must match the delta-scan aggregate for an unchanged index")
+
+	docs, gotHash, err := src.SessionDocs(ctx, "session-1")
+	require.NoError(t, err)
+	assert.Equal(t, wantHash, gotHash)
+	require.Len(t, docs, len(want))
+	for i, got := range docs {
+		w := want[i]
+		assert.Equal(t, w.DocKey, got.DocKey)
+		assert.Equal(t, w.SessionID, got.SessionID)
+		assert.Equal(t, w.SourceUUID, got.SourceUUID)
+		assert.Equal(t, w.Ordinal, got.Ordinal)
+		assert.Equal(t, w.OrdinalEnd, got.OrdinalEnd)
+		assert.Equal(t, w.Subordinate, got.Subordinate)
+		assert.Equal(t, w.OffsetsJSON, got.OffsetsJSON)
+		assert.Equal(t, w.Content, got.Content)
+		assert.Equal(t, w.ContentHash, got.ContentHash)
+		require.Len(t, got.Chunks, len(w.Chunks))
+		for j, gc := range got.Chunks {
+			assert.Equal(t, w.Chunks[j].ChunkIndex, gc.ChunkIndex)
+			assert.Equal(t, w.Chunks[j].Embedding, gc.Embedding)
+		}
+	}
+}

--- a/cmd/agentsview/vector_push_source_test.go
+++ b/cmd/agentsview/vector_push_source_test.go
@@ -250,3 +250,32 @@ func TestVectorPushSourceRoundTrip(t *testing.T) {
 		}
 	}
 }
+
+// TestCloseVectorPushSource pins the creator-owned handle lifecycle: closing
+// releases the memoized read-only vectors.db handle (so per-push and
+// per-watch-loop sources do not leak SQLite handles), a nil source is a
+// no-op, and a closed adapter transparently reopens on the next call.
+func TestCloseVectorPushSource(t *testing.T) {
+	closeVectorPushSource(nil) // must not panic
+
+	cfg := enabledVectorConfig(t)
+	buildTestVectorsDB(t, cfg)
+	src := newVectorPushSource(cfg)
+	require.NotNil(t, src)
+
+	ctx := context.Background()
+	_, ok, err := src.Generation(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	adapter := src.(*vectorPushSource)
+	require.NotNil(t, adapter.ix, "Generation memoizes the open handle")
+
+	closeVectorPushSource(src)
+	assert.Nil(t, adapter.ix, "close releases the memoized handle")
+	closeVectorPushSource(src) // idempotent
+
+	_, ok, err = src.Generation(ctx)
+	require.NoError(t, err)
+	assert.True(t, ok, "a closed adapter reopens lazily")
+	closePushSource(t, src)
+}

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -5,7 +5,7 @@
 
 services:
   postgres:
-    image: postgres:16-alpine
+    image: pgvector/pgvector:pg16
     environment:
       POSTGRES_USER: agentsview_test
       POSTGRES_PASSWORD: agentsview_test_password

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -466,6 +466,7 @@ agentsview pg push [target] [flags]
 | Flag                 | Default | Description                                                    |
 | -------------------- | ------- | -------------------------------------------------------------- |
 | `--full`             | `false` | Force full local resync and re-push                            |
+| `--no-vectors`       | `false` | Skip the semantic-search vector phase for this run             |
 | `--projects`         |         | Comma-separated projects to push (inclusive)                   |
 | `--exclude-projects` |         | Comma-separated projects to exclude from push                  |
 | `--all-projects`     | `false` | Ignore configured project filters for this run                 |
@@ -506,7 +507,10 @@ agentsview pg serve [flags]
 ```
 
 Accepts the same serve flags (`--host`, `--port`, `--proxy`, etc.) plus
-PostgreSQL configuration from `config.toml`.
+PostgreSQL configuration from `config.toml`. When the host's `[vector]` config
+matches a generation pushed to PostgreSQL, semantic and hybrid search are served
+from pgvector — see
+[Semantic Search — PostgreSQL](/semantic-search/#postgresql).
 
 ______________________________________________________________________
 
@@ -535,6 +539,28 @@ agentsview pg service uninstall
 | `start`     | Start the installed service                               |
 | `stop`      | Stop the installed service                                |
 | `uninstall` | Stop and remove the service unit                          |
+
+______________________________________________________________________
+
+### `agentsview pg vectors`
+
+Inspect and drop semantic-search embedding generations stored in PostgreSQL.
+See [Semantic Search — Maintenance](/semantic-search/#maintenance) for details.
+
+```bash
+agentsview pg vectors list [flags]
+agentsview pg vectors drop <id> [flags]
+```
+
+| Command     | Description                                                                              |
+| ----------- | ---------------------------------------------------------------------------------------- |
+| `list`      | List generations with model, dimension, document/chunk counts, and contributing machines |
+| `drop <id>` | Drop a generation and all of its embeddings (prompts for confirmation)                   |
+
+| Flag       | Default | Description                                          |
+| ---------- | ------- | ---------------------------------------------------- |
+| `--target` |         | PG target name (default: the default configured target) |
+| `--yes`    | `false` | Skip the confirmation prompt (`drop` only)           |
 
 ______________________________________________________________________
 

--- a/docs/pg-sync.md
+++ b/docs/pg-sync.md
@@ -84,6 +84,7 @@ agentsview pg push [target] [flags]
 |------|---------|-------------|
 | `--all` | `false` | Push every configured PG target sequentially |
 | `--full` | `false` | Force full local resync and re-push, bypassing change detection |
+| `--no-vectors` | `false` | Skip the semantic-search vector phase for this run |
 | `--projects` | | Comma-separated projects to push (inclusive) |
 | `--exclude-projects` | | Comma-separated projects to exclude |
 | `--all-projects` | `false` | Ignore configured project filters for this run |
@@ -226,6 +227,23 @@ guarantees as session content (`secret_findings` table,
 per-session `secret_leak_count`, and the
 [`has-secret`](/session-api/#agentsview-session-list) list
 filter).
+
+#### Vector Push
+
+When `[vector]` is enabled locally, `pg push` runs a vector phase
+after the session and message phases, copying the machine's
+active embedding generation from `vectors.db` into pgvector so a
+shared PostgreSQL deployment can answer `--semantic`/`--hybrid`.
+Only changed sessions are re-sent. Skip the phase for one run
+with `--no-vectors`, or disable it persistently with
+`push_vectors = false` under `[pg]`. Databases without pgvector
+(for example CockroachDB) skip the phase and keep syncing session
+content. See
+[semantic search: PostgreSQL](/semantic-search/#postgresql) for
+the full push, serve, and maintenance workflow.
+
+`pg vectors list` and `pg vectors drop <id>` inspect and remove
+pushed generations.
 
 ### `agentsview pg status`
 

--- a/docs/semantic-search-internals.md
+++ b/docs/semantic-search-internals.md
@@ -557,6 +557,21 @@ covers the invariants.
   rows another generation still references (they stay at non-negative,
   hydratable ordinals), because an evicted session may merely have left this
   pusher's project filter while its docs still exist locally.
+- **Changed documents leave older generations' chunks in place — by design.**
+  `vector_documents` is shared across generations while chunk tables are
+  per-generation, mirroring the local mirror + per-generation vec0 layout.
+  When content changes, the pusher re-embeds only its active generation, so
+  another generation's chunks for the same doc now pair an older embedding
+  with the current shared metadata. This is a deliberate staleness trade-off,
+  not a race: deleting those chunks would permanently blind readers still on
+  that generation (only a pusher running that embedding config can rebuild
+  them, and per-generation `vector_push_state` means such a pusher's next push
+  re-sends exactly the changed docs). The skew is bounded to ranking —
+  hydration always reads the current shared row, and anchor/snippet resolution
+  clamps a stale chunk index (`vector.DocAnchor`): a hit anchors to a real
+  current member and snippets that member's own text, never another member's
+  and never a panic. Vanished docs are the opposite case and DO cascade across
+  every generation, per the previous bullet.
 - **Eviction is scoped by push ownership, not machine names.** Deletions apply
   only to sessions this pusher owns per its owner marker, because machine
   names are aliasable. Both the per-session push transaction and each eviction

--- a/docs/semantic-search-internals.md
+++ b/docs/semantic-search-internals.md
@@ -28,15 +28,15 @@ special-casing during the swap instead of a plain re-scan afterward.
 
 ### Embedding stores and `IndexSpec`
 
-`vectors.db` can host more than one embedding store. Each store is bound by
-an `IndexSpec` (internal/vector): its documents table, its own key/value
-metadata table, and a table prefix for the kit-managed generation
-bookkeeping. Schema-version resets, metadata (watermarks, scope, generation
-model names), and generation lifecycles are all scoped per store, so
-resetting or rebuilding one store never touches another. The conversation
-message store described in this document is the spec returned by
-`MessageIndexSpec()`; `embeddings list/activate/retire` accept `--store`
-(default `messages`) because generation IDs are only unique within a store.
+`vectors.db` can host more than one embedding store. Each store is bound by an
+`IndexSpec` (internal/vector): its documents table, its own key/value metadata
+table, and a table prefix for the kit-managed generation bookkeeping.
+Schema-version resets, metadata (watermarks, scope, generation model names), and
+generation lifecycles are all scoped per store, so resetting or rebuilding one
+store never touches another. The conversation message store described in this
+document is the spec returned by `MessageIndexSpec()`;
+`embeddings list/activate/retire` accept `--store` (default `messages`) because
+generation IDs are only unique within a store.
 
 ## Unit model: user documents and runs
 
@@ -493,6 +493,128 @@ across backends.
   and are CI-gated. If real-corpus profiling ever shows meaningful cost, the
   remedy is an explicit opt-out — citations must never silently self-disable
   based on index or corpus state.
+
+## PostgreSQL replica
+
+`internal/postgres` implements the same `db.VectorSearcher` seam over
+[pgvector](https://github.com/pgvector/pgvector), making PostgreSQL a passive
+replica of the local `vectors.db`: embeddings are never computed server-side,
+and `pg push` copies the active generation's documents and chunks. The fusion
+machinery — `RRFMerge`, unit fusion keys, the subordinate penalty, snippet
+construction — is exported from `internal/db` and reused rather than duplicated,
+so semantic/hybrid parity between backends holds by construction. The
+user-facing behavior (fingerprint gate, graceful 501 degradation, shared
+generations) is described in
+[Semantic Search — PostgreSQL](/semantic-search/#postgresql); this section
+covers the invariants.
+
+### Schema shape
+
+- `vector_generations` is keyed by the **same config fingerprint** as local
+  generations, so machines with identical `[vector.embeddings]` configs share
+  one generation; `vector_generation_machines` records contributors for
+  observability.
+- `vector_documents` mirrors the local `vector_messages` table: `doc_key`
+  primary key plus a `UNIQUE (session_id, ordinal)` index, with full document
+  content duplicated into PG so snippets and anchoring reuse the exact local
+  mirror semantics (rebuilding content from `messages` at query time would
+  need duplicate extraction logic that can drift).
+- `vector_chunks_g<id>` is one table per generation with a `halfvec(N)` column
+  and an HNSW cosine index. Per-generation tables are required because a
+  pgvector column has a fixed typed dimension; `halfvec` stays under HNSW's
+  dimension ceiling (covering 2560-dim models that plain `vector` cannot
+  index) and halves storage. Index DDL schema-qualifies the type and operator
+  (`OPERATOR(schema.<=>)`) because the session `search_path` is
+  target-schema-only.
+- **`vector_documents` is deliberately shared across generations.** A newer push
+  can overwrite content an older generation's chunks hydrate against — the
+  same transient skew the local `vectors.db` has with its single shared mirror
+  table. Serve only ever targets one fingerprint-matched generation, the skew
+  self-heals on the next re-push, and generation-scoping the documents would
+  duplicate full content per generation for no read-path benefit. Do not "fix"
+  this by forking the mirror shapes.
+
+### Push invariants
+
+- **Delta state lives in PG, not the local sync-state store.**
+  `vector_push_state (generation_id, session_id, doc_agg_hash)` is written in
+  the same transaction as the doc/chunk upserts; `doc_agg_hash` is a sha256
+  over each embedded doc's full row identity (`doc_key`, `source_uuid`,
+  ordinals, `subordinate`, offsets, `content_hash`), so metadata-only changes
+  re-push, not just content changes. State living with the data makes a PG
+  reset self-healing — state and vectors vanish together.
+- **Doc replacement is park-to-sentinel.** `doc_key` is stable but ordinals
+  shift, so plain `ON CONFLICT (doc_key)` upserts collide with
+  `UNIQUE (session_id, ordinal)`. Each changed session first parks its
+  existing rows at unique negative ordinals (seeded below `MIN(ordinal)`, like
+  the local mirror's parking floor), upserts current docs onto the freed
+  slots, then deletes rows still parked — docs that vanished locally —
+  together with every generation's chunks for them. The cascade matters: local
+  kit removal deletes a vanished doc's vectors from all generations, and
+  preserving another generation's chunks in PG would leave them referencing a
+  row hidden behind the read path's `ordinal >= 0` tombstone guard — dead KNN
+  slots that never hydrate. Whole-session eviction, by contrast, preserves doc
+  rows another generation still references (they stay at non-negative,
+  hydratable ordinals), because an evicted session may merely have left this
+  pusher's project filter while its docs still exist locally.
+- **Eviction is scoped by push ownership, not machine names.** Deletions apply
+  only to sessions this pusher owns per its owner marker, because machine
+  names are aliasable. Both the per-session push transaction and each eviction
+  transaction re-probe the `sessions` row `FOR UPDATE` and re-adjudicate
+  ownership inside the transaction — the delta scan's ownership read can be
+  minutes stale, and without the re-probe one pusher could delete chunks a
+  concurrent pusher claimed and pushed after the scan. Legacy rows with an
+  empty `owner_marker` fall back to the `sessions.machine` column checked
+  against this pusher's machine name and marker aliases — a legacy row naming
+  another machine is a conflict on both the push and evict paths, never
+  adopted. Filtered pushes additionally scope by *local* project membership,
+  so a session that moved out of the project filter locally is not evicted
+  based on a stale PG-side project value. Sessions whose session-phase push
+  failed are never eviction candidates in the same run — a failed session
+  whose embedded docs all vanished locally is counted as deferred, keeping
+  vector state from running ahead of the sessions rows that failed to write.
+- **A partially embedded local index defers the whole phase.** A
+  same-fingerprint full rebuild clears and refills the active generation in
+  place, so a push running concurrently would read partial session coverage as
+  truth and evict valid PG vectors. The push source refuses to export a
+  generation with missing embeddings (`ErrVectorSourceNotReady`, a clean phase
+  skip), and the push re-checks the source immediately before running its
+  eviction list in case a rebuild started mid-push.
+- **A session is replaced only when its export matches the delta scan.**
+  `ExportSessionDocs` reads docs, chunks, and the session's aggregate hash in
+  one local read snapshot and returns the hash of exactly the exported set;
+  the push defers the session (writing nothing) when that hash differs from
+  the hash its delta scan read. Without this, a rebuild starting between the
+  scan and the export could replace valid PG vectors with a partial view and
+  record the scan's hash as current — a state a same-fingerprint rebuild (same
+  content, same hash) would never repair. On the first deferral the push also
+  re-checks the source; an unready or swapped generation stops the phase,
+  since every remaining session would diverge the same way.
+
+### Read path
+
+- Startup wiring verifies **both** the fingerprint-matched generation row and
+  its chunk table. Registering a generation and creating its chunk table are
+  separate statements on the push side, so an interrupted push can leave the
+  row without the table; wiring a searcher against it would fail every query
+  with a missing-relation error instead of degrading to
+  `ErrSemanticUnavailable`.
+- The KNN query fetches **exactly k chunks** — no over-fetch multiplier — to
+  match the SQLite searcher's brute-force contract; the shared caller already
+  over-fetches for metadata post-filtering.
+- HNSW's default candidate pool (`hnsw.ef_search = 40`) silently caps results
+  below k for large fetches, so each search runs
+  `SET LOCAL hnsw.ef_search = clamp(k, 40, 1000)` in the query transaction.
+  For k past pgvector's 1000 ceiling, `hnsw.iterative_scan = 'relaxed_order'`
+  (pgvector >= 0.8) lets the scan continue; the GUC is probed with
+  `current_setting(..., missing_ok)` first so older pgvector skips it instead
+  of aborting the transaction.
+- The hybrid keyword leg selects ILIKE candidates in recency order over the
+  embedded-universe predicates, resolves them to units through
+  `ResolveMessageUnits` point lookups against `vector_documents`, and feeds
+  the shared RRF merge — everything after candidate selection matches the
+  SQLite contract, with the BM25-vs-recency leg-ranking difference documented
+  in the [user-facing docs](/semantic-search/#hybrid-keyword-leg).
 
 ## Error taxonomy
 

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -13,12 +13,12 @@ For the architecture behind this page — storage layout, generations,
 concurrency, and the search path — see
 [Semantic Search Internals](/semantic-search-internals/).
 
-!!! note "SQLite only"
+!!! note "Backends"
 
-    Semantic and hybrid search require the local SQLite archive.
-    [PostgreSQL sync](/pg-sync/) and the [DuckDB mirror](/duckdb/) do not support a
-    vector backend yet, so `--semantic`/`--hybrid` against `--pg` or a DuckDB-backed
-    server return the same "not available" error described below.
+    Semantic and hybrid search run on the local SQLite archive and on
+    [PostgreSQL](#postgresql) via pgvector. The [DuckDB mirror](/duckdb/) has no
+    vector backend, so `--semantic`/`--hybrid` against a DuckDB-backed server return
+    the "not available" error described below.
 
 ## Enabling `[vector]`
 
@@ -432,22 +432,127 @@ of `ordinal_range` to read the whole stretch.
 
 ## Error taxonomy
 
-| Situation                                                                                        | Message                                                                                                                                                    |
-| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `[vector]` not enabled                                                                           | `vector search is not enabled: set [vector] enabled = true in config.toml` (from `agentsview embeddings ...`)                                              |
-| No `VectorSearcher` wired (index never built, or PG/DuckDB backend)                              | `semantic search not available: enable [vector] in config.toml and run 'agentsview embeddings build'`                                                      |
-| Only a building generation exists                                                                | same message, plus `: index is building: N% complete`                                                                                                      |
-| Active generation's fingerprint no longer matches config (model, dimension, or chunking changed) | same message, plus `: index is stale (embedding config changed): run 'agentsview embeddings build --full-rebuild'`                                         |
-| Index was built by an incompatible agentsview version (mirror schema mismatch)                   | same message, plus `` : vector index was built by an incompatible version: run `agentsview embeddings build` ``                                            |
-| `--scope` with a lexical mode (or without `--semantic`/`--hybrid`)                               | CLI: `--scope requires --semantic or --hybrid`; HTTP/MCP: `scope is only supported for semantic and hybrid search modes`                                   |
-| Embeddings endpoint unreachable or timed out                                                     | `[vector.embeddings] request: ...` (the underlying transport error)                                                                                        |
-| Embeddings endpoint returned non-200                                                             | `[vector.embeddings] status <code>: <body>`                                                                                                                |
-| `--in` names a source other than `messages` with `--semantic`/`--hybrid`                         | CLI: `--semantic searches messages only; drop --in` (or `--hybrid ...`); HTTP/MCP: `search: semantic search only supports the messages source (got "...")` |
-| `--cursor` with `--semantic`/`--hybrid`                                                          | `semantic search returns a single ranked page; cursor pagination is not supported`                                                                         |
+| Situation                                                                                               | Message                                                                                                                                                    |
+| ------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `[vector]` not enabled                                                                                  | `vector search is not enabled: set [vector] enabled = true in config.toml` (from `agentsview embeddings ...`)                                              |
+| No `VectorSearcher` wired (index never built, DuckDB backend, or PG with no matching pushed generation) | `semantic search not available: enable [vector] in config.toml and run 'agentsview embeddings build'`                                                      |
+| Only a building generation exists                                                                       | same message, plus `: index is building: N% complete`                                                                                                      |
+| Active generation's fingerprint no longer matches config (model, dimension, or chunking changed)        | same message, plus `: index is stale (embedding config changed): run 'agentsview embeddings build --full-rebuild'`                                         |
+| Index was built by an incompatible agentsview version (mirror schema mismatch)                          | same message, plus `` : vector index was built by an incompatible version: run `agentsview embeddings build` ``                                            |
+| `--scope` with a lexical mode (or without `--semantic`/`--hybrid`)                                      | CLI: `--scope requires --semantic or --hybrid`; HTTP/MCP: `scope is only supported for semantic and hybrid search modes`                                   |
+| Embeddings endpoint unreachable or timed out                                                            | `[vector.embeddings] request: ...` (the underlying transport error)                                                                                        |
+| Embeddings endpoint returned non-200                                                                    | `[vector.embeddings] status <code>: <body>`                                                                                                                |
+| `--in` names a source other than `messages` with `--semantic`/`--hybrid`                                | CLI: `--semantic searches messages only; drop --in` (or `--hybrid ...`); HTTP/MCP: `search: semantic search only supports the messages source (got "...")` |
+| `--cursor` with `--semantic`/`--hybrid`                                                                 | `semantic search returns a single ranked page; cursor pagination is not supported`                                                                         |
 
 Over HTTP (`GET /api/v1/search/content`) and MCP (`search_content`), the "not
 available" family of errors maps to HTTP `501 Not Implemented` and the matching
 MCP tool error, carrying the same remediation text.
+
+## PostgreSQL
+
+The `--pg` read path and `agentsview pg serve` support semantic and hybrid
+search backed by [pgvector](https://github.com/pgvector/pgvector), so a shared
+PostgreSQL deployment answers `--semantic`/`--hybrid` the same way a local
+SQLite index does. Only the DuckDB mirror lacks a vector backend and still
+returns the "not available" error (HTTP 501).
+
+### Pushing embeddings
+
+`agentsview pg push` runs a vector phase after the session and message phases:
+it copies the machine's active generation from the local `vectors.db` mirror
+into PostgreSQL as per-generation `halfvec` chunk tables. Only the active
+generation is pushed, and only sessions whose document set changed since the
+last push are re-sent, mirroring the incremental session push (`pg push --full`
+bypasses the change detection and re-sends every session's vectors). The
+`pg push` summary reports the phase as
+`Vectors: N session(s) pushed, ... docs, ... chunks`, or
+`Vectors: skipped (<reason>)` when it does not run.
+
+Skip the phase for a single run with `--no-vectors`, or disable it persistently:
+
+```toml
+[pg]
+push_vectors = false
+```
+
+`push_vectors` defaults to true, so a machine with `[vector]` enabled pushes its
+embeddings automatically. A machine without `[vector]` enabled has no generation
+to push and skips the phase regardless.
+
+### Serving semantic search
+
+`pg serve` — and every `--pg` direct-read command — wires PG-backed semantic
+search at startup when three conditions hold on the serving host:
+
+1. `[vector]` is enabled in that host's `config.toml`.
+1. The host's embedding config fingerprint (model, dimension, chunking, prompt
+   affixes) matches a generation already pushed to PostgreSQL. The fingerprint
+   is immutable, so a startup match cannot go stale while the process runs;
+   changing the local embeddings config changes the fingerprint and requires a
+   restart to pick up.
+1. The configured embeddings server is reachable from the serving host, because
+   query text is embedded at search time with the same encoder the index was
+   built with.
+
+If no generation matches, `pg serve` starts normally but semantic and hybrid
+search return the 501 "not available" error carrying the mismatch reason, which
+lists the fingerprints PostgreSQL does have so an operator can tell a "wrong
+config" miss from a "never pushed" one. A missing pgvector extension or vector
+tables degrade the same way — see
+[Backends without pgvector](#backends-without-pgvector).
+
+### Shared generations across machines
+
+A generation is keyed by its config fingerprint, so every machine with an
+identical `[vector.embeddings]` config pushes into the *same* PostgreSQL
+generation. Their documents and chunks accumulate side by side, and any serving
+host with the matching fingerprint searches the union. Coverage is partial by
+construction: a session becomes semantically searchable only once the machine
+that owns it has pushed its embeddings, so a freshly pushed session's text can
+match lexically (through the hybrid keyword leg) before its vectors arrive.
+
+### Storage and indexing
+
+Embeddings are stored as pgvector `halfvec` (16-bit) columns, one chunk table
+per generation, each indexed with an HNSW cosine index. `halfvec` halves storage
+versus 32-bit `vector` and stays under HNSW's dimension ceiling, so models up to
+2560 dimensions index cleanly where plain `vector` cannot. Per-generation tables
+are required because a pgvector column has a fixed typed dimension.
+
+### Backends without pgvector
+
+Semantic search degrades gracefully when the extension is absent or too old.
+`pg push` best-effort runs `CREATE EXTENSION IF NOT EXISTS vector`; if that
+fails — CockroachDB, which has no pgvector; a database where the extension
+package is not installed; or a role lacking `CREATE` privilege — schema setup
+logs a one-line notice and continues, and the vector phase is skipped. `halfvec`
+needs pgvector 0.7.0 or newer: `CREATE EXTENSION IF NOT EXISTS` never upgrades
+an existing extension object, so when an older version is installed `pg push`
+attempts `ALTER EXTENSION vector UPDATE` (healing servers whose pgvector package
+was upgraded in place) and otherwise skips the vector phase, reporting the
+installed version. Session and message sync are unaffected in every case. On the
+read side a missing vector table is treated as "no generation found", so
+`pg serve` starts and only `--semantic`/`--hybrid` return 501 while lexical
+search keeps working.
+
+### Maintenance
+
+`agentsview pg vectors list` prints every generation with its model, dimension,
+document and chunk counts, contributing machines, and creation time.
+`agentsview pg vectors drop <id>` removes a generation and all of its embeddings
+(prompted unless `--yes`); use it to reclaim space after retiring an embedding
+model. Both accept `--target` to select a non-default PG target.
+
+### Hybrid keyword leg
+
+Both backends fuse the same two legs with the same reciprocal-rank merge, but
+their keyword legs rank differently. SQLite's hybrid keyword leg is BM25-ranked
+through FTS5; PostgreSQL's is an `ILIKE` scan ordered by recency (newest first).
+The vector leg, the RRF fusion, the subordinate-unit penalty, scope filtering,
+and hit anchoring are identical, so top results usually agree — but the
+keyword-leg input order, and therefore fusion ties broken by keyword rank, can
+differ between the backends.
 
 ## Limitations
 
@@ -473,10 +578,10 @@ MCP tool error, carrying the same remediation text.
   messages append — but its content changes, so each build re-embeds the
   current tail. That is the intended cost of grouping; finished runs never
   re-embed.
-- **SQLite only.** PostgreSQL sync and the DuckDB mirror have no vector backend;
-  `--semantic`/`--hybrid` against `--pg` or a DuckDB-backed server return the
-  "not available" error (HTTP 501) described above. `pgvector` support is a
-  possible follow-up.
+- **DuckDB mirror has no vector backend.** `--semantic`/`--hybrid` against a
+  DuckDB-backed server return the "not available" error (HTTP 501) described
+  above. PostgreSQL is supported through pgvector — see
+  [PostgreSQL](#postgresql).
 - **The index embeds message `content` verbatim.** Like `--fts`, it only draws
   from the `messages` source, so raw tool_input/tool_result rows are never
   candidates. System messages are handled more strictly, though: `--fts` still

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,6 +65,15 @@ type PGConfig struct {
 	AllowInsecure   bool     `toml:"allow_insecure" json:"allow_insecure"`
 	Projects        []string `toml:"projects" json:"projects,omitempty"`
 	ExcludeProjects []string `toml:"exclude_projects" json:"exclude_projects,omitempty"`
+	// PushVectors gates the vector phase of pg push. A pointer so an
+	// absent key defaults to enabled without a load-time default pass.
+	PushVectors *bool `toml:"push_vectors" json:"push_vectors,omitempty"`
+}
+
+// PushVectorsEnabled reports whether pg push should run its vector phase
+// for this target; unset means enabled.
+func (p PGConfig) PushVectorsEnabled() bool {
+	return p.PushVectors == nil || *p.PushVectors
 }
 
 type pgEnvOverrides struct {
@@ -88,6 +97,7 @@ var pgConfigKeys = map[string]struct{}{
 	"allow_insecure":   {},
 	"projects":         {},
 	"exclude_projects": {},
+	"push_vectors":     {},
 }
 
 // DuckDBConfig holds DuckDB mirror and Quack connection settings.
@@ -1057,6 +1067,9 @@ func (c *Config) applyConfigTOML(data string) error {
 		}
 		if legacyPG.ExcludeProjects != nil {
 			c.PG.ExcludeProjects = legacyPG.ExcludeProjects
+		}
+		if legacyPG.PushVectors != nil {
+			c.PG.PushVectors = legacyPG.PushVectors
 		}
 	}
 	// Merge duckdb field-by-field so env vars override only

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1820,3 +1820,48 @@ func TestIsDefaultAgentsviewDBPath(t *testing.T) {
 		})
 	}
 }
+
+func TestPGConfigPushVectorsEnabled(t *testing.T) {
+	boolPtr := func(b bool) *bool { return &b }
+	tests := []struct {
+		name string
+		cfg  PGConfig
+		want bool
+	}{
+		{"unset defaults to true", PGConfig{}, true},
+		{"explicit false", PGConfig{PushVectors: boolPtr(false)}, false},
+		{"explicit true", PGConfig{PushVectors: boolPtr(true)}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.cfg.PushVectorsEnabled())
+		})
+	}
+}
+
+func TestPGConfig_LoadsFromTOML(t *testing.T) {
+	f := newConfigFixture(t)
+	f.WriteTOML(t, map[string]any{
+		"pg": map[string]any{
+			"url":          "postgres://localhost/test",
+			"push_vectors": false,
+		},
+	})
+
+	cfg := f.LoadMinimal(t)
+
+	assert.False(t, cfg.PG.PushVectorsEnabled())
+}
+
+func TestPGConfig_PushVectorsDefaultsTrue(t *testing.T) {
+	f := newConfigFixture(t)
+	f.WriteTOML(t, map[string]any{
+		"pg": map[string]any{
+			"url": "postgres://localhost/test",
+		},
+	})
+
+	cfg := f.LoadMinimal(t)
+
+	assert.True(t, cfg.PG.PushVectorsEnabled())
+}

--- a/internal/db/fingerprints_batch.go
+++ b/internal/db/fingerprints_batch.go
@@ -1,0 +1,782 @@
+package db
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"strings"
+)
+
+// This file holds batched (session_id IN ...) twins of the per-session
+// fingerprint queries in messages.go, secret_findings.go, and pins.go.
+// Push backends fingerprint every candidate session on every push; issuing
+// the dozen per-session queries once per session dominated full-push
+// preparation time, so the push loop prefetches per-chunk maps instead.
+//
+// Byte-identity contract: for any session ID, each batched method's map
+// value must equal the corresponding per-session method's return value
+// (including nil-vs-empty slice semantics), because push fingerprints are
+// hashed and compared against fingerprints stored by earlier pushes. The
+// per-row formatting is shared with the per-session methods; the parity
+// tests in fingerprints_batch_test.go pin the query side.
+
+// sessionFingerprintBatchSize bounds how many session IDs a single batched
+// fingerprint query binds, staying under SQLite's default 999-variable limit.
+const sessionFingerprintBatchSize = 900
+
+func forEachSessionIDBatch(
+	sessionIDs []string, fn func(chunk []string) error,
+) error {
+	for start := 0; start < len(sessionIDs); start += sessionFingerprintBatchSize {
+		end := min(start+sessionFingerprintBatchSize, len(sessionIDs))
+		if err := fn(sessionIDs[start:end]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func sessionIDArgs(sessionIDs []string) (string, []any) {
+	placeholders := make([]string, len(sessionIDs))
+	args := make([]any, len(sessionIDs))
+	for i, id := range sessionIDs {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	return strings.Join(placeholders, ","), args
+}
+
+type fingerprintBuilders map[string]*strings.Builder
+
+func (m fingerprintBuilders) get(sessionID string) *strings.Builder {
+	b := m[sessionID]
+	if b == nil {
+		b = &strings.Builder{}
+		m[sessionID] = b
+	}
+	return b
+}
+
+func (m fingerprintBuilders) mergeInto(out map[string]string) {
+	for id, b := range m {
+		out[id] += b.String()
+	}
+}
+
+// MessageContentAggregate mirrors MessageContentFingerprint's
+// sum/max/min triple for the batched lookup.
+type MessageContentAggregate struct {
+	Sum int64
+	Max int64
+	Min int64
+}
+
+// MessageContentFingerprints is the batched twin of
+// MessageContentFingerprint. Sessions without messages are absent from the
+// map; the zero MessageContentAggregate matches the per-session result.
+func (db *DB) MessageContentFingerprints(
+	sessionIDs []string,
+) (map[string]MessageContentAggregate, error) {
+	out := make(map[string]MessageContentAggregate, len(sessionIDs))
+	err := forEachSessionIDBatch(sessionIDs, func(chunk []string) error {
+		ph, args := sessionIDArgs(chunk)
+		rows, err := db.getReader().Query(`
+			SELECT session_id, COALESCE(SUM(content_length), 0),
+				COALESCE(MAX(content_length), 0),
+				COALESCE(MIN(content_length), 0)
+			FROM messages
+			WHERE session_id IN (`+ph+`)
+			GROUP BY session_id`,
+			args...,
+		)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var sessionID string
+			var agg MessageContentAggregate
+			if err := rows.Scan(
+				&sessionID, &agg.Sum, &agg.Max, &agg.Min,
+			); err != nil {
+				return err
+			}
+			out[sessionID] = agg
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// MessageTokenFingerprints is the batched twin of MessageTokenFingerprint.
+func (db *DB) MessageTokenFingerprints(
+	sessionIDs []string,
+) (map[string]string, error) {
+	out := make(map[string]string, len(sessionIDs))
+	err := forEachSessionIDBatch(sessionIDs, func(chunk []string) error {
+		ph, args := sessionIDArgs(chunk)
+		rows, err := db.getReader().Query(`
+			SELECT session_id, ordinal, model, token_usage, context_tokens,
+				output_tokens, has_context_tokens, has_output_tokens,
+				claude_message_id, claude_request_id,
+				source_type, source_subtype, source_uuid,
+				source_parent_uuid, is_sidechain, is_compact_boundary
+			 FROM messages
+			 WHERE session_id IN (`+ph+`)
+			 ORDER BY session_id, ordinal ASC`,
+			args...,
+		)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		builders := fingerprintBuilders{}
+		for rows.Next() {
+			var sessionID string
+			var r tokenFingerprintRow
+			if err := rows.Scan(
+				&sessionID, &r.ordinal, &r.model, &r.tokenUsage,
+				&r.contextTokens, &r.outputTokens,
+				&r.hasContextTokens, &r.hasOutputTokens,
+				&r.claudeMessageID, &r.claudeRequestID,
+				&r.sourceType, &r.sourceSubtype, &r.sourceUUID,
+				&r.sourceParentUUID, &r.isSidechain, &r.isCompactBoundary,
+			); err != nil {
+				return err
+			}
+			r.appendTo(builders.get(sessionID))
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		builders.mergeInto(out)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// MessageContentHashFingerprints is the batched twin of
+// MessageContentHashFingerprint.
+func (db *DB) MessageContentHashFingerprints(
+	sessionIDs []string,
+) (map[string]string, error) {
+	out := make(map[string]string, len(sessionIDs))
+	err := forEachSessionIDBatch(sessionIDs, func(chunk []string) error {
+		ph, args := sessionIDArgs(chunk)
+		rows, err := db.getReader().Query(`
+			SELECT session_id, ordinal, content, content_length
+			 FROM messages
+			 WHERE session_id IN (`+ph+`)
+			 ORDER BY session_id, ordinal ASC`,
+			args...,
+		)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		builders := fingerprintBuilders{}
+		for rows.Next() {
+			var sessionID, content string
+			var ordinal, contentLength int
+			if err := rows.Scan(
+				&sessionID, &ordinal, &content, &contentLength,
+			); err != nil {
+				return err
+			}
+			appendContentHashFingerprintRow(
+				builders.get(sessionID), ordinal, contentLength, content,
+			)
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		builders.mergeInto(out)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// MessageRoleTimeFingerprintsWithTimestampNormalizer is the batched twin of
+// MessageRoleTimeFingerprintWithTimestampNormalizer.
+func (db *DB) MessageRoleTimeFingerprintsWithTimestampNormalizer(
+	sessionIDs []string,
+	normalizeTimestamp func(string) string,
+) (map[string]string, error) {
+	out := make(map[string]string, len(sessionIDs))
+	err := forEachSessionIDBatch(sessionIDs, func(chunk []string) error {
+		ph, args := sessionIDArgs(chunk)
+		rows, err := db.getReader().Query(`
+			SELECT session_id, ordinal, role, COALESCE(timestamp, '')
+			 FROM messages
+			 WHERE session_id IN (`+ph+`)
+			 ORDER BY session_id, ordinal ASC`,
+			args...,
+		)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		builders := fingerprintBuilders{}
+		for rows.Next() {
+			var sessionID, role, timestamp string
+			var ordinal int
+			if err := rows.Scan(
+				&sessionID, &ordinal, &role, &timestamp,
+			); err != nil {
+				return err
+			}
+			appendRoleTimeFingerprintRow(
+				builders.get(sessionID), ordinal, role, timestamp,
+				normalizeTimestamp,
+			)
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		builders.mergeInto(out)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// MessageFlagsFingerprints is the batched twin of MessageFlagsFingerprint.
+func (db *DB) MessageFlagsFingerprints(
+	sessionIDs []string,
+) (map[string]string, error) {
+	out := make(map[string]string, len(sessionIDs))
+	err := forEachSessionIDBatch(sessionIDs, func(chunk []string) error {
+		ph, args := sessionIDArgs(chunk)
+		rows, err := db.getReader().Query(`
+			SELECT session_id, ordinal, is_system, has_thinking,
+				has_tool_use, thinking_text
+			 FROM messages
+			 WHERE session_id IN (`+ph+`)
+			 ORDER BY session_id, ordinal ASC`,
+			args...,
+		)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		builders := fingerprintBuilders{}
+		for rows.Next() {
+			var sessionID string
+			var r flagsFingerprintRow
+			if err := rows.Scan(
+				&sessionID, &r.ordinal, &r.isSystem, &r.hasThinking,
+				&r.hasToolUse, &r.thinkingText,
+			); err != nil {
+				return err
+			}
+			r.appendTo(builders.get(sessionID))
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		builders.mergeInto(out)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// SystemMessageFingerprints is the batched twin of SystemMessageFingerprint.
+// The ordinal list is joined in Go rather than with GROUP_CONCAT so the
+// per-session ordering never depends on SQLite's aggregate scan order.
+func (db *DB) SystemMessageFingerprints(
+	sessionIDs []string,
+) (map[string]string, error) {
+	out := make(map[string]string, len(sessionIDs))
+	err := forEachSessionIDBatch(sessionIDs, func(chunk []string) error {
+		ph, args := sessionIDArgs(chunk)
+		rows, err := db.getReader().Query(`
+			SELECT session_id, ordinal FROM messages
+			WHERE session_id IN (`+ph+`) AND is_system = 1
+			ORDER BY session_id, ordinal`,
+			args...,
+		)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		builders := fingerprintBuilders{}
+		for rows.Next() {
+			var sessionID string
+			var ordinal int
+			if err := rows.Scan(&sessionID, &ordinal); err != nil {
+				return err
+			}
+			b := builders.get(sessionID)
+			if b.Len() > 0 {
+				b.WriteByte(',')
+			}
+			fmt.Fprintf(b, "%d", ordinal)
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		builders.mergeInto(out)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// ToolCallCounts is the batched twin of ToolCallCount. Sessions without
+// tool calls are absent from the map; zero matches the per-session result.
+func (db *DB) ToolCallCounts(sessionIDs []string) (map[string]int, error) {
+	out := make(map[string]int, len(sessionIDs))
+	err := forEachSessionIDBatch(sessionIDs, func(chunk []string) error {
+		ph, args := sessionIDArgs(chunk)
+		rows, err := db.getReader().Query(`
+			SELECT session_id, COUNT(*) FROM tool_calls
+			WHERE session_id IN (`+ph+`)
+			GROUP BY session_id`,
+			args...,
+		)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var sessionID string
+			var n int
+			if err := rows.Scan(&sessionID, &n); err != nil {
+				return err
+			}
+			out[sessionID] = n
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// ToolCallContentFingerprints is the batched twin of
+// ToolCallContentFingerprint.
+func (db *DB) ToolCallContentFingerprints(
+	sessionIDs []string,
+) (map[string]int64, error) {
+	out := make(map[string]int64, len(sessionIDs))
+	err := forEachSessionIDBatch(sessionIDs, func(chunk []string) error {
+		ph, args := sessionIDArgs(chunk)
+		rows, err := db.getReader().Query(`
+			SELECT session_id, COALESCE(SUM(result_content_length), 0)
+			FROM tool_calls
+			WHERE session_id IN (`+ph+`)
+			GROUP BY session_id`,
+			args...,
+		)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var sessionID string
+			var sum int64
+			if err := rows.Scan(&sessionID, &sum); err != nil {
+				return err
+			}
+			out[sessionID] = sum
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// ToolCallFingerprints is the batched twin of ToolCallFingerprint.
+func (db *DB) ToolCallFingerprints(
+	sessionIDs []string,
+) (map[string]string, error) {
+	out := make(map[string]string, len(sessionIDs))
+	err := forEachSessionIDBatch(sessionIDs, func(chunk []string) error {
+		ph, args := sessionIDArgs(chunk)
+		rows, err := db.getReader().Query(`
+			SELECT tc.session_id, m.ordinal, tc.tool_name, tc.category,
+				COALESCE(tc.tool_use_id, ''), COALESCE(tc.input_json, ''),
+				COALESCE(tc.skill_name, ''),
+				COALESCE(tc.subagent_session_id, ''),
+				COALESCE(tc.result_content_length, 0),
+				COALESCE(tc.result_content, ''),
+				COALESCE(tc.file_path, '')
+			 FROM tool_calls tc
+			 JOIN messages m ON m.id = tc.message_id
+			 WHERE tc.session_id IN (`+ph+`)
+			 ORDER BY tc.session_id, m.ordinal ASC, tc.id ASC`,
+			args...,
+		)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		builders := fingerprintBuilders{}
+		var indexer toolCallIndexer
+		for rows.Next() {
+			var sessionID string
+			var r toolCallFingerprintRow
+			if err := rows.Scan(
+				&sessionID, &r.messageOrdinal, &r.toolName, &r.category,
+				&r.toolUseID, &r.inputJSON, &r.skillName,
+				&r.subagentSessionID, &r.resultContentLength,
+				&r.resultContent, &r.filePath,
+			); err != nil {
+				return err
+			}
+			r.callIndex = indexer.next(sessionID, r.messageOrdinal)
+			r.appendTo(builders.get(sessionID))
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		builders.mergeInto(out)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// ToolResultEventFingerprintsWithTimestampNormalizer is the batched twin of
+// ToolResultEventFingerprintWithTimestampNormalizer.
+func (db *DB) ToolResultEventFingerprintsWithTimestampNormalizer(
+	sessionIDs []string,
+	normalizeTimestamp func(string) string,
+) (map[string]string, error) {
+	out := make(map[string]string, len(sessionIDs))
+	err := forEachSessionIDBatch(sessionIDs, func(chunk []string) error {
+		ph, args := sessionIDArgs(chunk)
+		rows, err := db.getReader().Query(`
+			SELECT session_id, tool_call_message_ordinal, call_index,
+				event_index, COALESCE(tool_use_id, ''),
+				COALESCE(agent_id, ''),
+				COALESCE(subagent_session_id, ''), source, status,
+				content, content_length, COALESCE(timestamp, '')
+			 FROM tool_result_events
+			 WHERE session_id IN (`+ph+`)
+			 ORDER BY session_id, tool_call_message_ordinal ASC,
+				call_index ASC, event_index ASC`,
+			args...,
+		)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		builders := fingerprintBuilders{}
+		for rows.Next() {
+			var sessionID string
+			var r toolResultEventFingerprintRow
+			if err := rows.Scan(
+				&sessionID, &r.messageOrdinal, &r.callIndex, &r.eventIndex,
+				&r.toolUseID, &r.agentID, &r.subagentSessionID,
+				&r.source, &r.status, &r.content, &r.contentLength,
+				&r.timestamp,
+			); err != nil {
+				return err
+			}
+			r.appendTo(builders.get(sessionID), normalizeTimestamp)
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		builders.mergeInto(out)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// SessionSecretFindingsBySession is the batched twin of
+// SessionSecretFindings. Every requested session ID gets an entry; sessions
+// without findings map to an empty non-nil slice, matching the per-session
+// method (the push fingerprint JSON-encodes the slice, so nil and empty
+// must not be conflated).
+func (db *DB) SessionSecretFindingsBySession(
+	ctx context.Context, sessionIDs []string,
+) (map[string][]SecretFinding, error) {
+	out := make(map[string][]SecretFinding, len(sessionIDs))
+	for _, id := range sessionIDs {
+		out[id] = []SecretFinding{}
+	}
+	err := forEachSessionIDBatch(sessionIDs, func(chunk []string) error {
+		ph, args := sessionIDArgs(chunk)
+		rows, err := db.getReader().QueryContext(ctx, `
+			SELECT session_id, rule_name, confidence,
+			       location_kind, message_ordinal, call_index, event_index,
+			       match_start, match_end, match_index,
+			       redacted_match, rules_version
+			FROM secret_findings
+			WHERE session_id IN (`+ph+`)
+			ORDER BY session_id, message_ordinal, match_start, match_index`,
+			args...,
+		)
+		if err != nil {
+			return fmt.Errorf("querying secret findings batch: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var f SecretFinding
+			if err := rows.Scan(
+				&f.SessionID, &f.RuleName, &f.Confidence,
+				&f.LocationKind, &f.MessageOrdinal, &f.CallIndex,
+				&f.EventIndex, &f.MatchStart, &f.MatchEnd, &f.MatchIndex,
+				&f.RedactedMatch, &f.RulesVersion,
+			); err != nil {
+				return fmt.Errorf("scanning secret finding: %w", err)
+			}
+			out[f.SessionID] = append(out[f.SessionID], f)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// PinnedMessagesBySession is the batched twin of the per-session
+// ListPinnedMessages call. Sessions without pins are absent from the map;
+// the nil slice matches the per-session method (the push fingerprint
+// JSON-encodes the slice, so nil and empty must not be conflated).
+func (db *DB) PinnedMessagesBySession(
+	ctx context.Context, sessionIDs []string,
+) (map[string][]PinnedMessage, error) {
+	out := make(map[string][]PinnedMessage, len(sessionIDs))
+	err := forEachSessionIDBatch(sessionIDs, func(chunk []string) error {
+		ph, args := sessionIDArgs(chunk)
+		rows, err := db.getReader().QueryContext(ctx,
+			"SELECT "+pinnedBaseCols+
+				" FROM pinned_messages WHERE session_id IN ("+ph+")"+
+				" ORDER BY session_id, created_at DESC",
+			args...,
+		)
+		if err != nil {
+			return fmt.Errorf("listing pinned messages batch: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			p, err := scanPinnedRow(rows)
+			if err != nil {
+				return fmt.Errorf("scanning pinned message: %w", err)
+			}
+			out[p.SessionID] = append(out[p.SessionID], p)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Row formatters shared by the per-session fingerprint methods and their
+// batched twins above. Keeping the sanitize-and-format step in one place is
+// what guarantees the two paths cannot drift.
+
+type tokenFingerprintRow struct {
+	ordinal           int
+	model             string
+	tokenUsage        string
+	contextTokens     int
+	outputTokens      int
+	hasContextTokens  bool
+	hasOutputTokens   bool
+	claudeMessageID   string
+	claudeRequestID   string
+	sourceType        string
+	sourceSubtype     string
+	sourceUUID        string
+	sourceParentUUID  string
+	isSidechain       bool
+	isCompactBoundary bool
+}
+
+// appendTo sanitizes before measuring: the PG-readback fingerprint sees
+// values sanitized at insert time, so raw values (e.g. NUL bytes from a
+// corrupt parse) would never match and the fast path would rewrite the
+// session on every push.
+func (r tokenFingerprintRow) appendTo(b *strings.Builder) {
+	model := SanitizeUTF8(r.model)
+	tokenUsage := SanitizeUTF8(r.tokenUsage)
+	claudeMsgID := SanitizeUTF8(r.claudeMessageID)
+	claudeReqID := SanitizeUTF8(r.claudeRequestID)
+	srcType := SanitizeUTF8(r.sourceType)
+	srcSubtype := SanitizeUTF8(r.sourceSubtype)
+	srcUUID := SanitizeUTF8(r.sourceUUID)
+	srcParentUUID := SanitizeUTF8(r.sourceParentUUID)
+	fmt.Fprintf(b,
+		"%d|%d:%s|%d:%s|%d|%d|%t|%t|%s|%s|"+
+			"%d:%s|%d:%s|%d:%s|%d:%s|%t|%t;",
+		r.ordinal,
+		len(model), model,
+		len(tokenUsage), tokenUsage,
+		r.contextTokens, r.outputTokens,
+		r.hasContextTokens, r.hasOutputTokens,
+		claudeMsgID, claudeReqID,
+		len(srcType), srcType,
+		len(srcSubtype), srcSubtype,
+		len(srcUUID), srcUUID,
+		len(srcParentUUID), srcParentUUID,
+		r.isSidechain, r.isCompactBoundary,
+	)
+}
+
+func appendContentHashFingerprintRow(
+	b *strings.Builder, ordinal, contentLength int, content string,
+) {
+	sum := sha256.Sum256([]byte(SanitizeUTF8(content)))
+	fmt.Fprintf(b, "%d|%d|%x;", ordinal, contentLength, sum)
+}
+
+func appendRoleTimeFingerprintRow(
+	b *strings.Builder, ordinal int, role, timestamp string,
+	normalizeTimestamp func(string) string,
+) {
+	role = SanitizeUTF8(role)
+	if normalizeTimestamp != nil {
+		timestamp = normalizeTimestamp(timestamp)
+	}
+	fmt.Fprintf(b, "%d|%d:%s|%d:%s;",
+		ordinal, len(role), role, len(timestamp), timestamp)
+}
+
+type flagsFingerprintRow struct {
+	ordinal      int
+	isSystem     bool
+	hasThinking  bool
+	hasToolUse   bool
+	thinkingText string
+}
+
+func (r flagsFingerprintRow) appendTo(b *strings.Builder) {
+	sum := sha256.Sum256([]byte(SanitizeUTF8(r.thinkingText)))
+	fmt.Fprintf(b, "%d|%t|%t|%t|%x;",
+		r.ordinal, r.isSystem, r.hasThinking, r.hasToolUse, sum)
+}
+
+type toolCallFingerprintRow struct {
+	messageOrdinal      int
+	callIndex           int
+	toolName            string
+	category            string
+	toolUseID           string
+	inputJSON           string
+	skillName           string
+	subagentSessionID   string
+	resultContentLength int
+	resultContent       string
+	filePath            string
+}
+
+func (r toolCallFingerprintRow) appendTo(b *strings.Builder) {
+	toolName := SanitizeUTF8(r.toolName)
+	category := SanitizeUTF8(r.category)
+	toolUseID := SanitizeUTF8(r.toolUseID)
+	inputJSON := SanitizeUTF8(r.inputJSON)
+	skillName := SanitizeUTF8(r.skillName)
+	subagentSessionID := SanitizeUTF8(r.subagentSessionID)
+	resultContent := SanitizeUTF8(r.resultContent)
+	filePath := SanitizeUTF8(r.filePath)
+	fmt.Fprintf(b,
+		"%d|%d|%d:%s|%d:%s|%d:%s|%d:%s|%d:%s|%d:%s|%d|%d:%s|%d:%s;",
+		r.messageOrdinal, r.callIndex,
+		len(toolName), toolName,
+		len(category), category,
+		len(toolUseID), toolUseID,
+		len(inputJSON), inputJSON,
+		len(skillName), skillName,
+		len(subagentSessionID), subagentSessionID,
+		r.resultContentLength,
+		len(resultContent), resultContent,
+		len(filePath), filePath,
+	)
+}
+
+// toolCallIndexer derives the per-message call index from rows ordered by
+// (session_id,) message ordinal, insertion id — the same derivation the
+// per-session ToolCallFingerprint used inline.
+type toolCallIndexer struct {
+	lastSessionID      string
+	lastMessageOrdinal int
+	callIndex          int
+	started            bool
+}
+
+func (ix *toolCallIndexer) next(sessionID string, messageOrdinal int) int {
+	if ix.started &&
+		sessionID == ix.lastSessionID &&
+		messageOrdinal == ix.lastMessageOrdinal {
+		ix.callIndex++
+		return ix.callIndex
+	}
+	ix.started = true
+	ix.lastSessionID = sessionID
+	ix.lastMessageOrdinal = messageOrdinal
+	ix.callIndex = 0
+	return 0
+}
+
+type toolResultEventFingerprintRow struct {
+	messageOrdinal    int
+	callIndex         int
+	eventIndex        int
+	toolUseID         string
+	agentID           string
+	subagentSessionID string
+	source            string
+	status            string
+	content           string
+	contentLength     int
+	timestamp         string
+}
+
+func (r toolResultEventFingerprintRow) appendTo(
+	b *strings.Builder, normalizeTimestamp func(string) string,
+) {
+	timestamp := r.timestamp
+	if normalizeTimestamp != nil {
+		timestamp = normalizeTimestamp(timestamp)
+	}
+	toolUseID := SanitizeUTF8(r.toolUseID)
+	agentID := SanitizeUTF8(r.agentID)
+	subagentSessionID := SanitizeUTF8(r.subagentSessionID)
+	source := SanitizeUTF8(r.source)
+	status := SanitizeUTF8(r.status)
+	content := SanitizeUTF8(r.content)
+	contentSum := sha256.Sum256([]byte(content))
+	fmt.Fprintf(b,
+		"%d|%d|%d|%d:%s|%d:%s|%d:%s|%d:%s|%d:%s|%d|%x|%d:%s;",
+		r.messageOrdinal, r.callIndex, r.eventIndex,
+		len(toolUseID), toolUseID,
+		len(agentID), agentID,
+		len(subagentSessionID), subagentSessionID,
+		len(source), source,
+		len(status), status,
+		r.contentLength,
+		contentSum,
+		len(timestamp), timestamp,
+	)
+}

--- a/internal/db/fingerprints_batch_test.go
+++ b/internal/db/fingerprints_batch_test.go
@@ -1,0 +1,233 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fingerprintBatchFixture builds two populated sessions plus one empty
+// session and returns their IDs along with a never-inserted ID, covering
+// the missing-key defaults the batched twins must share with the
+// per-session methods.
+func fingerprintBatchFixture(t *testing.T) (*DB, []string) {
+	t.Helper()
+	d := testDB(t)
+
+	insertSession(t, d, "fp-a", "alpha")
+	insertSession(t, d, "fp-b", "alpha")
+	insertSession(t, d, "fp-empty", "alpha")
+
+	sysMsg := userMsgAt("fp-a", 0, "system prompt", "2026-07-01T10:00:00Z")
+	sysMsg.IsSystem = true
+	asst := asstMsgAt("fp-a", 1, "raw\x00bytes\x80here", "2026-07-01T10:00:05Z")
+	asst.ThinkingText = "thinking\x00text"
+	asst.HasThinking = true
+	asst.HasToolUse = true
+	asst.Model = "claude-test"
+	asst.ContextTokens = 100
+	asst.OutputTokens = 20
+	asst.HasContextTokens = true
+	asst.HasOutputTokens = true
+	asst.ClaudeMessageID = "msg-1"
+	asst.SourceUUID = "uuid-1"
+	asst.ToolCalls = []ToolCall{
+		{
+			ToolName:            "Bash",
+			Category:            "execution",
+			ToolUseID:           "tu-1",
+			InputJSON:           `{"command":"ls"}`,
+			ResultContentLength: 4,
+			ResultContent:       "ok\x00!",
+			FilePath:            "/tmp/x",
+			ResultEvents: []ToolResultEvent{
+				{
+					ToolUseID: "tu-1", Source: "cli", Status: "ok",
+					Content: "done", ContentLength: 4,
+					Timestamp: "2026-07-01T10:00:06Z", EventIndex: 0,
+				},
+				{
+					ToolUseID: "tu-1", Source: "cli", Status: "ok",
+					Content: "more", ContentLength: 4, EventIndex: 1,
+				},
+			},
+		},
+		{
+			ToolName:  "Read",
+			Category:  "file",
+			ToolUseID: "tu-2",
+			InputJSON: `{"path":"a.go"}`,
+		},
+	}
+	tail := userMsg("fp-a", 2, "follow-up")
+	tail.IsSystem = true
+	insertMessages(t, d, sysMsg, asst, tail)
+
+	other := asstMsg("fp-b", 0, "short")
+	other.ToolCalls = []ToolCall{{ToolName: "Grep", Category: "search"}}
+	insertMessages(t, d, other, userMsg("fp-b", 1, "longer message body"))
+
+	// A NULL timestamp exercises the COALESCE both paths must share.
+	_, err := d.getWriter().Exec(
+		"UPDATE messages SET timestamp = NULL" +
+			" WHERE session_id = 'fp-b' AND ordinal = 1",
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, d.ReplaceSessionSecretFindings(
+		"fp-a",
+		[]SecretFinding{
+			{
+				SessionID: "fp-a", RuleName: "aws-key",
+				Confidence: "high", LocationKind: "message",
+				MessageOrdinal: 1, MatchStart: 3, MatchEnd: 9,
+				RedactedMatch: "AKIA…", RulesVersion: "v1",
+			},
+			{
+				SessionID: "fp-a", RuleName: "token",
+				Confidence: "low", LocationKind: "tool_result",
+				MessageOrdinal: 1, CallIndex: Ptr(0),
+				MatchStart: 1, MatchEnd: 2, MatchIndex: 1,
+				RedactedMatch: "t…", RulesVersion: "v1",
+			},
+		},
+		2, "v1",
+	))
+
+	var msgID int64
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT id FROM messages WHERE session_id = 'fp-a' AND ordinal = 1",
+	).Scan(&msgID))
+	pinID, err := d.PinMessage("fp-a", msgID, Ptr("note"))
+	require.NoError(t, err)
+	require.NotZero(t, pinID)
+
+	return d, []string{"fp-a", "fp-b", "fp-empty", "fp-missing"}
+}
+
+// TestBatchedFingerprintsMatchPerSession pins the byte-identity contract
+// between each batched fingerprint method and its per-session twin: push
+// fingerprints hash these values and compare them against fingerprints
+// stored by earlier pushes, so any divergence re-pushes every session.
+func TestBatchedFingerprintsMatchPerSession(t *testing.T) {
+	d, ids := fingerprintBatchFixture(t)
+	normalize := func(ts string) string {
+		if ts == "" {
+			return ""
+		}
+		return "norm:" + ts
+	}
+
+	content, err := d.MessageContentFingerprints(ids)
+	require.NoError(t, err)
+	tokens, err := d.MessageTokenFingerprints(ids)
+	require.NoError(t, err)
+	contentHash, err := d.MessageContentHashFingerprints(ids)
+	require.NoError(t, err)
+	roleTime, err := d.MessageRoleTimeFingerprintsWithTimestampNormalizer(
+		ids, normalize,
+	)
+	require.NoError(t, err)
+	flags, err := d.MessageFlagsFingerprints(ids)
+	require.NoError(t, err)
+	system, err := d.SystemMessageFingerprints(ids)
+	require.NoError(t, err)
+	callCounts, err := d.ToolCallCounts(ids)
+	require.NoError(t, err)
+	callSums, err := d.ToolCallContentFingerprints(ids)
+	require.NoError(t, err)
+	callFPs, err := d.ToolCallFingerprints(ids)
+	require.NoError(t, err)
+	resultFPs, err := d.ToolResultEventFingerprintsWithTimestampNormalizer(
+		ids, normalize,
+	)
+	require.NoError(t, err)
+
+	for _, id := range ids {
+		sum, maxLen, minLen, err := d.MessageContentFingerprint(id)
+		require.NoError(t, err, id)
+		assert.Equal(t,
+			MessageContentAggregate{Sum: sum, Max: maxLen, Min: minLen},
+			content[id], "content aggregate %s", id)
+
+		wantToken, err := d.MessageTokenFingerprint(id)
+		require.NoError(t, err, id)
+		assert.Equal(t, wantToken, tokens[id], "token fp %s", id)
+
+		wantHash, err := d.MessageContentHashFingerprint(id)
+		require.NoError(t, err, id)
+		assert.Equal(t, wantHash, contentHash[id], "content hash fp %s", id)
+
+		wantRoleTime, err := d.MessageRoleTimeFingerprintWithTimestampNormalizer(
+			id, normalize,
+		)
+		require.NoError(t, err, id)
+		assert.Equal(t, wantRoleTime, roleTime[id], "role/time fp %s", id)
+
+		wantFlags, err := d.MessageFlagsFingerprint(id)
+		require.NoError(t, err, id)
+		assert.Equal(t, wantFlags, flags[id], "flags fp %s", id)
+
+		wantSystem, err := d.SystemMessageFingerprint(id)
+		require.NoError(t, err, id)
+		assert.Equal(t, wantSystem, system[id], "system fp %s", id)
+
+		wantCount, err := d.ToolCallCount(id)
+		require.NoError(t, err, id)
+		assert.Equal(t, wantCount, callCounts[id], "tool call count %s", id)
+
+		wantSum, err := d.ToolCallContentFingerprint(id)
+		require.NoError(t, err, id)
+		assert.Equal(t, wantSum, callSums[id], "tool call sum %s", id)
+
+		wantCallFP, err := d.ToolCallFingerprint(id)
+		require.NoError(t, err, id)
+		assert.Equal(t, wantCallFP, callFPs[id], "tool call fp %s", id)
+
+		wantResultFP, err := d.ToolResultEventFingerprintWithTimestampNormalizer(
+			id, normalize,
+		)
+		require.NoError(t, err, id)
+		assert.Equal(t, wantResultFP, resultFPs[id], "tool result fp %s", id)
+	}
+
+	assert.NotEmpty(t, tokens["fp-a"], "fixture must produce a token fp")
+	assert.NotEmpty(t, callFPs["fp-a"], "fixture must produce a tool call fp")
+	assert.Equal(t, "0,2", system["fp-a"], "system ordinals")
+}
+
+// TestBatchedFindingsAndPinsMatchPerSession pins nil-vs-empty slice
+// semantics: the push dependency fingerprint JSON-encodes both slices, so
+// a session without findings must stay [] and a session without pins must
+// stay null, exactly as the per-session methods return them.
+func TestBatchedFindingsAndPinsMatchPerSession(t *testing.T) {
+	d, ids := fingerprintBatchFixture(t)
+	ctx := context.Background()
+
+	findings, err := d.SessionSecretFindingsBySession(ctx, ids)
+	require.NoError(t, err)
+	pins, err := d.PinnedMessagesBySession(ctx, ids)
+	require.NoError(t, err)
+
+	for _, id := range ids {
+		wantFindings, err := d.SessionSecretFindings(ctx, id)
+		require.NoError(t, err, id)
+		got, ok := findings[id]
+		require.True(t, ok, "findings entry %s", id)
+		assert.Equal(t, wantFindings, got, "findings %s", id)
+		assert.NotNil(t, got, "findings must be non-nil for %s", id)
+
+		wantPins, err := d.ListPinnedMessages(ctx, id, "")
+		require.NoError(t, err, id)
+		assert.Equal(t, wantPins, pins[id], "pins %s", id)
+	}
+
+	require.Len(t, findings["fp-a"], 2)
+	assert.Equal(t, "token", findings["fp-a"][0].RuleName,
+		"findings keep natural position order (match_start ascending)")
+	require.Len(t, pins["fp-a"], 1)
+	_, hasEmptyPins := pins["fp-empty"]
+	assert.False(t, hasEmptyPins, "pin map omits sessions without pins")
+}

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -1801,49 +1801,17 @@ func (db *DB) MessageTokenFingerprint(sessionID string) (string, error) {
 
 	var b strings.Builder
 	for rows.Next() {
-		var ordinal, contextTokens, outputTokens int
-		var model, tokenUsage string
-		var hasContextTokens, hasOutputTokens bool
-		var claudeMsgID, claudeReqID string
-		var srcType, srcSubtype, srcUUID, srcParentUUID string
-		var isSidechain, isCompactBoundary bool
+		var r tokenFingerprintRow
 		if err := rows.Scan(
-			&ordinal, &model, &tokenUsage, &contextTokens,
-			&outputTokens, &hasContextTokens, &hasOutputTokens,
-			&claudeMsgID, &claudeReqID,
-			&srcType, &srcSubtype, &srcUUID, &srcParentUUID,
-			&isSidechain, &isCompactBoundary,
+			&r.ordinal, &r.model, &r.tokenUsage, &r.contextTokens,
+			&r.outputTokens, &r.hasContextTokens, &r.hasOutputTokens,
+			&r.claudeMessageID, &r.claudeRequestID,
+			&r.sourceType, &r.sourceSubtype, &r.sourceUUID,
+			&r.sourceParentUUID, &r.isSidechain, &r.isCompactBoundary,
 		); err != nil {
 			return "", err
 		}
-		// Sanitize before measuring: the PG-readback
-		// fingerprint sees values sanitized at insert time,
-		// so raw values (e.g. NUL bytes from a corrupt parse)
-		// would never match and the fast path would rewrite
-		// the session on every push.
-		model = SanitizeUTF8(model)
-		tokenUsage = SanitizeUTF8(tokenUsage)
-		claudeMsgID = SanitizeUTF8(claudeMsgID)
-		claudeReqID = SanitizeUTF8(claudeReqID)
-		srcType = SanitizeUTF8(srcType)
-		srcSubtype = SanitizeUTF8(srcSubtype)
-		srcUUID = SanitizeUTF8(srcUUID)
-		srcParentUUID = SanitizeUTF8(srcParentUUID)
-		fmt.Fprintf(&b,
-			"%d|%d:%s|%d:%s|%d|%d|%t|%t|%s|%s|"+
-				"%d:%s|%d:%s|%d:%s|%d:%s|%t|%t;",
-			ordinal,
-			len(model), model,
-			len(tokenUsage), tokenUsage,
-			contextTokens, outputTokens,
-			hasContextTokens, hasOutputTokens,
-			claudeMsgID, claudeReqID,
-			len(srcType), srcType,
-			len(srcSubtype), srcSubtype,
-			len(srcUUID), srcUUID,
-			len(srcParentUUID), srcParentUUID,
-			isSidechain, isCompactBoundary,
-		)
+		r.appendTo(&b)
 	}
 	return b.String(), rows.Err()
 }
@@ -1876,8 +1844,7 @@ func (db *DB) MessageContentHashFingerprint(sessionID string) (string, error) {
 		); err != nil {
 			return "", err
 		}
-		sum := sha256.Sum256([]byte(SanitizeUTF8(content)))
-		fmt.Fprintf(&b, "%d|%d|%x;", ordinal, contentLength, sum)
+		appendContentHashFingerprintRow(&b, ordinal, contentLength, content)
 	}
 	return b.String(), rows.Err()
 }
@@ -1928,12 +1895,9 @@ func (db *DB) MessageRoleTimeFingerprintWithTimestampNormalizer(
 		if err := rows.Scan(&ordinal, &role, &timestamp); err != nil {
 			return "", err
 		}
-		role = SanitizeUTF8(role)
-		if normalizeTimestamp != nil {
-			timestamp = normalizeTimestamp(timestamp)
-		}
-		fmt.Fprintf(&b, "%d|%d:%s|%d:%s;",
-			ordinal, len(role), role, len(timestamp), timestamp)
+		appendRoleTimeFingerprintRow(
+			&b, ordinal, role, timestamp, normalizeTimestamp,
+		)
 	}
 	return b.String(), rows.Err()
 }
@@ -1962,17 +1926,14 @@ func (db *DB) MessageFlagsFingerprint(sessionID string) (string, error) {
 
 	var b strings.Builder
 	for rows.Next() {
-		var ordinal int
-		var isSystem, hasThinking, hasToolUse bool
-		var thinkingText string
+		var r flagsFingerprintRow
 		if err := rows.Scan(
-			&ordinal, &isSystem, &hasThinking, &hasToolUse, &thinkingText,
+			&r.ordinal, &r.isSystem, &r.hasThinking, &r.hasToolUse,
+			&r.thinkingText,
 		); err != nil {
 			return "", err
 		}
-		sum := sha256.Sum256([]byte(SanitizeUTF8(thinkingText)))
-		fmt.Fprintf(&b, "%d|%t|%t|%t|%x;",
-			ordinal, isSystem, hasThinking, hasToolUse, sum)
+		r.appendTo(&b)
 	}
 	return b.String(), rows.Err()
 }
@@ -2115,46 +2076,19 @@ func (db *DB) ToolCallFingerprint(sessionID string) (string, error) {
 	defer rows.Close()
 
 	var b strings.Builder
-	lastMessageOrdinal := -1
-	callIndex := 0
+	var indexer toolCallIndexer
 	for rows.Next() {
-		var messageOrdinal, resultContentLength int
-		var toolName, category, toolUseID, inputJSON string
-		var skillName, subagentSessionID, resultContent, filePath string
+		var r toolCallFingerprintRow
 		if err := rows.Scan(
-			&messageOrdinal, &toolName, &category,
-			&toolUseID, &inputJSON, &skillName, &subagentSessionID,
-			&resultContentLength, &resultContent, &filePath,
+			&r.messageOrdinal, &r.toolName, &r.category,
+			&r.toolUseID, &r.inputJSON, &r.skillName,
+			&r.subagentSessionID, &r.resultContentLength,
+			&r.resultContent, &r.filePath,
 		); err != nil {
 			return "", err
 		}
-		if messageOrdinal == lastMessageOrdinal {
-			callIndex++
-		} else {
-			lastMessageOrdinal = messageOrdinal
-			callIndex = 0
-		}
-		toolName = SanitizeUTF8(toolName)
-		category = SanitizeUTF8(category)
-		toolUseID = SanitizeUTF8(toolUseID)
-		inputJSON = SanitizeUTF8(inputJSON)
-		skillName = SanitizeUTF8(skillName)
-		subagentSessionID = SanitizeUTF8(subagentSessionID)
-		resultContent = SanitizeUTF8(resultContent)
-		filePath = SanitizeUTF8(filePath)
-		fmt.Fprintf(&b,
-			"%d|%d|%d:%s|%d:%s|%d:%s|%d:%s|%d:%s|%d:%s|%d|%d:%s|%d:%s;",
-			messageOrdinal, callIndex,
-			len(toolName), toolName,
-			len(category), category,
-			len(toolUseID), toolUseID,
-			len(inputJSON), inputJSON,
-			len(skillName), skillName,
-			len(subagentSessionID), subagentSessionID,
-			resultContentLength,
-			len(resultContent), resultContent,
-			len(filePath), filePath,
-		)
+		r.callIndex = indexer.next(sessionID, r.messageOrdinal)
+		r.appendTo(&b)
 	}
 	return b.String(), rows.Err()
 }
@@ -2184,39 +2118,16 @@ func (db *DB) ToolResultEventFingerprintWithTimestampNormalizer(
 
 	var b strings.Builder
 	for rows.Next() {
-		var messageOrdinal, callIndex, eventIndex, contentLength int
-		var toolUseID, agentID, subagentSessionID string
-		var source, status, content, timestamp string
+		var r toolResultEventFingerprintRow
 		if err := rows.Scan(
-			&messageOrdinal, &callIndex, &eventIndex,
-			&toolUseID, &agentID, &subagentSessionID,
-			&source, &status, &content, &contentLength, &timestamp,
+			&r.messageOrdinal, &r.callIndex, &r.eventIndex,
+			&r.toolUseID, &r.agentID, &r.subagentSessionID,
+			&r.source, &r.status, &r.content, &r.contentLength,
+			&r.timestamp,
 		); err != nil {
 			return "", err
 		}
-		if normalizeTimestamp != nil {
-			timestamp = normalizeTimestamp(timestamp)
-		}
-		toolUseID = SanitizeUTF8(toolUseID)
-		agentID = SanitizeUTF8(agentID)
-		subagentSessionID = SanitizeUTF8(subagentSessionID)
-		source = SanitizeUTF8(source)
-		status = SanitizeUTF8(status)
-		content = SanitizeUTF8(content)
-		contentSum := sha256.Sum256([]byte(content))
-		fmt.Fprintf(
-			&b,
-			"%d|%d|%d|%d:%s|%d:%s|%d:%s|%d:%s|%d:%s|%d|%x|%d:%s;",
-			messageOrdinal, callIndex, eventIndex,
-			len(toolUseID), toolUseID,
-			len(agentID), agentID,
-			len(subagentSessionID), subagentSessionID,
-			len(source), source,
-			len(status), status,
-			contentLength,
-			contentSum,
-			len(timestamp), timestamp,
-		)
+		r.appendTo(&b, normalizeTimestamp)
 	}
 	return b.String(), rows.Err()
 }

--- a/internal/db/search_content.go
+++ b/internal/db/search_content.go
@@ -713,11 +713,11 @@ func classifyFTSError(err error) error {
 	return err
 }
 
-// semanticOverfetchMin floors the candidate count requested from the
-// VectorSearcher (k = max(f.Limit*4, semanticOverfetchMin)): session-scope
+// SemanticOverfetchMin floors the candidate count requested from the
+// VectorSearcher (k = max(f.Limit*4, SemanticOverfetchMin)): session-scope
 // filtering may drop some of the searcher's top hits, so more are fetched
 // than will ultimately be returned.
-const semanticOverfetchMin = 200
+const SemanticOverfetchMin = 200
 
 // validateSemanticSources returns a SearchInputError unless f.Sources is
 // empty or exactly {"messages"}: semantic (and hybrid) search only indexes
@@ -760,13 +760,13 @@ func ValidateSemanticFilter(f ContentSearchFilter) error {
 	return nil
 }
 
-// scopeExcludes reports whether a unit with the given subordinate flag
+// ScopeExcludes reports whether a unit with the given subordinate flag
 // falls outside the requested scope: "top" excludes subordinate units,
 // "subordinate" excludes top-level ones, and ""/"all" exclude nothing.
 // Scope filtering runs on each leg's hits before the RRF merge (and before
 // the limit), so a scoped search still fills up to Limit from the
 // over-fetched candidates instead of returning a post-truncation remnant.
-func scopeExcludes(scope string, subordinate bool) bool {
+func ScopeExcludes(scope string, subordinate bool) bool {
 	switch scope {
 	case "top":
 		return subordinate
@@ -781,7 +781,7 @@ func scopeExcludes(scope string, subordinate bool) bool {
 // from the wired VectorSearcher, keeps hits whose session passes the
 // filter's metadata scope (loaded with one query over the hit session IDs;
 // the sidebar-child exclusion is lifted — f.Scope governs subordinate-unit
-// visibility instead, dropping hits scopeExcludes rules out),
+// visibility instead, dropping hits ScopeExcludes rules out),
 // routes the surviving ranking through the same RRF merge hybrid uses as a
 // one-leg fusion (so subordinate units are penalized identically; matches
 // still carry the searcher's own scores), enriches surviving (session_id,
@@ -798,7 +798,7 @@ func (db *DB) searchContentSemantic(
 		return ContentSearchPage{}, ErrSemanticUnavailable
 	}
 
-	k := max(f.Limit*4, semanticOverfetchMin)
+	k := max(f.Limit*4, SemanticOverfetchMin)
 	hits, err := searcher.SemanticSearch(ctx, f.Pattern, k)
 	if err != nil {
 		return ContentSearchPage{}, err
@@ -813,14 +813,14 @@ func (db *DB) searchContentSemantic(
 	}
 	surviving := make([]VectorHit, 0, len(hits))
 	for _, h := range hits {
-		if allowed[h.SessionID] && !scopeExcludes(f.Scope, h.Subordinate) {
+		if allowed[h.SessionID] && !ScopeExcludes(f.Scope, h.Subordinate) {
 			surviving = append(surviving, h)
 		}
 	}
 	if len(surviving) == 0 {
 		return ContentSearchPage{}, nil
 	}
-	surviving = applySubordinatePenalty(surviving)
+	surviving = ApplySubordinatePenalty(surviving)
 
 	meta, err := db.enrichSemanticHits(ctx, surviving)
 	if err != nil {
@@ -847,7 +847,7 @@ func (db *DB) searchContentSemantic(
 			ParentSessionID: info.parentSessionID,
 			Sidechain:       info.isSidechain,
 			Timestamp:       info.timestamp,
-			Snippet:         f.semanticSnippet(info.content, h.Snippet),
+			Snippet:         f.SemanticSnippet(info.content, h.Snippet),
 			Score:           &score,
 		})
 		if len(out) >= f.Limit {
@@ -857,36 +857,36 @@ func (db *DB) searchContentSemantic(
 	return ContentSearchPage{Matches: out}, nil
 }
 
-// unitFusionKey identifies one embedding unit across the hybrid search's
+// UnitFusionKey identifies one embedding unit across the hybrid search's
 // legs: the mirror's unique (session_id, ordinal_start) pair. The vector leg
 // derives it from a VectorHit, the FTS leg from a resolved UnitRef, so hits
 // on the same unit fuse.
-func unitFusionKey(sessionID string, ordinalStart int) string {
+func UnitFusionKey(sessionID string, ordinalStart int) string {
 	return "u\x00" + sessionID + "\x00" + strconv.Itoa(ordinalStart)
 }
 
-// messageFusionKey identifies an FTS hit with no containing unit at message
+// MessageFusionKey identifies an FTS hit with no containing unit at message
 // granularity, so an exact-string hit outside the embeddable universe never
 // vanishes from the fused result. The "m" prefix keeps it disjoint from
-// unitFusionKey's space.
-func messageFusionKey(sessionID string, ordinal int) string {
+// UnitFusionKey's space.
+func MessageFusionKey(sessionID string, ordinal int) string {
 	return "m\x00" + sessionID + "\x00" + strconv.Itoa(ordinal)
 }
 
-// unitRanked is one leg entry for rrfMerge: a fusion key plus the unit's
+// RankedUnit is one leg entry for RRFMerge: a fusion key plus the unit's
 // subordinate flag.
-type unitRanked struct {
+type RankedUnit struct {
 	Key         string
 	Subordinate bool
 }
 
-// mergedUnit is one fused rrfMerge result.
-type mergedUnit struct {
-	unit  unitRanked
-	score float64
+// FusedUnit is one fused RRFMerge result.
+type FusedUnit struct {
+	Unit  RankedUnit
+	Score float64
 }
 
-// rrfMerge fuses per-leg unit rankings (best first) with reciprocal-rank
+// RRFMerge fuses per-leg unit rankings (best first) with reciprocal-rank
 // fusion, penalizing subordinate units by shifting their effective rank
 // (rank+5 against a rank constant of 60). Semantic-only search routes its
 // single ranked list through this same merge as a one-leg fusion, so the
@@ -897,11 +897,11 @@ type mergedUnit struct {
 // twice. This is a local merge rather than kitvec.Merge because kit's Merge
 // has no per-hit rank-offset hook for the subordinate penalty; upstreaming
 // such a hook would let this collapse onto kit's implementation later.
-func rrfMerge(legs [][]unitRanked, limit int) []mergedUnit {
+func RRFMerge(legs [][]RankedUnit, limit int) []FusedUnit {
 	const rankConstant = 60
 	const subordinatePenalty = 5
 	scores := make(map[string]float64)
-	var units []unitRanked
+	var units []RankedUnit
 	for _, leg := range legs {
 		for i, u := range leg {
 			rank := i + 1
@@ -914,18 +914,18 @@ func rrfMerge(legs [][]unitRanked, limit int) []mergedUnit {
 			scores[u.Key] += 1.0 / float64(rankConstant+rank)
 		}
 	}
-	merged := make([]mergedUnit, len(units))
+	merged := make([]FusedUnit, len(units))
 	for i, u := range units {
-		merged[i] = mergedUnit{unit: u, score: scores[u.Key]}
+		merged[i] = FusedUnit{Unit: u, Score: scores[u.Key]}
 	}
-	slices.SortFunc(merged, func(a, b mergedUnit) int {
-		if a.score != b.score {
-			if a.score > b.score {
+	slices.SortFunc(merged, func(a, b FusedUnit) int {
+		if a.Score != b.Score {
+			if a.Score > b.Score {
 				return -1
 			}
 			return 1
 		}
-		return strings.Compare(a.unit.Key, b.unit.Key)
+		return strings.Compare(a.Unit.Key, b.Unit.Key)
 	})
 	if limit > 0 && len(merged) > limit {
 		merged = merged[:limit]
@@ -933,27 +933,27 @@ func rrfMerge(legs [][]unitRanked, limit int) []mergedUnit {
 	return merged
 }
 
-// applySubordinatePenalty reorders rank-ordered semantic hits through
-// rrfMerge as a one-leg fusion, so mode "semantic" penalizes subordinate
+// ApplySubordinatePenalty reorders rank-ordered semantic hits through
+// RRFMerge as a one-leg fusion, so mode "semantic" penalizes subordinate
 // units exactly like mode "hybrid" (one implementation, no hybrid-only
 // special case). Hits keep their own scores; only the order changes. A
 // duplicate fusion key (two hits on the same unit) keeps its best-ranked
 // hit.
-func applySubordinatePenalty(hits []VectorHit) []VectorHit {
-	leg := make([]unitRanked, 0, len(hits))
+func ApplySubordinatePenalty(hits []VectorHit) []VectorHit {
+	leg := make([]RankedUnit, 0, len(hits))
 	byKey := make(map[string]VectorHit, len(hits))
 	for _, h := range hits {
-		key := unitFusionKey(h.SessionID, h.OrdinalStart)
+		key := UnitFusionKey(h.SessionID, h.OrdinalStart)
 		if _, dup := byKey[key]; dup {
 			continue
 		}
-		leg = append(leg, unitRanked{Key: key, Subordinate: h.Subordinate})
+		leg = append(leg, RankedUnit{Key: key, Subordinate: h.Subordinate})
 		byKey[key] = h
 	}
-	merged := rrfMerge([][]unitRanked{leg}, 0)
+	merged := RRFMerge([][]RankedUnit{leg}, 0)
 	out := make([]VectorHit, 0, len(merged))
 	for _, m := range merged {
-		out = append(out, byKey[m.unit.Key])
+		out = append(out, byKey[m.Unit.Key])
 	}
 	return out
 }
@@ -973,10 +973,10 @@ type hybridDisplay struct {
 	snippet      string
 }
 
-// hybridLeg is one rank-ordered fusion leg: entries for rrfMerge plus each
+// hybridLeg is one rank-ordered fusion leg: entries for RRFMerge plus each
 // key's display info.
 type hybridLeg struct {
-	ranked  []unitRanked
+	ranked  []RankedUnit
 	display map[string]hybridDisplay
 }
 
@@ -984,7 +984,7 @@ type hybridLeg struct {
 // rankings are each over-fetched to k, the vector leg is filtered down to
 // sessions passing the filter's metadata scope (the FTS leg filters in SQL),
 // FTS message hits are resolved to their containing units, and the two
-// rank-ordered leg lists are fused at unit granularity with rrfMerge.
+// rank-ordered leg lists are fused at unit granularity with RRFMerge.
 // Returned matches are enriched with session/message metadata via the same
 // lookup semantic search uses, ordered by fused score descending, truncated
 // to f.Limit.
@@ -1002,7 +1002,7 @@ func (db *DB) searchContentHybrid(
 		return ContentSearchPage{}, errFTSUnavailable
 	}
 
-	k := max(f.Limit*4, semanticOverfetchMin)
+	k := max(f.Limit*4, SemanticOverfetchMin)
 	vecLeg, err := db.hybridVectorLeg(ctx, f, searcher, k)
 	if err != nil {
 		return ContentSearchPage{}, err
@@ -1015,7 +1015,7 @@ func (db *DB) searchContentHybrid(
 		return ContentSearchPage{}, nil
 	}
 
-	merged := rrfMerge([][]unitRanked{vecLeg.ranked, ftsLeg.ranked}, f.Limit)
+	merged := RRFMerge([][]RankedUnit{vecLeg.ranked, ftsLeg.ranked}, f.Limit)
 	return db.enrichHybridMatches(ctx, f, merged, vecLeg.display, ftsLeg.display)
 }
 
@@ -1041,14 +1041,14 @@ func (db *DB) hybridVectorLeg(
 		return hybridLeg{}, err
 	}
 	for _, h := range hits {
-		if !allowed[h.SessionID] || scopeExcludes(f.Scope, h.Subordinate) {
+		if !allowed[h.SessionID] || ScopeExcludes(f.Scope, h.Subordinate) {
 			continue
 		}
-		key := unitFusionKey(h.SessionID, h.OrdinalStart)
+		key := UnitFusionKey(h.SessionID, h.OrdinalStart)
 		if _, seen := leg.display[key]; seen {
 			continue
 		}
-		leg.ranked = append(leg.ranked, unitRanked{Key: key, Subordinate: h.Subordinate})
+		leg.ranked = append(leg.ranked, RankedUnit{Key: key, Subordinate: h.Subordinate})
 		leg.display[key] = hybridDisplay{
 			sessionID: h.SessionID, ordinal: h.Ordinal, snippet: h.Snippet,
 			ordinalStart: h.OrdinalStart, ordinalEnd: h.OrdinalEnd,
@@ -1177,13 +1177,13 @@ func (db *DB) appendHybridFTSHits(
 	var unitless []int
 	for i := range hits {
 		hit := &hits[i]
-		keys[i] = messageFusionKey(hit.sessionID, hit.ordinal)
+		keys[i] = MessageFusionKey(hit.sessionID, hit.ordinal)
 		hit.ordinalStart, hit.ordinalEnd = hit.ordinal, hit.ordinal
 		if units[i].DocKey == "" {
 			unitless = append(unitless, i)
 			continue
 		}
-		keys[i] = unitFusionKey(units[i].SessionID, units[i].OrdinalStart)
+		keys[i] = UnitFusionKey(units[i].SessionID, units[i].OrdinalStart)
 		hit.ordinalStart = units[i].OrdinalStart
 		hit.ordinalEnd = units[i].OrdinalEnd
 		hit.subordinate = units[i].Subordinate
@@ -1193,13 +1193,13 @@ func (db *DB) appendHybridFTSHits(
 	}
 
 	for i, hit := range hits {
-		if scopeExcludes(scope, hit.subordinate) {
+		if ScopeExcludes(scope, hit.subordinate) {
 			continue
 		}
 		if _, seen := leg.display[keys[i]]; seen {
 			continue
 		}
-		leg.ranked = append(leg.ranked, unitRanked{Key: keys[i], Subordinate: hit.subordinate})
+		leg.ranked = append(leg.ranked, RankedUnit{Key: keys[i], Subordinate: hit.subordinate})
 		leg.display[keys[i]] = hit
 	}
 	return nil
@@ -1211,20 +1211,20 @@ func (db *DB) appendHybridFTSHits(
 // wins: the match anchors on the FTS-matched message's ordinal and centers
 // on the FTS snippet (the vector leg's chunk anchor may be a different run
 // member). Either way the returned snippet itself is built (and redacted)
-// from the anchor message's full content via semanticSnippet, the same
+// from the anchor message's full content via SemanticSnippet, the same
 // guarantee mode "semantic" gives. Unit-less FTS rows arrive with their
 // derived range and subordinate flag already assigned pre-merge
 // (classifyUnitlessHybridHits), so no derivation runs here.
 func (db *DB) enrichHybridMatches(
-	ctx context.Context, f ContentSearchFilter, merged []mergedUnit,
+	ctx context.Context, f ContentSearchFilter, merged []FusedUnit,
 	vecDisplay, ftsDisplay map[string]hybridDisplay,
 ) (ContentSearchPage, error) {
 	displays := make([]hybridDisplay, len(merged))
 	asHits := make([]VectorHit, len(merged))
 	for i, m := range merged {
-		d, ok := ftsDisplay[m.unit.Key]
+		d, ok := ftsDisplay[m.Unit.Key]
 		if !ok {
-			d = vecDisplay[m.unit.Key]
+			d = vecDisplay[m.Unit.Key]
 		}
 		displays[i] = d
 		asHits[i] = VectorHit{SessionID: d.sessionID, Ordinal: d.ordinal}
@@ -1241,7 +1241,7 @@ func (db *DB) enrichHybridMatches(
 		if !ok {
 			continue
 		}
-		score := m.score
+		score := m.Score
 		out = append(out, ContentMatch{
 			SessionID:       d.sessionID,
 			Project:         info.project,
@@ -1255,7 +1255,7 @@ func (db *DB) enrichHybridMatches(
 			ParentSessionID: info.parentSessionID,
 			Sidechain:       info.isSidechain,
 			Timestamp:       info.timestamp,
-			Snippet:         f.semanticSnippet(info.content, d.snippet),
+			Snippet:         f.SemanticSnippet(info.content, d.snippet),
 			Score:           &score,
 		})
 	}
@@ -1336,7 +1336,7 @@ type semanticHitKey struct {
 
 // semanticHitInfo is the session/message metadata enrichSemanticHits attaches
 // to a surviving hit. content is the message's full, un-truncated content:
-// semantic/hybrid snippets are built from it (see semanticSnippet) rather
+// semantic/hybrid snippets are built from it (see SemanticSnippet) rather
 // than from the searcher's pre-truncated chunk/snippet text, so secret
 // redaction sees the same whole-body context the substring/regex/fts paths
 // give it instead of a fragment that can split a secret at the truncation
@@ -1444,7 +1444,7 @@ func approxSnippetSpan(content, approx string) (start, end int, ok bool) {
 	return off, off + len(trimmed), true
 }
 
-// semanticSnippet builds the returned snippet for "semantic" and "hybrid"
+// SemanticSnippet builds the returned snippet for "semantic" and "hybrid"
 // matches from the message's full content, not from the searcher's
 // pre-truncated approx (chunk or FTS snippet() text): redaction
 // (buildSnippet -> secrets.RedactWindow) must see the whole message so a
@@ -1453,7 +1453,7 @@ func approxSnippetSpan(content, approx string) (start, end int, ok bool) {
 // center the window; when it cannot be located in content, FTSSnippetRange
 // centers on the query pattern instead, and failing that on the start of
 // content -- content is still what gets redacted either way.
-func (f ContentSearchFilter) semanticSnippet(content, approx string) string {
+func (f ContentSearchFilter) SemanticSnippet(content, approx string) string {
 	if start, end, ok := approxSnippetSpan(content, approx); ok {
 		return f.buildSnippet(content, start, end)
 	}

--- a/internal/db/search_content_hybrid_test.go
+++ b/internal/db/search_content_hybrid_test.go
@@ -231,10 +231,10 @@ func TestSearchContentHybridRedactsSecretPastChunkTruncation(t *testing.T) {
 }
 
 // mergedKeys projects a merged result to its keys in rank order.
-func mergedKeys(merged []mergedUnit) []string {
+func mergedKeys(merged []FusedUnit) []string {
 	keys := make([]string, len(merged))
 	for i, m := range merged {
-		keys[i] = m.unit.Key
+		keys[i] = m.Unit.Key
 	}
 	return keys
 }
@@ -243,33 +243,33 @@ func mergedKeys(merged []mergedUnit) []string {
 // merge level: a unit ranked by both legs scores the sum of its per-leg
 // reciprocal ranks and outranks a unit seen by only one leg.
 func TestRRFMergeBothLegsOutrankSingleLeg(t *testing.T) {
-	merged := rrfMerge([][]unitRanked{
+	merged := RRFMerge([][]RankedUnit{
 		{{Key: "a"}, {Key: "b"}},
 		{{Key: "a"}},
 	}, 0)
 	require.Equal(t, []string{"a", "b"}, mergedKeys(merged))
-	assert.InDelta(t, 2.0/61.0, merged[0].score, 1e-12, "double-leg score")
-	assert.InDelta(t, 1.0/62.0, merged[1].score, 1e-12, "single-leg score")
+	assert.InDelta(t, 2.0/61.0, merged[0].Score, 1e-12, "double-leg score")
+	assert.InDelta(t, 1.0/62.0, merged[1].Score, 1e-12, "single-leg score")
 }
 
 // TestRRFMergeSubordinatePenaltyAcrossLegs pins the rank+5 penalty: a
 // subordinate unit at leg rank 1 must fall below a top-level unit at the
 // same rank in the other leg.
 func TestRRFMergeSubordinatePenaltyAcrossLegs(t *testing.T) {
-	merged := rrfMerge([][]unitRanked{
+	merged := RRFMerge([][]RankedUnit{
 		{{Key: "sub", Subordinate: true}},
 		{{Key: "top"}},
 	}, 0)
 	require.Equal(t, []string{"top", "sub"}, mergedKeys(merged))
-	assert.InDelta(t, 1.0/61.0, merged[0].score, 1e-12)
-	assert.InDelta(t, 1.0/66.0, merged[1].score, 1e-12, "subordinate uses rank+5")
+	assert.InDelta(t, 1.0/61.0, merged[0].Score, 1e-12)
+	assert.InDelta(t, 1.0/66.0, merged[1].Score, 1e-12, "subordinate uses rank+5")
 }
 
 // TestRRFMergeOneLegSubordinatePenaltyReorders pins the one-leg (semantic-
 // only) fusion contract: a subordinate unit ranked immediately above a
 // top-level unit drops below it after the merge.
 func TestRRFMergeOneLegSubordinatePenaltyReorders(t *testing.T) {
-	merged := rrfMerge([][]unitRanked{{
+	merged := RRFMerge([][]RankedUnit{{
 		{Key: "sub", Subordinate: true},
 		{Key: "top"},
 	}}, 0)
@@ -280,13 +280,13 @@ func TestRRFMergeOneLegSubordinatePenaltyReorders(t *testing.T) {
 // rank 1 (effective rank 6) scores exactly like a top-level unit at rank 6,
 // and the tie breaks by ascending key, not map iteration order.
 func TestRRFMergeDeterministicTieBreak(t *testing.T) {
-	leg := []unitRanked{
+	leg := []RankedUnit{
 		{Key: "zzz", Subordinate: true},
 		{Key: "m2"}, {Key: "m3"}, {Key: "m4"}, {Key: "m5"},
 		{Key: "aaa"},
 	}
 	for range 20 {
-		merged := rrfMerge([][]unitRanked{leg}, 0)
+		merged := RRFMerge([][]RankedUnit{leg}, 0)
 		require.Equal(t,
 			[]string{"m2", "m3", "m4", "m5", "aaa", "zzz"}, mergedKeys(merged))
 	}
@@ -295,7 +295,7 @@ func TestRRFMergeDeterministicTieBreak(t *testing.T) {
 // TestRRFMergeLimitHonored pins truncation: limit > 0 caps the merged list
 // at the top-scored units.
 func TestRRFMergeLimitHonored(t *testing.T) {
-	merged := rrfMerge([][]unitRanked{
+	merged := RRFMerge([][]RankedUnit{
 		{{Key: "a"}, {Key: "b"}, {Key: "c"}},
 	}, 2)
 	assert.Equal(t, []string{"a", "b"}, mergedKeys(merged))
@@ -564,7 +564,7 @@ func TestSearchContentHybridMatchCarriesUnitRangeAndLineage(t *testing.T) {
 
 // TestSearchContentHybridFTSLegCollapseRefillsFromDeeperRanks pins the
 // batched FTS leg against unit collapse: when more than k (the
-// semanticOverfetchMin=200 fusion depth) rank-ordered FTS rows all fall
+// SemanticOverfetchMin=200 fusion depth) rank-ordered FTS rows all fall
 // inside ONE run-unit, they collapse to a single leg entry, and a match in a
 // different unit ranked below all of them must still be fetched and returned
 // rather than being cut off by the first batch's window.

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -3129,6 +3129,41 @@ func (db *DB) ListSessionsModifiedBetween(
 	return sessions, rows.Err()
 }
 
+// SessionProjectsByIDs returns each session's current project keyed by session
+// ID. IDs with no sessions row are absent from the result, so a caller can tell
+// "unknown session" (missing key) from "empty project" (present, empty value).
+// It is the live-project source for scoping a filtered push by each session's
+// current project rather than by a possibly stale mirror.
+func (db *DB) SessionProjectsByIDs(
+	ctx context.Context, ids []string,
+) (map[string]string, error) {
+	out := make(map[string]string, len(ids))
+	if len(ids) == 0 {
+		return out, nil
+	}
+	err := queryChunked(ids, func(chunk []string) error {
+		placeholders, args := inPlaceholders(chunk)
+		rows, err := db.getReader().QueryContext(ctx,
+			"SELECT id, project FROM sessions WHERE id IN "+placeholders, args...)
+		if err != nil {
+			return fmt.Errorf("reading session projects: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var id, project string
+			if err := rows.Scan(&id, &project); err != nil {
+				return fmt.Errorf("scanning session project: %w", err)
+			}
+			out[id] = project
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // trustedSQLiteExpr is a string type for SQL expressions known to be safe
 // (literals, column references). Using a distinct type prevents accidental
 // injection of user input, mirroring the trustedSQL pattern in pgsync/time.go.

--- a/internal/postgres/messages.go
+++ b/internal/postgres/messages.go
@@ -295,10 +295,11 @@ func (s *Store) SearchSession(
 // HasFTS returns true because ILIKE search is available.
 func (s *Store) HasFTS() bool { return true }
 
-// HasSemantic returns false: the PostgreSQL store has no VectorSearcher seam
-// yet, so SearchContent rejects "semantic"/"hybrid" modes up front with
+// HasSemantic reports whether a PG vector searcher was wired at startup
+// (pg serve found a generation matching its embeddings fingerprint). When
+// false, SearchContent rejects "semantic"/"hybrid" modes up front with
 // db.ErrSemanticUnavailable.
-func (s *Store) HasSemantic() bool { return false }
+func (s *Store) HasSemantic() bool { return s.getVectorSearcher() != nil }
 
 // escapeLike escapes SQL LIKE metacharacters so the bind
 // parameter is treated as a literal substring.

--- a/internal/postgres/project_identity_pgtest_test.go
+++ b/internal/postgres/project_identity_pgtest_test.go
@@ -1,0 +1,159 @@
+//go:build pgtest
+
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/export"
+)
+
+type identityRow struct {
+	Project       string
+	Machine       string
+	RootPath      string
+	GitRemote     string
+	GitRemoteName string
+	Key           string
+}
+
+func readIdentityRows(
+	t *testing.T, ctx context.Context, pg *sql.DB,
+) []identityRow {
+	t.Helper()
+	rows, err := pg.QueryContext(ctx, `
+		SELECT project, machine, root_path, git_remote, git_remote_name, key
+		FROM project_identity_observations
+		ORDER BY project, machine, root_path, git_remote`)
+	require.NoError(t, err)
+	defer rows.Close()
+	var out []identityRow
+	for rows.Next() {
+		var r identityRow
+		require.NoError(t, rows.Scan(
+			&r.Project, &r.Machine, &r.RootPath,
+			&r.GitRemote, &r.GitRemoteName, &r.Key,
+		))
+		out = append(out, r)
+	}
+	require.NoError(t, rows.Err())
+	return out
+}
+
+// TestSyncProjectIdentityObservationsBatchMatchesSequential pins that the
+// set-based observation sync leaves the table in exactly the state the
+// per-row upsert loop produced, across the fallback-vs-real-remote cases
+// the per-row logic encodes.
+func TestSyncProjectIdentityObservationsBatchMatchesSequential(t *testing.T) {
+	pgURL := testPGURL(t)
+	const schema = "agentsview_projident_batch_test"
+	pg, err := Open(pgURL, schema, true)
+	require.NoError(t, err, "Open")
+	defer pg.Close()
+
+	ctx := context.Background()
+	_, err = pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
+
+	obs := func(root, remote, name string) export.ProjectIdentityObservation {
+		return export.ProjectIdentityObservation{
+			Project:       "proj",
+			Machine:       "m1",
+			RootPath:      root,
+			GitRemote:     remote,
+			GitRemoteName: name,
+			ObservedAt:    time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
+			Key:           fmt.Sprintf("%s|%s", root, remote),
+		}
+	}
+
+	// Pre-existing PG state the batch must interact with: a fallback row
+	// that a batched real observation must delete, a real-remote row that
+	// must suppress a batched fallback, and a real-remote row the batch
+	// updates via ON CONFLICT.
+	preExisting := []export.ProjectIdentityObservation{
+		obs("/replaced-fallback", "", ""),
+		obs("/has-remote", "git@x:h.git", "origin"),
+		obs("/updated", "git@x:u.git", "old-name"),
+	}
+
+	// The batch covers: real+fallback for one root in both orders, a
+	// surviving fallback, a fallback suppressed by pre-existing state, a
+	// real row replacing a pre-existing fallback, an ON CONFLICT update,
+	// and duplicate conflict keys where the last observation wins.
+	batch := []export.ProjectIdentityObservation{
+		obs("/mixed-real-first", "git@x:m1.git", "origin"),
+		obs("/mixed-real-first", "", ""),
+		obs("/mixed-fallback-first", "", ""),
+		obs("/mixed-fallback-first", "git@x:m2.git", "origin"),
+		obs("/fallback-only", "", ""),
+		obs("/has-remote", "", ""),
+		obs("/replaced-fallback", "git@x:r.git", "origin"),
+		obs("/updated", "git@x:u.git", "dup-old"),
+		obs("/updated", "git@x:u.git", "new-name"),
+	}
+
+	reset := func() {
+		_, err := pg.ExecContext(ctx,
+			`DELETE FROM project_identity_observations`)
+		require.NoError(t, err)
+		tx, err := pg.BeginTx(ctx, nil)
+		require.NoError(t, err)
+		defer func() { _ = tx.Rollback() }()
+		for _, o := range preExisting {
+			require.NoError(t,
+				upsertProjectIdentityObservation(ctx, tx, o, ""))
+		}
+		require.NoError(t, tx.Commit())
+	}
+
+	reset()
+	tx, err := pg.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	for _, o := range batch {
+		require.NoError(t, upsertProjectIdentityObservation(ctx, tx, o, ""))
+	}
+	require.NoError(t, tx.Commit())
+	sequential := readIdentityRows(t, ctx, pg)
+
+	reset()
+	tx, err = pg.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	require.NoError(t, syncProjectIdentityObservationsBatch(ctx, tx, batch))
+	require.NoError(t, tx.Commit())
+	batched := readIdentityRows(t, ctx, pg)
+
+	assert.Equal(t, sequential, batched,
+		"batched sync must leave the table in the sequential state")
+
+	// Anchor the shared outcome so a bug that changes both paths in the
+	// same way cannot slip through the differential comparison.
+	assert.Equal(t, []identityRow{
+		{"proj", "m1", "/fallback-only", "", "", "/fallback-only|"},
+		{"proj", "m1", "/has-remote", "git@x:h.git", "origin",
+			"/has-remote|git@x:h.git"},
+		{"proj", "m1", "/mixed-fallback-first", "git@x:m2.git", "origin",
+			"/mixed-fallback-first|git@x:m2.git"},
+		{"proj", "m1", "/mixed-real-first", "git@x:m1.git", "origin",
+			"/mixed-real-first|git@x:m1.git"},
+		{"proj", "m1", "/replaced-fallback", "git@x:r.git", "origin",
+			"/replaced-fallback|git@x:r.git"},
+		{"proj", "m1", "/updated", "git@x:u.git", "new-name",
+			"/updated|git@x:u.git"},
+	}, batched)
+
+	// An empty batch must be a no-op rather than an SQL error.
+	tx, err = pg.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	require.NoError(t, syncProjectIdentityObservationsBatch(ctx, tx, nil))
+	require.NoError(t, tx.Commit())
+	assert.Equal(t, batched, readIdentityRows(t, ctx, pg))
+}

--- a/internal/postgres/project_identity_upsert.go
+++ b/internal/postgres/project_identity_upsert.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 
 	"go.kenn.io/agentsview/internal/export"
 )
@@ -55,7 +56,17 @@ func upsertProjectIdentityObservation(
 			normalized_remote, key_source, key
 		) VALUES (
 			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
-		)
+		)`+projectIdentityObservationConflictClause,
+		obs.Project, obs.Machine, obs.RootPath, obs.GitRemote,
+		obs.GitRemoteName, obs.WorktreeName, obs.WorktreeRootPath,
+		obs.ObservedAt, obs.NormalizedRemote, obs.KeySource, obs.Key,
+	); err != nil {
+		return fmt.Errorf("upserting pg project identity observation: %w", err)
+	}
+	return nil
+}
+
+const projectIdentityObservationConflictClause = `
 		ON CONFLICT (project, machine, root_path, git_remote)
 		DO UPDATE SET
 			git_remote_name = EXCLUDED.git_remote_name,
@@ -64,12 +75,252 @@ func upsertProjectIdentityObservation(
 			observed_at = EXCLUDED.observed_at,
 			normalized_remote = EXCLUDED.normalized_remote,
 			key_source = EXCLUDED.key_source,
-			key = EXCLUDED.key`,
-		obs.Project, obs.Machine, obs.RootPath, obs.GitRemote,
-		obs.GitRemoteName, obs.WorktreeName, obs.WorktreeRootPath,
-		obs.ObservedAt, obs.NormalizedRemote, obs.KeySource, obs.Key,
+			key = EXCLUDED.key`
+
+// projectIdentityRootKey identifies the root a fallback (empty git_remote)
+// observation competes with real-remote observations over.
+type projectIdentityRootKey struct {
+	project  string
+	machine  string
+	rootPath string
+}
+
+func observationRootKey(
+	obs export.ProjectIdentityObservation,
+) projectIdentityRootKey {
+	return projectIdentityRootKey{
+		project:  obs.Project,
+		machine:  obs.Machine,
+		rootPath: obs.RootPath,
+	}
+}
+
+type projectIdentityObservationPlan struct {
+	// realRemote holds deduped observations with a git remote.
+	realRemote []export.ProjectIdentityObservation
+	// fallbacks holds deduped empty-remote observations whose root has no
+	// real-remote observation in the batch. Whether each survives still
+	// depends on the rows already in PG.
+	fallbacks []export.ProjectIdentityObservation
+	// realRoots lists the roots of realRemote in first-seen order; stale
+	// fallback rows for these roots must be deleted.
+	realRoots []projectIdentityRootKey
+}
+
+// planProjectIdentityObservationSync reduces a batch to the final state of
+// applying upsertProjectIdentityObservation to each row in order: the last
+// observation per conflict key wins, and an empty-remote observation never
+// survives alongside a real-remote observation for the same root — an
+// earlier real row makes the fallback's existence check succeed, and a
+// later real row deletes the already-inserted fallback.
+func planProjectIdentityObservationSync(
+	observations []export.ProjectIdentityObservation,
+) projectIdentityObservationPlan {
+	type conflictKey struct {
+		root      projectIdentityRootKey
+		gitRemote string
+	}
+	keyOrder := make([]conflictKey, 0, len(observations))
+	latest := make(map[conflictKey]export.ProjectIdentityObservation,
+		len(observations))
+	realRootSet := make(map[projectIdentityRootKey]bool)
+
+	var plan projectIdentityObservationPlan
+	for _, obs := range observations {
+		key := conflictKey{
+			root: observationRootKey(obs), gitRemote: obs.GitRemote,
+		}
+		if _, seen := latest[key]; !seen {
+			keyOrder = append(keyOrder, key)
+		}
+		latest[key] = obs
+		if obs.GitRemote != "" && !realRootSet[key.root] {
+			realRootSet[key.root] = true
+			plan.realRoots = append(plan.realRoots, key.root)
+		}
+	}
+	for _, key := range keyOrder {
+		obs := latest[key]
+		if obs.GitRemote != "" {
+			plan.realRemote = append(plan.realRemote, obs)
+			continue
+		}
+		if !realRootSet[key.root] {
+			plan.fallbacks = append(plan.fallbacks, obs)
+		}
+	}
+	return plan
+}
+
+// syncProjectIdentityObservationsBatch applies a batch of observations with
+// set-based statements: one DELETE for stale fallback rows, one existence
+// probe for fallback candidates, and multi-row upserts. The final table
+// state matches applying upsertProjectIdentityObservation row by row with
+// no excluded remote.
+func syncProjectIdentityObservationsBatch(
+	ctx context.Context,
+	tx *sql.Tx,
+	observations []export.ProjectIdentityObservation,
+) error {
+	plan := planProjectIdentityObservationSync(observations)
+	if err := deleteProjectIdentityFallbackRows(
+		ctx, tx, plan.realRoots,
 	); err != nil {
-		return fmt.Errorf("upserting pg project identity observation: %w", err)
+		return err
+	}
+	fallbacks, err := projectIdentityFallbacksWithoutRealRemote(
+		ctx, tx, plan.fallbacks,
+	)
+	if err != nil {
+		return err
+	}
+	if err := insertProjectIdentityObservations(
+		ctx, tx, plan.realRemote,
+	); err != nil {
+		return err
+	}
+	return insertProjectIdentityObservations(ctx, tx, fallbacks)
+}
+
+// projectIdentityRootKeyBatchSize bounds tuple-IN lists at three bind
+// parameters per key.
+const projectIdentityRootKeyBatchSize = 300
+
+// projectIdentityInsertBatchSize bounds multi-row upserts at eleven bind
+// parameters per row.
+const projectIdentityInsertBatchSize = 500
+
+func rootKeyTupleArgs(keys []projectIdentityRootKey) (string, []any) {
+	tuples := make([]string, len(keys))
+	args := make([]any, 0, len(keys)*3)
+	for i, key := range keys {
+		base := i * 3
+		tuples[i] = fmt.Sprintf("($%d, $%d, $%d)", base+1, base+2, base+3)
+		args = append(args, key.project, key.machine, key.rootPath)
+	}
+	return strings.Join(tuples, ", "), args
+}
+
+func deleteProjectIdentityFallbackRows(
+	ctx context.Context,
+	tx *sql.Tx,
+	roots []projectIdentityRootKey,
+) error {
+	for start := 0; start < len(roots); start += projectIdentityRootKeyBatchSize {
+		end := min(start+projectIdentityRootKeyBatchSize, len(roots))
+		tuples, args := rootKeyTupleArgs(roots[start:end])
+		if _, err := tx.ExecContext(ctx, `
+			DELETE FROM project_identity_observations
+			WHERE git_remote = ''
+			  AND (project, machine, root_path) IN (`+tuples+`)`,
+			args...,
+		); err != nil {
+			return fmt.Errorf(
+				"removing stale pg project identity root fallbacks: %w", err,
+			)
+		}
+	}
+	return nil
+}
+
+// projectIdentityFallbacksWithoutRealRemote drops fallback candidates whose
+// root already has a real-remote row in PG, mirroring the per-row
+// existence check in upsertProjectIdentityObservation.
+func projectIdentityFallbacksWithoutRealRemote(
+	ctx context.Context,
+	tx *sql.Tx,
+	candidates []export.ProjectIdentityObservation,
+) ([]export.ProjectIdentityObservation, error) {
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+	shadowed := make(map[projectIdentityRootKey]bool)
+	for start := 0; start < len(candidates); start += projectIdentityRootKeyBatchSize {
+		end := min(start+projectIdentityRootKeyBatchSize, len(candidates))
+		keys := make([]projectIdentityRootKey, 0, end-start)
+		for _, obs := range candidates[start:end] {
+			keys = append(keys, observationRootKey(obs))
+		}
+		tuples, args := rootKeyTupleArgs(keys)
+		rows, err := tx.QueryContext(ctx, `
+			SELECT DISTINCT project, machine, root_path
+			FROM project_identity_observations
+			WHERE git_remote != ''
+			  AND (project, machine, root_path) IN (`+tuples+`)`,
+			args...,
+		)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"checking pg project identity remote observations: %w", err,
+			)
+		}
+		if err := scanProjectIdentityRootKeys(rows, shadowed); err != nil {
+			return nil, err
+		}
+	}
+	out := make([]export.ProjectIdentityObservation, 0, len(candidates))
+	for _, obs := range candidates {
+		if !shadowed[observationRootKey(obs)] {
+			out = append(out, obs)
+		}
+	}
+	return out, nil
+}
+
+func scanProjectIdentityRootKeys(
+	rows *sql.Rows, out map[projectIdentityRootKey]bool,
+) error {
+	defer rows.Close()
+	for rows.Next() {
+		var key projectIdentityRootKey
+		if err := rows.Scan(
+			&key.project, &key.machine, &key.rootPath,
+		); err != nil {
+			return fmt.Errorf(
+				"scanning pg project identity remote observation: %w", err,
+			)
+		}
+		out[key] = true
+	}
+	return rows.Err()
+}
+
+func insertProjectIdentityObservations(
+	ctx context.Context,
+	tx *sql.Tx,
+	observations []export.ProjectIdentityObservation,
+) error {
+	for start := 0; start < len(observations); start += projectIdentityInsertBatchSize {
+		end := min(start+projectIdentityInsertBatchSize, len(observations))
+		chunk := observations[start:end]
+		valueRows := make([]string, len(chunk))
+		args := make([]any, 0, len(chunk)*11)
+		for i, obs := range chunk {
+			base := i * 11
+			valueRows[i] = fmt.Sprintf(
+				"($%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d)",
+				base+1, base+2, base+3, base+4, base+5, base+6,
+				base+7, base+8, base+9, base+10, base+11,
+			)
+			args = append(args,
+				obs.Project, obs.Machine, obs.RootPath, obs.GitRemote,
+				obs.GitRemoteName, obs.WorktreeName, obs.WorktreeRootPath,
+				obs.ObservedAt, obs.NormalizedRemote, obs.KeySource, obs.Key,
+			)
+		}
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO project_identity_observations (
+				project, machine, root_path, git_remote, git_remote_name,
+				worktree_name, worktree_root_path, observed_at,
+				normalized_remote, key_source, key
+			) VALUES `+strings.Join(valueRows, ",\n\t\t\t")+
+			projectIdentityObservationConflictClause,
+			args...,
+		); err != nil {
+			return fmt.Errorf(
+				"upserting pg project identity observations: %w", err,
+			)
+		}
 	}
 	return nil
 }

--- a/internal/postgres/project_identity_upsert_unit_test.go
+++ b/internal/postgres/project_identity_upsert_unit_test.go
@@ -1,0 +1,91 @@
+package postgres
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.kenn.io/agentsview/internal/export"
+)
+
+func identityObs(
+	root, remote, remoteName string,
+) export.ProjectIdentityObservation {
+	return export.ProjectIdentityObservation{
+		Project:       "proj",
+		Machine:       "m1",
+		RootPath:      root,
+		GitRemote:     remote,
+		GitRemoteName: remoteName,
+		ObservedAt:    time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
+	}
+}
+
+func TestPlanProjectIdentityObservationSync(t *testing.T) {
+	tests := []struct {
+		name          string
+		observations  []export.ProjectIdentityObservation
+		wantReal      []string // GitRemoteName markers, in order
+		wantFallbacks []string // RootPath markers, in order
+		wantRoots     []string // RootPath markers, in order
+	}{
+		{
+			name: "real shadows fallback regardless of order",
+			observations: []export.ProjectIdentityObservation{
+				identityObs("/a", "", ""),
+				identityObs("/a", "git@x:a.git", "origin"),
+				identityObs("/b", "git@x:b.git", "origin"),
+				identityObs("/b", "", ""),
+			},
+			wantReal:  []string{"origin", "origin"},
+			wantRoots: []string{"/a", "/b"},
+		},
+		{
+			name: "fallback without real survives to the pg check",
+			observations: []export.ProjectIdentityObservation{
+				identityObs("/a", "", ""),
+				identityObs("/b", "git@x:b.git", "origin"),
+			},
+			wantReal:      []string{"origin"},
+			wantFallbacks: []string{"/a"},
+			wantRoots:     []string{"/b"},
+		},
+		{
+			name: "last observation per conflict key wins",
+			observations: []export.ProjectIdentityObservation{
+				identityObs("/a", "git@x:a.git", "old"),
+				identityObs("/a", "git@x:a.git", "new"),
+				identityObs("/a", "git@y:a.git", "other"),
+			},
+			wantReal:  []string{"new", "other"},
+			wantRoots: []string{"/a"},
+		},
+		{
+			name: "empty input plans nothing",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan := planProjectIdentityObservationSync(tt.observations)
+
+			var gotReal []string
+			for _, obs := range plan.realRemote {
+				gotReal = append(gotReal, obs.GitRemoteName)
+			}
+			assert.Equal(t, tt.wantReal, gotReal, "real remote observations")
+
+			var gotFallbacks []string
+			for _, obs := range plan.fallbacks {
+				gotFallbacks = append(gotFallbacks, obs.RootPath)
+			}
+			assert.Equal(t, tt.wantFallbacks, gotFallbacks, "fallbacks")
+
+			var gotRoots []string
+			for _, root := range plan.realRoots {
+				gotRoots = append(gotRoots, root.rootPath)
+			}
+			assert.Equal(t, tt.wantRoots, gotRoots, "real roots")
+		})
+	}
+}

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -50,15 +50,47 @@ type PushResult struct {
 	SkippedConflicts int
 	Errors           int
 	Duration         time.Duration
+	Vectors          VectorPushResult
+}
+
+// pushPrepareProgressStride bounds how many sessions the fingerprint loop
+// processes between "preparing" progress reports.
+const pushPrepareProgressStride = 500
+
+// timedPushSetupStep runs one pre-batch setup step and logs its duration when
+// it exceeds a second, so a slow silent stretch of a push (per-row metadata
+// upserts against a remote target, for example) is attributable in the log.
+func timedPushSetupStep(name string, fn func() error) error {
+	start := time.Now()
+	if err := fn(); err != nil {
+		return err
+	}
+	if d := time.Since(start); d > time.Second {
+		log.Printf("pgsync: %s took %s", name, d.Round(time.Millisecond))
+	}
+	return nil
 }
 
 // PushProgress is reported after each batch during Push.
 type PushProgress struct {
+	// Phase is "preparing" while per-session push fingerprints are computed
+	// (SessionsDone/SessionsTotal count candidate sessions fingerprinted; on
+	// a full push this covers every local session and can run for minutes),
+	// "" during the session/message push, and "vectors" during the vector
+	// phase, whose progress is carried by the Vector* fields.
+	Phase            string
 	SessionsDone     int
 	SessionsTotal    int
 	MessagesDone     int
 	SkippedConflicts int
 	Errors           int
+	// VectorSessionsDone counts local sessions examined by the vector
+	// phase's delta scan (most are unchanged and skipped cheaply);
+	// VectorSessionsTotal is the local candidate count and
+	// VectorChunksPushed the embedding chunks written so far.
+	VectorSessionsDone  int
+	VectorSessionsTotal int
+	VectorChunksPushed  int
 }
 
 // Push syncs local sessions and messages to PostgreSQL.
@@ -72,6 +104,14 @@ func (s *Sync) Push(
 	var result PushResult
 	state := s.effectiveSyncState()
 	aliasBackfillState := s.aliasBackfillSyncStateOrDefault()
+
+	// Announce the preparation phase immediately: everything between here
+	// and the first batch (marker checks, metadata syncs, fingerprints)
+	// produces no per-batch reports, and some of it runs for minutes on a
+	// full push against a remote target.
+	if onProgress != nil {
+		onProgress(PushProgress{Phase: "preparing"})
+	}
 
 	if err := CheckDataVersionCompat(ctx, s.pg); err != nil {
 		return result, err
@@ -208,13 +248,16 @@ func (s *Sync) Push(
 			}
 		}
 	}
-	if err := s.syncModelPricing(ctx); err != nil {
+	if err := timedPushSetupStep("model pricing sync",
+		func() error { return s.syncModelPricing(ctx) }); err != nil {
 		return result, err
 	}
-	if err := s.syncCursorUsageEvents(ctx); err != nil {
+	if err := timedPushSetupStep("cursor usage event sync",
+		func() error { return s.syncCursorUsageEvents(ctx) }); err != nil {
 		return result, err
 	}
-	if err := s.syncProjectIdentityObservations(ctx); err != nil {
+	if err := timedPushSetupStep("project identity observation sync",
+		func() error { return s.syncProjectIdentityObservations(ctx) }); err != nil {
 		return result, err
 	}
 
@@ -293,22 +336,55 @@ func (s *Sync) Push(
 			"computing local usage event fingerprints: %w", err,
 		)
 	}
-	for id, sess := range sessionByID {
-		usageFP, usageKnown := usageFingerprints[id]
-		dependencyFP, err := localSessionDependencyPushFingerprint(
-			ctx, s.local, id, usageFP, usageKnown,
-		)
-		if err != nil {
-			return result, fmt.Errorf(
-				"computing local dependency fingerprint %s: %w",
-				id, err,
-			)
+	// The fingerprint loop issues several local queries per candidate
+	// session; on a full push that covers every session and runs for
+	// minutes, so it reports its own progress phase rather than sitting
+	// silent until the first batch lands.
+	log.Printf("pgsync: computing push fingerprints for %d candidate session(s)",
+		len(sessionByID))
+	reportPrepare := func(done int) {
+		if onProgress == nil {
+			return
 		}
-		sessionFingerprints[id] = sessionPushFingerprint(
-			sess, pushedSessionMachine(sess, s.machine),
-			usageFP, markerID, dependencyFP,
-		)
+		onProgress(PushProgress{
+			Phase:         "preparing",
+			SessionsDone:  done,
+			SessionsTotal: len(sessionByID),
+		})
 	}
+	reportPrepare(0)
+	prepared := 0
+	candidateIDs := mapKeys(sessionByID)
+	for start := 0; start < len(candidateIDs); start += pushComparisonBatchSize {
+		end := min(start+pushComparisonBatchSize, len(candidateIDs))
+		chunk := candidateIDs[start:end]
+		depState, err := readLocalPushDependencyState(ctx, s.local, chunk)
+		if err != nil {
+			return result, err
+		}
+		for _, id := range chunk {
+			usageFP, usageKnown := usageFingerprints[id]
+			dependencyFP, err := depState.dependencyFingerprint(
+				s.local, id, usageFP, usageKnown,
+			)
+			if err != nil {
+				return result, fmt.Errorf(
+					"computing local dependency fingerprint %s: %w",
+					id, err,
+				)
+			}
+			sess := sessionByID[id]
+			sessionFingerprints[id] = sessionPushFingerprint(
+				sess, pushedSessionMachine(sess, s.machine),
+				usageFP, markerID, dependencyFP,
+			)
+			prepared++
+			if prepared%pushPrepareProgressStride == 0 {
+				reportPrepare(prepared)
+			}
+		}
+	}
+	reportPrepare(prepared)
 
 	if len(priorFingerprints) > 0 {
 		for id := range sessionByID {
@@ -362,11 +438,19 @@ func (s *Sync) Push(
 		); err != nil {
 			return result, err
 		}
+		result.Vectors, err = s.runVectorPushPhase(ctx, full, nil, onProgress)
+		if err != nil {
+			return result, err
+		}
 		result.Duration = time.Since(start)
 		return result, nil
 	}
 
 	var pushed []db.Session
+	// Sessions whose individual retry also failed: their PG sessions/messages
+	// rows are stale or absent, so the vector phase must not push their newer
+	// local vectors ahead of them.
+	var failedSessions map[string]struct{}
 	const batchSize = 50
 	for i := 0; i < len(sessions); i += batchSize {
 		end := min(i+batchSize, len(sessions))
@@ -401,6 +485,10 @@ func (s *Sync) Push(
 					result.SkippedConflicts += sr.skippedConflicts
 				} else {
 					result.Errors++
+					if failedSessions == nil {
+						failedSessions = make(map[string]struct{})
+					}
+					failedSessions[sess.ID] = struct{}{}
 				}
 			}
 		}
@@ -455,8 +543,36 @@ func (s *Sync) Push(
 	); err != nil {
 		return result, err
 	}
+	result.Vectors, err = s.runVectorPushPhase(ctx, full, failedSessions, onProgress)
+	if err != nil {
+		return result, err
+	}
 	result.Duration = time.Since(start)
 	return result, nil
+}
+
+// runVectorPushPhase runs the vector push phase and wraps its error. With no
+// source attached the phase never runs: it returns a Skipped result with an
+// empty reason, which the summary printer renders as nothing (an unconfigured
+// phase is not a diagnosable skip like an unavailable extension). Without this
+// the zero-valued VectorPushResult would print "Vectors: 0 session(s) pushed".
+// failedSessions names sessions whose session-phase push failed; their vectors
+// are deferred so pgvector data never runs ahead of the sessions/messages rows.
+// full bypasses the unchanged-hash skip so a --full push also repairs vector
+// rows whose push state wrongly reports them current. onProgress, when
+// non-nil, receives Phase "vectors" reports as the delta scan advances.
+func (s *Sync) runVectorPushPhase(
+	ctx context.Context, full bool, failedSessions map[string]struct{},
+	onProgress func(PushProgress),
+) (VectorPushResult, error) {
+	if s.vectorSource == nil {
+		return VectorPushResult{Skipped: true}, nil
+	}
+	res, err := s.pushVectors(ctx, full, failedSessions, onProgress)
+	if err != nil {
+		return res, fmt.Errorf("vector push: %w", err)
+	}
+	return res, nil
 }
 
 func (s *Sync) syncProjectIdentityObservations(ctx context.Context) error {
@@ -470,19 +586,20 @@ func (s *Sync) syncProjectIdentityObservations(ctx context.Context) error {
 	if len(observations) == 0 {
 		return nil
 	}
+	log.Printf("pgsync: syncing %d project identity observation(s)",
+		len(observations))
+	for i, obs := range observations {
+		observations[i] = export.SanitizeStoredProjectIdentityObservation(obs)
+	}
 	tx, err := s.pg.BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("beginning project identity observation sync: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
-	for _, obs := range observations {
-		obs = export.SanitizeStoredProjectIdentityObservation(obs)
-		if err := upsertProjectIdentityObservation(ctx, tx, obs, ""); err != nil {
-			return fmt.Errorf(
-				"syncing project identity observation %s/%s/%s: %w",
-				obs.Project, obs.Machine, obs.RootPath, err,
-			)
-		}
+	if err := syncProjectIdentityObservationsBatch(
+		ctx, tx, observations,
+	); err != nil {
+		return fmt.Errorf("syncing project identity observations: %w", err)
 	}
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("committing project identity observation sync: %w", err)

--- a/internal/postgres/push_fingerprint.go
+++ b/internal/postgres/push_fingerprint.go
@@ -76,6 +76,17 @@ func localSessionDependencyPushFingerprint(
 	if err != nil {
 		return "", fmt.Errorf("reading local pinned messages: %w", err)
 	}
+	return hashLocalDependencyPayload(msgFP, findings, pins)
+}
+
+// hashLocalDependencyPayload is the shared final step of the per-session
+// and batched dependency fingerprints. The JSON encoding is the persisted
+// fingerprint format: any change re-pushes every session on the next push.
+func hashLocalDependencyPayload(
+	msgFP pushLocalMessageFingerprint,
+	findings []db.SecretFinding,
+	pins []db.PinnedMessage,
+) (string, error) {
 	payload := struct {
 		Messages       pushLocalMessageFingerprint
 		SecretFindings []db.SecretFinding
@@ -91,6 +102,126 @@ func localSessionDependencyPushFingerprint(
 	}
 	sum := sha256.Sum256(data)
 	return fmt.Sprintf("%x", sum), nil
+}
+
+// localPushDependencyState holds one chunk's worth of prefetched local
+// fingerprint inputs. The push loop fingerprints every candidate session on
+// every push; reading these per session (a dozen point queries each) took
+// minutes on a full push, so the loop prefetches them in batched queries.
+// Values must match the per-session methods byte for byte — see the
+// batched twins in internal/db for the identity contract.
+type localPushDependencyState struct {
+	contentAgg     map[string]db.MessageContentAggregate
+	contentHashFP  map[string]string
+	roleTimeFP     map[string]string
+	flagsFP        map[string]string
+	systemFP       map[string]string
+	tokenFP        map[string]string
+	toolCallCount  map[string]int
+	toolCallSum    map[string]int64
+	toolCallFP     map[string]string
+	toolResultFP   map[string]string
+	secretFindings map[string][]db.SecretFinding
+	pins           map[string][]db.PinnedMessage
+}
+
+func readLocalPushDependencyState(
+	ctx context.Context, local *db.DB, sessionIDs []string,
+) (*localPushDependencyState, error) {
+	st := &localPushDependencyState{}
+	var err error
+	if st.contentAgg, err = local.MessageContentFingerprints(sessionIDs); err != nil {
+		return nil, fmt.Errorf("computing local content fingerprints: %w", err)
+	}
+	if st.contentHashFP, err = local.MessageContentHashFingerprints(sessionIDs); err != nil {
+		return nil, fmt.Errorf("computing local content hash fingerprints: %w", err)
+	}
+	if st.roleTimeFP, err = local.MessageRoleTimeFingerprintsWithTimestampNormalizer(
+		sessionIDs, pgPushTimestampFingerprintText,
+	); err != nil {
+		return nil, fmt.Errorf("computing local role/time fingerprints: %w", err)
+	}
+	if st.flagsFP, err = local.MessageFlagsFingerprints(sessionIDs); err != nil {
+		return nil, fmt.Errorf(
+			"computing local message flags fingerprints: %w", err,
+		)
+	}
+	if st.systemFP, err = local.SystemMessageFingerprints(sessionIDs); err != nil {
+		return nil, fmt.Errorf(
+			"computing local system message fingerprints: %w", err,
+		)
+	}
+	if st.tokenFP, err = local.MessageTokenFingerprints(sessionIDs); err != nil {
+		return nil, fmt.Errorf("computing local token fingerprints: %w", err)
+	}
+	if st.toolCallCount, err = local.ToolCallCounts(sessionIDs); err != nil {
+		return nil, fmt.Errorf("counting local tool_calls: %w", err)
+	}
+	if st.toolCallSum, err = local.ToolCallContentFingerprints(sessionIDs); err != nil {
+		return nil, fmt.Errorf(
+			"computing local tool_call content fingerprints: %w", err,
+		)
+	}
+	if st.toolCallFP, err = local.ToolCallFingerprints(sessionIDs); err != nil {
+		return nil, fmt.Errorf("computing local tool_call fingerprints: %w", err)
+	}
+	if st.toolResultFP, err = local.ToolResultEventFingerprintsWithTimestampNormalizer(
+		sessionIDs, pgPushTimestampFingerprintText,
+	); err != nil {
+		return nil, fmt.Errorf(
+			"computing local tool_result_event fingerprints: %w", err,
+		)
+	}
+	if st.secretFindings, err = local.SessionSecretFindingsBySession(
+		ctx, sessionIDs,
+	); err != nil {
+		return nil, fmt.Errorf("reading local secret findings: %w", err)
+	}
+	if st.pins, err = local.PinnedMessagesBySession(ctx, sessionIDs); err != nil {
+		return nil, fmt.Errorf("reading local pinned messages: %w", err)
+	}
+	return st, nil
+}
+
+// dependencyFingerprint assembles the same fingerprint as
+// localSessionDependencyPushFingerprint from the prefetched maps. local is
+// only queried on the usageKnown=false fallback, which the push loop never
+// takes (it prefetches usage fingerprints for every candidate).
+func (st *localPushDependencyState) dependencyFingerprint(
+	local *db.DB,
+	sessionID string,
+	usageEventFingerprint string,
+	usageKnown bool,
+) (string, error) {
+	agg := st.contentAgg[sessionID]
+	msgFP := pushLocalMessageFingerprint{
+		Sum:           agg.Sum,
+		Max:           agg.Max,
+		Min:           agg.Min,
+		ContentHashFP: st.contentHashFP[sessionID],
+		RoleTimeFP:    st.roleTimeFP[sessionID],
+		FlagsFP:       st.flagsFP[sessionID],
+		SystemFP:      st.systemFP[sessionID],
+		ToolCallCount: st.toolCallCount[sessionID],
+		ToolCallSum:   st.toolCallSum[sessionID],
+		ToolCallFP:    st.toolCallFP[sessionID],
+		ToolResultFP:  st.toolResultFP[sessionID],
+		TokenFP:       st.tokenFP[sessionID],
+	}
+	if usageKnown {
+		msgFP.UsageEventFP = usageEventFingerprint
+	} else {
+		var err error
+		msgFP.UsageEventFP, err = local.UsageEventFingerprint(sessionID)
+		if err != nil {
+			return "", fmt.Errorf(
+				"computing local usage event fingerprint: %w", err,
+			)
+		}
+	}
+	return hashLocalDependencyPayload(
+		msgFP, st.secretFindings[sessionID], st.pins[sessionID],
+	)
 }
 
 func localPushMessageFingerprint(

--- a/internal/postgres/push_fingerprint_unit_test.go
+++ b/internal/postgres/push_fingerprint_unit_test.go
@@ -1,0 +1,97 @@
+package postgres
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+// TestBatchedDependencyFingerprintMatchesPerSession pins that the chunked
+// prefetch path the push loop uses produces the exact fingerprint the
+// per-session path produces. A divergence would change every stored session
+// fingerprint and re-push the entire archive on the next push.
+func TestBatchedDependencyFingerprintMatchesPerSession(t *testing.T) {
+	local, err := db.Open(filepath.Join(t.TempDir(), "local.db"))
+	require.NoError(t, err)
+	defer local.Close()
+	ctx := context.Background()
+
+	require.NoError(t, local.UpsertSession(db.Session{
+		ID: "dep-a", Project: "alpha", Machine: "m1", Agent: "claude-code",
+	}))
+	require.NoError(t, local.UpsertSession(db.Session{
+		ID: "dep-empty", Project: "alpha", Machine: "m1", Agent: "claude-code",
+	}))
+
+	note := "pinned"
+	require.NoError(t, local.InsertMessages([]db.Message{
+		{
+			SessionID: "dep-a", Ordinal: 0, Role: "user",
+			Content: "hello", ContentLength: 5,
+			Timestamp: "2026-07-01T10:00:00Z", IsSystem: true,
+		},
+		{
+			SessionID: "dep-a", Ordinal: 1, Role: "assistant",
+			Content: "with\x00nul", ContentLength: 8,
+			ThinkingText: "thinking", HasThinking: true, HasToolUse: true,
+			Model: "claude-test", ContextTokens: 10, OutputTokens: 2,
+			HasContextTokens: true, HasOutputTokens: true,
+			ToolCalls: []db.ToolCall{
+				{
+					ToolName: "Bash", Category: "execution",
+					ToolUseID: "tu-1", InputJSON: `{"command":"ls"}`,
+					ResultContentLength: 2, ResultContent: "ok",
+					ResultEvents: []db.ToolResultEvent{{
+						ToolUseID: "tu-1", Source: "cli", Status: "ok",
+						Content: "ok", ContentLength: 2,
+						Timestamp: "2026-07-01T10:00:01Z",
+					}},
+				},
+				{ToolName: "Read", Category: "file"},
+			},
+		},
+	}))
+	require.NoError(t, local.ReplaceSessionSecretFindings("dep-a",
+		[]db.SecretFinding{{
+			SessionID: "dep-a", RuleName: "token", Confidence: "high",
+			LocationKind: "message", MessageOrdinal: 1,
+			MatchStart: 0, MatchEnd: 4, RedactedMatch: "w…",
+			RulesVersion: "v1",
+		}}, 1, "v1"))
+	pinned, err := local.GetMessageByOrdinal("dep-a", 1)
+	require.NoError(t, err)
+	require.NotNil(t, pinned)
+	pinID, err := local.PinMessage("dep-a", pinned.ID, &note)
+	require.NoError(t, err)
+	require.NotZero(t, pinID)
+
+	ids := []string{"dep-a", "dep-empty", "dep-missing"}
+	usageFPs, err := local.UsageEventFingerprints(ids)
+	require.NoError(t, err)
+
+	state, err := readLocalPushDependencyState(ctx, local, ids)
+	require.NoError(t, err)
+
+	for _, id := range ids {
+		for _, usageKnown := range []bool{true, false} {
+			want, err := localSessionDependencyPushFingerprint(
+				ctx, local, id, usageFPs[id], usageKnown,
+			)
+			require.NoError(t, err, id)
+			got, err := state.dependencyFingerprint(
+				local, id, usageFPs[id], usageKnown,
+			)
+			require.NoError(t, err, id)
+			assert.Equal(t, want, got,
+				"dependency fingerprint %s (usageKnown=%t)", id, usageKnown)
+		}
+	}
+
+	assert.NotEqual(t, "", state.contentHashFP["dep-a"],
+		"fixture must exercise the message fingerprint maps")
+}

--- a/internal/postgres/schema.go
+++ b/internal/postgres/schema.go
@@ -812,6 +812,9 @@ func EnsureSchema(
 		"pg schema: content search index step completed in %s",
 		time.Since(step).Round(time.Millisecond),
 	)
+	if _, err := ensureVectorBaseSchemaPG(ctx, db); err != nil {
+		log.Printf("pg schema: vector schema setup failed: %v", err)
+	}
 	step = time.Now()
 	runRepair, err := shouldRunTokenCoverageRepair(
 		ctx, db, tokenCoverageColumnsAdded,

--- a/internal/postgres/search_content.go
+++ b/internal/postgres/search_content.go
@@ -44,9 +44,13 @@ func (s *Store) SearchContent(
 		if err := db.ValidateSemanticFilter(f); err != nil {
 			return db.ContentSearchPage{}, err
 		}
-		// No VectorSearcher seam on the PostgreSQL store yet (HasSemantic
-		// always false): gate after input validation.
-		return db.ContentSearchPage{}, db.ErrSemanticUnavailable
+		if s.getVectorSearcher() == nil {
+			return db.ContentSearchPage{}, s.semanticUnavailableError()
+		}
+		if f.Mode == "semantic" {
+			return s.searchContentSemanticPG(ctx, f)
+		}
+		return s.searchContentHybridPG(ctx, f)
 	}
 
 	if len(f.Sources) == 0 {

--- a/internal/postgres/search_content_hybrid.go
+++ b/internal/postgres/search_content_hybrid.go
@@ -1,0 +1,364 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+// pgHybridDisplay carries what one fused unit needs for presentation: the
+// anchor (session, ordinal) the match reports and enriches by, the unit's
+// ordinal span and subordinate flag (structurally derived for a unit-less
+// message-granularity keyword hit, see classifyUnitlessHybridHitsPG), plus the
+// leg's raw (unredacted) approximate snippet text used only to center the
+// redacted window. It is the PG twin of internal/db's hybridDisplay.
+type pgHybridDisplay struct {
+	sessionID    string
+	ordinal      int
+	ordinalStart int
+	ordinalEnd   int
+	subordinate  bool
+	snippet      string
+}
+
+// pgHybridLeg is one rank-ordered fusion leg: entries for db.RRFMerge plus each
+// key's display info.
+type pgHybridLeg struct {
+	ranked  []db.RankedUnit
+	display map[string]pgHybridDisplay
+}
+
+// searchContentHybridPG runs mode "hybrid" on the PostgreSQL store, mirroring
+// internal/db.searchContentHybrid with the keyword-leg substitution PG uses
+// (ILIKE candidates ordered by recency instead of BM25 rank). The vector and
+// keyword rankings are each over-fetched to k, the vector leg filtered down to
+// sessions passing the filter's metadata scope, keyword message hits resolved
+// to their containing units, and the two rank-ordered leg lists fused at unit
+// granularity with db.RRFMerge. Returned matches are enriched with
+// session/message metadata via the same lookup semantic search uses, ordered
+// by fused score descending, truncated to f.Limit. The caller (SearchContent)
+// has already run db.ValidateSemanticFilter and confirmed a searcher is wired.
+func (s *Store) searchContentHybridPG(
+	ctx context.Context, f db.ContentSearchFilter,
+) (db.ContentSearchPage, error) {
+	searcher := s.getVectorSearcher()
+	if searcher == nil {
+		return db.ContentSearchPage{}, s.semanticUnavailableError()
+	}
+
+	k := max(f.Limit*4, db.SemanticOverfetchMin)
+	vecLeg, err := s.hybridVectorLegPG(ctx, f, searcher, k)
+	if err != nil {
+		return db.ContentSearchPage{}, err
+	}
+	kwLeg, err := s.hybridKeywordLegPG(ctx, f, searcher, k)
+	if err != nil {
+		return db.ContentSearchPage{}, err
+	}
+	if len(vecLeg.ranked) == 0 && len(kwLeg.ranked) == 0 {
+		return db.ContentSearchPage{}, nil
+	}
+
+	merged := db.RRFMerge([][]db.RankedUnit{vecLeg.ranked, kwLeg.ranked}, f.Limit)
+	return s.enrichHybridMatchesPG(ctx, f, merged, vecLeg.display, kwLeg.display)
+}
+
+// hybridVectorLegPG over-fetches k semantic unit hits, drops any whose session
+// fails the filter's metadata scope or whose subordinate flag falls outside
+// f.Scope (via survivingVectorHitsPG, shared with the semantic mode), and
+// returns the survivors as a rank-ordered fusion leg keyed by unit. Both
+// filters run before the merge so reciprocal-rank fusion only ranks eligible
+// units and a scoped search can still fill the limit.
+func (s *Store) hybridVectorLegPG(
+	ctx context.Context, f db.ContentSearchFilter, searcher db.VectorSearcher, k int,
+) (pgHybridLeg, error) {
+	leg := pgHybridLeg{display: make(map[string]pgHybridDisplay)}
+	surviving, err := s.survivingVectorHitsPG(ctx, f, searcher, k)
+	if err != nil {
+		return pgHybridLeg{}, err
+	}
+	for _, h := range surviving {
+		key := db.UnitFusionKey(h.SessionID, h.OrdinalStart)
+		if _, seen := leg.display[key]; seen {
+			continue
+		}
+		leg.ranked = append(leg.ranked, db.RankedUnit{Key: key, Subordinate: h.Subordinate})
+		leg.display[key] = pgHybridDisplay{
+			sessionID: h.SessionID, ordinal: h.Ordinal, snippet: h.Snippet,
+			ordinalStart: h.OrdinalStart, ordinalEnd: h.OrdinalEnd,
+			subordinate: h.Subordinate,
+		}
+	}
+	return leg, nil
+}
+
+// maxHybridKeywordBatches caps how many k-row ILIKE batches the keyword leg
+// fetches. It is the PG twin of internal/db.maxHybridFTSBatches (unexported
+// there); defined locally so this diff stays self-contained. It bounds the
+// worst-case work when discard dominates — many rows collapsing into one unit,
+// or a narrow f.Scope dropping most rows — while letting the leg keep paging
+// past discarded rows instead of under-filling after the first batch.
+const maxHybridKeywordBatches = 4
+
+// hybridKeywordLegPG runs a recency-ordered ILIKE query over the embedded
+// universe (role user/assistant, is_system = FALSE, system-prefix excluded),
+// scoped in SQL to sessions passing the child-exclusion-lifted filter (so both
+// hybrid legs see the same universe), resolves each message hit to its
+// containing unit, drops units outside f.Scope, and returns up to k hits as a
+// rank-ordered fusion leg. A hit inside a unit adopts the unit's fusion key and
+// subordinate flag while keeping its own message ordinal as the anchor and its
+// keyword snippet for display; several hits in one unit collapse to the
+// best-ranked one. A hit with no containing unit keeps a message-granularity
+// key and survives fusion on its own, with its range and subordinate flag
+// structurally derived before the scope filter and merge. Rows are fetched in
+// recency-ordered batches of k with OFFSET continuation: collapse and scope
+// filtering can discard most of a batch, so the leg keeps fetching until it
+// holds k entries, the stream is exhausted, or maxHybridKeywordBatches is hit.
+func (s *Store) hybridKeywordLegPG(
+	ctx context.Context, f db.ContentSearchFilter, searcher db.VectorSearcher, k int,
+) (pgHybridLeg, error) {
+	leg := pgHybridLeg{display: make(map[string]pgHybridDisplay, k)}
+	for batch := range maxHybridKeywordBatches {
+		hits, err := s.fetchHybridKeywordBatchPG(ctx, f, k, batch*k)
+		if err != nil {
+			return pgHybridLeg{}, err
+		}
+		if err := s.appendHybridKeywordHitsPG(ctx, searcher, f, hits, &leg); err != nil {
+			return pgHybridLeg{}, err
+		}
+		if len(hits) < k || len(leg.ranked) >= k {
+			break
+		}
+	}
+	return leg, nil
+}
+
+// fetchHybridKeywordBatchPG fetches one recency-ordered batch of at most k
+// keyword message rows, starting at offset. The term-AND ILIKE predicate
+// (pgContentSearchPredicate with Mode "fts") preserves SQLite's implicit-AND
+// FTS-term semantics; recency ordering is the documented PG keyword ranking (no
+// BM25), with (session_id, ordinal) as a deterministic tiebreak so OFFSET
+// continuation is stable across batches. The display snippet is windowed in Go
+// around the first case-insensitive pattern occurrence; it centers the redacted
+// window only, since redaction (SemanticSnippet) always runs on full content.
+func (s *Store) fetchHybridKeywordBatchPG(
+	ctx context.Context, f db.ContentSearchFilter, k, offset int,
+) ([]pgHybridDisplay, error) {
+	scopeWhere, scopeArgs := buildPGSessionBaseFilter(semanticPGSessionFilter(f))
+	pb := &paramBuilder{n: len(scopeArgs), args: append([]any{}, scopeArgs...)}
+
+	kf := f
+	kf.Mode = "fts"
+	contentPred := pgContentSearchPredicate("m.content", kf, escapeLike(f.Pattern), pb)
+	limitP := pb.add(k)
+	offsetP := pb.add(offset)
+
+	query := fmt.Sprintf(`
+		SELECT m.session_id, m.ordinal, m.content
+		FROM messages m
+		JOIN sessions s ON s.id = m.session_id
+		WHERE %s
+		  AND m.role IN ('user', 'assistant') AND m.is_system = FALSE
+		  AND %s
+		  AND m.session_id IN (SELECT id FROM sessions WHERE %s)
+		ORDER BY COALESCE(s.ended_at, s.started_at, s.created_at) DESC NULLS LAST,
+		         m.session_id ASC, m.ordinal ASC
+		LIMIT %s OFFSET %s`,
+		contentPred, db.PostgresSystemPrefixSQL("m.content", "m.role"),
+		scopeWhere, limitP, offsetP)
+
+	rows, err := s.pg.QueryContext(ctx, query, pb.args...)
+	if err != nil {
+		return nil, fmt.Errorf("pg hybrid keyword leg: %w", err)
+	}
+	defer rows.Close()
+
+	var hits []pgHybridDisplay
+	for rows.Next() {
+		var hit pgHybridDisplay
+		var content string
+		if err := rows.Scan(&hit.sessionID, &hit.ordinal, &content); err != nil {
+			return nil, fmt.Errorf("scan hybrid keyword hit: %w", err)
+		}
+		hit.snippet = pgKeywordApproxSnippet(content, f.Pattern)
+		hits = append(hits, hit)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return hits, nil
+}
+
+// pgKeywordApproxSnippet windows content around the pattern's term-aware span
+// (db.FTSSnippetRange, the same helper the fts snippet path uses via
+// pgSubstringSnippet), rune-snapped via pgSnippetBounds. Centering on the raw
+// pattern would fall back to the message start for quoted phrases or multi-term
+// queries whose pattern is not a literal substring; FTSSnippetRange instead
+// locates the de-quoted phrase, then the first matched term, then the start. The
+// result is the raw, unredacted centering text SemanticSnippet later locates in
+// the full content; redaction always runs on the full content, not this window.
+func pgKeywordApproxSnippet(content, pattern string) string {
+	start, end := db.FTSSnippetRange(pattern, content)
+	lo, hi := pgSnippetBounds(content, start, end)
+	return content[lo:hi]
+}
+
+// appendHybridKeywordHitsPG resolves one batch of keyword message hits to their
+// containing units, classifies unit-less hits structurally (range and
+// subordinate flag, so the scope filter and fusion penalty treat them exactly
+// like lexical mode), and accumulates the survivors into leg: hits outside
+// scope are dropped, and a unit already seen (within or across batches) keeps
+// its earlier, better-ranked entry.
+func (s *Store) appendHybridKeywordHitsPG(
+	ctx context.Context, searcher db.VectorSearcher, f db.ContentSearchFilter,
+	hits []pgHybridDisplay, leg *pgHybridLeg,
+) error {
+	if len(hits) == 0 {
+		return nil
+	}
+	refs := make([]db.MessageRef, len(hits))
+	for i, hit := range hits {
+		refs[i] = db.MessageRef{SessionID: hit.sessionID, Ordinal: hit.ordinal}
+	}
+	units, err := searcher.ResolveMessageUnits(ctx, refs)
+	if err != nil {
+		return fmt.Errorf("resolving keyword hits to units: %w", err)
+	}
+	if len(units) != len(refs) {
+		return fmt.Errorf(
+			"resolving keyword hits to units: got %d units for %d refs", len(units), len(refs))
+	}
+
+	keys := make([]string, len(hits))
+	var unitless []int
+	for i := range hits {
+		hit := &hits[i]
+		keys[i] = db.MessageFusionKey(hit.sessionID, hit.ordinal)
+		hit.ordinalStart, hit.ordinalEnd = hit.ordinal, hit.ordinal
+		if units[i].DocKey == "" {
+			unitless = append(unitless, i)
+			continue
+		}
+		keys[i] = db.UnitFusionKey(units[i].SessionID, units[i].OrdinalStart)
+		hit.ordinalStart = units[i].OrdinalStart
+		hit.ordinalEnd = units[i].OrdinalEnd
+		hit.subordinate = units[i].Subordinate
+	}
+	if err := s.classifyUnitlessHybridHitsPG(ctx, hits, unitless); err != nil {
+		return err
+	}
+
+	for i, hit := range hits {
+		if db.ScopeExcludes(f.Scope, hit.subordinate) {
+			continue
+		}
+		if _, seen := leg.display[keys[i]]; seen {
+			continue
+		}
+		leg.ranked = append(leg.ranked, db.RankedUnit{Key: keys[i], Subordinate: hit.subordinate})
+		leg.display[keys[i]] = hit
+	}
+	return nil
+}
+
+// classifyUnitlessHybridHitsPG assigns each unit-less keyword hit (the resolver
+// returned no mirror unit; hits[i] for i in idxs) its structurally derived
+// conversation-unit range and subordinate flag BEFORE scope filtering and
+// fusion, so a unit-less sidechain (or subagent/fork-session) hit is excluded,
+// included, and penalized exactly like lexical mode classifies the same anchor.
+// It reuses fillAnchorMetaPG and db.DeriveUnitRanges + db.SubordinateSession,
+// mirroring internal/db.classifyUnitlessHybridHits.
+func (s *Store) classifyUnitlessHybridHitsPG(
+	ctx context.Context, hits []pgHybridDisplay, idxs []int,
+) error {
+	if len(idxs) == 0 {
+		return nil
+	}
+	matches := make([]db.ContentMatch, len(idxs))
+	for k, i := range idxs {
+		matches[k] = db.ContentMatch{SessionID: hits[i].sessionID, Ordinal: hits[i].ordinal}
+	}
+	metas, err := s.fillAnchorMetaPG(ctx, matches)
+	if err != nil {
+		return err
+	}
+	anchors := make([]db.UnitAnchor, len(idxs))
+	for k := range idxs {
+		meta := metas[k]
+		anchors[k] = db.UnitAnchor{
+			SessionID:  matches[k].SessionID,
+			Ordinal:    matches[k].Ordinal,
+			Role:       meta.role.String,
+			Sidechain:  meta.sidechain.Valid && meta.sidechain.Bool,
+			Embeddable: meta.embeddable.Valid && meta.embeddable.Bool,
+			Missing:    meta.missing,
+		}
+	}
+	ranges, err := db.DeriveUnitRanges(ctx, s, anchors)
+	if err != nil {
+		return fmt.Errorf("deriving hybrid unit-less ranges: %w", err)
+	}
+	for k, i := range idxs {
+		hits[i].ordinalStart, hits[i].ordinalEnd = ranges[k][0], ranges[k][1]
+		hits[i].subordinate = anchors[k].Sidechain ||
+			db.SubordinateSession(metas[k].relationship, metas[k].parentSessionID)
+	}
+	return nil
+}
+
+// enrichHybridMatchesPG looks up session/message metadata for the fused units
+// (reusing enrichSemanticHitsPG) and assembles the final page in fused-score
+// order. When the keyword leg contributed a unit, its display wins: the match
+// anchors on the keyword-matched message's ordinal and centers on the keyword
+// snippet (the vector leg's chunk anchor may be a different run member). Either
+// way the returned snippet is built (and redacted) from the anchor message's
+// full content via SemanticSnippet, the guarantee mode "semantic" gives.
+// Unit-less keyword rows arrive with their derived range and subordinate flag
+// already assigned pre-merge, so no derivation runs here.
+func (s *Store) enrichHybridMatchesPG(
+	ctx context.Context, f db.ContentSearchFilter, merged []db.FusedUnit,
+	vecDisplay, kwDisplay map[string]pgHybridDisplay,
+) (db.ContentSearchPage, error) {
+	displays := make([]pgHybridDisplay, len(merged))
+	asHits := make([]db.VectorHit, len(merged))
+	for i, m := range merged {
+		d, ok := kwDisplay[m.Unit.Key]
+		if !ok {
+			d = vecDisplay[m.Unit.Key]
+		}
+		displays[i] = d
+		asHits[i] = db.VectorHit{SessionID: d.sessionID, Ordinal: d.ordinal}
+	}
+	meta, err := s.enrichSemanticHitsPG(ctx, asHits)
+	if err != nil {
+		return db.ContentSearchPage{}, err
+	}
+
+	out := make([]db.ContentMatch, 0, len(merged))
+	for i, m := range merged {
+		d := displays[i]
+		info, ok := meta[db.MessageRef{SessionID: d.sessionID, Ordinal: d.ordinal}]
+		if !ok {
+			continue
+		}
+		score := m.Score
+		out = append(out, db.ContentMatch{
+			SessionID:       d.sessionID,
+			Project:         info.project,
+			Agent:           info.agent,
+			Location:        "message",
+			Role:            info.role,
+			Ordinal:         d.ordinal,
+			OrdinalRange:    [2]int{d.ordinalStart, d.ordinalEnd},
+			Subordinate:     d.subordinate,
+			Relationship:    info.relationshipType,
+			ParentSessionID: info.parentSessionID,
+			Sidechain:       info.isSidechain,
+			Timestamp:       info.timestamp,
+			Snippet:         f.SemanticSnippet(info.content, d.snippet),
+			Score:           &score,
+		})
+	}
+	return db.ContentSearchPage{Matches: out}, nil
+}

--- a/internal/postgres/search_content_hybrid_pg_test.go
+++ b/internal/postgres/search_content_hybrid_pg_test.go
@@ -1,0 +1,306 @@
+//go:build pgtest
+
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+// hybridFakeSearcher is a canned db.VectorSearcher for PG hybrid tests: it
+// returns a fixed, rank-ordered slice of vector hits and resolves message
+// refs against an explicit units list first, then against the units implied
+// by hits (the real resolver reads the same mirror the hits come from). This
+// isolates the fusion + keyword-leg logic (real ILIKE SQL over messages) from
+// the pgvector-backed searcher, which Task 8/9 tests already cover. It mirrors
+// internal/db's fakeVectorSearcher so parity between the backends is visible.
+type hybridFakeSearcher struct {
+	hits  []db.VectorHit
+	units []db.UnitRef
+}
+
+func (f *hybridFakeSearcher) SemanticSearch(
+	_ context.Context, _ string, limit int,
+) ([]db.VectorHit, error) {
+	hits := f.hits
+	if limit > 0 && limit < len(hits) {
+		hits = hits[:limit]
+	}
+	return hits, nil
+}
+
+func (f *hybridFakeSearcher) ResolveMessageUnits(
+	_ context.Context, refs []db.MessageRef,
+) ([]db.UnitRef, error) {
+	out := make([]db.UnitRef, len(refs))
+	for i, ref := range refs {
+		out[i] = f.resolveRef(ref)
+	}
+	return out, nil
+}
+
+func (f *hybridFakeSearcher) resolveRef(ref db.MessageRef) db.UnitRef {
+	for _, u := range f.units {
+		if u.SessionID == ref.SessionID &&
+			ref.Ordinal >= u.OrdinalStart && ref.Ordinal <= u.OrdinalEnd {
+			return u
+		}
+	}
+	for _, h := range f.hits {
+		if h.SessionID == ref.SessionID &&
+			ref.Ordinal >= h.OrdinalStart && ref.Ordinal <= h.OrdinalEnd {
+			return db.UnitRef{
+				DocKey:       fmt.Sprintf("fake:%s:%d", h.SessionID, h.OrdinalStart),
+				SessionID:    h.SessionID,
+				OrdinalStart: h.OrdinalStart,
+				OrdinalEnd:   h.OrdinalEnd,
+				Subordinate:  h.Subordinate,
+			}
+		}
+	}
+	return db.UnitRef{}
+}
+
+// wireHybrid seeds a fresh content-search store, wires the fake searcher, and
+// returns the store. It reuses setupContentSearch (base schema, no pgvector),
+// since the vector leg and resolver are faked and the keyword leg runs real
+// ILIKE SQL over the messages table.
+func wireHybrid(t *testing.T, f *hybridFakeSearcher) *Store {
+	t.Helper()
+	store := setupContentSearch(t)
+	store.SetVectorSearcher(f)
+	return store
+}
+
+const (
+	hybridStart = "2026-05-01T10:00:00Z"
+	hybridEnd   = "2026-05-01T10:30:00Z"
+)
+
+// TestPGHybridBothLegsFuseKeywordAnchor pins the end-to-end unit fusion: a
+// vector hit on a run and a keyword hit inside that same run fuse into ONE
+// result whose anchor ordinal is the keyword-matched message (overriding the
+// vector leg's chunk anchor) and whose snippet centers on the keyword text.
+func TestPGHybridBothLegsFuseKeywordAnchor(t *testing.T) {
+	f := &hybridFakeSearcher{hits: []db.VectorHit{
+		{SessionID: "s1", Ordinal: 1, OrdinalStart: 1, OrdinalEnd: 2,
+			Score: 0.9, Snippet: "first step of the answer"},
+	}}
+	store := wireHybrid(t, f)
+	insertCSSession(t, store, "s1", "proj", "claude", hybridStart, hybridEnd)
+	insertCSUnitMessage(t, store, "s1", 0, "user", "the question", false, false)
+	insertCSUnitMessage(t, store, "s1", 1, "assistant", "first step of the answer", false, false)
+	insertCSUnitMessage(t, store, "s1", 2, "assistant", "second step mentions zebra", false, false)
+
+	page, err := store.SearchContent(context.Background(), db.ContentSearchFilter{
+		Pattern: "zebra", Mode: "hybrid", Limit: 50,
+	})
+	require.NoError(t, err, "SearchContent hybrid")
+	require.Len(t, page.Matches, 1,
+		"the run's vector hit and its keyword-matched member must fuse into one result")
+
+	m := page.Matches[0]
+	assert.Equal(t, "s1", m.SessionID)
+	assert.Equal(t, 2, m.Ordinal, "anchor overridden to the keyword-matched message")
+	assert.Equal(t, "assistant", m.Role, "role of the keyword-matched message")
+	assert.Equal(t, [2]int{1, 2}, m.OrdinalRange, "range spans the containing unit")
+	assert.Contains(t, m.Snippet, "zebra", "keyword snippet wins for display")
+	require.NotNil(t, m.Score)
+	assert.InDelta(t, 2.0/61.0, *m.Score, 1e-9, "fused score: rank 1 in both legs")
+}
+
+// TestPGHybridVectorOnlyAndKeywordOnlyBothAppear pins RRF union semantics: a
+// hit found only by the vector leg and a hit found only by the keyword leg
+// both survive fusion, not just the leg-overlapping ones.
+func TestPGHybridVectorOnlyAndKeywordOnlyBothAppear(t *testing.T) {
+	f := &hybridFakeSearcher{hits: []db.VectorHit{
+		{SessionID: "vec-only", Ordinal: 0, Score: 0.9, Snippet: "totally unrelated content"},
+	}}
+	store := wireHybrid(t, f)
+	insertCSSession(t, store, "kw-only", "proj", "claude", hybridStart, hybridEnd)
+	insertCSUnitMessage(t, store, "kw-only", 0, "user", "needle in a haystack", false, false)
+	insertCSSession(t, store, "vec-only", "proj", "claude", hybridStart, hybridEnd)
+	insertCSUnitMessage(t, store, "vec-only", 0, "user", "totally unrelated content", false, false)
+
+	page, err := store.SearchContent(context.Background(), db.ContentSearchFilter{
+		Pattern: "needle", Mode: "hybrid", Limit: 50,
+	})
+	require.NoError(t, err, "SearchContent hybrid")
+	require.Len(t, page.Matches, 2, "the keyword-only and vector-only hits both survive")
+
+	var ids []string
+	for _, m := range page.Matches {
+		ids = append(ids, m.SessionID)
+	}
+	assert.ElementsMatch(t, []string{"kw-only", "vec-only"}, ids)
+}
+
+// TestPGHybridKeywordHitOutsideUniverseKeepsMessageGranularity pins the
+// no-unit escape hatch: a keyword hit on a message with no containing mirror
+// unit survives fusion under its own message-granularity key with its own
+// ordinal, carrying a structurally derived unit range (the uncovered hit sits
+// in a two-message assistant run) rather than a self-range.
+func TestPGHybridKeywordHitOutsideUniverseKeepsMessageGranularity(t *testing.T) {
+	f := &hybridFakeSearcher{hits: []db.VectorHit{
+		{SessionID: "covered", Ordinal: 0, Score: 0.9, Snippet: "unrelated content"},
+	}}
+	store := wireHybrid(t, f)
+	insertCSSession(t, store, "uncovered", "proj", "claude", hybridStart, hybridEnd)
+	insertCSUnitMessage(t, store, "uncovered", 0, "user", "irrelevant lead-in", false, false)
+	insertCSUnitMessage(t, store, "uncovered", 1, "assistant", "tool output mentions zebra", false, false)
+	insertCSUnitMessage(t, store, "uncovered", 2, "assistant", "further elaboration", false, false)
+	insertCSSession(t, store, "covered", "proj", "claude", hybridStart, hybridEnd)
+	insertCSUnitMessage(t, store, "covered", 0, "user", "unrelated content", false, false)
+
+	page, err := store.SearchContent(context.Background(), db.ContentSearchFilter{
+		Pattern: "zebra", Mode: "hybrid", Limit: 50,
+	})
+	require.NoError(t, err, "SearchContent hybrid")
+	require.Len(t, page.Matches, 2, "the unit-less keyword hit must not vanish")
+
+	byID := map[string]db.ContentMatch{}
+	for _, m := range page.Matches {
+		byID[m.SessionID] = m
+	}
+	uncovered, ok := byID["uncovered"]
+	require.True(t, ok, "no-unit keyword hit survives")
+	assert.Equal(t, 1, uncovered.Ordinal, "message-granularity ordinal kept")
+	assert.Equal(t, [2]int{1, 2}, uncovered.OrdinalRange,
+		"unit-less hit gets the derived run range, not a self-range")
+	assert.False(t, uncovered.Subordinate,
+		"unit-less top-level non-sidechain hit stays non-subordinate")
+	assert.Contains(t, uncovered.Snippet, "zebra")
+}
+
+// TestPGHybridScopeFiltersBothLegs pins that Scope filtering sees both legs:
+// scope=top drops the vector-leg subordinate hit AND the keyword-leg
+// subordinate hit, while scope=subordinate keeps only them. The keyword-leg
+// subordinate flag comes from the resolved unit.
+func TestPGHybridScopeFiltersBothLegs(t *testing.T) {
+	f := &hybridFakeSearcher{
+		hits: []db.VectorHit{
+			{SessionID: "topvec", Ordinal: 0, Score: 0.9, Snippet: "topvec body"},
+			{SessionID: "subvec", Ordinal: 0, Subordinate: true, Score: 0.8, Snippet: "subvec body"},
+		},
+		units: []db.UnitRef{
+			{DocKey: "u:subkw:0", SessionID: "subkw", OrdinalStart: 0, OrdinalEnd: 0, Subordinate: true},
+		},
+	}
+	store := wireHybrid(t, f)
+	// Vector-only sessions (no keyword match).
+	insertCSSession(t, store, "topvec", "proj", "claude", hybridStart, hybridEnd)
+	insertCSUnitMessage(t, store, "topvec", 0, "user", "topvec body", false, false)
+	insertCSSession(t, store, "subvec", "proj", "claude", hybridStart, hybridEnd)
+	insertCSUnitMessage(t, store, "subvec", 0, "assistant", "subvec body", false, false)
+	// Keyword sessions.
+	insertCSSession(t, store, "topkw", "proj", "claude", hybridStart, hybridEnd)
+	insertCSUnitMessage(t, store, "topkw", 0, "user", "zebra top level", false, false)
+	insertCSChildSession(t, store, "subkw", "proj", "claude", "topkw", hybridStart, hybridEnd)
+	insertCSUnitMessage(t, store, "subkw", 0, "assistant", "zebra subordinate", false, false)
+
+	ctx := context.Background()
+	top, err := store.SearchContent(ctx, db.ContentSearchFilter{
+		Pattern: "zebra", Mode: "hybrid", Scope: "top", Limit: 50,
+	})
+	require.NoError(t, err, "SearchContent scope=top")
+	topIDs := hybridSessionIDs(top)
+	assert.ElementsMatch(t, []string{"topvec", "topkw"}, topIDs,
+		"scope=top keeps only top-level units from both legs")
+
+	sub, err := store.SearchContent(ctx, db.ContentSearchFilter{
+		Pattern: "zebra", Mode: "hybrid", Scope: "subordinate", Limit: 50,
+	})
+	require.NoError(t, err, "SearchContent scope=subordinate")
+	subIDs := hybridSessionIDs(sub)
+	assert.ElementsMatch(t, []string{"subvec", "subkw"}, subIDs,
+		"scope=subordinate keeps only subordinate units from both legs")
+	for _, m := range sub.Matches {
+		assert.True(t, m.Subordinate, "surviving matches are subordinate")
+	}
+}
+
+// TestPGHybridRRFOrderParity pins that the page order equals what db.RRFMerge
+// produces for the two legs' known ranks: the doubly-ranked unit leads, then a
+// tie between the two single-leg units breaks by ascending fusion key (the
+// message key sorts before the unit key), independent of session recency.
+func TestPGHybridRRFOrderParity(t *testing.T) {
+	f := &hybridFakeSearcher{hits: []db.VectorHit{
+		{SessionID: "both", Ordinal: 0, Score: 0.9, Snippet: "needle here"},
+		{SessionID: "vec", Ordinal: 0, Score: 0.8, Snippet: "no match here"},
+	}}
+	store := wireHybrid(t, f)
+	insertCSSession(t, store, "both", "proj", "claude", hybridStart, hybridEnd)
+	insertCSUnitMessage(t, store, "both", 0, "user", "needle here", false, false)
+	insertCSSession(t, store, "vec", "proj", "claude", hybridStart, hybridEnd)
+	insertCSUnitMessage(t, store, "vec", 0, "user", "no match here", false, false)
+	insertCSSession(t, store, "kw", "proj", "claude", hybridStart, hybridEnd)
+	insertCSUnitMessage(t, store, "kw", 0, "user", "needle appears", false, false)
+
+	page, err := store.SearchContent(context.Background(), db.ContentSearchFilter{
+		Pattern: "needle", Mode: "hybrid", Limit: 50,
+	})
+	require.NoError(t, err, "SearchContent hybrid")
+
+	// The vector leg ranks [both, vec]; the keyword leg ranks [both, kw]
+	// (both/kw match "needle"; vec does not). "both" resolves to the vector
+	// unit in both legs; "kw" has no unit, so it keeps a message key.
+	vecRanked := []db.RankedUnit{
+		{Key: db.UnitFusionKey("both", 0)}, {Key: db.UnitFusionKey("vec", 0)},
+	}
+	kwRanked := []db.RankedUnit{
+		{Key: db.UnitFusionKey("both", 0)}, {Key: db.MessageFusionKey("kw", 0)},
+	}
+	merged := db.RRFMerge([][]db.RankedUnit{vecRanked, kwRanked}, 50)
+	keyToSession := map[string]string{
+		db.UnitFusionKey("both", 0):  "both",
+		db.UnitFusionKey("vec", 0):   "vec",
+		db.MessageFusionKey("kw", 0): "kw",
+	}
+	want := make([]string, len(merged))
+	for i, u := range merged {
+		want[i] = keyToSession[u.Unit.Key]
+	}
+	require.Equal(t, want, hybridSessionIDs(page),
+		"page order must match db.RRFMerge over the two legs")
+}
+
+// TestPGHybridKeywordSnippetCentersOnTerm pins the term-aware keyword snippet:
+// a two-term query whose terms are non-adjacent in the message (so the raw
+// pattern is not a literal substring) centers the snippet on a matched term, not
+// the message start. The first matched term sits far past the start window, so
+// under the old raw-pattern centering the snippet would not contain it.
+func TestPGHybridKeywordSnippetCentersOnTerm(t *testing.T) {
+	f := &hybridFakeSearcher{}
+	store := wireHybrid(t, f)
+
+	// "alpha" lands at byte 160, past the ~60-char start snippet window; "omega"
+	// follows later. The raw pattern "alpha omega" is not a substring.
+	lead := strings.Repeat("x ", 80)
+	content := lead + "alpha then a stretch of filler words before omega ends it"
+	insertCSSession(t, store, "s1", "proj", "claude", hybridStart, hybridEnd)
+	insertCSUnitMessage(t, store, "s1", 0, "user", content, false, false)
+
+	page, err := store.SearchContent(context.Background(), db.ContentSearchFilter{
+		Pattern: "alpha omega", Mode: "hybrid", Limit: 50,
+	})
+	require.NoError(t, err, "SearchContent hybrid")
+	require.Len(t, page.Matches, 1, "the two-term keyword hit survives")
+	assert.Contains(t, page.Matches[0].Snippet, "alpha",
+		"snippet centers on a matched term, not the message start")
+}
+
+// hybridSessionIDs projects a page's matches to session IDs in order.
+func hybridSessionIDs(page db.ContentSearchPage) []string {
+	out := make([]string, len(page.Matches))
+	for i, m := range page.Matches {
+		out[i] = m.SessionID
+	}
+	return out
+}

--- a/internal/postgres/search_content_parity_pg_test.go
+++ b/internal/postgres/search_content_parity_pg_test.go
@@ -1,0 +1,124 @@
+//go:build pgtest
+
+package postgres
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+// classifySearchErr buckets a SearchContent failure into the two error
+// classes the HTTP layer maps to distinct status codes: "input" is a
+// *db.SearchInputError (400) and "unavailable" is db.ErrSemanticUnavailable
+// (501). An input error must never also satisfy errors.Is ErrSemanticUnavailable,
+// otherwise a 400 could be reported as a 501.
+func classifySearchErr(t *testing.T, err error) string {
+	t.Helper()
+	require.Error(t, err)
+	var inputErr *db.SearchInputError
+	if errors.As(err, &inputErr) {
+		assert.False(t, errors.Is(err, db.ErrSemanticUnavailable),
+			"input error must not also be ErrSemanticUnavailable: %v", err)
+		return "input"
+	}
+	if errors.Is(err, db.ErrSemanticUnavailable) {
+		return "unavailable"
+	}
+	require.Failf(t, "unexpected error class", "%T: %v", err, err)
+	return ""
+}
+
+// TestSearchContentSemanticErrorParity pins that db.DB (SQLite) and
+// postgres.Store classify the same semantic/hybrid requests into the same
+// error class. Neither store has a VectorSearcher wired, so invalid inputs
+// must be rejected as *db.SearchInputError (400) before the capability gate,
+// while an otherwise-valid semantic/hybrid request falls through to
+// db.ErrSemanticUnavailable (501). Running one input table through both
+// backends is the cross-backend check the per-backend suites don't make.
+func TestSearchContentSemanticErrorParity(t *testing.T) {
+	sqlite, err := db.Open(filepath.Join(t.TempDir(), "parity.db"))
+	require.NoError(t, err, "open sqlite")
+	t.Cleanup(func() { sqlite.Close() })
+
+	pg := setupContentSearch(t)
+
+	cases := []struct {
+		name   string
+		filter db.ContentSearchFilter
+		want   string
+	}{
+		{
+			name:   "semantic cursor rejected",
+			filter: db.ContentSearchFilter{Pattern: "x", Mode: "semantic", Cursor: 1},
+			want:   "input",
+		},
+		{
+			name:   "hybrid cursor rejected",
+			filter: db.ContentSearchFilter{Pattern: "x", Mode: "hybrid", Cursor: 1},
+			want:   "input",
+		},
+		{
+			name: "semantic non-messages source rejected",
+			filter: db.ContentSearchFilter{
+				Pattern: "x", Mode: "semantic", Sources: []string{"tool_input"},
+			},
+			want: "input",
+		},
+		{
+			name: "hybrid non-messages source rejected",
+			filter: db.ContentSearchFilter{
+				Pattern: "x", Mode: "hybrid", Sources: []string{"tool_result"},
+			},
+			want: "input",
+		},
+		{
+			name:   "semantic bad scope rejected",
+			filter: db.ContentSearchFilter{Pattern: "x", Mode: "semantic", Scope: "bogus"},
+			want:   "input",
+		},
+		{
+			name:   "hybrid bad scope rejected",
+			filter: db.ContentSearchFilter{Pattern: "x", Mode: "hybrid", Scope: "bogus"},
+			want:   "input",
+		},
+		{
+			name:   "unknown mode rejected",
+			filter: db.ContentSearchFilter{Pattern: "x", Mode: "bogus"},
+			want:   "input",
+		},
+		{
+			name:   "valid semantic hits capability gate",
+			filter: db.ContentSearchFilter{Pattern: "x", Mode: "semantic"},
+			want:   "unavailable",
+		},
+		{
+			name:   "valid hybrid hits capability gate",
+			filter: db.ContentSearchFilter{Pattern: "x", Mode: "hybrid"},
+			want:   "unavailable",
+		},
+		{
+			name: "valid semantic messages-only hits capability gate",
+			filter: db.ContentSearchFilter{
+				Pattern: "x", Mode: "semantic", Sources: []string{"messages"},
+			},
+			want: "unavailable",
+		},
+	}
+
+	ctx := context.Background()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, sqliteErr := sqlite.SearchContent(ctx, tc.filter)
+			_, pgErr := pg.SearchContent(ctx, tc.filter)
+			assert.Equal(t, tc.want, classifySearchErr(t, sqliteErr), "sqlite class")
+			assert.Equal(t, tc.want, classifySearchErr(t, pgErr), "postgres class")
+		})
+	}
+}

--- a/internal/postgres/search_content_semantic.go
+++ b/internal/postgres/search_content_semantic.go
@@ -1,0 +1,233 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+// searchContentSemanticPG runs mode "semantic" on the PostgreSQL store,
+// mirroring internal/db.searchContentSemantic exactly with PG idioms: it
+// over-fetches ranked hits from the wired VectorSearcher, keeps hits whose
+// session passes the filter's metadata scope (the sidebar-child exclusion is
+// lifted -- f.Scope governs subordinate-unit visibility instead, dropping hits
+// db.ScopeExcludes rules out), routes the survivors through the same RRF merge
+// hybrid uses as a one-leg fusion (db.ApplySubordinatePenalty, so subordinate
+// units are penalized identically while matches keep the searcher's own
+// scores), enriches surviving anchor (session_id, ordinal) pairs with
+// session/message metadata in one query, and returns them in the fused order,
+// truncated to f.Limit. The caller (SearchContent) has already run
+// db.ValidateSemanticFilter and confirmed a searcher is wired.
+func (s *Store) searchContentSemanticPG(
+	ctx context.Context, f db.ContentSearchFilter,
+) (db.ContentSearchPage, error) {
+	searcher := s.getVectorSearcher()
+	if searcher == nil {
+		return db.ContentSearchPage{}, s.semanticUnavailableError()
+	}
+
+	k := max(f.Limit*4, db.SemanticOverfetchMin)
+	surviving, err := s.survivingVectorHitsPG(ctx, f, searcher, k)
+	if err != nil {
+		return db.ContentSearchPage{}, err
+	}
+	if len(surviving) == 0 {
+		return db.ContentSearchPage{}, nil
+	}
+	surviving = db.ApplySubordinatePenalty(surviving)
+
+	meta, err := s.enrichSemanticHitsPG(ctx, surviving)
+	if err != nil {
+		return db.ContentSearchPage{}, err
+	}
+
+	out := make([]db.ContentMatch, 0, min(len(surviving), f.Limit))
+	for _, h := range surviving {
+		info, ok := meta[db.MessageRef{SessionID: h.SessionID, Ordinal: h.Ordinal}]
+		if !ok {
+			continue
+		}
+		score := float64(h.Score)
+		out = append(out, db.ContentMatch{
+			SessionID:       h.SessionID,
+			Project:         info.project,
+			Agent:           info.agent,
+			Location:        "message",
+			Role:            info.role,
+			Ordinal:         h.Ordinal,
+			OrdinalRange:    [2]int{h.OrdinalStart, h.OrdinalEnd},
+			Subordinate:     h.Subordinate,
+			Relationship:    info.relationshipType,
+			ParentSessionID: info.parentSessionID,
+			Sidechain:       info.isSidechain,
+			Timestamp:       info.timestamp,
+			Snippet:         f.SemanticSnippet(info.content, h.Snippet),
+			Score:           &score,
+		})
+		if len(out) >= f.Limit {
+			break
+		}
+	}
+	return db.ContentSearchPage{Matches: out}, nil
+}
+
+// survivingVectorHitsPG over-fetches k ranked hits from the searcher and keeps
+// only those whose session passes the filter's metadata scope (the
+// child-exclusion-lifted lookup) and whose subordinate flag falls inside
+// f.Scope, preserving the searcher's rank order. Shared by the semantic mode
+// and the hybrid vector leg so both filter the vector candidates identically.
+func (s *Store) survivingVectorHitsPG(
+	ctx context.Context, f db.ContentSearchFilter, searcher db.VectorSearcher, k int,
+) ([]db.VectorHit, error) {
+	hits, err := searcher.SemanticSearch(ctx, f.Pattern, k)
+	if err != nil {
+		return nil, err
+	}
+	if len(hits) == 0 {
+		return nil, nil
+	}
+	allowed, err := s.semanticAllowedSessionIDsPG(ctx, f, pgUniqueSessionIDs(hits))
+	if err != nil {
+		return nil, err
+	}
+	surviving := make([]db.VectorHit, 0, len(hits))
+	for _, h := range hits {
+		if allowed[h.SessionID] && !db.ScopeExcludes(f.Scope, h.Subordinate) {
+			surviving = append(surviving, h)
+		}
+	}
+	return surviving, nil
+}
+
+// pgUniqueSessionIDs returns the distinct session IDs referenced by hits.
+// Order is irrelevant: the result only feeds an ANY(...) array bind.
+func pgUniqueSessionIDs(hits []db.VectorHit) []string {
+	seen := make(map[string]bool, len(hits))
+	ids := make([]string, 0, len(hits))
+	for _, h := range hits {
+		if !seen[h.SessionID] {
+			seen[h.SessionID] = true
+			ids = append(ids, h.SessionID)
+		}
+	}
+	return ids
+}
+
+// semanticPGSessionFilter maps a ContentSearchFilter for the semantic/hybrid
+// session scope: the shared pgSessionFilter mapping plus the child one-shot
+// exemption (SessionFilter.ChildExemptOneShot) -- child sessions must not be
+// dropped by the one-shot gate in these modes, while top-level one-shots keep
+// today's exclusion. It mirrors internal/db.semanticContentSessionFilter.
+func semanticPGSessionFilter(f db.ContentSearchFilter) db.SessionFilter {
+	sf := pgSessionFilter(f)
+	sf.ChildExemptOneShot = true
+	return sf
+}
+
+// semanticAllowedSessionIDsPG returns the subset of ids whose session passes
+// the ContentSearchFilter's metadata scope (project, agent, date range,
+// one-shot/automated, ...), reusing buildPGSessionBaseFilter so this path
+// cannot drift from the substring/regex scope subquery. Like SQLite's
+// semanticAllowedSessionIDs it omits the sidebar-child exclusion and exempts
+// child sessions from the one-shot gate (semanticPGSessionFilter): in
+// semantic/hybrid modes Scope supersedes IncludeChildren, so subordinate units
+// stay visible to the vector leg. The whole id set binds as one array
+// parameter (pgx expands ANY natively), so no IN chunking is needed.
+func (s *Store) semanticAllowedSessionIDsPG(
+	ctx context.Context, f db.ContentSearchFilter, ids []string,
+) (map[string]bool, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	where, args := buildPGSessionBaseFilter(semanticPGSessionFilter(f))
+	query := fmt.Sprintf(
+		"SELECT id FROM sessions WHERE %s AND id = ANY($%d)", where, len(args)+1)
+	args = append(args, ids)
+
+	rows, err := s.pg.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("pg semantic search session scope: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	allowed := make(map[string]bool, len(ids))
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan pg semantic session id: %w", err)
+		}
+		allowed[id] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return allowed, nil
+}
+
+// pgSemanticHitInfo is the session/message metadata enrichSemanticHitsPG
+// attaches to a surviving hit. content is the message's full, un-truncated
+// content: semantic/hybrid snippets are built from it (SemanticSnippet) rather
+// than the searcher's pre-truncated chunk text, so secret redaction sees the
+// same whole-body context the lexical paths give it. relationshipType,
+// parentSessionID, and isSidechain carry the hit's lineage joined from the
+// sessions/messages rows; isSidechain is the ANCHOR ordinal's message flag.
+type pgSemanticHitInfo struct {
+	project, agent, role, timestamp, content string
+	relationshipType, parentSessionID        string
+	isSidechain                              bool
+}
+
+// enrichSemanticHitsPG looks up session/message metadata for hits' anchor
+// (session_id, ordinal) pairs via parallel unnest arrays joined to
+// messages/sessions, keyed by db.MessageRef{SessionID, Ordinal}. A hit whose
+// anchor message is missing from PG is absent from the map and dropped by the
+// caller, matching SQLite's enrichSemanticHits. The whole batch binds as two
+// array parameters (session_ids text[], ordinals int[]), so any hit count
+// stays well under PG's bind limit.
+func (s *Store) enrichSemanticHitsPG(
+	ctx context.Context, hits []db.VectorHit,
+) (map[db.MessageRef]pgSemanticHitInfo, error) {
+	out := make(map[db.MessageRef]pgSemanticHitInfo, len(hits))
+	if len(hits) == 0 {
+		return out, nil
+	}
+	sessionIDs := make([]string, len(hits))
+	ordinals := make([]int32, len(hits))
+	for i, h := range hits {
+		sessionIDs[i] = h.SessionID
+		ordinals[i] = int32(h.Ordinal)
+	}
+
+	const query = `
+SELECT m.session_id, s.project, s.agent, m.role, m.ordinal,
+       COALESCE(m.timestamp::text, ''), m.content,
+       COALESCE(s.relationship_type, ''), COALESCE(s.parent_session_id, ''),
+       m.is_sidechain
+  FROM (SELECT unnest($1::text[]) AS session_id,
+               unnest($2::int[]) AS ordinal) h
+  JOIN messages m ON m.session_id = h.session_id AND m.ordinal = h.ordinal
+  JOIN sessions s ON s.id = m.session_id`
+
+	rows, err := s.pg.QueryContext(ctx, query, sessionIDs, ordinals)
+	if err != nil {
+		return nil, fmt.Errorf("pg semantic search enrich: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var ref db.MessageRef
+		var info pgSemanticHitInfo
+		if err := rows.Scan(&ref.SessionID, &info.project, &info.agent,
+			&info.role, &ref.Ordinal, &info.timestamp, &info.content,
+			&info.relationshipType, &info.parentSessionID,
+			&info.isSidechain); err != nil {
+			return nil, fmt.Errorf("scan pg semantic hit: %w", err)
+		}
+		out[ref] = info
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/internal/postgres/search_content_semantic_pg_test.go
+++ b/internal/postgres/search_content_semantic_pg_test.go
@@ -1,0 +1,299 @@
+//go:build pgtest
+
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+// semanticSearchSchema is an isolated schema for semantic-search tests.
+const semanticSearchSchema = "agentsview_semantic_search_test"
+
+// insertSemDoc inserts a vector_documents row, exposing the subordinate flag
+// (insertSearchDoc hardcodes FALSE) so the fixture can seed a subordinate unit.
+func insertSemDoc(
+	t *testing.T, pg *sql.DB,
+	docKey, sessionID string, ordinal, ordinalEnd int, subordinate bool,
+	offsets, content string,
+) {
+	t.Helper()
+	_, err := pg.Exec(`
+INSERT INTO vector_documents (
+    doc_key, session_id, source_uuid, ordinal, ordinal_end,
+    subordinate, offsets, content, content_hash)
+VALUES ($1, $2, '', $3, $4, $5, $6, $7, 'h')`,
+		docKey, sessionID, ordinal, ordinalEnd, subordinate, offsets, content)
+	require.NoError(t, err, "insert doc "+docKey)
+}
+
+// setupSemanticSearch creates a fresh schema with the base vector tables, a
+// Store pointing at it, sessions/messages plus aligned vector docs+chunks, and
+// returns the store, the generation id, and its chunk table. It skips when the
+// pgvector extension is unavailable.
+//
+// The KNN fixture is scored against query [1,0,0,0]; cosine ranking best-first:
+//
+//	dsub  [1,0,0,0]     1.000  Ssub, subordinate (subagent child), user ord 0
+//	d1    [1,0.2,0,0]   0.981  S1, top-level, user ord 0
+//	d2    [1,0.5,0,0]   0.894  S2 (project beta), top-level, user ord 0
+//	run1  [1,1,0,0]     0.707  S1, top-level run ord 10-12, anchor member B ord 12
+//
+// run1's chunk 0 is [0,0,1,0] (score 0) so chunk 1 wins the rollup and, with
+// searchMaxInputChars=20, anchors to member B (ordinal 12, snippet runMemberB).
+func setupSemanticSearch(t *testing.T) (*Store, int64, string) {
+	t.Helper()
+	pgURL := testPGURL(t)
+
+	pg, err := Open(pgURL, semanticSearchSchema, true)
+	require.NoError(t, err, "Open")
+	defer pg.Close()
+	ctx := context.Background()
+	_, err = pg.Exec(`DROP SCHEMA IF EXISTS ` + semanticSearchSchema + ` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, semanticSearchSchema), "EnsureSchema")
+	unavailable, err := ensureVectorBaseSchemaPG(ctx, pg)
+	require.NoError(t, err, "ensureVectorBaseSchemaPG")
+	if unavailable != "" {
+		t.Skip(unavailable)
+	}
+
+	store, err := NewStore(pgURL, semanticSearchSchema, true)
+	require.NoError(t, err, "NewStore")
+	t.Cleanup(func() { store.Close() })
+
+	genID, table := seedSemanticFixture(t, store)
+	return store, genID, table
+}
+
+// seedSemanticFixture inserts the sessions, messages, vector documents, and
+// chunks described on setupSemanticSearch, returning the generation id and its
+// chunk table.
+func seedSemanticFixture(t *testing.T, store *Store) (int64, string) {
+	t.Helper()
+	ctx := context.Background()
+	pg := store.DB()
+
+	const start, end = "2026-05-01T10:00:00Z", "2026-05-01T10:30:00Z"
+	insertCSSession(t, store, "S1", "alpha", "claude", start, end)
+	insertCSSession(t, store, "S2", "beta", "claude", start, end)
+	insertCSChildSession(t, store, "Ssub", "alpha", "claude", "S1", start, end)
+
+	insertCSUnitMessage(t, store, "S1", 0, "user", "hello alpha content", false, false)
+	insertCSUnitMessage(t, store, "S1", 10, "assistant", runMemberA, false, false)
+	insertCSUnitMessage(t, store, "S1", 12, "assistant", runMemberB, false, false)
+	insertCSUnitMessage(t, store, "S2", 0, "user", "beta another content", false, false)
+	insertCSUnitMessage(t, store, "Ssub", 0, "assistant", "subordinate hit content", false, false)
+
+	insertSemDoc(t, pg, "d1", "S1", 0, 0, false, "[]", "hello alpha content")
+	insertSemDoc(t, pg, "d2", "S2", 0, 0, false, "[]", "beta another content")
+	insertSemDoc(t, pg, "run1", "S1", 10, 12, false, runOffsets, runContent)
+	insertSemDoc(t, pg, "dsub", "Ssub", 0, 0, true, "[]", "subordinate hit content")
+
+	genID, err := ensureVectorGeneration(ctx, pg, "fp-sem", "m", 4)
+	require.NoError(t, err, "ensureVectorGeneration")
+	require.NoError(t, ensureVectorChunkTable(ctx, pg, genID, 4), "ensureVectorChunkTable")
+	extSchema, err := vectorExtensionSchema(ctx, pg)
+	require.NoError(t, err, "vectorExtensionSchema")
+	halfvec := extSchema + ".halfvec"
+	table := vectorChunkTable(genID)
+
+	insertSearchChunk(t, pg, table, halfvec, "dsub", 0, []float32{1, 0, 0, 0})
+	insertSearchChunk(t, pg, table, halfvec, "d1", 0, []float32{1, 0.2, 0, 0})
+	insertSearchChunk(t, pg, table, halfvec, "d2", 0, []float32{1, 0.5, 0, 0})
+	insertSearchChunk(t, pg, table, halfvec, "run1", 0, []float32{0, 0, 1, 0})
+	insertSearchChunk(t, pg, table, halfvec, "run1", 1, []float32{1, 1, 0, 0})
+
+	return genID, table
+}
+
+// wireSemanticSearcher wires a fixed-query searcher over the fixture and
+// returns the store for a semantic SearchContent call.
+func wireSemanticSearcher(t *testing.T, store *Store, genID int64) {
+	t.Helper()
+	store.SetVectorSearcher(NewVectorSearcher(
+		store.DB(), genID, 4, searchMaxInputChars, fixedEncoder([]float32{1, 0, 0, 0})))
+}
+
+// semKey identifies a match by session and anchor ordinal (S1 contributes two
+// anchors, so ordinal alone is not unique).
+type semKey struct {
+	session string
+	ordinal int
+}
+
+func semMatchesByKey(
+	t *testing.T, page db.ContentSearchPage,
+) map[semKey]db.ContentMatch {
+	t.Helper()
+	out := make(map[semKey]db.ContentMatch, len(page.Matches))
+	for _, m := range page.Matches {
+		k := semKey{m.SessionID, m.Ordinal}
+		_, dup := out[k]
+		require.False(t, dup, "duplicate match %+v", k)
+		out[k] = m
+	}
+	return out
+}
+
+// TestPGSemanticSearchRankedResults pins the base semantic path: the searcher's
+// ranked hits survive the session-scope filter, the one-leg subordinate penalty
+// reorders them, snippets come from message content, Location is "message", and
+// a run hit carries the unit's ordinal range with the anchor member's snippet.
+func TestPGSemanticSearchRankedResults(t *testing.T) {
+	store, genID, _ := setupSemanticSearch(t)
+	wireSemanticSearcher(t, store, genID)
+
+	page, err := store.SearchContent(context.Background(), db.ContentSearchFilter{
+		Pattern: "content", Mode: "semantic", Limit: 50,
+	})
+	require.NoError(t, err, "SearchContent semantic")
+	require.Len(t, page.Matches, 4, "matches")
+
+	// Penalty reorders the searcher order [dsub, d1, d2, run1] to
+	// [d1, d2, run1, dsub]: the subordinate unit drops last.
+	want := []semKey{{"S1", 0}, {"S2", 0}, {"S1", 12}, {"Ssub", 0}}
+	for i, k := range want {
+		assert.Equal(t, k.session, page.Matches[i].SessionID, "pos %d session", i)
+		assert.Equal(t, k.ordinal, page.Matches[i].Ordinal, "pos %d ordinal", i)
+		assert.Equal(t, "message", page.Matches[i].Location, "pos %d location", i)
+		require.NotNil(t, page.Matches[i].Score, "pos %d score", i)
+	}
+
+	byKey := semMatchesByKey(t, page)
+	run := byKey[semKey{"S1", 12}]
+	assert.Equal(t, [2]int{10, 12}, run.OrdinalRange, "run hit spans the unit")
+	assert.Equal(t, runMemberB, run.Snippet, "member-local snippet from message content")
+	assert.False(t, run.Subordinate, "top-level run")
+
+	d1 := byKey[semKey{"S1", 0}]
+	assert.Equal(t, "alpha", d1.Project, "project from sessions join")
+	assert.Contains(t, d1.Snippet, "hello alpha content", "snippet from message content")
+	assert.InDelta(t, 0.981, *d1.Score, 0.01, "keeps the searcher's cosine score")
+
+	sub := byKey[semKey{"Ssub", 0}]
+	assert.True(t, sub.Subordinate, "subagent unit is subordinate")
+	assert.Equal(t, "subagent", sub.Relationship, "lineage from sessions join")
+	assert.Equal(t, "S1", sub.ParentSessionID, "parent from sessions join")
+}
+
+// TestPGSemanticSearchProjectFilter pins that a project filter drops sessions
+// whose metadata does not match, before the ranking is assembled.
+func TestPGSemanticSearchProjectFilter(t *testing.T) {
+	store, genID, _ := setupSemanticSearch(t)
+	wireSemanticSearcher(t, store, genID)
+
+	page, err := store.SearchContent(context.Background(), db.ContentSearchFilter{
+		Pattern: "content", Mode: "semantic", Limit: 50, Project: "alpha",
+	})
+	require.NoError(t, err, "SearchContent semantic")
+	require.Len(t, page.Matches, 3, "beta session (S2) excluded")
+	for _, m := range page.Matches {
+		assert.NotEqual(t, "S2", m.SessionID, "non-matching project excluded")
+		assert.Equal(t, "alpha", m.Project, "surviving projects are alpha")
+	}
+}
+
+// TestPGSemanticSearchScope pins Scope: "top" drops subordinate units and
+// "subordinate" keeps only them, applied before the penalty and the limit.
+func TestPGSemanticSearchScope(t *testing.T) {
+	store, genID, _ := setupSemanticSearch(t)
+	wireSemanticSearcher(t, store, genID)
+	ctx := context.Background()
+
+	top, err := store.SearchContent(ctx, db.ContentSearchFilter{
+		Pattern: "content", Mode: "semantic", Limit: 50, Scope: "top",
+	})
+	require.NoError(t, err, "SearchContent scope=top")
+	require.Len(t, top.Matches, 3, "subordinate unit dropped")
+	for _, m := range top.Matches {
+		assert.False(t, m.Subordinate, "scope=top keeps only top-level units")
+		assert.NotEqual(t, "Ssub", m.SessionID, "subordinate session excluded")
+	}
+
+	sub, err := store.SearchContent(ctx, db.ContentSearchFilter{
+		Pattern: "content", Mode: "semantic", Limit: 50, Scope: "subordinate",
+	})
+	require.NoError(t, err, "SearchContent scope=subordinate")
+	require.Len(t, sub.Matches, 1, "only the subordinate unit survives")
+	assert.Equal(t, "Ssub", sub.Matches[0].SessionID)
+	assert.True(t, sub.Matches[0].Subordinate)
+}
+
+// TestPGSemanticSearchSubordinatePenaltyReorders pins the one-leg RRF fusion:
+// the subordinate unit ranks first by cosine score yet lands last after the
+// penalty, while every match keeps the searcher's own score (not the fusion
+// score).
+func TestPGSemanticSearchSubordinatePenaltyReorders(t *testing.T) {
+	store, genID, _ := setupSemanticSearch(t)
+	wireSemanticSearcher(t, store, genID)
+
+	page, err := store.SearchContent(context.Background(), db.ContentSearchFilter{
+		Pattern: "content", Mode: "semantic", Limit: 50,
+	})
+	require.NoError(t, err, "SearchContent semantic")
+	require.Len(t, page.Matches, 4, "matches")
+
+	first := page.Matches[0]
+	last := page.Matches[len(page.Matches)-1]
+	assert.Equal(t, "S1", first.SessionID, "top-level unit overtakes the subordinate one")
+	assert.Equal(t, "Ssub", last.SessionID, "subordinate unit demoted to last")
+	require.NotNil(t, first.Score)
+	require.NotNil(t, last.Score)
+	assert.Greater(t, *last.Score, *first.Score,
+		"subordinate kept its higher cosine score despite ranking last")
+	assert.InDelta(t, 1.0, *last.Score, 0.01, "subordinate keeps the searcher's score")
+}
+
+// TestPGSemanticSearchNoSearcherUnavailable pins that a store with no searcher
+// wired returns db.ErrSemanticUnavailable carrying the configured reason.
+func TestPGSemanticSearchNoSearcherUnavailable(t *testing.T) {
+	store := setupContentSearch(t)
+	store.SetSemanticUnavailableReason("no embeddings generation built")
+
+	_, err := store.SearchContent(context.Background(), db.ContentSearchFilter{
+		Pattern: "hello", Mode: "semantic", Limit: 50,
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, db.ErrSemanticUnavailable),
+		"want ErrSemanticUnavailable, got %v", err)
+	assert.Contains(t, err.Error(), "no embeddings generation built",
+		"reason surfaced to the caller")
+}
+
+// TestPGSemanticSearchInvalidInput pins backend parity: an invalid semantic
+// request (cursor pagination or a non-messages source) returns a
+// *db.SearchInputError, validated before the capability gate even with a
+// searcher wired.
+func TestPGSemanticSearchInvalidInput(t *testing.T) {
+	store, genID, _ := setupSemanticSearch(t)
+	wireSemanticSearcher(t, store, genID)
+	ctx := context.Background()
+
+	cases := map[string]db.ContentSearchFilter{
+		"cursor": {Pattern: "x", Mode: "semantic", Cursor: 1, Limit: 50},
+		"source": {
+			Pattern: "x", Mode: "semantic", Sources: []string{"tool_input"}, Limit: 50,
+		},
+	}
+	for name, f := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := store.SearchContent(ctx, f)
+			require.Error(t, err)
+			var inputErr *db.SearchInputError
+			assert.True(t, errors.As(err, &inputErr),
+				"want *db.SearchInputError, got %T: %v", err, err)
+			assert.False(t, errors.Is(err, db.ErrSemanticUnavailable),
+				"invalid input must not be masked as ErrSemanticUnavailable")
+			assert.NotEmpty(t, strings.TrimSpace(inputErr.Error()))
+		})
+	}
+}

--- a/internal/postgres/sessions.go
+++ b/internal/postgres/sessions.go
@@ -30,6 +30,16 @@ type Store struct {
 	pricingLoadMu sync.Mutex
 	pricingLoad   *pricingLoad
 	customPricing map[string]config.CustomModelRate
+
+	// vectorMu guards the semantic-search seam. vectorSearcher is the PG
+	// vector searcher wired at pg serve startup when a generation matches
+	// the configured embeddings fingerprint; semanticUnavailableReason is a
+	// human explanation surfaced (wrapped in db.ErrSemanticUnavailable) when
+	// no searcher could be wired (extension missing, no matching generation,
+	// stale build).
+	vectorMu                  sync.RWMutex
+	vectorSearcher            db.VectorSearcher
+	semanticUnavailableReason string
 }
 
 // pgSessionCols is the column list for standard PG session

--- a/internal/postgres/sync.go
+++ b/internal/postgres/sync.go
@@ -143,6 +143,16 @@ func isUndefinedColumn(err error) bool {
 	return strings.Contains(err.Error(), "42703")
 }
 
+// isInsufficientPrivilege returns true when the role lacks a required
+// privilege (PG SQLSTATE 42501) — e.g. a restricted push role that cannot
+// create vector tables in a schema provisioned by a privileged role.
+func isInsufficientPrivilege(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "42501")
+}
+
 // Sync manages push-only sync from local SQLite to a remote
 // PostgreSQL database.
 type Sync struct {

--- a/internal/postgres/sync.go
+++ b/internal/postgres/sync.go
@@ -160,6 +160,10 @@ type Sync struct {
 	projects        []string
 	excludeProjects []string
 
+	// vectorSource, when set, supplies the local vectors.db active generation
+	// pushed as a phase at the end of Push. Nil disables the phase.
+	vectorSource VectorPushSource
+
 	closeOnce sync.Once
 	closeErr  error
 
@@ -194,6 +198,9 @@ type SyncOptions struct {
 	// MigrateLegacySyncState moves unsuffixed legacy sync-state keys into the
 	// named default target the first time that target runs.
 	MigrateLegacySyncState bool
+	// VectorSource, when non-nil, enables the vector push phase, replicating
+	// the local vectors.db active generation into PG. Nil skips the phase.
+	VectorSource VectorPushSource
 }
 
 // New creates a Sync instance and verifies the PG connection.
@@ -271,6 +278,7 @@ func New(
 		migrateLegacySyncState: migrateLegacySyncState,
 		projects:               opts.Projects,
 		excludeProjects:        opts.ExcludeProjects,
+		vectorSource:           opts.VectorSource,
 	}, nil
 }
 
@@ -389,6 +397,15 @@ func (s *Sync) ensureSchemaLocked(ctx context.Context) error {
 		// existing rows.
 		if err := runSchemaDataRepairsPG(ctx, s.pg); err != nil {
 			return err
+		}
+		// pushSchemaCurrent predates the vector tables, so a schema
+		// created before this feature is "current" yet lacks them; a
+		// plain post-upgrade pg push would never create them. Run the
+		// same best-effort vector setup the full EnsureSchema path does
+		// (schema.go), once per Sync via the schemaDone memo. Failure
+		// leaves semantic search unavailable but must not fail the push.
+		if _, err := ensureVectorBaseSchemaPG(ctx, s.pg); err != nil {
+			log.Printf("pg schema: vector schema setup failed: %v", err)
 		}
 		s.schemaDone = true
 		return nil

--- a/internal/postgres/vector_admin.go
+++ b/internal/postgres/vector_admin.go
@@ -1,0 +1,269 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// VectorGenerationRow is one row of `pg vectors list`: a registered PG vector
+// generation with its embedding identity and the live doc/chunk/machine counts
+// derived from its per-generation chunk table and the machine registry.
+type VectorGenerationRow struct {
+	ID          int64
+	Fingerprint string
+	Model       string
+	Dimension   int
+	Docs        int64
+	Chunks      int64
+	Machines    []string
+	CreatedAt   time.Time
+}
+
+// ListVectorGenerations returns every registered generation with its doc,
+// chunk, and machine counts, ordered by id (oldest first). Docs and chunks come
+// from the generation's chunk table (docs = distinct doc_keys, chunks = rows);
+// a generation whose chunk table does not yet exist reports zero for both. A
+// missing vector_generations table (pgvector never installed, SQLSTATE 42P01)
+// yields an empty list rather than an error, matching the read-side gate's
+// tolerance elsewhere in this package.
+func ListVectorGenerations(
+	ctx context.Context, pg *sql.DB,
+) ([]VectorGenerationRow, error) {
+	rows, err := pg.QueryContext(ctx, `
+SELECT id, fingerprint, model, dimension, created_at
+  FROM vector_generations ORDER BY id`)
+	if isUndefinedTable(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("listing vector generations: %w", err)
+	}
+	var gens []VectorGenerationRow
+	for rows.Next() {
+		var g VectorGenerationRow
+		if err := rows.Scan(
+			&g.ID, &g.Fingerprint, &g.Model, &g.Dimension, &g.CreatedAt,
+		); err != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("scanning vector generation: %w", err)
+		}
+		gens = append(gens, g)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, fmt.Errorf("iterating vector generations: %w", err)
+	}
+	_ = rows.Close()
+
+	for i := range gens {
+		if err := fillVectorGenerationCounts(ctx, pg, &gens[i]); err != nil {
+			return nil, err
+		}
+	}
+	return gens, nil
+}
+
+// fillVectorGenerationCounts populates a row's Docs, Chunks, and Machines from
+// the generation's chunk table and the machine registry. The counts must be
+// read after the outer generation query is drained (they issue their own
+// queries), so ListVectorGenerations collects rows first, then fills each.
+func fillVectorGenerationCounts(
+	ctx context.Context, pg *sql.DB, g *VectorGenerationRow,
+) error {
+	docs, chunks, err := vectorChunkCounts(ctx, pg, g.ID)
+	if err != nil {
+		return err
+	}
+	g.Docs, g.Chunks = docs, chunks
+	machines, err := vectorGenerationMachines(ctx, pg, g.ID)
+	if err != nil {
+		return err
+	}
+	g.Machines = machines
+	return nil
+}
+
+// vectorChunkCounts returns the distinct doc_key count and total chunk-row
+// count in the generation's chunk table. A generation row can exist before its
+// chunk table is created (or after a partial reset); a missing table is not an
+// error and reports zero for both, guarded by to_regclass.
+func vectorChunkCounts(
+	ctx context.Context, pg *sql.DB, genID int64,
+) (docs, chunks int64, err error) {
+	table := vectorChunkTable(genID)
+	var present bool
+	if err := pg.QueryRowContext(ctx,
+		`SELECT to_regclass($1) IS NOT NULL`, table).Scan(&present); err != nil {
+		return 0, 0, fmt.Errorf("probing chunk table for generation %d: %w", genID, err)
+	}
+	if !present {
+		return 0, 0, nil
+	}
+	if err := pg.QueryRowContext(ctx, fmt.Sprintf(
+		`SELECT count(DISTINCT doc_key), count(*) FROM %s`, table,
+	)).Scan(&docs, &chunks); err != nil {
+		return 0, 0, fmt.Errorf("counting chunks for generation %d: %w", genID, err)
+	}
+	return docs, chunks, nil
+}
+
+// vectorGenerationMachines lists the machines that have pushed the generation,
+// sorted by name, from vector_generation_machines.
+func vectorGenerationMachines(
+	ctx context.Context, pg *sql.DB, genID int64,
+) ([]string, error) {
+	rows, err := pg.QueryContext(ctx,
+		`SELECT machine FROM vector_generation_machines
+		  WHERE generation_id = $1 ORDER BY machine`, genID)
+	if err != nil {
+		return nil, fmt.Errorf("listing machines for generation %d: %w", genID, err)
+	}
+	defer func() { _ = rows.Close() }()
+	var machines []string
+	for rows.Next() {
+		var m string
+		if err := rows.Scan(&m); err != nil {
+			return nil, fmt.Errorf("scanning generation machine: %w", err)
+		}
+		machines = append(machines, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating generation machines: %w", err)
+	}
+	return machines, nil
+}
+
+// DropVectorGeneration removes a generation and all of its data: its chunk
+// table, its vector_push_state and vector_generation_machines rows, and its
+// vector_generations row, then prunes vector_documents rows referenced by no
+// remaining generation's chunk table (shared docs another generation still
+// embeds survive). It runs in one transaction so a failure leaves the
+// generation intact. Dropping an id that does not exist, or dropping against a
+// database without the vector tables (SQLSTATE 42P01), returns a clear error.
+func DropVectorGeneration(ctx context.Context, pg *sql.DB, id int64) error {
+	var one int
+	err := pg.QueryRowContext(ctx,
+		`SELECT 1 FROM vector_generations WHERE id = $1`, id).Scan(&one)
+	if isUndefinedTable(err) {
+		return fmt.Errorf(
+			"no vector generations exist (pgvector not initialized for this target)")
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("vector generation %d does not exist", id)
+	}
+	if err != nil {
+		return fmt.Errorf("looking up vector generation %d: %w", id, err)
+	}
+
+	tx, err := pg.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin drop generation tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if err := dropVectorGenerationRows(ctx, tx, id); err != nil {
+		return err
+	}
+	remaining, err := existingChunkGenerationsTx(ctx, tx)
+	if err != nil {
+		return err
+	}
+	if err := pruneUnreferencedVectorDocs(ctx, tx, remaining); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit drop generation tx: %w", err)
+	}
+	return nil
+}
+
+// dropVectorGenerationRows drops the generation's chunk table and deletes its
+// state, machine, and generation rows within the transaction. PG DDL is
+// transactional, so a later step's failure rolls the DROP back with the rest.
+func dropVectorGenerationRows(ctx context.Context, tx *sql.Tx, id int64) error {
+	if _, err := tx.ExecContext(ctx,
+		fmt.Sprintf(`DROP TABLE IF EXISTS %s`, vectorChunkTable(id))); err != nil {
+		return fmt.Errorf("dropping chunk table for generation %d: %w", id, err)
+	}
+	stmts := []struct {
+		what string
+		sql  string
+	}{
+		{"push state", `DELETE FROM vector_push_state WHERE generation_id = $1`},
+		{"machine rows", `DELETE FROM vector_generation_machines WHERE generation_id = $1`},
+		{"generation row", `DELETE FROM vector_generations WHERE id = $1`},
+	}
+	for _, s := range stmts {
+		if _, err := tx.ExecContext(ctx, s.sql, id); err != nil {
+			return fmt.Errorf("deleting %s for generation %d: %w", s.what, id, err)
+		}
+	}
+	return nil
+}
+
+// existingChunkGenerationsTx returns the ids of the still-registered
+// generations whose chunk table currently exists, probed with to_regclass. It
+// mirrors Sync.existingChunkGenerations but runs inside the drop transaction so
+// the orphan-doc prune never references a missing chunk table (which would
+// abort the transaction). The outer generation query is drained before the
+// per-generation probes, since a transaction serves one query at a time.
+func existingChunkGenerationsTx(ctx context.Context, tx *sql.Tx) ([]int64, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT id FROM vector_generations`)
+	if err != nil {
+		return nil, fmt.Errorf("listing remaining generations: %w", err)
+	}
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("scanning remaining generation id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, fmt.Errorf("iterating remaining generations: %w", err)
+	}
+	_ = rows.Close()
+
+	var existing []int64
+	for _, id := range ids {
+		var present bool
+		if err := tx.QueryRowContext(ctx,
+			`SELECT to_regclass($1) IS NOT NULL`,
+			vectorChunkTable(id)).Scan(&present); err != nil {
+			return nil, fmt.Errorf("probing chunk table for generation %d: %w", id, err)
+		}
+		if present {
+			existing = append(existing, id)
+		}
+	}
+	return existing, nil
+}
+
+// pruneUnreferencedVectorDocs deletes vector_documents rows that no remaining
+// generation's chunk table references. When no generation with a chunk table
+// remains, every doc is orphaned and removed. genIDs must be pre-filtered to
+// existing chunk tables (existingChunkGenerationsTx) so the NOT EXISTS probes
+// never reference a missing table.
+func pruneUnreferencedVectorDocs(
+	ctx context.Context, tx *sql.Tx, genIDs []int64,
+) error {
+	var conds strings.Builder
+	for _, id := range genIDs {
+		fmt.Fprintf(&conds,
+			" AND NOT EXISTS (SELECT 1 FROM %s c WHERE c.doc_key = d.doc_key)",
+			vectorChunkTable(id))
+	}
+	stmt := fmt.Sprintf(
+		`DELETE FROM vector_documents d WHERE true%s`, conds.String())
+	if _, err := tx.ExecContext(ctx, stmt); err != nil {
+		return fmt.Errorf("pruning unreferenced vector docs: %w", err)
+	}
+	return nil
+}

--- a/internal/postgres/vector_admin_pg_test.go
+++ b/internal/postgres/vector_admin_pg_test.go
@@ -1,0 +1,198 @@
+//go:build pgtest
+
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pushAdminGeneration pushes one generation's docs through the fake source and
+// returns its resolved PG generation id, reusing the vector push test harness.
+func pushAdminGeneration(
+	t *testing.T, sync *Sync, fake *fakeVectorSource, fingerprint string,
+) int64 {
+	t.Helper()
+	ctx := context.Background()
+	_, err := sync.Push(ctx, false, nil)
+	require.NoError(t, err, "push "+fingerprint)
+	id, _, ok, err := LookupVectorGeneration(ctx, sync.pg, fingerprint)
+	require.NoError(t, err)
+	require.True(t, ok, "generation "+fingerprint+" registered")
+	return id
+}
+
+// TestListAndDropVectorGenerations seeds two generations that share one doc
+// (X#0) while genA alone embeds Y#0. It verifies ListVectorGenerations returns
+// both with correct doc/chunk/machine counts in id order, that
+// DropVectorGeneration(genA) removes genA's chunk table, state, machine, and
+// generation rows, keeps the shared doc (genB still references it), prunes the
+// genA-only doc, and that dropping a nonexistent id errors clearly.
+func TestListAndDropVectorGenerations(t *testing.T) {
+	pgURL := testPGURL(t)
+	sync, localDB, pg := newVectorPushTestSync(
+		t, pgURL, "agentsview_vector_admin_test")
+	ctx := context.Background()
+
+	seedVectorSession(t, localDB, "X")
+	seedVectorSession(t, localDB, "Y")
+
+	fake := &fakeVectorSource{
+		gen:    VectorGenerationInfo{Fingerprint: "fp-a", Model: "model-a", Dimension: 4},
+		hasGen: true,
+		hashes: map[string]string{"X": "hx", "Y": "hy"},
+		docs: map[string][]VectorPushDoc{
+			"X": {vdoc("X", "X#0", 0, "cx", "hx1", []float32{1, 0, 0, 0})},
+			"Y": {vdoc("Y", "Y#0", 0, "cy", "hy1", []float32{0, 1, 0, 0})},
+		},
+	}
+	sync.vectorSource = fake
+	genA := pushAdminGeneration(t, sync, fake, "fp-a")
+
+	// Gen B (new fingerprint/model) embeds only the shared X#0.
+	fake.gen.Fingerprint = "fp-b"
+	fake.gen.Model = "model-b"
+	fake.hashes = map[string]string{"X": "hx"}
+	fake.docs = map[string][]VectorPushDoc{
+		"X": {vdoc("X", "X#0", 0, "cx", "hx1", []float32{1, 0, 0, 0})},
+	}
+	genB := pushAdminGeneration(t, sync, fake, "fp-b")
+
+	gens, err := ListVectorGenerations(ctx, pg)
+	require.NoError(t, err)
+	require.Len(t, gens, 2)
+	assert.Equal(t, genA, gens[0].ID, "generations listed in id order")
+	assert.Equal(t, genB, gens[1].ID)
+
+	a, b := gens[0], gens[1]
+	assert.Equal(t, "model-a", a.Model)
+	assert.Equal(t, 4, a.Dimension)
+	assert.Equal(t, int64(2), a.Docs, "genA embeds X#0 and Y#0")
+	assert.Equal(t, int64(2), a.Chunks)
+	assert.Equal(t, []string{"test-machine"}, a.Machines)
+	assert.False(t, a.CreatedAt.IsZero(), "created_at populated")
+	assert.Equal(t, "fp-a", a.Fingerprint)
+
+	assert.Equal(t, "model-b", b.Model)
+	assert.Equal(t, int64(1), b.Docs, "genB embeds only the shared X#0")
+	assert.Equal(t, int64(1), b.Chunks)
+	assert.Equal(t, []string{"test-machine"}, b.Machines)
+
+	require.NoError(t, DropVectorGeneration(ctx, pg, genA))
+
+	var reg sql.NullString
+	require.NoError(t, pg.QueryRowContext(ctx,
+		`SELECT to_regclass($1)`, vectorChunkTable(genA)).Scan(&reg))
+	assert.False(t, reg.Valid, "genA chunk table dropped")
+
+	assert.Equal(t, 0, countRows(t, pg,
+		`SELECT COUNT(*) FROM vector_generations WHERE id = $1`, genA))
+	assert.Equal(t, 0, countRows(t, pg,
+		`SELECT COUNT(*) FROM vector_push_state WHERE generation_id = $1`, genA))
+	assert.Equal(t, 0, countRows(t, pg,
+		`SELECT COUNT(*) FROM vector_generation_machines WHERE generation_id = $1`, genA))
+
+	assert.Equal(t, 1, countRows(t, pg,
+		`SELECT COUNT(*) FROM vector_documents WHERE doc_key = $1`, "X#0"),
+		"shared doc survives, genB still references it")
+	assert.Equal(t, 0, countRows(t, pg,
+		`SELECT COUNT(*) FROM vector_documents WHERE doc_key = $1`, "Y#0"),
+		"genA-only doc pruned")
+
+	assert.Equal(t, 1, countRows(t, pg,
+		`SELECT COUNT(*) FROM `+vectorChunkTable(genB)), "genB chunk table intact")
+
+	gens, err = ListVectorGenerations(ctx, pg)
+	require.NoError(t, err)
+	require.Len(t, gens, 1)
+	assert.Equal(t, genB, gens[0].ID)
+
+	err = DropVectorGeneration(ctx, pg, 99999)
+	require.Error(t, err, "dropping a nonexistent generation errors")
+	assert.Contains(t, err.Error(), "99999")
+
+	// A subsequent push against genB must not abort after genA was dropped.
+	fake.hashes["X"] = "hx2"
+	fake.docs["X"] = []VectorPushDoc{
+		vdoc("X", "X#0", 0, "cx-updated", "hx2", []float32{0, 0, 1, 0}),
+	}
+	res, err := sync.Push(ctx, false, nil)
+	require.NoError(t, err, "push after drop must not abort")
+	assert.Equal(t, 1, res.Vectors.SessionsPushed)
+}
+
+// TestListVectorGenerationsMissingTable verifies the read tolerates a database
+// where the vector_generations table never existed (pgvector never installed,
+// SQLSTATE 42P01): the list is empty and no error surfaces.
+func TestListVectorGenerationsMissingTable(t *testing.T) {
+	pgURL := testPGURL(t)
+	schema := "agentsview_vector_admin_missing_test"
+	pg, err := Open(pgURL, schema, true)
+	require.NoError(t, err, "Open")
+	t.Cleanup(func() { _ = pg.Close() })
+
+	ctx := context.Background()
+	_, err = pg.ExecContext(ctx, `DROP SCHEMA IF EXISTS `+schema+` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	_, err = pg.ExecContext(ctx, `CREATE SCHEMA `+schema)
+	require.NoError(t, err, "create schema")
+	t.Cleanup(func() {
+		_, _ = pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	})
+
+	gens, err := ListVectorGenerations(ctx, pg)
+	require.NoError(t, err, "missing table yields empty list, not error")
+	assert.Empty(t, gens)
+}
+
+// TestVectorPushToleratesMissingChunkTable pins existingChunkGenerations'
+// to_regclass-NULL branch: a generation row whose chunk table was removed (a
+// partial reset, or a concurrent drop) must not abort a later push against a
+// different generation. deleteOrphanVectorDocs must reference only chunk tables
+// that still exist.
+func TestVectorPushToleratesMissingChunkTable(t *testing.T) {
+	pgURL := testPGURL(t)
+	sync, localDB, pg := newVectorPushTestSync(
+		t, pgURL, "agentsview_vector_admin_dangling_test")
+	ctx := context.Background()
+
+	seedVectorSession(t, localDB, "S")
+
+	fake := &fakeVectorSource{
+		gen:    VectorGenerationInfo{Fingerprint: "fp-x", Model: "m", Dimension: 4},
+		hasGen: true,
+		hashes: map[string]string{"S": "h1"},
+		docs: map[string][]VectorPushDoc{
+			"S": {
+				vdoc("S", "S#0", 0, "c0", "hc0", []float32{1, 0, 0, 0}),
+				vdoc("S", "S#1", 1, "c1", "hc1", []float32{0, 1, 0, 0}),
+			},
+		},
+	}
+	sync.vectorSource = fake
+	genX := pushAdminGeneration(t, sync, fake, "fp-x")
+
+	// Second generation embeds the same docs so vector_documents rows are shared.
+	fake.gen.Fingerprint = "fp-y"
+	_ = pushAdminGeneration(t, sync, fake, "fp-y")
+
+	// Remove genX's chunk table while leaving its generation row: the partial
+	// state existingChunkGenerations is built to tolerate.
+	_, err := pg.ExecContext(ctx,
+		`DROP TABLE IF EXISTS `+vectorChunkTable(genX))
+	require.NoError(t, err, "drop genX chunk table")
+
+	// Shrink genY's session so the prune path runs; it must reference only the
+	// surviving chunk table and not abort on genX's missing one.
+	fake.hashes["S"] = "h2"
+	fake.docs["S"] = []VectorPushDoc{
+		vdoc("S", "S#0", 0, "c0", "hc0", []float32{1, 0, 0, 0}),
+	}
+	res, err := sync.pushVectors(ctx, false, nil, nil)
+	require.NoError(t, err, "push must not abort on a missing chunk table")
+	assert.Equal(t, 1, res.SessionsPushed)
+}

--- a/internal/postgres/vector_push.go
+++ b/internal/postgres/vector_push.go
@@ -227,6 +227,9 @@ func (s *Sync) pushVectors(
 	}
 	unavailable, err := ensureVectorBaseSchemaPG(ctx, s.pg)
 	if err != nil {
+		if s.skipVectorsOnPrivilegeError(err, &res) {
+			return res, nil
+		}
 		return res, err
 	}
 	if unavailable != "" {
@@ -235,6 +238,9 @@ func (s *Sync) pushVectors(
 	}
 	resolved, err := s.resolveVectorGeneration(ctx, gen)
 	if err != nil {
+		if s.skipVectorsOnPrivilegeError(err, &res) {
+			return res, nil
+		}
 		return res, err
 	}
 	owner, err := s.vectorOwnerIdentity(ctx)
@@ -261,6 +267,24 @@ func (s *Sync) pushVectors(
 		res.SessionsPushed, res.SessionsUnchanged, res.SessionsDeferred,
 		res.SessionsEvicted, res.ChunksPushed)
 	return res, nil
+}
+
+// skipVectorsOnPrivilegeError reports whether err is an
+// insufficient-privilege error (SQLSTATE 42501) from the vector SETUP phase
+// — base tables, generation registration, chunk table — and marks res as
+// skipped when it is: a restricted role that cannot create vector tables in
+// an already-provisioned schema degrades exactly like a database without
+// pgvector, instead of failing a push whose session phase succeeded.
+// Privilege errors AFTER setup (mid-push writes) never reach this and still
+// fail the push loudly.
+func (s *Sync) skipVectorsOnPrivilegeError(err error, res *VectorPushResult) bool {
+	if !isInsufficientPrivilege(err) {
+		return false
+	}
+	res.Skipped = true
+	res.SkippedReason = "insufficient PostgreSQL privileges for vector tables"
+	log.Printf("vector push: skipped: %v", err)
+	return true
 }
 
 // applyVectorDeltas pushes changed/new sessions and evicts sessions absent from

--- a/internal/postgres/vector_push.go
+++ b/internal/postgres/vector_push.go
@@ -1,0 +1,1117 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log"
+	"math"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+// VectorGenerationInfo identifies the local embedding generation being pushed.
+// Machines whose embedding config produces the same Fingerprint share one PG
+// generation (and one chunk table); Model and Dimension are recorded for
+// diagnostics and to size the halfvec column.
+type VectorGenerationInfo struct {
+	Fingerprint string
+	Model       string
+	Dimension   int
+}
+
+// VectorPushChunk is one embedded slice of a document. ChunkIndex is stable
+// within a doc_key so re-pushes overwrite the same (doc_key, chunk_index) row.
+type VectorPushChunk struct {
+	ChunkIndex int
+	Embedding  []float32
+}
+
+// VectorPushDoc mirrors one local vectors.db document row plus its embeddings.
+// DocKey is globally unique and shared across generations, which is why
+// vector_documents is a single backend-agnostic table upserted by doc_key
+// rather than a per-generation table.
+type VectorPushDoc struct {
+	DocKey      string
+	SessionID   string
+	SourceUUID  string
+	Ordinal     int
+	OrdinalEnd  int
+	Subordinate bool
+	OffsetsJSON string
+	Content     string
+	ContentHash string
+	Chunks      []VectorPushChunk
+}
+
+// VectorPushSource supplies the locally built vectors.db active generation to
+// the PG push phase. Generation reports the active generation (ok=false when
+// none is built, an error wrapping ErrVectorSourceNotReady when one exists but
+// must not be exported right now). SessionDocHashes returns per-session
+// aggregate hashes used for delta detection; SessionDocs returns the full docs
+// for one session only when that session needs a (re)push, together with the
+// aggregate hash of exactly the returned doc set computed in the same read
+// snapshot ("" when no docs are embedded). The push compares that hash against
+// the delta-scan hash and defers the session on any divergence, so a local
+// index rewritten between the scan and the export can never overwrite valid PG
+// vectors with a partial view.
+type VectorPushSource interface {
+	Generation(ctx context.Context) (VectorGenerationInfo, bool, error)
+	SessionDocHashes(ctx context.Context) (map[string]string, error)
+	SessionDocs(
+		ctx context.Context, sessionID string,
+	) ([]VectorPushDoc, string, error)
+}
+
+// ErrVectorSourceNotReady marks a Generation error meaning the local vector
+// index exists but is not safe to export right now — an embeddings build is
+// rewriting it (or one was interrupted), so its session coverage is partial. A
+// push that ran anyway would read that partial view as truth and evict or
+// overwrite valid PG vectors. pushVectors turns this into a clean phase skip;
+// the next push after the build completes sends everything that changed.
+var ErrVectorSourceNotReady = errors.New(
+	"local vector index is not fully embedded (build in progress or interrupted)")
+
+// VectorPushResult summarizes the vector push phase. Skipped is set (with a
+// human reason) when the phase cannot run: no source, no active generation, or
+// no pgvector extension. The counters describe what changed on PG.
+//
+// DocsDeleted counts vector_documents rows removed: on eviction of a whole
+// session and when a doc vanished from a re-pushed session (its shared row is
+// removed only when no other generation still embeds it). Conflicts counts
+// sessions this pusher left untouched because the PG owner marker names a
+// different machine — on the push path (a locally changed session PG says
+// another machine owns) and on the evict path (an owned-elsewhere session
+// absent from local, kept rather than evicted). The user-facing print of
+// Conflicts lands with the CLI wiring.
+type VectorPushResult struct {
+	Skipped           bool
+	SkippedReason     string
+	SessionsPushed    int
+	SessionsUnchanged int
+	// SessionsDeferred counts changed sessions whose vectors were withheld
+	// because their session-phase push failed this run; the delta state is
+	// untouched, so the next successful push sends them.
+	SessionsDeferred int
+	DocsPushed       int
+	ChunksPushed     int
+	DocsDeleted      int
+	SessionsEvicted  int
+	Conflicts        int
+}
+
+// vectorChunkInsertBatch caps rows per multi-row INSERT so parameter counts
+// stay well under PG's 65535 bound (each chunk row binds 3 parameters).
+const vectorChunkInsertBatch = 200
+
+// vectorProgressStride bounds how many unchanged sessions the delta scan
+// examines between progress reports; pushed sessions always report.
+const vectorProgressStride = 2000
+
+// vectorGeneration is the resolved PG generation this push targets: its id and
+// the schema-qualified halfvec type. The type must be qualified because the
+// connection's search_path is the target schema only, while pgvector's types
+// live in whichever schema first installed the extension.
+type vectorGeneration struct {
+	id          int64
+	halfvecType string
+}
+
+// vectorPushScope carries the push-wide constants threaded through every
+// per-session push and eviction: the target generation, its local fingerprint
+// (for the pre-eviction re-check against the source), the id list of all
+// generations whose chunk table exists (for the shared-doc cross-generation
+// guard, already filtered so a missing table cannot abort a tx), and this
+// pusher's owner identity. Bundling them keeps per-session helpers under the
+// positional-parameter limit.
+type vectorPushScope struct {
+	gen         vectorGeneration
+	fingerprint string
+	genIDs      []int64
+	owner       vectorOwnerIdentity
+}
+
+// vectorPushStateRow is the PG-side delta state for one owned session in one
+// generation, joined with the session's current owner marker and machine.
+type vectorPushStateRow struct {
+	docAggHash    string
+	ownerMarker   string
+	machine       string
+	sessionExists bool
+}
+
+// vectorOwnerIdentity is the set of PG session identities this pusher treats
+// as its own, mirroring the session phase's sameSessionOwner: a non-empty
+// owner_marker decides ownership outright, while an empty marker (a legacy or
+// unclaimed row) falls back to the sessions.machine column checked against
+// this pusher's machine name and its recorded marker aliases. One divergence
+// from the session phase is deliberate: sameSessionOwner compares against
+// each pushed session's own machine field, which lets a legacy row be adopted
+// through a locally mirrored remote session; the vector phase compares only
+// against this pusher's identities, so a legacy row that names another
+// machine is a conflict here even when a mirrored copy exists locally —
+// deferring to that machine's own vector push rather than overwriting it.
+type vectorOwnerIdentity struct {
+	markerID       string
+	machine        string
+	legacyMachines []string
+}
+
+func (id vectorOwnerIdentity) owns(ownerMarker, machine string) bool {
+	if ownerMarker != "" {
+		return ownerMarker == id.markerID
+	}
+	if machine == "" || machine == "local" || machine == id.machine {
+		return true
+	}
+	return slices.Contains(id.legacyMachines, machine)
+}
+
+// vectorOwnerIdentity resolves this push's owner identity: its marker id plus
+// the machine name and marker-machine aliases used to adjudicate legacy PG
+// rows whose owner_marker is empty.
+func (s *Sync) vectorOwnerIdentity(
+	ctx context.Context,
+) (vectorOwnerIdentity, error) {
+	markerID, err := s.pushMarkerID()
+	if err != nil {
+		return vectorOwnerIdentity{}, err
+	}
+	markerMachine, aliases, _, err := s.pgPushMarkerMachineState(ctx, markerID)
+	if err != nil {
+		return vectorOwnerIdentity{}, err
+	}
+	return vectorOwnerIdentity{
+		markerID:       markerID,
+		machine:        s.machine,
+		legacyMachines: pushMarkerLegacyMachines(markerMachine, aliases),
+	}, nil
+}
+
+// pushVectors replicates the local active generation's embeddings into PG,
+// pushing only sessions whose aggregate hash changed and evicting state for
+// sessions this pusher no longer has. It is a no-op (Skipped) when there is no
+// source, no active generation, or no pgvector extension. Sessions are already
+// committed by the caller when this runs; a failure here surfaces as a push
+// error without undoing them. full bypasses the unchanged-hash skip, matching
+// the session phase's --full semantics: a full push re-sends every session's
+// vectors, repairing PG rows whose vector_push_state wrongly reports them
+// current. failedSessions names sessions whose session-phase push failed this
+// run: their vectors are deferred (counted in SessionsDeferred) so pgvector
+// data never runs ahead of the corresponding sessions/messages rows.
+// onProgress, when non-nil, receives Phase "vectors" reports so interactive
+// pushes are not silent through a long first vector push.
+func (s *Sync) pushVectors(
+	ctx context.Context, full bool, failedSessions map[string]struct{},
+	onProgress func(PushProgress),
+) (VectorPushResult, error) {
+	var res VectorPushResult
+	if s.vectorSource == nil {
+		res.Skipped, res.SkippedReason = true, "no vector source configured"
+		return res, nil
+	}
+	gen, hasGen, err := s.vectorSource.Generation(ctx)
+	if errors.Is(err, ErrVectorSourceNotReady) {
+		res.Skipped, res.SkippedReason = true, err.Error()
+		log.Printf("vector push: skipped: %v", err)
+		return res, nil
+	}
+	if err != nil {
+		return res, fmt.Errorf("resolving local vector generation: %w", err)
+	}
+	if !hasGen {
+		res.Skipped, res.SkippedReason = true, "no active local generation"
+		return res, nil
+	}
+	unavailable, err := ensureVectorBaseSchemaPG(ctx, s.pg)
+	if err != nil {
+		return res, err
+	}
+	if unavailable != "" {
+		res.Skipped, res.SkippedReason = true, unavailable
+		return res, nil
+	}
+	resolved, err := s.resolveVectorGeneration(ctx, gen)
+	if err != nil {
+		return res, err
+	}
+	owner, err := s.vectorOwnerIdentity(ctx)
+	if err != nil {
+		return res, err
+	}
+	local, err := s.vectorSource.SessionDocHashes(ctx)
+	if err != nil {
+		return res, fmt.Errorf("reading local vector doc hashes: %w", err)
+	}
+	pgState, err := s.readVectorPushState(ctx, resolved.id)
+	if err != nil {
+		return res, err
+	}
+	log.Printf("vector push: comparing %d local session(s) against %d PG state row(s) for generation %d",
+		len(local), len(pgState), resolved.id)
+	if err := s.applyVectorDeltas(
+		ctx, resolved, gen.Fingerprint, owner, full, local, pgState,
+		failedSessions, onProgress, &res,
+	); err != nil {
+		return res, err
+	}
+	log.Printf("vector push: %d session(s) pushed, %d unchanged, %d deferred, %d evicted, %d chunks",
+		res.SessionsPushed, res.SessionsUnchanged, res.SessionsDeferred,
+		res.SessionsEvicted, res.ChunksPushed)
+	return res, nil
+}
+
+// applyVectorDeltas pushes changed/new sessions and evicts sessions absent from
+// local, accumulating counters into res. Sessions owned by another machine are
+// left untouched on both paths and counted in res.Conflicts (ownership
+// conflicts mirror the session push). When a project filter is active, sessions
+// that fail the filter are excluded from both paths entirely: they are neither
+// pushed, counted unchanged, evicted, nor counted as conflicts, mirroring the
+// session push's project scope so a filtered `pg push` never touches vector
+// state for out-of-scope sessions. Local candidates are scoped by their live
+// local project and PG-only eviction candidates by their PG project (see
+// vectorSessionsOutOfScope). Changed sessions in failedSessions are deferred
+// rather than pushed: their session-phase push failed, so sending newer
+// vectors would leave pgvector data ahead of the sessions/messages rows.
+// Their delta state is untouched and the next successful push sends them.
+// Failed sessions are excluded from eviction the same way: the local hash map
+// only lists sessions with embedded docs, so a failed session whose docs all
+// vanished locally would otherwise be evicted — vector state running ahead of
+// the sessions/messages rows its session-phase push failed to write. full
+// re-sends
+// unchanged sessions too, while still honoring out-of-scope exclusion,
+// ownership conflicts, and failed-session deferral. onProgress, when non-nil,
+// receives a Phase "vectors" report after every pushed session and every
+// vectorProgressStride examined ones, so long delta scans stay visible
+// without a callback per unchanged session.
+func (s *Sync) applyVectorDeltas(
+	ctx context.Context, gen vectorGeneration, fingerprint string,
+	owner vectorOwnerIdentity, full bool,
+	local map[string]string, pgState map[string]vectorPushStateRow,
+	failedSessions map[string]struct{}, onProgress func(PushProgress),
+	res *VectorPushResult,
+) error {
+	allGenIDs, err := s.allVectorGenerationIDs(ctx)
+	if err != nil {
+		return err
+	}
+	genIDs, err := s.existingChunkGenerations(ctx, allGenIDs)
+	if err != nil {
+		return err
+	}
+	scope := vectorPushScope{
+		gen: gen, fingerprint: fingerprint, genIDs: genIDs, owner: owner,
+	}
+
+	outOfScope, err := s.vectorSessionsOutOfScope(ctx, local, pgState)
+	if err != nil {
+		return err
+	}
+
+	examined := 0
+	report := func() {
+		if onProgress == nil {
+			return
+		}
+		onProgress(PushProgress{
+			Phase:               "vectors",
+			VectorSessionsDone:  examined,
+			VectorSessionsTotal: len(local),
+			VectorChunksPushed:  res.ChunksPushed,
+		})
+	}
+	for sessionID, agg := range local {
+		examined++
+		if _, skip := outOfScope[sessionID]; skip {
+			continue
+		}
+		prev, hasState := pgState[sessionID]
+		if hasState && !owner.owns(prev.ownerMarker, prev.machine) {
+			res.Conflicts++
+			continue
+		}
+		if !full && hasState && prev.docAggHash == agg {
+			res.SessionsUnchanged++
+			continue
+		}
+		if _, failed := failedSessions[sessionID]; failed {
+			res.SessionsDeferred++
+			continue
+		}
+		outcome, err := s.pushVectorSession(ctx, scope, sessionID, agg)
+		if err != nil {
+			return err
+		}
+		if outcome.conflict {
+			res.Conflicts++
+		}
+		if outcome.deferred {
+			res.SessionsDeferred++
+			// One diverged session can be a transient local change; a source
+			// that is no longer ready (or swapped generations) means a build
+			// is rewriting the whole index — every remaining session would
+			// diverge too, so stop the phase (evictions included) and let the
+			// next push, run against the completed build, send everything.
+			if !s.vectorSourceStillCurrent(ctx, scope.fingerprint) {
+				log.Printf(
+					"vector push: stopping after %d pushed session(s): local generation changed or became unready mid-push",
+					res.SessionsPushed)
+				return nil
+			}
+		}
+		if outcome.pushed {
+			res.SessionsPushed++
+			res.DocsPushed += outcome.docs
+			res.ChunksPushed += outcome.chunks
+			res.DocsDeleted += outcome.deleted
+			report()
+		} else if examined%vectorProgressStride == 0 {
+			report()
+		}
+	}
+	report()
+
+	var evict []string
+	for sessionID, st := range pgState {
+		if _, inLocal := local[sessionID]; inLocal {
+			continue
+		}
+		if _, skip := outOfScope[sessionID]; skip {
+			continue
+		}
+		if _, failed := failedSessions[sessionID]; failed {
+			res.SessionsDeferred++
+			continue
+		}
+		switch {
+		case !st.sessionExists || owner.owns(st.ownerMarker, st.machine):
+			evict = append(evict, sessionID)
+		default:
+			res.Conflicts++
+		}
+	}
+	if len(evict) > 0 && !s.vectorSourceStillCurrent(ctx, scope.fingerprint) {
+		log.Printf(
+			"vector push: skipping eviction of %d session(s): local generation changed or became unready mid-push",
+			len(evict))
+		return nil
+	}
+	return s.evictVectorSessions(ctx, scope, evict, res)
+}
+
+// vectorSourceStillCurrent re-verifies that the local source still reports the
+// same fully embedded generation the delta scan read its hashes from. It gates
+// two decisions computed from that earlier read: the eviction list (an
+// embeddings build that starts mid-push collapses the local coverage the list
+// was computed from — evicting on that view would remove valid PG vectors
+// wholesale — and a generation swap invalidates it outright) and whether to
+// keep pushing after a session's export hash diverged from its delta-scan hash
+// (an unready source means every remaining session would diverge too).
+// Deferring is always safe: both the eviction list and per-session deltas are
+// re-derived from scratch on the next push. (A full rebuild that both starts
+// and completes between the hash read and this check is not detectable from
+// the source's state, but the per-session export-hash comparison in
+// pushVectorSession covers the replacement path regardless, and eviction
+// candidates lost to that window are re-pushed by the next push.)
+func (s *Sync) vectorSourceStillCurrent(
+	ctx context.Context, fingerprint string,
+) bool {
+	cur, ok, err := s.vectorSource.Generation(ctx)
+	return err == nil && ok && cur.Fingerprint == fingerprint
+}
+
+// vectorSessionsOutOfScope computes the set of candidate sessions a filtered
+// push must not touch, partitioned by which project value is authoritative.
+// Any candidate with a live local sessions row — present in the vectors.db
+// hash map or not, since a live session can have zero embedded docs — is
+// scoped by its LIVE local project: a session that moved out of the filter
+// locally (alpha->beta) keeps its old PG project because the filtered session
+// push skipped it, so scoping those by PG would let a stale value re-push or
+// evict their vectors. Only candidates genuinely absent from the local
+// sessions table keep the PG-project scope; theirs is then the only project
+// there is, and it is correct for eviction. Returns nil (empty set) when no
+// filter is active, so the common unfiltered path issues no query.
+func (s *Sync) vectorSessionsOutOfScope(
+	ctx context.Context,
+	local map[string]string, pgState map[string]vectorPushStateRow,
+) (map[string]struct{}, error) {
+	if !s.isFiltered() {
+		return nil, nil
+	}
+	localIDs := make([]string, 0, len(local))
+	for id := range local {
+		localIDs = append(localIDs, id)
+	}
+	out, err := s.localOutOfScopeVectorSessions(ctx, localIDs)
+	if err != nil {
+		return nil, err
+	}
+	if out == nil {
+		out = make(map[string]struct{})
+	}
+	var pgOnly []string
+	for id := range pgState {
+		if _, inLocal := local[id]; !inLocal {
+			pgOnly = append(pgOnly, id)
+		}
+	}
+	absent, err := s.scopeEvictionCandidatesByLocalProject(ctx, pgOnly, out)
+	if err != nil {
+		return nil, err
+	}
+	pgOut, err := s.outOfScopeVectorSessions(ctx, absent)
+	if err != nil {
+		return nil, err
+	}
+	for id := range pgOut {
+		out[id] = struct{}{}
+	}
+	return out, nil
+}
+
+// scopeEvictionCandidatesByLocalProject scopes eviction candidates that still
+// have a live local sessions row by that row's project — adding filter
+// failures to out — and returns the candidates with no local row at all, whose
+// scoping must fall back to the PG project. Candidates reach here because they
+// are absent from the vectors.db hash map, which only proves they have no
+// embedded docs, not that the session left the local archive. Caller
+// guarantees a filter is active.
+func (s *Sync) scopeEvictionCandidatesByLocalProject(
+	ctx context.Context, candidateIDs []string, out map[string]struct{},
+) ([]string, error) {
+	if len(candidateIDs) == 0 {
+		return nil, nil
+	}
+	projects, err := s.local.SessionProjectsByIDs(ctx, candidateIDs)
+	if err != nil {
+		return nil, fmt.Errorf("reading local session projects: %w", err)
+	}
+	var absent []string
+	for _, id := range candidateIDs {
+		project, ok := projects[id]
+		if !ok {
+			absent = append(absent, id)
+			continue
+		}
+		if projectFailsFilter(project, s.projects, s.excludeProjects) {
+			out[id] = struct{}{}
+		}
+	}
+	return absent, nil
+}
+
+// localOutOfScopeVectorSessions returns the subset of localIDs whose LIVE local
+// sessions.project fails this push's filter, read from the local DB rather than
+// PG so a session that changed projects locally is scoped by its current value.
+// A session absent from the local sessions table is left in scope: the
+// per-session in-tx ownership probe skips it when no PG row exists, matching the
+// unfiltered path rather than silently swallowing it here. Caller guarantees a
+// filter is active.
+func (s *Sync) localOutOfScopeVectorSessions(
+	ctx context.Context, localIDs []string,
+) (map[string]struct{}, error) {
+	if len(localIDs) == 0 {
+		return nil, nil
+	}
+	projects, err := s.local.SessionProjectsByIDs(ctx, localIDs)
+	if err != nil {
+		return nil, fmt.Errorf("reading local session projects: %w", err)
+	}
+	out := make(map[string]struct{})
+	for _, id := range localIDs {
+		project, ok := projects[id]
+		if !ok {
+			continue
+		}
+		if projectFailsFilter(project, s.projects, s.excludeProjects) {
+			out[id] = struct{}{}
+		}
+	}
+	return out, nil
+}
+
+// projectFailsFilter reports whether project is excluded by the push's
+// include/exclude filter, mirroring the session push's SQL predicate: an
+// include filter excludes any project not in the allowed set; an exclude filter
+// excludes any project in the excluded set. Caller guarantees exactly one of
+// projects/excludeProjects is set (ValidateProjectFilters rejects both).
+func projectFailsFilter(project string, projects, excludeProjects []string) bool {
+	if len(projects) > 0 {
+		return !slices.Contains(projects, project)
+	}
+	return slices.Contains(excludeProjects, project)
+}
+
+// outOfScopeVectorSessions returns the subset of PG-only eviction candidateIDs
+// whose PG sessions.project fails this push's project filter. These are state
+// rows whose session no longer exists locally, so there is no live local
+// project to scope them by; the PG project is authoritative for the eviction
+// decision. Sessions with no PG row are never returned: the evict path already
+// treats a vanished session as evictable. Returns nil (empty set) when no
+// filter is active, so the common unfiltered path issues no query.
+func (s *Sync) outOfScopeVectorSessions(
+	ctx context.Context, candidateIDs []string,
+) (map[string]struct{}, error) {
+	if !s.isFiltered() || len(candidateIDs) == 0 {
+		return nil, nil
+	}
+	query, args := vectorOutOfScopeQuery(
+		candidateIDs, s.projects, s.excludeProjects,
+	)
+	rows, err := s.pg.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("reading out-of-scope vector sessions: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[string]struct{})
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scanning out-of-scope vector session: %w", err)
+		}
+		out[id] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating out-of-scope vector sessions: %w", err)
+	}
+	return out, nil
+}
+
+// vectorOutOfScopeQuery builds the SQL that selects candidate session IDs whose
+// PG project fails the filter. It mirrors the session push's include/exclude
+// semantics: an include filter selects sessions whose project is not in the
+// allowed set; an exclude filter selects sessions whose project is in the
+// excluded set. Caller guarantees exactly one of projects/excludeProjects is
+// set (ValidateProjectFilters rejects both).
+func vectorOutOfScopeQuery(
+	ids, projects, excludeProjects []string,
+) (string, []any) {
+	if len(projects) > 0 {
+		return `SELECT id FROM sessions
+		         WHERE id = ANY($1) AND NOT (project = ANY($2))`,
+			[]any{ids, projects}
+	}
+	return `SELECT id FROM sessions
+	         WHERE id = ANY($1) AND project = ANY($2)`,
+		[]any{ids, excludeProjects}
+}
+
+// resolveVectorGeneration registers the generation, creates its chunk table,
+// and records this machine's push against it.
+func (s *Sync) resolveVectorGeneration(
+	ctx context.Context, gen VectorGenerationInfo,
+) (vectorGeneration, error) {
+	genID, err := ensureVectorGeneration(
+		ctx, s.pg, gen.Fingerprint, gen.Model, gen.Dimension,
+	)
+	if err != nil {
+		return vectorGeneration{}, err
+	}
+	if err := ensureVectorChunkTable(ctx, s.pg, genID, gen.Dimension); err != nil {
+		return vectorGeneration{}, err
+	}
+	extSchema, err := vectorExtensionSchema(ctx, s.pg)
+	if err != nil {
+		return vectorGeneration{}, err
+	}
+	if _, err := s.pg.ExecContext(ctx, `
+INSERT INTO vector_generation_machines (generation_id, machine, last_push_at)
+VALUES ($1, $2, now())
+ON CONFLICT (generation_id, machine) DO UPDATE SET last_push_at = now()`,
+		genID, s.machine); err != nil {
+		return vectorGeneration{}, fmt.Errorf("recording vector push machine: %w", err)
+	}
+	return vectorGeneration{id: genID, halfvecType: extSchema + ".halfvec"}, nil
+}
+
+// readVectorPushState loads the delta state for genID, joined with each
+// session's current owner marker and machine (the machine adjudicates legacy
+// rows whose owner_marker is empty; see vectorOwnerIdentity). A LEFT JOIN miss
+// (sessionExists false) marks a state row whose session row is gone; such rows
+// are always stale.
+func (s *Sync) readVectorPushState(
+	ctx context.Context, genID int64,
+) (map[string]vectorPushStateRow, error) {
+	rows, err := s.pg.QueryContext(ctx, `
+SELECT ps.session_id, ps.doc_agg_hash, s.owner_marker, s.machine,
+       (s.id IS NOT NULL)
+  FROM vector_push_state ps
+  LEFT JOIN sessions s ON s.id = ps.session_id
+ WHERE ps.generation_id = $1`, genID)
+	if err != nil {
+		return nil, fmt.Errorf("reading vector push state: %w", err)
+	}
+	defer rows.Close()
+
+	state := make(map[string]vectorPushStateRow)
+	for rows.Next() {
+		var sessionID, aggHash string
+		var ownerMarker, machine sql.NullString
+		var exists bool
+		if err := rows.Scan(
+			&sessionID, &aggHash, &ownerMarker, &machine, &exists,
+		); err != nil {
+			return nil, fmt.Errorf("scanning vector push state: %w", err)
+		}
+		state[sessionID] = vectorPushStateRow{
+			docAggHash:    aggHash,
+			ownerMarker:   ownerMarker.String,
+			machine:       machine.String,
+			sessionExists: exists,
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating vector push state: %w", err)
+	}
+	return state, nil
+}
+
+// vectorSessionOutcome reports what one pushVectorSession call did. pushed is
+// false when the session was skipped: conflict marks a skip because the
+// sessions row is owned by another machine (counted in res.Conflicts);
+// deferred marks a skip because the session's export hash no longer matched
+// its delta-scan hash — the local index changed mid-push, so nothing was
+// written and the next push re-derives the delta; a skip with neither flag
+// means the sessions row is gone (the session phase did not push it).
+// docs/chunks/deleted are zero on any skip.
+type vectorSessionOutcome struct {
+	pushed   bool
+	conflict bool
+	deferred bool
+	docs     int
+	chunks   int
+	deleted  int
+}
+
+// pushVectorSession replaces one session's docs, chunks, and push state for the
+// scoped generation in a single transaction. It re-verifies ownership inside
+// the transaction: a missing sessions row means the session phase did not push
+// it (skip), and a different owner marker means another machine owns it
+// (conflict skip, mirroring the session push's conflict).
+//
+// doc_key is source_uuid-based and stable across ordinal-shifting rewrites, but
+// vector_documents has a UNIQUE (session_id, ordinal): upserting by doc_key
+// alone collides with a not-yet-updated sibling when ordinals shift. So the tx
+// first parks every existing session row at a unique negative ordinal, then
+// upserts the current docs onto their final ordinals (freed by the park), then
+// deletes rows still parked — docs that vanished locally — together with every
+// generation's chunks for them (see deleteParkedVectorDocs). This mirrors the
+// local mirror's park-to-sentinel slot replacement (internal/vector/mirror.go).
+func (s *Sync) pushVectorSession(
+	ctx context.Context, scope vectorPushScope, sessionID, aggHash string,
+) (vectorSessionOutcome, error) {
+	tx, err := s.pg.BeginTx(ctx, nil)
+	if err != nil {
+		return vectorSessionOutcome{}, fmt.Errorf("begin vector push tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// FOR UPDATE locks the sessions row for the life of this tx so a concurrent
+	// pusher cannot take ownership between this probe and the vector writes
+	// below (under READ COMMITTED an unlocked probe could read a stale owner).
+	// This is deadlock-safe: the session push phase has already committed before
+	// pushVectors runs (see pushVectors), so no session-push tx holds this row
+	// concurrently, and each vector push tx locks exactly one session row (by
+	// primary key) before its own vector-table writes — a single, consistent
+	// lock so two vector pushes cannot form a cycle.
+	var ownerMarker, machine sql.NullString
+	err = tx.QueryRowContext(ctx,
+		`SELECT owner_marker, machine FROM sessions WHERE id = $1 FOR UPDATE`,
+		sessionID,
+	).Scan(&ownerMarker, &machine)
+	if errors.Is(err, sql.ErrNoRows) {
+		return vectorSessionOutcome{}, nil
+	}
+	if err != nil {
+		return vectorSessionOutcome{}, fmt.Errorf(
+			"checking vector session ownership %s: %w", sessionID, err)
+	}
+	if !scope.owner.owns(ownerMarker.String, machine.String) {
+		return vectorSessionOutcome{conflict: true}, nil
+	}
+
+	// Export the full docs (content + decoded chunk blobs) only after the
+	// session passes the existence/ownership probe. A local-only session with no
+	// PG row, or one owned elsewhere, skips forever; fetching docs first would
+	// re-export them on every push for sessions that never land.
+	docs, exportHash, err := s.vectorSource.SessionDocs(ctx, sessionID)
+	if err != nil {
+		return vectorSessionOutcome{}, fmt.Errorf(
+			"reading local docs for session %s: %w", sessionID, err)
+	}
+	// The export hash covers exactly the docs read above, in the same local
+	// snapshot. A mismatch with the delta-scan hash means the local index
+	// changed between the scan and this export — typically an embeddings
+	// rebuild clearing and refilling the generation in place — and the docs
+	// may be a partial view. Writing them would replace valid PG vectors and
+	// record aggHash as current, which a same-fingerprint rebuild (same doc
+	// content, same hash) would never repair. Defer instead: nothing is
+	// written, and the next push re-derives the delta from the settled index.
+	if exportHash != aggHash {
+		return vectorSessionOutcome{deferred: true}, nil
+	}
+
+	if err := parkSessionVectorDocs(ctx, tx, sessionID); err != nil {
+		return vectorSessionOutcome{}, err
+	}
+	if err := upsertVectorDocs(ctx, tx, docs); err != nil {
+		return vectorSessionOutcome{}, err
+	}
+	chunks, err := replaceVectorChunks(ctx, tx, scope.gen, sessionID, docs)
+	if err != nil {
+		return vectorSessionOutcome{}, err
+	}
+	deleted, err := deleteParkedVectorDocs(ctx, tx, sessionID, scope.genIDs)
+	if err != nil {
+		return vectorSessionOutcome{}, err
+	}
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO vector_push_state (generation_id, session_id, doc_agg_hash)
+VALUES ($1, $2, $3)
+ON CONFLICT (generation_id, session_id)
+DO UPDATE SET doc_agg_hash = EXCLUDED.doc_agg_hash`,
+		scope.gen.id, sessionID, aggHash); err != nil {
+		return vectorSessionOutcome{}, fmt.Errorf(
+			"upserting vector push state %s: %w", sessionID, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return vectorSessionOutcome{}, fmt.Errorf("commit vector push tx: %w", err)
+	}
+	return vectorSessionOutcome{
+		pushed: true, docs: len(docs), chunks: chunks, deleted: deleted,
+	}, nil
+}
+
+// parkSessionVectorDocs moves every non-negative-ordinal vector_documents row
+// for sessionID to a unique negative ordinal below the session's existing
+// parked floor, freeing the (session_id, ordinal) unique index so a subsequent
+// doc_key upsert of shifted/renumbered docs cannot collide with a sibling not
+// yet updated. Rows already parked (negative) are left as-is; seeding below
+// MIN(ordinal) keeps every parked ordinal distinct across overlapping pushes,
+// mirroring the local mirror's parkingFloor (internal/vector/mirror.go). The
+// transform is injective, so the single statement never violates the index at
+// any intermediate row.
+func parkSessionVectorDocs(ctx context.Context, tx *sql.Tx, sessionID string) error {
+	if _, err := tx.ExecContext(ctx, `
+WITH floor AS (
+    SELECT COALESCE(MIN(ordinal), 0) AS f
+      FROM vector_documents WHERE session_id = $1 AND ordinal < 0
+), parked AS (
+    SELECT doc_key, row_number() OVER (ORDER BY ordinal) AS rn
+      FROM vector_documents WHERE session_id = $1 AND ordinal >= 0
+)
+UPDATE vector_documents d
+   SET ordinal = (SELECT f FROM floor) - parked.rn
+  FROM parked
+ WHERE d.doc_key = parked.doc_key`, sessionID); err != nil {
+		return fmt.Errorf("parking vector docs for session %s: %w", sessionID, err)
+	}
+	return nil
+}
+
+// upsertVectorDocs upserts each doc by its globally unique doc_key onto its
+// final ordinal. The caller parks the session's prior rows to negative ordinals
+// first, so every final (session_id, ordinal) slot is free and an ordinal shift
+// cannot collide with a sibling row that has not been updated yet.
+func upsertVectorDocs(ctx context.Context, tx *sql.Tx, docs []VectorPushDoc) error {
+	for _, doc := range docs {
+		offsets := doc.OffsetsJSON
+		if offsets == "" {
+			offsets = "[]"
+		}
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO vector_documents (
+    doc_key, session_id, source_uuid, ordinal, ordinal_end,
+    subordinate, offsets, content, content_hash)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+ON CONFLICT (doc_key) DO UPDATE SET
+    session_id = EXCLUDED.session_id,
+    source_uuid = EXCLUDED.source_uuid,
+    ordinal = EXCLUDED.ordinal,
+    ordinal_end = EXCLUDED.ordinal_end,
+    subordinate = EXCLUDED.subordinate,
+    offsets = EXCLUDED.offsets,
+    content = EXCLUDED.content,
+    content_hash = EXCLUDED.content_hash`,
+			doc.DocKey, doc.SessionID, sanitizePG(doc.SourceUUID),
+			doc.Ordinal, doc.OrdinalEnd, doc.Subordinate,
+			sanitizePG(offsets), sanitizePG(doc.Content),
+			doc.ContentHash); err != nil {
+			return fmt.Errorf("upserting vector doc %s: %w", doc.DocKey, err)
+		}
+	}
+	return nil
+}
+
+// replaceVectorChunks deletes all of the session's chunk rows for genID and
+// re-inserts the current chunk set. Sessions are small, so wholesale replace is
+// simpler and correct versus per-doc surgical deletes. It returns the number of
+// chunk rows inserted.
+func replaceVectorChunks(
+	ctx context.Context, tx *sql.Tx, gen vectorGeneration,
+	sessionID string, docs []VectorPushDoc,
+) (int, error) {
+	table := vectorChunkTable(gen.id)
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
+DELETE FROM %s WHERE doc_key IN (
+    SELECT doc_key FROM vector_documents WHERE session_id = $1)`, table),
+		sessionID); err != nil {
+		return 0, fmt.Errorf("clearing chunks for session %s: %w", sessionID, err)
+	}
+
+	type chunkRow struct {
+		docKey     string
+		chunkIndex int
+		embedding  string
+	}
+	var rows []chunkRow
+	for _, doc := range docs {
+		for _, chunk := range doc.Chunks {
+			literal, err := halfvecLiteral(chunk.Embedding)
+			if err != nil {
+				return 0, fmt.Errorf(
+					"doc %s chunk %d: %w", doc.DocKey, chunk.ChunkIndex, err)
+			}
+			rows = append(rows, chunkRow{
+				docKey:     doc.DocKey,
+				chunkIndex: chunk.ChunkIndex,
+				embedding:  literal,
+			})
+		}
+	}
+
+	for start := 0; start < len(rows); start += vectorChunkInsertBatch {
+		end := min(start+vectorChunkInsertBatch, len(rows))
+		batch := rows[start:end]
+		var values strings.Builder
+		args := make([]any, 0, len(batch)*3)
+		for i, r := range batch {
+			if i > 0 {
+				values.WriteByte(',')
+			}
+			base := i * 3
+			fmt.Fprintf(&values, "($%d,$%d,$%d::%s)",
+				base+1, base+2, base+3, gen.halfvecType)
+			args = append(args, r.docKey, r.chunkIndex, r.embedding)
+		}
+		stmt := fmt.Sprintf(
+			`INSERT INTO %s (doc_key, chunk_index, embedding) VALUES %s`,
+			table, values.String())
+		if _, err := tx.ExecContext(ctx, stmt, args...); err != nil {
+			return 0, fmt.Errorf("inserting chunks for session %s: %w", sessionID, err)
+		}
+	}
+	return len(rows), nil
+}
+
+// evictVectorSessions removes each session's chunks and push state for the
+// scoped generation and prunes its now-orphaned shared doc rows, one
+// transaction per session. Ownership was adjudicated from the delta scan's
+// state read, which can be minutes stale by the time evictions run, so each
+// transaction re-probes the sessions row FOR UPDATE (the same lock discipline
+// as pushVectorSession): a session another pusher claimed since the scan is
+// skipped as a conflict rather than having that owner's fresh chunks deleted.
+// A still-missing sessions row keeps the eviction — the state row is stale by
+// definition — and a row recreated after this tx commits is re-pushed by its
+// new owner's next vector push.
+func (s *Sync) evictVectorSessions(
+	ctx context.Context, scope vectorPushScope, sessionIDs []string,
+	res *VectorPushResult,
+) error {
+	if len(sessionIDs) == 0 {
+		return nil
+	}
+	table := vectorChunkTable(scope.gen.id)
+	for _, sessionID := range sessionIDs {
+		tx, err := s.pg.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("begin vector evict tx: %w", err)
+		}
+		var ownerMarker, machine sql.NullString
+		err = tx.QueryRowContext(ctx,
+			`SELECT owner_marker, machine FROM sessions WHERE id = $1 FOR UPDATE`,
+			sessionID,
+		).Scan(&ownerMarker, &machine)
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			// No sessions row: the push state is stale, evict below.
+		case err != nil:
+			_ = tx.Rollback()
+			return fmt.Errorf(
+				"checking vector evict ownership %s: %w", sessionID, err)
+		case !scope.owner.owns(ownerMarker.String, machine.String):
+			_ = tx.Rollback()
+			res.Conflicts++
+			continue
+		}
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
+DELETE FROM %s WHERE doc_key IN (
+    SELECT doc_key FROM vector_documents WHERE session_id = $1)`, table),
+			sessionID); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("evicting chunks for session %s: %w", sessionID, err)
+		}
+		if _, err := tx.ExecContext(ctx, `
+DELETE FROM vector_push_state
+ WHERE generation_id = $1 AND session_id = $2`,
+			scope.gen.id, sessionID); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("evicting push state for session %s: %w", sessionID, err)
+		}
+		deleted, err := deleteOrphanVectorDocs(ctx, tx, sessionID, scope.genIDs)
+		if err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit vector evict tx: %w", err)
+		}
+		res.SessionsEvicted++
+		res.DocsDeleted += deleted
+	}
+	return nil
+}
+
+// existingChunkGenerations returns the subset of genIDs whose per-generation
+// chunk table currently exists, checked with to_regclass on the schema-
+// qualified table name. Filtering up front means the shared-doc cross-
+// generation guard never references a missing chunk table (a generation row can
+// exist before its chunk table, or after a partial reset), which would
+// otherwise abort the deleting transaction.
+func (s *Sync) existingChunkGenerations(
+	ctx context.Context, genIDs []int64,
+) ([]int64, error) {
+	quotedSchema, err := quoteIdentifier(s.schema)
+	if err != nil {
+		return nil, fmt.Errorf("quoting schema for chunk-table probe: %w", err)
+	}
+	var existing []int64
+	for _, id := range genIDs {
+		var present bool
+		if err := s.pg.QueryRowContext(ctx, `SELECT to_regclass($1) IS NOT NULL`,
+			quotedSchema+"."+vectorChunkTable(id)).Scan(&present); err != nil {
+			return nil, fmt.Errorf(
+				"probing chunk table for generation %d: %w", id, err)
+		}
+		if present {
+			existing = append(existing, id)
+		}
+	}
+	return existing, nil
+}
+
+// allVectorGenerationIDs lists every registered generation so eviction can
+// check each generation's chunk table before removing a shared doc row.
+func (s *Sync) allVectorGenerationIDs(ctx context.Context) ([]int64, error) {
+	rows, err := s.pg.QueryContext(ctx, `SELECT id FROM vector_generations`)
+	if err != nil {
+		return nil, fmt.Errorf("listing vector generations: %w", err)
+	}
+	defer rows.Close()
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scanning vector generation id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating vector generations: %w", err)
+	}
+	return ids, nil
+}
+
+// deleteParkedVectorDocs removes the session's still-parked doc rows — docs
+// that vanished from the local mirror — together with every generation's
+// chunks for them. The local mirror is shared across generations and kit's
+// removal deletes a vanished doc's vectors from every generation
+// (sqlitevec's all-generations delete), so PG mirrors that. Preserving
+// another generation's chunks instead would leave them referencing a row
+// hidden behind the read path's ordinal >= 0 tombstone guard: dead KNN slots
+// that can never hydrate, silently shrinking that generation's results.
+// genIDs must be pre-filtered to existing chunk tables (see
+// existingChunkGenerations) so a missing table cannot abort the tx. Returns
+// the number of doc rows deleted.
+func deleteParkedVectorDocs(
+	ctx context.Context, tx *sql.Tx, sessionID string, genIDs []int64,
+) (int, error) {
+	for _, id := range genIDs {
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`
+DELETE FROM %s WHERE doc_key IN (
+    SELECT doc_key FROM vector_documents
+     WHERE session_id = $1 AND ordinal < 0)`, vectorChunkTable(id)),
+			sessionID); err != nil {
+			return 0, fmt.Errorf(
+				"clearing parked chunks for session %s: %w", sessionID, err)
+		}
+	}
+	result, err := tx.ExecContext(ctx,
+		`DELETE FROM vector_documents WHERE session_id = $1 AND ordinal < 0`,
+		sessionID)
+	if err != nil {
+		return 0, fmt.Errorf("pruning parked docs for session %s: %w", sessionID, err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("counting pruned docs for session %s: %w", sessionID, err)
+	}
+	return int(affected), nil
+}
+
+// deleteOrphanVectorDocs deletes the session's doc rows that no listed
+// generation's chunk table still references, for whole-session eviction (the
+// session left this pusher's embedded set — possibly just a project-filter
+// change, with the docs still present locally). vector_documents is shared
+// across generations by doc_key, so a doc another generation still embeds
+// survives here — those rows keep their non-negative ordinals and stay
+// hydratable, unlike parked rows (see deleteParkedVectorDocs). genIDs must be
+// pre-filtered to existing chunk tables (see existingChunkGenerations) so a
+// missing table cannot abort the tx. Returns the number of doc rows deleted.
+func deleteOrphanVectorDocs(
+	ctx context.Context, tx *sql.Tx, sessionID string, genIDs []int64,
+) (int, error) {
+	var conds strings.Builder
+	for _, id := range genIDs {
+		fmt.Fprintf(&conds,
+			" AND NOT EXISTS (SELECT 1 FROM %s c WHERE c.doc_key = d.doc_key)",
+			vectorChunkTable(id))
+	}
+	stmt := fmt.Sprintf(
+		`DELETE FROM vector_documents d WHERE d.session_id = $1%s`,
+		conds.String())
+	result, err := tx.ExecContext(ctx, stmt, sessionID)
+	if err != nil {
+		return 0, fmt.Errorf("pruning orphan docs for session %s: %w", sessionID, err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("counting pruned docs for session %s: %w", sessionID, err)
+	}
+	return int(affected), nil
+}
+
+// halfvecLiteral renders v in pgvector's text input format ("[1,2,3]"), bound
+// as a parameter and cast with ::halfvec. It errors on any non-finite element
+// (NaN, +Inf, -Inf): pgvector rejects those on input, so a single pathological
+// vector would otherwise abort the whole multi-row INSERT with an opaque driver
+// error. Catching it here lets the caller attribute the failure to a doc/chunk.
+func halfvecLiteral(v []float32) (string, error) {
+	var b strings.Builder
+	b.WriteByte('[')
+	for i, f := range v {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		f64 := float64(f)
+		if math.IsNaN(f64) || math.IsInf(f64, 0) {
+			return "", fmt.Errorf("non-finite embedding value at index %d", i)
+		}
+		b.WriteString(strconv.FormatFloat(f64, 'g', -1, 32))
+	}
+	b.WriteByte(']')
+	return b.String(), nil
+}

--- a/internal/postgres/vector_push_pg_test.go
+++ b/internal/postgres/vector_push_pg_test.go
@@ -1,0 +1,1354 @@
+//go:build pgtest
+
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+// fakeVectorSource is an in-memory VectorPushSource whose generation, aggregate
+// hashes, and per-session docs are mutated between pushes to drive the delta,
+// eviction, and cross-generation cases. genOverride, when set, replaces the
+// nth Generation answer (1-based call count) so a test can change the source's
+// state between the push's initial Generation call and its mid-push
+// re-checks. exportHashes, when set, overrides the per-session hash SessionDocs
+// returns (simulating a local index that changed between the delta scan and
+// the export); by default SessionDocs echoes the delta-scan hash so pushes
+// proceed.
+type fakeVectorSource struct {
+	gen          VectorGenerationInfo
+	hasGen       bool
+	hashes       map[string]string
+	docs         map[string][]VectorPushDoc
+	exportHashes map[string]string
+	docsCalls    map[string]int // per-session SessionDocs invocation count
+	genCalls     int
+	genOverride  func(call int) (VectorGenerationInfo, bool, error)
+}
+
+func (f *fakeVectorSource) Generation(
+	ctx context.Context,
+) (VectorGenerationInfo, bool, error) {
+	f.genCalls++
+	if f.genOverride != nil {
+		return f.genOverride(f.genCalls)
+	}
+	return f.gen, f.hasGen, nil
+}
+
+func (f *fakeVectorSource) SessionDocHashes(
+	ctx context.Context,
+) (map[string]string, error) {
+	return f.hashes, nil
+}
+
+func (f *fakeVectorSource) SessionDocs(
+	ctx context.Context, id string,
+) ([]VectorPushDoc, string, error) {
+	if f.docsCalls == nil {
+		f.docsCalls = make(map[string]int)
+	}
+	f.docsCalls[id]++
+	if hash, ok := f.exportHashes[id]; ok {
+		return f.docs[id], hash, nil
+	}
+	return f.docs[id], f.hashes[id], nil
+}
+
+// newVectorPushTestSync creates a fresh schema with the base + vector tables
+// and returns a Sync wired to a local SQLite DB. It skips the test when the
+// pgvector extension is unavailable, since the whole phase no-ops there.
+func newVectorPushTestSync(
+	t *testing.T, pgURL, schema string,
+) (*Sync, *db.DB, *sql.DB) {
+	t.Helper()
+	pg, err := Open(pgURL, schema, true)
+	require.NoError(t, err, "Open")
+	t.Cleanup(func() { _ = pg.Close() })
+
+	ctx := context.Background()
+	_, err = pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
+
+	available, err := VectorExtensionAvailable(ctx, pg)
+	require.NoError(t, err, "VectorExtensionAvailable")
+	if !available {
+		t.Skip("pgvector extension unavailable")
+	}
+
+	localDB, err := db.Open(filepath.Join(t.TempDir(), "local.db"))
+	require.NoError(t, err, "db.Open")
+	t.Cleanup(func() { _ = localDB.Close() })
+
+	sync := &Sync{
+		pg:         pg,
+		local:      localDB,
+		machine:    "test-machine",
+		schema:     schema,
+		schemaDone: true,
+	}
+	return sync, localDB, pg
+}
+
+// seedVectorSession inserts a minimal session with one message so that a Push
+// creates a PG sessions row carrying this pusher's owner marker.
+func seedVectorSession(t *testing.T, localDB *db.DB, id string) {
+	t.Helper()
+	require.NoError(t, localDB.UpsertSession(db.Session{
+		ID:               id,
+		Project:          "proj",
+		Machine:          "test-machine",
+		Agent:            "claude",
+		MessageCount:     1,
+		UserMessageCount: 1,
+		CreatedAt:        "2026-01-01T00:00:00Z",
+	}), "UpsertSession "+id)
+	require.NoError(t, localDB.InsertMessages([]db.Message{{
+		SessionID:     id,
+		Ordinal:       0,
+		Role:          "user",
+		Content:       id,
+		ContentLength: len(id),
+	}}), "InsertMessages "+id)
+}
+
+// seedVectorSessionProject inserts a minimal session under the given project so
+// the PG sessions row carries a project the vector push filter can scope on.
+func seedVectorSessionProject(t *testing.T, localDB *db.DB, id, project string) {
+	t.Helper()
+	require.NoError(t, localDB.UpsertSession(db.Session{
+		ID:               id,
+		Project:          project,
+		Machine:          "test-machine",
+		Agent:            "claude",
+		MessageCount:     1,
+		UserMessageCount: 1,
+		CreatedAt:        "2026-01-01T00:00:00Z",
+	}), "UpsertSession "+id)
+	require.NoError(t, localDB.InsertMessages([]db.Message{{
+		SessionID:     id,
+		Ordinal:       0,
+		Role:          "user",
+		Content:       id,
+		ContentLength: len(id),
+	}}), "InsertMessages "+id)
+}
+
+// vdoc builds a VectorPushDoc with the supplied embeddings as consecutive
+// chunks (chunk_index 0..n-1).
+func vdoc(
+	sessionID, docKey string, ordinal int,
+	content, hash string, chunks ...[]float32,
+) VectorPushDoc {
+	d := VectorPushDoc{
+		DocKey:      docKey,
+		SessionID:   sessionID,
+		Ordinal:     ordinal,
+		OrdinalEnd:  ordinal,
+		OffsetsJSON: "[]",
+		Content:     content,
+		ContentHash: hash,
+	}
+	for i, emb := range chunks {
+		d.Chunks = append(d.Chunks, VectorPushChunk{ChunkIndex: i, Embedding: emb})
+	}
+	return d
+}
+
+func countRows(t *testing.T, pg *sql.DB, query string, args ...any) int {
+	t.Helper()
+	var n int
+	require.NoError(t, pg.QueryRow(query, args...).Scan(&n), "count: "+query)
+	return n
+}
+
+// docOrdinal returns the current ordinal of the doc_key's vector_documents row.
+func docOrdinal(t *testing.T, pg *sql.DB, docKey string) int {
+	t.Helper()
+	var ord int
+	require.NoError(t, pg.QueryRow(
+		`SELECT ordinal FROM vector_documents WHERE doc_key = $1`, docKey,
+	).Scan(&ord), "ordinal of "+docKey)
+	return ord
+}
+
+func TestVectorPushRoundTrip(t *testing.T) {
+	pgURL := testPGURL(t)
+	sync, localDB, pg := newVectorPushTestSync(
+		t, pgURL, "agentsview_vector_push_roundtrip_test")
+	ctx := context.Background()
+
+	seedVectorSession(t, localDB, "A")
+	seedVectorSession(t, localDB, "B")
+
+	sync.vectorSource = &fakeVectorSource{
+		gen:    VectorGenerationInfo{Fingerprint: "fp-rt", Model: "m", Dimension: 4},
+		hasGen: true,
+		hashes: map[string]string{"A": "ha", "B": "hb"},
+		docs: map[string][]VectorPushDoc{
+			"A": {
+				vdoc("A", "A#0", 0, "c1", "h1",
+					[]float32{1, 0, 0, 0}, []float32{0, 1, 0, 0}),
+				vdoc("A", "A#1", 1, "c2", "h2", []float32{0, 0, 1, 0}),
+			},
+			"B": {vdoc("B", "B#0", 0, "c3", "h3", []float32{0, 0, 0, 1})},
+		},
+	}
+
+	var vectorReports, prepareReports []PushProgress
+	res, err := sync.Push(ctx, false, func(p PushProgress) {
+		switch p.Phase {
+		case "vectors":
+			vectorReports = append(vectorReports, p)
+		case "preparing":
+			prepareReports = append(prepareReports, p)
+		}
+	})
+	require.NoError(t, err, "Push")
+	assert.False(t, res.Vectors.Skipped)
+	assert.Equal(t, 2, res.Vectors.SessionsPushed)
+	assert.Equal(t, 3, res.Vectors.DocsPushed)
+	assert.Equal(t, 4, res.Vectors.ChunksPushed)
+
+	require.NotEmpty(t, prepareReports, "fingerprint phase must report progress")
+	prepared := prepareReports[len(prepareReports)-1]
+	assert.Equal(t, 2, prepared.SessionsDone)
+	assert.Equal(t, 2, prepared.SessionsTotal)
+
+	require.NotEmpty(t, vectorReports, "vector phase must report progress")
+	final := vectorReports[len(vectorReports)-1]
+	assert.Equal(t, 2, final.VectorSessionsDone)
+	assert.Equal(t, 2, final.VectorSessionsTotal)
+	assert.Equal(t, 4, final.VectorChunksPushed)
+
+	genID, dim, ok, err := LookupVectorGeneration(ctx, pg, "fp-rt")
+	require.NoError(t, err, "LookupVectorGeneration")
+	require.True(t, ok, "generation registered")
+	assert.Equal(t, 4, dim)
+
+	assert.Equal(t, 3,
+		countRows(t, pg, `SELECT COUNT(*) FROM vector_documents`))
+	assert.Equal(t, 4,
+		countRows(t, pg, `SELECT COUNT(*) FROM `+vectorChunkTable(genID)))
+	assert.Equal(t, 2, countRows(t, pg,
+		`SELECT COUNT(*) FROM vector_push_state WHERE generation_id = $1`, genID))
+	assert.Equal(t, 1, countRows(t, pg,
+		`SELECT COUNT(*) FROM vector_generation_machines
+		 WHERE generation_id = $1 AND machine = $2`, genID, "test-machine"))
+}
+
+func TestVectorPushDeltaNoop(t *testing.T) {
+	pgURL := testPGURL(t)
+	sync, localDB, _ := newVectorPushTestSync(
+		t, pgURL, "agentsview_vector_push_noop_test")
+	ctx := context.Background()
+
+	seedVectorSession(t, localDB, "A")
+	seedVectorSession(t, localDB, "B")
+
+	sync.vectorSource = &fakeVectorSource{
+		gen:    VectorGenerationInfo{Fingerprint: "fp-noop", Model: "m", Dimension: 4},
+		hasGen: true,
+		hashes: map[string]string{"A": "ha", "B": "hb"},
+		docs: map[string][]VectorPushDoc{
+			"A": {vdoc("A", "A#0", 0, "c1", "h1", []float32{1, 0, 0, 0})},
+			"B": {vdoc("B", "B#0", 0, "c3", "h3", []float32{0, 0, 0, 1})},
+		},
+	}
+
+	_, err := sync.Push(ctx, false, nil)
+	require.NoError(t, err, "first Push")
+
+	res, err := sync.Push(ctx, false, nil)
+	require.NoError(t, err, "second Push")
+	assert.Equal(t, 2, res.Vectors.SessionsUnchanged)
+	assert.Equal(t, 0, res.Vectors.SessionsPushed)
+	assert.Equal(t, 0, res.Vectors.DocsPushed)
+}
+
+// TestVectorPushFullRepairsSilentCorruption pins --full's repair contract for
+// the vector phase: a chunk row missing from PG while vector_push_state still
+// reports the session current is invisible to a normal delta push, but a full
+// push bypasses the unchanged-hash skip and restores it.
+func TestVectorPushFullRepairsSilentCorruption(t *testing.T) {
+	pgURL := testPGURL(t)
+	sync, localDB, pg := newVectorPushTestSync(
+		t, pgURL, "agentsview_vector_push_full_test")
+	ctx := context.Background()
+
+	seedVectorSession(t, localDB, "A")
+
+	sync.vectorSource = &fakeVectorSource{
+		gen:    VectorGenerationInfo{Fingerprint: "fp-full", Model: "m", Dimension: 4},
+		hasGen: true,
+		hashes: map[string]string{"A": "ha"},
+		docs: map[string][]VectorPushDoc{
+			"A": {vdoc("A", "A#0", 0, "c1", "h1", []float32{1, 0, 0, 0})},
+		},
+	}
+
+	_, err := sync.Push(ctx, false, nil)
+	require.NoError(t, err, "seed Push")
+	genID, _, ok, err := LookupVectorGeneration(ctx, pg, "fp-full")
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Silently lose the chunk while push state still says "current".
+	_, err = pg.Exec(`DELETE FROM ` + vectorChunkTable(genID))
+	require.NoError(t, err, "corrupting chunk table")
+
+	res, err := sync.pushVectors(ctx, false, nil, nil)
+	require.NoError(t, err, "delta pushVectors")
+	assert.Equal(t, 1, res.SessionsUnchanged, "delta push cannot see the loss")
+	assert.Equal(t, 0,
+		countRows(t, pg, `SELECT COUNT(*) FROM `+vectorChunkTable(genID)))
+
+	res, err = sync.pushVectors(ctx, true, nil, nil)
+	require.NoError(t, err, "full pushVectors")
+	assert.Equal(t, 1, res.SessionsPushed)
+	assert.Equal(t, 0, res.SessionsUnchanged)
+	assert.Equal(t, 1,
+		countRows(t, pg, `SELECT COUNT(*) FROM `+vectorChunkTable(genID)),
+		"full push restores the missing chunk")
+}
+
+// TestVectorPushDeferredOnSessionError pins that a changed session named in
+// failedSessions is deferred — its newer local vectors must not land ahead of
+// sessions/messages rows its session-phase push failed to write — and that
+// the untouched delta state sends it on the next successful push.
+func TestVectorPushDeferredOnSessionError(t *testing.T) {
+	pgURL := testPGURL(t)
+	sync, localDB, pg := newVectorPushTestSync(
+		t, pgURL, "agentsview_vector_push_deferred_test")
+	ctx := context.Background()
+
+	seedVectorSession(t, localDB, "A")
+	seedVectorSession(t, localDB, "B")
+
+	fake := &fakeVectorSource{
+		gen:    VectorGenerationInfo{Fingerprint: "fp-def", Model: "m", Dimension: 4},
+		hasGen: true,
+		hashes: map[string]string{"A": "ha1", "B": "hb1"},
+		docs: map[string][]VectorPushDoc{
+			"A": {vdoc("A", "A#0", 0, "old", "h-old", []float32{1, 0, 0, 0})},
+			"B": {vdoc("B", "B#0", 0, "cb", "hb", []float32{0, 0, 0, 1})},
+		},
+	}
+	sync.vectorSource = fake
+
+	_, err := sync.Push(ctx, false, nil)
+	require.NoError(t, err, "seed Push")
+
+	// A's docs change locally, but its session push failed this run.
+	fake.hashes["A"] = "ha2"
+	fake.docs["A"] = []VectorPushDoc{
+		vdoc("A", "A#0", 0, "new", "h-new", []float32{0, 1, 0, 0}),
+	}
+	res, err := sync.pushVectors(ctx, false, map[string]struct{}{"A": {}}, nil)
+	require.NoError(t, err, "deferred pushVectors")
+	assert.Equal(t, 1, res.SessionsDeferred)
+	assert.Equal(t, 0, res.SessionsPushed)
+	assert.Equal(t, 1, res.SessionsUnchanged, "B is unchanged")
+
+	var content string
+	require.NoError(t, pg.QueryRow(
+		`SELECT content FROM vector_documents WHERE doc_key = $1`, "A#0",
+	).Scan(&content))
+	assert.Equal(t, "old", content, "deferred session keeps its prior vectors")
+
+	// Next push with no failures sends the deferred session.
+	res, err = sync.pushVectors(ctx, false, nil, nil)
+	require.NoError(t, err, "healing pushVectors")
+	assert.Equal(t, 0, res.SessionsDeferred)
+	assert.Equal(t, 1, res.SessionsPushed)
+	require.NoError(t, pg.QueryRow(
+		`SELECT content FROM vector_documents WHERE doc_key = $1`, "A#0",
+	).Scan(&content))
+	assert.Equal(t, "new", content)
+}
+
+func TestVectorPushContentChange(t *testing.T) {
+	pgURL := testPGURL(t)
+	sync, localDB, pg := newVectorPushTestSync(
+		t, pgURL, "agentsview_vector_push_content_test")
+	ctx := context.Background()
+
+	seedVectorSession(t, localDB, "A")
+	seedVectorSession(t, localDB, "B")
+
+	fake := &fakeVectorSource{
+		gen:    VectorGenerationInfo{Fingerprint: "fp-cc", Model: "m", Dimension: 4},
+		hasGen: true,
+		hashes: map[string]string{"A": "ha", "B": "hb"},
+		docs: map[string][]VectorPushDoc{
+			"A": {vdoc("A", "A#0", 0, "c1", "h1", []float32{1, 0, 0, 0})},
+			"B": {vdoc("B", "B#0", 0, "c3", "h3", []float32{0, 0, 0, 1})},
+		},
+	}
+	sync.vectorSource = fake
+
+	_, err := sync.Push(ctx, false, nil)
+	require.NoError(t, err, "first Push")
+
+	fake.hashes["A"] = "ha2"
+	fake.docs["A"] = []VectorPushDoc{
+		vdoc("A", "A#0", 0, "c1-updated", "h1b", []float32{0, 1, 0, 0}),
+	}
+
+	res, err := sync.Push(ctx, false, nil)
+	require.NoError(t, err, "second Push")
+	assert.Equal(t, 1, res.Vectors.SessionsPushed)
+	assert.Equal(t, 1, res.Vectors.SessionsUnchanged)
+
+	var content, hash string
+	require.NoError(t, pg.QueryRow(
+		`SELECT content, content_hash FROM vector_documents WHERE doc_key = $1`,
+		"A#0").Scan(&content, &hash), "read updated doc")
+	assert.Equal(t, "c1-updated", content)
+	assert.Equal(t, "h1b", hash)
+}
+
+func TestVectorPushEviction(t *testing.T) {
+	pgURL := testPGURL(t)
+	sync, localDB, pg := newVectorPushTestSync(
+		t, pgURL, "agentsview_vector_push_evict_test")
+	ctx := context.Background()
+
+	seedVectorSession(t, localDB, "A")
+	seedVectorSession(t, localDB, "B")
+
+	fake := &fakeVectorSource{
+		gen:    VectorGenerationInfo{Fingerprint: "fp-ev", Model: "m", Dimension: 4},
+		hasGen: true,
+		hashes: map[string]string{"A": "ha", "B": "hb"},
+		docs: map[string][]VectorPushDoc{
+			"A": {vdoc("A", "A#0", 0, "c1", "h1", []float32{1, 0, 0, 0})},
+			"B": {vdoc("B", "B#0", 0, "c3", "h3", []float32{0, 0, 0, 1})},
+		},
+	}
+	sync.vectorSource = fake
+
+	_, err := sync.Push(ctx, false, nil)
+	require.NoError(t, err, "first Push")
+	genID, _, ok, err := LookupVectorGeneration(ctx, pg, "fp-ev")
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	delete(fake.hashes, "B")
+	delete(fake.docs, "B")
+
+	res, err := sync.Push(ctx, false, nil)
+	require.NoError(t, err, "second Push")
+	assert.Equal(t, 1, res.Vectors.SessionsEvicted)
+	assert.Equal(t, 1, res.Vectors.DocsDeleted)
+
+	assert.Equal(t, 0, countRows(t, pg,
+		`SELECT COUNT(*) FROM `+vectorChunkTable(genID)+` WHERE doc_key = $1`,
+		"B#0"))
+	assert.Equal(t, 0, countRows(t, pg,
+		`SELECT COUNT(*) FROM vector_push_state
+		 WHERE generation_id = $1 AND session_id = $2`, genID, "B"))
+	assert.Equal(t, 0, countRows(t, pg,
+		`SELECT COUNT(*) FROM vector_documents WHERE session_id = $1`, "B"))
+	assert.Equal(t, 1, countRows(t, pg,
+		`SELECT COUNT(*) FROM vector_documents WHERE session_id = $1`, "A"))
+}
+
+func TestVectorPushNoActiveGeneration(t *testing.T) {
+	pgURL := testPGURL(t)
+	sync, localDB, pg := newVectorPushTestSync(
+		t, pgURL, "agentsview_vector_push_nogen_test")
+	ctx := context.Background()
+
+	seedVectorSession(t, localDB, "A")
+	sync.vectorSource = &fakeVectorSource{hasGen: false}
+
+	res, err := sync.Push(ctx, false, nil)
+	require.NoError(t, err, "Push")
+	assert.True(t, res.Vectors.Skipped)
+	assert.NotEmpty(t, res.Vectors.SkippedReason)
+	assert.Equal(t, 0,
+		countRows(t, pg, `SELECT COUNT(*) FROM vector_generations`))
+}
+
+func TestVectorPushSharedDocAcrossGenerations(t *testing.T) {
+	pgURL := testPGURL(t)
+	sync, localDB, pg := newVectorPushTestSync(
+		t, pgURL, "agentsview_vector_push_sharedgen_test")
+	ctx := context.Background()
+
+	seedVectorSession(t, localDB, "X")
+	seedVectorSession(t, localDB, "Y")
+
+	fake := &fakeVectorSource{
+		gen:    VectorGenerationInfo{Fingerprint: "fp-a", Model: "m", Dimension: 4},
+		hasGen: true,
+		hashes: map[string]string{"X": "hx", "Y": "hy"},
+		docs: map[string][]VectorPushDoc{
+			"X": {vdoc("X", "X#0", 0, "cx", "hx1", []float32{1, 0, 0, 0})},
+			"Y": {vdoc("Y", "Y#0", 0, "cy", "hy1", []float32{0, 1, 0, 0})},
+		},
+	}
+	sync.vectorSource = fake
+
+	_, err := sync.Push(ctx, false, nil)
+	require.NoError(t, err, "push gen A")
+	genA, _, ok, err := LookupVectorGeneration(ctx, pg, "fp-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Switch to a second generation (new fingerprint) sharing the same docs.
+	fake.gen.Fingerprint = "fp-b"
+	_, err = sync.Push(ctx, false, nil)
+	require.NoError(t, err, "push gen B")
+	genB, _, ok, err := LookupVectorGeneration(ctx, pg, "fp-b")
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Drop Y from gen B's source, triggering a gen-B eviction of Y.
+	delete(fake.hashes, "Y")
+	delete(fake.docs, "Y")
+
+	res, err := sync.Push(ctx, false, nil)
+	require.NoError(t, err, "push gen B without Y")
+	assert.Equal(t, 1, res.Vectors.SessionsEvicted)
+	assert.Equal(t, 0, res.Vectors.DocsDeleted,
+		"Y's doc is still referenced by gen A, so it must survive")
+
+	assert.Equal(t, 1, countRows(t, pg,
+		`SELECT COUNT(*) FROM `+vectorChunkTable(genA)+` WHERE doc_key = $1`,
+		"Y#0"), "gen A chunks for Y survive")
+	assert.Equal(t, 0, countRows(t, pg,
+		`SELECT COUNT(*) FROM `+vectorChunkTable(genB)+` WHERE doc_key = $1`,
+		"Y#0"), "gen B chunks for Y evicted")
+	assert.Equal(t, 1, countRows(t, pg,
+		`SELECT COUNT(*) FROM vector_documents WHERE doc_key = $1`, "Y#0"),
+		"shared doc row survives")
+	assert.Equal(t, 0, countRows(t, pg,
+		`SELECT COUNT(*) FROM vector_push_state
+		 WHERE generation_id = $1 AND session_id = $2`, genB, "Y"))
+}
+
+// TestVectorPushOrdinalShift pins the slot-safe replacement: stable doc_keys
+// whose ordinals shift up (0/1 -> 1/2 with a new doc taking slot 0) re-push
+// without a UNIQUE (session_id, ordinal) violation and land on their final
+// ordinals.
+func TestVectorPushOrdinalShift(t *testing.T) {
+	pgURL := testPGURL(t)
+	sync, localDB, pg := newVectorPushTestSync(
+		t, pgURL, "agentsview_vector_push_shift_test")
+	ctx := context.Background()
+
+	seedVectorSession(t, localDB, "A")
+
+	fake := &fakeVectorSource{
+		gen:    VectorGenerationInfo{Fingerprint: "fp-sh", Model: "m", Dimension: 4},
+		hasGen: true,
+		hashes: map[string]string{"A": "h1"},
+		docs: map[string][]VectorPushDoc{
+			"A": {
+				vdoc("A", "k0", 0, "c0", "hc0", []float32{1, 0, 0, 0}),
+				vdoc("A", "k1", 1, "c1", "hc1", []float32{0, 1, 0, 0}),
+			},
+		},
+	}
+	sync.vectorSource = fake
+
+	_, err := sync.Push(ctx, false, nil)
+	require.NoError(t, err, "first Push")
+
+	// Shift k0/k1 up to ordinals 1/2 and insert kNew at ordinal 0.
+	fake.hashes["A"] = "h2"
+	fake.docs["A"] = []VectorPushDoc{
+		vdoc("A", "kNew", 0, "cn", "hcn", []float32{0, 0, 1, 0}),
+		vdoc("A", "k0", 1, "c0", "hc0", []float32{1, 0, 0, 0}),
+		vdoc("A", "k1", 2, "c1", "hc1", []float32{0, 1, 0, 0}),
+	}
+
+	res, err := sync.Push(ctx, false, nil)
+	require.NoError(t, err, "shift Push")
+	assert.Equal(t, 1, res.Vectors.SessionsPushed)
+	assert.Equal(t, 0, res.Vectors.DocsDeleted)
+
+	assert.Equal(t, 0, docOrdinal(t, pg, "kNew"))
+	assert.Equal(t, 1, docOrdinal(t, pg, "k0"))
+	assert.Equal(t, 2, docOrdinal(t, pg, "k1"))
+	assert.Equal(t, 3,
+		countRows(t, pg, `SELECT COUNT(*) FROM vector_documents WHERE session_id = $1`, "A"))
+}
+
+// TestVectorPushDocRemovedAndShared pins that a doc removed from a re-pushed
+// session disappears from vector_documents in the same push, cascading its
+// chunks out of every generation — including one that still embedded it.
+// Regression: preserving the shared row parked at a negative ordinal left the
+// older generation with chunks the read path could never hydrate (the
+// ordinal >= 0 tombstone guard), silently shrinking its results. Local kit
+// removal deletes a vanished doc's vectors from all generations, and PG must
+// match.
+func TestVectorPushDocRemovedAndShared(t *testing.T) {
+	pgURL := testPGURL(t)
+	sync, localDB, pg := newVectorPushTestSync(
+		t, pgURL, "agentsview_vector_push_shrink_test")
+	ctx := context.Background()
+
+	seedVectorSession(t, localDB, "A")
+
+	// Gen A embeds kShared + kDropShared (not kDropSolo).
+	fake := &fakeVectorSource{
+		gen:    VectorGenerationInfo{Fingerprint: "fp-ga", Model: "m", Dimension: 4},
+		hasGen: true,
+		hashes: map[string]string{"A": "ha"},
+		docs: map[string][]VectorPushDoc{
+			"A": {
+				vdoc("A", "kShared", 0, "cs", "hcs", []float32{1, 0, 0, 0}),
+				vdoc("A", "kDropShared", 1, "cds", "hcds", []float32{0, 1, 0, 0}),
+			},
+		},
+	}
+	sync.vectorSource = fake
+	_, err := sync.Push(ctx, false, nil)
+	require.NoError(t, err, "push gen A")
+	genA, _, ok, err := LookupVectorGeneration(ctx, pg, "fp-ga")
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Gen B embeds all three docs for A.
+	fake.gen.Fingerprint = "fp-gb"
+	fake.hashes["A"] = "hb1"
+	fake.docs["A"] = []VectorPushDoc{
+		vdoc("A", "kShared", 0, "cs", "hcs", []float32{1, 0, 0, 0}),
+		vdoc("A", "kDropShared", 1, "cds", "hcds", []float32{0, 1, 0, 0}),
+		vdoc("A", "kDropSolo", 2, "cdo", "hcdo", []float32{0, 0, 1, 0}),
+	}
+	_, err = sync.Push(ctx, false, nil)
+	require.NoError(t, err, "push gen B")
+	genB, _, ok, err := LookupVectorGeneration(ctx, pg, "fp-gb")
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Shrink gen B's A to only kShared: kDropShared + kDropSolo vanish locally.
+	fake.hashes["A"] = "hb2"
+	fake.docs["A"] = []VectorPushDoc{
+		vdoc("A", "kShared", 0, "cs", "hcs", []float32{1, 0, 0, 0}),
+	}
+	res, err := sync.Push(ctx, false, nil)
+	require.NoError(t, err, "shrink push gen B")
+	assert.Equal(t, 1, res.Vectors.SessionsPushed)
+	assert.Equal(t, 2, res.Vectors.DocsDeleted,
+		"kDropSolo and kDropShared both vanished locally")
+
+	// Both vanished docs are gone, whether or not another generation embedded
+	// them.
+	assert.Equal(t, 0, countRows(t, pg,
+		`SELECT COUNT(*) FROM vector_documents WHERE doc_key = $1`, "kDropSolo"))
+	assert.Equal(t, 0, countRows(t, pg,
+		`SELECT COUNT(*) FROM vector_documents WHERE doc_key = $1`, "kDropShared"))
+	assert.Equal(t, 0, countRows(t, pg,
+		`SELECT COUNT(*) FROM `+vectorChunkTable(genA)+` WHERE doc_key = $1`,
+		"kDropShared"), "gen A chunks for kDropShared cascade-deleted")
+	assert.Equal(t, 0, countRows(t, pg,
+		`SELECT COUNT(*) FROM `+vectorChunkTable(genB)+` WHERE doc_key = $1`,
+		"kDropShared"), "gen B chunks for kDropShared cleared")
+	// No parked tombstones survive the push, and every remaining gen A chunk
+	// hydrates: the older generation must not retain chunks pointing at rows
+	// the read path's ordinal >= 0 guard hides.
+	assert.Equal(t, 0, countRows(t, pg,
+		`SELECT COUNT(*) FROM vector_documents WHERE ordinal < 0`))
+	assert.Equal(t, 0, countRows(t, pg, `
+		SELECT COUNT(*) FROM `+vectorChunkTable(genA)+` c
+		LEFT JOIN vector_documents d
+		  ON d.doc_key = c.doc_key AND d.ordinal >= 0
+		WHERE d.doc_key IS NULL`),
+		"gen A has no chunks that cannot hydrate")
+	// kShared stays live at its positive ordinal in both generations.
+	assert.Equal(t, 0, docOrdinal(t, pg, "kShared"))
+	assert.Equal(t, 1, countRows(t, pg,
+		`SELECT COUNT(*) FROM `+vectorChunkTable(genA)+` WHERE doc_key = $1`,
+		"kShared"), "gen A keeps its chunks for the still-present doc")
+}
+
+// TestVectorPushConflictSkipped pins finding 3: a session whose PG owner marker
+// names another machine is skipped on push (counted in Conflicts) and left
+// untouched on evict (also counted).
+func TestVectorPushConflictSkipped(t *testing.T) {
+	pgURL := testPGURL(t)
+	sync, localDB, pg := newVectorPushTestSync(
+		t, pgURL, "agentsview_vector_push_conflict_test")
+	ctx := context.Background()
+
+	seedVectorSession(t, localDB, "A")
+	seedVectorSession(t, localDB, "B")
+
+	fake := &fakeVectorSource{
+		gen:    VectorGenerationInfo{Fingerprint: "fp-cf", Model: "m", Dimension: 4},
+		hasGen: true,
+		hashes: map[string]string{"A": "ha", "B": "hb"},
+		docs: map[string][]VectorPushDoc{
+			"A": {vdoc("A", "cA0", 0, "ca", "hca", []float32{1, 0, 0, 0})},
+			"B": {vdoc("B", "cB0", 0, "cb", "hcb", []float32{0, 0, 0, 1})},
+		},
+	}
+	sync.vectorSource = fake
+	_, err := sync.Push(ctx, false, nil)
+	require.NoError(t, err, "first Push")
+
+	// Hand A to another machine on the PG side.
+	_, err = pg.Exec(
+		`UPDATE sessions SET owner_marker = 'other-machine' WHERE id = $1`, "A")
+	require.NoError(t, err, "reassign owner")
+
+	// A changed locally: the vector phase must skip it as a conflict, leaving
+	// its pushed content intact.
+	fake.hashes["A"] = "ha2"
+	fake.docs["A"] = []VectorPushDoc{
+		vdoc("A", "cA0", 0, "ca-new", "hca2", []float32{0, 1, 0, 0}),
+	}
+	res, err := sync.pushVectors(ctx, false, nil, nil)
+	require.NoError(t, err, "push conflict")
+	assert.Equal(t, 1, res.Conflicts)
+	assert.Equal(t, 0, res.SessionsPushed)
+	var content string
+	require.NoError(t, pg.QueryRow(
+		`SELECT content FROM vector_documents WHERE doc_key = $1`, "cA0",
+	).Scan(&content))
+	assert.Equal(t, "ca", content, "conflicted doc left untouched")
+
+	// A now vanishes from local: the evict path must leave the other machine's
+	// session in place and count the conflict.
+	delete(fake.hashes, "A")
+	delete(fake.docs, "A")
+	res, err = sync.pushVectors(ctx, false, nil, nil)
+	require.NoError(t, err, "evict conflict")
+	assert.Equal(t, 1, res.Conflicts)
+	assert.Equal(t, 0, res.SessionsEvicted)
+	genID, _, ok, err := LookupVectorGeneration(ctx, pg, "fp-cf")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, 1, countRows(t, pg,
+		`SELECT COUNT(*) FROM vector_push_state
+		 WHERE generation_id = $1 AND session_id = $2`, genID, "A"))
+	assert.Equal(t, 1, countRows(t, pg,
+		`SELECT COUNT(*) FROM vector_documents WHERE session_id = $1`, "A"))
+}
+
+// TestVectorPushLegacyMachineOwnership pins machine-aware ownership for
+// legacy PG rows whose owner_marker is empty: a foreign machine name blocks
+// both the push and evict paths (counted as conflicts), while this pusher's
+// own machine name self-heals — its vectors push and evict normally.
+func TestVectorPushLegacyMachineOwnership(t *testing.T) {
+	pgURL := testPGURL(t)
+	sync, localDB, pg := newVectorPushTestSync(
+		t, pgURL, "agentsview_vector_push_legacy_test")
+	ctx := context.Background()
+
+	seedVectorSession(t, localDB, "A")
+	seedVectorSession(t, localDB, "B")
+
+	fake := &fakeVectorSource{
+		gen:    VectorGenerationInfo{Fingerprint: "fp-lg", Model: "m", Dimension: 4},
+		hasGen: true,
+		hashes: map[string]string{"A": "ha", "B": "hb"},
+		docs: map[string][]VectorPushDoc{
+			"A": {vdoc("A", "lA0", 0, "ca", "hca", []float32{1, 0, 0, 0})},
+			"B": {vdoc("B", "lB0", 0, "cb", "hcb", []float32{0, 0, 0, 1})},
+		},
+	}
+	sync.vectorSource = fake
+	_, err := sync.Push(ctx, false, nil)
+	require.NoError(t, err, "first Push")
+
+	// Rewrite both PG rows as legacy (empty marker): A owned by a foreign
+	// machine, B carrying this pusher's own machine name.
+	_, err = pg.Exec(`UPDATE sessions
+	   SET owner_marker = '', machine = 'other-machine' WHERE id = $1`, "A")
+	require.NoError(t, err, "make A a foreign legacy row")
+	_, err = pg.Exec(`UPDATE sessions
+	   SET owner_marker = '', machine = 'test-machine' WHERE id = $1`, "B")
+	require.NoError(t, err, "make B an owned legacy row")
+
+	// Both change locally: only B may push.
+	fake.hashes["A"], fake.hashes["B"] = "ha2", "hb2"
+	fake.docs["A"] = []VectorPushDoc{
+		vdoc("A", "lA0", 0, "ca-new", "hca2", []float32{0, 1, 0, 0}),
+	}
+	fake.docs["B"] = []VectorPushDoc{
+		vdoc("B", "lB0", 0, "cb-new", "hcb2", []float32{0, 0, 1, 0}),
+	}
+	res, err := sync.pushVectors(ctx, false, nil, nil)
+	require.NoError(t, err, "legacy push")
+	assert.Equal(t, 1, res.Conflicts, "foreign legacy row is a conflict")
+	assert.Equal(t, 1, res.SessionsPushed, "owned legacy row self-heals")
+	var content string
+	require.NoError(t, pg.QueryRow(
+		`SELECT content FROM vector_documents WHERE doc_key = $1`, "lA0",
+	).Scan(&content))
+	assert.Equal(t, "ca", content, "foreign legacy doc left untouched")
+	require.NoError(t, pg.QueryRow(
+		`SELECT content FROM vector_documents WHERE doc_key = $1`, "lB0",
+	).Scan(&content))
+	assert.Equal(t, "cb-new", content)
+
+	// Both vanish locally: only B may be evicted.
+	fake.hashes = map[string]string{}
+	fake.docs = map[string][]VectorPushDoc{}
+	res, err = sync.pushVectors(ctx, false, nil, nil)
+	require.NoError(t, err, "legacy evict")
+	assert.Equal(t, 1, res.Conflicts, "foreign legacy row is not evicted")
+	assert.Equal(t, 1, res.SessionsEvicted)
+	assert.Equal(t, 1, countRows(t, pg,
+		`SELECT COUNT(*) FROM vector_documents WHERE session_id = $1`, "A"))
+	assert.Equal(t, 0, countRows(t, pg,
+		`SELECT COUNT(*) FROM vector_documents WHERE session_id = $1`, "B"))
+}
+
+// TestVectorPushEvictionSkippedWhenSourceTurnsUnready pins the pre-eviction
+// re-check: when the local source becomes unready between the delta scan and
+// the eviction pass (an embeddings rebuild started mid-push), the eviction
+// list — computed from a now-partial local view — must be dropped, and the
+// next healthy push re-derives and applies it.
+func TestVectorPushEvictionSkippedWhenSourceTurnsUnready(t *testing.T) {
+	pgURL := testPGURL(t)
+	sync, localDB, pg := newVectorPushTestSync(
+		t, pgURL, "agentsview_vector_push_unready_test")
+	ctx := context.Background()
+
+	seedVectorSession(t, localDB, "A")
+	seedVectorSession(t, localDB, "B")
+
+	fake := &fakeVectorSource{
+		gen:    VectorGenerationInfo{Fingerprint: "fp-ur", Model: "m", Dimension: 4},
+		hasGen: true,
+		hashes: map[string]string{"A": "ha", "B": "hb"},
+		docs: map[string][]VectorPushDoc{
+			"A": {vdoc("A", "uA0", 0, "ca", "hca", []float32{1, 0, 0, 0})},
+			"B": {vdoc("B", "uB0", 0, "cb", "hcb", []float32{0, 0, 0, 1})},
+		},
+	}
+	sync.vectorSource = fake
+	_, err := sync.Push(ctx, false, nil)
+	require.NoError(t, err, "first Push")
+
+	// B vanishes locally, but the source turns unready before the evict pass.
+	delete(fake.hashes, "B")
+	delete(fake.docs, "B")
+	fake.genCalls = 0
+	fake.genOverride = func(call int) (VectorGenerationInfo, bool, error) {
+		if call == 1 {
+			return fake.gen, true, nil
+		}
+		return VectorGenerationInfo{}, false, fmt.Errorf(
+			"%w: rebuild started", ErrVectorSourceNotReady)
+	}
+	res, err := sync.pushVectors(ctx, false, nil, nil)
+	require.NoError(t, err, "push with mid-push rebuild")
+	assert.Equal(t, 0, res.SessionsEvicted, "eviction must be dropped")
+	assert.Equal(t, 1, countRows(t, pg,
+		`SELECT COUNT(*) FROM vector_documents WHERE session_id = $1`, "B"),
+		"B's docs survive the aborted eviction")
+
+	// The next healthy push evicts B.
+	fake.genOverride = nil
+	res, err = sync.pushVectors(ctx, false, nil, nil)
+	require.NoError(t, err, "healthy push")
+	assert.Equal(t, 1, res.SessionsEvicted)
+	assert.Equal(t, 0, countRows(t, pg,
+		`SELECT COUNT(*) FROM vector_documents WHERE session_id = $1`, "B"))
+}
+
+// TestVectorPushProjectScope pins the project-scope gate: a filtered push
+// (projects=[alpha]) must leave vector state for an out-of-scope beta session
+// already in PG untouched, while still pushing the in-scope alpha session's
+// changes. The vectors.db source carries every session regardless of scope, so
+// without the gate the beta doc would be re-pushed under a filtered push.
+func TestVectorPushProjectScope(t *testing.T) {
+	pgURL := testPGURL(t)
+	sync, localDB, pg := newVectorPushTestSync(
+		t, pgURL, "agentsview_vector_push_scope_test")
+	ctx := context.Background()
+
+	seedVectorSessionProject(t, localDB, "alpha", "alpha")
+	seedVectorSessionProject(t, localDB, "beta", "beta")
+
+	fake := &fakeVectorSource{
+		gen:    VectorGenerationInfo{Fingerprint: "fp-scope", Model: "m", Dimension: 4},
+		hasGen: true,
+		hashes: map[string]string{"alpha": "ha", "beta": "hb"},
+		docs: map[string][]VectorPushDoc{
+			"alpha": {vdoc("alpha", "alpha#0", 0, "a-orig", "ha1", []float32{1, 0, 0, 0})},
+			"beta":  {vdoc("beta", "beta#0", 0, "b-orig", "hb1", []float32{0, 0, 0, 1})},
+		},
+	}
+	sync.vectorSource = fake
+
+	// Unfiltered push lands both alpha and beta vectors in PG.
+	_, err := sync.Push(ctx, false, nil)
+	require.NoError(t, err, "unfiltered push")
+
+	// Restrict the push to project alpha and change both sessions locally.
+	sync.projects = []string{"alpha"}
+	fake.hashes["alpha"] = "ha2"
+	fake.docs["alpha"] = []VectorPushDoc{
+		vdoc("alpha", "alpha#0", 0, "a-updated", "ha2", []float32{0, 1, 0, 0}),
+	}
+	fake.hashes["beta"] = "hb2"
+	fake.docs["beta"] = []VectorPushDoc{
+		vdoc("beta", "beta#0", 0, "b-updated", "hb2", []float32{0, 1, 0, 0}),
+	}
+
+	res, err := sync.pushVectors(ctx, false, nil, nil)
+	require.NoError(t, err, "filtered vector push")
+	assert.Equal(t, 1, res.SessionsPushed, "only in-scope alpha pushed")
+	assert.Equal(t, 0, res.Conflicts, "beta is out of scope, not a conflict")
+	assert.Equal(t, 0, res.SessionsEvicted, "beta must not be evicted")
+
+	var alphaContent, betaContent string
+	require.NoError(t, pg.QueryRow(
+		`SELECT content FROM vector_documents WHERE doc_key = $1`, "alpha#0",
+	).Scan(&alphaContent))
+	require.NoError(t, pg.QueryRow(
+		`SELECT content FROM vector_documents WHERE doc_key = $1`, "beta#0",
+	).Scan(&betaContent))
+	assert.Equal(t, "a-updated", alphaContent, "in-scope alpha updated")
+	assert.Equal(t, "b-orig", betaContent, "out-of-scope beta untouched")
+
+	genID, _, ok, err := LookupVectorGeneration(ctx, pg, "fp-scope")
+	require.NoError(t, err)
+	require.True(t, ok)
+	var betaHash string
+	require.NoError(t, pg.QueryRow(
+		`SELECT doc_agg_hash FROM vector_push_state
+		 WHERE generation_id = $1 AND session_id = $2`, genID, "beta",
+	).Scan(&betaHash))
+	assert.Equal(t, "hb", betaHash, "beta push state left at its original hash")
+}
+
+// TestVectorPushLocalProjectMoveOutOfScope pins that filtered pushes scope
+// local candidates by their LIVE local project, not the (possibly stale) PG
+// project. A session pushed in scope (project alpha) then moved out of scope
+// locally (alpha->beta) keeps its old PG project because the filtered session
+// push skips it; scoping by PG would let the next `pg push --projects alpha`
+// re-push or evict its vectors. Scoping by the local project must leave them
+// untouched.
+func TestVectorPushLocalProjectMoveOutOfScope(t *testing.T) {
+	pgURL := testPGURL(t)
+	sync, localDB, pg := newVectorPushTestSync(
+		t, pgURL, "agentsview_vector_push_localmove_test")
+	ctx := context.Background()
+
+	seedVectorSessionProject(t, localDB, "mover", "alpha")
+
+	fake := &fakeVectorSource{
+		gen:    VectorGenerationInfo{Fingerprint: "fp-move", Model: "m", Dimension: 4},
+		hasGen: true,
+		hashes: map[string]string{"mover": "h1"},
+		docs: map[string][]VectorPushDoc{
+			"mover": {vdoc("mover", "mover#0", 0, "orig", "hc1", []float32{1, 0, 0, 0})},
+		},
+	}
+	sync.vectorSource = fake
+
+	// Unfiltered push lands the alpha vector in PG (PG project = alpha).
+	_, err := sync.Push(ctx, false, nil)
+	require.NoError(t, err, "unfiltered push")
+
+	// The session moves to beta locally, but its PG sessions.project stays alpha
+	// (a filtered session push skips it). The local doc content also changes.
+	require.NoError(t, localDB.UpsertSession(db.Session{
+		ID:               "mover",
+		Project:          "beta",
+		Machine:          "test-machine",
+		Agent:            "claude",
+		MessageCount:     1,
+		UserMessageCount: 1,
+		CreatedAt:        "2026-01-01T00:00:00Z",
+	}), "move mover to beta")
+	fake.hashes["mover"] = "h2"
+	fake.docs["mover"] = []VectorPushDoc{
+		vdoc("mover", "mover#0", 0, "updated", "hc2", []float32{0, 1, 0, 0}),
+	}
+
+	var pgProject string
+	require.NoError(t, pg.QueryRow(
+		`SELECT project FROM sessions WHERE id = $1`, "mover",
+	).Scan(&pgProject))
+	require.Equal(t, "alpha", pgProject, "PG project is still stale alpha")
+
+	// A push filtered to alpha must treat mover (now local beta) as out of scope.
+	sync.projects = []string{"alpha"}
+	res, err := sync.pushVectors(ctx, false, nil, nil)
+	require.NoError(t, err, "filtered vector push after local move")
+	assert.Equal(t, 0, res.SessionsPushed, "moved-out session not pushed")
+	assert.Equal(t, 0, res.SessionsEvicted, "moved-out session not evicted")
+	assert.Equal(t, 0, res.Conflicts, "moved-out session is not a conflict")
+
+	var content string
+	require.NoError(t, pg.QueryRow(
+		`SELECT content FROM vector_documents WHERE doc_key = $1`, "mover#0",
+	).Scan(&content))
+	assert.Equal(t, "orig", content, "out-of-scope vector left untouched")
+
+	genID, _, ok, err := LookupVectorGeneration(ctx, pg, "fp-move")
+	require.NoError(t, err)
+	require.True(t, ok)
+	var stateHash string
+	require.NoError(t, pg.QueryRow(
+		`SELECT doc_agg_hash FROM vector_push_state
+		 WHERE generation_id = $1 AND session_id = $2`, genID, "mover",
+	).Scan(&stateHash))
+	assert.Equal(t, "h1", stateHash, "push state left at its original hash")
+}
+
+// TestVectorPushSkipsDocExportForMissingSession pins that a local-only session
+// with no PG sessions row is skipped without exporting its docs. Doc export
+// (content + chunk decode) must run only after the in-tx existence probe
+// passes, so a session that always skips never re-exports docs each push.
+func TestVectorPushSkipsDocExportForMissingSession(t *testing.T) {
+	pgURL := testPGURL(t)
+	sync, localDB, _ := newVectorPushTestSync(
+		t, pgURL, "agentsview_vector_push_skipexport_test")
+	ctx := context.Background()
+
+	// "A" is a real session (pushed to PG). "ghost" is local-only: it never gets
+	// a PG sessions row, so the vector push must skip it.
+	seedVectorSession(t, localDB, "A")
+
+	fake := &fakeVectorSource{
+		gen:    VectorGenerationInfo{Fingerprint: "fp-skip", Model: "m", Dimension: 4},
+		hasGen: true,
+		hashes: map[string]string{"A": "ha", "ghost": "hg"},
+		docs: map[string][]VectorPushDoc{
+			"A":     {vdoc("A", "A#0", 0, "ca", "hca", []float32{1, 0, 0, 0})},
+			"ghost": {vdoc("ghost", "g#0", 0, "cg", "hcg", []float32{0, 1, 0, 0})},
+		},
+	}
+	sync.vectorSource = fake
+
+	// Push seeds A's PG sessions row (session phase) then runs the vector phase.
+	// ghost is absent from localDB, so it never gets a PG sessions row.
+	res, err := sync.Push(ctx, false, nil)
+	require.NoError(t, err, "Push")
+	assert.Equal(t, 1, res.Vectors.SessionsPushed, "only A lands")
+	assert.Equal(t, 0, res.Vectors.Conflicts, "missing session is not a conflict")
+
+	assert.Equal(t, 1, fake.docsCalls["A"], "A's docs exported once")
+	assert.Zero(t, fake.docsCalls["ghost"],
+		"missing session's docs never exported")
+}
+
+// TestVectorPushOrphanStateEvicted pins finding-3 rule d: a vector_push_state
+// row whose sessions row has vanished is evicted regardless of owner marker.
+func TestVectorPushOrphanStateEvicted(t *testing.T) {
+	pgURL := testPGURL(t)
+	sync, localDB, pg := newVectorPushTestSync(
+		t, pgURL, "agentsview_vector_push_orphan_test")
+	ctx := context.Background()
+
+	seedVectorSession(t, localDB, "A")
+	seedVectorSession(t, localDB, "B")
+
+	fake := &fakeVectorSource{
+		gen:    VectorGenerationInfo{Fingerprint: "fp-or", Model: "m", Dimension: 4},
+		hasGen: true,
+		hashes: map[string]string{"A": "ha", "B": "hb"},
+		docs: map[string][]VectorPushDoc{
+			"A": {vdoc("A", "oA0", 0, "ca", "hca", []float32{1, 0, 0, 0})},
+			"B": {vdoc("B", "oB0", 0, "cb", "hcb", []float32{0, 0, 0, 1})},
+		},
+	}
+	sync.vectorSource = fake
+	_, err := sync.Push(ctx, false, nil)
+	require.NoError(t, err, "first Push")
+	genID, _, ok, err := LookupVectorGeneration(ctx, pg, "fp-or")
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Session A's row disappears (e.g. deleted) but its vector state lingers,
+	// and A leaves local so it is an eviction candidate.
+	_, err = pg.Exec(`DELETE FROM sessions WHERE id = $1`, "A")
+	require.NoError(t, err, "delete session row")
+	delete(fake.hashes, "A")
+	delete(fake.docs, "A")
+
+	res, err := sync.pushVectors(ctx, false, nil, nil)
+	require.NoError(t, err, "evict orphan")
+	assert.Equal(t, 1, res.SessionsEvicted)
+	assert.Equal(t, 0, res.Conflicts, "orphaned state is not a conflict")
+
+	assert.Equal(t, 0, countRows(t, pg,
+		`SELECT COUNT(*) FROM vector_push_state
+		 WHERE generation_id = $1 AND session_id = $2`, genID, "A"))
+	assert.Equal(t, 0, countRows(t, pg,
+		`SELECT COUNT(*) FROM `+vectorChunkTable(genID)+` WHERE doc_key = $1`, "oA0"))
+	assert.Equal(t, 0, countRows(t, pg,
+		`SELECT COUNT(*) FROM vector_documents WHERE session_id = $1`, "A"))
+}
+
+// TestVectorPushDefersSessionWhenExportDiverges pins the replacement-path
+// guard against concurrent local rebuilds: when a session's export hash no
+// longer matches the hash the delta scan read (an embeddings build rewrote
+// the local index between the two reads), the session is deferred with
+// nothing written — the previously pushed PG chunks and push state survive
+// untouched. Without the guard, the push would replace valid PG vectors with
+// the partial view and record the stale scan hash as current, which a
+// same-fingerprint rebuild (same content, same hash) would never repair.
+func TestVectorPushDefersSessionWhenExportDiverges(t *testing.T) {
+	pgURL := testPGURL(t)
+	sync, localDB, pg := newVectorPushTestSync(
+		t, pgURL, "agentsview_vector_push_diverge_test")
+	ctx := context.Background()
+
+	seedVectorSession(t, localDB, "A")
+
+	source := &fakeVectorSource{
+		gen:    VectorGenerationInfo{Fingerprint: "fp-div", Model: "m", Dimension: 4},
+		hasGen: true,
+		hashes: map[string]string{"A": "ha"},
+		docs: map[string][]VectorPushDoc{
+			"A": {vdoc("A", "A#0", 0, "c1", "h1",
+				[]float32{1, 0, 0, 0}, []float32{0, 1, 0, 0})},
+		},
+	}
+	sync.vectorSource = source
+
+	_, err := sync.Push(ctx, false, nil)
+	require.NoError(t, err, "seed Push")
+	genID, _, ok, err := LookupVectorGeneration(ctx, pg, "fp-div")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, 2,
+		countRows(t, pg, `SELECT COUNT(*) FROM `+vectorChunkTable(genID)))
+
+	// The delta scan sees a changed session, but by export time the local
+	// index has moved again: SessionDocs returns a shrunken doc set whose
+	// hash differs from the scan's.
+	source.hashes = map[string]string{"A": "ha-changed"}
+	source.exportHashes = map[string]string{"A": "ha-mid-rebuild"}
+	source.docs = map[string][]VectorPushDoc{
+		"A": {vdoc("A", "A#0", 0, "c1", "h1", []float32{9, 9, 9, 9})},
+	}
+
+	res, err := sync.pushVectors(ctx, false, nil, nil)
+	require.NoError(t, err, "diverged pushVectors")
+	assert.Equal(t, 1, res.SessionsDeferred, "diverged session must defer")
+	assert.Equal(t, 0, res.SessionsPushed)
+
+	assert.Equal(t, 2,
+		countRows(t, pg, `SELECT COUNT(*) FROM `+vectorChunkTable(genID)),
+		"previously pushed chunks must survive the deferral")
+	assert.Equal(t, 1, countRows(t, pg, `
+		SELECT COUNT(*) FROM vector_push_state
+		 WHERE generation_id = $1 AND session_id = 'A' AND doc_agg_hash = 'ha'`,
+		genID), "push state must keep the last successfully exported hash")
+
+	// Once the local index settles (export hash matches the scan again), the
+	// deferred session is re-derived and pushed.
+	source.exportHashes = nil
+	res, err = sync.pushVectors(ctx, false, nil, nil)
+	require.NoError(t, err, "settled pushVectors")
+	assert.Equal(t, 1, res.SessionsPushed)
+	assert.Equal(t, 1,
+		countRows(t, pg, `SELECT COUNT(*) FROM `+vectorChunkTable(genID)))
+}
+
+// TestVectorEvictionRechecksOwnershipInTx pins the eviction-path TOCTOU
+// guard: ownership read by the delta scan can be minutes stale, so each
+// eviction transaction re-probes the sessions row FOR UPDATE. A session
+// another pusher claimed after the scan is skipped as a conflict — its new
+// owner's chunks and push state survive — while a session whose row vanished
+// is still evicted.
+func TestVectorEvictionRechecksOwnershipInTx(t *testing.T) {
+	pgURL := testPGURL(t)
+	sync, localDB, pg := newVectorPushTestSync(
+		t, pgURL, "agentsview_vector_evict_recheck_test")
+	ctx := context.Background()
+
+	seedVectorSession(t, localDB, "A")
+	seedVectorSession(t, localDB, "B")
+
+	sync.vectorSource = &fakeVectorSource{
+		gen:    VectorGenerationInfo{Fingerprint: "fp-ev", Model: "m", Dimension: 4},
+		hasGen: true,
+		hashes: map[string]string{"A": "ha", "B": "hb"},
+		docs: map[string][]VectorPushDoc{
+			"A": {vdoc("A", "A#0", 0, "c1", "h1", []float32{1, 0, 0, 0})},
+			"B": {vdoc("B", "B#0", 0, "c2", "h2", []float32{0, 1, 0, 0})},
+		},
+	}
+
+	_, err := sync.Push(ctx, false, nil)
+	require.NoError(t, err, "seed Push")
+	genID, _, ok, err := LookupVectorGeneration(ctx, pg, "fp-ev")
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Simulate a concurrent pusher claiming A after this push's delta scan
+	// (which would have seen it as ours), and B's session row vanishing.
+	_, err = pg.ExecContext(ctx, `
+		UPDATE sessions SET owner_marker = 'other-marker', machine = 'other-machine'
+		 WHERE id = 'A'`)
+	require.NoError(t, err, "reassign A")
+	_, err = pg.ExecContext(ctx, `DELETE FROM sessions WHERE id = 'B'`)
+	require.NoError(t, err, "delete B")
+
+	owner, err := sync.vectorOwnerIdentity(ctx)
+	require.NoError(t, err)
+	allGenIDs, err := sync.allVectorGenerationIDs(ctx)
+	require.NoError(t, err)
+	genIDs, err := sync.existingChunkGenerations(ctx, allGenIDs)
+	require.NoError(t, err)
+	scope := vectorPushScope{
+		gen:         vectorGeneration{id: genID},
+		fingerprint: "fp-ev",
+		genIDs:      genIDs,
+		owner:       owner,
+	}
+
+	var res VectorPushResult
+	require.NoError(t,
+		sync.evictVectorSessions(ctx, scope, []string{"A", "B"}, &res))
+
+	assert.Equal(t, 1, res.Conflicts, "reclaimed session is a conflict")
+	assert.Equal(t, 1, res.SessionsEvicted, "vanished session is evicted")
+	assert.Equal(t, 1, countRows(t, pg, `
+		SELECT COUNT(*) FROM vector_push_state
+		 WHERE generation_id = $1 AND session_id = 'A'`, genID),
+		"the new owner's push state survives")
+	assert.Equal(t, 1, countRows(t, pg, `
+		SELECT COUNT(*) FROM `+vectorChunkTable(genID)+` c
+		 WHERE c.doc_key IN (
+			SELECT doc_key FROM vector_documents WHERE session_id = 'A')`),
+		"the new owner's chunks survive")
+	assert.Equal(t, 0, countRows(t, pg, `
+		SELECT COUNT(*) FROM vector_push_state
+		 WHERE generation_id = $1 AND session_id = 'B'`, genID))
+}
+
+// TestVectorPushEvictionDefersFailedSession pins that failedSessions gates
+// eviction, not just replacement: a failed session with zero embedded docs is
+// absent from the local hash map and would otherwise be evicted — vector
+// state running ahead of the sessions/messages rows its session-phase push
+// failed to write. It must defer instead, and evict on the next clean push.
+func TestVectorPushEvictionDefersFailedSession(t *testing.T) {
+	pgURL := testPGURL(t)
+	sync, localDB, pg := newVectorPushTestSync(
+		t, pgURL, "agentsview_vector_evict_failed_test")
+	ctx := context.Background()
+
+	seedVectorSession(t, localDB, "A")
+
+	fake := &fakeVectorSource{
+		gen:    VectorGenerationInfo{Fingerprint: "fp-evf", Model: "m", Dimension: 4},
+		hasGen: true,
+		hashes: map[string]string{"A": "ha"},
+		docs: map[string][]VectorPushDoc{
+			"A": {vdoc("A", "A#0", 0, "c1", "h1", []float32{1, 0, 0, 0})},
+		},
+	}
+	sync.vectorSource = fake
+
+	_, err := sync.Push(ctx, false, nil)
+	require.NoError(t, err, "seed Push")
+	genID, _, ok, err := LookupVectorGeneration(ctx, pg, "fp-evf")
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// A's embedded docs all vanish locally while its session push fails.
+	fake.hashes = map[string]string{}
+	fake.docs = map[string][]VectorPushDoc{}
+
+	res, err := sync.pushVectors(ctx, false, map[string]struct{}{"A": {}}, nil)
+	require.NoError(t, err, "failed-session pushVectors")
+	assert.Equal(t, 0, res.SessionsEvicted, "failed session must not be evicted")
+	assert.Equal(t, 1, res.SessionsDeferred)
+	assert.Equal(t, 1,
+		countRows(t, pg, `SELECT COUNT(*) FROM `+vectorChunkTable(genID)),
+		"failed session keeps its vectors")
+	assert.Equal(t, 1, countRows(t, pg, `
+		SELECT COUNT(*) FROM vector_push_state
+		 WHERE generation_id = $1 AND session_id = 'A'`, genID))
+
+	res, err = sync.pushVectors(ctx, false, nil, nil)
+	require.NoError(t, err, "clean pushVectors")
+	assert.Equal(t, 1, res.SessionsEvicted, "next clean push evicts")
+	assert.Equal(t, 0,
+		countRows(t, pg, `SELECT COUNT(*) FROM `+vectorChunkTable(genID)))
+}
+
+// TestVectorPushFilteredEvictionScopesByLocalProject pins the eviction-scope
+// partition for filtered pushes: an eviction candidate absent from the vector
+// hash map can still have a live local sessions row (zero embedded docs), and
+// that row's LIVE project — not the stale PG project — decides scope. Only
+// candidates genuinely absent from the local sessions table fall back to PG
+// project scoping.
+func TestVectorPushFilteredEvictionScopesByLocalProject(t *testing.T) {
+	pgURL := testPGURL(t)
+	sync, localDB, pg := newVectorPushTestSync(
+		t, pgURL, "agentsview_vector_evict_scope_test")
+	ctx := context.Background()
+
+	seedVectorSessionProject(t, localDB, "moved", "alpha")
+	seedVectorSessionProject(t, localDB, "gone-out", "beta")
+	seedVectorSessionProject(t, localDB, "gone-in", "alpha")
+
+	fake := &fakeVectorSource{
+		gen:    VectorGenerationInfo{Fingerprint: "fp-evs", Model: "m", Dimension: 4},
+		hasGen: true,
+		hashes: map[string]string{"moved": "hm", "gone-out": "ho", "gone-in": "hi"},
+		docs: map[string][]VectorPushDoc{
+			"moved":    {vdoc("moved", "m#0", 0, "cm", "hm1", []float32{1, 0, 0, 0})},
+			"gone-out": {vdoc("gone-out", "o#0", 0, "co", "ho1", []float32{0, 1, 0, 0})},
+			"gone-in":  {vdoc("gone-in", "i#0", 0, "ci", "hi1", []float32{0, 0, 1, 0})},
+		},
+	}
+	sync.vectorSource = fake
+
+	// Unfiltered push lands all three sessions' vectors and PG rows.
+	_, err := sync.Push(ctx, false, nil)
+	require.NoError(t, err, "unfiltered push")
+	genID, _, ok, err := LookupVectorGeneration(ctx, pg, "fp-evs")
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// "moved" changes project locally (alpha -> beta) — its PG project stays
+	// alpha because a filtered session push skips it. The others vanish from
+	// the local archive entirely. All three drop out of the embedded set.
+	require.NoError(t, localDB.UpsertSession(db.Session{
+		ID: "moved", Project: "beta", Machine: "test-machine",
+		Agent: "claude", MessageCount: 1, UserMessageCount: 1,
+		CreatedAt: "2026-01-01T00:00:00Z",
+	}), "move session to beta")
+	require.NoError(t, localDB.DeleteSession("gone-out"))
+	require.NoError(t, localDB.DeleteSession("gone-in"))
+	fake.hashes = map[string]string{}
+	fake.docs = map[string][]VectorPushDoc{}
+
+	sync.projects = []string{"alpha"}
+	res, err := sync.pushVectors(ctx, false, nil, nil)
+	require.NoError(t, err, "filtered pushVectors")
+
+	assert.Equal(t, 1, res.SessionsEvicted,
+		"only the locally-absent alpha session is evicted")
+	chunkCount := func(sessionID string) int {
+		return countRows(t, pg, `
+			SELECT COUNT(*) FROM `+vectorChunkTable(genID)+` c
+			 WHERE c.doc_key IN (
+				SELECT doc_key FROM vector_documents WHERE session_id = $1)`,
+			sessionID)
+	}
+	assert.Equal(t, 1, chunkCount("moved"),
+		"session that moved out of the filter locally is untouched")
+	assert.Equal(t, 1, chunkCount("gone-out"),
+		"locally-absent session with out-of-filter PG project is untouched")
+	assert.Equal(t, 0, chunkCount("gone-in"),
+		"locally-absent session with in-filter PG project is evicted")
+}

--- a/internal/postgres/vector_push_pg_test.go
+++ b/internal/postgres/vector_push_pg_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"testing"
 
@@ -1351,4 +1352,91 @@ func TestVectorPushFilteredEvictionScopesByLocalProject(t *testing.T) {
 		"locally-absent session with out-of-filter PG project is untouched")
 	assert.Equal(t, 0, chunkCount("gone-in"),
 		"locally-absent session with in-filter PG project is evicted")
+}
+
+// TestVectorPushSkipsOnInsufficientPrivilege pins the restricted-role degrade
+// path: a schema provisioned by a privileged role (core tables exist) whose
+// push role cannot CREATE means the vector base DDL fails with SQLSTATE
+// 42501. That must skip the vector phase with a reason — matching a database
+// without pgvector — not fail a push whose session phase succeeded.
+func TestVectorPushSkipsOnInsufficientPrivilege(t *testing.T) {
+	pgURL := testPGURL(t)
+	const schema = "agentsview_vector_privilege_test"
+	const role = "agentsview_vector_restricted"
+	const rolePassword = "agentsview_vector_restricted_pw"
+
+	admin, err := Open(pgURL, schema, true)
+	require.NoError(t, err, "Open admin")
+	t.Cleanup(func() { _ = admin.Close() })
+
+	ctx := context.Background()
+	_, err = admin.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, admin, schema))
+	unavailable, err := ensureVectorBaseSchemaPG(ctx, admin)
+	require.NoError(t, err)
+	if unavailable != "" {
+		t.Skip(unavailable)
+	}
+
+	// Simulate a schema provisioned by an older, pre-vector agentsview:
+	// core tables exist but the vector tables do not, so the restricted
+	// role's own setup must CREATE them — and cannot.
+	for _, tbl := range []string{
+		"vector_push_state", "vector_documents",
+		"vector_generation_machines", "vector_generations",
+	} {
+		_, err = admin.Exec(`DROP TABLE IF EXISTS ` + tbl + ` CASCADE`)
+		require.NoError(t, err, tbl)
+	}
+
+	_, _ = admin.Exec(`DROP OWNED BY ` + role) // clear grants from prior runs
+	_, _ = admin.Exec(`DROP ROLE IF EXISTS ` + role)
+	_, err = admin.Exec(
+		`CREATE ROLE ` + role + ` LOGIN PASSWORD '` + rolePassword + `'`)
+	require.NoError(t, err, "create restricted role")
+	t.Cleanup(func() {
+		_, _ = admin.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+		_, _ = admin.Exec(`DROP OWNED BY ` + role)
+		_, _ = admin.Exec(`DROP ROLE IF EXISTS ` + role)
+	})
+	for _, grant := range []string{
+		`GRANT USAGE ON SCHEMA ` + schema + ` TO ` + role,
+		`GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA ` +
+			schema + ` TO ` + role,
+	} {
+		_, err = admin.Exec(grant)
+		require.NoError(t, err, grant)
+	}
+
+	restrictedURL, err := url.Parse(pgURL)
+	require.NoError(t, err)
+	restrictedURL.User = url.UserPassword(role, rolePassword)
+	restricted, err := Open(restrictedURL.String(), schema, true)
+	require.NoError(t, err, "Open restricted")
+	t.Cleanup(func() { _ = restricted.Close() })
+
+	localDB, err := db.Open(filepath.Join(t.TempDir(), "local.db"))
+	require.NoError(t, err, "db.Open")
+	t.Cleanup(func() { _ = localDB.Close() })
+
+	sync := &Sync{
+		pg:         restricted,
+		local:      localDB,
+		machine:    "test-machine",
+		schema:     schema,
+		schemaDone: true,
+	}
+	sync.vectorSource = &fakeVectorSource{
+		gen: VectorGenerationInfo{
+			Fingerprint: "fp-priv", Model: "m", Dimension: 4,
+		},
+		hasGen: true,
+		hashes: map[string]string{},
+	}
+
+	res, err := sync.pushVectors(ctx, false, nil, nil)
+	require.NoError(t, err, "privilege failure must skip, not fail the push")
+	assert.True(t, res.Skipped)
+	assert.Contains(t, res.SkippedReason, "privileges")
 }

--- a/internal/postgres/vector_push_unit_test.go
+++ b/internal/postgres/vector_push_unit_test.go
@@ -1,0 +1,74 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVectorOwnerIdentityOwns(t *testing.T) {
+	owner := vectorOwnerIdentity{
+		markerID:       "marker-a",
+		machine:        "laptop",
+		legacyMachines: []string{"old-laptop"},
+	}
+	tests := []struct {
+		name        string
+		ownerMarker string
+		machine     string
+		want        bool
+	}{
+		{name: "matching marker", ownerMarker: "marker-a", machine: "other", want: true},
+		{name: "foreign marker", ownerMarker: "marker-b", machine: "laptop", want: false},
+		{name: "legacy row empty machine", machine: "", want: true},
+		{name: "legacy row local machine", machine: "local", want: true},
+		{name: "legacy row own machine", machine: "laptop", want: true},
+		{name: "legacy row alias machine", machine: "old-laptop", want: true},
+		{name: "legacy row foreign machine", machine: "other-machine", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, owner.owns(tt.ownerMarker, tt.machine))
+		})
+	}
+}
+
+// notReadyVectorSource reports a not-ready local index, as the vectors.db
+// adapter does while an embeddings build is rewriting the active generation.
+type notReadyVectorSource struct{}
+
+func (notReadyVectorSource) Generation(
+	context.Context,
+) (VectorGenerationInfo, bool, error) {
+	return VectorGenerationInfo{}, false, fmt.Errorf(
+		"%w: 7 document(s) pending", ErrVectorSourceNotReady)
+}
+
+func (notReadyVectorSource) SessionDocHashes(
+	context.Context,
+) (map[string]string, error) {
+	return nil, nil
+}
+
+func (notReadyVectorSource) SessionDocs(
+	context.Context, string,
+) ([]VectorPushDoc, string, error) {
+	return nil, "", nil
+}
+
+// TestPushVectorsSkipsWhenSourceNotReady pins that a not-ready source turns
+// the vector phase into a clean skip — not an error, and not a push over a
+// partial local view that would evict valid PG vectors.
+func TestPushVectorsSkipsWhenSourceNotReady(t *testing.T) {
+	sync := &Sync{vectorSource: notReadyVectorSource{}}
+
+	res, err := sync.pushVectors(context.Background(), false, nil, nil)
+
+	require.NoError(t, err)
+	assert.True(t, res.Skipped)
+	assert.Contains(t, res.SkippedReason, "not fully embedded")
+	assert.Contains(t, res.SkippedReason, "7 document(s) pending")
+}

--- a/internal/postgres/vector_schema.go
+++ b/internal/postgres/vector_schema.go
@@ -1,0 +1,292 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+)
+
+// vectorBaseDDL creates the backend-agnostic vector tables. Chunk tables
+// are per-generation (fixed halfvec dimension) and created lazily by
+// ensureVectorChunkTable. vector_documents mirrors the local vectors.db
+// mirror table (internal/vector/index.go messageMirrorDDL); vector_push_state
+// is the pusher-side delta state, written transactionally with doc/chunk
+// upserts so a PG reset wipes state and data together (self-healing).
+const vectorBaseDDL = `
+CREATE TABLE IF NOT EXISTS vector_generations (
+    id          BIGSERIAL PRIMARY KEY,
+    fingerprint TEXT NOT NULL UNIQUE,
+    model       TEXT NOT NULL,
+    dimension   INTEGER NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE TABLE IF NOT EXISTS vector_generation_machines (
+    generation_id BIGINT NOT NULL,
+    machine       TEXT NOT NULL,
+    last_push_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (generation_id, machine)
+);
+CREATE TABLE IF NOT EXISTS vector_documents (
+    doc_key      TEXT PRIMARY KEY,
+    session_id   TEXT NOT NULL,
+    source_uuid  TEXT NOT NULL DEFAULT '',
+    ordinal      INTEGER NOT NULL,
+    ordinal_end  INTEGER NOT NULL,
+    subordinate  BOOLEAN NOT NULL DEFAULT FALSE,
+    offsets      TEXT NOT NULL DEFAULT '[]',
+    content      TEXT NOT NULL,
+    content_hash TEXT NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_vector_documents_session_ordinal
+    ON vector_documents (session_id, ordinal);
+CREATE TABLE IF NOT EXISTS vector_push_state (
+    generation_id BIGINT NOT NULL,
+    session_id    TEXT NOT NULL,
+    doc_agg_hash  TEXT NOT NULL,
+    PRIMARY KEY (generation_id, session_id)
+);
+`
+
+// VectorExtensionAvailable reports whether the pgvector extension is
+// installed in this database (probe only; no DDL).
+func VectorExtensionAvailable(ctx context.Context, pg *sql.DB) (bool, error) {
+	var one int
+	err := pg.QueryRowContext(ctx,
+		`SELECT 1 FROM pg_extension WHERE extname = 'vector'`).Scan(&one)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("probing pgvector extension: %w", err)
+	}
+	return true, nil
+}
+
+// vectorHalfvecAvailable reports whether the installed pgvector provides the
+// halfvec type (added in pgvector 0.7.0), plus the installed extension
+// version for diagnostics. The type probe is scoped to the extension's own
+// namespace so an unrelated type named halfvec elsewhere cannot satisfy it.
+func vectorHalfvecAvailable(ctx context.Context, pg *sql.DB) (bool, string, error) {
+	var hasHalfvec bool
+	var version string
+	err := pg.QueryRowContext(ctx, `
+SELECT EXISTS (
+           SELECT 1 FROM pg_type t
+           WHERE t.typname = 'halfvec' AND t.typnamespace = e.extnamespace
+       ), e.extversion
+  FROM pg_extension e WHERE e.extname = 'vector'`).Scan(&hasHalfvec, &version)
+	if err == sql.ErrNoRows {
+		return false, "", nil
+	}
+	if err != nil {
+		return false, "", fmt.Errorf("probing pgvector halfvec support: %w", err)
+	}
+	return hasHalfvec, version, nil
+}
+
+// ensureVectorBaseSchemaPG best-effort-installs pgvector and creates the
+// base vector tables. A non-empty reason (with nil error) means vectors are
+// unavailable on this server: like createContentSearchIndexesPG it never
+// fails schema setup — CockroachDB, a missing package, a role without CREATE
+// privilege, or a pgvector too old for halfvec leave semantic search
+// unavailable with a one-line notice.
+func ensureVectorBaseSchemaPG(ctx context.Context, pg *sql.DB) (string, error) {
+	if _, err := pg.ExecContext(ctx,
+		`CREATE EXTENSION IF NOT EXISTS vector`); err != nil {
+		log.Printf("pg schema: pgvector unavailable, semantic search disabled: %v", err)
+	}
+	available, err := VectorExtensionAvailable(ctx, pg)
+	if err != nil {
+		return "", err
+	}
+	if !available {
+		return "pgvector extension unavailable", nil
+	}
+	hasHalfvec, version, err := vectorHalfvecAvailable(ctx, pg)
+	if err != nil {
+		return "", err
+	}
+	if !hasHalfvec {
+		// CREATE EXTENSION IF NOT EXISTS never upgrades an existing
+		// extension object, so a server whose pgvector package was upgraded
+		// in place can still run an old extension version. ALTER EXTENSION
+		// heals that case; a server with no newer version fails it and
+		// vectors degrade below.
+		if _, err := pg.ExecContext(ctx, `ALTER EXTENSION vector UPDATE`); err != nil {
+			log.Printf("pg schema: pgvector %s upgrade attempt failed: %v", version, err)
+		} else if hasHalfvec, version, err = vectorHalfvecAvailable(ctx, pg); err != nil {
+			return "", err
+		}
+	}
+	if !hasHalfvec {
+		reason := fmt.Sprintf(
+			"pgvector %s lacks the halfvec type; upgrade the server to pgvector 0.7.0+",
+			version)
+		log.Printf("pg schema: %s; semantic search disabled", reason)
+		return reason, nil
+	}
+	if _, err := pg.ExecContext(ctx, vectorBaseDDL); err != nil {
+		return "", fmt.Errorf("creating vector base schema: %w", err)
+	}
+	return "", nil
+}
+
+// vectorChunkTable names generation genID's chunk table. Per-generation
+// tables are required: pgvector columns have a fixed typed dimension and
+// HNSW requires it (mirrors sqlite-vec's per-generation vec0 tables).
+func vectorChunkTable(genID int64) string {
+	return fmt.Sprintf("vector_chunks_g%d", genID)
+}
+
+// vectorExtensionSchema locates the namespace pgvector's types and operator
+// classes were installed into. CREATE EXTENSION installs into whichever
+// schema was first on search_path the first time it ran anywhere in the
+// database, which is not necessarily the connection's current search_path
+// (Open sets search_path to the target schema only, mirroring
+// createContentSearchIndexesPG's pg_trgm lookup). halfvec and
+// halfvec_cosine_ops must be schema-qualified with it, or every schema
+// besides the one that happened to install the extension fails to resolve
+// them.
+func vectorExtensionSchema(ctx context.Context, pg *sql.DB) (string, error) {
+	var extSchema string
+	if err := pg.QueryRowContext(ctx,
+		`SELECT n.nspname FROM pg_extension e
+		 JOIN pg_namespace n ON n.oid = e.extnamespace
+		 WHERE e.extname = 'vector'`,
+	).Scan(&extSchema); err != nil {
+		return "", fmt.Errorf("locating pgvector schema: %w", err)
+	}
+	quoted, err := quoteIdentifier(extSchema)
+	if err != nil {
+		return "", fmt.Errorf("invalid pgvector schema %q: %w", extSchema, err)
+	}
+	return quoted, nil
+}
+
+// ensureVectorChunkTable creates genID's halfvec chunk table and its HNSW
+// cosine index. halfvec stays under HNSW's dimension limits (covers
+// 2560-dim models plain vector cannot index) and halves storage.
+func ensureVectorChunkTable(
+	ctx context.Context, pg *sql.DB, genID int64, dimension int,
+) error {
+	extSchema, err := vectorExtensionSchema(ctx, pg)
+	if err != nil {
+		return err
+	}
+	table := vectorChunkTable(genID)
+	if _, err := pg.ExecContext(ctx, fmt.Sprintf(`
+CREATE TABLE IF NOT EXISTS %s (
+    doc_key     TEXT NOT NULL,
+    chunk_index INTEGER NOT NULL,
+    embedding   %s.halfvec(%d) NOT NULL,
+    PRIMARY KEY (doc_key, chunk_index)
+)`, table, extSchema, dimension)); err != nil {
+		return fmt.Errorf("creating %s: %w", table, err)
+	}
+	if _, err := pg.ExecContext(ctx, fmt.Sprintf(
+		`CREATE INDEX IF NOT EXISTS idx_%s_hnsw ON %s
+		 USING hnsw (embedding %s.halfvec_cosine_ops)`, table, table, extSchema)); err != nil {
+		return fmt.Errorf("creating %s hnsw index: %w", table, err)
+	}
+	return nil
+}
+
+// ensureVectorGeneration registers fingerprint's generation, returning its
+// id. Machines with matching embedding configs share one generation.
+func ensureVectorGeneration(
+	ctx context.Context, pg *sql.DB, fingerprint, model string, dimension int,
+) (int64, error) {
+	if _, err := pg.ExecContext(ctx, `
+INSERT INTO vector_generations (fingerprint, model, dimension)
+VALUES ($1, $2, $3) ON CONFLICT (fingerprint) DO NOTHING`,
+		fingerprint, model, dimension); err != nil {
+		return 0, fmt.Errorf("registering vector generation: %w", err)
+	}
+	id, _, ok, err := LookupVectorGeneration(ctx, pg, fingerprint)
+	if err != nil {
+		return 0, err
+	}
+	if !ok {
+		return 0, fmt.Errorf("vector generation %q vanished after insert", fingerprint)
+	}
+	return id, nil
+}
+
+// LookupVectorGeneration resolves a config fingerprint to its PG
+// generation, the read-side gate pg serve checks at startup. A missing
+// vector_generations table (pgvector never installed, SQLSTATE 42P01) is
+// treated as a clean not-found, not an error, so pg serve degrades to a
+// plain "semantic search unavailable" notice instead of failing startup.
+func LookupVectorGeneration(
+	ctx context.Context, pg *sql.DB, fingerprint string,
+) (int64, int, bool, error) {
+	var id int64
+	var dim int
+	err := pg.QueryRowContext(ctx,
+		`SELECT id, dimension FROM vector_generations WHERE fingerprint = $1`,
+		fingerprint).Scan(&id, &dim)
+	if err == sql.ErrNoRows {
+		return 0, 0, false, nil
+	}
+	if isUndefinedTable(err) {
+		return 0, 0, false, nil
+	}
+	if err != nil {
+		return 0, 0, false, fmt.Errorf("looking up vector generation: %w", err)
+	}
+	return id, dim, true, nil
+}
+
+// VectorChunkTableExists reports whether genID's chunk table exists — the
+// second half of the read-side startup gate. A generation row can exist
+// without its chunk table: registering the generation and creating the table
+// are separate statements on the push side, so a push interrupted between
+// them (or a manual table drop) leaves the row behind. Wiring a searcher
+// against such a generation would fail every query with a missing-relation
+// error instead of degrading to db.ErrSemanticUnavailable. The unqualified
+// name resolves through the connection's search_path, like every other
+// read-side query.
+func VectorChunkTableExists(
+	ctx context.Context, pg *sql.DB, genID int64,
+) (bool, error) {
+	var present bool
+	if err := pg.QueryRowContext(ctx, `SELECT to_regclass($1) IS NOT NULL`,
+		vectorChunkTable(genID)).Scan(&present); err != nil {
+		return false, fmt.Errorf(
+			"probing chunk table for generation %d: %w", genID, err)
+	}
+	return present, nil
+}
+
+// ListVectorGenerationFingerprints returns every registered generation's
+// fingerprint ordered by id (oldest first), for pg serve's startup notice
+// when no generation matches the local config. A missing vector_generations
+// table (SQLSTATE 42P01) yields an empty slice, not an error, matching
+// LookupVectorGeneration's tolerance for a database without pgvector.
+func ListVectorGenerationFingerprints(
+	ctx context.Context, pg *sql.DB,
+) ([]string, error) {
+	rows, err := pg.QueryContext(ctx,
+		`SELECT fingerprint FROM vector_generations ORDER BY id`)
+	if isUndefinedTable(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("listing vector generations: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var fingerprints []string
+	for rows.Next() {
+		var fp string
+		if err := rows.Scan(&fp); err != nil {
+			return nil, fmt.Errorf("scanning vector generation fingerprint: %w", err)
+		}
+		fingerprints = append(fingerprints, fp)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating vector generations: %w", err)
+	}
+	return fingerprints, nil
+}

--- a/internal/postgres/vector_schema_pg_test.go
+++ b/internal/postgres/vector_schema_pg_test.go
@@ -1,0 +1,269 @@
+//go:build pgtest
+
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const vectorSchemaTestSchema = "agentsview_vector_schema_test"
+
+func cleanVectorSchemaTestPG(t *testing.T, pgURL string) {
+	t.Helper()
+	pg, err := sql.Open("pgx", pgURL)
+	require.NoError(t, err, "connecting to pg")
+	defer pg.Close()
+	_, _ = pg.Exec(
+		"DROP SCHEMA IF EXISTS " + vectorSchemaTestSchema + " CASCADE",
+	)
+}
+
+// TestEnsureVectorBaseSchema verifies that ensureVectorBaseSchemaPG installs
+// pgvector and the base vector tables idempotently, and that generation
+// registration and chunk table creation round-trip through
+// ensureVectorGeneration, ensureVectorChunkTable, and
+// LookupVectorGeneration.
+func TestEnsureVectorBaseSchema(t *testing.T) {
+	pgURL := testPGURL(t)
+	cleanVectorSchemaTestPG(t, pgURL)
+	t.Cleanup(func() { cleanVectorSchemaTestPG(t, pgURL) })
+
+	pg, err := Open(pgURL, vectorSchemaTestSchema, true)
+	require.NoError(t, err, "connecting to pg")
+	defer pg.Close()
+
+	ctx := context.Background()
+
+	// EnsureSchema creates the schema itself (Open only sets search_path;
+	// it does not create the target schema), and also exercises the
+	// ensureVectorBaseSchemaPG wiring inside EnsureSchema.
+	require.NoError(t, EnsureSchema(ctx, pg, vectorSchemaTestSchema))
+
+	unavailable, err := ensureVectorBaseSchemaPG(ctx, pg)
+	require.NoError(t, err)
+	if unavailable != "" {
+		t.Skip(unavailable)
+	}
+
+	// Idempotent.
+	_, err = ensureVectorBaseSchemaPG(ctx, pg)
+	require.NoError(t, err)
+
+	id, err := ensureVectorGeneration(ctx, pg, "fp-1", "test-model", 4)
+	require.NoError(t, err)
+	id2, err := ensureVectorGeneration(ctx, pg, "fp-1", "test-model", 4)
+	require.NoError(t, err)
+	assert.Equal(t, id, id2)
+
+	require.NoError(t, ensureVectorChunkTable(ctx, pg, id, 4))
+	require.NoError(t, ensureVectorChunkTable(ctx, pg, id, 4)) // idempotent
+
+	gotID, dim, ok, err := LookupVectorGeneration(ctx, pg, "fp-1")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, id, gotID)
+	assert.Equal(t, 4, dim)
+
+	_, _, ok, err = LookupVectorGeneration(ctx, pg, "fp-missing")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+// TestVectorChunkTableExists pins the second half of the read-side startup
+// gate: a generation row registered without its chunk table (a push
+// interrupted between ensureVectorGeneration and ensureVectorChunkTable)
+// reports the table absent, so serve degrades to unavailable instead of
+// wiring a searcher that fails every query with a missing-relation error.
+func TestVectorChunkTableExists(t *testing.T) {
+	pgURL := testPGURL(t)
+	cleanVectorSchemaTestPG(t, pgURL)
+	t.Cleanup(func() { cleanVectorSchemaTestPG(t, pgURL) })
+
+	pg, err := Open(pgURL, vectorSchemaTestSchema, true)
+	require.NoError(t, err, "connecting to pg")
+	defer pg.Close()
+
+	ctx := context.Background()
+	require.NoError(t, EnsureSchema(ctx, pg, vectorSchemaTestSchema))
+	unavailable, err := ensureVectorBaseSchemaPG(ctx, pg)
+	require.NoError(t, err)
+	if unavailable != "" {
+		t.Skip(unavailable)
+	}
+
+	// Generation registered, chunk table not yet created.
+	id, err := ensureVectorGeneration(ctx, pg, "fp-partial", "test-model", 4)
+	require.NoError(t, err)
+	exists, err := VectorChunkTableExists(ctx, pg, id)
+	require.NoError(t, err)
+	assert.False(t, exists, "generation row without chunk table")
+
+	require.NoError(t, ensureVectorChunkTable(ctx, pg, id, 4))
+	exists, err = VectorChunkTableExists(ctx, pg, id)
+	require.NoError(t, err)
+	assert.True(t, exists, "chunk table created")
+}
+
+// TestVectorGenerationLookupTolerateMissingTable verifies that the read-side
+// gate degrades cleanly when the vector_generations table never existed
+// (pgvector never installed): LookupVectorGeneration reports not-found and
+// ListVectorGenerationFingerprints returns empty, both without error, so pg
+// serve records a "semantic unavailable" reason instead of aborting startup.
+func TestVectorGenerationLookupTolerateMissingTable(t *testing.T) {
+	pgURL := testPGURL(t)
+	cleanVectorSchemaTestPG(t, pgURL)
+	t.Cleanup(func() { cleanVectorSchemaTestPG(t, pgURL) })
+
+	pg, err := Open(pgURL, vectorSchemaTestSchema, true)
+	require.NoError(t, err, "connecting to pg")
+	defer pg.Close()
+
+	ctx := context.Background()
+	// Create the schema but deliberately do not install the vector tables,
+	// so vector_generations does not exist (SQLSTATE 42P01 on query).
+	_, err = pg.ExecContext(ctx,
+		"CREATE SCHEMA IF NOT EXISTS "+vectorSchemaTestSchema)
+	require.NoError(t, err)
+	require.False(t, tableExistsPG(t, pg, "vector_generations"),
+		"vector_generations must be absent for the 42P01 tolerance check")
+
+	_, _, ok, err := LookupVectorGeneration(ctx, pg, "fp-any")
+	require.NoError(t, err, "missing table must be tolerated as not-found")
+	assert.False(t, ok)
+
+	fingerprints, err := ListVectorGenerationFingerprints(ctx, pg)
+	require.NoError(t, err, "missing table must yield an empty list, not an error")
+	assert.Empty(t, fingerprints)
+}
+
+// TestListVectorGenerationFingerprints verifies fingerprints come back in id
+// order (oldest generation first), the order pg serve's startup notice lists
+// the generations PG already has.
+func TestListVectorGenerationFingerprints(t *testing.T) {
+	pgURL := testPGURL(t)
+	cleanVectorSchemaTestPG(t, pgURL)
+	t.Cleanup(func() { cleanVectorSchemaTestPG(t, pgURL) })
+
+	pg, err := Open(pgURL, vectorSchemaTestSchema, true)
+	require.NoError(t, err, "connecting to pg")
+	defer pg.Close()
+
+	ctx := context.Background()
+	require.NoError(t, EnsureSchema(ctx, pg, vectorSchemaTestSchema))
+	unavailable, err := ensureVectorBaseSchemaPG(ctx, pg)
+	require.NoError(t, err)
+	if unavailable != "" {
+		t.Skip(unavailable)
+	}
+
+	_, err = ensureVectorGeneration(ctx, pg, "fp-alpha", "model-a", 4)
+	require.NoError(t, err)
+	_, err = ensureVectorGeneration(ctx, pg, "fp-beta", "model-b", 8)
+	require.NoError(t, err)
+
+	fingerprints, err := ListVectorGenerationFingerprints(ctx, pg)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"fp-alpha", "fp-beta"}, fingerprints)
+}
+
+// tableExistsPG reports whether a base table exists in the connection's
+// current schema.
+func tableExistsPG(t *testing.T, pg *sql.DB, table string) bool {
+	t.Helper()
+	var one int
+	err := pg.QueryRow(
+		`SELECT 1 FROM information_schema.tables
+		 WHERE table_schema = current_schema() AND table_name = $1`, table,
+	).Scan(&one)
+	if err == sql.ErrNoRows {
+		return false
+	}
+	require.NoError(t, err, "checking table "+table)
+	return true
+}
+
+// TestEnsureSchemaFastPathCreatesVectorTables simulates upgrading an existing
+// deployment: a full schema is already current (so EnsureSchema takes the
+// pushSchemaCurrent fast path), but predates the vector tables. A plain
+// post-upgrade pg push must still create them via the fast path's best-effort
+// vector setup, otherwise semantic search never becomes available.
+func TestEnsureSchemaFastPathCreatesVectorTables(t *testing.T) {
+	pgURL := testPGURL(t)
+	cleanVectorSchemaTestPG(t, pgURL)
+	t.Cleanup(func() { cleanVectorSchemaTestPG(t, pgURL) })
+
+	pg, err := Open(pgURL, vectorSchemaTestSchema, true)
+	require.NoError(t, err, "connecting to pg")
+	defer pg.Close()
+
+	ctx := context.Background()
+	require.NoError(t, EnsureSchema(ctx, pg, vectorSchemaTestSchema))
+
+	if available, err := VectorExtensionAvailable(ctx, pg); err != nil {
+		require.NoError(t, err)
+	} else if !available {
+		t.Skip("pgvector extension unavailable")
+	}
+	require.True(t, pushSchemaCurrent(ctx, pg),
+		"a freshly ensured schema must read as current so the fast path is exercised")
+
+	// Simulate a pre-vector deployment: drop the four vector tables while the
+	// rest of the schema stays current.
+	for _, table := range []string{
+		"vector_push_state", "vector_documents",
+		"vector_generation_machines", "vector_generations",
+	} {
+		_, err := pg.ExecContext(ctx, `DROP TABLE IF EXISTS `+table+` CASCADE`)
+		require.NoError(t, err, "dropping "+table)
+	}
+	require.False(t, tableExistsPG(t, pg, "vector_generations"),
+		"vector_generations must be gone before the fast-path re-ensure")
+
+	sync := &Sync{
+		pg:      pg,
+		machine: "test-machine",
+		schema:  vectorSchemaTestSchema,
+	}
+	require.NoError(t, sync.EnsureSchema(ctx))
+
+	assert.True(t, tableExistsPG(t, pg, "vector_generations"),
+		"the fast path must recreate the vector tables on an up-to-date schema")
+	assert.True(t, tableExistsPG(t, pg, "vector_documents"))
+	assert.True(t, tableExistsPG(t, pg, "vector_push_state"))
+}
+
+// TestVectorHalfvecGate pins the availability gate's two observable shapes:
+// on a server with pgvector >= 0.7 the gate reports available (empty reason)
+// and the halfvec probe returns the type plus a version; on a server without
+// pgvector the gate degrades to a reason instead of an error, which is what
+// keeps an old or missing extension from hard-failing `pg push`.
+func TestVectorHalfvecGate(t *testing.T) {
+	pgURL := testPGURL(t)
+	cleanVectorSchemaTestPG(t, pgURL)
+	t.Cleanup(func() { cleanVectorSchemaTestPG(t, pgURL) })
+
+	pg, err := Open(pgURL, vectorSchemaTestSchema, true)
+	require.NoError(t, err, "connecting to pg")
+	defer pg.Close()
+
+	ctx := context.Background()
+	require.NoError(t, EnsureSchema(ctx, pg, vectorSchemaTestSchema))
+
+	unavailable, err := ensureVectorBaseSchemaPG(ctx, pg)
+	require.NoError(t, err, "gate must degrade, never error")
+	hasHalfvec, version, err := vectorHalfvecAvailable(ctx, pg)
+	require.NoError(t, err)
+
+	if unavailable == "" {
+		assert.True(t, hasHalfvec, "available gate implies halfvec exists")
+		assert.NotEmpty(t, version, "installed extension reports a version")
+		return
+	}
+	assert.False(t, hasHalfvec,
+		"unavailable reason %q must mean halfvec is missing", unavailable)
+}

--- a/internal/postgres/vector_search.go
+++ b/internal/postgres/vector_search.go
@@ -1,0 +1,429 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/vector"
+)
+
+// QueryEncodeFunc embeds a single query string into the generation's vector
+// space. It is the read-side counterpart of the build-time encoder, supplied
+// by pg serve when it wires the searcher; a returned error means the
+// embeddings endpoint failed for this request (transient), not that semantic
+// search is unconfigured.
+type QueryEncodeFunc func(ctx context.Context, text string) ([]float32, error)
+
+// vectorSearcher is the PG-backed db.VectorSearcher: chunk-level KNN over one
+// generation's pgvector chunk table, doc-level rollup, and hydration against
+// the shared vector_documents mirror. It mirrors internal/vector's Index
+// searcher semantics (Search + hydrateHits + resolveHit) for the PG backend.
+type vectorSearcher struct {
+	pg            *sql.DB
+	genID         int64
+	dimension     int
+	maxInputChars int
+	encode        QueryEncodeFunc
+	chunkTable    string
+
+	// schemaMu guards the lazily resolved, quoted pgvector extension schema.
+	// The constructor takes no context, so it is resolved on first query
+	// (mirroring vector_push.go's vectorGeneration.halfvecType): both the
+	// ::halfvec cast and the `<=>` cosine operator must be schema-qualified,
+	// or they fail to resolve when pgvector lives in a schema off search_path.
+	schemaMu  sync.Mutex
+	extSchema string
+}
+
+// NewVectorSearcher builds a PG vector searcher for generation genID. The
+// chunk table (vector_chunks_g<genID>) and dimension must match what the push
+// phase created; maxInputChars is the build-time chunk size, threaded into
+// vector.DocAnchor so anchor/snippet re-splitting matches how chunks were cut.
+func NewVectorSearcher(
+	pg *sql.DB, genID int64, dimension, maxInputChars int, encode QueryEncodeFunc,
+) db.VectorSearcher {
+	return &vectorSearcher{
+		pg:            pg,
+		genID:         genID,
+		dimension:     dimension,
+		maxInputChars: maxInputChars,
+		encode:        encode,
+		chunkTable:    vectorChunkTable(genID),
+	}
+}
+
+// resolveExtSchema returns the quoted schema pgvector's types and operators
+// live in, resolving it once from pg_extension. It is cached because the
+// pgvector schema cannot change for a live connection pool.
+func (v *vectorSearcher) resolveExtSchema(ctx context.Context) (string, error) {
+	v.schemaMu.Lock()
+	defer v.schemaMu.Unlock()
+	if v.extSchema != "" {
+		return v.extSchema, nil
+	}
+	schema, err := vectorExtensionSchema(ctx, v.pg)
+	if err != nil {
+		return "", fmt.Errorf("resolving pgvector schema: %w", err)
+	}
+	v.extSchema = schema
+	return v.extSchema, nil
+}
+
+// SemanticSearch embeds query, runs chunk-level KNN over the generation's
+// chunk table, rolls chunks up to one hit per document (best chunk wins,
+// score order preserved), truncates to limit documents, and hydrates each
+// against vector_documents. It mirrors vector.Index.Search + searcherAdapter:
+// an encoder failure is wrapped in db.ErrSemanticTransient; a document that
+// vanished (or was parked at a negative-ordinal tombstone) between KNN and
+// hydration is dropped rather than erroring.
+func (v *vectorSearcher) SemanticSearch(
+	ctx context.Context, query string, limit int,
+) ([]db.VectorHit, error) {
+	vec, err := v.encode(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", db.ErrSemanticTransient, err)
+	}
+	if len(vec) != v.dimension {
+		return nil, fmt.Errorf(
+			"query embedding has %d dimensions, generation expects %d",
+			len(vec), v.dimension)
+	}
+	extSchema, err := v.resolveExtSchema(ctx)
+	if err != nil {
+		return nil, err
+	}
+	chunks, err := v.knnChunks(ctx, vec, extSchema, limit)
+	if err != nil {
+		return nil, err
+	}
+	docs := rollupChunkHits(chunks, limit)
+	if len(docs) == 0 {
+		return nil, nil
+	}
+	return v.hydrateHits(ctx, docs)
+}
+
+// chunkHit is one chunk-level KNN neighbor: the document it belongs to, which
+// chunk matched, and its cosine similarity (1 - cosine distance, higher is
+// better).
+type chunkHit struct {
+	docKey     string
+	chunkIndex int
+	score      float32
+}
+
+// knnChunks runs the chunk-level KNN, returning up to exactly limit neighbors
+// ordered best (nearest) first. Fetching exactly `limit` chunks matches the
+// local sqlite-vec searcher's candidate pool (kit's queryGenerationSQL also
+// runs its KNN with LIMIT k before rollup), per the backend-parity rule: after
+// rollup the doc pool can be smaller than `limit` when a high-ranking run doc
+// contributes several neighbors, and both backends must shrink identically.
+// The query vector binds once as a halfvec-cast parameter; both the cast and
+// the cosine `<=>` operator are schema-qualified (::schema.halfvec,
+// OPERATOR(schema.<=>)) so they resolve when pgvector lives in a schema off
+// the connection's search_path.
+//
+// Recall contract: results are approximate ANN (HNSW), not the local backend's
+// exact brute-force scan — that divergence is the accepted halfvec/HNSW spec
+// trade-off. But the candidate pool must not silently cap below k: pgvector's
+// default hnsw.ef_search (40) would return only ~40 rows regardless of LIMIT k.
+// The KNN therefore runs inside a transaction with hnsw.ef_search set to k
+// clamped to [40, 1000] (see tuneHNSWRecall / hnswEfSearch): small-k searches
+// keep the stock 40 floor, larger k widens the pool up to pgvector's 1000
+// ceiling, and past that ceiling iterative scan keeps filling.
+func (v *vectorSearcher) knnChunks(
+	ctx context.Context, vec []float32, extSchema string, limit int,
+) ([]chunkHit, error) {
+	k := max(limit, 0)
+	literal, err := halfvecLiteral(vec)
+	if err != nil {
+		return nil, fmt.Errorf("query embedding: %w", err)
+	}
+	dist := fmt.Sprintf("embedding OPERATOR(%s.<=>) $1::%s.halfvec", extSchema, extSchema)
+	q := fmt.Sprintf(`
+SELECT doc_key, chunk_index, 1 - (%s) AS score
+  FROM %s
+ ORDER BY %s
+ LIMIT $2`, dist, v.chunkTable, dist)
+
+	tx, err := v.pg.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return nil, fmt.Errorf("begin chunk knn tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := tuneHNSWRecall(ctx, tx, k); err != nil {
+		return nil, err
+	}
+
+	rows, err := tx.QueryContext(ctx, q, literal, k)
+	if err != nil {
+		return nil, fmt.Errorf("chunk knn query: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var hits []chunkHit
+	for rows.Next() {
+		var h chunkHit
+		var score float64
+		if err := rows.Scan(&h.docKey, &h.chunkIndex, &score); err != nil {
+			return nil, fmt.Errorf("scanning chunk knn row: %w", err)
+		}
+		h.score = float32(score)
+		hits = append(hits, h)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating chunk knn rows: %w", err)
+	}
+	return hits, nil
+}
+
+// tuneHNSWRecall raises pgvector's per-scan HNSW candidate pool for the current
+// transaction so a KNN with LIMIT k returns k neighbors instead of silently
+// capping at the default hnsw.ef_search (40). ef_search is set to k clamped to
+// [40, 1000] — the recall knob is never tuned below its default, so small-k
+// searches keep stock recall — and never above pgvector's ceiling. k is an int
+// derived from the caller's limit and interpolated only after clamping, so the
+// SET LOCAL statement carries no unvalidated input. SET LOCAL requires a
+// transaction and resets on commit/rollback, so this never leaks into a pooled
+// connection.
+//
+// For k above the 1000 ceiling, ef_search alone cannot fill the pool, so
+// hnsw.iterative_scan = 'relaxed_order' (pgvector >= 0.8) lets the scan keep
+// going past ef_search. Older pgvector lacks that GUC and would abort the tx on
+// an unknown-GUC error, so it is probed first with current_setting(..., true)
+// (missing_ok), which yields NULL instead of erroring; a NULL result skips the
+// setting and leaves the 1000-row cap in place.
+// hnswEfSearch clamps the KNN candidate-pool size k to pgvector's usable
+// hnsw.ef_search range [40, 1000]: never below the stock default 40 (so small-k
+// searches keep default recall) and never above pgvector's 1000 ceiling (past
+// which ef_search alone cannot widen the pool — tuneHNSWRecall falls back to
+// iterative scan there).
+func hnswEfSearch(k int) int {
+	return min(max(k, 40), 1000)
+}
+
+func tuneHNSWRecall(ctx context.Context, tx *sql.Tx, k int) error {
+	efSearch := hnswEfSearch(k)
+	if _, err := tx.ExecContext(ctx,
+		fmt.Sprintf("SET LOCAL hnsw.ef_search = %d", efSearch)); err != nil {
+		return fmt.Errorf("setting hnsw.ef_search: %w", err)
+	}
+	if k <= 1000 {
+		return nil
+	}
+	var current sql.NullString
+	if err := tx.QueryRowContext(ctx,
+		`SELECT current_setting('hnsw.iterative_scan', true)`,
+	).Scan(&current); err != nil {
+		return fmt.Errorf("probing hnsw.iterative_scan: %w", err)
+	}
+	if !current.Valid {
+		return nil
+	}
+	if _, err := tx.ExecContext(ctx,
+		"SET LOCAL hnsw.iterative_scan = 'relaxed_order'"); err != nil {
+		return fmt.Errorf("setting hnsw.iterative_scan: %w", err)
+	}
+	return nil
+}
+
+// rollupChunkHits collapses chunk hits to one hit per document, keeping the
+// first (best) chunk seen per doc_key and preserving order, then truncates to
+// limit documents. hits must already be ordered best-first (the KNN query
+// orders by distance), so first-seen equals best-scoring — matching kit's
+// RollupByDocument intent without a re-sort.
+func rollupChunkHits(hits []chunkHit, limit int) []chunkHit {
+	seen := make(map[string]struct{}, len(hits))
+	out := make([]chunkHit, 0, len(hits))
+	for _, h := range hits {
+		if _, ok := seen[h.docKey]; ok {
+			continue
+		}
+		seen[h.docKey] = struct{}{}
+		out = append(out, h)
+	}
+	if limit >= 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}
+
+// vectorDoc is the subset of a vector_documents row needed to hydrate a chunk
+// hit into a db.VectorHit. offsets is empty for user documents and carries one
+// entry per member for run documents.
+type vectorDoc struct {
+	sessionID   string
+	ordinal     int
+	ordinalEnd  int
+	subordinate bool
+	offsets     []db.UnitOffset
+	content     string
+}
+
+// hydrateHits looks up each hit's document row and builds its db.VectorHit,
+// resolving the anchor ordinal and display snippet via vector.DocAnchor (a run
+// hit anchors to the member whose rune span contains the matched chunk's
+// center, with a member-local snippet; a user hit anchors to its own ordinal).
+// A hit whose document vanished from vector_documents mid-flight, or is parked
+// at a negative-ordinal tombstone, is absent from the lookup and dropped.
+func (v *vectorSearcher) hydrateHits(
+	ctx context.Context, hits []chunkHit,
+) ([]db.VectorHit, error) {
+	docKeys := make([]string, len(hits))
+	for i, h := range hits {
+		docKeys[i] = h.docKey
+	}
+	docs, err := v.lookupDocs(ctx, docKeys)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]db.VectorHit, 0, len(hits))
+	for _, h := range hits {
+		doc, ok := docs[h.docKey]
+		if !ok {
+			continue
+		}
+		anchorOrdinal, snippet := vector.DocAnchor(
+			doc.content, doc.offsets, doc.ordinal, h.chunkIndex, v.maxInputChars)
+		out = append(out, db.VectorHit{
+			SessionID:    doc.sessionID,
+			Ordinal:      anchorOrdinal,
+			OrdinalStart: doc.ordinal,
+			OrdinalEnd:   doc.ordinalEnd,
+			Subordinate:  doc.subordinate,
+			Score:        h.score,
+			Snippet:      snippet,
+		})
+	}
+	return out, nil
+}
+
+// lookupDocs reads the document rows for docKeys, keyed by doc_key. The whole
+// key set binds as one array parameter (pgx expands ANY natively), so no IN
+// chunking is needed. The `ordinal >= 0` guard excludes tombstone rows parked
+// at a negative sentinel by the vector push's slot replacement, mirroring
+// internal/vector's lookupMirrorDocs: a mid-refresh tombstone must never
+// hydrate into a hit carrying a negative ordinal.
+func (v *vectorSearcher) lookupDocs(
+	ctx context.Context, docKeys []string,
+) (map[string]vectorDoc, error) {
+	docs := make(map[string]vectorDoc, len(docKeys))
+	if len(docKeys) == 0 {
+		return docs, nil
+	}
+	rows, err := v.pg.QueryContext(ctx, `
+SELECT doc_key, session_id, ordinal, ordinal_end, subordinate, offsets, content
+  FROM vector_documents
+ WHERE ordinal >= 0 AND doc_key = ANY($1)`, docKeys)
+	if err != nil {
+		return nil, fmt.Errorf("looking up search hit documents: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var key, offsets string
+		var doc vectorDoc
+		if err := rows.Scan(&key, &doc.sessionID, &doc.ordinal,
+			&doc.ordinalEnd, &doc.subordinate, &offsets, &doc.content); err != nil {
+			return nil, fmt.Errorf("scanning search hit document: %w", err)
+		}
+		if err := json.Unmarshal([]byte(offsets), &doc.offsets); err != nil {
+			return nil, fmt.Errorf("parsing offsets for search hit %s: %w", key, err)
+		}
+		docs[key] = doc
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating search hit documents: %w", err)
+	}
+	return docs, nil
+}
+
+// ResolveMessageUnits maps each ref to the vector_documents unit containing
+// it, returning a slice parallel to refs; a ref with no containing unit (its
+// message lies outside the embeddable universe, or in a gap between units)
+// yields a zero db.UnitRef. Each ref is a point lookup — greatest unit ordinal
+// <= ref ordinal, then a containment check against ordinal_end — via one
+// prepared statement, so a batch of any size never approaches PG's bind limit.
+// The `ordinal >= 0` guard skips tombstone rows parked at a negative sentinel,
+// so a ref can never resolve into mid-refresh state (parity with
+// internal/vector's ResolveMessageUnits).
+func (v *vectorSearcher) ResolveMessageUnits(
+	ctx context.Context, refs []db.MessageRef,
+) ([]db.UnitRef, error) {
+	out := make([]db.UnitRef, len(refs))
+	if len(refs) == 0 {
+		return out, nil
+	}
+	stmt, err := v.pg.PrepareContext(ctx, `
+SELECT doc_key, ordinal, ordinal_end, subordinate
+  FROM vector_documents
+ WHERE session_id = $1 AND ordinal >= 0 AND ordinal <= $2
+ ORDER BY ordinal DESC LIMIT 1`)
+	if err != nil {
+		return nil, fmt.Errorf("resolve message units: %w", err)
+	}
+	defer func() { _ = stmt.Close() }()
+
+	for i, ref := range refs {
+		var unit db.UnitRef
+		err := stmt.QueryRowContext(ctx, ref.SessionID, ref.Ordinal).Scan(
+			&unit.DocKey, &unit.OrdinalStart, &unit.OrdinalEnd, &unit.Subordinate)
+		if errors.Is(err, sql.ErrNoRows) {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf(
+				"resolve message unit (%s, %d): %w", ref.SessionID, ref.Ordinal, err)
+		}
+		if ref.Ordinal > unit.OrdinalEnd {
+			continue
+		}
+		unit.SessionID = ref.SessionID
+		out[i] = unit
+	}
+	return out, nil
+}
+
+// SetVectorSearcher wires (or, with nil, clears) the PG semantic search
+// backend. Safe to call concurrently with SearchContent/HasSemantic.
+func (s *Store) SetVectorSearcher(searcher db.VectorSearcher) {
+	s.vectorMu.Lock()
+	defer s.vectorMu.Unlock()
+	s.vectorSearcher = searcher
+}
+
+// getVectorSearcher returns the currently wired PG vector searcher, or nil.
+func (s *Store) getVectorSearcher() db.VectorSearcher {
+	s.vectorMu.RLock()
+	defer s.vectorMu.RUnlock()
+	return s.vectorSearcher
+}
+
+// SetSemanticUnavailableReason records a human explanation for why semantic
+// search could not be wired (extension missing, no matching generation, stale
+// build), surfaced by semanticUnavailableError. Safe to call concurrently.
+func (s *Store) SetSemanticUnavailableReason(reason string) {
+	s.vectorMu.Lock()
+	defer s.vectorMu.Unlock()
+	s.semanticUnavailableReason = reason
+}
+
+// semanticUnavailableError wraps db.ErrSemanticUnavailable with the recorded
+// reason when one is set, so a caller (SearchContent's semantic/hybrid modes)
+// can explain why semantic search is off; without a reason it returns the
+// bare sentinel.
+func (s *Store) semanticUnavailableError() error {
+	s.vectorMu.RLock()
+	reason := s.semanticUnavailableReason
+	s.vectorMu.RUnlock()
+	if reason == "" {
+		return db.ErrSemanticUnavailable
+	}
+	return fmt.Errorf("%w: %s", db.ErrSemanticUnavailable, reason)
+}

--- a/internal/postgres/vector_search_pg_test.go
+++ b/internal/postgres/vector_search_pg_test.go
@@ -1,0 +1,318 @@
+//go:build pgtest
+
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+// searchMaxInputChars is the chunk size the searcher re-splits content with to
+// resolve anchors/snippets. It is small so the run fixture's short content
+// re-splits into multiple chunks (see runContent), exercising member anchoring.
+const searchMaxInputChars = 20
+
+// fixedEncoder returns a QueryEncodeFunc that always emits vec, ignoring the
+// query text: the fixture's chunk vectors are chosen so a fixed query yields a
+// deterministic cosine ranking.
+func fixedEncoder(vec []float32) QueryEncodeFunc {
+	return func(context.Context, string) ([]float32, error) { return vec, nil }
+}
+
+// newVectorSearchTestPG drops and recreates the schema with the base vector
+// tables and skips when pgvector is unavailable.
+func newVectorSearchTestPG(t *testing.T, pgURL, schema string) *sql.DB {
+	t.Helper()
+	pg, err := Open(pgURL, schema, true)
+	require.NoError(t, err, "Open")
+	t.Cleanup(func() { _ = pg.Close() })
+
+	ctx := context.Background()
+	_, err = pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
+
+	unavailable, err := ensureVectorBaseSchemaPG(ctx, pg)
+	require.NoError(t, err, "ensureVectorBaseSchemaPG")
+	if unavailable != "" {
+		t.Skip(unavailable)
+	}
+	return pg
+}
+
+func insertSearchDoc(
+	t *testing.T, pg *sql.DB,
+	docKey, sessionID string, ordinal, ordinalEnd int,
+	offsets, content string,
+) {
+	t.Helper()
+	_, err := pg.Exec(`
+INSERT INTO vector_documents (
+    doc_key, session_id, source_uuid, ordinal, ordinal_end,
+    subordinate, offsets, content, content_hash)
+VALUES ($1, $2, '', $3, $4, FALSE, $5, $6, 'h')`,
+		docKey, sessionID, ordinal, ordinalEnd, offsets, content)
+	require.NoError(t, err, "insert doc "+docKey)
+}
+
+func insertSearchChunk(
+	t *testing.T, pg *sql.DB, table, halfvecType, docKey string,
+	chunkIndex int, emb []float32,
+) {
+	t.Helper()
+	literal, err := halfvecLiteral(emb)
+	require.NoError(t, err, "halfvecLiteral "+docKey)
+	_, err = pg.Exec(
+		`INSERT INTO `+table+` (doc_key, chunk_index, embedding)
+		 VALUES ($1, $2, $3::`+halfvecType+`)`,
+		docKey, chunkIndex, literal)
+	require.NoError(t, err, "insert chunk "+docKey)
+}
+
+// seedVectorSearchFixture builds a deterministic KNN fixture for query
+// [1,0,0,0]. Cosine similarity ignores magnitude, so the chunk directions are
+// spread across the x/y plane to give distinct, unambiguous scores by doc's
+// best chunk:
+//
+//	u1   [1,0,0,0]           1.000  user doc, ordinal 5
+//	r1   [1,0.2,0,0]         0.981  run doc chunk 1 (chunk 0 is [0,0,1,0] -> 0)
+//	tomb [0.95,0.3122,0,0]   0.950  parked at negative ordinal (tombstone)
+//	gone [0.9,0.4359,0,0]    0.900  doc row deleted, chunk kept
+//	u2   [0,1,0,0]           0.000  user doc, ordinal 20
+//
+// tomb and gone must be dropped during hydration, leaving [u1, r1, u2].
+func seedVectorSearchFixture(t *testing.T, pg *sql.DB) (genID int64, table string) {
+	t.Helper()
+	ctx := context.Background()
+	genID, err := ensureVectorGeneration(ctx, pg, "fp-search", "m", 4)
+	require.NoError(t, err, "ensureVectorGeneration")
+	require.NoError(t, ensureVectorChunkTable(ctx, pg, genID, 4), "ensureVectorChunkTable")
+	extSchema, err := vectorExtensionSchema(ctx, pg)
+	require.NoError(t, err, "vectorExtensionSchema")
+	halfvec := extSchema + ".halfvec"
+	table = vectorChunkTable(genID)
+
+	insertSearchDoc(t, pg, "u1", "S", 5, 5, "[]", "alpha user content")
+	insertSearchDoc(t, pg, "r1", "S", 10, 12, runOffsets, runContent)
+	insertSearchDoc(t, pg, "u2", "S", 20, 20, "[]", "gamma")
+	insertSearchDoc(t, pg, "gone", "S", 30, 30, "[]", "vanished")
+	insertSearchDoc(t, pg, "tomb", "S", -1, -1, "[]", "parked tombstone")
+
+	insertSearchChunk(t, pg, table, halfvec, "u1", 0, []float32{1, 0, 0, 0})
+	insertSearchChunk(t, pg, table, halfvec, "r1", 0, []float32{0, 0, 1, 0})
+	insertSearchChunk(t, pg, table, halfvec, "r1", 1, []float32{1, 0.2, 0, 0})
+	insertSearchChunk(t, pg, table, halfvec, "u2", 0, []float32{0, 1, 0, 0})
+	insertSearchChunk(t, pg, table, halfvec, "gone", 0, []float32{0.9, 0.4359, 0, 0})
+	insertSearchChunk(t, pg, table, halfvec, "tomb", 0, []float32{0.95, 0.3122, 0, 0})
+
+	// gone's chunk stays; its document row disappears between KNN and hydrate.
+	_, err = pg.Exec(`DELETE FROM vector_documents WHERE doc_key = 'gone'`)
+	require.NoError(t, err, "delete gone doc")
+	return genID, table
+}
+
+// runContent joins two run members with "\n\n"; runOffsets records their rune
+// starts (ordinals 10 and 12). With searchMaxInputChars=20 the content
+// re-splits so chunk index 1's center falls inside member B (ordinal 12).
+var (
+	runMemberA = strings.Repeat("a", 17)
+	runMemberB = strings.Repeat("b", 17)
+	runContent = runMemberA + "\n\n" + runMemberB
+	runOffsets = `[{"o":10,"r":0,"b":0},{"o":12,"r":19,"b":19}]`
+)
+
+func TestPGVectorSearcher(t *testing.T) {
+	pgURL := testPGURL(t)
+	pg := newVectorSearchTestPG(t, pgURL, "agentsview_vector_search_test")
+	ctx := context.Background()
+
+	genID, _ := seedVectorSearchFixture(t, pg)
+	searcher := NewVectorSearcher(
+		pg, genID, 4, searchMaxInputChars, fixedEncoder([]float32{1, 0, 0, 0}))
+
+	t.Run("ranking rollup hydration tombstone", func(t *testing.T) {
+		hits, err := searcher.SemanticSearch(ctx, "query", 10)
+		require.NoError(t, err, "SemanticSearch")
+
+		keys := make([]string, len(hits))
+		for i, h := range hits {
+			keys[i] = h.SessionID
+		}
+		require.Len(t, hits, 3, "gone and tomb dropped, r1 rolled to one hit")
+
+		// Ranking order: u1 (1.0) > r1 (0.992) > u2 (0.0).
+		assert.Equal(t, 5, hits[0].Ordinal, "u1 first")
+		assert.Equal(t, "alpha user content", hits[0].Snippet)
+		assert.InDelta(t, 1.0, hits[0].Score, 1e-3, "u1 cosine ~1.0")
+		assert.Greater(t, hits[0].Score, hits[1].Score, "scores descend")
+		assert.Greater(t, hits[1].Score, hits[2].Score, "scores descend")
+
+		// r1 is the run doc: anchor to member B (ordinal 12), member-local snippet.
+		r1 := hits[1]
+		assert.Equal(t, 12, r1.Ordinal, "run hit anchors to member B")
+		assert.Equal(t, 10, r1.OrdinalStart)
+		assert.Equal(t, 12, r1.OrdinalEnd)
+		assert.Equal(t, runMemberB, r1.Snippet, "member-local snippet")
+		assert.False(t, r1.Subordinate)
+
+		// u2 last; tombstone and vanished doc absent.
+		assert.Equal(t, 20, hits[2].Ordinal)
+		for _, h := range hits {
+			assert.GreaterOrEqual(t, h.Ordinal, 0, "no negative-ordinal tombstone hydrated")
+		}
+	})
+
+	t.Run("limit truncates documents", func(t *testing.T) {
+		hits, err := searcher.SemanticSearch(ctx, "query", 1)
+		require.NoError(t, err)
+		require.Len(t, hits, 1)
+		assert.Equal(t, 5, hits[0].Ordinal, "only top-ranked u1")
+	})
+
+	t.Run("encoder error is transient", func(t *testing.T) {
+		bad := NewVectorSearcher(pg, genID, 4, searchMaxInputChars,
+			func(context.Context, string) ([]float32, error) {
+				return nil, errors.New("embeddings endpoint down")
+			})
+		_, err := bad.SemanticSearch(ctx, "query", 5)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, db.ErrSemanticTransient),
+			"encoder failure surfaces db.ErrSemanticTransient")
+	})
+
+	t.Run("dimension mismatch is rejected", func(t *testing.T) {
+		wrongDim := NewVectorSearcher(pg, genID, 4, searchMaxInputChars,
+			fixedEncoder([]float32{1, 0, 0}))
+		_, err := wrongDim.SemanticSearch(ctx, "query", 5)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "dimensions")
+	})
+
+	t.Run("resolve message units", func(t *testing.T) {
+		tests := []struct {
+			name      string
+			ordinal   int
+			wantDoc   string // "" means zero UnitRef
+			wantStart int
+			wantEnd   int
+		}{
+			{"inside unit", 11, "r1", 10, 12},
+			{"exact ordinal_end boundary", 12, "r1", 10, 12},
+			{"gap between units", 15, "", 0, 0},
+			{"before first unit", 2, "", 0, 0},
+			{"tombstone guard", 3, "", 0, 0}, // without ordinal>=0, tomb(-1) matches
+			{"user unit", 20, "u2", 20, 20},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				units, err := searcher.ResolveMessageUnits(ctx,
+					[]db.MessageRef{{SessionID: "S", Ordinal: tt.ordinal}})
+				require.NoError(t, err)
+				require.Len(t, units, 1)
+				u := units[0]
+				assert.Equal(t, tt.wantDoc, u.DocKey)
+				if tt.wantDoc == "" {
+					assert.Equal(t, db.UnitRef{}, u, "zero UnitRef")
+					return
+				}
+				assert.Equal(t, "S", u.SessionID)
+				assert.Equal(t, tt.wantStart, u.OrdinalStart)
+				assert.Equal(t, tt.wantEnd, u.OrdinalEnd)
+			})
+		}
+	})
+
+	t.Run("resolve preserves ref order and handles empty", func(t *testing.T) {
+		empty, err := searcher.ResolveMessageUnits(ctx, nil)
+		require.NoError(t, err)
+		assert.Empty(t, empty)
+
+		units, err := searcher.ResolveMessageUnits(ctx, []db.MessageRef{
+			{SessionID: "S", Ordinal: 15}, // gap -> zero
+			{SessionID: "S", Ordinal: 11}, // r1
+		})
+		require.NoError(t, err)
+		require.Len(t, units, 2)
+		assert.Equal(t, db.UnitRef{}, units[0])
+		assert.Equal(t, "r1", units[1].DocKey)
+	})
+}
+
+// TestPGVectorSearcherExactK pins the exact-k chunk fetch: a single doc whose
+// chunks occupy all top-k chunk ranks rolls up to one hit, and a next-best doc
+// whose only chunk sits at rank k+1 never enters the result. Over-fetching more
+// than k chunks would surface the outside-k doc, so this guards the LIMIT k
+// candidate pool that keeps PG parity with the local sqlite-vec searcher.
+func TestPGVectorSearcherExactK(t *testing.T) {
+	pgURL := testPGURL(t)
+	pg := newVectorSearchTestPG(t, pgURL, "agentsview_vector_search_exactk_test")
+	ctx := context.Background()
+
+	genID, err := ensureVectorGeneration(ctx, pg, "fp-exactk", "m", 4)
+	require.NoError(t, err, "ensureVectorGeneration")
+	require.NoError(t, ensureVectorChunkTable(ctx, pg, genID, 4), "ensureVectorChunkTable")
+	extSchema, err := vectorExtensionSchema(ctx, pg)
+	require.NoError(t, err, "vectorExtensionSchema")
+	halfvec := extSchema + ".halfvec"
+	table := vectorChunkTable(genID)
+
+	// "multi" contributes the two nearest chunks (ranks 1 and 2 for query
+	// [1,0,0,0]); "outside" is next-best at rank 3, beyond k=2.
+	insertSearchDoc(t, pg, "multi", "S", 1, 1, "[]", "multi doc content")
+	insertSearchDoc(t, pg, "outside", "S", 2, 2, "[]", "outside doc content")
+	insertSearchChunk(t, pg, table, halfvec, "multi", 0, []float32{1, 0, 0, 0})
+	insertSearchChunk(t, pg, table, halfvec, "multi", 1, []float32{1, 0.1, 0, 0})
+	insertSearchChunk(t, pg, table, halfvec, "outside", 0, []float32{0, 1, 0, 0})
+
+	searcher := NewVectorSearcher(
+		pg, genID, 4, searchMaxInputChars, fixedEncoder([]float32{1, 0, 0, 0}))
+	hits, err := searcher.SemanticSearch(ctx, "query", 2)
+	require.NoError(t, err, "SemanticSearch")
+	require.Len(t, hits, 1, "both top-2 chunks belong to multi -> one rolled-up doc")
+	assert.Equal(t, 1, hits[0].Ordinal, "only multi survives; outside sits beyond k")
+}
+
+// TestPGVectorSearcherEfSearchRecall pins the HNSW recall contract: with a
+// candidate pool larger than pgvector's default hnsw.ef_search (40), a search
+// for k neighbors must return k docs, not ~40. The searcher raises ef_search to
+// k inside the query transaction; without that the KNN silently caps the pool
+// below k, diverging from the local backend's exact scan.
+func TestPGVectorSearcherEfSearchRecall(t *testing.T) {
+	pgURL := testPGURL(t)
+	pg := newVectorSearchTestPG(t, pgURL, "agentsview_vector_search_efsearch_test")
+	ctx := context.Background()
+
+	genID, err := ensureVectorGeneration(ctx, pg, "fp-efsearch", "m", 4)
+	require.NoError(t, err, "ensureVectorGeneration")
+	require.NoError(t, ensureVectorChunkTable(ctx, pg, genID, 4), "ensureVectorChunkTable")
+	extSchema, err := vectorExtensionSchema(ctx, pg)
+	require.NoError(t, err, "vectorExtensionSchema")
+	halfvec := extSchema + ".halfvec"
+	table := vectorChunkTable(genID)
+
+	// 100 distinct docs (> the ef_search default of 40), one chunk each. The
+	// vectors spread across the plane so all are neighbors of the query.
+	const docCount = 100
+	for i := 0; i < docCount; i++ {
+		key := fmt.Sprintf("d%d", i)
+		insertSearchDoc(t, pg, key, "S", i, i, "[]", fmt.Sprintf("doc %d", i))
+		emb := []float32{1, float32(i) / float32(docCount), 0, 0}
+		insertSearchChunk(t, pg, table, halfvec, key, 0, emb)
+	}
+
+	searcher := NewVectorSearcher(
+		pg, genID, 4, searchMaxInputChars, fixedEncoder([]float32{1, 0, 0, 0}))
+	hits, err := searcher.SemanticSearch(ctx, "query", docCount)
+	require.NoError(t, err, "SemanticSearch")
+	assert.Len(t, hits, docCount,
+		"ef_search raised to k returns all %d docs, not the ~40 default cap", docCount)
+}

--- a/internal/postgres/vector_search_unit_test.go
+++ b/internal/postgres/vector_search_unit_test.go
@@ -1,0 +1,111 @@
+package postgres
+
+import (
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+func TestHalfvecLiteral(t *testing.T) {
+	t.Run("finite vector renders pgvector text form", func(t *testing.T) {
+		literal, err := halfvecLiteral([]float32{1, -0.5, 0})
+		require.NoError(t, err)
+		assert.Equal(t, "[1,-0.5,0]", literal)
+	})
+
+	t.Run("empty vector", func(t *testing.T) {
+		literal, err := halfvecLiteral(nil)
+		require.NoError(t, err)
+		assert.Equal(t, "[]", literal)
+	})
+
+	nonFinite := []struct {
+		name string
+		vec  []float32
+	}{
+		{"NaN", []float32{0, float32(math.NaN()), 1}},
+		{"+Inf", []float32{float32(math.Inf(1)), 0}},
+		{"-Inf", []float32{0, 0, float32(math.Inf(-1))}},
+	}
+	for _, tt := range nonFinite {
+		t.Run(tt.name+" is rejected", func(t *testing.T) {
+			_, err := halfvecLiteral(tt.vec)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "non-finite embedding value")
+		})
+	}
+}
+
+func TestHNSWEfSearch(t *testing.T) {
+	cases := []struct {
+		name string
+		k    int
+		want int
+	}{
+		{"below floor clamps up", 1, 40},
+		{"just below floor", 39, 40},
+		{"at floor", 40, 40},
+		{"mid range passes through", 500, 500},
+		{"at ceiling", 1000, 1000},
+		{"above ceiling clamps down", 5000, 1000},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, hnswEfSearch(tc.k))
+		})
+	}
+}
+
+func TestRollupChunkHits(t *testing.T) {
+	// Best-first order in, one row per doc out (first seen wins), truncated.
+	hits := []chunkHit{
+		{docKey: "a", chunkIndex: 0, score: 0.9},
+		{docKey: "b", chunkIndex: 1, score: 0.8},
+		{docKey: "a", chunkIndex: 2, score: 0.7}, // dominated duplicate dropped
+		{docKey: "c", chunkIndex: 0, score: 0.6},
+	}
+
+	rolled := rollupChunkHits(hits, 10)
+	require.Len(t, rolled, 3)
+	assert.Equal(t, "a", rolled[0].docKey)
+	assert.Equal(t, 0, rolled[0].chunkIndex, "best chunk kept for doc a")
+	assert.Equal(t, "b", rolled[1].docKey)
+	assert.Equal(t, "c", rolled[2].docKey)
+
+	truncated := rollupChunkHits(hits, 2)
+	require.Len(t, truncated, 2)
+	assert.Equal(t, "a", truncated[0].docKey)
+	assert.Equal(t, "b", truncated[1].docKey)
+
+	assert.Empty(t, rollupChunkHits(nil, 5))
+}
+
+func TestSemanticUnavailableError(t *testing.T) {
+	s := &Store{}
+
+	// No reason set: bare sentinel.
+	err := s.semanticUnavailableError()
+	assert.True(t, errors.Is(err, db.ErrSemanticUnavailable))
+
+	s.SetSemanticUnavailableReason("pgvector extension not installed")
+	err = s.semanticUnavailableError()
+	assert.True(t, errors.Is(err, db.ErrSemanticUnavailable),
+		"reasoned error still wraps the sentinel")
+	assert.Contains(t, err.Error(), "pgvector extension not installed")
+}
+
+func TestStoreVectorSearcherWiring(t *testing.T) {
+	s := &Store{}
+	assert.False(t, s.HasSemantic(), "no searcher wired")
+
+	s.SetVectorSearcher(NewVectorSearcher(nil, 1, 4, 100, nil))
+	assert.True(t, s.HasSemantic(), "searcher wired")
+
+	s.SetVectorSearcher(nil)
+	assert.False(t, s.HasSemantic(), "searcher cleared")
+}

--- a/internal/server/huma_routes_embeddings.go
+++ b/internal/server/huma_routes_embeddings.go
@@ -29,6 +29,25 @@ func WithEmbeddingsManager(m EmbeddingsManager) Option {
 	return func(s *Server) { s.embeddingsManager = m }
 }
 
+// WithEmbeddingsUnavailableReason records why the embeddings routes are
+// unavailable, so their 501 responses carry an actionable message instead of
+// the generic "embeddings manager not available" — e.g. when the daemon
+// disabled vector serving at startup because another process held
+// vectors.write.lock.
+func WithEmbeddingsUnavailableReason(reason string) Option {
+	return func(s *Server) { s.embeddingsUnavailableReason = reason }
+}
+
+// embeddingsUnavailableError is the 501 every embeddings route returns while
+// no manager is wired, carrying the recorded cause when one exists.
+func (s *Server) embeddingsUnavailableError() error {
+	msg := s.embeddingsUnavailableReason
+	if msg == "" {
+		msg = "embeddings manager not available"
+	}
+	return apiError(http.StatusNotImplemented, msg)
+}
+
 func (s *Server) registerEmbeddingsRoutes() {
 	group := newRouteGroup(s.api, "/api/v1/embeddings", "Embeddings")
 
@@ -71,7 +90,7 @@ func (s *Server) humaEmbeddingsBuild(
 	_ context.Context, in *embeddingsBuildInput,
 ) (*embeddingsBuildOutput, error) {
 	if s.embeddingsManager == nil {
-		return nil, apiError(http.StatusNotImplemented, "embeddings manager not available")
+		return nil, s.embeddingsUnavailableError()
 	}
 	if err := s.embeddingsManager.StartBuild(in.Body); err != nil {
 		if errors.Is(err, vector.ErrBuildRunning) {
@@ -92,7 +111,7 @@ func (s *Server) humaEmbeddingsStatus(
 	_ context.Context, _ *emptyInput,
 ) (*jsonOutput[vector.BuildStatus], error) {
 	if s.embeddingsManager == nil {
-		return nil, apiError(http.StatusNotImplemented, "embeddings manager not available")
+		return nil, s.embeddingsUnavailableError()
 	}
 	return &jsonOutput[vector.BuildStatus]{Body: s.embeddingsManager.Status()}, nil
 }
@@ -101,7 +120,7 @@ func (s *Server) humaEmbeddingsGenerations(
 	ctx context.Context, _ *emptyInput,
 ) (*jsonOutput[embeddingsGenerationsResponse], error) {
 	if s.embeddingsManager == nil {
-		return nil, apiError(http.StatusNotImplemented, "embeddings manager not available")
+		return nil, s.embeddingsUnavailableError()
 	}
 	gens, err := s.embeddingsManager.Generations(ctx)
 	if err != nil {
@@ -119,7 +138,7 @@ func (s *Server) humaEmbeddingsActivate(
 	ctx context.Context, in *embeddingsGenerationActionInput,
 ) (*noContentOutput, error) {
 	if s.embeddingsManager == nil {
-		return nil, apiError(http.StatusNotImplemented, "embeddings manager not available")
+		return nil, s.embeddingsUnavailableError()
 	}
 	if err := s.embeddingsManager.Activate(ctx, in.ID, in.Body.Force); err != nil {
 		return nil, embeddingsActionError(err)
@@ -131,7 +150,7 @@ func (s *Server) humaEmbeddingsRetire(
 	ctx context.Context, in *embeddingsGenerationActionInput,
 ) (*noContentOutput, error) {
 	if s.embeddingsManager == nil {
-		return nil, apiError(http.StatusNotImplemented, "embeddings manager not available")
+		return nil, s.embeddingsUnavailableError()
 	}
 	if err := s.embeddingsManager.Retire(ctx, in.ID, in.Body.Force); err != nil {
 		return nil, embeddingsActionError(err)

--- a/internal/server/huma_routes_embeddings_test.go
+++ b/internal/server/huma_routes_embeddings_test.go
@@ -107,6 +107,23 @@ func TestEmbeddingsRoutesRegisteredWhenManagerNil(t *testing.T) {
 	assert.NotEqual(t, "/", patternWith)
 }
 
+// TestEmbeddingsUnavailableReasonReplacesGeneric501 pins that a recorded
+// unavailability reason (e.g. vector serving disabled at startup because
+// vectors.write.lock was held) reaches the 501 body, so CLI users see why
+// the daemon cannot build and how to recover instead of the generic message.
+func TestEmbeddingsUnavailableReasonReplacesGeneric501(t *testing.T) {
+	reason := "vector serving is disabled for this daemon run: restart the daemon"
+	srv := testServer(t, 0, WithEmbeddingsUnavailableReason(reason))
+
+	w := serveGet(t, srv, "/api/v1/embeddings/status")
+	assertRecorderStatus(t, w, http.StatusNotImplemented)
+	assert.Contains(t, w.Body.String(), reason)
+
+	generic := serveGet(t, newEmbeddingsTestServer(t, nil), "/api/v1/embeddings/status")
+	assertRecorderStatus(t, generic, http.StatusNotImplemented)
+	assert.Contains(t, generic.Body.String(), "embeddings manager not available")
+}
+
 func TestOpenAPIDocumentsEmbeddingsRoutesWithoutManager(t *testing.T) {
 	spec := readOpenAPISpec(t, testServer(t, 0).Handler())
 

--- a/internal/server/huma_routes_push.go
+++ b/internal/server/huma_routes_push.go
@@ -2,25 +2,136 @@ package server
 
 import (
 	"context"
+	"log"
 	"net/http"
+	"strings"
+	"time"
 
+	"github.com/danielgtaylor/huma/v2"
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
 	duckdbsync "go.kenn.io/agentsview/internal/duckdb"
 	"go.kenn.io/agentsview/internal/postgres"
 )
 
+// pushProgressLogInterval bounds how often the daemon-side push handlers log
+// progress to debug.log. A package var so tests can shrink it.
+var pushProgressLogInterval = 15 * time.Second
+
+// pushProgressStreamInterval bounds how often a push handler forwards progress
+// reports onto its SSE stream: the session loop reports per session, which
+// would otherwise emit one event per row. A package var so tests can shrink it.
+var pushProgressStreamInterval = 200 * time.Millisecond
+
+// newPushProgressStreamSender wraps send so it forwards at most one progress
+// report per pushProgressStreamInterval.
+func newPushProgressStreamSender[P any](send func(P)) func(P) {
+	var last time.Time
+	return func(p P) {
+		if time.Since(last) < pushProgressStreamInterval {
+			return
+		}
+		last = time.Now()
+		send(p)
+	}
+}
+
+// newPGPushProgressLogger returns an onProgress callback that logs pg push
+// progress at most once per pushProgressLogInterval, phase-aware so the
+// vector phase is distinguishable from the session phase.
+func newPGPushProgressLogger() func(postgres.PushProgress) {
+	var last time.Time
+	return func(p postgres.PushProgress) {
+		if time.Since(last) < pushProgressLogInterval {
+			return
+		}
+		last = time.Now()
+		switch p.Phase {
+		case "preparing":
+			if p.SessionsTotal == 0 {
+				log.Printf("pg push: preparing (sync state, metadata, fingerprints)")
+				return
+			}
+			log.Printf("pg push: preparing %d/%d session(s)",
+				p.SessionsDone, p.SessionsTotal)
+		case "vectors":
+			log.Printf("pg push: vectors %d/%d session(s) scanned, %d chunks",
+				p.VectorSessionsDone, p.VectorSessionsTotal, p.VectorChunksPushed)
+		default:
+			log.Printf("pg push: %d/%d session(s), %d messages",
+				p.SessionsDone, p.SessionsTotal, p.MessagesDone)
+		}
+	}
+}
+
+// newDuckDBPushProgressLogger is newPGPushProgressLogger's DuckDB analog.
+func newDuckDBPushProgressLogger() func(duckdbsync.PushProgress) {
+	var last time.Time
+	return func(p duckdbsync.PushProgress) {
+		if time.Since(last) < pushProgressLogInterval {
+			return
+		}
+		last = time.Now()
+		log.Printf("duckdb push: %d/%d session(s), %d messages",
+			p.SessionsDone, p.SessionsTotal, p.MessagesDone)
+	}
+}
+
 func (s *Server) registerPushRoutes() {
 	group := newRouteGroup(s.api, "/api/v1/push", "Push")
 
-	registerRoute(
-		group, http.MethodPost, "/pg",
-		"Push to PostgreSQL", s.humaPGPush,
+	stream(
+		s, group, http.MethodPost, "/pg",
+		"Push to PostgreSQL", s.humaPGPush, streamJSONResponse(),
 	)
-	registerRoute(
-		group, http.MethodPost, "/duckdb",
-		"Push to DuckDB", s.humaDuckDBPush,
+	stream(
+		s, group, http.MethodPost, "/duckdb",
+		"Push to DuckDB", s.humaDuckDBPush, streamJSONResponse(),
 	)
+}
+
+// runPushStream executes run once and writes its outcome to the client: SSE
+// progress/done/error events when the request negotiated an event stream
+// (the CLI's daemon-delegated push renders these live), a single JSON body
+// otherwise. run receives the progress callback to thread into the push;
+// it is a throttled SSE sender in stream mode and nil in JSON mode — the
+// daemon-side debug.log progress logger is composed by the caller.
+func runPushStream[T any](
+	hctx huma.Context,
+	run func(onProgress func(T)) (any, error),
+) {
+	if strings.Contains(hctx.Header("Accept"), "text/event-stream") {
+		if sse, ok := newHumaSSEStream(hctx); ok {
+			send := newPushProgressStreamSender(func(p T) {
+				sse.SendJSON("progress", p)
+			})
+			result, err := run(send)
+			if err != nil {
+				sse.SendJSON("error", map[string]string{"error": err.Error()})
+				return
+			}
+			sse.SendJSON("done", result)
+			return
+		}
+	}
+	result, err := run(nil)
+	if err != nil {
+		writeHumaJSON(hctx, http.StatusInternalServerError,
+			map[string]string{"error": err.Error()})
+		return
+	}
+	writeHumaJSON(hctx, http.StatusOK, result)
+}
+
+// composePushProgress fans one progress report out to each non-nil callback.
+func composePushProgress[P any](fns ...func(P)) func(P) {
+	return func(p P) {
+		for _, fn := range fns {
+			if fn != nil {
+				fn(p)
+			}
+		}
+	}
 }
 
 type daemonPushInput struct {
@@ -35,14 +146,16 @@ type daemonPushRequest struct {
 	DuckDB                 *config.DuckDBConfig `json:"duckdb,omitempty"`
 	SyncStateTarget        string               `json:"sync_state_target,omitempty"`
 	MigrateLegacySyncState bool                 `json:"migrate_legacy_sync_state,omitempty"`
+	// NoVectors carries the CLI --no-vectors flag, which has no daemon-side
+	// flag of its own, into the push handler's vector-source gate.
+	NoVectors bool `json:"no_vectors,omitempty"`
 }
 
-type pgPushOutput struct {
-	Body postgres.PushResult
-}
-
-type duckDBPushOutput struct {
-	Body duckdbsync.PushResult
+// WithVectorPushSource wires the local vectors.db push source used by the
+// daemon's pg push handler. Nil (the default) leaves the vector push phase
+// disabled, e.g. when [vector] is not configured.
+func WithVectorPushSource(src postgres.VectorPushSource) Option {
+	return func(s *Server) { s.vectorPushSource = src }
 }
 
 func (s *Server) localPushTarget() (*db.DB, error) {
@@ -54,6 +167,19 @@ func (s *Server) localPushTarget() (*db.DB, error) {
 		)
 	}
 	return local, nil
+}
+
+// pgPushVectorSource returns the vector push source to attach for this push,
+// or nil when the phase is gated off: no source is wired ([vector] disabled),
+// the target opts out via push_vectors=false, or the caller passed
+// --no-vectors. A nil source leaves postgres.Sync's vector phase skipped.
+func (s *Server) pgPushVectorSource(
+	pgCfg config.PGConfig, noVectors bool,
+) postgres.VectorPushSource {
+	if s.vectorPushSource == nil || !pgCfg.PushVectorsEnabled() || noVectors {
+		return nil
+	}
+	return s.vectorPushSource
 }
 
 func (s *Server) pgPushConfig(req daemonPushRequest) (config.PGConfig, error) {
@@ -90,7 +216,7 @@ func duckDBPushSyncOptions(
 func (s *Server) humaPGPush(
 	ctx context.Context,
 	in *daemonPushInput,
-) (*pgPushOutput, error) {
+) (*huma.StreamResponse, error) {
 	if err := postgres.ValidateProjectFilters(
 		in.Body.Projects,
 		in.Body.ExcludeProjects,
@@ -110,39 +236,48 @@ func (s *Server) humaPGPush(
 	}
 
 	engine := s.syncEngineForLocal(local)
-	var result postgres.PushResult
-	_, err = engine.SyncThenRun(ctx, in.Body.Full, nil,
-		func(forceFull bool) error {
-			ps, err := postgres.New(
-				pgCfg.URL, pgCfg.Schema, local,
-				pgCfg.MachineName, pgCfg.AllowInsecure,
-				postgres.SyncOptions{
-					Projects:               in.Body.Projects,
-					ExcludeProjects:        in.Body.ExcludeProjects,
-					SyncStateTarget:        in.Body.SyncStateTarget,
-					MigrateLegacySyncState: in.Body.MigrateLegacySyncState,
-				},
+	vectorSource := s.pgPushVectorSource(pgCfg, in.Body.NoVectors)
+	body := in.Body
+	return &huma.StreamResponse{Body: func(hctx huma.Context) {
+		runPushStream(hctx, func(
+			streamProgress func(postgres.PushProgress),
+		) (any, error) {
+			onProgress := composePushProgress(
+				newPGPushProgressLogger(), streamProgress,
 			)
-			if err != nil {
-				return err
-			}
-			defer ps.Close()
-			if err := ps.EnsureSchema(ctx); err != nil {
-				return err
-			}
-			result, err = ps.Push(ctx, forceFull, nil)
-			return err
+			var result postgres.PushResult
+			_, err := engine.SyncThenRun(ctx, body.Full, nil,
+				func(forceFull bool) error {
+					ps, err := postgres.New(
+						pgCfg.URL, pgCfg.Schema, local,
+						pgCfg.MachineName, pgCfg.AllowInsecure,
+						postgres.SyncOptions{
+							Projects:               body.Projects,
+							ExcludeProjects:        body.ExcludeProjects,
+							SyncStateTarget:        body.SyncStateTarget,
+							MigrateLegacySyncState: body.MigrateLegacySyncState,
+							VectorSource:           vectorSource,
+						},
+					)
+					if err != nil {
+						return err
+					}
+					defer ps.Close()
+					if err := ps.EnsureSchema(ctx); err != nil {
+						return err
+					}
+					result, err = ps.Push(ctx, forceFull, onProgress)
+					return err
+				})
+			return result, err
 		})
-	if err != nil {
-		return nil, apiError(http.StatusInternalServerError, err.Error())
-	}
-	return &pgPushOutput{Body: result}, nil
+	}}, nil
 }
 
 func (s *Server) humaDuckDBPush(
 	ctx context.Context,
 	in *daemonPushInput,
-) (*duckDBPushOutput, error) {
+) (*huma.StreamResponse, error) {
 	if err := postgres.ValidateProjectFilters(
 		in.Body.Projects,
 		in.Body.ExcludeProjects,
@@ -163,33 +298,40 @@ func (s *Server) humaDuckDBPush(
 
 	engine := s.syncEngineForLocal(local)
 	opts := duckDBPushSyncOptions(in.Body, duckCfg)
-	var result duckdbsync.PushResult
-	_, err = engine.SyncThenRun(ctx, in.Body.Full, nil,
-		func(forceFull bool) error {
-			var syncer *duckdbsync.Sync
-			var err error
-			if duckCfg.URL != "" {
-				syncer, err = duckdbsync.NewFromConfig(
-					duckCfg, local, opts,
-				)
-			} else {
-				syncer, err = duckdbsync.New(
-					duckCfg.Path, local, duckCfg.MachineName,
-					opts,
-				)
-			}
-			if err != nil {
-				return err
-			}
-			defer syncer.Close()
-			if err := syncer.EnsureSchema(ctx); err != nil {
-				return err
-			}
-			result, err = syncer.Push(ctx, forceFull, nil)
-			return err
+	body := in.Body
+	return &huma.StreamResponse{Body: func(hctx huma.Context) {
+		runPushStream(hctx, func(
+			streamProgress func(duckdbsync.PushProgress),
+		) (any, error) {
+			onProgress := composePushProgress(
+				newDuckDBPushProgressLogger(), streamProgress,
+			)
+			var result duckdbsync.PushResult
+			_, err := engine.SyncThenRun(ctx, body.Full, nil,
+				func(forceFull bool) error {
+					var syncer *duckdbsync.Sync
+					var err error
+					if duckCfg.URL != "" {
+						syncer, err = duckdbsync.NewFromConfig(
+							duckCfg, local, opts,
+						)
+					} else {
+						syncer, err = duckdbsync.New(
+							duckCfg.Path, local, duckCfg.MachineName,
+							opts,
+						)
+					}
+					if err != nil {
+						return err
+					}
+					defer syncer.Close()
+					if err := syncer.EnsureSchema(ctx); err != nil {
+						return err
+					}
+					result, err = syncer.Push(ctx, forceFull, onProgress)
+					return err
+				})
+			return result, err
 		})
-	if err != nil {
-		return nil, apiError(http.StatusInternalServerError, err.Error())
-	}
-	return &duckDBPushOutput{Body: result}, nil
+	}}, nil
 }

--- a/internal/server/huma_routes_push_internal_test.go
+++ b/internal/server/huma_routes_push_internal_test.go
@@ -1,18 +1,119 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/config"
 	duckdbsync "go.kenn.io/agentsview/internal/duckdb"
+	"go.kenn.io/agentsview/internal/postgres"
 )
+
+// stubVectorPushSource is a no-op postgres.VectorPushSource: the gating test
+// only needs identity, never a method call.
+type stubVectorPushSource struct{}
+
+func (stubVectorPushSource) Generation(
+	context.Context,
+) (postgres.VectorGenerationInfo, bool, error) {
+	return postgres.VectorGenerationInfo{}, false, nil
+}
+
+func (stubVectorPushSource) SessionDocHashes(
+	context.Context,
+) (map[string]string, error) {
+	return nil, nil
+}
+
+func (stubVectorPushSource) SessionDocs(
+	context.Context, string,
+) ([]postgres.VectorPushDoc, string, error) {
+	return nil, "", nil
+}
+
+// TestPGPushProgressLoggerThrottlesAndReportsPhases pins the daemon-side
+// push heartbeat: reports inside the throttle window log nothing, and the
+// vector phase logs its own counters instead of the session line.
+func TestPGPushProgressLoggerThrottlesAndReportsPhases(t *testing.T) {
+	origInterval := pushProgressLogInterval
+	pushProgressLogInterval = time.Hour
+	t.Cleanup(func() { pushProgressLogInterval = origInterval })
+
+	var buf bytes.Buffer
+	origOut := log.Writer()
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(origOut) })
+
+	logProgress := newPGPushProgressLogger()
+	logProgress(postgres.PushProgress{SessionsDone: 1, SessionsTotal: 10, MessagesDone: 5})
+	logProgress(postgres.PushProgress{SessionsDone: 2, SessionsTotal: 10, MessagesDone: 9})
+	assert.Contains(t, buf.String(), "pg push: 1/10 session(s), 5 messages")
+	assert.NotContains(t, buf.String(), "2/10",
+		"second report inside the throttle window must not log")
+
+	pushProgressLogInterval = 0
+	logProgress(postgres.PushProgress{
+		Phase:               "vectors",
+		VectorSessionsDone:  3,
+		VectorSessionsTotal: 7,
+		VectorChunksPushed:  42,
+	})
+	assert.Contains(t, buf.String(),
+		"pg push: vectors 3/7 session(s) scanned, 42 chunks")
+
+	logProgress(postgres.PushProgress{
+		Phase:         "preparing",
+		SessionsDone:  500,
+		SessionsTotal: 46000,
+	})
+	assert.Contains(t, buf.String(), "pg push: preparing 500/46000 session(s)")
+
+	logProgress(postgres.PushProgress{Phase: "preparing"})
+	assert.Contains(t, buf.String(),
+		"pg push: preparing (sync state, metadata, fingerprints)",
+		"zero-total preparing report renders the setup-stage line")
+}
+
+func TestPGPushVectorSourceGating(t *testing.T) {
+	disabled := false
+	tests := []struct {
+		name      string
+		wired     bool
+		pushFlag  *bool
+		noVectors bool
+		wantSrc   bool
+	}{
+		{name: "wired and enabled", wired: true, wantSrc: true},
+		{name: "no source wired", wired: false, wantSrc: false},
+		{name: "target opts out", wired: true, pushFlag: &disabled, wantSrc: false},
+		{name: "caller passed --no-vectors", wired: true, noVectors: true, wantSrc: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Server{}
+			if tt.wired {
+				s.vectorPushSource = stubVectorPushSource{}
+			}
+			got := s.pgPushVectorSource(
+				config.PGConfig{PushVectors: tt.pushFlag}, tt.noVectors,
+			)
+			if tt.wantSrc {
+				assert.NotNil(t, got)
+			} else {
+				assert.Nil(t, got)
+			}
+		})
+	}
+}
 
 type openAPISpec struct {
 	Paths map[string]map[string]openAPIOperation `json:"paths"`
@@ -191,4 +292,37 @@ func TestSyncRemotesRouteIsStreaming(t *testing.T) {
 	op := requireOpenAPIOperation(t, spec, "post", "/api/v1/sync/remotes")
 	require.Contains(t, op.Responses, "200")
 	assertStreamingResponseContent(t, op.Responses["200"].Content)
+}
+
+// TestPushRoutesAreStreaming pins that both push routes negotiate SSE (the
+// CLI's daemon-delegated push renders the streamed progress) while still
+// declaring a plain JSON response for non-streaming clients.
+func TestPushRoutesAreStreaming(t *testing.T) {
+	s := testServer(t, 30)
+	spec := readOpenAPISpec(t, s.Handler())
+	for _, path := range []string{"/api/v1/push/pg", "/api/v1/push/duckdb"} {
+		op := requireOpenAPIOperation(t, spec, "post", path)
+		require.Contains(t, op.Responses, "200", path)
+		assertStreamingResponseContent(t, op.Responses["200"].Content)
+	}
+}
+
+// TestNewPushProgressStreamSenderThrottles pins the SSE fan-out throttle: the
+// session loop reports per session, and forwarding every report would emit
+// one SSE event per row.
+func TestNewPushProgressStreamSenderThrottles(t *testing.T) {
+	origInterval := pushProgressStreamInterval
+	pushProgressStreamInterval = time.Hour
+	t.Cleanup(func() { pushProgressStreamInterval = origInterval })
+
+	var got []int
+	send := newPushProgressStreamSender(func(v int) { got = append(got, v) })
+	send(1)
+	send(2)
+	assert.Equal(t, []int{1}, got,
+		"second report inside the throttle window must not send")
+
+	pushProgressStreamInterval = 0
+	send(3)
+	assert.Equal(t, []int{1, 3}, got)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -22,6 +22,7 @@ import (
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/insight"
+	"go.kenn.io/agentsview/internal/postgres"
 	"go.kenn.io/agentsview/internal/service"
 	"go.kenn.io/agentsview/internal/sync"
 	"go.kenn.io/agentsview/internal/web"
@@ -99,6 +100,17 @@ type Server struct {
 	// build lifecycle routes. Nil (the default) leaves those routes
 	// unregistered, e.g. when semantic search is not configured.
 	embeddingsManager EmbeddingsManager
+
+	// embeddingsUnavailableReason, when non-empty, replaces the generic
+	// "embeddings manager not available" 501 message on the embeddings
+	// routes with a cause-specific one (e.g. vector serving disabled at
+	// startup because vectors.write.lock was held).
+	embeddingsUnavailableReason string
+
+	// vectorPushSource, when set, supplies the local vectors.db active
+	// generation to the daemon's pg push handler. Nil leaves the vector
+	// push phase skipped, e.g. when [vector] is disabled.
+	vectorPushSource postgres.VectorPushSource
 }
 
 // New creates a new Server.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2494,6 +2494,43 @@ func TestDuckDBPushLocalNoSyncDaemonWritesConfiguredPath(t *testing.T) {
 	assert.FileExists(t, target)
 }
 
+// TestDuckDBPushStreamsSSEDoneEvent pins the push route's SSE mode: a client
+// that accepts text/event-stream (the CLI's daemon-delegated push) gets an
+// event stream ending in a done event carrying the push result, instead of a
+// single JSON body after a silent wait.
+func TestDuckDBPushStreamsSSEDoneEvent(t *testing.T) {
+	if runtime.GOOS == "windows" && runtime.GOARCH == "arm64" {
+		t.Skip("duckdb-go-bindings does not ship a windows/arm64 library")
+	}
+
+	te := setupNoSyncMode(t)
+	target := filepath.Join(t.TempDir(), "agentsview.duckdb")
+	body, err := json.Marshal(struct {
+		Full   bool                `json:"full"`
+		DuckDB config.DuckDBConfig `json:"duckdb"`
+	}{
+		Full: true,
+		DuckDB: config.DuckDBConfig{
+			Path:        target,
+			MachineName: "workstation",
+		},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/push/duckdb",
+		strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "http://127.0.0.1:0")
+	req.Header.Set("Accept", "text/event-stream")
+	w := httptest.NewRecorder()
+	te.handler.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	assert.Contains(t, w.Header().Get("Content-Type"), "text/event-stream")
+	assert.Contains(t, w.Body.String(), "event: done")
+	assert.FileExists(t, target)
+}
+
 func TestCORSPreflightRejectsBadOrigin(t *testing.T) {
 	te := setupHostOnly(t)
 

--- a/internal/vector/build.go
+++ b/internal/vector/build.go
@@ -102,6 +102,13 @@ func (ix *Index) Build(
 	// build compares against a real stored scope again.
 	scopeChanged := !hasScope || storedScope != o.IncludeAutomated
 	full := o.FullRebuild || o.Backstop || firstEver || scopeChanged
+	// Report the scanning phase before the mirror refresh: on a large archive
+	// the refresh (and the pending count below) can run for a while with no
+	// chunk totals yet, and without a phase report a progress consumer can
+	// only render a misleading "0/0 chunks".
+	if o.Progress != nil {
+		o.Progress(BuildProgress{Phase: "scanning"})
+	}
 	refreshStats, err := ix.Refresh(ctx, src, full, o.IncludeAutomated)
 	if err != nil {
 		return BuildResult{}, err

--- a/internal/vector/build_test.go
+++ b/internal/vector/build_test.go
@@ -396,6 +396,9 @@ func TestBuildProgressReceivesFinalDoneEqualToTotalChunks(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotEmpty(t, calls)
+	assert.Equal(t, "scanning", calls[0].Phase,
+		"the first report must announce the mirror-refresh scan, before any "+
+			"chunk totals exist, so consumers can render more than 0/0 chunks")
 	last := calls[len(calls)-1]
 	assert.EqualValues(t, result.Fill.Chunks, last.Done)
 	assert.EqualValues(t, result.Fill.Chunks, last.Total,

--- a/internal/vector/export.go
+++ b/internal/vector/export.go
@@ -1,0 +1,280 @@
+package vector
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"math"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+// ExportChunk is one embedded chunk of a document, decoded from the
+// sqlite-vec blob back into float32s for replication to another backend.
+type ExportChunk struct {
+	ChunkIndex int
+	Embedding  []float32
+}
+
+// ExportDoc is one embedded mirror document plus its chunk vectors, the
+// unit pg push replicates. OffsetsJSON is the mirror's raw offsets column.
+type ExportDoc struct {
+	DocKey, SessionID, SourceUUID     string
+	Ordinal, OrdinalEnd               int
+	Subordinate                       bool
+	OffsetsJSON, Content, ContentHash string
+	Chunks                            []ExportChunk
+}
+
+// ActiveExport identifies the active generation for replication.
+type ActiveExport struct {
+	Fingerprint, Model string
+	Ordinal            int64
+	Dimension          int
+}
+
+// ActiveExport returns the active generation's identity, or ok=false when
+// no generation is active (nothing to push). Like Search, it fails closed
+// with ErrMirrorVersionMismatch before touching any table when ix was
+// opened read-only against a mirror whose schema version does not match
+// this binary's, rather than exporting rows shaped by a different schema.
+func (ix *Index) ActiveExport(ctx context.Context) (ActiveExport, bool, error) {
+	if ix.versionMismatch {
+		return ActiveExport{}, false, ErrMirrorVersionMismatch
+	}
+	var exp ActiveExport
+	err := ix.db.QueryRowContext(ctx,
+		`SELECT ordinal, gen_key, dimension FROM `+ix.spec.generationsTable()+
+			` WHERE state = 'active' ORDER BY ordinal LIMIT 1`,
+	).Scan(&exp.Ordinal, &exp.Fingerprint, &exp.Dimension)
+	if err == sql.ErrNoRows {
+		return ActiveExport{}, false, nil
+	}
+	if err != nil {
+		return ActiveExport{}, false, fmt.Errorf("lookup active generation: %w", err)
+	}
+	model, _, err := ix.metaGet(ctx, "gen_model:"+exp.Fingerprint)
+	if err != nil {
+		return ActiveExport{}, false, fmt.Errorf("lookup generation model: %w", err)
+	}
+	exp.Model = model
+	return exp, true, nil
+}
+
+// SessionEmbeddedDocHashes returns, per session, a sha256 aggregate over the
+// full exported row identity of each doc embedded at its current revision in
+// genOrdinal, ordered by (doc_key). The aggregate covers doc_key, source_uuid,
+// ordinal, ordinal_end, subordinate, offsets, and content_hash so that a
+// metadata-only change (an ordinal shift on unchanged content, the
+// compaction/resync case) still moves the aggregate; hashing only
+// (doc_key, content_hash) would leave PG anchors stale. pg push compares these
+// against the aggregates stored in PG to skip unchanged sessions.
+//
+// Like Search, it fails closed with ErrMirrorVersionMismatch before touching
+// any table when ix was opened read-only against a mirror whose schema version
+// does not match this binary's.
+func (ix *Index) SessionEmbeddedDocHashes(
+	ctx context.Context, genOrdinal int64,
+) (map[string]string, error) {
+	if ix.versionMismatch {
+		return nil, ErrMirrorVersionMismatch
+	}
+	rows, err := ix.db.QueryContext(ctx, `
+SELECT d.session_id, d.doc_key, d.source_uuid, d.ordinal, d.ordinal_end,
+       d.subordinate, d.offsets, d.content_hash
+  FROM `+ix.spec.DocsTable+` d
+  JOIN `+ix.spec.stampsTable()+` st ON st.doc_key = d.doc_key
+ WHERE st.ordinal = ? AND st.revision = d.content_hash AND d.ordinal >= 0
+ ORDER BY d.session_id, d.doc_key`, genOrdinal)
+	if err != nil {
+		return nil, fmt.Errorf("scan embedded doc hashes: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[string]string)
+	var cur string
+	h := sha256.New()
+	flush := func() {
+		if cur != "" {
+			out[cur] = hex.EncodeToString(h.Sum(nil))
+			h.Reset()
+		}
+	}
+	for rows.Next() {
+		var sessionID string
+		var d ExportDoc
+		if err := rows.Scan(&sessionID, &d.DocKey, &d.SourceUUID, &d.Ordinal,
+			&d.OrdinalEnd, &d.Subordinate, &d.OffsetsJSON,
+			&d.ContentHash); err != nil {
+			return nil, fmt.Errorf("scan embedded doc hash row: %w", err)
+		}
+		if sessionID != cur {
+			flush()
+			cur = sessionID
+		}
+		writeEmbeddedDocIdentity(h, d)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	flush()
+	return out, nil
+}
+
+// writeEmbeddedDocIdentity appends one doc's exported row identity to h using
+// the framing SessionEmbeddedDocHashes established: NUL-terminated fields, a
+// newline per doc. Content and chunk vectors are deliberately excluded — the
+// aggregate detects doc-set and metadata drift, and content_hash already
+// covers the body. Shared by the full-index aggregate scan and the
+// single-session export hash so the two can never drift.
+func writeEmbeddedDocIdentity(h hash.Hash, d ExportDoc) {
+	writeField := func(s string) {
+		h.Write([]byte(s))
+		h.Write([]byte{0})
+	}
+	writeField(d.DocKey)
+	writeField(d.SourceUUID)
+	writeField(strconv.Itoa(d.Ordinal))
+	writeField(strconv.Itoa(d.OrdinalEnd))
+	writeField(strconv.FormatBool(d.Subordinate))
+	writeField(d.OffsetsJSON)
+	writeField(d.ContentHash)
+	h.Write([]byte{'\n'})
+}
+
+// aggregateEmbeddedDocHash computes the SessionEmbeddedDocHashes value for one
+// exported doc set: the docs hashed in doc_key order. An empty set yields "",
+// matching the session's absence from the SessionEmbeddedDocHashes map.
+func aggregateEmbeddedDocHash(docs []ExportDoc) string {
+	if len(docs) == 0 {
+		return ""
+	}
+	ordered := slices.Clone(docs)
+	slices.SortFunc(ordered, func(a, b ExportDoc) int {
+		return strings.Compare(a.DocKey, b.DocKey)
+	})
+	h := sha256.New()
+	for _, d := range ordered {
+		writeEmbeddedDocIdentity(h, d)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// ExportSessionDocs returns sessionID's embedded docs in genOrdinal with
+// their chunk vectors decoded to float32, plus the aggregate hash of exactly
+// the returned doc set (the SessionEmbeddedDocHashes formula; "" when no docs
+// are embedded). Docs, chunks, and hash are read inside one SQLite read
+// transaction, so an embeddings build rewriting the mirror concurrently
+// cannot yield a doc set whose hash claims coverage the chunk reads no
+// longer see — pg push compares the returned hash against its delta-scan
+// hash and defers the session on any divergence. Like Search, it fails
+// closed with ErrMirrorVersionMismatch before touching any table when ix was
+// opened read-only against a mirror whose schema version does not match this
+// binary's.
+func (ix *Index) ExportSessionDocs(
+	ctx context.Context, genOrdinal int64, sessionID string,
+) ([]ExportDoc, string, error) {
+	if ix.versionMismatch {
+		return nil, "", ErrMirrorVersionMismatch
+	}
+	tx, err := ix.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("begin export snapshot: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	rows, err := tx.QueryContext(ctx, `
+SELECT d.doc_key, d.session_id, d.source_uuid, d.ordinal, d.ordinal_end,
+       d.subordinate, d.offsets, d.content, d.content_hash
+  FROM `+ix.spec.DocsTable+` d
+  JOIN `+ix.spec.stampsTable()+` st ON st.doc_key = d.doc_key
+ WHERE st.ordinal = ? AND st.revision = d.content_hash
+   AND d.session_id = ? AND d.ordinal >= 0
+ ORDER BY d.ordinal`, genOrdinal, sessionID)
+	if err != nil {
+		return nil, "", fmt.Errorf("export session docs: %w", err)
+	}
+	defer rows.Close()
+
+	var docs []ExportDoc
+	for rows.Next() {
+		var d ExportDoc
+		if err := rows.Scan(&d.DocKey, &d.SessionID, &d.SourceUUID,
+			&d.Ordinal, &d.OrdinalEnd, &d.Subordinate,
+			&d.OffsetsJSON, &d.Content, &d.ContentHash); err != nil {
+			return nil, "", fmt.Errorf("scan export doc: %w", err)
+		}
+		docs = append(docs, d)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, "", err
+	}
+	if err := rows.Close(); err != nil {
+		return nil, "", err
+	}
+
+	vecTable := fmt.Sprintf("%s_v%d", ix.spec.VectorsPrefix, genOrdinal)
+	for i := range docs {
+		chunks, err := exportDocChunks(
+			ctx, tx, ix.spec, vecTable, genOrdinal, docs[i].DocKey,
+		)
+		if err != nil {
+			return nil, "", err
+		}
+		docs[i].Chunks = chunks
+	}
+	return docs, aggregateEmbeddedDocHash(docs), nil
+}
+
+func exportDocChunks(
+	ctx context.Context, tx *sql.Tx, spec IndexSpec,
+	vecTable string, genOrdinal int64, docKey string,
+) ([]ExportChunk, error) {
+	rows, err := tx.QueryContext(ctx, `
+SELECT c.chunk_index, v.embedding
+  FROM `+spec.chunksTable()+` c
+  JOIN `+vecTable+` v ON v.rowid = c.vec_rowid
+ WHERE c.ordinal = ? AND c.doc_key = ?
+ ORDER BY c.chunk_index`, genOrdinal, docKey)
+	if err != nil {
+		return nil, fmt.Errorf("export chunks for %s: %w", docKey, err)
+	}
+	defer rows.Close()
+
+	var chunks []ExportChunk
+	for rows.Next() {
+		var idx int
+		var blob []byte
+		if err := rows.Scan(&idx, &blob); err != nil {
+			return nil, fmt.Errorf("scan chunk for %s: %w", docKey, err)
+		}
+		vec, err := decodeFloat32Blob(blob)
+		if err != nil {
+			return nil, fmt.Errorf("decode chunk %d of %s: %w", idx, docKey, err)
+		}
+		chunks = append(chunks, ExportChunk{ChunkIndex: idx, Embedding: vec})
+	}
+	return chunks, rows.Err()
+}
+
+// decodeFloat32Blob decodes sqlite-vec's raw little-endian float32 blob. A
+// nil or empty blob decodes to an empty (non-nil) slice; the guard also proves
+// b is non-nil to NilAway before the slice expression below.
+func decodeFloat32Blob(b []byte) ([]float32, error) {
+	if len(b)%4 != 0 {
+		return nil, fmt.Errorf("embedding blob length %d not a multiple of 4", len(b))
+	}
+	if len(b) == 0 {
+		return []float32{}, nil
+	}
+	out := make([]float32, len(b)/4)
+	for i := range out {
+		out[i] = math.Float32frombits(binary.LittleEndian.Uint32(b[i*4:]))
+	}
+	return out, nil
+}

--- a/internal/vector/export_test.go
+++ b/internal/vector/export_test.go
@@ -1,0 +1,240 @@
+package vector
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/db"
+	kitvec "go.kenn.io/kit/vector"
+)
+
+// fakeExportEncoder returns a deterministic 4-dimensional encoder for export
+// tests, mirroring fakeBuildEncoder's shape at a different dimension so the
+// round-trip test can assert Dimension and per-chunk vector length.
+func fakeExportEncoder() kitvec.EncodeFunc {
+	return func(_ context.Context, texts []string) ([][]float32, error) {
+		out := make([][]float32, len(texts))
+		for i := range texts {
+			out[i] = []float32{1, 0, 0, 0}
+		}
+		return out, nil
+	}
+}
+
+// exportTestSource returns a fakeUnitSource with two sessions: session-1
+// holds a user doc plus a multi-message run doc, session-2 holds a single
+// user doc, the small corpus TestExportRoundTrip and
+// TestSessionEmbeddedDocHashesChangesWithContent share.
+func exportTestSource() *fakeUnitSource {
+	return &fakeUnitSource{rows: []fakeUnit{
+		{
+			unit:    userDoc("session-1", "u1", 0, "hello"),
+			endedAt: "2024-01-01T00:00:00Z",
+		},
+		{
+			unit: runDoc("session-1", "a1", 1, 2, "first\n\nsecond", []db.UnitOffset{
+				{Ordinal: 1}, {Ordinal: 2, RuneStart: 7, ByteStart: 7},
+			}),
+			endedAt: "2024-01-01T00:00:01Z",
+		},
+		{
+			unit:    userDoc("session-2", "u2", 0, "world"),
+			endedAt: "2024-01-01T00:00:02Z",
+		},
+	}}
+}
+
+// newBuiltTestIndex opens a temp index, refreshes exportTestSource's two
+// sessions, and builds+activates a generation with a fake 4-dim encoder.
+func newBuiltTestIndex(t *testing.T) (*Index, kitvec.Generation) {
+	t.Helper()
+	ix := openTestIndex(t)
+	ctx := context.Background()
+	src := exportTestSource()
+	gen := fakeGeneration4Dim()
+
+	result, err := ix.Build(ctx, src, fakeExportEncoder(), gen, BuildOptions{})
+	require.NoError(t, err)
+	require.True(t, result.Activated)
+	return ix, gen
+}
+
+// newEmptyTestIndex opens a temp index with no build, for the no-active-
+// generation case.
+func newEmptyTestIndex(t *testing.T) *Index {
+	t.Helper()
+	return openTestIndex(t)
+}
+
+func fakeGeneration4Dim() kitvec.Generation {
+	return kitvec.Generation{Model: "fake-export-model", Dimensions: 4}
+}
+
+func TestExportRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	ix, gen := newBuiltTestIndex(t)
+
+	exp, ok, err := ix.ActiveExport(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, gen.Fingerprint(), exp.Fingerprint)
+	assert.Equal(t, 4, exp.Dimension)
+	assert.NotEmpty(t, exp.Model)
+
+	hashes, err := ix.SessionEmbeddedDocHashes(ctx, exp.Ordinal)
+	require.NoError(t, err)
+	require.Len(t, hashes, 2)
+
+	docs, aggHash, err := ix.ExportSessionDocs(ctx, exp.Ordinal, "session-1")
+	require.NoError(t, err)
+	require.NotEmpty(t, docs)
+	assert.Equal(t, hashes["session-1"], aggHash,
+		"export hash must equal the session's SessionEmbeddedDocHashes value")
+	for _, d := range docs {
+		assert.Equal(t, "session-1", d.SessionID)
+		assert.NotEmpty(t, d.ContentHash)
+		require.NotEmpty(t, d.Chunks)
+		for _, c := range d.Chunks {
+			assert.Len(t, c.Embedding, 4)
+		}
+	}
+
+	noDocs, emptyHash, err := ix.ExportSessionDocs(ctx, exp.Ordinal, "absent")
+	require.NoError(t, err)
+	assert.Empty(t, noDocs)
+	assert.Equal(t, "", emptyHash,
+		"an empty export hashes to \"\", matching absence from the hash map")
+}
+
+func TestExportNoActiveGeneration(t *testing.T) {
+	ctx := context.Background()
+	ix := newEmptyTestIndex(t)
+	_, ok, err := ix.ActiveExport(ctx)
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+// TestSessionEmbeddedDocHashesChangesWithContent builds, captures each
+// session's embedded-doc aggregate hash, mutates session-1's user doc
+// content in the fake source and refreshes (without rebuilding), then
+// captures again: session-1's stamp no longer matches its new content_hash,
+// so it drops out of the aggregate (session-1's run doc, a1, is untouched
+// and stays embedded, so the session key survives with a changed hash);
+// session-2, untouched, keeps a stable hash.
+func TestSessionEmbeddedDocHashesChangesWithContent(t *testing.T) {
+	ctx := context.Background()
+	ix := openTestIndex(t)
+	src := exportTestSource()
+	gen := fakeGeneration4Dim()
+
+	_, err := ix.Build(ctx, src, fakeExportEncoder(), gen, BuildOptions{})
+	require.NoError(t, err)
+
+	exp, ok, err := ix.ActiveExport(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	before, err := ix.SessionEmbeddedDocHashes(ctx, exp.Ordinal)
+	require.NoError(t, err)
+	require.Contains(t, before, "session-1")
+	require.Contains(t, before, "session-2")
+
+	// A later timestamp than the watermark Build's Refresh already advanced
+	// to, or the fake source's incremental scan would never resurface it.
+	src.rows[0].unit.Content = "changed"
+	src.rows[0].endedAt = "2024-01-02T00:00:00Z"
+	_, err = ix.Refresh(ctx, src, false, true)
+	require.NoError(t, err)
+
+	after, err := ix.SessionEmbeddedDocHashes(ctx, exp.Ordinal)
+	require.NoError(t, err)
+	require.Contains(t, after, "session-1",
+		"session-1's untouched run doc keeps it in the aggregate")
+	assert.NotEqual(t, before["session-1"], after["session-1"],
+		"the mutated session's aggregate must change")
+	assert.Equal(t, before["session-2"], after["session-2"],
+		"the untouched session's hash is stable")
+
+	// The export hash follows the shrunken embedded subset, so a pg push whose
+	// delta scan read `before` sees the divergence and defers the session
+	// instead of exporting the partial view.
+	_, exportHash, err := ix.ExportSessionDocs(ctx, exp.Ordinal, "session-1")
+	require.NoError(t, err)
+	assert.Equal(t, after["session-1"], exportHash,
+		"export hash tracks the current embedded subset")
+	assert.NotEqual(t, before["session-1"], exportHash,
+		"a stale delta-scan hash no longer matches the export")
+}
+
+// TestSessionEmbeddedDocHashesChangesWithMetadata guards the compaction/resync
+// case: a doc whose content (and content_hash) is unchanged but whose ordinal
+// shifts keeps its UUID-derived doc_key and its embedding stamp, so it stays
+// embedded — yet the aggregate must still change so pg push re-anchors it. A
+// hash over only (doc_key, content_hash) would miss this and leave PG anchors
+// stale. session-2, untouched, keeps a stable hash.
+func TestSessionEmbeddedDocHashesChangesWithMetadata(t *testing.T) {
+	ctx := context.Background()
+	ix := openTestIndex(t)
+	src := exportTestSource()
+	gen := fakeGeneration4Dim()
+
+	_, err := ix.Build(ctx, src, fakeExportEncoder(), gen, BuildOptions{})
+	require.NoError(t, err)
+
+	exp, ok, err := ix.ActiveExport(ctx)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	before, err := ix.SessionEmbeddedDocHashes(ctx, exp.Ordinal)
+	require.NoError(t, err)
+	require.Contains(t, before, "session-1")
+	require.Contains(t, before, "session-2")
+
+	// Shift session-1's user doc to a free ordinal slot without touching its
+	// content. The UUID-keyed doc_key ("u:session-1:u1") and content_hash are
+	// unchanged, so its Build-time stamp still matches and the doc stays
+	// embedded. Bump endedAt past the watermark so the incremental scan
+	// resurfaces it.
+	src.rows[0].unit.Ordinal = 5
+	src.rows[0].unit.OrdinalEnd = 5
+	src.rows[0].endedAt = "2024-01-02T00:00:00Z"
+	_, err = ix.Refresh(ctx, src, false, true)
+	require.NoError(t, err)
+
+	after, err := ix.SessionEmbeddedDocHashes(ctx, exp.Ordinal)
+	require.NoError(t, err)
+	require.Contains(t, after, "session-1",
+		"a pure ordinal shift keeps the doc embedded (content_hash unchanged)")
+	assert.NotEqual(t, before["session-1"], after["session-1"],
+		"a metadata-only ordinal shift must still move the aggregate")
+	assert.Equal(t, before["session-2"], after["session-2"],
+		"the untouched session's hash is stable")
+}
+
+// TestExportVersionMismatchReturnsSentinel covers the read-path version gate on
+// the export API: a read-only Index over a mirror stamped with a different
+// MirrorSchemaVersion must refuse ActiveExport, SessionEmbeddedDocHashes, and
+// ExportSessionDocs with ErrMirrorVersionMismatch, the same fail-closed
+// behavior Search and StaleActive apply, instead of exporting rows shaped by a
+// different schema.
+func TestExportVersionMismatchReturnsSentinel(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "vectors.db")
+	seedV2Mirror(t, path)
+
+	ro, err := Open(ctx, path, true, 4000)
+	require.NoError(t, err, "read-only Open must succeed even against a v2-stamped mirror")
+	defer ro.Close()
+
+	_, _, err = ro.ActiveExport(ctx)
+	assert.ErrorIs(t, err, ErrMirrorVersionMismatch)
+
+	_, err = ro.SessionEmbeddedDocHashes(ctx, 1)
+	assert.ErrorIs(t, err, ErrMirrorVersionMismatch)
+
+	_, _, err = ro.ExportSessionDocs(ctx, 1, "s1")
+	assert.ErrorIs(t, err, ErrMirrorVersionMismatch)
+}

--- a/internal/vector/search.go
+++ b/internal/vector/search.go
@@ -222,6 +222,26 @@ func (ix *Index) resolveHit(h kitvec.Hit[string], doc mirrorDoc) Hit {
 	return hit
 }
 
+// DocAnchor resolves the anchor ordinal and display snippet for a matched
+// chunk of a document, for backends that store the mirror elsewhere (the PG
+// vector searcher). It mirrors resolveHit exactly: a user document (empty
+// offsets) anchors to its own docOrdinal with a chunk snippet (see
+// chunkSnippet); a run document anchors to the member whose rune span
+// contains the matched chunk's center rune, with a member-local snippet
+// (see resolveRunAnchor).
+func DocAnchor(
+	content string, offsets []db.UnitOffset, docOrdinal, chunkIndex, maxInputChars int,
+) (int, string) {
+	split := kitvec.SplitOptions{
+		MaxRunes: maxInputChars,
+		Overlap:  ChunkOverlap(maxInputChars),
+	}
+	if len(offsets) == 0 {
+		return docOrdinal, chunkSnippet(content, chunkIndex, split)
+	}
+	return resolveRunAnchor(content, offsets, chunkIndex, split)
+}
+
 // runMemberSeparatorRunes is the rune length of the "\n\n" separator
 // db's runUnit joins run members with (see internal/db's runUnit). The
 // separator belongs to no member's span, so a member's text within the
@@ -233,15 +253,24 @@ const runMemberSeparatorRunes = 2
 // chunk's center rune (see anchorMemberIndex), and the snippet is the
 // intersection of the chunk's rune window with that member's span — always
 // a substring of the anchor message's own text, so the db layer's snippet
-// centering (semanticSnippet) can locate it inside the anchor message's
+// centering (SemanticSnippet) can locate it inside the anchor message's
 // content. A degenerate/stale ChunkIndex whose re-split window misses the
 // member entirely falls back to the anchor member's whole span text; the
 // result is never text from a different member, and never a panic.
 func (ix *Index) resolveRunHit(
 	content string, offsets []db.UnitOffset, chunkIndex int,
 ) (ordinal int, snippet string) {
+	return resolveRunAnchor(content, offsets, chunkIndex, ix.split)
+}
+
+// resolveRunAnchor is resolveRunHit's package-level body, shared with
+// DocAnchor for backends (the PG vector searcher) that resolve chunk hits
+// against a document loaded outside an Index.
+func resolveRunAnchor(
+	content string, offsets []db.UnitOffset, chunkIndex int, split kitvec.SplitOptions,
+) (ordinal int, snippet string) {
 	runes := []rune(content)
-	start, end := chunkWindow(len(runes), chunkIndex, ix.split)
+	start, end := chunkWindow(len(runes), chunkIndex, split)
 	member := anchorMemberIndex(offsets, start, end)
 
 	memberStart := min(offsets[member].RuneStart, len(runes))
@@ -344,7 +373,14 @@ SELECT doc_key, session_id, ordinal, ordinal_end, subordinate, offsets, content
 // content's chunk count (content changed since embedding) yields an empty
 // snippet rather than a panic.
 func (ix *Index) snippet(content string, chunkIndex int) string {
-	chunks := kitvec.Split(content, ix.split)
+	return chunkSnippet(content, chunkIndex, ix.split)
+}
+
+// chunkSnippet is the snippet method's package-level body, shared with
+// DocAnchor for backends (the PG vector searcher) that resolve chunk hits
+// against a document loaded outside an Index.
+func chunkSnippet(content string, chunkIndex int, split kitvec.SplitOptions) string {
+	chunks := kitvec.Split(content, split)
 	if chunkIndex < 0 || chunkIndex >= len(chunks) {
 		return ""
 	}

--- a/internal/vector/search_test.go
+++ b/internal/vector/search_test.go
@@ -709,3 +709,63 @@ func TestResolveMessageUnitsVersionMismatchGate(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrMirrorVersionMismatch)
 }
+
+// runDocAnchorFixture returns the three-member run content and offsets
+// shared by TestDocAnchor's run-doc cases: "aaaaa" (ordinal 5), "bbbbb"
+// (ordinal 6), "ccccc" (ordinal 7), joined with "\n\n" as db's runUnit does.
+func runDocAnchorFixture() (string, []db.UnitOffset) {
+	content := "aaaaa\n\nbbbbb\n\nccccc"
+	offsets := []db.UnitOffset{
+		{Ordinal: 5, RuneStart: 0, ByteStart: 0},
+		{Ordinal: 6, RuneStart: 7, ByteStart: 7},
+		{Ordinal: 7, RuneStart: 14, ByteStart: 14},
+	}
+	return content, offsets
+}
+
+// TestDocAnchorRunDocReturnsMemberAnchorAndLocalSnippet pins DocAnchor's run
+// branch: with maxInputChars large enough that the whole content is one
+// chunk, the anchor is the member whose span contains the chunk's center
+// rune, and the snippet is confined to that member's own text rather than
+// spilling into a neighboring member.
+func TestDocAnchorRunDocReturnsMemberAnchorAndLocalSnippet(t *testing.T) {
+	content, offsets := runDocAnchorFixture()
+
+	anchor, snippet := DocAnchor(content, offsets, 0, 0, 100)
+
+	assert.Equal(t, 6, anchor, "anchor must be the member containing the chunk's center rune")
+	assert.Equal(t, "bbbbb", snippet, "snippet must be the anchor member's own text")
+}
+
+// TestDocAnchorEmptyOffsetsReturnsDocOrdinalAndWholeSnippet pins DocAnchor's
+// user-doc branch: empty offsets means the caller-supplied docOrdinal
+// anchors as-is, with a snippet of the whole matched chunk.
+func TestDocAnchorEmptyOffsetsReturnsDocOrdinalAndWholeSnippet(t *testing.T) {
+	anchor, snippet := DocAnchor("a plain user question", nil, 3, 0, 100)
+
+	assert.Equal(t, 3, anchor)
+	assert.Equal(t, "a plain user question", snippet)
+}
+
+// TestDocAnchorOutOfRangeChunkIndexFallsBack pins the documented fallback
+// for a stale/degenerate ChunkIndex whose re-split window misses the
+// content entirely: a user doc yields an empty snippet (see chunkSnippet),
+// while a run doc falls back to the anchor member's own span text (see
+// resolveRunAnchor) rather than a panic or cross-member text.
+func TestDocAnchorOutOfRangeChunkIndexFallsBack(t *testing.T) {
+	t.Run("user doc", func(t *testing.T) {
+		anchor, snippet := DocAnchor("a plain user question", nil, 3, 99, 100)
+
+		assert.Equal(t, 3, anchor)
+		assert.Empty(t, snippet)
+	})
+
+	t.Run("run doc", func(t *testing.T) {
+		content, offsets := runDocAnchorFixture()
+
+		anchor, snippet := DocAnchor(content, offsets, 0, 99, 10)
+
+		assert.Equal(t, 7, anchor)
+		assert.Equal(t, "ccccc", snippet)
+	})
+}


### PR DESCRIPTION
PostgreSQL-backed agentsview now supports the `semantic` and `hybrid` search modes that previously existed only on SQLite. Embeddings are never computed server-side: `pg push` replicates the local active embedding generation from `vectors.db` into pgvector tables, and `pg serve` (plus every `--pg` direct-read command) answers semantic and hybrid queries from PostgreSQL instead of returning HTTP 501.

## Push path

- `pg push` gains a vector phase after sessions/messages: it copies the active generation into per-generation `halfvec(N)` chunk tables with HNSW cosine indexes, plus a shared `vector_documents` mirror so snippets and hit anchoring reuse exact local semantics. Opt out with `--no-vectors` or `push_vectors = false` under `[pg]`.
- Generations are keyed by the existing config fingerprint, so machines with identical `[vector.embeddings]` configs share one generation and a serving host searches the union.
- Delta state lives in a PG-side `vector_push_state` table written transactionally with the data, so a PG reset is self-healing. The per-session aggregate hash covers full doc row identity, so metadata-only changes re-push.
- Doc replacement is park-to-sentinel (park existing rows at negative ordinals, upsert onto the freed slots, delete still-parked rows), because `doc_key` is stable while `UNIQUE(session_id, ordinal)` slots shift. Eviction is scoped to sessions the pusher owns per its owner marker (probed with `FOR UPDATE`) and, for filtered pushes, by local project membership.
- Databases without pgvector (CockroachDB, missing extension package, insufficient privilege) degrade gracefully: one notice, vector phase skipped, session/message sync unaffected, semantic search keeps returning 501.

## Read path

- `internal/postgres` implements the same `db.VectorSearcher` seam; the RRF merge, unit fusion keys, subordinate penalty, and snippet helpers are exported from `internal/db` and reused, so mode behavior matches SQLite by construction. Invalid-input parity is pinned by a 10-case cross-backend test.
- Startup fingerprints the host's encoder config and looks up a matching PG generation; a miss keeps semantic at 501 with an error naming the expected and present fingerprints.
- KNN fetches exactly k chunks and sets `hnsw.ef_search = clamp(k, 40, 1000)` per query (with an `iterative_scan` fallback probe past pgvector's ceiling) so large fetches aren't silently capped at the default candidate pool of 40.
- Hybrid fuses the vector leg with an ILIKE keyword leg resolved to document units via `vector_documents`. Known limitation: the PG keyword leg is recency-ordered rather than BM25-ranked (documented).

## Maintenance and infra

- New `pg vectors list` / `pg vectors drop <id>` commands for inspecting and retiring generations.
- The compose test image and CI service container switch to `pgvector/pgvector` images.
- Docs: PostgreSQL sections in semantic-search and pg-sync pages, CLI reference entries, and a maintainer-level "PostgreSQL replica" internals section covering the push/read invariants (including the deliberate cross-generation `vector_documents` sharing).

## Where to look

- `internal/postgres/vector_push.go` — delta, ownership, and park-to-sentinel replacement (the subtlest code in the PR)
- `internal/postgres/vector_search.go` — KNN, ef_search tuning, hydration
- `internal/postgres/search_content_hybrid.go` — keyword-leg unit resolution and fusion
- `internal/vector/export.go` — the vectors.db export API and its fail-closed version gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)