### PR TITLE
test: make runtime warning helpers condition-based

### DIFF
--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -42,15 +42,15 @@ func TestRuntimeWarningHelper(t *testing.T) {
 	assert.Contains(t, logOutput.String(), "could not write daemon runtime record")
 }
 
-func TestServeRuntimeRecordWriteFailureWarnsVisible(t *testing.T) {
-	out, err := runServeRuntimeWarningHelper(t, true)
+func TestServeRuntimeRecordWriteFailureWarnsVisibleAfterSlowStartup(t *testing.T) {
+	out, err := runServeRuntimeWarningHelper(t, true, 1200*time.Millisecond)
 	require.NoError(t, err, string(out))
 	assert.Contains(t, string(out), "could not write daemon runtime record")
 	assert.Contains(t, string(out), "icacls <dir> /setowner <user>")
 }
 
 func TestServeRuntimeRecordWriteSuccessDoesNotWarnVisible(t *testing.T) {
-	out, err := runServeRuntimeWarningHelper(t, false)
+	out, err := runServeRuntimeWarningHelper(t, false, 0)
 	require.NoError(t, err, string(out))
 	assert.Contains(t, string(out), "runtime record write reached")
 	assert.NotContains(t, string(out), "could not write daemon runtime record")
@@ -68,17 +68,108 @@ func TestDuckDBServeRuntimeRecordWriteFailureWarnsVisible(t *testing.T) {
 	assert.Contains(t, string(out), "could not write daemon runtime record")
 }
 
-func runServeRuntimeWarningHelper(t *testing.T, failWrite bool) ([]byte, error) {
+func runServeRuntimeWarningHelper(
+	t *testing.T, failWrite bool, startupDelay time.Duration,
+) ([]byte, error) {
 	t.Helper()
 	dataDir := t.TempDir()
-	cmd := exec.Command(os.Args[0], "-test.run=TestRunServeRuntimeWarningHelperProcess")
-	cmd.Env = append(
-		os.Environ(),
-		"AGENTSVIEW_RUN_SERVE_RUNTIME_WARNING_HELPER=1",
-		"AGENTSVIEW_RUN_SERVE_RUNTIME_WARNING_FAIL="+fmt.Sprint(failWrite),
-		"AGENTSVIEW_DATA_DIR="+dataDir,
+	marker := "runtime record write reached"
+	if failWrite {
+		// Wait for the remedy, which is emitted after the warning, so the parent
+		// cannot stop the helper between the two lines under test.
+		marker = "icacls <dir> /setowner <user>"
+	}
+	return runRuntimeWarningHelperProcess(
+		t, "serve", "TestRunServeRuntimeWarningHelperProcess",
+		[]string{
+			"AGENTSVIEW_RUN_SERVE_RUNTIME_WARNING_HELPER=1",
+			"AGENTSVIEW_RUN_SERVE_RUNTIME_WARNING_FAIL=" + fmt.Sprint(failWrite),
+			"AGENTSVIEW_RUN_SERVE_RUNTIME_WARNING_DELAY=" + startupDelay.String(),
+			"AGENTSVIEW_DATA_DIR=" + dataDir,
+		},
+		marker,
 	)
-	return cmd.CombinedOutput()
+}
+
+func runRuntimeWarningHelperProcess(
+	t *testing.T, helperName, testName string, env []string, marker string,
+) ([]byte, error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^"+testName+"$")
+	cmd.Env = append(os.Environ(), env...)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("pipe %s helper stdout: %w", helperName, err)
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start %s helper: %w", helperName, err)
+	}
+
+	var stdoutOutput bytes.Buffer
+	observed := false
+	var stopErr error
+	scanner := bufio.NewScanner(stdout)
+	for scanner.Scan() {
+		line := scanner.Text()
+		stdoutOutput.WriteString(line)
+		stdoutOutput.WriteByte('\n')
+		if !observed && strings.Contains(line, marker) {
+			observed = true
+			stopErr = cmd.Cancel()
+		}
+	}
+	scanErr := scanner.Err()
+	waitErr := cmd.Wait()
+
+	combined := append([]byte(nil), stdoutOutput.Bytes()...)
+	combined = append(combined, stderr.Bytes()...)
+	if observed {
+		if scanErr != nil {
+			return combined, fmt.Errorf(
+				"scan %s helper stdout after marker: %w\noutput:\n%s",
+				helperName, scanErr, combined,
+			)
+		}
+		if stopErr != nil {
+			return combined, fmt.Errorf(
+				"stop %s helper after stdout marker: %w\noutput:\n%s",
+				helperName, stopErr, combined,
+			)
+		}
+		if _, ok := waitErr.(*exec.ExitError); waitErr != nil && !ok {
+			return combined, fmt.Errorf(
+				"wait for stopped %s helper after stdout marker: %w\noutput:\n%s",
+				helperName, waitErr, combined,
+			)
+		}
+		return stdoutOutput.Bytes(), nil
+	}
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return combined, fmt.Errorf(
+			"%s helper deadline expired before stdout marker %q: %w\noutput:\n%s",
+			helperName, marker, ctx.Err(), combined,
+		)
+	}
+	if scanErr != nil {
+		return combined, fmt.Errorf(
+			"scan %s helper stdout before marker %q: %w\noutput:\n%s",
+			helperName, marker, scanErr, combined,
+		)
+	}
+	if waitErr != nil {
+		return combined, fmt.Errorf(
+			"%s helper exited nonzero before stdout marker %q: %w\noutput:\n%s",
+			helperName, marker, waitErr, combined,
+		)
+	}
+	return combined, fmt.Errorf(
+		"%s helper exited with status 0 before stdout marker %q\noutput:\n%s",
+		helperName, marker, combined,
+	)
 }
 
 func TestRunServeRuntimeWarningHelperProcess(t *testing.T) {
@@ -105,10 +196,17 @@ func TestRunServeRuntimeWarningHelperProcess(t *testing.T) {
 			return path, err
 		}
 	}
+	// This is only an orphan guard if the parent dies; normal completion is
+	// driven by the parent observing the expected output on stdout.
 	go func() {
-		time.Sleep(time.Second)
+		time.Sleep(2 * time.Minute)
 		os.Exit(0)
 	}()
+	startupDelay, err := time.ParseDuration(
+		os.Getenv("AGENTSVIEW_RUN_SERVE_RUNTIME_WARNING_DELAY"),
+	)
+	require.NoError(t, err)
+	time.Sleep(startupDelay)
 	runServe(config.Config{
 		Host:    "127.0.0.1",
 		Port:    0,
@@ -121,101 +219,28 @@ func TestRunServeRuntimeWarningHelperProcess(t *testing.T) {
 func runDuckDBRuntimeWarningHelper(t *testing.T) ([]byte, error) {
 	t.Helper()
 	dataDir := t.TempDir()
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	cmd := exec.CommandContext(
-		ctx, os.Args[0], "-test.run=TestRunDuckDBRuntimeWarningHelperProcess",
-	)
-	cmd.Env = append(
-		os.Environ(),
-		"AGENTSVIEW_RUN_DUCKDB_RUNTIME_WARNING_HELPER=1",
-		"AGENTSVIEW_DATA_DIR="+dataDir,
-		"AGENTSVIEW_DUCKDB_RUNTIME_WARNING_PATH="+filepath.Join(dataDir, "mirror.duckdb"),
-	)
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return nil, fmt.Errorf("pipe DuckDB helper stdout: %w", err)
-	}
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err := cmd.Start(); err != nil {
-		return nil, fmt.Errorf("start DuckDB helper: %w", err)
-	}
-
-	const marker = "could not write daemon runtime record"
-	var stdoutOutput bytes.Buffer
-	observed := false
-	var stopErr error
-	scanner := bufio.NewScanner(stdout)
-	for scanner.Scan() {
-		line := scanner.Text()
-		stdoutOutput.WriteString(line)
-		stdoutOutput.WriteByte('\n')
-		if !observed && strings.Contains(line, marker) {
-			observed = true
-			stopErr = cmd.Cancel()
-		}
-	}
-	scanErr := scanner.Err()
-	waitErr := cmd.Wait()
-
-	combined := append([]byte(nil), stdoutOutput.Bytes()...)
-	combined = append(combined, stderr.Bytes()...)
-	if observed {
-		if scanErr != nil {
-			return combined, fmt.Errorf(
-				"scan DuckDB helper stdout after warning: %w\noutput:\n%s",
-				scanErr, combined,
-			)
-		}
-		if stopErr != nil {
-			return combined, fmt.Errorf(
-				"stop DuckDB helper after stdout warning: %w\noutput:\n%s",
-				stopErr, combined,
-			)
-		}
-		if _, ok := waitErr.(*exec.ExitError); waitErr != nil && !ok {
-			return combined, fmt.Errorf(
-				"wait for stopped DuckDB helper after stdout warning: %w\noutput:\n%s",
-				waitErr, combined,
-			)
-		}
-		return stdoutOutput.Bytes(), nil
-	}
-	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-		return combined, fmt.Errorf(
-			"DuckDB helper deadline expired before stdout warning: %w\noutput:\n%s",
-			ctx.Err(), combined,
-		)
-	}
-	if scanErr != nil {
-		return combined, fmt.Errorf(
-			"scan DuckDB helper stdout before warning: %w\noutput:\n%s",
-			scanErr, combined,
-		)
-	}
-	if waitErr != nil {
-		return combined, fmt.Errorf(
-			"DuckDB helper exited nonzero before stdout warning: %w\noutput:\n%s",
-			waitErr, combined,
-		)
-	}
-	return combined, fmt.Errorf(
-		"DuckDB helper exited with status 0 before stdout warning\noutput:\n%s",
-		combined,
+	return runRuntimeWarningHelperProcess(
+		t, "DuckDB", "TestRunDuckDBRuntimeWarningHelperProcess",
+		[]string{
+			"AGENTSVIEW_RUN_DUCKDB_RUNTIME_WARNING_HELPER=1",
+			"AGENTSVIEW_DATA_DIR=" + dataDir,
+			"AGENTSVIEW_DUCKDB_RUNTIME_WARNING_PATH=" + filepath.Join(dataDir, "mirror.duckdb"),
+		},
+		"could not write daemon runtime record",
 	)
 }
 
 func runPGRuntimeWarningHelper(t *testing.T) ([]byte, error) {
 	t.Helper()
 	dataDir := t.TempDir()
-	cmd := exec.Command(os.Args[0], "-test.run=TestRunPGRuntimeWarningHelperProcess")
-	cmd.Env = append(
-		os.Environ(),
-		"AGENTSVIEW_RUN_PG_RUNTIME_WARNING_HELPER=1",
-		"AGENTSVIEW_DATA_DIR="+dataDir,
+	return runRuntimeWarningHelperProcess(
+		t, "PostgreSQL", "TestRunPGRuntimeWarningHelperProcess",
+		[]string{
+			"AGENTSVIEW_RUN_PG_RUNTIME_WARNING_HELPER=1",
+			"AGENTSVIEW_DATA_DIR=" + dataDir,
+		},
+		"could not write daemon runtime record",
 	)
-	return cmd.CombinedOutput()
 }
 
 func TestRunPGRuntimeWarningHelperProcess(t *testing.T) {
@@ -250,8 +275,10 @@ func TestRunPGRuntimeWarningHelperProcess(t *testing.T) {
 			cleanup: func() { cancel(); _ = database.Close() },
 		}, nil
 	}
+	// This is only an orphan guard if the parent dies; normal completion is
+	// driven by the parent observing the warning on stdout.
 	go func() {
-		time.Sleep(time.Second)
+		time.Sleep(2 * time.Minute)
 		os.Exit(0)
 	}()
 	runPGServe(appCfg, "")


### PR DESCRIPTION
Runtime warning entrypoint tests stopped helper processes after one second. On loaded runners, startup can consume that cutoff and exit cleanly before the warning is emitted, producing an empty-output failure unrelated to product behavior.

Helper lifetime now follows an expected stdout marker with a bounded deadline and distant orphan guard. The serve regression deliberately crosses the old cutoff, and PostgreSQL shares the same marker-driven path already used for DuckDB, removing the same latent runner-speed dependency.