### PR TITLE
Fix project selector crash on empty project names

### DIFF
--- a/frontend/src/lib/components/layout/ProjectTypeahead.svelte
+++ b/frontend/src/lib/components/layout/ProjectTypeahead.svelte
@@ -19,12 +19,15 @@
   };
 
   const options = $derived.by(() => {
-    const items = projects.map((p) => ({
-      name: p.name,
-      label: `${p.name} (${p.session_count})`,
-      displayLabel: p.name,
-      count: p.session_count,
-    }));
+    // An empty-name project would duplicate the all-projects key, and "" already means unfiltered.
+    const items = projects
+      .filter((p) => p.name !== "")
+      .map((p) => ({
+        name: p.name,
+        label: `${p.name} (${p.session_count})`,
+        displayLabel: p.name,
+        count: p.session_count,
+      }));
     return [allOption, ...items];
   });
 

--- a/frontend/src/lib/components/layout/ProjectTypeahead.test.ts
+++ b/frontend/src/lib/components/layout/ProjectTypeahead.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import { fireEvent, screen } from "@testing-library/svelte";
+import { mount, unmount } from "svelte";
+import type { ProjectInfo } from "../../api/types/core.js";
+import { m } from "../../i18n/index.js";
+import ProjectTypeahead from "./ProjectTypeahead.svelte";
+
+const projects: ProjectInfo[] = [
+  { name: "", session_count: 53 },
+  { name: "repo-a", session_count: 2 },
+];
+
+describe("ProjectTypeahead", () => {
+  let component: Record<string, unknown> | null = null;
+
+  afterEach(() => {
+    if (component) {
+      unmount(component);
+      component = null;
+    }
+    document.body.innerHTML = "";
+  });
+
+  it("opens without crashing when a project has an empty name", async () => {
+    const onselect = vi.fn();
+    component = mount(ProjectTypeahead, {
+      target: document.body,
+      props: { projects, value: "", onselect },
+    });
+
+    await fireEvent.click(screen.getByRole("button"));
+
+    // The omitted empty-name row cannot round-trip through the "" = all-projects contract.
+    const options = screen.getAllByRole("option");
+    expect(options.map((option) => option.textContent?.trim())).toEqual([
+      m.shared_all_projects(),
+      "repo-a (2)",
+    ]);
+
+    await fireEvent.mouseDown(options[0]!);
+    expect(onselect).toHaveBeenLastCalledWith("");
+
+    await fireEvent.click(screen.getByRole("button"));
+    await fireEvent.mouseDown(screen.getAllByRole("option")[1]!);
+    expect(onselect).toHaveBeenLastCalledWith("repo-a");
+  });
+
+  it("keeps a nonempty external value selected", async () => {
+    component = mount(ProjectTypeahead, {
+      target: document.body,
+      props: { projects, value: "repo-a", onselect: vi.fn() },
+    });
+
+    await fireEvent.click(screen.getByRole("button"));
+
+    expect(screen.getByRole("option", { name: "repo-a (2)" }).getAttribute("aria-selected")).toBe(
+      "true",
+    );
+    expect(
+      screen.getByRole("option", { name: m.shared_all_projects() }).getAttribute("aria-selected"),
+    ).toBe("false");
+  });
+});


### PR DESCRIPTION
Opening the header project selector crashed with Svelte's `each_key_duplicate` when the database contained a project with an empty name (e.g. Antigravity CLI summary-mode sessions): kit-ui's Typeahead keys options on `option.name`, and the empty-name project collided with the built-in All projects option, which also uses `""`.

Omit empty-name projects from the option list. A row for them was never functional because `""` already means the unfiltered state in the app-wide filter contract, and their sessions stay reachable under All projects. Named projects and the selection contract are unchanged.

Fixes #1123.