### PR TITLE
Pin recorded models in resume commands

### DIFF
--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -273,11 +273,7 @@
   );
 
   let resumeModel = $derived(
-    messagesStore.sessionId === session?.id
-      && !messagesStore.loading
-      && !messagesStore.hasOlder
-      ? messagesStore.mainModel
-      : "",
+    session ? messagesStore.resumeModelFor(session.id) : "",
   );
 
   const gradeStyle = $derived(

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -272,6 +272,14 @@
       : "",
   );
 
+  let resumeModel = $derived(
+    messagesStore.sessionId === session?.id
+      && !messagesStore.loading
+      && !messagesStore.hasOlder
+      ? messagesStore.mainModel
+      : "",
+  );
+
   const gradeStyle = $derived(
     getGradeStyle(session?.health_grade),
   );
@@ -427,7 +435,9 @@
     } catch {
       // Fall back to local command build.
     }
-    const cmd = buildResumeCommand(session.agent, session.id);
+    const cmd = buildResumeCommand(session.agent, session.id, {
+      model: resumeModel,
+    });
     if (cmd) {
       const ok = await copyToClipboard(cmd);
       showFeedback(ok
@@ -459,7 +469,9 @@
     } catch {
       // Fall back to local build.
     }
-    const cmd = buildResumeCommand(session.agent, session.id);
+    const cmd = buildResumeCommand(session.agent, session.id, {
+      model: resumeModel,
+    });
     if (cmd) {
       const ok = await copyToClipboard(cmd);
       showFeedback(ok
@@ -528,7 +540,9 @@
     } catch {
       // Fall back to local command build.
     }
-    const cmd = buildResumeCommand(session.agent, session.id);
+    const cmd = buildResumeCommand(session.agent, session.id, {
+      model: resumeModel,
+    });
     if (cmd) {
       const ok = await copyToClipboard(cmd);
       showFeedback(ok

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
@@ -19,6 +19,7 @@ import {
 import { messages } from "../../stores/messages.svelte.js";
 import { setLocale } from "../../i18n/index.js";
 import { router } from "../../stores/router.svelte.js";
+import { copyToClipboard } from "../../utils/clipboard.js";
 
 const { generateForSession } = vi.hoisted(() => ({
   generateForSession: vi.fn(),
@@ -333,6 +334,300 @@ describe("SessionBreadcrumb", () => {
     });
 
     unmount(component);
+  });
+
+  it("keeps the backend default resume command authoritative when a local model exists", async () => {
+    vi.mocked(copyToClipboard).mockClear();
+    messages.sessionId = "run:123456789abcdef";
+    messages.messages = [makeAssistantMessage("claude sonnet")];
+    sessionsService.postApiV1SessionsIdResume.mockResolvedValue({
+      launched: false,
+      command: "claude --resume run:123456789abcdef",
+      cwd: "/tmp/project",
+    });
+
+    const component = mount(SessionBreadcrumb, {
+      target: document.body,
+      props: {
+        session: makeSession("claude", {
+          file_path: "/tmp/project/session.jsonl",
+        }),
+        onBack: () => {},
+      },
+    });
+
+    await tick();
+    document.querySelector<HTMLButtonElement>(".resume-btn")?.click();
+    await tick();
+    const defaultTerminal = Array.from(
+      document.querySelectorAll<HTMLButtonElement>(".open-menu-item"),
+    ).find((button) => button.textContent?.includes("Default terminal"));
+    defaultTerminal?.click();
+    await vi.waitFor(() => {
+      expect(copyToClipboard).toHaveBeenCalledWith(
+        "claude --resume run:123456789abcdef",
+      );
+    });
+
+    unmount(component);
+    messages.clear();
+  });
+
+  it("pins the active model when the backend resume request fails", async () => {
+    vi.mocked(copyToClipboard).mockClear();
+    messages.sessionId = "run:123456789abcdef";
+    messages.messages = [makeAssistantMessage("claude sonnet")];
+    sessionsService.postApiV1SessionsIdResume.mockRejectedValue(
+      new Error("backend unavailable"),
+    );
+
+    const component = mount(SessionBreadcrumb, {
+      target: document.body,
+      props: {
+        session: makeSession("claude"),
+        onBack: () => {},
+      },
+    });
+
+    await tick();
+    document.querySelector<HTMLButtonElement>(".resume-btn")?.click();
+    await tick();
+    const defaultTerminal = Array.from(
+      document.querySelectorAll<HTMLButtonElement>(".open-menu-item"),
+    ).find((button) => button.textContent?.includes("Default terminal"));
+    defaultTerminal?.click();
+    await vi.waitFor(() => {
+      expect(copyToClipboard).toHaveBeenCalledWith(
+        "claude --resume 'run:123456789abcdef' --model 'claude sonnet'",
+      );
+    });
+
+    unmount(component);
+    messages.clear();
+  });
+
+  it("does not pin a partial-history model when older messages remain unloaded", async () => {
+    vi.mocked(copyToClipboard).mockClear();
+    messages.sessionId = "run:123456789abcdef";
+    messages.messages = [makeAssistantMessage("claude sonnet")];
+    messages.hasOlder = true;
+    sessionsService.postApiV1SessionsIdResume.mockRejectedValue(
+      new Error("backend unavailable"),
+    );
+
+    const component = mount(SessionBreadcrumb, {
+      target: document.body,
+      props: {
+        session: makeSession("claude", { message_count: 3001 }),
+        onBack: () => {},
+      },
+    });
+
+    await tick();
+    document.querySelector<HTMLButtonElement>(".resume-btn")?.click();
+    await tick();
+    const defaultTerminal = Array.from(
+      document.querySelectorAll<HTMLButtonElement>(".open-menu-item"),
+    ).find((button) => button.textContent?.includes("Default terminal"));
+    defaultTerminal?.click();
+    await vi.waitFor(() => {
+      expect(copyToClipboard).toHaveBeenCalledWith(
+        "claude --resume 'run:123456789abcdef'",
+      );
+    });
+    expect(document.querySelector(".model-badge")?.textContent).toBe("claude sonnet");
+
+    unmount(component);
+    messages.clear();
+  });
+
+  it("does not pin a reloading stable model in the resume fallback", async () => {
+    vi.mocked(copyToClipboard).mockClear();
+    messages.sessionId = "run:123456789abcdef";
+    messages.loading = true;
+    (messages as any)._stableMainModel = "claude sonnet";
+    sessionsService.postApiV1SessionsIdResume.mockRejectedValue(
+      new Error("backend unavailable"),
+    );
+
+    const component = mount(SessionBreadcrumb, {
+      target: document.body,
+      props: {
+        session: makeSession("claude", { message_count: 3001 }),
+        onBack: () => {},
+      },
+    });
+
+    await tick();
+    document.querySelector<HTMLButtonElement>(".resume-btn")?.click();
+    await tick();
+    const defaultTerminal = Array.from(
+      document.querySelectorAll<HTMLButtonElement>(".open-menu-item"),
+    ).find((button) => button.textContent?.includes("Default terminal"));
+    defaultTerminal?.click();
+    await vi.waitFor(() => {
+      expect(copyToClipboard).toHaveBeenCalledWith(
+        "claude --resume 'run:123456789abcdef'",
+      );
+    });
+    expect(document.querySelector(".model-badge")?.textContent).toBe("claude sonnet");
+
+    unmount(component);
+    messages.clear();
+  });
+
+  it("pins the active model when handleResumeIn falls back locally", async () => {
+    vi.mocked(copyToClipboard).mockClear();
+    messages.sessionId = "run:123456789abcdef";
+    messages.messages = [makeAssistantMessage("claude sonnet")];
+    openersService.getApiV1Openers.mockResolvedValue({
+      openers: [{
+        id: "test-terminal",
+        name: "Test Terminal",
+        kind: "terminal",
+        bin: "wt.exe",
+      }],
+    });
+    sessionsService.postApiV1SessionsIdResume.mockRejectedValue(
+      new Error("backend unavailable"),
+    );
+
+    const component = mount(SessionBreadcrumb, {
+      target: document.body,
+      props: {
+        session: makeSession("claude"),
+        onBack: () => {},
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(document.querySelector(".resume-btn")).toBeTruthy();
+    });
+    document.querySelector<HTMLButtonElement>(".resume-btn")?.click();
+    await tick();
+    const opener = Array.from(
+      document.querySelectorAll<HTMLButtonElement>(".open-menu-item"),
+    ).find((button) => button.textContent?.includes("Test Terminal"));
+    opener?.click();
+    await vi.waitFor(() => {
+      expect(copyToClipboard).toHaveBeenCalledWith(
+        "claude --resume 'run:123456789abcdef' --model 'claude sonnet'",
+      );
+    });
+
+    unmount(component);
+    messages.clear();
+  });
+
+  it("keeps backend opener commands authoritative when a local model exists", async () => {
+    vi.mocked(copyToClipboard).mockClear();
+    messages.sessionId = "run:123456789abcdef";
+    messages.messages = [makeAssistantMessage("claude sonnet")];
+    openersService.getApiV1Openers.mockResolvedValue({
+      openers: [{
+        id: "test-terminal",
+        name: "Test Terminal",
+        kind: "terminal",
+        bin: "wt.exe",
+      }],
+    });
+    sessionsService.postApiV1SessionsIdResume.mockResolvedValue({
+      launched: false,
+      command: "claude --resume run:123456789abcdef",
+      cwd: "/tmp/project",
+    });
+
+    const component = mount(SessionBreadcrumb, {
+      target: document.body,
+      props: {
+        session: makeSession("claude"),
+        onBack: () => {},
+      },
+    });
+
+    await tick();
+    document.querySelector<HTMLButtonElement>(".resume-btn")?.click();
+    await tick();
+    const opener = Array.from(
+      document.querySelectorAll<HTMLButtonElement>(".open-menu-item"),
+    ).find((button) => button.textContent?.includes("Test Terminal"));
+    opener?.click();
+    await vi.waitFor(() => {
+      expect(copyToClipboard).toHaveBeenCalledWith(
+        "claude --resume run:123456789abcdef",
+      );
+    });
+
+    unmount(component);
+    messages.clear();
+  });
+
+  it("pins the active model when handleCopyResumeCommand falls back locally", async () => {
+    vi.mocked(copyToClipboard).mockClear();
+    messages.sessionId = "run:123456789abcdef";
+    messages.messages = [makeAssistantMessage("claude sonnet")];
+    sessionsService.postApiV1SessionsIdResume.mockRejectedValue(
+      new Error("backend unavailable"),
+    );
+
+    const component = mount(SessionBreadcrumb, {
+      target: document.body,
+      props: {
+        session: makeSession("claude"),
+        onBack: () => {},
+      },
+    });
+
+    await tick();
+    document.querySelector<HTMLButtonElement>(".resume-btn")?.click();
+    await tick();
+    const copyCommand = Array.from(
+      document.querySelectorAll<HTMLButtonElement>(".open-menu-item"),
+    ).find((button) => button.textContent?.includes("Copy command"));
+    copyCommand?.click();
+    await vi.waitFor(() => {
+      expect(copyToClipboard).toHaveBeenCalledWith(
+        "claude --resume 'run:123456789abcdef' --model 'claude sonnet'",
+      );
+    });
+
+    unmount(component);
+    messages.clear();
+  });
+
+  it("keeps backend command-only responses authoritative when a local model exists", async () => {
+    vi.mocked(copyToClipboard).mockClear();
+    messages.sessionId = "run:123456789abcdef";
+    messages.messages = [makeAssistantMessage("claude sonnet")];
+    sessionsService.postApiV1SessionsIdResume.mockResolvedValue({
+      launched: false,
+      command: "claude --resume run:123456789abcdef",
+      cwd: "/tmp/project",
+    });
+
+    const component = mount(SessionBreadcrumb, {
+      target: document.body,
+      props: {
+        session: makeSession("claude"),
+        onBack: () => {},
+      },
+    });
+
+    await tick();
+    document.querySelector<HTMLButtonElement>(".resume-btn")?.click();
+    await tick();
+    const copyCommand = Array.from(
+      document.querySelectorAll<HTMLButtonElement>(".open-menu-item"),
+    ).find((button) => button.textContent?.includes("Copy command"));
+    copyCommand?.click();
+    await vi.waitFor(() => {
+      expect(copyToClipboard).toHaveBeenCalledWith(
+        "claude --resume run:123456789abcdef",
+      );
+    });
+
+    unmount(component);
+    messages.clear();
   });
 
   it("offers a Codex Desktop deep link for a local terminal-created session", async () => {

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
@@ -1,21 +1,11 @@
 // @vitest-environment jsdom
-import {
-  describe,
-  it,
-  expect,
-  vi,
-  beforeEach,
-  afterEach,
-} from "vite-plus/test";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vite-plus/test";
 import { mount, unmount, tick } from "svelte";
 import { createClassComponent } from "svelte/legacy";
 // @ts-ignore
 import SessionBreadcrumb from "./SessionBreadcrumb.svelte";
 import type { Message, Session } from "../../api/types.js";
-import {
-  OpenersService,
-  SessionsService,
-} from "../../api/generated/index";
+import { OpenersService, SessionsService } from "../../api/generated/index";
 import { messages } from "../../stores/messages.svelte.js";
 import { setLocale } from "../../i18n/index.js";
 import { router } from "../../stores/router.svelte.js";
@@ -33,9 +23,7 @@ vi.mock("../../stores/insights.svelte.js", () => ({
 
 vi.mock("../../api/client.js", () => ({
   listOpeners: vi.fn().mockResolvedValue({ openers: [] }),
-  getSessionDirectory: vi
-    .fn()
-    .mockResolvedValue({ path: "" }),
+  getSessionDirectory: vi.fn().mockResolvedValue({ path: "" }),
   resumeSession: vi.fn(),
   openSession: vi.fn(),
 }));
@@ -45,8 +33,7 @@ vi.mock("../../utils/clipboard.js", () => ({
 }));
 
 vi.mock("../../api/generated/index", async (importOriginal) => {
-  const orig =
-    await importOriginal<typeof import("../../api/generated/index")>();
+  const orig = await importOriginal<typeof import("../../api/generated/index")>();
   return {
     ...orig,
     OpenersService: {
@@ -129,9 +116,7 @@ interface SessionUsageBreakdownEntry {
   has_cost: boolean;
 }
 
-function makeUsage(
-  overrides: Partial<SessionUsage> = {},
-): SessionUsage {
+function makeUsage(overrides: Partial<SessionUsage> = {}): SessionUsage {
   return {
     session_id: "run:123456789abcdef",
     agent: "claude",
@@ -151,9 +136,7 @@ function makeUsage(
 }
 
 async function openUsageBreakdown(): Promise<void> {
-  const details = document.querySelector<HTMLDetailsElement>(
-    ".usage-breakdown",
-  );
+  const details = document.querySelector<HTMLDetailsElement>(".usage-breakdown");
   expect(details).not.toBeNull();
   details!.open = true;
   details!.dispatchEvent(new Event("toggle"));
@@ -200,15 +183,9 @@ async function flushPromises() {
 
 beforeEach(() => {
   generateForSession.mockReset();
-  openersService.getApiV1Openers
-    .mockReset()
-    .mockResolvedValue({ openers: [] });
-  sessionsService.getApiV1SessionsIdDirectory
-    .mockReset()
-    .mockResolvedValue({ path: "" });
-  sessionsService.getApiV1SessionsIdUsage
-    .mockReset()
-    .mockResolvedValue(makeUsage());
+  openersService.getApiV1Openers.mockReset().mockResolvedValue({ openers: [] });
+  sessionsService.getApiV1SessionsIdDirectory.mockReset().mockResolvedValue({ path: "" });
+  sessionsService.getApiV1SessionsIdUsage.mockReset().mockResolvedValue(makeUsage());
   sessionsService.postApiV1SessionsIdResume.mockReset();
 });
 
@@ -249,30 +226,20 @@ describe("SessionBreadcrumb", () => {
     });
     await tick();
 
-    const backButton = document.querySelector<HTMLButtonElement>(
-      ".breadcrumb-link",
-    );
+    const backButton = document.querySelector<HTMLButtonElement>(".breadcrumb-link");
     expect(backButton?.textContent?.trim()).toBe("会话");
     expect(backButton?.getAttribute("title")).toBe("返回会话列表");
 
-    const linkButton = document.querySelector<HTMLButtonElement>(
-      ".link-btn",
-    );
+    const linkButton = document.querySelector<HTMLButtonElement>(".link-btn");
     expect(linkButton?.getAttribute("aria-label")).toBe("复制会话链接");
     expect(linkButton?.getAttribute("title")).toBe("复制会话链接");
 
-    const findButton = document.querySelector<HTMLButtonElement>(
-      ".find-btn",
-    );
+    const findButton = document.querySelector<HTMLButtonElement>(".find-btn");
     expect(findButton?.getAttribute("aria-label")).toBe("在会话中查找");
     expect(findButton?.getAttribute("title")).toBe("在会话中查找 (/)");
 
-    const resumeButton = document.querySelector<HTMLButtonElement>(
-      ".resume-btn",
-    );
-    expect(resumeButton?.textContent?.replace(/\s+/g, " ").trim()).toBe(
-      "继续",
-    );
+    const resumeButton = document.querySelector<HTMLButtonElement>(".resume-btn");
+    expect(resumeButton?.textContent?.replace(/\s+/g, " ").trim()).toBe("继续");
     resumeButton?.click();
     await tick();
 
@@ -282,9 +249,7 @@ describe("SessionBreadcrumb", () => {
     expect(document.body.textContent).toContain("打开方式");
     expect(document.body.textContent).toContain("VS Code");
 
-    const actionsButton = document.querySelector<HTMLButtonElement>(
-      ".actions-btn",
-    );
+    const actionsButton = document.querySelector<HTMLButtonElement>(".actions-btn");
     expect(actionsButton?.getAttribute("aria-label")).toBe("会话操作");
     actionsButton?.click();
     await tick();
@@ -320,9 +285,7 @@ describe("SessionBreadcrumb", () => {
     document.querySelector<HTMLButtonElement>(".resume-btn")?.click();
     await tick();
 
-    const resumeItem = document.querySelector<HTMLButtonElement>(
-      ".open-menu-item",
-    );
+    const resumeItem = document.querySelector<HTMLButtonElement>(".open-menu-item");
     expect(resumeItem).toBeTruthy();
     resumeItem!.click();
     await Promise.resolve();
@@ -340,6 +303,7 @@ describe("SessionBreadcrumb", () => {
     vi.mocked(copyToClipboard).mockClear();
     messages.sessionId = "run:123456789abcdef";
     messages.messages = [makeAssistantMessage("claude sonnet")];
+    messages.historyComplete = true;
     sessionsService.postApiV1SessionsIdResume.mockResolvedValue({
       launched: false,
       command: "claude --resume run:123456789abcdef",
@@ -364,9 +328,7 @@ describe("SessionBreadcrumb", () => {
     ).find((button) => button.textContent?.includes("Default terminal"));
     defaultTerminal?.click();
     await vi.waitFor(() => {
-      expect(copyToClipboard).toHaveBeenCalledWith(
-        "claude --resume run:123456789abcdef",
-      );
+      expect(copyToClipboard).toHaveBeenCalledWith("claude --resume run:123456789abcdef");
     });
 
     unmount(component);
@@ -377,9 +339,8 @@ describe("SessionBreadcrumb", () => {
     vi.mocked(copyToClipboard).mockClear();
     messages.sessionId = "run:123456789abcdef";
     messages.messages = [makeAssistantMessage("claude sonnet")];
-    sessionsService.postApiV1SessionsIdResume.mockRejectedValue(
-      new Error("backend unavailable"),
-    );
+    messages.historyComplete = true;
+    sessionsService.postApiV1SessionsIdResume.mockRejectedValue(new Error("backend unavailable"));
 
     const component = mount(SessionBreadcrumb, {
       target: document.body,
@@ -410,10 +371,9 @@ describe("SessionBreadcrumb", () => {
     vi.mocked(copyToClipboard).mockClear();
     messages.sessionId = "run:123456789abcdef";
     messages.messages = [makeAssistantMessage("claude sonnet")];
+    messages.historyComplete = false;
     messages.hasOlder = true;
-    sessionsService.postApiV1SessionsIdResume.mockRejectedValue(
-      new Error("backend unavailable"),
-    );
+    sessionsService.postApiV1SessionsIdResume.mockRejectedValue(new Error("backend unavailable"));
 
     const component = mount(SessionBreadcrumb, {
       target: document.body,
@@ -431,9 +391,7 @@ describe("SessionBreadcrumb", () => {
     ).find((button) => button.textContent?.includes("Default terminal"));
     defaultTerminal?.click();
     await vi.waitFor(() => {
-      expect(copyToClipboard).toHaveBeenCalledWith(
-        "claude --resume 'run:123456789abcdef'",
-      );
+      expect(copyToClipboard).toHaveBeenCalledWith("claude --resume 'run:123456789abcdef'");
     });
     expect(document.querySelector(".model-badge")?.textContent).toBe("claude sonnet");
 
@@ -446,9 +404,7 @@ describe("SessionBreadcrumb", () => {
     messages.sessionId = "run:123456789abcdef";
     messages.loading = true;
     (messages as any)._stableMainModel = "claude sonnet";
-    sessionsService.postApiV1SessionsIdResume.mockRejectedValue(
-      new Error("backend unavailable"),
-    );
+    sessionsService.postApiV1SessionsIdResume.mockRejectedValue(new Error("backend unavailable"));
 
     const component = mount(SessionBreadcrumb, {
       target: document.body,
@@ -466,9 +422,7 @@ describe("SessionBreadcrumb", () => {
     ).find((button) => button.textContent?.includes("Default terminal"));
     defaultTerminal?.click();
     await vi.waitFor(() => {
-      expect(copyToClipboard).toHaveBeenCalledWith(
-        "claude --resume 'run:123456789abcdef'",
-      );
+      expect(copyToClipboard).toHaveBeenCalledWith("claude --resume 'run:123456789abcdef'");
     });
     expect(document.querySelector(".model-badge")?.textContent).toBe("claude sonnet");
 
@@ -480,17 +434,18 @@ describe("SessionBreadcrumb", () => {
     vi.mocked(copyToClipboard).mockClear();
     messages.sessionId = "run:123456789abcdef";
     messages.messages = [makeAssistantMessage("claude sonnet")];
+    messages.historyComplete = true;
     openersService.getApiV1Openers.mockResolvedValue({
-      openers: [{
-        id: "test-terminal",
-        name: "Test Terminal",
-        kind: "terminal",
-        bin: "wt.exe",
-      }],
+      openers: [
+        {
+          id: "test-terminal",
+          name: "Test Terminal",
+          kind: "terminal",
+          bin: "wt.exe",
+        },
+      ],
     });
-    sessionsService.postApiV1SessionsIdResume.mockRejectedValue(
-      new Error("backend unavailable"),
-    );
+    sessionsService.postApiV1SessionsIdResume.mockRejectedValue(new Error("backend unavailable"));
 
     const component = mount(SessionBreadcrumb, {
       target: document.body,
@@ -505,9 +460,9 @@ describe("SessionBreadcrumb", () => {
     });
     document.querySelector<HTMLButtonElement>(".resume-btn")?.click();
     await tick();
-    const opener = Array.from(
-      document.querySelectorAll<HTMLButtonElement>(".open-menu-item"),
-    ).find((button) => button.textContent?.includes("Test Terminal"));
+    const opener = Array.from(document.querySelectorAll<HTMLButtonElement>(".open-menu-item")).find(
+      (button) => button.textContent?.includes("Test Terminal"),
+    );
     opener?.click();
     await vi.waitFor(() => {
       expect(copyToClipboard).toHaveBeenCalledWith(
@@ -524,12 +479,14 @@ describe("SessionBreadcrumb", () => {
     messages.sessionId = "run:123456789abcdef";
     messages.messages = [makeAssistantMessage("claude sonnet")];
     openersService.getApiV1Openers.mockResolvedValue({
-      openers: [{
-        id: "test-terminal",
-        name: "Test Terminal",
-        kind: "terminal",
-        bin: "wt.exe",
-      }],
+      openers: [
+        {
+          id: "test-terminal",
+          name: "Test Terminal",
+          kind: "terminal",
+          bin: "wt.exe",
+        },
+      ],
     });
     sessionsService.postApiV1SessionsIdResume.mockResolvedValue({
       launched: false,
@@ -548,14 +505,12 @@ describe("SessionBreadcrumb", () => {
     await tick();
     document.querySelector<HTMLButtonElement>(".resume-btn")?.click();
     await tick();
-    const opener = Array.from(
-      document.querySelectorAll<HTMLButtonElement>(".open-menu-item"),
-    ).find((button) => button.textContent?.includes("Test Terminal"));
+    const opener = Array.from(document.querySelectorAll<HTMLButtonElement>(".open-menu-item")).find(
+      (button) => button.textContent?.includes("Test Terminal"),
+    );
     opener?.click();
     await vi.waitFor(() => {
-      expect(copyToClipboard).toHaveBeenCalledWith(
-        "claude --resume run:123456789abcdef",
-      );
+      expect(copyToClipboard).toHaveBeenCalledWith("claude --resume run:123456789abcdef");
     });
 
     unmount(component);
@@ -566,9 +521,8 @@ describe("SessionBreadcrumb", () => {
     vi.mocked(copyToClipboard).mockClear();
     messages.sessionId = "run:123456789abcdef";
     messages.messages = [makeAssistantMessage("claude sonnet")];
-    sessionsService.postApiV1SessionsIdResume.mockRejectedValue(
-      new Error("backend unavailable"),
-    );
+    messages.historyComplete = true;
+    sessionsService.postApiV1SessionsIdResume.mockRejectedValue(new Error("backend unavailable"));
 
     const component = mount(SessionBreadcrumb, {
       target: document.body,
@@ -621,9 +575,7 @@ describe("SessionBreadcrumb", () => {
     ).find((button) => button.textContent?.includes("Copy command"));
     copyCommand?.click();
     await vi.waitFor(() => {
-      expect(copyToClipboard).toHaveBeenCalledWith(
-        "claude --resume run:123456789abcdef",
-      );
+      expect(copyToClipboard).toHaveBeenCalledWith("claude --resume run:123456789abcdef");
     });
 
     unmount(component);
@@ -645,24 +597,16 @@ describe("SessionBreadcrumb", () => {
     document.querySelector<HTMLButtonElement>(".resume-btn")?.click();
     await tick();
 
-    const link = document.querySelector<HTMLAnchorElement>(
-      '[data-testid="codex-desktop-link"]',
-    );
+    const link = document.querySelector<HTMLAnchorElement>('[data-testid="codex-desktop-link"]');
     expect(link).toBeTruthy();
-    expect(link?.getAttribute("href")).toBe(
-      "codex://threads/terminal-session-123",
-    );
+    expect(link?.getAttribute("href")).toBe("codex://threads/terminal-session-123");
     expect(link?.textContent).toContain("Codex Desktop");
 
-    const menuLabels = Array.from(
-      document.querySelectorAll(".open-menu-name"),
-    ).map((node) => node.textContent?.trim());
-    const codexMenuIndex = menuLabels.findIndex((label) =>
-      label?.includes("Codex Desktop"),
+    const menuLabels = Array.from(document.querySelectorAll(".open-menu-name")).map((node) =>
+      node.textContent?.trim(),
     );
-    expect(codexMenuIndex).toBeLessThan(
-      menuLabels.indexOf("Copy command"),
-    );
+    const codexMenuIndex = menuLabels.findIndex((label) => label?.includes("Codex Desktop"));
+    expect(codexMenuIndex).toBeLessThan(menuLabels.indexOf("Copy command"));
 
     await unmount(component);
   });
@@ -679,12 +623,8 @@ describe("SessionBreadcrumb", () => {
     await tick();
     const badge = document.querySelector(".agent-badge");
     expect(badge).toBeTruthy();
-    expect(badge?.getAttribute("style")).toContain(
-      "var(--accent-rose)",
-    );
-    expect(badge?.getAttribute("style")).toContain(
-      "var(--accent-rose-foreground)",
-    );
+    expect(badge?.getAttribute("style")).toContain("var(--accent-rose)");
+    expect(badge?.getAttribute("style")).toContain("var(--accent-rose-foreground)");
 
     unmount(component);
   });
@@ -708,12 +648,10 @@ describe("SessionBreadcrumb", () => {
 
     await vi.waitFor(() => {
       expect(
-        document.querySelector<HTMLAnchorElement>(
-          '[data-testid="claude-code-link"]',
-        )?.getAttribute("href"),
-      ).toBe(
-        "claude://code/new?folder=%2Ftmp%2Fclaude%20project",
-      );
+        document
+          .querySelector<HTMLAnchorElement>('[data-testid="claude-code-link"]')
+          ?.getAttribute("href"),
+      ).toBe("claude://code/new?folder=%2Ftmp%2Fclaude%20project");
     });
 
     await unmount(component);
@@ -730,12 +668,8 @@ describe("SessionBreadcrumb", () => {
 
     await tick();
     const badge = document.querySelector(".agent-badge");
-    expect(badge?.getAttribute("style")).toContain(
-      "var(--accent-blue)",
-    );
-    expect(badge?.getAttribute("style")).toContain(
-      "var(--accent-blue-foreground)",
-    );
+    expect(badge?.getAttribute("style")).toContain("var(--accent-blue)");
+    expect(badge?.getAttribute("style")).toContain("var(--accent-blue-foreground)");
 
     unmount(component);
   });
@@ -763,21 +697,15 @@ describe("SessionBreadcrumb", () => {
       expect(linkBtn).toBeTruthy();
 
       // First copy
-      linkBtn!.dispatchEvent(
-        new MouseEvent("click", { bubbles: true }),
-      );
+      linkBtn!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
       await tick();
       await vi.advanceTimersByTimeAsync(0);
       await tick();
-      expect(
-        linkBtn!.classList.contains("link-btn--copied"),
-      ).toBe(true);
+      expect(linkBtn!.classList.contains("link-btn--copied")).toBe(true);
 
       // Advance 1s, then copy again
       await vi.advanceTimersByTimeAsync(1000);
-      linkBtn!.dispatchEvent(
-        new MouseEvent("click", { bubbles: true }),
-      );
+      linkBtn!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
       await tick();
       await vi.advanceTimersByTimeAsync(0);
       await tick();
@@ -786,16 +714,12 @@ describe("SessionBreadcrumb", () => {
       // would have expired, but it was cleared
       await vi.advanceTimersByTimeAsync(600);
       await tick();
-      expect(
-        linkBtn!.classList.contains("link-btn--copied"),
-      ).toBe(true);
+      expect(linkBtn!.classList.contains("link-btn--copied")).toBe(true);
 
       // After full 1.5s from second click, state clears
       await vi.advanceTimersByTimeAsync(900);
       await tick();
-      expect(
-        linkBtn!.classList.contains("link-btn--copied"),
-      ).toBe(false);
+      expect(linkBtn!.classList.contains("link-btn--copied")).toBe(false);
 
       unmount(component);
     });
@@ -817,9 +741,7 @@ describe("SessionBreadcrumb", () => {
 
     await tick();
     const tokenBadge = document.querySelector(".token-badge");
-    expect(tokenBadge?.textContent?.replace(/\s+/g, " ").trim()).toBe(
-      "2.4k ctx / 180 out",
-    );
+    expect(tokenBadge?.textContent?.replace(/\s+/g, " ").trim()).toBe("2.4k ctx / 180 out");
 
     unmount(component);
   });
@@ -864,9 +786,7 @@ describe("SessionBreadcrumb", () => {
 
     await tick();
     const tokenBadge = document.querySelector(".token-badge");
-    expect(tokenBadge?.textContent?.replace(/\s+/g, " ").trim()).toBe(
-      "— ctx / 180 out",
-    );
+    expect(tokenBadge?.textContent?.replace(/\s+/g, " ").trim()).toBe("— ctx / 180 out");
 
     unmount(component);
   });
@@ -887,12 +807,8 @@ describe("SessionBreadcrumb", () => {
 
     await tick();
 
-    const mobileTokenBadge = document.querySelector(
-      ".token-badge--mobile",
-    );
-    expect(
-      mobileTokenBadge?.textContent?.replace(/\s+/g, " ").trim(),
-    ).toBe("2.4k ctx / 180 out");
+    const mobileTokenBadge = document.querySelector(".token-badge--mobile");
+    expect(mobileTokenBadge?.textContent?.replace(/\s+/g, " ").trim()).toBe("2.4k ctx / 180 out");
 
     unmount(component);
   });
@@ -961,9 +877,7 @@ describe("SessionBreadcrumb", () => {
       const badge = document.querySelector(".malformed-badge");
       expect(badge).toBeTruthy();
       expect(badge?.textContent?.trim()).toBe("3 malformed lines");
-      expect(badge?.getAttribute("title")).toBe(
-        "3 lines in the source file could not be parsed",
-      );
+      expect(badge?.getAttribute("title")).toBe("3 lines in the source file could not be parsed");
       unmount(component);
     });
 
@@ -980,9 +894,7 @@ describe("SessionBreadcrumb", () => {
       await tick();
       const badge = document.querySelector(".malformed-badge");
       expect(badge?.textContent?.trim()).toBe("1 malformed line");
-      expect(badge?.getAttribute("title")).toBe(
-        "1 line in the source file could not be parsed",
-      );
+      expect(badge?.getAttribute("title")).toBe("1 line in the source file could not be parsed");
       unmount(component);
     });
 
@@ -1029,9 +941,7 @@ describe("SessionBreadcrumb", () => {
       await tick();
       const badge = document.querySelector(".decode-badge");
       expect(badge).toBeTruthy();
-      expect(badge?.textContent?.trim().toLowerCase()).toContain(
-        "unverified schema",
-      );
+      expect(badge?.textContent?.trim().toLowerCase()).toContain("unverified schema");
       unmount(component);
     });
 
@@ -1176,12 +1086,8 @@ describe("SessionBreadcrumb", () => {
       const mobileTokenIdx = children.findIndex((el) =>
         el.classList.contains("token-badge--mobile"),
       );
-      const costIdx = children.findIndex((el) =>
-        el.classList.contains("cost-badge"),
-      );
-      const modelIdx = children.findIndex((el) =>
-        el.classList.contains("model-badge"),
-      );
+      const costIdx = children.findIndex((el) => el.classList.contains("cost-badge"));
+      const modelIdx = children.findIndex((el) => el.classList.contains("model-badge"));
 
       expect(desktopTokenIdx).toBeGreaterThanOrEqual(0);
       expect(mobileTokenIdx).toBeGreaterThan(desktopTokenIdx);
@@ -1206,9 +1112,7 @@ describe("SessionBreadcrumb", () => {
 
       await flushPromises();
       await vi.waitFor(() => {
-        expect(
-          sessionsService.getApiV1SessionsIdUsage,
-        ).toHaveBeenCalled();
+        expect(sessionsService.getApiV1SessionsIdUsage).toHaveBeenCalled();
       });
       await flushPromises();
       expect(document.querySelector(".cost-badge")).toBeNull();
@@ -1217,9 +1121,7 @@ describe("SessionBreadcrumb", () => {
     });
 
     it("renders no cost badge when the usage request fails", async () => {
-      sessionsService.getApiV1SessionsIdUsage.mockRejectedValue(
-        new Error("boom"),
-      );
+      sessionsService.getApiV1SessionsIdUsage.mockRejectedValue(new Error("boom"));
 
       const component = mount(SessionBreadcrumb, {
         target: document.body,
@@ -1231,9 +1133,7 @@ describe("SessionBreadcrumb", () => {
 
       await flushPromises();
       await vi.waitFor(() => {
-        expect(
-          sessionsService.getApiV1SessionsIdUsage,
-        ).toHaveBeenCalled();
+        expect(sessionsService.getApiV1SessionsIdUsage).toHaveBeenCalled();
       });
       await flushPromises();
       expect(document.querySelector(".cost-badge")).toBeNull();
@@ -1297,32 +1197,22 @@ describe("SessionBreadcrumb", () => {
       });
 
       await vi.waitFor(() => {
-        expect(
-          document.querySelector(".usage-breakdown-trigger")
-            ?.textContent
-            ?.trim(),
-        ).toBe("2 steps");
+        expect(document.querySelector(".usage-breakdown-trigger")?.textContent?.trim()).toBe(
+          "2 steps",
+        );
       });
-      expect(
-        document.querySelectorAll(".usage-breakdown-row"),
-      ).toHaveLength(0);
-      expect(
-        sessionsService.getApiV1SessionsIdUsage,
-      ).toHaveBeenCalledTimes(1);
-      expect(
-        sessionsService.getApiV1SessionsIdUsage,
-      ).toHaveBeenCalledWith({ id: "run:123456789abcdef" });
+      expect(document.querySelectorAll(".usage-breakdown-row")).toHaveLength(0);
+      expect(sessionsService.getApiV1SessionsIdUsage).toHaveBeenCalledTimes(1);
+      expect(sessionsService.getApiV1SessionsIdUsage).toHaveBeenCalledWith({
+        id: "run:123456789abcdef",
+      });
 
       await openUsageBreakdown();
-      expect(
-        sessionsService.getApiV1SessionsIdUsage,
-      ).toHaveBeenCalledWith({
+      expect(sessionsService.getApiV1SessionsIdUsage).toHaveBeenCalledWith({
         id: "run:123456789abcdef",
         breakdown: true,
       });
-      const renderedRows = Array.from(
-        document.querySelectorAll(".usage-breakdown-row"),
-      );
+      const renderedRows = Array.from(document.querySelectorAll(".usage-breakdown-row"));
       expect(renderedRows).toHaveLength(2);
       const first = renderedRows[0]!;
       const second = renderedRows[1]!;
@@ -1337,9 +1227,7 @@ describe("SessionBreadcrumb", () => {
     });
 
     it("renders no usage breakdown when the usage response counts no rows", async () => {
-      sessionsService.getApiV1SessionsIdUsage.mockResolvedValue(
-        makeUsage({ breakdown_count: 0 }),
-      );
+      sessionsService.getApiV1SessionsIdUsage.mockResolvedValue(makeUsage({ breakdown_count: 0 }));
 
       const component = mount(SessionBreadcrumb, {
         target: document.body,
@@ -1351,9 +1239,7 @@ describe("SessionBreadcrumb", () => {
 
       await flushPromises();
       await vi.waitFor(() => {
-        expect(
-          sessionsService.getApiV1SessionsIdUsage,
-        ).toHaveBeenCalled();
+        expect(sessionsService.getApiV1SessionsIdUsage).toHaveBeenCalled();
       });
       expect(document.querySelector(".usage-breakdown")).toBeNull();
 
@@ -1394,16 +1280,12 @@ describe("SessionBreadcrumb", () => {
       });
 
       await vi.waitFor(() => {
-        expect(
-          document.querySelector(".usage-breakdown-trigger")
-            ?.textContent
-            ?.trim(),
-        ).toBe("8 steps");
+        expect(document.querySelector(".usage-breakdown-trigger")?.textContent?.trim()).toBe(
+          "8 steps",
+        );
       });
       await openUsageBreakdown();
-      expect(
-        document.querySelectorAll(".usage-breakdown-row"),
-      ).toHaveLength(8);
+      expect(document.querySelectorAll(".usage-breakdown-row")).toHaveLength(8);
 
       unmount(component);
     });
@@ -1412,9 +1294,7 @@ describe("SessionBreadcrumb", () => {
       const rowsFetch = deferred<SessionUsage>();
       sessionsService.getApiV1SessionsIdUsage.mockImplementation(
         ({ breakdown }: { id: string; breakdown?: boolean }) =>
-          breakdown
-            ? rowsFetch.promise
-            : Promise.resolve(makeUsage({ breakdown_count: 1 })),
+          breakdown ? rowsFetch.promise : Promise.resolve(makeUsage({ breakdown_count: 1 })),
       );
 
       const component = mount(SessionBreadcrumb, {
@@ -1426,21 +1306,15 @@ describe("SessionBreadcrumb", () => {
       });
 
       await vi.waitFor(() => {
-        expect(
-          document.querySelector(".usage-breakdown-trigger")
-            ?.textContent
-            ?.trim(),
-        ).toBe("1 step");
+        expect(document.querySelector(".usage-breakdown-trigger")?.textContent?.trim()).toBe(
+          "1 step",
+        );
       });
       await openUsageBreakdown();
-      expect(
-        document.querySelector(".usage-breakdown-status")
-          ?.textContent
-          ?.trim(),
-      ).toBe("Loading usage...");
-      expect(
-        document.querySelectorAll(".usage-breakdown-row"),
-      ).toHaveLength(0);
+      expect(document.querySelector(".usage-breakdown-status")?.textContent?.trim()).toBe(
+        "Loading usage...",
+      );
+      expect(document.querySelectorAll(".usage-breakdown-row")).toHaveLength(0);
 
       rowsFetch.resolve(
         makeUsage({
@@ -1464,9 +1338,7 @@ describe("SessionBreadcrumb", () => {
       );
       await flushPromises();
       expect(document.querySelector(".usage-breakdown-status")).toBeNull();
-      expect(
-        document.querySelectorAll(".usage-breakdown-row"),
-      ).toHaveLength(1);
+      expect(document.querySelectorAll(".usage-breakdown-row")).toHaveLength(1);
 
       unmount(component);
     });
@@ -1488,21 +1360,13 @@ describe("SessionBreadcrumb", () => {
       });
 
       await vi.waitFor(() => {
-        expect(
-          document.querySelector(".usage-breakdown-trigger")
-            ?.textContent
-            ?.trim(),
-        ).toBe("3 steps");
+        expect(document.querySelector(".usage-breakdown-trigger")?.textContent?.trim()).toBe(
+          "3 steps",
+        );
       });
       await openUsageBreakdown();
-      expect(
-        document.querySelector(".usage-breakdown-status")
-          ?.textContent
-          ?.trim(),
-      ).toBe("Failed");
-      expect(
-        document.querySelectorAll(".usage-breakdown-row"),
-      ).toHaveLength(0);
+      expect(document.querySelector(".usage-breakdown-status")?.textContent?.trim()).toBe("Failed");
+      expect(document.querySelectorAll(".usage-breakdown-row")).toHaveLength(0);
 
       unmount(component);
     });
@@ -1558,9 +1422,7 @@ describe("SessionBreadcrumb", () => {
         expect(badge?.textContent?.trim()).toBe("$2.00");
       });
       await openUsageBreakdown();
-      expect(
-        document.querySelector(".usage-breakdown-row")?.textContent,
-      ).toContain("gpt-5.4");
+      expect(document.querySelector(".usage-breakdown-row")?.textContent).toContain("gpt-5.4");
 
       // The first session's response arrives late and must not
       // overwrite the newer session's cost or step count.
@@ -1573,29 +1435,19 @@ describe("SessionBreadcrumb", () => {
         }),
       );
       await flushPromises();
-      expect(
-        document.querySelector(".cost-badge")?.textContent?.trim(),
-      ).toBe("$2.00");
-      expect(
-        document.querySelector(".usage-breakdown-trigger")
-          ?.textContent
-          ?.trim(),
-      ).toBe("1 step");
-      expect(
-        document.querySelector(".usage-breakdown-row")?.textContent,
-      ).toContain("gpt-5.4");
+      expect(document.querySelector(".cost-badge")?.textContent?.trim()).toBe("$2.00");
+      expect(document.querySelector(".usage-breakdown-trigger")?.textContent?.trim()).toBe(
+        "1 step",
+      );
+      expect(document.querySelector(".usage-breakdown-row")?.textContent).toContain("gpt-5.4");
 
       component.$destroy();
     });
 
     it("refetches when a resync changes context tokens without output movement", async () => {
       sessionsService.getApiV1SessionsIdUsage
-        .mockResolvedValueOnce(
-          makeUsage({ has_cost: true, cost_usd: 1 }),
-        )
-        .mockResolvedValueOnce(
-          makeUsage({ has_cost: true, cost_usd: 1.75 }),
-        );
+        .mockResolvedValueOnce(makeUsage({ has_cost: true, cost_usd: 1 }))
+        .mockResolvedValueOnce(makeUsage({ has_cost: true, cost_usd: 1.75 }));
 
       const component = createClassComponent({
         component: SessionBreadcrumb,
@@ -1619,9 +1471,7 @@ describe("SessionBreadcrumb", () => {
         const badge = document.querySelector(".cost-badge");
         expect(badge?.textContent?.trim()).toBe("$1.75");
       });
-      expect(
-        sessionsService.getApiV1SessionsIdUsage,
-      ).toHaveBeenCalledTimes(2);
+      expect(sessionsService.getApiV1SessionsIdUsage).toHaveBeenCalledTimes(2);
 
       component.$destroy();
     });
@@ -1663,9 +1513,7 @@ describe("SessionBreadcrumb", () => {
         session: makeSession("claude", { id: "run:aaa" }),
       });
       await flushPromises();
-      expect(
-        sessionsService.getApiV1SessionsIdUsage,
-      ).toHaveBeenCalledTimes(3);
+      expect(sessionsService.getApiV1SessionsIdUsage).toHaveBeenCalledTimes(3);
 
       // B's late response must not be shown on A.
       bRequest.resolve(
@@ -1717,9 +1565,7 @@ describe("SessionBreadcrumb", () => {
         session: makeSession("claude", { message_count: 3 }),
       });
       await flushPromises();
-      expect(
-        sessionsService.getApiV1SessionsIdUsage,
-      ).toHaveBeenCalledTimes(2);
+      expect(sessionsService.getApiV1SessionsIdUsage).toHaveBeenCalledTimes(2);
 
       second.resolve(makeUsage({ has_cost: true, cost_usd: 3.5 }));
       await vi.waitFor(() => {
@@ -1729,12 +1575,9 @@ describe("SessionBreadcrumb", () => {
 
       first.resolve(makeUsage({ has_cost: true, cost_usd: 1 }));
       await flushPromises();
-      expect(
-        document.querySelector(".cost-badge")?.textContent?.trim(),
-      ).toBe("$3.50");
+      expect(document.querySelector(".cost-badge")?.textContent?.trim()).toBe("$3.50");
 
       component.$destroy();
     });
   });
-
 });

--- a/frontend/src/lib/stores/messages.svelte.ts
+++ b/frontend/src/lib/stores/messages.svelte.ts
@@ -1,22 +1,9 @@
-import {
-  SessionsService,
-} from "../api/generated/index";
-import type {
-  Message,
-  MessagesResponse,
-  Session,
-} from "../api/types.js";
-import {
-  configureGeneratedClient,
-  isAbortError,
-  withAbort,
-} from "../api/runtime.js";
+import { SessionsService } from "../api/generated/index";
+import type { Message, MessagesResponse, Session } from "../api/types.js";
+import { configureGeneratedClient, isAbortError, withAbort } from "../api/runtime.js";
 import { clearContentCaches } from "../utils/content-parser.js";
 import { computeMainModel } from "../utils/model.js";
-import {
-  buildReadProgressToken,
-  readProgress,
-} from "./read-progress.svelte.js";
+import { buildReadProgressToken, readProgress } from "./read-progress.svelte.js";
 
 const MESSAGE_PAGE_SIZE = 1000;
 const FULL_SESSION_MESSAGE_THRESHOLD = 3_000;
@@ -37,6 +24,8 @@ class MessagesStore {
   activeSessionUnreadOrdinal: number | null = $state(null);
   hasOlder: boolean = $state(false);
   loadingOlder: boolean = $state(false);
+  historyComplete: boolean = $state(false);
+  private reloading: boolean = $state(false);
   private _stableMainModel: string = $state("");
   mainModel: string = $derived(
     this.loading
@@ -54,11 +43,18 @@ class MessagesStore {
   private hasPendingSessionToken: boolean = false;
   private pendingSessionUnreadOrdinal: number | null = null;
 
+  resumeModelFor(sessionId: string): string {
+    return this.sessionId === sessionId &&
+      this.historyComplete &&
+      !this.loading &&
+      !this.loadingOlder &&
+      !this.reloading
+      ? this.mainModel
+      : "";
+  }
+
   async loadSession(id: string) {
-    if (
-      this.sessionId === id &&
-      (this.messages.length > 0 || this.loading)
-    ) {
+    if (this.sessionId === id && (this.messages.length > 0 || this.loading)) {
       return;
     }
     const readMarker = readProgress.get(id);
@@ -85,42 +81,29 @@ class MessagesStore {
         pendingToken = buildReadProgressToken(sess);
       } catch (err) {
         if (isAbortError(err)) return;
-        console.warn(
-          "Failed to fetch session metadata:",
-          err,
-        );
+        console.warn("Failed to fetch session metadata:", err);
       }
 
-      if (
-        countHint !== null &&
-        countHint > FULL_SESSION_MESSAGE_THRESHOLD
-      ) {
+      if (countHint !== null && countHint > FULL_SESSION_MESSAGE_THRESHOLD) {
         await this.loadProgressively(id, ac.signal);
       } else {
-        await this.loadAllMessages(
-          id,
-          ac.signal,
-          countHint ?? undefined,
-        );
+        await this.loadAllMessages(id, ac.signal, countHint ?? undefined);
       }
       if (this.sessionId === id) {
         this.publishOrDeferSessionToken(
           pendingToken,
           null,
-          readMarker !== null &&
-            readMarker.token !== pendingToken,
+          readMarker !== null && readMarker.token !== pendingToken,
         );
       }
     } catch (err) {
       if (isAbortError(err)) return;
+      if (this.sessionId === id) this.historyComplete = false;
       console.warn("Failed to load session messages:", err);
     } finally {
       if (this.sessionId === id) {
         this.loading = false;
-        this._stableMainModel =
-          this.messages.length > 0
-            ? computeMainModel(this.messages)
-            : "";
+        this._stableMainModel = this.messages.length > 0 ? computeMainModel(this.messages) : "";
       }
     }
   }
@@ -128,25 +111,26 @@ class MessagesStore {
   reload(): Promise<void> {
     if (!this.sessionId) return Promise.resolve();
 
-    if (
-      this.reloadPromise &&
-      this.reloadSessionId === this.sessionId
-    ) {
+    if (this.reloadPromise && this.reloadSessionId === this.sessionId) {
       this.pendingReload = true;
       return this.reloadPromise;
     }
 
     const id = this.sessionId;
     this.reloadSessionId = id;
+    this.reloading = true;
 
     const promise = this.reloadNow(id).finally(async () => {
       if (this.reloadPromise === promise) {
         this.reloadPromise = null;
         this.reloadSessionId = null;
       }
-      if (this.pendingReload && this.sessionId === id) {
+      const shouldReload = this.pendingReload && this.sessionId === id;
+      if (shouldReload) {
         this.pendingReload = false;
         await this.reload();
+      } else if (this.sessionId === id) {
+        this.reloading = false;
       }
     });
     this.reloadPromise = promise;
@@ -166,6 +150,8 @@ class MessagesStore {
     this.activeSessionUnreadOrdinal = null;
     this.hasOlder = false;
     this.loadingOlder = false;
+    this.historyComplete = false;
+    this.reloading = false;
     this.reloadPromise = null;
     this.reloadSessionId = null;
     this.pendingReload = false;
@@ -175,10 +161,7 @@ class MessagesStore {
     this.pendingSessionUnreadOrdinal = null;
   }
 
-  private async fetchPages(
-    id: string,
-    opts: FetchPageOptions,
-  ): Promise<Message[]> {
+  private async fetchPages(id: string, opts: FetchPageOptions): Promise<Message[]> {
     const loaded: Message[] = [];
     let from = opts.from;
 
@@ -201,15 +184,8 @@ class MessagesStore {
       const last = res.messages[res.messages.length - 1];
       if (!last) break;
 
-      const nextFrom =
-        opts.direction === "asc"
-          ? last.ordinal + 1
-          : last.ordinal - 1;
-      if (
-        opts.direction === "asc"
-          ? nextFrom <= from
-          : nextFrom >= from
-      ) {
+      const nextFrom = opts.direction === "asc" ? last.ordinal + 1 : last.ordinal - 1;
+      if (opts.direction === "asc" ? nextFrom <= from : nextFrom >= from) {
         break;
       }
       from = nextFrom;
@@ -218,13 +194,10 @@ class MessagesStore {
     return loaded;
   }
 
-  private async loadAllMessages(
-    id: string,
-    signal: AbortSignal,
-    messageCountHint?: number,
-  ) {
+  private async loadAllMessages(id: string, signal: AbortSignal, messageCountHint?: number) {
     let from = 0;
     let loaded: Message[] = [];
+    let complete = false;
 
     for (;;) {
       configureGeneratedClient();
@@ -237,18 +210,23 @@ class MessagesStore {
         }) as unknown as Promise<MessagesResponse>,
         signal,
       );
-      if (res.messages.length === 0) break;
+      if (this.sessionId !== id) return;
+      if (res.messages.length === 0) {
+        complete = true;
+        break;
+      }
 
       loaded = [...loaded, ...res.messages];
       this.messages = loaded;
 
       const newest = loaded[loaded.length - 1];
-      this.messageCount =
-        messageCountHint ??
-        (newest ? newest.ordinal + 1 : loaded.length);
+      this.messageCount = messageCountHint ?? (newest ? newest.ordinal + 1 : loaded.length);
       this.hasOlder = false;
 
-      if (res.messages.length < MESSAGE_PAGE_SIZE) break;
+      if (res.messages.length < MESSAGE_PAGE_SIZE) {
+        complete = true;
+        break;
+      }
       const last = res.messages[res.messages.length - 1];
       if (!last) break;
       const nextFrom = last.ordinal + 1;
@@ -257,16 +235,13 @@ class MessagesStore {
     }
 
     const newest = this.messages[this.messages.length - 1];
-    this.messageCount =
-      messageCountHint ??
-      (newest ? newest.ordinal + 1 : this.messages.length);
+    if (this.sessionId !== id) return;
+    this.messageCount = messageCountHint ?? (newest ? newest.ordinal + 1 : this.messages.length);
     this.hasOlder = false;
+    this.historyComplete = complete;
   }
 
-  private async loadProgressively(
-    id: string,
-    signal: AbortSignal,
-  ) {
+  private async loadProgressively(id: string, signal: AbortSignal) {
     configureGeneratedClient();
     const firstRes = await withAbort(
       SessionsService.getApiV1SessionsIdMessages({
@@ -276,51 +251,36 @@ class MessagesStore {
       }) as unknown as Promise<MessagesResponse>,
       signal,
     );
+    if (this.sessionId !== id) return;
 
     this.messages = [...firstRes.messages].reverse();
+    this.historyComplete = false;
     const newest = this.messages[this.messages.length - 1];
     this.messageCount = newest ? newest.ordinal + 1 : 0;
     const oldest = this.messages[0]?.ordinal;
-    this.hasOlder =
-      oldest !== undefined ? oldest > 0 : false;
+    this.hasOlder = oldest !== undefined ? oldest > 0 : false;
+    this.historyComplete = !this.hasOlder;
   }
 
-  private async loadFrom(
-    id: string,
-    from: number,
-    signal: AbortSignal,
-  ) {
+  private async loadFrom(id: string, from: number, signal: AbortSignal) {
     const pages = await this.fetchPages(id, {
       from,
       limit: MESSAGE_PAGE_SIZE,
       direction: "asc",
       signal,
     });
+    if (this.sessionId !== id) return;
     if (pages.length > 0) {
-      const updates = new Map(
-        pages.map((m) => [m.ordinal, m]),
-      );
-      const existingOrdinals = new Set(
-        this.messages.map((m) => m.ordinal),
-      );
-      const appended = pages.filter(
-        (m) => !existingOrdinals.has(m.ordinal),
-      );
+      const updates = new Map(pages.map((m) => [m.ordinal, m]));
+      const existingOrdinals = new Set(this.messages.map((m) => m.ordinal));
+      const appended = pages.filter((m) => !existingOrdinals.has(m.ordinal));
       clearContentCaches();
-      this.messages = [
-        ...this.messages.map((m) => updates.get(m.ordinal) ?? m),
-        ...appended,
-      ];
+      this.messages = [...this.messages.map((m) => updates.get(m.ordinal) ?? m), ...appended];
     }
   }
 
   async loadOlder() {
-    if (
-      !this.sessionId ||
-      this.loadOlderPromise ||
-      !this.hasOlder ||
-      this.messages.length === 0
-    ) {
+    if (!this.sessionId || this.loadOlderPromise || !this.hasOlder || this.messages.length === 0) {
       return this.loadOlderPromise ?? undefined;
     }
 
@@ -340,6 +300,7 @@ class MessagesStore {
     const oldest = this.messages[0]!.ordinal;
     if (oldest <= 0) {
       this.hasOlder = false;
+      this.historyComplete = true;
       this.publishPendingSessionToken(id);
       return;
     }
@@ -362,15 +323,18 @@ class MessagesStore {
       if (this.sessionId !== id) return;
       if (res.messages.length === 0) {
         this.hasOlder = false;
+        this.historyComplete = true;
         this.publishPendingSessionToken(id);
         return;
       }
       const chunk = [...res.messages].reverse();
       this.messages.unshift(...chunk);
       this.hasOlder = chunk[0]!.ordinal > 0;
+      this.historyComplete = !this.hasOlder;
       this.publishPendingSessionToken(id);
     } catch (err) {
       if (isAbortError(err)) return;
+      if (this.sessionId === id) this.historyComplete = false;
       console.warn("Failed to load older messages:", err);
     } finally {
       if (this.sessionId === id) {
@@ -394,10 +358,7 @@ class MessagesStore {
       if (this.messages[0]!.ordinal <= targetOrdinal) return;
     }
 
-    const p = this.doEnsureOrdinal(
-      id,
-      targetOrdinal,
-    ).finally(() => {
+    const p = this.doEnsureOrdinal(id, targetOrdinal).finally(() => {
       if (this.loadOlderPromise === p) {
         this.loadOlderPromise = null;
       }
@@ -406,10 +367,7 @@ class MessagesStore {
     return p;
   }
 
-  private async doEnsureOrdinal(
-    id: string,
-    targetOrdinal: number,
-  ) {
+  private async doEnsureOrdinal(id: string, targetOrdinal: number) {
     const signal = this.abortController?.signal;
     if (!signal || signal.aborted) return;
 
@@ -433,6 +391,7 @@ class MessagesStore {
         if (this.sessionId !== id) return;
         if (res.messages.length === 0) {
           this.hasOlder = false;
+          this.historyComplete = true;
           break;
         }
 
@@ -455,15 +414,13 @@ class MessagesStore {
       }
 
       const oldestNow = this.messages[0]?.ordinal;
-      this.hasOlder =
-        oldestNow !== undefined && oldestNow > 0;
+      this.hasOlder = oldestNow !== undefined && oldestNow > 0;
+      this.historyComplete = !this.hasOlder;
       this.publishPendingSessionToken(id);
     } catch (err) {
       if (isAbortError(err)) return;
-      console.warn(
-        "Failed to load older messages for ordinal:",
-        err,
-      );
+      if (this.sessionId === id) this.historyComplete = false;
+      console.warn("Failed to load older messages for ordinal:", err);
     } finally {
       if (this.sessionId === id) {
         this.loadingOlder = false;
@@ -490,31 +447,36 @@ class MessagesStore {
       const newCount = sess.message_count ?? 0;
       const oldCount = this.messageCount;
       if (newCount === oldCount) {
-        await this.refreshLoadedWindow(id, signal);
+        const refreshed = await this.refreshLoadedWindow(id, signal);
+        const newest = this.messages[this.messages.length - 1];
+        this.historyComplete =
+          refreshed && this.messages[0]?.ordinal === 0 && newest?.ordinal === oldCount - 1;
       } else if (newCount > oldCount && this.messages.length > 0) {
         const oldestOrdinal = this.messages[0]!.ordinal;
         await this.loadFrom(id, oldestOrdinal, signal);
         if (this.sessionId !== id) return;
 
-        const newest =
-          this.messages[this.messages.length - 1];
-        if (newest && newest.ordinal !== newCount - 1) {
+        const newest = this.messages[this.messages.length - 1];
+        if (!newest || newest.ordinal !== newCount - 1) {
           await this.fullReload(id, signal, newCount);
         } else {
           this.messageCount = newCount;
+          this.historyComplete = this.messages[0]?.ordinal === 0 && newest.ordinal === newCount - 1;
         }
       } else {
         await this.fullReload(id, signal, newCount);
       }
 
       if (this.sessionId === id) {
-        const unreadOrdinal = pendingToken !== previousToken
-          ? earliestChangedOrdinal(previousMessages, this.messages)
-          : null;
+        const unreadOrdinal =
+          pendingToken !== previousToken
+            ? earliestChangedOrdinal(previousMessages, this.messages)
+            : null;
         this.publishOrDeferSessionToken(pendingToken, unreadOrdinal);
       }
     } catch (err) {
       if (isAbortError(err)) return;
+      if (this.sessionId === id) this.historyComplete = false;
       console.warn("Reload failed:", err);
     }
   }
@@ -538,28 +500,20 @@ class MessagesStore {
   }
 
   private publishPendingSessionToken(id: string) {
-    if (
-      this.sessionId !== id ||
-      this.hasOlder ||
-      !this.hasPendingSessionToken
-    ) {
+    if (this.sessionId !== id || this.hasOlder || !this.hasPendingSessionToken) {
       return;
     }
     this.activeSessionToken = this.pendingSessionToken;
-    this.activeSessionUnreadOrdinal =
-      this.pendingSessionUnreadOrdinal;
+    this.activeSessionUnreadOrdinal = this.pendingSessionUnreadOrdinal;
     this.pendingSessionToken = null;
     this.hasPendingSessionToken = false;
     this.pendingSessionUnreadOrdinal = null;
   }
 
-  private async refreshLoadedWindow(
-    id: string,
-    signal: AbortSignal,
-  ) {
+  private async refreshLoadedWindow(id: string, signal: AbortSignal): Promise<boolean> {
     const oldest = this.messages[0];
     const newest = this.messages[this.messages.length - 1];
-    if (!oldest || !newest) return;
+    if (!oldest || !newest) return false;
 
     const refreshed = await this.fetchPages(id, {
       from: oldest.ordinal,
@@ -568,92 +522,54 @@ class MessagesStore {
       signal,
     });
     if (this.sessionId !== id || refreshed.length === 0) {
-      return;
+      return false;
     }
 
     const updates = new Map(
       refreshed
-        .filter(
-          (m) =>
-            m.ordinal >= oldest.ordinal &&
-            m.ordinal <= newest.ordinal,
-        )
+        .filter((m) => m.ordinal >= oldest.ordinal && m.ordinal <= newest.ordinal)
         .map((m) => [m.ordinal, m]),
     );
     clearContentCaches();
-    this.messages = this.messages.map(
-      (m) => updates.get(m.ordinal) ?? m,
-    );
+    this.messages = this.messages.map((m) => updates.get(m.ordinal) ?? m);
+    return true;
   }
 
-  private async fullReload(
-    id: string,
-    signal: AbortSignal,
-    messageCountHint?: number,
-  ) {
+  private async fullReload(id: string, signal: AbortSignal, messageCountHint?: number) {
     clearContentCaches();
     this.loading = true;
     try {
-      if (
-        messageCountHint !== undefined &&
-        messageCountHint > FULL_SESSION_MESSAGE_THRESHOLD
-      ) {
+      if (messageCountHint !== undefined && messageCountHint > FULL_SESSION_MESSAGE_THRESHOLD) {
         await this.loadProgressively(id, signal);
       } else {
-        await this.loadAllMessages(
-          id,
-          signal,
-          messageCountHint,
-        );
+        await this.loadAllMessages(id, signal, messageCountHint);
       }
     } finally {
       if (this.sessionId === id) {
         this.loading = false;
-        this._stableMainModel =
-          this.messages.length > 0
-            ? computeMainModel(this.messages)
-            : "";
+        this._stableMainModel = this.messages.length > 0 ? computeMainModel(this.messages) : "";
       }
     }
   }
 }
 
-function earliestChangedOrdinal(
-  previous: Message[],
-  current: Message[],
-): number | null {
-  const previousByOrdinal = new Map(
-    previous.map((message) => [message.ordinal, message]),
-  );
-  const currentByOrdinal = new Map(
-    current.map((message) => [message.ordinal, message]),
-  );
-  const ordinals = new Set([
-    ...previousByOrdinal.keys(),
-    ...currentByOrdinal.keys(),
-  ]);
+function earliestChangedOrdinal(previous: Message[], current: Message[]): number | null {
+  const previousByOrdinal = new Map(previous.map((message) => [message.ordinal, message]));
+  const currentByOrdinal = new Map(current.map((message) => [message.ordinal, message]));
+  const ordinals = new Set([...previousByOrdinal.keys(), ...currentByOrdinal.keys()]);
   let earliest: number | null = null;
   for (const ordinal of ordinals) {
     const before = previousByOrdinal.get(ordinal);
     const after = currentByOrdinal.get(ordinal);
-    if (
-      before !== undefined &&
-      after !== undefined &&
-      transcriptMessageEqual(before, after)
-    ) {
+    if (before !== undefined && after !== undefined && transcriptMessageEqual(before, after)) {
       continue;
     }
-    earliest = earliest === null
-      ? ordinal
-      : Math.min(earliest, ordinal);
+    earliest = earliest === null ? ordinal : Math.min(earliest, ordinal);
   }
   return earliest;
 }
 
-function transcriptMessageEqual(
-  before: Message,
-  after: Message,
-): boolean {
+function transcriptMessageEqual(before: Message, after: Message): boolean {
   const visibleContent = (message: Message) => ({
     role: message.role,
     content: message.content,
@@ -689,8 +605,7 @@ function transcriptMessageEqual(
       })),
     })),
   });
-  return JSON.stringify(visibleContent(before)) ===
-    JSON.stringify(visibleContent(after));
+  return JSON.stringify(visibleContent(before)) === JSON.stringify(visibleContent(after));
 }
 
 export const messages = new MessagesStore();

--- a/frontend/src/lib/stores/messages.test.ts
+++ b/frontend/src/lib/stores/messages.test.ts
@@ -1,39 +1,34 @@
-import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
-import { messages } from './messages.svelte.js';
-import { readProgress } from './read-progress.svelte.js';
-import { parseContent } from '../utils/content-parser.js';
-import type {
-  Message,
-  MessagesResponse,
-  Session,
-} from '../api/types.js';
+import { describe, it, expect, vi, beforeEach } from "vite-plus/test";
+import { messages } from "./messages.svelte.js";
+import { readProgress } from "./read-progress.svelte.js";
+import { parseContent } from "../utils/content-parser.js";
+import type { Message, MessagesResponse, Session } from "../api/types.js";
 
 const api = vi.hoisted(() => ({
   getMessages: vi.fn(),
   getSession: vi.fn(),
 }));
 
-vi.mock('../api/runtime.js', () => ({
+vi.mock("../api/runtime.js", () => ({
   configureGeneratedClient: vi.fn(),
   callGenerated: vi.fn((request: () => Promise<unknown>) => request()),
   isAbortError: (err: unknown) => {
-    if (err instanceof DOMException && err.name === 'AbortError') {
+    if (err instanceof DOMException && err.name === "AbortError") {
       return true;
     }
-    if (err === null || typeof err !== 'object') {
+    if (err === null || typeof err !== "object") {
       return false;
     }
     const candidate = err as {
       isCancelled?: unknown;
       name?: unknown;
     };
-    return candidate.isCancelled === true ||
-      candidate.name === 'CancelError';
+    return candidate.isCancelled === true || candidate.name === "CancelError";
   },
   withAbort: <T>(promise: Promise<T>) => promise,
 }));
 
-vi.mock('../api/generated/index', () => ({
+vi.mock("../api/generated/index", () => ({
   SessionsService: {
     getApiV1SessionsId: vi.fn(({ id }) => api.getSession(id)),
     getApiV1SessionsIdMessages: vi.fn((params) =>
@@ -45,7 +40,7 @@ vi.mock('../api/generated/index', () => ({
           direction: params.direction,
         },
         { signal: new AbortController().signal },
-      )
+      ),
     ),
   },
 }));
@@ -61,23 +56,20 @@ function createDeferred<T>() {
 }
 
 function generatedCancelError(): Error & { isCancelled: true } {
-  const err = new Error('Request aborted') as Error & {
+  const err = new Error("Request aborted") as Error & {
     isCancelled: true;
   };
-  err.name = 'CancelError';
+  err.name = "CancelError";
   err.isCancelled = true;
   return err;
 }
 
-function makeSession(
-  id: string,
-  messageCount: number,
-): Session {
+function makeSession(id: string, messageCount: number): Session {
   return {
     id,
-    project: 'project-alpha',
-    machine: 'test-machine',
-    agent: 'test-agent',
+    project: "project-alpha",
+    machine: "test-machine",
+    agent: "test-agent",
     first_message: null,
     started_at: null,
     ended_at: null,
@@ -93,9 +85,9 @@ function makeSession(
 function makeMessage(ordinal: number): Message {
   return {
     id: ordinal + 1,
-    session_id: 's1',
+    session_id: "s1",
     ordinal,
-    role: ordinal % 2 === 0 ? 'user' : 'assistant',
+    role: ordinal % 2 === 0 ? "user" : "assistant",
     content: `msg ${ordinal}`,
     timestamp: new Date(ordinal * 1000).toISOString(),
     has_thinking: false,
@@ -112,145 +104,275 @@ function makeMessage(ordinal: number): Message {
   };
 }
 
-function makeMessagesResponse(
-  rows: Message[],
-): MessagesResponse {
+function makeMessagesResponse(rows: Message[]): MessagesResponse {
   return {
     messages: rows,
     count: rows.length,
   };
 }
 
-async function setupSession(
-  sessionId: string,
-  messageCount: number,
-  msgs: Message[] = [],
-) {
-  vi.mocked(api.getSession).mockResolvedValue(
-    makeSession(sessionId, messageCount),
-  );
-  vi.mocked(api.getMessages).mockResolvedValue(
-    makeMessagesResponse(msgs),
-  );
+async function setupSession(sessionId: string, messageCount: number, msgs: Message[] = []) {
+  vi.mocked(api.getSession).mockResolvedValue(makeSession(sessionId, messageCount));
+  vi.mocked(api.getMessages).mockResolvedValue(makeMessagesResponse(msgs));
   await messages.loadSession(sessionId);
 }
 
-describe('MessagesStore', () => {
+describe("MessagesStore", () => {
   beforeEach(() => {
     messages.clear();
     readProgress.reset();
     vi.clearAllMocks();
   });
 
-  it('should clear reload state when loading a new session', async () => {
-    await setupSession('s1', 10);
-    expect(messages.sessionId).toBe('s1');
+  it("should clear reload state when loading a new session", async () => {
+    await setupSession("s1", 10);
+    expect(messages.sessionId).toBe("s1");
 
     // Trigger a reload that hangs
-    const { promise: pendingReload, resolve: resolveReload } =
-      createDeferred<Session>();
+    const { promise: pendingReload, resolve: resolveReload } = createDeferred<Session>();
     vi.mocked(api.getSession).mockReturnValue(pendingReload);
 
     const p1 = messages.reload();
 
     // Switch to session s2
-    vi.mocked(api.getSession).mockResolvedValue(
-      makeSession('s2', 5),
-    );
-    await messages.loadSession('s2');
+    vi.mocked(api.getSession).mockResolvedValue(makeSession("s2", 5));
+    await messages.loadSession("s2");
 
-    expect(messages.sessionId).toBe('s2');
+    expect(messages.sessionId).toBe("s2");
 
     // A new reload should create a fresh promise, not reuse p1
-    const { promise: s2Reload, resolve: resolveS2 } =
-      createDeferred<Session>();
+    const { promise: s2Reload, resolve: resolveS2 } = createDeferred<Session>();
     vi.mocked(api.getSession).mockReturnValue(s2Reload);
     const p2 = messages.reload();
     expect(p2).not.toBe(p1);
 
     // Resolve dangling promises to clean up
-    resolveReload(makeSession('s1', 10));
-    resolveS2(makeSession('s2', 5));
+    resolveReload(makeSession("s1", 10));
+    resolveS2(makeSession("s2", 5));
     await Promise.all([p1, p2]);
   });
 
-  it('should retain mainModel during reload', async () => {
+  it("should retain mainModel during reload", async () => {
     const msgs = Array.from({ length: 5 }, (_, i) => ({
       ...makeMessage(i),
-      model: 'claude-3-opus',
+      model: "claude-3-opus",
     }));
-    await setupSession('s1', 5, msgs);
+    await setupSession("s1", 5, msgs);
 
-    expect(messages.mainModel).toBe('claude-3-opus');
+    expect(messages.mainModel).toBe("claude-3-opus");
 
     // Start a reload that hangs — mainModel must stay stable.
-    const { promise: hang, resolve: resolveHang } =
-      createDeferred<Session>();
+    const { promise: hang, resolve: resolveHang } = createDeferred<Session>();
     vi.mocked(api.getSession).mockReturnValue(hang);
 
     const p = messages.reload();
 
     // While reload is in flight, mainModel should still be
     // computed from the existing messages, not blank.
-    expect(messages.mainModel).toBe('claude-3-opus');
+    expect(messages.mainModel).toBe("claude-3-opus");
 
-    resolveHang(makeSession('s1', 5));
+    resolveHang(makeSession("s1", 5));
     await p;
 
-    expect(messages.mainModel).toBe('claude-3-opus');
+    expect(messages.mainModel).toBe("claude-3-opus");
   });
 
-  it('publishes a new transcript token only after refreshed messages arrive', async () => {
+  it("gates resume models through an in-flight, failed, and recovered reload", async () => {
+    const modelMessage = {
+      ...makeMessage(1),
+      model: "claude sonnet",
+    };
+    await setupSession("s1", 2, [makeMessage(0), modelMessage]);
+    expect(messages.resumeModelFor("s1")).toBe("claude sonnet");
+
+    const pendingSession = createDeferred<Session>();
+    const pendingMessages = createDeferred<MessagesResponse>();
+    vi.mocked(api.getSession).mockReturnValueOnce(pendingSession.promise);
+    vi.mocked(api.getMessages).mockReturnValueOnce(pendingMessages.promise);
+    const inFlight = messages.reload();
+    expect(messages.resumeModelFor("s1")).toBe("");
+
+    pendingSession.resolve(makeSession("s1", 2));
+    await vi.waitFor(() => {
+      expect(vi.mocked(api.getMessages)).toHaveBeenCalledTimes(2);
+    });
+    pendingMessages.resolve(makeMessagesResponse([makeMessage(0), modelMessage]));
+    await inFlight;
+    expect(messages.resumeModelFor("s1")).toBe("claude sonnet");
+
+    vi.mocked(api.getSession).mockResolvedValueOnce(makeSession("s1", 2));
+    vi.mocked(api.getMessages).mockRejectedValueOnce(new Error("reload failed"));
+    await messages.reload();
+    expect(messages.resumeModelFor("s1")).toBe("");
+
+    vi.mocked(api.getSession).mockResolvedValueOnce(makeSession("s1", 2));
+    vi.mocked(api.getMessages).mockResolvedValueOnce(
+      makeMessagesResponse([makeMessage(0), modelMessage]),
+    );
+    await messages.reload();
+    expect(messages.resumeModelFor("s1")).toBe("claude sonnet");
+  });
+
+  it("keeps partial history ineligible through page failure and pagination recovery", async () => {
+    const modelMessage = {
+      ...makeMessage(999),
+      model: "claude sonnet",
+    };
+    vi.mocked(api.getSession).mockResolvedValue(makeSession("s1", 3_001));
+    vi.mocked(api.getMessages).mockResolvedValueOnce(
+      makeMessagesResponse(
+        Array.from({ length: 100 }, (_, i) => ({
+          ...makeMessage(999 - i),
+          model: i === 0 ? modelMessage.model : "",
+        })),
+      ),
+    );
+    await messages.loadSession("s1");
+    expect(messages.resumeModelFor("s1")).toBe("");
+
+    vi.mocked(api.getMessages).mockRejectedValueOnce(new Error("older page failed"));
+    await messages.loadOlder();
+    expect(messages.resumeModelFor("s1")).toBe("");
+
+    vi.mocked(api.getMessages).mockResolvedValueOnce(
+      makeMessagesResponse(
+        Array.from({ length: 900 }, (_, i) => ({
+          ...makeMessage(899 - i),
+          model: i === 0 ? modelMessage.model : "",
+        })),
+      ),
+    );
+    await messages.loadOlder();
+    expect(messages.resumeModelFor("s1")).toBe("claude sonnet");
+  });
+
+  it("coalesces reloads and resets eligibility on session replacement and clear", async () => {
+    const s1Message = { ...makeMessage(1), model: "claude sonnet" };
+    await setupSession("s1", 2, [makeMessage(0), s1Message]);
+
+    const pendingSession = createDeferred<Session>();
+    const pendingMessages = createDeferred<MessagesResponse>();
+    vi.mocked(api.getSession).mockReturnValueOnce(pendingSession.promise);
+    vi.mocked(api.getMessages).mockReturnValueOnce(pendingMessages.promise);
+    const first = messages.reload();
+    expect(messages.reload()).toBe(first);
+    expect(messages.resumeModelFor("s1")).toBe("");
+
+    pendingSession.resolve(makeSession("s1", 2));
+    await vi.waitFor(() => {
+      expect(vi.mocked(api.getMessages)).toHaveBeenCalledTimes(2);
+    });
+    pendingMessages.resolve(makeMessagesResponse([makeMessage(0), s1Message]));
+    await first;
+    expect(messages.resumeModelFor("s1")).toBe("claude sonnet");
+
+    const replacementSession = createDeferred<Session>();
+    vi.mocked(api.getSession).mockReturnValueOnce(replacementSession.promise);
+    const replacementReload = messages.reload();
+    vi.mocked(api.getSession).mockResolvedValueOnce(makeSession("s2", 1));
+    vi.mocked(api.getMessages).mockResolvedValueOnce(
+      makeMessagesResponse([
+        {
+          ...makeMessage(0),
+          role: "assistant",
+          model: "o3-mini",
+        },
+      ]),
+    );
+    await messages.loadSession("s2");
+    expect(messages.resumeModelFor("s1")).toBe("");
+    expect(messages.resumeModelFor("s2")).toBe("o3-mini");
+    replacementSession.resolve(makeSession("s1", 2));
+    await replacementReload;
+
+    messages.clear();
+    expect(messages.resumeModelFor("s2")).toBe("");
+  });
+
+  it("ignores a deferred old-session page after the replacement session loads", async () => {
+    const s1Page = createDeferred<MessagesResponse>();
+    vi.mocked(api.getSession).mockResolvedValueOnce(makeSession("s1", 1));
+    vi.mocked(api.getMessages).mockReturnValueOnce(s1Page.promise);
+    const s1Load = messages.loadSession("s1");
+    await vi.waitFor(() => {
+      expect(vi.mocked(api.getMessages)).toHaveBeenCalledTimes(1);
+    });
+
+    vi.mocked(api.getSession).mockResolvedValueOnce(makeSession("s2", 1));
+    vi.mocked(api.getMessages).mockResolvedValueOnce(
+      makeMessagesResponse([
+        {
+          ...makeMessage(0),
+          role: "assistant",
+          model: "o3-mini",
+        },
+      ]),
+    );
+    await messages.loadSession("s2");
+    expect(messages.resumeModelFor("s2")).toBe("o3-mini");
+
+    s1Page.resolve(
+      makeMessagesResponse([
+        {
+          ...makeMessage(0),
+          role: "assistant",
+          model: "claude sonnet",
+        },
+      ]),
+    );
+    await s1Load;
+
+    expect(messages.sessionId).toBe("s2");
+    expect(messages.mainModel).toBe("o3-mini");
+    expect(messages.resumeModelFor("s2")).not.toBe("claude sonnet");
+    expect(messages.resumeModelFor("s2")).toBe("o3-mini");
+  });
+
+  it("publishes a new transcript token only after refreshed messages arrive", async () => {
     vi.mocked(api.getSession).mockResolvedValue({
-      ...makeSession('s1', 2),
-      transcript_revision: 'old',
+      ...makeSession("s1", 2),
+      transcript_revision: "old",
     });
     vi.mocked(api.getMessages).mockResolvedValueOnce(
       makeMessagesResponse([makeMessage(0), makeMessage(1)]),
     );
-    await messages.loadSession('s1');
-    expect(messages.activeSessionToken).toBe('old');
+    await messages.loadSession("s1");
+    expect(messages.activeSessionToken).toBe("old");
 
     vi.mocked(api.getSession).mockResolvedValueOnce({
-      ...makeSession('s1', 2),
-      transcript_revision: 'new',
+      ...makeSession("s1", 2),
+      transcript_revision: "new",
     });
     const refreshed = createDeferred<MessagesResponse>();
-    vi.mocked(api.getMessages).mockReturnValueOnce(
-      refreshed.promise,
-    );
+    vi.mocked(api.getMessages).mockReturnValueOnce(refreshed.promise);
 
     const reload = messages.reload();
     await vi.waitFor(() => {
       expect(vi.mocked(api.getMessages)).toHaveBeenCalledTimes(2);
     });
-    expect(messages.activeSessionToken).toBe('old');
+    expect(messages.activeSessionToken).toBe("old");
 
-    refreshed.resolve(
-      makeMessagesResponse([makeMessage(0), makeMessage(1)]),
-    );
+    refreshed.resolve(makeMessagesResponse([makeMessage(0), makeMessage(1)]));
     await reload;
-    expect(messages.activeSessionToken).toBe('new');
+    expect(messages.activeSessionToken).toBe("new");
   });
 
-  it('publishes the earliest changed ordinal with a revised token', async () => {
+  it("publishes the earliest changed ordinal with a revised token", async () => {
     const original = [makeMessage(0), makeMessage(1), makeMessage(2)];
     vi.mocked(api.getSession).mockResolvedValue({
-      ...makeSession('s1', original.length),
-      transcript_revision: 'old',
+      ...makeSession("s1", original.length),
+      transcript_revision: "old",
     });
-    vi.mocked(api.getMessages).mockResolvedValueOnce(
-      makeMessagesResponse(original),
-    );
-    await messages.loadSession('s1');
+    vi.mocked(api.getMessages).mockResolvedValueOnce(makeMessagesResponse(original));
+    await messages.loadSession("s1");
 
     vi.mocked(api.getSession).mockResolvedValueOnce({
-      ...makeSession('s1', original.length),
-      transcript_revision: 'new',
+      ...makeSession("s1", original.length),
+      transcript_revision: "new",
     });
     vi.mocked(api.getMessages).mockResolvedValueOnce(
       makeMessagesResponse([
-        { ...makeMessage(0), content: 'edited earlier message' },
+        { ...makeMessage(0), content: "edited earlier message" },
         makeMessage(1),
         makeMessage(2),
       ]),
@@ -258,160 +380,140 @@ describe('MessagesStore', () => {
 
     await messages.reload();
 
-    expect(messages.activeSessionToken).toBe('new');
+    expect(messages.activeSessionToken).toBe("new");
     expect(messages.activeSessionUnreadOrdinal).toBe(0);
   });
 
-  it('ignores replacement row IDs when locating changed transcript content', async () => {
+  it("ignores replacement row IDs when locating changed transcript content", async () => {
     const original = [makeMessage(0), makeMessage(1)];
     vi.mocked(api.getSession).mockResolvedValue({
-      ...makeSession('s1', original.length),
-      transcript_revision: 'old',
+      ...makeSession("s1", original.length),
+      transcript_revision: "old",
     });
-    vi.mocked(api.getMessages).mockResolvedValueOnce(
-      makeMessagesResponse(original),
-    );
-    await messages.loadSession('s1');
+    vi.mocked(api.getMessages).mockResolvedValueOnce(makeMessagesResponse(original));
+    await messages.loadSession("s1");
 
     vi.mocked(api.getSession).mockResolvedValueOnce({
-      ...makeSession('s1', original.length),
-      transcript_revision: 'new',
+      ...makeSession("s1", original.length),
+      transcript_revision: "new",
     });
     vi.mocked(api.getMessages).mockResolvedValueOnce(
-      makeMessagesResponse(original.map((message) => ({
-        ...message,
-        id: message.id + 100,
-      }))),
+      makeMessagesResponse(
+        original.map((message) => ({
+          ...message,
+          id: message.id + 100,
+        })),
+      ),
     );
 
     await messages.reload();
 
-    expect(messages.activeSessionToken).toBe('new');
+    expect(messages.activeSessionToken).toBe("new");
     expect(messages.activeSessionUnreadOrdinal).toBeNull();
   });
 
-  it('keeps a revised token pending until progressively loaded history is visible', async () => {
+  it("keeps a revised token pending until progressively loaded history is visible", async () => {
     const count = 4_000;
     vi.mocked(api.getSession).mockResolvedValue({
-      ...makeSession('s1', count),
-      transcript_revision: 'old',
+      ...makeSession("s1", count),
+      transcript_revision: "old",
     });
-    const tail = Array.from(
-      { length: 1_000 },
-      (_, i) => makeMessage(count - 1 - i),
-    );
-    vi.mocked(api.getMessages).mockResolvedValueOnce(
-      makeMessagesResponse(tail),
-    );
-    await messages.loadSession('s1');
+    const tail = Array.from({ length: 1_000 }, (_, i) => makeMessage(count - 1 - i));
+    vi.mocked(api.getMessages).mockResolvedValueOnce(makeMessagesResponse(tail));
+    await messages.loadSession("s1");
     expect(messages.hasOlder).toBe(true);
-    expect(messages.activeSessionToken).toBe('old');
+    expect(messages.activeSessionToken).toBe("old");
 
     vi.mocked(api.getSession).mockResolvedValueOnce({
-      ...makeSession('s1', count),
-      transcript_revision: 'new',
+      ...makeSession("s1", count),
+      transcript_revision: "new",
     });
-    vi.mocked(api.getMessages).mockResolvedValueOnce(
-      makeMessagesResponse([...tail].reverse()),
-    );
+    vi.mocked(api.getMessages).mockResolvedValueOnce(makeMessagesResponse([...tail].reverse()));
+    vi.mocked(api.getMessages).mockResolvedValueOnce(makeMessagesResponse([]));
     await messages.reload();
-    expect(messages.activeSessionToken).toBe('old');
+    expect(messages.activeSessionToken).toBe("old");
 
     vi.mocked(api.getMessages).mockResolvedValueOnce(
       makeMessagesResponse([makeMessage(1), makeMessage(0)]),
     );
     await messages.loadOlder();
     expect(messages.hasOlder).toBe(false);
-    expect(messages.activeSessionToken).toBe('new');
+    expect(messages.activeSessionToken).toBe("new");
     expect(messages.activeSessionUnreadOrdinal).toBe(0);
   });
 
-  it('publishes an already-current token for progressively loaded history', async () => {
+  it("publishes an already-current token for progressively loaded history", async () => {
     const count = 4_000;
-    readProgress.baseline('s1', 'current', count - 1);
+    readProgress.baseline("s1", "current", count - 1);
     vi.mocked(api.getSession).mockResolvedValue({
-      ...makeSession('s1', count),
-      transcript_revision: 'current',
+      ...makeSession("s1", count),
+      transcript_revision: "current",
     });
     vi.mocked(api.getMessages).mockResolvedValueOnce(
-      makeMessagesResponse(
-        Array.from(
-          { length: 1_000 },
-          (_, i) => makeMessage(count - 1 - i),
-        ),
-      ),
+      makeMessagesResponse(Array.from({ length: 1_000 }, (_, i) => makeMessage(count - 1 - i))),
     );
 
-    await messages.loadSession('s1');
+    await messages.loadSession("s1");
 
     expect(messages.hasOlder).toBe(true);
-    expect(messages.activeSessionToken).toBe('current');
+    expect(messages.activeSessionToken).toBe("current");
   });
 
-  it('should not carry over mainModel to a different session', async () => {
+  it("should not carry over mainModel to a different session", async () => {
     const s1Msgs = Array.from({ length: 3 }, (_, i) => ({
       ...makeMessage(i),
-      model: 'claude-3-opus',
+      model: "claude-3-opus",
     }));
-    await setupSession('s1', 3, s1Msgs);
-    expect(messages.mainModel).toBe('claude-3-opus');
+    await setupSession("s1", 3, s1Msgs);
+    expect(messages.mainModel).toBe("claude-3-opus");
 
     // Switch to s2 with a different model.
     const s2Msgs = Array.from({ length: 3 }, (_, i) => ({
       ...makeMessage(i),
-      model: 'claude-3-sonnet',
+      model: "claude-3-sonnet",
     }));
-    vi.mocked(api.getSession).mockResolvedValue(
-      makeSession('s2', 3),
-    );
-    vi.mocked(api.getMessages).mockResolvedValue(
-      makeMessagesResponse(s2Msgs),
-    );
-    await messages.loadSession('s2');
+    vi.mocked(api.getSession).mockResolvedValue(makeSession("s2", 3));
+    vi.mocked(api.getMessages).mockResolvedValue(makeMessagesResponse(s2Msgs));
+    await messages.loadSession("s2");
 
     // Must show s2's model, not s1's.
-    expect(messages.mainModel).toBe('claude-3-sonnet');
+    expect(messages.mainModel).toBe("claude-3-sonnet");
   });
 
-  it('should not reuse reload promise from different session', async () => {
-    await setupSession('s1', 10);
+  it("should not reuse reload promise from different session", async () => {
+    await setupSession("s1", 10);
 
     // Start reload for s1
-    const { promise: s1Promise, resolve: resolveS1 } =
-      createDeferred<Session>();
+    const { promise: s1Promise, resolve: resolveS1 } = createDeferred<Session>();
     vi.mocked(api.getSession).mockReturnValue(s1Promise);
 
     const p1 = messages.reload();
 
     // Switch to s2
-    vi.mocked(api.getSession).mockResolvedValue(
-      makeSession('s2', 5),
-    );
-    await messages.loadSession('s2');
+    vi.mocked(api.getSession).mockResolvedValue(makeSession("s2", 5));
+    await messages.loadSession("s2");
 
     // Start reload for s2 — must be a new promise
-    const { promise: s2Promise, resolve: resolveS2 } =
-      createDeferred<Session>();
+    const { promise: s2Promise, resolve: resolveS2 } = createDeferred<Session>();
     vi.mocked(api.getSession).mockReturnValue(s2Promise);
 
     const p2 = messages.reload();
 
     expect(p2).not.toBe(p1);
 
-    resolveS1(makeSession('s1', 10));
-    resolveS2(makeSession('s2', 5));
+    resolveS1(makeSession("s1", 10));
+    resolveS2(makeSession("s2", 5));
     await Promise.all([p1, p2]);
   });
 
-  it('should coalesce reloads for the same session', async () => {
-    await setupSession('s1', 10);
+  it("should coalesce reloads for the same session", async () => {
+    await setupSession("s1", 10);
 
     // Start reload
-    const { promise: s1Promise, resolve: resolveS1 } =
-      createDeferred<Session>();
+    const { promise: s1Promise, resolve: resolveS1 } = createDeferred<Session>();
     vi.mocked(api.getSession)
       .mockReturnValueOnce(s1Promise)
-      .mockResolvedValue(makeSession('s1', 10));
+      .mockResolvedValue(makeSession("s1", 10));
 
     const p1 = messages.reload();
     const p2 = messages.reload();
@@ -419,24 +521,17 @@ describe('MessagesStore', () => {
     // Coalesced: same promise returned
     expect(p1).toBe(p2);
 
-    resolveS1(makeSession('s1', 10));
+    resolveS1(makeSession("s1", 10));
     await p1;
   });
 
-  it('should no-op ensureOrdinalLoaded when full session is already loaded', async () => {
-    vi.mocked(api.getSession).mockResolvedValue(
-      makeSession('s1', 20),
-    );
+  it("should no-op ensureOrdinalLoaded when full session is already loaded", async () => {
+    vi.mocked(api.getSession).mockResolvedValue(makeSession("s1", 20));
     vi.mocked(api.getMessages).mockResolvedValueOnce(
-      makeMessagesResponse(
-        Array.from(
-          { length: 20 },
-          (_, i) => makeMessage(i),
-        ),
-      ),
+      makeMessagesResponse(Array.from({ length: 20 }, (_, i) => makeMessage(i))),
     );
 
-    await messages.loadSession('s1');
+    await messages.loadSession("s1");
 
     expect(messages.messages.length).toBe(20);
     expect(messages.messages[0]).toBeDefined();
@@ -451,26 +546,22 @@ describe('MessagesStore', () => {
     expect(messages.messages[0]!.ordinal).toBe(0);
   });
 
-  it('should not clear pending reload of a new session when old session reload finishes', async () => {
+  it("should not clear pending reload of a new session when old session reload finishes", async () => {
     // 1. Setup Session A
-    await setupSession('s1', 10);
+    await setupSession("s1", 10);
 
     // 2. Start Reload for Session A (P1) — hangs
-    const { promise: p1Promise, resolve: resolveP1 } =
-      createDeferred<Session>();
+    const { promise: p1Promise, resolve: resolveP1 } = createDeferred<Session>();
     vi.mocked(api.getSession).mockReturnValue(p1Promise);
 
     messages.reload();
 
     // 3. Switch to Session B
-    vi.mocked(api.getSession).mockResolvedValue(
-      makeSession('s2', 5),
-    );
-    await messages.loadSession('s2');
+    vi.mocked(api.getSession).mockResolvedValue(makeSession("s2", 5));
+    await messages.loadSession("s2");
 
     // 4. Start Reload for Session B (P2) — hangs
-    const { promise: p2Promise, resolve: resolveP2 } =
-      createDeferred<Session>();
+    const { promise: p2Promise, resolve: resolveP2 } = createDeferred<Session>();
     vi.mocked(api.getSession).mockReturnValue(p2Promise);
 
     const p2 = messages.reload();
@@ -481,36 +572,26 @@ describe('MessagesStore', () => {
 
     // 6. Resolve P1 (Session A).
     // This should NOT interfere with Session B's pending reload.
-    const callsBeforeP1 =
-      vi.mocked(api.getSession).mock.calls.length;
-    resolveP1(makeSession('s1', 10));
-    await new Promise(resolve => setTimeout(resolve, 0));
+    const callsBeforeP1 = vi.mocked(api.getSession).mock.calls.length;
+    resolveP1(makeSession("s1", 10));
+    await new Promise((resolve) => setTimeout(resolve, 0));
 
     // P1 completing must not trigger an auto-reload for
     // Session B — getSession call count should be unchanged
-    expect(
-      vi.mocked(api.getSession).mock.calls.length,
-    ).toBe(callsBeforeP1);
+    expect(vi.mocked(api.getSession).mock.calls.length).toBe(callsBeforeP1);
 
     // 7. Resolve P2 (Session B).
     // The pending reload should trigger automatically and
     // update state with the new count (6).
-    vi.mocked(api.getSession).mockResolvedValue(
-      makeSession('s2', 6),
-    );
-    vi.mocked(api.getMessages).mockResolvedValue(
-      makeMessagesResponse([]),
-    );
-    const callsBeforeP2 =
-      vi.mocked(api.getSession).mock.calls.length;
-    resolveP2(makeSession('s2', 5));
+    vi.mocked(api.getSession).mockResolvedValue(makeSession("s2", 6));
+    vi.mocked(api.getMessages).mockResolvedValue(makeMessagesResponse([]));
+    const callsBeforeP2 = vi.mocked(api.getSession).mock.calls.length;
+    resolveP2(makeSession("s2", 5));
 
     // Wait for the automatic pending reload to fire and
     // call getSession again
     await vi.waitFor(() => {
-      expect(
-        vi.mocked(api.getSession).mock.calls.length,
-      ).toBeGreaterThan(callsBeforeP2);
+      expect(vi.mocked(api.getSession).mock.calls.length).toBeGreaterThan(callsBeforeP2);
     });
 
     // The auto-reload fetched session with count=6,
@@ -518,16 +599,14 @@ describe('MessagesStore', () => {
     expect(messages.messageCount).toBe(6);
   });
 
-  it('should fallback to full reload if incremental fetch is out of sync', async () => {
+  it("should fallback to full reload if incremental fetch is out of sync", async () => {
     // 1. Initial State: Session 's1' with 2 messages
-    vi.mocked(api.getSession).mockResolvedValue(
-      makeSession('s1', 2),
-    );
+    vi.mocked(api.getSession).mockResolvedValue(makeSession("s1", 2));
     vi.mocked(api.getMessages).mockResolvedValueOnce(
       makeMessagesResponse([makeMessage(0), makeMessage(1)]),
     );
 
-    await messages.loadSession('s1');
+    await messages.loadSession("s1");
     expect(messages.messageCount).toBe(2);
 
     // 2. Prepare for Reload
@@ -535,21 +614,12 @@ describe('MessagesStore', () => {
     // Incremental fetch returns only [2], missing [3].
     // This mismatch should trigger full reload.
 
-    vi.mocked(api.getSession).mockResolvedValueOnce(
-      makeSession('s1', 4),
-    );
+    vi.mocked(api.getSession).mockResolvedValueOnce(makeSession("s1", 4));
+
+    vi.mocked(api.getMessages).mockResolvedValueOnce(makeMessagesResponse([makeMessage(2)]));
 
     vi.mocked(api.getMessages).mockResolvedValueOnce(
-      makeMessagesResponse([makeMessage(2)]),
-    );
-
-    vi.mocked(api.getMessages).mockResolvedValueOnce(
-      makeMessagesResponse([
-        makeMessage(1),
-        makeMessage(0),
-        makeMessage(2),
-        makeMessage(3),
-      ]),
+      makeMessagesResponse([makeMessage(1), makeMessage(0), makeMessage(2), makeMessage(3)]),
     );
 
     await messages.reload();
@@ -559,11 +629,11 @@ describe('MessagesStore', () => {
     expect(messages.messages[3]!.ordinal).toBe(3);
 
     expect(vi.mocked(api.getMessages)).toHaveBeenLastCalledWith(
-      's1',
+      "s1",
       expect.objectContaining({
         from: 0,
         limit: 1000,
-        direction: 'asc',
+        direction: "asc",
       }),
       expect.objectContaining({
         signal: expect.any(AbortSignal),
@@ -571,50 +641,36 @@ describe('MessagesStore', () => {
     );
   });
 
-  it('should refresh the loaded window when reload count is unchanged', async () => {
-    vi.mocked(api.getSession).mockResolvedValue(
-      makeSession('s1', 3),
-    );
+  it("should refresh the loaded window when reload count is unchanged", async () => {
+    vi.mocked(api.getSession).mockResolvedValue(makeSession("s1", 3));
     vi.mocked(api.getMessages).mockResolvedValueOnce(
-      makeMessagesResponse([
-        makeMessage(0),
-        makeMessage(1),
-        makeMessage(2),
-      ]),
+      makeMessagesResponse([makeMessage(0), makeMessage(1), makeMessage(2)]),
     );
 
-    await messages.loadSession('s1');
-    expect(messages.messages[0]!.content).toBe('msg 0');
+    await messages.loadSession("s1");
+    expect(messages.messages[0]!.content).toBe("msg 0");
 
     const updated = {
       ...makeMessage(0),
-      content: 'msg 0 rewritten content',
-      content_length: 'msg 0 rewritten content'.length,
+      content: "msg 0 rewritten content",
+      content_length: "msg 0 rewritten content".length,
     };
-    vi.mocked(api.getSession).mockResolvedValueOnce(
-      makeSession('s1', 3),
-    );
+    vi.mocked(api.getSession).mockResolvedValueOnce(makeSession("s1", 3));
     vi.mocked(api.getMessages).mockResolvedValueOnce(
-      makeMessagesResponse([
-        updated,
-        makeMessage(1),
-        makeMessage(2),
-      ]),
+      makeMessagesResponse([updated, makeMessage(1), makeMessage(2)]),
     );
 
     await messages.reload();
 
     expect(messages.messageCount).toBe(3);
     expect(messages.messages).toHaveLength(3);
-    expect(messages.messages[0]!.content).toBe(
-      'msg 0 rewritten content',
-    );
+    expect(messages.messages[0]!.content).toBe("msg 0 rewritten content");
     expect(vi.mocked(api.getMessages)).toHaveBeenLastCalledWith(
-      's1',
+      "s1",
       expect.objectContaining({
         from: 0,
         limit: 1000,
-        direction: 'asc',
+        direction: "asc",
       }),
       expect.objectContaining({
         signal: expect.any(AbortSignal),
@@ -622,43 +678,30 @@ describe('MessagesStore', () => {
     );
   });
 
-  it('should clear parser caches for same-length rewritten messages on same-count reload', async () => {
+  it("should clear parser caches for same-length rewritten messages on same-count reload", async () => {
     const original = {
       ...makeMessage(0),
-      content: 'alpha1',
+      content: "alpha1",
       content_length: 6,
     };
-    vi.mocked(api.getSession).mockResolvedValue(
-      makeSession('s1', 1),
-    );
-    vi.mocked(api.getMessages).mockResolvedValueOnce(
-      makeMessagesResponse([original]),
-    );
+    vi.mocked(api.getSession).mockResolvedValue(makeSession("s1", 1));
+    vi.mocked(api.getMessages).mockResolvedValueOnce(makeMessagesResponse([original]));
 
-    await messages.loadSession('s1');
+    await messages.loadSession("s1");
     expect(
-      parseContent(
-        original.content,
-        original.has_tool_use,
-        original.id,
-        original.content_length,
-      ),
-    ).toEqual([{ type: 'text', content: 'alpha1' }]);
+      parseContent(original.content, original.has_tool_use, original.id, original.content_length),
+    ).toEqual([{ type: "text", content: "alpha1" }]);
 
     const rewritten = {
       ...original,
-      content: 'bravo2',
+      content: "bravo2",
     };
-    vi.mocked(api.getSession).mockResolvedValueOnce(
-      makeSession('s1', 1),
-    );
-    vi.mocked(api.getMessages).mockResolvedValueOnce(
-      makeMessagesResponse([rewritten]),
-    );
+    vi.mocked(api.getSession).mockResolvedValueOnce(makeSession("s1", 1));
+    vi.mocked(api.getMessages).mockResolvedValueOnce(makeMessagesResponse([rewritten]));
 
     await messages.reload();
 
-    expect(messages.messages[0]!.content).toBe('bravo2');
+    expect(messages.messages[0]!.content).toBe("bravo2");
     expect(
       parseContent(
         messages.messages[0]!.content,
@@ -666,19 +709,17 @@ describe('MessagesStore', () => {
         messages.messages[0]!.id,
         messages.messages[0]!.content_length,
       ),
-    ).toEqual([{ type: 'text', content: 'bravo2' }]);
+    ).toEqual([{ type: "text", content: "bravo2" }]);
   });
 
-  it('should refresh the loaded tail when appending new messages', async () => {
-    vi.mocked(api.getSession).mockResolvedValue(
-      makeSession('s1', 2),
-    );
+  it("should refresh the loaded tail when appending new messages", async () => {
+    vi.mocked(api.getSession).mockResolvedValue(makeSession("s1", 2));
     vi.mocked(api.getMessages).mockResolvedValueOnce(
       makeMessagesResponse([makeMessage(0), makeMessage(1)]),
     );
 
-    await messages.loadSession('s1');
-    expect(messages.messages[1]!.content).toBe('msg 1');
+    await messages.loadSession("s1");
+    expect(messages.messages[1]!.content).toBe("msg 1");
     expect(
       parseContent(
         messages.messages[1]!.content,
@@ -686,16 +727,14 @@ describe('MessagesStore', () => {
         messages.messages[1]!.id,
         messages.messages[1]!.content_length,
       ),
-    ).toEqual([{ type: 'text', content: 'msg 1' }]);
+    ).toEqual([{ type: "text", content: "msg 1" }]);
 
     const updatedTail = {
       ...makeMessage(1),
-      content: 'tail!!',
+      content: "tail!!",
       content_length: 6,
     };
-    vi.mocked(api.getSession).mockResolvedValueOnce(
-      makeSession('s1', 3),
-    );
+    vi.mocked(api.getSession).mockResolvedValueOnce(makeSession("s1", 3));
     vi.mocked(api.getMessages).mockResolvedValueOnce(
       makeMessagesResponse([updatedTail, makeMessage(2)]),
     );
@@ -703,10 +742,8 @@ describe('MessagesStore', () => {
     await messages.reload();
 
     expect(messages.messageCount).toBe(3);
-    expect(messages.messages.map((m) => m.ordinal)).toEqual([
-      0, 1, 2,
-    ]);
-    expect(messages.messages[1]!.content).toBe('tail!!');
+    expect(messages.messages.map((m) => m.ordinal)).toEqual([0, 1, 2]);
+    expect(messages.messages[1]!.content).toBe("tail!!");
     expect(
       parseContent(
         messages.messages[1]!.content,
@@ -714,13 +751,13 @@ describe('MessagesStore', () => {
         messages.messages[1]!.id,
         messages.messages[1]!.content_length,
       ),
-    ).toEqual([{ type: 'text', content: 'tail!!' }]);
+    ).toEqual([{ type: "text", content: "tail!!" }]);
     expect(vi.mocked(api.getMessages)).toHaveBeenLastCalledWith(
-      's1',
+      "s1",
       expect.objectContaining({
         from: 0,
         limit: 1000,
-        direction: 'asc',
+        direction: "asc",
       }),
       expect.objectContaining({
         signal: expect.any(AbortSignal),
@@ -728,48 +765,36 @@ describe('MessagesStore', () => {
     );
   });
 
-  it('should refresh earlier loaded messages when appending new messages', async () => {
-    vi.mocked(api.getSession).mockResolvedValue(
-      makeSession('s1', 2),
-    );
+  it("should refresh earlier loaded messages when appending new messages", async () => {
+    vi.mocked(api.getSession).mockResolvedValue(makeSession("s1", 2));
     vi.mocked(api.getMessages).mockResolvedValueOnce(
       makeMessagesResponse([makeMessage(0), makeMessage(1)]),
     );
 
-    await messages.loadSession('s1');
-    expect(messages.messages[0]!.content).toBe('msg 0');
+    await messages.loadSession("s1");
+    expect(messages.messages[0]!.content).toBe("msg 0");
 
     const updatedEarlier = {
       ...makeMessage(0),
-      content: 'msg 0 rewritten',
-      content_length: 'msg 0 rewritten'.length,
+      content: "msg 0 rewritten",
+      content_length: "msg 0 rewritten".length,
     };
-    vi.mocked(api.getSession).mockResolvedValueOnce(
-      makeSession('s1', 3),
-    );
+    vi.mocked(api.getSession).mockResolvedValueOnce(makeSession("s1", 3));
     vi.mocked(api.getMessages).mockResolvedValueOnce(
-      makeMessagesResponse([
-        updatedEarlier,
-        makeMessage(1),
-        makeMessage(2),
-      ]),
+      makeMessagesResponse([updatedEarlier, makeMessage(1), makeMessage(2)]),
     );
 
     await messages.reload();
 
     expect(messages.messageCount).toBe(3);
-    expect(messages.messages.map((m) => m.ordinal)).toEqual([
-      0, 1, 2,
-    ]);
-    expect(messages.messages[0]!.content).toBe(
-      'msg 0 rewritten',
-    );
+    expect(messages.messages.map((m) => m.ordinal)).toEqual([0, 1, 2]);
+    expect(messages.messages[0]!.content).toBe("msg 0 rewritten");
     expect(vi.mocked(api.getMessages)).toHaveBeenLastCalledWith(
-      's1',
+      "s1",
       expect.objectContaining({
         from: 0,
         limit: 1000,
-        direction: 'asc',
+        direction: "asc",
       }),
       expect.objectContaining({
         signal: expect.any(AbortSignal),
@@ -777,29 +802,22 @@ describe('MessagesStore', () => {
     );
   });
 
-  it('should not update messageCount prematurely if incremental fetch fails and triggers full reload', async () => {
+  it("should not update messageCount prematurely if incremental fetch fails and triggers full reload", async () => {
     // 1. Initial State: Session 's1' with 2 messages
-    vi.mocked(api.getSession).mockResolvedValue(
-      makeSession('s1', 2),
-    );
+    vi.mocked(api.getSession).mockResolvedValue(makeSession("s1", 2));
     vi.mocked(api.getMessages).mockResolvedValueOnce(
       makeMessagesResponse([makeMessage(0), makeMessage(1)]),
     );
 
-    await messages.loadSession('s1');
+    await messages.loadSession("s1");
     expect(messages.messageCount).toBe(2);
 
-    vi.mocked(api.getSession).mockResolvedValueOnce(
-      makeSession('s1', 4),
-    );
+    vi.mocked(api.getSession).mockResolvedValueOnce(makeSession("s1", 4));
 
-    vi.mocked(api.getMessages).mockResolvedValueOnce(
-      makeMessagesResponse([makeMessage(2)]),
-    );
+    vi.mocked(api.getMessages).mockResolvedValueOnce(makeMessagesResponse([makeMessage(2)]));
 
     // Full reload — delayed via deferred
-    const { promise: fullReload, resolve: resolveFullReload } =
-      createDeferred<MessagesResponse>();
+    const { promise: fullReload, resolve: resolveFullReload } = createDeferred<MessagesResponse>();
     vi.mocked(api.getMessages).mockReturnValueOnce(
       fullReload as ReturnType<typeof api.getMessages>,
     );
@@ -808,9 +826,7 @@ describe('MessagesStore', () => {
 
     // Wait for the full reload call to be initiated
     await vi.waitFor(() => {
-      expect(
-        vi.mocked(api.getMessages),
-      ).toHaveBeenCalledTimes(3);
+      expect(vi.mocked(api.getMessages)).toHaveBeenCalledTimes(3);
     });
 
     // messageCount should still be 2 until full reload
@@ -818,12 +834,7 @@ describe('MessagesStore', () => {
     expect(messages.messageCount).toBe(2);
 
     resolveFullReload(
-      makeMessagesResponse([
-        makeMessage(0),
-        makeMessage(1),
-        makeMessage(2),
-        makeMessage(3),
-      ]),
+      makeMessagesResponse([makeMessage(0), makeMessage(1), makeMessage(2), makeMessage(3)]),
     );
 
     await reloadPromise;
@@ -831,38 +842,28 @@ describe('MessagesStore', () => {
     expect(messages.messageCount).toBe(4);
   });
 
-  describe('loadOlder abort handling', () => {
+  describe("loadOlder abort handling", () => {
     async function setupProgressiveSession() {
       // Progressive loading triggers when count > 20_000.
       // The first desc page returns ordinals 900..999 (reversed
       // to 900..999 ascending). hasOlder is true because
       // oldest ordinal (900) > 0.
       const count = 25_000;
-      vi.mocked(api.getSession).mockResolvedValue(
-        makeSession('s1', count),
-      );
-      const descPage = Array.from(
-        { length: 100 },
-        (_, i) => makeMessage(999 - i),
-      );
-      vi.mocked(api.getMessages).mockResolvedValueOnce(
-        makeMessagesResponse(descPage),
-      );
+      vi.mocked(api.getSession).mockResolvedValue(makeSession("s1", count));
+      const descPage = Array.from({ length: 100 }, (_, i) => makeMessage(999 - i));
+      vi.mocked(api.getMessages).mockResolvedValueOnce(makeMessagesResponse(descPage));
 
-      await messages.loadSession('s1');
+      await messages.loadSession("s1");
       expect(messages.hasOlder).toBe(true);
       expect(messages.messages[0]!.ordinal).toBe(900);
     }
 
-    it('should not surface abort error as unhandled rejection from loadOlder', async () => {
+    it("should not surface abort error as unhandled rejection from loadOlder", async () => {
       await setupProgressiveSession();
 
       // Make getMessages hang until aborted
-      const { promise: hang, reject: rejectHang } =
-        createDeferred<MessagesResponse>();
-      vi.mocked(api.getMessages).mockReturnValue(
-        hang as ReturnType<typeof api.getMessages>,
-      );
+      const { promise: hang, reject: rejectHang } = createDeferred<MessagesResponse>();
+      vi.mocked(api.getMessages).mockReturnValue(hang as ReturnType<typeof api.getMessages>);
 
       const olderPromise = messages.loadOlder();
       expect(messages.loadingOlder).toBe(true);
@@ -875,14 +876,11 @@ describe('MessagesStore', () => {
       await expect(olderPromise).resolves.toBeUndefined();
     });
 
-    it('should serialize concurrent loadOlder and ensureOrdinalLoaded', async () => {
+    it("should serialize concurrent loadOlder and ensureOrdinalLoaded", async () => {
       await setupProgressiveSession();
 
       // First loadOlder call — hangs
-      const {
-        promise: firstHang,
-        resolve: resolveFirst,
-      } = createDeferred<MessagesResponse>();
+      const { promise: firstHang, resolve: resolveFirst } = createDeferred<MessagesResponse>();
       vi.mocked(api.getMessages).mockReturnValueOnce(
         firstHang as ReturnType<typeof api.getMessages>,
       );
@@ -893,31 +891,19 @@ describe('MessagesStore', () => {
       // loadOlder before starting its own fetch. After
       // loadOlder resolves (800-899), ensureOrdinal needs
       // data further back (700-799).
-      const ensureChunk = Array.from(
-        { length: 100 },
-        (_, i) => makeMessage(799 - i),
-      );
+      const ensureChunk = Array.from({ length: 100 }, (_, i) => makeMessage(799 - i));
       vi.mocked(api.getMessages)
-        .mockResolvedValueOnce(
-          makeMessagesResponse(ensureChunk),
-        )
-        .mockResolvedValueOnce(
-          makeMessagesResponse([]),
-        );
+        .mockResolvedValueOnce(makeMessagesResponse(ensureChunk))
+        .mockResolvedValueOnce(makeMessagesResponse([]));
 
       const p2 = messages.ensureOrdinalLoaded(0);
 
       // p1 still pending — getMessages should only have been
       // called once so far (the loadOlder call)
-      expect(
-        vi.mocked(api.getMessages),
-      ).toHaveBeenCalledTimes(2); // 1 from loadSession + 1 from loadOlder
+      expect(vi.mocked(api.getMessages)).toHaveBeenCalledTimes(2); // 1 from loadSession + 1 from loadOlder
 
       // Resolve the first loadOlder
-      const loadOlderChunk = Array.from(
-        { length: 100 },
-        (_, i) => makeMessage(899 - i),
-      );
+      const loadOlderChunk = Array.from({ length: 100 }, (_, i) => makeMessage(899 - i));
       resolveFirst(makeMessagesResponse(loadOlderChunk));
 
       await p1;
@@ -927,25 +913,19 @@ describe('MessagesStore', () => {
       expect(messages.loadingOlder).toBe(false);
 
       // Ordinals should be strictly ascending with no duplicates
-      const ordinals = messages.messages.map(
-        (m) => m.ordinal,
-      );
+      const ordinals = messages.messages.map((m) => m.ordinal);
       for (let i = 1; i < ordinals.length; i++) {
         expect(ordinals[i]).toBeGreaterThan(ordinals[i - 1]!);
       }
       expect(new Set(ordinals).size).toBe(ordinals.length);
     });
 
-    it('should not allow overlapping loadOlder calls', async () => {
+    it("should not allow overlapping loadOlder calls", async () => {
       await setupProgressiveSession();
-      const callsBefore =
-        vi.mocked(api.getMessages).mock.calls.length;
+      const callsBefore = vi.mocked(api.getMessages).mock.calls.length;
 
-      const { promise: hang, resolve: resolveHang } =
-        createDeferred<MessagesResponse>();
-      vi.mocked(api.getMessages).mockReturnValueOnce(
-        hang as ReturnType<typeof api.getMessages>,
-      );
+      const { promise: hang, resolve: resolveHang } = createDeferred<MessagesResponse>();
+      vi.mocked(api.getMessages).mockReturnValueOnce(hang as ReturnType<typeof api.getMessages>);
 
       const p1 = messages.loadOlder();
       // Second call while first is in-flight should not start
@@ -953,117 +933,78 @@ describe('MessagesStore', () => {
       const p2 = messages.loadOlder();
 
       // Only one additional getMessages call was made
-      expect(
-        vi.mocked(api.getMessages).mock.calls.length -
-          callsBefore,
-      ).toBe(1);
+      expect(vi.mocked(api.getMessages).mock.calls.length - callsBefore).toBe(1);
 
-      const olderChunk = Array.from(
-        { length: 100 },
-        (_, i) => makeMessage(899 - i),
-      );
+      const olderChunk = Array.from({ length: 100 }, (_, i) => makeMessage(899 - i));
       resolveHang(makeMessagesResponse(olderChunk));
       await Promise.all([p1, p2]);
 
       expect(messages.loadingOlder).toBe(false);
 
       // Ordinals should be strictly ascending with no duplicates
-      const ordinals = messages.messages.map(
-        (m) => m.ordinal,
-      );
+      const ordinals = messages.messages.map((m) => m.ordinal);
       for (let i = 1; i < ordinals.length; i++) {
         expect(ordinals[i]).toBeGreaterThan(ordinals[i - 1]!);
       }
       expect(new Set(ordinals).size).toBe(ordinals.length);
     });
 
-    it('should not let stale loadOlder promise clear a newer session loadOlderPromise', async () => {
+    it("should not let stale loadOlder promise clear a newer session loadOlderPromise", async () => {
       await setupProgressiveSession();
 
       // Start loadOlder for session A — hangs
-      const {
-        promise: s1Hang,
-        resolve: resolveS1,
-      } = createDeferred<MessagesResponse>();
-      vi.mocked(api.getMessages).mockReturnValueOnce(
-        s1Hang as ReturnType<typeof api.getMessages>,
-      );
+      const { promise: s1Hang, resolve: resolveS1 } = createDeferred<MessagesResponse>();
+      vi.mocked(api.getMessages).mockReturnValueOnce(s1Hang as ReturnType<typeof api.getMessages>);
 
       const p1 = messages.loadOlder();
 
       // Switch to session B (progressive)
       const s2Count = 25_000;
-      vi.mocked(api.getSession).mockResolvedValue(
-        makeSession('s2', s2Count),
-      );
-      const s2DescPage = Array.from(
-        { length: 100 },
-        (_, i) => makeMessage(999 - i),
-      );
-      vi.mocked(api.getMessages).mockResolvedValueOnce(
-        makeMessagesResponse(s2DescPage),
-      );
-      await messages.loadSession('s2');
+      vi.mocked(api.getSession).mockResolvedValue(makeSession("s2", s2Count));
+      const s2DescPage = Array.from({ length: 100 }, (_, i) => makeMessage(999 - i));
+      vi.mocked(api.getMessages).mockResolvedValueOnce(makeMessagesResponse(s2DescPage));
+      await messages.loadSession("s2");
       expect(messages.hasOlder).toBe(true);
 
       // Start loadOlder for session B — hangs
-      const {
-        promise: s2Hang,
-        resolve: resolveS2,
-      } = createDeferred<MessagesResponse>();
-      vi.mocked(api.getMessages).mockReturnValueOnce(
-        s2Hang as ReturnType<typeof api.getMessages>,
-      );
+      const { promise: s2Hang, resolve: resolveS2 } = createDeferred<MessagesResponse>();
+      vi.mocked(api.getMessages).mockReturnValueOnce(s2Hang as ReturnType<typeof api.getMessages>);
 
       const p2 = messages.loadOlder();
 
       // Resolve the stale session A promise — this must NOT
       // clear loadOlderPromise, which now belongs to session B
-      const s1Chunk = Array.from(
-        { length: 100 },
-        (_, i) => makeMessage(899 - i),
-      );
+      const s1Chunk = Array.from({ length: 100 }, (_, i) => makeMessage(899 - i));
       resolveS1(makeMessagesResponse(s1Chunk));
       await p1;
 
       // Session B's loadOlder should still be recognized as
       // in-flight: a third loadOlder call should return the
       // existing promise, not start a new one
-      const callsBefore =
-        vi.mocked(api.getMessages).mock.calls.length;
+      const callsBefore = vi.mocked(api.getMessages).mock.calls.length;
       const p3 = messages.loadOlder();
-      expect(
-        vi.mocked(api.getMessages).mock.calls.length,
-      ).toBe(callsBefore);
+      expect(vi.mocked(api.getMessages).mock.calls.length).toBe(callsBefore);
 
       // Resolve session B's loadOlder
-      const s2Chunk = Array.from(
-        { length: 100 },
-        (_, i) => makeMessage(899 - i),
-      );
+      const s2Chunk = Array.from({ length: 100 }, (_, i) => makeMessage(899 - i));
       resolveS2(makeMessagesResponse(s2Chunk));
       await Promise.all([p2, p3]);
 
       expect(messages.loadingOlder).toBe(false);
 
       // Ordinals should be strictly ascending with no duplicates
-      const ordinals = messages.messages.map(
-        (m) => m.ordinal,
-      );
+      const ordinals = messages.messages.map((m) => m.ordinal);
       for (let i = 1; i < ordinals.length; i++) {
         expect(ordinals[i]).toBeGreaterThan(ordinals[i - 1]!);
       }
       expect(new Set(ordinals).size).toBe(ordinals.length);
     });
 
-    it('should not surface abort error from ensureOrdinalLoaded on session switch', async () => {
+    it("should not surface abort error from ensureOrdinalLoaded on session switch", async () => {
       await setupProgressiveSession();
 
-      const { promise: hang, reject: rejectHang } =
-        createDeferred<MessagesResponse>();
-      vi.mocked(api.getMessages).mockReturnValue(
-        hang as ReturnType<typeof api.getMessages>,
-      );
+      const { promise: hang, reject: rejectHang } = createDeferred<MessagesResponse>();
+      vi.mocked(api.getMessages).mockReturnValue(hang as ReturnType<typeof api.getMessages>);
 
       const p = messages.ensureOrdinalLoaded(0);
 

--- a/frontend/src/lib/utils/keyboard.test.ts
+++ b/frontend/src/lib/utils/keyboard.test.ts
@@ -1,11 +1,4 @@
-import {
-  describe,
-  it,
-  expect,
-  vi,
-  beforeEach,
-  afterEach,
-} from "vite-plus/test";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vite-plus/test";
 import { ui } from "../stores/ui.svelte.js";
 import { sessions } from "../stores/sessions.svelte.js";
 import { starred } from "../stores/starred.svelte.js";
@@ -19,10 +12,7 @@ vi.mock("../utils/clipboard.js", () => ({
   copyToClipboard: vi.fn().mockResolvedValue(true),
 }));
 
-function fireKey(
-  key: string,
-  opts: Partial<KeyboardEventInit> = {},
-) {
+function fireKey(key: string, opts: Partial<KeyboardEventInit> = {}) {
   const event = new KeyboardEvent("keydown", {
     key,
     bubbles: true,
@@ -274,11 +264,7 @@ describe("registerShortcuts", () => {
     }
 
     it("should navigate forward skipping unstarred when filterOnly is enabled", () => {
-      sessions.sessions = [
-        makeSession("s1"),
-        makeSession("s2"),
-        makeSession("s3"),
-      ];
+      sessions.sessions = [makeSession("s1"), makeSession("s2"), makeSession("s3")];
       sessions.activeSessionId = "s1";
       starred.star("s1");
       starred.star("s3");
@@ -291,11 +277,7 @@ describe("registerShortcuts", () => {
     });
 
     it("should navigate forward without filter when filterOnly is disabled", () => {
-      sessions.sessions = [
-        makeSession("s1"),
-        makeSession("s2"),
-        makeSession("s3"),
-      ];
+      sessions.sessions = [makeSession("s1"), makeSession("s2"), makeSession("s3")];
       sessions.activeSessionId = "s1";
       starred.star("s1");
       starred.star("s3");
@@ -308,11 +290,7 @@ describe("registerShortcuts", () => {
     });
 
     it("should navigate backward skipping unstarred when filterOnly is enabled", () => {
-      sessions.sessions = [
-        makeSession("s1"),
-        makeSession("s2"),
-        makeSession("s3"),
-      ];
+      sessions.sessions = [makeSession("s1"), makeSession("s2"), makeSession("s3")];
       sessions.activeSessionId = "s3";
       starred.star("s1");
       starred.star("s3");
@@ -325,10 +303,7 @@ describe("registerShortcuts", () => {
     });
 
     it("should be a no-op when filtered list is empty", () => {
-      sessions.sessions = [
-        makeSession("s1"),
-        makeSession("s2"),
-      ];
+      sessions.sessions = [makeSession("s1"), makeSession("s2")];
       sessions.activeSessionId = "s1";
       // No sessions are starred, so filtered list will be empty
       starred.filterOnly = true;
@@ -420,27 +395,31 @@ describe("registerShortcuts", () => {
     sessions.sessions = [session];
     sessions.activeSessionId = session.id;
     messages.sessionId = session.id;
-    messages.messages = [{
-      id: 1,
-      session_id: session.id,
-      ordinal: 0,
-      role: "assistant",
-      content: "answer",
-      timestamp: "",
-      has_thinking: false,
-      thinking_text: "",
-      has_tool_use: false,
-      content_length: 6,
-      model: "claude sonnet",
-      token_usage: null,
-      context_tokens: 0,
-      output_tokens: 0,
-      has_context_tokens: false,
-      has_output_tokens: false,
-      is_system: false,
-    }];
-    vi.spyOn(SessionsService, "postApiV1SessionsIdResume")
-      .mockRejectedValue(new Error("backend unavailable"));
+    messages.historyComplete = true;
+    messages.messages = [
+      {
+        id: 1,
+        session_id: session.id,
+        ordinal: 0,
+        role: "assistant",
+        content: "answer",
+        timestamp: "",
+        has_thinking: false,
+        thinking_text: "",
+        has_tool_use: false,
+        content_length: 6,
+        model: "claude sonnet",
+        token_usage: null,
+        context_tokens: 0,
+        output_tokens: 0,
+        has_context_tokens: false,
+        has_output_tokens: false,
+        is_system: false,
+      },
+    ];
+    vi.spyOn(SessionsService, "postApiV1SessionsIdResume").mockRejectedValue(
+      new Error("backend unavailable"),
+    );
 
     fireKey("c");
     await vi.waitFor(() => {
@@ -470,37 +449,36 @@ describe("registerShortcuts", () => {
     sessions.sessions = [session];
     sessions.activeSessionId = session.id;
     messages.sessionId = session.id;
-    messages.messages = [{
-      id: 1,
-      session_id: session.id,
-      ordinal: 0,
-      role: "assistant",
-      content: "answer",
-      timestamp: "",
-      has_thinking: false,
-      thinking_text: "",
-      has_tool_use: false,
-      content_length: 6,
-      model: "claude sonnet",
-      token_usage: null,
-      context_tokens: 0,
-      output_tokens: 0,
-      has_context_tokens: false,
-      has_output_tokens: false,
-      is_system: false,
-    }];
-    vi.spyOn(SessionsService, "postApiV1SessionsIdResume")
-      .mockResolvedValue({
-        launched: false,
-        command: "claude --resume run:keyboard-session",
-        cwd: "/tmp/project",
-      });
+    messages.messages = [
+      {
+        id: 1,
+        session_id: session.id,
+        ordinal: 0,
+        role: "assistant",
+        content: "answer",
+        timestamp: "",
+        has_thinking: false,
+        thinking_text: "",
+        has_tool_use: false,
+        content_length: 6,
+        model: "claude sonnet",
+        token_usage: null,
+        context_tokens: 0,
+        output_tokens: 0,
+        has_context_tokens: false,
+        has_output_tokens: false,
+        is_system: false,
+      },
+    ];
+    vi.spyOn(SessionsService, "postApiV1SessionsIdResume").mockResolvedValue({
+      launched: false,
+      command: "claude --resume run:keyboard-session",
+      cwd: "/tmp/project",
+    });
 
     fireKey("c");
     await vi.waitFor(() => {
-      expect(copyToClipboard).toHaveBeenCalledWith(
-        "claude --resume run:keyboard-session",
-      );
+      expect(copyToClipboard).toHaveBeenCalledWith("claude --resume run:keyboard-session");
     });
     messages.clear();
   });
@@ -524,34 +502,35 @@ describe("registerShortcuts", () => {
     sessions.sessions = [session];
     sessions.activeSessionId = session.id;
     messages.sessionId = session.id;
-    messages.messages = [{
-      id: 1,
-      session_id: session.id,
-      ordinal: 0,
-      role: "assistant",
-      content: "answer",
-      timestamp: "",
-      has_thinking: false,
-      thinking_text: "",
-      has_tool_use: false,
-      content_length: 6,
-      model: "claude sonnet",
-      token_usage: null,
-      context_tokens: 0,
-      output_tokens: 0,
-      has_context_tokens: false,
-      has_output_tokens: false,
-      is_system: false,
-    }];
+    messages.messages = [
+      {
+        id: 1,
+        session_id: session.id,
+        ordinal: 0,
+        role: "assistant",
+        content: "answer",
+        timestamp: "",
+        has_thinking: false,
+        thinking_text: "",
+        has_tool_use: false,
+        content_length: 6,
+        model: "claude sonnet",
+        token_usage: null,
+        context_tokens: 0,
+        output_tokens: 0,
+        has_context_tokens: false,
+        has_output_tokens: false,
+        is_system: false,
+      },
+    ];
     messages.hasOlder = true;
-    vi.spyOn(SessionsService, "postApiV1SessionsIdResume")
-      .mockRejectedValue(new Error("backend unavailable"));
+    vi.spyOn(SessionsService, "postApiV1SessionsIdResume").mockRejectedValue(
+      new Error("backend unavailable"),
+    );
 
     fireKey("c");
     await vi.waitFor(() => {
-      expect(copyToClipboard).toHaveBeenCalledWith(
-        "claude --resume 'run:keyboard-session'",
-      );
+      expect(copyToClipboard).toHaveBeenCalledWith("claude --resume 'run:keyboard-session'");
     });
     messages.clear();
   });
@@ -577,14 +556,13 @@ describe("registerShortcuts", () => {
     messages.sessionId = session.id;
     messages.loading = true;
     (messages as any)._stableMainModel = "claude sonnet";
-    vi.spyOn(SessionsService, "postApiV1SessionsIdResume")
-      .mockRejectedValue(new Error("backend unavailable"));
+    vi.spyOn(SessionsService, "postApiV1SessionsIdResume").mockRejectedValue(
+      new Error("backend unavailable"),
+    );
 
     fireKey("c");
     await vi.waitFor(() => {
-      expect(copyToClipboard).toHaveBeenCalledWith(
-        "claude --resume 'run:keyboard-session'",
-      );
+      expect(copyToClipboard).toHaveBeenCalledWith("claude --resume 'run:keyboard-session'");
     });
     messages.clear();
   });

--- a/frontend/src/lib/utils/keyboard.test.ts
+++ b/frontend/src/lib/utils/keyboard.test.ts
@@ -10,7 +10,14 @@ import { ui } from "../stores/ui.svelte.js";
 import { sessions } from "../stores/sessions.svelte.js";
 import { starred } from "../stores/starred.svelte.js";
 import { router } from "../stores/router.svelte.js";
+import { messages } from "../stores/messages.svelte.js";
+import { SessionsService } from "../api/generated/index";
+import { copyToClipboard } from "../utils/clipboard.js";
 import { registerShortcuts } from "./keyboard.js";
+
+vi.mock("../utils/clipboard.js", () => ({
+  copyToClipboard: vi.fn().mockResolvedValue(true),
+}));
 
 function fireKey(
   key: string,
@@ -392,5 +399,193 @@ describe("registerShortcuts", () => {
       fireKey("k", { metaKey: true });
       expect(ui.activeModal).toBeNull();
     });
+  });
+
+  it("pins the active session model in the resume fallback", async () => {
+    const session = {
+      id: "run:keyboard-session",
+      project: "proj",
+      machine: "local",
+      agent: "claude",
+      first_message: null,
+      started_at: null,
+      ended_at: null,
+      message_count: 1,
+      user_message_count: 1,
+      total_output_tokens: 0,
+      peak_context_tokens: 0,
+      is_automated: false,
+      created_at: "2024-01-01T00:00:00Z",
+    };
+    sessions.sessions = [session];
+    sessions.activeSessionId = session.id;
+    messages.sessionId = session.id;
+    messages.messages = [{
+      id: 1,
+      session_id: session.id,
+      ordinal: 0,
+      role: "assistant",
+      content: "answer",
+      timestamp: "",
+      has_thinking: false,
+      thinking_text: "",
+      has_tool_use: false,
+      content_length: 6,
+      model: "claude sonnet",
+      token_usage: null,
+      context_tokens: 0,
+      output_tokens: 0,
+      has_context_tokens: false,
+      has_output_tokens: false,
+      is_system: false,
+    }];
+    vi.spyOn(SessionsService, "postApiV1SessionsIdResume")
+      .mockRejectedValue(new Error("backend unavailable"));
+
+    fireKey("c");
+    await vi.waitFor(() => {
+      expect(copyToClipboard).toHaveBeenCalledWith(
+        "claude --resume 'run:keyboard-session' --model 'claude sonnet'",
+      );
+    });
+    messages.clear();
+  });
+
+  it("keeps successful backend resume commands authoritative", async () => {
+    const session = {
+      id: "run:keyboard-session",
+      project: "proj",
+      machine: "local",
+      agent: "claude",
+      first_message: null,
+      started_at: null,
+      ended_at: null,
+      message_count: 1,
+      user_message_count: 1,
+      total_output_tokens: 0,
+      peak_context_tokens: 0,
+      is_automated: false,
+      created_at: "2024-01-01T00:00:00Z",
+    };
+    sessions.sessions = [session];
+    sessions.activeSessionId = session.id;
+    messages.sessionId = session.id;
+    messages.messages = [{
+      id: 1,
+      session_id: session.id,
+      ordinal: 0,
+      role: "assistant",
+      content: "answer",
+      timestamp: "",
+      has_thinking: false,
+      thinking_text: "",
+      has_tool_use: false,
+      content_length: 6,
+      model: "claude sonnet",
+      token_usage: null,
+      context_tokens: 0,
+      output_tokens: 0,
+      has_context_tokens: false,
+      has_output_tokens: false,
+      is_system: false,
+    }];
+    vi.spyOn(SessionsService, "postApiV1SessionsIdResume")
+      .mockResolvedValue({
+        launched: false,
+        command: "claude --resume run:keyboard-session",
+        cwd: "/tmp/project",
+      });
+
+    fireKey("c");
+    await vi.waitFor(() => {
+      expect(copyToClipboard).toHaveBeenCalledWith(
+        "claude --resume run:keyboard-session",
+      );
+    });
+    messages.clear();
+  });
+
+  it("does not pin a partial-history model in the resume fallback", async () => {
+    const session = {
+      id: "run:keyboard-session",
+      project: "proj",
+      machine: "local",
+      agent: "claude",
+      first_message: null,
+      started_at: null,
+      ended_at: null,
+      message_count: 3001,
+      user_message_count: 1,
+      total_output_tokens: 0,
+      peak_context_tokens: 0,
+      is_automated: false,
+      created_at: "2024-01-01T00:00:00Z",
+    };
+    sessions.sessions = [session];
+    sessions.activeSessionId = session.id;
+    messages.sessionId = session.id;
+    messages.messages = [{
+      id: 1,
+      session_id: session.id,
+      ordinal: 0,
+      role: "assistant",
+      content: "answer",
+      timestamp: "",
+      has_thinking: false,
+      thinking_text: "",
+      has_tool_use: false,
+      content_length: 6,
+      model: "claude sonnet",
+      token_usage: null,
+      context_tokens: 0,
+      output_tokens: 0,
+      has_context_tokens: false,
+      has_output_tokens: false,
+      is_system: false,
+    }];
+    messages.hasOlder = true;
+    vi.spyOn(SessionsService, "postApiV1SessionsIdResume")
+      .mockRejectedValue(new Error("backend unavailable"));
+
+    fireKey("c");
+    await vi.waitFor(() => {
+      expect(copyToClipboard).toHaveBeenCalledWith(
+        "claude --resume 'run:keyboard-session'",
+      );
+    });
+    messages.clear();
+  });
+
+  it("does not pin a reloading stable model in the resume fallback", async () => {
+    const session = {
+      id: "run:keyboard-session",
+      project: "proj",
+      machine: "local",
+      agent: "claude",
+      first_message: null,
+      started_at: null,
+      ended_at: null,
+      message_count: 3001,
+      user_message_count: 1,
+      total_output_tokens: 0,
+      peak_context_tokens: 0,
+      is_automated: false,
+      created_at: "2024-01-01T00:00:00Z",
+    };
+    sessions.sessions = [session];
+    sessions.activeSessionId = session.id;
+    messages.sessionId = session.id;
+    messages.loading = true;
+    (messages as any)._stableMainModel = "claude sonnet";
+    vi.spyOn(SessionsService, "postApiV1SessionsIdResume")
+      .mockRejectedValue(new Error("backend unavailable"));
+
+    fireKey("c");
+    await vi.waitFor(() => {
+      expect(copyToClipboard).toHaveBeenCalledWith(
+        "claude --resume 'run:keyboard-session'",
+      );
+    });
+    messages.clear();
   });
 });

--- a/frontend/src/lib/utils/keyboard.ts
+++ b/frontend/src/lib/utils/keyboard.ts
@@ -4,6 +4,7 @@ import { starred } from "../stores/starred.svelte.js";
 import { sync } from "../stores/sync.svelte.js";
 import { router } from "../stores/router.svelte.js";
 import { inSessionSearch } from "../stores/inSessionSearch.svelte.js";
+import { messages } from "../stores/messages.svelte.js";
 import { getExportUrl } from "../api/client.js";
 import {
   SessionsService,
@@ -55,6 +56,12 @@ function handleEscape(): void {
   if (sessions.activeSessionId && !isInputFocused()) {
     sessions.deselectSession();
   }
+}
+
+function activeResumeModel(sessionId: string): string {
+  return messages.sessionId === sessionId && !messages.loading && !messages.hasOlder
+    ? messages.mainModel
+    : "";
 }
 
 /**
@@ -210,12 +217,14 @@ export function registerShortcuts(
             ) || buildResumeCommand(
               session.agent,
               session.id,
+              { model: activeResumeModel(session.id) },
             );
             if (cmd) copyToClipboard(cmd);
           }).catch(() => {
             const cmd = buildResumeCommand(
               session.agent,
               session.id,
+              { model: activeResumeModel(session.id) },
             );
             if (cmd) copyToClipboard(cmd);
           });

--- a/frontend/src/lib/utils/keyboard.ts
+++ b/frontend/src/lib/utils/keyboard.ts
@@ -6,17 +6,9 @@ import { router } from "../stores/router.svelte.js";
 import { inSessionSearch } from "../stores/inSessionSearch.svelte.js";
 import { messages } from "../stores/messages.svelte.js";
 import { getExportUrl } from "../api/client.js";
-import {
-  SessionsService,
-  type ResumeRequest,
-  type ResumeResponse,
-} from "../api/generated/index";
+import { SessionsService, type ResumeRequest, type ResumeResponse } from "../api/generated/index";
 import { configureGeneratedClient } from "../api/runtime.js";
-import {
-  supportsResume,
-  buildResumeCommand,
-  formatResumeResponseCommand,
-} from "./resume.js";
+import { supportsResume, buildResumeCommand, formatResumeResponseCommand } from "./resume.js";
 import { copyToClipboard } from "./clipboard.js";
 
 function isInputFocused(): boolean {
@@ -33,10 +25,7 @@ function isInputFocused(): boolean {
 
 function isFindInput(): boolean {
   const el = document.activeElement;
-  return (
-    el instanceof HTMLInputElement &&
-    el.getAttribute("aria-label") === "Search query"
-  );
+  return el instanceof HTMLInputElement && el.getAttribute("aria-label") === "Search query";
 }
 
 interface ShortcutOptions {
@@ -59,28 +48,21 @@ function handleEscape(): void {
 }
 
 function activeResumeModel(sessionId: string): string {
-  return messages.sessionId === sessionId && !messages.loading && !messages.hasOlder
-    ? messages.mainModel
-    : "";
+  return messages.resumeModelFor(sessionId);
 }
 
 /**
  * Register global keyboard shortcuts.
  * Returns a cleanup function to remove the listener.
  */
-export function registerShortcuts(
-  opts: ShortcutOptions,
-): () => void {
+export function registerShortcuts(opts: ShortcutOptions): () => void {
   function handler(e: KeyboardEvent) {
     const meta = e.metaKey || e.ctrlKey;
 
     // Cmd+K — always works
     if (meta && e.key === "k") {
       e.preventDefault();
-      ui.activeModal =
-        ui.activeModal === "commandPalette"
-          ? null
-          : "commandPalette";
+      ui.activeModal = ui.activeModal === "commandPalette" ? null : "commandPalette";
       return;
     }
 
@@ -181,10 +163,7 @@ export function registerShortcuts(
       r: () => sync.triggerSync(),
       e: () => {
         if (sessions.activeSessionId) {
-          window.open(
-            getExportUrl(sessions.activeSessionId),
-            "_blank",
-          );
+          window.open(getExportUrl(sessions.activeSessionId), "_blank");
         }
       },
       p: () => {
@@ -211,23 +190,21 @@ export function registerShortcuts(
             requestBody: {
               command_only: true,
             } satisfies ResumeRequest,
-          }).then((resp) => {
-            const cmd = formatResumeResponseCommand(
-              session.agent, resp as ResumeResponse,
-            ) || buildResumeCommand(
-              session.agent,
-              session.id,
-              { model: activeResumeModel(session.id) },
-            );
-            if (cmd) copyToClipboard(cmd);
-          }).catch(() => {
-            const cmd = buildResumeCommand(
-              session.agent,
-              session.id,
-              { model: activeResumeModel(session.id) },
-            );
-            if (cmd) copyToClipboard(cmd);
-          });
+          })
+            .then((resp) => {
+              const cmd =
+                formatResumeResponseCommand(session.agent, resp as ResumeResponse) ||
+                buildResumeCommand(session.agent, session.id, {
+                  model: activeResumeModel(session.id),
+                });
+              if (cmd) copyToClipboard(cmd);
+            })
+            .catch(() => {
+              const cmd = buildResumeCommand(session.agent, session.id, {
+                model: activeResumeModel(session.id),
+              });
+              if (cmd) copyToClipboard(cmd);
+            });
         }
       },
       "/": () => {
@@ -236,18 +213,12 @@ export function registerShortcuts(
         }
       },
       Delete: () => {
-        if (
-          router.route === "sessions" &&
-          sessions.activeSessionId
-        ) {
+        if (router.route === "sessions" && sessions.activeSessionId) {
           ui.activeModal = "confirmDelete";
         }
       },
       Backspace: () => {
-        if (
-          router.route === "sessions" &&
-          sessions.activeSessionId
-        ) {
+        if (router.route === "sessions" && sessions.activeSessionId) {
           ui.activeModal = "confirmDelete";
         }
       },

--- a/frontend/src/lib/utils/model.test.ts
+++ b/frontend/src/lib/utils/model.test.ts
@@ -53,6 +53,24 @@ describe("computeMainModel", () => {
     ).toBe("a-model");
   });
 
+  it("matches the resume mixed-model selection boundary", () => {
+    expect(
+      computeMainModel([
+        msg("assistant", "mixed-model-tie-z"),
+        msg("assistant", "mixed-model-tie-a"),
+      ]),
+    ).toBe("mixed-model-tie-a");
+  });
+
+  it("matches UTF-16 tie ordering for astral and BMP models", () => {
+    expect(
+      computeMainModel([
+        msg("assistant", "\uE000"),
+        msg("assistant", "\u{10000}"),
+      ]),
+    ).toBe("\u{10000}");
+  });
+
   it("ignores user messages", () => {
     expect(
       computeMainModel([
@@ -66,6 +84,25 @@ describe("computeMainModel", () => {
     expect(
       computeMainModel([
         msg("assistant", ""),
+        msg("assistant", "claude-sonnet-4.6"),
+      ]),
+    ).toBe("claude-sonnet-4.6");
+  });
+
+  it("ignores synthetic-only histories", () => {
+    expect(
+      computeMainModel([
+        msg("assistant", "<synthetic>"),
+        msg("assistant", "<synthetic>"),
+      ]),
+    ).toBe("");
+  });
+
+  it("ignores synthetic models when real models are present", () => {
+    expect(
+      computeMainModel([
+        msg("assistant", "<synthetic>"),
+        msg("assistant", "claude-sonnet-4.6"),
         msg("assistant", "claude-sonnet-4.6"),
       ]),
     ).toBe("claude-sonnet-4.6");

--- a/frontend/src/lib/utils/model.ts
+++ b/frontend/src/lib/utils/model.ts
@@ -8,7 +8,7 @@ import type { Message } from "../api/types.js";
 export function computeMainModel(messages: Message[]): string {
   const counts = new Map<string, number>();
   for (const m of messages) {
-    if (m.role === "assistant" && m.model) {
+    if (m.role === "assistant" && m.model && m.model !== "<synthetic>") {
       counts.set(m.model, (counts.get(m.model) ?? 0) + 1);
     }
   }

--- a/frontend/src/lib/utils/resume.test.ts
+++ b/frontend/src/lib/utils/resume.test.ts
@@ -41,6 +41,30 @@ describe("buildResumeCommand", () => {
     ).toBe("codex resume sess-1");
   });
 
+  it("pins Claude and Codex models with shell quoting", () => {
+    expect(
+      buildResumeCommand("claude", "run-1", { model: "claude sonnet" }),
+    ).toBe("claude --resume run-1 --model 'claude sonnet'");
+    expect(
+      buildResumeCommand("codex", "codex:run-1", { model: "o3-mini" }),
+    ).toBe("codex resume run-1 -m o3-mini");
+    expect(
+      buildResumeCommand("claude", "run-1", { model: "x'$(command)" }),
+    ).toBe("claude --resume run-1 --model 'x'\"'\"'$(command)'");
+    expect(
+      buildResumeCommand("codex", "codex:run-1", { model: "x'$(command)" }),
+    ).toBe("codex resume run-1 -m 'x'\"'\"'$(command)'");
+  });
+
+  it("leaves unsupported and no-model commands unchanged", () => {
+    expect(
+      buildResumeCommand("gemini", "run-1", { model: "model-bearing-non-target" }),
+    ).toBe("gemini --resume run-1");
+    expect(buildResumeCommand("claude", "run-1", { model: "" })).toBe(
+      "claude --resume run-1",
+    );
+  });
+
   it("generates gemini resume command", () => {
     expect(
       buildResumeCommand("gemini", "gemini:sess-2"),

--- a/frontend/src/lib/utils/resume.ts
+++ b/frontend/src/lib/utils/resume.ts
@@ -31,6 +31,7 @@ export interface ClaudeResumeFlags {
   skipPermissions?: boolean;
   forkSession?: boolean;
   print?: boolean;
+  model?: string;
 }
 
 /** Minimal shape of a backend resume response used for clipboard copy. */
@@ -93,6 +94,11 @@ export function buildResumeCommand(
 
   const rawId = stripIdPrefix(sessionId, agent);
   let cmd = builder(rawId);
+
+  if (flags?.model) {
+    if (agent === "claude") cmd += ` --model ${shellQuote(flags.model)}`;
+    if (agent === "codex") cmd += ` -m ${shellQuote(flags.model)}`;
+  }
 
   if (agent === "claude" && flags) {
     if (flags.skipPermissions)

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -127,6 +127,11 @@ type Message struct {
 	IsCompactBoundary bool            `json:"is_compact_boundary,omitempty"`
 }
 
+type ModelCount struct {
+	Model string
+	Count int
+}
+
 // TokenPresence reports whether context/output token fields were
 // present in stored message metadata. It preserves explicit flags,
 // falls back to non-zero numeric values for legacy rows, and inspects
@@ -361,6 +366,37 @@ func (db *DB) GetAllMessages(
 		return nil, err
 	}
 	return msgs, nil
+}
+
+func (db *DB) GetResumeModelCounts(
+	ctx context.Context, sessionID string,
+) ([]ModelCount, error) {
+	rows, err := db.getReader().QueryContext(ctx, `
+		SELECT model, COUNT(*)
+		FROM messages
+		WHERE session_id = ?
+			AND role = 'assistant'
+			AND model != ''
+			AND model != '<synthetic>'
+		GROUP BY model`,
+		sessionID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("querying resume model counts: %w", err)
+	}
+	defer rows.Close()
+	var counts []ModelCount
+	for rows.Next() {
+		var count ModelCount
+		if err := rows.Scan(&count.Model, &count.Count); err != nil {
+			return nil, fmt.Errorf("scanning resume model count: %w", err)
+		}
+		counts = append(counts, count)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating resume model counts: %w", err)
+	}
+	return counts, nil
 }
 
 // EmbeddableUnit is one embedding document: a single embeddable user

--- a/internal/db/store.go
+++ b/internal/db/store.go
@@ -40,6 +40,7 @@ type Store interface {
 	GetMessages(ctx context.Context, sessionID string, from, limit int, asc bool) ([]Message, error)
 	GetMessagesWindow(ctx context.Context, sessionID string, w MessageWindow) ([]Message, error)
 	GetAllMessages(ctx context.Context, sessionID string) ([]Message, error)
+	GetResumeModelCounts(ctx context.Context, sessionID string) ([]ModelCount, error)
 	GetSessionActivity(ctx context.Context, sessionID string) (*SessionActivityResponse, error)
 
 	// Timing.

--- a/internal/db/store_contract_test.go
+++ b/internal/db/store_contract_test.go
@@ -268,6 +268,13 @@ func contractMessagesOrderingAndToolResults(
 	require.NoError(t, err)
 	require.Equal(t, []int{0, 1, 2, 3, 4}, messageOrdinals(all))
 
+	modelCounts, err := store.GetResumeModelCounts(ctx, fixture.alphaID)
+	require.NoError(t, err)
+	require.Equal(t, []ModelCount{{
+		Model: "claude-sonnet-contract",
+		Count: 2,
+	}}, modelCounts)
+
 	activity, err := store.GetSessionActivity(ctx, fixture.alphaID)
 	require.NoError(t, err)
 	require.NotNil(t, activity)

--- a/internal/duckdb/messages.go
+++ b/internal/duckdb/messages.go
@@ -236,6 +236,37 @@ func (s *Store) GetAllMessages(ctx context.Context, sessionID string) ([]db.Mess
 	return msgs, nil
 }
 
+func (s *Store) GetResumeModelCounts(
+	ctx context.Context, sessionID string,
+) ([]db.ModelCount, error) {
+	rows, err := s.queryContext(ctx, `
+		SELECT model, COUNT(*)
+		FROM messages
+		WHERE session_id = ?
+			AND role = 'assistant'
+			AND model != ''
+			AND model != '<synthetic>'
+		GROUP BY model`,
+		sessionID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("querying duckdb resume model counts: %w", err)
+	}
+	defer rows.Close()
+	var counts []db.ModelCount
+	for rows.Next() {
+		var count db.ModelCount
+		if err := rows.Scan(&count.Model, &count.Count); err != nil {
+			return nil, fmt.Errorf("scanning duckdb resume model count: %w", err)
+		}
+		counts = append(counts, count)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating duckdb resume model counts: %w", err)
+	}
+	return counts, nil
+}
+
 func scanMessages(rows *sql.Rows) ([]db.Message, error) {
 	var msgs []db.Message
 	for rows.Next() {

--- a/internal/duckdb/store_contract_test.go
+++ b/internal/duckdb/store_contract_test.go
@@ -267,6 +267,13 @@ func duckContractMessagesSearchAndSecrets(
 	require.NoError(t, err)
 	require.Equal(t, []int{0, 1}, duckMessageOrdinals(all))
 
+	modelCounts, err := store.GetResumeModelCounts(ctx, fixture.alphaID)
+	require.NoError(t, err)
+	require.Equal(t, []db.ModelCount{{
+		Model: "claude-test",
+		Count: 1,
+	}}, modelCounts)
+
 	activity, err := store.GetSessionActivity(ctx, fixture.alphaID)
 	require.NoError(t, err)
 	require.NotNil(t, activity)

--- a/internal/postgres/messages.go
+++ b/internal/postgres/messages.go
@@ -249,6 +249,37 @@ func (s *Store) GetAllMessages(
 	return msgs, nil
 }
 
+func (s *Store) GetResumeModelCounts(
+	ctx context.Context, sessionID string,
+) ([]db.ModelCount, error) {
+	rows, err := s.pg.QueryContext(ctx, `
+		SELECT model, COUNT(*)
+		FROM messages
+		WHERE session_id = $1
+			AND role = 'assistant'
+			AND model != ''
+			AND model != '<synthetic>'
+		GROUP BY model`,
+		sessionID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("querying postgres resume model counts: %w", err)
+	}
+	defer rows.Close()
+	var counts []db.ModelCount
+	for rows.Next() {
+		var count db.ModelCount
+		if err := rows.Scan(&count.Model, &count.Count); err != nil {
+			return nil, fmt.Errorf("scanning postgres resume model count: %w", err)
+		}
+		counts = append(counts, count)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating postgres resume model counts: %w", err)
+	}
+	return counts, nil
+}
+
 // SearchSession performs ILIKE substring search within a single
 // session's messages, returning matching ordinals.
 func (s *Store) SearchSession(

--- a/internal/server/huma_routes_sessions.go
+++ b/internal/server/huma_routes_sessions.go
@@ -1208,12 +1208,19 @@ func (s *Server) humaResumeSession(
 	}
 	prefix := string(session.Agent) + ":"
 	rawID := strings.TrimPrefix(in.ID, prefix)
-	var cmd string
-	if strings.Contains(tmpl, "%s") {
-		cmd = fmt.Sprintf(tmpl, shellQuote(rawID))
-	} else {
-		cmd = tmpl
+	if s.db.ReadOnly() && !req.CommandOnly {
+		return nil, apiError(http.StatusNotImplemented,
+			"session launch not available in remote mode")
 	}
+	model := ""
+	if resumeAgentNeedsModel(string(session.Agent)) {
+		counts, err := s.db.GetResumeModelCounts(ctx, session.ID)
+		if err != nil {
+			return nil, internalError("resume: model lookup failed", err)
+		}
+		model = primaryResumeModel(counts)
+	}
+	cmd := resumeCommand(string(session.Agent), tmpl, rawID, model)
 	if string(session.Agent) == "claude" {
 		if req.SkipPermissions {
 			cmd += " --dangerously-skip-permissions"
@@ -1239,10 +1246,6 @@ func (s *Server) humaResumeSession(
 				Cwd:      launchDir,
 			},
 		}, nil
-	}
-	if s.db.ReadOnly() {
-		return nil, apiError(http.StatusNotImplemented,
-			"session launch not available in remote mode")
 	}
 	if req.OpenerID != "" {
 		return s.humaResumeWithOpener(session, rawID, cmd, responseCmd, launchDir, req.OpenerID)

--- a/internal/server/resume.go
+++ b/internal/server/resume.go
@@ -51,6 +51,65 @@ var resumeAgents = map[string]string{
 	"kiro":     "kiro-cli chat --resume-id %s",
 }
 
+const syntheticModel = "<synthetic>"
+
+func resumeCommand(agent, tmpl, rawID, model string) string {
+	cmd := fmt.Sprintf(tmpl, shellQuote(rawID))
+	if !resumeAgentNeedsModel(agent) {
+		return cmd
+	}
+	if model == "" {
+		return cmd
+	}
+	switch agent {
+	case "claude":
+		cmd += " --model " + shellQuote(model)
+	case "codex":
+		cmd += " -m " + shellQuote(model)
+	}
+	return cmd
+}
+
+func resumeAgentNeedsModel(agent string) bool {
+	return agent == "claude" || agent == "codex"
+}
+
+func primaryResumeModel(counts []db.ModelCount) string {
+	best := ""
+	bestN := 0
+	for _, count := range counts {
+		if !resumeModelEligible(count.Model) {
+			continue
+		}
+		model, n := count.Model, count.Count
+		if best == "" || n > bestN ||
+			(n == bestN && utf16LexLess(model, best)) {
+			best = model
+			bestN = n
+		}
+	}
+	return best
+}
+
+func resumeModelEligible(model string) bool {
+	return model != "" && model != syntheticModel
+}
+
+func utf16LexLess(a, b string) bool {
+	if b == "" {
+		return a != ""
+	}
+	aUnits := utf16.Encode([]rune(a))
+	bUnits := utf16.Encode([]rune(b))
+	for i := 0; i < len(aUnits) && i < len(bUnits); i++ {
+		if aUnits[i] == bUnits[i] {
+			continue
+		}
+		return aUnits[i] < bUnits[i]
+	}
+	return len(aUnits) < len(bUnits)
+}
+
 // terminalCandidates lists terminal emulators to try on Linux, in
 // preference order. Each entry is {binary, args-before-command...}.
 // The resume command is appended after the last arg.

--- a/internal/server/resume_handler_test.go
+++ b/internal/server/resume_handler_test.go
@@ -1,9 +1,11 @@
 package server_test
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -11,13 +13,37 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 	"unicode/utf16"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/server"
 )
+
+type failingResumeModelCountsStore struct {
+	readOnlyTestStore
+}
+
+func (failingResumeModelCountsStore) GetResumeModelCounts(
+	context.Context, string,
+) ([]db.ModelCount, error) {
+	return nil, errors.New("boom")
+}
+
+type resumeCountsOnlyStore struct {
+	readOnlyTestStore
+}
+
+func (resumeCountsOnlyStore) GetAllMessages(
+	context.Context, string,
+) ([]db.Message, error) {
+	return nil, errors.New("unexpected GetAllMessages call")
+}
 
 func canonicalTestPath(path string) string {
 	if path == "" {
@@ -150,6 +176,112 @@ func TestResumeSession(t *testing.T) {
 		s.Agent = "claude"
 	})
 
+	t.Run("claude_recorded_model", func(t *testing.T) {
+		te.seedSession(t, "claude-model", projectDir, 3, func(s *db.Session) {
+			s.Agent = "claude"
+		})
+		te.seedMessages(t, "claude-model", 3, func(i int, m *db.Message) {
+			if i == 1 {
+				m.Model = "claude sonnet"
+			}
+		})
+		w := te.post(t, "/api/v1/sessions/claude-model/resume",
+			`{"command_only":true}`)
+		assertStatus(t, w, http.StatusOK)
+		var resp resumeTestResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Contains(t, resp.Command, "claude --resume claude-model --model 'claude sonnet'")
+	})
+
+	t.Run("claude_recorded_model_shell_quoted", func(t *testing.T) {
+		te.seedSession(t, "claude-model-quoted", projectDir, 3, func(s *db.Session) {
+			s.Agent = "claude"
+		})
+		te.seedMessages(t, "claude-model-quoted", 3, func(i int, m *db.Message) {
+			if i == 1 {
+				m.Model = "x'$(command)"
+			}
+		})
+		w := te.post(t, "/api/v1/sessions/claude-model-quoted/resume",
+			`{"command_only":true}`)
+		assertStatus(t, w, http.StatusOK)
+		var resp resumeTestResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Contains(
+			t,
+			resp.Command,
+			`claude --resume claude-model-quoted --model 'x'"'"'$(command)'`,
+		)
+	})
+
+	t.Run("codex_recorded_model", func(t *testing.T) {
+		te.seedSession(t, "codex-model", projectDir, 3, func(s *db.Session) {
+			s.Agent = "codex"
+		})
+		te.seedMessages(t, "codex-model", 3, func(i int, m *db.Message) {
+			if i == 1 {
+				m.Model = "o3-mini"
+			}
+		})
+		w := te.post(t, "/api/v1/sessions/codex-model/resume",
+			`{"command_only":true}`)
+		assertStatus(t, w, http.StatusOK)
+		var resp resumeTestResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Equal(t, "codex resume codex-model -m o3-mini", resp.Command)
+	})
+
+	t.Run("codex_recorded_model_shell_quoted", func(t *testing.T) {
+		te.seedSession(t, "codex-model-quoted", projectDir, 3, func(s *db.Session) {
+			s.Agent = "codex"
+		})
+		te.seedMessages(t, "codex-model-quoted", 3, func(i int, m *db.Message) {
+			if i == 1 {
+				m.Model = "x'$(command)"
+			}
+		})
+		w := te.post(t, "/api/v1/sessions/codex-model-quoted/resume",
+			`{"command_only":true}`)
+		assertStatus(t, w, http.StatusOK)
+		var resp resumeTestResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Contains(
+			t,
+			resp.Command,
+			`codex resume codex-model-quoted -m 'x'"'"'$(command)'`,
+		)
+	})
+
+	t.Run("mixed_model", func(t *testing.T) {
+		te.seedSession(t, "mixed-model", projectDir, 5, func(s *db.Session) {
+			s.Agent = "claude"
+		})
+		te.seedMessages(t, "mixed-model", 5, func(i int, m *db.Message) {
+			switch i {
+			case 1:
+				m.Model = "mixed-model-tie-z"
+			case 3:
+				m.Model = "mixed-model-tie-a"
+			}
+		})
+		w := te.post(t, "/api/v1/sessions/mixed-model/resume",
+			`{"command_only":true}`)
+		assertStatus(t, w, http.StatusOK)
+		var resp resumeTestResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Contains(t, resp.Command, "claude --resume mixed-model --model mixed-model-tie-a")
+	})
+
+	t.Run("no_recorded_model", func(t *testing.T) {
+		w := te.post(t, "/api/v1/sessions/sess-1/resume",
+			`{"command_only":true}`)
+		assertStatus(t, w, http.StatusOK)
+		var resp resumeTestResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Contains(t, resp.Command, "claude --resume sess-1")
+		assert.NotContains(t, resp.Command, "--model")
+	})
+
 	t.Run("command only", func(t *testing.T) {
 		w := te.post(t,
 			"/api/v1/sessions/sess-1/resume",
@@ -211,6 +343,31 @@ func TestResumeSession(t *testing.T) {
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 		assert.False(t, resp.Launched, "expected launched=false for command_only")
 		assert.Equal(t, "copilot --resume=abc123", resp.Command)
+	})
+
+	t.Run("copilot ignores model-bearing messages", func(t *testing.T) {
+		projectDir := t.TempDir()
+		te.seedSession(t, "copilot:model-bearing", projectDir, 3, func(s *db.Session) {
+			s.Agent = "copilot"
+		})
+		te.seedMessages(t, "copilot:model-bearing", 3, func(i int, m *db.Message) {
+			if i == 1 {
+				m.Role = "assistant"
+				m.Model = "model-bearing-non-target"
+			}
+		})
+		w := te.post(t,
+			"/api/v1/sessions/copilot:model-bearing/resume",
+			`{"command_only":true}`,
+		)
+		assertStatus(t, w, http.StatusOK)
+		var resp struct {
+			Launched bool   `json:"launched"`
+			Command  string `json:"command"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.False(t, resp.Launched, "expected launched=false for command_only")
+		assert.Equal(t, "copilot --resume=model-bearing", resp.Command)
 	})
 
 	t.Run("kiro current-store command only", func(t *testing.T) {
@@ -521,6 +678,157 @@ func TestResumeSession(t *testing.T) {
 		t.Cleanup(func() { _ = os.Remove(promptPath) })
 	})
 
+	t.Run("whole session remote launch rejects before local launch", func(t *testing.T) {
+		dir := tempDirWithRetryCleanup(t)
+		dbPath := filepath.Join(dir, "test.db")
+		database := dbtest.OpenTestDBAt(t, dbPath)
+		store := failingResumeModelCountsStore{
+			readOnlyTestStore{Store: database},
+		}
+		cfg := config.Config{
+			Host:         "127.0.0.1",
+			Port:         0,
+			DataDir:      dir,
+			DBPath:       dbPath,
+			WriteTimeout: 30 * time.Second,
+		}
+		srv := server.New(cfg, store, nil)
+		te := &testEnv{
+			srv:         srv,
+			handler:     wrapTestHandler(cfg, srv.Handler()),
+			db:          database,
+			engine:      nil,
+			broadcaster: nil,
+			dataDir:     dir,
+		}
+		te.seedSession(t, "sess-remote-launch", projectDir, 3, func(s *db.Session) {
+			s.Agent = "claude"
+		})
+
+		w := te.post(t,
+			"/api/v1/sessions/sess-remote-launch/resume",
+			`{}`,
+		)
+		assertStatus(t, w, http.StatusNotImplemented)
+	})
+
+	t.Run("whole session command only works in read only mode", func(t *testing.T) {
+		te := setupPGMode(t)
+		te.seedSession(t, "sess-remote-command", projectDir, 3, func(s *db.Session) {
+			s.Agent = "claude"
+		})
+		te.seedMessages(t, "sess-remote-command", 3, func(i int, m *db.Message) {
+			if i == 1 {
+				m.Model = "claude sonnet"
+			}
+		})
+
+		w := te.post(t,
+			"/api/v1/sessions/sess-remote-command/resume",
+			`{"command_only":true}`,
+		)
+		assertStatus(t, w, http.StatusOK)
+		var resp struct {
+			Launched bool   `json:"launched"`
+			Command  string `json:"command"`
+			Cwd      string `json:"cwd"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.False(t, resp.Launched)
+		assert.Contains(
+			t,
+			resp.Command,
+			"claude --resume sess-remote-command --model 'claude sonnet'",
+		)
+		assertSamePath(t, "cwd", resp.Cwd, projectDir)
+	})
+
+	t.Run("whole session command only uses compact model counts", func(t *testing.T) {
+		dir := tempDirWithRetryCleanup(t)
+		dbPath := filepath.Join(dir, "test.db")
+		database := dbtest.OpenTestDBAt(t, dbPath)
+		store := resumeCountsOnlyStore{
+			readOnlyTestStore{Store: database},
+		}
+		cfg := config.Config{
+			Host:         "127.0.0.1",
+			Port:         0,
+			DataDir:      dir,
+			DBPath:       dbPath,
+			WriteTimeout: 30 * time.Second,
+		}
+		srv := server.New(cfg, store, nil)
+		te := &testEnv{
+			srv:         srv,
+			handler:     wrapTestHandler(cfg, srv.Handler()),
+			db:          database,
+			engine:      nil,
+			broadcaster: nil,
+			dataDir:     dir,
+		}
+
+		te.seedSession(t, "sess-remote-compact", projectDir, 3, func(s *db.Session) {
+			s.Agent = "claude"
+		})
+		te.seedMessages(t, "sess-remote-compact", 3, func(i int, m *db.Message) {
+			if i == 1 {
+				m.Model = "claude sonnet"
+			}
+		})
+
+		w := te.post(t,
+			"/api/v1/sessions/sess-remote-compact/resume",
+			`{"command_only":true}`,
+		)
+		assertStatus(t, w, http.StatusOK)
+		var resp struct {
+			Launched bool   `json:"launched"`
+			Command  string `json:"command"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.False(t, resp.Launched)
+		assert.Contains(
+			t,
+			resp.Command,
+			"claude --resume sess-remote-compact --model 'claude sonnet'",
+		)
+	})
+
+	t.Run("whole session command only reports model lookup failure", func(t *testing.T) {
+		dir := tempDirWithRetryCleanup(t)
+		dbPath := filepath.Join(dir, "test.db")
+		database := dbtest.OpenTestDBAt(t, dbPath)
+		store := failingResumeModelCountsStore{
+			readOnlyTestStore{Store: database},
+		}
+		cfg := config.Config{
+			Host:         "127.0.0.1",
+			Port:         0,
+			DataDir:      dir,
+			DBPath:       dbPath,
+			WriteTimeout: 30 * time.Second,
+		}
+		srv := server.New(cfg, store, nil)
+		te := &testEnv{
+			srv:         srv,
+			handler:     wrapTestHandler(cfg, srv.Handler()),
+			db:          database,
+			engine:      nil,
+			broadcaster: nil,
+			dataDir:     dir,
+		}
+
+		te.seedSession(t, "sess-remote-error", projectDir, 3, func(s *db.Session) {
+			s.Agent = "claude"
+		})
+
+		w := te.post(t,
+			"/api/v1/sessions/sess-remote-error/resume",
+			`{"command_only":true}`,
+		)
+		assertStatus(t, w, http.StatusInternalServerError)
+	})
+
 	t.Run("deleted session rejected", func(t *testing.T) {
 		te.seedSession(t, "del-1", "/tmp", 3, func(s *db.Session) {
 			s.Agent = "claude"
@@ -531,6 +839,114 @@ func TestResumeSession(t *testing.T) {
 			`{"command_only":true}`,
 		)
 		assertStatus(t, w, http.StatusNotFound)
+	})
+}
+
+type resumeTestResponse struct {
+	Command string `json:"command"`
+}
+
+func TestPrimaryResumeModel(t *testing.T) {
+	te := setup(t)
+	t.Run("alphabetical tie", func(t *testing.T) {
+		te.seedSession(t, "model-selection", t.TempDir(), 5, func(s *db.Session) {
+			s.Agent = "codex"
+		})
+		te.seedMessages(t, "model-selection", 5, func(i int, m *db.Message) {
+			if i == 1 {
+				m.Model = "mixed-model-tie-z"
+			}
+			if i == 3 {
+				m.Model = "mixed-model-tie-a"
+			}
+		})
+		w := te.post(t, "/api/v1/sessions/model-selection/resume",
+			`{"command_only":true}`)
+		assertStatus(t, w, http.StatusOK)
+		var resp resumeTestResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Equal(t, "codex resume model-selection -m mixed-model-tie-a", resp.Command)
+	})
+
+	t.Run("higher count ignores user-only models", func(t *testing.T) {
+		te.seedSession(t, "model-selection-count", t.TempDir(), 5, func(s *db.Session) {
+			s.Agent = "codex"
+		})
+		te.seedMessages(t, "model-selection-count", 5, func(i int, m *db.Message) {
+			switch i {
+			case 0:
+				m.Role = "user"
+				m.Model = "user-only-model"
+			case 1, 3:
+				m.Model = "later-model"
+			case 4:
+				m.Model = "earlier-model"
+			}
+		})
+		w := te.post(t, "/api/v1/sessions/model-selection-count/resume",
+			`{"command_only":true}`)
+		assertStatus(t, w, http.StatusOK)
+		var resp resumeTestResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Equal(t, "codex resume model-selection-count -m later-model", resp.Command)
+	})
+
+	t.Run("UTF-16 tie parity", func(t *testing.T) {
+		te.seedSession(t, "model-selection-utf16", t.TempDir(), 5, func(s *db.Session) {
+			s.Agent = "codex"
+		})
+		te.seedMessages(t, "model-selection-utf16", 5, func(i int, m *db.Message) {
+			switch i {
+			case 1:
+				m.Model = "\uE000"
+			case 3:
+				m.Model = "\U00010000"
+			}
+		})
+		w := te.post(t, "/api/v1/sessions/model-selection-utf16/resume",
+			`{"command_only":true}`)
+		assertStatus(t, w, http.StatusOK)
+		var resp resumeTestResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Equal(t, "codex resume model-selection-utf16 -m '𐀀'", resp.Command)
+	})
+
+	t.Run("synthetic-only histories omit model pin", func(t *testing.T) {
+		te.seedSession(t, "model-selection-synthetic", t.TempDir(), 5, func(s *db.Session) {
+			s.Agent = "codex"
+		})
+		te.seedMessages(t, "model-selection-synthetic", 5, func(i int, m *db.Message) {
+			if i == 1 || i == 3 {
+				m.Model = "<synthetic>"
+			}
+		})
+		w := te.post(t, "/api/v1/sessions/model-selection-synthetic/resume",
+			`{"command_only":true}`)
+		assertStatus(t, w, http.StatusOK)
+		var resp resumeTestResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Equal(t, "codex resume model-selection-synthetic", resp.Command)
+	})
+
+	t.Run("synthetic models lose to real models", func(t *testing.T) {
+		te.seedSession(t, "model-selection-real", t.TempDir(), 5, func(s *db.Session) {
+			s.Agent = "codex"
+		})
+		te.seedMessages(t, "model-selection-real", 5, func(i int, m *db.Message) {
+			switch i {
+			case 1, 3:
+				m.Model = "<synthetic>"
+			case 2:
+				m.Role = "assistant"
+				m.Model = "real-model"
+			}
+		})
+		w := te.post(t, "/api/v1/sessions/model-selection-real/resume",
+			`{"command_only":true}`)
+		assertStatus(t, w, http.StatusOK)
+		var resp resumeTestResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Equal(t, "codex resume model-selection-real -m real-model", resp.Command)
 	})
 }
 


### PR DESCRIPTION
Resume commands could ignore the model recorded in the session and fall back to the CLI default, which breaks prompt-cache reuse.

This change keeps the backend and frontend resume paths aligned on the same selected model, preserves shell quoting for model values, and matches JavaScript UTF-16 tie-break ordering when multiple models have the same usage count. Backend resume generation now uses compact per-model counts instead of hydrating full transcripts, and the model-aware command is reused for command-only responses, launcher paths, and clipboard fallbacks.

Frontend local fallback pinning now stays behind a store-owned complete-history predicate. The breadcrumb and keyboard fallbacks pin only when the requested session matches a successfully complete, current, idle history; partial pages, later-page failures, and in-flight or failed reloads stay unpinned, while display-only model badges remain unchanged.

Message-point forks and sessions without model data keep their existing behavior.

Closes #1104
