### PR TITLE
fix(parser): restore Codex subagent lineage and titles

### DIFF
--- a/cmd/agentsview/cli_test.go
+++ b/cmd/agentsview/cli_test.go
@@ -167,7 +167,13 @@ func TestServeCheckDataVersionRejectsNewerDatabase(t *testing.T) {
 	assert.Empty(t, out)
 	assert.Contains(t, err.Error(), "database data version")
 	assert.Contains(t, err.Error(), "is newer than this agentsview binary")
-	assert.Contains(t, err.Error(), `Run "agentsview update"`)
+	assert.Contains(t, err.Error(),
+		fmt.Sprintf("Use an AgentsView build with data version %d or newer", futureVersion))
+	assert.Contains(t, err.Error(),
+		fmt.Sprintf("restore an archive backup compatible with data version %d",
+			db.CurrentDataVersion()))
+	assert.Contains(t, err.Error(), "The archive was not modified")
+	assert.NotContains(t, err.Error(), `Run "agentsview update"`)
 }
 
 func TestServeCheckDataVersionDoesNotCreateConfig(t *testing.T) {

--- a/cmd/agentsview/doctor.go
+++ b/cmd/agentsview/doctor.go
@@ -497,7 +497,10 @@ func doctorLikelyCause(
 		return "SQLite user_version is stale; inspect debug.log for resync aborts or failures"
 	}
 	if *report.UserVersion > currentVersion {
-		return "SQLite user_version is newer than this binary. Run \"agentsview update\" or install the latest AgentsView release before serving or syncing"
+		return fmt.Sprintf(
+			"SQLite user_version is newer than this binary. Use an AgentsView build with data version %d or newer, or restore an archive backup compatible with data version %d",
+			*report.UserVersion, currentVersion,
+		)
 	}
 	return "data-version resync is not expected; Running initial sync... is normal incremental startup work"
 }

--- a/cmd/agentsview/doctor_test.go
+++ b/cmd/agentsview/doctor_test.go
@@ -164,7 +164,13 @@ func TestDoctorSyncNewerDatabaseReportsRefusedStartup(t *testing.T) {
 		"Startup sync decision: refuse startup (database requires newer agentsview)")
 	assert.Contains(t, out,
 		"Likely cause: SQLite user_version is newer than this binary")
