### PR TITLE
feat(parser): ingest Antigravity parent links

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -306,7 +306,9 @@ const projectIdentityRemoteScrubCompletedKey = "project_identity_remote_scrub_v1
 // (66: Claude session identity metadata. Re-parsing populates the new
 // agent_label and entrypoint session columns from top-level agentSetting
 // and entrypoint fields on existing Claude rows.)
-const dataVersion = 66
+// (67: Antigravity CLI reader metadata. Re-parsing populates parent_session_id
+// and relationship_type from agyReader.parentCascadeId in trajectory sidecars.)
+const dataVersion = 67
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -930,9 +930,9 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 		"expected tool_result_events table after reopen")
 }
 
-func TestCurrentDataVersionQueuedSystemMessages(t *testing.T) {
-	assert.Equal(t, 66, CurrentDataVersion(),
-		"queued system message parser changes require a data version bump")
+func TestCurrentDataVersionAntigravityParentLinks(t *testing.T) {
+	assert.Equal(t, 67, CurrentDataVersion(),
+		"Antigravity parent-link parsing requires a data version bump")
 }
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {
 	d := testDB(t)

--- a/internal/parser/antigravity_cli.go
+++ b/internal/parser/antigravity_cli.go
@@ -105,6 +105,10 @@ func (p *antigravityCLIProvider) parseSessionWithStatus(
 	var messages []ParsedMessage
 	var usageEvents []ParsedUsageEvent
 	var hasTrajectory bool
+	// parentCascadeID is reader-owned lineage metadata from the sidecar.
+	// It is independent of which source wins transcript coverage, so a
+	// lagging sidecar can still contribute an authoritative parent pointer.
+	var parentCascadeID string
 	// hasGenMetadata records whether the .db source carried gen_metadata
 	// rows. Combined with the FINAL usageEvents (after the sidecar gap-fill
 	// below) it flags a gen_metadata table that decoded into zero usage.
@@ -139,6 +143,9 @@ func (p *antigravityCLIProvider) parseSessionWithStatus(
 		// as a current transcript.
 		sidecarPath := strings.TrimSuffix(path, ".db") + ".trajectory.json"
 		tRes, tErr := parseAntigravityCLITrajectory(sidecarPath)
+		if tErr == nil {
+			parentCascadeID = tRes.parentCascadeID
+		}
 		sidecarOK := tErr == nil &&
 			hasDisplayableAntigravityCLITrajectoryMessage(tRes.messages)
 		sidecarCovers := dbErr != nil || dbResult.rawStepCount == 0 ||
@@ -184,6 +191,7 @@ func (p *antigravityCLIProvider) parseSessionWithStatus(
 		// and even a sidecar older than the .pb beats the fallbacks.
 		sidecarPath := strings.TrimSuffix(path, ".pb") + ".trajectory.json"
 		if tRes, err := parseAntigravityCLITrajectory(sidecarPath); err == nil {
+			parentCascadeID = tRes.parentCascadeID
 			// Usage events flow whenever the sidecar parses, even when
 			// no message is displayable, matching the message-less
 			// usage stance of the .db branch. The displayable gate
@@ -297,6 +305,10 @@ func (p *antigravityCLIProvider) parseSessionWithStatus(
 			Size:  size,
 			Mtime: mtime,
 		},
+	}
+	if parentCascadeID != "" && !strings.EqualFold(parentCascadeID, id) {
+		sess.ParentSessionID = antigravityCLIIDPrefix + parentCascadeID
+		sess.RelationshipType = RelSubagent
 	}
 	accumulateMessageTokenUsage(sess, messages)
 	applyUsageEventTokenTotals(sess, usageEvents)
@@ -977,6 +989,11 @@ type agyTrajectory struct {
 	CascadeID         string                 `json:"cascadeId"`
 	Steps             []agyStep              `json:"steps"`
 	GeneratorMetadata []agyGeneratorMetadata `json:"generatorMetadata"`
+	AgyReader         json.RawMessage        `json:"agyReader"`
+}
+
+type agyReaderMetadata struct {
+	ParentCascadeID string `json:"parentCascadeId"`
 }
 
 // agyGeneratorMetadata records one model generation: the trajectory
@@ -1298,9 +1315,42 @@ func agyToolDetail(name, inputJSON string) string {
 // same session), and the usage events extracted from
 // generatorMetadata.
 type agyTrajectoryParseResult struct {
-	messages    []ParsedMessage
-	rawSteps    int
-	usageEvents []ParsedUsageEvent
+	messages        []ParsedMessage
+	rawSteps        int
+	usageEvents     []ParsedUsageEvent
+	parentCascadeID string
+}
+
+func parseAgyReaderParentCascadeID(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var metadata agyReaderMetadata
+	if err := json.Unmarshal(raw, &metadata); err != nil {
+		return ""
+	}
+	return canonicalAgyCascadeID(metadata.ParentCascadeID)
+}
+
+func canonicalAgyCascadeID(value string) string {
+	if len(value) != 36 {
+		return ""
+	}
+	for i := range value {
+		if i == 8 || i == 13 || i == 18 || i == 23 {
+			if value[i] != '-' {
+				return ""
+			}
+			continue
+		}
+		c := value[i]
+		if (c < '0' || c > '9') &&
+			(c < 'a' || c > 'f') &&
+			(c < 'A' || c > 'F') {
+			return ""
+		}
+	}
+	return strings.ToLower(value)
 }
 
 // parseAntigravityCLITrajectory reads a <uuid>.trajectory.json sidecar
@@ -1535,9 +1585,10 @@ func parseAntigravityCLITrajectory(
 
 	flushPendingResults()
 	return agyTrajectoryParseResult{
-		messages:    msgs,
-		rawSteps:    len(traj.Steps),
-		usageEvents: extractAgyGeneratorUsage(traj, plannerMsgIdx, msgs),
+		messages:        msgs,
+		rawSteps:        len(traj.Steps),
+		usageEvents:     extractAgyGeneratorUsage(traj, plannerMsgIdx, msgs),
+		parentCascadeID: parseAgyReaderParentCascadeID(traj.AgyReader),
 	}, nil
 }
 

--- a/internal/parser/antigravity_test.go
+++ b/internal/parser/antigravity_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -1700,6 +1701,85 @@ func TestAntigravityCLITrajectoryWithoutSupportedMessagesFallsBack(t *testing.T)
 			assert.Equal(t, "history fallback", msgs[0].Content)
 			assert.Equal(t, 1, sess.MessageCount)
 			assert.Equal(t, "history fallback", sess.FirstMessage)
+		})
+	}
+}
+
+func TestAntigravityCLIReadsAgyReaderParentLink(t *testing.T) {
+	const (
+		childID  = "12121212-3434-5656-7878-909090909090"
+		parentID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	)
+	tests := []struct {
+		name             string
+		ext              string
+		parentCascadeID  string
+		wantParent       string
+		wantRelationship RelationshipType
+	}{
+		{
+			name:             "legacy pb with parent metadata",
+			ext:              ".pb",
+			parentCascadeID:  strings.ToUpper(parentID),
+			wantParent:       antigravityCLIIDPrefix + parentID,
+			wantRelationship: RelSubagent,
+		},
+		{
+			name:             "modern db with lagging sidecar metadata",
+			ext:              ".db",
+			parentCascadeID:  parentID,
+			wantParent:       antigravityCLIIDPrefix + parentID,
+			wantRelationship: RelSubagent,
+		},
+		{
+			name:             "old sidecar without reader metadata",
+			ext:              ".pb",
+			wantRelationship: RelNone,
+		},
+		{
+			name:             "invalid parent metadata is ignored",
+			ext:              ".pb",
+			parentCascadeID:  "../../not-a-cascade",
+			wantRelationship: RelNone,
+		},
+		{
+			name:             "self parent metadata is ignored",
+			ext:              ".pb",
+			parentCascadeID:  childID,
+			wantRelationship: RelNone,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			mustMkdir(t, filepath.Join(root, "conversations"))
+			sourcePath := filepath.Join(root, "conversations", childID+tc.ext)
+			if tc.ext == ".db" {
+				createAntigravityTestDB(t, sourcePath) // two raw DB steps
+			} else {
+				mustWrite(t, sourcePath, []byte("pb-stub"))
+			}
+			reader := ""
+			if tc.parentCascadeID != "" {
+				reader = `,"agyReader":{"parentCascadeId":` +
+					strconv.Quote(tc.parentCascadeID) + `}`
+			}
+			// One displayable sidecar step deliberately lags the two-step DB
+			// fixture. Parent metadata is independent of transcript-source
+			// selection and must still be ingested.
+			sidecar := `{"trajectoryId":"traj","cascadeId":"` + childID + `"` + reader + `,"steps":[{` +
+				`"type":"CORTEX_STEP_TYPE_USER_INPUT",` +
+				`"metadata":{"createdAt":"2026-07-15T00:00:00Z"},` +
+				`"userInput":{"userResponse":"child prompt"}}]}`
+			mustWrite(t, strings.TrimSuffix(sourcePath, tc.ext)+".trajectory.json", []byte(sidecar))
+
+			sess, _, err := parseAntigravityCLITestSession(
+				t, sourcePath, "", "test-machine",
+			)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantParent, sess.ParentSessionID)
+			assert.Equal(t, tc.wantRelationship, sess.RelationshipType)
 		})
 	}
 }

