### PR TITLE
fix(postgres): refresh pricing before pushes

### DIFF
--- a/cmd/agentsview/activity_test.go
+++ b/cmd/agentsview/activity_test.go
@@ -21,6 +21,7 @@ import (
 	"go.kenn.io/agentsview/internal/export"
 	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/pricing"
+	"go.kenn.io/agentsview/internal/pricingrefresh"
 	"go.kenn.io/agentsview/internal/server"
 	"go.kenn.io/agentsview/internal/sync"
 )
@@ -237,7 +238,7 @@ func TestActivityReportJSONMatchesHTTPExportMetadata(t *testing.T) {
 	dbPath := filepath.Join(dataDir, "sessions.db")
 	database := dbtest.OpenTestDBAt(t, dbPath)
 	fallbackModel := fallbackPricedModel(t)
-	require.NoError(t, seedFallbackPricing(database))
+	require.NoError(t, pricingrefresh.SeedFallback(database))
 	seedUsageDailyExportMetadataFixture(t, database, fallbackModel)
 
 	cliOut := captureStdout(t, func() {

--- a/cmd/agentsview/archive_query_backend.go
+++ b/cmd/agentsview/archive_query_backend.go
@@ -11,6 +11,7 @@ import (
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/pricing"
+	"go.kenn.io/agentsview/internal/pricingrefresh"
 	"go.kenn.io/agentsview/internal/sync"
 )
 
@@ -274,9 +275,9 @@ func (b localArchiveQueryBackend) SessionUsage(
 		return nil, tokenUseExitNotFound, nil
 	}
 	if len(u.UnpricedModels) > 0 && !b.offline {
-		refreshed, refErr := refreshPricingIfStale(
+		refreshed, refErr := pricingrefresh.RefreshIfStale(
 			b.database, pricing.FetchLiteLLMPricing,
-			pricingRefreshCooldown, time.Now(),
+			pricingrefresh.RefreshCooldown, time.Now(),
 		)
 		if refErr != nil {
 			fmt.Fprintf(os.Stderr,

--- a/cmd/agentsview/archive_write_backend.go
+++ b/cmd/agentsview/archive_write_backend.go
@@ -16,6 +16,7 @@ import (
 	duckdbsync "go.kenn.io/agentsview/internal/duckdb"
 	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/postgres"
+	"go.kenn.io/agentsview/internal/pricingrefresh"
 	syncpkg "go.kenn.io/agentsview/internal/sync"
 )
 
@@ -389,8 +390,16 @@ func (b daemonArchiveWriteBackend) PGPushWatch(
 }
 
 type localArchiveWriteBackend struct {
-	appCfg   config.Config
-	database *db.DB
+	appCfg        config.Config
+	database      *db.DB
+	ensurePricing func(*db.DB) (bool, error)
+}
+
+func (b *localArchiveWriteBackend) ensureCurrentPricing() (bool, error) {
+	if b.ensurePricing != nil {
+		return b.ensurePricing(b.database)
+	}
+	return pricingrefresh.EnsureCurrent(b.database)
 }
 
 func (b *localArchiveWriteBackend) PGPush(
@@ -403,6 +412,9 @@ func (b *localArchiveWriteBackend) PGPush(
 	didResync := runLocalSync(ctx, b.appCfg, b.database, cfg.Full)
 	if err := ctx.Err(); err != nil {
 		return postgres.PushResult{}, err
+	}
+	if _, err := b.ensureCurrentPricing(); err != nil {
+		log.Printf("warning: pricing refresh failed: %v", err)
 	}
 	forceFull := cfg.Full || didResync
 
@@ -662,6 +674,10 @@ func (b *localArchiveWriteBackend) PGPushWatch(
 			// carry current signal/secret fields.
 			engine.FlushSignals()
 			return nil
+		},
+		ensurePricing: func() error {
+			_, ensureErr := b.ensureCurrentPricing()
+			return ensureErr
 		},
 		connect: func() (pgTarget, error) {
 			applyClassifierConfig(b.appCfg)

--- a/cmd/agentsview/archive_write_backend.go
+++ b/cmd/agentsview/archive_write_backend.go
@@ -392,10 +392,10 @@ func (b daemonArchiveWriteBackend) PGPushWatch(
 type localArchiveWriteBackend struct {
 	appCfg        config.Config
 	database      *db.DB
-	ensurePricing func(*db.DB) (bool, error)
+	ensurePricing func(*db.DB) error
 }
 
-func (b *localArchiveWriteBackend) ensureCurrentPricing() (bool, error) {
+func (b *localArchiveWriteBackend) ensureCurrentPricing() error {
 	if b.ensurePricing != nil {
 		return b.ensurePricing(b.database)
 	}
@@ -407,12 +407,9 @@ func (b *localArchiveWriteBackend) newPGPusher(
 	connect func() (pgTarget, error),
 ) *pgPusher {
 	return &pgPusher{
-		localSync: localSync,
-		ensurePricing: func() error {
-			_, err := b.ensureCurrentPricing()
-			return err
-		},
-		connect: connect,
+		localSync:     localSync,
+		ensurePricing: b.ensureCurrentPricing,
+		connect:       connect,
 	}
 }
 
@@ -427,7 +424,7 @@ func (b *localArchiveWriteBackend) PGPush(
 	if err := ctx.Err(); err != nil {
 		return postgres.PushResult{}, err
 	}
-	if _, err := b.ensureCurrentPricing(); err != nil {
+	if err := b.ensureCurrentPricing(); err != nil {
 		log.Printf("warning: pricing refresh failed: %v", err)
 	}
 	forceFull := cfg.Full || didResync

--- a/cmd/agentsview/archive_write_backend.go
+++ b/cmd/agentsview/archive_write_backend.go
@@ -402,6 +402,20 @@ func (b *localArchiveWriteBackend) ensureCurrentPricing() (bool, error) {
 	return pricingrefresh.EnsureCurrent(b.database)
 }
 
+func (b *localArchiveWriteBackend) newPGPusher(
+	localSync func(context.Context) error,
+	connect func() (pgTarget, error),
+) *pgPusher {
+	return &pgPusher{
+		localSync: localSync,
+		ensurePricing: func() error {
+			_, err := b.ensureCurrentPricing()
+			return err
+		},
+		connect: connect,
+	}
+}
+
 func (b *localArchiveWriteBackend) PGPush(
 	ctx context.Context,
 	target pgTargetSelection,
@@ -666,8 +680,8 @@ func (b *localArchiveWriteBackend) PGPushWatch(
 	vectorSource := pgVectorPushSource(b.appCfg, target, cfg)
 	defer closeVectorPushSource(vectorSource)
 
-	pusher := &pgPusher{
-		localSync: func(c context.Context) error {
+	pusher := b.newPGPusher(
+		func(c context.Context) error {
 			engine.SyncAll(c, nil)
 			// The push scans SQLite rows right after this returns;
 			// flush deferred signal recomputes so pushed sessions
@@ -675,11 +689,7 @@ func (b *localArchiveWriteBackend) PGPushWatch(
 			engine.FlushSignals()
 			return nil
 		},
-		ensurePricing: func() error {
-			_, ensureErr := b.ensureCurrentPricing()
-			return ensureErr
-		},
-		connect: func() (pgTarget, error) {
+		func() (pgTarget, error) {
 			applyClassifierConfig(b.appCfg)
 			s, cErr := postgres.New(
 				target.PG.URL, target.PG.Schema, b.database,
@@ -691,7 +701,7 @@ func (b *localArchiveWriteBackend) PGPushWatch(
 			}
 			return s, nil
 		},
-	}
+	)
 	defer pusher.reset()
 
 	fmt.Printf(

--- a/cmd/agentsview/archive_write_backend.go
+++ b/cmd/agentsview/archive_write_backend.go
@@ -392,14 +392,16 @@ func (b daemonArchiveWriteBackend) PGPushWatch(
 type localArchiveWriteBackend struct {
 	appCfg        config.Config
 	database      *db.DB
-	ensurePricing func(*db.DB) error
+	ensurePricing func(context.Context, *db.DB) error
 }
 
-func (b *localArchiveWriteBackend) ensureCurrentPricing() error {
+func (b *localArchiveWriteBackend) ensureCurrentPricing(
+	ctx context.Context,
+) error {
 	if b.ensurePricing != nil {
-		return b.ensurePricing(b.database)
+		return b.ensurePricing(ctx, b.database)
 	}
-	return pricingrefresh.EnsureCurrent(b.database)
+	return pricingrefresh.EnsureCurrent(ctx, b.database)
 }
 
 func (b *localArchiveWriteBackend) newPGPusher(
@@ -424,8 +426,14 @@ func (b *localArchiveWriteBackend) PGPush(
 	if err := ctx.Err(); err != nil {
 		return postgres.PushResult{}, err
 	}
-	if err := b.ensureCurrentPricing(); err != nil {
+	if err := b.ensureCurrentPricing(ctx); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return postgres.PushResult{}, ctxErr
+		}
 		log.Printf("warning: pricing refresh failed: %v", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return postgres.PushResult{}, err
 	}
 	forceFull := cfg.Full || didResync
 

--- a/cmd/agentsview/archive_write_backend_test.go
+++ b/cmd/agentsview/archive_write_backend_test.go
@@ -97,7 +97,7 @@ func TestLocalArchiveWriteBackendPGPushStopsAfterCanceledLocalSync(t *testing.T)
 
 func TestLocalPGPushEnsuresPricingBeforeConnecting(t *testing.T) {
 	backend := testLocalArchiveWriteBackend(t)
-	backend.ensurePricing = func(database *db.DB) error {
+	backend.ensurePricing = func(_ context.Context, database *db.DB) error {
 		require.NoError(t, database.UpsertModelPricing([]db.ModelPricing{{
 			ModelPattern:  "new-model",
 			InputPerMTok:  2,
@@ -122,7 +122,7 @@ func TestLocalPGPushEnsuresPricingBeforeConnecting(t *testing.T) {
 func TestLocalPGWatchPusherUsesBackendPricingEnsure(t *testing.T) {
 	backend := testLocalArchiveWriteBackend(t)
 	ensureCalls := 0
-	backend.ensurePricing = func(database *db.DB) error {
+	backend.ensurePricing = func(_ context.Context, database *db.DB) error {
 		require.Same(t, backend.database, database)
 		ensureCalls++
 		return nil

--- a/cmd/agentsview/archive_write_backend_test.go
+++ b/cmd/agentsview/archive_write_backend_test.go
@@ -95,6 +95,30 @@ func TestLocalArchiveWriteBackendPGPushStopsAfterCanceledLocalSync(t *testing.T)
 		})
 }
 
+func TestLocalPGPushEnsuresPricingBeforeConnecting(t *testing.T) {
+	backend := testLocalArchiveWriteBackend(t)
+	backend.ensurePricing = func(database *db.DB) (bool, error) {
+		require.NoError(t, database.UpsertModelPricing([]db.ModelPricing{{
+			ModelPattern:  "new-model",
+			InputPerMTok:  2,
+			OutputPerMTok: 8,
+		}}))
+		return true, nil
+	}
+
+	_, err := backend.PGPush(
+		context.Background(),
+		pgTargetSelection{PG: config.PGConfig{URL: unreachablePGURL}},
+		PGPushConfig{}, nil, nil,
+	)
+
+	require.Error(t, err)
+	rate, err := backend.database.GetModelPricing("new-model")
+	require.NoError(t, err)
+	require.NotNil(t, rate)
+	assert.Equal(t, 8.0, rate.OutputPerMTok)
+}
+
 func TestLocalArchiveWriteBackendDuckDBPushStopsAfterCanceledLocalSync(t *testing.T) {
 	testLocalArchivePushStopsAfterCanceledSync(t,
 		func(backend *localArchiveWriteBackend, ctx context.Context) error {

--- a/cmd/agentsview/archive_write_backend_test.go
+++ b/cmd/agentsview/archive_write_backend_test.go
@@ -97,13 +97,13 @@ func TestLocalArchiveWriteBackendPGPushStopsAfterCanceledLocalSync(t *testing.T)
 
 func TestLocalPGPushEnsuresPricingBeforeConnecting(t *testing.T) {
 	backend := testLocalArchiveWriteBackend(t)
-	backend.ensurePricing = func(database *db.DB) (bool, error) {
+	backend.ensurePricing = func(database *db.DB) error {
 		require.NoError(t, database.UpsertModelPricing([]db.ModelPricing{{
 			ModelPattern:  "new-model",
 			InputPerMTok:  2,
 			OutputPerMTok: 8,
 		}}))
-		return true, nil
+		return nil
 	}
 
 	_, err := backend.PGPush(
@@ -122,10 +122,10 @@ func TestLocalPGPushEnsuresPricingBeforeConnecting(t *testing.T) {
 func TestLocalPGWatchPusherUsesBackendPricingEnsure(t *testing.T) {
 	backend := testLocalArchiveWriteBackend(t)
 	ensureCalls := 0
-	backend.ensurePricing = func(database *db.DB) (bool, error) {
+	backend.ensurePricing = func(database *db.DB) error {
 		require.Same(t, backend.database, database)
 		ensureCalls++
-		return true, nil
+		return nil
 	}
 	target := &fakeTarget{}
 	pusher := backend.newPGPusher(

--- a/cmd/agentsview/archive_write_backend_test.go
+++ b/cmd/agentsview/archive_write_backend_test.go
@@ -119,6 +119,27 @@ func TestLocalPGPushEnsuresPricingBeforeConnecting(t *testing.T) {
 	assert.Equal(t, 8.0, rate.OutputPerMTok)
 }
 
+func TestLocalPGWatchPusherUsesBackendPricingEnsure(t *testing.T) {
+	backend := testLocalArchiveWriteBackend(t)
+	ensureCalls := 0
+	backend.ensurePricing = func(database *db.DB) (bool, error) {
+		require.Same(t, backend.database, database)
+		ensureCalls++
+		return true, nil
+	}
+	target := &fakeTarget{}
+	pusher := backend.newPGPusher(
+		func(context.Context) error { return nil },
+		func() (pgTarget, error) { return target, nil },
+	)
+
+	require.NoError(t, pusher.push(
+		context.Background(), reasonChange, false,
+	))
+	assert.Equal(t, 1, ensureCalls)
+	assert.Equal(t, 1, target.pushes)
+}
+
 func TestLocalArchiveWriteBackendDuckDBPushStopsAfterCanceledLocalSync(t *testing.T) {
 	testLocalArchivePushStopsAfterCanceledSync(t,
 		func(backend *localArchiveWriteBackend, ctx context.Context) error {

--- a/cmd/agentsview/pg_watch.go
+++ b/cmd/agentsview/pg_watch.go
@@ -31,7 +31,7 @@ type pgTarget interface {
 // unreachable database never crashes the daemon.
 type pgPusher struct {
 	localSync     func(context.Context) error
-	ensurePricing func() error
+	ensurePricing func(context.Context) error
 	connect       func() (pgTarget, error)
 	target        pgTarget
 }
@@ -45,9 +45,15 @@ func (p *pgPusher) push(
 		return fmt.Errorf("local sync: %w", err)
 	}
 	if p.ensurePricing != nil {
-		if err := p.ensurePricing(); err != nil {
+		if err := p.ensurePricing(ctx); err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
 			log.Printf("warning: pricing refresh failed: %v", err)
 		}
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	if p.target == nil {
 		t, err := p.connect()

--- a/cmd/agentsview/pg_watch.go
+++ b/cmd/agentsview/pg_watch.go
@@ -30,9 +30,10 @@ type pgTarget interface {
 // connecting and reconnecting after errors so a transiently
 // unreachable database never crashes the daemon.
 type pgPusher struct {
-	localSync func(context.Context) error
-	connect   func() (pgTarget, error)
-	target    pgTarget
+	localSync     func(context.Context) error
+	ensurePricing func() error
+	connect       func() (pgTarget, error)
+	target        pgTarget
 }
 
 // push performs one local-sync-then-push cycle. On any PG error it
@@ -42,6 +43,11 @@ func (p *pgPusher) push(
 ) error {
 	if err := p.localSync(ctx); err != nil {
 		return fmt.Errorf("local sync: %w", err)
+	}
+	if p.ensurePricing != nil {
+		if err := p.ensurePricing(); err != nil {
+			log.Printf("warning: pricing refresh failed: %v", err)
+		}
 	}
 	if p.target == nil {
 		t, err := p.connect()

--- a/cmd/agentsview/pg_watch_test.go
+++ b/cmd/agentsview/pg_watch_test.go
@@ -219,7 +219,7 @@ func newTestPgPusher(targets ...*fakeTarget) (*pgPusher, *pusherRecorder) {
 	rec := &pusherRecorder{}
 	p := &pgPusher{
 		localSync:     func(context.Context) error { return nil },
-		ensurePricing: func() error { return nil },
+		ensurePricing: func(context.Context) error { return nil },
 		connect: func() (pgTarget, error) {
 			tgt := targets[rec.connects]
 			rec.connects++
@@ -239,7 +239,7 @@ func TestPGPusherEnsuresPricingAfterLocalSyncBeforeConnect(t *testing.T) {
 			events = append(events, "local sync")
 			return nil
 		},
-		ensurePricing: func() error {
+		ensurePricing: func(context.Context) error {
 			events = append(events, "pricing ensure")
 			return nil
 		},
@@ -263,7 +263,7 @@ func TestPGPusherPricingFailureWarnsAndContinues(t *testing.T) {
 	logs := captureLogOutput(t)
 	pusher := &pgPusher{
 		localSync:     func(context.Context) error { return nil },
-		ensurePricing: func() error { return wantErr },
+		ensurePricing: func(context.Context) error { return wantErr },
 		connect:       func() (pgTarget, error) { return target, nil },
 	}
 
@@ -273,6 +273,28 @@ func TestPGPusherPricingFailureWarnsAndContinues(t *testing.T) {
 	assert.Equal(t, 1, target.pushes)
 	assert.Contains(t, logs.String(), "pricing refresh failed")
 	assert.Contains(t, logs.String(), wantErr.Error())
+}
+
+func TestPGPusherCanceledPricingStopsBeforeConnect(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	connectCalled := false
+	pusher := &pgPusher{
+		localSync: func(context.Context) error { return nil },
+		ensurePricing: func(got context.Context) error {
+			require.Equal(t, ctx, got)
+			cancel()
+			return got.Err()
+		},
+		connect: func() (pgTarget, error) {
+			connectCalled = true
+			return &fakeTarget{}, nil
+		},
+	}
+
+	err := pusher.push(ctx, reasonChange, false)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.False(t, connectCalled)
 }
 
 // requireReconnectAfterTargetError verifies that a push failure on first closes

--- a/cmd/agentsview/pg_watch_test.go
+++ b/cmd/agentsview/pg_watch_test.go
@@ -191,6 +191,7 @@ type fakeTarget struct {
 	ensureErr  error
 	pushErr    error
 	pushResult postgres.PushResult
+	onPush     func()
 	pushes     int
 	closed     int
 }
@@ -200,6 +201,9 @@ func (f *fakeTarget) Push(
 	context.Context, bool, func(postgres.PushProgress),
 ) (postgres.PushResult, error) {
 	f.pushes++
+	if f.onPush != nil {
+		f.onPush()
+	}
 	return f.pushResult, f.pushErr
 }
 func (f *fakeTarget) Close() error { f.closed++; return nil }
@@ -214,7 +218,8 @@ type pusherRecorder struct {
 func newTestPgPusher(targets ...*fakeTarget) (*pgPusher, *pusherRecorder) {
 	rec := &pusherRecorder{}
 	p := &pgPusher{
-		localSync: func(context.Context) error { return nil },
+		localSync:     func(context.Context) error { return nil },
+		ensurePricing: func() error { return nil },
 		connect: func() (pgTarget, error) {
 			tgt := targets[rec.connects]
 			rec.connects++
@@ -222,6 +227,52 @@ func newTestPgPusher(targets ...*fakeTarget) (*pgPusher, *pusherRecorder) {
 		},
 	}
 	return p, rec
+}
+
+func TestPGPusherEnsuresPricingAfterLocalSyncBeforeConnect(t *testing.T) {
+	var events []string
+	target := &fakeTarget{
+		onPush: func() { events = append(events, "push") },
+	}
+	pusher := &pgPusher{
+		localSync: func(context.Context) error {
+			events = append(events, "local sync")
+			return nil
+		},
+		ensurePricing: func() error {
+			events = append(events, "pricing ensure")
+			return nil
+		},
+		connect: func() (pgTarget, error) {
+			events = append(events, "connect")
+			return target, nil
+		},
+	}
+
+	require.NoError(t, pusher.push(
+		context.Background(), reasonChange, false,
+	))
+	assert.Equal(t, []string{
+		"local sync", "pricing ensure", "connect", "push",
+	}, events)
+}
+
+func TestPGPusherPricingFailureWarnsAndContinues(t *testing.T) {
+	wantErr := errors.New("catalog unavailable")
+	target := &fakeTarget{}
+	logs := captureLogOutput(t)
+	pusher := &pgPusher{
+		localSync:     func(context.Context) error { return nil },
+		ensurePricing: func() error { return wantErr },
+		connect:       func() (pgTarget, error) { return target, nil },
+	}
+
+	require.NoError(t, pusher.push(
+		context.Background(), reasonChange, false,
+	))
+	assert.Equal(t, 1, target.pushes)
+	assert.Contains(t, logs.String(), "pricing refresh failed")
+	assert.Contains(t, logs.String(), wantErr.Error())
 }
 
 // requireReconnectAfterTargetError verifies that a push failure on first closes

--- a/cmd/agentsview/usage.go
+++ b/cmd/agentsview/usage.go
@@ -19,6 +19,7 @@ import (
 	"go.kenn.io/agentsview/internal/export"
 	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/pricing"
+	"go.kenn.io/agentsview/internal/pricingrefresh"
 	"go.kenn.io/agentsview/internal/service"
 	"go.kenn.io/agentsview/internal/sync"
 )
@@ -382,27 +383,10 @@ func printSyncSummaryStderr(stats sync.SyncStats, t time.Time) {
 // every restart while still propagating corrected fallback
 // rates when the binary is upgraded.
 func seedPricing(database *db.DB) {
-	if err := seedFallbackPricing(database); err != nil {
+	if err := pricingrefresh.SeedFallback(database); err != nil {
 		log.Printf("pricing seed: %v", err)
 	}
 	go refreshPricingFromLiteLLM(database)
-}
-
-func seedFallbackPricing(database *db.DB) error {
-	const metaKey = "_fallback_version"
-	stored, err := database.GetPricingMeta(metaKey)
-	if err != nil {
-		return err
-	}
-	if stored == pricing.FallbackVersion {
-		return nil
-	}
-	if err := upsertPricing(
-		database, pricing.FallbackPricing(),
-	); err != nil {
-		return err
-	}
-	return database.SetPricingMeta(metaKey, pricing.FallbackVersion)
 }
 
 // refreshPricingFromLiteLLM fetches the upstream LiteLLM
@@ -410,75 +394,15 @@ func seedFallbackPricing(database *db.DB) error {
 // from a goroutine after the synchronous fallback seed so a
 // slow or failing fetch never blocks server startup.
 func refreshPricingFromLiteLLM(database *db.DB) {
-	prices, err := pricing.FetchLiteLLMPricing()
-	if err != nil {
-		log.Printf(
-			"pricing refresh: litellm fetch failed: %v", err,
-		)
-		return
-	}
-	if err := upsertPricing(database, prices); err != nil {
-		log.Printf("pricing refresh: upsert failed: %v", err)
-	}
-}
-
-// pricingRefreshMetaKey marks the last time the CLI tried to
-// refresh model_pricing from LiteLLM. Cooldown is enforced
-// against this value, win or fail, so a repeatedly-failing
-// fetch (offline, DNS broken) does not block every CLI call.
-const pricingRefreshMetaKey = "_litellm_last_attempt"
-
-// pricingRefreshCooldown is the minimum interval between
-// CLI-triggered LiteLLM fetches. Short enough that a newly
-// released model gets priced within hours of the user noticing,
-// long enough that statusline-style repeated CLI invocations
-// don't hammer LiteLLM when a session uses a truly unpriced
-// model (e.g. a local Ollama model).
-const pricingRefreshCooldown = time.Hour
-
-// refreshPricingIfStale fetches the LiteLLM pricing catalog
-// and upserts it when the last attempt is older than cooldown
-// (or has never run). The fetcher is injectable for tests so
-// the cooldown logic can be exercised without network. Returns
-// true when an upsert succeeded; callers can re-query pricing
-// after a true result. Errors from the fetch are returned so
-// the caller can emit a warning; cooldown is recorded before
-// the fetch so a persistent failure won't retry every call.
-func refreshPricingIfStale(
-	database *db.DB,
-	fetch func() ([]pricing.ModelPricing, error),
-	cooldown time.Duration,
-	now time.Time,
-) (bool, error) {
-	stored, err := database.GetPricingMeta(pricingRefreshMetaKey)
-	if err != nil {
-		return false, fmt.Errorf(
-			"reading pricing refresh meta: %w", err)
-	}
-	if stored != "" {
-		last, perr := time.Parse(time.RFC3339, stored)
-		if perr == nil && now.Sub(last) < cooldown {
-			return false, nil
-		}
-	}
-	if err := database.SetPricingMeta(
-		pricingRefreshMetaKey, now.UTC().Format(time.RFC3339),
+	if err := pricingrefresh.Refresh(
+		database, pricing.FetchLiteLLMPricing,
 	); err != nil {
-		return false, fmt.Errorf(
-			"recording pricing refresh attempt: %w", err)
+		log.Printf("pricing refresh: %v", err)
 	}
-	prices, err := fetch()
-	if err != nil {
-		return false, err
-	}
-	if err := upsertPricing(database, prices); err != nil {
-		return false, err
-	}
-	return true, nil
 }
 
 func ensurePricing(database *db.DB, offline bool) {
-	if _, err := ensurePricingWithFetcher(
+	if _, err := pricingrefresh.Ensure(
 		database, offline, pricing.FetchLiteLLMPricing, time.Now(),
 	); err != nil {
 		fmt.Fprintf(os.Stderr,
@@ -520,24 +444,6 @@ func applyFallbackPricing(
 		sources[model] = export.PricingRowSourceCustom
 	}
 	database.SetEffectivePricing(rates, sources)
-}
-
-func ensurePricingWithFetcher(
-	database *db.DB, offline bool,
-	fetch func() ([]pricing.ModelPricing, error),
-	now time.Time,
-) (bool, error) {
-	if offline {
-		return false, upsertPricing(database, pricing.FallbackPricing())
-	}
-
-	if err := seedFallbackPricing(database); err != nil {
-		return false, err
-	}
-
-	return refreshPricingIfStale(
-		database, fetch, pricingRefreshCooldown, now,
-	)
 }
 
 func fetchHTTPDailyUsage(
@@ -617,26 +523,6 @@ func fetchHTTPDailyUsage(
 		Totals:        out.Totals,
 		SessionCounts: out.SessionCounts,
 	}, nil
-}
-
-// upsertPricing copies pricing rows into the db.ModelPricing
-// shape and upserts them. Shared by ensurePricing (CLI),
-// seedPricing (startup fallback), and
-// refreshPricingFromLiteLLM (async refresh).
-func upsertPricing(
-	database *db.DB, prices []pricing.ModelPricing,
-) error {
-	dbPrices := make([]db.ModelPricing, len(prices))
-	for i, p := range prices {
-		dbPrices[i] = db.ModelPricing{
-			ModelPattern:         p.ModelPattern,
-			InputPerMTok:         p.InputPerMTok,
-			OutputPerMTok:        p.OutputPerMTok,
-			CacheCreationPerMTok: p.CacheCreationPerMTok,
-			CacheReadPerMTok:     p.CacheReadPerMTok,
-		}
-	}
-	return database.UpsertModelPricing(dbPrices)
 }
 
 func printDailyTable(

--- a/cmd/agentsview/usage_test.go
+++ b/cmd/agentsview/usage_test.go
@@ -6,7 +6,6 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -24,7 +23,7 @@ import (
 	"go.kenn.io/agentsview/internal/export"
 	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/parsertest"
-	"go.kenn.io/agentsview/internal/pricing"
+	"go.kenn.io/agentsview/internal/pricingrefresh"
 )
 
 var goldenFixtureNow = time.Date(2026, 7, 3, 12, 0, 0, 0, time.UTC)
@@ -986,7 +985,7 @@ func TestUsageDailyJSONIncludesExportMetadata(t *testing.T) {
 	dataDir := testDataDir(t)
 	database := dbtest.OpenTestDBAt(t, filepath.Join(dataDir, "sessions.db"))
 	fallbackModel := fallbackPricedModel(t)
-	require.NoError(t, seedFallbackPricing(database))
+	require.NoError(t, pricingrefresh.SeedFallback(database))
 	seedUsageDailyExportMetadataFixture(t, database, fallbackModel)
 	require.NoError(t, database.Close())
 
@@ -1407,116 +1406,6 @@ func TestNewUsageCursorCommandExplicitMemberFilterDoesNotReuseConfigSibling(t *t
 	}
 }
 
-func TestRefreshPricingIfStale_FreshAttemptSkipsFetch(t *testing.T) {
-	d := newTestDB(t)
-	now := pricingTestNow()
-
-	// Last attempt 10 minutes ago, cooldown 1 hour: skip.
-	prev := seedPricingAttempt(t, d, now, 10*time.Minute)
-
-	fetcher := &pricingFetchRecorder{}
-	refreshed, err := refreshPricingIfStale(
-		d, fetcher.fetch, pricingTestCooldown, now,
-	)
-	require.NoError(t, err)
-	assert.False(t, refreshed, "refreshed = true, want false within cooldown")
-	assert.Zero(t, fetcher.calls, "fetch should not run within cooldown")
-
-	// Meta value preserved (we did not overwrite it).
-	assertPricingAttemptMeta(t, d, prev)
-}
-
-func TestRefreshPricingIfStale_StaleTriggersFetch(t *testing.T) {
-	d := newTestDB(t)
-	now := pricingTestNow()
-
-	// Last attempt 2 hours ago, cooldown 1 hour: refresh.
-	seedPricingAttempt(t, d, now, 2*time.Hour)
-
-	fetcher := &pricingFetchRecorder{rows: []pricing.ModelPricing{{
-		ModelPattern:  "gpt-5.5",
-		InputPerMTok:  1.25,
-		OutputPerMTok: 10.0,
-	}}}
-	refreshed, err := refreshPricingIfStale(
-		d, fetcher.fetch, pricingTestCooldown, now,
-	)
-	require.NoError(t, err)
-	require.True(t, refreshed, "refreshed = false, want true after cooldown")
-
-	// Pricing row written.
-	p, err := d.GetModelPricing("gpt-5.5")
-	require.NoError(t, err)
-	require.NotNil(t, p, "gpt-5.5 row missing")
-	assert.Equal(t, 10.0, p.OutputPerMTok)
-
-	// Meta updated to now.
-	assertPricingAttemptMeta(t, d, now.Format(time.RFC3339))
-}
-
-func TestRefreshPricingIfStale_NeverAttemptedTriggersFetch(t *testing.T) {
-	d := newTestDB(t)
-	now := pricingTestNow()
-
-	fetcher := &pricingFetchRecorder{}
-	refreshed, err := refreshPricingIfStale(
-		d, fetcher.fetch, pricingTestCooldown, now,
-	)
-	require.NoError(t, err)
-	assert.Equal(t, 1, fetcher.calls, "fetch should run when meta empty")
-	assert.True(t, refreshed, "refreshed = false, want true on first attempt")
-}
-
-func TestRefreshPricingIfStale_FetchFailureRecordsAttempt(t *testing.T) {
-	d := newTestDB(t)
-	now := pricingTestNow()
-
-	wantErr := errors.New("network down")
-	fetcher := &pricingFetchRecorder{err: wantErr}
-	refreshed, err := refreshPricingIfStale(
-		d, fetcher.fetch, pricingTestCooldown, now,
-	)
-	assert.ErrorIs(t, err, wantErr)
-	assert.False(t, refreshed, "refreshed = true, want false on fetch failure")
-
-	// Cooldown still recorded so a persistent failure doesn't
-	// retry on every CLI call.
-	assertPricingAttemptMeta(t, d, now.Format(time.RFC3339))
-
-	// A second call within cooldown skips the fetch entirely.
-	second := &pricingFetchRecorder{}
-	_, err = refreshPricingIfStale(
-		d, second.fetch, pricingTestCooldown, now.Add(time.Minute),
-	)
-	require.NoError(t, err)
-	assert.Zero(t, second.calls, "second call should be suppressed by cooldown")
-}
-
-func TestEnsurePricingWithFetcherSkipsFetchWithinCooldown(t *testing.T) {
-	d := newTestDB(t)
-	now := pricingTestNow()
-
-	seedPricingAttempt(t, d, now, 10*time.Minute)
-
-	fetcher := &pricingFetchRecorder{rows: []pricing.ModelPricing{{
-		ModelPattern:  "network-only-model",
-		InputPerMTok:  1,
-		OutputPerMTok: 1,
-	}}}
-	refreshed, err := ensurePricingWithFetcher(d, false, fetcher.fetch, now)
-	require.NoError(t, err)
-	assert.False(t, refreshed)
-	assert.Zero(t, fetcher.calls, "fetch should not run within cooldown")
-
-	fallback, err := d.GetModelPricing("gpt-5.5")
-	require.NoError(t, err)
-	require.NotNil(t, fallback, "fallback pricing should be seeded")
-
-	networkOnly, err := d.GetModelPricing("network-only-model")
-	require.NoError(t, err)
-	assert.Nil(t, networkOnly, "cooldown should prevent network upsert")
-}
-
 // sampleDailyUsageJSON is a full usage summary body with a single day and
 // non-zero totals, shared by the HTTP and daemon usage tests.
 const sampleDailyUsageJSON = `{
@@ -1575,9 +1464,6 @@ const emptyDailyUsageJSON = `{"totals":{},"daily":[]}`
 // totalCostOnlyUsageJSON carries a non-zero total cost but no daily rows.
 const totalCostOnlyUsageJSON = `{"totals":{"totalCost":0.42},"daily":[]}`
 
-// pricingTestCooldown is the cooldown used by the pricing refresh tests.
-const pricingTestCooldown = time.Hour
-
 // newAgentDataDir creates a temp data dir and points AGENTSVIEW_DATA_DIR at it.
 func newAgentDataDir(t *testing.T) string {
 	t.Helper()
@@ -1601,43 +1487,6 @@ func assertNoLocalSessionsDB(t *testing.T, dataDir string) {
 func writeJSONResponse(w http.ResponseWriter, body string) {
 	w.Header().Set("Content-Type", "application/json")
 	_, _ = w.Write([]byte(body))
-}
-
-// pricingTestNow is the fixed clock used by the pricing refresh tests.
-func pricingTestNow() time.Time {
-	return time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
-}
-
-// seedPricingAttempt records a pricing refresh attempt aged `age` before now
-// and returns the RFC3339 timestamp written.
-func seedPricingAttempt(
-	t *testing.T, d *db.DB, now time.Time, age time.Duration,
-) string {
-	t.Helper()
-	ts := now.Add(-age).Format(time.RFC3339)
-	require.NoError(t, d.SetPricingMeta(pricingRefreshMetaKey, ts))
-	return ts
-}
-
-// assertPricingAttemptMeta asserts the stored refresh attempt timestamp.
-func assertPricingAttemptMeta(t *testing.T, d *db.DB, want string) {
-	t.Helper()
-	got, err := d.GetPricingMeta(pricingRefreshMetaKey)
-	require.NoError(t, err)
-	assert.Equal(t, want, got)
-}
-
-// pricingFetchRecorder is a fake pricing fetcher that records call counts and
-// returns canned rows or an error.
-type pricingFetchRecorder struct {
-	calls int
-	rows  []pricing.ModelPricing
-	err   error
-}
-
-func (f *pricingFetchRecorder) fetch() ([]pricing.ModelPricing, error) {
-	f.calls++
-	return f.rows, f.err
 }
 
 // zeroTotalsCopilotUsageJSON is a daily-usage summary with sessions present

--- a/internal/pricing/catalog/litellm.go
+++ b/internal/pricing/catalog/litellm.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -34,8 +35,28 @@ const perMTok = 1_000_000
 // FetchLiteLLMPricing downloads the LiteLLM pricing JSON
 // and parses it into ModelPricing entries.
 func FetchLiteLLMPricing() ([]ModelPricing, error) {
+	return FetchLiteLLMPricingContext(context.Background())
+}
+
+// FetchLiteLLMPricingContext downloads the LiteLLM pricing JSON and binds the
+// request lifetime to ctx.
+func FetchLiteLLMPricingContext(
+	ctx context.Context,
+) ([]ModelPricing, error) {
 	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Get(litellmURL)
+	return fetchLiteLLMPricing(ctx, client, litellmURL)
+}
+
+func fetchLiteLLMPricing(
+	ctx context.Context,
+	client *http.Client,
+	url string,
+) ([]ModelPricing, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating litellm pricing request: %w", err)
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("fetching litellm pricing: %w", err)
 	}

--- a/internal/pricing/catalog/litellm_test.go
+++ b/internal/pricing/catalog/litellm_test.go
@@ -1,0 +1,29 @@
+package catalog
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFetchLiteLLMPricingHonorsCanceledContext(t *testing.T) {
+	var requested atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(
+		w http.ResponseWriter, _ *http.Request,
+	) {
+		requested.Store(true)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := fetchLiteLLMPricing(ctx, server.Client(), server.URL)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.False(t, requested.Load())
+}

--- a/internal/pricing/litellm.go
+++ b/internal/pricing/litellm.go
@@ -1,6 +1,10 @@
 package pricing
 
-import "go.kenn.io/agentsview/internal/pricing/catalog"
+import (
+	"context"
+
+	"go.kenn.io/agentsview/internal/pricing/catalog"
+)
 
 // ModelPricing holds per-model token pricing in cost per
 // million tokens. Separate from db.ModelPricing — the CLI
@@ -11,6 +15,14 @@ type ModelPricing = catalog.ModelPricing
 // and parses it into ModelPricing entries.
 func FetchLiteLLMPricing() ([]ModelPricing, error) {
 	return catalog.FetchLiteLLMPricing()
+}
+
+// FetchLiteLLMPricingContext downloads the LiteLLM pricing JSON and binds the
+// request lifetime to ctx.
+func FetchLiteLLMPricingContext(
+	ctx context.Context,
+) ([]ModelPricing, error) {
+	return catalog.FetchLiteLLMPricingContext(ctx)
 }
 
 // ParseLiteLLMPricing parses the LiteLLM JSON map into

--- a/internal/pricingrefresh/refresh.go
+++ b/internal/pricingrefresh/refresh.go
@@ -1,0 +1,120 @@
+// Package pricingrefresh manages the SQLite model-pricing catalog lifecycle.
+package pricingrefresh
+
+import (
+	"fmt"
+	"time"
+
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/pricing"
+)
+
+const (
+	fallbackVersionMetaKey = "_fallback_version"
+	refreshAttemptMetaKey  = "_litellm_last_attempt"
+)
+
+// RefreshCooldown is the minimum interval between upstream fetch attempts.
+// Attempts are recorded before fetching, so failures observe the same cooldown.
+const RefreshCooldown = time.Hour
+
+// SeedFallback installs the embedded catalog when its version changed.
+func SeedFallback(database *db.DB) error {
+	stored, err := database.GetPricingMeta(fallbackVersionMetaKey)
+	if err != nil {
+		return err
+	}
+	if stored == pricing.FallbackVersion {
+		return nil
+	}
+	if err := upsert(database, pricing.FallbackPricing()); err != nil {
+		return err
+	}
+	return database.SetPricingMeta(
+		fallbackVersionMetaKey, pricing.FallbackVersion,
+	)
+}
+
+// Refresh fetches and stores the upstream pricing catalog immediately.
+func Refresh(
+	database *db.DB,
+	fetch func() ([]pricing.ModelPricing, error),
+) error {
+	prices, err := fetch()
+	if err != nil {
+		return fmt.Errorf("litellm fetch failed: %w", err)
+	}
+	if err := upsert(database, prices); err != nil {
+		return fmt.Errorf("upsert failed: %w", err)
+	}
+	return nil
+}
+
+// RefreshIfStale refreshes when the last attempt is older than cooldown.
+func RefreshIfStale(
+	database *db.DB,
+	fetch func() ([]pricing.ModelPricing, error),
+	cooldown time.Duration,
+	now time.Time,
+) (bool, error) {
+	stored, err := database.GetPricingMeta(refreshAttemptMetaKey)
+	if err != nil {
+		return false, fmt.Errorf("reading pricing refresh meta: %w", err)
+	}
+	if stored != "" {
+		last, parseErr := time.Parse(time.RFC3339, stored)
+		if parseErr == nil && now.Sub(last) < cooldown {
+			return false, nil
+		}
+	}
+	if err := database.SetPricingMeta(
+		refreshAttemptMetaKey, now.UTC().Format(time.RFC3339),
+	); err != nil {
+		return false, fmt.Errorf(
+			"recording pricing refresh attempt: %w", err,
+		)
+	}
+	prices, err := fetch()
+	if err != nil {
+		return false, err
+	}
+	if err := upsert(database, prices); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// Ensure seeds fallback pricing and refreshes online catalogs when due.
+func Ensure(
+	database *db.DB,
+	offline bool,
+	fetch func() ([]pricing.ModelPricing, error),
+	now time.Time,
+) (bool, error) {
+	if offline {
+		return false, upsert(database, pricing.FallbackPricing())
+	}
+	if err := SeedFallback(database); err != nil {
+		return false, err
+	}
+	return RefreshIfStale(database, fetch, RefreshCooldown, now)
+}
+
+// EnsureCurrent applies the standard online pricing lifecycle.
+func EnsureCurrent(database *db.DB) (bool, error) {
+	return Ensure(database, false, pricing.FetchLiteLLMPricing, time.Now())
+}
+
+func upsert(database *db.DB, prices []pricing.ModelPricing) error {
+	dbPrices := make([]db.ModelPricing, len(prices))
+	for i, price := range prices {
+		dbPrices[i] = db.ModelPricing{
+			ModelPattern:         price.ModelPattern,
+			InputPerMTok:         price.InputPerMTok,
+			OutputPerMTok:        price.OutputPerMTok,
+			CacheCreationPerMTok: price.CacheCreationPerMTok,
+			CacheReadPerMTok:     price.CacheReadPerMTok,
+		}
+	}
+	return database.UpsertModelPricing(dbPrices)
+}

--- a/internal/pricingrefresh/refresh.go
+++ b/internal/pricingrefresh/refresh.go
@@ -2,6 +2,7 @@
 package pricingrefresh
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -101,8 +102,11 @@ func Ensure(
 }
 
 // EnsureCurrent applies the standard online pricing lifecycle.
-func EnsureCurrent(database *db.DB) error {
-	_, err := Ensure(database, false, pricing.FetchLiteLLMPricing, time.Now())
+func EnsureCurrent(ctx context.Context, database *db.DB) error {
+	fetch := func() ([]pricing.ModelPricing, error) {
+		return pricing.FetchLiteLLMPricingContext(ctx)
+	}
+	_, err := Ensure(database, false, fetch, time.Now())
 	return err
 }
 

--- a/internal/pricingrefresh/refresh.go
+++ b/internal/pricingrefresh/refresh.go
@@ -103,10 +103,36 @@ func Ensure(
 
 // EnsureCurrent applies the standard online pricing lifecycle.
 func EnsureCurrent(ctx context.Context, database *db.DB) error {
-	fetch := func() ([]pricing.ModelPricing, error) {
-		return pricing.FetchLiteLLMPricingContext(ctx)
+	return ensureCurrent(
+		ctx, database, pricing.FetchLiteLLMPricingContext, time.Now(),
+	)
+}
+
+func ensureCurrent(
+	ctx context.Context,
+	database *db.DB,
+	fetch func(context.Context) ([]pricing.ModelPricing, error),
+	now time.Time,
+) error {
+	previousAttempt, err := database.GetPricingMeta(refreshAttemptMetaKey)
+	if err != nil {
+		return fmt.Errorf("reading pricing refresh meta: %w", err)
 	}
-	_, err := Ensure(database, false, fetch, time.Now())
+	fetchCurrent := func() ([]pricing.ModelPricing, error) {
+		return fetch(ctx)
+	}
+	_, err = Ensure(database, false, fetchCurrent, now)
+	if err == nil || ctx.Err() == nil {
+		return err
+	}
+	if restoreErr := database.SetPricingMeta(
+		refreshAttemptMetaKey, previousAttempt,
+	); restoreErr != nil {
+		return fmt.Errorf(
+			"restoring pricing refresh attempt after cancellation: %v: %w",
+			restoreErr, err,
+		)
+	}
 	return err
 }
 

--- a/internal/pricingrefresh/refresh.go
+++ b/internal/pricingrefresh/refresh.go
@@ -101,8 +101,9 @@ func Ensure(
 }
 
 // EnsureCurrent applies the standard online pricing lifecycle.
-func EnsureCurrent(database *db.DB) (bool, error) {
-	return Ensure(database, false, pricing.FetchLiteLLMPricing, time.Now())
+func EnsureCurrent(database *db.DB) error {
+	_, err := Ensure(database, false, pricing.FetchLiteLLMPricing, time.Now())
+	return err
 }
 
 func upsert(database *db.DB, prices []pricing.ModelPricing) error {

--- a/internal/pricingrefresh/refresh_test.go
+++ b/internal/pricingrefresh/refresh_test.go
@@ -1,0 +1,200 @@
+package pricingrefresh
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/pricing"
+)
+
+const refreshAttemptMetaKeyForTest = "_litellm_last_attempt"
+
+type fetchRecorder struct {
+	calls int
+	rows  []pricing.ModelPricing
+	err   error
+}
+
+func (f *fetchRecorder) fetch() ([]pricing.ModelPricing, error) {
+	f.calls++
+	return f.rows, f.err
+}
+
+func TestEnsureSeedsFallbackAndFetchedModel(t *testing.T) {
+	database := testDB(t)
+	fetcher := &fetchRecorder{rows: []pricing.ModelPricing{{
+		ModelPattern:  "new-model",
+		InputPerMTok:  2,
+		OutputPerMTok: 8,
+	}}}
+
+	refreshed, err := Ensure(
+		database, false, fetcher.fetch, pricingTestNow(),
+	)
+	require.NoError(t, err)
+	assert.True(t, refreshed)
+	assert.Equal(t, 1, fetcher.calls)
+
+	fallback, err := database.GetModelPricing("gpt-5.5")
+	require.NoError(t, err)
+	require.NotNil(t, fallback)
+	fetched, err := database.GetModelPricing("new-model")
+	require.NoError(t, err)
+	require.NotNil(t, fetched)
+	assert.Equal(t, 8.0, fetched.OutputPerMTok)
+}
+
+func TestRefreshIfStaleFreshAttemptSkipsFetch(t *testing.T) {
+	database := testDB(t)
+	now := pricingTestNow()
+	previous := seedPricingAttempt(t, database, now, 10*time.Minute)
+	fetcher := &fetchRecorder{}
+
+	refreshed, err := RefreshIfStale(
+		database, fetcher.fetch, time.Hour, now,
+	)
+
+	require.NoError(t, err)
+	assert.False(t, refreshed)
+	assert.Zero(t, fetcher.calls)
+	assertPricingAttemptMeta(t, database, previous)
+}
+
+func TestRefreshIfStaleStaleTriggersFetch(t *testing.T) {
+	database := testDB(t)
+	now := pricingTestNow()
+	seedPricingAttempt(t, database, now, 2*time.Hour)
+	fetcher := &fetchRecorder{rows: []pricing.ModelPricing{{
+		ModelPattern:  "new-model",
+		InputPerMTok:  1.25,
+		OutputPerMTok: 10,
+	}}}
+
+	refreshed, err := RefreshIfStale(
+		database, fetcher.fetch, time.Hour, now,
+	)
+
+	require.NoError(t, err)
+	assert.True(t, refreshed)
+	price, err := database.GetModelPricing("new-model")
+	require.NoError(t, err)
+	require.NotNil(t, price)
+	assert.Equal(t, 10.0, price.OutputPerMTok)
+	assertPricingAttemptMeta(t, database, now.Format(time.RFC3339))
+}
+
+func TestRefreshIfStaleNeverAttemptedTriggersFetch(t *testing.T) {
+	database := testDB(t)
+	fetcher := &fetchRecorder{}
+
+	refreshed, err := RefreshIfStale(
+		database, fetcher.fetch, time.Hour, pricingTestNow(),
+	)
+
+	require.NoError(t, err)
+	assert.True(t, refreshed)
+	assert.Equal(t, 1, fetcher.calls)
+}
+
+func TestRefreshIfStaleFetchFailureRecordsAttempt(t *testing.T) {
+	database := testDB(t)
+	now := pricingTestNow()
+	wantErr := errors.New("network down")
+	fetcher := &fetchRecorder{err: wantErr}
+
+	refreshed, err := RefreshIfStale(
+		database, fetcher.fetch, time.Hour, now,
+	)
+
+	assert.ErrorIs(t, err, wantErr)
+	assert.False(t, refreshed)
+	assertPricingAttemptMeta(t, database, now.Format(time.RFC3339))
+
+	second := &fetchRecorder{}
+	_, err = RefreshIfStale(
+		database, second.fetch, time.Hour, now.Add(time.Minute),
+	)
+	require.NoError(t, err)
+	assert.Zero(t, second.calls)
+}
+
+func TestEnsureSkipsFetchWithinCooldown(t *testing.T) {
+	database := testDB(t)
+	now := pricingTestNow()
+	seedPricingAttempt(t, database, now, 10*time.Minute)
+	fetcher := &fetchRecorder{rows: []pricing.ModelPricing{{
+		ModelPattern:  "network-only-model",
+		InputPerMTok:  1,
+		OutputPerMTok: 1,
+	}}}
+
+	refreshed, err := Ensure(database, false, fetcher.fetch, now)
+
+	require.NoError(t, err)
+	assert.False(t, refreshed)
+	assert.Zero(t, fetcher.calls)
+	fallback, err := database.GetModelPricing("gpt-5.5")
+	require.NoError(t, err)
+	require.NotNil(t, fallback)
+	networkOnly, err := database.GetModelPricing("network-only-model")
+	require.NoError(t, err)
+	assert.Nil(t, networkOnly)
+}
+
+func TestEnsureOfflineSeedsFallbackWithoutFetch(t *testing.T) {
+	database := testDB(t)
+	fetch := func() ([]pricing.ModelPricing, error) {
+		t.Fatal("offline ensure must not fetch")
+		return nil, nil
+	}
+
+	refreshed, err := Ensure(database, true, fetch, pricingTestNow())
+
+	require.NoError(t, err)
+	assert.False(t, refreshed)
+	fallback, err := database.GetModelPricing("gpt-5.5")
+	require.NoError(t, err)
+	require.NotNil(t, fallback)
+}
+
+func testDB(t *testing.T) *db.DB {
+	t.Helper()
+	return dbtest.OpenTestDBAt(
+		t, filepath.Join(t.TempDir(), "sessions.db"),
+	)
+}
+
+func pricingTestNow() time.Time {
+	return time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
+}
+
+func seedPricingAttempt(
+	t *testing.T,
+	database *db.DB,
+	now time.Time,
+	age time.Duration,
+) string {
+	t.Helper()
+	timestamp := now.Add(-age).Format(time.RFC3339)
+	require.NoError(t, database.SetPricingMeta(
+		refreshAttemptMetaKeyForTest, timestamp,
+	))
+	return timestamp
+}
+
+func assertPricingAttemptMeta(
+	t *testing.T,
+	database *db.DB,
+	want string,
+) {
+	t.Helper()
+	got, err := database.GetPricingMeta(refreshAttemptMetaKeyForTest)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}

--- a/internal/pricingrefresh/refresh_test.go
+++ b/internal/pricingrefresh/refresh_test.go
@@ -1,6 +1,7 @@
 package pricingrefresh
 
 import (
+	"context"
 	"errors"
 	"path/filepath"
 	"testing"
@@ -177,6 +178,33 @@ func TestEnsureOfflineSeedsFallbackWithoutFetch(t *testing.T) {
 	fallback, err := database.GetModelPricing("gpt-5.5")
 	require.NoError(t, err)
 	require.NotNil(t, fallback)
+}
+
+func TestEnsureCurrentCancellationAllowsImmediateRetry(t *testing.T) {
+	database := testDB(t)
+	now := pricingTestNow()
+	previous := seedPricingAttempt(t, database, now, 2*time.Hour)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	err := ensureCurrent(ctx, database, func(
+		context.Context,
+	) ([]pricing.ModelPricing, error) {
+		cancel()
+		return nil, ctx.Err()
+	}, now)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assertPricingAttemptMeta(t, database, previous)
+	retryCalls := 0
+	err = ensureCurrent(context.Background(), database, func(
+		context.Context,
+	) ([]pricing.ModelPricing, error) {
+		retryCalls++
+		return nil, nil
+	}, now.Add(time.Minute))
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, retryCalls)
 }
 
 func testDB(t *testing.T) *db.DB {

--- a/internal/pricingrefresh/refresh_test.go
+++ b/internal/pricingrefresh/refresh_test.go
@@ -124,6 +124,22 @@ func TestRefreshIfStaleFetchFailureRecordsAttempt(t *testing.T) {
 	assert.Zero(t, second.calls)
 }
 
+func TestEnsureFetchFailurePreservesFallback(t *testing.T) {
+	database := testDB(t)
+	wantErr := errors.New("network down")
+	fetcher := &fetchRecorder{err: wantErr}
+
+	refreshed, err := Ensure(
+		database, false, fetcher.fetch, pricingTestNow(),
+	)
+
+	assert.ErrorIs(t, err, wantErr)
+	assert.False(t, refreshed)
+	fallback, priceErr := database.GetModelPricing("gpt-5.5")
+	require.NoError(t, priceErr)
+	require.NotNil(t, fallback)
+}
+
 func TestEnsureSkipsFetchWithinCooldown(t *testing.T) {
 	database := testDB(t)
 	now := pricingTestNow()

--- a/internal/server/huma_routes_push.go
+++ b/internal/server/huma_routes_push.go
@@ -248,8 +248,14 @@ func (s *Server) humaPGPush(
 			var result postgres.PushResult
 			_, err := engine.SyncThenRun(ctx, body.Full, nil,
 				func(forceFull bool) error {
-					if refreshErr := s.ensurePricing(local); refreshErr != nil {
+					if refreshErr := s.ensurePricing(ctx, local); refreshErr != nil {
+						if ctxErr := ctx.Err(); ctxErr != nil {
+							return ctxErr
+						}
 						log.Printf("pricing refresh: %v", refreshErr)
+					}
+					if ctxErr := ctx.Err(); ctxErr != nil {
+						return ctxErr
 					}
 					ps, err := postgres.New(
 						pgCfg.URL, pgCfg.Schema, local,

--- a/internal/server/huma_routes_push.go
+++ b/internal/server/huma_routes_push.go
@@ -248,7 +248,7 @@ func (s *Server) humaPGPush(
 			var result postgres.PushResult
 			_, err := engine.SyncThenRun(ctx, body.Full, nil,
 				func(forceFull bool) error {
-					if _, refreshErr := s.ensurePricing(local); refreshErr != nil {
+					if refreshErr := s.ensurePricing(local); refreshErr != nil {
 						log.Printf("pricing refresh: %v", refreshErr)
 					}
 					ps, err := postgres.New(

--- a/internal/server/huma_routes_push.go
+++ b/internal/server/huma_routes_push.go
@@ -248,6 +248,9 @@ func (s *Server) humaPGPush(
 			var result postgres.PushResult
 			_, err := engine.SyncThenRun(ctx, body.Full, nil,
 				func(forceFull bool) error {
+					if _, refreshErr := s.ensurePricing(local); refreshErr != nil {
+						log.Printf("pricing refresh: %v", refreshErr)
+					}
 					ps, err := postgres.New(
 						pgCfg.URL, pgCfg.Schema, local,
 						pgCfg.MachineName, pgCfg.AllowInsecure,

--- a/internal/server/huma_routes_push_internal_test.go
+++ b/internal/server/huma_routes_push_internal_test.go
@@ -8,12 +8,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
 	duckdbsync "go.kenn.io/agentsview/internal/duckdb"
 	"go.kenn.io/agentsview/internal/postgres"
 )
@@ -214,6 +216,39 @@ func TestPGPushRejectsIncludeAndExcludeProjects(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, statusErr.GetStatus())
 	assert.Contains(t, err.Error(),
 		"projects and exclude_projects are mutually exclusive")
+}
+
+func TestPGPushEnsuresPricingAfterLocalSync(t *testing.T) {
+	s := testServer(t, 30*time.Second)
+	database := s.db.(*db.DB)
+	s.ensurePricing = func(got *db.DB) (bool, error) {
+		require.Same(t, database, got)
+		require.NoError(t, got.UpsertModelPricing([]db.ModelPricing{{
+			ModelPattern:  "new-model",
+			InputPerMTok:  2,
+			OutputPerMTok: 8,
+		}}))
+		return true, nil
+	}
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/push/pg",
+		strings.NewReader(`{"full":false,"pg":{"url":"postgres://nobody:nobody@127.0.0.1:1/test?sslmode=disable","schema":"agentsview","machine_name":"test","allow_insecure":false}}`),
+	)
+	req.Host = "127.0.0.1:0"
+	req.RemoteAddr = "127.0.0.1:1234"
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "http://127.0.0.1:0")
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code,
+		"body: %s", w.Body.String())
+	rate, err := database.GetModelPricing("new-model")
+	require.NoError(t, err)
+	require.NotNil(t, rate)
+	assert.Equal(t, 8.0, rate.OutputPerMTok)
 }
 
 func TestDuckDBPushRejectsIncludeAndExcludeProjects(t *testing.T) {

--- a/internal/server/huma_routes_push_internal_test.go
+++ b/internal/server/huma_routes_push_internal_test.go
@@ -221,14 +221,14 @@ func TestPGPushRejectsIncludeAndExcludeProjects(t *testing.T) {
 func TestPGPushEnsuresPricingAfterLocalSync(t *testing.T) {
 	s := testServer(t, 30*time.Second)
 	database := s.db.(*db.DB)
-	s.ensurePricing = func(got *db.DB) (bool, error) {
+	s.ensurePricing = func(got *db.DB) error {
 		require.Same(t, database, got)
 		require.NoError(t, got.UpsertModelPricing([]db.ModelPricing{{
 			ModelPattern:  "new-model",
 			InputPerMTok:  2,
 			OutputPerMTok: 8,
 		}}))
-		return true, nil
+		return nil
 	}
 
 	req := httptest.NewRequest(

--- a/internal/server/huma_routes_push_internal_test.go
+++ b/internal/server/huma_routes_push_internal_test.go
@@ -221,7 +221,7 @@ func TestPGPushRejectsIncludeAndExcludeProjects(t *testing.T) {
 func TestPGPushEnsuresPricingAfterLocalSync(t *testing.T) {
 	s := testServer(t, 30*time.Second)
 	database := s.db.(*db.DB)
-	s.ensurePricing = func(got *db.DB) error {
+	s.ensurePricing = func(_ context.Context, got *db.DB) error {
 		require.Same(t, database, got)
 		require.NoError(t, got.UpsertModelPricing([]db.ModelPricing{{
 			ModelPattern:  "new-model",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -121,7 +121,7 @@ type Server struct {
 	// push phase skipped, e.g. when [vector] is disabled.
 	vectorPushSource postgres.VectorPushSource
 
-	ensurePricing func(*db.DB) error
+	ensurePricing func(context.Context, *db.DB) error
 }
 
 // New creates a new Server.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -121,7 +121,7 @@ type Server struct {
 	// push phase skipped, e.g. when [vector] is disabled.
 	vectorPushSource postgres.VectorPushSource
 
-	ensurePricing func(*db.DB) (bool, error)
+	ensurePricing func(*db.DB) error
 }
 
 // New creates a new Server.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -23,6 +23,7 @@ import (
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/insight"
 	"go.kenn.io/agentsview/internal/postgres"
+	"go.kenn.io/agentsview/internal/pricingrefresh"
 	"go.kenn.io/agentsview/internal/remotesync"
 	"go.kenn.io/agentsview/internal/service"
 	"go.kenn.io/agentsview/internal/sync"
@@ -119,6 +120,8 @@ type Server struct {
 	// generation to the daemon's pg push handler. Nil leaves the vector
 	// push phase skipped, e.g. when [vector] is disabled.
 	vectorPushSource postgres.VectorPushSource
+
+	ensurePricing func(*db.DB) (bool, error)
 }
 
 // New creates a new Server.
@@ -152,6 +155,7 @@ func New(
 		httpRemoteCleanupRegistry: new(remotesync.CleanupRegistry),
 		insightLogDrainTimeout:    defaultInsightLogDrainTimeout,
 		insightLogStopWaitTimeout: defaultInsightLogStopWaitTimeout,
+		ensurePricing:             pricingrefresh.EnsureCurrent,
 		generateStreamFunc: func(
 			ctx context.Context, agent, prompt string,
 			onLog insight.LogFunc,


### PR DESCRIPTION
PostgreSQL pushes now prepare source SQLite pricing with the same fallback seed, LiteLLM refresh, metadata, and one-hour cooldown used by local usage paths. The shared lifecycle runs after local sync and before PostgreSQL connection for direct, watched, and daemon-delegated pushes, so archive swaps cannot discard fresh rates and newly released models no longer arrive unpriced.

Catalog refresh failures remain warnings and pushes continue with available embedded rates, except cancellation, which now stops before PostgreSQL connection and cancels the in-flight LiteLLM request. `pg serve` remains read-only. The main review points are the extracted lifecycle in `internal/pricingrefresh`, the context-aware fetch in `internal/pricing/catalog`, the direct/watch wiring in `archive_write_backend.go` and `pg_watch.go`, and the daemon callback in `huma_routes_push.go`.
