### PR TITLE
fix(parser): strip Codex recommended plugin context

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -30,6 +30,11 @@ import (
 // trigger a non-destructive re-sync (mtime reset + skip cache
 // clear) so existing session data is preserved.
 //
+// Bumped to 60: the Codex parser removes the recommended-plugins
+// discovery envelope injected ahead of the first genuine user turn.
+// Existing Codex rows need re-parsing so the synthetic plugin list is
+// removed from stored messages, previews, and user-message counts.
+//
 // Bumped to 50: parser-derived text is sanitized for PostgreSQL
 // parity and fingerprints. Existing rows need re-parsing so stored
 // message/session shape, timestamps, roles, token counts, and content
@@ -277,7 +282,8 @@ import (
 // (51: Gemini cumulative-to-delta token reparse.)
 // (17: Codex <skill> template filtering.)
 // (16: <turn_aborted> system messages.)
-const dataVersion = 59
+// (60: Codex recommended-plugins prefix filtering.)
+const dataVersion = 60
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -833,31 +833,6 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 		"expected tool_result_events table after reopen")
 }
 
-func TestCurrentDataVersionKimiUsageEvents(t *testing.T) {
-	assert.GreaterOrEqual(t, CurrentDataVersion(), 55,
-		"Kimi persisted usage events require a data version bump")
-}
-
-func TestCurrentDataVersionGoalContextFiltering(t *testing.T) {
-	assert.GreaterOrEqual(t, CurrentDataVersion(), 56,
-		"Codex goal-context filtering requires a data version bump")
-}
-
-func TestCurrentDataVersionResultContentNULSanitization(t *testing.T) {
-	assert.GreaterOrEqual(t, CurrentDataVersion(), 58,
-		"message/result content NUL sanitization requires a data version bump")
-}
-
-func TestCurrentDataVersionToolInputNULSanitization(t *testing.T) {
-	assert.GreaterOrEqual(t, CurrentDataVersion(), 59,
-		"tool-call input_json NUL sanitization requires a data version bump")
-}
-
-func TestCurrentDataVersionRecommendedPluginsFiltering(t *testing.T) {
-	assert.GreaterOrEqual(t, CurrentDataVersion(), 60,
-		"Codex recommended-plugins filtering requires a data version bump")
-}
-
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {
 	d := testDB(t)
 	insertSession(t, d, "s-events", "proj")

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -853,6 +853,11 @@ func TestCurrentDataVersionToolInputNULSanitization(t *testing.T) {
 		"tool-call input_json NUL sanitization requires a data version bump")
 }
 