-	assert.Contains(t, out, `Run "agentsview update"`)
+	assert.Contains(t, out,
+		fmt.Sprintf("Use an AgentsView build with data version %d or newer",
+			futureVersion))
+	assert.Contains(t, out,
+		fmt.Sprintf("restore an archive backup compatible with data version %d",
+			db.CurrentDataVersion()))
+	assert.NotContains(t, out, `Run "agentsview update"`)
 }
 
 func TestWriteDoctorSummaryMode(t *testing.T) {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -33,14 +33,10 @@ const projectIdentityRemoteScrubCompletedKey = "project_identity_remote_scrub_v1
 // trigger a non-destructive re-sync (mtime reset + skip cache
 // clear) so existing session data is preserved.
 //
-// Bumped to 64: inbound Codex agent_message records now become user
-// turns, restoring subagent prompts, follow-ups, and session titles.
-// Existing Codex rows need re-parsing to backfill the missing content.
-//
-// Bumped to 63: the Codex parser now persists subagent lineage from
-// session metadata and links current sub_agent_activity spawn events.
-// Existing Codex rows need re-parsing so parent relationships and
-// tool-call links are backfilled.
+// Bumped to 63: the Codex parser now persists current subagent lineage,
+// links spawn events, restores plaintext agent messages, suppresses opaque
+// encrypted payloads, and derives titles for encrypted child sessions.
+// Existing Codex rows need re-parsing to backfill the corrected sessions.
 //
 // Bumped to 61: the ZCode parser now persists transcript messages,
 // tool calls, and tool results from the message/part tables.
@@ -303,7 +299,7 @@ const projectIdentityRemoteScrubCompletedKey = "project_identity_remote_scrub_v1
 // (62: Local session machine identity now uses the operating-system hostname
 // instead of the ambiguous literal "local". Re-parsing updates existing
 // source-backed rows while the resync archive copy preserves orphaned history.)
-const dataVersion = 64
+const dataVersion = 63
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -329,7 +329,8 @@ type DataVersionTooNewError struct {
 
 func (e *DataVersionTooNewError) Error() string {
 	return fmt.Sprintf(
-		"database data version %d is newer than this agentsview binary's data version %d. Run \"agentsview update\" or install the latest AgentsView release before serving or syncing this archive",
+		"database data version %d is newer than this agentsview binary's data version %d, so this binary cannot safely open the archive. Use an AgentsView build with data version %d or newer, or restore an archive backup compatible with data version %d. The archive was not modified",
+		e.DatabaseVersion, e.BinaryVersion,
 		e.DatabaseVersion, e.BinaryVersion,
 	)
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -33,6 +33,11 @@ const projectIdentityRemoteScrubCompletedKey = "project_identity_remote_scrub_v1
 // trigger a non-destructive re-sync (mtime reset + skip cache
 // clear) so existing session data is preserved.
 //
+// Bumped to 63: the Codex parser now persists subagent lineage from
+// session metadata and links current sub_agent_activity spawn events.
+// Existing Codex rows need re-parsing so parent relationships and
+// tool-call links are backfilled.
+//
 // Bumped to 61: the ZCode parser now persists transcript messages,
 // tool calls, and tool results from the message/part tables.
 // Existing ZCode rows need re-parsing so stored sessions backfill
@@ -294,7 +299,7 @@ const projectIdentityRemoteScrubCompletedKey = "project_identity_remote_scrub_v1
 // (62: Local session machine identity now uses the operating-system hostname
 // instead of the ambiguous literal "local". Re-parsing updates existing
 // source-backed rows while the resync archive copy preserves orphaned history.)
-const dataVersion = 62
+const dataVersion = 63
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -33,6 +33,10 @@ const projectIdentityRemoteScrubCompletedKey = "project_identity_remote_scrub_v1
 // trigger a non-destructive re-sync (mtime reset + skip cache
 // clear) so existing session data is preserved.
 //
+// Bumped to 64: inbound Codex agent_message records now become user
+// turns, restoring subagent prompts, follow-ups, and session titles.
+// Existing Codex rows need re-parsing to backfill the missing content.
+//
 // Bumped to 63: the Codex parser now persists subagent lineage from
 // session metadata and links current sub_agent_activity spawn events.
 // Existing Codex rows need re-parsing so parent relationships and
@@ -299,7 +303,7 @@ const projectIdentityRemoteScrubCompletedKey = "project_identity_remote_scrub_v1
 // (62: Local session machine identity now uses the operating-system hostname
 // instead of the ambiguous literal "local". Re-parsing updates existing
 // source-backed rows while the resync archive copy preserves orphaned history.)
-const dataVersion = 63
+const dataVersion = 64
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"bufio"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1340,7 +1341,8 @@ func extractCodexInboundAgentMessage(
 	payload.Get("content").ForEach(
 		func(_, block gjson.Result) bool {
 			if block.Get("type").Str == "encrypted_content" {
-				if text := block.Get("encrypted_content").Str; text != "" {
+				text := block.Get("encrypted_content").Str
+				if text != "" && !isCodexEncryptedToolContent(text) {
 					texts = append(texts, text)
 				}
 			}
@@ -1348,6 +1350,34 @@ func extractCodexInboundAgentMessage(
 		},
 	)
 	return strings.Join(texts, "\n")
+}
+
+// isCodexEncryptedToolContent recognizes the URL-safe base64 envelope used
+// by Fernet without attempting to decrypt it. Current Codex multi-agent tools
+// can emit either plaintext or an opaque Fernet value in encrypted_content,
+// so the content type alone is not enough to decide whether it is displayable.
+func isCodexEncryptedToolContent(content string) bool {
+	if !strings.HasPrefix(content, "gAAAAA") {
+		return false
+	}
+	decoded, err := base64.URLEncoding.DecodeString(content)
+	if err != nil {
+		decoded, err = base64.RawURLEncoding.DecodeString(content)
+	}
+	if err != nil || len(decoded) < 73 || decoded[0] != 0x80 {
+		return false
+	}
+	const fernetEnvelopeBytes = 1 + 8 + 16 + 32
+	ciphertextBytes := len(decoded) - fernetEnvelopeBytes
+	return ciphertextBytes >= 16 && ciphertextBytes%16 == 0
+}
+
+func codexAgentPathLeaf(agentPath string) string {
+	trimmed := strings.Trim(agentPath, "/")
+	if i := strings.LastIndex(trimmed, "/"); i >= 0 {
+		return trimmed[i+1:]
+	}
+	return trimmed
 }
 
 // extractCodexInitialUserContent filters the synthetic blocks bundled with
@@ -1500,6 +1530,12 @@ func (p *codexProvider) parseSessionSnapshot(
 		}
 	}
 
+	sessionName := LookupCodexThreadName(path, b.sessionID)
+	if sessionName == "" && b.firstMessage == "" &&
+		b.relationshipType == RelSubagent {
+		sessionName = codexAgentPathLeaf(b.agentPath)
+	}
+
 	sess := &ParsedSession{
 		ID:                sessionID,
 		Project:           b.project,
@@ -1509,7 +1545,7 @@ func (p *codexProvider) parseSessionSnapshot(
 		RelationshipType:  b.relationshipType,
 		Cwd:               b.cwd,
 		FirstMessage:      b.firstMessage,
-		SessionName:       LookupCodexThreadName(path, b.sessionID),
+		SessionName:       sessionName,
 		StartedAt:         b.startedAt,
 		EndedAt:           b.endedAt,
 		MessageCount:      len(b.messages),

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -239,6 +239,12 @@ func (b *codexSessionBuilder) handleSessionMeta(
 	payload gjson.Result, envelopeTS time.Time,
 ) (skip bool) {
 	b.sessionID = payload.Get("id").Str
+	b.agentPath = strings.TrimSpace(payload.Get("agent_path").Str)
+	if b.agentPath == "" {
+		b.agentPath = strings.TrimSpace(
+			payload.Get("source.subagent.thread_spawn.agent_path").Str,
+		)
+	}
 	b.parentSessionID = strings.TrimSpace(
 		payload.Get("source.subagent.thread_spawn.parent_thread_id").Str,
 	)
@@ -277,6 +283,9 @@ func (b *codexSessionBuilder) handleResponseItem(
 		return
 	case "function_call_output", "custom_tool_call_output":
 		b.handleFunctionCallOutput(payload, ts)
+		return
+	case "agent_message":
+		b.handleAgentMessage(payload, ts)
 		return
 	}
 
@@ -326,6 +335,33 @@ func (b *codexSessionBuilder) handleResponseItem(
 	b.messages = append(b.messages, ParsedMessage{
 		Ordinal:       b.ordinal,
 		Role:          RoleType(role),
+		Content:       content,
+		Timestamp:     ts,
+		ContentLength: len(content),
+		Model:         b.model,
+	})
+	b.ordinal++
+}
+
+func (b *codexSessionBuilder) handleAgentMessage(
+	payload gjson.Result, ts time.Time,
+) {
+	content := extractCodexInboundAgentMessage(payload, b.agentPath)
+	if strings.TrimSpace(content) == "" {
+		return
+	}
+	first, replay := b.observeUserPrompt(content)
+	if first {
+		b.firstMessage = truncate(
+			strings.ReplaceAll(content, "\n", " "), 300,
+		)
+	}
+	if replay {
+		return
+	}
+	b.messages = append(b.messages, ParsedMessage{
+		Ordinal:       b.ordinal,
+		Role:          RoleUser,
 		Content:       content,
 		Timestamp:     ts,
 		ContentLength: len(content),
@@ -1293,6 +1329,27 @@ func extractCodexContent(payload gjson.Result) string {
 	return strings.Join(extractCodexTextBlocks(payload), "\n")
 }
 
+func extractCodexInboundAgentMessage(
+	payload gjson.Result, agentPath string,
+) string {
+	if agentPath == "" ||
+		strings.TrimSpace(payload.Get("recipient").Str) != agentPath {
+		return ""
+	}
+	var texts []string
+	payload.Get("content").ForEach(
+		func(_, block gjson.Result) bool {
+			if block.Get("type").Str == "encrypted_content" {
+				if text := block.Get("encrypted_content").Str; text != "" {
+					texts = append(texts, text)
+				}
+			}
+			return true
+		},
+	)
+	return strings.Join(texts, "\n")
+}
+
 // extractCodexInitialUserContent filters the synthetic blocks bundled with
 // Codex's recommended-plugins injection while retaining user-authored blocks
 // from the same response item.
@@ -1718,6 +1775,14 @@ func seedCodexIncrementalStateFromReader(
 				if cwd := payload.Get("cwd").Str; cwd != "" {
 					seed.cwd = cwd
 				}
+				seed.agentPath = strings.TrimSpace(
+					payload.Get("agent_path").Str,
+				)
+				if seed.agentPath == "" {
+					seed.agentPath = strings.TrimSpace(payload.Get(
+						"source.subagent.thread_spawn.agent_path",
+					).Str)
+				}
 				seed.forkGate.armFromMeta(
 					payload,
 					parseTimestamp(gjson.Get(line, "timestamp").Str),
@@ -1757,6 +1822,13 @@ func observeCodexIncrementalUserMessage(
 	s *codexIncrementalSeed,
 	payload gjson.Result,
 ) {
+	if payload.Get("type").Str == "agent_message" {
+		content := extractCodexInboundAgentMessage(payload, s.agentPath)
+		if strings.TrimSpace(content) != "" {
+			s.observeUserPrompt(content)
+		}
+		return
+	}
 	if payload.Get("role").Str != "user" {
 		return
 	}

--- a/internal/parser/codex.go
+++ b/internal/parser/codex.go
@@ -61,6 +61,8 @@ type codexSessionBuilder struct {
 	startedAt            time.Time
 	endedAt              time.Time
 	sessionID            string
+	parentSessionID      string
+	relationshipType     RelationshipType
 	project              string
 	ordinal              int
 	callNames            map[string]string
@@ -237,6 +239,19 @@ func (b *codexSessionBuilder) handleSessionMeta(
 	payload gjson.Result, envelopeTS time.Time,
 ) (skip bool) {
 	b.sessionID = payload.Get("id").Str
+	b.parentSessionID = strings.TrimSpace(
+		payload.Get("source.subagent.thread_spawn.parent_thread_id").Str,
+	)
+	if b.parentSessionID == "" &&
+		payload.Get("thread_source").Str == "subagent" {
+		b.parentSessionID = strings.TrimSpace(
+			payload.Get("parent_thread_id").Str,
+		)
+	}
+	if b.parentSessionID != "" {
+		b.parentSessionID = codexSubagentSessionID(b.parentSessionID)
+		b.relationshipType = RelSubagent
+	}
 
 	if cwd := payload.Get("cwd").Str; cwd != "" {
 		b.cwd = cwd
@@ -328,6 +343,8 @@ func (b *codexSessionBuilder) handleEventMsg(payload gjson.Result) {
 		b.handleTokenCountEvent(payload)
 	case "collab_agent_spawn_end":
 		b.handleCollabAgentSpawnEnd(payload)
+	case "sub_agent_activity":
+		b.handleSubagentActivity(payload)
 	}
 }
 
@@ -364,6 +381,21 @@ func (b *codexSessionBuilder) handleCollabAgentSpawnEnd(
 ) {
 	callID := payload.Get("call_id").Str
 	agentID := strings.TrimSpace(payload.Get("new_thread_id").Str)
+	if callID == "" || agentID == "" {
+		return
+	}
+	b.agentSpawnCalls[agentID] = callID
+	b.setCallSubagentSessionID(callID, codexSubagentSessionID(agentID))
+}
+
+func (b *codexSessionBuilder) handleSubagentActivity(
+	payload gjson.Result,
+) {
+	if payload.Get("kind").Str != "started" {
+		return
+	}
+	callID := payload.Get("event_id").Str
+	agentID := strings.TrimSpace(payload.Get("agent_thread_id").Str)
 	if callID == "" || agentID == "" {
 		return
 	}
@@ -1416,6 +1448,8 @@ func (p *codexProvider) parseSessionSnapshot(
 		Project:           b.project,
 		Machine:           machine,
 		Agent:             AgentCodex,
+		ParentSessionID:   b.parentSessionID,
+		RelationshipType:  b.relationshipType,
 		Cwd:               b.cwd,
 		FirstMessage:      b.firstMessage,
 		SessionName:       LookupCodexThreadName(path, b.sessionID),
@@ -2166,8 +2200,15 @@ func isCodexSubagentNotification(content string) bool {
 func codexIncrementalNeedsFullParse(line string) bool {
 	switch gjson.Get(line, "type").Str {
 	case codexTypeEventMsg:
-		return gjson.Get(line, "payload.type").Str ==
-			"collab_agent_spawn_end"
+		payload := gjson.Get(line, "payload")
+		switch payload.Get("type").Str {
+		case "collab_agent_spawn_end":
+			return true
+		case "sub_agent_activity":
+			return payload.Get("kind").Str == "started"
+		default:
+			return false
+		}
 	case codexTypeResponseItem:
 	default:
 		return false

--- a/internal/parser/codex_cursor.go
+++ b/internal/parser/codex_cursor.go
@@ -26,6 +26,7 @@ const (
 type codexCursorState struct {
 	model                    string
 	cwd                      string
+	agentPath                string
 	firstUserDigest          [sha256.Size]byte
 	firstUserSeen            bool
 	sawUserTurnAfterFirst    bool
@@ -229,6 +230,7 @@ func newCodexCursorKey(
 func cloneCodexCursorState(state codexCursorState) codexCursorState {
 	state.model = strings.Clone(state.model)
 	state.cwd = strings.Clone(state.cwd)
+	state.agentPath = strings.Clone(state.agentPath)
 	state.lastTaskEvent = strings.Clone(state.lastTaskEvent)
 	return state
 }
@@ -241,6 +243,7 @@ func estimateCodexCursorEntryBytes(
 		len(key.path)+
 			len(state.model)+
 			len(state.cwd)+
+			len(state.agentPath)+
 			len(state.lastTaskEvent),
 	)
 }

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -245,6 +245,53 @@ func TestParseCodexSession_InboundAgentMessagesAreUserTurns(t *testing.T) {
 	assert.Equal(t, followUp, msgs[2].Content)
 }
 
+func TestParseCodexSession_EncryptedAgentMessageUsesTaskName(t *testing.T) {
+	const encrypted = "gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+	content := testjsonl.JoinJSONL(
+		testjsonl.CodexSubagentSessionMetaJSON(
+			"child", "parent", "/tmp/project", "user", tsEarly,
+		),
+		testjsonl.CodexAgentMessageJSON(
+			"/root", "/root/worker", "Task received from parent.",
+			encrypted, tsEarlyS1,
+		),
+		testjsonl.CodexMsgJSON(
+			"assistant", "I completed the encrypted task.", tsEarlyS5,
+		),
+	)
+
+	sess, msgs := runCodexParserTest(t, "test.jsonl", content, false)
+
+	require.NotNil(t, sess)
+	assert.Empty(t, sess.FirstMessage)
+	assert.Equal(t, "worker", sess.SessionName)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, RoleAssistant, msgs[0].Role)
+	assert.Equal(t, "I completed the encrypted task.", msgs[0].Content)
+}
+
+func TestParseCodexSession_FernetPrefixPlaintextRemainsVisible(t *testing.T) {
+	const prompt = "gAAAAA is only a prefix here, not an encrypted token."
+	content := testjsonl.JoinJSONL(
+		testjsonl.CodexSubagentSessionMetaJSON(
+			"child", "parent", "/tmp/project", "user", tsEarly,
+		),
+		testjsonl.CodexAgentMessageJSON(
+			"/root", "/root/worker", "Task received from parent.",
+			prompt, tsEarlyS1,
+		),
+	)
+
+	sess, msgs := runCodexParserTest(t, "test.jsonl", content, false)
+
+	require.NotNil(t, sess)
+	assert.Equal(t, prompt, sess.FirstMessage)
+	assert.Empty(t, sess.SessionName)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, RoleUser, msgs[0].Role)
+	assert.Equal(t, prompt, msgs[0].Content)
+}
+
 func TestParseCodexSession_UsesThreadNameFromSessionIndex(t *testing.T) {
 	root := t.TempDir()
 	sessionDir := filepath.Join(root, "sessions", "2026", "06", "11")

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -117,6 +117,90 @@ func TestParseCodexSession_Basic(t *testing.T) {
 	assertSessionMeta(t, sess, "codex:abc-123", "my_api", AgentCodex)
 }
 
+func TestParseCodexSession_SubagentLineage(t *testing.T) {
+	const (
+		childID  = "01900000-0000-7000-8000-000000000002"
+		parentID = "01900000-0000-7000-8000-000000000001"
+	)
+
+	tests := []struct {
+		name             string
+		meta             string
+		wantParent       string
+		wantRelationship RelationshipType
+	}{
+		{
+			name: "current nested source",
+			meta: fmt.Sprintf(
+				`{"timestamp":%q,"type":"session_meta","payload":{"id":%q,"cwd":"/tmp","source":{"subagent":{"thread_spawn":{"parent_thread_id":%q,"depth":1}}}}}`,
+				tsEarly, childID, parentID,
+			),
+			wantParent:       "codex:" + parentID,
+			wantRelationship: RelSubagent,
+		},
+		{
+			name: "legacy top-level fields",
+			meta: fmt.Sprintf(
+				`{"timestamp":%q,"type":"session_meta","payload":{"id":%q,"cwd":"/tmp","thread_source":"subagent","parent_thread_id":%q}}`,
+				tsEarly, childID, parentID,
+			),
+			wantParent:       "codex:" + parentID,
+			wantRelationship: RelSubagent,
+		},
+		{
+			name:             "root session",
+			meta:             testjsonl.CodexSessionMetaJSON(childID, "/tmp", "user", tsEarly),
+			wantRelationship: RelNone,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sess, _ := runCodexParserTest(t, "test.jsonl", tt.meta, false)
+
+			require.NotNil(t, sess)
+			assert.Equal(t, tt.wantParent, sess.ParentSessionID)
+			assert.Equal(t, tt.wantRelationship, sess.RelationshipType)
+		})
+	}
+}
+
+func TestParseCodexSession_SubagentActivityLinksSpawn(t *testing.T) {
+	const childID = "01900000-0000-7000-8000-000000000002"
+	activity := testjsonl.CodexSubagentActivityJSON(
+		"started", "call_spawn", childID,
+		"/root/identity_lifecycle", tsLate,
+	)
+	content := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON("parent", "/tmp", "user", tsEarly),
+		testjsonl.CodexMsgJSON("user", "delegate the task", tsEarlyS1),
+		testjsonl.CodexFunctionCallWithCallIDJSON(
+			"spawn_agent", "call_spawn",
+			map[string]any{"task_name": "identity_lifecycle"}, tsEarlyS5,
+		),
+		activity,
+		testjsonl.CodexFunctionCallOutputJSON(
+			"call_spawn", `{"task_name":"/root/identity_lifecycle"}`, tsLateS5,
+		),
+	)
+
+	_, msgs := runCodexParserTest(t, "test.jsonl", content, false)
+
+	require.Len(t, msgs, 2)
+	assertToolCalls(t, msgs[1].ToolCalls, []ParsedToolCall{{
+		ToolUseID:         "call_spawn",
+		ToolName:          "spawn_agent",
+		Category:          "Task",
+		SubagentSessionID: "codex:" + childID,
+	}})
+	assert.True(t, codexIncrementalNeedsFullParse(activity))
+	interacted := testjsonl.CodexSubagentActivityJSON(
+		"interacted", "call_message", childID,
+		"/root/identity_lifecycle", tsLateS5,
+	)
+	assert.False(t, codexIncrementalNeedsFullParse(interacted))
+}
+
 func TestParseCodexSession_UsesThreadNameFromSessionIndex(t *testing.T) {
 	root := t.TempDir()
 	sessionDir := filepath.Join(root, "sessions", "2026", "06", "11")

--- a/internal/parser/codex_parser_test.go
+++ b/internal/parser/codex_parser_test.go
@@ -201,6 +201,50 @@ func TestParseCodexSession_SubagentActivityLinksSpawn(t *testing.T) {
 	assert.False(t, codexIncrementalNeedsFullParse(interacted))
 }
 
+func TestParseCodexSession_InboundAgentMessagesAreUserTurns(t *testing.T) {
+	const (
+		initialTask = "Inspect the parser and report the root cause."
+		followUp    = "Also identify the safest regression test."
+	)
+	initialContext := fmt.Sprintf(
+		`{"timestamp":%q,"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<recommended_plugins>\nplugin list\n</recommended_plugins>"},{"type":"input_text","text":"# AGENTS.md\n<INSTRUCTIONS>\nRepository rules\n</INSTRUCTIONS>"},{"type":"input_text","text":"<environment_context>\n<cwd>/tmp/project</cwd>\n</environment_context>"}]}}`,
+		tsEarlyS1,
+	)
+	content := testjsonl.JoinJSONL(
+		testjsonl.CodexSubagentSessionMetaJSON(
+			"child", "parent", "/tmp/project", "user", tsEarly,
+		),
+		initialContext,
+		testjsonl.CodexAgentMessageJSON(
+			"/root", "/root/worker", "Task received from parent.",
+			initialTask, tsEarlyS5,
+		),
+		testjsonl.CodexMsgJSON(
+			"assistant", "I found the parser branch.", tsLate,
+		),
+		testjsonl.CodexAgentMessageJSON(
+			"/root/worker", "/root", "Update sent to parent.",
+			"This outbound update must stay hidden.", tsLateS5,
+		),
+		testjsonl.CodexAgentMessageJSON(
+			"/root", "/root/worker", "Follow-up received from parent.",
+			followUp, "2024-01-01T11:00:10Z",
+		),
+	)
+
+	sess, msgs := runCodexParserTest(t, "test.jsonl", content, false)
+
+	require.NotNil(t, sess)
+	assert.Equal(t, initialTask, sess.FirstMessage)
+	require.Len(t, msgs, 3)
+	assert.Equal(t, RoleUser, msgs[0].Role)
+	assert.Equal(t, initialTask, msgs[0].Content)
+	assert.Equal(t, RoleAssistant, msgs[1].Role)
+	assert.Equal(t, "I found the parser branch.", msgs[1].Content)
+	assert.Equal(t, RoleUser, msgs[2].Role)
+	assert.Equal(t, followUp, msgs[2].Content)
+}
+
 func TestParseCodexSession_UsesThreadNameFromSessionIndex(t *testing.T) {
 	root := t.TempDir()
 	sessionDir := filepath.Join(root, "sessions", "2026", "06", "11")

--- a/internal/parser/codex_provider_test.go
+++ b/internal/parser/codex_provider_test.go
@@ -919,6 +919,63 @@ func TestCodexProviderTokenCountCursorParity(t *testing.T) {
 	}
 }
 
+func TestCodexProviderParseIncrementalInboundAgentMessage(t *testing.T) {
+	root := t.TempDir()
+	const uuid = "01900000-0000-7000-8000-000000000002"
+	initial := testjsonl.JoinJSONL(
+		testjsonl.CodexSubagentSessionMetaJSON(
+			uuid, "01900000-0000-7000-8000-000000000001",
+			"/tmp/project", "user", tsEarly,
+		),
+		testjsonl.CodexAgentMessageJSON(
+			"/root", "/root/worker", "Task received from parent.",
+			"Inspect the parser.", tsEarlyS1,
+		),
+	)
+	path := writeCodexProviderSessionContent(t, root, uuid, initial)
+	provider, ok := NewProvider(
+		AgentCodex, ProviderConfig{Roots: []string{root}},
+	)
+	require.True(t, ok)
+	source := requireCodexProviderSource(t, provider, uuid)
+	initialFingerprint, err := provider.Fingerprint(
+		context.Background(), source,
+	)
+	require.NoError(t, err)
+	full, err := provider.Parse(context.Background(), ParseRequest{
+		Source: source, Fingerprint: initialFingerprint,
+	})
+	require.NoError(t, err)
+	require.Len(t, full.Results, 1)
+	require.Len(t, full.Results[0].Result.Messages, 1)
+
+	tail := testjsonl.CodexAgentMessageJSON(
+		"/root", "/root/worker", "Follow-up received from parent.",
+		"Check incremental parsing too.", tsEarlyS5,
+	) + "\n"
+	appendCodexProviderContent(t, path, tail)
+	currentFingerprint, err := provider.Fingerprint(
+		context.Background(), source,
+	)
+	require.NoError(t, err)
+
+	outcome, status, err := provider.ParseIncremental(
+		context.Background(),
+		IncrementalRequest{
+			Source: source, Fingerprint: currentFingerprint,
+			SessionID: "codex:" + uuid,
+			Offset:    initialFingerprint.Size, StartOrdinal: 1,
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, IncrementalApplied, status)
+	require.Len(t, outcome.Messages, 1)
+	assert.Equal(t, RoleUser, outcome.Messages[0].Role)
+	assert.Equal(t, "Check incremental parsing too.", outcome.Messages[0].Content)
+	assert.Equal(t, 1, outcome.Messages[0].Ordinal)
+}
+
 func TestCodexProviderParseIncrementalNoLifecycleMarker(t *testing.T) {
 	root := t.TempDir()
 	uuid := "019eb791-cf7d-75c1-8439-9ed74c1229e5"

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -2597,6 +2597,84 @@ func TestSyncEngineCodex(t *testing.T) {
 	})
 }
 
+func TestSyncEngineCodexSubagentLineage(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentCodex)
+	const (
+		parentID = "01900000-0000-7000-8000-000000000001"
+		childID  = "01900000-0000-7000-8000-000000000002"
+	)
+
+	parentContent := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(parentID, "/tmp/project", "user", tsEarly),
+		testjsonl.CodexMsgJSON("user", "delegate the task", tsEarlyS1),
+		testjsonl.CodexFunctionCallWithCallIDJSON(
+			"spawn_agent", "call_spawn",
+			map[string]any{"task_name": "identity_lifecycle"}, tsEarlyS5,
+		),
+	)
+	childContent := testjsonl.JoinJSONL(
+		testjsonl.CodexSubagentSessionMetaJSON(
+			childID, parentID, "/tmp/project", "user",
+			"2024-01-01T10:01:00Z",
+		),
+		testjsonl.CodexMsgJSON(
+			"assistant", "subtask complete", "2024-01-01T10:01:05Z",
+		),
+	)
+
+	parentPath := env.writeCodexSession(
+		t, filepath.Join("2024", "01", "15"),
+		"rollout-20240115-parent.jsonl", parentContent,
+	)
+	env.writeCodexSession(
+		t, filepath.Join("2024", "01", "15"),
+		"rollout-20240115-child.jsonl", childContent,
+	)
+
+	runSyncAndAssert(t, env.engine, sync.SyncStats{
+		TotalSessions: 2, Synced: 2,
+	})
+
+	assertSessionState(t, env.db, "codex:"+childID, func(sess *db.Session) {
+		require.NotNil(t, sess.ParentSessionID)
+		assert.Equal(t, "codex:"+parentID, *sess.ParentSessionID)
+		assert.Equal(t, "subagent", sess.RelationshipType)
+	})
+
+	var linkedID sql.NullString
+	err := env.db.Reader().QueryRow(`
+		SELECT subagent_session_id
+		FROM tool_calls
+		WHERE session_id = ? AND tool_use_id = ?`,
+		"codex:"+parentID, "call_spawn",
+	).Scan(&linkedID)
+	require.NoError(t, err)
+	assert.False(t, linkedID.Valid)
+
+	appended := testjsonl.CodexSubagentActivityJSON(
+		"started", "call_spawn", childID,
+		"/root/identity_lifecycle", "2024-01-01T10:01:00Z",
+	)
+	f, err := os.OpenFile(parentPath, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, writeErr := f.WriteString(appended + "\n")
+	closeErr := f.Close()
+	require.NoError(t, writeErr)
+	require.NoError(t, closeErr)
+
+	env.engine.SyncPaths([]string{parentPath})
+
+	err = env.db.Reader().QueryRow(`
+		SELECT subagent_session_id
+		FROM tool_calls
+		WHERE session_id = ? AND tool_use_id = ?`,
+		"codex:"+parentID, "call_spawn",
+	).Scan(&linkedID)
+	require.NoError(t, err)
+	require.True(t, linkedID.Valid)
+	assert.Equal(t, "codex:"+childID, linkedID.String)
+}
+
 func TestSyncEngineProgress(t *testing.T) {
 	env := setupFocusedTestEnv(t, parser.AgentClaude, parser.AgentPiebald)
 

--- a/internal/testjsonl/testjsonl.go
+++ b/internal/testjsonl/testjsonl.go
@@ -160,6 +160,8 @@ func CodexSubagentSessionMetaJSON(
 			"id":               id,
 			"cwd":              cwd,
 			"originator":       originator,
+			"agent_nickname":   "worker",
+			"agent_path":       "/root/worker",
 			"parent_thread_id": parentID,
 			"session_id":       parentID,
 			"thread_source":    "subagent",
@@ -168,7 +170,37 @@ func CodexSubagentSessionMetaJSON(
 					"thread_spawn": map[string]any{
 						"parent_thread_id": parentID,
 						"depth":            1,
+						"agent_nickname":   "worker",
+						"agent_path":       "/root/worker",
 					},
+				},
+			},
+		},
+	}
+	return mustMarshal(m)
+}
+
+// CodexAgentMessageJSON returns a current Codex inter-agent message. Codex
+// stores the delivered task in the encrypted_content field even when its
+// value is plaintext.
+func CodexAgentMessageJSON(
+	author, recipient, visibleContent, deliveredContent, timestamp string,
+) string {
+	m := map[string]any{
+		"type":      "response_item",
+		"timestamp": timestamp,
+		"payload": map[string]any{
+			"type":      "agent_message",
+			"author":    author,
+			"recipient": recipient,
+			"content": []map[string]any{
+				{
+					"type": "input_text",
+					"text": visibleContent,
+				},
+				{
+					"type":              "encrypted_content",
+					"encrypted_content": deliveredContent,
 				},
 			},
 		},

--- a/internal/testjsonl/testjsonl.go
+++ b/internal/testjsonl/testjsonl.go
@@ -148,6 +148,52 @@ func CodexSessionMetaJSON(
 	return mustMarshal(m)
 }
 
+// CodexSubagentSessionMetaJSON returns the session_meta shape written by
+// current Codex multi-agent rollouts.
+func CodexSubagentSessionMetaJSON(
+	id, parentID, cwd, originator, timestamp string,
+) string {
+	m := map[string]any{
+		"type":      "session_meta",
+		"timestamp": timestamp,
+		"payload": map[string]any{
+			"id":               id,
+			"cwd":              cwd,
+			"originator":       originator,
+			"parent_thread_id": parentID,
+			"session_id":       parentID,
+			"thread_source":    "subagent",
+			"source": map[string]any{
+				"subagent": map[string]any{
+					"thread_spawn": map[string]any{
+						"parent_thread_id": parentID,
+						"depth":            1,
+					},
+				},
+			},
+		},
+	}
+	return mustMarshal(m)
+}
+
+// CodexSubagentActivityJSON returns a current Codex sub-agent lifecycle event.
+func CodexSubagentActivityJSON(
+	kind, eventID, agentThreadID, agentPath, timestamp string,
+) string {
+	m := map[string]any{
+		"type":      "event_msg",
+		"timestamp": timestamp,
+		"payload": map[string]any{
+			"type":            "sub_agent_activity",
+			"kind":            kind,
+			"event_id":        eventID,
+			"agent_thread_id": agentThreadID,
+			"agent_path":      agentPath,
+		},
+	}
+	return mustMarshal(m)
+}
+
 // CodexForkedSessionMetaJSON returns the session_meta of a forked
 // Codex session (payload carries forked_from_id).
 func CodexForkedSessionMetaJSON(


### PR DESCRIPTION
Current Codex multi-agent rollouts encode child lineage in session metadata and lifecycle events, while spawn results no longer carry the legacy child ID. Agentsview previously treated affected children as roots, failed to link parent spawn calls, and could expose opaque encrypted tool parameters as transcript text.

Parse the current lineage and lifecycle formats while retaining legacy compatibility. Addressed plaintext agent messages remain visible, encrypted payloads stay out of transcripts and search, and encrypted child sessions use their task path for a useful title. The existing data-version bump reparses source-backed archives non-destructively to recover the corrected relationships, links, messages, and titles.

When an archive has a newer data version than the running binary, startup and sync diagnostics now identify the compatible build or backup versions instead of assuming an update will resolve the mismatch. The fatal error also confirms that the refused startup left the archive unchanged.