### PR TITLE
Assign distinct colors across active attribution series

### DIFF
--- a/frontend/src/lib/components/usage/AttributionPanel.svelte
+++ b/frontend/src/lib/components/usage/AttributionPanel.svelte
@@ -4,7 +4,7 @@
     type GroupBy,
     type AttributionView,
   } from "../../stores/usage.svelte.js";
-  import { projectColor } from "../../utils/projectColor.js";
+  import { seriesColorMap } from "../../utils/projectColor.js";
   import Treemap from "./Treemap.svelte";
   import { m } from "../../i18n/index.js";
 
@@ -29,7 +29,7 @@
     pct: number;
   }
 
-  const rows = $derived.by((): Row[] => {
+  const rowItems = $derived.by(() => {
     const s = usage.summary;
     if (!s) return [];
 
@@ -60,13 +60,22 @@
     }
 
     items.sort((a, b) => b.cost - a.cost);
+    return items;
+  });
+
+  const colorMap = $derived(
+    seriesColorMap(rowItems.map((item) => item.id).sort()),
+  );
+
+  const rows = $derived.by((): Row[] => {
+    const items = rowItems;
     const total = items.reduce((s, d) => s + d.cost, 0);
 
     return items.map((d) => ({
       id: d.id,
       label: d.label,
       cost: d.cost,
-      color: projectColor(d.id),
+      color: colorMap.get(d.id) ?? "var(--text-muted)",
       pct: total > 0 ? d.cost / total : 0,
     }));
   });

--- a/frontend/src/lib/components/usage/AttributionPanel.test.ts
+++ b/frontend/src/lib/components/usage/AttributionPanel.test.ts
@@ -199,4 +199,23 @@ describe("AttributionPanel colors", () => {
     expect(new Set(colors).size).toBe(2);
     unmount(component);
   });
+
+  it("routes distinct model colors through the treemap and rail", async () => {
+    usage.summary = summaryWithModels();
+    usage.toggles.attribution.groupBy = "model";
+    usage.toggles.attribution.view = "treemap";
+
+    const component = mount(AttributionPanel, { target: document.body });
+    await tick();
+
+    const tileColors = Array.from(
+      document.querySelectorAll<SVGRectElement>(".tile rect"),
+    ).map((tile) => tile.getAttribute("fill"));
+    const railColors = Array.from(
+      document.querySelectorAll<HTMLElement>(".rail-dot"),
+    ).map((dot) => dot.style.background);
+    expect(new Set(tileColors).size).toBe(2);
+    expect(railColors).toEqual(tileColors);
+    unmount(component);
+  });
 });

--- a/frontend/src/lib/components/usage/AttributionPanel.test.ts
+++ b/frontend/src/lib/components/usage/AttributionPanel.test.ts
@@ -81,6 +81,29 @@ function summaryWithDuplicateProjectLabels(): UsageSummaryResponse {
   return summary;
 }
 
+function summaryWithModels(): UsageSummaryResponse {
+  const summary = summaryWithAgents([]);
+  summary.modelTotals = [
+    {
+      model: "claude-sonnet-5",
+      inputTokens: 60,
+      outputTokens: 30,
+      cacheCreationTokens: 0,
+      cacheReadTokens: 0,
+      cost: 8,
+    },
+    {
+      model: "claude-opus-4-8",
+      inputTokens: 40,
+      outputTokens: 20,
+      cacheCreationTokens: 0,
+      cacheReadTokens: 0,
+      cost: 4,
+    },
+  ];
+  return summary;
+}
+
 describe("AttributionPanel agent exclusion", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -150,6 +173,30 @@ describe("AttributionPanel project identity", () => {
         }),
       ),
     );
+    unmount(component);
+  });
+});
+
+describe("AttributionPanel colors", () => {
+  afterEach(() => {
+    usage.summary = null;
+    usage.toggles.attribution.groupBy = "project";
+    usage.toggles.attribution.view = "list";
+    document.body.innerHTML = "";
+  });
+
+  it("keeps colliding model rows distinct", async () => {
+    usage.summary = summaryWithModels();
+    usage.toggles.attribution.groupBy = "model";
+    usage.toggles.attribution.view = "list";
+
+    const component = mount(AttributionPanel, { target: document.body });
+    await tick();
+
+    const colors = Array.from(
+      document.querySelectorAll<HTMLElement>(".list-dot"),
+    ).map((dot) => dot.getAttribute("style"));
+    expect(new Set(colors).size).toBe(2);
     unmount(component);
   });
 });

