### PR TITLE
perf(claude): apply subagent linkage incrementally

### DIFF
--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -3275,6 +3275,51 @@ func TestSetToolCallSubagentSession(t *testing.T) {
 	assert.Equal(t, "agent-existing", got["toolu_task2"], "toolu_task2 subagent")
 }
 
+func TestWriteSessionIncrementalBlocksLinkedResultContent(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "s1", "proj")
+	insertMessages(t, d, Message{
+		SessionID:  "s1",
+		Ordinal:    0,
+		Role:       "assistant",
+		HasToolUse: true,
+		ToolCalls: []ToolCall{{
+			SessionID: "s1",
+			ToolName:  "Agent",
+			Category:  "Task",
+			ToolUseID: "toolu_blocked",
+		}},
+	})
+
+	require.NoError(t, d.WriteSessionIncremental(
+		"s1", nil, IncrementalSessionUpdate{
+			MsgCount:    1,
+			NextOrdinal: 1,
+			SubagentLinks: []ToolCallSubagentLink{{
+				ToolUseID:         "toolu_blocked",
+				SubagentSessionID: "agent-child",
+				ResultContent:     "secret result",
+				ResultContentLen:  len("secret result"),
+				HasResult:         true,
+			}},
+			BlockedResultCategories: map[string]bool{"Task": true},
+		},
+	), "incremental write")
+
+	var subagent, content string
+	var contentLen int
+	require.NoError(t, d.Reader().QueryRow(`
+		SELECT COALESCE(subagent_session_id, ''), result_content_length,
+		       COALESCE(result_content, '')
+		FROM tool_calls
+		WHERE session_id = ? AND tool_use_id = ?`,
+		"s1", "toolu_blocked",
+	).Scan(&subagent, &contentLen, &content), "query linked result")
+	assert.Equal(t, "agent-child", subagent)
+	assert.Equal(t, len("secret result"), contentLen)
+	assert.Empty(t, content)
+}
+
 func TestFTSBackfill(t *testing.T) {
 	dCheck := testDB(t)
 	requireFTS(t, dCheck)

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -3226,6 +3226,55 @@ func TestToolCallSubagentSessionID(t *testing.T) {
 		nullSubagent.String)
 }
 
