### PR TITLE
Reject and repair invalid embedding vectors

### DIFF
--- a/cmd/agentsview/daemon_runtime.go
+++ b/cmd/agentsview/daemon_runtime.go
@@ -20,12 +20,15 @@ import (
 	"github.com/gofrs/flock"
 	"github.com/shirou/gopsutil/v4/process"
 	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/server"
 	"go.kenn.io/kit/daemon"
 )
 
 const (
-	daemonService          = "agentsview"
-	daemonAPIVersion       = 2
+	daemonService = "agentsview"
+	// Version 3 adds repair scan-completion and remaining-count certainty to
+	// embeddings status; older daemons cannot represent those semantics safely.
+	daemonAPIVersion       = server.APIVersion
 	runtimeReadOnly        = "read_only"
 	runtimeHost            = "host"
 	runtimePort            = "port"
@@ -539,7 +542,8 @@ func daemonRuntimeCompatibilityError(rt *DaemonRuntime) error {
 	}
 	if rt.API != daemonAPIVersion {
 		return fmt.Errorf(
-			"daemon API version %d is incompatible with client API version %d",
+			"daemon API version %d is incompatible with client API version %d; "+
+				"restart the daemon after upgrading AgentsView",
 			rt.API, daemonAPIVersion,
 		)
 	}

--- a/cmd/agentsview/daemon_runtime_test.go
+++ b/cmd/agentsview/daemon_runtime_test.go
@@ -319,7 +319,13 @@ func holdExternalDaemonStartLock(t *testing.T, dataDir string) func() {
 
 	var once sync.Once
 	unlock := func() {
-		once.Do(func() { _ = stdin.Close() })
+		once.Do(func() {
+			_ = stdin.Close()
+			deadline := time.Now().Add(5 * time.Second)
+			for isExternalDaemonStarting(dataDir) && time.Now().Before(deadline) {
+				time.Sleep(10 * time.Millisecond)
+			}
+		})
 	}
 	t.Cleanup(unlock)
 	return unlock

--- a/cmd/agentsview/daemon_runtime_test.go
+++ b/cmd/agentsview/daemon_runtime_test.go
@@ -1065,6 +1065,7 @@ func TestFindDaemonRuntime_IgnoresIncompatibleRuntime(t *testing.T) {
 	require.NotNil(t, rt)
 	require.Error(t, compatErr)
 	assert.Contains(t, compatErr.Error(), "API version")
+	assert.Contains(t, compatErr.Error(), "restart the daemon")
 	assert.True(t, IsLocalDaemonActive(dir),
 		"incompatible writable daemon still owns the local archive")
 }

--- a/cmd/agentsview/embeddings.go
+++ b/cmd/agentsview/embeddings.go
@@ -70,9 +70,10 @@ func newEmbeddingsCommand() *cobra.Command {
 
 // EmbeddingsBuildOptions holds the parsed `embeddings build` flags.
 type EmbeddingsBuildOptions struct {
-	FullRebuild bool
-	Backstop    bool
-	Yes         bool
+	FullRebuild   bool
+	Backstop      bool
+	RepairInvalid bool
+	Yes           bool
 	// IncludeAutomated is the --include-automated flag's parsed value; only
 	// meaningful when IncludeAutomatedSet is true (see that field).
 	IncludeAutomated bool
@@ -104,6 +105,8 @@ func newEmbeddingsBuildCommand() *cobra.Command {
 		"Re-embed every document, even ones already embedded under the active generation")
 	cmd.Flags().BoolVar(&opts.Backstop, "backstop", false,
 		"Force a full mirror reconciliation scan without forcing a re-embed")
+	cmd.Flags().BoolVar(&opts.RepairInvalid, "repair-invalid", false,
+		"Regenerate only documents with malformed, non-finite, or zero-norm stored vectors")
 	cmd.Flags().BoolVar(&opts.Yes, "yes", false,
 		"Skip the full-rebuild confirmation prompt")
 	cmd.Flags().StringVar(&opts.Using, "using", "",
@@ -117,6 +120,8 @@ func newEmbeddingsBuildCommand() *cobra.Command {
 			"scheduled builds: mixing this flag with a different config "+
 			"default flips the index's scope on every other build, forcing "+
 			"a full mirror reconciliation each time.")
+	cmd.MarkFlagsMutuallyExclusive("full-rebuild", "repair-invalid")
+	cmd.MarkFlagsMutuallyExclusive("backstop", "repair-invalid")
 	return cmd
 }
 
@@ -349,6 +354,7 @@ func runEmbeddingsBuild(
 	req := vector.BuildRequest{
 		FullRebuild:      opts.FullRebuild,
 		Backstop:         opts.Backstop,
+		RepairInvalid:    opts.RepairInvalid,
 		IncludeAutomated: includeAutomated,
 		Using:            opts.Using,
 	}
@@ -456,11 +462,11 @@ func runDirectBuild(
 			if !res.started {
 				return errors.New("a build is already running")
 			}
-			if res.err != nil {
-				return res.err
-			}
 			if status := m.Status(); status.LastResult != nil {
 				printBuildSummary(out, *status.LastResult)
+			}
+			if res.err != nil {
+				return res.err
 			}
 			return nil
 		case <-ticker.C:
@@ -524,15 +530,16 @@ func pollDaemonBuildStatus(
 	}
 }
 
-// finalizeBuildStatus reports a stopped build's outcome: a non-empty
-// LastError becomes the returned (non-zero-exit) error, otherwise the
-// LastResult prints the same final summary the direct path prints.
+// finalizeBuildStatus reports a stopped build's outcome. LastResult prints
+// the same final summary the direct path prints, including partial results
+// from a failed attempt; a non-empty LastError then becomes the returned
+// non-zero-exit error.
 func finalizeBuildStatus(out io.Writer, status vector.BuildStatus) error {
-	if status.LastError != "" {
-		return errors.New(status.LastError)
-	}
 	if status.LastResult != nil {
 		printBuildSummary(out, *status.LastResult)
+	}
+	if status.LastError != "" {
+		return errors.New(status.LastError)
 	}
 	return nil
 }
@@ -579,6 +586,20 @@ func printBuildProgress(w io.Writer, phase string, done, total int64) {
 // build auto-activated its generation, the activation line) for either
 // build path.
 func printBuildSummary(w io.Writer, result vector.BuildResult) {
+	if result.Repair.Scanned {
+		fmt.Fprintf(w, "Repair targets: %d documents (%d chunks invalidated).\n",
+			result.Repair.Documents, result.Repair.Chunks)
+		if !result.Repair.ScanComplete {
+			fmt.Fprintln(w, "Repair scan incomplete.")
+		}
+		if !result.Repair.RemainingKnown {
+			fmt.Fprintf(w, "Repair incomplete: %d failed, remaining unknown.\n",
+				result.Repair.Failed)
+		} else if result.Repair.Failed > 0 || result.Repair.Remaining > 0 {
+			fmt.Fprintf(w, "Repair incomplete: %d failed, %d remaining.\n",
+				result.Repair.Failed, result.Repair.Remaining)
+		}
+	}
 	fmt.Fprintf(w, "Embedded %d documents (%d chunks), skipped %d, stale %d\n",
 		result.Fill.Documents, result.Fill.Chunks, result.Fill.Skipped, result.Fill.Stale)
 	if result.Activated {

--- a/cmd/agentsview/embeddings.go
+++ b/cmd/agentsview/embeddings.go
@@ -778,9 +778,11 @@ func directGenerationAction(
 // HTTP client for its embeddings API. Callers only reach it after
 // IsLocalDaemonActive reported true.
 func resolveEmbeddingsDaemonClient(cfg config.Config) (embeddingsDaemonClient, error) {
-	rt := FindDaemonRuntime(cfg.DataDir, cfg.AuthToken)
+	rt := FindWritableDaemonRuntime(cfg.DataDir, cfg.AuthToken)
 	if rt == nil {
-		if _, err := FindIncompatibleDaemonRuntime(cfg.DataDir, cfg.AuthToken); err != nil {
+		if _, err := findIncompatibleWritableDaemonRuntime(
+			cfg.DataDir, cfg.AuthToken,
+		); err != nil {
 			return embeddingsDaemonClient{}, err
 		}
 		return embeddingsDaemonClient{}, errors.New("no reachable local agentsview daemon found")

--- a/cmd/agentsview/embeddings.go
+++ b/cmd/agentsview/embeddings.go
@@ -780,6 +780,9 @@ func directGenerationAction(
 func resolveEmbeddingsDaemonClient(cfg config.Config) (embeddingsDaemonClient, error) {
 	rt := FindDaemonRuntime(cfg.DataDir, cfg.AuthToken)
 	if rt == nil {
+		if _, err := FindIncompatibleDaemonRuntime(cfg.DataDir, cfg.AuthToken); err != nil {
+			return embeddingsDaemonClient{}, err
+		}
 		return embeddingsDaemonClient{}, errors.New("no reachable local agentsview daemon found")
 	}
 	return embeddingsDaemonClient{baseURL: urlFromDaemonRuntime(rt), token: cfg.AuthToken}, nil

--- a/cmd/agentsview/embeddings_test.go
+++ b/cmd/agentsview/embeddings_test.go
@@ -950,6 +950,21 @@ func TestEmbeddingsActivateInvalidIDReturnsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid generation id")
 }
 
+func TestResolveEmbeddingsDaemonClientReportsIncompatibleDaemon(t *testing.T) {
+	dataDir := runtimeTestDir(t)
+	writeLiveRuntime(t, dataDir, false,
+		withRuntimeVersion("old"),
+		withRuntimeAPIVersion(daemonAPIVersion-1),
+	)
+	require.True(t, IsLocalDaemonActive(dataDir))
+	require.Nil(t, FindDaemonRuntime(dataDir))
+
+	_, err := resolveEmbeddingsDaemonClient(config.Config{DataDir: dataDir})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "daemon API version")
+	assert.Contains(t, err.Error(), "restart the daemon after upgrading AgentsView")
+}
+
 // startEmbeddingsTestDaemon starts an httptest server that answers the kit
 // daemon ping (so FindDaemonRuntime's probe succeeds) plus the given
 // embeddings endpoint handlers, writes a live writable runtime record for

--- a/cmd/agentsview/embeddings_test.go
+++ b/cmd/agentsview/embeddings_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -960,6 +961,34 @@ func TestResolveEmbeddingsDaemonClientReportsIncompatibleDaemon(t *testing.T) {
 	require.Nil(t, FindDaemonRuntime(dataDir))
 
 	_, err := resolveEmbeddingsDaemonClient(config.Config{DataDir: dataDir})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "daemon API version")
+	assert.Contains(t, err.Error(), "restart the daemon after upgrading AgentsView")
+}
+
+func TestResolveEmbeddingsDaemonClientPrefersIncompatibleWritableDaemonError(
+	t *testing.T,
+) {
+	dataDir := runtimeTestDir(t)
+	readOnlyEndpoint, _ := writeLiveRuntime(t, dataDir, true)
+
+	writablePID := startSleepProcess(t)
+	writableEndpoint := newPingDaemonWithPID(t, writablePID)
+	writablePath, err := writeRuntimeRecordForTest(dataDir, daemonRuntimeRecord(
+		writableEndpoint.Host, writableEndpoint.Port,
+		withRuntimePID(writablePID),
+		withRuntimeVersion("old"),
+		withRuntimeAPIVersion(daemonAPIVersion-1),
+	))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Remove(writablePath) })
+
+	compatible := FindDaemonRuntime(dataDir)
+	require.NotNil(t, compatible)
+	require.True(t, compatible.ReadOnly)
+	assert.Equal(t, readOnlyEndpoint.Port, compatible.Port)
+
+	_, err = resolveEmbeddingsDaemonClient(config.Config{DataDir: dataDir})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "daemon API version")
 	assert.Contains(t, err.Error(), "restart the daemon after upgrading AgentsView")

--- a/cmd/agentsview/embeddings_test.go
+++ b/cmd/agentsview/embeddings_test.go
@@ -342,6 +342,152 @@ func TestEmbeddingsBuildDirectEndToEnd(t *testing.T) {
 	assert.Contains(t, out.String(), "Generation activated.")
 }
 
+func TestRunDirectBuildPrintsFailedAttemptResult(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "vectors.db")
+	ix, err := vector.Open(ctx, path, false, 8192)
+	require.NoError(t, err)
+	defer ix.Close()
+	gen := kitvec.Generation{Model: "fake-model", Dimensions: 4}
+	src := testPushUnitSource()
+	_, err = ix.Build(ctx, src, fakePushEncoder(), gen, vector.BuildOptions{})
+	require.NoError(t, err)
+
+	raw, err := sql.Open(vectorTestDriverName, path)
+	require.NoError(t, err)
+	var ordinal int64
+	require.NoError(t, raw.QueryRow(
+		`SELECT ordinal FROM message_vectors_generations WHERE gen_key = ?`,
+		gen.Fingerprint()).Scan(&ordinal))
+	_, err = raw.Exec(`UPDATE message_vectors_v`+strconv.FormatInt(ordinal, 10)+` SET embedding = ?`,
+		make([]byte, 4*4))
+	require.NoError(t, err)
+	require.NoError(t, raw.Close())
+
+	failingEncoder := func(context.Context, []string) ([][]float32, error) {
+		return nil, &vector.HTTPStatusError{
+			Status: http.StatusBadRequest,
+			Body:   "input exceeds token limit",
+		}
+	}
+	m := vector.NewManager(ix, src, vector.EncoderSet{
+		Default: "default",
+		ByName: map[string]vector.ManagedEncoder{
+			"default": {Encode: failingEncoder},
+		},
+	}, gen)
+
+	var out bytes.Buffer
+	err = runDirectBuild(ctx, &out, m, vector.BuildRequest{RepairInvalid: true})
+	require.ErrorContains(t, err, "3 permanently rejected")
+	status := m.Status()
+	require.NotNil(t, status.LastResult)
+	assert.True(t, status.LastResult.Repair.ScanComplete)
+	assert.Equal(t, 3, status.LastResult.Repair.Failed)
+	assert.Equal(t, 3, status.LastResult.Repair.Remaining)
+	assert.True(t, status.LastResult.Repair.RemainingKnown)
+	assert.Contains(t, out.String(), "Repair targets: 3 documents (3 chunks invalidated).")
+	assert.Contains(t, out.String(), "Repair incomplete: 3 failed, 3 remaining.")
+	assert.Contains(t, out.String(), "Embedded 0 documents (0 chunks), skipped 0, stale 0")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/embeddings/build", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/api/v1/embeddings/status", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(status))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	var daemonOut bytes.Buffer
+	err = buildViaDaemon(ctx, &daemonOut, embeddingsDaemonClient{baseURL: srv.URL},
+		vector.BuildRequest{RepairInvalid: true})
+	require.ErrorContains(t, err, "3 permanently rejected")
+	assert.Contains(t, daemonOut.String(), "Repair incomplete: 3 failed, 3 remaining.")
+}
+
+func TestRunDirectBuildPrintsCommittedTargetsAfterScanFailure(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "vectors.db")
+	ix, err := vector.Open(ctx, path, false, 8192)
+	require.NoError(t, err)
+	defer ix.Close()
+	gen := kitvec.Generation{Model: "fake-model", Dimensions: 4}
+	const documentCount = 129
+	src := fakePushUnitSource{units: make([]db.EmbeddableUnit, 0, documentCount)}
+	for i := range documentCount {
+		id := fmt.Sprintf("doc-%03d", i)
+		src.units = append(src.units, db.EmbeddableUnit{
+			SessionID: "session-1", Kind: "user", SourceUUID: id,
+			Ordinal: i, OrdinalEnd: i, Content: id,
+		})
+	}
+	_, err = ix.Build(ctx, src, fakePushEncoder(), gen, vector.BuildOptions{})
+	require.NoError(t, err)
+
+	raw, err := sql.Open(vectorTestDriverName, path)
+	require.NoError(t, err)
+	var ordinal int64
+	require.NoError(t, raw.QueryRow(
+		`SELECT ordinal FROM message_vectors_generations WHERE gen_key = ?`,
+		gen.Fingerprint()).Scan(&ordinal))
+	_, err = raw.Exec(`UPDATE message_vectors_v`+strconv.FormatInt(ordinal, 10)+` SET embedding = ?`,
+		make([]byte, 4*4))
+	require.NoError(t, err)
+	_, err = raw.Exec(`
+CREATE TRIGGER fail_second_repair_batch
+BEFORE INSERT ON message_vectors_repair_queue
+WHEN NEW.doc_key = 'u:session-1:doc-128'
+BEGIN
+    SELECT RAISE(ABORT, 'injected later repair batch failure');
+END`)
+	require.NoError(t, err)
+	require.NoError(t, raw.Close())
+
+	m := vector.NewManager(ix, src, vector.EncoderSet{
+		Default: "default",
+		ByName: map[string]vector.ManagedEncoder{
+			"default": {Encode: func(context.Context, []string) ([][]float32, error) {
+				t.Fatal("scan failure must stop before refill")
+				return nil, nil
+			}},
+		},
+	}, gen)
+	var out bytes.Buffer
+	err = runDirectBuild(ctx, &out, m, vector.BuildRequest{RepairInvalid: true})
+	require.ErrorContains(t, err, "injected later repair batch failure")
+	status := m.Status()
+	require.NotNil(t, status.LastResult)
+	assert.True(t, status.LastResult.Repair.Scanned)
+	assert.False(t, status.LastResult.Repair.ScanComplete)
+	assert.Equal(t, 128, status.LastResult.Repair.Documents)
+	assert.Equal(t, 128, status.LastResult.Repair.Remaining)
+	assert.True(t, status.LastResult.Repair.RemainingKnown)
+	assert.Contains(t, out.String(), "Repair targets: 128 documents (128 chunks invalidated).")
+	assert.Contains(t, out.String(), "Repair scan incomplete.")
+	assert.Contains(t, out.String(), "Repair incomplete: 0 failed, 128 remaining.")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/embeddings/build", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/api/v1/embeddings/status", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(status))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	var daemonOut bytes.Buffer
+	err = buildViaDaemon(ctx, &daemonOut, embeddingsDaemonClient{baseURL: srv.URL},
+		vector.BuildRequest{RepairInvalid: true})
+	require.ErrorContains(t, err, "injected later repair batch failure")
+	assert.Contains(t, daemonOut.String(), "Repair scan incomplete.")
+	assert.Contains(t, daemonOut.String(), "Repair incomplete: 0 failed, 128 remaining.")
+}
+
 // TestEmbeddingsBuildDirectPrintsProgress shrinks the direct path's
 // progress ticker and slows the embeddings stub down so the build is still
 // running when the ticker fires, asserting at least one progress line in
@@ -877,7 +1023,9 @@ func TestEmbeddingsBuildDispatchesToDaemon(t *testing.T) {
 			buildCalled.Store(true)
 			var req vector.BuildRequest
 			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
-			assert.True(t, req.Backstop, "--backstop must pass through to the daemon")
+			assert.False(t, req.Backstop)
+			assert.True(t, req.RepairInvalid,
+				"--repair-invalid must pass through to the daemon")
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusAccepted)
 			_ = json.NewEncoder(w).Encode(map[string]bool{"started": true})
@@ -889,7 +1037,11 @@ func TestEmbeddingsBuildDispatchesToDaemon(t *testing.T) {
 				Running: false,
 				LastResult: &vector.BuildResult{
 					Activated: true,
-					Fill:      kitvec.FillStats{Documents: 5, Chunks: 6},
+					Repair: vector.RepairStats{
+						Scanned: true, ScanComplete: true, RemainingKnown: true,
+						Documents: 2, Chunks: 3,
+					},
+					Fill: kitvec.FillStats{Documents: 5, Chunks: 6},
 				},
 			})
 		},
@@ -898,15 +1050,60 @@ func TestEmbeddingsBuildDispatchesToDaemon(t *testing.T) {
 	cmd := newEmbeddingsBuildCommand()
 	var out bytes.Buffer
 	cmd.SetOut(&out)
-	cmd.SetArgs([]string{"--backstop"})
+	cmd.SetArgs([]string{"--repair-invalid"})
 	require.NoError(t, cmd.Execute())
 
 	assert.True(t, buildCalled.Load(), "build must route through the daemon endpoint")
 	assert.True(t, statusCalled.Load(), "build must poll the daemon status endpoint")
 	assert.Contains(t, out.String(), "Embedded 5 documents (6 chunks), skipped 0, stale 0")
+	assert.Contains(t, out.String(), "Repair targets: 2 documents (3 chunks invalidated).")
 	assert.Contains(t, out.String(), "Generation activated.")
 	assert.NoFileExists(t, filepath.Join(dataDir, "vectors.db"),
 		"daemon-dispatched build must not open vectors.db directly")
+}
+
+func TestEmbeddingsBuildRejectsBackstopWithRepair(t *testing.T) {
+	cmd := newEmbeddingsBuildCommand()
+	require.NoError(t, cmd.Flags().Set("backstop", "true"))
+	require.NoError(t, cmd.Flags().Set("repair-invalid", "true"))
+
+	err := cmd.ValidateFlagGroups()
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "if any flags in the group")
+}
+
+func TestEmbeddingsBuildRejectsRepairWithFullRebuild(t *testing.T) {
+	cmd := newEmbeddingsBuildCommand()
+	cmd.SetArgs([]string{"--repair-invalid", "--full-rebuild", "--yes"})
+
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "[full-rebuild repair-invalid]")
+}
+
+func TestPrintBuildSummaryReportsCleanRepairScan(t *testing.T) {
+	var out bytes.Buffer
+	printBuildSummary(&out, vector.BuildResult{
+		Repair: vector.RepairStats{
+			Scanned: true, ScanComplete: true, RemainingKnown: true,
+		},
+	})
+
+	assert.Contains(t, out.String(), "Repair targets: 0 documents (0 chunks invalidated).")
+}
+
+func TestPrintBuildSummaryReportsUnknownRemainingCount(t *testing.T) {
+	var out bytes.Buffer
+	printBuildSummary(&out, vector.BuildResult{
+		Repair: vector.RepairStats{
+			Scanned: true, ScanComplete: false, Documents: 7, Remaining: 7,
+		},
+	})
+
+	assert.Contains(t, out.String(), "Repair scan incomplete.")
+	assert.Contains(t, out.String(), "Repair incomplete: 0 failed, remaining unknown.")
+	assert.NotContains(t, out.String(), "7 remaining")
 }
 
 // TestEmbeddingsActivateDispatchesToDaemon drives the real `embeddings
@@ -997,6 +1194,13 @@ func TestBuildViaDaemonLastErrorReturnsNonZero(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(vector.BuildStatus{
 			Running:   false,
 			LastError: "encoder rejected input",
+			LastResult: &vector.BuildResult{
+				Repair: vector.RepairStats{
+					Scanned: true, ScanComplete: true, RemainingKnown: true,
+					Documents: 2, Chunks: 3, Failed: 1, Remaining: 1,
+				},
+				Fill: kitvec.FillStats{Documents: 1, Chunks: 1},
+			},
 		})
 	})
 	srv := httptest.NewServer(mux)
