### PR TITLE
feat(cli): add stable version JSON contract

### DIFF
--- a/cmd/agentsview/cli.go
+++ b/cmd/agentsview/cli.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -817,16 +818,36 @@ func newDuckDBQuackCommand() *cobra.Command {
 }
 
 func newVersionCommand() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:          "version",
 		Short:        "Show version information",
 		GroupID:      groupMeta,
 		SilenceUsage: true,
 		Args:         cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if outputFormat(cmd) == "json" {
+				return json.NewEncoder(cmd.OutOrStdout()).Encode(versionJSON{
+					SchemaVersion: 1,
+					Name:          "agentsview",
+					Version:       version,
+					Commit:        commit,
+					BuildDate:     buildDate,
+				})
+			}
 			printVersion(cmd.OutOrStdout())
+			return nil
 		},
 	}
+	registerFormatFlags(cmd.Flags())
+	return cmd
+}
+
+type versionJSON struct {
+	SchemaVersion int    `json:"schema_version"`
+	Name          string `json:"name"`
+	Version       string `json:"version"`
+	Commit        string `json:"commit"`
+	BuildDate     string `json:"build_date"`
 }
 
 func printVersion(w io.Writer) {

--- a/cmd/agentsview/cli_test.go
+++ b/cmd/agentsview/cli_test.go
@@ -245,6 +245,37 @@ func TestRootVersionFlag(t *testing.T) {
 	assert.Contains(t, got, "agentsview ", "version output = %q", got)
 }
 
+func TestVersionJSONContractDoesNotRequireRuntimeState(t *testing.T) {
+	oldVersion, oldCommit, oldBuildDate := version, commit, buildDate
+	t.Cleanup(func() {
+		version, commit, buildDate = oldVersion, oldCommit, oldBuildDate
+	})
+	version = "v1.2.3"
+	commit = "abc1234"
+	buildDate = "2026-07-12T14:30:00Z"
+
+	dataDirFile := filepath.Join(t.TempDir(), "not-a-directory")
+	require.NoError(t, os.WriteFile(dataDirFile, []byte("occupied"), 0o600))
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDirFile)
+
+	got, err := executeCommand(newRootCommand(), "version", "--json")
+	require.NoError(t, err, "Execute")
+
+	var doc struct {
+		SchemaVersion int    `json:"schema_version"`
+		Name          string `json:"name"`
+		Version       string `json:"version"`
+		Commit        string `json:"commit"`
+		BuildDate     string `json:"build_date"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(got), &doc))
+	assert.Equal(t, 1, doc.SchemaVersion)
+	assert.Equal(t, "agentsview", doc.Name)
+	assert.Equal(t, "v1.2.3", doc.Version)
+	assert.Equal(t, "abc1234", doc.Commit)
+	assert.Equal(t, "2026-07-12T14:30:00Z", doc.BuildDate)
+}
+
 func TestNormalizeLegacyLongFlags(t *testing.T) {
 	flags := collectLongFlags(newRootCommand())
 	got, rewrites := normalizeLegacyLongFlags([]string{

--- a/cmd/agentsview/output_format_test.go
+++ b/cmd/agentsview/output_format_test.go
@@ -46,6 +46,7 @@ func TestOutputFormat_RejectsInvalid(t *testing.T) {
 // --format and the --json alias. token-use (deprecated, JSON-only) and
 // openapi (spec-only) are deliberately excluded.
 var machineOutputCommandPaths = [][]string{
+	{"version"},
 	{"projects"},
 	{"health"},
 	{"usage", "daily"},

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -306,15 +306,44 @@ ______________________________________________________________________
 
 ### `agentsview version`
 
-Print the version, git commit, and build date.
+Print the version, git commit, and build date. Use `--json` for a stable,
+machine-readable response that does not require a running daemon, configuration,
+or database.
 
 ```bash
 agentsview version
+agentsview version --json
+agentsview version --format json
 ```
 
 ```
 agentsview 0.23.0 (commit d49f1a9, built 2026-04-19)
 ```
+
+```json
+{
+  "schema_version": 1,
+  "name": "agentsview",
+  "version": "0.23.0",
+  "commit": "d49f1a9",
+  "build_date": "2026-04-19T12:00:00Z"
+}
+```
+
+The JSON contract uses these fields:
+
+| Field            | Type    | Meaning                                      |
+| ---------------- | ------- | -------------------------------------------- |
+| `schema_version` | integer | Version of this JSON contract; currently `1` |
+| `name`           | string  | Canonical tool name, always `agentsview`     |
+| `version`        | string  | Build version                                |
+| `commit`         | string  | Source commit recorded at build time         |
+| `build_date`     | string  | UTC build timestamp, or an empty string       |
+
+Consumers should require the expected `schema_version` and ignore unknown
+fields. Adding an optional field does not require a schema bump; removing or
+renaming a field, changing a field's type or meaning, or making a previously
+valid response invalid does.
 
 ______________________________________________________________________
 


### PR DESCRIPTION
Adds a versioned machine-readable identity response that succeeds without daemon, configuration, or database state.

The existing plaintext `agentsview --version` and `agentsview version` surfaces remain unchanged for compatibility. Machine consumers can opt into the shared CLI output convention through either `--format json` or its `--json` shorthand, require the documented schema version, and ignore future optional fields.