### PR TITLE
fix(parser): classify queued system prompts before single-turn counting (#1131)

### DIFF
--- a/frontend/src/lib/utils/messages.test.ts
+++ b/frontend/src/lib/utils/messages.test.ts
@@ -81,6 +81,54 @@ describe("isSystemMessage", () => {
     ).toBe(false);
   });
 
+  it("does not match a prefix-adjacent task notification", () => {
+    expect(
+      isSystemMessage(msg({ content: "<task-notification-status>ready" })),
+    ).toBe(false);
+  });
+
+  it("hides reminder-only fallback content", () => {
+    expect(
+      isSystemMessage(
+        msg({ content: "<system-reminder>remember this</system-reminder>" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps reminder-prefixed real prompts visible", () => {
+    expect(
+      isSystemMessage(
+        msg({
+          content:
+            "<system-reminder>remember this</system-reminder>\n\nreal prompt",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it.each([
+    "<system-reminder>a</system-reminder><task-notification>done</task-notification>",
+    "<system-reminder>a</system-reminder><system-reminder>b</system-reminder>",
+    '<system-reminder>a</system-reminder><goal_context>state</goal_context>',
+  ])("classifies the terminal remainder: %s", (content) => {
+    expect(isSystemMessage(msg({ content }))).toBe(true);
+  });
+
+  it.each([
+    "<system-reminder>a</system-reminder>real prompt",
+    "<system-reminder>a",
+  ])("keeps non-classified reminder content visible: %s", (content) => {
+    expect(isSystemMessage(msg({ content }))).toBe(false);
+  });
+
+  it("hides system reminders without making them visible cards", () => {
+    expect(
+      isSystemMessage(
+        msg({ is_system: true, source_subtype: "system_reminder" }),
+      ),
+    ).toBe(true);
+  });
+
   it.each([
     [
       "non-goal internal context",

--- a/frontend/src/lib/utils/messages.ts
+++ b/frontend/src/lib/utils/messages.ts
@@ -10,6 +10,9 @@ const SYSTEM_MSG_PREFIXES = [
   "Stop hook feedback:",
 ];
 
+const SYSTEM_REMINDER_OPEN_TAG = "<system-reminder>";
+const SYSTEM_REMINDER_CLOSE_TAG = "</system-reminder>";
+
 const LEGACY_GOAL_CONTEXT_PREFIX = "<goal_context>";
 const CODEX_INTERNAL_CONTEXT_TAG_PREFIX = "<codex_internal_context";
 const GOAL_CONTEXT_SOURCE_ATTR_RE = /(?:^|\s)source="goal"(?:\s|\/|$)/;
@@ -42,11 +45,31 @@ export function isSystemMessage(m: Message): boolean {
   }
   if (m.is_system) return true;
   if (m.role !== "user") return false;
-  const trimmed = m.content.trim();
+  const { remainder, stripped } = stripLeadingReminderBlocks(m.content);
+  if (stripped && remainder.length === 0) return true;
+  const trimmed = stripped ? remainder : m.content.trim();
   return (
     isGoalContextMessage(trimmed) ||
     SYSTEM_MSG_PREFIXES.some((p) => trimmed.startsWith(p))
   );
+}
+
+function stripLeadingReminderBlocks(content: string): {
+  remainder: string;
+  stripped: boolean;
+} {
+  const original = content.trimStart();
+  let rest = original;
+  let stripped = false;
+  while (rest.startsWith(SYSTEM_REMINDER_OPEN_TAG)) {
+    const closeIdx = rest.indexOf(SYSTEM_REMINDER_CLOSE_TAG);
+    if (closeIdx < 0) return { remainder: original, stripped: false };
+    rest = rest
+      .slice(closeIdx + SYSTEM_REMINDER_CLOSE_TAG.length)
+      .trimStart();
+    stripped = true;
+  }
+  return { remainder: rest, stripped };
 }
 
 function isGoalContextMessage(trimmedContent: string): boolean {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -299,7 +299,11 @@ const projectIdentityRemoteScrubCompletedKey = "project_identity_remote_scrub_v1
 // (62: Local session machine identity now uses the operating-system hostname
 // instead of the ambiguous literal "local". Re-parsing updates existing
 // source-backed rows while the resync archive copy preserves orphaned history.)
-const dataVersion = 63
+// (65: Claude leading system-reminder blocks are stripped from mixed
+// user prompts before persistence, while reminder-only content still
+// promotes to system_reminder. Existing rows need re-parsing so reminder
+// metadata stops hiding real prompts and inflating reminder-only storage.)
+const dataVersion = 65
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -930,6 +930,10 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 		"expected tool_result_events table after reopen")
 }
 
+func TestCurrentDataVersionQueuedSystemMessages(t *testing.T) {
+	assert.Equal(t, 65, CurrentDataVersion(),
+		"queued system message parser changes require a data version bump")
+}
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {
 	d := testDB(t)
 	insertSession(t, d, "s-events", "proj")

--- a/internal/db/search.go
+++ b/internal/db/search.go
@@ -31,6 +31,11 @@ var SystemMsgPrefixes = []string{
 }
 
 const (
+	systemReminderOpenTag  = "<system-reminder>"
+	systemReminderCloseTag = "</system-reminder>"
+)
+
+const (
 	legacyGoalContextPrefix        = "<goal_context>"
 	codexInternalContextTagPrefix  = "<codex_internal_context"
 	goalContextSourceAttr          = `source="goal"`
@@ -100,6 +105,7 @@ func systemPrefixSQL(
 			"substr(%s, 1, %d) = '%s'", trimmed, len(p), p,
 		))
 	}
+	parts = append(parts, systemReminderTerminalSQL(trimmed, dialect))
 	parts = append(parts, goalContextPrefixSQL(trimmed, dialect))
 	guard := ""
 	if dialect == systemPrefixSQLite {
@@ -150,6 +156,46 @@ func systemPrefixSQLTrimmed(contentCol string) string {
 		"\u0085\u00A0\u1680" +
 		"\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A" +
 		"\u2028\u2029\u202F\u205F\u3000\uFEFF')"
+}
+
+func systemReminderTerminalSQL(
+	trimmed string, dialect systemPrefixSQLDialect,
+) string {
+	closePos := sqlPosition(dialect, systemReminderCloseTag, "rest")
+	next := systemPrefixSQLTrimmed(fmt.Sprintf(
+		"substr(rest, (%s) + %d)", closePos, len(systemReminderCloseTag),
+	))
+	terminal := fmt.Sprintf(
+		"(substr(rest, 1, %d) <> '%s' OR %s = 0)",
+		len(systemReminderOpenTag), systemReminderOpenTag, closePos,
+	)
+	classification := terminalRemainderSQL("rest", dialect)
+	seedReminder := fmt.Sprintf(
+		"substr(%s, 1, %d) = '%s'",
+		trimmed, len(systemReminderOpenTag), systemReminderOpenTag,
+	)
+	return fmt.Sprintf(`(%s AND EXISTS (WITH RECURSIVE reminder_remainder(rest) AS (
+SELECT %s
+UNION ALL
+SELECT %s FROM reminder_remainder
+WHERE substr(rest, 1, %d) = '%s' AND %s > 0
+)
+SELECT 1 FROM reminder_remainder
+WHERE %s AND (rest = '' OR %s)
+LIMIT 1))`, seedReminder, trimmed, next,
+		len(systemReminderOpenTag), systemReminderOpenTag, closePos,
+		terminal, classification)
+}
+
+func terminalRemainderSQL(content string, dialect systemPrefixSQLDialect) string {
+	parts := make([]string, 0, len(SystemMsgPrefixes)+1)
+	for _, p := range SystemMsgPrefixes {
+		parts = append(parts, fmt.Sprintf(
+			"substr(%s, 1, %d) = '%s'", content, len(p), p,
+		))
+	}
+	parts = append(parts, goalContextPrefixSQL(content, dialect))
+	return strings.Join(parts, " OR ")
 }
 
 func goalContextPrefixSQL(trimmed string, dialect systemPrefixSQLDialect) string {
@@ -217,16 +263,40 @@ func IsSystemPrefixed(content, role string) bool {
 	if role != "user" {
 		return false
 	}
-	if IsGoalContextPrefixed(content, role) {
+	trimmed := strings.TrimLeft(content, systemPrefixTrimCutset)
+	remainder, stripped := stripLeadingSystemReminderBlocks(trimmed)
+	if stripped {
+		if remainder == "" {
+			return true
+		}
+		trimmed = remainder
+	}
+	if IsGoalContextPrefixed(trimmed, role) {
 		return true
 	}
-	trimmed := strings.TrimLeft(content, systemPrefixTrimCutset)
 	for _, p := range SystemMsgPrefixes {
 		if strings.HasPrefix(trimmed, p) {
 			return true
 		}
 	}
 	return false
+}
+
+func stripLeadingSystemReminderBlocks(content string) (string, bool) {
+	rest := strings.TrimLeft(content, systemPrefixTrimCutset)
+	stripped := false
+	for strings.HasPrefix(rest, systemReminderOpenTag) {
+		closeIdx := strings.Index(rest, systemReminderCloseTag)
+		if closeIdx < 0 {
+			return "", false
+		}
+		rest = strings.TrimLeft(
+			rest[closeIdx+len(systemReminderCloseTag):],
+			systemPrefixTrimCutset,
+		)
+		stripped = true
+	}
+	return rest, stripped
 }
 
 // SearchResult holds a session-level match with the best-ranked snippet.

--- a/internal/db/search_test.go
+++ b/internal/db/search_test.go
@@ -20,6 +20,12 @@ func TestIsSystemPrefixed(t *testing.T) {
 		{"plain user message", "fix the build", "user", false},
 		{"continued-session prefix", SystemMsgPrefixes[0] + " from a prior run", "user", true},
 		{"task-notification prefix", "<task-notification>done</task-notification>", "user", true},
+		{"system-reminder only", "<system-reminder>remember</system-reminder>", "user", true},
+		{"consecutive reminders only", "<system-reminder>a</system-reminder><system-reminder>b</system-reminder>", "user", true},
+		{"reminder then task notification", "<system-reminder>remember</system-reminder><task-notification>done</task-notification>", "user", true},
+		{"reminder then goal context", "<system-reminder>remember</system-reminder><goal_context>state</goal_context>", "user", true},
+		{"system-reminder plus prompt", "<system-reminder>remember</system-reminder>\n\nreal prompt", "user", false},
+		{"malformed reminder stays user content", "<system-reminder>remember", "user", false},
 		{"leading whitespace then prefix", "\n\t  <command-name>/foo", "user", true},
 		{"bom then prefix", "\uFEFF<command-message>x", "user", true},
 		{"legacy goal context prefix", "\n\t<goal_context>state</goal_context>", "user", true},
@@ -37,6 +43,7 @@ func TestIsSystemPrefixed(t *testing.T) {
 			assert.Equal(t, tc.want, IsSystemPrefixed(tc.content, tc.role))
 		})
 	}
+	assert.NotContains(t, SystemMsgPrefixes, "<task-notification-status>")
 }
 
 func TestIsGoalContextPrefixed(t *testing.T) {
@@ -68,6 +75,11 @@ func TestIsGoalContextPrefixed(t *testing.T) {
 }
 
 func TestSystemPrefixSQL(t *testing.T) {
+	postgresSQL := PostgresSystemPrefixSQL("content", "role")
+	assert.Contains(t, postgresSQL, "POSITION('</system-reminder>' IN")
+	assert.Contains(t, postgresSQL, "WITH RECURSIVE reminder_remainder")
+	assert.NotContains(t, postgresSQL, "instr(")
+
 	d := testDB(t)
 	rows, err := d.getReader().QueryContext(context.Background(), `
 		WITH candidates(label, role, content) AS (
@@ -83,7 +95,16 @@ source="goal">state'),
 				('self-closing-goal', 'user', '<codex_internal_context source="goal"/>state'),
 				('non-goal-internal', 'user', '<codex_internal_context source="other">state'),
 				('data-source', 'user', '<codex_internal_context data-source="goal">state'),
-				('missing-close', 'user', '<codex_internal_context source="goal" state')
+				('missing-close', 'user', '<codex_internal_context source="goal" state'),
+				('reminder-only', 'user', '<system-reminder>remember</system-reminder>'),
+				('reminder-plus-prompt', 'user', '<system-reminder>remember</system-reminder>
+
+real prompt'),
+				('reminder-reminder-only', 'user', '<system-reminder>a</system-reminder><system-reminder>b</system-reminder>'),
+				('reminder-task', 'user', '<system-reminder>remember</system-reminder><task-notification>done</task-notification>'),
+				('reminder-goal', 'user', '<system-reminder>remember</system-reminder><goal_context>state</goal_context>'),
+				('reminder-ordinary', 'user', '<system-reminder>remember</system-reminder>real prompt'),
+				('reminder-malformed', 'user', '<system-reminder>remember')
 		)
 		SELECT label FROM candidates
 		WHERE `+SystemPrefixSQL("content", "role")+`
@@ -104,6 +125,9 @@ source="goal">state'),
 		"missing-close",
 		"non-goal-internal",
 		"normal",
+		"reminder-malformed",
+		"reminder-ordinary",
+		"reminder-plus-prompt",
 	}, got)
 }
 
@@ -192,6 +216,29 @@ func TestSearch(t *testing.T) {
 	insertMessages(t, d, userMsg("s-prefixonly", 0,
 		"This session is being continued from a previous conversation"))
 
+	// Session s-reminderonly: only system-reminder prefix content (is_system=false).
+	// Search fallback must exclude it the same way as other prefix-only sessions.
+	insertSession(t, d, "s-reminderonly", "proj-prefixonly",
+		func(s *Session) {
+			s.Agent = "claude"
+			s.SessionName = new("reminderonlydnterm unique display")
+			s.StartedAt = new("2024-01-07T10:00:00Z")
+			s.EndedAt = new("2024-01-07T11:00:00Z")
+		},
+	)
+	insertMessages(t, d, userMsg("s-reminderonly", 0,
+		"<system-reminder>remember this</system-reminder>"))
+
+	insertSession(t, d, "s-reminderprompt", "proj-prefixonly",
+		func(s *Session) {
+			s.Agent = "claude"
+			s.StartedAt = new("2024-01-08T10:00:00Z")
+			s.EndedAt = new("2024-01-08T11:00:00Z")
+		},
+	)
+	insertMessages(t, d, userMsg("s-reminderprompt", 0,
+		"<system-reminder>remember this</system-reminder>\n\nreminderpromptterm real prompt"))
+
 	t.Run("deduplication: two messages in same session → one result", func(t *testing.T) {
 		page, err := d.Search(context.Background(), SearchFilter{
 			Query: "alpha", Limit: 10,
@@ -269,6 +316,23 @@ func TestSearch(t *testing.T) {
 		})
 		require.NoError(t, err, "Search")
 		assert.Empty(t, page.Results, "prefix-only session")
+	})
+
+	t.Run("name branch excludes system-reminder-only sessions", func(t *testing.T) {
+		page, err := d.Search(context.Background(), SearchFilter{
+			Query: "reminderonlydnterm", Limit: 10,
+		})
+		require.NoError(t, err, "Search")
+		assert.Empty(t, page.Results, "system-reminder-only session")
+	})
+
+	t.Run("content branch keeps reminder-prefixed real prompts", func(t *testing.T) {
+		page, err := d.Search(context.Background(), SearchFilter{
+			Query: "reminderpromptterm", Limit: 10,
+		})
+		require.NoError(t, err, "Search")
+		require.Len(t, page.Results, 1)
+		assert.Equal(t, "s-reminderprompt", page.Results[0].SessionID)
 	})
 
 	t.Run("invalid sort value defaults to relevance (SQL injection guard)", func(t *testing.T) {

--- a/internal/duckdb/store_contract_test.go
+++ b/internal/duckdb/store_contract_test.go
@@ -79,6 +79,31 @@ func TestDuckDBStoreContract(t *testing.T) {
 	}
 }
 
+func TestDuckDBSystemPrefixSQLTerminalRemainder(t *testing.T) {
+	conn := openTestDuckDB(t)
+	rows, err := conn.Query(`
+		WITH candidates(label, role, content) AS (VALUES
+			('reminder-only', 'user', '<system-reminder>a</system-reminder><system-reminder>b</system-reminder>'),
+			('reminder-task', 'user', '<system-reminder>a</system-reminder><task-notification>done</task-notification>'),
+			('reminder-ordinary', 'user', '<system-reminder>a</system-reminder>real prompt'),
+			('reminder-malformed', 'user', '<system-reminder>a')
+		)
+		SELECT label FROM candidates
+		WHERE ` + db.DuckDBSystemPrefixSQL("content", "role") + `
+		ORDER BY label`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var got []string
+	for rows.Next() {
+		var label string
+		require.NoError(t, rows.Scan(&label))
+		got = append(got, label)
+	}
+	require.NoError(t, rows.Err())
+	assert.Equal(t, []string{"reminder-malformed", "reminder-ordinary"}, got)
+}
+
 // TestDuckDBStoreHasSemanticFalse pins that the DuckDB store reports no
 // semantic search capability until it gets its own VectorSearcher seam.
 func TestDuckDBStoreHasSemanticFalse(t *testing.T) {

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -353,6 +353,9 @@ func claudeParseWithExclusions(
 // clean for sessions that ended without an orphan tool_use.
 func lastAssistantStopReason(messages []ParsedMessage) string {
 	for _, v := range slices.Backward(messages) {
+		if v.IsSystem {
+			continue
+		}
 		if v.Role == RoleAssistant {
 			return v.StopReason
 		}
@@ -526,7 +529,7 @@ func claudeParseSessionFrom(
 	annotateSubagentSessions(msgs, subagentMap)
 	if len(queuedCommands) > 0 {
 		msgs = mergeQueuedCommands(
-			msgs, queuedCommands, startOrdinal,
+			msgs, queuedCommands, startOrdinal, queuedCommandMessage,
 		)
 		for _, qc := range queuedCommands {
 			if qc.timestamp.After(endedAt) {
@@ -735,9 +738,9 @@ func extractMessagesFrom(
 		// looks like a command envelope but can't be
 		// normalized, skip it to avoid raw XML in transcripts.
 		if e.entryType == "user" {
-			if cmdText, ok := extractCommandText(text); ok {
-				text = cmdText
-			} else if isCommandEnvelope(text) {
+			var skip bool
+			text, skip = preprocessClaudeUserText(text)
+			if skip {
 				continue
 			}
 		}
@@ -762,6 +765,7 @@ func extractMessagesFrom(
 					ContentLength:    len(text),
 					SourceType:       "system",
 					SourceSubtype:    subtype,
+					ToolResults:      trs,
 					SourceUUID:       e.uuid,
 					SourceParentUUID: e.parentUuid,
 					IsSidechain:      gjson.Get(e.line, "isSidechain").Bool(),
@@ -1106,7 +1110,9 @@ func extractQueuedCommand(line string) (claudeQueuedCommand, bool) {
 		return claudeQueuedCommand{}, false
 	}
 	prompt := gjson.Get(line, "attachment.prompt").Str
-	if strings.TrimSpace(prompt) == "" {
+	var skip bool
+	prompt, skip = preprocessClaudeUserText(prompt)
+	if skip || strings.TrimSpace(prompt) == "" {
 		return claudeQueuedCommand{}, false
 	}
 	return claudeQueuedCommand{
@@ -1123,7 +1129,7 @@ func extractQueuedCommand(line string) (claudeQueuedCommand, bool) {
 func applyQueuedCommands(
 	r ParseResult, queued []claudeQueuedCommand,
 ) ParseResult {
-	merged := mergeQueuedCommands(r.Messages, queued, 0)
+	merged := mergeQueuedCommands(r.Messages, queued, 0, queuedCommandMessage)
 	firstMsg, userCount := firstMessageAndUserCount(merged)
 	r.Session.FirstMessage = firstMsg
 	r.Session.UserMessageCount = userCount
@@ -1152,12 +1158,13 @@ func mergeQueuedCommands(
 	messages []ParsedMessage,
 	queued []claudeQueuedCommand,
 	startOrdinal int,
+	buildMessage func(claudeQueuedCommand) ParsedMessage,
 ) []ParsedMessage {
 	out := make([]ParsedMessage, 0, len(messages)+len(queued))
 	i, j := 0, 0
 	for i < len(messages) && j < len(queued) {
 		if queuedBefore(queued[j], messages[i]) {
-			out = append(out, queuedCommandMessage(queued[j]))
+			out = append(out, buildMessage(queued[j]))
 			j++
 		} else {
 			out = append(out, messages[i])
@@ -1168,7 +1175,7 @@ func mergeQueuedCommands(
 		out = append(out, messages[i])
 	}
 	for ; j < len(queued); j++ {
-		out = append(out, queuedCommandMessage(queued[j]))
+		out = append(out, buildMessage(queued[j]))
 	}
 	for k := range out {
 		out[k].Ordinal = startOrdinal + k
@@ -1193,12 +1200,22 @@ func queuedBefore(
 }
 
 // queuedCommandMessage builds a ParsedMessage from a collected
-// queued_command attachment. Role stays user (the user typed
-// this) and IsSystem is false so it counts as a real user turn;
-// SourceSubtype lets the UI distinguish it from inline prompts.
+// queued_command attachment.
 func queuedCommandMessage(
 	q claudeQueuedCommand,
 ) ParsedMessage {
+	q.prompt = stripLeadingClaudeSystemReminderContent(q.prompt)
+	if subtype := classifyClaudeSystemMessage(q.prompt); subtype != "" {
+		return ParsedMessage{
+			Role:          RoleUser,
+			Content:       q.prompt,
+			Timestamp:     q.timestamp,
+			IsSystem:      true,
+			ContentLength: len(q.prompt),
+			SourceType:    "system",
+			SourceSubtype: subtype,
+		}
+	}
 	return ParsedMessage{
 		Role:          RoleUser,
 		Content:       q.prompt,
@@ -1684,9 +1701,9 @@ func extractMessages(entries []dagEntry) (
 		// looks like a command envelope but can't be
 		// normalized, skip it to avoid raw XML in transcripts.
 		if e.entryType == "user" {
-			if cmdText, ok := extractCommandText(text); ok {
-				text = cmdText
-			} else if isCommandEnvelope(text) {
+			var skip bool
+			text, skip = preprocessClaudeUserText(text)
+			if skip {
 				continue
 			}
 		}
@@ -1711,6 +1728,7 @@ func extractMessages(entries []dagEntry) (
 					ContentLength:    len(text),
 					SourceType:       "system",
 					SourceSubtype:    subtype,
+					ToolResults:      trs,
 					SourceUUID:       e.uuid,
 					SourceParentUUID: e.parentUuid,
 					IsSidechain:      gjson.Get(e.line, "isSidechain").Bool(),
@@ -1984,6 +2002,27 @@ func extractCommandText(content string) (string, bool) {
 	return name, true
 }
 
+func preprocessClaudeUserText(content string) (string, bool) {
+	trimmed := trimClaudeSystemMessagePrefix(content)
+	remainder, stripped := stripLeadingClaudeSystemReminderBlocks(trimmed)
+	if stripped && remainder != "" {
+		trimmed = remainder
+	}
+	if cmdText, ok := extractCommandText(trimmed); ok {
+		return cmdText, false
+	}
+	if isCommandEnvelope(trimmed) {
+		return "", true
+	}
+	if stripped && remainder == "" {
+		return content, false
+	}
+	if !stripped {
+		return content, false
+	}
+	return trimmed, false
+}
+
 // isCommandEnvelope returns true if the content is a pure
 // command XML envelope (starts with a command tag and contains
 // nothing but command tags and whitespace). Used as a fallback
@@ -2123,9 +2162,7 @@ func extractCompactSummary(line string) string {
 // local command output) are treated as regular noise and return "";
 // only the caveat variant is a semantic "resume" marker.
 func classifyClaudeSystemMessage(content string) string {
-	trimmed := strings.TrimLeftFunc(content, func(r rune) bool {
-		return r == '\uFEFF' || unicode.IsSpace(r)
-	})
+	trimmed := trimClaudeSystemMessagePrefix(content)
 	switch {
 	case strings.HasPrefix(trimmed, "This session is being continued"):
 		return "continuation"
@@ -2137,27 +2174,56 @@ func classifyClaudeSystemMessage(content string) string {
 		return "task_notification"
 	case strings.HasPrefix(trimmed, "Stop hook feedback:"):
 		return "stop_hook"
+	case strings.HasPrefix(trimmed, "<system-reminder>"):
+		remainder, stripped := stripLeadingClaudeSystemReminderBlocks(trimmed)
+		if !stripped {
+			return ""
+		}
+		if remainder != "" {
+			return ""
+		}
+		return "system_reminder"
 	}
 	return ""
+}
+
+func stripLeadingClaudeSystemReminderContent(content string) string {
+	trimmed := trimClaudeSystemMessagePrefix(content)
+	remainder, stripped := stripLeadingClaudeSystemReminderBlocks(trimmed)
+	if stripped && remainder != "" {
+		return remainder
+	}
+	return content
+}
+
+func stripLeadingClaudeSystemReminderBlocks(content string) (string, bool) {
+	rest := trimClaudeSystemMessagePrefix(content)
+	stripped := false
+	for strings.HasPrefix(rest, "<system-reminder>") {
+		closeIdx := strings.Index(rest, "</system-reminder>")
+		if closeIdx < 0 {
+			return "", false
+		}
+		rest = trimClaudeSystemMessagePrefix(
+			rest[closeIdx+len("</system-reminder>"):],
+		)
+		stripped = true
+	}
+	return rest, stripped
+}
+
+func trimClaudeSystemMessagePrefix(content string) string {
+	return strings.TrimLeftFunc(content, func(r rune) bool {
+		return r == '\uFEFF' || unicode.IsSpace(r)
+	})
 }
 
 // isClaudeSystemMessage returns true if the content matches
 // a known system-injected user message pattern.
 func isClaudeSystemMessage(content string) bool {
-	trimmed := strings.TrimLeftFunc(content, func(r rune) bool {
-		return r == '\uFEFF' || unicode.IsSpace(r)
-	})
-	prefixes := [...]string{
-		"This session is being continued",
-		"[Request interrupted",
-		"<task-notification>",
-		"<local-command-",
-		"Stop hook feedback:",
+	trimmed := trimClaudeSystemMessagePrefix(content)
+	if classifyClaudeSystemMessage(trimmed) != "" {
+		return true
 	}
-	for _, p := range prefixes {
-		if strings.HasPrefix(trimmed, p) {
-			return true
-		}
-	}
-	return false
+	return strings.HasPrefix(trimmed, "<local-command-")
 }

--- a/internal/parser/claude_parser_test.go
+++ b/internal/parser/claude_parser_test.go
@@ -100,6 +100,29 @@ func TestParseClaudeSession_UsageProbe(t *testing.T) {
 			"a session whose only user turn is /usage must be skipped")
 	})
 
+	t.Run("skips a reminder-prefixed /usage-only session", func(t *testing.T) {
+		content := testjsonl.ClaudeUserJSON(
+			"<system-reminder>probe</system-reminder>\n"+usageCmd,
+			tsEarly,
+		)
+		assert.Empty(t, parse(t, content),
+			"reminders must be stripped before /usage detection")
+	})
+
+	t.Run("normalizes a reminder-prefixed command", func(t *testing.T) {
+		content := testjsonl.JoinJSONL(
+			testjsonl.ClaudeUserJSON(
+				"<system-reminder>context</system-reminder>\n"+
+					"<command-name>/clear</command-name>",
+				tsEarly,
+			),
+			testjsonl.ClaudeAssistantJSON("ready", tsEarlyS1),
+		)
+		_, msgs := runClaudeParserTest(t, "reminder-command.jsonl", content)
+		require.Len(t, msgs, 2)
+		assert.Equal(t, "/clear", msgs[0].Content)
+	})
+
 	t.Run("skips a queued /usage-only session", func(t *testing.T) {
 		content := testjsonl.JoinJSONL(
 			testjsonl.ClaudeAssistantJSON("checking usage", tsEarly),
@@ -425,6 +448,62 @@ func TestParseClaudeSession_QueuedCommand(t *testing.T) {
 		}
 	})
 
+	t.Run("adjacent_system_prefix_stays_user", func(t *testing.T) {
+		content := testjsonl.JoinJSONL(
+			testjsonl.ClaudeUserJSON("first request", tsZero),
+			testjsonl.ClaudeQueuedCommandJSON(
+				"<task-notification-status>ready", tsZeroS1,
+			),
+			testjsonl.ClaudeAssistantJSON([]map[string]any{
+				{"type": "text", "text": "ok"},
+			}, tsZeroS2),
+		)
+		sess, msgs := runClaudeParserTest(t, "test.jsonl", content)
+		require.Len(t, msgs, 3)
+		assert.Equal(t, 2, sess.UserMessageCount)
+		assert.False(t, msgs[1].IsSystem)
+		assert.Equal(t, "queued_command", msgs[1].SourceSubtype)
+	})
+
+	t.Run("leading_system_reminder_keeps_real_queued_prompt", func(t *testing.T) {
+		content := testjsonl.JoinJSONL(
+			testjsonl.ClaudeUserJSON("first request", tsZero),
+			testjsonl.ClaudeQueuedCommandJSON(
+				"<system-reminder>remember this</system-reminder>\n\nactual queued prompt",
+				tsZeroS1,
+			),
+			testjsonl.ClaudeAssistantJSON([]map[string]any{
+				{"type": "text", "text": "ok"},
+			}, tsZeroS2),
+		)
+		sess, msgs := runClaudeParserTest(t, "test.jsonl", content)
+		require.Len(t, msgs, 3)
+		assert.Equal(t, 2, sess.UserMessageCount)
+		assert.False(t, msgs[1].IsSystem)
+		assert.Equal(t, "queued_command", msgs[1].SourceSubtype)
+		assert.Equal(t, "actual queued prompt", msgs[1].Content)
+	})
+
+	t.Run("normalizes_reminder_prefixed_command", func(t *testing.T) {
+		content := testjsonl.JoinJSONL(
+			testjsonl.ClaudeUserJSON("first request", tsZero),
+			testjsonl.ClaudeQueuedCommandJSON(
+				"<system-reminder>remember this</system-reminder>\n"+
+					"<command-name>/clear</command-name>",
+				tsZeroS1,
+			),
+			testjsonl.ClaudeAssistantJSON([]map[string]any{
+				{"type": "text", "text": "ok"},
+			}, tsZeroS2),
+		)
+		sess, msgs := runClaudeParserTest(t, "test.jsonl", content)
+		require.Len(t, msgs, 3)
+		assert.Equal(t, 2, sess.UserMessageCount)
+		assert.Equal(t, "/clear", msgs[1].Content)
+		assert.Equal(t, "queued_command", msgs[1].SourceSubtype)
+		assert.False(t, msgs[1].IsSystem)
+	})
+
 	t.Run("becomes first message when session opens with one", func(t *testing.T) {
 		content := testjsonl.JoinJSONL(
 			testjsonl.ClaudeQueuedCommandJSON(
@@ -495,6 +574,90 @@ func TestParseClaudeSession_QueuedCommand(t *testing.T) {
 		assert.Equal(t, "queued_command", msgs[2].SourceSubtype)
 		assert.Equal(t, 2, sess.UserMessageCount)
 	})
+}
+
+func TestParseClaudeSession_QueuedSystemMessagesDoNotCount(t *testing.T) {
+	content := loadFixture(t, "claude/queued_system_messages.jsonl")
+	sess, msgs := runClaudeParserTest(t, "test.jsonl", content)
+	assert.Equal(t, 1, sess.UserMessageCount)
+	assert.Equal(t, "Your final response is captured verbatim into ...", sess.FirstMessage)
+	var systems []ParsedMessage
+	for _, msg := range msgs {
+		if msg.IsSystem {
+			systems = append(systems, msg)
+		}
+	}
+	require.Len(t, systems, 2)
+	assert.Equal(t, "task_notification", systems[0].SourceSubtype)
+	assert.Equal(t, "task_notification", systems[1].SourceSubtype)
+}
+
+func TestParseClaudeSession_LeadingSystemReminderKeepsRealPrompt(t *testing.T) {
+	content := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON(
+			"<system-reminder>remember this</system-reminder>\n\nreal prompt",
+			tsZero,
+		),
+		testjsonl.ClaudeAssistantJSON("ok", tsZeroS1),
+	)
+	sess, msgs := runClaudeParserTest(t, "test.jsonl", content)
+	require.Len(t, msgs, 2)
+	assert.Equal(t, 1, sess.UserMessageCount)
+	assert.Equal(t, "real prompt", sess.FirstMessage)
+	assert.False(t, msgs[0].IsSystem)
+	assert.Equal(t, "real prompt", msgs[0].Content)
+}
+
+func TestParseClaudeSession_MalformedSystemReminderStaysUser(t *testing.T) {
+	content := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON(
+			"<system-reminder>literal tag at the start", tsZero,
+		),
+		testjsonl.ClaudeAssistantJSON("ok", tsZeroS1),
+	)
+	sess, msgs := runClaudeParserTest(t, "test.jsonl", content)
+	require.Len(t, msgs, 2)
+	assert.Equal(t, 1, sess.UserMessageCount)
+	assert.Equal(t, "<system-reminder>literal tag at the start", sess.FirstMessage)
+	assert.False(t, msgs[0].IsSystem)
+	assert.Equal(t, "<system-reminder>literal tag at the start", msgs[0].Content)
+}
+
+func TestParseClaudeSession_SystemReminderPromotionPreservesToolResults(t *testing.T) {
+	content := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("real prompt", tsZero),
+		testjsonl.ClaudeAssistantJSON("ok", tsZeroS1),
+		`{"type":"user","timestamp":"`+tsZeroS2+`","uuid":"u2","parentUuid":"a1","message":{"content":[{"type":"text","text":"<system-reminder>remember this</system-reminder>"},{"type":"tool_result","tool_use_id":"toolu_r","content":"tool output","is_error":false}]}}`,
+	)
+	_, msgs := runClaudeParserTest(t, "test.jsonl", content)
+	require.Len(t, msgs, 3)
+	assert.True(t, msgs[2].IsSystem)
+	assert.Equal(t, "system_reminder", msgs[2].SourceSubtype)
+	require.Len(t, msgs[2].ToolResults, 1)
+	assert.Equal(t, "toolu_r", msgs[2].ToolResults[0].ToolUseID)
+	assert.Equal(t, "tool output",
+		DecodeContent(msgs[2].ToolResults[0].ContentRaw))
+}
+
+func TestParseClaudeSession_QueuedSystemMessageKinds(t *testing.T) {
+	content := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("real prompt", tsZero),
+		testjsonl.ClaudeQueuedCommandJSON("<task-notification>done</task-notification>", tsZeroS1),
+		testjsonl.ClaudeQueuedCommandJSON("Stop hook feedback: blocked", tsZeroS2),
+		testjsonl.ClaudeQueuedCommandJSON("<system-reminder>remember</system-reminder>", "2024-01-01T00:00:03Z"),
+		testjsonl.ClaudeQueuedCommandJSON("ordinary queued prompt", "2024-01-01T00:00:04Z"),
+	)
+	sess, msgs := runClaudeParserTest(t, "test.jsonl", content)
+	assert.Equal(t, 2, sess.UserMessageCount)
+	require.Len(t, msgs, 5)
+	assert.Equal(t, []string{"task_notification", "stop_hook", "system_reminder", "queued_command"}, []string{
+		msgs[1].SourceSubtype, msgs[2].SourceSubtype, msgs[3].SourceSubtype, msgs[4].SourceSubtype,
+	})
+	for i := 1; i < 4; i++ {
+		assert.True(t, msgs[i].IsSystem)
+		assert.Equal(t, "system", msgs[i].SourceType)
+	}
+	assert.False(t, msgs[4].IsSystem)
 }
 
 func TestParseClaudeSession_ParentSessionID(t *testing.T) {
@@ -657,6 +820,94 @@ func TestParseClaudeSessionFrom_QueueOperationPreservesSubagentMapping(
 		"agent-child123",
 		newMsgs[0].ToolCalls[0].SubagentSessionID,
 	)
+}
+
+func TestParseClaudeSessionFrom_QueuedSystemMessage(t *testing.T) {
+	t.Parallel()
+
+	initial := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("hello", tsEarly),
+		testjsonl.ClaudeAssistantJSON("hi", tsEarlyS1),
+	)
+	path := createTestFile(t, "inc-queued-system.jsonl", initial)
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+
+	appended := testjsonl.JoinJSONL(
+		testjsonl.ClaudeQueuedCommandJSON(
+			"<system-reminder>remember</system-reminder>", tsEarlyS5,
+		),
+		testjsonl.ClaudeAssistantJSON("done", tsLate),
+	)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.WriteString(appended)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	newMsgs, _, _, err := callParseClaudeSessionFrom(path, info.Size(), 2, "")
+	require.NoError(t, err)
+	require.Len(t, newMsgs, 2)
+	assert.True(t, newMsgs[0].IsSystem)
+	assert.Equal(t, "system", newMsgs[0].SourceType)
+	assert.Equal(t, "system_reminder", newMsgs[0].SourceSubtype)
+}
+
+func TestParseClaudeSessionFrom_ReminderPrefixedCommand(t *testing.T) {
+	t.Parallel()
+
+	initial := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("hello", tsEarly),
+		testjsonl.ClaudeAssistantJSON("hi", tsEarlyS1),
+	)
+	path := createTestFile(t, "inc-reminder-command.jsonl", initial)
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+
+	appended := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON(
+			"<system-reminder>context</system-reminder>\n"+
+				"<command-name>/clear</command-name>",
+			tsEarlyS5,
+		),
+		testjsonl.ClaudeAssistantJSON("done", tsLate),
+	)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.WriteString(appended)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	newMsgs, _, _, err := callParseClaudeSessionFrom(path, info.Size(), 2, "")
+	require.NoError(t, err)
+	require.Len(t, newMsgs, 2)
+	assert.Equal(t, "/clear", newMsgs[0].Content)
+}
+
+func TestParseClaudeSessionFrom_SystemReminderToolResultsFallBack(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	initial := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("hello", tsEarly),
+		testjsonl.ClaudeAssistantJSON("hi", tsEarlyS1),
+	)
+	path := createTestFile(t, "inc-reminder-tool-result.jsonl", initial)
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+
+	appended := `{"type":"user","timestamp":"` + tsEarlyS5 +
+		`","uuid":"u2","parentUuid":"a1","message":{"content":[{"type":"text","text":"<system-reminder>remember this</system-reminder>"},{"type":"tool_result","tool_use_id":"toolu_r","content":"tool output","is_error":false}]}}` + "\n"
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.WriteString(appended)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	_, _, _, err = callParseClaudeSessionFrom(path, info.Size(), 2, "")
+	assert.ErrorIs(t, err, ErrClaudeIncrementalNeedsFullParse)
+	assert.True(t, IsIncrementalFullParseFallback(err))
 }
 
 func TestParseClaudeSessionFrom_SkipsNonMessages(
@@ -1209,6 +1460,19 @@ func TestParseClaudeSession_TerminationStatus(t *testing.T) {
 		content := loadFixture(t, "claude/valid_session.jsonl")
 		sess, _ := runClaudeParserTest(t, "test.jsonl", content)
 		assert.Equal(t, TerminationClean, sess.TerminationStatus)
+	})
+
+	t.Run("awaiting_user ignores trailing compact boundary", func(t *testing.T) {
+		content := testjsonl.JoinJSONL(
+			testjsonl.ClaudeUserJSON("hello", tsZero),
+			`{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"`+tsZeroS1+`","message":{"role":"assistant","stop_reason":"end_turn","content":[{"type":"text","text":"done"}]}}`,
+			`{"type":"user","isCompactSummary":true,"uuid":"compact-uuid","parentUuid":"a1","timestamp":"`+tsZeroS2+`","message":{"role":"user","content":[{"type":"text","text":"Summary of conversation so far..."}]}}`,
+		)
+		sess, msgs := runClaudeParserTest(t, "test.jsonl", content)
+		assert.Equal(t, TerminationAwaitingUser, sess.TerminationStatus)
+		require.Len(t, msgs, 3)
+		assert.True(t, msgs[2].IsSystem)
+		assert.True(t, msgs[2].IsCompactBoundary)
 	})
 
 	t.Run("tool_call_pending", func(t *testing.T) {
@@ -1799,6 +2063,10 @@ func TestClassifyClaudeSystemMessage(t *testing.T) {
 		{"interrupted", "[Request interrupted by user]", "interrupted"},
 		{"task notification", "<task-notification>done</task-notification>", "task_notification"},
 		{"stop hook", "Stop hook feedback: ...", "stop_hook"},
+		{"system_reminder", "<system-reminder>remember this</system-reminder>", "system_reminder"},
+		{"system_reminder plus prompt", "<system-reminder>remember this</system-reminder>\n\nreal prompt", ""},
+		{"malformed system_reminder", "<system-reminder>literal tag at the start", ""},
+		{"task-notification-status", "<task-notification-status>ready", ""},
 		{"bom prefix", "\uFEFF  This session is being continued", "continuation"},
 		{"non-caveat local-command", "<local-command-stdout>foo</local-command-stdout>", ""},
 		{"regular text", "what do you think?", ""},

--- a/internal/parser/openclaude.go
+++ b/internal/parser/openclaude.go
@@ -528,7 +528,9 @@ func parseOpenClaudeSession(
 	}
 
 	if len(queuedCommands) > 0 {
-		messages = mergeQueuedCommands(messages, queuedCommands, 0)
+		messages = mergeQueuedCommands(
+			messages, queuedCommands, 0, openClaudeQueuedCommandMessage,
+		)
 		firstUser, userCount = firstMessageAndUserCount(messages)
 		for _, qc := range queuedCommands {
 			if qc.timestamp.After(endedAt) {
@@ -578,7 +580,7 @@ func parseOpenClaudeSession(
 	}
 	accumulateMessageTokenUsage(sess, messages)
 	sess.TerminationStatus = Classify(
-		openClaudeSemanticMessages(messages),
+		messages,
 		lastAssistantStopReason(openClaudeSemanticMessages(messages)),
 		isTruncated,
 	)
@@ -627,6 +629,17 @@ func extractOpenClaudeQueuedCommand(line string) (claudeQueuedCommand, bool) {
 		prompt:    prompt,
 		timestamp: extractTimestamp(line),
 	}, true
+}
+
+func openClaudeQueuedCommandMessage(q claudeQueuedCommand) ParsedMessage {
+	return ParsedMessage{
+		Role:          RoleUser,
+		Content:       q.prompt,
+		Timestamp:     q.timestamp,
+		ContentLength: len(q.prompt),
+		SourceType:    "user",
+		SourceSubtype: "queued_command",
+	}
 }
 
 func openClaudeSessionID(id string) string {

--- a/internal/parser/openclaude_test.go
+++ b/internal/parser/openclaude_test.go
@@ -152,6 +152,105 @@ func TestOpenClaudeDiscoverParseAndFindSource(t *testing.T) {
 	assert.Contains(t, result.Messages[2].Content, "Compact summary")
 }
 
+func TestOpenClaudeTerminationUsesSystemToolResults(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "tool-project")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+
+	path := filepath.Join(projectDir, "session-tools.jsonl")
+	content := strings.Join([]string{
+		buildMetadataLine(map[string]any{
+			"type": "user", "timestamp": tsEarly, "uuid": "u1",
+			"message": map[string]any{"role": "user", "content": "read file"},
+		}),
+		buildMetadataLine(map[string]any{
+			"type": "assistant", "timestamp": tsEarlyS1, "uuid": "a1",
+			"message": map[string]any{
+				"role": "assistant", "stop_reason": "tool_use",
+				"content": []map[string]any{{
+					"type": "tool_use", "id": "toolu_sys", "name": "Read", "input": map[string]any{},
+				}},
+			},
+		}),
+		buildMetadataLine(map[string]any{
+			"type": "system", "subtype": "tool_result", "timestamp": tsEarlyS5, "uuid": "s1",
+			"message": map[string]any{
+				"role": "system",
+				"content": []map[string]any{{
+					"type": "tool_result", "tool_use_id": "toolu_sys", "content": "file contents",
+				}},
+			},
+		}),
+	}, "\n") + "\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	provider, ok := NewProvider(AgentOpenClaude, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	discovered, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, discovered, 1)
+
+	outcome, err := provider.Parse(context.Background(), ParseRequest{Source: discovered[0]})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	result := outcome.Results[0].Result
+
+	assert.Equal(t, TerminationClean, result.Session.TerminationStatus)
+	require.Len(t, result.Messages, 3)
+	assert.True(t, result.Messages[2].IsSystem)
+	require.Len(t, result.Messages[2].ToolResults, 1)
+	assert.Equal(t, "toolu_sys", result.Messages[2].ToolResults[0].ToolUseID)
+}
+
+func TestOpenClaudeTerminationCompactBoundaryDoesNotResolveToolCall(t *testing.T) {
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "compact-project")
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+
+	path := filepath.Join(projectDir, "session-compact.jsonl")
+	content := strings.Join([]string{
+		buildMetadataLine(map[string]any{
+			"type": "user", "timestamp": tsEarly, "uuid": "u1",
+			"message": map[string]any{"role": "user", "content": "read file"},
+		}),
+		buildMetadataLine(map[string]any{
+			"type": "assistant", "timestamp": tsEarlyS1, "uuid": "a1",
+			"message": map[string]any{
+				"role": "assistant", "stop_reason": "tool_use",
+				"content": []map[string]any{{
+					"type": "tool_use", "id": "toolu_boundary", "name": "Read", "input": map[string]any{},
+				}},
+			},
+		}),
+		buildMetadataLine(map[string]any{
+			"type": "system", "subtype": "compact_boundary", "timestamp": tsEarlyS5, "uuid": "s1",
+			"message": map[string]any{
+				"content": []map[string]any{{
+					"type": "text", "text": "Compacted earlier turns",
+				}},
+			},
+		}),
+	}, "\n") + "\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	provider, ok := NewProvider(AgentOpenClaude, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	discovered, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, discovered, 1)
+
+	outcome, err := provider.Parse(context.Background(), ParseRequest{Source: discovered[0]})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	result := outcome.Results[0].Result
+
+	assert.Equal(t, TerminationToolCallPending, result.Session.TerminationStatus)
+	require.Len(t, result.Messages, 3)
+	assert.True(t, result.Messages[2].IsSystem)
+	assert.True(t, result.Messages[2].IsCompactBoundary)
+	assert.Equal(t, RoleAssistant, result.Messages[2].Role)
+}
+
 func TestOpenClaudeQueuedCommandAttachment(t *testing.T) {
 	root := t.TempDir()
 	projectDir := filepath.Join(root, "queue-project")
@@ -178,6 +277,15 @@ func TestOpenClaudeQueuedCommandAttachment(t *testing.T) {
 					{"type": "text", "text": "/resume next step"},
 					{"type": "text", "text": "with context"},
 				},
+			},
+		}),
+		buildMetadataLine(map[string]any{
+			"type":      "attachment",
+			"timestamp": "2024-01-01T10:00:01.250Z",
+			"attachment": map[string]any{
+				"type":        "queued_command",
+				"commandMode": "prompt",
+				"prompt":      "<system-reminder>remember this</system-reminder>\n\nactual prompt",
 			},
 		}),
 		buildMetadataLine(map[string]any{
@@ -240,11 +348,14 @@ func TestOpenClaudeQueuedCommandAttachment(t *testing.T) {
 	require.Len(t, outcome.Results, 1)
 
 	result := outcome.Results[0].Result
-	require.Len(t, result.Messages, 3)
+	require.Len(t, result.Messages, 4)
 	assert.Equal(t, "/resume next step\nwith context", result.Messages[1].Content)
 	assert.Equal(t, "queued_command", result.Messages[1].SourceSubtype)
 	assert.Equal(t, RoleUser, result.Messages[1].Role)
-	assert.Equal(t, 2, result.Session.UserMessageCount)
+	assert.Equal(t, "<system-reminder>remember this</system-reminder>\n\nactual prompt", result.Messages[2].Content)
+	assert.Equal(t, "queued_command", result.Messages[2].SourceSubtype)
+	assert.False(t, result.Messages[2].IsSystem)
+	assert.Equal(t, 3, result.Session.UserMessageCount)
 	assert.Equal(t, "first prompt", result.Session.FirstMessage)
 }
 

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -832,6 +832,12 @@ func TestIsClaudeSystemMessage(t *testing.T) {
 		{"task-notification",
 			"<task-notification>some data</task-notification>",
 			true},
+		{"system-reminder",
+			"<system-reminder>some data</system-reminder>", true},
+		{"system-reminder plus prompt",
+			"<system-reminder>some data</system-reminder>\n\nreal prompt", false},
+		{"task-notification-status",
+			"<task-notification-status>some data", false},
 		{"command-message is not system",
 			"<command-message>foo</command-message>", false},
 		{"command-name is not system",
@@ -956,6 +962,39 @@ func TestExtractCommandText(t *testing.T) {
 				"extractCommandText(%q) ok", tt.content)
 			assert.Equalf(t, tt.want, got,
 				"extractCommandText(%q)", tt.content)
+		})
+	}
+}
+
+func TestPreprocessClaudeUserText(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want string
+		skip bool
+	}{
+		{
+			name: "ordinary content preserves whitespace",
+			in:   "  ordinary prompt",
+			want: "  ordinary prompt",
+		},
+		{
+			name: "reminder precedes command envelope",
+			in:   "<system-reminder>context</system-reminder>\n<command-name>/clear</command-name>",
+			want: "/clear",
+		},
+		{
+			name: "malformed reminder stays content",
+			in:   "<system-reminder>context",
+			want: "<system-reminder>context",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, skip := preprocessClaudeUserText(tt.in)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.skip, skip)
 		})
 	}
 }

--- a/internal/parser/termination.go
+++ b/internal/parser/termination.go
@@ -63,7 +63,14 @@ func Classify(
 	// message follows the last assistant turn, the agent is no
 	// longer parked — the user has already replied, so the UI
 	// should not show a "waiting for you" indicator.
-	lastIsAssistant := messages[len(messages)-1].Role == RoleAssistant
+	lastIsAssistant := false
+	for _, m := range slices.Backward(messages) {
+		if m.IsSystem {
+			continue
+		}
+		lastIsAssistant = m.Role == RoleAssistant
+		break
+	}
 	if lastIsAssistant && isAwaitingUserStopReason(stopReason) {
 		return TerminationAwaitingUser
 	}
@@ -92,6 +99,9 @@ func isAwaitingUserStopReason(stopReason string) bool {
 func hasOrphanedToolCall(messages []ParsedMessage) bool {
 	lastAssistantIdx := -1
 	for i, v := range slices.Backward(messages) {
+		if v.IsSystem {
+			continue
+		}
 		if v.Role == RoleAssistant {
 			lastAssistantIdx = i
 			break

--- a/internal/parser/termination_test.go
+++ b/internal/parser/termination_test.go
@@ -61,6 +61,24 @@ func TestClassify(t *testing.T) {
 			want: TerminationClean,
 		},
 		{
+			name: "awaiting_user: queued system notification after end_turn",
+			messages: []ParsedMessage{
+				{Role: RoleAssistant, Content: "done"},
+				{Role: RoleUser, Content: "queued notification", IsSystem: true},
+			},
+			stopReason: "end_turn",
+			want:       TerminationAwaitingUser,
+		},
+		{
+			name: "awaiting_user: queued system notification after task_complete",
+			messages: []ParsedMessage{
+				{Role: RoleAssistant, Content: "done"},
+				{Role: RoleUser, Content: "queued notification", IsSystem: true},
+			},
+			stopReason: "task_complete",
+			want:       TerminationAwaitingUser,
+		},
+		{
 			name: "clean: tool call resolved by tool result",
 			messages: []ParsedMessage{
 				{Role: RoleUser, Content: "read file"},
@@ -74,6 +92,35 @@ func TestClassify(t *testing.T) {
 			},
 			stopReason: "end_turn",
 			want:       TerminationAwaitingUser,
+		},
+		{
+			name: "clean: final tool call resolved by system tool result",
+			messages: []ParsedMessage{
+				{Role: RoleAssistant, ToolCalls: []ParsedToolCall{
+					{ToolUseID: "toolu_sys", ToolName: "Read"},
+				}},
+				{Role: RoleUser, ToolResults: []ParsedToolResult{
+					{ToolUseID: "toolu_sys"},
+				}, IsSystem: true},
+			},
+			want: TerminationClean,
+		},
+		{
+			name: "tool_call_pending: compact boundary after final tool call does not mask orphan",
+			messages: []ParsedMessage{
+				{Role: RoleAssistant, ToolCalls: []ParsedToolCall{
+					{ToolUseID: "toolu_boundary", ToolName: "Read"},
+				}},
+				{
+					Role:              RoleAssistant,
+					Content:           "Compacted earlier turns",
+					IsSystem:          true,
+					IsCompactBoundary: true,
+					SourceSubtype:     "compact_boundary",
+				},
+			},
+			stopReason: "tool_use",
+			want:       TerminationToolCallPending,
 		},
 		{
 			name: "tool_call_pending: last assistant has unmatched tool_use",

--- a/internal/parser/testdata/claude/queued_system_messages.jsonl
+++ b/internal/parser/testdata/claude/queued_system_messages.jsonl
@@ -1,0 +1,3 @@
+{"type":"user","timestamp":"2024-01-01T00:00:00Z","message":{"content":"Your final response is captured verbatim into ..."}}
+{"type":"attachment","timestamp":"2024-01-01T00:00:02Z","attachment":{"type":"queued_command","commandMode":"prompt","prompt":"<task-notification>\n<task-id>a29fa76dc1fa3212f...</task-id>\n<status>completed</status>\n</task-notification>"}}
+{"type":"attachment","timestamp":"2024-01-01T00:00:04Z","attachment":{"type":"queued_command","commandMode":"prompt","prompt":"<task-notification>\n<task-id>a5db2a604af3b5fcd...</task-id>\n<status>completed</status>\n</task-notification>"}}

--- a/internal/postgres/search_content_parity_pg_test.go
+++ b/internal/postgres/search_content_parity_pg_test.go
@@ -17,8 +17,7 @@ import (
 // classifySearchErr buckets a SearchContent failure into the two error
 // classes the HTTP layer maps to distinct status codes: "input" is a
 // *db.SearchInputError (400) and "unavailable" is db.ErrSemanticUnavailable
-// (501). An input error must never also satisfy errors.Is ErrSemanticUnavailable,
-// otherwise a 400 could be reported as a 501.
+// (501). An input error must never also satisfy errors.Is ErrSemanticUnavailable.
 func classifySearchErr(t *testing.T, err error) string {
 	t.Helper()
 	require.Error(t, err)
@@ -35,13 +34,10 @@ func classifySearchErr(t *testing.T, err error) string {
 	return ""
 }
 
-// TestSearchContentSemanticErrorParity pins that db.DB (SQLite) and
-// postgres.Store classify the same semantic/hybrid requests into the same
-// error class. Neither store has a VectorSearcher wired, so invalid inputs
-// must be rejected as *db.SearchInputError (400) before the capability gate,
-// while an otherwise-valid semantic/hybrid request falls through to
-// db.ErrSemanticUnavailable (501). Running one input table through both
-// backends is the cross-backend check the per-backend suites don't make.
+// TestSearchContentSemanticErrorParity runs the same semantic and hybrid
+// error-classification table through SQLite and PostgreSQL. The PostgreSQL
+// calls use setupContentSearch, so this parity proof executes against the
+// actual backend whenever TEST_PG_URL is available.
 func TestSearchContentSemanticErrorParity(t *testing.T) {
 	sqlite, err := db.Open(filepath.Join(t.TempDir(), "parity.db"))
 	require.NoError(t, err, "open sqlite")
@@ -54,62 +50,16 @@ func TestSearchContentSemanticErrorParity(t *testing.T) {
 		filter db.ContentSearchFilter
 		want   string
 	}{
-		{
-			name:   "semantic cursor rejected",
-			filter: db.ContentSearchFilter{Pattern: "x", Mode: "semantic", Cursor: 1},
-			want:   "input",
-		},
-		{
-			name:   "hybrid cursor rejected",
-			filter: db.ContentSearchFilter{Pattern: "x", Mode: "hybrid", Cursor: 1},
-			want:   "input",
-		},
-		{
-			name: "semantic non-messages source rejected",
-			filter: db.ContentSearchFilter{
-				Pattern: "x", Mode: "semantic", Sources: []string{"tool_input"},
-			},
-			want: "input",
-		},
-		{
-			name: "hybrid non-messages source rejected",
-			filter: db.ContentSearchFilter{
-				Pattern: "x", Mode: "hybrid", Sources: []string{"tool_result"},
-			},
-			want: "input",
-		},
-		{
-			name:   "semantic bad scope rejected",
-			filter: db.ContentSearchFilter{Pattern: "x", Mode: "semantic", Scope: "bogus"},
-			want:   "input",
-		},
-		{
-			name:   "hybrid bad scope rejected",
-			filter: db.ContentSearchFilter{Pattern: "x", Mode: "hybrid", Scope: "bogus"},
-			want:   "input",
-		},
-		{
-			name:   "unknown mode rejected",
-			filter: db.ContentSearchFilter{Pattern: "x", Mode: "bogus"},
-			want:   "input",
-		},
-		{
-			name:   "valid semantic hits capability gate",
-			filter: db.ContentSearchFilter{Pattern: "x", Mode: "semantic"},
-			want:   "unavailable",
-		},
-		{
-			name:   "valid hybrid hits capability gate",
-			filter: db.ContentSearchFilter{Pattern: "x", Mode: "hybrid"},
-			want:   "unavailable",
-		},
-		{
-			name: "valid semantic messages-only hits capability gate",
-			filter: db.ContentSearchFilter{
-				Pattern: "x", Mode: "semantic", Sources: []string{"messages"},
-			},
-			want: "unavailable",
-		},
+		{name: "semantic cursor rejected", filter: db.ContentSearchFilter{Pattern: "x", Mode: "semantic", Cursor: 1}, want: "input"},
+		{name: "hybrid cursor rejected", filter: db.ContentSearchFilter{Pattern: "x", Mode: "hybrid", Cursor: 1}, want: "input"},
+		{name: "semantic non-messages source rejected", filter: db.ContentSearchFilter{Pattern: "x", Mode: "semantic", Sources: []string{"tool_input"}}, want: "input"},
+		{name: "hybrid non-messages source rejected", filter: db.ContentSearchFilter{Pattern: "x", Mode: "hybrid", Sources: []string{"tool_result"}}, want: "input"},
+		{name: "semantic bad scope rejected", filter: db.ContentSearchFilter{Pattern: "x", Mode: "semantic", Scope: "bogus"}, want: "input"},
+		{name: "hybrid bad scope rejected", filter: db.ContentSearchFilter{Pattern: "x", Mode: "hybrid", Scope: "bogus"}, want: "input"},
+		{name: "unknown mode rejected", filter: db.ContentSearchFilter{Pattern: "x", Mode: "bogus"}, want: "input"},
+		{name: "valid semantic hits capability gate", filter: db.ContentSearchFilter{Pattern: "x", Mode: "semantic"}, want: "unavailable"},
+		{name: "valid hybrid hits capability gate", filter: db.ContentSearchFilter{Pattern: "x", Mode: "hybrid"}, want: "unavailable"},
+		{name: "valid semantic messages-only hits capability gate", filter: db.ContentSearchFilter{Pattern: "x", Mode: "semantic", Sources: []string{"messages"}}, want: "unavailable"},
 	}
 
 	ctx := context.Background()

--- a/internal/postgres/search_content_pgtest_test.go
+++ b/internal/postgres/search_content_pgtest_test.go
@@ -334,6 +334,52 @@ func TestPGSearchContentExcludeSystem(t *testing.T) {
 		"ExcludeSystem=true should suppress system messages")
 }
 
+// TestPGSearchContentExcludeSystemReminderFalseFlag executes the PostgreSQL
+// system-prefix predicate against rows whose is_system flag is false. The
+// reminder-only row is excluded, while a reminder followed by user content is
+// retained, across every message search path that uses this predicate.
+func TestPGSearchContentExcludeSystemReminderFalseFlag(t *testing.T) {
+	store := setupContentSearch(t)
+	insertCSSession(t, store, "cs-sys-reminder", "proj", "claude",
+		"2026-05-01T10:00:00Z", "2026-05-01T10:30:00Z")
+	insertCSMessage(t, store, "cs-sys-reminder", 0, "user",
+		"PGREMINDER ordinary user content", "2026-05-01T10:00:00Z", false)
+	insertCSMessage(t, store, "cs-sys-reminder", 1, "user",
+		"<system-reminder>PGREMINDER internal</system-reminder>",
+		"2026-05-01T10:00:01Z", false)
+	insertCSMessage(t, store, "cs-sys-reminder", 2, "user",
+		"<system-reminder>PGREMINDER context</system-reminder>\n\nPGREMINDER prompt",
+		"2026-05-01T10:00:02Z", false)
+
+	ctx := context.Background()
+	for _, mode := range []string{"substring", "fts", "regex"} {
+		t.Run(mode, func(t *testing.T) {
+			f := db.ContentSearchFilter{
+				Pattern: "PGREMINDER", Mode: mode,
+				Sources: []string{"messages"}, Limit: 50,
+			}
+			all, err := store.SearchContent(ctx, f)
+			require.NoError(t, err, "SearchContent %s", mode)
+			assert.ElementsMatch(t, []int{0, 1, 2}, messageOrdinals(all),
+				"without ExcludeSystem")
+
+			f.ExcludeSystem = true
+			filtered, err := store.SearchContent(ctx, f)
+			require.NoError(t, err, "SearchContent %s ExcludeSystem", mode)
+			assert.ElementsMatch(t, []int{0, 2}, messageOrdinals(filtered),
+				"reminder-only false-flag row must be excluded")
+		})
+	}
+}
+
+func messageOrdinals(page db.ContentSearchPage) []int {
+	ordinals := make([]int, len(page.Matches))
+	for i, match := range page.Matches {
+		ordinals[i] = match.Ordinal
+	}
+	return ordinals
+}
+
 // TestPGSearchContentProjectFilter verifies the Project session filter.
 func TestPGSearchContentProjectFilter(t *testing.T) {
 	store := setupContentSearch(t)


### PR DESCRIPTION
Queued Claude sessions that contain one real prompt plus queued runtime messages are being stored with an inflated `user_message_count`, which defeats the single-turn filter. A concrete repro in issue #1131 shows session `883331d3-25ce-40ef-b984-71c8a2d9c9e7` recorded as `user_message_count = 3` even though the only real user turn is the opening prompt; the extra counted turns are queued `<task-notification>` messages. The same path also misclassifies queued `Stop hook feedback:` and queued `<system-reminder>` content.

Claude parsing currently splits this behavior in two places. Queued `queued_command` attachments bypass `ClassifyClaudeSystemMessage`, so `queuedCommandMessage` hardcodes them as non-system user messages and they increment the count before the single-turn filter ever runs. Complete leading `<system-reminder>` blocks also reach command handling and compatibility fallbacks before their terminal remainder is classified, which leaves reminder-prefixed command envelopes as raw XML and lets reminder-prefixed `/usage` probes miss the existing exclusion.

The fix keeps the parser as the single source of truth. The shared queued-message merge now delegates message construction back to each provider, so Claude can classify queued runtime content as semantic system messages while OpenClaude still preserves accepted prompt attachments as counted `queued_command` user turns. Complete leading reminder blocks are normalized before Claude command handling, which lets reminder-prefixed command envelopes resolve to slash-command text and lets reminder-prefixed `/usage` probes hit the existing exclusion. The same terminal-remainder rule now drives the Go fallback, the generated SQLite/PostgreSQL/DuckDB predicates, and the frontend hidden-message fallback, while `VISIBLE_SYSTEM_SUBTYPES` stays unchanged so system reminders remain hidden rather than turning into visible boundary cards.

Termination classification now follows the final non-system assistant turn without dropping later system-carried tool results. Claude and OpenClaude both skip trailing compact boundaries or queued system notifications when deciding whether an assistant is waiting for the user, while orphaned-tool detection still scans later system messages so a matching tool result can resolve the final tool call. The filter itself stays untouched. No `user_message_count > 1` SQL predicate changes, because the bug is a wrong count flowing into a correct filter. `dataVersion` advances so existing stored sessions receive the corrected flags and counts through the repository's existing non-destructive reparse path, while ordinary queued prompts and queue-operation task-notification linkage keep their current behavior. This refines PR #406's queued-command ingestion contract by preserving real queued prompts while classifying queued system prompts and reminder-prefixed fallback content before they are counted or hidden.

Closes #1131
