### PR TITLE
fix(frontend): preserve remote markdown export links

### DIFF
--- a/frontend/src/lib/api/client-markdown-export.test.ts
+++ b/frontend/src/lib/api/client-markdown-export.test.ts
@@ -35,6 +35,18 @@ describe("markdown export URLs", () => {
     );
   });
 
+  it("keeps the configured remote origin in markdown export URLs", () => {
+    storage.getItem.mockImplementation((key: string) =>
+      key === "agentsview-server-url"
+        ? "https://remote.example.test/agentsview"
+        : "",
+    );
+
+    expect(getMarkdownExportUrl("sess-123", "all")).toBe(
+      "https://remote.example.test/agentsview/api/v1/sessions/sess-123/md?depth=all",
+    );
+  });
+
   it("builds markdown export URL for an insight", () => {
     expect(getInsightMarkdownExportUrl(42)).toBe(
       "/api/v1/insights/42/md",

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -10,6 +10,7 @@ import {
   authHeaders,
   getAuthToken,
   getBase,
+  isRemoteConnection,
   responseErrorMessage,
 } from "./runtime.js";
 
@@ -330,6 +331,9 @@ export function getMarkdownExportUrl(
   );
   if (depth !== undefined) {
     url.searchParams.set("depth", String(depth));
+  }
+  if (isRemoteConnection()) {
+    return url.toString();
   }
   return `${url.pathname}${url.search}`;
 }


### PR DESCRIPTION
Preserves the configured remote origin when copying a session Markdown export link.

The URL builder previously discarded the origin before the header resolved the link, sending remote users back to the local UI. Local and base-path links remain relative.