+func TestSetToolCallSubagentSession(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "s1", "proj")
+	insertMessages(t, d, Message{
+		SessionID:     "s1",
+		Ordinal:       0,
+		Role:          "assistant",
+		Content:       "[Task: implement feature]",
+		ContentLength: 24,
+		Timestamp:     tsZero,
+		HasToolUse:    true,
+		ToolCalls: []ToolCall{
+			{
+				SessionID: "s1",
+				ToolName:  "Task",
+				Category:  "Tool",
+				ToolUseID: "toolu_task1",
+			},
+			{
+				SessionID:         "s1",
+				ToolName:          "Task",
+				Category:          "Tool",
+				ToolUseID:         "toolu_task2",
+				SubagentSessionID: "agent-existing",
+			},
+		},
+	})
+
+	requireNoError(t, d.SetToolCallSubagentSession("s1", "toolu_task1", "agent-new"), "set subagent session")
+
+	rows, err := d.Reader().Query(`
+		SELECT tool_use_id, COALESCE(subagent_session_id, '')
+		FROM tool_calls
+		WHERE session_id = 's1'
+		ORDER BY tool_use_id`)
+	requireNoError(t, err, "query tool_calls")
+	defer rows.Close()
+
+	got := map[string]string{}
+	for rows.Next() {
+		var toolUseID, subagent string
+		requireNoError(t, rows.Scan(&toolUseID, &subagent), "scan tool_calls")
+		got[toolUseID] = subagent
+	}
+	requireNoError(t, rows.Err(), "rows")
+	assert.Equal(t, "agent-new", got["toolu_task1"], "toolu_task1 subagent")
+	assert.Equal(t, "agent-existing", got["toolu_task2"], "toolu_task2 subagent")
+}
+
 func TestFTSBackfill(t *testing.T) {
 	dCheck := testDB(t)
 	requireFTS(t, dCheck)

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -3241,13 +3241,13 @@ func TestSetToolCallSubagentSession(t *testing.T) {
 			{
 				SessionID: "s1",
 				ToolName:  "Task",
-				Category:  "Tool",
+				Category:  "Task",
 				ToolUseID: "toolu_task1",
 			},
 			{
 				SessionID:         "s1",
 				ToolName:          "Task",
-				Category:          "Tool",
+				Category:          "Task",
 				ToolUseID:         "toolu_task2",
 				SubagentSessionID: "agent-existing",
 			},

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -2056,6 +2056,51 @@ func (db *DB) ToolCallCount(sessionID string) (int, error) {
 	return n, err
 }
 
+func (db *DB) SetToolCallSubagentSession(
+	sessionID, toolUseID, subagentSessionID string,
+) error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	result, err := db.getWriter().Exec(
+		`UPDATE tool_calls
+		 SET subagent_session_id = ?
+		 WHERE session_id = ? AND tool_use_id = ?
+		   AND COALESCE(subagent_session_id, '') != ?`,
+		subagentSessionID, sessionID, toolUseID, subagentSessionID,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"updating subagent_session_id for %s/%s: %w",
+			sessionID, toolUseID, err,
+		)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil || affected > 0 {
+		return err
+	}
+
+	var exists int
+	if err := db.getReader().QueryRow(
+		`SELECT COUNT(*)
+		 FROM tool_calls
+		 WHERE session_id = ? AND tool_use_id = ?`,
+		sessionID, toolUseID,
+	).Scan(&exists); err != nil {
+		return fmt.Errorf(
+			"checking tool_call for %s/%s: %w",
+			sessionID, toolUseID, err,
+		)
+	}
+	if exists == 0 {
+		return fmt.Errorf(
+			"tool_call not found for session %s tool_use_id %s",
+			sessionID, toolUseID,
+		)
+	}
+	return nil
+}
+
 // SystemMessageFingerprint returns the ordered, comma-separated list of
 // ordinals for system messages in a session (e.g. "0,2,5"). This is an
 // exact fingerprint of the system-message ordinal set: any reclassification

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -2097,10 +2097,7 @@ func applyToolCallSubagentLinkTx(
 		sessionID, link.ToolUseID,
 	).Scan(&toolName, &category, &currentSubagent); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return fmt.Errorf(
-				"tool_call not found for session %s tool_use_id %s",
-				sessionID, link.ToolUseID,
-			)
+			return nil
 		}
 		return fmt.Errorf(
 			"checking tool_call for %s/%s: %w",

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -979,8 +979,8 @@ func (db *DB) WriteSessionIncremental(
 		return err
 	}
 	for _, link := range update.SubagentLinks {
-		if err := setToolCallSubagentSessionTx(
-			tx, sessionID, link.ToolUseID, link.SubagentSessionID,
+		if err := applyToolCallSubagentLinkTx(
+			tx, sessionID, link, update.BlockedResultCategories,
 		); err != nil {
 			return err
 		}
@@ -2074,55 +2074,65 @@ func (db *DB) SetToolCallSubagentSession(
 		return fmt.Errorf("beginning subagent linkage tx: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
-	if err := setToolCallSubagentSessionTx(
-		tx, sessionID, toolUseID, subagentSessionID,
+	if err := applyToolCallSubagentLinkTx(
+		tx, sessionID, ToolCallSubagentLink{
+			ToolUseID:         toolUseID,
+			SubagentSessionID: subagentSessionID,
+		}, nil,
 	); err != nil {
 		return err
 	}
 	return tx.Commit()
 }
 
-func setToolCallSubagentSessionTx(
-	tx *sql.Tx, sessionID, toolUseID, subagentSessionID string,
+func applyToolCallSubagentLinkTx(
+	tx *sql.Tx, sessionID string, link ToolCallSubagentLink,
+	blockedResultCategories map[string]bool,
 ) error {
-	result, err := tx.Exec(
-		`UPDATE tool_calls
-		 SET subagent_session_id = ?
-		 WHERE session_id = ? AND tool_use_id = ?
-		   AND COALESCE(subagent_session_id, '') = ''
-		   AND (category = 'Task' OR instr(tool_name, 'subagent') > 0)`,
-		subagentSessionID, sessionID, toolUseID,
-	)
-	if err != nil {
-		return fmt.Errorf(
-			"updating subagent_session_id for %s/%s: %w",
-			sessionID, toolUseID, err,
-		)
-	}
-	affected, err := result.RowsAffected()
-	if err != nil || affected > 0 {
-		return err
-	}
-
-	var exists int
+	var toolName, category, currentSubagent string
 	if err := tx.QueryRow(
-		`SELECT COUNT(*)
+		`SELECT tool_name, category, COALESCE(subagent_session_id, '')
 		 FROM tool_calls
 		 WHERE session_id = ? AND tool_use_id = ?`,
-		sessionID, toolUseID,
-	).Scan(&exists); err != nil {
+		sessionID, link.ToolUseID,
+	).Scan(&toolName, &category, &currentSubagent); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf(
+				"tool_call not found for session %s tool_use_id %s",
+				sessionID, link.ToolUseID,
+			)
+		}
 		return fmt.Errorf(
 			"checking tool_call for %s/%s: %w",
-			sessionID, toolUseID, err,
+			sessionID, link.ToolUseID, err,
 		)
 	}
-	if exists == 0 {
-		return fmt.Errorf(
-			"tool_call not found for session %s tool_use_id %s",
-			sessionID, toolUseID,
-		)
+	if currentSubagent == "" &&
+		(category == "Task" || strings.Contains(toolName, "subagent")) {
+		currentSubagent = link.SubagentSessionID
 	}
-	return nil
+
+	if !link.HasResult {
+		_, err := tx.Exec(
+			`UPDATE tool_calls SET subagent_session_id = ?
+			 WHERE session_id = ? AND tool_use_id = ?`,
+			currentSubagent, sessionID, link.ToolUseID,
+		)
+		return err
+	}
+	resultContent := link.ResultContent
+	if blockedResultCategories[category] {
+		resultContent = ""
+	}
+	_, err := tx.Exec(
+		`UPDATE tool_calls
+		 SET subagent_session_id = ?, result_content_length = ?,
+		     result_content = ?
+		 WHERE session_id = ? AND tool_use_id = ?`,
+		currentSubagent, link.ResultContentLen, resultContent,
+		sessionID, link.ToolUseID,
+	)
+	return err
 }
 
 // SystemMessageFingerprint returns the ordered, comma-separated list of

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -2116,7 +2116,7 @@ func applyToolCallSubagentLinkTx(
 		_, err := tx.Exec(
 			`UPDATE tool_calls SET subagent_session_id = ?
 			 WHERE session_id = ? AND tool_use_id = ?`,
-			currentSubagent, sessionID, link.ToolUseID,
+			nilIfEmpty(currentSubagent), sessionID, link.ToolUseID,
 		)
 		return err
 	}
@@ -2129,7 +2129,7 @@ func applyToolCallSubagentLinkTx(
 		 SET subagent_session_id = ?, result_content_length = ?,
 		     result_content = ?
 		 WHERE session_id = ? AND tool_use_id = ?`,
-		currentSubagent, link.ResultContentLen, resultContent,
+		nilIfEmpty(currentSubagent), link.ResultContentLen, resultContent,
 		sessionID, link.ToolUseID,
 	)
 	return err

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -2089,8 +2089,9 @@ func setToolCallSubagentSessionTx(
 		`UPDATE tool_calls
 		 SET subagent_session_id = ?
 		 WHERE session_id = ? AND tool_use_id = ?
-		   AND COALESCE(subagent_session_id, '') != ?`,
-		subagentSessionID, sessionID, toolUseID, subagentSessionID,
+		   AND COALESCE(subagent_session_id, '') = ''
+		   AND (category = 'Task' OR instr(tool_name, 'subagent') > 0)`,
+		subagentSessionID, sessionID, toolUseID,
 	)
 	if err != nil {
 		return fmt.Errorf(

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -978,6 +978,13 @@ func (db *DB) WriteSessionIncremental(
 	if err := writeMessagesTx(tx, msgs); err != nil {
 		return err
 	}
+	for _, link := range update.SubagentLinks {
+		if err := setToolCallSubagentSessionTx(
+			tx, sessionID, link.ToolUseID, link.SubagentSessionID,
+		); err != nil {
+			return err
+		}
+	}
 	if err := updateSessionIncrementalTx(tx, sessionID, update); err != nil {
 		return err
 	}
@@ -2062,7 +2069,23 @@ func (db *DB) SetToolCallSubagentSession(
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
-	result, err := db.getWriter().Exec(
+	tx, err := db.getWriter().Begin()
+	if err != nil {
+		return fmt.Errorf("beginning subagent linkage tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := setToolCallSubagentSessionTx(
+		tx, sessionID, toolUseID, subagentSessionID,
+	); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func setToolCallSubagentSessionTx(
+	tx *sql.Tx, sessionID, toolUseID, subagentSessionID string,
+) error {
+	result, err := tx.Exec(
 		`UPDATE tool_calls
 		 SET subagent_session_id = ?
 		 WHERE session_id = ? AND tool_use_id = ?
@@ -2081,7 +2104,7 @@ func (db *DB) SetToolCallSubagentSession(
 	}
 
 	var exists int
-	if err := db.getReader().QueryRow(
+	if err := tx.QueryRow(
 		`SELECT COUNT(*)
 		 FROM tool_calls
 		 WHERE session_id = ? AND tool_use_id = ?`,

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -1763,6 +1763,12 @@ type IncrementalSessionUpdate struct {
 	PeakContextTokens    int
 	HasTotalOutputTokens bool
 	HasPeakContextTokens bool
+	SubagentLinks        []ToolCallSubagentLink
+}
+
+type ToolCallSubagentLink struct {
+	ToolUseID         string
+	SubagentSessionID string
 }
 
 // GetSessionForIncremental returns session state needed for

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -1750,25 +1750,29 @@ type IncrementalInfo struct {
 }
 
 type IncrementalSessionUpdate struct {
-	EndedAt              *string
-	TerminationStatus    *string
-	MsgCount             int
-	UserMsgCount         int
-	FileSize             int64
-	FileMtime            int64
-	FileHash             *string
-	NextOrdinal          int
-	LastEntryUUID        string
-	TotalOutputTokens    int
-	PeakContextTokens    int
-	HasTotalOutputTokens bool
-	HasPeakContextTokens bool
-	SubagentLinks        []ToolCallSubagentLink
+	EndedAt                 *string
+	TerminationStatus       *string
+	MsgCount                int
+	UserMsgCount            int
+	FileSize                int64
+	FileMtime               int64
+	FileHash                *string
+	NextOrdinal             int
+	LastEntryUUID           string
+	TotalOutputTokens       int
+	PeakContextTokens       int
+	HasTotalOutputTokens    bool
+	HasPeakContextTokens    bool
+	SubagentLinks           []ToolCallSubagentLink
+	BlockedResultCategories map[string]bool
 }
 
 type ToolCallSubagentLink struct {
 	ToolUseID         string
 	SubagentSessionID string
+	ResultContent     string
+	ResultContentLen  int
+	HasResult         bool
 }
 
 // GetSessionForIncremental returns session state needed for

--- a/internal/db/validate.go
+++ b/internal/db/validate.go
@@ -224,6 +224,14 @@ func sanitizeToolCallContent(
 	}
 }
 
+// SanitizeToolCall applies the parser-derived content contract to one tool
+// call that is being updated outside a normal message write.
+func SanitizeToolCall(tc *ToolCall) ValidationStats {
+	var stats ValidationStats
+	sanitizeToolCallContent(tc, &stats)
+	return stats
+}
+
 // SanitizeUsageEvent applies the contract to a single usage event row.
 func SanitizeUsageEvent(ev *UsageEvent) ValidationStats {
 	var stats ValidationStats

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -384,6 +384,8 @@ var ErrClaudeIncrementalNeedsFullParse = fmt.Errorf(
 type ClaudeSubagentLink struct {
 	ToolUseID         string
 	SubagentSessionID string
+	ResultContentRaw  string
+	ResultContentLen  int
 }
 
 func claudeParseSessionFrom(
@@ -1064,28 +1066,30 @@ func extractToolResultAgentIDLink(line string) (ClaudeSubagentLink, bool) {
 	if !content.IsArray() {
 		return ClaudeSubagentLink{}, false
 	}
-	var toolUseID string
+	var toolResult ParsedToolResult
 	content.ForEach(func(_, block gjson.Result) bool {
 		if block.Get("type").Str != "tool_result" {
 			return true
 		}
-		tuid := block.Get("tool_use_id").Str
-		if tuid == "" {
+		result, ok := parseToolResult(block)
+		if !ok {
 			return true
 		}
-		if toolUseID != "" {
-			toolUseID = ""
+		if toolResult.ToolUseID != "" {
+			toolResult = ParsedToolResult{}
 			return false
 		}
-		toolUseID = tuid
+		toolResult = result
 		return true
 	})
-	if toolUseID == "" {
+	if toolResult.ToolUseID == "" {
 		return ClaudeSubagentLink{}, false
 	}
 	return ClaudeSubagentLink{
-		ToolUseID:         toolUseID,
+		ToolUseID:         toolResult.ToolUseID,
 		SubagentSessionID: sessionID,
+		ResultContentRaw:  toolResult.ContentRaw,
+		ResultContentLen:  toolResult.ContentLength,
 	}, true
 }
 

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -376,18 +376,22 @@ var ErrDAGDetected = fmt.Errorf(
 
 // ErrClaudeIncrementalNeedsFullParse signals that appended Claude
 // lines contain content the incremental path cannot stitch into
-// already-stored rows (subagent linkage updates from
-// toolUseResult.agentId, or same-message.id chunk merging).
+// already-stored rows (currently same-message.id chunk merging).
 var ErrClaudeIncrementalNeedsFullParse = fmt.Errorf(
 	"incremental parse: appended Claude lines require full parse",
 )
+
+type ClaudeSubagentLink struct {
+	ToolUseID         string
+	SubagentSessionID string
+}
 
 func claudeParseSessionFrom(
 	path string,
 	offset int64,
 	startOrdinal int,
 	lastEntryUUID string,
-) ([]ParsedMessage, time.Time, int64, error) {
+) ([]ParsedMessage, []ClaudeSubagentLink, time.Time, int64, error) {
 	var (
 		entries        []dagEntry
 		queuedCommands []claudeQueuedCommand
@@ -472,7 +476,7 @@ func claudeParseSessionFrom(
 		},
 	)
 	if err != nil {
-		return nil, time.Time{}, 0, fmt.Errorf(
+		return nil, nil, time.Time{}, 0, fmt.Errorf(
 			"reading claude %s from offset %d: %w",
 			path, offset, err,
 		)
@@ -482,33 +486,33 @@ func claudeParseSessionFrom(
 	// the empty-entries early return below would silently succeed. Check
 	// first and force a full parse so the display name is persisted.
 	if sawRename {
-		return nil, time.Time{}, 0, ErrClaudeIncrementalNeedsFullParse
+		return nil, nil, time.Time{}, 0, ErrClaudeIncrementalNeedsFullParse
 	}
 
 	// Queue/progress events can repair subagent linkage on an already-stored
 	// tool call. If the mapped tool_use_id is not introduced in this append,
 	// incremental parsing would advance file_size without updating that row.
 	if needsClaudeFullParseForSubagentMap(entries, subagentMap) {
-		return nil, time.Time{}, 0, ErrClaudeIncrementalNeedsFullParse
+		return nil, nil, time.Time{}, 0, ErrClaudeIncrementalNeedsFullParse
 	}
 
 	if len(entries) == 0 && len(queuedCommands) == 0 {
-		return nil, latestTS, consumed, nil
+		return nil, nil, latestTS, consumed, nil
 	}
 
 	// Detect forks: if any entry's parentUuid doesn't
 	// match the previous entry's uuid, the appended data
 	// contains a branch that requires full DAG processing.
 	if hasDAGFork(entries, lastEntryUUID) {
-		return nil, time.Time{}, 0, ErrDAGDetected
+		return nil, nil, time.Time{}, 0, ErrDAGDetected
 	}
 
-	// Subagent linkage updates (toolUseResult.agentId) and
-	// same-message.id chunk merging both need state the full
-	// parser builds across the whole file. Bail to a full parse
-	// when appended lines contain either.
+	links := collectClaudeSubagentLinks(entries)
+
+	// same-message.id chunk merging still needs state the full parser
+	// builds across the whole file.
 	if needsClaudeFullParse(entries) {
-		return nil, time.Time{}, 0,
+		return nil, nil, time.Time{}, 0,
 			ErrClaudeIncrementalNeedsFullParse
 	}
 
@@ -532,22 +536,19 @@ func claudeParseSessionFrom(
 	if latestTS.After(endedAt) {
 		endedAt = latestTS
 	}
-	return msgs, endedAt, consumed, nil
+	return msgs, links, endedAt, consumed, nil
 }
 
 // needsClaudeFullParse returns true when appended entries contain
-// either a tool_result with toolUseResult.agentId (whose linkage
-// must update an already-stored tool_call row) or a consecutive
-// same-message.id assistant run (whose chunks the full parser
-// merges into one message). Both cases require a full re-parse.
+// a consecutive same-message.id assistant run whose chunks the full
+// parser merges into one message, or a tool_result that still refers to
+// a tool_use outside this append without a typed incremental linkage path.
 func needsClaudeFullParse(entries []dagEntry) bool {
 	toolUseIDs := make(map[string]struct{})
 	var prevAssistantMID string
 	for _, e := range entries {
 		if e.entryType == "user" {
-			if gjson.Get(e.line, "toolUseResult.agentId").Str != "" {
-				return true
-			}
+			link, hasLink := extractToolResultAgentIDLink(e.line)
 			content := gjson.Get(e.line, "message.content")
 			if content.IsArray() {
 				unmatched := false
@@ -559,7 +560,8 @@ func needsClaudeFullParse(entries []dagEntry) bool {
 					if toolUseID == "" {
 						return true
 					}
-					if _, ok := toolUseIDs[toolUseID]; !ok {
+					if _, ok := toolUseIDs[toolUseID]; !ok &&
+						(!hasLink || toolUseID != link.ToolUseID) {
 						unmatched = true
 						return false
 					}
@@ -593,6 +595,26 @@ func needsClaudeFullParse(entries []dagEntry) bool {
 		prevAssistantMID = ""
 	}
 	return false
+}
+
+func collectClaudeSubagentLinks(entries []dagEntry) []ClaudeSubagentLink {
+	seen := make(map[string]struct{})
+	links := make([]ClaudeSubagentLink, 0, len(entries))
+	for _, entry := range entries {
+		if entry.entryType != "user" {
+			continue
+		}
+		link, ok := extractToolResultAgentIDLink(entry.line)
+		if !ok {
+			continue
+		}
+		if _, exists := seen[link.ToolUseID]; exists {
+			continue
+		}
+		seen[link.ToolUseID] = struct{}{}
+		links = append(links, link)
+	}
+	return links
 }
 
 func needsClaudeFullParseForSubagentMap(
@@ -1019,9 +1041,19 @@ func parseDAG(
 }
 
 func collectToolResultAgentID(line string, subagentMap map[string]string) {
+	link, ok := extractToolResultAgentIDLink(line)
+	if !ok {
+		return
+	}
+	if _, exists := subagentMap[link.ToolUseID]; !exists {
+		subagentMap[link.ToolUseID] = link.SubagentSessionID
+	}
+}
+
+func extractToolResultAgentIDLink(line string) (ClaudeSubagentLink, bool) {
 	agentID := gjson.Get(line, "toolUseResult.agentId").Str
 	if agentID == "" {
-		return
+		return ClaudeSubagentLink{}, false
 	}
 	sessionID := agentID
 	if !strings.HasPrefix(sessionID, "agent-") {
@@ -1030,7 +1062,7 @@ func collectToolResultAgentID(line string, subagentMap map[string]string) {
 
 	content := gjson.Get(line, "message.content")
 	if !content.IsArray() {
-		return
+		return ClaudeSubagentLink{}, false
 	}
 	var toolUseID string
 	content.ForEach(func(_, block gjson.Result) bool {
@@ -1049,11 +1081,12 @@ func collectToolResultAgentID(line string, subagentMap map[string]string) {
 		return true
 	})
 	if toolUseID == "" {
-		return
+		return ClaudeSubagentLink{}, false
 	}
-	if _, exists := subagentMap[toolUseID]; !exists {
-		subagentMap[toolUseID] = sessionID
-	}
+	return ClaudeSubagentLink{
+		ToolUseID:         toolUseID,
+		SubagentSessionID: sessionID,
+	}, true
 }
 
 // extractQueuedCommand parses a Claude Code attachment entry and

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -600,7 +600,6 @@ func needsClaudeFullParse(entries []dagEntry) bool {
 }
 
 func collectClaudeSubagentLinks(entries []dagEntry) []ClaudeSubagentLink {
-	seen := make(map[string]struct{})
 	links := make([]ClaudeSubagentLink, 0, len(entries))
 	for _, entry := range entries {
 		if entry.entryType != "user" {
@@ -610,10 +609,6 @@ func collectClaudeSubagentLinks(entries []dagEntry) []ClaudeSubagentLink {
 		if !ok {
 			continue
 		}
-		if _, exists := seen[link.ToolUseID]; exists {
-			continue
-		}
-		seen[link.ToolUseID] = struct{}{}
 		links = append(links, link)
 	}
 	return links

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -386,6 +386,7 @@ type ClaudeSubagentLink struct {
 	SubagentSessionID string
 	ResultContentRaw  string
 	ResultContentLen  int
+	HasResult         bool
 }
 
 func claudeParseSessionFrom(
@@ -608,6 +609,11 @@ func collectClaudeSubagentLinks(entries []dagEntry) []ClaudeSubagentLink {
 		link, ok := extractToolResultAgentIDLink(entry.line)
 		if !ok {
 			continue
+		}
+		if gjson.Get(entry.line, "isMeta").Bool() {
+			link.ResultContentRaw = ""
+			link.ResultContentLen = 0
+			link.HasResult = false
 		}
 		links = append(links, link)
 	}
@@ -1085,6 +1091,7 @@ func extractToolResultAgentIDLink(line string) (ClaudeSubagentLink, bool) {
 		SubagentSessionID: sessionID,
 		ResultContentRaw:  toolResult.ContentRaw,
 		ResultContentLen:  toolResult.ContentLength,
+		HasResult:         true,
 	}, true
 }
 

--- a/internal/parser/claude_parser_test.go
+++ b/internal/parser/claude_parser_test.go
@@ -31,6 +31,15 @@ func runClaudeParserTest(t *testing.T, fileName, content string) (ParsedSession,
 func callParseClaudeSessionFrom(
 	path string, offset int64, startOrdinal int, lastEntryUUID string,
 ) ([]ParsedMessage, time.Time, int64, error) {
+	msgs, _, endedAt, consumed, err := callParseClaudeSessionFromWithLinks(
+		path, offset, startOrdinal, lastEntryUUID,
+	)
+	return msgs, endedAt, consumed, err
+}
+
+func callParseClaudeSessionFromWithLinks(
+	path string, offset int64, startOrdinal int, lastEntryUUID string,
+) ([]ParsedMessage, []ClaudeSubagentLink, time.Time, int64, error) {
 	fn := reflect.ValueOf(claudeParseSessionFrom)
 	args := []reflect.Value{
 		reflect.ValueOf(path),
@@ -46,14 +55,26 @@ func callParseClaudeSessionFrom(
 	if !out[0].IsNil() {
 		msgs = out[0].Interface().([]ParsedMessage)
 	}
-	endedAt := out[1].Interface().(time.Time)
-	consumed := out[2].Interface().(int64)
+	var links []ClaudeSubagentLink
+	endedIdx := 1
+	consumedIdx := 2
+	errIdx := 3
+	if len(out) == 5 {
+		if !out[1].IsNil() {
+			links = out[1].Interface().([]ClaudeSubagentLink)
+		}
+		endedIdx = 2
+		consumedIdx = 3
+		errIdx = 4
+	}
+	endedAt := out[endedIdx].Interface().(time.Time)
+	consumed := out[consumedIdx].Interface().(int64)
 
 	var err error
-	if !out[3].IsNil() {
-		err = out[3].Interface().(error)
+	if !out[errIdx].IsNil() {
+		err = out[errIdx].Interface().(error)
 	}
-	return msgs, endedAt, consumed, err
+	return msgs, links, endedAt, consumed, err
 }
 
 // TestParseClaudeSession_UsageProbe verifies that sessions whose only
@@ -910,11 +931,10 @@ func TestParseClaudeSessionFrom_LinearUUID(
 	assert.False(t, endedAt.IsZero())
 }
 
-// Appended user entry carries toolUseResult.agentId, which the
-// incremental path can't propagate to an already-stored tool_call
-// row. ParseClaudeSessionFrom must signal full-parse fallback so
-// the engine re-parses the whole session.
-func TestParseClaudeSessionFrom_ToolUseResultAgentIDFallsBack(
+// Appended user entry carries toolUseResult.agentId. The incremental
+// parser should return a typed linkage effect while still parsing the
+// appended user message.
+func TestParseClaudeSessionFrom_ToolUseResultAgentIDLinksIncrementally(
 	t *testing.T,
 ) {
 	t.Parallel()
@@ -947,9 +967,14 @@ func TestParseClaudeSessionFrom_ToolUseResultAgentIDFallsBack(
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	_, _, _, err = callParseClaudeSessionFrom(path, offset, 1, "")
-	assert.ErrorIs(t, err, ErrClaudeIncrementalNeedsFullParse)
-	assert.True(t, IsIncrementalFullParseFallback(err))
+	newMsgs, links, _, _, err := callParseClaudeSessionFromWithLinks(
+		path, offset, 1, "",
+	)
+	require.NoError(t, err)
+	assert.Len(t, newMsgs, 1)
+	require.Len(t, links, 1)
+	assert.Equal(t, "toolu_x", links[0].ToolUseID)
+	assert.Equal(t, "agent-abc123", links[0].SubagentSessionID)
 }
 
 func TestParseClaudeSession_ResolvesPersistedToolResultOutput(

--- a/internal/parser/claude_provider.go
+++ b/internal/parser/claude_provider.go
@@ -173,6 +173,7 @@ func (p *claudeProvider) ParseIncremental(
 		if consumed > 0 {
 			return IncrementalOutcome{
 				SessionID:     req.SessionID,
+				SubagentLinks: links,
 				EndedAt:       endedAt,
 				ConsumedBytes: consumed,
 			}, IncrementalApplied, nil

--- a/internal/parser/claude_provider.go
+++ b/internal/parser/claude_provider.go
@@ -156,7 +156,7 @@ func (p *claudeProvider) ParseIncremental(
 	if req.Fingerprint.Size == req.Offset {
 		return IncrementalOutcome{}, IncrementalNoNewData, nil
 	}
-	newMsgs, endedAt, consumed, err := claudeParseSessionFrom(
+	newMsgs, links, endedAt, consumed, err := claudeParseSessionFrom(
 		path,
 		req.Offset,
 		req.StartOrdinal,
@@ -183,6 +183,7 @@ func (p *claudeProvider) ParseIncremental(
 	return IncrementalOutcome{
 		SessionID:            req.SessionID,
 		Messages:             newMsgs,
+		SubagentLinks:        links,
 		EndedAt:              endedAt,
 		ConsumedBytes:        consumed,
 		MessageCount:         len(newMsgs),

--- a/internal/parser/claude_provider_test.go
+++ b/internal/parser/claude_provider_test.go
@@ -311,6 +311,8 @@ func TestClaudeProviderParseIncrementalPreservesLinkWithoutMessage(t *testing.T)
 	assert.Equal(t, []ClaudeSubagentLink{{
 		ToolUseID:         "toolu_link_only",
 		SubagentSessionID: "agent-linkonly",
+		ResultContentRaw:  `"done"`,
+		ResultContentLen:  len("done"),
 	}}, outcome.SubagentLinks)
 }
 

--- a/internal/parser/claude_provider_test.go
+++ b/internal/parser/claude_provider_test.go
@@ -267,6 +267,53 @@ func TestClaudeProviderParseIncremental(t *testing.T) {
 	assert.Contains(t, outcome.Messages[1].Content, "got it")
 }
 
+func TestClaudeProviderParseIncrementalPreservesLinkWithoutMessage(t *testing.T) {
+	root := t.TempDir()
+	sourcePath := filepath.Join(root, "-Users-dev-code-demo", "inc-link-only.jsonl")
+	initial := claudeProviderFixture("hello world")
+	writeSourceFile(t, sourcePath, initial)
+
+	appended := `{"type":"user","isMeta":true,"timestamp":"2024-01-01T10:00:05Z","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_link_only","content":"done"}]},"toolUseResult":{"status":"completed","agentId":"linkonly"}}` + "\n"
+	f, err := os.OpenFile(sourcePath, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.WriteString(appended)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	provider, ok := NewProvider(AgentClaude, ProviderConfig{
+		Roots:   []string{root},
+		Machine: "devbox",
+	})
+	require.True(t, ok)
+	source, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
+		RawSessionID: "inc-link-only",
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	outcome, status, err := provider.ParseIncremental(
+		context.Background(),
+		IncrementalRequest{
+			Source: source,
+			Fingerprint: SourceFingerprint{
+				Key:  sourcePath,
+				Size: int64(len(initial) + len(appended)),
+			},
+			SessionID:    "inc-link-only",
+			Offset:       int64(len(initial)),
+			StartOrdinal: 2,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, IncrementalApplied, status)
+	assert.Empty(t, outcome.Messages)
+	assert.Equal(t, int64(len(appended)), outcome.ConsumedBytes)
+	assert.Equal(t, []ClaudeSubagentLink{{
+		ToolUseID:         "toolu_link_only",
+		SubagentSessionID: "agent-linkonly",
+	}}, outcome.SubagentLinks)
+}
+
 func TestClaudeProviderParseIncrementalTruncatedNeedsFullParse(t *testing.T) {
 	root := t.TempDir()
 	sourcePath := filepath.Join(root, "-Users-dev-code-demo", "truncated.jsonl")

--- a/internal/parser/claude_provider_test.go
+++ b/internal/parser/claude_provider_test.go
@@ -311,8 +311,6 @@ func TestClaudeProviderParseIncrementalPreservesLinkWithoutMessage(t *testing.T)
 	assert.Equal(t, []ClaudeSubagentLink{{
 		ToolUseID:         "toolu_link_only",
 		SubagentSessionID: "agent-linkonly",
-		ResultContentRaw:  `"done"`,
-		ResultContentLen:  len("done"),
 	}}, outcome.SubagentLinks)
 }
 

--- a/internal/parser/provider.go
+++ b/internal/parser/provider.go
@@ -367,6 +367,7 @@ type IncrementalRequest struct {
 type IncrementalOutcome struct {
 	SessionID            string
 	Messages             []ParsedMessage
+	SubagentLinks        []ClaudeSubagentLink
 	EndedAt              time.Time
 	ConsumedBytes        int64
 	MessageCount         int

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -3667,6 +3667,7 @@ type incrementalUpdate struct {
 	machine              string
 	cwd                  string
 	msgs                 []parser.ParsedMessage
+	links                []parser.ClaudeSubagentLink
 	endedAt              time.Time
 	terminationStatus    *string
 	msgCount             int // total (old + new)
@@ -5171,7 +5172,7 @@ func (e *Engine) tryProviderIncrementalAppend(
 	parseFn := func(
 		_ string, sessionID string, offset int64,
 		startOrdinal int, lastEntryUUID string,
-	) ([]parser.ParsedMessage, time.Time, int64, *string, error) {
+	) ([]parser.ParsedMessage, []parser.ClaudeSubagentLink, time.Time, int64, *string, error) {
 		outcome, status, perr := provider.ParseIncremental(
 			ctx,
 			parser.IncrementalRequest{
@@ -5185,30 +5186,30 @@ func (e *Engine) tryProviderIncrementalAppend(
 			},
 		)
 		if perr != nil {
-			return nil, time.Time{}, 0, nil, perr
+			return nil, nil, time.Time{}, 0, nil, perr
 		}
 		switch status {
 		case parser.IncrementalNeedsFullParse:
 			if outcome.ForceReplace {
 				// Signal the shared helper to fall back to a
 				// full parse that replaces stored messages.
-				return nil, time.Time{}, 0, nil,
+				return nil, nil, time.Time{}, 0, nil,
 					parser.ErrClaudeIncrementalNeedsFullParse
 			}
 			// A plain full-parse fallback (e.g. DAG detected):
 			// return a non-fallback error so the helper runs a
 			// normal full parse without forceReplace.
-			return nil, time.Time{}, 0, nil, parser.ErrDAGDetected
+			return nil, nil, time.Time{}, 0, nil, parser.ErrDAGDetected
 		case parser.IncrementalNoNewData:
-			return nil, time.Time{}, 0, nil, nil
+			return nil, nil, time.Time{}, 0, nil, nil
 		default:
 			var terminationStatus *string
 			if outcome.TerminationStatus != nil {
 				status := string(*outcome.TerminationStatus)
 				terminationStatus = &status
 			}
-			return outcome.Messages, outcome.EndedAt,
-				outcome.ConsumedBytes, terminationStatus, nil
+			return outcome.Messages, outcome.SubagentLinks,
+				outcome.EndedAt, outcome.ConsumedBytes, terminationStatus, nil
 		}
 	}
 
@@ -5224,7 +5225,7 @@ func (e *Engine) tryProviderIncrementalAppend(
 type incrementalParseFunc func(
 	path string, sessionID string, offset int64,
 	startOrdinal int, lastEntryUUID string,
-) ([]parser.ParsedMessage, time.Time, int64, *string, error)
+) ([]parser.ParsedMessage, []parser.ClaudeSubagentLink, time.Time, int64, *string, error)
 
 // tryIncrementalJSONL attempts an incremental parse of an
 // append-only JSONL file by reading only bytes appended since
@@ -5347,7 +5348,7 @@ func (e *Engine) tryIncrementalJSONL(
 		incMtime = parser.CodexEffectiveMtime(file.Path, incMtime)
 	}
 
-	newMsgs, endedAt, consumed, terminationStatus, err := parseFn(
+	newMsgs, links, endedAt, consumed, terminationStatus, err := parseFn(
 		file.Path, inc.ID, inc.FileSize, inc.NextOrdinal, inc.LastEntryUUID,
 	)
 	if err != nil {
@@ -5401,6 +5402,7 @@ func (e *Engine) tryIncrementalJSONL(
 					project:              inc.Project,
 					machine:              inc.Machine,
 					cwd:                  inc.Cwd,
+					links:                links,
 					endedAt:              endedAt,
 					terminationStatus:    terminationStatus,
 					msgCount:             inc.MsgCount,
@@ -5490,6 +5492,7 @@ func (e *Engine) tryIncrementalJSONL(
 			machine:              inc.Machine,
 			cwd:                  inc.Cwd,
 			msgs:                 newMsgs,
+			links:                links,
 			endedAt:              endedAt,
 			terminationStatus:    terminationStatus,
 			msgCount:             inc.MsgCount + len(newMsgs),
@@ -7469,6 +7472,17 @@ func (e *Engine) writeIncremental(
 	// clamped rows. The sum itself is not clamped to the per-message bound,
 	// since a long session legitimately exceeds it.
 	endedAt, _ = blankImplausibleTimestampPtr(endedAt)
+
+	for _, link := range inc.links {
+		if err := e.db.SetToolCallSubagentSession(
+			inc.sessionID, link.ToolUseID, link.SubagentSessionID,
+		); err != nil {
+			return fmt.Errorf(
+				"incremental subagent linkage %s %s: %w",
+				inc.sessionID, link.ToolUseID, err,
+			)
+		}
+	}
 
 	if err := e.db.WriteSessionIncremental(
 		inc.sessionID,

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -7476,8 +7476,13 @@ func (e *Engine) writeIncremental(
 	subagentLinks := make([]db.ToolCallSubagentLink, len(inc.links))
 	for i, link := range inc.links {
 		subagentLinks[i] = db.ToolCallSubagentLink{
-			ToolUseID:         link.ToolUseID,
-			SubagentSessionID: link.SubagentSessionID,
+			ToolUseID: link.ToolUseID,
+			SubagentSessionID: applyIDPrefixToID(
+				e.idPrefix, link.SubagentSessionID,
+			),
+			ResultContent:    parser.DecodeContent(link.ResultContentRaw),
+			ResultContentLen: link.ResultContentLen,
+			HasResult:        true,
 		}
 	}
 
@@ -7485,20 +7490,21 @@ func (e *Engine) writeIncremental(
 		inc.sessionID,
 		dbMsgs,
 		db.IncrementalSessionUpdate{
-			EndedAt:              endedAt,
-			TerminationStatus:    inc.terminationStatus,
-			MsgCount:             msgCount,
-			UserMsgCount:         userMsgCount,
-			FileSize:             inc.fileSize,
-			FileMtime:            inc.fileMtime,
-			FileHash:             strPtr(inc.fileHash),
-			NextOrdinal:          inc.nextOrdinal,
-			LastEntryUUID:        inc.lastEntryUUID,
-			TotalOutputTokens:    inc.totalOutputTokens,
-			PeakContextTokens:    inc.peakContextTokens,
-			HasTotalOutputTokens: inc.hasTotalOutputTokens,
-			HasPeakContextTokens: inc.hasPeakContextTokens,
-			SubagentLinks:        subagentLinks,
+			EndedAt:                 endedAt,
+			TerminationStatus:       inc.terminationStatus,
+			MsgCount:                msgCount,
+			UserMsgCount:            userMsgCount,
+			FileSize:                inc.fileSize,
+			FileMtime:               inc.fileMtime,
+			FileHash:                strPtr(inc.fileHash),
+			NextOrdinal:             inc.nextOrdinal,
+			LastEntryUUID:           inc.lastEntryUUID,
+			TotalOutputTokens:       inc.totalOutputTokens,
+			PeakContextTokens:       inc.peakContextTokens,
+			HasTotalOutputTokens:    inc.hasTotalOutputTokens,
+			HasPeakContextTokens:    inc.hasPeakContextTokens,
+			SubagentLinks:           subagentLinks,
+			BlockedResultCategories: e.blockedResultCategories,
 		},
 	); err != nil {
 		return fmt.Errorf(

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -7473,14 +7473,11 @@ func (e *Engine) writeIncremental(
 	// since a long session legitimately exceeds it.
 	endedAt, _ = blankImplausibleTimestampPtr(endedAt)
 
-	for _, link := range inc.links {
-		if err := e.db.SetToolCallSubagentSession(
-			inc.sessionID, link.ToolUseID, link.SubagentSessionID,
-		); err != nil {
-			return fmt.Errorf(
-				"incremental subagent linkage %s %s: %w",
-				inc.sessionID, link.ToolUseID, err,
-			)
+	subagentLinks := make([]db.ToolCallSubagentLink, len(inc.links))
+	for i, link := range inc.links {
+		subagentLinks[i] = db.ToolCallSubagentLink{
+			ToolUseID:         link.ToolUseID,
+			SubagentSessionID: link.SubagentSessionID,
 		}
 	}
 
@@ -7501,6 +7498,7 @@ func (e *Engine) writeIncremental(
 			PeakContextTokens:    inc.peakContextTokens,
 			HasTotalOutputTokens: inc.hasTotalOutputTokens,
 			HasPeakContextTokens: inc.hasPeakContextTokens,
+			SubagentLinks:        subagentLinks,
 		},
 	); err != nil {
 		return fmt.Errorf(

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -7487,7 +7487,7 @@ func (e *Engine) writeIncremental(
 			),
 			ResultContent:    toolCall.ResultContent,
 			ResultContentLen: toolCall.ResultContentLength,
-			HasResult:        true,
+			HasResult:        link.HasResult,
 		}
 	}
 

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -7475,13 +7475,18 @@ func (e *Engine) writeIncremental(
 
 	subagentLinks := make([]db.ToolCallSubagentLink, len(inc.links))
 	for i, link := range inc.links {
+		toolCall := db.ToolCall{
+			ResultContent:       parser.DecodeContent(link.ResultContentRaw),
+			ResultContentLength: link.ResultContentLen,
+		}
+		e.anomalies.recordSanitize(db.SanitizeToolCall(&toolCall))
 		subagentLinks[i] = db.ToolCallSubagentLink{
 			ToolUseID: link.ToolUseID,
 			SubagentSessionID: applyIDPrefixToID(
 				e.idPrefix, link.SubagentSessionID,
 			),
-			ResultContent:    parser.DecodeContent(link.ResultContentRaw),
-			ResultContentLen: link.ResultContentLen,
+			ResultContent:    toolCall.ResultContent,
+			ResultContentLen: toolCall.ResultContentLength,
 			HasResult:        true,
 		}
 	}

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -9868,6 +9868,41 @@ func TestIncrementalSync_ClaudeAgentIDMissingToolCallAdvancesCursor(t *testing.T
 	assertSessionMessageCount(t, env.db, "parent-missing-link", 1)
 }
 
+func TestIncrementalSync_ClaudeMetaAgentIDResultMatchesFullParse(t *testing.T) {
+	env := setupTestEnv(t)
+
+	initial := testjsonl.JoinJSONL(
+		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"go"},"cwd":"/tmp"}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"a1","parentUuid":"u1","message":{"content":[{"type":"tool_use","id":"toolu_meta_link","name":"Agent","input":{"description":"d","subagent_type":"Explore","prompt":"p"}}]}}`,
+	)
+	path := env.writeClaudeSession(
+		t, "proj-meta-link", "parent-meta-link.jsonl", initial,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+
+	appended := `{"type":"user","isMeta":true,"timestamp":"2024-01-01T10:00:02Z","uuid":"r1","parentUuid":"a1","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_meta_link","content":"meta-only output"}]},"toolUseResult":{"status":"completed","agentId":"metachild"}}` + "\n"
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err, "open for append")
+	_, writeErr := f.WriteString(appended)
+	require.NoError(t, f.Close(), "close append")
+	require.NoError(t, writeErr, "append")
+
+	env.engine.SyncPaths([]string{path})
+
+	assertToolCall := func(stage string) {
+		msgs := fetchMessages(t, env.db, "parent-meta-link")
+		require.Len(t, msgs, 2, stage)
+		require.Len(t, msgs[1].ToolCalls, 1, stage)
+		assert.Equal(t, "agent-metachild", msgs[1].ToolCalls[0].SubagentSessionID, stage)
+		assert.Empty(t, msgs[1].ToolCalls[0].ResultContent, stage)
+		assert.Zero(t, msgs[1].ToolCalls[0].ResultContentLength, stage)
+	}
+	assertToolCall("incremental parse")
+
+	env.engine.ResyncAll(context.Background(), nil)
+	assertToolCall("full parse")
+}
+
 func TestIncrementalSync_ClaudeCrossSyncToolResultFallback(t *testing.T) {
 	env := setupTestEnv(t)
 

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -9660,6 +9660,51 @@ func TestIncrementalSync_ClaudeAgentIDLinksIncrementally(t *testing.T) {
 	).Scan(&got), "query after append")
 	assert.Equal(t, assistantMessageID, gotMessageID, "assistant message row should remain in place during incremental linkage")
 	assert.Equal(t, "agent-childlate", got.String, "subagent_session_id = %q, want %q", got.String, "agent-childlate")
+	msgs := fetchMessages(t, env.db, "parent-late-link")
+	require.Len(t, msgs, 2)
+	require.Len(t, msgs[1].ToolCalls, 1)
+	assert.Equal(t, "done", msgs[1].ToolCalls[0].ResultContent)
+	assert.Equal(t, len("done"), msgs[1].ToolCalls[0].ResultContentLength)
+}
+
+func TestIncrementalSync_ClaudeAgentIDLinkUsesRemotePrefix(t *testing.T) {
+	claudeDir := t.TempDir()
+	database := dbtest.OpenTestDB(t)
+	env := &testEnv{claudeDir: claudeDir, db: database}
+	env.engine = sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {claudeDir},
+		},
+		Machine:  "host",
+		IDPrefix: "host~",
+	})
+
+	initial := testjsonl.JoinJSONL(
+		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"go"},"cwd":"/tmp"}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"a1","parentUuid":"u1","message":{"content":[{"type":"tool_use","id":"toolu_prefix","name":"Agent","input":{"description":"d","subagent_type":"Explore","prompt":"p"}}]}}`,
+	)
+	path := env.writeClaudeSession(
+		t, "proj-prefix-link", "parent-prefix-link.jsonl", initial,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+
+	toolResult := `{"type":"user","timestamp":"2024-01-01T10:00:02Z","uuid":"r1","parentUuid":"a1","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_prefix","content":"done"}]},"toolUseResult":{"status":"completed","agentId":"childprefix"}}`
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err, "open for append")
+	_, writeErr := f.WriteString(toolResult + "\n")
+	require.NoError(t, f.Close(), "close append")
+	require.NoError(t, writeErr, "append")
+
+	env.engine.SyncPaths([]string{path})
+
+	var got string
+	require.NoError(t, database.Reader().QueryRow(`
+		SELECT subagent_session_id
+		FROM tool_calls
+		WHERE session_id = ? AND tool_use_id = ?`,
+		"host~parent-prefix-link", "toolu_prefix",
+	).Scan(&got), "query prefixed link")
+	assert.Equal(t, "host~agent-childprefix", got)
 }
 
 func TestIncrementalSync_ClaudeAgentIDLinksToolUseFromSameAppend(t *testing.T) {

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -9577,15 +9577,12 @@ func TestIncrementalSync_ClaudeMidStreamSplitFallsBackToFullParse(t *testing.T) 
 	assert.Equal(t, "Hello world", msgs[1].Content, "msgs[1].Content = %q, want exactly %q", msgs[1].Content, "Hello world")
 }
 
-// TestIncrementalSync_ClaudeAgentIDFallbackUpdatesStoredToolCall covers
-// the cross-sync subagent linkage case: the first sync stores an
-// assistant tool_use row with no subagent_session_id, and a later sync
-// appends a tool_result whose toolUseResult.agentId should populate the
-// already-stored tool_call. The parser signals
-// IsIncrementalFullParseFallback, so the full-parse fallback must run
-// with forceReplace=true; otherwise the append-only write path skips
-// the existing row and the linkage is silently dropped.
-func TestIncrementalSync_ClaudeAgentIDFallbackUpdatesStoredToolCall(t *testing.T) {
+// TestIncrementalSync_ClaudeAgentIDLinksIncrementally covers the cross-
+// sync subagent linkage case: the first sync stores an assistant
+// tool_use row with no subagent_session_id, and a later sync appends a
+// tool_result whose toolUseResult.agentId should populate the
+// already-stored tool_call without forcing a full message replacement.
+func TestIncrementalSync_ClaudeAgentIDLinksIncrementally(t *testing.T) {
 	env := setupTestEnv(t)
 
 	parentInitial := testjsonl.JoinJSONL(
@@ -9615,6 +9612,14 @@ func TestIncrementalSync_ClaudeAgentIDFallbackUpdatesStoredToolCall(t *testing.T
 	env.engine.SyncAll(context.Background(), nil)
 
 	// Linkage starts empty (the toolUseResult hasn't appeared yet).
+	var assistantMessageID int64
+	require.NoError(t, env.db.Reader().QueryRow(`
+		SELECT id
+		FROM messages
+		WHERE session_id = ? AND ordinal = 1`,
+		"parent-late-link",
+	).Scan(&assistantMessageID), "query message id before append")
+
 	var got sql.NullString
 	require.NoError(t, env.db.Reader().QueryRow(`
 		SELECT subagent_session_id
@@ -9639,12 +9644,21 @@ func TestIncrementalSync_ClaudeAgentIDFallbackUpdatesStoredToolCall(t *testing.T
 
 	env.engine.SyncPaths([]string{path})
 
+	var gotMessageID int64
+	require.NoError(t, env.db.Reader().QueryRow(`
+		SELECT id
+		FROM messages
+		WHERE session_id = ? AND ordinal = 1`,
+		"parent-late-link",
+	).Scan(&gotMessageID), "query message id after append")
+
 	require.NoError(t, env.db.Reader().QueryRow(`
 		SELECT subagent_session_id
 		FROM tool_calls
 		WHERE session_id = ? AND tool_use_id = ?`,
 		"parent-late-link", "toolu_late",
 	).Scan(&got), "query after append")
+	assert.Equal(t, assistantMessageID, gotMessageID, "assistant message row should remain in place during incremental linkage")
 	assert.Equal(t, "agent-childlate", got.String, "subagent_session_id = %q, want %q", got.String, "agent-childlate")
 }
 

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -9741,6 +9741,38 @@ func TestIncrementalSync_ClaudeAgentIDLinksToolUseFromSameAppend(t *testing.T) {
 	assert.Equal(t, "agent-childsameappend", got.String)
 }
 
+func TestIncrementalSync_ClaudeAgentIDUsesFirstLinkAndLatestResult(t *testing.T) {
+	env := setupTestEnv(t)
+
+	initial := testjsonl.JoinJSONL(
+		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"go"},"cwd":"/tmp"}`,
+	)
+	path := env.writeClaudeSession(
+		t, "proj-multiple-links", "parent-multiple-links.jsonl", initial,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+
+	appended := testjsonl.JoinJSONL(
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"a1","parentUuid":"u1","message":{"content":[{"type":"tool_use","id":"toolu_multiple_links","name":"Agent","input":{"description":"d","subagent_type":"Explore","prompt":"p"}}]}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:02Z","uuid":"r1","parentUuid":"a1","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_multiple_links","content":"partial"}]},"toolUseResult":{"status":"running","agentId":"firstchild"}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:03Z","uuid":"r2","parentUuid":"r1","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_multiple_links","content":"final"}]},"toolUseResult":{"status":"completed","agentId":"laterchild"}}`,
+	)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err, "open for append")
+	_, writeErr := f.WriteString(appended)
+	require.NoError(t, f.Close(), "close append")
+	require.NoError(t, writeErr, "append")
+
+	env.engine.SyncPaths([]string{path})
+
+	msgs := fetchMessages(t, env.db, "parent-multiple-links")
+	require.Len(t, msgs, 2)
+	require.Len(t, msgs[1].ToolCalls, 1)
+	assert.Equal(t, "agent-firstchild", msgs[1].ToolCalls[0].SubagentSessionID)
+	assert.Equal(t, "final", msgs[1].ToolCalls[0].ResultContent)
+	assert.Equal(t, len("final"), msgs[1].ToolCalls[0].ResultContentLength)
+}
+
 func TestIncrementalSync_ClaudeAgentIDPreservesExistingSubagentLink(t *testing.T) {
 	env := setupTestEnv(t)
 

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -9662,6 +9662,40 @@ func TestIncrementalSync_ClaudeAgentIDLinksIncrementally(t *testing.T) {
 	assert.Equal(t, "agent-childlate", got.String, "subagent_session_id = %q, want %q", got.String, "agent-childlate")
 }
 
+func TestIncrementalSync_ClaudeAgentIDLinksToolUseFromSameAppend(t *testing.T) {
+	env := setupTestEnv(t)
+
+	initial := testjsonl.JoinJSONL(
+		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"go"},"cwd":"/tmp"}`,
+	)
+	path := env.writeClaudeSession(
+		t, "proj-same-append-link", "parent-same-append-link.jsonl", initial,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+
+	appended := testjsonl.JoinJSONL(
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"a1","parentUuid":"u1","message":{"id":"msg_one","content":[{"type":"tool_use","id":"toolu_same_append","name":"Agent","input":{"description":"d","subagent_type":"Explore","prompt":"p"}}],"usage":{"input_tokens":1,"output_tokens":1},"stop_reason":"tool_use"}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:02Z","uuid":"r1","parentUuid":"a1","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_same_append","content":"done"}]},"toolUseResult":{"status":"completed","agentId":"childsameappend"}}`,
+	)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err, "open for append")
+	_, writeErr := f.WriteString(appended)
+	require.NoError(t, f.Close(), "close append")
+	require.NoError(t, writeErr, "append")
+
+	env.engine.SyncPaths([]string{path})
+
+	assertSessionMessageCount(t, env.db, "parent-same-append-link", 2)
+	var got sql.NullString
+	require.NoError(t, env.db.Reader().QueryRow(`
+		SELECT subagent_session_id
+		FROM tool_calls
+		WHERE session_id = ? AND tool_use_id = ?`,
+		"parent-same-append-link", "toolu_same_append",
+	).Scan(&got), "query after append")
+	assert.Equal(t, "agent-childsameappend", got.String)
+}
+
 func TestIncrementalSync_ClaudeCrossSyncToolResultFallback(t *testing.T) {
 	env := setupTestEnv(t)
 

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -9696,6 +9696,71 @@ func TestIncrementalSync_ClaudeAgentIDLinksToolUseFromSameAppend(t *testing.T) {
 	assert.Equal(t, "agent-childsameappend", got.String)
 }
 
+func TestIncrementalSync_ClaudeAgentIDPreservesExistingSubagentLink(t *testing.T) {
+	env := setupTestEnv(t)
+
+	initial := testjsonl.JoinJSONL(
+		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"go"},"cwd":"/tmp"}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"a1","parentUuid":"u1","message":{"content":[{"type":"tool_use","id":"toolu_first_link","name":"Agent","input":{"description":"d","subagent_type":"Explore","prompt":"p"}}]}}`,
+		`{"type":"queue-operation","operation":"enqueue","timestamp":"2024-01-01T10:00:02Z","sessionId":"parent-first-link","content":"{\"task_id\":\"queuefirst\",\"tool_use_id\":\"toolu_first_link\",\"description\":\"d\",\"task_type\":\"local_agent\"}"}`,
+	)
+	path := env.writeClaudeSession(
+		t, "proj-first-link", "parent-first-link.jsonl", initial,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+
+	toolResult := `{"type":"user","timestamp":"2024-01-01T10:00:03Z","uuid":"r1","parentUuid":"a1","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_first_link","content":"done"}]},"toolUseResult":{"status":"completed","agentId":"laterresult"}}`
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err, "open for append")
+	_, writeErr := f.WriteString(toolResult + "\n")
+	require.NoError(t, f.Close(), "close append")
+	require.NoError(t, writeErr, "append")
+
+	env.engine.SyncPaths([]string{path})
+
+	var got string
+	require.NoError(t, env.db.Reader().QueryRow(`
+		SELECT subagent_session_id
+		FROM tool_calls
+		WHERE session_id = ? AND tool_use_id = ?`,
+		"parent-first-link", "toolu_first_link",
+	).Scan(&got), "query after append")
+	assert.Equal(t, "agent-queuefirst", got)
+}
+
+func TestIncrementalSync_ClaudeAgentIDDoesNotLinkNonSubagentTool(t *testing.T) {
+	env := setupTestEnv(t)
+
+	initial := testjsonl.JoinJSONL(
+		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"go"},"cwd":"/tmp"}`,
+	)
+	path := env.writeClaudeSession(
+		t, "proj-read-link", "parent-read-link.jsonl", initial,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+
+	appended := testjsonl.JoinJSONL(
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"a1","parentUuid":"u1","message":{"content":[{"type":"tool_use","id":"toolu_read_link","name":"Read","input":{"file_path":"README.md"}}]}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:00:02Z","uuid":"r1","parentUuid":"a1","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_read_link","content":"done"}]},"toolUseResult":{"status":"completed","agentId":"notasubagent"}}`,
+	)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err, "open for append")
+	_, writeErr := f.WriteString(appended)
+	require.NoError(t, f.Close(), "close append")
+	require.NoError(t, writeErr, "append")
+
+	env.engine.SyncPaths([]string{path})
+
+	var got sql.NullString
+	require.NoError(t, env.db.Reader().QueryRow(`
+		SELECT subagent_session_id
+		FROM tool_calls
+		WHERE session_id = ? AND tool_use_id = ?`,
+		"parent-read-link", "toolu_read_link",
+	).Scan(&got), "query after append")
+	assert.False(t, got.Valid)
+}
+
 func TestIncrementalSync_ClaudeCrossSyncToolResultFallback(t *testing.T) {
 	env := setupTestEnv(t)
 

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -9635,7 +9635,7 @@ func TestIncrementalSync_ClaudeAgentIDLinksIncrementally(t *testing.T) {
 	// the existing subagent session. Incremental parse will return
 	// ErrClaudeIncrementalNeedsFullParse so the engine must full-
 	// parse with forceReplace to update the stored tool_call row.
-	toolResult := `{"type":"user","timestamp":"2024-01-01T10:00:02Z","uuid":"r1","parentUuid":"a1","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_late","content":"done"}]},"toolUseResult":{"status":"completed","agentId":"childlate"}}`
+	toolResult := `{"type":"user","timestamp":"2024-01-01T10:00:02Z","uuid":"r1","parentUuid":"a1","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_late","content":"done\u0000\u0001"}]},"toolUseResult":{"status":"completed","agentId":"childlate"}}`
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
 	require.NoError(t, err, "open for append")
 	_, writeErr := f.WriteString(toolResult + "\n")
@@ -9836,6 +9836,36 @@ func TestIncrementalSync_ClaudeAgentIDDoesNotLinkNonSubagentTool(t *testing.T) {
 		"parent-read-link", "toolu_read_link",
 	).Scan(&got), "query after append")
 	assert.False(t, got.Valid)
+}
+
+func TestIncrementalSync_ClaudeAgentIDMissingToolCallAdvancesCursor(t *testing.T) {
+	env := setupTestEnv(t)
+
+	initial := testjsonl.JoinJSONL(
+		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"go"},"cwd":"/tmp"}`,
+	)
+	path := env.writeClaudeSession(
+		t, "proj-missing-link", "parent-missing-link.jsonl", initial,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+
+	appended := `{"type":"user","isMeta":true,"timestamp":"2024-01-01T10:00:01Z","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_missing","content":"done"}]},"toolUseResult":{"status":"completed","agentId":"missingchild"}}` + "\n"
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err, "open for append")
+	_, writeErr := f.WriteString(appended)
+	require.NoError(t, f.Close(), "close append")
+	require.NoError(t, writeErr, "append")
+
+	env.engine.SyncPaths([]string{path})
+
+	info, err := os.Stat(path)
+	require.NoError(t, err, "stat appended transcript")
+	sess, err := env.db.GetSessionFull(context.Background(), "parent-missing-link")
+	require.NoError(t, err, "get session after append")
+	require.NotNil(t, sess.FileSize)
+	assert.Equal(t, info.Size(), *sess.FileSize)
+	assert.True(t, sess.LastWriteIncremental)
+	assertSessionMessageCount(t, env.db, "parent-missing-link", 1)
 }
 
 func TestIncrementalSync_ClaudeCrossSyncToolResultFallback(t *testing.T) {


### PR DESCRIPTION
Claude subagent progress and tool-result appends can arrive after the parent Task call has already been persisted, which made the incremental Claude path fall back to a full JSONL parse for linkage data that should be attachable in place. In subagent-heavy sessions that turns normal watcher activity into repeated reparses of the same large session file, raising daemon CPU and memory use and slowing read commands that should stay cheap.

This change carries subagent linkage through the incremental parser as explicit metadata, lets sync apply it to the existing tool call during the same incremental write path, and keeps the persisted content aligned with the canonical full parser. The update stays inside Claude parsing, incremental sync, and local tool-call persistence; it does not add a schema migration, watcher timing change, CLI shortcut, or backend-specific behavior.

Fixes #1073