### PR TITLE
Speed up configured full HTTP remote syncs

### DIFF
--- a/cmd/agentsview/archive_query_backend.go
+++ b/cmd/agentsview/archive_query_backend.go
@@ -250,7 +250,7 @@ func (b localArchiveQueryBackend) SessionUsage(
 		engine := sync.NewEngine(b.database, sync.EngineConfig{
 			AgentDirs:               b.cfg.AgentDirs,
 			IncludeCwdPrefixes:      b.cfg.SyncIncludeCwdPrefixes,
-			Machine:                 "local",
+			Machine:                 b.cfg.LocalMachineName,
 			BlockedResultCategories: b.cfg.ResultContentBlockedCategories,
 		})
 		if syncErr := engine.SyncSingleSessionContext(

--- a/cmd/agentsview/archive_write_backend.go
+++ b/cmd/agentsview/archive_write_backend.go
@@ -633,7 +633,7 @@ func (b *localArchiveWriteBackend) PGPushWatch(
 	engine := syncpkg.NewEngine(b.database, syncpkg.EngineConfig{
 		AgentDirs:               b.appCfg.AgentDirs,
 		IncludeCwdPrefixes:      b.appCfg.SyncIncludeCwdPrefixes,
-		Machine:                 "local",
+		Machine:                 b.appCfg.LocalMachineName,
 		BlockedResultCategories: b.appCfg.ResultContentBlockedCategories,
 	})
 	defer engine.Close()

--- a/cmd/agentsview/import.go
+++ b/cmd/agentsview/import.go
@@ -45,11 +45,13 @@ func runImport(cfg ImportConfig) {
 
 	switch cfg.Type {
 	case "claude-ai":
-		stats, err = runClaudeAIImport(ctx, database, dir)
+		stats, err = runClaudeAIImport(
+			ctx, database, dir, appCfg.LocalMachineName,
+		)
 	case "chatgpt":
 		assetsDir := filepath.Join(appCfg.DataDir, "assets")
 		stats, err = runChatGPTImport(
-			ctx, database, dir, assetsDir,
+			ctx, database, dir, assetsDir, appCfg.LocalMachineName,
 		)
 	default:
 		log.Fatalf(
@@ -71,7 +73,7 @@ func runImport(cfg ImportConfig) {
 }
 
 func runClaudeAIImport(
-	ctx context.Context, database *db.DB, path string,
+	ctx context.Context, database *db.DB, path, machine string,
 ) (importer.ImportStats, error) {
 	jsonPath := path
 	info, err := os.Stat(path)
@@ -104,13 +106,13 @@ func runClaudeAIImport(
 					"\rRebuilding search index...   ",
 				)
 			},
-		},
+		}, machine,
 	)
 }
 
 func runChatGPTImport(
 	ctx context.Context, database *db.DB,
-	dir, assetsDir string,
+	dir, assetsDir, machine string,
 ) (importer.ImportStats, error) {
 	return importer.ImportChatGPT(
 		ctx, database, dir, assetsDir,
@@ -128,7 +130,7 @@ func runChatGPTImport(
 					"\rRebuilding search index...   ",
 				)
 			},
-		},
+		}, machine,
 	)
 }
 

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -318,6 +318,7 @@ func runServe(cfg config.Config, opts serveOptions) {
 		server.WithBaseContext(ctx),
 		server.WithBroadcaster(broadcaster),
 		server.WithIdleTracker(idleTracker),
+		server.WithHTTPRemoteCleanupRegistry(httpRemoteCleanupRegistry),
 		server.WithPprof(opts.Pprof),
 	}
 	srvOpts = append(srvOpts, vectorServe.ServerOpts...)

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -211,7 +211,7 @@ func runServe(cfg config.Config, opts serveOptions) {
 		engine = sync.NewEngine(database, sync.EngineConfig{
 			AgentDirs:               cfg.AgentDirs,
 			IncludeCwdPrefixes:      cfg.SyncIncludeCwdPrefixes,
-			Machine:                 "local",
+			Machine:                 cfg.LocalMachineName,
 			BlockedResultCategories: cfg.ResultContentBlockedCategories,
 			Emitter:                 emitter,
 			DeferStartupMaintenance: opts.SkipInitialSync,
@@ -276,7 +276,7 @@ func runServe(cfg config.Config, opts serveOptions) {
 	identityBackfillEngine := engine
 	if identityBackfillEngine == nil {
 		identityBackfillEngine = sync.NewEngine(database, sync.EngineConfig{
-			Machine: "local",
+			Machine: cfg.LocalMachineName,
 		})
 	}
 	go idleTracker.Do(func() {

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -1392,7 +1392,17 @@ func startRemoteHostSync(
 ) {
 	syncFn := remoteHostSyncFunc(
 		ctx, cfg, database, engine, rh,
-		runRemoteSyncTransport,
+		func(
+			ctx context.Context,
+			cfg config.Config,
+			database *db.DB,
+			rh config.RemoteHost,
+			full bool,
+		) (remotesync.SyncStats, error) {
+			return runRemoteSyncTransportWithCleanup(
+				ctx, cfg, database, rh, full, false,
+			)
+		},
 	)
 	runRemoteHostSyncLoop(ctx, rh.Host, rh.Interval, syncFn, emitter, idleTracker, nil)
 }
@@ -1409,6 +1419,9 @@ type remoteSyncRunner func(
 	bool,
 ) (remotesync.SyncStats, error)
 
+// remoteHostSyncFunc owns the HTTP cleanup registry around the engine lock.
+// Its injected transport must therefore run HTTP without acquiring that
+// registry recursively; SSH transports have no cleanup-registry ownership.
 func remoteHostSyncFunc(
 	ctx context.Context,
 	cfg config.Config,
@@ -1421,12 +1434,24 @@ func remoteHostSyncFunc(
 		if runner == nil {
 			return 0, fmt.Errorf("scheduled remote sync missing exclusive runner")
 		}
+		runExclusive := func() (remotesync.SyncStats, error) {
+			var stats remotesync.SyncStats
+			err := runner.RunExclusive(func() error {
+				var err error
+				stats, err = runRemote(
+					ctx, cfg, database, rh, database.NeedsResync(),
+				)
+				return err
+			})
+			return stats, err
+		}
 		var stats remotesync.SyncStats
-		err := runner.RunExclusive(func() error {
-			var err error
-			stats, err = runRemote(ctx, cfg, database, rh, database.NeedsResync())
-			return err
-		})
+		var err error
+		if rh.Transport == config.RemoteTransportHTTP {
+			stats, err = httpRemoteCleanupRegistry.Run(runExclusive)
+		} else {
+			stats, err = runExclusive()
+		}
 		return stats.SessionsSynced, err
 	}
 }

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -574,6 +574,78 @@ func TestRemoteHostSyncFuncSerializesWithEngineExclusiveLock(t *testing.T) {
 	}
 }
 
+type scheduledLockOrderRunner struct {
+	held bool
+}
+
+func (r *scheduledLockOrderRunner) RunExclusive(work func() error) error {
+	if r.held {
+		return errors.New("engine lock acquired recursively")
+	}
+	r.held = true
+	defer func() { r.held = false }()
+	return work()
+}
+
+type scheduledLockOrderCleanup struct {
+	runner  remoteSyncExclusiveRunner
+	retries int
+}
+
+func (c *scheduledLockOrderCleanup) Error() string { return "pending cleanup" }
+
+func (c *scheduledLockOrderCleanup) RetryCleanup() error {
+	c.retries++
+	if c.retries == 1 {
+		return errors.New("retain pending cleanup")
+	}
+	return c.runner.RunExclusive(func() error { return nil })
+}
+
+func TestRemoteHostSyncFuncAcquiresHTTPCleanupBeforeEngine(t *testing.T) {
+	originalRegistry := httpRemoteCleanupRegistry
+	httpRemoteCleanupRegistry = new(remotesync.CleanupRegistry)
+	t.Cleanup(func() { httpRemoteCleanupRegistry = originalRegistry })
+	runner := &scheduledLockOrderRunner{}
+	owner := &scheduledLockOrderCleanup{runner: runner}
+	_, seedErr := httpRemoteCleanupRegistry.Run(
+		func() (remotesync.SyncStats, error) {
+			return remotesync.SyncStats{}, owner
+		},
+	)
+	require.Error(t, seedErr)
+	originalHTTP := runHTTPRemoteSync
+	httpCalls := 0
+	runHTTPRemoteSync = func(
+		context.Context, config.Config, *db.DB, config.RemoteHost, bool,
+	) (remotesync.SyncStats, error) {
+		httpCalls++
+		return remotesync.SyncStats{SessionsSynced: 1}, nil
+	}
+	t.Cleanup(func() { runHTTPRemoteSync = originalHTTP })
+	database := dbtest.OpenTestDB(t)
+	syncFn := remoteHostSyncFunc(
+		context.Background(), config.Config{}, database, runner,
+		config.RemoteHost{Host: "http-host", Transport: config.RemoteTransportHTTP},
+		func(
+			ctx context.Context, cfg config.Config, database *db.DB,
+			rh config.RemoteHost, full bool,
+		) (remotesync.SyncStats, error) {
+			return runRemoteSyncTransportWithCleanup(
+				ctx, cfg, database, rh, full, false,
+			)
+		},
+	)
+
+	synced, err := syncFn()
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, synced)
+	assert.Equal(t, 1, httpCalls)
+	assert.Equal(t, 2, owner.retries,
+		"retained cleanup must acquire the engine before scheduled work")
+}
+
 func TestRemoteHostSyncFuncUsesCallerContext(t *testing.T) {
 	database := dbtest.OpenTestDB(t)
 	engine := agentsync.NewEngine(database, agentsync.EngineConfig{
@@ -628,7 +700,14 @@ func TestRemoteHostSyncFuncDispatchesHTTPTransport(t *testing.T) {
 			Transport: config.RemoteTransportHTTP,
 			URL:       "https://test-host.example.test",
 		},
-		runRemoteSyncTransport,
+		func(
+			ctx context.Context, cfg config.Config, database *db.DB,
+			rh config.RemoteHost, full bool,
+		) (remotesync.SyncStats, error) {
+			return runRemoteSyncTransportWithCleanup(
+				ctx, cfg, database, rh, full, false,
+			)
+		},
 	)
 
 	synced, err := syncFn()

--- a/cmd/agentsview/parse_diff.go
+++ b/cmd/agentsview/parse_diff.go
@@ -128,7 +128,7 @@ func doParseDiff(cfg ParseDiffConfig) (failed bool) {
 	engine := sync.NewDiffEngine(database, sync.EngineConfig{
 		AgentDirs:               appCfg.AgentDirs,
 		IncludeCwdPrefixes:      appCfg.SyncIncludeCwdPrefixes,
-		Machine:                 "local",
+		Machine:                 appCfg.LocalMachineName,
 		BlockedResultCategories: appCfg.ResultContentBlockedCategories,
 	})
 

--- a/cmd/agentsview/session_sync.go
+++ b/cmd/agentsview/session_sync.go
@@ -75,7 +75,7 @@ func syncService(
 	engine := sync.NewEngine(d, sync.EngineConfig{
 		AgentDirs:          cfg.AgentDirs,
 		IncludeCwdPrefixes: cfg.SyncIncludeCwdPrefixes,
-		Machine:            "local",
+		Machine:            cfg.LocalMachineName,
 	})
 	// Close the engine before the DB so pending debounced signal
 	// recomputes flush while the DB is still open.

--- a/cmd/agentsview/sync.go
+++ b/cmd/agentsview/sync.go
@@ -350,10 +350,26 @@ func runRemoteSyncTransport(
 	rh config.RemoteHost,
 	full bool,
 ) (remotesync.SyncStats, error) {
+	return runRemoteSyncTransportWithCleanup(
+		ctx, appCfg, database, rh, full, true,
+	)
+}
+
+func runRemoteSyncTransportWithCleanup(
+	ctx context.Context,
+	appCfg config.Config,
+	database *db.DB,
+	rh config.RemoteHost,
+	full bool,
+	acquireHTTPCleanup bool,
+) (remotesync.SyncStats, error) {
 	switch rh.Transport {
 	case "", config.RemoteTransportSSH:
 		return runSSHRemoteSync(ctx, appCfg, database, rh, full)
 	case config.RemoteTransportHTTP:
+		if !acquireHTTPCleanup {
+			return runHTTPRemoteSync(ctx, appCfg, database, rh, full)
+		}
 		return httpRemoteCleanupRegistry.Run(func() (remotesync.SyncStats, error) {
 			return runHTTPRemoteSync(ctx, appCfg, database, rh, full)
 		})

--- a/cmd/agentsview/sync.go
+++ b/cmd/agentsview/sync.go
@@ -834,7 +834,7 @@ func coordinateLocalSync(
 	engine := sync.NewEngine(database, sync.EngineConfig{
 		AgentDirs:               appCfg.AgentDirs,
 		IncludeCwdPrefixes:      appCfg.SyncIncludeCwdPrefixes,
-		Machine:                 "local",
+		Machine:                 appCfg.LocalMachineName,
 		BlockedResultCategories: appCfg.ResultContentBlockedCategories,
 	})
 	defer engine.Close()

--- a/cmd/agentsview/sync.go
+++ b/cmd/agentsview/sync.go
@@ -107,10 +107,10 @@ func doSync(cfg SyncConfig) (hadRemoteFailures bool) {
 					remoteHosts, cfg.Full, includeLocal, progress.Print,
 				)
 				progress.Finish()
+				reportRemoteFailures(failures)
 				if err != nil {
 					fatal("daemon remote sync: %v", err)
 				}
-				reportRemoteFailures(failures)
 				return len(failures) > 0
 			}
 			if useDaemon {
@@ -162,18 +162,29 @@ func doSync(cfg SyncConfig) (hadRemoteFailures bool) {
 		return false
 	}
 
-	failures := syncLocalAndRemotes(
-		appCfg.RemoteHosts, cfg.Full,
-		func() bool {
-			return runLocalSync(
-				context.Background(), appCfg, database, cfg.Full,
-			)
-		},
-		func(rh config.RemoteHost, full bool) error {
-			return runRemoteSyncOnce(appCfg, database, rh, full)
-		},
+	if len(appCfg.RemoteHosts) == 0 {
+		runLocalSync(context.Background(), appCfg, database, cfg.Full)
+		return false
+	}
+	progress := newRemoteProgressPrinter(os.Stdout, time.Now)
+	_, failures, blocked := runConfiguredLocalAndRemotesCLI(
+		context.Background(), appCfg, database, appCfg.RemoteHosts,
+		cfg.Full, progress.Print,
 	)
+	progress.Finish()
 	reportRemoteFailures(failures)
+	if blocked != nil {
+		var pending *remotesync.PendingCleanupError
+		if errors.As(blocked, &pending) {
+			log.Printf("remote HTTP sync blocked by pending cleanup: %v", blocked)
+			fmt.Fprintf(os.Stderr,
+				"sync: remote HTTP cleanup remains pending: %s\n",
+				remotesync.FailureSummary(blocked),
+			)
+			return true
+		}
+		fatal("local sync: %v", blocked)
+	}
 	return len(failures) > 0
 }
 
@@ -298,7 +309,7 @@ func syncLocalAndRemotes(
 	hosts []config.RemoteHost, cfgFull bool,
 	localSync func() bool,
 	remoteSync func(config.RemoteHost, bool) error,
-) []remoteHostFailure {
+) ([]remoteHostFailure, error) {
 	didResync := localSync()
 	full := cfgFull || didResync
 	return runRemoteHosts(hosts, full, remoteSync)
@@ -343,12 +354,48 @@ func runRemoteSyncTransport(
 	case "", config.RemoteTransportSSH:
 		return runSSHRemoteSync(ctx, appCfg, database, rh, full)
 	case config.RemoteTransportHTTP:
-		return runHTTPRemoteSync(ctx, appCfg, database, rh, full)
+		return httpRemoteCleanupRegistry.Run(func() (remotesync.SyncStats, error) {
+			return runHTTPRemoteSync(ctx, appCfg, database, rh, full)
+		})
 	default:
 		return remotesync.SyncStats{}, fmt.Errorf(
 			"invalid remote transport %q", rh.Transport,
 		)
 	}
+}
+
+var httpRemoteCleanupRegistry = new(remotesync.CleanupRegistry)
+
+var errUnifiedRebuildAborted = sync.ErrUnifiedRebuildAborted
+
+type preparedHTTPRebuildCLI interface {
+	BorrowRebuildContributors() ([]sync.RebuildContributor, func(), error)
+	Close() error
+}
+
+var prepareHTTPRebuildCLI = func(
+	ctx context.Context, syncs []remotesync.HTTPSync,
+) (preparedHTTPRebuildCLI, error) {
+	return remotesync.PrepareHTTPSyncs(ctx, syncs)
+}
+
+var runLocalSyncWithRebuildCLI = runLocalSyncWithRebuild
+var runLocalSyncWithFallbackCLI = runLocalSyncWithFallback
+
+type preparedHTTPRebuildLeaseCLI struct {
+	prepared preparedHTTPRebuildCLI
+	release  func()
+}
+
+func (l *preparedHTTPRebuildLeaseCLI) Close() error {
+	if l == nil {
+		return nil
+	}
+	if l.release != nil {
+		l.release()
+		l.release = nil
+	}
+	return l.prepared.Close()
 }
 
 var runSSHRemoteSync = func(
@@ -402,24 +449,29 @@ type remoteHostFailure struct {
 	Err  error
 }
 
-// runRemoteHosts syncs each configured host in declared order via
-// syncFn, continuing past failures, and returns the collected
-// failures. It performs no logging so it can be unit-tested
-// without capturing the global logger; callers own all output.
+// runRemoteHosts syncs each configured host in declared order via syncFn and
+// continues past host-attributable failures. A pending cleanup from an earlier
+// host stops iteration and is returned separately because the callback for the
+// current host never ran. The helper performs no logging so callers own all
+// output.
 func runRemoteHosts(
 	hosts []config.RemoteHost, full bool,
 	syncFn func(config.RemoteHost, bool) error,
-) []remoteHostFailure {
+) ([]remoteHostFailure, error) {
 	var failures []remoteHostFailure
 	for _, rh := range hosts {
 		if err := syncFn(rh, full); err != nil {
+			var pending *remotesync.PendingCleanupError
+			if errors.As(err, &pending) {
+				return failures, pending
+			}
 			failures = append(failures, remoteHostFailure{
 				Host: rh,
 				Err:  err,
 			})
 		}
 	}
-	return failures
+	return failures, nil
 }
 
 // reportRemoteFailures writes per-host failures to the debug log
@@ -453,6 +505,215 @@ func remoteFailureDisplay(f remoteHostFailure) string {
 	return f.Err.Error()
 }
 
+// runConfiguredLocalAndRemotes coordinates a direct local sync with every
+// configured remote. Full rebuilds prepare all HTTP mirrors before database
+// work, add them to the atomic local rebuild, and run only SSH remotes after a
+// successful swap. Incremental runs retain the ordinary local-then-remote
+// active-archive path.
+func runConfiguredLocalAndRemotes(
+	ctx context.Context,
+	appCfg config.Config,
+	database *db.DB,
+	hosts []config.RemoteHost,
+	full bool,
+	progress sync.ProgressFunc,
+) (didResync bool, failures []remoteHostFailure, retErr error) {
+	httpHosts, sshHosts := partitionConfiguredRemoteHosts(hosts)
+	didResync = full || database.NeedsResync()
+	outerOwnsHTTP := didResync && len(httpHosts) > 0
+
+	run := func() (remotesync.SyncStats, error) {
+		if len(httpHosts) == 0 {
+			_, err := runLocalSyncWithFallbackCLI(
+				ctx, appCfg, database, full, progress,
+				func(forceFull bool) error {
+					var blocked error
+					failures, blocked = runRemoteHosts(
+						hosts, forceFull,
+						func(rh config.RemoteHost, remoteFull bool) error {
+							_, err := runRemoteSyncTransport(
+								ctx, appCfg, database, rh, remoteFull,
+							)
+							return err
+						},
+					)
+					return blocked
+				},
+			)
+			return remotesync.SyncStats{}, err
+		}
+		_, err := runLocalSyncWithRebuildCLI(
+			ctx, appCfg, database, full, progress,
+			func() (sync.RebuildOptions, sync.RebuildCleanup, error) {
+				prepared, err := prepareConfiguredHTTPHosts(
+					ctx, appCfg, database, httpHosts, progress,
+				)
+				if err != nil {
+					return sync.RebuildOptions{}, prepared, err
+				}
+				if prepared == nil {
+					return sync.RebuildOptions{}, nil, nil
+				}
+				contributors, release, err := prepared.BorrowRebuildContributors()
+				if err != nil {
+					return sync.RebuildOptions{}, prepared, err
+				}
+				return sync.RebuildOptions{Contributors: contributors},
+					&preparedHTTPRebuildLeaseCLI{
+						prepared: prepared,
+						release:  release,
+					}, nil
+			},
+			func(forceFull, rebuilt bool) error {
+				remoteHosts := hosts
+				if rebuilt {
+					remoteHosts = sshHosts
+				}
+				var blocked error
+				failures, blocked = runRemoteHosts(
+					remoteHosts, forceFull,
+					func(rh config.RemoteHost, remoteFull bool) error {
+						_, err := runRemoteSyncTransport(
+							ctx, appCfg, database, rh, remoteFull,
+						)
+						return err
+					},
+				)
+				return blocked
+			},
+		)
+		return remotesync.SyncStats{}, err
+	}
+
+	var coordinatorErr error
+	if outerOwnsHTTP {
+		_, coordinatorErr = httpRemoteCleanupRegistry.Run(run)
+	} else {
+		_, coordinatorErr = run()
+	}
+	if coordinatorErr == nil {
+		return didResync, failures, nil
+	}
+	var pending *remotesync.PendingCleanupError
+	if errors.As(coordinatorErr, &pending) {
+		return didResync, failures, coordinatorErr
+	}
+	if failure, ok := configuredHTTPCoordinatorFailure(
+		httpHosts, coordinatorErr,
+	); ok {
+		failures = append(failures, failure)
+		return didResync, failures, nil
+	}
+	return didResync, failures, coordinatorErr
+}
+
+var runConfiguredLocalAndRemotesCLI = runConfiguredLocalAndRemotes
+
+func partitionConfiguredRemoteHosts(
+	hosts []config.RemoteHost,
+) (httpHosts, sshHosts []config.RemoteHost) {
+	for _, host := range hosts {
+		if host.Transport == config.RemoteTransportHTTP {
+			httpHosts = append(httpHosts, host)
+		} else {
+			sshHosts = append(sshHosts, host)
+		}
+	}
+	return httpHosts, sshHosts
+}
+
+func prepareConfiguredHTTPHosts(
+	ctx context.Context,
+	appCfg config.Config,
+	database *db.DB,
+	hosts []config.RemoteHost,
+	progress sync.ProgressFunc,
+) (preparedHTTPRebuildCLI, error) {
+	if len(hosts) == 0 {
+		return nil, nil
+	}
+	syncs := make([]remotesync.HTTPSync, 0, len(hosts))
+	for _, host := range hosts {
+		if host.Token == "" {
+			return nil, &remotesync.HostError{
+				Host:      host.Host,
+				Operation: "authenticate",
+				Err:       errors.New("HTTP remote sync token is required"),
+			}
+		}
+		syncs = append(syncs, remotesync.HTTPSync{
+			Host:                    host.Host,
+			URL:                     host.URL,
+			Token:                   host.Token,
+			Full:                    true,
+			DataDir:                 appCfg.DataDir,
+			DB:                      database,
+			BlockedResultCategories: appCfg.ResultContentBlockedCategories,
+			Progress:                progress,
+		})
+	}
+	return prepareHTTPRebuildCLI(ctx, syncs)
+}
+
+func configuredHTTPCoordinatorFailure(
+	hosts []config.RemoteHost,
+	err error,
+) (remoteHostFailure, bool) {
+	var pending *remotesync.PendingCleanupError
+	if errors.As(err, &pending) {
+		return remoteHostFailure{}, false
+	}
+	primary := primaryCoordinatorError(err)
+	var hostName string
+	failureErr := primary
+	var contributorErr *sync.RebuildContributorError
+	if errors.As(primary, &contributorErr) {
+		hostName = contributorErr.Contributor
+		failureErr = contributorErr.Err
+	} else {
+		var hostErr *remotesync.HostError
+		if errors.As(primary, &hostErr) {
+			hostName = hostErr.Host
+		}
+	}
+	for _, host := range hosts {
+		if host.Host == hostName {
+			return remoteHostFailure{Host: host, Err: failureErr}, true
+		}
+	}
+	return remoteHostFailure{}, false
+}
+
+func primaryCoordinatorError(err error) error {
+	for err != nil {
+		if joined, ok := err.(interface{ Unwrap() []error }); ok {
+			children := joined.Unwrap()
+			var first error
+			for _, child := range children {
+				if child != nil {
+					first = child
+					break
+				}
+			}
+			if first == nil {
+				return err
+			}
+			err = first
+			continue
+		}
+		switch err.(type) {
+		case *sync.RebuildContributorError, *remotesync.HostError:
+			return err
+		}
+		unwrapped := errors.Unwrap(err)
+		if unwrapped == nil {
+			return err
+		}
+		err = unwrapped
+	}
+	return nil
+}
+
 // runLocalSync runs a local sync (incremental or full resync).
 // It returns true if a full resync was performed, which callers
 // can use to force a full PG push (watermarks become stale after
@@ -460,6 +721,88 @@ func remoteFailureDisplay(f remoteHostFailure) string {
 func runLocalSync(
 	ctx context.Context, appCfg config.Config, database *db.DB, full bool,
 ) bool {
+	didResync := full || database.NeedsResync()
+	var progress sync.ProgressFunc
+	var resyncProgress *resyncProgressPrinter
+	if didResync {
+		fmt.Println("Data version changed, running full resync...")
+		resyncProgress = newResyncProgressPrinter(os.Stdout, time.Now)
+		progress = resyncProgress.Print
+	} else {
+		fmt.Println("Running initial sync...")
+		progress = printSyncProgress
+	}
+	started := time.Now()
+	didResync, stats, err := coordinateLocalSync(
+		ctx, appCfg, database, full, progress, true,
+		func() (sync.RebuildOptions, sync.RebuildCleanup, error) {
+			return sync.RebuildOptions{}, nil, nil
+		},
+		func(bool, bool) error { return nil },
+	)
+	if resyncProgress != nil {
+		resyncProgress.Finish()
+	}
+	if err != nil {
+		log.Printf("local sync failed: %v", err)
+	}
+	printDirectSyncResult(ctx, database, stats, started)
+	return didResync
+}
+
+func runLocalSyncWithRebuild(
+	ctx context.Context,
+	appCfg config.Config,
+	database *db.DB,
+	full bool,
+	progress sync.ProgressFunc,
+	prepare func() (sync.RebuildOptions, sync.RebuildCleanup, error),
+	work func(forceFull, rebuilt bool) error,
+) (didResync bool, err error) {
+	started := time.Now()
+	didResync, stats, err := coordinateLocalSync(
+		ctx, appCfg, database, full, progress, false, prepare, work,
+	)
+	if err != nil {
+		return didResync, err
+	}
+	printDirectSyncResult(ctx, database, stats, started)
+	return didResync, nil
+}
+
+func runLocalSyncWithFallback(
+	ctx context.Context,
+	appCfg config.Config,
+	database *db.DB,
+	full bool,
+	progress sync.ProgressFunc,
+	work func(forceFull bool) error,
+) (didResync bool, err error) {
+	started := time.Now()
+	didResync, stats, err := coordinateLocalSync(
+		ctx, appCfg, database, full, progress, true,
+		func() (sync.RebuildOptions, sync.RebuildCleanup, error) {
+			return sync.RebuildOptions{}, nil, nil
+		},
+		func(forceFull, _ bool) error { return work(forceFull) },
+	)
+	if err != nil {
+		return didResync, err
+	}
+	printDirectSyncResult(ctx, database, stats, started)
+	return didResync, nil
+}
+
+func coordinateLocalSync(
+	ctx context.Context,
+	appCfg config.Config,
+	database *db.DB,
+	full bool,
+	progress sync.ProgressFunc,
+	fallbackOnAbort bool,
+	prepare func() (sync.RebuildOptions, sync.RebuildCleanup, error),
+	work func(forceFull, rebuilt bool) error,
+) (didResync bool, stats sync.SyncStats, err error) {
 	for _, def := range parser.Registry {
 		if !appCfg.IsUserConfigured(def.Type) {
 			continue
@@ -480,28 +823,47 @@ func runLocalSync(
 	})
 	defer engine.Close()
 
-	didResync := full || database.NeedsResync()
-	// No startup state writer: this is a one-shot CLI sync, not a
-	// daemon startup, so there is no start lock for status to read
-	// under.
-	if didResync {
-		runInitialResync(ctx, engine, nil)
+	didResync = full || database.NeedsResync()
+	if fallbackOnAbort {
+		stats, err = engine.SyncThenRun(
+			ctx, full, progress,
+			func(forceFull bool) error { return work(forceFull, didResync) },
+		)
 	} else {
-		runInitialSync(ctx, engine, nil)
+		stats, err = engine.SyncThenRunWithRebuild(
+			ctx, full, progress, prepare, work,
+		)
 	}
 	engine.PhaseStats().Log("sync")
+	if err != nil {
+		return didResync, stats, err
+	}
+	if stats.Aborted && !fallbackOnAbort {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return didResync, stats, ctxErr
+		}
+		return didResync, stats, errUnifiedRebuildAborted
+	}
+	return didResync, stats, nil
+}
 
+func printDirectSyncResult(
+	ctx context.Context,
+	database *db.DB,
+	stats sync.SyncStats,
+	started time.Time,
+) {
+	printSyncSummary(stats, started)
 	fmt.Println()
-	stats, err := database.GetStats(
+	databaseStats, err := database.GetStats(
 		ctx, false, false,
 	)
 	if err == nil {
 		fmt.Printf(
 			"Database: %d sessions, %d messages\n",
-			stats.SessionCount, stats.MessageCount,
+			databaseStats.SessionCount, databaseStats.MessageCount,
 		)
 	}
-	return didResync
 }
 
 func runDaemonSync(
@@ -603,7 +965,7 @@ func runDaemonRemoteSync(
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		return nil, err
 	}
-	return remoteFailuresFromResponse(out), nil
+	return daemonRemoteSyncResult(out)
 }
 
 type daemonRemoteSyncResponse struct {
@@ -611,6 +973,20 @@ type daemonRemoteSyncResponse struct {
 		Host config.RemoteHost `json:"host"`
 		Err  string            `json:"error"`
 	} `json:"failures"`
+	Error string `json:"error"`
+}
+
+func daemonRemoteSyncResult(
+	out daemonRemoteSyncResponse,
+) ([]remoteHostFailure, error) {
+	failures := remoteFailuresFromResponse(out)
+	if out.Error != "" {
+		if out.Error == sync.ErrUnifiedRebuildAborted.Error() {
+			return failures, sync.ErrUnifiedRebuildAborted
+		}
+		return failures, errors.New(out.Error)
+	}
+	return failures, nil
 }
 
 func remoteFailuresFromResponse(
@@ -643,7 +1019,7 @@ func parseDaemonRemoteSyncSSE(
 				if err := json.Unmarshal([]byte(data.String()), &out); err != nil {
 					return nil, err
 				}
-				return remoteFailuresFromResponse(out), nil
+				return daemonRemoteSyncResult(out)
 			case "progress":
 				if data.Len() > 0 {
 					if err := reportDaemonSyncProgress(data.String(), onProgress); err != nil {
@@ -688,7 +1064,7 @@ func parseDaemonRemoteSyncSSE(
 		if err := json.Unmarshal([]byte(data.String()), &out); err != nil {
 			return nil, err
 		}
-		return remoteFailuresFromResponse(out), nil
+		return daemonRemoteSyncResult(out)
 	}
 	if lastNonDoneData != "" {
 		return nil, fmt.Errorf("daemon remote sync error: %s", lastNonDoneData)

--- a/cmd/agentsview/sync_test.go
+++ b/cmd/agentsview/sync_test.go
@@ -12,9 +12,11 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -23,10 +25,791 @@ import (
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/remotesync"
 	agentsync "go.kenn.io/agentsview/internal/sync"
+	"go.kenn.io/agentsview/internal/testjsonl"
 	"go.kenn.io/kit/daemon"
 )
+
+type fakeCLIPreparedHTTPRebuild struct {
+	contributors  []agentsync.RebuildContributor
+	closed        int
+	released      bool
+	closeReleased bool
+}
+
+type cliLifecycleError struct{ err error }
+
+func (e *cliLifecycleError) Error() string { return "lifecycle: " + e.err.Error() }
+func (e *cliLifecycleError) Unwrap() error { return e.err }
+
+func (p *fakeCLIPreparedHTTPRebuild) BorrowRebuildContributors() (
+	[]agentsync.RebuildContributor, func(), error,
+) {
+	return p.contributors, func() { p.released = true }, nil
+}
+
+func (p *fakeCLIPreparedHTTPRebuild) Close() error {
+	p.closed++
+	p.closeReleased = p.released
+	return nil
+}
+
+func newDirectSyncFixture(t *testing.T) (config.Config, *db.DB) {
+	t.Helper()
+	dataDir := t.TempDir()
+	localRoot := filepath.Join(dataDir, "local-claude")
+	require.NoError(t, os.MkdirAll(filepath.Join(localRoot, "project"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(localRoot, "project", "session.jsonl"),
+		[]byte(testjsonl.NewSessionBuilder().
+			AddClaudeUser("2026-07-12T00:00:00Z", "local direct sync").
+			String()),
+		0o600,
+	))
+	cfg := config.Config{
+		DataDir: dataDir,
+		DBPath:  filepath.Join(dataDir, "sessions.db"),
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {localRoot},
+		},
+	}
+	database, err := db.Open(cfg.DBPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	return cfg, database
+}
+
+func isolateDirectCLISources(t *testing.T) {
+	t.Helper()
+	root := t.TempDir()
+	t.Setenv("HOME", root)
+	for _, def := range parser.Registry {
+		if def.EnvVar != "" {
+			t.Setenv(def.EnvVar, filepath.Join(root, string(def.Type)))
+		}
+		if def.DefaultRootEnvVar != "" {
+			t.Setenv(def.DefaultRootEnvVar, root)
+		}
+	}
+}
+
+func TestDoSyncConfiguredFullUsesUnifiedHTTPContributorBeforeSSH(t *testing.T) {
+	cfg, database := newDirectSyncFixture(t)
+	httpHost := config.RemoteHost{
+		Host: "http-box", Transport: config.RemoteTransportHTTP,
+		URL: "http://127.0.0.1:1", Token: "token",
+	}
+	sshHost := config.RemoteHost{Host: "ssh-box"}
+	var order []string
+	prepared := &fakeCLIPreparedHTTPRebuild{contributors: []agentsync.RebuildContributor{{
+		Name: "http-box",
+		AfterSync: func(*agentsync.Engine, *db.DB) error {
+			order = append(order, "http contributor")
+			return nil
+		},
+	}}}
+	originalPrepare := prepareHTTPRebuildCLI
+	prepareHTTPRebuildCLI = func(
+		context.Context, []remotesync.HTTPSync,
+	) (preparedHTTPRebuildCLI, error) {
+		order = append(order, "prepare")
+		return prepared, nil
+	}
+	t.Cleanup(func() { prepareHTTPRebuildCLI = originalPrepare })
+	originalSSH := runSSHRemoteSync
+	runSSHRemoteSync = func(
+		_ context.Context, _ config.Config, _ *db.DB,
+		rh config.RemoteHost, full bool,
+	) (remotesync.SyncStats, error) {
+		order = append(order, "ssh")
+		assert.Equal(t, sshHost, rh)
+		assert.True(t, full)
+		return remotesync.SyncStats{}, nil
+	}
+	t.Cleanup(func() { runSSHRemoteSync = originalSSH })
+
+	didResync, failures, err := runConfiguredLocalAndRemotes(
+		context.Background(), cfg, database,
+		[]config.RemoteHost{sshHost, httpHost}, true, nil,
+	)
+
+	require.NoError(t, err)
+	assert.True(t, didResync)
+	assert.Empty(t, failures)
+	assert.Equal(t, []string{"prepare", "http contributor", "ssh"}, order)
+	assert.Equal(t, 1, prepared.closed)
+	assert.True(t, prepared.closeReleased,
+		"contributor borrow must release before prepared sources close")
+}
+
+func TestDoSyncConfiguredFullSSHOnlyFallsBackBeforeRemoteImport(t *testing.T) {
+	cfg, database := newDirectSyncFixture(t)
+	for _, roots := range cfg.AgentDirs {
+		for _, root := range roots {
+			require.NoError(t, os.RemoveAll(root))
+		}
+	}
+	missingPath := filepath.Join(t.TempDir(), "missing-remote.jsonl")
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "preserved-ssh-session", Project: "archive", Machine: "ssh-box",
+		Agent: "claude", FilePath: &missingPath, MessageCount: 1,
+	}))
+	sshHost := config.RemoteHost{Host: "ssh-box"}
+	sshCalls := 0
+	originalSSH := runSSHRemoteSync
+	runSSHRemoteSync = func(
+		_ context.Context, _ config.Config, _ *db.DB,
+		rh config.RemoteHost, full bool,
+	) (remotesync.SyncStats, error) {
+		sshCalls++
+		assert.Equal(t, sshHost, rh)
+		assert.True(t, full)
+		return remotesync.SyncStats{}, nil
+	}
+	t.Cleanup(func() { runSSHRemoteSync = originalSSH })
+
+	didResync, failures, err := runConfiguredLocalAndRemotes(
+		context.Background(), cfg, database,
+		[]config.RemoteHost{sshHost}, true, nil,
+	)
+
+	require.NoError(t, err)
+	assert.True(t, didResync)
+	assert.Empty(t, failures)
+	assert.Equal(t, 1, sshCalls,
+		"SSH import must run after the legacy local fallback")
+	preserved, err := database.GetSession(context.Background(), "preserved-ssh-session")
+	require.NoError(t, err)
+	assert.NotNil(t, preserved)
+}
+
+func TestDoSyncAutomaticResyncUsesUnifiedHTTPContributor(t *testing.T) {
+	cfg, database := newDirectSyncFixture(t)
+	require.NoError(t, database.Close())
+	raw, err := sql.Open("sqlite3", cfg.DBPath)
+	require.NoError(t, err)
+	_, err = raw.Exec("PRAGMA user_version = 0")
+	require.NoError(t, err)
+	require.NoError(t, raw.Close())
+	database, err = db.Open(cfg.DBPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	require.True(t, database.NeedsResync())
+
+	prepared := &fakeCLIPreparedHTTPRebuild{}
+	prepareCalls := 0
+	originalPrepare := prepareHTTPRebuildCLI
+	prepareHTTPRebuildCLI = func(
+		context.Context, []remotesync.HTTPSync,
+	) (preparedHTTPRebuildCLI, error) {
+		prepareCalls++
+		return prepared, nil
+	}
+	t.Cleanup(func() { prepareHTTPRebuildCLI = originalPrepare })
+
+	didResync, failures, err := runConfiguredLocalAndRemotes(
+		context.Background(), cfg, database,
+		[]config.RemoteHost{{
+			Host: "http-box", Transport: config.RemoteTransportHTTP,
+			URL: "http://127.0.0.1:1", Token: "token",
+		}}, false, nil,
+	)
+
+	require.NoError(t, err)
+	assert.True(t, didResync)
+	assert.Empty(t, failures)
+	assert.Equal(t, 1, prepareCalls)
+	assert.False(t, database.NeedsResync())
+}
+
+func TestDoSyncPreparationFailureMapsRemoteAndSkipsSSH(t *testing.T) {
+	cfg, database := newDirectSyncFixture(t)
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "preserved", Project: "archive", Machine: "local", Agent: "codex",
+	}))
+	prepCause := errors.New("manifest unavailable")
+	prepared := &fakeCLIPreparedHTTPRebuild{}
+	originalPrepare := prepareHTTPRebuildCLI
+	prepareHTTPRebuildCLI = func(
+		context.Context, []remotesync.HTTPSync,
+	) (preparedHTTPRebuildCLI, error) {
+		return prepared, &remotesync.HostError{
+			Host: "http-box", Operation: "prepare", Err: prepCause,
+		}
+	}
+	t.Cleanup(func() { prepareHTTPRebuildCLI = originalPrepare })
+	sshCalls := 0
+	originalSSH := runSSHRemoteSync
+	runSSHRemoteSync = func(
+		context.Context, config.Config, *db.DB, config.RemoteHost, bool,
+	) (remotesync.SyncStats, error) {
+		sshCalls++
+		return remotesync.SyncStats{}, nil
+	}
+	t.Cleanup(func() { runSSHRemoteSync = originalSSH })
+
+	didResync, failures, err := runConfiguredLocalAndRemotes(
+		context.Background(), cfg, database, []config.RemoteHost{
+			{Host: "http-box", Transport: config.RemoteTransportHTTP,
+				URL: "http://127.0.0.1:1", Token: "token"},
+			{Host: "ssh-box"},
+		}, true, nil,
+	)
+
+	require.NoError(t, err)
+	assert.True(t, didResync)
+	require.Len(t, failures, 1)
+	assert.Equal(t, "http-box", failures[0].Host.Host)
+	assert.ErrorIs(t, failures[0].Err, prepCause)
+	assert.Equal(t, 0, sshCalls)
+	assert.Equal(t, 1, prepared.closed,
+		"partial preparation ownership must be closed on failure")
+	preserved, getErr := database.GetSession(context.Background(), "preserved")
+	require.NoError(t, getErr)
+	assert.NotNil(t, preserved, "failed preparation must not swap")
+}
+
+func TestDoSyncContributorFailureMapsRemotePreservesCauseAndSkipsSSH(t *testing.T) {
+	cfg, database := newDirectSyncFixture(t)
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "preserved", Project: "archive", Machine: "local", Agent: "codex",
+	}))
+	cause := errors.New("cache snapshot failed")
+	prepared := &fakeCLIPreparedHTTPRebuild{contributors: []agentsync.RebuildContributor{{
+		Name:      "http-box",
+		AfterSync: func(*agentsync.Engine, *db.DB) error { return cause },
+	}}}
+	originalPrepare := prepareHTTPRebuildCLI
+	prepareHTTPRebuildCLI = func(
+		context.Context, []remotesync.HTTPSync,
+	) (preparedHTTPRebuildCLI, error) {
+		return prepared, nil
+	}
+	t.Cleanup(func() { prepareHTTPRebuildCLI = originalPrepare })
+	sshCalls := 0
+	originalSSH := runSSHRemoteSync
+	runSSHRemoteSync = func(
+		context.Context, config.Config, *db.DB, config.RemoteHost, bool,
+	) (remotesync.SyncStats, error) {
+		sshCalls++
+		return remotesync.SyncStats{}, nil
+	}
+	t.Cleanup(func() { runSSHRemoteSync = originalSSH })
+
+	didResync, failures, err := runConfiguredLocalAndRemotes(
+		context.Background(), cfg, database, []config.RemoteHost{
+			{Host: "http-box", Transport: config.RemoteTransportHTTP,
+				URL: "http://127.0.0.1:1", Token: "token"},
+			{Host: "ssh-box"},
+		}, true, nil,
+	)
+
+	require.NoError(t, err)
+	assert.True(t, didResync)
+	require.Len(t, failures, 1)
+	assert.Equal(t, "http-box", failures[0].Host.Host)
+	assert.ErrorIs(t, failures[0].Err, cause)
+	assert.Equal(t, 0, sshCalls)
+	preserved, getErr := database.GetSession(context.Background(), "preserved")
+	require.NoError(t, getErr)
+	assert.NotNil(t, preserved, "failed contributor must not swap")
+}
+
+func TestDoSyncUnknownCoordinatorFailureRemainsLocalError(t *testing.T) {
+	cfg, database := newDirectSyncFixture(t)
+	cause := errors.New("temporary database unavailable")
+	originalPrepare := prepareHTTPRebuildCLI
+	prepareHTTPRebuildCLI = func(
+		context.Context, []remotesync.HTTPSync,
+	) (preparedHTTPRebuildCLI, error) {
+		return nil, cause
+	}
+	t.Cleanup(func() { prepareHTTPRebuildCLI = originalPrepare })
+
+	_, failures, err := runConfiguredLocalAndRemotes(
+		context.Background(), cfg, database, []config.RemoteHost{{
+			Host: "http-box", Transport: config.RemoteTransportHTTP,
+			URL: "http://127.0.0.1:1", Token: "token",
+		}}, true, nil,
+	)
+
+	assert.Empty(t, failures)
+	assert.ErrorIs(t, err, cause)
+}
+
+func TestConfiguredHTTPCoordinatorFailureUsesPrimaryOperationOnly(t *testing.T) {
+	hosts := []config.RemoteHost{
+		{Host: "alpha", Transport: config.RemoteTransportHTTP},
+		{Host: "cleanup", Transport: config.RemoteTransportHTTP},
+	}
+	localCause := errors.New("local database failed")
+	prepCause := errors.New("alpha manifest failed")
+	contributorCause := errors.New("alpha contributor failed")
+	cleanupCause := errors.New("cleanup failed")
+	cleanupHost := &remotesync.HostError{
+		Host: "cleanup", Operation: "cleanup", Err: cleanupCause,
+	}
+	tests := []struct {
+		name     string
+		err      error
+		wantHost string
+		wantIs   error
+		wantMap  bool
+	}{
+		{
+			name: "pending cleanup wrapping prior host stays coordinator error",
+			err: &remotesync.PendingCleanupError{Err: &remotesync.HostError{
+				Host: "alpha", Operation: "prepare", Err: prepCause,
+			}},
+			wantIs: prepCause,
+		},
+		{
+			name:    "secondary cleanup host cannot steal local failure",
+			err:     errors.Join(localCause, cleanupHost),
+			wantIs:  localCause,
+			wantMap: false,
+		},
+		{
+			name: "primary preparation host wins over cleanup host",
+			err: &cliLifecycleError{err: errors.Join(
+				&remotesync.HostError{
+					Host: "alpha", Operation: "prepare", Err: prepCause,
+				},
+				cleanupHost,
+			)},
+			wantHost: "alpha",
+			wantIs:   prepCause,
+			wantMap:  true,
+		},
+		{
+			name: "primary contributor wins over cleanup host",
+			err: errors.Join(&agentsync.RebuildContributorError{
+				Contributor: "alpha", Err: contributorCause,
+			}, cleanupHost),
+			wantHost: "alpha",
+			wantIs:   contributorCause,
+			wantMap:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			failure, ok := configuredHTTPCoordinatorFailure(hosts, tt.err)
+			assert.Equal(t, tt.wantMap, ok)
+			assert.ErrorIs(t, tt.err, tt.wantIs)
+			if tt.wantMap {
+				assert.Equal(t, tt.wantHost, failure.Host.Host)
+				assert.ErrorIs(t, failure.Err, tt.wantIs)
+			}
+		})
+	}
+}
+
+func TestRunConfiguredLocalAndRemotesKeepsPendingCleanupBlocked(t *testing.T) {
+	cfg, database := newDirectSyncFixture(t)
+	pendingCause := errors.New("prior alpha cleanup")
+	pending := &remotesync.PendingCleanupError{Err: &remotesync.HostError{
+		Host: "http-box", Operation: "cleanup", Err: pendingCause,
+	}}
+	originalRun := runLocalSyncWithRebuildCLI
+	runLocalSyncWithRebuildCLI = func(
+		context.Context, config.Config, *db.DB, bool, agentsync.ProgressFunc,
+		func() (agentsync.RebuildOptions, agentsync.RebuildCleanup, error),
+		func(bool, bool) error,
+	) (bool, error) {
+		return true, pending
+	}
+	t.Cleanup(func() { runLocalSyncWithRebuildCLI = originalRun })
+
+	_, failures, err := runConfiguredLocalAndRemotes(
+		context.Background(), cfg, database, []config.RemoteHost{{
+			Host: "http-box", Transport: config.RemoteTransportHTTP,
+			URL: "http://127.0.0.1:1", Token: "token",
+		}}, true, nil,
+	)
+
+	assert.Empty(t, failures)
+	var gotPending *remotesync.PendingCleanupError
+	require.ErrorAs(t, err, &gotPending)
+	assert.ErrorIs(t, err, pendingCause)
+}
+
+func TestRunLocalSyncWithRebuildReturnsAbortedSentinelWithoutSummary(t *testing.T) {
+	dataDir := t.TempDir()
+	cfg := config.Config{DataDir: dataDir, DBPath: filepath.Join(dataDir, "sessions.db")}
+	database, err := db.Open(cfg.DBPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	missingPath := filepath.Join(dataDir, "missing.jsonl")
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "old-file-session", Agent: "claude", Machine: "local",
+		Project: "preserved", FilePath: &missingPath, MessageCount: 1,
+	}))
+	workCalls := 0
+	var runErr error
+	out := captureStdout(t, func() {
+		_, runErr = runLocalSyncWithRebuild(
+			context.Background(), cfg, database, true, nil,
+			func() (agentsync.RebuildOptions, agentsync.RebuildCleanup, error) {
+				return agentsync.RebuildOptions{Contributors: []agentsync.RebuildContributor{{
+					Name: "http-box",
+				}}}, nil, nil
+			},
+			func(bool, bool) error {
+				workCalls++
+				return nil
+			},
+		)
+	})
+
+	assert.ErrorIs(t, runErr, errUnifiedRebuildAborted)
+	assert.Equal(t, 0, workCalls)
+	assert.NotContains(t, out, "Sync complete")
+	preserved, getErr := database.GetSession(context.Background(), "old-file-session")
+	require.NoError(t, getErr)
+	assert.NotNil(t, preserved)
+}
+
+func TestRunLocalSyncWithRebuildCancellationPreservesContextError(t *testing.T) {
+	cfg, database := newDirectSyncFixture(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var runErr error
+	out := captureStdout(t, func() {
+		_, runErr = runLocalSyncWithRebuild(
+			ctx, cfg, database, true, nil,
+			func() (agentsync.RebuildOptions, agentsync.RebuildCleanup, error) {
+				return agentsync.RebuildOptions{Contributors: []agentsync.RebuildContributor{{
+					Name: "http-box",
+				}}}, nil, nil
+			},
+			func(bool, bool) error { return nil },
+		)
+	})
+
+	assert.ErrorIs(t, runErr, context.Canceled)
+	assert.NotErrorIs(t, runErr, errUnifiedRebuildAborted)
+	assert.NotContains(t, out, "Sync complete")
+}
+
+func TestRunLocalSyncZeroContributorRetainsAbortFallback(t *testing.T) {
+	dataDir := t.TempDir()
+	cfg := config.Config{DataDir: dataDir, DBPath: filepath.Join(dataDir, "sessions.db")}
+	database, err := db.Open(cfg.DBPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	missingPath := filepath.Join(dataDir, "missing.jsonl")
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "old-file-session", Agent: "claude", Machine: "local",
+		Project: "preserved", FilePath: &missingPath, MessageCount: 1,
+	}))
+
+	didResync := runLocalSync(context.Background(), cfg, database, true)
+
+	assert.True(t, didResync)
+	preserved, getErr := database.GetSession(context.Background(), "old-file-session")
+	require.NoError(t, getErr)
+	assert.NotNil(t, preserved,
+		"legacy zero-contributor fallback must keep the active archive")
+}
+
+func TestDoSyncConfiguredFullUnifiedHTTPUsesManifestDeltaAndOrderedProgress(
+	t *testing.T,
+) {
+	cfg, database := newDirectSyncFixture(t)
+	remoteRoot := filepath.Join(t.TempDir(), "remote-claude")
+	require.NoError(t, os.MkdirAll(filepath.Join(remoteRoot, "project"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(remoteRoot, "project", "remote.jsonl"),
+		[]byte(testjsonl.NewSessionBuilder().
+			AddClaudeUser("2026-07-12T01:00:00Z", "remote direct sync").
+			String()),
+		0o600,
+	))
+	targets := remotesync.TargetSet{Dirs: map[parser.AgentType][]string{
+		parser.AgentClaude: {remoteRoot},
+	}}
+	var archiveRequests atomic.Int32
+	remote := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/remote-sync/targets":
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(targets); err != nil {
+				http.Error(w, "encode targets", http.StatusInternalServerError)
+			}
+		case "/api/v1/remote-sync/manifest":
+			var requested remotesync.TargetSet
+			if err := json.NewDecoder(r.Body).Decode(&requested); err != nil {
+				http.Error(w, "decode manifest request", http.StatusBadRequest)
+				return
+			}
+			manifest, err := remotesync.BuildManifest(requested)
+			if err != nil {
+				http.Error(w, "build manifest", http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(manifest); err != nil {
+				http.Error(w, "encode manifest", http.StatusInternalServerError)
+			}
+		case "/api/v1/remote-sync/archive":
+			archiveRequests.Add(1)
+			var requested remotesync.ArchiveRequest
+			if err := json.NewDecoder(r.Body).Decode(&requested); err != nil {
+				http.Error(w, "decode archive request", http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/x-tar")
+			var err error
+			if requested.DeltaFiles != nil {
+				err = remotesync.WriteArchiveFiles(
+					w, targets.DeltaAllowedRoots(), requested.DeltaFiles,
+				)
+			} else {
+				err = remotesync.WriteArchive(w, requested.TargetSet)
+			}
+			if err != nil {
+				http.Error(w, "write archive", http.StatusInternalServerError)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(remote.Close)
+	host := config.RemoteHost{
+		Host: "http-box", Transport: config.RemoteTransportHTTP,
+		URL: remote.URL, Token: "remote-token",
+	}
+	now := time.Date(2026, 7, 12, 1, 0, 0, 0, time.UTC)
+	printer := newRemoteProgressPrinter(&bytes.Buffer{}, func() time.Time {
+		now = now.Add(time.Millisecond)
+		return now
+	})
+	var output bytes.Buffer
+	printer.w = &output
+
+	didResync, failures, err := runConfiguredLocalAndRemotes(
+		context.Background(), cfg, database, []config.RemoteHost{host},
+		true, printer.Print,
+	)
+	printer.Finish()
+	require.NoError(t, err)
+	assert.True(t, didResync)
+	assert.Empty(t, failures)
+	assert.Equal(t, int32(1), archiveRequests.Load())
+	page, err := database.ListSessions(context.Background(), db.SessionFilter{Limit: 10})
+	require.NoError(t, err)
+	assert.Len(t, page.Sessions, 2)
+
+	progressOutput := output.String()
+	labels := []string{
+		"Downloading session archive from http-box",
+		"Extracting session archive from http-box",
+		"Processing sessions from http-box",
+		"Rebuilding search index",
+		"Swapping rebuilt database into place",
+	}
+	previous := -1
+	for _, label := range labels {
+		position := strings.Index(progressOutput, label)
+		require.Greater(t, position, previous, "progress output: %s", progressOutput)
+		previous = position
+	}
+	assert.Contains(t, progressOutput,
+		"Swapping rebuilt database into place completed in")
+
+	_, failures, err = runConfiguredLocalAndRemotes(
+		context.Background(), cfg, database, []config.RemoteHost{host},
+		true, nil,
+	)
+	require.NoError(t, err)
+	assert.Empty(t, failures)
+	assert.Equal(t, int32(1), archiveRequests.Load(),
+		"unchanged full rebuild must not request a second archive")
+}
+
+func TestDoSyncIncrementalKeepsOrdinaryRemotePath(t *testing.T) {
+	cfg, database := newDirectSyncFixture(t)
+	host := config.RemoteHost{
+		Host: "http-box", Transport: config.RemoteTransportHTTP,
+		URL: "http://127.0.0.1:1", Token: "token",
+	}
+	prepareCalls := 0
+	originalPrepare := prepareHTTPRebuildCLI
+	prepareHTTPRebuildCLI = func(
+		context.Context, []remotesync.HTTPSync,
+	) (preparedHTTPRebuildCLI, error) {
+		prepareCalls++
+		return &fakeCLIPreparedHTTPRebuild{}, nil
+	}
+	t.Cleanup(func() { prepareHTTPRebuildCLI = originalPrepare })
+	activeCalls := 0
+	restore := stubHTTPRemoteSyncForTest(t, func(
+		_ context.Context, got config.RemoteHost, full bool,
+	) (remotesync.SyncStats, error) {
+		activeCalls++
+		assert.Equal(t, host, got)
+		assert.False(t, full)
+		return remotesync.SyncStats{}, nil
+	})
+	t.Cleanup(restore)
+
+	didResync, failures, err := runConfiguredLocalAndRemotes(
+		context.Background(), cfg, database, []config.RemoteHost{host}, false, nil,
+	)
+
+	require.NoError(t, err)
+	assert.False(t, didResync)
+	assert.Empty(t, failures)
+	assert.Equal(t, 0, prepareCalls)
+	assert.Equal(t, 1, activeCalls)
+}
+
+func TestDoSyncPreparationFailureReturnsRemoteFailureOutcome(t *testing.T) {
+	env := newSyncCLIEnv(t)
+	t.Setenv("AGENTSVIEW_NO_DAEMON", "1")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(env.DataDir, "config.toml"),
+		[]byte(`[[remote_hosts]]
+host = "http-box"
+transport = "http"
+url = "http://127.0.0.1:1"
+token = "remote-token"
+`),
+		0o600,
+	))
+	originalPrepare := prepareHTTPRebuildCLI
+	prepareHTTPRebuildCLI = func(
+		context.Context, []remotesync.HTTPSync,
+	) (preparedHTTPRebuildCLI, error) {
+		return nil, &remotesync.HostError{
+			Host: "http-box", Operation: "prepare", Err: errors.New("offline"),
+		}
+	}
+	t.Cleanup(func() { prepareHTTPRebuildCLI = originalPrepare })
+
+	hadRemoteFailures := doSync(SyncConfig{Full: true})
+
+	assert.True(t, hadRemoteFailures)
+}
+
+func TestDoSyncContributorFailureReturnsRemoteFailureOutcome(t *testing.T) {
+	env := newSyncCLIEnv(t)
+	t.Setenv("AGENTSVIEW_NO_DAEMON", "1")
+	isolateDirectCLISources(t)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(env.DataDir, "config.toml"),
+		[]byte(`[[remote_hosts]]
+host = "http-box"
+transport = "http"
+url = "http://127.0.0.1:1"
+token = "remote-token"
+`),
+		0o600,
+	))
+	cause := errors.New("persist remote cache")
+	prepared := &fakeCLIPreparedHTTPRebuild{contributors: []agentsync.RebuildContributor{{
+		Name:      "http-box",
+		AfterSync: func(*agentsync.Engine, *db.DB) error { return cause },
+	}}}
+	originalPrepare := prepareHTTPRebuildCLI
+	prepareHTTPRebuildCLI = func(
+		context.Context, []remotesync.HTTPSync,
+	) (preparedHTTPRebuildCLI, error) {
+		return prepared, nil
+	}
+	t.Cleanup(func() { prepareHTTPRebuildCLI = originalPrepare })
+	originalRegistry := httpRemoteCleanupRegistry
+	httpRemoteCleanupRegistry = new(remotesync.CleanupRegistry)
+	t.Cleanup(func() { httpRemoteCleanupRegistry = originalRegistry })
+
+	hadRemoteFailures := doSync(SyncConfig{Full: true})
+
+	assert.True(t, hadRemoteFailures)
+	assert.Equal(t, 1, prepared.closed)
+	assert.True(t, prepared.closeReleased)
+}
+
+func TestDoSyncAbortedUnifiedRebuildExitsNonZeroWithoutSuccessSummary(
+	t *testing.T,
+) {
+	dataDir := t.TempDir()
+	cmd := exec.Command(
+		os.Args[0],
+		"-test.run=^TestDoSyncAbortedUnifiedRebuildHelperProcess$",
+	)
+	cmd.Env = append(os.Environ(),
+		"AGENTSVIEW_ABORTED_UNIFIED_HELPER=1",
+		"AGENTSVIEW_NO_DAEMON=1",
+		"AGENTSVIEW_DATA_DIR="+dataDir,
+	)
+
+	out, err := cmd.CombinedOutput()
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	assert.Equal(t, 1, exitErr.ExitCode())
+	assert.Contains(t, string(out), "fatal: local sync: "+errUnifiedRebuildAborted.Error())
+	assert.NotContains(t, string(out), "Sync complete")
+}
+
+func TestDoSyncAbortedUnifiedRebuildHelperProcess(t *testing.T) {
+	if os.Getenv("AGENTSVIEW_ABORTED_UNIFIED_HELPER") != "1" {
+		return
+	}
+	dataDir := os.Getenv("AGENTSVIEW_DATA_DIR")
+	require.NotEmpty(t, dataDir)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dataDir, "config.toml"),
+		[]byte(`[[remote_hosts]]
+host = "http-box"
+transport = "http"
+url = "http://127.0.0.1:1"
+token = "remote-token"
+`),
+		0o600,
+	))
+	runConfiguredLocalAndRemotesCLI = func(
+		context.Context, config.Config, *db.DB, []config.RemoteHost,
+		bool, agentsync.ProgressFunc,
+	) (bool, []remoteHostFailure, error) {
+		return true, nil, errUnifiedRebuildAborted
+	}
+	doSync(SyncConfig{Full: true})
+	os.Exit(0)
+}
+
+func TestDoSyncSingleHostFullStaysOnActiveArchivePath(t *testing.T) {
+	newSyncCLIEnv(t)
+	t.Setenv("AGENTSVIEW_NO_DAEMON", "1")
+	prepareCalls := 0
+	originalPrepare := prepareHTTPRebuildCLI
+	prepareHTTPRebuildCLI = func(
+		context.Context, []remotesync.HTTPSync,
+	) (preparedHTTPRebuildCLI, error) {
+		prepareCalls++
+		return nil, nil
+	}
+	t.Cleanup(func() { prepareHTTPRebuildCLI = originalPrepare })
+	sshCalls := 0
+	originalSSH := runSSHRemoteSync
+	runSSHRemoteSync = func(
+		_ context.Context, _ config.Config, _ *db.DB,
+		rh config.RemoteHost, full bool,
+	) (remotesync.SyncStats, error) {
+		sshCalls++
+		assert.Equal(t, "one-box", rh.Host)
+		assert.True(t, full)
+		return remotesync.SyncStats{}, nil
+	}
+	t.Cleanup(func() { runSSHRemoteSync = originalSSH })
+
+	hadRemoteFailures := doSync(SyncConfig{Host: "one-box", Full: true})
+
+	assert.False(t, hadRemoteFailures)
+	assert.Equal(t, 0, prepareCalls)
+	assert.Equal(t, 1, sshCalls)
+}
 
 func TestRunRemoteHosts_AttemptsAllAndCollectsFailures(t *testing.T) {
 	hosts := []config.RemoteHost{
@@ -37,7 +820,7 @@ func TestRunRemoteHosts_AttemptsAllAndCollectsFailures(t *testing.T) {
 	failBeta := errors.New("ssh down")
 
 	var attempted []config.RemoteHost
-	failures := runRemoteHosts(hosts, true, func(rh config.RemoteHost, full bool) error {
+	failures, blocked := runRemoteHosts(hosts, true, func(rh config.RemoteHost, full bool) error {
 		attempted = append(attempted, rh)
 		assert.True(t, full, "full flag should propagate to syncFn")
 		if rh.Host == "beta" {
@@ -45,6 +828,7 @@ func TestRunRemoteHosts_AttemptsAllAndCollectsFailures(t *testing.T) {
 		}
 		return nil
 	})
+	require.NoError(t, blocked)
 
 	// Every host attempted, in declared order, even after a failure.
 	require.Equal(t, hosts, attempted)
@@ -56,9 +840,10 @@ func TestRunRemoteHosts_AttemptsAllAndCollectsFailures(t *testing.T) {
 
 func TestRunRemoteHosts_AllSucceedReturnsEmpty(t *testing.T) {
 	hosts := []config.RemoteHost{{Host: "alpha"}, {Host: "beta"}}
-	failures := runRemoteHosts(hosts, false, func(config.RemoteHost, bool) error {
+	failures, blocked := runRemoteHosts(hosts, false, func(config.RemoteHost, bool) error {
 		return nil
 	})
+	require.NoError(t, blocked)
 	assert.Empty(t, failures)
 }
 
@@ -126,6 +911,130 @@ func stubHTTPRemoteSyncForTest(
 	return func() { runHTTPRemoteSync = orig }
 }
 
+func TestRunRemoteSyncTransportRetainsFailedHTTPCleanupUntilReleased(t *testing.T) {
+	originalRegistry := httpRemoteCleanupRegistry
+	httpRemoteCleanupRegistry = new(remotesync.CleanupRegistry)
+	t.Cleanup(func() { httpRemoteCleanupRegistry = originalRegistry })
+
+	owner := &syncTransportCleanupError{
+		cause: errors.New("http sync failed"),
+		results: []error{
+			errors.New("cleanup still failed"),
+			nil,
+		},
+	}
+	runs := 0
+	restore := stubHTTPRemoteSyncForTest(t, func(
+		context.Context, config.RemoteHost, bool,
+	) (remotesync.SyncStats, error) {
+		runs++
+		if runs == 1 {
+			return remotesync.SyncStats{}, owner
+		}
+		return remotesync.SyncStats{SessionsSynced: 1}, nil
+	})
+	t.Cleanup(restore)
+	rh := config.RemoteHost{Host: "alpha", Transport: config.RemoteTransportHTTP}
+
+	_, err := runRemoteSyncTransport(
+		context.Background(), config.Config{}, nil, rh, false,
+	)
+	require.Same(t, owner, err)
+	assert.Equal(t, 1, owner.retries,
+		"cleanup must be retried before the transport returns the error")
+	assert.Equal(t, 1, runs)
+
+	stats, err := runRemoteSyncTransport(
+		context.Background(), config.Config{}, nil, rh, false,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.SessionsSynced)
+	assert.Equal(t, 2, owner.retries)
+	assert.Equal(t, 2, runs,
+		"later HTTP work starts after retained cleanup releases")
+}
+
+func TestRunRemoteHostsStopsOnPendingHTTPCleanupWithoutMisattribution(t *testing.T) {
+	originalRegistry := httpRemoteCleanupRegistry
+	httpRemoteCleanupRegistry = new(remotesync.CleanupRegistry)
+	t.Cleanup(func() { httpRemoteCleanupRegistry = originalRegistry })
+
+	owner := &syncTransportCleanupError{
+		cause: errors.New("alpha HTTP sync failed"),
+		results: []error{
+			errors.New("cleanup failed after alpha"),
+			errors.New("cleanup still blocks beta"),
+			errors.New("cleanup still blocks later call"),
+			nil,
+		},
+	}
+	var callbacks []string
+	restore := stubHTTPRemoteSyncForTest(t, func(
+		_ context.Context, rh config.RemoteHost, _ bool,
+	) (remotesync.SyncStats, error) {
+		callbacks = append(callbacks, rh.Host)
+		if rh.Host == "alpha" {
+			return remotesync.SyncStats{}, owner
+		}
+		return remotesync.SyncStats{SessionsSynced: 1}, nil
+	})
+	t.Cleanup(restore)
+	run := func(rh config.RemoteHost, full bool) error {
+		_, err := runRemoteSyncTransport(
+			context.Background(), config.Config{}, nil, rh, full,
+		)
+		return err
+	}
+	httpHost := func(host string) config.RemoteHost {
+		return config.RemoteHost{Host: host, Transport: config.RemoteTransportHTTP}
+	}
+
+	failures, blocked := runRemoteHosts([]config.RemoteHost{
+		httpHost("alpha"), httpHost("beta"), httpHost("gamma"),
+	}, false, run)
+	require.Len(t, failures, 1)
+	assert.Equal(t, "alpha", failures[0].Host.Host)
+	assert.Same(t, owner, failures[0].Err)
+	var pending *remotesync.PendingCleanupError
+	require.ErrorAs(t, blocked, &pending)
+	assert.ErrorIs(t, blocked, owner)
+	assert.Equal(t, []string{"alpha"}, callbacks,
+		"beta's callback is blocked and iteration stops before gamma")
+	assert.Equal(t, 2, owner.retries)
+
+	failures, blocked = runRemoteHosts(
+		[]config.RemoteHost{httpHost("delta")}, false, run,
+	)
+	assert.Empty(t, failures)
+	require.ErrorAs(t, blocked, &pending)
+	assert.Equal(t, []string{"alpha"}, callbacks)
+	assert.Equal(t, 3, owner.retries)
+
+	failures, blocked = runRemoteHosts(
+		[]config.RemoteHost{httpHost("epsilon")}, false, run,
+	)
+	assert.Empty(t, failures)
+	require.NoError(t, blocked)
+	assert.Equal(t, []string{"alpha", "epsilon"}, callbacks)
+	assert.Equal(t, 4, owner.retries)
+}
+
+type syncTransportCleanupError struct {
+	cause   error
+	results []error
+	retries int
+}
+
+func (e *syncTransportCleanupError) Error() string { return e.cause.Error() }
+
+func (e *syncTransportCleanupError) Unwrap() error { return e.cause }
+
+func (e *syncTransportCleanupError) RetryCleanup() error {
+	result := e.results[e.retries]
+	e.retries++
+	return result
+}
+
 func TestSyncLocalAndRemotes_ResyncForcesRemoteFull(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -143,7 +1052,7 @@ func TestSyncLocalAndRemotes_ResyncForcesRemoteFull(t *testing.T) {
 			hosts := []config.RemoteHost{{Host: "alpha"}, {Host: "beta"}}
 			localCalled := false
 			var gotFull []bool
-			failures := syncLocalAndRemotes(hosts, tt.cfgFull,
+			failures, blocked := syncLocalAndRemotes(hosts, tt.cfgFull,
 				func() bool { localCalled = true; return tt.didResync },
 				func(_ config.RemoteHost, full bool) error {
 					gotFull = append(gotFull, full)
@@ -151,6 +1060,7 @@ func TestSyncLocalAndRemotes_ResyncForcesRemoteFull(t *testing.T) {
 				})
 
 			require.True(t, localCalled, "local sync must run")
+			require.NoError(t, blocked)
 			assert.Empty(t, failures)
 			require.Len(t, gotFull, len(hosts))
 			for _, full := range gotFull {
@@ -407,10 +1317,10 @@ func TestRemoteProgressPrinterRendersByteProgressInPlace(t *testing.T) {
 		BytesDone:  4 << 20,
 		BytesTotal: 4 << 20,
 	})
-	now = now.Add(850 * time.Millisecond)
 	printer.Print(agentsync.Progress{
 		Detail: "Extracting session archive from devbox",
 	})
+	now = now.Add(850 * time.Millisecond)
 	printer.Finish()
 
 	got := out.String()
@@ -419,8 +1329,10 @@ func TestRemoteProgressPrinterRendersByteProgressInPlace(t *testing.T) {
 	assert.Contains(t, got,
 		"\r  Downloading session archive from devbox: 4.0 MB/4.0 MB (100%)\x1b[K")
 	assert.Contains(t, got,
-		"\n  Downloading session archive from devbox completed in 1s\n")
+		"\n  Downloading session archive from devbox completed in 150ms\n")
 	assert.Contains(t, got, "  Extracting session archive from devbox...\n")
+	assert.Contains(t, got,
+		"  Extracting session archive from devbox completed in 850ms\n")
 }
 
 func TestRemoteProgressPrinterRendersLocalSyncProgressWithoutDetail(t *testing.T) {
@@ -808,6 +1720,146 @@ func TestRunDaemonRemoteSyncReportsProgressEvents(t *testing.T) {
 	assert.Empty(t, failures)
 	require.Len(t, progress, 1)
 	assert.Equal(t, agentsync.PhaseRebuildingSearch, progress[0].Phase)
+}
+
+func TestRunDaemonRemoteSyncJSONReturnsTopLevelErrorWithEarlierFailures(t *testing.T) {
+	const blocked = "HTTP remote sync failed: pending cleanup still owns resources"
+	ts := remoteSyncRouteTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := io.WriteString(w, `{
+			"failures":[{"host":{"host":"alpha"},"error":"alpha failed"}],
+			"error":"`+blocked+`"
+		}`)
+		require.NoError(t, err)
+	})
+
+	failures, err := runDaemonRemoteSync(
+		context.Background(), transport{URL: ts.URL}, "",
+		[]config.RemoteHost{{Host: "alpha"}, {Host: "beta"}},
+		false, false, nil,
+	)
+
+	require.EqualError(t, err, blocked)
+	require.Len(t, failures, 1)
+	assert.Equal(t, "alpha", failures[0].Host.Host)
+	assert.EqualError(t, failures[0].Err, "alpha failed")
+}
+
+func TestRunDaemonRemoteSyncJSONRejectsAbortedUnifiedRebuild(t *testing.T) {
+	ts := remoteSyncRouteTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := io.WriteString(w, `{
+			"local_stats":{"aborted":true},
+			"failures":[],
+			"error":"`+agentsync.ErrUnifiedRebuildAborted.Error()+`"
+		}`)
+		require.NoError(t, err)
+	})
+
+	failures, err := runDaemonRemoteSync(
+		context.Background(), transport{URL: ts.URL}, "",
+		[]config.RemoteHost{{Host: "alpha"}}, true, true, nil,
+	)
+
+	require.ErrorIs(t, err, agentsync.ErrUnifiedRebuildAborted)
+	assert.Empty(t, failures)
+}
+
+func TestRunDaemonRemoteSyncSSEReturnsTopLevelErrorWithEarlierFailures(t *testing.T) {
+	const blocked = "HTTP remote sync failed: pending cleanup still owns resources"
+	ts := remoteSyncRouteTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, err := io.WriteString(w,
+			"event: done\n"+
+				`data: {"failures":[{"host":{"host":"alpha"},"error":"alpha failed"}],"error":"`+blocked+`"}`+
+				"\n\n",
+		)
+		require.NoError(t, err)
+	})
+
+	failures, err := runDaemonRemoteSync(
+		context.Background(), transport{URL: ts.URL}, "",
+		[]config.RemoteHost{{Host: "alpha"}, {Host: "beta"}},
+		false, false, nil,
+	)
+
+	require.EqualError(t, err, blocked)
+	require.Len(t, failures, 1)
+	assert.Equal(t, "alpha", failures[0].Host.Host)
+	assert.EqualError(t, failures[0].Err, "alpha failed")
+}
+
+func TestRunDaemonRemoteSyncSSERejectsAbortedUnifiedRebuild(t *testing.T) {
+	ts := remoteSyncRouteTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, err := io.WriteString(w,
+			"event: done\n"+
+				`data: {"local_stats":{"aborted":true},"failures":[],"error":"`+
+				agentsync.ErrUnifiedRebuildAborted.Error()+`"}`+
+				"\n\n",
+		)
+		require.NoError(t, err)
+	})
+
+	failures, err := runDaemonRemoteSync(
+		context.Background(), transport{URL: ts.URL}, "",
+		[]config.RemoteHost{{Host: "alpha"}}, true, true, nil,
+	)
+
+	require.ErrorIs(t, err, agentsync.ErrUnifiedRebuildAborted)
+	assert.Empty(t, failures)
+}
+
+func TestDoSyncDaemonAbortedUnifiedRebuildExitsNonZero(t *testing.T) {
+	dataDir := t.TempDir()
+	cmd := exec.Command(
+		os.Args[0],
+		"-test.run=^TestDoSyncDaemonAbortedUnifiedRebuildHelperProcess$",
+	)
+	cmd.Env = append(os.Environ(),
+		"AGENTSVIEW_DAEMON_ABORTED_UNIFIED_HELPER=1",
+		"AGENTSVIEW_DATA_DIR="+dataDir,
+	)
+
+	out, err := cmd.CombinedOutput()
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	assert.Equal(t, 1, exitErr.ExitCode())
+	assert.Contains(t, string(out),
+		"fatal: daemon remote sync: "+agentsync.ErrUnifiedRebuildAborted.Error())
+	assert.NotContains(t, string(out), "Sync complete")
+}
+
+func TestDoSyncDaemonAbortedUnifiedRebuildHelperProcess(t *testing.T) {
+	if os.Getenv("AGENTSVIEW_DAEMON_ABORTED_UNIFIED_HELPER") != "1" {
+		return
+	}
+	dataDir := os.Getenv("AGENTSVIEW_DATA_DIR")
+	require.NotEmpty(t, dataDir)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dataDir, "config.toml"),
+		[]byte(`[[remote_hosts]]
+host = "alpha"
+transport = "http"
+url = "http://127.0.0.1:1"
+token = "remote-token"
+`),
+		0o600,
+	))
+	ts := remoteSyncRouteTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, err := io.WriteString(w,
+			"event: done\n"+
+				`data: {"local_stats":{"aborted":true},"failures":[],"error":"`+
+				agentsync.ErrUnifiedRebuildAborted.Error()+`"}`+
+				"\n\n",
+		)
+		require.NoError(t, err)
+	})
+	registerSyncRouteTestRuntime(t, dataDir, ts.URL)
+
+	doSync(SyncConfig{Full: true})
+	os.Exit(0)
 }
 
 func TestDoSyncConfiguredRemoteHostsUsesDaemonRouteWithLocalSync(

--- a/cmd/agentsview/sync_test.go
+++ b/cmd/agentsview/sync_test.go
@@ -69,8 +69,9 @@ func newDirectSyncFixture(t *testing.T) (config.Config, *db.DB) {
 		0o600,
 	))
 	cfg := config.Config{
-		DataDir: dataDir,
-		DBPath:  filepath.Join(dataDir, "sessions.db"),
+		DataDir:          dataDir,
+		DBPath:           filepath.Join(dataDir, "sessions.db"),
+		LocalMachineName: "collector-host",
 		AgentDirs: map[parser.AgentType][]string{
 			parser.AgentClaude: {localRoot},
 		},

--- a/cmd/agentsview/sync_test.go
+++ b/cmd/agentsview/sync_test.go
@@ -144,6 +144,67 @@ func TestDoSyncConfiguredFullUsesUnifiedHTTPContributorBeforeSSH(t *testing.T) {
 		"contributor borrow must release before prepared sources close")
 }
 
+func TestDoSyncConfiguredFullIgnoresSSHHistoryDuringUnifiedSafetyCheck(t *testing.T) {
+	cfg, database := newDirectSyncFixture(t)
+	for _, roots := range cfg.AgentDirs {
+		for _, root := range roots {
+			require.NoError(t, os.RemoveAll(root))
+		}
+	}
+	missingPath := filepath.Join(t.TempDir(), "missing-ssh-session.jsonl")
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "preserved-ssh-session", Project: "archive", Machine: "ssh-box",
+		Agent: "claude", FilePath: &missingPath, MessageCount: 1,
+	}))
+	httpRoot := t.TempDir()
+	prepared := &fakeCLIPreparedHTTPRebuild{contributors: []agentsync.RebuildContributor{{
+		Name: "http-box",
+		Config: agentsync.EngineConfig{
+			AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {httpRoot}},
+			Machine:   "http-box", IDPrefix: "http-box~", Ephemeral: true,
+		},
+	}}}
+	originalPrepare := prepareHTTPRebuildCLI
+	prepareHTTPRebuildCLI = func(
+		context.Context, []remotesync.HTTPSync,
+	) (preparedHTTPRebuildCLI, error) {
+		return prepared, nil
+	}
+	t.Cleanup(func() { prepareHTTPRebuildCLI = originalPrepare })
+	sshCalls := 0
+	originalSSH := runSSHRemoteSync
+	runSSHRemoteSync = func(
+		_ context.Context, _ config.Config, database *db.DB,
+		rh config.RemoteHost, full bool,
+	) (remotesync.SyncStats, error) {
+		sshCalls++
+		assert.Equal(t, "ssh-box", rh.Host)
+		assert.True(t, full)
+		preserved, err := database.GetSession(
+			context.Background(), "preserved-ssh-session",
+		)
+		require.NoError(t, err)
+		assert.NotNil(t, preserved,
+			"SSH pass must observe its archived session after the unified swap")
+		return remotesync.SyncStats{}, nil
+	}
+	t.Cleanup(func() { runSSHRemoteSync = originalSSH })
+
+	didResync, failures, err := runConfiguredLocalAndRemotes(
+		context.Background(), cfg, database,
+		[]config.RemoteHost{
+			{Host: "http-box", Transport: config.RemoteTransportHTTP, Token: "token"},
+			{Host: "ssh-box"},
+		}, true, nil,
+	)
+
+	require.NoError(t, err)
+	assert.True(t, didResync)
+	assert.Empty(t, failures)
+	assert.Equal(t, 1, sshCalls,
+		"SSH synchronization must run after an empty local/HTTP rebuild")
+}
+
 func TestDoSyncConfiguredFullSSHOnlyFallsBackBeforeRemoteImport(t *testing.T) {
 	cfg, database := newDirectSyncFixture(t)
 	for _, roots := range cfg.AgentDirs {

--- a/cmd/agentsview/usage.go
+++ b/cmd/agentsview/usage.go
@@ -311,7 +311,7 @@ func ensureFreshData(
 		engine := sync.NewEngine(database, sync.EngineConfig{
 			AgentDirs:          appCfg.AgentDirs,
 			IncludeCwdPrefixes: appCfg.SyncIncludeCwdPrefixes,
-			Machine:            "local",
+			Machine:            appCfg.LocalMachineName,
 		})
 		defer engine.Close()
 		fmt.Fprintln(os.Stderr,
@@ -335,7 +335,7 @@ func ensureFreshData(
 	engine := sync.NewEngine(database, sync.EngineConfig{
 		AgentDirs:          appCfg.AgentDirs,
 		IncludeCwdPrefixes: appCfg.SyncIncludeCwdPrefixes,
-		Machine:            "local",
+		Machine:            appCfg.LocalMachineName,
 	})
 	defer engine.Close()
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,6 +23,10 @@ description: Release history for AgentsView
 
 **Bug fixes**
 
+- Identify locally ingested sessions by the machine's hostname instead of the
+  ambiguous `local` label, and keep full-rebuild safety independent when a
+  configured remote has the same hostname as the collector.
+
 - Remove **recommended-plugin context injected into Codex sessions** from
   parsed transcripts so it no longer appears as user-authored content.
 - Include **overnight session activity** in date-filtered results by matching

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,15 @@ description: Release history for AgentsView
   IDE sessions, falling back to the existing heuristic decode when a sidecar is
   missing, malformed, or does not cover the session's database steps.
 
+**Improvements**
+
+- Speed up configured HTTP **full remote syncs** by ingesting local and remote
+  sessions through one batched temporary-database rebuild with FTS suspended,
+  then rebuilding search once and swapping atomically. `--full` now reparses
+  every session without retransferring unchanged mirror files from
+  manifest-capable spokes; older HTTP-capable spokes retain the full-archive
+  compatibility fallback.
+
 **Bug fixes**
 
 - Remove **recommended-plugin context injected into Codex sessions** from

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -234,14 +234,21 @@ url = "http://devbox1.tailnet.ts.net:8080"
 token = "remote-token"
 ```
 
-With hosts configured, `agentsview sync` (no `--host`) runs the local sync
-first, then syncs each configured host in the order declared using its
-configured transport. `--full` applies to every host; for HTTP hosts it
-re-downloads the full archive into the persistent mirror and bypasses the remote
-path/mtime skip cache (see
-[Incremental Sync](/remote-access/#incremental-sync)). A failing host is
-reported on stderr and skipped so the remaining hosts still run; the command
-exits non-zero if any host failed.
+With hosts configured, `agentsview sync` (no `--host`) includes local sources
+and configured HTTP hosts in one coordinated sync. During a full or automatic
+data-version rebuild, AgentsView prepares every HTTP mirror, bulk-ingests the
+local and HTTP sources into one temporary database with FTS updates suspended,
+rebuilds FTS once, and atomically swaps the completed archive into place. SSH
+hosts run through their existing active-archive path only after that swap.
+
+`--full` reparses every discovered local and remote session, but it does not
+force unchanged HTTP mirror files to be transferred again. Manifest-capable
+spokes still send only changed files; older HTTP-capable spokes fall back to
+their existing full-archive endpoint. An HTTP preparation or contributor
+failure aborts the combined rebuild without replacing the active archive or
+running SSH. Ordinary incremental and post-swap SSH failures retain per-host
+reporting, and the command exits non-zero if any host failed. See
+[Incremental Sync](/remote-access/#incremental-sync).
 
 `agentsview sync --host X` syncs one host, not the whole configured list. When
 the local daemon knows a configured host with that identity, it uses the stored
@@ -258,11 +265,13 @@ endpoints. Ad hoc HTTP remotes are not supported. Hosts must be unique within
 the list, since remote sessions are namespaced by host.
 
 During HTTP remote sync, the collector prints durable phase lines for resolving
-remote roots, downloading and extracting the archive, processing sessions, and
-the final per-host summary. Archive downloads also show live byte progress when
-the remote daemon provides a `Content-Length` header. If an upgraded binary does
-not show those phases, restart the local collector daemon; restarting the remote
-daemon as well avoids version skew while smoke testing.
+remote roots, fetching and comparing the manifest, transferring and extracting
+changed files, processing each contributor, rebuilding FTS, and swapping the
+database. Archive downloads also show live compressed-byte progress when the
+remote daemon provides a `Content-Length` header. The new phases and bulk-ingest
+path come from the collector; a spoke upgrade is needed only for manifest-delta
+transfer. If an upgraded binary does not show those phases, restart the local
+collector daemon.
 
 ______________________________________________________________________
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -138,6 +138,13 @@ endpoints. HTTP transfers use a persistent per-host mirror and request file
 deltas when fewer than half of the manifest files need fetching; see
 [Remote Access — Incremental Sync](/remote-access/#incremental-sync).
 
+When a full or automatic data-version rebuild includes local sources, configured
+HTTP hosts join the same temporary-database bulk ingest and atomic swap. `--full`
+reparses the complete local and remote corpus without retransferring unchanged
+files from manifest-capable spokes. Older HTTP-capable spokes remain compatible
+through the full-archive fallback; upgrading them is required only to gain delta
+transfer.
+
 Each `remote_hosts.host` value must be unique and stable. It namespaces imported
 session IDs, the database skip cache, and the persistent mirror; changing it for
 the same machine can duplicate sessions, while reusing it for another machine

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -186,6 +186,17 @@ run.
    The separate database skip cache avoids unnecessary parsing of unchanged
    sessions during normal syncs.
 
+For a configured full sync that includes local sources, mirror preparation
+finishes before database work begins. The collector then ingests local sources
+and every prepared HTTP mirror through the same batched temporary-database path,
+with FTS maintenance suspended during ingest and rebuilt once before an atomic
+swap. Configured SSH hosts run afterward. A preparation, parser, batch-write, or
+FTS failure leaves the active archive unchanged and prevents the SSH phase.
+
+Remote-only syncs, including
+`agentsview sync --host <configured-http-host> --full`, continue to import into
+the active archive and do not use the combined rebuild path.
+
 If no directory-scoped files changed, the collector skips the archive request
 and imports directly from the existing mirror. Files that disappear remotely are
 deleted from the mirror, but remote import is intentionally non-destructive:
@@ -203,9 +214,7 @@ of the remote state database.
 A full HTTP transfer occurs in these cases:
 
 - the per-host mirror is new or was removed
-- `agentsview sync --full` is used
 - at least half of the manifest files are missing or changed
-- a collector data-version resync forces its configured remote syncs full
 - a delta request is rejected after a manifest succeeded; the collector retries
   once with a full archive
 - the remote daemon does not support manifests, in which case the collector uses
@@ -214,18 +223,26 @@ A full HTTP transfer occurs in these cases:
 Windsurf's curated export is also fetched in full on every sync, independently
 of the directory-scoped archive decision.
 
-`--full` refreshes the mirror bytes and bypasses the persistent remote
-path/mtime skip cache during import. It does not delete the local database or
-turn remote sync into a destructive reconciliation.
+`--full` reparses every discovered remote session but still uses the manifest
+comparison to decide which mirror bytes need transferring. It does not delete
+the local database or turn remote sync into a destructive reconciliation.
 
 ### Compatibility And Recovery
 
-A 0.37.4 collector works with older remote daemons. A missing manifest route —
+A current collector works with older remote daemons that already expose the
+HTTP remote-sync target and archive endpoints. A missing manifest route —
 including an old daemon's HTML app shell answering that route — makes the
-collector report that incremental sync is unavailable and use the legacy
+collector report that incremental transfer is unavailable and use the legacy
 full-archive flow. That flow extracts to a temporary directory and does not
-create or update the persistent mirror. Older collectors also continue to use
-the full-archive endpoint on a 0.37.4 remote.
+create or update the persistent mirror. During a configured full local sync,
+the temporary source still uses the collector's new batched ingest path.
+
+Therefore the collector can be upgraded and tested before its spokes. Upgrading
+only the collector provides the database-ingest speedup; upgrading each spoke
+adds manifest-delta transfer and avoids downloading its complete archive. A
+spoke old enough to lack the target or archive endpoints was not compatible
+with HTTP remote sync before this change either. Older collectors also continue
+to use the full-archive endpoint on a current remote.
 
 The normal mirror comparison detects interrupted extraction when the resulting
 file size or modification time differs from the manifest, and the next sync
@@ -234,23 +251,13 @@ an interrupted extraction.
 
 The comparison does not hash file content. A remote rewrite that preserves both
 size and modification time, or local mirror corruption with the same metadata,
-can therefore look unchanged. Run a full sync to refresh the bytes:
-
-```bash
-# Refresh local sessions and every configured remote.
-agentsview sync --full
-
-# Refresh one configured host through the local daemon.
-agentsview sync --host devbox1 --full
-```
-
-The second form requires `devbox1` to match a configured `[[remote_hosts]]`
-entry; otherwise `--host` is an ad hoc SSH sync.
+can therefore look unchanged. Because `--full` now separates reparsing from
+mirror transfer, it does not repair same-stat corruption by itself.
 
 The mirror is a disposable transfer cache. When no sync is running, deleting a
-host's mirror directory is safe and makes the next compatible sync bootstrap it
-again. Leave the adjacent `.lock` file in place. Removing mirror files never
-removes imported sessions from the database.
+host's mirror directory is the repair procedure: the next compatible sync
+bootstraps it again. Leave the adjacent `.lock` file in place. Removing mirror
+files never removes imported sessions from the database.
 
 ### Transfer Safety
 

--- a/docs/session-api.md
+++ b/docs/session-api.md
@@ -156,7 +156,7 @@ agentsview session get <id> [--format json]
 {
   "id": "abc-123",
   "project": "myapp",
-  "machine": "local",
+  "machine": "workstation",
   "agent": "claude",
   "first_message": "...",
   "display_name": "...",

--- a/docs/superpowers/specs/2026-07-12-daemon-and-remote-progress-ux-design.md
+++ b/docs/superpowers/specs/2026-07-12-daemon-and-remote-progress-ux-design.md
@@ -1,0 +1,112 @@
+# Daemon Startup and Remote Progress UX Design
+
+## Context
+
+Canonical `agentsview daemon start` and `agentsview daemon restart` currently
+wait five seconds for a spawned server to publish its writable runtime. A
+healthy startup that spends longer than five seconds in its initial sync is then
+reported as a fatal error even though the identified child continues to run. The
+existing 90-second automatic-start readiness window is a better fit for
+canonical lifecycle commands while preserving the rule that they must not claim
+the daemon is ready before its health endpoint is available.
+
+While the daemon is starting, `agentsview daemon status` reads
+`startup-state.json`. That snapshot contains the PID, elapsed time, phase,
+detail, and log path, but not the child binary version, so status cannot show
+the version until the writable runtime has been published and probed.
+
+During a multi-source full rebuild, contributor progress is labelled for the
+current HTTP host after the coordinator has added all prior-source counts. For
+example, a local pass of 40,000 sessions followed by a remote corpus of 60,000
+sessions is displayed as `Processing sessions from <host>: .../100000`. The
+aggregate is valid for coordinator accounting but misleading under a
+host-specific label.
+
+## Goals
+
+- Let normal canonical daemon starts and restarts wait long enough for healthy
+  initial syncs without weakening readiness claims.
+- Show the starting child binary's version before runtime publication.
+- Make HTTP contributor progress counters match the host named in the label.
+- Preserve lifecycle safety, aggregate rebuild statistics, atomic swap behavior,
+  and compatibility with startup snapshots from older binaries.
+
+## Design
+
+### Canonical daemon readiness window
+
+`backgroundLaunchPolicy` will carry the readiness timeout selected by its
+caller. Canonical `daemon start` and `daemon restart` will pass the existing
+`backgroundAutoStartReadyTimeout` value of 90 seconds. The compatibility
+`serve --background` path will retain its five-second window.
+
+The background launcher will use the policy timeout when it is positive and fall
+back to `backgroundServeReadyTimeout` otherwise. This keeps existing callers and
+tests with a zero-value policy unchanged.
+
+If the child publishes a healthy writable runtime within 90 seconds, the
+canonical command reports the normal ready result. If the child exits, the
+command still fails immediately. If it remains alive but unready after 90
+seconds, the existing slow-start error and status guidance remain unchanged; the
+command must not print `running` or `restarted` without readiness evidence.
+
+### Version during startup
+
+`startupState` will gain an optional `version` field. The startup-state writer
+will initialize it from the child process's build version before its first phase
+write. Starting-status rendering will show `version:` when the field is present.
+
+The field is additive and uses `omitempty`. Older startup snapshots remain
+readable and simply omit the version line. New CLIs reading an old daemon's
+snapshot therefore retain today's output rather than inventing a version. Once
+runtime publication succeeds, the existing health-probe version remains
+authoritative for running-daemon status.
+
+### Host-specific contributor progress
+
+The rebuild coordinator will stop adding prior-source session and message counts
+to each contributor's progress events. Contributor engines already produce
+counts scoped to their own discovery and processing pass, and the remote
+progress transformer labels those events with the contributor host. The CLI will
+therefore render, for example:
+
+```text
+Processing sessions from remote-host: 12000/60000 sessions (20%)
+```
+
+The phase counter may reset when the rebuild moves from local work to a remote
+host; the changed label makes that phase transition explicit. Aggregate final
+`SyncStats`, failure ratios, contributor ordering, database writes, and swap
+decisions continue to use merged statistics and are unchanged.
+
+## Error Handling and Compatibility
+
+- A longer wait changes only how long canonical commands observe the existing
+  child; it does not suppress child-exit, lock, configuration, compatibility,
+  or health errors.
+- Startup version publication is best-effort like the rest of the startup
+  snapshot. Snapshot write failures remain warnings and never block startup.
+- Host-only progress changes presentation events only. It does not change
+  manifest counts, discovered sessions, imported IDs, skip caches, or archive
+  contents.
+
+## Testing
+
+- Command tests assert canonical start and restart request the 90-second
+  readiness window while compatibility launches retain five seconds.
+- Startup-state round-trip and rendering tests cover the version line and an
+  older snapshot without the field.
+- Contributor progress tests assert local and remote phases report their own
+  session and message totals, while final merged statistics still equal the
+  sum of all sources.
+- Existing lifecycle failure tests continue to prove that an exited or
+  persistently unready child is never reported as ready.
+
+## Non-goals
+
+- Streaming startup progress directly in the blocking start or restart command.
+- Waiting indefinitely for daemon readiness.
+- Changing the HTTP manifest, parser discovery rules, or the number of remote
+  sessions ingested.
+- Addressing the separate per-source rebuild abort-safety review finding; that
+  requires its own correctness change and regression coverage.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -459,6 +459,11 @@ type Config struct {
 	Automated            AutomatedConfig        `json:"automated,omitempty" toml:"automated"`
 	Agent                map[string]AgentConfig `json:"agent,omitempty" toml:"agent"`
 	WriteTimeout         time.Duration          `json:"-" toml:"-"`
+	// LocalMachineName is the operating-system hostname used to identify
+	// sessions ingested from this machine. It is runtime-derived rather than
+	// persisted configuration so local and remote source labels share the same
+	// hostname namespace.
+	LocalMachineName string `json:"-" toml:"-"`
 
 	// AgentDirs maps each AgentType to its configured
 	// directories. Single-dir agents store a one-element
@@ -665,6 +670,13 @@ func Default() (Config, error) {
 		)
 	}
 	dataDir := filepath.Join(home, ".agentsview")
+	hostname, err := os.Hostname()
+	if err != nil {
+		return Config{}, fmt.Errorf("identify local sync machine: %w", err)
+	}
+	if strings.TrimSpace(hostname) == "" {
+		return Config{}, fmt.Errorf("identify local sync machine: hostname is empty")
+	}
 
 	agentDirs := make(map[parser.AgentType][]string)
 	agentDirSource := make(map[parser.AgentType]dirSource)
@@ -691,6 +703,7 @@ func Default() (Config, error) {
 		DataDir:                        dataDir,
 		DBPath:                         filepath.Join(dataDir, "sessions.db"),
 		WriteTimeout:                   30 * time.Second,
+		LocalMachineName:               hostname,
 		AgentDirs:                      agentDirs,
 		agentDirSource:                 agentDirSource,
 		WatchExcludePatterns:           []string{".git", "node_modules", "__pycache__", ".venv", "venv", "vendor", ".next"},
@@ -1615,6 +1628,9 @@ func splitFlagList(value string) []string {
 
 func finalize(cfg *Config) error {
 	var err error
+	if strings.TrimSpace(cfg.LocalMachineName) == "" {
+		return fmt.Errorf("identify local sync machine: hostname is empty")
+	}
 	if err := normalizeProxyConfig(&cfg.Proxy); err != nil {
 		return err
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1332,6 +1332,16 @@ func TestResolvePG_Defaults(t *testing.T) {
 	assert.NotEmpty(t, resolved.MachineName, "MachineName should default to hostname")
 }
 
+func TestLoadResolvesLocalMachineNameFromHostname(t *testing.T) {
+	setupTestEnv(t)
+	cfg, err := loadConfigFromPFlags(t)
+	require.NoError(t, err)
+	hostname, err := os.Hostname()
+	require.NoError(t, err)
+
+	assert.Equal(t, hostname, cfg.LocalMachineName)
+}
+
 func TestResolvePG_ExpandsEnvVars(t *testing.T) {
 	t.Setenv("PGPASS", "env-secret")
 	t.Setenv("PGURL", "postgres://localhost/test")

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -291,7 +291,10 @@ const projectIdentityRemoteScrubCompletedKey = "project_identity_remote_scrub_v1
 // (17: Codex <skill> template filtering.)
 // (16: <turn_aborted> system messages.)
 // (60: Codex recommended-plugins prefix filtering.)
-const dataVersion = 61
+// (62: Local session machine identity now uses the operating-system hostname
+// instead of the ambiguous literal "local". Re-parsing updates existing
+// source-backed rows while the resync archive copy preserves orphaned history.)
+const dataVersion = 62
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/read_only_test.go
+++ b/internal/db/read_only_test.go
@@ -252,6 +252,9 @@ func TestOpenReadOnlyWriteMethodsReturnErrReadOnly(t *testing.T) {
 	requireReadOnlyOp(t, "ReplaceSkippedFiles", func() error {
 		return readonly.ReplaceSkippedFiles(map[string]int64{"x": 1})
 	})
+	requireReadOnlyOp(t, "ClearRemoteSkippedFiles", func() error {
+		return readonly.ClearRemoteSkippedFiles("remote-host")
+	})
 	requireReadOnlyOp(t, "UpdateSessionIncremental", func() error {
 		return readonly.UpdateSessionIncremental("s", IncrementalSessionUpdate{})
 	})

--- a/internal/db/remote_skipped.go
+++ b/internal/db/remote_skipped.go
@@ -34,6 +34,28 @@ func (db *DB) LoadRemoteSkippedFiles(
 	return result, rows.Err()
 }
 
+// ClearRemoteSkippedFiles removes all skip cache entries for the given host.
+// Entries for other hosts are not affected.
+func (db *DB) ClearRemoteSkippedFiles(host string) error {
+	if err := db.requireWritable(); err != nil {
+		return err
+	}
+
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	if _, err := db.getWriter().Exec(
+		"DELETE FROM remote_skipped_files WHERE host = ?",
+		host,
+	); err != nil {
+		return fmt.Errorf(
+			"clearing remote skipped files for %s: %w",
+			host, err,
+		)
+	}
+	return nil
+}
+
 // ReplaceRemoteSkippedFiles replaces all skip cache entries
 // for the given host in a single transaction. Entries for
 // other hosts are not affected.

--- a/internal/db/remote_skipped_test.go
+++ b/internal/db/remote_skipped_test.go
@@ -98,3 +98,24 @@ func TestRemoteSkippedFiles(t *testing.T) {
 			"replace-other-2: loaded %v, want %v", loaded2, host2)
 	})
 }
+
+func TestClearRemoteSkippedFiles(t *testing.T) {
+	d := dbtest.OpenTestDB(t)
+
+	require.NoError(t, d.ReplaceRemoteSkippedFiles(
+		"host-a", map[string]int64{"/sessions/a.jsonl": 101},
+	))
+	require.NoError(t, d.ReplaceRemoteSkippedFiles(
+		"host-b", map[string]int64{"/sessions/b.jsonl": 202},
+	))
+
+	require.NoError(t, d.ClearRemoteSkippedFiles("host-a"))
+
+	hostA, err := d.LoadRemoteSkippedFiles("host-a")
+	require.NoError(t, err, "LoadRemoteSkippedFiles host-a")
+	assert.Empty(t, hostA)
+
+	hostB, err := d.LoadRemoteSkippedFiles("host-b")
+	require.NoError(t, err, "LoadRemoteSkippedFiles host-b")
+	assert.Equal(t, map[string]int64{"/sessions/b.jsonl": 202}, hostB)
+}

--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -58,12 +58,33 @@ func nonSourceBackedAgents() []parser.AgentType {
 func (db *DB) FileBackedSessionCount(
 	ctx context.Context,
 ) (int, error) {
+	return db.fileBackedSessionCount(ctx, "", false)
+}
+
+// FileBackedSessionCountForMachine returns the protected root-session count
+// for one sync source machine. Multi-source rebuilds use it so one healthy
+// source cannot satisfy the empty-discovery guard for another source.
+func (db *DB) FileBackedSessionCountForMachine(
+	ctx context.Context, machine string,
+) (int, error) {
+	return db.fileBackedSessionCount(ctx, machine, true)
+}
+
+func (db *DB) fileBackedSessionCount(
+	ctx context.Context, machine string, scoped bool,
+) (int, error) {
+	machinePredicate := ""
+	args := nonSourceBackedAgentArgs()
+	if scoped {
+		machinePredicate = " AND machine = ?"
+		args = append(args, machine)
+	}
 	var count int
 	err := db.getReader().QueryRowContext(ctx,
 		`SELECT COUNT(*) FROM sessions
 		 WHERE agent NOT IN (`+nonSourceBackedAgentPlaceholders()+`)
-		 AND `+rootSessionFilter,
-		nonSourceBackedAgentArgs()...,
+		 AND `+rootSessionFilter+machinePredicate,
+		args...,
 	).Scan(&count)
 	if err != nil {
 		return 0, fmt.Errorf(

--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -58,7 +58,7 @@ func nonSourceBackedAgents() []parser.AgentType {
 func (db *DB) FileBackedSessionCount(
 	ctx context.Context,
 ) (int, error) {
-	return db.fileBackedSessionCount(ctx, "", false)
+	return db.fileBackedSessionCount(ctx, "", "", false)
 }
 
 // FileBackedSessionCountForMachine returns the protected root-session count
@@ -67,17 +67,30 @@ func (db *DB) FileBackedSessionCount(
 func (db *DB) FileBackedSessionCountForMachine(
 	ctx context.Context, machine string,
 ) (int, error) {
-	return db.fileBackedSessionCount(ctx, machine, true)
+	return db.fileBackedSessionCount(ctx, machine, "", true)
+}
+
+// FileBackedSessionCountForSource returns the protected root-session count
+// for one namespaced rebuild contributor. ID prefixes distinguish a remote
+// contributor from local sessions when both machines have the same hostname.
+func (db *DB) FileBackedSessionCountForSource(
+	ctx context.Context, machine, idPrefix string,
+) (int, error) {
+	return db.fileBackedSessionCount(ctx, machine, idPrefix, true)
 }
 
 func (db *DB) fileBackedSessionCount(
-	ctx context.Context, machine string, scoped bool,
+	ctx context.Context, machine, idPrefix string, scoped bool,
 ) (int, error) {
 	machinePredicate := ""
 	args := nonSourceBackedAgentArgs()
 	if scoped {
 		machinePredicate = " AND machine = ?"
 		args = append(args, machine)
+	}
+	if idPrefix != "" {
+		machinePredicate += " AND substr(id, 1, length(?)) = ?"
+		args = append(args, idPrefix, idPrefix)
 	}
 	var count int
 	err := db.getReader().QueryRowContext(ctx,

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"strings"
 	"time"
 
 	"go.kenn.io/agentsview/internal/db"
@@ -103,6 +104,7 @@ func ImportClaudeAI(
 	store db.Store,
 	r io.Reader,
 	cb *ImportCallbacks,
+	machine ...string,
 ) (stats ImportStats, retErr error) {
 	fts := newLazyFTS(store, cb.indexing)
 	defer func() {
@@ -131,6 +133,9 @@ func ImportClaudeAI(
 			return ctx.Err()
 		}
 
+		result.Session.Machine = resolvedImportMachine(
+			result.Session.Machine, machine,
+		)
 		status, err := upsertConversation(
 			ctx, store, result, fts,
 		)
@@ -285,6 +290,7 @@ func ImportChatGPT(
 	dir string,
 	assetsDir string,
 	cb *ImportCallbacks,
+	machine ...string,
 ) (stats ImportStats, retErr error) {
 	fts := newLazyFTS(store, cb.indexing)
 	defer func() {
@@ -319,6 +325,7 @@ func ImportChatGPT(
 			}
 
 			s := result.Session
+			s.Machine = resolvedImportMachine(s.Machine, machine)
 
 			existing, err := store.GetSession(ctx, s.ID)
 			if err != nil {
@@ -416,6 +423,13 @@ func ImportChatGPT(
 
 	retErr = err
 	return
+}
+
+func resolvedImportMachine(current string, override []string) string {
+	if len(override) > 0 && strings.TrimSpace(override[0]) != "" {
+		return override[0]
+	}
+	return current
 }
 
 func ptrEqual(a, b *string) bool {

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -125,7 +125,7 @@ func TestImportClaudeAI(t *testing.T) {
 	ctx := context.Background()
 
 	stats, err := ImportClaudeAI(
-		ctx, d, strings.NewReader(testConversationsJSON), nil,
+		ctx, d, strings.NewReader(testConversationsJSON), nil, "workstation",
 	)
 	require.NoError(t, err)
 	assert.Equal(t, 1, stats.Imported)
@@ -136,6 +136,7 @@ func TestImportClaudeAI(t *testing.T) {
 	require.NotNil(t, s)
 	assert.Equal(t, "claude.ai", s.Project)
 	assert.Equal(t, "claude-ai", s.Agent)
+	assert.Equal(t, "workstation", s.Machine)
 	require.NotNil(t, s.DisplayName)
 	assert.Equal(t, "First Chat", *s.DisplayName)
 
@@ -287,7 +288,7 @@ func TestImportChatGPT(t *testing.T) {
 	assetsDir := filepath.Join(t.TempDir(), "assets")
 
 	stats, err := ImportChatGPT(
-		ctx, d, dir, assetsDir, nil,
+		ctx, d, dir, assetsDir, nil, "workstation",
 	)
 	require.NoError(t, err)
 	assert.Equal(t, 1, stats.Imported)
@@ -297,6 +298,7 @@ func TestImportChatGPT(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, s)
 	assert.Equal(t, "chatgpt.com", s.Project)
+	assert.Equal(t, "workstation", s.Machine)
 }
 
 func TestImportChatGPTSanitizesParserRows(t *testing.T) {

--- a/internal/remotesync/cleanup_registry.go
+++ b/internal/remotesync/cleanup_registry.go
@@ -1,0 +1,73 @@
+package remotesync
+
+import (
+	"errors"
+	"sync"
+)
+
+type cleanupRetrier interface {
+	RetryCleanup() error
+}
+
+// PendingCleanupError reports that a cleanup retained from an earlier HTTP
+// sync still owns resources, so the requested sync callback did not run.
+// Err preserves the original operation and cleanup error chain.
+type PendingCleanupError struct {
+	Err error
+}
+
+func (e *PendingCleanupError) Error() string {
+	if e == nil || e.Err == nil {
+		return "pending HTTP sync cleanup still failed"
+	}
+	return "pending HTTP sync cleanup still failed: " + e.Err.Error()
+}
+
+func (e *PendingCleanupError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// CleanupRegistry serializes HTTP sync work and retains at most one failed
+// prepared-source cleanup. A retained cleanup must succeed before later work
+// can start, so ownership cannot be overwritten or grow without bound.
+type CleanupRegistry struct {
+	mu      sync.Mutex
+	pending error
+}
+
+// Run retries cleanup errors before they can be converted to strings or
+// discarded by a caller. The original error is returned unchanged so its
+// operation and cleanup causes remain available to errors.Is and errors.As.
+func (r *CleanupRegistry) Run(
+	run func() (SyncStats, error),
+) (SyncStats, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.pending != nil {
+		if retryCleanup(r.pending) != nil {
+			return SyncStats{}, &PendingCleanupError{Err: r.pending}
+		}
+		r.pending = nil
+	}
+
+	stats, err := run()
+	if err == nil {
+		return stats, nil
+	}
+	if cleanupErr := retryCleanup(err); cleanupErr != nil {
+		r.pending = err
+	}
+	return stats, err
+}
+
+func retryCleanup(err error) error {
+	var retrier cleanupRetrier
+	if !errors.As(err, &retrier) {
+		return nil
+	}
+	return retrier.RetryCleanup()
+}

--- a/internal/remotesync/cleanup_registry.go
+++ b/internal/remotesync/cleanup_registry.go
@@ -2,6 +2,7 @@ package remotesync
 
 import (
 	"errors"
+	"reflect"
 	"sync"
 )
 
@@ -30,9 +31,9 @@ func (e *PendingCleanupError) Unwrap() error {
 	return e.Err
 }
 
-// CleanupRegistry serializes HTTP sync work and retains at most one failed
-// prepared-source cleanup. A retained cleanup must succeed before later work
-// can start, so ownership cannot be overwritten or grow without bound.
+// CleanupRegistry serializes HTTP sync work and retains at most one aggregate
+// of failed cleanup owners. Every retained owner must release before later
+// work can start, so ownership cannot be overwritten or grow without bound.
 type CleanupRegistry struct {
 	mu      sync.Mutex
 	pending error
@@ -48,7 +49,8 @@ func (r *CleanupRegistry) Run(
 	defer r.mu.Unlock()
 
 	if r.pending != nil {
-		if retryCleanup(r.pending) != nil {
+		if pending := retryCleanup(r.pending); pending != nil {
+			r.pending = pending
 			return SyncStats{}, &PendingCleanupError{Err: r.pending}
 		}
 		r.pending = nil
@@ -59,15 +61,100 @@ func (r *CleanupRegistry) Run(
 		return stats, nil
 	}
 	if cleanupErr := retryCleanup(err); cleanupErr != nil {
-		r.pending = err
+		r.pending = cleanupErr
 	}
 	return stats, err
 }
 
 func retryCleanup(err error) error {
-	var retrier cleanupRetrier
-	if !errors.As(err, &retrier) {
+	if retained, ok := err.(*retainedCleanupError); ok {
+		if retained.RetryCleanup() != nil {
+			return retained
+		}
 		return nil
 	}
-	return retrier.RetryCleanup()
+
+	retriers := cleanupRetriers(err)
+	if len(retriers) == 0 {
+		return nil
+	}
+	if len(retriers) == 1 {
+		if retriers[0].RetryCleanup() != nil {
+			return err
+		}
+		return nil
+	}
+
+	retained := &retainedCleanupError{cause: err, retriers: retriers}
+	if retained.RetryCleanup() != nil {
+		return retained
+	}
+	return nil
+}
+
+type retainedCleanupError struct {
+	cause    error
+	retriers []cleanupRetrier
+}
+
+func (e *retainedCleanupError) Error() string { return e.cause.Error() }
+func (e *retainedCleanupError) Unwrap() error { return e.cause }
+
+func (e *retainedCleanupError) RetryCleanup() error {
+	remaining := e.retriers[:0]
+	var retryErr error
+	for _, retrier := range e.retriers {
+		if err := retrier.RetryCleanup(); err != nil {
+			remaining = append(remaining, retrier)
+			retryErr = errors.Join(retryErr, err)
+		}
+	}
+	e.retriers = remaining
+	return retryErr
+}
+
+func cleanupRetriers(err error) []cleanupRetrier {
+	var retriers []cleanupRetrier
+	stack := []error{err}
+	for len(stack) > 0 {
+		current := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if current == nil {
+			continue
+		}
+		if retrier, ok := current.(cleanupRetrier); ok &&
+			!containsCleanupRetrier(retriers, retrier) {
+			retriers = append(retriers, retrier)
+		}
+		switch wrapped := current.(type) {
+		case interface{ Unwrap() []error }:
+			stack = append(stack, wrapped.Unwrap()...)
+		case interface{ Unwrap() error }:
+			stack = append(stack, wrapped.Unwrap())
+		}
+	}
+	return retriers
+}
+
+func containsCleanupRetrier(
+	retriers []cleanupRetrier, candidate cleanupRetrier,
+) bool {
+	for _, retrier := range retriers {
+		left := reflect.ValueOf(retrier)
+		right := reflect.ValueOf(candidate)
+		if left.Type() != right.Type() {
+			continue
+		}
+		if left.Type().Comparable() && left.Interface() == right.Interface() {
+			return true
+		}
+		switch left.Kind() {
+		case reflect.Chan, reflect.Func, reflect.Pointer,
+			reflect.Slice, reflect.UnsafePointer:
+			if left.Pointer() == right.Pointer() {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/internal/remotesync/cleanup_registry_test.go
+++ b/internal/remotesync/cleanup_registry_test.go
@@ -1,0 +1,137 @@
+package remotesync
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCleanupRegistryRetriesBeforeReturningAndBeforeLaterWork(t *testing.T) {
+	operationErr := errors.New("operation failed")
+	cleanupErr := errors.New("cleanup failed")
+	owner := &cleanupRetryTestError{
+		cause: operationErr,
+		results: []error{
+			cleanupErr,
+			cleanupErr,
+			cleanupErr,
+			nil,
+		},
+	}
+	var registry CleanupRegistry
+	runs := 0
+
+	_, err := registry.Run(func() (SyncStats, error) {
+		runs++
+		return SyncStats{}, owner
+	})
+	require.Same(t, owner, err)
+	assert.ErrorIs(t, err, operationErr)
+	assert.Equal(t, 1, owner.retryCount())
+	assert.Equal(t, 1, runs)
+
+	_, err = registry.Run(func() (SyncStats, error) {
+		runs++
+		return SyncStats{}, nil
+	})
+	var pending *PendingCleanupError
+	require.ErrorAs(t, err, &pending)
+	assert.NotSame(t, owner, err)
+	assert.Same(t, owner, pending.Err)
+	assert.ErrorIs(t, err, owner)
+	assert.ErrorIs(t, err, operationErr)
+	assert.Equal(t, 2, owner.retryCount())
+	assert.Equal(t, 1, runs, "retained cleanup blocks new work")
+
+	_, err = registry.Run(func() (SyncStats, error) {
+		runs++
+		return SyncStats{}, nil
+	})
+	require.ErrorAs(t, err, &pending)
+	assert.ErrorIs(t, err, owner)
+	assert.Equal(t, 3, owner.retryCount())
+	assert.Equal(t, 1, runs, "later calls remain explicitly blocked")
+
+	_, err = registry.Run(func() (SyncStats, error) {
+		runs++
+		return SyncStats{SessionsSynced: 1}, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 4, owner.retryCount())
+	assert.Equal(t, 2, runs, "new work starts only after retained ownership releases")
+}
+
+func TestCleanupRegistrySerializesConcurrentWork(t *testing.T) {
+	var registry CleanupRegistry
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	secondAttempting := make(chan struct{})
+	secondStarted := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, _ = registry.Run(func() (SyncStats, error) {
+			close(firstStarted)
+			<-releaseFirst
+			return SyncStats{}, nil
+		})
+	}()
+	<-firstStarted
+	go func() {
+		defer wg.Done()
+		close(secondAttempting)
+		_, _ = registry.Run(func() (SyncStats, error) {
+			close(secondStarted)
+			return SyncStats{}, nil
+		})
+	}()
+	<-secondAttempting
+
+	select {
+	case <-secondStarted:
+		require.FailNow(t, "concurrent work entered before the active run completed")
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(releaseFirst)
+	wg.Wait()
+	assertClosed(t, secondStarted)
+}
+
+type cleanupRetryTestError struct {
+	mu      sync.Mutex
+	cause   error
+	results []error
+	retries int
+}
+
+func (e *cleanupRetryTestError) Error() string { return e.cause.Error() }
+
+func (e *cleanupRetryTestError) Unwrap() error { return e.cause }
+
+func (e *cleanupRetryTestError) RetryCleanup() error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	result := e.results[e.retries]
+	e.retries++
+	return result
+}
+
+func (e *cleanupRetryTestError) retryCount() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.retries
+}
+
+func assertClosed(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-ch:
+	default:
+		assert.Fail(t, "channel remains open")
+	}
+}

--- a/internal/remotesync/cleanup_registry_test.go
+++ b/internal/remotesync/cleanup_registry_test.go
@@ -2,6 +2,7 @@ package remotesync
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -63,6 +64,60 @@ func TestCleanupRegistryRetriesBeforeReturningAndBeforeLaterWork(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 4, owner.retryCount())
 	assert.Equal(t, 2, runs, "new work starts only after retained ownership releases")
+}
+
+func TestCleanupRegistryRetriesEveryDistinctJoinedOwner(t *testing.T) {
+	firstFailure := errors.New("first cleanup still blocked")
+	first := &cleanupRetryTestError{
+		cause:   errors.New("first cleanup owner"),
+		results: []error{firstFailure, nil},
+	}
+	secondFailure := errors.New("second cleanup still blocked")
+	second := &cleanupRetryTestError{
+		cause:   errors.New("second cleanup owner"),
+		results: []error{secondFailure, secondFailure, nil},
+	}
+	joined := errors.Join(
+		fmt.Errorf("wrapped first owner: %w", first),
+		second,
+		fmt.Errorf("duplicate first owner: %w", first),
+	)
+	var registry CleanupRegistry
+	runs := 0
+
+	_, err := registry.Run(func() (SyncStats, error) {
+		runs++
+		return SyncStats{}, joined
+	})
+	require.Same(t, joined, err)
+	assert.Equal(t, 1, first.retryCount(),
+		"one owner appearing twice in the error tree is retried once")
+	assert.Equal(t, 1, second.retryCount(),
+		"a sibling owner is retried even when the first owner retains cleanup")
+
+	_, err = registry.Run(func() (SyncStats, error) {
+		runs++
+		return SyncStats{SessionsSynced: 1}, nil
+	})
+	var pending *PendingCleanupError
+	require.ErrorAs(t, err, &pending)
+	assert.ErrorIs(t, err, first.cause)
+	assert.ErrorIs(t, err, second.cause)
+	assert.Equal(t, 2, first.retryCount())
+	assert.Equal(t, 2, second.retryCount())
+	assert.Equal(t, 1, runs,
+		"new work stays blocked while any retained owner still fails")
+
+	_, err = registry.Run(func() (SyncStats, error) {
+		runs++
+		return SyncStats{SessionsSynced: 1}, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, first.retryCount(),
+		"successful owners are not retried with the retained failures")
+	assert.Equal(t, 3, second.retryCount())
+	assert.Equal(t, 2, runs,
+		"new work starts after every retained owner releases")
 }
 
 func TestCleanupRegistrySerializesConcurrentWork(t *testing.T) {

--- a/internal/remotesync/failure.go
+++ b/internal/remotesync/failure.go
@@ -21,6 +21,11 @@ func FailureSummary(err error) string {
 	if err == nil {
 		return generic
 	}
+	var pending *PendingCleanupError
+	if errors.As(err, &pending) {
+		return "HTTP remote sync blocked: cleanup from an earlier sync " +
+			"still owns resources"
+	}
 
 	var statusErr *StatusError
 	if errors.As(err, &statusErr) {

--- a/internal/remotesync/failure_test.go
+++ b/internal/remotesync/failure_test.go
@@ -43,6 +43,14 @@ func TestFailureSummary(t *testing.T) {
 			want: "HTTP remote sync failed",
 		},
 		{
+			name: "pending cleanup takes precedence over retained status",
+			err: &PendingCleanupError{Err: &StatusError{
+				Code: 403, Detail: "private retained response",
+			}},
+			want: "HTTP remote sync blocked: cleanup from an earlier sync " +
+				"still owns resources",
+		},
+		{
 			name: "unauthorized status",
 			err: fmt.Errorf("fetch targets: %w", &StatusError{
 				Code:   401,

--- a/internal/remotesync/http.go
+++ b/internal/remotesync/http.go
@@ -285,16 +285,16 @@ func (hs HTTPSync) downloadAndExtract(
 	if err != nil {
 		return "", err
 	}
-	tmpDir, err := os.MkdirTemp("", "agentsview-http-*")
-	if err != nil {
-		return "", fmt.Errorf("create temp dir: %w", err)
-	}
+	var tmpDir string
 	defer func() {
 		cleanupErr := archive.Close()
 		if err == nil && cleanupErr == nil {
 			return
 		}
-		rootErr := os.RemoveAll(tmpDir)
+		var rootErr error
+		if tmpDir != "" {
+			rootErr = os.RemoveAll(tmpDir)
+		}
 		if cleanupErr != nil || rootErr != nil {
 			var retainedArchive *downloadedArchive
 			if cleanupErr != nil {
@@ -311,6 +311,10 @@ func (hs HTTPSync) downloadAndExtract(
 		}
 		root = ""
 	}()
+	tmpDir, err = os.MkdirTemp("", "agentsview-http-*")
+	if err != nil {
+		return "", fmt.Errorf("create temp dir: %w", err)
+	}
 	extractLabel := fmt.Sprintf("Extracting session archive from %s", hs.Host)
 	if err := archive.extract(ctx, tmpDir, hs.Progress, extractLabel); err != nil {
 		return "", err

--- a/internal/remotesync/http.go
+++ b/internal/remotesync/http.go
@@ -11,7 +11,9 @@ import (
 	"mime"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
+	"sync"
 
 	"go.kenn.io/agentsview/internal/db"
 	syncpkg "go.kenn.io/agentsview/internal/sync"
@@ -27,88 +29,67 @@ type HTTPSync struct {
 	BlockedResultCategories []string
 	Progress                syncpkg.ProgressFunc
 	Client                  *http.Client
+	runPrepare              func(context.Context) (*PreparedHTTP, error)
+	removeArchiveSpool      func(string) error
 }
 
-func (hs HTTPSync) Run(ctx context.Context) (SyncStats, error) {
-	client := hs.Client
-	if client == nil {
-		client = http.DefaultClient
+// PreparedCleanupError reports an operation failure while retaining a prepared
+// HTTP source whose cleanup still needs to be retried. RetryCleanup is safe to
+// call more than once. Error matching traverses the original operation and
+// cleanup causes through Unwrap.
+type PreparedCleanupError struct {
+	mu       sync.Mutex
+	cause    error
+	prepared *PreparedHTTP
+}
+
+func (e *PreparedCleanupError) Error() string { return e.cause.Error() }
+
+func (e *PreparedCleanupError) Unwrap() error { return e.cause }
+
+// RetryCleanup retries release of the source retained by this error.
+func (e *PreparedCleanupError) RetryCleanup() error {
+	if e == nil {
+		return nil
 	}
-	hs.report(syncpkg.Progress{
-		Detail: fmt.Sprintf("Resolving agent directories on %s", hs.Host),
-	})
-	targets, err := hs.fetchTargets(ctx, client)
-	if err != nil {
-		return SyncStats{}, err
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.prepared == nil {
+		return nil
 	}
-	if err := validateTargetSetPaths(targets); err != nil {
-		return SyncStats{}, err
+	if err := e.prepared.Close(); err != nil {
+		return err
 	}
-	if hs.DataDir != "" {
-		stats, handled, err := hs.tryMirrorSync(ctx, client, targets)
-		if handled || err != nil {
-			return stats, err
+	e.prepared = nil
+	return nil
+}
+
+func (hs HTTPSync) Run(ctx context.Context) (stats SyncStats, err error) {
+	prepare := hs.Prepare
+	if hs.runPrepare != nil {
+		prepare = hs.runPrepare
+	}
+	prepared, prepareErr := prepare(ctx)
+	if prepareErr != nil {
+		if prepared == nil {
+			return SyncStats{}, prepareErr
 		}
-		hs.report(syncpkg.Progress{
-			Detail: fmt.Sprintf(
-				"Remote %s does not support incremental sync; downloading full archive",
-				hs.Host,
-			),
-		})
+		cleanupErr := prepared.Close()
+		if cleanupErr == nil {
+			return SyncStats{}, prepareErr
+		}
+		return SyncStats{}, &PreparedCleanupError{
+			cause: errors.Join(prepareErr, cleanupErr), prepared: prepared,
+		}
 	}
-	return hs.runLegacy(ctx, client, targets)
-}
-
-// tryMirrorSync runs the incremental mirror flow, reporting
-// handled=false when the remote lacks manifest support and the caller
-// should fall back to the legacy full-archive path. The mirror lock is
-// acquired BEFORE the manifest fetch: concurrent syncs of the same
-// host would otherwise fetch manifests in one order and apply them in
-// another, and the stale manifest's deletion pass would remove files
-// the newer sync just mirrored.
-func (hs HTTPSync) tryMirrorSync(
-	ctx context.Context, client *http.Client, targets TargetSet,
-) (SyncStats, bool, error) {
-	// The manifest covers only dir-scoped agents; file-scoped agents
-	// (Windsurf) stream curated, sanitized exports the manifest cannot
-	// model, so they are fetched as a separate small full archive on
-	// every mirror sync instead of dragging the whole host onto the
-	// full-archive path.
-	dirScoped, fileScoped := targets.SplitFileScoped()
-	mirrorRoot := MirrorDir(hs.DataDir, hs.Host)
-	lock, err := AcquireMirrorLock(ctx, mirrorRoot)
-	if err != nil {
-		return SyncStats{}, true, err
-	}
-	defer func() { _ = lock.Close() }()
-	manifest, supported, err := hs.fetchManifest(ctx, client, dirScoped)
-	if err != nil {
-		return SyncStats{}, true, err
-	}
-	if !supported {
-		return SyncStats{}, false, nil
-	}
-	split := splitTargets{
-		all:        targets,
-		dirScoped:  dirScoped,
-		fileScoped: fileScoped,
-	}
-	stats, err := hs.runMirror(ctx, client, split, manifest, mirrorRoot)
-	return stats, true, err
-}
-
-// runLegacy is the pre-manifest flow: download the full tree into a
-// throwaway temp dir and import it. It remains the path for old
-// daemons (no manifest endpoint) and for callers without a DataDir.
-func (hs HTTPSync) runLegacy(
-	ctx context.Context, client *http.Client, targets TargetSet,
-) (SyncStats, error) {
-	tmpDir, err := hs.downloadAndExtract(ctx, client, targets)
-	if err != nil {
-		return SyncStats{}, err
-	}
-	defer os.RemoveAll(tmpDir)
-	return hs.importRoot(ctx, targets, tmpDir)
+	defer func() {
+		if cleanupErr := prepared.Close(); cleanupErr != nil {
+			err = &PreparedCleanupError{
+				cause: errors.Join(err, cleanupErr), prepared: prepared,
+			}
+		}
+	}()
+	return prepared.ImportActive(ctx)
 }
 
 func (hs HTTPSync) importRoot(
@@ -131,81 +112,6 @@ func (hs HTTPSync) importRoot(
 		),
 	})
 	return stats, nil
-}
-
-// splitTargets carries a target set alongside its SplitFileScoped
-// partition so the mirror flow addresses each half without
-// re-deriving it.
-type splitTargets struct {
-	all        TargetSet
-	dirScoped  TargetSet
-	fileScoped TargetSet
-}
-
-// runMirror syncs incrementally: diff the manifest against the
-// persistent mirror, download only changed files, and import over the
-// complete mirror tree so parser sibling reads keep working. The
-// caller holds the mirror lock from before the manifest fetch through
-// import, because extraction truncates files in place and the engine
-// reads the mirror during SyncAll.
-func (hs HTTPSync) runMirror(
-	ctx context.Context,
-	client *http.Client,
-	targets splitTargets,
-	manifest Manifest,
-	mirrorRoot string,
-) (SyncStats, error) {
-	delta, err := MirrorDiff(mirrorRoot, manifest)
-	if err != nil {
-		return SyncStats{}, err
-	}
-	// Deletions run BEFORE extraction so a remote path that changed
-	// type does not wedge the mirror: a stale file would block
-	// creating a directory of the same name and vice versa.
-	// ApplyMirrorDeletions prunes emptied directories for the same
-	// reason. The pass also clears all file-scoped mirror content
-	// (never in the manifest); the file-scoped archive re-populates it
-	// below, so exports removed on the remote disappear locally too.
-	if err := ApplyMirrorDeletions(mirrorRoot, delta.Deletions); err != nil {
-		return SyncStats{}, err
-	}
-	// Directories stranded at fetch paths (crashed extraction) are
-	// invisible to the deletion pass and would block writing the file.
-	if err := RemoveMirrorTypeConflicts(mirrorRoot, delta.Fetch); err != nil {
-		return SyncStats{}, err
-	}
-	if len(delta.Fetch) > 0 || hs.Full {
-		// Bootstrap heuristic: past half the corpus a full archive is
-		// cheaper than uploading a huge file list, and it doubles as
-		// the empty-mirror bootstrap (fetch == total). --full bypasses
-		// the stat diff entirely: it is the user's remedy for a stale
-		// or corrupt mirror, which the size/mtime comparison cannot
-		// detect (a same-size same-mtime rewrite, or local bit rot).
-		full := hs.Full || len(delta.Fetch)*2 >= delta.Total
-		err := hs.downloadIntoMirror(ctx, client, targets.dirScoped, delta.Fetch, full, mirrorRoot)
-		var statusErr *StatusError
-		if err != nil && !full && errors.As(err, &statusErr) {
-			// Mid-rollout oddity: manifest worked but the delta
-			// request was refused. Retry once as a full archive.
-			err = hs.downloadIntoMirror(ctx, client, targets.dirScoped, delta.Fetch, true, mirrorRoot)
-		}
-		if err != nil {
-			return SyncStats{}, err
-		}
-	}
-	if !targets.fileScoped.IsEmpty() {
-		// File-scoped exports (sanitized Windsurf state DBs) are
-		// regenerated per archive and carry no stat identity the
-		// manifest could diff, so they are re-fetched as a small full
-		// archive on every sync. Extraction preserves the stamped
-		// mtime, so downstream freshness checks still skip unchanged
-		// sessions.
-		err := hs.downloadIntoMirror(ctx, client, targets.fileScoped, nil, true, mirrorRoot)
-		if err != nil {
-			return SyncStats{}, err
-		}
-	}
-	return hs.importRoot(ctx, targets.all, mirrorRoot)
 }
 
 func (hs HTTPSync) fetchManifest(
@@ -275,11 +181,17 @@ func (hs HTTPSync) downloadIntoMirror(
 	fetch []string,
 	full bool,
 	mirrorRoot string,
-) error {
+) (err error) {
 	request := ArchiveRequest{TargetSet: targets}
-	label := fmt.Sprintf("Downloading %d changed files from %s", len(fetch), hs.Host)
+	downloadLabel := fmt.Sprintf(
+		"Downloading %d changed files from %s", len(fetch), hs.Host,
+	)
+	extractLabel := fmt.Sprintf(
+		"Extracting %d changed files from %s", len(fetch), hs.Host,
+	)
 	if full {
-		label = fmt.Sprintf("Downloading session archive from %s", hs.Host)
+		downloadLabel = fmt.Sprintf("Downloading session archive from %s", hs.Host)
+		extractLabel = fmt.Sprintf("Extracting session archive from %s", hs.Host)
 	} else {
 		request.DeltaFiles = fetch
 	}
@@ -301,39 +213,20 @@ func (hs HTTPSync) downloadIntoMirror(
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return httpStatusError(resp)
+	archive, err := hs.downloadArchive(
+		ctx, resp, downloadLabel, filepath.Dir(mirrorRoot),
+	)
+	if err != nil {
+		return err
 	}
-	hs.report(syncpkg.Progress{
-		Detail:     label,
-		BytesTotal: positiveContentLength(resp.ContentLength),
-	})
-	// Progress counts compressed wire bytes so totals stay meaningful.
-	progress := &progressReader{
-		r:     resp.Body,
-		total: positiveContentLength(resp.ContentLength),
-		report: func(done, total int64) {
-			hs.report(syncpkg.Progress{
-				Detail:     label,
-				BytesDone:  done,
-				BytesTotal: total,
-			})
-		},
-	}
-	stream := io.Reader(progress)
-	if resp.Header.Get("Content-Encoding") == "gzip" {
-		gz, err := gzip.NewReader(progress)
-		if err != nil {
-			return fmt.Errorf("decode archive gzip: %w", err)
+	defer func() {
+		if cleanupErr := archive.Close(); cleanupErr != nil {
+			err = retainDownloadedArchiveCleanup(
+				errors.Join(err, cleanupErr), archive, "",
+			)
 		}
-		defer gz.Close()
-		stream = gz
-	}
-	if err := os.MkdirAll(mirrorRoot, 0o755); err != nil {
-		return fmt.Errorf("create mirror dir: %w", err)
-	}
-	if _, err := ExtractTarStream(ctx, stream, mirrorRoot); err != nil {
+	}()
+	if err := archive.extract(ctx, mirrorRoot, hs.Progress, extractLabel); err != nil {
 		return fmt.Errorf("extract archive into mirror: %w", err)
 	}
 	return nil
@@ -369,7 +262,7 @@ func (hs HTTPSync) downloadAndExtract(
 	ctx context.Context,
 	client *http.Client,
 	targets TargetSet,
-) (string, error) {
+) (root string, err error) {
 	body, err := json.Marshal(targets)
 	if err != nil {
 		return "", err
@@ -382,69 +275,45 @@ func (hs HTTPSync) downloadAndExtract(
 	}
 	hs.authorize(req)
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept-Encoding", "gzip")
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", httpStatusError(resp)
+	downloadLabel := fmt.Sprintf("Downloading session archive from %s", hs.Host)
+	archive, err := hs.downloadArchive(ctx, resp, downloadLabel, os.TempDir())
+	if err != nil {
+		return "", err
 	}
 	tmpDir, err := os.MkdirTemp("", "agentsview-http-*")
 	if err != nil {
 		return "", fmt.Errorf("create temp dir: %w", err)
 	}
-	archivePath := tmpDir + "/remote-sync.tar"
-	archive, err := os.Create(archivePath)
-	if err != nil {
-		os.RemoveAll(tmpDir)
-		return "", fmt.Errorf("create archive temp file: %w", err)
-	}
-	downloadLabel := fmt.Sprintf("Downloading session archive from %s", hs.Host)
-	hs.report(syncpkg.Progress{
-		Detail:     downloadLabel,
-		BytesTotal: positiveContentLength(resp.ContentLength),
-	})
-	reader := &progressReader{
-		r:     resp.Body,
-		total: positiveContentLength(resp.ContentLength),
-		report: func(done, total int64) {
-			hs.report(syncpkg.Progress{
-				Detail:     downloadLabel,
-				BytesDone:  done,
-				BytesTotal: total,
-			})
-		},
-	}
-	if _, err := io.Copy(archive, reader); err != nil {
-		_ = archive.Close()
-		os.RemoveAll(tmpDir)
-		return "", fmt.Errorf("download archive: %w", err)
-	}
-	if err := archive.Close(); err != nil {
-		os.RemoveAll(tmpDir)
-		return "", fmt.Errorf("close archive temp file: %w", err)
-	}
-	hs.report(syncpkg.Progress{
-		Detail: fmt.Sprintf("Extracting session archive from %s", hs.Host),
-	})
-	archive, err = os.Open(archivePath)
-	if err != nil {
-		os.RemoveAll(tmpDir)
-		return "", fmt.Errorf("open archive temp file: %w", err)
-	}
-	if _, err := ExtractTarStream(ctx, archive, tmpDir); err != nil {
-		_ = archive.Close()
-		os.RemoveAll(tmpDir)
-		return "", fmt.Errorf("extract tar: %w", err)
-	}
-	if err := archive.Close(); err != nil {
-		os.RemoveAll(tmpDir)
-		return "", fmt.Errorf("close archive temp file: %w", err)
-	}
-	if err := os.Remove(archivePath); err != nil {
-		os.RemoveAll(tmpDir)
-		return "", fmt.Errorf("remove archive temp file: %w", err)
+	defer func() {
+		cleanupErr := archive.Close()
+		if err == nil && cleanupErr == nil {
+			return
+		}
+		rootErr := os.RemoveAll(tmpDir)
+		if cleanupErr != nil || rootErr != nil {
+			var retainedArchive *downloadedArchive
+			if cleanupErr != nil {
+				retainedArchive = archive
+			}
+			var retainedRoot string
+			if rootErr != nil {
+				retainedRoot = tmpDir
+			}
+			err = retainDownloadedArchiveCleanup(
+				errors.Join(err, cleanupErr, rootErr),
+				retainedArchive, retainedRoot,
+			)
+		}
+		root = ""
+	}()
+	extractLabel := fmt.Sprintf("Extracting session archive from %s", hs.Host)
+	if err := archive.extract(ctx, tmpDir, hs.Progress, extractLabel); err != nil {
+		return "", err
 	}
 	return tmpDir, nil
 }
@@ -453,6 +322,10 @@ func (hs HTTPSync) report(progress syncpkg.Progress) {
 	if hs.Progress != nil {
 		hs.Progress(progress)
 	}
+}
+
+func (hs HTTPSync) reportProgressDetail(detail string) {
+	hs.report(syncpkg.Progress{Detail: detail})
 }
 
 func positiveContentLength(n int64) int64 {

--- a/internal/remotesync/http_prepare.go
+++ b/internal/remotesync/http_prepare.go
@@ -1,0 +1,448 @@
+package remotesync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"slices"
+	"sort"
+	"sync"
+
+	"go.kenn.io/agentsview/internal/db"
+	syncpkg "go.kenn.io/agentsview/internal/sync"
+)
+
+var (
+	ErrDuplicateMirrorLock = errors.New("duplicate mirror lock identity")
+	ErrPreparedInUse       = errors.New("prepared HTTP sources are in use")
+	ErrPreparedClosed      = errors.New("prepared HTTP sources are closing or closed")
+)
+
+// HostError attributes an HTTP preparation failure to its configured host.
+// The cause remains available to errors.Is and errors.As callers.
+type HostError struct {
+	Host      string
+	Operation string
+	Err       error
+}
+
+func (e *HostError) Error() string {
+	if e.Operation == "" {
+		return fmt.Sprintf("HTTP host %q: %v", e.Host, e.Err)
+	}
+	return fmt.Sprintf("HTTP host %q %s: %v", e.Host, e.Operation, e.Err)
+}
+
+func (e *HostError) Unwrap() error { return e.Err }
+
+// PreparedHTTPSyncs owns a deterministically prepared group of HTTP sources.
+// Source ownership stays internal so locks and temporary roots can only be
+// released as a group.
+type PreparedHTTPSyncs struct {
+	mu      sync.Mutex
+	sources []*PreparedHTTP
+	closing bool
+	borrows int
+}
+
+// PrepareHTTPSyncs prepares HTTP hosts in deterministic order, using canonical
+// mirror-lock paths for persistent sources and host/URL keys for legacy
+// temporary sources. It copies the input so callers retain their original
+// ordering. When both the preparation and its unwind fail, the returned set is
+// nonnil and callers must retry Close even though err is also nonnil.
+func PrepareHTTPSyncs(
+	ctx context.Context, syncs []HTTPSync,
+) (*PreparedHTTPSyncs, error) {
+	return prepareHTTPSyncs(ctx, syncs, func(
+		ctx context.Context, hs HTTPSync,
+	) (*PreparedHTTP, error) {
+		return hs.Prepare(ctx)
+	})
+}
+
+func prepareHTTPSyncs(
+	ctx context.Context,
+	syncs []HTTPSync,
+	prepare func(context.Context, HTTPSync) (*PreparedHTTP, error),
+) (*PreparedHTTPSyncs, error) {
+	type orderedSync struct {
+		sync    HTTPSync
+		sortKey string
+	}
+	ordered := make([]orderedSync, 0, len(syncs))
+	seenLocks := make(map[string]HTTPSync, len(syncs))
+	for _, hs := range syncs {
+		if hs.DataDir == "" {
+			// Legacy sources use isolated temporary roots and never acquire a
+			// mirror lock. Give them a stable ordering without resolving a
+			// nonexistent lock path (which would create cwd artifacts).
+			ordered = append(ordered, orderedSync{
+				sync: hs, sortKey: "legacy\x00" + hs.Host + "\x00" + hs.URL,
+			})
+			continue
+		}
+		lockPath, err := canonicalMirrorLockPath(MirrorDir(hs.DataDir, hs.Host))
+		if err != nil {
+			return nil, &HostError{
+				Host: hs.Host, Operation: "resolve mirror lock", Err: err,
+			}
+		}
+		if previous, exists := seenLocks[lockPath]; exists {
+			cause := fmt.Errorf(
+				"%w: hosts %q and %q use %q",
+				ErrDuplicateMirrorLock, previous.Host, hs.Host, lockPath,
+			)
+			return nil, &HostError{
+				Host: hs.Host, Operation: "resolve mirror lock", Err: cause,
+			}
+		}
+		seenLocks[lockPath] = hs
+		ordered = append(ordered, orderedSync{
+			sync: hs, sortKey: "mirror\x00" + lockPath,
+		})
+	}
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return ordered[i].sortKey < ordered[j].sortKey
+	})
+
+	prepared := &PreparedHTTPSyncs{
+		sources: make([]*PreparedHTTP, 0, len(ordered)),
+	}
+	for _, input := range ordered {
+		hs := input.sync
+		source, err := prepare(ctx, hs)
+		if err != nil {
+			if source != nil {
+				prepared.sources = append(prepared.sources, source)
+			}
+			primary := &HostError{Host: hs.Host, Operation: "prepare", Err: err}
+			cleanupErr := prepared.Close()
+			if cleanupErr != nil {
+				return prepared, errors.Join(primary, cleanupErr)
+			}
+			return nil, primary
+		}
+		prepared.sources = append(prepared.sources, source)
+	}
+	return prepared, nil
+}
+
+// BorrowRebuildContributors borrows rebuild descriptions while the prepared
+// set retains cleanup ownership. Callers must invoke the idempotent release
+// function after the rebuild stops using every contributor. Close refuses to
+// release any source while a borrow remains active.
+func (p *PreparedHTTPSyncs) BorrowRebuildContributors() (
+	contributors []syncpkg.RebuildContributor,
+	release func(),
+	err error,
+) {
+	if p == nil {
+		return nil, nil, ErrPreparedClosed
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closing {
+		return nil, nil, ErrPreparedClosed
+	}
+	contributors = make([]syncpkg.RebuildContributor, 0, len(p.sources))
+	for _, source := range p.sources {
+		if source == nil {
+			continue
+		}
+		contributor, err := source.RebuildContributor()
+		if err != nil {
+			return nil, nil, &HostError{
+				Host: source.sync.Host, Operation: "build rebuild contributor", Err: err,
+			}
+		}
+		contributors = append(contributors, contributor)
+	}
+	p.borrows++
+	var once sync.Once
+	release = func() {
+		once.Do(func() {
+			p.mu.Lock()
+			p.borrows--
+			p.mu.Unlock()
+		})
+	}
+	return contributors, release, nil
+}
+
+// Close releases prepared sources in reverse order. Successfully closed
+// sources are forgotten; failed sources remain owned so cleanup can be retried.
+func (p *PreparedHTTPSyncs) Close() error {
+	if p == nil {
+		return nil
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.closing = true
+	if p.borrows > 0 {
+		return ErrPreparedInUse
+	}
+	var cleanupErr error
+	for i := range slices.Backward(p.sources) {
+		source := p.sources[i]
+		if source == nil {
+			continue
+		}
+		if err := source.Close(); err != nil {
+			cleanupErr = errors.Join(cleanupErr, &HostError{
+				Host: source.sync.Host, Operation: "cleanup prepared source", Err: err,
+			})
+			continue
+		}
+		p.sources[i] = nil
+	}
+	return cleanupErr
+}
+
+// PreparedHTTP is a downloaded remote source ready for active import. A
+// persistent mirror remains locked until Close so another process cannot mutate
+// files while the importer reads them. Legacy sources own their temporary root.
+type PreparedHTTP struct {
+	sync        HTTPSync
+	targets     TargetSet
+	root        string
+	lock        *MirrorLockHandle
+	cleanupRoot bool
+	closing     bool
+	closed      bool
+	removeRoot  func(string) error
+	releaseLock func(*MirrorLockHandle) error
+}
+
+// Prepare resolves the remote targets and prepares either the persistent
+// manifest mirror or an isolated legacy archive without importing sessions.
+// When preparation and automatic cleanup both fail, it returns a nonnil source
+// with the error; callers must retry Close on every nonnil result. If cleanup
+// succeeds, preparation failures retain the ordinary (nil, err) shape.
+func (hs HTTPSync) Prepare(ctx context.Context) (*PreparedHTTP, error) {
+	return hs.prepare(ctx, nil)
+}
+
+func (hs HTTPSync) prepare(
+	ctx context.Context, configure func(*PreparedHTTP),
+) (result *PreparedHTTP, err error) {
+	client := hs.Client
+	if client == nil {
+		client = http.DefaultClient
+	}
+	hs.reportProgressResolvingTargets()
+	targets, err := hs.fetchTargets(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateTargetSetPaths(targets); err != nil {
+		return nil, err
+	}
+
+	prepared := &PreparedHTTP{
+		sync:        hs,
+		targets:     targets,
+		removeRoot:  os.RemoveAll,
+		releaseLock: func(lock *MirrorLockHandle) error { return lock.Close() },
+	}
+	if configure != nil {
+		configure(prepared)
+	}
+	defer func() {
+		if err != nil {
+			if cleanupErr := prepared.Close(); cleanupErr != nil {
+				result = prepared
+				err = errors.Join(err, cleanupErr)
+			}
+		}
+	}()
+
+	if hs.DataDir == "" {
+		prepared.root, err = hs.downloadAndExtract(ctx, client, targets)
+		if err != nil {
+			return nil, err
+		}
+		prepared.cleanupRoot = true
+		return prepared, nil
+	}
+
+	mirrorRoot := MirrorDir(hs.DataDir, hs.Host)
+	prepared.lock, err = AcquireMirrorLock(ctx, mirrorRoot)
+	if err != nil {
+		return nil, err
+	}
+	dirScoped, fileScoped := targets.SplitFileScoped()
+	hs.reportProgressDetail(fmt.Sprintf(
+		"Fetching session manifest from %s", hs.Host,
+	))
+	manifest, supported, err := hs.fetchManifest(ctx, client, dirScoped)
+	if err != nil {
+		return nil, err
+	}
+	if !supported {
+		hs.reportLegacyFallback()
+		prepared.root, err = hs.downloadAndExtract(ctx, client, targets)
+		if err != nil {
+			return nil, err
+		}
+		prepared.cleanupRoot = true
+		return prepared, nil
+	}
+
+	prepared.root = mirrorRoot
+	err = hs.prepareMirror(ctx, client, splitTargets{
+		dirScoped:  dirScoped,
+		fileScoped: fileScoped,
+	}, manifest, mirrorRoot)
+	if err != nil {
+		return nil, err
+	}
+	return prepared, nil
+}
+
+// Root returns the prepared source root.
+func (p *PreparedHTTP) Root() string { return p.root }
+
+// Targets returns the target set represented by Root.
+func (p *PreparedHTTP) Targets() TargetSet { return p.targets }
+
+// ImportActive imports the prepared source into the active database.
+func (p *PreparedHTTP) ImportActive(ctx context.Context) (SyncStats, error) {
+	if p == nil || p.closing || p.closed {
+		return SyncStats{}, fmt.Errorf("prepared HTTP source is closed")
+	}
+	return p.sync.importRoot(ctx, p.targets, p.root)
+}
+
+// RebuildContributor converts this prepared source into an atomic rebuild
+// contributor. PreparedHTTP retains ownership of its root and mirror lock;
+// callers must Close it after the rebuild finishes.
+func (p *PreparedHTTP) RebuildContributor() (syncpkg.RebuildContributor, error) {
+	if p == nil || p.closing || p.closed {
+		return syncpkg.RebuildContributor{}, fmt.Errorf(
+			"prepared HTTP source is closed",
+		)
+	}
+	layout, config, err := newImportInputs(
+		p.sync.Host, p.sync.BlockedResultCategories, p.targets, p.root,
+	)
+	if err != nil {
+		return syncpkg.RebuildContributor{}, err
+	}
+	return syncpkg.RebuildContributor{
+		Name:   p.sync.Host,
+		Config: config,
+		Progress: func(progress syncpkg.Progress) syncpkg.Progress {
+			return transformHostProgress(p.sync.Host, progress)
+		},
+		AfterSync: func(engine *syncpkg.Engine, database *db.DB) error {
+			return saveEngineSkipCache(database, engine, layout.paths)
+		},
+	}, nil
+}
+
+// Close releases the mirror lock and removes an owned legacy root. It is safe
+// to call more than once.
+func (p *PreparedHTTP) Close() error {
+	if p == nil || p.closed {
+		return nil
+	}
+	p.closing = true
+	var cleanupErr, lockErr error
+	if p.cleanupRoot && p.root != "" {
+		if err := p.removeRoot(p.root); err != nil {
+			cleanupErr = fmt.Errorf("remove prepared HTTP root: %w", err)
+		} else {
+			p.cleanupRoot = false
+		}
+	}
+	if p.lock != nil {
+		if err := p.releaseLock(p.lock); err != nil {
+			lockErr = err
+		} else {
+			p.lock = nil
+		}
+	}
+	p.closed = !p.cleanupRoot && p.lock == nil
+	return errors.Join(cleanupErr, lockErr)
+}
+
+func (hs HTTPSync) reportProgressResolvingTargets() {
+	hs.reportProgressDetail(fmt.Sprintf("Resolving agent directories on %s", hs.Host))
+}
+
+func (hs HTTPSync) reportLegacyFallback() {
+	hs.reportProgressDetail(fmt.Sprintf(
+		"Remote %s does not support incremental sync; downloading full archive",
+		hs.Host,
+	))
+}
+
+// splitTargets carries a target set alongside its SplitFileScoped partition so
+// mirror preparation addresses each half without re-deriving it.
+type splitTargets struct {
+	dirScoped  TargetSet
+	fileScoped TargetSet
+}
+
+// prepareMirror applies the manifest delta to the persistent mirror. The
+// caller holds the mirror lock from before the manifest fetch until the
+// prepared source is closed.
+func (hs HTTPSync) prepareMirror(
+	ctx context.Context,
+	client *http.Client,
+	targets splitTargets,
+	manifest Manifest,
+	mirrorRoot string,
+) error {
+	delta, err := MirrorDiff(mirrorRoot, manifest)
+	if err != nil {
+		return err
+	}
+	hs.reportProgressDetail(fmt.Sprintf(
+		"Compared session manifest from %s: %d total, %d changed, %d deleted",
+		hs.Host, delta.Total, len(delta.Fetch), len(delta.Deletions),
+	))
+	mutatesMirror := len(delta.Deletions) > 0 || len(delta.Fetch) > 0 ||
+		!targets.fileScoped.IsEmpty()
+	if !mutatesMirror {
+		return nil
+	}
+	if err := hs.DB.ClearRemoteSkippedFiles(hs.Host); err != nil {
+		return fmt.Errorf("clear remote skip cache before mirror mutation: %w", err)
+	}
+
+	// Deletions precede extraction so remote file/directory type changes cannot
+	// wedge the mirror. File-scoped content is absent from the manifest and is
+	// re-populated by its separate full archive below.
+	if err := ApplyMirrorDeletions(mirrorRoot, delta.Deletions); err != nil {
+		return err
+	}
+	if err := RemoveMirrorTypeConflicts(mirrorRoot, delta.Fetch); err != nil {
+		return err
+	}
+	if len(delta.Fetch) > 0 {
+		full := len(delta.Fetch)*2 >= delta.Total
+		err := hs.downloadIntoMirror(
+			ctx, client, targets.dirScoped, delta.Fetch, full, mirrorRoot,
+		)
+		var statusErr *StatusError
+		if err != nil && !full && errors.As(err, &statusErr) {
+			err = hs.downloadIntoMirror(
+				ctx, client, targets.dirScoped, delta.Fetch, true, mirrorRoot,
+			)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	if !targets.fileScoped.IsEmpty() {
+		if err := hs.downloadIntoMirror(
+			ctx, client, targets.fileScoped, nil, true, mirrorRoot,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/remotesync/http_test.go
+++ b/internal/remotesync/http_test.go
@@ -6,13 +6,18 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
+	"strings"
+	stdsync "sync"
 	"testing"
 	"time"
 
@@ -111,11 +116,566 @@ func TestHTTPSyncReportsDownloadAndImportProgress(t *testing.T) {
 	assert.Equal(t, int64(len(archive)), maxBytesTotal(progress))
 }
 
+func TestHTTPSyncReportsCompressedTransferThenExtraction(t *testing.T) {
+	archive := buildHTTPTestTar(t, map[string]string{
+		"home/user/.claude/projects/test/session.jsonl": "compressed archive",
+	})
+	var compressed bytes.Buffer
+	gz := gzip.NewWriter(&compressed)
+	_, err := gz.Write(archive)
+	require.NoError(t, err)
+	require.NoError(t, gz.Close())
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/remote-sync/archive", r.URL.Path)
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Set("Content-Length", strconv.Itoa(compressed.Len()))
+		_, _ = w.Write(compressed.Bytes())
+	}))
+	t.Cleanup(ts.Close)
+
+	var progress []syncpkg.Progress
+	hs := HTTPSync{
+		Host: "devbox",
+		URL:  ts.URL,
+		Progress: func(p syncpkg.Progress) {
+			progress = append(progress, p)
+		},
+	}
+	mirrorRoot := filepath.Join(t.TempDir(), "remote-mirrors", "devbox")
+	err = hs.downloadIntoMirror(
+		context.Background(), ts.Client(), TargetSet{}, []string{"session.jsonl"},
+		false, mirrorRoot,
+	)
+	require.NoError(t, err)
+
+	downloadLabel := "Downloading 1 changed files from devbox"
+	extractLabel := "Extracting 1 changed files from devbox"
+	assert.Equal(t, []string{downloadLabel, extractLabel},
+		uniqueProgressDetails(progress))
+	require.NotEmpty(t, progress)
+	assert.Equal(t, int64(compressed.Len()), maxBytesDone(progress))
+	assert.Equal(t, int64(compressed.Len()), maxBytesTotal(progress))
+}
+
+func TestPrepareHTTPSyncReportsManifestComparisonBeforeTransfer(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	remote.writeSession(t, "a.jsonl",
+		time.Date(2026, 7, 8, 10, 0, 0, 0, time.UTC), "session a")
+	_, hs := newMirrorSync(t, remote, t.TempDir())
+	var progress []syncpkg.Progress
+	hs.Progress = func(p syncpkg.Progress) {
+		progress = append(progress, p)
+	}
+
+	prepared, err := hs.Prepare(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, prepared.Close()) })
+
+	assert.Equal(t, []string{
+		"Resolving agent directories on devbox",
+		"Fetching session manifest from devbox",
+		"Compared session manifest from devbox: 1 total, 1 changed, 0 deleted",
+		"Downloading session archive from devbox",
+		"Extracting session archive from devbox",
+	}, uniqueProgressDetails(progress))
+}
+
+func TestHTTPSyncLegacyCompressedTransferPreservesWireProgress(t *testing.T) {
+	archive := buildHTTPTestTar(t, map[string]string{
+		"home/user/.claude/projects/test/session.jsonl": "legacy compressed",
+	})
+	var compressed bytes.Buffer
+	gz := gzip.NewWriter(&compressed)
+	_, err := gz.Write(archive)
+	require.NoError(t, err)
+	require.NoError(t, gz.Close())
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "gzip", r.Header.Get("Accept-Encoding"))
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Set("Content-Length", strconv.Itoa(compressed.Len()))
+		_, _ = w.Write(compressed.Bytes())
+	}))
+	t.Cleanup(ts.Close)
+
+	var progress []syncpkg.Progress
+	hs := HTTPSync{
+		Host: "devbox",
+		URL:  ts.URL,
+		Progress: func(p syncpkg.Progress) {
+			progress = append(progress, p)
+		},
+	}
+	root, err := hs.downloadAndExtract(
+		context.Background(), ts.Client(), TargetSet{},
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, os.RemoveAll(root)) })
+	body, err := os.ReadFile(filepath.Join(
+		root, "home/user/.claude/projects/test/session.jsonl",
+	))
+	require.NoError(t, err)
+	assert.Equal(t, "legacy compressed", string(body))
+	assert.Equal(t, []string{
+		"Downloading session archive from devbox",
+		"Extracting session archive from devbox",
+	}, uniqueProgressDetails(progress))
+	assert.Equal(t, int64(compressed.Len()), maxBytesDone(progress))
+	assert.Equal(t, int64(compressed.Len()), maxBytesTotal(progress))
+}
+
+func TestHTTPSyncRemovesSpooledArchive(t *testing.T) {
+	tests := []struct {
+		name          string
+		archive       []byte
+		contentLength int
+		status        int
+		wantErr       bool
+	}{
+		{
+			name: "after successful extraction",
+			archive: buildHTTPTestTar(t, map[string]string{
+				"home/user/.claude/projects/test/session.jsonl": "complete",
+			}),
+		},
+		{
+			name: "after extraction failure",
+			archive: tarWithoutEndMarker(t,
+				"home/user/.claude/projects/test/session.jsonl", "truncated"),
+			wantErr: true,
+		},
+		{
+			name: "after response body read failure",
+			archive: buildHTTPTestTar(t, map[string]string{
+				"home/user/.claude/projects/test/session.jsonl": "incomplete response",
+			}),
+			contentLength: 1 << 20,
+			wantErr:       true,
+		},
+		{
+			name:          "after non-success response body read failure",
+			archive:       []byte("upstream failure"),
+			contentLength: 1 << 20,
+			status:        http.StatusBadGateway,
+			wantErr:       true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if tt.contentLength > 0 {
+					w.Header().Set("Content-Length", strconv.Itoa(tt.contentLength))
+				}
+				if tt.status > 0 {
+					w.WriteHeader(tt.status)
+				}
+				_, _ = w.Write(tt.archive)
+			}))
+			t.Cleanup(ts.Close)
+			parent := filepath.Join(t.TempDir(), "remote-mirrors")
+			mirrorRoot := filepath.Join(parent, "devbox")
+
+			err := (HTTPSync{Host: "devbox", URL: ts.URL}).downloadIntoMirror(
+				context.Background(), ts.Client(), TargetSet{}, []string{"session.jsonl"},
+				false, mirrorRoot,
+			)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			if tt.status > 0 {
+				var statusErr *StatusError
+				require.ErrorAs(t, err, &statusErr)
+				assert.Equal(t, tt.status, statusErr.Code)
+			}
+			entries, readErr := os.ReadDir(parent)
+			if errors.Is(readErr, os.ErrNotExist) {
+				return
+			}
+			require.NoError(t, readErr)
+			for _, entry := range entries {
+				assert.NotContains(t, entry.Name(), "agentsview-http-archive-",
+					"owned spool artifacts must be removed")
+			}
+		})
+	}
+}
+
+func TestHTTPSyncMirrorRetainsPostExtractionSpoolCleanup(t *testing.T) {
+	archive := buildHTTPTestTar(t, map[string]string{
+		"home/user/session.jsonl": "complete",
+	})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(archive)
+	}))
+	t.Cleanup(ts.Close)
+	removeErr := errors.New("spool removal failed")
+	removeCalls := 0
+	hs := HTTPSync{Host: "devbox", URL: ts.URL, removeArchiveSpool: func(path string) error {
+		removeCalls++
+		if removeCalls == 1 {
+			return removeErr
+		}
+		return os.RemoveAll(path)
+	}}
+	mirrorRoot := filepath.Join(t.TempDir(), "mirrors", "devbox")
+
+	err := hs.downloadIntoMirror(
+		context.Background(), ts.Client(), TargetSet{}, []string{"session.jsonl"},
+		false, mirrorRoot,
+	)
+
+	require.ErrorIs(t, err, removeErr)
+	var owner *downloadedArchiveCleanupError
+	require.ErrorAs(t, err, &owner,
+		"post-extraction cleanup must remain retryable")
+	assert.FileExists(t, filepath.Join(mirrorRoot, "home/user/session.jsonl"))
+	require.NoError(t, owner.RetryCleanup())
+	assert.Equal(t, 2, removeCalls)
+}
+
+func TestHTTPSyncLegacyRetainsCleanupWithoutLeakingExtractedRoot(t *testing.T) {
+	archive := buildHTTPTestTar(t, map[string]string{
+		"home/user/session.jsonl": "complete",
+	})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(archive)
+	}))
+	t.Cleanup(ts.Close)
+	tempParent := t.TempDir()
+	setPortableTempDir(t, tempParent)
+	removeErr := errors.New("spool removal failed")
+	removeCalls := 0
+	hs := HTTPSync{Host: "devbox", URL: ts.URL, removeArchiveSpool: func(path string) error {
+		removeCalls++
+		if removeCalls == 1 {
+			return removeErr
+		}
+		return os.RemoveAll(path)
+	}}
+
+	root, err := hs.downloadAndExtract(
+		context.Background(), ts.Client(), TargetSet{},
+	)
+
+	assert.Empty(t, root, "failed cleanup must not transfer root ownership")
+	require.ErrorIs(t, err, removeErr)
+	var owner *downloadedArchiveCleanupError
+	require.ErrorAs(t, err, &owner,
+		"post-extraction cleanup must remain retryable")
+	require.NoError(t, owner.RetryCleanup())
+	entries, readErr := os.ReadDir(tempParent)
+	require.NoError(t, readErr)
+	assert.Empty(t, entries,
+		"retry must release both the spool and extracted legacy root")
+}
+
+func TestHTTPSyncRemovesSpooledArchiveOnCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	parent := filepath.Join(t.TempDir(), "remote-mirrors")
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       &cancelEOFBody{ctx: ctx},
+		Header:     make(http.Header),
+	}
+	hs := HTTPSync{Progress: func(p syncpkg.Progress) {
+		if p.BytesDone > 0 {
+			cancel()
+		}
+	}}
+
+	archive, err := hs.downloadArchive(ctx, resp, "Downloading", parent)
+	if archive != nil {
+		t.Cleanup(func() { require.NoError(t, archive.Close()) })
+	}
+	require.ErrorIs(t, err, context.Canceled)
+	entries, readErr := os.ReadDir(parent)
+	require.NoError(t, readErr)
+	assert.Empty(t, entries)
+}
+
+func TestDownloadArchiveCloseFailureRemovesIsolatedSpool(t *testing.T) {
+	closeErr := errors.New("close response body")
+	parent := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(parent, "existing"), []byte("keep"), 0o644,
+	))
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body: &closeErrorBody{
+			Reader: bytes.NewReader([]byte("wire archive")),
+			err:    closeErr,
+		},
+		Header: make(http.Header),
+	}
+
+	archive, err := (HTTPSync{}).downloadArchive(
+		context.Background(), resp, "Downloading", parent,
+	)
+
+	assert.Nil(t, archive)
+	require.ErrorIs(t, err, closeErr)
+	entries, readErr := os.ReadDir(parent)
+	require.NoError(t, readErr)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "existing", entries[0].Name())
+}
+
+func TestDownloadedArchiveUsesIsolatedSpoolOutsideMirror(t *testing.T) {
+	parent := t.TempDir()
+	mirrorRoot := filepath.Join(parent, "devbox")
+	require.NoError(t, os.Mkdir(mirrorRoot, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(parent, "existing"), []byte("keep"), 0o644,
+	))
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewReader([]byte("wire archive"))),
+		Header:     make(http.Header),
+	}
+
+	archive, err := (HTTPSync{}).downloadArchive(
+		context.Background(), resp, "Downloading", parent,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, archive)
+	t.Cleanup(func() { require.NoError(t, archive.Close()) })
+
+	tempDir := filepath.Dir(archive.path)
+	assert.DirExists(t, tempDir)
+	assert.FileExists(t, archive.path)
+	assert.Equal(t, parent, filepath.Dir(tempDir))
+	assert.NotEqual(t, parent, tempDir)
+	assert.False(t, within(mirrorRoot, archive.path),
+		"spool must not be created inside the manifest mirror")
+	require.NoError(t, archive.Close())
+	entries, readErr := os.ReadDir(parent)
+	require.NoError(t, readErr)
+	require.Len(t, entries, 2)
+	assert.Equal(t, []string{"devbox", "existing"},
+		[]string{entries[0].Name(), entries[1].Name()})
+}
+
+func TestDownloadedArchiveExtractionCancellationMidEntry(t *testing.T) {
+	body := make([]byte, 32<<10)
+	state := uint32(1)
+	for i := range body {
+		state ^= state << 13
+		state ^= state >> 17
+		state ^= state << 5
+		body[i] = byte(state)
+	}
+	archiveBytes := buildHTTPTestTar(t, map[string]string{
+		"home/user/large-session.jsonl": string(body),
+	})
+	var compressed bytes.Buffer
+	gz := gzip.NewWriter(&compressed)
+	_, err := gz.Write(archiveBytes)
+	require.NoError(t, err)
+	require.NoError(t, gz.Close())
+	require.Greater(t, compressed.Len(), 1024)
+
+	tests := []struct {
+		name       string
+		wire       []byte
+		compressed bool
+	}{
+		{name: "plain", wire: archiveBytes},
+		{name: "gzip", wire: compressed.Bytes(), compressed: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spoolParent := t.TempDir()
+			spoolDir := filepath.Join(spoolParent, "agentsview-http-archive-test")
+			require.NoError(t, os.Mkdir(spoolDir, 0o700))
+			require.NoError(t, os.WriteFile(
+				filepath.Join(spoolDir, "owned"), []byte("spool"), 0o600,
+			))
+			reached := make(chan struct{})
+			release := make(chan struct{})
+			reader := &gatedArchiveReader{
+				r:         bytes.NewReader(tt.wire),
+				gateAfter: 768,
+				reached:   reached,
+				release:   release,
+			}
+			archive := &downloadedArchive{
+				dir:        spoolDir,
+				path:       filepath.Join(spoolDir, "archive"),
+				compressed: tt.compressed,
+				open:       func() (io.ReadCloser, error) { return reader, nil },
+			}
+			t.Cleanup(func() { require.NoError(t, archive.Close()) })
+			dst := filepath.Join(t.TempDir(), "extracted")
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+			released := false
+			t.Cleanup(func() {
+				if !released {
+					close(release)
+				}
+			})
+			errCh := make(chan error, 1)
+			go func() {
+				errCh <- archive.extract(ctx, dst, nil, "Extracting")
+			}()
+
+			select {
+			case <-reached:
+			case <-time.After(time.Second):
+				require.FailNow(t, "timed out waiting for extraction to enter file body")
+			}
+			cancel()
+			close(release)
+			released = true
+			select {
+			case err := <-errCh:
+				require.ErrorIs(t, err, context.Canceled)
+			case <-time.After(time.Second):
+				require.FailNow(t, "timed out waiting for canceled extraction")
+			}
+			assert.NoFileExists(t,
+				filepath.Join(dst, "home/user/large-session.jsonl"))
+			require.NoError(t, archive.Close())
+			assert.NoDirExists(t, spoolDir)
+		})
+	}
+}
+
+func TestPrepareHTTPSyncCancellationReleasesMirrorOwnership(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	remote.writeSession(t, "large.jsonl",
+		time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC),
+		strings.Repeat("entry\n", 4096))
+	dataDir := t.TempDir()
+	_, hs := newMirrorSync(t, remote, dataDir)
+	ctx, cancel := context.WithCancel(context.Background())
+	extractionStarted := false
+	hs.Progress = func(p syncpkg.Progress) {
+		if strings.HasPrefix(p.Detail, "Extracting ") {
+			extractionStarted = true
+			cancel()
+		}
+	}
+
+	prepared, err := hs.Prepare(ctx)
+
+	assert.Nil(t, prepared)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.True(t, extractionStarted)
+	mirrorRoot := MirrorDir(dataDir, "devbox")
+	assertMirrorUnlocked(t, mirrorRoot)
+	entries, readErr := os.ReadDir(filepath.Dir(mirrorRoot))
+	require.NoError(t, readErr)
+	for _, entry := range entries {
+		assert.NotContains(t, entry.Name(), "agentsview-http-archive-",
+			"canceled preparation must release its spool ownership")
+	}
+}
+
+func TestHTTPSyncLegacyCancellationCleansOwnedRoots(t *testing.T) {
+	archive := buildHTTPTestTar(t, map[string]string{
+		"home/user/large-session.jsonl": strings.Repeat("entry\n", 4096),
+	})
+	var compressed bytes.Buffer
+	gz := gzip.NewWriter(&compressed)
+	_, err := gz.Write(archive)
+	require.NoError(t, err)
+	require.NoError(t, gz.Close())
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Set("Content-Length", strconv.Itoa(compressed.Len()))
+		_, _ = w.Write(compressed.Bytes())
+	}))
+	t.Cleanup(ts.Close)
+	tempParent := t.TempDir()
+	setPortableTempDir(t, tempParent)
+	ctx, cancel := context.WithCancel(context.Background())
+	hs := HTTPSync{
+		Host: "devbox",
+		URL:  ts.URL,
+		Progress: func(p syncpkg.Progress) {
+			if strings.HasPrefix(p.Detail, "Extracting ") {
+				cancel()
+			}
+		},
+	}
+
+	root, err := hs.downloadAndExtract(ctx, ts.Client(), TargetSet{})
+
+	assert.Empty(t, root)
+	require.ErrorIs(t, err, context.Canceled)
+	entries, readErr := os.ReadDir(tempParent)
+	require.NoError(t, readErr)
+	assert.Empty(t, entries,
+		"canceled legacy extraction must remove its spool and extraction root")
+}
+
+type cancelEOFBody struct {
+	ctx  context.Context
+	sent bool
+}
+
+func (b *cancelEOFBody) Read(p []byte) (int, error) {
+	if !b.sent {
+		b.sent = true
+		return copy(p, "partial response"), nil
+	}
+	<-b.ctx.Done()
+	return 0, io.EOF
+}
+
+func (*cancelEOFBody) Close() error { return nil }
+
+type closeErrorBody struct {
+	io.Reader
+	err error
+}
+
+func (b *closeErrorBody) Close() error { return b.err }
+
+type gatedArchiveReader struct {
+	r         *bytes.Reader
+	gateAfter int
+	read      int
+	reached   chan struct{}
+	release   chan struct{}
+	gated     bool
+}
+
+func (r *gatedArchiveReader) Read(p []byte) (int, error) {
+	if r.read >= r.gateAfter && !r.gated {
+		r.gated = true
+		close(r.reached)
+		<-r.release
+	}
+	if len(p) > 256 {
+		p = p[:256]
+	}
+	n, err := r.r.Read(p)
+	r.read += n
+	return n, err
+}
+
+func (*gatedArchiveReader) Close() error { return nil }
+
 func progressDetails(progress []syncpkg.Progress) []string {
 	out := make([]string, 0, len(progress))
 	for _, p := range progress {
 		if p.Detail != "" {
 			out = append(out, p.Detail)
+		}
+	}
+	return out
+}
+
+func uniqueProgressDetails(progress []syncpkg.Progress) []string {
+	var out []string
+	for _, detail := range progressDetails(progress) {
+		if len(out) == 0 || out[len(out)-1] != detail {
+			out = append(out, detail)
 		}
 	}
 	return out
@@ -165,14 +725,17 @@ func buildHTTPTestTar(t *testing.T, files map[string]string) []byte {
 // tree, serving targets/manifest/archive with the same package
 // functions the real server uses.
 type mirrorTestRemote struct {
-	dir             string // remote-side agent dir (absolute)
-	targets         TargetSet
-	archiveRequests []ArchiveRequest
-	manifestStatus  int    // 0 = serve manifest; else respond with this status
-	manifestHTML    bool   // true = mimic an old daemon's SPA catch-all
-	onManifest      func() // called before serving a manifest response
-	rejectDelta     bool
-	ts              *httptest.Server
+	dir               string // remote-side agent dir (absolute)
+	targets           TargetSet
+	archiveRequests   []ArchiveRequest
+	archiveBody       []byte
+	onArchive         func(ArchiveRequest)
+	manifestStatus    int    // 0 = serve manifest; else respond with this status
+	manifestHTML      bool   // true = mimic an old daemon's SPA catch-all
+	onManifest        func() // called before serving a manifest response
+	onManifestRequest func(*http.Request)
+	rejectDelta       bool
+	ts                *httptest.Server
 }
 
 func newMirrorTestRemote(t *testing.T) *mirrorTestRemote {
@@ -192,6 +755,9 @@ func newMirrorTestRemote(t *testing.T) *mirrorTestRemote {
 		case "/api/v1/remote-sync/manifest":
 			if remote.onManifest != nil {
 				remote.onManifest()
+			}
+			if remote.onManifestRequest != nil {
+				remote.onManifestRequest(r)
 			}
 			if remote.manifestStatus != 0 {
 				http.Error(w, "no manifest here", remote.manifestStatus)
@@ -223,6 +789,9 @@ func newMirrorTestRemote(t *testing.T) *mirrorTestRemote {
 			var req ArchiveRequest
 			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
 			remote.archiveRequests = append(remote.archiveRequests, req)
+			if remote.onArchive != nil {
+				remote.onArchive(req)
+			}
 			if remote.rejectDelta && req.DeltaFiles != nil {
 				http.Error(w, "delta not allowed", http.StatusForbidden)
 				return
@@ -230,6 +799,10 @@ func newMirrorTestRemote(t *testing.T) *mirrorTestRemote {
 			// Serve the requested target subset, as the real handler
 			// does after SelectAllowedTargets.
 			w.Header().Set("Content-Type", "application/x-tar")
+			if remote.archiveBody != nil {
+				_, _ = w.Write(remote.archiveBody)
+				return
+			}
 			if req.DeltaFiles != nil {
 				require.NoError(t, WriteArchiveFiles(
 					w, remote.targets.DeltaAllowedRoots(), req.DeltaFiles))
@@ -578,43 +1151,1406 @@ func TestHTTPSyncHoldsMirrorLockDuringManifestFetch(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestHTTPSyncFullRefreshesMirrorBytes(t *testing.T) {
+func TestPrepareHTTPSyncContributorDeltaCardinality(t *testing.T) {
+	for _, fileCount := range []int{5, 500} {
+		t.Run(strconv.Itoa(fileCount), func(t *testing.T) {
+			remote := newMirrorTestRemote(t)
+			base := time.Date(2026, 7, 8, 10, 0, 0, 123456789, time.UTC)
+			var changed string
+			for i := range fileCount {
+				path := remote.writeSession(t, fmt.Sprintf("%03d.jsonl", i),
+					base, fmt.Sprintf("session %d", i))
+				if i == 0 {
+					changed = path
+				}
+			}
+			dataDir := t.TempDir()
+			database, hs := newMirrorSync(t, remote, dataDir)
+
+			prepared, err := hs.Prepare(context.Background())
+			require.NoError(t, err)
+			require.NoError(t, prepared.Close())
+			require.Len(t, remote.archiveRequests, 1)
+			assert.Nil(t, remote.archiveRequests[0].DeltaFiles)
+
+			remote.writeSession(t, "000.jsonl", base.Add(time.Second),
+				"session 0", "session 0 continued")
+			hs.Full = true
+			prepared, err = hs.Prepare(context.Background())
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, prepared.Close()) })
+			contributor, err := prepared.RebuildContributor()
+			require.NoError(t, err)
+			engine := syncpkg.NewEngine(database, syncpkg.EngineConfig{})
+			stats, err := engine.ResyncAllWithOptions(
+				context.Background(), nil,
+				syncpkg.RebuildOptions{Contributors: []syncpkg.RebuildContributor{
+					contributor,
+				}},
+			)
+			engine.Close()
+			require.NoError(t, err)
+			assert.False(t, stats.Aborted)
+			require.NoError(t, prepared.Close())
+
+			require.Len(t, remote.archiveRequests, 2)
+			assert.Equal(t, []string{changed}, remote.archiveRequests[1].DeltaFiles)
+		})
+	}
+}
+
+func TestPreparedHTTPSyncContributorKeepsLockUntilClose(t *testing.T) {
 	remote := newMirrorTestRemote(t)
-	base := time.Date(2026, 7, 8, 10, 0, 0, 123456789, time.UTC)
-	path := remote.writeSession(t, "a.jsonl", base, "session a")
+	remote.writeSession(t, "session.jsonl",
+		time.Date(2026, 7, 8, 10, 0, 0, 0, time.UTC), "locked contributor")
+	database, hs := newMirrorSync(t, remote, t.TempDir())
+	prepared, err := hs.Prepare(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, prepared.Close()) })
+	contributor, err := prepared.RebuildContributor()
+	require.NoError(t, err)
+
+	contributorStarted := make(chan struct{})
+	continueContributor := make(chan struct{})
+	originalProgress := contributor.Progress
+	contributor.Progress = func(progress syncpkg.Progress) syncpkg.Progress {
+		if progress.Phase == syncpkg.PhaseDiscovering {
+			select {
+			case <-contributorStarted:
+			default:
+				close(contributorStarted)
+				<-continueContributor
+			}
+		}
+		return originalProgress(progress)
+	}
+	engine := syncpkg.NewEngine(database, syncpkg.EngineConfig{})
+	t.Cleanup(engine.Close)
+	type rebuildResult struct {
+		stats syncpkg.SyncStats
+		err   error
+	}
+	rebuilt := make(chan rebuildResult, 1)
+	go func() {
+		stats, runErr := engine.ResyncAllWithOptions(
+			context.Background(), nil,
+			syncpkg.RebuildOptions{Contributors: []syncpkg.RebuildContributor{
+				contributor,
+			}},
+		)
+		rebuilt <- rebuildResult{stats: stats, err: runErr}
+	}()
+	select {
+	case <-contributorStarted:
+	case <-time.After(time.Second):
+		require.FailNow(t, "timed out waiting for contributor")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	competing, lockErr := AcquireMirrorLock(ctx, prepared.Root())
+	cancel()
+	if competing != nil {
+		require.NoError(t, competing.Close())
+	}
+	assert.Error(t, lockErr, "prepared source must retain its lock during contribution")
+	close(continueContributor)
+	select {
+	case result := <-rebuilt:
+		require.NoError(t, result.err)
+		assert.False(t, result.stats.Aborted)
+	case <-time.After(time.Second):
+		require.FailNow(t, "timed out waiting for rebuild")
+	}
+
+	require.NoError(t, prepared.Close())
+	assertMirrorUnlocked(t, MirrorDir(hs.DataDir, hs.Host))
+}
+
+func TestPrepareHTTPSyncUnchangedFullMakesNoArchiveRequest(t *testing.T) {
+	for _, fileCount := range []int{5, 500} {
+		t.Run(strconv.Itoa(fileCount), func(t *testing.T) {
+			remote := newMirrorTestRemote(t)
+			mtime := time.Date(2026, 7, 8, 10, 0, 0, 0, time.UTC)
+			for i := range fileCount {
+				remote.writeSession(t, fmt.Sprintf("%03d.jsonl", i), mtime,
+					fmt.Sprintf("session %d", i))
+			}
+			_, hs := newMirrorSync(t, remote, t.TempDir())
+
+			prepared, err := hs.Prepare(context.Background())
+			require.NoError(t, err)
+			require.NoError(t, prepared.Close())
+			require.Len(t, remote.archiveRequests, 1)
+
+			hs.Full = true
+			prepared, err = hs.Prepare(context.Background())
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, prepared.Close()) })
+			assert.Len(t, remote.archiveRequests, 1,
+				"unchanged full preparation must not transfer the %d-file mirror",
+				fileCount)
+		})
+	}
+}
+
+func TestPrepareHTTPSyncManualMirrorRemovalBootstrapsFull(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	remote.writeSession(t, "a.jsonl",
+		time.Date(2026, 7, 8, 10, 0, 0, 0, time.UTC), "session a")
 	dataDir := t.TempDir()
 	_, hs := newMirrorSync(t, remote, dataDir)
-	_, err := hs.Run(context.Background())
-	require.NoError(t, err)
 
-	// Corrupt the mirror copy preserving size and mtime: invisible to
-	// the stat diff.
-	local, err := safeRemappedRemotePath(MirrorDir(dataDir, "devbox"), path)
+	prepared, err := hs.Prepare(context.Background())
 	require.NoError(t, err)
-	good, err := os.ReadFile(local)
-	require.NoError(t, err)
-	info, err := os.Stat(local)
-	require.NoError(t, err)
-	corrupt := bytes.Repeat([]byte("x"), len(good))
-	require.NoError(t, os.WriteFile(local, corrupt, 0o644))
-	require.NoError(t, os.Chtimes(local, info.ModTime(), info.ModTime()))
+	require.NoError(t, prepared.Close())
+	require.Len(t, remote.archiveRequests, 1)
 
-	// A normal sync sees no delta and leaves the corrupt bytes.
-	_, err = hs.Run(context.Background())
+	require.NoError(t, os.RemoveAll(MirrorDir(dataDir, "devbox")))
+	prepared, err = hs.Prepare(context.Background())
 	require.NoError(t, err)
-	stale, err := os.ReadFile(local)
-	require.NoError(t, err)
-	require.Equal(t, corrupt, stale)
-	require.Len(t, remote.archiveRequests, 1, "no-delta sync must not download")
+	t.Cleanup(func() { require.NoError(t, prepared.Close()) })
 
-	// --full forces a full archive refresh into the mirror.
-	hs.Full = true
-	_, err = hs.Run(context.Background())
-	require.NoError(t, err)
-	healed, err := os.ReadFile(local)
-	require.NoError(t, err)
-	assert.Equal(t, good, healed)
 	require.Len(t, remote.archiveRequests, 2)
-	assert.Nil(t, remote.archiveRequests[1].DeltaFiles,
-		"--full must request the full archive, not a delta")
+	assert.Nil(t, remote.archiveRequests[1].DeltaFiles)
+}
+
+func TestPreparedHTTPSyncCloseReleasesLockAndRemovesLegacyRoot(t *testing.T) {
+	t.Run("manifest mirror persists", func(t *testing.T) {
+		remote := newMirrorTestRemote(t)
+		remote.writeSession(t, "a.jsonl",
+			time.Date(2026, 7, 8, 10, 0, 0, 0, time.UTC), "session a")
+		dataDir := t.TempDir()
+		_, hs := newMirrorSync(t, remote, dataDir)
+
+		prepared, err := hs.Prepare(context.Background())
+		require.NoError(t, err)
+		root := prepared.Root()
+		assert.Equal(t, MirrorDir(dataDir, "devbox"), root)
+		assert.DirExists(t, root)
+		assert.Equal(t, remote.targets, prepared.Targets())
+		assertMirrorLocked(t, root)
+
+		require.NoError(t, prepared.Close())
+		require.NoError(t, prepared.Close(), "persistent Close must be idempotent")
+		assert.DirExists(t, root, "persistent mirror must survive Close")
+		assertMirrorUnlocked(t, root)
+	})
+
+	t.Run("legacy root is owned", func(t *testing.T) {
+		remote := newMirrorTestRemote(t)
+		remote.manifestStatus = http.StatusNotFound
+		remote.writeSession(t, "a.jsonl",
+			time.Date(2026, 7, 8, 10, 0, 0, 0, time.UTC), "session a")
+		dataDir := t.TempDir()
+		_, hs := newMirrorSync(t, remote, dataDir)
+
+		prepared, err := hs.Prepare(context.Background())
+		require.NoError(t, err)
+		root := prepared.Root()
+		assert.DirExists(t, root)
+		assert.NotEqual(t, MirrorDir(dataDir, "devbox"), root)
+		assert.NoDirExists(t, MirrorDir(dataDir, "devbox"))
+		assertMirrorLocked(t, MirrorDir(dataDir, "devbox"))
+
+		require.NoError(t, prepared.Close())
+		require.NoError(t, prepared.Close(), "legacy Close must be idempotent")
+		assert.NoDirExists(t, root, "owned legacy root must be removed")
+		assertMirrorUnlocked(t, MirrorDir(dataDir, "devbox"))
+	})
+}
+
+func TestPreparedHTTPSyncCloseRetriesFailedCleanup(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	remote.manifestStatus = http.StatusNotFound
+	remote.writeSession(t, "a.jsonl",
+		time.Date(2026, 7, 8, 10, 0, 0, 0, time.UTC), "session a")
+	dataDir := t.TempDir()
+	_, hs := newMirrorSync(t, remote, dataDir)
+	prepared, err := hs.Prepare(context.Background())
+	require.NoError(t, err)
+	root := prepared.Root()
+
+	removeErr := errors.New("transient remove failure")
+	unlockErr := errors.New("transient unlock failure")
+	removeCalls := 0
+	prepared.removeRoot = func(path string) error {
+		removeCalls++
+		if removeCalls == 1 {
+			return removeErr
+		}
+		return os.RemoveAll(path)
+	}
+	unlockCalls := 0
+	prepared.releaseLock = func(lock *MirrorLockHandle) error {
+		unlockCalls++
+		if unlockCalls == 1 {
+			return unlockErr
+		}
+		return lock.Close()
+	}
+
+	err = prepared.Close()
+	assert.ErrorIs(t, err, removeErr)
+	assert.ErrorIs(t, err, unlockErr)
+	assert.DirExists(t, root)
+	assertMirrorLocked(t, MirrorDir(dataDir, "devbox"))
+
+	require.NoError(t, prepared.Close())
+	assert.NoDirExists(t, root)
+	assertMirrorUnlocked(t, MirrorDir(dataDir, "devbox"))
+	require.NoError(t, prepared.Close(), "fully cleaned Close must be idempotent")
+}
+
+func TestPreparedHTTPSyncCloseTracksCleanupIndependently(t *testing.T) {
+	prepareLegacy := func(t *testing.T) (*PreparedHTTP, string) {
+		t.Helper()
+		remote := newMirrorTestRemote(t)
+		remote.manifestStatus = http.StatusNotFound
+		remote.writeSession(t, "a.jsonl",
+			time.Date(2026, 7, 8, 10, 0, 0, 0, time.UTC), "session a")
+		dataDir := t.TempDir()
+		_, hs := newMirrorSync(t, remote, dataDir)
+		prepared, err := hs.Prepare(context.Background())
+		require.NoError(t, err)
+		return prepared, MirrorDir(dataDir, "devbox")
+	}
+
+	t.Run("successful unlock is not repeated", func(t *testing.T) {
+		prepared, mirrorRoot := prepareLegacy(t)
+		removeErr := errors.New("transient remove failure")
+		removeCalls := 0
+		prepared.removeRoot = func(path string) error {
+			removeCalls++
+			if removeCalls == 1 {
+				return removeErr
+			}
+			return os.RemoveAll(path)
+		}
+		unlockCalls := 0
+		prepared.releaseLock = func(lock *MirrorLockHandle) error {
+			unlockCalls++
+			return lock.Close()
+		}
+
+		assert.ErrorIs(t, prepared.Close(), removeErr)
+		assertMirrorUnlocked(t, mirrorRoot)
+		require.NoError(t, prepared.Close())
+		assert.Equal(t, 1, unlockCalls)
+	})
+
+	t.Run("successful removal is not repeated", func(t *testing.T) {
+		prepared, mirrorRoot := prepareLegacy(t)
+		unlockErr := errors.New("transient unlock failure")
+		removeCalls := 0
+		prepared.removeRoot = func(path string) error {
+			removeCalls++
+			return os.RemoveAll(path)
+		}
+		unlockCalls := 0
+		prepared.releaseLock = func(lock *MirrorLockHandle) error {
+			unlockCalls++
+			if unlockCalls == 1 {
+				return unlockErr
+			}
+			return lock.Close()
+		}
+
+		assert.ErrorIs(t, prepared.Close(), unlockErr)
+		assert.NoDirExists(t, prepared.Root())
+		assertMirrorLocked(t, mirrorRoot)
+		require.NoError(t, prepared.Close())
+		assert.Equal(t, 1, removeCalls)
+		assertMirrorUnlocked(t, mirrorRoot)
+	})
+}
+
+func TestPrepareHTTPSyncClearsOnlySelectedHostCacheBeforeMirrorMutation(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	base := time.Date(2026, 7, 8, 10, 0, 0, 0, time.UTC)
+	changed := remote.writeSession(t, "a.jsonl", base, "session a")
+	remote.writeSession(t, "b.jsonl", base, "session b")
+	remote.writeSession(t, "c.jsonl", base, "session c")
+	database, hs := newMirrorSync(t, remote, t.TempDir())
+	prepared, err := hs.Prepare(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, prepared.Close())
+
+	require.NoError(t, database.ReplaceRemoteSkippedFiles(
+		"devbox", map[string]int64{changed: 101},
+	))
+	require.NoError(t, database.ReplaceRemoteSkippedFiles(
+		"other-host", map[string]int64{"/remote/other.jsonl": 202},
+	))
+	remote.writeSession(t, "a.jsonl", base.Add(time.Second),
+		"session a", "continued")
+	type cacheSnapshot struct {
+		selected map[string]int64
+		other    map[string]int64
+		err      error
+	}
+	atArchive := make(chan cacheSnapshot, 1)
+	remote.onArchive = func(ArchiveRequest) {
+		selected, err := database.LoadRemoteSkippedFiles("devbox")
+		if err != nil {
+			atArchive <- cacheSnapshot{err: err}
+			return
+		}
+		other, err := database.LoadRemoteSkippedFiles("other-host")
+		atArchive <- cacheSnapshot{selected: selected, other: other, err: err}
+	}
+
+	prepared, err = hs.Prepare(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, prepared.Close()) })
+	var snapshot cacheSnapshot
+	select {
+	case snapshot = <-atArchive:
+	case <-time.After(time.Second):
+		require.FailNow(t, "timed out waiting for archive cache snapshot")
+	}
+	require.NoError(t, snapshot.err)
+	assert.Empty(t, snapshot.selected,
+		"selected cache must be clear before archive extraction starts")
+	assert.Equal(t, map[string]int64{"/remote/other.jsonl": 202}, snapshot.other)
+	selected, err := database.LoadRemoteSkippedFiles("devbox")
+	require.NoError(t, err)
+	assert.Empty(t, selected)
+}
+
+func TestPrepareHTTPSyncUnchangedPreservesSelectedHostCache(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	path := remote.writeSession(t, "a.jsonl",
+		time.Date(2026, 7, 8, 10, 0, 0, 0, time.UTC), "session a")
+	database, hs := newMirrorSync(t, remote, t.TempDir())
+	prepared, err := hs.Prepare(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, prepared.Close())
+
+	require.NoError(t, database.ReplaceRemoteSkippedFiles(
+		"devbox", map[string]int64{path: 303},
+	))
+	require.NoError(t, database.ReplaceRemoteSkippedFiles(
+		"other-host", map[string]int64{"/remote/other.jsonl": 304},
+	))
+	requests := len(remote.archiveRequests)
+	prepared, err = hs.Prepare(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, prepared.Close()) })
+	assert.Len(t, remote.archiveRequests, requests)
+	selected, err := database.LoadRemoteSkippedFiles("devbox")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]int64{path: 303}, selected)
+	other, err := database.LoadRemoteSkippedFiles("other-host")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]int64{"/remote/other.jsonl": 304}, other)
+}
+
+func TestPrepareHTTPSyncFailureCleansOwnedResources(t *testing.T) {
+	t.Run("manifest failure releases lock", func(t *testing.T) {
+		remote := newMirrorTestRemote(t)
+		remote.manifestStatus = http.StatusInternalServerError
+		_, hs := newMirrorSync(t, remote, t.TempDir())
+
+		prepared, err := hs.Prepare(context.Background())
+		require.Error(t, err)
+		assert.Nil(t, prepared)
+		assertMirrorUnlocked(t, MirrorDir(hs.DataDir, "devbox"))
+	})
+
+	t.Run("legacy extraction failure removes temp root", func(t *testing.T) {
+		remote := newMirrorTestRemote(t)
+		remote.manifestStatus = http.StatusNotFound
+		path := remote.writeSession(t, "a.jsonl",
+			time.Date(2026, 7, 8, 10, 0, 0, 0, time.UTC), "session a")
+		name, err := safeRemotePathArchiveName(path)
+		require.NoError(t, err)
+		remote.archiveBody = tarWithoutEndMarker(t, name, "partial legacy")
+		tempParent := t.TempDir()
+		setPortableTempDir(t, tempParent)
+		_, hs := newMirrorSync(t, remote, t.TempDir())
+
+		prepared, err := hs.Prepare(context.Background())
+		require.Error(t, err)
+		assert.Nil(t, prepared)
+		roots, globErr := filepath.Glob(filepath.Join(tempParent, "agentsview-http-*"))
+		require.NoError(t, globErr)
+		assert.Empty(t, roots)
+		assert.NoDirExists(t, MirrorDir(hs.DataDir, "devbox"))
+		assertMirrorUnlocked(t, MirrorDir(hs.DataDir, "devbox"))
+	})
+
+	t.Run("failed mirror extraction leaves bytes and invalidated cache", func(t *testing.T) {
+		remote := newMirrorTestRemote(t)
+		path := remote.writeSession(t, "a.jsonl",
+			time.Date(2026, 7, 8, 10, 0, 0, 0, time.UTC), "session a")
+		name, err := safeRemotePathArchiveName(path)
+		require.NoError(t, err)
+		remote.archiveBody = tarWithoutEndMarker(t, name, "partial mirror")
+		database, hs := newMirrorSync(t, remote, t.TempDir())
+		require.NoError(t, database.ReplaceRemoteSkippedFiles(
+			"devbox", map[string]int64{path: 404},
+		))
+		require.NoError(t, database.ReplaceRemoteSkippedFiles(
+			"other-host", map[string]int64{"/remote/other.jsonl": 505},
+		))
+
+		prepared, err := hs.Prepare(context.Background())
+		require.Error(t, err)
+		assert.Nil(t, prepared)
+		local, mapErr := safeRemappedRemotePath(MirrorDir(hs.DataDir, "devbox"), path)
+		require.NoError(t, mapErr)
+		body, readErr := os.ReadFile(local)
+		require.NoError(t, readErr)
+		assert.Equal(t, "partial mirror", string(body))
+		selected, loadErr := database.LoadRemoteSkippedFiles("devbox")
+		require.NoError(t, loadErr)
+		assert.Empty(t, selected)
+		other, loadErr := database.LoadRemoteSkippedFiles("other-host")
+		require.NoError(t, loadErr)
+		assert.Equal(t, map[string]int64{"/remote/other.jsonl": 505}, other)
+		assertMirrorUnlocked(t, MirrorDir(hs.DataDir, "devbox"))
+	})
+}
+
+func TestPrepareHTTPSyncsSortsHostsAndUnwindsOnFailure(t *testing.T) {
+	remoteA := newMirrorTestRemote(t)
+	remoteA.manifestStatus = http.StatusNotFound
+	remoteA.writeSession(t, "a.jsonl",
+		time.Date(2026, 7, 11, 10, 0, 0, 0, time.UTC), "host a")
+	remoteB := newMirrorTestRemote(t)
+	remoteB.manifestStatus = http.StatusInternalServerError
+	remoteB.writeSession(t, "b.jsonl",
+		time.Date(2026, 7, 11, 10, 0, 0, 0, time.UTC), "host b")
+
+	dataDir := t.TempDir()
+	tempParent := t.TempDir()
+	setPortableTempDir(t, tempParent)
+	database, syncA := newMirrorSync(t, remoteA, dataDir)
+	syncA.Host = "host-a"
+	syncB := syncA
+	syncB.Host = "host-b"
+	syncB.URL = remoteB.ts.URL
+	syncB.DB = database
+	var requestOrder []string
+	remoteA.onManifest = func() { requestOrder = append(requestOrder, "host-a") }
+	remoteB.onManifest = func() { requestOrder = append(requestOrder, "host-b") }
+
+	syncs := []HTTPSync{syncB, syncA}
+	prepared, err := PrepareHTTPSyncs(context.Background(), syncs)
+	require.Error(t, err)
+	assert.Nil(t, prepared)
+	assert.Equal(t, []string{"host-b", "host-a"}, []string{
+		syncs[0].Host, syncs[1].Host,
+	}, "preparation must not mutate caller ordering")
+	assert.Equal(t, []string{"host-a", "host-b"}, requestOrder)
+	var hostErr *HostError
+	require.ErrorAs(t, err, &hostErr)
+	assert.Equal(t, "host-b", hostErr.Host)
+	assertMirrorUnlocked(t, MirrorDir(dataDir, "host-a"))
+	assertMirrorUnlocked(t, MirrorDir(dataDir, "host-b"))
+	roots, globErr := filepath.Glob(filepath.Join(tempParent, "agentsview-http-*"))
+	require.NoError(t, globErr)
+	assert.Empty(t, roots, "unwind removes the successful legacy root and spools")
+}
+
+func TestPrepareHTTPSyncsLegacySourcesDoNotCreateWorkingDirectoryLocks(t *testing.T) {
+	remoteA := newMirrorTestRemote(t)
+	remoteA.writeSession(t, "a.jsonl",
+		time.Date(2026, 7, 11, 11, 0, 0, 0, time.UTC), "host a")
+	remoteB := newMirrorTestRemote(t)
+	remoteB.writeSession(t, "b.jsonl",
+		time.Date(2026, 7, 11, 11, 0, 0, 0, time.UTC), "host b")
+
+	workingDir := t.TempDir()
+	previousDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(workingDir))
+	t.Cleanup(func() { require.NoError(t, os.Chdir(previousDir)) })
+	setPortableTempDir(t, t.TempDir())
+
+	var requestOrder []string
+	remoteA.onArchive = func(ArchiveRequest) {
+		requestOrder = append(requestOrder, "host-a")
+	}
+	remoteB.onArchive = func(ArchiveRequest) {
+		requestOrder = append(requestOrder, "host-b")
+	}
+	syncA := HTTPSync{Host: "host-a", URL: remoteA.ts.URL, Client: remoteA.ts.Client()}
+	syncB := HTTPSync{Host: "host-b", URL: remoteB.ts.URL, Client: remoteB.ts.Client()}
+	syncs := []HTTPSync{syncB, syncA}
+
+	prepared, err := PrepareHTTPSyncs(context.Background(), syncs)
+	require.NoError(t, err)
+	require.NotNil(t, prepared)
+	require.NoError(t, prepared.Close())
+
+	assert.Equal(t, []string{"host-b", "host-a"}, []string{
+		syncs[0].Host, syncs[1].Host,
+	}, "preparation must not mutate caller ordering")
+	assert.Equal(t, []string{"host-a", "host-b"}, requestOrder)
+	assert.NoDirExists(t, filepath.Join(workingDir, "remote-mirrors"),
+		"legacy sources have no persistent mirror lock identity")
+}
+
+func TestPrepareHTTPSyncsOrdersConcurrentCallersByMirrorLockPath(t *testing.T) {
+	remoteA := newMirrorTestRemote(t)
+	remoteA.writeSession(t, "a.jsonl",
+		time.Date(2026, 7, 11, 14, 0, 0, 0, time.UTC), "mirror a")
+	remoteB := newMirrorTestRemote(t)
+	remoteB.writeSession(t, "b.jsonl",
+		time.Date(2026, 7, 11, 14, 0, 0, 0, time.UTC), "mirror b")
+
+	base := t.TempDir()
+	dataDirA := base + string(filepath.Separator) + "z" +
+		string(filepath.Separator) + ".." + string(filepath.Separator) + "a-data"
+	dataDirB := filepath.Join(base, "b-data")
+	database, syncA := newMirrorSync(t, remoteA, dataDirA)
+	syncA.Host = "shared-host"
+	syncB := syncA
+	syncB.DataDir = dataDirB
+	syncB.URL = remoteB.ts.URL
+	syncB.DB = database
+	assert.Less(t, MirrorDir(dataDirA, syncA.Host), MirrorDir(dataDirB, syncB.Host))
+
+	firstA := make(chan struct{})
+	firstB := make(chan struct{})
+	var onceA, onceB stdsync.Once
+	var orderMu stdsync.Mutex
+	orders := map[string][]string{}
+	record := func(
+		caller, mirror string, ownOnce *stdsync.Once,
+		own chan struct{}, other <-chan struct{},
+	) {
+		orderMu.Lock()
+		orders[caller] = append(orders[caller], mirror)
+		orderMu.Unlock()
+		ownOnce.Do(func() { close(own) })
+		select {
+		case <-other:
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	remoteA.onManifestRequest = func(r *http.Request) {
+		record(r.Header.Get("Authorization"), "mirror-a",
+			&onceA, firstA, firstB)
+	}
+	remoteB.onManifestRequest = func(r *http.Request) {
+		record(r.Header.Get("Authorization"), "mirror-b",
+			&onceB, firstB, firstA)
+	}
+
+	callerOne := []HTTPSync{syncB, syncA}
+	callerOne[0].Token = "caller-one"
+	callerOne[1].Token = "caller-one"
+	callerTwo := []HTTPSync{syncA, syncB}
+	callerTwo[0].Token = "caller-two"
+	callerTwo[1].Token = "caller-two"
+	type result struct {
+		caller   string
+		prepared *PreparedHTTPSyncs
+		err      error
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	start := make(chan struct{})
+	results := make(chan result, 2)
+	for caller, syncs := range map[string][]HTTPSync{
+		"caller-one": callerOne,
+		"caller-two": callerTwo,
+	} {
+		go func() {
+			<-start
+			prepared, err := PrepareHTTPSyncs(ctx, syncs)
+			results <- result{caller: caller, prepared: prepared, err: err}
+		}()
+	}
+	close(start)
+
+	got := make(map[string]error, 2)
+	for range 2 {
+		select {
+		case result := <-results:
+			got[result.caller] = result.err
+			if result.prepared != nil {
+				require.NoError(t, result.prepared.Close())
+			}
+		case <-ctx.Done():
+			require.FailNow(t, "concurrent preparation deadlocked",
+				"orders=%v", orders)
+		}
+	}
+	require.NoError(t, got["caller-one"])
+	require.NoError(t, got["caller-two"])
+	orderMu.Lock()
+	assert.Equal(t, []string{"mirror-a", "mirror-b"}, orders["Bearer caller-one"])
+	assert.Equal(t, []string{"mirror-a", "mirror-b"}, orders["Bearer caller-two"])
+	orderMu.Unlock()
+	assert.Equal(t, []string{"shared-host", "shared-host"}, []string{
+		callerOne[0].Host, callerOne[1].Host,
+	})
+	assert.Equal(t, []string{dataDirB, dataDirA}, []string{
+		callerOne[0].DataDir, callerOne[1].DataDir,
+	}, "preparation must preserve caller-one input order")
+	assert.Equal(t, []string{dataDirA, dataDirB}, []string{
+		callerTwo[0].DataDir, callerTwo[1].DataDir,
+	}, "preparation must preserve caller-two input order")
+}
+
+func TestPrepareHTTPSyncsRejectsDuplicateCanonicalLockIdentity(t *testing.T) {
+	t.Run("clean parent alias", func(t *testing.T) {
+		base := t.TempDir()
+		canonical := filepath.Join(base, "data")
+		alias := base + string(filepath.Separator) + "z" +
+			string(filepath.Separator) + ".." + string(filepath.Separator) + "data"
+		assertDuplicateCanonicalLockIdentity(t, canonical, alias)
+	})
+
+	t.Run("symlink parent alias", func(t *testing.T) {
+		base := t.TempDir()
+		realParent := filepath.Join(base, "real")
+		require.NoError(t, os.MkdirAll(realParent, 0o755))
+		linkParent := filepath.Join(base, "link")
+		if err := os.Symlink(realParent, linkParent); err != nil {
+			t.Skipf("symlinks unavailable: %v", err)
+		}
+		assertDuplicateCanonicalLockIdentity(
+			t, filepath.Join(realParent, "data"), filepath.Join(linkParent, "data"),
+		)
+	})
+
+	t.Run("case alias on insensitive volume", func(t *testing.T) {
+		base := t.TempDir()
+		probe := filepath.Join(base, "CaseSensitiveProbe")
+		require.NoError(t, os.Mkdir(probe, 0o755))
+		probeAlias := filepath.Join(base, "cASEsENSITIVEpROBE")
+		actualInfo, err := os.Stat(probe)
+		require.NoError(t, err)
+		aliasInfo, err := os.Stat(probeAlias)
+		if os.IsNotExist(err) {
+			t.Skip("test volume is case-sensitive")
+		}
+		require.NoError(t, err)
+		if !os.SameFile(actualInfo, aliasInfo) {
+			t.Skip("case aliases do not identify the same directory")
+		}
+		require.NoError(t, os.Remove(probe))
+		actualParent := filepath.Join(base, "InitiallyMissingCaseParent")
+		aliasParent := filepath.Join(base, "iNITIALLYmISSINGcASEpARENT")
+		assert.NoDirExists(t, actualParent)
+		assert.NoDirExists(t, aliasParent)
+		assertDuplicateCanonicalLockIdentity(
+			t, filepath.Join(actualParent, "data"), filepath.Join(aliasParent, "data"),
+		)
+	})
+
+	t.Run("unicode normalization alias", func(t *testing.T) {
+		base := t.TempDir()
+		probe := filepath.Join(base, "Caf\u00e9Probe")
+		probeAlias := filepath.Join(base, "Cafe\u0301Probe")
+		require.NoError(t, os.Mkdir(probe, 0o755))
+		actualInfo, err := os.Stat(probe)
+		require.NoError(t, err)
+		aliasInfo, err := os.Stat(probeAlias)
+		if os.IsNotExist(err) {
+			t.Skip("test volume does not alias Unicode normalization forms")
+		}
+		require.NoError(t, err)
+		if !os.SameFile(actualInfo, aliasInfo) {
+			t.Skip("Unicode normalization forms identify different directories")
+		}
+		require.NoError(t, os.Remove(probe))
+		actualParent := filepath.Join(base, "Caf\u00e9Missing")
+		aliasParent := filepath.Join(base, "Cafe\u0301Missing")
+		assert.NoDirExists(t, actualParent)
+		assert.NoDirExists(t, aliasParent)
+		assertDuplicateCanonicalLockIdentity(
+			t, filepath.Join(actualParent, "data"), filepath.Join(aliasParent, "data"),
+		)
+	})
+}
+
+func assertDuplicateCanonicalLockIdentity(t *testing.T, dataDirA, dataDirB string) {
+	t.Helper()
+	remote := newMirrorTestRemote(t)
+	remote.writeSession(t, "duplicate.jsonl",
+		time.Date(2026, 7, 11, 14, 30, 0, 0, time.UTC), "duplicate")
+	database, syncA := newMirrorSync(t, remote, dataDirA)
+	syncA.Host = "shared-host"
+	syncB := syncA
+	syncB.DataDir = dataDirB
+	syncB.DB = database
+	manifestRequests := 0
+	remote.onManifest = func() { manifestRequests++ }
+	syncs := []HTTPSync{syncB, syncA}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 750*time.Millisecond)
+	defer cancel()
+	prepared, err := PrepareHTTPSyncs(ctx, syncs)
+	require.Error(t, err)
+	assert.Nil(t, prepared)
+	assert.ErrorIs(t, err, ErrDuplicateMirrorLock)
+	var hostErr *HostError
+	require.ErrorAs(t, err, &hostErr)
+	assert.Equal(t, "shared-host", hostErr.Host)
+	assert.Equal(t, "resolve mirror lock", hostErr.Operation)
+	assert.Contains(t, hostErr.Error(), `"shared-host"`)
+	assert.Zero(t, manifestRequests,
+		"duplicates must fail before acquiring a lock or preparing a source")
+	lockArtifact := MirrorDir(dataDirA, syncA.Host) + ".lock"
+	lockInfo, statErr := os.Stat(lockArtifact)
+	require.NoError(t, statErr)
+	assert.False(t, lockInfo.IsDir())
+	if runtime.GOOS != "windows" {
+		assert.Equal(t, os.FileMode(0o600), lockInfo.Mode().Perm(),
+			"preflight creates only the same private lock artifact acquisition needs")
+	}
+	assert.Equal(t, []string{dataDirB, dataDirA}, []string{
+		syncs[0].DataDir, syncs[1].DataDir,
+	}, "duplicate detection must preserve caller order")
+	lockCtx, lockCancel := context.WithTimeout(context.Background(), time.Second)
+	defer lockCancel()
+	lock, lockErr := AcquireMirrorLock(lockCtx, MirrorDir(dataDirA, syncA.Host))
+	require.NoError(t, lockErr)
+	require.NoError(t, lock.Close())
+}
+
+func TestPreparedHTTPSyncsHoldAllLocksUntilClose(t *testing.T) {
+	remoteA := newMirrorTestRemote(t)
+	remoteA.writeSession(t, "a.jsonl",
+		time.Date(2026, 7, 11, 11, 0, 0, 0, time.UTC), "host a")
+	remoteB := newMirrorTestRemote(t)
+	remoteB.writeSession(t, "b.jsonl",
+		time.Date(2026, 7, 11, 11, 0, 0, 0, time.UTC), "host b")
+	dataDir := t.TempDir()
+	database, syncA := newMirrorSync(t, remoteA, dataDir)
+	syncA.Host = "host-a"
+	syncB := syncA
+	syncB.Host = "host-b"
+	syncB.URL = remoteB.ts.URL
+	syncB.DB = database
+
+	prepared, err := PrepareHTTPSyncs(
+		context.Background(), []HTTPSync{syncB, syncA},
+	)
+	require.NoError(t, err)
+	contributors, release, err := prepared.BorrowRebuildContributors()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		release()
+		require.NoError(t, prepared.Close())
+	})
+	assert.Equal(t, []string{"host-a", "host-b"}, []string{
+		contributors[0].Name, contributors[1].Name,
+	})
+
+	for _, host := range []string{"host-a", "host-b"} {
+		lockCtx, cancel := context.WithTimeout(context.Background(), 40*time.Millisecond)
+		competing, lockErr := AcquireMirrorLock(
+			lockCtx, MirrorDir(dataDir, host),
+		)
+		cancel()
+		if competing != nil {
+			require.NoError(t, competing.Close())
+		}
+		assert.Error(t, lockErr,
+			"all mirror locks remain held across earlier contributor work")
+	}
+
+	release()
+	require.NoError(t, prepared.Close())
+	for _, host := range []string{"host-a", "host-b"} {
+		lockCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		competing, lockErr := AcquireMirrorLock(
+			lockCtx, MirrorDir(dataDir, host),
+		)
+		cancel()
+		require.NoError(t, lockErr, host)
+		require.NotNil(t, competing, host)
+		require.NoError(t, competing.Close())
+	}
+	_, _, err = prepared.BorrowRebuildContributors()
+	assert.ErrorIs(t, err, ErrPreparedClosed,
+		"closed aggregate cannot expose contributors")
+}
+
+func TestPreparedHTTPSyncsBorrowBlocksCloseUntilRelease(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	remote.writeSession(t, "borrow.jsonl",
+		time.Date(2026, 7, 11, 15, 30, 0, 0, time.UTC), "borrowed")
+	dataDir := t.TempDir()
+	_, hs := newMirrorSync(t, remote, dataDir)
+	prepared, err := PrepareHTTPSyncs(context.Background(), []HTTPSync{hs})
+	require.NoError(t, err)
+	contributors, release, err := prepared.BorrowRebuildContributors()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		release()
+		require.NoError(t, prepared.Close())
+	})
+	require.Len(t, contributors, 1)
+	assert.Equal(t, hs.Host, contributors[0].Name)
+
+	assert.ErrorIs(t, prepared.Close(), ErrPreparedInUse)
+	_, _, err = prepared.BorrowRebuildContributors()
+	assert.ErrorIs(t, err, ErrPreparedClosed,
+		"a Close attempt ends new borrowing while retained ownership remains retryable")
+	lockCtx, cancel := context.WithTimeout(context.Background(), 40*time.Millisecond)
+	competing, lockErr := AcquireMirrorLock(lockCtx, MirrorDir(dataDir, hs.Host))
+	cancel()
+	if competing != nil {
+		require.NoError(t, competing.Close())
+	}
+	assert.Error(t, lockErr, "borrowed Close must retain its mirror lock")
+
+	release()
+	release()
+	require.NoError(t, prepared.Close())
+	lockCtx, cancel = context.WithTimeout(context.Background(), time.Second)
+	competing, lockErr = AcquireMirrorLock(lockCtx, MirrorDir(dataDir, hs.Host))
+	cancel()
+	require.NoError(t, lockErr)
+	require.NotNil(t, competing)
+	require.NoError(t, competing.Close())
+	_, _, err = prepared.BorrowRebuildContributors()
+	assert.ErrorIs(t, err, ErrPreparedClosed)
+}
+
+func TestPreparedHTTPSyncsBorrowAndCloseAreRaceSafe(t *testing.T) {
+	prepared := &PreparedHTTPSyncs{sources: []*PreparedHTTP{{
+		sync:        HTTPSync{Host: "race-host"},
+		lock:        &MirrorLockHandle{},
+		releaseLock: func(*MirrorLockHandle) error { return nil },
+	}}}
+	_, initialRelease, err := prepared.BorrowRebuildContributors()
+	require.NoError(t, err)
+	start := make(chan struct{})
+	borrowResults := make(chan error, 8)
+	closeResult := make(chan error, 1)
+	for range 8 {
+		go func() {
+			<-start
+			_, release, borrowErr := prepared.BorrowRebuildContributors()
+			if borrowErr == nil {
+				release()
+				release()
+			}
+			borrowResults <- borrowErr
+		}()
+	}
+	go func() {
+		<-start
+		closeResult <- prepared.Close()
+	}()
+	close(start)
+	for range 8 {
+		borrowErr := <-borrowResults
+		assert.True(t, borrowErr == nil || errors.Is(borrowErr, ErrPreparedClosed),
+			"unexpected borrow result: %v", borrowErr)
+	}
+	assert.ErrorIs(t, <-closeResult, ErrPreparedInUse)
+	initialRelease()
+	require.NoError(t, prepared.Close())
+}
+
+func TestPreparedHTTPSyncsCloseReversesJoinsAndRetries(t *testing.T) {
+	transient := errors.New("transient release")
+	var order []string
+	bCalls := 0
+	prepared := &PreparedHTTPSyncs{sources: []*PreparedHTTP{
+		{
+			lock: &MirrorLockHandle{},
+			releaseLock: func(*MirrorLockHandle) error {
+				order = append(order, "host-a")
+				return nil
+			},
+		},
+		{
+			lock: &MirrorLockHandle{},
+			releaseLock: func(*MirrorLockHandle) error {
+				order = append(order, "host-b")
+				bCalls++
+				if bCalls == 1 {
+					return transient
+				}
+				return nil
+			},
+		},
+	}}
+
+	assert.ErrorIs(t, prepared.Close(), transient)
+	assert.Equal(t, []string{"host-b", "host-a"}, order)
+	require.NoError(t, prepared.Close())
+	assert.Equal(t, []string{"host-b", "host-a", "host-b"}, order,
+		"only failed ownership is retained for retry")
+	require.NoError(t, prepared.Close(), "fully closed aggregate is idempotent")
+}
+
+func TestPrepareHTTPSyncsReturnsFailedUnwindOwnership(t *testing.T) {
+	remoteA := newMirrorTestRemote(t)
+	remoteA.manifestStatus = http.StatusNotFound
+	remoteA.writeSession(t, "a.jsonl",
+		time.Date(2026, 7, 11, 15, 0, 0, 0, time.UTC), "legacy a")
+	remoteB := newMirrorTestRemote(t)
+	remoteB.manifestStatus = http.StatusInternalServerError
+	remoteB.writeSession(t, "b.jsonl",
+		time.Date(2026, 7, 11, 15, 0, 0, 0, time.UTC), "host b")
+	tempParent := t.TempDir()
+	setPortableTempDir(t, tempParent)
+	dataDir := t.TempDir()
+	database, syncA := newMirrorSync(t, remoteA, dataDir)
+	syncA.Host = "host-a"
+	syncB := syncA
+	syncB.Host = "host-b"
+	syncB.URL = remoteB.ts.URL
+	syncB.DB = database
+	removeErr := errors.New("transient aggregate remove failure")
+	unlockErr := errors.New("transient aggregate unlock failure")
+	removeCalls := 0
+	unlockCalls := 0
+	var ownedRoot string
+
+	prepared, err := prepareHTTPSyncs(
+		context.Background(), []HTTPSync{syncB, syncA},
+		func(ctx context.Context, hs HTTPSync) (*PreparedHTTP, error) {
+			source, prepareErr := hs.Prepare(ctx)
+			if prepareErr != nil || hs.Host != "host-a" {
+				return source, prepareErr
+			}
+			ownedRoot = source.Root()
+			source.removeRoot = func(path string) error {
+				removeCalls++
+				if removeCalls == 1 {
+					return removeErr
+				}
+				return os.RemoveAll(path)
+			}
+			source.releaseLock = func(lock *MirrorLockHandle) error {
+				unlockCalls++
+				if unlockCalls == 1 {
+					return unlockErr
+				}
+				return lock.Close()
+			}
+			return source, nil
+		},
+	)
+	require.Error(t, err)
+	require.NotNil(t, prepared,
+		"failed cleanup ownership must be returned with the preparation error")
+	assert.ErrorIs(t, err, removeErr)
+	assert.ErrorIs(t, err, unlockErr)
+	var primary *HostError
+	require.ErrorAs(t, err, &primary)
+	assert.Equal(t, "host-b", primary.Host)
+	assert.Equal(t, "prepare", primary.Operation)
+	assert.Contains(t, err.Error(), `HTTP host "host-a" cleanup prepared source`)
+	assert.DirExists(t, ownedRoot)
+	assertMirrorLocked(t, MirrorDir(dataDir, "host-a"))
+
+	require.NoError(t, prepared.Close())
+	assert.NoDirExists(t, ownedRoot)
+	assertMirrorUnlocked(t, MirrorDir(dataDir, "host-a"))
+	require.NoError(t, prepared.Close(), "cleanup retry must remain idempotent")
+}
+
+func TestPrepareHTTPSyncRetainsCurrentSourceWhenCleanupFails(t *testing.T) {
+	t.Run("single source", func(t *testing.T) {
+		remote := newMirrorTestRemote(t)
+		remote.manifestStatus = http.StatusInternalServerError
+		_, hs := newMirrorSync(t, remote, t.TempDir())
+		unlockErr := errors.New("transient current-source unlock failure")
+		unlockCalls := 0
+
+		source, err := hs.prepare(context.Background(), func(source *PreparedHTTP) {
+			source.releaseLock = func(lock *MirrorLockHandle) error {
+				unlockCalls++
+				if unlockCalls == 1 {
+					return unlockErr
+				}
+				return lock.Close()
+			}
+		})
+		require.Error(t, err)
+		require.NotNil(t, source)
+		assert.ErrorIs(t, err, unlockErr)
+		var statusErr *StatusError
+		assert.ErrorAs(t, err, &statusErr)
+		assertMirrorLocked(t, MirrorDir(hs.DataDir, hs.Host))
+
+		require.NoError(t, source.Close())
+		assertMirrorUnlocked(t, MirrorDir(hs.DataDir, hs.Host))
+	})
+
+	t.Run("aggregate current source", func(t *testing.T) {
+		remote := newMirrorTestRemote(t)
+		remote.manifestStatus = http.StatusInternalServerError
+		_, hs := newMirrorSync(t, remote, t.TempDir())
+		unlockErr := errors.New("transient aggregate current-source unlock failure")
+		unlockCalls := 0
+
+		prepared, err := prepareHTTPSyncs(
+			context.Background(), []HTTPSync{hs},
+			func(ctx context.Context, hs HTTPSync) (*PreparedHTTP, error) {
+				return hs.prepare(ctx, func(source *PreparedHTTP) {
+					source.releaseLock = func(lock *MirrorLockHandle) error {
+						unlockCalls++
+						if unlockCalls <= 2 {
+							return unlockErr
+						}
+						return lock.Close()
+					}
+				})
+			},
+		)
+		require.Error(t, err)
+		require.NotNil(t, prepared)
+		assert.ErrorIs(t, err, unlockErr)
+		var hostErr *HostError
+		require.ErrorAs(t, err, &hostErr)
+		assert.Equal(t, hs.Host, hostErr.Host)
+		assert.Equal(t, "prepare", hostErr.Operation)
+		assert.Contains(t, err.Error(), "cleanup prepared source")
+		assertMirrorLocked(t, MirrorDir(hs.DataDir, hs.Host))
+
+		require.NoError(t, prepared.Close())
+		assertMirrorUnlocked(t, MirrorDir(hs.DataDir, hs.Host))
+	})
+}
+
+func TestHTTPSyncRunHandlesPreparationCleanupOwnership(t *testing.T) {
+	t.Run("transient cleanup is completed before return", func(t *testing.T) {
+		remote := newMirrorTestRemote(t)
+		remote.manifestStatus = http.StatusInternalServerError
+		_, hs := newMirrorSync(t, remote, t.TempDir())
+		unlockErr := errors.New("transient Run unlock failure")
+		unlockCalls := 0
+		base := hs
+		hs.runPrepare = func(ctx context.Context) (*PreparedHTTP, error) {
+			return base.prepare(ctx, func(source *PreparedHTTP) {
+				source.releaseLock = func(lock *MirrorLockHandle) error {
+					unlockCalls++
+					if unlockCalls == 1 {
+						return unlockErr
+					}
+					return lock.Close()
+				}
+			})
+		}
+
+		_, err := hs.Run(context.Background())
+		require.Error(t, err)
+		assert.ErrorIs(t, err, unlockErr)
+		var owner *PreparedCleanupError
+		assert.False(t, errors.As(err, &owner),
+			"successful Run retry must not return cleanup ownership")
+		assert.Equal(t, 2, unlockCalls)
+		assertMirrorUnlocked(t, MirrorDir(hs.DataDir, hs.Host))
+	})
+
+	t.Run("persistent cleanup ownership is retryable from error", func(t *testing.T) {
+		remote := newMirrorTestRemote(t)
+		remote.manifestStatus = http.StatusInternalServerError
+		_, hs := newMirrorSync(t, remote, t.TempDir())
+		unlockErr := errors.New("persistent Run unlock failure")
+		unlockCalls := 0
+		base := hs
+		hs.runPrepare = func(ctx context.Context) (*PreparedHTTP, error) {
+			return base.prepare(ctx, func(source *PreparedHTTP) {
+				source.releaseLock = func(lock *MirrorLockHandle) error {
+					unlockCalls++
+					if unlockCalls <= 2 {
+						return unlockErr
+					}
+					return lock.Close()
+				}
+			})
+		}
+
+		_, err := hs.Run(context.Background())
+		require.Error(t, err)
+		assert.ErrorIs(t, err, unlockErr)
+		var statusErr *StatusError
+		assert.ErrorAs(t, err, &statusErr)
+		var owner *PreparedCleanupError
+		require.ErrorAs(t, err, &owner)
+		assert.Equal(t, 2, unlockCalls, "Run must not double-close before returning")
+		assertMirrorLocked(t, MirrorDir(hs.DataDir, hs.Host))
+
+		require.NoError(t, owner.RetryCleanup())
+		assert.Equal(t, 3, unlockCalls)
+		assertMirrorUnlocked(t, MirrorDir(hs.DataDir, hs.Host))
+		require.NoError(t, owner.RetryCleanup(), "cleanup retry is idempotent")
+		assert.Equal(t, 3, unlockCalls)
+	})
+}
+
+func TestCleanupRegistryBlocksLaterRunWithPreparedCleanupError(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	remote.manifestStatus = http.StatusInternalServerError
+	_, hs := newMirrorSync(t, remote, t.TempDir())
+	unlockErr := errors.New("persistent registry unlock failure")
+	unlockCalls := 0
+	base := hs
+	hs.runPrepare = func(ctx context.Context) (*PreparedHTTP, error) {
+		return base.prepare(ctx, func(source *PreparedHTTP) {
+			source.releaseLock = func(lock *MirrorLockHandle) error {
+				unlockCalls++
+				if unlockCalls <= 4 {
+					return unlockErr
+				}
+				return lock.Close()
+			}
+		})
+	}
+	var registry CleanupRegistry
+	callbacks := 0
+
+	_, err := registry.Run(func() (SyncStats, error) {
+		callbacks++
+		return hs.Run(context.Background())
+	})
+	require.Error(t, err)
+	var owner *PreparedCleanupError
+	require.ErrorAs(t, err, &owner)
+	assert.ErrorIs(t, err, unlockErr)
+	assert.Equal(t, 3, unlockCalls)
+	assertMirrorLocked(t, MirrorDir(hs.DataDir, hs.Host))
+
+	_, err = registry.Run(func() (SyncStats, error) {
+		callbacks++
+		return SyncStats{}, nil
+	})
+	var pending *PendingCleanupError
+	require.ErrorAs(t, err, &pending)
+	var retained *PreparedCleanupError
+	require.ErrorAs(t, err, &retained)
+	assert.Same(t, owner, retained)
+	assert.ErrorIs(t, err, owner)
+	assert.ErrorIs(t, err, unlockErr)
+	assert.Equal(t, 1, callbacks, "pending cleanup must block the later callback")
+	assert.Equal(t, 4, unlockCalls)
+	assertMirrorLocked(t, MirrorDir(hs.DataDir, hs.Host))
+
+	_, err = registry.Run(func() (SyncStats, error) {
+		callbacks++
+		return SyncStats{SessionsSynced: 1}, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, callbacks)
+	assert.Equal(t, 5, unlockCalls)
+	assertMirrorUnlocked(t, MirrorDir(hs.DataDir, hs.Host))
+}
+
+func TestPreparedHTTPCloseAttemptMakesSourceUnusableUntilCleanupCompletes(t *testing.T) {
+	unlockErr := errors.New("unlock remains pending")
+	unlockCalls := 0
+	prepared := &PreparedHTTP{
+		root: t.TempDir(),
+		lock: &MirrorLockHandle{},
+		releaseLock: func(*MirrorLockHandle) error {
+			unlockCalls++
+			if unlockCalls == 1 {
+				return unlockErr
+			}
+			return nil
+		},
+	}
+
+	require.ErrorIs(t, prepared.Close(), unlockErr)
+	_, importErr := prepared.ImportActive(context.Background())
+	assert.ErrorContains(t, importErr, "closed")
+	_, contributorErr := prepared.RebuildContributor()
+	assert.ErrorContains(t, contributorErr, "closed")
+	require.NoError(t, prepared.Close())
+	assert.Equal(t, 2, unlockCalls)
+}
+
+type failingArchiveBody struct{ err error }
+
+func (r failingArchiveBody) Read([]byte) (int, error) { return 0, r.err }
+func (failingArchiveBody) Close() error               { return nil }
+
+func TestCleanupRegistryRetainsFailedArchiveSpoolCleanup(t *testing.T) {
+	spoolRoot := t.TempDir()
+	readErr := errors.New("archive transfer failed")
+	removeErr := errors.New("spool removal failed")
+	removeCalls := 0
+	hs := HTTPSync{removeArchiveSpool: func(path string) error {
+		removeCalls++
+		if removeCalls <= 2 {
+			return removeErr
+		}
+		return os.RemoveAll(path)
+	}}
+	registry := new(CleanupRegistry)
+	callbacks := 0
+
+	_, err := registry.Run(func() (SyncStats, error) {
+		callbacks++
+		archive, downloadErr := hs.downloadArchive(
+			context.Background(),
+			&http.Response{
+				StatusCode: http.StatusOK,
+				Body:       failingArchiveBody{err: readErr},
+			},
+			"Downloading archive", spoolRoot,
+		)
+		assert.Nil(t, archive)
+		return SyncStats{}, downloadErr
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, readErr)
+	assert.ErrorIs(t, err, removeErr)
+	var owner *downloadedArchiveCleanupError
+	require.ErrorAs(t, err, &owner)
+	assert.Equal(t, 2, removeCalls, "registry retries cleanup before retaining it")
+
+	_, err = registry.Run(func() (SyncStats, error) {
+		callbacks++
+		return SyncStats{SessionsSynced: 1}, nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, callbacks)
+	assert.Equal(t, 3, removeCalls)
+	entries, readDirErr := os.ReadDir(spoolRoot)
+	require.NoError(t, readDirErr)
+	assert.Empty(t, entries)
+}
+
+func TestPrepareHTTPSyncsCacheInvalidationFailureDoesNotMutateMirror(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	base := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
+	path := remote.writeSession(t, "a.jsonl", base, "original")
+	dataDir := t.TempDir()
+	database, hs := newMirrorSync(t, remote, dataDir)
+	hs.Host = "readonly-host"
+	prepared, err := hs.Prepare(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, prepared.Close())
+
+	local, err := safeRemappedRemotePath(MirrorDir(dataDir, hs.Host), path)
+	require.NoError(t, err)
+	beforeBytes, err := os.ReadFile(local)
+	require.NoError(t, err)
+	beforeInfo, err := os.Stat(local)
+	require.NoError(t, err)
+	requestsBefore := len(remote.archiveRequests)
+	remote.writeSession(t, "a.jsonl", base.Add(time.Second),
+		"replacement with a different size")
+	readonly, err := db.OpenReadOnly(database.Path())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, readonly.Close()) })
+	hs.DB = readonly
+
+	preparedSet, err := PrepareHTTPSyncs(context.Background(), []HTTPSync{hs})
+	require.Error(t, err)
+	assert.Nil(t, preparedSet)
+	var hostErr *HostError
+	require.ErrorAs(t, err, &hostErr)
+	assert.Equal(t, "readonly-host", hostErr.Host)
+	assert.ErrorIs(t, err, db.ErrReadOnly)
+	afterBytes, readErr := os.ReadFile(local)
+	require.NoError(t, readErr)
+	afterInfo, statErr := os.Stat(local)
+	require.NoError(t, statErr)
+	assert.Equal(t, beforeBytes, afterBytes)
+	assert.Equal(t, beforeInfo.ModTime(), afterInfo.ModTime())
+	assert.Len(t, remote.archiveRequests, requestsBefore,
+		"cache failure must stop before archive download or extraction")
+	assertMirrorUnlocked(t, MirrorDir(dataDir, hs.Host))
+}
+
+func TestPrepareHTTPSyncSameMtimeSizeChangeRecoversAfterAbortedRebuild(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	base := time.Date(2026, 7, 11, 13, 0, 0, 0, time.UTC)
+	changed := remote.writeSession(t, "changed.jsonl", base,
+		"the original message is intentionally much longer")
+	deleted := remote.writeSession(t, "deleted.jsonl", base, "retained archive row")
+	dataDir := t.TempDir()
+	database, hs := newMirrorSync(t, remote, dataDir)
+	stats, err := hs.Run(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 2, stats.SessionsSynced)
+	initial, err := database.ListSessions(
+		context.Background(), db.SessionFilter{Limit: 10},
+	)
+	require.NoError(t, err)
+	var changedSessionID string
+	for _, session := range initial.Sessions {
+		messages, messageErr := database.GetMessages(
+			context.Background(), session.ID, 0, 10, true,
+		)
+		require.NoError(t, messageErr)
+		if len(messages) == 1 && strings.Contains(
+			messages[0].Content, "intentionally much longer",
+		) {
+			changedSessionID = session.ID
+		}
+	}
+	require.NotEmpty(t, changedSessionID)
+
+	require.NoError(t, database.ReplaceRemoteSkippedFiles(
+		hs.Host, map[string]int64{changed: base.UnixNano()},
+	))
+	remote.writeSession(t, "changed.jsonl", base, "new")
+	require.NoError(t, os.Remove(deleted))
+	prepared, err := hs.Prepare(context.Background())
+	require.NoError(t, err)
+	changedLocal, err := safeRemappedRemotePath(prepared.Root(), changed)
+	require.NoError(t, err)
+	changedBytes, err := os.ReadFile(changedLocal)
+	require.NoError(t, err)
+	assert.Contains(t, string(changedBytes), "new")
+	deletedLocal, err := safeRemappedRemotePath(prepared.Root(), deleted)
+	require.NoError(t, err)
+	assert.NoFileExists(t, deletedLocal)
+	cache, err := database.LoadRemoteSkippedFiles(hs.Host)
+	require.NoError(t, err)
+	assert.Empty(t, cache, "cache invalidation commits before mirror mutation")
+	require.NoError(t, prepared.Close(), "simulate rebuild abort before import")
+
+	stats, err = hs.Run(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.SessionsSynced)
+	page, err := database.ListSessions(context.Background(), db.SessionFilter{Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, page.Sessions, 2,
+		"remote deletion must not delete the persistent archive row")
+	messages, err := database.GetMessages(
+		context.Background(), changedSessionID, 0, 10, true,
+	)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Equal(t, "new", messages[0].Content)
+}
+
+func tarWithoutEndMarker(t *testing.T, name, body string) []byte {
+	t.Helper()
+	archive := buildHTTPTestTar(t, map[string]string{name: body})
+	require.GreaterOrEqual(t, len(archive), tarEndMarkerSize)
+	return archive[:len(archive)-tarEndMarkerSize]
+}
+
+func setPortableTempDir(t *testing.T, dir string) {
+	t.Helper()
+	for _, name := range []string{"TMPDIR", "TMP", "TEMP"} {
+		t.Setenv(name, dir)
+	}
+}
+
+func assertMirrorLocked(t *testing.T, mirrorRoot string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	lock, err := AcquireMirrorLock(ctx, mirrorRoot)
+	if lock != nil {
+		require.NoError(t, lock.Close())
+	}
+	assert.Error(t, err)
+}
+
+func assertMirrorUnlocked(t *testing.T, mirrorRoot string) {
+	t.Helper()
+	lock, err := AcquireMirrorLock(context.Background(), mirrorRoot)
+	require.NoError(t, err)
+	require.NoError(t, lock.Close())
 }

--- a/internal/remotesync/http_test.go
+++ b/internal/remotesync/http_test.go
@@ -372,6 +372,54 @@ func TestHTTPSyncLegacyRetainsCleanupWithoutLeakingExtractedRoot(t *testing.T) {
 		"retry must release both the spool and extracted legacy root")
 }
 
+func TestHTTPSyncLegacyRetainsSpoolWhenExtractionRootCreationFails(t *testing.T) {
+	archive := buildHTTPTestTar(t, map[string]string{
+		"home/user/session.jsonl": "complete",
+	})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Length", strconv.Itoa(len(archive)))
+		_, _ = w.Write(archive)
+	}))
+	t.Cleanup(ts.Close)
+	validTemp := t.TempDir()
+	setPortableTempDir(t, validTemp)
+	invalidTemp := filepath.Join(t.TempDir(), "not-a-directory")
+	require.NoError(t, os.WriteFile(invalidTemp, []byte("block"), 0o600))
+	removeErr := errors.New("spool cleanup failed")
+	removeCalls := 0
+	hs := HTTPSync{
+		Host: "devbox",
+		URL:  ts.URL,
+		Progress: func(p syncpkg.Progress) {
+			if p.BytesDone == int64(len(archive)) {
+				for _, name := range []string{"TMPDIR", "TMP", "TEMP"} {
+					require.NoError(t, os.Setenv(name, invalidTemp))
+				}
+			}
+		},
+		removeArchiveSpool: func(string) error {
+			removeCalls++
+			if removeCalls == 1 {
+				return removeErr
+			}
+			return nil
+		},
+	}
+
+	root, err := hs.downloadAndExtract(
+		context.Background(), ts.Client(), TargetSet{},
+	)
+
+	assert.Empty(t, root)
+	require.ErrorContains(t, err, "create temp dir")
+	require.ErrorIs(t, err, removeErr)
+	var owner *downloadedArchiveCleanupError
+	require.ErrorAs(t, err, &owner,
+		"failed cleanup must retain the downloaded spool")
+	require.NoError(t, owner.RetryCleanup())
+	assert.Equal(t, 2, removeCalls)
+}
+
 func TestHTTPSyncRemovesSpooledArchiveOnCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	parent := filepath.Join(t.TempDir(), "remote-mirrors")

--- a/internal/remotesync/http_transfer.go
+++ b/internal/remotesync/http_transfer.go
@@ -1,0 +1,209 @@
+package remotesync
+
+import (
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+
+	syncpkg "go.kenn.io/agentsview/internal/sync"
+)
+
+// downloadedArchive owns an isolated directory containing a raw HTTP
+// response-body spool until Close. Keeping the wire representation separate
+// from extraction makes transfer progress independent from tar processing and
+// preserves meaningful Content-Length totals for compressed responses.
+type downloadedArchive struct {
+	dir        string
+	path       string
+	compressed bool
+	open       func() (io.ReadCloser, error)
+	remove     func(string) error
+}
+
+// downloadedArchiveCleanupError retains a spool whose removal failed so the
+// process-level cleanup registry can retry it before another HTTP sync starts.
+type downloadedArchiveCleanupError struct {
+	mu      sync.Mutex
+	cause   error
+	archive *downloadedArchive
+	root    string
+	remove  func(string) error
+}
+
+func (e *downloadedArchiveCleanupError) Error() string { return e.cause.Error() }
+func (e *downloadedArchiveCleanupError) Unwrap() error { return e.cause }
+func (e *downloadedArchiveCleanupError) RetryCleanup() error {
+	if e == nil {
+		return nil
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	var cleanupErr error
+	if e.archive != nil {
+		if err := e.archive.Close(); err != nil {
+			cleanupErr = errors.Join(cleanupErr, err)
+		} else {
+			e.archive = nil
+		}
+	}
+	if e.root != "" {
+		remove := e.remove
+		if remove == nil {
+			remove = os.RemoveAll
+		}
+		if err := remove(e.root); err != nil {
+			cleanupErr = errors.Join(cleanupErr,
+				fmt.Errorf("remove extracted archive root: %w", err))
+		} else {
+			e.root = ""
+		}
+	}
+	return cleanupErr
+}
+
+func retainDownloadedArchiveCleanup(
+	cause error, archive *downloadedArchive, root string,
+) error {
+	return &downloadedArchiveCleanupError{
+		cause: cause, archive: archive, root: root,
+	}
+}
+
+func (hs HTTPSync) downloadArchive(
+	ctx context.Context,
+	resp *http.Response,
+	label string,
+	spoolDir string,
+) (result *downloadedArchive, err error) {
+	var owned *downloadedArchive
+	defer func() {
+		err = errors.Join(err, resp.Body.Close())
+		if err != nil && owned != nil {
+			if cleanupErr := owned.Close(); cleanupErr != nil {
+				err = &downloadedArchiveCleanupError{
+					cause: errors.Join(err, cleanupErr), archive: owned,
+				}
+			}
+			result = nil
+		}
+	}()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, httpStatusError(resp)
+	}
+	if err := os.MkdirAll(spoolDir, 0o700); err != nil {
+		return nil, fmt.Errorf("create archive spool dir: %w", err)
+	}
+	tempDir, err := os.MkdirTemp(spoolDir, "agentsview-http-archive-*")
+	if err != nil {
+		return nil, fmt.Errorf("create archive spool dir: %w", err)
+	}
+	owned = &downloadedArchive{
+		dir:        tempDir,
+		path:       filepath.Join(tempDir, "archive"),
+		compressed: resp.Header.Get("Content-Encoding") == "gzip",
+		remove:     hs.removeArchiveSpool,
+	}
+	spool, err := os.Create(owned.path)
+	if err != nil {
+		return nil, fmt.Errorf("create archive spool: %w", err)
+	}
+
+	total := positiveContentLength(resp.ContentLength)
+	hs.report(syncpkg.Progress{Detail: label, BytesTotal: total})
+	reader := &progressReader{
+		r:     &contextReader{ctx: ctx, r: resp.Body},
+		total: total,
+		report: func(done, total int64) {
+			hs.report(syncpkg.Progress{
+				Detail:     label,
+				BytesDone:  done,
+				BytesTotal: total,
+			})
+		},
+	}
+	_, copyErr := io.Copy(spool, reader)
+	closeErr := spool.Close()
+	if copyErr != nil {
+		return nil, errors.Join(
+			fmt.Errorf("download archive: %w", copyErr), closeErr,
+		)
+	}
+	if closeErr != nil {
+		return nil, fmt.Errorf("close archive spool: %w", closeErr)
+	}
+	return owned, nil
+}
+
+type contextReader struct {
+	ctx context.Context
+	r   io.Reader
+}
+
+func (r *contextReader) Read(p []byte) (int, error) {
+	select {
+	case <-r.ctx.Done():
+		return 0, r.ctx.Err()
+	default:
+		return r.r.Read(p)
+	}
+}
+
+func (a *downloadedArchive) extract(
+	ctx context.Context,
+	dst string,
+	report syncpkg.ProgressFunc,
+	label string,
+) (err error) {
+	if report != nil {
+		report(syncpkg.Progress{Detail: label})
+	}
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return fmt.Errorf("create extraction dir: %w", err)
+	}
+	open := a.open
+	if open == nil {
+		open = func() (io.ReadCloser, error) { return os.Open(a.path) }
+	}
+	archive, err := open()
+	if err != nil {
+		return fmt.Errorf("open archive spool: %w", err)
+	}
+	defer func() { err = errors.Join(err, archive.Close()) }()
+
+	var stream io.Reader = archive
+	if a.compressed {
+		gz, gzipErr := gzip.NewReader(archive)
+		if gzipErr != nil {
+			return fmt.Errorf("decode archive gzip: %w", gzipErr)
+		}
+		defer func() { err = errors.Join(err, gz.Close()) }()
+		stream = gz
+	}
+	stream = &contextReader{ctx: ctx, r: stream}
+	if _, err := ExtractTarStream(ctx, stream, dst); err != nil {
+		return fmt.Errorf("extract archive: %w", err)
+	}
+	return nil
+}
+
+func (a *downloadedArchive) Close() error {
+	if a == nil || a.dir == "" {
+		return nil
+	}
+	remove := a.remove
+	if remove == nil {
+		remove = os.RemoveAll
+	}
+	if err := remove(a.dir); err != nil {
+		return fmt.Errorf("remove archive spool dir: %w", err)
+	}
+	a.dir = ""
+	a.path = ""
+	return nil
+}

--- a/internal/remotesync/import.go
+++ b/internal/remotesync/import.go
@@ -13,7 +13,7 @@ import (
 func (im Importer) ImportExtracted(
 	ctx context.Context,
 	targets TargetSet,
-	tmpDir string,
+	root string,
 ) (SyncStats, error) {
 	var stats SyncStats
 	if err := validateTargetSetPaths(targets); err != nil {
@@ -22,55 +22,24 @@ func (im Importer) ImportExtracted(
 	if len(targets.Dirs) == 0 {
 		return stats, nil
 	}
-	engineDirs := make(map[parser.AgentType][]string)
-	remoteDirs := make([]string, 0)
-	tempDirs := make([]string, 0)
-	for agentType, agentDirList := range targets.Dirs {
-		for _, remoteDir := range agentDirList {
-			local, err := safeRemappedRemotePath(tmpDir, remoteDir)
-			if err != nil {
-				return stats, err
-			}
-			engineDirs[agentType] = append(engineDirs[agentType], local)
-			remoteDirs = append(remoteDirs, remoteDir)
-			tempDirs = append(tempDirs, local)
-		}
+	layout, config, err := newImportInputs(
+		im.Host, im.BlockedResultCategories, targets, root,
+	)
+	if err != nil {
+		return stats, err
 	}
 
-	rewriter := func(tempPath string) string {
-		remotePath, ok := tempPathToRemotePath(tempPath, remoteDirs, tempDirs)
-		if !ok {
-			remotePath = RemapToRemotePath(tmpDir, "", tempPath)
-		}
-		return im.Host + ":" + remotePath
-	}
-
-	engine := syncpkg.NewEngine(im.DB, syncpkg.EngineConfig{
-		AgentDirs:               engineDirs,
-		Machine:                 im.Host,
-		IDPrefix:                im.Host + "~",
-		PathRewriter:            rewriter,
-		Ephemeral:               true,
-		BlockedResultCategories: im.BlockedResultCategories,
-	})
+	engine := syncpkg.NewEngine(im.DB, config)
 	defer engine.Close()
 
 	if !im.Full {
-		remoteCache, err := im.DB.LoadRemoteSkippedFiles(im.Host)
-		if err != nil {
-			return stats, fmt.Errorf("load skip cache: %w", err)
+		if err := loadImportSkipCache(im.DB, im.Host, engine, layout); err != nil {
+			return stats, err
 		}
-		remoteCache = migrateVisualStudioCopilotRemoteSkips(
-			im.DB, im.Host, remoteCache,
-		)
-		translated := translateRemoteCacheToTemp(
-			remoteCache, remoteDirs, tempDirs,
-		)
-		engine.InjectSkipCache(translated)
 	}
 
-	engineStats := engine.SyncAll(ctx, im.hostProgress)
-	if err := im.saveSkipCache(engine, remoteDirs, tempDirs); err != nil {
+	engineStats := engine.SyncAll(ctx, hostProgress(im.Host, im.Progress))
+	if err := saveEngineSkipCache(im.DB, engine, layout.paths); err != nil {
 		return stats, err
 	}
 	stats.SessionsSynced = engineStats.Synced
@@ -80,19 +49,119 @@ func (im Importer) ImportExtracted(
 	return stats, nil
 }
 
-func (im Importer) hostProgress(p syncpkg.Progress) {
-	if im.Progress == nil {
-		return
+// importLayout maps stable remote paths to one prepared source root. Keeping
+// this mapping independent from Importer lets prepared HTTP imports and future
+// rebuild contributors share the exact engine inputs and cache translation.
+type importLayout struct {
+	engineDirs map[parser.AgentType][]string
+	paths      remotePathMap
+}
+
+type remotePathMap struct {
+	host       string
+	root       string
+	remoteDirs []string
+	localDirs  []string
+}
+
+func newImportLayout(targets TargetSet, root string) (importLayout, error) {
+	layout := importLayout{
+		engineDirs: make(map[parser.AgentType][]string),
 	}
+	layout.paths.root = root
+	for agentType, agentDirList := range targets.Dirs {
+		for _, remoteDir := range agentDirList {
+			local, err := safeRemappedRemotePath(root, remoteDir)
+			if err != nil {
+				return importLayout{}, err
+			}
+			layout.engineDirs[agentType] = append(layout.engineDirs[agentType], local)
+			layout.paths.remoteDirs = append(layout.paths.remoteDirs, remoteDir)
+			layout.paths.localDirs = append(layout.paths.localDirs, local)
+		}
+	}
+	return layout, nil
+}
+
+func newImportInputs(
+	host string,
+	blockedResultCategories []string,
+	targets TargetSet,
+	root string,
+) (importLayout, syncpkg.EngineConfig, error) {
+	layout, err := newImportLayout(targets, root)
+	if err != nil {
+		return importLayout{}, syncpkg.EngineConfig{}, err
+	}
+	layout.paths.host = host
+	return layout, importEngineConfig(
+		host, blockedResultCategories, layout,
+	), nil
+}
+
+func (p remotePathMap) pathRewriter() func(string) string {
+	return func(localPath string) string {
+		remotePath, ok := tempPathToRemotePath(
+			localPath, p.remoteDirs, p.localDirs,
+		)
+		if !ok {
+			remotePath = RemapToRemotePath(p.root, "", localPath)
+		}
+		return p.host + ":" + remotePath
+	}
+}
+
+func importEngineConfig(
+	host string,
+	blockedResultCategories []string,
+	layout importLayout,
+) syncpkg.EngineConfig {
+	return syncpkg.EngineConfig{
+		AgentDirs:               layout.engineDirs,
+		Machine:                 host,
+		IDPrefix:                host + "~",
+		PathRewriter:            layout.paths.pathRewriter(),
+		Ephemeral:               true,
+		BlockedResultCategories: blockedResultCategories,
+	}
+}
+
+func loadImportSkipCache(
+	database *db.DB,
+	host string,
+	engine *syncpkg.Engine,
+	layout importLayout,
+) error {
+	remoteCache, err := database.LoadRemoteSkippedFiles(host)
+	if err != nil {
+		return fmt.Errorf("load skip cache: %w", err)
+	}
+	remoteCache = migrateVisualStudioCopilotRemoteSkips(database, host, remoteCache)
+	engine.InjectSkipCache(translateRemoteCacheToTemp(
+		remoteCache, layout.paths.remoteDirs, layout.paths.localDirs,
+	))
+	return nil
+}
+
+func hostProgress(host string, progress syncpkg.ProgressFunc) syncpkg.ProgressFunc {
+	if progress == nil {
+		return nil
+	}
+	return func(p syncpkg.Progress) {
+		progress(transformHostProgress(host, p))
+	}
+}
+
+func transformHostProgress(host string, p syncpkg.Progress) syncpkg.Progress {
 	switch {
 	case p.Phase == syncpkg.PhaseDiscovering:
-		p.Detail = fmt.Sprintf("Discovering sessions from %s", im.Host)
+		p.Detail = fmt.Sprintf("Discovering sessions from %s", host)
 	case p.Phase == syncpkg.PhaseSyncing && p.SessionsTotal > 0:
-		p.Detail = fmt.Sprintf("Processing sessions from %s", im.Host)
+		p.Detail = fmt.Sprintf("Processing sessions from %s", host)
 	case p.Phase == syncpkg.PhaseDone && p.SessionsTotal > 0:
-		p.Detail = fmt.Sprintf("Processing sessions from %s", im.Host)
+		p.Detail = fmt.Sprintf("Processing sessions from %s", host)
 	}
-	im.Progress(p)
+	return p
 }
 
 func translateRemoteCacheToTemp(
@@ -116,22 +185,22 @@ func translateRemoteCacheToTemp(
 	return translated
 }
 
-func (im Importer) saveSkipCache(
+func saveEngineSkipCache(
+	database *db.DB,
 	engine *syncpkg.Engine,
-	remoteDirs []string,
-	tempDirs []string,
+	paths remotePathMap,
 ) error {
 	snapshot := engine.SnapshotSkipCache()
 	remoteCache := make(map[string]int64, len(snapshot))
-	for tempPath, mtime := range snapshot {
-		remotePath, ok := tempPathToRemotePath(tempPath, remoteDirs, tempDirs)
+	for localPath, mtime := range snapshot {
+		remotePath, ok := tempPathToRemotePath(
+			localPath, paths.remoteDirs, paths.localDirs,
+		)
 		if ok {
 			remoteCache[remotePath] = mtime
 		}
 	}
-	if err := im.DB.ReplaceRemoteSkippedFiles(
-		im.Host, remoteCache,
-	); err != nil {
+	if err := database.ReplaceRemoteSkippedFiles(paths.host, remoteCache); err != nil {
 		return fmt.Errorf("save skip cache: %w", err)
 	}
 	return nil

--- a/internal/remotesync/import_test.go
+++ b/internal/remotesync/import_test.go
@@ -1,17 +1,177 @@
 package remotesync
 
 import (
+	"archive/tar"
+	"bytes"
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/parser"
+	syncpkg "go.kenn.io/agentsview/internal/sync"
 	"go.kenn.io/agentsview/internal/testjsonl"
 )
+
+func TestPreparedHTTPSyncRebuildContributor(t *testing.T) {
+	const (
+		sessionID   = "session"
+		remoteDir   = "/remote"
+		remoteFile  = "/remote/path/session.jsonl"
+		skippedDir  = "/remote-skips"
+		skippedFile = "/remote-skips/path/intentionally-empty.jsonl"
+	)
+	sessionBody := testjsonl.NewSessionBuilder().AddClaudeUserWithSessionID(
+		"2024-01-01T00:00:00Z", "remote rebuild searchable", sessionID,
+	).String()
+	usageBody := testjsonl.ClaudeUserJSON(
+		"<command-name>/usage</command-name>\n"+
+			"<command-message>usage</command-message>\n"+
+			"<command-args></command-args>",
+		"2024-01-01T00:01:00Z",
+	)
+	files := map[string]string{
+		remoteFile:  sessionBody,
+		skippedFile: usageBody,
+	}
+	mtime := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	manifest := Manifest{Files: []ManifestEntry{
+		{Path: remoteFile, Size: int64(len(sessionBody)), MtimeNS: mtime.UnixNano()},
+		{Path: skippedFile, Size: int64(len(usageBody)), MtimeNS: mtime.UnixNano()},
+	}}
+	archive := func(t *testing.T) []byte {
+		t.Helper()
+		var buf bytes.Buffer
+		tw := tar.NewWriter(&buf)
+		for _, path := range []string{remoteFile, skippedFile} {
+			name, err := safeRemotePathArchiveName(path)
+			require.NoError(t, err)
+			body := files[path]
+			require.NoError(t, tw.WriteHeader(&tar.Header{
+				Name: name, Mode: 0o644, Size: int64(len(body)), ModTime: mtime,
+			}))
+			_, err = tw.Write([]byte(body))
+			require.NoError(t, err)
+		}
+		require.NoError(t, tw.Close())
+		return buf.Bytes()
+	}(t)
+	targets := TargetSet{Dirs: map[parser.AgentType][]string{
+		parser.AgentClaude: {remoteDir, skippedDir},
+	}}
+	targetsJSON, err := json.Marshal(targets)
+	require.NoError(t, err)
+	manifestJSON, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/remote-sync/targets":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(targetsJSON)
+		case "/api/v1/remote-sync/manifest":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(manifestJSON)
+		case "/api/v1/remote-sync/archive":
+			w.Header().Set("Content-Type", "application/x-tar")
+			_, _ = w.Write(archive)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	database, err := db.Open(filepath.Join(t.TempDir(), "active.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	require.NoError(t, database.ReplaceRemoteSkippedFiles("devbox", map[string]int64{
+		remoteFile: mtime.UnixNano(),
+	}))
+	hs := HTTPSync{
+		Host: "devbox", URL: server.URL, DataDir: t.TempDir(), DB: database,
+	}
+	prepared, err := hs.Prepare(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, prepared.Close()) })
+	assert.FileExists(t, remappedRemotePath(prepared.Root(), remoteFile))
+	contributor, err := prepared.RebuildContributor()
+	require.NoError(t, err)
+
+	localEngine := syncpkg.NewEngine(database, syncpkg.EngineConfig{})
+	t.Cleanup(localEngine.Close)
+	stats, err := localEngine.ResyncAllWithOptions(
+		context.Background(), nil,
+		syncpkg.RebuildOptions{Contributors: []syncpkg.RebuildContributor{contributor}},
+	)
+	require.NoError(t, err)
+	assert.False(t, stats.Aborted)
+
+	full, err := database.GetSessionFull(context.Background(), "devbox~"+sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, full)
+	assert.Equal(t, "devbox", full.Machine)
+	require.NotNil(t, full.FilePath)
+	assert.Equal(t, "devbox:"+remoteFile, *full.FilePath)
+	messages, err := database.GetMessages(
+		context.Background(), "devbox~"+sessionID, 0, 10, true,
+	)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Equal(t, "remote rebuild searchable", messages[0].Content)
+	search, err := database.SearchContent(context.Background(), db.ContentSearchFilter{
+		Pattern: "searchable", Limit: 10, IncludeOneShot: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, search.Matches, 1)
+	assert.Equal(t, "devbox~"+sessionID, search.Matches[0].SessionID)
+	remoteCache, err := database.LoadRemoteSkippedFiles("devbox")
+	require.NoError(t, err)
+	require.Len(t, remoteCache, 1)
+	for cachedPath := range remoteCache {
+		assert.True(t, strings.HasPrefix(
+			cachedPath, skippedFile+"?source_hash=",
+		), "rowless Claude skips must persist their content hash")
+	}
+	assert.NotContains(t, remoteCache, remoteFile,
+		"a full contributor must not load the active database's stale host cache")
+
+	prepared.targets = TargetSet{Dirs: map[parser.AgentType][]string{
+		parser.AgentClaude: {skippedDir},
+	}}
+	activeStats, err := prepared.ImportActive(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, activeStats.Failed)
+	assert.Equal(t, 1, activeStats.Skipped)
+}
+
+func TestPreparedHTTPSyncImportActiveImportsPreparedRoot(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	remote.writeSession(t, "session.jsonl",
+		time.Date(2026, 7, 8, 10, 0, 0, 0, time.UTC), "prepared import")
+	database, hs := newMirrorSync(t, remote, t.TempDir())
+
+	prepared, err := hs.Prepare(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, prepared.Close()) })
+	before, err := database.ListSessions(context.Background(), db.SessionFilter{Limit: 10})
+	require.NoError(t, err)
+	assert.Empty(t, before.Sessions, "Prepare must not import active sessions")
+
+	stats, err := prepared.ImportActive(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.SessionsSynced)
+	after, err := database.ListSessions(context.Background(), db.SessionFilter{Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, after.Sessions, 1)
+	assert.Equal(t, "devbox", after.Sessions[0].Machine)
+}
 
 func TestImporterImportsExtractedRemoteFiles(t *testing.T) {
 	database, err := db.Open(filepath.Join(t.TempDir(), "test.db"))

--- a/internal/remotesync/lock_identity.go
+++ b/internal/remotesync/lock_identity.go
@@ -1,0 +1,45 @@
+package remotesync
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// canonicalMirrorLockPath returns the canonical path used for mirror locking.
+// It creates the lock parent and lock file before resolving identity. Those are
+// the same harmless artifacts lock acquisition already needs, and creating them
+// here lets preflight identify aliases even when the configured data directory
+// did not previously exist. Mirror extraction continues to use the configured
+// root; only lock identity is canonicalized.
+func canonicalMirrorLockPath(mirrorRoot string) (string, error) {
+	absRoot, err := filepath.Abs(mirrorRoot)
+	if err != nil {
+		return "", fmt.Errorf("make mirror lock path absolute: %w", err)
+	}
+	absRoot = filepath.Clean(absRoot)
+
+	lockPath := absRoot + ".lock"
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o700); err != nil {
+		return "", fmt.Errorf("create mirror lock parent: %w", err)
+	}
+	lockFile, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDONLY, 0o600)
+	if err != nil {
+		return "", fmt.Errorf("open mirror lock identity %s: %w", lockPath, err)
+	}
+	resolved, resolveErr := filepath.EvalSymlinks(lockPath)
+	if resolveErr != nil {
+		resolveErr = fmt.Errorf("resolve mirror lock path %s: %w", lockPath, resolveErr)
+	} else {
+		resolved, resolveErr = platformCanonicalLockPath(lockFile, resolved)
+	}
+	closeErr := lockFile.Close()
+	if closeErr != nil {
+		closeErr = fmt.Errorf("close mirror lock identity %s: %w", lockPath, closeErr)
+	}
+	if err := errors.Join(resolveErr, closeErr); err != nil {
+		return "", err
+	}
+	return filepath.Clean(resolved), nil
+}

--- a/internal/remotesync/lock_identity_darwin.go
+++ b/internal/remotesync/lock_identity_darwin.go
@@ -1,0 +1,31 @@
+//go:build darwin
+
+package remotesync
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// platformCanonicalLockPath asks Darwin for the canonical path of the opened
+// lock file. F_GETPATH reflects the volume's case and Unicode normalization
+// rules without scanning any directory or globally folding path spelling.
+func platformCanonicalLockPath(lockFile *os.File, _ string) (string, error) {
+	buffer := make([]byte, 4096)
+	if err := unix.FcntlFlock(
+		lockFile.Fd(), unix.F_GETPATH,
+		(*unix.Flock_t)(unsafe.Pointer(&buffer[0])),
+	); err != nil {
+		return "", fmt.Errorf("resolve Darwin mirror lock identity: %w", err)
+	}
+	before, _, ok := bytes.Cut(buffer, []byte{0})
+	if !ok {
+		return "", fmt.Errorf("resolve Darwin mirror lock identity: path is not terminated")
+	}
+	return filepath.Clean(string(before)), nil
+}

--- a/internal/remotesync/lock_identity_other.go
+++ b/internal/remotesync/lock_identity_other.go
@@ -1,0 +1,9 @@
+//go:build !windows && !darwin
+
+package remotesync
+
+import "os"
+
+func platformCanonicalLockPath(_ *os.File, path string) (string, error) {
+	return path, nil
+}

--- a/internal/remotesync/lock_identity_windows.go
+++ b/internal/remotesync/lock_identity_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package remotesync
+
+import (
+	"os"
+	"strings"
+)
+
+func platformCanonicalLockPath(_ *os.File, path string) (string, error) {
+	return strings.ToLower(path), nil
+}

--- a/internal/remotesync/mirror.go
+++ b/internal/remotesync/mirror.go
@@ -211,10 +211,11 @@ type MirrorLockHandle struct {
 func AcquireMirrorLock(
 	ctx context.Context, mirrorRoot string,
 ) (*MirrorLockHandle, error) {
-	if err := os.MkdirAll(filepath.Dir(mirrorRoot), 0o700); err != nil {
-		return nil, fmt.Errorf("create mirror parent dir: %w", err)
+	lockPath, err := canonicalMirrorLockPath(mirrorRoot)
+	if err != nil {
+		return nil, err
 	}
-	lock := flock.New(mirrorRoot + ".lock")
+	lock := flock.New(lockPath)
 	locked, err := lock.TryLockContext(ctx, 250*time.Millisecond)
 	if err != nil {
 		return nil, fmt.Errorf("acquire mirror lock %s: %w", lock.Path(), err)

--- a/internal/remotesync/mirror_test.go
+++ b/internal/remotesync/mirror_test.go
@@ -131,9 +131,37 @@ func TestAcquireMirrorLockIsExclusive(t *testing.T) {
 	require.NoError(t, second.Close())
 }
 
+func TestAcquireMirrorLockCanonicalizesSymlinkedParent(t *testing.T) {
+	base := t.TempDir()
+	realParent := filepath.Join(base, "real")
+	require.NoError(t, os.MkdirAll(realParent, 0o755))
+	linkParent := filepath.Join(base, "link")
+	if err := os.Symlink(realParent, linkParent); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	realRoot := filepath.Join(realParent, "data", "remote-mirrors", "shared")
+	aliasRoot := filepath.Join(linkParent, "data", "remote-mirrors", "shared")
+	lock, err := AcquireMirrorLock(context.Background(), realRoot)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = lock.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	aliasLock, err := AcquireMirrorLock(ctx, aliasRoot)
+	cancel()
+	if aliasLock != nil {
+		require.NoError(t, aliasLock.Close())
+	}
+	assert.Error(t, err, "symlink aliases must contend on one canonical lock")
+
+	require.NoError(t, lock.Close())
+	aliasLock, err = AcquireMirrorLock(context.Background(), aliasRoot)
+	require.NoError(t, err)
+	require.NoError(t, aliasLock.Close())
+}
+
 func TestRemoveMirrorTypeConflictsRemovesDirAtFetchPath(t *testing.T) {
 	root := t.TempDir()
-	wedged := "/home/u/.claude/projects/p/s.jsonl"
+	wedged := "/archives/claude/projects/p/s.jsonl"
 	local, err := safeRemappedRemotePath(root, wedged)
 	require.NoError(t, err)
 	require.NoError(t, os.MkdirAll(local, 0o755))

--- a/internal/server/huma_routes_settings.go
+++ b/internal/server/huma_routes_settings.go
@@ -122,7 +122,7 @@ func (s *Server) localWorktreeMappingHumaDB() (*db.DB, string, error) {
 	}
 	machine := strings.TrimSpace(s.engine.Machine())
 	if machine == "" {
-		machine = "local"
+		machine = s.cfg.LocalMachineName
 	}
 	return localDB, machine, nil
 }

--- a/internal/server/huma_routes_sync.go
+++ b/internal/server/huma_routes_sync.go
@@ -59,6 +59,7 @@ type remoteSyncFailure struct {
 type remoteSyncResponse struct {
 	LocalStats *syncpkg.SyncStats  `json:"local_stats,omitempty"`
 	Failures   []remoteSyncFailure `json:"failures,omitempty"`
+	Error      string              `json:"error,omitempty"`
 }
 
 var runRemoteSync = func(
@@ -93,6 +94,34 @@ var runHTTPRemoteSync = func(
 		BlockedResultCategories: cfg.ResultContentBlockedCategories,
 		Progress:                progress,
 	}.Run(ctx)
+}
+
+type preparedHTTPRebuild interface {
+	BorrowRebuildContributors() ([]syncpkg.RebuildContributor, func(), error)
+	Close() error
+}
+
+var prepareHTTPRebuild = func(
+	ctx context.Context,
+	syncs []remotesync.HTTPSync,
+) (preparedHTTPRebuild, error) {
+	return remotesync.PrepareHTTPSyncs(ctx, syncs)
+}
+
+type preparedHTTPRebuildLease struct {
+	prepared preparedHTTPRebuild
+	release  func()
+}
+
+func (l *preparedHTTPRebuildLease) Close() error {
+	if l == nil {
+		return nil
+	}
+	if l.release != nil {
+		l.release()
+		l.release = nil
+	}
+	return l.prepared.Close()
 }
 
 func (s *Server) humaSyncStatus(
@@ -330,30 +359,252 @@ func (s *Server) runRemoteSyncRequest(
 	var localStats *syncpkg.SyncStats
 	failures := make([]remoteSyncFailure, 0)
 	var remoteStats remotesync.SyncStats
-	run := func(full bool) {
-		failures, remoteStats = s.runRemoteSyncHosts(
-			ctx, local, req.Hosts, full, progress,
-		)
-	}
+	var blocked error
 	if req.IncludeLocal {
-		stats, _ := engine.SyncThenRun(ctx, req.Full, progress,
-			func(forceFull bool) error {
-				run(forceFull)
-				return nil
-			})
-		localStats = &stats
+		httpHosts, sshHosts := partitionRemoteHosts(req.Hosts)
+		outerOwnsHTTP := len(httpHosts) > 0
+		coordinatedRun := func() (remotesync.SyncStats, error) {
+			if !outerOwnsHTTP {
+				stats, err := engine.SyncThenRun(
+					ctx, req.Full, progress, func(forceFull bool) error {
+						failures, remoteStats, blocked = s.runRemoteSyncHostsOwned(
+							ctx, local, req.Hosts, forceFull, progress, true,
+						)
+						return blocked
+					},
+				)
+				localStats = &stats
+				return remotesync.SyncStats{}, err
+			}
+			stats, err := engine.SyncThenRunWithRebuild(
+				ctx, req.Full, progress,
+				func() (
+					syncpkg.RebuildOptions,
+					syncpkg.RebuildCleanup,
+					error,
+				) {
+					prepared, err := prepareHTTPHosts(
+						ctx, s.cfg, local, httpHosts, progress,
+					)
+					if err != nil {
+						return syncpkg.RebuildOptions{}, prepared, err
+					}
+					if prepared == nil {
+						return syncpkg.RebuildOptions{}, nil, nil
+					}
+					contributors, release, err := prepared.BorrowRebuildContributors()
+					if err != nil {
+						return syncpkg.RebuildOptions{}, prepared, err
+					}
+					return syncpkg.RebuildOptions{Contributors: contributors},
+						&preparedHTTPRebuildLease{
+							prepared: prepared,
+							release:  release,
+						}, nil
+				},
+				func(forceFull, rebuilt bool) error {
+					hosts := req.Hosts
+					if rebuilt {
+						hosts = sshHosts
+					}
+					failures, remoteStats, blocked = s.runRemoteSyncHostsOwned(
+						ctx, local, hosts, forceFull, progress, !outerOwnsHTTP,
+					)
+					return blocked
+				},
+			)
+			localStats = &stats
+			return remotesync.SyncStats{}, err
+		}
+		var coordinatorErr error
+		if outerOwnsHTTP {
+			_, coordinatorErr = s.httpRemoteCleanupRegistry.Run(coordinatedRun)
+		} else {
+			_, coordinatorErr = coordinatedRun()
+		}
+		if coordinatorErr != nil {
+			if failure, ok := httpCoordinatorFailure(httpHosts, coordinatorErr); ok {
+				log.Printf("remote sync %s: %v", failure.Host.Host, coordinatorErr)
+				failures = append(failures, failure)
+				blocked = nil
+			} else {
+				blocked = coordinatorErr
+			}
+		} else if localStats != nil && localStats.Aborted {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				blocked = ctxErr
+			} else {
+				blocked = syncpkg.ErrUnifiedRebuildAborted
+			}
+		}
 	} else {
-		_ = engine.RunExclusive(func() error {
-			run(req.Full)
-			return nil
-		})
+		httpHosts, _ := partitionRemoteHosts(req.Hosts)
+		outerOwnsHTTP := len(httpHosts) > 0
+		exclusiveRun := func() (remotesync.SyncStats, error) {
+			err := engine.RunExclusive(func() error {
+				failures, remoteStats, blocked = s.runRemoteSyncHostsOwned(
+					ctx, local, req.Hosts, req.Full, progress, !outerOwnsHTTP,
+				)
+				return blocked
+			})
+			return remotesync.SyncStats{}, err
+		}
+		if outerOwnsHTTP {
+			_, blocked = s.httpRemoteCleanupRegistry.Run(exclusiveRun)
+		} else {
+			_, blocked = exclusiveRun()
+		}
 	}
 	s.emitRemoteSyncChanged(remoteStats)
 
 	return remoteSyncResponse{
 		LocalStats: localStats,
 		Failures:   failures,
+		Error:      remoteSyncTopLevelError(blocked),
 	}
+}
+
+func remoteSyncTopLevelError(err error) string {
+	if err == nil {
+		return ""
+	}
+	if errors.Is(err, context.Canceled) {
+		return context.Canceled.Error()
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return context.DeadlineExceeded.Error()
+	}
+	if errors.Is(err, syncpkg.ErrUnifiedRebuildAborted) {
+		return syncpkg.ErrUnifiedRebuildAborted.Error()
+	}
+	if isHTTPRemoteCoordinatorError(err) {
+		return remotesync.FailureSummary(err)
+	}
+	return "local sync failed"
+}
+
+func partitionRemoteHosts(
+	hosts []config.RemoteHost,
+) (httpHosts, sshHosts []config.RemoteHost) {
+	for _, host := range hosts {
+		if host.Transport == config.RemoteTransportHTTP {
+			httpHosts = append(httpHosts, host)
+		} else {
+			sshHosts = append(sshHosts, host)
+		}
+	}
+	return httpHosts, sshHosts
+}
+
+func prepareHTTPHosts(
+	ctx context.Context,
+	cfg config.Config,
+	local *db.DB,
+	hosts []config.RemoteHost,
+	progress func(syncpkg.Progress),
+) (preparedHTTPRebuild, error) {
+	if len(hosts) == 0 {
+		return nil, nil
+	}
+	syncs := make([]remotesync.HTTPSync, 0, len(hosts))
+	for _, host := range hosts {
+		if host.Token == "" {
+			return nil, &remotesync.HostError{
+				Host:      host.Host,
+				Operation: "authenticate",
+				Err:       errors.New("HTTP remote sync token is required"),
+			}
+		}
+		syncs = append(syncs, remotesync.HTTPSync{
+			Host:                    host.Host,
+			URL:                     host.URL,
+			Token:                   host.Token,
+			Full:                    true,
+			DataDir:                 cfg.DataDir,
+			DB:                      local,
+			BlockedResultCategories: cfg.ResultContentBlockedCategories,
+			Progress:                progress,
+		})
+	}
+	return prepareHTTPRebuild(ctx, syncs)
+}
+
+func httpCoordinatorFailure(
+	hosts []config.RemoteHost,
+	err error,
+) (remoteSyncFailure, bool) {
+	var pending *remotesync.PendingCleanupError
+	if errors.As(err, &pending) {
+		return remoteSyncFailure{}, false
+	}
+	primary := primaryRemoteCoordinatorError(err)
+	var hostName string
+	summaryErr := primary
+	var contributorErr *syncpkg.RebuildContributorError
+	if errors.As(primary, &contributorErr) {
+		hostName = contributorErr.Contributor
+		summaryErr = contributorErr.Err
+	} else {
+		var hostErr *remotesync.HostError
+		if errors.As(primary, &hostErr) {
+			hostName = hostErr.Host
+		}
+	}
+	for _, host := range hosts {
+		if host.Host == hostName {
+			return remoteSyncFailure{
+				Host: remoteSyncFailureHost(host),
+				Err:  remotesync.FailureSummary(summaryErr),
+			}, true
+		}
+	}
+	return remoteSyncFailure{}, false
+}
+
+func primaryRemoteCoordinatorError(err error) error {
+	for err != nil {
+		if joined, ok := err.(interface{ Unwrap() []error }); ok {
+			var first error
+			for _, child := range joined.Unwrap() {
+				if child != nil {
+					first = child
+					break
+				}
+			}
+			if first == nil {
+				return err
+			}
+			err = first
+			continue
+		}
+		switch err.(type) {
+		case *syncpkg.RebuildContributorError, *remotesync.HostError:
+			return err
+		}
+		unwrapped := errors.Unwrap(err)
+		if unwrapped == nil {
+			return err
+		}
+		err = unwrapped
+	}
+	return nil
+}
+
+func isHTTPRemoteCoordinatorError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var pending *remotesync.PendingCleanupError
+	if errors.As(err, &pending) {
+		return true
+	}
+	primary := primaryRemoteCoordinatorError(err)
+	var contributor *syncpkg.RebuildContributorError
+	if errors.As(primary, &contributor) {
+		return true
+	}
+	var host *remotesync.HostError
+	return errors.As(primary, &host)
 }
 
 func (s *Server) runRemoteSyncHosts(
@@ -362,7 +613,28 @@ func (s *Server) runRemoteSyncHosts(
 	hosts []config.RemoteHost,
 	full bool,
 	progress func(syncpkg.Progress),
-) ([]remoteSyncFailure, remotesync.SyncStats) {
+) ([]remoteSyncFailure, remotesync.SyncStats, error) {
+	return s.runRemoteSyncHostsOwned(
+		ctx, local, hosts, full, progress, true,
+	)
+}
+
+type httpCleanupRetrier interface {
+	RetryCleanup() error
+}
+
+// runRemoteSyncHostsOwned optionally acquires the server's HTTP cleanup
+// registry per host. A false value is only valid while the caller already
+// owns that registry around the entire operation; retryable cleanup errors are
+// then returned immediately so the outer owner can retain them.
+func (s *Server) runRemoteSyncHostsOwned(
+	ctx context.Context,
+	local *db.DB,
+	hosts []config.RemoteHost,
+	full bool,
+	progress func(syncpkg.Progress),
+	acquireHTTPRegistry bool,
+) ([]remoteSyncFailure, remotesync.SyncStats, error) {
 	failures := make([]remoteSyncFailure, 0)
 	var totals remotesync.SyncStats
 	for _, rh := range hosts {
@@ -381,7 +653,16 @@ func (s *Server) runRemoteSyncHosts(
 			}
 			stats, err = runRemoteSync(ctx, rs)
 		case config.RemoteTransportHTTP:
-			stats, err = runHTTPRemoteSync(ctx, s.cfg, local, rh, full, progress)
+			runHTTP := func() (remotesync.SyncStats, error) {
+				return runHTTPRemoteSync(
+					ctx, s.cfg, local, rh, full, progress,
+				)
+			}
+			if acquireHTTPRegistry {
+				stats, err = s.httpRemoteCleanupRegistry.Run(runHTTP)
+			} else {
+				stats, err = runHTTP()
+			}
 		default:
 			err = fmt.Errorf("invalid remote transport %q", rh.Transport)
 		}
@@ -390,6 +671,10 @@ func (s *Server) runRemoteSyncHosts(
 		totals.Skipped += stats.Skipped
 		totals.Failed += stats.Failed
 		if err != nil {
+			var pending *remotesync.PendingCleanupError
+			if errors.As(err, &pending) {
+				return failures, totals, pending
+			}
 			// The raw error can embed the remote URL and response
 			// bodies, so it goes only to the local log; the API
 			// response carries the sanitized summary.
@@ -398,9 +683,15 @@ func (s *Server) runRemoteSyncHosts(
 				Host: remoteSyncFailureHost(rh),
 				Err:  remoteSyncFailureError(rh, err),
 			})
+			if !acquireHTTPRegistry {
+				var cleanup httpCleanupRetrier
+				if errors.As(err, &cleanup) {
+					return failures, totals, err
+				}
+			}
 		}
 	}
-	return failures, totals
+	return failures, totals, nil
 }
 
 func remoteSyncFailureHost(rh config.RemoteHost) config.RemoteHost {

--- a/internal/server/huma_routes_sync.go
+++ b/internal/server/huma_routes_sync.go
@@ -187,7 +187,7 @@ func (s *Server) syncEngineForLocal(local *db.DB) *syncpkg.Engine {
 	s.onDemandEngine = syncpkg.NewEngine(local, syncpkg.EngineConfig{
 		AgentDirs:               s.cfg.AgentDirs,
 		IncludeCwdPrefixes:      s.cfg.SyncIncludeCwdPrefixes,
-		Machine:                 "local",
+		Machine:                 s.cfg.LocalMachineName,
 		BlockedResultCategories: s.cfg.ResultContentBlockedCategories,
 		Emitter:                 emitter,
 	})

--- a/internal/server/huma_routes_sync.go
+++ b/internal/server/huma_routes_sync.go
@@ -449,10 +449,20 @@ func (s *Server) runRemoteSyncRequest(
 			})
 			return remotesync.SyncStats{}, err
 		}
+		var coordinatorErr error
 		if outerOwnsHTTP {
-			_, blocked = s.httpRemoteCleanupRegistry.Run(exclusiveRun)
+			_, coordinatorErr = s.httpRemoteCleanupRegistry.Run(exclusiveRun)
 		} else {
-			_, blocked = exclusiveRun()
+			_, coordinatorErr = exclusiveRun()
+		}
+		if coordinatorErr != nil {
+			if failure, ok := httpCoordinatorFailure(httpHosts, coordinatorErr); ok {
+				log.Printf("remote sync %s: %v", failure.Host.Host, coordinatorErr)
+				failures = append(failures, failure)
+				blocked = nil
+			} else {
+				blocked = coordinatorErr
+			}
 		}
 	}
 	s.emitRemoteSyncChanged(remoteStats)
@@ -679,16 +689,19 @@ func (s *Server) runRemoteSyncHostsOwned(
 			// bodies, so it goes only to the local log; the API
 			// response carries the sanitized summary.
 			log.Printf("remote sync %s: %v", rh.Host, err)
+			if !acquireHTTPRegistry &&
+				rh.Transport == config.RemoteTransportHTTP {
+				var cleanup httpCleanupRetrier
+				if errors.As(err, &cleanup) {
+					return failures, totals, &remotesync.HostError{
+						Host: rh.Host, Operation: "sync", Err: err,
+					}
+				}
+			}
 			failures = append(failures, remoteSyncFailure{
 				Host: remoteSyncFailureHost(rh),
 				Err:  remoteSyncFailureError(rh, err),
 			})
-			if !acquireHTTPRegistry {
-				var cleanup httpCleanupRetrier
-				if errors.As(err, &cleanup) {
-					return failures, totals, err
-				}
-			}
 		}
 	}
 	return failures, totals, nil

--- a/internal/server/huma_routes_sync_internal_test.go
+++ b/internal/server/huma_routes_sync_internal_test.go
@@ -992,6 +992,49 @@ func TestRunRemoteSyncRequestIncrementalKeepsActiveHTTPPath(t *testing.T) {
 	assert.Equal(t, 1, activeCalls)
 }
 
+func TestRunRemoteSyncRequestAttributesOuterOwnedHTTPCleanup(t *testing.T) {
+	for _, includeLocal := range []bool{false, true} {
+		name := "remote-only"
+		if includeLocal {
+			name = "include-local"
+		}
+		t.Run(name, func(t *testing.T) {
+			f := newSyncRouteFixture(t)
+			owner := &serverHTTPCleanupError{
+				cause: errors.New("active HTTP import failed"),
+				results: []error{
+					errors.New("cleanup still holds mirror"),
+					nil,
+				},
+			}
+			stubRunHTTPRemoteSync(t, func(
+				_ context.Context, rh config.RemoteHost, _ bool,
+			) (remotesync.SyncStats, error) {
+				assert.Equal(t, "alpha", rh.Host)
+				return remotesync.SyncStats{}, owner
+			})
+
+			response := f.srv.runRemoteSyncRequest(
+				context.Background(), f.db, f.srv.syncEngineForLocal(f.db),
+				remoteSyncRequest{
+					IncludeLocal: includeLocal,
+					Hosts: []config.RemoteHost{{
+						Host: "alpha", Transport: config.RemoteTransportHTTP,
+					}},
+				}, nil,
+			)
+
+			assert.Empty(t, response.Error,
+				"an HTTP host cleanup failure is not a local sync failure")
+			require.Len(t, response.Failures, 1,
+				"the outer coordinator reports the host exactly once")
+			assert.Equal(t, "alpha", response.Failures[0].Host.Host)
+			assert.Equal(t, "HTTP remote sync failed", response.Failures[0].Err)
+			assert.Equal(t, 1, owner.retries)
+		})
+	}
+}
+
 func TestRunRemoteSyncRequestIncrementalRetainsActiveHTTPCleanup(t *testing.T) {
 	f := newSyncRouteFixture(t)
 	owner := &serverHTTPCleanupError{

--- a/internal/server/huma_routes_sync_internal_test.go
+++ b/internal/server/huma_routes_sync_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	stdlibsync "sync"
@@ -233,6 +234,15 @@ func assertOnlySessionFirstMessageContains(
 	assertFirstMessageContains(t, page.Sessions[0].FirstMessage, want)
 }
 
+func assertSessionCount(t *testing.T, database *db.DB, want int) {
+	t.Helper()
+	page, err := database.ListSessions(context.Background(), db.SessionFilter{
+		Limit: 10,
+	})
+	require.NoError(t, err)
+	assert.Len(t, page.Sessions, want)
+}
+
 func stubRunRemoteSync(
 	t *testing.T,
 	fn func(context.Context, *ssh.RemoteSync) (ssh.SyncStats, error),
@@ -260,6 +270,816 @@ func stubRunHTTPRemoteSync(
 		return fn(ctx, rh, full)
 	}
 	t.Cleanup(func() { runHTTPRemoteSync = originalRunHTTPRemoteSync })
+}
+
+type fakePreparedHTTPRebuild struct {
+	contributors []syncpkg.RebuildContributor
+	closed       int
+	closeErrors  []error
+}
+
+func (p *fakePreparedHTTPRebuild) BorrowRebuildContributors() (
+	[]syncpkg.RebuildContributor, func(), error,
+) {
+	return p.contributors, func() {}, nil
+}
+
+func (p *fakePreparedHTTPRebuild) Close() error {
+	p.closed++
+	if p.closed <= len(p.closeErrors) {
+		return p.closeErrors[p.closed-1]
+	}
+	return nil
+}
+
+func TestHTTPCoordinatorFailurePrefersContributorOverCleanupHost(t *testing.T) {
+	contributorCause := errors.New("alpha contributor failed")
+	cleanupCause := errors.New("beta cleanup failed")
+	err := errors.Join(
+		&syncpkg.RebuildContributorError{
+			Contributor: "alpha", Err: contributorCause,
+		},
+		&remotesync.HostError{
+			Host: "beta", Operation: "cleanup", Err: cleanupCause,
+		},
+	)
+
+	failure, ok := httpCoordinatorFailure([]config.RemoteHost{
+		{Host: "alpha", Transport: config.RemoteTransportHTTP},
+		{Host: "beta", Transport: config.RemoteTransportHTTP},
+	}, err)
+
+	require.True(t, ok)
+	assert.Equal(t, "alpha", failure.Host.Host)
+	assert.Equal(t, remotesync.FailureSummary(contributorCause), failure.Err)
+}
+
+type failingRebuildCleanup struct {
+	errors []error
+	calls  int
+}
+
+type lockOrderCleanup struct {
+	engine       *syncpkg.Engine
+	probeEntered chan struct{}
+	releaseProbe chan struct{}
+	calls        int
+}
+
+func (c *lockOrderCleanup) Error() string { return "pending cleanup" }
+
+func (c *lockOrderCleanup) RetryCleanup() error {
+	c.calls++
+	if c.calls == 1 {
+		return errors.New("retain pending cleanup")
+	}
+	return c.engine.RunExclusive(func() error {
+		close(c.probeEntered)
+		<-c.releaseProbe
+		return nil
+	})
+}
+
+func TestRunRemoteSyncRequestHTTPPathsAcquireCleanupBeforeEngine(t *testing.T) {
+	f := newSyncRouteFixture(t)
+	engine := f.srv.syncEngineForLocal(f.db)
+	owner := &lockOrderCleanup{
+		engine:       engine,
+		probeEntered: make(chan struct{}),
+		releaseProbe: make(chan struct{}),
+	}
+	_, seedErr := f.srv.httpRemoteCleanupRegistry.Run(
+		func() (remotesync.SyncStats, error) {
+			return remotesync.SyncStats{}, owner
+		},
+	)
+	require.Error(t, seedErr)
+
+	var mu stdlibsync.Mutex
+	var callbacks []string
+	stubRunHTTPRemoteSync(t, func(
+		_ context.Context, rh config.RemoteHost, _ bool,
+	) (remotesync.SyncStats, error) {
+		mu.Lock()
+		callbacks = append(callbacks, rh.Host)
+		mu.Unlock()
+		return remotesync.SyncStats{}, nil
+	})
+	host := func(name string) config.RemoteHost {
+		return config.RemoteHost{Host: name, Transport: config.RemoteTransportHTTP}
+	}
+
+	remoteOnlyDone := make(chan remoteSyncResponse, 1)
+	go func() {
+		remoteOnlyDone <- f.srv.runRemoteSyncRequest(
+			context.Background(), f.db, engine,
+			remoteSyncRequest{Hosts: []config.RemoteHost{host("remote-only")}}, nil,
+		)
+	}()
+
+	select {
+	case <-owner.probeEntered:
+	case <-time.After(time.Second):
+		require.FailNow(t, "cleanup retry could not acquire engine")
+	}
+
+	includeLocalDone := make(chan remoteSyncResponse, 1)
+	go func() {
+		includeLocalDone <- f.srv.runRemoteSyncRequest(
+			context.Background(), f.db, engine,
+			remoteSyncRequest{
+				IncludeLocal: true,
+				Hosts:        []config.RemoteHost{host("include-local")},
+			}, nil,
+		)
+	}()
+	close(owner.releaseProbe)
+
+	for _, done := range []chan remoteSyncResponse{remoteOnlyDone, includeLocalDone} {
+		select {
+		case response := <-done:
+			assert.Empty(t, response.Failures)
+		case <-time.After(time.Second):
+			require.FailNow(t, "HTTP request did not complete")
+		}
+	}
+	mu.Lock()
+	assert.Equal(t, []string{"remote-only", "include-local"}, callbacks)
+	mu.Unlock()
+}
+
+func (c *failingRebuildCleanup) Close() error {
+	c.calls++
+	if c.calls <= len(c.errors) {
+		return c.errors[c.calls-1]
+	}
+	return nil
+}
+
+func TestRebuildCleanupFailureIsRetainedByHTTPCleanupRegistry(t *testing.T) {
+	f := newSyncRouteFixture(t)
+	engine := f.srv.syncEngineForLocal(f.db)
+	cleanup := &failingRebuildCleanup{errors: []error{
+		errors.New("deferred close failed"),
+		errors.New("immediate retry failed"),
+	}}
+	registry := remotesync.CleanupRegistry{}
+
+	_, firstErr := registry.Run(func() (remotesync.SyncStats, error) {
+		_, err := engine.SyncThenRunWithRebuild(
+			context.Background(), true, nil,
+			func() (syncpkg.RebuildOptions, syncpkg.RebuildCleanup, error) {
+				return syncpkg.RebuildOptions{}, cleanup, nil
+			},
+			func(bool, bool) error { return nil },
+		)
+		return remotesync.SyncStats{}, err
+	})
+	require.Error(t, firstErr)
+	assert.Equal(t, 2, cleanup.calls,
+		"registry must immediately retry the failed deferred close")
+
+	nextRan := false
+	_, secondErr := registry.Run(func() (remotesync.SyncStats, error) {
+		nextRan = true
+		return remotesync.SyncStats{}, nil
+	})
+	require.NoError(t, secondErr)
+	assert.True(t, nextRan)
+	assert.Equal(t, 3, cleanup.calls,
+		"retained cleanup must finish before the next callback")
+}
+
+func stubPrepareHTTPRebuild(
+	t *testing.T,
+	fn func(context.Context, []remotesync.HTTPSync) (preparedHTTPRebuild, error),
+) {
+	t.Helper()
+	original := prepareHTTPRebuild
+	prepareHTTPRebuild = fn
+	t.Cleanup(func() { prepareHTTPRebuild = original })
+}
+
+func TestRunRemoteSyncRequestUnifiedHTTPContributorFailureSkipsSSH(t *testing.T) {
+	f := newSyncRouteFixture(t)
+	f.writeClaudeSession(t, "proj/local.jsonl", "local survives contributor failure")
+	assertSessionCount(t, f.db, 0)
+
+	sentinel := errors.New("persist remote cache")
+	prepared := &fakePreparedHTTPRebuild{contributors: []syncpkg.RebuildContributor{{
+		Name:      "alpha",
+		AfterSync: func(*syncpkg.Engine, *db.DB) error { return sentinel },
+	}}}
+	stubPrepareHTTPRebuild(t, func(
+		_ context.Context, syncs []remotesync.HTTPSync,
+	) (preparedHTTPRebuild, error) {
+		require.Len(t, syncs, 1)
+		assert.Equal(t, "alpha", syncs[0].Host)
+		return prepared, nil
+	})
+	sshCalls := 0
+	stubRunRemoteSync(t, func(
+		context.Context, *ssh.RemoteSync,
+	) (ssh.SyncStats, error) {
+		sshCalls++
+		return ssh.SyncStats{}, nil
+	})
+
+	response := f.srv.runRemoteSyncRequest(
+		context.Background(), f.db, f.srv.syncEngineForLocal(f.db),
+		remoteSyncRequest{
+			Full: true, IncludeLocal: true,
+			Hosts: []config.RemoteHost{
+				{Host: "alpha", Transport: config.RemoteTransportHTTP, Token: "secret"},
+				{Host: "beta", Transport: config.RemoteTransportSSH},
+			},
+		}, nil,
+	)
+
+	require.Len(t, response.Failures, 1)
+	assert.Equal(t, "alpha", response.Failures[0].Host.Host)
+	assert.NotContains(t, response.Failures[0].Err, sentinel.Error())
+	assert.Zero(t, sshCalls)
+	assert.Equal(t, 1, prepared.closed)
+	assertSessionCount(t, f.db, 0)
+}
+
+func TestRunRemoteSyncRequestContributorFailurePrecedesRetainedCleanupHost(t *testing.T) {
+	f := newSyncRouteFixture(t)
+	contributorCause := &remotesync.StatusError{
+		Code: http.StatusForbidden, Detail: "private contributor detail",
+	}
+	cleanupCause := errors.New("beta mirror cleanup failed")
+	cleanupErr := &remotesync.HostError{
+		Host: "beta", Operation: "cleanup", Err: cleanupCause,
+	}
+	prepared := &fakePreparedHTTPRebuild{
+		contributors: []syncpkg.RebuildContributor{{
+			Name: "alpha",
+			AfterSync: func(*syncpkg.Engine, *db.DB) error {
+				return contributorCause
+			},
+		}},
+		closeErrors: []error{cleanupErr, cleanupErr},
+	}
+	stubPrepareHTTPRebuild(t, func(
+		_ context.Context, syncs []remotesync.HTTPSync,
+	) (preparedHTTPRebuild, error) {
+		require.Len(t, syncs, 2)
+		return prepared, nil
+	})
+	activeCalls := 0
+	stubRunHTTPRemoteSync(t, func(
+		context.Context, config.RemoteHost, bool,
+	) (remotesync.SyncStats, error) {
+		activeCalls++
+		return remotesync.SyncStats{}, nil
+	})
+	httpHost := func(host string) config.RemoteHost {
+		return config.RemoteHost{
+			Host: host, Transport: config.RemoteTransportHTTP, Token: "secret",
+		}
+	}
+
+	first := f.srv.runRemoteSyncRequest(
+		context.Background(), f.db, f.srv.syncEngineForLocal(f.db),
+		remoteSyncRequest{
+			Full: true, IncludeLocal: true,
+			Hosts: []config.RemoteHost{httpHost("alpha"), httpHost("beta")},
+		}, nil,
+	)
+	require.Len(t, first.Failures, 1)
+	assert.Equal(t, "alpha", first.Failures[0].Host.Host)
+	assert.Contains(t, first.Failures[0].Err, "403 Forbidden")
+	assert.NotContains(t, first.Failures[0].Err, contributorCause.Detail)
+	assert.Equal(t, 2, prepared.closed,
+		"failed deferred cleanup must be retried and retained")
+	assert.Zero(t, activeCalls)
+
+	second := f.srv.runRemoteSyncRequest(
+		context.Background(), f.db, f.srv.syncEngineForLocal(f.db),
+		remoteSyncRequest{Hosts: []config.RemoteHost{httpHost("gamma")}}, nil,
+	)
+	assert.Empty(t, second.Failures)
+	assert.Equal(t, 3, prepared.closed,
+		"next request must release retained beta cleanup first")
+	assert.Equal(t, 1, activeCalls)
+}
+
+func TestRunRemoteSyncRequestUnifiedHTTPUsesMirrorDeltaAndBulkRebuild(t *testing.T) {
+	broadcaster := NewBroadcaster(0)
+	f := newSyncRouteFixture(t, withBroadcasterForSyncRoutes(broadcaster))
+	events, unsubscribe := broadcaster.Subscribe()
+	t.Cleanup(unsubscribe)
+	f.writeClaudeSession(t, "proj/local.jsonl", "unified local")
+	remoteDir := filepath.Join(t.TempDir(), "remote-claude")
+	remotePath := filepath.Join(remoteDir, "project", "remote.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(remotePath), 0o755))
+	require.NoError(t, os.WriteFile(
+		remotePath,
+		[]byte(testjsonl.NewSessionBuilder().
+			AddClaudeUser("2024-01-01T00:00:00Z", "unified remote").
+			String()),
+		0o644,
+	))
+	targets := remotesync.TargetSet{Dirs: map[parser.AgentType][]string{
+		parser.AgentClaude: {remoteDir},
+	}}
+	archiveRequests := 0
+	serverErrors := make(chan error, 8)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/remote-sync/targets":
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(targets); err != nil {
+				serverErrors <- err
+			}
+		case "/api/v1/remote-sync/manifest":
+			manifest, err := remotesync.BuildManifest(targets)
+			if err != nil {
+				serverErrors <- err
+				http.Error(w, "manifest failed", http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(manifest); err != nil {
+				serverErrors <- err
+			}
+		case "/api/v1/remote-sync/archive":
+			var request remotesync.ArchiveRequest
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				serverErrors <- err
+				http.Error(w, "bad request", http.StatusBadRequest)
+				return
+			}
+			archiveRequests++
+			w.Header().Set("Content-Type", "application/x-tar")
+			var err error
+			if request.DeltaFiles == nil {
+				err = remotesync.WriteArchive(w, request.TargetSet)
+			} else {
+				err = remotesync.WriteArchiveFiles(
+					w, targets.DeltaAllowedRoots(), request.DeltaFiles,
+				)
+			}
+			if err != nil {
+				serverErrors <- err
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(ts.Close)
+	host := config.RemoteHost{
+		Host: "alpha", Transport: config.RemoteTransportHTTP,
+		URL: ts.URL, Token: "remote-token",
+	}
+
+	for range 2 {
+		response := f.srv.runRemoteSyncRequest(
+			context.Background(), f.db, f.srv.syncEngineForLocal(f.db),
+			remoteSyncRequest{
+				Full: true, IncludeLocal: true, Hosts: []config.RemoteHost{host},
+			}, nil,
+		)
+		assert.Empty(t, response.Failures)
+		require.NotNil(t, response.LocalStats)
+		assert.False(t, response.LocalStats.Aborted)
+		assert.Equal(t, 2, response.LocalStats.Synced)
+		select {
+		case event := <-events:
+			assert.Equal(t, "sync", event.Scope)
+		case <-time.After(time.Second):
+			require.FailNow(t, "unified rebuild did not emit a sync event")
+		}
+	}
+
+	assert.Equal(t, 1, archiveRequests,
+		"unchanged full rebuild should reuse the prepared mirror")
+	assertSessionCount(t, f.db, 2)
+	select {
+	case err := <-serverErrors:
+		require.NoError(t, err)
+	default:
+	}
+}
+
+func TestRunRemoteSyncRequestHTTPPreparationFailureSkipsSSHAndSwap(t *testing.T) {
+	f := newSyncRouteFixture(t)
+	f.writeClaudeSession(t, "proj/local.jsonl", "must remain outside active db")
+	prepared := &fakePreparedHTTPRebuild{}
+	remoteCause := &remotesync.StatusError{
+		Code: http.StatusForbidden, Detail: "private response body",
+	}
+	stubPrepareHTTPRebuild(t, func(
+		context.Context, []remotesync.HTTPSync,
+	) (preparedHTTPRebuild, error) {
+		return prepared, &remotesync.HostError{
+			Host: "alpha", Operation: "prepare", Err: remoteCause,
+		}
+	})
+	sshCalls := 0
+	stubRunRemoteSync(t, func(
+		context.Context, *ssh.RemoteSync,
+	) (ssh.SyncStats, error) {
+		sshCalls++
+		return ssh.SyncStats{}, nil
+	})
+
+	response := f.srv.runRemoteSyncRequest(
+		context.Background(), f.db, f.srv.syncEngineForLocal(f.db),
+		remoteSyncRequest{
+			Full: true, IncludeLocal: true,
+			Hosts: []config.RemoteHost{
+				{Host: "alpha", Transport: config.RemoteTransportHTTP, Token: "secret"},
+				{Host: "beta", Transport: config.RemoteTransportSSH},
+			},
+		}, nil,
+	)
+
+	require.Len(t, response.Failures, 1)
+	assert.Equal(t, "alpha", response.Failures[0].Host.Host)
+	assert.Contains(t, response.Failures[0].Err, "403 Forbidden")
+	assert.NotContains(t, response.Failures[0].Err, remoteCause.Detail)
+	assert.Zero(t, sshCalls)
+	assert.Equal(t, 1, prepared.closed)
+	assertSessionCount(t, f.db, 0)
+}
+
+func TestRunRemoteSyncRequestAbortedUnifiedRebuildReturnsTopLevelError(t *testing.T) {
+	f := newSyncRouteFixture(t)
+	missingPath := filepath.Join(f.dir, "missing.jsonl")
+	require.NoError(t, f.db.UpsertSession(db.Session{
+		ID: "preserved-old-session", Agent: "claude", Machine: "local",
+		Project: "preserved", FilePath: &missingPath, MessageCount: 1,
+	}))
+	stubPrepareHTTPRebuild(t, func(
+		context.Context, []remotesync.HTTPSync,
+	) (preparedHTTPRebuild, error) {
+		return &fakePreparedHTTPRebuild{}, nil
+	})
+	sshCalls := 0
+	stubRunRemoteSync(t, func(
+		context.Context, *ssh.RemoteSync,
+	) (ssh.SyncStats, error) {
+		sshCalls++
+		return ssh.SyncStats{}, nil
+	})
+
+	response := f.srv.runRemoteSyncRequest(
+		context.Background(), f.db, f.srv.syncEngineForLocal(f.db),
+		remoteSyncRequest{
+			Full: true, IncludeLocal: true,
+			Hosts: []config.RemoteHost{
+				{Host: "alpha", Transport: config.RemoteTransportHTTP, Token: "secret"},
+				{Host: "beta", Transport: config.RemoteTransportSSH},
+			},
+		}, nil,
+	)
+
+	require.NotNil(t, response.LocalStats)
+	assert.True(t, response.LocalStats.Aborted)
+	assert.Equal(t, "unified local and HTTP rebuild aborted", response.Error)
+	assert.Empty(t, response.Failures,
+		"an aggregate rebuild abort is not a host failure")
+	assert.Zero(t, sshCalls)
+	preserved, err := f.db.GetSession(context.Background(), "preserved-old-session")
+	require.NoError(t, err)
+	assert.NotNil(t, preserved)
+}
+
+func TestRemoteSyncTopLevelErrorDoesNotMislabelLocalFailure(t *testing.T) {
+	localErr := errors.New("private local FTS failure")
+	cleanupErr := &remotesync.HostError{
+		Host: "alpha", Operation: "cleanup", Err: errors.New("mirror unlock failed"),
+	}
+
+	got := remoteSyncTopLevelError(errors.Join(localErr, cleanupErr))
+
+	assert.Equal(t, "local sync failed", got)
+	assert.NotContains(t, got, localErr.Error())
+	assert.NotContains(t, got, "alpha")
+}
+
+func TestRemoteSyncTopLevelErrorReportsPendingCleanupBeforeWrappedCause(t *testing.T) {
+	err := &remotesync.PendingCleanupError{Err: &remotesync.StatusError{
+		Code: http.StatusForbidden, Detail: "private retained body",
+	}}
+
+	got := remoteSyncTopLevelError(err)
+
+	assert.Equal(t,
+		"HTTP remote sync blocked: cleanup from an earlier sync still owns resources",
+		got,
+	)
+	assert.NotContains(t, got, "403")
+	assert.NotContains(t, got, "private")
+}
+
+func TestServerUsesInjectedHTTPRemoteCleanupRegistry(t *testing.T) {
+	f := newSyncRouteFixture(t)
+	shared := new(remotesync.CleanupRegistry)
+	srv := New(f.srv.cfg, f.db, nil,
+		WithHTTPRemoteCleanupRegistry(shared))
+
+	assert.Same(t, shared, srv.httpRemoteCleanupRegistry)
+}
+
+func TestRunRemoteSyncRequestCanceledRebuildReportsCancellation(t *testing.T) {
+	f := newSyncRouteFixture(t)
+	stubPrepareHTTPRebuild(t, func(
+		context.Context, []remotesync.HTTPSync,
+	) (preparedHTTPRebuild, error) {
+		return &fakePreparedHTTPRebuild{}, nil
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	response := f.srv.runRemoteSyncRequest(
+		ctx, f.db, f.srv.syncEngineForLocal(f.db),
+		remoteSyncRequest{
+			Full: true, IncludeLocal: true,
+			Hosts: []config.RemoteHost{{
+				Host: "alpha", Transport: config.RemoteTransportHTTP, Token: "secret",
+			}},
+		}, nil,
+	)
+
+	require.NotNil(t, response.LocalStats)
+	assert.True(t, response.LocalStats.Aborted)
+	assert.Equal(t, context.Canceled.Error(), response.Error)
+	assert.NotEqual(t, syncpkg.ErrUnifiedRebuildAborted.Error(), response.Error)
+	assert.Empty(t, response.Failures)
+}
+
+func TestRunRemoteSyncRequestSanitizesWrappedContextErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		cause error
+	}{
+		{name: "canceled", cause: context.Canceled},
+		{name: "deadline", cause: context.DeadlineExceeded},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newSyncRouteFixture(t)
+			privateURL := "http://example.invalid/private/archive?token=secret-token"
+			stubPrepareHTTPRebuild(t, func(
+				context.Context, []remotesync.HTTPSync,
+			) (preparedHTTPRebuild, error) {
+				return nil, &url.Error{
+					Op: "Get", URL: privateURL, Err: tt.cause,
+				}
+			})
+
+			response := f.srv.runRemoteSyncRequest(
+				context.Background(), f.db, f.srv.syncEngineForLocal(f.db),
+				remoteSyncRequest{
+					Full: true, IncludeLocal: true,
+					Hosts: []config.RemoteHost{{
+						Host: "alpha", Transport: config.RemoteTransportHTTP,
+						Token: "configured-token",
+					}},
+				}, nil,
+			)
+
+			assert.Equal(t, tt.cause.Error(), response.Error)
+			assert.NotContains(t, response.Error, privateURL)
+			assert.NotContains(t, response.Error, "secret-token")
+			assert.NotContains(t, response.Error, "/private/archive")
+			assert.Empty(t, response.Failures)
+		})
+	}
+}
+
+func TestRunRemoteSyncRequestMixedRunsSSHFullAfterUnifiedSwap(t *testing.T) {
+	f := newSyncRouteFixture(t)
+	f.writeClaudeSession(t, "proj/local.jsonl", "local swapped before ssh")
+	order := make([]string, 0, 3)
+	prepared := &fakePreparedHTTPRebuild{contributors: []syncpkg.RebuildContributor{{
+		Name: "alpha",
+		AfterSync: func(_ *syncpkg.Engine, database *db.DB) error {
+			order = append(order, "http")
+			return nil
+		},
+	}}}
+	stubPrepareHTTPRebuild(t, func(
+		context.Context, []remotesync.HTTPSync,
+	) (preparedHTTPRebuild, error) {
+		order = append(order, "prepare")
+		return prepared, nil
+	})
+	stubRunRemoteSync(t, func(
+		_ context.Context, rs *ssh.RemoteSync,
+	) (ssh.SyncStats, error) {
+		order = append(order, "ssh")
+		assert.True(t, rs.Full)
+		assertOnlySessionFirstMessageContains(t, f.db, "local swapped before ssh")
+		return ssh.SyncStats{}, errors.New("ssh unavailable")
+	})
+
+	response := f.srv.runRemoteSyncRequest(
+		context.Background(), f.db, f.srv.syncEngineForLocal(f.db),
+		remoteSyncRequest{
+			Full: true, IncludeLocal: true,
+			Hosts: []config.RemoteHost{
+				{Host: "alpha", Transport: config.RemoteTransportHTTP, Token: "secret"},
+				{Host: "beta", Transport: config.RemoteTransportSSH},
+			},
+		}, nil,
+	)
+
+	assert.Equal(t, []string{"prepare", "http", "ssh"}, order)
+	require.Len(t, response.Failures, 1)
+	assert.Equal(t, "beta", response.Failures[0].Host.Host)
+	assertOnlySessionFirstMessageContains(t, f.db, "local swapped before ssh")
+}
+
+func TestRunRemoteSyncRequestFullSSHOnlyFallsBackBeforeRemoteImport(t *testing.T) {
+	f := newSyncRouteFixture(t)
+	missingPath := filepath.Join(f.dir, "missing-remote.jsonl")
+	require.NoError(t, f.db.UpsertSession(db.Session{
+		ID: "preserved-ssh-session", Project: "archive", Machine: "ssh-box",
+		Agent: "claude", FilePath: &missingPath, MessageCount: 1,
+	}))
+	sshCalls := 0
+	stubRunRemoteSync(t, func(
+		_ context.Context, rs *ssh.RemoteSync,
+	) (ssh.SyncStats, error) {
+		sshCalls++
+		assert.True(t, rs.Full)
+		return ssh.SyncStats{}, nil
+	})
+
+	response := f.srv.runRemoteSyncRequest(
+		context.Background(), f.db, f.srv.syncEngineForLocal(f.db),
+		remoteSyncRequest{
+			Full: true, IncludeLocal: true,
+			Hosts: []config.RemoteHost{{
+				Host: "ssh-box", Transport: config.RemoteTransportSSH,
+			}},
+		}, nil,
+	)
+
+	require.NotNil(t, response.LocalStats)
+	assert.Empty(t, response.Error)
+	assert.Empty(t, response.Failures)
+	assert.Equal(t, 1, sshCalls,
+		"SSH import must run after the legacy local fallback")
+	preserved, err := f.db.GetSession(context.Background(), "preserved-ssh-session")
+	require.NoError(t, err)
+	assert.NotNil(t, preserved)
+}
+
+func TestRunRemoteSyncRequestRemoteOnlyKeepsActiveHTTPPath(t *testing.T) {
+	f := newSyncRouteFixture(t)
+	prepareCalls := 0
+	stubPrepareHTTPRebuild(t, func(
+		context.Context, []remotesync.HTTPSync,
+	) (preparedHTTPRebuild, error) {
+		prepareCalls++
+		return &fakePreparedHTTPRebuild{}, nil
+	})
+	activeCalls := 0
+	stubRunHTTPRemoteSync(t, func(
+		_ context.Context, rh config.RemoteHost, full bool,
+	) (remotesync.SyncStats, error) {
+		activeCalls++
+		assert.Equal(t, "alpha", rh.Host)
+		assert.True(t, full)
+		return remotesync.SyncStats{}, nil
+	})
+
+	response := f.srv.runRemoteSyncRequest(
+		context.Background(), f.db, f.srv.syncEngineForLocal(f.db),
+		remoteSyncRequest{Full: true, Hosts: []config.RemoteHost{{
+			Host: "alpha", Transport: config.RemoteTransportHTTP,
+		}}}, nil,
+	)
+
+	assert.Empty(t, response.Failures)
+	assert.Zero(t, prepareCalls)
+	assert.Equal(t, 1, activeCalls)
+}
+
+func TestRunRemoteSyncRequestIncrementalKeepsActiveHTTPPath(t *testing.T) {
+	f := newSyncRouteFixture(t)
+	prepareCalls := 0
+	stubPrepareHTTPRebuild(t, func(
+		context.Context, []remotesync.HTTPSync,
+	) (preparedHTTPRebuild, error) {
+		prepareCalls++
+		return &fakePreparedHTTPRebuild{}, nil
+	})
+	activeCalls := 0
+	stubRunHTTPRemoteSync(t, func(
+		_ context.Context, _ config.RemoteHost, full bool,
+	) (remotesync.SyncStats, error) {
+		activeCalls++
+		assert.False(t, full)
+		return remotesync.SyncStats{}, nil
+	})
+
+	response := f.srv.runRemoteSyncRequest(
+		context.Background(), f.db, f.srv.syncEngineForLocal(f.db),
+		remoteSyncRequest{IncludeLocal: true, Hosts: []config.RemoteHost{{
+			Host: "alpha", Transport: config.RemoteTransportHTTP,
+		}}}, nil,
+	)
+
+	assert.Empty(t, response.Failures)
+	assert.Zero(t, prepareCalls)
+	assert.Equal(t, 1, activeCalls)
+}
+
+func TestRunRemoteSyncRequestIncrementalRetainsActiveHTTPCleanup(t *testing.T) {
+	f := newSyncRouteFixture(t)
+	owner := &serverHTTPCleanupError{
+		cause: errors.New("active HTTP import failed"),
+		results: []error{
+			errors.New("cleanup still holds mirror"),
+			nil,
+		},
+	}
+	var callbacks []string
+	stubRunHTTPRemoteSync(t, func(
+		_ context.Context, rh config.RemoteHost, _ bool,
+	) (remotesync.SyncStats, error) {
+		callbacks = append(callbacks, rh.Host)
+		if rh.Host == "alpha" {
+			return remotesync.SyncStats{}, owner
+		}
+		return remotesync.SyncStats{SessionsSynced: 1}, nil
+	})
+	httpHost := func(host string) config.RemoteHost {
+		return config.RemoteHost{Host: host, Transport: config.RemoteTransportHTTP}
+	}
+
+	first := f.srv.runRemoteSyncRequest(
+		context.Background(), f.db, f.srv.syncEngineForLocal(f.db),
+		remoteSyncRequest{
+			IncludeLocal: true, Hosts: []config.RemoteHost{httpHost("alpha")},
+		}, nil,
+	)
+	require.Len(t, first.Failures, 1)
+	assert.Equal(t, []string{"alpha"}, callbacks)
+	assert.Equal(t, 1, owner.retries)
+
+	second := f.srv.runRemoteSyncRequest(
+		context.Background(), f.db, f.srv.syncEngineForLocal(f.db),
+		remoteSyncRequest{
+			IncludeLocal: true, Hosts: []config.RemoteHost{httpHost("beta")},
+		}, nil,
+	)
+	assert.Empty(t, second.Failures)
+	assert.Equal(t, []string{"alpha", "beta"}, callbacks)
+	assert.Equal(t, 2, owner.retries)
+}
+
+func TestRunRemoteSyncRequestAutomaticResyncUsesUnifiedHTTPPath(t *testing.T) {
+	f := newSyncRouteFixture(t, withStaleDB())
+	f.writeClaudeSession(t, "proj/local.jsonl", "automatic unified rebuild")
+	prepareCalls := 0
+	stubPrepareHTTPRebuild(t, func(
+		context.Context, []remotesync.HTTPSync,
+	) (preparedHTTPRebuild, error) {
+		prepareCalls++
+		return &fakePreparedHTTPRebuild{}, nil
+	})
+	activeHTTPCalls := 0
+	stubRunHTTPRemoteSync(t, func(
+		context.Context, config.RemoteHost, bool,
+	) (remotesync.SyncStats, error) {
+		activeHTTPCalls++
+		return remotesync.SyncStats{}, nil
+	})
+	sshCalls := 0
+	stubRunRemoteSync(t, func(
+		_ context.Context, rs *ssh.RemoteSync,
+	) (ssh.SyncStats, error) {
+		sshCalls++
+		assert.True(t, rs.Full)
+		assert.False(t, f.db.NeedsResync(),
+			"post-rebuild SSH must observe the swapped data version")
+		return ssh.SyncStats{}, nil
+	})
+
+	response := f.srv.runRemoteSyncRequest(
+		context.Background(), f.db, f.srv.syncEngineForLocal(f.db),
+		remoteSyncRequest{
+			IncludeLocal: true,
+			Hosts: []config.RemoteHost{
+				{Host: "alpha", Transport: config.RemoteTransportHTTP, Token: "secret"},
+				{Host: "beta", Transport: config.RemoteTransportSSH},
+			},
+		}, nil,
+	)
+
+	assert.Empty(t, response.Failures)
+	assert.Equal(t, 1, prepareCalls)
+	assert.Zero(t, activeHTTPCalls)
+	assert.Equal(t, 1, sshCalls)
+	assert.False(t, f.db.NeedsResync())
 }
 
 func TestSyncEngineForLocalReusesNoSyncEngineConcurrently(t *testing.T) {
@@ -529,7 +1349,7 @@ func TestRunRemoteSyncHostsDispatchesHTTPTransport(t *testing.T) {
 		return remotesync.SyncStats{SessionsSynced: 1, SessionsTotal: 1}, nil
 	})
 
-	failures, stats := f.srv.runRemoteSyncHosts(
+	failures, stats, blocked := f.srv.runRemoteSyncHosts(
 		context.Background(),
 		f.db,
 		[]config.RemoteHost{{
@@ -542,9 +1362,85 @@ func TestRunRemoteSyncHostsDispatchesHTTPTransport(t *testing.T) {
 	)
 
 	assert.Empty(t, failures)
+	require.NoError(t, blocked)
 	assert.False(t, sshCalled, "server HTTP remote must not use SSH runner")
 	assert.Equal(t, "https://alpha.example.test", got.URL)
 	assert.Equal(t, remotesync.SyncStats{SessionsSynced: 1, SessionsTotal: 1}, stats)
+}
+
+func TestRunRemoteSyncHostsRetainsFailedHTTPCleanupUntilReleased(t *testing.T) {
+	f := newSyncRouteFixture(t)
+	owner := &serverHTTPCleanupError{
+		cause: errors.New("alpha HTTP sync failed"),
+		results: []error{
+			errors.New("cleanup failed after alpha"),
+			errors.New("cleanup still blocks beta"),
+			errors.New("cleanup still blocks later request"),
+			nil,
+		},
+	}
+	var callbacks []string
+	stubRunHTTPRemoteSync(t, func(
+		_ context.Context, rh config.RemoteHost, _ bool,
+	) (remotesync.SyncStats, error) {
+		callbacks = append(callbacks, rh.Host)
+		if rh.Host == "alpha" {
+			return remotesync.SyncStats{}, owner
+		}
+		return remotesync.SyncStats{SessionsSynced: 1}, nil
+	})
+	httpHost := func(host string) config.RemoteHost {
+		return config.RemoteHost{Host: host, Transport: config.RemoteTransportHTTP}
+	}
+
+	failures, _, blocked := f.srv.runRemoteSyncHosts(
+		context.Background(), f.db, []config.RemoteHost{
+			httpHost("alpha"), httpHost("beta"), httpHost("gamma"),
+		}, false, nil,
+	)
+	require.Len(t, failures, 1)
+	assert.Equal(t, "alpha", failures[0].Host.Host)
+	var pending *remotesync.PendingCleanupError
+	require.ErrorAs(t, blocked, &pending)
+	assert.ErrorIs(t, blocked, owner)
+	assert.Equal(t, []string{"alpha"}, callbacks,
+		"beta's callback is blocked and iteration stops before gamma")
+	assert.Equal(t, 2, owner.retries)
+
+	failures, _, blocked = f.srv.runRemoteSyncHosts(
+		context.Background(), f.db,
+		[]config.RemoteHost{httpHost("delta")}, false, nil,
+	)
+	assert.Empty(t, failures)
+	require.ErrorAs(t, blocked, &pending)
+	assert.Equal(t, []string{"alpha"}, callbacks)
+	assert.Equal(t, 3, owner.retries)
+
+	failures, stats, blocked := f.srv.runRemoteSyncHosts(
+		context.Background(), f.db,
+		[]config.RemoteHost{httpHost("epsilon")}, false, nil,
+	)
+	assert.Empty(t, failures)
+	require.NoError(t, blocked)
+	assert.Equal(t, 1, stats.SessionsSynced)
+	assert.Equal(t, []string{"alpha", "epsilon"}, callbacks)
+	assert.Equal(t, 4, owner.retries)
+}
+
+type serverHTTPCleanupError struct {
+	cause   error
+	results []error
+	retries int
+}
+
+func (e *serverHTTPCleanupError) Error() string { return e.cause.Error() }
+
+func (e *serverHTTPCleanupError) Unwrap() error { return e.cause }
+
+func (e *serverHTTPCleanupError) RetryCleanup() error {
+	result := e.results[e.retries]
+	e.retries++
+	return result
 }
 
 func TestHumaSyncRemotesStreamsLocalProgress(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -23,6 +23,7 @@ import (
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/insight"
 	"go.kenn.io/agentsview/internal/postgres"
+	"go.kenn.io/agentsview/internal/remotesync"
 	"go.kenn.io/agentsview/internal/service"
 	"go.kenn.io/agentsview/internal/sync"
 	"go.kenn.io/agentsview/internal/web"
@@ -61,6 +62,8 @@ type Server struct {
 	httpSrv        *http.Server
 	version        VersionInfo
 	dataDir        string
+
+	httpRemoteCleanupRegistry *remotesync.CleanupRegistry
 
 	// baseCtx, when set, is used as the base context for all
 	// incoming requests. Cancelling it causes SSE handlers to
@@ -141,6 +144,7 @@ func New(
 		engine:                    engine,
 		sessions:                  sessions,
 		mux:                       http.NewServeMux(),
+		httpRemoteCleanupRegistry: new(remotesync.CleanupRegistry),
 		insightLogDrainTimeout:    defaultInsightLogDrainTimeout,
 		insightLogStopWaitTimeout: defaultInsightLogStopWaitTimeout,
 		generateStreamFunc: func(
@@ -209,6 +213,16 @@ func WithDataDir(dir string) Option {
 // exit and unblocking graceful shutdown.
 func WithBaseContext(ctx context.Context) Option {
 	return func(s *Server) { s.baseCtx = ctx }
+}
+
+// WithHTTPRemoteCleanupRegistry shares cleanup ownership with other HTTP sync
+// entry points in the same process, such as scheduled daemon syncs.
+func WithHTTPRemoteCleanupRegistry(registry *remotesync.CleanupRegistry) Option {
+	return func(s *Server) {
+		if registry != nil {
+			s.httpRemoteCleanupRegistry = registry
+		}
+	}
 }
 
 // WithBroadcaster wires an event broadcaster into the server so the

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1306,7 +1306,7 @@ func (e *Engine) resyncAllWithOptionsLocked(
 	// between storage and SQLite sources across resyncs. Fail closed:
 	// if we can't query, assume old DB has file-backed data
 	// worth protecting.
-	oldFileSessions, err := e.protectedFileSessionCount(origDB, "", false)
+	oldFileSessions, err := e.protectedFileSessionCount(origDB, "", "", false)
 	if err != nil {
 		log.Printf("resync: get old file count: %v", err)
 		oldFileSessions = 1
@@ -1316,16 +1316,16 @@ func (e *Engine) resyncAllWithOptionsLocked(
 	contributorOldFileSessions := make([]int, len(opts.Contributors))
 	if len(opts.Contributors) > 0 {
 		localOldFileSessions, err = e.protectedFileSessionCount(
-			origDB, e.machine, e.machine != "",
+			origDB, e.machine, "", e.machine != "",
 		)
 		if err != nil {
 			log.Printf("resync: get old local file count: %v", err)
 			localOldFileSessions = 1
 		}
-		rebuildOldFileSessions = localOldFileSessions
 		for i, contributor := range opts.Contributors {
 			count, countErr := e.protectedFileSessionCount(
 				origDB, contributor.Config.Machine,
+				contributor.Config.IDPrefix,
 				contributor.Config.Machine != "",
 			)
 			if countErr != nil {
@@ -1336,6 +1336,16 @@ func (e *Engine) resyncAllWithOptionsLocked(
 				count = 1
 			}
 			contributorOldFileSessions[i] = count
+			if contributor.Config.Machine == e.machine &&
+				contributor.Config.IDPrefix != "" {
+				localOldFileSessions -= count
+				if localOldFileSessions < 0 {
+					localOldFileSessions = 0
+				}
+			}
+		}
+		rebuildOldFileSessions = localOldFileSessions
+		for _, count := range contributorOldFileSessions {
 			rebuildOldFileSessions += count
 		}
 	}
@@ -1935,7 +1945,7 @@ func removeWAL(path string) {
 }
 
 func (e *Engine) countRootOpenCodeFormatSessions(
-	database *db.DB, agent parser.AgentType, machine string, scoped bool,
+	database *db.DB, agent parser.AgentType, machine, idPrefix string, scoped bool,
 ) int {
 	if !isOpenCodeFormatStorageAgent(agent) {
 		return 0
@@ -1945,6 +1955,10 @@ func (e *Engine) countRootOpenCodeFormatSessions(
 	if scoped {
 		machinePredicate = " AND machine = ?"
 		args = append(args, machine)
+	}
+	if idPrefix != "" {
+		machinePredicate += " AND substr(id, 1, length(?)) = ?"
+		args = append(args, idPrefix, idPrefix)
 	}
 	var count int
 	err := database.Reader().QueryRow(`
@@ -1961,14 +1975,20 @@ func (e *Engine) countRootOpenCodeFormatSessions(
 }
 
 func (e *Engine) protectedFileSessionCount(
-	database *db.DB, machine string, scoped bool,
+	database *db.DB, machine, idPrefix string, scoped bool,
 ) (int, error) {
 	var count int
 	var err error
 	if scoped {
-		count, err = database.FileBackedSessionCountForMachine(
-			context.Background(), machine,
-		)
+		if idPrefix != "" {
+			count, err = database.FileBackedSessionCountForSource(
+				context.Background(), machine, idPrefix,
+			)
+		} else {
+			count, err = database.FileBackedSessionCountForMachine(
+				context.Background(), machine,
+			)
+		}
 	} else {
 		count, err = database.FileBackedSessionCount(context.Background())
 	}
@@ -1982,7 +2002,7 @@ func (e *Engine) protectedFileSessionCount(
 		parser.AgentIcodemate,
 	} {
 		count -= e.countRootOpenCodeFormatSessions(
-			database, agent, machine, scoped,
+			database, agent, machine, idPrefix, scoped,
 		)
 	}
 	if count < 0 {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1215,6 +1215,54 @@ func (e *Engine) ResyncAll(
 func (e *Engine) resyncAllLocked(
 	ctx context.Context, onProgress ProgressFunc,
 ) (stats SyncStats) {
+	stats, _ = e.resyncAllWithOptionsLocked(
+		ctx, onProgress, RebuildOptions{}, productionRebuildOperations,
+	)
+	// Preserve the legacy result shape; phase diagnostics are part of the
+	// options entrypoint's observable contract only.
+	stats.RebuildPhases = nil
+	e.mu.Lock()
+	e.lastSyncStats = stats
+	e.mu.Unlock()
+	return stats
+}
+
+// ResyncAllWithOptions atomically rebuilds the archive from the local sources
+// plus each configured contributor.
+func (e *Engine) ResyncAllWithOptions(
+	ctx context.Context, onProgress ProgressFunc, opts RebuildOptions,
+) (stats SyncStats, err error) {
+	return e.resyncAllWithOptionsAndOperations(
+		ctx, onProgress, opts, productionRebuildOperations,
+	)
+}
+
+func (e *Engine) resyncAllWithOptionsAndOperations(
+	ctx context.Context, onProgress ProgressFunc, opts RebuildOptions,
+	ops rebuildOperations,
+) (stats SyncStats, err error) {
+	if e.refuseWriteInForceParse("ResyncAllWithOptions") {
+		return SyncStats{}, nil
+	}
+	e.syncMu.Lock()
+	defer func() {
+		if stats.Synced > 0 && !stats.Aborted {
+			e.emit("sync")
+		}
+	}()
+	defer e.syncMu.Unlock()
+	defer e.clearCurrentProgress()
+	opts.includePhaseDiagnostics = true
+	return e.resyncAllWithOptionsLocked(
+		ctx, onProgress, opts, ops,
+	)
+}
+
+func (e *Engine) resyncAllWithOptionsLocked(
+	ctx context.Context, onProgress ProgressFunc, opts RebuildOptions,
+	ops rebuildOperations,
+) (stats SyncStats, retErr error) {
+	ops = ops.withDefaults()
 	reportResyncProgress := func(p Progress) {
 		p.Resync = true
 		if p.Phase == PhaseSyncing && p.Detail == "" {
@@ -1312,7 +1360,7 @@ func (e *Engine) resyncAllLocked(
 		e.mu.Lock()
 		e.lastSyncStats = stats
 		e.mu.Unlock()
-		return
+		return stats, err
 	}
 	if err := newDB.CopyArchiveIdentityFrom(origPath); err != nil {
 		log.Printf("resync: preserve archive identity: %v", err)
@@ -1378,7 +1426,7 @@ func (e *Engine) resyncAllLocked(
 			e.mu.Lock()
 			e.lastSyncStats = stats
 			e.mu.Unlock()
-			return
+			return stats, err
 		}
 		ftsDropped = true
 		log.Printf(
@@ -1405,6 +1453,93 @@ func (e *Engine) resyncAllLocked(
 	e.db = origDB // restore immediately
 	e.openCodeArchiveStore = nil
 	e.phaseStats.Log("resync")
+	if opts.includePhaseDiagnostics {
+		stats.RebuildPhases = append(stats.RebuildPhases,
+			phaseSnapshot("local", &e.phaseStats))
+	}
+	if stats.Aborted || ctx.Err() != nil {
+		newDB.Close()
+		removeTempDB(tempPath)
+		restoreSkipCache()
+		stats.Aborted = true
+		stats.Warnings = append(stats.Warnings, fmt.Sprintf(
+			"resync aborted: %d synced, %d failed",
+			stats.Synced, stats.Failed,
+		))
+		e.mu.Lock()
+		e.lastSyncStats = stats
+		e.mu.Unlock()
+		if err := ctx.Err(); err != nil {
+			return stats, err
+		}
+		return stats, nil
+	}
+
+	for _, contributor := range opts.Contributors {
+		contributorEngine := NewEngine(newDB, contributor.Config)
+		contributorEngine.openCodeArchiveStore = origDB
+		contributorProgress := func(p Progress) {
+			if contributor.Progress != nil {
+				p = contributor.Progress(p)
+			}
+			p.SessionsDone += stats.TotalSessions
+			p.SessionsTotal += stats.TotalSessions
+			p.MessagesIndexed += stats.messagesIndexed
+			reportResyncProgress(p)
+		}
+		contributorStats := contributorEngine.syncAllLocked(
+			ctx, contributorProgress, time.Time{}, nil,
+			syncWriteBulk, true, false,
+		)
+		contributorEngine.phaseStats.Log("resync contributor " + contributor.Name)
+		phase := phaseSnapshot(contributor.Name, &contributorEngine.phaseStats)
+		mergeSyncStats(&stats, contributorStats)
+		if opts.includePhaseDiagnostics {
+			stats.RebuildPhases = append(stats.RebuildPhases, phase)
+		}
+		if contributorStats.Aborted || stats.Aborted || ctx.Err() != nil {
+			contributorEngine.Close()
+			newDB.Close()
+			removeTempDB(tempPath)
+			restoreSkipCache()
+			stats.Aborted = true
+			stats.Warnings = append(stats.Warnings, fmt.Sprintf(
+				"resync aborted: contributor %q did not complete",
+				contributor.Name,
+			))
+			e.mu.Lock()
+			e.lastSyncStats = stats
+			e.mu.Unlock()
+			if err := ctx.Err(); err != nil {
+				return stats, err
+			}
+			return stats, nil
+		}
+		if contributor.AfterSync != nil {
+			if err := contributor.AfterSync(contributorEngine, newDB); err != nil {
+				contributorEngine.Close()
+				newDB.Close()
+				removeTempDB(tempPath)
+				restoreSkipCache()
+				if reopenErr := origDB.Reopen(); reopenErr != nil {
+					log.Printf("resync: contributor failure recovery reopen: %v", reopenErr)
+				}
+				stats.Aborted = true
+				stats.Warnings = append(stats.Warnings, fmt.Sprintf(
+					"resync contributor %q failed: %v",
+					contributor.Name, err,
+				))
+				e.mu.Lock()
+				e.lastSyncStats = stats
+				e.mu.Unlock()
+				return stats, &RebuildContributorError{
+					Contributor: contributor.Name,
+					Err:         err,
+				}
+			}
+		}
+		contributorEngine.Close()
+	}
 
 	abortSwap := shouldAbortResyncSwap(stats, oldFileSessions, trashedCopied)
 	if abortSwap {
@@ -1424,7 +1559,10 @@ func (e *Engine) resyncAllLocked(
 		e.mu.Lock()
 		e.lastSyncStats = stats
 		e.mu.Unlock()
-		return stats
+		if err := ctx.Err(); err != nil {
+			return stats, err
+		}
+		return stats, nil
 	}
 
 	// 4. Close origDB connections first to quiesce writes,
@@ -1453,7 +1591,7 @@ func (e *Engine) resyncAllLocked(
 		e.mu.Lock()
 		e.lastSyncStats = stats
 		e.mu.Unlock()
-		return stats
+		return stats, err
 	}
 
 	// Re-copy excluded session IDs now that origDB is quiesced.
@@ -1487,7 +1625,7 @@ func (e *Engine) resyncAllLocked(
 		e.mu.Lock()
 		e.lastSyncStats = stats
 		e.mu.Unlock()
-		return stats
+		return stats, err
 	}
 
 	// Copy insights into newDB from the quiesced old DB file.
@@ -1513,7 +1651,7 @@ func (e *Engine) resyncAllLocked(
 		e.mu.Lock()
 		e.lastSyncStats = stats
 		e.mu.Unlock()
-		return stats
+		return stats, err
 	}
 	log.Printf(
 		"resync: copy insights: %s",
@@ -1564,7 +1702,7 @@ func (e *Engine) resyncAllLocked(
 		e.mu.Lock()
 		e.lastSyncStats = stats
 		e.mu.Unlock()
-		return stats
+		return stats, err
 	}
 	stats.OrphanedCopied = orphaned
 
@@ -1601,7 +1739,7 @@ func (e *Engine) resyncAllLocked(
 		e.mu.Lock()
 		e.lastSyncStats = stats
 		e.mu.Unlock()
-		return stats
+		return stats, err
 	}
 
 	// Merge user-managed data and immutable project-identity snapshots from the
@@ -1629,7 +1767,7 @@ func (e *Engine) resyncAllLocked(
 		e.mu.Lock()
 		e.lastSyncStats = stats
 		e.mu.Unlock()
-		return stats
+		return stats, err
 	}
 	if _, err := newDB.ApplyWorktreeProjectMappingsFromSync(
 		context.Background(), e.machine,
@@ -1660,7 +1798,7 @@ func (e *Engine) resyncAllLocked(
 			"Rebuilding search index",
 			"Rebuilding the search index may take a while on large archives.",
 		)
-		if err := newDB.RebuildFTS(); err != nil {
+		if err := ops.rebuildFTS(newDB); err != nil {
 			log.Printf("resync: rebuild fts: %v", err)
 			stats.Aborted = true
 			stats.Warnings = append(stats.Warnings,
@@ -1676,7 +1814,7 @@ func (e *Engine) resyncAllLocked(
 			e.mu.Lock()
 			e.lastSyncStats = stats
 			e.mu.Unlock()
-			return stats
+			return stats, err
 		}
 		log.Printf(
 			"resync: rebuild fts: %s",
@@ -1709,15 +1847,21 @@ func (e *Engine) resyncAllLocked(
 		e.mu.Lock()
 		e.lastSyncStats = stats
 		e.mu.Unlock()
-		return stats
+		return stats, err
 	}
 	removeWAL(tempPath)
 
-	if err := origDB.Reopen(); err != nil {
+	if err := ops.reopen(origDB); err != nil {
 		log.Printf("resync: reopen db: %v", err)
+		stats.Aborted = true
 		stats.Warnings = append(stats.Warnings,
-			"reopen after resync failed: "+err.Error(),
+			"resync swap completed but reopening active database failed: "+
+				err.Error(),
 		)
+		e.mu.Lock()
+		e.lastSyncStats = stats
+		e.mu.Unlock()
+		return stats, err
 	} else {
 		origDB.MarkDataCurrent()
 		if err := origDB.CheckpointWALTruncateWithRetry(ctx); err != nil {
@@ -1857,6 +2001,96 @@ func (e *Engine) syncThenRunLocked(
 	// pushed sessions could carry stale signal/secret fields.
 	e.signalSched.flushAllInline()
 	if err := work(full || didResync); err != nil {
+		return stats, err
+	}
+	return stats, nil
+}
+
+// RebuildCleanup owns resources prepared for a multi-source rebuild. Close
+// may be retried when it fails so callers can retain mirror locks and temporary
+// roots instead of silently losing cleanup ownership.
+type RebuildCleanup interface {
+	Close() error
+}
+
+type rebuildCleanupError struct {
+	owner RebuildCleanup
+	err   error
+}
+
+func (e *rebuildCleanupError) Error() string { return e.err.Error() }
+func (e *rebuildCleanupError) Unwrap() error { return e.err }
+func (e *rebuildCleanupError) RetryCleanup() error {
+	return e.owner.Close()
+}
+
+// SyncThenRunWithRebuild coordinates local sync, optional contributor
+// preparation, an atomic multi-source rebuild, and post-rebuild work under the
+// engine's exclusive sync lock. Preparation only runs when a rebuild is
+// required, and work never runs after a failed or aborted rebuild.
+func (e *Engine) SyncThenRunWithRebuild(
+	ctx context.Context,
+	full bool,
+	onProgress ProgressFunc,
+	prepare func() (RebuildOptions, RebuildCleanup, error),
+	work func(forceFull, rebuilt bool) error,
+) (stats SyncStats, retErr error) {
+	if e.refuseWriteInForceParse("SyncThenRunWithRebuild") {
+		return SyncStats{}, nil
+	}
+	e.syncMu.Lock()
+	defer func() {
+		if stats.Synced > 0 && !stats.Aborted {
+			e.emit("sync")
+		}
+	}()
+	defer e.syncMu.Unlock()
+	defer func() {
+		if retErr == nil && !stats.Aborted {
+			// Match SyncThenRun: successful foreground coordination unblocks
+			// startup backfills while syncMu is still held.
+			e.ReleaseStartupMaintenance()
+		}
+	}()
+	defer e.clearCurrentProgress()
+
+	didResync := full || e.db.NeedsResync()
+	if didResync {
+		opts, cleanup, err := prepare()
+		if cleanup != nil {
+			defer func() {
+				if err := cleanup.Close(); err != nil {
+					retErr = errors.Join(retErr, &rebuildCleanupError{
+						owner: cleanup,
+						err:   err,
+					})
+				}
+			}()
+		}
+		if err != nil {
+			return SyncStats{}, err
+		}
+		opts.includePhaseDiagnostics = true
+		stats, err = e.resyncAllWithOptionsLocked(
+			ctx, onProgress, opts, productionRebuildOperations,
+		)
+		if err != nil {
+			return stats, err
+		}
+		if stats.Aborted {
+			return stats, nil
+		}
+	} else {
+		stats = e.syncAllLocked(
+			ctx, onProgress, time.Time{}, nil,
+			syncWriteDefault, true, false,
+		)
+	}
+	if err := ctx.Err(); err != nil {
+		return stats, err
+	}
+	e.signalSched.flushAllInline()
+	if err := work(full || didResync, didResync); err != nil {
 		return stats, err
 	}
 	return stats, nil
@@ -4676,17 +4910,16 @@ func providerProcessCacheKeyWithHash(
 
 func providerFingerprintHashInCacheKey(agent parser.AgentType) bool {
 	switch agent {
-	case parser.AgentDevin, parser.AgentQoder, parser.AgentWindsurf:
+	case parser.AgentClaude, parser.AgentCodex, parser.AgentDevin, parser.AgentQoder, parser.AgentWindsurf:
 		return true
 	default:
 		return false
 	}
 }
 
-// providerFingerprintHashRequiredForFreshness is deliberately broader than
-// providerFingerprintHashInCacheKey. Codex hashes every transcript to verify a
-// same-stat rewrite against the persisted row, but retaining one skip-cache key
-// per content version would make the cache grow with a hot append-only file.
+// providerFingerprintHashRequiredForFreshness also protects stored rows. Hash
+// cache keys protect rowless parser exclusions and failures; cacheSkip removes
+// older hash siblings so hot append-only files retain only one content version.
 func providerFingerprintHashRequiredForFreshness(agent parser.AgentType) bool {
 	switch agent {
 	case parser.AgentClaude, parser.AgentCodex, parser.AgentDevin, parser.AgentQoder, parser.AgentWindsurf:
@@ -4712,14 +4945,16 @@ func (e *Engine) providerSkipCacheEntryFreshInDB(
 	if e.pathRewriter != nil {
 		lookupPath = e.pathRewriter(lookupPath)
 	}
-	if agent == parser.AgentCodex {
+	if agent == parser.AgentClaude || agent == parser.AgentCodex {
 		storedIDs, err := e.db.ListSessionIDsByFilePath(
-			lookupPath, string(parser.AgentCodex),
+			lookupPath, string(agent),
 		)
 		if err == nil && len(storedIDs) == 0 {
-			// A cached parse failure has no persisted source row or hash to
-			// compare. Retain its retry suppression until a source signal changes;
-			// hash validation applies once a session has actually been stored.
+			// A cached parse failure or intentionally ignored source has no
+			// persisted row or hash to compare. Retry suppression is therefore
+			// mtime/source-signal based until a row exists: a same-mtime rewrite
+			// cannot be distinguished in this no-row state. Hash validation applies
+			// once a session has actually been stored.
 			return true
 		}
 	}
@@ -4886,6 +5121,7 @@ func (e *Engine) shouldCacheSkip(
 // its mtime changes.
 func (e *Engine) cacheSkip(path string, mtime int64, sourceFingerprint ...string) {
 	e.skipMu.Lock()
+	e.removeSkipHashSiblingsLocked(path)
 	e.skipCache[path] = mtime
 	fingerprint := ""
 	if len(sourceFingerprint) > 0 {
@@ -4906,10 +5142,28 @@ func (e *Engine) cacheSkip(path string, mtime int64, sourceFingerprint ...string
 // produces a valid session.
 func (e *Engine) clearSkip(path string) {
 	e.skipMu.Lock()
+	e.removeSkipHashSiblingsLocked(path)
 	delete(e.skipCache, path)
 	delete(e.skipFingerprints, path)
 	e.skipMu.Unlock()
 	_ = e.db.DeleteSkippedFile(path)
+}
+
+func (e *Engine) removeSkipHashSiblingsLocked(path string) {
+	const marker = "?source_hash="
+	base, _, hasHash := strings.Cut(path, marker)
+	if !hasHash {
+		return
+	}
+	prefix := base + marker
+	delete(e.skipCache, base)
+	delete(e.skipFingerprints, base)
+	for cached := range e.skipCache {
+		if cached != path && strings.HasPrefix(cached, prefix) {
+			delete(e.skipCache, cached)
+			delete(e.skipFingerprints, cached)
+		}
+	}
 }
 
 // clearWatcherOverflowCaches invalidates every freshness shortcut whose

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1306,6 +1306,7 @@ func (e *Engine) resyncAllWithOptionsLocked(
 		oldFileSessions = 1
 	}
 	localOldFileSessions := oldFileSessions
+	rebuildOldFileSessions := oldFileSessions
 	contributorOldFileSessions := make([]int, len(opts.Contributors))
 	if len(opts.Contributors) > 0 {
 		localOldFileSessions, err = e.protectedFileSessionCount(
@@ -1315,6 +1316,7 @@ func (e *Engine) resyncAllWithOptionsLocked(
 			log.Printf("resync: get old local file count: %v", err)
 			localOldFileSessions = 1
 		}
+		rebuildOldFileSessions = localOldFileSessions
 		for i, contributor := range opts.Contributors {
 			count, countErr := e.protectedFileSessionCount(
 				origDB, contributor.Config.Machine,
@@ -1328,6 +1330,7 @@ func (e *Engine) resyncAllWithOptionsLocked(
 				count = 1
 			}
 			contributorOldFileSessions[i] = count
+			rebuildOldFileSessions += count
 		}
 	}
 
@@ -1565,7 +1568,7 @@ func (e *Engine) resyncAllWithOptionsLocked(
 		)
 	}
 	abortSwap := localSafetyAbort ||
-		shouldAbortResyncSwap(stats, oldFileSessions, trashedCopied)
+		shouldAbortResyncSwap(stats, rebuildOldFileSessions, trashedCopied)
 	if abortSwap {
 		log.Printf(
 			"resync: aborting swap, %d synced / %d failed / %d total",

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1300,27 +1300,34 @@ func (e *Engine) resyncAllWithOptionsLocked(
 	// between storage and SQLite sources across resyncs. Fail closed:
 	// if we can't query, assume old DB has file-backed data
 	// worth protecting.
-	oldFileSessions, err := origDB.FileBackedSessionCount(
-		context.Background(),
-	)
+	oldFileSessions, err := e.protectedFileSessionCount(origDB, "", false)
 	if err != nil {
 		log.Printf("resync: get old file count: %v", err)
 		oldFileSessions = 1
-	} else {
-		oldFileSessions -= e.countRootOpenCodeFormatSessions(
-			origDB, parser.AgentOpenCode,
+	}
+	localOldFileSessions := oldFileSessions
+	contributorOldFileSessions := make([]int, len(opts.Contributors))
+	if len(opts.Contributors) > 0 {
+		localOldFileSessions, err = e.protectedFileSessionCount(
+			origDB, e.machine, e.machine != "",
 		)
-		oldFileSessions -= e.countRootOpenCodeFormatSessions(
-			origDB, parser.AgentKilo,
-		)
-		oldFileSessions -= e.countRootOpenCodeFormatSessions(
-			origDB, parser.AgentMiMoCode,
-		)
-		oldFileSessions -= e.countRootOpenCodeFormatSessions(
-			origDB, parser.AgentIcodemate,
-		)
-		if oldFileSessions < 0 {
-			oldFileSessions = 0
+		if err != nil {
+			log.Printf("resync: get old local file count: %v", err)
+			localOldFileSessions = 1
+		}
+		for i, contributor := range opts.Contributors {
+			count, countErr := e.protectedFileSessionCount(
+				origDB, contributor.Config.Machine,
+				contributor.Config.Machine != "",
+			)
+			if countErr != nil {
+				log.Printf(
+					"resync: get old contributor %q file count: %v",
+					contributor.Name, countErr,
+				)
+				count = 1
+			}
+			contributorOldFileSessions[i] = count
 		}
 	}
 
@@ -1457,6 +1464,7 @@ func (e *Engine) resyncAllWithOptionsLocked(
 		stats.RebuildPhases = append(stats.RebuildPhases,
 			phaseSnapshot("local", &e.phaseStats))
 	}
+	localStats := stats
 	if stats.Aborted || ctx.Err() != nil {
 		newDB.Close()
 		removeTempDB(tempPath)
@@ -1475,7 +1483,7 @@ func (e *Engine) resyncAllWithOptionsLocked(
 		return stats, nil
 	}
 
-	for _, contributor := range opts.Contributors {
+	for contributorIndex, contributor := range opts.Contributors {
 		contributorEngine := NewEngine(newDB, contributor.Config)
 		contributorEngine.openCodeArchiveStore = origDB
 		contributorProgress := func(p Progress) {
@@ -1493,11 +1501,17 @@ func (e *Engine) resyncAllWithOptionsLocked(
 		)
 		contributorEngine.phaseStats.Log("resync contributor " + contributor.Name)
 		phase := phaseSnapshot(contributor.Name, &contributorEngine.phaseStats)
+		contributorSafetyAbort := shouldAbortResyncSwap(
+			contributorStats,
+			contributorOldFileSessions[contributorIndex],
+			0,
+		)
 		mergeSyncStats(&stats, contributorStats)
 		if opts.includePhaseDiagnostics {
 			stats.RebuildPhases = append(stats.RebuildPhases, phase)
 		}
-		if contributorStats.Aborted || stats.Aborted || ctx.Err() != nil {
+		if contributorStats.Aborted || stats.Aborted || ctx.Err() != nil ||
+			contributorSafetyAbort {
 			contributorEngine.Close()
 			newDB.Close()
 			removeTempDB(tempPath)
@@ -1541,7 +1555,17 @@ func (e *Engine) resyncAllWithOptionsLocked(
 		contributorEngine.Close()
 	}
 
-	abortSwap := shouldAbortResyncSwap(stats, oldFileSessions, trashedCopied)
+	localSafetyAbort := false
+	if len(opts.Contributors) > 0 {
+		// Evaluate local safety after contributors so a contributor's own
+		// cancellation or failure remains the reported abort reason. Trash
+		// copied from the old archive cannot make an empty local pass safe.
+		localSafetyAbort = shouldAbortResyncSwap(
+			localStats, localOldFileSessions, 0,
+		)
+	}
+	abortSwap := localSafetyAbort ||
+		shouldAbortResyncSwap(stats, oldFileSessions, trashedCopied)
 	if abortSwap {
 		log.Printf(
 			"resync: aborting swap, %d synced / %d failed / %d total",
@@ -1899,10 +1923,16 @@ func removeWAL(path string) {
 }
 
 func (e *Engine) countRootOpenCodeFormatSessions(
-	database *db.DB, agent parser.AgentType,
+	database *db.DB, agent parser.AgentType, machine string, scoped bool,
 ) int {
 	if !isOpenCodeFormatStorageAgent(agent) {
 		return 0
+	}
+	machinePredicate := ""
+	args := []any{string(agent)}
+	if scoped {
+		machinePredicate = " AND machine = ?"
+		args = append(args, machine)
 	}
 	var count int
 	err := database.Reader().QueryRow(`
@@ -1911,11 +1941,42 @@ func (e *Engine) countRootOpenCodeFormatSessions(
 		  AND message_count > 0
 		  AND relationship_type NOT IN ('subagent', 'fork')
 		  AND deleted_at IS NULL
-	`, string(agent)).Scan(&count)
+	`+machinePredicate, args...).Scan(&count)
 	if err != nil {
 		log.Printf("count root %s sessions: %v", agent, err)
 	}
 	return count
+}
+
+func (e *Engine) protectedFileSessionCount(
+	database *db.DB, machine string, scoped bool,
+) (int, error) {
+	var count int
+	var err error
+	if scoped {
+		count, err = database.FileBackedSessionCountForMachine(
+			context.Background(), machine,
+		)
+	} else {
+		count, err = database.FileBackedSessionCount(context.Background())
+	}
+	if err != nil {
+		return 0, err
+	}
+	for _, agent := range []parser.AgentType{
+		parser.AgentOpenCode,
+		parser.AgentKilo,
+		parser.AgentMiMoCode,
+		parser.AgentIcodemate,
+	} {
+		count -= e.countRootOpenCodeFormatSessions(
+			database, agent, machine, scoped,
+		)
+	}
+	if count < 0 {
+		count = 0
+	}
+	return count, nil
 }
 
 // Sync state keys persisted in pg_sync_state.

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -116,9 +116,13 @@ type Engine struct {
 	// non-interactive sessions (nil result). The file is
 	// retried when its mtime changes. S3 entries also keep an
 	// in-memory source fingerprint when one is available.
-	skipMu            gosync.RWMutex
-	skipCache         map[string]int64
-	skipFingerprints  map[string]string
+	skipMu           gosync.RWMutex
+	skipCache        map[string]int64
+	skipFingerprints map[string]string
+	// skipHashKeys maps a source base path to its one current
+	// ?source_hash= cache key. It is built once when the cache loads so a
+	// watcher mutation never scans unrelated archive entries.
+	skipHashKeys      map[string]string
 	s3CodexIndexMu    gosync.Mutex
 	s3CodexIndexCache map[string]s3CodexIndexSnapshot
 	// idPrefix and pathRewriter support remote sync:
@@ -257,6 +261,7 @@ func NewEngine(
 		migrateLegacyCodexExecSkips(database, skipCache)
 		migrateVisualStudioCopilotSkips(database, skipCache)
 	}
+	skipHashKeys, _ := normalizeSourceHashSkipCache(skipCache, nil)
 
 	dirs := make(map[parser.AgentType][]string, len(cfg.AgentDirs))
 	for k, v := range cfg.AgentDirs {
@@ -279,6 +284,7 @@ func NewEngine(
 		cwdFilter:               newCwdPrefixFilter(cfg.IncludeCwdPrefixes),
 		skipCache:               skipCache,
 		skipFingerprints:        make(map[string]string),
+		skipHashKeys:            skipHashKeys,
 		s3CodexIndexCache:       make(map[string]s3CodexIndexSnapshot),
 		ephemeral:               cfg.Ephemeral,
 		idPrefix:                cfg.IDPrefix,
@@ -1342,12 +1348,15 @@ func (e *Engine) resyncAllWithOptionsLocked(
 	// matches the persisted DB until the next restart.
 	e.skipMu.Lock()
 	savedSkipCache := e.skipCache
+	savedSkipHashKeys := e.skipHashKeys
 	e.skipCache = make(map[string]int64)
+	e.skipHashKeys = make(map[string]string)
 	e.skipMu.Unlock()
 
 	restoreSkipCache := func() {
 		e.skipMu.Lock()
 		e.skipCache = savedSkipCache
+		e.skipHashKeys = savedSkipHashKeys
 		e.skipMu.Unlock()
 	}
 
@@ -5181,12 +5190,64 @@ func (e *Engine) shouldCacheSkip(
 	return true
 }
 
-// cacheSkip records a file so it won't be retried until
-// its mtime changes.
-func (e *Engine) cacheSkip(path string, mtime int64, sourceFingerprint ...string) {
+const sourceHashSkipMarker = "?source_hash="
+
+// normalizeSourceHashSkipCache performs the one archive-sized pass needed to
+// repair legacy duplicate source-hash entries and build the watcher-time
+// sibling index. A family with multiple hashed keys is ambiguous: same-mtime
+// rewrites are why the hash exists, so no stored key can safely be called
+// current. Drop that family so the source reparses once and establishes a
+// trustworthy key.
+func normalizeSourceHashSkipCache(
+	cache map[string]int64, fingerprints map[string]string,
+) (map[string]string, map[string]struct{}) {
+	index := make(map[string]string)
+	counts := make(map[string]int)
+	ambiguous := make(map[string]struct{})
+	for path := range cache {
+		base, _, hashed := strings.Cut(path, sourceHashSkipMarker)
+		if !hashed {
+			continue
+		}
+		counts[base]++
+		if counts[base] == 1 {
+			index[base] = path
+		}
+	}
+	for path := range cache {
+		base, _, hashed := strings.Cut(path, sourceHashSkipMarker)
+		if hashed && counts[base] > 1 {
+			delete(cache, path)
+			ambiguous[base] = struct{}{}
+			if fingerprints != nil {
+				delete(fingerprints, path)
+			}
+		}
+	}
+	for base := range index {
+		delete(cache, base)
+		if fingerprints != nil {
+			delete(fingerprints, base)
+		}
+		if counts[base] > 1 {
+			delete(index, base)
+		}
+	}
+	return index, ambiguous
+}
+
+// cacheSkip records a file so it won't be retried until its mtime changes.
+// The returned work count measures sibling-index probes and is used by the
+// cardinality regression to keep watcher-time work independent of cache size.
+func (e *Engine) cacheSkip(
+	path string, mtime int64, sourceFingerprint ...string,
+) int {
 	e.skipMu.Lock()
-	e.removeSkipHashSiblingsLocked(path)
+	work := e.removeSkipHashSiblingsLocked(path)
 	e.skipCache[path] = mtime
+	if base, _, hashed := strings.Cut(path, sourceHashSkipMarker); hashed {
+		e.skipHashKeys[base] = path
+	}
 	fingerprint := ""
 	if len(sourceFingerprint) > 0 {
 		fingerprint = sourceFingerprint[0]
@@ -5200,34 +5261,44 @@ func (e *Engine) cacheSkip(path string, mtime int64, sourceFingerprint ...string
 		delete(e.skipFingerprints, path)
 	}
 	e.skipMu.Unlock()
+	return work
 }
 
-// clearSkip removes a skip-cache entry when a file
-// produces a valid session.
-func (e *Engine) clearSkip(path string) {
+// clearSkip removes a skip-cache entry when a file produces a valid session.
+// Its work count has the same cardinality-regression role as cacheSkip's.
+func (e *Engine) clearSkip(path string) int {
 	e.skipMu.Lock()
-	e.removeSkipHashSiblingsLocked(path)
+	work := e.removeSkipHashSiblingsLocked(path)
 	delete(e.skipCache, path)
 	delete(e.skipFingerprints, path)
 	e.skipMu.Unlock()
 	_ = e.db.DeleteSkippedFile(path)
+	return work
 }
 
-func (e *Engine) removeSkipHashSiblingsLocked(path string) {
-	const marker = "?source_hash="
-	base, _, hasHash := strings.Cut(path, marker)
-	if !hasHash {
-		return
+func (e *Engine) removeSkipHashSiblingsLocked(path string) int {
+	if e.skipHashKeys == nil {
+		e.skipHashKeys, _ = normalizeSourceHashSkipCache(
+			e.skipCache, e.skipFingerprints,
+		)
 	}
-	prefix := base + marker
+	base, _, hasHash := strings.Cut(path, sourceHashSkipMarker)
+	if !hasHash {
+		if sibling, ok := e.skipHashKeys[path]; ok {
+			delete(e.skipCache, sibling)
+			delete(e.skipFingerprints, sibling)
+			delete(e.skipHashKeys, path)
+		}
+		return 1
+	}
 	delete(e.skipCache, base)
 	delete(e.skipFingerprints, base)
-	for cached := range e.skipCache {
-		if cached != path && strings.HasPrefix(cached, prefix) {
-			delete(e.skipCache, cached)
-			delete(e.skipFingerprints, cached)
-		}
+	if sibling, ok := e.skipHashKeys[base]; ok {
+		delete(e.skipCache, sibling)
+		delete(e.skipFingerprints, sibling)
+		delete(e.skipHashKeys, base)
 	}
+	return 2
 }
 
 // clearWatcherOverflowCaches invalidates every freshness shortcut whose
@@ -5237,6 +5308,7 @@ func (e *Engine) clearWatcherOverflowCaches() {
 	e.skipMu.Lock()
 	e.skipCache = make(map[string]int64)
 	e.skipFingerprints = make(map[string]string)
+	e.skipHashKeys = make(map[string]string)
 	e.skipMu.Unlock()
 	if !e.ephemeral {
 		if err := e.db.ReplaceSkippedFiles(map[string]int64{}); err != nil {
@@ -5255,7 +5327,24 @@ func (e *Engine) clearWatcherOverflowCaches() {
 func (e *Engine) InjectSkipCache(entries map[string]int64) {
 	e.skipMu.Lock()
 	defer e.skipMu.Unlock()
-	maps.Copy(e.skipCache, entries)
+	if e.skipHashKeys == nil {
+		e.skipHashKeys, _ = normalizeSourceHashSkipCache(
+			e.skipCache, e.skipFingerprints,
+		)
+	}
+	incoming := make(map[string]int64, len(entries))
+	maps.Copy(incoming, entries)
+	_, ambiguous := normalizeSourceHashSkipCache(incoming, nil)
+	for base := range ambiguous {
+		e.removeSkipHashSiblingsLocked(base + sourceHashSkipMarker)
+	}
+	for path, mtime := range incoming {
+		e.removeSkipHashSiblingsLocked(path)
+		e.skipCache[path] = mtime
+		if base, _, hashed := strings.Cut(path, sourceHashSkipMarker); hashed {
+			e.skipHashKeys[base] = path
+		}
+	}
 }
 
 // SnapshotSkipCache returns a copy of the in-memory skip

--- a/internal/sync/engine_bench_test.go
+++ b/internal/sync/engine_bench_test.go
@@ -379,3 +379,50 @@ func BenchmarkResyncBulkIngest(b *testing.B) {
 		},
 	)
 }
+
+// BenchmarkResyncBulkContributorIngest measures the same cold archive shape
+// when it enters the atomic rebuild through a contributor engine.
+func BenchmarkResyncBulkContributorIngest(b *testing.B) {
+	ctx := context.Background()
+	benchColdArchive(b,
+		func(engine *Engine) SyncStats {
+			dir := engine.agentDirs[parser.AgentClaude][0]
+			engine.agentDirs = nil
+			stats, err := engine.ResyncAllWithOptions(ctx, nil, RebuildOptions{
+				Contributors: []RebuildContributor{{
+					Name: "benchmark-contributor",
+					Config: EngineConfig{
+						AgentDirs: map[parser.AgentType][]string{
+							parser.AgentClaude: {dir},
+						},
+						Machine:   "benchmark-contributor",
+						IDPrefix:  "benchmark~",
+						Ephemeral: true,
+					},
+				}},
+			})
+			if err != nil {
+				b.Fatalf("contributor rebuild: %v", err)
+			}
+			return stats
+		},
+		func(_ *Engine, stats SyncStats, sessions int) {
+			if stats.Synced != sessions {
+				b.Fatalf(
+					"contributor ingest stored %d of %d sessions (failed=%d)",
+					stats.Synced, sessions, stats.Failed,
+				)
+			}
+			if len(stats.RebuildPhases) != 2 {
+				b.Fatalf("contributor ingest recorded %d rebuild phases", len(stats.RebuildPhases))
+			}
+			writes := stats.RebuildPhases[1].BatchedWrites
+			if writes != int64(sessions) {
+				b.Fatalf(
+					"contributor ingest wrote %d of %d sessions via the batch pipeline",
+					writes, sessions,
+				)
+			}
+		},
+	)
+}

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -2062,6 +2063,173 @@ func TestResyncAllAppliesWorktreeProjectMappingDuringBulkWrites(
 	)
 }
 
+func TestResyncAllWithOptionsIngestsContributors(t *testing.T) {
+	localRoot := t.TempDir()
+	remoteRoot := t.TempDir()
+	env := setupSingleAgentTestEnvWithDirs(t, parser.AgentClaude, []string{localRoot})
+
+	localPath := filepath.Join(localRoot, "project-local", "local-session.jsonl")
+	remotePath := filepath.Join(remoteRoot, "project-remote", "remote-session.jsonl")
+	dbtest.WriteTestFile(t, localPath, []byte(testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsZero, "local rebuild message").String()))
+	dbtest.WriteTestFile(t, remotePath, []byte(testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarlyS1, "remote rebuild message").String()))
+	olderPath := filepath.Join(localRoot, "archived", "older-active.jsonl")
+	dbtest.WriteTestFile(t, olderPath, []byte(testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, "older active archive message").String()))
+	require.Equal(t, 2, env.engine.SyncAll(context.Background(), nil).Synced)
+	require.NoError(t, os.Remove(olderPath))
+	observedBeforeSwap := false
+
+	stats, err := env.engine.ResyncAllWithOptions(
+		context.Background(), nil, sync.RebuildOptions{Contributors: []sync.RebuildContributor{{
+			Name: "remote-host",
+			Config: sync.EngineConfig{
+				AgentDirs:    map[parser.AgentType][]string{parser.AgentClaude: {remoteRoot}},
+				Machine:      "remote-host",
+				IDPrefix:     "remote~",
+				PathRewriter: func(path string) string { return "remote:" + path },
+				Ephemeral:    true,
+			},
+			AfterSync: func(_ *sync.Engine, tempDB *db.DB) error {
+				observedBeforeSwap = true
+				assert.NotEqual(t, env.db.Path(), tempDB.Path())
+				assert.Equal(t, env.db.Path()+"-resync", tempDB.Path())
+
+				older, getErr := env.db.GetSession(context.Background(), "older-active")
+				require.NoError(t, getErr)
+				require.NotNil(t, older, "active archive lost old row before swap")
+				assertMessageContent(t, env.db, "older-active", "older active archive message")
+				page, searchErr := env.db.Search(context.Background(), db.SearchFilter{
+					Query: "older active archive message", Limit: 5,
+				})
+				require.NoError(t, searchErr)
+				require.Len(t, page.Results, 1, "active search changed before swap")
+				remote, getErr := env.db.GetSession(context.Background(), "remote~remote-session")
+				require.NoError(t, getErr)
+				assert.Nil(t, remote, "contributor row reached active DB before swap")
+
+				remote, getErr = tempDB.GetSession(context.Background(), "remote~remote-session")
+				require.NoError(t, getErr)
+				require.NotNil(t, remote, "contributor row missing from temporary DB")
+				older, getErr = tempDB.GetSession(context.Background(), "older-active")
+				require.NoError(t, getErr)
+				assert.Nil(t, older, "orphan copy ran before contributor callback")
+				return nil
+			},
+		}}},
+	)
+	require.NoError(t, err)
+	require.True(t, observedBeforeSwap)
+	require.False(t, stats.Aborted, "resync aborted: %+v", stats)
+	assert.Equal(t, 2, stats.Synced)
+	assert.Equal(t, 1, stats.OrphanedCopied)
+
+	local, err := env.db.GetSession(context.Background(), "local-session")
+	require.NoError(t, err)
+	require.NotNil(t, local)
+	assert.Equal(t, "local", local.Machine)
+	remote, err := env.db.GetSession(context.Background(), "remote~remote-session")
+	require.NoError(t, err)
+	require.NotNil(t, remote)
+	assert.Equal(t, "remote-host", remote.Machine)
+	assert.Equal(t, "remote:"+remotePath, env.db.GetSessionFilePath(remote.ID))
+	older, err := env.db.GetSession(context.Background(), "older-active")
+	require.NoError(t, err)
+	require.NotNil(t, older)
+
+	for _, query := range []string{"local rebuild message", "remote rebuild message"} {
+		page, searchErr := env.db.Search(context.Background(), db.SearchFilter{Query: query, Limit: 5})
+		require.NoError(t, searchErr)
+		assert.Len(t, page.Results, 1, query)
+	}
+	require.Len(t, stats.RebuildPhases, 2)
+	require.Len(t, env.engine.LastSyncStats().RebuildPhases, 2)
+	assert.Equal(t, "local", stats.RebuildPhases[0].Contributor)
+	assert.EqualValues(t, 1, stats.RebuildPhases[0].BatchedWrites)
+	assert.Equal(t, "remote-host", stats.RebuildPhases[1].Contributor)
+	assert.EqualValues(t, 1, stats.RebuildPhases[1].BatchedWrites)
+}
+
+func TestResyncContributorFailureLeavesArchiveUnchanged(t *testing.T) {
+	localRoot := t.TempDir()
+	remoteRoot := t.TempDir()
+	env := setupSingleAgentTestEnvWithDirs(t, parser.AgentClaude, []string{localRoot})
+	oldPath := filepath.Join(localRoot, "old-project", "old-session.jsonl")
+	dbtest.WriteTestFile(t, oldPath, []byte(testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsZero, "durable old archive message").String()))
+	require.Equal(t, 1, env.engine.SyncAll(context.Background(), nil).Synced)
+	require.NoError(t, os.Remove(oldPath))
+	newPath := filepath.Join(localRoot, "new-project", "new-session.jsonl")
+	dbtest.WriteTestFile(t, newPath, []byte(testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarlyS1, "partial replacement message").String()))
+	remotePath := filepath.Join(remoteRoot, "remote-project", "remote-session.jsonl")
+	dbtest.WriteTestFile(t, remotePath, []byte(testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarlyS5, "partial remote message").String()))
+
+	sentinel := errors.New("after sync failed")
+	stats, err := env.engine.ResyncAllWithOptions(context.Background(), nil,
+		sync.RebuildOptions{Contributors: []sync.RebuildContributor{{
+			Name: "broken-remote",
+			Config: sync.EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {remoteRoot}},
+				Machine:   "broken-remote",
+				IDPrefix:  "broken~",
+				Ephemeral: true,
+			},
+			AfterSync: func(*sync.Engine, *db.DB) error { return sentinel },
+		}}})
+	require.Error(t, err)
+	assert.True(t, stats.Aborted)
+	var contributorErr *sync.RebuildContributorError
+	require.True(t, errors.As(err, &contributorErr))
+	assert.Equal(t, "broken-remote", contributorErr.Contributor)
+	assert.ErrorIs(t, err, sentinel)
+	assert.Contains(t, stats.Warnings,
+		`resync contributor "broken-remote" failed: after sync failed`)
+
+	oldSession, getErr := env.db.GetSession(context.Background(), "old-session")
+	require.NoError(t, getErr)
+	require.NotNil(t, oldSession)
+	newSession, getErr := env.db.GetSession(context.Background(), "new-session")
+	require.NoError(t, getErr)
+	assert.Nil(t, newSession)
+	page, searchErr := env.db.Search(context.Background(), db.SearchFilter{
+		Query: "durable old archive message", Limit: 5,
+	})
+	require.NoError(t, searchErr)
+	require.Len(t, page.Results, 1)
+	assert.NoFileExists(t, env.db.Path()+"-resync")
+	assert.NoFileExists(t, env.db.Path()+"-resync-wal")
+	assert.NoFileExists(t, env.db.Path()+"-resync-shm")
+}
+
+func TestResyncEmptyContributorDoesNotAbortNonEmptyLocalRebuild(t *testing.T) {
+	localRoot := t.TempDir()
+	emptyRoot := t.TempDir()
+	env := setupSingleAgentTestEnvWithDirs(t, parser.AgentClaude, []string{localRoot})
+	dbtest.WriteTestFile(t, filepath.Join(localRoot, "project", "local.jsonl"),
+		[]byte(testjsonl.NewSessionBuilder().
+			AddClaudeUser(tsZero, "nonempty local rebuild").String()))
+
+	stats, err := env.engine.ResyncAllWithOptions(context.Background(), nil,
+		sync.RebuildOptions{Contributors: []sync.RebuildContributor{{
+			Name: "empty",
+			Config: sync.EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {emptyRoot}},
+				Machine:   "empty",
+				IDPrefix:  "empty~",
+				Ephemeral: true,
+			},
+		}}})
+	require.NoError(t, err)
+	assert.False(t, stats.Aborted, "resync aborted: %+v", stats)
+	assert.Equal(t, 1, stats.Synced)
+	assert.EqualValues(t, 1, stats.RebuildPhases[0].BatchedWrites)
+	assert.Zero(t, stats.RebuildPhases[1].BatchedWrites)
+	assertSessionMessageCount(t, env.db, "local", 1)
+}
+
 func TestResyncAllExcludesExistingClaudeUsageProbe(t *testing.T) {
 	env := setupSingleAgentTestEnv(t, parser.AgentClaude)
 
@@ -2106,6 +2274,305 @@ func TestResyncAllExcludesExistingClaudeUsageProbe(t *testing.T) {
 	assert.Nil(t, got, "stale /usage probe row must be excluded")
 	assert.False(t, env.db.IsSessionExcluded(sessionID),
 		"parser exclusions must not become permanent user deletions")
+}
+
+func TestResyncContributorExclusionIsNotRestoredAsOrphan(t *testing.T) {
+	localRoot := t.TempDir()
+	remoteRoot := t.TempDir()
+	env := setupSingleAgentTestEnvWithDirs(t, parser.AgentClaude, []string{localRoot})
+	dbtest.WriteTestFile(t, filepath.Join(localRoot, "local", "local.jsonl"),
+		[]byte(testjsonl.NewSessionBuilder().AddClaudeUser(tsZero, "local").String()))
+
+	const rawID = "remote-usage-probe"
+	const storedID = "remote~remote-usage-probe"
+	usageCmd := "<command-name>/usage</command-name>\n" +
+		"<command-message>usage</command-message>\n<command-args></command-args>"
+	content := testjsonl.ClaudeUserJSON(usageCmd, tsEarly)
+	path := filepath.Join(remoteRoot, "remote", rawID+".jsonl")
+	dbtest.WriteTestFile(t, path, []byte(content))
+	storedPath := "remote:" + path
+	size := int64(len(content))
+	mtime := time.Now().Add(-time.Hour).UnixNano()
+	firstMessage := "/usage"
+	startedAt := tsEarly
+	require.NoError(t, env.db.UpsertSession(db.Session{
+		ID: storedID, Project: "remote", Machine: "remote", Agent: string(parser.AgentClaude),
+		FirstMessage: &firstMessage, StartedAt: &startedAt, EndedAt: &startedAt,
+		MessageCount: 1, UserMessageCount: 1, FilePath: &storedPath,
+		FileSize: &size, FileMtime: &mtime,
+	}))
+
+	stats, err := env.engine.ResyncAllWithOptions(context.Background(), nil,
+		sync.RebuildOptions{Contributors: []sync.RebuildContributor{{
+			Name: "remote",
+			Config: sync.EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {remoteRoot}},
+				Machine:   "remote", IDPrefix: "remote~", Ephemeral: true,
+				PathRewriter: func(path string) string { return "remote:" + path },
+			},
+		}}})
+	require.NoError(t, err)
+	require.False(t, stats.Aborted, "resync aborted: %+v", stats)
+	assert.Zero(t, stats.OrphanedCopied)
+	got, getErr := env.db.GetSession(context.Background(), storedID)
+	require.NoError(t, getErr)
+	assert.Nil(t, got)
+}
+
+func TestResyncContributorPreservesPinnedAndTrashedRemoteState(t *testing.T) {
+	localRoot := t.TempDir()
+	remoteRoot := t.TempDir()
+	env := setupSingleAgentTestEnvWithDirs(t, parser.AgentClaude, []string{localRoot})
+	dbtest.WriteTestFile(t, filepath.Join(localRoot, "local", "local.jsonl"),
+		[]byte(testjsonl.NewSessionBuilder().AddClaudeUser(tsZero, "local").String()))
+	remotePath := filepath.Join(remoteRoot, "remote", "remote-trash.jsonl")
+	dbtest.WriteTestFile(t, remotePath, []byte(testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, "preserved remote prompt").
+		AddClaudeAssistant(tsEarlyS1, "preserved remote reply").String()))
+	remoteConfig := sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {remoteRoot}},
+		Machine:   "remote", IDPrefix: "remote~", Ephemeral: true,
+		PathRewriter: func(path string) string { return "remote:" + path },
+	}
+	remoteEngine := sync.NewEngine(env.db, remoteConfig)
+	require.Equal(t, 1, remoteEngine.SyncAll(context.Background(), nil).Synced)
+	remoteEngine.Close()
+	msgs := fetchMessages(t, env.db, "remote~remote-trash")
+	require.Len(t, msgs, 2)
+	note := "keep this remote message"
+	_, err := env.db.PinMessage("remote~remote-trash", msgs[1].ID, &note)
+	require.NoError(t, err)
+	require.NoError(t, env.db.SoftDeleteSession("remote~remote-trash"))
+
+	stats, err := env.engine.ResyncAllWithOptions(context.Background(), nil,
+		sync.RebuildOptions{Contributors: []sync.RebuildContributor{{
+			Name: "remote", Config: remoteConfig,
+		}}})
+	require.NoError(t, err)
+	require.False(t, stats.Aborted, "resync aborted: %+v", stats)
+	full, err := env.db.GetSessionFull(context.Background(), "remote~remote-trash")
+	require.NoError(t, err)
+	require.NotNil(t, full)
+	assert.NotNil(t, full.DeletedAt)
+	preservedMessages := fetchMessages(t, env.db, "remote~remote-trash")
+	require.Len(t, preservedMessages, 2)
+	assert.Equal(t, "preserved remote prompt", preservedMessages[0].Content)
+	assert.Equal(t, "preserved remote reply", preservedMessages[1].Content)
+	pins, err := env.db.ListPinnedMessages(context.Background(), "remote~remote-trash", "")
+	require.NoError(t, err)
+	require.Len(t, pins, 1)
+	require.NotNil(t, pins[0].Note)
+	assert.Equal(t, note, *pins[0].Note)
+}
+
+type usageParityProvider struct {
+	parser.ProviderBase
+	source parser.SourceRef
+	result parser.ParseResult
+}
+
+func (p *usageParityProvider) Discover(context.Context) ([]parser.SourceRef, error) {
+	return []parser.SourceRef{p.source}, nil
+}
+
+func (p *usageParityProvider) Fingerprint(
+	context.Context, parser.SourceRef,
+) (parser.SourceFingerprint, error) {
+	return parser.SourceFingerprint{
+		Key: p.source.FingerprintKey, Size: 128, MTimeNS: 1_700_000_000_000_000_000,
+	}, nil
+}
+
+func (p *usageParityProvider) Parse(
+	context.Context, parser.ParseRequest,
+) (parser.ParseOutcome, error) {
+	return parser.ParseOutcome{
+		Results:           []parser.ParseResultOutcome{{Result: p.result}},
+		ResultSetComplete: true,
+	}, nil
+}
+
+type usageParityFactory struct{ provider *usageParityProvider }
+
+func (f usageParityFactory) Definition() parser.AgentDef {
+	return f.provider.Definition()
+}
+
+func (f usageParityFactory) Capabilities() parser.Capabilities {
+	return f.provider.Capabilities()
+}
+
+func (f usageParityFactory) NewProvider(parser.ProviderConfig) parser.Provider {
+	return f.provider
+}
+
+func newUsageParityProvider(sourcePath, machine string) *usageParityProvider {
+	const rawID = "usage-equivalent"
+	messageOrdinal := 0
+	costUSD := 0.0125
+	started := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	return &usageParityProvider{
+		ProviderBase: parser.ProviderBase{
+			Def: parser.AgentDef{Type: parser.AgentCowork, FileBased: true},
+			Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+				DiscoverSources:      parser.CapabilitySupported,
+				CompositeFingerprint: parser.CapabilitySupported,
+			}},
+		},
+		source: parser.SourceRef{
+			Provider: parser.AgentCowork, Key: sourcePath,
+			DisplayPath: sourcePath, FingerprintKey: sourcePath,
+		},
+		result: parser.ParseResult{
+			Session: parser.ParsedSession{
+				ID: rawID, Project: "usage-parity", Machine: machine,
+				Agent: parser.AgentCowork, StartedAt: started, EndedAt: started,
+				FirstMessage: "usage parity fixture", MessageCount: 1,
+				UserMessageCount: 1,
+				File: parser.FileInfo{
+					Path: sourcePath, Size: 128, Mtime: 1_700_000_000_000_000_000,
+				},
+			},
+			Messages: []parser.ParsedMessage{{
+				Ordinal: 0, Role: parser.RoleUser,
+				Content: "usage parity fixture", Timestamp: started,
+			}},
+			UsageEvents: []parser.ParsedUsageEvent{{
+				SessionID: rawID, MessageOrdinal: &messageOrdinal,
+				Source: "literal-provider-usage", Model: "literal-model-v1",
+				InputTokens: 101, OutputTokens: 37,
+				CacheCreationInputTokens: 23, CacheReadInputTokens: 19,
+				ReasoningTokens: 11, CostUSD: &costUSD,
+				CostStatus: "exact", CostSource: "literal-fixture",
+				OccurredAt: "2026-01-02T03:04:05Z",
+				DedupKey:   "usage-equivalent:event-1",
+			}},
+		},
+	}
+}
+
+func TestResyncContributorPersistsEquivalentUsageEvents(t *testing.T) {
+	localRoot := t.TempDir()
+	remoteRoot := t.TempDir()
+	localProvider := newUsageParityProvider(
+		filepath.Join(localRoot, "usage-equivalent.fixture"), "local",
+	)
+	remoteProvider := newUsageParityProvider(
+		filepath.Join(remoteRoot, "usage-equivalent.fixture"), "remote",
+	)
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentCowork: {localRoot}},
+		Machine:   "local",
+		ProviderFactories: []parser.ProviderFactory{
+			usageParityFactory{provider: localProvider},
+		},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			parser.AgentCowork: parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+
+	stats, err := engine.ResyncAllWithOptions(context.Background(), nil,
+		sync.RebuildOptions{Contributors: []sync.RebuildContributor{{
+			Name: "remote",
+			Config: sync.EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{parser.AgentCowork: {remoteRoot}},
+				Machine:   "remote", IDPrefix: "remote~", Ephemeral: true,
+				ProviderFactories: []parser.ProviderFactory{
+					usageParityFactory{provider: remoteProvider},
+				},
+				ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+					parser.AgentCowork: parser.ProviderMigrationProviderAuthoritative,
+				},
+			},
+		}}})
+	require.NoError(t, err)
+	require.False(t, stats.Aborted, "resync aborted: %+v", stats)
+
+	localEvents, err := database.GetUsageEvents(context.Background(), "usage-equivalent")
+	require.NoError(t, err)
+	require.Len(t, localEvents, 1)
+	remoteEvents, err := database.GetUsageEvents(context.Background(), "remote~usage-equivalent")
+	require.NoError(t, err)
+	require.Len(t, remoteEvents, 1)
+
+	localEvent := localEvents[0]
+	remoteEvent := remoteEvents[0]
+	assert.Equal(t, "usage-equivalent", localEvent.SessionID)
+	assert.Equal(t, "remote~usage-equivalent", remoteEvent.SessionID)
+	localEvent.ID = 0
+	remoteEvent.ID = 0
+	remoteEvent.SessionID = localEvent.SessionID
+	assert.Equal(t, localEvent, remoteEvent,
+		"contributor usage must differ only by its persisted session namespace")
+
+	messageOrdinal := 0
+	costUSD := 0.0125
+	assert.Equal(t, db.UsageEvent{
+		SessionID: "usage-equivalent", MessageOrdinal: &messageOrdinal,
+		Source: "literal-provider-usage", Model: "literal-model-v1",
+		InputTokens: 101, OutputTokens: 37,
+		CacheCreationInputTokens: 23, CacheReadInputTokens: 19,
+		ReasoningTokens: 11, CostUSD: &costUSD,
+		CostStatus: "exact", CostSource: "literal-fixture",
+		OccurredAt: "2026-01-02T03:04:05Z",
+		DedupKey:   "usage-equivalent:event-1",
+	}, localEvent)
+}
+
+func TestResyncContributorPreservesAnnotationsOrphansAndOtherHosts(t *testing.T) {
+	localRoot := t.TempDir()
+	remoteRoot := t.TempDir()
+	otherRoot := t.TempDir()
+	env := setupSingleAgentTestEnvWithDirs(t, parser.AgentClaude, []string{localRoot})
+	dbtest.WriteTestFile(t, filepath.Join(localRoot, "local", "local.jsonl"),
+		[]byte(testjsonl.NewSessionBuilder().AddClaudeUser(tsZero, "local").String()))
+	remoteCurrent := filepath.Join(remoteRoot, "remote", "annotated.jsonl")
+	remoteOrphan := filepath.Join(remoteRoot, "remote", "remote-orphan.jsonl")
+	dbtest.WriteTestFile(t, remoteCurrent, []byte(testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, "annotated remote").String()))
+	dbtest.WriteTestFile(t, remoteOrphan, []byte(testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarlyS1, "remote orphan").String()))
+	remoteConfig := sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {remoteRoot}},
+		Machine:   "remote", IDPrefix: "remote~", Ephemeral: true,
+	}
+	remoteEngine := sync.NewEngine(env.db, remoteConfig)
+	require.Equal(t, 2, remoteEngine.SyncAll(context.Background(), nil).Synced)
+	remoteEngine.Close()
+	annotation := "user annotation survives"
+	require.NoError(t, env.db.RenameSession("remote~annotated", &annotation))
+	require.NoError(t, os.Remove(remoteOrphan))
+
+	otherPath := filepath.Join(otherRoot, "other", "other-host.jsonl")
+	dbtest.WriteTestFile(t, otherPath, []byte(testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarlyS5, "other host archive").String()))
+	otherEngine := sync.NewEngine(env.db, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {otherRoot}},
+		Machine:   "other", IDPrefix: "other~", Ephemeral: true,
+	})
+	require.Equal(t, 1, otherEngine.SyncAll(context.Background(), nil).Synced)
+	otherEngine.Close()
+	require.NoError(t, os.Remove(otherPath))
+
+	stats, err := env.engine.ResyncAllWithOptions(context.Background(), nil,
+		sync.RebuildOptions{Contributors: []sync.RebuildContributor{{
+			Name: "remote", Config: remoteConfig,
+		}}})
+	require.NoError(t, err)
+	require.False(t, stats.Aborted, "resync aborted: %+v", stats)
+	assert.Equal(t, 2, stats.OrphanedCopied)
+	annotated, err := env.db.GetSession(context.Background(), "remote~annotated")
+	require.NoError(t, err)
+	require.NotNil(t, annotated)
+	require.NotNil(t, annotated.DisplayName)
+	assert.Equal(t, annotation, *annotated.DisplayName)
+	for _, id := range []string{"remote~remote-orphan", "other~other-host"} {
+		session, getErr := env.db.GetSession(context.Background(), id)
+		require.NoError(t, getErr)
+		assert.NotNil(t, session, id)
+	}
 }
 
 func TestSyncEngineCodex(t *testing.T) {
@@ -2776,9 +3243,10 @@ func TestCodexExecMigrationIdempotent(t *testing.T) {
 	)
 	info, err := os.Stat(path)
 	require.NoError(t, err, "stat codex session")
+	cacheKey := fmt.Sprintf("%s?source_hash=%x", path, sha256.Sum256([]byte(content)))
 
 	require.NoError(t, env.db.ReplaceSkippedFiles(map[string]int64{
-		path: info.ModTime().UnixNano(),
+		cacheKey: info.ModTime().UnixNano(),
 	}), "seed skipped files")
 
 	// Rebuild the engine without resetting the migration
@@ -2802,7 +3270,7 @@ func TestCodexExecMigrationIdempotent(t *testing.T) {
 
 	loaded, err := env.db.LoadSkippedFiles()
 	require.NoError(t, err, "load skipped files")
-	_, ok := loaded[path]
+	_, ok := loaded[cacheKey]
 	require.True(t, ok,
 		"post-migration skip entry for %s was cleared; migration must be idempotent",
 		path,
@@ -11271,6 +11739,9 @@ func TestResyncAllCancelledPreservesOriginalDB(t *testing.T) {
 	stats := env.engine.ResyncAll(ctx, nil)
 
 	require.True(t, stats.Aborted, "expected ResyncAll to report Aborted")
+	assert.Equal(t, []string{"resync aborted: 0 synced, 0 failed"}, stats.Warnings)
+	assert.Equal(t, stats, env.engine.LastSyncStats(),
+		"legacy LastSyncStats must match the returned cancellation result")
 
 	// Original DB should be preserved — session still
 	// has the original data.

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -2927,7 +2927,7 @@ func TestStampProviderFileIdentityPreservesProviderSnapshotIdentity(t *testing.T
 	assert.Equal(t, replacementDevice, results[1].Session.File.Device)
 }
 
-func TestProviderProcessCacheKeyCodexStaysContentIndependent(t *testing.T) {
+func TestProviderProcessCacheKeyCodexIncludesContentHash(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "session.jsonl")
 	file := parser.DiscoveredFile{Path: path, Agent: parser.AgentCodex}
 	source := parser.SourceRef{
@@ -2942,9 +2942,10 @@ func TestProviderProcessCacheKeyCodexStaysContentIndependent(t *testing.T) {
 		Key: path, Hash: "second-content-hash",
 	})
 
-	assert.Equal(t, path, first)
-	assert.Equal(t, first, second,
-		"Codex content versions must reuse one bounded skip-cache key")
+	assert.Equal(t, path+"?source_hash=first-content-hash", first)
+	assert.Equal(t, path+"?source_hash=second-content-hash", second)
+	assert.NotEqual(t, first, second,
+		"same-stat content rewrites must not reuse a rowless skip entry")
 }
 
 func (p *incrementalRequestRecorder) Parse(

--- a/internal/sync/perf_invariant_test.go
+++ b/internal/sync/perf_invariant_test.go
@@ -3,7 +3,13 @@ package sync
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+	gosync "sync"
 	"testing"
+
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/testjsonl"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -63,4 +69,138 @@ func TestWarmFullSyncDoesNoBulkWriteWork(t *testing.T) {
 		"warm no-op sync must not run any bulk-write batch")
 	assert.Zero(t, stats.BatchedWrites.Load(),
 		"warm no-op sync must not rewrite any session")
+}
+
+// TestRebuildLocalAndRemoteContributorsBulkWriteDiscoveredCount protects the
+// shared full-rebuild ingest path: both source shapes must send every
+// discovered session through batched writes. A remote contributor accidentally
+// restored to the active-archive write mode would report zero batched writes.
+func TestRebuildLocalAndRemoteContributorsBulkWriteDiscoveredCount(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	type workCounts struct {
+		localBatches  int64
+		remoteBatches int64
+		localWrites   int64
+		remoteWrites  int64
+	}
+	observed := make(map[int]workCounts)
+	for _, sessionsPerSource := range []int{5, 500} {
+		t.Run(fmt.Sprintf("%d_sessions", sessionsPerSource), func(t *testing.T) {
+			localRoot := t.TempDir()
+			remoteRoot := t.TempDir()
+			writeSessions := func(root, prefix string) {
+				t.Helper()
+				for i := range sessionsPerSource {
+					path := filepath.Join(root, "project",
+						fmt.Sprintf("%s-%03d.jsonl", prefix, i))
+					require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+					require.NoError(t, os.WriteFile(path, []byte(
+						testjsonl.NewSessionBuilder().
+							AddClaudeUser("2024-01-01T00:00:00Z",
+								fmt.Sprintf("%s %d", prefix, i)).
+							String(),
+					), 0o644))
+				}
+			}
+			writeSessions(localRoot, "local")
+			writeSessions(remoteRoot, "remote")
+
+			database := openTestDB(t)
+			engine := NewEngine(database, EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {localRoot}},
+				Machine:   "local",
+			})
+			t.Cleanup(engine.Close)
+
+			var progressMu gosync.Mutex
+			remoteStarted := false
+			localDiscovered := 0
+			remoteDiscovered := 0
+			stats, err := engine.ResyncAllWithOptions(context.Background(), func(p Progress) {
+				progressMu.Lock()
+				defer progressMu.Unlock()
+				if !remoteStarted && p.SessionsTotal > localDiscovered {
+					localDiscovered = p.SessionsTotal
+				}
+			}, RebuildOptions{
+				Contributors: []RebuildContributor{{
+					Name: "remote",
+					Config: EngineConfig{
+						AgentDirs: map[parser.AgentType][]string{
+							parser.AgentClaude: {remoteRoot},
+						},
+						Machine:   "remote",
+						IDPrefix:  "remote~",
+						Ephemeral: true,
+					},
+					Progress: func(p Progress) Progress {
+						progressMu.Lock()
+						defer progressMu.Unlock()
+						remoteStarted = true
+						if p.SessionsTotal > remoteDiscovered {
+							remoteDiscovered = p.SessionsTotal
+						}
+						return p
+					},
+				}},
+			})
+			require.NoError(t, err)
+			require.False(t, stats.Aborted)
+			require.Len(t, stats.RebuildPhases, 2)
+
+			progressMu.Lock()
+			assert.Equal(t, sessionsPerSource, localDiscovered,
+				"local discovery must stay bounded by the local corpus")
+			assert.Equal(t, sessionsPerSource, remoteDiscovered,
+				"remote discovery must stay bounded by the remote corpus")
+			progressMu.Unlock()
+
+			wantBatches := int64((sessionsPerSource + batchSize - 1) / batchSize)
+			for i, wantName := range []string{"local", "remote"} {
+				phase := stats.RebuildPhases[i]
+				assert.Equal(t, wantName, phase.Contributor,
+					"contributors must retain deterministic local-then-remote order")
+				assert.EqualValues(t, sessionsPerSource, phase.BatchedWrites,
+					"%s must bulk-write every discovered session", wantName)
+				assert.EqualValues(t, sessionsPerSource, phase.WriteBatchSize,
+					"%s batch sizes must sum to its discovered count", wantName)
+				assert.Equal(t, wantBatches, phase.Batches,
+					"%s must use ceil(%d/%d) batches", wantName,
+					sessionsPerSource, batchSize)
+			}
+			assert.Equal(t, sessionsPerSource*2, stats.TotalSessions,
+				"combined discovery count")
+			assert.Equal(t, sessionsPerSource*2, stats.Synced,
+				"combined written session count")
+			assert.Equal(t, stats.RebuildPhases[0].Batches,
+				stats.RebuildPhases[1].Batches,
+				"equivalent local and remote corpora must have equal batch work")
+			assert.Equal(t, stats.RebuildPhases[0].BatchedWrites,
+				stats.RebuildPhases[1].BatchedWrites,
+				"equivalent local and remote corpora must have equal write work")
+
+			observed[sessionsPerSource] = workCounts{
+				localBatches:  stats.RebuildPhases[0].Batches,
+				remoteBatches: stats.RebuildPhases[1].Batches,
+				localWrites:   stats.RebuildPhases[0].BatchedWrites,
+				remoteWrites:  stats.RebuildPhases[1].BatchedWrites,
+			}
+		})
+	}
+
+	small := observed[5]
+	large := observed[500]
+	assert.Equal(t, small.localBatches*5, large.localBatches,
+		"local batch count must grow from 1 to 5 at the 100-session boundary")
+	assert.Equal(t, small.remoteBatches*5, large.remoteBatches,
+		"remote batch count must grow from 1 to 5 at the 100-session boundary")
+	assert.Equal(t, small.localWrites*100, large.localWrites,
+		"local writes must grow exactly with corpus cardinality")
+	assert.Equal(t, small.remoteWrites*100, large.remoteWrites,
+		"remote writes must grow exactly with corpus cardinality")
+	assert.Equal(t, large.localWrites, large.remoteWrites,
+		"large equivalent contributors must retain equal work counts")
 }

--- a/internal/sync/perf_invariant_test.go
+++ b/internal/sync/perf_invariant_test.go
@@ -30,6 +30,41 @@ import (
 //     (discovery_workspace_manifest_test.go, antigravity/gemini
 //     provider tests) pin O(roots) discovery work (#912).
 
+func TestSourceHashSkipMutationWorkIsArchiveCardinalityIndependent(t *testing.T) {
+	type workCounts struct {
+		insert int
+		remove int
+	}
+	observed := make(map[int]workCounts)
+	for _, cacheSize := range []int{8, 8000} {
+		t.Run(fmt.Sprintf("%d_entries", cacheSize), func(t *testing.T) {
+			database := openTestDB(t)
+			engine := NewEngine(database, EngineConfig{})
+			t.Cleanup(engine.Close)
+			entries := make(map[string]int64, cacheSize)
+			for i := range cacheSize {
+				entries[fmt.Sprintf(
+					"/archive/session-%05d.jsonl?source_hash=old", i,
+				)] = 1
+			}
+			engine.InjectSkipCache(entries)
+
+			const base = "/archive/session-00000.jsonl?source_hash="
+			insertWork := engine.cacheSkip(base+"new", 2)
+			removeWork := engine.clearSkip(base + "new")
+
+			assert.Equal(t, cacheSize-1, len(engine.SnapshotSkipCache()))
+			observed[cacheSize] = workCounts{
+				insert: insertWork,
+				remove: removeWork,
+			}
+		})
+	}
+
+	assert.Equal(t, observed[8], observed[8000],
+		"one watcher mutation must do the same sibling work at every archive size")
+}
+
 // TestWarmFullSyncDoesNoBulkWriteWork verifies that a second full
 // sync over an unchanged Claude archive skips every session before
 // the parse and never enters the bulk-write pipeline. Claude has its

--- a/internal/sync/progress.go
+++ b/internal/sync/progress.go
@@ -51,13 +51,14 @@ type SyncResult struct {
 // produced at least one session — used by ResyncAll to compare
 // against Failed on the same unit.
 type SyncStats struct {
-	TotalSessions  int      `json:"total_sessions"`
-	Synced         int      `json:"synced"`
-	Skipped        int      `json:"skipped"`
-	Failed         int      `json:"failed"`
-	OrphanedCopied int      `json:"orphaned_copied,omitempty"`
-	Warnings       []string `json:"warnings,omitempty"`
-	Aborted        bool     `json:"aborted,omitempty"`
+	TotalSessions  int                 `json:"total_sessions"`
+	Synced         int                 `json:"synced"`
+	Skipped        int                 `json:"skipped"`
+	Failed         int                 `json:"failed"`
+	OrphanedCopied int                 `json:"orphaned_copied,omitempty"`
+	Warnings       []string            `json:"warnings,omitempty"`
+	Aborted        bool                `json:"aborted,omitempty"`
+	RebuildPhases  []RebuildPhaseStats `json:"rebuild_phases,omitempty"`
 
 	// Anomalies aggregates per-run parser/sanitizer anomaly signals
 	// surfaced in the CLI sync summary. These are live per-run counters

--- a/internal/sync/provider_process_test.go
+++ b/internal/sync/provider_process_test.go
@@ -702,6 +702,27 @@ func TestCacheSkipRetainsOnlyLatestSourceHashKey(t *testing.T) {
 	assert.Equal(t, map[string]int64{base + "new": 1}, engine.SnapshotSkipCache())
 }
 
+func TestNewEngineNormalizesLegacySourceHashSkipDuplicates(t *testing.T) {
+	database := openTestDB(t)
+	const (
+		plain     = "/archive/session.jsonl"
+		hashBase  = plain + "?source_hash="
+		unrelated = "/archive/unrelated.jsonl"
+	)
+	require.NoError(t, database.ReplaceSkippedFiles(map[string]int64{
+		plain:            1,
+		hashBase + "old": 2,
+		hashBase + "new": 3,
+		unrelated:        4,
+	}))
+
+	engine := NewEngine(database, EngineConfig{})
+	t.Cleanup(engine.Close)
+
+	assert.Equal(t, map[string]int64{unrelated: 4}, engine.SnapshotSkipCache(),
+		"ambiguous legacy hashes must reparse once instead of choosing a stale key")
+}
+
 func TestProcessFileClaudeCachedStoredSessionChangedHashReparses(t *testing.T) {
 	root := t.TempDir()
 	sourcePath, fingerprint := writeProcessProviderSource(t, root, "stored.jsonl")

--- a/internal/sync/provider_process_test.go
+++ b/internal/sync/provider_process_test.go
@@ -591,6 +591,168 @@ func TestSyncSingleSessionProviderAuthoritativeBypassesProviderSkipCache(t *test
 	assert.False(t, cached)
 }
 
+func TestProcessFileClaudeCachedSourceWithoutStoredSessionSkipsParse(t *testing.T) {
+	root := t.TempDir()
+	sourcePath, fingerprint := writeProcessProviderSource(t, root, "noninteractive.jsonl")
+	fingerprint.Hash = "unchanged-content"
+	source := processFixtureSource(sourcePath)
+	source.Provider = parser.AgentClaude
+	provider := newProcessFixtureProvider(
+		source,
+		fingerprint,
+		parser.ParseOutcome{ResultSetComplete: true},
+	)
+	provider.Def.Type = parser.AgentClaude
+	provider.Def.IDPrefix = "claude:"
+	engine := NewEngine(openTestDB(t), EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {root},
+		},
+		Machine:           "devbox",
+		ProviderFactories: []parser.ProviderFactory{processFixtureFactory{provider: provider}},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			parser.AgentClaude: parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	engine.cacheSkip(providerProcessCacheKey(
+		parser.DiscoveredFile{Path: sourcePath, Agent: parser.AgentClaude},
+		source, fingerprint,
+	), fingerprint.MTimeNS)
+
+	res := engine.processFile(context.Background(), parser.DiscoveredFile{
+		Path:  sourcePath,
+		Agent: parser.AgentClaude,
+	})
+
+	require.NoError(t, res.err)
+	assert.True(t, res.skip)
+	assert.Equal(t, []string{"find-source", "fingerprint"}, provider.calls)
+	assert.Empty(t, provider.parseRequests)
+}
+
+func TestProcessFileRowlessCachedSourceChangedHashReparses(t *testing.T) {
+	for _, agent := range []parser.AgentType{parser.AgentClaude, parser.AgentCodex} {
+		t.Run(string(agent), func(t *testing.T) {
+			root := t.TempDir()
+			sourcePath, fingerprint := writeProcessProviderSource(
+				t, root, "became-interactive.jsonl",
+			)
+			fingerprint.Hash = "new-valid-content"
+			source := processFixtureSource(sourcePath)
+			source.Provider = agent
+			provider := newProcessFixtureProvider(
+				source,
+				fingerprint,
+				parser.ParseOutcome{
+					Results: []parser.ParseResultOutcome{{
+						Result: processFixtureResult(
+							string(agent)+":valid", agent, "fixture-project",
+							sourcePath, fingerprint,
+						),
+						DataVersion: parser.DataVersionCurrent,
+					}},
+					ResultSetComplete: true,
+				},
+			)
+			provider.Def.Type = agent
+			provider.Def.IDPrefix = string(agent) + ":"
+			engine := NewEngine(openTestDB(t), EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{agent: {root}},
+				Machine:   "devbox",
+				ProviderFactories: []parser.ProviderFactory{
+					processFixtureFactory{provider: provider},
+				},
+				ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+					agent: parser.ProviderMigrationProviderAuthoritative,
+				},
+			})
+			oldFingerprint := fingerprint
+			oldFingerprint.Hash = "old-ignored-content"
+			oldKey := providerProcessCacheKey(
+				parser.DiscoveredFile{Path: sourcePath, Agent: agent},
+				source, oldFingerprint,
+			)
+			engine.cacheSkip(oldKey, fingerprint.MTimeNS)
+
+			res := engine.processFile(context.Background(), parser.DiscoveredFile{
+				Path: sourcePath, Agent: agent,
+			})
+
+			require.NoError(t, res.err)
+			assert.False(t, res.skip)
+			assert.Equal(t, []string{"find-source", "fingerprint", "parse"}, provider.calls)
+			require.Len(t, provider.parseRequests, 1)
+		})
+	}
+}
+
+func TestCacheSkipRetainsOnlyLatestSourceHashKey(t *testing.T) {
+	engine := &Engine{
+		skipCache:        make(map[string]int64),
+		skipFingerprints: make(map[string]string),
+	}
+	const (
+		plain = "/archive/session.jsonl"
+		base  = plain + "?source_hash="
+	)
+	engine.cacheSkip(plain, 1)
+	engine.cacheSkip(base+"old", 1)
+	engine.cacheSkip(base+"new", 1)
+
+	assert.Equal(t, map[string]int64{base + "new": 1}, engine.SnapshotSkipCache())
+}
+
+func TestProcessFileClaudeCachedStoredSessionChangedHashReparses(t *testing.T) {
+	root := t.TempDir()
+	sourcePath, fingerprint := writeProcessProviderSource(t, root, "stored.jsonl")
+	fingerprint.Hash = "new-content"
+	source := processFixtureSource(sourcePath)
+	source.Provider = parser.AgentClaude
+	provider := newProcessFixtureProvider(
+		source,
+		fingerprint,
+		parser.ParseOutcome{ResultSetComplete: true},
+	)
+	provider.Def.Type = parser.AgentClaude
+	provider.Def.IDPrefix = "claude:"
+	engine := NewEngine(openTestDB(t), EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {root},
+		},
+		Machine:           "devbox",
+		ProviderFactories: []parser.ProviderFactory{processFixtureFactory{provider: provider}},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			parser.AgentClaude: parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	stored := processFixtureResult(
+		"claude:stored",
+		parser.AgentClaude,
+		"fixture-project",
+		sourcePath,
+		fingerprint,
+	)
+	stored.Session.File.Hash = "old-content"
+	written, _, failed, _ := engine.writeBatch(
+		[]pendingWrite{{sess: stored.Session, msgs: stored.Messages}},
+		syncWriteDefault,
+		false,
+	)
+	require.Equal(t, 1, written)
+	require.Zero(t, failed)
+	engine.cacheSkip(source.FingerprintKey, fingerprint.MTimeNS)
+
+	res := engine.processFile(context.Background(), parser.DiscoveredFile{
+		Path:  sourcePath,
+		Agent: parser.AgentClaude,
+	})
+
+	require.NoError(t, res.err)
+	assert.False(t, res.skip)
+	assert.Equal(t, []string{"find-source", "fingerprint", "parse"}, provider.calls)
+	require.Len(t, provider.parseRequests, 1)
+}
+
 func TestProcessFileProviderDevinSkipsStoredFreshSource(t *testing.T) {
 	root := t.TempDir()
 	dbPath, transcriptPath := writeProcessProviderDevinFixture(

--- a/internal/sync/rebuild_contributor.go
+++ b/internal/sync/rebuild_contributor.go
@@ -1,0 +1,111 @@
+package sync
+
+import (
+	"errors"
+	"fmt"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+// ErrUnifiedRebuildAborted reports that the atomic local and HTTP rebuild was
+// discarded without a narrower preparation or contributor error. Callers must
+// treat the operation as unsuccessful even though the active archive remains
+// intact.
+var ErrUnifiedRebuildAborted = errors.New(
+	"unified local and HTTP rebuild aborted",
+)
+
+// RebuildContributor adds another configured sync source to an atomic full
+// rebuild. Contributors run sequentially against the same temporary database.
+type RebuildContributor struct {
+	Name      string
+	Config    EngineConfig
+	Progress  func(Progress) Progress
+	AfterSync func(*Engine, *db.DB) error
+}
+
+// RebuildOptions configures optional sources for an atomic full rebuild.
+type RebuildOptions struct {
+	Contributors []RebuildContributor
+	// includePhaseDiagnostics is enabled only by the options entrypoint. The
+	// legacy ResyncAll wrapper keeps both returned and in-flight stats free of
+	// options-only diagnostics.
+	includePhaseDiagnostics bool
+}
+
+// RebuildPhaseStats records observable bulk-write diagnostics for one source
+// participating in a rebuild.
+type RebuildPhaseStats struct {
+	Contributor    string `json:"contributor"`
+	PrepNanos      int64  `json:"prep_nanos"`
+	ScanNanos      int64  `json:"scan_nanos"`
+	WriteNanos     int64  `json:"write_nanos"`
+	Batches        int64  `json:"batches"`
+	BatchedWrites  int64  `json:"batched_writes"`
+	WriteBatchSize int64  `json:"write_batch_size"`
+}
+
+// RebuildContributorError identifies a contributor whose lifecycle hook
+// prevented the atomic rebuild from completing.
+type RebuildContributorError struct {
+	Contributor string
+	Err         error
+}
+
+func (e *RebuildContributorError) Error() string {
+	return fmt.Sprintf("rebuild contributor %q: %v", e.Contributor, e.Err)
+}
+
+func (e *RebuildContributorError) Unwrap() error { return e.Err }
+
+type rebuildOperations struct {
+	rebuildFTS func(*db.DB) error
+	reopen     func(*db.DB) error
+}
+
+var productionRebuildOperations = rebuildOperations{
+	rebuildFTS: func(database *db.DB) error { return database.RebuildFTS() },
+	reopen:     func(database *db.DB) error { return database.Reopen() },
+}
+
+func (ops rebuildOperations) withDefaults() rebuildOperations {
+	if ops.rebuildFTS == nil {
+		ops.rebuildFTS = productionRebuildOperations.rebuildFTS
+	}
+	if ops.reopen == nil {
+		ops.reopen = productionRebuildOperations.reopen
+	}
+	return ops
+}
+
+func phaseSnapshot(name string, stats *PhaseStats) RebuildPhaseStats {
+	return RebuildPhaseStats{
+		Contributor:    name,
+		PrepNanos:      stats.PrepNanos.Load(),
+		ScanNanos:      stats.ScanNanos.Load(),
+		WriteNanos:     stats.WriteNanos.Load(),
+		Batches:        stats.Batches.Load(),
+		BatchedWrites:  stats.BatchedWrites.Load(),
+		WriteBatchSize: stats.WriteBatchSize.Load(),
+	}
+}
+
+func mergeSyncStats(dst *SyncStats, src SyncStats) {
+	dst.TotalSessions += src.TotalSessions
+	dst.Synced += src.Synced
+	dst.Skipped += src.Skipped
+	dst.Failed += src.Failed
+	dst.OrphanedCopied += src.OrphanedCopied
+	dst.Warnings = append(dst.Warnings, src.Warnings...)
+	dst.Aborted = dst.Aborted || src.Aborted
+	dst.RebuildPhases = append(dst.RebuildPhases, src.RebuildPhases...)
+	dst.Anomalies.merge(src.Anomalies)
+	dst.filesOK += src.filesOK
+	dst.filesDiscovered += src.filesDiscovered
+	dst.nonContainerDiscovered += src.nonContainerDiscovered
+	dst.messagesIndexed += src.messagesIndexed
+	dst.parserExcludedFiles += src.parserExcludedFiles
+	dst.parserExcludedIDs = append(dst.parserExcludedIDs, src.parserExcludedIDs...)
+	dst.cwdFilteredSessions += src.cwdFilteredSessions
+	dst.cwdFilteredFiles += src.cwdFilteredFiles
+}

--- a/internal/sync/rebuild_contributor_test.go
+++ b/internal/sync/rebuild_contributor_test.go
@@ -202,6 +202,43 @@ func TestResyncAbortsWhenContributorLosesHistoricalSource(t *testing.T) {
 	assert.NotNil(t, remote, "aborted rebuild must preserve the active archive")
 }
 
+func TestResyncDoesNotTreatSameNamedContributorAsLocalHistory(t *testing.T) {
+	localRoot := t.TempDir()
+	remoteRoot := t.TempDir()
+	remotePath := filepath.Join(remoteRoot, "project", "remote.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(remotePath), 0o755))
+	require.NoError(t, os.WriteFile(remotePath, []byte(testjsonl.NewSessionBuilder().
+		AddClaudeUser("2026-01-01T00:00:00Z", "same-name remote source").String()), 0o644))
+	database, err := db.Open(filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {localRoot}},
+		Machine:   "collector-host",
+	})
+	t.Cleanup(engine.Close)
+	options := RebuildOptions{Contributors: []RebuildContributor{{
+		Name: "collector-host",
+		Config: EngineConfig{
+			AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {remoteRoot}},
+			Machine:   "collector-host", IDPrefix: "collector-host~", Ephemeral: true,
+		},
+	}}}
+
+	initial, err := engine.ResyncAllWithOptions(context.Background(), nil, options)
+	require.NoError(t, err)
+	require.False(t, initial.Aborted)
+
+	stats, err := engine.ResyncAllWithOptions(context.Background(), nil, options)
+
+	require.NoError(t, err)
+	assert.False(t, stats.Aborted,
+		"remote-prefixed history must not make an empty local source look incomplete")
+	remote, err := database.GetSession(context.Background(), "collector-host~remote")
+	require.NoError(t, err)
+	assert.NotNil(t, remote)
+}
+
 func TestResyncContributorPostSwapReopenFailureReturnsCoordinatorError(t *testing.T) {
 	root := t.TempDir()
 	database, err := db.Open(filepath.Join(t.TempDir(), "archive.db"))

--- a/internal/sync/rebuild_contributor_test.go
+++ b/internal/sync/rebuild_contributor_test.go
@@ -1,0 +1,728 @@
+package sync
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/testjsonl"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeSyncStatsIncludesAdditiveRebuildFields(t *testing.T) {
+	dst := SyncStats{
+		OrphanedCopied: 2,
+		RebuildPhases:  []RebuildPhaseStats{{Contributor: "local", BatchedWrites: 1}},
+	}
+	src := SyncStats{
+		OrphanedCopied: 3,
+		RebuildPhases:  []RebuildPhaseStats{{Contributor: "remote", BatchedWrites: 2}},
+	}
+
+	mergeSyncStats(&dst, src)
+
+	assert.Equal(t, 5, dst.OrphanedCopied)
+	assert.Equal(t, []RebuildPhaseStats{
+		{Contributor: "local", BatchedWrites: 1},
+		{Contributor: "remote", BatchedWrites: 2},
+	}, dst.RebuildPhases)
+}
+
+func TestResyncAllLegacyOmitsContributorDiagnostics(t *testing.T) {
+	root := t.TempDir()
+	database, err := db.Open(filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {root}},
+		Machine:   "local",
+	})
+	t.Cleanup(engine.Close)
+	path := filepath.Join(root, "project", "legacy.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(testjsonl.NewSessionBuilder().
+		AddClaudeUser("2026-01-01T00:00:00Z", "legacy phase fixture").String()), 0o644))
+
+	stats := engine.ResyncAll(context.Background(), nil)
+
+	require.False(t, stats.Aborted)
+	assert.Nil(t, stats.RebuildPhases)
+	assert.Nil(t, engine.LastSyncStats().RebuildPhases)
+	payload, err := json.Marshal(stats)
+	require.NoError(t, err)
+	assert.NotContains(t, string(payload), "rebuild_phases")
+}
+
+func TestResyncContributorsRunInOrderWithCumulativeProgress(t *testing.T) {
+	localRoot := t.TempDir()
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+	for _, fixture := range []struct {
+		root    string
+		project string
+		id      string
+		content string
+	}{
+		{localRoot, "local", "local", "local cumulative progress"},
+		{rootA, "a", "contributor-a", "contributor A progress"},
+		{rootB, "b", "contributor-b", "contributor B progress"},
+	} {
+		path := filepath.Join(fixture.root, fixture.project, fixture.id+".jsonl")
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(testjsonl.NewSessionBuilder().
+			AddClaudeUser("2026-01-01T00:00:00Z", fixture.content).String()), 0o644))
+	}
+	database, err := db.Open(filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {localRoot}},
+		Machine:   "local",
+	})
+	t.Cleanup(engine.Close)
+
+	order := []string{}
+	progressByContributor := map[string]Progress{}
+	labelProgress := func(name string) func(Progress) Progress {
+		return func(p Progress) Progress {
+			p.Detail = name
+			return p
+		}
+	}
+	onProgress := func(p Progress) {
+		if p.Detail == "A" || p.Detail == "B" {
+			progressByContributor[p.Detail] = p
+		}
+	}
+	ftsCalls := 0
+	stats, err := engine.resyncAllWithOptionsAndOperations(
+		context.Background(), onProgress, RebuildOptions{
+			Contributors: []RebuildContributor{
+				{
+					Name: "A",
+					Config: EngineConfig{
+						AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {rootA}},
+						Machine:   "A", IDPrefix: "A~", Ephemeral: true,
+					},
+					Progress: labelProgress("A"),
+					AfterSync: func(*Engine, *db.DB) error {
+						order = append(order, "A")
+						return nil
+					},
+				},
+				{
+					Name: "B",
+					Config: EngineConfig{
+						AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {rootB}},
+						Machine:   "B", IDPrefix: "B~", Ephemeral: true,
+					},
+					Progress: labelProgress("B"),
+					AfterSync: func(*Engine, *db.DB) error {
+						order = append(order, "B")
+						return nil
+					},
+				},
+			},
+		}, rebuildOperations{
+			rebuildFTS: func(database *db.DB) error {
+				ftsCalls++
+				return database.RebuildFTS()
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.False(t, stats.Aborted, "resync aborted: %+v", stats)
+	assert.Equal(t, []string{"A", "B"}, order)
+	assert.Equal(t, 3, stats.Synced)
+	assert.Equal(t, []string{"local", "A", "B"}, []string{
+		stats.RebuildPhases[0].Contributor,
+		stats.RebuildPhases[1].Contributor,
+		stats.RebuildPhases[2].Contributor,
+	})
+	assert.Equal(t, 1, ftsCalls, "FTS rebuilt once instead of per contributor")
+	assert.Equal(t, Progress{
+		Phase: PhaseDone, Detail: "A", Resync: true,
+		SessionsTotal: 2, SessionsDone: 2, MessagesIndexed: 2,
+	}, progressByContributor["A"])
+	assert.Equal(t, Progress{
+		Phase: PhaseDone, Detail: "B", Resync: true,
+		SessionsTotal: 3, SessionsDone: 3, MessagesIndexed: 3,
+	}, progressByContributor["B"])
+}
+
+func TestResyncContributorPostSwapReopenFailureReturnsCoordinatorError(t *testing.T) {
+	root := t.TempDir()
+	database, err := db.Open(filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	emitter := &fakeEmitter{}
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {root}},
+		Machine:   "local",
+		Emitter:   emitter,
+	})
+	t.Cleanup(engine.Close)
+	path := filepath.Join(root, "project", "session.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(testjsonl.NewSessionBuilder().
+		AddClaudeUser("2026-01-01T00:00:00Z", "post swap reopen fixture").String()), 0o644))
+
+	sentinel := errors.New("reopen sentinel")
+	stats, err := engine.resyncAllWithOptionsAndOperations(
+		context.Background(), nil, RebuildOptions{}, rebuildOperations{
+			rebuildFTS: productionRebuildOperations.rebuildFTS,
+			reopen:     func(*db.DB) error { return sentinel },
+		},
+	)
+	require.ErrorIs(t, err, sentinel)
+	assert.True(t, stats.Aborted)
+	assert.Contains(t, stats.Warnings,
+		"resync swap completed but reopening active database failed: reopen sentinel")
+	assert.Empty(t, emitter.got(), "failed reopen published a successful sync")
+	assert.True(t, engine.LastSyncStats().Aborted)
+
+	// The rename already completed. Restore the handle and prove the rebuilt
+	// file is now the active archive even though publication failed.
+	require.NoError(t, database.Reopen())
+	session, getErr := database.GetSession(context.Background(), "session")
+	require.NoError(t, getErr)
+	require.NotNil(t, session)
+}
+
+func TestResyncContributorFTSFailureAbortsAndCleansTempDB(t *testing.T) {
+	root := t.TempDir()
+	database, err := db.Open(filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {root}},
+		Machine:   "local",
+	})
+	t.Cleanup(engine.Close)
+	oldPath := filepath.Join(root, "old", "old.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(oldPath), 0o755))
+	require.NoError(t, os.WriteFile(oldPath, []byte(testjsonl.NewSessionBuilder().
+		AddClaudeUser("2026-01-01T00:00:00Z", "search survives failure").String()), 0o644))
+	require.Equal(t, 1, engine.SyncAll(context.Background(), nil).Synced)
+	require.NoError(t, os.Remove(oldPath))
+	newPath := filepath.Join(root, "new", "new.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(newPath), 0o755))
+	require.NoError(t, os.WriteFile(newPath, []byte(testjsonl.NewSessionBuilder().
+		AddClaudeUser("2026-01-01T00:00:01Z", "partial new data").String()), 0o644))
+
+	sentinel := errors.New("fts sentinel")
+	engine.syncMu.Lock()
+	stats, err := engine.resyncAllWithOptionsLocked(
+		context.Background(), nil, RebuildOptions{}, rebuildOperations{
+			rebuildFTS: func(*db.DB) error { return sentinel },
+		},
+	)
+	engine.syncMu.Unlock()
+	require.ErrorIs(t, err, sentinel)
+	assert.True(t, stats.Aborted)
+	page, searchErr := database.Search(context.Background(), db.SearchFilter{
+		Query: "search survives failure", Limit: 5,
+	})
+	require.NoError(t, searchErr)
+	require.Len(t, page.Results, 1)
+	assert.NoFileExists(t, database.Path()+resyncTempSuffix)
+	assert.NoFileExists(t, database.Path()+resyncTempSuffix+"-wal")
+	assert.NoFileExists(t, database.Path()+resyncTempSuffix+"-shm")
+}
+
+type blockingRebuildProvider struct {
+	parser.ProviderBase
+	started chan struct{}
+}
+
+func (p *blockingRebuildProvider) Discover(context.Context) ([]parser.SourceRef, error) {
+	return []parser.SourceRef{{
+		Provider: parser.AgentCowork, Key: "blocked-source",
+		DisplayPath: "blocked-source", FingerprintKey: "blocked-source",
+	}}, nil
+}
+
+func (p *blockingRebuildProvider) Fingerprint(
+	context.Context, parser.SourceRef,
+) (parser.SourceFingerprint, error) {
+	return parser.SourceFingerprint{Key: "blocked-source", Size: 1, MTimeNS: 1}, nil
+}
+
+func (p *blockingRebuildProvider) Parse(
+	ctx context.Context, _ parser.ParseRequest,
+) (parser.ParseOutcome, error) {
+	close(p.started)
+	<-ctx.Done()
+	return parser.ParseOutcome{}, ctx.Err()
+}
+
+type blockingRebuildFactory struct{ provider *blockingRebuildProvider }
+
+func (f blockingRebuildFactory) Definition() parser.AgentDef {
+	return f.provider.Definition()
+}
+
+func (f blockingRebuildFactory) Capabilities() parser.Capabilities {
+	return f.provider.Capabilities()
+}
+
+func (f blockingRebuildFactory) NewProvider(parser.ProviderConfig) parser.Provider {
+	return f.provider
+}
+
+type trackingRebuildProvider struct {
+	parser.ProviderBase
+	discoverCalls int
+}
+
+func (p *trackingRebuildProvider) Discover(context.Context) ([]parser.SourceRef, error) {
+	p.discoverCalls++
+	return nil, nil
+}
+
+func (p *trackingRebuildProvider) Parse(
+	context.Context, parser.ParseRequest,
+) (parser.ParseOutcome, error) {
+	return parser.ParseOutcome{}, nil
+}
+
+type trackingRebuildFactory struct{ provider *trackingRebuildProvider }
+
+func (f trackingRebuildFactory) Definition() parser.AgentDef {
+	return f.provider.Definition()
+}
+
+func (f trackingRebuildFactory) Capabilities() parser.Capabilities {
+	return f.provider.Capabilities()
+}
+
+func (f trackingRebuildFactory) NewProvider(parser.ProviderConfig) parser.Provider {
+	return f.provider
+}
+
+func TestResyncContributorCancellationPreservesArchiveAndCleansTempDB(t *testing.T) {
+	root := t.TempDir()
+	database, err := db.Open(filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {root}},
+		Machine:   "local",
+	})
+	t.Cleanup(engine.Close)
+	oldPath := filepath.Join(root, "old", "old.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(oldPath), 0o755))
+	require.NoError(t, os.WriteFile(oldPath, []byte(testjsonl.NewSessionBuilder().
+		AddClaudeUser("2026-01-01T00:00:00Z", "archive before cancel").String()), 0o644))
+	require.Equal(t, 1, engine.SyncAll(context.Background(), nil).Synced)
+	require.NoError(t, os.Remove(oldPath))
+
+	provider := &blockingRebuildProvider{
+		ProviderBase: parser.ProviderBase{
+			Def: parser.AgentDef{Type: parser.AgentCowork},
+			Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+				DiscoverSources: parser.CapabilitySupported,
+			}},
+		},
+		started: make(chan struct{}),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	firstHookCalls := 0
+	secondHookCalls := 0
+	secondProvider := &trackingRebuildProvider{ProviderBase: parser.ProviderBase{
+		Def: parser.AgentDef{Type: parser.AgentCowork},
+		Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+			DiscoverSources: parser.CapabilitySupported,
+		}},
+	}}
+	result := make(chan struct {
+		stats SyncStats
+		err   error
+	}, 1)
+	go func() {
+		stats, runErr := engine.ResyncAllWithOptions(ctx, nil, RebuildOptions{
+			Contributors: []RebuildContributor{
+				{
+					Name: "blocking",
+					Config: EngineConfig{
+						AgentDirs: map[parser.AgentType][]string{parser.AgentCowork: {root}},
+						Machine:   "blocking", Ephemeral: true,
+						ProviderFactories: []parser.ProviderFactory{
+							blockingRebuildFactory{provider: provider},
+						},
+						ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+							parser.AgentCowork: parser.ProviderMigrationProviderAuthoritative,
+						},
+					},
+					AfterSync: func(*Engine, *db.DB) error {
+						firstHookCalls++
+						return nil
+					},
+				},
+				{
+					Name: "later",
+					Config: EngineConfig{
+						AgentDirs: map[parser.AgentType][]string{parser.AgentCowork: {root}},
+						Machine:   "later", Ephemeral: true,
+						ProviderFactories: []parser.ProviderFactory{
+							trackingRebuildFactory{provider: secondProvider},
+						},
+						ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+							parser.AgentCowork: parser.ProviderMigrationProviderAuthoritative,
+						},
+					},
+					AfterSync: func(*Engine, *db.DB) error {
+						secondHookCalls++
+						return nil
+					},
+				},
+			},
+		})
+		result <- struct {
+			stats SyncStats
+			err   error
+		}{stats: stats, err: runErr}
+	}()
+
+	select {
+	case <-provider.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("contributor parse did not reach controlled boundary")
+	}
+	cancel()
+	select {
+	case got := <-result:
+		require.ErrorIs(t, got.err, context.Canceled)
+		assert.True(t, got.stats.Aborted)
+		assert.Zero(t, firstHookCalls, "AfterSync ran on incomplete contributor data")
+		assert.Zero(t, secondProvider.discoverCalls, "later contributor started after cancellation")
+		assert.Zero(t, secondHookCalls, "later contributor hook ran after cancellation")
+	case <-time.After(5 * time.Second):
+		t.Fatal("cancelled contributor rebuild did not return")
+	}
+
+	page, searchErr := database.Search(context.Background(), db.SearchFilter{
+		Query: "archive before cancel", Limit: 5,
+	})
+	require.NoError(t, searchErr)
+	require.Len(t, page.Results, 1)
+	assert.NoFileExists(t, database.Path()+resyncTempSuffix)
+	assert.NoFileExists(t, database.Path()+resyncTempSuffix+"-wal")
+	assert.NoFileExists(t, database.Path()+resyncTempSuffix+"-shm")
+}
+
+func TestResyncLocalCancellationPreventsContributors(t *testing.T) {
+	root := t.TempDir()
+	database, err := db.Open(filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	oldPath := filepath.Join(root, "old", "old.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(oldPath), 0o755))
+	require.NoError(t, os.WriteFile(oldPath, []byte(testjsonl.NewSessionBuilder().
+		AddClaudeUser("2026-01-01T00:00:00Z", "archive before local cancel").String()), 0o644))
+	seedEngine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {root}},
+		Machine:   "local",
+	})
+	require.Equal(t, 1, seedEngine.SyncAll(context.Background(), nil).Synced)
+	seedEngine.Close()
+	require.NoError(t, os.Remove(oldPath))
+
+	blocking := &blockingRebuildProvider{
+		ProviderBase: parser.ProviderBase{
+			Def: parser.AgentDef{Type: parser.AgentCowork},
+			Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+				DiscoverSources: parser.CapabilitySupported,
+			}},
+		},
+		started: make(chan struct{}),
+	}
+	later := &trackingRebuildProvider{ProviderBase: parser.ProviderBase{
+		Def: parser.AgentDef{Type: parser.AgentCowork},
+		Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+			DiscoverSources: parser.CapabilitySupported,
+		}},
+	}}
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentCowork: {root}},
+		Machine:   "local",
+		ProviderFactories: []parser.ProviderFactory{
+			blockingRebuildFactory{provider: blocking},
+		},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			parser.AgentCowork: parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan struct {
+		stats SyncStats
+		err   error
+	}, 1)
+	go func() {
+		stats, runErr := engine.ResyncAllWithOptions(ctx, nil, RebuildOptions{
+			Contributors: []RebuildContributor{{
+				Name: "later",
+				Config: EngineConfig{
+					AgentDirs: map[parser.AgentType][]string{parser.AgentCowork: {root}},
+					Machine:   "later", Ephemeral: true,
+					ProviderFactories: []parser.ProviderFactory{
+						trackingRebuildFactory{provider: later},
+					},
+					ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+						parser.AgentCowork: parser.ProviderMigrationProviderAuthoritative,
+					},
+				},
+			}},
+		})
+		result <- struct {
+			stats SyncStats
+			err   error
+		}{stats: stats, err: runErr}
+	}()
+	select {
+	case <-blocking.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("local parse did not reach controlled boundary")
+	}
+	cancel()
+	select {
+	case got := <-result:
+		require.ErrorIs(t, got.err, context.Canceled)
+		assert.True(t, got.stats.Aborted)
+		assert.Zero(t, later.discoverCalls)
+	case <-time.After(5 * time.Second):
+		t.Fatal("cancelled local rebuild did not return")
+	}
+	page, searchErr := database.Search(context.Background(), db.SearchFilter{
+		Query: "archive before local cancel", Limit: 5,
+	})
+	require.NoError(t, searchErr)
+	require.Len(t, page.Results, 1)
+	assert.NoFileExists(t, database.Path()+resyncTempSuffix)
+	assert.NoFileExists(t, database.Path()+resyncTempSuffix+"-wal")
+	assert.NoFileExists(t, database.Path()+resyncTempSuffix+"-shm")
+}
+
+type staticUsageRebuildProvider struct {
+	parser.ProviderBase
+	source parser.SourceRef
+	result parser.ParseResult
+}
+
+func (p *staticUsageRebuildProvider) Discover(context.Context) ([]parser.SourceRef, error) {
+	return []parser.SourceRef{p.source}, nil
+}
+
+func (p *staticUsageRebuildProvider) Fingerprint(
+	context.Context, parser.SourceRef,
+) (parser.SourceFingerprint, error) {
+	return parser.SourceFingerprint{Key: p.source.FingerprintKey, Size: 10, MTimeNS: 10}, nil
+}
+
+func (p *staticUsageRebuildProvider) Parse(
+	context.Context, parser.ParseRequest,
+) (parser.ParseOutcome, error) {
+	return parser.ParseOutcome{
+		Results:           []parser.ParseResultOutcome{{Result: p.result}},
+		ResultSetComplete: true,
+	}, nil
+}
+
+type staticUsageRebuildFactory struct{ provider *staticUsageRebuildProvider }
+
+func (f staticUsageRebuildFactory) Definition() parser.AgentDef {
+	return f.provider.Definition()
+}
+
+func (f staticUsageRebuildFactory) Capabilities() parser.Capabilities {
+	return f.provider.Capabilities()
+}
+
+func (f staticUsageRebuildFactory) NewProvider(parser.ProviderConfig) parser.Provider {
+	return f.provider
+}
+
+func newStaticUsageRebuildProvider(id, path string, input, output int) *staticUsageRebuildProvider {
+	started := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	return &staticUsageRebuildProvider{
+		ProviderBase: parser.ProviderBase{
+			Def: parser.AgentDef{Type: parser.AgentCowork, FileBased: true},
+			Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+				DiscoverSources:      parser.CapabilitySupported,
+				CompositeFingerprint: parser.CapabilitySupported,
+			}},
+		},
+		source: parser.SourceRef{
+			Provider: parser.AgentCowork, Key: path, DisplayPath: path, FingerprintKey: path,
+		},
+		result: parser.ParseResult{
+			Session: parser.ParsedSession{
+				ID: id, Project: "usage", Machine: "fixture", Agent: parser.AgentCowork,
+				StartedAt: started, EndedAt: started, FirstMessage: "usage fixture",
+				MessageCount: 1, UserMessageCount: 1,
+				File: parser.FileInfo{Path: path, Size: 10, Mtime: 10},
+			},
+			Messages: []parser.ParsedMessage{{
+				Ordinal: 0, Role: parser.RoleUser, Content: "usage fixture", Timestamp: started,
+			}},
+			UsageEvents: []parser.ParsedUsageEvent{{
+				SessionID: id, Source: "fixture", Model: "fixture-model",
+				InputTokens: input, OutputTokens: output,
+				OccurredAt: "2026-01-01T00:00:00Z", DedupKey: id + "-usage",
+			}},
+		},
+	}
+}
+
+func TestResyncContributorBatchFailureAbortsAndCleansTempDB(t *testing.T) {
+	root := t.TempDir()
+	database, err := db.Open(filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {root}},
+		Machine:   "local",
+	})
+	t.Cleanup(engine.Close)
+	oldPath := filepath.Join(root, "old", "old.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(oldPath), 0o755))
+	require.NoError(t, os.WriteFile(oldPath, []byte(testjsonl.NewSessionBuilder().
+		AddClaudeUser("2026-01-01T00:00:00Z", "archive before batch failure").String()), 0o644))
+	require.Equal(t, 1, engine.SyncAll(context.Background(), nil).Synced)
+	require.NoError(t, os.Remove(oldPath))
+
+	bad := newStaticUsageRebuildProvider("batch-rejected", "bad-source", 1, 1)
+	bad.result.UsageEvents = nil
+	bad.result.Messages = append(bad.result.Messages, parser.ParsedMessage{
+		Ordinal: 0, Role: parser.RoleAssistant, Content: "duplicate ordinal",
+		Timestamp: time.Date(2026, 1, 1, 0, 0, 1, 0, time.UTC),
+	})
+	stats, err := engine.ResyncAllWithOptions(context.Background(), nil, RebuildOptions{
+		Contributors: []RebuildContributor{{
+			Name: "bad-batch",
+			Config: EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{parser.AgentCowork: {"bad-root"}},
+				Machine:   "bad-batch", Ephemeral: true,
+				ProviderFactories: []parser.ProviderFactory{
+					staticUsageRebuildFactory{provider: bad},
+				},
+				ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+					parser.AgentCowork: parser.ProviderMigrationProviderAuthoritative,
+				},
+			},
+		}},
+	})
+	require.NoError(t, err)
+	assert.True(t, stats.Aborted)
+	assert.Equal(t, 1, stats.Failed)
+	page, searchErr := database.Search(context.Background(), db.SearchFilter{
+		Query: "archive before batch failure", Limit: 5,
+	})
+	require.NoError(t, searchErr)
+	require.Len(t, page.Results, 1)
+	assert.NoFileExists(t, database.Path()+resyncTempSuffix)
+	assert.NoFileExists(t, database.Path()+resyncTempSuffix+"-wal")
+	assert.NoFileExists(t, database.Path()+resyncTempSuffix+"-shm")
+}
+
+type malformedRebuildProvider struct{ parser.ProviderBase }
+
+func (p *malformedRebuildProvider) Discover(context.Context) ([]parser.SourceRef, error) {
+	out := make([]parser.SourceRef, 3)
+	for i := range out {
+		key := fmt.Sprintf("malformed-%d.jsonl", i)
+		out[i] = parser.SourceRef{
+			Provider: parser.AgentCowork, Key: key, DisplayPath: key, FingerprintKey: key,
+		}
+	}
+	return out, nil
+}
+
+func (p *malformedRebuildProvider) Fingerprint(
+	_ context.Context, source parser.SourceRef,
+) (parser.SourceFingerprint, error) {
+	return parser.SourceFingerprint{Key: source.FingerprintKey, Size: 8, MTimeNS: 10}, nil
+}
+
+func (p *malformedRebuildProvider) Parse(
+	_ context.Context, request parser.ParseRequest,
+) (parser.ParseOutcome, error) {
+	return parser.ParseOutcome{}, fmt.Errorf("malformed fixture %s", request.Source.Key)
+}
+
+type malformedRebuildFactory struct{ provider *malformedRebuildProvider }
+
+func (f malformedRebuildFactory) Definition() parser.AgentDef {
+	return f.provider.Definition()
+}
+
+func (f malformedRebuildFactory) Capabilities() parser.Capabilities {
+	return f.provider.Capabilities()
+}
+
+func (f malformedRebuildFactory) NewProvider(parser.ProviderConfig) parser.Provider {
+	return f.provider
+}
+
+func TestResyncContributorParserFailuresAbortAndCleanTempDB(t *testing.T) {
+	root := t.TempDir()
+	database, err := db.Open(filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {root}},
+		Machine:   "local",
+	})
+	t.Cleanup(engine.Close)
+	oldPath := filepath.Join(root, "old", "old.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(oldPath), 0o755))
+	require.NoError(t, os.WriteFile(oldPath, []byte(testjsonl.NewSessionBuilder().
+		AddClaudeUser("2026-01-01T00:00:00Z", "archive before parser failures").String()), 0o644))
+	require.Equal(t, 1, engine.SyncAll(context.Background(), nil).Synced)
+	require.NoError(t, os.Remove(oldPath))
+	provider := &malformedRebuildProvider{ProviderBase: parser.ProviderBase{
+		Def: parser.AgentDef{Type: parser.AgentCowork, FileBased: true},
+		Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+			DiscoverSources:      parser.CapabilitySupported,
+			CompositeFingerprint: parser.CapabilitySupported,
+		}},
+	}}
+
+	stats, err := engine.ResyncAllWithOptions(context.Background(), nil, RebuildOptions{
+		Contributors: []RebuildContributor{{
+			Name: "malformed",
+			Config: EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{parser.AgentCowork: {"malformed-root"}},
+				Machine:   "malformed", Ephemeral: true,
+				ProviderFactories: []parser.ProviderFactory{
+					malformedRebuildFactory{provider: provider},
+				},
+				ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+					parser.AgentCowork: parser.ProviderMigrationProviderAuthoritative,
+				},
+			},
+		}},
+	})
+	require.NoError(t, err)
+	assert.True(t, stats.Aborted)
+	assert.Equal(t, 3, stats.Failed)
+	assert.Equal(t, 3, stats.TotalSessions)
+	page, searchErr := database.Search(context.Background(), db.SearchFilter{
+		Query: "archive before parser failures", Limit: 5,
+	})
+	require.NoError(t, searchErr)
+	require.Len(t, page.Results, 1)
+	assert.NoFileExists(t, database.Path()+resyncTempSuffix)
+	assert.NoFileExists(t, database.Path()+resyncTempSuffix+"-wal")
+	assert.NoFileExists(t, database.Path()+resyncTempSuffix+"-shm")
+}

--- a/internal/sync/rebuild_contributor_test.go
+++ b/internal/sync/rebuild_contributor_test.go
@@ -159,6 +159,49 @@ func TestResyncContributorsRunInOrderWithCumulativeProgress(t *testing.T) {
 	}, progressByContributor["B"])
 }
 
+func TestResyncAbortsWhenContributorLosesHistoricalSource(t *testing.T) {
+	localRoot := t.TempDir()
+	remoteRoot := t.TempDir()
+	writeSession := func(root, project, name, content string) string {
+		path := filepath.Join(root, project, name+".jsonl")
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(testjsonl.NewSessionBuilder().
+			AddClaudeUser("2026-01-01T00:00:00Z", content).String()), 0o644))
+		return path
+	}
+	writeSession(localRoot, "local", "local", "local source")
+	remotePath := writeSession(remoteRoot, "remote", "remote", "remote source")
+	database, err := db.Open(filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {localRoot}},
+		Machine:   "local",
+	})
+	t.Cleanup(engine.Close)
+	options := RebuildOptions{Contributors: []RebuildContributor{{
+		Name: "remote",
+		Config: EngineConfig{
+			AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {remoteRoot}},
+			Machine:   "remote", IDPrefix: "remote~", Ephemeral: true,
+		},
+	}}}
+
+	initial, err := engine.ResyncAllWithOptions(context.Background(), nil, options)
+	require.NoError(t, err)
+	require.False(t, initial.Aborted)
+	require.NoError(t, os.Remove(remotePath))
+
+	stats, err := engine.ResyncAllWithOptions(context.Background(), nil, options)
+
+	require.NoError(t, err)
+	assert.True(t, stats.Aborted,
+		"a healthy local pass must not mask an empty historical contributor")
+	remote, err := database.GetSession(context.Background(), "remote~remote")
+	require.NoError(t, err)
+	assert.NotNil(t, remote, "aborted rebuild must preserve the active archive")
+}
+
 func TestResyncContributorPostSwapReopenFailureReturnsCoordinatorError(t *testing.T) {
 	root := t.TempDir()
 	database, err := db.Open(filepath.Join(t.TempDir(), "archive.db"))


### PR DESCRIPTION
Large configured HTTP remotes made a full sync disproportionately expensive because unchanged source archives were retransferred and remote sessions were written through the active database with live FTS maintenance. That made remote processing several times slower than reparsing an equivalent local corpus.

This separates mirror transfer decisions from full reparsing. HTTP mirrors are reconciled before database work, then local sources and prepared HTTP remotes share one batched temporary-database rebuild with FTS rebuilt once and the result swapped atomically. Rebuild safety is evaluated independently for local and remote contributors, and the aggregate guard includes only participating sources so deferred SSH history cannot block the swap.

Local ingestion now identifies sessions with the operating-system hostname instead of the ambiguous `local` label. Contributor safety counts are also scoped by their remote ID namespace, so a collector and remote with the same hostname remain independent. The data-version bump reparses existing source-backed sessions into the hostname identity while preserving orphaned archive history.

Preparation, contributor, cancellation, and rebuild failures leave the active archive intact. HTTP sync entry points use one cleanup-before-engine lock order, and failed temporary-resource cleanup retains every distinct owner for retry—including joined failures and extraction setup errors—until all resources release. Retryable per-host cleanup remains attributed as one sanitized remote failure rather than being reported as a local sync failure.

Hashed Claude and Codex skip-cache entries now use a source-family index built when cache state is loaded. Watcher replacement is constant work regardless of archive size, remote cache injection scales with the incoming batch, and ambiguous legacy duplicate families reparse once instead of retaining an arbitrary stale key.

Configured SSH-only syncs retain the legacy aborted-resync fallback, while mixed HTTP and SSH syncs run SSH imports after a successful atomic swap. Remote-only syncs retain their active-archive behavior.

Collectors remain compatible with older HTTP-capable spokes through the legacy full-archive endpoint. A collector-only upgrade gains the bulk-ingest improvement; upgrading spokes additionally enables manifest-delta transfer. The durable remote-sync documentation describes that rollout boundary and the manual repair procedure for same-stat mirror corruption.

The branch also records the reviewed follow-up design for daemon startup readiness, startup version reporting, and host-local contributor progress; those UX changes are not implemented here.

Closes #1094