### PR TITLE
perf(sync): keep full HTTP remote sync incremental

### DIFF
--- a/cmd/agentsview/cli.go
+++ b/cmd/agentsview/cli.go
@@ -322,6 +322,10 @@ func newSyncCommand() *cobra.Command {
 		&cfg.Full, "full", false,
 		"Force a full resync regardless of data version",
 	)
+	cmd.Flags().BoolVar(
+		&cfg.RepairMirror, "repair-mirror", false,
+		"Refresh configured HTTP remote mirrors from a full archive",
+	)
 	cmd.Flags().StringVar(
 		&cfg.Host, "host", "",
 		"SSH hostname for remote sync",

--- a/cmd/agentsview/cli_test.go
+++ b/cmd/agentsview/cli_test.go
@@ -325,7 +325,33 @@ func TestRootHelpDocumentsRemoteHosts(t *testing.T) {
 func TestSyncHelpMentionsConfiguredHosts(t *testing.T) {
 	help, err := executeCommand(newRootCommand(), "sync", "--help")
 	require.NoError(t, err, "Execute")
-	for _, want := range []string{"remote_hosts", "--host", "passwordless"} {
+	for _, want := range []string{"remote_hosts", "--host", "--repair-mirror", "passwordless"} {
 		assert.Contains(t, help, want, "sync help missing %q", want)
 	}
+}
+
+func TestSyncCommandParsesRepairMirrorFlag(t *testing.T) {
+	env := newSyncCLIEnv(t)
+
+	got, handler := captureRemoteSyncRequest(t)
+	ts := remoteSyncRouteTestServer(t, handler)
+	registerSyncRouteTestRuntime(t, env.DataDir, ts.URL)
+
+	_, err := executeCommand(
+		newRootCommand(),
+		"sync",
+		"--host", "devbox",
+		"--user", "alice",
+		"--port", "2222",
+		"--repair-mirror",
+	)
+	require.NoError(t, err)
+	assert.False(t, got.IncludeLocal)
+	assert.False(t, got.Full)
+	assert.True(t, got.RepairMirror)
+	require.Len(t, got.Hosts, 1)
+	assert.Equal(t, "devbox", got.Hosts[0].Host)
+	assert.Equal(t, "alice", got.Hosts[0].User)
+	assert.Equal(t, 2222, got.Hosts[0].Port)
+	env.assertNoLocalDB(t)
 }

--- a/cmd/agentsview/sync.go
+++ b/cmd/agentsview/sync.go
@@ -26,10 +26,11 @@ import (
 
 // SyncConfig holds parsed CLI options for the sync command.
 type SyncConfig struct {
-	Full bool
-	Host string
-	User string
-	Port int
+	Full         bool
+	RepairMirror bool
+	Host         string
+	User         string
+	Port         int
 	// CPUProfile, MemProfile, and Trace are hidden flags that capture a
 	// pprof CPU profile, allocation snapshot, and runtime trace for the
 	// sync pass. Empty strings disable each independently.
@@ -93,9 +94,9 @@ func doSync(cfg SyncConfig) (hadRemoteFailures bool) {
 			if useDaemon && len(remoteHosts) > 0 {
 				fmt.Println("Running sync with remotes via daemon...")
 				progress := newRemoteProgressPrinter(os.Stdout, time.Now)
-				failures, err := runDaemonRemoteSync(
+				failures, err := runDaemonRemoteSyncWithRepair(
 					context.Background(), tr, appCfg.AuthToken,
-					remoteHosts, cfg.Full, includeLocal, progress.Print,
+					remoteHosts, cfg.Full, cfg.RepairMirror, includeLocal, progress.Print,
 				)
 				progress.Finish()
 				if err != nil {
@@ -161,7 +162,7 @@ func doSync(cfg SyncConfig) (hadRemoteFailures bool) {
 			)
 		},
 		func(rh config.RemoteHost, full bool) error {
-			return runRemoteSyncOnce(appCfg, database, rh, full)
+			return runRemoteSyncOnceWithRepair(appCfg, database, rh, full, cfg.RepairMirror)
 		},
 	)
 	reportRemoteFailures(failures)
@@ -185,6 +186,7 @@ type remoteProgressPrinter struct {
 	started  time.Time
 	inPlace  bool
 	finished bool
+	progress sync.Progress
 }
 
 const remoteLocalSyncProgressLabel = "Syncing local sessions"
@@ -234,6 +236,9 @@ func (p *remoteProgressPrinter) Print(progress sync.Progress) {
 			p.label = label
 			p.started = p.now()
 		}
+		if strings.Contains(label, "Processing") {
+			p.progress = progress
+		}
 		p.inPlace = true
 		fmt.Fprintf(p.w, "\r  %s\x1b[K", formatSyncProgress(progress))
 		return
@@ -273,10 +278,15 @@ func (p *remoteProgressPrinter) finishCurrent() {
 		fmt.Fprint(p.w, "\n")
 	}
 	elapsed := p.now().Sub(p.started).Round(time.Millisecond)
-	fmt.Fprintf(p.w, "  %s completed in %s\n", p.label, elapsed)
+	throughput := ""
+	if p.progress.SessionsDone > 0 && elapsed > 0 {
+		throughput = fmt.Sprintf(", %.1f sessions/s", float64(p.progress.SessionsDone)/elapsed.Seconds())
+	}
+	fmt.Fprintf(p.w, "  %s completed in %s%s\n", p.label, elapsed, throughput)
 	p.label = ""
 	p.started = time.Time{}
 	p.inPlace = false
+	p.progress = sync.Progress{}
 }
 
 // syncLocalAndRemotes runs the local sync, then the configured
@@ -303,8 +313,8 @@ func runRemoteSync(
 		User: cfg.User,
 		Port: cfg.Port,
 	}
-	if err := runRemoteSyncOnce(
-		appCfg, database, rh, cfg.Full,
+	if err := runRemoteSyncOnceWithRepair(
+		appCfg, database, rh, cfg.Full, cfg.RepairMirror,
 	); err != nil {
 		fatal("remote sync: %v", err)
 	}
@@ -317,6 +327,17 @@ func runRemoteSyncOnce(
 	appCfg config.Config, database *db.DB,
 	rh config.RemoteHost, full bool,
 ) error {
+	return runRemoteSyncOnceWithRepair(appCfg, database, rh, full, false)
+}
+
+func runRemoteSyncOnceWithRepair(
+	appCfg config.Config, database *db.DB,
+	rh config.RemoteHost, full, repairMirror bool,
+) error {
+	if repairMirror && rh.Transport == config.RemoteTransportHTTP {
+		_, err := runHTTPRemoteSyncWithRepair(context.Background(), appCfg, database, rh, full, true)
+		return err
+	}
 	_, err := runRemoteSyncTransport(
 		context.Background(), appCfg, database, rh, full,
 	)
@@ -367,6 +388,16 @@ var runHTTPRemoteSync = func(
 	rh config.RemoteHost,
 	full bool,
 ) (remotesync.SyncStats, error) {
+	return runHTTPRemoteSyncWithRepair(ctx, appCfg, database, rh, full, false)
+}
+
+var runHTTPRemoteSyncWithRepair = func(
+	ctx context.Context,
+	appCfg config.Config,
+	database *db.DB,
+	rh config.RemoteHost,
+	full, repairMirror bool,
+) (remotesync.SyncStats, error) {
 	token := rh.Token
 	if token == "" {
 		return remotesync.SyncStats{}, fmt.Errorf(
@@ -379,6 +410,7 @@ var runHTTPRemoteSync = func(
 		URL:                     rh.URL,
 		Token:                   token,
 		Full:                    full,
+		RepairMirror:            repairMirror,
 		DataDir:                 appCfg.DataDir,
 		DB:                      database,
 		BlockedResultCategories: appCfg.ResultContentBlockedCategories,
@@ -549,12 +581,27 @@ func runDaemonRemoteSync(
 	includeLocal bool,
 	onProgress sync.ProgressFunc,
 ) ([]remoteHostFailure, error) {
+	return runDaemonRemoteSyncWithRepair(ctx, tr, authToken, hosts, full, false, includeLocal, onProgress)
+}
+
+func runDaemonRemoteSyncWithRepair(
+	ctx context.Context,
+	tr transport,
+	authToken string,
+	hosts []config.RemoteHost,
+	full bool,
+	repairMirror bool,
+	includeLocal bool,
+	onProgress sync.ProgressFunc,
+) ([]remoteHostFailure, error) {
 	body, err := json.Marshal(struct {
 		Full         bool                `json:"full"`
+		RepairMirror bool                `json:"repair_mirror,omitempty"`
 		IncludeLocal bool                `json:"include_local"`
 		Hosts        []config.RemoteHost `json:"hosts"`
 	}{
 		Full:         full,
+		RepairMirror: repairMirror,
 		IncludeLocal: includeLocal,
 		Hosts:        hosts,
 	})

--- a/cmd/agentsview/sync_test.go
+++ b/cmd/agentsview/sync_test.go
@@ -84,6 +84,32 @@ func TestRunRemoteSyncOnceDispatchesHTTP(t *testing.T) {
 	assert.Equal(t, "http://devbox:8080", called.URL)
 }
 
+func TestRunRemoteSyncOnceWithRepairDispatchesHTTPRepairDirectly(t *testing.T) {
+	var called config.RemoteHost
+	var gotFull, gotRepair bool
+	restore := stubHTTPRemoteSyncWithRepairForTest(t, func(
+		_ context.Context,
+		rh config.RemoteHost,
+		full, repairMirror bool,
+	) (remotesync.SyncStats, error) {
+		called = rh
+		gotFull = full
+		gotRepair = repairMirror
+		return remotesync.SyncStats{SessionsSynced: 2}, nil
+	})
+	defer restore()
+
+	err := runRemoteSyncOnceWithRepair(config.Config{}, nil, config.RemoteHost{
+		Host: "devbox", Transport: config.RemoteTransportHTTP,
+		URL: "http://devbox:8080", Token: "remote-token",
+	}, true, true)
+
+	require.NoError(t, err)
+	assert.Equal(t, "http://devbox:8080", called.URL)
+	assert.True(t, gotFull)
+	assert.True(t, gotRepair)
+}
+
 func TestRunHTTPRemoteSyncRequiresExplicitHTTPToken(t *testing.T) {
 	called := false
 	ts := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
@@ -124,6 +150,24 @@ func stubHTTPRemoteSyncForTest(
 		return fn(ctx, rh, full)
 	}
 	return func() { runHTTPRemoteSync = orig }
+}
+
+func stubHTTPRemoteSyncWithRepairForTest(
+	t *testing.T,
+	fn func(context.Context, config.RemoteHost, bool, bool) (remotesync.SyncStats, error),
+) func() {
+	t.Helper()
+	orig := runHTTPRemoteSyncWithRepair
+	runHTTPRemoteSyncWithRepair = func(
+		ctx context.Context,
+		_ config.Config,
+		_ *db.DB,
+		rh config.RemoteHost,
+		full, repairMirror bool,
+	) (remotesync.SyncStats, error) {
+		return fn(ctx, rh, full, repairMirror)
+	}
+	return func() { runHTTPRemoteSyncWithRepair = orig }
 }
 
 func TestSyncLocalAndRemotes_ResyncForcesRemoteFull(t *testing.T) {
@@ -344,7 +388,7 @@ func TestResyncProgressPrinterRendersDoneProgressBeforeCompletion(t *testing.T) 
 		"\n  Syncing sessions into rebuilt database completed in 1s\n")
 }
 
-func TestRemoteProgressPrinterWritesTimedStepLines(t *testing.T) {
+func TestRemoteProgressPrinterRendersMirrorPhasesAndThroughput(t *testing.T) {
 	now := time.Date(2026, 6, 24, 12, 0, 0, 0, time.UTC)
 	clock := func() time.Time { return now }
 	var out bytes.Buffer
@@ -385,7 +429,7 @@ func TestRemoteProgressPrinterWritesTimedStepLines(t *testing.T) {
 	assert.Contains(t, got, "  Downloading session data from devbox (3 agents)...\n")
 	assert.Contains(t, got, "  Downloading session data from devbox (3 agents) completed in 2s\n")
 	assert.Contains(t, got, "\r  Processing sessions from devbox: 10/10 sessions (100%) · 100 messages\x1b[K")
-	assert.Contains(t, got, "\n  Processing sessions from devbox completed in 3.35s\n")
+	assert.Contains(t, got, "\n  Processing sessions from devbox completed in 3.35s, 3.0 sessions/s\n")
 	assert.Contains(t, got, "  Synced 10 sessions from devbox (1 unchanged)\n")
 	assert.True(t, strings.HasSuffix(got, "\n"), "remote progress should finish on a newline")
 }
@@ -591,15 +635,17 @@ func TestDoSyncRemoteHostUsesDaemonRouteWhenWritableDaemonRunning(t *testing.T) 
 	registerSyncRouteTestRuntime(t, env.DataDir, ts.URL)
 
 	hadFailures := doSync(SyncConfig{
-		Host: "devbox",
-		User: "alice",
-		Port: 2222,
-		Full: true,
+		Host:         "devbox",
+		User:         "alice",
+		Port:         2222,
+		Full:         true,
+		RepairMirror: true,
 	})
 
 	require.False(t, hadFailures)
 	assert.False(t, got.IncludeLocal)
 	assert.True(t, got.Full)
+	assert.True(t, got.RepairMirror)
 	require.Len(t, got.Hosts, 1)
 	assert.Equal(t, config.RemoteHost{
 		Host: "devbox",
@@ -748,8 +794,15 @@ func (e syncCLIEnv) assertNoLocalDB(t *testing.T) {
 // /api/v1/sync/remotes route.
 type remoteSyncRequest struct {
 	Full         bool                `json:"full"`
+	RepairMirror bool                `json:"repair_mirror"`
 	IncludeLocal bool                `json:"include_local"`
 	Hosts        []config.RemoteHost `json:"hosts"`
+}
+
+func TestRemoteSyncRepairIntentContract(t *testing.T) {
+	body, err := json.Marshal(remoteSyncRequest{Full: true, RepairMirror: true})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"full":true,"repair_mirror":true,"include_local":false,"hosts":null}`, string(body))
 }
 
 // captureRemoteSyncRequest returns a handler that records the decoded remote

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -237,11 +237,17 @@ token = "remote-token"
 With hosts configured, `agentsview sync` (no `--host`) runs the local sync
 first, then syncs each configured host in the order declared using its
 configured transport. `--full` applies to every host; for HTTP hosts it
-re-downloads the full archive into the persistent mirror and bypasses the remote
+reparses every session while keeping manifest-based mirror transfer incremental
+and bypassing the remote
 path/mtime skip cache (see
 [Incremental Sync](/remote-access/#incremental-sync)). A failing host is
 reported on stderr and skipped so the remaining hosts still run; the command
 exits non-zero if any host failed.
+
+Use `--repair-mirror` when a configured HTTP host's mirror bytes need a full
+archive refresh, such as same-size, same-mtime corruption. For HTTP hosts it
+also reparses every imported remote session after the repair. The repair flag
+doesn't change SSH behavior.
 
 `agentsview sync --host X` syncs one host, not the whole configured list. When
 the local daemon knows a configured host with that identity, it uses the stored

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -203,9 +203,8 @@ of the remote state database.
 A full HTTP transfer occurs in these cases:
 
 - the per-host mirror is new or was removed
-- `agentsview sync --full` is used
+- `agentsview sync --repair-mirror` is used
 - at least half of the manifest files are missing or changed
-- a collector data-version resync forces its configured remote syncs full
 - a delta request is rejected after a manifest succeeded; the collector retries
   once with a full archive
 - the remote daemon does not support manifests, in which case the collector uses
@@ -214,9 +213,14 @@ A full HTTP transfer occurs in these cases:
 Windsurf's curated export is also fetched in full on every sync, independently
 of the directory-scoped archive decision.
 
-`--full` refreshes the mirror bytes and bypasses the persistent remote
-path/mtime skip cache during import. It does not delete the local database or
-turn remote sync into a destructive reconciliation.
+`--full` bypasses the persistent remote path/mtime skip cache during import, so
+it reparses every session without implying a full mirror transfer.
+An automatic collector data-version resync also reparses configured remotes
+full, but it stays on the manifest and delta mirror path unless repair or
+fallback rules require a full archive.
+`--repair-mirror` refreshes the dir-scoped mirror from a full archive and then
+reparses every imported remote session. Neither flag deletes the local database
+or turns remote sync into a destructive reconciliation.
 
 ### Compatibility And Recovery
 
@@ -234,14 +238,15 @@ an interrupted extraction.
 
 The comparison does not hash file content. A remote rewrite that preserves both
 size and modification time, or local mirror corruption with the same metadata,
-can therefore look unchanged. Run a full sync to refresh the bytes:
+can therefore look unchanged. Request an explicit mirror repair to refresh the
+bytes:
 
 ```bash
 # Refresh local sessions and every configured remote.
-agentsview sync --full
+agentsview sync --repair-mirror
 
 # Refresh one configured host through the local daemon.
-agentsview sync --host devbox1 --full
+agentsview sync --host devbox1 --repair-mirror
 ```
 
 The second form requires `devbox1` to match a configured `[[remote_hosts]]`

--- a/internal/remotesync/http.go
+++ b/internal/remotesync/http.go
@@ -22,6 +22,7 @@ type HTTPSync struct {
 	URL                     string
 	Token                   string
 	Full                    bool
+	RepairMirror            bool
 	DataDir                 string
 	DB                      *db.DB
 	BlockedResultCategories []string
@@ -116,7 +117,7 @@ func (hs HTTPSync) importRoot(
 ) (SyncStats, error) {
 	stats, err := Importer{
 		Host:                    hs.Host,
-		Full:                    hs.Full,
+		Full:                    hs.Full || hs.RepairMirror,
 		DB:                      hs.DB,
 		BlockedResultCategories: hs.BlockedResultCategories,
 		Progress:                hs.Progress,
@@ -174,14 +175,13 @@ func (hs HTTPSync) runMirror(
 	if err := RemoveMirrorTypeConflicts(mirrorRoot, delta.Fetch); err != nil {
 		return SyncStats{}, err
 	}
-	if len(delta.Fetch) > 0 || hs.Full {
+	if len(delta.Fetch) > 0 || hs.RepairMirror {
 		// Bootstrap heuristic: past half the corpus a full archive is
 		// cheaper than uploading a huge file list, and it doubles as
-		// the empty-mirror bootstrap (fetch == total). --full bypasses
-		// the stat diff entirely: it is the user's remedy for a stale
-		// or corrupt mirror, which the size/mtime comparison cannot
-		// detect (a same-size same-mtime rewrite, or local bit rot).
-		full := hs.Full || len(delta.Fetch)*2 >= delta.Total
+		// the empty-mirror bootstrap (fetch == total). Repair bypasses
+		// the stat diff for stale or corrupt mirror bytes, which size and
+		// mtime comparison cannot detect.
+		full := hs.RepairMirror || len(delta.Fetch)*2 >= delta.Total
 		err := hs.downloadIntoMirror(ctx, client, targets.dirScoped, delta.Fetch, full, mirrorRoot)
 		var statusErr *StatusError
 		if err != nil && !full && errors.As(err, &statusErr) {
@@ -333,6 +333,7 @@ func (hs HTTPSync) downloadIntoMirror(
 	if err := os.MkdirAll(mirrorRoot, 0o755); err != nil {
 		return fmt.Errorf("create mirror dir: %w", err)
 	}
+	hs.report(syncpkg.Progress{Detail: fmt.Sprintf("Extracting session archive from %s", hs.Host)})
 	if _, err := ExtractTarStream(ctx, stream, mirrorRoot); err != nil {
 		return fmt.Errorf("extract archive into mirror: %w", err)
 	}

--- a/internal/remotesync/http_test.go
+++ b/internal/remotesync/http_test.go
@@ -97,26 +97,6 @@ func progressDetails(progress []syncpkg.Progress) []string {
 	return out
 }
 
-func maxBytesDone(progress []syncpkg.Progress) int64 {
-	var max int64
-	for _, p := range progress {
-		if p.BytesDone > max {
-			max = p.BytesDone
-		}
-	}
-	return max
-}
-
-func maxBytesTotal(progress []syncpkg.Progress) int64 {
-	var max int64
-	for _, p := range progress {
-		if p.BytesTotal > max {
-			max = p.BytesTotal
-		}
-	}
-	return max
-}
-
 func buildHTTPTestTar(t *testing.T, files map[string]string) []byte {
 	t.Helper()
 	var buf bytes.Buffer

--- a/internal/remotesync/http_test.go
+++ b/internal/remotesync/http_test.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"testing"
 	"time"
 
@@ -60,41 +59,18 @@ func TestHTTPSyncDownloadsArchiveAndImports(t *testing.T) {
 	assert.Equal(t, 1, stats.SessionsSynced)
 }
 
-func TestHTTPSyncReportsDownloadAndImportProgress(t *testing.T) {
-	archive := buildHTTPTestTar(t, map[string]string{
-		"home/wes/.claude/projects/test-project/session.jsonl": testjsonl.NewSessionBuilder().
-			AddClaudeUser("2024-01-01T00:00:00Z", "http remote progress").
-			String(),
-	})
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/api/v1/remote-sync/targets":
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"dirs":{"claude":["/home/wes/.claude/projects"]}}`))
-		case "/api/v1/remote-sync/archive":
-			w.Header().Set("Content-Type", "application/x-tar")
-			w.Header().Set("Content-Length", strconv.Itoa(len(archive)))
-			_, _ = w.Write(archive)
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	t.Cleanup(ts.Close)
-
-	database, err := db.Open(filepath.Join(t.TempDir(), "test.db"))
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, database.Close()) })
+func TestHTTPSyncReportsMirrorProgressPhases(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	base := time.Date(2026, 7, 8, 10, 0, 0, 123456789, time.UTC)
+	remote.writeSession(t, "a.jsonl", base, "http remote progress")
+	dataDir := t.TempDir()
+	_, hs := newMirrorSync(t, remote, dataDir)
 	var progress []syncpkg.Progress
 
-	stats, err := HTTPSync{
-		Host:  "devbox",
-		URL:   ts.URL,
-		Token: "remote-token",
-		DB:    database,
-		Progress: func(p syncpkg.Progress) {
-			progress = append(progress, p)
-		},
-	}.Run(context.Background())
+	hs.Progress = func(p syncpkg.Progress) {
+		progress = append(progress, p)
+	}
+	stats, err := hs.Run(context.Background())
 
 	require.NoError(t, err)
 	assert.Equal(t, 1, stats.SessionsSynced)
@@ -107,8 +83,8 @@ func TestHTTPSyncReportsDownloadAndImportProgress(t *testing.T) {
 	assert.Contains(t, progressDetails(progress),
 		"Processing sessions from devbox")
 	require.NotEmpty(t, progress, "expected progress events")
-	assert.Equal(t, int64(len(archive)), maxBytesDone(progress))
-	assert.Equal(t, int64(len(archive)), maxBytesTotal(progress))
+	require.Len(t, remote.archiveRequests, 1)
+	assert.Empty(t, remote.archiveRequests[0].DeltaFiles)
 }
 
 func progressDetails(progress []syncpkg.Progress) []string {
@@ -325,11 +301,12 @@ func TestHTTPSyncMirrorSecondSyncTransfersOnlyDelta(t *testing.T) {
 	added := remote.writeSession(t, "f.jsonl", base.Add(6*time.Second), "session f")
 	require.NoError(t, os.Remove(staleRemote))
 
+	hs.Full = true
 	stats, err = hs.Run(context.Background())
 	require.NoError(t, err)
 	require.Len(t, remote.archiveRequests, 2)
 	assert.ElementsMatch(t, []string{changed, added}, remote.archiveRequests[1].DeltaFiles)
-	assert.Equal(t, 2, stats.SessionsSynced)
+	assert.GreaterOrEqual(t, stats.SessionsTotal, 2)
 
 	// The deleted remote file is gone from the mirror, but its
 	// session survives in the DB (archive semantics).
@@ -342,6 +319,7 @@ func TestHTTPSyncMirrorSecondSyncTransfersOnlyDelta(t *testing.T) {
 	assert.Len(t, page.Sessions, 6)
 
 	// Third sync with no remote changes: no archive request at all.
+	hs.Full = false
 	stats, err = hs.Run(context.Background())
 	require.NoError(t, err)
 	assert.Len(t, remote.archiveRequests, 2)
@@ -578,7 +556,7 @@ func TestHTTPSyncHoldsMirrorLockDuringManifestFetch(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestHTTPSyncFullRefreshesMirrorBytes(t *testing.T) {
+func TestHTTPSyncRepairMirrorRefreshesBytes(t *testing.T) {
 	remote := newMirrorTestRemote(t)
 	base := time.Date(2026, 7, 8, 10, 0, 0, 123456789, time.UTC)
 	path := remote.writeSession(t, "a.jsonl", base, "session a")
@@ -607,14 +585,51 @@ func TestHTTPSyncFullRefreshesMirrorBytes(t *testing.T) {
 	require.Equal(t, corrupt, stale)
 	require.Len(t, remote.archiveRequests, 1, "no-delta sync must not download")
 
-	// --full forces a full archive refresh into the mirror.
-	hs.Full = true
-	_, err = hs.Run(context.Background())
+	// Explicit mirror repair forces a full archive refresh and reparse.
+	hs.RepairMirror = true
+	stats, err := hs.Run(context.Background())
 	require.NoError(t, err)
 	healed, err := os.ReadFile(local)
 	require.NoError(t, err)
 	assert.Equal(t, good, healed)
+	assert.Equal(t, 1, stats.SessionsSynced)
+	assert.Zero(t, stats.Skipped)
 	require.Len(t, remote.archiveRequests, 2)
 	assert.Nil(t, remote.archiveRequests[1].DeltaFiles,
-		"--full must request the full archive, not a delta")
+		"repair must request the full archive, not a delta")
+}
+
+func TestHTTPSyncFullReprocessesWithoutFullMirrorDownload(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	base := time.Date(2026, 7, 8, 10, 0, 0, 123456789, time.UTC)
+	remote.writeSession(t, "a.jsonl", base, "session a")
+	dataDir := t.TempDir()
+	_, hs := newMirrorSync(t, remote, dataDir)
+	require.NoError(t, func() error { _, err := hs.Run(context.Background()); return err }())
+
+	hs.Full = true
+	stats, err := hs.Run(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.SessionsTotal)
+	assert.Len(t, remote.archiveRequests, 1,
+		"full reprocess must not download an unchanged dir-scoped mirror")
+}
+
+func TestHTTPSyncFullReprocessesAllSessionsWithoutMirrorRepair(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	base := time.Date(2026, 7, 8, 10, 0, 0, 123456789, time.UTC)
+	remote.writeSession(t, "a.jsonl", base, "session a")
+	dataDir := t.TempDir()
+	_, hs := newMirrorSync(t, remote, dataDir)
+	_, err := hs.Run(context.Background())
+	require.NoError(t, err)
+
+	hs.Full = true
+	stats, err := hs.Run(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.SessionsTotal)
+	assert.Equal(t, 1, stats.SessionsSynced)
+	assert.Zero(t, stats.Skipped)
+	assert.Len(t, remote.archiveRequests, 1,
+		"full reprocess must not download an unchanged dir-scoped mirror")
 }

--- a/internal/remotesync/import.go
+++ b/internal/remotesync/import.go
@@ -51,6 +51,8 @@ func (im Importer) ImportExtracted(
 		IDPrefix:                im.Host + "~",
 		PathRewriter:            rewriter,
 		Ephemeral:               true,
+		ForceParse:              im.Full,
+		AllowForceParseWrites:   im.Full,
 		BlockedResultCategories: im.BlockedResultCategories,
 	})
 	defer engine.Close()

--- a/internal/server/huma_routes_sync.go
+++ b/internal/server/huma_routes_sync.go
@@ -47,6 +47,7 @@ type remoteSyncInput struct {
 
 type remoteSyncRequest struct {
 	Full         bool                `json:"full"`
+	RepairMirror bool                `json:"repair_mirror,omitempty"`
 	IncludeLocal bool                `json:"include_local"`
 	Hosts        []config.RemoteHost `json:"hosts"`
 }
@@ -76,6 +77,17 @@ var runHTTPRemoteSync = func(
 	full bool,
 	progress func(syncpkg.Progress),
 ) (remotesync.SyncStats, error) {
+	return runHTTPRemoteSyncWithRepair(ctx, cfg, local, rh, full, false, progress)
+}
+
+var runHTTPRemoteSyncWithRepair = func(
+	ctx context.Context,
+	cfg config.Config,
+	local *db.DB,
+	rh config.RemoteHost,
+	full, repairMirror bool,
+	progress func(syncpkg.Progress),
+) (remotesync.SyncStats, error) {
 	token := rh.Token
 	if token == "" {
 		return remotesync.SyncStats{}, fmt.Errorf(
@@ -88,6 +100,7 @@ var runHTTPRemoteSync = func(
 		URL:                     rh.URL,
 		Token:                   token,
 		Full:                    full,
+		RepairMirror:            repairMirror,
 		DataDir:                 cfg.DataDir,
 		DB:                      local,
 		BlockedResultCategories: cfg.ResultContentBlockedCategories,
@@ -332,21 +345,21 @@ func (s *Server) runRemoteSyncRequest(
 	var localStats *syncpkg.SyncStats
 	failures := make([]remoteSyncFailure, 0)
 	var remoteStats remotesync.SyncStats
-	run := func(full bool) {
-		failures, remoteStats = s.runRemoteSyncHosts(
-			ctx, local, req.Hosts, full, progress,
+	run := func(full, repairMirror bool) {
+		failures, remoteStats = s.runRemoteSyncHostsWithRepair(
+			ctx, local, req.Hosts, full, repairMirror, progress,
 		)
 	}
 	if req.IncludeLocal {
 		stats, _ := engine.SyncThenRun(ctx, req.Full, progress,
 			func(forceFull bool) error {
-				run(forceFull)
+				run(forceFull, req.RepairMirror)
 				return nil
 			})
 		localStats = &stats
 	} else {
 		_ = engine.RunExclusive(func() error {
-			run(req.Full)
+			run(req.Full, req.RepairMirror)
 			return nil
 		})
 	}
@@ -363,6 +376,16 @@ func (s *Server) runRemoteSyncHosts(
 	local *db.DB,
 	hosts []config.RemoteHost,
 	full bool,
+	progress func(syncpkg.Progress),
+) ([]remoteSyncFailure, remotesync.SyncStats) {
+	return s.runRemoteSyncHostsWithRepair(ctx, local, hosts, full, false, progress)
+}
+
+func (s *Server) runRemoteSyncHostsWithRepair(
+	ctx context.Context,
+	local *db.DB,
+	hosts []config.RemoteHost,
+	full, repairMirror bool,
 	progress func(syncpkg.Progress),
 ) ([]remoteSyncFailure, remotesync.SyncStats) {
 	failures := make([]remoteSyncFailure, 0)
@@ -383,7 +406,11 @@ func (s *Server) runRemoteSyncHosts(
 			}
 			stats, err = runRemoteSync(ctx, rs)
 		case config.RemoteTransportHTTP:
-			stats, err = runHTTPRemoteSync(ctx, s.cfg, local, rh, full, progress)
+			if repairMirror {
+				stats, err = runHTTPRemoteSyncWithRepair(ctx, s.cfg, local, rh, full, true, progress)
+			} else {
+				stats, err = runHTTPRemoteSync(ctx, s.cfg, local, rh, full, progress)
+			}
 		default:
 			err = fmt.Errorf("invalid remote transport %q", rh.Transport)
 		}

--- a/internal/server/huma_routes_sync_internal_test.go
+++ b/internal/server/huma_routes_sync_internal_test.go
@@ -262,6 +262,27 @@ func stubRunHTTPRemoteSync(
 	t.Cleanup(func() { runHTTPRemoteSync = originalRunHTTPRemoteSync })
 }
 
+func stubRunHTTPRemoteSyncWithRepair(
+	t *testing.T,
+	fn func(context.Context, config.RemoteHost, bool, bool) (remotesync.SyncStats, error),
+) {
+	t.Helper()
+	originalRunHTTPRemoteSyncWithRepair := runHTTPRemoteSyncWithRepair
+	runHTTPRemoteSyncWithRepair = func(
+		ctx context.Context,
+		_ config.Config,
+		_ *db.DB,
+		rh config.RemoteHost,
+		full, repairMirror bool,
+		_ func(syncpkg.Progress),
+	) (remotesync.SyncStats, error) {
+		return fn(ctx, rh, full, repairMirror)
+	}
+	t.Cleanup(func() {
+		runHTTPRemoteSyncWithRepair = originalRunHTTPRemoteSyncWithRepair
+	})
+}
+
 func TestSyncEngineForLocalReusesNoSyncEngineConcurrently(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "test.db")
@@ -685,6 +706,44 @@ func TestSyncRemotesUsesStoredConfigForConfiguredHost(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
 	assert.Equal(t, stored.URL, got.URL)
 	assert.Equal(t, stored.Token, got.Token)
+}
+
+func TestSyncRemotesRelaysRepairMirrorToConfiguredHTTPHost(t *testing.T) {
+	stored := config.RemoteHost{
+		Host:      "devbox",
+		Transport: config.RemoteTransportHTTP,
+		URL:       "http://stored.example",
+		Token:     "stored-token",
+	}
+	f := newSyncRouteFixture(t, withRemoteHosts(stored))
+	called := false
+	var got config.RemoteHost
+	var gotFull, gotRepair bool
+	stubRunHTTPRemoteSyncWithRepair(t, func(
+		_ context.Context,
+		rh config.RemoteHost,
+		full, repairMirror bool,
+	) (remotesync.SyncStats, error) {
+		called = true
+		got = rh
+		gotFull = full
+		gotRepair = repairMirror
+		return remotesync.SyncStats{SessionsSynced: 1, SessionsTotal: 1}, nil
+	})
+
+	w := serveJSON(t, f.handler, http.MethodPost, "/api/v1/sync/remotes",
+		remoteSyncRequest{
+			Full:         true,
+			RepairMirror: true,
+			Hosts:        []config.RemoteHost{{Host: "devbox"}},
+		},
+		withRemoteAddr("203.0.113.10:9999"))
+
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.True(t, called)
+	assert.Equal(t, stored, got)
+	assert.True(t, gotFull)
+	assert.True(t, gotRepair)
 }
 
 func TestSyncRemotesRedactsStoredHTTPConfigOnFailure(t *testing.T) {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -80,6 +80,15 @@ type EngineConfig struct {
 	// local sync watermarks or pollute the skipped_files table
 	// with temp-dir paths.
 	Ephemeral bool
+	// ForceParse disables stored-state freshness skips so every
+	// discovered source is reparsed even when its persisted file
+	// metadata still matches.
+	ForceParse bool
+	// AllowForceParseWrites permits sync entrypoints to run on a
+	// force-parse engine. parse-diff leaves this false; remotesync
+	// full reparse opts in so it can bypass freshness skips and still
+	// write refreshed rows.
+	AllowForceParseWrites bool
 	// Emitter, when non-nil, is called once after each sync pass
 	// that wrote data. Safe to leave nil (e.g., in PG serve mode
 	// where the engine is not run).
@@ -133,6 +142,9 @@ type Engine struct {
 	// parse-diff fully re-parses every discovered file. Normal sync
 	// never sets it; behavior must be identical when false.
 	forceParse bool
+	// allowForceParseWrites lets a force-parse engine perform normal
+	// writes. It stays false for report-only parse-diff engines.
+	allowForceParseWrites bool
 
 	// phaseStats accumulates per-phase wall-clock time inside the bulk
 	// write path. Exposed via PhaseStats() so a CLI driver can log the
@@ -200,6 +212,9 @@ func (e *Engine) refuseWriteInForceParse(op string) bool {
 	if !e.forceParse {
 		return false
 	}
+	if e.allowForceParseWrites {
+		return false
+	}
 	log.Printf(
 		"sync: refusing %s on a report-only (parse-diff) engine; "+
 			"forceParse engines never write", op,
@@ -262,6 +277,8 @@ func NewEngine(
 		skipFingerprints:        make(map[string]string),
 		s3CodexIndexCache:       make(map[string]s3CodexIndexSnapshot),
 		ephemeral:               cfg.Ephemeral,
+		forceParse:              cfg.ForceParse,
+		allowForceParseWrites:   cfg.AllowForceParseWrites,
 		idPrefix:                cfg.IDPrefix,
 		pathRewriter:            cfg.PathRewriter,
 		emitter:                 cfg.Emitter,


### PR DESCRIPTION
`agentsview sync --full` currently treats "reparse every HTTP-remote session" and "repair the persistent mirror cache" as the same operation, so unchanged remotes still download and re-extract the whole dir-scoped archive before parsing. This change keeps ordinary full sync on the manifest-backed mirror path, reparses every remote session as requested, and moves whole-mirror repair behind the explicit `--repair-mirror` path instead of baking it into every full sync. Explicit repair still reparses every imported remote session after refreshing the mirror bytes.

The transfer decision stays bounded by the existing mirror rules: bootstrap, half-or-more changed files, or a rejected delta still fall back to a full archive, file-scoped exports still fetch as their own small full archives, and mirror deletions remain non-destructive to the local database. This follows the scoped direction in #1094 from @wesm, keeping ordinary full sync work proportional to changed mirror files rather than total archive size while preserving repair as an explicit action.

Progress output is also split into archive transfer, archive extraction, discovery, and session processing so the elapsed timers line up with the actual work. Remote progress continues to show compressed transfer bytes, and the processing phase now reports throughput when the session and message counters make that meaningful for operators watching long remote syncs.

Closes #1094
