### PR TITLE
perf(sync): bound background watcher memory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,10 @@ Instructions for autonomous coding agents working in this repository.
 - Applies to all agent-driven work in this repo.
 - If multiple instruction files exist, follow the most specific one for the
   files you are editing.
+- Requests to review, analyze, or explain are read-only unless the user also
+  asks for changes.
+- `AGENTS.md` is the source of truth for standing rules; keep `CLAUDE.md` as a
+  symlink to it and record new durable rules here.
 
 ## Roborev
 
@@ -21,8 +25,9 @@ Instructions for autonomous coding agents working in this repository.
 1. Commit every turn that changes tracked files.
 1. Do not make empty commits. If a turn is read-only or only changes ignored
    files, state that no commit was made.
-1. Do not amend commits.
+1. Do not amend, squash, or rebase commits unless explicitly requested.
 1. Do not change branches without explicit user permission.
+1. Deliver changes through pull requests from feature branches.
 1. Do not merge pull requests. Open them and report status; merging is always
    the user's decision, even when checks are green and the change is urgent.
 
@@ -34,12 +39,45 @@ Instructions for autonomous coding agents working in this repository.
 - Do not include generated-with lines, attribution blocks, validation footers,
   or command transcripts in commit messages.
 
+## Content Hygiene
+
+- Keep private project names, hostnames, personal identities, infrastructure
+  details, and absolute user paths out of code, tests, fixtures, docs, commit
+  messages, and pull request text. Run the private-data scrub before
+  publishing.
+- Keep pull request titles and descriptions synchronized with the current diff.
+- Do not post pull request or issue comments unless explicitly requested.
+
 ## Validation
 
 - Run relevant tests before committing when practical.
 - If tests cannot be run, state that clearly in the handoff.
 - After Go code changes, run `go fmt ./...` and `go vet ./...` before
   committing.
+
+## Background Memory
+
+- Keep passive daemon memory within a few hundred megabytes on macOS, Linux, and
+  Windows. Treat sustained growth beyond that range as a regression.
+- Background watcher, polling, and sync work must be bounded by the changed
+  batch, not by total archive size. Do not scan or materialize every stored
+  session for each filesystem event.
+- Declare expensive scheduling inputs as provider capabilities and compute them
+  only for providers that observably consume them. Default new capabilities to
+  unsupported.
+- Add cardinality-scaling regressions for background paths: compare small and
+  large archives and assert that unchanged per-event work remains bounded.
+  Preserve deletion, tombstone, and persistent-archive behavior in the same
+  tests.
+- Diagnose long-running memory with allocation and CPU profiles plus live heap,
+  forced-GC heap, and operating-system physical/dirty memory. Raw RSS alone is
+  not proof of live memory because it includes clean reclaimable mappings.
+- Profile branch binaries only against isolated production-scale database and
+  source clones. Never point profiling workloads at live archives or live
+  agent transcripts.
+- Include a retention observation long enough to reproduce the reported growth
+  window. On macOS record `vmmap` physical footprint and dirty memory; use
+  portable Go allocation and heap metrics for Linux and Windows.
 
 ## Backend Parity
 
@@ -76,6 +114,11 @@ Instructions for autonomous coding agents working in this repository.
 - Do not revert user-authored or unrelated local changes unless explicitly
   requested.
 - Avoid destructive git commands unless explicitly requested.
+- Never install over a live binary, run migrations against a production
+  database, or write to live data directories without explicit permission.
+  Point branch builds and profiling runs at isolated scratch data.
+- For login or OAuth flows, give the user the exact command to run rather than
+  driving the interactive authentication flow.
 - The SQLite database is a persistent archive. Never delete, drop, truncate, or
   recreate it to handle data version changes. Schema changes use
   non-destructive migrations such as `ALTER TABLE` and `UPDATE`; parser