--- a/frontend/src/lib/components/usage/CostTimeSeriesChart.svelte
+++ b/frontend/src/lib/components/usage/CostTimeSeriesChart.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { usage, type GroupBy } from "../../stores/usage.svelte.js";
-  import { projectColor } from "../../utils/projectColor.js";
+  import { seriesColorMap } from "../../utils/projectColor.js";
   import { m } from "../../i18n/index.js";
 
   const CHART_H = 180;
@@ -143,6 +143,12 @@
     return { points, keys, maxY: maxY || 1, labels };
   });
 
+  const colorMap = $derived(
+    seriesColorMap(
+      seriesData.keys.filter((key) => key !== "__other__").sort(),
+    ),
+  );
+
   const chartWidth = $derived(
     Math.max(containerWidth - Y_LABEL_W - X_LABEL_RIGHT_PAD, 100),
   );
@@ -194,6 +200,7 @@
     maxY: number,
     w: number,
     h: number,
+    colors: ReadonlyMap<string, string>,
   ): Array<{ key: string; d: string; color: string }> {
     if (points.length === 0) return [];
 
@@ -219,7 +226,7 @@
           `L${x0 + BAR_WIDTH},${bot}Z`;
         const color = key === "__other__"
           ? "var(--text-muted)"
-          : projectColor(key);
+          : colors.get(key) ?? "var(--text-muted)";
         result.push({ key, d, color });
         baseline += val;
       }
@@ -255,7 +262,7 @@
 
       const color = key === "__other__"
         ? "var(--text-muted)"
-        : projectColor(key);
+        : colors.get(key) ?? "var(--text-muted)";
       result.push({ key, d, color });
 
       for (let i = 0; i < points.length; i++) {
@@ -273,6 +280,7 @@
       scale.max,
       chartWidth,
       CHART_H,
+      colorMap,
     ),
   );
 
@@ -419,7 +427,7 @@
           <span class="legend-item">
             <span
               class="legend-dot"
-              style="background: {key === '__other__' ? 'var(--text-muted)' : projectColor(key)}"
+              style="background: {colorMap.get(key) ?? 'var(--text-muted)'}"
             ></span>
 			{key === "__other__" ? m.shared_other() : (seriesData.labels[key] ?? key)}
           </span>

--- a/frontend/src/lib/components/usage/CostTimeSeriesChart.test.ts
+++ b/frontend/src/lib/components/usage/CostTimeSeriesChart.test.ts
@@ -14,6 +14,7 @@ import type {
   DailyUsageEntry,
   UsageSummaryResponse,
 } from "../../api/types/usage.js";
+import { projectColor } from "../../utils/projectColor.js";
 
 const OBSERVED_WIDTH = 1648;
 
@@ -118,6 +119,23 @@ function usageSummary(): UsageSummaryResponse {
   };
 }
 
