### PR TITLE
test(parser): skip allocation check under race detector

### DIFF
--- a/internal/parser/linereader_test.go
+++ b/internal/parser/linereader_test.go
@@ -158,6 +158,10 @@ func TestLineReaderIOError(t *testing.T) {
 }
 
 func TestReadCodexJSONLReaderReusesWorkspace(t *testing.T) {
+	if raceEnabled {
+		t.Skip("allocation counts are unreliable under the race detector")
+	}
+
 	var readErr error
 	allocs := testing.AllocsPerRun(100, func() {
 		r := bytes.NewReader(nil)

--- a/internal/parser/race_disabled_test.go
+++ b/internal/parser/race_disabled_test.go
@@ -1,0 +1,5 @@
+//go:build !race
+
+package parser
+
+const raceEnabled = false

--- a/internal/parser/race_enabled_test.go
+++ b/internal/parser/race_enabled_test.go
@@ -1,0 +1,5 @@
+//go:build race
+
+package parser
+
+const raceEnabled = true


### PR DESCRIPTION
Race instrumentation changes sync.Pool behavior by randomly discarding returned values, so the hard allocation ceiling can fail despite unchanged parser behavior. Make race builds explicitly skip this unsupported measurement while retaining the normal allocation regression guard. Behavioral parser coverage continues to run under the race detector.