--- a/internal/sync/antigravity_cli_integration_test.go
+++ b/internal/sync/antigravity_cli_integration_test.go
@@ -126,6 +126,72 @@ func TestSyncEngineAntigravityCLI_HappyPath(t *testing.T) {
 	assert.Equal(t, "listing files now", msgs[1].Content)
 }
 
+func TestSyncEngineAntigravityCLI_ParentLinkArrivalOrder(t *testing.T) {
+	tests := []struct {
+		name       string
+		firstChild bool
+	}{
+		{name: "child before parent", firstChild: true},
+		{name: "parent before child", firstChild: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := setupSingleAgentTestEnv(t, parser.AgentAntigravityCLI)
+			const (
+				parentID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+				childID  = "11111111-2222-4333-8444-555555555555"
+			)
+			convDir := filepath.Join(env.antigravityCLIDir, "conversations")
+			require.NoError(t, os.MkdirAll(convDir, 0o755))
+
+			writeSession := func(id, parent, prompt string) {
+				t.Helper()
+				require.NoError(t, os.WriteFile(
+					filepath.Join(convDir, id+".pb"), []byte("pb-stub"), 0o644,
+				))
+				trajectory := antigravityCLISingleUserTrajectory(id, prompt)
+				if parent != "" {
+					trajectory = antigravityCLIParentedTrajectory(id, parent, prompt)
+				}
+				require.NoError(t, os.WriteFile(
+					filepath.Join(convDir, id+".trajectory.json"),
+					[]byte(trajectory), 0o644,
+				))
+			}
+			assertChildLink := func() {
+				t.Helper()
+				assertSessionState(t, env.db, "antigravity-cli:"+childID, func(sess *db.Session) {
+					require.NotNil(t, sess.ParentSessionID)
+					assert.Equal(t, "antigravity-cli:"+parentID, *sess.ParentSessionID)
+					assert.Equal(t, "subagent", sess.RelationshipType)
+				})
+			}
+
+			if tc.firstChild {
+				writeSession(childID, parentID, "child prompt")
+			} else {
+				writeSession(parentID, "", "parent prompt")
+			}
+			runSyncAndAssert(t, env.engine, sync.SyncStats{
+				TotalSessions: 1,
+				Synced:        1,
+			})
+			if tc.firstChild {
+				assertChildLink()
+				writeSession(parentID, "", "parent prompt")
+			} else {
+				writeSession(childID, parentID, "child prompt")
+			}
+			runSyncAndAssert(t, env.engine, sync.SyncStats{
+				TotalSessions: 2,
+				Synced:        1,
+				Skipped:       1,
+			})
+			assertChildLink()
+		})
+	}
+}
+
 func TestSyncEngineAntigravityCLI_SidecarUpdates(t *testing.T) {
 	env := setupSingleAgentTestEnv(t, parser.AgentAntigravityCLI)
 	syncUUID := "44444444-5555-6666-7777-888888888888"
@@ -676,6 +742,21 @@ func antigravityCLISingleUserTrajectory(uuid, prompt string) string {
 			}
 		]
 	}`, uuid, prompt)
+}
+
+func antigravityCLIParentedTrajectory(uuid, parent, prompt string) string {
+	return fmt.Sprintf(`{
+		"trajectoryId": %q,
+		"agyReader": {"parentCascadeId": %q},
+		"steps": [
+			{
+				"type": "CORTEX_STEP_TYPE_USER_INPUT",
+				"status": "STATUS_COMPLETED",
+				"metadata": {"createdAt": "2026-05-20T22:45:00Z"},
+				"userInput": {"userResponse": %q}
+			}
+		]
+	}`, uuid, parent, prompt)
 }
 
 func copyAntigravityCLITestSchemaTemplate(t *testing.T, path string) {


### PR DESCRIPTION
agy-reader now stamps an authoritative `agyReader.parentCascadeId` into Antigravity trajectory sidecars. Consume that field for Antigravity CLI sessions, qualify the bare UUID with the source prefix, and persist the relationship explicitly as a subagent link.

Parent metadata is retained independently of transcript-source selection, so it still applies when a live database is ahead of its sidecar. Missing metadata remains a no-op for older sidecars, while malformed and self-referential pointers are ignored.

The parser data version advances to 67 so existing Antigravity sessions are reparsed. Child rows can retain their qualified parent pointer before the parent row exists, making parent-first and child-first ingestion converge through normal persistence.
