### PR TITLE
fix(frontend): cancel obsolete UI read queries

### DIFF
--- a/frontend/e2e/read-cancellation.spec.ts
+++ b/frontend/e2e/read-cancellation.spec.ts
@@ -1,0 +1,97 @@
+import {
+  expect,
+  test,
+  type Page,
+  type Request,
+} from "@playwright/test";
+import { clickNavTab } from "./helpers/nav";
+
+async function holdFirstRoute(page: Page, pattern: string) {
+  let releaseGate!: () => void;
+  let reportStarted!: (request: Request) => void;
+  let first = true;
+  const gate = new Promise<void>((resolve) => {
+    releaseGate = resolve;
+  });
+  const started = new Promise<Request>((resolve) => {
+    reportStarted = resolve;
+  });
+
+  await page.route(pattern, async (route) => {
+    if (!first) {
+      await route.continue();
+      return;
+    }
+    first = false;
+    reportStarted(route.request());
+    await gate;
+    try {
+      await route.continue();
+    } catch (error) {
+      if (!/already handled|cancel|closed/i.test(String(error))) throw error;
+    }
+  });
+
+  let released = false;
+  return {
+    started,
+    release() {
+      if (released) return;
+      released = true;
+      releaseGate();
+    },
+  };
+}
+
+test("switching top-level tabs aborts the hidden activity read", async ({
+  page,
+}) => {
+  const held = await holdFirstRoute(page, "**/api/v1/activity/report*");
+  try {
+    await page.goto("/activity");
+    const activityRequest = await held.started;
+    const failed = page.waitForEvent("requestfailed", (request) =>
+      request === activityRequest
+    );
+    const usageStarted = page.waitForRequest((request) =>
+      new URL(request.url()).pathname.endsWith("/api/v1/usage/summary")
+    );
+
+    await clickNavTab(page, "Usage");
+
+    await expect(page.locator(".usage-page")).toBeVisible();
+    await usageStarted;
+    expect((await failed).failure()).not.toBeNull();
+  } finally {
+    held.release();
+  }
+});
+
+test("changing grouping aborts the obsolete trends read", async ({ page }) => {
+  const held = await holdFirstRoute(page, "**/api/v1/trends/terms*");
+  try {
+    await page.goto("/trends");
+    const firstRequest = await held.started;
+    const failed = page.waitForEvent("requestfailed", (request) =>
+      request === firstRequest
+    );
+    const replacementStarted = page.waitForRequest((request) => {
+      const url = new URL(request.url());
+      return url.pathname.endsWith("/api/v1/trends/terms") &&
+        url.searchParams.get("granularity") === "month";
+    });
+
+    await page.locator(".group-trigger").click();
+    await page.getByRole("menuitemradio", { name: "month" }).click();
+
+    await replacementStarted;
+    expect((await failed).failure()).not.toBeNull();
+    held.release();
+    await expect(page.locator(".chart-panel")).toHaveAttribute(
+      "aria-busy",
+      "false",
+    );
+  } finally {
+    held.release();
+  }
+});

