### PR TITLE
fix(ci): retry transient SSH image builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,7 @@ jobs:
       - name: Run shell script tests
         run: |
           bash scripts/install_test.sh
+          bash scripts/retry_test.sh
           bash scripts/check_desktop_release_health_test.sh
           bash scripts/check_desktop_release_health_from_event_test.sh
           bash desktop/scripts/test-repair-appimage-diricon.sh
@@ -280,7 +281,7 @@ jobs:
           TEST_PG_URL: postgres://agentsview_test:agentsview_test_password@localhost:5433/agentsview_test?sslmode=disable
 
       - name: Build SSH test container
-        run: docker build -t agentsview-sshd -f testdata/ssh/Dockerfile .
+        run: bash scripts/retry.sh 3 10 docker build -t agentsview-sshd -f testdata/ssh/Dockerfile .
 
       - name: Start SSH test container
         run: |

--- a/docs/superpowers/plans/2026-07-12-ci-docker-build-retry.md
+++ b/docs/superpowers/plans/2026-07-12-ci-docker-build-retry.md
@@ -1,0 +1,114 @@
+# CI Docker Build Retry Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development
+> (if subagents available) or superpowers:executing-plans to implement this
+> plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep transient Docker Hub failures from discarding an otherwise
+successful integration run while preserving prompt failure for persistent
+errors.
+
+**Architecture:** Add one generic, bounded shell retry helper and exercise it
+through real subprocesses in a behavioral shell test. Route only the SSH test
+image build through the helper and add the test to the existing scripts CI job.
+
+**Tech Stack:** Bash, GitHub Actions, Docker CLI
+
+______________________________________________________________________
+
+### Task 1: Specify retry behavior with an executable shell test
+
+**Files:**
+
+- Create: `scripts/retry_test.sh`
+
+- [ ] **Step 1: Write the failing behavioral test**
+
+    Create a temporary fake command that records its arguments and attempt count,
+    fails twice, and succeeds on its third invocation. Assert that
+    `scripts/retry.sh 3 0 <fake-command> "argument with spaces"` succeeds after
+    exactly three attempts and forwards the argument unchanged.
+
+    Put a fake `sleep` on `PATH`, invoke the helper with a base delay of 10
+    seconds, and assert that the two waits receive literal durations `10` and
+    `20` without actually pausing the test.
+
+    Add a second fake command that always exits 17. Assert that the helper invokes
+    it exactly three times and returns exit status 17.
+
+- [ ] **Step 2: Run the test to verify it fails for the missing helper**
+
+    Run: `bash scripts/retry_test.sh`
+
+    Expected: FAIL because `scripts/retry.sh` does not exist.
+
+### Task 2: Implement the bounded retry helper
+
+**Files:**
+
+- Create: `scripts/retry.sh`
+
+- Test: `scripts/retry_test.sh`
+
+- [ ] **Step 1: Add the minimal retry loop**
+
+    Accept a maximum-attempt count and delay in seconds followed by the command
+    and its arguments. Run the command until it succeeds or reaches the limit,
+    sleep for `base delay * failed-attempt number` between failures, emit a
+    concise retry message to standard error, and return the final command's exit
+    status when exhausted.
+
+- [ ] **Step 2: Run the behavioral test to verify it passes**
+
+    Run: `bash scripts/retry_test.sh`
+
+    Expected: PASS with the success message from the test script.
+
+### Task 3: Adopt the helper in CI
+
+**Files:**
+
+- Modify: `.github/workflows/ci.yml:117-123`
+
+- Modify: `.github/workflows/ci.yml:282-283`
+
+- [ ] **Step 1: Add the retry test to the scripts job**
+
+    Run `bash scripts/retry_test.sh` alongside the existing shell-script tests.
+
+- [ ] **Step 2: Wrap the SSH image build**
+
+    Replace the direct build invocation with
+    `bash scripts/retry.sh 3 10 docker build -t agentsview-sshd -f testdata/ssh/Dockerfile .`.
+
+- [ ] **Step 3: Run focused validation**
+
+    Run: `bash scripts/retry_test.sh`
+
+    Run: `actionlint .github/workflows/ci.yml` when `actionlint` is available.
+
+    Run: `git diff --check`
+
+    Expected: all commands exit successfully.
+
+### Task 4: Publish the change
+
+**Files:**
+
+- Commit the design, plan, helper, test, and workflow changes.
+
+- [ ] **Step 1: Review and scrub the outgoing diff and messages**
+
+    Verify that no private paths, identities, hostnames, or unrelated changes are
+    present.
+
+- [ ] **Step 2: Commit the implementation**
+
+    Use a focused conventional commit explaining why transient registry
+    availability should not invalidate successful integration work.
+
+- [ ] **Step 3: Push and open a pull request**
+
+    As explicitly requested by the user, push the current feature branch and open
+    a rationale-first PR whose description is a summary only, without a
+    test-plan section or checklist.

