### PR TITLE
fix: show live daemon version in status

### DIFF
--- a/cmd/agentsview/daemon.go
+++ b/cmd/agentsview/daemon.go
@@ -79,7 +79,7 @@ type daemonCommandDeps struct {
 	stopCaddy                  func(io.Writer, daemon.RuntimeRecord) error
 	validateConfig             func(config.Config) error
 	checkDataVersion           func(string) error
-	probeRecord                func(daemon.RuntimeRecord, string) bool
+	probeRecord                func(daemon.RuntimeRecord, string) (daemon.PingInfo, bool)
 	now                        func() time.Time
 }
 
@@ -103,10 +103,8 @@ func defaultDaemonCommandDeps() daemonCommandDeps {
 		stopCaddy:           stopOrphanedCaddyChildWithWriter,
 		validateConfig:      validateServeConfig,
 		checkDataVersion:    db.CheckDataVersion,
-		probeRecord: func(rec daemon.RuntimeRecord, token string) bool {
-			return daemonRecordPingConfirmed(rec, token)
-		},
-		now: time.Now,
+		probeRecord:         probeDaemonRecord,
+		now:                 time.Now,
 	}
 }
 
@@ -469,7 +467,10 @@ func writeDaemonRecordStatus(
 ) {
 	rt := daemonRuntimeFromRecord(rec)
 	compatErr := daemonRuntimeCompatibilityError(rt)
-	responding := deps.probeRecord(rec, cfg.AuthToken)
+	info, responding := deps.probeRecord(rec, cfg.AuthToken)
+	if responding && info.Version != "" {
+		rt.Record.Version = info.Version
+	}
 	if compatErr != nil {
 		fmt.Fprintln(w, "agentsview found an incompatible running writable daemon.")
 		for _, line := range serveStatusLines(rt) {

--- a/cmd/agentsview/daemon_safety_test.go
+++ b/cmd/agentsview/daemon_safety_test.go
@@ -337,7 +337,9 @@ func TestDaemonStatusReportsIncompatibleAndNotResponding(t *testing.T) {
 		rec.Metadata[runtimeAPIVersion] = "0"
 		return []daemon.RuntimeRecord{rec}, nil
 	}
-	deps.probeRecord = func(daemon.RuntimeRecord, string) bool { return false }
+	deps.probeRecord = func(daemon.RuntimeRecord, string) (daemon.PingInfo, bool) {
+		return daemon.PingInfo{}, false
+	}
 
 	require.NoError(t, executeDaemonCommand(t, *deps, out, "status"))
 	assert.Contains(t, out.String(), "incompatible")

--- a/cmd/agentsview/daemon_test.go
+++ b/cmd/agentsview/daemon_test.go
@@ -69,7 +69,9 @@ func daemonCommandTestDeps(t *testing.T) (*daemonCommandDeps, *bytes.Buffer) {
 	deps.stopCaddy = func(io.Writer, daemon.RuntimeRecord) error { return nil }
 	deps.validateConfig = func(config.Config) error { return nil }
 	deps.checkDataVersion = func(string) error { return nil }
-	deps.probeRecord = func(daemon.RuntimeRecord, string) bool { return true }
+	deps.probeRecord = func(rec daemon.RuntimeRecord, _ string) (daemon.PingInfo, bool) {
+		return daemon.PingInfo{PID: rec.PID}, true
+	}
 	deps.now = func() time.Time { return time.Unix(200, 0) }
 	return &deps, out
 }
@@ -308,13 +310,17 @@ func TestDaemonStatusRendersStoppedStartingReadOnlyAndIncompatible(t *testing.T)
 				rec.Metadata[runtimeAPIVersion] = "0"
 				return []daemon.RuntimeRecord{rec}, nil
 			}
-			d.probeRecord = func(daemon.RuntimeRecord, string) bool { return true }
+			d.probeRecord = func(rec daemon.RuntimeRecord, _ string) (daemon.PingInfo, bool) {
+				return daemon.PingInfo{PID: rec.PID}, true
+			}
 		}, wanted: []string{"incompatible", "pid:     11", "API version"}},
 		{name: "running", setup: func(d *daemonCommandDeps) {
 			d.statusRecords = func(string, string) ([]daemon.RuntimeRecord, error) {
 				return []daemon.RuntimeRecord{testWritableRecord(12, "/runtime/12.json")}, nil
 			}
-			d.probeRecord = func(daemon.RuntimeRecord, string) bool { return true }
+			d.probeRecord = func(rec daemon.RuntimeRecord, _ string) (daemon.PingInfo, bool) {
+				return daemon.PingInfo{PID: rec.PID}, true
+			}
 		}, wanted: []string{"running at http://127.0.0.1:8012", "pid:     12", "version: 1.2.3", "uptime:"}},
 	}
 	for _, tt := range tests {
@@ -409,11 +415,42 @@ func TestDaemonStatusNotRespondingIsUseful(t *testing.T) {
 	deps.statusRecords = func(string, string) ([]daemon.RuntimeRecord, error) {
 		return []daemon.RuntimeRecord{testWritableRecord(55, "/runtime/55.json")}, nil
 	}
-	deps.probeRecord = func(daemon.RuntimeRecord, string) bool { return false }
+	deps.probeRecord = func(daemon.RuntimeRecord, string) (daemon.PingInfo, bool) {
+		return daemon.PingInfo{}, false
+	}
 	require.NoError(t, executeDaemonCommand(t, *deps, out, "status"))
 	assert.Contains(t, out.String(), "not responding")
 	assert.Contains(t, out.String(), "pid:     55")
 	assert.Contains(t, out.String(), "/runtime/55.json")
+}
+
+func TestDaemonStatusUsesPingVersionAsAuthoritative(t *testing.T) {
+	endpoint := newPingDaemon(t)
+	for _, tt := range []struct {
+		name          string
+		recordVersion string
+	}{
+		{name: "missing runtime version"},
+		{name: "stale runtime version", recordVersion: "stale-record-version"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := testWritableRecord(os.Getpid(), "")
+			rec.Version = tt.recordVersion
+			rec.Address = endpoint.Addr
+			rec.Metadata[runtimeHost] = endpoint.Host
+			rec.Metadata[runtimePort] = strconv.Itoa(endpoint.Port)
+
+			deps, out := daemonCommandTestDeps(t)
+			deps.statusRecords = func(string, string) ([]daemon.RuntimeRecord, error) {
+				return []daemon.RuntimeRecord{rec}, nil
+			}
+			deps.probeRecord = probeDaemonRecord
+
+			require.NoError(t, executeDaemonCommand(t, *deps, out, "status"))
+			assert.Contains(t, out.String(), "version: test")
+			assert.NotContains(t, out.String(), "stale-record-version")
+		})
+	}
 }
 
 func TestDaemonStatusDiscoversAuthenticatedLegacyDaemon(t *testing.T) {

--- a/cmd/agentsview/serve_lifecycle.go
+++ b/cmd/agentsview/serve_lifecycle.go
@@ -371,13 +371,22 @@ func stopTargetConfirmed(rec daemon.RuntimeRecord, authToken string) bool {
 func daemonRecordPingConfirmed(
 	rec daemon.RuntimeRecord, authToken string,
 ) bool {
+	_, confirmed := probeDaemonRecord(rec, authToken)
+	return confirmed
+}
+
+// probeDaemonRecord returns the ping identity when rec's PID answers as the
+// agentsview daemon it claims to be.
+func probeDaemonRecord(
+	rec daemon.RuntimeRecord, authToken string,
+) (daemon.PingInfo, bool) {
 	info, err := probeRuntime(
 		context.Background(), rec, authToken, daemon.ProbeOptions{
 			ExpectedService: daemonService,
 			Timeout:         500 * time.Millisecond,
 		},
 	)
-	return err == nil && info.PID == rec.PID
+	return info, err == nil && info.PID == rec.PID
 }
 
 // processIdentityConfirmed reports whether the process now holding rec.PID is


### PR DESCRIPTION
Daemon status can omit or stale-report the running version when its runtime record is incomplete, making it harder to confirm which binary is active.

Use the authenticated, PID-confirmed ping identity as the version authority. Runtime-record metadata remains a fallback when the daemon is unresponsive or returns no version, so status retains useful diagnostics without writing to the runtime store.