+func TestCurrentDataVersionRecommendedPluginsFiltering(t *testing.T) {
+	assert.GreaterOrEqual(t, CurrentDataVersion(), 60,
+		"Codex recommended-plugins filtering requires a data version bump")
+}
+
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {
 	d := testDB(t)
 	insertSession(t, d, "s-events", "proj")

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -283,7 +283,7 @@ func (b *codexSessionBuilder) handleResponseItem(
 
 	content := extractCodexContent(payload)
 	if role == "user" && b.firstUserContent == "" {
-		content = stripCodexRecommendedPluginsPrefix(content)
+		content = extractCodexInitialUserContent(payload)
 	}
 	if strings.TrimSpace(content) == "" {
 		return
@@ -1266,9 +1266,7 @@ func isCodexSubagentFunctionOutput(output gjson.Result) bool {
 	return true
 }
 
-// extractCodexContent joins all text blocks from a Codex
-// response item's content array.
-func extractCodexContent(payload gjson.Result) string {
+func extractCodexTextBlocks(payload gjson.Result) []string {
 	var texts []string
 	payload.Get("content").ForEach(
 		func(_, block gjson.Result) bool {
@@ -1281,7 +1279,34 @@ func extractCodexContent(payload gjson.Result) string {
 			return true
 		},
 	)
-	return strings.Join(texts, "\n")
+	return texts
+}
+
+// extractCodexContent joins all text blocks from a Codex
+// response item's content array.
+func extractCodexContent(payload gjson.Result) string {
+	return strings.Join(extractCodexTextBlocks(payload), "\n")
+}
+
+// extractCodexInitialUserContent filters the synthetic blocks bundled with
+// Codex's recommended-plugins injection while retaining user-authored blocks
+// from the same response item.
+func extractCodexInitialUserContent(payload gjson.Result) string {
+	texts := extractCodexTextBlocks(payload)
+	if len(texts) == 0 ||
+		!strings.HasPrefix(texts[0], "<recommended_plugins>") {
+		return strings.Join(texts, "\n")
+	}
+
+	texts[0] = stripCodexRecommendedPluginsPrefix(texts[0])
+	kept := texts[:0]
+	for _, text := range texts {
+		if strings.TrimSpace(text) == "" || isCodexSystemMessage(text) {
+			continue
+		}
+		kept = append(kept, text)
+	}
+	return strings.Join(kept, "\n")
 }
 
 // IsCodexExecSessionFile reports whether any session_meta
@@ -1655,7 +1680,7 @@ func (s *codexIncrementalSeed) observeUserMessage(
 	}
 	content := extractCodexContent(payload)
 	if s.firstUserContent == "" {
-		content = stripCodexRecommendedPluginsPrefix(content)
+		content = extractCodexInitialUserContent(payload)
 	}
 	if strings.TrimSpace(content) == "" {
 		return

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -282,6 +282,9 @@ func (b *codexSessionBuilder) handleResponseItem(
 	}
 
 	content := extractCodexContent(payload)
+	if role == "user" && b.firstUserContent == "" {
+		content = stripCodexRecommendedPluginsPrefix(content)
+	}
 	if strings.TrimSpace(content) == "" {
 		return
 	}
@@ -1651,6 +1654,9 @@ func (s *codexIncrementalSeed) observeUserMessage(
 		return
 	}
 	content := extractCodexContent(payload)
+	if s.firstUserContent == "" {
+		content = stripCodexRecommendedPluginsPrefix(content)
+	}
 	if strings.TrimSpace(content) == "" {
 		return
 	}
@@ -1766,6 +1772,25 @@ func isCodexSystemMessage(content string) bool {
 		strings.HasPrefix(trimmed, "<skill>") ||
 		isCodexSubagentNotification(content) ||
 		isCodexGoalContext(content)
+}
+
+// stripCodexRecommendedPluginsPrefix removes the plugin-discovery envelope
+// that recent Codex versions prepend to the synthetic context item at the
+// start of a session. It is called only while looking for the first genuine
+// user turn, so a later user message that quotes the envelope is preserved.
+func stripCodexRecommendedPluginsPrefix(content string) string {
+	const (
+		openTag  = "<recommended_plugins>"
+		closeTag = "</recommended_plugins>"
+	)
+	if !strings.HasPrefix(content, openTag) {
+		return content
+	}
+	_, rest, ok := strings.Cut(content[len(openTag):], closeTag)
+	if !ok {
+		return content
+	}
+	return strings.TrimLeft(rest, "\r\n")
 }
 
 // isCodexGoalContext reports whether content is a Codex /goal

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -1293,14 +1293,18 @@ func extractCodexContent(payload gjson.Result) string {
 // from the same response item.
 func extractCodexInitialUserContent(payload gjson.Result) string {
 	texts := extractCodexTextBlocks(payload)
-	if len(texts) == 0 ||
-		!strings.HasPrefix(texts[0], "<recommended_plugins>") {
+	if len(texts) == 0 {
 		return strings.Join(texts, "\n")
 	}
 
-	texts[0] = stripCodexRecommendedPluginsPrefix(texts[0])
+	stripped := stripCodexRecommendedPlugins(texts[0])
+	if stripped == texts[0] {
+		return strings.Join(texts, "\n")
+	}
+	texts[0] = stripped
 	kept := texts[:0]
 	for _, text := range texts {
+		text = stripCodexInitialSystemPrefix(text)
 		if strings.TrimSpace(text) == "" || isCodexSystemMessage(text) {
 			continue
 		}
@@ -1799,23 +1803,57 @@ func isCodexSystemMessage(content string) bool {
 		isCodexGoalContext(content)
 }
 
-// stripCodexRecommendedPluginsPrefix removes the plugin-discovery envelope
+// stripCodexRecommendedPlugins removes the plugin-discovery envelope
 // that recent Codex versions prepend to the synthetic context item at the
 // start of a session. It is called only while looking for the first genuine
 // user turn, so a later user message that quotes the envelope is preserved.
-func stripCodexRecommendedPluginsPrefix(content string) string {
+func stripCodexRecommendedPlugins(content string) string {
 	const (
 		openTag  = "<recommended_plugins>"
 		closeTag = "</recommended_plugins>"
 	)
-	if !strings.HasPrefix(content, openTag) {
+	start := strings.Index(content, openTag)
+	if start < 0 {
 		return content
 	}
-	_, rest, ok := strings.Cut(content[len(openTag):], closeTag)
-	if !ok {
+	relativeEnd := strings.Index(content[start+len(openTag):], closeTag)
+	if relativeEnd < 0 {
 		return content
 	}
-	return strings.TrimLeft(rest, "\r\n")
+	end := start + len(openTag) + relativeEnd + len(closeTag)
+	prefix := content[:start]
+	suffix := strings.TrimLeft(content[end:], "\r\n")
+	if strings.TrimSpace(prefix) == "" {
+		return suffix
+	}
+	return prefix + suffix
+}
+
+// stripCodexInitialSystemPrefix removes complete synthetic envelopes from the
+// start of an initial text block. A genuine prompt may follow an injected
+// envelope in the same block, so only text through the first matching close
+// tag is removed.
+func stripCodexInitialSystemPrefix(content string) string {
+	for {
+		trimmed := strings.TrimLeft(content, "\r\n")
+		var closeTag string
+		switch {
+		case strings.HasPrefix(trimmed, "# AGENTS.md"):
+			closeTag = "</INSTRUCTIONS>"
+		case strings.HasPrefix(trimmed, "<environment_context>"):
+			closeTag = "</environment_context>"
+		case strings.HasPrefix(trimmed, "<INSTRUCTIONS>"):
+			closeTag = "</INSTRUCTIONS>"
+		default:
+			return content
+		}
+
+		_, after, ok := strings.Cut(trimmed, closeTag)
+		if !ok {
+			return content
+		}
+		content = strings.TrimLeft(after, "\r\n")
+	}
 }
 
 // isCodexGoalContext reports whether content is a Codex /goal

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -1542,6 +1542,32 @@ func TestParseCodexSession_EdgeCases(t *testing.T) {
 		assert.Equal(t, 1, sess.UserMessageCount)
 	})
 
+	t.Run("preserves prompt bundled with initial context", func(t *testing.T) {
+		plugins := "<recommended_plugins>\n" +
+			"Install Google Drive when useful.\n" +
+			"</recommended_plugins>"
+		initialContext := fmt.Sprintf(
+			`{"timestamp":%q,"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":%q},{"type":"input_text","text":%q},{"type":"input_text","text":%q},{"type":"input_text","text":%q}]}}`,
+			tsEarlyS1,
+			plugins,
+			"# AGENTS.md instructions for /tmp/project\n\n<INSTRUCTIONS>\nrepo rules\n</INSTRUCTIONS>",
+			"<environment_context>\n  <cwd>/tmp/project</cwd>\n</environment_context>",
+			"Review the changes",
+		)
+		content := testjsonl.JoinJSONL(
+			testjsonl.CodexSessionMetaJSON("abc", "/tmp", "user", tsEarly),
+			initialContext,
+		)
+
+		sess, msgs := runCodexParserTest(t, "test.jsonl", content, false)
+
+		require.NotNil(t, sess)
+		require.Len(t, msgs, 1)
+		assert.Equal(t, "Review the changes", msgs[0].Content)
+		assert.Equal(t, "Review the changes", sess.FirstMessage)
+		assert.Equal(t, 1, sess.UserMessageCount)
+	})
+
 	t.Run("preserves user prompt after recommended plugins", func(t *testing.T) {
 		content := testjsonl.JoinJSONL(
 			testjsonl.CodexSessionMetaJSON("abc", "/tmp", "user", tsEarly),

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -1516,6 +1516,57 @@ func TestParseCodexSession_EdgeCases(t *testing.T) {
 		assert.Equal(t, "Actual user message", msgs[0].Content)
 	})
 
+	t.Run("strips recommended plugins from initial context", func(t *testing.T) {
+		plugins := "<recommended_plugins>\n" +
+			"Install Google Drive when useful.\n" +
+			"</recommended_plugins>"
+		initialContext := fmt.Sprintf(
+			`{"timestamp":%q,"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":%q},{"type":"input_text","text":%q},{"type":"input_text","text":%q}]}}`,
+			tsEarlyS1,
+			plugins,
+			"# AGENTS.md instructions for /tmp/project\n\n<INSTRUCTIONS>\nrepo rules\n</INSTRUCTIONS>",
+			"<environment_context>\n  <cwd>/tmp/project</cwd>\n</environment_context>",
+		)
+		content := testjsonl.JoinJSONL(
+			testjsonl.CodexSessionMetaJSON("abc", "/tmp", "user", tsEarly),
+			initialContext,
+			testjsonl.CodexMsgJSON("user", "Review the changes", tsEarlyS5),
+		)
+
+		sess, msgs := runCodexParserTest(t, "test.jsonl", content, false)
+
+		require.NotNil(t, sess)
+		require.Len(t, msgs, 1)
+		assert.Equal(t, "Review the changes", msgs[0].Content)
+		assert.Equal(t, "Review the changes", sess.FirstMessage)
+		assert.Equal(t, 1, sess.UserMessageCount)
+	})
+
+	t.Run("preserves user prompt after recommended plugins", func(t *testing.T) {
+		content := testjsonl.JoinJSONL(
+			testjsonl.CodexSessionMetaJSON("abc", "/tmp", "user", tsEarly),
+			testjsonl.CodexMsgJSON(
+				"user",
+				"<recommended_plugins>\nplugin list\n</recommended_plugins>\nFix the parser",
+				tsEarlyS1,
+			),
+			testjsonl.CodexMsgJSON(
+				"user",
+				"<recommended_plugins>later user text</recommended_plugins>",
+				tsEarlyS5,
+			),
+		)
+
+		sess, msgs := runCodexParserTest(t, "test.jsonl", content, false)
+
+		require.NotNil(t, sess)
+		require.Len(t, msgs, 2)
+		assert.Equal(t, "Fix the parser", msgs[0].Content)
+		assert.Equal(t, "<recommended_plugins>later user text</recommended_plugins>", msgs[1].Content)
+		assert.Equal(t, "Fix the parser", sess.FirstMessage)
+		assert.Equal(t, 2, sess.UserMessageCount)
+	})
+
 	// Codex injects skill template content as role=user JSONL
 	// entries when the model invokes a skill. These look like
 	// follow-up user turns to a naive count, which inflates
@@ -2048,6 +2099,39 @@ func TestParseCodexSessionFrom_DedupsReemittedPrompt(t *testing.T) {
 		assert.Contains(t, newMsgs[0].Content, "No issues found.")
 		assert.Equal(t, len(msgs), newMsgs[0].Ordinal,
 			"kept message must keep contiguous ordinals (no gap from the dropped replay)")
+	})
+
+	t.Run("dedups replay after stripped recommended plugins", func(t *testing.T) {
+		initial := testjsonl.JoinJSONL(
+			testjsonl.CodexSessionMetaJSON("inc-plugins", "/tmp", "codex_cli_rs", tsEarly),
+			testjsonl.CodexMsgJSON(
+				"user",
+				"<recommended_plugins>\nplugin list\n</recommended_plugins>\n"+prompt,
+				tsEarlyS1,
+			),
+			testjsonl.CodexMsgJSON("assistant", "looking", tsEarlyS5),
+		)
+		path := createTestFile(t, "incremental-plugins.jsonl", initial)
+		sess, msgs, err := parseCodexTestSession(t, path, "local", false)
+		require.NoError(t, err)
+		require.Equal(t, prompt, sess.FirstMessage)
+		require.Len(t, msgs, 2)
+
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+		offset := info.Size()
+
+		appendLines(t, path, testjsonl.JoinJSONL(
+			testjsonl.CodexMsgJSON("user", "<turn_aborted>\ninterrupted", tsLate),
+			testjsonl.CodexMsgJSON("user", prompt, tsLate),
+			testjsonl.CodexMsgJSON("assistant", "No issues found.", tsLateS5),
+		))
+
+		newMsgs, _, _, err := parseCodexTestSessionFrom(t, path, offset, len(msgs), false)
+		require.NoError(t, err)
+		require.Len(t, newMsgs, 1)
+		assert.Equal(t, RoleAssistant, newMsgs[0].Role)
+		assert.Equal(t, "No issues found.", newMsgs[0].Content)
 	})
 
 	t.Run("keeps a re-emitted prompt when the prefix already had a distinct turn", func(t *testing.T) {

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -1568,6 +1568,29 @@ func TestParseCodexSession_EdgeCases(t *testing.T) {
 		assert.Equal(t, 1, sess.UserMessageCount)
 	})
 
+	t.Run("preserves prompt sharing a block with initial context", func(t *testing.T) {
+		initialContext := fmt.Sprintf(
+			`{"timestamp":%q,"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":%q}]}}`,
+			tsEarlyS1,
+			"<recommended_plugins>\nplugin list\n</recommended_plugins>\n"+
+				"# AGENTS.md instructions for /tmp/project\n\n"+
+				"<INSTRUCTIONS>\nrepo rules\n</INSTRUCTIONS>\n\n"+
+				"Review the changes",
+		)
+		content := testjsonl.JoinJSONL(
+			testjsonl.CodexSessionMetaJSON("abc", "/tmp", "user", tsEarly),
+			initialContext,
+		)
+
+		sess, msgs := runCodexParserTest(t, "test.jsonl", content, false)
+
+		require.NotNil(t, sess)
+		require.Len(t, msgs, 1)
+		assert.Equal(t, "Review the changes", msgs[0].Content)
+		assert.Equal(t, "Review the changes", sess.FirstMessage)
+		assert.Equal(t, 1, sess.UserMessageCount)
+	})
+
 	t.Run("preserves user prompt after recommended plugins", func(t *testing.T) {
 		content := testjsonl.JoinJSONL(
 			testjsonl.CodexSessionMetaJSON("abc", "/tmp", "user", tsEarly),
@@ -1591,6 +1614,23 @@ func TestParseCodexSession_EdgeCases(t *testing.T) {
 		assert.Equal(t, "<recommended_plugins>later user text</recommended_plugins>", msgs[1].Content)
 		assert.Equal(t, "Fix the parser", sess.FirstMessage)
 		assert.Equal(t, 2, sess.UserMessageCount)
+	})
+
+	t.Run("finds recommended plugins after leading whitespace", func(t *testing.T) {
+		content := testjsonl.JoinJSONL(
+			testjsonl.CodexSessionMetaJSON("abc", "/tmp", "user", tsEarly),
+			testjsonl.CodexMsgJSON(
+				"user",
+				"\n<recommended_plugins>plugin list</recommended_plugins>\nFix the parser",
+				tsEarlyS1,
+			),
+		)
+
+		sess, msgs := runCodexParserTest(t, "test.jsonl", content, false)
+
+		require.NotNil(t, sess)
+		require.Len(t, msgs, 1)
+		assert.Equal(t, "Fix the parser", msgs[0].Content)
 	})
 
 	// Codex injects skill template content as role=user JSONL


### PR DESCRIPTION
Recent Codex builds prepend a `<recommended_plugins>` envelope to the synthetic `role=user` context at the start of sessions. Because it appears before the existing AGENTS.md and environment envelopes, agentsview mistakes the whole item for user-authored content, polluting message history and previews while inflating user-message counts and disrupting automated-session classification.

Strip the envelope only while locating the first genuine user turn, preserving later user-authored mentions and the prompt when Codex places it in the same item. Data version 60 triggers the existing non-destructive resync so already indexed Codex sessions are repaired.