@@ -1007,6 +1211,9 @@ func TestBuildViaDaemonLastErrorReturnsNonZero(t *testing.T) {
 	err := buildViaDaemon(context.Background(), &out, client, vector.BuildRequest{})
 	require.Error(t, err)
 	assert.Equal(t, "encoder rejected input", err.Error())
+	assert.Contains(t, out.String(), "Repair targets: 2 documents (3 chunks invalidated).")
+	assert.Contains(t, out.String(), "Repair incomplete: 1 failed, 1 remaining.")
+	assert.Contains(t, out.String(), "Embedded 1 documents (1 chunks), skipped 0, stale 0")
 }
 
 // TestDirectListGenerationsVersionMismatchSurfacesRebuildRequired pins the

--- a/cmd/agentsview/serve_background_test.go
+++ b/cmd/agentsview/serve_background_test.go
@@ -1163,8 +1163,11 @@ func TestEnsureBackgroundServeLaunchLoserReplacesStaleDaemonAfterStartup(
 	released := make(chan struct{})
 	go func() {
 		time.Sleep(2 * startProbeTick())
-		unlockStart()
+		// The parent launch lock clears before the child finishes startup.
+		// Preserve that lifecycle ordering now that unlockStart waits until
+		// the child lock is observably released.
 		_ = launchLock.Unlock()
+		unlockStart()
 		close(released)
 	}()
 

--- a/cmd/agentsview/vector_test_driver_cgo_test.go
+++ b/cmd/agentsview/vector_test_driver_cgo_test.go
@@ -1,0 +1,5 @@
+//go:build !windows && cgo
+
+package main
+
+const vectorTestDriverName = "sqlite3"

--- a/cmd/agentsview/vector_test_driver_modernc_test.go
+++ b/cmd/agentsview/vector_test_driver_modernc_test.go
@@ -1,0 +1,5 @@
+//go:build windows || !cgo
+
+package main
+
+const vectorTestDriverName = "sqlite"

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -210,7 +210,44 @@ The encoder POSTs to `<endpoint>/embeddings` with an OpenAI-style
 `{"data": [{"index": 0, "embedding": [...]}]}` back — this matches Ollama's
 `/v1/embeddings` route as well as OpenAI and most self-hosted OpenAI-compatible
 servers. A response whose embedding length doesn't match `dimension` is
-rejected.
+rejected. AgentsView also rejects non-finite components (`NaN` or infinity),
+JSON `null` components, and zero-norm vectors before they can be written to the
+index. Those failures are retried according to `max_retries`; if every attempt
+is invalid, the build stops and leaves the document pending.
+
+### Direct `llama-server` for high-throughput Ollama models
+
+Ollama's normal `/v1/embeddings` route above is the supported, simplest setup.
+Operators who run the `llama-server` binary bundled with Ollama directly to get
+explicit slot and batch controls should disable its prompt-state cache for a
+dedicated embedding service:
+
+```bash
+llama-server \
+  --model /path/to/embedding-model.gguf \
+  --alias my-embedding-model \
+  --host 127.0.0.1 --port 11435 \
+  --embedding --parallel 4 \
+  --batch-size 8192 --ubatch-size 8192 \
+  --cache-ram 0 --no-cache-prompt --no-cache-idle-slots \
+  --slot-prompt-similarity 0
+```
+
+These are `llama-server` command-line flags, not `ollama serve` environment
+variables. Its prompt cache stores reusable inference state rather than a final
+embedding API result. Independent document embeddings do not need conversational
+prefix reuse, and bad or saturated slot state can yield non-finite output for
+otherwise valid input. Some llama.cpp builds do not apply the global
+`--no-cache-prompt` default to embedding tasks; without
+`--slot-prompt-similarity 0`, an exact retry can then be routed back to the same
+bad slot. Disabling similarity routing lets retries use the least-recently-used
+slot while retaining multiple request slots and large physical/logical batches.
+
+Run `llama-server --help` for the installed binary before adopting this direct
+setup. If any of these flags are unavailable, upgrade the bundled llama.cpp
+binary or use Ollama's normal `/v1/embeddings` route instead. AgentsView's
+validation remains the final safety boundary either way: invalid endpoint output
+aborts the build and is never written.
 
 ## What gets embedded: units, not messages
 
@@ -243,6 +280,7 @@ agentsview embeddings build            # incremental: refresh + fill whatever's 
 agentsview embeddings build --yes      # skip confirmation prompts
 agentsview embeddings build --full-rebuild --yes  # re-embeds every document
 agentsview embeddings build --backstop # force a full mirror reconciliation scan
+agentsview embeddings build --repair-invalid # regenerate only documents with invalid stored vectors
 agentsview embeddings build --include-automated  # embed automated sessions for this build only
 agentsview embeddings build --using build-box    # encode against a named server instead of the default
 ```
@@ -260,6 +298,74 @@ so mixing the flag with a different config default flips the index's scope back
 and forth on every other build, forcing a full mirror reconciliation each time.
 Set `include_automated = true` in `config.toml` instead if you want automated
 sessions embedded on every build.
+
+`--repair-invalid` targets the existing generation whose fingerprint matches the
+current embedding configuration; it fails without writing if that generation
+does not exist. It does not accept a generation ID. The command scans stored
+documents with a revision-current generation stamp in bounded batches and checks
+for malformed byte length, a length that differs from the generation's declared
+dimension, missing referenced vector rows, duplicate, missing, or unexpected
+chunk indices, non-finite components, and zero norm. Documents already pending
+because their content changed are left for an ordinary build. If one chunk is
+invalid, AgentsView invalidates that document's target-generation chunks and
+stamp, then runs a repair-only fill restricted to the affected document keys.
+Each bounded invalidation transaction queues its targets before removing old
+data, so interruption during a large scan remains resumable without holding
+every affected document in memory.
+
+Repair never refreshes or expands the document mirror, creates or resets a
+generation, or changes generation state. Valid documents, other generations, and
+unrelated work that was already pending are preserved. A later ordinary
+`embeddings build` handles that unrelated work. Queued targets are cleared only
+after non-empty replacement vectors are saved, except when the current queued
+revision splits into zero chunks and is validly completed by an empty-document
+stamp. Once queued, a document remains a repair target across content revisions:
+a stale save writes nothing, and the next repair reads the latest mirrored
+content. This ownership applies only to documents already identified as corrupt,
+not to unrelated pending changes. An ordinary build that saves non-empty
+validated vectors for the queued generation also clears the target. An ordinary
+permanent rejection may write an empty skip stamp, but it leaves the repair
+target queued; a rejection inside repair writes no stamp. Timeouts,
+cancellations, and retryable service errors abort repair immediately. Full
+rebuilds preserve queued targets before refill, so an empty permanent-skip stamp
+during that rebuild cannot erase repair ownership. A permanent rejection inside
+repair remains queued and unstamped, but repair attempts later targets before
+returning a nonzero aggregate error. A failure after a valid save but before
+queue cleanup may leave a valid stamp; the queued target is still retried
+safely. Repair never uses the ordinary build's empty-vector skip stamp. Mirror
+deletion removes queued targets for documents that no longer exist; the queue
+has a document-key index so that cleanup does not scan all interrupted repairs.
+
+A nonempty mapping is valid only when its sorted chunk indices exactly match the
+configured splitter's output and every mapping references a valid vector. A
+stamped document with no chunk mappings is not classified as corruption, because
+ordinary builds intentionally use that representation for a document the
+endpoint permanently rejects. Raw vector rows with no chunk mapping are also
+outside repair scope: they cannot be surfaced as search hits. The scan is
+explicit because its work scales with the stored generation; scheduled delta and
+backstop builds do not run it automatically. CLI repair statistics report the
+queued target count and the chunk mappings invalidated by the current scan; the
+ordinary embedded count reports successful replacements. Repair succeeds only
+after the integrity scan completes and the durable target queue is empty. On a
+failed repair, the CLI prints the partial result, including whether the scan
+completed plus failed and remaining target counts, before returning a nonzero
+status. A later scan-batch failure retains counts from earlier committed batches
+and best-effort reports the durable queue size. The committed count remains the
+fallback, and cancellation does not cancel the short queue recount. If that
+recount also fails, the result marks the count unknown and the CLI reports
+`remaining unknown` rather than presenting the fallback as exact. Failed target
+counts cover non-stale encode/save failures that determine or accompany the
+invocation failure. Stale saves remain in the ordinary stale count, sibling work
+canceled after another failure is not counted, and scan failures are reported
+through the incomplete scan state.
+
+The repair status contract requires local daemon API version 3. After upgrading
+AgentsView, restart any explicitly managed daemon; the CLI rejects an older
+daemon instead of treating absent completion or certainty fields as false.
+
+`--repair-invalid` is mutually exclusive with both `--full-rebuild` and
+`--backstop`: repair preserves the existing mirror and valid work, while those
+modes deliberately rebuild or reconcile broader index state.
 
 `embeddings build` mirrors the embeddable universe (user documents and assistant
 runs, see [What gets embedded](#what-gets-embedded-units-not-messages)) into
@@ -485,18 +591,20 @@ of `ordinal_range` to read the whole stretch.
 
 ## Error taxonomy
 
-| Situation                                                                                               | Message                                                                                                                                                    |
-| ------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `[vector]` not enabled                                                                                  | `vector search is not enabled: set [vector] enabled = true in config.toml` (from `agentsview embeddings ...`)                                              |
-| No `VectorSearcher` wired (index never built, DuckDB backend, or PG with no matching pushed generation) | `semantic search not available: enable [vector] in config.toml and run 'agentsview embeddings build'`                                                      |
-| Only a building generation exists                                                                       | same message, plus `: index is building: N% complete`                                                                                                      |
-| Active generation's fingerprint no longer matches config (model, dimension, or chunking changed)        | same message, plus `: index is stale (embedding config changed): run 'agentsview embeddings build --full-rebuild'`                                         |
-| Index was built by an incompatible agentsview version (mirror schema mismatch)                          | same message, plus `` : vector index was built by an incompatible version: run `agentsview embeddings build` ``                                            |
-| `--scope` with a lexical mode (or without `--semantic`/`--hybrid`)                                      | CLI: `--scope requires --semantic or --hybrid`; HTTP/MCP: `scope is only supported for semantic and hybrid search modes`                                   |
-| Embeddings endpoint unreachable or timed out                                                            | `[vector.embeddings] request: ...` (the underlying transport error)                                                                                        |
-| Embeddings endpoint returned non-200                                                                    | `[vector.embeddings] status <code>: <body>`                                                                                                                |
-| `--in` names a source other than `messages` with `--semantic`/`--hybrid`                                | CLI: `--semantic searches messages only; drop --in` (or `--hybrid ...`); HTTP/MCP: `search: semantic search only supports the messages source (got "...")` |
-| `--cursor` with `--semantic`/`--hybrid`                                                                 | `semantic search returns a single ranked page; cursor pagination is not supported`                                                                         |
+| Situation                                                                                               | Message                                                                                                                                                      |
+| ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `[vector]` not enabled                                                                                  | `vector search is not enabled: set [vector] enabled = true in config.toml` (from `agentsview embeddings ...`)                                                |
+| No `VectorSearcher` wired (index never built, DuckDB backend, or PG with no matching pushed generation) | `semantic search not available: enable [vector] in config.toml and run 'agentsview embeddings build'`                                                        |
+| Only a building generation exists                                                                       | same message, plus `: index is building: N% complete`                                                                                                        |
+| Active generation's fingerprint no longer matches config (model, dimension, or chunking changed)        | same message, plus `: index is stale (embedding config changed): run 'agentsview embeddings build --full-rebuild'`                                           |
+| Index was built by an incompatible agentsview version (mirror schema mismatch)                          | same message, plus `` : vector index was built by an incompatible version: run `agentsview embeddings build` ``                                              |
+| `--scope` with a lexical mode (or without `--semantic`/`--hybrid`)                                      | CLI: `--scope requires --semantic or --hybrid`; HTTP/MCP: `scope is only supported for semantic and hybrid search modes`                                     |
+| Embeddings endpoint unreachable or timed out                                                            | `[vector.embeddings] request: ...` (the underlying transport error)                                                                                          |
+| Embeddings endpoint returned non-200                                                                    | `[vector.embeddings] status <code>: <body>`                                                                                                                  |
+| Embeddings endpoint returned a non-finite or zero-norm vector                                           | `[vector.embeddings] invalid embedding at index <n>: ...`; correct the endpoint/cache configuration, then run `agentsview embeddings build --repair-invalid` |
+| Embeddings endpoint returned a JSON `null` component                                                    | `[vector.embeddings] decode response: embedding component <n> is null`; correct the endpoint/cache configuration, then run the targeted repair               |
+| `--in` names a source other than `messages` with `--semantic`/`--hybrid`                                | CLI: `--semantic searches messages only; drop --in` (or `--hybrid ...`); HTTP/MCP: `search: semantic search only supports the messages source (got "...")`   |
+| `--cursor` with `--semantic`/`--hybrid`                                                                 | `semantic search returns a single ranked page; cursor pagination is not supported`                                                                           |
 
 Over HTTP (`GET /api/v1/search/content`) and MCP (`search_content`), the "not
 available" family of errors maps to HTTP `501 Not Implemented` and the matching

--- a/docs/superpowers/plans/2026-07-13-invalid-embedding-repair.md
+++ b/docs/superpowers/plans/2026-07-13-invalid-embedding-repair.md
@@ -1,0 +1,383 @@
+# Invalid Embedding Repair Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent malformed embeddings from being persisted and provide an
+opt-in build mode that regenerates only documents whose stored vectors are
+invalid.
+
+**Architecture:** A shared validator rejects non-finite and zero-norm vectors at
+both the HTTP-response and index-persistence boundaries. The target-generation
+repair pass streams stored vectors, durably queues affected document keys,
+invalidates only those documents, and refills through a queue-backed store that
+cannot see unrelated pending work. Repair bypasses mirror refresh and generation
+lifecycle operations entirely.
+
+**Tech Stack:** Go, `database/sql`, sqlite-vec, Cobra, Huma, testify, Markdown.
+
+## Global Constraints
+
+- Never persist or stamp a document whose embedding is malformed, non-finite, or
+  zero norm.
+- Never normalize, truncate, clamp, substitute, or skip-stamp invalid endpoint
+  output.
+- Repair only the selected target generation and only revision-current documents
+  containing an invalid mapped vector or a partial nonempty mapping.
+- Repair must not refresh or expand the mirror, create or reset a generation, or
+  change generation state.
+- Do not scan for corruption during background builds; repair is explicitly
+  opt-in.
+- Do not modify or recreate the persistent session archive.
+- Preserve existing generation selection, activation, and incremental-fill
+  behavior.
+
+______________________________________________________________________
+
+### Task 1: Validate Endpoint and Build Encoder Output
+
+**Files:**
+
+- Modify: `internal/vector/encoder.go`
+- Modify: `internal/vector/encoder_test.go`
+- Modify: `internal/vector/build.go`
+- Modify: `internal/vector/build_test.go`
+
+**Interfaces:**
+
+- Produces: `validateEmbedding([]float32, int) error` and
+  `validateEmbeddings([][]float32) error`.
+
+- Produces: `InvalidEmbeddingError`, returned for non-finite components and zero
+  norms.
+
+- Consumes: `kitvec.EncodeFunc`; `Index.Build` wraps it before passing it to
+  `kitvec.Fill`.
+
+- [x] **Step 1: Add failing endpoint-validation tests**
+
+Add table-driven tests that return base64 vectors containing `NaN`, positive
+infinity, negative infinity, and all zeros, and assert `NewEncoder` returns no
+vectors plus an `InvalidEmbeddingError`. Add literal JSON response tests for
+`[0.5,null]` and `[null,null]`, asserting decoding fails rather than converting
+nulls to zero. Add a server that returns invalid output once and valid output
+next, asserting two requests and a successful vector.
+
+- [x] **Step 2: Run endpoint tests and confirm the intended failures**
+
+Run:
+`go test -tags fts5 ./internal/vector -run 'TestEncoder.*(Invalid|Null|Retries)' -count=1`
+
+Expected: FAIL because invalid vectors are accepted and JSON null elements
+decode as zeros.
+
+- [x] **Step 3: Implement shared validation and retry classification**
+
+In `embeddingVector.UnmarshalJSON`, decode JSON arrays as `[]json.RawMessage`,
+reject a trimmed element equal to `null`, and unmarshal each remaining element
+to `float32`. Define `InvalidEmbeddingError` with response/component context.
+Implement validation using `math.IsNaN`, `math.IsInf`, and a `float64` squared
+norm. Call it from `reorderAndValidate`, and make validation failures from
+`attemptEncode` retryable.
+
+- [x] **Step 4: Add a failing persistence-boundary test**
+
+Build with a custom `kitvec.EncodeFunc` that returns a zero or non-finite
+vector. Assert `Index.Build` returns `InvalidEmbeddingError`, and query the
+target generation to prove it has no vector chunk and no completion stamp.
+
+- [x] **Step 5: Run the persistence-boundary test and confirm failure**
+
+Run:
+`go test -tags fts5 ./internal/vector -run TestBuildRejectsInvalidEncoderOutput -count=1`
+
+Expected: FAIL because the alternate encoder currently reaches `SaveVectors`.
+
+- [x] **Step 6: Wrap every build encoder with validation**
+
+Add a small `validatingEncoder` wrapper in `build.go` that returns no vectors
+when `validateEmbeddings` fails, and pass it into the existing progress wrapper
+and fill operation.
+
+- [x] **Step 7: Run focused vector tests**
+
+Run:
+`go test -tags fts5 ./internal/vector -run 'TestEncoder|TestBuildRejectsInvalidEncoderOutput' -count=1`
+
+Expected: PASS.
+
+### Task 2: Durable Repair Queue Lifecycle
+
+**Files:**
+
+- Modify: `internal/vector/index.go`
+- Modify: `internal/vector/mirror.go`
+- Modify: `internal/vector/mirror_test.go`
+- Create: `internal/vector/repair_test.go`
+
+**Interfaces:**
+
+- Produces: `message_vectors_repair_queue`, keyed by generation ordinal and
+  document key, plus a document-key-first cleanup index.
+
+- [x] **Step 1: Create the durable queue with the vector mirror**
+
+Create the queue on writable index open and add the document-key index required
+by mirror cleanup. A whole mirror-schema replacement recreates the queue with
+the mirror, but a generation full rebuild must preserve queued targets: only a
+later ordinary non-empty validated save or a repair-verified zero-chunk save may
+complete them.
+
+- [x] **Step 2: Keep queue lifecycle aligned with mirror deletion**
+
+Delete a document's repair targets from both mirror deletion paths and cover the
+indexed deletion query plan. Orphan pruning belongs to the detection stage that
+owns repair startup; post-save cleanup belongs to the refill stage that owns
+completion.
+
+### Task 3: Bounded Integrity Detection and Invalidation
+
+**Files:**
+
+- Create: `internal/vector/repair.go`
+- Modify: `internal/vector/repair_test.go`
+- Modify: `internal/vector/build.go`
+
+**Interfaces:**
+
+- Produces:
+  `(*Index).repairInvalidVectors(context.Context, string) (repairResult, error)`.
+
+- Extends: `BuildOptions.RepairInvalid bool` and
+  `BuildResult.Repair RepairStats`.
+
+- Produces scan-owned
+  `RepairStats{Scanned, ScanComplete, RemainingKnown bool; Documents, Chunks, Remaining int}`
+  plus the bounded queue-count helper. Refill adds `Failed` in Task 4.
+
+- [x] **Step 1: Add failing targeted-detection tests**
+
+Create two documents in a target generation and a second generation, corrupt one
+target-generation chunk through sqlite-vec, then invoke the detection and
+invalidation pass directly. Assert exactly one document is durably queued, its
+target-generation chunks and stamp are removed, the valid document and other
+generation are byte-for-byte unaffected, and the result reports one repair
+target plus the number of invalidated chunks. Also cover a missing vector row, a
+partial nonempty mapping, and a stale-stamp content change that must remain
+ordinary pending work. Re-encoding is reserved for Task 4.
+
+- [x] **Step 2: Run the repair test and confirm failure**
+
+Run:
+`go test -tags fts5 ./internal/vector -run TestRepairInvalidVectorsQueuesOnlyAffectedDocument -count=1`
+
+Expected: FAIL because `RepairInvalid`, `RepairStats`, and the repair pass do
+not exist.
+
+- [x] **Step 3: Implement bounded detection and invalidation**
+
+In `repair.go`, resolve the generation ordinal and vector table, then
+keyset-page through bounded groups of documents. Stream each group's chunk
+indices and raw `embedding` values, decode little-endian float32 blobs, and
+reuse the shared validator. Treat malformed blob lengths, wrong dimensions,
+missing referenced vector rows, and duplicate, missing, or unexpected chunk
+indices as invalid. Only scan documents whose generation stamp matches the
+mirror's current content revision, leaving ordinary pending content changes
+untouched. Commit one invalidation transaction per bounded group, queueing each
+key before deleting its target-generation vectors, chunk-map rows, and stamp.
+Keep queued keys until the canonical completion policy in Task 4 is satisfied,
+clear queued keys when their mirror document is deleted, and prune orphans at
+repair startup. Count every invalidated chunk without materializing the affected
+corpus or creating one corpus-sized transaction.
+
+- [x] **Step 4: Verify interruption between scan batches**
+
+Inject a failure when the second batch queues its first key. Prove the first
+batch remains committed and queued and the partial result reports scan-started,
+scan-incomplete, and the durable remaining count. Use the committed count as a
+fallback and run the best-effort recount under a short context detached from
+build cancellation. Remove the failure, rerun the detection scan, and verify it
+completes while preserving the durable queue. Queue drainage and repaired-vector
+convergence belong to Task 4A.
+
+### Task 4: Restricted Refill and Resumption
+
+**Files:**
+
+- Modify: `internal/vector/repair.go`
+- Modify: `internal/vector/repair_test.go`
+- Modify: `internal/vector/build.go`
+
+**Interfaces:**
+
+- Produces: queue-backed `repairStore` and `fillRepairQueue`, whose pending and
+  progress queries read only durable repair targets.
+
+- Extends the scan-owned statistics with `Failed`; final refill recounts update
+  `Remaining` and `RemainingKnown`.
+
+#### Task 4A: Restricted Refill and Failure Handling
+
+- [x] **Step 1: Add failing refill and failure-policy tests**
+
+Cover retryable errors, cancellation, permanent rejection followed by later
+targets, configured document concurrency, and failure between a successful
+vector save and queue deletion. Encode and save failures remain queued and
+unstamped; a completion-cleanup failure may leave a valid stamp but must remain
+queued and retryable. Resume a queue preserved by Task 3's interrupted scan and
+prove the restricted refill drains it without broadening into unrelated pending
+work.
+
+- [x] **Step 2: Invoke the restricted repair fill**
+
+When `BuildOptions.RepairInvalid` is true, bypass mirror refresh and generation
+resolution entirely. Use the configured fingerprint only if that generation
+already exists, store the scan stats in `BuildResult`, and run a fill through a
+store restricted to the affected document keys. Do not create, reset, activate,
+or retire any generation. Do not install the ordinary build's permanent-error
+skip callback on the repair fill, and make the repair store reject empty saves
+unless the current queued revision deterministically splits into zero chunks.
+That exception is a valid empty-document completion, not an encoder-error skip.
+Keyset-page the repair fill so a permanently rejected target remains queued
+without starving later targets; continue to every later target after permanent
+document-specific rejection, then return an aggregate error unless the queue is
+empty. Retryable endpoint or system errors, timeouts, and cancellation abort the
+current invocation. The restricted refill reads only queue membership and never
+broadens into unrelated work.
+
+#### Task 4B: Cross-Build Queue Ownership
+
+- [x] **Step 3: Preserve ownership across revisions and ordinary builds**
+
+The queue owns its document across revision changes and a later repair reads the
+latest mirrored revision; a stale save writes nothing and leaves the key queued.
+An ordinary build clears a target only after a non-empty validated save for that
+generation. Its empty permanent-skip stamp may remain, but cannot clear the
+target. Full generation reset also preserves the queue. Cover revision drift,
+ordinary completion, and a full rebuild whose permanent skip writes only an
+empty stamp.
+
+#### Task 4C: Zero-Chunk Completion and Bounded Ordinary Cleanup
+
+- [x] **Step 4: Converge empty revisions without weakening persistence**
+
+Repair may clear a target after a revision-current save only when the current
+content deterministically splits into zero chunks. Every other empty repair save
+is rejected. Cover a queued nonempty revision becoming zero-chunk content
+without calling the encoder. Pin ordinary completion's query plan to the queue's
+composite primary key so the additional no-match lookup stays bounded per saved
+document.
+
+- [x] **Step 5: Run vector tests**
+
+Run: `go test -tags fts5 ./internal/vector -count=1`
+
+Expected: PASS, including preservation of valid documents and retired
+generations.
+
+### Task 5: Expose Repair Through Manager, API, CLI, and Documentation
+
+**Files:**
+
+- Modify: `internal/vector/manager.go`
+- Modify: `internal/vector/manager_test.go`
+- Modify: `internal/server/huma_routes_embeddings.go`
+- Modify: `internal/server/huma_routes_embeddings_test.go`
+- Modify: `internal/server/server.go`
+- Modify: `internal/server/server_test.go`
+- Modify: `cmd/agentsview/embeddings.go`
+- Modify: `cmd/agentsview/embeddings_test.go`
+- Modify: `cmd/agentsview/daemon_runtime.go`
+- Modify: `cmd/agentsview/daemon_runtime_test.go`
+- Modify: `docs/semantic-search.md`
+- Modify: `frontend/src/lib/api/generated/models/VectorBuildRequest.ts`
+- Modify: `frontend/src/lib/api/generated/models/VectorBuildResult.ts`
+- Create: `frontend/src/lib/api/generated/models/VectorRepairStats.ts`
+
+**Interfaces:**
+
+- Extends:
+  `BuildRequest.RepairInvalid bool \`json:"repair_invalid,omitempty"\`\`.
+
+- Extends: `EmbeddingsBuildOptions.RepairInvalid bool`.
+
+- Adds: `agentsview embeddings build --repair-invalid`.
+
+- [x] **Step 1: Add failing request and CLI behavior tests**
+
+Assert the Huma build endpoint accepts `{"repair_invalid":true}` and passes it
+to the manager. Assert `runEmbeddingsBuild` sends `RepairInvalid: true` to the
+daemon without triggering the full-rebuild confirmation. Assert
+`printBuildSummary` reports repair targets and invalidated chunks separately
+from successfully embedded documents. Use a real failed repair through the
+manager, direct CLI, and daemon-status serialization; assert its scan state,
+partial result, failed count, and remaining queue count are printed before the
+command returns a nonzero error. Exercise a real context cancellation after one
+scan batch commits, then prove `Index.Build`, manager status serialization, and
+direct CLI output preserve the exact remaining count.
+
+- [x] **Step 2: Run focused tests and confirm failure**
+
+Run:
+`go test -tags fts5 ./internal/server ./cmd/agentsview -run 'Test.*RepairInvalid' -count=1`
+
+Expected: FAIL because the request field, flag, threading, and summary are
+absent.
+
+- [x] **Step 3: Thread the option through each owned boundary**
+
+Add the JSON request field and copy it into `BuildOptions` in
+`Manager.runBuild`. Register the Cobra boolean flag, copy it into
+`BuildRequest`, and print a repair summary when the scan invalidates documents.
+Always store the most recent `BuildResult`, including a failed attempt's partial
+repair statistics, so a new error is never paired with a stale prior success.
+Print that result before returning the direct or daemon error. Validate
+repair/full-rebuild and repair/backstop conflicts synchronously in the manager
+and map them to HTTP 400 before a build starts. Regenerate the tracked
+TypeScript API client with `npm run generate:api` and run `npm run check`. Leave
+scheduler-generated requests at the default `false` so background builds remain
+bounded. Define one shared HTTP/daemon API version, bump it to version 3 for the
+expanded repair status contract, and reject a still-running version-2 daemon
+with restart guidance rather than decoding absent status fields as false.
+
+- [x] **Step 4: Update semantic-search documentation**
+
+Document `--repair-invalid` as the targeted recovery command. Retain the
+standard Ollama `/v1/embeddings` setup, add a distinct direct-`llama-server`
+high-throughput example with
+`--cache-ram 0 --no-cache-prompt --no-cache-idle-slots`, explain why
+prompt-state caching is unsafe for independent embeddings, and add
+invalid-vector guidance to the error taxonomy.
+
+- [x] **Step 5: Run focused CLI, server, manager, and vector tests**
+
+Run:
+`go test -tags fts5 ./internal/vector ./internal/server ./cmd/agentsview -count=1`
+
+Expected: PASS.
+
+### Task 6: Format, Verify, and Commit
+
+**Files:**
+
+- No additional files.
+
+**Interfaces:**
+
+- Produces: a verified, reviewable implementation commit.
+
+- [x] **Step 1: Format and run repository validation**
+
+Run: `gofmt -w` on changed Go files, `go fmt ./...`, `go vet ./...`,
+`make test`, and `make build`.
+
+Expected: all commands exit zero.
+
+- [x] **Step 2: Commit the tracked implementation**
+
+Stage every tracked implementation artifact from the preceding tasks, including
+the generated TypeScript API models, along with the plan, Go source/tests, and
+documentation. Commit with a focused conventional message and without generated
+attribution.

--- a/docs/superpowers/specs/2026-07-13-invalid-embedding-rejection-design.md
+++ b/docs/superpowers/specs/2026-07-13-invalid-embedding-rejection-design.md
@@ -26,7 +26,7 @@ otherwise hide an invalid vector.
   without a vector or completion stamp.
 - Document cache-safe Ollama and direct `llama-server` operation for embeddings.
 - Repair a corrupted local generation by invalidating and regenerating only
-  documents that contain an invalid stored chunk.
+  documents that contain an invalid stored chunk or a partial chunk mapping.
 
 ## Non-goals
 
@@ -36,6 +36,12 @@ otherwise hide an invalid vector.
 - Do not change the generic vector library's encode-error callback in this
   change. Its continue behavior intentionally skip-stamps a permanently
   rejected document, which is not valid for malformed embedding output.
+- Do not classify a stamped document with no chunk mappings as corrupt. Ordinary
+  builds intentionally use that representation when an endpoint permanently
+  rejects a document, so absence alone is ambiguous.
+- Do not clean raw vector rows that have no chunk mapping. They cannot surface
+  as search hits and are not attributable to a document through the repair
+  scan.
 - Do not modify or recreate the persistent session archive.
 
 ## Design
@@ -113,24 +119,88 @@ affected stored vectors.
 ### Targeted stored-vector repair
 
 `agentsview embeddings build` will gain an explicit `--repair-invalid` option.
-It will scan only the target generation selected by the normal build-resolution
-logic. The scan will stream each chunk's raw sqlite-vec float32 blob and its
-document key, applying the same finite and non-zero validation used for new
-endpoint responses. A malformed blob length is also invalid stored data.
+It targets only the existing generation whose fingerprint matches the current
+embedding configuration and fails without writing if that generation does not
+exist. It does not refresh the document mirror, resolve or create a broader
+build target, or change generation state. The scan applies the same finite and
+non-zero validation used for new endpoint responses to each mapped sqlite-vec
+float32 blob. Malformed byte length, wrong dimension, a missing referenced
+vector row, or duplicate, missing, or unexpected chunk indices are also invalid
+stored data. Only documents whose generation stamp matches the mirror's current
+content revision participate in integrity detection; stale stamps identify
+ordinary pending content changes and repair must not broaden into that work.
+Durable queue entries remain independent of this scan gate so interrupted
+repairs still resume. Once a document is queued, the queue owns it across
+revision changes: a stale save writes nothing and leaves the target queued, and
+the next repair attempt reads the latest mirrored content. This does not claim
+unrelated pending documents because only keys already identified as corrupt
+receive that durable ownership.
+
+The structural invariant is exact: when at least one mapping exists, its sorted
+chunk indices must equal `kitvec.Split(content, options)` and every mapping must
+reference a valid vector. The zero-mapping exception in the non-goals remains
+intentional because it represents ordinary permanent-error skip stamps.
 
 If any chunk is invalid, the whole document must be regenerated because the
 generation stamp covers the document and `SaveVectors` replaces all of its
-chunks together. After the read scan closes, one write transaction will remove
-only the affected documents' rows from the target generation's vec0 table, their
-target-generation chunk-map rows, and their target-generation stamps. Other
-documents and other generations remain unchanged. Removing the stamps makes
-those documents pending for the incremental fill that follows in the same build
-call.
+chunks together. The scan keyset-pages through bounded document groups. After
+each group's read cursor closes, one bounded transaction durably queues its
+affected keys before removing only those documents' rows from the target
+generation's vec0 table, their target-generation chunk-map rows, and their
+target-generation stamps. Other documents and other generations remain
+unchanged. Committing per group keeps both memory and transaction size bounded;
+the durable queue preserves already-invalidated work if a later group or refill
+fails.
+
+The refill store exposes only queued keys. It removes a key only after a
+non-empty replacement save succeeds, except when the current queued revision
+deterministically splits into zero chunks; that case completes with the valid
+empty-document stamp. It treats the queue—not the generation stamp—as the
+authority so a failure between saving vectors and deleting the key is retried
+safely. Repair does not use the ordinary fill's permanent-error skip callback,
+and the store rejects every other empty save as defense in depth. A permanent
+rejection inside the repair fill remains queued and unstamped, while a keyset
+cursor lets the invocation attempt every later target once before returning an
+aggregate error. Retryable endpoint or system errors, timeouts, and cancellation
+abort the current invocation instead of continuing against a failing service. An
+ordinary build that saves non-empty validated vectors for the queued generation
+clears the same target. Its ordinary permanent rejection may leave a stamp-only
+record, but the target remains queued; a repair-fill permanent rejection writes
+no stamp. A full generation rebuild also preserves queued targets before refill,
+so its own empty skip stamp cannot erase repair ownership. Encode or save
+failures leave a target unstamped, while a failure after a valid save but before
+queue cleanup may leave a valid stamp and is retried because the queue remains
+authoritative. Success means the integrity scan finished and the durable queue
+is empty. Mirror deletion removes queued keys for documents that no longer
+exist, using a document-key-first index so cleanup cost does not scale with the
+total queue.
+
+Every non-empty ordinary save performs one repair-queue completion delete for
+its generation and document. That lookup uses the queue's `(ordinal, doc_key)`
+primary key even when no target exists; a query-plan regression pins the bounded
+cost.
 
 The integrity scan is opt-in rather than part of every scheduled incremental
 build. It necessarily scales with the stored generation, while background sync
-work must remain bounded by changed input. Build results and CLI output will
-report how many documents and chunks were invalidated.
+work must remain bounded by changed input. Build results and CLI output report
+the target count (newly detected plus resumed queue entries) and mappings
+invalidated by this scan separately from the fill's successful replacement
+count. `Scanned` means the integrity pass began after resolving its generation;
+`ScanComplete` means it traversed every bounded batch. A later-batch failure
+returns the accumulated committed target counts and a best-effort durable queue
+count. The committed count is the fallback, and the recount uses a short timeout
+detached from build cancellation so cancellation cannot turn known work into a
+misleading zero. `RemainingKnown` distinguishes an exact recount from that
+fallback; when false, CLI output says the remaining count is unknown rather than
+presenting the fallback as exact. `Failed` counts non-stale target encode/save
+failures that determine or accompany the invocation failure. Stale saves remain
+in `Fill.Stale`, sibling work canceled after another failure is not counted, and
+scan failures are represented by `ScanComplete == false`. Failed builds retain
+and expose this partial result before returning a nonzero status.
+
+These repair status semantics bump the local daemon API from version 2 to 3. The
+CLI rejects an older daemon instead of interpreting absent fields as false; an
+explicitly managed daemon must be restarted after upgrading AgentsView.
 
 ### Local recovery
 
@@ -146,10 +216,11 @@ Recovery will use:
 agentsview embeddings build --repair-invalid
 ```
 
-The command will scan the active target generation through the daemon, remove
-only documents containing invalid chunks, and let the ordinary incremental fill
-regenerate them. This avoids ad-hoc SQL against a database owned by the daemon,
-does not recompute valid embeddings, and does not touch the session archive.
+The command will scan the configured existing generation through the daemon,
+remove only revision-current documents containing an invalid mapped vector or a
+partial nonempty mapping, and run the queue-restricted repair fill. This avoids
+ad-hoc SQL against a database owned by the daemon, does not recompute valid
+embeddings, and does not touch the session archive.
 
 After completion, verification will require:
 
@@ -172,7 +243,35 @@ Focused Go tests will cover behavior owned by AgentsView:
 - a custom build encoder returning an invalid vector cannot create either a
   chunk vector or a generation stamp;
 - targeted repair invalidates every chunk and the stamp for a document with one
-  bad chunk, while preserving valid documents and every other generation; and
+  bad chunk, while preserving valid documents and every other generation;
+- repair detects a missing vector row and a partial chunk mapping;
+- queued work remains visible if completion cleanup fails after a valid save,
+  then a retry replaces it and drains the queue;
+- a content change that alters chunk layout remains ordinary pending work and is
+  not claimed by repair;
+- a revision change after a target is queued causes the stale save to write
+  nothing, retains queue ownership, and repairs the latest mirrored revision
+  on retry;
+- a queued revision that becomes zero-chunk content completes with a valid empty
+  stamp without invoking the endpoint;
+- an ordinary build that saves non-empty vectors for a queued generation clears
+  that target, while a stamp-only skip does not;
+- a full rebuild preserves queued targets before refill, including when its
+  encoder permanently skips one of them;
+- failure in a later scan batch leaves the earlier batch durably queued, exposes
+  scan-incomplete and remaining counts, and a retry converges;
+- a canceled scan retains its committed-count fallback and can recount the queue
+  without inheriting the canceled build context;
+- a failed detached recount marks the remaining count unknown instead of
+  presenting the committed fallback as exact;
+- permanent rejection of one target does not prevent later targets from being
+  repaired, and the command returns a nonzero aggregate failure with the
+  rejected target still queued;
+- failed manager, direct CLI, and daemon CLI paths expose the partial result and
+  print failed and remaining counts before returning the error;
+- mirror deletion clears orphaned queue targets through a document-key index;
+- ordinary save completion uses the repair queue's composite primary key even
+  when no matching target exists; and
 - valid finite, non-zero vectors continue through the existing response and
   build paths.
 

--- a/frontend/src/lib/api/generated/index.ts
+++ b/frontend/src/lib/api/generated/index.ts
@@ -202,6 +202,7 @@ export type { VectorBuildResult } from './models/VectorBuildResult';
 export type { VectorBuildStatus } from './models/VectorBuildStatus';
 export type { VectorGenerationInfo } from './models/VectorGenerationInfo';
 export type { VectorRefreshStats } from './models/VectorRefreshStats';
+export type { VectorRepairStats } from './models/VectorRepairStats';
 export type { VersionInfo } from './models/VersionInfo';
 export type { WorktreeMappingRequest } from './models/WorktreeMappingRequest';
 export type { WorktreeMappingsResponse } from './models/WorktreeMappingsResponse';

--- a/frontend/src/lib/api/generated/models/ApiErrorResponse.ts
+++ b/frontend/src/lib/api/generated/models/ApiErrorResponse.ts
@@ -5,4 +5,3 @@
 export type ApiErrorResponse = {
   error: string;
 };
-

--- a/frontend/src/lib/api/generated/models/SyncSyncStats.ts
+++ b/frontend/src/lib/api/generated/models/SyncSyncStats.ts
@@ -13,4 +13,3 @@ export type SyncSyncStats = {
   total_sessions: number;
   warnings?: any[] | null;
 };
-

--- a/frontend/src/lib/api/generated/models/VectorBuildRequest.ts
+++ b/frontend/src/lib/api/generated/models/VectorBuildRequest.ts
@@ -6,6 +6,7 @@ export type VectorBuildRequest = {
   backstop?: boolean;
   full_rebuild?: boolean;
   include_automated?: boolean;
+  repair_invalid?: boolean;
   using?: string;
 };
 

--- a/frontend/src/lib/api/generated/models/VectorBuildResult.ts
+++ b/frontend/src/lib/api/generated/models/VectorBuildResult.ts
@@ -4,10 +4,12 @@
 /* eslint-disable */
 import type { FillStats } from './FillStats';
 import type { VectorRefreshStats } from './VectorRefreshStats';
+import type { VectorRepairStats } from './VectorRepairStats';
 export type VectorBuildResult = {
   Activated: boolean;
   Fill: FillStats;
   Fingerprint: string;
   Refresh: VectorRefreshStats;
+  Repair: VectorRepairStats;
 };
 

--- a/frontend/src/lib/api/generated/models/VectorRepairStats.ts
+++ b/frontend/src/lib/api/generated/models/VectorRepairStats.ts
@@ -1,0 +1,13 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type VectorRepairStats = {
+  chunks: number;
+  documents: number;
+  failed: number;
+  remaining: number;
+  remaining_known: boolean;
+  scan_complete: boolean;
+  scanned: boolean;
+};

--- a/frontend/src/lib/components/settings/EmbeddingsSettings.test.ts
+++ b/frontend/src/lib/components/settings/EmbeddingsSettings.test.ts
@@ -166,6 +166,15 @@ describe("EmbeddingsSettings", () => {
         Fingerprint: "fp-1",
         Activated: true,
         Refresh: { Upserted: 5, Deleted: 0, Unchanged: 100 },
+        Repair: {
+          scanned: false,
+          scan_complete: false,
+          documents: 0,
+          chunks: 0,
+          failed: 0,
+          remaining: 0,
+          remaining_known: false,
+        },
         Fill: { Documents: 12, Chunks: 345, Skipped: 0, Stale: 0 },
       },
     };

--- a/internal/server/huma_routes_embeddings.go
+++ b/internal/server/huma_routes_embeddings.go
@@ -96,7 +96,8 @@ func (s *Server) humaEmbeddingsBuild(
 		if errors.Is(err, vector.ErrBuildRunning) {
 			return nil, apiError(http.StatusConflict, err.Error())
 		}
-		if errors.Is(err, vector.ErrUnknownServer) {
+		if errors.Is(err, vector.ErrUnknownServer) ||
+			errors.Is(err, vector.ErrInvalidBuildRequest) {
 			return nil, apiError(http.StatusBadRequest, err.Error())
 		}
 		return nil, internalError("start embeddings build", err)

--- a/internal/server/huma_routes_embeddings_test.go
+++ b/internal/server/huma_routes_embeddings_test.go
@@ -157,6 +157,36 @@ func TestEmbeddingsBuildReturnsAcceptedAndStartsBuild(t *testing.T) {
 
 	require.Len(t, fake.startBuildCalls, 1)
 	assert.True(t, fake.startBuildCalls[0].FullRebuild)
+	assert.False(t, fake.startBuildCalls[0].RepairInvalid)
+}
+
+func TestEmbeddingsBuildInvalidRequestReturnsBadRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		req  vector.BuildRequest
+	}{
+		{
+			name: "full rebuild with repair",
+			req:  vector.BuildRequest{FullRebuild: true, RepairInvalid: true},
+		},
+		{
+			name: "backstop with repair",
+			req:  vector.BuildRequest{Backstop: true, RepairInvalid: true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &fakeEmbeddingsManager{startBuildErr: fmt.Errorf(
+				"%w: mutually exclusive build modes", vector.ErrInvalidBuildRequest)}
+			s := newEmbeddingsTestServer(t, fake)
+
+			w := serveJSON(t, s.mux, http.MethodPost, "/api/v1/embeddings/build", tt.req)
+			assertRecorderStatus(t, w, http.StatusBadRequest)
+			assert.Contains(t, w.Body.String(), "mutually exclusive")
+			require.Len(t, fake.startBuildCalls, 1)
+			assert.Equal(t, tt.req, fake.startBuildCalls[0])
+		})
+	}
 }
 
 func TestEmbeddingsBuildReturnsConflictWhenAlreadyRunning(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -41,6 +41,11 @@ type VersionInfo struct {
 	DataVersion                int    `json:"data_version"`
 }
 
+// APIVersion is shared by HTTP version reporting and local daemon discovery.
+// Bump it when a client-visible contract cannot be decoded safely by an older
+// CLI or daemon.
+const APIVersion = 3
+
 const daemonService = "agentsview"
 
 const (
@@ -165,7 +170,7 @@ func New(
 		opt(s)
 	}
 	if s.version.APIVersion == 0 {
-		s.version.APIVersion = 2
+		s.version.APIVersion = APIVersion
 	}
 	if s.version.DataVersion == 0 {
 		s.version.DataVersion = db.CurrentDataVersion()

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4505,7 +4505,7 @@ func TestGetVersion(t *testing.T) {
 		)
 	}
 	assert.True(t, resp.InsightGenerationAvailable)
-	assert.Equal(t, 2, resp.APIVersion)
+	assert.Equal(t, server.APIVersion, resp.APIVersion)
 	assert.Equal(t, db.CurrentDataVersion(), resp.DataVersion)
 }
 
@@ -4519,7 +4519,7 @@ func TestGetVersion_Default(t *testing.T) {
 	if resp.Version != "" {
 		t.Errorf("version = %q, want empty", resp.Version)
 	}
-	assert.Equal(t, 2, resp.APIVersion)
+	assert.Equal(t, server.APIVersion, resp.APIVersion)
 	assert.Equal(t, db.CurrentDataVersion(), resp.DataVersion)
 }
 

--- a/internal/vector/build.go
+++ b/internal/vector/build.go
@@ -193,7 +193,7 @@ func (ix *Index) buildInvalidRepair(
 				base: ix.store, db: ix.db, spec: ix.spec, fingerprint: target,
 				ordinal: repair.Ordinal, queueTable: ix.spec.repairQueueTable(), split: ix.split,
 			}
-			remaining, remainingKnown, countErr := repairRemainingAfterScanError(
+			remaining, remainingKnown, countErr := repairRemaining(
 				ctx, store, result.Repair.Documents,
 			)
 			result.Repair.Remaining = remaining
@@ -208,7 +208,12 @@ func (ix *Index) buildInvalidRepair(
 	}
 	total, err := store.countPendingChunks(ctx, ix.split)
 	if err != nil {
-		return result, err
+		remaining, remainingKnown, countErr := repairRemaining(
+			ctx, store, result.Repair.Documents,
+		)
+		result.Repair.Remaining = remaining
+		result.Repair.RemainingKnown = remainingKnown
+		return result, errors.Join(err, countErr)
 	}
 
 	wrapped, finish := ix.wrapProgress(validatingEncoder(enc), total, o.Progress)
@@ -220,9 +225,10 @@ func (ix *Index) buildInvalidRepair(
 	finish()
 	result.Fill = fill.Stats
 	result.Repair.Failed = fill.Failed
-	remaining, countErr := store.countTargets(ctx)
+	fallback := max(result.Repair.Documents-result.Fill.Documents, 0)
+	remaining, remainingKnown, countErr := repairRemaining(ctx, store, fallback)
 	result.Repair.Remaining = remaining
-	result.Repair.RemainingKnown = countErr == nil
+	result.Repair.RemainingKnown = remainingKnown
 	if countErr != nil {
 		return result, errors.Join(fillErr, countErr)
 	}
@@ -241,11 +247,11 @@ func (ix *Index) buildInvalidRepair(
 	return result, nil
 }
 
-// repairRemainingAfterScanError preserves the accumulated committed target
-// count as a fallback, then attempts a bounded recount independent of a canceled
-// build context. Cancellation is a common reason the scan stopped, but it must
-// not hide queue work that earlier batches already committed.
-func repairRemainingAfterScanError(
+// repairRemaining preserves the accumulated committed target count as a
+// fallback, then attempts a bounded recount independent of a canceled build
+// context. Cancellation during any post-scan phase must not hide queue work
+// that the scan already committed.
+func repairRemaining(
 	ctx context.Context, store *repairStore, fallback int,
 ) (remaining int, known bool, err error) {
 	countCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), repairStatusCountTimeout)

--- a/internal/vector/build.go
+++ b/internal/vector/build.go
@@ -20,6 +20,8 @@ import (
 // the completed (or aborted) run. Tests lower it to 0 for determinism.
 var progressInterval = 2 * time.Second
 
+const repairStatusCountTimeout = 2 * time.Second
+
 // BuildOptions configures one Build pass.
 type BuildOptions struct {
 	// FullRebuild forces every document to be re-embedded under the target
@@ -28,6 +30,10 @@ type BuildOptions struct {
 	// Backstop forces a full mirror reconciliation scan (ignoring the
 	// refresh watermark) without forcing a re-embed.
 	Backstop bool
+	// RepairInvalid scans the configured existing generation for malformed,
+	// structurally incomplete, wrong-dimension, non-finite, or zero-norm
+	// vectors and runs a fill restricted to only the affected documents.
+	RepairInvalid bool
 	// IncludeAutomated controls whether automated sessions' units are
 	// scanned into the mirror at all (see UnitSource.ScanEmbeddableUnits).
 	// It is part of the mirror's identity: Build compares it against the
@@ -65,6 +71,7 @@ type BuildResult struct {
 	Fingerprint string
 	Activated   bool // building generation auto-activated on completion
 	Refresh     RefreshStats
+	Repair      RepairStats
 	Fill        kitvec.FillStats
 }
 
@@ -72,16 +79,27 @@ type BuildResult struct {
 // config: Model, Dimensions, and the fingerprinted Params — max_input_chars,
 // doc_unit_scheme, and chunk_overlap_chars; see vectorGeneration in
 // cmd/agentsview/embeddings.go). It
-// refreshes the mirror, resolves which generation to fill
+// Ordinary builds refresh the mirror, resolve which generation to fill
 // (top-up the active one, start a new building generation, or reset and
-// refill the active one for FullRebuild), fills pending documents, and
-// auto-activates a building generation once it fully covers the mirror.
+// refill the active one for FullRebuild), fill pending documents, and
+// auto-activate a building generation once it fully covers the mirror.
+// RepairInvalid instead operates only on an existing generation and never
+// refreshes the mirror or changes generation state.
 func (ix *Index) Build(
 	ctx context.Context, src UnitSource, enc kitvec.EncodeFunc,
 	gen kitvec.Generation, o BuildOptions,
 ) (BuildResult, error) {
 	if err := ix.requireWritable(); err != nil {
 		return BuildResult{}, err
+	}
+	if o.RepairInvalid && o.FullRebuild {
+		return BuildResult{}, fmt.Errorf("repair-invalid and full-rebuild are mutually exclusive")
+	}
+	if o.RepairInvalid && o.Backstop {
+		return BuildResult{}, fmt.Errorf("repair-invalid and backstop are mutually exclusive")
+	}
+	if o.RepairInvalid {
+		return ix.buildInvalidRepair(ctx, enc, gen, o)
 	}
 
 	firstEver, err := ix.noWatermarkYet(ctx)
@@ -122,21 +140,27 @@ func (ix *Index) Build(
 	if err != nil {
 		return BuildResult{}, err
 	}
+	result := BuildResult{Fingerprint: target, Refresh: refreshStats}
 
 	total, err := ix.countPending(ctx, target)
 	if err != nil {
-		return BuildResult{}, err
+		return result, err
 	}
 
-	wrapped, finish := ix.wrapProgress(enc, total, o.Progress)
-	fillStats, fillErr := kitvec.Fill[string, string](ctx, ix.store, target, wrapped, kitvec.FillOptions[string]{
+	wrapped, finish := ix.wrapProgress(validatingEncoder(enc), total, o.Progress)
+	fillStore := &repairQueueCompletingStore{
+		Store: ix.store,
+		db:    ix.db,
+		spec:  ix.spec,
+	}
+	fillStats, fillErr := kitvec.Fill[string, string](ctx, fillStore, target, wrapped, kitvec.FillOptions[string]{
 		Split:         ix.split,
 		Batch:         kitvec.BatchOptions{BatchSize: o.BatchSize, Concurrency: 1},
 		Concurrency:   o.Concurrency,
 		OnEncodeError: skipPermanentEncodeError,
 	})
 	finish()
-	result := BuildResult{Fingerprint: target, Refresh: refreshStats, Fill: fillStats}
+	result.Fill = fillStats
 	if fillErr != nil {
 		return result, fillErr
 	}
@@ -147,6 +171,103 @@ func (ix *Index) Build(
 	}
 	result.Activated = activated
 	return result, nil
+}
+
+// buildInvalidRepair is separate from the ordinary build path so repair cannot
+// accidentally refresh or expand the mirror, change its stored scope, create a
+// generation, or alter generation state. repairInvalidVectors verifies that
+// the configured fingerprint already exists before invalidating anything.
+func (ix *Index) buildInvalidRepair(
+	ctx context.Context, enc kitvec.EncodeFunc, gen kitvec.Generation, o BuildOptions,
+) (BuildResult, error) {
+	target := gen.Fingerprint()
+	result := BuildResult{Fingerprint: target}
+	if o.Progress != nil {
+		o.Progress(BuildProgress{Phase: "scanning"})
+	}
+	repair, err := ix.repairInvalidVectors(ctx, target)
+	result.Repair = repair.Stats
+	if err != nil {
+		if repair.Stats.Scanned {
+			store := &repairStore{
+				base: ix.store, db: ix.db, spec: ix.spec, fingerprint: target,
+				ordinal: repair.Ordinal, queueTable: ix.spec.repairQueueTable(), split: ix.split,
+			}
+			remaining, remainingKnown, countErr := repairRemainingAfterScanError(
+				ctx, store, result.Repair.Documents,
+			)
+			result.Repair.Remaining = remaining
+			result.Repair.RemainingKnown = remainingKnown
+			return result, errors.Join(err, countErr)
+		}
+		return result, err
+	}
+	store := &repairStore{
+		base: ix.store, db: ix.db, spec: ix.spec, fingerprint: target,
+		ordinal: repair.Ordinal, queueTable: ix.spec.repairQueueTable(), split: ix.split,
+	}
+	total, err := store.countPendingChunks(ctx, ix.split)
+	if err != nil {
+		return result, err
+	}
+
+	wrapped, finish := ix.wrapProgress(validatingEncoder(enc), total, o.Progress)
+	fill, fillErr := fillRepairQueue(ctx, store, target, wrapped, repairFillOptions{
+		Split:       ix.split,
+		Batch:       kitvec.BatchOptions{BatchSize: o.BatchSize, Concurrency: 1},
+		Concurrency: o.Concurrency,
+	})
+	finish()
+	result.Fill = fill.Stats
+	result.Repair.Failed = fill.Failed
+	remaining, countErr := store.countTargets(ctx)
+	result.Repair.Remaining = remaining
+	result.Repair.RemainingKnown = countErr == nil
+	if countErr != nil {
+		return result, errors.Join(fillErr, countErr)
+	}
+	if fillErr != nil {
+		return result, fillErr
+	}
+	if fill.Failed > 0 {
+		return result, fmt.Errorf(
+			"invalid vector repair incomplete: %d permanently rejected targets remain queued; first failure: %v",
+			fill.Failed, fill.FirstFailure)
+	}
+	if remaining > 0 {
+		return result, fmt.Errorf(
+			"invalid vector repair incomplete: %d targets remain queued", remaining)
+	}
+	return result, nil
+}
+
+// repairRemainingAfterScanError preserves the accumulated committed target
+// count as a fallback, then attempts a bounded recount independent of a canceled
+// build context. Cancellation is a common reason the scan stopped, but it must
+// not hide queue work that earlier batches already committed.
+func repairRemainingAfterScanError(
+	ctx context.Context, store *repairStore, fallback int,
+) (remaining int, known bool, err error) {
+	countCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), repairStatusCountTimeout)
+	defer cancel()
+	remaining, err = store.countTargets(countCtx)
+	if err != nil {
+		return fallback, false, err
+	}
+	return remaining, true, nil
+}
+
+func validatingEncoder(enc kitvec.EncodeFunc) kitvec.EncodeFunc {
+	return func(ctx context.Context, texts []string) ([][]float32, error) {
+		vectors, err := enc(ctx, texts)
+		if err != nil {
+			return nil, err
+		}
+		if err := validateEmbeddings(vectors); err != nil {
+			return nil, err
+		}
+		return vectors, nil
+	}
 }
 
 // skipPermanentEncodeError implements kitvec.FillOptions.OnEncodeError: a
@@ -164,13 +285,17 @@ func (ix *Index) Build(
 // the next scheduled build should retry the document rather than silently
 // giving up on it.
 func skipPermanentEncodeError(doc string, err error) bool {
-	var statusErr *HTTPStatusError
-	if !errors.As(err, &statusErr) || !statusErr.Permanent() {
+	if !isPermanentEncodeError(err) {
 		return false
 	}
 	log.Printf("vector build: skipping document %s: permanently rejected by embeddings endpoint: %v",
 		doc, err)
 	return true
+}
+
+func isPermanentEncodeError(err error) bool {
+	var statusErr *HTTPStatusError
+	return errors.As(err, &statusErr) && statusErr != nil && statusErr.Permanent()
 }
 
 // noWatermarkYet reports whether Refresh has never advanced the stored
@@ -337,8 +462,10 @@ func (ix *Index) ordinalForFingerprint(ctx context.Context, fp string) (int64, e
 
 // resetGeneration clears fp's generation of all embedded state (its vec0
 // vectors, chunk map, and stamps) in a single transaction, so a subsequent
-// Fill call re-embeds every document from scratch. It leaves the
-// generation row itself (and its state) untouched.
+// Fill call re-embeds every document from scratch. It leaves the generation
+// row itself (and its state) untouched, along with durable repair targets:
+// an ordinary build may complete them only with a non-empty validated save;
+// repair may also complete a revision-current, verified zero-chunk document.
 func (ix *Index) resetGeneration(ctx context.Context, fp string) error {
 	tx, err := ix.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -363,7 +490,6 @@ func (ix *Index) resetGeneration(ctx context.Context, fp string) error {
 	if _, err := tx.ExecContext(ctx, `DELETE FROM `+ix.spec.stampsTable()+` WHERE ordinal = ?`, ordinal); err != nil {
 		return fmt.Errorf("clearing stamps: %w", err)
 	}
-
 	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("commit reset generation: %w", err)
 	}

--- a/internal/vector/build_test.go
+++ b/internal/vector/build_test.go
@@ -491,6 +491,33 @@ func TestBuildEncoderErrorAbortsAndRetryResumesWithoutReembedding(t *testing.T) 
 	assert.True(t, result.Activated)
 }
 
+func TestBuildRejectsInvalidEncoderOutput(t *testing.T) {
+	ix := openTestIndex(t)
+	ctx := context.Background()
+	src := twoDocSource()
+	gen := fakeGeneration("invalid-output-model")
+	invalidEncoder := func(_ context.Context, texts []string) ([][]float32, error) {
+		out := make([][]float32, len(texts))
+		for i := range out {
+			out[i] = []float32{0, 0, 0}
+		}
+		return out, nil
+	}
+
+	result, err := ix.Build(ctx, src, invalidEncoder, gen, BuildOptions{})
+
+	var invalidErr *InvalidEmbeddingError
+	require.ErrorAs(t, err, &invalidErr)
+	assert.Zero(t, result.Fill.Documents)
+	var stamps, chunks int
+	require.NoError(t, ix.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM message_vectors_stamps`).Scan(&stamps))
+	require.NoError(t, ix.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM message_vectors_chunks`).Scan(&chunks))
+	assert.Zero(t, stamps, "invalid output must not stamp a document complete")
+	assert.Zero(t, chunks, "invalid output must not reach vector persistence")
+}
+
 // TestBuildSkipsPermanentlyRejectedDocumentAndContinues is the fix-1
 // regression test: a single document the endpoint permanently rejects
 // (400) must not wedge the whole build. kit stamps it without vectors so
@@ -646,6 +673,13 @@ func TestBuild5xxEncodeErrorStillAbortsFill(t *testing.T) {
 	var statusErr *HTTPStatusError
 	require.ErrorAs(t, err, &statusErr)
 	assert.Equal(t, http.StatusInternalServerError, statusErr.Status)
+}
+
+func TestPermanentEncodeErrorRejectsTypedNilStatusError(t *testing.T) {
+	var statusErr *HTTPStatusError
+	var err error = statusErr
+
+	assert.False(t, isPermanentEncodeError(err))
 }
 
 // TestResolveBuildTargetRetiresOtherBuildingGeneration is the fix-3

--- a/internal/vector/encoder.go
+++ b/internal/vector/encoder.go
@@ -79,6 +79,25 @@ type HTTPStatusError struct {
 	RetryAfter *time.Duration
 }
 
+// InvalidEmbeddingError reports endpoint output that has the expected shape
+// but cannot participate in cosine distance. Index identifies the embedding
+// within the response batch; Component is -1 for a zero-norm vector.
+type InvalidEmbeddingError struct {
+	Index     int
+	Component int
+	Reason    string
+}
+
+func (e *InvalidEmbeddingError) Error() string {
+	if e.Component >= 0 {
+		return fmt.Sprintf(
+			"[vector.embeddings] invalid embedding at index %d component %d: %s",
+			e.Index, e.Component, e.Reason)
+	}
+	return fmt.Sprintf(
+		"[vector.embeddings] invalid embedding at index %d: %s", e.Index, e.Reason)
+}
+
 func (e *HTTPStatusError) Error() string {
 	return fmt.Sprintf("[vector.embeddings] status %d: %s", e.Status, e.Body)
 }
@@ -158,6 +177,7 @@ type embeddingsResponseBody struct {
 type embeddingVector []float32
 
 func (v *embeddingVector) UnmarshalJSON(b []byte) error {
+	b = bytes.TrimSpace(b)
 	if len(b) > 0 && b[0] == '"' {
 		var s string
 		if err := json.Unmarshal(b, &s); err != nil {
@@ -177,11 +197,46 @@ func (v *embeddingVector) UnmarshalJSON(b []byte) error {
 		*v = out
 		return nil
 	}
-	var floats []float32
-	if err := json.Unmarshal(b, &floats); err != nil {
+	var elements []json.RawMessage
+	if err := json.Unmarshal(b, &elements); err != nil {
 		return err
 	}
+	floats := make([]float32, len(elements))
+	for i, element := range elements {
+		if bytes.Equal(bytes.TrimSpace(element), []byte("null")) {
+			return fmt.Errorf("embedding component %d is null", i)
+		}
+		if err := json.Unmarshal(element, &floats[i]); err != nil {
+			return fmt.Errorf("decode embedding component %d: %w", i, err)
+		}
+	}
 	*v = floats
+	return nil
+}
+
+func validateEmbedding(vector []float32, index int) error {
+	var squaredNorm float64
+	for component, value := range vector {
+		f := float64(value)
+		if math.IsNaN(f) || math.IsInf(f, 0) {
+			return &InvalidEmbeddingError{
+				Index: index, Component: component, Reason: "non-finite component",
+			}
+		}
+		squaredNorm += f * f
+	}
+	if squaredNorm == 0 {
+		return &InvalidEmbeddingError{Index: index, Component: -1, Reason: "zero norm"}
+	}
+	return nil
+}
+
+func validateEmbeddings(vectors [][]float32) error {
+	for index, vector := range vectors {
+		if err := validateEmbedding(vector, index); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -366,7 +421,8 @@ func (ec *encoderClient) attemptEncode(
 
 	vectors, err := reorderAndValidate(decoded, texts, cfg)
 	if err != nil {
-		return nil, false, err
+		var invalidErr *InvalidEmbeddingError
+		return nil, errors.As(err, &invalidErr), err
 	}
 	return vectors, false, nil
 }
@@ -414,6 +470,9 @@ func reorderAndValidate(
 		if !ok {
 			return nil, fmt.Errorf("[vector.embeddings] missing embedding for index %d", i)
 		}
+	}
+	if err := validateEmbeddings(out); err != nil {
+		return nil, err
 	}
 	return out, nil
 }

--- a/internal/vector/encoder_test.go
+++ b/internal/vector/encoder_test.go
@@ -127,6 +127,102 @@ func TestEncoderDecodesBase64Embeddings(t *testing.T) {
 	assert.Equal(t, []float32{4, 5, 6}, out[1])
 }
 
+func TestEncoderRejectsInvalidBase64Embeddings(t *testing.T) {
+	tests := []struct {
+		name      string
+		embedding []float32
+		reason    string
+	}{
+		{name: "nan", embedding: []float32{1, float32(math.NaN()), 0}, reason: "non-finite"},
+		{name: "positive infinity", embedding: []float32{1, float32(math.Inf(1)), 0}, reason: "non-finite"},
+		{name: "negative infinity", embedding: []float32{1, float32(math.Inf(-1)), 0}, reason: "non-finite"},
+		{name: "zero norm", embedding: []float32{0, 0, 0}, reason: "zero norm"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				writeJSON(t, w, http.StatusOK, map[string]any{
+					"data": []map[string]any{{
+						"index": 0, "embedding": base64Embedding(tt.embedding),
+					}},
+				})
+			}))
+			defer srv.Close()
+
+			enc := NewEncoder(EncoderConfig{
+				Endpoint: srv.URL + "/v1", Model: "test-model", Dimension: 3,
+				Timeout: time.Second, MaxRetries: 1,
+			})
+			out, err := enc(context.Background(), []string{"hello"})
+
+			assert.Nil(t, out, "an invalid batch must expose no partial vectors")
+			var invalidErr *InvalidEmbeddingError
+			require.ErrorAs(t, err, &invalidErr)
+			assert.Equal(t, 0, invalidErr.Index)
+			assert.Contains(t, err.Error(), tt.reason)
+		})
+	}
+}
+
+func TestEncoderRejectsNullEmbeddingElements(t *testing.T) {
+	tests := []struct {
+		name      string
+		embedding string
+	}{
+		{name: "mixed", embedding: `[0.5,null,0.25]`},
+		{name: "all null", embedding: `[null,null,null]`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, err := io.WriteString(w, `{"data":[{"index":0,"embedding":`+tt.embedding+`}]}`)
+				require.NoError(t, err)
+			}))
+			defer srv.Close()
+
+			enc := NewEncoder(EncoderConfig{
+				Endpoint: srv.URL + "/v1", Model: "test-model", Dimension: 3,
+				Timeout: time.Second, MaxRetries: 1,
+			})
+			out, err := enc(context.Background(), []string{"hello"})
+
+			assert.Nil(t, out)
+			require.ErrorContains(t, err, "null")
+		})
+	}
+}
+
+func TestEncoderRetriesInvalidEmbeddingResponse(t *testing.T) {
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if requests.Add(1) == 1 {
+			writeJSON(t, w, http.StatusOK, map[string]any{
+				"data": []map[string]any{{
+					"index": 0, "embedding": base64Embedding([]float32{0, 0, 0}),
+				}},
+			})
+			return
+		}
+		writeJSON(t, w, http.StatusOK, map[string]any{
+			"data": []map[string]any{{
+				"index": 0, "embedding": base64Embedding([]float32{1, 2, 3}),
+			}},
+		})
+	}))
+	defer srv.Close()
+
+	enc := NewEncoder(EncoderConfig{
+		Endpoint: srv.URL + "/v1", Model: "test-model", Dimension: 3,
+		Timeout: time.Second, MaxRetries: 2,
+	})
+	out, err := enc(context.Background(), []string{"hello"})
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), requests.Load())
+	assert.Equal(t, [][]float32{{1, 2, 3}}, out)
+}
+
 // TestEncoderBase64WrongByteCountFailsDimensionCheck asserts a base64
 // payload whose float count disagrees with the configured dimension is
 // rejected rather than silently stored.

--- a/internal/vector/index.go
+++ b/internal/vector/index.go
@@ -93,6 +93,7 @@ func (s IndexSpec) schema() sqlitevec.Schema {
 func (s IndexSpec) generationsTable() string { return s.VectorsPrefix + "_generations" }
 func (s IndexSpec) stampsTable() string      { return s.VectorsPrefix + "_stamps" }
 func (s IndexSpec) chunksTable() string      { return s.VectorsPrefix + "_chunks" }
+func (s IndexSpec) repairQueueTable() string { return s.VectorsPrefix + "_repair_queue" }
 
 // MessageIndexSpec is the conversation-message embedding store. Its table
 // names, metadata keys, and schema version predate IndexSpec and must stay
@@ -210,6 +211,23 @@ func OpenSpec(
 	if err != nil {
 		db.Close()
 		return nil, fmt.Errorf("opening vector store: %w", err)
+	}
+	if !readOnly {
+		if _, err := db.ExecContext(ctx, `
+CREATE TABLE IF NOT EXISTS `+spec.repairQueueTable()+` (
+    ordinal INTEGER NOT NULL,
+    doc_key TEXT NOT NULL,
+    PRIMARY KEY (ordinal, doc_key)
+)`); err != nil {
+			db.Close()
+			return nil, fmt.Errorf("creating invalid vector repair queue: %w", err)
+		}
+		if _, err := db.ExecContext(ctx,
+			`CREATE INDEX IF NOT EXISTS `+spec.repairQueueTable()+`_doc_key ON `+
+				spec.repairQueueTable()+` (doc_key)`); err != nil {
+			db.Close()
+			return nil, fmt.Errorf("indexing invalid vector repair queue by document: %w", err)
+		}
 	}
 
 	overlap := ChunkOverlap(maxInputChars)

--- a/internal/vector/manager.go
+++ b/internal/vector/manager.go
@@ -43,6 +43,11 @@ func (e *refusalError) Is(target error) bool { return target == ErrGenerationRef
 // offending name.
 var ErrUnknownServer = errors.New("unknown embeddings server")
 
+// ErrInvalidBuildRequest indicates caller-selected build modes conflict. The
+// manager returns it before changing build status so asynchronous callers can
+// reject the request synchronously.
+var ErrInvalidBuildRequest = errors.New("invalid embeddings build request")
+
 type unknownServerError struct {
 	name string
 }
@@ -52,6 +57,18 @@ func (e *unknownServerError) Error() string {
 }
 
 func (e *unknownServerError) Is(target error) bool { return target == ErrUnknownServer }
+
+func validateBuildRequest(req BuildRequest) error {
+	if req.RepairInvalid && req.FullRebuild {
+		return fmt.Errorf("%w: repair-invalid and full-rebuild are mutually exclusive",
+			ErrInvalidBuildRequest)
+	}
+	if req.RepairInvalid && req.Backstop {
+		return fmt.Errorf("%w: repair-invalid and backstop are mutually exclusive",
+			ErrInvalidBuildRequest)
+	}
+	return nil
+}
 
 // Manager serializes embedding builds over one Index: only one Build call
 // may run at a time, whether triggered via StartBuild (async, for the HTTP
@@ -88,6 +105,9 @@ type Manager struct {
 type BuildRequest struct {
 	FullRebuild bool `json:"full_rebuild,omitempty"`
 	Backstop    bool `json:"backstop,omitempty"`
+	// RepairInvalid scans only the selected target generation and queues
+	// documents containing unusable stored vectors for regeneration.
+	RepairInvalid bool `json:"repair_invalid,omitempty"`
 	// IncludeAutomated is the resolved include-automated scope for this
 	// build (caller-resolved from config and, for the CLI's one-off
 	// --include-automated flag, its override). See BuildOptions.IncludeAutomated.
@@ -209,6 +229,9 @@ func recoveringEncoder(enc kitvec.EncodeFunc) kitvec.EncodeFunc {
 // The goroutine runs against context.Background() so it outlives the HTTP
 // request that triggered it.
 func (m *Manager) StartBuild(req BuildRequest) error {
+	if err := validateBuildRequest(req); err != nil {
+		return err
+	}
 	me, err := m.resolveEncoder(req)
 	if err != nil {
 		return err
@@ -227,6 +250,9 @@ func (m *Manager) StartBuild(req BuildRequest) error {
 // should drop a scheduled run rather than queue it: it returns (false, nil)
 // without starting anything if a build is already running.
 func (m *Manager) TryBuild(ctx context.Context, req BuildRequest) (bool, error) {
+	if err := validateBuildRequest(req); err != nil {
+		return false, err
+	}
 	me, err := m.resolveEncoder(req)
 	if err != nil {
 		return false, err
@@ -347,6 +373,7 @@ func (m *Manager) runBuild(
 	return m.ix.Build(ctx, m.src, me.Encode, m.gen, BuildOptions{
 		FullRebuild:      req.FullRebuild,
 		Backstop:         req.Backstop,
+		RepairInvalid:    req.RepairInvalid,
 		IncludeAutomated: req.IncludeAutomated,
 		BatchSize:        me.Settings.BatchSize,
 		Concurrency:      me.Settings.Concurrency,
@@ -369,22 +396,22 @@ func (m *Manager) reportProgress(p BuildProgress) {
 }
 
 // finish records a completed build's outcome and clears the running state.
-// A successful build sets LastResult and clears any previous LastError; a
-// failed build sets LastError and leaves the last successful LastResult (if
-// any) untouched.
+// LastResult always describes the most recent attempt, including its partial
+// progress when the attempt failed, so status consumers never pair a new
+// LastError with a stale successful result.
 func (m *Manager) finish(result BuildResult, err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.running = false
 	m.status.Running = false
 	m.clearETA()
+	r := result
+	m.status.LastResult = &r
 	if err != nil {
 		m.status.LastError = err.Error()
 		return
 	}
 	m.status.LastError = ""
-	r := result
-	m.status.LastResult = &r
 }
 
 // clearETA resets both the private accumulator and its public status snapshot.

--- a/internal/vector/manager_test.go
+++ b/internal/vector/manager_test.go
@@ -2,6 +2,7 @@ package vector
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -120,6 +121,40 @@ func TestManagerBuildUnknownUsingFailsBeforeStarting(t *testing.T) {
 	assert.False(t, started)
 }
 
+func TestManagerRejectsConflictingRepairRequestBeforeStarting(t *testing.T) {
+	tests := []struct {
+		name string
+		req  BuildRequest
+	}{
+		{
+			name: "full rebuild",
+			req:  BuildRequest{FullRebuild: true, RepairInvalid: true},
+		},
+		{
+			name: "backstop",
+			req:  BuildRequest{Backstop: true, RepairInvalid: true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ix := openTestIndex(t)
+			m := NewManager(ix, twoDocSource(), soloEncoders(fakeBuildEncoder()),
+				fakeGeneration("fake-model"))
+
+			err := m.StartBuild(tt.req)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "mutually exclusive")
+			assert.False(t, m.Status().Running)
+
+			started, err := m.TryBuild(context.Background(), tt.req)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "mutually exclusive")
+			assert.False(t, started)
+			assert.False(t, m.Status().Running)
+		})
+	}
+}
+
 func TestManagerStartBuildSetsRunningAndConcurrentStartReturnsErrBuildRunning(t *testing.T) {
 	ix := openTestIndex(t)
 	src := twoDocSource()
@@ -186,7 +221,40 @@ func TestManagerStatusSetsLastErrorOnEncoderFailure(t *testing.T) {
 
 	status := m.Status()
 	assert.Contains(t, status.LastError, "encoder rejected input")
-	assert.Nil(t, status.LastResult)
+	require.NotNil(t, status.LastResult)
+	assert.Equal(t, gen.Fingerprint(), status.LastResult.Fingerprint)
+	assert.Zero(t, status.LastResult.Fill.Documents)
+}
+
+func TestManagerFailureReplacesPriorSuccessfulResult(t *testing.T) {
+	ix := openTestIndex(t)
+	ctx := context.Background()
+	gen := fakeGeneration("fake-model")
+	fail := false
+	encoder := func(ctx context.Context, texts []string) ([][]float32, error) {
+		if fail {
+			return nil, errors.New("encoder rejected input")
+		}
+		return fakeBuildEncoder()(ctx, texts)
+	}
+	m := NewManager(ix, twoDocSource(), soloEncoders(encoder), gen)
+
+	started, err := m.TryBuild(ctx, BuildRequest{})
+	require.True(t, started)
+	require.NoError(t, err)
+	require.NotNil(t, m.Status().LastResult)
+	assert.Equal(t, 2, m.Status().LastResult.Fill.Documents)
+
+	fail = true
+	started, err = m.TryBuild(ctx, BuildRequest{FullRebuild: true})
+	require.True(t, started)
+	require.ErrorContains(t, err, "encoder rejected input")
+
+	status := m.Status()
+	require.NotNil(t, status.LastResult)
+	assert.Zero(t, status.LastResult.Fill.Documents,
+		"the failed attempt must replace the stale successful result")
+	assert.Contains(t, status.LastError, "encoder rejected input")
 }
 
 func TestManagerStatusStampsBuildIdentityAndSpace(t *testing.T) {
@@ -407,7 +475,7 @@ func TestManagerStartBuildRecoversPanickedEncoder(t *testing.T) {
 	status := m.Status()
 	assert.Contains(t, status.LastError, "panicked")
 	assert.Contains(t, status.LastError, "encoder exploded")
-	assert.Nil(t, status.LastResult)
+	require.NotNil(t, status.LastResult)
 
 	require.NoError(t, m.StartBuild(BuildRequest{}),
 		"manager must accept a new build after a panicked one")

--- a/internal/vector/mirror.go
+++ b/internal/vector/mirror.go
@@ -431,6 +431,9 @@ func (ix *Index) finalizeEvictions(ctx context.Context, evicted map[string]struc
 		if err := ix.store.DeleteVectors(ctx, key); err != nil {
 			return deleted, fmt.Errorf("deleting evicted vectors for %s: %w", key, err)
 		}
+		if err := ix.deleteRepairTargets(ctx, key); err != nil {
+			return deleted, err
+		}
 		if _, err := ix.db.ExecContext(ctx,
 			`DELETE FROM `+ix.spec.DocsTable+` WHERE doc_key = ?`, key,
 		); err != nil {
@@ -506,6 +509,9 @@ func (ix *Index) reconcileDeletions(
 		if err := ix.store.DeleteVectors(ctx, key); err != nil {
 			return 0, fmt.Errorf("deleting vectors for %s: %w", key, err)
 		}
+		if err := ix.deleteRepairTargets(ctx, key); err != nil {
+			return 0, err
+		}
 		if _, err := ix.db.ExecContext(ctx,
 			`DELETE FROM `+ix.spec.DocsTable+` WHERE doc_key = ?`, key,
 		); err != nil {
@@ -513,6 +519,15 @@ func (ix *Index) reconcileDeletions(
 		}
 	}
 	return len(vanished), nil
+}
+
+func (ix *Index) deleteRepairTargets(ctx context.Context, docKey string) error {
+	if _, err := ix.db.ExecContext(ctx,
+		`DELETE FROM `+ix.spec.repairQueueTable()+` WHERE doc_key = ?`, docKey,
+	); err != nil {
+		return fmt.Errorf("deleting invalid vector repair targets for %s: %w", docKey, err)
+	}
+	return nil
 }
 
 // refreshWatermark reads the stored refresh watermark, returning "" when

--- a/internal/vector/repair.go
+++ b/internal/vector/repair.go
@@ -1,0 +1,583 @@
+package vector
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	kitvec "go.kenn.io/kit/vector"
+)
+
+// RepairStats reports the target set prepared for a repair-only fill.
+type RepairStats struct {
+	Scanned bool `json:"scanned"`
+	// ScanComplete distinguishes a fully traversed integrity scan from one
+	// that stopped after committing one or more bounded invalidation batches.
+	ScanComplete bool `json:"scan_complete"`
+	// Documents includes unfinished targets resumed from the durable queue and
+	// newly invalidated documents discovered by this scan.
+	Documents int `json:"documents"`
+	// Chunks counts mappings invalidated by this scan. Resumed targets were
+	// invalidated by an earlier run and therefore do not add to this count.
+	Chunks int `json:"chunks"`
+	// Failed counts non-stale target encode/save failures that determine or
+	// accompany this invocation's failure. Stale saves are reported by
+	// Fill.Stale, and sibling work canceled after another failure is not counted.
+	Failed int `json:"failed"`
+	// Remaining is the durable target count after this run's fill attempt.
+	Remaining int `json:"remaining"`
+	// RemainingKnown is false only when the bounded queue recount failed and
+	// Remaining is therefore the accumulated committed-count fallback.
+	RemainingKnown bool `json:"remaining_known"`
+}
+
+type repairResult struct {
+	Stats   RepairStats
+	Ordinal int64
+}
+
+const repairScanDocumentBatch = 128
+
+// repairInvalidVectors removes target-generation state only for documents
+// containing at least one unusable stored vector. Stamp removal makes those
+// documents pending for the restricted Fill that follows in Build.
+func (ix *Index) repairInvalidVectors(
+	ctx context.Context, fingerprint string,
+) (repairResult, error) {
+	var ordinal int64
+	var dimension int
+	err := ix.db.QueryRowContext(ctx,
+		`SELECT ordinal, dimension FROM `+ix.spec.generationsTable()+` WHERE gen_key = ?`,
+		fingerprint,
+	).Scan(&ordinal, &dimension)
+	if err != nil {
+		return repairResult{}, fmt.Errorf(
+			"lookup generation for invalid vector repair %s: %w", fingerprint, err)
+	}
+	result := repairResult{Stats: RepairStats{Scanned: true}, Ordinal: ordinal}
+	vecTable := fmt.Sprintf("%s_v%d", ix.spec.VectorsPrefix, ordinal)
+	if _, err := ix.db.ExecContext(ctx, `
+DELETE FROM `+ix.spec.repairQueueTable()+` AS q
+ WHERE q.ordinal = ?
+   AND NOT EXISTS (
+       SELECT 1 FROM `+ix.spec.DocsTable+` d WHERE d.doc_key = q.doc_key)`, ordinal); err != nil {
+		return result, fmt.Errorf("prune orphaned invalid vector repair targets: %w", err)
+	}
+	if err := ix.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM `+ix.spec.repairQueueTable()+` WHERE ordinal = ?`, ordinal,
+	).Scan(&result.Stats.Documents); err != nil {
+		return result, fmt.Errorf("count queued invalid vector repairs: %w", err)
+	}
+
+	lastDocKey := ""
+	for {
+		documents, err := ix.repairScanBatchKeys(ctx, ordinal, lastDocKey)
+		if err != nil {
+			return result, err
+		}
+		if len(documents) == 0 {
+			break
+		}
+		lastDocKey = documents[len(documents)-1]
+		affected, err := ix.scanInvalidRepairDocuments(
+			ctx, ordinal, dimension, vecTable, documents,
+		)
+		if err != nil {
+			return result, err
+		}
+		batch, err := ix.invalidateRepairDocuments(ctx, ordinal, vecTable, affected)
+		if err != nil {
+			return result, err
+		}
+		result.Stats.Documents += batch.Documents
+		result.Stats.Chunks += batch.Chunks
+	}
+	result.Stats.ScanComplete = true
+	return result, nil
+}
+
+func (ix *Index) repairScanBatchKeys(
+	ctx context.Context, ordinal int64, after string,
+) ([]string, error) {
+	rows, err := ix.db.QueryContext(ctx, `
+SELECT c.doc_key
+  FROM `+ix.spec.chunksTable()+` c
+  JOIN `+ix.spec.DocsTable+` d ON d.doc_key = c.doc_key
+  JOIN `+ix.spec.stampsTable()+` s
+    ON s.ordinal = c.ordinal AND s.doc_key = c.doc_key
+   AND s.revision IS d.content_hash
+ WHERE c.ordinal = ? AND c.doc_key > ?
+ GROUP BY c.doc_key
+ ORDER BY c.doc_key
+ LIMIT ?`, ordinal, after, repairScanDocumentBatch)
+	if err != nil {
+		return nil, fmt.Errorf("scan target generation document keys: %w", err)
+	}
+	defer rows.Close()
+
+	documents := make([]string, 0, repairScanDocumentBatch)
+	for rows.Next() {
+		var docKey string
+		if err := rows.Scan(&docKey); err != nil {
+			return nil, fmt.Errorf("scan target generation document key: %w", err)
+		}
+		documents = append(documents, docKey)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate target generation document keys: %w", err)
+	}
+	return documents, nil
+}
+
+func (ix *Index) scanInvalidRepairDocuments(
+	ctx context.Context, ordinal int64, dimension int, vecTable string, documents []string,
+) ([]string, error) {
+	if len(documents) == 0 {
+		return nil, nil
+	}
+	args := make([]any, 0, len(documents)+1)
+	args = append(args, ordinal)
+	for _, docKey := range documents {
+		args = append(args, docKey)
+	}
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(documents)), ",")
+	rows, err := ix.db.QueryContext(ctx, `
+SELECT c.doc_key, d.content, c.chunk_index, v.embedding
+  FROM `+ix.spec.chunksTable()+` c
+  JOIN `+ix.spec.DocsTable+` d ON d.doc_key = c.doc_key
+  JOIN `+ix.spec.stampsTable()+` s
+    ON s.ordinal = c.ordinal AND s.doc_key = c.doc_key
+   AND s.revision IS d.content_hash
+  LEFT JOIN `+vecTable+` v ON v.rowid = c.vec_rowid
+ WHERE c.ordinal = ? AND c.doc_key IN (`+placeholders+`)
+ ORDER BY c.doc_key, c.chunk_index`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("scan target generation vectors: %w", err)
+	}
+	defer rows.Close()
+
+	var affected []string
+	currentDoc := ""
+	var expected []kitvec.Chunk
+	seen := 0
+	invalid := false
+	finishDocument := func() {
+		if currentDoc != "" && (invalid || seen != len(expected)) {
+			affected = append(affected, currentDoc)
+		}
+	}
+	for rows.Next() {
+		var docKey, content string
+		var chunkIndex int
+		var blob []byte
+		if err := rows.Scan(&docKey, &content, &chunkIndex, &blob); err != nil {
+			return nil, fmt.Errorf("scan target generation vector: %w", err)
+		}
+		if docKey != currentDoc {
+			finishDocument()
+			currentDoc = docKey
+			expected = kitvec.Split(content, ix.split)
+			seen = 0
+			invalid = false
+		}
+		if seen >= len(expected) || expected[seen].Index != chunkIndex {
+			invalid = true
+		}
+		seen++
+		if validateStoredEmbeddingBlob(blob, dimension) != nil {
+			invalid = true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate target generation vectors: %w", err)
+	}
+	finishDocument()
+	return affected, nil
+}
+
+func (ix *Index) invalidateRepairDocuments(
+	ctx context.Context, ordinal int64, vecTable string, documents []string,
+) (RepairStats, error) {
+	if len(documents) == 0 {
+		return RepairStats{}, nil
+	}
+	tx, err := ix.db.BeginTx(ctx, nil)
+	if err != nil {
+		return RepairStats{}, fmt.Errorf("begin invalid vector repair batch: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var stats RepairStats
+	for _, docKey := range documents {
+		inserted, err := tx.ExecContext(ctx, `
+INSERT INTO `+ix.spec.repairQueueTable()+` (ordinal, doc_key) VALUES (?, ?)
+ON CONFLICT(ordinal, doc_key) DO NOTHING`, ordinal, docKey)
+		if err != nil {
+			return RepairStats{}, fmt.Errorf("queue invalid document %s for repair: %w", docKey, err)
+		}
+		count, err := inserted.RowsAffected()
+		if err != nil {
+			return RepairStats{}, fmt.Errorf("count queued invalid document %s: %w", docKey, err)
+		}
+		stats.Documents += int(count)
+		rowids, err := repairDocumentRowIDs(ctx, tx, ix.spec, ordinal, docKey)
+		if err != nil {
+			return RepairStats{}, err
+		}
+		stats.Chunks += len(rowids)
+		for _, rowid := range rowids {
+			if _, err := tx.ExecContext(ctx,
+				`DELETE FROM `+vecTable+` WHERE rowid = ?`, rowid); err != nil {
+				return RepairStats{}, fmt.Errorf("delete invalid vector for %s: %w", docKey, err)
+			}
+		}
+		if _, err := tx.ExecContext(ctx,
+			`DELETE FROM `+ix.spec.chunksTable()+` WHERE ordinal = ? AND doc_key = ?`,
+			ordinal, docKey); err != nil {
+			return RepairStats{}, fmt.Errorf("delete invalid chunk map for %s: %w", docKey, err)
+		}
+		if _, err := tx.ExecContext(ctx,
+			`DELETE FROM `+ix.spec.stampsTable()+` WHERE ordinal = ? AND doc_key = ?`,
+			ordinal, docKey); err != nil {
+			return RepairStats{}, fmt.Errorf("delete invalid vector stamp for %s: %w", docKey, err)
+		}
+
+		// SaveVectors removes all generations when embed_gen points to an
+		// unstamped generation (the normal content-invalidation case). If this
+		// unchanged document has another revision-current generation, point to
+		// it temporarily so the following fill replaces only target vectors.
+		if _, err := tx.ExecContext(ctx, `
+UPDATE `+ix.spec.DocsTable+` AS d
+   SET embed_gen = (
+       SELECT g.gen_key
+         FROM `+ix.spec.stampsTable()+` s
+         JOIN `+ix.spec.generationsTable()+` g ON g.ordinal = s.ordinal
+        WHERE s.doc_key = d.doc_key
+          AND s.ordinal <> ?
+          AND s.revision IS d.content_hash
+        ORDER BY s.ordinal DESC
+        LIMIT 1)
+ WHERE d.doc_key = ?
+   AND EXISTS (
+       SELECT 1
+         FROM `+ix.spec.stampsTable()+` s
+        WHERE s.doc_key = d.doc_key
+          AND s.ordinal <> ?
+          AND s.revision IS d.content_hash)`, ordinal, docKey, ordinal); err != nil {
+			return RepairStats{}, fmt.Errorf("preserve fallback generation for %s: %w", docKey, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return RepairStats{}, fmt.Errorf("commit invalid vector repair batch: %w", err)
+	}
+	return stats, nil
+}
+
+func validateStoredEmbeddingBlob(blob []byte, dimension int) error {
+	vector, err := decodeFloat32Blob(blob)
+	if err != nil {
+		return fmt.Errorf("invalid embedding byte length: %w", err)
+	}
+	if len(vector) != dimension {
+		return fmt.Errorf("invalid embedding dimension: got %d, want %d", len(vector), dimension)
+	}
+	return validateEmbedding(vector, 0)
+}
+
+// repairStore restricts kit's fill loop to the documents found by the repair
+// scan. Other legitimately pending documents remain untouched for a later
+// ordinary incremental build.
+type repairStore struct {
+	base        kitvec.Store[string, string]
+	db          *sql.DB
+	spec        IndexSpec
+	fingerprint string
+	ordinal     int64
+	queueTable  string
+	split       kitvec.SplitOptions
+}
+
+// repairQueueCompletingStore lets an ordinary build satisfy a durable repair
+// target when it saves non-empty replacement vectors for that same generation.
+// Without this, a later repair invocation would re-embed work the ordinary
+// build already completed. Stamp-only saves intentionally leave the target
+// queued: they do not replace the invalid vectors repair was asked to restore.
+type repairQueueCompletingStore struct {
+	kitvec.Store[string, string]
+	db   *sql.DB
+	spec IndexSpec
+}
+
+func (s *repairQueueCompletingStore) SaveVectors(
+	ctx context.Context, gen, doc string, revision any, vectors []kitvec.ChunkVector,
+) error {
+	if err := s.Store.SaveVectors(ctx, gen, doc, revision, vectors); err != nil {
+		return err
+	}
+	if len(vectors) == 0 {
+		return nil
+	}
+	if _, err := s.db.ExecContext(ctx, `
+DELETE FROM `+s.spec.repairQueueTable()+`
+ WHERE doc_key = ?
+   AND ordinal = (
+       SELECT ordinal FROM `+s.spec.generationsTable()+` WHERE gen_key = ?)`, doc, gen); err != nil {
+		return fmt.Errorf("complete invalid vector repair during ordinary build for %s: %w", doc, err)
+	}
+	return nil
+}
+
+func (s *repairStore) pendingAfter(
+	ctx context.Context, gen string, after string, limit int,
+) ([]kitvec.Pending[string], error) {
+	if gen != s.fingerprint {
+		return nil, fmt.Errorf("repair store generation %s does not match target %s", gen, s.fingerprint)
+	}
+	if limit <= 0 {
+		return nil, nil
+	}
+
+	rows, err := s.db.QueryContext(ctx, `
+SELECT d.doc_key, d.content, d.content_hash
+  FROM `+s.spec.DocsTable+` d
+  JOIN `+s.queueTable+` q ON q.doc_key = d.doc_key AND q.ordinal = ?
+ WHERE d.doc_key > ?
+ ORDER BY d.doc_key
+ LIMIT ?`, s.ordinal, after, limit)
+	if err != nil {
+		return nil, fmt.Errorf("scan repair documents: %w", err)
+	}
+	var pending []kitvec.Pending[string]
+	for rows.Next() {
+		var p kitvec.Pending[string]
+		if err := rows.Scan(&p.Doc, &p.Content, &p.Revision); err != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("scan repair document: %w", err)
+		}
+		pending = append(pending, p)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, fmt.Errorf("iterate repair documents: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, fmt.Errorf("close repair document scan: %w", err)
+	}
+	return pending, nil
+}
+
+func (s *repairStore) countTargets(ctx context.Context) (int, error) {
+	var count int
+	if err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM `+s.queueTable+` WHERE ordinal = ?`, s.ordinal,
+	).Scan(&count); err != nil {
+		return 0, fmt.Errorf("count remaining invalid vector repair targets: %w", err)
+	}
+	return count, nil
+}
+
+func (s *repairStore) countPendingChunks(
+	ctx context.Context, split kitvec.SplitOptions,
+) (int64, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT d.content
+  FROM `+s.spec.DocsTable+` d
+  JOIN `+s.queueTable+` q ON q.doc_key = d.doc_key AND q.ordinal = ?
+ ORDER BY d.doc_key`, s.ordinal)
+	if err != nil {
+		return 0, fmt.Errorf("count repair documents: %w", err)
+	}
+	defer rows.Close()
+
+	var total int64
+	for rows.Next() {
+		var content string
+		if err := rows.Scan(&content); err != nil {
+			return 0, fmt.Errorf("scan repair document content: %w", err)
+		}
+		total += int64(len(kitvec.Split(content, split)))
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("iterate repair document content: %w", err)
+	}
+	return total, nil
+}
+
+func (s *repairStore) SaveVectors(
+	ctx context.Context, gen, doc string, revision any, vectors []kitvec.ChunkVector,
+) error {
+	if len(vectors) == 0 {
+		var content string
+		err := s.db.QueryRowContext(ctx, `
+SELECT content FROM `+s.spec.DocsTable+`
+ WHERE doc_key = ? AND content_hash IS ?`, doc, revision).Scan(&content)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("validate empty invalid vector repair for %s: %w", doc, err)
+		}
+		if err == nil && len(kitvec.Split(content, s.split)) > 0 {
+			return fmt.Errorf("refusing to complete invalid vector repair for %s without replacement vectors", doc)
+		}
+	}
+	if err := s.base.SaveVectors(ctx, gen, doc, revision, vectors); err != nil {
+		return err
+	}
+	if _, err := s.db.ExecContext(ctx,
+		`DELETE FROM `+s.queueTable+` WHERE ordinal = ? AND doc_key = ?`, s.ordinal, doc); err != nil {
+		return fmt.Errorf("complete invalid vector repair for %s: %w", doc, err)
+	}
+	return nil
+}
+
+type repairFillOptions struct {
+	Split       kitvec.SplitOptions
+	Batch       kitvec.BatchOptions
+	Concurrency int
+}
+
+type repairFillOutcome struct {
+	Stats        kitvec.FillStats
+	Failed       int
+	FirstFailure error
+}
+
+type repairEncoded struct {
+	doc     kitvec.Pending[string]
+	chunks  []kitvec.Chunk
+	vectors []kitvec.Vector
+	err     error
+}
+
+// fillRepairQueue attempts every target that was queued when the invocation
+// began. Its keyset cursor lets permanently rejected targets remain queued
+// without starving later keys or accumulating an invocation-sized skip set.
+func fillRepairQueue(
+	ctx context.Context, store *repairStore, gen string, enc kitvec.EncodeFunc,
+	o repairFillOptions,
+) (repairFillOutcome, error) {
+	var outcome repairFillOutcome
+	after := ""
+	for {
+		pending, err := store.pendingAfter(ctx, gen, after, repairScanDocumentBatch)
+		if err != nil {
+			return outcome, err
+		}
+		if len(pending) == 0 {
+			return outcome, nil
+		}
+		after = pending[len(pending)-1].Doc
+		page, err := fillRepairPage(ctx, store, gen, enc, o, pending)
+		outcome.Stats.Documents += page.Stats.Documents
+		outcome.Stats.Chunks += page.Stats.Chunks
+		outcome.Stats.Stale += page.Stats.Stale
+		outcome.Failed += page.Failed
+		if outcome.FirstFailure == nil {
+			outcome.FirstFailure = page.FirstFailure
+		}
+		if err != nil {
+			return outcome, err
+		}
+	}
+}
+
+func fillRepairPage(
+	ctx context.Context, store *repairStore, gen string, enc kitvec.EncodeFunc,
+	o repairFillOptions, pending []kitvec.Pending[string],
+) (repairFillOutcome, error) {
+	pageCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	workers := o.Concurrency
+	if workers <= 0 {
+		workers = 1
+	}
+	workers = min(workers, len(pending))
+	sem := make(chan struct{}, workers)
+	results := make(chan repairEncoded, len(pending))
+	var wg sync.WaitGroup
+	for _, document := range pending {
+		wg.Go(func() {
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-pageCtx.Done():
+				results <- repairEncoded{doc: document, err: pageCtx.Err()}
+				return
+			}
+			chunks := kitvec.Split(document.Content, o.Split)
+			vectors, err := kitvec.EncodeBatched(pageCtx, enc, chunks, o.Batch)
+			results <- repairEncoded{doc: document, chunks: chunks, vectors: vectors, err: err}
+		})
+	}
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	var outcome repairFillOutcome
+	var pageErr error
+	for encoded := range results {
+		if encoded.err != nil {
+			if isPermanentEncodeError(encoded.err) {
+				outcome.Failed++
+				if outcome.FirstFailure == nil {
+					outcome.FirstFailure = fmt.Errorf(
+						"encode repair target %s: %w", encoded.doc.Doc, encoded.err)
+				}
+				continue
+			}
+			if pageErr == nil {
+				outcome.Failed++
+				pageErr = fmt.Errorf("encode repair target %s: %w", encoded.doc.Doc, encoded.err)
+				cancel()
+			}
+			continue
+		}
+		if pageErr != nil {
+			continue
+		}
+		vectors := make([]kitvec.ChunkVector, len(encoded.chunks))
+		for i, chunk := range encoded.chunks {
+			vectors[i] = kitvec.ChunkVector{ChunkIndex: chunk.Index, Vector: encoded.vectors[i]}
+		}
+		if err := store.SaveVectors(ctx, gen, encoded.doc.Doc, encoded.doc.Revision, vectors); err != nil {
+			if errors.Is(err, kitvec.ErrStale) {
+				outcome.Stats.Stale++
+				continue
+			}
+			outcome.Failed++
+			pageErr = fmt.Errorf("save repair target %s: %w", encoded.doc.Doc, err)
+			cancel()
+			continue
+		}
+		outcome.Stats.Documents++
+		outcome.Stats.Chunks += len(vectors)
+	}
+	return outcome, pageErr
+}
+
+func repairDocumentRowIDs(
+	ctx context.Context, tx *sql.Tx, spec IndexSpec, ordinal int64, docKey string,
+) ([]int64, error) {
+	rows, err := tx.QueryContext(ctx,
+		`SELECT vec_rowid FROM `+spec.chunksTable()+`
+          WHERE ordinal = ? AND doc_key = ? ORDER BY chunk_index`, ordinal, docKey)
+	if err != nil {
+		return nil, fmt.Errorf("read invalid chunk map for %s: %w", docKey, err)
+	}
+	defer rows.Close()
+
+	var rowids []int64
+	for rows.Next() {
+		var rowid int64
+		if err := rows.Scan(&rowid); err != nil {
+			return nil, fmt.Errorf("scan invalid chunk map for %s: %w", docKey, err)
+		}
+		rowids = append(rowids, rowid)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate invalid chunk map for %s: %w", docKey, err)
+	}
+	return rowids, nil
+}

--- a/internal/vector/repair.go
+++ b/internal/vector/repair.go
@@ -144,8 +144,41 @@ func (ix *Index) scanInvalidRepairDocuments(
 		args = append(args, docKey)
 	}
 	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(documents)), ",")
+	type documentState struct {
+		expected int
+		seen     int
+		invalid  bool
+	}
+	states := make(map[string]*documentState, len(documents))
+	contentRows, err := ix.db.QueryContext(ctx, `
+SELECT d.doc_key, d.content
+  FROM `+ix.spec.DocsTable+` d
+  JOIN `+ix.spec.stampsTable()+` s
+    ON s.doc_key = d.doc_key AND s.ordinal = ?
+   AND s.revision IS d.content_hash
+ WHERE d.doc_key IN (`+placeholders+`)
+ ORDER BY d.doc_key`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("read repair document content: %w", err)
+	}
+	for contentRows.Next() {
+		var docKey, content string
+		if err := contentRows.Scan(&docKey, &content); err != nil {
+			contentRows.Close()
+			return nil, fmt.Errorf("scan repair document content: %w", err)
+		}
+		states[docKey] = &documentState{expected: len(kitvec.Split(content, ix.split))}
+	}
+	if err := contentRows.Err(); err != nil {
+		contentRows.Close()
+		return nil, fmt.Errorf("iterate repair document content: %w", err)
+	}
+	if err := contentRows.Close(); err != nil {
+		return nil, fmt.Errorf("close repair document content scan: %w", err)
+	}
+
 	rows, err := ix.db.QueryContext(ctx, `
-SELECT c.doc_key, d.content, c.chunk_index, v.embedding
+SELECT c.doc_key, c.chunk_index, v.embedding
   FROM `+ix.spec.chunksTable()+` c
   JOIN `+ix.spec.DocsTable+` d ON d.doc_key = c.doc_key
   JOIN `+ix.spec.stampsTable()+` s
@@ -159,42 +192,35 @@ SELECT c.doc_key, d.content, c.chunk_index, v.embedding
 	}
 	defer rows.Close()
 
-	var affected []string
-	currentDoc := ""
-	var expected []kitvec.Chunk
-	seen := 0
-	invalid := false
-	finishDocument := func() {
-		if currentDoc != "" && (invalid || seen != len(expected)) {
-			affected = append(affected, currentDoc)
-		}
-	}
 	for rows.Next() {
-		var docKey, content string
+		var docKey string
 		var chunkIndex int
 		var blob []byte
-		if err := rows.Scan(&docKey, &content, &chunkIndex, &blob); err != nil {
+		if err := rows.Scan(&docKey, &chunkIndex, &blob); err != nil {
 			return nil, fmt.Errorf("scan target generation vector: %w", err)
 		}
-		if docKey != currentDoc {
-			finishDocument()
-			currentDoc = docKey
-			expected = kitvec.Split(content, ix.split)
-			seen = 0
-			invalid = false
+		state := states[docKey]
+		if state == nil {
+			continue
 		}
-		if seen >= len(expected) || expected[seen].Index != chunkIndex {
-			invalid = true
+		if state.seen >= state.expected || state.seen != chunkIndex {
+			state.invalid = true
 		}
-		seen++
+		state.seen++
 		if validateStoredEmbeddingBlob(blob, dimension) != nil {
-			invalid = true
+			state.invalid = true
 		}
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate target generation vectors: %w", err)
 	}
-	finishDocument()
+	var affected []string
+	for _, docKey := range documents {
+		state := states[docKey]
+		if state != nil && (state.invalid || state.seen != state.expected) {
+			affected = append(affected, docKey)
+		}
+	}
 	return affected, nil
 }
 

--- a/internal/vector/repair_test.go
+++ b/internal/vector/repair_test.go
@@ -1,0 +1,979 @@
+package vector
+
+import (
+	"context"
+	"database/sql"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	"net/http"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	kitvec "go.kenn.io/kit/vector"
+)
+
+func TestBuildRepairInvalidRegeneratesOnlyAffectedDocuments(t *testing.T) {
+	ix := openTestIndex(t)
+	ix.split = kitvec.SplitOptions{MaxRunes: 5}
+	ctx := context.Background()
+	src := &fakeUnitSource{rows: []fakeUnit{
+		{unit: userDoc("s1", "bad", 0, "abcdefghij"), endedAt: "2024-01-01T00:00:00Z"},
+		{unit: userDoc("s1", "good", 1, "short"), endedAt: "2024-01-01T00:00:01Z"},
+	}}
+	oldGen := fakeGeneration("old-model")
+	activeGen := fakeGeneration("active-model")
+	require.NoError(t, buildWithoutResult(ix, ctx, src, oldGen))
+	require.NoError(t, buildWithoutResult(ix, ctx, src, activeGen))
+
+	oldOrdinal, err := ix.ordinalForFingerprint(ctx, oldGen.Fingerprint())
+	require.NoError(t, err)
+	activeOrdinal, err := ix.ordinalForFingerprint(ctx, activeGen.Fingerprint())
+	require.NoError(t, err)
+
+	var oldBadRowID, activeBadRowID, activeGoodRowID int64
+	var oldBadBlob, activeGoodBlob []byte
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT c.vec_rowid, v.embedding
+  FROM message_vectors_chunks c
+  JOIN message_vectors_v`+fmtInt64(oldOrdinal)+` v ON v.rowid = c.vec_rowid
+ WHERE c.ordinal = ? AND c.doc_key = 'u:s1:bad' AND c.chunk_index = 0`, oldOrdinal,
+	).Scan(&oldBadRowID, &oldBadBlob))
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT c.vec_rowid
+  FROM message_vectors_chunks c
+ WHERE c.ordinal = ? AND c.doc_key = 'u:s1:bad' AND c.chunk_index = 0`, activeOrdinal,
+	).Scan(&activeBadRowID))
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT c.vec_rowid, v.embedding
+  FROM message_vectors_chunks c
+  JOIN message_vectors_v`+fmtInt64(activeOrdinal)+` v ON v.rowid = c.vec_rowid
+ WHERE c.ordinal = ? AND c.doc_key = 'u:s1:good' AND c.chunk_index = 0`, activeOrdinal,
+	).Scan(&activeGoodRowID, &activeGoodBlob))
+
+	_, err = ix.db.ExecContext(ctx,
+		`UPDATE message_vectors_v`+fmtInt64(activeOrdinal)+` SET embedding = ? WHERE rowid = ?`,
+		make([]byte, 3*4), activeBadRowID)
+	require.NoError(t, err)
+	// This source document did not exist when the mirror was built. Repair mode
+	// must not refresh the mirror, discover it, or turn it into missing work.
+	src.rows = append(src.rows,
+		fakeUnit{unit: userDoc("s1", "pending", 2, "pending"), endedAt: "2024-01-01T00:00:02Z"})
+
+	var encodedChunks int
+	repairEncoder := func(_ context.Context, texts []string) ([][]float32, error) {
+		encodedChunks += len(texts)
+		out := make([][]float32, len(texts))
+		for i := range out {
+			out[i] = []float32{0, 1, 0}
+		}
+		return out, nil
+	}
+	result, err := ix.Build(ctx, src, repairEncoder, activeGen, BuildOptions{RepairInvalid: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, RepairStats{
+		Scanned: true, ScanComplete: true, Documents: 1, Chunks: 2, RemainingKnown: true,
+	}, result.Repair)
+	assert.Equal(t, 1, result.Fill.Documents)
+	assert.Equal(t, 2, encodedChunks, "all chunks of the affected document are regenerated")
+
+	var newActiveBadRowID, newActiveGoodRowID, newOldBadRowID int64
+	var newActiveBadBlob, newActiveGoodBlob, newOldBadBlob []byte
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT c.vec_rowid, v.embedding
+  FROM message_vectors_chunks c
+  JOIN message_vectors_v`+fmtInt64(activeOrdinal)+` v ON v.rowid = c.vec_rowid
+ WHERE c.ordinal = ? AND c.doc_key = 'u:s1:bad' AND c.chunk_index = 0`, activeOrdinal,
+	).Scan(&newActiveBadRowID, &newActiveBadBlob))
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT c.vec_rowid, v.embedding
+  FROM message_vectors_chunks c
+  JOIN message_vectors_v`+fmtInt64(activeOrdinal)+` v ON v.rowid = c.vec_rowid
+ WHERE c.ordinal = ? AND c.doc_key = 'u:s1:good' AND c.chunk_index = 0`, activeOrdinal,
+	).Scan(&newActiveGoodRowID, &newActiveGoodBlob))
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT c.vec_rowid, v.embedding
+  FROM message_vectors_chunks c
+  JOIN message_vectors_v`+fmtInt64(oldOrdinal)+` v ON v.rowid = c.vec_rowid
+ WHERE c.ordinal = ? AND c.doc_key = 'u:s1:bad' AND c.chunk_index = 0`, oldOrdinal,
+	).Scan(&newOldBadRowID, &newOldBadBlob))
+
+	assert.NotEqual(t, activeBadRowID, newActiveBadRowID)
+	newActiveBadVector, err := decodeFloat32Blob(newActiveBadBlob)
+	require.NoError(t, err)
+	assert.NoError(t, validateEmbedding(newActiveBadVector, 0))
+	assert.Equal(t, activeGoodRowID, newActiveGoodRowID)
+	assert.Equal(t, activeGoodBlob, newActiveGoodBlob)
+	assert.Equal(t, oldBadRowID, newOldBadRowID)
+	assert.Equal(t, oldBadBlob, newOldBadBlob)
+
+	var mirrorDocuments int64
+	require.NoError(t, ix.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM `+ix.spec.DocsTable).Scan(&mirrorDocuments))
+	assert.Equal(t, int64(2), mirrorDocuments, "repair must not expand the mirror")
+
+	activeInfo, err := ix.GenerationByID(ctx, activeOrdinal)
+	require.NoError(t, err)
+	assert.Zero(t, activeInfo.Missing, "repair must preserve complete generation coverage")
+
+	second, err := ix.Build(ctx, src, func(context.Context, []string) ([][]float32, error) {
+		t.Fatal("a clean repair scan must not encode unrelated pending documents")
+		return nil, nil
+	}, activeGen, BuildOptions{RepairInvalid: true})
+	require.NoError(t, err)
+	assert.Equal(t, RepairStats{
+		Scanned: true, ScanComplete: true, RemainingKnown: true,
+	}, second.Repair)
+	assert.Zero(t, second.Fill.Documents)
+}
+
+func TestValidateStoredEmbeddingBlobRejectsEveryCorruptionClass(t *testing.T) {
+	tests := []struct {
+		name      string
+		blob      []byte
+		dimension int
+		reason    string
+	}{
+		{name: "malformed bytes", blob: []byte{1, 2, 3}, dimension: 3, reason: "byte length"},
+		{name: "wrong dimension", blob: float32Blob(1, 2), dimension: 3, reason: "dimension"},
+		{name: "nan", blob: float32Blob(1, float32(math.NaN()), 2), dimension: 3, reason: "non-finite"},
+		{name: "positive infinity", blob: float32Blob(1, float32(math.Inf(1)), 2), dimension: 3, reason: "non-finite"},
+		{name: "negative infinity", blob: float32Blob(1, float32(math.Inf(-1)), 2), dimension: 3, reason: "non-finite"},
+		{name: "zero norm", blob: float32Blob(0, 0, 0), dimension: 3, reason: "zero norm"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateStoredEmbeddingBlob(tt.blob, tt.dimension)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.reason)
+		})
+	}
+}
+
+func TestRepairInvalidVectorsQueuesOnlyAffectedDocument(t *testing.T) {
+	ix := openTestIndex(t)
+	ctx := context.Background()
+	src := &fakeUnitSource{rows: []fakeUnit{
+		{unit: userDoc("s1", "bad", 0, "bad"), endedAt: "2024-01-01T00:00:00Z"},
+		{unit: userDoc("s1", "good", 1, "good"), endedAt: "2024-01-01T00:00:01Z"},
+	}}
+	gen := fakeGeneration("active-model")
+	require.NoError(t, buildWithoutResult(ix, ctx, src, gen))
+	ordinal, err := ix.ordinalForFingerprint(ctx, gen.Fingerprint())
+	require.NoError(t, err)
+
+	var rowID int64
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT vec_rowid FROM message_vectors_chunks
+ WHERE ordinal = ? AND doc_key = 'u:s1:bad'`, ordinal).Scan(&rowID))
+	_, err = ix.db.ExecContext(ctx,
+		`UPDATE message_vectors_v`+fmtInt64(ordinal)+` SET embedding = ? WHERE rowid = ?`,
+		make([]byte, 3*4), rowID)
+	require.NoError(t, err)
+
+	result, err := ix.repairInvalidVectors(ctx, gen.Fingerprint())
+	require.NoError(t, err)
+	assert.Equal(t, RepairStats{
+		Scanned: true, ScanComplete: true, Documents: 1, Chunks: 1,
+	}, result.Stats)
+
+	var queued, badChunks, badStamps, goodChunks int
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM message_vectors_repair_queue
+ WHERE ordinal = ? AND doc_key = 'u:s1:bad'`, ordinal).Scan(&queued))
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM message_vectors_chunks
+ WHERE ordinal = ? AND doc_key = 'u:s1:bad'`, ordinal).Scan(&badChunks))
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM message_vectors_stamps
+ WHERE ordinal = ? AND doc_key = 'u:s1:bad'`, ordinal).Scan(&badStamps))
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM message_vectors_chunks
+ WHERE ordinal = ? AND doc_key = 'u:s1:good'`, ordinal).Scan(&goodChunks))
+	assert.Equal(t, 1, queued)
+	assert.Zero(t, badChunks)
+	assert.Zero(t, badStamps)
+	assert.Equal(t, 1, goodChunks)
+}
+
+func TestBuildRepairInvalidRejectsBackstop(t *testing.T) {
+	ix := openTestIndex(t)
+	ctx := context.Background()
+	gen := fakeGeneration("active-model")
+	require.NoError(t, buildWithoutResult(ix, ctx, twoDocSource(), gen))
+
+	_, err := ix.Build(ctx, twoDocSource(), fakeBuildEncoder(), gen, BuildOptions{
+		Backstop:      true,
+		RepairInvalid: true,
+	})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "repair-invalid and backstop are mutually exclusive")
+}
+
+func TestBuildRepairInvalidRegeneratesMissingVectorRow(t *testing.T) {
+	ix := openTestIndex(t)
+	ctx := context.Background()
+	src := &fakeUnitSource{rows: []fakeUnit{
+		{unit: userDoc("s1", "bad", 0, "bad"), endedAt: "2024-01-01T00:00:00Z"},
+	}}
+	gen := fakeGeneration("active-model")
+	require.NoError(t, buildWithoutResult(ix, ctx, src, gen))
+	ordinal, err := ix.ordinalForFingerprint(ctx, gen.Fingerprint())
+	require.NoError(t, err)
+
+	var rowID int64
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT vec_rowid FROM message_vectors_chunks
+ WHERE ordinal = ? AND doc_key = 'u:s1:bad'`, ordinal).Scan(&rowID))
+	_, err = ix.db.ExecContext(ctx,
+		`DELETE FROM message_vectors_v`+fmtInt64(ordinal)+` WHERE rowid = ?`, rowID)
+	require.NoError(t, err)
+
+	result, err := ix.Build(ctx, src, fakeBuildEncoder(), gen,
+		BuildOptions{RepairInvalid: true})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Repair.Documents)
+	assert.Equal(t, 1, result.Fill.Documents)
+
+	var replacementRows int
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT COUNT(*)
+  FROM message_vectors_chunks c
+  JOIN message_vectors_v`+fmtInt64(ordinal)+` v ON v.rowid = c.vec_rowid
+ WHERE c.ordinal = ? AND c.doc_key = 'u:s1:bad'`, ordinal).Scan(&replacementRows))
+	assert.Equal(t, 1, replacementRows)
+}
+
+func TestBuildRepairInvalidResumesAffectedKeysAfterEncodeFailure(t *testing.T) {
+	ix := openTestIndex(t)
+	ctx := context.Background()
+	src := &fakeUnitSource{rows: []fakeUnit{
+		{unit: userDoc("s1", "bad", 0, "bad"), endedAt: "2024-01-01T00:00:00Z"},
+		{unit: userDoc("s1", "good", 1, "good"), endedAt: "2024-01-01T00:00:01Z"},
+	}}
+	gen := fakeGeneration("active-model")
+	require.NoError(t, buildWithoutResult(ix, ctx, src, gen))
+	ordinal, err := ix.ordinalForFingerprint(ctx, gen.Fingerprint())
+	require.NoError(t, err)
+
+	var badRowID int64
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT vec_rowid FROM message_vectors_chunks
+ WHERE ordinal = ? AND doc_key = 'u:s1:bad'`, ordinal).Scan(&badRowID))
+	_, err = ix.db.ExecContext(ctx,
+		`UPDATE message_vectors_v`+fmtInt64(ordinal)+` SET embedding = ? WHERE rowid = ?`,
+		make([]byte, 3*4), badRowID)
+	require.NoError(t, err)
+	src.rows = append(src.rows,
+		fakeUnit{unit: userDoc("s1", "pending", 2, "pending"), endedAt: "2024-01-01T00:00:02Z"})
+
+	_, err = ix.Build(ctx, src, func(context.Context, []string) ([][]float32, error) {
+		return nil, errors.New("endpoint failed")
+	}, gen, BuildOptions{RepairInvalid: true})
+	require.ErrorContains(t, err, "endpoint failed")
+
+	var encoded []string
+	second, err := ix.Build(ctx, src, func(_ context.Context, texts []string) ([][]float32, error) {
+		encoded = append(encoded, texts...)
+		return fakeBuildEncoder()(ctx, texts)
+	}, gen, BuildOptions{RepairInvalid: true})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"bad"}, encoded)
+	assert.Equal(t, 1, second.Repair.Documents)
+	assert.Equal(t, 1, second.Fill.Documents)
+
+	third, err := ix.Build(ctx, src, func(context.Context, []string) ([][]float32, error) {
+		t.Fatal("a completed repair must leave no durable targets")
+		return nil, nil
+	}, gen, BuildOptions{RepairInvalid: true})
+	require.NoError(t, err)
+	assert.Equal(t, RepairStats{
+		Scanned: true, ScanComplete: true, RemainingKnown: true,
+	}, third.Repair)
+}
+
+func TestBuildRepairInvalidQueueOwnsTargetAcrossRevisionDrift(t *testing.T) {
+	ix := openTestIndex(t)
+	ctx := context.Background()
+	src := &fakeUnitSource{rows: []fakeUnit{
+		{unit: userDoc("s1", "bad", 0, "old content"), endedAt: "2024-01-01T00:00:00Z"},
+	}}
+	gen := fakeGeneration("active-model")
+	require.NoError(t, buildWithoutResult(ix, ctx, src, gen))
+	ordinal, err := ix.ordinalForFingerprint(ctx, gen.Fingerprint())
+	require.NoError(t, err)
+
+	var rowID int64
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT vec_rowid FROM message_vectors_chunks
+ WHERE ordinal = ? AND doc_key = 'u:s1:bad'`, ordinal).Scan(&rowID))
+	_, err = ix.db.ExecContext(ctx,
+		`UPDATE message_vectors_v`+fmtInt64(ordinal)+` SET embedding = ? WHERE rowid = ?`,
+		make([]byte, 3*4), rowID)
+	require.NoError(t, err)
+
+	first, err := ix.Build(ctx, src, func(_ context.Context, texts []string) ([][]float32, error) {
+		require.Equal(t, []string{"old content"}, texts)
+		_, updateErr := ix.db.ExecContext(ctx, `
+UPDATE vector_messages
+   SET content = ?, content_hash = ?
+ WHERE doc_key = 'u:s1:bad'`, "new content", contentHash("new content"))
+		require.NoError(t, updateErr)
+		return fakeBuildEncoder()(ctx, texts)
+	}, gen, BuildOptions{RepairInvalid: true})
+	require.ErrorContains(t, err, "targets remain queued")
+	assert.Equal(t, 1, first.Fill.Stale)
+	assert.Equal(t, 1, first.Repair.Remaining)
+
+	var encoded []string
+	second, err := ix.Build(ctx, src, func(_ context.Context, texts []string) ([][]float32, error) {
+		encoded = append(encoded, texts...)
+		return fakeBuildEncoder()(ctx, texts)
+	}, gen, BuildOptions{RepairInvalid: true})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"new content"}, encoded,
+		"the durable queue owns the document and repairs its latest revision")
+	assert.Equal(t, 1, second.Fill.Documents)
+	assert.Zero(t, second.Repair.Remaining)
+}
+
+func TestBuildRepairInvalidCompletesQueuedRevisionThatBecomesEmpty(t *testing.T) {
+	ix := openTestIndex(t)
+	ctx := context.Background()
+	src := &fakeUnitSource{rows: []fakeUnit{
+		{unit: userDoc("s1", "bad", 0, "old content"), endedAt: "2024-01-01T00:00:00Z"},
+	}}
+	gen := fakeGeneration("active-model")
+	require.NoError(t, buildWithoutResult(ix, ctx, src, gen))
+	ordinal, err := ix.ordinalForFingerprint(ctx, gen.Fingerprint())
+	require.NoError(t, err)
+
+	var rowID int64
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT vec_rowid FROM message_vectors_chunks
+ WHERE ordinal = ? AND doc_key = 'u:s1:bad'`, ordinal).Scan(&rowID))
+	_, err = ix.db.ExecContext(ctx,
+		`UPDATE message_vectors_v`+fmtInt64(ordinal)+` SET embedding = ? WHERE rowid = ?`,
+		make([]byte, 3*4), rowID)
+	require.NoError(t, err)
+
+	first, err := ix.Build(ctx, src, func(_ context.Context, texts []string) ([][]float32, error) {
+		require.Equal(t, []string{"old content"}, texts)
+		_, updateErr := ix.db.ExecContext(ctx, `
+UPDATE vector_messages
+   SET content = '', content_hash = ?
+ WHERE doc_key = 'u:s1:bad'`, contentHash(""))
+		require.NoError(t, updateErr)
+		return fakeBuildEncoder()(ctx, texts)
+	}, gen, BuildOptions{RepairInvalid: true})
+	require.ErrorContains(t, err, "targets remain queued")
+	assert.Equal(t, 1, first.Fill.Stale)
+
+	second, err := ix.Build(ctx, src, func(context.Context, []string) ([][]float32, error) {
+		t.Fatal("zero-chunk content must complete without calling the encoder")
+		return nil, nil
+	}, gen, BuildOptions{RepairInvalid: true})
+	require.NoError(t, err)
+	assert.Equal(t, 1, second.Fill.Documents)
+	assert.Zero(t, second.Fill.Chunks)
+	assert.Zero(t, second.Repair.Remaining)
+
+	var queued, stamped int
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM message_vectors_repair_queue
+ WHERE ordinal = ? AND doc_key = 'u:s1:bad'`, ordinal).Scan(&queued))
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM message_vectors_stamps
+ WHERE ordinal = ? AND doc_key = 'u:s1:bad' AND revision = ?`,
+		ordinal, contentHash("")).Scan(&stamped))
+	assert.Zero(t, queued)
+	assert.Equal(t, 1, stamped)
+}
+
+func TestOrdinaryBuildClearsCompletedRepairTarget(t *testing.T) {
+	ix := openTestIndex(t)
+	ctx := context.Background()
+	src := &fakeUnitSource{rows: []fakeUnit{
+		{unit: userDoc("s1", "bad", 0, "bad"), endedAt: "2024-01-01T00:00:00Z"},
+	}}
+	gen := fakeGeneration("active-model")
+	require.NoError(t, buildWithoutResult(ix, ctx, src, gen))
+	ordinal, err := ix.ordinalForFingerprint(ctx, gen.Fingerprint())
+	require.NoError(t, err)
+
+	var rowID int64
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT vec_rowid FROM message_vectors_chunks
+ WHERE ordinal = ? AND doc_key = 'u:s1:bad'`, ordinal).Scan(&rowID))
+	_, err = ix.db.ExecContext(ctx,
+		`UPDATE message_vectors_v`+fmtInt64(ordinal)+` SET embedding = ? WHERE rowid = ?`,
+		make([]byte, 3*4), rowID)
+	require.NoError(t, err)
+
+	_, err = ix.Build(ctx, src, func(context.Context, []string) ([][]float32, error) {
+		return nil, errors.New("endpoint failed")
+	}, gen, BuildOptions{RepairInvalid: true})
+	require.ErrorContains(t, err, "endpoint failed")
+
+	result, err := ix.Build(ctx, src, fakeBuildEncoder(), gen, BuildOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Fill.Documents)
+
+	var queued int
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM message_vectors_repair_queue
+ WHERE ordinal = ? AND doc_key = 'u:s1:bad'`, ordinal).Scan(&queued))
+	assert.Zero(t, queued,
+		"an ordinary successful save for the queued generation must complete the repair target")
+
+	repair, err := ix.Build(ctx, src, func(context.Context, []string) ([][]float32, error) {
+		t.Fatal("repair must not re-embed work completed by an ordinary build")
+		return nil, nil
+	}, gen, BuildOptions{RepairInvalid: true})
+	require.NoError(t, err)
+	assert.Equal(t, RepairStats{
+		Scanned: true, ScanComplete: true, RemainingKnown: true,
+	}, repair.Repair)
+}
+
+func TestOrdinaryBuildStampOnlySkipKeepsRepairTarget(t *testing.T) {
+	ix := openTestIndex(t)
+	ctx := context.Background()
+	src := &fakeUnitSource{rows: []fakeUnit{
+		{unit: userDoc("s1", "bad", 0, "bad"), endedAt: "2024-01-01T00:00:00Z"},
+	}}
+	gen := fakeGeneration("active-model")
+	require.NoError(t, buildWithoutResult(ix, ctx, src, gen))
+	ordinal, err := ix.ordinalForFingerprint(ctx, gen.Fingerprint())
+	require.NoError(t, err)
+
+	var rowID int64
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT vec_rowid FROM message_vectors_chunks
+ WHERE ordinal = ? AND doc_key = 'u:s1:bad'`, ordinal).Scan(&rowID))
+	_, err = ix.db.ExecContext(ctx,
+		`UPDATE message_vectors_v`+fmtInt64(ordinal)+` SET embedding = ? WHERE rowid = ?`,
+		make([]byte, 3*4), rowID)
+	require.NoError(t, err)
+
+	_, err = ix.Build(ctx, src, func(context.Context, []string) ([][]float32, error) {
+		return nil, errors.New("endpoint failed")
+	}, gen, BuildOptions{RepairInvalid: true})
+	require.ErrorContains(t, err, "endpoint failed")
+
+	ordinary, err := ix.Build(ctx, src, func(context.Context, []string) ([][]float32, error) {
+		return nil, &HTTPStatusError{Status: http.StatusBadRequest, Body: "input exceeds token limit"}
+	}, gen, BuildOptions{FullRebuild: true})
+	require.NoError(t, err)
+	assert.Equal(t, 1, ordinary.Fill.Skipped)
+
+	var queued int
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM message_vectors_repair_queue
+ WHERE ordinal = ? AND doc_key = 'u:s1:bad'`, ordinal).Scan(&queued))
+	assert.Equal(t, 1, queued, "a stamp without vectors must not complete repair")
+
+	repair, err := ix.Build(ctx, src, fakeBuildEncoder(), gen,
+		BuildOptions{RepairInvalid: true})
+	require.NoError(t, err)
+	assert.Equal(t, 1, repair.Fill.Documents)
+	assert.Zero(t, repair.Repair.Remaining)
+}
+
+func TestBuildRepairInvalidKeepsTargetAfterPermanentEncodeFailure(t *testing.T) {
+	assertFailedRepairRemainsQueued(t, &HTTPStatusError{
+		Status: http.StatusBadRequest,
+		Body:   "input exceeds token limit",
+	})
+}
+
+func TestBuildRepairInvalidKeepsTargetAfterContextDeadline(t *testing.T) {
+	assertFailedRepairRemainsQueued(t, context.DeadlineExceeded)
+}
+
+func assertFailedRepairRemainsQueued(t *testing.T, encodeErr error) {
+	t.Helper()
+	ix := openTestIndex(t)
+	ctx := context.Background()
+	src := &fakeUnitSource{rows: []fakeUnit{
+		{unit: userDoc("s1", "bad", 0, "bad"), endedAt: "2024-01-01T00:00:00Z"},
+	}}
+	gen := fakeGeneration("active-model")
+	require.NoError(t, buildWithoutResult(ix, ctx, src, gen))
+	ordinal, err := ix.ordinalForFingerprint(ctx, gen.Fingerprint())
+	require.NoError(t, err)
+
+	var rowID int64
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT vec_rowid FROM message_vectors_chunks
+ WHERE ordinal = ? AND doc_key = 'u:s1:bad'`, ordinal).Scan(&rowID))
+	_, err = ix.db.ExecContext(ctx,
+		`UPDATE message_vectors_v`+fmtInt64(ordinal)+` SET embedding = ? WHERE rowid = ?`,
+		make([]byte, 3*4), rowID)
+	require.NoError(t, err)
+
+	failed, err := ix.Build(ctx, src, func(context.Context, []string) ([][]float32, error) {
+		return nil, encodeErr
+	}, gen, BuildOptions{RepairInvalid: true})
+	require.Error(t, err)
+	assert.Equal(t, 1, failed.Repair.Failed)
+	assert.Equal(t, 1, failed.Repair.Remaining)
+
+	var queued, stamped int
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM message_vectors_repair_queue
+ WHERE ordinal = ? AND doc_key = 'u:s1:bad'`, ordinal).Scan(&queued))
+	assert.Equal(t, 1, queued, "an unsuccessful replacement must remain queued")
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM message_vectors_stamps
+ WHERE ordinal = ? AND doc_key = 'u:s1:bad'`, ordinal).Scan(&stamped))
+	assert.Zero(t, stamped, "an unsuccessful replacement must remain unstamped")
+
+	result, err := ix.Build(ctx, src, fakeBuildEncoder(), gen,
+		BuildOptions{RepairInvalid: true})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Fill.Documents)
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM message_vectors_repair_queue
+ WHERE ordinal = ? AND doc_key = 'u:s1:bad'`, ordinal).Scan(&queued))
+	assert.Zero(t, queued)
+}
+
+func TestBuildRepairInvalidContinuesAfterPermanentTargetFailure(t *testing.T) {
+	ix := openTestIndex(t)
+	ctx := context.Background()
+	src := &fakeUnitSource{rows: []fakeUnit{
+		{unit: userDoc("s1", "a-bad", 0, "bad"), endedAt: "2024-01-01T00:00:00Z"},
+		{unit: userDoc("s1", "z-good", 1, "good"), endedAt: "2024-01-01T00:00:01Z"},
+	}}
+	gen := fakeGeneration("active-model")
+	require.NoError(t, buildWithoutResult(ix, ctx, src, gen))
+	ordinal, err := ix.ordinalForFingerprint(ctx, gen.Fingerprint())
+	require.NoError(t, err)
+	_, err = ix.db.ExecContext(ctx,
+		`UPDATE message_vectors_v`+fmtInt64(ordinal)+` SET embedding = ?`, make([]byte, 3*4))
+	require.NoError(t, err)
+
+	result, err := ix.Build(ctx, src, func(_ context.Context, texts []string) ([][]float32, error) {
+		if texts[0] == "bad" {
+			return nil, &HTTPStatusError{
+				Status: http.StatusBadRequest,
+				Body:   "input exceeds token limit",
+			}
+		}
+		return fakeBuildEncoder()(ctx, texts)
+	}, gen, BuildOptions{RepairInvalid: true})
+	require.ErrorContains(t, err, "1 permanently rejected")
+	assert.Equal(t, 1, result.Fill.Documents, "later repair targets must still be attempted")
+	assert.Equal(t, 1, result.Repair.Failed)
+	assert.Equal(t, 1, result.Repair.Remaining)
+
+	var queuedBad, queuedGood, stampedBad, stampedGood int
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM message_vectors_repair_queue
+ WHERE ordinal = ? AND doc_key = 'u:s1:a-bad'`, ordinal).Scan(&queuedBad))
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM message_vectors_repair_queue
+ WHERE ordinal = ? AND doc_key = 'u:s1:z-good'`, ordinal).Scan(&queuedGood))
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM message_vectors_stamps
+ WHERE ordinal = ? AND doc_key = 'u:s1:a-bad'`, ordinal).Scan(&stampedBad))
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM message_vectors_stamps
+ WHERE ordinal = ? AND doc_key = 'u:s1:z-good'`, ordinal).Scan(&stampedGood))
+	assert.Equal(t, 1, queuedBad)
+	assert.Zero(t, queuedGood)
+	assert.Zero(t, stampedBad)
+	assert.Equal(t, 1, stampedGood)
+}
+
+func TestBuildRepairInvalidUsesConfiguredDocumentConcurrency(t *testing.T) {
+	ix := openTestIndex(t)
+	ctx := context.Background()
+	src := &fakeUnitSource{rows: []fakeUnit{
+		{unit: userDoc("s1", "one", 0, "one"), endedAt: "2024-01-01T00:00:00Z"},
+		{unit: userDoc("s1", "two", 1, "two"), endedAt: "2024-01-01T00:00:01Z"},
+	}}
+	gen := fakeGeneration("active-model")
+	require.NoError(t, buildWithoutResult(ix, ctx, src, gen))
+	ordinal, err := ix.ordinalForFingerprint(ctx, gen.Fingerprint())
+	require.NoError(t, err)
+	_, err = ix.db.ExecContext(ctx,
+		`UPDATE message_vectors_v`+fmtInt64(ordinal)+` SET embedding = ?`, make([]byte, 3*4))
+	require.NoError(t, err)
+
+	started := make(chan struct{}, 2)
+	release := make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(release)
+		}
+	}()
+	var active, peak atomic.Int32
+	encoder := func(_ context.Context, texts []string) ([][]float32, error) {
+		current := active.Add(1)
+		for {
+			previous := peak.Load()
+			if current <= previous || peak.CompareAndSwap(previous, current) {
+				break
+			}
+		}
+		started <- struct{}{}
+		<-release
+		active.Add(-1)
+		return fakeBuildEncoder()(ctx, texts)
+	}
+	type buildOutcome struct {
+		result BuildResult
+		err    error
+	}
+	done := make(chan buildOutcome, 1)
+	go func() {
+		result, err := ix.Build(ctx, src, encoder, gen,
+			BuildOptions{RepairInvalid: true, Concurrency: 2})
+		done <- buildOutcome{result: result, err: err}
+	}()
+	for range 2 {
+		select {
+		case <-started:
+		case <-time.After(2 * time.Second):
+			close(release)
+			released = true
+			require.FailNow(t, "repair did not start two document encodes concurrently")
+		}
+	}
+	close(release)
+	released = true
+	outcome := <-done
+	require.NoError(t, outcome.err)
+	assert.Equal(t, int32(2), peak.Load())
+	assert.Equal(t, 2, outcome.result.Fill.Documents)
+}
+
+func TestBuildRepairInvalidRegeneratesPartiallyMissingChunkMap(t *testing.T) {
+	ix := openTestIndex(t)
+	ix.split = kitvec.SplitOptions{MaxRunes: 5}
+	ctx := context.Background()
+	src := &fakeUnitSource{rows: []fakeUnit{
+		{unit: userDoc("s1", "bad", 0, "abcdefghij"), endedAt: "2024-01-01T00:00:00Z"},
+	}}
+	gen := fakeGeneration("active-model")
+	require.NoError(t, buildWithoutResult(ix, ctx, src, gen))
+	ordinal, err := ix.ordinalForFingerprint(ctx, gen.Fingerprint())
+	require.NoError(t, err)
+
+	var rowID int64
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT vec_rowid FROM message_vectors_chunks
+ WHERE ordinal = ? AND doc_key = 'u:s1:bad' AND chunk_index = 1`, ordinal).Scan(&rowID))
+	_, err = ix.db.ExecContext(ctx, `
+DELETE FROM message_vectors_chunks
+ WHERE ordinal = ? AND doc_key = 'u:s1:bad' AND chunk_index = 1`, ordinal)
+	require.NoError(t, err)
+	_, err = ix.db.ExecContext(ctx,
+		`DELETE FROM message_vectors_v`+fmtInt64(ordinal)+` WHERE rowid = ?`, rowID)
+	require.NoError(t, err)
+
+	result, err := ix.Build(ctx, src, fakeBuildEncoder(), gen,
+		BuildOptions{RepairInvalid: true})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Repair.Documents)
+	assert.Equal(t, 1, result.Fill.Documents)
+	assert.Equal(t, 2, result.Fill.Chunks)
+}
+
+func TestBuildRepairInvalidResumesAfterLaterScanBatchFails(t *testing.T) {
+	ix := openTestIndex(t)
+	ctx := context.Background()
+	const documentCount = repairScanDocumentBatch + 1
+	src := &fakeUnitSource{rows: make([]fakeUnit, 0, documentCount)}
+	for i := range documentCount {
+		id := fmt.Sprintf("doc-%03d", i)
+		src.rows = append(src.rows, fakeUnit{
+			unit:    userDoc("s1", id, i, id),
+			endedAt: fmt.Sprintf("2024-01-01T00:%02d:%02dZ", i/60, i%60),
+		})
+	}
+	gen := fakeGeneration("active-model")
+	require.NoError(t, buildWithoutResult(ix, ctx, src, gen))
+	ordinal, err := ix.ordinalForFingerprint(ctx, gen.Fingerprint())
+	require.NoError(t, err)
+	_, err = ix.db.ExecContext(ctx,
+		`UPDATE message_vectors_v`+fmtInt64(ordinal)+` SET embedding = ?`, make([]byte, 3*4))
+	require.NoError(t, err)
+	_, err = ix.db.ExecContext(ctx, `
+CREATE TRIGGER fail_second_repair_batch
+BEFORE INSERT ON message_vectors_repair_queue
+WHEN NEW.doc_key = 'u:s1:doc-128'
+BEGIN
+    SELECT RAISE(ABORT, 'injected later repair batch failure');
+END`)
+	require.NoError(t, err)
+
+	partial, err := ix.Build(ctx, src, fakeBuildEncoder(), gen,
+		BuildOptions{RepairInvalid: true})
+	require.ErrorContains(t, err, "injected later repair batch failure")
+	assert.True(t, partial.Repair.Scanned)
+	assert.False(t, partial.Repair.ScanComplete)
+	assert.Equal(t, repairScanDocumentBatch, partial.Repair.Documents)
+	assert.Equal(t, repairScanDocumentBatch, partial.Repair.Remaining)
+	assert.True(t, partial.Repair.RemainingKnown)
+	var queued int
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM message_vectors_repair_queue WHERE ordinal = ?`, ordinal).Scan(&queued))
+	assert.Equal(t, repairScanDocumentBatch, queued,
+		"the first committed scan batch must remain durably queued")
+	_, err = ix.db.ExecContext(ctx, `DROP TRIGGER fail_second_repair_batch`)
+	require.NoError(t, err)
+
+	result, err := ix.Build(ctx, src, fakeBuildEncoder(), gen,
+		BuildOptions{RepairInvalid: true})
+	require.NoError(t, err)
+	assert.True(t, result.Repair.ScanComplete)
+	assert.Equal(t, documentCount, result.Repair.Documents)
+	assert.Equal(t, documentCount, result.Fill.Documents)
+
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM message_vectors_repair_queue WHERE ordinal = ?`, ordinal).Scan(&queued))
+	assert.Zero(t, queued)
+}
+
+func TestRepairRemainingAfterScanErrorIgnoresCanceledBuildContext(t *testing.T) {
+	ix := openTestIndex(t)
+	ctx := context.Background()
+	gen := fakeGeneration("active-model")
+	require.NoError(t, buildWithoutResult(ix, ctx, twoDocSource(), gen))
+	ordinal, err := ix.ordinalForFingerprint(ctx, gen.Fingerprint())
+	require.NoError(t, err)
+	_, err = ix.db.ExecContext(ctx, `
+INSERT INTO message_vectors_repair_queue (ordinal, doc_key)
+VALUES (?, 'u:s1:u1')`, ordinal)
+	require.NoError(t, err)
+
+	canceled, cancel := context.WithCancel(ctx)
+	cancel()
+	store := &repairStore{
+		base: ix.store, db: ix.db, spec: ix.spec, fingerprint: gen.Fingerprint(),
+		ordinal: ordinal, queueTable: ix.spec.repairQueueTable(), split: ix.split,
+	}
+	remaining, known, err := repairRemainingAfterScanError(canceled, store, 7)
+	require.NoError(t, err)
+	assert.True(t, known)
+	assert.Equal(t, 1, remaining,
+		"the recount must survive cancellation instead of reporting zero or only the fallback")
+}
+
+func TestRepairRemainingAfterScanErrorReturnsFallbackWhenRecountFails(t *testing.T) {
+	raw, err := sql.Open("sqlite3", filepath.Join(t.TempDir(), "closed.db"))
+	require.NoError(t, err)
+	require.NoError(t, raw.Close())
+	store := &repairStore{db: raw, ordinal: 1, queueTable: "repair_queue"}
+
+	remaining, known, err := repairRemainingAfterScanError(context.Background(), store, 7)
+	require.Error(t, err)
+	assert.Equal(t, 7, remaining)
+	assert.False(t, known)
+}
+
+func TestBuildRepairInvalidRetriesAfterQueueCleanupFailure(t *testing.T) {
+	ix := openTestIndex(t)
+	ctx := context.Background()
+	src := &fakeUnitSource{rows: []fakeUnit{
+		{unit: userDoc("s1", "saved", 0, "saved"), endedAt: "2024-01-01T00:00:00Z"},
+	}}
+	gen := fakeGeneration("active-model")
+	require.NoError(t, buildWithoutResult(ix, ctx, src, gen))
+	ordinal, err := ix.ordinalForFingerprint(ctx, gen.Fingerprint())
+	require.NoError(t, err)
+	var rowID int64
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT vec_rowid FROM message_vectors_chunks
+ WHERE ordinal = ? AND doc_key = 'u:s1:saved'`, ordinal).Scan(&rowID))
+	_, err = ix.db.ExecContext(ctx,
+		`UPDATE message_vectors_v`+fmtInt64(ordinal)+` SET embedding = ? WHERE rowid = ?`,
+		make([]byte, 3*4), rowID)
+	require.NoError(t, err)
+	repair, err := ix.repairInvalidVectors(ctx, gen.Fingerprint())
+	require.NoError(t, err)
+	require.Equal(t, 1, repair.Stats.Documents)
+	_, err = ix.db.ExecContext(ctx, `
+CREATE TRIGGER fail_repair_queue_cleanup
+BEFORE DELETE ON message_vectors_repair_queue
+WHEN OLD.doc_key = 'u:s1:saved'
+BEGIN
+    SELECT RAISE(ABORT, 'injected repair queue cleanup failure');
+END`)
+	require.NoError(t, err)
+	store := &repairStore{
+		base: ix.store, db: ix.db, spec: ix.spec, fingerprint: gen.Fingerprint(),
+		ordinal: ordinal, queueTable: ix.spec.repairQueueTable(), split: ix.split,
+	}
+	_, err = fillRepairQueue(ctx, store, gen.Fingerprint(), fakeBuildEncoder(),
+		repairFillOptions{Split: ix.split})
+	require.ErrorContains(t, err, "injected repair queue cleanup failure")
+	_, err = ix.db.ExecContext(ctx, `DROP TRIGGER fail_repair_queue_cleanup`)
+	require.NoError(t, err)
+
+	var encoded []string
+	result, err := ix.Build(ctx, src, func(_ context.Context, texts []string) ([][]float32, error) {
+		encoded = append(encoded, texts...)
+		return fakeBuildEncoder()(ctx, texts)
+	}, gen, BuildOptions{RepairInvalid: true})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"saved"}, encoded)
+	assert.Equal(t, 1, result.Fill.Documents)
+
+	var queued int
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM message_vectors_repair_queue
+ WHERE ordinal = ? AND doc_key = 'u:s1:saved'`, ordinal).Scan(&queued))
+	assert.Zero(t, queued)
+}
+
+func TestBuildRepairInvalidIgnoresOrdinaryPendingContentChange(t *testing.T) {
+	ix := openTestIndex(t)
+	ix.split = kitvec.SplitOptions{MaxRunes: 5}
+	ctx := context.Background()
+	src := &fakeUnitSource{rows: []fakeUnit{
+		{unit: userDoc("s1", "changed", 0, "short"), endedAt: "2024-01-01T00:00:00Z"},
+	}}
+	gen := fakeGeneration("active-model")
+	require.NoError(t, buildWithoutResult(ix, ctx, src, gen))
+
+	src.rows[0] = fakeUnit{
+		unit:    userDoc("s1", "changed", 0, "abcdefghij"),
+		endedAt: "2024-01-01T00:00:01Z",
+	}
+	_, err := ix.Build(ctx, src, func(context.Context, []string) ([][]float32, error) {
+		return nil, errors.New("leave changed document pending")
+	}, gen, BuildOptions{})
+	require.ErrorContains(t, err, "leave changed document pending")
+
+	result, err := ix.Build(ctx, src, func(context.Context, []string) ([][]float32, error) {
+		t.Fatal("repair must not embed an ordinary pending content change")
+		return nil, nil
+	}, gen, BuildOptions{RepairInvalid: true})
+	require.NoError(t, err)
+	assert.Equal(t, RepairStats{
+		Scanned: true, ScanComplete: true, RemainingKnown: true,
+	}, result.Repair)
+	assert.Zero(t, result.Fill.Documents)
+}
+
+func TestBackstopRemovesRepairQueueEntryForDeletedDocument(t *testing.T) {
+	ix := openTestIndex(t)
+	ctx := context.Background()
+	src := &fakeUnitSource{rows: []fakeUnit{
+		{unit: userDoc("s1", "bad", 0, "bad"), endedAt: "2024-01-01T00:00:00Z"},
+		{unit: userDoc("s1", "good", 1, "good"), endedAt: "2024-01-01T00:00:01Z"},
+	}}
+	gen := fakeGeneration("active-model")
+	require.NoError(t, buildWithoutResult(ix, ctx, src, gen))
+	ordinal, err := ix.ordinalForFingerprint(ctx, gen.Fingerprint())
+	require.NoError(t, err)
+
+	var badRowID int64
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT vec_rowid FROM message_vectors_chunks
+ WHERE ordinal = ? AND doc_key = 'u:s1:bad'`, ordinal).Scan(&badRowID))
+	_, err = ix.db.ExecContext(ctx,
+		`UPDATE message_vectors_v`+fmtInt64(ordinal)+` SET embedding = ? WHERE rowid = ?`,
+		make([]byte, 3*4), badRowID)
+	require.NoError(t, err)
+
+	_, err = ix.Build(ctx, src, func(context.Context, []string) ([][]float32, error) {
+		return nil, errors.New("endpoint failed")
+	}, gen, BuildOptions{RepairInvalid: true})
+	require.ErrorContains(t, err, "endpoint failed")
+
+	var queued int
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM message_vectors_repair_queue
+ WHERE ordinal = ? AND doc_key = 'u:s1:bad'`, ordinal).Scan(&queued))
+	require.Equal(t, 1, queued)
+
+	src.rows = src.rows[1:]
+	_, err = ix.Build(ctx, src, fakeBuildEncoder(), gen, BuildOptions{Backstop: true})
+	require.NoError(t, err)
+
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM message_vectors_repair_queue
+ WHERE ordinal = ? AND doc_key = 'u:s1:bad'`, ordinal).Scan(&queued))
+	assert.Zero(t, queued, "deleting a mirror document must clear its repair target")
+}
+
+func TestRepairQueueDocumentCleanupUsesDocumentKeyIndex(t *testing.T) {
+	ix := openTestIndex(t)
+	ctx := context.Background()
+	rows, err := ix.db.QueryContext(ctx, `
+EXPLAIN QUERY PLAN
+DELETE FROM message_vectors_repair_queue WHERE doc_key = ?`, "u:s1:deleted")
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var details []string
+	for rows.Next() {
+		var id, parent, unused int
+		var detail string
+		require.NoError(t, rows.Scan(&id, &parent, &unused, &detail))
+		details = append(details, detail)
+	}
+	require.NoError(t, rows.Err())
+	assert.Contains(t, strings.Join(details, "\n"),
+		"message_vectors_repair_queue_doc_key",
+		"mirror cleanup must not scan the ordinal-first repair queue")
+}
+
+func TestOrdinaryRepairCompletionUsesQueuePrimaryKey(t *testing.T) {
+	ix := openTestIndex(t)
+	ctx := context.Background()
+	rows, err := ix.db.QueryContext(ctx, `
+EXPLAIN QUERY PLAN
+DELETE FROM message_vectors_repair_queue
+ WHERE doc_key = ?
+   AND ordinal = (
+       SELECT ordinal FROM message_vectors_generations WHERE gen_key = ?)`,
+		"u:s1:done", "fingerprint")
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var details []string
+	for rows.Next() {
+		var id, parent, unused int
+		var detail string
+		require.NoError(t, rows.Scan(&id, &parent, &unused, &detail))
+		details = append(details, detail)
+	}
+	require.NoError(t, rows.Err())
+	assert.Contains(t, strings.Join(details, "\n"),
+		"sqlite_autoindex_message_vectors_repair_queue_1",
+		"ordinary saves must add only one indexed queue lookup")
+}
+
+func float32Blob(values ...float32) []byte {
+	blob := make([]byte, 4*len(values))
+	for i, value := range values {
+		binary.LittleEndian.PutUint32(blob[i*4:], math.Float32bits(value))
+	}
+	return blob
+}
+
+func buildWithoutResult(
+	ix *Index, ctx context.Context, src UnitSource, gen kitvec.Generation,
+) error {
+	_, err := ix.Build(ctx, src, fakeBuildEncoder(), gen, BuildOptions{})
+	return err
+}
+
+func fmtInt64(value int64) string {
+	return strconv.FormatInt(value, 10)
+}

--- a/internal/vector/repair_test.go
+++ b/internal/vector/repair_test.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"net/http"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -202,6 +203,35 @@ SELECT COUNT(*) FROM message_vectors_chunks
 	assert.Zero(t, badChunks)
 	assert.Zero(t, badStamps)
 	assert.Equal(t, 1, goodChunks)
+}
+
+func TestScanInvalidRepairDocumentsAllocatesContentOncePerDocument(t *testing.T) {
+	ix := openTestIndex(t)
+	ix.split = kitvec.SplitOptions{MaxRunes: 1024}
+	ctx := context.Background()
+	content := strings.Repeat("x", 256*1024)
+	src := &fakeUnitSource{rows: []fakeUnit{
+		{unit: userDoc("s1", "large", 0, content), endedAt: "2024-01-01T00:00:00Z"},
+	}}
+	gen := fakeGeneration("active-model")
+	require.NoError(t, buildWithoutResult(ix, ctx, src, gen))
+	ordinal, err := ix.ordinalForFingerprint(ctx, gen.Fingerprint())
+	require.NoError(t, err)
+
+	runtime.GC()
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+	affected, err := ix.scanInvalidRepairDocuments(
+		ctx, ordinal, 3, fmt.Sprintf("%s_v%d", ix.spec.VectorsPrefix, ordinal),
+		[]string{"u:s1:large"},
+	)
+	runtime.ReadMemStats(&after)
+	require.NoError(t, err)
+	assert.Empty(t, affected)
+
+	allocated := after.TotalAlloc - before.TotalAlloc
+	assert.Less(t, allocated, uint64(len(content)*32),
+		"repair scan allocations must scale with document content, not content times chunk count")
 }
 
 func TestBuildRepairInvalidRejectsBackstop(t *testing.T) {

--- a/internal/vector/repair_test.go
+++ b/internal/vector/repair_test.go
@@ -499,6 +499,43 @@ func TestBuildRepairInvalidKeepsTargetAfterContextDeadline(t *testing.T) {
 	assertFailedRepairRemainsQueued(t, context.DeadlineExceeded)
 }
 
+func TestBuildRepairInvalidCountsRemainingTargetsAfterCancellationDuringFill(t *testing.T) {
+	ix := openTestIndex(t)
+	ctx := context.Background()
+	src := &fakeUnitSource{rows: []fakeUnit{
+		{unit: userDoc("s1", "bad", 0, "bad"), endedAt: "2024-01-01T00:00:00Z"},
+	}}
+	gen := fakeGeneration("active-model")
+	require.NoError(t, buildWithoutResult(ix, ctx, src, gen))
+	ordinal, err := ix.ordinalForFingerprint(ctx, gen.Fingerprint())
+	require.NoError(t, err)
+
+	var rowID int64
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT vec_rowid FROM message_vectors_chunks
+ WHERE ordinal = ? AND doc_key = 'u:s1:bad'`, ordinal).Scan(&rowID))
+	_, err = ix.db.ExecContext(ctx,
+		`UPDATE message_vectors_v`+fmtInt64(ordinal)+` SET embedding = ? WHERE rowid = ?`,
+		make([]byte, 3*4), rowID)
+	require.NoError(t, err)
+
+	buildCtx, cancel := context.WithCancel(ctx)
+	result, err := ix.Build(buildCtx, src, func(ctx context.Context, _ []string) ([][]float32, error) {
+		cancel()
+		return nil, ctx.Err()
+	}, gen, BuildOptions{RepairInvalid: true})
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, result.Repair.Failed)
+	assert.Equal(t, 1, result.Repair.Remaining)
+	assert.True(t, result.Repair.RemainingKnown)
+
+	var queued int
+	require.NoError(t, ix.db.QueryRowContext(ctx, `
+SELECT COUNT(*) FROM message_vectors_repair_queue
+ WHERE ordinal = ? AND doc_key = 'u:s1:bad'`, ordinal).Scan(&queued))
+	assert.Equal(t, 1, queued, "the canceled fill must leave its durable target queued")
+}
+
 func assertFailedRepairRemainsQueued(t *testing.T, encodeErr error) {
 	t.Helper()
 	ix := openTestIndex(t)
@@ -747,7 +784,7 @@ SELECT COUNT(*) FROM message_vectors_repair_queue WHERE ordinal = ?`, ordinal).S
 	assert.Zero(t, queued)
 }
 
-func TestRepairRemainingAfterScanErrorIgnoresCanceledBuildContext(t *testing.T) {
+func TestRepairRemainingIgnoresCanceledBuildContext(t *testing.T) {
 	ix := openTestIndex(t)
 	ctx := context.Background()
 	gen := fakeGeneration("active-model")
@@ -765,20 +802,20 @@ VALUES (?, 'u:s1:u1')`, ordinal)
 		base: ix.store, db: ix.db, spec: ix.spec, fingerprint: gen.Fingerprint(),
 		ordinal: ordinal, queueTable: ix.spec.repairQueueTable(), split: ix.split,
 	}
