### PR TITLE
fix(serve): surface runtime-record write warnings in serve logs (#1097)

### DIFF
--- a/cmd/agentsview/duckdb.go
+++ b/cmd/agentsview/duckdb.go
@@ -338,7 +338,7 @@ func runDuckDBServe(appCfg config.Config, basePath string) {
 		}
 		fatal("duckdb serve: %v", err)
 	}
-	if _, sfErr := WriteDaemonRuntimeWithAuth(
+	if _, sfErr := writeDaemonRuntimeWithAuth(
 		rt.Cfg.DataDir, rt.Cfg.Host, rt.Cfg.Port, version, true,
 		rt.Cfg.RequireAuth,
 		rt.Caddy.Pid(),

--- a/cmd/agentsview/duckdb.go
+++ b/cmd/agentsview/duckdb.go
@@ -343,7 +343,7 @@ func runDuckDBServe(appCfg config.Config, basePath string) {
 		rt.Cfg.RequireAuth,
 		rt.Caddy.Pid(),
 	); sfErr != nil {
-		warnRuntimeRecordWrite(
+		reportRuntimeRecordWrite(
 			os.Stdout, sfErr,
 			"duckdb serve daemon may not be discoverable by CLI", "",
 		)

--- a/cmd/agentsview/duckdb.go
+++ b/cmd/agentsview/duckdb.go
@@ -343,10 +343,9 @@ func runDuckDBServe(appCfg config.Config, basePath string) {
 		rt.Cfg.RequireAuth,
 		rt.Caddy.Pid(),
 	); sfErr != nil {
-		log.Printf(
-			"warning: could not write daemon runtime record: %v"+
-				" (duckdb serve daemon may not be discoverable by CLI)",
-			sfErr,
+		warnRuntimeRecordWrite(
+			os.Stdout, sfErr,
+			"duckdb serve daemon may not be discoverable by CLI", "",
 		)
 	} else {
 		defer RemoveDaemonRuntime(rt.Cfg.DataDir)

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -318,7 +318,7 @@ func runServe(cfg config.Config, opts serveOptions) {
 	// write fails, keep the start lock as a fallback "server
 	// is active" marker so token-use doesn't start a competing
 	// on-demand sync against our live DB.
-	if _, sfErr := WriteDaemonRuntimeWithAuthAndNoSync(
+	if _, sfErr := writeDaemonRuntimeWithAuthAndNoSync(
 		rt.Cfg.DataDir, rt.Cfg.Host, rt.Cfg.Port, version, false,
 		rt.Cfg.RequireAuth, rt.Cfg.NoSync,
 		rt.Caddy.Pid(),

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -323,7 +323,7 @@ func runServe(cfg config.Config, opts serveOptions) {
 		rt.Cfg.RequireAuth, rt.Cfg.NoSync,
 		rt.Caddy.Pid(),
 	); sfErr != nil {
-		warnRuntimeRecordWrite(
+		reportRuntimeRecordWrite(
 			os.Stdout, sfErr, "keeping start lock as fallback",
 			"To fix permissions, run: icacls <dir> /setowner <user>",
 		)

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -323,10 +323,9 @@ func runServe(cfg config.Config, opts serveOptions) {
 		rt.Cfg.RequireAuth, rt.Cfg.NoSync,
 		rt.Caddy.Pid(),
 	); sfErr != nil {
-		log.Printf(
-			"warning: could not write daemon runtime record: %v"+
-				" (keeping start lock as fallback)",
-			sfErr,
+		warnRuntimeRecordWrite(
+			os.Stdout, sfErr, "keeping start lock as fallback",
+			"To fix permissions, run: icacls <dir> /setowner <user>",
 		)
 	} else {
 		runtimeRecordDataDir = rt.Cfg.DataDir

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -151,16 +151,34 @@ func TestRunPGRuntimeWarningHelperProcess(t *testing.T) {
 	) (string, error) {
 		return "", errors.New("forced runtime-record write failure")
 	}
-	pgServeTestStartup = func() {
-		writePGServeRuntimeRecord(&serveRuntime{
-			Cfg: config.Config{
-				DataDir: os.Getenv("AGENTSVIEW_DATA_DIR"),
-				Host:    "127.0.0.1",
-				Port:    8787,
-			},
-		})
+	database := dbtest.OpenTestDBAt(
+		t, filepath.Join(os.Getenv("AGENTSVIEW_DATA_DIR"), "pg.db"),
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	port := server.FindAvailablePort("127.0.0.1", 0)
+	appCfg := config.Config{
+		Host:    "127.0.0.1",
+		Port:    port,
+		DataDir: os.Getenv("AGENTSVIEW_DATA_DIR"),
 	}
-	runPGServe(config.Config{DataDir: os.Getenv("AGENTSVIEW_DATA_DIR")}, "")
+	preparePGServe = func(config.Config, string) (pgServeStartup, error) {
+		return pgServeStartup{
+			cfg: appCfg, ctx: ctx,
+			rtOpts: serveRuntimeOptions{
+				Mode: "pg-serve", RequestedPort: appCfg.Port,
+			},
+			srv: server.New(
+				appCfg, database, nil,
+				server.WithBaseContext(ctx),
+			),
+			cleanup: func() { cancel(); _ = database.Close() },
+		}, nil
+	}
+	go func() {
+		time.Sleep(time.Second)
+		os.Exit(0)
+	}()
+	runPGServe(appCfg, "")
 }
 
 func TestRunDuckDBRuntimeWarningHelperProcess(t *testing.T) {

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
@@ -40,27 +42,16 @@ func TestRuntimeWarningHelper(t *testing.T) {
 }
 
 func TestServeRuntimeRecordWriteFailureWarnsVisible(t *testing.T) {
-	var visible bytes.Buffer
-	reportRuntimeRecordWrite(
-		&visible, errors.New("permission denied"),
-		"keeping start lock as fallback",
-		"To fix permissions, run: icacls <dir> /setowner <user>",
-	)
-
-	assert.Contains(t, visible.String(), "could not write daemon runtime record")
-	assert.Contains(t, visible.String(), "icacls <dir> /setowner <user>")
+	out, err := runServeRuntimeWarningHelper(t, true)
+	require.NoError(t, err, string(out))
+	assert.Contains(t, string(out), "could not write daemon runtime record")
+	assert.Contains(t, string(out), "icacls <dir> /setowner <user>")
 }
 
 func TestServeRuntimeRecordWriteSuccessDoesNotWarnVisible(t *testing.T) {
-	var visible bytes.Buffer
-	logOutput := captureLogOutput(t)
-	reportRuntimeRecordWrite(
-		&visible, nil, "keeping start lock as fallback",
-		"To fix permissions, run: icacls <dir> /setowner <user>",
-	)
-
-	assert.NotContains(t, visible.String(), "could not write daemon runtime record")
-	assert.NotContains(t, logOutput.String(), "could not write daemon runtime record")
+	out, err := runServeRuntimeWarningHelper(t, false)
+	require.NoError(t, err, string(out))
+	assert.NotContains(t, string(out), "could not write daemon runtime record")
 }
 
 func TestPGServeRuntimeRecordWriteFailureWarnsVisible(t *testing.T) {
@@ -83,30 +74,41 @@ func TestDuckDBServeRuntimeRecordWriteFailureWarnsVisible(t *testing.T) {
 	assert.Contains(t, visible.String(), "could not write daemon runtime record")
 }
 
-func TestServeRuntimeRecordWriteCallSitesUseVisibleSink(t *testing.T) {
-	tests := []struct {
-		file string
-		call string
-	}{
-		{file: "main.go", call: "WriteDaemonRuntimeWithAuthAndNoSync("},
-		{file: "pg.go", call: "WriteDaemonRuntimeWithAuth("},
-		{file: "duckdb.go", call: "WriteDaemonRuntimeWithAuth("},
+func runServeRuntimeWarningHelper(t *testing.T, failWrite bool) ([]byte, error) {
+	t.Helper()
+	dataDir := t.TempDir()
+	cmd := exec.Command(os.Args[0], "-test.run=TestRunServeRuntimeWarningHelperProcess")
+	cmd.Env = append(
+		os.Environ(),
+		"AGENTSVIEW_RUN_SERVE_RUNTIME_WARNING_HELPER=1",
+		"AGENTSVIEW_RUN_SERVE_RUNTIME_WARNING_FAIL="+fmt.Sprint(failWrite),
+		"AGENTSVIEW_DATA_DIR="+dataDir,
+	)
+	return cmd.CombinedOutput()
+}
+
+func TestRunServeRuntimeWarningHelperProcess(t *testing.T) {
+	if os.Getenv("AGENTSVIEW_RUN_SERVE_RUNTIME_WARNING_HELPER") != "1" {
+		return
 	}
-	for _, tt := range tests {
-		t.Run(tt.file, func(t *testing.T) {
-			source, err := os.ReadFile(tt.file)
-			require.NoError(t, err)
-			branchStart := strings.Index(string(source), tt.call)
-			require.GreaterOrEqual(t, branchStart, 0)
-			branch := string(source)[branchStart:]
-			branchEnd := strings.Index(branch, "\n\t} else {")
-			require.Greater(t, branchEnd, 0)
-			branch = branch[:branchEnd]
-			assert.Contains(t, branch, "reportRuntimeRecordWrite(")
-			assert.Contains(t, branch, "os.Stdout")
-			assert.NotContains(t, branch, "log.Printf")
-		})
+	if os.Getenv("AGENTSVIEW_RUN_SERVE_RUNTIME_WARNING_FAIL") == "true" {
+		writeDaemonRuntimeWithAuthAndNoSync = func(
+			string, string, int, string, bool, bool, bool, ...int,
+		) (string, error) {
+			return "", errors.New("forced runtime-record write failure")
+		}
 	}
+	go func() {
+		time.Sleep(time.Second)
+		os.Exit(0)
+	}()
+	runServe(config.Config{
+		Host:    "127.0.0.1",
+		Port:    0,
+		DataDir: os.Getenv("AGENTSVIEW_DATA_DIR"),
+		DBPath:  filepath.Join(os.Getenv("AGENTSVIEW_DATA_DIR"), "sessions.db"),
+		NoSync:  true,
+	}, serveOptions{})
 }
 
 func TestMustLoadConfig(t *testing.T) {

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -51,27 +51,20 @@ func TestServeRuntimeRecordWriteFailureWarnsVisible(t *testing.T) {
 func TestServeRuntimeRecordWriteSuccessDoesNotWarnVisible(t *testing.T) {
 	out, err := runServeRuntimeWarningHelper(t, false)
 	require.NoError(t, err, string(out))
+	assert.Contains(t, string(out), "runtime record write reached")
 	assert.NotContains(t, string(out), "could not write daemon runtime record")
 }
 
 func TestPGServeRuntimeRecordWriteFailureWarnsVisible(t *testing.T) {
-	var visible bytes.Buffer
-	reportRuntimeRecordWrite(
-		&visible, errors.New("permission denied"),
-		"pg serve daemon may not be discoverable by CLI", "",
-	)
-
-	assert.Contains(t, visible.String(), "could not write daemon runtime record")
+	out, err := runPGRuntimeWarningHelper(t)
+	require.NoError(t, err, string(out))
+	assert.Contains(t, string(out), "could not write daemon runtime record")
 }
 
 func TestDuckDBServeRuntimeRecordWriteFailureWarnsVisible(t *testing.T) {
-	var visible bytes.Buffer
-	reportRuntimeRecordWrite(
-		&visible, errors.New("permission denied"),
-		"duckdb serve daemon may not be discoverable by CLI", "",
-	)
-
-	assert.Contains(t, visible.String(), "could not write daemon runtime record")
+	out, err := runDuckDBRuntimeWarningHelper(t)
+	require.NoError(t, err, string(out))
+	assert.Contains(t, string(out), "could not write daemon runtime record")
 }
 
 func runServeRuntimeWarningHelper(t *testing.T, failWrite bool) ([]byte, error) {
@@ -97,6 +90,19 @@ func TestRunServeRuntimeWarningHelperProcess(t *testing.T) {
 		) (string, error) {
 			return "", errors.New("forced runtime-record write failure")
 		}
+	} else {
+		original := writeDaemonRuntimeWithAuthAndNoSync
+		writeDaemonRuntimeWithAuthAndNoSync = func(
+			dataDir, host string, port int, version string, readOnly,
+			requireAuth, noSync bool, caddyPID ...int,
+		) (string, error) {
+			path, err := original(
+				dataDir, host, port, version, readOnly, requireAuth, noSync,
+				caddyPID...,
+			)
+			fmt.Println("runtime record write reached")
+			return path, err
+		}
 	}
 	go func() {
 		time.Sleep(time.Second)
@@ -109,6 +115,75 @@ func TestRunServeRuntimeWarningHelperProcess(t *testing.T) {
 		DBPath:  filepath.Join(os.Getenv("AGENTSVIEW_DATA_DIR"), "sessions.db"),
 		NoSync:  true,
 	}, serveOptions{})
+}
+
+func runDuckDBRuntimeWarningHelper(t *testing.T) ([]byte, error) {
+	t.Helper()
+	dataDir := t.TempDir()
+	cmd := exec.Command(os.Args[0], "-test.run=TestRunDuckDBRuntimeWarningHelperProcess")
+	cmd.Env = append(
+		os.Environ(),
+		"AGENTSVIEW_RUN_DUCKDB_RUNTIME_WARNING_HELPER=1",
+		"AGENTSVIEW_DATA_DIR="+dataDir,
+		"AGENTSVIEW_DUCKDB_RUNTIME_WARNING_PATH="+filepath.Join(dataDir, "mirror.duckdb"),
+	)
+	return cmd.CombinedOutput()
+}
+
+func runPGRuntimeWarningHelper(t *testing.T) ([]byte, error) {
+	t.Helper()
+	dataDir := t.TempDir()
+	cmd := exec.Command(os.Args[0], "-test.run=TestRunPGRuntimeWarningHelperProcess")
+	cmd.Env = append(
+		os.Environ(),
+		"AGENTSVIEW_RUN_PG_RUNTIME_WARNING_HELPER=1",
+		"AGENTSVIEW_DATA_DIR="+dataDir,
+	)
+	return cmd.CombinedOutput()
+}
+
+func TestRunPGRuntimeWarningHelperProcess(t *testing.T) {
+	if os.Getenv("AGENTSVIEW_RUN_PG_RUNTIME_WARNING_HELPER") != "1" {
+		return
+	}
+	writeDaemonRuntimeWithAuth = func(
+		string, string, int, string, bool, bool, ...int,
+	) (string, error) {
+		return "", errors.New("forced runtime-record write failure")
+	}
+	pgServeTestStartup = func() {
+		writePGServeRuntimeRecord(&serveRuntime{
+			Cfg: config.Config{
+				DataDir: os.Getenv("AGENTSVIEW_DATA_DIR"),
+				Host:    "127.0.0.1",
+				Port:    8787,
+			},
+		})
+	}
+	runPGServe(config.Config{DataDir: os.Getenv("AGENTSVIEW_DATA_DIR")}, "")
+}
+
+func TestRunDuckDBRuntimeWarningHelperProcess(t *testing.T) {
+	if os.Getenv("AGENTSVIEW_RUN_DUCKDB_RUNTIME_WARNING_HELPER") != "1" {
+		return
+	}
+	writeDaemonRuntimeWithAuth = func(
+		string, string, int, string, bool, bool, ...int,
+	) (string, error) {
+		return "", errors.New("forced runtime-record write failure")
+	}
+	go func() {
+		time.Sleep(time.Second)
+		os.Exit(0)
+	}()
+	runDuckDBServe(config.Config{
+		Host:    "127.0.0.1",
+		Port:    0,
+		DataDir: os.Getenv("AGENTSVIEW_DATA_DIR"),
+		DuckDB: config.DuckDBConfig{
+			Path: os.Getenv("AGENTSVIEW_DUCKDB_RUNTIME_WARNING_PATH"),
+		},
+	}, "")
 }
 
 func TestMustLoadConfig(t *testing.T) {

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -191,7 +191,7 @@ func TestRunDuckDBRuntimeWarningHelperProcess(t *testing.T) {
 		return "", errors.New("forced runtime-record write failure")
 	}
 	go func() {
-		time.Sleep(time.Second)
+		time.Sleep(3 * time.Second)
 		os.Exit(0)
 	}()
 	runDuckDBServe(config.Config{

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -28,7 +28,7 @@ func TestRuntimeWarningHelper(t *testing.T) {
 	logOutput := captureLogOutput(t)
 	var visible bytes.Buffer
 
-	warnRuntimeRecordWrite(
+	reportRuntimeRecordWrite(
 		&visible, errors.New("permission denied"),
 		"keeping start lock as fallback",
 		"To fix permissions, run: icacls <dir> /setowner <user>",
@@ -41,7 +41,7 @@ func TestRuntimeWarningHelper(t *testing.T) {
 
 func TestServeRuntimeRecordWriteFailureWarnsVisible(t *testing.T) {
 	var visible bytes.Buffer
-	warnRuntimeRecordWrite(
+	reportRuntimeRecordWrite(
 		&visible, errors.New("permission denied"),
 		"keeping start lock as fallback",
 		"To fix permissions, run: icacls <dir> /setowner <user>",
@@ -53,12 +53,19 @@ func TestServeRuntimeRecordWriteFailureWarnsVisible(t *testing.T) {
 
 func TestServeRuntimeRecordWriteSuccessDoesNotWarnVisible(t *testing.T) {
 	var visible bytes.Buffer
+	logOutput := captureLogOutput(t)
+	reportRuntimeRecordWrite(
+		&visible, nil, "keeping start lock as fallback",
+		"To fix permissions, run: icacls <dir> /setowner <user>",
+	)
+
 	assert.NotContains(t, visible.String(), "could not write daemon runtime record")
+	assert.NotContains(t, logOutput.String(), "could not write daemon runtime record")
 }
 
 func TestPGServeRuntimeRecordWriteFailureWarnsVisible(t *testing.T) {
 	var visible bytes.Buffer
-	warnRuntimeRecordWrite(
+	reportRuntimeRecordWrite(
 		&visible, errors.New("permission denied"),
 		"pg serve daemon may not be discoverable by CLI", "",
 	)
@@ -68,12 +75,38 @@ func TestPGServeRuntimeRecordWriteFailureWarnsVisible(t *testing.T) {
 
 func TestDuckDBServeRuntimeRecordWriteFailureWarnsVisible(t *testing.T) {
 	var visible bytes.Buffer
-	warnRuntimeRecordWrite(
+	reportRuntimeRecordWrite(
 		&visible, errors.New("permission denied"),
 		"duckdb serve daemon may not be discoverable by CLI", "",
 	)
 
 	assert.Contains(t, visible.String(), "could not write daemon runtime record")
+}
+
+func TestServeRuntimeRecordWriteCallSitesUseVisibleSink(t *testing.T) {
+	tests := []struct {
+		file string
+		call string
+	}{
+		{file: "main.go", call: "WriteDaemonRuntimeWithAuthAndNoSync("},
+		{file: "pg.go", call: "WriteDaemonRuntimeWithAuth("},
+		{file: "duckdb.go", call: "WriteDaemonRuntimeWithAuth("},
+	}
+	for _, tt := range tests {
+		t.Run(tt.file, func(t *testing.T) {
+			source, err := os.ReadFile(tt.file)
+			require.NoError(t, err)
+			branchStart := strings.Index(string(source), tt.call)
+			require.GreaterOrEqual(t, branchStart, 0)
+			branch := string(source)[branchStart:]
+			branchEnd := strings.Index(branch, "\n\t} else {")
+			require.Greater(t, branchEnd, 0)
+			branch = branch[:branchEnd]
+			assert.Contains(t, branch, "reportRuntimeRecordWrite(")
+			assert.Contains(t, branch, "os.Stdout")
+			assert.NotContains(t, branch, "log.Printf")
+		})
+	}
 }
 
 func TestMustLoadConfig(t *testing.T) {

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -24,6 +24,58 @@ import (
 	agentsync "go.kenn.io/agentsview/internal/sync"
 )
 
+func TestRuntimeWarningHelper(t *testing.T) {
+	logOutput := captureLogOutput(t)
+	var visible bytes.Buffer
+
+	warnRuntimeRecordWrite(
+		&visible, errors.New("permission denied"),
+		"keeping start lock as fallback",
+		"To fix permissions, run: icacls <dir> /setowner <user>",
+	)
+
+	assert.Contains(t, visible.String(), "could not write daemon runtime record")
+	assert.Contains(t, visible.String(), "icacls <dir> /setowner <user>")
+	assert.Contains(t, logOutput.String(), "could not write daemon runtime record")
+}
+
+func TestServeRuntimeRecordWriteFailureWarnsVisible(t *testing.T) {
+	var visible bytes.Buffer
+	warnRuntimeRecordWrite(
+		&visible, errors.New("permission denied"),
+		"keeping start lock as fallback",
+		"To fix permissions, run: icacls <dir> /setowner <user>",
+	)
+
+	assert.Contains(t, visible.String(), "could not write daemon runtime record")
+	assert.Contains(t, visible.String(), "icacls <dir> /setowner <user>")
+}
+
+func TestServeRuntimeRecordWriteSuccessDoesNotWarnVisible(t *testing.T) {
+	var visible bytes.Buffer
+	assert.NotContains(t, visible.String(), "could not write daemon runtime record")
+}
+
+func TestPGServeRuntimeRecordWriteFailureWarnsVisible(t *testing.T) {
+	var visible bytes.Buffer
+	warnRuntimeRecordWrite(
+		&visible, errors.New("permission denied"),
+		"pg serve daemon may not be discoverable by CLI", "",
+	)
+
+	assert.Contains(t, visible.String(), "could not write daemon runtime record")
+}
+
+func TestDuckDBServeRuntimeRecordWriteFailureWarnsVisible(t *testing.T) {
+	var visible bytes.Buffer
+	warnRuntimeRecordWrite(
+		&visible, errors.New("permission denied"),
+		"duckdb serve daemon may not be discoverable by CLI", "",
+	)
+
+	assert.Contains(t, visible.String(), "could not write daemon runtime record")
+}
+
 func TestMustLoadConfig(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/cmd/agentsview/pg.go
+++ b/cmd/agentsview/pg.go
@@ -468,6 +468,10 @@ func loadPGServeConfig(cmd *cobra.Command) (config.Config, string, error) {
 
 func runPGServe(appCfg config.Config, basePath string) {
 	setupLogFile(appCfg.DataDir)
+	if pgServeTestStartup != nil {
+		pgServeTestStartup()
+		return
+	}
 	if appCfg.RequireAuth {
 		if err := appCfg.EnsureAuthToken(); err != nil {
 			fatal("pg serve: generating auth token: %v", err)
@@ -578,16 +582,7 @@ func runPGServe(appCfg config.Config, basePath string) {
 	// Write the kit runtime record so CLI commands can discover this
 	// daemon. ReadOnly=true marks it as pg serve (read-only)
 	// so clients can select an appropriate transport.
-	if _, sfErr := writeDaemonRuntimeWithAuth(
-		rt.Cfg.DataDir, rt.Cfg.Host, rt.Cfg.Port, version, true,
-		rt.Cfg.RequireAuth,
-		rt.Caddy.Pid(),
-	); sfErr != nil {
-		reportRuntimeRecordWrite(
-			os.Stdout, sfErr,
-			"pg serve daemon may not be discoverable by CLI", "",
-		)
-	} else {
+	if writePGServeRuntimeRecord(rt) {
 		defer RemoveDaemonRuntime(rt.Cfg.DataDir)
 	}
 
@@ -612,6 +607,21 @@ func runPGServe(appCfg config.Config, basePath string) {
 	if err := waitForServerRuntime(ctx, srv, rt); err != nil {
 		fatal("pg serve: %v", err)
 	}
+}
+
+func writePGServeRuntimeRecord(rt *serveRuntime) bool {
+	if _, sfErr := writeDaemonRuntimeWithAuth(
+		rt.Cfg.DataDir, rt.Cfg.Host, rt.Cfg.Port, version, true,
+		rt.Cfg.RequireAuth,
+		rt.Caddy.Pid(),
+	); sfErr != nil {
+		reportRuntimeRecordWrite(
+			os.Stdout, sfErr,
+			"pg serve daemon may not be discoverable by CLI", "",
+		)
+		return false
+	}
+	return true
 }
 
 func resolvePushProjects(

--- a/cmd/agentsview/pg.go
+++ b/cmd/agentsview/pg.go
@@ -529,7 +529,7 @@ func preparePGServeImpl(appCfg config.Config, basePath string) (pgServeStartup, 
 		return pgServeStartup{}, fmt.Errorf(
 			"pg serve: schema incompatible: %w\n"+
 				"Drop and recreate the PG schema, then run "+
-				"'agentsview pg push --full' to repopulate.",
+				"'agentsview pg push --full' to repopulate",
 			err,
 		)
 	}

--- a/cmd/agentsview/pg.go
+++ b/cmd/agentsview/pg.go
@@ -466,28 +466,27 @@ func loadPGServeConfig(cmd *cobra.Command) (config.Config, string, error) {
 	return cfg, basePath, nil
 }
 
-func runPGServe(appCfg config.Config, basePath string) {
-	setupLogFile(appCfg.DataDir)
-	if pgServeTestStartup != nil {
-		pgServeTestStartup()
-		return
-	}
-	if appCfg.RequireAuth {
-		if err := appCfg.EnsureAuthToken(); err != nil {
-			fatal("pg serve: generating auth token: %v", err)
-		}
-	}
+type pgServeStartup struct {
+	cfg     config.Config
+	ctx     context.Context
+	rtOpts  serveRuntimeOptions
+	srv     *server.Server
+	cleanup func()
+}
 
+var preparePGServe = preparePGServeImpl
+
+func preparePGServeImpl(appCfg config.Config, basePath string) (pgServeStartup, error) {
 	if err := validateServeConfig(appCfg); err != nil {
-		fatal("invalid serve config: %v", err)
+		return pgServeStartup{}, fmt.Errorf("invalid serve config: %w", err)
 	}
 
 	pgCfg, err := appCfg.ResolvePG()
 	if err != nil {
-		fatal("pg serve: %v", err)
+		return pgServeStartup{}, fmt.Errorf("pg serve: %w", err)
 	}
 	if pgCfg.URL == "" {
-		fatal("pg serve: url not configured")
+		return pgServeStartup{}, errors.New("pg serve: url not configured")
 	}
 
 	applyClassifierConfig(appCfg)
@@ -495,9 +494,9 @@ func runPGServe(appCfg config.Config, basePath string) {
 		pgCfg.URL, pgCfg.Schema, pgCfg.AllowInsecure,
 	)
 	if err != nil {
-		fatal("pg serve: %v", err)
+		return pgServeStartup{}, fmt.Errorf("pg serve: %w", err)
 	}
-	defer store.Close()
+	cleanupStore := func() { _ = store.Close() }
 
 	if len(appCfg.CustomModelPricing) > 0 {
 		store.SetCustomPricing(appCfg.CustomModelPricing)
@@ -507,37 +506,47 @@ func runPGServe(appCfg config.Config, basePath string) {
 		context.Background(),
 		os.Interrupt, syscall.SIGTERM,
 	)
-	defer stop()
+	cleanup := func() {
+		stop()
+		cleanupStore()
+	}
 
 	if err := postgres.EnsureSchema(
 		ctx, store.DB(), pgCfg.Schema,
 	); err != nil {
 		if !postgres.IsReadOnlyError(err) {
-			fatal("pg serve: schema migration failed: %v", err)
+			cleanup()
+			return pgServeStartup{}, fmt.Errorf(
+				"pg serve: schema migration failed: %w", err,
+			)
 		}
 	}
 
 	if err := postgres.CheckSchemaCompat(
 		ctx, store.DB(),
 	); err != nil {
-		fatal("pg serve: schema incompatible: %v\n"+
-			"Drop and recreate the PG schema, then run "+
-			"'agentsview pg push --full' to repopulate.", err)
+		cleanup()
+		return pgServeStartup{}, fmt.Errorf(
+			"pg serve: schema incompatible: %w\n"+
+				"Drop and recreate the PG schema, then run "+
+				"'agentsview pg push --full' to repopulate.",
+			err,
+		)
 	}
 	if err := postgres.CheckDataVersionCompat(
 		ctx, store.DB(),
 	); err != nil {
-		fatal("pg serve: %v", err)
+		cleanup()
+		return pgServeStartup{}, fmt.Errorf("pg serve: %w", err)
 	}
 	if err := wirePGVectorSearch(ctx, appCfg, store, "pg serve"); err != nil {
-		fatal("pg serve: %v", err)
+		cleanup()
+		return pgServeStartup{}, fmt.Errorf("pg serve: %w", err)
 	}
-	if err := store.DetectInsightGenerationAvailability(
-		ctx,
-	); err != nil {
-		fatal(
-			"pg serve: probing insight generation capability: %v",
-			err,
+	if err := store.DetectInsightGenerationAvailability(ctx); err != nil {
+		cleanup()
+		return pgServeStartup{}, fmt.Errorf(
+			"pg serve: probing insight generation capability: %w", err,
 		)
 	}
 
@@ -547,7 +556,8 @@ func runPGServe(appCfg config.Config, basePath string) {
 	}
 	appCfg, err = prepareServeRuntimeConfig(appCfg, rtOpts)
 	if err != nil {
-		fatal("pg serve: %v", err)
+		cleanup()
+		return pgServeStartup{}, fmt.Errorf("pg serve: %w", err)
 	}
 
 	opts := []server.Option{
@@ -564,7 +574,29 @@ func runPGServe(appCfg config.Config, basePath string) {
 	if basePath != "" {
 		opts = append(opts, server.WithBasePath(basePath))
 	}
-	srv := server.New(appCfg, store, nil, opts...)
+	return pgServeStartup{
+		cfg: appCfg, ctx: ctx, rtOpts: rtOpts,
+		srv: server.New(appCfg, store, nil, opts...), cleanup: cleanup,
+	}, nil
+}
+
+func runPGServe(appCfg config.Config, basePath string) {
+	setupLogFile(appCfg.DataDir)
+	if appCfg.RequireAuth {
+		if err := appCfg.EnsureAuthToken(); err != nil {
+			fatal("pg serve: generating auth token: %v", err)
+		}
+	}
+
+	startup, err := preparePGServe(appCfg, basePath)
+	if err != nil {
+		fatal("%v", err)
+	}
+	defer startup.cleanup()
+	appCfg = startup.cfg
+	ctx := startup.ctx
+	rtOpts := startup.rtOpts
+	srv := startup.srv
 
 	rt, err := startServerWithOptionalCaddy(
 		ctx,

--- a/cmd/agentsview/pg.go
+++ b/cmd/agentsview/pg.go
@@ -578,7 +578,7 @@ func runPGServe(appCfg config.Config, basePath string) {
 	// Write the kit runtime record so CLI commands can discover this
 	// daemon. ReadOnly=true marks it as pg serve (read-only)
 	// so clients can select an appropriate transport.
-	if _, sfErr := WriteDaemonRuntimeWithAuth(
+	if _, sfErr := writeDaemonRuntimeWithAuth(
 		rt.Cfg.DataDir, rt.Cfg.Host, rt.Cfg.Port, version, true,
 		rt.Cfg.RequireAuth,
 		rt.Caddy.Pid(),

--- a/cmd/agentsview/pg.go
+++ b/cmd/agentsview/pg.go
@@ -583,10 +583,9 @@ func runPGServe(appCfg config.Config, basePath string) {
 		rt.Cfg.RequireAuth,
 		rt.Caddy.Pid(),
 	); sfErr != nil {
-		log.Printf(
-			"warning: could not write daemon runtime record: %v"+
-				" (pg serve daemon may not be discoverable by CLI)",
-			sfErr,
+		warnRuntimeRecordWrite(
+			os.Stdout, sfErr,
+			"pg serve daemon may not be discoverable by CLI", "",
 		)
 	} else {
 		defer RemoveDaemonRuntime(rt.Cfg.DataDir)

--- a/cmd/agentsview/pg.go
+++ b/cmd/agentsview/pg.go
@@ -583,7 +583,7 @@ func runPGServe(appCfg config.Config, basePath string) {
 		rt.Cfg.RequireAuth,
 		rt.Caddy.Pid(),
 	); sfErr != nil {
-		warnRuntimeRecordWrite(
+		reportRuntimeRecordWrite(
 			os.Stdout, sfErr,
 			"pg serve daemon may not be discoverable by CLI", "",
 		)

--- a/cmd/agentsview/runtime_warning.go
+++ b/cmd/agentsview/runtime_warning.go
@@ -6,6 +6,11 @@ import (
 	"log"
 )
 
+var (
+	writeDaemonRuntimeWithAuthAndNoSync = WriteDaemonRuntimeWithAuthAndNoSync
+	writeDaemonRuntimeWithAuth          = WriteDaemonRuntimeWithAuth
+)
+
 func warnRuntimeRecordWrite(
 	out io.Writer, err error, context, remedy string,
 ) {

--- a/cmd/agentsview/runtime_warning.go
+++ b/cmd/agentsview/runtime_warning.go
@@ -9,6 +9,7 @@ import (
 var (
 	writeDaemonRuntimeWithAuthAndNoSync = WriteDaemonRuntimeWithAuthAndNoSync
 	writeDaemonRuntimeWithAuth          = WriteDaemonRuntimeWithAuth
+	pgServeTestStartup                  func()
 )
 
 func warnRuntimeRecordWrite(

--- a/cmd/agentsview/runtime_warning.go
+++ b/cmd/agentsview/runtime_warning.go
@@ -9,7 +9,6 @@ import (
 var (
 	writeDaemonRuntimeWithAuthAndNoSync = WriteDaemonRuntimeWithAuthAndNoSync
 	writeDaemonRuntimeWithAuth          = WriteDaemonRuntimeWithAuth
-	pgServeTestStartup                  func()
 )
 
 func warnRuntimeRecordWrite(

--- a/cmd/agentsview/runtime_warning.go
+++ b/cmd/agentsview/runtime_warning.go
@@ -20,3 +20,12 @@ func warnRuntimeRecordWrite(
 		fmt.Fprintln(out, remedy)
 	}
 }
+
+func reportRuntimeRecordWrite(
+	out io.Writer, err error, context, remedy string,
+) {
+	if err == nil {
+		return
+	}
+	warnRuntimeRecordWrite(out, err, context, remedy)
+}

--- a/cmd/agentsview/runtime_warning.go
+++ b/cmd/agentsview/runtime_warning.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+)
+
+func warnRuntimeRecordWrite(
+	out io.Writer, err error, context, remedy string,
+) {
+	warning := fmt.Sprintf(
+		"warning: could not write daemon runtime record: %v (%s)",
+		err, context,
+	)
+	log.Print(warning)
+	fmt.Fprintln(out, warning)
+	if remedy != "" {
+		log.Print(remedy)
+		fmt.Fprintln(out, remedy)
+	}
+}


### PR DESCRIPTION
When a serve process binds successfully but fails to persist its daemon runtime record, the one actionable warning lands only in `debug.log`. Background launches point users at `serve.log`, so the visible lifecycle output shows the normal banner and log path while hiding the reason discovery broke.

This change routes that post-bind runtime-record warning through the same visible stream as the serve banner, while keeping the existing startup behavior intact. The writable local serve path adds the owner-fix hint in the log text, and the read-only PostgreSQL and DuckDB serve paths reuse the same visible-warning contract without changing their discovery semantics. PostgreSQL now reaches the real post-bind runtime-write branch through a narrow pre-bind startup seam, so the regression proof exercises the production warning path instead of a test-only shortcut. The lifecycle fallback and stop recovery stay in the sibling slice.

The scope and failing log-path trace came from https://github.com/kenn-io/agentsview/issues/1097#issuecomment-4948947592. Focused runtime-warning entrypoint tests, `go vet ./cmd/agentsview`, formatting, diff checks, and the final adversarial rerun all passed on this branch.

Refs #1097
