### PR TITLE
feat(vector): support reduced output dimensions for embedding models

### DIFF
--- a/cmd/agentsview/embeddings.go
+++ b/cmd/agentsview/embeddings.go
@@ -247,6 +247,13 @@ func vectorGeneration(c config.VectorEmbeddingsConfig) kitvec.Generation {
 	if c.InputSuffix != "" {
 		params["input_suffix"] = c.InputSuffix
 	}
+	// request_dimensions likewise joins only when enabled. Reduced vectors
+	// are renormalized prefixes, not byte-identical to a native embedding of
+	// the same length, so flipping the flag must cut a new generation even
+	// when the dimension value itself is unchanged.
+	if c.RequestDimensions {
+		params["request_dimensions"] = "true"
+	}
 	return kitvec.Generation{
 		Model:      c.Model,
 		Dimensions: c.Dimension,
@@ -268,13 +275,14 @@ func newVectorEncoder(c config.VectorEmbeddingsConfig, serverName string) (kitve
 			"parsing [vector.embeddings.servers.%s] timeout %q: %w", name, server.Timeout, err)
 	}
 	return vector.NewEncoder(vector.EncoderConfig{
-		Endpoint:    server.Endpoint,
-		APIKey:      server.APIKey(),
-		Model:       c.Model,
-		Dimension:   c.Dimension,
-		Timeout:     timeout,
-		MaxRetries:  server.MaxRetries,
-		InputSuffix: c.InputSuffix,
+		Endpoint:          server.Endpoint,
+		APIKey:            server.APIKey(),
+		Model:             c.Model,
+		Dimension:         c.Dimension,
+		RequestDimensions: c.RequestDimensions,
+		Timeout:           timeout,
+		MaxRetries:        server.MaxRetries,
+		InputSuffix:       c.InputSuffix,
 	}), nil
 }
 

--- a/cmd/agentsview/embeddings_test.go
+++ b/cmd/agentsview/embeddings_test.go
@@ -142,6 +142,23 @@ func TestVectorGenerationParams(t *testing.T) {
 		"chunk_overlap_chars": strconv.Itoa(vector.ChunkOverlap(4000)),
 		"input_suffix":        "<|endoftext|>",
 	}, gen.Params)
+
+	// request_dimensions follows the same only-when-set rule, and enabling it
+	// must change the fingerprint even at an unchanged dimension value, so
+	// the staleness gate forces a rebuild before reduced query vectors are
+	// compared against native-dimension stored vectors.
+	nativeFingerprint := gen.Fingerprint()
+	c.RequestDimensions = true
+	gen = vectorGeneration(c)
+	assert.Equal(t, map[string]string{
+		"max_input_chars":     "4000",
+		"doc_unit_scheme":     "run_v1",
+		"chunk_overlap_chars": strconv.Itoa(vector.ChunkOverlap(4000)),
+		"input_suffix":        "<|endoftext|>",
+		"request_dimensions":  "true",
+	}, gen.Params)
+	assert.NotEqual(t, nativeFingerprint, gen.Fingerprint(),
+		"enabling request_dimensions cuts a new generation")
 }
 
 // TestEmbeddingsDisabledReturnsError asserts every subcommand refuses with

--- a/docs/semantic-search-internals.md
+++ b/docs/semantic-search-internals.md
@@ -178,19 +178,20 @@ The vector index moves through kit's generation lifecycle: **building → active
 retired**. A generation's fingerprint is derived from `model` + `dimension` +
 the params map
 `{max_input_chars, doc_unit_scheme: "run_v1", chunk_overlap_chars}`