+function modelDailyEntry(
+  index: number,
+  models: Array<{ modelName: string; cost: number }>,
+): DailyUsageEntry {
+  const entry = dailyEntry(index);
+  entry.projectBreakdowns = undefined;
+  entry.modelBreakdowns = models.map(({ modelName, cost }) => ({
+    modelName,
+    inputTokens: 60,
+    outputTokens: 30,
+    cacheCreationTokens: 0,
+    cacheReadTokens: 0,
+    cost,
+  }));
+  return entry;
+}
+
 describe("CostTimeSeriesChart", () => {
   beforeEach(() => {
     globalThis.ResizeObserver =
@@ -180,28 +198,14 @@ describe("CostTimeSeriesChart", () => {
     usage.summary = usageSummary();
     usage.toggles.timeSeries.groupBy = "model";
     usage.summary.daily = [
-      {
-        ...usage.summary.daily[0]!,
-        projectBreakdowns: undefined,
-        modelBreakdowns: [
-          {
-            modelName: "claude-sonnet-5",
-            inputTokens: 60,
-            outputTokens: 30,
-            cacheCreationTokens: 0,
-            cacheReadTokens: 0,
-            cost: 6,
-          },
-          {
-            modelName: "claude-opus-4-8",
-            inputTokens: 40,
-            outputTokens: 20,
-            cacheCreationTokens: 0,
-            cacheReadTokens: 0,
-            cost: 4,
-          },
-        ],
-      },
+      modelDailyEntry(0, [
+        { modelName: "claude-sonnet-5", cost: 6 },
+        { modelName: "claude-opus-4-8", cost: 4 },
+      ]),
+      modelDailyEntry(1, [
+        { modelName: "claude-sonnet-5", cost: 3 },
+        { modelName: "claude-opus-4-8", cost: 2 },
+      ]),
     ];
 
     const component = mount(CostTimeSeriesChart, { target: document.body });
@@ -210,11 +214,60 @@ describe("CostTimeSeriesChart", () => {
     const paths = Array.from(
       document.querySelectorAll<SVGPathElement>("path[opacity='0.7']"),
     ).map((path) => path.getAttribute("fill"));
+    const pathData = Array.from(
+      document.querySelectorAll<SVGPathElement>("path[opacity='0.7']"),
+    ).map((path) => path.getAttribute("d"));
     const dots = Array.from(
       document.querySelectorAll<HTMLElement>(".legend-dot"),
     ).map((dot) => dot.style.background);
     expect(new Set(paths).size).toBe(2);
+    expect(pathData.every((d) => d?.startsWith("M40,"))).toBe(true);
     expect(dots).toEqual(paths);
+    unmount(component);
+  });
+
+  it("keeps a single rendered model series on its established color", async () => {
+    usage.summary = usageSummary();
+    usage.toggles.timeSeries.groupBy = "model";
+    usage.summary.daily = [
+      modelDailyEntry(0, [{ modelName: "single-model", cost: 6 }]),
+      modelDailyEntry(1, [{ modelName: "single-model", cost: 3 }]),
+    ];
+
+    const component = mount(CostTimeSeriesChart, { target: document.body });
+    await tick();
+
+    const paths = document.querySelectorAll<SVGPathElement>(
+      "path[opacity='0.7']",
+    );
+    expect(paths).toHaveLength(1);
+    expect(paths[0]!.getAttribute("fill")).toBe(projectColor("single-model"));
+    expect(document.querySelectorAll(".legend-item")).toHaveLength(0);
+    unmount(component);
+  });
+
+  it("keeps rendered other-series output muted", async () => {
+    usage.summary = usageSummary();
+    usage.toggles.timeSeries.groupBy = "model";
+    const models = Array.from({ length: 6 }, (_, index) => ({
+      modelName: `model-${index}`,
+      cost: 6 - index,
+    }));
+    usage.summary.daily = [modelDailyEntry(0, models)];
+
+    const component = mount(CostTimeSeriesChart, { target: document.body });
+    await tick();
+
+    const paths = Array.from(
+      document.querySelectorAll<SVGPathElement>("path[opacity='0.7']"),
+    );
+    const dots = Array.from(
+      document.querySelectorAll<HTMLElement>(".legend-dot"),
+    );
+    expect(paths).toHaveLength(6);
+    expect(dots).toHaveLength(6);
+    expect(paths.at(-1)!.getAttribute("fill")).toBe("var(--text-muted)");
+    expect(dots.at(-1)!.style.background).toBe("var(--text-muted)");
     unmount(component);
   });
 });

--- a/frontend/src/lib/components/usage/CostTimeSeriesChart.test.ts
+++ b/frontend/src/lib/components/usage/CostTimeSeriesChart.test.ts
@@ -175,4 +175,46 @@ describe("CostTimeSeriesChart", () => {
 	expect(document.querySelectorAll(".legend-item")).toHaveLength(2);
 	unmount(component);
   });
+
+  it("uses distinct active model colors for paths and legend dots", async () => {
+    usage.summary = usageSummary();
+    usage.toggles.timeSeries.groupBy = "model";
+    usage.summary.daily = [
+      {
+        ...usage.summary.daily[0]!,
+        projectBreakdowns: undefined,
+        modelBreakdowns: [
+          {
+            modelName: "claude-sonnet-5",
+            inputTokens: 60,
+            outputTokens: 30,
+            cacheCreationTokens: 0,
+            cacheReadTokens: 0,
+            cost: 6,
+          },
+          {
+            modelName: "claude-opus-4-8",
+            inputTokens: 40,
+            outputTokens: 20,
+            cacheCreationTokens: 0,
+            cacheReadTokens: 0,
+            cost: 4,
+          },
+        ],
+      },
+    ];
+
+    const component = mount(CostTimeSeriesChart, { target: document.body });
+    await tick();
+
+    const paths = Array.from(
+      document.querySelectorAll<SVGPathElement>("path[opacity='0.7']"),
+    ).map((path) => path.getAttribute("fill"));
+    const dots = Array.from(
+      document.querySelectorAll<HTMLElement>(".legend-dot"),
+    ).map((dot) => dot.style.background);
+    expect(new Set(paths).size).toBe(2);
+    expect(dots).toEqual(paths);
+    unmount(component);
+  });
 });

--- a/frontend/src/lib/utils/projectColor.test.ts
+++ b/frontend/src/lib/utils/projectColor.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vite-plus/test";
-import { projectColor, PROJECT_PALETTE } from "./projectColor.js";
+import {
+  projectColor,
+  PROJECT_PALETTE,
+  seriesColorMap,
+} from "./projectColor.js";
 
 describe("projectColor", () => {
   it("returns a palette color for any non-empty string", () => {
@@ -22,5 +26,40 @@ describe("projectColor", () => {
     ];
     const seen = new Set(names.map(projectColor));
     expect(seen.size).toBeGreaterThanOrEqual(6);
+  });
+
+  it("resolves the reported model collision", () => {
+    const ids = ["claude-sonnet-5", "claude-opus-4-8"];
+    expect(projectColor(ids[0]!)).toBe(projectColor(ids[1]!));
+    expect(seriesColorMap(ids).get(ids[0]!)).not.toBe(
+      seriesColorMap(ids).get(ids[1]!),
+    );
+  });
+
+  it("is stable across permutations and duplicates", () => {
+    const ids = ["claude-sonnet-5", "claude-opus-4-8", "claude-sonnet-5"];
+    expect([...seriesColorMap(ids)]).toEqual([
+      ...seriesColorMap([...ids].reverse()),
+    ]);
+  });
+
+  it("keeps empty and other identifiers muted", () => {
+    const colors = seriesColorMap(["", "__other__"]);
+    expect(colors.get("")).toBe("var(--text-muted)");
+    expect(colors.get("__other__")).toBe("var(--text-muted)");
+  });
+
+  it("uses every palette slot before deterministic overflow", () => {
+    const ids = Array.from({ length: PROJECT_PALETTE.length }, (_, i) => `id-${i}`);
+    const atCapacity = seriesColorMap(ids);
+    expect(new Set(ids.map((id) => atCapacity.get(id))).size).toBe(
+      PROJECT_PALETTE.length,
+    );
+
+    const overflowIds = [...ids, "id-overflow"];
+    const overflow = seriesColorMap(overflowIds);
+    const repeat = seriesColorMap([...overflowIds].reverse());
+    expect(overflow).toEqual(repeat);
+    expect(PROJECT_PALETTE).toContain(overflow.get("id-overflow"));
   });
 });

--- a/frontend/src/lib/utils/projectColor.ts
+++ b/frontend/src/lib/utils/projectColor.ts
@@ -22,3 +22,35 @@ export const PROJECT_PALETTE: readonly string[] = [
 export function projectColor(name: string): string {
   return hashColor(name, PROJECT_PALETTE);
 }
+
+export function seriesColorMap(
+  ids: readonly string[],
+): ReadonlyMap<string, string> {
+  const colors = new Map<string, string>();
+  const occupied = new Set<number>();
+  const uniqueIds = [...new Set(ids)]
+    .filter((id) => id !== "" && id !== "__other__")
+    .sort();
+
+  for (const id of uniqueIds) {
+    const preferred = PROJECT_PALETTE.indexOf(projectColor(id));
+    if (preferred < 0) continue;
+
+    let slot = preferred;
+    for (let offset = 0; offset < PROJECT_PALETTE.length; offset++) {
+      const candidate = (preferred + offset) % PROJECT_PALETTE.length;
+      if (!occupied.has(candidate)) {
+        slot = candidate;
+        occupied.add(candidate);
+        break;
+      }
+    }
+    colors.set(id, PROJECT_PALETTE[slot]!);
+  }
+
+  for (const id of ids) {
+    if (id === "" || id === "__other__") colors.set(id, "var(--text-muted)");
+  }
+
+  return colors;
+}


### PR DESCRIPTION
Usage attribution could assign the same palette token to multiple active model series because each chart element hashed its identifier independently. Colliding regions and legend entries then became visually indistinguishable even though the underlying attribution data was separate.

Color selection now happens once for the active identifier set. The shared frontend allocator keeps the existing palette and hash preference, resolves occupied slots deterministically while palette capacity remains, and defines stable overflow behavior. Attribution rows, treemap items, time-series paths, and legend dots consume the same assignment map, so chart and legend colors cannot drift.

Grouping, ranking, cost calculations, exclusions, and the muted “Other” series are unchanged. The reported collision pair and screenshots came from @mslynch's [issue report](https://github.com/kenn-io/agentsview/issues/1126).

Fixes #1126
