### PR TITLE
fix(stats): align session counts with list visibility (#1048)

### DIFF
--- a/cmd/agentsview/stats.go
+++ b/cmd/agentsview/stats.go
@@ -25,6 +25,7 @@ func newStatsCommand() *cobra.Command {
 	var (
 		since, until, agent, timezone         string
 		includeProjects, excludeProjects      []string
+		includeOneShot, includeAutomated      bool
 		includeGitOutcomes, includeGHOutcomes bool
 	)
 	cmd := &cobra.Command{
@@ -57,15 +58,18 @@ func newStatsCommand() *cobra.Command {
 				ghToken = resolveGitHubToken(cmd.Context())
 			}
 			stats, err := svc.Stats(cmd.Context(), service.StatsFilter{
-				Since:                 since,
-				Until:                 until,
-				Agent:                 agentFilter,
-				IncludeProjects:       includeProjects,
-				ExcludeProjects:       excludeProjects,
-				Timezone:              timezone,
-				IncludeGitOutcomes:    includeGitOutcomes,
-				IncludeGitHubOutcomes: includeGHOutcomes,
-				GHToken:               ghToken,
+				ApplyDefaultVisibility: true,
+				Since:                  since,
+				Until:                  until,
+				Agent:                  agentFilter,
+				IncludeOneShot:         includeOneShot,
+				IncludeAutomated:       includeAutomated,
+				IncludeProjects:        includeProjects,
+				ExcludeProjects:        excludeProjects,
+				Timezone:               timezone,
+				IncludeGitOutcomes:     includeGitOutcomes,
+				IncludeGitHubOutcomes:  includeGHOutcomes,
+				GHToken:                ghToken,
 			})
 			if err != nil {
 				return err
@@ -80,6 +84,7 @@ func newStatsCommand() *cobra.Command {
 	registerFormatFlags(cmd.Flags())
 	registerStatsFlags(cmd,
 		&since, &until, &agent, &timezone,
+		&includeOneShot, &includeAutomated,
 		&includeProjects, &excludeProjects,
 		&includeGitOutcomes, &includeGHOutcomes,
 	)
@@ -116,6 +121,7 @@ func resolveGitHubToken(ctx context.Context) string {
 func registerStatsFlags(
 	cmd *cobra.Command,
 	since, until, agent, timezone *string,
+	includeOneShot, includeAutomated *bool,
 	includeProjects, excludeProjects *[]string,
 	includeGitOutcomes, includeGHOutcomes *bool,
 ) {
@@ -126,6 +132,10 @@ func registerStatsFlags(
 		"End of window (YYYY-MM-DD; default: now)")
 	f.StringVar(agent, "agent", "all",
 		"Filter by agent (claude, codex, cursor, ... or 'all')")
+	f.BoolVar(includeOneShot, "include-one-shot", false,
+		"Include one-shot sessions (excluded by default)")
+	f.BoolVar(includeAutomated, "include-automated", false,
+		"Include automated sessions (excluded by default)")
 	f.StringArrayVar(includeProjects, "include-project", nil,
 		"Restrict to these projects (repeatable)")
 	f.StringArrayVar(excludeProjects, "exclude-project", nil,

--- a/cmd/agentsview/stats_test.go
+++ b/cmd/agentsview/stats_test.go
@@ -432,7 +432,7 @@ func TestStatsCommandSkipsReadOnlyDaemon(t *testing.T) {
 	assert.False(t, called, "read-only daemon stats endpoint should be skipped")
 	var got db.SessionStats
 	require.NoError(t, json.Unmarshal([]byte(out), &got))
-	assert.Equal(t, len(goldenFixtureSessions), got.Totals.SessionsAll)
+	assert.Equal(t, 9, got.Totals.SessionsAll)
 }
 
 // updateGolden toggles regeneration of stats_golden.json.

--- a/cmd/agentsview/testdata/stats_golden.json
+++ b/cmd/agentsview/testdata/stats_golden.json
@@ -2,35 +2,35 @@
   "adoption": {
     "claude_only": true,
     "distinct_skills": 1,
-    "plan_mode_rate": 0.1111111111111111,
-    "subagents_per_session": 0.2222222222222222
+    "plan_mode_rate": 0.14285714285714285,
+    "subagents_per_session": 0.2857142857142857
   },
   "agent_portfolio": {
     "by_messages": {
-      "claude": 322,
+      "claude": 318,
       "codex": 20,
       "cursor": 6
     },
     "by_messages_human": {
-      "claude": 322,
+      "claude": 318,
       "codex": 20,
       "cursor": 6
     },
     "by_sessions": {
-      "claude": 9,
+      "claude": 7,
       "codex": 1,
       "cursor": 1
     },
     "by_sessions_human": {
-      "claude": 9,
+      "claude": 7,
       "codex": 1,
       "cursor": 1
     },
     "by_tokens": {
-      "claude": 151420
+      "claude": 151020
     },
     "by_tokens_human": {
-      "claude": 151420
+      "claude": 151020
     },
     "primary": "claude",
     "primary_human": "claude"
@@ -39,9 +39,9 @@
     "automation": 0,
     "deep": 2,
     "marathon": 1,
-    "primary": "quick",
-    "primary_human": "quick",
-    "quick": 5,
+    "primary": "standard",
+    "primary_human": "standard",
+    "quick": 3,
     "standard": 3
   },
   "cache_economics": {
@@ -62,7 +62,7 @@
           ]
         },
         {
-          "count": 9,
+          "count": 7,
           "edge": [
             0.5,
             0.75
@@ -83,11 +83,11 @@
           ]
         }
       ],
-      "overall": 0.5793498147018812
+      "overall": 0.579437494120967
     },
     "claude_only": true,
-    "dollars_saved_vs_uncached": 2.373315,
-    "dollars_spent": 6.751545
+    "dollars_saved_vs_uncached": 2.3702250000000005,
+    "dollars_spent": 6.7420350000000004
   },
   "code_attribution": {
     "sources": [
@@ -113,14 +113,14 @@
             ]
           },
           {
-            "count": 1,
+            "count": 0,
             "edge": [
               1,
               5
             ]
           },
           {
-            "count": 3,
+            "count": 2,
             "edge": [
               5,
               20
@@ -148,7 +148,7 @@
             ]
           }
         ],
-        "mean": 60.36363636363637
+        "mean": 72.77777777777777
       },
       "scope_human": {
         "buckets": [
@@ -160,14 +160,14 @@
             ]
           },
           {
-            "count": 1,
+            "count": 0,
             "edge": [
               1,
               5
             ]
           },
           {
-            "count": 3,
+            "count": 2,
             "edge": [
               5,
               20
@@ -195,12 +195,12 @@
             ]
           }
         ],
-        "mean": 60.36363636363637
+        "mean": 72.77777777777777
       }
     },
     "peak_context_tokens": {
       "claude_only": false,
-      "null_count": 4,
+      "null_count": 2,
       "scope_all": {
         "buckets": [
           {
@@ -300,7 +300,7 @@
       "scope_all": {
         "buckets": [
           {
-            "count": 9,
+            "count": 7,
             "edge": [
               0,
               1
@@ -342,12 +342,12 @@
             ]
           }
         ],
-        "mean": 0.3195454545454545
+        "mean": 0.39055555555555554
       },
       "scope_human": {
         "buckets": [
           {
-            "count": 9,
+            "count": 7,
             "edge": [
               0,
               1
@@ -389,14 +389,14 @@
             ]
           }
         ],
-        "mean": 0.3195454545454545
+        "mean": 0.39055555555555554
       }
     },
     "user_messages": {
       "scope_all": {
         "buckets": [
           {
-            "count": 2,
+            "count": 0,
             "edge": [
               0,
               2
@@ -438,7 +438,7 @@
             ]
           }
         ],
-        "mean": 15.818181818181818
+        "mean": 19.11111111111111
       },
       "scope_human": {
         "buckets": [
@@ -490,36 +490,26 @@
   "model_mix": {
     "by_tokens": {
       "claude-opus-4-20250514": 33740,
-      "claude-sonnet-4-20250514": 117680
+      "claude-sonnet-4-20250514": 117280
     }
   },
   "outcomes": {
-    "avg_edit_churn": 0.7777777777777778,
+    "avg_edit_churn": 1,
     "claude_only": true,
-    "compactions_per_session": 0.3333333333333333,
+    "compactions_per_session": 0.42857142857142855,
     "failure": 1,
     "grade_distribution": {
-      "A": 5,
+      "A": 3,
       "B": 3,
       "C": 1
     },
-    "success": 8,
+    "success": 6,
     "tool_retry_rate": 0.23076923076923078,
     "unknown": 0
   },
   "schema_version": 1,
   "temporal": {
     "hourly_utc": [
-      {
-        "sessions": 1,
-        "ts": "2026-04-05T10:00:00Z",
-        "user_messages": 1
-      },
-      {
-        "sessions": 1,
-        "ts": "2026-04-05T11:00:00Z",
-        "user_messages": 1
-      },
       {
         "sessions": 1,
         "ts": "2026-04-06T10:00:00Z",
@@ -583,12 +573,12 @@
     "total_calls": 26
   },
   "totals": {
-    "messages_total": 348,
-    "sessions_all": 11,
+    "messages_total": 344,
+    "sessions_all": 9,
     "sessions_automation": 0,
-    "sessions_human": 11,
+    "sessions_human": 9,
     "sessions_subagent": 0,
-    "user_messages_total": 174
+    "user_messages_total": 172
   },
   "velocity": {
     "first_response_seconds": {
@@ -596,7 +586,7 @@
       "p50": 10,
       "p90": 10
     },
-    "messages_per_active_hour": 126.67340748230536,
+    "messages_per_active_hour": 125.47112462006079,
     "turn_cycle_seconds": {
       "mean": 10,
       "p50": 10,

--- a/internal/db/query_dialect.go
+++ b/internal/db/query_dialect.go
@@ -586,24 +586,9 @@ func sessionFilterPredicates(
 		preds = append(preds, pred)
 	}
 
-	scope := normalizeAutomatedScope(f.AutomatedScope, f.ExcludeAutomated)
-	oneShotPred := ""
-	if f.ExcludeOneShot {
-		pred := oneShotPredicate(f, b, q, scope)
-		if f.IncludeChildren {
-			oneShotPred = pred
-		} else {
-			preds = append(preds, pred)
-		}
-	}
-	switch scope {
-	case "human":
-		preds = append(preds, q("is_automated")+" = "+
-			b.dialect.falseLiteral)
-	case "automated":
-		preds = append(preds, q("is_automated")+" = "+
-			b.dialect.trueLiteral)
-	}
+	preds, oneShotPred := appendSessionVisibilityPredicates(
+		preds, f, b, q,
+	)
 	if len(f.Outcome) > 0 {
 		preds = append(preds,
 			inPredicate(q("outcome"), f.Outcome, b))
@@ -630,6 +615,33 @@ func sessionFilterPredicates(
 		preds = append(preds,
 			"EXISTS (SELECT 1 FROM starred_sessions ss WHERE ss.session_id = "+
 				q("id")+")")
+	}
+	return preds, oneShotPred
+}
+
+func appendSessionVisibilityPredicates(
+	preds []string,
+	f SessionFilter,
+	b *QueryBuilder,
+	q func(string) string,
+) ([]string, string) {
+	scope := normalizeAutomatedScope(f.AutomatedScope, f.ExcludeAutomated)
+	oneShotPred := ""
+	if f.ExcludeOneShot {
+		pred := oneShotPredicate(f, b, q, scope)
+		if f.IncludeChildren {
+			oneShotPred = pred
+		} else {
+			preds = append(preds, pred)
+		}
+	}
+	switch scope {
+	case "human":
+		preds = append(preds, q("is_automated")+" = "+
+			b.dialect.falseLiteral)
+	case "automated":
+		preds = append(preds, q("is_automated")+" = "+
+			b.dialect.trueLiteral)
 	}
 	return preds, oneShotPred
 }

--- a/internal/db/session_stats.go
+++ b/internal/db/session_stats.go
@@ -19,15 +19,18 @@ import (
 // StatsFilter mirrors the service-layer StatsFilter but lives in db
 // because db functions take typed filters without cross-package deps.
 type StatsFilter struct {
-	Since                 string
-	Until                 string
-	Agent                 string
-	IncludeProjects       []string
-	ExcludeProjects       []string
-	Timezone              string
-	IncludeGitOutcomes    bool
-	IncludeGitHubOutcomes bool
-	GHToken               string
+	Since                  string
+	Until                  string
+	Agent                  string
+	ApplyDefaultVisibility bool
+	IncludeOneShot         bool
+	IncludeAutomated       bool
+	IncludeProjects        []string
+	ExcludeProjects        []string
+	Timezone               string
+	IncludeGitOutcomes     bool
+	IncludeGitHubOutcomes  bool
+	GHToken                string
 }
 
 // StatsInputError marks invalid user-supplied stats filters so HTTP
@@ -443,6 +446,19 @@ func (db *DB) loadSessionsInWindow(
 	args := []any{
 		from.UTC().Format(time.RFC3339Nano),
 		to.UTC().Format(time.RFC3339Nano),
+	}
+	if f.ApplyDefaultVisibility {
+		visibilityBuilder := NewQueryBuilder(SQLiteQueryDialect(), len(args))
+		preds, _ = appendSessionVisibilityPredicates(
+			preds,
+			SessionFilter{
+				ExcludeOneShot:   !f.IncludeOneShot,
+				ExcludeAutomated: !f.IncludeAutomated,
+			},
+			visibilityBuilder,
+			func(col string) string { return "s." + col },
+		)
+		args = append(args, visibilityBuilder.Args()...)
 	}
 
 	if f.Agent != "" {

--- a/internal/server/huma_routes_metadata.go
+++ b/internal/server/huma_routes_metadata.go
@@ -28,6 +28,7 @@ type statsInput struct {
 }
 
 type sessionStatsInput struct {
+	BoolIncludeInput
 	Since                 string   `query:"since" doc:"Start of window"`
 	Until                 string   `query:"until" doc:"End of window"`
 	Agent                 string   `query:"agent" doc:"Filter by agent"`
@@ -74,15 +75,18 @@ func (s *Server) humaGetSessionStats(
 		githubToken = s.githubToken(ctx)
 	}
 	stats, err := s.sessions.Stats(ctx, service.StatsFilter{
-		Since:                 in.Since,
-		Until:                 in.Until,
-		Agent:                 in.Agent,
-		IncludeProjects:       in.IncludeProjects,
-		ExcludeProjects:       in.ExcludeProjects,
-		Timezone:              in.Timezone,
-		IncludeGitOutcomes:    in.IncludeGitOutcomes,
-		IncludeGitHubOutcomes: in.IncludeGitHubOutcomes,
-		GHToken:               githubToken,
+		ApplyDefaultVisibility: true,
+		Since:                  in.Since,
+		Until:                  in.Until,
+		Agent:                  in.Agent,
+		IncludeOneShot:         in.IncludeOneShot,
+		IncludeAutomated:       in.IncludeAutomated,
+		IncludeProjects:        in.IncludeProjects,
+		ExcludeProjects:        in.ExcludeProjects,
+		Timezone:               in.Timezone,
+		IncludeGitOutcomes:     in.IncludeGitOutcomes,
+		IncludeGitHubOutcomes:  in.IncludeGitHubOutcomes,
+		GHToken:                githubToken,
 	})
 	if err != nil {
 		if handled := handleHumaContextError(err); handled != nil {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2295,6 +2295,56 @@ func TestGetStats_ExcludeOneShotDefault(t *testing.T) {
 	}
 }
 
+func TestSessionStats_DefaultVisibilityMatchesListDefaults(t *testing.T) {
+	te := setup(t)
+	startedAt := time.Now().UTC().Add(-2 * time.Hour).Format(time.RFC3339)
+	endedAt := time.Now().UTC().Add(-90 * time.Minute).Format(time.RFC3339)
+	te.seedSession(t, "deep", "my-app", 10, func(s *db.Session) {
+		s.UserMessageCount = 5
+		s.StartedAt = &startedAt
+		s.EndedAt = &endedAt
+	})
+	te.seedSession(t, "one-shot", "my-app", 5, func(s *db.Session) {
+		s.UserMessageCount = 1
+		s.StartedAt = &startedAt
+		s.EndedAt = &endedAt
+	})
+	te.seedSession(t, "automated", "my-app", 6, func(s *db.Session) {
+		fm := "You are a code reviewer. Review the code."
+		s.FirstMessage = &fm
+		s.UserMessageCount = 1
+		s.StartedAt = &startedAt
+		s.EndedAt = &endedAt
+	})
+	te.seedMessages(t, "deep", 10)
+	te.seedMessages(t, "one-shot", 5)
+	te.seedMessages(t, "automated", 6)
+
+	w := te.get(t, "/api/v1/session-stats")
+	assertStatus(t, w, http.StatusOK)
+	resp := decode[db.SessionStats](t, w)
+	assert.Equal(t, 1, resp.Totals.SessionsAll, "default sessions_all")
+	assert.Equal(t, 10, resp.Totals.MessagesTotal, "default messages_total")
+
+	w = te.get(t, "/api/v1/session-stats?include_one_shot=true")
+	assertStatus(t, w, http.StatusOK)
+	resp = decode[db.SessionStats](t, w)
+	assert.Equal(t, 2, resp.Totals.SessionsAll, "include_one_shot sessions_all")
+	assert.Equal(t, 15, resp.Totals.MessagesTotal, "include_one_shot messages_total")
+
+	w = te.get(t, "/api/v1/session-stats?include_automated=true")
+	assertStatus(t, w, http.StatusOK)
+	resp = decode[db.SessionStats](t, w)
+	assert.Equal(t, 2, resp.Totals.SessionsAll, "include_automated sessions_all")
+	assert.Equal(t, 16, resp.Totals.MessagesTotal, "include_automated messages_total")
+
+	w = te.get(t, "/api/v1/session-stats?include_one_shot=true&include_automated=true")
+	assertStatus(t, w, http.StatusOK)
+	resp = decode[db.SessionStats](t, w)
+	assert.Equal(t, 3, resp.Totals.SessionsAll, "include_all sessions_all")
+	assert.Equal(t, 21, resp.Totals.MessagesTotal, "include_all messages_total")
+}
+
 func TestListMachines_ExcludeOneShotDefault(t *testing.T) {
 	te := setup(t)
 	te.seedSession(t, "s1", "my-app", 5, func(s *db.Session) {

--- a/internal/service/direct.go
+++ b/internal/service/direct.go
@@ -1066,15 +1066,18 @@ func (b *directBackend) Stats(
 	}
 	f.Agent = normalizeStatsAgentFilter(f.Agent)
 	stats, err := b.local.GetSessionStats(ctx, db.StatsFilter{
-		Since:                 f.Since,
-		Until:                 f.Until,
-		Agent:                 f.Agent,
-		IncludeProjects:       f.IncludeProjects,
-		ExcludeProjects:       f.ExcludeProjects,
-		Timezone:              f.Timezone,
-		IncludeGitOutcomes:    f.IncludeGitOutcomes,
-		IncludeGitHubOutcomes: f.IncludeGitHubOutcomes,
-		GHToken:               f.GHToken,
+		Since:                  f.Since,
+		Until:                  f.Until,
+		Agent:                  f.Agent,
+		ApplyDefaultVisibility: f.ApplyDefaultVisibility,
+		IncludeOneShot:         f.IncludeOneShot,
+		IncludeAutomated:       f.IncludeAutomated,
+		IncludeProjects:        f.IncludeProjects,
+		ExcludeProjects:        f.ExcludeProjects,
+		Timezone:               f.Timezone,
+		IncludeGitOutcomes:     f.IncludeGitOutcomes,
+		IncludeGitHubOutcomes:  f.IncludeGitHubOutcomes,
+		GHToken:                f.GHToken,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/service/http.go
+++ b/internal/service/http.go
@@ -348,6 +348,14 @@ func (b *httpBackend) Stats(
 	setIfNotEmpty("until", f.Until)
 	setIfNotEmpty("agent", f.Agent)
 	setIfNotEmpty("timezone", f.Timezone)
+	includeOneShot := f.IncludeOneShot
+	includeAutomated := f.IncludeAutomated
+	if !f.ApplyDefaultVisibility {
+		includeOneShot = true
+		includeAutomated = true
+	}
+	q.Set("include_one_shot", strconv.FormatBool(includeOneShot))
+	q.Set("include_automated", strconv.FormatBool(includeAutomated))
 	for _, p := range f.IncludeProjects {
 		q.Add("include_project", p)
 	}

--- a/internal/service/stats_test.go
+++ b/internal/service/stats_test.go
@@ -36,6 +36,8 @@ func TestHTTPBackendStats(t *testing.T) {
 		Since:                 "2026-04-01",
 		Until:                 "2026-04-15",
 		Agent:                 "codex",
+		IncludeOneShot:        true,
+		IncludeAutomated:      true,
 		IncludeProjects:       []string{"alpha"},
 		ExcludeProjects:       []string{"beta"},
 		Timezone:              "UTC",
@@ -49,10 +51,35 @@ func TestHTTPBackendStats(t *testing.T) {
 	assert.Equal(t, "2026-04-01", gotQuery.Get("since"))
 	assert.Equal(t, "2026-04-15", gotQuery.Get("until"))
 	assert.Equal(t, "codex", gotQuery.Get("agent"))
+	assert.Equal(t, "true", gotQuery.Get("include_one_shot"))
+	assert.Equal(t, "true", gotQuery.Get("include_automated"))
 	assert.Equal(t, "alpha", gotQuery.Get("include_project"))
 	assert.Equal(t, "beta", gotQuery.Get("exclude_project"))
 	assert.Equal(t, "UTC", gotQuery.Get("timezone"))
 	assert.Equal(t, "true", gotQuery.Get("include_git_outcomes"))
 	assert.Equal(t, "true", gotQuery.Get("include_github_outcomes"))
 	assert.Equal(t, 7, stats.Totals.SessionsAll)
+}
+
+func TestHTTPBackendStatsDisablesDefaultVisibilityWithExplicitIncludes(t *testing.T) {
+	t.Parallel()
+	var gotQuery url.Values
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			gotQuery = r.URL.Query()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"schema_version":1,"totals":{"sessions_all":2}}`))
+		}))
+	t.Cleanup(srv.Close)
+	svc := service.NewHTTPBackend(srv.URL, "", false)
+
+	stats, err := svc.Stats(context.Background(), service.StatsFilter{
+		Since: "28d",
+		Agent: "all",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, stats)
+	assert.Equal(t, "true", gotQuery.Get("include_one_shot"))
+	assert.Equal(t, "true", gotQuery.Get("include_automated"))
 }

--- a/internal/service/stats_types.go
+++ b/internal/service/stats_types.go
@@ -5,15 +5,18 @@ import "go.kenn.io/agentsview/internal/db"
 
 // StatsFilter mirrors the session-stats CLI flag set.
 type StatsFilter struct {
-	Since                 string   `json:"since,omitempty"`
-	Until                 string   `json:"until,omitempty"`
-	Agent                 string   `json:"agent,omitempty"`
-	IncludeProjects       []string `json:"include_projects,omitempty"`
-	ExcludeProjects       []string `json:"exclude_projects,omitempty"`
-	Timezone              string   `json:"timezone,omitempty"`
-	IncludeGitOutcomes    bool     `json:"include_git_outcomes,omitempty"`
-	IncludeGitHubOutcomes bool     `json:"include_github_outcomes,omitempty"`
-	GHToken               string   `json:"-"`
+	ApplyDefaultVisibility bool     `json:"-"`
+	Since                  string   `json:"since,omitempty"`
+	Until                  string   `json:"until,omitempty"`
+	Agent                  string   `json:"agent,omitempty"`
+	IncludeOneShot         bool     `json:"include_one_shot,omitempty"`
+	IncludeAutomated       bool     `json:"include_automated,omitempty"`
+	IncludeProjects        []string `json:"include_projects,omitempty"`
+	ExcludeProjects        []string `json:"exclude_projects,omitempty"`
+	Timezone               string   `json:"timezone,omitempty"`
+	IncludeGitOutcomes     bool     `json:"include_git_outcomes,omitempty"`
+	IncludeGitHubOutcomes  bool     `json:"include_github_outcomes,omitempty"`
+	GHToken                string   `json:"-"`
 }
 
 // SessionStats is the transport-neutral response type; currently just


### PR DESCRIPTION
agentsview stats counted a broader session population than the default session list because the stats path bypassed the one-shot and automated visibility predicates that the list applies by default. That made the same Hermes archive report 89 sessions in the list and 789 in stats.

This change moves those default visibility predicates behind one shared database helper and applies them to stats at the two public entry points that own the default contract: the CLI stats command and the HTTP session-stats endpoint. Internal raw-service callers keep explicit control over whether they want default visibility or the broader population. The HTTP stats client now also sends include_one_shot and include_automated when default visibility is disabled, so direct and HTTP-backed stats return the same result for the same filter.

The result is one default visibility contract shared by the session list and stats across both transports.

Fixes #1048