--- a/docs/superpowers/specs/2026-07-12-ci-docker-build-retry-design.md
+++ b/docs/superpowers/specs/2026-07-12-ci-docker-build-retry-design.md
@@ -1,0 +1,34 @@
+# CI Docker Build Retry Design
+
+## Problem
+
+The integration job builds an SSH test image from Docker Hub after the
+PostgreSQL tests complete. A transient Docker Hub authentication or registry
+failure currently fails the entire job immediately, even when a subsequent
+attempt would succeed.
+
+## Design
+
+Add a small shell helper that runs an arbitrary command up to a fixed number of
+attempts. It will return immediately when the command succeeds, wait with a
+short linear backoff between failures, and return the final command's exit
+status after the last attempt.
+
+The integration workflow will invoke the SSH image build through this helper
+with three total attempts. Retries will remain bounded so persistent Dockerfile,
+dependency, or registry failures still fail CI promptly.
+
+## Testing
+
+A behavioral shell test will run the helper against controlled fake commands. It
+will verify that a command which fails twice and then succeeds is attempted
+three times, that arguments are forwarded unchanged, and that a command which
+never succeeds stops after the configured limit and preserves its exit status.
+The existing shell-script CI job will run this test.
+
+## Tradeoffs
+
+Retrying every Docker build failure may add a short delay for deterministic
+build errors. Restricting retries to specific error text would be brittle
+because Docker and registry failure messages vary, so bounded unconditional
+retries provide the simpler and more reliable policy.

--- a/scripts/retry.sh
+++ b/scripts/retry.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -u
 
+usage() {
+    echo "usage: retry.sh <max-attempts> <base-delay-seconds> <command> [args...]" >&2
+    exit 2
+}
+
+if [ "$#" -lt 3 ] || ! [[ "$1" =~ ^[1-9][0-9]*$ ]] || \
+    ! [[ "$2" =~ ^[0-9]+$ ]]; then
+    usage
+fi
+
 max_attempts="$1"
 base_delay="$2"
 shift 2

--- a/scripts/retry.sh
+++ b/scripts/retry.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -u
+
+max_attempts="$1"
+base_delay="$2"
+shift 2
+
+attempt=1
+while true; do
+    "$@"
+    status=$?
+    if [ "$status" -eq 0 ]; then
+        exit 0
+    fi
+    if [ "$attempt" -ge "$max_attempts" ]; then
+        exit "$status"
+    fi
+
+    delay=$((base_delay * attempt))
+    printf 'command failed with status %s; retrying in %s seconds\n' \
+        "$status" "$delay" >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/scripts/retry_test.sh
+++ b/scripts/retry_test.sh
@@ -37,7 +37,48 @@ cat > "$TMP_DIR/sleep" <<'EOF'
 printf '%s\n' "$@" >> "$SLEEP_FILE"
 EOF
 
