### PR TITLE
feat(sessions): show read progress

### DIFF
--- a/frontend/e2e/helpers/mock-sessions.ts
+++ b/frontend/e2e/helpers/mock-sessions.ts
@@ -12,6 +12,7 @@ interface MockSession {
   started_at: string;
   ended_at: string;
   message_count: number;
+  latest_display_ordinal: number | null;
   user_message_count?: number;
   created_at: string;
   file_path: string;
@@ -35,6 +36,7 @@ export function createMockSessions(
     started_at: now,
     ended_at: now,
     message_count: 10,
+    latest_display_ordinal: 9,
     user_message_count: 5,
     created_at: now,
     file_path: `/tmp/${prefix}-${i}.json`,
@@ -154,6 +156,7 @@ function toSidebarIndexRow(session: MockSession) {
     created_at: session.created_at,
     termination_status: session.termination_status ?? null,
     message_count: session.message_count,
+    latest_display_ordinal: session.latest_display_ordinal,
     user_message_count:
       session.user_message_count ?? session.message_count,
     is_automated: session.is_automated ?? false,

--- a/frontend/e2e/read-progress.spec.ts
+++ b/frontend/e2e/read-progress.spec.ts
@@ -127,7 +127,7 @@ test("persists read progress until later output is visible", async ({ page }) =>
   await expect(unreadDivider).toHaveCount(0);
 });
 
-test("captures a visible read-progress divider", async ({ page }) => {
+test("captures responsive unread state", async ({ page }) => {
   const artifactDir = process.env.PR_RENDER_ARTIFACT_DIR;
   test.skip(
     !process.env.PR_RENDER_LINT_PATH || !artifactDir,
@@ -135,12 +135,12 @@ test("captures a visible read-progress divider", async ({ page }) => {
   );
   const [session] = createMockSessions(1, "read-progress-proof", () => "project");
   session!.id = "read-progress-proof";
-  session!.message_count = 5;
+  session!.message_count = 60;
   await page.addInitScript(() => {
     localStorage.setItem("agentsview-read-progress", JSON.stringify({
       version: 1,
       sessions: {
-        "read-progress-proof": { ordinal: 2, messageCount: 3 },
+        "read-progress-proof": { ordinal: 49, messageCount: 50 },
       },
     }));
   });
@@ -151,32 +151,39 @@ test("captures a visible read-progress divider", async ({ page }) => {
   await page.route(
     "**/api/v1/sessions/read-progress-proof/messages*",
     async (route) => route.fulfill({
-      json: { messages: makeMessages(5), count: 5 },
+      json: { messages: makeMessages(60), count: 60 },
     }),
   );
 
   const sessions = new SessionsPage(page);
   await sessions.goto();
   await sessions.selectFirstSession();
-  const divider = page.locator(".read-progress-divider");
-  await expect(divider).toBeVisible();
+  const unreadIndicator = page.locator(".unread-indicator");
+  await expect(unreadIndicator).toHaveCount(1);
 
   const lint: Record<number, unknown> = {};
   for (const width of [1280, 768, 400]) {
     await page.setViewportSize({ width, height: 720 });
-    await expect(divider).toBeVisible();
+    await expect(unreadIndicator).toHaveCount(1);
     lint[width] = {
       sidebar: await page.evaluate(renderLintSnippet(".session-list-scroll")),
       transcript: await page.evaluate(renderLintSnippet(".message-list-scroll")),
     };
     expect(lint[width]).toEqual({ sidebar: [], transcript: [] });
     if (width === 400) {
+      await expect(page.getByLabel("Close sidebar")).not.toBeVisible();
+      await page.screenshot({
+        path: path.join(artifactDir, "agentsview-T1057-2-after-400-closed.png"),
+      });
       await page.getByLabel("Toggle sidebar").click();
-      await expect(page.locator(".unread-indicator")).toBeVisible();
+      await expect(unreadIndicator).toBeVisible();
       await page.screenshot({
         path: path.join(artifactDir, "agentsview-T1057-2-after-400-sidebar.png"),
       });
-      await page.getByLabel("Close sidebar").click({ force: true });
+      await page.getByLabel("Close sidebar").evaluate((element) => {
+        element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      await expect(page.getByLabel("Close sidebar")).not.toBeVisible();
     }
     await page.screenshot({
       path: path.join(artifactDir, `agentsview-T1057-2-after-${width}.png`),

--- a/frontend/e2e/read-progress.spec.ts
+++ b/frontend/e2e/read-progress.spec.ts
@@ -178,18 +178,10 @@ test("acknowledges a trailing system message only after the last displayable row
   await expect(page.locator(".unread-indicator")).toHaveCount(0);
 });
 
-test("keeps an incomplete range unacknowledged", async ({ page }) => {
+test("acknowledges a progressive first visit by backend total", async ({ page }) => {
   const [session] = createMockSessions(1, "read-progress-partial", () => "project");
   session!.id = "read-progress-partial";
-  session!.message_count = 3;
-  await page.addInitScript(() => {
-    localStorage.setItem("agentsview-read-progress", JSON.stringify({
-      version: 1,
-      sessions: {
-        "read-progress-partial": { ordinal: 0, messageCount: 1 },
-      },
-    }));
-  });
+  session!.message_count = 3_005;
   await page.route(
     sessionsRoutePattern,
     handleSessionsRoute([{ sessions: [session!], project: null }]),
@@ -197,7 +189,10 @@ test("keeps an incomplete range unacknowledged", async ({ page }) => {
   await page.route(
     "**/api/v1/sessions/read-progress-partial/messages*",
     async (route) => route.fulfill({
-      json: { messages: makeMessages(3).slice(1), count: 3 },
+      json: {
+        messages: makeMessages(3_005).slice(-1_000).reverse(),
+        count: 3_005,
+      },
     }),
   );
 
@@ -210,10 +205,10 @@ test("keeps an incomplete range unacknowledged", async ({ page }) => {
   });
   await expect
     .poll(() => page.evaluate(() => localStorage.getItem("agentsview-read-progress")))
-    .not.toContain('"totalMessageCount"');
+    .toContain('"totalMessageCount":3005');
 
   await page.locator(".breadcrumb-link").click();
-  await expect(page.locator(".unread-indicator")).toHaveCount(1);
+  await expect(page.locator(".unread-indicator")).toHaveCount(0);
 });
 
 test("captures responsive unread state", async ({ page }) => {

--- a/frontend/e2e/read-progress.spec.ts
+++ b/frontend/e2e/read-progress.spec.ts
@@ -111,6 +111,20 @@ test("persists read progress until later output is visible", async ({ page }) =>
   await expect
     .poll(() => page.evaluate(() => localStorage.getItem("agentsview-read-progress")))
     .toContain('"messageCount":50');
+  await page.reload();
+  await sp.goto();
+  await sp.selectFirstSession();
+  await expect(unreadIndicator).toHaveCount(1);
+  await sp.scroller.evaluate((element) => {
+    element.scrollTop = element.scrollHeight;
+    element.dispatchEvent(new Event("scroll"));
+  });
+  await expect(page.getByText("Message 59")).toBeVisible();
+  await expect
+    .poll(() => page.evaluate(() => localStorage.getItem("agentsview-read-progress")))
+    .toContain('"messageCount":60');
+  await expect(unreadIndicator).toHaveCount(0);
+  await expect(unreadDivider).toHaveCount(0);
 });
 
 test("captures a visible read-progress divider", async ({ page }) => {
@@ -156,6 +170,14 @@ test("captures a visible read-progress divider", async ({ page }) => {
       transcript: await page.evaluate(renderLintSnippet(".message-list-scroll")),
     };
     expect(lint[width]).toEqual({ sidebar: [], transcript: [] });
+    if (width === 400) {
+      await page.getByLabel("Toggle sidebar").click();
+      await expect(page.locator(".unread-indicator")).toBeVisible();
+      await page.screenshot({
+        path: path.join(artifactDir, "agentsview-T1057-2-after-400-sidebar.png"),
+      });
+      await page.getByLabel("Close sidebar").click({ force: true });
+    }
     await page.screenshot({
       path: path.join(artifactDir, `agentsview-T1057-2-after-${width}.png`),
     });

--- a/frontend/e2e/read-progress.spec.ts
+++ b/frontend/e2e/read-progress.spec.ts
@@ -32,6 +32,19 @@ function makeMessages(count: number) {
   }));
 }
 
+function makeMessagesWithTrailingSystem() {
+  return [
+    ...makeMessages(2),
+    {
+      ...makeMessages(1)[0]!,
+      id: 3,
+      ordinal: 2,
+      content: "system",
+      is_system: true,
+    },
+  ];
+}
+
 function renderLintSnippet(scope: string): string {
   const lintPath = process.env.PR_RENDER_LINT_PATH;
   if (!lintPath) throw new Error("PR_RENDER_LINT_PATH is required");
@@ -125,6 +138,82 @@ test("persists read progress until later output is visible", async ({ page }) =>
     .toContain('"messageCount":60');
   await expect(unreadIndicator).toHaveCount(0);
   await expect(unreadDivider).toHaveCount(0);
+});
+
+test("acknowledges a trailing system message only after the last displayable row", async ({ page }) => {
+  const [session] = createMockSessions(1, "read-progress-system", () => "project");
+  session!.id = "read-progress-system";
+  session!.message_count = 3;
+  await page.addInitScript(() => {
+    localStorage.setItem("agentsview-read-progress", JSON.stringify({
+      version: 1,
+      sessions: {
+        "read-progress-system": { ordinal: 0, messageCount: 1 },
+      },
+    }));
+  });
+  await page.route(
+    sessionsRoutePattern,
+    handleSessionsRoute([{ sessions: [session!], project: null }]),
+  );
+  await page.route(
+    "**/api/v1/sessions/read-progress-system/messages*",
+    async (route) => route.fulfill({
+      json: { messages: makeMessagesWithTrailingSystem(), count: 3 },
+    }),
+  );
+
+  const sessions = new SessionsPage(page);
+  await sessions.goto();
+  await sessions.selectFirstSession();
+  await sessions.scroller.evaluate((element) => {
+    element.scrollTop = element.scrollHeight;
+    element.dispatchEvent(new Event("scroll"));
+  });
+  await expect
+    .poll(() => page.evaluate(() => localStorage.getItem("agentsview-read-progress")))
+    .toContain('"totalMessageCount":3');
+
+  await page.locator(".breadcrumb-link").click();
+  await expect(page.locator(".unread-indicator")).toHaveCount(0);
+});
+
+test("keeps an incomplete range unacknowledged", async ({ page }) => {
+  const [session] = createMockSessions(1, "read-progress-partial", () => "project");
+  session!.id = "read-progress-partial";
+  session!.message_count = 3;
+  await page.addInitScript(() => {
+    localStorage.setItem("agentsview-read-progress", JSON.stringify({
+      version: 1,
+      sessions: {
+        "read-progress-partial": { ordinal: 0, messageCount: 1 },
+      },
+    }));
+  });
+  await page.route(
+    sessionsRoutePattern,
+    handleSessionsRoute([{ sessions: [session!], project: null }]),
+  );
+  await page.route(
+    "**/api/v1/sessions/read-progress-partial/messages*",
+    async (route) => route.fulfill({
+      json: { messages: makeMessages(3).slice(1), count: 3 },
+    }),
+  );
+
+  const sessions = new SessionsPage(page);
+  await sessions.goto();
+  await sessions.selectFirstSession();
+  await sessions.scroller.evaluate((element) => {
+    element.scrollTop = element.scrollHeight;
+    element.dispatchEvent(new Event("scroll"));
+  });
+  await expect
+    .poll(() => page.evaluate(() => localStorage.getItem("agentsview-read-progress")))
+    .not.toContain('"totalMessageCount"');
+
+  await page.locator(".breadcrumb-link").click();
+  await expect(page.locator(".unread-indicator")).toHaveCount(1);
 });
 
 test("captures responsive unread state", async ({ page }) => {

--- a/frontend/e2e/read-progress.spec.ts
+++ b/frontend/e2e/read-progress.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from "@playwright/test";
+import {
+  createMockSessions,
+  handleSessionsRoute,
+  sessionsRoutePattern,
+} from "./helpers/mock-sessions";
+import { SessionsPage } from "./pages/sessions-page";
+
+function makeMessages(count: number) {
+  const timestamp = new Date().toISOString();
+  return Array.from({ length: count }, (_, ordinal) => ({
+    id: ordinal + 1,
+    session_id: "read-progress",
+    ordinal,
+    role: ordinal % 2 === 0 ? "user" : "assistant",
+    content: `Message ${ordinal}`,
+    timestamp,
+    has_thinking: false,
+    thinking_text: "",
+    has_tool_use: false,
+    content_length: 9,
+    model: "",
+    token_usage: null,
+    context_tokens: 0,
+    output_tokens: 0,
+    has_context_tokens: false,
+    has_output_tokens: false,
+    tool_calls: [],
+    is_system: false,
+  }));
+}
+
+test("persists read progress until later output is visible", async ({ page }) => {
+  let messageCount = 50;
+  const [session] = createMockSessions(1, "read-progress", () => "project");
+  session!.id = "read-progress";
+  session!.message_count = messageCount;
+
+  await page.route(
+    sessionsRoutePattern,
+    handleSessionsRoute([{ sessions: [session!], project: null }]),
+  );
+  await page.route(
+    "**/api/v1/sessions/read-progress/messages*",
+    async (route) => {
+      await route.fulfill({
+        json: { messages: makeMessages(messageCount), count: messageCount },
+      });
+    },
+  );
+
+  const sp = new SessionsPage(page);
+  await sp.goto();
+  await sp.selectFirstSession();
+  await expect
+    .poll(() => page.evaluate(() => localStorage.getItem("agentsview-read-progress")))
+    .toContain('"messageCount":50');
+
+  messageCount = 60;
+  session!.message_count = messageCount;
+  await page.reload();
+  await sp.goto();
+  await sp.selectFirstSession();
+
+  await expect(page.getByLabel("Unread messages")).toHaveCount(1);
+
+  await sp.scroller.evaluate((element) => {
+    element.scrollTop = element.scrollHeight;
+    element.dispatchEvent(new Event("scroll"));
+  });
+  await expect(page.getByLabel("Unread messages")).toHaveCount(0);
+});

--- a/frontend/e2e/read-progress.spec.ts
+++ b/frontend/e2e/read-progress.spec.ts
@@ -62,6 +62,7 @@ test("persists read progress until later output is visible", async ({ page }) =>
   const [session] = createMockSessions(1, "read-progress", () => "project");
   session!.id = "read-progress";
   session!.message_count = messageCount;
+  session!.latest_display_ordinal = messageCount - 1;
   await page.addInitScript(() => {
     class TestEventSource extends EventTarget {
       url: string;
@@ -99,11 +100,12 @@ test("persists read progress until later output is visible", async ({ page }) =>
   await sp.selectFirstSession();
   await expect
     .poll(() => page.evaluate(() => localStorage.getItem("agentsview-read-progress")))
-    .toContain('"messageCount":50');
+    .toContain('"seenOrdinal":49');
   const initialMessageRequests = messageRequests;
 
   messageCount = 60;
   session!.message_count = messageCount;
+  session!.latest_display_ordinal = messageCount - 1;
   await expect
     .poll(() => page.evaluate(() => (
       window as Window & { sessionSources: Array<{ url: string }> }
@@ -123,7 +125,7 @@ test("persists read progress until later output is visible", async ({ page }) =>
   await expect.poll(() => messageRequests).toBeGreaterThan(initialMessageRequests);
   await expect
     .poll(() => page.evaluate(() => localStorage.getItem("agentsview-read-progress")))
-    .toContain('"messageCount":50');
+    .toContain('"seenOrdinal":49');
   await page.reload();
   await sp.goto();
   await sp.selectFirstSession();
@@ -135,7 +137,7 @@ test("persists read progress until later output is visible", async ({ page }) =>
   await expect(page.getByText("Message 59")).toBeVisible();
   await expect
     .poll(() => page.evaluate(() => localStorage.getItem("agentsview-read-progress")))
-    .toContain('"messageCount":60');
+    .toContain('"seenOrdinal":59');
   await expect(unreadIndicator).toHaveCount(0);
   await expect(unreadDivider).toHaveCount(0);
 });
@@ -144,6 +146,7 @@ test("acknowledges a trailing system message only after the last displayable row
   const [session] = createMockSessions(1, "read-progress-system", () => "project");
   session!.id = "read-progress-system";
   session!.message_count = 3;
+  session!.latest_display_ordinal = 1;
   await page.addInitScript(() => {
     localStorage.setItem("agentsview-read-progress", JSON.stringify({
       version: 1,
@@ -172,7 +175,7 @@ test("acknowledges a trailing system message only after the last displayable row
   });
   await expect
     .poll(() => page.evaluate(() => localStorage.getItem("agentsview-read-progress")))
-    .toContain('"totalMessageCount":3');
+    .toContain('"seenOrdinal":1');
 
   await page.locator(".breadcrumb-link").click();
   await expect(page.locator(".unread-indicator")).toHaveCount(0);
@@ -182,6 +185,7 @@ test("acknowledges a progressive first visit by backend total", async ({ page })
   const [session] = createMockSessions(1, "read-progress-partial", () => "project");
   session!.id = "read-progress-partial";
   session!.message_count = 3_005;
+  session!.latest_display_ordinal = 3_004;
   await page.route(
     sessionsRoutePattern,
     handleSessionsRoute([{ sessions: [session!], project: null }]),
@@ -205,7 +209,7 @@ test("acknowledges a progressive first visit by backend total", async ({ page })
   });
   await expect
     .poll(() => page.evaluate(() => localStorage.getItem("agentsview-read-progress")))
-    .toContain('"totalMessageCount":3005');
+    .toContain('"seenOrdinal":3004');
 
   await page.locator(".breadcrumb-link").click();
   await expect(page.locator(".unread-indicator")).toHaveCount(0);
@@ -220,11 +224,12 @@ test("captures responsive unread state", async ({ page }) => {
   const [session] = createMockSessions(1, "read-progress-proof", () => "project");
   session!.id = "read-progress-proof";
   session!.message_count = 60;
+  session!.latest_display_ordinal = 59;
   await page.addInitScript(() => {
     localStorage.setItem("agentsview-read-progress", JSON.stringify({
-      version: 1,
+      version: 2,
       sessions: {
-        "read-progress-proof": { ordinal: 4, messageCount: 5 },
+        "read-progress-proof": { seenOrdinal: 4 },
       },
     }));
     window.IntersectionObserver = class {

--- a/frontend/e2e/read-progress.spec.ts
+++ b/frontend/e2e/read-progress.spec.ts
@@ -140,9 +140,15 @@ test("captures responsive unread state", async ({ page }) => {
     localStorage.setItem("agentsview-read-progress", JSON.stringify({
       version: 1,
       sessions: {
-        "read-progress-proof": { ordinal: 49, messageCount: 50 },
+        "read-progress-proof": { ordinal: 4, messageCount: 5 },
       },
     }));
+    window.IntersectionObserver = class {
+      observe() {}
+      disconnect() {}
+      unobserve() {}
+      takeRecords() { return []; }
+    } as unknown as typeof IntersectionObserver;
   });
   await page.route(
     sessionsRoutePattern,
@@ -159,17 +165,18 @@ test("captures responsive unread state", async ({ page }) => {
   await sessions.goto();
   await sessions.selectFirstSession();
   const unreadIndicator = page.locator(".unread-indicator");
+  const unreadDivider = page.locator(".read-progress-divider");
   await expect(unreadIndicator).toHaveCount(1);
+  await expect(unreadDivider).toBeVisible();
 
   const lint: Record<number, unknown> = {};
   for (const width of [1280, 768, 400]) {
     await page.setViewportSize({ width, height: 720 });
     await expect(unreadIndicator).toHaveCount(1);
-    lint[width] = {
-      sidebar: await page.evaluate(renderLintSnippet(".session-list-scroll")),
-      transcript: await page.evaluate(renderLintSnippet(".message-list-scroll")),
-    };
-    expect(lint[width]).toEqual({ sidebar: [], transcript: [] });
+    await expect(unreadDivider).toBeVisible();
+    const transcript = await page.evaluate(
+      renderLintSnippet(".message-list-scroll"),
+    );
     if (width === 400) {
       await expect(page.getByLabel("Close sidebar")).not.toBeVisible();
       await page.screenshot({
@@ -177,6 +184,11 @@ test("captures responsive unread state", async ({ page }) => {
       });
       await page.getByLabel("Toggle sidebar").click();
       await expect(unreadIndicator).toBeVisible();
+      lint[width] = {
+        sidebar: await page.evaluate(renderLintSnippet(".session-list-scroll")),
+        transcript,
+      };
+      expect(lint[width]).toEqual({ sidebar: [], transcript: [] });
       await page.screenshot({
         path: path.join(artifactDir, "agentsview-T1057-2-after-400-sidebar.png"),
       });
@@ -184,6 +196,12 @@ test("captures responsive unread state", async ({ page }) => {
         element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
       });
       await expect(page.getByLabel("Close sidebar")).not.toBeVisible();
+    } else {
+      lint[width] = {
+        sidebar: await page.evaluate(renderLintSnippet(".session-list-scroll")),
+        transcript,
+      };
+      expect(lint[width]).toEqual({ sidebar: [], transcript: [] });
     }
     await page.screenshot({
       path: path.join(artifactDir, `agentsview-T1057-2-after-${width}.png`),

--- a/frontend/e2e/read-progress.spec.ts
+++ b/frontend/e2e/read-progress.spec.ts
@@ -99,7 +99,9 @@ test("persists read progress until later output is visible", async ({ page }) =>
   await sp.goto();
   await sp.selectFirstSession();
   await expect
-    .poll(() => page.evaluate(() => localStorage.getItem("agentsview-read-progress")))
+    .poll(() => page.evaluate(() =>
+      localStorage.getItem("agentsview-read-progress:session:read-progress")
+    ))
     .toContain('"seenOrdinal":49');
   const initialMessageRequests = messageRequests;
 
@@ -124,7 +126,9 @@ test("persists read progress until later output is visible", async ({ page }) =>
   await expect(unreadDivider).toHaveCount(0);
   await expect.poll(() => messageRequests).toBeGreaterThan(initialMessageRequests);
   await expect
-    .poll(() => page.evaluate(() => localStorage.getItem("agentsview-read-progress")))
+    .poll(() => page.evaluate(() =>
+      localStorage.getItem("agentsview-read-progress:session:read-progress")
+    ))
     .toContain('"seenOrdinal":49');
   await page.reload();
   await sp.goto();
@@ -136,7 +140,9 @@ test("persists read progress until later output is visible", async ({ page }) =>
   });
   await expect(page.getByText("Message 59")).toBeVisible();
   await expect
-    .poll(() => page.evaluate(() => localStorage.getItem("agentsview-read-progress")))
+    .poll(() => page.evaluate(() =>
+      localStorage.getItem("agentsview-read-progress:session:read-progress")
+    ))
     .toContain('"seenOrdinal":59');
   await expect(unreadIndicator).toHaveCount(0);
   await expect(unreadDivider).toHaveCount(0);
@@ -148,12 +154,14 @@ test("acknowledges a trailing system message only after the last displayable row
   session!.message_count = 3;
   session!.latest_display_ordinal = 1;
   await page.addInitScript(() => {
-    localStorage.setItem("agentsview-read-progress", JSON.stringify({
-      version: 1,
-      sessions: {
-        "read-progress-system": { ordinal: 0, messageCount: 1 },
-      },
-    }));
+    localStorage.setItem(
+      "agentsview-read-progress:index",
+      JSON.stringify(["read-progress-system"]),
+    );
+    localStorage.setItem(
+      "agentsview-read-progress:session:read-progress-system",
+      JSON.stringify({ seenOrdinal: 0 }),
+    );
   });
   await page.route(
     sessionsRoutePattern,
@@ -174,7 +182,11 @@ test("acknowledges a trailing system message only after the last displayable row
     element.dispatchEvent(new Event("scroll"));
   });
   await expect
-    .poll(() => page.evaluate(() => localStorage.getItem("agentsview-read-progress")))
+    .poll(() => page.evaluate(() =>
+      localStorage.getItem(
+        "agentsview-read-progress:session:read-progress-system",
+      )
+    ))
     .toContain('"seenOrdinal":1');
 
   await page.locator(".breadcrumb-link").click();
@@ -208,7 +220,11 @@ test("acknowledges a progressive first visit by backend total", async ({ page })
     element.dispatchEvent(new Event("scroll"));
   });
   await expect
-    .poll(() => page.evaluate(() => localStorage.getItem("agentsview-read-progress")))
+    .poll(() => page.evaluate(() =>
+      localStorage.getItem(
+        "agentsview-read-progress:session:read-progress-partial",
+      )
+    ))
     .toContain('"seenOrdinal":3004');
 
   await page.locator(".breadcrumb-link").click();
@@ -226,12 +242,14 @@ test("captures responsive unread state", async ({ page }) => {
   session!.message_count = 60;
   session!.latest_display_ordinal = 59;
   await page.addInitScript(() => {
-    localStorage.setItem("agentsview-read-progress", JSON.stringify({
-      version: 2,
-      sessions: {
-        "read-progress-proof": { seenOrdinal: 4 },
-      },
-    }));
+    localStorage.setItem(
+      "agentsview-read-progress:index",
+      JSON.stringify(["read-progress-proof"]),
+    );
+    localStorage.setItem(
+      "agentsview-read-progress:session:read-progress-proof",
+      JSON.stringify({ seenOrdinal: 4 }),
+    );
     window.IntersectionObserver = class {
       observe() {}
       disconnect() {}

--- a/frontend/e2e/read-progress.spec.ts
+++ b/frontend/e2e/read-progress.spec.ts
@@ -1,4 +1,6 @@
 import { test, expect } from "@playwright/test";
+import { createRequire } from "node:module";
+import path from "node:path";
 import {
   createMockSessions,
   handleSessionsRoute,
@@ -30,11 +32,40 @@ function makeMessages(count: number) {
   }));
 }
 
+function renderLintSnippet(scope: string): string {
+  const lintPath = process.env.PR_RENDER_LINT_PATH;
+  if (!lintPath) throw new Error("PR_RENDER_LINT_PATH is required");
+  const require = createRequire(import.meta.url);
+  return (require(lintPath) as {
+    renderLintSnippet: (selector: string, options: object) => string;
+  }).renderLintSnippet(scope, {
+    checks: ["overlap", "clip", "container-escape", "raw-string", "a11y"],
+  });
+}
+
 test("persists read progress until later output is visible", async ({ page }) => {
   let messageCount = 50;
+  let messageRequests = 0;
   const [session] = createMockSessions(1, "read-progress", () => "project");
   session!.id = "read-progress";
   session!.message_count = messageCount;
+  await page.addInitScript(() => {
+    class TestEventSource extends EventTarget {
+      url: string;
+
+      constructor(url: string) {
+        super();
+        this.url = url;
+        (window as Window & { sessionSources: TestEventSource[] }).sessionSources
+          ??= [];
+        (window as Window & { sessionSources: TestEventSource[] }).sessionSources
+          .push(this);
+      }
+
+      close() {}
+    }
+    window.EventSource = TestEventSource as unknown as typeof EventSource;
+  });
 
   await page.route(
     sessionsRoutePattern,
@@ -43,6 +74,7 @@ test("persists read progress until later output is visible", async ({ page }) =>
   await page.route(
     "**/api/v1/sessions/read-progress/messages*",
     async (route) => {
+      messageRequests += 1;
       await route.fulfill({
         json: { messages: makeMessages(messageCount), count: messageCount },
       });
@@ -55,21 +87,81 @@ test("persists read progress until later output is visible", async ({ page }) =>
   await expect
     .poll(() => page.evaluate(() => localStorage.getItem("agentsview-read-progress")))
     .toContain('"messageCount":50');
+  const initialMessageRequests = messageRequests;
 
   messageCount = 60;
   session!.message_count = messageCount;
-  await page.reload();
-  await sp.goto();
-  await sp.selectFirstSession();
+  await expect
+    .poll(() => page.evaluate(() => (
+      window as Window & { sessionSources: Array<{ url: string }> }
+    ).sessionSources.some((source) => source.url.includes("read-progress/watch"))))
+    .toBe(true);
+  await page.evaluate(() => {
+    const source = (window as Window & {
+      sessionSources: Array<EventTarget & { url: string }>;
+    }).sessionSources.find((entry) => entry.url.includes("read-progress/watch"));
+    source?.dispatchEvent(new Event("session_updated"));
+  });
 
   const unreadIndicator = page.locator(".unread-indicator");
   const unreadDivider = page.locator(".read-progress-divider");
   await expect(unreadIndicator).toHaveCount(1);
-
-  await sp.scroller.evaluate((element) => {
-    element.scrollTop = element.scrollHeight;
-    element.dispatchEvent(new Event("scroll"));
-  });
-  await expect(unreadIndicator).toHaveCount(0);
   await expect(unreadDivider).toHaveCount(0);
+  await expect.poll(() => messageRequests).toBeGreaterThan(initialMessageRequests);
+  await expect
+    .poll(() => page.evaluate(() => localStorage.getItem("agentsview-read-progress")))
+    .toContain('"messageCount":50');
+});
+
+test("captures a visible read-progress divider", async ({ page }) => {
+  const artifactDir = process.env.PR_RENDER_ARTIFACT_DIR;
+  test.skip(
+    !process.env.PR_RENDER_LINT_PATH || !artifactDir,
+    "render proof requires PR_RENDER_LINT_PATH and PR_RENDER_ARTIFACT_DIR",
+  );
+  const [session] = createMockSessions(1, "read-progress-proof", () => "project");
+  session!.id = "read-progress-proof";
+  session!.message_count = 5;
+  await page.addInitScript(() => {
+    localStorage.setItem("agentsview-read-progress", JSON.stringify({
+      version: 1,
+      sessions: {
+        "read-progress-proof": { ordinal: 2, messageCount: 3 },
+      },
+    }));
+  });
+  await page.route(
+    sessionsRoutePattern,
+    handleSessionsRoute([{ sessions: [session!], project: null }]),
+  );
+  await page.route(
+    "**/api/v1/sessions/read-progress-proof/messages*",
+    async (route) => route.fulfill({
+      json: { messages: makeMessages(5), count: 5 },
+    }),
+  );
+
+  const sessions = new SessionsPage(page);
+  await sessions.goto();
+  await sessions.selectFirstSession();
+  const divider = page.locator(".read-progress-divider");
+  await expect(divider).toBeVisible();
+
+  const lint: Record<number, unknown> = {};
+  for (const width of [1280, 768, 400]) {
+    await page.setViewportSize({ width, height: 720 });
+    await expect(divider).toBeVisible();
+    lint[width] = {
+      sidebar: await page.evaluate(renderLintSnippet(".session-list-scroll")),
+      transcript: await page.evaluate(renderLintSnippet(".message-list-scroll")),
+    };
+    expect(lint[width]).toEqual({ sidebar: [], transcript: [] });
+    await page.screenshot({
+      path: path.join(artifactDir, `agentsview-T1057-2-after-${width}.png`),
+    });
+  }
+  await page.screenshot({
+    path: path.join(artifactDir, "agentsview-T1057-2-after.png"),
+  });
+  console.log(`render lint ${JSON.stringify(lint)}`);
 });

--- a/frontend/e2e/read-progress.spec.ts
+++ b/frontend/e2e/read-progress.spec.ts
@@ -62,11 +62,14 @@ test("persists read progress until later output is visible", async ({ page }) =>
   await sp.goto();
   await sp.selectFirstSession();
 
-  await expect(page.getByLabel("Unread messages")).toHaveCount(1);
+  const unreadIndicator = page.locator(".unread-indicator");
+  const unreadDivider = page.locator(".read-progress-divider");
+  await expect(unreadIndicator).toHaveCount(1);
 
   await sp.scroller.evaluate((element) => {
     element.scrollTop = element.scrollHeight;
     element.dispatchEvent(new Event("scroll"));
   });
-  await expect(page.getByLabel("Unread messages")).toHaveCount(0);
+  await expect(unreadIndicator).toHaveCount(0);
+  await expect(unreadDivider).toHaveCount(0);
 });

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1739,5 +1739,9 @@
   "appearance_high_contrast": "High contrast",
   "appearance_on": "On",
   "appearance_off": "Off",
-  "appearance_text_size": "Text size"
+  "appearance_text_size": "Text size",
+  "read_progress_boundary": "Read progress boundary",
+  "read_progress_new_messages": "New messages",
+  "read_progress_earlier_messages": "Earlier messages",
+  "read_progress_unread_messages": "Unread messages"
 }

--- a/frontend/messages/ko.json
+++ b/frontend/messages/ko.json
@@ -1703,5 +1703,9 @@
   "appearance_high_contrast": "고대비",
   "appearance_on": "켜짐",
   "appearance_off": "꺼짐",
-  "appearance_text_size": "텍스트 크기"
+  "appearance_text_size": "텍스트 크기",
+  "read_progress_boundary": "읽기 진행 경계",
+  "read_progress_new_messages": "새 메시지",
+  "read_progress_earlier_messages": "이전 메시지",
+  "read_progress_unread_messages": "읽지 않은 메시지"
 }

--- a/frontend/messages/zh-CN.json
+++ b/frontend/messages/zh-CN.json
@@ -1703,5 +1703,9 @@
   "appearance_high_contrast": "高对比度",
   "appearance_on": "开",
   "appearance_off": "关",
-  "appearance_text_size": "文字大小"
+  "appearance_text_size": "文字大小",
+  "read_progress_boundary": "阅读进度边界",
+  "read_progress_new_messages": "新消息",
+  "read_progress_earlier_messages": "较早消息",
+  "read_progress_unread_messages": "未读消息"
 }

--- a/frontend/messages/zh-TW.json
+++ b/frontend/messages/zh-TW.json
@@ -1703,5 +1703,9 @@
   "appearance_high_contrast": "高對比度",
   "appearance_on": "開",
   "appearance_off": "關",
-  "appearance_text_size": "文字大小"
+  "appearance_text_size": "文字大小",
+  "read_progress_boundary": "閱讀進度邊界",
+  "read_progress_new_messages": "新訊息",
+  "read_progress_earlier_messages": "較早訊息",
+  "read_progress_unread_messages": "未讀訊息"
 }

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -423,12 +423,15 @@
   // the URL with localStorage-restored filters.
   $effect(() => {
     const route = router.route;
+    const currentUrlSessionId = router.sessionId;
+    const filterParams = filtersToParams(sessions.filters);
+    const currentParams = router.params;
     untrack(() => {
       const action = resolveSessionRouteWriteBack({
         route,
-        currentUrlSessionId: router.sessionId,
-        filterParams: filtersToParams(sessions.filters),
-        currentParams: router.params,
+        currentUrlSessionId,
+        filterParams,
+        currentParams,
       });
       if (action.kind === "none") return;
       if (action.clearYoke) {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -80,6 +80,7 @@
   import { setupVisibilityHealthCheck } from "./lib/utils/health.js";
   import { registerShortcuts } from "./lib/utils/keyboard.js";
   import { shouldAutoSwitchTranscriptModeToNormal } from "./lib/utils/transcript-mode.js";
+  import { isSystemMessage } from "./lib/utils/messages.js";
   import {
     filterParamsEqual,
     hasFilterParams,
@@ -173,7 +174,7 @@
     const messageSessionId = messages.sessionId;
     const loading = messages.loading;
     const initialLoadSucceeded = messages.initialLoadSucceeded;
-    const displayMessages = messages.messages.filter((message) => !message.is_system);
+    const displayMessages = messages.messages.filter((message) => !isSystemMessage(message));
     const displayOrdinal = displayMessages.at(-1)?.ordinal ?? -1;
     const displayCount = displayMessages.length;
     const eligibleAcknowledgedTotal = messages.hasCompleteMessageRange()

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -75,6 +75,7 @@
   import { settings } from "./lib/stores/settings.svelte.js";
   import { yokedDates } from "./lib/stores/yokedDates.svelte.js";
   import { m } from "./lib/i18n/index.js";
+  import { readProgress } from "./lib/stores/read-progress.svelte.js";
   import { setAuthToken, getAuthToken, setServerUrl, getBase } from "./lib/api/runtime.js";
   import { setupVisibilityHealthCheck } from "./lib/utils/health.js";
   import { registerShortcuts } from "./lib/utils/keyboard.js";
@@ -163,6 +164,20 @@
         sync.unwatchSession();
         pins.clearSession();
       }
+    });
+  });
+
+  // First visits start fully read; visible rows advance later SSE output.
+  $effect(() => {
+    const id = sessions.activeSessionId;
+    const messageSessionId = messages.sessionId;
+    const loading = messages.loading;
+    const loaded = messages.messages;
+    const messageCount = messages.messageCount;
+    untrack(() => {
+      if (!id || id !== messageSessionId || loading) return;
+      const latest = loaded[loaded.length - 1]?.ordinal ?? -1;
+      readProgress.baseline(id, latest, messageCount);
     });
   });
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -172,10 +172,11 @@
     const id = sessions.activeSessionId;
     const messageSessionId = messages.sessionId;
     const loading = messages.loading;
+    const initialLoadSucceeded = messages.initialLoadSucceeded;
     const loaded = messages.messages;
     const messageCount = messages.messageCount;
     untrack(() => {
-      if (!id || id !== messageSessionId || loading) return;
+      if (!id || id !== messageSessionId || loading || !initialLoadSucceeded) return;
       const latest = loaded[loaded.length - 1]?.ordinal ?? -1;
       readProgress.baseline(id, latest, messageCount);
     });

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -174,10 +174,15 @@
     const loading = messages.loading;
     const initialLoadSucceeded = messages.initialLoadSucceeded;
     const latestDisplayOrdinal = messages.latestDisplayOrdinal;
+    const latestDisplayContentLength = messages.latestDisplayContentLength;
     untrack(() => {
       if (!id || id !== messageSessionId || loading || !initialLoadSucceeded ||
         latestDisplayOrdinal === undefined) return;
-      readProgress.baseline(id, latestDisplayOrdinal);
+      readProgress.baseline(
+        id,
+        latestDisplayOrdinal,
+        latestDisplayContentLength,
+      );
     });
   });
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -173,12 +173,20 @@
     const messageSessionId = messages.sessionId;
     const loading = messages.loading;
     const initialLoadSucceeded = messages.initialLoadSucceeded;
-    const loaded = messages.messages;
-    const messageCount = messages.messageCount;
+    const displayMessages = messages.messages.filter((message) => !message.is_system);
+    const displayOrdinal = displayMessages.at(-1)?.ordinal ?? -1;
+    const displayCount = displayMessages.length;
+    const eligibleAcknowledgedTotal = messages.hasCompleteMessageRange()
+      ? messages.messageCount
+      : undefined;
     untrack(() => {
       if (!id || id !== messageSessionId || loading || !initialLoadSucceeded) return;
-      const latest = loaded[loaded.length - 1]?.ordinal ?? -1;
-      readProgress.baseline(id, latest, messageCount);
+      readProgress.baseline(
+        id,
+        displayOrdinal,
+        displayCount,
+        eligibleAcknowledgedTotal,
+      );
     });
   });
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -39,6 +39,12 @@
 
 <script lang="ts">
   import { onMount, untrack } from "svelte";
+  import {
+    getLastRecentlyDeletedBatch,
+    resolveSessionRouteSync,
+    resolveSessionRouteWriteBack,
+    shouldBaselineReadProgress,
+  } from "./app-logic.js";
   import AppHeader from "./lib/components/layout/AppHeader.svelte";
   import ThreeColumnLayout from "./lib/components/layout/ThreeColumnLayout.svelte";
   import SessionBreadcrumb from "./lib/components/layout/SessionBreadcrumb.svelte";
@@ -81,11 +87,7 @@
   import { registerShortcuts } from "./lib/utils/keyboard.js";
   import { shouldAutoSwitchTranscriptModeToNormal } from "./lib/utils/transcript-mode.js";
   import {
-    filterParamsEqual,
     hasFilterParams,
-    sessionDateIntentCleared,
-    sessionRouteParamsForDetailExit,
-    sessionRouteParamsForFilters,
   } from "./lib/stores/sessionRouteParams.js";
 
   let globalAuthToken: string = $state("");
@@ -176,8 +178,13 @@
     const latestDisplayOrdinal = messages.latestDisplayOrdinal;
     const latestDisplayContentLength = messages.latestDisplayContentLength;
     untrack(() => {
-      if (!id || id !== messageSessionId || loading || !initialLoadSucceeded ||
-        latestDisplayOrdinal === undefined) return;
+      if (!shouldBaselineReadProgress({
+        activeSessionId: id,
+        messageSessionId,
+        loading,
+        initialLoadSucceeded,
+        latestDisplayOrdinal,
+      }) || !id || latestDisplayOrdinal === undefined) return;
       readProgress.baseline(
         id,
         latestDisplayOrdinal,
@@ -304,14 +311,6 @@
     messageListRef?.scrollToOrdinal(ordinal);
   }
 
-  function clearYokeForClearedSessionDates(
-    nextParams: Record<string, string>,
-  ): void {
-    if (sessionDateIntentCleared(router.params, nextParams)) {
-      yokedDates.clear();
-    }
-  }
-
   let lastDetailFilterParamsSignature: string | null = $state(null);
 
   // React to route changes: reload sessions and apply URL params.
@@ -382,52 +381,37 @@
     const activeId = sessions.activeSessionId;
     const currentUrlSessionId = router.sessionId;
     const filterParams = filtersToParams(sessions.filters);
-    const filterParamsSignature = JSON.stringify(filterParams);
     untrack(() => {
-      if (router.route !== "sessions") {
-        lastDetailFilterParamsSignature = null;
-        return;
+      const action = resolveSessionRouteSync({
+        route: router.route,
+        activeSessionId: activeId,
+        currentUrlSessionId,
+        filterParams,
+        currentParams: router.params,
+        lastDetailFilterParamsSignature,
+      });
+
+      if (action.clearYoke) {
+        yokedDates.clear();
       }
-      if (activeId) {
-        const nextParams = sessionRouteParamsForFilters(
-          filterParams,
-          router.params,
-        );
-        if (activeId === currentUrlSessionId) {
-          if (
-            lastDetailFilterParamsSignature !== null &&
-            lastDetailFilterParamsSignature !== filterParamsSignature &&
-            !filterParamsEqual(router.params, nextParams)
-          ) {
-            clearYokeForClearedSessionDates(nextParams);
-            router.replaceParams(nextParams);
-          }
-          lastDetailFilterParamsSignature = filterParamsSignature;
+
+      switch (action.kind) {
+        case "replace-params":
+          router.replaceParams(action.nextParams);
+          lastDetailFilterParamsSignature = action.nextSignature;
           return;
-        }
-        clearYokeForClearedSessionDates(nextParams);
-        router.navigateToSession(activeId, nextParams);
-        lastDetailFilterParamsSignature = filterParamsSignature;
-      } else {
-        if (currentUrlSessionId === null) {
-          lastDetailFilterParamsSignature = null;
+        case "navigate-to-session":
+          router.navigateToSession(action.sessionId, action.nextParams);
+          lastDetailFilterParamsSignature = action.nextSignature;
           return;
-        }
-        const filterChangedOnDetail =
-          lastDetailFilterParamsSignature !== null &&
-          lastDetailFilterParamsSignature !== filterParamsSignature;
-        const nextParams = filterChangedOnDetail
-          ? sessionRouteParamsForFilters(
-              filterParams,
-              router.params,
-            )
-          : sessionRouteParamsForDetailExit(
-              filterParams,
-              router.params,
-            );
-        clearYokeForClearedSessionDates(nextParams);
-        router.navigateFromSession(nextParams);
-        lastDetailFilterParamsSignature = null;
+        case "navigate-from-session":
+          router.navigateFromSession(action.nextParams);
+          lastDetailFilterParamsSignature = action.nextSignature;
+          return;
+        case "reset-signature":
+        case "none":
+          lastDetailFilterParamsSignature = action.nextSignature;
+          return;
       }
     });
   });
@@ -439,16 +423,18 @@
   // the URL with localStorage-restored filters.
   $effect(() => {
     const route = router.route;
-    const newParams = sessionRouteParamsForFilters(
-      filtersToParams(sessions.filters),
-      router.params,
-    );
     untrack(() => {
-      if (route !== "sessions") return;
-      if (router.sessionId) return;
-      if (filterParamsEqual(router.params, newParams)) return;
-      clearYokeForClearedSessionDates(newParams);
-      router.replaceParams(newParams);
+      const action = resolveSessionRouteWriteBack({
+        route,
+        currentUrlSessionId: router.sessionId,
+        filterParams: filtersToParams(sessions.filters),
+        currentParams: router.params,
+      });
+      if (action.kind === "none") return;
+      if (action.clearYoke) {
+        yokedDates.clear();
+      }
+      router.replaceParams(action.nextParams);
     });
   });
 
@@ -628,7 +614,7 @@
       onclick={async (e) => {
         const btn = e.currentTarget;
         if (btn.disabled) return;
-        const last = sessions.recentlyDeleted[sessions.recentlyDeleted.length - 1];
+        const last = getLastRecentlyDeletedBatch(sessions.recentlyDeleted);
         if (!last) return;
         btn.disabled = true;
         try {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -80,7 +80,6 @@
   import { setupVisibilityHealthCheck } from "./lib/utils/health.js";
   import { registerShortcuts } from "./lib/utils/keyboard.js";
   import { shouldAutoSwitchTranscriptModeToNormal } from "./lib/utils/transcript-mode.js";
-  import { isSystemMessage } from "./lib/utils/messages.js";
   import {
     filterParamsEqual,
     hasFilterParams,
@@ -174,18 +173,11 @@
     const messageSessionId = messages.sessionId;
     const loading = messages.loading;
     const initialLoadSucceeded = messages.initialLoadSucceeded;
-    const displayMessages = messages.messages.filter((message) => !isSystemMessage(message));
-    const displayOrdinal = displayMessages.at(-1)?.ordinal ?? -1;
-    const displayCount = displayMessages.length;
-    const eligibleAcknowledgedTotal = messages.messageCount;
+    const latestDisplayOrdinal = messages.latestDisplayOrdinal;
     untrack(() => {
-      if (!id || id !== messageSessionId || loading || !initialLoadSucceeded) return;
-      readProgress.baseline(
-        id,
-        displayOrdinal,
-        displayCount,
-        eligibleAcknowledgedTotal,
-      );
+      if (!id || id !== messageSessionId || loading || !initialLoadSucceeded ||
+        latestDisplayOrdinal === undefined) return;
+      readProgress.baseline(id, latestDisplayOrdinal);
     });
   });
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -177,9 +177,7 @@
     const displayMessages = messages.messages.filter((message) => !isSystemMessage(message));
     const displayOrdinal = displayMessages.at(-1)?.ordinal ?? -1;
     const displayCount = displayMessages.length;
-    const eligibleAcknowledgedTotal = messages.hasCompleteMessageRange()
-      ? messages.messageCount
-      : undefined;
+    const eligibleAcknowledgedTotal = messages.messageCount;
     untrack(() => {
       if (!id || id !== messageSessionId || loading || !initialLoadSucceeded) return;
       readProgress.baseline(

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -1,25 +1,38 @@
 import { describe, expect, it } from "vite-plus/test";
 import { hasVisibleSegments } from "./lib/utils/content-parser.js";
 import { findUserPromptOrdinal } from "./App.svelte";
-import sourceRaw from "./App.svelte?raw";
+import {
+  getLastRecentlyDeletedBatch,
+  resolveSessionRouteSync,
+  resolveSessionRouteWriteBack,
+  shouldBaselineReadProgress,
+} from "./app-logic.js";
 import { SESSION_FILTER_KEYS } from "./lib/stores/sessionRouteParams.js";
 import type { Message } from "./lib/api/types.js";
 
-const source = sourceRaw.replace(/\r\n/g, "\n");
-
-function appSourceSlice(startMarker: string, endMarker: string): string {
-  const start = source.indexOf(startMarker);
-  expect(start).toBeGreaterThan(-1);
-  const end = source.indexOf(endMarker, start);
-  expect(end).toBeGreaterThan(start);
-  return source.slice(start, end);
-}
-
 describe("App session URL date state", () => {
   it("baselines read progress from successful session metadata", () => {
-    expect(source).toContain("const latestDisplayOrdinal = messages.latestDisplayOrdinal;");
-    expect(source).toContain("latestDisplayOrdinal === undefined");
-    expect(source).toContain("readProgress.baseline(id, latestDisplayOrdinal);");
+    expect(shouldBaselineReadProgress({
+      activeSessionId: "s1",
+      messageSessionId: "s1",
+      loading: false,
+      initialLoadSucceeded: true,
+      latestDisplayOrdinal: 7,
+    })).toBe(true);
+    expect(shouldBaselineReadProgress({
+      activeSessionId: "s1",
+      messageSessionId: "s1",
+      loading: false,
+      initialLoadSucceeded: true,
+      latestDisplayOrdinal: undefined,
+    })).toBe(false);
+    expect(shouldBaselineReadProgress({
+      activeSessionId: "s1",
+      messageSessionId: "s2",
+      loading: false,
+      initialLoadSucceeded: true,
+      latestDisplayOrdinal: 7,
+    })).toBe(false);
   });
 
   it("treats rolling window and termination as sessions route params", () => {
@@ -28,141 +41,242 @@ describe("App session URL date state", () => {
   });
 
   it("preserves rolling window dates when writing sessions URLs", () => {
-    expect(source).toContain("sessionRouteParamsForFilters(");
-    expect(source).toContain("router.navigateFromSession(nextParams)");
-    expect(source).toContain(
-      "const newParams = sessionRouteParamsForFilters(",
-    );
-    expect(source).not.toContain(
-      "navigateFromSession(filtersToParams(sessions.filters))",
-    );
-    expect(source).not.toContain(
-      "const newParams = filtersToParams(sessions.filters);",
-    );
+    const action = resolveSessionRouteWriteBack({
+      route: "sessions",
+      currentUrlSessionId: null,
+      currentParams: {
+        window_days: "30",
+        date_from: "2026-05-22",
+        date_to: "2026-06-20",
+      },
+      filterParams: {
+        termination: "success",
+        date_from: "2026-05-22",
+        date_to: "2026-06-20",
+      },
+      now: new Date("2026-06-20T12:00:00Z"),
+    });
+
+    expect(action).toMatchObject({
+      kind: "replace-params",
+      nextParams: {
+        window_days: "30",
+        termination: "success",
+        date_from: "2026-05-22",
+        date_to: "2026-06-20",
+      },
+      clearYoke: false,
+    });
   });
 
   it("preserves rolling window dates when entering session detail", () => {
-    const syncUrlIndex = source.indexOf("// Sync active session to URL.");
-    const navigateFromSessionIndex = source.indexOf(
-      "router.navigateFromSession",
-      syncUrlIndex,
-    );
-    const activeSessionBranch = source.slice(
-      syncUrlIndex,
-      navigateFromSessionIndex,
-    );
+    const action = resolveSessionRouteSync({
+      route: "sessions",
+      activeSessionId: "session-1",
+      currentUrlSessionId: null,
+      currentParams: {
+        window_days: "30",
+        date_from: "2026-05-22",
+        date_to: "2026-06-20",
+      },
+      filterParams: {
+        date_from: "2026-05-22",
+        date_to: "2026-06-20",
+      },
+      lastDetailFilterParamsSignature: null,
+      now: new Date("2026-06-20T12:00:00Z"),
+    });
 
-    expect(activeSessionBranch).toContain(
-      "const nextParams = sessionRouteParamsForFilters(",
-    );
-    expect(activeSessionBranch).toContain(
-      "router.navigateToSession(activeId, nextParams)",
-    );
-    expect(activeSessionBranch).not.toContain(
-      "router.navigateToSession(activeId);",
-    );
+    expect(action).toMatchObject({
+      kind: "navigate-to-session",
+      sessionId: "session-1",
+      nextParams: {
+        window_days: "30",
+        date_from: "2026-05-22",
+        date_to: "2026-06-20",
+      },
+      nextSignature: JSON.stringify({
+        date_from: "2026-05-22",
+        date_to: "2026-06-20",
+      }),
+      clearYoke: false,
+    });
   });
 
   it("preserves direct detail URL params when leaving session detail", () => {
-    const syncUrlIndex = source.indexOf("// Sync active session to URL.");
-    const navigateFromSessionIndex = source.indexOf(
-      "router.navigateFromSession",
-      syncUrlIndex,
-    );
-    const inactiveSessionBranch = source.slice(
-      navigateFromSessionIndex - 260,
-      navigateFromSessionIndex + 80,
-    );
+    const action = resolveSessionRouteSync({
+      route: "sessions",
+      activeSessionId: null,
+      currentUrlSessionId: "session-1",
+      currentParams: {
+        window_days: "30",
+        termination: "error",
+        msg: "99",
+      },
+      filterParams: {
+        project: "agentsview",
+      },
+      lastDetailFilterParamsSignature: null,
+    });
 
-    expect(source).toContain("sessionRouteParamsForDetailExit");
-    expect(inactiveSessionBranch).toContain(
-      ": sessionRouteParamsForDetailExit(",
-    );
-    expect(inactiveSessionBranch).toContain(
-      "router.navigateFromSession(nextParams)",
-    );
+    expect(action).toMatchObject({
+      kind: "navigate-from-session",
+      nextParams: {
+        window_days: "30",
+        termination: "error",
+      },
+      clearYoke: false,
+    });
   });
 
   it("updates detail URL params after explicit filter changes", () => {
-    const syncUrlBlock = appSourceSlice(
-      "// Sync active session to URL.",
-      "// URL write-back",
-    );
+    const filterParams = {
+      termination: "success",
+      date_from: "2026-05-22",
+      date_to: "2026-06-20",
+    };
+    const action = resolveSessionRouteSync({
+      route: "sessions",
+      activeSessionId: "session-1",
+      currentUrlSessionId: "session-1",
+      currentParams: {
+        window_days: "30",
+        termination: "error",
+        date_from: "2026-05-22",
+        date_to: "2026-06-20",
+      },
+      filterParams,
+      lastDetailFilterParamsSignature: JSON.stringify({
+        termination: "error",
+        date_from: "2026-05-22",
+        date_to: "2026-06-20",
+      }),
+      now: new Date("2026-06-20T12:00:00Z"),
+    });
 
-    expect(source).toContain(
-      "let lastDetailFilterParamsSignature: string | null = $state(null);",
-    );
-    expect(syncUrlBlock).toContain("const filterParams = filtersToParams(");
-    expect(syncUrlBlock).toContain(
-      "lastDetailFilterParamsSignature !== null &&",
-    );
-    expect(syncUrlBlock).toContain("router.replaceParams(nextParams);");
-    expect(syncUrlBlock).toContain(
-      "lastDetailFilterParamsSignature = filterParamsSignature;",
-    );
+    expect(action).toMatchObject({
+      kind: "replace-params",
+      nextParams: {
+        window_days: "30",
+        termination: "success",
+        date_from: "2026-05-22",
+        date_to: "2026-06-20",
+      },
+      nextSignature: JSON.stringify(filterParams),
+      clearYoke: false,
+    });
   });
 
   it("does not preserve stale detail params after filter changes", () => {
-    const syncUrlBlock = appSourceSlice(
-      "// Sync active session to URL.",
-      "// URL write-back",
-    );
+    const filterParams = {
+      date_from: "2026-06-10",
+      date_to: "2026-06-20",
+    };
+    const action = resolveSessionRouteSync({
+      route: "sessions",
+      activeSessionId: null,
+      currentUrlSessionId: "session-1",
+      currentParams: {
+        msg: "12",
+        date_from: "2026-05-22",
+        date_to: "2026-06-20",
+      },
+      filterParams,
+      lastDetailFilterParamsSignature: JSON.stringify({
+        date_from: "2026-05-22",
+        date_to: "2026-06-20",
+      }),
+      now: new Date("2026-06-20T12:00:00Z"),
+    });
 
-    expect(syncUrlBlock).toContain("const filterChangedOnDetail =");
-    expect(syncUrlBlock).toContain(
-      "filterChangedOnDetail\n          ? sessionRouteParamsForFilters(",
-    );
-    expect(syncUrlBlock).toContain(
-      ": sessionRouteParamsForDetailExit(",
-    );
+    expect(action).toMatchObject({
+      kind: "navigate-from-session",
+      nextParams: filterParams,
+      clearYoke: false,
+    });
   });
 
   it("clears stored yoke when session date params are removed while analytics is unmounted", () => {
-    const syncUrlBlock = appSourceSlice(
-      "// Sync active session to URL.",
-      "// URL write-back",
-    );
-    const writeBackBlock = appSourceSlice(
-      "// URL write-back",
-      "function showAbout",
-    );
+    const syncAction = resolveSessionRouteSync({
+      route: "sessions",
+      activeSessionId: null,
+      currentUrlSessionId: "session-1",
+      currentParams: {
+        window_days: "30",
+        date_from: "2026-05-22",
+        date_to: "2026-06-20",
+      },
+      filterParams: {
+        project: "agentsview",
+      },
+      lastDetailFilterParamsSignature: JSON.stringify({
+        date_from: "2026-05-22",
+        date_to: "2026-06-20",
+      }),
+    });
+    const writeBackAction = resolveSessionRouteWriteBack({
+      route: "sessions",
+      currentUrlSessionId: null,
+      currentParams: {
+        window_days: "30",
+        date_from: "2026-05-22",
+        date_to: "2026-06-20",
+      },
+      filterParams: {
+        agent: "claude",
+      },
+    });
 
-    expect(source).toContain("import { yokedDates");
-    expect(source).toContain("function clearYokeForClearedSessionDates");
-    expect(source).toContain("sessionDateIntentCleared(");
-    expect(source).toContain("yokedDates.clear();");
-    expect(syncUrlBlock).toContain(
-      "clearYokeForClearedSessionDates(nextParams);",
-    );
-    expect(writeBackBlock).toContain(
-      "clearYokeForClearedSessionDates(newParams);",
-    );
+    expect(syncAction.clearYoke).toBe(true);
+    expect(writeBackAction).toMatchObject({
+      kind: "replace-params",
+      nextParams: { agent: "claude" },
+      clearYoke: true,
+    });
   });
 
   it("clears detail filter signatures outside session detail routes", () => {
-    const syncUrlBlock = appSourceSlice(
-      "// Sync active session to URL.",
-      "// URL write-back",
-    );
-
-    expect(syncUrlBlock).toContain(
-      'if (router.route !== "sessions") {\n        lastDetailFilterParamsSignature = null;',
-    );
-    expect(syncUrlBlock).toContain(
-      "if (currentUrlSessionId === null) {\n          lastDetailFilterParamsSignature = null;",
-    );
+    expect(resolveSessionRouteSync({
+      route: "usage",
+      activeSessionId: "session-1",
+      currentUrlSessionId: "session-1",
+      currentParams: {},
+      filterParams: {},
+      lastDetailFilterParamsSignature: "old",
+    })).toEqual({
+      kind: "reset-signature",
+      nextSignature: null,
+      clearYoke: false,
+    });
+    expect(resolveSessionRouteSync({
+      route: "sessions",
+      activeSessionId: null,
+      currentUrlSessionId: null,
+      currentParams: {},
+      filterParams: {},
+      lastDetailFilterParamsSignature: "old",
+    })).toEqual({
+      kind: "reset-signature",
+      nextSignature: null,
+      clearYoke: false,
+    });
   });
 
   it("restores the full recently deleted batch from the undo toast", () => {
-    const undoBlock = appSourceSlice(
-      "{#if sessions.recentlyDeleted.length > 0}",
-      "</div>\n{/if}",
-    );
+    const batch = {
+      key: 2,
+      ids: ["session-2", "session-3"],
+      timer: {} as ReturnType<typeof setTimeout>,
+    };
 
-    expect(undoBlock).toContain(
-      "await sessions.restoreRecentlyDeleted(last);",
-    );
-    expect(undoBlock).not.toContain("await sessions.restoreSession(last.id);");
+    expect(getLastRecentlyDeletedBatch([
+      {
+        key: 1,
+        ids: ["session-1"],
+        timer: {} as ReturnType<typeof setTimeout>,
+      },
+      batch,
+    ])).toBe(batch);
   });
 });
 

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -1,10 +1,8 @@
 import { describe, expect, it } from "vite-plus/test";
-import type { Message } from "./lib/api/types.js";
 import { hasVisibleSegments } from "./lib/utils/content-parser.js";
 import { findUserPromptOrdinal } from "./App.svelte";
 import sourceRaw from "./App.svelte?raw";
 import { SESSION_FILTER_KEYS } from "./lib/stores/sessionRouteParams.js";
-import { isSystemMessage } from "./lib/utils/messages.js";
 import type { Message } from "./lib/api/types.js";
 
 const source = sourceRaw.replace(/\r\n/g, "\n");
@@ -18,18 +16,10 @@ function appSourceSlice(startMarker: string, endMarker: string): string {
 }
 
 describe("App session URL date state", () => {
-  it("uses the transcript classifier for visible system subtypes in its baseline", () => {
-    const visibleContinuation = {
-      is_system: true,
-      source_subtype: "continuation",
-    } as Message;
-
-    expect(isSystemMessage(visibleContinuation)).toBe(false);
-    expect(source).toContain('import { isSystemMessage } from "./lib/utils/messages.js";');
-    expect(source).toContain(
-      "messages.messages.filter((message) => !isSystemMessage(message))",
-    );
-    expect(source).toContain("const eligibleAcknowledgedTotal = messages.messageCount;");
+  it("baselines read progress from successful session metadata", () => {
+    expect(source).toContain("const latestDisplayOrdinal = messages.latestDisplayOrdinal;");
+    expect(source).toContain("latestDisplayOrdinal === undefined");
+    expect(source).toContain("readProgress.baseline(id, latestDisplayOrdinal);");
   });
 
   it("treats rolling window and termination as sessions route params", () => {

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -29,6 +29,7 @@ describe("App session URL date state", () => {
     expect(source).toContain(
       "messages.messages.filter((message) => !isSystemMessage(message))",
     );
+    expect(source).toContain("const eligibleAcknowledgedTotal = messages.messageCount;");
   });
 
   it("treats rolling window and termination as sessions route params", () => {

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -4,6 +4,8 @@ import { hasVisibleSegments } from "./lib/utils/content-parser.js";
 import { findUserPromptOrdinal } from "./App.svelte";
 import sourceRaw from "./App.svelte?raw";
 import { SESSION_FILTER_KEYS } from "./lib/stores/sessionRouteParams.js";
+import { isSystemMessage } from "./lib/utils/messages.js";
+import type { Message } from "./lib/api/types.js";
 
 const source = sourceRaw.replace(/\r\n/g, "\n");
 
@@ -16,6 +18,19 @@ function appSourceSlice(startMarker: string, endMarker: string): string {
 }
 
 describe("App session URL date state", () => {
+  it("uses the transcript classifier for visible system subtypes in its baseline", () => {
+    const visibleContinuation = {
+      is_system: true,
+      source_subtype: "continuation",
+    } as Message;
+
+    expect(isSystemMessage(visibleContinuation)).toBe(false);
+    expect(source).toContain('import { isSystemMessage } from "./lib/utils/messages.js";');
+    expect(source).toContain(
+      "messages.messages.filter((message) => !isSystemMessage(message))",
+    );
+  });
+
   it("treats rolling window and termination as sessions route params", () => {
     expect(SESSION_FILTER_KEYS.has("window_days")).toBe(true);
     expect(SESSION_FILTER_KEYS.has("termination")).toBe(true);

--- a/frontend/src/app-logic.ts
+++ b/frontend/src/app-logic.ts
@@ -1,0 +1,208 @@
+import {
+  filterParamsEqual,
+  sessionDateIntentCleared,
+  sessionRouteParamsForDetailExit,
+  sessionRouteParamsForFilters,
+} from "./lib/stores/sessionRouteParams.js";
+
+export interface ReadProgressBaselineState {
+  activeSessionId: string | null;
+  messageSessionId: string | null;
+  loading: boolean;
+  initialLoadSucceeded: boolean;
+  latestDisplayOrdinal: number | null | undefined;
+}
+
+export function shouldBaselineReadProgress(
+  state: ReadProgressBaselineState,
+): boolean {
+  return !!state.activeSessionId &&
+    state.activeSessionId === state.messageSessionId &&
+    !state.loading &&
+    state.initialLoadSucceeded &&
+    state.latestDisplayOrdinal !== undefined;
+}
+
+type SessionRouteActionBase = {
+  clearYoke: boolean;
+};
+
+export type SessionRouteSyncAction =
+  | ({
+      kind: "reset-signature";
+      nextSignature: null;
+    } & SessionRouteActionBase)
+  | ({
+      kind: "none";
+      nextSignature: string | null;
+    } & SessionRouteActionBase)
+  | ({
+      kind: "replace-params";
+      nextParams: Record<string, string>;
+      nextSignature: string;
+    } & SessionRouteActionBase)
+  | ({
+      kind: "navigate-to-session";
+      sessionId: string;
+      nextParams: Record<string, string>;
+      nextSignature: string;
+    } & SessionRouteActionBase)
+  | ({
+      kind: "navigate-from-session";
+      nextParams: Record<string, string>;
+      nextSignature: null;
+    } & SessionRouteActionBase);
+
+export interface SessionRouteSyncState {
+  route: string;
+  activeSessionId: string | null;
+  currentUrlSessionId: string | null;
+  filterParams: Record<string, string>;
+  currentParams: Record<string, string>;
+  lastDetailFilterParamsSignature: string | null;
+  now?: Date;
+}
+
+export function resolveSessionRouteSync(
+  state: SessionRouteSyncState,
+): SessionRouteSyncAction {
+  const {
+    route,
+    activeSessionId,
+    currentUrlSessionId,
+    filterParams,
+    currentParams,
+    lastDetailFilterParamsSignature,
+    now,
+  } = state;
+  const filterParamsSignature = JSON.stringify(filterParams);
+
+  if (route !== "sessions") {
+    return {
+      kind: "reset-signature",
+      nextSignature: null,
+      clearYoke: false,
+    };
+  }
+
+  if (activeSessionId) {
+    const nextParams = sessionRouteParamsForFilters(
+      filterParams,
+      currentParams,
+      now,
+    );
+
+    if (activeSessionId === currentUrlSessionId) {
+      if (
+        lastDetailFilterParamsSignature !== null &&
+        lastDetailFilterParamsSignature !== filterParamsSignature &&
+        !filterParamsEqual(currentParams, nextParams)
+      ) {
+        return {
+          kind: "replace-params",
+          nextParams,
+          nextSignature: filterParamsSignature,
+          clearYoke: sessionDateIntentCleared(currentParams, nextParams),
+        };
+      }
+
+      return {
+        kind: "none",
+        nextSignature: filterParamsSignature,
+        clearYoke: false,
+      };
+    }
+
+    return {
+      kind: "navigate-to-session",
+      sessionId: activeSessionId,
+      nextParams,
+      nextSignature: filterParamsSignature,
+      clearYoke: sessionDateIntentCleared(currentParams, nextParams),
+    };
+  }
+
+  if (currentUrlSessionId === null) {
+    return {
+      kind: "reset-signature",
+      nextSignature: null,
+      clearYoke: false,
+    };
+  }
+
+  const filterChangedOnDetail =
+    lastDetailFilterParamsSignature !== null &&
+    lastDetailFilterParamsSignature !== filterParamsSignature;
+  const nextParams = filterChangedOnDetail
+    ? sessionRouteParamsForFilters(filterParams, currentParams, now)
+    : sessionRouteParamsForDetailExit(filterParams, currentParams);
+
+  return {
+    kind: "navigate-from-session",
+    nextParams,
+    nextSignature: null,
+    clearYoke: sessionDateIntentCleared(currentParams, nextParams),
+  };
+}
+
+export type SessionRouteWriteBackAction =
+  | {
+      kind: "none";
+      clearYoke: false;
+    }
+  | {
+      kind: "replace-params";
+      nextParams: Record<string, string>;
+      clearYoke: boolean;
+    };
+
+export interface SessionRouteWriteBackState {
+  route: string;
+  currentUrlSessionId: string | null;
+  filterParams: Record<string, string>;
+  currentParams: Record<string, string>;
+  now?: Date;
+}
+
+export function resolveSessionRouteWriteBack(
+  state: SessionRouteWriteBackState,
+): SessionRouteWriteBackAction {
+  const {
+    route,
+    currentUrlSessionId,
+    filterParams,
+    currentParams,
+    now,
+  } = state;
+
+  if (route !== "sessions" || currentUrlSessionId !== null) {
+    return {
+      kind: "none",
+      clearYoke: false,
+    };
+  }
+
+  const nextParams = sessionRouteParamsForFilters(
+    filterParams,
+    currentParams,
+    now,
+  );
+  if (filterParamsEqual(currentParams, nextParams)) {
+    return {
+      kind: "none",
+      clearYoke: false,
+    };
+  }
+
+  return {
+    kind: "replace-params",
+    nextParams,
+    clearYoke: sessionDateIntentCleared(currentParams, nextParams),
+  };
+}
+
+export function getLastRecentlyDeletedBatch<T>(
+  batches: readonly T[],
+): T | null {
+  return batches.at(-1) ?? null;
+}

--- a/frontend/src/lib/api/generated/models/DbSession.ts
+++ b/frontend/src/lib/api/generated/models/DbSession.ts
@@ -31,6 +31,7 @@ export type DbSession = {
   id: string;
   is_automated: boolean;
   is_truncated?: boolean;
+  latest_display_ordinal: number | null;
   local_modified_at?: string;
   machine: string;
   message_count: number;

--- a/frontend/src/lib/api/generated/models/DbSession.ts
+++ b/frontend/src/lib/api/generated/models/DbSession.ts
@@ -31,6 +31,7 @@ export type DbSession = {
   id: string;
   is_automated: boolean;
   is_truncated?: boolean;
+  latest_display_content_length: number | null;
   latest_display_ordinal: number | null;
   local_modified_at?: string;
   machine: string;

--- a/frontend/src/lib/api/generated/models/DbSidebarSessionIndexRow.ts
+++ b/frontend/src/lib/api/generated/models/DbSidebarSessionIndexRow.ts
@@ -10,6 +10,7 @@ export type DbSidebarSessionIndexRow = {
   id: string;
   is_automated: boolean;
   is_teammate: boolean;
+  latest_display_content_length: number | null;
   latest_display_ordinal: number | null;
   machine: string;
   message_count: number;

--- a/frontend/src/lib/api/generated/models/DbSidebarSessionIndexRow.ts
+++ b/frontend/src/lib/api/generated/models/DbSidebarSessionIndexRow.ts
@@ -10,6 +10,7 @@ export type DbSidebarSessionIndexRow = {
   id: string;
   is_automated: boolean;
   is_teammate: boolean;
+  latest_display_ordinal: number | null;
   machine: string;
   message_count: number;
   parent_session_id?: string;

--- a/frontend/src/lib/api/generated/models/ServiceSessionDetail.ts
+++ b/frontend/src/lib/api/generated/models/ServiceSessionDetail.ts
@@ -34,6 +34,7 @@ export type ServiceSessionDetail = {
   id: string;
   is_automated: boolean;
   is_truncated?: boolean;
+  latest_display_content_length: number | null;
   latest_display_ordinal: number | null;
   local_modified_at?: string;
   machine: string;

--- a/frontend/src/lib/api/generated/models/ServiceSessionDetail.ts
+++ b/frontend/src/lib/api/generated/models/ServiceSessionDetail.ts
@@ -34,6 +34,7 @@ export type ServiceSessionDetail = {
   id: string;
   is_automated: boolean;
   is_truncated?: boolean;
+  latest_display_ordinal: number | null;
   local_modified_at?: string;
   machine: string;
   message_count: number;

--- a/frontend/src/lib/api/types/core.ts
+++ b/frontend/src/lib/api/types/core.ts
@@ -29,6 +29,7 @@ export interface Session {
   started_at: string | null;
   ended_at: string | null;
   message_count: number;
+  latest_display_ordinal: number | null;
   user_message_count: number;
   parent_session_id?: string;
   relationship_type?: string;
@@ -96,6 +97,7 @@ export interface SidebarSessionIndexRow {
   created_at: string;
   termination_status?: string | null;
   message_count: number;
+  latest_display_ordinal: number | null;
   user_message_count: number;
   is_automated: boolean;
   is_teammate?: boolean;

--- a/frontend/src/lib/api/types/core.ts
+++ b/frontend/src/lib/api/types/core.ts
@@ -30,6 +30,7 @@ export interface Session {
   ended_at: string | null;
   message_count: number;
   latest_display_ordinal: number | null;
+  latest_display_content_length?: number | null;
   user_message_count: number;
   parent_session_id?: string;
   relationship_type?: string;
@@ -98,6 +99,7 @@ export interface SidebarSessionIndexRow {
   termination_status?: string | null;
   message_count: number;
   latest_display_ordinal: number | null;
+  latest_display_content_length?: number | null;
   user_message_count: number;
   is_automated: boolean;
   is_teammate?: boolean;

--- a/frontend/src/lib/components/content/MessageList.svelte
+++ b/frontend/src/lib/components/content/MessageList.svelte
@@ -42,6 +42,12 @@
   let followSettleTimer:
     | ReturnType<typeof setTimeout>
     | null = null;
+  let visibleProgressSignature: string | null = $state(null);
+
+  type ReadCursor = {
+    ordinal: number;
+    contentLength: number | null;
+  };
 
   let baseMessages: Message[] = $derived.by(() =>
     messages.messages.filter((m) => !isSystemMessage(m)),
@@ -179,51 +185,67 @@
     const top = v.scrollOffset ?? containerRef?.scrollTop ?? 0;
     const height = containerRef?.clientHeight || v.scrollRect?.height || 0;
     const bottom = top + height;
-    let latestOrdinal = -1;
+    let latestCursor: ReadCursor | null = null;
     for (const row of v.getVirtualItems()) {
       if (row.end <= top || row.start >= bottom) continue;
       const item = itemAt(row.index);
       if (!item) continue;
       if (item.kind === "message") {
-        latestOrdinal = Math.max(latestOrdinal, item.message.ordinal);
+        latestCursor = maxCursor(latestCursor, {
+          ordinal: item.message.ordinal,
+          contentLength: item.message.content_length,
+        });
       } else {
-        latestOrdinal = Math.max(
-          latestOrdinal,
+        latestCursor = maxCursor(
+          latestCursor,
           latestVisibleToolGroupOrdinal(row.index),
         );
       }
     }
-    if (latestOrdinal >= 0) {
-      recordVisible(sessionId, latestOrdinal);
+    if (latestCursor !== null) {
+      recordVisible(
+        sessionId,
+        latestCursor.ordinal,
+        latestCursor.contentLength,
+      );
     }
   }
 
-  function latestVisibleToolGroupOrdinal(rowIndex: number) {
-    if (!containerRef) return -1;
+  function latestVisibleToolGroupOrdinal(rowIndex: number): ReadCursor | null {
+    if (!containerRef) return null;
     const row = containerRef.querySelector<HTMLElement>(
       `.virtual-row[data-index="${rowIndex}"]`,
     );
-    if (!row) return -1;
+    if (!row) return null;
     const rootRect = containerRef.getBoundingClientRect();
-    let latestOrdinal = -1;
+    let latestCursor: ReadCursor | null = null;
     for (const node of row.querySelectorAll<HTMLElement>("[data-message-ordinal]")) {
       const ordinal = Number(node.dataset.messageOrdinal);
       if (!Number.isInteger(ordinal) || ordinal < 0) continue;
       const rect = node.getBoundingClientRect();
       if (rect.bottom <= rootRect.top || rect.top >= rootRect.bottom) continue;
-      latestOrdinal = Math.max(latestOrdinal, ordinal);
+      const contentLength = parseContentLength(node.dataset.messageContentLength);
+      latestCursor = maxCursor(latestCursor, { ordinal, contentLength });
     }
-    return latestOrdinal;
+    return latestCursor;
   }
 
-  function recordVisible(sessionId: string, ordinal: number) {
-    readProgress.recordVisible(sessionId, ordinal);
+  function recordVisible(
+    sessionId: string,
+    ordinal: number,
+    contentLength?: number | null,
+  ) {
+    readProgress.recordVisible(sessionId, ordinal, contentLength);
   }
 
-  function observeMessage(node: HTMLElement, ordinal: number | undefined) {
+  function observeMessage(
+    node: HTMLElement,
+    payload: { ordinal: number; contentLength: number } | undefined,
+  ) {
     const sessionId = messages.sessionId;
-    if (!sessionId || ordinal === undefined) return {};
-    const record = () => recordVisible(sessionId, ordinal);
+    if (!sessionId || payload === undefined) return {};
+    const record = () =>
+      recordVisible(sessionId, payload.ordinal, payload.contentLength);
     if (typeof IntersectionObserver === "undefined") {
       const root = node.closest(".message-list-scroll");
       const rect = node.getBoundingClientRect();
@@ -251,6 +273,25 @@
       void messages.messages.length;
       publishVisibleTimestamp();
     }
+  });
+
+  $effect(() => {
+    const sessionId = messages.sessionId;
+    const loading = messages.loading;
+    const count = messages.messageCount;
+    const latest = latestDisplaySignature();
+    if (!sessionId || loading || !containerRef) return;
+    const signature = `${sessionId}|${count}|${latest}`;
+    if (visibleProgressSignature === null || !visibleProgressSignature.startsWith(`${sessionId}|`)) {
+      visibleProgressSignature = signature;
+      return;
+    }
+    if (visibleProgressSignature === signature) return;
+    visibleProgressSignature = signature;
+    requestAnimationFrame(() => {
+      if (messages.sessionId !== sessionId || messages.loading) return;
+      recordVisibleProgress();
+    });
   });
 
   function handleScroll() {
@@ -558,6 +599,50 @@
     return `${m.ordinal}:${m.content_length}:${m.timestamp}`;
   }
 
+  function parseContentLength(value: string | undefined): number | null {
+    const parsed = Number(value);
+    return Number.isInteger(parsed) && parsed >= 0 ? parsed : null;
+  }
+
+  function maxCursor(
+    current: ReadCursor | null,
+    next: ReadCursor | null,
+  ): ReadCursor | null {
+    if (!next) return current;
+    if (!current) return next;
+    if (next.ordinal > current.ordinal) return next;
+    if (next.ordinal < current.ordinal) return current;
+    const nextContentLength = next.contentLength ?? -1;
+    const currentContentLength = current.contentLength ?? -1;
+    return nextContentLength > currentContentLength ? next : current;
+  }
+
+  function cursorGreaterThanSeen(
+    ordinal: number,
+    contentLength: number | null,
+    seenOrdinal: number | null,
+    seenContentLength: number | null | undefined,
+  ): boolean {
+    if (seenOrdinal === null) return true;
+    if (ordinal > seenOrdinal) return true;
+    if (ordinal < seenOrdinal) return false;
+    return contentLength != null && seenContentLength != null &&
+      contentLength > seenContentLength;
+  }
+
+  function cursorAtOrBeforeSeen(
+    ordinal: number,
+    contentLength: number | null,
+    seenOrdinal: number | null,
+    seenContentLength: number | null | undefined,
+  ): boolean {
+    if (seenOrdinal === null) return false;
+    if (ordinal < seenOrdinal) return true;
+    if (ordinal > seenOrdinal) return false;
+    return seenContentLength == null || contentLength == null ||
+      contentLength <= seenContentLength;
+  }
+
   $effect(() => {
     const follow = ui.followLatest;
     if (!follow) {
@@ -605,30 +690,61 @@
     const marker = readProgress.get(messages.sessionId ?? "");
     if (!marker) return null;
     const seenOrdinal = marker.seenOrdinal;
+    const seenContentLength = marker.seenContentLength;
     const items = ui.sortNewestFirst
       ? [...displayItemsAsc].reverse()
       : displayItemsAsc;
     if (ui.sortNewestFirst && seenOrdinal === null) return null;
     if (ui.sortNewestFirst &&
-      !items.some((item) => item.ordinals.some((value) => value > seenOrdinal!))) return null;
+      !items.some((item) =>
+        itemCursors(item).some((cursor) =>
+          cursorGreaterThanSeen(
+            cursor.ordinal,
+            cursor.contentLength,
+            seenOrdinal,
+            seenContentLength,
+          ),
+        )
+      )) return null;
     for (const item of items) {
-      const ordinals = ui.sortNewestFirst
-        ? [...item.ordinals].reverse()
-        : item.ordinals;
-      const ordinal = ordinals.find((value) =>
+      const cursor = itemCursors(item).find((value) =>
         ui.sortNewestFirst
-          ? value <= seenOrdinal!
-          : seenOrdinal === null || value > seenOrdinal,
+          ? cursorAtOrBeforeSeen(
+            value.ordinal,
+            value.contentLength,
+            seenOrdinal,
+            seenContentLength,
+          )
+          : cursorGreaterThanSeen(
+            value.ordinal,
+            value.contentLength,
+            seenOrdinal,
+            seenContentLength,
+          ),
       );
-      if (ordinal !== undefined) {
+      if (cursor !== undefined) {
         return {
-          ordinal,
+          ordinal: cursor.ordinal,
           label: ui.sortNewestFirst ? m.read_progress_earlier_messages() : m.read_progress_new_messages(),
         };
       }
     }
     return null;
   });
+
+  function itemCursors(item: DisplayItem): ReadCursor[] {
+    if (item.kind === "message") {
+      return [{
+        ordinal: item.message.ordinal,
+        contentLength: item.message.content_length,
+      }];
+    }
+    const source = ui.sortNewestFirst ? [...item.messages].reverse() : item.messages;
+    return source.map((message) => ({
+      ordinal: message.ordinal,
+      contentLength: message.content_length,
+    }));
+  }
 </script>
 
 {#if !sessions.activeSessionId}
@@ -665,7 +781,12 @@
             data-index={row.index}
             style="position: absolute; top: 0; left: 0; width: 100%; transform: translateY({row.start}px);"
             use:measureElement={virtualizer.instance}
-            use:observeMessage={item.kind === "message" ? item.message.ordinal : undefined}
+            use:observeMessage={item.kind === "message"
+              ? {
+                ordinal: item.message.ordinal,
+                contentLength: item.message.content_length,
+              }
+              : undefined}
             onclick={() => {
               const sel = window.getSelection();
               if (sel && sel.toString().length > 0) return;
@@ -684,11 +805,13 @@
                 highlightQuery={highlightQuery}
                 isCurrentHighlight={item.ordinals.includes(inSessionSearch.currentOrdinal ?? -1)}
                 sortNewestFirst={ui.sortNewestFirst}
+                visibleSessionId={messages.sessionId}
                 divider={readProgressDivider !== null && item.ordinals.includes(readProgressDivider.ordinal)
                   ? readProgressDivider
                   : undefined}
                 onMessageVisible={messages.sessionId
-                  ? recordVisible.bind(null, messages.sessionId)
+                  ? (sessionId, ordinal, contentLength) =>
+                    recordVisible(sessionId, ordinal, contentLength)
                   : undefined}
               />
             {:else if item.message.is_compact_boundary}

--- a/frontend/src/lib/components/content/MessageList.svelte
+++ b/frontend/src/lib/components/content/MessageList.svelte
@@ -687,12 +687,9 @@
                 divider={readProgressDivider !== null && item.ordinals.includes(readProgressDivider.ordinal)
                   ? readProgressDivider
                   : undefined}
-                onMessageVisible={(ordinal) => {
-                  const sessionId = messages.sessionId;
-                  if (sessionId) {
-                    recordVisible(sessionId, ordinal);
-                  }
-                }}
+                onMessageVisible={messages.sessionId
+                  ? recordVisible.bind(null, messages.sessionId)
+                  : undefined}
               />
             {:else if item.message.is_compact_boundary}
               <CompactBoundaryDivider message={item.message} />

--- a/frontend/src/lib/components/content/MessageList.svelte
+++ b/frontend/src/lib/components/content/MessageList.svelte
@@ -95,8 +95,14 @@
     ).filter(isItemVisible);
   });
 
-  let displayedMessageCount = $derived(
-    (baseMessages[baseMessages.length - 1]?.ordinal ?? -1) + 1,
+  let latestDisplayOrdinal = $derived(
+    baseMessages[baseMessages.length - 1]?.ordinal ?? -1,
+  );
+
+  let displayedMessageCount = $derived(baseMessages.length);
+
+  let eligibleAcknowledgedTotal = $derived(
+    messages.hasCompleteMessageRange() ? messages.messageCount : undefined,
   );
 
   $effect(() => {
@@ -197,22 +203,24 @@
       latestOrdinal = Math.max(latestOrdinal, item.message.ordinal);
     }
     if (latestOrdinal >= 0) {
-      readProgress.recordVisible(
-        sessionId,
-        latestOrdinal,
-        displayedMessageCount,
-      );
+      recordVisible(sessionId, latestOrdinal);
     }
+  }
+
+  function recordVisible(sessionId: string, ordinal: number) {
+    readProgress.recordVisible(
+      sessionId,
+      ordinal,
+      latestDisplayOrdinal,
+      displayedMessageCount,
+      eligibleAcknowledgedTotal,
+    );
   }
 
   function observeMessage(node: HTMLElement, ordinal: number | undefined) {
     const sessionId = messages.sessionId;
     if (!sessionId || ordinal === undefined) return {};
-    const record = () => readProgress.recordVisible(
-      sessionId,
-      ordinal,
-      (messages.messages.filter((message) => !isSystemMessage(message)).at(-1)?.ordinal ?? -1) + 1,
-    );
+    const record = () => recordVisible(sessionId, ordinal);
     if (typeof IntersectionObserver === "undefined") {
       const root = node.closest(".message-list-scroll");
       const rect = node.getBoundingClientRect();
@@ -660,7 +668,7 @@
               ui.selectOrdinal(item.ordinals[0]!);
             }}
           >
-            {#if readProgressDivider !== null && item.ordinals.includes(readProgressDivider.ordinal)}
+            {#if item.kind !== "tool-group" && readProgressDivider !== null && item.ordinals.includes(readProgressDivider.ordinal)}
               <div class="read-progress-divider" role="separator" aria-label={m.read_progress_boundary()}>
                 {readProgressDivider.label}
               </div>
@@ -672,14 +680,13 @@
                 highlightQuery={highlightQuery}
                 isCurrentHighlight={item.ordinals.includes(inSessionSearch.currentOrdinal ?? -1)}
                 sortNewestFirst={ui.sortNewestFirst}
+                divider={readProgressDivider !== null && item.ordinals.includes(readProgressDivider.ordinal)
+                  ? readProgressDivider
+                  : undefined}
                 onMessageVisible={(ordinal) => {
                   const sessionId = messages.sessionId;
                   if (sessionId) {
-                    readProgress.recordVisible(
-                      sessionId,
-                      ordinal,
-                      displayedMessageCount,
-                    );
+                    recordVisible(sessionId, ordinal);
                   }
                 }}
               />

--- a/frontend/src/lib/components/content/MessageList.svelte
+++ b/frontend/src/lib/components/content/MessageList.svelte
@@ -25,6 +25,7 @@
   import { resolveMessageLayout } from "../../utils/message-layout.js";
   import { inSessionSearch } from "../../stores/inSessionSearch.svelte.js";
   import { sessionActivity } from "../../stores/sessionActivity.svelte.js";
+  import { readProgress } from "../../stores/read-progress.svelte.js";
   import SessionFindBar from "./SessionFindBar.svelte";
   import {
     getAlignedOffsetScrollAlign,
@@ -171,6 +172,31 @@
     sessionActivity.firstVisibleTimestamp = null;
   }
 
+  function recordVisibleProgress() {
+    const v = virtualizer.instance;
+    const sessionId = messages.sessionId;
+    if (!v || !sessionId) return;
+    const top = v.scrollOffset ?? containerRef?.scrollTop ?? 0;
+    const height = containerRef?.clientHeight || v.scrollRect?.height || 0;
+    const bottom = top + height;
+    let latestOrdinal = -1;
+    for (const row of v.getVirtualItems()) {
+      if (row.end <= top || row.start >= bottom) continue;
+      const item = itemAt(row.index);
+      if (!item) continue;
+      for (const ordinal of item.ordinals) {
+        latestOrdinal = Math.max(latestOrdinal, ordinal);
+      }
+    }
+    if (latestOrdinal >= 0) {
+      readProgress.recordVisible(
+        sessionId,
+        latestOrdinal,
+        messages.messageCount,
+      );
+    }
+  }
+
   // Recompute visible timestamp when minimap opens or
   // message content changes (e.g. SSE reload).
   $effect(() => {
@@ -210,8 +236,18 @@
         publishVisibleTimestamp();
       }
 
+      recordVisibleProgress();
+
     });
   }
+
+  $effect(() => {
+    const sessionId = messages.sessionId;
+    const loading = messages.loading;
+    const count = displayItemsAsc.length;
+    if (!sessionId || loading || count === 0) return;
+    requestAnimationFrame(recordVisibleProgress);
+  });
 
   function handleManualScrollIntent() {
     if (ui.followLatest) {
@@ -527,6 +563,16 @@
   let effectiveLayout = $derived(
     resolveMessageLayout(ui.messageLayout, highlightQuery !== ""),
   );
+
+  let unreadStartOrdinal = $derived.by(() => {
+    const marker = readProgress.get(messages.sessionId ?? "");
+    if (!marker) return null;
+    for (const item of displayItemsAsc) {
+      const ordinal = item.ordinals.find((value) => value > marker.ordinal);
+      if (ordinal !== undefined) return ordinal;
+    }
+    return null;
+  });
 </script>
 
 {#if !sessions.activeSessionId}
@@ -569,6 +615,11 @@
               ui.selectOrdinal(item.ordinals[0]!);
             }}
           >
+            {#if unreadStartOrdinal !== null && item.ordinals.includes(unreadStartOrdinal)}
+              <div class="read-progress-divider" role="separator" aria-label="Unread messages">
+                New messages
+              </div>
+            {/if}
             {#if item.kind === "tool-group"}
               <ToolCallGroup
                 messages={item.messages}
@@ -610,6 +661,26 @@
   .virtual-row {
     padding: 5px 12px;
     overflow-anchor: none;
+  }
+
+  .read-progress-divider {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 8px 0;
+    color: var(--accent-blue);
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .read-progress-divider::before,
+  .read-progress-divider::after {
+    content: "";
+    height: 1px;
+    flex: 1;
+    background: color-mix(in srgb, var(--accent-blue) 55%, transparent);
   }
 
   .virtual-row.selected > :global(*) {

--- a/frontend/src/lib/components/content/MessageList.svelte
+++ b/frontend/src/lib/components/content/MessageList.svelte
@@ -611,7 +611,10 @@
       return null;
     }
     for (const item of items) {
-      const ordinal = item.ordinals.find((value) =>
+      const ordinals = ui.sortNewestFirst
+        ? [...item.ordinals].reverse()
+        : item.ordinals;
+      const ordinal = ordinals.find((value) =>
         ui.sortNewestFirst
           ? value <= marker.ordinal
           : value > marker.ordinal,

--- a/frontend/src/lib/components/content/MessageList.svelte
+++ b/frontend/src/lib/components/content/MessageList.svelte
@@ -21,7 +21,10 @@
   import {
     hasVisibleSegments,
   } from "../../utils/content-parser.js";
-  import { isSystemMessage } from "../../utils/messages.js";
+  import {
+    isSystemMessage,
+    renderedContentLength,
+  } from "../../utils/messages.js";
   import { resolveMessageLayout } from "../../utils/message-layout.js";
   import { inSessionSearch } from "../../stores/inSessionSearch.svelte.js";
   import { sessionActivity } from "../../stores/sessionActivity.svelte.js";
@@ -193,7 +196,7 @@
       if (item.kind === "message") {
         latestCursor = maxCursor(latestCursor, {
           ordinal: item.message.ordinal,
-          contentLength: item.message.content_length,
+          contentLength: renderedContentLength(item.message),
         });
       } else {
         latestCursor = maxCursor(
@@ -592,11 +595,11 @@
     if (!item) return "";
     if (item.kind === "tool-group") {
       return item.messages
-        .map((m) => `${m.ordinal}:${m.content_length}:${m.timestamp}`)
+        .map((m) => `${m.ordinal}:${renderedContentLength(m)}:${m.timestamp}`)
         .join("|");
     }
     const m = item.message;
-    return `${m.ordinal}:${m.content_length}:${m.timestamp}`;
+    return `${m.ordinal}:${renderedContentLength(m)}:${m.timestamp}`;
   }
 
   function parseContentLength(value: string | undefined): number | null {
@@ -736,13 +739,13 @@
     if (item.kind === "message") {
       return [{
         ordinal: item.message.ordinal,
-        contentLength: item.message.content_length,
+        contentLength: renderedContentLength(item.message),
       }];
     }
     const source = ui.sortNewestFirst ? [...item.messages].reverse() : item.messages;
     return source.map((message) => ({
       ordinal: message.ordinal,
-      contentLength: message.content_length,
+      contentLength: renderedContentLength(message),
     }));
   }
 </script>
@@ -784,7 +787,7 @@
             use:observeMessage={item.kind === "message"
               ? {
                 ordinal: item.message.ordinal,
-                contentLength: item.message.content_length,
+                contentLength: renderedContentLength(item.message),
               }
               : undefined}
             onclick={() => {

--- a/frontend/src/lib/components/content/MessageList.svelte
+++ b/frontend/src/lib/components/content/MessageList.svelte
@@ -36,6 +36,7 @@
 
   let containerRef: HTMLDivElement | undefined = $state(undefined);
   let scrollRaf: number | null = null;
+  let progressRaf: number | null = null;
   let lastScrollRequest = 0;
   let activeFollowScrollRequest: number | null = null;
   let followingScrollRaf: number | null = null;
@@ -191,8 +192,13 @@
     for (const row of v.getVirtualItems()) {
       if (row.end <= top || row.start >= bottom) continue;
       const item = itemAt(row.index);
-      if (!item || item.kind !== "message") continue;
-      latestOrdinal = Math.max(latestOrdinal, item.message.ordinal);
+      if (!item) continue;
+      latestOrdinal = Math.max(
+        latestOrdinal,
+        item.kind === "message"
+          ? item.message.ordinal
+          : Math.max(...item.ordinals),
+      );
     }
     if (latestOrdinal >= 0) {
       recordVisible(sessionId, latestOrdinal);
@@ -240,6 +246,27 @@
       void messages.messages.length;
       publishVisibleTimestamp();
     }
+  });
+
+  $effect(() => {
+    void messages.messageCount;
+    void latestDisplayOrdinal;
+    void displayedMessageCount;
+    const sessionId = messages.sessionId;
+    if (!sessionId || latestDisplayOrdinal < 0) return;
+    if (progressRaf !== null) {
+      cancelAnimationFrame(progressRaf);
+    }
+    progressRaf = requestAnimationFrame(() => {
+      progressRaf = null;
+      recordVisibleProgress();
+    });
+    return () => {
+      if (progressRaf !== null) {
+        cancelAnimationFrame(progressRaf);
+        progressRaf = null;
+      }
+    };
   });
 
   function handleScroll() {
@@ -329,6 +356,10 @@
     if (scrollRaf !== null) {
       cancelAnimationFrame(scrollRaf);
       scrollRaf = null;
+    }
+    if (progressRaf !== null) {
+      cancelAnimationFrame(progressRaf);
+      progressRaf = null;
     }
     if (followingScrollRaf !== null) {
       cancelAnimationFrame(followingScrollRaf);

--- a/frontend/src/lib/components/content/MessageList.svelte
+++ b/frontend/src/lib/components/content/MessageList.svelte
@@ -101,15 +101,7 @@
 
   let displayedMessageCount = $derived(baseMessages.length);
 
-  let eligibleAcknowledgedTotal = $derived(
-    messages.hasCompleteMessageRange() ? messages.messageCount : undefined,
-  );
-
-  $effect(() => {
-    const sessionId = messages.sessionId ?? "";
-    readProgress.setVisibleCount(sessionId, displayedMessageCount);
-    return () => readProgress.clearVisibleCount(sessionId);
-  });
+  let eligibleAcknowledgedTotal = $derived(messages.messageCount);
 
   function itemAt(index: number) {
     if (ui.sortNewestFirst) {

--- a/frontend/src/lib/components/content/MessageList.svelte
+++ b/frontend/src/lib/components/content/MessageList.svelte
@@ -193,16 +193,36 @@
       if (row.end <= top || row.start >= bottom) continue;
       const item = itemAt(row.index);
       if (!item) continue;
-      latestOrdinal = Math.max(
-        latestOrdinal,
-        item.kind === "message"
-          ? item.message.ordinal
-          : Math.max(...item.ordinals),
-      );
+      if (item.kind === "message") {
+        latestOrdinal = Math.max(latestOrdinal, item.message.ordinal);
+      } else {
+        latestOrdinal = Math.max(
+          latestOrdinal,
+          latestVisibleToolGroupOrdinal(row.index),
+        );
+      }
     }
     if (latestOrdinal >= 0) {
       recordVisible(sessionId, latestOrdinal);
     }
+  }
+
+  function latestVisibleToolGroupOrdinal(rowIndex: number) {
+    if (!containerRef) return -1;
+    const row = containerRef.querySelector<HTMLElement>(
+      `.virtual-row[data-index="${rowIndex}"]`,
+    );
+    if (!row) return -1;
+    const rootRect = containerRef.getBoundingClientRect();
+    let latestOrdinal = -1;
+    for (const node of row.querySelectorAll<HTMLElement>("[data-message-ordinal]")) {
+      const ordinal = Number(node.dataset.messageOrdinal);
+      if (!Number.isInteger(ordinal) || ordinal < 0) continue;
+      const rect = node.getBoundingClientRect();
+      if (rect.bottom <= rootRect.top || rect.top >= rootRect.bottom) continue;
+      latestOrdinal = Math.max(latestOrdinal, ordinal);
+    }
+    return latestOrdinal;
   }
 
   function recordVisible(sessionId: string, ordinal: number) {

--- a/frontend/src/lib/components/content/MessageList.svelte
+++ b/frontend/src/lib/components/content/MessageList.svelte
@@ -99,6 +99,10 @@
     (baseMessages[baseMessages.length - 1]?.ordinal ?? -1) + 1,
   );
 
+  $effect(() => {
+    readProgress.setVisibleCount(messages.sessionId ?? "", displayedMessageCount);
+  });
+
   function itemAt(index: number) {
     if (ui.sortNewestFirst) {
       const mapped = displayItemsAsc.length - 1 - index;
@@ -599,7 +603,7 @@
       if (ordinal !== undefined) {
         return {
           ordinal,
-          label: ui.sortNewestFirst ? "Earlier messages" : "New messages",
+          label: ui.sortNewestFirst ? m.read_progress_earlier_messages() : m.read_progress_new_messages(),
         };
       }
     }
@@ -648,8 +652,8 @@
               ui.selectOrdinal(item.ordinals[0]!);
             }}
           >
-            {#if item.kind === "message" && readProgressDivider !== null && item.ordinals.includes(readProgressDivider.ordinal)}
-              <div class="read-progress-divider" role="separator" aria-label="Read progress boundary">
+            {#if readProgressDivider !== null && item.ordinals.includes(readProgressDivider.ordinal)}
+              <div class="read-progress-divider" role="separator" aria-label={m.read_progress_boundary()}>
                 {readProgressDivider.label}
               </div>
             {/if}
@@ -659,7 +663,6 @@
                 timestamp={item.timestamp}
                 highlightQuery={highlightQuery}
                 isCurrentHighlight={item.ordinals.includes(inSessionSearch.currentOrdinal ?? -1)}
-                readMarker={readProgress.get(messages.sessionId ?? "")?.ordinal ?? null}
                 sortNewestFirst={ui.sortNewestFirst}
                 onMessageVisible={(ordinal) => {
                   const sessionId = messages.sessionId;

--- a/frontend/src/lib/components/content/MessageList.svelte
+++ b/frontend/src/lib/components/content/MessageList.svelte
@@ -183,10 +183,8 @@
     for (const row of v.getVirtualItems()) {
       if (row.end <= top || row.start >= bottom) continue;
       const item = itemAt(row.index);
-      if (!item) continue;
-      for (const ordinal of item.ordinals) {
-        latestOrdinal = Math.max(latestOrdinal, ordinal);
-      }
+      if (!item || item.kind !== "message") continue;
+      latestOrdinal = Math.max(latestOrdinal, item.message.ordinal);
     }
     if (latestOrdinal >= 0) {
       readProgress.recordVisible(
@@ -240,14 +238,6 @@
 
     });
   }
-
-  $effect(() => {
-    const sessionId = messages.sessionId;
-    const loading = messages.loading;
-    const count = displayItemsAsc.length;
-    if (!sessionId || loading || count === 0) return;
-    requestAnimationFrame(recordVisibleProgress);
-  });
 
   function handleManualScrollIntent() {
     if (ui.followLatest) {
@@ -564,12 +554,24 @@
     resolveMessageLayout(ui.messageLayout, highlightQuery !== ""),
   );
 
-  let unreadStartOrdinal = $derived.by(() => {
+  let readProgressDivider = $derived.by(() => {
     const marker = readProgress.get(messages.sessionId ?? "");
     if (!marker) return null;
-    for (const item of displayItemsAsc) {
-      const ordinal = item.ordinals.find((value) => value > marker.ordinal);
-      if (ordinal !== undefined) return ordinal;
+    const items = ui.sortNewestFirst
+      ? [...displayItemsAsc].reverse()
+      : displayItemsAsc;
+    for (const item of items) {
+      const ordinal = item.ordinals.find((value) =>
+        ui.sortNewestFirst
+          ? value <= marker.ordinal
+          : value > marker.ordinal,
+      );
+      if (ordinal !== undefined) {
+        return {
+          ordinal,
+          label: ui.sortNewestFirst ? "Earlier messages" : "New messages",
+        };
+      }
     }
     return null;
   });
@@ -615,9 +617,9 @@
               ui.selectOrdinal(item.ordinals[0]!);
             }}
           >
-            {#if unreadStartOrdinal !== null && item.ordinals.includes(unreadStartOrdinal)}
-              <div class="read-progress-divider" role="separator" aria-label="Unread messages">
-                New messages
+            {#if readProgressDivider !== null && item.ordinals.includes(readProgressDivider.ordinal)}
+              <div class="read-progress-divider" role="separator" aria-label="Read progress boundary">
+                {readProgressDivider.label}
               </div>
             {/if}
             {#if item.kind === "tool-group"}

--- a/frontend/src/lib/components/content/MessageList.svelte
+++ b/frontend/src/lib/components/content/MessageList.svelte
@@ -195,6 +195,32 @@
     }
   }
 
+  function observeMessage(node: HTMLElement, ordinal: number | undefined) {
+    const sessionId = messages.sessionId;
+    if (!sessionId || ordinal === undefined) return {};
+    const record = () => readProgress.recordVisible(
+      sessionId,
+      ordinal,
+      messages.messageCount,
+    );
+    if (typeof IntersectionObserver === "undefined") {
+      const root = node.closest(".message-list-scroll");
+      const rect = node.getBoundingClientRect();
+      const rootRect = root?.getBoundingClientRect();
+      if (rootRect && rect.bottom > rootRect.top && rect.top < rootRect.bottom) {
+        record();
+      }
+      return {};
+    }
+    const observer = new IntersectionObserver((entries) => {
+      if (!entries.some((entry) => entry.isIntersecting)) return;
+      record();
+      observer.disconnect();
+    }, { root: node.closest(".message-list-scroll") });
+    observer.observe(node);
+    return { destroy: () => observer.disconnect() };
+  }
+
   // Recompute visible timestamp when minimap opens or
   // message content changes (e.g. SSE reload).
   $effect(() => {
@@ -611,6 +637,7 @@
             data-index={row.index}
             style="position: absolute; top: 0; left: 0; width: 100%; transform: translateY({row.start}px);"
             use:measureElement={virtualizer.instance}
+            use:observeMessage={item.kind === "message" ? item.message.ordinal : undefined}
             onclick={() => {
               const sel = window.getSelection();
               if (sel && sel.toString().length > 0) return;

--- a/frontend/src/lib/components/content/MessageList.svelte
+++ b/frontend/src/lib/components/content/MessageList.svelte
@@ -209,7 +209,7 @@
     const record = () => readProgress.recordVisible(
       sessionId,
       ordinal,
-      displayedMessageCount,
+      (messages.messages.filter((message) => !isSystemMessage(message)).at(-1)?.ordinal ?? -1) + 1,
     );
     if (typeof IntersectionObserver === "undefined") {
       const root = node.closest(".message-list-scroll");

--- a/frontend/src/lib/components/content/MessageList.svelte
+++ b/frontend/src/lib/components/content/MessageList.svelte
@@ -100,7 +100,9 @@
   );
 
   $effect(() => {
-    readProgress.setVisibleCount(messages.sessionId ?? "", displayedMessageCount);
+    const sessionId = messages.sessionId ?? "";
+    readProgress.setVisibleCount(sessionId, displayedMessageCount);
+    return () => readProgress.clearVisibleCount(sessionId);
   });
 
   function itemAt(index: number) {
@@ -594,6 +596,12 @@
     const items = ui.sortNewestFirst
       ? [...displayItemsAsc].reverse()
       : displayItemsAsc;
+    if (
+      ui.sortNewestFirst &&
+      !items.some((item) => item.ordinals.some((value) => value > marker.ordinal))
+    ) {
+      return null;
+    }
     for (const item of items) {
       const ordinal = item.ordinals.find((value) =>
         ui.sortNewestFirst

--- a/frontend/src/lib/components/content/MessageList.svelte
+++ b/frontend/src/lib/components/content/MessageList.svelte
@@ -617,7 +617,7 @@
               ui.selectOrdinal(item.ordinals[0]!);
             }}
           >
-            {#if readProgressDivider !== null && item.ordinals.includes(readProgressDivider.ordinal)}
+            {#if item.kind === "message" && readProgressDivider !== null && item.ordinals.includes(readProgressDivider.ordinal)}
               <div class="read-progress-divider" role="separator" aria-label="Read progress boundary">
                 {readProgressDivider.label}
               </div>
@@ -628,6 +628,18 @@
                 timestamp={item.timestamp}
                 highlightQuery={highlightQuery}
                 isCurrentHighlight={item.ordinals.includes(inSessionSearch.currentOrdinal ?? -1)}
+                readMarker={readProgress.get(messages.sessionId ?? "")?.ordinal ?? null}
+                sortNewestFirst={ui.sortNewestFirst}
+                onMessageVisible={(ordinal) => {
+                  const sessionId = messages.sessionId;
+                  if (sessionId) {
+                    readProgress.recordVisible(
+                      sessionId,
+                      ordinal,
+                      messages.messageCount,
+                    );
+                  }
+                }}
               />
             {:else if item.message.is_compact_boundary}
               <CompactBoundaryDivider message={item.message} />

--- a/frontend/src/lib/components/content/MessageList.svelte
+++ b/frontend/src/lib/components/content/MessageList.svelte
@@ -95,6 +95,10 @@
     ).filter(isItemVisible);
   });
 
+  let displayedMessageCount = $derived(
+    (baseMessages[baseMessages.length - 1]?.ordinal ?? -1) + 1,
+  );
+
   function itemAt(index: number) {
     if (ui.sortNewestFirst) {
       const mapped = displayItemsAsc.length - 1 - index;
@@ -190,7 +194,7 @@
       readProgress.recordVisible(
         sessionId,
         latestOrdinal,
-        messages.messageCount,
+        displayedMessageCount,
       );
     }
   }
@@ -201,7 +205,7 @@
     const record = () => readProgress.recordVisible(
       sessionId,
       ordinal,
-      messages.messageCount,
+      displayedMessageCount,
     );
     if (typeof IntersectionObserver === "undefined") {
       const root = node.closest(".message-list-scroll");
@@ -663,7 +667,7 @@
                     readProgress.recordVisible(
                       sessionId,
                       ordinal,
-                      messages.messageCount,
+                      displayedMessageCount,
                     );
                   }
                 }}

--- a/frontend/src/lib/components/content/MessageList.svelte
+++ b/frontend/src/lib/components/content/MessageList.svelte
@@ -36,7 +36,6 @@
 
   let containerRef: HTMLDivElement | undefined = $state(undefined);
   let scrollRaf: number | null = null;
-  let progressRaf: number | null = null;
   let lastScrollRequest = 0;
   let activeFollowScrollRequest: number | null = null;
   let followingScrollRaf: number | null = null;
@@ -95,14 +94,6 @@
       },
     ).filter(isItemVisible);
   });
-
-  let latestDisplayOrdinal = $derived(
-    baseMessages[baseMessages.length - 1]?.ordinal ?? -1,
-  );
-
-  let displayedMessageCount = $derived(baseMessages.length);
-
-  let eligibleAcknowledgedTotal = $derived(messages.messageCount);
 
   function itemAt(index: number) {
     if (ui.sortNewestFirst) {
@@ -226,13 +217,7 @@
   }
 
   function recordVisible(sessionId: string, ordinal: number) {
-    readProgress.recordVisible(
-      sessionId,
-      ordinal,
-      latestDisplayOrdinal,
-      displayedMessageCount,
-      eligibleAcknowledgedTotal,
-    );
+    readProgress.recordVisible(sessionId, ordinal);
   }
 
   function observeMessage(node: HTMLElement, ordinal: number | undefined) {
@@ -266,27 +251,6 @@
       void messages.messages.length;
       publishVisibleTimestamp();
     }
-  });
-
-  $effect(() => {
-    void messages.messageCount;
-    void latestDisplayOrdinal;
-    void displayedMessageCount;
-    const sessionId = messages.sessionId;
-    if (!sessionId || latestDisplayOrdinal < 0) return;
-    if (progressRaf !== null) {
-      cancelAnimationFrame(progressRaf);
-    }
-    progressRaf = requestAnimationFrame(() => {
-      progressRaf = null;
-      recordVisibleProgress();
-    });
-    return () => {
-      if (progressRaf !== null) {
-        cancelAnimationFrame(progressRaf);
-        progressRaf = null;
-      }
-    };
   });
 
   function handleScroll() {
@@ -376,10 +340,6 @@
     if (scrollRaf !== null) {
       cancelAnimationFrame(scrollRaf);
       scrollRaf = null;
-    }
-    if (progressRaf !== null) {
-      cancelAnimationFrame(progressRaf);
-      progressRaf = null;
     }
     if (followingScrollRaf !== null) {
       cancelAnimationFrame(followingScrollRaf);
@@ -644,23 +604,21 @@
   let readProgressDivider = $derived.by(() => {
     const marker = readProgress.get(messages.sessionId ?? "");
     if (!marker) return null;
+    const seenOrdinal = marker.seenOrdinal;
     const items = ui.sortNewestFirst
       ? [...displayItemsAsc].reverse()
       : displayItemsAsc;
-    if (
-      ui.sortNewestFirst &&
-      !items.some((item) => item.ordinals.some((value) => value > marker.ordinal))
-    ) {
-      return null;
-    }
+    if (ui.sortNewestFirst && seenOrdinal === null) return null;
+    if (ui.sortNewestFirst &&
+      !items.some((item) => item.ordinals.some((value) => value > seenOrdinal!))) return null;
     for (const item of items) {
       const ordinals = ui.sortNewestFirst
         ? [...item.ordinals].reverse()
         : item.ordinals;
       const ordinal = ordinals.find((value) =>
         ui.sortNewestFirst
-          ? value <= marker.ordinal
-          : value > marker.ordinal,
+          ? value <= seenOrdinal!
+          : seenOrdinal === null || value > seenOrdinal,
       );
       if (ordinal !== undefined) {
         return {

--- a/frontend/src/lib/components/content/MessageList.svelte
+++ b/frontend/src/lib/components/content/MessageList.svelte
@@ -243,28 +243,50 @@
 
   function observeMessage(
     node: HTMLElement,
-    payload: { ordinal: number; contentLength: number } | undefined,
+    payload:
+      | {
+          sessionId: string;
+          ordinal: number;
+          contentLength: number;
+        }
+      | undefined,
   ) {
-    const sessionId = messages.sessionId;
-    if (!sessionId || payload === undefined) return {};
-    const record = () =>
-      recordVisible(sessionId, payload.ordinal, payload.contentLength);
-    if (typeof IntersectionObserver === "undefined") {
-      const root = node.closest(".message-list-scroll");
-      const rect = node.getBoundingClientRect();
-      const rootRect = root?.getBoundingClientRect();
-      if (rootRect && rect.bottom > rootRect.top && rect.top < rootRect.bottom) {
-        record();
+    let cleanup = () => {};
+
+    const bind = (next: typeof payload) => {
+      cleanup();
+      cleanup = () => {};
+      if (!next) return;
+      const record = () =>
+        recordVisible(next.sessionId, next.ordinal, next.contentLength);
+      if (typeof IntersectionObserver === "undefined") {
+        const root = node.closest(".message-list-scroll");
+        const check = () => {
+          const rect = node.getBoundingClientRect();
+          const rootRect = root?.getBoundingClientRect();
+          if (rootRect && rect.bottom > rootRect.top && rect.top < rootRect.bottom) {
+            record();
+          }
+        };
+        check();
+        root?.addEventListener("scroll", check, { passive: true });
+        cleanup = () => root?.removeEventListener("scroll", check);
+        return;
       }
-      return {};
-    }
-    const observer = new IntersectionObserver((entries) => {
-      if (!entries.some((entry) => entry.isIntersecting)) return;
-      record();
-      observer.disconnect();
-    }, { root: node.closest(".message-list-scroll") });
-    observer.observe(node);
-    return { destroy: () => observer.disconnect() };
+      const observer = new IntersectionObserver((entries) => {
+        if (!entries.some((entry) => entry.isIntersecting)) return;
+        record();
+        observer.disconnect();
+      }, { root: node.closest(".message-list-scroll") });
+      observer.observe(node);
+      cleanup = () => observer.disconnect();
+    };
+
+    bind(payload);
+    return {
+      update: bind,
+      destroy: () => cleanup(),
+    };
   }
 
   // Recompute visible timestamp when minimap opens or
@@ -784,8 +806,9 @@
             data-index={row.index}
             style="position: absolute; top: 0; left: 0; width: 100%; transform: translateY({row.start}px);"
             use:measureElement={virtualizer.instance}
-            use:observeMessage={item.kind === "message"
+            use:observeMessage={item.kind === "message" && messages.sessionId
               ? {
+                sessionId: messages.sessionId,
                 ordinal: item.message.ordinal,
                 contentLength: renderedContentLength(item.message),
               }

--- a/frontend/src/lib/components/content/MessageList.test.ts
+++ b/frontend/src/lib/components/content/MessageList.test.ts
@@ -417,6 +417,65 @@ describe("MessageList read progress", () => {
     }
   });
 
+  it("keeps a queued tool-group observer bound to the original session", async () => {
+    const originalObserver = globalThis.IntersectionObserver;
+    const callbacks: IntersectionObserverCallback[] = [];
+    class ObserverMock {
+      constructor(callback: IntersectionObserverCallback) {
+        callbacks.push(callback);
+      }
+
+      observe() {}
+      disconnect() {}
+      unobserve() {}
+      takeRecords() { return []; }
+      root = null;
+      rootMargin = "0px";
+      thresholds = [];
+    }
+    Object.defineProperty(globalThis, "IntersectionObserver", {
+      configurable: true,
+      writable: true,
+      value: ObserverMock,
+    });
+    try {
+      messages.messages = [3, 4, 5].map((ordinal) => ({
+        ...makeMessage(ordinal),
+        role: "assistant",
+        content: "",
+        content_length: 0,
+        has_tool_use: true,
+      }));
+      virtualizerMock.getVirtualItems.mockReturnValue([{
+        index: 0,
+        key: "tool-group",
+        start: 0,
+        end: 100,
+      }]);
+      readProgress.clear("s1");
+      readProgress.clear("s2");
+      readProgress.baseline("s1", 3);
+      component = mount(MessageList, { target: document.body });
+      await tick();
+
+      const queued = callbacks.at(-1)!;
+      messages.sessionId = "s2";
+      await tick();
+      queued([
+        { isIntersecting: true } as IntersectionObserverEntry,
+      ], {} as IntersectionObserver);
+
+      expect(readProgress.get("s1")).toEqual({ seenOrdinal: 5 });
+      expect(readProgress.get("s2")).toBeNull();
+    } finally {
+      Object.defineProperty(globalThis, "IntersectionObserver", {
+        configurable: true,
+        writable: true,
+        value: originalObserver,
+      });
+    }
+  });
+
   it("acknowledges a trailing system message after its last displayable row is visible", async () => {
     const originalObserver = globalThis.IntersectionObserver;
     const callbacks: IntersectionObserverCallback[] = [];

--- a/frontend/src/lib/components/content/MessageList.test.ts
+++ b/frontend/src/lib/components/content/MessageList.test.ts
@@ -248,6 +248,48 @@ describe("MessageList read progress", () => {
     expect(document.body.textContent).toContain("msg 5");
   });
 
+  it("clears a session visible count when the list switches sessions", async () => {
+    messages.messages = [0, 1, 2, 3].map(makeMessage);
+    messages.messageCount = 4;
+    readProgress.clear("s1");
+    readProgress.baseline("s1", 3, 4);
+    component = mount(MessageList, { target: document.body });
+    await tick();
+
+    messages.sessionId = "s2";
+    await tick();
+
+    expect(readProgress.get("s1")).toEqual({ ordinal: 3, messageCount: 4 });
+    expect(readProgress.hasUnread("s1", 5)).toBe(true);
+  });
+
+  it("hides the newest-first divider for a fully read transcript", async () => {
+    ui.sortNewestFirst = true;
+    readProgress.clear("s1");
+    readProgress.baseline("s1", 5, 6);
+    component = mount(MessageList, { target: document.body });
+    await tick();
+
+    expect(document.querySelectorAll(".read-progress-divider")).toHaveLength(0);
+  });
+
+  it("hides the newest-first divider after new output becomes visible", async () => {
+    ui.sortNewestFirst = true;
+    component = mount(MessageList, { target: document.body });
+    await tick();
+
+    expect(document.querySelectorAll(".read-progress-divider")).toHaveLength(1);
+    document.querySelector<HTMLElement>(".message-list-scroll")?.dispatchEvent(
+      new Event("scroll"),
+    );
+    await vi.waitFor(() => {
+      expect(readProgress.get("s1")).toEqual({ ordinal: 5, messageCount: 6 });
+    });
+    await tick();
+
+    expect(document.querySelectorAll(".read-progress-divider")).toHaveLength(0);
+  });
+
   it("does not mark every submessage in a visible tool group as read", async () => {
     messages.messages = [4, 5].map((ordinal) => ({
       ...makeMessage(ordinal),

--- a/frontend/src/lib/components/content/MessageList.test.ts
+++ b/frontend/src/lib/components/content/MessageList.test.ts
@@ -71,6 +71,20 @@ function deferred<T>() {
   return { promise, resolve };
 }
 
+function rect(top: number, bottom: number): DOMRect {
+  return {
+    top,
+    bottom,
+    left: 0,
+    right: 100,
+    width: 100,
+    height: bottom - top,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
 describe("MessageList follow cancellation", () => {
   let component: ReturnType<typeof mount> | undefined;
   let rafSpy: ReturnType<typeof vi.spyOn>;
@@ -458,7 +472,43 @@ describe("MessageList read progress", () => {
     expect(readProgress.hasUnread("s1", 3)).toBe(false);
   });
 
-  it("uses visible tool-group ordinals when backend counts change", async () => {
+  it("does not acknowledge hidden tool-group submessages when backend counts change", async () => {
+    messages.messages = [3, 4, 5].map((ordinal) => ({
+      ...makeMessage(ordinal),
+      role: "assistant",
+      content: "",
+      content_length: 0,
+      has_tool_use: true,
+    }));
+    messages.messageCount = 6;
+    readProgress.clear("s1");
+    readProgress.baseline("s1", 3, 1, 3);
+    virtualizerMock.getVirtualItems.mockReturnValue([{
+      index: 0,
+      key: "tool-group",
+      start: 0,
+      end: 100,
+    }]);
+    component = mount(MessageList, { target: document.body });
+    await tick();
+
+    const scroller = document.querySelector<HTMLElement>(".message-list-scroll")!;
+    vi.spyOn(scroller, "getBoundingClientRect").mockReturnValue(rect(0, 100));
+    vi.spyOn(document.querySelector<HTMLElement>('[data-message-ordinal="3"]')!, "getBoundingClientRect").mockReturnValue(rect(-80, -20));
+    vi.spyOn(document.querySelector<HTMLElement>('[data-message-ordinal="4"]')!, "getBoundingClientRect").mockReturnValue(rect(20, 80));
+    vi.spyOn(document.querySelector<HTMLElement>('[data-message-ordinal="5"]')!, "getBoundingClientRect").mockReturnValue(rect(120, 180));
+    messages.messageCount = 7;
+    await tick();
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+
+    expect(readProgress.get("s1")).toEqual({
+      ordinal: 4,
+      messageCount: 3,
+    });
+    expect(readProgress.hasUnread("s1", 7)).toBe(true);
+  });
+
+  it("acknowledges visible latest tool-group submessages when backend counts change", async () => {
     messages.messages = [3, 4, 5].map((ordinal) => ({
       ...makeMessage(ordinal),
       role: "assistant",
@@ -478,6 +528,11 @@ describe("MessageList read progress", () => {
     component = mount(MessageList, { target: document.body });
     await tick();
 
+    const scroller = document.querySelector<HTMLElement>(".message-list-scroll")!;
+    vi.spyOn(scroller, "getBoundingClientRect").mockReturnValue(rect(0, 100));
+    vi.spyOn(document.querySelector<HTMLElement>('[data-message-ordinal="3"]')!, "getBoundingClientRect").mockReturnValue(rect(-180, -120));
+    vi.spyOn(document.querySelector<HTMLElement>('[data-message-ordinal="4"]')!, "getBoundingClientRect").mockReturnValue(rect(-80, -20));
+    vi.spyOn(document.querySelector<HTMLElement>('[data-message-ordinal="5"]')!, "getBoundingClientRect").mockReturnValue(rect(20, 80));
     messages.messageCount = 7;
     await tick();
     await new Promise((resolve) => window.setTimeout(resolve, 0));

--- a/frontend/src/lib/components/content/MessageList.test.ts
+++ b/frontend/src/lib/components/content/MessageList.test.ts
@@ -451,12 +451,15 @@ describe("MessageList read progress", () => {
     const originalObserver = globalThis.IntersectionObserver;
     const callbacks: IntersectionObserverCallback[] = [];
     class ObserverMock {
+      active = true;
       constructor(callback: IntersectionObserverCallback) {
-        callbacks.push(callback);
+        callbacks.push((entries, observer) => {
+          if (this.active) callback(entries, observer);
+        });
       }
 
       observe() {}
-      disconnect() {}
+      disconnect() { this.active = false; }
       unobserve() {}
       takeRecords() { return []; }
       root = null;
@@ -489,16 +492,19 @@ describe("MessageList read progress", () => {
     }
   });
 
-  it("keeps a queued tool-group observer bound to the original session", async () => {
+  it("disconnects a reused observer before a session change", async () => {
     const originalObserver = globalThis.IntersectionObserver;
     const callbacks: IntersectionObserverCallback[] = [];
     class ObserverMock {
+      active = true;
       constructor(callback: IntersectionObserverCallback) {
-        callbacks.push(callback);
+        callbacks.push((entries, observer) => {
+          if (this.active) callback(entries, observer);
+        });
       }
 
       observe() {}
-      disconnect() {}
+      disconnect() { this.active = false; }
       unobserve() {}
       takeRecords() { return []; }
       root = null;
@@ -511,7 +517,7 @@ describe("MessageList read progress", () => {
       value: ObserverMock,
     });
     try {
-      messages.messages = [3, 4, 5].map((ordinal) => ({
+      messages.messages = [5].map((ordinal) => ({
         ...makeMessage(ordinal),
         role: "assistant",
         content: "",
@@ -532,16 +538,18 @@ describe("MessageList read progress", () => {
 
       const queued = callbacks.at(-1)!;
       messages.sessionId = "s2";
+      messages.messages = [...messages.messages];
       await tick();
-      queued([
-        { isIntersecting: true } as IntersectionObserverEntry,
-      ], {} as IntersectionObserver);
+      await tick();
+      expect(queued).not.toBe(callbacks.at(-1));
+      for (const callback of callbacks) {
+        callback(
+          [{ isIntersecting: true } as IntersectionObserverEntry],
+          {} as IntersectionObserver,
+        );
+      }
 
-      expect(readProgress.get("s1")).toMatchObject({
-        seenOrdinal: 5,
-        seenContentLength: 0,
-      });
-      expect(readProgress.get("s2")).toBeNull();
+      expect(readProgress.get("s1")).toMatchObject({ seenOrdinal: 3 });
     } finally {
       Object.defineProperty(globalThis, "IntersectionObserver", {
         configurable: true,

--- a/frontend/src/lib/components/content/MessageList.test.ts
+++ b/frontend/src/lib/components/content/MessageList.test.ts
@@ -223,7 +223,7 @@ describe("MessageList read progress", () => {
     virtualizerMock.scrollOffset = 300;
     scroller!.dispatchEvent(new Event("scroll"));
     await vi.waitFor(() => {
-      expect(readProgress.get("s1")).toEqual({ ordinal: 5, messageCount: 6 });
+      expect(readProgress.get("s1")).toEqual({ ordinal: 5, messageCount: 5 });
     });
     await tick();
 
@@ -283,14 +283,14 @@ describe("MessageList read progress", () => {
       new Event("scroll"),
     );
     await vi.waitFor(() => {
-      expect(readProgress.get("s1")).toEqual({ ordinal: 5, messageCount: 6 });
+      expect(readProgress.get("s1")).toEqual({ ordinal: 5, messageCount: 5 });
     });
     await tick();
 
     expect(document.querySelectorAll(".read-progress-divider")).toHaveLength(0);
   });
 
-  it("does not mark every submessage in a visible tool group as read", async () => {
+  it("places the divider inside a tool group and does not mark every submessage read", async () => {
     messages.messages = [4, 5].map((ordinal) => ({
       ...makeMessage(ordinal),
       role: "assistant",
@@ -309,6 +309,9 @@ describe("MessageList read progress", () => {
     }]);
     component = mount(MessageList, { target: document.body });
     await tick();
+
+    const boundary = document.querySelector(".read-progress-divider");
+    expect(boundary?.nextElementSibling?.getAttribute("data-message-ordinal")).toBe("4");
 
     document.querySelector<HTMLElement>(".message-list-scroll")?.dispatchEvent(
       new Event("scroll"),
@@ -357,7 +360,7 @@ describe("MessageList read progress", () => {
     }
   });
 
-  it("uses the last displayable message for read progress count", async () => {
+  it("acknowledges a trailing system message after its last displayable row is visible", async () => {
     const originalObserver = globalThis.IntersectionObserver;
     const callbacks: IntersectionObserverCallback[] = [];
     class ObserverMock {
@@ -400,7 +403,14 @@ describe("MessageList read progress", () => {
         { isIntersecting: true } as IntersectionObserverEntry,
       ], {} as IntersectionObserver);
 
-      expect(readProgress.get("s1")).toEqual({ ordinal: 1, messageCount: 2 });
+      expect(readProgress.get("s1")).toEqual({
+        ordinal: 1,
+        messageCount: 2,
+        totalMessageCount: 3,
+      });
+      messages.sessionId = "s2";
+      await tick();
+      expect(readProgress.hasUnread("s1", 3)).toBe(false);
     } finally {
       Object.defineProperty(globalThis, "IntersectionObserver", {
         configurable: true,

--- a/frontend/src/lib/components/content/MessageList.test.ts
+++ b/frontend/src/lib/components/content/MessageList.test.ts
@@ -273,4 +273,43 @@ describe("MessageList read progress", () => {
 
     expect(readProgress.get("s1")).toEqual({ ordinal: 3, messageCount: 4 });
   });
+
+  it("records a normal row when its observer reports it visible", async () => {
+    const originalObserver = globalThis.IntersectionObserver;
+    const callbacks: IntersectionObserverCallback[] = [];
+    class ObserverMock {
+      constructor(callback: IntersectionObserverCallback) {
+        callbacks.push(callback);
+      }
+
+      observe() {}
+      disconnect() {}
+      unobserve() {}
+      takeRecords() { return []; }
+      root = null;
+      rootMargin = "0px";
+      thresholds = [];
+    }
+    Object.defineProperty(globalThis, "IntersectionObserver", {
+      configurable: true,
+      writable: true,
+      value: ObserverMock,
+    });
+    try {
+      component = mount(MessageList, { target: document.body });
+      await tick();
+
+      callbacks[3]!([
+        { isIntersecting: true } as IntersectionObserverEntry,
+      ], {} as IntersectionObserver);
+
+      expect(readProgress.get("s1")).toEqual({ ordinal: 4, messageCount: 5 });
+    } finally {
+      Object.defineProperty(globalThis, "IntersectionObserver", {
+        configurable: true,
+        writable: true,
+        value: originalObserver,
+      });
+    }
+  });
 });

--- a/frontend/src/lib/components/content/MessageList.test.ts
+++ b/frontend/src/lib/components/content/MessageList.test.ts
@@ -223,10 +223,9 @@ describe("MessageList read progress", () => {
     virtualizerMock.scrollOffset = 300;
     scroller!.dispatchEvent(new Event("scroll"));
     await vi.waitFor(() => {
-      expect(readProgress.get("s1")).toEqual({
+      expect(readProgress.get("s1")).toMatchObject({
         ordinal: 5,
         messageCount: 5,
-        totalMessageCount: 5,
       });
     });
     await tick();
@@ -287,10 +286,9 @@ describe("MessageList read progress", () => {
       new Event("scroll"),
     );
     await vi.waitFor(() => {
-      expect(readProgress.get("s1")).toEqual({
+      expect(readProgress.get("s1")).toMatchObject({
         ordinal: 5,
         messageCount: 5,
-        totalMessageCount: 5,
       });
     });
     await tick();
@@ -427,6 +425,68 @@ describe("MessageList read progress", () => {
         value: originalObserver,
       });
     }
+  });
+
+  it("acknowledges a trailing system message appended while the latest row stays visible", async () => {
+    messages.messages = [makeMessage(0), makeMessage(1)];
+    messages.messageCount = 2;
+    readProgress.clear("s1");
+    readProgress.baseline("s1", 1, 2, 2);
+    virtualizerMock.getVirtualItems.mockReturnValue([0, 1].map((index) => ({
+      index,
+      key: `row-${index}`,
+      start: index * 100,
+      end: (index + 1) * 100,
+    })));
+    component = mount(MessageList, { target: document.body });
+    await tick();
+
+    messages.messages = [
+      makeMessage(0),
+      makeMessage(1),
+      { ...makeMessage(2), is_system: true },
+    ];
+    messages.messageCount = 3;
+    await tick();
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+
+    expect(readProgress.get("s1")).toEqual({
+      ordinal: 1,
+      messageCount: 2,
+      totalMessageCount: 3,
+    });
+    expect(readProgress.hasUnread("s1", 3)).toBe(false);
+  });
+
+  it("uses visible tool-group ordinals when backend counts change", async () => {
+    messages.messages = [3, 4, 5].map((ordinal) => ({
+      ...makeMessage(ordinal),
+      role: "assistant",
+      content: "",
+      content_length: 0,
+      has_tool_use: true,
+    }));
+    messages.messageCount = 6;
+    readProgress.clear("s1");
+    readProgress.baseline("s1", 4, 2, 5);
+    virtualizerMock.getVirtualItems.mockReturnValue([{
+      index: 0,
+      key: "tool-group",
+      start: 0,
+      end: 100,
+    }]);
+    component = mount(MessageList, { target: document.body });
+    await tick();
+
+    messages.messageCount = 7;
+    await tick();
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+
+    expect(readProgress.get("s1")).toEqual({
+      ordinal: 5,
+      messageCount: 3,
+      totalMessageCount: 7,
+    });
   });
 
   it("keeps progressively loaded older messages from becoming unread", async () => {

--- a/frontend/src/lib/components/content/MessageList.test.ts
+++ b/frontend/src/lib/components/content/MessageList.test.ts
@@ -263,6 +263,29 @@ describe("MessageList read progress", () => {
     expect(readProgress.hasUnread("s1", 1)).toBe(true);
   });
 
+  it("treats same-ordinal content growth as unread and places the divider before that message", async () => {
+    messages.messages = [
+      { ...makeMessage(0), content_length: 4, content: "old0" },
+      { ...makeMessage(1), content_length: 12, content: "grown message" },
+    ];
+    messages.messageCount = 2;
+    readProgress.clear("s1");
+    readProgress.baseline("s1", 1, 6);
+    virtualizerMock.getVirtualItems.mockReturnValue([0, 1].map((index) => ({
+      index,
+      key: `row-${index}`,
+      start: index * 100,
+      end: (index + 1) * 100,
+    })));
+
+    component = mount(MessageList, { target: document.body });
+    await tick();
+
+    const divider = document.querySelector(".read-progress-divider");
+    expect(divider?.parentElement?.textContent).toContain("grown message");
+    expect(readProgress.hasUnread("s1", 1, 12)).toBe(true);
+  });
+
   it("places one divider at the next ordinal and clears it after it is visible", async () => {
     component = mount(MessageList, { target: document.body });
     await tick();
@@ -375,7 +398,7 @@ describe("MessageList read progress", () => {
     );
     await tick();
 
-    expect(readProgress.get("s1")).toEqual({ seenOrdinal: 4 });
+    expect(readProgress.get("s1")).toMatchObject({ seenOrdinal: 4 });
   });
 
   it("records a normal row when its observer reports it visible", async () => {
@@ -407,7 +430,10 @@ describe("MessageList read progress", () => {
         { isIntersecting: true } as IntersectionObserverEntry,
       ], {} as IntersectionObserver);
 
-      expect(readProgress.get("s1")).toEqual({ seenOrdinal: 4 });
+      expect(readProgress.get("s1")).toMatchObject({
+        seenOrdinal: 4,
+        seenContentLength: 6,
+      });
     } finally {
       Object.defineProperty(globalThis, "IntersectionObserver", {
         configurable: true,
@@ -465,7 +491,10 @@ describe("MessageList read progress", () => {
         { isIntersecting: true } as IntersectionObserverEntry,
       ], {} as IntersectionObserver);
 
-      expect(readProgress.get("s1")).toEqual({ seenOrdinal: 5 });
+      expect(readProgress.get("s1")).toMatchObject({
+        seenOrdinal: 5,
+        seenContentLength: 0,
+      });
       expect(readProgress.get("s2")).toBeNull();
     } finally {
       Object.defineProperty(globalThis, "IntersectionObserver", {
@@ -519,7 +548,10 @@ describe("MessageList read progress", () => {
         { isIntersecting: true } as IntersectionObserverEntry,
       ], {} as IntersectionObserver);
 
-      expect(readProgress.get("s1")).toEqual({ seenOrdinal: 1 });
+      expect(readProgress.get("s1")).toMatchObject({
+        seenOrdinal: 1,
+        seenContentLength: 6,
+      });
       messages.sessionId = "s2";
       await tick();
       expect(readProgress.hasUnread("s1", 1)).toBe(false);
@@ -555,7 +587,10 @@ describe("MessageList read progress", () => {
     await tick();
     await new Promise((resolve) => window.setTimeout(resolve, 0));
 
-    expect(readProgress.get("s1")).toEqual({ seenOrdinal: 1 });
+    expect(readProgress.get("s1")).toMatchObject({
+      seenOrdinal: 1,
+      seenContentLength: 6,
+    });
     expect(readProgress.hasUnread("s1", 1)).toBe(false);
   });
 
@@ -589,7 +624,10 @@ describe("MessageList read progress", () => {
     await tick();
     await new Promise((resolve) => window.setTimeout(resolve, 0));
 
-    expect(readProgress.get("s1")).toEqual({ seenOrdinal: 4 });
+    expect(readProgress.get("s1")).toMatchObject({
+      seenOrdinal: 4,
+      seenContentLength: 0,
+    });
     expect(readProgress.hasUnread("s1", 5)).toBe(true);
   });
 
@@ -623,7 +661,10 @@ describe("MessageList read progress", () => {
     await tick();
     await new Promise((resolve) => window.setTimeout(resolve, 0));
 
-    expect(readProgress.get("s1")).toEqual({ seenOrdinal: 5 });
+    expect(readProgress.get("s1")).toMatchObject({
+      seenOrdinal: 5,
+      seenContentLength: 0,
+    });
   });
 
   it("keeps progressively loaded older messages from becoming unread", async () => {
@@ -648,7 +689,9 @@ describe("MessageList read progress", () => {
     );
     await tick();
 
-    expect(readProgress.get("s1")).toEqual({ seenOrdinal: 3_002 });
+    expect(readProgress.get("s1")).toMatchObject({
+      seenOrdinal: 3_002,
+    });
     expect(readProgress.hasUnread("s1", 3_002)).toBe(false);
   });
 });

--- a/frontend/src/lib/components/content/MessageList.test.ts
+++ b/frontend/src/lib/components/content/MessageList.test.ts
@@ -286,6 +286,52 @@ describe("MessageList read progress", () => {
     expect(readProgress.hasUnread("s1", 1, 12)).toBe(true);
   });
 
+  it("tracks same-ordinal tool result growth with the rendered cursor", async () => {
+    messages.messages = [
+      makeMessage(0),
+      {
+        ...makeMessage(1),
+        role: "assistant",
+        content: "tool",
+        content_length: 4,
+        has_tool_use: true,
+        tool_calls: [{
+          tool_name: "Bash",
+          result_content: "old",
+          result_content_length: 3,
+          result_events: [{
+            source: "tool",
+            status: "completed",
+            content: "event",
+            content_length: 5,
+            event_index: 0,
+          }],
+        }],
+      },
+    ];
+    messages.messageCount = 2;
+    readProgress.clear("s1");
+    readProgress.baseline("s1", 1, 11);
+    virtualizerMock.getVirtualItems.mockReturnValue([0, 1].map((index) => ({
+      index,
+      key: `row-${index}`,
+      start: index * 100,
+      end: (index + 1) * 100,
+    })));
+
+    component = mount(MessageList, { target: document.body });
+    await tick();
+
+    expect(readProgress.hasUnread("s1", 1, 12)).toBe(true);
+    document.querySelector<HTMLElement>(".message-list-scroll")!.dispatchEvent(new Event("scroll"));
+    await vi.waitFor(() => {
+      expect(readProgress.get("s1")).toEqual({
+        seenOrdinal: 1,
+        seenContentLength: 12,
+      });
+    });
+  });
+
   it("places one divider at the next ordinal and clears it after it is visible", async () => {
     component = mount(MessageList, { target: document.body });
     await tick();

--- a/frontend/src/lib/components/content/MessageList.test.ts
+++ b/frontend/src/lib/components/content/MessageList.test.ts
@@ -165,3 +165,112 @@ describe("MessageList follow cancellation", () => {
     });
   });
 });
+describe("MessageList read progress", () => {
+  let component: ReturnType<typeof mount> | undefined;
+  let rafSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    messages.clear();
+    sessions.activeSessionId = "s1";
+    messages.sessionId = "s1";
+    messages.messages = [1, 2, 3, 4, 5].map(makeMessage);
+    messages.messageCount = 5;
+    ui.sortNewestFirst = false;
+    readProgress.clear("s1");
+    readProgress.baseline("s1", 3, 3);
+    virtualizerMock.scrollOffset = 0;
+    virtualizerMock.scrollRect.height = 300;
+    virtualizerMock.getVirtualItems.mockReturnValue(
+      [0, 1, 2, 3, 4].map((index) => ({
+        index,
+        key: `row-${index}`,
+        start: index * 100,
+        end: (index + 1) * 100,
+      })),
+    );
+    rafSpy = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((cb: FrameRequestCallback) => {
+        window.setTimeout(() => cb(performance.now()), 0);
+        return 1;
+      });
+  });
+
+  afterEach(() => {
+    if (component) unmount(component);
+    component = undefined;
+    rafSpy.mockRestore();
+    readProgress.clear("s1");
+    messages.clear();
+    sessions.activeSessionId = null;
+    ui.sortNewestFirst = false;
+    ui.showAllBlocks();
+    document.body.innerHTML = "";
+  });
+
+  it("places one divider at the next ordinal and clears it after it is visible", async () => {
+    component = mount(MessageList, { target: document.body });
+    await tick();
+
+    expect(document.querySelectorAll(".read-progress-divider")).toHaveLength(1);
+    expect(document.body.textContent).toContain("New messages");
+
+    const scroller = document.querySelector<HTMLElement>(".message-list-scroll");
+    expect(scroller).not.toBeNull();
+    virtualizerMock.scrollOffset = 300;
+    scroller!.dispatchEvent(new Event("scroll"));
+    await vi.waitFor(() => {
+      expect(readProgress.get("s1")).toEqual({ ordinal: 5, messageCount: 5 });
+    });
+    await tick();
+
+    expect(document.querySelectorAll(".read-progress-divider")).toHaveLength(0);
+  });
+
+  it("separates unread and read ranges in newest first and filtered views", async () => {
+    messages.loading = true;
+    ui.sortNewestFirst = true;
+    component = mount(MessageList, { target: document.body });
+    await tick();
+
+    expect(document.querySelectorAll(".read-progress-divider")).toHaveLength(1);
+    expect(document.querySelectorAll(".virtual-row")[2]?.textContent).toContain("Earlier messages");
+    expect(document.querySelectorAll(".virtual-row")[2]?.textContent).toContain("msg 3");
+
+    ui.sortNewestFirst = false;
+    ui.setBlockVisible("user", false);
+    await tick();
+
+    expect(document.querySelectorAll(".read-progress-divider")).toHaveLength(1);
+    expect(document.body.textContent).toContain("msg 5");
+  });
+
+  it("does not mark every submessage in a visible tool group as read", async () => {
+    messages.messages = [4, 5].map((ordinal) => ({
+      ...makeMessage(ordinal),
+      role: "assistant",
+      content: "",
+      content_length: 0,
+      has_tool_use: true,
+    }));
+    messages.messageCount = 6;
+    readProgress.clear("s1");
+    readProgress.baseline("s1", 3, 4);
+    virtualizerMock.getVirtualItems.mockReturnValue([{
+      index: 0,
+      key: "tool-group",
+      start: 0,
+      end: 100,
+    }]);
+    component = mount(MessageList, { target: document.body });
+    await tick();
+
+    document.querySelector<HTMLElement>(".message-list-scroll")?.dispatchEvent(
+      new Event("scroll"),
+    );
+    await tick();
+
+    expect(readProgress.get("s1")).toEqual({ ordinal: 3, messageCount: 4 });
+  });
+});

--- a/frontend/src/lib/components/content/MessageList.test.ts
+++ b/frontend/src/lib/components/content/MessageList.test.ts
@@ -194,7 +194,7 @@ describe("MessageList read progress", () => {
     messages.messageCount = 5;
     ui.sortNewestFirst = false;
     readProgress.clear("s1");
-    readProgress.baseline("s1", 3, 3);
+    readProgress.baseline("s1", 3);
     virtualizerMock.scrollOffset = 0;
     virtualizerMock.scrollRect.height = 300;
     virtualizerMock.getVirtualItems.mockReturnValue(
@@ -225,6 +225,44 @@ describe("MessageList read progress", () => {
     document.body.innerHTML = "";
   });
 
+  it("places the chronological divider before ordinal zero from a null cursor", async () => {
+    messages.messages = [0, 1].map(makeMessage);
+    readProgress.clear("s1");
+    readProgress.baseline("s1", null);
+    virtualizerMock.getVirtualItems.mockReturnValue([0, 1].map((index) => ({
+      index,
+      key: `row-${index}`,
+      start: index * 100,
+      end: (index + 1) * 100,
+    })));
+
+    component = mount(MessageList, { target: document.body });
+    await tick();
+
+    const divider = document.querySelector(".read-progress-divider");
+    expect(divider?.parentElement?.textContent).toContain("msg 0");
+    expect(divider?.textContent).toContain("New messages");
+  });
+
+  it("renders no earlier divider when newest-first has no read range", async () => {
+    messages.messages = [0, 1].map(makeMessage);
+    readProgress.clear("s1");
+    readProgress.baseline("s1", null);
+    ui.sortNewestFirst = true;
+    virtualizerMock.getVirtualItems.mockReturnValue([0, 1].map((index) => ({
+      index,
+      key: `row-${index}`,
+      start: index * 100,
+      end: (index + 1) * 100,
+    })));
+
+    component = mount(MessageList, { target: document.body });
+    await tick();
+
+    expect(document.querySelectorAll(".read-progress-divider")).toHaveLength(0);
+    expect(readProgress.hasUnread("s1", 1)).toBe(true);
+  });
+
   it("places one divider at the next ordinal and clears it after it is visible", async () => {
     component = mount(MessageList, { target: document.body });
     await tick();
@@ -238,8 +276,7 @@ describe("MessageList read progress", () => {
     scroller!.dispatchEvent(new Event("scroll"));
     await vi.waitFor(() => {
       expect(readProgress.get("s1")).toMatchObject({
-        ordinal: 5,
-        messageCount: 5,
+        seenOrdinal: 5,
       });
     });
     await tick();
@@ -269,21 +306,21 @@ describe("MessageList read progress", () => {
     messages.messages = [0, 1, 2, 3].map(makeMessage);
     messages.messageCount = 4;
     readProgress.clear("s1");
-    readProgress.baseline("s1", 3, 4);
+    readProgress.baseline("s1", 3);
     component = mount(MessageList, { target: document.body });
     await tick();
 
     messages.sessionId = "s2";
     await tick();
 
-    expect(readProgress.get("s1")).toEqual({ ordinal: 3, messageCount: 4 });
+    expect(readProgress.get("s1")).toEqual({ seenOrdinal: 3 });
     expect(readProgress.hasUnread("s1", 5)).toBe(true);
   });
 
   it("hides the newest-first divider for a fully read transcript", async () => {
     ui.sortNewestFirst = true;
     readProgress.clear("s1");
-    readProgress.baseline("s1", 5, 6);
+    readProgress.baseline("s1", 5);
     component = mount(MessageList, { target: document.body });
     await tick();
 
@@ -301,8 +338,7 @@ describe("MessageList read progress", () => {
     );
     await vi.waitFor(() => {
       expect(readProgress.get("s1")).toMatchObject({
-        ordinal: 5,
-        messageCount: 5,
+        seenOrdinal: 5,
       });
     });
     await tick();
@@ -320,7 +356,7 @@ describe("MessageList read progress", () => {
     }));
     messages.messageCount = 6;
     readProgress.clear("s1");
-    readProgress.baseline("s1", 4, 5);
+    readProgress.baseline("s1", 4);
     ui.sortNewestFirst = true;
     virtualizerMock.getVirtualItems.mockReturnValue([{
       index: 0,
@@ -339,7 +375,7 @@ describe("MessageList read progress", () => {
     );
     await tick();
 
-    expect(readProgress.get("s1")).toEqual({ ordinal: 4, messageCount: 5 });
+    expect(readProgress.get("s1")).toEqual({ seenOrdinal: 4 });
   });
 
   it("records a normal row when its observer reports it visible", async () => {
@@ -371,7 +407,7 @@ describe("MessageList read progress", () => {
         { isIntersecting: true } as IntersectionObserverEntry,
       ], {} as IntersectionObserver);
 
-      expect(readProgress.get("s1")).toEqual({ ordinal: 4, messageCount: 5 });
+      expect(readProgress.get("s1")).toEqual({ seenOrdinal: 4 });
     } finally {
       Object.defineProperty(globalThis, "IntersectionObserver", {
         configurable: true,
@@ -410,7 +446,7 @@ describe("MessageList read progress", () => {
       ];
       messages.messageCount = 3;
       readProgress.clear("s1");
-      readProgress.baseline("s1", 0, 1);
+      readProgress.baseline("s1", 0);
       virtualizerMock.getVirtualItems.mockReturnValue([0, 1].map((index) => ({
         index,
         key: `row-${index}`,
@@ -424,14 +460,10 @@ describe("MessageList read progress", () => {
         { isIntersecting: true } as IntersectionObserverEntry,
       ], {} as IntersectionObserver);
 
-      expect(readProgress.get("s1")).toEqual({
-        ordinal: 1,
-        messageCount: 2,
-        totalMessageCount: 3,
-      });
+      expect(readProgress.get("s1")).toEqual({ seenOrdinal: 1 });
       messages.sessionId = "s2";
       await tick();
-      expect(readProgress.hasUnread("s1", 3)).toBe(false);
+      expect(readProgress.hasUnread("s1", 1)).toBe(false);
     } finally {
       Object.defineProperty(globalThis, "IntersectionObserver", {
         configurable: true,
@@ -445,7 +477,7 @@ describe("MessageList read progress", () => {
     messages.messages = [makeMessage(0), makeMessage(1)];
     messages.messageCount = 2;
     readProgress.clear("s1");
-    readProgress.baseline("s1", 1, 2, 2);
+    readProgress.baseline("s1", 1);
     virtualizerMock.getVirtualItems.mockReturnValue([0, 1].map((index) => ({
       index,
       key: `row-${index}`,
@@ -464,12 +496,8 @@ describe("MessageList read progress", () => {
     await tick();
     await new Promise((resolve) => window.setTimeout(resolve, 0));
 
-    expect(readProgress.get("s1")).toEqual({
-      ordinal: 1,
-      messageCount: 2,
-      totalMessageCount: 3,
-    });
-    expect(readProgress.hasUnread("s1", 3)).toBe(false);
+    expect(readProgress.get("s1")).toEqual({ seenOrdinal: 1 });
+    expect(readProgress.hasUnread("s1", 1)).toBe(false);
   });
 
   it("does not acknowledge hidden tool-group submessages when backend counts change", async () => {
@@ -482,7 +510,7 @@ describe("MessageList read progress", () => {
     }));
     messages.messageCount = 6;
     readProgress.clear("s1");
-    readProgress.baseline("s1", 3, 1, 3);
+    readProgress.baseline("s1", 3);
     virtualizerMock.getVirtualItems.mockReturnValue([{
       index: 0,
       key: "tool-group",
@@ -498,14 +526,12 @@ describe("MessageList read progress", () => {
     vi.spyOn(document.querySelector<HTMLElement>('[data-message-ordinal="4"]')!, "getBoundingClientRect").mockReturnValue(rect(20, 80));
     vi.spyOn(document.querySelector<HTMLElement>('[data-message-ordinal="5"]')!, "getBoundingClientRect").mockReturnValue(rect(120, 180));
     messages.messageCount = 7;
+    scroller.dispatchEvent(new Event("scroll"));
     await tick();
     await new Promise((resolve) => window.setTimeout(resolve, 0));
 
-    expect(readProgress.get("s1")).toEqual({
-      ordinal: 4,
-      messageCount: 3,
-    });
-    expect(readProgress.hasUnread("s1", 7)).toBe(true);
+    expect(readProgress.get("s1")).toEqual({ seenOrdinal: 4 });
+    expect(readProgress.hasUnread("s1", 5)).toBe(true);
   });
 
   it("acknowledges visible latest tool-group submessages when backend counts change", async () => {
@@ -518,7 +544,7 @@ describe("MessageList read progress", () => {
     }));
     messages.messageCount = 6;
     readProgress.clear("s1");
-    readProgress.baseline("s1", 4, 2, 5);
+    readProgress.baseline("s1", 4);
     virtualizerMock.getVirtualItems.mockReturnValue([{
       index: 0,
       key: "tool-group",
@@ -534,14 +560,11 @@ describe("MessageList read progress", () => {
     vi.spyOn(document.querySelector<HTMLElement>('[data-message-ordinal="4"]')!, "getBoundingClientRect").mockReturnValue(rect(-80, -20));
     vi.spyOn(document.querySelector<HTMLElement>('[data-message-ordinal="5"]')!, "getBoundingClientRect").mockReturnValue(rect(20, 80));
     messages.messageCount = 7;
+    scroller.dispatchEvent(new Event("scroll"));
     await tick();
     await new Promise((resolve) => window.setTimeout(resolve, 0));
 
-    expect(readProgress.get("s1")).toEqual({
-      ordinal: 5,
-      messageCount: 3,
-      totalMessageCount: 7,
-    });
+    expect(readProgress.get("s1")).toEqual({ seenOrdinal: 5 });
   });
 
   it("keeps progressively loaded older messages from becoming unread", async () => {
@@ -549,7 +572,7 @@ describe("MessageList read progress", () => {
     messages.messageCount = 3_003;
     messages.hasOlder = true;
     readProgress.clear("s1");
-    readProgress.baseline("s1", 3_002, 3, 3_003);
+    readProgress.baseline("s1", 3_002);
     virtualizerMock.getVirtualItems.mockReturnValue([0, 1, 2].map((index) => ({
       index,
       key: `row-${index}`,
@@ -566,11 +589,7 @@ describe("MessageList read progress", () => {
     );
     await tick();
 
-    expect(readProgress.get("s1")).toEqual({
-      ordinal: 3_002,
-      messageCount: 3,
-      totalMessageCount: 3_003,
-    });
-    expect(readProgress.hasUnread("s1", 3_003)).toBe(false);
+    expect(readProgress.get("s1")).toEqual({ seenOrdinal: 3_002 });
+    expect(readProgress.hasUnread("s1", 3_002)).toBe(false);
   });
 });

--- a/frontend/src/lib/components/content/MessageList.test.ts
+++ b/frontend/src/lib/components/content/MessageList.test.ts
@@ -290,8 +290,8 @@ describe("MessageList read progress", () => {
     expect(document.querySelectorAll(".read-progress-divider")).toHaveLength(0);
   });
 
-  it("places the divider inside a tool group and does not mark every submessage read", async () => {
-    messages.messages = [4, 5].map((ordinal) => ({
+  it("uses the rendered newest-first ordinal when a divider falls inside a tool group", async () => {
+    messages.messages = [3, 4, 5].map((ordinal) => ({
       ...makeMessage(ordinal),
       role: "assistant",
       content: "",
@@ -300,7 +300,8 @@ describe("MessageList read progress", () => {
     }));
     messages.messageCount = 6;
     readProgress.clear("s1");
-    readProgress.baseline("s1", 3, 4);
+    readProgress.baseline("s1", 4, 5);
+    ui.sortNewestFirst = true;
     virtualizerMock.getVirtualItems.mockReturnValue([{
       index: 0,
       key: "tool-group",
@@ -318,7 +319,7 @@ describe("MessageList read progress", () => {
     );
     await tick();
 
-    expect(readProgress.get("s1")).toEqual({ ordinal: 3, messageCount: 4 });
+    expect(readProgress.get("s1")).toEqual({ ordinal: 4, messageCount: 5 });
   });
 
   it("records a normal row when its observer reports it visible", async () => {

--- a/frontend/src/lib/components/content/MessageList.test.ts
+++ b/frontend/src/lib/components/content/MessageList.test.ts
@@ -223,7 +223,11 @@ describe("MessageList read progress", () => {
     virtualizerMock.scrollOffset = 300;
     scroller!.dispatchEvent(new Event("scroll"));
     await vi.waitFor(() => {
-      expect(readProgress.get("s1")).toEqual({ ordinal: 5, messageCount: 5 });
+      expect(readProgress.get("s1")).toEqual({
+        ordinal: 5,
+        messageCount: 5,
+        totalMessageCount: 5,
+      });
     });
     await tick();
 
@@ -283,7 +287,11 @@ describe("MessageList read progress", () => {
       new Event("scroll"),
     );
     await vi.waitFor(() => {
-      expect(readProgress.get("s1")).toEqual({ ordinal: 5, messageCount: 5 });
+      expect(readProgress.get("s1")).toEqual({
+        ordinal: 5,
+        messageCount: 5,
+        totalMessageCount: 5,
+      });
     });
     await tick();
 
@@ -419,5 +427,35 @@ describe("MessageList read progress", () => {
         value: originalObserver,
       });
     }
+  });
+
+  it("keeps progressively loaded older messages from becoming unread", async () => {
+    messages.messages = [3_000, 3_001, 3_002].map(makeMessage);
+    messages.messageCount = 3_003;
+    messages.hasOlder = true;
+    readProgress.clear("s1");
+    readProgress.baseline("s1", 3_002, 3, 3_003);
+    virtualizerMock.getVirtualItems.mockReturnValue([0, 1, 2].map((index) => ({
+      index,
+      key: `row-${index}`,
+      start: index * 100,
+      end: (index + 1) * 100,
+    })));
+    component = mount(MessageList, { target: document.body });
+    await tick();
+
+    messages.messages = [2_000, 2_001, 2_002, 3_000, 3_001, 3_002].map(makeMessage);
+    await tick();
+    document.querySelector<HTMLElement>(".message-list-scroll")?.dispatchEvent(
+      new Event("scroll"),
+    );
+    await tick();
+
+    expect(readProgress.get("s1")).toEqual({
+      ordinal: 3_002,
+      messageCount: 3,
+      totalMessageCount: 3_003,
+    });
+    expect(readProgress.hasUnread("s1", 3_003)).toBe(false);
   });
 });

--- a/frontend/src/lib/components/content/MessageList.test.ts
+++ b/frontend/src/lib/components/content/MessageList.test.ts
@@ -12,17 +12,19 @@ import type { Message } from "../../api/types.js";
 import { messages } from "../../stores/messages.svelte.js";
 import { sessions } from "../../stores/sessions.svelte.js";
 import { ui } from "../../stores/ui.svelte.js";
+import { readProgress } from "../../stores/read-progress.svelte.js";
 import { setLocale } from "../../i18n/index.js";
 
 const virtualizerMock = vi.hoisted(() => ({
   options: { count: 0 },
   scrollOffset: 0,
-  getVirtualItems: vi.fn(() => []),
+  getVirtualItems: vi.fn<() => unknown[]>(() => []),
   getTotalSize: vi.fn(() => 120),
   measureElement: vi.fn(),
   scrollToIndex: vi.fn(),
   scrollToOffset: vi.fn(),
   getOffsetForIndex: vi.fn(),
+  scrollRect: { height: 300 },
 }));
 
 vi.mock("../../virtual/createVirtualizer.svelte.js", () => ({
@@ -221,7 +223,7 @@ describe("MessageList read progress", () => {
     virtualizerMock.scrollOffset = 300;
     scroller!.dispatchEvent(new Event("scroll"));
     await vi.waitFor(() => {
-      expect(readProgress.get("s1")).toEqual({ ordinal: 5, messageCount: 5 });
+      expect(readProgress.get("s1")).toEqual({ ordinal: 5, messageCount: 6 });
     });
     await tick();
 
@@ -304,6 +306,59 @@ describe("MessageList read progress", () => {
       ], {} as IntersectionObserver);
 
       expect(readProgress.get("s1")).toEqual({ ordinal: 4, messageCount: 5 });
+    } finally {
+      Object.defineProperty(globalThis, "IntersectionObserver", {
+        configurable: true,
+        writable: true,
+        value: originalObserver,
+      });
+    }
+  });
+
+  it("uses the last displayable message for read progress count", async () => {
+    const originalObserver = globalThis.IntersectionObserver;
+    const callbacks: IntersectionObserverCallback[] = [];
+    class ObserverMock {
+      constructor(callback: IntersectionObserverCallback) {
+        callbacks.push(callback);
+      }
+
+      observe() {}
+      disconnect() {}
+      unobserve() {}
+      takeRecords() { return []; }
+      root = null;
+      rootMargin = "0px";
+      thresholds = [];
+    }
+    Object.defineProperty(globalThis, "IntersectionObserver", {
+      configurable: true,
+      writable: true,
+      value: ObserverMock,
+    });
+    try {
+      messages.messages = [
+        makeMessage(0),
+        makeMessage(1),
+        { ...makeMessage(2), is_system: true },
+      ];
+      messages.messageCount = 3;
+      readProgress.clear("s1");
+      readProgress.baseline("s1", 0, 1);
+      virtualizerMock.getVirtualItems.mockReturnValue([0, 1].map((index) => ({
+        index,
+        key: `row-${index}`,
+        start: index * 100,
+        end: (index + 1) * 100,
+      })));
+      component = mount(MessageList, { target: document.body });
+      await tick();
+
+      callbacks[1]!([
+        { isIntersecting: true } as IntersectionObserverEntry,
+      ], {} as IntersectionObserver);
+
+      expect(readProgress.get("s1")).toEqual({ ordinal: 1, messageCount: 2 });
     } finally {
       Object.defineProperty(globalThis, "IntersectionObserver", {
         configurable: true,

--- a/frontend/src/lib/components/content/SubagentInline.test.ts
+++ b/frontend/src/lib/components/content/SubagentInline.test.ts
@@ -66,6 +66,7 @@ function makeSession(
     is_automated: false,
     created_at: "2026-02-20T12:30:00Z",
     ...overrides,
+    latest_display_ordinal: overrides.latest_display_ordinal ?? 0,
   };
 }
 

--- a/frontend/src/lib/components/content/ToolCallGroup.svelte
+++ b/frontend/src/lib/components/content/ToolCallGroup.svelte
@@ -73,7 +73,16 @@
   });
 
   function observeMessage(node: HTMLElement, ordinal: number) {
-    if (!onMessageVisible || typeof IntersectionObserver === "undefined") {
+    if (!onMessageVisible) {
+      return {};
+    }
+    if (typeof IntersectionObserver === "undefined") {
+      const root = node.closest(".message-list-scroll");
+      const rect = node.getBoundingClientRect();
+      const rootRect = root?.getBoundingClientRect();
+      if (rootRect && rect.bottom > rootRect.top && rect.top < rootRect.bottom) {
+        onMessageVisible(ordinal);
+      }
       return {};
     }
     const observer = new IntersectionObserver((entries) => {

--- a/frontend/src/lib/components/content/ToolCallGroup.svelte
+++ b/frontend/src/lib/components/content/ToolCallGroup.svelte
@@ -23,6 +23,9 @@
     timestamp: string;
     highlightQuery?: string;
     isCurrentHighlight?: boolean;
+    readMarker?: number | null;
+    sortNewestFirst?: boolean;
+    onMessageVisible?: (ordinal: number) => void;
   }
 
   let {
@@ -30,6 +33,9 @@
     timestamp,
     highlightQuery = "",
     isCurrentHighlight = false,
+    readMarker = null,
+    sortNewestFirst = false,
+    onMessageVisible,
   }: Props = $props();
 
   let copied = $state(false);
@@ -52,6 +58,30 @@
   );
 
   let label = $derived(m.tool_call_group_call_count({ count: totalCalls }));
+
+  let displayMessages = $derived(
+    sortNewestFirst ? [...messages].reverse() : messages,
+  );
+
+  function isBoundary(ordinal: number): boolean {
+    if (readMarker === null) return false;
+    return sortNewestFirst
+      ? ordinal <= readMarker
+      : ordinal > readMarker;
+  }
+
+  function observeMessage(node: HTMLElement, ordinal: number) {
+    if (!onMessageVisible || typeof IntersectionObserver === "undefined") {
+      return {};
+    }
+    const observer = new IntersectionObserver((entries) => {
+      if (!entries.some((entry) => entry.isIntersecting)) return;
+      onMessageVisible?.(ordinal);
+      observer.disconnect();
+    }, { root: node.closest(".message-list-scroll") });
+    observer.observe(node);
+    return { destroy: () => observer.disconnect() };
+  }
 
   /** Index turn timings by message id for O(1) lookup. */
   let turnByMessage = $derived.by(() => {
@@ -142,9 +172,15 @@
   </div>
 
   <div class="tool-group-body">
-    {#each messages as message (message.ordinal)}
+    {#each displayMessages as message (message.ordinal)}
       {@const calls = message.tool_calls ?? []}
       {@const turn = turnByMessage.get(message.id)}
+      <div use:observeMessage={message.ordinal}>
+      {#if isBoundary(message.ordinal)}
+        <div class="read-progress-divider" role="separator" aria-label="Read progress boundary">
+          {sortNewestFirst ? "Earlier messages" : "New messages"}
+        </div>
+      {/if}
       {#if calls.length === 1}
         {@const soloCall = calls[0]!}
         <ToolBlock
@@ -183,6 +219,7 @@
           />
         {/each}
       {/if}
+      </div>
     {/each}
   </div>
 </div>
@@ -229,6 +266,26 @@
     display: flex;
     flex-direction: column;
     gap: 2px;
+  }
+
+  .read-progress-divider {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 8px 0;
+    color: var(--accent-blue);
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .read-progress-divider::before,
+  .read-progress-divider::after {
+    content: "";
+    height: 1px;
+    flex: 1;
+    background: color-mix(in srgb, var(--accent-blue) 55%, transparent);
   }
 
   .tool-group-body :global(.tool-block) {

--- a/frontend/src/lib/components/content/ToolCallGroup.svelte
+++ b/frontend/src/lib/components/content/ToolCallGroup.svelte
@@ -64,15 +64,17 @@
   );
 
   function observeMessage(node: HTMLElement, ordinal: number) {
-    if (!onMessageVisible) {
+    const handleVisible = onMessageVisible;
+    if (!handleVisible) {
       return {};
     }
+    const reportVisible = () => handleVisible(ordinal);
     if (typeof IntersectionObserver === "undefined") {
       const root = node.closest(".message-list-scroll");
       const check = () => {
         const rect = node.getBoundingClientRect();
         const rootRect = root?.getBoundingClientRect();
-        if (rootRect && rect.bottom > rootRect.top && rect.top < rootRect.bottom) onMessageVisible(ordinal);
+        if (rootRect && rect.bottom > rootRect.top && rect.top < rootRect.bottom) reportVisible();
       };
       check();
       root?.addEventListener("scroll", check, { passive: true });
@@ -80,7 +82,7 @@
     }
     const observer = new IntersectionObserver((entries) => {
       if (!entries.some((entry) => entry.isIntersecting)) return;
-      onMessageVisible?.(ordinal);
+      reportVisible();
       observer.disconnect();
     }, { root: node.closest(".message-list-scroll") });
     observer.observe(node);

--- a/frontend/src/lib/components/content/ToolCallGroup.svelte
+++ b/frontend/src/lib/components/content/ToolCallGroup.svelte
@@ -63,12 +63,14 @@
     sortNewestFirst ? [...messages].reverse() : messages,
   );
 
-  function isBoundary(ordinal: number): boolean {
-    if (readMarker === null) return false;
-    return sortNewestFirst
-      ? ordinal <= readMarker
-      : ordinal > readMarker;
-  }
+  let dividerOrdinal = $derived.by(() => {
+    if (readMarker === null) return null;
+    return displayMessages.find((message) =>
+      sortNewestFirst
+        ? message.ordinal <= readMarker
+        : message.ordinal > readMarker,
+    )?.ordinal ?? null;
+  });
 
   function observeMessage(node: HTMLElement, ordinal: number) {
     if (!onMessageVisible || typeof IntersectionObserver === "undefined") {
@@ -176,7 +178,7 @@
       {@const calls = message.tool_calls ?? []}
       {@const turn = turnByMessage.get(message.id)}
       <div use:observeMessage={message.ordinal}>
-      {#if isBoundary(message.ordinal)}
+      {#if dividerOrdinal === message.ordinal}
         <div class="read-progress-divider" role="separator" aria-label="Read progress boundary">
           {sortNewestFirst ? "Earlier messages" : "New messages"}
         </div>

--- a/frontend/src/lib/components/content/ToolCallGroup.svelte
+++ b/frontend/src/lib/components/content/ToolCallGroup.svelte
@@ -24,6 +24,7 @@
     highlightQuery?: string;
     isCurrentHighlight?: boolean;
     sortNewestFirst?: boolean;
+    divider?: { ordinal: number; label: string };
     onMessageVisible?: (ordinal: number) => void;
   }
 
@@ -33,6 +34,7 @@
     highlightQuery = "",
     isCurrentHighlight = false,
     sortNewestFirst = false,
+    divider,
     onMessageVisible,
   }: Props = $props();
 
@@ -175,9 +177,14 @@
 
   <div class="tool-group-body">
     {#each displayMessages as message (message.ordinal)}
+      {#if divider?.ordinal === message.ordinal}
+        <div class="read-progress-divider" role="separator" aria-label={m.read_progress_boundary()}>
+          {divider.label}
+        </div>
+      {/if}
       {@const calls = message.tool_calls ?? []}
       {@const turn = turnByMessage.get(message.id)}
-      <div use:observeMessage={message.ordinal}>
+      <div data-message-ordinal={message.ordinal} use:observeMessage={message.ordinal}>
       {#if calls.length === 1}
         {@const soloCall = calls[0]!}
         <ToolBlock

--- a/frontend/src/lib/components/content/ToolCallGroup.svelte
+++ b/frontend/src/lib/components/content/ToolCallGroup.svelte
@@ -23,7 +23,6 @@
     timestamp: string;
     highlightQuery?: string;
     isCurrentHighlight?: boolean;
-    readMarker?: number | null;
     sortNewestFirst?: boolean;
     onMessageVisible?: (ordinal: number) => void;
   }
@@ -33,7 +32,6 @@
     timestamp,
     highlightQuery = "",
     isCurrentHighlight = false,
-    readMarker = null,
     sortNewestFirst = false,
     onMessageVisible,
   }: Props = $props();
@@ -63,27 +61,20 @@
     sortNewestFirst ? [...messages].reverse() : messages,
   );
 
-  let dividerOrdinal = $derived.by(() => {
-    if (readMarker === null) return null;
-    return displayMessages.find((message) =>
-      sortNewestFirst
-        ? message.ordinal <= readMarker
-        : message.ordinal > readMarker,
-    )?.ordinal ?? null;
-  });
-
   function observeMessage(node: HTMLElement, ordinal: number) {
     if (!onMessageVisible) {
       return {};
     }
     if (typeof IntersectionObserver === "undefined") {
       const root = node.closest(".message-list-scroll");
-      const rect = node.getBoundingClientRect();
-      const rootRect = root?.getBoundingClientRect();
-      if (rootRect && rect.bottom > rootRect.top && rect.top < rootRect.bottom) {
-        onMessageVisible(ordinal);
-      }
-      return {};
+      const check = () => {
+        const rect = node.getBoundingClientRect();
+        const rootRect = root?.getBoundingClientRect();
+        if (rootRect && rect.bottom > rootRect.top && rect.top < rootRect.bottom) onMessageVisible(ordinal);
+      };
+      check();
+      root?.addEventListener("scroll", check, { passive: true });
+      return { destroy: () => root?.removeEventListener("scroll", check) };
     }
     const observer = new IntersectionObserver((entries) => {
       if (!entries.some((entry) => entry.isIntersecting)) return;
@@ -187,11 +178,6 @@
       {@const calls = message.tool_calls ?? []}
       {@const turn = turnByMessage.get(message.id)}
       <div use:observeMessage={message.ordinal}>
-      {#if dividerOrdinal === message.ordinal}
-        <div class="read-progress-divider" role="separator" aria-label="Read progress boundary">
-          {sortNewestFirst ? "Earlier messages" : "New messages"}
-        </div>
-      {/if}
       {#if calls.length === 1}
         {@const soloCall = calls[0]!}
         <ToolBlock
@@ -277,26 +263,6 @@
     display: flex;
     flex-direction: column;
     gap: 2px;
-  }
-
-  .read-progress-divider {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    margin: 8px 0;
-    color: var(--accent-blue);
-    font-size: 11px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-  }
-
-  .read-progress-divider::before,
-  .read-progress-divider::after {
-    content: "";
-    height: 1px;
-    flex: 1;
-    background: color-mix(in srgb, var(--accent-blue) 55%, transparent);
   }
 
   .tool-group-body :global(.tool-block) {

--- a/frontend/src/lib/components/content/ToolCallGroup.svelte
+++ b/frontend/src/lib/components/content/ToolCallGroup.svelte
@@ -25,7 +25,8 @@
     isCurrentHighlight?: boolean;
     sortNewestFirst?: boolean;
     divider?: { ordinal: number; label: string };
-    onMessageVisible?: (ordinal: number) => void;
+    visibleSessionId?: string | null;
+    onMessageVisible?: (sessionId: string, ordinal: number, contentLength: number) => void;
   }
 
   let {
@@ -35,6 +36,7 @@
     isCurrentHighlight = false,
     sortNewestFirst = false,
     divider,
+    visibleSessionId = null,
     onMessageVisible,
   }: Props = $props();
 
@@ -63,12 +65,22 @@
     sortNewestFirst ? [...messages].reverse() : messages,
   );
 
-  function observeMessage(node: HTMLElement, ordinal: number) {
+  function observeMessage(
+    node: HTMLElement,
+    payload:
+      | { sessionId: string; ordinal: number; contentLength: number }
+      | undefined,
+  ) {
     const handleVisible = onMessageVisible;
-    if (!handleVisible) {
+    if (!handleVisible || !payload) {
       return {};
     }
-    const reportVisible = () => handleVisible(ordinal);
+    const reportVisible = () =>
+      handleVisible(
+        payload.sessionId,
+        payload.ordinal,
+        payload.contentLength,
+      );
     if (typeof IntersectionObserver === "undefined") {
       const root = node.closest(".message-list-scroll");
       const check = () => {
@@ -186,7 +198,17 @@
       {/if}
       {@const calls = message.tool_calls ?? []}
       {@const turn = turnByMessage.get(message.id)}
-      <div data-message-ordinal={message.ordinal} use:observeMessage={message.ordinal}>
+      <div
+        data-message-ordinal={message.ordinal}
+        data-message-content-length={message.content_length}
+        use:observeMessage={visibleSessionId
+          ? {
+            sessionId: visibleSessionId,
+            ordinal: message.ordinal,
+            contentLength: message.content_length,
+          }
+          : undefined}
+      >
       {#if calls.length === 1}
         {@const soloCall = calls[0]!}
         <ToolBlock

--- a/frontend/src/lib/components/content/ToolCallGroup.svelte
+++ b/frontend/src/lib/components/content/ToolCallGroup.svelte
@@ -15,6 +15,7 @@
   import ParallelGroup from "./ParallelGroup.svelte";
   import { CopyButton } from "@kenn-io/kit-ui";
   import { displayToolName } from "../../utils/toolDisplay.js";
+  import { renderedContentLength } from "../../utils/messages.js";
   import { SettingsIcon } from "../../icons.js";
   import { m } from "../../i18n/index.js";
 
@@ -200,12 +201,12 @@
       {@const turn = turnByMessage.get(message.id)}
       <div
         data-message-ordinal={message.ordinal}
-        data-message-content-length={message.content_length}
+        data-message-content-length={renderedContentLength(message)}
         use:observeMessage={visibleSessionId
           ? {
             sessionId: visibleSessionId,
             ordinal: message.ordinal,
-            contentLength: message.content_length,
+            contentLength: renderedContentLength(message),
           }
           : undefined}
       >

--- a/frontend/src/lib/components/content/ToolCallGroup.svelte
+++ b/frontend/src/lib/components/content/ToolCallGroup.svelte
@@ -72,34 +72,35 @@
       | { sessionId: string; ordinal: number; contentLength: number }
       | undefined,
   ) {
-    const handleVisible = onMessageVisible;
-    if (!handleVisible || !payload) {
-      return {};
-    }
-    const reportVisible = () =>
-      handleVisible(
-        payload.sessionId,
-        payload.ordinal,
-        payload.contentLength,
-      );
-    if (typeof IntersectionObserver === "undefined") {
-      const root = node.closest(".message-list-scroll");
-      const check = () => {
-        const rect = node.getBoundingClientRect();
-        const rootRect = root?.getBoundingClientRect();
-        if (rootRect && rect.bottom > rootRect.top && rect.top < rootRect.bottom) reportVisible();
-      };
-      check();
-      root?.addEventListener("scroll", check, { passive: true });
-      return { destroy: () => root?.removeEventListener("scroll", check) };
-    }
-    const observer = new IntersectionObserver((entries) => {
-      if (!entries.some((entry) => entry.isIntersecting)) return;
-      reportVisible();
-      observer.disconnect();
-    }, { root: node.closest(".message-list-scroll") });
-    observer.observe(node);
-    return { destroy: () => observer.disconnect() };
+    let cleanup = () => {};
+    const bind = (next: typeof payload) => {
+      cleanup();
+      cleanup = () => {};
+      if (!onMessageVisible || !next) return;
+      const reportVisible = () =>
+        onMessageVisible(next.sessionId, next.ordinal, next.contentLength);
+      if (typeof IntersectionObserver === "undefined") {
+        const root = node.closest(".message-list-scroll");
+        const check = () => {
+          const rect = node.getBoundingClientRect();
+          const rootRect = root?.getBoundingClientRect();
+          if (rootRect && rect.bottom > rootRect.top && rect.top < rootRect.bottom) reportVisible();
+        };
+        check();
+        root?.addEventListener("scroll", check, { passive: true });
+        cleanup = () => root?.removeEventListener("scroll", check);
+        return;
+      }
+      const observer = new IntersectionObserver((entries) => {
+        if (!entries.some((entry) => entry.isIntersecting)) return;
+        reportVisible();
+        observer.disconnect();
+      }, { root: node.closest(".message-list-scroll") });
+      observer.observe(node);
+      cleanup = () => observer.disconnect();
+    };
+    bind(payload);
+    return { update: bind, destroy: () => cleanup() };
   }
 
   /** Index turn timings by message id for O(1) lookup. */

--- a/frontend/src/lib/components/content/ToolCallGroup.test.ts
+++ b/frontend/src/lib/components/content/ToolCallGroup.test.ts
@@ -63,21 +63,35 @@ describe("ToolCallGroup read progress", () => {
       writable: true,
       value: ObserverMock,
     });
-    const seen: number[] = [];
+    const seen: Array<[number, number]> = [];
     component = mount(ToolCallGroup, {
       target: document.body,
       props: {
-        messages: [makeToolMessage(4), makeToolMessage(5)],
+        messages: [makeToolMessage(4), {
+          ...makeToolMessage(5),
+          content_length: 4,
+          tool_calls: [{
+            tool_name: "Bash",
+            result_content_length: 3,
+            result_events: [{
+              source: "tool",
+              status: "completed",
+              content: "event",
+              content_length: 5,
+              event_index: 0,
+            }],
+          }],
+        }],
         timestamp: new Date().toISOString(),
         visibleSessionId: "s1",
-        onMessageVisible: (_sessionId: string, ordinal: number) => seen.push(ordinal),
+        onMessageVisible: (_sessionId: string, ordinal: number, contentLength: number) => seen.push([ordinal, contentLength]),
       },
     });
     await tick();
 
     callbacks[1]!([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver);
 
-    expect(seen).toEqual([5]);
+    expect(seen).toEqual([[5, 12]]);
   });
 
   it("reports tool messages without IntersectionObserver", async () => {

--- a/frontend/src/lib/components/content/ToolCallGroup.test.ts
+++ b/frontend/src/lib/components/content/ToolCallGroup.test.ts
@@ -79,6 +79,44 @@ describe("ToolCallGroup read progress", () => {
     expect(seen).toEqual([5]);
   });
 
+  it("reports tool messages without IntersectionObserver", async () => {
+    originalObserver = globalThis.IntersectionObserver;
+    Object.defineProperty(globalThis, "IntersectionObserver", {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+    const seen: number[] = [];
+    const target = document.createElement("div");
+    target.className = "message-list-scroll";
+    document.body.append(target);
+    const rectSpy = vi
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockReturnValue({
+        bottom: 100,
+        height: 100,
+        left: 0,
+        right: 100,
+        top: 0,
+        width: 100,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      });
+    component = mount(ToolCallGroup, {
+      target,
+      props: {
+        messages: [makeToolMessage(4)],
+        timestamp: new Date().toISOString(),
+        onMessageVisible: (ordinal: number) => seen.push(ordinal),
+      },
+    });
+    await tick();
+
+    expect(seen).toEqual([4]);
+    rectSpy.mockRestore();
+  });
+
   it("splits tool groups at the watermark in both sort directions", () => {
     component = mount(ToolCallGroup, {
       target: document.body,

--- a/frontend/src/lib/components/content/ToolCallGroup.test.ts
+++ b/frontend/src/lib/components/content/ToolCallGroup.test.ts
@@ -117,27 +117,34 @@ describe("ToolCallGroup read progress", () => {
     rectSpy.mockRestore();
   });
 
-  it("leaves the global read boundary to MessageList", () => {
+  it("places the divider immediately before its chronological submessage", () => {
     component = mount(ToolCallGroup, {
       target: document.body,
       props: {
         messages: [makeToolMessage(4), makeToolMessage(5)],
         timestamp: new Date().toISOString(),
+        divider: { ordinal: 5, label: "New messages" },
       },
     });
 
-    expect(document.querySelectorAll(".read-progress-divider")).toHaveLength(0);
+    const target = document.querySelector('[data-message-ordinal="5"]');
+    expect(target?.previousElementSibling?.classList.contains("read-progress-divider")).toBe(true);
+    expect(target?.previousElementSibling?.textContent).toContain("New messages");
+  });
 
-    unmount(component);
+  it("places the divider immediately before its newest-first submessage", () => {
     component = mount(ToolCallGroup, {
       target: document.body,
       props: {
         messages: [makeToolMessage(4), makeToolMessage(5)],
         timestamp: new Date().toISOString(),
         sortNewestFirst: true,
+        divider: { ordinal: 5, label: "Earlier messages" },
       },
     });
 
-    expect(document.querySelectorAll(".read-progress-divider")).toHaveLength(0);
+    const target = document.querySelector('[data-message-ordinal="5"]');
+    expect(target?.previousElementSibling?.classList.contains("read-progress-divider")).toBe(true);
+    expect(target?.previousElementSibling?.textContent).toContain("Earlier messages");
   });
 });

--- a/frontend/src/lib/components/content/ToolCallGroup.test.ts
+++ b/frontend/src/lib/components/content/ToolCallGroup.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mount, tick, unmount } from "svelte";
+import type { Message } from "../../api/types.js";
+// @ts-ignore
+import ToolCallGroup from "./ToolCallGroup.svelte";
+
+function makeToolMessage(ordinal: number): Message {
+  return {
+    id: ordinal,
+    session_id: "s1",
+    ordinal,
+    role: "assistant",
+    content: "",
+    timestamp: new Date(ordinal * 1000).toISOString(),
+    has_thinking: false,
+    thinking_text: "",
+    has_tool_use: true,
+    content_length: 0,
+    model: "",
+    token_usage: null,
+    context_tokens: 0,
+    output_tokens: 0,
+    has_context_tokens: false,
+    has_output_tokens: false,
+    is_system: false,
+  };
+}
+
+describe("ToolCallGroup read progress", () => {
+  let component: ReturnType<typeof mount> | undefined;
+  let originalObserver: typeof IntersectionObserver | undefined;
+
+  afterEach(() => {
+    if (component) unmount(component);
+    component = undefined;
+    Object.defineProperty(globalThis, "IntersectionObserver", {
+      configurable: true,
+      writable: true,
+      value: originalObserver,
+    });
+    document.body.innerHTML = "";
+  });
+
+  it("reports only the intersecting tool submessage", async () => {
+    const callbacks: IntersectionObserverCallback[] = [];
+    originalObserver = globalThis.IntersectionObserver;
+    class ObserverMock {
+      constructor(callback: IntersectionObserverCallback) {
+        callbacks.push(callback);
+      }
+
+      observe() {}
+      disconnect() {}
+      unobserve() {}
+      takeRecords() { return []; }
+      root = null;
+      rootMargin = "0px";
+      thresholds = [];
+    }
+    Object.defineProperty(globalThis, "IntersectionObserver", {
+      configurable: true,
+      writable: true,
+      value: ObserverMock,
+    });
+    const seen: number[] = [];
+    component = mount(ToolCallGroup, {
+      target: document.body,
+      props: {
+        messages: [makeToolMessage(4), makeToolMessage(5)],
+        timestamp: new Date().toISOString(),
+        onMessageVisible: (ordinal: number) => seen.push(ordinal),
+      },
+    });
+    await tick();
+
+    callbacks[1]!([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver);
+
+    expect(seen).toEqual([5]);
+  });
+
+  it("splits tool groups at the watermark in both sort directions", () => {
+    component = mount(ToolCallGroup, {
+      target: document.body,
+      props: {
+        messages: [makeToolMessage(4), makeToolMessage(5)],
+        timestamp: new Date().toISOString(),
+        readMarker: 4,
+      },
+    });
+
+    expect(document.querySelectorAll(".read-progress-divider")).toHaveLength(1);
+    expect(document.body.textContent).toContain("New messages");
+
+    unmount(component);
+    component = mount(ToolCallGroup, {
+      target: document.body,
+      props: {
+        messages: [makeToolMessage(4), makeToolMessage(5)],
+        timestamp: new Date().toISOString(),
+        readMarker: 4,
+        sortNewestFirst: true,
+      },
+    });
+
+    expect(document.querySelectorAll(".read-progress-divider")).toHaveLength(1);
+    expect(document.body.textContent).toContain("Earlier messages");
+  });
+});

--- a/frontend/src/lib/components/content/ToolCallGroup.test.ts
+++ b/frontend/src/lib/components/content/ToolCallGroup.test.ts
@@ -69,7 +69,8 @@ describe("ToolCallGroup read progress", () => {
       props: {
         messages: [makeToolMessage(4), makeToolMessage(5)],
         timestamp: new Date().toISOString(),
-        onMessageVisible: (ordinal: number) => seen.push(ordinal),
+        visibleSessionId: "s1",
+        onMessageVisible: (_sessionId: string, ordinal: number) => seen.push(ordinal),
       },
     });
     await tick();
@@ -108,7 +109,8 @@ describe("ToolCallGroup read progress", () => {
       props: {
         messages: [makeToolMessage(4)],
         timestamp: new Date().toISOString(),
-        onMessageVisible: (ordinal: number) => seen.push(ordinal),
+        visibleSessionId: "s1",
+        onMessageVisible: (_sessionId: string, ordinal: number) => seen.push(ordinal),
       },
     });
     await tick();

--- a/frontend/src/lib/components/content/ToolCallGroup.test.ts
+++ b/frontend/src/lib/components/content/ToolCallGroup.test.ts
@@ -133,6 +133,40 @@ describe("ToolCallGroup read progress", () => {
     rectSpy.mockRestore();
   });
 
+  it("cleans up the fallback listener on destroy", async () => {
+    originalObserver = globalThis.IntersectionObserver;
+    Object.defineProperty(globalThis, "IntersectionObserver", {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+    const seen: number[] = [];
+    const target = document.createElement("div");
+    target.className = "message-list-scroll";
+    document.body.append(target);
+    const rectSpy = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockReturnValue({
+        bottom: 100, height: 100, left: 0, right: 100, top: 0, width: 100,
+        x: 0, y: 0, toJSON: () => ({}),
+      });
+    component = mount(ToolCallGroup, {
+      target,
+      props: {
+        messages: [makeToolMessage(4)],
+        timestamp: new Date().toISOString(),
+        visibleSessionId: "s1",
+        onMessageVisible: (_sessionId: string, ordinal: number) => seen.push(ordinal),
+      },
+    });
+    await tick();
+    expect(seen).toEqual([4]);
+    unmount(component);
+    component = undefined;
+    target.dispatchEvent(new Event("scroll"));
+    expect(seen).toEqual([4]);
+    rectSpy.mockRestore();
+  });
+
   it("places the divider immediately before its chronological submessage", () => {
     component = mount(ToolCallGroup, {
       target: document.body,

--- a/frontend/src/lib/components/content/ToolCallGroup.test.ts
+++ b/frontend/src/lib/components/content/ToolCallGroup.test.ts
@@ -117,18 +117,16 @@ describe("ToolCallGroup read progress", () => {
     rectSpy.mockRestore();
   });
 
-  it("splits tool groups at the watermark in both sort directions", () => {
+  it("leaves the global read boundary to MessageList", () => {
     component = mount(ToolCallGroup, {
       target: document.body,
       props: {
         messages: [makeToolMessage(4), makeToolMessage(5)],
         timestamp: new Date().toISOString(),
-        readMarker: 4,
       },
     });
 
-    expect(document.querySelectorAll(".read-progress-divider")).toHaveLength(1);
-    expect(document.body.textContent).toContain("New messages");
+    expect(document.querySelectorAll(".read-progress-divider")).toHaveLength(0);
 
     unmount(component);
     component = mount(ToolCallGroup, {
@@ -136,12 +134,10 @@ describe("ToolCallGroup read progress", () => {
       props: {
         messages: [makeToolMessage(4), makeToolMessage(5)],
         timestamp: new Date().toISOString(),
-        readMarker: 4,
         sortNewestFirst: true,
       },
     });
 
-    expect(document.querySelectorAll(".read-progress-divider")).toHaveLength(1);
-    expect(document.body.textContent).toContain("Earlier messages");
+    expect(document.querySelectorAll(".read-progress-divider")).toHaveLength(0);
   });
 });

--- a/frontend/src/lib/components/layout/AppHeader.test.ts
+++ b/frontend/src/lib/components/layout/AppHeader.test.ts
@@ -50,6 +50,7 @@ function testSession(overrides: Partial<Session> = {}): Session {
     is_automated: false,
     created_at: "2026-06-13T12:00:00Z",
     ...overrides,
+    latest_display_ordinal: overrides.latest_display_ordinal ?? 1,
   };
 }
 

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
@@ -94,6 +94,7 @@ function makeSession(
     is_automated: false,
     created_at: "2026-02-20T12:30:00Z",
     ...overrides,
+    latest_display_ordinal: overrides.latest_display_ordinal ?? 1,
   };
 }
 

--- a/frontend/src/lib/components/sidebar/SessionItem.svelte
+++ b/frontend/src/lib/components/sidebar/SessionItem.svelte
@@ -149,7 +149,11 @@
   let hasUnread = $derived.by(() => {
     const group = !expanded && groupSessions ? groupSessions : [session];
     return group.some((entry) =>
-      readProgress.hasUnread(entry.id, entry.latest_display_ordinal),
+      readProgress.hasUnread(
+        entry.id,
+        entry.latest_display_ordinal,
+        entry.latest_display_content_length ?? null,
+      ),
     );
   });
 

--- a/frontend/src/lib/components/sidebar/SessionItem.svelte
+++ b/frontend/src/lib/components/sidebar/SessionItem.svelte
@@ -149,7 +149,7 @@
   let hasUnread = $derived.by(() => {
     const group = !expanded && groupSessions ? groupSessions : [session];
     return group.some((entry) =>
-      readProgress.hasUnread(entry.id, entry.message_count),
+      readProgress.hasUnread(entry.id, entry.latest_display_ordinal),
     );
   });
 

--- a/frontend/src/lib/components/sidebar/SessionItem.svelte
+++ b/frontend/src/lib/components/sidebar/SessionItem.svelte
@@ -146,9 +146,12 @@
   );
 
   let isStarred = $derived(starred.isStarred(session.id));
-  let hasUnread = $derived(
-    readProgress.hasUnread(session.id, session.message_count),
-  );
+  let hasUnread = $derived.by(() => {
+    const group = !expanded && groupSessions ? groupSessions : [session];
+    return group.some((entry) =>
+      readProgress.hasUnread(entry.id, entry.message_count),
+    );
+  });
 
   let childCount = $derived(
     continuationCount > 1 ? continuationCount - 1 : 0,

--- a/frontend/src/lib/components/sidebar/SessionItem.svelte
+++ b/frontend/src/lib/components/sidebar/SessionItem.svelte
@@ -434,7 +434,7 @@
           <span class="session-time">{timeStr}</span>
           <span class="session-count">{session.user_message_count}</span>
           {#if hasUnread}
-            <span class="unread-indicator" aria-label="Unread messages" title="Unread messages"></span>
+            <span class="unread-indicator" aria-label={m.read_progress_unread_messages()} title={m.read_progress_unread_messages()}></span>
           {/if}
           {#if hasSubagents}
             <UserRoundIcon class="group-hint-icon" size="9" strokeWidth="2" aria-hidden="true" />

--- a/frontend/src/lib/components/sidebar/SessionItem.svelte
+++ b/frontend/src/lib/components/sidebar/SessionItem.svelte
@@ -6,6 +6,7 @@
     type SessionGroupInput,
   } from "../../stores/sessions.svelte.js";
   import { starred } from "../../stores/starred.svelte.js";
+  import { readProgress } from "../../stores/read-progress.svelte.js";
   import { formatRelativeTime, truncate } from "../../utils/format.js";
   import { agentColor as getAgentColor, agentLabel } from "../../utils/agents.js";
   import {
@@ -145,6 +146,9 @@
   );
 
   let isStarred = $derived(starred.isStarred(session.id));
+  let hasUnread = $derived(
+    readProgress.hasUnread(session.id, session.message_count),
+  );
 
   let childCount = $derived(
     continuationCount > 1 ? continuationCount - 1 : 0,
@@ -426,6 +430,9 @@
           {/if}
           <span class="session-time">{timeStr}</span>
           <span class="session-count">{session.user_message_count}</span>
+          {#if hasUnread}
+            <span class="unread-indicator" aria-label="Unread messages" title="Unread messages"></span>
+          {/if}
           {#if hasSubagents}
             <UserRoundIcon class="group-hint-icon" size="9" strokeWidth="2" aria-hidden="true" />
           {/if}
@@ -713,6 +720,14 @@
 
   .session-count::before {
     content: "\2022 ";
+  }
+
+  .unread-indicator {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    background: var(--accent-blue);
   }
 
   .continuation-badge {

--- a/frontend/src/lib/components/sidebar/SessionList.svelte
+++ b/frontend/src/lib/components/sidebar/SessionList.svelte
@@ -212,7 +212,7 @@
 
   function hasUnread(entries: SessionGroupInput[]): boolean {
     return entries.some((entry) =>
-      readProgress.hasUnread(entry.id, entry.message_count),
+      readProgress.hasUnread(entry.id, entry.latest_display_ordinal),
     );
   }
 

--- a/frontend/src/lib/components/sidebar/SessionList.svelte
+++ b/frontend/src/lib/components/sidebar/SessionList.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
   import { onDestroy, onMount } from "svelte";
   import { m } from "../../i18n/index.js";
-  import { sessions } from "../../stores/sessions.svelte.js";
+  import {
+    sessions,
+    type SessionGroupInput,
+  } from "../../stores/sessions.svelte.js";
   import { starred } from "../../stores/starred.svelte.js";
+  import { readProgress } from "../../stores/read-progress.svelte.js";
   import SessionItem from "./SessionItem.svelte";
   import SessionFilterControl from "../filters/SessionFilterControl.svelte";
   import {
@@ -27,6 +31,7 @@
     computeTotalSize,
     findStart,
     isSubagentDescendant,
+    isTeammateDescendant,
     selectPrimaryId,
   } from "./session-list-utils.js";
 
@@ -203,6 +208,21 @@
     return item.group?.sessions.find(
       (s) => s.id === item.group!.primarySessionId,
     ) ?? item.group?.sessions[0];
+  }
+
+  function hasUnread(entries: SessionGroupInput[]): boolean {
+    return entries.some((entry) =>
+      readProgress.hasUnread(entry.id, entry.message_count),
+    );
+  }
+
+  function childSessions(
+    group: NonNullable<DisplayItem["group"]>,
+    predicate: (entry: SessionGroupInput) => boolean,
+  ): SessionGroupInput[] {
+    return group.sessions.filter((entry) =>
+      entry.id !== group.primarySessionId && predicate(entry),
+    );
   }
 
   function needsVisibleHydration(item: DisplayItem): boolean {
@@ -574,6 +594,7 @@
         style="position: absolute; top: 0; left: 0; width: 100%; height: {item.height}px; transform: translateY({item.top}px);"
       >
         {#if item.type === "header"}
+          {@const section = groupSections.find((entry) => entry.label === item.label)}
           <button
             class="group-header"
             onclick={() => toggleGroup(item.label)}
@@ -595,10 +616,14 @@
             {/if}
             <span class="group-name">{item.label}</span>
             <span class="group-count">{item.count}</span>
+            {#if section && hasUnread(section.groups.flatMap((group) => group.sessions))}
+              <span class="group-unread-indicator" aria-label="Unread messages"></span>
+            {/if}
           </button>
         {:else if item.type === "subagent-group" && item.group}
           {@const subKey = `subagent:${item.group.key}`}
           {@const subExpanded = expandedGroups.has(subKey)}
+          {@const subagents = childSessions(item.group, (entry) => isSubagentDescendant(entry, item.group!.sessions))}
           <button
             class="sub-group-header"
             style:padding-left="{8 + (item.depth ?? 1) * 16}px"
@@ -614,10 +639,14 @@
             <UserRoundIcon class="sub-group-icon" size="10" strokeWidth="2" aria-hidden="true" />
             <span class="sub-group-label">{m.sidebar_subagents()}</span>
             <span class="sub-group-count">({item.count})</span>
+            {#if hasUnread(subagents)}
+              <span class="group-unread-indicator" aria-label="Unread messages"></span>
+            {/if}
           </button>
         {:else if item.type === "team-group" && item.group}
           {@const teamKey = `team:${item.group.key}`}
           {@const teamExpanded = expandedGroups.has(teamKey)}
+          {@const teammates = childSessions(item.group, (entry) => isTeammateDescendant(entry, item.group!.sessions))}
           <button
             class="sub-group-header"
             style:padding-left="{8 + (item.depth ?? 1) * 16}px"
@@ -633,6 +662,9 @@
             <UsersRoundIcon class="sub-group-icon" size="12" strokeWidth="2" aria-hidden="true" />
             <span class="sub-group-label">{m.sidebar_team()}</span>
             <span class="sub-group-count">({item.count})</span>
+            {#if hasUnread(teammates)}
+              <span class="group-unread-indicator" aria-label="Unread messages"></span>
+            {/if}
           </button>
         {:else if item.isChild && item.session}
           <SessionItem
@@ -864,6 +896,14 @@
     padding: 0 5px;
     border-radius: 8px;
     line-height: 16px;
+  }
+
+  .group-unread-indicator {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    background: var(--accent-blue);
   }
 
   /* Sub-group headers (Subagents, Team) at depth 1 */

--- a/frontend/src/lib/components/sidebar/SessionList.svelte
+++ b/frontend/src/lib/components/sidebar/SessionList.svelte
@@ -621,7 +621,7 @@
             <span class="group-name">{item.label}</span>
             <span class="group-count">{item.count}</span>
             {#if section && hasUnread(section.groups.flatMap((group) => group.sessions))}
-              <span class="group-unread-indicator" aria-label="Unread messages"></span>
+              <span class="group-unread-indicator" aria-label={m.read_progress_unread_messages()}></span>
             {/if}
           </button>
         {:else if item.type === "subagent-group" && item.group}
@@ -644,7 +644,7 @@
             <span class="sub-group-label">{m.sidebar_subagents()}</span>
             <span class="sub-group-count">({item.count})</span>
             {#if hasUnread(subagents)}
-              <span class="group-unread-indicator" aria-label="Unread messages"></span>
+              <span class="group-unread-indicator" aria-label={m.read_progress_unread_messages()}></span>
             {/if}
           </button>
         {:else if item.type === "team-group" && item.group}
@@ -667,7 +667,7 @@
             <span class="sub-group-label">{m.sidebar_team()}</span>
             <span class="sub-group-count">({item.count})</span>
             {#if hasUnread(teammates)}
-              <span class="group-unread-indicator" aria-label="Unread messages"></span>
+              <span class="group-unread-indicator" aria-label={m.read_progress_unread_messages()}></span>
             {/if}
           </button>
         {:else if item.isChild && item.session}

--- a/frontend/src/lib/components/sidebar/SessionList.svelte
+++ b/frontend/src/lib/components/sidebar/SessionList.svelte
@@ -218,10 +218,14 @@
 
   function childSessions(
     group: NonNullable<DisplayItem["group"]>,
-    predicate: (entry: SessionGroupInput) => boolean,
+    predicate: (
+      entry: SessionGroupInput,
+      allSessions: SessionGroupInput[],
+    ) => boolean,
   ): SessionGroupInput[] {
+    const allSessions = group.allSessions ?? group.sessions;
     return group.sessions.filter((entry) =>
-      entry.id !== group.primarySessionId && predicate(entry),
+      entry.id !== group.primarySessionId && predicate(entry, allSessions),
     );
   }
 
@@ -623,7 +627,7 @@
         {:else if item.type === "subagent-group" && item.group}
           {@const subKey = `subagent:${item.group.key}`}
           {@const subExpanded = expandedGroups.has(subKey)}
-          {@const subagents = childSessions(item.group, (entry) => isSubagentDescendant(entry, item.group!.sessions))}
+          {@const subagents = childSessions(item.group, isSubagentDescendant)}
           <button
             class="sub-group-header"
             style:padding-left="{8 + (item.depth ?? 1) * 16}px"
@@ -646,7 +650,7 @@
         {:else if item.type === "team-group" && item.group}
           {@const teamKey = `team:${item.group.key}`}
           {@const teamExpanded = expandedGroups.has(teamKey)}
-          {@const teammates = childSessions(item.group, (entry) => isTeammateDescendant(entry, item.group!.sessions))}
+          {@const teammates = childSessions(item.group, isTeammateDescendant)}
           <button
             class="sub-group-header"
             style:padding-left="{8 + (item.depth ?? 1) * 16}px"

--- a/frontend/src/lib/components/sidebar/SessionList.svelte
+++ b/frontend/src/lib/components/sidebar/SessionList.svelte
@@ -212,7 +212,11 @@
 
   function hasUnread(entries: SessionGroupInput[]): boolean {
     return entries.some((entry) =>
-      readProgress.hasUnread(entry.id, entry.latest_display_ordinal),
+      readProgress.hasUnread(
+        entry.id,
+        entry.latest_display_ordinal,
+        entry.latest_display_content_length ?? null,
+      ),
     );
   }
 

--- a/frontend/src/lib/components/sidebar/SessionList.test.ts
+++ b/frontend/src/lib/components/sidebar/SessionList.test.ts
@@ -15,12 +15,13 @@ import sessionItemSource from "./SessionItem.svelte?raw";
 import { sessions } from "../../stores/sessions.svelte.js";
 import type { Session } from "../../api/types.js";
 import { starred } from "../../stores/starred.svelte.js";
-import { m, setLocale } from "../../i18n/index.js";
+  import { m, setLocale } from "../../i18n/index.js";
 import {
   ITEM_HEIGHT,
   OVERSCAN,
   STORAGE_KEY_GROUP,
 } from "./session-list-utils.js";
+  import { readProgress } from "../../stores/read-progress.svelte.js";
 
 vi.mock("../../api/client.js", () => ({
   listSessions: vi.fn().mockResolvedValue({
@@ -91,6 +92,7 @@ describe("SessionList filter dropdown", () => {
     starred.ids = new Set();
     setLocale("en");
     localStorage.clear();
+    localStorage.removeItem(STORAGE_KEY_GROUP);
     readProgress.clear("read-session");
     readProgress.clear("neighbouring-session");
     readProgress.clear("group-root");
@@ -111,6 +113,7 @@ describe("SessionList filter dropdown", () => {
     clientHeightSpy?.mockRestore();
     rafSpy?.mockRestore();
     vi.restoreAllMocks();
+    localStorage.removeItem(STORAGE_KEY_GROUP);
     readProgress.clear("read-session");
     readProgress.clear("neighbouring-session");
     readProgress.clear("group-root");
@@ -858,6 +861,24 @@ describe("SessionList visible hydration", () => {
     expect(
       document.querySelector('[data-session-id="group-root"] .unread-indicator'),
     ).not.toBeNull();
+  });
+
+  it("shows unread state on a collapsed project group", async () => {
+    localStorage.setItem(STORAGE_KEY_GROUP, "project");
+    sessions.sessions = [
+      makeSession({
+        id: "group-root",
+        display_name: "Root",
+        message_count: 5,
+      }),
+    ];
+    readProgress.baseline("group-root", 2, 3);
+    vi.spyOn(sessions, "hydrateVisibleSessions").mockResolvedValue(undefined);
+
+    component = mount(SessionList, { target: document.body });
+    await tick();
+
+    expect(document.querySelector(".group-header .group-unread-indicator")).not.toBeNull();
   });
 });
 

--- a/frontend/src/lib/components/sidebar/SessionList.test.ts
+++ b/frontend/src/lib/components/sidebar/SessionList.test.ts
@@ -867,6 +867,27 @@ describe("SessionList visible hydration", () => {
     ).not.toBeNull();
   });
 
+  it("shows unread state when the latest display message grows at the same ordinal", async () => {
+    sessions.sessions = [
+      makeSession({
+        id: "same-ordinal",
+        display_name: "Same ordinal growth",
+        message_count: 5,
+        latest_display_ordinal: 4,
+        latest_display_content_length: 12,
+      }),
+    ];
+    readProgress.baseline("same-ordinal", 4, 6);
+    vi.spyOn(sessions, "hydrateVisibleSessions").mockResolvedValue(undefined);
+
+    component = mount(SessionList, { target: document.body });
+    await tick();
+
+    expect(
+      document.querySelector('[data-session-id="same-ordinal"] .unread-indicator'),
+    ).not.toBeNull();
+  });
+
   it("shows unread state on a collapsed project group", async () => {
     localStorage.setItem(STORAGE_KEY_GROUP, "project");
     sessions.sessions = [

--- a/frontend/src/lib/components/sidebar/SessionList.test.ts
+++ b/frontend/src/lib/components/sidebar/SessionList.test.ts
@@ -845,16 +845,18 @@ describe("SessionList visible hydration", () => {
         id: "group-root",
         display_name: "Root",
         message_count: 3,
+        latest_display_ordinal: 2,
       }),
       makeSession({
         id: "group-child",
         parent_session_id: "group-root",
         display_name: "Child",
         message_count: 5,
+        latest_display_ordinal: 4,
       }),
     ];
-    readProgress.baseline("group-root", 2, 3);
-    readProgress.baseline("group-child", 2, 3);
+    readProgress.baseline("group-root", 2);
+    readProgress.baseline("group-child", 2);
     vi.spyOn(sessions, "hydrateVisibleSessions").mockResolvedValue(undefined);
 
     component = mount(SessionList, { target: document.body });
@@ -872,9 +874,10 @@ describe("SessionList visible hydration", () => {
         id: "group-root",
         display_name: "Root",
         message_count: 5,
+        latest_display_ordinal: 4,
       }),
     ];
-    readProgress.baseline("group-root", 2, 3);
+    readProgress.baseline("group-root", 2);
     vi.spyOn(sessions, "hydrateVisibleSessions").mockResolvedValue(undefined);
 
     component = mount(SessionList, { target: document.body });
@@ -886,7 +889,7 @@ describe("SessionList visible hydration", () => {
   it("keeps a starred subagent descendant unread when its parent is filtered", async () => {
     localStorage.setItem(STORAGE_KEY_GROUP, "none");
     sessions.sessions = [
-      makeSession({ id: "group-root", display_name: "Root", message_count: 3 }),
+      makeSession({ id: "group-root", display_name: "Root", message_count: 3, latest_display_ordinal: 2 }),
       makeSession({
         id: "filtered-subagent",
         parent_session_id: "group-root",
@@ -898,12 +901,13 @@ describe("SessionList visible hydration", () => {
         parent_session_id: "filtered-subagent",
         display_name: "Starred subagent",
         message_count: 5,
+        latest_display_ordinal: 4,
       }),
     ];
     starred.filterOnly = true;
     starred.ids = new Set(["group-root", "starred-subagent"]);
-    readProgress.baseline("group-root", 2, 3);
-    readProgress.baseline("starred-subagent", 2, 3);
+    readProgress.baseline("group-root", 2);
+    readProgress.baseline("starred-subagent", 2);
     vi.spyOn(sessions, "hydrateVisibleSessions").mockResolvedValue(undefined);
 
     component = mount(SessionList, { target: document.body });
@@ -926,6 +930,7 @@ function makeSession(
     started_at: "2024-01-01T00:00:00Z",
     ended_at: "2024-01-01T00:01:00Z",
     message_count: 1,
+    latest_display_ordinal: 0,
     user_message_count: 1,
     total_output_tokens: 0,
     peak_context_tokens: 0,

--- a/frontend/src/lib/components/sidebar/SessionList.test.ts
+++ b/frontend/src/lib/components/sidebar/SessionList.test.ts
@@ -91,6 +91,10 @@ describe("SessionList filter dropdown", () => {
     starred.ids = new Set();
     setLocale("en");
     localStorage.clear();
+    readProgress.clear("read-session");
+    readProgress.clear("neighbouring-session");
+    readProgress.clear("group-root");
+    readProgress.clear("group-child");
   });
 
   afterEach(() => {
@@ -107,6 +111,10 @@ describe("SessionList filter dropdown", () => {
     clientHeightSpy?.mockRestore();
     rafSpy?.mockRestore();
     vi.restoreAllMocks();
+    readProgress.clear("read-session");
+    readProgress.clear("neighbouring-session");
+    readProgress.clear("group-root");
+    readProgress.clear("group-child");
   });
 
   it("bounds the filter menu to the viewport and lets it scroll", async () => {
@@ -824,6 +832,32 @@ describe("SessionList visible hydration", () => {
     await tick();
 
     expect(loadMore).not.toHaveBeenCalled();
+  });
+
+  it("keeps a collapsed continuation unread when a child has newer output", async () => {
+    sessions.sessions = [
+      makeSession({
+        id: "group-root",
+        display_name: "Root",
+        message_count: 3,
+      }),
+      makeSession({
+        id: "group-child",
+        parent_session_id: "group-root",
+        display_name: "Child",
+        message_count: 5,
+      }),
+    ];
+    readProgress.baseline("group-root", 2, 3);
+    readProgress.baseline("group-child", 2, 3);
+    vi.spyOn(sessions, "hydrateVisibleSessions").mockResolvedValue(undefined);
+
+    component = mount(SessionList, { target: document.body });
+    await tick();
+
+    expect(
+      document.querySelector('[data-session-id="group-root"] .unread-indicator'),
+    ).not.toBeNull();
   });
 });
 

--- a/frontend/src/lib/components/sidebar/SessionList.test.ts
+++ b/frontend/src/lib/components/sidebar/SessionList.test.ts
@@ -97,6 +97,7 @@ describe("SessionList filter dropdown", () => {
     readProgress.clear("neighbouring-session");
     readProgress.clear("group-root");
     readProgress.clear("group-child");
+    readProgress.clear("starred-subagent");
   });
 
   afterEach(() => {
@@ -118,6 +119,7 @@ describe("SessionList filter dropdown", () => {
     readProgress.clear("neighbouring-session");
     readProgress.clear("group-root");
     readProgress.clear("group-child");
+    readProgress.clear("starred-subagent");
   });
 
   it("bounds the filter menu to the viewport and lets it scroll", async () => {
@@ -879,6 +881,37 @@ describe("SessionList visible hydration", () => {
     await tick();
 
     expect(document.querySelector(".group-header .group-unread-indicator")).not.toBeNull();
+  });
+
+  it("keeps a starred subagent descendant unread when its parent is filtered", async () => {
+    localStorage.setItem(STORAGE_KEY_GROUP, "none");
+    sessions.sessions = [
+      makeSession({ id: "group-root", display_name: "Root", message_count: 3 }),
+      makeSession({
+        id: "filtered-subagent",
+        parent_session_id: "group-root",
+        relationship_type: "subagent",
+        display_name: "Filtered subagent",
+      }),
+      makeSession({
+        id: "starred-subagent",
+        parent_session_id: "filtered-subagent",
+        display_name: "Starred subagent",
+        message_count: 5,
+      }),
+    ];
+    starred.filterOnly = true;
+    starred.ids = new Set(["group-root", "starred-subagent"]);
+    readProgress.baseline("group-root", 2, 3);
+    readProgress.baseline("starred-subagent", 2, 3);
+    vi.spyOn(sessions, "hydrateVisibleSessions").mockResolvedValue(undefined);
+
+    component = mount(SessionList, { target: document.body });
+    await tick();
+    document.querySelector<HTMLButtonElement>(".tree-toggle")?.click();
+    await tick();
+
+    expect(document.querySelector(".sub-group-header .group-unread-indicator")).not.toBeNull();
   });
 });
 

--- a/frontend/src/lib/components/sidebar/session-list-utils.test.ts
+++ b/frontend/src/lib/components/sidebar/session-list-utils.test.ts
@@ -34,6 +34,7 @@ function makeSession(overrides: Partial<Session> = {}): Session {
     is_automated: false,
     created_at: "2025-01-01T00:00:00Z",
     ...overrides,
+    latest_display_ordinal: overrides.latest_display_ordinal ?? 9,
   };
 }
 

--- a/frontend/src/lib/components/sidebar/session-list-utils.ts
+++ b/frontend/src/lib/components/sidebar/session-list-utils.ts
@@ -157,6 +157,13 @@ function isTeammate(
   return false;
 }
 
+export function isTeammateDescendant(
+  session: SessionGroupInput,
+  groupSessions: SessionGroupInput[],
+): boolean {
+  return isTeammate(session, groupSessions);
+}
+
 /**
  * Check if a session is a subagent (has relationship_type === "subagent").
  * Continuation/fork sessions are NOT subagents.

--- a/frontend/src/lib/stores/insights.test.ts
+++ b/frontend/src/lib/stores/insights.test.ts
@@ -79,6 +79,7 @@ function makeSession(overrides: Partial<Session> = {}): Session {
     is_automated: false,
     created_at: "2026-07-05T14:30:00Z",
     ...overrides,
+    latest_display_ordinal: overrides.latest_display_ordinal ?? 1,
   };
 }
 

--- a/frontend/src/lib/stores/messages.svelte.ts
+++ b/frontend/src/lib/stores/messages.svelte.ts
@@ -154,14 +154,15 @@ class MessagesStore {
     this.loadOlderPromise = null;
   }
 
-  private hasCompleteMessageRange(): boolean {
+  hasCompleteMessageRange(): boolean {
     const first = this.messages[0];
     const last = this.messages[this.messages.length - 1];
     return this.messageCount === 0
-      ? this.messages.length === 0
+      ? this.messages.length === 0 && !this.hasOlder
       : this.messages.length === this.messageCount &&
         first?.ordinal === 0 &&
-        last?.ordinal === this.messageCount - 1;
+        last?.ordinal === this.messageCount - 1 &&
+        !this.hasOlder;
   }
 
   private async fetchPages(

--- a/frontend/src/lib/stores/messages.svelte.ts
+++ b/frontend/src/lib/stores/messages.svelte.ts
@@ -461,6 +461,7 @@ class MessagesStore {
       const oldCount = this.messageCount;
       if (newCount === oldCount) {
         await this.refreshLoadedWindow(id, signal);
+        if (this.sessionId === id) this.initialLoadSucceeded = true;
         return;
       }
 
@@ -477,6 +478,7 @@ class MessagesStore {
         }
 
         this.messageCount = newCount;
+        this.initialLoadSucceeded = true;
         return;
       }
 
@@ -540,6 +542,7 @@ class MessagesStore {
           messageCountHint,
         );
       }
+      this.initialLoadSucceeded = true;
     } finally {
       if (this.sessionId === id) {
         this.loading = false;

--- a/frontend/src/lib/stores/messages.svelte.ts
+++ b/frontend/src/lib/stores/messages.svelte.ts
@@ -27,6 +27,7 @@ interface FetchPageOptions {
 class MessagesStore {
   messages: Message[] = $state([]);
   loading: boolean = $state(false);
+  initialLoadSucceeded: boolean = $state(false);
   sessionId: string | null = $state(null);
   messageCount: number = $state(0);
   hasOlder: boolean = $state(false);
@@ -60,6 +61,7 @@ class MessagesStore {
     const ac = new AbortController();
     this.abortController = ac;
 
+    let succeeded = false;
     try {
       let countHint: number | null = null;
       try {
@@ -89,12 +91,14 @@ class MessagesStore {
           countHint ?? undefined,
         );
       }
+      succeeded = true;
     } catch (err) {
       if (isAbortError(err)) return;
       console.warn("Failed to load session messages:", err);
     } finally {
       if (this.sessionId === id) {
         this.loading = false;
+        this.initialLoadSucceeded = succeeded;
         this._stableMainModel =
           this.messages.length > 0
             ? computeMainModel(this.messages)
@@ -138,6 +142,7 @@ class MessagesStore {
     clearContentCaches();
     this.sessionId = null;
     this.loading = false;
+    this.initialLoadSucceeded = false;
     this._stableMainModel = "";
     this.messageCount = 0;
     this.hasOlder = false;

--- a/frontend/src/lib/stores/messages.svelte.ts
+++ b/frontend/src/lib/stores/messages.svelte.ts
@@ -91,7 +91,7 @@ class MessagesStore {
           countHint ?? undefined,
         );
       }
-      succeeded = true;
+      succeeded = this.hasCompleteMessageRange();
     } catch (err) {
       if (isAbortError(err)) return;
       console.warn("Failed to load session messages:", err);
@@ -151,6 +151,16 @@ class MessagesStore {
     this.reloadSessionId = null;
     this.pendingReload = false;
     this.loadOlderPromise = null;
+  }
+
+  private hasCompleteMessageRange(): boolean {
+    const first = this.messages[0];
+    const last = this.messages[this.messages.length - 1];
+    return this.messageCount === 0
+      ? this.messages.length === 0
+      : this.messages.length === this.messageCount &&
+        first?.ordinal === 0 &&
+        last?.ordinal === this.messageCount - 1;
   }
 
   private async fetchPages(
@@ -461,7 +471,9 @@ class MessagesStore {
       const oldCount = this.messageCount;
       if (newCount === oldCount) {
         await this.refreshLoadedWindow(id, signal);
-        if (this.sessionId === id) this.initialLoadSucceeded = true;
+        if (this.sessionId === id && this.hasCompleteMessageRange()) {
+          this.initialLoadSucceeded = true;
+        }
         return;
       }
 
@@ -478,7 +490,9 @@ class MessagesStore {
         }
 
         this.messageCount = newCount;
-        this.initialLoadSucceeded = true;
+        if (this.hasCompleteMessageRange()) {
+          this.initialLoadSucceeded = true;
+        }
         return;
       }
 
@@ -542,7 +556,9 @@ class MessagesStore {
           messageCountHint,
         );
       }
-      this.initialLoadSucceeded = true;
+      if (this.hasCompleteMessageRange()) {
+        this.initialLoadSucceeded = true;
+      }
     } finally {
       if (this.sessionId === id) {
         this.loading = false;

--- a/frontend/src/lib/stores/messages.svelte.ts
+++ b/frontend/src/lib/stores/messages.svelte.ts
@@ -84,14 +84,15 @@ class MessagesStore {
         countHint > FULL_SESSION_MESSAGE_THRESHOLD
       ) {
         await this.loadProgressively(id, ac.signal);
+        succeeded = true;
       } else {
         await this.loadAllMessages(
           id,
           ac.signal,
           countHint ?? undefined,
         );
+        succeeded = this.hasCompleteMessageRange();
       }
-      succeeded = this.hasCompleteMessageRange();
     } catch (err) {
       if (isAbortError(err)) return;
       console.warn("Failed to load session messages:", err);
@@ -470,8 +471,12 @@ class MessagesStore {
       const newCount = sess.message_count ?? 0;
       const oldCount = this.messageCount;
       if (newCount === oldCount) {
+        if (!this.initialLoadSucceeded && !this.hasOlder) {
+          await this.fullReload(id, signal, newCount);
+          return;
+        }
         await this.refreshLoadedWindow(id, signal);
-        if (this.sessionId === id && this.hasCompleteMessageRange()) {
+        if (this.sessionId === id && (this.hasCompleteMessageRange() || this.hasOlder)) {
           this.initialLoadSucceeded = true;
         }
         return;
@@ -549,6 +554,7 @@ class MessagesStore {
         messageCountHint > FULL_SESSION_MESSAGE_THRESHOLD
       ) {
         await this.loadProgressively(id, signal);
+        this.initialLoadSucceeded = true;
       } else {
         await this.loadAllMessages(
           id,

--- a/frontend/src/lib/stores/messages.svelte.ts
+++ b/frontend/src/lib/stores/messages.svelte.ts
@@ -30,6 +30,7 @@ class MessagesStore {
   initialLoadSucceeded: boolean = $state(false);
   sessionId: string | null = $state(null);
   messageCount: number = $state(0);
+  latestDisplayOrdinal: number | null | undefined = $state(undefined);
   hasOlder: boolean = $state(false);
   loadingOlder: boolean = $state(false);
   private _stableMainModel: string = $state("");
@@ -63,7 +64,8 @@ class MessagesStore {
 
     let succeeded = false;
     try {
-      let countHint: number | null = null;
+      let countHint: number | undefined;
+      let latestDisplayOrdinal: number | null | undefined;
       try {
         configureGeneratedClient();
         const sess = await withAbort(
@@ -71,6 +73,7 @@ class MessagesStore {
           ac.signal,
         );
         countHint = sess.message_count ?? 0;
+        latestDisplayOrdinal = sess.latest_display_ordinal;
       } catch (err) {
         if (isAbortError(err)) return;
         console.warn(
@@ -80,19 +83,19 @@ class MessagesStore {
       }
 
       if (
-        countHint !== null &&
+        countHint !== undefined &&
         countHint > FULL_SESSION_MESSAGE_THRESHOLD
       ) {
-        await this.loadProgressively(id, ac.signal);
-        succeeded = true;
+        await this.loadProgressively(id, ac.signal, countHint);
       } else {
         await this.loadAllMessages(
           id,
           ac.signal,
-          countHint ?? undefined,
+          countHint,
         );
-        succeeded = this.hasCompleteMessageRange();
       }
+      succeeded = countHint !== undefined && latestDisplayOrdinal !== undefined;
+      if (succeeded) this.latestDisplayOrdinal = latestDisplayOrdinal;
     } catch (err) {
       if (isAbortError(err)) return;
       console.warn("Failed to load session messages:", err);
@@ -146,23 +149,13 @@ class MessagesStore {
     this.initialLoadSucceeded = false;
     this._stableMainModel = "";
     this.messageCount = 0;
+    this.latestDisplayOrdinal = undefined;
     this.hasOlder = false;
     this.loadingOlder = false;
     this.reloadPromise = null;
     this.reloadSessionId = null;
     this.pendingReload = false;
     this.loadOlderPromise = null;
-  }
-
-  hasCompleteMessageRange(): boolean {
-    const first = this.messages[0];
-    const last = this.messages[this.messages.length - 1];
-    return this.messageCount === 0
-      ? this.messages.length === 0 && !this.hasOlder
-      : this.messages.length === this.messageCount &&
-        first?.ordinal === 0 &&
-        last?.ordinal === this.messageCount - 1 &&
-        !this.hasOlder;
   }
 
   private async fetchPages(
@@ -232,10 +225,7 @@ class MessagesStore {
       loaded = [...loaded, ...res.messages];
       this.messages = loaded;
 
-      const newest = loaded[loaded.length - 1];
-      this.messageCount =
-        messageCountHint ??
-        (newest ? newest.ordinal + 1 : loaded.length);
+      this.messageCount = messageCountHint ?? loaded.length;
       this.hasOlder = false;
 
       if (res.messages.length < MESSAGE_PAGE_SIZE) break;
@@ -246,16 +236,14 @@ class MessagesStore {
       from = nextFrom;
     }
 
-    const newest = this.messages[this.messages.length - 1];
-    this.messageCount =
-      messageCountHint ??
-      (newest ? newest.ordinal + 1 : this.messages.length);
+    this.messageCount = messageCountHint ?? this.messages.length;
     this.hasOlder = false;
   }
 
   private async loadProgressively(
     id: string,
     signal: AbortSignal,
+    messageCountHint: number,
   ) {
     configureGeneratedClient();
     const firstRes = await withAbort(
@@ -268,18 +256,15 @@ class MessagesStore {
     );
 
     this.messages = [...firstRes.messages].reverse();
-    const newest = this.messages[this.messages.length - 1];
-    this.messageCount = newest ? newest.ordinal + 1 : 0;
-    const oldest = this.messages[0]?.ordinal;
-    this.hasOlder =
-      oldest !== undefined ? oldest > 0 : false;
+    this.messageCount = messageCountHint;
+    this.hasOlder = this.messages.length < this.messageCount;
   }
 
   private async loadFrom(
     id: string,
     from: number,
     signal: AbortSignal,
-  ) {
+  ): Promise<number> {
     const pages = await this.fetchPages(id, {
       from,
       limit: MESSAGE_PAGE_SIZE,
@@ -301,7 +286,9 @@ class MessagesStore {
         ...this.messages.map((m) => updates.get(m.ordinal) ?? m),
         ...appended,
       ];
+      return appended.length;
     }
+    return 0;
   }
 
   async loadOlder() {
@@ -328,10 +315,6 @@ class MessagesStore {
     if (!id || this.messages.length === 0) return;
 
     const oldest = this.messages[0]!.ordinal;
-    if (oldest <= 0) {
-      this.hasOlder = false;
-      return;
-    }
 
     const signal = this.abortController?.signal;
     if (!signal || signal.aborted) return;
@@ -354,8 +337,12 @@ class MessagesStore {
         return;
       }
       const chunk = [...res.messages].reverse();
+      if (chunk[0]!.ordinal >= oldest) {
+        this.hasOlder = false;
+        return;
+      }
       this.messages.unshift(...chunk);
-      this.hasOlder = chunk[0]!.ordinal > 0;
+      this.hasOlder = this.messages.length < this.messageCount;
     } catch (err) {
       if (isAbortError(err)) return;
       console.warn("Failed to load older messages:", err);
@@ -405,8 +392,9 @@ class MessagesStore {
       let from = this.messages[0]!.ordinal - 1;
       let lastOldest = this.messages[0]!.ordinal;
       const chunks: Message[][] = [];
+      let loadedCount = this.messages.length;
 
-      while (from >= 0) {
+      while (loadedCount < this.messageCount) {
         configureGeneratedClient();
         const res = await withAbort(
           SessionsService.getApiV1SessionsIdMessages({
@@ -425,6 +413,7 @@ class MessagesStore {
 
         const chunk = [...res.messages].reverse();
         chunks.push(chunk);
+        loadedCount += chunk.length;
         const chunkOldest = chunk[0]!.ordinal;
 
         if (chunkOldest <= targetOrdinal) break;
@@ -443,7 +432,7 @@ class MessagesStore {
 
       const oldestNow = this.messages[0]?.ordinal;
       this.hasOlder =
-        oldestNow !== undefined && oldestNow > 0;
+        oldestNow !== undefined && this.messages.length < this.messageCount;
     } catch (err) {
       if (isAbortError(err)) return;
       console.warn(
@@ -470,39 +459,62 @@ class MessagesStore {
       if (this.sessionId !== id) return;
 
       const newCount = sess.message_count ?? 0;
+      const newLatestDisplayOrdinal = sess.latest_display_ordinal;
       const oldCount = this.messageCount;
       if (newCount === oldCount) {
         if (!this.initialLoadSucceeded && !this.hasOlder) {
-          await this.fullReload(id, signal, newCount);
+          await this.fullReload(
+            id,
+            signal,
+            newCount,
+            newLatestDisplayOrdinal,
+          );
           return;
         }
-        await this.refreshLoadedWindow(id, signal);
-        if (this.sessionId === id && (this.hasCompleteMessageRange() || this.hasOlder)) {
-          this.initialLoadSucceeded = true;
+        const identitiesMatch = await this.refreshLoadedWindow(id, signal);
+        if (this.sessionId !== id) return;
+        if (!identitiesMatch) {
+          await this.fullReload(
+            id,
+            signal,
+            newCount,
+            newLatestDisplayOrdinal,
+          );
+          return;
         }
+        this.latestDisplayOrdinal = newLatestDisplayOrdinal;
+        this.initialLoadSucceeded = true;
         return;
       }
 
       if (newCount > oldCount && this.messages.length > 0) {
         const oldestOrdinal = this.messages[0]!.ordinal;
-        await this.loadFrom(id, oldestOrdinal, signal);
+        const appended = await this.loadFrom(id, oldestOrdinal, signal);
         if (this.sessionId !== id) return;
 
-        const newest =
-          this.messages[this.messages.length - 1];
-        if (newest && newest.ordinal !== newCount - 1) {
-          await this.fullReload(id, signal, newCount);
+        if (appended !== newCount - oldCount) {
+          await this.fullReload(
+            id,
+            signal,
+            newCount,
+            newLatestDisplayOrdinal,
+          );
           return;
         }
 
         this.messageCount = newCount;
-        if (this.hasCompleteMessageRange()) {
-          this.initialLoadSucceeded = true;
-        }
+        this.latestDisplayOrdinal = newLatestDisplayOrdinal;
+        this.hasOlder = this.messages.length < this.messageCount;
+        this.initialLoadSucceeded = true;
         return;
       }
 
-      await this.fullReload(id, signal, newCount);
+      await this.fullReload(
+        id,
+        signal,
+        newCount,
+        newLatestDisplayOrdinal,
+      );
     } catch (err) {
       if (isAbortError(err)) return;
       console.warn("Reload failed:", err);
@@ -512,10 +524,10 @@ class MessagesStore {
   private async refreshLoadedWindow(
     id: string,
     signal: AbortSignal,
-  ) {
+  ): Promise<boolean> {
     const oldest = this.messages[0];
     const newest = this.messages[this.messages.length - 1];
-    if (!oldest || !newest) return;
+    if (!oldest || !newest) return this.messages.length === 0;
 
     const refreshed = await this.fetchPages(id, {
       from: oldest.ordinal,
@@ -523,9 +535,14 @@ class MessagesStore {
       direction: "asc",
       signal,
     });
-    if (this.sessionId !== id || refreshed.length === 0) {
-      return;
-    }
+    if (this.sessionId !== id) return true;
+
+    const existingOrdinals = this.messages.map((m) => m.ordinal);
+    const refreshedOrdinals = refreshed.map((m) => m.ordinal);
+    if (
+      refreshedOrdinals.length !== existingOrdinals.length ||
+      refreshedOrdinals.some((ordinal, index) => ordinal !== existingOrdinals[index])
+    ) return false;
 
     const updates = new Map(
       refreshed
@@ -540,12 +557,14 @@ class MessagesStore {
     this.messages = this.messages.map(
       (m) => updates.get(m.ordinal) ?? m,
     );
+    return true;
   }
 
   private async fullReload(
     id: string,
     signal: AbortSignal,
     messageCountHint?: number,
+    latestDisplayOrdinal?: number | null,
   ) {
     clearContentCaches();
     this.loading = true;
@@ -554,8 +573,7 @@ class MessagesStore {
         messageCountHint !== undefined &&
         messageCountHint > FULL_SESSION_MESSAGE_THRESHOLD
       ) {
-        await this.loadProgressively(id, signal);
-        this.initialLoadSucceeded = true;
+        await this.loadProgressively(id, signal, messageCountHint);
       } else {
         await this.loadAllMessages(
           id,
@@ -563,9 +581,8 @@ class MessagesStore {
           messageCountHint,
         );
       }
-      if (this.hasCompleteMessageRange()) {
-        this.initialLoadSucceeded = true;
-      }
+      this.latestDisplayOrdinal = latestDisplayOrdinal;
+      this.initialLoadSucceeded = latestDisplayOrdinal !== undefined;
     } finally {
       if (this.sessionId === id) {
         this.loading = false;

--- a/frontend/src/lib/stores/messages.svelte.ts
+++ b/frontend/src/lib/stores/messages.svelte.ts
@@ -31,6 +31,7 @@ class MessagesStore {
   sessionId: string | null = $state(null);
   messageCount: number = $state(0);
   latestDisplayOrdinal: number | null | undefined = $state(undefined);
+  latestDisplayContentLength: number | null | undefined = $state(undefined);
   hasOlder: boolean = $state(false);
   loadingOlder: boolean = $state(false);
   private _stableMainModel: string = $state("");
@@ -66,6 +67,7 @@ class MessagesStore {
     try {
       let countHint: number | undefined;
       let latestDisplayOrdinal: number | null | undefined;
+      let latestDisplayContentLength: number | null | undefined;
       try {
         configureGeneratedClient();
         const sess = await withAbort(
@@ -74,6 +76,7 @@ class MessagesStore {
         );
         countHint = sess.message_count ?? 0;
         latestDisplayOrdinal = sess.latest_display_ordinal;
+        latestDisplayContentLength = sess.latest_display_content_length;
       } catch (err) {
         if (isAbortError(err)) return;
         console.warn(
@@ -95,7 +98,10 @@ class MessagesStore {
         );
       }
       succeeded = countHint !== undefined && latestDisplayOrdinal !== undefined;
-      if (succeeded) this.latestDisplayOrdinal = latestDisplayOrdinal;
+      if (succeeded) {
+        this.latestDisplayOrdinal = latestDisplayOrdinal;
+        this.latestDisplayContentLength = latestDisplayContentLength;
+      }
     } catch (err) {
       if (isAbortError(err)) return;
       console.warn("Failed to load session messages:", err);
@@ -150,6 +156,7 @@ class MessagesStore {
     this._stableMainModel = "";
     this.messageCount = 0;
     this.latestDisplayOrdinal = undefined;
+    this.latestDisplayContentLength = undefined;
     this.hasOlder = false;
     this.loadingOlder = false;
     this.reloadPromise = null;
@@ -460,6 +467,7 @@ class MessagesStore {
 
       const newCount = sess.message_count ?? 0;
       const newLatestDisplayOrdinal = sess.latest_display_ordinal;
+      const newLatestDisplayContentLength = sess.latest_display_content_length;
       const oldCount = this.messageCount;
       if (newCount === oldCount) {
         if (!this.initialLoadSucceeded && !this.hasOlder) {
@@ -468,6 +476,7 @@ class MessagesStore {
             signal,
             newCount,
             newLatestDisplayOrdinal,
+            newLatestDisplayContentLength,
           );
           return;
         }
@@ -479,10 +488,12 @@ class MessagesStore {
             signal,
             newCount,
             newLatestDisplayOrdinal,
+            newLatestDisplayContentLength,
           );
           return;
         }
         this.latestDisplayOrdinal = newLatestDisplayOrdinal;
+        this.latestDisplayContentLength = newLatestDisplayContentLength;
         this.initialLoadSucceeded = true;
         return;
       }
@@ -498,12 +509,14 @@ class MessagesStore {
             signal,
             newCount,
             newLatestDisplayOrdinal,
+            newLatestDisplayContentLength,
           );
           return;
         }
 
         this.messageCount = newCount;
         this.latestDisplayOrdinal = newLatestDisplayOrdinal;
+        this.latestDisplayContentLength = newLatestDisplayContentLength;
         this.hasOlder = this.messages.length < this.messageCount;
         this.initialLoadSucceeded = true;
         return;
@@ -514,6 +527,7 @@ class MessagesStore {
         signal,
         newCount,
         newLatestDisplayOrdinal,
+        newLatestDisplayContentLength,
       );
     } catch (err) {
       if (isAbortError(err)) return;
@@ -565,6 +579,7 @@ class MessagesStore {
     signal: AbortSignal,
     messageCountHint?: number,
     latestDisplayOrdinal?: number | null,
+    latestDisplayContentLength?: number | null,
   ) {
     clearContentCaches();
     this.loading = true;
@@ -582,6 +597,7 @@ class MessagesStore {
         );
       }
       this.latestDisplayOrdinal = latestDisplayOrdinal;
+      this.latestDisplayContentLength = latestDisplayContentLength;
       this.initialLoadSucceeded = latestDisplayOrdinal !== undefined;
     } finally {
       if (this.sessionId === id) {

--- a/frontend/src/lib/stores/messages.test.ts
+++ b/frontend/src/lib/stores/messages.test.ts
@@ -154,6 +154,22 @@ describe('MessagesStore', () => {
     expect(messages.initialLoadSucceeded).toBe(true);
   });
 
+  it('marks a recovered reload as an initial-load success', async () => {
+      vi.mocked(api.getSession).mockResolvedValue(makeSession('s1', 1));
+      vi.mocked(api.getMessages).mockRejectedValue(new Error('offline'));
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await messages.loadSession('s1');
+    expect(messages.initialLoadSucceeded).toBe(false);
+
+      vi.mocked(api.getMessages).mockResolvedValue(
+        makeMessagesResponse([makeMessage(0)]),
+      );
+    await messages.reload();
+
+    expect(messages.initialLoadSucceeded).toBe(true);
+  });
+
   it('should clear reload state when loading a new session', async () => {
     await setupSession('s1', 10);
     expect(messages.sessionId).toBe('s1');

--- a/frontend/src/lib/stores/messages.test.ts
+++ b/frontend/src/lib/stores/messages.test.ts
@@ -140,6 +140,20 @@ describe('MessagesStore', () => {
     vi.clearAllMocks();
   });
 
+  it('marks the initial load successful only after messages load', async () => {
+    vi.mocked(api.getSession).mockResolvedValue(makeSession('s1', 1));
+    vi.mocked(api.getMessages).mockRejectedValue(new Error('offline'));
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await messages.loadSession('s1');
+
+    expect(messages.initialLoadSucceeded).toBe(false);
+
+    await setupSession('s1', 1, [makeMessage(0)]);
+
+    expect(messages.initialLoadSucceeded).toBe(true);
+  });
+
   it('should clear reload state when loading a new session', async () => {
     await setupSession('s1', 10);
     expect(messages.sessionId).toBe('s1');

--- a/frontend/src/lib/stores/messages.test.ts
+++ b/frontend/src/lib/stores/messages.test.ts
@@ -71,6 +71,7 @@ function generatedCancelError(): Error & { isCancelled: true } {
 function makeSession(
   id: string,
   messageCount: number,
+  latestDisplayOrdinal: number | null = messageCount > 0 ? messageCount - 1 : null,
 ): Session {
   return {
     id,
@@ -81,6 +82,7 @@ function makeSession(
     started_at: null,
     ended_at: null,
     message_count: messageCount,
+    latest_display_ordinal: latestDisplayOrdinal,
     user_message_count: messageCount,
     total_output_tokens: 0,
     peak_context_tokens: 0,
@@ -154,6 +156,87 @@ describe('MessagesStore', () => {
     expect(messages.initialLoadSucceeded).toBe(true);
   });
 
+  it('treats non-zero-based complete loads as successful', async () => {
+    vi.mocked(api.getSession).mockResolvedValue(makeSession('s1', 2, 2));
+    vi.mocked(api.getMessages).mockResolvedValueOnce(
+      makeMessagesResponse([makeMessage(1), makeMessage(2)]),
+    );
+
+    await messages.loadSession('s1');
+
+    expect(messages.initialLoadSucceeded).toBe(true);
+
+    vi.mocked(api.getSession).mockResolvedValueOnce(makeSession('s1', 2, 2));
+    vi.mocked(api.getMessages).mockResolvedValueOnce(
+      makeMessagesResponse([makeMessage(1), makeMessage(2)]),
+    );
+    await messages.reload();
+
+    expect(messages.initialLoadSucceeded).toBe(true);
+    expect(vi.mocked(api.getMessages)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(api.getMessages)).toHaveBeenLastCalledWith(
+      's1',
+      expect.objectContaining({
+        from: 1,
+        limit: 1000,
+        direction: 'asc',
+      }),
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it('treats sparse complete loads as successful', async () => {
+    vi.mocked(api.getSession).mockResolvedValue(makeSession('s1', 2, 20));
+    vi.mocked(api.getMessages).mockResolvedValueOnce(
+      makeMessagesResponse([makeMessage(10), makeMessage(20)]),
+    );
+
+    await messages.loadSession('s1');
+
+    expect(messages.initialLoadSucceeded).toBe(true);
+
+    vi.mocked(api.getSession).mockResolvedValueOnce(makeSession('s1', 2, 20));
+    vi.mocked(api.getMessages).mockResolvedValueOnce(
+      makeMessagesResponse([makeMessage(10), makeMessage(20)]),
+    );
+    await messages.reload();
+
+    expect(messages.initialLoadSucceeded).toBe(true);
+    expect(vi.mocked(api.getMessages)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(api.getMessages)).toHaveBeenLastCalledWith(
+      's1',
+      expect.objectContaining({
+        from: 10,
+        limit: 1000,
+        direction: 'asc',
+      }),
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it('full reloads an equal-count sparse ordinal identity rewrite', async () => {
+    vi.mocked(api.getSession).mockResolvedValue(makeSession('s1', 2, 3));
+    vi.mocked(api.getMessages).mockResolvedValueOnce(
+      makeMessagesResponse([makeMessage(1), makeMessage(3)]),
+    );
+    await messages.loadSession('s1');
+
+    vi.mocked(api.getSession).mockResolvedValueOnce(makeSession('s1', 2, 4));
+    vi.mocked(api.getMessages)
+      .mockResolvedValueOnce(makeMessagesResponse([makeMessage(1), makeMessage(4)]))
+      .mockResolvedValueOnce(makeMessagesResponse([makeMessage(1), makeMessage(4)]));
+
+    await messages.reload();
+
+    expect(messages.messages.map((message) => message.ordinal)).toEqual([1, 4]);
+    expect(messages.messages.some((message) => message.ordinal === 3)).toBe(false);
+    expect(messages.latestDisplayOrdinal).toBe(4);
+  });
+
   it('marks a recovered reload as an initial-load success', async () => {
       vi.mocked(api.getSession).mockResolvedValue(makeSession('s1', 1));
       vi.mocked(api.getMessages).mockRejectedValue(new Error('offline'));
@@ -170,7 +253,7 @@ describe('MessagesStore', () => {
     expect(messages.initialLoadSucceeded).toBe(true);
   });
 
-  it('keeps a partial paged recovery from becoming the initial baseline', async () => {
+  it('marks a completed recovery successful without ordinal endpoint checks', async () => {
     const firstPage = Array.from({ length: 1_000 }, (_, ordinal) =>
       makeMessage(ordinal),
     );
@@ -192,7 +275,7 @@ describe('MessagesStore', () => {
       .mockResolvedValueOnce(makeMessagesResponse([]));
     await messages.reload();
 
-    expect(messages.initialLoadSucceeded).toBe(false);
+    expect(messages.initialLoadSucceeded).toBe(true);
   });
 
   it('should clear reload state when loading a new session', async () => {

--- a/frontend/src/lib/stores/messages.test.ts
+++ b/frontend/src/lib/stores/messages.test.ts
@@ -170,6 +170,31 @@ describe('MessagesStore', () => {
     expect(messages.initialLoadSucceeded).toBe(true);
   });
 
+  it('keeps a partial paged recovery from becoming the initial baseline', async () => {
+    const firstPage = Array.from({ length: 1_000 }, (_, ordinal) =>
+      makeMessage(ordinal),
+    );
+    vi.mocked(api.getSession).mockResolvedValue(makeSession('s1', 1_001));
+    vi.mocked(api.getMessages)
+      .mockResolvedValueOnce(makeMessagesResponse(firstPage))
+      .mockRejectedValueOnce(new Error('missing page'));
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await messages.loadSession('s1');
+
+    expect(messages.messageCount).toBe(1_001);
+    expect(messages.messages).toHaveLength(1_000);
+    expect(messages.initialLoadSucceeded).toBe(false);
+
+    vi.mocked(api.getMessages).mockReset();
+    vi.mocked(api.getMessages)
+      .mockResolvedValueOnce(makeMessagesResponse(firstPage))
+      .mockResolvedValueOnce(makeMessagesResponse([]));
+    await messages.reload();
+
+    expect(messages.initialLoadSucceeded).toBe(false);
+  });
+
   it('should clear reload state when loading a new session', async () => {
     await setupSession('s1', 10);
     expect(messages.sessionId).toBe('s1');

--- a/frontend/src/lib/stores/read-progress.svelte.ts
+++ b/frontend/src/lib/stores/read-progress.svelte.ts
@@ -10,6 +10,24 @@ interface StoredReadProgress {
 
 const STORAGE_KEY = "agentsview-read-progress";
 
+type StorageLike = Pick<Storage, "getItem" | "setItem">;
+
+function storage(): StorageLike | null {
+  try {
+    if (
+      typeof localStorage === "undefined" ||
+      localStorage == null ||
+      typeof localStorage.getItem !== "function" ||
+      typeof localStorage.setItem !== "function"
+    ) {
+      return null;
+    }
+    return localStorage;
+  } catch {
+    return null;
+  }
+}
+
 function isMarker(value: unknown): value is ReadProgressMarker {
   if (!value || typeof value !== "object") return false;
   const marker = value as Record<string, unknown>;
@@ -23,8 +41,9 @@ function isMarker(value: unknown): value is ReadProgressMarker {
 
 function readStoredMarkers(): Record<string, ReadProgressMarker> {
   try {
-    if (typeof localStorage === "undefined") return {};
-    const raw = localStorage.getItem(STORAGE_KEY);
+    const local = storage();
+    if (!local) return {};
+    const raw = local.getItem(STORAGE_KEY);
     if (!raw) return {};
     const stored = JSON.parse(raw) as Partial<StoredReadProgress>;
     if (stored.version !== 1 || !stored.sessions || typeof stored.sessions !== "object") {
@@ -93,12 +112,13 @@ export class ReadProgressStore {
 
   private persist() {
     try {
-      if (typeof localStorage === "undefined") return;
+      const local = storage();
+      if (!local) return;
       const value: StoredReadProgress = {
         version: 1,
         sessions: this.markers,
       };
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+      local.setItem(STORAGE_KEY, JSON.stringify(value));
     } catch {
       // Storage is optional, keep the in-memory marker usable.
     }

--- a/frontend/src/lib/stores/read-progress.svelte.ts
+++ b/frontend/src/lib/stores/read-progress.svelte.ts
@@ -84,6 +84,10 @@ function acknowledgedTotal(
   return eligibleTotal;
 }
 
+function safeOrdinal(value: number): number {
+  return Number.isInteger(value) && value >= -1 ? value : -1;
+}
+
 export class ReadProgressStore {
   private markers: Record<string, ReadProgressMarker> = $state(
     readStoredMarkers(),
@@ -99,18 +103,28 @@ export class ReadProgressStore {
     displayCount: number,
     eligibleAcknowledgedTotal?: number,
   ) {
-    if (!sessionId || this.markers[sessionId]) return;
+    if (!sessionId) return;
+    const ordinal = safeOrdinal(displayOrdinal);
+    const count = safeCount(displayCount);
     const totalMessageCount = acknowledgedTotal(
       displayCount,
       eligibleAcknowledgedTotal,
     );
+    const marker = this.markers[sessionId];
+    if (marker) {
+      const acknowledged = marker.totalMessageCount ?? marker.messageCount;
+      if (
+        ordinal >= marker.ordinal &&
+        (totalMessageCount === undefined || totalMessageCount >= acknowledged)
+      ) {
+        return;
+      }
+    }
     this.markers = {
       ...this.markers,
       [sessionId]: {
-        ordinal: Number.isInteger(displayOrdinal) && displayOrdinal >= -1
-          ? displayOrdinal
-          : -1,
-        messageCount: safeCount(displayCount),
+        ordinal,
+        messageCount: count,
         ...(totalMessageCount !== undefined ? { totalMessageCount } : {}),
       },
     };
@@ -129,10 +143,26 @@ export class ReadProgressStore {
     const totalMessageCount = observedOrdinal === latestDisplayOrdinal
       ? acknowledgedTotal(displayCount, eligibleAcknowledgedTotal)
       : undefined;
+    const acknowledged = marker.totalMessageCount ?? marker.messageCount;
+    if (
+      totalMessageCount !== undefined &&
+      (latestDisplayOrdinal < marker.ordinal || totalMessageCount < acknowledged)
+    ) {
+      this.markers = {
+        ...this.markers,
+        [sessionId]: {
+          ordinal: safeOrdinal(latestDisplayOrdinal),
+          messageCount: safeCount(displayCount),
+          totalMessageCount,
+        },
+      };
+      this.persist();
+      return;
+    }
     if (observedOrdinal <= marker.ordinal) {
       if (
         totalMessageCount !== undefined &&
-        totalMessageCount > (marker.totalMessageCount ?? marker.messageCount)
+        totalMessageCount > acknowledged
       ) {
         this.markers = {
           ...this.markers,
@@ -151,7 +181,7 @@ export class ReadProgressStore {
           Math.min(safeCount(displayCount), observedOrdinal + 1),
         ),
         ...(totalMessageCount !== undefined &&
-          totalMessageCount > (marker.totalMessageCount ?? marker.messageCount)
+          totalMessageCount > acknowledged
           ? { totalMessageCount }
           : {}),
       },

--- a/frontend/src/lib/stores/read-progress.svelte.ts
+++ b/frontend/src/lib/stores/read-progress.svelte.ts
@@ -1,9 +1,10 @@
 export interface ReadProgressMarker {
   seenOrdinal: number | null;
+  seenContentLength?: number | null;
 }
 
 interface StoredReadProgress {
-  version: 2;
+  version: 3;
   sessions: Record<string, ReadProgressMarker>;
 }
 
@@ -29,9 +30,15 @@ function isOrdinal(value: unknown): value is number | null {
   return value === null || (Number.isInteger(value) && (value as number) >= 0);
 }
 
+function isContentLength(value: unknown): value is number | null | undefined {
+  return value === undefined || value === null ||
+    (Number.isInteger(value) && (value as number) >= 0);
+}
+
 function isMarker(value: unknown): value is ReadProgressMarker {
   return !!value && typeof value === "object" &&
-    isOrdinal((value as Record<string, unknown>).seenOrdinal);
+    isOrdinal((value as Record<string, unknown>).seenOrdinal) &&
+    isContentLength((value as Record<string, unknown>).seenContentLength);
 }
 
 function readStoredMarkers(): Record<string, ReadProgressMarker> {
@@ -45,8 +52,15 @@ function readStoredMarkers(): Record<string, ReadProgressMarker> {
     if (!stored.sessions || typeof stored.sessions !== "object" ||
       Array.isArray(stored.sessions)) return {};
     const entries = Object.entries(stored.sessions);
-    if (stored.version === 2) {
+    if (stored.version === 3) {
       return Object.fromEntries(entries.filter(([, marker]) => isMarker(marker)));
+    }
+    if (stored.version === 2) {
+      return Object.fromEntries(entries.flatMap(([id, value]) =>
+        isMarker(value)
+          ? [[id, { seenOrdinal: value.seenOrdinal }]]
+          : [],
+      ));
     }
     if (stored.version === 1) {
       return Object.fromEntries(entries.flatMap(([id, value]) => {
@@ -71,27 +85,46 @@ export class ReadProgressStore {
     return this.markers[sessionId] ?? null;
   }
 
-  baseline(sessionId: string, latestDisplayOrdinal: number | null) {
-    if (!sessionId || !isOrdinal(latestDisplayOrdinal)) return;
+  baseline(
+    sessionId: string,
+    latestDisplayOrdinal: number | null,
+    latestDisplayContentLength: number | null = null,
+  ) {
+    if (!sessionId || !this.isCursor(latestDisplayOrdinal, latestDisplayContentLength)) return;
     const marker = this.markers[sessionId];
-    if (!marker || this.regressed(marker.seenOrdinal, latestDisplayOrdinal)) {
-      this.set(sessionId, latestDisplayOrdinal);
+    if (
+      !marker ||
+      this.regressed(marker, latestDisplayOrdinal, latestDisplayContentLength) ||
+      this.shouldEnrich(marker, latestDisplayOrdinal, latestDisplayContentLength)
+    ) {
+      this.set(sessionId, latestDisplayOrdinal, latestDisplayContentLength);
     }
   }
 
-  reconcile(sessionId: string, latestDisplayOrdinal: number | null) {
-    if (!sessionId || !isOrdinal(latestDisplayOrdinal)) return;
+  reconcile(
+    sessionId: string,
+    latestDisplayOrdinal: number | null,
+    latestDisplayContentLength: number | null = null,
+  ) {
+    if (!sessionId || !this.isCursor(latestDisplayOrdinal, latestDisplayContentLength)) return;
     const marker = this.markers[sessionId];
-    if (marker && this.regressed(marker.seenOrdinal, latestDisplayOrdinal)) {
-      this.set(sessionId, latestDisplayOrdinal);
+    if (marker && this.regressed(marker, latestDisplayOrdinal, latestDisplayContentLength)) {
+      this.set(sessionId, latestDisplayOrdinal, latestDisplayContentLength);
     }
   }
 
-  recordVisible(sessionId: string, observedOrdinal: number) {
+  recordVisible(
+    sessionId: string,
+    observedOrdinal: number,
+    observedContentLength?: number | null,
+  ) {
     const marker = this.markers[sessionId];
-    if (!marker || !Number.isInteger(observedOrdinal) || observedOrdinal < 0) return;
-    if (marker.seenOrdinal === null || observedOrdinal > marker.seenOrdinal) {
-      this.set(sessionId, observedOrdinal);
+    if (!marker || !this.isCursor(observedOrdinal, observedContentLength)) return;
+    if (
+      this.cursorGreater(observedOrdinal, observedContentLength, marker) ||
+      this.shouldEnrich(marker, observedOrdinal, observedContentLength)
+    ) {
+      this.set(sessionId, observedOrdinal, observedContentLength);
     }
   }
 
@@ -102,28 +135,87 @@ export class ReadProgressStore {
     this.persist();
   }
 
-  hasUnread(sessionId: string, latestDisplayOrdinal: number | null): boolean {
+  hasUnread(
+    sessionId: string,
+    latestDisplayOrdinal: number | null,
+    latestDisplayContentLength: number | null = null,
+  ): boolean {
     const marker = this.markers[sessionId];
-    return !!marker && latestDisplayOrdinal !== null &&
-      (marker.seenOrdinal === null || latestDisplayOrdinal > marker.seenOrdinal);
+    return !!marker &&
+      this.isCursor(latestDisplayOrdinal, latestDisplayContentLength) &&
+      this.cursorGreater(latestDisplayOrdinal, latestDisplayContentLength, marker);
   }
 
-  private regressed(seen: number | null, latest: number | null): boolean {
-    return seen !== null && (latest === null || latest < seen);
+  private regressed(
+    marker: ReadProgressMarker,
+    latestOrdinal: number | null,
+    latestContentLength?: number | null,
+  ): boolean {
+    if (marker.seenOrdinal === null) return false;
+    if (latestOrdinal === null) return true;
+    if (latestOrdinal < marker.seenOrdinal) return true;
+    return latestOrdinal === marker.seenOrdinal &&
+      this.contentLengthLess(latestContentLength, marker.seenContentLength);
   }
 
-  private set(sessionId: string, seenOrdinal: number | null) {
-    this.markers = { ...this.markers, [sessionId]: { seenOrdinal } };
+  private set(
+    sessionId: string,
+    seenOrdinal: number | null,
+    seenContentLength?: number | null,
+  ) {
+    const marker: ReadProgressMarker = { seenOrdinal };
+    if (seenContentLength !== undefined && seenContentLength !== null) {
+      marker.seenContentLength = seenContentLength;
+    }
+    this.markers = { ...this.markers, [sessionId]: marker };
     this.persist();
   }
 
   private persist() {
     try {
-      const value: StoredReadProgress = { version: 2, sessions: this.markers };
+      const value: StoredReadProgress = { version: 3, sessions: this.markers };
       storage()?.setItem(STORAGE_KEY, JSON.stringify(value));
     } catch {
       // Storage is optional, keep the in-memory marker usable.
     }
+  }
+
+  private isCursor(
+    ordinal: number | null,
+    contentLength?: number | null,
+  ): boolean {
+    return isOrdinal(ordinal) && isContentLength(contentLength);
+  }
+
+  private shouldEnrich(
+    marker: ReadProgressMarker,
+    ordinal: number | null,
+    contentLength: number | null | undefined,
+  ): boolean {
+    return ordinal !== null &&
+      marker.seenOrdinal === ordinal &&
+      marker.seenContentLength == null &&
+      contentLength != null;
+  }
+
+  private cursorGreater(
+    ordinal: number | null,
+    contentLength: number | null | undefined,
+    marker: ReadProgressMarker,
+  ): boolean {
+    if (ordinal === null) return false;
+    if (marker.seenOrdinal === null) return true;
+    if (ordinal > marker.seenOrdinal) return true;
+    if (ordinal < marker.seenOrdinal) return false;
+    if (contentLength == null || marker.seenContentLength == null) return false;
+    return contentLength > marker.seenContentLength;
+  }
+
+  private contentLengthLess(
+    current: number | null | undefined,
+    seen: number | null | undefined,
+  ): boolean {
+    return current != null && seen != null && current < seen;
   }
 }
 

--- a/frontend/src/lib/stores/read-progress.svelte.ts
+++ b/frontend/src/lib/stores/read-progress.svelte.ts
@@ -1,11 +1,9 @@
 export interface ReadProgressMarker {
-  ordinal: number;
-  messageCount: number;
-  totalMessageCount?: number;
+  seenOrdinal: number | null;
 }
 
 interface StoredReadProgress {
-  version: 1;
+  version: 2;
   sessions: Record<string, ReadProgressMarker>;
 }
 
@@ -20,72 +18,48 @@ function storage(): StorageLike | null {
       localStorage == null ||
       typeof localStorage.getItem !== "function" ||
       typeof localStorage.setItem !== "function"
-    ) {
-      return null;
-    }
+    ) return null;
     return localStorage;
   } catch {
     return null;
   }
 }
 
+function isOrdinal(value: unknown): value is number | null {
+  return value === null || (Number.isInteger(value) && (value as number) >= 0);
+}
+
 function isMarker(value: unknown): value is ReadProgressMarker {
-  if (!value || typeof value !== "object") return false;
-  const marker = value as Record<string, unknown>;
-  return (
-    Number.isInteger(marker.ordinal) &&
-    (marker.ordinal as number) >= -1 &&
-    Number.isInteger(marker.messageCount) &&
-    (marker.messageCount as number) >= 0 &&
-    (marker.totalMessageCount === undefined ||
-      (Number.isInteger(marker.totalMessageCount) &&
-        (marker.totalMessageCount as number) >= (marker.messageCount as number)))
-  );
+  return !!value && typeof value === "object" &&
+    isOrdinal((value as Record<string, unknown>).seenOrdinal);
 }
 
 function readStoredMarkers(): Record<string, ReadProgressMarker> {
   try {
-    const local = storage();
-    if (!local) return {};
-    const raw = local.getItem(STORAGE_KEY);
+    const raw = storage()?.getItem(STORAGE_KEY);
     if (!raw) return {};
-    const stored = JSON.parse(raw) as Partial<StoredReadProgress>;
-    if (
-      stored.version !== 1 ||
-      !stored.sessions ||
-      typeof stored.sessions !== "object" ||
-      Array.isArray(stored.sessions)
-    ) {
-      return {};
+    const stored = JSON.parse(raw) as {
+      version?: unknown;
+      sessions?: unknown;
+    };
+    if (!stored.sessions || typeof stored.sessions !== "object" ||
+      Array.isArray(stored.sessions)) return {};
+    const entries = Object.entries(stored.sessions);
+    if (stored.version === 2) {
+      return Object.fromEntries(entries.filter(([, marker]) => isMarker(marker)));
     }
-    return Object.fromEntries(
-      Object.entries(stored.sessions).filter(([, marker]) => isMarker(marker)),
-    );
+    if (stored.version === 1) {
+      return Object.fromEntries(entries.flatMap(([id, value]) => {
+        const ordinal = (value as Record<string, unknown> | null)?.ordinal;
+        return Number.isInteger(ordinal) && (ordinal as number) >= -1
+          ? [[id, { seenOrdinal: ordinal === -1 ? null : ordinal as number }]]
+          : [];
+      }));
+    }
+    return {};
   } catch {
     return {};
   }
-}
-
-function safeCount(value: number): number {
-  return Number.isInteger(value) && value >= 0 ? value : 0;
-}
-
-function acknowledgedTotal(
-  displayCount: number,
-  eligibleTotal: number | undefined,
-): number | undefined {
-  if (
-    eligibleTotal === undefined ||
-    !Number.isInteger(eligibleTotal) ||
-    eligibleTotal < safeCount(displayCount)
-  ) {
-    return undefined;
-  }
-  return eligibleTotal;
-}
-
-function safeOrdinal(value: number): number {
-  return Number.isInteger(value) && value >= -1 ? value : -1;
 }
 
 export class ReadProgressStore {
@@ -97,101 +71,28 @@ export class ReadProgressStore {
     return this.markers[sessionId] ?? null;
   }
 
-  baseline(
-    sessionId: string,
-    displayOrdinal: number,
-    displayCount: number,
-    eligibleAcknowledgedTotal?: number,
-  ) {
-    if (!sessionId) return;
-    const ordinal = safeOrdinal(displayOrdinal);
-    const count = safeCount(displayCount);
-    const totalMessageCount = acknowledgedTotal(
-      displayCount,
-      eligibleAcknowledgedTotal,
-    );
+  baseline(sessionId: string, latestDisplayOrdinal: number | null) {
+    if (!sessionId || !isOrdinal(latestDisplayOrdinal)) return;
     const marker = this.markers[sessionId];
-    if (marker) {
-      const acknowledged = marker.totalMessageCount ?? marker.messageCount;
-      const hiddenOnlyGrowth = ordinal === -1 &&
-        count === 0 &&
-        totalMessageCount !== undefined &&
-        totalMessageCount > acknowledged;
-      if (
-        !hiddenOnlyGrowth &&
-        ordinal >= marker.ordinal &&
-        (totalMessageCount === undefined || totalMessageCount >= acknowledged)
-      ) {
-        return;
-      }
+    if (!marker || this.regressed(marker.seenOrdinal, latestDisplayOrdinal)) {
+      this.set(sessionId, latestDisplayOrdinal);
     }
-    this.markers = {
-      ...this.markers,
-      [sessionId]: {
-        ordinal,
-        messageCount: count,
-        ...(totalMessageCount !== undefined ? { totalMessageCount } : {}),
-      },
-    };
-    this.persist();
   }
 
-  recordVisible(
-    sessionId: string,
-    observedOrdinal: number,
-    latestDisplayOrdinal: number,
-    displayCount: number,
-    eligibleAcknowledgedTotal?: number,
-  ) {
+  reconcile(sessionId: string, latestDisplayOrdinal: number | null) {
+    if (!sessionId || !isOrdinal(latestDisplayOrdinal)) return;
     const marker = this.markers[sessionId];
-    if (!marker || !Number.isInteger(observedOrdinal)) return;
-    const totalMessageCount = observedOrdinal === latestDisplayOrdinal
-      ? acknowledgedTotal(displayCount, eligibleAcknowledgedTotal)
-      : undefined;
-    const acknowledged = marker.totalMessageCount ?? marker.messageCount;
-    if (
-      totalMessageCount !== undefined &&
-      (latestDisplayOrdinal < marker.ordinal || totalMessageCount < acknowledged)
-    ) {
-      this.markers = {
-        ...this.markers,
-        [sessionId]: {
-          ordinal: safeOrdinal(latestDisplayOrdinal),
-          messageCount: safeCount(displayCount),
-          totalMessageCount,
-        },
-      };
-      this.persist();
-      return;
+    if (marker && this.regressed(marker.seenOrdinal, latestDisplayOrdinal)) {
+      this.set(sessionId, latestDisplayOrdinal);
     }
-    if (observedOrdinal <= marker.ordinal) {
-      if (
-        totalMessageCount !== undefined &&
-        totalMessageCount > acknowledged
-      ) {
-        this.markers = {
-          ...this.markers,
-          [sessionId]: { ...marker, totalMessageCount },
-        };
-        this.persist();
-      }
-      return;
+  }
+
+  recordVisible(sessionId: string, observedOrdinal: number) {
+    const marker = this.markers[sessionId];
+    if (!marker || !Number.isInteger(observedOrdinal) || observedOrdinal < 0) return;
+    if (marker.seenOrdinal === null || observedOrdinal > marker.seenOrdinal) {
+      this.set(sessionId, observedOrdinal);
     }
-    this.markers = {
-      ...this.markers,
-      [sessionId]: {
-        ordinal: observedOrdinal,
-        messageCount: Math.max(
-          marker.messageCount,
-          Math.min(safeCount(displayCount), observedOrdinal + 1),
-        ),
-        ...(totalMessageCount !== undefined &&
-          totalMessageCount > acknowledged
-          ? { totalMessageCount }
-          : {}),
-      },
-    };
-    this.persist();
   }
 
   clear(sessionId: string) {
@@ -201,21 +102,25 @@ export class ReadProgressStore {
     this.persist();
   }
 
-  hasUnread(sessionId: string, messageCount: number): boolean {
+  hasUnread(sessionId: string, latestDisplayOrdinal: number | null): boolean {
     const marker = this.markers[sessionId];
-    if (!marker) return false;
-    return safeCount(messageCount) > (marker.totalMessageCount ?? marker.messageCount);
+    return !!marker && latestDisplayOrdinal !== null &&
+      (marker.seenOrdinal === null || latestDisplayOrdinal > marker.seenOrdinal);
+  }
+
+  private regressed(seen: number | null, latest: number | null): boolean {
+    return seen !== null && (latest === null || latest < seen);
+  }
+
+  private set(sessionId: string, seenOrdinal: number | null) {
+    this.markers = { ...this.markers, [sessionId]: { seenOrdinal } };
+    this.persist();
   }
 
   private persist() {
     try {
-      const local = storage();
-      if (!local) return;
-      const value: StoredReadProgress = {
-        version: 1,
-        sessions: this.markers,
-      };
-      local.setItem(STORAGE_KEY, JSON.stringify(value));
+      const value: StoredReadProgress = { version: 2, sessions: this.markers };
+      storage()?.setItem(STORAGE_KEY, JSON.stringify(value));
     } catch {
       // Storage is optional, keep the in-memory marker usable.
     }

--- a/frontend/src/lib/stores/read-progress.svelte.ts
+++ b/frontend/src/lib/stores/read-progress.svelte.ts
@@ -113,7 +113,12 @@ export class ReadProgressStore {
     const marker = this.markers[sessionId];
     if (marker) {
       const acknowledged = marker.totalMessageCount ?? marker.messageCount;
+      const hiddenOnlyGrowth = ordinal === -1 &&
+        count === 0 &&
+        totalMessageCount !== undefined &&
+        totalMessageCount > acknowledged;
       if (
+        !hiddenOnlyGrowth &&
         ordinal >= marker.ordinal &&
         (totalMessageCount === undefined || totalMessageCount >= acknowledged)
       ) {

--- a/frontend/src/lib/stores/read-progress.svelte.ts
+++ b/frontend/src/lib/stores/read-progress.svelte.ts
@@ -3,22 +3,11 @@ export interface ReadProgressMarker {
   seenContentLength?: number | null;
 }
 
-interface StoredReadProgress {
-  version: 3;
-  /** Session IDs ordered from least to most recently visited. */
-  recency: string[];
-  sessions: Record<string, ReadProgressMarker>;
-}
-
-const STORAGE_KEY = "agentsview-read-progress";
+const INDEX_KEY = "agentsview-read-progress:index";
+const MARKER_KEY_PREFIX = "agentsview-read-progress:session:";
 const DEFAULT_CAPACITY = 1_000;
 
-interface ReadProgressSnapshot {
-  sessions: Record<string, ReadProgressMarker>;
-  recency: string[];
-}
-
-type StorageLike = Pick<Storage, "getItem" | "setItem">;
+type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
 
 function storage(): StorageLike | null {
   try {
@@ -26,7 +15,8 @@ function storage(): StorageLike | null {
       typeof localStorage === "undefined" ||
       localStorage == null ||
       typeof localStorage.getItem !== "function" ||
-      typeof localStorage.setItem !== "function"
+      typeof localStorage.setItem !== "function" ||
+      typeof localStorage.removeItem !== "function"
     ) return null;
     return localStorage;
   } catch {
@@ -49,65 +39,59 @@ function isMarker(value: unknown): value is ReadProgressMarker {
     isContentLength((value as Record<string, unknown>).seenContentLength);
 }
 
-function snapshot(
-  sessions: Record<string, ReadProgressMarker>,
-  recency: unknown,
-): ReadProgressSnapshot {
-  const ordered: string[] = [];
-  const seen = new Set<string>();
-  if (Array.isArray(recency)) {
-    for (const id of recency) {
-      if (typeof id !== "string" || seen.has(id) || !sessions[id]) continue;
-      seen.add(id);
-      ordered.push(id);
-    }
-  }
-  for (const id of Object.keys(sessions)) {
-    if (seen.has(id)) continue;
-    ordered.push(id);
-  }
-  return { sessions, recency: ordered };
+function markerKey(sessionId: string): string {
+  return `${MARKER_KEY_PREFIX}${sessionId}`;
 }
 
-function readStoredMarkers(): ReadProgressSnapshot {
+function readStoredRecency(): string[] {
   try {
-    const raw = storage()?.getItem(STORAGE_KEY);
-    if (!raw) return snapshot({}, []);
-    const stored = JSON.parse(raw) as {
-      version?: unknown;
-      sessions?: unknown;
-      recency?: unknown;
-    };
-    if (!stored.sessions || typeof stored.sessions !== "object" ||
-      Array.isArray(stored.sessions)) return snapshot({}, []);
-    const entries = Object.entries(stored.sessions);
-    if (stored.version === 3) {
-      if (!Array.isArray(stored.recency)) return snapshot({}, []);
-      return snapshot(
-        Object.fromEntries(entries.filter(([, marker]) => isMarker(marker))),
-        stored.recency,
-      );
-    }
-    if (stored.version === 2) {
-      const sessions = Object.fromEntries(entries.flatMap(([id, value]) =>
-        isMarker(value)
-          ? [[id, { seenOrdinal: value.seenOrdinal }]]
-          : []
-      ));
-      return snapshot(sessions, Object.keys(sessions));
-    }
-    if (stored.version === 1) {
-      const sessions = Object.fromEntries(entries.flatMap(([id, value]) => {
-        const ordinal = (value as Record<string, unknown> | null)?.ordinal;
-        return Number.isInteger(ordinal) && (ordinal as number) >= -1
-          ? [[id, { seenOrdinal: ordinal === -1 ? null : ordinal as number }]]
-          : [];
-      }));
-      return snapshot(sessions, Object.keys(sessions));
-    }
-    return snapshot({}, []);
+    const raw = storage()?.getItem(INDEX_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    const seen = new Set<string>();
+    return [...parsed].reverse().flatMap((id) => {
+      if (typeof id !== "string" || !id || seen.has(id)) return [];
+      seen.add(id);
+      return [id];
+    }).reverse();
   } catch {
-    return snapshot({}, []);
+    return [];
+  }
+}
+
+function readStoredMarker(sessionId: string): ReadProgressMarker | null {
+  try {
+    const raw = storage()?.getItem(markerKey(sessionId));
+    if (!raw) return null;
+    const marker = JSON.parse(raw) as unknown;
+    return isMarker(marker) ? marker : null;
+  } catch {
+    return null;
+  }
+}
+
+function removeStoredMarker(sessionId: string) {
+  try {
+    storage()?.removeItem(markerKey(sessionId));
+  } catch {
+    // Storage is optional, keep the in-memory marker usable.
+  }
+}
+
+function persistRecency(recency: string[]) {
+  try {
+    storage()?.setItem(INDEX_KEY, JSON.stringify(recency));
+  } catch {
+    // Storage is optional, keep the in-memory marker usable.
+  }
+}
+
+function persistMarker(sessionId: string, marker: ReadProgressMarker) {
+  try {
+    storage()?.setItem(markerKey(sessionId), JSON.stringify(marker));
+  } catch {
+    // Storage is optional, keep the in-memory marker usable.
   }
 }
 
@@ -121,12 +105,26 @@ export class ReadProgressStore {
         `Read progress capacity must be a positive integer, got ${capacity}`,
       );
     }
-    const stored = readStoredMarkers();
-    this.recency = stored.recency.slice(-capacity);
-    this.markers = Object.fromEntries(
-      this.recency.map((id) => [id, stored.sessions[id]!]),
-    );
-    if (this.recency.length < stored.recency.length) this.persist();
+    const storedRecency = readStoredRecency();
+    const retained = storedRecency.slice(-capacity);
+    for (const id of storedRecency.slice(0, -capacity)) {
+      removeStoredMarker(id);
+    }
+    for (const id of retained) {
+      const marker = readStoredMarker(id);
+      if (marker) {
+        this.markers[id] = marker;
+        this.recency.push(id);
+      } else {
+        removeStoredMarker(id);
+      }
+    }
+    if (
+      this.recency.length !== storedRecency.length ||
+      this.recency.some((id, index) => id !== storedRecency[index])
+    ) {
+      persistRecency(this.recency);
+    }
   }
 
   get(sessionId: string): ReadProgressMarker | null {
@@ -146,9 +144,8 @@ export class ReadProgressStore {
       this.shouldEnrich(marker, latestDisplayOrdinal, latestDisplayContentLength)
     ) {
       this.set(sessionId, latestDisplayOrdinal, latestDisplayContentLength);
-    } else {
-      this.touch(sessionId);
     }
+    this.touch(sessionId);
   }
 
   reconcile(
@@ -180,10 +177,10 @@ export class ReadProgressStore {
 
   clear(sessionId: string) {
     if (!this.markers[sessionId]) return;
-    const { [sessionId]: _, ...remaining } = this.markers;
-    this.markers = remaining;
+    delete this.markers[sessionId];
     this.recency = this.recency.filter((id) => id !== sessionId);
-    this.persist();
+    removeStoredMarker(sessionId);
+    persistRecency(this.recency);
   }
 
   hasUnread(
@@ -218,39 +215,23 @@ export class ReadProgressStore {
     if (seenContentLength !== undefined && seenContentLength !== null) {
       marker.seenContentLength = seenContentLength;
     }
-    this.storeMarker(sessionId, marker);
+    this.markers[sessionId] = marker;
+    persistMarker(sessionId, marker);
   }
 
   private touch(sessionId: string) {
-    const marker = this.markers[sessionId];
-    if (!marker || this.recency.at(-1) === sessionId) return;
-    this.storeMarker(sessionId, marker);
-  }
-
-  private storeMarker(sessionId: string, marker: ReadProgressMarker) {
+    if (!this.markers[sessionId] || this.recency.at(-1) === sessionId) return;
     const recency = this.recency.filter((id) => id !== sessionId);
     recency.push(sessionId);
     const evicted = recency.length > this.capacity
       ? recency.splice(0, recency.length - this.capacity)
       : [];
-    const markers = { ...this.markers, [sessionId]: marker };
-    for (const id of evicted) delete markers[id];
-    this.recency = recency;
-    this.markers = markers;
-    this.persist();
-  }
-
-  private persist() {
-    try {
-      const value: StoredReadProgress = {
-        version: 3,
-        recency: this.recency,
-        sessions: this.markers,
-      };
-      storage()?.setItem(STORAGE_KEY, JSON.stringify(value));
-    } catch {
-      // Storage is optional, keep the in-memory marker usable.
+    for (const id of evicted) {
+      delete this.markers[id];
+      removeStoredMarker(id);
     }
+    this.recency = recency;
+    persistRecency(this.recency);
   }
 
   private isCursor(

--- a/frontend/src/lib/stores/read-progress.svelte.ts
+++ b/frontend/src/lib/stores/read-progress.svelte.ts
@@ -5,10 +5,18 @@ export interface ReadProgressMarker {
 
 interface StoredReadProgress {
   version: 3;
+  /** Session IDs ordered from least to most recently visited. */
+  recency: string[];
   sessions: Record<string, ReadProgressMarker>;
 }
 
 const STORAGE_KEY = "agentsview-read-progress";
+const DEFAULT_CAPACITY = 1_000;
+
+interface ReadProgressSnapshot {
+  sessions: Record<string, ReadProgressMarker>;
+  recency: string[];
+}
 
 type StorageLike = Pick<Storage, "getItem" | "setItem">;
 
@@ -41,45 +49,85 @@ function isMarker(value: unknown): value is ReadProgressMarker {
     isContentLength((value as Record<string, unknown>).seenContentLength);
 }
 
-function readStoredMarkers(): Record<string, ReadProgressMarker> {
+function snapshot(
+  sessions: Record<string, ReadProgressMarker>,
+  recency: unknown,
+): ReadProgressSnapshot {
+  const ordered: string[] = [];
+  const seen = new Set<string>();
+  if (Array.isArray(recency)) {
+    for (const id of recency) {
+      if (typeof id !== "string" || seen.has(id) || !sessions[id]) continue;
+      seen.add(id);
+      ordered.push(id);
+    }
+  }
+  for (const id of Object.keys(sessions)) {
+    if (seen.has(id)) continue;
+    ordered.push(id);
+  }
+  return { sessions, recency: ordered };
+}
+
+function readStoredMarkers(): ReadProgressSnapshot {
   try {
     const raw = storage()?.getItem(STORAGE_KEY);
-    if (!raw) return {};
+    if (!raw) return snapshot({}, []);
     const stored = JSON.parse(raw) as {
       version?: unknown;
       sessions?: unknown;
+      recency?: unknown;
     };
     if (!stored.sessions || typeof stored.sessions !== "object" ||
-      Array.isArray(stored.sessions)) return {};
+      Array.isArray(stored.sessions)) return snapshot({}, []);
     const entries = Object.entries(stored.sessions);
     if (stored.version === 3) {
-      return Object.fromEntries(entries.filter(([, marker]) => isMarker(marker)));
+      if (!Array.isArray(stored.recency)) return snapshot({}, []);
+      return snapshot(
+        Object.fromEntries(entries.filter(([, marker]) => isMarker(marker))),
+        stored.recency,
+      );
     }
     if (stored.version === 2) {
-      return Object.fromEntries(entries.flatMap(([id, value]) =>
+      const sessions = Object.fromEntries(entries.flatMap(([id, value]) =>
         isMarker(value)
           ? [[id, { seenOrdinal: value.seenOrdinal }]]
-          : [],
+          : []
       ));
+      return snapshot(sessions, Object.keys(sessions));
     }
     if (stored.version === 1) {
-      return Object.fromEntries(entries.flatMap(([id, value]) => {
+      const sessions = Object.fromEntries(entries.flatMap(([id, value]) => {
         const ordinal = (value as Record<string, unknown> | null)?.ordinal;
         return Number.isInteger(ordinal) && (ordinal as number) >= -1
           ? [[id, { seenOrdinal: ordinal === -1 ? null : ordinal as number }]]
           : [];
       }));
+      return snapshot(sessions, Object.keys(sessions));
     }
-    return {};
+    return snapshot({}, []);
   } catch {
-    return {};
+    return snapshot({}, []);
   }
 }
 
 export class ReadProgressStore {
-  private markers: Record<string, ReadProgressMarker> = $state(
-    readStoredMarkers(),
-  );
+  private markers: Record<string, ReadProgressMarker> = $state({});
+  private recency: string[] = [];
+
+  constructor(private readonly capacity = DEFAULT_CAPACITY) {
+    if (!Number.isInteger(capacity) || capacity < 1) {
+      throw new Error(
+        `Read progress capacity must be a positive integer, got ${capacity}`,
+      );
+    }
+    const stored = readStoredMarkers();
+    this.recency = stored.recency.slice(-capacity);
+    this.markers = Object.fromEntries(
+      this.recency.map((id) => [id, stored.sessions[id]!]),
+    );
+    if (this.recency.length < stored.recency.length) this.persist();
+  }
 
   get(sessionId: string): ReadProgressMarker | null {
     return this.markers[sessionId] ?? null;
@@ -98,6 +146,8 @@ export class ReadProgressStore {
       this.shouldEnrich(marker, latestDisplayOrdinal, latestDisplayContentLength)
     ) {
       this.set(sessionId, latestDisplayOrdinal, latestDisplayContentLength);
+    } else {
+      this.touch(sessionId);
     }
   }
 
@@ -132,6 +182,7 @@ export class ReadProgressStore {
     if (!this.markers[sessionId]) return;
     const { [sessionId]: _, ...remaining } = this.markers;
     this.markers = remaining;
+    this.recency = this.recency.filter((id) => id !== sessionId);
     this.persist();
   }
 
@@ -167,13 +218,35 @@ export class ReadProgressStore {
     if (seenContentLength !== undefined && seenContentLength !== null) {
       marker.seenContentLength = seenContentLength;
     }
-    this.markers = { ...this.markers, [sessionId]: marker };
+    this.storeMarker(sessionId, marker);
+  }
+
+  private touch(sessionId: string) {
+    const marker = this.markers[sessionId];
+    if (!marker || this.recency.at(-1) === sessionId) return;
+    this.storeMarker(sessionId, marker);
+  }
+
+  private storeMarker(sessionId: string, marker: ReadProgressMarker) {
+    const recency = this.recency.filter((id) => id !== sessionId);
+    recency.push(sessionId);
+    const evicted = recency.length > this.capacity
+      ? recency.splice(0, recency.length - this.capacity)
+      : [];
+    const markers = { ...this.markers, [sessionId]: marker };
+    for (const id of evicted) delete markers[id];
+    this.recency = recency;
+    this.markers = markers;
     this.persist();
   }
 
   private persist() {
     try {
-      const value: StoredReadProgress = { version: 3, sessions: this.markers };
+      const value: StoredReadProgress = {
+        version: 3,
+        recency: this.recency,
+        sessions: this.markers,
+      };
       storage()?.setItem(STORAGE_KEY, JSON.stringify(value));
     } catch {
       // Storage is optional, keep the in-memory marker usable.

--- a/frontend/src/lib/stores/read-progress.svelte.ts
+++ b/frontend/src/lib/stores/read-progress.svelte.ts
@@ -122,6 +122,12 @@ export class ReadProgressStore {
     this.visibleCounts = { ...this.visibleCounts, [sessionId]: count };
   }
 
+  clearVisibleCount(sessionId: string) {
+    if (!(sessionId in this.visibleCounts)) return;
+    const { [sessionId]: _, ...remaining } = this.visibleCounts;
+    this.visibleCounts = remaining;
+  }
+
   clear(sessionId: string) {
     if (!this.markers[sessionId]) return;
     const { [sessionId]: _, ...remaining } = this.markers;

--- a/frontend/src/lib/stores/read-progress.svelte.ts
+++ b/frontend/src/lib/stores/read-progress.svelte.ts
@@ -46,7 +46,12 @@ function readStoredMarkers(): Record<string, ReadProgressMarker> {
     const raw = local.getItem(STORAGE_KEY);
     if (!raw) return {};
     const stored = JSON.parse(raw) as Partial<StoredReadProgress>;
-    if (stored.version !== 1 || !stored.sessions || typeof stored.sessions !== "object") {
+    if (
+      stored.version !== 1 ||
+      !stored.sessions ||
+      typeof stored.sessions !== "object" ||
+      Array.isArray(stored.sessions)
+    ) {
       return {};
     }
     return Object.fromEntries(

--- a/frontend/src/lib/stores/read-progress.svelte.ts
+++ b/frontend/src/lib/stores/read-progress.svelte.ts
@@ -36,7 +36,10 @@ function isMarker(value: unknown): value is ReadProgressMarker {
     Number.isInteger(marker.ordinal) &&
     (marker.ordinal as number) >= -1 &&
     Number.isInteger(marker.messageCount) &&
-    (marker.messageCount as number) >= 0
+    (marker.messageCount as number) >= 0 &&
+    (marker.totalMessageCount === undefined ||
+      (Number.isInteger(marker.totalMessageCount) &&
+        (marker.totalMessageCount as number) >= (marker.messageCount as number)))
   );
 }
 
@@ -67,6 +70,20 @@ function safeCount(value: number): number {
   return Number.isInteger(value) && value >= 0 ? value : 0;
 }
 
+function acknowledgedTotal(
+  displayCount: number,
+  eligibleTotal: number | undefined,
+): number | undefined {
+  if (
+    eligibleTotal === undefined ||
+    !Number.isInteger(eligibleTotal) ||
+    eligibleTotal < safeCount(displayCount)
+  ) {
+    return undefined;
+  }
+  return eligibleTotal;
+}
+
 export class ReadProgressStore {
   private markers: Record<string, ReadProgressMarker> = $state(
     readStoredMarkers(),
@@ -77,24 +94,52 @@ export class ReadProgressStore {
     return this.markers[sessionId] ?? null;
   }
 
-  baseline(sessionId: string, ordinal: number, messageCount: number) {
+  baseline(
+    sessionId: string,
+    displayOrdinal: number,
+    displayCount: number,
+    eligibleAcknowledgedTotal?: number,
+  ) {
     if (!sessionId || this.markers[sessionId]) return;
+    const totalMessageCount = acknowledgedTotal(
+      displayCount,
+      eligibleAcknowledgedTotal,
+    );
     this.markers = {
       ...this.markers,
       [sessionId]: {
-        ordinal: Number.isInteger(ordinal) && ordinal >= -1 ? ordinal : -1,
-        messageCount: safeCount(messageCount),
+        ordinal: Number.isInteger(displayOrdinal) && displayOrdinal >= -1
+          ? displayOrdinal
+          : -1,
+        messageCount: safeCount(displayCount),
+        ...(totalMessageCount !== undefined ? { totalMessageCount } : {}),
       },
     };
     this.persist();
   }
 
-  recordVisible(sessionId: string, ordinal: number, messageCount: number, totalMessageCount = messageCount) {
+  recordVisible(
+    sessionId: string,
+    observedOrdinal: number,
+    latestDisplayOrdinal: number,
+    displayCount: number,
+    eligibleAcknowledgedTotal?: number,
+  ) {
     const marker = this.markers[sessionId];
-    if (!marker || !Number.isInteger(ordinal)) return;
-    if (ordinal <= marker.ordinal) {
-      if (safeCount(messageCount) <= marker.messageCount && safeCount(totalMessageCount) > (marker.totalMessageCount ?? marker.messageCount)) {
-        this.markers = { ...this.markers, [sessionId]: { ...marker, totalMessageCount: safeCount(totalMessageCount) } };
+    if (!marker || !Number.isInteger(observedOrdinal)) return;
+    const totalMessageCount = observedOrdinal === latestDisplayOrdinal
+      ? acknowledgedTotal(displayCount, eligibleAcknowledgedTotal)
+      : undefined;
+    if (observedOrdinal <= marker.ordinal) {
+      if (
+        safeCount(displayCount) <= marker.messageCount &&
+        totalMessageCount !== undefined &&
+        totalMessageCount > (marker.totalMessageCount ?? marker.messageCount)
+      ) {
+        this.markers = {
+          ...this.markers,
+          [sessionId]: { ...marker, totalMessageCount },
+        };
         this.persist();
       }
       return;
@@ -102,13 +147,14 @@ export class ReadProgressStore {
     this.markers = {
       ...this.markers,
       [sessionId]: {
-        ordinal,
+        ordinal: observedOrdinal,
         messageCount: Math.max(
           marker.messageCount,
-          Math.min(safeCount(messageCount), ordinal + 1),
+          Math.min(safeCount(displayCount), observedOrdinal + 1),
         ),
-        ...(safeCount(totalMessageCount) > safeCount(messageCount)
-          ? { totalMessageCount: safeCount(totalMessageCount) }
+        ...(totalMessageCount !== undefined &&
+          totalMessageCount > (marker.totalMessageCount ?? marker.messageCount)
+          ? { totalMessageCount }
           : {}),
       },
     };

--- a/frontend/src/lib/stores/read-progress.svelte.ts
+++ b/frontend/src/lib/stores/read-progress.svelte.ts
@@ -70,6 +70,7 @@ export class ReadProgressStore {
   private markers: Record<string, ReadProgressMarker> = $state(
     readStoredMarkers(),
   );
+  private visibleCounts: Record<string, number> = $state({});
 
   get(sessionId: string): ReadProgressMarker | null {
     return this.markers[sessionId] ?? null;
@@ -103,6 +104,13 @@ export class ReadProgressStore {
     this.persist();
   }
 
+  setVisibleCount(sessionId: string, messageCount: number) {
+    if (!sessionId) return;
+    const count = safeCount(messageCount);
+    if (this.visibleCounts[sessionId] === count) return;
+    this.visibleCounts = { ...this.visibleCounts, [sessionId]: count };
+  }
+
   clear(sessionId: string) {
     if (!this.markers[sessionId]) return;
     const { [sessionId]: _, ...remaining } = this.markers;
@@ -112,7 +120,7 @@ export class ReadProgressStore {
 
   hasUnread(sessionId: string, messageCount: number): boolean {
     const marker = this.markers[sessionId];
-    return marker !== undefined && safeCount(messageCount) > marker.messageCount;
+    return marker !== undefined && (this.visibleCounts[sessionId] ?? safeCount(messageCount)) > marker.messageCount;
   }
 
   private persist() {

--- a/frontend/src/lib/stores/read-progress.svelte.ts
+++ b/frontend/src/lib/stores/read-progress.svelte.ts
@@ -1,0 +1,108 @@
+export interface ReadProgressMarker {
+  ordinal: number;
+  messageCount: number;
+}
+
+interface StoredReadProgress {
+  version: 1;
+  sessions: Record<string, ReadProgressMarker>;
+}
+
+const STORAGE_KEY = "agentsview-read-progress";
+
+function isMarker(value: unknown): value is ReadProgressMarker {
+  if (!value || typeof value !== "object") return false;
+  const marker = value as Record<string, unknown>;
+  return (
+    Number.isInteger(marker.ordinal) &&
+    (marker.ordinal as number) >= -1 &&
+    Number.isInteger(marker.messageCount) &&
+    (marker.messageCount as number) >= 0
+  );
+}
+
+function readStoredMarkers(): Record<string, ReadProgressMarker> {
+  try {
+    if (typeof localStorage === "undefined") return {};
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const stored = JSON.parse(raw) as Partial<StoredReadProgress>;
+    if (stored.version !== 1 || !stored.sessions || typeof stored.sessions !== "object") {
+      return {};
+    }
+    return Object.fromEntries(
+      Object.entries(stored.sessions).filter(([, marker]) => isMarker(marker)),
+    );
+  } catch {
+    return {};
+  }
+}
+
+function safeCount(value: number): number {
+  return Number.isInteger(value) && value >= 0 ? value : 0;
+}
+
+export class ReadProgressStore {
+  private markers: Record<string, ReadProgressMarker> = $state(
+    readStoredMarkers(),
+  );
+
+  get(sessionId: string): ReadProgressMarker | null {
+    return this.markers[sessionId] ?? null;
+  }
+
+  baseline(sessionId: string, ordinal: number, messageCount: number) {
+    if (!sessionId || this.markers[sessionId]) return;
+    this.markers = {
+      ...this.markers,
+      [sessionId]: {
+        ordinal: Number.isInteger(ordinal) && ordinal >= -1 ? ordinal : -1,
+        messageCount: safeCount(messageCount),
+      },
+    };
+    this.persist();
+  }
+
+  recordVisible(sessionId: string, ordinal: number, messageCount: number) {
+    const marker = this.markers[sessionId];
+    if (!marker || !Number.isInteger(ordinal) || ordinal <= marker.ordinal) return;
+    this.markers = {
+      ...this.markers,
+      [sessionId]: {
+        ordinal,
+        messageCount: Math.max(
+          marker.messageCount,
+          Math.min(safeCount(messageCount), ordinal + 1),
+        ),
+      },
+    };
+    this.persist();
+  }
+
+  clear(sessionId: string) {
+    if (!this.markers[sessionId]) return;
+    const { [sessionId]: _, ...remaining } = this.markers;
+    this.markers = remaining;
+    this.persist();
+  }
+
+  hasUnread(sessionId: string, messageCount: number): boolean {
+    const marker = this.markers[sessionId];
+    return marker !== undefined && safeCount(messageCount) > marker.messageCount;
+  }
+
+  private persist() {
+    try {
+      if (typeof localStorage === "undefined") return;
+      const value: StoredReadProgress = {
+        version: 1,
+        sessions: this.markers,
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+    } catch {
+      // Storage is optional, keep the in-memory marker usable.
+    }
+  }
+}
+
+export const readProgress = new ReadProgressStore();

--- a/frontend/src/lib/stores/read-progress.svelte.ts
+++ b/frontend/src/lib/stores/read-progress.svelte.ts
@@ -88,7 +88,6 @@ export class ReadProgressStore {
   private markers: Record<string, ReadProgressMarker> = $state(
     readStoredMarkers(),
   );
-  private visibleCounts: Record<string, number> = $state({});
 
   get(sessionId: string): ReadProgressMarker | null {
     return this.markers[sessionId] ?? null;
@@ -132,7 +131,6 @@ export class ReadProgressStore {
       : undefined;
     if (observedOrdinal <= marker.ordinal) {
       if (
-        safeCount(displayCount) <= marker.messageCount &&
         totalMessageCount !== undefined &&
         totalMessageCount > (marker.totalMessageCount ?? marker.messageCount)
       ) {
@@ -161,19 +159,6 @@ export class ReadProgressStore {
     this.persist();
   }
 
-  setVisibleCount(sessionId: string, messageCount: number) {
-    if (!sessionId) return;
-    const count = safeCount(messageCount);
-    if (this.visibleCounts[sessionId] === count) return;
-    this.visibleCounts = { ...this.visibleCounts, [sessionId]: count };
-  }
-
-  clearVisibleCount(sessionId: string) {
-    if (!(sessionId in this.visibleCounts)) return;
-    const { [sessionId]: _, ...remaining } = this.visibleCounts;
-    this.visibleCounts = remaining;
-  }
-
   clear(sessionId: string) {
     if (!this.markers[sessionId]) return;
     const { [sessionId]: _, ...remaining } = this.markers;
@@ -184,7 +169,6 @@ export class ReadProgressStore {
   hasUnread(sessionId: string, messageCount: number): boolean {
     const marker = this.markers[sessionId];
     if (!marker) return false;
-    if (this.visibleCounts[sessionId] !== undefined) return this.visibleCounts[sessionId] > marker.messageCount;
     return safeCount(messageCount) > (marker.totalMessageCount ?? marker.messageCount);
   }
 

--- a/frontend/src/lib/stores/read-progress.svelte.ts
+++ b/frontend/src/lib/stores/read-progress.svelte.ts
@@ -1,6 +1,7 @@
 export interface ReadProgressMarker {
   ordinal: number;
   messageCount: number;
+  totalMessageCount?: number;
 }
 
 interface StoredReadProgress {
@@ -88,9 +89,16 @@ export class ReadProgressStore {
     this.persist();
   }
 
-  recordVisible(sessionId: string, ordinal: number, messageCount: number) {
+  recordVisible(sessionId: string, ordinal: number, messageCount: number, totalMessageCount = messageCount) {
     const marker = this.markers[sessionId];
-    if (!marker || !Number.isInteger(ordinal) || ordinal <= marker.ordinal) return;
+    if (!marker || !Number.isInteger(ordinal)) return;
+    if (ordinal <= marker.ordinal) {
+      if (safeCount(messageCount) <= marker.messageCount && safeCount(totalMessageCount) > (marker.totalMessageCount ?? marker.messageCount)) {
+        this.markers = { ...this.markers, [sessionId]: { ...marker, totalMessageCount: safeCount(totalMessageCount) } };
+        this.persist();
+      }
+      return;
+    }
     this.markers = {
       ...this.markers,
       [sessionId]: {
@@ -99,6 +107,9 @@ export class ReadProgressStore {
           marker.messageCount,
           Math.min(safeCount(messageCount), ordinal + 1),
         ),
+        ...(safeCount(totalMessageCount) > safeCount(messageCount)
+          ? { totalMessageCount: safeCount(totalMessageCount) }
+          : {}),
       },
     };
     this.persist();
@@ -120,7 +131,9 @@ export class ReadProgressStore {
 
   hasUnread(sessionId: string, messageCount: number): boolean {
     const marker = this.markers[sessionId];
-    return marker !== undefined && (this.visibleCounts[sessionId] ?? safeCount(messageCount)) > marker.messageCount;
+    if (!marker) return false;
+    if (this.visibleCounts[sessionId] !== undefined) return this.visibleCounts[sessionId] > marker.messageCount;
+    return safeCount(messageCount) > (marker.totalMessageCount ?? marker.messageCount);
   }
 
   private persist() {

--- a/frontend/src/lib/stores/read-progress.test.ts
+++ b/frontend/src/lib/stores/read-progress.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ReadProgressStore } from "./read-progress.svelte.js";
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("ReadProgressStore", () => {
+  it("keeps absent state distinct and advances one session monotonically", () => {
+    const store = new ReadProgressStore();
+
+    expect(store.get("one")).toBeNull();
+    store.baseline("one", 3, 4);
+    store.baseline("two", 8, 9);
+    store.recordVisible("one", 2, 3);
+    store.recordVisible("one", 5, 6);
+
+    expect(store.get("one")).toEqual({ ordinal: 5, messageCount: 6 });
+    expect(store.get("two")).toEqual({ ordinal: 8, messageCount: 9 });
+    expect(store.hasUnread("one", 6)).toBe(false);
+    expect(store.hasUnread("one", 7)).toBe(true);
+  });
+
+  it("restores valid records and ignores malformed JSON and wrong records", () => {
+    localStorage.setItem(
+      "agentsview-read-progress",
+      JSON.stringify({
+        version: 1,
+        sessions: {
+          valid: { ordinal: 2, messageCount: 3 },
+          invalid: { ordinal: "2", messageCount: 3 },
+        },
+      }),
+    );
+    expect(new ReadProgressStore().get("valid")).toEqual({
+      ordinal: 2,
+      messageCount: 3,
+    });
+    expect(new ReadProgressStore().get("invalid")).toBeNull();
+
+    localStorage.setItem("agentsview-read-progress", "malformed JSON");
+    expect(new ReadProgressStore().get("valid")).toBeNull();
+    localStorage.setItem(
+      "agentsview-read-progress",
+      JSON.stringify({ version: 1, sessions: [] }),
+    );
+    expect(new ReadProgressStore().get("valid")).toBeNull();
+  });
+
+  it("keeps rendering state when storage access or writes fail", () => {
+    const getItem = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("storage unavailable");
+    });
+    const store = new ReadProgressStore();
+    getItem.mockRestore();
+    const setItem = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota exceeded");
+    });
+
+    store.baseline("one", -1, 0);
+    store.recordVisible("one", 0, 1);
+
+    expect(store.get("one")).toEqual({ ordinal: 0, messageCount: 1 });
+  });
+});

--- a/frontend/src/lib/stores/read-progress.test.ts
+++ b/frontend/src/lib/stores/read-progress.test.ts
@@ -23,6 +23,16 @@ describe("ReadProgressStore", () => {
     expect(store.hasUnread("one", 7)).toBe(true);
   });
 
+  it("uses the current summary after a session stops being visible", () => {
+    const store = new ReadProgressStore();
+    store.baseline("one", 3, 4);
+    store.setVisibleCount("one", 4);
+    store.clearVisibleCount("one");
+
+    expect(store.get("one")).toEqual({ ordinal: 3, messageCount: 4 });
+    expect(store.hasUnread("one", 5)).toBe(true);
+  });
+
   it("restores valid records and ignores malformed JSON and wrong records", () => {
     localStorage.setItem(
       "agentsview-read-progress",

--- a/frontend/src/lib/stores/read-progress.test.ts
+++ b/frontend/src/lib/stores/read-progress.test.ts
@@ -14,8 +14,8 @@ describe("ReadProgressStore", () => {
     expect(store.get("one")).toBeNull();
     store.baseline("one", 3, 4);
     store.baseline("two", 8, 9);
-    store.recordVisible("one", 2, 3);
-    store.recordVisible("one", 5, 6);
+    store.recordVisible("one", 2, 3, 4);
+    store.recordVisible("one", 5, 5, 6);
 
     expect(store.get("one")).toEqual({ ordinal: 5, messageCount: 6 });
     expect(store.get("two")).toEqual({ ordinal: 8, messageCount: 9 });
@@ -73,7 +73,7 @@ describe("ReadProgressStore", () => {
     });
 
     store.baseline("one", -1, 0);
-    store.recordVisible("one", 0, 1);
+    store.recordVisible("one", 0, 0, 1);
 
     expect(store.get("one")).toEqual({ ordinal: 0, messageCount: 1 });
   });
@@ -90,10 +90,46 @@ describe("ReadProgressStore", () => {
     try {
       const store = new ReadProgressStore();
       store.baseline("one", -1, 0);
-      store.recordVisible("one", 0, 1);
+      store.recordVisible("one", 0, 0, 1);
       expect(store.get("one")).toEqual({ ordinal: 0, messageCount: 1 });
     } finally {
       Object.defineProperty(globalThis, "localStorage", descriptor!);
     }
+  });
+
+  it("acknowledges a complete backend total only at the latest display ordinal", () => {
+    const store = new ReadProgressStore();
+    store.baseline("one", 0, 1);
+    store.recordVisible("one", 1, 2, 3, 4);
+    expect(store.get("one")).toEqual({ ordinal: 1, messageCount: 2 });
+
+    store.recordVisible("one", 2, 2, 3, 4);
+    expect(store.get("one")).toEqual({
+      ordinal: 2,
+      messageCount: 3,
+      totalMessageCount: 4,
+    });
+    expect(store.hasUnread("one", 4)).toBe(false);
+  });
+
+  it("preserves legacy markers and rejects invalid acknowledged totals", () => {
+    localStorage.setItem(
+      "agentsview-read-progress",
+      JSON.stringify({
+        version: 1,
+        sessions: {
+          legacy: { ordinal: 2, messageCount: 3 },
+          invalid: { ordinal: 2, messageCount: 3, totalMessageCount: 2 },
+        },
+      }),
+    );
+    const store = new ReadProgressStore();
+    expect(store.get("legacy")).toEqual({ ordinal: 2, messageCount: 3 });
+    expect(store.get("invalid")).toBeNull();
+
+    store.baseline("one", 1, 2, 1);
+    expect(store.get("one")).toEqual({ ordinal: 1, messageCount: 2 });
+    store.recordVisible("one", 2, 2, 3, 2);
+    expect(store.get("one")).toEqual({ ordinal: 2, messageCount: 3 });
   });
 });

--- a/frontend/src/lib/stores/read-progress.test.ts
+++ b/frontend/src/lib/stores/read-progress.test.ts
@@ -23,14 +23,18 @@ describe("ReadProgressStore", () => {
     expect(store.hasUnread("one", 7)).toBe(true);
   });
 
-  it("uses the current summary after a session stops being visible", () => {
+  it("uses acknowledged backend totals instead of loaded display counts", () => {
     const store = new ReadProgressStore();
-    store.baseline("one", 3, 4);
-    store.setVisibleCount("one", 4);
-    store.clearVisibleCount("one");
+    store.baseline("one", 3_999, 1_000, 4_000);
+    store.recordVisible("one", 3_999, 3_999, 2_000, 4_000);
 
-    expect(store.get("one")).toEqual({ ordinal: 3, messageCount: 4 });
-    expect(store.hasUnread("one", 5)).toBe(true);
+    expect(store.get("one")).toEqual({
+      ordinal: 3_999,
+      messageCount: 1_000,
+      totalMessageCount: 4_000,
+    });
+    expect(store.hasUnread("one", 4_000)).toBe(false);
+    expect(store.hasUnread("one", 4_001)).toBe(true);
   });
 
   it("restores valid records and ignores malformed JSON and wrong records", () => {
@@ -97,19 +101,19 @@ describe("ReadProgressStore", () => {
     }
   });
 
-  it("acknowledges a complete backend total only at the latest display ordinal", () => {
+  it("acknowledges a backend total only at the latest display ordinal", () => {
     const store = new ReadProgressStore();
     store.baseline("one", 0, 1);
-    store.recordVisible("one", 1, 2, 3, 4);
+    store.recordVisible("one", 1, 2, 3, 400);
     expect(store.get("one")).toEqual({ ordinal: 1, messageCount: 2 });
 
-    store.recordVisible("one", 2, 2, 3, 4);
+    store.recordVisible("one", 2, 2, 3, 400);
     expect(store.get("one")).toEqual({
       ordinal: 2,
       messageCount: 3,
-      totalMessageCount: 4,
+      totalMessageCount: 400,
     });
-    expect(store.hasUnread("one", 4)).toBe(false);
+    expect(store.hasUnread("one", 400)).toBe(false);
   });
 
   it("preserves legacy markers and rejects invalid acknowledged totals", () => {

--- a/frontend/src/lib/stores/read-progress.test.ts
+++ b/frontend/src/lib/stores/read-progress.test.ts
@@ -8,172 +8,100 @@ afterEach(() => {
 });
 
 describe("ReadProgressStore", () => {
-  it("keeps absent state distinct and advances one session monotonically", () => {
+  it("keeps absent markers distinct and advances sessions monotonically", () => {
     const store = new ReadProgressStore();
 
     expect(store.get("one")).toBeNull();
-    store.baseline("one", 3, 4);
-    store.baseline("two", 8, 9);
-    store.recordVisible("one", 2, 3, 4);
-    store.recordVisible("one", 5, 5, 6);
+    store.baseline("one", 3);
+    store.baseline("two", 8);
+    store.recordVisible("one", 2);
+    store.recordVisible("one", 5);
 
-    expect(store.get("one")).toEqual({ ordinal: 5, messageCount: 6 });
-    expect(store.get("two")).toEqual({ ordinal: 8, messageCount: 9 });
-    expect(store.hasUnread("one", 6)).toBe(false);
-    expect(store.hasUnread("one", 7)).toBe(true);
+    expect(store.get("one")).toEqual({ seenOrdinal: 5 });
+    expect(store.get("two")).toEqual({ seenOrdinal: 8 });
+    expect(store.hasUnread("one", 5)).toBe(false);
+    expect(store.hasUnread("one", 6)).toBe(true);
+    expect(store.hasUnread("missing", 6)).toBe(false);
   });
 
-  it("uses acknowledged backend totals instead of loaded display counts", () => {
+  it("treats null followed by ordinal zero as unread until observed", () => {
     const store = new ReadProgressStore();
-    store.baseline("one", 3_999, 1_000, 4_000);
-    store.recordVisible("one", 3_999, 3_999, 2_000, 4_000);
+    store.baseline("one", null);
 
-    expect(store.get("one")).toEqual({
-      ordinal: 3_999,
-      messageCount: 1_000,
-      totalMessageCount: 4_000,
-    });
-    expect(store.hasUnread("one", 4_000)).toBe(false);
-    expect(store.hasUnread("one", 4_001)).toBe(true);
+    expect(store.hasUnread("one", 0)).toBe(true);
+    store.recordVisible("one", 0);
+    expect(store.get("one")).toEqual({ seenOrdinal: 0 });
+    expect(store.hasUnread("one", 0)).toBe(false);
   });
 
-  it("rebaselines stale markers when the backend total shrinks", () => {
+  it("repairs regressions without creating inactive markers", () => {
     const store = new ReadProgressStore();
-    store.baseline("one", 99, 100, 100);
-    store.baseline("one", 9, 10, 10);
+    store.baseline("tracked", 99);
 
-    expect(store.get("one")).toEqual({
-      ordinal: 9,
-      messageCount: 10,
-      totalMessageCount: 10,
-    });
-    expect(store.hasUnread("one", 10)).toBe(false);
-    expect(store.hasUnread("one", 11)).toBe(true);
+    store.reconcile("tracked", 9);
+    store.reconcile("absent", 9);
+
+    expect(store.get("tracked")).toEqual({ seenOrdinal: 9 });
+    expect(store.get("absent")).toBeNull();
   });
 
-  it("acknowledges backend total growth for hidden-only sessions", () => {
+  it("keeps existing lower markers unread on a successful baseline", () => {
     const store = new ReadProgressStore();
-    store.baseline("one", -1, 0, 2);
-    store.baseline("one", -1, 0, 3);
+    store.baseline("one", 3);
+    store.baseline("one", 5);
 
-    expect(store.get("one")).toEqual({
-      ordinal: -1,
-      messageCount: 0,
-      totalMessageCount: 3,
-    });
-    expect(store.hasUnread("one", 3)).toBe(false);
+    expect(store.get("one")).toEqual({ seenOrdinal: 3 });
+    expect(store.hasUnread("one", 5)).toBe(true);
   });
 
-  it("reconciles stale markers when visible progress sees a smaller total", () => {
-    const store = new ReadProgressStore();
-    store.baseline("one", 99, 100, 100);
-    store.recordVisible("one", 9, 9, 10, 10);
+  it("migrates valid version one ordinals and validates version two", () => {
+    localStorage.setItem("agentsview-read-progress", JSON.stringify({
+      version: 1,
+      sessions: {
+        numeric: { ordinal: 2, messageCount: 3 },
+        empty: { ordinal: -1, messageCount: 0 },
+        invalid: { ordinal: "2", messageCount: 3 },
+      },
+    }));
+    let store = new ReadProgressStore();
+    expect(store.get("numeric")).toEqual({ seenOrdinal: 2 });
+    expect(store.get("empty")).toEqual({ seenOrdinal: null });
+    expect(store.get("invalid")).toBeNull();
 
-    expect(store.get("one")).toEqual({
-      ordinal: 9,
-      messageCount: 10,
-      totalMessageCount: 10,
-    });
-    expect(store.hasUnread("one", 10)).toBe(false);
+    localStorage.setItem("agentsview-read-progress", JSON.stringify({
+      version: 2,
+      sessions: {
+        numeric: { seenOrdinal: 4 },
+        empty: { seenOrdinal: null },
+        invalid: { seenOrdinal: -1 },
+      },
+    }));
+    store = new ReadProgressStore();
+    expect(store.get("numeric")).toEqual({ seenOrdinal: 4 });
+    expect(store.get("empty")).toEqual({ seenOrdinal: null });
+    expect(store.get("invalid")).toBeNull();
   });
 
-  it("restores valid records and ignores malformed JSON and wrong records", () => {
-    localStorage.setItem(
-      "agentsview-read-progress",
-      JSON.stringify({
-        version: 1,
-        sessions: {
-          valid: { ordinal: 2, messageCount: 3 },
-          invalid: { ordinal: "2", messageCount: 3 },
-        },
-      }),
-    );
-    expect(new ReadProgressStore().get("valid")).toEqual({
-      ordinal: 2,
-      messageCount: 3,
-    });
-    expect(new ReadProgressStore().get("invalid")).toBeNull();
-
+  it("ignores malformed storage and keeps in-memory state when writes fail", () => {
     localStorage.setItem("agentsview-read-progress", "malformed JSON");
-    expect(new ReadProgressStore().get("valid")).toBeNull();
-    localStorage.setItem(
-      "agentsview-read-progress",
-      JSON.stringify({
-        version: 1,
-        sessions: [{ valid: { ordinal: 2, messageCount: 3 } }],
-      }),
-    );
-    expect(new ReadProgressStore().get("valid")).toBeNull();
-  });
-
-  it("keeps rendering state when storage access or writes fail", () => {
-    const getItem = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
-      throw new Error("storage unavailable");
-    });
     const store = new ReadProgressStore();
-    getItem.mockRestore();
-    const setItem = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
       throw new Error("quota exceeded");
     });
 
-    store.baseline("one", -1, 0);
-    store.recordVisible("one", 0, 0, 1);
+    store.baseline("one", null);
+    store.recordVisible("one", 0);
 
-    expect(store.get("one")).toEqual({ ordinal: 0, messageCount: 1 });
+    expect(store.get("one")).toEqual({ seenOrdinal: 0 });
   });
 
-  it("uses in-memory state when localStorage is not Storage-like", () => {
-    const descriptor = Object.getOwnPropertyDescriptor(
-      globalThis,
-      "localStorage",
-    );
-    Object.defineProperty(globalThis, "localStorage", {
-      configurable: true,
-      value: { getItem() {} },
-    });
-    try {
-      const store = new ReadProgressStore();
-      store.baseline("one", -1, 0);
-      store.recordVisible("one", 0, 0, 1);
-      expect(store.get("one")).toEqual({ ordinal: 0, messageCount: 1 });
-    } finally {
-      Object.defineProperty(globalThis, "localStorage", descriptor!);
-    }
-  });
-
-  it("acknowledges a backend total only at the latest display ordinal", () => {
+  it("persists the version two cursor shape", () => {
     const store = new ReadProgressStore();
-    store.baseline("one", 0, 1);
-    store.recordVisible("one", 1, 2, 3, 400);
-    expect(store.get("one")).toEqual({ ordinal: 1, messageCount: 2 });
+    store.baseline("one", 7);
 
-    store.recordVisible("one", 2, 2, 3, 400);
-    expect(store.get("one")).toEqual({
-      ordinal: 2,
-      messageCount: 3,
-      totalMessageCount: 400,
+    expect(JSON.parse(localStorage.getItem("agentsview-read-progress")!)).toEqual({
+      version: 2,
+      sessions: { one: { seenOrdinal: 7 } },
     });
-    expect(store.hasUnread("one", 400)).toBe(false);
-  });
-
-  it("preserves legacy markers and rejects invalid acknowledged totals", () => {
-    localStorage.setItem(
-      "agentsview-read-progress",
-      JSON.stringify({
-        version: 1,
-        sessions: {
-          legacy: { ordinal: 2, messageCount: 3 },
-          invalid: { ordinal: 2, messageCount: 3, totalMessageCount: 2 },
-        },
-      }),
-    );
-    const store = new ReadProgressStore();
-    expect(store.get("legacy")).toEqual({ ordinal: 2, messageCount: 3 });
-    expect(store.get("invalid")).toBeNull();
-
-    store.baseline("one", 1, 2, 1);
-    expect(store.get("one")).toEqual({ ordinal: 1, messageCount: 2 });
-    store.recordVisible("one", 2, 2, 3, 2);
-    expect(store.get("one")).toEqual({ ordinal: 2, messageCount: 3 });
   });
 });

--- a/frontend/src/lib/stores/read-progress.test.ts
+++ b/frontend/src/lib/stores/read-progress.test.ts
@@ -87,6 +87,61 @@ describe("ReadProgressStore", () => {
     expect(store.hasUnread("one", 5)).toBe(true);
   });
 
+  it("evicts the least recently visited session at capacity", () => {
+    const store = new ReadProgressStore(3);
+    store.baseline("oldest", 1);
+    store.baseline("middle", 2);
+    store.baseline("newest", 3);
+
+    // Revisiting a session refreshes its recency without acknowledging
+    // output beyond the existing marker.
+    store.baseline("oldest", 9);
+    store.baseline("incoming", 4);
+
+    expect(store.get("middle")).toBeNull();
+    expect(store.get("oldest")).toEqual({ seenOrdinal: 1 });
+    expect(store.hasUnread("oldest", 9)).toBe(true);
+    expect(store.get("newest")).toEqual({ seenOrdinal: 3 });
+    expect(store.get("incoming")).toEqual({ seenOrdinal: 4 });
+    expect(JSON.parse(localStorage.getItem("agentsview-read-progress")!)).toEqual({
+      version: 3,
+      recency: ["newest", "oldest", "incoming"],
+      sessions: {
+        oldest: { seenOrdinal: 1 },
+        newest: { seenOrdinal: 3 },
+        incoming: { seenOrdinal: 4 },
+      },
+    });
+  });
+
+  it("prunes oversized persisted progress when loading", () => {
+    localStorage.setItem("agentsview-read-progress", JSON.stringify({
+      version: 3,
+      recency: ["one", "two", "three", "four"],
+      sessions: {
+        one: { seenOrdinal: 1 },
+        two: { seenOrdinal: 2 },
+        three: { seenOrdinal: 3 },
+        four: { seenOrdinal: 4 },
+      },
+    }));
+
+    const store = new ReadProgressStore(2);
+
+    expect(store.get("one")).toBeNull();
+    expect(store.get("two")).toBeNull();
+    expect(store.get("three")).toEqual({ seenOrdinal: 3 });
+    expect(store.get("four")).toEqual({ seenOrdinal: 4 });
+    expect(JSON.parse(localStorage.getItem("agentsview-read-progress")!)).toEqual({
+      version: 3,
+      recency: ["three", "four"],
+      sessions: {
+        three: { seenOrdinal: 3 },
+        four: { seenOrdinal: 4 },
+      },
+    });
+  });
+
   it("migrates valid version one and two cursors and validates version three", () => {
     localStorage.setItem("agentsview-read-progress", JSON.stringify({
       version: 1,
@@ -116,6 +171,7 @@ describe("ReadProgressStore", () => {
 
     localStorage.setItem("agentsview-read-progress", JSON.stringify({
       version: 3,
+      recency: ["numeric", "empty", "invalid"],
       sessions: {
         numeric: { seenOrdinal: 4, seenContentLength: 11 },
         empty: { seenOrdinal: null },
@@ -150,6 +206,7 @@ describe("ReadProgressStore", () => {
 
     expect(JSON.parse(localStorage.getItem("agentsview-read-progress")!)).toEqual({
       version: 3,
+      recency: ["one"],
       sessions: { one: { seenOrdinal: 7, seenContentLength: 12 } },
     });
   });

--- a/frontend/src/lib/stores/read-progress.test.ts
+++ b/frontend/src/lib/stores/read-progress.test.ts
@@ -24,6 +24,39 @@ describe("ReadProgressStore", () => {
     expect(store.hasUnread("missing", 6)).toBe(false);
   });
 
+  it("tracks same-ordinal content growth when both cursors have content lengths", () => {
+    const store = new ReadProgressStore();
+    store.baseline("one", 5, 12);
+
+    expect(store.hasUnread("one", 5, 12)).toBe(false);
+    expect(store.hasUnread("one", 5, 18)).toBe(true);
+
+    store.recordVisible("one", 5, 18);
+
+    expect(store.get("one")).toEqual({
+      seenOrdinal: 5,
+      seenContentLength: 18,
+    });
+    expect(store.hasUnread("one", 5, 18)).toBe(false);
+  });
+
+  it("enriches same-ordinal legacy markers with a content-length cursor", () => {
+    const store = new ReadProgressStore();
+    store.baseline("one", 5);
+
+    store.baseline("one", 5, 12);
+    expect(store.get("one")).toEqual({
+      seenOrdinal: 5,
+      seenContentLength: 12,
+    });
+
+    store.recordVisible("one", 5, 18);
+    expect(store.get("one")).toEqual({
+      seenOrdinal: 5,
+      seenContentLength: 18,
+    });
+  });
+
   it("treats null followed by ordinal zero as unread until observed", () => {
     const store = new ReadProgressStore();
     store.baseline("one", null);
@@ -54,7 +87,7 @@ describe("ReadProgressStore", () => {
     expect(store.hasUnread("one", 5)).toBe(true);
   });
 
-  it("migrates valid version one ordinals and validates version two", () => {
+  it("migrates valid version one and two cursors and validates version three", () => {
     localStorage.setItem("agentsview-read-progress", JSON.stringify({
       version: 1,
       sessions: {
@@ -80,6 +113,22 @@ describe("ReadProgressStore", () => {
     expect(store.get("numeric")).toEqual({ seenOrdinal: 4 });
     expect(store.get("empty")).toEqual({ seenOrdinal: null });
     expect(store.get("invalid")).toBeNull();
+
+    localStorage.setItem("agentsview-read-progress", JSON.stringify({
+      version: 3,
+      sessions: {
+        numeric: { seenOrdinal: 4, seenContentLength: 11 },
+        empty: { seenOrdinal: null },
+        invalid: { seenOrdinal: 4, seenContentLength: -1 },
+      },
+    }));
+    store = new ReadProgressStore();
+    expect(store.get("numeric")).toEqual({
+      seenOrdinal: 4,
+      seenContentLength: 11,
+    });
+    expect(store.get("empty")).toEqual({ seenOrdinal: null });
+    expect(store.get("invalid")).toBeNull();
   });
 
   it("ignores malformed storage and keeps in-memory state when writes fail", () => {
@@ -95,13 +144,13 @@ describe("ReadProgressStore", () => {
     expect(store.get("one")).toEqual({ seenOrdinal: 0 });
   });
 
-  it("persists the version two cursor shape", () => {
+  it("persists the version three cursor shape", () => {
     const store = new ReadProgressStore();
-    store.baseline("one", 7);
+    store.baseline("one", 7, 12);
 
     expect(JSON.parse(localStorage.getItem("agentsview-read-progress")!)).toEqual({
-      version: 2,
-      sessions: { one: { seenOrdinal: 7 } },
+      version: 3,
+      sessions: { one: { seenOrdinal: 7, seenContentLength: 12 } },
     });
   });
 });

--- a/frontend/src/lib/stores/read-progress.test.ts
+++ b/frontend/src/lib/stores/read-progress.test.ts
@@ -51,6 +51,19 @@ describe("ReadProgressStore", () => {
     expect(store.hasUnread("one", 11)).toBe(true);
   });
 
+  it("acknowledges backend total growth for hidden-only sessions", () => {
+    const store = new ReadProgressStore();
+    store.baseline("one", -1, 0, 2);
+    store.baseline("one", -1, 0, 3);
+
+    expect(store.get("one")).toEqual({
+      ordinal: -1,
+      messageCount: 0,
+      totalMessageCount: 3,
+    });
+    expect(store.hasUnread("one", 3)).toBe(false);
+  });
+
   it("reconciles stale markers when visible progress sees a smaller total", () => {
     const store = new ReadProgressStore();
     store.baseline("one", 99, 100, 100);

--- a/frontend/src/lib/stores/read-progress.test.ts
+++ b/frontend/src/lib/stores/read-progress.test.ts
@@ -44,7 +44,10 @@ describe("ReadProgressStore", () => {
     expect(new ReadProgressStore().get("valid")).toBeNull();
     localStorage.setItem(
       "agentsview-read-progress",
-      JSON.stringify({ version: 1, sessions: [] }),
+      JSON.stringify({
+        version: 1,
+        sessions: [{ valid: { ordinal: 2, messageCount: 3 } }],
+      }),
     );
     expect(new ReadProgressStore().get("valid")).toBeNull();
   });

--- a/frontend/src/lib/stores/read-progress.test.ts
+++ b/frontend/src/lib/stores/read-progress.test.ts
@@ -64,4 +64,23 @@ describe("ReadProgressStore", () => {
 
     expect(store.get("one")).toEqual({ ordinal: 0, messageCount: 1 });
   });
+
+  it("uses in-memory state when localStorage is not Storage-like", () => {
+    const descriptor = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "localStorage",
+    );
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: { getItem() {} },
+    });
+    try {
+      const store = new ReadProgressStore();
+      store.baseline("one", -1, 0);
+      store.recordVisible("one", 0, 1);
+      expect(store.get("one")).toEqual({ ordinal: 0, messageCount: 1 });
+    } finally {
+      Object.defineProperty(globalThis, "localStorage", descriptor!);
+    }
+  });
 });

--- a/frontend/src/lib/stores/read-progress.test.ts
+++ b/frontend/src/lib/stores/read-progress.test.ts
@@ -103,28 +103,29 @@ describe("ReadProgressStore", () => {
     expect(store.hasUnread("oldest", 9)).toBe(true);
     expect(store.get("newest")).toEqual({ seenOrdinal: 3 });
     expect(store.get("incoming")).toEqual({ seenOrdinal: 4 });
-    expect(JSON.parse(localStorage.getItem("agentsview-read-progress")!)).toEqual({
-      version: 3,
-      recency: ["newest", "oldest", "incoming"],
-      sessions: {
-        oldest: { seenOrdinal: 1 },
-        newest: { seenOrdinal: 3 },
-        incoming: { seenOrdinal: 4 },
-      },
-    });
+    expect(localStorage.getItem("agentsview-read-progress:session:middle"))
+      .toBeNull();
+    expect(JSON.parse(
+      localStorage.getItem("agentsview-read-progress:index")!,
+    )).toEqual(["newest", "oldest", "incoming"]);
   });
 
   it("prunes oversized persisted progress when loading", () => {
-    localStorage.setItem("agentsview-read-progress", JSON.stringify({
-      version: 3,
-      recency: ["one", "two", "three", "four"],
-      sessions: {
-        one: { seenOrdinal: 1 },
-        two: { seenOrdinal: 2 },
-        three: { seenOrdinal: 3 },
-        four: { seenOrdinal: 4 },
-      },
-    }));
+    localStorage.setItem(
+      "agentsview-read-progress:index",
+      JSON.stringify(["one", "two", "three", "four"]),
+    );
+    for (const [id, seenOrdinal] of Object.entries({
+      one: 1,
+      two: 2,
+      three: 3,
+      four: 4,
+    })) {
+      localStorage.setItem(
+        `agentsview-read-progress:session:${id}`,
+        JSON.stringify({ seenOrdinal }),
+      );
+    }
 
     const store = new ReadProgressStore(2);
 
@@ -132,63 +133,31 @@ describe("ReadProgressStore", () => {
     expect(store.get("two")).toBeNull();
     expect(store.get("three")).toEqual({ seenOrdinal: 3 });
     expect(store.get("four")).toEqual({ seenOrdinal: 4 });
-    expect(JSON.parse(localStorage.getItem("agentsview-read-progress")!)).toEqual({
-      version: 3,
-      recency: ["three", "four"],
-      sessions: {
-        three: { seenOrdinal: 3 },
-        four: { seenOrdinal: 4 },
-      },
-    });
+    expect(localStorage.getItem("agentsview-read-progress:session:one"))
+      .toBeNull();
+    expect(localStorage.getItem("agentsview-read-progress:session:two"))
+      .toBeNull();
+    expect(JSON.parse(
+      localStorage.getItem("agentsview-read-progress:index")!,
+    )).toEqual(["three", "four"]);
   });
 
-  it("migrates valid version one and two cursors and validates version three", () => {
-    localStorage.setItem("agentsview-read-progress", JSON.stringify({
-      version: 1,
-      sessions: {
-        numeric: { ordinal: 2, messageCount: 3 },
-        empty: { ordinal: -1, messageCount: 0 },
-        invalid: { ordinal: "2", messageCount: 3 },
-      },
-    }));
-    let store = new ReadProgressStore();
-    expect(store.get("numeric")).toEqual({ seenOrdinal: 2 });
-    expect(store.get("empty")).toEqual({ seenOrdinal: null });
-    expect(store.get("invalid")).toBeNull();
+  it("writes only the active marker when visible progress advances", () => {
+    const store = new ReadProgressStore();
+    store.baseline("one", 1);
+    const write = vi.spyOn(localStorage, "setItem");
 
-    localStorage.setItem("agentsview-read-progress", JSON.stringify({
-      version: 2,
-      sessions: {
-        numeric: { seenOrdinal: 4 },
-        empty: { seenOrdinal: null },
-        invalid: { seenOrdinal: -1 },
-      },
-    }));
-    store = new ReadProgressStore();
-    expect(store.get("numeric")).toEqual({ seenOrdinal: 4 });
-    expect(store.get("empty")).toEqual({ seenOrdinal: null });
-    expect(store.get("invalid")).toBeNull();
+    store.recordVisible("one", 2);
 
-    localStorage.setItem("agentsview-read-progress", JSON.stringify({
-      version: 3,
-      recency: ["numeric", "empty", "invalid"],
-      sessions: {
-        numeric: { seenOrdinal: 4, seenContentLength: 11 },
-        empty: { seenOrdinal: null },
-        invalid: { seenOrdinal: 4, seenContentLength: -1 },
-      },
-    }));
-    store = new ReadProgressStore();
-    expect(store.get("numeric")).toEqual({
-      seenOrdinal: 4,
-      seenContentLength: 11,
-    });
-    expect(store.get("empty")).toEqual({ seenOrdinal: null });
-    expect(store.get("invalid")).toBeNull();
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(write).toHaveBeenCalledWith(
+      "agentsview-read-progress:session:one",
+      JSON.stringify({ seenOrdinal: 2 }),
+    );
   });
 
   it("ignores malformed storage and keeps in-memory state when writes fail", () => {
-    localStorage.setItem("agentsview-read-progress", "malformed JSON");
+    localStorage.setItem("agentsview-read-progress:index", "malformed JSON");
     const store = new ReadProgressStore();
     vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
       throw new Error("quota exceeded");
@@ -200,14 +169,15 @@ describe("ReadProgressStore", () => {
     expect(store.get("one")).toEqual({ seenOrdinal: 0 });
   });
 
-  it("persists the version three cursor shape", () => {
+  it("persists a marker separately from the recency index", () => {
     const store = new ReadProgressStore();
     store.baseline("one", 7, 12);
 
-    expect(JSON.parse(localStorage.getItem("agentsview-read-progress")!)).toEqual({
-      version: 3,
-      recency: ["one"],
-      sessions: { one: { seenOrdinal: 7, seenContentLength: 12 } },
-    });
+    expect(JSON.parse(
+      localStorage.getItem("agentsview-read-progress:session:one")!,
+    )).toEqual({ seenOrdinal: 7, seenContentLength: 12 });
+    expect(JSON.parse(
+      localStorage.getItem("agentsview-read-progress:index")!,
+    )).toEqual(["one"]);
   });
 });

--- a/frontend/src/lib/stores/read-progress.test.ts
+++ b/frontend/src/lib/stores/read-progress.test.ts
@@ -37,6 +37,33 @@ describe("ReadProgressStore", () => {
     expect(store.hasUnread("one", 4_001)).toBe(true);
   });
 
+  it("rebaselines stale markers when the backend total shrinks", () => {
+    const store = new ReadProgressStore();
+    store.baseline("one", 99, 100, 100);
+    store.baseline("one", 9, 10, 10);
+
+    expect(store.get("one")).toEqual({
+      ordinal: 9,
+      messageCount: 10,
+      totalMessageCount: 10,
+    });
+    expect(store.hasUnread("one", 10)).toBe(false);
+    expect(store.hasUnread("one", 11)).toBe(true);
+  });
+
+  it("reconciles stale markers when visible progress sees a smaller total", () => {
+    const store = new ReadProgressStore();
+    store.baseline("one", 99, 100, 100);
+    store.recordVisible("one", 9, 9, 10, 10);
+
+    expect(store.get("one")).toEqual({
+      ordinal: 9,
+      messageCount: 10,
+      totalMessageCount: 10,
+    });
+    expect(store.hasUnread("one", 10)).toBe(false);
+  });
+
   it("restores valid records and ignores malformed JSON and wrong records", () => {
     localStorage.setItem(
       "agentsview-read-progress",

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -18,6 +18,7 @@ import { sync } from "./sync.svelte.js";
 import { events } from "./events.svelte.js";
 import { starred } from "./starred.svelte.js";
 import { yokedDates } from "./yokedDates.svelte.js";
+import { readProgress } from "./read-progress.svelte.js";
 
 type SidebarIndexParams = Parameters<
   typeof SessionsService.getApiV1SessionsSidebarIndex
@@ -52,6 +53,7 @@ export interface SessionGroupInput {
   created_at: string;
   termination_status?: string | null;
   message_count: number;
+  latest_display_ordinal: number | null;
   user_message_count?: number;
   is_automated?: boolean;
   is_teammate?: boolean;
@@ -431,6 +433,11 @@ class SessionsStore {
         session.id,
         session,
       ]));
+      for (const row of index.sessions) {
+        if (row.id !== this.activeSessionId && readProgress.get(row.id)) {
+          readProgress.reconcile(row.id, row.latest_display_ordinal);
+        }
+      }
       this.sessions = index.sessions.map((row) =>
         sidebarIndexRowToSession(row, existing.get(row.id))
       );
@@ -571,11 +578,14 @@ class SessionsStore {
       }) as unknown as SidebarSessionIndexResponse;
       if (this.loadVersion !== version) return;
       this.sessions.push(
-        ...index.sessions.map((row) =>
-          sidebarIndexRowToSession(row, this.sessions.find(
+        ...index.sessions.map((row) => {
+          if (row.id !== this.activeSessionId && readProgress.get(row.id)) {
+            readProgress.reconcile(row.id, row.latest_display_ordinal);
+          }
+          return sidebarIndexRowToSession(row, this.sessions.find(
             (existing) => existing.id === row.id,
-          ))
-        ),
+          ));
+        }),
       );
       this.nextCursor = index.next_cursor ?? null;
       this.total = index.total;
@@ -1314,6 +1324,7 @@ function sidebarIndexRowToSession(
     started_at: row.started_at,
     ended_at: row.ended_at,
     message_count: row.message_count,
+    latest_display_ordinal: row.latest_display_ordinal,
     user_message_count: row.user_message_count,
     parent_session_id: row.parent_session_id ?? undefined,
     relationship_type: row.relationship_type ?? undefined,
@@ -1338,6 +1349,7 @@ function sidebarIndexRowToSession(
     started_at: skinny.started_at,
     ended_at: skinny.ended_at,
     message_count: skinny.message_count,
+    latest_display_ordinal: skinny.latest_display_ordinal,
     user_message_count: skinny.user_message_count,
     parent_session_id: skinny.parent_session_id,
     relationship_type: skinny.relationship_type,

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -54,6 +54,7 @@ export interface SessionGroupInput {
   termination_status?: string | null;
   message_count: number;
   latest_display_ordinal: number | null;
+  latest_display_content_length?: number | null;
   user_message_count?: number;
   is_automated?: boolean;
   is_teammate?: boolean;
@@ -435,7 +436,11 @@ class SessionsStore {
       ]));
       for (const row of index.sessions) {
         if (row.id !== this.activeSessionId && readProgress.get(row.id)) {
-          readProgress.reconcile(row.id, row.latest_display_ordinal);
+          readProgress.reconcile(
+            row.id,
+            row.latest_display_ordinal,
+            row.latest_display_content_length ?? null,
+          );
         }
       }
       this.sessions = index.sessions.map((row) =>
@@ -580,7 +585,11 @@ class SessionsStore {
       this.sessions.push(
         ...index.sessions.map((row) => {
           if (row.id !== this.activeSessionId && readProgress.get(row.id)) {
-            readProgress.reconcile(row.id, row.latest_display_ordinal);
+            readProgress.reconcile(
+              row.id,
+              row.latest_display_ordinal,
+              row.latest_display_content_length ?? null,
+            );
           }
           return sidebarIndexRowToSession(row, this.sessions.find(
             (existing) => existing.id === row.id,
@@ -1325,6 +1334,7 @@ function sidebarIndexRowToSession(
     ended_at: row.ended_at,
     message_count: row.message_count,
     latest_display_ordinal: row.latest_display_ordinal,
+    latest_display_content_length: row.latest_display_content_length ?? null,
     user_message_count: row.user_message_count,
     parent_session_id: row.parent_session_id ?? undefined,
     relationship_type: row.relationship_type ?? undefined,
@@ -1350,6 +1360,7 @@ function sidebarIndexRowToSession(
     ended_at: skinny.ended_at,
     message_count: skinny.message_count,
     latest_display_ordinal: skinny.latest_display_ordinal,
+    latest_display_content_length: skinny.latest_display_content_length,
     user_message_count: skinny.user_message_count,
     parent_session_id: skinny.parent_session_id,
     relationship_type: skinny.relationship_type,

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -18,6 +18,7 @@ import { yokedDates } from "./yokedDates.svelte.js";
 import type { Filters } from "./sessions.svelte.js";
 import type { Session } from "../api/types.js";
 import { callGenerated } from "../api/runtime.js";
+import { readProgress } from "./read-progress.svelte.js";
 
 const api = vi.hoisted(() => ({
   listSessions: vi.fn(),
@@ -112,6 +113,7 @@ type SkinnySessionRow = {
   created_at: string;
   termination_status?: string | null;
   message_count: number;
+  latest_display_ordinal: number | null;
   user_message_count: number;
   is_automated: boolean;
   is_teammate?: boolean;
@@ -130,6 +132,7 @@ function makeSkinnyRow(
     created_at: "2024-01-01T00:00:00Z",
     termination_status: null,
     message_count: 1,
+    latest_display_ordinal: 0,
     user_message_count: 1,
     is_automated: false,
     is_teammate: false,
@@ -204,6 +207,7 @@ describe("SessionsStore", () => {
     starred.ids = new Set();
     yokedDates.clear();
     sessions = createSessionsStore();
+    for (const id of ["inactive", "absent", "active"]) readProgress.clear(id);
   });
 
   describe("initFromParams", () => {
@@ -288,6 +292,23 @@ describe("SessionsStore", () => {
   });
 
   describe("sidebar loading", () => {
+    it("reconciles only tracked inactive cursor regressions", async () => {
+      readProgress.baseline("inactive", 9);
+      sessions.activeSessionId = "active";
+      readProgress.baseline("active", 9);
+      mockSidebarIndex([
+        makeSkinnyRow({ id: "inactive", latest_display_ordinal: 4 }),
+        makeSkinnyRow({ id: "absent", latest_display_ordinal: 4 }),
+        makeSkinnyRow({ id: "active", latest_display_ordinal: 4 }),
+      ]);
+
+      await sessions.load();
+
+      expect(readProgress.get("inactive")).toEqual({ seenOrdinal: 4 });
+      expect(readProgress.get("absent")).toBeNull();
+      expect(readProgress.get("active")).toEqual({ seenOrdinal: 9 });
+    });
+
     it("does not load sessions when no sidebar consumer is mounted", async () => {
       sessions.refreshSidebarIfAttached();
 
@@ -2287,6 +2308,7 @@ function makeSession(
     is_automated: false,
     created_at: "2024-01-01T00:00:00Z",
     ...overrides,
+    latest_display_ordinal: overrides.latest_display_ordinal ?? 0,
   };
 }
 

--- a/frontend/src/lib/utils/keyboard.test.ts
+++ b/frontend/src/lib/utils/keyboard.test.ts
@@ -258,6 +258,7 @@ describe("registerShortcuts", () => {
         started_at: null,
         ended_at: null,
         message_count: 1,
+        latest_display_ordinal: 0,
         user_message_count: 1,
         total_output_tokens: 0,
         peak_context_tokens: 0,

--- a/frontend/src/lib/utils/messages.ts
+++ b/frontend/src/lib/utils/messages.ts
@@ -72,6 +72,18 @@ export function isCompactBoundary(m: Message): boolean {
   return Boolean(m.is_compact_boundary);
 }
 
+export function renderedContentLength(message: Message): number {
+  return message.content_length + (message.tool_calls ?? []).reduce(
+    (total, toolCall) => total +
+      (toolCall.result_content_length ?? 0) +
+      (toolCall.result_events ?? []).reduce(
+        (eventTotal, event) => eventTotal + event.content_length,
+        0,
+      ),
+    0,
+  );
+}
+
 export interface MessagePreview {
   /** Display text, with Claude Code shell-shortcut wrappers
    *  replaced: `<bash-input>cmd</bash-input>` becomes `!cmd`,

--- a/internal/db/search.go
+++ b/internal/db/search.go
@@ -114,6 +114,11 @@ func PostgresDisplayMessageSQL(alias string) string {
 	return displayMessageSQL(alias, systemPrefixPostgres)
 }
 
+// DuckDBDisplayMessageSQL returns the DuckDB transcript-visibility predicate.
+func DuckDBDisplayMessageSQL(alias string) string {
+	return displayMessageSQL(alias, systemPrefixDuckDB)
+}
+
 func displayMessageSQL(alias string, dialect systemPrefixSQLDialect) string {
 	booleanTrue, booleanFalse := "1", "0"
 	prefix := SystemPrefixSQL(alias+".content", alias+".role")

--- a/internal/db/search.go
+++ b/internal/db/search.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -43,10 +44,8 @@ func IsDisplayMessage(m Message) bool {
 	if m.IsCompactBoundary {
 		return true
 	}
-	for _, subtype := range visibleSystemSubtypes {
-		if m.SourceSubtype == subtype {
-			return true
-		}
+	if slices.Contains(visibleSystemSubtypes, m.SourceSubtype) {
+		return true
 	}
 	return !m.IsSystem && !IsSystemPrefixed(m.Content, m.Role)
 }

--- a/internal/db/search.go
+++ b/internal/db/search.go
@@ -119,6 +119,83 @@ func DuckDBDisplayMessageSQL(alias string) string {
 	return displayMessageSQL(alias, systemPrefixDuckDB)
 }
 
+func LatestDisplayOrdinalSubquery(
+	sessionAlias, messageAlias string,
+) string {
+	return latestDisplayOrdinalSubquery(
+		sessionAlias,
+		messageAlias,
+		DisplayMessageSQL(messageAlias),
+	)
+}
+
+func PostgresLatestDisplayOrdinalSubquery(
+	sessionAlias, messageAlias string,
+) string {
+	return latestDisplayOrdinalSubquery(
+		sessionAlias,
+		messageAlias,
+		PostgresDisplayMessageSQL(messageAlias),
+	)
+}
+
+func DuckDBLatestDisplayOrdinalSubquery(
+	sessionAlias, messageAlias string,
+) string {
+	return latestDisplayOrdinalSubquery(
+		sessionAlias,
+		messageAlias,
+		DuckDBDisplayMessageSQL(messageAlias),
+	)
+}
+
+func LatestDisplayContentLengthSubquery(
+	sessionAlias, messageAlias string,
+) string {
+	return latestDisplayContentLengthSubquery(
+		sessionAlias,
+		messageAlias,
+		DisplayMessageSQL(messageAlias),
+	)
+}
+
+func PostgresLatestDisplayContentLengthSubquery(
+	sessionAlias, messageAlias string,
+) string {
+	return latestDisplayContentLengthSubquery(
+		sessionAlias,
+		messageAlias,
+		PostgresDisplayMessageSQL(messageAlias),
+	)
+}
+
+func DuckDBLatestDisplayContentLengthSubquery(
+	sessionAlias, messageAlias string,
+) string {
+	return latestDisplayContentLengthSubquery(
+		sessionAlias,
+		messageAlias,
+		DuckDBDisplayMessageSQL(messageAlias),
+	)
+}
+
+func latestDisplayOrdinalSubquery(
+	sessionAlias, messageAlias, predicate string,
+) string {
+	return `(SELECT MAX(` + messageAlias + `.ordinal) FROM messages ` +
+		messageAlias + ` WHERE ` + messageAlias + `.session_id = ` +
+		sessionAlias + `.id AND ` + predicate + `)`
+}
+
+func latestDisplayContentLengthSubquery(
+	sessionAlias, messageAlias, predicate string,
+) string {
+	return `(SELECT ` + messageAlias + `.content_length FROM messages ` +
+		messageAlias + ` WHERE ` + messageAlias + `.session_id = ` +
+		sessionAlias + `.id AND ` + predicate +
+		` ORDER BY ` + messageAlias + `.ordinal DESC LIMIT 1)`
+}
+
 func displayMessageSQL(alias string, dialect systemPrefixSQLDialect) string {
 	booleanTrue, booleanFalse := "1", "0"
 	contentCol, roleCol := alias+".content", alias+".role"

--- a/internal/db/search.go
+++ b/internal/db/search.go
@@ -190,7 +190,14 @@ func latestDisplayOrdinalSubquery(
 func latestDisplayContentLengthSubquery(
 	sessionAlias, messageAlias, predicate string,
 ) string {
-	return `(SELECT ` + messageAlias + `.content_length FROM messages ` +
+	return `(SELECT COALESCE(` + messageAlias + `.content_length, 0) +
+		COALESCE((SELECT SUM(tc.result_content_length) FROM tool_calls tc` +
+		` WHERE tc.session_id = ` + messageAlias + `.session_id` +
+		` AND tc.message_id = ` + messageAlias + `.id), 0) +
+		COALESCE((SELECT SUM(tre.content_length) FROM tool_result_events tre` +
+		` WHERE tre.session_id = ` + messageAlias + `.session_id` +
+		` AND tre.tool_call_message_ordinal = ` + messageAlias + `.ordinal), 0)` +
+		` FROM messages ` +
 		messageAlias + ` WHERE ` + messageAlias + `.session_id = ` +
 		sessionAlias + `.id AND ` + predicate +
 		` ORDER BY ` + messageAlias + `.ordinal DESC LIMIT 1)`

--- a/internal/db/search.go
+++ b/internal/db/search.go
@@ -156,6 +156,7 @@ func LatestDisplayContentLengthSubquery(
 		sessionAlias,
 		messageAlias,
 		DisplayMessageSQL(messageAlias),
+		"tc.message_id = "+messageAlias+".id",
 	)
 }
 
@@ -166,6 +167,7 @@ func PostgresLatestDisplayContentLengthSubquery(
 		sessionAlias,
 		messageAlias,
 		PostgresDisplayMessageSQL(messageAlias),
+		"tc.message_ordinal = "+messageAlias+".ordinal",
 	)
 }
 
@@ -176,6 +178,7 @@ func DuckDBLatestDisplayContentLengthSubquery(
 		sessionAlias,
 		messageAlias,
 		DuckDBDisplayMessageSQL(messageAlias),
+		"tc.message_id = "+messageAlias+".id",
 	)
 }
 
@@ -188,12 +191,12 @@ func latestDisplayOrdinalSubquery(
 }
 
 func latestDisplayContentLengthSubquery(
-	sessionAlias, messageAlias, predicate string,
+	sessionAlias, messageAlias, predicate, toolCallPredicate string,
 ) string {
 	return `(SELECT COALESCE(` + messageAlias + `.content_length, 0) +
 		COALESCE((SELECT SUM(tc.result_content_length) FROM tool_calls tc` +
 		` WHERE tc.session_id = ` + messageAlias + `.session_id` +
-		` AND tc.message_id = ` + messageAlias + `.id), 0) +
+		` AND ` + toolCallPredicate + `), 0) +
 		COALESCE((SELECT SUM(tre.content_length) FROM tool_result_events tre` +
 		` WHERE tre.session_id = ` + messageAlias + `.session_id` +
 		` AND tre.tool_call_message_ordinal = ` + messageAlias + `.ordinal), 0)` +

--- a/internal/db/search.go
+++ b/internal/db/search.go
@@ -30,6 +30,27 @@ var SystemMsgPrefixes = []string{
 	"Stop hook feedback:",
 }
 
+var visibleSystemSubtypes = []string{
+	"continuation",
+	"resume",
+	"interrupted",
+	"task_notification",
+	"stop_hook",
+}
+
+// IsDisplayMessage reports whether a message belongs in the transcript.
+func IsDisplayMessage(m Message) bool {
+	if m.IsCompactBoundary {
+		return true
+	}
+	for _, subtype := range visibleSystemSubtypes {
+		if m.SourceSubtype == subtype {
+			return true
+		}
+	}
+	return !m.IsSystem && !IsSystemPrefixed(m.Content, m.Role)
+}
+
 const (
 	legacyGoalContextPrefix        = "<goal_context>"
 	codexInternalContextTagPrefix  = "<codex_internal_context"
@@ -82,6 +103,32 @@ func PostgresSystemPrefixSQL(contentCol, roleCol string) string {
 // DuckDBSystemPrefixSQL is the DuckDB form of SystemPrefixSQL.
 func DuckDBSystemPrefixSQL(contentCol, roleCol string) string {
 	return systemPrefixSQL(contentCol, roleCol, systemPrefixDuckDB)
+}
+
+// DisplayMessageSQL returns the SQLite transcript-visibility predicate.
+func DisplayMessageSQL(alias string) string {
+	return displayMessageSQL(alias, systemPrefixSQLite)
+}
+
+// PostgresDisplayMessageSQL returns the PostgreSQL transcript-visibility predicate.
+func PostgresDisplayMessageSQL(alias string) string {
+	return displayMessageSQL(alias, systemPrefixPostgres)
+}
+
+func displayMessageSQL(alias string, dialect systemPrefixSQLDialect) string {
+	booleanTrue, booleanFalse := "1", "0"
+	prefix := SystemPrefixSQL(alias+".content", alias+".role")
+	if dialect == systemPrefixPostgres {
+		booleanTrue, booleanFalse = "TRUE", "FALSE"
+		prefix = PostgresSystemPrefixSQL(alias+".content", alias+".role")
+	}
+	quoted := make([]string, len(visibleSystemSubtypes))
+	for i, subtype := range visibleSystemSubtypes {
+		quoted[i] = "'" + subtype + "'"
+	}
+	return "(" + alias + ".is_compact_boundary = " + booleanTrue +
+		" OR " + alias + ".source_subtype IN (" + strings.Join(quoted, ", ") + ")" +
+		" OR (" + alias + ".is_system = " + booleanFalse + " AND " + prefix + "))"
 }
 
 func systemPrefixSQL(

--- a/internal/db/search.go
+++ b/internal/db/search.go
@@ -121,10 +121,15 @@ func DuckDBDisplayMessageSQL(alias string) string {
 
 func displayMessageSQL(alias string, dialect systemPrefixSQLDialect) string {
 	booleanTrue, booleanFalse := "1", "0"
-	prefix := SystemPrefixSQL(alias+".content", alias+".role")
-	if dialect == systemPrefixPostgres {
+	contentCol, roleCol := alias+".content", alias+".role"
+	prefix := SystemPrefixSQL(contentCol, roleCol)
+	switch dialect {
+	case systemPrefixPostgres:
 		booleanTrue, booleanFalse = "TRUE", "FALSE"
-		prefix = PostgresSystemPrefixSQL(alias+".content", alias+".role")
+		prefix = PostgresSystemPrefixSQL(contentCol, roleCol)
+	case systemPrefixDuckDB:
+		booleanTrue, booleanFalse = "TRUE", "FALSE"
+		prefix = DuckDBSystemPrefixSQL(contentCol, roleCol)
 	}
 	quoted := make([]string, len(visibleSystemSubtypes))
 	for i, subtype := range visibleSystemSubtypes {

--- a/internal/db/search_test.go
+++ b/internal/db/search_test.go
@@ -107,6 +107,28 @@ source="goal">state'),
 	}, got)
 }
 
+func TestDisplayMessageSQLDialectForms(t *testing.T) {
+	t.Parallel()
+
+	sqlite := DisplayMessageSQL("m")
+	assert.Contains(t, sqlite, "m.is_compact_boundary = 1")
+	assert.Contains(t, sqlite, "m.is_system = 0")
+	assert.Contains(t, sqlite, SystemPrefixSQL("m.content", "m.role"))
+	assert.Contains(t, sqlite, "unicode(m.content)")
+
+	postgres := PostgresDisplayMessageSQL("m")
+	assert.Contains(t, postgres, "m.is_compact_boundary = TRUE")
+	assert.Contains(t, postgres, "m.is_system = FALSE")
+	assert.Contains(t, postgres, PostgresSystemPrefixSQL("m.content", "m.role"))
+	assert.NotContains(t, postgres, "unicode(m.content)")
+
+	duckdb := DuckDBDisplayMessageSQL("m")
+	assert.Contains(t, duckdb, "m.is_compact_boundary = TRUE")
+	assert.Contains(t, duckdb, "m.is_system = FALSE")
+	assert.Contains(t, duckdb, DuckDBSystemPrefixSQL("m.content", "m.role"))
+	assert.NotContains(t, duckdb, "unicode(m.content)")
+}
+
 func TestSearch(t *testing.T) {
 	d := testDB(t)
 	requireFTS(t, d)

--- a/internal/db/search_test.go
+++ b/internal/db/search_test.go
@@ -129,6 +129,20 @@ func TestDisplayMessageSQLDialectForms(t *testing.T) {
 	assert.NotContains(t, duckdb, "unicode(m.content)")
 }
 
+func TestLatestDisplayContentLengthSubqueryUsesDialectToolCallLineage(t *testing.T) {
+	sqlite := LatestDisplayContentLengthSubquery("s", "m")
+	assert.Contains(t, sqlite, "tc.message_id = m.id")
+	assert.NotContains(t, sqlite, "tc.message_ordinal = m.ordinal")
+
+	postgres := PostgresLatestDisplayContentLengthSubquery("s", "m")
+	assert.Contains(t, postgres, "tc.message_ordinal = m.ordinal")
+	assert.NotContains(t, postgres, "tc.message_id = m.id")
+
+	duckdb := DuckDBLatestDisplayContentLengthSubquery("s", "m")
+	assert.Contains(t, duckdb, "tc.message_id = m.id")
+	assert.NotContains(t, duckdb, "tc.message_ordinal = m.ordinal")
+}
+
 func TestSearch(t *testing.T) {
 	d := testDB(t)
 	requireFTS(t, d)

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -58,9 +58,10 @@ const sessionStorageCols = `id, project, machine, agent,
 	deleted_at, termination_status, created_at`
 
 var sessionAPICols = sessionStorageCols + `,
-	(SELECT MAX(m.ordinal) FROM messages m
-	 WHERE m.session_id = sessions.id AND ` + DisplayMessageSQL("m") + `)
-	 AS latest_display_ordinal`
+	` + LatestDisplayOrdinalSubquery("sessions", "m") + `
+	 AS latest_display_ordinal,
+	` + LatestDisplayContentLengthSubquery("sessions", "m") + `
+	 AS latest_display_content_length`
 
 // sessionPruneCols is the storage projection used by prune reads
 // needed by FindPruneCandidates.
@@ -140,7 +141,12 @@ type rowScanner interface {
 
 func scanSessionAPIRow(rs rowScanner) (Session, error) {
 	var s Session
-	err := scanSessionFields(rs, &s, &s.LatestDisplayOrdinal)
+	err := scanSessionFields(
+		rs,
+		&s,
+		&s.LatestDisplayOrdinal,
+		&s.LatestDisplayContentLength,
+	)
 	return s, err
 }
 
@@ -272,25 +278,26 @@ func (s *Session) UnmarshalJSON(data []byte) error {
 
 // Session represents a row in the sessions table.
 type Session struct {
-	ID                   string  `json:"id"`
-	Project              string  `json:"project"`
-	Machine              string  `json:"machine"`
-	Agent                string  `json:"agent"`
-	FirstMessage         *string `json:"first_message"`
-	DisplayName          *string `json:"display_name,omitempty"`
-	SessionName          *string `json:"-"`
-	StartedAt            *string `json:"started_at"`
-	EndedAt              *string `json:"ended_at"`
-	MessageCount         int     `json:"message_count"`
-	LatestDisplayOrdinal *int    `json:"latest_display_ordinal"`
-	UserMessageCount     int     `json:"user_message_count"`
-	ParentSessionID      *string `json:"parent_session_id,omitempty"`
-	RelationshipType     string  `json:"relationship_type,omitempty"`
-	TotalOutputTokens    int     `json:"total_output_tokens"`
-	PeakContextTokens    int     `json:"peak_context_tokens"`
-	HasTotalOutputTokens bool    `json:"has_total_output_tokens"`
-	HasPeakContextTokens bool    `json:"has_peak_context_tokens"`
-	IsAutomated          bool    `json:"is_automated"`
+	ID                         string  `json:"id"`
+	Project                    string  `json:"project"`
+	Machine                    string  `json:"machine"`
+	Agent                      string  `json:"agent"`
+	FirstMessage               *string `json:"first_message"`
+	DisplayName                *string `json:"display_name,omitempty"`
+	SessionName                *string `json:"-"`
+	StartedAt                  *string `json:"started_at"`
+	EndedAt                    *string `json:"ended_at"`
+	MessageCount               int     `json:"message_count"`
+	LatestDisplayOrdinal       *int    `json:"latest_display_ordinal"`
+	LatestDisplayContentLength *int    `json:"latest_display_content_length"`
+	UserMessageCount           int     `json:"user_message_count"`
+	ParentSessionID            *string `json:"parent_session_id,omitempty"`
+	RelationshipType           string  `json:"relationship_type,omitempty"`
+	TotalOutputTokens          int     `json:"total_output_tokens"`
+	PeakContextTokens          int     `json:"peak_context_tokens"`
+	HasTotalOutputTokens       bool    `json:"has_total_output_tokens"`
+	HasPeakContextTokens       bool    `json:"has_peak_context_tokens"`
+	IsAutomated                bool    `json:"is_automated"`
 
 	// Session signals (computed from messages/tool_calls).
 	ToolFailureSignalCount int      `json:"tool_failure_signal_count"`
@@ -593,22 +600,23 @@ type SessionPage struct {
 }
 
 type SidebarSessionIndexRow struct {
-	ID                   string  `json:"id"`
-	ParentSessionID      *string `json:"parent_session_id,omitempty"`
-	RelationshipType     string  `json:"relationship_type,omitempty"`
-	Project              string  `json:"project"`
-	Machine              string  `json:"machine"`
-	Agent                string  `json:"agent"`
-	DisplayName          *string `json:"display_name,omitempty"`
-	StartedAt            *string `json:"started_at"`
-	EndedAt              *string `json:"ended_at"`
-	CreatedAt            string  `json:"created_at"`
-	TerminationStatus    *string `json:"termination_status,omitempty"`
-	MessageCount         int     `json:"message_count"`
-	LatestDisplayOrdinal *int    `json:"latest_display_ordinal"`
-	UserMessageCount     int     `json:"user_message_count"`
-	IsAutomated          bool    `json:"is_automated"`
-	IsTeammate           bool    `json:"is_teammate"`
+	ID                         string  `json:"id"`
+	ParentSessionID            *string `json:"parent_session_id,omitempty"`
+	RelationshipType           string  `json:"relationship_type,omitempty"`
+	Project                    string  `json:"project"`
+	Machine                    string  `json:"machine"`
+	Agent                      string  `json:"agent"`
+	DisplayName                *string `json:"display_name,omitempty"`
+	StartedAt                  *string `json:"started_at"`
+	EndedAt                    *string `json:"ended_at"`
+	CreatedAt                  string  `json:"created_at"`
+	TerminationStatus          *string `json:"termination_status,omitempty"`
+	MessageCount               int     `json:"message_count"`
+	LatestDisplayOrdinal       *int    `json:"latest_display_ordinal"`
+	LatestDisplayContentLength *int    `json:"latest_display_content_length"`
+	UserMessageCount           int     `json:"user_message_count"`
+	IsAutomated                bool    `json:"is_automated"`
+	IsTeammate                 bool    `json:"is_teammate"`
 }
 
 type SidebarSessionIndex struct {
@@ -735,8 +743,8 @@ func (db *DB) GetSidebarSessionIndex(
 			user_message_count,
 			is_automated,
 			INSTR(COALESCE(first_message, ''), '<teammate-message') > 0,
-			(SELECT MAX(m.ordinal) FROM messages m
-			 WHERE m.session_id = sessions.id AND ` + DisplayMessageSQL("m") + `)
+			` + LatestDisplayOrdinalSubquery("sessions", "m") + `,
+			` + LatestDisplayContentLengthSubquery("sessions", "m") + `
 		FROM sessions
 		WHERE ` + where + `
 		ORDER BY COALESCE(
@@ -774,6 +782,7 @@ func (db *DB) GetSidebarSessionIndex(
 			&row.IsAutomated,
 			&row.IsTeammate,
 			&row.LatestDisplayOrdinal,
+			&row.LatestDisplayContentLength,
 		); err != nil {
 			return SidebarSessionIndex{},
 				fmt.Errorf("scanning sidebar session index: %w", err)
@@ -988,8 +997,8 @@ func (db *DB) getSidebarSessionIndexPage(
 			s.user_message_count,
 			s.is_automated,
 			INSTR(COALESCE(s.first_message, ''), '<teammate-message') > 0,
-			(SELECT MAX(m.ordinal) FROM messages m
-			 WHERE m.session_id = s.id AND ` + DisplayMessageSQL("m") + `)
+			` + LatestDisplayOrdinalSubquery("s", "m") + `,
+			` + LatestDisplayContentLengthSubquery("s", "m") + `
 		FROM sessions s
 		JOIN ranked_tree t ON s.id = t.id
 		ORDER BY
@@ -1023,6 +1032,7 @@ func (db *DB) getSidebarSessionIndexPage(
 			&row.IsAutomated,
 			&row.IsTeammate,
 			&row.LatestDisplayOrdinal,
+			&row.LatestDisplayContentLength,
 		); err != nil {
 			return SidebarSessionIndex{},
 				fmt.Errorf("scanning sidebar tree page: %w", err)

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -28,9 +28,8 @@ var ErrSessionExcluded = errors.New("session excluded")
 // should surface a conflict instead of silently overwriting it.
 var ErrSessionTrashed = errors.New("session trashed")
 
-// sessionBaseCols is the column list for standard session queries
-// (list, get). Keep in sync with scanSessionRow.
-const sessionBaseCols = `id, project, machine, agent,
+// sessionStorageCols is the persisted projection for session reads.
+const sessionStorageCols = `id, project, machine, agent,
 	first_message, COALESCE(display_name, session_name) AS display_name, started_at, ended_at,
 	message_count, user_message_count,
 	parent_session_id, relationship_type,
@@ -58,7 +57,12 @@ const sessionBaseCols = `id, project, machine, agent,
 	parser_malformed_lines, is_truncated,
 	deleted_at, termination_status, created_at`
 
-// sessionPruneCols extends sessionBaseCols with file metadata
+var sessionAPICols = sessionStorageCols + `,
+	(SELECT MAX(m.ordinal) FROM messages m
+	 WHERE m.session_id = sessions.id AND ` + DisplayMessageSQL("m") + `)
+	 AS latest_display_ordinal`
+
+// sessionPruneCols is the storage projection used by prune reads
 // needed by FindPruneCandidates.
 const sessionPruneCols = `id, project, machine, agent,
 	first_message, COALESCE(display_name, session_name) AS display_name, started_at, ended_at,
@@ -134,10 +138,21 @@ type rowScanner interface {
 	Scan(dest ...any) error
 }
 
-// scanSessionRow scans sessionBaseCols into a Session.
-func scanSessionRow(rs rowScanner) (Session, error) {
+// scanSessionStorageRow scans sessionStorageCols into a Session.
+func scanSessionStorageRow(rs rowScanner) (Session, error) {
 	var s Session
-	err := rs.Scan(
+	err := scanSessionFields(rs, &s)
+	return s, err
+}
+
+func scanSessionAPIRow(rs rowScanner) (Session, error) {
+	var s Session
+	err := scanSessionFields(rs, &s, &s.LatestDisplayOrdinal)
+	return s, err
+}
+
+func scanSessionFields(rs rowScanner, s *Session, extra ...any) error {
+	dest := []any{
 		&s.ID, &s.Project, &s.Machine, &s.Agent,
 		&s.FirstMessage, &s.DisplayName, &s.StartedAt, &s.EndedAt,
 		&s.MessageCount, &s.UserMessageCount,
@@ -166,8 +181,8 @@ func scanSessionRow(rs rowScanner) (Session, error) {
 		&s.TranscriptFidelity,
 		&s.ParserMalformedLines, &s.IsTruncated,
 		&s.DeletedAt, &s.TerminationStatus, &s.CreatedAt,
-	)
-	return s, err
+	}
+	return rs.Scan(append(dest, extra...)...)
 }
 
 const CurrentQualitySignalVersion = 2
@@ -274,6 +289,7 @@ type Session struct {
 	StartedAt            *string `json:"started_at"`
 	EndedAt              *string `json:"ended_at"`
 	MessageCount         int     `json:"message_count"`
+	LatestDisplayOrdinal *int    `json:"latest_display_ordinal"`
 	UserMessageCount     int     `json:"user_message_count"`
 	ParentSessionID      *string `json:"parent_session_id,omitempty"`
 	RelationshipType     string  `json:"relationship_type,omitempty"`
@@ -584,21 +600,22 @@ type SessionPage struct {
 }
 
 type SidebarSessionIndexRow struct {
-	ID                string  `json:"id"`
-	ParentSessionID   *string `json:"parent_session_id,omitempty"`
-	RelationshipType  string  `json:"relationship_type,omitempty"`
-	Project           string  `json:"project"`
-	Machine           string  `json:"machine"`
-	Agent             string  `json:"agent"`
-	DisplayName       *string `json:"display_name,omitempty"`
-	StartedAt         *string `json:"started_at"`
-	EndedAt           *string `json:"ended_at"`
-	CreatedAt         string  `json:"created_at"`
-	TerminationStatus *string `json:"termination_status,omitempty"`
-	MessageCount      int     `json:"message_count"`
-	UserMessageCount  int     `json:"user_message_count"`
-	IsAutomated       bool    `json:"is_automated"`
-	IsTeammate        bool    `json:"is_teammate"`
+	ID                   string  `json:"id"`
+	ParentSessionID      *string `json:"parent_session_id,omitempty"`
+	RelationshipType     string  `json:"relationship_type,omitempty"`
+	Project              string  `json:"project"`
+	Machine              string  `json:"machine"`
+	Agent                string  `json:"agent"`
+	DisplayName          *string `json:"display_name,omitempty"`
+	StartedAt            *string `json:"started_at"`
+	EndedAt              *string `json:"ended_at"`
+	CreatedAt            string  `json:"created_at"`
+	TerminationStatus    *string `json:"termination_status,omitempty"`
+	MessageCount         int     `json:"message_count"`
+	LatestDisplayOrdinal *int    `json:"latest_display_ordinal"`
+	UserMessageCount     int     `json:"user_message_count"`
+	IsAutomated          bool    `json:"is_automated"`
+	IsTeammate           bool    `json:"is_teammate"`
 }
 
 type SidebarSessionIndex struct {
@@ -663,7 +680,7 @@ func (db *DB) ListSessions(
 		)
 	}
 
-	query := "SELECT " + sessionBaseCols +
+	query := "SELECT " + sessionAPICols +
 		" FROM sessions WHERE " + cursorWhere + " " +
 		pageBuilder.OrderByClause(rs, f) + " " +
 		pageBuilder.Limit(f.Limit+1)
@@ -676,7 +693,7 @@ func (db *DB) ListSessions(
 	}
 	defer rows.Close()
 
-	sessions, err := scanSessionRows(rows)
+	sessions, err := scanSessionAPIRows(rows)
 	if err != nil {
 		return SessionPage{}, err
 	}
@@ -724,7 +741,9 @@ func (db *DB) GetSidebarSessionIndex(
 			message_count,
 			user_message_count,
 			is_automated,
-			INSTR(COALESCE(first_message, ''), '<teammate-message') > 0
+			INSTR(COALESCE(first_message, ''), '<teammate-message') > 0,
+			(SELECT MAX(m.ordinal) FROM messages m
+			 WHERE m.session_id = sessions.id AND ` + DisplayMessageSQL("m") + `)
 		FROM sessions
 		WHERE ` + where + `
 		ORDER BY COALESCE(
@@ -761,6 +780,7 @@ func (db *DB) GetSidebarSessionIndex(
 			&row.UserMessageCount,
 			&row.IsAutomated,
 			&row.IsTeammate,
+			&row.LatestDisplayOrdinal,
 		); err != nil {
 			return SidebarSessionIndex{},
 				fmt.Errorf("scanning sidebar session index: %w", err)
@@ -974,7 +994,9 @@ func (db *DB) getSidebarSessionIndexPage(
 			s.message_count,
 			s.user_message_count,
 			s.is_automated,
-			INSTR(COALESCE(s.first_message, ''), '<teammate-message') > 0
+			INSTR(COALESCE(s.first_message, ''), '<teammate-message') > 0,
+			(SELECT MAX(m.ordinal) FROM messages m
+			 WHERE m.session_id = s.id AND ` + DisplayMessageSQL("m") + `)
 		FROM sessions s
 		JOIN ranked_tree t ON s.id = t.id
 		ORDER BY
@@ -1007,6 +1029,7 @@ func (db *DB) getSidebarSessionIndexPage(
 			&row.UserMessageCount,
 			&row.IsAutomated,
 			&row.IsTeammate,
+			&row.LatestDisplayOrdinal,
 		); err != nil {
 			return SidebarSessionIndex{},
 				fmt.Errorf("scanning sidebar tree page: %w", err)
@@ -1028,11 +1051,11 @@ func (db *DB) GetSession(
 ) (*Session, error) {
 	row := db.getReader().QueryRowContext(
 		ctx,
-		"SELECT "+sessionBaseCols+" FROM sessions WHERE id = ? AND deleted_at IS NULL",
+		"SELECT "+sessionAPICols+" FROM sessions WHERE id = ? AND deleted_at IS NULL",
 		id,
 	)
 
-	s, err := scanSessionRow(row)
+	s, err := scanSessionAPIRow(row)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -1406,7 +1429,7 @@ func (db *DB) insertSessionIfAbsent(ctx context.Context, s Session) error {
 func (db *DB) GetChildSessions(
 	ctx context.Context, parentID string,
 ) ([]Session, error) {
-	query := "SELECT " + sessionBaseCols +
+	query := "SELECT " + sessionAPICols +
 		" FROM sessions WHERE parent_session_id = ?" +
 		" AND deleted_at IS NULL" +
 		" ORDER BY started_at"
@@ -1418,7 +1441,7 @@ func (db *DB) GetChildSessions(
 	}
 	defer rows.Close()
 
-	return scanSessionRows(rows)
+	return scanSessionAPIRows(rows)
 }
 
 // LinkSubagentSessions sets parent_session_id and
@@ -2614,12 +2637,11 @@ func (db *DB) GetBranches(
 	return branches, rows.Err()
 }
 
-// scanSessionRows iterates rows and scans each using
-// scanSessionRow.
-func scanSessionRows(rows *sql.Rows) ([]Session, error) {
+// scanSessionAPIRows scans the public session projection.
+func scanSessionAPIRows(rows *sql.Rows) ([]Session, error) {
 	sessions := []Session{}
 	for rows.Next() {
-		s, err := scanSessionRow(rows)
+		s, err := scanSessionAPIRow(rows)
 		if err != nil {
 			return nil, fmt.Errorf("scanning session: %w", err)
 		}
@@ -2844,7 +2866,7 @@ func (db *DB) RenameSession(id string, displayName *string) error {
 func (db *DB) ListTrashedSessions(
 	ctx context.Context,
 ) ([]Session, error) {
-	query := "SELECT " + sessionBaseCols +
+	query := "SELECT " + sessionAPICols +
 		" FROM sessions WHERE deleted_at IS NOT NULL" +
 		" ORDER BY deleted_at DESC LIMIT 500"
 	rows, err := db.getReader().QueryContext(ctx, query)
@@ -2852,7 +2874,7 @@ func (db *DB) ListTrashedSessions(
 		return nil, fmt.Errorf("querying trashed sessions: %w", err)
 	}
 	defer rows.Close()
-	return scanSessionRows(rows)
+	return scanSessionAPIRows(rows)
 }
 
 // EmptyTrash permanently deletes all soft-deleted sessions.

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -138,13 +138,6 @@ type rowScanner interface {
 	Scan(dest ...any) error
 }
 
-// scanSessionStorageRow scans sessionStorageCols into a Session.
-func scanSessionStorageRow(rs rowScanner) (Session, error) {
-	var s Session
-	err := scanSessionFields(rs, &s)
-	return s, err
-}
-
 func scanSessionAPIRow(rs rowScanner) (Session, error) {
 	var s Session
 	err := scanSessionFields(rs, &s, &s.LatestDisplayOrdinal)

--- a/internal/db/sessions_test.go
+++ b/internal/db/sessions_test.go
@@ -75,8 +75,8 @@ func TestSessionAPILatestDisplayOrdinal(t *testing.T) {
 	insertMessages(t, d,
 		userMsg("display-cursor", 1, "visible"),
 		Message{SessionID: "display-cursor", Ordinal: 3, Role: "user", Content: "hidden", IsSystem: true},
-		Message{SessionID: "display-cursor", Ordinal: 5, Role: "system", Content: "compact", IsSystem: true, IsCompactBoundary: true},
-		Message{SessionID: "display-cursor", Ordinal: 7, Role: "system", Content: "continued", IsSystem: true, SourceSubtype: "continuation"},
+		Message{SessionID: "display-cursor", Ordinal: 5, Role: "system", Content: "compact", ContentLength: 7, IsSystem: true, IsCompactBoundary: true},
+		Message{SessionID: "display-cursor", Ordinal: 7, Role: "system", Content: "continued here", ContentLength: 14, IsSystem: true, SourceSubtype: "continuation"},
 		userMsg("display-cursor", 9, "This session is being continued by metadata"),
 		Message{SessionID: "hidden-only", Ordinal: 4, Role: "user", Content: "hidden", IsSystem: true},
 	)
@@ -86,6 +86,8 @@ func TestSessionAPILatestDisplayOrdinal(t *testing.T) {
 	require.NotNil(t, session)
 	require.NotNil(t, session.LatestDisplayOrdinal)
 	assert.Equal(t, 7, *session.LatestDisplayOrdinal)
+	require.NotNil(t, session.LatestDisplayContentLength)
+	assert.Equal(t, 14, *session.LatestDisplayContentLength)
 
 	page, err := d.ListSessions(ctx, SessionFilter{Limit: 10, IncludeChildren: true})
 	require.NoError(t, err)
@@ -95,7 +97,10 @@ func TestSessionAPILatestDisplayOrdinal(t *testing.T) {
 	}
 	require.NotNil(t, byID["display-cursor"].LatestDisplayOrdinal)
 	assert.Equal(t, 7, *byID["display-cursor"].LatestDisplayOrdinal)
+	require.NotNil(t, byID["display-cursor"].LatestDisplayContentLength)
+	assert.Equal(t, 14, *byID["display-cursor"].LatestDisplayContentLength)
 	assert.Nil(t, byID["hidden-only"].LatestDisplayOrdinal)
+	assert.Nil(t, byID["hidden-only"].LatestDisplayContentLength)
 
 	index, err := d.GetSidebarSessionIndex(ctx, SessionFilter{})
 	require.NoError(t, err)
@@ -108,6 +113,8 @@ func TestSessionAPILatestDisplayOrdinal(t *testing.T) {
 	require.NotNil(t, sidebar)
 	require.NotNil(t, sidebar.LatestDisplayOrdinal)
 	assert.Equal(t, 7, *sidebar.LatestDisplayOrdinal)
+	require.NotNil(t, sidebar.LatestDisplayContentLength)
+	assert.Equal(t, 14, *sidebar.LatestDisplayContentLength)
 
 	require.NoError(t, d.SoftDeleteSession("display-cursor"))
 	trashed, err := d.ListTrashedSessions(ctx)
@@ -115,6 +122,8 @@ func TestSessionAPILatestDisplayOrdinal(t *testing.T) {
 	require.Len(t, trashed, 1)
 	require.NotNil(t, trashed[0].LatestDisplayOrdinal)
 	assert.Equal(t, 7, *trashed[0].LatestDisplayOrdinal)
+	require.NotNil(t, trashed[0].LatestDisplayContentLength)
+	assert.Equal(t, 14, *trashed[0].LatestDisplayContentLength)
 }
 
 func TestIsDisplayMessage(t *testing.T) {

--- a/internal/db/sessions_test.go
+++ b/internal/db/sessions_test.go
@@ -76,7 +76,10 @@ func TestSessionAPILatestDisplayOrdinal(t *testing.T) {
 		userMsg("display-cursor", 1, "visible"),
 		Message{SessionID: "display-cursor", Ordinal: 3, Role: "user", Content: "hidden", IsSystem: true},
 		Message{SessionID: "display-cursor", Ordinal: 5, Role: "system", Content: "compact", ContentLength: 7, IsSystem: true, IsCompactBoundary: true},
-		Message{SessionID: "display-cursor", Ordinal: 7, Role: "system", Content: "continued here", ContentLength: 14, IsSystem: true, SourceSubtype: "continuation"},
+		Message{SessionID: "display-cursor", Ordinal: 7, Role: "system", Content: "continued here", ContentLength: 14, IsSystem: true, SourceSubtype: "continuation", HasToolUse: true, ToolCalls: []ToolCall{{
+			ToolName: "Bash", ResultContentLength: 5, ResultContent: "legacy",
+			ResultEvents: []ToolResultEvent{{Content: "event!!", ContentLength: 7}},
+		}}},
 		userMsg("display-cursor", 9, "This session is being continued by metadata"),
 		Message{SessionID: "hidden-only", Ordinal: 4, Role: "user", Content: "hidden", IsSystem: true},
 	)
@@ -87,7 +90,7 @@ func TestSessionAPILatestDisplayOrdinal(t *testing.T) {
 	require.NotNil(t, session.LatestDisplayOrdinal)
 	assert.Equal(t, 7, *session.LatestDisplayOrdinal)
 	require.NotNil(t, session.LatestDisplayContentLength)
-	assert.Equal(t, 14, *session.LatestDisplayContentLength)
+	assert.Equal(t, 26, *session.LatestDisplayContentLength)
 
 	page, err := d.ListSessions(ctx, SessionFilter{Limit: 10, IncludeChildren: true})
 	require.NoError(t, err)
@@ -98,7 +101,7 @@ func TestSessionAPILatestDisplayOrdinal(t *testing.T) {
 	require.NotNil(t, byID["display-cursor"].LatestDisplayOrdinal)
 	assert.Equal(t, 7, *byID["display-cursor"].LatestDisplayOrdinal)
 	require.NotNil(t, byID["display-cursor"].LatestDisplayContentLength)
-	assert.Equal(t, 14, *byID["display-cursor"].LatestDisplayContentLength)
+	assert.Equal(t, 26, *byID["display-cursor"].LatestDisplayContentLength)
 	assert.Nil(t, byID["hidden-only"].LatestDisplayOrdinal)
 	assert.Nil(t, byID["hidden-only"].LatestDisplayContentLength)
 
@@ -114,7 +117,7 @@ func TestSessionAPILatestDisplayOrdinal(t *testing.T) {
 	require.NotNil(t, sidebar.LatestDisplayOrdinal)
 	assert.Equal(t, 7, *sidebar.LatestDisplayOrdinal)
 	require.NotNil(t, sidebar.LatestDisplayContentLength)
-	assert.Equal(t, 14, *sidebar.LatestDisplayContentLength)
+	assert.Equal(t, 26, *sidebar.LatestDisplayContentLength)
 
 	require.NoError(t, d.SoftDeleteSession("display-cursor"))
 	trashed, err := d.ListTrashedSessions(ctx)
@@ -123,7 +126,7 @@ func TestSessionAPILatestDisplayOrdinal(t *testing.T) {
 	require.NotNil(t, trashed[0].LatestDisplayOrdinal)
 	assert.Equal(t, 7, *trashed[0].LatestDisplayOrdinal)
 	require.NotNil(t, trashed[0].LatestDisplayContentLength)
-	assert.Equal(t, 14, *trashed[0].LatestDisplayContentLength)
+	assert.Equal(t, 26, *trashed[0].LatestDisplayContentLength)
 }
 
 func TestIsDisplayMessage(t *testing.T) {

--- a/internal/db/sessions_test.go
+++ b/internal/db/sessions_test.go
@@ -63,6 +63,79 @@ func TestFindSessionIDsByPartial(t *testing.T) {
 	assert.Nil(t, got, "empty input")
 }
 
+func TestSessionAPILatestDisplayOrdinal(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	for _, id := range []string{"display-cursor", "hidden-only"} {
+		insertSession(t, d, id, "proj", func(s *Session) {
+			s.MessageCount = 5
+			s.UserMessageCount = 1
+		})
+	}
+	insertMessages(t, d,
+		userMsg("display-cursor", 1, "visible"),
+		Message{SessionID: "display-cursor", Ordinal: 3, Role: "user", Content: "hidden", IsSystem: true},
+		Message{SessionID: "display-cursor", Ordinal: 5, Role: "system", Content: "compact", IsSystem: true, IsCompactBoundary: true},
+		Message{SessionID: "display-cursor", Ordinal: 7, Role: "system", Content: "continued", IsSystem: true, SourceSubtype: "continuation"},
+		userMsg("display-cursor", 9, "This session is being continued by metadata"),
+		Message{SessionID: "hidden-only", Ordinal: 4, Role: "user", Content: "hidden", IsSystem: true},
+	)
+
+	session, err := d.GetSession(ctx, "display-cursor")
+	require.NoError(t, err)
+	require.NotNil(t, session)
+	require.NotNil(t, session.LatestDisplayOrdinal)
+	assert.Equal(t, 7, *session.LatestDisplayOrdinal)
+
+	page, err := d.ListSessions(ctx, SessionFilter{Limit: 10, IncludeChildren: true})
+	require.NoError(t, err)
+	byID := make(map[string]Session, len(page.Sessions))
+	for _, row := range page.Sessions {
+		byID[row.ID] = row
+	}
+	require.NotNil(t, byID["display-cursor"].LatestDisplayOrdinal)
+	assert.Equal(t, 7, *byID["display-cursor"].LatestDisplayOrdinal)
+	assert.Nil(t, byID["hidden-only"].LatestDisplayOrdinal)
+
+	index, err := d.GetSidebarSessionIndex(ctx, SessionFilter{})
+	require.NoError(t, err)
+	var sidebar *SidebarSessionIndexRow
+	for i := range index.Sessions {
+		if index.Sessions[i].ID == "display-cursor" {
+			sidebar = &index.Sessions[i]
+		}
+	}
+	require.NotNil(t, sidebar)
+	require.NotNil(t, sidebar.LatestDisplayOrdinal)
+	assert.Equal(t, 7, *sidebar.LatestDisplayOrdinal)
+
+	require.NoError(t, d.SoftDeleteSession("display-cursor"))
+	trashed, err := d.ListTrashedSessions(ctx)
+	require.NoError(t, err)
+	require.Len(t, trashed, 1)
+	require.NotNil(t, trashed[0].LatestDisplayOrdinal)
+	assert.Equal(t, 7, *trashed[0].LatestDisplayOrdinal)
+}
+
+func TestIsDisplayMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  Message
+		want bool
+	}{
+		{"ordinary", userMsg("s", 0, "hello"), true},
+		{"system", Message{IsSystem: true}, false},
+		{"compact", Message{IsSystem: true, IsCompactBoundary: true}, true},
+		{"promoted", Message{IsSystem: true, SourceSubtype: "stop_hook"}, true},
+		{"legacy prefix", userMsg("s", 0, "  <task-notification>hidden"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsDisplayMessage(tt.msg))
+		})
+	}
+}
+
 func TestFindSessionIDsByPartialLiteralCaseSensitive(t *testing.T) {
 	d := testDB(t)
 	insertSession(t, d, "abc_def", "proj")

--- a/internal/duckdb/store.go
+++ b/internal/duckdb/store.go
@@ -185,7 +185,7 @@ func (s *Store) IngestEvalTrajectory(
 	return db.EvalTrajectoryIngestResult{}, db.ErrReadOnly
 }
 
-const duckSessionCols = `id, project, machine, agent,
+const duckSessionStorageCols = `id, project, machine, agent,
 	first_message, COALESCE(display_name, session_name) AS display_name, created_at, started_at,
 	ended_at, message_count, user_message_count,
 	parent_session_id, relationship_type,
@@ -210,11 +210,21 @@ const duckSessionCols = `id, project, machine, agent,
 	secret_leak_count, secrets_rules_version,
 	deleted_at, termination_status`
 
-func scanSession(rs interface{ Scan(...any) error }) (db.Session, error) {
-	var s db.Session
+var duckSessionAPICols = duckSessionStorageCols + `,
+	(SELECT MAX(m.ordinal) FROM messages m
+	 WHERE m.session_id = sessions.id AND ` + db.DuckDBDisplayMessageSQL("m") + `)
+	 AS latest_display_ordinal`
+
+type duckRowScanner interface {
+	Scan(...any) error
+}
+
+func scanSessionFields(
+	rs duckRowScanner, s *db.Session, extra ...any,
+) error {
 	var createdAt any
 	var startedAt, endedAt, deletedAt any
-	err := rs.Scan(
+	dest := []any{
 		&s.ID, &s.Project, &s.Machine, &s.Agent,
 		&s.FirstMessage, &s.DisplayName,
 		&createdAt, &startedAt, &endedAt,
@@ -242,9 +252,10 @@ func scanSession(rs interface{ Scan(...any) error }) (db.Session, error) {
 		&s.ParserMalformedLines, &s.IsTruncated,
 		&s.SecretLeakCount, &s.SecretsRulesVersion,
 		&deletedAt, &s.TerminationStatus,
-	)
+	}
+	err := rs.Scan(append(dest, extra...)...)
 	if err != nil {
-		return s, err
+		return err
 	}
 	s.CreatedAt = formatDBTime(createdAt)
 	if v := formatDBTime(startedAt); v != "" {
@@ -256,13 +267,27 @@ func scanSession(rs interface{ Scan(...any) error }) (db.Session, error) {
 	if v := formatDBTime(deletedAt); v != "" {
 		s.DeletedAt = &v
 	}
-	return s, nil
+	return nil
 }
 
-func scanSessionRows(rows *sql.Rows) ([]db.Session, error) {
+func scanSession(rs duckRowScanner) (db.Session, error) {
+	var s db.Session
+	err := scanSessionFields(rs, &s)
+	return s, err
+}
+
+func scanSessionAPIRow(rs duckRowScanner) (db.Session, error) {
+	var s db.Session
+	err := scanSessionFields(rs, &s, &s.LatestDisplayOrdinal)
+	return s, err
+}
+
+func scanSessionRows(
+	rows *sql.Rows, scan func(duckRowScanner) (db.Session, error),
+) ([]db.Session, error) {
 	sessions := []db.Session{}
 	for rows.Next() {
-		s, err := scanSession(rows)
+		s, err := scan(rows)
 		if err != nil {
 			return nil, fmt.Errorf("scanning duckdb session: %w", err)
 		}
@@ -406,7 +431,7 @@ func (s *Store) ListSessions(ctx context.Context, f db.SessionFilter) (db.Sessio
 		}
 		cursorWhere += " AND " + pageBuilder.CursorPredicate(rs, f, vals, cur.ID)
 	}
-	query := "SELECT " + duckSessionCols +
+	query := "SELECT " + duckSessionAPICols +
 		" FROM sessions WHERE " + cursorWhere + " " +
 		pageBuilder.OrderByClause(rs, f) + " " +
 		pageBuilder.Limit(f.Limit+1)
@@ -416,7 +441,7 @@ func (s *Store) ListSessions(ctx context.Context, f db.SessionFilter) (db.Sessio
 		return db.SessionPage{}, fmt.Errorf("querying duckdb sessions: %w", err)
 	}
 	defer rows.Close()
-	sessions, err := scanSessionRows(rows)
+	sessions, err := scanSessionRows(rows, scanSessionAPIRow)
 	if err != nil {
 		return db.SessionPage{}, err
 	}
@@ -451,6 +476,9 @@ func (s *Store) GetSidebarSessionIndex(ctx context.Context, f db.SessionFilter) 
 			termination_status,
 			message_count,
 			user_message_count,
+			(SELECT MAX(m.ordinal) FROM messages m
+			 WHERE m.session_id = sessions.id AND ` + db.DuckDBDisplayMessageSQL("m") + `)
+			 AS latest_display_ordinal,
 			is_automated,
 			position('<teammate-message' in COALESCE(first_message, '')) > 0
 		FROM sessions
@@ -486,6 +514,7 @@ func (s *Store) GetSidebarSessionIndex(ctx context.Context, f db.SessionFilter) 
 			&row.TerminationStatus,
 			&row.MessageCount,
 			&row.UserMessageCount,
+			&row.LatestDisplayOrdinal,
 			&row.IsAutomated,
 			&row.IsTeammate,
 		); err != nil {
@@ -515,10 +544,10 @@ func (s *Store) GetSidebarSessionIndex(ctx context.Context, f db.SessionFilter) 
 
 func (s *Store) GetSession(ctx context.Context, id string) (*db.Session, error) {
 	row := s.queryRowContext(ctx,
-		"SELECT "+duckSessionCols+" FROM sessions WHERE id = ? AND deleted_at IS NULL",
+		"SELECT "+duckSessionAPICols+" FROM sessions WHERE id = ? AND deleted_at IS NULL",
 		id,
 	)
-	sess, err := scanSession(row)
+	sess, err := scanSessionAPIRow(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
@@ -530,7 +559,7 @@ func (s *Store) GetSession(ctx context.Context, id string) (*db.Session, error) 
 
 func (s *Store) GetSessionFull(ctx context.Context, id string) (*db.Session, error) {
 	row := s.queryRowContext(ctx,
-		"SELECT "+duckSessionCols+" FROM sessions WHERE id = ?",
+		"SELECT "+duckSessionStorageCols+" FROM sessions WHERE id = ?",
 		id,
 	)
 	sess, err := scanSession(row)
@@ -545,7 +574,7 @@ func (s *Store) GetSessionFull(ctx context.Context, id string) (*db.Session, err
 
 func (s *Store) GetChildSessions(ctx context.Context, parentID string) ([]db.Session, error) {
 	rows, err := s.queryContext(ctx,
-		"SELECT "+duckSessionCols+` FROM sessions
+		"SELECT "+duckSessionAPICols+` FROM sessions
 		 WHERE parent_session_id = ? AND deleted_at IS NULL
 		 ORDER BY COALESCE(started_at, created_at) ASC`,
 		parentID,
@@ -554,7 +583,7 @@ func (s *Store) GetChildSessions(ctx context.Context, parentID string) ([]db.Ses
 		return nil, fmt.Errorf("querying duckdb child sessions: %w", err)
 	}
 	defer rows.Close()
-	return scanSessionRows(rows)
+	return scanSessionRows(rows, scanSessionAPIRow)
 }
 
 func (s *Store) GetSessionVersion(id string) (int, int64, bool) {

--- a/internal/duckdb/store.go
+++ b/internal/duckdb/store.go
@@ -211,9 +211,10 @@ const duckSessionStorageCols = `id, project, machine, agent,
 	deleted_at, termination_status`
 
 var duckSessionAPICols = duckSessionStorageCols + `,
-	(SELECT MAX(m.ordinal) FROM messages m
-	 WHERE m.session_id = sessions.id AND ` + db.DuckDBDisplayMessageSQL("m") + `)
-	 AS latest_display_ordinal`
+	` + db.DuckDBLatestDisplayOrdinalSubquery("sessions", "m") + `
+	 AS latest_display_ordinal,
+	` + db.DuckDBLatestDisplayContentLengthSubquery("sessions", "m") + `
+	 AS latest_display_content_length`
 
 type duckRowScanner interface {
 	Scan(...any) error
@@ -278,7 +279,12 @@ func scanSession(rs duckRowScanner) (db.Session, error) {
 
 func scanSessionAPIRow(rs duckRowScanner) (db.Session, error) {
 	var s db.Session
-	err := scanSessionFields(rs, &s, &s.LatestDisplayOrdinal)
+	err := scanSessionFields(
+		rs,
+		&s,
+		&s.LatestDisplayOrdinal,
+		&s.LatestDisplayContentLength,
+	)
 	return s, err
 }
 
@@ -476,9 +482,10 @@ func (s *Store) GetSidebarSessionIndex(ctx context.Context, f db.SessionFilter) 
 			termination_status,
 			message_count,
 			user_message_count,
-			(SELECT MAX(m.ordinal) FROM messages m
-			 WHERE m.session_id = sessions.id AND ` + db.DuckDBDisplayMessageSQL("m") + `)
+			` + db.DuckDBLatestDisplayOrdinalSubquery("sessions", "m") + `
 			 AS latest_display_ordinal,
+			` + db.DuckDBLatestDisplayContentLengthSubquery("sessions", "m") + `
+			 AS latest_display_content_length,
 			is_automated,
 			position('<teammate-message' in COALESCE(first_message, '')) > 0
 		FROM sessions
@@ -515,6 +522,7 @@ func (s *Store) GetSidebarSessionIndex(ctx context.Context, f db.SessionFilter) 
 			&row.MessageCount,
 			&row.UserMessageCount,
 			&row.LatestDisplayOrdinal,
+			&row.LatestDisplayContentLength,
 			&row.IsAutomated,
 			&row.IsTeammate,
 		); err != nil {

--- a/internal/duckdb/store_contract_test.go
+++ b/internal/duckdb/store_contract_test.go
@@ -209,6 +209,8 @@ func duckContractSessionsCursorsAndMetadata(
 	require.Equal(t, "alpha", alpha.Project)
 	require.NotNil(t, alpha.LatestDisplayOrdinal)
 	assert.Equal(t, 1, *alpha.LatestDisplayOrdinal)
+	require.NotNil(t, alpha.LatestDisplayContentLength)
+	assert.Greater(t, *alpha.LatestDisplayContentLength, 0)
 
 	full, err := store.GetSessionFull(ctx, fixture.alphaID)
 	require.NoError(t, err)
@@ -229,6 +231,8 @@ func duckContractSessionsCursorsAndMetadata(
 	require.NotNil(t, sidebar)
 	require.NotNil(t, sidebar.LatestDisplayOrdinal)
 	assert.Equal(t, 1, *sidebar.LatestDisplayOrdinal)
+	require.NotNil(t, sidebar.LatestDisplayContentLength)
+	assert.Greater(t, *sidebar.LatestDisplayContentLength, 0)
 
 	stats, err := store.GetStats(ctx, false, false)
 	require.NoError(t, err)

--- a/internal/duckdb/store_contract_test.go
+++ b/internal/duckdb/store_contract_test.go
@@ -210,7 +210,7 @@ func duckContractSessionsCursorsAndMetadata(
 	require.NotNil(t, alpha.LatestDisplayOrdinal)
 	assert.Equal(t, 1, *alpha.LatestDisplayOrdinal)
 	require.NotNil(t, alpha.LatestDisplayContentLength)
-	assert.Greater(t, *alpha.LatestDisplayContentLength, 0)
+	assert.Equal(t, len("secret token sk-duckdb")+len("legacy")+len("duck result"), *alpha.LatestDisplayContentLength)
 
 	full, err := store.GetSessionFull(ctx, fixture.alphaID)
 	require.NoError(t, err)
@@ -232,7 +232,7 @@ func duckContractSessionsCursorsAndMetadata(
 	require.NotNil(t, sidebar.LatestDisplayOrdinal)
 	assert.Equal(t, 1, *sidebar.LatestDisplayOrdinal)
 	require.NotNil(t, sidebar.LatestDisplayContentLength)
-	assert.Greater(t, *sidebar.LatestDisplayContentLength, 0)
+	assert.Equal(t, len("secret token sk-duckdb")+len("legacy")+len("duck result"), *sidebar.LatestDisplayContentLength)
 
 	stats, err := store.GetStats(ctx, false, false)
 	require.NoError(t, err)

--- a/internal/duckdb/store_contract_test.go
+++ b/internal/duckdb/store_contract_test.go
@@ -207,15 +207,28 @@ func duckContractSessionsCursorsAndMetadata(
 	require.NoError(t, err)
 	require.NotNil(t, alpha)
 	require.Equal(t, "alpha", alpha.Project)
+	require.NotNil(t, alpha.LatestDisplayOrdinal)
+	assert.Equal(t, 1, *alpha.LatestDisplayOrdinal)
 
 	full, err := store.GetSessionFull(ctx, fixture.alphaID)
 	require.NoError(t, err)
 	require.NotNil(t, full)
 	require.Equal(t, fixture.alphaID, full.ID)
+	assert.Nil(t, full.LatestDisplayOrdinal)
 
 	index, err := store.GetSidebarSessionIndex(ctx, db.SessionFilter{Project: "alpha"})
 	require.NoError(t, err)
 	require.Contains(t, duckSidebarSessionIDs(index.Sessions), fixture.alphaID)
+	var sidebar *db.SidebarSessionIndexRow
+	for i := range index.Sessions {
+		if index.Sessions[i].ID == fixture.alphaID {
+			sidebar = &index.Sessions[i]
+			break
+		}
+	}
+	require.NotNil(t, sidebar)
+	require.NotNil(t, sidebar.LatestDisplayOrdinal)
+	assert.Equal(t, 1, *sidebar.LatestDisplayOrdinal)
 
 	stats, err := store.GetStats(ctx, false, false)
 	require.NoError(t, err)

--- a/internal/duckdb/store_test.go
+++ b/internal/duckdb/store_test.go
@@ -189,6 +189,134 @@ func TestStoreReadsSessionsMessagesAndMetadata(t *testing.T) {
 	assert.Equal(t, []string{"test-machine"}, machines)
 }
 
+func TestSessionAPILatestDisplayOrdinal(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+
+	display := syncSession("display-cursor", "alpha", "visible", "2026-01-10T00:00:00.000Z", 5)
+	hiddenOnly := syncSession("hidden-only", "alpha", "hidden", "2026-01-10T00:05:00.000Z", 1)
+	parent := syncSession("duck-parent-cursor", "alpha", "parent", "2026-01-10T00:10:00.000Z", 1)
+	child := syncSession("duck-child-cursor", "alpha", "child", "2026-01-10T00:11:00.000Z", 1)
+	parentID := parent.ID
+	child.ParentSessionID = &parentID
+	child.RelationshipType = "subagent"
+
+	_, err := local.WriteSessionBatchAtomic([]db.SessionBatchWrite{
+		{
+			Session: display,
+			Messages: []db.Message{
+				syncMessage(display.ID, 1, "user", "visible", "2026-01-10T00:00:00.000Z"),
+				{
+					SessionID:     display.ID,
+					Ordinal:       3,
+					Role:          "user",
+					Content:       "hidden",
+					IsSystem:      true,
+					Timestamp:     "2026-01-10T00:01:00.000Z",
+					ContentLength: len("hidden"),
+				},
+				{
+					SessionID:         display.ID,
+					Ordinal:           5,
+					Role:              "system",
+					Content:           "compact",
+					IsSystem:          true,
+					IsCompactBoundary: true,
+					Timestamp:         "2026-01-10T00:02:00.000Z",
+					ContentLength:     len("compact"),
+				},
+				{
+					SessionID:     display.ID,
+					Ordinal:       7,
+					Role:          "system",
+					Content:       "continued",
+					IsSystem:      true,
+					SourceSubtype: "continuation",
+					Timestamp:     "2026-01-10T00:03:00.000Z",
+					ContentLength: len("continued"),
+				},
+				syncMessage(display.ID, 9, "user", db.SystemMsgPrefixes[0]+" by metadata", "2026-01-10T00:04:00.000Z"),
+			},
+			DataVersion:     1,
+			ReplaceMessages: true,
+		},
+		{
+			Session: hiddenOnly,
+			Messages: []db.Message{{
+				SessionID:     hiddenOnly.ID,
+				Ordinal:       4,
+				Role:          "user",
+				Content:       "hidden",
+				IsSystem:      true,
+				Timestamp:     "2026-01-10T00:05:00.000Z",
+				ContentLength: len("hidden"),
+			}},
+			DataVersion:     1,
+			ReplaceMessages: true,
+		},
+		{
+			Session:         parent,
+			Messages:        []db.Message{syncMessage(parent.ID, 0, "user", "parent", "2026-01-10T00:10:00.000Z")},
+			DataVersion:     1,
+			ReplaceMessages: true,
+		},
+		{
+			Session:         child,
+			Messages:        []db.Message{syncMessage(child.ID, 2, "assistant", "child", "2026-01-10T00:11:00.000Z")},
+			DataVersion:     1,
+			ReplaceMessages: true,
+		},
+	})
+	require.NoError(t, err)
+
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+	_, err = syncer.Push(ctx, true, nil)
+	require.NoError(t, err)
+	store := NewStoreFromDB(syncer.DB())
+
+	session, err := store.GetSession(ctx, display.ID)
+	require.NoError(t, err)
+	require.NotNil(t, session)
+	require.NotNil(t, session.LatestDisplayOrdinal)
+	assert.Equal(t, 7, *session.LatestDisplayOrdinal)
+
+	full, err := store.GetSessionFull(ctx, display.ID)
+	require.NoError(t, err)
+	require.NotNil(t, full)
+	assert.Nil(t, full.LatestDisplayOrdinal)
+
+	page, err := store.ListSessions(ctx, db.SessionFilter{Limit: 10, IncludeChildren: true})
+	require.NoError(t, err)
+	byID := map[string]db.Session{}
+	for _, row := range page.Sessions {
+		byID[row.ID] = row
+	}
+	require.NotNil(t, byID[display.ID].LatestDisplayOrdinal)
+	assert.Equal(t, 7, *byID[display.ID].LatestDisplayOrdinal)
+	assert.Nil(t, byID[hiddenOnly.ID].LatestDisplayOrdinal)
+	require.NotNil(t, byID[child.ID].LatestDisplayOrdinal)
+	assert.Equal(t, 2, *byID[child.ID].LatestDisplayOrdinal)
+
+	index, err := store.GetSidebarSessionIndex(ctx, db.SessionFilter{IncludeChildren: true})
+	require.NoError(t, err)
+	var sidebar *db.SidebarSessionIndexRow
+	for i := range index.Sessions {
+		if index.Sessions[i].ID == display.ID {
+			sidebar = &index.Sessions[i]
+			break
+		}
+	}
+	require.NotNil(t, sidebar)
+	require.NotNil(t, sidebar.LatestDisplayOrdinal)
+	assert.Equal(t, 7, *sidebar.LatestDisplayOrdinal)
+
+	children, err := store.GetChildSessions(ctx, parent.ID)
+	require.NoError(t, err)
+	require.Len(t, children, 1)
+	require.NotNil(t, children[0].LatestDisplayOrdinal)
+	assert.Equal(t, 2, *children[0].LatestDisplayOrdinal)
+}
+
 func TestStoreGetStatsPreservesRootAndScopeFilters(t *testing.T) {
 	ctx := context.Background()
 	local := newLocalDB(t)

--- a/internal/duckdb/sync_test.go
+++ b/internal/duckdb/sync_test.go
@@ -2061,11 +2061,13 @@ func seedDuckDBSyncFixture(t *testing.T, local *db.DB) syncFixture {
 				syncMessage(alphaID, 0, "user", "alpha first", "2026-01-10T00:00:00.000Z"),
 				syncMessage(alphaID, 1, "assistant", alphaSecret, "2026-01-10T00:01:00.000Z",
 					db.ToolCall{
-						ToolName:  "search",
-						Category:  "search",
-						SkillName: "duck-search",
-						ToolUseID: "tool-alpha",
-						InputJSON: `{"query":"duck"}`,
+						ToolName:            "search",
+						Category:            "search",
+						SkillName:           "duck-search",
+						ToolUseID:           "tool-alpha",
+						InputJSON:           `{"query":"duck"}`,
+						ResultContent:       "legacy",
+						ResultContentLength: len("legacy"),
 						ResultEvents: []db.ToolResultEvent{{
 							Source:        "tool",
 							Status:        "complete",

--- a/internal/postgres/schema.go
+++ b/internal/postgres/schema.go
@@ -1827,7 +1827,7 @@ func CheckSchemaCompat(
 	ctx context.Context, db *sql.DB,
 ) error {
 	rows, err := db.QueryContext(ctx,
-		`SELECT updated_at, `+pgSessionCols+`
+		`SELECT updated_at, `+pgSessionStorageCols+`
 		 FROM sessions LIMIT 0`)
 	if err != nil {
 		return fmt.Errorf(

--- a/internal/postgres/sessions.go
+++ b/internal/postgres/sessions.go
@@ -73,9 +73,10 @@ const pgSessionStorageCols = `id, project, machine, agent,
 	deleted_at, termination_status`
 
 var pgSessionAPICols = pgSessionStorageCols + `,
-	(SELECT MAX(m.ordinal) FROM messages m
-	 WHERE m.session_id = sessions.id AND ` + db.PostgresDisplayMessageSQL("m") + `)
-	 AS latest_display_ordinal`
+	` + db.PostgresLatestDisplayOrdinalSubquery("sessions", "m") + `
+	 AS latest_display_ordinal,
+	` + db.PostgresLatestDisplayContentLengthSubquery("sessions", "m") + `
+	 AS latest_display_content_length`
 
 // paramBuilder generates numbered PostgreSQL placeholders.
 type paramBuilder struct {
@@ -294,6 +295,7 @@ func scanPGAPISession(
 		&s.SecretLeakCount, &s.SecretsRulesVersion,
 		&deletedAt, &s.TerminationStatus,
 		&s.LatestDisplayOrdinal,
+		&s.LatestDisplayContentLength,
 	}
 	if err := rs.Scan(dest...); err != nil {
 		return s, err
@@ -584,8 +586,8 @@ func (s *Store) GetSidebarSessionIndex(
 			user_message_count,
 			is_automated,
 			position('<teammate-message' in COALESCE(first_message, '')) > 0,
-			(SELECT MAX(m.ordinal) FROM messages m
-			 WHERE m.session_id = sessions.id AND ` + db.PostgresDisplayMessageSQL("m") + `)
+			` + db.PostgresLatestDisplayOrdinalSubquery("sessions", "m") + `,
+			` + db.PostgresLatestDisplayContentLengthSubquery("sessions", "m") + `
 		FROM sessions
 		WHERE ` + where + `
 		ORDER BY COALESCE(
@@ -822,8 +824,8 @@ func (s *Store) getSidebarSessionIndexPage(
 			s.user_message_count,
 			s.is_automated,
 			position('<teammate-message' in COALESCE(s.first_message, '')) > 0,
-			(SELECT MAX(m.ordinal) FROM messages m
-			 WHERE m.session_id = s.id AND ` + db.PostgresDisplayMessageSQL("m") + `)
+			` + db.PostgresLatestDisplayOrdinalSubquery("s", "m") + `,
+			` + db.PostgresLatestDisplayContentLengthSubquery("s", "m") + `
 		FROM sessions s
 		JOIN ranked_tree t ON s.id = t.id
 		ORDER BY
@@ -869,6 +871,7 @@ func scanPGSidebarSessionIndexRows(
 			&row.IsAutomated,
 			&row.IsTeammate,
 			&row.LatestDisplayOrdinal,
+			&row.LatestDisplayContentLength,
 		); err != nil {
 			return nil, fmt.Errorf(
 				"scanning sidebar session index: %w",

--- a/internal/postgres/sessions.go
+++ b/internal/postgres/sessions.go
@@ -42,10 +42,10 @@ type Store struct {
 	semanticUnavailableReason string
 }
 
-// pgSessionCols is the column list for standard PG session
-// queries. PG has no file_path, file_size, file_mtime,
+// pgSessionStorageCols is the persisted PG session projection.
+// PG has no file_path, file_size, file_mtime,
 // file_hash, or local_modified_at columns.
-const pgSessionCols = `id, project, machine, agent,
+const pgSessionStorageCols = `id, project, machine, agent,
 	first_message, COALESCE(display_name, session_name) AS display_name, created_at, started_at,
 	ended_at, message_count, user_message_count,
 	parent_session_id, relationship_type,
@@ -71,6 +71,11 @@ const pgSessionCols = `id, project, machine, agent,
 	transcript_fidelity, parser_malformed_lines, is_truncated,
 	secret_leak_count, secrets_rules_version,
 	deleted_at, termination_status`
+
+var pgSessionAPICols = pgSessionStorageCols + `,
+	(SELECT MAX(m.ordinal) FROM messages m
+	 WHERE m.session_id = sessions.id AND ` + db.PostgresDisplayMessageSQL("m") + `)
+	 AS latest_display_ordinal`
 
 // paramBuilder generates numbered PostgreSQL placeholders.
 type paramBuilder struct {
@@ -193,7 +198,7 @@ func pgTerminationPred(status string, pb *paramBuilder) string {
 	return "(" + strings.Join(preds, " OR ") + ")"
 }
 
-// scanPGSession scans a row with pgSessionCols into a
+// scanPGSession scans a row with pgSessionStorageCols into a
 // db.Session, converting TIMESTAMPTZ columns to string.
 func scanPGSession(
 	rs interface{ Scan(...any) error },
@@ -201,7 +206,7 @@ func scanPGSession(
 	var s db.Session
 	var createdAt *time.Time
 	var startedAt, endedAt, deletedAt *time.Time
-	err := rs.Scan(
+	dest := []any{
 		&s.ID, &s.Project, &s.Machine, &s.Agent,
 		&s.FirstMessage, &s.DisplayName,
 		&createdAt, &startedAt, &endedAt,
@@ -230,8 +235,67 @@ func scanPGSession(
 		&s.TranscriptFidelity, &s.ParserMalformedLines, &s.IsTruncated,
 		&s.SecretLeakCount, &s.SecretsRulesVersion,
 		&deletedAt, &s.TerminationStatus,
-	)
+	}
+	err := rs.Scan(dest...)
 	if err != nil {
+		return s, err
+	}
+	if createdAt != nil {
+		s.CreatedAt = FormatISO8601(*createdAt)
+	}
+	if startedAt != nil {
+		str := FormatISO8601(*startedAt)
+		s.StartedAt = &str
+	}
+	if endedAt != nil {
+		str := FormatISO8601(*endedAt)
+		s.EndedAt = &str
+	}
+	if deletedAt != nil {
+		str := FormatISO8601(*deletedAt)
+		s.DeletedAt = &str
+	}
+	return s, nil
+}
+
+func scanPGAPISession(
+	rs interface{ Scan(...any) error },
+) (db.Session, error) {
+	var s db.Session
+	var createdAt *time.Time
+	var startedAt, endedAt, deletedAt *time.Time
+	dest := []any{
+		&s.ID, &s.Project, &s.Machine, &s.Agent,
+		&s.FirstMessage, &s.DisplayName,
+		&createdAt, &startedAt, &endedAt,
+		&s.MessageCount, &s.UserMessageCount,
+		&s.ParentSessionID, &s.RelationshipType,
+		&s.TotalOutputTokens, &s.PeakContextTokens,
+		&s.HasTotalOutputTokens, &s.HasPeakContextTokens,
+		&s.IsAutomated,
+		&s.ToolFailureSignalCount, &s.ToolRetryCount,
+		&s.EditChurnCount, &s.ConsecutiveFailureMax,
+		&s.Outcome, &s.OutcomeConfidence,
+		&s.EndedWithRole, &s.FinalFailureStreak,
+		&s.SignalsPendingSince,
+		&s.CompactionCount, &s.MidTaskCompactionCount,
+		&s.ContextPressureMax,
+		&s.HealthScore, &s.HealthGrade,
+		&s.HasToolCalls, &s.HasContextData,
+		&s.QualitySignalVersion,
+		&s.ShortPromptCount, &s.UnstructuredStart,
+		&s.MissingSuccessCriteriaCount,
+		&s.MissingVerificationCount, &s.DuplicatePromptCount,
+		&s.NoCodeContextCount, &s.RunawayToolLoopCount,
+		&s.DataVersion,
+		&s.Cwd, &s.GitBranch,
+		&s.SourceSessionID, &s.SourceVersion,
+		&s.TranscriptFidelity, &s.ParserMalformedLines, &s.IsTruncated,
+		&s.SecretLeakCount, &s.SecretsRulesVersion,
+		&deletedAt, &s.TerminationStatus,
+		&s.LatestDisplayOrdinal,
+	}
+	if err := rs.Scan(dest...); err != nil {
 		return s, err
 	}
 	if createdAt != nil {
@@ -297,6 +361,18 @@ func scanPGSessionRows(
 			return nil, fmt.Errorf(
 				"scanning session: %w", err,
 			)
+		}
+		sessions = append(sessions, s)
+	}
+	return sessions, rows.Err()
+}
+
+func scanPGAPISessionRows(rows *sql.Rows) ([]db.Session, error) {
+	sessions := []db.Session{}
+	for rows.Next() {
+		s, err := scanPGAPISession(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scanning session: %w", err)
 		}
 		sessions = append(sessions, s)
 	}
@@ -458,7 +534,7 @@ func (s *Store) ListSessions(
 		)
 	}
 
-	query := "SELECT " + pgSessionCols +
+	query := "SELECT " + pgSessionAPICols +
 		" FROM sessions WHERE " + cursorWhere + " " +
 		pageBuilder.OrderByClause(rs, f) + " " +
 		pageBuilder.Limit(f.Limit+1)
@@ -473,7 +549,7 @@ func (s *Store) ListSessions(
 	}
 	defer rows.Close()
 
-	sessions, err := scanPGSessionRows(rows)
+	sessions, err := scanPGAPISessionRows(rows)
 	if err != nil {
 		return db.SessionPage{}, err
 	}
@@ -524,7 +600,9 @@ func (s *Store) GetSidebarSessionIndex(
 			message_count,
 			user_message_count,
 			is_automated,
-			position('<teammate-message' in COALESCE(first_message, '')) > 0
+			position('<teammate-message' in COALESCE(first_message, '')) > 0,
+			(SELECT MAX(m.ordinal) FROM messages m
+			 WHERE m.session_id = sessions.id AND ` + db.PostgresDisplayMessageSQL("m") + `)
 		FROM sessions
 		WHERE ` + where + `
 		ORDER BY COALESCE(
@@ -760,7 +838,9 @@ func (s *Store) getSidebarSessionIndexPage(
 			s.message_count,
 			s.user_message_count,
 			s.is_automated,
-			position('<teammate-message' in COALESCE(s.first_message, '')) > 0
+			position('<teammate-message' in COALESCE(s.first_message, '')) > 0,
+			(SELECT MAX(m.ordinal) FROM messages m
+			 WHERE m.session_id = s.id AND ` + db.PostgresDisplayMessageSQL("m") + `)
 		FROM sessions s
 		JOIN ranked_tree t ON s.id = t.id
 		ORDER BY
@@ -805,6 +885,7 @@ func scanPGSidebarSessionIndexRows(
 			&row.UserMessageCount,
 			&row.IsAutomated,
 			&row.IsTeammate,
+			&row.LatestDisplayOrdinal,
 		); err != nil {
 			return nil, fmt.Errorf(
 				"scanning sidebar session index: %w",
@@ -837,12 +918,12 @@ func (s *Store) GetSession(
 ) (*db.Session, error) {
 	row := s.pg.QueryRowContext(
 		ctx,
-		"SELECT "+pgSessionCols+
+		"SELECT "+pgSessionAPICols+
 			" FROM sessions WHERE id = $1"+
 			" AND deleted_at IS NULL",
 		id,
 	)
-	sess, err := scanPGSession(row)
+	sess, err := scanPGAPISession(row)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -909,7 +990,7 @@ func (s *Store) GetSessionFull(
 ) (*db.Session, error) {
 	row := s.pg.QueryRowContext(
 		ctx,
-		"SELECT "+pgSessionCols+
+		"SELECT "+pgSessionStorageCols+
 			" FROM sessions WHERE id = $1",
 		id,
 	)
@@ -930,7 +1011,7 @@ func (s *Store) GetSessionFull(
 func (s *Store) GetChildSessions(
 	ctx context.Context, parentID string,
 ) ([]db.Session, error) {
-	query := "SELECT " + pgSessionCols +
+	query := "SELECT " + pgSessionAPICols +
 		" FROM sessions" +
 		" WHERE parent_session_id = $1" +
 		" AND deleted_at IS NULL" +
@@ -944,7 +1025,7 @@ func (s *Store) GetChildSessions(
 	}
 	defer rows.Close()
 
-	return scanPGSessionRows(rows)
+	return scanPGAPISessionRows(rows)
 }
 
 // GetStats returns database statistics, counting only root

--- a/internal/postgres/sessions.go
+++ b/internal/postgres/sessions.go
@@ -350,23 +350,6 @@ func (s *Store) FindSessionIDsByPartial(
 	return ids, rows.Err()
 }
 
-// scanPGSessionRows iterates rows and scans each.
-func scanPGSessionRows(
-	rows *sql.Rows,
-) ([]db.Session, error) {
-	sessions := []db.Session{}
-	for rows.Next() {
-		s, err := scanPGSession(rows)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"scanning session: %w", err,
-			)
-		}
-		sessions = append(sessions, s)
-	}
-	return sessions, rows.Err()
-}
-
 func scanPGAPISessionRows(rows *sql.Rows) ([]db.Session, error) {
 	sessions := []db.Session{}
 	for rows.Next() {

--- a/internal/postgres/store.go
+++ b/internal/postgres/store.go
@@ -531,7 +531,7 @@ func (s *Store) ListTrashedSessions(
 	ctx context.Context,
 ) ([]db.Session, error) {
 	rows, err := s.pg.QueryContext(ctx,
-		"SELECT "+pgSessionCols+
+		"SELECT "+pgSessionAPICols+
 			" FROM sessions WHERE deleted_at IS NOT NULL"+
 			" ORDER BY deleted_at DESC LIMIT 500",
 	)
@@ -539,7 +539,7 @@ func (s *Store) ListTrashedSessions(
 		return nil, fmt.Errorf("querying trashed sessions: %w", err)
 	}
 	defer rows.Close()
-	return scanPGSessionRows(rows)
+	return scanPGAPISessionRows(rows)
 }
 
 // EmptyTrash permanently deletes every trashed session.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -956,6 +956,10 @@ func TestOpenAPIEndpointDocumentsLatestDisplayOrdinal(t *testing.T) {
 		property, ok := schema.Properties["latest_display_ordinal"]
 		require.True(t, ok, "schema %s cursor missing", name)
 		assert.JSONEq(t, `["integer","null"]`, string(property.Type))
+		assert.Contains(t, schema.Required, "latest_display_content_length")
+		contentLength, ok := schema.Properties["latest_display_content_length"]
+		require.True(t, ok, "schema %s content-length cursor missing", name)
+		assert.JSONEq(t, `["integer","null"]`, string(contentLength.Type))
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -928,6 +928,37 @@ func TestOpenAPIEndpointDocumentsBatchDeleteSessionIDsAsNonNullableArray(t *test
 		`session_ids must be a non-nullable array, not the nullable ["array","null"] union`)
 }
 
+func TestOpenAPIEndpointDocumentsLatestDisplayOrdinal(t *testing.T) {
+	te := setup(t)
+	w := te.get(t, "/api/openapi.json")
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var spec struct {
+		Components struct {
+			Schemas map[string]struct {
+				Required   []string `json:"required"`
+				Properties map[string]struct {
+					Type json.RawMessage `json:"type"`
+				} `json:"properties"`
+			} `json:"schemas"`
+		} `json:"components"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &spec))
+
+	for _, name := range []string{
+		"DbSession",
+		"ServiceSessionDetail",
+		"DbSidebarSessionIndexRow",
+	} {
+		schema, ok := spec.Components.Schemas[name]
+		require.True(t, ok, "schema %s missing", name)
+		assert.Contains(t, schema.Required, "latest_display_ordinal")
+		property, ok := schema.Properties["latest_display_ordinal"]
+		require.True(t, ok, "schema %s cursor missing", name)
+		assert.JSONEq(t, `["integer","null"]`, string(property.Type))
+	}
+}
+
 func TestOpenAPIEndpointDocumentsQualitySignalResponses(t *testing.T) {
 	te := setup(t)
 

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -3202,6 +3202,16 @@ func (e *Engine) countDBBackedSessions(
 	return total
 }
 
+func (e *Engine) getActiveStoredSession(
+	ctx context.Context, sessionID string,
+) (*db.Session, error) {
+	sess, err := e.db.GetSessionFull(ctx, sessionID)
+	if err != nil || sess == nil || sess.DeletedAt != nil {
+		return nil, err
+	}
+	return sess, nil
+}
+
 // syncProviderDBBacked enumerates a DB-backed provider's sources, parses only
 // the changed ones through the provider facade, and returns their pending
 // writes. Change detection compares the provider fingerprint mtime against the
@@ -4980,7 +4990,7 @@ func (e *Engine) providerSingleSessionFresh(
 	) {
 		return 0, false, true
 	}
-	sess, _ := e.db.GetSession(ctx, e.idPrefix+sessionID)
+	sess, _ := e.getActiveStoredSession(ctx, e.idPrefix+sessionID)
 	return info.ModTime().UnixNano(), sess != nil &&
 		sess.Project != "" &&
 		!parser.NeedsProjectReparse(sess.Project), false
@@ -8407,7 +8417,7 @@ func (e *Engine) SourceMtime(sessionID string) int64 {
 			} else if ok && def.Type == parser.AgentCodex {
 				stat = statCodexS3Session
 			}
-			if sess, err := e.db.GetSession(
+			if sess, err := e.getActiveStoredSession(
 				context.Background(), sessionID,
 			); err == nil && sess != nil {
 				switch sess.Agent {
@@ -8674,7 +8684,7 @@ func (e *Engine) SyncSingleSessionContext(
 	switch agent {
 	case parser.AgentClaude:
 		// Try to preserve existing project from DB first
-		if sess, _ := e.db.GetSession(ctx, sessionID); sess != nil &&
+		if sess, _ := e.getActiveStoredSession(ctx, sessionID); sess != nil &&
 			sess.Project != "" &&
 			!parser.NeedsProjectReparse(sess.Project) {
 			file.Project = sess.Project
@@ -8686,7 +8696,7 @@ func (e *Engine) SyncSingleSessionContext(
 		// parsed session, so an empty project here would overwrite the
 		// existing "visualstudio" value. Prefer the stored project; fall
 		// back to the canonical default discovery assigns.
-		if sess, _ := e.db.GetSession(ctx, sessionID); sess != nil &&
+		if sess, _ := e.getActiveStoredSession(ctx, sessionID); sess != nil &&
 			sess.Project != "" &&
 			!parser.NeedsProjectReparse(sess.Project) {
 			file.Project = sess.Project
@@ -8713,7 +8723,7 @@ func (e *Engine) SyncSingleSessionContext(
 	case parser.AgentIflow:
 		// path is <iflowDir>/<project>/session-<uuid>.jsonl
 		// Extract project dir name from parent directory
-		if sess, _ := e.db.GetSession(ctx, sessionID); sess != nil &&
+		if sess, _ := e.getActiveStoredSession(ctx, sessionID); sess != nil &&
 			sess.Project != "" &&
 			!parser.NeedsProjectReparse(sess.Project) {
 			file.Project = sess.Project
@@ -8745,7 +8755,7 @@ func (e *Engine) SyncSingleSessionContext(
 		// from the sessionID prefix as a final fallback that works
 		// even when the DB row is missing or stale.
 		if file.Project == "" {
-			if sess, _ := e.db.GetSession(ctx, sessionID); sess != nil &&
+			if sess, _ := e.getActiveStoredSession(ctx, sessionID); sess != nil &&
 				sess.Project != "" &&
 				!parser.NeedsProjectReparse(sess.Project) {
 				file.Project = sess.Project
@@ -8774,7 +8784,7 @@ func (e *Engine) SyncSingleSessionContext(
 		if classified, ok := e.classifyReasonixPath(path); ok {
 			file.Project = classified.Project
 		} else {
-			if sess, _ := e.db.GetSession(ctx, sessionID); sess != nil &&
+			if sess, _ := e.getActiveStoredSession(ctx, sessionID); sess != nil &&
 				sess.Project != "" &&
 				!parser.NeedsProjectReparse(sess.Project) {
 				file.Project = sess.Project
@@ -8861,7 +8871,7 @@ func (e *Engine) applyWorktreeMappingToSingleSession(
 	sessionID string,
 ) error {
 	ctx := context.Background()
-	sess, err := e.db.GetSession(ctx, sessionID)
+	sess, err := e.getActiveStoredSession(ctx, sessionID)
 	if err != nil || sess == nil || sess.Cwd == "" {
 		return err
 	}

--- a/internal/sync/s3.go
+++ b/internal/sync/s3.go
@@ -194,7 +194,7 @@ func (e *Engine) processS3Session(
 			idPrefix, sessionID, sourceInfo, sourceFingerprint,
 		) &&
 			e.db.GetSessionFilePath(fullID) == file.Path {
-			sess, _ := e.db.GetSession(ctx, fullID)
+			sess, _ := e.getActiveStoredSession(ctx, fullID)
 			if sess != nil &&
 				sess.Project != "" &&
 				!parser.NeedsProjectReparse(sess.Project) {
@@ -211,7 +211,7 @@ func (e *Engine) processS3Session(
 				idPrefix, sessionID, sourceInfo, sourceFingerprint,
 			) &&
 				e.db.GetSessionFilePath(fullID) == file.Path {
-				sess, _ := e.db.GetSession(ctx, fullID)
+				sess, _ := e.getActiveStoredSession(ctx, fullID)
 				indexNameChanged := false
 				if sess != nil &&
 					sess.Project != "" &&

--- a/internal/sync/s3_source.go
+++ b/internal/sync/s3_source.go
@@ -329,7 +329,7 @@ func (e *Engine) hydrateS3DiscoveredFile(
 	if !isS3SourcePath(file.Path) {
 		return
 	}
-	if sess, _ := e.db.GetSession(ctx, sessionID); sess != nil {
+	if sess, _ := e.getActiveStoredSession(ctx, sessionID); sess != nil {
 		if sess.Project != "" &&
 			!parser.NeedsProjectReparse(sess.Project) {
 			file.Project = sess.Project


### PR DESCRIPTION
Session updates currently reload the transcript without retaining where the reader stopped, so later output has no boundary in the session view and no signal in the sidebar.

This change adds a read-only `latest_display_ordinal` to session detail and sidebar metadata in SQLite, PostgreSQL, and DuckDB. All three backends derive it with the same transcript visibility rules, so hidden system rows do not affect unread state. Browser storage persists one per-session `seenOrdinal`; the first visit establishes a baseline, visible rows advance it, and sidebar unread state compares the two cursors directly.

Message counts remain loading metadata. Progressive loading, equal-count rewrites, and sparse or one-based ordinals no longer infer transcript position from count values. Existing newest-first boundaries, divider placement inside tool groups, and exact tool-group child visibility remain intact.

The SSE watch path, parser behavior, database schema, and prompt-navigation scope remain unchanged. Prompt navigation continues separately in #1064.

Closes #1057
