### PR TITLE
fix(hermes): export only the requested session transcript

### DIFF
--- a/cmd/agentsview/session_export.go
+++ b/cmd/agentsview/session_export.go
@@ -61,6 +61,15 @@ func newSessionExportCommand() *cobra.Command {
 					"session not in local archive: %s", args[0],
 				)
 			}
+			session, err := d.GetSession(cmd.Context(), id)
+			if err != nil {
+				return err
+			}
+			if session == nil {
+				return fmt.Errorf(
+					"session not in local archive: %s", args[0],
+				)
+			}
 			storedPath := d.GetSessionFilePath(id)
 			if storedPath == "" {
 				return fmt.Errorf(
@@ -132,6 +141,21 @@ func newSessionExportCommand() *cobra.Command {
 				if errors.Is(err, os.ErrNotExist) {
 					return fmt.Errorf(
 						"source file not found: %s", dbPath,
+					)
+				}
+				return err
+			}
+			if session.Agent == string(parser.AgentHermes) &&
+				session.SourceVersion == "hermes-state-db" &&
+				session.SourceSessionID != "" {
+				err := parser.WriteHermesSessionJSONL(
+					cmd.OutOrStdout(),
+					cfg.AgentDirs[parser.AgentHermes],
+					session.SourceSessionID,
+				)
+				if errors.Is(err, os.ErrNotExist) {
+					return fmt.Errorf(
+						"source file not found for session %s", id,
 					)
 				}
 				return err

--- a/cmd/agentsview/session_export.go
+++ b/cmd/agentsview/session_export.go
@@ -150,6 +150,7 @@ func newSessionExportCommand() *cobra.Command {
 				session.SourceSessionID != "" {
 				err := parser.WriteHermesSessionJSONL(
 					cmd.OutOrStdout(),
+					storedPath,
 					cfg.AgentDirs[parser.AgentHermes],
 					session.SourceSessionID,
 				)

--- a/cmd/agentsview/session_export.go
+++ b/cmd/agentsview/session_export.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -146,13 +147,16 @@ func newSessionExportCommand() *cobra.Command {
 				return err
 			}
 			if session.Agent == string(parser.AgentHermes) &&
-				session.SourceVersion == "hermes-state-db" &&
-				session.SourceSessionID != "" {
+				filepath.Base(parser.ResolveSourceFilePath(storedPath)) == "state.db" {
+				rawSessionID := session.SourceSessionID
+				if rawSessionID == "" {
+					rawSessionID, _ = rawHermesSessionID(id)
+				}
 				err := parser.WriteHermesSessionJSONL(
 					cmd.OutOrStdout(),
 					storedPath,
 					cfg.AgentDirs[parser.AgentHermes],
-					session.SourceSessionID,
+					rawSessionID,
 				)
 				if errors.Is(err, os.ErrNotExist) {
 					return fmt.Errorf(
@@ -181,6 +185,16 @@ func newSessionExportCommand() *cobra.Command {
 func rawAiderSessionID(sessionID string) (string, bool) {
 	def, ok := parser.AgentByPrefix(sessionID)
 	if !ok || def.Type != parser.AgentAider {
+		return "", false
+	}
+	_, rawID := parser.StripHostPrefix(sessionID)
+	rawID = strings.TrimPrefix(rawID, def.IDPrefix)
+	return rawID, rawID != ""
+}
+
+func rawHermesSessionID(sessionID string) (string, bool) {
+	def, ok := parser.AgentByPrefix(sessionID)
+	if !ok || def.Type != parser.AgentHermes {
 		return "", false
 	}
 	_, rawID := parser.StripHostPrefix(sessionID)

--- a/cmd/agentsview/session_test.go
+++ b/cmd/agentsview/session_test.go
@@ -1042,6 +1042,31 @@ func TestSessionExportHermesStateDB(t *testing.T) {
 	}
 }
 
+func TestSessionExportHermesStateDBWithoutSourceVersion(t *testing.T) {
+	dataDir := newAgentDataDir(t)
+
+	root := t.TempDir()
+	dbPath := createHermesExportStateDB(t, root)
+
+	seedSessionWithOpts(t, dataDir, "hermes:child", "proj",
+		func(s *db.Session) {
+			s.Agent = string(parser.AgentHermes)
+			s.FilePath = &dbPath
+		})
+
+	out, err := executeCommand(newRootCommand(),
+		"session", "export", "hermes:child")
+	require.NoError(t, err)
+	assert.NotContains(t, out, "SQLite format 3")
+	assert.Contains(t, out, `"role":"session_meta"`)
+	assert.Contains(t, out, "target hermes message")
+	assert.NotContains(t, out, "sibling hermes message")
+
+	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
+		assert.JSONEq(t, line, line)
+	}
+}
+
 func TestSessionExport_AiderVirtualPathStreamsOnlySelectedRun(t *testing.T) {
 	dataDir := newAgentDataDir(t)
 

--- a/cmd/agentsview/session_test.go
+++ b/cmd/agentsview/session_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -947,6 +948,95 @@ func TestSessionExport_StreamsFromDisk(t *testing.T) {
 		"session", "export", "s-1")
 	require.NoError(t, err)
 	assert.Equal(t, body, out)
+}
+
+func createHermesExportStateDB(t *testing.T, root string) string {
+	t.Helper()
+	sessionsDir := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+
+	dbPath := filepath.Join(root, "state.db")
+	conn, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	_, err = conn.Exec(`
+		CREATE TABLE sessions (
+			id TEXT PRIMARY KEY,
+			source TEXT NOT NULL,
+			model TEXT,
+			parent_session_id TEXT,
+			started_at REAL NOT NULL,
+			ended_at REAL,
+			message_count INTEGER DEFAULT 0,
+			input_tokens INTEGER DEFAULT 0,
+			output_tokens INTEGER DEFAULT 0,
+			cache_read_tokens INTEGER DEFAULT 0,
+			cache_write_tokens INTEGER DEFAULT 0,
+			reasoning_tokens INTEGER DEFAULT 0,
+			estimated_cost_usd REAL,
+			actual_cost_usd REAL,
+			cost_status TEXT,
+			cost_source TEXT,
+			title TEXT,
+			api_call_count INTEGER DEFAULT 0
+		);
+		CREATE TABLE messages (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			session_id TEXT NOT NULL,
+			role TEXT NOT NULL,
+			content TEXT,
+			tool_call_id TEXT,
+			tool_calls TEXT,
+			timestamp REAL NOT NULL,
+			finish_reason TEXT,
+			reasoning TEXT,
+			reasoning_content TEXT,
+			reasoning_details TEXT,
+			codex_reasoning_items TEXT,
+			codex_message_items TEXT
+		);
+		INSERT INTO sessions (
+			id, source, model, started_at, ended_at, message_count, title
+		) VALUES
+			('child', 'profile', 'gpt-5.4', 1778767200.0, 1778767800.0, 1, 'Child Session'),
+			('sibling', 'profile', 'gpt-5.4', 1778767200.0, 1778767800.0, 1, 'Sibling Session');
+		INSERT INTO messages (
+			session_id, role, content, timestamp
+		) VALUES
+			('child', 'user', 'target hermes message', 1778767210.0),
+			('sibling', 'user', 'sibling hermes message', 1778767211.0);
+	`)
+	require.NoError(t, err)
+	return dbPath
+}
+
+func TestSessionExportHermesStateDB(t *testing.T) {
+	dataDir := newAgentDataDir(t)
+
+	root := t.TempDir()
+	dbPath := createHermesExportStateDB(t, root)
+	t.Setenv("HERMES_SESSIONS_DIR", filepath.Join(root, "sessions"))
+
+	seedSessionWithOpts(t, dataDir, "hermes:child", "proj",
+		func(s *db.Session) {
+			s.Agent = string(parser.AgentHermes)
+			s.SourceSessionID = "child"
+			s.SourceVersion = "hermes-state-db"
+			s.FilePath = &dbPath
+		})
+
+	out, err := executeCommand(newRootCommand(),
+		"session", "export", "hermes:child")
+	require.NoError(t, err)
+	assert.NotContains(t, out, "SQLite format 3")
+	assert.Contains(t, out, `"role":"session_meta"`)
+	assert.Contains(t, out, "target hermes message")
+	assert.NotContains(t, out, "sibling hermes message")
+
+	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
+		assert.JSONEq(t, line, line)
+	}
 }
 
 func TestSessionExport_AiderVirtualPathStreamsOnlySelectedRun(t *testing.T) {

--- a/cmd/agentsview/session_test.go
+++ b/cmd/agentsview/session_test.go
@@ -1014,9 +1014,11 @@ func createHermesExportStateDB(t *testing.T, root string) string {
 func TestSessionExportHermesStateDB(t *testing.T) {
 	dataDir := newAgentDataDir(t)
 
+	wrongRoot := t.TempDir()
+	_ = createHermesExportStateDB(t, wrongRoot)
 	root := t.TempDir()
 	dbPath := createHermesExportStateDB(t, root)
-	t.Setenv("HERMES_SESSIONS_DIR", filepath.Join(root, "sessions"))
+	t.Setenv("HERMES_SESSIONS_DIR", filepath.Join(wrongRoot, "sessions"))
 
 	seedSessionWithOpts(t, dataDir, "hermes:child", "proj",
 		func(s *db.Session) {
@@ -1033,6 +1035,7 @@ func TestSessionExportHermesStateDB(t *testing.T) {
 	assert.Contains(t, out, `"role":"session_meta"`)
 	assert.Contains(t, out, "target hermes message")
 	assert.NotContains(t, out, "sibling hermes message")
+	assert.NotContains(t, out, "wrong root message")
 
 	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
 		assert.JSONEq(t, line, line)

--- a/internal/parser/hermes.go
+++ b/internal/parser/hermes.go
@@ -773,13 +773,15 @@ func writeHermesStateSessionJSONL(
 ) error {
 	conn, err := sql.Open("sqlite3", "file:"+sqliteURIPath(stateDB)+"?mode=ro")
 	if err != nil {
-		return fmt.Errorf("open hermes state db: %w", err)
+		return hermesStateLookupError{
+			err: fmt.Errorf("open hermes state db: %w", err),
+		}
 	}
 	defer conn.Close()
 
 	ss, found, err := readHermesStateSession(conn, rawSessionID)
 	if err != nil {
-		return err
+		return hermesStateLookupError{err: err}
 	}
 	if !found {
 		return fmt.Errorf(
@@ -789,7 +791,7 @@ func writeHermesStateSessionJSONL(
 	}
 	messages, err := readHermesStateMessagesForSession(conn, rawSessionID)
 	if err != nil {
-		return err
+		return hermesStateLookupError{err: err}
 	}
 	selectedPath, _, _, _ := chooseHermesStateSessionSource(
 		ss,

--- a/internal/parser/hermes.go
+++ b/internal/parser/hermes.go
@@ -791,7 +791,31 @@ func writeHermesStateSessionJSONL(
 	if err != nil {
 		return err
 	}
+	selectedPath, _, _, _ := chooseHermesStateSessionSource(
+		ss,
+		messages,
+		filepath.Join(filepath.Dir(stateDB), "sessions"),
+		stateDB,
+		"",
+		"",
+	)
+	if selectedPath != stateDB {
+		return copyHermesTranscriptFile(w, selectedPath)
+	}
 	return encodeHermesStateSessionJSONL(w, ss, messages)
+}
+
+func copyHermesTranscriptFile(w io.Writer, path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("open %s: %w", path, os.ErrNotExist)
+		}
+		return fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+	_, err = io.Copy(w, f)
+	return err
 }
 
 func encodeHermesStateSessionJSONL(
@@ -859,31 +883,9 @@ func buildHermesStateResult(
 	ss hermesStateSession, stateMessages []hermesStateMessage,
 	sessionsDir, stateDB, project, machine string,
 ) (ParseResult, bool) {
-	jsonPath := filepath.Join(sessionsDir, "session_"+ss.id+".json")
-	jsonlPath := filepath.Join(sessionsDir, ss.id+".jsonl")
-
-	var sess *ParsedSession
-	var msgs []ParsedMessage
-	var err error
-	selectedPath := stateDB
-	if IsRegularFile(jsonPath) {
-		sess, msgs, err = parseHermesJSONSession(jsonPath, project, machine)
-		if err == nil && sess != nil &&
-			hermesMessageQuality(msgs) >= hermesStateQuality(stateMessages) {
-			selectedPath = jsonPath
-		} else {
-			sess, msgs = nil, nil
-		}
-	}
-	if sess == nil && IsRegularFile(jsonlPath) {
-		sess, msgs, err = parseHermesJSONLSession(jsonlPath, project, machine)
-		if err == nil && sess != nil &&
-			(hermesMessageQuality(msgs) >= hermesStateQuality(stateMessages) || len(stateMessages) == 0) {
-			selectedPath = jsonlPath
-		} else {
-			sess, msgs = nil, nil
-		}
-	}
+	selectedPath, sess, msgs, _ := chooseHermesStateSessionSource(
+		ss, stateMessages, sessionsDir, stateDB, project, machine,
+	)
 	usageEvents := hermesUsageEvents(ss, "hermes:"+ss.id)
 	if sess == nil {
 		msgs = convertHermesStateMessages(stateMessages)
@@ -908,6 +910,33 @@ func buildHermesStateResult(
 		Messages:    msgs,
 		UsageEvents: usageEvents,
 	}, true
+}
+
+func chooseHermesStateSessionSource(
+	ss hermesStateSession,
+	stateMessages []hermesStateMessage,
+	sessionsDir, stateDB, project, machine string,
+) (selectedPath string, sess *ParsedSession, msgs []ParsedMessage, err error) {
+	selectedPath = stateDB
+	jsonPath := filepath.Join(sessionsDir, "session_"+ss.id+".json")
+	jsonlPath := filepath.Join(sessionsDir, ss.id+".jsonl")
+	if IsRegularFile(jsonPath) {
+		sess, msgs, err = parseHermesJSONSession(jsonPath, project, machine)
+		if err == nil && sess != nil &&
+			hermesMessageQuality(msgs) >= hermesStateQuality(stateMessages) {
+			return jsonPath, sess, msgs, nil
+		}
+		sess, msgs = nil, nil
+	}
+	if IsRegularFile(jsonlPath) {
+		sess, msgs, err = parseHermesJSONLSession(jsonlPath, project, machine)
+		if err == nil && sess != nil &&
+			(hermesMessageQuality(msgs) >= hermesStateQuality(stateMessages) || len(stateMessages) == 0) {
+			return jsonlPath, sess, msgs, nil
+		}
+		sess, msgs = nil, nil
+	}
+	return selectedPath, nil, nil, nil
 }
 
 func applyHermesStateMetadata(

--- a/internal/parser/hermes.go
+++ b/internal/parser/hermes.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"math"
 	"os"
@@ -681,6 +682,177 @@ func readHermesStateMessages(
 		out[sid] = append(out[sid], hm)
 	}
 	return out, rows.Err()
+}
+
+func readHermesStateSession(
+	conn *sql.DB, rawSessionID string,
+) (hermesStateSession, bool, error) {
+	row := conn.QueryRow(`
+		SELECT id, source, COALESCE(model, ''),
+			COALESCE(parent_session_id, ''), started_at,
+			COALESCE(ended_at, 0), COALESCE(message_count, 0),
+			COALESCE(input_tokens, 0), COALESCE(output_tokens, 0),
+			COALESCE(cache_read_tokens, 0),
+			COALESCE(cache_write_tokens, 0),
+			COALESCE(reasoning_tokens, 0),
+			estimated_cost_usd, actual_cost_usd,
+			COALESCE(cost_status, ''), COALESCE(cost_source, ''),
+			COALESCE(title, ''), COALESCE(api_call_count, 0)
+		FROM sessions
+		WHERE id = ?`,
+		rawSessionID,
+	)
+	var ss hermesStateSession
+	var started, ended float64
+	err := row.Scan(
+		&ss.id, &ss.source, &ss.model,
+		&ss.parentSessionID, &started, &ended,
+		&ss.messageCount, &ss.inputTokens, &ss.outputTokens,
+		&ss.cacheReadTokens, &ss.cacheWriteTokens,
+		&ss.reasoningTokens, &ss.estimatedCost, &ss.actualCost,
+		&ss.costStatus, &ss.costSource, &ss.title, &ss.apiCallCount,
+	)
+	if err == sql.ErrNoRows {
+		return hermesStateSession{}, false, nil
+	}
+	if err != nil {
+		return hermesStateSession{}, false, fmt.Errorf(
+			"query hermes session %s: %w", rawSessionID, err,
+		)
+	}
+	ss.startedAt = hermesUnixTime(started)
+	ss.endedAt = hermesUnixTime(ended)
+	return ss, true, nil
+}
+
+func readHermesStateMessagesForSession(
+	conn *sql.DB, rawSessionID string,
+) ([]hermesStateMessage, error) {
+	rows, err := conn.Query(`
+		SELECT role, COALESCE(content, ''), COALESCE(tool_call_id, ''),
+			COALESCE(tool_calls, ''), timestamp,
+			COALESCE(finish_reason, ''), COALESCE(reasoning, ''),
+			COALESCE(reasoning_content, ''),
+			COALESCE(reasoning_details, ''),
+			COALESCE(codex_reasoning_items, ''),
+			COALESCE(codex_message_items, '')
+		FROM messages
+		WHERE session_id = ?
+		ORDER BY timestamp ASC, id ASC`,
+		rawSessionID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"query hermes messages for %s: %w", rawSessionID, err,
+		)
+	}
+	defer rows.Close()
+
+	var out []hermesStateMessage
+	for rows.Next() {
+		var hm hermesStateMessage
+		var ts float64
+		if err := rows.Scan(
+			&hm.role, &hm.content, &hm.toolCallID, &hm.toolCalls, &ts,
+			&hm.finishReason, &hm.reasoning, &hm.reasoningContent,
+			&hm.reasoningDetails, &hm.codexReasoningItems,
+			&hm.codexMessageItems,
+		); err != nil {
+			return nil, fmt.Errorf(
+				"scan hermes message for %s: %w", rawSessionID, err,
+			)
+		}
+		hm.timestamp = hermesUnixTime(ts)
+		out = append(out, hm)
+	}
+	return out, rows.Err()
+}
+
+func writeHermesStateSessionJSONL(
+	w io.Writer, stateDB, rawSessionID string,
+) error {
+	conn, err := sql.Open("sqlite3", "file:"+sqliteURIPath(stateDB)+"?mode=ro")
+	if err != nil {
+		return fmt.Errorf("open hermes state db: %w", err)
+	}
+	defer conn.Close()
+
+	ss, found, err := readHermesStateSession(conn, rawSessionID)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf(
+			"hermes session %s not found in %s: %w",
+			rawSessionID, stateDB, os.ErrNotExist,
+		)
+	}
+	messages, err := readHermesStateMessagesForSession(conn, rawSessionID)
+	if err != nil {
+		return err
+	}
+	return encodeHermesStateSessionJSONL(w, ss, messages)
+}
+
+func encodeHermesStateSessionJSONL(
+	w io.Writer, ss hermesStateSession, messages []hermesStateMessage,
+) error {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+
+	meta := map[string]any{"role": "session_meta"}
+	if ss.model != "" {
+		meta["model"] = ss.model
+	}
+	if ts := timeString(ss.startedAt, time.Time{}); ts != "" {
+		meta["timestamp"] = ts
+	}
+	if err := enc.Encode(meta); err != nil {
+		return fmt.Errorf("encode hermes session meta: %w", err)
+	}
+	for _, hm := range messages {
+		record := map[string]any{"role": hm.role}
+		if hm.content != "" {
+			record["content"] = hm.content
+		}
+		if hm.toolCallID != "" {
+			record["tool_call_id"] = hm.toolCallID
+		}
+		if hm.toolCalls != "" && json.Valid([]byte(hm.toolCalls)) {
+			record["tool_calls"] = json.RawMessage(hm.toolCalls)
+		}
+		if ts := timeString(hm.timestamp, time.Time{}); ts != "" {
+			record["timestamp"] = ts
+		}
+		if hm.finishReason != "" {
+			record["finish_reason"] = hm.finishReason
+		}
+		if hm.reasoning != "" {
+			record["reasoning"] = hm.reasoning
+		}
+		if hm.reasoningContent != "" {
+			record["reasoning_content"] = hm.reasoningContent
+		}
+		if hm.reasoningDetails != "" {
+			record["reasoning_details"] = hm.reasoningDetails
+		}
+		if hm.codexReasoningItems != "" &&
+			json.Valid([]byte(hm.codexReasoningItems)) {
+			record["codex_reasoning_items"] = json.RawMessage(
+				hm.codexReasoningItems,
+			)
+		}
+		if hm.codexMessageItems != "" &&
+			json.Valid([]byte(hm.codexMessageItems)) {
+			record["codex_message_items"] = json.RawMessage(
+				hm.codexMessageItems,
+			)
+		}
+		if err := enc.Encode(record); err != nil {
+			return fmt.Errorf("encode hermes session %s: %w", ss.id, err)
+		}
+	}
+	return nil
 }
 
 func buildHermesStateResult(

--- a/internal/parser/hermes.go
+++ b/internal/parser/hermes.go
@@ -926,7 +926,6 @@ func chooseHermesStateSessionSource(
 			hermesMessageQuality(msgs) >= hermesStateQuality(stateMessages) {
 			return jsonPath, sess, msgs, nil
 		}
-		sess, msgs = nil, nil
 	}
 	if IsRegularFile(jsonlPath) {
 		sess, msgs, err = parseHermesJSONLSession(jsonlPath, project, machine)
@@ -934,7 +933,6 @@ func chooseHermesStateSessionSource(
 			(hermesMessageQuality(msgs) >= hermesStateQuality(stateMessages) || len(stateMessages) == 0) {
 			return jsonlPath, sess, msgs, nil
 		}
-		sess, msgs = nil, nil
 	}
 	return selectedPath, nil, nil, nil
 }

--- a/internal/parser/hermes_provider.go
+++ b/internal/parser/hermes_provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"database/sql"
+	"errors"
 	"fmt"
 	"hash"
 	"io"
@@ -80,8 +81,19 @@ func (p *hermesProvider) Fingerprint(
 }
 
 func WriteHermesSessionJSONL(
-	w io.Writer, roots []string, rawSessionID string,
+	w io.Writer, storedPath string, roots []string, rawSessionID string,
 ) error {
+	if path := ResolveSourceFilePath(storedPath); filepath.Base(path) == "state.db" {
+		if _, err := os.Stat(path); err == nil {
+			err = writeHermesStateSessionJSONL(w, path, rawSessionID)
+			if err == nil {
+				return nil
+			}
+			if !errors.Is(err, os.ErrNotExist) {
+				return err
+			}
+		}
+	}
 	provider, ok := NewProvider(AgentHermes, ProviderConfig{Roots: roots})
 	if !ok {
 		return fmt.Errorf("hermes provider unavailable")
@@ -110,16 +122,7 @@ func WriteHermesSessionJSONL(
 	if filepath.Base(path) == "state.db" {
 		return writeHermesStateSessionJSONL(w, path, rawSessionID)
 	}
-	f, err := os.Open(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return fmt.Errorf("open %s: %w", path, os.ErrNotExist)
-		}
-		return fmt.Errorf("open %s: %w", path, err)
-	}
-	defer f.Close()
-	_, err = io.Copy(w, f)
-	return err
+	return copyHermesTranscriptFile(w, path)
 }
 
 func (p *hermesProvider) Parse(

--- a/internal/parser/hermes_provider.go
+++ b/internal/parser/hermes_provider.go
@@ -83,15 +83,19 @@ func (p *hermesProvider) Fingerprint(
 func WriteHermesSessionJSONL(
 	w io.Writer, storedPath string, roots []string, rawSessionID string,
 ) error {
+	var storedStateErr error
 	if path := ResolveSourceFilePath(storedPath); filepath.Base(path) == "state.db" {
 		if _, err := os.Stat(path); err == nil {
 			err = writeHermesStateSessionJSONL(w, path, rawSessionID)
 			if err == nil {
 				return nil
 			}
-			if !errors.Is(err, os.ErrNotExist) {
+			var lookupErr hermesStateLookupError
+			if !errors.Is(err, os.ErrNotExist) &&
+				!errors.As(err, &lookupErr) {
 				return err
 			}
+			storedStateErr = err
 		}
 	}
 	provider, ok := NewProvider(AgentHermes, ProviderConfig{Roots: roots})
@@ -110,6 +114,9 @@ func WriteHermesSessionJSONL(
 		return err
 	}
 	if !found {
+		if storedStateErr != nil && !errors.Is(storedStateErr, os.ErrNotExist) {
+			return storedStateErr
+		}
 		return fmt.Errorf(
 			"hermes session %s source not found: %w",
 			rawSessionID, os.ErrNotExist,
@@ -294,7 +301,6 @@ func (s hermesSourceSet) FindSource(
 						"falling back to transcripts", stateDB, err,
 				)
 			case !found:
-				continue
 			default:
 				if source, ok := s.sourceRef(root, stateDB); ok {
 					return source, true, nil
@@ -311,6 +317,18 @@ func (s hermesSourceSet) FindSource(
 		}
 	}
 	return SourceRef{}, false, nil
+}
+
+type hermesStateLookupError struct {
+	err error
+}
+
+func (e hermesStateLookupError) Error() string {
+	return e.err.Error()
+}
+
+func (e hermesStateLookupError) Unwrap() error {
+	return e.err
 }
 
 func hermesStateDBHasSession(stateDB string, rawID string) (bool, error) {

--- a/internal/parser/hermes_provider.go
+++ b/internal/parser/hermes_provider.go
@@ -97,6 +97,12 @@ func WriteHermesSessionJSONL(
 			}
 			storedStateErr = err
 		}
+		if transcript := findHermesSourceFile(
+			filepath.Join(filepath.Dir(path), "sessions"),
+			rawSessionID,
+		); transcript != "" {
+			return copyHermesTranscriptFile(w, transcript)
+		}
 	}
 	provider, ok := NewProvider(AgentHermes, ProviderConfig{Roots: roots})
 	if !ok {

--- a/internal/parser/hermes_provider.go
+++ b/internal/parser/hermes_provider.go
@@ -79,6 +79,49 @@ func (p *hermesProvider) Fingerprint(
 	return p.sources.Fingerprint(ctx, source)
 }
 
+func WriteHermesSessionJSONL(
+	w io.Writer, roots []string, rawSessionID string,
+) error {
+	provider, ok := NewProvider(AgentHermes, ProviderConfig{Roots: roots})
+	if !ok {
+		return fmt.Errorf("hermes provider unavailable")
+	}
+	hp, ok := provider.(*hermesProvider)
+	if !ok {
+		return fmt.Errorf("hermes provider unavailable")
+	}
+	source, found, err := hp.FindSource(
+		context.Background(),
+		FindSourceRequest{RawSessionID: rawSessionID},
+	)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf(
+			"hermes session %s source not found: %w",
+			rawSessionID, os.ErrNotExist,
+		)
+	}
+	path, ok := hp.sources.pathFromSource(source)
+	if !ok {
+		return fmt.Errorf("hermes source path unavailable")
+	}
+	if filepath.Base(path) == "state.db" {
+		return writeHermesStateSessionJSONL(w, path, rawSessionID)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("open %s: %w", path, os.ErrNotExist)
+		}
+		return fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+	_, err = io.Copy(w, f)
+	return err
+}
+
 func (p *hermesProvider) Parse(
 	ctx context.Context,
 	req ParseRequest,

--- a/internal/parser/hermes_test.go
+++ b/internal/parser/hermes_test.go
@@ -427,6 +427,61 @@ func TestWriteHermesSessionJSONL_FallsBackWhenStoredStateDBUnreadable(t *testing
 	assert.Equal(t, body, buf.String())
 }
 
+func TestWriteHermesSessionJSONL_PrioritizesAdjacentTranscriptBeforeRoots(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		prepareRoot func(t *testing.T, root string)
+	}{
+		{
+			name: "missing stored state db",
+		},
+		{
+			name: "unreadable stored state db",
+			prepareRoot: func(t *testing.T, root string) {
+				t.Helper()
+				require.NoError(t, os.WriteFile(
+					filepath.Join(root, "state.db"),
+					[]byte("not a sqlite database"),
+					0o644,
+				))
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			storedRoot := t.TempDir()
+			storedSessions := filepath.Join(storedRoot, "sessions")
+			require.NoError(t, os.MkdirAll(storedSessions, 0o755))
+			if tt.prepareRoot != nil {
+				tt.prepareRoot(t, storedRoot)
+			}
+			body := strings.Join([]string{
+				`{"role":"session_meta","model":"gpt-4","timestamp":"2026-05-14T10:00:00Z"}`,
+				`{"role":"user","content":"adjacent stored transcript","timestamp":"2026-05-14T10:01:00Z"}`,
+				"",
+			}, "\n")
+			require.NoError(t, os.WriteFile(
+				filepath.Join(storedSessions, "child.jsonl"),
+				[]byte(body),
+				0o644,
+			))
+
+			otherRoot := t.TempDir()
+			otherSessions := filepath.Join(otherRoot, "sessions")
+			require.NoError(t, os.MkdirAll(otherSessions, 0o755))
+			createHermesStateDB(t, otherRoot)
+
+			var buf strings.Builder
+			require.NoError(t, WriteHermesSessionJSONL(
+				&buf,
+				filepath.Join(storedRoot, "state.db"),
+				[]string{otherSessions, storedSessions},
+				"child",
+			))
+			assert.Equal(t, body, buf.String())
+		})
+	}
+}
+
 func TestWriteHermesSessionJSONL_PrefersTranscriptWhenQualityWins(t *testing.T) {
 	root := t.TempDir()
 	sessionsDir := filepath.Join(root, "sessions")

--- a/internal/parser/hermes_test.go
+++ b/internal/parser/hermes_test.go
@@ -361,6 +361,72 @@ func TestWriteHermesSessionJSONL_FallsBackWhenStoredStateDBMissesSession(t *test
 	assert.Contains(t, buf.String(), "state db only has one message")
 }
 
+func TestWriteHermesSessionJSONL_FallsBackToTranscriptWhenStateDBMissesSessionInSameRoot(t *testing.T) {
+	root := t.TempDir()
+	sessionsDir := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+	createHermesStateDB(t, root)
+	dbPath := filepath.Join(root, "state.db")
+
+	conn, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+	_, err = conn.Exec(`DELETE FROM messages WHERE session_id = 'child'`)
+	require.NoError(t, err)
+	_, err = conn.Exec(`DELETE FROM sessions WHERE id = 'child'`)
+	require.NoError(t, err)
+
+	body := strings.Join([]string{
+		`{"role":"session_meta","model":"gpt-4","timestamp":"2026-05-14T10:00:00Z"}`,
+		`{"role":"user","content":"fallback transcript prompt","timestamp":"2026-05-14T10:01:00Z"}`,
+		"",
+	}, "\n")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sessionsDir, "child.jsonl"),
+		[]byte(body),
+		0o644,
+	))
+
+	var buf strings.Builder
+	require.NoError(t, WriteHermesSessionJSONL(
+		&buf,
+		dbPath,
+		[]string{sessionsDir},
+		"child",
+	))
+	assert.Equal(t, body, buf.String())
+}
+
+func TestWriteHermesSessionJSONL_FallsBackWhenStoredStateDBUnreadable(t *testing.T) {
+	root := t.TempDir()
+	sessionsDir := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "state.db"),
+		[]byte("not a sqlite database"),
+		0o644,
+	))
+	body := strings.Join([]string{
+		`{"role":"session_meta","model":"gpt-4","timestamp":"2026-05-14T10:00:00Z"}`,
+		`{"role":"user","content":"fallback unreadable transcript","timestamp":"2026-05-14T10:01:00Z"}`,
+		"",
+	}, "\n")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sessionsDir, "child.jsonl"),
+		[]byte(body),
+		0o644,
+	))
+
+	var buf strings.Builder
+	require.NoError(t, WriteHermesSessionJSONL(
+		&buf,
+		filepath.Join(root, "state.db"),
+		[]string{sessionsDir},
+		"child",
+	))
+	assert.Equal(t, body, buf.String())
+}
+
 func TestWriteHermesSessionJSONL_PrefersTranscriptWhenQualityWins(t *testing.T) {
 	root := t.TempDir()
 	sessionsDir := filepath.Join(root, "sessions")

--- a/internal/parser/hermes_test.go
+++ b/internal/parser/hermes_test.go
@@ -300,7 +300,10 @@ func TestWriteHermesSessionJSONL_UsesMatchingProfileStateDB(t *testing.T) {
 
 	var buf strings.Builder
 	require.NoError(t, WriteHermesSessionJSONL(
-		&buf, []string{defaultSessions, profileSessions}, "child",
+		&buf,
+		filepath.Join(profileRoot, "state.db"),
+		[]string{defaultSessions, profileSessions},
+		"child",
 	))
 
 	out := buf.String()
@@ -332,7 +335,55 @@ func TestWriteHermesSessionJSONL_TranscriptSourceCopiesFile(t *testing.T) {
 
 	var buf strings.Builder
 	require.NoError(t, WriteHermesSessionJSONL(
-		&buf, []string{sessionsDir}, "child",
+		&buf, filepath.Join(root, "state.db"), []string{sessionsDir}, "child",
+	))
+	assert.Equal(t, body, buf.String())
+}
+
+func TestWriteHermesSessionJSONL_FallsBackWhenStoredStateDBMissesSession(t *testing.T) {
+	defaultRoot := t.TempDir()
+	defaultSessions := filepath.Join(defaultRoot, "sessions")
+	require.NoError(t, os.MkdirAll(defaultSessions, 0o755))
+	createHermesStateDB(t, defaultRoot)
+
+	profileRoot := t.TempDir()
+	profileSessions := filepath.Join(profileRoot, "sessions")
+	require.NoError(t, os.MkdirAll(profileSessions, 0o755))
+	createHermesStateDB(t, profileRoot)
+
+	var buf strings.Builder
+	require.NoError(t, WriteHermesSessionJSONL(
+		&buf,
+		filepath.Join(defaultRoot, "state.db"),
+		[]string{defaultSessions, profileSessions},
+		"child",
+	))
+	assert.Contains(t, buf.String(), "state db only has one message")
+}
+
+func TestWriteHermesSessionJSONL_PrefersTranscriptWhenQualityWins(t *testing.T) {
+	root := t.TempDir()
+	sessionsDir := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+	createHermesStateDB(t, root)
+	body := strings.Join([]string{
+		`{"role":"session_meta","model":"gpt-4","timestamp":"2026-05-14T10:00:00Z"}`,
+		`{"role":"user","content":"transcript prompt","timestamp":"2026-05-14T10:01:00Z"}`,
+		`{"role":"assistant","content":"transcript answer","timestamp":"2026-05-14T10:02:00Z"}`,
+		"",
+	}, "\n")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sessionsDir, "child.jsonl"),
+		[]byte(body),
+		0o644,
+	))
+
+	var buf strings.Builder
+	require.NoError(t, WriteHermesSessionJSONL(
+		&buf,
+		filepath.Join(root, "state.db"),
+		[]string{sessionsDir},
+		"child",
 	))
 	assert.Equal(t, body, buf.String())
 }

--- a/internal/parser/hermes_test.go
+++ b/internal/parser/hermes_test.go
@@ -249,6 +249,94 @@ func TestParseHermesArchive_FallsBackToTranscriptsWhenStateDBUnreadable(
 	assert.Empty(t, res.UsageEvents)
 }
 
+func TestWriteHermesSessionJSONL_UsesMatchingProfileStateDB(t *testing.T) {
+	defaultRoot := t.TempDir()
+	defaultSessions := filepath.Join(defaultRoot, "sessions")
+	require.NoError(t, os.MkdirAll(defaultSessions, 0o755))
+	createHermesStateDB(t, defaultRoot)
+
+	defaultDB, err := sql.Open("sqlite3", filepath.Join(defaultRoot, "state.db"))
+	require.NoError(t, err)
+	defer func() { _ = defaultDB.Close() }()
+	_, err = defaultDB.Exec(`
+		DELETE FROM messages;
+		DELETE FROM sessions;
+		INSERT INTO sessions (
+			id, source, model, started_at, ended_at, message_count, title
+		) VALUES (
+			'default-only', 'default', 'gpt-default',
+			1778767200.0, 1778767800.0, 1, 'Default Session'
+		);
+		INSERT INTO messages (
+			session_id, role, content, timestamp
+		) VALUES (
+			'default-only', 'user', 'wrong root message', 1778767210.0
+		);
+	`)
+	require.NoError(t, err)
+
+	profileRoot := t.TempDir()
+	profileSessions := filepath.Join(profileRoot, "sessions")
+	require.NoError(t, os.MkdirAll(profileSessions, 0o755))
+	createHermesStateDB(t, profileRoot)
+
+	profileDB, err := sql.Open("sqlite3", filepath.Join(profileRoot, "state.db"))
+	require.NoError(t, err)
+	defer func() { _ = profileDB.Close() }()
+	_, err = profileDB.Exec(`
+		INSERT INTO sessions (
+			id, source, model, started_at, ended_at, message_count, title
+		) VALUES (
+			'sibling', 'profile', 'gpt-sibling',
+			1778767200.0, 1778767800.0, 1, 'Sibling Session'
+		);
+		INSERT INTO messages (
+			session_id, role, content, timestamp
+		) VALUES (
+			'sibling', 'user', 'sibling message', 1778767211.0
+		);
+	`)
+	require.NoError(t, err)
+
+	var buf strings.Builder
+	require.NoError(t, WriteHermesSessionJSONL(
+		&buf, []string{defaultSessions, profileSessions}, "child",
+	))
+
+	out := buf.String()
+	assert.NotContains(t, out, "SQLite format 3")
+	assert.Contains(t, out, `"role":"session_meta"`)
+	assert.Contains(t, out, "state db only has one message")
+	assert.NotContains(t, out, "wrong root message")
+	assert.NotContains(t, out, "sibling message")
+
+	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
+		assert.JSONEq(t, line, line)
+	}
+}
+
+func TestWriteHermesSessionJSONL_TranscriptSourceCopiesFile(t *testing.T) {
+	root := t.TempDir()
+	sessionsDir := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+	body := strings.Join([]string{
+		`{"role":"session_meta","model":"gpt-4","timestamp":"2026-04-03T15:27:00Z"}`,
+		`{"role":"user","content":"hello from transcript","timestamp":"2026-04-03T15:28:00Z"}`,
+		"",
+	}, "\n")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sessionsDir, "child.jsonl"),
+		[]byte(body),
+		0o644,
+	))
+
+	var buf strings.Builder
+	require.NoError(t, WriteHermesSessionJSONL(
+		&buf, []string{sessionsDir}, "child",
+	))
+	assert.Equal(t, body, buf.String())
+}
+
 func TestParseHermesArchive_UsesStateMessagesWhenJSONLIsLowerQuality(
 	t *testing.T,
 ) {


### PR DESCRIPTION
Hermes sessions imported from `state.db` all record the aggregate database as their source path, so `session export` currently succeeds by streaming SQLite bytes instead of the requested session's JSONL. Profile-backed sessions can also resolve through the wrong database, returning a payload that does not contain the requested session, and the first export fix still re-discovered from live roots instead of honoring the archived source path. It also stopped too early when the archived database missed the session or could not be read, even when the right transcript file was present in that same Hermes root.

This keeps Hermes export on the provider-owned path, but now starts from the archived `storedPath` and only falls back to root-based rediscovery when that exact source and its adjacent transcript directory cannot satisfy the raw session ID. Every Hermes session whose archived path resolves to `state.db` now goes through that filtered exporter, even when the archived row does not carry `SourceVersion` or `SourceSessionID`; in that case export derives the raw Hermes ID from the archived `hermes:<id>` session ID instead of falling through to raw file copy. When the selected source is a Hermes `state.db`, export now uses the same transcript-selection rule as archive parsing, so `session_<id>.json` or `<id>.jsonl` wins whenever it is at least as complete as the database transcript. A same-root `state.db` miss now continues into transcript discovery for that profile, and missing, unreadable, or schema-incompatible stored databases now search the adjacent `sessions` directory before live-root rediscovery, so a duplicate raw ID in an earlier configured root cannot steal the export. Transcript-backed Hermes sessions continue through the same provider authority, while Aider, Visual Studio Copilot, Windsurf, and ordinary raw-file exports keep their existing behavior.

The change is limited to session export and Hermes source serialization. It does not change Hermes ingestion, archive schema, session list or stats behavior; the separate count mismatch remains tracked in https://github.com/kenn-io/agentsview/issues/1048. Focused tests cover the SQLite-header regression, stored-path precedence, explicit fallback rediscovery, transcript-vs-state export parity, same-root transcript fallback after database misses, adjacent transcript priority across changed roots and duplicate raw IDs, unreadable stored-database fallback, missing sources, and non-Hermes export preservation.

Fixes #1047