-(`vectorGeneration` in `cmd/agentsview/embeddings.go`), plus `input_suffix` when
-configured — an empty suffix is omitted from the map rather than included as
-`""`, so configs written before the key existed keep their fingerprints.
-`chunk_overlap_chars` is computed by `vector.ChunkOverlap` —
-`max_input_chars * 15 / 100` — the same function `Open` uses for kit's
-`SplitOptions`, so the split behavior and its fingerprint can never drift apart.
-Changing any input — the model, the dimension, the chunking cap, the input
-suffix, the overlap formula, or the document-unit scheme — produces a different
-fingerprint and cuts a new generation. Which
-`[vector.embeddings.servers.<name>]` entry encoded a document is deliberately
-*not* a fingerprint input: every server serves the same globally-configured
-model, so their vectors are interchangeable and a build may switch servers
-(`embeddings build --using <name>`) without invalidating the generation.
+(`vectorGeneration` in `cmd/agentsview/embeddings.go`), plus `input_suffix` and
+`request_dimensions` when configured — an unset value is omitted from the map
+rather than included as `""`/`false`, so configs written before those keys
+existed keep their fingerprints. `chunk_overlap_chars` is computed by
+`vector.ChunkOverlap` — `max_input_chars * 15 / 100` — the same function `Open`
+uses for kit's `SplitOptions`, so the split behavior and its fingerprint can
+never drift apart. Changing any input — the model, the dimension, whether
+reduced output dimensions are requested, the chunking cap, the input suffix, the
+overlap formula, or the document-unit scheme — produces a different fingerprint
+and cuts a new generation. Which `[vector.embeddings.servers.<name>]` entry
+encoded a document is deliberately *not* a fingerprint input: every server
+serves the same globally-configured model, so their vectors are interchangeable
+and a build may switch servers (`embeddings build --using <name>`) without
+invalidating the generation.
 
 - `embeddings build` (incremental): mirror refresh, then fill whatever the
   active generation is missing.

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -35,6 +35,7 @@ include_automated = false         # default; automated sessions (e.g. roborev) a
 model = "nomic-embed-text"
 dimension = 768                   # every returned vector must have this length
 max_input_chars = 8192            # per-chunk rune cap (default 8192)
+# request_dimensions = true      # ask for Matryoshka-reduced vectors of exactly `dimension` (see below)
 # input_suffix = "<|endoftext|>"  # appended to every embedded text; default empty (see below)
 default_server = "local"          # server used for query encoding and unnamed builds
 
@@ -58,11 +59,12 @@ parse. Restart the daemon (or run a CLI command) after editing the file.
 
 ### Named embeddings servers
 
-Model identity — `model`, `dimension`, `max_input_chars`, `input_suffix` — is
-global: every server in the `servers` table must serve that same model, so
-vectors produced by any of them are interchangeable and land in the same
-generation. What varies per server is transport and capacity: `endpoint`,
-`api_key_env`, `timeout`, `max_retries`, `batch_size`, and `concurrency`.
+Model identity — `model`, `dimension`, `request_dimensions`, `max_input_chars`,
+`input_suffix` — is global: every server in the `servers` table must serve that
+same model, so vectors produced by any of them are interchangeable and land in
+the same generation. What varies per server is transport and capacity:
+`endpoint`, `api_key_env`, `timeout`, `max_retries`, `batch_size`, and
+`concurrency`.
 
 This split exists so you can encode search queries against a fast local server
 while offloading bulk index builds to a bigger remote machine:
@@ -112,6 +114,50 @@ served by llama.cpp, which is benchmarked with `<|endoftext|>` appended to each
 input. The suffix is part of the generation fingerprint, so changing it
 (including setting it for the first time) re-embeds the whole archive on the
 next build.