--- a/internal/parser/aider_provider.go
+++ b/internal/parser/aider_provider.go
@@ -301,18 +301,10 @@ func aiderParseContainer(
 
 func aiderProviderCapabilities() Capabilities {
 	return Capabilities{
-		Source: SourceCapabilities{
-			DiscoverSources:      CapabilitySupported,
-			WatchSources:         CapabilitySupported,
-			ClassifyChangedPath:  CapabilitySupported,
-			FindSource:           CapabilitySupported,
-			CompositeFingerprint: CapabilityNotApplicable,
-			IncrementalAppend:    CapabilityNotApplicable,
-			MultiSessionSource:   CapabilitySupported,
-			PerSessionErrors:     CapabilityNotApplicable,
-			ExcludedSessions:     CapabilityNotApplicable,
-			ForceReplaceOnParse:  CapabilitySupported,
-		},
+		Source: multiSessionContainerSourceCapabilities(
+			CapabilityNotApplicable,
+			CapabilityUnsupported,
+		),
 		Content: ContentCapabilities{
 			FirstMessage:         CapabilitySupported,
 			Cwd:                  CapabilitySupported,

--- a/internal/parser/capabilities.go
+++ b/internal/parser/capabilities.go
@@ -29,6 +29,7 @@ type SourceCapabilities struct {
 	DiscoverSources      CapabilitySupport
 	WatchSources         CapabilitySupport
 	ClassifyChangedPath  CapabilitySupport
+	StoredSourceHints    CapabilitySupport
 	FindSource           CapabilitySupport
 	CompositeFingerprint CapabilitySupport
 	IncrementalAppend    CapabilitySupport

--- a/internal/parser/db_backed_provider.go
+++ b/internal/parser/db_backed_provider.go
@@ -545,6 +545,7 @@ func warpProviderSpec() dbBackedProviderSpec {
 
 func dbBackedSourceCapabilities(multiSession CapabilitySupport) SourceCapabilities {
 	source := jsonlFileProviderSourceCapabilities()
+	source.StoredSourceHints = CapabilitySupported
 	source.MultiSessionSource = multiSession
 	source.ForceReplaceOnParse = CapabilitySupported
 	return source

--- a/internal/parser/kiro_provider.go
+++ b/internal/parser/kiro_provider.go
@@ -669,6 +669,7 @@ func kiroLegacyPathUnderRoot(root, path string) bool {
 
 func kiroProviderCapabilities() Capabilities {
 	source := jsonlFileProviderSourceCapabilities()
+	source.StoredSourceHints = CapabilitySupported
 	source.MultiSessionSource = CapabilitySupported
 	source.PerSessionErrors = CapabilitySupported
 	source.ForceReplaceOnParse = CapabilitySupported

--- a/internal/parser/multi_session_container.go
+++ b/internal/parser/multi_session_container.go
@@ -88,6 +88,25 @@ type multiSessionConfig struct {
 
 type MultiSessionOption func(*multiSessionConfig)
 
+func multiSessionContainerSourceCapabilities(
+	compositeFingerprint CapabilitySupport,
+	storedSourceHints CapabilitySupport,
+) SourceCapabilities {
+	return SourceCapabilities{
+		DiscoverSources:      CapabilitySupported,
+		WatchSources:         CapabilitySupported,
+		ClassifyChangedPath:  CapabilitySupported,
+		StoredSourceHints:    storedSourceHints,
+		FindSource:           CapabilitySupported,
+		CompositeFingerprint: compositeFingerprint,
+		IncrementalAppend:    CapabilityNotApplicable,
+		MultiSessionSource:   CapabilitySupported,
+		PerSessionErrors:     CapabilityNotApplicable,
+		ExcludedSessions:     CapabilityNotApplicable,
+		ForceReplaceOnParse:  CapabilitySupported,
+	}
+}
+
 func WithContainerDiscovery(fn func(root string) []string) MultiSessionOption {
 	return func(c *multiSessionConfig) { c.discoverContainers = fn }
 }

--- a/internal/parser/provider_test.go
+++ b/internal/parser/provider_test.go
@@ -147,6 +147,31 @@ func TestProviderRegistryMirrorsAgentRegistry(t *testing.T) {
 	}
 }
 
+func TestStoredSourceHintCapabilitiesMatchConsumers(t *testing.T) {
+	wantSupported := map[AgentType]bool{
+		AgentDevin:     true,
+		AgentForge:     true,
+		AgentKiro:      true,
+		AgentPiebald:   true,
+		AgentShelley:   true,
+		AgentVSCopilot: true,
+		AgentWarp:      true,
+		AgentWindsurf:  true,
+		AgentZCode:     true,
+		AgentZed:       true,
+	}
+
+	for _, factory := range ProviderFactories() {
+		agent := factory.Definition().Type
+		got := factory.Capabilities().Source.StoredSourceHints
+		if wantSupported[agent] {
+			assert.Equalf(t, CapabilitySupported, got, "%s consumes stored path hints", agent)
+		} else {
+			assert.Equalf(t, CapabilityUnsupported, got, "%s must not schedule stored path hints", agent)
+		}
+	}
+}
+
 func TestProviderFactoryLookupRejectsMissingAgent(t *testing.T) {
 	require.NotEmpty(t, Registry)
 	agent := Registry[0].Type

--- a/internal/parser/shelley_provider.go
+++ b/internal/parser/shelley_provider.go
@@ -266,18 +266,10 @@ func parseShelleyVirtualPath(path string) (string, string, bool) {
 
 func shelleyProviderCapabilities() Capabilities {
 	return Capabilities{
-		Source: SourceCapabilities{
-			DiscoverSources:      CapabilitySupported,
-			WatchSources:         CapabilitySupported,
-			ClassifyChangedPath:  CapabilitySupported,
-			FindSource:           CapabilitySupported,
-			CompositeFingerprint: CapabilitySupported,
-			IncrementalAppend:    CapabilityNotApplicable,
-			MultiSessionSource:   CapabilitySupported,
-			PerSessionErrors:     CapabilityNotApplicable,
-			ExcludedSessions:     CapabilityNotApplicable,
-			ForceReplaceOnParse:  CapabilitySupported,
-		},
+		Source: multiSessionContainerSourceCapabilities(
+			CapabilitySupported,
+			CapabilitySupported,
+		),
 		Content: ContentCapabilities{
 			FirstMessage:         CapabilitySupported,
 			SessionName:          CapabilitySupported,

--- a/internal/parser/visualstudio_copilot_provider.go
+++ b/internal/parser/visualstudio_copilot_provider.go
@@ -666,18 +666,10 @@ func visualStudioCopilotTraceUnderRoot(
 
 func visualStudioCopilotProviderCapabilities() Capabilities {
 	return Capabilities{
-		Source: SourceCapabilities{
-			DiscoverSources:      CapabilitySupported,
-			WatchSources:         CapabilitySupported,
-			ClassifyChangedPath:  CapabilitySupported,
-			FindSource:           CapabilitySupported,
-			CompositeFingerprint: CapabilitySupported,
-			IncrementalAppend:    CapabilityNotApplicable,
-			MultiSessionSource:   CapabilitySupported,
-			PerSessionErrors:     CapabilityNotApplicable,
-			ExcludedSessions:     CapabilityNotApplicable,
-			ForceReplaceOnParse:  CapabilitySupported,
-		},
+		Source: multiSessionContainerSourceCapabilities(
+			CapabilitySupported,
+			CapabilitySupported,
+		),
 		Content: ContentCapabilities{
 			FirstMessage:         CapabilitySupported,
 			ToolCalls:            CapabilitySupported,

--- a/internal/parser/windsurf_provider.go
+++ b/internal/parser/windsurf_provider.go
@@ -928,6 +928,7 @@ func windsurfProviderCapabilities() Capabilities {
 			DiscoverSources:      CapabilitySupported,
 			WatchSources:         CapabilitySupported,
 			ClassifyChangedPath:  CapabilitySupported,
+			StoredSourceHints:    CapabilitySupported,
 			FindSource:           CapabilitySupported,
 			CompositeFingerprint: CapabilitySupported,
 			IncrementalAppend:    CapabilityNotApplicable,

--- a/internal/parser/zed_provider.go
+++ b/internal/parser/zed_provider.go
@@ -277,18 +277,10 @@ func parseZedVirtualPath(path string) (string, string, bool) {
 
 func zedProviderCapabilities() Capabilities {
 	return Capabilities{
-		Source: SourceCapabilities{
-			DiscoverSources:      CapabilitySupported,
-			WatchSources:         CapabilitySupported,
-			ClassifyChangedPath:  CapabilitySupported,
-			FindSource:           CapabilitySupported,
-			CompositeFingerprint: CapabilitySupported,
-			IncrementalAppend:    CapabilityNotApplicable,
-			MultiSessionSource:   CapabilitySupported,
-			PerSessionErrors:     CapabilityNotApplicable,
-			ExcludedSessions:     CapabilityNotApplicable,
-			ForceReplaceOnParse:  CapabilitySupported,
-		},
+		Source: multiSessionContainerSourceCapabilities(
+			CapabilitySupported,
+			CapabilitySupported,
+		),
 		Content: ContentCapabilities{
 			FirstMessage:         CapabilitySupported,
 			SessionName:          CapabilitySupported,

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -730,7 +730,7 @@ func (e *Engine) classifyProviderChangedPath(
 		}
 		for _, watchRoot := range watchRoots {
 			var storedSourcePaths []string
-			if providerChangedPathWantsStoredHints(def.Type) {
+			if provider.Capabilities().Source.StoredSourceHints == parser.CapabilitySupported {
 				var err error
 				storedSourcePaths, err = e.db.ListStoredSourcePathHints(
 					string(def.Type),
@@ -873,16 +873,6 @@ func providerChangedPathForceParse(
 	}
 	return eventKind == "remove" &&
 		providerDeletedPhysicalSQLiteSource(agent, sourcePath)
-}
-
-// providerChangedPathWantsStoredHints reports whether an agent's
-// SourcesForChangedPath implementation reads
-// ChangedPathRequest.StoredSourcePaths. The OpenCode-family source sets
-// resolve changed paths purely from the on-disk layout, so the per-event
-// stored-hints lookup — a LIKE scan over every stored session row of the
-// agent — would be computed and discarded on every watcher event.
-func providerChangedPathWantsStoredHints(agent parser.AgentType) bool {
-	return !isOpenCodeFormatStorageAgent(agent)
 }
 
 func providerVirtualSourceBackedByEvent(sourcePath, eventPath string) bool {

--- a/internal/sync/stored_source_hints_test.go
+++ b/internal/sync/stored_source_hints_test.go
@@ -1,0 +1,283 @@
+package sync
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/testjsonl"
+)
+
+type hintRecordingFactory struct {
+	agent parser.AgentType
+	caps  parser.Capabilities
+	seen  *[][]string
+}
+
+func (f hintRecordingFactory) Definition() parser.AgentDef {
+	return parser.AgentDef{Type: f.agent, DisplayName: string(f.agent)}
+}
+
+func (f hintRecordingFactory) Capabilities() parser.Capabilities { return f.caps }
+
+func (f hintRecordingFactory) NewProvider(cfg parser.ProviderConfig) parser.Provider {
+	return &hintRecordingProvider{ProviderBase: parser.ProviderBase{
+		Def: f.Definition(), Caps: f.caps, Config: cfg.Clone(),
+	}, seen: f.seen}
+}
+
+type hintRecordingProvider struct {
+	parser.ProviderBase
+	seen *[][]string
+}
+
+func (p *hintRecordingProvider) WatchPlan(context.Context) (parser.WatchPlan, error) {
+	return parser.WatchPlan{Roots: []parser.WatchRoot{{Path: p.Config.Roots[0]}}}, nil
+}
+
+func (p *hintRecordingProvider) SourcesForChangedPath(
+	_ context.Context,
+	req parser.ChangedPathRequest,
+) ([]parser.SourceRef, error) {
+	*p.seen = append(*p.seen, append([]string(nil), req.StoredSourcePaths...))
+	return []parser.SourceRef{{
+		Provider: p.Definition().Type, Key: req.Path,
+		DisplayPath: req.Path, FingerprintKey: req.Path,
+	}}, nil
+}
+
+func (p *hintRecordingProvider) Parse(context.Context, parser.ParseRequest) (parser.ParseOutcome, error) {
+	return parser.ParseOutcome{}, nil
+}
+
+func TestClassifyProviderChangedPathSchedulesStoredSourceHintsByCapability(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		caps parser.CapabilitySupport
+		want bool
+	}{
+		{name: "supported", caps: parser.CapabilitySupported, want: true},
+		{name: "unsupported", caps: parser.CapabilityUnsupported, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			changedPath := filepath.Join(root, "container.db")
+			require.NoError(t, os.WriteFile(changedPath, []byte("fixture"), 0o600))
+			persistedPath := filepath.Join(root, "archive", "stored#member")
+			database := dbtest.OpenTestDB(t)
+			require.NoError(t, database.UpsertSession(db.Session{
+				ID: "hint-agent:stored", Agent: "hint-agent", Project: "fixture",
+				Machine: "local", FilePath: strPtr(persistedPath),
+			}))
+
+			var seen [][]string
+			caps := parser.Capabilities{Source: parser.SourceCapabilities{
+				ClassifyChangedPath: parser.CapabilitySupported,
+				StoredSourceHints:   tc.caps,
+			}}
+			factory := hintRecordingFactory{agent: "hint-agent", caps: caps, seen: &seen}
+			engine := &Engine{
+				db: database, machine: "local",
+				agentDirs:         map[parser.AgentType][]string{"hint-agent": {root}},
+				providerFactories: map[parser.AgentType]parser.ProviderFactory{"hint-agent": factory},
+				providerMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+					"hint-agent": parser.ProviderMigrationProviderAuthoritative,
+				},
+			}
+
+			files := engine.classifyProviderChangedPath(changedPath)
+
+			require.Len(t, files, 1)
+			require.Len(t, seen, 1)
+			if tc.want {
+				assert.Equal(t, []string{persistedPath}, seen[0])
+			} else {
+				assert.Empty(t, seen[0])
+			}
+		})
+	}
+}
+
+func TestClassifyCodexChangedPathAllocationsStayBounded(t *testing.T) {
+	measure := func(t *testing.T, hintCount int) float64 {
+		t.Helper()
+		root := t.TempDir()
+		path := filepath.Join(root, "rollout-2026-07-11T10-00-00-alloc.jsonl")
+		content := testjsonl.JoinJSONL(
+			testjsonl.CodexSessionMetaJSON(
+				"alloc", "/workspace/agentsview", "codex_cli_rs", "2026-07-11T10:00:00Z",
+			),
+			testjsonl.CodexMsgJSON("user", "measure allocations", "2026-07-11T10:00:01Z"),
+		)
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+		database := dbtest.OpenTestDB(t)
+		for i := range hintCount {
+			hint := filepath.Join(root, "archive", fmt.Sprintf("%04d.jsonl", i))
+			require.NoError(t, database.UpsertSession(db.Session{
+				ID: fmt.Sprintf("codex:hint-%04d", i), Agent: string(parser.AgentCodex),
+				Project: "archive", Machine: "local", FilePath: strPtr(hint),
+			}))
+		}
+		engine := &Engine{
+			db: database, machine: "local",
+			agentDirs:         map[parser.AgentType][]string{parser.AgentCodex: {root}},
+			providerFactories: providerFactoryMap(parser.ProviderFactories()),
+			providerMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+				parser.AgentCodex: parser.ProviderMigrationProviderAuthoritative,
+			},
+		}
+		warm := engine.classifyProviderChangedPath(path)
+		require.Len(t, warm, 1)
+		assert.Equal(t, path, warm[0].Path)
+		assert.Equal(t, parser.AgentCodex, warm[0].Agent)
+
+		var got []parser.DiscoveredFile
+		allocs := testing.AllocsPerRun(5, func() {
+			got = engine.classifyProviderChangedPath(path)
+		})
+		require.Len(t, got, 1)
+		assert.Equal(t, path, got[0].Path)
+		assert.Equal(t, parser.AgentCodex, got[0].Agent)
+		return allocs
+	}
+
+	smallAllocs := measure(t, 10)
+	largeAllocs := measure(t, 2000)
+	assert.LessOrEqual(t, largeAllocs, smallAllocs*2,
+		"stored archives must not scale Codex changed-path allocations")
+}
+
+func TestClassifyProviderChangedPathPreservesHintDependentTombstones(t *testing.T) {
+	tests := []struct {
+		name  string
+		agent parser.AgentType
+		setup func(t *testing.T) (root, changedPath, deletedPath string)
+	}{
+		{
+			name: "Forge dbBackedSourceSet", agent: parser.AgentForge,
+			setup: func(t *testing.T) (string, string, string) {
+				root := t.TempDir()
+				path := writeProcessProviderForgeDB(t, root)
+				conn, err := sql.Open("sqlite3", path)
+				require.NoError(t, err)
+				_, err = conn.Exec(`DELETE FROM conversations WHERE conversation_id = 'conv-001'`)
+				require.NoError(t, err)
+				require.NoError(t, conn.Close())
+				return root, path, path + "#conv-001"
+			},
+		},
+		{
+			name: "Zed multiSessionContainerSourceSet", agent: parser.AgentZed,
+			setup: func(t *testing.T) (string, string, string) {
+				root := t.TempDir()
+				path := filepath.Join(root, "threads", "threads.db")
+				require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+				store, err := sql.Open("sqlite3", path)
+				require.NoError(t, err)
+				_, err = store.Exec(`CREATE TABLE threads (
+					id TEXT PRIMARY KEY, summary TEXT NOT NULL, updated_at TEXT NOT NULL,
+					data_type TEXT NOT NULL, data BLOB NOT NULL, parent_id TEXT,
+					folder_paths TEXT, folder_paths_order TEXT, created_at TEXT)`)
+				require.NoError(t, err)
+				require.NoError(t, store.Close())
+				return root, path, parser.ZedSQLiteVirtualPath(path, "deleted")
+			},
+		},
+		{
+			name: "Devin direct DB reader", agent: parser.AgentDevin,
+			setup: func(t *testing.T) (string, string, string) {
+				root := t.TempDir()
+				path, _ := writeProcessProviderDevinFixture(
+					t, root, "deleted", "reply", 1710000000000, 1710000005000,
+				)
+				conn, err := sql.Open("sqlite3", path)
+				require.NoError(t, err)
+				_, err = conn.Exec(`DELETE FROM sessions WHERE id = 'deleted'`)
+				require.NoError(t, err)
+				require.NoError(t, conn.Close())
+				return root, path, path + "#deleted"
+			},
+		},
+		{
+			name: "Kiro SQLite helper", agent: parser.AgentKiro,
+			setup: func(t *testing.T) (string, string, string) {
+				root := t.TempDir()
+				path := filepath.Join(root, "data.sqlite3")
+				store, err := sql.Open("sqlite3", path)
+				require.NoError(t, err)
+				_, err = store.Exec(`CREATE TABLE conversations_v2 (
+					key TEXT NOT NULL, conversation_id TEXT NOT NULL, value TEXT NOT NULL,
+					created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL,
+					PRIMARY KEY (key, conversation_id))`)
+				require.NoError(t, err)
+				payload, err := os.ReadFile(filepath.Join(
+					"..", "parser", "testdata", "kiro_sqlite", "standard_payload.json",
+				))
+				require.NoError(t, err)
+				_, err = store.Exec(`INSERT INTO conversations_v2
+					(key, conversation_id, value, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`,
+					"/workspace/agentsview", "deleted", string(payload),
+					1710000000000, 1710000005000)
+				require.NoError(t, err)
+				_, err = store.Exec(`DELETE FROM conversations_v2 WHERE conversation_id = 'deleted'`)
+				require.NoError(t, err)
+				require.NoError(t, store.Close())
+				return root, path, parser.KiroSQLiteVirtualPath(path, "deleted")
+			},
+		},
+		{
+			name: "Windsurf direct state DB reader", agent: parser.AgentWindsurf,
+			setup: func(t *testing.T) (string, string, string) {
+				root := filepath.Join(t.TempDir(), "Windsurf", "User")
+				path := filepath.Join(root, "workspaceStorage", "fixture", "state.vscdb")
+				require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+				writeSyncWindsurfStateDB(t, path, windsurfSyncPayload("deleted", "reply"))
+				updateSyncWindsurfStateDB(t, path, `{}`)
+				return root, path, path + "#deleted"
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root, changedPath, deletedPath := tc.setup(t)
+			database := dbtest.OpenTestDB(t)
+			require.NoError(t, database.UpsertSession(db.Session{
+				ID: string(tc.agent) + ":deleted", Agent: string(tc.agent),
+				Project: "fixture", Machine: "local", FilePath: strPtr(deletedPath),
+			}))
+			engine := &Engine{
+				db: database, machine: "local", skipCache: make(map[string]int64),
+				agentDirs:         map[parser.AgentType][]string{tc.agent: {root}},
+				providerFactories: providerFactoryMap(parser.ProviderFactories()),
+				providerMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+					tc.agent: parser.ProviderMigrationProviderAuthoritative,
+				},
+			}
+
+			files := engine.classifyProviderChangedPath(changedPath)
+			var tombstone parser.DiscoveredFile
+			for _, file := range files {
+				if file.Path == deletedPath {
+					tombstone = file
+				}
+			}
+			require.Equal(t, deletedPath, tombstone.Path)
+			assert.Equal(t, tc.agent, tombstone.Agent)
+
+			result := engine.processFile(context.Background(), tombstone)
+			require.NoError(t, result.err)
+			assert.True(t, result.forceReplace)
+			assert.Empty(t, result.results)
+		})
+	}
+}


### PR DESCRIPTION
Active watcher events were loading every persisted source path for providers that never consume those hints. On large archives, passive daemon work therefore scaled with total archive size, creating sustained allocation churn, avoidable CPU use, and a growing physical-memory high-water mark.

Changed-path scheduling now treats stored source hints as an explicit provider capability. Only providers with observable deletion or tombstone behavior opt in; Codex, Aider, and other non-consumers stay on an archive-size-independent path. Exact capability inventory, real-provider tombstone coverage, and a small-versus-large allocation regression keep both memory bounds and persistent-archive semantics enforceable.

Repository guidance now makes a few-hundred-megabyte passive budget, cardinality-scaling tests, isolated profiling, and long-run heap/physical-memory checks standing requirements. The main maintenance tradeoff is that new direct hint consumers must declare the capability and add behavior coverage.

The scheduling gate is in internal/sync/engine.go, provider declarations are under internal/parser, and the engine-boundary regressions are in internal/sync/stored_source_hints_test.go. A four-hour isolated retention observation is still in progress.