### PR TITLE
test: make embed scheduler burst deterministic

### DIFF
--- a/cmd/agentsview/embed_scheduler_test.go
+++ b/cmd/agentsview/embed_scheduler_test.go
@@ -91,14 +91,16 @@ func TestEmbedSchedulerBurstOfNotifyProducesExactlyOneBuild(t *testing.T) {
 	fake := &fakeEmbedManager{}
 	s := newEmbedScheduler(fake, 20*time.Millisecond, 0, false)
 
+	// Queue the whole burst before Run starts so the test exercises the
+	// scheduler's documented pre-reader coalescing without racing the debounce
+	// interval on slow or coarsely scheduled runners.
+	for range 10 {
+		s.Notify()
+	}
+
 	ctx := t.Context()
 	go s.Run(ctx)
 	defer s.Stop()
-
-	for range 10 {
-		s.Notify()
-		time.Sleep(2 * time.Millisecond)
-	}
 
 	waitForSchedulerCondition(t, func() bool { return fake.callCount() >= 1 },
 		"expected a build after the burst quieted")


### PR DESCRIPTION
The embed scheduler burst regression test relied on ten sleep-spaced notifications completing within a 20 ms debounce interval. On slower or coarsely scheduled Windows runners, that synthetic burst could cross the debounce boundary and legitimately produce two builds, creating a false product-regression signal.

Queue the notifications before the scheduler starts so the test exercises the scheduler’s documented pre-reader coalescing contract directly. The exactly-one-build assertion remains intact without depending on runner speed.

Fixes #1119