### PR TITLE
fix: replay vscode copilot jsonl splice replacements

### DIFF
--- a/internal/parser/vscode_copilot.go
+++ b/internal/parser/vscode_copilot.go
@@ -816,12 +816,13 @@ func jsonlPush(
 		}
 		if spliceIdx != nil {
 			idx := max(0, min(*spliceIdx, len(arr)))
+			end := min(idx+len(items), len(arr))
 			newArr := make(
-				[]any, 0, len(arr)+len(items),
+				[]any, 0, len(arr)-(end-idx)+len(items),
 			)
 			newArr = append(newArr, arr[:idx]...)
 			newArr = append(newArr, items...)
-			newArr = append(newArr, arr[idx:]...)
+			newArr = append(newArr, arr[end:]...)
 			p[lastKey] = newArr
 		} else {
 			p[lastKey] = append(arr, items...)
@@ -837,12 +838,13 @@ func jsonlPush(
 		}
 		if spliceIdx != nil {
 			si := max(0, min(*spliceIdx, len(arr)))
+			end := min(si+len(items), len(arr))
 			newArr := make(
-				[]any, 0, len(arr)+len(items),
+				[]any, 0, len(arr)-(end-si)+len(items),
 			)
 			newArr = append(newArr, arr[:si]...)
 			newArr = append(newArr, items...)
-			newArr = append(newArr, arr[si:]...)
+			newArr = append(newArr, arr[end:]...)
 			p[idx] = newArr
 		} else {
 			p[idx] = append(arr, items...)

--- a/internal/parser/vscode_copilot_test.go
+++ b/internal/parser/vscode_copilot_test.go
@@ -598,9 +598,9 @@ func TestReconstructJSONL(t *testing.T) {
 			},
 		},
 		{
-			name: "push with splice index",
+			name: "push with splice index replaces existing items",
 			lines: []string{
-				`{"kind":0,"v":{"items":["a","c"]}}`,
+				`{"kind":0,"v":{"items":["a","old","c"]}}`,
 				`{"kind":2,"k":["items"],"v":["b"],"i":1}`,
 			},
 			check: func(t *testing.T, data []byte) {
@@ -612,7 +612,7 @@ func TestReconstructJSONL(t *testing.T) {
 			},
 		},
 		{
-			name: "push with negative splice index",
+			name: "push with negative splice index replaces from front",
 			lines: []string{
 				`{"kind":0,"v":{"items":["a","b"]}}`,
 				`{"kind":2,"k":["items"],"v":["z"],"i":-1}`,
@@ -621,8 +621,8 @@ func TestReconstructJSONL(t *testing.T) {
 				var m map[string]any
 				require.NoError(t, json.Unmarshal(data, &m))
 				items := m["items"].([]any)
-				require.Len(t, items, 3, "len")
-				// Negative index clamped to 0: inserted at front
+				require.Len(t, items, 2, "len")
+				// Negative index clamped to 0: replaced at front.
 				assert.Equal(t, "z", items[0], "items[0]")
 			},
 		},


### PR DESCRIPTION
VS Code Copilot session files (`chatSessions/*.jsonl`) can be parsed with responses truncated mid-stream. 

The issue is that indexed `kind=2` operations are treated as insertions. For response arrays, VS Code uses indexed `kind=2` operations with `i` defined as splice replacements: they replace the existing items starting at index `i`.

This PR updates `jsonlPush` so indexed `kind=2` operations replace `len(items)` existing items starting at the clamped splice index, instead of inserting before that index, if `i` is defined. Also, it updates regression coverage for indexed splice replacement in `TestReconstructJSONL`.