-chmod +x "$TMP_DIR/eventually_succeeds" "$TMP_DIR/always_fails" "$TMP_DIR/sleep"
+cat > "$TMP_DIR/invalid_command" <<'EOF'
+#!/bin/bash
+touch "$INVALID_COMMAND_FILE"
+EOF
+
+chmod +x "$TMP_DIR/eventually_succeeds" "$TMP_DIR/always_fails" \
+    "$TMP_DIR/invalid_command" "$TMP_DIR/sleep"
+
+export INVALID_COMMAND_FILE="$TMP_DIR/invalid-command-ran"
+EXPECTED_USAGE="usage: retry.sh <max-attempts> <base-delay-seconds> <command> [args...]"
+
+assert_invalid() {
+    local description="$1"
+    shift
+    local output status
+
+    rm -f "$INVALID_COMMAND_FILE"
+    set +e
+    output="$(bash "$SCRIPT_DIR/retry.sh" "$@" 2>&1)"
+    status=$?
+    set -e
+
+    if [ "$status" -ne 2 ]; then
+        printf 'FAIL: %s returned %s instead of 2\n' "$description" "$status" >&2
+        return 1
+    fi
+    if [ "$output" != "$EXPECTED_USAGE" ]; then
+        printf 'FAIL: %s emitted unexpected error: %s\n' "$description" "$output" >&2
+        return 1
+    fi
+    if [ -e "$INVALID_COMMAND_FILE" ]; then
+        printf 'FAIL: %s ran the wrapped command\n' "$description" >&2
+        return 1
+    fi
+}
+
+assert_invalid "nonnumeric max attempts" nope 0 "$TMP_DIR/invalid_command"
+assert_invalid "zero max attempts" 0 0 "$TMP_DIR/invalid_command"
+assert_invalid "negative max attempts" -1 0 "$TMP_DIR/invalid_command"
+assert_invalid "nonnumeric base delay" 3 nope "$TMP_DIR/invalid_command"
+assert_invalid "negative base delay" 3 -1 "$TMP_DIR/invalid_command"
+assert_invalid "missing command" 3 0
 
 PATH="$TMP_DIR:$PATH" bash "$SCRIPT_DIR/retry.sh" \
     3 10 "$TMP_DIR/eventually_succeeds" "argument with spaces"

--- a/scripts/retry_test.sh
+++ b/scripts/retry_test.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+export ATTEMPT_FILE="$TMP_DIR/attempts"
+export ARGUMENT_FILE="$TMP_DIR/arguments"
+export SLEEP_FILE="$TMP_DIR/sleeps"
+
+cat > "$TMP_DIR/eventually_succeeds" <<'EOF'
+#!/bin/bash
+attempt=0
+if [ -f "$ATTEMPT_FILE" ]; then
+    attempt="$(cat "$ATTEMPT_FILE")"
+fi
+attempt=$((attempt + 1))
+printf '%s\n' "$attempt" > "$ATTEMPT_FILE"
+printf '%s\n' "$#" >> "$ARGUMENT_FILE"
+printf '<%s>\n' "$@" >> "$ARGUMENT_FILE"
+[ "$attempt" -ge 3 ]
+EOF
+
+cat > "$TMP_DIR/always_fails" <<'EOF'
+#!/bin/bash
+attempt=0
+if [ -f "$ATTEMPT_FILE" ]; then
+    attempt="$(cat "$ATTEMPT_FILE")"
+fi
+printf '%s\n' "$((attempt + 1))" > "$ATTEMPT_FILE"
+exit 17
+EOF
+
+cat > "$TMP_DIR/sleep" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$@" >> "$SLEEP_FILE"
+EOF
+
+chmod +x "$TMP_DIR/eventually_succeeds" "$TMP_DIR/always_fails" "$TMP_DIR/sleep"
+
+PATH="$TMP_DIR:$PATH" bash "$SCRIPT_DIR/retry.sh" \
+    3 10 "$TMP_DIR/eventually_succeeds" "argument with spaces"
+
+[ "$(cat "$ATTEMPT_FILE")" = "3" ]
+[ "$(cat "$ARGUMENT_FILE")" = $'1\n<argument with spaces>\n1\n<argument with spaces>\n1\n<argument with spaces>' ]
+[ "$(cat "$SLEEP_FILE")" = $'10\n20' ]
+
+rm -f "$ATTEMPT_FILE" "$SLEEP_FILE"
+set +e
+PATH="$TMP_DIR:$PATH" bash "$SCRIPT_DIR/retry.sh" \
+    3 0 "$TMP_DIR/always_fails"
+status=$?
+set -e
+
+[ "$status" -eq 17 ]
+[ "$(cat "$ATTEMPT_FILE")" = "3" ]
+
+echo "retry tests passed"


### PR DESCRIPTION
Transient Docker Hub authentication or registry outages can currently discard an integration run after the PostgreSQL suite has already passed. That makes external availability indistinguishable from a product or test regression.

Route the SSH test image build through a bounded three-attempt retry with linear backoff while preserving the final failure status. The helper is behaviorally covered for recovery, exhaustion, argument forwarding, backoff timing, and invalid configuration. Persistent build errors remain visible after at most 30 seconds of additional waiting.