+
+### Reduced output dimensions (Matryoshka)
+
+Matryoshka-trained embedding models — Qwen3-Embedding, OpenAI's
+`text-embedding-3-*` — can serve shorter vectors than their native output by
+truncating and renormalizing server-side, trading a little recall for a smaller,
+faster index. By default agentsview never asks for this: `dimension` only
+validates that responses have the expected length, and nothing extra goes on the
+wire. Setting `request_dimensions = true` sends `dimension` as the
+OpenAI-compatible `dimensions` request field on every embeddings call — document
+builds and search-query encoding alike, so both always use the same requested
+length:
+
+```toml
+[vector]
+enabled = true
+
+[vector.embeddings]
+model = "qwen3-embedding:0.6b"
+dimension = 256                 # reduced from the model's native 1024
+request_dimensions = true
+
+[vector.embeddings.servers.local]
+endpoint = "http://localhost:11434/v1"
+```
+
+```bash
+# Qwen3-Embedding supports Matryoshka reduction; Ollama's OpenAI-compatible
+# /v1/embeddings route passes the dimensions field through to it.
+ollama pull qwen3-embedding:0.6b
+```
+
+This requires an endpoint and model that support dimension selection. Reduction
+is never faked client-side: an endpoint that rejects the `dimensions` field
+fails the build or query with an error naming `request_dimensions` and the fix,
+and one that silently ignores the field and returns native-length vectors fails
+the dimension check with the same guidance, rather than agentsview truncating
+vectors itself. Endpoints that don't support the field keep working as long as
+`request_dimensions` stays unset.
+
+`request_dimensions` is part of the generation fingerprint (like `input_suffix`,
+only when enabled): reduced vectors are renormalized prefixes, not
+byte-identical to native output, so enabling it — or changing `dimension` —
+makes the existing index stale and re-embeds the archive on the next build.
 
 The first scheduled build that `run_after_sync` triggers after enabling
 `[vector]` embeds the entire existing archive, not just deltas, since the mirror

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -132,15 +132,24 @@ type VectorConfig struct {
 // VectorEmbeddingsConfig describes the embedding space — the model identity
 // every server must share — and the named servers that can encode it.
 //
-// Model identity (model, dimension, max_input_chars, input_suffix) is
-// deliberately global rather than per-server: it joins the generation
-// fingerprint, and query vectors are only comparable to stored document
-// vectors from the same space. Servers differ only in transport and
+// Model identity (model, dimension, request_dimensions, max_input_chars,
+// input_suffix) is deliberately global rather than per-server: it joins the
+// generation fingerprint, and query vectors are only comparable to stored
+// document vectors from the same space. Servers differ only in transport and
 // capacity, so a build run on any server produces vectors every other
 // server's queries can search.
 type VectorEmbeddingsConfig struct {
 	Model     string `toml:"model" json:"model"`
 	Dimension int    `toml:"dimension" json:"dimension"`
+	// RequestDimensions, when true, sends Dimension as the OpenAI-compatible
+	// "dimensions" request field — for documents at build time and queries at
+	// search time alike — asking the endpoint for Matryoshka-reduced vectors
+	// of exactly that length (e.g. Qwen3-Embedding through Ollama). Requires
+	// a model and endpoint that support dimension selection; when false (the
+	// default) the field is never sent and Dimension only validates response
+	// length. Part of the generation fingerprint: enabling it re-embeds the
+	// archive on the next build.
+	RequestDimensions bool `toml:"request_dimensions" json:"request_dimensions,omitempty"`
 	// MaxInputChars caps the rune length of each chunk sent for
 	// embedding. Default 8192.
 	MaxInputChars int `toml:"max_input_chars" json:"max_input_chars"`
@@ -1112,6 +1121,9 @@ func (c *Config) applyConfigTOML(data string) error {
 	}
 	if file.Vector.Embeddings.Dimension != 0 {
 		c.Vector.Embeddings.Dimension = file.Vector.Embeddings.Dimension
+	}
+	if file.Vector.Embeddings.RequestDimensions {
+		c.Vector.Embeddings.RequestDimensions = true
 	}
 	if meta.IsDefined("vector", "embeddings", "max_input_chars") {
 		c.Vector.Embeddings.MaxInputChars = file.Vector.Embeddings.MaxInputChars

--- a/internal/config/config_vector_test.go
+++ b/internal/config/config_vector_test.go
@@ -304,6 +304,24 @@ func TestVectorConfigTOMLLoad(t *testing.T) {
 		assert.Equal(t, "24h", cfg.Vector.Embed.BackstopInterval, "unset backstop_interval keeps default")
 		assert.False(t, cfg.Vector.IncludeAutomated, "unset include_automated keeps the false default")
 		assert.Empty(t, cfg.Vector.Embeddings.InputSuffix, "unset input_suffix defaults to empty")
+		assert.False(t, cfg.Vector.Embeddings.RequestDimensions,
+			"unset request_dimensions keeps the false default")
+	})
+
+	t.Run("request_dimensions true is loaded", func(t *testing.T) {
+		cfg := loadMinimalWithConfig(t, map[string]any{
+			"vector": map[string]any{
+				"enabled": true,
+				"embeddings": map[string]any{
+					"model":              "qwen3-embedding:0.6b",
+					"dimension":          256,
+					"request_dimensions": true,
+					"servers":            minimalServers(),
+				},
+			},
+		})
+		assert.True(t, cfg.Vector.Embeddings.RequestDimensions)
+		assert.Equal(t, 256, cfg.Vector.Embeddings.Dimension)
 	})
 
 	t.Run("named servers with default_server load and resolve", func(t *testing.T) {

--- a/internal/vector/encoder.go
+++ b/internal/vector/encoder.go
@@ -32,6 +32,13 @@ type EncoderConfig struct {
 	Model string
 	// Dimension is the length every returned vector must have.
 	Dimension int
+	// RequestDimensions, when true, sends Dimension as the OpenAI-compatible
+	// "dimensions" request field, asking the endpoint for Matryoshka-reduced
+	// vectors of exactly that length. When false (the default) the field is
+	// omitted — for models served at their native dimension and endpoints
+	// that do not support dimension selection — and Dimension only validates
+	// response length.
+	RequestDimensions bool
 	// Timeout bounds each individual HTTP request.
 	Timeout time.Duration
 	// MaxRetries is the maximum total attempts on 429/5xx/network errors
@@ -129,6 +136,11 @@ type embeddingsRequestBody struct {
 	// difference dominates round-trip time on slow links. Empty omits the
 	// field for servers that reject it.
 	EncodingFormat string `json:"encoding_format,omitempty"`
+	// Dimensions asks the endpoint to reduce every embedding to exactly this
+	// length (Matryoshka truncation plus renormalization, server-side). Zero
+	// omits the field so native-dimension configurations and endpoints
+	// without dimension selection keep working.
+	Dimensions int `json:"dimensions,omitempty"`
 }
 
 // embeddingsResponseBody is the OpenAI-compatible embeddings response.
@@ -218,6 +230,9 @@ func (ec *encoderClient) marshalRequest(texts []string) ([]byte, error) {
 	if !ec.floatMode.Load() {
 		body.EncodingFormat = "base64"
 	}
+	if ec.cfg.RequestDimensions {
+		body.Dimensions = ec.cfg.Dimension
+	}
 	reqBody, err := json.Marshal(body)
 	if err != nil {
 		return nil, fmt.Errorf("[vector.embeddings] marshal request: %w", err)
@@ -252,6 +267,17 @@ func (ec *encoderClient) encode(ctx context.Context, texts []string) ([][]float3
 			ec.floatMode.Store(true)
 			return ec.encode(ctx, texts)
 		}
+		if ec.cfg.RequestDimensions && isDimensionsRejection(err) {
+			// Unlike encoding_format there is no safe downgrade: dropping the
+			// dimensions field would change the embedding space, so fail with
+			// the fix spelled out instead of retrying an identical request.
+			return nil, fmt.Errorf(
+				"[vector.embeddings] endpoint rejected the dimensions field "+
+					"(model %q or this endpoint may not support reduced output dimensions): "+
+					"unset [vector.embeddings] request_dimensions or set dimension to the "+
+					"model's native output length: %w",
+				ec.cfg.Model, err)
+		}
 		lastErr = err
 		if !retryable || attempt == attempts {
 			return nil, lastErr
@@ -277,6 +303,22 @@ func isEncodingFormatRejection(err error) bool {
 		return false
 	}
 	return strings.Contains(strings.ToLower(statusErr.Body), "encoding_format")
+}
+
+// isDimensionsRejection reports whether err is a client-error response whose
+// body names the dimensions field, i.e. a server refusing the reduced-output
+// request rather than the input. Callers must only consult it when the
+// request actually carried the field; the match is body-text based and a
+// request without the field cannot be rejected for it.
+func isDimensionsRejection(err error) bool {
+	var statusErr *HTTPStatusError
+	if !errors.As(err, &statusErr) {
+		return false
+	}
+	if statusErr.Status < 400 || statusErr.Status >= 500 {
+		return false
+	}
+	return strings.Contains(strings.ToLower(statusErr.Body), "dimensions")
 }
 
 // attemptEncode makes a single HTTP request and decodes the response. The
@@ -322,7 +364,7 @@ func (ec *encoderClient) attemptEncode(
 		return nil, true, fmt.Errorf("[vector.embeddings] decode response: %w", err)
 	}
 
-	vectors, err := reorderAndValidate(decoded, texts, cfg.Dimension)
+	vectors, err := reorderAndValidate(decoded, texts, cfg)
 	if err != nil {
 		return nil, false, err
 	}
@@ -330,10 +372,14 @@ func (ec *encoderClient) attemptEncode(
 }
 
 // reorderAndValidate reorders the decoded embeddings by their reported
-// index and validates counts and dimensions against the request.
+// index and validates counts and dimensions against the request. A
+// wrong-length vector is always an error — reduction happens server-side or
+// not at all, never by client-side truncation — and when the request carried
+// the dimensions field the error says the endpoint ignored it.
 func reorderAndValidate(
-	decoded embeddingsResponseBody, texts []string, dimension int,
+	decoded embeddingsResponseBody, texts []string, cfg EncoderConfig,
 ) ([][]float32, error) {
+	dimension := cfg.Dimension
 	if len(decoded.Data) != len(texts) {
 		return nil, fmt.Errorf(
 			"[vector.embeddings] count mismatch: got %d embeddings, want %d",
@@ -348,6 +394,15 @@ func reorderAndValidate(
 				"[vector.embeddings] index %d out of range for %d texts", d.Index, len(texts))
 		}
 		if len(d.Embedding) != dimension {
+			if cfg.RequestDimensions {
+				return nil, fmt.Errorf(
+					"[vector.embeddings] dimension mismatch at index %d: got %d, want %d "+
+						"(the endpoint ignored the requested dimensions field; model %q or "+
+						"this endpoint may not support reduced output dimensions — unset "+
+						"[vector.embeddings] request_dimensions or set dimension to the "+
+						"model's native output length)",
+					d.Index, len(d.Embedding), dimension, cfg.Model)
+			}
 			return nil, fmt.Errorf(
 				"[vector.embeddings] dimension mismatch at index %d: got %d, want %d",
 				d.Index, len(d.Embedding), dimension)

--- a/internal/vector/encoder_test.go
+++ b/internal/vector/encoder_test.go
@@ -284,6 +284,210 @@ func TestEncoderDimensionMismatch(t *testing.T) {
 	assert.Contains(t, err.Error(), "[vector.embeddings] dimension")
 }
 
+// TestEncoderRequestDimensionsSentWhenConfigured asserts an encoder with
+// RequestDimensions set sends the configured Dimension as the
+// OpenAI-compatible "dimensions" request field and accepts the reduced
+// vectors an honoring server returns.
+func TestEncoderRequestDimensionsSentWhenConfigured(t *testing.T) {
+	var gotBody map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &gotBody))
+		writeJSON(t, w, http.StatusOK, embeddingsResponse{
+			Data: []embeddingDatum{{Index: 0, Embedding: []float32{1, 2}}},
+		})
+	}))
+	defer srv.Close()
+
+	enc := NewEncoder(EncoderConfig{
+		Endpoint:          srv.URL + "/v1",
+		Model:             "test-model",
+		Dimension:         2,
+		RequestDimensions: true,
+		Timeout:           5 * time.Second,
+		MaxRetries:        1,
+	})
+
+	out, err := enc(context.Background(), []string{"hello"})
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.Equal(t, []float32{1, 2}, out[0])
+
+	require.Contains(t, gotBody, "dimensions")
+	assert.EqualValues(t, 2, gotBody["dimensions"],
+		"the configured dimension is the requested output length")
+}
+
+// TestEncoderOmitsDimensionsFieldByDefault asserts the wire format is
+// unchanged for native-dimension configurations: without RequestDimensions
+// the request body carries no "dimensions" key at all, so endpoints that
+// reject unknown fields keep working.
+func TestEncoderOmitsDimensionsFieldByDefault(t *testing.T) {
+	var gotBody map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(body, &gotBody))
+		writeJSON(t, w, http.StatusOK, embeddingsResponse{
+			Data: []embeddingDatum{{Index: 0, Embedding: []float32{1, 2, 3}}},
+		})
+	}))
+	defer srv.Close()
+
+	enc := NewEncoder(EncoderConfig{
+		Endpoint:   srv.URL + "/v1",
+		Model:      "test-model",
+		Dimension:  3,
+		Timeout:    5 * time.Second,
+		MaxRetries: 1,
+	})
+
+	_, err := enc(context.Background(), []string{"hello"})
+	require.NoError(t, err)
+	assert.NotContains(t, gotBody, "dimensions")
+}
+
+// TestEncoderDimensionsRejectionFailsFastWithActionableError asserts a 4xx
+// response naming the dimensions field aborts immediately — no retry, no
+// silent downgrade that would change the embedding space — with an error
+// that names the request_dimensions setting and still carries the
+// HTTPStatusError for the build loop's permanence classification.
+func TestEncoderDimensionsRejectionFailsFastWithActionableError(t *testing.T) {
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		writeJSON(t, w, http.StatusBadRequest, map[string]any{
+			"error": "this model does not support the dimensions parameter",
+		})
+	}))
+	defer srv.Close()
+
+	enc := NewEncoder(EncoderConfig{
+		Endpoint:          srv.URL + "/v1",
+		Model:             "test-model",
+		Dimension:         2,
+		RequestDimensions: true,
+		Timeout:           5 * time.Second,
+		MaxRetries:        3,
+	})
+
+	_, err := enc(context.Background(), []string{"hello"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "request_dimensions",
+		"the error names the setting to change")
+	assert.Contains(t, err.Error(), "native output length")
+	assert.Equal(t, int32(1), requests.Load(), "a 4xx rejection is not retried")
+
+	var statusErr *HTTPStatusError
+	require.ErrorAs(t, err, &statusErr)
+	assert.Equal(t, http.StatusBadRequest, statusErr.Status)
+	assert.False(t, statusErr.Permanent(),
+		"a config-level rejection must abort the build, not skip-stamp documents")
+}
+
+// TestEncoderNoDimensionsHintWhenFieldNotRequested asserts the actionable
+// hint is gated on having actually sent the field: with RequestDimensions
+// unset, a 4xx body that happens to mention dimensions flows through the
+// normal error path untouched.
+func TestEncoderNoDimensionsHintWhenFieldNotRequested(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, http.StatusBadRequest, map[string]any{
+			"error": "input exceeds supported dimensions",
+		})
+	}))
+	defer srv.Close()
+
+	enc := NewEncoder(EncoderConfig{
+		Endpoint:   srv.URL + "/v1",
+		Model:      "test-model",
+		Dimension:  3,
+		Timeout:    5 * time.Second,
+		MaxRetries: 1,
+	})
+
+	_, err := enc(context.Background(), []string{"hello"})
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "request_dimensions")
+}
+
+// TestEncoderDimensionMismatchWhenEndpointIgnoresRequestedDimensions asserts
+// a server that silently ignores the dimensions field and returns
+// native-length vectors produces an error saying so, instead of the vectors
+// being truncated client-side or the generic mismatch message leaving the
+// user to guess.
+func TestEncoderDimensionMismatchWhenEndpointIgnoresRequestedDimensions(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, http.StatusOK, embeddingsResponse{
+			Data: []embeddingDatum{{Index: 0, Embedding: []float32{1, 2, 3, 4}}},
+		})
+	}))
+	defer srv.Close()
+
+	enc := NewEncoder(EncoderConfig{
+		Endpoint:          srv.URL + "/v1",
+		Model:             "test-model",
+		Dimension:         2,
+		RequestDimensions: true,
+		Timeout:           5 * time.Second,
+		MaxRetries:        3,
+	})
+
+	out, err := enc(context.Background(), []string{"hello"})
+	require.Error(t, err)
+	assert.Nil(t, out, "wrong-length vectors are never truncated client-side")
+	assert.Contains(t, err.Error(), "got 4, want 2")
+	assert.Contains(t, err.Error(), "ignored the requested dimensions field")
+	assert.Contains(t, err.Error(), "request_dimensions")
+}
+
+// TestEncoderBase64FallbackKeepsRequestedDimensions asserts the
+// encoding_format float downgrade re-marshals the request with the
+// dimensions field intact, so the transport fallback cannot silently change
+// the requested output length.
+func TestEncoderBase64FallbackKeepsRequestedDimensions(t *testing.T) {
+	var bodies []map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		var decoded map[string]any
+		require.NoError(t, json.Unmarshal(body, &decoded))
+		bodies = append(bodies, decoded)
+
+		if _, ok := decoded["encoding_format"]; ok {
+			writeJSON(t, w, http.StatusBadRequest, map[string]any{
+				"error": "unknown field: encoding_format",
+			})
+			return
+		}
+		writeJSON(t, w, http.StatusOK, embeddingsResponse{
+			Data: []embeddingDatum{{Index: 0, Embedding: []float32{1, 2}}},
+		})
+	}))
+	defer srv.Close()
+
+	enc := NewEncoder(EncoderConfig{
+		Endpoint:          srv.URL + "/v1",
+		Model:             "test-model",
+		Dimension:         2,
+		RequestDimensions: true,
+		Timeout:           5 * time.Second,
+	})
+
+	out, err := enc(context.Background(), []string{"hello"})
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	assert.Equal(t, []float32{1, 2}, out[0])
+
+	require.Len(t, bodies, 2, "base64 attempt plus the float retry")
+	for i, b := range bodies {
+		assert.EqualValues(t, 2, b["dimensions"],
+			"request %d carries the requested dimensions", i)
+	}
+}
+
 func TestEncoderCountMismatch(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		writeJSON(t, w, http.StatusOK, embeddingsResponse{

--- a/internal/vector/search_test.go
+++ b/internal/vector/search_test.go
@@ -2,9 +2,15 @@ package vector
 
 import (
 	"context"
+	"encoding/json"
+	"math"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
@@ -768,4 +774,105 @@ func TestDocAnchorOutOfRangeChunkIndexFallsBack(t *testing.T) {
 		assert.Equal(t, 7, anchor)
 		assert.Equal(t, "ccccc", snippet)
 	})
+}
+
+// TestSearchReducedDimensionsEndToEnd exercises the full reduced-dimension
+// path against a Matryoshka-style stub server: every embeddings request —
+// document builds and the search query alike — carries the configured
+// dimensions field, the index stores vectors at the reduced length, and
+// semantic search ranks in the reduced space. The stub serves native
+// 4-dimensional vectors and honors the OpenAI-compatible dimensions field by
+// slicing and renormalizing, the way Matryoshka-capable endpoints do.
+func TestSearchReducedDimensionsEndToEnd(t *testing.T) {
+	const nativeDim, reducedDim = 4, 3
+
+	nativeVector := func(text string) []float32 {
+		switch {
+		case strings.Contains(text, "alpha"):
+			return []float32{1, 0, 0, 1}
+		case strings.Contains(text, "beta"):
+			return []float32{0, 1, 0, 1}
+		default:
+			return []float32{0, 0, 1, 1}
+		}
+	}
+
+	var mu sync.Mutex
+	var requestedDims []int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Input      []string `json:"input"`
+			Dimensions int      `json:"dimensions"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		mu.Lock()
+		requestedDims = append(requestedDims, req.Dimensions)
+		mu.Unlock()
+
+		dim := nativeDim
+		if req.Dimensions > 0 {
+			dim = req.Dimensions
+		}
+		data := make([]map[string]any, len(req.Input))
+		for i, text := range req.Input {
+			sliced := nativeVector(text)[:dim]
+			var norm float64
+			for _, v := range sliced {
+				norm += float64(v) * float64(v)
+			}
+			norm = math.Sqrt(norm)
+			vec := make([]float32, dim)
+			for j, v := range sliced {
+				vec[j] = float32(float64(v) / norm)
+			}
+			data[i] = map[string]any{"index": i, "embedding": vec}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"data": data}))
+	}))
+	defer srv.Close()
+
+	enc := NewEncoder(EncoderConfig{
+		Endpoint:          srv.URL + "/v1",
+		Model:             "matryoshka-model",
+		Dimension:         reducedDim,
+		RequestDimensions: true,
+		Timeout:           5 * time.Second,
+		MaxRetries:        1,
+	})
+
+	ix := openTestIndex(t)
+	ctx := context.Background()
+	gen := kitvec.Generation{
+		Model:      "matryoshka-model",
+		Dimensions: reducedDim,
+		Params:     map[string]string{"request_dimensions": "true"},
+	}
+
+	result, err := ix.Build(ctx, threeDocSearchSource(), enc, gen, BuildOptions{})
+	require.NoError(t, err)
+	assert.True(t, result.Activated)
+	assert.Equal(t, 3, result.Fill.Documents)
+
+	gens, err := ix.Generations(ctx)
+	require.NoError(t, err)
+	require.Len(t, gens, 1)
+	assert.Equal(t, reducedDim, gens[0].Dimension,
+		"the generation stores the reduced dimension")
+
+	hits, err := ix.Search(ctx, enc, "alpha", 10)
+	require.NoError(t, err)
+	require.NotEmpty(t, hits)
+	assert.Equal(t, "s1", hits[0].SessionID)
+	assert.Equal(t, 0, hits[0].Ordinal)
+	assert.Contains(t, hits[0].Snippet, "alpha")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.GreaterOrEqual(t, len(requestedDims), 2,
+		"at least one build request and the query request reached the server")
+	for i, d := range requestedDims {
+		assert.Equal(t, reducedDim, d,
+			"request %d must ask for the reduced dimension", i)
+	}
 }


### PR DESCRIPTION
The configured `dimension` only validated response length and joined the generation fingerprint; it was never sent as the OpenAI-compatible `dimensions` request field. That made Matryoshka dimension reduction unusable with models such as Qwen3-Embedding through Ollama, where the server only reduces output when the request asks for it — the only options were the model's native dimension or a hard dimension-mismatch failure.

A new opt-in `[vector.embeddings] request_dimensions` sends the configured dimension on every embeddings call. Because every encoder is constructed through the single `newVectorEncoder` path, document builds and search-query encoding always request the identical length, on every configured server. When the flag is unset the request body is byte-identical to before, so endpoints without dimension selection are unaffected.

Reduction is never faked client-side, because truncating locally would silently change the embedding space relative to what the server would produce. An endpoint that rejects the `dimensions` field fails fast with an error naming `request_dimensions` and the fix (deliberately unlike the `encoding_format` rejection, which downgrades transparently since it is transport-only), and an endpoint that silently ignores the field and returns native-length vectors hits the existing dimension check with the same guidance. Both errors keep their `HTTPStatusError` classification, so a config-level rejection aborts a build rather than skip-stamping the corpus.

The flag joins the generation fingerprint only when enabled, following the `input_suffix` precedent: configs written before the key existed keep their fingerprints, while enabling it cuts a new generation and the staleness gate forces a rebuild — reduced vectors are renormalized prefixes, not byte-identical to native output at the same length, so reusing an existing index would be wrong even when the dimension value is unchanged.

Reviewers should look at the error-classification changes in `internal/vector/encoder.go` (the new rejection path sits next to the encoding_format downgrade and must not disturb the retry/permanence rules), the fingerprint param in `cmd/agentsview/embeddings.go`, and the end-to-end reduced-dimension test in `internal/vector/search_test.go`, which drives a real HTTP encoder against a Matryoshka-style stub through build and search. `docs/semantic-search.md` gains a section with the Ollama/Qwen3 example. One limitation: there is no client-side probe for whether a model supports reduction — the first build or query surfaces the endpoint's answer as an actionable error.