### PR TITLE
fix: import current Grok Build sessions with full transcripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,12 +357,12 @@ thread JSON files.
 | Zed                   | `~/Library/Application Support/Zed/` (macOS)                                                                                                                            |
 | Zencoder              | `~/.zencoder/sessions/`                                                                                                                                                 |
 
-Grok support is summary-only: AgentsView reads the summary,
-searchable first prompt, timestamps, project label, and message count from
-`summary.json`, plus total output tokens and peak context tokens from
-`signals.json` when present. It does not decode the full transcript from
-`updates.jsonl` or `chat_history.jsonl`. Set `GROK_DIR` or `grok_dirs` to
-override the default directory.
+Grok sessions are read from `summary.json` (title, timestamps, project),
+optional `signals.json` (token counters), and `chat_history.jsonl` when
+present for the full transcript (user turns, assistant replies, thinking,
+and tool calls). If `chat_history.jsonl` is missing, AgentsView falls back
+to summary-only mode. Set `GROK_DIR` or `grok_dirs` to override the default
+directory.
 
 Each directory can be overridden with an environment variable. See the
 [configuration docs](https://agentsview.io/configuration/) for details. Cursor

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -239,7 +239,7 @@ can still be parsed.
 | Forge                 | `~/.forge/`                                                                      | SQLite database (`.forge.db`)                                                                                                   |
 | Gemini CLI            | `~/.gemini/`                                                                     | JSONL in `tmp/` subdirectory                                                                                                    |
 | gptme                 | `~/.local/share/gptme/logs/`                                                     | JSONL logs                                                                                                                      |
-| Grok                  | `~/.grok/sessions/`                                                              | `summary.json` metadata plus optional `signals.json` token counters                                                             |
+| Grok                  | `~/.grok/sessions/`                                                              | `summary.json` + optional `signals.json` + `chat_history.jsonl` transcript when present                                         |
 | Hermes Agent          | `~/.hermes/sessions/`                                                            | JSONL / JSON per session                                                                                                        |
 | iFlow                 | `~/.iflow/projects/`                                                             | JSONL per session                                                                                                               |
 | Kilo                  | `~/.local/share/kilo/`                                                           | SQLite DB or `storage/` JSON files                                                                                              |
@@ -271,11 +271,11 @@ can still be parsed.
 | Zed                   | (platform-specific, see below)                                                   | SQLite database (`threads/threads.db`)                                                                                          |
 | Zencoder              | `~/.zencoder/sessions/`                                                          | JSONL per session                                                                                                               |
 
-Grok support is summary-only: AgentsView reads the summary, searchable first
-prompt, timestamps, project label, and message count from `summary.json`, plus
-total output tokens and peak context tokens from `signals.json` when present.
-It does not decode the full transcript from `updates.jsonl` or
-`chat_history.jsonl`. Set `GROK_DIR` or `grok_dirs` to override the default
+Grok sessions are read from `summary.json` (title, timestamps, project),
+optional `signals.json` (token counters), and `chat_history.jsonl` when
+present for the full transcript (user turns, assistant replies, thinking,
+and tool calls). If `chat_history.jsonl` is missing, AgentsView falls back
+to summary-only mode. Set `GROK_DIR` or `grok_dirs` to override the default
 directory.
 
 **VS Code Copilot default directories** vary by platform:

--- a/internal/parser/grok.go
+++ b/internal/parser/grok.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,21 +12,26 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-type grokSummary struct {
-	Summary       string `json:"summary"`
-	FirstPrompt   string `json:"firstPrompt"`
-	ModelID       string `json:"modelId"`
-	CreatedAt     string `json:"createdAt"`
-	UpdatedAt     string `json:"updatedAt"`
-	LastActiveAt  string `json:"lastActiveAt"`
-	Hostname      string `json:"hostname"`
-	NumMessages   int    `json:"numMessages"`
-	WorktreeLabel string `json:"worktreeLabel"`
+type grokSummaryFields struct {
+	Summary       string
+	FirstPrompt   string
+	ModelID       string
+	CreatedAt     string
+	UpdatedAt     string
+	LastActiveAt  string
+	Hostname      string
+	NumMessages   int
+	WorktreeLabel string
+	GitRootDir    string
+	Cwd           string
+	HeadBranch    string
 }
 
 type grokSignalMetrics struct {
 	TotalOutputTokens int
 	PeakContextTokens int
+	UserMessageCount  int
+	HasUserMessages   bool
 }
 
 func ParseGrokSummary(
@@ -39,49 +45,97 @@ func ParseGrokSummary(
 	if err != nil {
 		return ParseResult{}, fmt.Errorf("read %s: %w", path, err)
 	}
-	var summary grokSummary
-	if err := json.Unmarshal(data, &summary); err != nil {
-		return ParseResult{}, fmt.Errorf("decode %s: %w", path, err)
+	if !gjson.ValidBytes(data) {
+		return ParseResult{}, fmt.Errorf("decode %s: invalid json", path)
 	}
 
+	summary := decodeGrokSummary(data)
 	rawID := filepath.Base(filepath.Dir(path))
 	if !IsValidSessionID(rawID) {
 		return ParseResult{}, fmt.Errorf("invalid grok session id for %s", path)
 	}
-	signals, err := parseGrokSignals(filepath.Join(filepath.Dir(path), "signals.json"))
+	sessionDir := filepath.Dir(path)
+	signals, err := parseGrokSignals(filepath.Join(sessionDir, "signals.json"))
 	if err != nil {
 		return ParseResult{}, err
 	}
 
-	project := firstNonEmptyJSONLString(
-		strings.TrimSpace(summary.WorktreeLabel),
-		strings.TrimSpace(projectHint),
-	)
+	project, cwd := grokProjectAndCwd(summary, projectHint)
 	startedAt := grokParseTime(summary.CreatedAt)
 	endedAt := grokEndedAt(summary)
-	firstPrompt := strings.TrimSpace(summary.FirstPrompt)
+
+	messages, malformed, transcriptErr := parseGrokChatHistory(
+		filepath.Join(sessionDir, "chat_history.jsonl"),
+	)
+	if transcriptErr != nil && !os.IsNotExist(transcriptErr) {
+		return ParseResult{}, transcriptErr
+	}
+
+	firstPrompt := ""
+	for _, msg := range messages {
+		if msg.Role == RoleUser && strings.TrimSpace(msg.Content) != "" {
+			firstPrompt = strings.TrimSpace(msg.Content)
+			break
+		}
+	}
+	if firstPrompt == "" {
+		firstPrompt = strings.TrimSpace(summary.FirstPrompt)
+	}
+	// Current Grok Build stores the searchable prompt text in
+	// session_summary / generated_title rather than firstPrompt.
+	if firstPrompt == "" {
+		firstPrompt = strings.TrimSpace(summary.Summary)
+	}
+
 	userMessageCount := 0
-	if firstPrompt != "" {
-		userMessageCount = 1
+	messageCount := 0
+	countsAuthoritative := false
+	transcriptFidelity := TranscriptFidelityFull
+	sourceVersion := "grok-chat-v1"
+
+	if len(messages) > 0 {
+		for _, msg := range messages {
+			messageCount++
+			// Tool-result carrier rows are RoleUser with empty content so the
+			// sync engine can pair them onto tool calls and then drop them.
+			if msg.Role == RoleUser && !msg.IsSystem &&
+				strings.TrimSpace(msg.Content) != "" {
+				userMessageCount++
+			}
+		}
+	} else {
+		// Fall back to summary-only when chat_history is missing/empty.
+		transcriptFidelity = TranscriptFidelitySummary
+		sourceVersion = "grok-summary-v1"
+		countsAuthoritative = true
+		switch {
+		case signals.HasUserMessages:
+			userMessageCount = signals.UserMessageCount
+		case firstPrompt != "":
+			userMessageCount = 1
+		}
+		messageCount = max(summary.NumMessages, userMessageCount)
+		if firstPrompt != "" {
+			messages = []ParsedMessage{{
+				Role:      RoleUser,
+				Content:   firstPrompt,
+				Timestamp: startedAt,
+			}}
+		}
 	}
-	messageCount := max(summary.NumMessages, userMessageCount)
-	var messages []ParsedMessage
-	if firstPrompt != "" {
-		messages = []ParsedMessage{{
-			Role:      "user",
-			Content:   firstPrompt,
-			Timestamp: startedAt,
-		}}
-	}
+
 	result := ParseResult{
 		Session: ParsedSession{
 			ID:                 "grok:" + rawID,
 			Project:            project,
 			Machine:            machine,
 			Agent:              AgentGrok,
+			Cwd:                cwd,
+			GitBranch:          summary.HeadBranch,
 			SourceSessionID:    rawID,
-			SourceVersion:      "grok-summary-v1",
-			TranscriptFidelity: "summary",
+			SourceVersion:      sourceVersion,
+			TranscriptFidelity: transcriptFidelity,
+			MalformedLines:     malformed,
 			FirstMessage: truncate(
 				strings.ReplaceAll(firstPrompt, "\n", " "),
 				300,
@@ -91,7 +145,7 @@ func ParseGrokSummary(
 			EndedAt:             endedAt,
 			MessageCount:        messageCount,
 			UserMessageCount:    userMessageCount,
-			CountsAuthoritative: true,
+			CountsAuthoritative: countsAuthoritative,
 			File: FileInfo{
 				Path:  path,
 				Size:  info.Size(),
@@ -114,6 +168,353 @@ func ParseGrokSummary(
 	return result, nil
 }
 
+func parseGrokChatHistory(path string) ([]ParsedMessage, int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer f.Close()
+
+	lr := newLineReader(f, maxLineSize)
+	defer releaseLineReader(lr)
+
+	var (
+		messages     []ParsedMessage
+		malformed    int
+		pendingThink string
+		hasPending   bool
+		ordinal      int
+	)
+
+	flushThinking := func() {
+		if !hasPending {
+			return
+		}
+		messages = append(messages, ParsedMessage{
+			Ordinal:       ordinal,
+			Role:          RoleAssistant,
+			Content:       "[Thinking]\n" + pendingThink + "\n[/Thinking]",
+			ThinkingText:  pendingThink,
+			HasThinking:   true,
+			ContentLength: len(pendingThink),
+		})
+		ordinal++
+		pendingThink = ""
+		hasPending = false
+	}
+
+	for {
+		line, ok := lr.next()
+		if !ok {
+			break
+		}
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if !gjson.Valid(line) {
+			malformed++
+			continue
+		}
+		root := gjson.Parse(line)
+		switch root.Get("type").Str {
+		case "system":
+			// System prompts are vendor boilerplate; skip them.
+			continue
+
+		case "user":
+			flushThinking()
+			content := grokUserContent(root.Get("content"))
+			if content == "" {
+				// Meta-only injections (user_info / system-reminder /
+				// skills catalog) are not real user turns.
+				continue
+			}
+			messages = append(messages, ParsedMessage{
+				Ordinal:       ordinal,
+				Role:          RoleUser,
+				Content:       content,
+				ContentLength: len(content),
+			})
+			ordinal++
+
+		case "reasoning":
+			text := grokReasoningText(root)
+			if text == "" {
+				continue
+			}
+			if hasPending {
+				pendingThink += "\n\n" + text
+			} else {
+				pendingThink = text
+				hasPending = true
+			}
+
+		case "assistant":
+			content := strings.TrimSpace(root.Get("content").Str)
+			toolCalls := grokToolCalls(root.Get("tool_calls"))
+			if content == "" && len(toolCalls) == 0 && !hasPending {
+				continue
+			}
+			msg := ParsedMessage{
+				Ordinal:       ordinal,
+				Role:          RoleAssistant,
+				Content:       content,
+				ContentLength: len(content),
+				Model:         strings.TrimSpace(root.Get("model_id").Str),
+				ToolCalls:     toolCalls,
+				HasToolUse:    len(toolCalls) > 0,
+			}
+			if hasPending {
+				msg.HasThinking = true
+				msg.ThinkingText = pendingThink
+				msg.Content = "[Thinking]\n" + pendingThink + "\n[/Thinking]\n" + content
+				msg.ContentLength = len(pendingThink) + len(content)
+				pendingThink = ""
+				hasPending = false
+			}
+			messages = append(messages, msg)
+			ordinal++
+
+		case "tool_result":
+			flushThinking()
+			toolCallID := strings.TrimSpace(root.Get("tool_call_id").Str)
+			if toolCallID == "" {
+				continue
+			}
+			content := root.Get("content")
+			contentRaw := content.Raw
+			contentLen := toolResultContentLength(content)
+			if content.Type == gjson.String {
+				// Preserve tool output as JSON-quoted string so
+				// pairToolResults / DecodeContent can surface it.
+				quoted, _ := json.Marshal(content.Str)
+				contentRaw = string(quoted)
+				contentLen = len(content.Str)
+			}
+			messages = append(messages, ParsedMessage{
+				Ordinal:       ordinal,
+				Role:          RoleUser,
+				ContentLength: contentLen,
+				ToolResults: []ParsedToolResult{{
+					ToolUseID:     toolCallID,
+					ContentRaw:    contentRaw,
+					ContentLength: contentLen,
+				}},
+			})
+			ordinal++
+
+		default:
+			// Unknown entry types are ignored but not treated as malformed.
+			continue
+		}
+	}
+	if err := lr.Err(); err != nil {
+		return nil, malformed, fmt.Errorf("reading %s: %w", path, err)
+	}
+	flushThinking()
+	return messages, malformed, nil
+}
+
+func grokUserContent(content gjson.Result) string {
+	var text string
+	switch {
+	case content.Type == gjson.String:
+		text = content.Str
+	case content.IsArray():
+		var parts []string
+		content.ForEach(func(_, part gjson.Result) bool {
+			if part.Get("type").Str == "text" {
+				if t := part.Get("text").Str; t != "" {
+					parts = append(parts, t)
+				}
+			}
+			return true
+		})
+		text = strings.Join(parts, "\n")
+	default:
+		return ""
+	}
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return ""
+	}
+	// Prefer the explicit user query when Grok wraps prompts.
+	if extracted := extractUserQuery(strings.Split(text, "\n")); extracted != text {
+		return extracted
+	}
+	if strings.Contains(text, "<user_query>") {
+		return extractUserQuery(strings.Split(text, "\n"))
+	}
+	// Drop pure context injections that never contain a user query.
+	if grokIsMetaUserContent(text) {
+		return ""
+	}
+	return text
+}
+
+func grokIsMetaUserContent(text string) bool {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return true
+	}
+	metaMarkers := []string{
+		"<user_info>",
+		"<git_status>",
+		"<system-reminder>",
+		"<agent_skills>",
+		"<mcp_servers>",
+	}
+	for _, marker := range metaMarkers {
+		if strings.Contains(trimmed, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func grokReasoningText(root gjson.Result) string {
+	summary := root.Get("summary")
+	if summary.IsArray() {
+		var parts []string
+		summary.ForEach(func(_, part gjson.Result) bool {
+			if part.Get("type").Str == "summary_text" {
+				if t := strings.TrimSpace(part.Get("text").Str); t != "" {
+					parts = append(parts, t)
+				}
+			}
+			return true
+		})
+		return strings.Join(parts, "\n\n")
+	}
+	return strings.TrimSpace(root.Get("content").Str)
+}
+
+func grokToolCalls(arr gjson.Result) []ParsedToolCall {
+	if !arr.IsArray() {
+		return nil
+	}
+	var out []ParsedToolCall
+	arr.ForEach(func(_, tc gjson.Result) bool {
+		name := firstNonEmptyJSONLString(
+			tc.Get("name").Str,
+			tc.Get("function.name").Str,
+		)
+		if name == "" {
+			return true
+		}
+		inputJSON := firstNonEmptyJSONLString(
+			tc.Get("arguments").Raw,
+			tc.Get("arguments").Str,
+			tc.Get("function.arguments").Raw,
+			tc.Get("function.arguments").Str,
+			tc.Get("input").Raw,
+		)
+		// arguments may already be a JSON string value; normalize to object JSON.
+		if args := tc.Get("arguments"); args.Type == gjson.String && gjson.Valid(args.Str) {
+			inputJSON = args.Str
+		}
+		out = append(out, ParsedToolCall{
+			ToolUseID: firstNonEmptyJSONLString(tc.Get("id").Str, tc.Get("tool_call_id").Str),
+			ToolName:  name,
+			Category:  NormalizeToolCategory(name),
+			InputJSON: inputJSON,
+			SkillName: inferToolSkillName(name, inputJSON),
+		})
+		return true
+	})
+	return out
+}
+
+func decodeGrokSummary(data []byte) grokSummaryFields {
+	root := gjson.ParseBytes(data)
+	return grokSummaryFields{
+		Summary: firstNonEmptyJSONLString(
+			strings.TrimSpace(root.Get("session_summary").String()),
+			strings.TrimSpace(root.Get("generated_title").String()),
+			strings.TrimSpace(root.Get("summary").String()),
+		),
+		FirstPrompt: firstNonEmptyJSONLString(
+			strings.TrimSpace(root.Get("firstPrompt").String()),
+			strings.TrimSpace(root.Get("first_prompt").String()),
+		),
+		ModelID: firstNonEmptyJSONLString(
+			strings.TrimSpace(root.Get("current_model_id").String()),
+			strings.TrimSpace(root.Get("modelId").String()),
+			strings.TrimSpace(root.Get("model_id").String()),
+		),
+		CreatedAt: firstNonEmptyJSONLString(
+			strings.TrimSpace(root.Get("created_at").String()),
+			strings.TrimSpace(root.Get("createdAt").String()),
+		),
+		UpdatedAt: firstNonEmptyJSONLString(
+			strings.TrimSpace(root.Get("updated_at").String()),
+			strings.TrimSpace(root.Get("updatedAt").String()),
+		),
+		LastActiveAt: firstNonEmptyJSONLString(
+			strings.TrimSpace(root.Get("last_active_at").String()),
+			strings.TrimSpace(root.Get("lastActiveAt").String()),
+		),
+		Hostname: strings.TrimSpace(root.Get("hostname").String()),
+		NumMessages: max(
+			int(root.Get("num_messages").Int()),
+			int(root.Get("numMessages").Int()),
+			int(root.Get("num_chat_messages").Int()),
+		),
+		WorktreeLabel: firstNonEmptyJSONLString(
+			strings.TrimSpace(root.Get("worktreeLabel").String()),
+			strings.TrimSpace(root.Get("worktree_label").String()),
+		),
+		GitRootDir: firstNonEmptyJSONLString(
+			strings.TrimSpace(root.Get("git_root_dir").String()),
+			strings.TrimSpace(root.Get("gitRootDir").String()),
+		),
+		Cwd: firstNonEmptyJSONLString(
+			strings.TrimSpace(root.Get("info.cwd").String()),
+			strings.TrimSpace(root.Get("cwd").String()),
+		),
+		HeadBranch: firstNonEmptyJSONLString(
+			strings.TrimSpace(root.Get("head_branch").String()),
+			strings.TrimSpace(root.Get("headBranch").String()),
+			strings.TrimSpace(root.Get("git.branch").String()),
+		),
+	}
+}
+
+func grokProjectAndCwd(
+	summary grokSummaryFields, projectHint string,
+) (project, cwd string) {
+	cwd = firstNonEmptyJSONLString(
+		strings.TrimSpace(summary.Cwd),
+		strings.TrimSpace(summary.GitRootDir),
+	)
+	if cwd != "" {
+		if p := ExtractProjectFromCwdWithBranch(cwd, summary.HeadBranch); p != "" {
+			return p, cwd
+		}
+	}
+
+	// Prefer the vendor-provided worktree label when present (legacy
+	// camelCase summary schema). Fall back to the path-derived hint.
+	if label := strings.TrimSpace(summary.WorktreeLabel); label != "" {
+		return label, cwd
+	}
+
+	hint := strings.TrimSpace(projectHint)
+	if decoded, err := url.PathUnescape(hint); err == nil && decoded != "" {
+		hint = decoded
+	}
+	if hint != "" {
+		if p := ExtractProjectFromCwdWithBranch(hint, summary.HeadBranch); p != "" {
+			return p, cwd
+		}
+		if p := GetProjectName(hint); p != "" {
+			return p, cwd
+		}
+	}
+	return "", cwd
+}
+
 func parseGrokSignals(path string) (grokSignalMetrics, error) {
 	data, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
@@ -125,12 +526,14 @@ func parseGrokSignals(path string) (grokSignalMetrics, error) {
 	if !gjson.ValidBytes(data) {
 		return grokSignalMetrics{}, fmt.Errorf("decode %s: invalid json", path)
 	}
-	return grokSignalMetrics{
+	root := gjson.ParseBytes(data)
+	metrics := grokSignalMetrics{
 		TotalOutputTokens: grokFirstPositiveInt(
 			data,
 			"tokenUsage.totalOutputTokens",
 			"usage.totalOutputTokens",
 			"outputTokens",
+			"totalOutputTokens",
 		),
 		PeakContextTokens: grokFirstPositiveInt(
 			data,
@@ -138,8 +541,16 @@ func parseGrokSignals(path string) (grokSignalMetrics, error) {
 			"usage.peakContextTokens",
 			"peakContextTokens",
 			"contextTokens",
+			"contextTokensUsed",
 		),
-	}, nil
+	}
+	if userCount := root.Get("userMessageCount"); userCount.Exists() {
+		metrics.HasUserMessages = true
+		if n := int(userCount.Int()); n > 0 {
+			metrics.UserMessageCount = n
+		}
+	}
+	return metrics, nil
 }
 
 func grokFirstPositiveInt(data []byte, paths ...string) int {
@@ -167,7 +578,7 @@ func grokParseTime(value string) time.Time {
 	return ts
 }
 
-func grokEndedAt(summary grokSummary) time.Time {
+func grokEndedAt(summary grokSummaryFields) time.Time {
 	for _, value := range []string{
 		summary.LastActiveAt,
 		summary.UpdatedAt,

--- a/internal/parser/grok.go
+++ b/internal/parser/grok.go
@@ -451,6 +451,23 @@ func grokToolCallInputJSON(tc gjson.Result) string {
 	return ""
 }
 
+// grokSummaryMessageCount prefers the chat-transcript count over the broader
+// event counter. Current Grok Build stores both: num_chat_messages is the
+// transcript-shaped total AgentsView should surface, while num_messages also
+// includes non-chat events and would inflate summary-only sessions.
+func grokSummaryMessageCount(root gjson.Result) int {
+	for _, path := range []string{
+		"num_chat_messages",
+		"num_messages",
+		"numMessages",
+	} {
+		if v := root.Get(path); v.Exists() {
+			return int(v.Int())
+		}
+	}
+	return 0
+}
+
 func decodeGrokSummary(data []byte) grokSummaryFields {
 	root := gjson.ParseBytes(data)
 	return grokSummaryFields{
@@ -480,12 +497,8 @@ func decodeGrokSummary(data []byte) grokSummaryFields {
 			strings.TrimSpace(root.Get("last_active_at").String()),
 			strings.TrimSpace(root.Get("lastActiveAt").String()),
 		),
-		Hostname: strings.TrimSpace(root.Get("hostname").String()),
-		NumMessages: max(
-			int(root.Get("num_messages").Int()),
-			int(root.Get("numMessages").Int()),
-			int(root.Get("num_chat_messages").Int()),
-		),
+		Hostname:    strings.TrimSpace(root.Get("hostname").String()),
+		NumMessages: grokSummaryMessageCount(root),
 		WorktreeLabel: firstNonEmptyJSONLString(
 			strings.TrimSpace(root.Get("worktreeLabel").String()),
 			strings.TrimSpace(root.Get("worktree_label").String()),

--- a/internal/parser/grok.go
+++ b/internal/parser/grok.go
@@ -346,31 +346,46 @@ func grokUserContent(content gjson.Result) string {
 	if strings.Contains(text, "<user_query>") {
 		return extractUserQuery(strings.Split(text, "\n"))
 	}
-	// Drop pure context injections that never contain a user query.
-	if grokIsMetaUserContent(text) {
-		return ""
-	}
-	return text
+	// Strip injected context blocks; keep any remaining real prompt text.
+	// Meta-only payloads collapse to empty and are skipped by the caller.
+	return grokStripMetaUserBlocks(text)
 }
 
-func grokIsMetaUserContent(text string) bool {
-	trimmed := strings.TrimSpace(text)
-	if trimmed == "" {
-		return true
+// grokStripMetaUserBlocks removes recognized Grok context-injection blocks
+// (user_info, git_status, system-reminder, agent_skills, mcp_servers) while
+// preserving any surrounding user text. Mixed payloads therefore keep the
+// real prompt instead of being discarded wholesale.
+func grokStripMetaUserBlocks(text string) string {
+	for _, tag := range []string{
+		"user_info",
+		"git_status",
+		"system-reminder",
+		"agent_skills",
+		"mcp_servers",
+	} {
+		text = grokStripXMLTagBlock(text, tag)
 	}
-	metaMarkers := []string{
-		"<user_info>",
-		"<git_status>",
-		"<system-reminder>",
-		"<agent_skills>",
-		"<mcp_servers>",
-	}
-	for _, marker := range metaMarkers {
-		if strings.Contains(trimmed, marker) {
-			return true
+	return strings.TrimSpace(text)
+}
+
+// grokStripXMLTagBlock removes every <tag>...</tag> span from text. An
+// unclosed opening tag drops the remainder of the string from that point.
+func grokStripXMLTagBlock(text, tag string) string {
+	open := "<" + tag + ">"
+	close := "</" + tag + ">"
+	for {
+		start := strings.Index(text, open)
+		if start < 0 {
+			return text
 		}
+		rest := text[start+len(open):]
+		endRel := strings.Index(rest, close)
+		if endRel < 0 {
+			return strings.TrimSpace(text[:start])
+		}
+		end := start + len(open) + endRel + len(close)
+		text = text[:start] + text[end:]
 	}
-	return false
 }
 
 func grokReasoningText(root gjson.Result) string {
@@ -403,17 +418,7 @@ func grokToolCalls(arr gjson.Result) []ParsedToolCall {
 		if name == "" {
 			return true
 		}
-		inputJSON := firstNonEmptyJSONLString(
-			tc.Get("arguments").Raw,
-			tc.Get("arguments").Str,
-			tc.Get("function.arguments").Raw,
-			tc.Get("function.arguments").Str,
-			tc.Get("input").Raw,
-		)
-		// arguments may already be a JSON string value; normalize to object JSON.
-		if args := tc.Get("arguments"); args.Type == gjson.String && gjson.Valid(args.Str) {
-			inputJSON = args.Str
-		}
+		inputJSON := grokToolCallInputJSON(tc)
 		out = append(out, ParsedToolCall{
 			ToolUseID: firstNonEmptyJSONLString(tc.Get("id").Str, tc.Get("tool_call_id").Str),
 			ToolName:  name,
@@ -424,6 +429,26 @@ func grokToolCalls(arr gjson.Result) []ParsedToolCall {
 		return true
 	})
 	return out
+}
+
+// grokToolCallInputJSON picks the first present arguments field and normalizes
+// JSON-encoded string values (OpenAI-style function.arguments) to the raw
+// object JSON so path extraction and skill inference can read them.
+func grokToolCallInputJSON(tc gjson.Result) string {
+	for _, path := range []string{"arguments", "function.arguments", "input"} {
+		args := tc.Get(path)
+		if !args.Exists() {
+			continue
+		}
+		if args.Type == gjson.String {
+			// Unwrap JSON-encoded strings (OpenAI-style); plain text stays as-is.
+			return args.Str
+		}
+		if raw := args.Raw; raw != "" && raw != "null" {
+			return raw
+		}
+	}
+	return ""
 }
 
 func decodeGrokSummary(data []byte) grokSummaryFields {

--- a/internal/parser/grok_provider.go
+++ b/internal/parser/grok_provider.go
@@ -65,7 +65,7 @@ func grokWatchRoots(roots []string) []WatchRoot {
 		out = append(out, WatchRoot{
 			Path:         root,
 			Recursive:    true,
-			IncludeGlobs: []string{"summary.json", "signals.json"},
+			IncludeGlobs: []string{"summary.json", "signals.json", "chat_history.jsonl"},
 			DebounceKey:  string(AgentGrok) + ":sessions:" + root,
 		})
 	}
@@ -140,7 +140,7 @@ func grokStrictMatch(root, path string) (singleFileMatch, bool) {
 
 func grokTrackedFileName(name string) bool {
 	switch name {
-	case "summary.json", "signals.json":
+	case "summary.json", "signals.json", "chat_history.jsonl":
 		return true
 	default:
 		return false
@@ -200,7 +200,8 @@ func grokFingerprintSource(src singleFileSource) (SourceFingerprint, error) {
 func grokCompanionFiles(summaryPath string) map[string]string {
 	dir := filepath.Dir(summaryPath)
 	return map[string]string{
-		"signals": filepath.Join(dir, "signals.json"),
+		"signals":      filepath.Join(dir, "signals.json"),
+		"chat_history": filepath.Join(dir, "chat_history.jsonl"),
 	}
 }
 

--- a/internal/parser/grok_test.go
+++ b/internal/parser/grok_test.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -197,6 +198,7 @@ func TestGrokProviderParsesChatHistoryTranscript(t *testing.T) {
 	assert.Equal(t, "call-1", result.Messages[1].ToolCalls[0].ToolUseID)
 	assert.Equal(t, "read_file", result.Messages[1].ToolCalls[0].ToolName)
 	assert.Equal(t, "Read", result.Messages[1].ToolCalls[0].Category)
+	assert.JSONEq(t, `{"target_file":"SKILL.md"}`, result.Messages[1].ToolCalls[0].InputJSON)
 	assert.Equal(t, "grok-4.5", result.Messages[1].Model)
 
 	assert.Equal(t, RoleUser, result.Messages[2].Role)
@@ -209,6 +211,91 @@ func TestGrokProviderParsesChatHistoryTranscript(t *testing.T) {
 
 	assert.Equal(t, RoleUser, result.Messages[4].Role)
 	assert.Equal(t, "fix the issues", result.Messages[4].Content)
+}
+
+func TestGrokProviderUnwrapsOpenAIStyleToolArguments(t *testing.T) {
+	// OpenAI-style tool calls nest name/arguments under "function" and encode
+	// arguments as a JSON string. InputJSON must be the decoded object so
+	// path extraction and skill inference can read fields.
+	root := t.TempDir()
+	sessionID := "sess-openai-tools"
+	writeGrokFixtureFile(t, grokSummaryPath(root, "cwd-key", sessionID), `{
+		"info": {"id": "sess-openai-tools", "cwd": "/tmp/proj"},
+		"session_summary": "tool args",
+		"created_at": "2026-07-12T04:00:00Z",
+		"updated_at": "2026-07-12T04:01:00Z"
+	}`)
+	writeGrokFixtureFile(t, filepath.Join(root, "cwd-key", sessionID, "chat_history.jsonl"), strings.Join([]string{
+		`{"type":"user","content":"read the skill"}`,
+		`{"type":"assistant","content":"","tool_calls":[{"id":"call-fn","type":"function","function":{"name":"read_file","arguments":"{\"target_file\":\"SKILL.md\",\"offset\":10}"}}],"model_id":"grok-4.5"}`,
+	}, "\n")+"\n")
+
+	provider := newGrokTestProvider(t, root)
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+
+	outcome, err := provider.Parse(context.Background(), ParseRequest{Source: sources[0]})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+
+	msgs := outcome.Results[0].Result.Messages
+	require.Len(t, msgs, 2)
+	require.Len(t, msgs[1].ToolCalls, 1)
+	tc := msgs[1].ToolCalls[0]
+	assert.Equal(t, "call-fn", tc.ToolUseID)
+	assert.Equal(t, "read_file", tc.ToolName)
+	assert.Equal(t, "Read", tc.Category)
+	assert.JSONEq(t, `{"target_file":"SKILL.md","offset":10}`, tc.InputJSON)
+	// Must not retain the outer JSON-string quotes.
+	assert.NotContains(t, tc.InputJSON, `\"target_file\"`)
+	assert.False(t, strings.HasPrefix(strings.TrimSpace(tc.InputJSON), `"`))
+}
+
+func TestGrokProviderKeepsUserPromptBesideMetadata(t *testing.T) {
+	// Mixed context-injection + real prompt must keep the prompt instead of
+	// dropping the whole user turn when any meta marker is present.
+	root := t.TempDir()
+	sessionID := "sess-mixed-meta"
+	writeGrokFixtureFile(t, grokSummaryPath(root, "cwd-key", sessionID), `{
+		"info": {"id": "sess-mixed-meta", "cwd": "/tmp/proj"},
+		"session_summary": "mixed meta",
+		"created_at": "2026-07-12T04:00:00Z",
+		"updated_at": "2026-07-12T04:01:00Z"
+	}`)
+	mixed := `<user_info>
+OS Version: macos
+</user_info>
+<git_status>
+## main
+</git_status>
+
+Please fix the flaky test in grok_test.go`
+	// Escape for JSON string embedding.
+	mixedJSON, err := json.Marshal(mixed)
+	require.NoError(t, err)
+	writeGrokFixtureFile(t, filepath.Join(root, "cwd-key", sessionID, "chat_history.jsonl"), strings.Join([]string{
+		`{"type":"user","content":` + string(mixedJSON) + `}`,
+		`{"type":"user","content":[{"type":"text","text":"<system-reminder>skills loaded</system-reminder>\n\nrun the suite"}]}`,
+		`{"type":"user","content":[{"type":"text","text":"<user_info>\nOS Version: macos\n</user_info>"}]}`,
+	}, "\n")+"\n")
+
+	provider := newGrokTestProvider(t, root)
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+
+	outcome, err := provider.Parse(context.Background(), ParseRequest{Source: sources[0]})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+
+	result := outcome.Results[0].Result
+	// Meta-only third message is dropped; two real prompts remain.
+	require.Len(t, result.Messages, 2)
+	assert.Equal(t, 2, result.Session.UserMessageCount)
+	assert.Equal(t, "Please fix the flaky test in grok_test.go", result.Messages[0].Content)
+	assert.Equal(t, "run the suite", result.Messages[1].Content)
+	assert.Equal(t, "Please fix the flaky test in grok_test.go", result.Session.FirstMessage)
 }
 
 func TestGrokProviderFindSource(t *testing.T) {

--- a/internal/parser/grok_test.go
+++ b/internal/parser/grok_test.go
@@ -130,9 +130,11 @@ func TestGrokProviderCurrentBuildSummarySchema(t *testing.T) {
 	assert.Equal(t, "/Users/dev/repos/wp-devops", session.Cwd)
 	assert.Equal(t, "refactor/shared-proxy-csv-utils", session.GitBranch)
 	// Without chat_history.jsonl, counts fall back to summary/signals.
+	// Prefer num_chat_messages (104) over the broader num_messages (927),
+	// which includes non-chat events and would inflate analytics filters.
 	assert.Equal(t, TranscriptFidelitySummary, session.TranscriptFidelity)
 	assert.Equal(t, "grok-summary-v1", session.SourceVersion)
-	assert.Equal(t, 927, session.MessageCount)
+	assert.Equal(t, 104, session.MessageCount)
 	assert.Equal(t, 7, session.UserMessageCount)
 	assert.Equal(t, 106663, session.PeakContextTokens)
 	assert.True(t, session.HasPeakContextTokens)

--- a/internal/parser/grok_test.go
+++ b/internal/parser/grok_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,22 +31,22 @@ func newGrokTestProvider(t *testing.T, root string) Provider {
 func TestGrokProviderSummarySource(t *testing.T) {
 	root := t.TempDir()
 	writeGrokFixtureFile(t, grokSummaryPath(root, "cwd-key", "sess-1"), `{
-		"summary": "Fix parser regression",
-		"firstPrompt": "Investigate the failing Grok session import",
-		"modelId": "grok-code-fast",
-		"createdAt": "2026-07-08T10:00:00Z",
-		"updatedAt": "2026-07-08T10:30:00Z",
-		"lastActiveAt": "2026-07-08T10:31:00Z",
-		"hostname": "devbox",
-		"numMessages": 6,
-		"worktreeLabel": "agentsview"
-	}`)
+			"summary": "Fix parser regression",
+			"firstPrompt": "Investigate the failing Grok session import",
+			"modelId": "grok-code-fast",
+			"createdAt": "2026-07-08T10:00:00Z",
+			"updatedAt": "2026-07-08T10:30:00Z",
+			"lastActiveAt": "2026-07-08T10:31:00Z",
+			"hostname": "devbox",
+			"numMessages": 6,
+			"worktreeLabel": "agentsview"
+		}`)
 	writeGrokFixtureFile(t, filepath.Join(root, "cwd-key", "sess-1", "signals.json"), `{
-		"tokenUsage": {
-			"totalOutputTokens": 321,
-			"peakContextTokens": 4096
-		}
-	}`)
+			"tokenUsage": {
+				"totalOutputTokens": 321,
+				"peakContextTokens": 4096
+			}
+		}`)
 	provider := newGrokTestProvider(t, root)
 	sources, err := provider.Discover(context.Background())
 	require.NoError(t, err)
@@ -74,6 +75,140 @@ func TestGrokProviderSummarySource(t *testing.T) {
 	require.Len(t, outcome.Results[0].Result.Messages, 1)
 	assert.Equal(t, RoleUser, outcome.Results[0].Result.Messages[0].Role)
 	assert.Equal(t, "Investigate the failing Grok session import", outcome.Results[0].Result.Messages[0].Content)
+}
+
+func TestGrokProviderCurrentBuildSummarySchema(t *testing.T) {
+	root := t.TempDir()
+	cwdKey := "%2FUsers%2Fdev%2Frepos%2Fwp-devops"
+	sessionID := "019f542b-45b0-7720-8184-e790ac116d20"
+	writeGrokFixtureFile(t, grokSummaryPath(root, cwdKey, sessionID), `{
+			"info": {
+				"id": "019f542b-45b0-7720-8184-e790ac116d20",
+				"cwd": "/Users/dev/repos/wp-devops"
+			},
+			"session_summary": "\u5ba1\u67e5\u4ed3\u5e93\u4ee3\u7801",
+			"generated_title": "\u5ba1\u67e5\u4ed3\u5e93\u4ee3\u7801",
+			"created_at": "2026-07-12T02:32:29.874617Z",
+			"updated_at": "2026-07-12T04:29:01.847426Z",
+			"last_active_at": "2026-07-12T04:09:52.574304Z",
+			"num_messages": 927,
+			"num_chat_messages": 104,
+			"current_model_id": "grok-4.5",
+			"git_root_dir": "/Users/dev/repos/wp-devops/",
+			"head_branch": "refactor/shared-proxy-csv-utils",
+			"agent_name": "grok-build-plan"
+		}`)
+	writeGrokFixtureFile(t, filepath.Join(root, cwdKey, sessionID, "signals.json"), `{
+			"userMessageCount": 7,
+			"assistantMessageCount": 48,
+			"contextTokensUsed": 106663,
+			"contextWindowTokens": 200000,
+			"primaryModelId": "grok-4.5"
+		}`)
+
+	provider := newGrokTestProvider(t, root)
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	assert.Equal(t, cwdKey, sources[0].ProjectHint)
+
+	outcome, err := provider.Parse(context.Background(), ParseRequest{
+		Source: sources[0],
+	})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+
+	session := outcome.Results[0].Result.Session
+	assert.Equal(t, "grok:"+sessionID, session.ID)
+	assert.Equal(t, AgentGrok, session.Agent)
+	assert.Equal(t, sessionID, session.SourceSessionID)
+	assert.Equal(t, "summary", session.TranscriptFidelity)
+	assert.Equal(t, "\u5ba1\u67e5\u4ed3\u5e93\u4ee3\u7801", session.SessionName)
+	assert.Equal(t, "\u5ba1\u67e5\u4ed3\u5e93\u4ee3\u7801", session.FirstMessage)
+	assert.Equal(t, "wp_devops", session.Project)
+	assert.Equal(t, "/Users/dev/repos/wp-devops", session.Cwd)
+	assert.Equal(t, "refactor/shared-proxy-csv-utils", session.GitBranch)
+	// Without chat_history.jsonl, counts fall back to summary/signals.
+	assert.Equal(t, TranscriptFidelitySummary, session.TranscriptFidelity)
+	assert.Equal(t, "grok-summary-v1", session.SourceVersion)
+	assert.Equal(t, 927, session.MessageCount)
+	assert.Equal(t, 7, session.UserMessageCount)
+	assert.Equal(t, 106663, session.PeakContextTokens)
+	assert.True(t, session.HasPeakContextTokens)
+	assert.False(t, session.HasTotalOutputTokens)
+	require.Len(t, outcome.Results[0].Result.Messages, 1)
+	assert.Equal(t, RoleUser, outcome.Results[0].Result.Messages[0].Role)
+	assert.Equal(t, "\u5ba1\u67e5\u4ed3\u5e93\u4ee3\u7801", outcome.Results[0].Result.Messages[0].Content)
+}
+
+func TestGrokProviderParsesChatHistoryTranscript(t *testing.T) {
+	root := t.TempDir()
+	cwdKey := "%2FUsers%2Fdev%2Frepos%2Fwp-devops"
+	sessionID := "019f5483-db23-74c1-9d35-7df33f1c3ddc"
+	writeGrokFixtureFile(t, grokSummaryPath(root, cwdKey, sessionID), `{
+			"info": {"id": "019f5483-db23-74c1-9d35-7df33f1c3ddc", "cwd": "/Users/dev/repos/wp-devops"},
+			"session_summary": "review branch",
+			"created_at": "2026-07-12T04:09:15.439384Z",
+			"updated_at": "2026-07-12T05:23:48.317854Z",
+			"last_active_at": "2026-07-12T05:23:48.317854Z",
+			"num_messages": 864,
+			"git_root_dir": "/Users/dev/repos/wp-devops/",
+			"head_branch": "refactor/shared-proxy-csv-utils"
+		}`)
+	writeGrokFixtureFile(t, filepath.Join(root, cwdKey, sessionID, "chat_history.jsonl"), strings.Join([]string{
+		`{"type":"system","content":"You are Grok"}`,
+		`{"type":"user","content":[{"type":"text","text":"<user_info>\nOS Version: macos\n</user_info>"}]}`,
+		`{"type":"user","content":[{"type":"text","text":"<user_query>review branch vs main</user_query>"}]}`,
+		`{"type":"reasoning","id":"","summary":[{"type":"summary_text","text":"Need to review the branch."}]}`,
+		`{"type":"assistant","content":"Loading review skill.","tool_calls":[{"id":"call-1","name":"read_file","arguments":"{\"target_file\":\"SKILL.md\"}"}],"model_id":"grok-4.5"}`,
+		`{"type":"tool_result","tool_call_id":"call-1","content":"skill body"}`,
+		`{"type":"assistant","content":"Review complete.","model_id":"grok-4.5"}`,
+		`{"type":"user","content":[{"type":"text","text":"<user_query>fix the issues</user_query>"}]}`,
+	}, "\n")+"\n")
+
+	provider := newGrokTestProvider(t, root)
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+
+	outcome, err := provider.Parse(context.Background(), ParseRequest{
+		Source: sources[0],
+	})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+
+	result := outcome.Results[0].Result
+	session := result.Session
+	assert.Equal(t, TranscriptFidelityFull, session.TranscriptFidelity)
+	assert.Equal(t, "grok-chat-v1", session.SourceVersion)
+	assert.Equal(t, "review branch vs main", session.FirstMessage)
+	assert.Equal(t, 2, session.UserMessageCount)
+	// user, assistant(+thinking+tool), tool_result, assistant, user
+	require.Len(t, result.Messages, 5)
+
+	assert.Equal(t, RoleUser, result.Messages[0].Role)
+	assert.Equal(t, "review branch vs main", result.Messages[0].Content)
+
+	assert.Equal(t, RoleAssistant, result.Messages[1].Role)
+	assert.True(t, result.Messages[1].HasThinking)
+	assert.Equal(t, "Need to review the branch.", result.Messages[1].ThinkingText)
+	assert.True(t, result.Messages[1].HasToolUse)
+	require.Len(t, result.Messages[1].ToolCalls, 1)
+	assert.Equal(t, "call-1", result.Messages[1].ToolCalls[0].ToolUseID)
+	assert.Equal(t, "read_file", result.Messages[1].ToolCalls[0].ToolName)
+	assert.Equal(t, "Read", result.Messages[1].ToolCalls[0].Category)
+	assert.Equal(t, "grok-4.5", result.Messages[1].Model)
+
+	assert.Equal(t, RoleUser, result.Messages[2].Role)
+	require.Len(t, result.Messages[2].ToolResults, 1)
+	assert.Equal(t, "call-1", result.Messages[2].ToolResults[0].ToolUseID)
+	assert.Equal(t, 10, result.Messages[2].ToolResults[0].ContentLength)
+
+	assert.Equal(t, RoleAssistant, result.Messages[3].Role)
+	assert.Equal(t, "Review complete.", result.Messages[3].Content)
+
+	assert.Equal(t, RoleUser, result.Messages[4].Role)
+	assert.Equal(t, "fix the issues", result.Messages[4].Content)
 }
 
 func TestGrokProviderFindSource(t *testing.T) {
@@ -159,20 +294,20 @@ func TestGrokProviderFingerprintTracksParsedFiles(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEqual(t, afterSummary.Hash, afterSignals.Hash)
 
-	writeGrokFixtureFile(t, updates, "{\"delta\":1}\n")
-	afterUpdates, err := provider.Fingerprint(context.Background(), source)
-	require.NoError(t, err)
-	assert.Equal(t, afterSignals.Hash, afterUpdates.Hash)
-
 	writeGrokFixtureFile(t, chat, "{\"message\":1}\n")
 	afterChat, err := provider.Fingerprint(context.Background(), source)
 	require.NoError(t, err)
-	assert.Equal(t, afterUpdates.Hash, afterChat.Hash)
+	assert.NotEqual(t, afterSignals.Hash, afterChat.Hash)
+
+	writeGrokFixtureFile(t, updates, "{\"delta\":1}\n")
+	afterUpdates, err := provider.Fingerprint(context.Background(), source)
+	require.NoError(t, err)
+	assert.Equal(t, afterChat.Hash, afterUpdates.Hash)
 
 	writeGrokFixtureFile(t, unrelated, "still ignored")
 	afterUnrelated, err := provider.Fingerprint(context.Background(), source)
 	require.NoError(t, err)
-	assert.Equal(t, afterChat.Hash, afterUnrelated.Hash)
+	assert.Equal(t, afterUpdates.Hash, afterUnrelated.Hash)
 }
 
 func TestGrokProviderChangedPathTracksParsedFiles(t *testing.T) {
@@ -181,7 +316,7 @@ func TestGrokProviderChangedPathTracksParsedFiles(t *testing.T) {
 	writeGrokFixtureFile(t, summary, `{"summary":"Changed path","firstPrompt":"hello","createdAt":"2026-07-08T10:00:00Z"}`)
 	provider := newGrokTestProvider(t, root)
 
-	for _, name := range []string{"summary.json", "signals.json"} {
+	for _, name := range []string{"summary.json", "signals.json", "chat_history.jsonl"} {
 		changed, err := provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{
 			Path: filepath.Join(root, "cwd-key", "sess-1", name),
 		})
@@ -190,13 +325,11 @@ func TestGrokProviderChangedPathTracksParsedFiles(t *testing.T) {
 		assert.Equal(t, filepath.Clean(summary), filepath.Clean(changed[0].FingerprintKey))
 	}
 
-	for _, name := range []string{"updates.jsonl", "chat_history.jsonl"} {
-		changed, err := provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{
-			Path: filepath.Join(root, "cwd-key", "sess-1", name),
-		})
-		require.NoError(t, err)
-		assert.Empty(t, changed)
-	}
+	changed, err := provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{
+		Path: filepath.Join(root, "cwd-key", "sess-1", "updates.jsonl"),
+	})
+	require.NoError(t, err)
+	assert.Empty(t, changed)
 }
 
 func TestGrokProviderArtifactBoundaries(t *testing.T) {


### PR DESCRIPTION
## Summary

Grok Build sessions under `~/.grok/sessions` were either missing or summary-only in AgentsView.

- Accept current snake_case `summary.json` / `signals.json` fields while keeping legacy camelCase support
- Resolve project labels from `git_root_dir` / `info.cwd` and URL-encoded cwd keys
- Parse `chat_history.jsonl` into full transcripts (user turns, assistant replies, thinking, tool calls)
- Fall back to summary-only mode when `chat_history.jsonl` is missing
- Update docs to describe the current Grok import surface

## Notes

- Grok still does not persist per-turn output tokens or cost in local session files, so breadcrumb `—out`, steps, and estimated cost remain unavailable when those fields are absent.
- Focused parser and sync coverage exercises the current schema and chat history path.