### PR TITLE
test(frontend): pin prompt navigation fixture

### DIFF
--- a/frontend/e2e/navigation.spec.ts
+++ b/frontend/e2e/navigation.spec.ts
@@ -32,17 +32,12 @@ test.describe("Navigation", () => {
   });
 
   test("Shift+J and Shift+K navigate visible user prompts", async ({ page }, testInfo) => {
-    const session = page
-      .locator(".session-item")
-      .filter({
-        has: page.locator(
-          '.session-project:text-is("project-beta")',
-        ),
-      })
-      .filter({
-        has: page.locator('.session-count:text-is("3")'),
-      });
-    await session.first().click();
+    const sessionId = "test-session-mixed-content-7";
+    const session = page.locator(`.session-item[data-session-id="${sessionId}"]`);
+    await expect(session).toHaveCount(1);
+    await session.click();
+    await expect(session).toHaveClass(/active/);
+    await expect(sp.scroller).toHaveAttribute("data-messages-session-id", sessionId);
     await expect(sp.messageRows).toHaveCount(6);
 
     const users = sp.messageRows.filter({


### PR DESCRIPTION
Prompt-navigation E2E coverage was previously identified by display metadata. That avoided one broad-text collision but can become ambiguous again if fixture data adds another session with the same project and user-message count, allowing the test to select a nested or unrelated session and fail before shortcut behavior is exercised.

Pin the setup to the fixture's stable session ID and wait until the message pane confirms that ID. This keeps future fixture changes from reintroducing the same class of CI flake while retaining the shortcut assertions.