### PR TITLE
fix(server): prevent stale SPA asset fallbacks

### DIFF
--- a/docs/superpowers/plans/2026-07-12-spa-cache-busting.md
+++ b/docs/superpowers/plans/2026-07-12-spa-cache-busting.md
@@ -1,0 +1,61 @@
+# SPA Cache Busting Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development
+> (if subagents available) or superpowers:executing-plans to implement this
+> plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent stale SPA entry documents from producing broken mixed frontend
+assets after a binary upgrade.
+
+**Architecture:** Keep the existing embedded filesystem and SPA fallback, but
+classify entry HTML, fingerprinted assets, and client-side routes before serving
+them. Protect the browser-visible HTTP contract with in-process handler tests
+using a literal in-memory filesystem.
+
+**Tech Stack:** Go, `net/http`, `httptest`, `testing/fstest`, Testify
+
+______________________________________________________________________
+
+### Task 1: Protect the SPA response contract
+
+**Files:**
+
+- Create: `internal/server/spa_test.go`
+
+- Modify: `internal/server/server.go`
+
+- [ ] **Step 1: Write failing HTTP tests**
+
+    Add tests which request `/`, an existing fingerprinted JavaScript asset, and a
+    missing JavaScript asset. Assert literal cache headers, status codes,
+    content types, and bodies. Keep a client-side route assertion to prove the
+    fallback remains intact.
+
+- [ ] **Step 2: Verify the tests fail for the missing behavior**
+
+    Run `go test -tags fts5 ./internal/server -run 'TestSPA' -count=1` and confirm
+    failures show absent cache headers and a 200 HTML response for the missing
+    asset.
+
+- [ ] **Step 3: Implement the response classification**
+
+    Set `Cache-Control: no-cache` before serving entry HTML, set the immutable
+    policy for existing `/assets/` paths, and call `http.NotFound` when an
+    `/assets/` path is absent. Preserve client-route and base-path fallbacks.
+
+- [ ] **Step 4: Verify the targeted behavior passes**
+
+    Run `go test -tags fts5 ./internal/server -run 'TestSPA' -count=1` and confirm
+    all SPA tests pass.
+
+- [ ] **Step 5: Verify repository checks**
+
+    Run `go fmt ./...`, `go vet ./...`, `make test-short`, and a production build.
+    Start the built binary against an isolated temporary data directory and use
+    `curl` to observe the entry cache header and a missing asset's 404 response.
+
+- [ ] **Step 6: Publish the focused change**
+
+    Review and scrub the diff and publication text, commit the focused change,
+    push `fix/spa-cache-busting`, and open a pull request with a rationale-first
+    summary.

