### PR TITLE
fix(daemon): report start progress until ready

### DIFF
--- a/cmd/agentsview/daemon.go
+++ b/cmd/agentsview/daemon.go
@@ -132,7 +132,11 @@ func newDaemonCommandWithDeps(deps daemonCommandDeps) *cobra.Command {
 			Use: "start", Short: "Start the background server",
 			SilenceUsage: true, Args: cobra.NoArgs,
 			RunE: func(cmd *cobra.Command, _ []string) error {
-				return runDaemonStart(cmd.OutOrStdout(), deps)
+				ctx, stop := signal.NotifyContext(
+					cmd.Context(), os.Interrupt, syscall.SIGTERM,
+				)
+				defer stop()
+				return runDaemonStart(ctx, cmd.OutOrStdout(), deps)
 			},
 		},
 		&cobra.Command{
@@ -186,7 +190,7 @@ func writableRuntimeFallbackForCommand(cfg config.Config, deps daemonCommandDeps
 	return rt
 }
 
-func runDaemonStart(w io.Writer, deps daemonCommandDeps) error {
+func runDaemonStart(ctx context.Context, w io.Writer, deps daemonCommandDeps) error {
 	dataDir, err := prepareDaemonMutation(deps)
 	if err != nil {
 		return fmt.Errorf("daemon start: %w", err)
@@ -214,11 +218,20 @@ func runDaemonStart(w io.Writer, deps daemonCommandDeps) error {
 	if deps.isStarting(cfg.DataDir) {
 		return daemonPersistentStartupError("daemon start", cfg.DataDir, deps.readStartupState(cfg.DataDir), deps.now())
 	}
+	progress := &daemonLaunchProgressWriter{w: w}
 	result, err := deps.startBackground(
 		cfg, []string{"serve"}, serveReplacementOptions{},
-		backgroundLaunchPolicy{ConfigOnly: true, Operation: "daemon start"},
+		backgroundLaunchPolicy{
+			ConfigOnly: true, Operation: "daemon start",
+			Context: ctx, Attached: true,
+			OnLaunch: progress.launch, OnProgress: progress.progress,
+		},
 	)
 	if err != nil {
+		if result.Started &&
+			(errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
+			return daemonWaitCanceledError("daemon start", result)
+		}
 		return backgroundResultError(err, result)
 	}
 	if result.Started && result.Runtime == nil {
@@ -230,6 +243,9 @@ func runDaemonStart(w io.Writer, deps daemonCommandDeps) error {
 		}
 		return errors.New("daemon start: startup did not publish a writable runtime; inspect serve.log before retrying")
 	}
+	// The attached launch callback already printed the log path alongside
+	// the child identity; keep the completion output to the result line.
+	result.LogPath = ""
 	writeDaemonStartResult(w, result, false)
 	return nil
 }
@@ -440,9 +456,9 @@ func daemonSlowStartupError(
 	)
 }
 
-const daemonRestartProgressHeartbeat = 5 * time.Second
+const daemonLaunchProgressHeartbeat = 5 * time.Second
 
-type daemonRestartProgressWriter struct {
+type daemonLaunchProgressWriter struct {
 	w                  io.Writer
 	phase              string
 	detail             string
@@ -450,21 +466,21 @@ type daemonRestartProgressWriter struct {
 	printedAnyProgress bool
 }
 
-func (p *daemonRestartProgressWriter) launch(pid int, logPath string) {
+func (p *daemonLaunchProgressWriter) launch(pid int, logPath string) {
 	fmt.Fprintf(p.w, "Starting agentsview (pid %d)...\n", pid)
 	if logPath != "" {
 		fmt.Fprintf(p.w, "  log: %s\n", logPath)
 	}
 }
 
-func (p *daemonRestartProgressWriter) progress(
+func (p *daemonLaunchProgressWriter) progress(
 	st *startupState, elapsed time.Duration,
 ) {
 	if st == nil || st.Phase == "" {
 		return
 	}
 	changed := !p.printedAnyProgress || st.Phase != p.phase || st.Detail != p.detail
-	if !changed && elapsed-p.lastPrintedAt < daemonRestartProgressHeartbeat {
+	if !changed && elapsed-p.lastPrintedAt < daemonLaunchProgressHeartbeat {
 		return
 	}
 	line := st.Phase
@@ -692,7 +708,7 @@ func runDaemonRestartWithPolicy(
 		ConfigOnly: true, Operation: "daemon restart",
 	}
 	if attached {
-		progress := &daemonRestartProgressWriter{w: w}
+		progress := &daemonLaunchProgressWriter{w: w}
 		policy.Context = ctx
 		policy.Attached = true
 		policy.OnLaunch = progress.launch
@@ -705,7 +721,7 @@ func runDaemonRestartWithPolicy(
 	if err != nil {
 		if attached && result.Started &&
 			(errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
-			return daemonRestartCanceledError(result)
+			return daemonWaitCanceledError("daemon restart", result)
 		}
 		return backgroundResultError(err, result)
 	}
@@ -737,14 +753,14 @@ func runDaemonRestartWithPolicy(
 	return nil
 }
 
-func daemonRestartCanceledError(result backgroundLaunchResult) error {
+func daemonWaitCanceledError(operation string, result backgroundLaunchResult) error {
 	details := []string{fmt.Sprintf("pid %d", result.childPID)}
 	if result.LogPath != "" {
 		details = append(details, "log "+result.LogPath)
 	}
 	return fmt.Errorf(
-		"daemon restart: wait canceled (%s); the child continues running; run `agentsview daemon status` to inspect it",
-		strings.Join(details, ", "),
+		"%s: wait canceled (%s); the child continues running; run `agentsview daemon status` to inspect it",
+		operation, strings.Join(details, ", "),
 	)
 }
 

--- a/cmd/agentsview/daemon_test.go
+++ b/cmd/agentsview/daemon_test.go
@@ -174,12 +174,76 @@ func TestDaemonStartUsesConfigOnlyPolicyAndIsIdempotent(t *testing.T) {
 	assert.Equal(t, []string{"serve"}, gotArgs)
 	assert.True(t, gotPolicy.ConfigOnly)
 	assert.Equal(t, "daemon start", gotPolicy.Operation)
-	assert.False(t, gotPolicy.Attached)
-	assert.Nil(t, gotPolicy.Context)
-	assert.Nil(t, gotPolicy.OnLaunch)
-	assert.Nil(t, gotPolicy.OnProgress)
+	assert.True(t, gotPolicy.Attached)
+	assert.NotNil(t, gotPolicy.Context)
+	assert.NotNil(t, gotPolicy.OnLaunch)
+	assert.NotNil(t, gotPolicy.OnProgress)
 	assert.Contains(t, out.String(), "already running")
 	assert.Contains(t, out.String(), "pid 41")
+}
+
+func TestDaemonStartStreamsProgressUntilReady(t *testing.T) {
+	deps, out := daemonCommandTestDeps(t)
+	deps.startBackground = func(
+		_ config.Config, _ []string, _ serveReplacementOptions,
+		policy backgroundLaunchPolicy,
+	) (backgroundLaunchResult, error) {
+		assert.True(t, policy.Attached)
+		require.NotNil(t, policy.Context)
+		require.NotNil(t, policy.OnLaunch)
+		require.NotNil(t, policy.OnProgress)
+
+		policy.OnLaunch(92, "/data/serve.log")
+		policy.OnProgress(&startupState{Phase: "opening database"}, 2*time.Second)
+		policy.OnProgress(&startupState{
+			Phase: "initial sync", Detail: "claude: 120/450 sessions (27%)",
+		}, 6*time.Second)
+		policy.OnProgress(&startupState{Phase: "starting HTTP server"}, 18*time.Second)
+		return backgroundLaunchResult{
+			Runtime: &DaemonRuntime{
+				Record: daemon.RuntimeRecord{PID: 92},
+				Host:   "127.0.0.1", Port: 8080,
+			},
+			Started: true, childPID: 92, LogPath: "/data/serve.log",
+		}, nil
+	}
+
+	require.NoError(t, executeDaemonCommand(t, *deps, out, "start"))
+	assert.Equal(t, "Starting agentsview (pid 92)...\n"+
+		"  log: /data/serve.log\n"+
+		"  opening database (2s)\n"+
+		"  initial sync: claude: 120/450 sessions (27%) (6s)\n"+
+		"  starting HTTP server (18s)\n"+
+		"agentsview running at http://127.0.0.1:8080 (pid 92)\n", out.String())
+}
+
+func TestDaemonStartCancellationLeavesChildRunning(t *testing.T) {
+	deps, out := daemonCommandTestDeps(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	deps.startBackground = func(
+		_ config.Config, _ []string, _ serveReplacementOptions,
+		policy backgroundLaunchPolicy,
+	) (backgroundLaunchResult, error) {
+		policy.OnLaunch(93, "/data/serve.log")
+		cancel()
+		return backgroundLaunchResult{
+			Started: true, childPID: 93, LogPath: "/data/serve.log",
+		}, context.Canceled
+	}
+
+	cmd := newDaemonCommandWithDeps(*deps)
+	cmd.SetContext(ctx)
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"start"})
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "pid 93")
+	assert.ErrorContains(t, err, "/data/serve.log")
+	assert.ErrorContains(t, err, "child continues running")
+	assert.ErrorContains(t, err, "agentsview daemon status")
+	assert.Contains(t, out.String(), "Starting agentsview (pid 93)...")
 }
 
 func TestDaemonStopUsesStartupStateFallbackWhileStarting(t *testing.T) {
@@ -775,7 +839,7 @@ func TestDaemonRestartStreamsProgressUntilReady(t *testing.T) {
 
 func TestDaemonRestartProgressHeartbeatUsesUnroundedElapsed(t *testing.T) {
 	var out bytes.Buffer
-	progress := daemonRestartProgressWriter{w: &out}
+	progress := daemonLaunchProgressWriter{w: &out}
 	startedAt := time.Unix(100, 0)
 	state := &startupState{StartedAt: startedAt, Phase: "initial sync"}
 


### PR DESCRIPTION
## Summary

`agentsview daemon start` spawned the child, waited only five seconds for the runtime record, and then exited with a fatal `startup is still in progress` error — even when the daemon was starting normally. Any startup slower than five seconds (database open, initial sync after a stop) made the command fail while the server came up fine moments later, forcing the user to poll `daemon status` by hand.

PR #1115 already fixed this for `daemon restart` by attaching the CLI to the launch: it streams startup-phase progress and waits until the runtime is published. This PR gives `daemon start` the same treatment:

```
Starting agentsview (pid 94345)...
  log: .../serve.log
  initial sync: 900/4800 sessions (19%) · 1800 messages (1s)
  initial sync: 4549/4800 sessions (95%) · 9000 messages (5s)
agentsview running at http://127.0.0.1:8081 (pid 94345)
```

The command now exits 0 with the final URL once the daemon is ready, however long startup takes. Interrupting the wait (Ctrl-C) reports that the child continues running and points at `daemon status`, matching restart's cancellation behavior; the child finishes startup on its own.

## Changes

- `daemon start` wires a signal-notified context and an attached `backgroundLaunchPolicy` (launch + progress callbacks) into `startServeBackground`, mirroring `daemon restart`.
- `daemonRestartProgressWriter` and `daemonRestartCanceledError` are renamed to launch-neutral `daemonLaunchProgressWriter` / `daemonWaitCanceledError` since both commands now share them.
- The detached slow-startup error path is kept as a defensive backstop; `serve restart` keeps its existing detached behavior.

## Where to look

- `cmd/agentsview/daemon.go`: `runDaemonStart` and the `start` subcommand wiring.
- `cmd/agentsview/daemon_test.go`: new progress-streaming and cancellation tests for `daemon start`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)