### PR TITLE
feat(parser): ingest ZCode transcript messages and tool calls (#1050)

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -30,6 +30,11 @@ import (
 // trigger a non-destructive re-sync (mtime reset + skip cache
 // clear) so existing session data is preserved.
 //
+// Bumped to 61: the ZCode parser now persists transcript messages,
+// tool calls, and tool results from the message/part tables.
+// Existing ZCode rows need re-parsing so stored sessions backfill
+// message counts and transcript content.
+//
 // Bumped to 60: the Codex parser removes the recommended-plugins
 // discovery envelope injected ahead of the first genuine user turn.
 // Existing Codex rows need re-parsing so the synthetic plugin list is
@@ -283,7 +288,7 @@ import (
 // (17: Codex <skill> template filtering.)
 // (16: <turn_aborted> system messages.)
 // (60: Codex recommended-plugins prefix filtering.)
-const dataVersion = 60
+const dataVersion = 61
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/parser/zcode.go
+++ b/internal/parser/zcode.go
@@ -688,6 +688,9 @@ func zcodeParseToolResult(block gjson.Result) (ParsedToolResult, bool) {
 	if !content.Exists() || content.Type == gjson.Null {
 		content = block.Get("state.output")
 	}
+	if !content.Exists() || content.Type == gjson.Null {
+		content = block.Get("state.error")
+	}
 	if content.Exists() && content.Type != gjson.Null {
 		return ParsedToolResult{
 			ToolUseID:     toolUseID,

--- a/internal/parser/zcode.go
+++ b/internal/parser/zcode.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/tidwall/gjson"
 )
 
 const ZCodeDBName = "db.sqlite"
@@ -53,7 +55,11 @@ func zcodeProviderCapabilities() Capabilities {
 			FirstMessage:         CapabilitySupported,
 			SessionName:          CapabilitySupported,
 			Cwd:                  CapabilitySupported,
+			Thinking:             CapabilitySupported,
+			ToolCalls:            CapabilitySupported,
+			ToolResults:          CapabilitySupported,
 			AggregateUsageEvents: CapabilitySupported,
+			Model:                CapabilitySupported,
 		},
 	}
 }
@@ -249,6 +255,19 @@ type zcodeUsageRow struct {
 	toolCallCount            sql.NullInt64
 }
 
+type zcodeMessageRow struct {
+	id          string
+	data        string
+	timeCreated string
+}
+
+type zcodePartRow struct {
+	id          string
+	messageID   string
+	timeCreated string
+	data        string
+}
+
 func loadZCodeSessionRow(db *sql.DB, sessionID string) (zcodeSessionRow, error) {
 	row := db.QueryRow(`
 		SELECT id,
@@ -317,17 +336,34 @@ func buildZCodeParseResult(
 		firstMessage = truncate(strings.ReplaceAll(firstMessage, "\n", " "), 300)
 	}
 
+	msgs, err := loadZCodeMessages(db, row.id)
+	if err != nil {
+		return ParseResult{}, err
+	}
+	parts, err := loadZCodeParts(db, row.id)
+	if err != nil {
+		return ParseResult{}, err
+	}
+	parsedMessages := buildZCodeMessages(msgs, parts)
+	userMessageCount := 0
+	for _, msg := range parsedMessages {
+		if msg.Role == RoleUser {
+			userMessageCount++
+		}
+	}
+
 	sess := ParsedSession{
-		ID:           "zcode:" + row.id,
-		Project:      project,
-		Machine:      machine,
-		Agent:        AgentZCode,
-		Cwd:          directory,
-		FirstMessage: firstMessage,
-		SessionName:  title,
-		StartedAt:    startedAt,
-		EndedAt:      endedAt,
-		MessageCount: 0,
+		ID:               "zcode:" + row.id,
+		Project:          project,
+		Machine:          machine,
+		Agent:            AgentZCode,
+		Cwd:              directory,
+		FirstMessage:     firstMessage,
+		SessionName:      title,
+		StartedAt:        startedAt,
+		EndedAt:          endedAt,
+		MessageCount:     len(parsedMessages),
+		UserMessageCount: userMessageCount,
 		File: FileInfo{
 			Path: ZCodeSQLiteVirtualPath(dbPath, row.id),
 		},
@@ -345,8 +381,362 @@ func buildZCodeParseResult(
 
 	return ParseResult{
 		Session:     sess,
+		Messages:    parsedMessages,
 		UsageEvents: usageEvents,
 	}, nil
+}
+
+func loadZCodeMessages(
+	db *sql.DB, sessionID string,
+) ([]zcodeMessageRow, error) {
+	rows, err := db.Query(`
+		SELECT id,
+		       COALESCE(data, '{}'),
+		       CAST(COALESCE(time_created, '') AS TEXT)
+		  FROM message
+		 WHERE session_id = ?
+		 ORDER BY CAST(COALESCE(time_created, '') AS TEXT), id
+	`, sessionID)
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "no such table: message") {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("listing zcode messages for %s: %w", sessionID, err)
+	}
+	defer rows.Close()
+
+	msgs := make([]zcodeMessageRow, 0)
+	for rows.Next() {
+		var row zcodeMessageRow
+		if err := rows.Scan(&row.id, &row.data, &row.timeCreated); err != nil {
+			return nil, fmt.Errorf("scanning zcode message row: %w", err)
+		}
+		if row.id == "" {
+			continue
+		}
+		msgs = append(msgs, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return msgs, nil
+}
+
+func loadZCodeParts(
+	db *sql.DB, sessionID string,
+) (map[string][]zcodePartRow, error) {
+	selectTime := `''`
+	orderBy := `id`
+	if has, err := zcodeTableHasColumn(db, "part", "time_created"); err != nil {
+		return nil, err
+	} else if has {
+		selectTime = `CAST(COALESCE(time_created, '') AS TEXT)`
+		orderBy = selectTime + `, id`
+	}
+
+	rows, err := db.Query(`
+		SELECT id,
+		       message_id,
+		       `+selectTime+`,
+		       COALESCE(data, '{}')
+		  FROM part
+		 WHERE session_id = ?
+		 ORDER BY `+orderBy, sessionID)
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "no such table: part") {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("listing zcode parts for %s: %w", sessionID, err)
+	}
+	defer rows.Close()
+
+	parts := make(map[string][]zcodePartRow)
+	for rows.Next() {
+		var row zcodePartRow
+		if err := rows.Scan(&row.id, &row.messageID, &row.timeCreated, &row.data); err != nil {
+			return nil, fmt.Errorf("scanning zcode part row: %w", err)
+		}
+		if row.messageID == "" {
+			continue
+		}
+		parts[row.messageID] = append(parts[row.messageID], row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return parts, nil
+}
+
+func buildZCodeMessages(
+	msgs []zcodeMessageRow,
+	parts map[string][]zcodePartRow,
+) []ParsedMessage {
+	if msgs == nil || parts == nil {
+		return nil
+	}
+
+	parsed := make([]ParsedMessage, 0, len(msgs))
+	for _, row := range msgs {
+		msg, ok := buildZCodeMessage(len(parsed), row, parts[row.id])
+		if !ok {
+			continue
+		}
+		parsed = append(parsed, msg)
+	}
+	return parsed
+}
+
+func buildZCodeMessage(
+	ordinal int,
+	row zcodeMessageRow,
+	parts []zcodePartRow,
+) (ParsedMessage, bool) {
+	role, ok := normalizeZCodeRole(gjson.Get(row.data, "role").Str)
+	if !ok {
+		return ParsedMessage{}, false
+	}
+
+	msg := ParsedMessage{
+		Ordinal:   ordinal,
+		Role:      role,
+		Timestamp: zcodeParseTime(row.timeCreated),
+		Model:     zcodeMessageModel(row.data),
+		IsSystem:  role == RoleSystem,
+	}
+
+	var texts []string
+	var thinking []string
+	for _, part := range parts {
+		block := gjson.Parse(part.data)
+		switch block.Get("type").Str {
+		case "text":
+			if text := zcodeBlockText(block); text != "" {
+				texts = append(texts, text)
+			}
+		case "thinking", "reasoning":
+			text := zcodeThinkingText(block)
+			if text == "" {
+				continue
+			}
+			msg.HasThinking = true
+			thinking = append(thinking, text)
+			texts = append(texts, "[Thinking]\n"+text+"\n[/Thinking]")
+		case "tool_use", "tool":
+			msg.HasToolUse = true
+			if tc, ok := zcodeParseToolCall(block); ok {
+				msg.ToolCalls = append(msg.ToolCalls, tc)
+			}
+			if tr, ok := zcodeParseToolResult(block); ok {
+				msg.ToolResults = append(msg.ToolResults, tr)
+			}
+		case "tool_result":
+			if tr, ok := zcodeParseToolResult(block); ok {
+				msg.ToolResults = append(msg.ToolResults, tr)
+			}
+		}
+	}
+
+	msg.Content = strings.Join(texts, "\n")
+	msg.ThinkingText = strings.Join(thinking, "\n\n")
+	msg.ContentLength = len(msg.Content)
+	return msg, true
+}
+
+func normalizeZCodeRole(role string) (RoleType, bool) {
+	switch strings.ToLower(strings.TrimSpace(role)) {
+	case "user":
+		return RoleUser, true
+	case "assistant", "model":
+		return RoleAssistant, true
+	case "system":
+		return RoleSystem, true
+	default:
+		return "", false
+	}
+}
+
+func zcodeMessageModel(raw string) string {
+	for _, path := range []string{
+		"modelID",
+		"model_id",
+		"model.modelID",
+		"model.id",
+		"model.name",
+		"model",
+	} {
+		if model := strings.TrimSpace(gjson.Get(raw, path).Str); model != "" {
+			return model
+		}
+	}
+	return ""
+}
+
+func zcodeBlockText(block gjson.Result) string {
+	for _, path := range []string{"text", "content", "value"} {
+		value := block.Get(path)
+		if !value.Exists() {
+			continue
+		}
+		if text := decodeContent(value); text != "" {
+			return text
+		}
+		if value.Type == gjson.String && value.Str != "" {
+			return value.Str
+		}
+	}
+	return ""
+}
+
+func zcodeThinkingText(block gjson.Result) string {
+	for _, path := range []string{"thinking", "text", "content"} {
+		value := block.Get(path)
+		if !value.Exists() {
+			continue
+		}
+		if text := decodeContent(value); text != "" {
+			return text
+		}
+		if value.Type == gjson.String && value.Str != "" {
+			return value.Str
+		}
+	}
+	return ""
+}
+
+func zcodeParseToolCall(block gjson.Result) (ParsedToolCall, bool) {
+	name := block.Get("name").Str
+	if name == "" {
+		name = block.Get("tool_name").Str
+	}
+	if name == "" {
+		name = block.Get("toolName").Str
+	}
+	if name == "" {
+		name = block.Get("tool").Str
+	}
+	if name == "" {
+		return ParsedToolCall{}, false
+	}
+
+	input := toolCallInput(block)
+	if input.Raw == "" || input.Raw == "{}" {
+		if stateInput := block.Get("state.input"); stateInput.Exists() {
+			input = stateInput
+		}
+	}
+	inputJSON := input.Raw
+	if inputJSON == "" {
+		inputJSON = "{}"
+	}
+	toolUseID := block.Get("id").Str
+	if toolUseID == "" {
+		toolUseID = block.Get("tool_use_id").Str
+	}
+	if toolUseID == "" {
+		toolUseID = block.Get("toolUseID").Str
+	}
+	if toolUseID == "" {
+		toolUseID = block.Get("callID").Str
+	}
+	if toolUseID == "" {
+		toolUseID = block.Get("callId").Str
+	}
+
+	call := ParsedToolCall{
+		ToolUseID: toolUseID,
+		ToolName:  name,
+		Category:  NormalizeToolCategory(name),
+		InputJSON: inputJSON,
+	}
+	switch name {
+	case "Skill", "skill":
+		call.SkillName = input.Get("skill").Str
+		if call.SkillName == "" {
+			call.SkillName = input.Get("name").Str
+		}
+	default:
+		call.SkillName = inferToolSkillName(name, inputJSON)
+	}
+	return call, true
+}
+
+func zcodeParseToolResult(block gjson.Result) (ParsedToolResult, bool) {
+	toolUseID := block.Get("tool_use_id").Str
+	if toolUseID == "" {
+		toolUseID = block.Get("toolUseID").Str
+	}
+	if toolUseID == "" {
+		toolUseID = block.Get("tool_call_id").Str
+	}
+	if toolUseID == "" {
+		toolUseID = block.Get("callID").Str
+	}
+	if toolUseID == "" {
+		toolUseID = block.Get("callId").Str
+	}
+	if toolUseID == "" {
+		return ParsedToolResult{}, false
+	}
+
+	content := block.Get("content")
+	if !content.Exists() || content.Type == gjson.Null {
+		content = block.Get("result")
+	}
+	if !content.Exists() || content.Type == gjson.Null {
+		content = block.Get("output")
+	}
+	if !content.Exists() || content.Type == gjson.Null {
+		content = block.Get("state.output")
+	}
+	if content.Exists() && content.Type != gjson.Null {
+		return ParsedToolResult{
+			ToolUseID:     toolUseID,
+			ContentLength: toolResultContentLength(content),
+			ContentRaw:    content.Raw,
+		}, true
+	}
+
+	for _, key := range []string{"text", "error", "value"} {
+		if text := block.Get(key).Str; text != "" {
+			return ParsedToolResult{
+				ToolUseID:     toolUseID,
+				ContentLength: len(text),
+				ContentRaw:    strconv.Quote(text),
+			}, true
+		}
+	}
+	return ParsedToolResult{}, false
+}
+
+func zcodeTableHasColumn(db *sql.DB, table, column string) (bool, error) {
+	rows, err := db.Query(`PRAGMA table_info(` + table + `)`)
+	if err != nil {
+		return false, fmt.Errorf("listing zcode table info for %s: %w", table, err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			cid        int
+			name       string
+			typeName   string
+			notNull    int
+			defaultV   sql.NullString
+			primaryKey int
+		)
+		if err := rows.Scan(
+			&cid, &name, &typeName, &notNull, &defaultV, &primaryKey,
+		); err != nil {
+			return false, fmt.Errorf("scanning zcode table info for %s: %w", table, err)
+		}
+		if strings.EqualFold(name, column) {
+			return true, nil
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return false, err
+	}
+	return false, nil
 }
 
 func listZCodeUsageEvents(

--- a/internal/parser/zcode_test.go
+++ b/internal/parser/zcode_test.go
@@ -40,6 +40,19 @@ const zcodeTestSchema = `
 		duration_ms INTEGER,
 		tool_call_count INTEGER
 	);
+	CREATE TABLE message (
+		id TEXT PRIMARY KEY NOT NULL,
+		session_id TEXT NOT NULL,
+		time_created TEXT,
+		data TEXT
+	);
+	CREATE TABLE part (
+		id TEXT PRIMARY KEY NOT NULL,
+		message_id TEXT NOT NULL,
+		session_id TEXT NOT NULL,
+		time_created TEXT,
+		data TEXT
+	);
 `
 
 type zcodeTestFixture struct {
@@ -116,6 +129,57 @@ func (f *zcodeTestFixture) insertUsage(
 	require.NoError(t, err)
 }
 
+func (f *zcodeTestFixture) insertMessage(
+	t *testing.T,
+	id, sessionID string,
+	createdAt any,
+	data string,
+) {
+	t.Helper()
+	_, err := f.database.Exec(`
+		INSERT INTO message (
+			id, session_id, time_created, data
+		) VALUES (?, ?, ?, ?)
+	`, id, sessionID, createdAt, data)
+	require.NoError(t, err)
+}
+
+func (f *zcodeTestFixture) insertPart(
+	t *testing.T,
+	id, messageID, sessionID string,
+	data string,
+) {
+	t.Helper()
+	f.insertPartAt(t, id, messageID, sessionID, nil, data)
+}
+
+func (f *zcodeTestFixture) insertPartAt(
+	t *testing.T,
+	id, messageID, sessionID string,
+	createdAt any,
+	data string,
+) {
+	t.Helper()
+	_, err := f.database.Exec(`
+		INSERT INTO part (
+			id, message_id, session_id, time_created, data
+		) VALUES (?, ?, ?, ?, ?)
+	`, id, messageID, sessionID, createdAt, data)
+	require.NoError(t, err)
+}
+
+func TestZCodeProviderCapabilities(t *testing.T) {
+	caps := zcodeProviderCapabilities()
+	assert.Equal(t, CapabilitySupported, caps.Content.FirstMessage)
+	assert.Equal(t, CapabilitySupported, caps.Content.SessionName)
+	assert.Equal(t, CapabilitySupported, caps.Content.Cwd)
+	assert.Equal(t, CapabilitySupported, caps.Content.Thinking)
+	assert.Equal(t, CapabilitySupported, caps.Content.ToolCalls)
+	assert.Equal(t, CapabilitySupported, caps.Content.ToolResults)
+	assert.Equal(t, CapabilitySupported, caps.Content.AggregateUsageEvents)
+	assert.Equal(t, CapabilitySupported, caps.Content.Model)
+}
+
 func TestZCodeParsesReportedIntegerTimestamps(t *testing.T) {
 	fixture := newZCodeTestFixture(t)
 	fixture.insertSession(
@@ -190,6 +254,65 @@ func TestZCodeProviderSourceMethodsAndParse(t *testing.T) {
 		600,
 		0,
 	)
+	fixture.insertMessage(
+		t,
+		"msg-1",
+		"session-001",
+		"2026-07-06T13:00:01Z",
+		`{"role":"user"}`,
+	)
+	fixture.insertPart(
+		t,
+		"part-1",
+		"msg-1",
+		"session-001",
+		`{"type":"text","text":"Inspect the login flow."}`,
+	)
+	fixture.insertMessage(
+		t,
+		"msg-2",
+		"session-001",
+		"2026-07-06T13:00:02Z",
+		`{"role":"assistant","model":{"modelID":"claude-sonnet-4-6"}}`,
+	)
+	fixture.insertPartAt(
+		t,
+		"part-z",
+		"msg-2",
+		"session-001",
+		"2026-07-06T13:00:02Z",
+		`{"type":"thinking","thinking":"I should read the auth code first."}`,
+	)
+	fixture.insertPartAt(
+		t,
+		"part-a",
+		"msg-2",
+		"session-001",
+		"2026-07-06T13:00:03Z",
+		`{"type":"text","text":"I'll inspect the auth code first."}`,
+	)
+	fixture.insertPartAt(
+		t,
+		"part-4",
+		"msg-2",
+		"session-001",
+		"2026-07-06T13:00:04Z",
+		`{"type":"tool_use","id":"call-1","name":"Read","input":{"file_path":"auth.go"}}`,
+	)
+	fixture.insertMessage(
+		t,
+		"msg-3",
+		"session-001",
+		"2026-07-06T13:00:03Z",
+		`{"role":"user"}`,
+	)
+	fixture.insertPart(
+		t,
+		"part-5",
+		"msg-3",
+		"session-001",
+		`{"type":"tool_result","tool_use_id":"call-1","content":"package auth"}`,
+	)
 
 	provider, ok := NewProvider(AgentZCode, ProviderConfig{
 		Roots: []string{
@@ -246,10 +369,27 @@ func TestZCodeProviderSourceMethodsAndParse(t *testing.T) {
 	assert.Equal(t, "/Users/alice/code/acme-app", sess.Cwd)
 	assert.Equal(t, "Acme session", sess.SessionName)
 	assert.Equal(t, "Acme session", sess.FirstMessage)
-	assert.Equal(t, 0, sess.MessageCount)
-	assert.Equal(t, 0, sess.UserMessageCount)
+	assert.Equal(t, 3, sess.MessageCount)
+	assert.Equal(t, 2, sess.UserMessageCount)
 	assert.Equal(t, fixture.DBPath+"#session-001", sess.File.Path)
 	assert.NotZero(t, sess.File.Size)
+	require.Len(t, result.Result.Messages, 3)
+	assert.Equal(t, RoleUser, result.Result.Messages[0].Role)
+	assert.Equal(t, "Inspect the login flow.", result.Result.Messages[0].Content)
+	assert.Equal(t, RoleAssistant, result.Result.Messages[1].Role)
+	assert.True(t, result.Result.Messages[1].HasThinking)
+	assert.True(t, result.Result.Messages[1].HasToolUse)
+	assert.Equal(t, "claude-sonnet-4-6", result.Result.Messages[1].Model)
+	assert.Equal(
+		t,
+		"[Thinking]\nI should read the auth code first.\n[/Thinking]\nI'll inspect the auth code first.",
+		result.Result.Messages[1].Content,
+	)
+	require.Len(t, result.Result.Messages[1].ToolCalls, 1)
+	assert.Equal(t, "Read", result.Result.Messages[1].ToolCalls[0].Category)
+	assert.Equal(t, RoleUser, result.Result.Messages[2].Role)
+	require.Len(t, result.Result.Messages[2].ToolResults, 1)
+	assert.Equal(t, "package auth", DecodeContent(result.Result.Messages[2].ToolResults[0].ContentRaw))
 	assert.Equal(t, 2, len(result.Result.UsageEvents))
 	assert.Equal(t, 275, sess.TotalOutputTokens)
 	assert.True(t, sess.HasTotalOutputTokens)
@@ -338,6 +478,221 @@ func TestZCodeUsageEventMapping(t *testing.T) {
 	assert.Contains(t, event.DedupKey, "turn=turn-alpha")
 	assert.Contains(t, event.DedupKey, "provider=builtin:bigmodel-coding-plan")
 	assert.Contains(t, event.DedupKey, "model=claude-sonnet-4-6")
+}
+
+func TestZCodeIngestsTranscriptMessages(t *testing.T) {
+	fixture := newZCodeTestFixture(t)
+	fixture.insertSession(
+		t,
+		"session-transcript",
+		"/Users/alice/code/acme-app",
+		"Transcript session",
+		"2026-07-06T13:00:01Z",
+		"2026-07-06T13:05:00Z",
+		"",
+		"",
+	)
+	fixture.insertMessage(
+		t,
+		"msg-1",
+		"session-transcript",
+		"2026-07-06T13:00:01Z",
+		`{"role":"user"}`,
+	)
+	fixture.insertPart(
+		t,
+		"part-1",
+		"msg-1",
+		"session-transcript",
+		`{"type":"text","text":"Fix the login bug."}`,
+	)
+	fixture.insertMessage(
+		t,
+		"msg-2",
+		"session-transcript",
+		"2026-07-06T13:00:02Z",
+		`{"role":"assistant","model":{"modelID":"claude-sonnet-4-6"}}`,
+	)
+	fixture.insertPartAt(
+		t,
+		"part-z",
+		"msg-2",
+		"session-transcript",
+		"2026-07-06T13:00:02Z",
+		`{"type":"thinking","thinking":"I should inspect the auth flow."}`,
+	)
+	fixture.insertPartAt(
+		t,
+		"part-a",
+		"msg-2",
+		"session-transcript",
+		"2026-07-06T13:00:03Z",
+		`{"type":"text","text":"I'll inspect the auth flow."}`,
+	)
+
+	result, err := parseZCodeSession(fixture.DBPath, "session-transcript", "devbox")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 2, result.Session.MessageCount)
+	assert.Equal(t, 1, result.Session.UserMessageCount)
+	require.Len(t, result.Messages, 2)
+	assert.Equal(t, RoleUser, result.Messages[0].Role)
+	assert.Equal(t, "Fix the login bug.", result.Messages[0].Content)
+	assert.Equal(t, RoleAssistant, result.Messages[1].Role)
+	assert.True(t, result.Messages[1].HasThinking)
+	assert.Equal(t, "I should inspect the auth flow.", result.Messages[1].ThinkingText)
+	assert.Equal(
+		t,
+		"[Thinking]\nI should inspect the auth flow.\n[/Thinking]\nI'll inspect the auth flow.",
+		result.Messages[1].Content,
+	)
+	assert.Equal(t, "claude-sonnet-4-6", result.Messages[1].Model)
+}
+
+func TestZCodeToolCallsAndResults(t *testing.T) {
+	fixture := newZCodeTestFixture(t)
+	fixture.insertSession(
+		t,
+		"session-tools",
+		"/Users/alice/code/acme-app",
+		"Tool session",
+		"2026-07-06T13:00:01Z",
+		"2026-07-06T13:05:00Z",
+		"",
+		"",
+	)
+	fixture.insertMessage(
+		t,
+		"msg-1",
+		"session-tools",
+		"2026-07-06T13:00:01Z",
+		`{"role":"assistant","modelID":"claude-sonnet-4-6"}`,
+	)
+	fixture.insertPart(
+		t,
+		"part-1",
+		"msg-1",
+		"session-tools",
+		`{"type":"tool_use","id":"call-read","name":"Read","input":{"file_path":"auth.go"}}`,
+	)
+	fixture.insertMessage(
+		t,
+		"msg-2",
+		"session-tools",
+		"2026-07-06T13:00:02Z",
+		`{"role":"user"}`,
+	)
+	fixture.insertPart(
+		t,
+		"part-2",
+		"msg-2",
+		"session-tools",
+		`{"type":"tool_result","tool_use_id":"call-read","content":"package auth"}`,
+	)
+
+	result, err := parseZCodeSession(fixture.DBPath, "session-tools", "devbox")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Messages, 2)
+
+	assistant := result.Messages[0]
+	assert.Equal(t, RoleAssistant, assistant.Role)
+	assert.True(t, assistant.HasToolUse)
+	require.Len(t, assistant.ToolCalls, 1)
+	assert.Equal(t, "call-read", assistant.ToolCalls[0].ToolUseID)
+	assert.Equal(t, "Read", assistant.ToolCalls[0].ToolName)
+	assert.Equal(t, "Read", assistant.ToolCalls[0].Category)
+	assert.Equal(t, `{"file_path":"auth.go"}`, assistant.ToolCalls[0].InputJSON)
+
+	toolResult := result.Messages[1]
+	assert.Equal(t, RoleUser, toolResult.Role)
+	require.Len(t, toolResult.ToolResults, 1)
+	assert.Equal(t, "call-read", toolResult.ToolResults[0].ToolUseID)
+	assert.Equal(t, len("package auth"), toolResult.ToolResults[0].ContentLength)
+	assert.Equal(t, "package auth", DecodeContent(toolResult.ToolResults[0].ContentRaw))
+}
+
+func TestZCodeOpenCodeStyleReasoningAndToolParts(t *testing.T) {
+	fixture := newZCodeTestFixture(t)
+	fixture.insertSession(
+		t,
+		"session-opencode-parts",
+		"/Users/alice/code/acme-app",
+		"OpenCode-style parts",
+		"2026-07-06T13:00:01Z",
+		"2026-07-06T13:05:00Z",
+		"",
+		"",
+	)
+	fixture.insertMessage(
+		t,
+		"msg-1",
+		"session-opencode-parts",
+		"2026-07-06T13:00:01Z",
+		`{"role":"user"}`,
+	)
+	fixture.insertPart(
+		t,
+		"part-1",
+		"msg-1",
+		"session-opencode-parts",
+		`{"type":"text","text":"Inspect the auth flow."}`,
+	)
+	fixture.insertMessage(
+		t,
+		"msg-2",
+		"session-opencode-parts",
+		"2026-07-06T13:00:02Z",
+		`{"role":"assistant","modelID":"claude-sonnet-4-6"}`,
+	)
+	fixture.insertPartAt(
+		t,
+		"part-b",
+		"msg-2",
+		"session-opencode-parts",
+		"2026-07-06T13:00:02Z",
+		`{"type":"reasoning","text":"I should inspect the auth flow."}`,
+	)
+	fixture.insertPartAt(
+		t,
+		"part-c",
+		"msg-2",
+		"session-opencode-parts",
+		"2026-07-06T13:00:03Z",
+		`{"type":"text","text":"I'll inspect the auth flow."}`,
+	)
+	fixture.insertPartAt(
+		t,
+		"part-a",
+		"msg-2",
+		"session-opencode-parts",
+		"2026-07-06T13:00:04Z",
+		`{"type":"tool","tool":"Read","callID":"call-read","state":{"input":{"file_path":"auth.go"},"output":"package auth"}}`,
+	)
+
+	result, err := parseZCodeSession(fixture.DBPath, "session-opencode-parts", "devbox")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Messages, 2)
+
+	assistant := result.Messages[1]
+	assert.Equal(t, RoleAssistant, assistant.Role)
+	assert.True(t, assistant.HasThinking)
+	assert.True(t, assistant.HasToolUse)
+	assert.Equal(t, "I should inspect the auth flow.", assistant.ThinkingText)
+	assert.Equal(
+		t,
+		"[Thinking]\nI should inspect the auth flow.\n[/Thinking]\nI'll inspect the auth flow.",
+		assistant.Content,
+	)
+	require.Len(t, assistant.ToolCalls, 1)
+	assert.Equal(t, "call-read", assistant.ToolCalls[0].ToolUseID)
+	assert.Equal(t, "Read", assistant.ToolCalls[0].ToolName)
+	assert.Equal(t, `{"file_path":"auth.go"}`, assistant.ToolCalls[0].InputJSON)
+	require.Len(t, assistant.ToolResults, 1)
+	assert.Equal(t, "call-read", assistant.ToolResults[0].ToolUseID)
+	assert.Equal(t, len("package auth"), assistant.ToolResults[0].ContentLength)
+	assert.Equal(t, "package auth", DecodeContent(assistant.ToolResults[0].ContentRaw))
 }
 
 func TestZCodeFingerprintTracksUsageMtime(t *testing.T) {
@@ -501,6 +856,47 @@ func TestZCodeParsesSessionWhenUsageTableIsMissing(t *testing.T) {
 	assert.False(t, result.Session.HasPeakContextTokens)
 }
 
+func TestZCodeMissingTranscriptTables(t *testing.T) {
+	fixture := newZCodeTestFixture(t)
+	_, err := fixture.database.Exec(`DROP TABLE part`)
+	require.NoError(t, err)
+	_, err = fixture.database.Exec(`DROP TABLE message`)
+	require.NoError(t, err)
+	fixture.insertSession(
+		t,
+		"session-no-transcript",
+		"/Users/alice/code/acme-app",
+		"No transcript",
+		"2026-07-06T13:00:01Z",
+		"2026-07-06T13:05:00Z",
+		"",
+		"",
+	)
+	fixture.insertUsage(
+		t,
+		"session-no-transcript",
+		"1",
+		"builtin:bigmodel-coding-plan",
+		"claude-sonnet-4-6",
+		"done",
+		1000, 200, 40, 50, 25, 1315,
+		"2026-07-06T13:00:02Z",
+		"2026-07-06T13:00:03Z",
+		1000,
+		2,
+	)
+
+	result, err := parseZCodeSession(fixture.DBPath, "session-no-transcript", "devbox")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 0, result.Session.MessageCount)
+	assert.Equal(t, 0, result.Session.UserMessageCount)
+	assert.Empty(t, result.Messages)
+	require.Len(t, result.UsageEvents, 1)
+	assert.Equal(t, 200, result.Session.TotalOutputTokens)
+	assert.True(t, result.Session.HasTotalOutputTokens)
+}
+
 func TestZCodeProviderRootWithoutDB(t *testing.T) {
 	root := t.TempDir()
 	cliRoot := filepath.Join(root, ".zcode", "cli")
@@ -522,4 +918,38 @@ func nullableZCodeString(v string) any {
 		return nil
 	}
 	return v
+}
+func TestZCodeSystemMessagesAreMarkedSystem(t *testing.T) {
+	fixture := newZCodeTestFixture(t)
+	fixture.insertSession(
+		t,
+		"session-system",
+		"/Users/alice/code/acme-app",
+		"System session",
+		"2026-07-06T13:00:01Z",
+		"2026-07-06T13:05:00Z",
+		"",
+		"",
+	)
+	fixture.insertMessage(
+		t,
+		"msg-system",
+		"session-system",
+		"2026-07-06T13:00:01Z",
+		`{"role":"system"}`,
+	)
+	fixture.insertPart(
+		t,
+		"part-system",
+		"msg-system",
+		"session-system",
+		`{"type":"text","text":"You are a code reviewer."}`,
+	)
+
+	result, err := parseZCodeSession(fixture.DBPath, "session-system", "devbox")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Messages, 1)
+	assert.Equal(t, RoleSystem, result.Messages[0].Role)
+	assert.True(t, result.Messages[0].IsSystem)
 }

--- a/internal/parser/zcode_test.go
+++ b/internal/parser/zcode_test.go
@@ -695,6 +695,49 @@ func TestZCodeOpenCodeStyleReasoningAndToolParts(t *testing.T) {
 	assert.Equal(t, "package auth", DecodeContent(assistant.ToolResults[0].ContentRaw))
 }
 
+func TestZCodeOpenCodeStyleFailedToolPart(t *testing.T) {
+	fixture := newZCodeTestFixture(t)
+	fixture.insertSession(
+		t,
+		"session-tool-error",
+		"/Users/alice/code/acme-app",
+		"Tool error",
+		"2026-07-06T13:00:01Z",
+		"2026-07-06T13:05:00Z",
+		"",
+		"",
+	)
+	fixture.insertMessage(
+		t,
+		"msg-1",
+		"session-tool-error",
+		"2026-07-06T13:00:02Z",
+		`{"role":"assistant","modelID":"claude-sonnet-4-6"}`,
+	)
+	fixture.insertPartAt(
+		t,
+		"part-1",
+		"msg-1",
+		"session-tool-error",
+		"2026-07-06T13:00:03Z",
+		`{"type":"tool","tool":"Read","callID":"call-read","state":{"input":{"file_path":"auth.go"},"error":"permission denied"}}`,
+	)
+
+	result, err := parseZCodeSession(fixture.DBPath, "session-tool-error", "devbox")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, result.Messages, 1)
+
+	assistant := result.Messages[0]
+	assert.Equal(t, RoleAssistant, assistant.Role)
+	assert.True(t, assistant.HasToolUse)
+	require.Len(t, assistant.ToolCalls, 1)
+	require.Len(t, assistant.ToolResults, 1)
+	assert.Equal(t, "call-read", assistant.ToolResults[0].ToolUseID)
+	assert.Equal(t, len("permission denied"), assistant.ToolResults[0].ContentLength)
+	assert.Equal(t, "permission denied", DecodeContent(assistant.ToolResults[0].ContentRaw))
+}
+
 func TestZCodeFingerprintTracksUsageMtime(t *testing.T) {
 	fixture := newZCodeTestFixture(t)
 	fixture.insertSession(

--- a/internal/sync/provider_process_test.go
+++ b/internal/sync/provider_process_test.go
@@ -302,7 +302,11 @@ func TestProcessFileProviderZCodeVirtualSource(t *testing.T) {
 	assert.Equal(t, "zcode:session-001", res.results[0].Session.ID)
 	assert.Equal(t, parser.AgentZCode, res.results[0].Session.Agent)
 	assert.Equal(t, "devbox", res.results[0].Session.Machine)
-	assert.Empty(t, res.results[0].Messages)
+	require.Len(t, res.results[0].Messages, 3)
+	assert.Equal(t, parser.RoleAssistant, res.results[0].Messages[1].Role)
+	assert.True(t, res.results[0].Messages[1].HasToolUse)
+	require.Len(t, res.results[0].Messages[1].ToolCalls, 1)
+	assert.Equal(t, "call-read", res.results[0].Messages[1].ToolCalls[0].ToolUseID)
 	require.Len(t, res.results[0].UsageEvents, 1)
 	assert.Equal(t, 1, res.results[0].UsageEvents[0].InputTokens)
 	assert.Equal(t, 2, res.results[0].UsageEvents[0].OutputTokens)
@@ -1435,6 +1439,18 @@ func writeProcessProviderZCodeDB(t *testing.T, cliRoot string) string {
 			duration_ms INTEGER,
 			tool_call_count INTEGER
 		);
+		CREATE TABLE message (
+			id TEXT PRIMARY KEY NOT NULL,
+			session_id TEXT NOT NULL,
+			time_created TEXT,
+			data TEXT
+		);
+		CREATE TABLE part (
+			id TEXT PRIMARY KEY NOT NULL,
+			message_id TEXT NOT NULL,
+			session_id TEXT NOT NULL,
+			data TEXT
+		);
 	`)
 	mustExecProcessProviderSQL(t, database,
 		`INSERT INTO session (
@@ -1455,6 +1471,45 @@ func writeProcessProviderZCodeDB(t *testing.T, cliRoot string) string {
 		"session-001", "1", "builtin:bigmodel-coding-plan", "claude-sonnet-4-6", "done",
 		int64(1), int64(2), int64(0), int64(0), int64(0), int64(3),
 		"2026-07-06T13:00:02Z", "2026-07-06T13:00:03Z", int64(1000), int64(1),
+	)
+	mustExecProcessProviderSQL(t, database,
+		`INSERT INTO message (
+			id, session_id, time_created, data
+		) VALUES (?, ?, ?, ?)`,
+		"msg-1", "session-001", "2026-07-06T13:00:01Z", `{"role":"user"}`,
+	)
+	mustExecProcessProviderSQL(t, database,
+		`INSERT INTO part (
+			id, message_id, session_id, data
+		) VALUES (?, ?, ?, ?)`,
+		"part-1", "msg-1", "session-001", `{"type":"text","text":"Inspect the auth flow."}`,
+	)
+	mustExecProcessProviderSQL(t, database,
+		`INSERT INTO message (
+			id, session_id, time_created, data
+		) VALUES (?, ?, ?, ?)`,
+		"msg-2", "session-001", "2026-07-06T13:00:02Z",
+		`{"role":"assistant","modelID":"claude-sonnet-4-6"}`,
+	)
+	mustExecProcessProviderSQL(t, database,
+		`INSERT INTO part (
+			id, message_id, session_id, data
+		) VALUES (?, ?, ?, ?)`,
+		"part-2", "msg-2", "session-001",
+		`{"type":"tool_use","id":"call-read","name":"Read","input":{"file_path":"auth.go"}}`,
+	)
+	mustExecProcessProviderSQL(t, database,
+		`INSERT INTO message (
+			id, session_id, time_created, data
+		) VALUES (?, ?, ?, ?)`,
+		"msg-3", "session-001", "2026-07-06T13:00:03Z", `{"role":"user"}`,
+	)
+	mustExecProcessProviderSQL(t, database,
+		`INSERT INTO part (
+			id, message_id, session_id, data
+		) VALUES (?, ?, ?, ?)`,
+		"part-3", "msg-3", "session-001",
+		`{"type":"tool_result","tool_use_id":"call-read","content":"package auth"}`,
 	)
 	return dbPath
 }

--- a/internal/sync/zcode_integration_test.go
+++ b/internal/sync/zcode_integration_test.go
@@ -13,7 +13,7 @@ import (
 	"go.kenn.io/agentsview/internal/parser"
 )
 
-func TestSyncZCode(t *testing.T) {
+func TestSyncZCodeTranscript(t *testing.T) {
 	root := t.TempDir()
 	dbPath := writeProcessProviderZCodeDB(t, filepath.Join(root, ".zcode", "cli"))
 	database := openTestDB(t)
@@ -29,12 +29,21 @@ func TestSyncZCode(t *testing.T) {
 	sess, err := database.GetSession(context.Background(), "zcode:session-001")
 	require.NoError(t, err)
 	require.NotNil(t, sess)
-	assert.Equal(t, 0, sess.MessageCount)
+	assert.Equal(t, 2, sess.MessageCount)
 	assert.Equal(t, "acme_app", sess.Project)
 	assert.Equal(t, dbPath+"#session-001", database.GetSessionFilePath("zcode:session-001"))
 	_, storedMtime, ok := database.GetSessionFileInfo("zcode:session-001")
 	require.True(t, ok)
 	assert.Equal(t, engine.SourceMtime("zcode:session-001"), storedMtime)
+
+	msgs, err := database.GetMessages(context.Background(), "zcode:session-001", 0, 100, true)
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "Inspect the auth flow.", msgs[0].Content)
+	assert.Equal(t, "assistant", msgs[1].Role)
+	require.Len(t, msgs[1].ToolCalls, 1)
+	assert.Equal(t, "Read", msgs[1].ToolCalls[0].ToolName)
+	assert.Equal(t, "package auth", msgs[1].ToolCalls[0].ResultContent)
 
 	events, err := database.GetUsageEvents(context.Background(), "zcode:session-001")
 	require.NoError(t, err)


### PR DESCRIPTION
ZCode sessions already sync into agentsview with metadata and aggregate token usage, but their transcript tables were not parsed, so every ZCode session rendered with zero messages. The session data already lives in message and part rows under ~/.zcode/cli/db/db.sqlite; agentsview was stopping at session and model_usage.

This change extends the ZCode provider to read the transcript rows and build normal parsed messages from them. Role and model come from each message row, text and reasoning blocks become message content, tool-call blocks become categorized tool calls, tool-result blocks become tool results, and session message counts now reflect the ingested transcript. The parser accepts ZCode's native OpenCode-style part rows, including reasoning blocks and tool blocks with tool, callID, nested state.input / state.output, and failed-tool state.error payloads, while still handling the earlier thinking, tool_use, and tool_result shapes. Missing transcript tables still parse as metadata-plus-usage sessions, so older databases keep their current fallback behavior.

Token totals stay sourced from model_usage, which is the existing ZCode usage authority. The parser data version bump reparses existing archived ZCode sessions so the next full resync backfills transcript content already present in the database.

Closes #1050