-	remaining, known, err := repairRemainingAfterScanError(canceled, store, 7)
+	remaining, known, err := repairRemaining(canceled, store, 7)
 	require.NoError(t, err)
 	assert.True(t, known)
 	assert.Equal(t, 1, remaining,
 		"the recount must survive cancellation instead of reporting zero or only the fallback")
 }
 
-func TestRepairRemainingAfterScanErrorReturnsFallbackWhenRecountFails(t *testing.T) {
-	raw, err := sql.Open("sqlite3", filepath.Join(t.TempDir(), "closed.db"))
+func TestRepairRemainingReturnsFallbackWhenRecountFails(t *testing.T) {
+	raw, err := sql.Open(vectorDriverName, vectorDSN(filepath.Join(t.TempDir(), "closed.db"), false))
 	require.NoError(t, err)
 	require.NoError(t, raw.Close())
 	store := &repairStore{db: raw, ordinal: 1, queueTable: "repair_queue"}
 
-	remaining, known, err := repairRemainingAfterScanError(context.Background(), store, 7)
+	remaining, known, err := repairRemaining(context.Background(), store, 7)
 	require.Error(t, err)
 	assert.Equal(t, 7, remaining)
 	assert.False(t, known)


### PR DESCRIPTION
Embedding providers can return dimensionally valid data that is still unusable for cosine search. AgentsView now rejects null components, non-finite values, and zero-norm vectors at the endpoint and persistence boundaries so faulty output is never stamped as complete.

Add an explicit embeddings build --repair-invalid recovery mode that scans one existing generation, durably queues only affected document keys, and resumes them after endpoint failures or cancellation. Repair status preserves exact remaining work when possible, repair scans keep document-content allocation bounded by the scanned batch, and failed targets remain available for later retries.

Repair runs on an isolated path: it does not refresh or expand the mirror, create or reset generations, change generation state, or fill unrelated missing work. Full rebuild and backstop modes remain mutually exclusive with repair.

Daemon compatibility now covers the expanded repair status contract. Embeddings commands resolve only the writable daemon and report restart guidance when an older writable daemon is still running, including when a compatible read-only server is also available.

Document standard Ollama configuration and the cache constraints required when using a direct multi-slot llama-server endpoint.