--- a/frontend/scripts/generate-api-client.mjs
+++ b/frontend/scripts/generate-api-client.mjs
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import {
   mkdtempSync,
+  readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -17,6 +18,33 @@ const frontendDir = resolve(
   "..",
 );
 const repoRoot = resolve(frontendDir, "..");
+
+function suppressExpectedAbortLogging() {
+  const requestPath = join(
+    frontendDir,
+    "src/lib/api/generated/core/request.ts",
+  );
+  const source = readFileSync(requestPath, "utf8");
+  const generatedCatch = `    } catch (error) {
+      console.error(error);
+    }
+`;
+  const cancellationAwareCatch = `    } catch (error) {
+      if (!(error instanceof DOMException && error.name === 'AbortError')) {
+        console.error(error);
+      }
+    }
+`;
+  if (!source.includes(generatedCatch)) {
+    throw new Error(
+      "generated request body handler no longer matches the abort-log patch",
+    );
+  }
+  writeFileSync(
+    requestPath,
+    source.replace(generatedCatch, cancellationAwareCatch),
+  );
+}
 
 function run(cmd, args, options = {}) {
   const result = spawnSync(cmd, args, {
@@ -60,6 +88,7 @@ try {
   } else {
     run("npx", openapiArgs, { cwd: frontendDir });
   }
+  suppressExpectedAbortLogging();
 } finally {
   rmSync(tempDir, { recursive: true, force: true });
 }

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -401,7 +401,10 @@
     const msgParam = router.params["msg"] ?? null;
     untrack(() => {
       if (sid) {
-        if (sid !== sessions.activeSessionId) {
+        if (
+          sid !== sessions.activeSessionId ||
+          sessions.activeSession === undefined
+        ) {
           sessions.navigateToSession(sid);
         }
         if (msgParam) {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -124,8 +124,18 @@
   // Only track activeSessionId — untrack the rest to prevent
   // reactive loops from messages.loading / messages.messages.
   $effect(() => {
+    const route = router.route;
     const id = sessions.activeSessionId;
     untrack(() => {
+      if (route !== "sessions") {
+        sessions.cancelRouteReads();
+        messages.cancelInFlight();
+        sessionActivity.cancelInFlight();
+        sessionTiming.cancelInFlight();
+        pins.cancelSessionPinsRead();
+        sync.unwatchSession();
+        return;
+      }
       // Preserve selection when a pending scroll is queued
       // for this specific session (e.g. search result
       // navigation sets session + ordinal before this effect

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -138,6 +138,52 @@ describe("App session URL date state", () => {
     expect(loadMessages).toHaveBeenCalledTimes(2);
   });
 
+  it("retries missing metadata when returning to the same session", async () => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    vi.spyOn(settings, "load").mockResolvedValue();
+    vi.spyOn(starred, "load").mockResolvedValue();
+    vi.spyOn(sync, "loadStatus").mockResolvedValue();
+    vi.spyOn(sync, "loadStats").mockResolvedValue();
+    vi.spyOn(sync, "loadVersion").mockResolvedValue();
+    vi.spyOn(sync, "checkForUpdate").mockResolvedValue();
+    vi.spyOn(sync, "startPolling").mockImplementation(() => {});
+    vi.spyOn(sync, "watchSession").mockImplementation(() => {});
+    vi.spyOn(sessions, "load").mockResolvedValue();
+    vi.spyOn(sessions, "loadProjects").mockResolvedValue();
+    vi.spyOn(sessions, "loadAgents").mockResolvedValue();
+    vi.spyOn(sessions, "attachSidebar").mockReturnValue(() => {});
+    vi.spyOn(sessions, "loadChildSessions").mockResolvedValue();
+    vi.spyOn(messages, "loadSession").mockResolvedValue();
+    vi.spyOn(sessionTiming, "load").mockResolvedValue();
+    vi.spyOn(pins, "loadForSession").mockResolvedValue();
+    vi.spyOn(usage, "fetchAll").mockResolvedValue();
+    const navigateToSession = vi
+      .spyOn(sessions, "navigateToSession")
+      .mockResolvedValue();
+
+    sessions.sessions = [];
+    sessions.activeSessionId = "session-1";
+    router.route = "sessions";
+    router.sessionId = "session-1";
+    component = mount(App, { target: document.body });
+    await flushEffects();
+    expect(navigateToSession).toHaveBeenCalledTimes(1);
+
+    router.navigate("usage");
+    await flushEffects();
+    router.navigateToSession("session-1");
+    await flushEffects();
+
+    expect(navigateToSession).toHaveBeenCalledTimes(2);
+  });
+
   it("treats rolling window and termination as sessions route params", () => {
     expect(SESSION_FILTER_KEYS.has("window_days")).toBe(true);
     expect(SESSION_FILTER_KEYS.has("termination")).toBe(true);

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -93,6 +93,51 @@ function appSourceSlice(startMarker: string, endMarker: string): string {
 }
 
 describe("App session URL date state", () => {
+  it("cancels session reads on route exit and restarts an incomplete load on return", async () => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    vi.spyOn(settings, "load").mockResolvedValue();
+    vi.spyOn(starred, "load").mockResolvedValue();
+    vi.spyOn(sync, "loadStatus").mockResolvedValue();
+    vi.spyOn(sync, "loadStats").mockResolvedValue();
+    vi.spyOn(sync, "loadVersion").mockResolvedValue();
+    vi.spyOn(sync, "checkForUpdate").mockResolvedValue();
+    vi.spyOn(sync, "startPolling").mockImplementation(() => {});
+    vi.spyOn(sync, "watchSession").mockImplementation(() => {});
+    vi.spyOn(sessions, "load").mockResolvedValue();
+    vi.spyOn(sessions, "loadProjects").mockResolvedValue();
+    vi.spyOn(sessions, "loadAgents").mockResolvedValue();
+    vi.spyOn(sessions, "attachSidebar").mockReturnValue(() => {});
+    vi.spyOn(sessions, "loadChildSessions").mockResolvedValue();
+    const cancelRouteReads = vi.spyOn(sessions, "cancelRouteReads");
+    const loadMessages = vi.spyOn(messages, "loadSession").mockResolvedValue();
+    const cancelMessages = vi.spyOn(messages, "cancelInFlight");
+    vi.spyOn(sessionTiming, "load").mockResolvedValue();
+    vi.spyOn(pins, "loadForSession").mockResolvedValue();
+    vi.spyOn(usage, "fetchAll").mockResolvedValue();
+
+    router.route = "sessions";
+    router.sessionId = "session-1";
+    sessions.activeSessionId = "session-1";
+    component = mount(App, { target: document.body });
+    await flushEffects();
+
+    router.navigate("usage");
+    await flushEffects();
+    expect(cancelRouteReads).toHaveBeenCalled();
+    expect(cancelMessages).toHaveBeenCalled();
+
+    router.navigateToSession("session-1");
+    await flushEffects();
+    expect(loadMessages).toHaveBeenCalledTimes(2);
+  });
+
   it("treats rolling window and termination as sessions route params", () => {
     expect(SESSION_FILTER_KEYS.has("window_days")).toBe(true);
     expect(SESSION_FILTER_KEYS.has("termination")).toBe(true);

--- a/frontend/src/lib/api/generated/core/request.ts
+++ b/frontend/src/lib/api/generated/core/request.ts
@@ -243,7 +243,9 @@ export const getResponseBody = async (response: Response): Promise<any> => {
         }
       }
     } catch (error) {
-      console.error(error);
+      if (!(error instanceof DOMException && error.name === 'AbortError')) {
+        console.error(error);
+      }
     }
   }
   return undefined;

--- a/frontend/src/lib/api/runtime.test.ts
+++ b/frontend/src/lib/api/runtime.test.ts
@@ -9,6 +9,21 @@ import {
 } from "./generated/index";
 
 describe("callGenerated", () => {
+  it("detaches abort handling after the transport settles", async () => {
+    const cancelTransport = vi.fn();
+    const request = Object.assign(Promise.resolve("done"), {
+      cancel: cancelTransport,
+    });
+    const controller = new AbortController();
+
+    await expect(
+      callGenerated(() => request, controller.signal),
+    ).resolves.toBe("done");
+    controller.abort();
+
+    expect(cancelTransport).not.toHaveBeenCalled();
+  });
+
   it("cancels the generated transport when its signal aborts", async () => {
     const cancelTransport = vi.fn();
     const request = new CancelablePromise<never>(

--- a/frontend/src/lib/api/runtime.test.ts
+++ b/frontend/src/lib/api/runtime.test.ts
@@ -1,13 +1,32 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   ApiError,
   callGenerated,
 } from "./runtime.js";
 import {
   ApiError as GeneratedApiError,
+  CancelablePromise,
 } from "./generated/index";
 
 describe("callGenerated", () => {
+  it("cancels the generated transport when its signal aborts", async () => {
+    const cancelTransport = vi.fn();
+    const request = new CancelablePromise<never>(
+      (_resolve, _reject, onCancel) => {
+        onCancel(cancelTransport);
+      },
+    );
+    const controller = new AbortController();
+
+    const result = callGenerated(() => request, controller.signal);
+    controller.abort();
+
+    await expect(result).rejects.toMatchObject({
+      name: "CancelError",
+    });
+    expect(cancelTransport).toHaveBeenCalledOnce();
+  });
+
   it("normalizes generated API error bodies", async () => {
     await expect(
       callGenerated(async () => {

--- a/frontend/src/lib/api/runtime.ts
+++ b/frontend/src/lib/api/runtime.ts
@@ -195,10 +195,11 @@ export function withAbort<T>(
   if (!signal || !isCancelable(promise)) return promise;
   if (signal.aborted) {
     promise.cancel();
-  } else {
-    signal.addEventListener("abort", () => promise.cancel(), {
-      once: true,
-    });
+    return promise;
   }
-  return promise;
+  const cancel = () => promise.cancel();
+  signal.addEventListener("abort", cancel, { once: true });
+  return promise.finally(() => {
+    signal.removeEventListener("abort", cancel);
+  });
 }

--- a/frontend/src/lib/api/timing.ts
+++ b/frontend/src/lib/api/timing.ts
@@ -6,6 +6,7 @@ import { ApiError, getAuthToken, getBase } from "./runtime.js";
  *  GET /api/v1/sessions/{id}/timing. */
 export async function fetchSessionTiming(
   sessionId: string,
+  signal?: AbortSignal,
 ): Promise<SessionTiming> {
   const headers = new Headers();
   const token = getAuthToken();
@@ -14,7 +15,7 @@ export async function fetchSessionTiming(
   }
   const res = await fetch(
     `${getBase()}/sessions/${encodeURIComponent(sessionId)}/timing`,
-    { headers },
+    { headers, signal },
   );
   if (!res.ok) {
     const body = await res.text();

--- a/frontend/src/lib/components/activity/ActivityInsight.svelte
+++ b/frontend/src/lib/components/activity/ActivityInsight.svelte
@@ -2,7 +2,11 @@
   import { EmptyState, Spinner, Typeahead, type TypeaheadOption } from "@kenn-io/kit-ui";
   import { m } from "../../i18n/index.js";
   import { InsightsService } from "../../api/generated/index";
-  import { configureGeneratedClient } from "../../api/runtime.js";
+  import {
+    callGenerated,
+    configureGeneratedClient,
+    isAbortError,
+  } from "../../api/runtime.js";
   import {
     generateInsight,
     type GenerateInsightHandle,
@@ -14,6 +18,7 @@
   import { highlightCodeFences } from "../../utils/highlight-fences.js";
   import type { Insight, InsightsResponse, AgentName } from "../../api/types.js";
   import { LightbulbIcon, PlusIcon } from "../../icons.js";
+  import { LatestRead } from "../../utils/latest-read.js";
 
   let {
     dateFrom,
@@ -35,6 +40,7 @@
   let genVersion = 0;
   // The in-flight generation, so we can abort it on range change/unmount.
   let handle: GenerateInsightHandle | null = null;
+  const insightListRead = new LatestRead();
 
   /**
    * Open the standalone Insights page prefilled for this panel's range.
@@ -88,19 +94,23 @@
     const from = dateFrom;
     const to = dateTo;
     const v = ++fetchVersion;
+    const signal = insightListRead.begin();
     abortGeneration();
     error = null;
     generating = false;
     loading = true;
 
     configureGeneratedClient();
-    InsightsService.getApiV1Insights({
-      type: "daily_activity",
-      dateFrom: from,
-      dateTo: to,
-    })
+    callGenerated(
+      () => InsightsService.getApiV1Insights({
+        type: "daily_activity",
+        dateFrom: from,
+        dateTo: to,
+      }),
+      signal,
+    )
       .then((res) => {
-        if (v !== fetchVersion) return;
+        if (v !== fetchVersion || !insightListRead.isCurrent(signal)) return;
         // The list endpoint treats date_from/date_to as range BOUNDS, so a
         // multi-day range also returns narrower insights nested inside it
         // (e.g. a single day) and project-scoped ones. This panel shows the
@@ -112,13 +122,18 @@
         insight = list[0] ?? null;
         loading = false;
       })
-      .catch(() => {
+      .catch((e) => {
+        if (isAbortError(e) || !insightListRead.isCurrent(signal)) return;
         if (v !== fetchVersion) return;
         insight = null;
         loading = false;
-      });
+      })
+      .finally(() => insightListRead.finish(signal));
 
-    return abortGeneration;
+    return () => {
+      insightListRead.cancel();
+      abortGeneration();
+    };
   });
 
   // The agent choice is shared with the standalone Insights page via the

--- a/frontend/src/lib/components/activity/ActivityInsight.test.ts
+++ b/frontend/src/lib/components/activity/ActivityInsight.test.ts
@@ -23,7 +23,11 @@ const mocks = vi.hoisted(() => ({
 vi.mock("../../api/generated/index", () => ({
   InsightsService: { getApiV1Insights: mocks.getInsights },
 }));
-vi.mock("../../api/runtime.js", () => ({ configureGeneratedClient: vi.fn() }));
+vi.mock("../../api/runtime.js", () => ({
+  configureGeneratedClient: vi.fn(),
+  callGenerated: vi.fn((request: () => Promise<unknown>) => request()),
+  isAbortError: vi.fn(() => false),
+}));
 vi.mock("../../api/client.js", () => ({
   generateInsight: mocks.generateInsight,
 }));

--- a/frontend/src/lib/components/activity/ActivityPage.svelte
+++ b/frontend/src/lib/components/activity/ActivityPage.svelte
@@ -295,6 +295,7 @@
     // manual button.
     const unsubEvents = events.subscribe(() => activity.markNewData());
     return () => {
+      activity.cancelInFlightReads();
       if (todayRolloverTimer !== undefined) {
         clearTimeout(todayRolloverTimer);
       }

--- a/frontend/src/lib/components/analytics/AnalyticsPage.svelte
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.svelte
@@ -498,6 +498,7 @@
   });
 
   onDestroy(() => {
+    analytics.cancelInFlightReads();
     const state = currentAnalyticsPanelDate();
     if (state) {
       analyticsPageDates.retain(

--- a/frontend/src/lib/components/content/SessionVitals.svelte
+++ b/frontend/src/lib/components/content/SessionVitals.svelte
@@ -1,8 +1,10 @@
 <!-- ABOUTME: Session Vital Signs panel — replaces ActivityMinimap on the right column. -->
 <script lang="ts">
+  import { onDestroy } from "svelte";
   import { sessionTiming } from "../../stores/sessionTiming.svelte.js";
   import { liveTick } from "../../stores/liveTick.svelte.js";
   import { fetchSessionTiming } from "../../api/timing.js";
+  import { isAbortError } from "../../api/runtime.js";
   import { formatDuration } from "../../utils/duration.js";
   import { categoryToken } from "../../utils/categoryToken.js";
   import { displayToolName } from "../../utils/toolDisplay.js";
@@ -19,6 +21,7 @@
   import CallGroup from "./CallGroup.svelte";
   import SubagentCalls from "./SubagentCalls.svelte";
   import { XIcon } from "../../icons.js";
+  import { LatestRead } from "../../utils/latest-read.js";
 
   interface Props {
     sessionId: string;
@@ -45,11 +48,48 @@
   let expandedSubagentIds = $state(new Set<string>());
   let subagentTimings = $state(new Map<string, SessionTiming>());
   let pendingSubagentIds = $state(new Set<string>());
+  const subagentTimingReads = new Map<string, LatestRead>();
+  let subagentReadSessionId: string | null = null;
+
+  function clearPendingSubagent(sid: string) {
+    const next = new Set(pendingSubagentIds);
+    next.delete(sid);
+    pendingSubagentIds = next;
+  }
+
+  function cancelSubagentRead(sid: string) {
+    subagentTimingReads.get(sid)?.cancel();
+    subagentTimingReads.delete(sid);
+    clearPendingSubagent(sid);
+  }
+
+  function cancelAllSubagentReads() {
+    for (const read of subagentTimingReads.values()) read.cancel();
+    subagentTimingReads.clear();
+  }
+
+  $effect(() => {
+    if (subagentReadSessionId === null) {
+      subagentReadSessionId = sessionId;
+      return;
+    }
+    if (sessionId === subagentReadSessionId) return;
+    cancelAllSubagentReads();
+    subagentReadSessionId = sessionId;
+    expandedSubagentIds = new Set();
+    subagentTimings = new Map();
+    pendingSubagentIds = new Set();
+  });
+
+  onDestroy(cancelAllSubagentReads);
 
   async function toggleSubagent(call: CallTiming) {
     if (!call.subagent_session_id) return;
     const sid = call.subagent_session_id;
-    if (pendingSubagentIds.has(sid)) return;
+    if (pendingSubagentIds.has(sid)) {
+      cancelSubagentRead(sid);
+      return;
+    }
     if (expandedSubagentIds.has(sid)) {
       const next = new Set(expandedSubagentIds);
       next.delete(sid);
@@ -57,22 +97,36 @@
       return;
     }
     if (!subagentTimings.has(sid)) {
+      const ownerSessionId = sessionId;
+      const read = new LatestRead();
+      subagentTimingReads.set(sid, read);
+      const signal = read.begin();
       const nextPending = new Set(pendingSubagentIds);
       nextPending.add(sid);
       pendingSubagentIds = nextPending;
       try {
-        const t = await fetchSessionTiming(sid);
-        if (!t) return;
+        const t = await fetchSessionTiming(sid, signal);
+        if (
+          !t ||
+          ownerSessionId !== sessionId ||
+          subagentTimingReads.get(sid) !== read ||
+          !read.isCurrent(signal)
+        ) return;
         const m = new Map(subagentTimings);
         m.set(sid, t);
         subagentTimings = m;
       } catch (err) {
+        if (signal.aborted || isAbortError(err)) return;
         console.error("failed to load sub-agent timing", err);
         return;
       } finally {
-        const cleanup = new Set(pendingSubagentIds);
-        cleanup.delete(sid);
-        pendingSubagentIds = cleanup;
+        if (
+          subagentTimingReads.get(sid) === read &&
+          read.finish(signal)
+        ) {
+          subagentTimingReads.delete(sid);
+          clearPendingSubagent(sid);
+        }
       }
     }
     const next = new Set(expandedSubagentIds);

--- a/frontend/src/lib/components/content/SessionVitals.test.ts
+++ b/frontend/src/lib/components/content/SessionVitals.test.ts
@@ -8,6 +8,7 @@ import {
   vi,
 } from "vitest";
 import { mount, tick, unmount } from "svelte";
+import { cleanup, render } from "@testing-library/svelte";
 import type { SessionTiming } from "../../api/types/timing.js";
 
 const mocks = vi.hoisted(() => {
@@ -26,6 +27,7 @@ const mocks = vi.hoisted(() => {
 
   return {
     fetchSessionTiming: vi.fn().mockResolvedValue(timing),
+    timing,
   };
 });
 
@@ -43,6 +45,7 @@ describe("SessionVitals", () => {
   let component: ReturnType<typeof mount> | undefined;
 
   beforeEach(() => {
+    mocks.fetchSessionTiming.mockReset().mockResolvedValue(mocks.timing);
     sessionTiming.reset();
     ui.vitalsOpen = true;
   });
@@ -54,6 +57,7 @@ describe("SessionVitals", () => {
     }
     sessionTiming.reset();
     ui.vitalsOpen = false;
+    cleanup();
     document.body.innerHTML = "";
   });
 
@@ -77,4 +81,131 @@ describe("SessionVitals", () => {
 
     expect(ui.vitalsOpen).toBe(false);
   });
+
+  it("aborts a pending sub-agent timing read when collapsed", async () => {
+    const signals: AbortSignal[] = [];
+    mocks.fetchSessionTiming.mockImplementation(
+      (sessionId: string, signal?: AbortSignal) => {
+        if (sessionId === "sess-1") return Promise.resolve(mocks.timing);
+        if (signal) signals.push(signal);
+        return new Promise<SessionTiming>(() => {});
+      },
+    );
+    component = mount(SessionVitals, {
+      target: document.body,
+      props: { sessionId: "sess-1" },
+    });
+    await tick();
+    await Promise.resolve();
+    await tick();
+    sessionTiming.applyEvent(parentTimingWithSubagent());
+    await tick();
+
+    const toggle = document.querySelector<HTMLButtonElement>(
+      `button[aria-label="${m.call_row_toggle_subagent_calls()}"]`,
+    );
+    expect(toggle).not.toBeNull();
+    toggle!.click();
+    await tick();
+    expect(signals).toHaveLength(1);
+
+    toggle!.click();
+    await tick();
+
+    expect(signals[0]?.aborted).toBe(true);
+  });
+
+  it("aborts a pending sub-agent timing read when unmounted", async () => {
+    const signals: AbortSignal[] = [];
+    mocks.fetchSessionTiming.mockImplementation(
+      (sessionId: string, signal?: AbortSignal) => {
+        if (sessionId === "sess-1") return Promise.resolve(mocks.timing);
+        if (signal) signals.push(signal);
+        return new Promise<SessionTiming>(() => {});
+      },
+    );
+    component = mount(SessionVitals, {
+      target: document.body,
+      props: { sessionId: "sess-1" },
+    });
+    await tick();
+    await Promise.resolve();
+    await tick();
+    sessionTiming.applyEvent(parentTimingWithSubagent());
+    await tick();
+
+    document
+      .querySelector<HTMLButtonElement>(
+        `button[aria-label="${m.call_row_toggle_subagent_calls()}"]`,
+      )!
+      .click();
+    await tick();
+    expect(signals).toHaveLength(1);
+
+    unmount(component);
+    component = undefined;
+
+    expect(signals[0]?.aborted).toBe(true);
+  });
+
+  it("aborts a pending sub-agent timing read when the parent changes", async () => {
+    const signals: AbortSignal[] = [];
+    mocks.fetchSessionTiming.mockImplementation(
+      (sessionId: string, signal?: AbortSignal) => {
+        if (sessionId.startsWith("sess-")) {
+          return Promise.resolve(mocks.timing);
+        }
+        if (signal) signals.push(signal);
+        return new Promise<SessionTiming>(() => {});
+      },
+    );
+    const view = render(SessionVitals, { sessionId: "sess-1" });
+    await tick();
+    await Promise.resolve();
+    await tick();
+    sessionTiming.applyEvent(parentTimingWithSubagent());
+    await tick();
+
+    document
+      .querySelector<HTMLButtonElement>(
+        `button[aria-label="${m.call_row_toggle_subagent_calls()}"]`,
+      )!
+      .click();
+    await tick();
+    expect(signals).toHaveLength(1);
+
+    await view.rerender({ sessionId: "sess-2" });
+    await tick();
+
+    expect(signals[0]?.aborted).toBe(true);
+  });
 });
+
+function parentTimingWithSubagent(): SessionTiming {
+  return {
+    ...mocks.timing,
+    tool_duration_ms: 400,
+    tool_call_count: 1,
+    subagent_count: 1,
+    turns: [
+      {
+        message_id: 1,
+        ordinal: 1,
+        started_at: "2026-07-14T12:00:00Z",
+        duration_ms: 400,
+        primary_category: "task",
+        calls: [
+          {
+            tool_use_id: "call-1",
+            tool_name: "Task",
+            category: "task",
+            subagent_session_id: "child-1",
+            duration_ms: 400,
+            is_parallel: false,
+            input_preview: "delegate",
+          },
+        ],
+      },
+    ],
+  };
+}

--- a/frontend/src/lib/components/content/SubagentInline.svelte
+++ b/frontend/src/lib/components/content/SubagentInline.svelte
@@ -7,7 +7,11 @@
     Session,
   } from "../../api/types.js";
   import { SessionsService } from "../../api/generated/index";
-  import { configureGeneratedClient } from "../../api/runtime.js";
+  import {
+    callGenerated,
+    configureGeneratedClient,
+    isAbortError,
+  } from "../../api/runtime.js";
   import { formatTokenUsage } from "../../utils/format.js";
   import { computeMainModel } from "../../utils/model.js";
   import { sessions } from "../../stores/sessions.svelte.js";
@@ -18,6 +22,8 @@
     ExternalLinkIcon,
   } from "../../icons.js";
   import { m } from "../../i18n/index.js";
+  import { LatestRead } from "../../utils/latest-read.js";
+  import { onDestroy } from "svelte";
 
   interface Props {
     sessionId: string;
@@ -29,34 +35,62 @@
   let sessionMeta = $state<Session | null>(null);
   let loading = $state(false);
   let error = $state<string | null>(null);
+  const nestedRead = new LatestRead();
+
+  $effect(() => {
+    sessionId;
+    nestedRead.cancel();
+    expanded = false;
+    messages = null;
+    sessionMeta = null;
+    loading = false;
+    error = null;
+  });
+
+  onDestroy(() => nestedRead.cancel());
 
   let subagentSession = $derived(sessions.childSessions.get(sessionId) ?? null);
   let tokenSourceSession = $derived(sessionMeta ?? subagentSession);
 
   async function toggleExpand() {
     expanded = !expanded;
+    if (!expanded) {
+      nestedRead.cancel();
+      loading = false;
+      return;
+    }
     if (expanded && !messages) {
+      const signal = nestedRead.begin();
       loading = true;
       error = null;
       try {
         configureGeneratedClient();
         const [resp, meta] = await Promise.all([
-          SessionsService.getApiV1SessionsIdMessages({
-            id: sessionId,
-            limit: 1000,
-          }) as unknown as Promise<MessagesResponse>,
-          (SessionsService.getApiV1SessionsId({
-            id: sessionId,
-          }) as unknown as Promise<Session>).catch(() => null),
+          callGenerated(
+            () => SessionsService.getApiV1SessionsIdMessages({
+              id: sessionId,
+              limit: 1000,
+            }),
+            signal,
+          ) as unknown as Promise<MessagesResponse>,
+          (callGenerated(
+            () => SessionsService.getApiV1SessionsId({ id: sessionId }),
+            signal,
+          ) as unknown as Promise<Session>).catch((e) => {
+            if (isAbortError(e)) throw e;
+            return null;
+          }),
         ]);
+        if (!nestedRead.isCurrent(signal)) return;
         messages = resp.messages;
         sessionMeta = meta;
       } catch (e) {
+        if (isAbortError(e) || !nestedRead.isCurrent(signal)) return;
         error = e instanceof Error
           ? e.message
           : m.subagent_inline_failed_to_load();
       } finally {
-        loading = false;
+        if (nestedRead.finish(signal)) loading = false;
       }
     }
   }

--- a/frontend/src/lib/components/content/SubagentInline.test.ts
+++ b/frontend/src/lib/components/content/SubagentInline.test.ts
@@ -10,15 +10,20 @@ const {
   getMessages,
   getSession,
   childSessions,
+  callGenerated,
 } = vi.hoisted(() => ({
   getMessages: vi.fn(),
   getSession: vi.fn(),
   childSessions: new Map<string, Session>(),
+  callGenerated: vi.fn(
+    (request: () => Promise<unknown>, _signal?: AbortSignal) => request(),
+  ),
 }));
 
 vi.mock("../../api/runtime.js", () => ({
   configureGeneratedClient: vi.fn(),
-  callGenerated: vi.fn((request: () => Promise<unknown>) => request()),
+  callGenerated,
+  isAbortError: vi.fn(() => false),
 }));
 
 vi.mock("../../api/generated/index", () => ({
@@ -74,10 +79,41 @@ afterEach(() => {
   childSessions.clear();
   getMessages.mockReset();
   getSession.mockReset();
+  callGenerated.mockReset();
+  callGenerated.mockImplementation(
+    (request: () => Promise<unknown>, _signal?: AbortSignal) => request(),
+  );
   document.body.innerHTML = "";
 });
 
 describe("SubagentInline", () => {
+  it("aborts the nested read when collapsed", async () => {
+    const signals: AbortSignal[] = [];
+    callGenerated.mockImplementation((request, signal) => {
+      signals.push(signal as AbortSignal);
+      return request();
+    });
+    getMessages.mockImplementationOnce(() => new Promise(() => {}));
+    getSession.mockImplementationOnce(() => new Promise(() => {}));
+    const component = mount(SubagentInline, {
+      target: document.body,
+      props: { sessionId: "subagent-session-id" },
+    });
+    await tick();
+    const toggle = document.querySelector<HTMLButtonElement>(
+      ".subagent-toggle",
+    )!;
+
+    toggle.click();
+    await tick();
+    toggle.click();
+    await tick();
+
+    expect(signals).toHaveLength(2);
+    expect(signals.every((signal) => signal.aborted)).toBe(true);
+    unmount(component);
+  });
+
   it("renders subagent controls in Simplified Chinese", async () => {
     setLocale("zh-CN");
     childSessions.set(

--- a/frontend/src/lib/components/insights/InsightsPage.svelte
+++ b/frontend/src/lib/components/insights/InsightsPage.svelte
@@ -24,6 +24,8 @@
   import { scoreToGrade } from "../../utils/grade.js";
   import { agentLabel } from "../../utils/agents.js";
   import { AnalyticsService } from "../../api/generated/index.js";
+  import { callGenerated, isAbortError } from "../../api/runtime.js";
+  import { LatestRead } from "../../utils/latest-read.js";
   import type {
     AgentName,
     AutomatedScope,
@@ -72,6 +74,7 @@
   let signalExamplesError: string | null = $state(null);
   let signalExamplesFilterKey: string | null = $state(null);
   let signalExamplesRequest = 0;
+  const signalEvidenceRead = new LatestRead();
   // A materialized page default is not date intent. Only picker input, a
   // dated URL, or a shared seed may serialize dates back into the URL.
   let insightDateIntentEstablished = false;
@@ -402,17 +405,22 @@
     const params = analytics.signalEvidenceParams();
     const requestKey = signalEvidenceKey(signal, params);
     const request = ++signalExamplesRequest;
+    const requestSignal = signalEvidenceRead.begin();
     selectedSignalId = signal;
     signalExamplesFilterKey = requestKey;
     signalExamplesLoading = true;
     signalExamplesError = null;
     try {
-      const response = await AnalyticsService.getApiV1AnalyticsSignalSessions({
-        ...params,
-        signal,
-        limit: 8,
-      });
+      const response = await callGenerated(
+        () => AnalyticsService.getApiV1AnalyticsSignalSessions({
+          ...params,
+          signal,
+          limit: 8,
+        }),
+        requestSignal,
+      );
       if (
+        signalEvidenceRead.isCurrent(requestSignal) &&
         selectedSignalId === signal &&
         signalExamplesFilterKey === requestKey &&
         signalExamplesRequest === request
@@ -420,6 +428,10 @@
         signalExamples = response.sessions ?? [];
       }
     } catch (err) {
+      if (
+        isAbortError(err) ||
+        !signalEvidenceRead.isCurrent(requestSignal)
+      ) return;
       if (
         selectedSignalId === signal &&
         signalExamplesFilterKey === requestKey &&
@@ -431,6 +443,7 @@
       }
     } finally {
       if (
+        signalEvidenceRead.finish(requestSignal) &&
         selectedSignalId === signal &&
         signalExamplesFilterKey === requestKey &&
         signalExamplesRequest === request
@@ -723,6 +736,9 @@
   });
 
   onDestroy(() => {
+    insights.cancelInFlightReads();
+    analytics.cancelInFlightReads();
+    signalEvidenceRead.cancel();
     const state = currentInsightPanelDate();
     if (state) {
       analyticsPageDates.retain(
@@ -1030,8 +1046,10 @@
                 class="text-btn"
                 type="button"
                 onclick={() => {
+                  signalEvidenceRead.cancel();
                   selectedSignalId = null;
                   signalExamples = [];
+                  signalExamplesLoading = false;
                   signalExamplesError = null;
                   signalExamplesFilterKey = null;
                 }}

--- a/frontend/src/lib/components/insights/InsightsPage.test.ts
+++ b/frontend/src/lib/components/insights/InsightsPage.test.ts
@@ -13,6 +13,10 @@ import { analyticsPageDates } from "../../stores/analyticsPageDates.js";
 import { router } from "../../stores/router.svelte.js";
 import { ui } from "../../stores/ui.svelte.js";
 import { yokedDates } from "../../stores/yokedDates.svelte.js";
+import {
+  AnalyticsService,
+  CancelablePromise,
+} from "../../api/generated/index.js";
 // @ts-ignore
 import InsightsPage from "./InsightsPage.svelte";
 import source from "./InsightsPage.svelte?raw";
@@ -371,6 +375,30 @@ describe("InsightsPage date yoke integration", () => {
     });
     expect(router.params.window_days).toBeUndefined();
     expect(yokedDates.range).toBeNull();
+  });
+
+  it("aborts its pending signals transport when unmounted", async () => {
+    const cancelTransport = vi.fn();
+    vi.spyOn(
+      AnalyticsService,
+      "getApiV1AnalyticsSignals",
+    ).mockImplementation(
+      () =>
+        new CancelablePromise((_resolve, _reject, onCancel) => {
+          onCancel(cancelTransport);
+        }),
+    );
+
+    component = mount(InsightsPage, { target: document.body });
+    await flushEffects();
+    expect(
+      AnalyticsService.getApiV1AnalyticsSignals,
+    ).toHaveBeenCalled();
+
+    unmount(component);
+    component = undefined;
+
+    expect(cancelTransport).toHaveBeenCalledOnce();
   });
 
   it("does not turn a bare Insights reload into explicit date intent", async () => {

--- a/frontend/src/lib/components/insights/InsightsPage.test.ts
+++ b/frontend/src/lib/components/insights/InsightsPage.test.ts
@@ -145,6 +145,7 @@ const state = vi.hoisted(() => {
       select: vi.fn(),
       selectTask: vi.fn(),
       cancelAll: vi.fn(),
+      cancelInFlightReads: vi.fn(),
       cancelTask: vi.fn(),
       dismissTask: vi.fn(),
       deleteItem: mocks.deleteItem,

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -166,9 +166,7 @@
   // marker in the session API.
   let costFetchKey: string | null = null;
   let costSessionId: string | null = null;
-  let costRequestSeq = 0;
   let breakdownFetchKey: string | null = null;
-  let breakdownRequestSeq = 0;
 
   function usageFetchKey(s: Session): string {
     return [
@@ -183,12 +181,12 @@
   }
 
   function resetUsageBreakdown() {
+    breakdownRead.cancel();
     sessionUsageBreakdownCount = 0;
     sessionUsageBreakdown = [];
     usageBreakdownOpen = false;
     usageBreakdownLoading = false;
     breakdownFetchKey = null;
-    breakdownRequestSeq++;
   }
 
   $effect(() => {
@@ -198,7 +196,6 @@
       resetUsageBreakdown();
       costFetchKey = null;
       costSessionId = null;
-      costRequestSeq++;
       return;
     }
     const id = session.id;
@@ -215,21 +212,19 @@
     if (key === costFetchKey) return;
     const signal = costRead.begin();
     costSessionId = id;
-    const seq = ++costRequestSeq;
     configureGeneratedClient();
     callGenerated(
       () => SessionsService.getApiV1SessionsIdUsage({ id }),
       signal,
     )
       .then((res) => {
-        if (seq !== costRequestSeq || !costRead.isCurrent(signal)) return;
+        if (!costRead.isCurrent(signal)) return;
         costFetchKey = key;
         sessionCost = res.has_cost ? res.cost_usd : null;
         sessionUsageBreakdownCount = res.breakdown_count ?? 0;
       })
       .catch((e) => {
         if (isAbortError(e) || !costRead.isCurrent(signal)) return;
-        if (seq !== costRequestSeq) return;
         sessionUsageBreakdownCount = 0;
         // Leave the fetch key unset so the next
         // session refresh retries the lookup.
@@ -249,7 +244,6 @@
     const id = session.id;
     const key = usageFetchKey(session);
     if (key === breakdownFetchKey) return;
-    const seq = ++breakdownRequestSeq;
     const signal = breakdownRead.begin();
     usageBreakdownLoading = true;
     configureGeneratedClient();
@@ -258,10 +252,7 @@
       signal,
     )
       .then((res) => {
-        if (
-          seq !== breakdownRequestSeq ||
-          !breakdownRead.isCurrent(signal)
-        ) return;
+        if (!breakdownRead.isCurrent(signal)) return;
         breakdownFetchKey = key;
         usageBreakdownLoading = false;
         sessionUsageBreakdown = Array.isArray(res.breakdown)
@@ -270,7 +261,6 @@
       })
       .catch((e) => {
         if (isAbortError(e) || !breakdownRead.isCurrent(signal)) return;
-        if (seq !== breakdownRequestSeq) return;
         usageBreakdownLoading = false;
         sessionUsageBreakdown = [];
         // Leave the fetch key unset so reopening retries.

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -14,7 +14,7 @@
     SearchIcon,
     SquareTerminalIcon,
   } from "../../icons.js";
-  import { onMount } from "svelte";
+  import { onDestroy, onMount } from "svelte";
   import type { Session } from "../../api/types.js";
   import {
     OpenersService,
@@ -22,7 +22,11 @@
     type ResumeRequest,
     type ResumeResponse,
   } from "../../api/generated/index";
-  import { configureGeneratedClient } from "../../api/runtime.js";
+  import {
+    callGenerated,
+    configureGeneratedClient,
+    isAbortError,
+  } from "../../api/runtime.js";
   import { copyToClipboard } from "../../utils/clipboard.js";
   import {
     agentColor,
@@ -44,6 +48,7 @@
   } from "../../utils/resume.js";
   import { codexDesktopLink } from "../../utils/codex.js";
   import { claudeCodeLink } from "../../utils/claude.js";
+  import { LatestRead } from "../../utils/latest-read.js";
 
   import { inSessionSearch } from "../../stores/inSessionSearch.svelte.js";
   import { messages as messagesStore } from "../../stores/messages.svelte.js";
@@ -68,6 +73,10 @@
   let openFeedback = $state("");
   let feedbackTimer: ReturnType<typeof setTimeout> | undefined;
   let sessionDir = $state<string | null>(null);
+  const openersRead = new LatestRead();
+  const directoryRead = new LatestRead();
+  const costRead = new LatestRead();
+  const breakdownRead = new LatestRead();
 
   interface Opener {
     id: string;
@@ -100,36 +109,49 @@
   }
 
   onMount(() => {
+    const signal = openersRead.begin();
     configureGeneratedClient();
-    OpenersService.getApiV1Openers()
+    callGenerated(() => OpenersService.getApiV1Openers(), signal)
       .then((res) => {
+        if (!openersRead.isCurrent(signal)) return;
         openers = (res as unknown as OpenersResponse).openers;
       })
-      .catch(() => {});
+      .catch((e) => {
+        if (!isAbortError(e)) openers = [];
+      })
+      .finally(() => openersRead.finish(signal));
+    return () => openersRead.cancel();
   });
 
   let resolvedSessionDirId: string | null = null;
   $effect(() => {
     if (!session) {
+      directoryRead.cancel();
       sessionDir = null;
       resolvedSessionDirId = null;
       return;
     }
     const id = session.id;
     if (id === resolvedSessionDirId) return;
+    const signal = directoryRead.begin();
     sessionDir = null;
     configureGeneratedClient();
-    SessionsService.getApiV1SessionsIdDirectory({ id })
+    callGenerated(
+      () => SessionsService.getApiV1SessionsIdDirectory({ id }),
+      signal,
+    )
       .then(({ path }) => {
-        if (session?.id === id) {
+        if (session?.id === id && directoryRead.isCurrent(signal)) {
           sessionDir = (path as SessionDirectoryResponse["path"]) || null;
           resolvedSessionDirId = id;
         }
       })
-      .catch(() => {
+      .catch((e) => {
+        if (isAbortError(e)) return;
         // Don't cache the ID on failure so the next
         // session refresh retries the lookup.
-      });
+      })
+      .finally(() => directoryRead.finish(signal));
   });
 
   let sessionCost = $state<number | null>(null);
@@ -171,6 +193,7 @@
 
   $effect(() => {
     if (!session) {
+      costRead.cancel();
       sessionCost = null;
       resetUsageBreakdown();
       costFetchKey = null;
@@ -190,50 +213,76 @@
       costFetchKey = null;
     }
     if (key === costFetchKey) return;
+    const signal = costRead.begin();
     costSessionId = id;
     const seq = ++costRequestSeq;
     configureGeneratedClient();
-    SessionsService.getApiV1SessionsIdUsage({ id })
+    callGenerated(
+      () => SessionsService.getApiV1SessionsIdUsage({ id }),
+      signal,
+    )
       .then((res) => {
-        if (seq !== costRequestSeq) return;
+        if (seq !== costRequestSeq || !costRead.isCurrent(signal)) return;
         costFetchKey = key;
         sessionCost = res.has_cost ? res.cost_usd : null;
         sessionUsageBreakdownCount = res.breakdown_count ?? 0;
       })
-      .catch(() => {
+      .catch((e) => {
+        if (isAbortError(e) || !costRead.isCurrent(signal)) return;
         if (seq !== costRequestSeq) return;
         sessionUsageBreakdownCount = 0;
         // Leave the fetch key unset so the next
         // session refresh retries the lookup.
-      });
+      })
+      .finally(() => costRead.finish(signal));
   });
 
   // Breakdown rows are fetched only when the menu opens; large
   // sessions can have thousands of entries and the count-only
   // /usage fetch above happens automatically on every session.
   $effect(() => {
-    if (!usageBreakdownOpen || !session) return;
+    if (!usageBreakdownOpen || !session) {
+      breakdownRead.cancel();
+      usageBreakdownLoading = false;
+      return;
+    }
     const id = session.id;
     const key = usageFetchKey(session);
     if (key === breakdownFetchKey) return;
     const seq = ++breakdownRequestSeq;
+    const signal = breakdownRead.begin();
     usageBreakdownLoading = true;
     configureGeneratedClient();
-    SessionsService.getApiV1SessionsIdUsage({ id, breakdown: true })
+    callGenerated(
+      () => SessionsService.getApiV1SessionsIdUsage({ id, breakdown: true }),
+      signal,
+    )
       .then((res) => {
-        if (seq !== breakdownRequestSeq) return;
+        if (
+          seq !== breakdownRequestSeq ||
+          !breakdownRead.isCurrent(signal)
+        ) return;
         breakdownFetchKey = key;
         usageBreakdownLoading = false;
         sessionUsageBreakdown = Array.isArray(res.breakdown)
           ? (res.breakdown as SessionUsageBreakdownEntry[])
           : [];
       })
-      .catch(() => {
+      .catch((e) => {
+        if (isAbortError(e) || !breakdownRead.isCurrent(signal)) return;
         if (seq !== breakdownRequestSeq) return;
         usageBreakdownLoading = false;
         sessionUsageBreakdown = [];
         // Leave the fetch key unset so reopening retries.
-      });
+      })
+      .finally(() => breakdownRead.finish(signal));
+  });
+
+  onDestroy(() => {
+    openersRead.cancel();
+    directoryRead.cancel();
+    costRead.cancel();
+    breakdownRead.cancel();
   });
 
   let sessionCostLabel = $derived(

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -124,16 +124,19 @@
   });
 
   let resolvedSessionDirId: string | null = null;
+  let pendingSessionDirId: string | null = null;
   $effect(() => {
     if (!session) {
       directoryRead.cancel();
       sessionDir = null;
       resolvedSessionDirId = null;
+      pendingSessionDirId = null;
       return;
     }
     const id = session.id;
-    if (id === resolvedSessionDirId) return;
+    if (id === resolvedSessionDirId || id === pendingSessionDirId) return;
     const signal = directoryRead.begin();
+    pendingSessionDirId = id;
     sessionDir = null;
     configureGeneratedClient();
     callGenerated(
@@ -151,7 +154,14 @@
         // Don't cache the ID on failure so the next
         // session refresh retries the lookup.
       })
-      .finally(() => directoryRead.finish(signal));
+      .finally(() => {
+        if (
+          directoryRead.finish(signal) &&
+          pendingSessionDirId === id
+        ) {
+          pendingSessionDirId = null;
+        }
+      });
   });
 
   let sessionCost = $state<number | null>(null);

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
@@ -459,11 +459,16 @@ describe("SessionBreadcrumb", () => {
       expect(document.querySelector(".resume-btn")).toBeTruthy();
     });
     document.querySelector<HTMLButtonElement>(".resume-btn")?.click();
-    await tick();
-    const opener = Array.from(document.querySelectorAll<HTMLButtonElement>(".open-menu-item")).find(
-      (button) => button.textContent?.includes("Test Terminal"),
-    );
-    opener?.click();
+    await vi.waitFor(() => {
+      const opener = Array.from(
+        document.querySelectorAll<HTMLButtonElement>(".open-menu-item"),
+      ).find((button) => button.textContent?.includes("Test Terminal"));
+      expect(opener).toBeTruthy();
+    });
+    const opener = Array.from(
+      document.querySelectorAll<HTMLButtonElement>(".open-menu-item"),
+    ).find((button) => button.textContent?.includes("Test Terminal"));
+    opener!.click();
     await vi.waitFor(() => {
       expect(copyToClipboard).toHaveBeenCalledWith(
         "claude --resume 'run:123456789abcdef' --model 'claude sonnet'",

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
@@ -662,6 +662,51 @@ describe("SessionBreadcrumb", () => {
     await unmount(component);
   });
 
+  it("keeps the directory read across same-session metadata refreshes", async () => {
+    const directory = deferred<{ path: string }>();
+    sessionsService.getApiV1SessionsIdDirectory.mockReturnValue(
+      directory.promise,
+    );
+
+    const component = createClassComponent({
+      component: SessionBreadcrumb,
+      target: document.body,
+      props: {
+        session: makeSession("claude", { message_count: 2 }),
+        onBack: () => {},
+      },
+    });
+    await flushPromises();
+
+    component.$set({
+      session: makeSession("claude", { message_count: 3 }),
+    });
+    await flushPromises();
+    component.$set({
+      session: makeSession("claude", { message_count: 4 }),
+    });
+    await flushPromises();
+
+    expect(
+      sessionsService.getApiV1SessionsIdDirectory,
+    ).toHaveBeenCalledOnce();
+
+    directory.resolve({ path: "/tmp/refreshed-session" });
+    await flushPromises();
+    document.querySelector<HTMLButtonElement>(".resume-btn")?.click();
+    await tick();
+
+    await vi.waitFor(() => {
+      expect(
+        document
+          .querySelector<HTMLAnchorElement>('[data-testid="claude-code-link"]')
+          ?.getAttribute("href"),
+      ).toBe("claude://code/new?folder=%2Ftmp%2Frefreshed-session");
+    });
+
+    component.$destroy();
+  });
+
   it("falls back to blue for unknown agents", async () => {
     const component = mount(SessionBreadcrumb, {
       target: document.body,

--- a/frontend/src/lib/components/modals/PublishModal.svelte
+++ b/frontend/src/lib/components/modals/PublishModal.svelte
@@ -9,9 +9,14 @@
     InsightsService,
     SessionsService,
   } from "../../api/generated/index";
-  import { configureGeneratedClient } from "../../api/runtime.js";
+  import {
+    callGenerated,
+    configureGeneratedClient,
+    isAbortError,
+  } from "../../api/runtime.js";
   import type { PublishResponse } from "../../api/types.js";
   import { copyToClipboard } from "../../utils/clipboard.js";
+  import { LatestRead } from "../../utils/latest-read.js";
 
   type View = "setup" | "progress" | "success" | "error";
 
@@ -20,6 +25,7 @@
   let errorMessage: string = $state("");
   let result: PublishResponse | null = $state(null);
   let closed = false;
+  const configRead = new LatestRead();
 
   const target = ui.publishTarget ??
     (sessions.activeSessionId
@@ -37,17 +43,24 @@
   }
 
   async function init() {
+    const signal = configRead.begin();
     try {
       configureGeneratedClient();
-      const config = await ConfigService.getApiV1ConfigGithub();
-      if (isClosed()) return;
+      const config = await callGenerated(
+        () => ConfigService.getApiV1ConfigGithub(),
+        signal,
+      );
+      if (isClosed() || !configRead.isCurrent(signal)) return;
       if (config.configured) {
         await doPublish();
       } else {
         view = "setup";
       }
-    } catch {
+    } catch (e) {
+      if (isAbortError(e) || !configRead.isCurrent(signal)) return;
       view = "setup";
+    } finally {
+      configRead.finish(signal);
     }
   }
 
@@ -119,6 +132,7 @@
 
   onDestroy(() => {
     closed = true;
+    configRead.cancel();
   });
 
   init();

--- a/frontend/src/lib/components/modals/PublishModal.test.ts
+++ b/frontend/src/lib/components/modals/PublishModal.test.ts
@@ -56,6 +56,8 @@ const sessionState = vi.hoisted(() => ({
 
 vi.mock("../../api/runtime.js", () => ({
   configureGeneratedClient: services.configureGeneratedClient,
+  callGenerated: vi.fn((request: () => Promise<unknown>) => request()),
+  isAbortError: vi.fn(() => false),
 }));
 
 vi.mock("../../api/generated/index", () => ({

--- a/frontend/src/lib/components/pinned/PinnedPage.svelte
+++ b/frontend/src/lib/components/pinned/PinnedPage.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onDestroy } from "svelte";
   import { CopyButton, EmptyState } from "@kenn-io/kit-ui";
   import { m } from "../../i18n/index.js";
   import {
@@ -18,6 +19,8 @@
   $effect(() => {
     pins.loadAll(sessions.filters.project || undefined);
   });
+
+  onDestroy(() => pins.cancelAllPinsRead());
 
   /** Set of expanded pin IDs. */
   let expanded: Set<number> = $state(new Set());

--- a/frontend/src/lib/components/recentedits/RecentEditsPage.svelte
+++ b/frontend/src/lib/components/recentedits/RecentEditsPage.svelte
@@ -3,12 +3,13 @@
   import { PencilIcon } from "../../icons.js";
   import { m } from "../../i18n/index.js";
   import { RecentEditsService } from "../../api/generated/index";
-  import { callGenerated } from "../../api/runtime.js";
+  import { callGenerated, isAbortError } from "../../api/runtime.js";
   import { ui } from "../../stores/ui.svelte.js";
   import { router } from "../../stores/router.svelte.js";
   import { sessions } from "../../stores/sessions.svelte.js";
   import { formatRelativeTime } from "../../utils/format.js";
   import ProjectTypeahead from "../layout/ProjectTypeahead.svelte";
+  import { LatestRead } from "../../utils/latest-read.js";
 
   interface Edit {
     session_id: string;
@@ -47,6 +48,7 @@
   let requestSeq = 0;
   // Debounce timer for the file-path search box; plain, gates control flow.
   let searchTimer: ReturnType<typeof setTimeout> | undefined;
+  const pageRead = new LatestRead();
 
   function key(f: FileRow) {
     return JSON.stringify([f.project, f.file_path]);
@@ -59,6 +61,7 @@
 
   async function load(reset = false) {
     const seq = ++requestSeq;
+    const signal = pageRead.begin();
     const project = sessions.filters.project || undefined;
     const searchTerm = search.trim() || undefined;
     // Derive the page offset from what is already loaded so a failed page
@@ -77,17 +80,19 @@
           project,
           search: searchTerm,
         }),
+        signal,
       )) as unknown as Resp;
       // A newer project change, refresh, or load-more supersedes this one.
-      if (seq !== requestSeq) return;
+      if (seq !== requestSeq || !pageRead.isCurrent(signal)) return;
       files = reset
         ? (res.files ?? [])
         : [...files, ...(res.files ?? [])];
       hasMore = res.has_more ?? false;
-    } catch {
+    } catch (e) {
+      if (isAbortError(e) || !pageRead.isCurrent(signal)) return;
       // leave current list; empty state covers first load
     } finally {
-      if (seq === requestSeq) loading = false;
+      if (pageRead.finish(signal)) loading = false;
     }
   }
 
@@ -123,7 +128,10 @@
   }
 
   // Drop a pending debounced search if the page unmounts mid-typing.
-  $effect(() => () => clearTimeout(searchTimer));
+  $effect(() => () => {
+    clearTimeout(searchTimer);
+    pageRead.cancel();
+  });
 
   // Initial load, and reload when the header's project filter changes.
   // No SSE subscription: feed only reloads on open, explicit refresh,

--- a/frontend/src/lib/components/recentedits/RecentEditsPage.test.ts
+++ b/frontend/src/lib/components/recentedits/RecentEditsPage.test.ts
@@ -38,6 +38,7 @@ const mocks = vi.hoisted(() => ({
     ],
     has_more: false,
   })),
+  signals: [] as AbortSignal[],
 }));
 
 vi.mock("../../api/generated/index", () => ({
@@ -47,7 +48,11 @@ vi.mock("../../api/generated/index", () => ({
 }));
 
 vi.mock("../../api/runtime.js", () => ({
-  callGenerated: (fn: () => unknown) => fn(),
+  callGenerated: (fn: () => unknown, signal?: AbortSignal) => {
+    if (signal) mocks.signals.push(signal);
+    return fn();
+  },
+  isAbortError: vi.fn(() => false),
   configureGeneratedClient: () => {},
 }));
 
@@ -79,7 +84,22 @@ describe("RecentEditsPage", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.signals.length = 0;
     setLocale("en");
+  });
+
+  it("aborts the visible page read when unmounted", async () => {
+    mocks.getApiV1RecentEdits.mockImplementationOnce(
+      () => new Promise(() => {}),
+    );
+    component = mount(RecentEditsPage, { target: document.body });
+    await tick();
+    const signal = mocks.signals[0];
+
+    unmount(component);
+    component = undefined;
+
+    expect(signal?.aborted).toBe(true);
   });
 
   afterEach(() => {

--- a/frontend/src/lib/components/settings/EmbeddingsSettings.svelte
+++ b/frontend/src/lib/components/settings/EmbeddingsSettings.svelte
@@ -5,7 +5,12 @@
   import { EmbeddingsService } from "../../api/generated/index";
   import type { VectorBuildStatus } from "../../api/generated/index";
   import type { VectorGenerationInfo } from "../../api/generated/models/VectorGenerationInfo";
-  import { ApiError, callGenerated } from "../../api/runtime.js";
+  import {
+    ApiError,
+    callGenerated,
+    isAbortError,
+  } from "../../api/runtime.js";
+  import { LatestRead } from "../../utils/latest-read.js";
 
   // Poll fast only while a build is actually running; when idle the section
   // only needs to notice an externally started build (CLI, scheduler)
@@ -26,6 +31,8 @@
   let timer: ReturnType<typeof setTimeout> | null = null;
   let disposed = false;
   let activePollsSinceGenerations = 0;
+  const statusRead = new LatestRead();
+  const generationsRead = new LatestRead();
 
   const numberFormat = $derived(new Intl.NumberFormat(getLocale()));
   const percentFormat = $derived(
@@ -72,11 +79,13 @@
   }
 
   async function refresh(withGenerations: boolean): Promise<void> {
+    const signal = statusRead.begin();
     try {
       const next = await callGenerated(() =>
         EmbeddingsService.getApiV1EmbeddingsStatus(),
+        signal,
       );
-      if (disposed) return;
+      if (disposed || !statusRead.isCurrent(signal)) return;
       const wasRunning = status?.running ?? false;
       status = next;
       unavailableReason = null;
@@ -87,7 +96,11 @@
         await refreshGenerations();
       }
     } catch (e) {
-      if (disposed) return;
+      if (
+        disposed ||
+        isAbortError(e) ||
+        !statusRead.isCurrent(signal)
+      ) return;
       elapsedMs = null;
       if (e instanceof ApiError && e.status === 501) {
         unavailableReason = e.message;
@@ -101,16 +114,22 @@
             : m.settings_embeddings_load_failed();
       }
     } finally {
-      loaded = true;
+      if (statusRead.finish(signal)) loaded = true;
     }
   }
 
   async function refreshGenerations(): Promise<void> {
-    const res = await callGenerated(() =>
-      EmbeddingsService.getApiV1EmbeddingsGenerations(),
-    );
-    if (disposed) return;
-    generations = (res.generations ?? []) as VectorGenerationInfo[];
+    const signal = generationsRead.begin();
+    try {
+      const res = await callGenerated(() =>
+        EmbeddingsService.getApiV1EmbeddingsGenerations(),
+        signal,
+      );
+      if (disposed || !generationsRead.isCurrent(signal)) return;
+      generations = (res.generations ?? []) as VectorGenerationInfo[];
+    } finally {
+      generationsRead.finish(signal);
+    }
   }
 
   function updateElapsed(s: VectorBuildStatus): void {
@@ -126,6 +145,8 @@
   function onVisibilityChange(): void {
     if (document.hidden) {
       clearTimer();
+      statusRead.cancel();
+      generationsRead.cancel();
       return;
     }
     clearTimer();
@@ -137,6 +158,8 @@
     document.addEventListener("visibilitychange", onVisibilityChange);
     return () => {
       disposed = true;
+      statusRead.cancel();
+      generationsRead.cancel();
       clearTimer();
       document.removeEventListener("visibilitychange", onVisibilityChange);
     };

--- a/frontend/src/lib/components/settings/RemoteSettings.svelte
+++ b/frontend/src/lib/components/settings/RemoteSettings.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onDestroy } from "svelte";
   import { m } from "../../i18n/index.js";
   import SettingsSection from "./SettingsSection.svelte";
   import { copyToClipboard } from "../../utils/clipboard.js";
@@ -10,6 +11,7 @@
     setAuthToken,
     isRemoteConnection,
   } from "../../api/runtime.js";
+  import { LatestRead } from "../../utils/latest-read.js";
 
   let serverUrl: string = $state(getServerUrl());
   let tokenInput: string = $state(getAuthToken());
@@ -21,10 +23,12 @@
 
   let isRemote: boolean = $derived(isRemoteConnection());
   let copied: boolean = $state(false);
+  const versionRead = new LatestRead();
 
   async function handleTestConnection() {
     if (!serverUrl.trim()) return;
     testing = true;
+    const signal = versionRead.begin();
     testResult = null;
     try {
       const base = serverUrl.replace(/\/+$/, "");
@@ -32,7 +36,8 @@
       if (tokenInput.trim()) {
         headers["Authorization"] = `Bearer ${tokenInput.trim()}`;
       }
-      const res = await fetch(`${base}/api/v1/version`, { headers });
+      const res = await fetch(`${base}/api/v1/version`, { headers, signal });
+      if (!versionRead.isCurrent(signal)) return;
       if (res.ok) {
         const data = await res.json();
         testResult = {
@@ -43,14 +48,17 @@
         testResult = { ok: false, message: m.settings_remote_server_returned({ status: res.status }) };
       }
     } catch (e) {
+      if (signal.aborted || !versionRead.isCurrent(signal)) return;
       testResult = {
         ok: false,
         message: e instanceof Error ? e.message : m.settings_remote_connection_failed(),
       };
     } finally {
-      testing = false;
+      if (versionRead.finish(signal)) testing = false;
     }
   }
+
+  onDestroy(() => versionRead.cancel());
 
   function handleConnect() {
     if (!serverUrl.trim()) return;

--- a/frontend/src/lib/components/settings/WorktreeMappingSettings.svelte
+++ b/frontend/src/lib/components/settings/WorktreeMappingSettings.svelte
@@ -7,7 +7,9 @@
     type DbWorktreeProjectMapping,
     type WorktreeMappingRequest,
   } from "../../api/generated/index";
-  import { callGenerated } from "../../api/runtime.js";
+  import { callGenerated, isAbortError } from "../../api/runtime.js";
+  import { LatestRead } from "../../utils/latest-read.js";
+  import { onDestroy } from "svelte";
 
   interface WorktreeMappingsResponse {
     machine: string;
@@ -35,9 +37,12 @@
   let layout = $state(explicitLayout);
   let project = $state("");
   let enabled = $state(true);
+  const mappingsRead = new LatestRead();
+  let disposed = false;
 
   $effect(() => {
     if (readOnly) {
+      mappingsRead.cancel();
       loading = false;
       return;
     }
@@ -45,21 +50,31 @@
   });
 
   async function loadMappings() {
+    if (disposed) return;
+    const signal = mappingsRead.begin();
     loading = true;
     error = "";
     try {
       const res =
         await callGenerated(() =>
           SettingsService.getApiV1SettingsWorktreeMappings(),
+          signal,
         ) as unknown as WorktreeMappingsResponse;
+      if (!mappingsRead.isCurrent(signal)) return;
       machine = res.machine;
       mappings = res.mappings;
     } catch (err) {
+      if (isAbortError(err) || !mappingsRead.isCurrent(signal)) return;
       error = err instanceof Error ? err.message : m.worktree_failed_load();
     } finally {
-      loading = false;
+      if (mappingsRead.finish(signal)) loading = false;
     }
   }
+
+  onDestroy(() => {
+    disposed = true;
+    mappingsRead.cancel();
+  });
 
   function resetForm() {
     editingId = null;

--- a/frontend/src/lib/components/trash/TrashPage.svelte
+++ b/frontend/src/lib/components/trash/TrashPage.svelte
@@ -2,16 +2,22 @@
   import { EmptyState } from "@kenn-io/kit-ui";
   import { m } from "../../i18n/index.js";
   import { TrashIcon } from "../../icons.js";
-  import { onMount } from "svelte";
+  import { onDestroy, onMount } from "svelte";
   import type { Session } from "../../api/types.js";
   import { SessionsService } from "../../api/generated/index";
-  import { configureGeneratedClient } from "../../api/runtime.js";
+  import {
+    callGenerated,
+    configureGeneratedClient,
+    isAbortError,
+  } from "../../api/runtime.js";
   import { sessions } from "../../stores/sessions.svelte.js";
   import { formatRelativeTime, truncate } from "../../utils/format.js";
   import { normalizeMessagePreview } from "../../utils/messages.js";
+  import { LatestRead } from "../../utils/latest-read.js";
   let trashedSessions: Session[] = $state([]);
   let loading = $state(true);
   let emptying = $state(false);
+  const trashRead = new LatestRead();
 
   interface TrashResponse {
     sessions: Session[];
@@ -22,18 +28,25 @@
   });
 
   async function loadTrash() {
+    const signal = trashRead.begin();
     loading = true;
     try {
       configureGeneratedClient();
-      const res =
-        await SessionsService.getApiV1Trash() as unknown as TrashResponse;
+      const res = await callGenerated(
+        () => SessionsService.getApiV1Trash(),
+        signal,
+      ) as unknown as TrashResponse;
+      if (!trashRead.isCurrent(signal)) return;
       trashedSessions = res.sessions ?? [];
-    } catch {
+    } catch (e) {
+      if (isAbortError(e) || !trashRead.isCurrent(signal)) return;
       // Silently ignore — page will show empty state.
     } finally {
-      loading = false;
+      if (trashRead.finish(signal)) loading = false;
     }
   }
+
+  onDestroy(() => trashRead.cancel());
 
   async function restoreSession(id: string) {
     try {

--- a/frontend/src/lib/components/trends/TrendsPage.svelte
+++ b/frontend/src/lib/components/trends/TrendsPage.svelte
@@ -248,6 +248,7 @@
     document.addEventListener("click", onGroupByDocClick);
     document.addEventListener("keydown", onGroupByKey);
     return () => {
+      trends.cancelInFlightReads();
       document.removeEventListener("click", onGroupByDocClick);
       document.removeEventListener("keydown", onGroupByKey);
     };

--- a/frontend/src/lib/components/trends/TrendsPage.test.ts
+++ b/frontend/src/lib/components/trends/TrendsPage.test.ts
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("../../api/runtime.js", () => ({
   configureGeneratedClient: vi.fn(),
   callGenerated: vi.fn((request: () => Promise<unknown>) => request()),
+  isAbortError: vi.fn(() => false),
 }));
 
 vi.mock("../../api/generated/index", () => ({

--- a/frontend/src/lib/components/usage/UsagePage.svelte
+++ b/frontend/src/lib/components/usage/UsagePage.svelte
@@ -379,6 +379,7 @@
   });
 
   onDestroy(() => {
+    usage.cancelInFlightReads();
     unsubEvents?.();
   });
 </script>

--- a/frontend/src/lib/stores/activity.svelte.ts
+++ b/frontend/src/lib/stores/activity.svelte.ts
@@ -1,10 +1,15 @@
 import type { AgentInfo, ProjectInfo } from "../api/types.js";
 import type { Report } from "../api/types/activity.js";
 import { ActivityService, MetadataService } from "../api/generated/index";
-import { configureGeneratedClient } from "../api/runtime.js";
+import {
+  callGenerated,
+  configureGeneratedClient,
+  isAbortError,
+} from "../api/runtime.js";
 import { sync } from "./sync.svelte.js";
 import { router } from "./router.svelte.js";
 import { localDateStr, rollingRange } from "../utils/dates.js";
+import { LatestRead } from "../utils/latest-read.js";
 
 export { localDateStr };
 
@@ -79,6 +84,8 @@ class ActivityStore {
   machines: string[] = $state([]);
 
   private loadVersion = 0;
+  private reportRead = new LatestRead();
+  private filterOptionsRead = new LatestRead();
   #filterOptionsLoaded = false;
   #filterOptionsPromise: Promise<void> | null = null;
   #filterOptionsVersion = 0;
@@ -116,6 +123,7 @@ class ActivityStore {
 
   async load({ background = false }: { background?: boolean } = {}) {
     const v = ++this.loadVersion;
+    const signal = this.reportRead.begin();
     if (this.materializeRollingWindow()) {
       this.writeUrl();
     }
@@ -123,6 +131,7 @@ class ActivityStore {
     // input or a partial deep link) the backend rejects the request, so hold
     // the current view until both are set instead of flashing an error.
     if (this.preset === "custom" && (!this.from || !this.to)) {
+      this.reportRead.finish(signal);
       this.loading = false;
       return;
     }
@@ -145,35 +154,40 @@ class ActivityStore {
         this.preset === "custom" && this.to
           ? customToInstant(this.to)
           : undefined;
-      const res = await ActivityService.getApiV1ActivityReport({
-        preset: this.preset,
-        date: this.date,
-        from: fromParam,
-        to: toParam,
-        timezone: this.timezone,
-        // The store keeps bucket as a free-form override string (populated by
-        // the Task 4 control); the generated client narrows it to the server's
-        // accepted set. An out-of-set value is rejected server-side.
-        bucket: (this.bucket || undefined) as
-          | "5m"
-          | "15m"
-          | "1h"
-          | "1d"
-          | "1w"
-          | undefined,
-        project: this.project || undefined,
-        agent: this.agent || undefined,
-        machine: this.machine || undefined,
-        automation: this.automation,
-      });
-      if (v !== this.loadVersion) return;
+      const res = await callGenerated(
+        () => ActivityService.getApiV1ActivityReport({
+          preset: this.preset,
+          date: this.date,
+          from: fromParam,
+          to: toParam,
+          timezone: this.timezone,
+          // The store keeps bucket as a free-form override string (populated by
+          // the Task 4 control); the generated client narrows it to the server's
+          // accepted set. An out-of-set value is rejected server-side.
+          bucket: (this.bucket || undefined) as
+            | "5m"
+            | "15m"
+            | "1h"
+            | "1d"
+            | "1w"
+            | undefined,
+          project: this.project || undefined,
+          agent: this.agent || undefined,
+          machine: this.machine || undefined,
+          automation: this.automation,
+        }),
+        signal,
+      );
+      if (v !== this.loadVersion || !this.reportRead.isCurrent(signal)) return;
       this.report = res as unknown as Report;
       this.lastUpdatedAt = Date.now();
       this.hasNewData = false;
-      this.loading = false;
     } catch (e) {
-      if (v !== this.loadVersion) return;
-      this.loading = false;
+      if (
+        isAbortError(e) ||
+        v !== this.loadVersion ||
+        !this.reportRead.isCurrent(signal)
+      ) return;
       // A failed background refresh keeps the last good report on screen so a
       // transient blip never blanks the report-first dashboard; the growing
       // "Updated Xm ago" label signals the staleness. With no report yet (a
@@ -185,7 +199,17 @@ class ActivityStore {
       this.report = null;
       this.error =
         e instanceof Error ? e.message : "Failed to load activity report";
+    } finally {
+      if (this.reportRead.finish(signal)) this.loading = false;
     }
+  }
+
+  cancelInFlightReads(): void {
+    this.loadVersion++;
+    this.reportRead.cancel();
+    this.filterOptionsRead.cancel();
+    this.#filterOptionsPromise = null;
+    this.loading = false;
   }
 
   /**
@@ -201,40 +225,60 @@ class ActivityStore {
     if (this.#filterOptionsLoaded) return;
     if (this.#filterOptionsPromise) return this.#filterOptionsPromise;
     const ver = this.#filterOptionsVersion;
+    const signal = this.filterOptionsRead.begin();
     const opts = { includeOneShot: true, includeAutomated: true };
     this.#filterOptionsPromise = (async () => {
       configureGeneratedClient();
       let ok = true;
       try {
-        const res = (await MetadataService.getApiV1Projects(
-          opts,
+        const res = (await callGenerated(
+          () => MetadataService.getApiV1Projects(opts),
+          signal,
         )) as unknown as { projects: ProjectInfo[] };
-        if (ver === this.#filterOptionsVersion) this.projects = res.projects;
-      } catch {
+        if (
+          ver === this.#filterOptionsVersion &&
+          this.filterOptionsRead.isCurrent(signal)
+        ) this.projects = res.projects;
+      } catch (e) {
+        if (isAbortError(e) || !this.filterOptionsRead.isCurrent(signal)) return;
         ok = false; // keep the current list; retry on the next call
       }
       try {
-        const res = (await MetadataService.getApiV1Agents(
-          opts,
+        const res = (await callGenerated(
+          () => MetadataService.getApiV1Agents(opts),
+          signal,
         )) as unknown as { agents: AgentInfo[] };
-        if (ver === this.#filterOptionsVersion) this.agents = res.agents;
-      } catch {
+        if (
+          ver === this.#filterOptionsVersion &&
+          this.filterOptionsRead.isCurrent(signal)
+        ) this.agents = res.agents;
+      } catch (e) {
+        if (isAbortError(e) || !this.filterOptionsRead.isCurrent(signal)) return;
         ok = false;
       }
       try {
-        const res = (await MetadataService.getApiV1Machines(
-          opts,
+        const res = (await callGenerated(
+          () => MetadataService.getApiV1Machines(opts),
+          signal,
         )) as unknown as { machines: string[] };
-        if (ver === this.#filterOptionsVersion) this.machines = res.machines;
-      } catch {
+        if (
+          ver === this.#filterOptionsVersion &&
+          this.filterOptionsRead.isCurrent(signal)
+        ) this.machines = res.machines;
+      } catch (e) {
+        if (isAbortError(e) || !this.filterOptionsRead.isCurrent(signal)) return;
         ok = false;
       }
-      if (ver === this.#filterOptionsVersion) {
+      if (
+        ver === this.#filterOptionsVersion &&
+        this.filterOptionsRead.isCurrent(signal)
+      ) {
         // Cache only a fully successful load so a transient failure is
         // retried rather than frozen as a permanent empty list.
         this.#filterOptionsLoaded = ok;
         this.#filterOptionsPromise = null;
       }
+      this.filterOptionsRead.finish(signal);
     })();
     return this.#filterOptionsPromise;
   }

--- a/frontend/src/lib/stores/activity.test.ts
+++ b/frontend/src/lib/stores/activity.test.ts
@@ -8,6 +8,12 @@ const api = vi.hoisted(() => ({
   getMachines: vi.fn(),
 }));
 
+const apiRuntimeMocks = vi.hoisted(() => ({
+  callGenerated: vi.fn(
+    (request: () => Promise<unknown>, _signal?: AbortSignal) => request(),
+  ),
+}));
+
 vi.mock("../api/generated/index", () => ({
   ActivityService: { getApiV1ActivityReport: api.getActivityReport },
   MetadataService: {
@@ -16,7 +22,11 @@ vi.mock("../api/generated/index", () => ({
     getApiV1Machines: api.getMachines,
   },
 }));
-vi.mock("../api/runtime.js", () => ({ configureGeneratedClient: vi.fn() }));
+vi.mock("../api/runtime.js", () => ({
+  configureGeneratedClient: vi.fn(),
+  callGenerated: apiRuntimeMocks.callGenerated,
+  isAbortError: vi.fn(() => false),
+}));
 vi.mock("./sync.svelte.js", () => ({ sync: { onSyncComplete: vi.fn() } }));
 vi.mock("./router.svelte.js", () => ({
   router: { params: {}, replaceParams: vi.fn(), route: "activity" },
@@ -74,6 +84,10 @@ beforeEach(() => {
   api.getProjects.mockReset();
   api.getAgents.mockReset();
   api.getMachines.mockReset();
+  apiRuntimeMocks.callGenerated.mockReset();
+  apiRuntimeMocks.callGenerated.mockImplementation(
+    (request: () => Promise<unknown>, _signal?: AbortSignal) => request(),
+  );
   api.getProjects.mockResolvedValue({ projects: [] });
   api.getAgents.mockResolvedValue({ agents: [] });
   api.getMachines.mockResolvedValue({ machines: [] });
@@ -107,6 +121,44 @@ afterEach(() => {
 });
 
 describe("load", () => {
+  it("aborts the obsolete report when a replacement starts", async () => {
+    const signals: AbortSignal[] = [];
+    apiRuntimeMocks.callGenerated.mockImplementation((
+      request: () => Promise<unknown>,
+      signal?: AbortSignal,
+    ) => {
+      signals.push(signal as AbortSignal);
+      return request();
+    });
+    api.getActivityReport
+      .mockImplementationOnce(() => new Promise(() => {}))
+      .mockResolvedValueOnce(makeReport());
+
+    void activity.load();
+    await Promise.resolve();
+    await activity.load();
+
+    expect(signals[0]?.aborted).toBe(true);
+  });
+
+  it("aborts the visible report on teardown", async () => {
+    const signals: AbortSignal[] = [];
+    apiRuntimeMocks.callGenerated.mockImplementation((
+      request: () => Promise<unknown>,
+      signal?: AbortSignal,
+    ) => {
+      signals.push(signal as AbortSignal);
+      return request();
+    });
+    api.getActivityReport.mockImplementationOnce(() => new Promise(() => {}));
+
+    void activity.load();
+    await Promise.resolve();
+    activity.cancelInFlightReads();
+
+    expect(signals[0]?.aborted).toBe(true);
+  });
+
   it("sends preset/date/timezone and stores the report", async () => {
     api.getActivityReport.mockResolvedValue(makeReport());
     await activity.load();

--- a/frontend/src/lib/stores/analytics.svelte.ts
+++ b/frontend/src/lib/stores/analytics.svelte.ts
@@ -546,6 +546,17 @@ class AnalyticsStore {
     }
   }
 
+  cancelInFlightReads(): void {
+    this.fetchAllVersion++;
+    for (const panel of Object.keys(this.abortControllers) as Panel[]) {
+      this.versions[panel]++;
+      this.abortControllers[panel]?.abort();
+      delete this.abortControllers[panel];
+      this.querying[panel] = false;
+      this.loading[panel] = false;
+    }
+  }
+
   private markRefreshComplete(): void {
     this.lastUpdatedAt = Date.now();
     this.hasNewData = false;

--- a/frontend/src/lib/stores/analytics.test.ts
+++ b/frontend/src/lib/stores/analytics.test.ts
@@ -996,6 +996,24 @@ describe("executeFetch concurrency and error handling", () => {
     expect(signals[0]).toBeDefined();
     expect(signals[0]?.aborted).toBe(true);
   });
+
+  it("aborts visible panel requests on teardown", async () => {
+    const signals: (AbortSignal | undefined)[] = [];
+    vi.mocked(callGenerated).mockImplementation(
+      (request: () => Promise<unknown>, signal?: AbortSignal) => {
+        signals.push(signal);
+        return request();
+      },
+    );
+    vi.mocked(analyticsService.getApiV1AnalyticsSummary)
+      .mockImplementationOnce(() => new Promise(() => {}));
+
+    void analytics.fetchSummary();
+    await Promise.resolve();
+    analytics.cancelInFlightReads();
+
+    expect(signals[0]?.aborted).toBe(true);
+  });
 });
 
 describe("AnalyticsStore rolling default date range", () => {

--- a/frontend/src/lib/stores/insights.svelte.ts
+++ b/frontend/src/lib/stores/insights.svelte.ts
@@ -12,13 +12,18 @@ import {
   ApiError as GeneratedApiError,
   InsightsService,
 } from "../api/generated/index";
-import { configureGeneratedClient } from "../api/runtime.js";
+import {
+  callGenerated,
+  configureGeneratedClient,
+  isAbortError,
+} from "../api/runtime.js";
 import {
   generateInsight,
   type GenerateInsightHandle,
   type InsightLogEvent,
 } from "../api/client.js";
 import { localDateStr } from "../utils/dates.js";
+import { LatestRead } from "../utils/latest-read.js";
 
 export interface InsightTask {
   clientId: string;
@@ -72,6 +77,7 @@ class InsightsStore {
 
   #handles = new Map<string, GenerateInsightHandle>();
   #version = 0;
+  #listRead = new LatestRead();
 
   get selectedItem(): Insight | undefined {
     return this.items.find(
@@ -94,12 +100,15 @@ class InsightsStore {
 
   async load() {
     const v = ++this.#version;
+    const signal = this.#listRead.begin();
     this.loading = true;
     try {
       configureGeneratedClient();
-      const res =
-        await InsightsService.getApiV1Insights({}) as unknown as InsightsResponse;
-      if (this.#version === v) {
+      const res = await callGenerated(
+        () => InsightsService.getApiV1Insights({}),
+        signal,
+      ) as unknown as InsightsResponse;
+      if (this.#version === v && this.#listRead.isCurrent(signal)) {
         this.items = res.insights;
         if (
           this.selectedId !== null &&
@@ -110,15 +119,22 @@ class InsightsStore {
           this.selectedId = null;
         }
       }
-    } catch {
+    } catch (e) {
+      if (isAbortError(e) || !this.#listRead.isCurrent(signal)) return;
       if (this.#version === v) {
         this.items = [];
       }
     } finally {
-      if (this.#version === v) {
+      if (this.#listRead.finish(signal)) {
         this.loading = false;
       }
     }
+  }
+
+  cancelInFlightReads(): void {
+    this.#version++;
+    this.#listRead.cancel();
+    this.loading = false;
   }
 
   setDateFrom(date: string) {

--- a/frontend/src/lib/stores/insights.test.ts
+++ b/frontend/src/lib/stores/insights.test.ts
@@ -28,13 +28,20 @@ const api = vi.hoisted(() => {
 
 const ApiError = api.ApiError;
 
+const runtimeMocks = vi.hoisted(() => ({
+  callGenerated: vi.fn(
+    (request: () => Promise<unknown>, _signal?: AbortSignal) => request(),
+  ),
+}));
+
 vi.mock("../api/client.js", () => ({
   generateInsight: api.generateInsight,
 }));
 
 vi.mock("../api/runtime.js", () => ({
   configureGeneratedClient: vi.fn(),
-  callGenerated: vi.fn((request: () => Promise<unknown>) => request()),
+  callGenerated: runtimeMocks.callGenerated,
+  isAbortError: vi.fn(() => false),
 }));
 
 vi.mock("../api/generated/index", () => ({
@@ -98,9 +105,48 @@ beforeEach(() => {
   insights.setAutomatedScope("human");
   insights.setSessionFilters(undefined);
   insights.promptText = "";
+  runtimeMocks.callGenerated.mockReset();
+  runtimeMocks.callGenerated.mockImplementation(
+    (request: () => Promise<unknown>, _signal?: AbortSignal) => request(),
+  );
 });
 
 describe("load", () => {
+  it("aborts an obsolete list read without aborting generation", async () => {
+    const signals: AbortSignal[] = [];
+    runtimeMocks.callGenerated.mockImplementation((request, signal) => {
+      signals.push(signal as AbortSignal);
+      return request();
+    });
+    vi.mocked(api.listInsights)
+      .mockImplementationOnce(() => new Promise(() => {}))
+      .mockResolvedValueOnce({ insights: [] });
+
+    void insights.load();
+    await Promise.resolve();
+    await insights.load();
+
+    expect(signals[0]?.aborted).toBe(true);
+    expect(api.generateInsight).not.toHaveBeenCalled();
+  });
+
+  it("aborts the list read on page teardown", async () => {
+    const signals: AbortSignal[] = [];
+    runtimeMocks.callGenerated.mockImplementation((request, signal) => {
+      signals.push(signal as AbortSignal);
+      return request();
+    });
+    vi.mocked(api.listInsights).mockImplementationOnce(
+      () => new Promise(() => {}),
+    );
+
+    void insights.load();
+    await Promise.resolve();
+    insights.cancelInFlightReads();
+
+    expect(signals[0]?.aborted).toBe(true);
+  });
+
   it("fetches insights and updates state", async () => {
     const s1 = makeInsight({ id: 1 });
     const s2 = makeInsight({ id: 2, project: "my-app" });

--- a/frontend/src/lib/stores/messages.svelte.ts
+++ b/frontend/src/lib/stores/messages.svelte.ts
@@ -35,6 +35,7 @@ class MessagesStore {
         : "",
   );
   private abortController: AbortController | null = null;
+  private cancelledSessionId: string | null = null;
   private reloadPromise: Promise<void> | null = null;
   private reloadSessionId: string | null = null;
   private pendingReload: boolean = false;
@@ -54,15 +55,24 @@ class MessagesStore {
   }
 
   async loadSession(id: string) {
-    if (this.sessionId === id && (this.messages.length > 0 || this.loading)) {
+    const resumesCancelledLoad =
+      this.sessionId === id && this.cancelledSessionId === id;
+    if (
+      this.sessionId === id &&
+      !resumesCancelledLoad &&
+      (this.messages.length > 0 || this.loading)
+    ) {
       return;
     }
     const readMarker = readProgress.get(id);
-    this.clear();
-    this._stableMainModel = "";
+    if (!resumesCancelledLoad) {
+      this.clear();
+      this._stableMainModel = "";
+      this.activeSessionToken = null;
+      this.activeSessionUnreadOrdinal = null;
+    }
     this.sessionId = id;
-    this.activeSessionToken = null;
-    this.activeSessionUnreadOrdinal = null;
+    this.cancelledSessionId = null;
     this.loading = true;
 
     const ac = new AbortController();
@@ -138,11 +148,11 @@ class MessagesStore {
   }
 
   clear() {
-    this.abortController?.abort();
-    this.abortController = null;
+    this.cancelInFlight();
     this.messages = [];
     clearContentCaches();
     this.sessionId = null;
+    this.cancelledSessionId = null;
     this.loading = false;
     this._stableMainModel = "";
     this.messageCount = 0;
@@ -161,7 +171,33 @@ class MessagesStore {
     this.pendingSessionUnreadOrdinal = null;
   }
 
-  private async fetchPages(id: string, opts: FetchPageOptions): Promise<Message[]> {
+  cancelInFlight(): void {
+    const hasInFlightRead =
+      this.loading ||
+      this.loadingOlder ||
+      this.reloadPromise !== null ||
+      this.loadOlderPromise !== null;
+    if (
+      hasInFlightRead &&
+      this.abortController &&
+      !this.abortController.signal.aborted
+    ) {
+      this.cancelledSessionId = this.sessionId;
+      this.abortController.abort();
+      this.abortController = null;
+    }
+    this.loading = false;
+    this.loadingOlder = false;
+    this.reloadPromise = null;
+    this.reloadSessionId = null;
+    this.pendingReload = false;
+    this.loadOlderPromise = null;
+  }
+
+  private async fetchPages(
+    id: string,
+    opts: FetchPageOptions,
+  ): Promise<Message[]> {
     const loaded: Message[] = [];
     let from = opts.from;
 

--- a/frontend/src/lib/stores/messages.test.ts
+++ b/frontend/src/lib/stores/messages.test.ts
@@ -9,6 +9,10 @@ const api = vi.hoisted(() => ({
   getSession: vi.fn(),
 }));
 
+const runtimeMocks = vi.hoisted(() => ({
+  signals: [] as AbortSignal[],
+}));
+
 vi.mock("../api/runtime.js", () => ({
   configureGeneratedClient: vi.fn(),
   callGenerated: vi.fn((request: () => Promise<unknown>) => request()),
@@ -25,7 +29,10 @@ vi.mock("../api/runtime.js", () => ({
     };
     return candidate.isCancelled === true || candidate.name === "CancelError";
   },
-  withAbort: <T>(promise: Promise<T>) => promise,
+  withAbort: <T>(promise: Promise<T>, signal: AbortSignal) => {
+    runtimeMocks.signals.push(signal);
+    return promise;
+  },
 }));
 
 vi.mock("../api/generated/index", () => ({
@@ -122,6 +129,31 @@ describe("MessagesStore", () => {
     messages.clear();
     readProgress.reset();
     vi.clearAllMocks();
+    runtimeMocks.signals.length = 0;
+  });
+
+  it('aborts in-flight reads without clearing cached messages', async () => {
+    await setupSession('s1', 1, [makeMessage(0)]);
+    const cached = messages.messages;
+    const pending = createDeferred<Session>();
+    vi.mocked(api.getSession).mockReturnValueOnce(pending.promise);
+
+    void messages.reload();
+    await Promise.resolve();
+    const signal = runtimeMocks.signals.at(-1)!;
+    messages.cancelInFlight();
+
+    expect(signal.aborted).toBe(true);
+    expect(messages.messages).toBe(cached);
+
+    vi.mocked(api.getSession).mockResolvedValueOnce(makeSession('s1', 1));
+    vi.mocked(api.getMessages).mockResolvedValueOnce(
+      makeMessagesResponse([makeMessage(0)]),
+    );
+    const resumed = messages.loadSession('s1');
+    expect(messages.messages).toBe(cached);
+    await resumed;
+    expect(messages.messages).toHaveLength(1);
   });
 
   it("should clear reload state when loading a new session", async () => {

--- a/frontend/src/lib/stores/pins.svelte.ts
+++ b/frontend/src/lib/stores/pins.svelte.ts
@@ -1,6 +1,11 @@
 import type { PinnedMessage } from "../api/types.js";
 import { PinsService } from "../api/generated/index";
-import { configureGeneratedClient } from "../api/runtime.js";
+import {
+  callGenerated,
+  configureGeneratedClient,
+  isAbortError,
+} from "../api/runtime.js";
+import { LatestRead } from "../utils/latest-read.js";
 
 interface PinsResponse {
   pins: PinnedMessage[];
@@ -27,6 +32,8 @@ class PinsStore {
   #mutationVersion = 0;
   /** Project that the current this.pins was fetched for. */
   #loadedProject: string | undefined = undefined;
+  #allPinsRead = new LatestRead();
+  #sessionPinsRead = new LatestRead();
 
   async loadAll(project?: string) {
     // Clear immediately when switching projects to prevent stale
@@ -37,23 +44,30 @@ class PinsStore {
     }
     this.loading = true;
     const loadVer = ++this.#loadAllVersion;
+    const signal = this.#allPinsRead.begin();
     const mutVer = this.#mutationVersion;
     try {
       configureGeneratedClient();
-      const res = await PinsService.getApiV1Pins({
-        project,
-      }) as unknown as PinsResponse;
+      const res = await callGenerated(
+        () => PinsService.getApiV1Pins({ project }),
+        signal,
+      ) as unknown as PinsResponse;
       // Apply only if this is the latest load AND no mutation
       // occurred since the request started (which would make
       // this response stale relative to the optimistic state).
-      if (this.#loadAllVersion === loadVer && this.#mutationVersion === mutVer) {
+      if (
+        this.#allPinsRead.isCurrent(signal) &&
+        this.#loadAllVersion === loadVer &&
+        this.#mutationVersion === mutVer
+      ) {
         this.pins = res.pins;
         this.#loadedProject = project;
       }
-    } catch {
+    } catch (e) {
+      if (isAbortError(e) || !this.#allPinsRead.isCurrent(signal)) return;
       // Silently ignore — pins are non-critical.
     } finally {
-      if (this.#loadAllVersion === loadVer) {
+      if (this.#allPinsRead.finish(signal)) {
         this.loading = false;
       }
     }
@@ -63,6 +77,7 @@ class PinsStore {
     const isNewSession = this.#currentSessionId !== sessionId;
     this.#currentSessionId = sessionId;
     const loadVer = ++this.#loadVersion;
+    const signal = this.#sessionPinsRead.begin();
     const mutVer = this.#mutationVersion;
     // Only clear on session change to avoid flickering pins
     // during re-fetches triggered by mutation completion.
@@ -71,23 +86,42 @@ class PinsStore {
     }
     try {
       configureGeneratedClient();
-      const res =
-        await PinsService.getApiV1SessionsIdPins({
-          id: sessionId,
-        }) as unknown as PinsResponse;
-      if (this.#loadVersion === loadVer && this.#mutationVersion === mutVer) {
+      const res = await callGenerated(
+        () => PinsService.getApiV1SessionsIdPins({ id: sessionId }),
+        signal,
+      ) as unknown as PinsResponse;
+      if (
+        this.#sessionPinsRead.isCurrent(signal) &&
+        this.#loadVersion === loadVer &&
+        this.#mutationVersion === mutVer
+      ) {
         this.sessionPinIds = new Set(
           res.pins.map((p) => p.message_id),
         );
       }
-    } catch {
+    } catch (e) {
+      if (isAbortError(e) || !this.#sessionPinsRead.isCurrent(signal)) return;
       // Silently ignore — pins are non-critical.
+    } finally {
+      this.#sessionPinsRead.finish(signal);
     }
   }
 
   clearSession() {
+    this.cancelSessionPinsRead();
     this.#currentSessionId = null;
     this.sessionPinIds = new Set();
+  }
+
+  cancelAllPinsRead(): void {
+    this.#loadAllVersion++;
+    this.#allPinsRead.cancel();
+    this.loading = false;
+  }
+
+  cancelSessionPinsRead(): void {
+    this.#loadVersion++;
+    this.#sessionPinsRead.cancel();
   }
 
   isPinned(messageId: number): boolean {

--- a/frontend/src/lib/stores/pins.test.ts
+++ b/frontend/src/lib/stores/pins.test.ts
@@ -2,9 +2,16 @@ import { describe, it, expect, beforeEach, vi } from "vite-plus/test";
 import { PinsService } from "../api/generated/index";
 import { createPinsStore } from "./pins.svelte.js";
 
+const apiRuntimeMocks = vi.hoisted(() => ({
+  callGenerated: vi.fn(
+    (request: () => Promise<unknown>, _signal?: AbortSignal) => request(),
+  ),
+}));
+
 vi.mock("../api/runtime.js", () => ({
   configureGeneratedClient: vi.fn(),
-  callGenerated: vi.fn((request: () => Promise<unknown>) => request()),
+  callGenerated: apiRuntimeMocks.callGenerated,
+  isAbortError: vi.fn(() => false),
 }));
 
 vi.mock("../api/generated/index", () => ({
@@ -31,7 +38,48 @@ describe("PinsStore.loadAll project filtering", () => {
 
   beforeEach(() => {
     store = createPinsStore();
+    apiRuntimeMocks.callGenerated.mockReset();
+    apiRuntimeMocks.callGenerated.mockImplementation(
+      (request: () => Promise<unknown>, _signal?: AbortSignal) => request(),
+    );
     pinsService.getApiV1Pins.mockResolvedValue({ pins: [] });
+  });
+
+  it("aborts an obsolete all-pins read when the project changes", async () => {
+    const signals: AbortSignal[] = [];
+    apiRuntimeMocks.callGenerated.mockImplementation((request, signal) => {
+      signals.push(signal as AbortSignal);
+      return request();
+    });
+    pinsService.getApiV1Pins
+      .mockImplementationOnce(() => new Promise(() => {}))
+      .mockResolvedValueOnce({ pins: [PIN_BETA] });
+
+    void store.loadAll("alpha");
+    await Promise.resolve();
+    await store.loadAll("beta");
+
+    expect(signals[0]?.aborted).toBe(true);
+  });
+
+  it("keeps all-pins and session-pins cancellation independent", async () => {
+    const signals: AbortSignal[] = [];
+    apiRuntimeMocks.callGenerated.mockImplementation((request, signal) => {
+      signals.push(signal as AbortSignal);
+      return request();
+    });
+    pinsService.getApiV1Pins.mockImplementationOnce(() => new Promise(() => {}));
+    pinsService.getApiV1SessionsIdPins.mockImplementationOnce(
+      () => new Promise(() => {}),
+    );
+
+    void store.loadAll();
+    void store.loadForSession("s1");
+    await Promise.resolve();
+    store.cancelSessionPinsRead();
+
+    expect(signals[0]?.aborted).toBe(false);
+    expect(signals[1]?.aborted).toBe(true);
   });
 
   it("populates pins on successful load", async () => {

--- a/frontend/src/lib/stores/sessionActivity.svelte.ts
+++ b/frontend/src/lib/stores/sessionActivity.svelte.ts
@@ -1,9 +1,14 @@
 import { SessionsService } from "../api/generated/index";
-import { configureGeneratedClient } from "../api/runtime.js";
+import {
+  callGenerated,
+  configureGeneratedClient,
+  isAbortError,
+} from "../api/runtime.js";
 import type {
   SessionActivityBucket,
   SessionActivityResponse,
 } from "../api/types/session-activity.js";
+import { LatestRead } from "../utils/latest-read.js";
 
 export function findActiveBucketIndex(
   buckets: SessionActivityBucket[],
@@ -30,6 +35,7 @@ class SessionActivityStore {
 
   private cachedSessionId: string | null = null;
   private loadVersion = 0;
+  private activityRead = new LatestRead();
 
   /** True when buckets are loaded for the given session. */
   isForSession(sessionId: string): boolean {
@@ -46,7 +52,7 @@ class SessionActivityStore {
   async load(sessionId: string) {
     if (
       this.cachedSessionId === sessionId &&
-      (this.buckets.length > 0 || this.loaded)
+      this.loaded
     ) {
       return;
     }
@@ -57,24 +63,32 @@ class SessionActivityStore {
       this.loaded = false;
     }
     const version = ++this.loadVersion;
+    const signal = this.activityRead.begin();
     this.loading = true;
     this.error = null;
     this.firstVisibleTimestamp = null;
     try {
       configureGeneratedClient();
-      const resp =
-        await SessionsService.getApiV1SessionsIdActivity({
-          id: sessionId,
-        }) as unknown as SessionActivityResponse;
+      const resp = await callGenerated(
+        () => SessionsService.getApiV1SessionsIdActivity({ id: sessionId }),
+        signal,
+      ) as unknown as SessionActivityResponse;
       // Ignore stale responses from previous sessions.
-      if (version !== this.loadVersion) return;
+      if (
+        version !== this.loadVersion ||
+        !this.activityRead.isCurrent(signal)
+      ) return;
       this.buckets = resp.buckets;
       this.intervalSeconds = resp.interval_seconds;
       this.totalMessages = resp.total_messages;
       this.cachedSessionId = sessionId;
       this.loaded = true;
     } catch (e) {
-      if (version !== this.loadVersion) return;
+      if (
+        isAbortError(e) ||
+        version !== this.loadVersion ||
+        !this.activityRead.isCurrent(signal)
+      ) return;
       this.error =
         e instanceof Error
           ? e.message
@@ -83,26 +97,28 @@ class SessionActivityStore {
       this.cachedSessionId = sessionId;
       this.loaded = true;
     } finally {
-      if (version === this.loadVersion) {
+      if (this.activityRead.finish(signal)) {
         this.loading = false;
       }
     }
   }
 
   reload(sessionId: string) {
-    this.cachedSessionId = null;
+    this.loaded = false;
     return this.load(sessionId);
   }
 
   /** Mark cached data as stale so the next load() refetches.
    *  Also discards any in-flight response. */
   invalidate() {
+    this.activityRead.cancel();
     this.loadVersion++;
     this.cachedSessionId = null;
     this.loaded = false;
   }
 
   clear() {
+    this.activityRead.cancel();
     this.loadVersion++;
     this.buckets = [];
     this.intervalSeconds = 0;
@@ -112,6 +128,12 @@ class SessionActivityStore {
     this.error = null;
     this.cachedSessionId = null;
     this.firstVisibleTimestamp = null;
+  }
+
+  cancelInFlight(): void {
+    this.loadVersion++;
+    this.activityRead.cancel();
+    this.loading = false;
   }
 }
 

--- a/frontend/src/lib/stores/sessionActivity.test.ts
+++ b/frontend/src/lib/stores/sessionActivity.test.ts
@@ -7,9 +7,16 @@ import { SessionsService } from "../api/generated/index";
 import type { SessionActivityBucket } from "../api/types/session-activity.js";
 import type { SessionActivityResponse } from "../api/types/session-activity.js";
 
+const apiRuntimeMocks = vi.hoisted(() => ({
+  callGenerated: vi.fn(
+    (request: () => Promise<unknown>, _signal?: AbortSignal) => request(),
+  ),
+}));
+
 vi.mock("../api/runtime.js", () => ({
   configureGeneratedClient: vi.fn(),
-  callGenerated: vi.fn((request: () => Promise<unknown>) => request()),
+  callGenerated: apiRuntimeMocks.callGenerated,
+  isAbortError: vi.fn(() => false),
 }));
 
 vi.mock("../api/generated/index", () => ({
@@ -68,6 +75,48 @@ describe("SessionActivityStore", () => {
   beforeEach(() => {
     sessionActivity.clear();
     vi.resetAllMocks();
+    apiRuntimeMocks.callGenerated.mockImplementation(
+      (request: () => Promise<unknown>, _signal?: AbortSignal) => request(),
+    );
+  });
+
+  it("aborts session activity when another session replaces it", async () => {
+    const signals: AbortSignal[] = [];
+    apiRuntimeMocks.callGenerated.mockImplementation((request, signal) => {
+      signals.push(signal as AbortSignal);
+      return request();
+    });
+    sessionsService.getApiV1SessionsIdActivity
+      .mockImplementationOnce(() => new Promise(() => {}))
+      .mockResolvedValueOnce(makeResponse(2));
+
+    void sessionActivity.load("s1");
+    await Promise.resolve();
+    await sessionActivity.load("s2");
+
+    expect(signals[0]?.aborted).toBe(true);
+  });
+
+  it("aborts session activity without clearing cached buckets", async () => {
+    const signals: AbortSignal[] = [];
+    apiRuntimeMocks.callGenerated.mockImplementation((request, signal) => {
+      signals.push(signal as AbortSignal);
+      return request();
+    });
+    sessionsService.getApiV1SessionsIdActivity.mockResolvedValueOnce(
+      makeResponse(2),
+    );
+    await sessionActivity.load("s1");
+    sessionsService.getApiV1SessionsIdActivity.mockImplementationOnce(
+      () => new Promise(() => {}),
+    );
+
+    void sessionActivity.reload("s1");
+    await Promise.resolve();
+    sessionActivity.cancelInFlight();
+
+    expect(signals.at(-1)?.aborted).toBe(true);
+    expect(sessionActivity.buckets).toHaveLength(2);
   });
 
   it("ignores stale response after session switch", async () => {

--- a/frontend/src/lib/stores/sessionTiming.svelte.ts
+++ b/frontend/src/lib/stores/sessionTiming.svelte.ts
@@ -1,5 +1,6 @@
 import { fetchSessionTiming } from "../api/timing.js";
 import type { SessionTiming } from "../api/types/timing.js";
+import { LatestRead } from "../utils/latest-read.js";
 
 /** Per-session timing snapshot fetched from
  *  GET /api/v1/sessions/{id}/timing and refreshed live by the
@@ -11,6 +12,7 @@ class SessionTimingStore {
 
   private currentSessionId: string | null = null;
   private loadVersion = 0;
+  private timingRead = new LatestRead();
 
   /** True when the current snapshot belongs to the given session. */
   isForSession(sessionId: string): boolean {
@@ -34,19 +36,27 @@ class SessionTimingStore {
     }
     this.currentSessionId = sessionId;
     const version = ++this.loadVersion;
+    const signal = this.timingRead.begin();
     this.loading = true;
     this.error = null;
     try {
-      const t = await fetchSessionTiming(sessionId);
-      if (version !== this.loadVersion) return;
+      const t = await fetchSessionTiming(sessionId, signal);
+      if (
+        version !== this.loadVersion ||
+        !this.timingRead.isCurrent(signal)
+      ) return;
       this.timing = t;
     } catch (e) {
-      if (version !== this.loadVersion) return;
+      if (
+        signal.aborted ||
+        version !== this.loadVersion ||
+        !this.timingRead.isCurrent(signal)
+      ) return;
       this.error =
         e instanceof Error ? e.message : String(e);
       this.timing = null;
     } finally {
-      if (version === this.loadVersion) {
+      if (this.timingRead.finish(signal)) {
         this.loading = false;
       }
     }
@@ -63,11 +73,18 @@ class SessionTimingStore {
 
   /** Drop cached state. Call when leaving session detail view. */
   reset(): void {
+    this.timingRead.cancel();
     this.loadVersion++;
     this.currentSessionId = null;
     this.timing = null;
     this.loading = false;
     this.error = null;
+  }
+
+  cancelInFlight(): void {
+    this.loadVersion++;
+    this.timingRead.cancel();
+    this.loading = false;
   }
 }
 

--- a/frontend/src/lib/stores/sessionTiming.test.ts
+++ b/frontend/src/lib/stores/sessionTiming.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { sessionTiming } from "./sessionTiming.svelte.js";
+
+const timingMocks = vi.hoisted(() => ({
+  fetchSessionTiming: vi.fn(),
+}));
+
+vi.mock("../api/timing.js", () => ({
+  fetchSessionTiming: timingMocks.fetchSessionTiming,
+}));
+
+beforeEach(() => {
+  sessionTiming.reset();
+  timingMocks.fetchSessionTiming.mockReset();
+});
+
+describe("SessionTimingStore", () => {
+  it("aborts timing when another session replaces it", async () => {
+    const signals: AbortSignal[] = [];
+    timingMocks.fetchSessionTiming.mockImplementation((id, signal) => {
+      signals.push(signal as AbortSignal);
+      if (id === "s1") return new Promise(() => {});
+      return Promise.resolve({ session_id: id });
+    });
+
+    void sessionTiming.load("s1");
+    await Promise.resolve();
+    await sessionTiming.load("s2");
+
+    expect(signals[0]?.aborted).toBe(true);
+  });
+
+  it("aborts the current timing read on route exit", async () => {
+    const signals: AbortSignal[] = [];
+    timingMocks.fetchSessionTiming.mockImplementation((_id, signal) => {
+      signals.push(signal as AbortSignal);
+      return new Promise(() => {});
+    });
+
+    void sessionTiming.load("s1");
+    await Promise.resolve();
+    sessionTiming.cancelInFlight();
+
+    expect(signals[0]?.aborted).toBe(true);
+  });
+});

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -18,6 +18,7 @@ import { sync } from "./sync.svelte.js";
 import { events } from "./events.svelte.js";
 import { starred } from "./starred.svelte.js";
 import { yokedDates } from "./yokedDates.svelte.js";
+import { LatestRead } from "../utils/latest-read.js";
 
 type SidebarIndexParams = Parameters<
   typeof SessionsService.getApiV1SessionsSidebarIndex
@@ -281,6 +282,10 @@ class SessionsStore {
   private sidebarLoadPromise: Promise<void> | null = null;
   private sidebarLoadSignature: string | null = null;
   private sidebarAbort: AbortController | null = null;
+  private routeAbort: AbortController | null = null;
+  private navigateRead = new LatestRead();
+  private refreshRead = new LatestRead();
+  private childSessionsRead = new LatestRead();
 
   private liveRefreshStarted = false;
   private unsubEvents: (() => void) | null = null;
@@ -488,6 +493,7 @@ class SessionsStore {
       new Map<string, Promise<void>>();
     this.sidebarHydrationInflightByVersion.set(version, inflight);
     const epoch = this.sidebarHydrationEpochByVersion.get(version) ?? 0;
+    const signal = this.routeSignal();
 
     await Promise.all(uniqueIds.map((id) => {
       if (cache.has(id)) return;
@@ -495,11 +501,13 @@ class SessionsStore {
       if (existing) return existing;
 
       const promise = this.runSidebarHydration(async () => {
+        if (signal.aborted) return;
         try {
           configureGeneratedClient();
-          const hydrated = await SessionsService.getApiV1SessionsId({
-            id,
-          }) as unknown as Session;
+          const hydrated = await callGenerated(
+            () => SessionsService.getApiV1SessionsId({ id }),
+            signal,
+          ) as unknown as Session;
           if (
             version !== this.sidebarIndexVersion ||
             epoch !== (this.sidebarHydrationEpochByVersion.get(version) ?? 0)
@@ -564,14 +572,18 @@ class SessionsStore {
   async loadMore() {
     if (!this.nextCursor || this.loading) return;
     const version = ++this.loadVersion;
+    const signal = this.routeSignal();
     this.loading = true;
     try {
       configureGeneratedClient();
-      const index = await SessionsService.getApiV1SessionsSidebarIndex({
-        ...this.apiParams,
-        cursor: this.nextCursor,
-        limit: SESSION_PAGE_SIZE,
-      }) as unknown as SidebarSessionIndexResponse;
+      const index = await callGenerated(
+        () => SessionsService.getApiV1SessionsSidebarIndex({
+          ...this.apiParams,
+          cursor: this.nextCursor!,
+          limit: SESSION_PAGE_SIZE,
+        }),
+        signal,
+      ) as unknown as SidebarSessionIndexResponse;
       if (this.loadVersion !== version) return;
       this.sessions.push(
         ...index.sessions.map((row) =>
@@ -690,6 +702,9 @@ class SessionsStore {
 
   private setActiveSession(id: string | null) {
     if (id === this.activeSessionId) return;
+    this.navigateRead.cancel();
+    this.refreshRead.cancel();
+    this.childSessionsRead.cancel();
     this.activeSessionId = id;
     this.refreshVersion++;
     this.childSessionsVersion++;
@@ -711,12 +726,14 @@ class SessionsStore {
       await this.hydrateSelectedIndexOnlySession(id);
       return;
     }
+    const signal = this.navigateRead.begin();
     try {
       configureGeneratedClient();
-      const session = await SessionsService.getApiV1SessionsId({
-        id,
-      }) as unknown as Session;
-      if (this.activeSessionId === id) {
+      const session = await callGenerated(
+        () => SessionsService.getApiV1SessionsId({ id }),
+        signal,
+      ) as unknown as Session;
+      if (this.activeSessionId === id && this.navigateRead.isCurrent(signal)) {
         const idx = this.sessions.findIndex((s) => s.id === id);
         if (idx >= 0) {
           this.mergeHydratedSession(session);
@@ -726,6 +743,8 @@ class SessionsStore {
       }
     } catch {
       // Session not found — selection stands without metadata
+    } finally {
+      this.navigateRead.finish(signal);
     }
   }
 
@@ -744,14 +763,17 @@ class SessionsStore {
     const id = this.activeSessionId;
     if (!id) return;
     const version = ++this.refreshVersion;
+    const signal = this.refreshRead.begin();
     try {
       configureGeneratedClient();
-      const session = await SessionsService.getApiV1SessionsId({
-        id,
-      }) as unknown as Session;
+      const session = await callGenerated(
+        () => SessionsService.getApiV1SessionsId({ id }),
+        signal,
+      ) as unknown as Session;
       if (
         this.refreshVersion !== version ||
-        this.activeSessionId !== id
+        this.activeSessionId !== id ||
+        !this.refreshRead.isCurrent(signal)
       ) {
         return;
       }
@@ -761,19 +783,24 @@ class SessionsStore {
       }
     } catch {
       // Session may have been deleted
+    } finally {
+      this.refreshRead.finish(signal);
     }
   }
 
   async loadChildSessions(parentId: string) {
     const version = ++this.childSessionsVersion;
+    const signal = this.childSessionsRead.begin();
     try {
       configureGeneratedClient();
-      const children = await SessionsService.getApiV1SessionsIdChildren({
-        id: parentId,
-      }) as unknown as Session[];
+      const children = await callGenerated(
+        () => SessionsService.getApiV1SessionsIdChildren({ id: parentId }),
+        signal,
+      ) as unknown as Session[];
       if (
         this.childSessionsVersion !== version ||
-        this.activeSessionId !== parentId
+        this.activeSessionId !== parentId ||
+        !this.childSessionsRead.isCurrent(signal)
       ) {
         return;
       }
@@ -790,6 +817,8 @@ class SessionsStore {
         return;
       }
       this.childSessions = new Map();
+    } finally {
+      this.childSessionsRead.finish(signal);
     }
   }
 
@@ -810,12 +839,15 @@ class SessionsStore {
   }
 
   private async doFetchSignalDetail(id: string) {
+    const signal = this.routeSignal();
     this.signalDetailLoading = true;
     try {
       configureGeneratedClient();
-      const session = await SessionsService.getApiV1SessionsId({
-        id,
-      }) as unknown as Session;
+      const session = await callGenerated(
+        () => SessionsService.getApiV1SessionsId({ id }),
+        signal,
+      ) as unknown as Session;
+      if (signal.aborted) return;
       this.signalDetailCache.set(id, {
         basis: session.health_score_basis ?? null,
         penalties: session.health_penalties ?? null,
@@ -1277,6 +1309,38 @@ class SessionsStore {
     }, LIVE_REFRESH_DEBOUNCE_MS);
   }
 
+  private routeSignal(): AbortSignal {
+    if (!this.routeAbort || this.routeAbort.signal.aborted) {
+      this.routeAbort = new AbortController();
+    }
+    return this.routeAbort.signal;
+  }
+
+  cancelRouteReads(): void {
+    this.sidebarAbort?.abort();
+    this.sidebarAbort = null;
+    this.sidebarLoadPromise = null;
+    this.sidebarLoadSignature = null;
+    this.routeAbort?.abort();
+    this.routeAbort = null;
+    this.navigateRead.cancel();
+    this.refreshRead.cancel();
+    this.childSessionsRead.cancel();
+    this.loadVersion++;
+    this.refreshVersion++;
+    this.childSessionsVersion++;
+    this.loading = false;
+    this.signalDetailInflight.clear();
+    this.signalDetailLoading = false;
+    for (const version of this.sidebarHydrationEpochByVersion.keys()) {
+      this.sidebarHydrationEpochByVersion.set(
+        version,
+        (this.sidebarHydrationEpochByVersion.get(version) ?? 0) + 1,
+      );
+    }
+    for (const resume of this.sidebarHydrationQueue.splice(0)) resume();
+  }
+
   dispose() {
     if (this.unsubEvents) {
       this.unsubEvents();
@@ -1290,11 +1354,7 @@ class SessionsStore {
       clearInterval(this.safetyNetTimer);
       this.safetyNetTimer = null;
     }
-    this.sidebarAbort?.abort();
-    this.sidebarAbort = null;
-    this.sidebarLoadPromise = null;
-    this.sidebarLoadSignature = null;
-    this.loadVersion++;
+    this.cancelRouteReads();
     this.liveRefreshStarted = false;
   }
 }

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -6,6 +6,7 @@ import {
 import {
   callGenerated,
   configureGeneratedClient,
+  isAbortError,
 } from "../api/runtime.js";
 import type {
   Session,
@@ -594,6 +595,9 @@ class SessionsStore {
       );
       this.nextCursor = index.next_cursor ?? null;
       this.total = index.total;
+    } catch (error) {
+      if (signal.aborted || isAbortError(error)) return;
+      throw error;
     } finally {
       if (this.loadVersion === version) {
         this.loading = false;
@@ -835,7 +839,15 @@ class SessionsStore {
     if (inflight) return inflight;
     const promise = this.doFetchSignalDetail(id);
     this.signalDetailInflight.set(id, promise);
-    await promise;
+    try {
+      await promise;
+    } finally {
+      if (this.signalDetailInflight.get(id) === promise) {
+        this.signalDetailInflight.delete(id);
+      }
+      this.signalDetailLoading =
+        this.signalDetailInflight.size > 0;
+    }
   }
 
   private async doFetchSignalDetail(id: string) {
@@ -855,10 +867,6 @@ class SessionsStore {
       this.mergeDetailIntoList(id);
     } catch {
       // Signal detail is non-critical
-    } finally {
-      this.signalDetailInflight.delete(id);
-      this.signalDetailLoading =
-        this.signalDetailInflight.size > 0;
     }
   }
 

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -62,6 +62,10 @@ vi.mock("../api/client.js", () => ({
 vi.mock("../api/runtime.js", () => ({
   configureGeneratedClient: vi.fn(),
   callGenerated: vi.fn((request: () => Promise<unknown>) => request()),
+  isAbortError: vi.fn(
+    (error: unknown) =>
+      error instanceof DOMException && error.name === "AbortError",
+  ),
 }));
 
 vi.mock("../api/generated/index", () => ({
@@ -96,6 +100,22 @@ function mockSidebarPage(
     sessions: [],
     total: 0,
     ...overrides,
+  });
+}
+
+function rejectGeneratedRequestOnAbort(
+  request: () => Promise<unknown>,
+  signal?: AbortSignal,
+): Promise<unknown> {
+  const result = request();
+  if (!signal) return result;
+  return new Promise((resolve, reject) => {
+    signal.addEventListener(
+      "abort",
+      () => reject(new DOMException("aborted", "AbortError")),
+      { once: true },
+    );
+    void result.then(resolve, reject);
   });
 }
 
@@ -201,6 +221,9 @@ describe("SessionsStore", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(callGenerated).mockImplementation(
+      (request: () => Promise<unknown>) => request(),
+    );
     storageData.clear();
     mockSidebarPage();
     mockSidebarIndex();
@@ -2308,6 +2331,50 @@ describe("SessionsStore", () => {
       expect(sessions.activeSession?.first_message).toBe(
         "fetched during navigation",
       );
+    });
+  });
+
+  describe("route cancellation", () => {
+    it("aborts pagination and treats cancellation as normal completion", async () => {
+      const signals: AbortSignal[] = [];
+      vi.mocked(callGenerated).mockImplementation(
+        (request: () => Promise<unknown>, signal?: AbortSignal) => {
+          if (signal) signals.push(signal);
+          return rejectGeneratedRequestOnAbort(request, signal);
+        },
+      );
+      vi.mocked(api.getSidebarSessionIndex).mockReturnValue(
+        new Promise(() => {}),
+      );
+      sessions.nextCursor = "next";
+
+      const load = sessions.loadMore();
+      await Promise.resolve();
+      sessions.cancelRouteReads();
+
+      expect(signals).toHaveLength(1);
+      expect(signals[0]?.aborted).toBe(true);
+      await expect(load).resolves.toBeUndefined();
+    });
+
+    it("keeps a replacement signal-detail request registered", async () => {
+      vi.mocked(callGenerated).mockImplementation(
+        rejectGeneratedRequestOnAbort,
+      );
+      vi.mocked(api.getSession).mockReturnValue(
+        new Promise(() => {}),
+      );
+
+      const obsolete = sessions.fetchSignalDetail("detail");
+      await Promise.resolve();
+      sessions.cancelRouteReads();
+      void sessions.fetchSignalDetail("detail");
+      await obsolete;
+
+      void sessions.fetchSignalDetail("detail");
+      await Promise.resolve();
+
+      expect(api.getSession).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/frontend/src/lib/stores/trends.svelte.ts
+++ b/frontend/src/lib/stores/trends.svelte.ts
@@ -2,8 +2,9 @@ import {
   TrendsService,
 } from "../api/generated/index";
 import type { TrendsTermsResponse } from "../api/types.js";
-import { callGenerated } from "../api/runtime.js";
+import { callGenerated, isAbortError } from "../api/runtime.js";
 import { rollingRange } from "../utils/dates.js";
+import { LatestRead } from "../utils/latest-read.js";
 import { perf } from "./perf.svelte.js";
 
 type TrendsTermsParams = Parameters<
@@ -32,6 +33,7 @@ class TrendsStore {
   loading = $state({ terms: false });
   errors = $state<{ terms: string | null }>({ terms: null });
   private version = 0;
+  private termsRead = new LatestRead();
 
   get timezone(): string {
     return Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -56,20 +58,26 @@ class TrendsStore {
 
   async fetchTerms(): Promise<void> {
     const v = ++this.version;
+    const signal = this.termsRead.begin();
     const isFirstLoad = this.response === null;
     this.loading.terms = true;
     this.errors.terms = null;
     const started = performance.now();
-    let status: "ok" | "error" = "ok";
+    let status: "ok" | "error" | "aborted" = "ok";
     try {
       const data = await callGenerated(() =>
         TrendsService.getApiV1TrendsTerms(this.params()),
+        signal,
       ) as unknown as TrendsTermsResponse;
-      if (this.version === v) {
+      if (this.version === v && this.termsRead.isCurrent(signal)) {
         this.response = data;
         this.errors.terms = null;
       }
     } catch (e) {
+      if (isAbortError(e) || !this.termsRead.isCurrent(signal)) {
+        status = "aborted";
+        return;
+      }
       status = "error";
       if (this.version === v) {
         this.errors.terms =
@@ -87,10 +95,16 @@ class TrendsStore {
         durationMs: performance.now() - started,
         status,
       });
-      if (this.version === v) {
+      if (this.termsRead.finish(signal)) {
         this.loading.terms = false;
       }
     }
+  }
+
+  cancelInFlightReads(): void {
+    this.version++;
+    this.termsRead.cancel();
+    this.loading.terms = false;
   }
 
   async setDateRange(from: string, to: string): Promise<void> {

--- a/frontend/src/lib/stores/trends.test.ts
+++ b/frontend/src/lib/stores/trends.test.ts
@@ -4,13 +4,20 @@ import { selectionFromRange } from "../components/shared/rangeSelection.js";
 import { TrendsService } from "../api/generated/index";
 import type { TrendsTermsResponse } from "../api/types.js";
 
+const apiRuntimeMocks = vi.hoisted(() => ({
+  callGenerated: vi.fn(
+    (request: () => Promise<unknown>, _signal?: AbortSignal) => request(),
+  ),
+}));
+
 // Capture the store's shipped default range at import time, before the
 // beforeEach reset overwrites it.
 const DEFAULT_RANGE = { from: trends.from, to: trends.to };
 
 vi.mock("../api/runtime.js", () => ({
   configureGeneratedClient: vi.fn(),
-  callGenerated: vi.fn((request: () => Promise<unknown>) => request()),
+  callGenerated: apiRuntimeMocks.callGenerated,
+  isAbortError: vi.fn(() => false),
 }));
 
 vi.mock("../api/generated/index", () => ({
@@ -48,10 +55,53 @@ function resetStore() {
 beforeEach(() => {
   resetStore();
   vi.clearAllMocks();
+  apiRuntimeMocks.callGenerated.mockImplementation(
+    (request: () => Promise<unknown>, _signal?: AbortSignal) => request(),
+  );
   trendsService.getApiV1TrendsTerms.mockResolvedValue(makeResponse());
 });
 
 describe("TrendsStore.fetchTerms", () => {
+  it("aborts the obsolete terms read when grouping changes", async () => {
+    const signals: AbortSignal[] = [];
+    apiRuntimeMocks.callGenerated.mockImplementation((
+      request: () => Promise<unknown>,
+      signal?: AbortSignal,
+    ) => {
+      signals.push(signal as AbortSignal);
+      return request();
+    });
+    trendsService.getApiV1TrendsTerms
+      .mockImplementationOnce(() => new Promise(() => {}))
+      .mockResolvedValueOnce(makeResponse());
+
+    void trends.fetchTerms();
+    await Promise.resolve();
+    await trends.setGranularity("month");
+
+    expect(signals[0]?.aborted).toBe(true);
+  });
+
+  it("aborts the visible terms read on teardown", async () => {
+    const signals: AbortSignal[] = [];
+    apiRuntimeMocks.callGenerated.mockImplementation((
+      request: () => Promise<unknown>,
+      signal?: AbortSignal,
+    ) => {
+      signals.push(signal as AbortSignal);
+      return request();
+    });
+    trendsService.getApiV1TrendsTerms.mockImplementationOnce(
+      () => new Promise(() => {}),
+    );
+
+    void trends.fetchTerms();
+    await Promise.resolve();
+    trends.cancelInFlightReads();
+
+    expect(signals[0]?.aborted).toBe(true);
+  });
+
   it("fetches default terms with timezone and date range", async () => {
     await trends.fetchTerms();
 

--- a/frontend/src/lib/stores/usage.svelte.ts
+++ b/frontend/src/lib/stores/usage.svelte.ts
@@ -940,6 +940,21 @@ class UsageStore {
     return false;
   }
 
+  cancelInFlightReads(): void {
+    this.fetchAllVersion++;
+    this.versions.summary++;
+    this.versions.pairwise++;
+    this.versions.topSessions++;
+    for (const panel of Object.keys(this.abortControllers) as UsagePanel[]) {
+      this.abortControllers[panel]?.abort();
+      delete this.abortControllers[panel];
+      this.querying[panel] = false;
+    }
+    this.loading.summary = false;
+    this.loading.pairwise = false;
+    this.loading.topSessions = false;
+  }
+
   private markRefreshComplete(): void {
     this.lastUpdatedAt = Date.now();
     this.hasNewData = false;

--- a/frontend/src/lib/stores/usage.test.ts
+++ b/frontend/src/lib/stores/usage.test.ts
@@ -982,6 +982,26 @@ describe("UsageStore session filter params", () => {
     expect(signals[0]?.aborted).toBe(true);
   });
 
+  it("aborts visible panel requests on teardown", async () => {
+    const signals: (AbortSignal | undefined)[] = [];
+    apiRuntimeMocks.callGenerated.mockImplementation(
+      (request: () => Promise<unknown>, signal?: AbortSignal) => {
+        signals.push(signal);
+        return request();
+      },
+    );
+    usageServiceMocks.getApiV1UsageSummary.mockImplementationOnce(
+      () => new Promise(() => {}),
+    );
+    const { usage } = await loadStore();
+
+    void usage.fetchSummary();
+    await Promise.resolve();
+    usage.cancelInFlightReads();
+
+    expect(signals[0]?.aborted).toBe(true);
+  });
+
   it("reuses summary params for top sessions during full refresh", async () => {
     vi.useFakeTimers({ toFake: ["Date"] });
     try {

--- a/frontend/src/lib/utils/latest-read.test.ts
+++ b/frontend/src/lib/utils/latest-read.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vite-plus/test";
+import { LatestRead } from "./latest-read.js";
+
+describe("LatestRead", () => {
+  it("aborts the previous read when a replacement begins", () => {
+    const slot = new LatestRead();
+    const first = slot.begin();
+    const second = slot.begin();
+
+    expect(first.aborted).toBe(true);
+    expect(second.aborted).toBe(false);
+    expect(slot.isCurrent(second)).toBe(true);
+  });
+
+  it("invalidates a read when its surface is cancelled", () => {
+    const slot = new LatestRead();
+    const signal = slot.begin();
+
+    slot.cancel();
+
+    expect(signal.aborted).toBe(true);
+    expect(slot.isCurrent(signal)).toBe(false);
+  });
+
+  it("does not let stale completion clear a newer read", () => {
+    const slot = new LatestRead();
+    const first = slot.begin();
+    const second = slot.begin();
+
+    expect(slot.finish(first)).toBe(false);
+    expect(slot.isCurrent(second)).toBe(true);
+    expect(slot.finish(second)).toBe(true);
+    expect(slot.isCurrent(second)).toBe(false);
+  });
+});

--- a/frontend/src/lib/utils/latest-read.ts
+++ b/frontend/src/lib/utils/latest-read.ts
@@ -1,0 +1,24 @@
+export class LatestRead {
+  #controller: AbortController | null = null;
+
+  begin(): AbortSignal {
+    this.cancel();
+    this.#controller = new AbortController();
+    return this.#controller.signal;
+  }
+
+  isCurrent(signal: AbortSignal): boolean {
+    return this.#controller?.signal === signal && !signal.aborted;
+  }
+
+  finish(signal: AbortSignal): boolean {
+    if (!this.isCurrent(signal)) return false;
+    this.#controller = null;
+    return true;
+  }
+
+  cancel(): void {
+    this.#controller?.abort();
+    this.#controller = null;
+  }
+}

--- a/internal/server/huma_routes_activity_cancellation_internal_test.go
+++ b/internal/server/huma_routes_activity_cancellation_internal_test.go
@@ -1,0 +1,66 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/activity"
+	"go.kenn.io/agentsview/internal/db"
+)
+
+type cancelAwareActivityStore struct {
+	db.Store
+	started  chan struct{}
+	canceled chan struct{}
+}
+
+func (s *cancelAwareActivityStore) GetActivityReport(
+	ctx context.Context,
+	_ db.AnalyticsFilter,
+	_ activity.Query,
+) (activity.Report, error) {
+	close(s.started)
+	<-ctx.Done()
+	close(s.canceled)
+	return activity.Report{}, ctx.Err()
+}
+
+func TestActivityReportPropagatesRequestCancellationToStore(t *testing.T) {
+	store := &cancelAwareActivityStore{
+		started:  make(chan struct{}),
+		canceled: make(chan struct{}),
+	}
+	server := newRoutedTestServerWithStore(t, store)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v1/activity/report?preset=day&date=2026-07-14&timezone=UTC",
+		nil,
+	).WithContext(ctx)
+	done := make(chan struct{})
+
+	go func() {
+		server.mux.ServeHTTP(httptest.NewRecorder(), req)
+		close(done)
+	}()
+
+	requireChannelClosed(t, store.started, "activity query did not start")
+	cancel()
+	requireChannelClosed(t, store.canceled, "store did not observe cancellation")
+	requireChannelClosed(t, done, "activity handler did not return")
+}
+
+func requireChannelClosed(t *testing.T, ch <-chan struct{}, message string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		require.FailNow(t, message)
+	}
+}


### PR DESCRIPTION
## Why

Switching tabs or changing a view parameter could leave the old read running. The UI waited for work that could no longer be shown before starting the replacement query, making navigation feel sluggish and wasting compute.

## What changed

- Cancel obsolete UI-owned reads when their route, session, date range, grouping, search, or component owner changes.
- Start the replacement view and its query immediately.
- Keep stale-response guards so late completions cannot overwrite current state.
- Preserve independent request ownership for panels that can remain visible together.

## Scope

This applies only to reads. Mutations, insight generation, imports, exports, sync, restore/delete, publish, and save flows are unchanged. Long-lived app caches also keep their existing lifetime.

## Where to review

- `LatestRead` and the generated-client abort bridge establish the cancellation contract.
- Aggregate and session stores own requests that follow route and filter state.
- Component teardown owns local reads such as timing, breadcrumbs, settings, pins, and trash.
- Playwright regressions cover both top-level navigation and same-page grouping changes.
