### PR TITLE
fix(i18n): localize the analytics model filter label

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -976,6 +976,7 @@
   "analytics_agent_comparison": "Agent Comparison",
   "analytics_no_comparison_data": "No comparison data (need 2+ agents)",
   "analytics_agent": "Agent",
+  "analytics_model": "Model",
   "analytics_cycle_p50": "Cycle p50",
   "analytics_msgs_per_min": "Msgs/min",
   "analytics_tools_per_min": "Tools/min",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -976,6 +976,7 @@
   "analytics_agent_comparison": "Comparaison des agents",
   "analytics_no_comparison_data": "Aucune donnée de comparaison (2 agents minimum requis)",
   "analytics_agent": "Agent",
+  "analytics_model": "Modèle",
   "analytics_cycle_p50": "Cycle p50",
   "analytics_msgs_per_min": "Msgs/min",
   "analytics_tools_per_min": "Outils/min",

--- a/frontend/messages/ko.json
+++ b/frontend/messages/ko.json
@@ -950,6 +950,7 @@
   "analytics_agent_comparison": "에이전트 비교",
   "analytics_no_comparison_data": "비교 데이터 없음 (에이전트 2개 이상 필요)",
   "analytics_agent": "에이전트",
+  "analytics_model": "모델",
   "analytics_cycle_p50": "사이클 p50",
   "analytics_msgs_per_min": "메시지/분",
   "analytics_tools_per_min": "도구/분",

--- a/frontend/messages/zh-CN.json
+++ b/frontend/messages/zh-CN.json
@@ -948,6 +948,7 @@
   "analytics_agent_comparison": "代理对比",
   "analytics_no_comparison_data": "无对比数据（需要 2 个以上代理）",
   "analytics_agent": "代理",
+  "analytics_model": "模型",
   "analytics_cycle_p50": "周期 p50",
   "analytics_msgs_per_min": "消息/分",
   "analytics_tools_per_min": "工具/分",

--- a/frontend/messages/zh-TW.json
+++ b/frontend/messages/zh-TW.json
@@ -948,6 +948,7 @@
   "analytics_agent_comparison": "代理對比",
   "analytics_no_comparison_data": "無對比數據（需要 2 個以上代理）",
   "analytics_agent": "代理",
+  "analytics_model": "模型",
   "analytics_cycle_p50": "周期 p50",
   "analytics_msgs_per_min": "消息/分",
   "analytics_tools_per_min": "工具/分",

--- a/frontend/src/lib/components/analytics/AnalyticsPage.svelte
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.svelte
@@ -536,7 +536,7 @@
       label={m.analytics_refresh()}
     />
     <FilterDropdown
-      label="Model"
+      label={m.analytics_model()}
       items={modelItems}
       excludedCsv={analytics.model}
       mode="include"


### PR DESCRIPTION
The model `FilterDropdown` on the analytics page passed a hard-coded `"Model"` string, while every sibling control on the same page already goes through a message function. The label therefore stayed English in every non-English locale.

This adds an `analytics_model` key alongside the existing `analytics_agent` and `analytics_project` keys and uses it for the label. The values reuse the wording already present in each catalog for `usage_model` and `activity_model`, so nothing new is invented for the translated locales.

Reviewers may want to look at `AnalyticsPage.svelte` — this was the only hard-coded `label="..."` left in the components tree, so the change is self-contained.