--- a/docs/superpowers/specs/2026-07-12-spa-cache-busting-design.md
+++ b/docs/superpowers/specs/2026-07-12-spa-cache-busting-design.md
@@ -1,0 +1,33 @@
+# SPA Cache Busting Design
+
+## Problem
+
+Browsers can retain an old SPA entry document after the embedded frontend is
+replaced. The stale document requests an obsolete fingerprinted JavaScript or
+CSS asset. The server currently treats that missing asset as a client-side route
+and returns `index.html` with status 200, so the browser receives HTML where it
+expected JavaScript or CSS. A fresh browser profile avoids the stale entry and
+hides the failure.
+
+## Design
+
+Keep SPA routing behavior while making cache intent and asset failures
+unambiguous:
+
+- Serve `index.html`, including base-path-injected and client-route fallback
+  responses, with `Cache-Control: no-cache` so browsers revalidate it.
+- Serve existing files below `/assets/` with
+  `Cache-Control: public, max-age=31536000, immutable`. Vite fingerprints
+  these filenames, so their contents do not change at a stable URL.
+- Return status 404 for missing files below `/assets/` instead of serving the
+  SPA entry document. Other missing paths remain client-side route fallbacks.
+
+The implementation remains in the existing SPA handler. It does not change the
+frontend build, generated assets, or component rendering.
+
+## Verification
+
+HTTP-level Go tests will use a small in-memory filesystem and assert the status,
+body, content type, and cache headers visible to a browser. Tests will cover the
+entry document, a fingerprinted asset, a missing asset, and the existing
+client-route fallback behavior.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -354,6 +354,13 @@ func (s *Server) handleSPA(w http.ResponseWriter, r *http.Request) {
 	f, err := s.spaFS.Open(path)
 	if err == nil {
 		f.Close()
+		if path == "index.html" {
+			w.Header().Set("Cache-Control", "no-cache")
+		}
+		if strings.HasPrefix(path, "assets/") {
+			w.Header().Set("Cache-Control",
+				"public, max-age=31536000, immutable")
+		}
 		// For index.html with a base path, inject <base href>.
 		if s.basePath != "" && path == "index.html" {
 			s.serveIndexWithBase(w, r)
@@ -363,7 +370,16 @@ func (s *Server) handleSPA(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Fingerprinted frontend assets are files, not client-side routes.
+	// Returning index.html here disguises stale asset URLs as successful
+	// JavaScript or CSS responses after an upgrade.
+	if strings.HasPrefix(path, "assets/") {
+		http.NotFound(w, r)
+		return
+	}
+
 	// SPA fallback: serve index.html for all routes
+	w.Header().Set("Cache-Control", "no-cache")
 	if s.basePath != "" {
 		s.serveIndexWithBase(w, r)
 		return

--- a/internal/server/spa_test.go
+++ b/internal/server/spa_test.go
@@ -53,8 +53,6 @@ func TestSPAFingerprintedAssetIsImmutable(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "public, max-age=31536000, immutable",
 		w.Header().Get("Cache-Control"))
-	assert.Equal(t, "text/javascript; charset=utf-8",
-		w.Header().Get("Content-Type"))
 	assert.Equal(t, "console.log('app');", w.Body.String())
 }
 

--- a/internal/server/spa_test.go
+++ b/internal/server/spa_test.go
@@ -1,0 +1,86 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testSPAIndex = "<!doctype html><html><head></head><body>app</body></html>"
+
+func newSPATestServer(t *testing.T, opts ...Option) *Server {
+	t.Helper()
+
+	s := testServer(t, 0, opts...)
+	assets := fstest.MapFS{
+		"index.html": {
+			Data: []byte(testSPAIndex),
+		},
+		"assets/index-abc123.js": {
+			Data: []byte("console.log('app');"),
+		},
+	}
+	s.spaFS = assets
+	s.spaHandler = http.FileServerFS(assets)
+	return s
+}
+
+func TestSPAIndexRequiresRevalidation(t *testing.T) {
+	s := newSPATestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "no-cache", w.Header().Get("Cache-Control"))
+	assert.Equal(t, testSPAIndex, w.Body.String())
+}
+
+func TestSPAFingerprintedAssetIsImmutable(t *testing.T) {
+	s := newSPATestServer(t)
+
+	req := httptest.NewRequest(
+		http.MethodGet, "/assets/index-abc123.js", nil,
+	)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "public, max-age=31536000, immutable",
+		w.Header().Get("Cache-Control"))
+	assert.Equal(t, "text/javascript; charset=utf-8",
+		w.Header().Get("Content-Type"))
+	assert.Equal(t, "console.log('app');", w.Body.String())
+}
+
+func TestSPAMissingAssetReturnsNotFound(t *testing.T) {
+	s := newSPATestServer(t)
+
+	req := httptest.NewRequest(
+		http.MethodGet, "/assets/obsolete.js", nil,
+	)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+	assert.NotContains(t, w.Body.String(), testSPAIndex)
+}
+
+func TestSPAClientRouteFallsBackToRevalidatedIndex(t *testing.T) {
+	s := newSPATestServer(t, WithBasePath("/viewer"))
+
+	req := httptest.NewRequest(
+		http.MethodGet, "/viewer/sessions/example", nil,
+	)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "no-cache", w.Header().Get("Cache-Control"))
+	assert.Contains(t, w.Body.String(), `<base href="/viewer/">`)
+}


### PR DESCRIPTION
Browsers can retain an older SPA entry document after upgrading the embedded frontend. When that document requests an obsolete fingerprinted bundle, the server currently returns the SPA entry HTML with status 200, leaving the interface partially broken and hiding the underlying cache mismatch.

Entry documents now require revalidation, while fingerprinted assets retain long-lived immutable caching. Missing `/assets/` requests return a real 404 instead of entering the client-route fallback; normal SPA routes and reverse-proxy base paths retain their existing behavior.