### PR TITLE
fix(test): give remotesync liveness guards a Windows-safe deadline

### DIFF
--- a/internal/remotesync/archive_test.go
+++ b/internal/remotesync/archive_test.go
@@ -88,7 +88,7 @@ func TestWriteArchiveIgnoresBytesAppendedAfterHeader(t *testing.T) {
 
 	select {
 	case <-writer.headerWritten:
-	case <-time.After(time.Second):
+	case <-time.After(backgroundWaitTimeout):
 		require.FailNow(t, "tar header was not written")
 	}
 	require.NoError(t, appendFile(path, "new"))

--- a/internal/remotesync/archive_unix_test.go
+++ b/internal/remotesync/archive_unix_test.go
@@ -26,7 +26,7 @@ func TestWriteArchiveSkipsFIFO(t *testing.T) {
 	select {
 	case err := <-done:
 		require.NoError(t, err)
-	case <-time.After(time.Second):
+	case <-time.After(backgroundWaitTimeout):
 		require.FailNow(t, "WriteArchive blocked on FIFO")
 	}
 }

--- a/internal/remotesync/http_test.go
+++ b/internal/remotesync/http_test.go
@@ -29,6 +29,12 @@ import (
 	"go.kenn.io/agentsview/internal/testjsonl"
 )
 
+// backgroundWaitTimeout bounds waits on background goroutines that are
+// expected to finish promptly. It is generous because cold windows-latest
+// runners can stall a full resync for several seconds; the timeout only
+// delays failure output when the code under test genuinely hangs.
+const backgroundWaitTimeout = 30 * time.Second
+
 func TestHTTPSyncDownloadsArchiveAndImports(t *testing.T) {
 	archive := buildHTTPTestTar(t, map[string]string{
 		"home/wes/.claude/projects/test-project/session.jsonl": testjsonl.NewSessionBuilder().
@@ -572,7 +578,7 @@ func TestDownloadedArchiveExtractionCancellationMidEntry(t *testing.T) {
 
 			select {
 			case <-reached:
-			case <-time.After(time.Second):
+			case <-time.After(backgroundWaitTimeout):
 				require.FailNow(t, "timed out waiting for extraction to enter file body")
 			}
 			cancel()
@@ -581,7 +587,7 @@ func TestDownloadedArchiveExtractionCancellationMidEntry(t *testing.T) {
 			select {
 			case err := <-errCh:
 				require.ErrorIs(t, err, context.Canceled)
-			case <-time.After(time.Second):
+			case <-time.After(backgroundWaitTimeout):
 				require.FailNow(t, "timed out waiting for canceled extraction")
 			}
 			assert.NoFileExists(t,
@@ -1290,7 +1296,7 @@ func TestPreparedHTTPSyncContributorKeepsLockUntilClose(t *testing.T) {
 	}()
 	select {
 	case <-contributorStarted:
-	case <-time.After(time.Second):
+	case <-time.After(backgroundWaitTimeout):
 		require.FailNow(t, "timed out waiting for contributor")
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
@@ -1305,7 +1311,7 @@ func TestPreparedHTTPSyncContributorKeepsLockUntilClose(t *testing.T) {
 	case result := <-rebuilt:
 		require.NoError(t, result.err)
 		assert.False(t, result.stats.Aborted)
-	case <-time.After(time.Second):
+	case <-time.After(backgroundWaitTimeout):
 		require.FailNow(t, "timed out waiting for rebuild")
 	}
 
@@ -1552,7 +1558,7 @@ func TestPrepareHTTPSyncClearsOnlySelectedHostCacheBeforeMirrorMutation(t *testi
 	var snapshot cacheSnapshot
 	select {
 	case snapshot = <-atArchive:
-	case <-time.After(time.Second):
+	case <-time.After(backgroundWaitTimeout):
 		require.FailNow(t, "timed out waiting for archive cache snapshot")
 	}
 	require.NoError(t, snapshot.err)


### PR DESCRIPTION
## Summary

`TestPreparedHTTPSyncContributorKeepsLockUntilClose` failed on windows-latest twice in two days (runs 29300492349 and 29213539491) with `timed out waiting for rebuild` at `http_test.go:1309`. The test's 1-second guard fired while the full resync it was waiting on — fresh DB build, FTS rebuild, atomic swap — was still making progress: the buffered test output shows the resync logging mid-run, and the second failure's 6.78s total test time (vs ~0.15s locally) confirms a stalled runner rather than a hang. This is the same failure class as #951: cold windows-latest runners blow through 1-second deadlines.

The waits are already condition-based channel receives; only the fatal guard deadline was arbitrary. This replaces every fatal 1-second `time.After` guard in `internal/remotesync` tests with a shared 30-second `backgroundWaitTimeout` constant. A generous deadline costs nothing when the code is healthy — the receive completes as soon as the goroutine finishes — and only delays failure output when something genuinely hangs.

Negative assertions (the 20ms "concurrent work must not start" window in `cleanup_registry_test.go`, the 30–50ms "lock must not be acquirable" probes, and the 50ms best-effort rendezvous in the shared-host ordering test) keep their short waits, since lengthening those would either slow every run or weaken the assertion.

Where to look: the constant and its comment at the top of `internal/remotesync/http_test.go`; the remaining sites are mechanical substitutions in `http_test.go`, `archive_test.go`, and `archive_unix_test.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)