### PR TITLE
fix(daemon): recover recordless writable daemons after startup-state lock acquisition

### DIFF
--- a/cmd/agentsview/daemon.go
+++ b/cmd/agentsview/daemon.go
@@ -450,6 +450,12 @@ func runDaemonStatus(w io.Writer, deps daemonCommandDeps) error {
 	}
 	records, err := deps.statusRecords(cfg.DataDir, cfg.AuthToken)
 	if err != nil {
+		if rt := writableRuntimeFallbackForCommand(cfg, deps); rt != nil {
+			for _, line := range serveStatusLines(rt) {
+				fmt.Fprintln(w, line)
+			}
+			return nil
+		}
 		return fmt.Errorf("daemon status: inspecting runtime store: %w", err)
 	}
 
@@ -550,13 +556,19 @@ func runDaemonStop(w io.Writer, deps daemonCommandDeps) error {
 	}
 	records, err := deps.writableRecords(cfg.DataDir, cfg.AuthToken)
 	if err != nil {
-		return fmt.Errorf("daemon stop: inspecting runtime store: %w", err)
-	}
-	records, fallback := writableDaemonRecordsWithFallback(records, func() *DaemonRuntime {
-		return writableRuntimeFallbackForCommand(cfg, deps)
-	})
-	if !fallback && deps.isStarting(cfg.DataDir) {
-		return daemonPersistentStartupError("daemon stop", cfg.DataDir, deps.readStartupState(cfg.DataDir), deps.now())
+		fallback := writableRuntimeFallbackForCommand(cfg, deps)
+		if fallback == nil {
+			return fmt.Errorf("daemon stop: inspecting runtime store: %w", err)
+		}
+		records = []daemon.RuntimeRecord{fallback.Record}
+	} else {
+		var fallback bool
+		records, fallback = writableDaemonRecordsWithFallback(records, func() *DaemonRuntime {
+			return writableRuntimeFallbackForCommand(cfg, deps)
+		})
+		if !fallback && deps.isStarting(cfg.DataDir) {
+			return daemonPersistentStartupError("daemon stop", cfg.DataDir, deps.readStartupState(cfg.DataDir), deps.now())
+		}
 	}
 	if len(records) == 0 {
 		fmt.Fprintln(w, "agentsview daemon is not running.")
@@ -602,7 +614,9 @@ func runDaemonRestart(w io.Writer, deps daemonCommandDeps) error {
 	}
 	records, err := deps.writableRecords(cfg.DataDir, cfg.AuthToken)
 	if err != nil {
-		return fmt.Errorf("daemon restart: inspecting runtime store: %w", err)
+		if fallback == nil {
+			return fmt.Errorf("daemon restart: inspecting runtime store: %w", err)
+		}
 	}
 	if fallback != nil {
 		records = []daemon.RuntimeRecord{fallback.Record}

--- a/cmd/agentsview/daemon.go
+++ b/cmd/agentsview/daemon.go
@@ -533,9 +533,6 @@ func runDaemonStop(w io.Writer, deps daemonCommandDeps) error {
 	if err := validateLockedDataDir(dataDir, cfg.DataDir); err != nil {
 		return fmt.Errorf("daemon stop: %w", err)
 	}
-	if deps.isStarting(cfg.DataDir) {
-		return daemonPersistentStartupError("daemon stop", cfg.DataDir, deps.readStartupState(cfg.DataDir), deps.now())
-	}
 	records, err := deps.writableRecords(cfg.DataDir, cfg.AuthToken)
 	if err != nil {
 		return fmt.Errorf("daemon stop: inspecting runtime store: %w", err)
@@ -546,6 +543,9 @@ func runDaemonStop(w io.Writer, deps daemonCommandDeps) error {
 				records = []daemon.RuntimeRecord{rt.Record}
 			}
 		}
+	}
+	if len(records) == 0 && deps.isStarting(cfg.DataDir) {
+		return daemonPersistentStartupError("daemon stop", cfg.DataDir, deps.readStartupState(cfg.DataDir), deps.now())
 	}
 	if len(records) == 0 {
 		fmt.Fprintln(w, "agentsview daemon is not running.")

--- a/cmd/agentsview/daemon.go
+++ b/cmd/agentsview/daemon.go
@@ -80,6 +80,7 @@ type daemonCommandDeps struct {
 	validateConfig             func(config.Config) error
 	checkDataVersion           func(string) error
 	probeRecord                func(daemon.RuntimeRecord, string) (daemon.PingInfo, bool)
+	writableRuntime            func(string, string) *DaemonRuntime
 	now                        func() time.Time
 }
 
@@ -104,7 +105,10 @@ func defaultDaemonCommandDeps() daemonCommandDeps {
 		validateConfig:      validateServeConfig,
 		checkDataVersion:    db.CheckDataVersion,
 		probeRecord:         probeDaemonRecord,
-		now:                 time.Now,
+		writableRuntime: func(dataDir, authToken string) *DaemonRuntime {
+			return FindWritableDaemonRuntime(dataDir, authToken)
+		},
+		now: time.Now,
 	}
 }
 
@@ -451,6 +455,14 @@ func runDaemonStatus(w io.Writer, deps daemonCommandDeps) error {
 		writeDaemonRecordStatus(w, cfg, writable[0], deps)
 		return nil
 	}
+	if deps.writableRuntime != nil {
+		if rt := deps.writableRuntime(cfg.DataDir, cfg.AuthToken); rt != nil {
+			for _, line := range serveStatusLines(rt) {
+				fmt.Fprintln(w, line)
+			}
+			return nil
+		}
+	}
 	if deps.isStarting(cfg.DataDir) {
 		fmt.Fprintln(w, "agentsview daemon is starting up.")
 		for _, line := range serveStartingStatusLines(deps.readStartupState(cfg.DataDir), deps.now()) {
@@ -527,6 +539,13 @@ func runDaemonStop(w io.Writer, deps daemonCommandDeps) error {
 	records, err := deps.writableRecords(cfg.DataDir, cfg.AuthToken)
 	if err != nil {
 		return fmt.Errorf("daemon stop: inspecting runtime store: %w", err)
+	}
+	if len(records) == 0 {
+		if deps.writableRuntime != nil {
+			if rt := deps.writableRuntime(cfg.DataDir, cfg.AuthToken); rt != nil {
+				records = []daemon.RuntimeRecord{rt.Record}
+			}
+		}
 	}
 	if len(records) == 0 {
 		fmt.Fprintln(w, "agentsview daemon is not running.")

--- a/cmd/agentsview/daemon.go
+++ b/cmd/agentsview/daemon.go
@@ -537,14 +537,13 @@ func runDaemonStop(w io.Writer, deps daemonCommandDeps) error {
 	if err != nil {
 		return fmt.Errorf("daemon stop: inspecting runtime store: %w", err)
 	}
-	if len(records) == 0 {
-		if deps.writableRuntime != nil {
-			if rt := deps.writableRuntime(cfg.DataDir, cfg.AuthToken); rt != nil {
-				records = []daemon.RuntimeRecord{rt.Record}
-			}
+	records, fallback := writableDaemonRecordsWithFallback(records, func() *DaemonRuntime {
+		if deps.writableRuntime == nil {
+			return nil
 		}
-	}
-	if len(records) == 0 && deps.isStarting(cfg.DataDir) {
+		return deps.writableRuntime(cfg.DataDir, cfg.AuthToken)
+	})
+	if !fallback && deps.isStarting(cfg.DataDir) {
 		return daemonPersistentStartupError("daemon stop", cfg.DataDir, deps.readStartupState(cfg.DataDir), deps.now())
 	}
 	if len(records) == 0 {

--- a/cmd/agentsview/daemon.go
+++ b/cmd/agentsview/daemon.go
@@ -168,6 +168,17 @@ func prepareDaemonMutation(deps daemonCommandDeps) (string, error) {
 	return dataDir, nil
 }
 
+func writableRuntimeFallbackForCommand(cfg config.Config, deps daemonCommandDeps) *DaemonRuntime {
+	if deps.writableRuntime == nil {
+		return nil
+	}
+	rt := deps.writableRuntime(cfg.DataDir, cfg.AuthToken)
+	if rt == nil || !rt.RuntimeFallback {
+		return nil
+	}
+	return rt
+}
+
 func runDaemonStart(w io.Writer, deps daemonCommandDeps) error {
 	dataDir, err := prepareDaemonMutation(deps)
 	if err != nil {
@@ -188,6 +199,10 @@ func runDaemonStart(w io.Writer, deps daemonCommandDeps) error {
 	}
 	if err := validateLockedDataDir(dataDir, cfg.DataDir); err != nil {
 		return fmt.Errorf("daemon start: %w", err)
+	}
+	if rt := writableRuntimeFallbackForCommand(cfg, deps); rt != nil {
+		writeDaemonStartResult(w, backgroundLaunchResult{Runtime: rt}, false)
+		return nil
 	}
 	if deps.isStarting(cfg.DataDir) {
 		return daemonPersistentStartupError("daemon start", cfg.DataDir, deps.readStartupState(cfg.DataDir), deps.now())
@@ -538,10 +553,7 @@ func runDaemonStop(w io.Writer, deps daemonCommandDeps) error {
 		return fmt.Errorf("daemon stop: inspecting runtime store: %w", err)
 	}
 	records, fallback := writableDaemonRecordsWithFallback(records, func() *DaemonRuntime {
-		if deps.writableRuntime == nil {
-			return nil
-		}
-		return deps.writableRuntime(cfg.DataDir, cfg.AuthToken)
+		return writableRuntimeFallbackForCommand(cfg, deps)
 	})
 	if !fallback && deps.isStarting(cfg.DataDir) {
 		return daemonPersistentStartupError("daemon stop", cfg.DataDir, deps.readStartupState(cfg.DataDir), deps.now())
@@ -578,7 +590,8 @@ func runDaemonRestart(w io.Writer, deps daemonCommandDeps) error {
 	if err := validateLockedDataDir(dataDir, cfg.DataDir); err != nil {
 		return fmt.Errorf("daemon restart: %w", err)
 	}
-	if deps.isStarting(cfg.DataDir) {
+	fallback := writableRuntimeFallbackForCommand(cfg, deps)
+	if fallback == nil && deps.isStarting(cfg.DataDir) {
 		return daemonPersistentStartupError("daemon restart", cfg.DataDir, deps.readStartupState(cfg.DataDir), deps.now())
 	}
 	if err := deps.validateConfig(cfg); err != nil {
@@ -590,6 +603,9 @@ func runDaemonRestart(w io.Writer, deps daemonCommandDeps) error {
 	records, err := deps.writableRecords(cfg.DataDir, cfg.AuthToken)
 	if err != nil {
 		return fmt.Errorf("daemon restart: inspecting runtime store: %w", err)
+	}
+	if fallback != nil {
+		records = []daemon.RuntimeRecord{fallback.Record}
 	}
 	wasRunning := len(records) > 0
 	if wasRunning {

--- a/cmd/agentsview/daemon_runtime.go
+++ b/cmd/agentsview/daemon_runtime.go
@@ -278,6 +278,7 @@ func findStartupStateFallback(dataDir, authToken string) *DaemonRuntime {
 	if err != nil || info.PID != st.PID {
 		return nil
 	}
+	rec.Version = info.Version
 	rt := daemonRuntimeFromRecord(rec)
 	rt.RuntimeFallback = true
 	rt.RuntimeError = st.RuntimeError

--- a/cmd/agentsview/daemon_runtime.go
+++ b/cmd/agentsview/daemon_runtime.go
@@ -186,6 +186,10 @@ func RemoveDaemonRuntime(dataDir string) {
 	}
 }
 
+var listDaemonRuntimeRecords = func(store daemon.RuntimeStore) ([]daemon.RuntimeRecord, error) {
+	return store.List()
+}
+
 // FindDaemonRuntime returns a live agentsview daemon whose kit runtime record
 // passes the ping probe. Writable daemons are preferred over read-only pg serve
 // daemons when both are discoverable. When authToken is non-empty, it is sent
@@ -196,13 +200,17 @@ func FindDaemonRuntime(dataDir string, authToken ...string) *DaemonRuntime {
 	store := runtimeStore(dataDir)
 	_, _ = store.CleanupDead()
 
-	records, err := store.List()
+	token := firstAuthToken(authToken)
+	records, err := listDaemonRuntimeRecords(store)
 	if err != nil {
+		rt := findStartupStateFallback(dataDir, token)
+		if rt != nil && daemonRuntimeCompatibilityError(rt) == nil {
+			return rt
+		}
 		return nil
 	}
 
 	ctx := context.Background()
-	token := firstAuthToken(authToken)
 	var readOnly *DaemonRuntime
 	writableRecordSeen := false
 	for _, rec := range records {
@@ -378,8 +386,12 @@ func findIncompatibleDaemonRuntime(
 
 	store := runtimeStore(dataDir)
 	_, _ = store.CleanupDead()
-	records, err := store.List()
+	records, err := listDaemonRuntimeRecords(store)
 	if err != nil {
+		rt := findStartupStateFallback(dataDir, token)
+		if rt != nil && daemonRuntimeCompatibilityError(rt) != nil {
+			return rt
+		}
 		return nil
 	}
 

--- a/cmd/agentsview/daemon_runtime.go
+++ b/cmd/agentsview/daemon_runtime.go
@@ -40,6 +40,7 @@ const (
 )
 
 var startProbeTickNanos int64 = int64(defaultStartProbeTick)
+var startLockTryLock = func(lock *flock.Flock) (bool, error) { return lock.TryLock() }
 
 func startProbeTick() time.Duration {
 	return time.Duration(atomic.LoadInt64(&startProbeTickNanos))
@@ -118,10 +119,16 @@ func WriteDaemonRuntimeWithAuthAndNoSync(
 			rec.Metadata[runtimeCaddyCreateTime] = strconv.FormatInt(ct, 10)
 		}
 	}
+	caddy := 0
+	if len(caddyPID) > 0 && caddyPID[0] > 0 {
+		caddy = caddyPID[0]
+	}
 	path, err := runtimeStore(dataDir).Write(rec)
 	if err != nil {
 		if !readOnly {
-			publishStartupStateFallback(dataDir, host, port, err)
+			publishStartupStateFallback(
+				dataDir, host, port, requireAuth, noSync, caddy, err,
+			)
 		}
 		return "", err
 	}
@@ -231,6 +238,9 @@ func FindDaemonRuntime(dataDir string, authToken ...string) *DaemonRuntime {
 	}
 	if !writableRecordSeen {
 		if rt := findStartupStateFallback(dataDir, token); rt != nil {
+			if daemonRuntimeCompatibilityError(rt) != nil {
+				return nil
+			}
 			return rt
 		}
 	}
@@ -246,6 +256,50 @@ func FindWritableDaemonRuntime(dataDir string, authToken ...string) *DaemonRunti
 		return nil
 	}
 	return rt
+}
+
+// writableDaemonRecordsWithFallback appends a confirmed fallback only when no live writable record exists.
+func writableDaemonRecordsWithFallback(
+	records []daemon.RuntimeRecord,
+	resolve func() *DaemonRuntime,
+) ([]daemon.RuntimeRecord, bool) {
+	if resolve == nil {
+		return records, false
+	}
+	filtered := records[:0]
+	hasWritable := false
+	for _, rec := range records {
+		rt := daemonRuntimeFromRecord(rec)
+		if !rt.ReadOnly && processCreateTimeStateForPID(
+			rec.PID, rec.Metadata[runtimeCreateTime],
+		) == processCreateTimeMismatch {
+			continue
+		}
+		filtered = append(filtered, rec)
+		if !rt.ReadOnly {
+			hasWritable = true
+		}
+	}
+	records = filtered
+	if hasWritable {
+		return records, false
+	}
+	rt := resolve()
+	if rt == nil {
+		return records, false
+	}
+	return append(records, rt.Record), rt.RuntimeFallback
+}
+
+func localWritableDaemonRecordsWithFallback(
+	dataDir, authToken string,
+) ([]daemon.RuntimeRecord, bool) {
+	return writableDaemonRecordsWithFallback(
+		liveDaemonRecords(dataDir),
+		func() *DaemonRuntime {
+			return FindWritableDaemonRuntime(dataDir, authToken)
+		},
+	)
 }
 
 func findStartupStateFallback(dataDir, authToken string) *DaemonRuntime {
@@ -269,9 +323,21 @@ func findStartupStateFallback(dataDir, authToken string) *DaemonRuntime {
 		runtimeHost:        st.Host,
 		runtimePort:        strconv.Itoa(st.Port),
 		runtimeReadOnly:    "false",
-		runtimeAPIVersion:  strconv.Itoa(daemonAPIVersion),
-		runtimeDataVersion: strconv.Itoa(db.CurrentDataVersion()),
+		runtimeAPIVersion:  strconv.Itoa(st.APIVersion),
+		runtimeDataVersion: strconv.Itoa(st.DataVersion),
 		runtimeCreateTime:  st.CreateTime,
+	}
+	if st.RequireAuthKnown {
+		rec.Metadata[runtimeRequireAuth] = strconv.FormatBool(st.RequireAuth)
+	}
+	if st.NoSyncKnown {
+		rec.Metadata[runtimeNoSync] = strconv.FormatBool(st.NoSync)
+	}
+	if st.CaddyPID > 0 {
+		rec.Metadata[runtimeCaddyPID] = strconv.Itoa(st.CaddyPID)
+	}
+	if st.CaddyCreateTime != "" {
+		rec.Metadata[runtimeCaddyCreateTime] = st.CaddyCreateTime
 	}
 	info, err := probeRuntime(context.Background(), rec, authToken,
 		daemon.ProbeOptions{ExpectedService: daemonService, Timeout: 500 * time.Millisecond})
@@ -319,6 +385,7 @@ func findIncompatibleDaemonRuntime(
 
 	ctx := context.Background()
 	var readOnly *DaemonRuntime
+	writableRecordSeen := false
 	for _, rec := range records {
 		if rec.Service != "" && rec.Service != daemonService {
 			continue
@@ -328,6 +395,9 @@ func findIncompatibleDaemonRuntime(
 		}
 		if runtimeRecordHasMismatchedCreateTime(store, rec) {
 			continue
+		}
+		if !daemonRuntimeFromRecord(rec).ReadOnly {
+			writableRecordSeen = true
 		}
 		info, err := probeRuntime(ctx, rec, token, daemon.ProbeOptions{
 			ExpectedService: daemonService,
@@ -345,6 +415,12 @@ func findIncompatibleDaemonRuntime(
 		}
 		if readOnly == nil {
 			readOnly = rt
+		}
+	}
+	if !writableRecordSeen {
+		if rt := findStartupStateFallback(dataDir, token); rt != nil &&
+			daemonRuntimeCompatibilityError(rt) != nil {
+			return rt
 		}
 	}
 	return readOnly
@@ -768,6 +844,10 @@ func UnmarkDaemonStarting(dataDir string) {
 }
 
 func isDaemonStarting(dataDir string) bool {
+	return daemonStartingWithLockProbe(dataDir, false)
+}
+
+func daemonStartingWithLockProbe(dataDir string, external bool) bool {
 	path, err := runtimeStore(dataDir).LockPath()
 	if err != nil {
 		return false
@@ -775,12 +855,12 @@ func isDaemonStarting(dataDir string) bool {
 	startLockMu.Lock()
 	defer startLockMu.Unlock()
 	if _, ok := startLocks.Load(path); ok {
-		return true
+		return !external
 	}
 	lock := flock.New(path)
-	locked, err := lock.TryLock()
+	locked, err := startLockTryLock(lock)
 	if err != nil {
-		return false
+		return true
 	}
 	if locked {
 		_ = lock.Unlock()
@@ -790,28 +870,7 @@ func isDaemonStarting(dataDir string) bool {
 }
 
 func isExternalDaemonStarting(dataDir string) bool {
-	path, err := runtimeStore(dataDir).LockPath()
-	if err != nil {
-		return false
-	}
-	startLockMu.Lock()
-	defer startLockMu.Unlock()
-	if _, ok := startLocks.Load(path); ok {
-		return false
-	}
-	lock := flock.New(path)
-	locked, err := lock.TryLock()
-	if err != nil {
-		// On Windows, probing a lock held by a helper process can report an
-		// error instead of a clean locked=false result. Treat uncertainty as
-		// active startup so replacement does not stop the incumbent daemon.
-		return true
-	}
-	if locked {
-		_ = lock.Unlock()
-		return false
-	}
-	return true
+	return daemonStartingWithLockProbe(dataDir, true)
 }
 
 const legacyStartupLockPrefix = "server.starting."

--- a/cmd/agentsview/daemon_runtime.go
+++ b/cmd/agentsview/daemon_runtime.go
@@ -56,6 +56,8 @@ type DaemonRuntime struct {
 	NoSync           bool
 	API              int
 	Data             int
+	RuntimeFallback  bool
+	RuntimeError     string
 }
 
 func runtimeStore(dataDir string) daemon.RuntimeStore {
@@ -116,7 +118,14 @@ func WriteDaemonRuntimeWithAuthAndNoSync(
 			rec.Metadata[runtimeCaddyCreateTime] = strconv.FormatInt(ct, 10)
 		}
 	}
-	return runtimeStore(dataDir).Write(rec)
+	path, err := runtimeStore(dataDir).Write(rec)
+	if err != nil {
+		if !readOnly {
+			publishStartupStateFallback(dataDir, host, port, err)
+		}
+		return "", err
+	}
+	return path, nil
 }
 
 // processCreateTimeMillis returns the OS-reported create time of pid in
@@ -188,6 +197,7 @@ func FindDaemonRuntime(dataDir string, authToken ...string) *DaemonRuntime {
 	ctx := context.Background()
 	token := firstAuthToken(authToken)
 	var readOnly *DaemonRuntime
+	writableRecordSeen := false
 	for _, rec := range records {
 		if rec.Service != "" && rec.Service != daemonService {
 			continue
@@ -197,6 +207,9 @@ func FindDaemonRuntime(dataDir string, authToken ...string) *DaemonRuntime {
 		}
 		if runtimeRecordHasMismatchedCreateTime(store, rec) {
 			continue
+		}
+		if !daemonRuntimeFromRecord(rec).ReadOnly {
+			writableRecordSeen = true
 		}
 		info, err := probeRuntime(ctx, rec, token, daemon.ProbeOptions{
 			ExpectedService: daemonService,
@@ -216,7 +229,59 @@ func FindDaemonRuntime(dataDir string, authToken ...string) *DaemonRuntime {
 			readOnly = rt
 		}
 	}
+	if !writableRecordSeen {
+		if rt := findStartupStateFallback(dataDir, token); rt != nil {
+			return rt
+		}
+	}
 	return readOnly
+}
+
+// FindWritableDaemonRuntime resolves the writable daemon used by lifecycle
+// operations. Runtime records stay primary; the startup-state fallback is
+// accepted only for a writable daemon with a live, identity-matching ping.
+func FindWritableDaemonRuntime(dataDir string, authToken ...string) *DaemonRuntime {
+	rt := FindDaemonRuntime(dataDir, authToken...)
+	if rt == nil || rt.ReadOnly {
+		return nil
+	}
+	return rt
+}
+
+func findStartupStateFallback(dataDir, authToken string) *DaemonRuntime {
+	if !IsDaemonStarting(dataDir) {
+		return nil
+	}
+	st := readStartupState(dataDir)
+	if st == nil || st.PID <= 0 || st.Host == "" || st.Port <= 0 ||
+		st.RuntimeError == "" || st.CreateTime == "" ||
+		!daemon.ProcessAlive(st.PID) ||
+		!processCreateTimeMatches(st.PID, st.CreateTime) {
+		return nil
+	}
+	rec := daemon.NewRuntimeRecord(daemonService, "", daemon.Endpoint{
+		Network: daemon.NetworkTCP,
+		Address: net.JoinHostPort(probeHostForDial(st.Host), strconv.Itoa(st.Port)),
+	})
+	rec.PID = st.PID
+	rec.StartedAt = st.StartedAt
+	rec.Metadata = map[string]string{
+		runtimeHost:        st.Host,
+		runtimePort:        strconv.Itoa(st.Port),
+		runtimeReadOnly:    "false",
+		runtimeAPIVersion:  strconv.Itoa(daemonAPIVersion),
+		runtimeDataVersion: strconv.Itoa(db.CurrentDataVersion()),
+		runtimeCreateTime:  st.CreateTime,
+	}
+	info, err := probeRuntime(context.Background(), rec, authToken,
+		daemon.ProbeOptions{ExpectedService: daemonService, Timeout: 500 * time.Millisecond})
+	if err != nil || info.PID != st.PID {
+		return nil
+	}
+	rt := daemonRuntimeFromRecord(rec)
+	rt.RuntimeFallback = true
+	rt.RuntimeError = st.RuntimeError
+	return rt
 }
 
 func FindIncompatibleDaemonRuntime(

--- a/cmd/agentsview/daemon_runtime_test.go
+++ b/cmd/agentsview/daemon_runtime_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gofrs/flock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/kit/daemon"
 )
@@ -529,6 +530,8 @@ func writeStartupFallbackFixture(
 		Port:         port,
 		RuntimeError: "permission denied writing runtime record",
 		CreateTime:   createTime,
+		APIVersion:   daemonAPIVersion,
+		DataVersion:  db.CurrentDataVersion(),
 		UpdatedAt:    time.Now(),
 	}
 	data, err := json.Marshal(state)
@@ -555,6 +558,211 @@ func TestWritableDaemonFallbackResolver(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(startupStatePath(dir), data, 0o600))
 	assert.Nil(t, FindWritableDaemonRuntime(dir), "stale fallback must fail closed")
+}
+
+func TestFindWritableDaemonRuntime_StartupFallbackSurvivesStartLockProbeError(t *testing.T) {
+	dir := runtimeTestDir(t)
+	host, port := testPingServer(t)
+	createTime, ok := processCreateTimeMillis(os.Getpid())
+	require.True(t, ok)
+	state := startupState{
+		PID:          os.Getpid(),
+		StartedAt:    time.Now().Add(-time.Minute),
+		Phase:        "starting HTTP server",
+		Host:         host,
+		Port:         port,
+		RuntimeError: "permission denied writing runtime record",
+		CreateTime:   strconv.FormatInt(createTime, 10),
+		APIVersion:   daemonAPIVersion,
+		DataVersion:  db.CurrentDataVersion(),
+		UpdatedAt:    time.Now(),
+	}
+	data, err := json.Marshal(state)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(startupStatePath(dir), data, 0o600))
+
+	oldTryLock := startLockTryLock
+	startLockTryLock = func(*flock.Flock) (bool, error) {
+		return false, errors.New("simulated lock probe failure")
+	}
+	t.Cleanup(func() { startLockTryLock = oldTryLock })
+
+	rt := FindWritableDaemonRuntime(dir)
+	require.NotNil(t, rt)
+	assert.True(t, rt.RuntimeFallback)
+	assert.True(t, IsLocalDaemonActive(dir))
+}
+
+func TestLocalWritableDaemonRecordsWithFallbackPreservesReadOnlyRecords(t *testing.T) {
+	dir := runtimeTestDir(t)
+	readOnlyHost, readOnlyPort := testPingServer(t)
+	createTime, ok := processCreateTimeMillis(os.Getpid())
+	require.True(t, ok)
+	writeRuntimeRecordFixture(t, dir, daemon.RuntimeRecord{
+		PID:       os.Getpid(),
+		Service:   daemonService,
+		Version:   "test",
+		Network:   daemon.NetworkTCP,
+		Address:   net.JoinHostPort(readOnlyHost, strconv.Itoa(readOnlyPort)),
+		StartedAt: time.Now(),
+		Metadata: map[string]string{
+			runtimeHost:        readOnlyHost,
+			runtimePort:        strconv.Itoa(readOnlyPort),
+			runtimeReadOnly:    "true",
+			runtimeAPIVersion:  strconv.Itoa(daemonAPIVersion),
+			runtimeDataVersion: strconv.Itoa(db.CurrentDataVersion()),
+			runtimeCreateTime:  strconv.FormatInt(createTime, 10),
+		},
+	})
+	host, port := testPingServer(t)
+	writeStartupFallbackFixture(t, dir, host, port, os.Getpid(), strconv.FormatInt(createTime, 10))
+
+	records, fallback := localWritableDaemonRecordsWithFallback(dir, "")
+	require.True(t, fallback)
+	require.Len(t, records, 2)
+
+	readOnlySeen := false
+	writableSeen := false
+	for _, rec := range records {
+		rt := daemonRuntimeFromRecord(rec)
+		if rt.ReadOnly {
+			readOnlySeen = true
+			assert.Equal(t, readOnlyPort, rt.Port)
+			continue
+		}
+		writableSeen = true
+		assert.Equal(t, port, rt.Port)
+	}
+	assert.True(t, readOnlySeen)
+	assert.True(t, writableSeen)
+}
+
+func TestFindDaemonRuntime_IgnoresIncompatibleStartupStateFallback(t *testing.T) {
+	dir := runtimeTestDir(t)
+	host, port := testPingServer(t)
+	createTime, ok := processCreateTimeMillis(os.Getpid())
+	require.True(t, ok)
+	writeStartupFallbackFixture(
+		t, dir, host, port, os.Getpid(), strconv.FormatInt(createTime, 10),
+	)
+	state := readStartupState(dir)
+	require.NotNil(t, state)
+	state.APIVersion = daemonAPIVersion + 1
+	data, err := json.Marshal(state)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(startupStatePath(dir), data, 0o600))
+
+	assert.Nil(t, FindDaemonRuntime(dir))
+	rt, compatErr := FindIncompatibleDaemonRuntime(dir)
+	require.NotNil(t, rt)
+	require.Error(t, compatErr)
+	assert.Contains(t, compatErr.Error(), "API version")
+	assert.True(t, rt.RuntimeFallback)
+}
+
+func TestWriteDaemonRuntimeFailurePreservesUpdateLaunchArgs(t *testing.T) {
+	dir := runtimeTestDir(t)
+	MarkDaemonStarting(dir)
+	t.Cleanup(func() { UnmarkDaemonStarting(dir) })
+	newStartupStateWriter(dir, time.Now).SetPhase("starting HTTP server")
+	host, port := testPingServer(t)
+	runtimePath, err := runtimeStore(dir).Path(os.Getpid())
+	require.NoError(t, err)
+	require.NoError(t, os.Mkdir(runtimePath, 0o700))
+
+	_, err = WriteDaemonRuntimeWithAuthAndNoSync(
+		dir, host, port, "test", false, true, true,
+	)
+	require.Error(t, err)
+
+	rt := FindWritableDaemonRuntime(dir)
+	require.NotNil(t, rt)
+	assert.Equal(t, "test", rt.Record.Version)
+	state := readStartupState(dir)
+	require.NotNil(t, state)
+	assert.True(t, state.RequireAuthKnown)
+	assert.True(t, state.RequireAuth)
+	assert.True(t, state.NoSyncKnown)
+	assert.True(t, state.NoSync)
+
+	oldStop := stopDaemonRuntimeForUpgrade
+	stopDaemonRuntimeForUpgrade = func(_ config.Config, _ *DaemonRuntime) error { return nil }
+	t.Cleanup(func() { stopDaemonRuntimeForUpgrade = oldStop })
+	result, err := stopWritableDaemonsForUpdate(config.Config{DataDir: dir})
+	require.NoError(t, err)
+	assert.True(t, result.Stopped)
+	args := restartDaemonAfterUpdateArgs(config.Config{}, result)
+	assert.Contains(t, args, "--require-auth")
+	assert.Contains(t, args, "--no-sync")
+}
+
+func TestWriteDaemonRuntimeFailurePreservesManagedCaddyIdentity(t *testing.T) {
+	dir := runtimeTestDir(t)
+	MarkDaemonStarting(dir)
+	t.Cleanup(func() { UnmarkDaemonStarting(dir) })
+	newStartupStateWriter(dir, time.Now).SetPhase("starting HTTP server")
+	host, port := testPingServer(t)
+	runtimePath, err := runtimeStore(dir).Path(os.Getpid())
+	require.NoError(t, err)
+	require.NoError(t, os.Mkdir(runtimePath, 0o700))
+	caddyCreateTime, ok := processCreateTimeMillis(os.Getpid())
+	require.True(t, ok)
+
+	_, err = WriteDaemonRuntimeWithAuthAndNoSync(
+		dir, host, port, "test", false, false, false, os.Getpid(),
+	)
+	require.Error(t, err)
+
+	state := readStartupState(dir)
+	require.NotNil(t, state)
+	assert.Equal(t, os.Getpid(), state.CaddyPID)
+	assert.Equal(t, strconv.FormatInt(caddyCreateTime, 10), state.CaddyCreateTime)
+
+	rt := FindWritableDaemonRuntime(dir)
+	require.NotNil(t, rt)
+	assert.Equal(t, strconv.Itoa(os.Getpid()), rt.Record.Metadata[runtimeCaddyPID])
+	assert.Equal(t, strconv.FormatInt(caddyCreateTime, 10), rt.Record.Metadata[runtimeCaddyCreateTime])
+}
+
+func TestStopWritableDaemonsForUpdateIgnoresStaleWritableRecordBeforeFallback(t *testing.T) {
+	dir := runtimeTestDir(t)
+	staleHost, stalePort := testPingServer(t)
+	createTime, ok := processCreateTimeMillis(os.Getpid())
+	require.True(t, ok)
+	writeRuntimeRecordFixture(t, dir, daemon.RuntimeRecord{
+		PID:       os.Getpid(),
+		Service:   daemonService,
+		Version:   "stale",
+		Network:   daemon.NetworkTCP,
+		Address:   net.JoinHostPort(staleHost, strconv.Itoa(stalePort)),
+		StartedAt: time.Now(),
+		Metadata: map[string]string{
+			runtimeHost:        staleHost,
+			runtimePort:        strconv.Itoa(stalePort),
+			runtimeAPIVersion:  strconv.Itoa(daemonAPIVersion),
+			runtimeDataVersion: strconv.Itoa(db.CurrentDataVersion()),
+			runtimeCreateTime:  "1",
+		},
+	})
+	host, port := testPingServer(t)
+	writeStartupFallbackFixture(
+		t, dir, host, port, os.Getpid(), strconv.FormatInt(createTime, 10),
+	)
+
+	oldStop := stopDaemonRuntimeForUpgrade
+	var stopped *DaemonRuntime
+	stopDaemonRuntimeForUpgrade = func(_ config.Config, rt *DaemonRuntime) error {
+		stopped = rt
+		return nil
+	}
+	t.Cleanup(func() { stopDaemonRuntimeForUpgrade = oldStop })
+
+	result, err := stopWritableDaemonsForUpdate(config.Config{DataDir: dir})
+	require.NoError(t, err)
+	require.NotNil(t, stopped)
+	assert.True(t, result.Stopped)
+	assert.Equal(t, port, stopped.Port)
+	assert.Equal(t, strconv.FormatInt(createTime, 10), stopped.Record.Metadata[runtimeCreateTime])
 }
 
 func newAuthenticatedPingDaemon(t *testing.T, token string) testDaemonEndpoint {

--- a/cmd/agentsview/daemon_runtime_test.go
+++ b/cmd/agentsview/daemon_runtime_test.go
@@ -539,6 +539,54 @@ func writeStartupFallbackFixture(
 	require.NoError(t, os.WriteFile(startupStatePath(dir), data, 0o600))
 }
 
+func failRuntimeRecordListing(t *testing.T) {
+	t.Helper()
+	oldList := listDaemonRuntimeRecords
+	listDaemonRuntimeRecords = func(daemon.RuntimeStore) ([]daemon.RuntimeRecord, error) {
+		return nil, errors.New("store unavailable")
+	}
+	t.Cleanup(func() { listDaemonRuntimeRecords = oldList })
+}
+
+func TestFindDaemonRuntime_UsesStartupFallbackWhenRuntimeStoreInspectionFails(t *testing.T) {
+	dir := runtimeTestDir(t)
+	host, port := testPingServer(t)
+	createTime, ok := processCreateTimeMillis(os.Getpid())
+	require.True(t, ok)
+	writeStartupFallbackFixture(
+		t, dir, host, port, os.Getpid(), strconv.FormatInt(createTime, 10),
+	)
+	failRuntimeRecordListing(t)
+
+	rt := FindDaemonRuntime(dir)
+	require.NotNil(t, rt)
+	assert.True(t, rt.RuntimeFallback)
+	assert.Equal(t, port, rt.Port)
+}
+
+func TestFindIncompatibleDaemonRuntime_UsesStartupFallbackWhenRuntimeStoreInspectionFails(t *testing.T) {
+	dir := runtimeTestDir(t)
+	host, port := testPingServer(t)
+	createTime, ok := processCreateTimeMillis(os.Getpid())
+	require.True(t, ok)
+	writeStartupFallbackFixture(
+		t, dir, host, port, os.Getpid(), strconv.FormatInt(createTime, 10),
+	)
+	state := readStartupState(dir)
+	require.NotNil(t, state)
+	state.APIVersion = daemonAPIVersion + 1
+	data, err := json.Marshal(state)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(startupStatePath(dir), data, 0o600))
+	failRuntimeRecordListing(t)
+
+	rt, compatErr := FindIncompatibleDaemonRuntime(dir)
+	require.NotNil(t, rt)
+	require.Error(t, compatErr)
+	assert.True(t, rt.RuntimeFallback)
+	assert.ErrorContains(t, compatErr, "API version")
+}
+
 func TestWritableDaemonFallbackResolver(t *testing.T) {
 	dir := runtimeTestDir(t)
 	host, port := testPingServer(t)

--- a/cmd/agentsview/daemon_runtime_test.go
+++ b/cmd/agentsview/daemon_runtime_test.go
@@ -515,6 +515,48 @@ func testPingServer(t *testing.T) (host string, port int) {
 	return endpoint.Host, endpoint.Port
 }
 
+func writeStartupFallbackFixture(
+	t *testing.T, dir, host string, port, pid int, createTime string,
+) {
+	t.Helper()
+	MarkDaemonStarting(dir)
+	t.Cleanup(func() { UnmarkDaemonStarting(dir) })
+	state := startupState{
+		PID:          pid,
+		StartedAt:    time.Now().Add(-time.Minute),
+		Phase:        "starting HTTP server",
+		Host:         host,
+		Port:         port,
+		RuntimeError: "permission denied writing runtime record",
+		CreateTime:   createTime,
+		UpdatedAt:    time.Now(),
+	}
+	data, err := json.Marshal(state)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(startupStatePath(dir), data, 0o600))
+}
+
+func TestWritableDaemonFallbackResolver(t *testing.T) {
+	dir := runtimeTestDir(t)
+	host, port := testPingServer(t)
+	createTime, ok := processCreateTimeMillis(os.Getpid())
+	require.True(t, ok)
+	writeStartupFallbackFixture(t, dir, host, port, os.Getpid(), strconv.FormatInt(createTime, 10))
+
+	rt := FindWritableDaemonRuntime(dir)
+	require.NotNil(t, rt)
+	assert.True(t, rt.RuntimeFallback)
+	assert.Equal(t, port, rt.Port)
+
+	state := readStartupState(dir)
+	require.NotNil(t, state)
+	state.CreateTime = "1"
+	data, err := json.Marshal(state)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(startupStatePath(dir), data, 0o600))
+	assert.Nil(t, FindWritableDaemonRuntime(dir), "stale fallback must fail closed")
+}
+
 func newAuthenticatedPingDaemon(t *testing.T, token string) testDaemonEndpoint {
 	t.Helper()
 	ping := daemon.NewPingHandler(daemon.PingHandlerOptions{

--- a/cmd/agentsview/daemon_test.go
+++ b/cmd/agentsview/daemon_test.go
@@ -211,6 +211,31 @@ func TestDaemonStopRegisteredRuntimePreservesStartupGuard(t *testing.T) {
 	assert.Contains(t, err.Error(), "startup is still in progress")
 }
 
+func TestDaemonStartUsesStartupStateFallbackWhileStarting(t *testing.T) {
+	deps, out := daemonCommandTestDeps(t)
+	deps.isStarting = func(string) bool { return true }
+	deps.writableRuntime = func(string, string) *DaemonRuntime {
+		return &DaemonRuntime{
+			Record:          testWritableRecord(79, ""),
+			Host:            "127.0.0.1",
+			Port:            8079,
+			RuntimeFallback: true,
+		}
+	}
+	starts := 0
+	deps.startBackground = func(
+		config.Config, []string, serveReplacementOptions, backgroundLaunchPolicy,
+	) (backgroundLaunchResult, error) {
+		starts++
+		return backgroundLaunchResult{}, nil
+	}
+
+	require.NoError(t, executeDaemonCommand(t, *deps, out, "start"))
+	assert.Zero(t, starts)
+	assert.Contains(t, out.String(), "already running")
+	assert.Contains(t, out.String(), "8079")
+}
+
 func TestDaemonStartPersistentStartupNeverLaunches(t *testing.T) {
 	deps, out := daemonCommandTestDeps(t)
 	deps.isStarting = func(string) bool { return true }
@@ -793,6 +818,43 @@ func TestDaemonRestartFailurePathsSignalNobody(t *testing.T) {
 			assert.Zero(t, signals)
 		})
 	}
+}
+
+func TestDaemonRestartUsesStartupStateFallbackWhileStarting(t *testing.T) {
+	deps, out := daemonCommandTestDeps(t)
+	deps.isStarting = func(string) bool { return true }
+	deps.writableRuntime = func(string, string) *DaemonRuntime {
+		return &DaemonRuntime{
+			Record:          testWritableRecord(113, ""),
+			Host:            "127.0.0.1",
+			Port:            8113,
+			RuntimeFallback: true,
+		}
+	}
+	var stopped daemon.RuntimeRecord
+	deps.stopProcess = func(rec daemon.RuntimeRecord, _ time.Duration) error {
+		stopped = rec
+		return nil
+	}
+	deps.startBackground = func(
+		_ config.Config, args []string, _ serveReplacementOptions,
+		policy backgroundLaunchPolicy,
+	) (backgroundLaunchResult, error) {
+		assert.Equal(t, []string{"serve"}, args)
+		assert.Equal(t, "daemon restart", policy.Operation)
+		return backgroundLaunchResult{
+			Runtime: &DaemonRuntime{
+				Record: daemon.RuntimeRecord{PID: 315},
+				Host:   "127.0.0.1", Port: 8080,
+			},
+			Started: true,
+		}, nil
+	}
+
+	require.NoError(t, executeDaemonCommand(t, *deps, out, "restart"))
+	assert.Equal(t, 113, stopped.PID)
+	assert.Contains(t, out.String(), "restarted")
+	assert.NotContains(t, out.String(), "startup is still in progress")
 }
 
 func TestDaemonRestartInvalidServeConfigDoesNotStopOrStart(t *testing.T) {

--- a/cmd/agentsview/daemon_test.go
+++ b/cmd/agentsview/daemon_test.go
@@ -185,7 +185,7 @@ func TestDaemonStopUsesStartupStateFallbackWhileStarting(t *testing.T) {
 	}
 	var stopped daemon.RuntimeRecord
 	deps.writableRuntime = func(string, string) *DaemonRuntime {
-		return &DaemonRuntime{Record: testWritableRecord(77, "")}
+		return &DaemonRuntime{Record: testWritableRecord(77, ""), RuntimeFallback: true}
 	}
 	deps.stopProcess = func(rec daemon.RuntimeRecord, _ time.Duration) error {
 		stopped = rec
@@ -197,6 +197,18 @@ func TestDaemonStopUsesStartupStateFallbackWhileStarting(t *testing.T) {
 	assert.Equal(t, 77, stopped.PID)
 	assert.Contains(t, out.String(), "Stopped agentsview (pid 77).")
 	assert.NotContains(t, out.String(), "starting up")
+}
+
+func TestDaemonStopRegisteredRuntimePreservesStartupGuard(t *testing.T) {
+	deps, out := daemonCommandTestDeps(t)
+	deps.isStarting = func(string) bool { return true }
+	deps.writableRecords = func(string, string) ([]daemon.RuntimeRecord, error) {
+		return []daemon.RuntimeRecord{testWritableRecord(78, "runtime.json")}, nil
+	}
+
+	err := executeDaemonCommand(t, *deps, out, "stop")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "startup is still in progress")
 }
 
 func TestDaemonStartPersistentStartupNeverLaunches(t *testing.T) {

--- a/cmd/agentsview/daemon_test.go
+++ b/cmd/agentsview/daemon_test.go
@@ -177,6 +177,28 @@ func TestDaemonStartUsesConfigOnlyPolicyAndIsIdempotent(t *testing.T) {
 	assert.Contains(t, out.String(), "pid 41")
 }
 
+func TestDaemonStopUsesStartupStateFallbackWhileStarting(t *testing.T) {
+	deps, out := daemonCommandTestDeps(t)
+	deps.isStarting = func(string) bool { return true }
+	deps.readStartupState = func(string) *startupState {
+		return &startupState{PID: 77, Phase: "starting HTTP server"}
+	}
+	var stopped daemon.RuntimeRecord
+	deps.writableRuntime = func(string, string) *DaemonRuntime {
+		return &DaemonRuntime{Record: testWritableRecord(77, "")}
+	}
+	deps.stopProcess = func(rec daemon.RuntimeRecord, _ time.Duration) error {
+		stopped = rec
+		return nil
+	}
+
+	err := executeDaemonCommand(t, *deps, out, "stop")
+	require.NoError(t, err)
+	assert.Equal(t, 77, stopped.PID)
+	assert.Contains(t, out.String(), "Stopped agentsview (pid 77).")
+	assert.NotContains(t, out.String(), "starting up")
+}
+
 func TestDaemonStartPersistentStartupNeverLaunches(t *testing.T) {
 	deps, out := daemonCommandTestDeps(t)
 	deps.isStarting = func(string) bool { return true }

--- a/cmd/agentsview/daemon_test.go
+++ b/cmd/agentsview/daemon_test.go
@@ -199,6 +199,25 @@ func TestDaemonStopUsesStartupStateFallbackWhileStarting(t *testing.T) {
 	assert.NotContains(t, out.String(), "starting up")
 }
 
+func TestDaemonStopUsesStartupStateFallbackWhenRuntimeStoreInspectionFails(t *testing.T) {
+	deps, out := daemonCommandTestDeps(t)
+	deps.writableRecords = func(string, string) ([]daemon.RuntimeRecord, error) {
+		return nil, errors.New("store unavailable")
+	}
+	deps.writableRuntime = func(string, string) *DaemonRuntime {
+		return &DaemonRuntime{Record: testWritableRecord(76, ""), RuntimeFallback: true}
+	}
+	var stopped daemon.RuntimeRecord
+	deps.stopProcess = func(rec daemon.RuntimeRecord, _ time.Duration) error {
+		stopped = rec
+		return nil
+	}
+
+	require.NoError(t, executeDaemonCommand(t, *deps, out, "stop"))
+	assert.Equal(t, 76, stopped.PID)
+	assert.Contains(t, out.String(), "Stopped agentsview (pid 76).")
+}
+
 func TestDaemonStopRegisteredRuntimePreservesStartupGuard(t *testing.T) {
 	deps, out := daemonCommandTestDeps(t)
 	deps.isStarting = func(string) bool { return true }
@@ -467,6 +486,25 @@ func TestDaemonStatusListsEveryWriterAndSurfacesInspectionErrors(t *testing.T) {
 	err = executeDaemonCommand(t, *deps, out, "status")
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "bad config")
+}
+
+func TestDaemonStatusUsesStartupStateFallbackWhenRuntimeStoreInspectionFails(t *testing.T) {
+	deps, out := daemonCommandTestDeps(t)
+	deps.statusRecords = func(string, string) ([]daemon.RuntimeRecord, error) {
+		return nil, errors.New("store unavailable")
+	}
+	deps.writableRuntime = func(string, string) *DaemonRuntime {
+		return &DaemonRuntime{
+			Record:          testWritableRecord(54, ""),
+			Host:            "127.0.0.1",
+			Port:            8054,
+			RuntimeFallback: true,
+		}
+	}
+
+	require.NoError(t, executeDaemonCommand(t, *deps, out, "status"))
+	assert.Contains(t, out.String(), "pid:     54")
+	assert.Contains(t, out.String(), "runtime record unwritten")
 }
 
 func TestDaemonStatusNotRespondingIsUseful(t *testing.T) {
@@ -855,6 +893,40 @@ func TestDaemonRestartUsesStartupStateFallbackWhileStarting(t *testing.T) {
 	assert.Equal(t, 113, stopped.PID)
 	assert.Contains(t, out.String(), "restarted")
 	assert.NotContains(t, out.String(), "startup is still in progress")
+}
+
+func TestDaemonRestartUsesStartupStateFallbackWhenRuntimeStoreInspectionFails(t *testing.T) {
+	deps, out := daemonCommandTestDeps(t)
+	deps.writableRecords = func(string, string) ([]daemon.RuntimeRecord, error) {
+		return nil, errors.New("store unavailable")
+	}
+	deps.writableRuntime = func(string, string) *DaemonRuntime {
+		return &DaemonRuntime{Record: testWritableRecord(114, ""), RuntimeFallback: true}
+	}
+	var stopped daemon.RuntimeRecord
+	deps.stopProcess = func(rec daemon.RuntimeRecord, _ time.Duration) error {
+		stopped = rec
+		return nil
+	}
+
+	require.NoError(t, executeDaemonCommand(t, *deps, out, "restart"))
+	assert.Equal(t, 114, stopped.PID)
+	assert.Contains(t, out.String(), "restarted")
+}
+
+func TestDaemonMutationsPreserveRuntimeStoreInspectionErrorWithoutFallback(t *testing.T) {
+	for _, command := range []string{"stop", "restart"} {
+		t.Run(command, func(t *testing.T) {
+			deps, out := daemonCommandTestDeps(t)
+			deps.writableRecords = func(string, string) ([]daemon.RuntimeRecord, error) {
+				return nil, errors.New("store unavailable")
+			}
+
+			err := executeDaemonCommand(t, *deps, out, command)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "store unavailable")
+		})
+	}
 }
 
 func TestDaemonRestartInvalidServeConfigDoesNotStopOrStart(t *testing.T) {

--- a/cmd/agentsview/serve_background.go
+++ b/cmd/agentsview/serve_background.go
@@ -622,6 +622,10 @@ func waitForExternalServeStartup(
 		if err := ctx.Err(); err != nil {
 			return nil, true, err
 		}
+		if rt := FindDaemonRuntime(dataDir, authToken); rt != nil &&
+			!rt.ReadOnly && rt.RuntimeFallback {
+			return rt, true, nil
+		}
 		remaining := time.Until(deadline)
 		if remaining <= 0 {
 			return nil, true, errServeStartupInProgress

--- a/cmd/agentsview/serve_background_test.go
+++ b/cmd/agentsview/serve_background_test.go
@@ -1004,6 +1004,22 @@ func TestEnsureBackgroundServeReprobesWhenExternalStartupFinishesBeforeWait(
 	assert.Equal(t, newDaemon.Port, rt.Port)
 }
 
+func TestWaitForBackgroundServeReady_UsesStartupStateFallbackWithoutRuntimeRecord(t *testing.T) {
+	dir := runtimeTestDir(t)
+	host, port := testPingServer(t)
+	createTime, ok := processCreateTimeMillis(os.Getpid())
+	require.True(t, ok)
+	writeStartupFallbackFixture(t, dir, host, port, os.Getpid(), strconv.FormatInt(createTime, 10))
+
+	waitCh := make(chan error)
+	rt, err := waitForBackgroundServeReady(
+		context.Background(), dir, "", waitCh, time.Second,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, rt)
+	assert.Equal(t, port, rt.Port)
+}
+
 func TestEnsureBackgroundServeLaunchLoserReplacesStaleDaemonAfterStartup(
 	t *testing.T,
 ) {

--- a/cmd/agentsview/serve_lifecycle.go
+++ b/cmd/agentsview/serve_lifecycle.go
@@ -168,10 +168,12 @@ func runServeStatus(cfg config.Config) {
 	}
 	if IsDaemonStarting(cfg.DataDir) {
 		fmt.Println("agentsview is starting up.")
-		for _, line := range serveStartingStatusLines(
-			readStartupState(cfg.DataDir), time.Now(),
-		) {
+		st := readStartupState(cfg.DataDir)
+		for _, line := range serveStartingStatusLines(st, time.Now()) {
 			fmt.Println(line)
+		}
+		if st != nil && st.Host != "" && st.Port > 0 && st.RuntimeError != "" {
+			fmt.Println("  stale fallback: endpoint or process identity could not be confirmed")
 		}
 		return
 	}
@@ -207,6 +209,9 @@ func serveStatusLines(rt *DaemonRuntime) []string {
 	}
 	if rt.ReadOnly {
 		lines = append(lines, "  mode:    read-only")
+	}
+	if rt.RuntimeFallback {
+		lines = append(lines, "  runtime record unwritten: "+rt.RuntimeError)
 	}
 	return lines
 }
@@ -269,6 +274,11 @@ func serveIncompatibleDaemonStatusLines(
 // signalling a stale record whose PID belongs to something else.
 func runServeStop(cfg config.Config) {
 	records := liveDaemonRecords(cfg.DataDir)
+	if len(records) == 0 {
+		if rt := FindWritableDaemonRuntime(cfg.DataDir, cfg.AuthToken); rt != nil {
+			records = []daemon.RuntimeRecord{rt.Record}
+		}
+	}
 	if len(records) == 0 {
 		if IsDaemonStarting(cfg.DataDir) {
 			fatal("serve stop: a server is starting; retry once it is ready")

--- a/cmd/agentsview/serve_lifecycle.go
+++ b/cmd/agentsview/serve_lifecycle.go
@@ -273,12 +273,9 @@ func serveIncompatibleDaemonStatusLines(
 // unrelated process). This keeps a hung-but-alive daemon stoppable while never
 // signalling a stale record whose PID belongs to something else.
 func runServeStop(cfg config.Config) {
-	records := liveDaemonRecords(cfg.DataDir)
-	if len(records) == 0 {
-		if rt := FindWritableDaemonRuntime(cfg.DataDir, cfg.AuthToken); rt != nil {
-			records = []daemon.RuntimeRecord{rt.Record}
-		}
-	}
+	records, _ := localWritableDaemonRecordsWithFallback(
+		cfg.DataDir, cfg.AuthToken,
+	)
 	if len(records) == 0 {
 		if IsDaemonStarting(cfg.DataDir) {
 			fatal("serve stop: a server is starting; retry once it is ready")
@@ -333,12 +330,9 @@ func stopDaemonRuntimeForUpgradeImpl(
 func stopWritableDaemonsForUpdate(
 	cfg config.Config,
 ) (updateDaemonStopResult, error) {
-	records := liveDaemonRecords(cfg.DataDir)
-	if len(records) == 0 {
-		if rt := FindWritableDaemonRuntime(cfg.DataDir, cfg.AuthToken); rt != nil {
-			records = []daemon.RuntimeRecord{rt.Record}
-		}
-	}
+	records, _ := localWritableDaemonRecordsWithFallback(
+		cfg.DataDir, cfg.AuthToken,
+	)
 	var result updateDaemonStopResult
 	for _, rec := range records {
 		rt := daemonRuntimeFromRecord(rec)

--- a/cmd/agentsview/serve_lifecycle.go
+++ b/cmd/agentsview/serve_lifecycle.go
@@ -334,6 +334,11 @@ func stopWritableDaemonsForUpdate(
 	cfg config.Config,
 ) (updateDaemonStopResult, error) {
 	records := liveDaemonRecords(cfg.DataDir)
+	if len(records) == 0 {
+		if rt := FindWritableDaemonRuntime(cfg.DataDir, cfg.AuthToken); rt != nil {
+			records = []daemon.RuntimeRecord{rt.Record}
+		}
+	}
 	var result updateDaemonStopResult
 	for _, rec := range records {
 		rt := daemonRuntimeFromRecord(rec)

--- a/cmd/agentsview/serve_lifecycle_test.go
+++ b/cmd/agentsview/serve_lifecycle_test.go
@@ -363,6 +363,30 @@ func TestStopWritableDaemonsForUpdateStopsAllAndRestartsOne(t *testing.T) {
 	assert.ElementsMatch(t, []int{os.Getpid(), secondPID}, stopped)
 }
 
+func TestStopWritableDaemonsForUpdateUsesStartupStateFallback(t *testing.T) {
+	dir := runtimeTestDir(t)
+	host, port := testPingServer(t)
+	createTime, ok := processCreateTimeMillis(os.Getpid())
+	require.True(t, ok)
+	writeStartupFallbackFixture(t, dir, host, port, os.Getpid(), strconv.FormatInt(createTime, 10))
+
+	oldStop := stopDaemonRuntimeForUpgrade
+	var stopped *DaemonRuntime
+	stopDaemonRuntimeForUpgrade = func(_ config.Config, rt *DaemonRuntime) error {
+		stopped = rt
+		return nil
+	}
+	t.Cleanup(func() { stopDaemonRuntimeForUpgrade = oldStop })
+
+	result, err := stopWritableDaemonsForUpdate(config.Config{DataDir: dir})
+	require.NoError(t, err)
+	assert.True(t, result.Stopped)
+	assert.Equal(t, host, result.Host)
+	assert.Equal(t, port, result.Port)
+	require.NotNil(t, stopped)
+	assert.Equal(t, os.Getpid(), stopped.Record.PID)
+}
+
 func TestStopDaemonProcessTerminatesAndCleansRecord(t *testing.T) {
 	requirePOSIXSignals(t, "graceful SIGTERM termination is POSIX-specific")
 	dir := runtimeTestDir(t)

--- a/cmd/agentsview/serve_lifecycle_test.go
+++ b/cmd/agentsview/serve_lifecycle_test.go
@@ -195,6 +195,56 @@ func TestRunServeStatusStartingWithoutStateFallsBack(t *testing.T) {
 	assert.NotContains(t, out, "phase:")
 }
 
+func TestRunServeStatus_StartupStateFallbackWithoutRuntimeRecord(t *testing.T) {
+	dir := runtimeTestDir(t)
+	host, port := testPingServer(t)
+	createTime, ok := processCreateTimeMillis(os.Getpid())
+	require.True(t, ok)
+	writeStartupFallbackFixture(t, dir, host, port, os.Getpid(), strconv.FormatInt(createTime, 10))
+
+	out := captureStdout(t, func() {
+		runServeStatus(config.Config{DataDir: dir})
+	})
+
+	assert.Contains(t, out, "agentsview running at")
+	assert.Contains(t, out, fmt.Sprintf("http://%s:%d", host, port))
+	assert.Contains(t, out, "runtime record unwritten")
+}
+
+func TestRunServeStatus_StartupStateFallbackStaleStateDoesNotClaimRunning(t *testing.T) {
+	dir := runtimeTestDir(t)
+	host, port := testPingServer(t)
+	writeStartupFallbackFixture(t, dir, host, port, os.Getpid(), "1")
+
+	out := captureStdout(t, func() {
+		runServeStatus(config.Config{DataDir: dir})
+	})
+
+	assert.NotContains(t, out, "agentsview running at")
+	assert.Contains(t, out, "agentsview is starting up.")
+	assert.Contains(t, out, "stale fallback")
+}
+
+func TestRunServeStop_StartupStateFallbackWithoutRuntimeRecord(t *testing.T) {
+	dir := runtimeTestDir(t)
+	host, port := testPingServer(t)
+	createTime, ok := processCreateTimeMillis(os.Getpid())
+	require.True(t, ok)
+	writeStartupFallbackFixture(t, dir, host, port, os.Getpid(), strconv.FormatInt(createTime, 10))
+
+	rt := FindWritableDaemonRuntime(dir)
+	require.NotNil(t, rt)
+	assert.True(t, stopTargetConfirmed(rt.Record, ""))
+}
+
+func TestRunServeStop_StartupStateFallbackRequiresIdentity(t *testing.T) {
+	dir := runtimeTestDir(t)
+	host, port := testPingServer(t)
+	writeStartupFallbackFixture(t, dir, host, port, os.Getpid(), "1")
+
+	assert.Nil(t, FindWritableDaemonRuntime(dir), "stale fallback must not authorize stop")
+}
+
 func TestUnmarkDaemonStartingRemovesStartupState(t *testing.T) {
 	dir := runtimeTestDir(t)
 	MarkDaemonStarting(dir)

--- a/cmd/agentsview/startup_state.go
+++ b/cmd/agentsview/startup_state.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"sync"
 	"time"
+
+	"go.kenn.io/agentsview/internal/db"
 )
 
 // startupStateFileName is the data-dir file holding the starting
@@ -23,16 +25,24 @@ const startupStateFileName = "startup-state.json"
 const startupDetailThrottle = time.Second
 
 type startupState struct {
-	PID          int       `json:"pid"`
-	StartedAt    time.Time `json:"started_at"`
-	Phase        string    `json:"phase"`
-	Detail       string    `json:"detail,omitempty"`
-	LogPath      string    `json:"log_path,omitempty"`
-	Host         string    `json:"host,omitempty"`
-	Port         int       `json:"port,omitempty"`
-	RuntimeError string    `json:"runtime_error,omitempty"`
-	CreateTime   string    `json:"create_time,omitempty"`
-	UpdatedAt    time.Time `json:"updated_at"`
+	PID              int       `json:"pid"`
+	StartedAt        time.Time `json:"started_at"`
+	Phase            string    `json:"phase"`
+	Detail           string    `json:"detail,omitempty"`
+	LogPath          string    `json:"log_path,omitempty"`
+	Host             string    `json:"host,omitempty"`
+	Port             int       `json:"port,omitempty"`
+	RuntimeError     string    `json:"runtime_error,omitempty"`
+	CreateTime       string    `json:"create_time,omitempty"`
+	APIVersion       int       `json:"api_version,omitempty"`
+	DataVersion      int       `json:"data_version,omitempty"`
+	CaddyPID         int       `json:"caddy_pid,omitempty"`
+	CaddyCreateTime  string    `json:"caddy_create_time,omitempty"`
+	RequireAuth      bool      `json:"require_auth,omitempty"`
+	RequireAuthKnown bool      `json:"require_auth_known,omitempty"`
+	NoSync           bool      `json:"no_sync,omitempty"`
+	NoSyncKnown      bool      `json:"no_sync_known,omitempty"`
+	UpdatedAt        time.Time `json:"updated_at"`
 }
 
 func startupStatePath(dataDir string) string {
@@ -155,7 +165,7 @@ func readStartupState(dataDir string) *startupState {
 // lifecycle readers can still report startup progress and require a daemon-
 // authored snapshot before trusting this fallback.
 func publishStartupStateFallback(
-	dataDir, host string, port int, runtimeErr error,
+	dataDir, host string, port int, requireAuth, noSync bool, caddyPID int, runtimeErr error,
 ) {
 	st := readStartupState(dataDir)
 	if st == nil || host == "" || port <= 0 || runtimeErr == nil {
@@ -164,6 +174,19 @@ func publishStartupStateFallback(
 	st.Host = host
 	st.Port = port
 	st.RuntimeError = runtimeErr.Error()
+	st.RequireAuth = requireAuth
+	st.RequireAuthKnown = true
+	st.NoSync = noSync
+	st.NoSyncKnown = true
+	st.APIVersion = daemonAPIVersion
+	st.DataVersion = db.CurrentDataVersion()
+	st.CaddyPID = caddyPID
+	st.CaddyCreateTime = ""
+	if caddyPID > 0 {
+		if caddyCreateTime, ok := processCreateTimeMillis(caddyPID); ok {
+			st.CaddyCreateTime = strconv.FormatInt(caddyCreateTime, 10)
+		}
+	}
 	if createTime, ok := processCreateTimeMillis(st.PID); ok {
 		st.CreateTime = strconv.FormatInt(createTime, 10)
 	}

--- a/cmd/agentsview/startup_state.go
+++ b/cmd/agentsview/startup_state.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"time"
 )
@@ -22,12 +23,16 @@ const startupStateFileName = "startup-state.json"
 const startupDetailThrottle = time.Second
 
 type startupState struct {
-	PID       int       `json:"pid"`
-	StartedAt time.Time `json:"started_at"`
-	Phase     string    `json:"phase"`
-	Detail    string    `json:"detail,omitempty"`
-	LogPath   string    `json:"log_path,omitempty"`
-	UpdatedAt time.Time `json:"updated_at"`
+	PID          int       `json:"pid"`
+	StartedAt    time.Time `json:"started_at"`
+	Phase        string    `json:"phase"`
+	Detail       string    `json:"detail,omitempty"`
+	LogPath      string    `json:"log_path,omitempty"`
+	Host         string    `json:"host,omitempty"`
+	Port         int       `json:"port,omitempty"`
+	RuntimeError string    `json:"runtime_error,omitempty"`
+	CreateTime   string    `json:"create_time,omitempty"`
+	UpdatedAt    time.Time `json:"updated_at"`
 }
 
 func startupStatePath(dataDir string) string {
@@ -143,6 +148,37 @@ func readStartupState(dataDir string) *startupState {
 		return nil
 	}
 	return &st
+}
+
+// publishStartupStateFallback records the endpoint after bind when the
+// definitive runtime record cannot be written. Keep the existing snapshot so
+// lifecycle readers can still report startup progress and require a daemon-
+// authored snapshot before trusting this fallback.
+func publishStartupStateFallback(
+	dataDir, host string, port int, runtimeErr error,
+) {
+	st := readStartupState(dataDir)
+	if st == nil || host == "" || port <= 0 || runtimeErr == nil {
+		return
+	}
+	st.Host = host
+	st.Port = port
+	st.RuntimeError = runtimeErr.Error()
+	if createTime, ok := processCreateTimeMillis(st.PID); ok {
+		st.CreateTime = strconv.FormatInt(createTime, 10)
+	}
+	st.UpdatedAt = time.Now()
+	data, err := json.Marshal(st)
+	if err != nil {
+		return
+	}
+	tmp := startupStatePath(dataDir) + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return
+	}
+	if err := os.Rename(tmp, startupStatePath(dataDir)); err != nil {
+		_ = os.Remove(tmp)
+	}
 }
 
 func removeStartupState(dataDir string) {

--- a/cmd/agentsview/transport_test.go
+++ b/cmd/agentsview/transport_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -56,6 +57,19 @@ func writeUnreachableDaemonRuntime(t *testing.T, dir string, readOnly bool) int 
 	ln.Close()
 	writeDaemonRuntimeForTest(t, dir, "127.0.0.1", port, "test", readOnly)
 	return port
+}
+
+func TestDetectTransport_UsesStartupStateFallbackWithoutRuntimeRecord(t *testing.T) {
+	dir := runtimeTestDir(t)
+	host, port := testPingServer(t)
+	createTime, ok := processCreateTimeMillis(os.Getpid())
+	require.True(t, ok)
+	writeStartupFallbackFixture(t, dir, host, port, os.Getpid(), strconv.FormatInt(createTime, 10))
+
+	tr, err := detectTransportContext(context.Background(), dir, "", time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, transportHTTP, tr.Mode)
+	assert.Equal(t, fmt.Sprintf("http://%s:%d", host, port), tr.URL)
 }
 
 // incompatibleRuntimeRecord builds a writable runtime record whose API

--- a/cmd/agentsview/transport_test.go
+++ b/cmd/agentsview/transport_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -65,6 +66,34 @@ func TestDetectTransport_UsesStartupStateFallbackWithoutRuntimeRecord(t *testing
 	createTime, ok := processCreateTimeMillis(os.Getpid())
 	require.True(t, ok)
 	writeStartupFallbackFixture(t, dir, host, port, os.Getpid(), strconv.FormatInt(createTime, 10))
+
+	tr, err := detectTransportContext(context.Background(), dir, "", time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, transportHTTP, tr.Mode)
+	assert.Equal(t, fmt.Sprintf("http://%s:%d", host, port), tr.URL)
+}
+
+func TestDetectTransport_UsesStartupStateFallbackWhileExternalLockRemainsHeld(t *testing.T) {
+	dir := runtimeTestDir(t)
+	holdExternalStartupLockForTest(t, dir)
+	host, port := testPingServer(t)
+	createTime, ok := processCreateTimeMillis(os.Getpid())
+	require.True(t, ok)
+	state := startupState{
+		PID:          os.Getpid(),
+		StartedAt:    time.Now().Add(-time.Minute),
+		Phase:        "starting HTTP server",
+		Host:         host,
+		Port:         port,
+		RuntimeError: "permission denied writing runtime record",
+		CreateTime:   strconv.FormatInt(createTime, 10),
+		APIVersion:   daemonAPIVersion,
+		DataVersion:  db.CurrentDataVersion(),
+		UpdatedAt:    time.Now(),
+	}
+	data, err := json.Marshal(state)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(startupStatePath(dir), data, 0o600))
 
 	tr, err := detectTransportContext(context.Background(), dir, "", time.Second)
 	require.NoError(t, err)

--- a/cmd/agentsview/transport_test.go
+++ b/cmd/agentsview/transport_test.go
@@ -72,6 +72,25 @@ func TestDetectTransport_UsesStartupStateFallbackWithoutRuntimeRecord(t *testing
 	assert.Equal(t, fmt.Sprintf("http://%s:%d", host, port), tr.URL)
 }
 
+func TestEnsureTransport_SameVersionFallbackDoesNotAutostart(t *testing.T) {
+	dir := runtimeTestDir(t)
+	host, port := testPingServer(t)
+	createTime, ok := processCreateTimeMillis(os.Getpid())
+	require.True(t, ok)
+	writeStartupFallbackFixture(t, dir, host, port, os.Getpid(), strconv.FormatInt(createTime, 10))
+	setTestVersion(t, "test")
+	forbidStartBackgroundServeForTransport(t,
+		"same-version fallback daemon must not trigger autostart")
+
+	cfg := config.Config{DataDir: dir}
+	tr, err := ensureTransport(&cfg, transportIntentRead, time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, transportHTTP, tr.Mode)
+	assert.Equal(t, fmt.Sprintf("http://%s:%d", host, port), tr.URL)
+	require.NotNil(t, tr.Runtime)
+	assert.Equal(t, "test", tr.Runtime.Record.Version)
+}
+
 // incompatibleRuntimeRecord builds a writable runtime record whose API
 // version metadata is "0", which the compatibility check rejects. It
 // models a daemon from an older release that still owns the archive.


### PR DESCRIPTION
Kit v0.7.1 and agentsview #1107 resolve the Administrator-owned-directory trigger from #1097 through the normal runtime-record path. This PR covers a separate failure mode: a writable daemon has already acquired the trusted startup-state lock and bound successfully, but publishing its runtime record then fails.

The daemon now records its bound endpoint, process identity, compatibility versions, launch options, and managed-Caddy identity in startup state when that post-lock write fails. Runtime records remain authoritative when present; otherwise discovery accepts the fallback only while the lock is held and the live ping matches the recorded process. If runtime-store enumeration itself fails, discovery and lifecycle commands use the same confirmed fallback; without one, they preserve the original inspection error. Stale state, incompatible daemons, and read-only servers continue to fail closed.

Status and transport discovery can use the recovered endpoint, while stop, restart, and upgrade paths can safely target the confirmed recordless writer. This preserves the existing policy of keeping an already-bound server alive after runtime-record publication fails instead of leaving that server running but undiscoverable.

Refs #1097