### PR TITLE
fix(sync): bound daemon memory and watcher recovery

### DIFF
--- a/.github/workflows/ci-macos-main.yml
+++ b/.github/workflows/ci-macos-main.yml
@@ -1,0 +1,37 @@
+name: CI (macOS)
+
+on:
+  # Persistent self-hosted runners must never be selectable from a workflow
+  # definition controlled by a pull request. The ci-runners group must allow
+  # this exact workflow path only from refs/heads/main.
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-macos-fsevents:
+    name: Go Test (macOS FSEvents)
+    runs-on:
+      group: ci-runners
+      labels: [self-hosted, macOS, ARM64]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
+        with:
+          go-version-file: go.mod
+
+      - name: Restore pricing snapshot
+        run: go run ./internal/pricing/cmd/litellm-snapshot -restore
+
+      - name: Run focused macOS FSEvents tests
+        run: CGO_ENABLED=1 go test -tags "fts5" ./internal/fsevents ./internal/sync ./internal/db ./cmd/agentsview -count=1 -timeout=20m

--- a/.github/workflows/desktop-macos-main.yml
+++ b/.github/workflows/desktop-macos-main.yml
@@ -1,8 +1,8 @@
 name: Desktop Artifacts (macOS)
 
 on:
-  # This workflow is the only workflow allowed to use the ci-runners group.
-  # The organization runner-group policy must pin access to this path on main.
+  # macOS self-hosted workflows are push-only for main. The organization
+  # runner-group policy must pin access to their exact workflow paths on main.
   push:
     branches: [main]
     paths:

--- a/cmd/agentsview/archive_audit_test.go
+++ b/cmd/agentsview/archive_audit_test.go
@@ -1,0 +1,356 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/sync"
+)
+
+// TestArchiveAuditRetriesWithBackoffOnFailure drives the audit schedule with a
+// wait seam that records delays and a stubbed worker that fails six times then
+// succeeds. It asserts the obligation is retained (attempts continue), the retry
+// delay doubles and caps at archiveAuditInterval, success returns to the daily
+// cadence, and no in-process sync ever runs.
+func TestArchiveAuditRetriesWithBackoffOnFailure(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	database, lock := openTestWriteDB(t, cfg)
+	engine := sync.NewEngine(database, workerEngineConfig(cfg))
+	t.Cleanup(engine.Close)
+	em := &scopedEmitter{scopes: make(chan string, 8)}
+
+	attempts := 0
+	restore := stubLaunchSyncWorker(t, func(
+		_ context.Context, _ config.Config, mode string, _ func(workerLine),
+	) (workerResult, error) {
+		assert.Equal(t, "audit", mode)
+		attempts++
+		if attempts <= 6 {
+			return workerResult{Status: "failed"}, errors.New("audit boom")
+		}
+		return workerResult{Status: "ok", Synced: 1, DiscoveryComplete: true}, nil
+	})
+	defer restore()
+
+	var delays []time.Duration
+	ctx, cancel := context.WithCancel(context.Background())
+	wait := func(ctx context.Context, d time.Duration) bool {
+		delays = append(delays, d)
+		return ctx.Err() == nil
+	}
+	audit := func(ctx context.Context) bool {
+		ok := runArchiveAudit(ctx, cfg, engine, database, lock, em) == nil
+		if attempts >= 7 {
+			cancel()
+		}
+		return ok
+	}
+
+	runArchiveAuditLoop(ctx, wait, audit)
+
+	assert.Equal(t, 7, attempts, "the audit obligation is retained across failures")
+	require.GreaterOrEqual(t, len(delays), 8)
+	assert.Equal(t, []time.Duration{
+		archiveAuditInterval, // initial daily wait
+		1 * time.Hour, 2 * time.Hour, 4 * time.Hour, 8 * time.Hour,
+		16 * time.Hour, archiveAuditInterval, // backoff doubles then caps at 24h
+		archiveAuditInterval, // success returns to the daily cadence
+	}, delays[:8])
+	assert.True(t, engine.LastSync().IsZero(),
+		"the audit must never run an in-process sync pass")
+}
+
+// TestArchiveAuditEmitsOnDataChange asserts a successful audit that changed data
+// emits the sessions scope so connected clients refresh.
+func TestArchiveAuditEmitsOnDataChange(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	database, lock := openTestWriteDB(t, cfg)
+	engine := sync.NewEngine(database, workerEngineConfig(cfg))
+	t.Cleanup(engine.Close)
+	em := &scopedEmitter{scopes: make(chan string, 1)}
+
+	restore := stubLaunchSyncWorker(t, func(
+		_ context.Context, _ config.Config, _ string, _ func(workerLine),
+	) (workerResult, error) {
+		return workerResult{Status: "ok", Synced: 2, DiscoveryComplete: true}, nil
+	})
+	defer restore()
+
+	require.NoError(t, runArchiveAudit(
+		context.Background(), cfg, engine, database, lock, em,
+	))
+	select {
+	case scope := <-em.scopes:
+		assert.Equal(t, "sessions", scope)
+	default:
+		require.FailNow(t, "an audit with Synced>0 must emit the sessions scope")
+	}
+}
+
+func TestArchiveAuditReloadsParentSkipCacheAfterWorkerTombstones(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	database, lock := openTestWriteDB(t, cfg)
+	hashKey := filepath.Join(cfg.AgentDirs[parser.AgentClaude][0], "project", "session.jsonl") +
+		"?source_hash=unchanged"
+	require.NoError(t, database.ReplaceSkippedFiles(map[string]int64{hashKey: 123}))
+	engine := sync.NewEngine(database, workerEngineConfig(cfg))
+	t.Cleanup(engine.Close)
+	require.Contains(t, engine.SnapshotSkipCache(), hashKey)
+
+	restore := stubLaunchSyncWorker(t, func(
+		_ context.Context, workerCfg config.Config, mode string, _ func(workerLine),
+	) (workerResult, error) {
+		assert.Equal(t, "audit", mode)
+		workerDB, err := db.Open(workerCfg.DBPath)
+		require.NoError(t, err)
+		require.NoError(t, workerDB.ReplaceSkippedFiles(map[string]int64{}))
+		require.NoError(t, workerDB.Close())
+		return workerResult{
+			Status: "ok", Tombstoned: 1, DiscoveryComplete: true,
+		}, nil
+	})
+	defer restore()
+
+	require.NoError(t, runArchiveAudit(
+		t.Context(), cfg, engine, database, lock, nil,
+	))
+	assert.NotContains(t, engine.SnapshotSkipCache(), hashKey,
+		"the daemon must discard a hash-qualified entry removed by its audit worker")
+}
+
+// TestArchiveAuditReloadsSkipCacheOnLostTerminalResult pins the reload trigger
+// to "the worker ran", not to the terminal result's content: a child can commit
+// tombstones and durable skip-cache deletions and then die before its result
+// line reaches the parent, so a zero-value result with a protocol error must
+// still refresh the daemon's in-memory skip cache.
+func TestArchiveAuditReloadsSkipCacheOnLostTerminalResult(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	database, lock := openTestWriteDB(t, cfg)
+	hashKey := filepath.Join(cfg.AgentDirs[parser.AgentClaude][0], "project", "session.jsonl") +
+		"?source_hash=unchanged"
+	require.NoError(t, database.ReplaceSkippedFiles(map[string]int64{hashKey: 123}))
+	engine := sync.NewEngine(database, workerEngineConfig(cfg))
+	t.Cleanup(engine.Close)
+	require.Contains(t, engine.SnapshotSkipCache(), hashKey)
+
+	restore := stubLaunchSyncWorker(t, func(
+		_ context.Context, workerCfg config.Config, _ string, _ func(workerLine),
+	) (workerResult, error) {
+		workerDB, err := db.Open(workerCfg.DBPath)
+		require.NoError(t, err)
+		require.NoError(t, workerDB.ReplaceSkippedFiles(map[string]int64{}))
+		require.NoError(t, workerDB.Close())
+		return workerResult{}, errors.New(
+			"audit worker: sync worker emitted 0 terminal results, want exactly 1",
+		)
+	})
+	defer restore()
+
+	err := runArchiveAudit(t.Context(), cfg, engine, database, lock, nil)
+	require.Error(t, err, "the protocol failure must surface so the caller retries")
+	assert.NotContains(t, engine.SnapshotSkipCache(), hashKey,
+		"a lost terminal result must not leave the daemon's skip cache stale")
+}
+
+// TestArchiveAuditEmitsOnPartialSuccess proves committed changes reach SSE
+// clients even when the pass also failed: the retry sees those rows as already
+// synchronized and would never re-emit, so the emit must not be gated on a nil
+// error. The error still propagates so the retry obligation is retained.
+func TestArchiveAuditEmitsOnPartialSuccess(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	database, lock := openTestWriteDB(t, cfg)
+	engine := sync.NewEngine(database, workerEngineConfig(cfg))
+	t.Cleanup(engine.Close)
+	em := &scopedEmitter{scopes: make(chan string, 1)}
+
+	restore := stubLaunchSyncWorker(t, func(
+		_ context.Context, _ config.Config, _ string, _ func(workerLine),
+	) (workerResult, error) {
+		return workerResult{Status: "failed", Synced: 2, Failed: 1},
+			errors.New("audit worker pass reported failed")
+	})
+	defer restore()
+
+	err := runArchiveAudit(context.Background(), cfg, engine, database, lock, em)
+	require.Error(t, err, "the partial failure must still surface for retry")
+	select {
+	case scope := <-em.scopes:
+		assert.Equal(t, "sessions", scope)
+	default:
+		require.FailNow(t, "an audit that committed sessions must emit even on failure")
+	}
+}
+
+// TestArchiveAuditSurfacesWorkerFailureWithoutFallback proves the no-fallback
+// rule: a failed worker audit returns an error (so the caller retries), runs no
+// in-process sync, and emits nothing.
+func TestArchiveAuditSurfacesWorkerFailureWithoutFallback(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	database, lock := openTestWriteDB(t, cfg)
+	engine := sync.NewEngine(database, workerEngineConfig(cfg))
+	t.Cleanup(engine.Close)
+	em := &scopedEmitter{scopes: make(chan string, 1)}
+
+	restore := stubLaunchSyncWorker(t, func(
+		_ context.Context, _ config.Config, _ string, _ func(workerLine),
+	) (workerResult, error) {
+		return workerResult{Status: "failed"}, errors.New("audit boom")
+	})
+	defer restore()
+
+	err := runArchiveAudit(context.Background(), cfg, engine, database, lock, em)
+	require.Error(t, err, "a failed audit must surface the error for retry")
+	assert.True(t, engine.LastSync().IsZero(),
+		"a failed audit must not fall back to an in-process sync")
+	select {
+	case <-em.scopes:
+		require.FailNow(t, "a failed audit must not emit")
+	default:
+	}
+}
+
+// TestArchiveAuditAttemptLogsWorkerError proves the worker's terminal Error is
+// no longer swallowed: a failed attempt logs the actual error and reports false.
+func TestArchiveAuditAttemptLogsWorkerError(t *testing.T) {
+	logs := captureLogOutput(t)
+	ok := runArchiveAuditAttempt(
+		context.Background(), nil,
+		func(context.Context) error { return errors.New("audit boom") },
+	)
+	assert.False(t, ok, "a failed attempt reports failure")
+	assert.Contains(t, logs.String(), "audit boom",
+		"the worker's terminal error must reach the log")
+}
+
+// TestArchiveAuditAttemptSilentOnCancel proves a failure during shutdown does not
+// log: the cancelled context suppresses the spurious failure line.
+func TestArchiveAuditAttemptSilentOnCancel(t *testing.T) {
+	logs := captureLogOutput(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	ok := runArchiveAuditAttempt(
+		ctx, nil,
+		func(context.Context) error { return errors.New("audit boom") },
+	)
+	assert.False(t, ok)
+	assert.NotContains(t, logs.String(), "audit boom",
+		"a cancelled attempt must not log a failure")
+}
+
+// TestArchiveAuditLoopSuppressesBackoffLogOnShutdown proves the loop stays quiet
+// once the context is cancelled: the "next attempt" backoff line is suppressed.
+func TestArchiveAuditLoopSuppressesBackoffLogOnShutdown(t *testing.T) {
+	logs := captureLogOutput(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	wait := func(ctx context.Context, _ time.Duration) bool {
+		return ctx.Err() == nil
+	}
+	audit := func(context.Context) bool {
+		cancel() // fail this attempt and shut down before the next wait
+		return false
+	}
+	runArchiveAuditLoop(ctx, wait, audit)
+	assert.NotContains(t, logs.String(), "next attempt",
+		"shutdown must not emit a backoff line")
+}
+
+// TestArchiveAuditLoopLogsBackoffWhileRunning proves the backoff line is still
+// logged for a genuine mid-run failure, so suppression is scoped to shutdown.
+func TestArchiveAuditLoopLogsBackoffWhileRunning(t *testing.T) {
+	logs := captureLogOutput(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	attempts := 0
+	wait := func(ctx context.Context, _ time.Duration) bool {
+		return ctx.Err() == nil
+	}
+	audit := func(context.Context) bool {
+		attempts++
+		if attempts >= 2 {
+			cancel()
+		}
+		return false // first attempt fails while the context is still live
+	}
+	runArchiveAuditLoop(ctx, wait, audit)
+	assert.Contains(t, logs.String(), "next attempt",
+		"a live-run failure must log the backoff line")
+}
+
+// TestArchiveAuditLoopStopsOnContextCancel guards the shutdown path: a cancelled
+// context ends the loop without running an audit.
+func TestArchiveAuditLoopStopsOnContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	audited := false
+	runArchiveAuditLoop(ctx,
+		func(context.Context, time.Duration) bool { return false },
+		func(context.Context) bool { audited = true; return true },
+	)
+	assert.False(t, audited, "a cancelled context must stop the loop before auditing")
+}
+
+// TestSyncWorkerAuditModeRunsSyncPass confirms the audit worker mode performs a
+// full authoritative pass over the archive and emits an ok terminal result.
+func TestSyncWorkerAuditModeRunsSyncPass(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	var out bytes.Buffer
+	require.NoError(t, runSyncWorker(cfg, "audit", &out))
+	result := decodeSingleResult(t, &out)
+	assert.Equal(t, "ok", result.Status)
+	assert.True(t, result.DiscoveryComplete)
+	assert.Equal(t, 3, result.Synced)
+}
+
+// TestSyncWorkerAuditTombstonesMissedDeletion is the audit's safety-net
+// regression: a source file deleted while no watcher was running must be
+// tombstoned by the daily audit, with the session row preserved in the
+// persistent archive.
+func TestSyncWorkerAuditTombstonesMissedDeletion(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	database, err := db.Open(cfg.DBPath)
+	require.NoError(t, err)
+	engine := sync.NewEngine(database, workerEngineConfig(cfg))
+	require.Equal(t, 3, engine.SyncAll(context.Background(), nil).Synced)
+	claudeDir := cfg.AgentDirs[parser.AgentClaude][0]
+	deletedPath := filepath.Join(claudeDir, "-home-proj0", "session0.jsonl")
+	hashKey := deletedPath + "?source_hash=unchanged"
+	require.NoError(t, database.ReplaceSkippedFiles(map[string]int64{hashKey: 123}))
+	engine.Close()
+	require.NoError(t, database.Close())
+
+	// Delete one source with no watcher running: only the audit can notice.
+	require.NoError(t, os.Remove(deletedPath))
+
+	var out bytes.Buffer
+	require.NoError(t, runSyncWorker(cfg, "audit", &out))
+	result := decodeSingleResult(t, &out)
+	assert.Equal(t, "ok", result.Status)
+	assert.Equal(t, 1, result.Tombstoned,
+		"the audit must reconcile the deletion the watcher missed")
+
+	database, err = db.Open(cfg.DBPath)
+	require.NoError(t, err)
+	defer database.Close()
+	var live, total int
+	require.NoError(t, database.Reader().QueryRow(
+		"SELECT COUNT(*) FROM sessions WHERE deleted_at IS NULL",
+	).Scan(&live))
+	require.NoError(t, database.Reader().QueryRow(
+		"SELECT COUNT(*) FROM sessions",
+	).Scan(&total))
+	assert.Equal(t, 2, live, "the deleted source's session must be tombstoned")
+	assert.Equal(t, 3, total, "tombstoning must preserve the archived row")
+	persistedSkips, err := database.LoadSkippedFiles()
+	require.NoError(t, err)
+	assert.NotContains(t, persistedSkips, hashKey,
+		"the audit worker must durably remove the tombstoned source's hash key")
+}

--- a/cmd/agentsview/archive_write_backend.go
+++ b/cmd/agentsview/archive_write_backend.go
@@ -54,6 +54,154 @@ type archiveWriteBackend interface {
 	) error
 }
 
+// archivePushWatchHooks exposes only the slow/nondeterministic owner boundaries
+// needed to verify production startup ordering. Nil hooks use the real watcher,
+// timers, push implementations, and local startup sync.
+type archivePushWatchHooks struct {
+	startWatcher func(
+		config.Config, *syncpkg.Engine, syncpkg.WatchCallback, syncpkg.WatcherOptions,
+	) (func(), func(), []string)
+	newLoop func(
+		string, time.Duration, time.Duration,
+		func(context.Context, pushReason) error,
+	) (*pushLoop, func())
+	duckDBPush func(
+		context.Context, pushReason, bool,
+	) (duckdbsync.PushResult, error)
+	pgPush func(
+		context.Context, pushReason, bool,
+	) (postgres.PushResult, error)
+	pgStartupSync func(
+		context.Context, *syncpkg.Engine, bool,
+	) (bool, error)
+	newPGPusher        func(*syncpkg.Engine) *pgPusher
+	newUnwatchedPoller func(context.Context, unwatchedPollSyncer) unwatchedRootPoller
+}
+
+// unwatchedRootPoller owns probe-gated authoritative polling for scopes the
+// watcher cannot cover: roots missing at startup, coverage lost at runtime,
+// and persistent polling dirs. sharedUnwatchedPollCoordinator implements it.
+type unwatchedRootPoller interface {
+	AddObligation(pollingObligation) error
+	RemoveObligation(string) error
+	Stop()
+}
+
+// newArchivePushUnwatchedPoller builds the pg watch polling owner for
+// deferred scopes. The watcher's full recovery and rename promotion defer
+// unavailable scopes to their polling probes, and the interval push runs a
+// plain SyncAll that never tombstones missed deletions, so without this owner
+// a deletion lost while a root was unavailable would stay active in the
+// archive (and every pushed mirror) indefinitely after the root returns.
+func newArchivePushUnwatchedPoller(
+	ctx context.Context,
+	hooks *archivePushWatchHooks,
+	engine unwatchedPollSyncer,
+) unwatchedRootPoller {
+	if hooks != nil && hooks.newUnwatchedPoller != nil {
+		return hooks.newUnwatchedPoller(ctx, engine)
+	}
+	ticker := time.NewTicker(unwatchedPollInterval)
+	return newUnwatchedPollCoordinatorWithTicks(
+		ctx, engine, ticker.C, ticker.Stop, func(work func()) { work() }, nil,
+	)
+}
+
+func startArchivePushWatcher(
+	hooks *archivePushWatchHooks,
+	cfg config.Config,
+	engine *syncpkg.Engine,
+	callback syncpkg.WatchCallback,
+	options syncpkg.WatcherOptions,
+) (func(), func(), []string) {
+	if hooks != nil && hooks.startWatcher != nil {
+		return hooks.startWatcher(cfg, engine, callback, options)
+	}
+	stop, open, unwatched, _ := startFileWatcher(cfg, engine, callback, options)
+	return stop, open, unwatched
+}
+
+func newArchivePushLoop(
+	hooks *archivePushWatchHooks,
+	label string,
+	debounce, interval time.Duration,
+	push func(context.Context, pushReason) error,
+) (*pushLoop, func()) {
+	if hooks != nil && hooks.newLoop != nil {
+		return hooks.newLoop(label, debounce, interval, push)
+	}
+	loop, ticker := newPushLoopWithLabel(label, debounce, interval, push)
+	return loop, ticker.Stop
+}
+
+func completeDuckDBWatchPush(
+	res duckdbsync.PushResult, reason pushReason,
+) error {
+	logDuckDBWatchPushResult(res, reason)
+	if res.Errors > 0 {
+		return fmt.Errorf("%d session(s) failed to push", res.Errors)
+	}
+	return nil
+}
+
+func completePGWatchPush(res postgres.PushResult, reason pushReason) error {
+	logPGWatchPushResult(res, reason)
+	if res.Errors > 0 {
+		return fmt.Errorf("%d session(s) failed to push", res.Errors)
+	}
+	return nil
+}
+
+func completePushWatchStartup(
+	ctx context.Context, initialErr error, loop *pushLoop, openDispatch func(),
+) {
+	if initialErr == nil {
+		if ctx.Err() == nil {
+			openDispatch()
+		}
+		return
+	}
+	ack := loop.NotifyDirtyWithAck()
+	go func() {
+		select {
+		case <-ctx.Done():
+			return
+		case err := <-ack:
+			if err == nil && ctx.Err() == nil {
+				openDispatch()
+			}
+		}
+	}()
+}
+
+func notifyPushForWatchBatch(
+	ctx context.Context, loop *pushLoop, batch syncpkg.WatchBatch,
+) error {
+	if !watchBatchNeedsPushAck(batch) {
+		loop.NotifyDirty()
+		return nil
+	}
+	ack := loop.NotifyDirtyWithAck()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-ack:
+		return err
+	}
+}
+
+func watchBatchNeedsPushAck(batch syncpkg.WatchBatch) bool {
+	if batch.FullSync || len(batch.ReconcileRoots) > 0 {
+		return true
+	}
+	for _, rename := range batch.Renames {
+		if rename.ItemType != syncpkg.ItemIsFile {
+			return true
+		}
+	}
+	return false
+}
+
 func resolveArchiveWriteBackend(
 	ctx context.Context,
 	appCfg config.Config,
@@ -93,8 +241,9 @@ func resolveArchiveWriteBackend(
 }
 
 type daemonArchiveWriteBackend struct {
-	appCfg config.Config
-	tr     transport
+	appCfg     config.Config
+	tr         transport
+	watchHooks *archivePushWatchHooks
 }
 
 // daemonPushHeartbeatInterval bounds how often the daemon-delegated push
@@ -222,43 +371,46 @@ func (b daemonArchiveWriteBackend) DuckDBPushWatch(
 		// every changed batch, and archive-scale diagnostics are
 		// skipped. Push ignores the defer behavior when full is set.
 		pushCfg.Automatic = true
-		backend := archiveWriteBackend(b)
-		cleanup := func() {}
-		if reason != reasonStartup {
-			var err error
-			backend, cleanup, err = resolveArchiveWriteBackend(
-				pctx, b.appCfg,
-			)
-			if err != nil {
-				return err
+		var res duckdbsync.PushResult
+		var err error
+		if b.watchHooks != nil && b.watchHooks.duckDBPush != nil {
+			res, err = b.watchHooks.duckDBPush(pctx, reason, full)
+		} else {
+			backend := archiveWriteBackend(b)
+			cleanup := func() {}
+			if reason != reasonStartup {
+				backend, cleanup, err = resolveArchiveWriteBackend(
+					pctx, b.appCfg,
+				)
+				if err != nil {
+					return err
+				}
 			}
+			defer cleanup()
+			res, err = backend.DuckDBPush(
+				pctx, duckCfg, pushCfg, projects, excludeProjects,
+			)
 		}
-		defer cleanup()
-		res, err := backend.DuckDBPush(
-			pctx, duckCfg, pushCfg, projects, excludeProjects,
-		)
 		if err != nil {
 			return err
 		}
-		logDuckDBWatchPushResult(res, reason)
-		return nil
+		return completeDuckDBWatchPush(res, reason)
 	}
-	if err := push(ctx, reasonStartup, cfg.Full); err != nil {
-		log.Printf("duckdb watch: initial daemon push failed: %v", err)
-	}
-
-	loop, ticker := newPushLoopWithLabel(
+	loop, stopLoop := newArchivePushLoop(
+		b.watchHooks,
 		"duckdb watch", debounce, interval,
 		func(c context.Context, r pushReason) error {
 			return push(c, r, false)
 		},
 	)
-	defer ticker.Stop()
+	defer stopLoop()
 
-	stopWatcher, unwatchedDirs := startFileWatcher(b.appCfg, nil,
-		func(_ syncpkg.WatchBatch) {
-			loop.NotifyDirty()
+	stopWatcher, openDispatch, unwatchedDirs := startArchivePushWatcher(
+		b.watchHooks, b.appCfg, nil,
+		func(callbackCtx context.Context, batch syncpkg.WatchBatch) error {
+			return notifyPushForWatchBatch(callbackCtx, loop, batch)
 		},
+		syncpkg.WatcherOptions{OnCoverageDegraded: loop.NotifyCoverageDegraded},
 	)
 	defer stopWatcher()
 	if len(unwatchedDirs) > 0 {
@@ -267,6 +419,11 @@ func (b daemonArchiveWriteBackend) DuckDBPushWatch(
 			len(unwatchedDirs), interval,
 		)
 	}
+	initialErr := push(ctx, reasonStartup, cfg.Full)
+	if initialErr != nil {
+		log.Printf("duckdb watch: initial daemon push failed: %v", initialErr)
+	}
+	completePushWatchStartup(ctx, initialErr, loop, openDispatch)
 
 	loop.Run(ctx)
 	return nil
@@ -329,42 +486,45 @@ func (b daemonArchiveWriteBackend) PGPushWatch(
 	push := func(pctx context.Context, reason pushReason, full bool) error {
 		pushCfg := cfg
 		pushCfg.Full = full
-		backend := archiveWriteBackend(b)
-		cleanup := func() {}
-		if reason != reasonStartup {
-			var err error
-			backend, cleanup, err = resolveArchiveWriteBackend(
-				pctx, b.appCfg,
-			)
-			if err != nil {
-				return err
+		var res postgres.PushResult
+		var err error
+		if b.watchHooks != nil && b.watchHooks.pgPush != nil {
+			res, err = b.watchHooks.pgPush(pctx, reason, full)
+		} else {
+			backend := archiveWriteBackend(b)
+			cleanup := func() {}
+			if reason != reasonStartup {
+				backend, cleanup, err = resolveArchiveWriteBackend(
+					pctx, b.appCfg,
+				)
+				if err != nil {
+					return err
+				}
 			}
+			defer cleanup()
+			res, err = backend.PGPush(
+				pctx, target, pushCfg, projects, exclude,
+			)
 		}
-		defer cleanup()
-		res, err := backend.PGPush(
-			pctx, target, pushCfg, projects, exclude,
-		)
 		if err != nil {
 			return err
 		}
-		logPGWatchPushResult(res, reason)
-		return nil
+		return completePGWatchPush(res, reason)
 	}
-	if err := push(ctx, reasonStartup, cfg.Full); err != nil {
-		log.Printf("pg watch: initial daemon push failed: %v", err)
-	}
-
-	loop, ticker := newPushLoop(debounce, interval,
+	loop, stopLoop := newArchivePushLoop(
+		b.watchHooks, "pg watch", debounce, interval,
 		func(c context.Context, r pushReason) error {
 			return push(c, r, false)
 		},
 	)
-	defer ticker.Stop()
+	defer stopLoop()
 
-	stopWatcher, unwatchedDirs := startFileWatcher(b.appCfg, nil,
-		func(_ syncpkg.WatchBatch) {
-			loop.NotifyDirty()
+	stopWatcher, openDispatch, unwatchedDirs := startArchivePushWatcher(
+		b.watchHooks, b.appCfg, nil,
+		func(callbackCtx context.Context, batch syncpkg.WatchBatch) error {
+			return notifyPushForWatchBatch(callbackCtx, loop, batch)
 		},
+		syncpkg.WatcherOptions{OnCoverageDegraded: loop.NotifyCoverageDegraded},
 	)
 	defer stopWatcher()
 	if len(unwatchedDirs) > 0 {
@@ -373,6 +533,11 @@ func (b daemonArchiveWriteBackend) PGPushWatch(
 			len(unwatchedDirs), interval,
 		)
 	}
+	initialErr := push(ctx, reasonStartup, cfg.Full)
+	if initialErr != nil {
+		log.Printf("pg watch: initial daemon push failed: %v", initialErr)
+	}
+	completePushWatchStartup(ctx, initialErr, loop, openDispatch)
 
 	loop.Run(ctx)
 	return nil
@@ -382,6 +547,7 @@ type localArchiveWriteBackend struct {
 	appCfg        config.Config
 	database      *db.DB
 	ensurePricing func(context.Context, *db.DB) error
+	watchHooks    *archivePushWatchHooks
 }
 
 func (b *localArchiveWriteBackend) ensureCurrentPricing(
@@ -483,8 +649,10 @@ func (b *localArchiveWriteBackend) duckDBPush(
 	if err := duckdbsync.ValidatePushTarget(duckCfg); err != nil {
 		return duckdbsync.PushResult{}, err
 	}
-	didResync := runLocalSync(ctx, b.appCfg, b.database, cfg.Full)
-	if err := ctx.Err(); err != nil {
+	didResync, err := runLocalSyncAuthoritative(
+		ctx, b.appCfg, b.database, cfg.Full,
+	)
+	if err != nil {
 		return duckdbsync.PushResult{}, err
 	}
 	forceFull := cfg.Full || didResync
@@ -534,29 +702,35 @@ func (b *localArchiveWriteBackend) DuckDBPushWatch(
 		// every changed batch, and archive-scale diagnostics are
 		// skipped. Push ignores the defer behavior when full is set.
 		pushCfg.Automatic = true
-		res, err := b.DuckDBPush(pctx, duckCfg, pushCfg, projects, exclude)
+		var res duckdbsync.PushResult
+		var err error
+		if b.watchHooks != nil && b.watchHooks.duckDBPush != nil {
+			res, err = b.watchHooks.duckDBPush(pctx, reason, full)
+		} else {
+			res, err = b.DuckDBPush(
+				pctx, duckCfg, pushCfg, projects, exclude,
+			)
+		}
 		if err != nil {
 			return err
 		}
-		logDuckDBWatchPushResult(res, reason)
-		return nil
+		return completeDuckDBWatchPush(res, reason)
 	}
-	if err := push(ctx, reasonStartup, cfg.Full); err != nil {
-		log.Printf("duckdb watch: initial push failed: %v", err)
-	}
-
-	loop, ticker := newPushLoopWithLabel(
+	loop, stopLoop := newArchivePushLoop(
+		b.watchHooks,
 		"duckdb watch", debounce, interval,
 		func(c context.Context, r pushReason) error {
 			return push(c, r, false)
 		},
 	)
-	defer ticker.Stop()
+	defer stopLoop()
 
-	stopWatcher, unwatchedDirs := startFileWatcher(b.appCfg, nil,
-		func(_ syncpkg.WatchBatch) {
-			loop.NotifyDirty()
+	stopWatcher, openDispatch, unwatchedDirs := startArchivePushWatcher(
+		b.watchHooks, b.appCfg, nil,
+		func(callbackCtx context.Context, batch syncpkg.WatchBatch) error {
+			return notifyPushForWatchBatch(callbackCtx, loop, batch)
 		},
+		syncpkg.WatcherOptions{OnCoverageDegraded: loop.NotifyCoverageDegraded},
 	)
 	defer stopWatcher()
 	if len(unwatchedDirs) > 0 {
@@ -565,6 +739,11 @@ func (b *localArchiveWriteBackend) DuckDBPushWatch(
 			len(unwatchedDirs), interval,
 		)
 	}
+	initialErr := push(ctx, reasonStartup, cfg.Full)
+	if initialErr != nil {
+		log.Printf("duckdb watch: initial push failed: %v", initialErr)
+	}
+	completePushWatchStartup(ctx, initialErr, loop, openDispatch)
 
 	loop.Run(ctx)
 	return nil
@@ -631,44 +810,46 @@ func (b *localArchiveWriteBackend) PGPushWatch(
 	})
 	defer engine.Close()
 
-	didResync, err := runPGWatchStartupSync(ctx, engine, cfg.Full)
-	if err != nil {
-		if errors.Is(err, context.Canceled) {
-			return nil
-		}
-		return err
+	var pusher *pgPusher
+	if b.watchHooks != nil && b.watchHooks.newPGPusher != nil {
+		pusher = b.watchHooks.newPGPusher(engine)
+	} else {
+		// One vectors.db adapter for the watch loop's lifetime: connect runs on
+		// every reconnect, and a fresh source per reconnect would leak the
+		// previous one's memoized read-only handle (postgres.Sync never closes
+		// its source). The adapter is designed for reuse — it reopens lazily
+		// after transient failures.
+		vectorSource := pgVectorPushSource(b.appCfg, target, cfg)
+		defer closeVectorPushSource(vectorSource)
+		pusher = b.newPGPusher(
+			func(c context.Context) error {
+				stats := engine.SyncAll(c, nil)
+				if err := c.Err(); err != nil {
+					return err
+				}
+				if !stats.AuthoritativeDiscoveryComplete() {
+					return errors.New("local sync discovery incomplete")
+				}
+				// The push scans SQLite rows right after this returns;
+				// flush deferred signal recomputes so pushed sessions
+				// carry current signal/secret fields.
+				engine.FlushSignals()
+				return nil
+			},
+			func() (pgTarget, error) {
+				applyClassifierConfig(b.appCfg)
+				s, cErr := postgres.New(
+					target.PG.URL, target.PG.Schema, b.database,
+					target.PG.MachineName, target.PG.AllowInsecure,
+					target.syncOptions(projects, exclude, vectorSource),
+				)
+				if cErr != nil {
+					return nil, cErr
+				}
+				return s, nil
+			},
+		)
 	}
-
-	// One vectors.db adapter for the watch loop's lifetime: connect runs on
-	// every reconnect, and a fresh source per reconnect would leak the
-	// previous one's memoized read-only handle (postgres.Sync never closes
-	// its source). The adapter is designed for reuse — it reopens lazily
-	// after transient failures.
-	vectorSource := pgVectorPushSource(b.appCfg, target, cfg)
-	defer closeVectorPushSource(vectorSource)
-
-	pusher := b.newPGPusher(
-		func(c context.Context) error {
-			engine.SyncAll(c, nil)
-			// The push scans SQLite rows right after this returns;
-			// flush deferred signal recomputes so pushed sessions
-			// carry current signal/secret fields.
-			engine.FlushSignals()
-			return nil
-		},
-		func() (pgTarget, error) {
-			applyClassifierConfig(b.appCfg)
-			s, cErr := postgres.New(
-				target.PG.URL, target.PG.Schema, b.database,
-				target.PG.MachineName, target.PG.AllowInsecure,
-				target.syncOptions(projects, exclude, vectorSource),
-			)
-			if cErr != nil {
-				return nil, cErr
-			}
-			return s, nil
-		},
-	)
 	defer pusher.reset()
 
 	fmt.Printf(
@@ -677,30 +858,78 @@ func (b *localArchiveWriteBackend) PGPushWatch(
 		target.PG.MachineName, debounce, interval,
 	)
 
-	if err := pusher.push(ctx, reasonStartup, didResync); err != nil {
-		log.Printf("pg watch: initial push failed: %v", err)
-	}
-
-	loop, ticker := newPushLoop(debounce, interval,
+	loop, stopLoop := newArchivePushLoop(
+		b.watchHooks, "pg watch", debounce, interval,
 		func(c context.Context, r pushReason) error {
 			return pusher.push(c, r, false)
 		},
 	)
-	defer ticker.Stop()
+	defer stopLoop()
 
-	stopWatcher, unwatchedDirs := startFileWatcher(b.appCfg, engine,
-		func(batch syncpkg.WatchBatch) {
-			syncWatchBatch(ctx, engine, batch)
-			loop.NotifyDirty()
+	poller := newArchivePushUnwatchedPoller(ctx, b.watchHooks, engine)
+	defer poller.Stop()
+
+	stopWatcher, openDispatch, unwatchedDirs := startArchivePushWatcher(
+		b.watchHooks, b.appCfg, engine,
+		func(callbackCtx context.Context, batch syncpkg.WatchBatch) error {
+			scope := func() watchRecoveryScope {
+				return probeWatchRecoveryScope(b.appCfg)
+			}
+			if err := syncWatchBatch(callbackCtx, engine, batch, scope); err != nil {
+				return err
+			}
+			return notifyPushForWatchBatch(callbackCtx, loop, batch)
+		},
+		syncpkg.WatcherOptions{
+			OnCoverageDegraded: func(roots []string) error {
+				// Degraded coverage needs both owners: the poller reconciles
+				// the affected roots authoritatively (including tombstoning
+				// missed deletions) and the loop re-pushes the refreshed
+				// archive on its floor.
+				if err := poller.AddObligation(pollingObligation{
+					Key: "watcher-fallback", Roots: roots,
+				}); err != nil {
+					return err
+				}
+				return loop.NotifyCoverageDegraded(roots)
+			},
+			OnPollingRequired: func(obligation syncpkg.PollingObligation) error {
+				return poller.AddObligation(pollingObligation{
+					Key:   obligation.Key,
+					Roots: obligation.Roots,
+					Probe: obligation.Probe,
+				})
+			},
+			OnPollingReleased: poller.RemoveObligation,
 		},
 	)
 	defer stopWatcher()
 	if len(unwatchedDirs) > 0 {
 		log.Printf(
-			"pg watch: %d root(s) not watched; relying on the %s floor for coverage",
-			len(unwatchedDirs), interval,
+			"pg watch: %d root(s) not watched; polling every %s",
+			len(unwatchedDirs), unwatchedPollInterval,
 		)
 	}
+
+	startupSync := runPGWatchStartupSync
+	if b.watchHooks != nil && b.watchHooks.pgStartupSync != nil {
+		startupSync = b.watchHooks.pgStartupSync
+	}
+	didResync, startupErr := startupSync(ctx, engine, cfg.Full)
+	if startupErr != nil && errors.Is(startupErr, context.Canceled) {
+		return nil
+	}
+	initialErr := startupErr
+	if initialErr == nil {
+		initialErr = pusher.push(ctx, reasonStartup, didResync)
+	}
+	if initialErr != nil {
+		if errors.Is(initialErr, context.Canceled) && ctx.Err() != nil {
+			return nil
+		}
+		log.Printf("pg watch: initial push failed: %v", initialErr)
+	}
+	completePushWatchStartup(ctx, initialErr, loop, openDispatch)
 
 	loop.Run(ctx)
 	return nil
@@ -712,13 +941,16 @@ func runPGWatchStartupSync(
 	full bool,
 ) (bool, error) {
 	didResync := false
-	_, err := engine.SyncThenRun(ctx, full, nil,
+	stats, err := engine.SyncThenRun(ctx, full, nil,
 		func(forceFull bool) error {
 			didResync = forceFull
 			return nil
 		})
 	if err != nil {
 		return false, err
+	}
+	if !stats.AuthoritativeDiscoveryComplete() {
+		return didResync, errors.New("startup sync discovery incomplete")
 	}
 	return didResync, nil
 }

--- a/cmd/agentsview/archive_write_backend_test.go
+++ b/cmd/agentsview/archive_write_backend_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	stdsync "sync"
@@ -14,8 +16,11 @@ import (
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/dbtest"
+	duckdbsync "go.kenn.io/agentsview/internal/duckdb"
+	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/postgres"
 	syncpkg "go.kenn.io/agentsview/internal/sync"
+	"go.kenn.io/agentsview/internal/testjsonl"
 )
 
 // TestDaemonPushHeartbeat pins the daemon-delegated push's client-side
@@ -196,6 +201,39 @@ func TestLocalArchiveWriteBackendDuckDBPushValidatesRemoteBeforeLocalSync(t *tes
 	assert.NotContains(t, out, "Opening DuckDB mirror")
 }
 
+func TestLocalArchiveWriteBackendDuckDBPushRejectsIncompleteDiscovery(t *testing.T) {
+	backend := testLocalArchiveWriteBackend(t)
+	original := coordinateLocalSyncRunner
+	coordinateLocalSyncRunner = func(
+		context.Context,
+		config.Config,
+		*db.DB,
+		bool,
+		syncpkg.ProgressFunc,
+		bool,
+		func() (syncpkg.RebuildOptions, syncpkg.RebuildCleanup, error),
+		func(bool, bool) error,
+	) (bool, syncpkg.SyncStats, error) {
+		return false, syncpkg.SyncStats{Aborted: true}, nil
+	}
+	t.Cleanup(func() { coordinateLocalSyncRunner = original })
+	mirrorPath := filepath.Join(t.TempDir(), "mirror.duckdb")
+
+	var err error
+	out := captureStdout(t, func() {
+		_, err = backend.DuckDBPush(
+			t.Context(),
+			config.DuckDBConfig{Path: mirrorPath, MachineName: "local"},
+			DuckDBPushConfig{}, nil, nil,
+		)
+	})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "local sync discovery incomplete")
+	assert.NotContains(t, out, "Opening DuckDB mirror",
+		"an incomplete local archive must stop before mirror push")
+}
+
 func TestRunPGWatchStartupSyncFallsBackAfterAbortedResync(t *testing.T) {
 	database := dbtest.OpenTestDB(t)
 	missingPath := filepath.Join(t.TempDir(), "missing.jsonl")
@@ -215,6 +253,62 @@ func TestRunPGWatchStartupSyncFallsBackAfterAbortedResync(t *testing.T) {
 	assert.False(t, engine.LastSync().IsZero())
 }
 
+type startupDiscoveryFailureFactory struct{ err error }
+
+func (f startupDiscoveryFailureFactory) Definition() parser.AgentDef {
+	return parser.AgentDef{Type: parser.AgentCowork, FileBased: true}
+}
+
+func (f startupDiscoveryFailureFactory) Capabilities() parser.Capabilities {
+	return parser.Capabilities{}
+}
+
+func (f startupDiscoveryFailureFactory) NewProvider(
+	cfg parser.ProviderConfig,
+) parser.Provider {
+	return &startupDiscoveryFailureProvider{
+		ProviderBase: parser.ProviderBase{Def: f.Definition(), Config: cfg},
+		err:          f.err,
+	}
+}
+
+type startupDiscoveryFailureProvider struct {
+	parser.ProviderBase
+	err error
+}
+
+func (p *startupDiscoveryFailureProvider) Discover(
+	context.Context,
+) ([]parser.SourceRef, error) {
+	return nil, p.err
+}
+
+func (p *startupDiscoveryFailureProvider) Parse(
+	context.Context, parser.ParseRequest,
+) (parser.ParseOutcome, error) {
+	return parser.ParseOutcome{}, nil
+}
+
+func TestRunPGWatchStartupSyncReportsIncompleteDiscovery(t *testing.T) {
+	database := dbtest.OpenTestDB(t)
+	root := t.TempDir()
+	engine := syncpkg.NewEngine(database, syncpkg.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentCowork: {root}},
+		ProviderFactories: []parser.ProviderFactory{
+			startupDiscoveryFailureFactory{err: errors.New("listing failed")},
+		},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			parser.AgentCowork: parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+
+	_, err := runPGWatchStartupSync(t.Context(), engine, false)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "discovery incomplete")
+}
+
 func TestLocalArchiveWriteBackendPGPushWatchCanceledStartupIsClean(t *testing.T) {
 	backend := testLocalArchiveWriteBackend(t)
 
@@ -229,6 +323,432 @@ func TestLocalArchiveWriteBackendPGPushWatchCanceledStartupIsClean(t *testing.T)
 	)
 
 	require.NoError(t, err)
+}
+
+type pushWatchOwnerCase struct {
+	name string
+	run  func(context.Context, *archivePushWatchHooks) error
+}
+
+func pushWatchOwnerCases(t *testing.T) []pushWatchOwnerCase {
+	t.Helper()
+	return []pushWatchOwnerCase{
+		{
+			name: "daemon DuckDB",
+			run: func(ctx context.Context, hooks *archivePushWatchHooks) error {
+				return (daemonArchiveWriteBackend{watchHooks: hooks}).DuckDBPushWatch(
+					ctx, config.DuckDBConfig{}, DuckDBPushConfig{}, nil, nil,
+					time.Hour, time.Hour,
+				)
+			},
+		},
+		{
+			name: "daemon PostgreSQL",
+			run: func(ctx context.Context, hooks *archivePushWatchHooks) error {
+				return (daemonArchiveWriteBackend{watchHooks: hooks}).PGPushWatch(
+					ctx, pgTargetSelection{}, PGPushConfig{}, nil, nil,
+					time.Hour, time.Hour,
+				)
+			},
+		},
+		{
+			name: "local DuckDB",
+			run: func(ctx context.Context, hooks *archivePushWatchHooks) error {
+				backend := testLocalArchiveWriteBackend(t)
+				backend.watchHooks = hooks
+				return backend.DuckDBPushWatch(
+					ctx, config.DuckDBConfig{}, DuckDBPushConfig{}, nil, nil,
+					time.Hour, time.Hour,
+				)
+			},
+		},
+		{
+			name: "local PostgreSQL",
+			run: func(ctx context.Context, hooks *archivePushWatchHooks) error {
+				backend := testLocalArchiveWriteBackend(t)
+				backend.watchHooks = hooks
+				return backend.PGPushWatch(
+					ctx, pgTargetSelection{}, PGPushConfig{}, nil, nil,
+					time.Hour, time.Hour,
+				)
+			},
+		},
+	}
+}
+
+type pushWatchAttempt struct {
+	index  int
+	reason pushReason
+}
+
+type pushWatchOwnerHarness struct {
+	mu             stdsync.Mutex
+	partial        map[int]bool
+	events         []string
+	attempts       chan pushWatchAttempt
+	opened         chan struct{}
+	callback       syncpkg.WatchCallback
+	degraded       func([]string) error
+	loop           *pushLoop
+	fire           chan time.Time
+	floor          chan time.Time
+	openCount      int
+	startupSyncs   int
+	localPushSyncs int
+	attemptCount   int
+}
+
+func newPushWatchOwnerHarness(partial ...int) *pushWatchOwnerHarness {
+	h := &pushWatchOwnerHarness{
+		partial:  make(map[int]bool, len(partial)),
+		attempts: make(chan pushWatchAttempt, 8),
+		opened:   make(chan struct{}, 2),
+		fire:     make(chan time.Time, 2),
+		floor:    make(chan time.Time, 2),
+	}
+	for _, index := range partial {
+		h.partial[index] = true
+	}
+	return h
+}
+
+func (h *pushWatchOwnerHarness) hooks() *archivePushWatchHooks {
+	return &archivePushWatchHooks{
+		startWatcher: func(
+			_ config.Config, _ *syncpkg.Engine, callback syncpkg.WatchCallback,
+			options syncpkg.WatcherOptions,
+		) (func(), func(), []string) {
+			h.record("collect")
+			h.mu.Lock()
+			h.callback = callback
+			h.degraded = options.OnCoverageDegraded
+			h.mu.Unlock()
+			return func() {}, func() {
+				h.mu.Lock()
+				h.openCount++
+				h.events = append(h.events, "open")
+				h.mu.Unlock()
+				h.opened <- struct{}{}
+			}, nil
+		},
+		newLoop: func(
+			label string, _ time.Duration, _ time.Duration,
+			push func(context.Context, pushReason) error,
+		) (*pushLoop, func()) {
+			h.loop = &pushLoop{
+				debounce: time.Hour,
+				dirty:    make(chan struct{}, 1),
+				floor:    h.floor,
+				after:    func(time.Duration) <-chan time.Time { return h.fire },
+				push:     push,
+				label:    label,
+			}
+			return h.loop, func() {}
+		},
+		duckDBPush: func(
+			_ context.Context, reason pushReason, _ bool,
+		) (duckdbsync.PushResult, error) {
+			attempt, partial := h.nextAttempt(reason)
+			if partial {
+				return duckdbsync.PushResult{Errors: 1}, nil
+			}
+			return duckdbsync.PushResult{SessionsPushed: attempt}, nil
+		},
+		pgPush: func(
+			_ context.Context, reason pushReason, _ bool,
+		) (postgres.PushResult, error) {
+			attempt, partial := h.nextAttempt(reason)
+			if partial {
+				return postgres.PushResult{Errors: 1}, nil
+			}
+			return postgres.PushResult{SessionsPushed: attempt}, nil
+		},
+		pgStartupSync: func(
+			context.Context, *syncpkg.Engine, bool,
+		) (bool, error) {
+			h.mu.Lock()
+			h.startupSyncs++
+			h.events = append(h.events, "startup-sync")
+			h.mu.Unlock()
+			return false, nil
+		},
+		newPGPusher: func(*syncpkg.Engine) *pgPusher {
+			target := &pushWatchPGTarget{harness: h}
+			return &pgPusher{
+				localSync: func(context.Context) error {
+					h.mu.Lock()
+					h.localPushSyncs++
+					h.events = append(h.events, "local-sync")
+					h.mu.Unlock()
+					return nil
+				},
+				connect: func() (pgTarget, error) { return target, nil },
+			}
+		},
+	}
+}
+
+func (h *pushWatchOwnerHarness) record(event string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.events = append(h.events, event)
+}
+
+func (h *pushWatchOwnerHarness) nextAttempt(reason pushReason) (int, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.nextAttemptLocked(reason)
+}
+
+func (h *pushWatchOwnerHarness) nextPGAttempt() (int, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.nextAttemptLocked("")
+}
+
+func (h *pushWatchOwnerHarness) nextAttemptLocked(
+	reason pushReason,
+) (int, bool) {
+	h.attemptCount++
+	index := h.attemptCount
+	h.events = append(h.events, "push")
+	partial := h.partial[index]
+	h.attempts <- pushWatchAttempt{index: index, reason: reason}
+	return index, partial
+}
+
+func (h *pushWatchOwnerHarness) pending() (bool, int) {
+	h.loop.pendingMu.Lock()
+	defer h.loop.pendingMu.Unlock()
+	return h.loop.pending, len(h.loop.waiters)
+}
+
+func (h *pushWatchOwnerHarness) snapshot() (
+	[]string, int, int, int,
+) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]string(nil), h.events...), h.openCount,
+		h.startupSyncs, h.localPushSyncs
+}
+
+func (h *pushWatchOwnerHarness) watcherCallback() syncpkg.WatchCallback {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.callback
+}
+
+func (h *pushWatchOwnerHarness) degradationCallback() func([]string) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.degraded
+}
+
+type pushWatchPGTarget struct {
+	harness *pushWatchOwnerHarness
+}
+
+func (*pushWatchPGTarget) EnsureSchema(context.Context) error { return nil }
+func (t *pushWatchPGTarget) Push(
+	_ context.Context, _ bool, _ func(postgres.PushProgress),
+) (postgres.PushResult, error) {
+	attempt, partial := t.harness.nextPGAttempt()
+	if partial {
+		return postgres.PushResult{Errors: 1}, nil
+	}
+	return postgres.PushResult{SessionsPushed: attempt}, nil
+}
+func (*pushWatchPGTarget) Close() error { return nil }
+
+func TestPushWatchProductionOwnersRetainPartialStartupUntilPeriodicSuccess(
+	t *testing.T,
+) {
+	for _, owner := range pushWatchOwnerCases(t) {
+		t.Run(owner.name, func(t *testing.T) {
+			h := newPushWatchOwnerHarness(1)
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+			done := make(chan error, 1)
+			go func() { done <- owner.run(ctx, h.hooks()) }()
+
+			first := receiveArchiveTest(t, h.attempts)
+			require.Equal(t, 1, first.index)
+			if owner.name != "local PostgreSQL" {
+				assert.Equal(t, reasonStartup, first.reason)
+			}
+			require.Eventually(t, func() bool {
+				pending, waiters := h.pending()
+				return pending && waiters == 1
+			}, time.Second, time.Millisecond,
+				"partial startup must retain one dirty generation and waiter")
+			select {
+			case <-h.opened:
+				require.Fail(t, "partial startup opened watcher dispatch")
+			default:
+			}
+
+			h.floor <- time.Now()
+			second := receiveArchiveTest(t, h.attempts)
+			require.Equal(t, 2, second.index)
+			if owner.name != "local PostgreSQL" {
+				assert.Equal(t, reasonInterval, second.reason)
+			}
+			receiveArchiveTest(t, h.opened)
+			require.Eventually(t, func() bool {
+				pending, waiters := h.pending()
+				return !pending && waiters == 0
+			}, time.Second, time.Millisecond,
+				"complete periodic push must drain startup work")
+
+			events, opens, startupSyncs, localSyncs := h.snapshot()
+			require.NotEmpty(t, events)
+			assert.Equal(t, "collect", events[0],
+				"watcher collection must precede startup work")
+			assert.Equal(t, 1, opens)
+			if owner.name == "local PostgreSQL" {
+				assert.Equal(t, 1, startupSyncs)
+				assert.GreaterOrEqual(t, localSyncs, 2,
+					"initial and retry pushes each run local sync")
+				assert.Less(t, indexOfEvent(events, "startup-sync"),
+					indexOfEvent(events, "push"))
+				assert.Less(t, indexOfEvent(events, "local-sync"),
+					indexOfEvent(events, "push"))
+			}
+
+			cancel()
+			require.NoError(t, receiveArchiveTest(t, done))
+		})
+	}
+}
+
+func TestPushWatchProductionOwnersRetryPartialAuthoritativeBatch(
+	t *testing.T,
+) {
+	for _, owner := range pushWatchOwnerCases(t) {
+		t.Run(owner.name, func(t *testing.T) {
+			h := newPushWatchOwnerHarness(2)
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+			done := make(chan error, 1)
+			go func() { done <- owner.run(ctx, h.hooks()) }()
+
+			first := receiveArchiveTest(t, h.attempts)
+			require.Equal(t, 1, first.index)
+			if owner.name != "local PostgreSQL" {
+				assert.Equal(t, reasonStartup, first.reason)
+			}
+			receiveArchiveTest(t, h.opened)
+			callback := h.watcherCallback()
+			require.NotNil(t, callback)
+			callbackDone := make(chan error, 1)
+			go func() {
+				callbackDone <- callback(ctx, syncpkg.WatchBatch{FullSync: true})
+			}()
+			require.Eventually(t, func() bool {
+				pending, waiters := h.pending()
+				return pending && waiters == 1
+			}, time.Second, time.Millisecond)
+
+			h.floor <- time.Now()
+			second := receiveArchiveTest(t, h.attempts)
+			require.Equal(t, 2, second.index)
+			if owner.name != "local PostgreSQL" {
+				assert.Equal(t, reasonInterval, second.reason)
+			}
+			select {
+			case err := <-callbackDone:
+				require.Fail(t, "partial runtime push acknowledged watcher batch", "%v", err)
+			case <-time.After(50 * time.Millisecond):
+			}
+			require.Eventually(t, func() bool {
+				pending, waiters := h.pending()
+				return pending && waiters == 1
+			}, time.Second, time.Millisecond)
+
+			h.floor <- time.Now()
+			third := receiveArchiveTest(t, h.attempts)
+			require.Equal(t, 3, third.index)
+			if owner.name != "local PostgreSQL" {
+				assert.Equal(t, reasonInterval, third.reason)
+			}
+			require.NoError(t, receiveArchiveTest(t, callbackDone))
+			require.Eventually(t, func() bool {
+				pending, waiters := h.pending()
+				return !pending && waiters == 0
+			}, time.Second, time.Millisecond)
+			_, opens, _, _ := h.snapshot()
+			assert.Equal(t, 1, opens, "runtime retries must not reopen dispatch")
+
+			cancel()
+			require.NoError(t, receiveArchiveTest(t, done))
+		})
+	}
+}
+
+func TestPushWatchProductionOwnersFallbackUsesActiveIntervalFloor(t *testing.T) {
+	for _, owner := range pushWatchOwnerCases(t) {
+		t.Run(owner.name, func(t *testing.T) {
+			h := newPushWatchOwnerHarness()
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan error, 1)
+			go func() { done <- owner.run(ctx, h.hooks()) }()
+
+			receiveArchiveTest(t, h.attempts)
+			receiveArchiveTest(t, h.opened)
+			degraded := h.degradationCallback()
+			require.NotNil(t, degraded, "watcher collection receives a degradation owner")
+			require.NoError(t, degraded([]string{"/root-a", "/root-a", "/root-b"}))
+			require.Eventually(t, func() bool {
+				pending, waiters := h.pending()
+				return pending && waiters == 0
+			}, time.Second, time.Millisecond)
+
+			h.floor <- time.Now()
+			attempt := receiveArchiveTest(t, h.attempts)
+			if owner.name != "local PostgreSQL" {
+				assert.Equal(t, reasonInterval, attempt.reason)
+			}
+			cancel()
+			require.NoError(t, receiveArchiveTest(t, done))
+		})
+	}
+}
+
+func indexOfEvent(events []string, want string) int {
+	for i, event := range events {
+		if event == want {
+			return i
+		}
+	}
+	return -1
+}
+
+func receiveArchiveTest[T any](t *testing.T, ch <-chan T) T {
+	t.Helper()
+	select {
+	case value := <-ch:
+		return value
+	case <-time.After(time.Second):
+		require.FailNow(t, "timed out waiting for archive watch result")
+		var zero T
+		return zero
+	}
+}
+
+func TestPushWatchCollectingCallbackAcknowledgesOnlyReconciliationBatches(t *testing.T) {
+	loop, _, _ := newTestLoop(func(context.Context, pushReason) error {
+		return nil
+	})
+
+	require.NoError(t, notifyPushForWatchBatch(
+		t.Context(), loop, syncpkg.WatchBatch{Paths: []string{"session.jsonl"}},
+	), "ordinary changes only enqueue non-blocking work")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := notifyPushForWatchBatch(ctx, loop, syncpkg.WatchBatch{FullSync: true})
+	require.ErrorIs(t, err, context.Canceled,
+		"authoritative batches wait with the watcher worker context")
 }
 
 func TestResolveArchiveWriteBackendCopiesNoSyncRuntime(t *testing.T) {
@@ -274,6 +794,140 @@ func testLocalArchivePushStopsAfterCanceledSync(
 	})
 
 	require.ErrorIs(t, err, context.Canceled)
+}
+
+type noopPGTarget struct{}
+
+func (noopPGTarget) EnsureSchema(context.Context) error { return nil }
+func (noopPGTarget) Push(
+	context.Context, bool, func(postgres.PushProgress),
+) (postgres.PushResult, error) {
+	return postgres.PushResult{}, nil
+}
+func (noopPGTarget) Close() error { return nil }
+
+// The watcher's full recovery and rename promotion defer unavailable scopes
+// to their polling probes, and pg watch's interval push is a plain SyncAll
+// that never tombstones missed deletions. Local pg watch must therefore own
+// those deferred scopes with a probe-gated authoritative poller: a root the
+// watcher cannot cover (here a symlinked recursive root, the same obligation
+// machinery that owns roots missing at startup on portable backends)
+// registers a polling obligation, and the poller reconciles its scope
+// authoritatively on ticks — with no watcher event and no floor push
+// involved.
+func TestLocalPGPushWatchGivesDeferredScopesAPollingOwner(t *testing.T) {
+	dataDir := t.TempDir()
+	dbPath := filepath.Join(dataDir, "sessions.db")
+	database := dbtest.OpenTestDBAt(t, dbPath)
+	target := t.TempDir()
+	codexRoot := filepath.Join(t.TempDir(), "sessions")
+	require.NoError(t, os.Symlink(target, codexRoot))
+
+	backend := &localArchiveWriteBackend{
+		appCfg: config.Config{
+			DataDir:          dataDir,
+			DBPath:           dbPath,
+			LocalMachineName: "local",
+			AgentDirs: map[parser.AgentType][]string{
+				parser.AgentCodex: {codexRoot},
+			},
+		},
+		database: database,
+	}
+
+	ticks := make(chan time.Time, 1)
+	owned := make(chan []string, 8)
+	fire := make(chan time.Time)
+	floor := make(chan time.Time)
+	backend.watchHooks = &archivePushWatchHooks{
+		newLoop: func(
+			label string, _, _ time.Duration,
+			push func(context.Context, pushReason) error,
+		) (*pushLoop, func()) {
+			return &pushLoop{
+				debounce: time.Hour,
+				dirty:    make(chan struct{}, 1),
+				floor:    floor,
+				after:    func(time.Duration) <-chan time.Time { return fire },
+				push:     push,
+				label:    label,
+			}, func() {}
+		},
+		pgStartupSync: func(context.Context, *syncpkg.Engine, bool) (bool, error) {
+			return false, nil
+		},
+		newPGPusher: func(*syncpkg.Engine) *pgPusher {
+			return &pgPusher{
+				localSync: func(context.Context) error { return nil },
+				connect:   func() (pgTarget, error) { return noopPGTarget{}, nil },
+			}
+		},
+		newUnwatchedPoller: func(
+			ctx context.Context, engine unwatchedPollSyncer,
+		) unwatchedRootPoller {
+			return newUnwatchedPollCoordinatorWithTicks(
+				ctx, engine, ticks, func() {}, func(work func()) { work() },
+				func(roots []string) {
+					owned <- append([]string(nil), roots...)
+				},
+			)
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	done := make(chan error, 1)
+	go func() {
+		done <- backend.PGPushWatch(
+			ctx, pgTargetSelection{}, PGPushConfig{}, nil, nil,
+			time.Hour, time.Hour,
+		)
+	}()
+
+	select {
+	case roots := <-owned:
+		assert.Contains(t, roots, codexRoot,
+			"the unwatchable root's polling obligation must reach the pg watch poller")
+	case err := <-done:
+		t.Fatalf("pg watch exited before registering obligations: %v", err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("no polling obligation was registered for the unwatchable root")
+	}
+
+	// A session lands under the unwatched scope; only the poller's
+	// authoritative tick can bring it into the archive.
+	uuid := "d4e5f6a7-4444-4555-8666-777788889999"
+	day := filepath.Join(codexRoot, "2026", "05", "04")
+	require.NoError(t, os.MkdirAll(day, 0o755))
+	content := testjsonl.NewSessionBuilder().
+		AddCodexMeta(
+			"2026-05-04T14:00:00Z", uuid, "/home/user/code/api",
+			"codex_cli_rs",
+		).
+		AddCodexMessage("2026-05-04T14:00:01Z", "user", "hello").
+		String()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(day, "rollout-2026-05-04T14-31-58-"+uuid+".jsonl"),
+		[]byte(content), 0o644,
+	))
+
+	require.Eventually(t, func() bool {
+		select {
+		case ticks <- time.Now():
+		default:
+		}
+		session, err := database.GetSession(context.Background(), "codex:"+uuid)
+		return err == nil && session != nil
+	}, 10*time.Second, 20*time.Millisecond,
+		"the returned root must be reconciled by the poller without watcher events or floor pushes")
+
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("pg watch did not shut down")
+	}
 }
 
 func testLocalArchiveWriteBackend(t *testing.T) *localArchiveWriteBackend {

--- a/cmd/agentsview/classifier_wiring_test.go
+++ b/cmd/agentsview/classifier_wiring_test.go
@@ -24,6 +24,7 @@ import (
 // same enclosing body.
 var triggerCalls = map[string]struct{}{
 	"db.Open":               {},
+	"db.OpenReadOnly":       {},
 	"postgres.Open":         {},
 	"postgres.NewStore":     {},
 	"postgres.New":          {},

--- a/cmd/agentsview/cli.go
+++ b/cmd/agentsview/cli.go
@@ -106,6 +106,7 @@ func newRootCommand() *cobra.Command {
 	root.AddCommand(newServeCommand())
 	root.AddCommand(newDaemonCommand())
 	root.AddCommand(newSyncCommand())
+	root.AddCommand(newSyncWorkerCommand())
 	root.AddCommand(newPruneCommand())
 	root.AddCommand(newUpdateCommand())
 	root.AddCommand(newTokenUseCommand())

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -11,9 +11,11 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime/debug"
 	"slices"
 	"strings"
 	"syscall"
+	"testing"
 	"time"
 	_ "time/tzdata"
 
@@ -43,6 +45,16 @@ const (
 	watcherSyncMinInterval         = 5 * time.Second
 	deferredStartupSyncGracePeriod = 30 * time.Second
 	recursiveWatchBudget           = 8192
+)
+
+const (
+	// archiveAuditInterval is the daily cadence for the full-archive audit: a
+	// rare safety net for silent watcher event loss now that the unscoped
+	// 15-minute reconcile is gone.
+	archiveAuditInterval = 24 * time.Hour
+	// archiveAuditRetryInitial is the first retry delay after a failed audit. It
+	// doubles on each subsequent failure and is capped at archiveAuditInterval.
+	archiveAuditRetryInitial = time.Hour
 )
 
 func main() {
@@ -95,9 +107,32 @@ type serveOptions struct {
 	Pprof           bool
 }
 
+// serveMemoryLimitBytes is the default Go soft memory limit for the
+// long-running serve daemon. Full parses of multi-megabyte transcripts
+// otherwise balloon the heap to several hundred megabytes; the pages
+// are freed afterwards but macOS keeps them in the process RSS
+// indefinitely, so the daemon's reported memory ratchets to the
+// largest transient since startup. A soft limit makes the GC hold the
+// heap near the cap during those bursts instead. CGO memory (SQLite)
+// is outside the limit, so total RSS settles somewhat above it.
+const serveMemoryLimitBytes = 256 << 20
+
+// applyServeMemoryLimit installs the default soft memory limit unless
+// the operator already set one via GOMEMLIMIT. Only the serve daemon
+// is capped: one-shot CLI commands exit immediately, and the resync
+// worker child returns all memory to the OS when it exits, so a cap
+// would only slow its full-archive rebuild down.
+func applyServeMemoryLimit() {
+	if os.Getenv("GOMEMLIMIT") != "" {
+		return
+	}
+	debug.SetMemoryLimit(serveMemoryLimitBytes)
+}
+
 func runServe(cfg config.Config, opts serveOptions) {
 	start := time.Now()
 	setupLogFile(cfg.DataDir)
+	applyServeMemoryLimit()
 
 	if err := validateServeConfig(cfg); err != nil {
 		fatal("invalid serve config: %v", err)
@@ -138,8 +173,50 @@ func runServe(cfg config.Config, opts serveOptions) {
 	MarkDaemonStarting(cfg.DataDir)
 	defer UnmarkDaemonStarting(cfg.DataDir)
 	startupProgress := newStartupStateWriter(cfg.DataDir, time.Now)
-	startupProgress.SetPhase("opening database")
 
+	// The signal context is created before the startup worker so SIGTERM can
+	// interrupt the worker pass. The server is fully drained by
+	// waitForServerRuntime before defers unwind, so registering stop here
+	// (rather than after the DB defer) does not affect shutdown ordering.
+	ctx, stop := signal.NotifyContext(
+		context.Background(), os.Interrupt, syscall.SIGTERM,
+	)
+	defer stop()
+
+	// Run the archive-scale startup sync in a short-lived worker process before
+	// taking the write lock, so its allocation high-water returns to the OS
+	// instead of pinning the daemon. The daemon then opens the DB, starts the
+	// watcher, and closes the worker-to-watcher event gap below. The worker
+	// acquires the write lock the daemon has not taken yet; on any failure the
+	// daemon falls back to its in-process initial sync.
+	var workerStartupResult workerResult
+	workerSyncDone := false
+	if !opts.SkipInitialSync && !cfg.NoSync && !testing.Testing() {
+		startupProgress.SetPhase("initial sync")
+		result, syncErr := runStartupSyncViaWorker(ctx, cfg, startupProgress)
+		workerStartupResult, workerSyncDone = startupWorkerOutcome(result, syncErr)
+		switch {
+		case syncErr == nil:
+		case errors.Is(syncErr, errWorkerSpawn):
+			log.Printf(
+				"startup sync worker spawn failed: %v "+
+					"(falling back to in-process initial sync)", syncErr,
+			)
+		default:
+			// The worker ran but reported a non-authoritative terminal result.
+			// Do NOT re-run the archive-scale sync in process: carry the
+			// aborted result forward so the bounded gap reconciliation and
+			// RecordStartupReconciled still open watcher dispatch with the
+			// incomplete stats.
+			log.Printf(
+				"ERROR: startup sync worker ran but did not complete: %v "+
+					"(surfacing incomplete pass; not re-syncing in process)",
+				syncErr,
+			)
+		}
+	}
+
+	startupProgress.SetPhase("opening database")
 	database, writeLock := mustOpenWriteDB(context.Background(), cfg)
 	runtimeRecordDataDir := ""
 	defer func() {
@@ -166,10 +243,6 @@ func runServe(cfg config.Config, opts serveOptions) {
 	// Remove stale temp DB from a prior crashed resync.
 	cleanResyncTemp(cfg.DBPath)
 
-	ctx, stop := signal.NotifyContext(
-		context.Background(), os.Interrupt, syscall.SIGTERM,
-	)
-	defer stop()
 	idleTracker := newDaemonIdleTracker(cfg, stop)
 
 	telemetryReporter := telemetry.NewReporterOrDisabled(telemetry.Options{
@@ -215,20 +288,103 @@ func runServe(cfg config.Config, opts serveOptions) {
 	}
 
 	var engine *sync.Engine
+	var stopWatcher func()
+	var openWatcherDispatch func()
+	var queueWatchRetry func(sync.WatchBatch)
+	var unwatchedPoller *sharedUnwatchedPollCoordinator
+	var completeWorkerStartup func()
 	if !cfg.NoSync {
+		var onStartupReconciled func(sync.SyncStats, error)
 		engine = sync.NewEngine(database, sync.EngineConfig{
 			AgentDirs:               cfg.AgentDirs,
 			IncludeCwdPrefixes:      cfg.SyncIncludeCwdPrefixes,
 			Machine:                 cfg.LocalMachineName,
 			BlockedResultCategories: cfg.ResultContentBlockedCategories,
 			Emitter:                 emitter,
-			DeferStartupMaintenance: opts.SkipInitialSync,
+			DeferStartupMaintenance: deferStartupMaintenance(
+				opts.SkipInitialSync, workerSyncDone,
+			),
+			OnStartupReconciled: func(stats sync.SyncStats, err error) {
+				onStartupReconciled(stats, err)
+			},
 		})
+		defer engine.Close()
+		unwatchedPoller = newUnwatchedPollCoordinator(ctx, engine, idleTracker)
+		defer unwatchedPoller.Stop()
+		stopWatcher, openWatcherDispatch, _, queueWatchRetry = startFileWatcher(
+			cfg, engine, func(_ context.Context, batch sync.WatchBatch) error {
+				done, ok := idleTracker.BeginWork()
+				if !ok {
+					return context.Canceled
+				}
+				defer done()
+				// The serve ctx reaches watcher-driven syncs so SIGTERM can
+				// interrupt database reconciliation before Stop waits for it.
+				return syncWatchBatch(ctx, engine, batch, func() watchRecoveryScope {
+					return probeWatchRecoveryScope(cfg)
+				})
+			},
+			sync.WatcherOptions{
+				OnCoverageDegraded: func(roots []string) error {
+					return unwatchedPoller.AddObligation(pollingObligation{
+						Key: "watcher-fallback", Roots: roots,
+					})
+				},
+				OnPollingRequired: func(obligation sync.PollingObligation) error {
+					return unwatchedPoller.AddObligation(pollingObligation{
+						Key:   obligation.Key,
+						Roots: obligation.Roots,
+						Probe: obligation.Probe,
+					})
+				},
+				OnPollingReleased: unwatchedPoller.RemoveObligation,
+			},
+		)
+		defer stopWatcher()
+		onStartupReconciled = newStartupReconciliationHandler(
+			ctx,
+			database.CheckpointWALTruncateWithRetry,
+			openWatcherDispatch,
+		)
 
 		if !opts.SkipInitialSync {
-			if database.NeedsResync() {
+			if workerSyncDone {
+				// The worker already ran the full startup pass out of process.
+				// Close the worker-to-watcher event gap with a bounded streaming
+				// reconciliation over the currently available watch roots (warm:
+				// the worker persisted skip state into the archive, which the
+				// engine loaded at init), then acknowledge startup. Unavailable
+				// scopes are deferred to their probes rather than reconciled as
+				// empty. Without this the daemon's engine never runs an
+				// in-process sync, so OnStartupReconciled would never fire and
+				// the watcher would stay in collecting mode forever.
+				//
+				// The reconciliation runs after the HTTP server is listening
+				// and the startup banner is printed: it can take a while on a
+				// large archive, and the archive the worker just synced is
+				// fully servable. The watcher keeps collecting events and
+				// startup maintenance keeps waiting until
+				// RecordStartupReconciled fires.
+				completeWorkerStartup = func() {
+					var gapErr error
+					if gapRoots := reconcileRootPaths(cfg); len(gapRoots) > 0 {
+						gapErr = engine.ReconcileWatchRoots(ctx, gapRoots, false)
+					}
+					if gapErr != nil && ctx.Err() == nil {
+						// Hand the failed gap reconciliation to the watcher's
+						// retry queue before dispatch opens, so the affected
+						// roots are re-reconciled with backoff instead of
+						// staying undiscovered until another event, manual
+						// sync, or the daily audit.
+						queueWatchRetry(gapReconciliationRetryBatch(gapErr))
+					}
+					engine.RecordStartupReconciled(
+						statsFromWorkerResult(workerStartupResult), gapErr,
+					)
+				}
+			} else if database.NeedsResync() {
 				startupProgress.SetPhase("full resync")
-				signalsCovered := runInitialResync(ctx, engine, startupProgress)
+				signalsCovered, _ := runInitialResync(ctx, engine, startupProgress)
 				if ctx.Err() == nil {
 					finishInitialResync(database, signalsCovered)
 				}
@@ -238,20 +394,6 @@ func runServe(cfg config.Config, opts serveOptions) {
 			}
 			if ctx.Err() != nil {
 				return
-			}
-
-			// The initial sync can leave hundreds of MB in the WAL, and
-			// SQLite checkpoints the whole log — not cancellable — when the
-			// final connection closes. A SIGTERM landing shortly after
-			// startup would spend the service manager's stop timeout inside
-			// that close and get escalated to SIGKILL, so truncate the WAL
-			// now at a controlled moment. Persistent readers just leave it
-			// for the periodic checkpoint loop.
-			if err := database.CheckpointWALTruncateWithRetry(
-				ctx,
-			); err != nil && !errors.Is(err, db.ErrWALCheckpointBusy) &&
-				ctx.Err() == nil {
-				log.Printf("post-sync wal checkpoint: %v", err)
 			}
 		}
 
@@ -278,7 +420,9 @@ func runServe(cfg config.Config, opts serveOptions) {
 			log.Printf("warning: remote_hosts config invalid, skipping periodic remote sync: %v", err)
 			validRemotes = false
 		}
-		go startPeriodicSync(ctx, cfg, engine, database, idleTracker, validRemotes, emitter)
+		go startPeriodicSync(
+			ctx, cfg, engine, database, writeLock, idleTracker, validRemotes, emitter,
+		)
 	}
 
 	identityBackfillEngine := engine
@@ -340,6 +484,14 @@ func runServe(cfg config.Config, opts serveOptions) {
 		srvOpts = append(srvOpts,
 			server.WithSessionMutationNotifier(extractSched.Notify))
 	}
+	if engine != nil {
+		srvOpts = append(srvOpts, server.WithLocalSyncRunner(
+			newForegroundSyncRunner(ctx, cfg, engine, database, writeLock),
+		))
+		srvOpts = append(srvOpts, server.WithLocalResyncRunner(
+			newForegroundResyncRunner(ctx, cfg, engine, database),
+		))
+	}
 	srv := server.New(cfg, database, engine, srvOpts...)
 
 	startupProgress.SetPhase("starting HTTP server")
@@ -379,7 +531,7 @@ func runServe(cfg config.Config, opts serveOptions) {
 			timer := time.NewTimer(deferredStartupSyncGracePeriod)
 			defer timer.Stop()
 			ran, fallbackErr := runDeferredStartupSyncFallback(
-				ctx, engine, idleTracker, timer.C,
+				ctx, cfg, engine, database, writeLock, idleTracker, timer.C,
 			)
 			if fallbackErr != nil && ctx.Err() == nil {
 				log.Printf("deferred startup sync: %v", fallbackErr)
@@ -423,27 +575,12 @@ func runServe(cfg config.Config, opts serveOptions) {
 		defer extractSched.Stop()
 	}
 
-	if engine != nil {
-		// Registered before stopWatcher so LIFO defer order stops
-		// the watcher first, then Close flushes any pending
-		// debounced signal recomputes.
-		defer engine.Close()
-		stopWatcher, unwatchedDirs := startFileWatcher(
-			cfg, engine, func(batch sync.WatchBatch) {
-				idleTracker.Do(func() {
-					// The serve ctx must reach watcher-driven syncs:
-					// stopWatcher waits for the in-flight callback, so
-					// a sync that ignored SIGTERM would hold shutdown
-					// open until the service manager escalates to
-					// SIGKILL.
-					syncWatchBatch(ctx, engine, batch)
-				})
-			},
-		)
-		defer stopWatcher()
-		if len(unwatchedDirs) > 0 {
-			go startUnwatchedPoll(ctx, engine, unwatchedDirs, idleTracker)
-		}
+	// Run the deferred worker-startup gap reconciliation now that the URL
+	// banner is out and every background service is started. It holds the
+	// engine's sync mutex, not this goroutine's defers, so a SIGTERM during
+	// a long reconciliation still unwinds through waitForServerRuntime.
+	if completeWorkerStartup != nil {
+		completeWorkerStartup()
 	}
 
 	if err := waitForServerRuntime(ctx, srv, rt); err != nil {
@@ -453,7 +590,10 @@ func runServe(cfg config.Config, opts serveOptions) {
 
 func runDeferredStartupSyncFallback(
 	ctx context.Context,
+	cfg config.Config,
 	engine *sync.Engine,
+	database *db.DB,
+	lock *writeOwnerLock,
 	idleTracker *server.IdleTracker,
 	timeout <-chan time.Time,
 ) (bool, error) {
@@ -468,8 +608,494 @@ func runDeferredStartupSyncFallback(
 		return false, nil
 	}
 	defer done()
+
+	// A foreground `agentsview sync` may have already driven startup
+	// reconciliation through newForegroundSyncRunner; skip the redundant worker
+	// pass in that case. This is only the fast path: a foreground worker still
+	// in flight records reconciliation before releasing the exclusive lock, and
+	// runWorkerSyncPass rechecks the gate while holding that lock, so the timer
+	// firing mid-pass cannot launch a second archive-scale worker.
+	if engine.StartupReconciled() {
+		return false, nil
+	}
+
+	// Route the skipped startup sync through the worker so it does not run at
+	// archive scale in the daemon. Only a failure in which no worker ran — a
+	// spawn or pre-launch handoff failure — (or a test binary) falls back to
+	// the in-process path; a worker that ran and reported failure is surfaced
+	// without re-running. Both paths acknowledge startup so the watcher leaves
+	// collecting mode.
+	if !testing.Testing() {
+		_, ran, err := runWorkerSyncPass(
+			ctx, ctx, cfg, engine, database, lock, true, nil,
+		)
+		if err == nil || !workerNeverRan(err) {
+			return ran, err
+		}
+		log.Printf(
+			"deferred startup sync worker did not run: %v "+
+				"(falling back in-process)", err,
+		)
+	}
+
 	_, ran, err := engine.RunStartupSyncFallback(ctx, nil)
 	return ran, err
+}
+
+// runStartupSyncViaWorker runs the daemon's startup sync in a short-lived
+// worker process, relaying its progress phases into the startup-state writer so
+// `serve status` reports live phases, and to the console so a foreground serve
+// shows the same "Running initial sync..." progress the in-process path prints.
+// It must run before the daemon takes the write lock so the worker can acquire
+// it. It returns the worker's terminal result (used to acknowledge startup) and
+// any launch/protocol error.
+//
+// The brief specifies a plain error return; it returns the result too so the
+// caller can pass the worker's discovery outcome to RecordStartupReconciled.
+func runStartupSyncViaWorker(
+	ctx context.Context, cfg config.Config, progress *startupStateWriter,
+) (workerResult, error) {
+	fmt.Println("Running initial sync...")
+	t := time.Now()
+	resyncAnnounced := false
+	progressShown := false
+	onLine := func(l workerLine) {
+		if l.Progress == nil {
+			return
+		}
+		p := *l.Progress
+		// Resync progress maps onto the "full resync" phase; the plain initial
+		// sync keeps the "initial sync" phase set before this call.
+		if p.Resync {
+			progress.SetPhase("full resync")
+			if !resyncAnnounced {
+				resyncAnnounced = true
+				fmt.Println("Data version changed, running full resync...")
+			}
+		}
+		printSyncProgress(p)
+		progressShown = true
+		progress.SetDetail(startupProgressDetail(p))
+	}
+	result, err := launchSyncWorker(ctx, cfg, "startup", onLine)
+	if err == nil && result.Stats != nil {
+		printSyncSummary(*result.Stats, t)
+	} else if progressShown {
+		// Terminate the in-place \r progress line so the next console
+		// output (fallback messages, the startup banner) starts clean.
+		fmt.Println()
+	}
+	return result, err
+}
+
+// startupWorkerOutcome decides how runServe proceeds after the startup worker.
+// It discriminates a spawn failure (the worker never ran) from a ran-and-failed
+// worker (a valid terminal result reporting incomplete discovery).
+//
+//   - err == nil: the worker completed; carry its result, done = true.
+//   - errors.Is(err, errWorkerSpawn): the worker never ran; done = false so the
+//     caller runs the in-process initial sync fallback.
+//   - any other err: the worker ran but did not complete; done = true with an
+//     aborted result (synthesized when the terminal record is unusable) so the
+//     caller surfaces the incomplete pass through gap reconciliation rather than
+//     re-running the archive-scale sync in process.
+func startupWorkerOutcome(result workerResult, err error) (workerResult, bool) {
+	switch {
+	case err == nil:
+		return result, true
+	case errors.Is(err, errWorkerSpawn):
+		return workerResult{}, false
+	default:
+		if result.Status == "" {
+			result.Status = "aborted"
+		}
+		result.DiscoveryComplete = false
+		return result, true
+	}
+}
+
+// deferStartupMaintenance reports whether archive-wide startup backfills must
+// wait for RecordStartupReconciled instead of starting immediately. Two paths
+// defer them: a daemon launched with the initial sync skipped (a foreground
+// client drives startup, released by its sync or the bounded fallback), and
+// the worker path, where the gap reconciliation runs only after the HTTP
+// server is up — maintenance released at construction would grab the sync
+// mutex first and stall that reconciliation, keeping watcher dispatch in
+// collecting mode. RecordStartupReconciled releases the gate in both cases.
+func deferStartupMaintenance(skipInitialSync, workerSyncDone bool) bool {
+	return skipInitialSync || workerSyncDone
+}
+
+// statsFromWorkerResult maps a worker terminal result onto SyncStats. The
+// worker carries the complete public SyncStats payload so /sync and /resync
+// responses keep parity with in-process passes; the summary counters are the
+// fallback for a terminal record without one. Either way, Aborted mirrors the
+// worker's DiscoveryComplete verdict: providerFailures does not cross the
+// worker protocol, and AuthoritativeDiscoveryComplete() must stay accurate on
+// the daemon side.
+func statsFromWorkerResult(r workerResult) sync.SyncStats {
+	if r.Stats != nil {
+		stats := *r.Stats
+		stats.Aborted = !r.DiscoveryComplete
+		return stats
+	}
+	return sync.SyncStats{
+		Synced:  r.Synced,
+		Skipped: r.Skipped,
+		Failed:  r.Failed,
+		Aborted: !r.DiscoveryComplete,
+	}
+}
+
+// reconcileRootPaths returns the scope for the startup gap reconciliation,
+// the archive audit, and the watcher's full recovery: every watch-root path
+// whose physical probe is currently present, plus present unwatched polling
+// dirs. Scopes gated by an unavailable
+// physical path are deferred, mirroring the watcher's polling-obligation
+// probes: an unmounted volume or a missing nested session subtree (e.g.
+// Gemini's <root>/tmp) streams an empty discovery without error, and an
+// authoritative pass over it would tombstone every active session beneath it.
+func reconcileRootPaths(cfg config.Config) []string {
+	return probeWatchRecoveryScope(cfg).available
+}
+
+// watchRecoveryScope is one probed availability snapshot of the configured
+// watch scope: the currently available reconciliation paths plus the
+// configured dirs whose physical scope is missing and therefore deferred to
+// their polling probes.
+type watchRecoveryScope struct {
+	available []string
+	deferred  map[string]struct{}
+}
+
+// coversProviderRoot reports whether a configured provider root is currently
+// available for authoritative reconciliation: no deferred scope overlaps the
+// root's engine-side expansion, and at least one probed available path lies
+// at or under the root.
+func (s watchRecoveryScope) coversProviderRoot(root string) bool {
+	root = filepath.Clean(root)
+	if overlapsDeferredScope(root, s.deferred) {
+		return false
+	}
+	for _, path := range s.available {
+		if path == root || pathWithinRoot(path, root) {
+			return true
+		}
+	}
+	return false
+}
+
+// probeWatchRecoveryScope computes the probed reconciliation scope backing
+// reconcileRootPaths; see that function for the deferral semantics.
+func probeWatchRecoveryScope(cfg config.Config) watchRecoveryScope {
+	roots, unwatchedDirs, symlinkGatedDirs := collectWatchRoots(cfg)
+	deferred := make(map[string]struct{})
+	// A recursive symlink root never joins the watch roots, so its exact
+	// availability probe is the symlink target itself: os.Stat follows the
+	// link and fails while the target is gone, deferring the configured
+	// scope before an overlapping present path could expand into it.
+	for symRoot, dirs := range symlinkGatedDirs {
+		if _, err := os.Stat(symRoot); err == nil {
+			continue
+		}
+		for _, dir := range dirs {
+			deferred[filepath.Clean(dir)] = struct{}{}
+		}
+	}
+	for _, r := range roots {
+		if r.exists {
+			continue
+		}
+		for _, dir := range r.pendingPollingDirs {
+			deferred[filepath.Clean(dir)] = struct{}{}
+		}
+	}
+	seen := make(map[string]struct{})
+	var paths []string
+	add := func(path string) {
+		path = filepath.Clean(path)
+		if _, ok := seen[path]; ok {
+			return
+		}
+		seen[path] = struct{}{}
+		paths = append(paths, path)
+	}
+	for _, r := range roots {
+		if !r.exists {
+			continue
+		}
+		// A present root sharing a configured dir with a missing physical
+		// subtree (Gemini's shallow <root> next to a missing <root>/tmp,
+		// a provider parent dir over missing session dirs) would expand to
+		// that dir's full provider scope; defer it with the subtree.
+		if slices.ContainsFunc(r.syncDirs(), func(dir string) bool {
+			_, gated := deferred[filepath.Clean(dir)]
+			return gated
+		}) {
+			continue
+		}
+		if overlapsDeferredScope(r.path, deferred) {
+			continue
+		}
+		add(r.path)
+	}
+	for _, dir := range unwatchedDirs {
+		if overlapsDeferredScope(filepath.Clean(dir), deferred) {
+			continue
+		}
+		if _, err := os.Stat(dir); err == nil {
+			add(dir)
+		}
+	}
+	return watchRecoveryScope{available: paths, deferred: deferred}
+}
+
+// overlapsDeferredScope reports whether the engine-side expansion of a
+// present reconciliation path would pull a deferred configured scope back
+// into an authoritative pass. The engine expands a requested root to every
+// configured dir that is its ancestor or descendant, and the tombstone pass
+// sweeps stored paths by root prefix, so a present path related to a deferred
+// dir in either direction (an outer root over an unmounted nested root, or
+// Codex's shallow parent probe over a sibling provider's missing dir) would
+// read that scope as an empty discovery and tombstone every baselined
+// session beneath it. Callers pass cleaned paths.
+func overlapsDeferredScope(path string, deferred map[string]struct{}) bool {
+	for dir := range deferred {
+		if path == dir || pathWithinRoot(path, dir) || pathWithinRoot(dir, path) {
+			return true
+		}
+	}
+	return false
+}
+
+// pathWithinRoot reports whether the cleaned path lies strictly below the
+// cleaned root.
+func pathWithinRoot(path, root string) bool {
+	return strings.HasPrefix(path, root+string(filepath.Separator))
+}
+
+// newForegroundSyncRunner builds the daemon's foreground local-sync runner used
+// by the sync HTTP handler. It routes through the worker so a foreground
+// `agentsview sync` never runs the archive-scale pass in the daemon. A failure
+// in which no worker ran — a spawn or pre-launch handoff failure — (or a test
+// binary) falls back to the in-process SyncThenRun; a worker that ran and
+// reported failure is surfaced without re-running.
+func newForegroundSyncRunner(
+	daemonCtx context.Context,
+	cfg config.Config, engine *sync.Engine, database *db.DB, lock *writeOwnerLock,
+) server.LocalSyncRunner {
+	return func(
+		ctx context.Context, progress func(sync.Progress),
+	) (sync.SyncStats, error) {
+		if !testing.Testing() {
+			onLine := func(l workerLine) {
+				if l.Progress != nil && progress != nil {
+					progress(*l.Progress)
+				}
+			}
+			// runWorkerSyncPass records completion with SyncThenRun parity:
+			// startup acknowledgement (watcher dispatch, startup maintenance)
+			// closes before the exclusive lock is released, and last-sync
+			// state plus the "sync" emit fire after it, so /sync/status and
+			// SSE subscribers observe the worker-backed pass.
+			stats, _, err := runWorkerSyncPass(
+				ctx, daemonCtx, cfg, engine, database, lock, false, onLine,
+			)
+			if err == nil || !workerNeverRan(err) {
+				return stats, err
+			}
+			log.Printf(
+				"foreground sync worker did not run: %v "+
+					"(falling back in-process)", err,
+			)
+		}
+		return engine.SyncThenRun(
+			ctx, false, progress, func(bool) error { return nil },
+		)
+	}
+}
+
+// newForegroundResyncRunner builds the daemon's foreground resync runner used by
+// the resync HTTP handler. It builds the replacement archive in a worker process
+// behind the write barrier, then swaps it in and resets caches. A spawn failure
+// (or a test binary) falls back to the in-process resync; a worker that ran and
+// reported failure is surfaced without re-running.
+func newForegroundResyncRunner(
+	daemonCtx context.Context,
+	cfg config.Config, engine *sync.Engine, database *db.DB,
+) server.LocalResyncRunner {
+	return func(
+		ctx context.Context, progress func(sync.Progress),
+	) (sync.SyncStats, error) {
+		if !testing.Testing() {
+			result, err, spawnFailed := runWorkerResyncBuild(
+				ctx, daemonCtx, cfg, engine, database, progress,
+			)
+			if !spawnFailed {
+				if result.Status == "aborted" && ctx.Err() == nil {
+					// Mirror syncThenRunLocked: a safety-aborted resync still
+					// catches up incrementally so safely applicable updates
+					// land instead of surfacing the bare abort. The worker
+					// "sync" mode refuses stale archives, so this warm,
+					// skip-cache-bounded pass runs in process like the
+					// pre-worker path it preserves. Only the worker's explicit
+					// "aborted" verdict takes this path: operational build
+					// failures report "failed" and must surface their error
+					// rather than masquerade as a successful incremental sync.
+					return syncAllReleasingStartupMaintenance(
+						ctx, engine, progress,
+					), nil
+				}
+				return statsFromWorkerResult(result), err
+			}
+			log.Printf(
+				"foreground resync worker spawn failed: %v "+
+					"(falling back in-process)", err,
+			)
+		}
+		// SyncThenRun, not ResyncAll: it keeps the abort-to-incremental
+		// fallback for a safely aborted in-process resync and releases
+		// startup maintenance on success, matching the handler's no-runner
+		// arm (runResyncWithFallback) and the sync runner's fallback above.
+		return engine.SyncThenRun(
+			ctx, true, progress, func(bool) error { return nil },
+		)
+	}
+}
+
+// syncAllReleasingStartupMaintenance runs an incremental pass and, mirroring
+// SyncThenRun, releases startup maintenance when the pass was not cancelled.
+// SyncAll records startup reconciliation on its own but never releases the
+// maintenance gate; without the explicit release, a skip-initial-sync daemon
+// whose foreground resync took this arm would keep archive-wide backfills
+// gated until shutdown, because the deferred startup fallback observes the
+// closed reconciliation gate and returns without releasing. A cancelled pass
+// that never reconciled leaves the gate closed so the deferred fallback still
+// owns recovery; once startup is reconciled the release is owed regardless of
+// ctx — cancellation can land between SyncAll recording reconciliation and
+// this check, and the deferred fallback skips on the closed reconciliation
+// gate without ever releasing.
+func syncAllReleasingStartupMaintenance(
+	ctx context.Context, engine *sync.Engine, progress func(sync.Progress),
+) sync.SyncStats {
+	stats := engine.SyncAll(ctx, progress)
+	if ctx.Err() == nil || engine.StartupReconciled() {
+		engine.ReleaseStartupMaintenance()
+	}
+	return stats
+}
+
+// runWorkerResyncBuild builds a resync replacement in a worker process behind the
+// write barrier, then swaps it in and resets caches. It closes the writer for the
+// whole build-and-swap window (readers keep serving, direct writes fail with
+// ErrWriterClosed) without releasing the write-owner flock: the worker never
+// opens the live archive writable. The worker's terminal result is returned so
+// the caller can distinguish an explicit safety abort (Status "aborted") from
+// an operational failure. spawnFailed is true only when the worker could not
+// be launched, so the caller falls back in process.
+func runWorkerResyncBuild(
+	ctx context.Context,
+	recoveryCtx context.Context,
+	cfg config.Config,
+	engine *sync.Engine,
+	database *db.DB,
+	progress func(sync.Progress),
+) (workerResult, error, bool) {
+	relay := func(l workerLine) {
+		if l.Progress != nil && progress != nil {
+			progress(*l.Progress)
+		}
+	}
+	var result workerResult
+	var launchErr error
+	var doneStats sync.SyncStats
+	barrierErr := engine.RunExclusive(func() error {
+		if cerr := closeWriterForPass(
+			recoveryCtx, database, "resync build",
+		); cerr != nil {
+			return cerr
+		}
+		result, launchErr = launchSyncWorker(ctx, cfg, "resync-build", relay)
+		if launchErr != nil {
+			// The worker never swapped; restore the writer the barrier closed.
+			// Restoration is mandatory — abandoning it would leave every write
+			// endpoint failing until restart.
+			if rerr := restoreArchiveAccess(
+				recoveryCtx,
+				"reopen writer after failed resync build",
+				database.ReopenWriter,
+			); rerr != nil {
+				launchErr = errors.Join(launchErr, rerr)
+			}
+			return launchErr
+		}
+		if serr := engine.SwapResyncDatabase(engine.ResyncTempPath()); serr != nil {
+			// Swap failures happen at or after CloseConnections closed the
+			// reader pool, so when the swap's own recovery did not restore
+			// the archive only a full Reopen brings reads back; ReopenWriter
+			// alone would leave every read on a closed pool until restart.
+			if database.WriterClosed() {
+				if rerr := restoreArchiveAccess(
+					recoveryCtx,
+					"reopen archive after failed resync swap",
+					database.Reopen,
+				); rerr != nil {
+					serr = errors.Join(
+						serr, fmt.Errorf("recovery reopen: %w", rerr),
+					)
+				}
+			}
+			return fmt.Errorf("swap resync database: %w", serr)
+		}
+		// The swap's reopen restored the writer and cleared the barrier;
+		// re-baseline the caches that referenced the replaced database.
+		if cerr := engine.ResetCachesAfterSwap(); cerr != nil {
+			return cerr
+		}
+		// Record the completed resync with ResyncAll parity before the
+		// exclusive lock is released: last-sync state feeds /sync/status
+		// hydration, and the closed startup gate keeps the deferred startup
+		// fallback from launching another archive-scale pass. The emit and
+		// startup callback fire after the lock below.
+		doneStats = statsFromWorkerResult(result)
+		engine.RecordStartupReconciledExclusive(doneStats, nil)
+		return nil
+	})
+	if barrierErr != nil {
+		if errors.Is(barrierErr, errWorkerSpawn) {
+			return workerResult{}, barrierErr, true
+		}
+		return result, barrierErr, false
+	}
+	engine.FinishStartupReconciled(doneStats)
+	return result, nil, false
+}
+
+func newStartupReconciliationHandler(
+	ctx context.Context,
+	checkpoint func(context.Context) error,
+	openDispatch func(),
+) func(sync.SyncStats, error) {
+	return func(_ sync.SyncStats, reconciliationErr error) {
+		if ctx.Err() != nil {
+			return
+		}
+		if reconciliationErr == nil {
+			err := checkpoint(ctx)
+			if ctx.Err() != nil {
+				return
+			}
+			if err != nil {
+				log.Printf("post-sync wal checkpoint: %v", err)
+			}
+		} else {
+			log.Printf(
+				"startup sync incomplete; opening watcher dispatch with retry coverage: %v",
+				reconciliationErr,
+			)
+		}
+		openDispatch()
+	}
 }
 
 func ensureServeAuthToken(cfg *config.Config) error {
@@ -653,6 +1279,14 @@ func openWriteDB(
 }
 
 func rejectLiveWritableDaemonBeforeDirectWrite(cfg config.Config) error {
+	if runningAsSyncWorker() {
+		// The daemon spawned this worker after closing its writer and
+		// releasing the write lock for the pass, so its still-live runtime
+		// record does not mean it owns the archive. The write-owner flock
+		// acquired next is the real guard: if the daemon has not actually
+		// yielded it, acquireWriteOwnerLock refuses.
+		return nil
+	}
 	dataDir := writeLockDataDir(cfg)
 	if isExternalDaemonStarting(dataDir) || isLegacyDaemonStarting(dataDir) {
 		return fmt.Errorf(
@@ -707,7 +1341,16 @@ func writeLockDataDir(cfg config.Config) string {
 
 func closeWriteDB(database *db.DB, lock *writeOwnerLock) {
 	if database != nil {
-		database.Close()
+		if err := database.Close(); err != nil {
+			// A failed close means a connection may still hold the SQLite
+			// file. Keep the write-owner flock so another process cannot
+			// acquire writer ownership alongside the surviving connection;
+			// process exit releases both the connection and the flock.
+			log.Printf(
+				"close sqlite database: %v; keeping write-owner lock", err,
+			)
+			return
+		}
 	}
 	if lock != nil {
 		if err := lock.Close(); err != nil {
@@ -758,7 +1401,7 @@ func cleanResyncTemp(dbPath string) {
 func runInitialSync(
 	ctx context.Context, engine *sync.Engine,
 	startupProgress *startupStateWriter,
-) {
+) sync.SyncStats {
 	fmt.Println("Running initial sync...")
 	t := time.Now()
 	stats := engine.SyncAll(ctx, func(p sync.Progress) {
@@ -766,6 +1409,7 @@ func runInitialSync(
 		startupProgress.SetDetail(startupProgressDetail(p))
 	})
 	printSyncSummary(stats, t)
+	return stats
 }
 
 // runInitialResync runs ResyncAll, falling back to incremental
@@ -775,7 +1419,7 @@ func runInitialSync(
 func runInitialResync(
 	ctx context.Context, engine *sync.Engine,
 	startupProgress *startupStateWriter,
-) bool {
+) (bool, sync.SyncStats) {
 	fmt.Println("Data version changed, running full resync...")
 	t := time.Now()
 	progress := newResyncProgressPrinter(os.Stdout, time.Now)
@@ -785,23 +1429,24 @@ func runInitialResync(
 	})
 	progress.Finish()
 	printSyncSummary(stats, t)
+	resyncStats := stats
 
 	fellBack := false
 	if stats.Aborted && ctx.Err() == nil {
 		fmt.Println("Resync incomplete, running incremental sync...")
 		t = time.Now()
-		fallback := engine.SyncAll(ctx, func(p sync.Progress) {
+		stats = engine.SyncAll(ctx, func(p sync.Progress) {
 			printSyncProgress(p)
 			startupProgress.SetDetail(startupProgressDetail(p))
 		})
-		printSyncSummary(fallback, t)
+		printSyncSummary(stats, t)
 		fellBack = true
 	}
 
 	if ctx.Err() != nil {
-		return false
+		return false, stats
 	}
-	return resyncCoversSignals(stats, fellBack)
+	return resyncCoversSignals(resyncStats, fellBack), stats
 }
 
 type signalsBackfillMarker interface {
@@ -1104,51 +1749,78 @@ func formatByteProgress(p sync.Progress) string {
 }
 
 func startFileWatcher(
-	cfg config.Config, engine *sync.Engine, onChange func(batch sync.WatchBatch),
-) (stopWatcher func(), unwatchedDirs []string) {
+	cfg config.Config, engine *sync.Engine, onChange sync.WatchCallback,
+	options sync.WatcherOptions,
+) (
+	stopWatcher func(), openDispatch func(), unwatchedDirs []string,
+	queueRetry func(sync.WatchBatch),
+) {
 	t := time.Now()
-	watcher, err := sync.NewWatcherWithInterval(
+	roots, unwatchedDirs, symlinkGatedDirs := collectWatchRoots(cfg)
+	watcher, err := sync.NewWatcherWithCallback(
 		watcherBatchDelay,
 		watcherSyncMinInterval,
 		onChange,
 		cfg.WatchExcludePatterns,
+		options,
 	)
 	if err != nil {
+		for _, root := range roots {
+			unwatchedDirs = appendUniqueStrings(unwatchedDirs, root.syncDirs()...)
+		}
+		if coverageErr := registerWatcherUnavailableObligations(
+			options, roots, unwatchedDirs, symlinkGatedDirs,
+		); coverageErr != nil {
+			err = errors.Join(err, coverageErr)
+		}
 		log.Printf(
 			"warning: file watcher unavailable: %v"+
 				"; will poll every %s",
 			err, unwatchedPollInterval,
 		)
-		return func() {}, []string{"all"}
+		return func() {}, func() {}, []string{"all"}, func(sync.WatchBatch) {}
 	}
-
-	roots, unwatchedDirs := collectWatchRoots(cfg)
 
 	var totalWatched int
 	var shallowWatched int
-	remaining := recursiveWatchBudget
-	for _, r := range roots {
-		if r.shallow {
-			if watcher.WatchShallow(r.root) {
+	registeredRoots := make([]sync.WatchRoot, 0, len(roots))
+	for _, root := range roots {
+		registeredRoots = append(registeredRoots, root.registeredRoot())
+	}
+	results := watcher.RegisterRoots(registeredRoots, recursiveWatchBudget)
+	unwatchedDirs = accountRegisteredWatchRoots(unwatchedDirs, roots, results)
+	for i, r := range roots {
+		result := results[i]
+		if !r.exists {
+			continue
+		}
+		totalWatched += result.Watched
+		if !r.recursive {
+			if result.Err == nil {
 				shallowWatched++
-				totalWatched++
 			} else {
-				unwatchedDirs = append(unwatchedDirs, r.dirs...)
+				unwatchedDirs = appendUniqueStrings(unwatchedDirs, r.syncDirs()...)
 			}
 			continue
 		}
-		result := watcher.WatchRecursiveBudgeted(r.root, remaining)
-		totalWatched += result.Watched
-		remaining -= result.Watched
 		if result.Unwatched > 0 || result.BudgetExhausted ||
 			result.ResourceExhausted || result.Err != nil {
-			unwatchedDirs = append(unwatchedDirs, r.dirs...)
+			unwatchedDirs = appendUniqueStrings(unwatchedDirs, r.syncDirs()...)
 			log.Printf(
 				"Couldn't watch %d directories under %s, will poll every %s",
-				result.Unwatched, r.root, unwatchedPollInterval,
+				result.Unwatched, r.path, unwatchedPollInterval,
 			)
 			if result.Err != nil {
-				log.Printf("watching %s: %v", r.root, result.Err)
+				log.Printf("watching %s: %v", r.path, result.Err)
+			}
+		}
+	}
+	if options.OnPollingRequired != nil {
+		obligations := watchPollingObligations(roots, results, unwatchedDirs)
+		obligations = append(obligations, symlinkPollingObligations(symlinkGatedDirs)...)
+		for _, obligation := range obligations {
+			if err := options.OnPollingRequired(obligation); err != nil {
+				log.Printf("register polling obligation %q: %v", obligation.Key, err)
 			}
 		}
 	}
@@ -1170,125 +1842,604 @@ func startFileWatcher(
 			len(unwatchedDirs), unwatchedPollInterval,
 		)
 	}
-	watcher.Start()
-	return watcher.Stop, unwatchedDirs
+	if err := watcher.StartCollecting(); err != nil {
+		log.Printf("warning: file watcher startup failed: %v", err)
+	}
+	return watcher.Stop, watcher.OpenDispatch, unwatchedDirs,
+		watcher.QueueRetryBatch
+}
+
+func watchPollingObligations(
+	roots []watchRoot,
+	results []sync.RecursiveWatchResult,
+	unwatchedDirs []string,
+) []sync.PollingObligation {
+	byKey := make(map[string][]string)
+	probes := make(map[string]string)
+	represented := make(map[string]struct{})
+	// The probe is the physical path whose availability gates the
+	// obligation's reconciliation roots: the watch root's own path for
+	// root-keyed groups, the dir itself for persistent dirs.
+	add := func(key, probe string, roots ...string) {
+		if key == "" {
+			return
+		}
+		probes[key] = filepath.Clean(probe)
+		for _, root := range roots {
+			if root == "" {
+				continue
+			}
+			root = filepath.Clean(root)
+			byKey[key] = appendUniqueString(byKey[key], root)
+			represented[root] = struct{}{}
+		}
+	}
+	for i, root := range roots {
+		var result sync.RecursiveWatchResult
+		if i < len(results) {
+			result = results[i]
+		}
+		if !result.MissingRootLifecycleOwned {
+			add(root.path, root.path, root.pendingPollingDirs...)
+		}
+		for _, dir := range root.persistentPollingDirs {
+			add("persistent:"+filepath.Clean(dir), dir, dir)
+		}
+		if i >= len(results) {
+			// No registration result exists for this root: the watcher was
+			// never constructed, so nothing covers the physical root. Gate
+			// its sync scopes on the root itself, or a root that disappears
+			// after the obligations are installed leaves its configured dir
+			// pollable and the fallback poll reconciles it as an
+			// authoritative empty discovery.
+			add(root.path, root.path, root.syncDirs()...)
+			continue
+		}
+		if result.Unwatched > 0 || result.BudgetExhausted ||
+			result.ResourceExhausted || result.Err != nil {
+			add(root.path, root.path, root.syncDirs()...)
+		}
+	}
+	for _, dir := range unwatchedDirs {
+		dir = filepath.Clean(dir)
+		if _, ok := represented[dir]; !ok {
+			add("persistent:"+dir, dir, dir)
+		}
+	}
+	obligations := make([]sync.PollingObligation, 0, len(byKey))
+	for key, roots := range byKey {
+		slices.Sort(roots)
+		obligations = append(obligations, sync.PollingObligation{
+			Key: key, Roots: roots, Probe: probes[key],
+		})
+	}
+	slices.SortFunc(obligations, func(a, b sync.PollingObligation) int {
+		return strings.Compare(a.Key, b.Key)
+	})
+	return obligations
+}
+
+// registerWatcherUnavailableObligations installs the polling obligations for
+// a daemon whose file watcher could not be constructed: the coverage-degraded
+// fallback poll over every sync dir plus the same probe gates the success
+// path registers, from watchPollingObligations (root-keyed gates on every
+// physical watch root and persistent dirs) and symlinkPollingObligations
+// (symlink target gates). Without the gates, the fallback would poll a
+// configured dir that still exists while the nested root or symlink target
+// holding every session is gone, and authoritative reconciliation would
+// tombstone every baselined session beneath it. watchPollingObligations gets
+// nil results because no watcher registered any roots: no per-root
+// registration outcome exists, no missing-root lifecycle can be natively
+// owned, and every root therefore gates its sync scopes on its own path.
+// The probe gates are registered before the ungated coverage fallback: the
+// poll coordinator's ticker is already live, so a tick landing between two
+// synchronous registrations polls whatever is installed at that instant, and
+// a fallback installed first would reconcile a scope whose gate has not
+// landed yet. Returns the coverage callback's error so the caller can join
+// it with the construction failure.
+func registerWatcherUnavailableObligations(
+	options sync.WatcherOptions,
+	roots []watchRoot,
+	unwatchedDirs []string,
+	symlinkGatedDirs map[string][]string,
+) error {
+	if options.OnPollingRequired != nil {
+		obligations := watchPollingObligations(roots, nil, unwatchedDirs)
+		obligations = append(
+			obligations, symlinkPollingObligations(symlinkGatedDirs)...,
+		)
+		for _, obligation := range obligations {
+			if err := options.OnPollingRequired(obligation); err != nil {
+				log.Printf(
+					"register polling obligation %q: %v", obligation.Key, err,
+				)
+			}
+		}
+	}
+	if options.OnCoverageDegraded == nil {
+		return nil
+	}
+	return options.OnCoverageDegraded(unwatchedDirs)
+}
+
+// symlinkPollingObligations gates persistent polling of dirs whose recursive
+// provider root is a symlink on the symlink target itself. The persistent
+// obligation's probe is the configured dir, which can still exist while the
+// symlink target holding every session is gone; polling the dir then would
+// read the broken link as an empty discovery and tombstone every baselined
+// session beneath it. The poll coordinator blocks a root when any obligation
+// referencing it has a missing probe, so this composes with the dir's own
+// persistent obligation.
+func symlinkPollingObligations(
+	symlinkGatedDirs map[string][]string,
+) []sync.PollingObligation {
+	obligations := make([]sync.PollingObligation, 0, len(symlinkGatedDirs))
+	for symRoot, dirs := range symlinkGatedDirs {
+		roots := make([]string, 0, len(dirs))
+		for _, dir := range dirs {
+			roots = appendUniqueString(roots, filepath.Clean(dir))
+		}
+		slices.Sort(roots)
+		obligations = append(obligations, sync.PollingObligation{
+			Key:   "symlink:" + filepath.Clean(symRoot),
+			Roots: roots,
+			Probe: filepath.Clean(symRoot),
+		})
+	}
+	slices.SortFunc(obligations, func(a, b sync.PollingObligation) int {
+		return strings.Compare(a.Key, b.Key)
+	})
+	return obligations
+}
+
+func accountRegisteredWatchRoots(
+	unwatchedDirs []string,
+	roots []watchRoot,
+	results []sync.RecursiveWatchResult,
+) []string {
+	persistent := make(map[string]bool)
+	for _, root := range roots {
+		for _, dir := range root.persistentPollingDirs {
+			persistent[dir] = true
+		}
+	}
+	covered := make(map[string]bool)
+	seen := make(map[string]bool)
+	for i, root := range roots {
+		if root.exists {
+			continue
+		}
+		pollingDirs := root.pendingPollingDirs
+		if len(pollingDirs) == 0 {
+			// Preserve the helper's historical behavior for callers that construct
+			// watch roots directly without collection metadata.
+			pollingDirs = root.syncDirs()
+		}
+		owned := i < len(results) && results[i].MissingRootLifecycleOwned
+		for _, dir := range pollingDirs {
+			if !seen[dir] {
+				seen[dir] = true
+				covered[dir] = owned
+			} else {
+				covered[dir] = covered[dir] && owned
+			}
+		}
+	}
+	return slices.DeleteFunc(unwatchedDirs, func(dir string) bool {
+		return covered[dir] && !persistent[dir]
+	})
 }
 
 type watchSyncer interface {
-	SyncPathsContext(context.Context, []string)
-	SyncAllAfterWatcherOverflow(context.Context, sync.ProgressFunc) sync.SyncStats
+	SyncPathsContext(context.Context, []string) error
+	HasActiveSessionSourceBelow(agent, path string) (bool, error)
+	ReconciliationRootsForAgent(agent string) []string
+	ReconcileWatchRoots(context.Context, []string, bool) error
+	ReconcileWatchRootsAfterLostEvents(context.Context, []string, bool) error
 }
 
-func syncWatchBatch(ctx context.Context, engine watchSyncer, batch sync.WatchBatch) {
-	if batch.FullSync {
-		engine.SyncAllAfterWatcherOverflow(ctx, nil)
-		return
+type watchReconciliationError struct {
+	cause error
+	retry sync.WatchBatch
+}
+
+func newWatchReconciliationError(
+	cause error, roots []string, full, lostEvents bool,
+) error {
+	var scoped interface{ ReconciliationRetryRoots() []string }
+	if errors.As(cause, &scoped) {
+		if failedRoots := deduplicateStrings(scoped.ReconciliationRetryRoots()); len(failedRoots) > 0 {
+			return &watchReconciliationError{
+				cause: cause,
+				retry: sync.WatchBatch{
+					ReconcileRoots: failedRoots,
+					LostEvents:     lostEvents,
+				},
+			}
+		}
 	}
-	engine.SyncPathsContext(ctx, batch.Paths)
+	retry := sync.WatchBatch{FullSync: full}
+	retry.LostEvents = lostEvents
+	if !full {
+		retry.ReconcileRoots = append([]string(nil), roots...)
+	}
+	return &watchReconciliationError{cause: cause, retry: retry}
+}
+
+// gapReconciliationRetryBatch classifies a failed worker-to-watcher gap
+// reconciliation the same way the watcher callback path does: scoped retry
+// roots when the error carries them, otherwise an authoritative full sync.
+// The daemon queues the batch on the watcher before opening dispatch so the
+// affected roots re-reconcile with backoff.
+func gapReconciliationRetryBatch(gapErr error) sync.WatchBatch {
+	var scoped interface{ ReconciliationRetryRoots() []string }
+	if errors.As(gapErr, &scoped) {
+		if roots := deduplicateStrings(scoped.ReconciliationRetryRoots()); len(roots) > 0 {
+			return sync.WatchBatch{ReconcileRoots: roots}
+		}
+	}
+	return sync.WatchBatch{FullSync: true}
+}
+
+func (e *watchReconciliationError) Error() string { return e.cause.Error() }
+
+func (e *watchReconciliationError) Unwrap() error { return e.cause }
+
+func (e *watchReconciliationError) WatchRetryBatch() sync.WatchBatch {
+	retry := e.retry
+	retry.Paths = append([]string(nil), retry.Paths...)
+	retry.ReconcileRoots = append([]string(nil), retry.ReconcileRoots...)
+	return retry
+}
+
+// syncWatchBatch applies one watcher batch to the engine. recoveryScope
+// supplies the probed availability snapshot used by a full recovery
+// (overflow or unscoped rename) and by directory-rename promotion, per
+// probeWatchRecoveryScope. Probing at call time keeps unavailable scopes (an
+// unmounted volume, a missing provider subtree) out of authoritative
+// reconciliation, which would otherwise read them as empty discoveries and
+// tombstone every baselined session beneath them.
+func syncWatchBatch(
+	ctx context.Context,
+	engine watchSyncer,
+	batch sync.WatchBatch,
+	recoveryScope func() watchRecoveryScope,
+) error {
+	paths := append([]string(nil), batch.Paths...)
+	full := batch.FullSync
+	reconcileRoots := append([]string(nil), batch.ReconcileRoots...)
+	lostEvents := batch.LostEvents
+	type renameOwner struct {
+		path  string
+		agent string
+	}
+	var scope watchRecoveryScope
+	scopeProbed := false
+	probeScope := func() watchRecoveryScope {
+		if !scopeProbed {
+			scope = recoveryScope()
+			scopeProbed = true
+		}
+		return scope
+	}
+	authoritativePaths := make(map[string]struct{})
+	authoritativeRenames := make(map[renameOwner]struct{})
+	promoteDirectoryRename := func(rename sync.WatchRename) {
+		roots := engine.ReconciliationRootsForAgent(rename.Agent)
+		if rename.Agent == "" || len(roots) == 0 {
+			full = true
+			return
+		}
+		// FSEvents may report only one endpoint of a cross-root move, so
+		// the promotion covers every currently available root of the owning
+		// provider. Unavailable siblings are deferred to their polling
+		// probes: reconciling them would read an unmounted volume as an
+		// empty discovery and tombstone every baselined session beneath it.
+		for _, root := range roots {
+			if probeScope().coversProviderRoot(root) {
+				reconcileRoots = append(reconcileRoots, root)
+			}
+		}
+	}
+	for _, rename := range batch.Renames {
+		owner := renameOwner{path: rename.Path, agent: rename.Agent}
+		if _, authoritative := authoritativeRenames[owner]; authoritative {
+			continue
+		}
+		switch rename.ItemType {
+		case sync.ItemIsFile:
+			paths = appendUniqueString(paths, rename.Path)
+		case sync.ItemIsDir:
+			promoteDirectoryRename(rename)
+			authoritativePaths[rename.Path] = struct{}{}
+			authoritativeRenames[owner] = struct{}{}
+			paths = removeString(paths, rename.Path)
+		default:
+			info, err := os.Stat(rename.Path)
+			if err == nil {
+				if info.IsDir() {
+					promoteDirectoryRename(rename)
+					authoritativePaths[rename.Path] = struct{}{}
+					authoritativeRenames[owner] = struct{}{}
+					paths = removeString(paths, rename.Path)
+				} else {
+					paths = appendUniqueString(paths, rename.Path)
+				}
+				continue
+			}
+			if !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("classifying watcher rename %q: %w", rename.Path, err)
+			}
+			hasDescendant, err := engine.HasActiveSessionSourceBelow(rename.Agent, rename.Path)
+			if err != nil {
+				return err
+			}
+			if hasDescendant {
+				promoteDirectoryRename(rename)
+				authoritativePaths[rename.Path] = struct{}{}
+				authoritativeRenames[owner] = struct{}{}
+				paths = removeString(paths, rename.Path)
+			} else {
+				if _, authoritative := authoritativePaths[rename.Path]; !authoritative {
+					paths = appendUniqueString(paths, rename.Path)
+				}
+			}
+		}
+	}
+	if len(paths) > 0 {
+		if err := engine.SyncPathsContext(ctx, paths); err != nil {
+			retry := sync.WatchBatch{FullSync: full, LostEvents: lostEvents}
+			if !full {
+				retry.Paths = append([]string(nil), paths...)
+				retry.ReconcileRoots = deduplicateStrings(reconcileRoots)
+			}
+			return &watchReconciliationError{
+				cause: err,
+				retry: retry,
+			}
+		}
+	}
+	if full {
+		// Scope the recovery to the currently available roots, exactly like
+		// the startup gap reconciliation and the archive audit. An engine-side
+		// full pass would expand to every configured dir without probing, read
+		// an unmounted volume or missing provider subtree as an empty
+		// discovery, and tombstone every baselined session beneath it.
+		// Unavailable scopes are deferred to their polling probes instead; a
+		// failed recovery retries as a full batch so availability is re-probed.
+		fullRoots := probeScope().available
+		if len(fullRoots) == 0 {
+			return nil
+		}
+		var err error
+		if lostEvents {
+			err = engine.ReconcileWatchRootsAfterLostEvents(ctx, fullRoots, false)
+		} else {
+			err = engine.ReconcileWatchRoots(ctx, fullRoots, false)
+		}
+		if err != nil {
+			return newWatchReconciliationError(err, nil, true, lostEvents)
+		}
+		return nil
+	}
+	roots := deduplicateStrings(reconcileRoots)
+	if len(roots) > 0 {
+		var err error
+		if lostEvents {
+			err = engine.ReconcileWatchRootsAfterLostEvents(ctx, roots, false)
+		} else {
+			err = engine.ReconcileWatchRoots(ctx, roots, false)
+		}
+		if err != nil {
+			return newWatchReconciliationError(err, roots, false, lostEvents)
+		}
+	}
+	return nil
+}
+
+func removeString(values []string, remove string) []string {
+	return slices.DeleteFunc(values, func(value string) bool { return value == remove })
+}
+
+func deduplicateStrings(values []string) []string {
+	if len(values) < 2 {
+		return values
+	}
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
+}
+
+type watchScope struct {
+	agent   parser.AgentType
+	syncDir string
 }
 
 type watchRoot struct {
-	dirs    []string
-	root    string // actual path passed to WatchRecursive
-	shallow bool   // use shallow watch (root only)
+	path                  string
+	recursive             bool
+	exists                bool
+	scopes                []watchScope
+	pendingPollingDirs    []string
+	persistentPollingDirs []string
 }
 
-func collectWatchRoots(cfg config.Config) (roots []watchRoot, unwatchedDirs []string) {
+func (r watchRoot) registeredRoot() sync.WatchRoot {
+	scopes := make([]sync.WatchScope, 0, len(r.scopes))
+	for _, scope := range r.scopes {
+		scopes = append(scopes, sync.WatchScope{
+			Agent:   string(scope.agent),
+			SyncDir: scope.syncDir,
+		})
+	}
+	return sync.WatchRoot{
+		Path:      r.path,
+		Recursive: r.recursive,
+		Exists:    r.exists,
+		Scopes:    scopes,
+	}
+}
+
+func (r watchRoot) syncDirs() []string {
+	dirs := make([]string, 0, len(r.scopes))
+	for _, scope := range r.scopes {
+		dirs = appendUniqueString(dirs, scope.syncDir)
+	}
+	return dirs
+}
+
+// collectWatchRoots resolves the configured watch plan. symlinkGatedDirs maps
+// each recursive provider root skipped because it is a symlink to the
+// configured dirs whose reconciliation scope its target availability gates;
+// those roots never join the watcher plan or the returned roots.
+func collectWatchRoots(cfg config.Config) (
+	roots []watchRoot,
+	unwatchedDirs []string,
+	symlinkGatedDirs map[string][]string,
+) {
 	rootIndexes := make(map[string]int)
-	addRoot := func(dir, root string, shallow bool) {
-		if idx, ok := rootIndexes[root]; ok {
-			if !slices.Contains(roots[idx].dirs, dir) {
-				roots[idx].dirs = append(roots[idx].dirs, dir)
+	persistentPollingDirs := make(map[string]struct{})
+	symlinkGatedDirs = make(map[string][]string)
+	addRoot := func(agent parser.AgentType, dir, path string, recursive, exists bool) {
+		path = filepath.Clean(path)
+		scope := watchScope{agent: agent, syncDir: dir}
+		if idx, ok := rootIndexes[path]; ok {
+			roots[idx].recursive = roots[idx].recursive || recursive
+			roots[idx].exists = roots[idx].exists || exists
+			if !slices.Contains(roots[idx].scopes, scope) {
+				roots[idx].scopes = append(roots[idx].scopes, scope)
 			}
 			return
 		}
-		rootIndexes[root] = len(roots)
+		rootIndexes[path] = len(roots)
 		roots = append(roots, watchRoot{
-			dirs:    []string{dir},
-			root:    root,
-			shallow: shallow,
+			path:      path,
+			recursive: recursive,
+			exists:    exists,
+			scopes:    []watchScope{scope},
 		})
 	}
 	for _, def := range parser.Registry {
 		for _, d := range cfg.ResolveDirs(def.Type) {
+			addAgentRoot := func(dir, root string, recursive, exists bool) {
+				addRoot(def.Type, dir, root, recursive, exists)
+			}
 			_, hasProvider := parser.ProviderFactoryByType(def.Type)
-			if providerWatched, providerUnwatched := collectProviderWatchRoots(def, d, addRoot); providerWatched {
-				unwatchedDirs = append(unwatchedDirs, providerUnwatched...)
+			if providerWatched, polling := collectProviderWatchRoots(def, d, addAgentRoot); providerWatched {
+				if polling.persistent {
+					persistentPollingDirs[d] = struct{}{}
+					unwatchedDirs = appendUniqueString(unwatchedDirs, d)
+				}
+				for _, symRoot := range polling.symlinkRoots {
+					symlinkGatedDirs[symRoot] = appendUniqueString(
+						symlinkGatedDirs[symRoot], d,
+					)
+				}
+				for _, missing := range polling.missingRoots {
+					idx, ok := rootIndexes[filepath.Clean(missing)]
+					if !ok || idx < 0 || idx >= len(roots) {
+						continue
+					}
+					roots[idx].pendingPollingDirs = appendUniqueString(
+						roots[idx].pendingPollingDirs, d,
+					)
+					unwatchedDirs = appendUniqueString(unwatchedDirs, d)
+				}
 				continue
 			}
 			if !def.FileBased {
 				if hasProvider {
-					unwatchedDirs = append(unwatchedDirs, d)
+					persistentPollingDirs[d] = struct{}{}
+					unwatchedDirs = appendUniqueString(unwatchedDirs, d)
 				}
 				continue
 			}
-			fallbackUnwatched := collectLegacyWatchRoots(def, d, addRoot)
-			unwatchedDirs = append(unwatchedDirs, fallbackUnwatched...)
+			fallbackUnwatched := collectLegacyWatchRoots(def, d, addAgentRoot)
+			for _, pollingDir := range fallbackUnwatched {
+				persistentPollingDirs[pollingDir] = struct{}{}
+				unwatchedDirs = appendUniqueString(unwatchedDirs, pollingDir)
+			}
 		}
 	}
-	return roots, unwatchedDirs
+	for dir := range persistentPollingDirs {
+		for i := range roots {
+			if slices.Contains(roots[i].syncDirs(), dir) {
+				roots[i].persistentPollingDirs = appendUniqueString(
+					roots[i].persistentPollingDirs, dir,
+				)
+				break
+			}
+		}
+	}
+	return roots, unwatchedDirs, symlinkGatedDirs
+}
+
+type providerPollingReasons struct {
+	missingRoots []string
+	// symlinkRoots are recursive provider roots skipped from watching because
+	// the root itself is a symlink. They are served by persistent polling, and
+	// their target availability gates the configured dir's reconciliation
+	// scope: a broken symlink streams an empty discovery without error.
+	symlinkRoots []string
+	persistent   bool
 }
 
 func collectProviderWatchRoots(
 	def parser.AgentDef,
 	dir string,
-	addRoot func(dir, root string, shallow bool),
-) (bool, []string) {
+	addRoot func(dir, root string, recursive, exists bool),
+) (bool, providerPollingReasons) {
 	factory, ok := parser.ProviderFactoryByType(def.Type)
 	if !ok {
-		return false, nil
+		return false, providerPollingReasons{}
 	}
 	provider := factory.NewProvider(parser.ProviderConfig{
 		Roots: []string{dir},
 	})
-	plan, err := provider.WatchPlan(context.Background())
-	if err != nil || len(plan.Roots) == 0 {
+	roots, err := parser.ResolveWatchRoots(context.Background(), provider)
+	if err != nil || len(roots) == 0 {
 		if err != nil && !errors.Is(err, parser.ErrUnsupportedProviderFeature) {
 			log.Printf("%s provider watch plan: %v", def.Type, err)
 		}
-		return false, nil
+		return false, providerPollingReasons{}
 	}
-	added := false
-	var addedRoots []watchRoot
+	planned := false
 	var missingRoots []string
-	var unwatchedDirs []string
-	for _, providerRoot := range plan.Roots {
+	var polling providerPollingReasons
+	for _, providerRoot := range roots {
 		root := filepath.Clean(providerRoot.Path)
 		if root == "" || root == "." {
 			continue
 		}
+		planned = true
 		if providerRoot.Recursive && isSymlinkPath(root) {
-			unwatchedDirs = appendUniqueString(unwatchedDirs, dir)
+			polling.persistent = true
+			polling.symlinkRoots = append(polling.symlinkRoots, root)
 			continue
 		}
-		if _, err := os.Stat(root); err == nil {
-			addRoot(dir, root, !providerRoot.Recursive)
-			added = true
-			addedRoots = append(addedRoots, watchRoot{
-				root:    root,
-				shallow: !providerRoot.Recursive,
-			})
+		_, err := os.Stat(root)
+		exists := err == nil
+		addRoot(dir, root, providerRoot.Recursive, exists)
+		if exists {
 			continue
 		}
 		missingRoots = append(missingRoots, root)
 	}
-	if !added {
-		if len(unwatchedDirs) > 0 {
-			return true, unwatchedDirs
-		}
-		return false, nil
+	if !planned {
+		return false, providerPollingReasons{}
 	}
-	// A watch target that does not exist yet but lives under an already-watched
-	// root needs no separate polling only when the ancestor is recursive or
-	// when a shallow root can observe creation of the missing root itself. A
-	// shallow ancestor sees only immediate child creation, so it cannot cover a
-	// missing nested provider root.
-	for _, missing := range missingRoots {
-		if !pathCoveredByAnyWatchRootCreation(missing, addedRoots) {
-			unwatchedDirs = appendUniqueString(unwatchedDirs, dir)
-		}
-	}
-	return true, unwatchedDirs
+	// Portable backends need polling for missing targets. Lifecycle-aware
+	// backends can claim each target after acquiring bounded ancestor coverage;
+	// their activation gate reconciles the target before opening native dispatch.
+	polling.missingRoots = append(polling.missingRoots, missingRoots...)
+	return true, polling
 }
 
 func isSymlinkPath(path string) bool {
@@ -1306,6 +2457,13 @@ func appendUniqueString(values []string, value string) []string {
 	return append(values, value)
 }
 
+func appendUniqueStrings(values []string, additions ...string) []string {
+	for _, value := range additions {
+		values = appendUniqueString(values, value)
+	}
+	return values
+}
+
 // pathCoveredByAnyWatchRootCreation reports whether path is covered by an
 // existing watch root strongly enough to observe creation of the missing root.
 // Recursive roots cover the whole subtree. Shallow roots only cover direct
@@ -1313,14 +2471,17 @@ func appendUniqueString(values []string, value string) []string {
 // which the next watcher setup can add the provider's deeper watch root.
 func pathCoveredByAnyWatchRootCreation(path string, roots []watchRoot) bool {
 	for _, root := range roots {
-		if root.shallow {
-			if filepath.Dir(path) == root.root {
+		if !root.exists {
+			continue
+		}
+		if !root.recursive {
+			if filepath.Dir(path) == root.path {
 				return true
 			}
 			continue
 		}
-		if path == root.root ||
-			strings.HasPrefix(path, root.root+string(filepath.Separator)) {
+		if path == root.path ||
+			strings.HasPrefix(path, root.path+string(filepath.Separator)) {
 			return true
 		}
 	}
@@ -1330,13 +2491,13 @@ func pathCoveredByAnyWatchRootCreation(path string, roots []watchRoot) bool {
 func collectLegacyWatchRoots(
 	def parser.AgentDef,
 	dir string,
-	addRoot func(dir, root string, shallow bool),
+	addRoot func(dir, root string, recursive, exists bool),
 ) []string {
 	var unwatchedDirs []string
 	if def.ShallowWatchRootsFunc != nil {
 		for _, watchDir := range def.ShallowWatchRootsFunc(dir) {
 			if _, err := os.Stat(watchDir); err == nil {
-				addRoot(dir, watchDir, true)
+				addRoot(dir, watchDir, false, true)
 			}
 		}
 	}
@@ -1347,7 +2508,7 @@ func collectLegacyWatchRoots(
 		}
 		for _, watchDir := range watchDirs {
 			if _, err := os.Stat(watchDir); err == nil {
-				addRoot(dir, watchDir, def.ShallowWatch)
+				addRoot(dir, watchDir, !def.ShallowWatch, true)
 				continue
 			}
 			unwatchedDirs = append(unwatchedDirs, dir)
@@ -1356,14 +2517,14 @@ func collectLegacyWatchRoots(
 	}
 	if len(def.WatchSubdirs) == 0 {
 		if _, err := os.Stat(dir); err == nil {
-			addRoot(dir, dir, def.ShallowWatch)
+			addRoot(dir, dir, !def.ShallowWatch, true)
 		}
 		return unwatchedDirs
 	}
 	for _, sub := range def.WatchSubdirs {
 		watchDir := filepath.Join(dir, sub)
 		if _, err := os.Stat(watchDir); err == nil {
-			addRoot(dir, watchDir, def.ShallowWatch)
+			addRoot(dir, watchDir, !def.ShallowWatch, true)
 		}
 	}
 	return unwatchedDirs
@@ -1374,6 +2535,7 @@ func startPeriodicSync(
 	cfg config.Config,
 	engine *sync.Engine,
 	database *db.DB,
+	lock *writeOwnerLock,
 	idleTracker *server.IdleTracker,
 	validRemotes bool,
 	emitter sync.Emitter,
@@ -1387,6 +2549,12 @@ func startPeriodicSync(
 			}
 		}
 	}
+
+	// The daily archive audit runs on its own cadence in a worker process; it
+	// must never run the archive-scale pass in the daemon. Its own loop keeps the
+	// scheduled reconcile below (Task 5) untouched.
+	go startArchiveAudit(ctx, cfg, engine, database, lock, idleTracker, emitter)
+
 	ticker := time.NewTicker(periodicSyncInterval)
 	defer ticker.Stop()
 	for {
@@ -1395,11 +2563,189 @@ func startPeriodicSync(
 			return
 		case <-ticker.C:
 		}
-		log.Println("Running scheduled sync...")
+		log.Println("Running scheduled reconciliation...")
 		idleTracker.Do(func() {
-			engine.SyncAll(ctx, nil)
+			runScheduledSyncPass(ctx, engine, scheduledReconcileTargets(cfg))
 			recomputePendingSessions(engine, database)
 		})
+	}
+}
+
+// startArchiveAudit drives the daily archive audit with retry-and-backoff
+// scheduling. Each attempt runs entirely in a worker process (via
+// runWorkerWritePass) wrapped in idleTracker.Do; a failed attempt is retained
+// and retried with a growing delay rather than falling back in process.
+func startArchiveAudit(
+	ctx context.Context,
+	cfg config.Config,
+	engine *sync.Engine,
+	database *db.DB,
+	lock *writeOwnerLock,
+	idleTracker *server.IdleTracker,
+	emitter sync.Emitter,
+) {
+	runArchiveAuditLoop(
+		ctx,
+		func(ctx context.Context, delay time.Duration) bool {
+			timer := time.NewTimer(delay)
+			defer timer.Stop()
+			select {
+			case <-ctx.Done():
+				return false
+			case <-timer.C:
+				return true
+			}
+		},
+		func(ctx context.Context) bool {
+			return runArchiveAuditAttempt(ctx, idleTracker, func(ctx context.Context) error {
+				return runArchiveAudit(ctx, cfg, engine, database, lock, emitter)
+			})
+		},
+	)
+}
+
+// runArchiveAuditAttempt runs one audit attempt as idle-tracked work and reports
+// success. It logs the worker's actual error on failure so the terminal Error
+// string is visible in debug.log, but stays quiet once the context is cancelled
+// so shutdown does not emit a spurious failure line.
+func runArchiveAuditAttempt(
+	ctx context.Context,
+	idleTracker *server.IdleTracker,
+	audit func(context.Context) error,
+) bool {
+	ok := false
+	idleTracker.Do(func() {
+		if err := audit(ctx); err != nil {
+			if ctx.Err() == nil {
+				log.Printf("archive audit attempt failed: %v", err)
+			}
+			return
+		}
+		ok = true
+	})
+	return ok
+}
+
+// runArchiveAuditLoop waits, runs one audit attempt, then reschedules from the
+// outcome: success returns to the daily interval; failure retries after a delay
+// that doubles each time and caps at archiveAuditInterval. wait blocks for the
+// delay and reports false when the context is done; audit reports whether the
+// attempt succeeded.
+func runArchiveAuditLoop(
+	ctx context.Context,
+	wait func(context.Context, time.Duration) bool,
+	audit func(context.Context) bool,
+) {
+	delay := archiveAuditInterval
+	retry := archiveAuditRetryInitial
+	for {
+		if !wait(ctx, delay) {
+			return
+		}
+		if audit(ctx) {
+			delay = archiveAuditInterval
+			retry = archiveAuditRetryInitial
+			continue
+		}
+		delay = retry
+		if ctx.Err() == nil {
+			log.Printf("archive audit failed; next attempt in %s", retry)
+		}
+		retry = min(retry*2, archiveAuditInterval)
+	}
+}
+
+// runArchiveAudit executes one audit attempt: a full authoritative
+// reconciliation in a worker process via runWorkerWritePass, never in the
+// daemon. It emits "sessions" whenever the terminal result reports committed
+// changes — synced or tombstoned — even when the pass also failed, because the
+// retry sees those rows as already synchronized and would never re-notify SSE
+// clients or the embedding scheduler. It returns an error on any failure —
+// spawn, pre-launch handoff, or a ran-and-failed worker — so the caller
+// retries with backoff; it never falls back to an in-process pass. The
+// daemon's in-memory skip cache is reloaded by runWorkerWritePass inside the
+// pass's own exclusive section, so no queued sync can re-persist stale
+// entries the audit worker removed.
+func runArchiveAudit(
+	ctx context.Context,
+	cfg config.Config,
+	engine *sync.Engine,
+	database *db.DB,
+	lock *writeOwnerLock,
+	emitter sync.Emitter,
+) error {
+	result, err := runWorkerWritePass(
+		ctx, ctx, cfg, engine, database, lock, "audit", nil,
+	)
+	if (result.Synced > 0 || result.Tombstoned > 0) && emitter != nil {
+		emitter.Emit("sessions")
+	}
+	return err
+}
+
+// scheduledSyncEngine is the reconciliation surface the scheduled pass needs.
+// Native-watched providers already get event-driven sync plus degraded-coverage
+// polling, so the scheduled pass only reconciles the opted-in providers.
+type scheduledSyncEngine interface {
+	ReconcileProviderRoots(ctx context.Context, agent parser.AgentType, roots []string) error
+}
+
+// scheduledReconcileTarget pairs an opted-in provider with the configured roots
+// the scheduled pass must reconcile for it.
+type scheduledReconcileTarget struct {
+	Agent parser.AgentType
+	Roots []string
+}
+
+// scheduledReconcileTargets selects the configured roots for providers that
+// declare PeriodicReconcile. Every other provider is covered by the watcher and
+// the degraded-coverage poller, so the scheduled pass leaves them untouched.
+func scheduledReconcileTargets(cfg config.Config) []scheduledReconcileTarget {
+	roots, _, _ := collectWatchRoots(cfg)
+	deferred := make(map[watchScope]struct{})
+	for _, root := range roots {
+		if root.exists {
+			continue
+		}
+		for _, scope := range root.scopes {
+			deferred[scope] = struct{}{}
+		}
+	}
+	byAgent := make(map[parser.AgentType][]string)
+	for _, root := range roots {
+		if !root.exists {
+			continue
+		}
+		for _, scope := range root.scopes {
+			if _, blocked := deferred[scope]; blocked {
+				continue
+			}
+			byAgent[scope.agent] = appendUniqueString(byAgent[scope.agent], scope.syncDir)
+		}
+	}
+	var targets []scheduledReconcileTarget
+	for _, def := range parser.Registry {
+		if !def.PeriodicReconcile {
+			continue
+		}
+		dirs := byAgent[def.Type]
+		if len(dirs) == 0 {
+			continue
+		}
+		targets = append(targets, scheduledReconcileTarget{Agent: def.Type, Roots: dirs})
+	}
+	return targets
+}
+
+// runScheduledSyncPass reconciles each opted-in provider within its own scope.
+// A failure for one provider is logged and does not block the others.
+func runScheduledSyncPass(
+	ctx context.Context, engine scheduledSyncEngine, targets []scheduledReconcileTarget,
+) {
+	for _, target := range targets {
+		if err := engine.ReconcileProviderRoots(ctx, target.Agent, target.Roots); err != nil {
+			log.Printf("scheduled reconciliation for %s: %v", target.Agent, err)
+		}
 	}
 }
 
@@ -1547,37 +2893,4 @@ func recomputePendingSessions(
 		// pass will retry any that failed.
 		_ = engine.RecomputeSignals(context.Background(), id)
 	}
-}
-
-type unwatchedPollSyncer interface {
-	SyncRootsSince(
-		context.Context, []string, time.Time, sync.ProgressFunc,
-	) sync.SyncStats
-}
-
-func startUnwatchedPoll(
-	ctx context.Context,
-	engine unwatchedPollSyncer,
-	roots []string,
-	idleTracker *server.IdleTracker,
-) {
-	ticker := time.NewTicker(unwatchedPollInterval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-		}
-		log.Println("Polling unwatched directories...")
-		idleTracker.Do(func() {
-			pollUnwatchedRootsOnce(ctx, engine, roots)
-		})
-	}
-}
-
-func pollUnwatchedRootsOnce(
-	ctx context.Context, engine unwatchedPollSyncer, roots []string,
-) {
-	engine.SyncRootsSince(ctx, roots, time.Time{}, nil)
 }

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -2728,15 +2728,23 @@ type scheduledReconcileTarget struct {
 // scheduledReconcileTargets selects the configured roots for providers that
 // declare PeriodicReconcile. Every other provider is covered by the watcher and
 // the degraded-coverage poller, so the scheduled pass leaves them untouched.
+// A candidate scope overlapping a missing same-agent scope in either direction
+// is deferred with it: the engine expands a requested root to every configured
+// same-agent dir that is its ancestor or descendant, so reconciling the
+// present scope would read the missing one as an authoritative empty discovery
+// and tombstone every session beneath it.
 func scheduledReconcileTargets(cfg config.Config) []scheduledReconcileTarget {
 	roots, _, _ := collectWatchRoots(cfg)
-	deferred := make(map[watchScope]struct{})
+	deferred := make(map[parser.AgentType]map[string]struct{})
 	for _, root := range roots {
 		if root.exists {
 			continue
 		}
 		for _, scope := range root.scopes {
-			deferred[scope] = struct{}{}
+			if deferred[scope.agent] == nil {
+				deferred[scope.agent] = make(map[string]struct{})
+			}
+			deferred[scope.agent][scope.syncDir] = struct{}{}
 		}
 	}
 	byAgent := make(map[parser.AgentType][]string)
@@ -2745,7 +2753,7 @@ func scheduledReconcileTargets(cfg config.Config) []scheduledReconcileTarget {
 			continue
 		}
 		for _, scope := range root.scopes {
-			if _, blocked := deferred[scope]; blocked {
+			if overlapsDeferredScope(scope.syncDir, deferred[scope.agent]) {
 				continue
 			}
 			byAgent[scope.agent] = appendUniqueString(byAgent[scope.agent], scope.syncDir)

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -858,9 +858,14 @@ func probeWatchRecoveryScope(cfg config.Config) watchRecoveryScope {
 // dir in either direction (an outer root over an unmounted nested root, or
 // Codex's shallow parent probe over a sibling provider's missing dir) would
 // read that scope as an empty discovery and tombstone every baselined
-// session beneath it. Callers pass cleaned paths.
+// session beneath it. Both sides are normalized to absolute form here because
+// the engine expands roots against configured dirs after filepath.Abs
+// (cleanRootPath): a scope configured relative and a path configured absolute
+// still overlap on the engine side, so they must overlap here too.
 func overlapsDeferredScope(path string, deferred map[string]struct{}) bool {
+	path = absRootPath(path)
 	for dir := range deferred {
+		dir = absRootPath(dir)
 		if path == dir || pathWithinRoot(path, dir) || pathWithinRoot(dir, path) {
 			return true
 		}
@@ -868,10 +873,27 @@ func overlapsDeferredScope(path string, deferred map[string]struct{}) bool {
 	return false
 }
 
+// absRootPath mirrors the engine's cleanRootPath so daemon-side scope-overlap
+// checks compare the same path form the engine's root expansion uses.
+func absRootPath(path string) string {
+	cleaned := filepath.Clean(path)
+	abs, err := filepath.Abs(cleaned)
+	if err != nil {
+		return cleaned
+	}
+	return abs
+}
+
 // pathWithinRoot reports whether the cleaned path lies strictly below the
-// cleaned root.
+// cleaned root. A cleaned filesystem root ("/" on Unix, a volume root on
+// Windows) already ends in the separator, so the descendant prefix is only
+// suffixed when missing.
 func pathWithinRoot(path, root string) bool {
-	return strings.HasPrefix(path, root+string(filepath.Separator))
+	prefix := root
+	if !strings.HasSuffix(prefix, string(filepath.Separator)) {
+		prefix += string(filepath.Separator)
+	}
+	return path != root && strings.HasPrefix(path, prefix)
 }
 
 // newForegroundSyncRunner builds the daemon's foreground local-sync runner used

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -2555,6 +2555,11 @@ func startPeriodicSync(
 	// scheduled reconcile below (Task 5) untouched.
 	go startArchiveAudit(ctx, cfg, engine, database, lock, idleTracker, emitter)
 
+	// Remote object roots are static config; resolve them once. The scheduled
+	// reconcile targets are re-probed each tick because disk availability
+	// changes.
+	remoteRoots := remoteSourceSyncRoots(cfg)
+
 	ticker := time.NewTicker(periodicSyncInterval)
 	defer ticker.Stop()
 	for {
@@ -2566,6 +2571,7 @@ func startPeriodicSync(
 		log.Println("Running scheduled reconciliation...")
 		idleTracker.Do(func() {
 			runScheduledSyncPass(ctx, engine, scheduledReconcileTargets(cfg))
+			runRemoteSourceSyncPass(ctx, engine, remoteRoots)
 			recomputePendingSessions(engine, database)
 		})
 	}

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -8,9 +8,13 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
+	"runtime/debug"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -26,6 +30,7 @@ import (
 	"go.kenn.io/agentsview/internal/remotesync"
 	"go.kenn.io/agentsview/internal/server"
 	agentsync "go.kenn.io/agentsview/internal/sync"
+	"go.kenn.io/agentsview/internal/testjsonl"
 )
 
 func TestRuntimeWarningHelper(t *testing.T) {
@@ -519,26 +524,21 @@ func TestNewDaemonIdleTrackerEnvOverridesConfig(t *testing.T) {
 }
 
 type fakeUnwatchedPollSyncer struct {
-	roots     []string
-	since     time.Time
 	calls     int
 	callRoots [][]string
-	callSince []time.Time
+	callFull  []bool
 }
 
-func (f *fakeUnwatchedPollSyncer) SyncRootsSince(
-	ctx context.Context, roots []string, since time.Time,
-	onProgress agentsync.ProgressFunc,
-) agentsync.SyncStats {
+func (f *fakeUnwatchedPollSyncer) ReconcileWatchRoots(
+	_ context.Context, roots []string, full bool,
+) error {
 	f.calls++
-	f.roots = append([]string(nil), roots...)
-	f.since = since
 	f.callRoots = append(f.callRoots, append([]string(nil), roots...))
-	f.callSince = append(f.callSince, since)
-	return agentsync.SyncStats{}
+	f.callFull = append(f.callFull, full)
+	return nil
 }
 
-func TestPollUnwatchedRootsOnceUsesScopedFullSync(t *testing.T) {
+func TestPollUnwatchedRootsOnceUsesScopedAuthoritativeReconciliation(t *testing.T) {
 	fake := &fakeUnwatchedPollSyncer{}
 	roots := []string{"/tmp/claude", "/tmp/codex"}
 
@@ -547,9 +547,9 @@ func TestPollUnwatchedRootsOnceUsesScopedFullSync(t *testing.T) {
 
 	require.Equal(t, 2, fake.calls)
 	assert.Equal(t, roots, fake.callRoots[0])
-	assert.True(t, fake.callSince[0].IsZero(), "first poll cutoff = %v", fake.callSince[0])
+	assert.False(t, fake.callFull[0])
 	assert.Equal(t, roots, fake.callRoots[1])
-	assert.True(t, fake.callSince[1].IsZero(), "second poll cutoff = %v", fake.callSince[1])
+	assert.False(t, fake.callFull[1])
 }
 
 func TestCollectWatchRootsPreservesDirsSharingWatchRoot(t *testing.T) {
@@ -564,12 +564,39 @@ func TestCollectWatchRootsPreservesDirsSharingWatchRoot(t *testing.T) {
 		},
 	}
 
-	roots, unwatchedDirs := collectWatchRoots(cfg)
+	roots, unwatchedDirs, _ := collectWatchRoots(cfg)
 
-	require.Empty(t, unwatchedDirs, "unwatched dirs before watcher setup")
-	require.Len(t, roots, 1, "shared watch root should be represented once")
-	assert.Equal(t, parent, roots[0].root)
-	assert.ElementsMatch(t, []string{sessionsDir, archivedDir}, roots[0].dirs)
+	assert.ElementsMatch(t, []string{sessionsDir, archivedDir}, unwatchedDirs,
+		"missing roots retain polling until native activation completes")
+	shared, ok := findCollectedWatchRoot(roots, parent)
+	require.True(t, ok, "shared watch root should be represented once")
+	assert.False(t, shared.recursive, "provider parent root is explicitly shallow")
+	assert.True(t, shared.exists)
+	assert.ElementsMatch(t, []watchScope{
+		{agent: parser.AgentCodex, syncDir: sessionsDir},
+		{agent: parser.AgentCodex, syncDir: archivedDir},
+	}, shared.scopes)
+	assert.ElementsMatch(t, []agentsync.WatchScope{
+		{Agent: string(parser.AgentCodex), SyncDir: sessionsDir},
+		{Agent: string(parser.AgentCodex), SyncDir: archivedDir},
+	}, shared.registeredRoot().Scopes,
+		"watcher registration must retain every configured polling scope")
+
+	sessions, ok := findCollectedWatchRoot(roots, sessionsDir)
+	require.True(t, ok, "missing sessions root remains in the logical plan")
+	assert.True(t, sessions.recursive)
+	assert.False(t, sessions.exists)
+	assert.Equal(t, []watchScope{{agent: parser.AgentCodex, syncDir: sessionsDir}}, sessions.scopes)
+	assert.Equal(t, []string{sessionsDir}, sessions.pendingPollingDirs)
+	assert.Empty(t, sessions.persistentPollingDirs)
+
+	archived, ok := findCollectedWatchRoot(roots, archivedDir)
+	require.True(t, ok, "missing archive root remains in the logical plan")
+	assert.True(t, archived.recursive)
+	assert.False(t, archived.exists)
+	assert.Equal(t, []watchScope{{agent: parser.AgentCodex, syncDir: archivedDir}}, archived.scopes)
+	assert.Equal(t, []string{archivedDir}, archived.pendingPollingDirs)
+	assert.Empty(t, archived.persistentPollingDirs)
 }
 
 func TestCollectWatchRootsPollsRecursiveSymlinkProviderRoot(t *testing.T) {
@@ -586,19 +613,21 @@ func TestCollectWatchRootsPollsRecursiveSymlinkProviderRoot(t *testing.T) {
 		},
 	}
 
-	roots, unwatchedDirs := collectWatchRoots(cfg)
+	roots, unwatchedDirs, _ := collectWatchRoots(cfg)
 
 	require.Len(t, roots, 2)
-	assert.Equal(t, root, roots[0].root)
-	assert.True(t, roots[0].shallow)
-	assert.Equal(t, []string{root}, roots[0].dirs)
+	assert.Equal(t, root, roots[0].path)
+	assert.False(t, roots[0].recursive)
+	assert.True(t, roots[0].exists)
+	assert.Equal(t, []watchScope{{agent: parser.AgentVSCopilot, syncDir: root}}, roots[0].scopes)
 	assert.Equal(
 		t,
 		filepath.Join(root, ".VS", "SampleApp", "copilot-chat", "thread", "sessions"),
-		roots[1].root,
+		roots[1].path,
 	)
-	assert.True(t, roots[1].shallow)
-	assert.Equal(t, []string{root}, roots[1].dirs)
+	assert.False(t, roots[1].recursive)
+	assert.True(t, roots[1].exists)
+	assert.Equal(t, []watchScope{{agent: parser.AgentVSCopilot, syncDir: root}}, roots[1].scopes)
 	assert.ElementsMatch(t, []string{root}, unwatchedDirs)
 }
 
@@ -1060,16 +1089,18 @@ func TestCollectWatchRootsHermesSessionsWatchesStateDBParent(t *testing.T) {
 		},
 	}
 
-	roots, unwatchedDirs := collectWatchRoots(cfg)
+	roots, unwatchedDirs, _ := collectWatchRoots(cfg)
 
 	require.Empty(t, unwatchedDirs, "unwatched dirs before watcher setup")
 	require.Len(t, roots, 2)
-	assert.Equal(t, root, roots[0].root)
-	assert.True(t, roots[0].shallow)
-	assert.Equal(t, []string{sessionsDir}, roots[0].dirs)
-	assert.Equal(t, sessionsDir, roots[1].root)
-	assert.False(t, roots[1].shallow)
-	assert.Equal(t, []string{sessionsDir}, roots[1].dirs)
+	assert.Equal(t, root, roots[0].path)
+	assert.False(t, roots[0].recursive)
+	assert.True(t, roots[0].exists)
+	assert.Equal(t, []watchScope{{agent: parser.AgentHermes, syncDir: sessionsDir}}, roots[0].scopes)
+	assert.Equal(t, sessionsDir, roots[1].path)
+	assert.True(t, roots[1].recursive)
+	assert.True(t, roots[1].exists)
+	assert.Equal(t, []watchScope{{agent: parser.AgentHermes, syncDir: sessionsDir}}, roots[1].scopes)
 }
 
 func TestCollectWatchRootsWatchesHermesProfilesContainerRecursively(t *testing.T) {
@@ -1081,13 +1112,14 @@ func TestCollectWatchRootsWatchesHermesProfilesContainerRecursively(t *testing.T
 		},
 	}
 
-	roots, unwatchedDirs := collectWatchRoots(cfg)
+	roots, unwatchedDirs, _ := collectWatchRoots(cfg)
 
 	require.Empty(t, unwatchedDirs)
 	require.Len(t, roots, 1)
-	assert.Equal(t, profilesRoot, roots[0].root)
-	assert.False(t, roots[0].shallow)
-	assert.Equal(t, []string{profilesRoot}, roots[0].dirs)
+	assert.Equal(t, profilesRoot, roots[0].path)
+	assert.True(t, roots[0].recursive)
+	assert.True(t, roots[0].exists)
+	assert.Equal(t, []watchScope{{agent: parser.AgentHermes, syncDir: profilesRoot}}, roots[0].scopes)
 }
 
 func TestCollectWatchRootsUsesCoworkProviderRecursiveRoot(t *testing.T) {
@@ -1098,14 +1130,15 @@ func TestCollectWatchRootsUsesCoworkProviderRecursiveRoot(t *testing.T) {
 		},
 	}
 
-	roots, unwatchedDirs := collectWatchRoots(cfg)
+	roots, unwatchedDirs, _ := collectWatchRoots(cfg)
 
 	require.Empty(t, unwatchedDirs, "cowork root should be watched directly")
 	got, ok := findCollectedWatchRoot(roots, root)
 	require.True(t, ok, "cowork provider WatchPlan root not collected")
-	assert.False(t, got.shallow,
+	assert.True(t, got.recursive,
 		"cowork provider recursive WatchPlan must override legacy ShallowWatch")
-	assert.Equal(t, []string{root}, got.dirs)
+	assert.True(t, got.exists)
+	assert.Equal(t, []watchScope{{agent: parser.AgentCowork, syncDir: root}}, got.scopes)
 }
 
 func TestCollectWatchRootsUsesGeminiProviderMetadataRoot(t *testing.T) {
@@ -1118,15 +1151,17 @@ func TestCollectWatchRootsUsesGeminiProviderMetadataRoot(t *testing.T) {
 		},
 	}
 
-	roots, unwatchedDirs := collectWatchRoots(cfg)
+	roots, unwatchedDirs, _ := collectWatchRoots(cfg)
 
 	require.Empty(t, unwatchedDirs, "all gemini provider roots exist")
 	metadataRoot, ok := findCollectedWatchRoot(roots, root)
 	require.True(t, ok, "gemini provider metadata root not collected")
-	assert.True(t, metadataRoot.shallow)
+	assert.False(t, metadataRoot.recursive)
+	assert.True(t, metadataRoot.exists)
 	tmp, ok := findCollectedWatchRoot(roots, tmpRoot)
 	require.True(t, ok, "gemini provider recursive tmp root not collected")
-	assert.False(t, tmp.shallow)
+	assert.True(t, tmp.recursive)
+	assert.True(t, tmp.exists)
 }
 
 func TestCollectWatchRootsUsesAntigravityCLIHistoryRoot(t *testing.T) {
@@ -1140,20 +1175,20 @@ func TestCollectWatchRootsUsesAntigravityCLIHistoryRoot(t *testing.T) {
 		},
 	}
 
-	roots, unwatchedDirs := collectWatchRoots(cfg)
+	roots, unwatchedDirs, _ := collectWatchRoots(cfg)
 
 	require.Empty(t, unwatchedDirs, "all antigravity cli provider roots exist")
 	historyRoot, ok := findCollectedWatchRoot(roots, root)
 	require.True(t, ok, "antigravity cli history.jsonl root not collected")
-	assert.True(t, historyRoot.shallow)
+	assert.False(t, historyRoot.recursive)
 	conversations, ok := findCollectedWatchRoot(
 		roots, filepath.Join(root, "conversations"),
 	)
 	require.True(t, ok, "antigravity cli conversations root not collected")
-	assert.True(t, conversations.shallow)
+	assert.False(t, conversations.recursive)
 	brain, ok := findCollectedWatchRoot(roots, filepath.Join(root, "brain"))
 	require.True(t, ok, "antigravity cli brain root not collected")
-	assert.False(t, brain.shallow)
+	assert.True(t, brain.recursive)
 }
 
 func TestCollectWatchRootsIncludesDevinProviderRootsForNonFileAgent(t *testing.T) {
@@ -1167,20 +1202,47 @@ func TestCollectWatchRootsIncludesDevinProviderRootsForNonFileAgent(t *testing.T
 		},
 	}
 
-	roots, unwatchedDirs := collectWatchRoots(cfg)
+	roots, unwatchedDirs, _ := collectWatchRoots(cfg)
 
 	require.Empty(t, unwatchedDirs)
 	cliRoot, ok := findCollectedWatchRoot(roots, filepath.Join(root, "cli"))
 	require.True(t, ok, "devin cli root not collected")
-	assert.True(t, cliRoot.shallow)
-	assert.Equal(t, []string{root}, cliRoot.dirs)
+	assert.False(t, cliRoot.recursive)
+	assert.True(t, cliRoot.exists)
+	assert.Equal(t, []watchScope{{agent: parser.AgentDevin, syncDir: root}}, cliRoot.scopes)
 	transcriptsRoot, ok := findCollectedWatchRoot(roots, filepath.Join(root, "cli", "transcripts"))
 	require.True(t, ok, "devin transcripts root not collected")
-	assert.True(t, transcriptsRoot.shallow)
-	assert.Equal(t, []string{root}, transcriptsRoot.dirs)
+	assert.False(t, transcriptsRoot.recursive)
+	assert.True(t, transcriptsRoot.exists)
+	assert.Equal(t, []watchScope{{agent: parser.AgentDevin, syncDir: root}}, transcriptsRoot.scopes)
 }
 
-func TestCollectWatchRootsMarksDevinRootUnwatchedWhenProviderPathsMissing(t *testing.T) {
+func TestCollectWatchRootsTracksExactAgentsForSharedRoot(t *testing.T) {
+	root := t.TempDir()
+	cfg := config.Config{AgentDirs: map[parser.AgentType][]string{
+		parser.AgentClaude: {root},
+		parser.AgentCodex:  {root},
+	}}
+
+	roots, unwatchedDirs, _ := collectWatchRoots(cfg)
+
+	require.Empty(t, unwatchedDirs)
+	shared, ok := findCollectedWatchRoot(roots, root)
+	require.True(t, ok)
+	assert.True(t, shared.recursive,
+		"a recursive owner must preserve recursive physical coverage")
+	assert.ElementsMatch(t, []watchScope{
+		{agent: parser.AgentClaude, syncDir: root},
+		{agent: parser.AgentCodex, syncDir: root},
+	}, shared.scopes)
+	assert.ElementsMatch(t, []agentsync.WatchScope{
+		{Agent: string(parser.AgentClaude), SyncDir: root},
+		{Agent: string(parser.AgentCodex), SyncDir: root},
+	}, shared.registeredRoot().Scopes,
+		"watcher registration must retain every rename-prefix owner")
+}
+
+func TestCollectWatchRootsPreservesMissingProviderRoots(t *testing.T) {
 	root := t.TempDir()
 	cfg := config.Config{
 		AgentDirs: map[parser.AgentType][]string{
@@ -1188,16 +1250,26 @@ func TestCollectWatchRootsMarksDevinRootUnwatchedWhenProviderPathsMissing(t *tes
 		},
 	}
 
-	roots, unwatchedDirs := collectWatchRoots(cfg)
+	roots, unwatchedDirs, _ := collectWatchRoots(cfg)
 
-	assert.Empty(t, roots)
+	require.Len(t, roots, 2)
+	cliRoot, ok := findCollectedWatchRoot(roots, filepath.Join(root, "cli"))
+	require.True(t, ok)
+	assert.False(t, cliRoot.recursive)
+	assert.False(t, cliRoot.exists)
+	assert.Equal(t, []watchScope{{agent: parser.AgentDevin, syncDir: root}}, cliRoot.scopes)
+	transcriptsRoot, ok := findCollectedWatchRoot(roots, filepath.Join(root, "cli", "transcripts"))
+	require.True(t, ok)
+	assert.False(t, transcriptsRoot.recursive)
+	assert.False(t, transcriptsRoot.exists)
+	assert.Equal(t, []watchScope{{agent: parser.AgentDevin, syncDir: root}}, transcriptsRoot.scopes)
 	assert.Equal(t, []string{root}, unwatchedDirs)
 }
 
-func TestMissingWatchRootCoverageDoesNotTreatShallowAncestorAsRecursive(t *testing.T) {
+func TestPathCoveredByAnyWatchRootCreationDoesNotTreatShallowAncestorAsRecursive(t *testing.T) {
 	root := filepath.Clean(filepath.Join(t.TempDir(), "state"))
-	shallowRoots := []watchRoot{{root: root, shallow: true}}
-	recursiveRoots := []watchRoot{{root: root, shallow: false}}
+	shallowRoots := []watchRoot{{path: root, recursive: false, exists: true}}
+	recursiveRoots := []watchRoot{{path: root, recursive: true, exists: true}}
 
 	assert.True(t,
 		pathCoveredByAnyWatchRootCreation(filepath.Join(root, "sessions"), shallowRoots),
@@ -1210,10 +1282,607 @@ func TestMissingWatchRootCoverageDoesNotTreatShallowAncestorAsRecursive(t *testi
 		"recursive roots cover nested missing roots")
 }
 
+func TestStartFileWatcherSuppressesPendingPollingWhenLifecycleIsOwned(t *testing.T) {
+	root := t.TempDir()
+	pending := watchRoot{
+		path:               filepath.Join(root, "state", "sessions"),
+		recursive:          true,
+		scopes:             []watchScope{{agent: parser.AgentDevin, syncDir: root}},
+		pendingPollingDirs: []string{root},
+	}
+
+	got := accountRegisteredWatchRoots(
+		[]string{root}, []watchRoot{pending},
+		[]agentsync.RecursiveWatchResult{{
+			Watched:                   1,
+			MissingRootLifecycleOwned: true,
+		}},
+	)
+
+	assert.Empty(t, got,
+		"native lifecycle ownership replaces the startup polling obligation")
+	assert.Empty(t, watchPollingObligations(
+		[]watchRoot{pending},
+		[]agentsync.RecursiveWatchResult{{
+			Watched:                   1,
+			MissingRootLifecycleOwned: true,
+		}},
+		got,
+	), "owned missing roots must not schedule authoritative polling")
+}
+
+func TestStartupReconciliationHandlerCheckpointsBeforeOpeningDispatch(t *testing.T) {
+	ctx := t.Context()
+	order := make([]string, 0, 2)
+	handler := newStartupReconciliationHandler(
+		ctx,
+		func(got context.Context) error {
+			assert.Equal(t, ctx, got)
+			order = append(order, "checkpoint")
+			return nil
+		},
+		func() { order = append(order, "open") },
+	)
+
+	handler(agentsync.SyncStats{}, nil)
+	assert.Equal(t, []string{"checkpoint", "open"}, order)
+}
+
+func TestInitialSyncWatcherStartupOwnerReconciles(t *testing.T) {
+	database := dbtest.OpenTestDB(t)
+	reconciled := make(chan agentsync.SyncStats, 1)
+	engine := agentsync.NewEngine(database, agentsync.EngineConfig{
+		OnStartupReconciled: func(stats agentsync.SyncStats, err error) {
+			require.NoError(t, err)
+			reconciled <- stats
+		},
+	})
+	t.Cleanup(engine.Close)
+
+	stats := runInitialSync(t.Context(), engine, nil)
+
+	assert.False(t, stats.Aborted)
+	select {
+	case got := <-reconciled:
+		assert.Equal(t, stats, got)
+	case <-time.After(time.Second):
+		require.FailNow(t, "initial sync did not reconcile watcher startup")
+	}
+}
+
+func TestInitialResyncWatcherStartupOwnerReportsFirstIncompleteAttempt(t *testing.T) {
+	database := dbtest.OpenTestDB(t)
+	missingPath := filepath.Join(t.TempDir(), "missing.jsonl")
+	dbtest.SeedSession(t, database, "existing", "project", func(s *db.Session) {
+		s.FilePath = &missingPath
+	})
+	type startupResult struct {
+		stats agentsync.SyncStats
+		err   error
+	}
+	reconciled := make(chan startupResult, 1)
+	engine := agentsync.NewEngine(database, agentsync.EngineConfig{
+		OnStartupReconciled: func(stats agentsync.SyncStats, err error) {
+			reconciled <- startupResult{stats: stats, err: err}
+		},
+	})
+	t.Cleanup(engine.Close)
+
+	covered, stats := runInitialResync(t.Context(), engine, nil)
+
+	assert.False(t, covered)
+	assert.False(t, stats.Aborted, "incremental fallback is the successful owner")
+	select {
+	case got := <-reconciled:
+		assert.True(t, got.stats.Aborted,
+			"dispatch reports the first incomplete attempt without waiting for fallback")
+		assert.ErrorContains(t, got.err, "startup discovery incomplete")
+	case <-time.After(time.Second):
+		require.FailNow(t, "incomplete startup attempt was not reported")
+	}
+}
+
+func TestStartupReconciliationHandlerKeepsDispatchClosedAfterCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	checkpointed := false
+	opened := false
+	handler := newStartupReconciliationHandler(
+		ctx,
+		func(context.Context) error { checkpointed = true; return nil },
+		func() { opened = true },
+	)
+
+	handler(agentsync.SyncStats{}, nil)
+	assert.False(t, checkpointed)
+	assert.False(t, opened)
+}
+
+func TestStartupReconciliationHandlerCheckpointErrorStillOpensDispatch(t *testing.T) {
+	opened := false
+	handler := newStartupReconciliationHandler(
+		t.Context(),
+		func(context.Context) error { return errors.New("checkpoint unavailable") },
+		func() { opened = true },
+	)
+
+	handler(agentsync.SyncStats{}, nil)
+	assert.True(t, opened,
+		"committed reconciliation remains valid after a best-effort checkpoint error")
+}
+
+func TestStartupReconciliationHandlerPartialDiscoveryStillOpensDispatch(t *testing.T) {
+	checkpointed := false
+	opened := false
+	handler := newStartupReconciliationHandler(
+		t.Context(),
+		func(context.Context) error { checkpointed = true; return nil },
+		func() { opened = true },
+	)
+
+	handler(agentsync.SyncStats{}, errors.New("one provider unavailable"))
+
+	assert.False(t, checkpointed,
+		"an incomplete startup pass must not checkpoint as authoritative")
+	assert.True(t, opened,
+		"a failed provider must not strand native watcher dispatch")
+}
+
+func TestStartupReconciliationHandlerLogsBusyCheckpointBeforeOpeningDispatch(
+	t *testing.T,
+) {
+	logs := captureLogOutput(t)
+	opened := false
+	loggedBeforeOpen := false
+	handler := newStartupReconciliationHandler(
+		t.Context(),
+		func(context.Context) error { return db.ErrWALCheckpointBusy },
+		func() {
+			loggedBeforeOpen = strings.Contains(
+				logs.String(), db.ErrWALCheckpointBusy.Error(),
+			)
+			opened = true
+		},
+	)
+
+	handler(agentsync.SyncStats{}, nil)
+
+	assert.Contains(t, logs.String(), "post-sync wal checkpoint")
+	assert.Contains(t, logs.String(), db.ErrWALCheckpointBusy.Error())
+	assert.True(t, loggedBeforeOpen, "busy checkpoint must be logged before dispatch")
+	assert.True(t, opened,
+		"busy checkpoint is logged but committed reconciliation still opens dispatch")
+}
+
+func TestStartFileWatcherKeepsPollingWhenAnyPendingRootLacksCoverage(t *testing.T) {
+	root := t.TempDir()
+	roots := []watchRoot{
+		{path: filepath.Join(root, "state", "sessions"), recursive: true, scopes: []watchScope{{agent: parser.AgentDevin, syncDir: root}}},
+		{path: filepath.Join(root, "state", "archive"), recursive: true, scopes: []watchScope{{agent: parser.AgentDevin, syncDir: root}}},
+	}
+
+	got := accountRegisteredWatchRoots(
+		[]string{root}, roots,
+		[]agentsync.RecursiveWatchResult{{Watched: 1}, {Unwatched: 1, Err: errors.New("descriptor unavailable")}},
+	)
+
+	assert.Equal(t, []string{root}, got)
+}
+
+func TestStartFileWatcherKeepsPollingForIndependentReasonAfterPendingCoverage(t *testing.T) {
+	root := t.TempDir()
+	roots := []watchRoot{
+		{
+			path: filepath.Join(root, "state", "sessions"), recursive: true,
+			scopes:             []watchScope{{agent: parser.AgentDevin, syncDir: root}},
+			pendingPollingDirs: []string{root},
+		},
+		{
+			path: root, exists: true,
+			scopes:                []watchScope{{agent: parser.AgentDevin, syncDir: root}},
+			persistentPollingDirs: []string{root},
+		},
+	}
+
+	got := accountRegisteredWatchRoots(
+		[]string{root}, roots,
+		[]agentsync.RecursiveWatchResult{{
+			Watched:                   1,
+			MissingRootLifecycleOwned: true,
+		}, {Watched: 1}},
+	)
+
+	assert.Equal(t, []string{root}, got,
+		"covering a missing root must not erase an independent polling reason")
+}
+
+func TestWatchPollingObligationsMissingRootLifecycleCardinality(t *testing.T) {
+	for _, rootCount := range []int{1, 128} {
+		t.Run(fmt.Sprintf("roots=%d", rootCount), func(t *testing.T) {
+			base := t.TempDir()
+			roots := make([]watchRoot, 0, rootCount)
+			owned := make([]agentsync.RecursiveWatchResult, 0, rootCount)
+			portable := make([]agentsync.RecursiveWatchResult, 0, rootCount)
+			unwatched := make([]string, 0, rootCount)
+			for i := range rootCount {
+				syncDir := filepath.Join(base, fmt.Sprintf("agent-%03d", i))
+				roots = append(roots, watchRoot{
+					path:               filepath.Join(syncDir, "sessions"),
+					recursive:          true,
+					scopes:             []watchScope{{agent: parser.AgentClaude, syncDir: syncDir}},
+					pendingPollingDirs: []string{syncDir},
+				})
+				owned = append(owned, agentsync.RecursiveWatchResult{
+					Watched:                   1,
+					MissingRootLifecycleOwned: true,
+				})
+				portable = append(portable, agentsync.RecursiveWatchResult{})
+				unwatched = append(unwatched, syncDir)
+			}
+
+			assert.Empty(t, watchPollingObligations(roots, owned, nil),
+				"native lifecycle work must remain independent of configured archive cardinality")
+			assert.Len(t, watchPollingObligations(roots, portable, unwatched), rootCount,
+				"portable backends retain one obligation per uncovered missing root")
+		})
+	}
+}
+
+func TestOpenCodeFormatMissingRootsUseNativeLifecycleWithoutPolling(t *testing.T) {
+	for _, rootCount := range []int{1, 128} {
+		t.Run(fmt.Sprintf("roots=%d", rootCount), func(t *testing.T) {
+			base := t.TempDir()
+			dirs := make([]string, 0, rootCount)
+			for i := range rootCount {
+				dirs = append(dirs, filepath.Join(base, fmt.Sprintf("mimocode-%03d", i)))
+			}
+			cfg := config.Config{AgentDirs: map[parser.AgentType][]string{
+				parser.AgentMiMoCode: dirs,
+			}}
+
+			roots, unwatched, _ := collectWatchRoots(cfg)
+			require.Len(t, roots, rootCount)
+			results := make([]agentsync.RecursiveWatchResult, rootCount)
+			for i := range results {
+				results[i] = agentsync.RecursiveWatchResult{
+					Watched:                   1,
+					MissingRootLifecycleOwned: true,
+				}
+			}
+			unwatched = accountRegisteredWatchRoots(unwatched, roots, results)
+
+			assert.Empty(t, watchPollingObligations(roots, results, unwatched),
+				"absent OpenCode-format providers must not add archive-scale polling")
+		})
+	}
+}
+
+func TestWatchPollingObligationsKeepPendingAndPersistentReasonsIndependent(t *testing.T) {
+	shared := filepath.Join(t.TempDir(), "shared")
+	pendingPath := filepath.Join(shared, "pending")
+	roots := []watchRoot{
+		{
+			path:               pendingPath,
+			scopes:             []watchScope{{agent: parser.AgentDevin, syncDir: shared}},
+			pendingPollingDirs: []string{shared},
+		},
+		{
+			path: filepath.Join(shared, "existing"), exists: true,
+			scopes:                []watchScope{{agent: parser.AgentDevin, syncDir: shared}},
+			persistentPollingDirs: []string{shared},
+		},
+	}
+
+	got := watchPollingObligations(
+		roots,
+		[]agentsync.RecursiveWatchResult{{Watched: 1}, {Watched: 1}},
+		[]string{shared},
+	)
+
+	assert.Equal(t, []agentsync.PollingObligation{
+		{Key: pendingPath, Roots: []string{shared}, Probe: pendingPath},
+		{Key: "persistent:" + shared, Roots: []string{shared}, Probe: shared},
+	}, got)
+}
+
+func TestWatchPollingObligationsCoverRegistrationFailureByLogicalRoot(t *testing.T) {
+	syncDir := t.TempDir()
+	watchPath := filepath.Join(syncDir, "sessions")
+	roots := []watchRoot{{
+		path: watchPath, exists: true, recursive: true,
+		scopes: []watchScope{{agent: parser.AgentClaude, syncDir: syncDir}},
+	}}
+
+	got := watchPollingObligations(
+		roots,
+		[]agentsync.RecursiveWatchResult{{Unwatched: 1, Err: errors.New("watch failed")}},
+		[]string{syncDir},
+	)
+
+	assert.Equal(t, []agentsync.PollingObligation{{
+		Key: watchPath, Roots: []string{syncDir}, Probe: watchPath,
+	}}, got)
+}
+
+// A persistent polling obligation probes the configured dir, which can still
+// exist while a recursive symlink root's target holding every session is gone.
+// The symlink obligation must gate the dir on the target itself so the poll
+// coordinator defers the scope instead of reconciling the broken link as an
+// empty discovery.
+func TestSymlinkPollingObligationsGateDirsOnTargetAvailability(t *testing.T) {
+	parent := t.TempDir()
+	target := filepath.Join(t.TempDir(), "codex-target")
+	require.NoError(t, os.MkdirAll(target, 0o755))
+	symRoot := filepath.Join(parent, "sessions")
+	requireSymlinkOrSkip(t, target, symRoot)
+
+	obligations := symlinkPollingObligations(map[string][]string{
+		symRoot: {parent},
+	})
+	require.Equal(t, []agentsync.PollingObligation{{
+		Key: "symlink:" + symRoot, Roots: []string{parent}, Probe: symRoot,
+	}}, obligations)
+
+	combined := []pollingObligation{
+		{Key: "persistent:" + parent, Roots: []string{parent}, Probe: parent},
+		{Key: obligations[0].Key, Roots: obligations[0].Roots, Probe: obligations[0].Probe},
+	}
+	assert.Equal(t, []string{parent}, availableUnwatchedPollRoots(combined),
+		"a working symlink target keeps the dir pollable")
+
+	require.NoError(t, os.RemoveAll(target))
+	assert.Empty(t, availableUnwatchedPollRoots(combined),
+		"a broken symlink target must defer the dir even though the dir itself exists")
+}
+
+// TestWatcherUnavailableFallbackDefersBrokenSymlinkScope guards the
+// watcher-construction failure path: the coverage-degraded fallback poll
+// covers every configured dir, and a configured dir can still exist while
+// the recursive symlink root holding every session is broken. The failure
+// path must register the symlink target gates too, or the fallback poll
+// reconciles the dir as an authoritative empty discovery and tombstones
+// every baselined session beneath the symlink.
+func TestWatcherUnavailableFallbackDefersBrokenSymlinkScope(t *testing.T) {
+	parent := t.TempDir()
+	target := filepath.Join(t.TempDir(), "sessions-target")
+	require.NoError(t, os.MkdirAll(target, 0o755))
+	symRoot := filepath.Join(parent, "sessions")
+	requireSymlinkOrSkip(t, target, symRoot)
+	other := requireExistingPollRoot(t, t.TempDir(), "other")
+
+	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 3)}
+	coordinator := newUnwatchedPollCoordinatorWithTicks(
+		t.Context(), syncer, make(chan time.Time), func() {},
+		func(run func()) { run() }, nil,
+	)
+	t.Cleanup(coordinator.Stop)
+	options := agentsync.WatcherOptions{
+		OnCoverageDegraded: func(roots []string) error {
+			return coordinator.AddObligation(pollingObligation{
+				Key: "watcher-fallback", Roots: roots,
+			})
+		},
+		OnPollingRequired: func(obligation agentsync.PollingObligation) error {
+			return coordinator.AddObligation(pollingObligation{
+				Key:   obligation.Key,
+				Roots: obligation.Roots,
+				Probe: obligation.Probe,
+			})
+		},
+	}
+
+	require.NoError(t, registerWatcherUnavailableObligations(
+		options,
+		nil,
+		[]string{parent, other},
+		map[string][]string{symRoot: {parent}},
+	))
+
+	bothDirs := []string{parent, other}
+	slices.Sort(bothDirs)
+	coordinator.requestPoll()
+	requirePollWithin(t, syncer.wake, time.Second)
+	assert.Equal(t, [][]string{bothDirs}, syncer.snapshot(),
+		"a working symlink target keeps the configured dir pollable")
+
+	require.NoError(t, os.RemoveAll(target))
+	coordinator.requestPoll()
+	requirePollWithin(t, syncer.wake, time.Second)
+	assert.Equal(t, [][]string{bothDirs, {other}}, syncer.snapshot(),
+		"a broken symlink target must defer the configured dir from the fallback poll")
+
+	require.NoError(t, os.MkdirAll(target, 0o755))
+	coordinator.requestPoll()
+	requirePollWithin(t, syncer.wake, time.Second)
+	assert.Equal(t, [][]string{bothDirs, {other}, bothDirs}, syncer.snapshot(),
+		"the deferred dir must resume once the symlink target returns")
+}
+
+// TestWatcherUnavailableFallbackDefersMissingNestedRootScope guards the same
+// watcher-construction failure path for physical nested watch roots: a
+// configured dir can exist while the nested root holding every session (for
+// example Gemini's <dir>/tmp) is missing. The failure path must register the
+// root-keyed probe obligations from watchPollingObligations too, or the
+// fallback poll reconciles the dir as an authoritative empty discovery and
+// tombstones every baselined session beneath the missing root.
+func TestWatcherUnavailableFallbackDefersMissingNestedRootScope(t *testing.T) {
+	parent := t.TempDir()
+	nestedRoot := filepath.Join(parent, "tmp")
+	other := requireExistingPollRoot(t, t.TempDir(), "other")
+
+	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 2)}
+	coordinator := newUnwatchedPollCoordinatorWithTicks(
+		t.Context(), syncer, make(chan time.Time), func() {},
+		func(run func()) { run() }, nil,
+	)
+	t.Cleanup(coordinator.Stop)
+	options := agentsync.WatcherOptions{
+		OnCoverageDegraded: func(roots []string) error {
+			return coordinator.AddObligation(pollingObligation{
+				Key: "watcher-fallback", Roots: roots,
+			})
+		},
+		OnPollingRequired: func(obligation agentsync.PollingObligation) error {
+			return coordinator.AddObligation(pollingObligation{
+				Key:   obligation.Key,
+				Roots: obligation.Roots,
+				Probe: obligation.Probe,
+			})
+		},
+	}
+	roots := []watchRoot{{
+		path:               nestedRoot,
+		recursive:          true,
+		scopes:             []watchScope{{agent: parser.AgentGemini, syncDir: parent}},
+		pendingPollingDirs: []string{parent},
+	}}
+
+	require.NoError(t, registerWatcherUnavailableObligations(
+		options, roots, []string{parent, other}, nil,
+	))
+
+	coordinator.requestPoll()
+	requirePollWithin(t, syncer.wake, time.Second)
+	assert.Equal(t, [][]string{{other}}, syncer.snapshot(),
+		"a missing nested watch root must defer the configured dir from the fallback poll")
+
+	require.NoError(t, os.MkdirAll(nestedRoot, 0o755))
+	bothDirs := []string{parent, other}
+	slices.Sort(bothDirs)
+	coordinator.requestPoll()
+	requirePollWithin(t, syncer.wake, time.Second)
+	assert.Equal(t, [][]string{{other}, bothDirs}, syncer.snapshot(),
+		"the deferred dir must rejoin the poll once the nested root is restored")
+}
+
+// TestWatcherUnavailableFallbackDefersNestedRootLostAfterRegistration guards
+// the watcher-construction failure path for a nested physical root that still
+// exists when the obligations are installed. Only roots already missing at
+// collection time populate pendingPollingDirs, so without a probe obligation
+// for every physical watch root a nested root that disappears after
+// registration leaves its configured dir pollable, and the fallback poll would
+// reconcile it as an authoritative empty discovery and tombstone every
+// baselined session beneath it.
+func TestWatcherUnavailableFallbackDefersNestedRootLostAfterRegistration(t *testing.T) {
+	parent := t.TempDir()
+	nestedRoot := filepath.Join(parent, "tmp")
+	require.NoError(t, os.MkdirAll(nestedRoot, 0o755))
+	other := requireExistingPollRoot(t, t.TempDir(), "other")
+
+	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 3)}
+	coordinator := newUnwatchedPollCoordinatorWithTicks(
+		t.Context(), syncer, make(chan time.Time), func() {},
+		func(run func()) { run() }, nil,
+	)
+	t.Cleanup(coordinator.Stop)
+	options := agentsync.WatcherOptions{
+		OnCoverageDegraded: func(roots []string) error {
+			return coordinator.AddObligation(pollingObligation{
+				Key: "watcher-fallback", Roots: roots,
+			})
+		},
+		OnPollingRequired: func(obligation agentsync.PollingObligation) error {
+			return coordinator.AddObligation(pollingObligation{
+				Key:   obligation.Key,
+				Roots: obligation.Roots,
+				Probe: obligation.Probe,
+			})
+		},
+	}
+	roots := []watchRoot{{
+		path:      nestedRoot,
+		recursive: true,
+		exists:    true,
+		scopes:    []watchScope{{agent: parser.AgentGemini, syncDir: parent}},
+	}}
+
+	require.NoError(t, registerWatcherUnavailableObligations(
+		options, roots, []string{parent, other}, nil,
+	))
+
+	bothDirs := []string{parent, other}
+	slices.Sort(bothDirs)
+	coordinator.requestPoll()
+	requirePollWithin(t, syncer.wake, time.Second)
+	assert.Equal(t, [][]string{bothDirs}, syncer.snapshot(),
+		"a present nested watch root keeps the configured dir pollable")
+
+	require.NoError(t, os.RemoveAll(nestedRoot))
+	coordinator.requestPoll()
+	requirePollWithin(t, syncer.wake, time.Second)
+	assert.Equal(t, [][]string{bothDirs, {other}}, syncer.snapshot(),
+		"a nested root lost after registration must defer the configured dir")
+
+	require.NoError(t, os.MkdirAll(nestedRoot, 0o755))
+	coordinator.requestPoll()
+	requirePollWithin(t, syncer.wake, time.Second)
+	assert.Equal(t, [][]string{bothDirs, {other}, bothDirs}, syncer.snapshot(),
+		"the deferred dir must rejoin the poll once the nested root is restored")
+}
+
+// TestWatcherUnavailableObligationsGateBeforeFallback snapshots the pollable
+// roots after every synchronous registration step. The poll coordinator's
+// ticker is already live when registerWatcherUnavailableObligations runs, so
+// a tick landing between two registrations polls whatever is installed at
+// that instant; the ungated watcher-fallback obligation must therefore land
+// only after every probe gate, or the intermediate poll reconciles a scope
+// whose missing nested root has no gate yet and tombstones its sessions.
+func TestWatcherUnavailableObligationsGateBeforeFallback(t *testing.T) {
+	parent := t.TempDir()
+	nestedRoot := filepath.Join(parent, "tmp")
+	other := requireExistingPollRoot(t, t.TempDir(), "other")
+
+	var coordinator *sharedUnwatchedPollCoordinator
+	var stepAvailable [][]string
+	coordinator = newUnwatchedPollCoordinatorWithTicks(
+		t.Context(),
+		&recordingUnwatchedPollSyncer{wake: make(chan struct{}, 8)},
+		make(chan time.Time), func() {}, func(run func()) { run() },
+		func([]string) {
+			stepAvailable = append(stepAvailable,
+				availableUnwatchedPollRoots(coordinator.currentPollObligations()))
+		},
+	)
+	t.Cleanup(coordinator.Stop)
+	options := agentsync.WatcherOptions{
+		OnCoverageDegraded: func(roots []string) error {
+			return coordinator.AddObligation(pollingObligation{
+				Key: "watcher-fallback", Roots: roots,
+			})
+		},
+		OnPollingRequired: func(obligation agentsync.PollingObligation) error {
+			return coordinator.AddObligation(pollingObligation{
+				Key:   obligation.Key,
+				Roots: obligation.Roots,
+				Probe: obligation.Probe,
+			})
+		},
+	}
+	roots := []watchRoot{{
+		path:               nestedRoot,
+		recursive:          true,
+		scopes:             []watchScope{{agent: parser.AgentGemini, syncDir: parent}},
+		pendingPollingDirs: []string{parent},
+	}}
+
+	require.NoError(t, registerWatcherUnavailableObligations(
+		options, roots, []string{parent, other}, nil,
+	))
+
+	require.NotEmpty(t, stepAvailable)
+	for step, available := range stepAvailable {
+		assert.NotContains(t, available, parent,
+			"registration step %d exposed a scope whose nested root is missing",
+			step)
+	}
+	assert.Contains(t, stepAvailable[len(stepAvailable)-1], other,
+		"the completed registration keeps unaffected dirs pollable")
+}
+
 func findCollectedWatchRoot(roots []watchRoot, path string) (watchRoot, bool) {
 	path = filepath.Clean(path)
 	for _, root := range roots {
-		if filepath.Clean(root.root) == path {
+		if filepath.Clean(root.path) == path {
 			return root, true
 		}
 	}
@@ -1490,52 +2159,1058 @@ func TestSchemaUpgradeHint(t *testing.T) {
 }
 
 type watchSyncRecorder struct {
-	pathCalls          [][]string
-	fullCalls          int
-	fullProgressNonNil bool
-	ctxValue           any
+	pathCalls      [][]string
+	pathErr        error
+	lookupResults  map[string]bool
+	lookupCalls    [][2]string
+	reconcileCalls []watchReconcileCall
+	reconcileRoots map[string][]string
+	reconcileErr   error
+	callOrder      []string
+	ctxValue       any
 }
 
-func (r *watchSyncRecorder) SyncPathsContext(ctx context.Context, paths []string) {
+type watchReconcileCall struct {
+	roots      []string
+	full       bool
+	lostEvents bool
+}
+
+type watchRetryBatchError interface {
+	error
+	WatchRetryBatch() agentsync.WatchBatch
+}
+
+type scopedReconciliationError struct {
+	roots []string
+}
+
+func (e scopedReconciliationError) Error() string { return "partial reconciliation" }
+
+func (e scopedReconciliationError) ReconciliationRetryRoots() []string {
+	return append([]string(nil), e.roots...)
+}
+
+// staticFullRoots stubs syncWatchBatch's probed recovery scope with a fixed
+// available root list; no arguments means no scope is physically available.
+func staticFullRoots(roots ...string) func() watchRecoveryScope {
+	return func() watchRecoveryScope {
+		return watchRecoveryScope{available: roots}
+	}
+}
+
+func requireWatchRetryBatch(t *testing.T, err error) agentsync.WatchBatch {
+	t.Helper()
+	var retryErr watchRetryBatchError
+	require.ErrorAs(t, err, &retryErr)
+	return retryErr.WatchRetryBatch()
+}
+
+func (r *watchSyncRecorder) SyncPathsContext(ctx context.Context, paths []string) error {
 	r.pathCalls = append(r.pathCalls, append([]string(nil), paths...))
+	r.callOrder = append(r.callOrder, "paths")
 	r.ctxValue = ctx.Value(watchSyncContextKey{})
+	return r.pathErr
 }
 
-func (r *watchSyncRecorder) SyncAllAfterWatcherOverflow(
-	ctx context.Context, progress agentsync.ProgressFunc,
-) agentsync.SyncStats {
-	r.fullCalls++
-	r.fullProgressNonNil = progress != nil
+func (r *watchSyncRecorder) HasActiveSessionSourceBelow(agent, path string) (bool, error) {
+	r.lookupCalls = append(r.lookupCalls, [2]string{agent, path})
+	return r.lookupResults[agent+"\x00"+path], nil
+}
+
+func (r *watchSyncRecorder) ReconciliationRootsForAgent(agent string) []string {
+	return append([]string(nil), r.reconcileRoots[agent]...)
+}
+
+func (r *watchSyncRecorder) ReconcileWatchRoots(
+	ctx context.Context, roots []string, full bool,
+) error {
+	r.reconcileCalls = append(r.reconcileCalls, watchReconcileCall{
+		roots: append([]string(nil), roots...),
+		full:  full,
+	})
+	r.callOrder = append(r.callOrder, "reconcile")
 	r.ctxValue = ctx.Value(watchSyncContextKey{})
-	return agentsync.SyncStats{}
+	return r.reconcileErr
+}
+
+func (r *watchSyncRecorder) ReconcileWatchRootsAfterLostEvents(
+	ctx context.Context, roots []string, full bool,
+) error {
+	r.reconcileCalls = append(r.reconcileCalls, watchReconcileCall{
+		roots:      append([]string(nil), roots...),
+		full:       full,
+		lostEvents: true,
+	})
+	r.callOrder = append(r.callOrder, "reconcile")
+	r.ctxValue = ctx.Value(watchSyncContextKey{})
+	return r.reconcileErr
 }
 
 type watchSyncContextKey struct{}
 
-func TestSyncWatchBatchRoutesOverflowToFullSync(t *testing.T) {
+func TestSyncWatchBatch(t *testing.T) {
 	ctx := context.WithValue(context.Background(), watchSyncContextKey{}, "serve")
+	tempDir := t.TempDir()
+	filePath := filepath.Join(tempDir, "session.jsonl")
+	require.NoError(t, os.WriteFile(filePath, []byte("session"), 0o600))
+	dirPath := filepath.Join(tempDir, "renamed-dir")
+	require.NoError(t, os.Mkdir(dirPath, 0o700))
+	missingPath := filepath.Join(tempDir, "missing")
+	root := filepath.Join(tempDir, "root")
+	probedRoot := filepath.Join(tempDir, "probed-root")
+	agent := string(parser.AgentCodex)
 
-	t.Run("ordinary paths", func(t *testing.T) {
+	t.Run("file rename uses changed path", func(t *testing.T) {
 		recorder := &watchSyncRecorder{}
-		syncWatchBatch(ctx, recorder, agentsync.WatchBatch{
-			Paths: []string{"/sessions/a.jsonl", "/sessions/b.jsonl"},
+		err := syncWatchBatch(ctx, recorder, agentsync.WatchBatch{Renames: []agentsync.WatchRename{{
+			Path: filePath, Root: root, Agent: agent, ItemType: agentsync.ItemIsFile,
+		}}}, staticFullRoots(probedRoot))
+
+		require.NoError(t, err)
+		assert.Equal(t, [][]string{{filePath}}, recorder.pathCalls)
+		assert.Empty(t, recorder.lookupCalls)
+		assert.Empty(t, recorder.reconcileCalls)
+		assert.Equal(t, "serve", recorder.ctxValue)
+	})
+
+	t.Run("directory rename reconciles only owning provider roots", func(t *testing.T) {
+		otherRoot := filepath.Join(tempDir, "other-root")
+		recorder := &watchSyncRecorder{reconcileRoots: map[string][]string{
+			agent: {root, otherRoot},
+		}}
+		err := syncWatchBatch(ctx, recorder, agentsync.WatchBatch{Renames: []agentsync.WatchRename{{
+			Path: dirPath, Root: root, Agent: agent, ItemType: agentsync.ItemIsDir,
+		}}}, staticFullRoots(probedRoot, root, otherRoot))
+
+		require.NoError(t, err)
+		assert.Empty(t, recorder.pathCalls)
+		assert.Empty(t, recorder.lookupCalls)
+		assert.Equal(t, []watchReconcileCall{{roots: []string{root, otherRoot}}}, recorder.reconcileCalls)
+	})
+
+	t.Run("directory rename defers unavailable provider roots", func(t *testing.T) {
+		otherRoot := filepath.Join(tempDir, "other-root")
+		recorder := &watchSyncRecorder{reconcileRoots: map[string][]string{
+			agent: {root, otherRoot},
+		}}
+		err := syncWatchBatch(ctx, recorder, agentsync.WatchBatch{Renames: []agentsync.WatchRename{{
+			Path: dirPath, Root: root, Agent: agent, ItemType: agentsync.ItemIsDir,
+		}}}, staticFullRoots(probedRoot, root))
+
+		require.NoError(t, err)
+		assert.Empty(t, recorder.pathCalls)
+		assert.Equal(t, []watchReconcileCall{{roots: []string{root}}}, recorder.reconcileCalls,
+			"an unavailable sibling root must be deferred, not reconciled as empty")
+	})
+
+	t.Run("directory rename with no available provider root defers entirely", func(t *testing.T) {
+		recorder := &watchSyncRecorder{reconcileRoots: map[string][]string{
+			agent: {root},
+		}}
+		err := syncWatchBatch(ctx, recorder, agentsync.WatchBatch{Renames: []agentsync.WatchRename{{
+			Path: dirPath, Root: root, Agent: agent, ItemType: agentsync.ItemIsDir,
+		}}}, staticFullRoots(probedRoot))
+
+		require.NoError(t, err)
+		assert.Empty(t, recorder.pathCalls)
+		assert.Empty(t, recorder.reconcileCalls,
+			"a fully unavailable provider scope defers to its polling probes instead of escalating")
+	})
+
+	t.Run("directory rename defers a root overlapping a deferred scope", func(t *testing.T) {
+		nested := filepath.Join(root, "mounted")
+		recorder := &watchSyncRecorder{reconcileRoots: map[string][]string{
+			agent: {root},
+		}}
+		err := syncWatchBatch(ctx, recorder, agentsync.WatchBatch{Renames: []agentsync.WatchRename{{
+			Path: dirPath, Root: root, Agent: agent, ItemType: agentsync.ItemIsDir,
+		}}}, func() watchRecoveryScope {
+			return watchRecoveryScope{
+				available: []string{filepath.Join(root, "sub")},
+				deferred:  map[string]struct{}{nested: {}},
+			}
 		})
 
-		assert.Equal(t, [][]string{{
-			"/sessions/a.jsonl",
-			"/sessions/b.jsonl",
-		}}, recorder.pathCalls)
-		assert.Zero(t, recorder.fullCalls)
-		assert.Equal(t, "serve", recorder.ctxValue)
+		require.NoError(t, err)
+		assert.Empty(t, recorder.reconcileCalls,
+			"a root whose expansion overlaps a deferred scope must be deferred with it")
 	})
 
-	t.Run("overflow", func(t *testing.T) {
+	t.Run("directory rename includes every shared-root owner", func(t *testing.T) {
+		claude := string(parser.AgentClaude)
+		claudeRoot := filepath.Join(tempDir, "claude-root")
+		recorder := &watchSyncRecorder{reconcileRoots: map[string][]string{
+			agent:  {root},
+			claude: {claudeRoot},
+		}}
+		err := syncWatchBatch(ctx, recorder, agentsync.WatchBatch{Renames: []agentsync.WatchRename{
+			{Path: dirPath, Root: root, Agent: agent, ItemType: agentsync.ItemIsDir},
+			{Path: dirPath, Root: root, Agent: claude, ItemType: agentsync.ItemIsDir},
+		}}, staticFullRoots(probedRoot, root, claudeRoot))
+
+		require.NoError(t, err)
+		assert.Equal(t, []watchReconcileCall{{roots: []string{root, claudeRoot}}}, recorder.reconcileCalls)
+	})
+
+	t.Run("unknown rename stats file", func(t *testing.T) {
 		recorder := &watchSyncRecorder{}
-		syncWatchBatch(ctx, recorder, agentsync.WatchBatch{FullSync: true})
+		err := syncWatchBatch(ctx, recorder, agentsync.WatchBatch{Renames: []agentsync.WatchRename{{
+			Path: filePath, Root: root, Agent: agent, ItemType: agentsync.ItemIsUnknown,
+		}}}, staticFullRoots(probedRoot))
 
+		require.NoError(t, err)
+		assert.Equal(t, [][]string{{filePath}}, recorder.pathCalls)
+		assert.Empty(t, recorder.lookupCalls)
+		assert.Empty(t, recorder.reconcileCalls)
+	})
+
+	for _, tc := range []struct {
+		name     string
+		itemType agentsync.WatchItemType
+		path     string
+	}{
+		{name: "directory metadata", itemType: agentsync.ItemIsDir, path: missingPath},
+		{name: "unknown rename stats directory", itemType: agentsync.ItemIsUnknown, path: dirPath},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			recorder := &watchSyncRecorder{}
+			err := syncWatchBatch(ctx, recorder, agentsync.WatchBatch{Renames: []agentsync.WatchRename{{
+				Path: tc.path, Root: root, Agent: agent, ItemType: tc.itemType,
+			}}}, staticFullRoots(probedRoot))
+
+			require.NoError(t, err)
+			assert.Empty(t, recorder.pathCalls)
+			assert.Empty(t, recorder.lookupCalls)
+			assert.Equal(t, []watchReconcileCall{{roots: []string{probedRoot}}}, recorder.reconcileCalls)
+		})
+	}
+
+	t.Run("missing unknown with active descendant reconciles fully", func(t *testing.T) {
+		recorder := &watchSyncRecorder{lookupResults: map[string]bool{
+			agent + "\x00" + missingPath: true,
+		}}
+		err := syncWatchBatch(ctx, recorder, agentsync.WatchBatch{Renames: []agentsync.WatchRename{{
+			Path: missingPath, Root: root, Agent: agent, ItemType: agentsync.ItemIsUnknown,
+		}}}, staticFullRoots(probedRoot))
+
+		require.NoError(t, err)
 		assert.Empty(t, recorder.pathCalls)
-		assert.Equal(t, 1, recorder.fullCalls)
-		assert.False(t, recorder.fullProgressNonNil)
+		assert.Equal(t, [][2]string{{agent, missingPath}}, recorder.lookupCalls)
+		assert.Equal(t, []watchReconcileCall{{roots: []string{probedRoot}}}, recorder.reconcileCalls)
+	})
+
+	t.Run("missing unknown without active descendant emits tombstone path", func(t *testing.T) {
+		recorder := &watchSyncRecorder{}
+		err := syncWatchBatch(ctx, recorder, agentsync.WatchBatch{Renames: []agentsync.WatchRename{{
+			Path: missingPath, Root: root, Agent: agent, ItemType: agentsync.ItemIsUnknown,
+		}}}, staticFullRoots(probedRoot))
+
+		require.NoError(t, err)
+		assert.Equal(t, [][]string{{missingPath}}, recorder.pathCalls)
+		assert.Equal(t, [][2]string{{agent, missingPath}}, recorder.lookupCalls)
+		assert.Empty(t, recorder.reconcileCalls)
+	})
+
+	t.Run("overlapping unrelated agent source does not promote", func(t *testing.T) {
+		recorder := &watchSyncRecorder{lookupResults: map[string]bool{
+			string(parser.AgentClaude) + "\x00" + missingPath: true,
+		}}
+		err := syncWatchBatch(ctx, recorder, agentsync.WatchBatch{Renames: []agentsync.WatchRename{{
+			Path: missingPath, Root: root, Agent: agent, ItemType: agentsync.ItemIsUnknown,
+		}}}, staticFullRoots(probedRoot))
+
+		require.NoError(t, err)
+		assert.Equal(t, [][2]string{{agent, missingPath}}, recorder.lookupCalls)
+		assert.Equal(t, [][]string{{missingPath}}, recorder.pathCalls)
+		assert.Empty(t, recorder.reconcileCalls)
+	})
+
+	t.Run("any exact shared-root owner can promote", func(t *testing.T) {
+		claude := string(parser.AgentClaude)
+		recorder := &watchSyncRecorder{lookupResults: map[string]bool{
+			claude + "\x00" + missingPath: true,
+		}}
+		err := syncWatchBatch(ctx, recorder, agentsync.WatchBatch{Renames: []agentsync.WatchRename{
+			{Path: missingPath, Root: root, Agent: claude, ItemType: agentsync.ItemIsUnknown},
+			{Path: missingPath, Root: root, Agent: agent, ItemType: agentsync.ItemIsUnknown},
+		}}, staticFullRoots(probedRoot))
+
+		require.NoError(t, err)
+		assert.Equal(t, [][2]string{{claude, missingPath}, {agent, missingPath}}, recorder.lookupCalls)
+		assert.Empty(t, recorder.pathCalls)
+		assert.Equal(t, []watchReconcileCall{{roots: []string{probedRoot}}}, recorder.reconcileCalls)
+	})
+
+	t.Run("ordinary paths precede deduplicated root reconciliation", func(t *testing.T) {
+		recorder := &watchSyncRecorder{}
+		err := syncWatchBatch(ctx, recorder, agentsync.WatchBatch{
+			Paths:          []string{"/sessions/a.jsonl", "/sessions/b.jsonl"},
+			ReconcileRoots: []string{"/sessions", "/sessions"},
+		}, staticFullRoots(probedRoot))
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"paths", "reconcile"}, recorder.callOrder)
+		assert.Equal(t, []watchReconcileCall{{roots: []string{"/sessions"}}}, recorder.reconcileCalls)
+	})
+
+	t.Run("root-count overflow reconciles available roots", func(t *testing.T) {
+		recorder := &watchSyncRecorder{}
+		err := syncWatchBatch(ctx, recorder, agentsync.WatchBatch{
+			FullSync: true, LostEvents: true,
+		}, staticFullRoots(probedRoot))
+
+		require.NoError(t, err)
+		assert.Empty(t, recorder.pathCalls)
+		assert.Equal(t, []watchReconcileCall{{
+			roots: []string{probedRoot}, lostEvents: true,
+		}}, recorder.reconcileCalls)
 		assert.Equal(t, "serve", recorder.ctxValue)
 	})
+
+	t.Run("full recovery defers when no scope is physically available", func(t *testing.T) {
+		recorder := &watchSyncRecorder{}
+		err := syncWatchBatch(ctx, recorder, agentsync.WatchBatch{
+			FullSync: true, LostEvents: true,
+		}, staticFullRoots())
+
+		require.NoError(t, err)
+		assert.Empty(t, recorder.pathCalls)
+		assert.Empty(t, recorder.reconcileCalls,
+			"unavailable scopes must be deferred, not reconciled as empty")
+	})
+
+	t.Run("reconciliation error is returned for watcher retry", func(t *testing.T) {
+		reconcileErr := errors.New("provider discovery incomplete")
+		recorder := &watchSyncRecorder{reconcileErr: reconcileErr}
+
+		err := syncWatchBatch(ctx, recorder, agentsync.WatchBatch{
+			ReconcileRoots: []string{"/sessions"},
+		}, staticFullRoots(probedRoot))
+
+		assert.ErrorContains(t, err, reconcileErr.Error())
+		assert.Equal(t, []watchReconcileCall{{roots: []string{"/sessions"}}}, recorder.reconcileCalls)
+	})
+
+	t.Run("full reconciliation retries only failed provider roots", func(t *testing.T) {
+		failedRoot := "/sessions/unavailable-provider"
+		reconcileErr := scopedReconciliationError{roots: []string{failedRoot}}
+		recorder := &watchSyncRecorder{reconcileErr: reconcileErr}
+
+		err := syncWatchBatch(ctx, recorder, agentsync.WatchBatch{
+			FullSync: true, LostEvents: true,
+		}, staticFullRoots(probedRoot))
+
+		assert.ErrorContains(t, err, reconcileErr.Error())
+		assert.Equal(t, agentsync.WatchBatch{
+			ReconcileRoots: []string{failedRoot},
+			LostEvents:     true,
+		}, requireWatchRetryBatch(t, err))
+	})
+
+	t.Run("full recovery failure without scope retries the full batch", func(t *testing.T) {
+		reconcileErr := errors.New("provider discovery incomplete")
+		recorder := &watchSyncRecorder{reconcileErr: reconcileErr}
+
+		err := syncWatchBatch(ctx, recorder, agentsync.WatchBatch{
+			FullSync: true, LostEvents: true,
+		}, staticFullRoots(probedRoot))
+
+		assert.ErrorContains(t, err, reconcileErr.Error())
+		assert.Equal(t, agentsync.WatchBatch{FullSync: true, LostEvents: true},
+			requireWatchRetryBatch(t, err),
+			"the retry must stay full so the recovery re-probes availability")
+	})
+
+	t.Run("scoped lost-event retry keeps forced recovery", func(t *testing.T) {
+		root := "/sessions/unavailable-provider"
+		recorder := &watchSyncRecorder{}
+
+		err := syncWatchBatch(ctx, recorder, agentsync.WatchBatch{
+			ReconcileRoots: []string{root},
+			LostEvents:     true,
+		}, staticFullRoots(probedRoot))
+
+		require.NoError(t, err)
+		assert.Equal(t, []watchReconcileCall{{
+			roots: []string{root}, lostEvents: true,
+		}}, recorder.reconcileCalls)
+	})
+
+	t.Run("changed path failure retains the exact bounded batch", func(t *testing.T) {
+		pathErr := errors.New("archive write failed")
+		recorder := &watchSyncRecorder{pathErr: pathErr}
+
+		err := syncWatchBatch(ctx, recorder, agentsync.WatchBatch{
+			Paths: []string{"/sessions/a.jsonl", "/sessions/b.jsonl"},
+		}, staticFullRoots(probedRoot))
+
+		assert.ErrorIs(t, err, pathErr)
+		assert.Equal(t, agentsync.WatchBatch{
+			Paths: []string{"/sessions/a.jsonl", "/sessions/b.jsonl"},
+		}, requireWatchRetryBatch(t, err))
+		assert.Empty(t, recorder.reconcileCalls)
+	})
+
+	t.Run("changed path failure retains pending root reconciliation", func(t *testing.T) {
+		pathErr := errors.New("archive write failed")
+		recorder := &watchSyncRecorder{pathErr: pathErr}
+
+		err := syncWatchBatch(ctx, recorder, agentsync.WatchBatch{
+			Paths:          []string{"/sessions/a.jsonl"},
+			ReconcileRoots: []string{"/sessions", "/sessions"},
+		}, staticFullRoots(probedRoot))
+
+		assert.ErrorIs(t, err, pathErr)
+		assert.Equal(t, agentsync.WatchBatch{
+			Paths:          []string{"/sessions/a.jsonl"},
+			ReconcileRoots: []string{"/sessions"},
+		}, requireWatchRetryBatch(t, err))
+		assert.Empty(t, recorder.reconcileCalls)
+	})
+
+	t.Run("changed path failure retains directory rename reconciliation", func(t *testing.T) {
+		pathErr := errors.New("archive write failed")
+		recorder := &watchSyncRecorder{pathErr: pathErr}
+
+		err := syncWatchBatch(ctx, recorder, agentsync.WatchBatch{
+			Paths: []string{"/sessions/a.jsonl"},
+			Renames: []agentsync.WatchRename{{
+				Path: dirPath, Root: root, Agent: agent, ItemType: agentsync.ItemIsDir,
+			}},
+		}, staticFullRoots(probedRoot))
+
+		assert.ErrorIs(t, err, pathErr)
+		assert.Equal(t, agentsync.WatchBatch{FullSync: true}, requireWatchRetryBatch(t, err))
+		assert.Empty(t, recorder.reconcileCalls)
+	})
+}
+
+type stubRetryRootsError struct{ roots []string }
+
+func (e *stubRetryRootsError) Error() string { return "reconciliation incomplete" }
+
+func (e *stubRetryRootsError) ReconciliationRetryRoots() []string { return e.roots }
+
+// TestGapReconciliationRetryBatch pins the startup-gap classification: a gap
+// reconciliation error carrying retry roots yields a scoped retry batch, and
+// any other failure escalates to an authoritative full sync.
+func TestGapReconciliationRetryBatch(t *testing.T) {
+	scoped := gapReconciliationRetryBatch(fmt.Errorf(
+		"gap: %w", &stubRetryRootsError{roots: []string{"/b", "/a", "/a"}},
+	))
+	assert.Equal(t, agentsync.WatchBatch{
+		ReconcileRoots: []string{"/b", "/a"},
+	}, scoped)
+
+	full := gapReconciliationRetryBatch(errors.New("plain failure"))
+	assert.Equal(t, agentsync.WatchBatch{FullSync: true}, full)
+
+	empty := gapReconciliationRetryBatch(fmt.Errorf(
+		"gap: %w", &stubRetryRootsError{},
+	))
+	assert.Equal(t, agentsync.WatchBatch{FullSync: true}, empty,
+		"an empty retry scope must escalate to a full sync")
+}
+
+func TestSyncWatchBatchReportsClassifiedReconciliationRetryScope(t *testing.T) {
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	filePath := filepath.Join(tempDir, "session.jsonl")
+	require.NoError(t, os.WriteFile(filePath, []byte("session"), 0o600))
+	dirPath := filepath.Join(tempDir, "renamed-dir")
+	require.NoError(t, os.Mkdir(dirPath, 0o700))
+	missingPath := filepath.Join(tempDir, "missing")
+	root := filepath.Join(tempDir, "root")
+	probedRoot := filepath.Join(tempDir, "probed-root")
+	agent := string(parser.AgentCodex)
+	reconcileErr := errors.New("provider discovery incomplete")
+
+	t.Run("unknown rename that stats as file retries roots", func(t *testing.T) {
+		recorder := &watchSyncRecorder{reconcileErr: reconcileErr}
+		err := syncWatchBatch(ctx, recorder, agentsync.WatchBatch{
+			Renames: []agentsync.WatchRename{{
+				Path: filePath, Root: root, Agent: agent,
+				ItemType: agentsync.ItemIsUnknown,
+			}},
+			ReconcileRoots: []string{root, root},
+		}, staticFullRoots(probedRoot))
+
+		assert.ErrorIs(t, err, reconcileErr)
+		assert.Equal(t, agentsync.WatchBatch{
+			ReconcileRoots: []string{root},
+		}, requireWatchRetryBatch(t, err))
+		assert.Equal(t, [][]string{{filePath}}, recorder.pathCalls)
+		assert.Empty(t, recorder.lookupCalls)
+		assert.Equal(t, []watchReconcileCall{{roots: []string{root}}}, recorder.reconcileCalls)
+	})
+
+	t.Run("missing unknown rename with negative lookup retries roots", func(t *testing.T) {
+		recorder := &watchSyncRecorder{reconcileErr: reconcileErr}
+		err := syncWatchBatch(ctx, recorder, agentsync.WatchBatch{
+			Renames: []agentsync.WatchRename{{
+				Path: missingPath, Root: root, Agent: agent,
+				ItemType: agentsync.ItemIsUnknown,
+			}},
+			ReconcileRoots: []string{root, root},
+		}, staticFullRoots(probedRoot))
+
+		assert.ErrorIs(t, err, reconcileErr)
+		assert.Equal(t, agentsync.WatchBatch{
+			ReconcileRoots: []string{root},
+		}, requireWatchRetryBatch(t, err))
+		assert.Equal(t, [][]string{{missingPath}}, recorder.pathCalls)
+		assert.Equal(t, [][2]string{{agent, missingPath}}, recorder.lookupCalls)
+		assert.Equal(t, []watchReconcileCall{{roots: []string{root}}}, recorder.reconcileCalls)
+	})
+
+	t.Run("directory rename retries full reconciliation", func(t *testing.T) {
+		recorder := &watchSyncRecorder{reconcileErr: reconcileErr}
+		err := syncWatchBatch(ctx, recorder, agentsync.WatchBatch{Renames: []agentsync.WatchRename{{
+			Path: dirPath, Root: root, Agent: agent,
+			ItemType: agentsync.ItemIsDir,
+		}}}, staticFullRoots(probedRoot))
+
+		assert.ErrorIs(t, err, reconcileErr)
+		assert.Equal(t, agentsync.WatchBatch{FullSync: true}, requireWatchRetryBatch(t, err))
+		assert.Empty(t, recorder.pathCalls)
+		assert.Empty(t, recorder.lookupCalls)
+		assert.Equal(t, []watchReconcileCall{{roots: []string{probedRoot}}}, recorder.reconcileCalls)
+	})
+
+	t.Run("missing unknown rename with positive lookup retries full reconciliation", func(t *testing.T) {
+		recorder := &watchSyncRecorder{
+			reconcileErr: reconcileErr,
+			lookupResults: map[string]bool{
+				agent + "\x00" + missingPath: true,
+			},
+		}
+		err := syncWatchBatch(ctx, recorder, agentsync.WatchBatch{Renames: []agentsync.WatchRename{{
+			Path: missingPath, Root: root, Agent: agent,
+			ItemType: agentsync.ItemIsUnknown,
+		}}}, staticFullRoots(probedRoot))
+
+		assert.ErrorIs(t, err, reconcileErr)
+		assert.Equal(t, agentsync.WatchBatch{FullSync: true}, requireWatchRetryBatch(t, err))
+		assert.Empty(t, recorder.pathCalls)
+		assert.Equal(t, [][2]string{{agent, missingPath}}, recorder.lookupCalls)
+		assert.Equal(t, []watchReconcileCall{{roots: []string{probedRoot}}}, recorder.reconcileCalls)
+	})
+}
+
+// The serve daemon installs its default soft memory limit only when the
+// operator has not set GOMEMLIMIT themselves.
+func TestApplyServeMemoryLimit(t *testing.T) {
+	prev := debug.SetMemoryLimit(-1)
+	t.Cleanup(func() { debug.SetMemoryLimit(prev) })
+
+	t.Run("sets the default when GOMEMLIMIT is unset", func(t *testing.T) {
+		t.Setenv("GOMEMLIMIT", "")
+		debug.SetMemoryLimit(math.MaxInt64)
+		applyServeMemoryLimit()
+		assert.Equal(t, int64(serveMemoryLimitBytes),
+			debug.SetMemoryLimit(-1))
+	})
+
+	t.Run("respects an operator override", func(t *testing.T) {
+		t.Setenv("GOMEMLIMIT", "1GiB")
+		debug.SetMemoryLimit(math.MaxInt64)
+		applyServeMemoryLimit()
+		assert.Equal(t, int64(math.MaxInt64), debug.SetMemoryLimit(-1))
+	})
+}
+
+// An absent configured root (unmounted volume, deleted directory) or a
+// present root whose physical session subtree is missing (Gemini's
+// <root>/tmp) streams an empty discovery without error, so the gap
+// reconciliation and archive audit must defer those scopes instead of
+// tombstoning every session beneath them.
+func TestReconcileRootPathsDefersUnavailableScopes(t *testing.T) {
+	presentDir := t.TempDir()
+	missingDir := filepath.Join(t.TempDir(), "gone")
+	geminiRoot := t.TempDir()
+	cfg := config.Config{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {presentDir, missingDir},
+			parser.AgentGemini: {geminiRoot},
+		},
+	}
+
+	paths := reconcileRootPaths(cfg)
+
+	assert.Contains(t, paths, presentDir)
+	assert.NotContains(t, paths, missingDir,
+		"an absent configured root must be deferred, not reconciled as empty")
+	assert.NotContains(t, paths, geminiRoot,
+		"a configured dir whose physical session subtree is missing keeps that subtree as its probe")
+	assert.NotContains(t, paths, filepath.Join(geminiRoot, "tmp"),
+		"the missing physical subtree itself must not be reconciled")
+
+	require.NoError(t, os.MkdirAll(filepath.Join(geminiRoot, "tmp"), 0o755))
+	paths = reconcileRootPaths(cfg)
+	assert.Contains(t, paths, filepath.Join(geminiRoot, "tmp"),
+		"a present physical subtree rejoins the reconciliation scope")
+}
+
+// The engine expands a requested reconciliation root to every configured dir
+// that is its ancestor or descendant, and the tombstone pass sweeps stored
+// paths by root prefix. A present path whose expansion overlaps a deferred
+// scope would therefore pull that scope back into an authoritative pass that
+// reads it as empty, so the probe must defer the overlapping present path too.
+func TestReconcileRootPathsDefersOverlapWithDeferredScopes(t *testing.T) {
+	t.Run("present root over a deferred nested configured root", func(t *testing.T) {
+		base := t.TempDir()
+		nested := filepath.Join(base, "mounted")
+		cfg := config.Config{
+			AgentDirs: map[parser.AgentType][]string{
+				parser.AgentClaude: {base, nested},
+			},
+		}
+
+		paths := reconcileRootPaths(cfg)
+		assert.NotContains(t, paths, base,
+			"a present root whose engine expansion covers a deferred nested root must be deferred with it")
+
+		require.NoError(t, os.MkdirAll(nested, 0o755))
+		paths = reconcileRootPaths(cfg)
+		assert.Contains(t, paths, base)
+		assert.Contains(t, paths, nested,
+			"both scopes rejoin the reconciliation once the nested root returns")
+	})
+
+	t.Run("present ancestor probe over another provider's deferred root", func(t *testing.T) {
+		parent := t.TempDir()
+		codexRoot := filepath.Join(parent, "codex")
+		require.NoError(t, os.MkdirAll(codexRoot, 0o755))
+		missingRoot := filepath.Join(parent, "other")
+		cfg := config.Config{
+			AgentDirs: map[parser.AgentType][]string{
+				parser.AgentCodex:  {codexRoot},
+				parser.AgentClaude: {missingRoot},
+			},
+		}
+
+		paths := reconcileRootPaths(cfg)
+		assert.Contains(t, paths, codexRoot)
+		assert.NotContains(t, paths, parent,
+			"Codex's shallow parent probe must not pull the sibling deferred scope back in")
+	})
+}
+
+// A recursive provider root that is a symlink is skipped from watching and
+// served by persistent polling, so it never joins the probed watch roots. Its
+// availability must still gate the reconciliation scope: a broken symlink
+// streams an empty discovery without error, and an overlapping present path
+// (Codex's shallow parent probe) would otherwise expand into the unavailable
+// scope and tombstone every baselined session beneath it.
+func TestReconcileRootPathsDefersBrokenSymlinkRootScope(t *testing.T) {
+	parent := t.TempDir()
+	target := filepath.Join(t.TempDir(), "codex-target")
+	require.NoError(t, os.MkdirAll(target, 0o755))
+	codexRoot := filepath.Join(parent, "codex")
+	requireSymlinkOrSkip(t, target, codexRoot)
+	cfg := config.Config{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodex: {codexRoot},
+		},
+	}
+
+	paths := reconcileRootPaths(cfg)
+	assert.Contains(t, paths, codexRoot,
+		"a symlink root with a present target stays available for reconciliation")
+	assert.Contains(t, paths, parent,
+		"the shallow parent probe stays available while the symlink target is present")
+
+	require.NoError(t, os.RemoveAll(target))
+	paths = reconcileRootPaths(cfg)
+	assert.NotContains(t, paths, codexRoot,
+		"a broken symlink root must not be reconciled as empty")
+	assert.NotContains(t, paths, parent,
+		"the shallow parent probe must not pull the broken symlink scope back in")
+
+	require.NoError(t, os.MkdirAll(target, 0o755))
+	paths = reconcileRootPaths(cfg)
+	assert.Contains(t, paths, codexRoot,
+		"a repaired symlink target rejoins the reconciliation scope")
+	assert.Contains(t, paths, parent)
+}
+
+// A symlink target that cannot be statted at all (EACCES on POSIX, access
+// denied on Windows) is not usable coverage either: the probe must defer the
+// scope on any stat error, not just NotExist, or discovery would run over a
+// root it cannot read.
+func TestReconcileRootPathsDefersUnstatableSymlinkTargetScope(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory read permissions are not enforced on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+	parent := t.TempDir()
+	targetParent := t.TempDir()
+	target := filepath.Join(targetParent, "codex-target")
+	require.NoError(t, os.MkdirAll(target, 0o755))
+	codexRoot := filepath.Join(parent, "codex")
+	requireSymlinkOrSkip(t, target, codexRoot)
+	cfg := config.Config{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodex: {codexRoot},
+		},
+	}
+
+	require.Contains(t, reconcileRootPaths(cfg), codexRoot)
+
+	require.NoError(t, os.Chmod(targetParent, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(targetParent, 0o755) })
+	paths := reconcileRootPaths(cfg)
+	assert.NotContains(t, paths, codexRoot,
+		"a symlink target that cannot be statted must defer, not reconcile")
+	assert.NotContains(t, paths, parent,
+		"the shallow parent probe must not pull the unstatable scope back in")
+
+	require.NoError(t, os.Chmod(targetParent, 0o755))
+	assert.Contains(t, reconcileRootPaths(cfg), codexRoot,
+		"a statable target rejoins the reconciliation scope")
+}
+
+// A watcher overflow forces a full recovery over every configured root. A
+// configured root that is a symlink whose target was removed streams an empty
+// discovery without error, so the recovery must defer that scope instead of
+// tombstoning every baselined session beneath it, while genuine deletions
+// under present roots still tombstone.
+func TestSyncWatchBatchFullRecoveryDefersBrokenSymlinkRoot(t *testing.T) {
+	dataDir := t.TempDir()
+	claudeRoot := t.TempDir()
+	parent := t.TempDir()
+	target := filepath.Join(t.TempDir(), "codex-target")
+	require.NoError(t, os.MkdirAll(target, 0o755))
+	codexRoot := filepath.Join(parent, "codex")
+	requireSymlinkOrSkip(t, target, codexRoot)
+
+	projDir := filepath.Join(claudeRoot, "-home-proj")
+	require.NoError(t, os.MkdirAll(projDir, 0o755))
+	claudeContent := func(text string) string {
+		return testjsonl.NewSessionBuilder().
+			AddClaudeUser("2026-01-01T00:00:00Z", text).
+			AddClaudeAssistant("2026-01-01T00:00:01Z", "ok").
+			String()
+	}
+	deletedPath := filepath.Join(projDir, "claude-deleted.jsonl")
+	require.NoError(t, os.WriteFile(
+		deletedPath, []byte(claudeContent("delete me")), 0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projDir, "claude-kept.jsonl"),
+		[]byte(claudeContent("keep me")), 0o644,
+	))
+
+	codexUUID := "f7a8b9ca-7890-1234-ef01-456789012345"
+	codexDay := filepath.Join(target, "2026", "05", "04")
+	require.NoError(t, os.MkdirAll(codexDay, 0o755))
+	codexContent := testjsonl.NewSessionBuilder().
+		AddCodexMeta(
+			"2026-05-04T14:00:00Z", codexUUID, "/home/user/code/api",
+			"codex_cli_rs",
+		).
+		AddCodexMessage("2026-05-04T14:00:01Z", "user", "hello").
+		String()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(codexDay, "rollout-2026-05-04T14-31-58-"+codexUUID+".jsonl"),
+		[]byte(codexContent), 0o644,
+	))
+
+	cfg := config.Config{
+		DataDir:          dataDir,
+		DBPath:           filepath.Join(dataDir, "sessions.db"),
+		LocalMachineName: "local",
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {claudeRoot},
+			parser.AgentCodex:  {codexRoot},
+		},
+	}
+	database := dbtest.OpenTestDBAt(t, cfg.DBPath)
+	engine := agentsync.NewEngine(database, agentsync.EngineConfig{
+		AgentDirs: cfg.AgentDirs,
+		Machine:   cfg.LocalMachineName,
+	})
+	t.Cleanup(engine.Close)
+
+	// Baseline every source with an authoritative pass while the symlink works.
+	require.NoError(t, engine.ReconcileWatchRootsAfterLostEvents(
+		t.Context(), nil, true,
+	))
+	baselined, err := database.GetSession(t.Context(), "codex:"+codexUUID)
+	require.NoError(t, err)
+	require.NotNil(t, baselined, "the codex session must sync before the outage")
+
+	// A genuine deletion under the present root; the symlink target vanishes.
+	require.NoError(t, os.Remove(deletedPath))
+	require.NoError(t, os.RemoveAll(target))
+
+	require.NoError(t, syncWatchBatch(
+		t.Context(), engine,
+		agentsync.WatchBatch{FullSync: true, LostEvents: true},
+		func() watchRecoveryScope { return probeWatchRecoveryScope(cfg) },
+	))
+
+	survivor, err := database.GetSession(t.Context(), "codex:"+codexUUID)
+	require.NoError(t, err)
+	assert.NotNil(t, survivor,
+		"sessions under a broken symlink root must not be tombstoned by an unrelated overflow")
+	kept, err := database.GetSession(t.Context(), "claude-kept")
+	require.NoError(t, err)
+	assert.NotNil(t, kept)
+	deleted, err := database.GetSession(t.Context(), "claude-deleted")
+	require.NoError(t, err)
+	assert.Nil(t, deleted,
+		"a genuine deletion under a present root must still tombstone")
+}
+
+// A watcher overflow forces a full recovery over every configured root. A
+// root whose physical path is unavailable (unmounted volume, deleted provider
+// dir) streams an empty discovery without error, so the recovery must defer
+// that scope instead of tombstoning every baselined session beneath it, while
+// genuine deletions under present roots still tombstone.
+func TestSyncWatchBatchFullRecoveryDefersUnavailableRoots(t *testing.T) {
+	dataDir := t.TempDir()
+	claudeRoot := t.TempDir()
+	codexRoot := filepath.Join(t.TempDir(), "volume")
+
+	projDir := filepath.Join(claudeRoot, "-home-proj")
+	require.NoError(t, os.MkdirAll(projDir, 0o755))
+	claudeContent := func(text string) string {
+		return testjsonl.NewSessionBuilder().
+			AddClaudeUser("2026-01-01T00:00:00Z", text).
+			AddClaudeAssistant("2026-01-01T00:00:01Z", "ok").
+			String()
+	}
+	deletedPath := filepath.Join(projDir, "claude-deleted.jsonl")
+	require.NoError(t, os.WriteFile(
+		deletedPath, []byte(claudeContent("delete me")), 0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(projDir, "claude-kept.jsonl"),
+		[]byte(claudeContent("keep me")), 0o644,
+	))
+
+	codexUUID := "f7a8b9ca-7890-1234-ef01-456789012345"
+	codexDay := filepath.Join(codexRoot, "2026", "05", "04")
+	require.NoError(t, os.MkdirAll(codexDay, 0o755))
+	codexContent := testjsonl.NewSessionBuilder().
+		AddCodexMeta(
+			"2026-05-04T14:00:00Z", codexUUID, "/home/user/code/api",
+			"codex_cli_rs",
+		).
+		AddCodexMessage("2026-05-04T14:00:01Z", "user", "hello").
+		String()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(codexDay, "rollout-2026-05-04T14-31-58-"+codexUUID+".jsonl"),
+		[]byte(codexContent), 0o644,
+	))
+
+	cfg := config.Config{
+		DataDir:          dataDir,
+		DBPath:           filepath.Join(dataDir, "sessions.db"),
+		LocalMachineName: "local",
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {claudeRoot},
+			parser.AgentCodex:  {codexRoot},
+		},
+	}
+	database := dbtest.OpenTestDBAt(t, cfg.DBPath)
+	engine := agentsync.NewEngine(database, agentsync.EngineConfig{
+		AgentDirs: cfg.AgentDirs,
+		Machine:   cfg.LocalMachineName,
+	})
+	t.Cleanup(engine.Close)
+
+	// Baseline every source with an authoritative pass while all roots exist.
+	require.NoError(t, engine.ReconcileWatchRootsAfterLostEvents(
+		t.Context(), nil, true,
+	))
+	baselined, err := database.GetSession(t.Context(), "codex:"+codexUUID)
+	require.NoError(t, err)
+	require.NotNil(t, baselined, "the codex session must sync before the outage")
+
+	// A genuine deletion under the present root; the codex volume unmounts.
+	require.NoError(t, os.Remove(deletedPath))
+	require.NoError(t, os.RemoveAll(codexRoot))
+
+	require.NoError(t, syncWatchBatch(
+		t.Context(), engine,
+		agentsync.WatchBatch{FullSync: true, LostEvents: true},
+		func() watchRecoveryScope { return probeWatchRecoveryScope(cfg) },
+	))
+
+	survivor, err := database.GetSession(t.Context(), "codex:"+codexUUID)
+	require.NoError(t, err)
+	assert.NotNil(t, survivor,
+		"sessions under an unavailable root must not be tombstoned by an unrelated overflow")
+	kept, err := database.GetSession(t.Context(), "claude-kept")
+	require.NoError(t, err)
+	assert.NotNil(t, kept)
+	deleted, err := database.GetSession(t.Context(), "claude-deleted")
+	require.NoError(t, err)
+	assert.Nil(t, deleted,
+		"a genuine deletion under a present root must still tombstone")
+	archived, err := database.GetSessionFull(t.Context(), "claude-deleted")
+	require.NoError(t, err)
+	require.NotNil(t, archived)
+	require.NotNil(t, archived.DeletionCause)
+	assert.Equal(t, "source_missing", *archived.DeletionCause)
+}
+
+// A configured root can nest inside another configured root of the same
+// provider (e.g. a mounted volume under the session dir). When the nested
+// root unmounts, the engine's expansion of the still-present outer root
+// covers the nested scope, so a full recovery scoped to "available" roots
+// would still read the nested scope as an empty discovery and tombstone its
+// baselined sessions unless the overlapping outer root is deferred with it.
+func TestSyncWatchBatchFullRecoveryDefersOverlappingUnavailableRoot(t *testing.T) {
+	dataDir := t.TempDir()
+	baseRoot := t.TempDir()
+	nestedRoot := filepath.Join(baseRoot, "mounted")
+
+	claudeContent := func(text string) string {
+		return testjsonl.NewSessionBuilder().
+			AddClaudeUser("2026-01-01T00:00:00Z", text).
+			AddClaudeAssistant("2026-01-01T00:00:01Z", "ok").
+			String()
+	}
+	outerProj := filepath.Join(baseRoot, "-home-outer")
+	require.NoError(t, os.MkdirAll(outerProj, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(outerProj, "claude-outer.jsonl"),
+		[]byte(claudeContent("outer")), 0o644,
+	))
+	nestedProj := filepath.Join(nestedRoot, "-home-nested")
+	require.NoError(t, os.MkdirAll(nestedProj, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(nestedProj, "claude-nested.jsonl"),
+		[]byte(claudeContent("nested")), 0o644,
+	))
+
+	cfg := config.Config{
+		DataDir:          dataDir,
+		DBPath:           filepath.Join(dataDir, "sessions.db"),
+		LocalMachineName: "local",
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {baseRoot, nestedRoot},
+		},
+	}
+	database := dbtest.OpenTestDBAt(t, cfg.DBPath)
+	engine := agentsync.NewEngine(database, agentsync.EngineConfig{
+		AgentDirs: cfg.AgentDirs,
+		Machine:   cfg.LocalMachineName,
+	})
+	t.Cleanup(engine.Close)
+
+	// Baseline both scopes with an authoritative pass while all roots exist.
+	require.NoError(t, engine.ReconcileWatchRootsAfterLostEvents(
+		t.Context(), nil, true,
+	))
+	baselined, err := database.GetSession(t.Context(), "claude-nested")
+	require.NoError(t, err)
+	require.NotNil(t, baselined, "the nested session must sync before the outage")
+
+	// The nested volume unmounts; the outer root stays present.
+	require.NoError(t, os.RemoveAll(nestedRoot))
+
+	require.NoError(t, syncWatchBatch(
+		t.Context(), engine,
+		agentsync.WatchBatch{FullSync: true, LostEvents: true},
+		func() watchRecoveryScope { return probeWatchRecoveryScope(cfg) },
+	))
+
+	survivor, err := database.GetSession(t.Context(), "claude-nested")
+	require.NoError(t, err)
+	assert.NotNil(t, survivor,
+		"sessions under an unavailable nested root must not be tombstoned via the overlapping outer root")
+	outer, err := database.GetSession(t.Context(), "claude-outer")
+	require.NoError(t, err)
+	assert.NotNil(t, outer)
+}
+
+// A directory rename expands to every configured root of the owning provider
+// because FSEvents may report only one endpoint of a cross-root move. A
+// sibling root whose physical path is unavailable streams an empty discovery
+// without error, so the promotion must keep only currently available roots:
+// reconciling the unavailable sibling would tombstone every baselined session
+// beneath it even though the rename happened under a healthy root.
+func TestSyncWatchBatchDirectoryRenameDefersUnavailableProviderRoots(t *testing.T) {
+	dataDir := t.TempDir()
+	rootA := filepath.Join(t.TempDir(), "codex-a")
+	rootB := filepath.Join(t.TempDir(), "volume")
+
+	writeCodexSession := func(root, uuid string) {
+		day := filepath.Join(root, "2026", "05", "04")
+		require.NoError(t, os.MkdirAll(day, 0o755))
+		content := testjsonl.NewSessionBuilder().
+			AddCodexMeta(
+				"2026-05-04T14:00:00Z", uuid, "/home/user/code/api",
+				"codex_cli_rs",
+			).
+			AddCodexMessage("2026-05-04T14:00:01Z", "user", "hello").
+			String()
+		require.NoError(t, os.WriteFile(
+			filepath.Join(day, "rollout-2026-05-04T14-31-58-"+uuid+".jsonl"),
+			[]byte(content), 0o644,
+		))
+	}
+	uuidA := "a1b2c3d4-1111-4222-8333-444455556666"
+	uuidB := "b2c3d4e5-2222-4333-8444-555566667777"
+	uuidC := "c3d4e5f6-3333-4444-8555-666677778888"
+	writeCodexSession(rootA, uuidA)
+	writeCodexSession(rootB, uuidB)
+
+	cfg := config.Config{
+		DataDir:          dataDir,
+		DBPath:           filepath.Join(dataDir, "sessions.db"),
+		LocalMachineName: "local",
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodex: {rootA, rootB},
+		},
+	}
+	database := dbtest.OpenTestDBAt(t, cfg.DBPath)
+	engine := agentsync.NewEngine(database, agentsync.EngineConfig{
+		AgentDirs: cfg.AgentDirs,
+		Machine:   cfg.LocalMachineName,
+	})
+	t.Cleanup(engine.Close)
+
+	// Baseline both roots with an authoritative pass while they exist.
+	require.NoError(t, engine.ReconcileWatchRootsAfterLostEvents(
+		t.Context(), nil, true,
+	))
+	baselined, err := database.GetSession(t.Context(), "codex:"+uuidB)
+	require.NoError(t, err)
+	require.NotNil(t, baselined, "the session under root B must sync before the outage")
+
+	// Root B unmounts; a new session lands under the healthy root A, and a
+	// directory rename under root A promotes the provider's roots.
+	require.NoError(t, os.RemoveAll(rootB))
+	writeCodexSession(rootA, uuidC)
+
+	require.NoError(t, syncWatchBatch(
+		t.Context(), engine,
+		agentsync.WatchBatch{Renames: []agentsync.WatchRename{{
+			Path:     filepath.Join(rootA, "2026"),
+			Root:     rootA,
+			Agent:    string(parser.AgentCodex),
+			ItemType: agentsync.ItemIsDir,
+		}}},
+		func() watchRecoveryScope { return probeWatchRecoveryScope(cfg) },
+	))
+
+	survivor, err := database.GetSession(t.Context(), "codex:"+uuidB)
+	require.NoError(t, err)
+	assert.NotNil(t, survivor,
+		"sessions under an unavailable sibling root must not be tombstoned by a rename under a healthy root")
+	kept, err := database.GetSession(t.Context(), "codex:"+uuidA)
+	require.NoError(t, err)
+	assert.NotNil(t, kept)
+	synced, err := database.GetSession(t.Context(), "codex:"+uuidC)
+	require.NoError(t, err)
+	assert.NotNil(t, synced,
+		"the available root must still reconcile the rename authoritatively")
 }

--- a/cmd/agentsview/periodic_sync_test.go
+++ b/cmd/agentsview/periodic_sync_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -112,6 +113,59 @@ func (f *fakeScheduledEngine) ReconcileProviderRoots(
 ) error {
 	f.calls = append(f.calls, scheduledReconcileTarget{Agent: agent, Roots: roots})
 	return f.err
+}
+
+func TestRemoteSourceSyncRootsSelectsSchemeRoots(t *testing.T) {
+	local := t.TempDir()
+	cfg := config.Config{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {local, "s3://bucket/machine/raw/claude"},
+			parser.AgentCodex: {
+				"s3://bucket/machine/raw/codex",
+				"S3://bucket/upper/raw/codex",
+			},
+		},
+	}
+	assert.Equal(t, []string{
+		"S3://bucket/upper/raw/codex",
+		"s3://bucket/machine/raw/claude",
+		"s3://bucket/machine/raw/codex",
+	}, remoteSourceSyncRoots(cfg),
+		"remote roots are selected by scheme, deduplicated, and sorted")
+}
+
+func TestRemoteSourceSyncRootsEmptyForLocalOnlyConfig(t *testing.T) {
+	cfg := config.Config{AgentDirs: map[parser.AgentType][]string{
+		parser.AgentClaude: {t.TempDir()},
+	}}
+	assert.Empty(t, remoteSourceSyncRoots(cfg))
+}
+
+type fakeRemoteSourceSyncEngine struct {
+	calls [][]string
+	since []time.Time
+	stats agentsync.SyncStats
+}
+
+func (f *fakeRemoteSourceSyncEngine) SyncRootsSince(
+	_ context.Context, roots []string, since time.Time, _ agentsync.ProgressFunc,
+) agentsync.SyncStats {
+	f.calls = append(f.calls, append([]string(nil), roots...))
+	f.since = append(f.since, since)
+	return f.stats
+}
+
+func TestRunRemoteSourceSyncPassSyncsConfiguredRemoteRoots(t *testing.T) {
+	engine := &fakeRemoteSourceSyncEngine{}
+	runRemoteSourceSyncPass(context.Background(), engine, nil)
+	assert.Empty(t, engine.calls, "no remote roots -> no scoped sync")
+
+	roots := []string{"s3://bucket/machine/raw/claude"}
+	runRemoteSourceSyncPass(context.Background(), engine, roots)
+	require.Len(t, engine.calls, 1)
+	assert.Equal(t, roots, engine.calls[0])
+	assert.True(t, engine.since[0].IsZero(),
+		"the pass must cover the full remote scope; unchanged objects skip on fingerprints")
 }
 
 func TestRunScheduledSyncPassCallsPerAgent(t *testing.T) {

--- a/cmd/agentsview/periodic_sync_test.go
+++ b/cmd/agentsview/periodic_sync_test.go
@@ -103,6 +103,47 @@ func TestScheduledReconcileDefersUnavailableOptedInRoots(t *testing.T) {
 	}
 }
 
+func TestScheduledReconcileDefersNestedUnavailableRoots(t *testing.T) {
+	parent := filepath.Join(t.TempDir(), "aider")
+	require.NoError(t, os.MkdirAll(parent, 0o755))
+	child := filepath.Join(parent, "unavailable")
+	sourcePath := filepath.Join(child, "project", ".aider.chat.history.md#0")
+
+	cfg := config.Config{AgentDirs: map[parser.AgentType][]string{
+		parser.AgentAider: {parent, child},
+	}}
+	database := dbtest.OpenTestDB(t)
+	sessionID := "aider:nested-archived"
+	dbtest.SeedSession(t, database, sessionID, "project",
+		func(session *db.Session) {
+			session.Agent = string(parser.AgentAider)
+			session.FilePath = &sourcePath
+		})
+	require.NoError(t,
+		database.SetSessionDataVersion(sessionID, db.CurrentDataVersion()))
+	require.NoError(t, database.BaselineActiveSessionSourcePaths(
+		t.Context(), "local", []db.SessionSourcePath{{
+			Agent: string(parser.AgentAider), FilePath: sourcePath,
+		}},
+	))
+	engine := agentsync.NewEngine(database, agentsync.EngineConfig{
+		AgentDirs: cfg.AgentDirs,
+		Machine:   "local",
+	})
+	t.Cleanup(engine.Close)
+
+	targets := scheduledReconcileTargets(cfg)
+	runScheduledSyncPass(t.Context(), engine, targets)
+
+	assert.Empty(t, targets,
+		"a present root must defer with a missing nested same-agent scope: "+
+			"the engine expands it back to the missing dir")
+	preserved, err := database.GetSession(t.Context(), sessionID)
+	require.NoError(t, err)
+	assert.NotNil(t, preserved,
+		"scheduled reconciliation must preserve sessions under the missing nested root")
+}
+
 type fakeScheduledEngine struct {
 	calls []scheduledReconcileTarget
 	err   error

--- a/cmd/agentsview/periodic_sync_test.go
+++ b/cmd/agentsview/periodic_sync_test.go
@@ -127,11 +127,12 @@ func TestRemoteSourceSyncRootsSelectsSchemeRoots(t *testing.T) {
 		},
 	}
 	assert.Equal(t, []string{
-		"S3://bucket/upper/raw/codex",
 		"s3://bucket/machine/raw/claude",
 		"s3://bucket/machine/raw/codex",
 	}, remoteSourceSyncRoots(cfg),
-		"remote roots are selected by scheme, deduplicated, and sorted")
+		"remote roots are selected by exact lowercase scheme, deduplicated, "+
+			"and sorted; provider discovery recognizes only lowercase s3://, "+
+			"so an uppercase root is a filesystem path here as it is at startup")
 }
 
 func TestRemoteSourceSyncRootsEmptyForLocalOnlyConfig(t *testing.T) {

--- a/cmd/agentsview/periodic_sync_test.go
+++ b/cmd/agentsview/periodic_sync_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/parser"
+	agentsync "go.kenn.io/agentsview/internal/sync"
+)
+
+func TestScheduledReconcileTargetsSelectsOnlyOptedInProviders(t *testing.T) {
+	home := t.TempDir()
+	aiderDir := filepath.Join(home, "aider")
+	coworkDir := filepath.Join(home, "cowork")
+	claudeDir := filepath.Join(home, "claude")
+	require.NoError(t, os.MkdirAll(aiderDir, 0o755))
+	require.NoError(t, os.MkdirAll(coworkDir, 0o755))
+	require.NoError(t, os.MkdirAll(claudeDir, 0o755))
+
+	cfg := config.Config{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentAider:  {aiderDir},
+			parser.AgentCowork: {coworkDir},
+			parser.AgentClaude: {claudeDir},
+		},
+	}
+	targets := scheduledReconcileTargets(cfg)
+	require.Len(t, targets, 1, "only the opted-in provider is scheduled")
+	assert.Equal(t, parser.AgentAider, targets[0].Agent)
+	assert.Equal(t, []string{aiderDir}, targets[0].Roots)
+}
+
+func TestScheduledReconcileDefersUnavailableOptedInRoots(t *testing.T) {
+	tests := []struct {
+		name       string
+		agent      parser.AgentType
+		sourcePath func(string) string
+	}{
+		{
+			name:  "aider",
+			agent: parser.AgentAider,
+			sourcePath: func(root string) string {
+				return filepath.Join(root, "project", ".aider.chat.history.md#0")
+			},
+		},
+		{
+			name:  "openhands",
+			agent: parser.AgentOpenHands,
+			sourcePath: func(root string) string {
+				return filepath.Join(root, "conversation-1")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			missingRoot := filepath.Join(t.TempDir(), "unavailable")
+			sourcePath := tc.sourcePath(missingRoot)
+			cfg := config.Config{AgentDirs: map[parser.AgentType][]string{
+				tc.agent: {missingRoot},
+			}}
+			database := dbtest.OpenTestDB(t)
+			sessionID := string(tc.agent) + ":archived"
+			dbtest.SeedSession(t, database, sessionID, "project",
+				func(session *db.Session) {
+					session.Agent = string(tc.agent)
+					session.FilePath = &sourcePath
+				})
+			require.NoError(t,
+				database.SetSessionDataVersion(sessionID, db.CurrentDataVersion()))
+			require.NoError(t, database.BaselineActiveSessionSourcePaths(
+				t.Context(), "local", []db.SessionSourcePath{{
+					Agent: string(tc.agent), FilePath: sourcePath,
+				}},
+			))
+			engine := agentsync.NewEngine(database, agentsync.EngineConfig{
+				AgentDirs: cfg.AgentDirs,
+				Machine:   "local",
+			})
+			t.Cleanup(engine.Close)
+
+			targets := scheduledReconcileTargets(cfg)
+			runScheduledSyncPass(t.Context(), engine, targets)
+
+			assert.Empty(t, targets,
+				"an unavailable physical root must defer its authoritative scope")
+			preserved, err := database.GetSession(
+				t.Context(), sessionID,
+			)
+			require.NoError(t, err)
+			assert.NotNil(t, preserved,
+				"scheduled reconciliation must preserve the archived session")
+		})
+	}
+}
+
+type fakeScheduledEngine struct {
+	calls []scheduledReconcileTarget
+	err   error
+}
+
+func (f *fakeScheduledEngine) ReconcileProviderRoots(
+	_ context.Context, agent parser.AgentType, roots []string,
+) error {
+	f.calls = append(f.calls, scheduledReconcileTarget{Agent: agent, Roots: roots})
+	return f.err
+}
+
+func TestRunScheduledSyncPassCallsPerAgent(t *testing.T) {
+	engine := &fakeScheduledEngine{}
+	runScheduledSyncPass(context.Background(), engine, nil)
+	assert.Empty(t, engine.calls, "no targets -> no reconciliation")
+
+	runScheduledSyncPass(context.Background(), engine,
+		[]scheduledReconcileTarget{{Agent: parser.AgentAider, Roots: []string{"/a"}}})
+	require.Len(t, engine.calls, 1)
+	assert.Equal(t, parser.AgentAider, engine.calls[0].Agent)
+	assert.Equal(t, []string{"/a"}, engine.calls[0].Roots)
+}

--- a/cmd/agentsview/pg_watch.go
+++ b/cmd/agentsview/pg_watch.go
@@ -79,7 +79,7 @@ func (p *pgPusher) push(
 			"pg watch: %d session(s) failed to push; will retry",
 			res.Errors,
 		)
-		return nil
+		return fmt.Errorf("%d session(s) failed to push", res.Errors)
 	}
 	logPGWatchPushResult(res, reason)
 	return nil

--- a/cmd/agentsview/pg_watch_loop.go
+++ b/cmd/agentsview/pg_watch_loop.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"log"
+	"sync"
 	"time"
 )
 
@@ -29,24 +30,28 @@ const defaultFlushTimeout = 30 * time.Second
 // under test. In production, after is time.After and floor is a
 // time.Ticker channel.
 type pushLoop struct {
-	debounce time.Duration
-	dirty    chan struct{}
-	floor    <-chan time.Time
-	after    func(time.Duration) <-chan time.Time
-	push     func(ctx context.Context, reason pushReason) error
-	label    string
+	debounce  time.Duration
+	dirty     chan struct{}
+	floor     <-chan time.Time
+	after     func(time.Duration) <-chan time.Time
+	push      func(ctx context.Context, reason pushReason) error
+	label     string
+	pendingMu sync.Mutex
+	pending   bool
+	waiters   []chan error
 	// flushTimeout bounds the final shutdown-flush push. Zero means
 	// no bound (used in tests that inject a fake pusher).
 	flushTimeout time.Duration
 }
 
-// newPushLoop builds a production loop with a real debounce timer and
-// floor ticker. The caller must Stop the returned ticker.
-func newPushLoop(
-	debounce, interval time.Duration,
-	push func(context.Context, pushReason) error,
-) (*pushLoop, *time.Ticker) {
-	return newPushLoopWithLabel("pg watch", debounce, interval, push)
+// NotifyCoverageDegraded logs that the watcher lost coverage of roots and
+// marks the loop dirty so the interval floor re-pushes the affected data.
+func (l *pushLoop) NotifyCoverageDegraded(roots []string) error {
+	log.Printf(
+		"%s: watcher coverage degraded root_count=%d", l.label, len(roots),
+	)
+	l.NotifyDirty()
+	return nil
 }
 
 func newPushLoopWithLabel(
@@ -69,6 +74,26 @@ func newPushLoopWithLabel(
 // NotifyDirty signals that local data changed. Non-blocking: a burst
 // collapses into a single pending push.
 func (l *pushLoop) NotifyDirty() {
+	l.pendingMu.Lock()
+	l.pending = true
+	l.pendingMu.Unlock()
+	l.signalDirty()
+}
+
+// NotifyDirtyWithAck marks the loop dirty and returns immediately. The result
+// channel completes only after a push covering this generation succeeds;
+// failed pushes retain both the dirty marker and every waiter for a retry.
+func (l *pushLoop) NotifyDirtyWithAck() <-chan error {
+	waiter := make(chan error, 1)
+	l.pendingMu.Lock()
+	l.pending = true
+	l.waiters = append(l.waiters, waiter)
+	l.pendingMu.Unlock()
+	l.signalDirty()
+	return waiter
+}
+
+func (l *pushLoop) signalDirty() {
 	select {
 	case l.dirty <- struct{}{}:
 	default:
@@ -111,7 +136,36 @@ func (l *pushLoop) Run(ctx context.Context) {
 }
 
 func (l *pushLoop) doPush(ctx context.Context, reason pushReason) {
+	hadPending, waiters := l.claimPending()
 	if err := l.push(ctx, reason); err != nil {
 		log.Printf("%s: push (%s) failed: %v", l.label, reason, err)
+		if hadPending {
+			l.restorePending(waiters)
+		}
+		return
 	}
+	for _, waiter := range waiters {
+		waiter <- nil
+		close(waiter)
+	}
+}
+
+func (l *pushLoop) claimPending() (bool, []chan error) {
+	l.pendingMu.Lock()
+	defer l.pendingMu.Unlock()
+	hadPending := l.pending
+	waiters := l.waiters
+	l.pending = false
+	l.waiters = nil
+	return hadPending, waiters
+}
+
+func (l *pushLoop) restorePending(waiters []chan error) {
+	l.pendingMu.Lock()
+	l.pending = true
+	if len(waiters) > 0 {
+		l.waiters = append(waiters, l.waiters...)
+	}
+	l.pendingMu.Unlock()
+	l.signalDirty()
 }

--- a/cmd/agentsview/pg_watch_loop_test.go
+++ b/cmd/agentsview/pg_watch_loop_test.go
@@ -5,6 +5,9 @@ import (
 	"errors"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // newTestLoop wires a pushLoop with caller-controlled timers.
@@ -118,6 +121,69 @@ func TestPushLoop_ErrorDoesNotStopLoop(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("loop did not survive a push error")
 	}
+}
+
+func TestPushLoop_NotifyDirtyWithAckWaitsForSuccessfulRetry(t *testing.T) {
+	attempts := make(chan pushReason, 2)
+	pushErr := errors.New("target unavailable")
+	call := 0
+	l, fire, _ := newTestLoop(func(_ context.Context, reason pushReason) error {
+		call++
+		attempts <- reason
+		if call == 1 {
+			return pushErr
+		}
+		return nil
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go l.Run(ctx)
+
+	ack := l.NotifyDirtyWithAck()
+	fire <- time.Now()
+	require.Equal(t, reasonChange, <-attempts)
+	select {
+	case err := <-ack:
+		require.Fail(t, "failed push acknowledged dirty generation", "%v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Failure retains the dirty generation and rearms debounce without a
+	// second producer notification.
+	fire <- time.Now()
+	require.Equal(t, reasonChange, <-attempts)
+	require.NoError(t, <-ack)
+}
+
+func TestPushLoop_NotifyDirtyWithAckIsNonBlockingAndCoalescesWaiters(t *testing.T) {
+	l, fire, _ := newTestLoop(func(context.Context, pushReason) error { return nil })
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go l.Run(ctx)
+
+	first := l.NotifyDirtyWithAck()
+	second := l.NotifyDirtyWithAck()
+	assert.NotNil(t, first)
+	assert.NotNil(t, second)
+	fire <- time.Now()
+	require.NoError(t, <-first)
+	require.NoError(t, <-second)
+}
+
+func TestPushWatchFallbackCoverageMarksLoopDirty(t *testing.T) {
+	loop, _, _ := newTestLoop(func(context.Context, pushReason) error { return nil })
+
+	require.NoError(t,
+		loop.NotifyCoverageDegraded([]string{"/root-a", "/root-a", "/root-b"}))
+	pending, waiters := func() (bool, int) {
+		loop.pendingMu.Lock()
+		defer loop.pendingMu.Unlock()
+		return loop.pending, len(loop.waiters)
+	}()
+	assert.True(t, pending,
+		"coverage degradation must mark the loop dirty for the next push")
+	assert.Zero(t, waiters,
+		"coverage degradation must not enqueue ack waiters")
 }
 
 func TestPushLoop_ShutdownFlushes(t *testing.T) {

--- a/cmd/agentsview/pg_watch_test.go
+++ b/cmd/agentsview/pg_watch_test.go
@@ -359,7 +359,8 @@ func TestPgPusher_LogsPartialPushErrors(t *testing.T) {
 	logs := captureLogOutput(t)
 
 	p, _ := newTestPgPusher(target)
-	require.NoError(t, p.push(context.Background(), reasonChange, false))
+	require.Error(t, p.push(context.Background(), reasonChange, false),
+		"partial pushes must remain pending for retry")
 
 	got := logs.String()
 	assert.Contains(t, got, "pushed 3 sessions, 9 messages, 2 errors")

--- a/cmd/agentsview/remote_source_sync.go
+++ b/cmd/agentsview/remote_source_sync.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"log"
+	"slices"
+	"strings"
+	"time"
+
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/sync"
+)
+
+// remoteSourceSyncEngine is the scoped-sync surface the periodic remote pass
+// needs.
+type remoteSourceSyncEngine interface {
+	SyncRootsSince(
+		ctx context.Context, roots []string, since time.Time,
+		onProgress sync.ProgressFunc,
+	) sync.SyncStats
+}
+
+// remoteSourceSyncRoots selects the configured remote object roots. Filesystem
+// watchers cannot observe them, the unwatched poller's os.Stat probes never see
+// them as present, and every local reconciliation path (scheduled, audit,
+// recovery) excludes remote roots from its scope, so post-startup changes there
+// are only discovered by the scheduled remote pass. The selection derives from
+// the configured dir's scheme alone — no provider construction or disk probing
+// — so it needs no per-provider capability.
+func remoteSourceSyncRoots(cfg config.Config) []string {
+	var roots []string
+	for _, def := range parser.Registry {
+		for _, dir := range cfg.ResolveDirs(def.Type) {
+			if isRemoteSourceRoot(dir) {
+				roots = appendUniqueString(roots, dir)
+			}
+		}
+	}
+	slices.Sort(roots)
+	return roots
+}
+
+// isRemoteSourceRoot mirrors the sync engine's remote reconciliation root
+// check.
+func isRemoteSourceRoot(dir string) bool {
+	return strings.HasPrefix(strings.ToLower(dir), "s3://")
+}
+
+// runRemoteSourceSyncPass syncs the configured remote roots so new or changed
+// remote sessions keep flowing in after startup. The pass is bounded to those
+// roots: discovery lists only the remote prefixes and unchanged objects skip on
+// their durable fingerprints before any fetch, so no local archive walk runs.
+// A zero cutoff covers the full remote scope, matching the pre-worker
+// 15-minute SyncAll behavior for these roots.
+func runRemoteSourceSyncPass(
+	ctx context.Context, engine remoteSourceSyncEngine, roots []string,
+) {
+	if len(roots) == 0 {
+		return
+	}
+	stats := engine.SyncRootsSince(ctx, roots, time.Time{}, nil)
+	if stats.Failed > 0 || stats.Aborted {
+		log.Printf(
+			"scheduled remote source sync: %d synced, %d failed, aborted=%v",
+			stats.Synced, stats.Failed, stats.Aborted,
+		)
+	}
+}

--- a/cmd/agentsview/remote_source_sync.go
+++ b/cmd/agentsview/remote_source_sync.go
@@ -41,10 +41,17 @@ func remoteSourceSyncRoots(cfg config.Config) []string {
 	return roots
 }
 
-// isRemoteSourceRoot mirrors the sync engine's remote reconciliation root
-// check.
+// isRemoteSourceRoot matches provider discovery's scheme check exactly:
+// Claude and Codex s3 discovery recognize only lowercase "s3://", and startup
+// cleans any other spelling as a filesystem path that yields nothing. Selecting
+// case-insensitively here would make the periodic pass claim roots the
+// providers cannot sync, so selection is lowercase-only to keep periodic
+// behavior identical to startup behavior. (The engine's
+// isRemoteReconciliationRoot stays case-insensitive on purpose: excluding an
+// uppercase root from local reconciliation is a harmless no-op, since no
+// sessions can ever exist under it.)
 func isRemoteSourceRoot(dir string) bool {
-	return strings.HasPrefix(strings.ToLower(dir), "s3://")
+	return strings.HasPrefix(dir, "s3://")
 }
 
 // runRemoteSourceSyncPass syncs the configured remote roots so new or changed

--- a/cmd/agentsview/resync_worker_test.go
+++ b/cmd/agentsview/resync_worker_test.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/sync"
+)
+
+// TestForegroundResyncRunnerFallsBackInProcess verifies the resync seam: under a
+// test binary the runner takes the in-process ResyncAll arm (the worker arm is
+// gated by !testing.Testing()), rebuilds the archive, and clears the stale-data
+// flag. The worker build-and-swap mechanism is covered by the engine split tests
+// and the resync-build worker mode test.
+func TestForegroundResyncRunnerFallsBackInProcess(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	database, err := db.Open(cfg.DBPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	engine := sync.NewEngine(database, workerEngineConfig(cfg))
+	t.Cleanup(engine.Close)
+	require.Equal(t, 3, engine.SyncAll(context.Background(), nil).Synced)
+
+	runner := newForegroundResyncRunner(context.Background(), cfg, engine, database)
+	stats, err := runner(context.Background(), nil)
+
+	require.NoError(t, err)
+	assert.False(t, stats.Aborted)
+	assert.Equal(t, 3, stats.Synced, "in-process resync fallback rebuilds the archive")
+	assert.False(t, database.NeedsResync())
+}
+
+// requireStartupMaintenanceReleased asserts that RunStartupMaintenance is no
+// longer gated: its work function must run promptly instead of blocking on the
+// startup-maintenance gate until shutdown.
+func requireStartupMaintenanceReleased(t *testing.T, engine *sync.Engine) {
+	t.Helper()
+	maintenanceRan := make(chan struct{})
+	maintenanceDone := make(chan error, 1)
+	go func() {
+		maintenanceDone <- engine.RunStartupMaintenance(
+			t.Context(), func() error {
+				close(maintenanceRan)
+				return nil
+			},
+		)
+	}()
+	select {
+	case <-maintenanceRan:
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "startup maintenance still gated after the pass")
+	}
+	require.NoError(t, <-maintenanceDone)
+}
+
+// TestForegroundResyncRunnerReleasesStartupMaintenance covers the
+// skip-initial-sync daemon shape: when the in-process fallback drives startup
+// reconciliation, it must also release the startup-maintenance gate.
+// Otherwise the deferred startup fallback sees the closed reconciliation gate,
+// returns early, and archive-wide backfills stay blocked until shutdown.
+func TestForegroundResyncRunnerReleasesStartupMaintenance(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	database, err := db.Open(cfg.DBPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	engineCfg := workerEngineConfig(cfg)
+	engineCfg.DeferStartupMaintenance = true
+	engine := sync.NewEngine(database, engineCfg)
+	t.Cleanup(engine.Close)
+
+	runner := newForegroundResyncRunner(context.Background(), cfg, engine, database)
+	_, err = runner(context.Background(), nil)
+
+	require.NoError(t, err)
+	require.True(t, engine.StartupReconciled(),
+		"a successful in-process resync closes the reconciliation gate")
+	requireStartupMaintenanceReleased(t, engine)
+}
+
+// TestForegroundResyncRunnerAbortedResyncFallsBackIncremental verifies the
+// in-process fallback keeps SyncThenRun's abort semantics: a safely aborted
+// resync catches up with an incremental pass instead of surfacing the bare
+// abort, and startup still reconciles and releases maintenance.
+func TestForegroundResyncRunnerAbortedResyncFallsBackIncremental(t *testing.T) {
+	database := dbtest.OpenTestDB(t)
+	missingPath := filepath.Join(t.TempDir(), "missing.jsonl")
+	dbtest.SeedSession(t, database, "existing", "proj", func(s *db.Session) {
+		s.FilePath = &missingPath
+	})
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		Machine:                 "local",
+		DeferStartupMaintenance: true,
+	})
+	t.Cleanup(engine.Close)
+
+	runner := newForegroundResyncRunner(
+		context.Background(), config.Config{}, engine, database,
+	)
+	stats, err := runner(context.Background(), nil)
+
+	require.NoError(t, err)
+	assert.False(t, stats.Aborted,
+		"a safely aborted resync must fall back to an incremental sync")
+	assert.True(t, engine.StartupReconciled(),
+		"the incremental fallback pass reconciles startup")
+	requireStartupMaintenanceReleased(t, engine)
+}
+
+// TestSyncAllReleasingStartupMaintenance covers the worker-aborted resync arm
+// (unreachable under a test binary): a completed incremental catch-up must
+// release the startup-maintenance gate, while a cancelled pass leaves the gate
+// closed so the deferred startup fallback still owns recovery.
+func TestSyncAllReleasingStartupMaintenance(t *testing.T) {
+	t.Run("releases after completed pass", func(t *testing.T) {
+		database := dbtest.OpenTestDB(t)
+		engine := sync.NewEngine(database, sync.EngineConfig{
+			Machine:                 "local",
+			DeferStartupMaintenance: true,
+		})
+		t.Cleanup(engine.Close)
+
+		syncAllReleasingStartupMaintenance(context.Background(), engine, nil)
+
+		requireStartupMaintenanceReleased(t, engine)
+	})
+	t.Run("releases when cancelled after reconciliation", func(t *testing.T) {
+		database := dbtest.OpenTestDB(t)
+		engine := sync.NewEngine(database, sync.EngineConfig{
+			Machine:                 "local",
+			DeferStartupMaintenance: true,
+		})
+		t.Cleanup(engine.Close)
+		// A completed pass closes the startup-reconciliation gate (SyncAll
+		// records it internally but never releases maintenance) ...
+		engine.SyncAll(context.Background(), nil)
+		require.True(t, engine.StartupReconciled(),
+			"a completed pass must close the reconciliation gate")
+
+		// ... and cancellation can land before the helper's own ctx check.
+		// The deferred startup fallback skips on the closed reconciliation
+		// gate without releasing, so the helper must release here or
+		// archive-wide backfills stay gated until shutdown.
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		syncAllReleasingStartupMaintenance(ctx, engine, nil)
+
+		requireStartupMaintenanceReleased(t, engine)
+	})
+	t.Run("keeps gate closed when cancelled", func(t *testing.T) {
+		database := dbtest.OpenTestDB(t)
+		engine := sync.NewEngine(database, sync.EngineConfig{
+			Machine:                 "local",
+			DeferStartupMaintenance: true,
+		})
+		t.Cleanup(engine.Close)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		syncAllReleasingStartupMaintenance(ctx, engine, nil)
+
+		maintenanceErr := make(chan error, 1)
+		blockedCtx, blockedCancel := context.WithTimeout(
+			context.Background(), 100*time.Millisecond,
+		)
+		defer blockedCancel()
+		go func() {
+			maintenanceErr <- engine.RunStartupMaintenance(
+				blockedCtx, func() error { return nil },
+			)
+		}()
+		require.ErrorIs(t, <-maintenanceErr, context.DeadlineExceeded,
+			"a cancelled pass must leave maintenance to the deferred fallback")
+	})
+}

--- a/cmd/agentsview/startup_sync_fallback_test.go
+++ b/cmd/agentsview/startup_sync_fallback_test.go
@@ -3,31 +3,109 @@
 package main
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/dbtest"
 	syncpkg "go.kenn.io/agentsview/internal/sync"
 )
 
 func TestRunDeferredStartupSyncFallbackPerformsSkippedSync(t *testing.T) {
 	database := dbtest.OpenTestDB(t)
+	reconciled := make(chan struct{}, 1)
 	engine := syncpkg.NewEngine(database, syncpkg.EngineConfig{
 		Machine:                 "local",
 		DeferStartupMaintenance: true,
+		OnStartupReconciled: func(syncpkg.SyncStats, error) {
+			reconciled <- struct{}{}
+		},
 	})
 	t.Cleanup(engine.Close)
 	timeout := make(chan time.Time, 1)
 	timeout <- time.Now()
 
+	// Under a test binary the worker path is skipped (testing.Testing()), so
+	// the fallback runs the in-process sync; database/lock stay unused.
 	ran, err := runDeferredStartupSyncFallback(
-		t.Context(), engine, nil, timeout,
+		t.Context(), config.Config{}, engine, database, nil, nil, timeout,
 	)
 
 	require.NoError(t, err)
 	assert.True(t, ran)
 	assert.False(t, engine.LastSyncStartedAt().IsZero(),
 		"timeout fallback must perform the skipped local sync")
+	select {
+	case <-reconciled:
+	case <-time.After(time.Second):
+		require.FailNow(t, "deferred fallback did not reconcile watcher startup")
+	}
+}
+
+// TestRunDeferredStartupSyncFallbackSkipsWhenAlreadyReconciled proves the gate
+// that avoids a redundant pass: once a foreground request has driven startup
+// reconciliation, the deferred fallback performs no sync.
+func TestRunDeferredStartupSyncFallbackSkipsWhenAlreadyReconciled(t *testing.T) {
+	database := dbtest.OpenTestDB(t)
+	engine := syncpkg.NewEngine(database, syncpkg.EngineConfig{
+		Machine:                 "local",
+		DeferStartupMaintenance: true,
+	})
+	t.Cleanup(engine.Close)
+	engine.RecordStartupReconciled(syncpkg.SyncStats{}, nil)
+	require.True(t, engine.StartupReconciled())
+
+	timeout := make(chan time.Time, 1)
+	timeout <- time.Now()
+	ran, err := runDeferredStartupSyncFallback(
+		t.Context(), config.Config{}, engine, database, nil, nil, timeout,
+	)
+
+	require.NoError(t, err)
+	assert.False(t, ran, "already-reconciled startup must skip the deferred sync")
+	assert.True(t, engine.LastSyncStartedAt().IsZero(),
+		"no redundant local sync should run")
+}
+
+// TestForegroundSyncRunnerReconcilesStartup covers Finding 2: the daemon's
+// foreground local-sync runner must reconcile startup so an `agentsview sync`
+// that drives the sync opens watcher dispatch. Under a test binary the runner
+// takes the in-process SyncThenRun arm, which reconciles natively; production's
+// worker arm mirrors it with RecordStartupReconciled.
+func TestForegroundSyncRunnerReconcilesStartup(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	database := dbtest.OpenTestDBAt(t, cfg.DBPath)
+	opened := make(chan struct{}, 1)
+	engine := syncpkg.NewEngine(database, syncpkg.EngineConfig{
+		AgentDirs:               cfg.AgentDirs,
+		Machine:                 "local",
+		DeferStartupMaintenance: true,
+		OnStartupReconciled: newStartupReconciliationHandler(
+			t.Context(),
+			func(context.Context) error { return nil },
+			func() {
+				select {
+				case opened <- struct{}{}:
+				default:
+				}
+			},
+		),
+	})
+	t.Cleanup(engine.Close)
+
+	runner := newForegroundSyncRunner(context.Background(), cfg, engine, database, nil)
+	stats, err := runner(t.Context(), nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, 3, stats.Synced, "foreground runner syncs the fixture archive")
+	assert.True(t, engine.StartupReconciled(),
+		"foreground sync must reconcile startup")
+	select {
+	case <-opened:
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "foreground runner did not open watcher dispatch")
+	}
 }

--- a/cmd/agentsview/startup_worker_test.go
+++ b/cmd/agentsview/startup_worker_test.go
@@ -1,0 +1,369 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/parser"
+	syncpkg "go.kenn.io/agentsview/internal/sync"
+)
+
+// engineWithDispatchHandler builds an engine over the fixture archive whose
+// OnStartupReconciled is the real startup reconciliation handler, so opening
+// dispatch (leaving collecting mode) is observable through openedDispatch.
+func engineWithDispatchHandler(
+	t *testing.T, cfg config.Config, openedDispatch chan<- struct{},
+) *syncpkg.Engine {
+	t.Helper()
+	database := dbtest.OpenTestDBAt(t, cfg.DBPath)
+	engine := syncpkg.NewEngine(database, syncpkg.EngineConfig{
+		AgentDirs: cfg.AgentDirs,
+		Machine:   "local",
+		OnStartupReconciled: newStartupReconciliationHandler(
+			t.Context(),
+			func(context.Context) error { return nil },
+			func() {
+				select {
+				case openedDispatch <- struct{}{}:
+				default:
+				}
+			},
+		),
+	})
+	t.Cleanup(engine.Close)
+	return engine
+}
+
+// TestStartupWorkerPathOpensWatcherDispatch reproduces the daemon side of the
+// worker handshake: after the worker's out-of-process pass, the daemon runs the
+// gap reconciliation and acknowledges startup, which must fire
+// OnStartupReconciled and open watcher dispatch.
+func TestStartupWorkerPathOpensWatcherDispatch(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	opened := make(chan struct{}, 1)
+	engine := engineWithDispatchHandler(t, cfg, opened)
+
+	// Gap reconciliation over all watch roots (warm; here it also performs the
+	// first sync since the fixture DB is empty), then acknowledge startup with
+	// the worker's terminal result.
+	gapErr := engine.ReconcileWatchRoots(t.Context(), reconcileRootPaths(cfg), true)
+	require.NoError(t, gapErr)
+	engine.RecordStartupReconciled(
+		statsFromWorkerResult(workerResult{
+			Status: "ok", Synced: 3, DiscoveryComplete: true,
+		}),
+		gapErr,
+	)
+
+	select {
+	case <-opened:
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "watcher dispatch did not open after worker handshake")
+	}
+}
+
+// TestStartupWorkerPathDefersMaintenanceUntilReconciled pins the worker-path
+// maintenance gate: with a completed worker pass the daemon defers the gap
+// reconciliation until after the HTTP server starts, so archive-wide startup
+// maintenance must not acquire the sync mutex before that reconciliation.
+// The gate opens only through RecordStartupReconciled.
+func TestStartupWorkerPathDefersMaintenanceUntilReconciled(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	database := dbtest.OpenTestDBAt(t, cfg.DBPath)
+	engine := syncpkg.NewEngine(database, syncpkg.EngineConfig{
+		AgentDirs: cfg.AgentDirs,
+		Machine:   "local",
+		DeferStartupMaintenance: deferStartupMaintenance(
+			false, true, // serve path: initial sync not skipped, worker ran
+		),
+	})
+	t.Cleanup(engine.Close)
+
+	maintenanceRan := make(chan struct{})
+	go func() {
+		_ = engine.RunStartupMaintenance(t.Context(), func() error {
+			close(maintenanceRan)
+			return nil
+		})
+	}()
+
+	select {
+	case <-maintenanceRan:
+		require.FailNow(t,
+			"startup maintenance must wait for the deferred gap reconciliation")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	gapErr := engine.ReconcileWatchRoots(t.Context(), reconcileRootPaths(cfg), true)
+	require.NoError(t, gapErr)
+	engine.RecordStartupReconciled(
+		statsFromWorkerResult(workerResult{
+			Status: "ok", Synced: 3, DiscoveryComplete: true,
+		}),
+		gapErr,
+	)
+
+	select {
+	case <-maintenanceRan:
+	case <-time.After(2 * time.Second):
+		require.FailNow(t,
+			"maintenance never released after RecordStartupReconciled")
+	}
+}
+
+// TestStartupWorkerFailureFallsBackInProcess asserts that a failed worker launch
+// is surfaced (so runServe falls back), and the in-process initial sync still
+// reconciles startup and opens dispatch.
+func TestStartupWorkerFailureFallsBackInProcess(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+
+	restore := stubLaunchSyncWorker(t, func(
+		context.Context, config.Config, string, func(workerLine),
+	) (workerResult, error) {
+		return workerResult{}, errors.New("spawn boom")
+	})
+	defer restore()
+
+	_, err := runStartupSyncViaWorker(
+		t.Context(), cfg, newStartupStateWriter(cfg.DataDir, time.Now),
+	)
+	require.Error(t, err, "worker failure must be surfaced so the daemon falls back")
+
+	opened := make(chan struct{}, 1)
+	engine := engineWithDispatchHandler(t, cfg, opened)
+	stats := runInitialSync(t.Context(), engine, nil)
+	assert.False(t, stats.Aborted)
+	assert.Equal(t, 3, stats.Synced, "in-process fallback syncs the fixture archive")
+	select {
+	case <-opened:
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "in-process fallback did not open dispatch")
+	}
+}
+
+// TestStartupWorkerOutcomeDiscriminatesSpawnFromRanFailed pins the Finding 1
+// contract: a spawn failure asks the caller to fall back in process, while a
+// worker that ran and reported failure is carried forward as an aborted result
+// so the caller surfaces it without re-syncing.
+func TestStartupWorkerOutcomeDiscriminatesSpawnFromRanFailed(t *testing.T) {
+	ok := workerResult{Status: "ok", Synced: 3, DiscoveryComplete: true}
+
+	tests := []struct {
+		name        string
+		result      workerResult
+		err         error
+		wantDone    bool
+		wantAborted bool
+		wantSynced  int
+	}{
+		{
+			name:       "completed",
+			result:     ok,
+			err:        nil,
+			wantDone:   true,
+			wantSynced: 3,
+		},
+		{
+			name:     "spawn failure falls back in process",
+			result:   workerResult{},
+			err:      fmt.Errorf("%w: exec: boom", errWorkerSpawn),
+			wantDone: false,
+		},
+		{
+			name: "ran and failed carries aborted result",
+			result: workerResult{
+				Status: "aborted", Synced: 1, DiscoveryComplete: false,
+			},
+			err:         errors.New("startup worker pass reported aborted"),
+			wantDone:    true,
+			wantAborted: true,
+			wantSynced:  1,
+		},
+		{
+			name:        "ran and failed with unusable result is synthesized",
+			result:      workerResult{},
+			err:         errors.New("startup worker emitted 0 terminal results"),
+			wantDone:    true,
+			wantAborted: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, done := startupWorkerOutcome(tc.result, tc.err)
+			assert.Equal(t, tc.wantDone, done)
+			if !done {
+				// A spawn failure discards the result and falls back in process.
+				return
+			}
+			stats := statsFromWorkerResult(got)
+			assert.Equal(t, tc.wantAborted, stats.Aborted)
+			assert.Equal(t, tc.wantSynced, stats.Synced)
+		})
+	}
+}
+
+// TestStartupWorkerRanFailedSurfacedWithoutResync exercises the Finding 1 daemon
+// path end to end: the worker ran and returned a valid terminal result with a
+// non-spawn error. The daemon must NOT fall back to the in-process initial sync
+// (done stays true), and the gap reconciliation plus RecordStartupReconciled
+// still open watcher dispatch, carrying the worker's aborted stats.
+func TestStartupWorkerRanFailedSurfacedWithoutResync(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+
+	restore := stubLaunchSyncWorker(t, func(
+		context.Context, config.Config, string, func(workerLine),
+	) (workerResult, error) {
+		return workerResult{Status: "aborted", DiscoveryComplete: false},
+			errors.New("startup worker pass reported aborted")
+	})
+	defer restore()
+
+	result, syncErr := runStartupSyncViaWorker(
+		t.Context(), cfg, newStartupStateWriter(cfg.DataDir, time.Now),
+	)
+	require.Error(t, syncErr)
+	require.False(t, errors.Is(syncErr, errWorkerSpawn),
+		"ran-and-failed must be distinct from spawn failure")
+
+	carried, done := startupWorkerOutcome(result, syncErr)
+	require.True(t, done, "daemon must not re-run the in-process initial sync")
+	stats := statsFromWorkerResult(carried)
+	require.True(t, stats.Aborted, "carried stats must reflect the aborted pass")
+
+	opened := make(chan struct{}, 1)
+	engine := engineWithDispatchHandler(t, cfg, opened)
+	gapErr := engine.ReconcileWatchRoots(t.Context(), reconcileRootPaths(cfg), true)
+	engine.RecordStartupReconciled(stats, gapErr)
+
+	select {
+	case <-opened:
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "dispatch did not open after ran-and-failed handshake")
+	}
+}
+
+func TestStatsFromWorkerResultMapsDiscoveryOntoAborted(t *testing.T) {
+	complete := statsFromWorkerResult(workerResult{
+		Status: "ok", Synced: 5, Skipped: 1, Failed: 0, DiscoveryComplete: true,
+	})
+	assert.False(t, complete.Aborted)
+	assert.True(t, complete.AuthoritativeDiscoveryComplete())
+	assert.Equal(t, 5, complete.Synced)
+
+	incomplete := statsFromWorkerResult(workerResult{
+		Status: "aborted", DiscoveryComplete: false,
+	})
+	assert.True(t, incomplete.Aborted)
+	assert.False(t, incomplete.AuthoritativeDiscoveryComplete())
+}
+
+func TestSyncWorkerChildArgsForwardsServeConfigFlags(t *testing.T) {
+	parent := []string{
+		"serve", "--host", "0.0.0.0", "--port", "9999",
+		"--background", "--pprof",
+	}
+	args := syncWorkerChildArgs(parent, "startup")
+
+	require.Equal(t, "sync-worker", args[0])
+	assert.Equal(t, []string{"--mode", "startup"}, args[1:3])
+	assert.Contains(t, args, "--host=0.0.0.0", "serve config flag forwarded")
+	assert.Contains(t, args, "--port=9999", "serve config flag forwarded")
+	for _, a := range args {
+		assert.NotContains(t, a, "background",
+			"serve-only lifecycle flag must not reach the worker")
+		assert.NotContains(t, a, "pprof",
+			"serve-only lifecycle flag must not reach the worker")
+	}
+}
+
+// TestSyncWorkerRealSpawnEmitsTerminalResult self-execs the built command in
+// worker mode against an isolated fixture archive and validates the on-the-wire
+// protocol: NDJSON lines, exactly one terminal result, exit 0.
+func TestSyncWorkerRealSpawnEmitsTerminalResult(t *testing.T) {
+	if testing.Short() {
+		t.Skip("real-spawn worker test re-execs the binary; skipped in -short")
+	}
+	cfg := testConfigWithClaudeFixture(t)
+	claudeDir := cfg.AgentDirs[parser.AgentClaude][0]
+
+	cmd := exec.Command(
+		os.Args[0],
+		"-test.run=^TestSyncWorkerMainHelperProcess$",
+		"--",
+		"sync-worker", "--mode", "startup",
+	)
+	// Minimal, isolated env so no developer/CI agent directory is scanned.
+	// os.UserHomeDir reads HOME on Unix but USERPROFILE on Windows, so the
+	// isolated home must be exported under both names.
+	home := t.TempDir()
+	cmd.Env = []string{
+		"PATH=" + os.Getenv("PATH"),
+		"HOME=" + home,
+		"USERPROFILE=" + home,
+		"AGENTSVIEW_SYNC_WORKER_MAIN_HELPER=1",
+		"AGENTSVIEW_DATA_DIR=" + cfg.DataDir,
+		"CLAUDE_PROJECTS_DIR=" + claudeDir,
+	}
+	// The Go runtime and SQLite need core system variables on Windows;
+	// passing them through keeps the env minimal without breaking the child.
+	for _, key := range []string{"SYSTEMROOT", "TEMP", "TMP"} {
+		if value := os.Getenv(key); value != "" {
+			cmd.Env = append(cmd.Env, key+"="+value)
+		}
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	require.NoError(t, cmd.Run(),
+		"worker must exit 0 on an authoritative pass; stderr:\n%s", stderr.String())
+
+	var results []workerResult
+	sawProgress := false
+	sc := bufio.NewScanner(&stdout)
+	for sc.Scan() {
+		var line workerLine
+		require.NoError(t, json.Unmarshal(sc.Bytes(), &line),
+			"every stdout line must be a workerLine JSON object; got %q", sc.Text())
+		if line.Progress != nil {
+			sawProgress = true
+		}
+		if line.Result != nil {
+			results = append(results, *line.Result)
+		}
+	}
+	require.NoError(t, sc.Err())
+	assert.True(t, sawProgress, "worker must stream progress")
+	require.Len(t, results, 1, "exactly one terminal result")
+	assert.Equal(t, "ok", results[0].Status)
+	assert.True(t, results[0].DiscoveryComplete)
+	assert.Equal(t, 3, results[0].Synced)
+}
+
+// TestSyncWorkerMainHelperProcess is the re-exec target for the real-spawn test.
+// It runs the actual CLI (via main) so os.Args[0] behaves like the agentsview
+// binary, then exits 0 to suppress the test framework's own stdout output.
+func TestSyncWorkerMainHelperProcess(t *testing.T) {
+	if os.Getenv("AGENTSVIEW_SYNC_WORKER_MAIN_HELPER") != "1" {
+		return
+	}
+	for i, arg := range os.Args {
+		if arg == "--" {
+			os.Args = append([]string{"agentsview"}, os.Args[i+1:]...)
+			main()
+			os.Exit(0)
+		}
+	}
+	t.Fatal("missing helper args")
+}

--- a/cmd/agentsview/sync.go
+++ b/cmd/agentsview/sync.go
@@ -21,6 +21,7 @@ import (
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/remotesync"
+	"go.kenn.io/agentsview/internal/server"
 	"go.kenn.io/agentsview/internal/ssh"
 	"go.kenn.io/agentsview/internal/sync"
 )
@@ -131,6 +132,22 @@ func doSync(cfg SyncConfig) (hadRemoteFailures bool) {
 					onProgress,
 				)
 				if progress != nil {
+					progress.Finish()
+				}
+				if errors.Is(err, errDaemonResyncRequired) {
+					// The archive's data version changed and the
+					// worker-backed daemon refuses to swap it under itself
+					// via /sync; the dedicated resync route rebuilds and
+					// swaps safely, preserving the previously automatic
+					// upgrade behavior.
+					fmt.Println(
+						"Archive data version changed; running full resync via daemon...",
+					)
+					progress = newResyncProgressPrinter(os.Stdout, time.Now)
+					stats, err = runDaemonSync(
+						context.Background(), tr, appCfg.AuthToken, true,
+						progress.Print,
+					)
 					progress.Finish()
 				}
 				if err != nil {
@@ -406,6 +423,7 @@ var prepareHTTPRebuildCLI = func(
 
 var runLocalSyncWithRebuildCLI = runLocalSyncWithRebuild
 var runLocalSyncWithFallbackCLI = runLocalSyncWithFallback
+var coordinateLocalSyncRunner = coordinateLocalSync
 
 type preparedHTTPRebuildLeaseCLI struct {
 	prepared preparedHTTPRebuildCLI
@@ -746,6 +764,33 @@ func primaryCoordinatorError(err error) error {
 func runLocalSync(
 	ctx context.Context, appCfg config.Config, database *db.DB, full bool,
 ) bool {
+	didResync, _, err := runLocalSyncResult(ctx, appCfg, database, full)
+	if err != nil {
+		log.Printf("local sync failed: %v", err)
+	}
+	return didResync
+}
+
+// runLocalSyncAuthoritative runs a local sync and returns an error unless its
+// provider discovery completed authoritatively. Push-watch callers use it so
+// a mirror update cannot acknowledge watcher reconciliation that never
+// established a complete view of the local sources.
+func runLocalSyncAuthoritative(
+	ctx context.Context, appCfg config.Config, database *db.DB, full bool,
+) (bool, error) {
+	didResync, stats, err := runLocalSyncResult(ctx, appCfg, database, full)
+	if err != nil {
+		return didResync, err
+	}
+	if !stats.AuthoritativeDiscoveryComplete() {
+		return didResync, errors.New("local sync discovery incomplete")
+	}
+	return didResync, nil
+}
+
+func runLocalSyncResult(
+	ctx context.Context, appCfg config.Config, database *db.DB, full bool,
+) (bool, sync.SyncStats, error) {
 	didResync := full || database.NeedsResync()
 	var progress sync.ProgressFunc
 	var resyncProgress *resyncProgressPrinter
@@ -758,7 +803,7 @@ func runLocalSync(
 		progress = printSyncProgress
 	}
 	started := time.Now()
-	didResync, stats, err := coordinateLocalSync(
+	didResync, stats, err := coordinateLocalSyncRunner(
 		ctx, appCfg, database, full, progress, true,
 		func() (sync.RebuildOptions, sync.RebuildCleanup, error) {
 			return sync.RebuildOptions{}, nil, nil
@@ -768,11 +813,8 @@ func runLocalSync(
 	if resyncProgress != nil {
 		resyncProgress.Finish()
 	}
-	if err != nil {
-		log.Printf("local sync failed: %v", err)
-	}
 	printDirectSyncResult(ctx, database, stats, started)
-	return didResync
+	return didResync, stats, err
 }
 
 func runLocalSyncWithRebuild(
@@ -891,6 +933,11 @@ func printDirectSyncResult(
 	}
 }
 
+// errDaemonResyncRequired marks a /sync rejected because the archive's data
+// version changed: the worker-backed daemon will not swap a stale archive
+// under itself, so the CLI must retry through /api/v1/resync.
+var errDaemonResyncRequired = errors.New("daemon requires a full resync")
+
 func runDaemonSync(
 	ctx context.Context,
 	tr transport,
@@ -920,9 +967,15 @@ func runDaemonSync(
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		msg, _ := io.ReadAll(resp.Body)
-		return sync.SyncStats{}, fmt.Errorf(
+		httpErr := fmt.Errorf(
 			"HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(msg)),
 		)
+		if !full && resp.Header.Get(server.ResyncRequiredHeader) != "" {
+			return sync.SyncStats{}, fmt.Errorf(
+				"%w: %w", errDaemonResyncRequired, httpErr,
+			)
+		}
+		return sync.SyncStats{}, httpErr
 	}
 	if strings.HasPrefix(
 		resp.Header.Get("Content-Type"), "application/json",

--- a/cmd/agentsview/sync_test.go
+++ b/cmd/agentsview/sync_test.go
@@ -28,6 +28,7 @@ import (
 	"go.kenn.io/agentsview/internal/dbtest"
 	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/remotesync"
+	"go.kenn.io/agentsview/internal/server"
 	agentsync "go.kenn.io/agentsview/internal/sync"
 	"go.kenn.io/agentsview/internal/testjsonl"
 	"go.kenn.io/kit/daemon"
@@ -1701,6 +1702,42 @@ func TestRunDaemonSyncTrimsBaseURLTrailingSlash(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, syncCalled)
 	assert.Equal(t, 7, stats.Synced)
+}
+
+// TestRunDaemonSyncDetectsResyncRequired pins the stale-archive UX: only a
+// /sync rejection carrying the resync-required header maps to
+// errDaemonResyncRequired (so the CLI retries via /api/v1/resync); a plain
+// non-200, or the same header on an already-full resync request, stays a
+// generic error.
+func TestRunDaemonSyncDetectsResyncRequired(t *testing.T) {
+	tests := []struct {
+		name       string
+		withHeader bool
+		full       bool
+		wantResync bool
+	}{
+		{name: "409 with header on sync", withHeader: true, wantResync: true},
+		{name: "409 without header", withHeader: false, wantResync: false},
+		{name: "409 with header on resync", withHeader: true, full: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := syncRouteTestServer(t, func(w http.ResponseWriter, _ *http.Request) {
+				if tt.withHeader {
+					w.Header().Set(server.ResyncRequiredHeader, "true")
+				}
+				w.WriteHeader(http.StatusConflict)
+			})
+
+			_, err := runDaemonSync(
+				context.Background(), transport{URL: ts.URL}, "", tt.full, nil,
+			)
+			require.Error(t, err)
+			assert.Equal(t, tt.wantResync,
+				errors.Is(err, errDaemonResyncRequired))
+			assert.Contains(t, err.Error(), "HTTP 409")
+		})
+	}
 }
 
 func TestDoSyncRemoteHostUsesDaemonRouteWhenWritableDaemonRunning(t *testing.T) {

--- a/cmd/agentsview/sync_worker.go
+++ b/cmd/agentsview/sync_worker.go
@@ -1,0 +1,367 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/sync"
+)
+
+// syncWorkerChildEnvVar marks a process spawned as a sync-worker child by the
+// daemon's writer handoff. The daemon closes its writer and releases the write
+// lock before spawning, so the child skips the live-writable-daemon rejection
+// (the daemon is knowingly yielding); the write-owner flock remains the real
+// guard.
+const syncWorkerChildEnvVar = "AGENTSVIEW_SYNC_WORKER"
+
+// runningAsSyncWorker reports whether this process is a sync-worker child
+// spawned by a daemon that has yielded write ownership for the pass.
+func runningAsSyncWorker() bool {
+	return os.Getenv(syncWorkerChildEnvVar) == "1"
+}
+
+// workerLine is one NDJSON record on the sync-worker's stdout. Every stdout
+// line unmarshals to a workerLine; log diagnostics are redirected to debug.log
+// (setupLogFile) and anything else lands on inherited stderr, so the parent can
+// parse stdout strictly. A run streams zero or more Progress lines followed by
+// exactly one Result line.
+type workerLine struct {
+	Progress *sync.Progress `json:"progress,omitempty"`
+	Result   *workerResult  `json:"result,omitempty"`
+}
+
+// workerResult is the single terminal record a sync-worker run emits. Status is
+// "ok" only when the pass completed and discovery was authoritative; the parent
+// treats anything else, or a missing/duplicate result, as a failed run.
+type workerResult struct {
+	Status            string `json:"status"` // "ok" | "aborted" | "failed"
+	Synced            int    `json:"synced"`
+	Skipped           int    `json:"skipped"`
+	Failed            int    `json:"failed"`
+	Tombstoned        int    `json:"tombstoned,omitempty"`
+	DiscoveryComplete bool   `json:"discoveryComplete"`
+	Error             string `json:"error,omitempty"`
+	// Stats carries the complete public SyncStats payload so the daemon's
+	// /sync and /resync responses keep result parity with in-process passes
+	// (total sessions, orphan counts, warnings, anomalies). The summary
+	// counters above remain the authoritative status inputs.
+	Stats *sync.SyncStats `json:"stats,omitempty"`
+}
+
+// newSyncWorkerCommand registers the hidden self-exec'd worker. The daemon runs
+// it as a short-lived child so archive-scale allocation high-water returns to
+// the OS when the child exits, instead of pinning the daemon's RSS.
+func newSyncWorkerCommand() *cobra.Command {
+	var mode string
+	cmd := &cobra.Command{
+		Use:          "sync-worker",
+		Short:        "Run one heavy sync pass and stream a terminal result",
+		Hidden:       true,
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			// Load config the same flag-aware way `serve` does so config flags
+			// the daemon forwarded into the child argv (see syncWorkerChildArgs)
+			// override env/config.toml identically to a serve --background child.
+			cfg, err := config.LoadPFlags(cmd.Flags())
+			if err != nil {
+				return fmt.Errorf("sync-worker: loading config: %w", err)
+			}
+			// Route log output to debug.log like every other subcommand.
+			// The daemon passes its own stderr to this child, so engine
+			// log.Printf diagnostics would otherwise flood the serve
+			// console instead of landing in the debug log.
+			setupLogFile(cfg.DataDir)
+			return runSyncWorker(cfg, mode, cmd.OutOrStdout())
+		},
+	}
+	cmd.Flags().StringVar(
+		&mode, "mode", "",
+		"worker mode: startup, sync, resync-build, audit",
+	)
+	if err := cmd.MarkFlagRequired("mode"); err != nil {
+		panic(err)
+	}
+	// Register the serve config flags so forwarded overrides parse and apply.
+	config.RegisterServePFlags(cmd.Flags())
+	return cmd
+}
+
+// runSyncWorker runs one worker pass with a background context.
+func runSyncWorker(cfg config.Config, mode string, out io.Writer) error {
+	return runSyncWorkerContext(context.Background(), cfg, mode, out)
+}
+
+// runSyncWorkerContext dispatches on mode, streaming NDJSON progress and exactly
+// one terminal result. It returns nil only when the terminal result is Status
+// "ok" with authoritative discovery; the child's exit code follows this error.
+func runSyncWorkerContext(
+	ctx context.Context, cfg config.Config, mode string, out io.Writer,
+) error {
+	enc := json.NewEncoder(out)
+	// Retain the first encode error: a dropped terminal-result line means the
+	// parent never sees the outcome, so the worker must exit non-zero even if the
+	// pass itself succeeded. The parent also treats a missing result as a
+	// protocol failure, but the worker's own exit contract must not lie.
+	var encErr error
+	emit := func(line workerLine) {
+		if err := enc.Encode(line); err != nil && encErr == nil {
+			encErr = err
+		}
+	}
+	onProgress := func(p sync.Progress) { emit(workerLine{Progress: &p}) }
+	var err error
+	switch mode {
+	case "startup", "sync", "audit":
+		// All three share the sync body. Only "startup" may resync-and-swap: it
+		// runs before the daemon opens the DB, so no live reader pins the old
+		// inode. "sync" (live foreground pass) and "audit" (daily safety net)
+		// run inside a writer handoff while the daemon's readers stay open, so
+		// they must refuse a stale-version archive rather than swap it out from
+		// under those readers; the real resync path is the resync-build flow,
+		// which swaps and resets caches daemon-side.
+		err = runSyncWorkerStartup(ctx, cfg, mode, emit, onProgress)
+	case "resync-build":
+		err = runSyncWorkerResyncBuild(ctx, cfg, mode, emit, onProgress)
+	default:
+		return fmt.Errorf("unknown sync-worker mode %q", mode)
+	}
+	if err != nil {
+		return err
+	}
+	if encErr != nil {
+		return fmt.Errorf("sync worker %s: writing terminal result: %w", mode, encErr)
+	}
+	return nil
+}
+
+// runSyncWorkerStartup performs a full sync (or full resync when the data
+// version changed) as a self-contained pass, then emits the terminal result. It
+// mirrors the sync/resync branch in runServe minus daemon-only wiring (watcher,
+// emitter, backfills). mode only labels the terminal error.
+func runSyncWorkerStartup(
+	ctx context.Context,
+	cfg config.Config,
+	mode string,
+	emit func(workerLine),
+	onProgress func(sync.Progress),
+) error {
+	database, writeLock, err := openWorkerWriteDB(cfg)
+	if err != nil {
+		return err
+	}
+	defer closeWriteDB(database, writeLock)
+
+	// Remove stale temp DB from a prior crashed resync before ResyncAll
+	// stages a fresh one, matching runServe's startup cleanup.
+	cleanResyncTemp(cfg.DBPath)
+
+	engine := sync.NewEngine(database, workerEngineConfig(cfg))
+	defer engine.Close()
+
+	if database.NeedsResync() && mode != "startup" {
+		// A resync would CloseConnections + rename the archive file, but the
+		// daemon's reader pool still points at the old inode and only the writer
+		// is reopened by path afterward. Swapping here would strand readers on a
+		// deleted file; refuse and let the resync-build flow do the swap.
+		return refuseWorkerResync(mode, emit)
+	}
+
+	var result workerResult
+	switch {
+	case database.NeedsResync():
+		stats := engine.ResyncAll(ctx, onProgress)
+		if stats.Aborted && ctx.Err() == nil {
+			// Mirror the in-process startup path (runInitialResync,
+			// syncThenRunLocked): a safety-aborted resync still catches up
+			// incrementally against the existing archive instead of leaving
+			// safely applicable updates unsynchronized.
+			stats = engine.SyncAll(ctx, onProgress)
+		}
+		result = workerResultFromStats(ctx, stats)
+	case mode == "audit":
+		// The audit is the safety net for watcher deletions the daemon
+		// missed, so it must run the authoritative reconciliation that
+		// tombstones sessions whose sources disappeared; SyncAll never
+		// tombstones. Unavailable scopes are deferred to their probes:
+		// reconciling them would read an unmounted or missing subtree as
+		// an empty discovery and tombstone every session beneath it.
+		var stats sync.SyncStats
+		var tombstoned int
+		var auditErr error
+		if auditRoots := reconcileRootPaths(cfg); len(auditRoots) > 0 {
+			stats, tombstoned, auditErr = engine.ReconcileWatchRootsWithStats(
+				ctx, auditRoots, false,
+			)
+		}
+		result = workerResultFromStats(ctx, stats)
+		result.Tombstoned = tombstoned
+		if auditErr != nil && result.Status == "ok" {
+			result.Status = "failed"
+			result.Error = auditErr.Error()
+		}
+	default:
+		result = workerResultFromStats(ctx, engine.SyncAll(ctx, onProgress))
+	}
+
+	emit(workerLine{Result: &result})
+	if result.Status != "ok" || !result.DiscoveryComplete {
+		return fmt.Errorf("sync worker %s: %s", mode, result.Status)
+	}
+	return nil
+}
+
+// runSyncWorkerResyncBuild builds a replacement archive at the resync temp path
+// from a read-only view of the original, then emits the terminal result. The
+// daemon holds the write barrier and performs the swap, so the worker never
+// opens the live archive writable and needs no write-owner flock. It leaves the
+// built database on disk at ResyncTempPath for the daemon to install.
+func runSyncWorkerResyncBuild(
+	ctx context.Context,
+	cfg config.Config,
+	mode string,
+	emit func(workerLine),
+	onProgress func(sync.Progress),
+) error {
+	// Remove a stale temp DB from a prior crashed resync before building a fresh
+	// one, matching runServe's startup cleanup and the in-process build.
+	cleanResyncTemp(cfg.DBPath)
+
+	// The worker is a fresh process, so the classifier singleton holds only
+	// built-in patterns until config is applied. The build classifies every
+	// session in the replacement archive (insert-time plus the forced
+	// is_automated backfill), so user patterns must be installed first. The
+	// other worker modes inherit this through openWorkerWriteDB -> openDB.
+	applyClassifierConfig(cfg)
+
+	origRO, err := db.OpenReadOnly(cfg.DBPath)
+	if err != nil {
+		return fmt.Errorf("resync-build: open read-only archive: %w", err)
+	}
+	defer origRO.Close()
+
+	engine := sync.NewEngine(origRO, workerEngineConfig(cfg))
+	defer engine.Close()
+
+	_, stats, buildErr := engine.ResyncBuild(ctx, onProgress)
+	result := resyncBuildResultFromStats(ctx, stats, buildErr)
+	emit(workerLine{Result: &result})
+	if result.Status != "ok" || !result.DiscoveryComplete {
+		if buildErr != nil {
+			return fmt.Errorf("sync worker %s: %w", mode, buildErr)
+		}
+		return fmt.Errorf("sync worker %s: %s", mode, result.Status)
+	}
+	return nil
+}
+
+// resyncBuildResultFromStats maps a resync build outcome to a terminal result.
+// Unlike a live sync pass, a completed build tolerates a minority of permanent
+// parse failures: shouldAbortResyncSwap already folded that judgment into
+// stats.Aborted, so Failed alone must not fail the pass and make the daemon
+// discard an otherwise valid replacement of a stale-version archive.
+//
+// Operational failures (buildErr) classify as "failed" even when the engine
+// also set stats.Aborted, such as a temp-DB create failure: "aborted" is
+// reserved for cancellation and explicit no-error safety aborts, because the
+// daemon responds to "aborted" by falling back to an incremental sync.
+func resyncBuildResultFromStats(
+	ctx context.Context, stats sync.SyncStats, buildErr error,
+) workerResult {
+	statsCopy := stats
+	result := workerResult{
+		Synced:            stats.Synced,
+		Skipped:           stats.Skipped,
+		Failed:            stats.Failed,
+		DiscoveryComplete: stats.AuthoritativeDiscoveryComplete(),
+		Stats:             &statsCopy,
+	}
+	switch {
+	case ctx.Err() != nil:
+		result.Status = "aborted"
+		result.DiscoveryComplete = false
+		result.Error = ctx.Err().Error()
+	case buildErr != nil:
+		result.Status = "failed"
+		result.Error = buildErr.Error()
+	case stats.Aborted:
+		result.Status = "aborted"
+		result.DiscoveryComplete = false
+	case !result.DiscoveryComplete:
+		result.Status = "failed"
+	default:
+		result.Status = "ok"
+	}
+	return result
+}
+
+// refuseWorkerResync emits a failed terminal result for a live-archive worker
+// pass (sync/audit) that found a stale-version archive it must not swap, and
+// returns a matching error so the child exits non-zero. The daemon surfaces the
+// message: a resync is required and only the resync-build flow may perform it.
+func refuseWorkerResync(mode string, emit func(workerLine)) error {
+	const msg = "archive data version changed; a full resync is required. " +
+		"The live-archive worker will not swap the archive out from under the " +
+		"running daemon: restart the daemon to resync at startup, or trigger a " +
+		"resync"
+	result := workerResult{Status: "failed", Error: msg}
+	emit(workerLine{Result: &result})
+	return fmt.Errorf("sync worker %s: %s", mode, msg)
+}
+
+// workerResultFromStats maps engine stats to a terminal result. Cancellation or
+// a safety abort is "aborted"; a completed pass with hard parse failures or
+// non-authoritative discovery is "failed"; otherwise "ok".
+func workerResultFromStats(
+	ctx context.Context, stats sync.SyncStats,
+) workerResult {
+	statsCopy := stats
+	result := workerResult{
+		Synced:            stats.Synced,
+		Skipped:           stats.Skipped,
+		Failed:            stats.Failed,
+		DiscoveryComplete: stats.AuthoritativeDiscoveryComplete(),
+		Stats:             &statsCopy,
+	}
+	switch {
+	case ctx.Err() != nil || stats.Aborted:
+		result.Status = "aborted"
+		// Aborted discovery is never authoritative, even if the counters
+		// happened to complete a provider listing before cancellation.
+		result.DiscoveryComplete = false
+		if ctx.Err() != nil {
+			result.Error = ctx.Err().Error()
+		}
+	case stats.Failed > 0 || !result.DiscoveryComplete:
+		result.Status = "failed"
+	default:
+		result.Status = "ok"
+	}
+	return result
+}
+
+// openWorkerWriteDB reuses the daemon's direct-write open path — including the
+// db.write.lock acquisition — but returns errors instead of exiting. Callers
+// must tear down through closeWriteDB so a failed database close (undrained
+// connections) retains the write-owner flock instead of letting another
+// process acquire writer ownership alongside a surviving SQLite connection.
+func openWorkerWriteDB(cfg config.Config) (*db.DB, *writeOwnerLock, error) {
+	return openWriteDB(context.Background(), cfg)
+}
+
+// workerEngineConfig mirrors the sync.EngineConfig literal in runServe minus the
+// daemon-only callbacks (emitter, watcher reconciliation, deferred maintenance).
+func workerEngineConfig(cfg config.Config) sync.EngineConfig {
+	return sync.EngineConfig{
+		AgentDirs:               cfg.AgentDirs,
+		IncludeCwdPrefixes:      cfg.SyncIncludeCwdPrefixes,
+		Machine:                 cfg.LocalMachineName,
+		BlockedResultCategories: cfg.ResultContentBlockedCategories,
+	}
+}

--- a/cmd/agentsview/sync_worker_test.go
+++ b/cmd/agentsview/sync_worker_test.go
@@ -1,0 +1,375 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/sync"
+	"go.kenn.io/agentsview/internal/testjsonl"
+)
+
+// testConfigWithClaudeFixture builds a config pointing at a temp data dir and a
+// Claude projects dir seeded with three parseable sessions.
+func testConfigWithClaudeFixture(t *testing.T) config.Config {
+	t.Helper()
+	dataDir := t.TempDir()
+	claudeDir := t.TempDir()
+	for i := range 3 {
+		projDir := filepath.Join(claudeDir, fmt.Sprintf("-home-proj%d", i))
+		require.NoError(t, os.MkdirAll(projDir, 0o755))
+		content := testjsonl.NewSessionBuilder().
+			AddClaudeUser("2026-01-01T00:00:00Z", "hello").
+			AddClaudeAssistant("2026-01-01T00:00:01Z", "hi").
+			String()
+		require.NoError(t, os.WriteFile(
+			filepath.Join(projDir, fmt.Sprintf("session%d.jsonl", i)),
+			[]byte(content), 0o644,
+		))
+	}
+	return config.Config{
+		DataDir:          dataDir,
+		DBPath:           filepath.Join(dataDir, "sessions.db"),
+		LocalMachineName: "local",
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {claudeDir},
+		},
+	}
+}
+
+// decodeSingleResult scans NDJSON worker output and returns the sole terminal
+// result, failing the test if the count is not exactly one.
+func decodeSingleResult(t *testing.T, out *bytes.Buffer) workerResult {
+	t.Helper()
+	var results []workerResult
+	sc := bufio.NewScanner(out)
+	for sc.Scan() {
+		var line workerLine
+		require.NoError(t, json.Unmarshal(sc.Bytes(), &line),
+			"every stdout line must be a workerLine JSON object")
+		if line.Result != nil {
+			results = append(results, *line.Result)
+		}
+	}
+	require.NoError(t, sc.Err())
+	require.Len(t, results, 1, "exactly one terminal result")
+	return results[0]
+}
+
+func TestSyncWorkerStartupModeSyncsAndEmitsTerminalResult(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	var out bytes.Buffer
+	require.NoError(t, runSyncWorker(cfg, "startup", &out))
+
+	var results []workerResult
+	sawProgress := false
+	sc := bufio.NewScanner(&out)
+	for sc.Scan() {
+		var line workerLine
+		require.NoError(t, json.Unmarshal(sc.Bytes(), &line),
+			"every stdout line must be a workerLine JSON object")
+		if line.Progress != nil {
+			sawProgress = true
+		}
+		if line.Result != nil {
+			results = append(results, *line.Result)
+		}
+	}
+	require.NoError(t, sc.Err())
+	assert.True(t, sawProgress)
+	require.Len(t, results, 1, "exactly one terminal result")
+	assert.Equal(t, "ok", results[0].Status)
+	assert.True(t, results[0].DiscoveryComplete)
+	assert.Equal(t, 3, results[0].Synced)
+	require.NotNil(t, results[0].Stats,
+		"the terminal result must carry the full SyncStats payload")
+	assert.Equal(t, 3, results[0].Stats.TotalSessions,
+		"public SyncStats fields must survive the NDJSON protocol")
+}
+
+func TestSyncWorkerReportsAbortAsFailure(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // aborted before work starts
+	var out bytes.Buffer
+	err := runSyncWorkerContext(ctx, cfg, "startup", &out)
+	require.Error(t, err, "aborted work must not exit zero")
+	result := decodeSingleResult(t, &out)
+	assert.Equal(t, "aborted", result.Status)
+	assert.False(t, result.DiscoveryComplete)
+}
+
+func TestSyncWorkerFailsWhenWriteLockHeld(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	holdWriteOwnerLockForTest(t, cfg.DataDir) // hold db.write.lock like a daemon
+	var out bytes.Buffer
+	err := runSyncWorker(cfg, "startup", &out)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "write lock")
+}
+
+func TestSyncWorkerRejectsUnknownMode(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	var out bytes.Buffer
+	err := runSyncWorker(cfg, "bogus", &out)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "unknown sync-worker mode")
+}
+
+func TestSyncWorkerResyncBuildModeBuildsReplacement(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	// Seed the archive the worker rebuilds from, then close it so the worker
+	// opens it read-only exactly as it does under the daemon's write barrier.
+	database, err := db.Open(cfg.DBPath)
+	require.NoError(t, err)
+	engine := sync.NewEngine(database, workerEngineConfig(cfg))
+	require.Equal(t, 3, engine.SyncAll(context.Background(), nil).Synced)
+	engine.Close()
+	require.NoError(t, database.Close())
+
+	var out bytes.Buffer
+	require.NoError(t, runSyncWorker(cfg, "resync-build", &out))
+	result := decodeSingleResult(t, &out)
+	assert.Equal(t, "ok", result.Status)
+	assert.True(t, result.DiscoveryComplete)
+	assert.Equal(t, 3, result.Synced)
+	assert.FileExists(t, cfg.DBPath+"-resync",
+		"worker must leave the built replacement for the daemon to swap")
+}
+
+// TestSyncWorkerResyncBuildAppliesClassifierConfig pins the classifier wiring
+// for the resync-build worker: it runs in a fresh process, so unless it
+// installs the configured automation patterns before building, the rebuilt
+// archive's forced is_automated backfill classifies every session with only
+// the built-in patterns.
+func TestSyncWorkerResyncBuildAppliesClassifierConfig(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	cfg.Automated.Prefixes = []string{"hello"}
+	t.Cleanup(func() {
+		db.SetUserAutomationPrefixes(nil)
+		db.SetUserAutomationSubstrings(nil)
+		db.SetUserAutomationExactMatches(nil)
+	})
+
+	// Seed the archive with default patterns, so no session is automated.
+	database, err := db.Open(cfg.DBPath)
+	require.NoError(t, err)
+	engine := sync.NewEngine(database, workerEngineConfig(cfg))
+	require.Equal(t, 3, engine.SyncAll(context.Background(), nil).Synced)
+	engine.Close()
+	require.NoError(t, database.Close())
+
+	var out bytes.Buffer
+	require.NoError(t, runSyncWorker(cfg, "resync-build", &out))
+	require.Equal(t, "ok", decodeSingleResult(t, &out).Status)
+
+	conn, err := sql.Open("sqlite3", cfg.DBPath+"-resync")
+	require.NoError(t, err)
+	defer conn.Close()
+	var automated int
+	require.NoError(t, conn.QueryRow(
+		"SELECT COUNT(*) FROM sessions WHERE is_automated = 1",
+	).Scan(&automated))
+	assert.Equal(t, 3, automated,
+		"the rebuilt archive must classify sessions with the configured user prefixes")
+}
+
+// markArchiveStale drops the archive's user_version so the next open reports
+// NeedsResync, mimicking a parser data-version bump under a running daemon.
+func markArchiveStale(t *testing.T, dbPath string) {
+	t.Helper()
+	conn, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = conn.Exec("PRAGMA user_version = 0")
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+}
+
+// TestSyncWorkerRefusesResyncForLiveArchiveModes locks in the split-brain guard:
+// the live-archive worker passes (sync/audit) run inside the daemon's writer
+// handoff, so they must refuse a stale-version archive instead of swapping the
+// file out from under the daemon's still-open reader pool.
+func TestSyncWorkerRefusesResyncForLiveArchiveModes(t *testing.T) {
+	for _, mode := range []string{"sync", "audit"} {
+		t.Run(mode, func(t *testing.T) {
+			cfg := testConfigWithClaudeFixture(t)
+			database, err := db.Open(cfg.DBPath)
+			require.NoError(t, err)
+			engine := sync.NewEngine(database, workerEngineConfig(cfg))
+			require.Equal(t, 3, engine.SyncAll(context.Background(), nil).Synced)
+			engine.Close()
+			require.NoError(t, database.Close())
+			markArchiveStale(t, cfg.DBPath)
+
+			before, err := os.Stat(cfg.DBPath)
+			require.NoError(t, err)
+
+			var out bytes.Buffer
+			err = runSyncWorkerContext(context.Background(), cfg, mode, &out)
+			require.Error(t, err, "a live-archive worker must refuse a stale archive")
+			assert.ErrorContains(t, err, "resync")
+
+			result := decodeSingleResult(t, &out)
+			assert.Equal(t, "failed", result.Status)
+			assert.False(t, result.DiscoveryComplete)
+			assert.Contains(t, result.Error, "resync")
+
+			after, err := os.Stat(cfg.DBPath)
+			require.NoError(t, err)
+			assert.True(t, os.SameFile(before, after),
+				"the archive file must not be swapped out from under the daemon")
+			assert.NoFileExists(t, cfg.DBPath+"-resync",
+				"a refused pass must not stage a replacement archive")
+		})
+	}
+}
+
+// failOnResultWriter fails the Write that carries the terminal result line so a
+// test can exercise a dropped terminal-result emit on an otherwise-ok pass.
+type failOnResultWriter struct{ attempted bool }
+
+func (w *failOnResultWriter) Write(p []byte) (int, error) {
+	if bytes.Contains(p, []byte(`"result"`)) {
+		w.attempted = true
+		return 0, errors.New("terminal write failed")
+	}
+	return len(p), nil
+}
+
+// TestSyncWorkerNonZeroWhenTerminalResultWriteFails pins the exit contract: a
+// pass that succeeds but whose terminal result cannot be written must still
+// return a non-nil error so the child exits non-zero.
+func TestSyncWorkerNonZeroWhenTerminalResultWriteFails(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	w := &failOnResultWriter{}
+	err := runSyncWorkerContext(context.Background(), cfg, "startup", w)
+	require.Error(t, err, "a dropped terminal result must fail the worker")
+	assert.True(t, w.attempted, "the terminal result write was attempted")
+	assert.ErrorContains(t, err, "terminal result")
+}
+
+// TestSyncWorkerStartupAbortedResyncFallsBackIncremental mirrors the
+// in-process startup path: when the required resync safety-aborts (here: all
+// sources vanished while the old archive has data), the worker must follow up
+// with an incremental sync instead of reporting a bare abort, and the original
+// archive must be preserved.
+func TestSyncWorkerStartupAbortedResyncFallsBackIncremental(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	database, err := db.Open(cfg.DBPath)
+	require.NoError(t, err)
+	engine := sync.NewEngine(database, workerEngineConfig(cfg))
+	require.Equal(t, 3, engine.SyncAll(context.Background(), nil).Synced)
+	engine.Close()
+	require.NoError(t, database.Close())
+	markArchiveStale(t, cfg.DBPath)
+
+	// Empty discovery against an archive with data safety-aborts the resync.
+	claudeDir := cfg.AgentDirs[parser.AgentClaude][0]
+	entries, err := os.ReadDir(claudeDir)
+	require.NoError(t, err)
+	for _, entry := range entries {
+		require.NoError(t, os.RemoveAll(filepath.Join(claudeDir, entry.Name())))
+	}
+
+	var out bytes.Buffer
+	require.NoError(t, runSyncWorker(cfg, "startup", &out),
+		"the incremental fallback must complete the pass")
+	result := decodeSingleResult(t, &out)
+	assert.Equal(t, "ok", result.Status,
+		"a safety-aborted resync must fall back to the incremental sync")
+	assert.True(t, result.DiscoveryComplete)
+
+	database, err = db.Open(cfg.DBPath)
+	require.NoError(t, err)
+	defer database.Close()
+	var total int
+	require.NoError(t, database.Reader().QueryRow(
+		"SELECT COUNT(*) FROM sessions",
+	).Scan(&total))
+	assert.Equal(t, 3, total, "the aborted resync must leave the archive intact")
+}
+
+// TestResyncBuildResultFromStatsToleratesMinorityParseFailures pins the
+// resync-build completion semantics: shouldAbortResyncSwap already folds the
+// failure-majority judgment into stats.Aborted, so a completed build with a
+// minority of permanent parse failures is a valid replacement the daemon must
+// not discard.
+func TestResyncBuildResultFromStatsToleratesMinorityParseFailures(t *testing.T) {
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	tests := []struct {
+		name       string
+		ctx        context.Context
+		stats      sync.SyncStats
+		buildErr   error
+		wantStatus string
+	}{
+		{
+			name:       "minority parse failures still ok",
+			ctx:        context.Background(),
+			stats:      sync.SyncStats{Synced: 10, Failed: 2},
+			wantStatus: "ok",
+		},
+		{
+			name:       "safety abort",
+			ctx:        context.Background(),
+			stats:      sync.SyncStats{Aborted: true},
+			wantStatus: "aborted",
+		},
+		{
+			name:       "build error",
+			ctx:        context.Background(),
+			stats:      sync.SyncStats{Synced: 10},
+			buildErr:   errors.New("build boom"),
+			wantStatus: "failed",
+		},
+		{
+			name:       "operational failure that also set aborted",
+			ctx:        context.Background(),
+			stats:      sync.SyncStats{Aborted: true},
+			buildErr:   errors.New("create resync temp db: boom"),
+			wantStatus: "failed",
+		},
+		{
+			name:       "cancelled context",
+			ctx:        cancelled,
+			stats:      sync.SyncStats{Synced: 10},
+			wantStatus: "aborted",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := resyncBuildResultFromStats(tt.ctx, tt.stats, tt.buildErr)
+			assert.Equal(t, tt.wantStatus, result.Status)
+			if tt.wantStatus == "ok" {
+				assert.True(t, result.DiscoveryComplete)
+				require.NotNil(t, result.Stats)
+				assert.Equal(t, tt.stats.Synced, result.Stats.Synced)
+			} else {
+				assert.NotEqual(t, "ok", result.Status)
+			}
+		})
+	}
+}
+
+func TestSyncWorkerSyncModeSyncsLikeStartup(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	var out bytes.Buffer
+	require.NoError(t, runSyncWorker(cfg, "sync", &out))
+	result := decodeSingleResult(t, &out)
+	assert.Equal(t, "ok", result.Status)
+	assert.True(t, result.DiscoveryComplete)
+	assert.Equal(t, 3, result.Synced)
+}

--- a/cmd/agentsview/test_helpers_test.go
+++ b/cmd/agentsview/test_helpers_test.go
@@ -132,9 +132,16 @@ func writeTestFile(t *testing.T, path string, content []byte) {
 }
 
 // requireSymlinkOrSkip creates a symlink from link to target, skipping the test
-// when the platform or filesystem does not support symlinks.
+// when the platform or filesystem does not support symlinks. The target must
+// exist first: os.Symlink on Windows types the link (file vs directory) by
+// statting the target at creation time, and a link created before its
+// directory target exists becomes a file symlink whose directory reads later
+// fail with access denied.
 func requireSymlinkOrSkip(t *testing.T, target, link string) {
 	t.Helper()
+	_, statErr := os.Stat(target)
+	require.NoError(t, statErr,
+		"symlink target must exist before creating the link")
 	err := os.Symlink(target, link)
 	if err == nil {
 		return

--- a/cmd/agentsview/unwatched_poll.go
+++ b/cmd/agentsview/unwatched_poll.go
@@ -1,0 +1,302 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log"
+	"os"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"go.kenn.io/agentsview/internal/server"
+)
+
+var errUnwatchedPollStopped = errors.New("unwatched poll coordinator stopped")
+
+type unwatchedPollSyncer interface {
+	ReconcileWatchRoots(context.Context, []string, bool) error
+}
+
+type unwatchedPollAdd struct {
+	obligation pollingObligation
+	remove     bool
+	done       chan struct{}
+}
+
+type pollingObligation struct {
+	Key   string
+	Roots []string
+	// Probe mirrors sync.PollingObligation.Probe: the physical watcher path
+	// whose availability gates this obligation's reconciliation Roots. When
+	// it is missing, the roots are deferred rather than reconciled
+	// authoritatively — a nested physical root (Gemini's <root>/tmp) can
+	// vanish while its configured scope <root> still exists, and reconciling
+	// the scope then would tombstone every session under the missing
+	// subtree. Empty means the Roots themselves are probed.
+	Probe string
+}
+
+type sharedUnwatchedPollCoordinator struct {
+	ctx          context.Context
+	workerCtx    context.Context
+	workerCancel context.CancelFunc
+	engine       unwatchedPollSyncer
+	ticks        <-chan time.Time
+	stopTicker   func()
+	doWork       func(func())
+	// onRootsOwned is a test observer invoked after installation and before ack.
+	onRootsOwned func([]string)
+	add          chan unwatchedPollAdd
+	// pollWake coalesces ticks and explicit wakes while the serialized worker runs.
+	pollWake chan struct{}
+	pollDone chan struct{}
+	pollMu   sync.Mutex
+	// pollObligations is the latest complete snapshot owned by the
+	// coordinator loop; each entry keeps its probe so availability is
+	// evaluated per obligation at poll time.
+	pollObligations []pollingObligation
+	stop            chan struct{}
+	done            chan struct{}
+	stopOnce        sync.Once
+}
+
+func newUnwatchedPollCoordinator(
+	ctx context.Context,
+	engine unwatchedPollSyncer,
+	idleTracker *server.IdleTracker,
+) *sharedUnwatchedPollCoordinator {
+	ticker := time.NewTicker(unwatchedPollInterval)
+	return newUnwatchedPollCoordinatorWithTicks(
+		ctx, engine, ticker.C, ticker.Stop, idleTracker.Do, nil,
+	)
+}
+
+func newUnwatchedPollCoordinatorWithTicks(
+	ctx context.Context,
+	engine unwatchedPollSyncer,
+	ticks <-chan time.Time,
+	stopTicker func(),
+	doWork func(func()),
+	onRootsOwned func([]string),
+) *sharedUnwatchedPollCoordinator {
+	workerCtx, workerCancel := context.WithCancel(ctx)
+	coordinator := &sharedUnwatchedPollCoordinator{
+		ctx:          ctx,
+		workerCtx:    workerCtx,
+		workerCancel: workerCancel,
+		engine:       engine,
+		ticks:        ticks,
+		stopTicker:   stopTicker,
+		doWork:       doWork,
+		add:          make(chan unwatchedPollAdd),
+		pollWake:     make(chan struct{}, 1),
+		pollDone:     make(chan struct{}),
+		stop:         make(chan struct{}),
+		done:         make(chan struct{}),
+		onRootsOwned: onRootsOwned,
+	}
+	go coordinator.run()
+	return coordinator
+}
+
+func (c *sharedUnwatchedPollCoordinator) AddObligation(
+	obligation pollingObligation,
+) error {
+	if obligation.Key == "" {
+		return errors.New("polling obligation key is empty")
+	}
+	return c.updateRoots(obligation, false)
+}
+
+func (c *sharedUnwatchedPollCoordinator) RemoveObligation(key string) error {
+	return c.updateRoots(pollingObligation{Key: key}, true)
+}
+
+func (c *sharedUnwatchedPollCoordinator) updateRoots(
+	obligation pollingObligation, remove bool,
+) error {
+	request := unwatchedPollAdd{
+		obligation: pollingObligation{
+			Key:   obligation.Key,
+			Roots: append([]string(nil), obligation.Roots...),
+			Probe: obligation.Probe,
+		},
+		remove: remove,
+		done:   make(chan struct{}),
+	}
+	select {
+	case <-c.done:
+		return errUnwatchedPollStopped
+	case c.add <- request:
+	}
+	<-request.done
+	return nil
+}
+
+func (c *sharedUnwatchedPollCoordinator) Stop() {
+	c.stopOnce.Do(func() {
+		c.workerCancel()
+		close(c.stop)
+	})
+	<-c.done
+}
+
+func (c *sharedUnwatchedPollCoordinator) run() {
+	defer close(c.done)
+	defer c.stopTicker()
+	go c.runPollWorker()
+	defer func() { <-c.pollDone }()
+	obligations := make(map[string]pollingObligation)
+	for {
+		select {
+		case <-c.ctx.Done():
+			return
+		case <-c.stop:
+			return
+		case request := <-c.add:
+			if request.remove {
+				delete(obligations, request.obligation.Key)
+			} else {
+				obligations[request.obligation.Key] = request.obligation
+			}
+			c.setPollObligations(obligations)
+			if c.onRootsOwned != nil {
+				c.onRootsOwned(unwatchedPollObligationRoots(obligations))
+			}
+			close(request.done)
+		case <-c.ticks:
+			c.requestPoll()
+		}
+	}
+}
+
+func (c *sharedUnwatchedPollCoordinator) setPollObligations(
+	obligations map[string]pollingObligation,
+) {
+	snapshot := make([]pollingObligation, 0, len(obligations))
+	for _, obligation := range obligations {
+		snapshot = append(snapshot, obligation)
+	}
+	slices.SortFunc(snapshot, func(a, b pollingObligation) int {
+		return strings.Compare(a.Key, b.Key)
+	})
+	c.pollMu.Lock()
+	c.pollObligations = snapshot
+	c.pollMu.Unlock()
+}
+
+func (c *sharedUnwatchedPollCoordinator) currentPollObligations() []pollingObligation {
+	c.pollMu.Lock()
+	defer c.pollMu.Unlock()
+	return append([]pollingObligation(nil), c.pollObligations...)
+}
+
+func (c *sharedUnwatchedPollCoordinator) requestPoll() {
+	select {
+	case c.pollWake <- struct{}{}:
+	default:
+	}
+}
+
+func (c *sharedUnwatchedPollCoordinator) runPollWorker() {
+	defer close(c.pollDone)
+	for {
+		select {
+		case <-c.workerCtx.Done():
+			return
+		default:
+		}
+		select {
+		case <-c.workerCtx.Done():
+			return
+		case <-c.pollWake:
+			if c.workerCtx.Err() != nil {
+				return
+			}
+			roots := availableUnwatchedPollRoots(c.currentPollObligations())
+			if len(roots) == 0 {
+				continue
+			}
+			log.Printf("polling %d unwatched root(s)", len(roots))
+			c.doWork(func() {
+				if c.workerCtx.Err() != nil {
+					return
+				}
+				pollUnwatchedRootsOnce(c.workerCtx, c.engine, roots)
+			})
+		}
+	}
+}
+
+// availableUnwatchedPollRoots selects the reconciliation roots whose
+// obligations are currently pollable. An obligation with a probe path is gated
+// on that physical path: while it is missing, its roots are deferred entirely
+// rather than authoritatively reconciled, because the configured scope can
+// still exist while the physical subtree holding every session is gone.
+//
+// A root shared by several obligations is gated on every probe that references
+// it, not just one: Gemini's shallow <root> metadata plan and recursive
+// <root>/tmp plan both reconcile <root>, and the present shallow plan must not
+// make <root> pollable while the subtree holding every session is missing.
+func availableUnwatchedPollRoots(obligations []pollingObligation) []string {
+	candidates := make(map[string]struct{})
+	blocked := make(map[string]struct{})
+	for _, obligation := range obligations {
+		probeMissing := false
+		if obligation.Probe != "" {
+			if _, err := os.Stat(obligation.Probe); err != nil {
+				probeMissing = true
+			}
+		}
+		for _, root := range obligation.Roots {
+			if root == "" {
+				continue
+			}
+			if probeMissing {
+				blocked[root] = struct{}{}
+				continue
+			}
+			if _, err := os.Stat(root); err == nil {
+				candidates[root] = struct{}{}
+			}
+		}
+	}
+	for root := range blocked {
+		delete(candidates, root)
+	}
+	return unwatchedPollRoots(candidates)
+}
+
+func unwatchedPollObligationRoots(obligations map[string]pollingObligation) []string {
+	owned := make(map[string]struct{})
+	for _, obligation := range obligations {
+		for _, root := range obligation.Roots {
+			if root != "" {
+				owned[root] = struct{}{}
+			}
+		}
+	}
+	return unwatchedPollRoots(owned)
+}
+
+func unwatchedPollRoots(owned map[string]struct{}) []string {
+	roots := make([]string, 0, len(owned))
+	for root := range owned {
+		roots = append(roots, root)
+	}
+	slices.Sort(roots)
+	return roots
+}
+
+func pollUnwatchedRootsOnce(
+	ctx context.Context, engine unwatchedPollSyncer, roots []string,
+) {
+	if len(roots) == 0 {
+		return
+	}
+	if err := engine.ReconcileWatchRoots(ctx, roots, false); err != nil {
+		log.Printf("polling unwatched roots: %v", err)
+	}
+}

--- a/cmd/agentsview/unwatched_poll.go
+++ b/cmd/agentsview/unwatched_poll.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"sync"
@@ -240,6 +241,13 @@ func (c *sharedUnwatchedPollCoordinator) runPollWorker() {
 // it, not just one: Gemini's shallow <root> metadata plan and recursive
 // <root>/tmp plan both reconcile <root>, and the present shallow plan must not
 // make <root> pollable while the subtree holding every session is missing.
+//
+// Blocking extends beyond exact root matches to every candidate overlapping a
+// blocked root in either direction (overlapsDeferredScope): ReconcileWatchRoots
+// expands each requested root to the configured dirs above and below it, so a
+// pollable ancestor or descendant of a blocked root would reconcile the
+// deferred scope as an authoritative empty discovery and tombstone its
+// sessions.
 func availableUnwatchedPollRoots(obligations []pollingObligation) []string {
 	candidates := make(map[string]struct{})
 	blocked := make(map[string]struct{})
@@ -255,7 +263,7 @@ func availableUnwatchedPollRoots(obligations []pollingObligation) []string {
 				continue
 			}
 			if probeMissing {
-				blocked[root] = struct{}{}
+				blocked[filepath.Clean(root)] = struct{}{}
 				continue
 			}
 			if _, err := os.Stat(root); err == nil {
@@ -263,8 +271,10 @@ func availableUnwatchedPollRoots(obligations []pollingObligation) []string {
 			}
 		}
 	}
-	for root := range blocked {
-		delete(candidates, root)
+	for root := range candidates {
+		if overlapsDeferredScope(filepath.Clean(root), blocked) {
+			delete(candidates, root)
+		}
 	}
 	return unwatchedPollRoots(candidates)
 }

--- a/cmd/agentsview/unwatched_poll_test.go
+++ b/cmd/agentsview/unwatched_poll_test.go
@@ -1,0 +1,603 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingUnwatchedPollSyncer struct {
+	mu           sync.Mutex
+	calls        [][]string
+	full         []bool
+	wake         chan struct{}
+	reconcileErr error
+}
+
+type blockingUnwatchedPollSyncer struct {
+	mu        sync.Mutex
+	started   chan []string
+	release   chan struct{}
+	calls     [][]string
+	active    int
+	maxActive int
+}
+
+type cancelBlockingUnwatchedPollSyncer struct {
+	mu       sync.Mutex
+	started  chan struct{}
+	canceled chan struct{}
+	calls    int
+}
+
+func (s *cancelBlockingUnwatchedPollSyncer) ReconcileWatchRoots(
+	ctx context.Context, _ []string, _ bool,
+) error {
+	s.mu.Lock()
+	s.calls++
+	s.mu.Unlock()
+	s.started <- struct{}{}
+	<-ctx.Done()
+	s.canceled <- struct{}{}
+	return ctx.Err()
+}
+
+func (s *cancelBlockingUnwatchedPollSyncer) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+func (s *blockingUnwatchedPollSyncer) ReconcileWatchRoots(
+	_ context.Context, roots []string, _ bool,
+) error {
+	owned := append([]string(nil), roots...)
+	s.mu.Lock()
+	s.calls = append(s.calls, owned)
+	s.active++
+	s.maxActive = max(s.maxActive, s.active)
+	s.mu.Unlock()
+	s.started <- owned
+	<-s.release
+	s.mu.Lock()
+	s.active--
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *blockingUnwatchedPollSyncer) snapshot() ([][]string, int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	calls := make([][]string, len(s.calls))
+	for i := range s.calls {
+		calls[i] = append([]string(nil), s.calls[i]...)
+	}
+	return calls, s.maxActive
+}
+
+func (s *recordingUnwatchedPollSyncer) ReconcileWatchRoots(
+	_ context.Context, roots []string, full bool,
+) error {
+	s.mu.Lock()
+	s.calls = append(s.calls, append([]string(nil), roots...))
+	s.full = append(s.full, full)
+	s.mu.Unlock()
+	select {
+	case s.wake <- struct{}{}:
+	default:
+	}
+	return s.reconcileErr
+}
+
+func (s *recordingUnwatchedPollSyncer) snapshot() [][]string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	result := make([][]string, len(s.calls))
+	for i := range s.calls {
+		result[i] = append([]string(nil), s.calls[i]...)
+	}
+	return result
+}
+
+func TestUnwatchedPollConcurrentAddDeduplicatesUpdatedRootSet(t *testing.T) {
+	ticks := make(chan time.Time)
+	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 4)}
+	coordinator := newUnwatchedPollCoordinatorWithTicks(
+		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil,
+	)
+	t.Cleanup(coordinator.Stop)
+	parent := t.TempDir()
+	rootA := requireExistingPollRoot(t, parent, "root-a")
+	rootB := requireExistingPollRoot(t, parent, "root-b")
+	rootC := requireExistingPollRoot(t, parent, "root-c")
+
+	additions := [][]string{
+		{rootB, rootA},
+		{rootA, rootC},
+		{rootC, rootB},
+	}
+	var wg sync.WaitGroup
+	addErrors := make(chan error, len(additions))
+	for i, roots := range additions {
+		wg.Go(func() {
+			addErrors <- coordinator.AddObligation(pollingObligation{
+				Key: fmt.Sprintf("direct-%d", i), Roots: roots,
+			})
+		})
+	}
+	wg.Wait()
+	close(addErrors)
+	for err := range addErrors {
+		require.NoError(t, err)
+	}
+
+	coordinator.requestPoll()
+	requirePollWithin(t, syncer.wake, time.Second)
+	assert.Equal(t, [][]string{{rootA, rootB, rootC}}, syncer.snapshot())
+}
+
+func TestUnwatchedPollTickUsesRootsAddedAfterStart(t *testing.T) {
+	ticks := make(chan time.Time, 1)
+	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 2)}
+	coordinator := newUnwatchedPollCoordinatorWithTicks(
+		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil,
+	)
+	t.Cleanup(coordinator.Stop)
+	parent := t.TempDir()
+	initial := requireExistingPollRoot(t, parent, "initial")
+	runtime := requireExistingPollRoot(t, parent, "runtime")
+	require.NoError(t, coordinator.AddObligation(pollingObligation{
+		Key: "initial", Roots: []string{initial},
+	}))
+	require.NoError(t, coordinator.AddObligation(pollingObligation{
+		Key: "runtime", Roots: []string{runtime},
+	}))
+
+	ticks <- time.Now()
+	requirePollWithin(t, syncer.wake, time.Second)
+
+	assert.Equal(t, [][]string{{initial, runtime}}, syncer.snapshot())
+	assert.Equal(t, []bool{false}, syncer.full,
+		"unwatched polling must reconcile the owned scopes authoritatively")
+}
+
+func TestUnwatchedPollSkipsAbsentObligatedRootUntilItReturns(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "provider")
+	require.NoError(t, os.Mkdir(root, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "session.jsonl"), []byte("session\n"), 0o600,
+	))
+
+	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 3)}
+	coordinator := newUnwatchedPollCoordinatorWithTicks(
+		t.Context(), syncer, make(chan time.Time), func() {},
+		func(run func()) { run() }, nil,
+	)
+	t.Cleanup(coordinator.Stop)
+	require.NoError(t, coordinator.AddObligation(pollingObligation{
+		Key: "provider-root", Roots: []string{root},
+	}))
+
+	coordinator.requestPoll()
+	requirePollWithin(t, syncer.wake, time.Second)
+	assert.Equal(t, [][]string{{root}}, syncer.snapshot())
+
+	require.NoError(t, os.RemoveAll(root))
+	coordinator.requestPoll()
+	assert.Never(t, func() bool { return len(syncer.snapshot()) > 1 },
+		100*time.Millisecond, 10*time.Millisecond,
+		"an absent root must not become an authoritative empty scope")
+
+	require.NoError(t, os.Mkdir(root, 0o755))
+	coordinator.requestPoll()
+	requirePollWithin(t, syncer.wake, time.Second)
+	assert.Equal(t, [][]string{{root}, {root}}, syncer.snapshot(),
+		"the polling obligation must remain active for a returning root")
+}
+
+// TestUnwatchedPollDefersScopesWhileProbePathMissing is the nested-root
+// regression (Gemini's <root>/tmp): the obligation's reconciliation scope is
+// the configured <root>, but its physical watcher path is <root>/tmp. While
+// the physical path is missing, polling must defer the scope entirely instead
+// of authoritatively reconciling the still-present <root>, which would
+// tombstone every session under the vanished subtree.
+func TestUnwatchedPollDefersScopesWhileProbePathMissing(t *testing.T) {
+	configured := t.TempDir()
+	physical := filepath.Join(configured, "tmp")
+	require.NoError(t, os.Mkdir(physical, 0o755))
+
+	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 3)}
+	coordinator := newUnwatchedPollCoordinatorWithTicks(
+		t.Context(), syncer, make(chan time.Time), func() {},
+		func(run func()) { run() }, nil,
+	)
+	t.Cleanup(coordinator.Stop)
+	require.NoError(t, coordinator.AddObligation(pollingObligation{
+		Key: physical, Roots: []string{configured}, Probe: physical,
+	}))
+
+	coordinator.requestPoll()
+	requirePollWithin(t, syncer.wake, time.Second)
+	assert.Equal(t, [][]string{{configured}}, syncer.snapshot(),
+		"an available probe reconciles the configured scope")
+
+	require.NoError(t, os.RemoveAll(physical))
+	coordinator.requestPoll()
+	assert.Never(t, func() bool { return len(syncer.snapshot()) > 1 },
+		100*time.Millisecond, 10*time.Millisecond,
+		"a missing physical watcher path must defer its reconciliation "+
+			"scopes even though the configured root still exists")
+
+	require.NoError(t, os.Mkdir(physical, 0o755))
+	coordinator.requestPoll()
+	requirePollWithin(t, syncer.wake, time.Second)
+	assert.Equal(t, [][]string{{configured}, {configured}}, syncer.snapshot(),
+		"the deferred scope must resume once the physical path returns")
+}
+
+// TestUnwatchedPollDefersSharedScopeWhileAnyProbeMissing pins the shared-scope
+// gating: Gemini's shallow <root> metadata plan and recursive <root>/tmp plan
+// both reconcile the configured <root>. While <root>/tmp is missing, the
+// present shallow plan must not make <root> pollable, or authoritative
+// reconciliation would tombstone every session under the vanished subtree.
+func TestUnwatchedPollDefersSharedScopeWhileAnyProbeMissing(t *testing.T) {
+	configured := t.TempDir()
+	sessions := filepath.Join(configured, "tmp")
+	require.NoError(t, os.Mkdir(sessions, 0o755))
+
+	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 3)}
+	coordinator := newUnwatchedPollCoordinatorWithTicks(
+		t.Context(), syncer, make(chan time.Time), func() {},
+		func(run func()) { run() }, nil,
+	)
+	t.Cleanup(coordinator.Stop)
+	require.NoError(t, coordinator.AddObligation(pollingObligation{
+		Key: configured, Roots: []string{configured}, Probe: configured,
+	}))
+	require.NoError(t, coordinator.AddObligation(pollingObligation{
+		Key: sessions, Roots: []string{configured}, Probe: sessions,
+	}))
+
+	coordinator.requestPoll()
+	requirePollWithin(t, syncer.wake, time.Second)
+	assert.Equal(t, [][]string{{configured}}, syncer.snapshot(),
+		"with every probe available the shared scope reconciles")
+
+	require.NoError(t, os.RemoveAll(sessions))
+	coordinator.requestPoll()
+	assert.Never(t, func() bool { return len(syncer.snapshot()) > 1 },
+		100*time.Millisecond, 10*time.Millisecond,
+		"a missing session subtree must defer the shared scope even though "+
+			"the metadata plan's probe still exists")
+
+	require.NoError(t, os.Mkdir(sessions, 0o755))
+	coordinator.requestPoll()
+	requirePollWithin(t, syncer.wake, time.Second)
+	assert.Equal(t, [][]string{{configured}, {configured}}, syncer.snapshot(),
+		"the shared scope must resume once every probe returns")
+}
+
+func TestUnwatchedPollObligationUpdatesRemainResponsiveDuringReconciliation(
+	t *testing.T,
+) {
+	ticks := make(chan time.Time)
+	syncer := &blockingUnwatchedPollSyncer{
+		started: make(chan []string, 4),
+		release: make(chan struct{}),
+	}
+	coordinator := newUnwatchedPollCoordinatorWithTicks(
+		context.Background(), syncer, ticks, func() {}, func(run func()) { run() }, nil,
+	)
+	t.Cleanup(func() {
+		select {
+		case <-syncer.release:
+		default:
+			close(syncer.release)
+		}
+		coordinator.Stop()
+	})
+	parent := t.TempDir()
+	initial := requireExistingPollRoot(t, parent, "initial")
+	replacement := requireExistingPollRoot(t, parent, "replacement")
+	require.NoError(t, coordinator.AddObligation(pollingObligation{
+		Key: "initial", Roots: []string{initial},
+	}))
+
+	coordinator.requestPoll()
+	assert.Equal(t, []string{initial},
+		requireReceivePollRoots(t, syncer.started, time.Second))
+
+	addResult := make(chan error, 1)
+	go func() {
+		addResult <- coordinator.AddObligation(pollingObligation{
+			Key: "replacement", Roots: []string{replacement},
+		})
+	}()
+	require.NoError(t, requireReceivePollResult(t, addResult, time.Second),
+		"watcher polling callbacks must not wait for reconciliation")
+	removeResult := make(chan error, 1)
+	go func() {
+		removeResult <- coordinator.RemoveObligation("initial")
+	}()
+	require.NoError(t, requireReceivePollResult(t, removeResult, time.Second),
+		"watcher polling removals must not wait for reconciliation")
+	coordinator.requestPoll()
+	coordinator.requestPoll()
+
+	close(syncer.release)
+	assert.Equal(t, []string{replacement},
+		requireReceivePollRoots(t, syncer.started, time.Second))
+	calls, maxActive := syncer.snapshot()
+	assert.Equal(t, [][]string{{initial}, {replacement}}, calls)
+	assert.Equal(t, 1, maxActive, "poll reconciliations must remain serialized")
+}
+
+func TestUnwatchedPollStopCancelsAndJoinsActiveReconciliation(t *testing.T) {
+	parentCtx, cancelParent := context.WithCancel(context.Background())
+	syncer := &cancelBlockingUnwatchedPollSyncer{
+		started:  make(chan struct{}, 2),
+		canceled: make(chan struct{}, 2),
+	}
+	coordinator := newUnwatchedPollCoordinatorWithTicks(
+		parentCtx, syncer, make(chan time.Time), func() {},
+		func(run func()) { run() }, nil,
+	)
+	t.Cleanup(func() {
+		cancelParent()
+		coordinator.Stop()
+	})
+	owned := requireExistingPollRoot(t, t.TempDir(), "owned")
+	require.NoError(t, coordinator.AddObligation(pollingObligation{
+		Key: "owned", Roots: []string{owned},
+	}))
+	coordinator.requestPoll()
+	requirePollWithin(t, syncer.started, time.Second)
+	coordinator.requestPoll()
+
+	stopDone := make(chan struct{})
+	go func() {
+		coordinator.Stop()
+		close(stopDone)
+	}()
+	requirePollWithin(t, stopDone, time.Second)
+	requirePollWithin(t, syncer.canceled, time.Second)
+	assert.Equal(t, 1, syncer.callCount(),
+		"shutdown must discard the wake queued during reconciliation")
+
+	coordinator.requestPoll()
+	assert.Never(t, func() bool { return syncer.callCount() > 1 },
+		100*time.Millisecond, 10*time.Millisecond,
+		"shutdown must not start another queued reconciliation")
+}
+
+func TestUnwatchedPollParentCancellationCancelsJoinsAndRejectsUpdates(
+	t *testing.T,
+) {
+	parentCtx, cancelParent := context.WithCancel(context.Background())
+	syncer := &cancelBlockingUnwatchedPollSyncer{
+		started:  make(chan struct{}, 1),
+		canceled: make(chan struct{}, 1),
+	}
+	coordinator := newUnwatchedPollCoordinatorWithTicks(
+		parentCtx, syncer, make(chan time.Time), func() {},
+		func(run func()) { run() }, nil,
+	)
+	t.Cleanup(func() {
+		cancelParent()
+		coordinator.Stop()
+	})
+	owned := requireExistingPollRoot(t, t.TempDir(), "owned")
+	require.NoError(t, coordinator.AddObligation(pollingObligation{
+		Key: "owned", Roots: []string{owned},
+	}))
+	coordinator.requestPoll()
+	requirePollWithin(t, syncer.started, time.Second)
+
+	cancelParent()
+	requirePollWithin(t, syncer.canceled, time.Second)
+	select {
+	case <-coordinator.done:
+	case <-time.After(time.Second):
+		require.FailNow(t, "parent cancellation did not join the poll worker")
+	}
+
+	lateUpdate := make(chan error, 1)
+	go func() {
+		lateUpdate <- coordinator.AddObligation(pollingObligation{
+			Key: "late", Roots: []string{"/late"},
+		})
+	}()
+	assert.ErrorIs(t, requireReceivePollResult(t, lateUpdate, time.Second),
+		errUnwatchedPollStopped)
+	assert.Equal(t, 1, syncer.callCount())
+}
+
+func TestUnwatchedPollRemoveRootsStopsReconciliationAfterNativeRecovery(t *testing.T) {
+	ticks := make(chan time.Time, 1)
+	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 2)}
+	coordinator := newUnwatchedPollCoordinatorWithTicks(
+		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil,
+	)
+	t.Cleanup(coordinator.Stop)
+	parent := t.TempDir()
+	recovered := requireExistingPollRoot(t, parent, "recovered")
+	stillUnwatched := requireExistingPollRoot(t, parent, "still-unwatched")
+	require.NoError(t, coordinator.AddObligation(pollingObligation{
+		Key: "recovered-watch", Roots: []string{recovered},
+	}))
+	require.NoError(t, coordinator.AddObligation(pollingObligation{
+		Key: "still-unwatched", Roots: []string{stillUnwatched},
+	}))
+	require.NoError(t, coordinator.RemoveObligation("recovered-watch"))
+
+	coordinator.requestPoll()
+	requirePollWithin(t, syncer.wake, time.Second)
+
+	assert.Equal(t, [][]string{{stillUnwatched}}, syncer.snapshot())
+}
+
+func TestUnwatchedPollRemovingOneOverlappingObligationKeepsSharedRoot(t *testing.T) {
+	ticks := make(chan time.Time)
+	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 2)}
+	coordinator := newUnwatchedPollCoordinatorWithTicks(
+		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil,
+	)
+	t.Cleanup(coordinator.Stop)
+	parent := t.TempDir()
+	shared := requireExistingPollRoot(t, parent, "shared")
+	persistentOnly := requireExistingPollRoot(t, parent, "persistent-only")
+	require.NoError(t, coordinator.AddObligation(pollingObligation{
+		Key: "pending", Roots: []string{shared},
+	}))
+	require.NoError(t, coordinator.AddObligation(pollingObligation{
+		Key: "persistent", Roots: []string{shared, persistentOnly},
+	}))
+	require.NoError(t, coordinator.RemoveObligation("pending"))
+
+	coordinator.requestPoll()
+	requirePollWithin(t, syncer.wake, time.Second)
+
+	assert.Equal(t,
+		[][]string{{persistentOnly, shared}}, syncer.snapshot())
+}
+
+func TestUnwatchedPollEmptyObligationNeverExpandsToFullReconciliation(t *testing.T) {
+	ticks := make(chan time.Time)
+	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 1)}
+	coordinator := newUnwatchedPollCoordinatorWithTicks(
+		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil,
+	)
+	t.Cleanup(coordinator.Stop)
+	require.NoError(t, coordinator.AddObligation(pollingObligation{Key: "empty"}))
+
+	coordinator.requestPoll()
+
+	assert.Never(t, func() bool { return len(syncer.snapshot()) > 0 },
+		100*time.Millisecond, 10*time.Millisecond)
+}
+
+func TestUnwatchedPollStopIsConcurrentAndRejectsLaterRoots(t *testing.T) {
+	ticks := make(chan time.Time)
+	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 1)}
+	coordinator := newUnwatchedPollCoordinatorWithTicks(
+		context.Background(), syncer, ticks, func() {}, func(run func()) { run() }, nil,
+	)
+	require.NoError(t, coordinator.AddObligation(pollingObligation{
+		Key: "owned", Roots: []string{"/owned"},
+	}))
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Go(func() {
+			coordinator.Stop()
+		})
+	}
+	wg.Wait()
+
+	assert.ErrorIs(t, coordinator.AddObligation(pollingObligation{
+		Key: "late", Roots: []string{"/late"},
+	}), errUnwatchedPollStopped)
+	coordinator.requestPoll()
+	assert.Empty(t, syncer.snapshot())
+}
+
+func TestUnwatchedPollAddObligationRacingStopReturnsOwnershipOrStopped(t *testing.T) {
+	const attempts = 64
+	for i := range attempts {
+		ticks := make(chan time.Time)
+		syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 1)}
+		ownedSnapshots := make(chan []string, 1)
+		coordinator := newUnwatchedPollCoordinatorWithTicks(
+			context.Background(), syncer, ticks, func() {}, func(run func()) { run() },
+			func(roots []string) {
+				ownedSnapshots <- append([]string(nil), roots...)
+			},
+		)
+		start := make(chan struct{})
+		addResult := make(chan error, 1)
+		stopDone := make(chan struct{})
+		root := fmt.Sprintf("/race-root-%d", i)
+		go func() {
+			<-start
+			addResult <- coordinator.AddObligation(pollingObligation{
+				Key: root, Roots: []string{root},
+			})
+		}()
+		go func() {
+			<-start
+			coordinator.Stop()
+			close(stopDone)
+		}()
+
+		close(start)
+		err := requireReceivePollResult(t, addResult, time.Second)
+		requirePollWithin(t, stopDone, time.Second)
+		if err != nil {
+			assert.ErrorIs(t, err, errUnwatchedPollStopped)
+		} else {
+			owned := requireReceivePollRoots(t, ownedSnapshots, time.Second)
+			assert.Contains(t, owned, root)
+		}
+		assert.ErrorIs(t,
+			coordinator.AddObligation(pollingObligation{
+				Key:   fmt.Sprintf("/late-root-%d", i),
+				Roots: []string{fmt.Sprintf("/late-root-%d", i)},
+			}),
+			errUnwatchedPollStopped,
+		)
+	}
+}
+
+func requireReceivePollRoots(
+	t *testing.T,
+	results <-chan []string,
+	timeout time.Duration,
+) []string {
+	t.Helper()
+	select {
+	case roots := <-results:
+		return roots
+	case <-time.After(timeout):
+		require.FailNow(t, "poll coordinator ownership did not arrive before timeout")
+		return nil
+	}
+}
+
+func requireExistingPollRoot(t *testing.T, parent, name string) string {
+	t.Helper()
+	root := filepath.Join(parent, name)
+	require.NoError(t, os.Mkdir(root, 0o755))
+	return root
+}
+
+func requireReceivePollResult(
+	t *testing.T,
+	results <-chan error,
+	timeout time.Duration,
+) error {
+	t.Helper()
+	select {
+	case err := <-results:
+		return err
+	case <-time.After(timeout):
+		require.FailNow(t, "poll coordinator result did not arrive before timeout")
+		return nil
+	}
+}
+
+func requirePollWithin(t *testing.T, ch <-chan struct{}, timeout time.Duration) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(timeout):
+		require.FailNow(t, "poll did not run before timeout")
+	}
+}

--- a/cmd/agentsview/unwatched_poll_test.go
+++ b/cmd/agentsview/unwatched_poll_test.go
@@ -339,6 +339,65 @@ func TestAvailableUnwatchedPollRootsDefersRootsOverlappingBlockedScopes(t *testi
 	}
 }
 
+// TestAvailableUnwatchedPollRootsBlocksMixedRelativeAndAbsoluteScopes pins the
+// path-form parity between this gate and the engine: ReconcileWatchRoots
+// expands requested roots against configured dirs in absolute form
+// (cleanRootPath), so a blocked scope configured relative and a pollable root
+// configured absolute (or vice versa) still overlap on the engine side. The
+// daemon-side blocking check must compare the same form, or the poll
+// reconciles the deferred scope authoritatively and tombstones its sessions.
+func TestAvailableUnwatchedPollRootsBlocksMixedRelativeAndAbsoluteScopes(t *testing.T) {
+	base, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+	t.Chdir(base)
+	scope := requireExistingPollRoot(t, base, "scope")
+	sub := requireExistingPollRoot(t, scope, "sub")
+	missingProbe := filepath.Join(base, "missing-probe")
+
+	tests := []struct {
+		name        string
+		obligations []pollingObligation
+	}{
+		{
+			name: "relative blocked scope defers absolute descendant",
+			obligations: []pollingObligation{
+				{Key: "blocked", Roots: []string{"scope"}, Probe: missingProbe},
+				{Key: "poll", Roots: []string{sub}},
+			},
+		},
+		{
+			name: "absolute blocked scope defers relative descendant",
+			obligations: []pollingObligation{
+				{Key: "blocked", Roots: []string{scope}, Probe: missingProbe},
+				{Key: "poll", Roots: []string{filepath.Join("scope", "sub")}},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Empty(t, availableUnwatchedPollRoots(tc.obligations),
+				"a blocked scope must defer overlapping roots regardless of "+
+					"the path form each side was configured with")
+		})
+	}
+}
+
+// TestAvailableUnwatchedPollRootsBlocksScopesUnderFilesystemRoot pins the
+// filesystem-root edge: a blocked scope at the filesystem root ("/" on Unix,
+// the volume root on Windows) already ends in the separator, so naive
+// root+separator prefix matching never sees any candidate as its descendant.
+func TestAvailableUnwatchedPollRootsBlocksScopesUnderFilesystemRoot(t *testing.T) {
+	candidate := t.TempDir()
+	fsRoot := filepath.VolumeName(candidate) + string(filepath.Separator)
+	obligations := []pollingObligation{
+		{Key: "blocked", Roots: []string{fsRoot},
+			Probe: filepath.Join(candidate, "missing-probe")},
+		{Key: "poll", Roots: []string{candidate}},
+	}
+	assert.Empty(t, availableUnwatchedPollRoots(obligations),
+		"a blocked filesystem-root scope must defer every candidate beneath it")
+}
+
 // TestUnwatchedPollPreservesSessionsUnderBlockedOverlappingScope drives the
 // real engine: agent A's configured dir is an ancestor of agent B's, B's probe
 // is missing, and A stays pollable. Polling A's root must not expand into B's

--- a/cmd/agentsview/unwatched_poll_test.go
+++ b/cmd/agentsview/unwatched_poll_test.go
@@ -11,6 +11,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/parser"
+	agentsync "go.kenn.io/agentsview/internal/sync"
 )
 
 type recordingUnwatchedPollSyncer struct {
@@ -283,6 +288,103 @@ func TestUnwatchedPollDefersSharedScopeWhileAnyProbeMissing(t *testing.T) {
 	requirePollWithin(t, syncer.wake, time.Second)
 	assert.Equal(t, [][]string{{configured}, {configured}}, syncer.snapshot(),
 		"the shared scope must resume once every probe returns")
+}
+
+// TestAvailableUnwatchedPollRootsDefersRootsOverlappingBlockedScopes pins the
+// cross-obligation analogue of overlapsDeferredScope: a missing probe blocks
+// its own roots, but ReconcileWatchRoots expands every requested root to the
+// configured dirs above and below it, so a still-available ancestor or
+// descendant root from another obligation would pull the deferred scope back
+// into an authoritative pass and tombstone its sessions.
+func TestAvailableUnwatchedPollRootsDefersRootsOverlappingBlockedScopes(t *testing.T) {
+	base := t.TempDir()
+	nested := requireExistingPollRoot(t, base, "nested")
+	missingProbe := filepath.Join(nested, "missing-probe")
+	unrelated := requireExistingPollRoot(t, t.TempDir(), "other")
+
+	tests := []struct {
+		name        string
+		obligations []pollingObligation
+		want        []string
+	}{
+		{
+			name: "blocked descendant defers available ancestor",
+			obligations: []pollingObligation{
+				{Key: "base", Roots: []string{base, unrelated}},
+				{Key: "nested", Roots: []string{nested}, Probe: missingProbe},
+			},
+			want: []string{unrelated},
+		},
+		{
+			name: "blocked ancestor defers available descendant",
+			obligations: []pollingObligation{
+				{Key: "nested", Roots: []string{nested, unrelated}},
+				{Key: "base", Roots: []string{base}, Probe: filepath.Join(base, "gone")},
+			},
+			want: []string{unrelated},
+		},
+		{
+			name: "available probes keep overlapping roots pollable",
+			obligations: []pollingObligation{
+				{Key: "base", Roots: []string{base}},
+				{Key: "nested", Roots: []string{nested}, Probe: nested},
+			},
+			want: []string{base, nested},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, availableUnwatchedPollRoots(tc.obligations))
+		})
+	}
+}
+
+// TestUnwatchedPollPreservesSessionsUnderBlockedOverlappingScope drives the
+// real engine: agent A's configured dir is an ancestor of agent B's, B's probe
+// is missing, and A stays pollable. Polling A's root must not expand into B's
+// configured scope and tombstone B's baselined session as an empty discovery.
+func TestUnwatchedPollPreservesSessionsUnderBlockedOverlappingScope(t *testing.T) {
+	base := t.TempDir()
+	nested := requireExistingPollRoot(t, base, "nested")
+	sourcePath := filepath.Join(nested, "project", "archived-session.jsonl")
+
+	database := dbtest.OpenTestDB(t)
+	const sessionID = "claude:archived"
+	dbtest.SeedSession(t, database, sessionID, "project",
+		func(session *db.Session) {
+			session.Agent = string(parser.AgentClaude)
+			session.FilePath = &sourcePath
+		})
+	require.NoError(t,
+		database.SetSessionDataVersion(sessionID, db.CurrentDataVersion()))
+	require.NoError(t, database.BaselineActiveSessionSourcePaths(
+		t.Context(), "local", []db.SessionSourcePath{{
+			Agent: string(parser.AgentClaude), FilePath: sourcePath,
+		}},
+	))
+	engine := agentsync.NewEngine(database, agentsync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentOpenHands: {base},
+			parser.AgentClaude:    {nested},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+
+	obligations := []pollingObligation{
+		{Key: "persistent:" + base, Roots: []string{base}, Probe: base},
+		{Key: "nested-gate", Roots: []string{nested},
+			Probe: filepath.Join(nested, "missing-subtree")},
+	}
+	roots := availableUnwatchedPollRoots(obligations)
+	pollUnwatchedRootsOnce(t.Context(), engine, roots)
+
+	assert.Empty(t, roots,
+		"an ancestor overlapping a blocked scope must not stay pollable")
+	preserved, err := database.GetSession(t.Context(), sessionID)
+	require.NoError(t, err)
+	assert.NotNil(t, preserved,
+		"polling must not tombstone sessions under the deferred nested scope")
 }
 
 func TestUnwatchedPollObligationUpdatesRemainResponsiveDuringReconciliation(

--- a/cmd/agentsview/worker_pass.go
+++ b/cmd/agentsview/worker_pass.go
@@ -1,0 +1,442 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/spf13/pflag"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/sync"
+)
+
+// workerLineMaxBytes caps a single NDJSON line from the worker. A malformed or
+// unbounded line is a protocol failure, not a reason to grow memory without
+// limit.
+const workerLineMaxBytes = 1 << 20 // 1 MB
+
+// Write-owner lock reacquisition retries with exponential backoff after a worker
+// pass. A contended lock (another process grabbed it during the handoff) is
+// transient, so the daemon keeps retrying rather than stranding itself
+// read-only until restart. A package var so tests can shrink the initial delay.
+var (
+	reacquireBackoffInitial = 250 * time.Millisecond
+	reacquireBackoffMax     = 10 * time.Second
+)
+
+// errWorkerSpawn marks a failure to start the worker process (locating the
+// executable, wiring stdout, or exec). Daemon call sites fall back to the
+// in-process path only when no worker ran (this error or errWorkerHandoff,
+// see workerNeverRan); a worker that ran and reported a non-ok result is
+// surfaced as-is rather than re-run in process.
+var errWorkerSpawn = errors.New("sync worker spawn failed")
+
+// errWorkerHandoff marks a pre-launch handoff failure: closing the writer or
+// releasing the write-owner lock ahead of a worker pass failed, so no worker
+// process ever ran and no sync occurred. Both failure paths restore the writer
+// (and keep the flock) before returning, so callers treat it like
+// errWorkerSpawn: fall back to the in-process pass or retry later.
+var errWorkerHandoff = errors.New("sync worker handoff failed")
+
+// workerNeverRan reports whether err marks a pass in which no worker process
+// ran: a spawn failure or a pre-launch handoff failure. Daemon call sites gate
+// their in-process fallback on it; a worker that ran and failed is surfaced
+// as-is rather than re-run.
+func workerNeverRan(err error) bool {
+	return errors.Is(err, errWorkerSpawn) || errors.Is(err, errWorkerHandoff)
+}
+
+// launchSyncWorker is the worker-launch seam. Production self-execs the binary;
+// tests stub it to exercise runWorkerWritePass without spawning a process.
+var launchSyncWorker = launchSyncWorkerProcess
+
+// closeWriterForHandoff indirects db.CloseWriter so tests can reproduce the
+// close-failure posture (writer closed, error returned) without pinning
+// internal pool state.
+var closeWriterForHandoff = (*db.DB).CloseWriter
+
+// closeWriterForPass closes the writer ahead of a worker handoff. A failed
+// close abandons the pass: the error is returned, the caller keeps the
+// write-owner flock and never launches the worker, and db retains the
+// undrained pool so a later close still cannot release ownership while that
+// connection survives. The writer is then reopened so the daemon keeps
+// serving writes instead of returning ErrWriterClosed until restart —
+// reopening cannot admit a second writer because ownership was never handed
+// off and the surviving connection belongs to this process.
+func closeWriterForPass(
+	recoveryCtx context.Context, database *db.DB, what string,
+) error {
+	err := closeWriterForHandoff(database)
+	if err == nil {
+		return nil
+	}
+	if rerr := restoreArchiveAccess(
+		recoveryCtx, "reopen writer after failed close for "+what,
+		database.ReopenWriter,
+	); rerr != nil {
+		err = errors.Join(err, rerr)
+	}
+	return fmt.Errorf("close writer for %s: %w", what, err)
+}
+
+// runWorkerWritePass yields write ownership around a worker run against the live
+// archive under the engine's exclusive sync lock. It performs no sync
+// bookkeeping; foreground and deferred-startup sync passes use
+// runWorkerSyncPass instead so completion is recorded with SyncThenRun parity.
+// The daemon's in-memory skip cache is reloaded inside the same exclusive
+// section (see workerWritePassLocked), so queued sync work never observes —
+// or re-persists — skip state the worker made stale.
+// recoveryCtx bounds post-pass lock and writer recovery: it must outlive the
+// pass's own ctx (a request context for foreground syncs) but end at daemon
+// shutdown, so persistent recovery failure cannot block exit while this pass
+// holds the exclusive sync lock.
+func runWorkerWritePass(
+	ctx context.Context,
+	recoveryCtx context.Context,
+	cfg config.Config,
+	engine *sync.Engine,
+	database *db.DB,
+	lock *writeOwnerLock,
+	mode string,
+	onLine func(workerLine),
+) (workerResult, error) {
+	var result workerResult
+	err := engine.RunExclusive(func() error {
+		var workerErr error
+		result, workerErr = workerWritePassLocked(
+			ctx, recoveryCtx, cfg, engine, database, lock, mode, onLine,
+		)
+		return workerErr
+	})
+	return result, err
+}
+
+// runWorkerSyncPass runs a "sync"-mode worker pass with SyncThenRun-equivalent
+// completion semantics. When skipIfReconciled is set, the startup gate is
+// rechecked while the exclusive lock is held — a foreground pass may have
+// reconciled startup while this caller waited on the lock, and only a
+// lock-held recheck closes that race. A worker that actually ran (spawn
+// succeeded) records reconciliation and last-sync bookkeeping before the lock
+// is released; the emit and startup callback fire after it, mirroring the
+// in-process defer ordering. A failure in which no worker ran — a spawn
+// failure or a pre-launch handoff failure — records nothing and reports
+// ran=false, so the caller's in-process fallback keeps first-attempt
+// semantics.
+func runWorkerSyncPass(
+	ctx context.Context,
+	recoveryCtx context.Context,
+	cfg config.Config,
+	engine *sync.Engine,
+	database *db.DB,
+	lock *writeOwnerLock,
+	skipIfReconciled bool,
+	onLine func(workerLine),
+) (stats sync.SyncStats, ran bool, err error) {
+	recorded := false
+	err = engine.RunExclusive(func() error {
+		if skipIfReconciled && engine.StartupReconciled() {
+			return nil
+		}
+		result, workerErr := workerWritePassLocked(
+			ctx, recoveryCtx, cfg, engine, database, lock, "sync", onLine,
+		)
+		if workerNeverRan(workerErr) {
+			return workerErr
+		}
+		ran = true
+		stats = statsFromWorkerResult(result)
+		engine.RecordStartupReconciledExclusive(stats, workerErr)
+		recorded = true
+		return workerErr
+	})
+	if recorded {
+		engine.FinishStartupReconciled(stats)
+	}
+	return stats, ran, err
+}
+
+// workerWritePassLocked is the writer-handoff body: it closes the writer
+// (readers keep serving), releases the write lock, runs the worker, then
+// unconditionally reacquires the lock and reopens the writer. Losing write
+// ownership permanently is worse than a failed pass, so reacquisition and
+// reopen run even when the worker fails. The caller holds the engine's
+// exclusive sync lock. The two pre-launch exits — a failed writer close and a
+// failed lock release — wrap errWorkerHandoff: no worker ran, and both paths
+// restore the writer (keeping the flock) before returning, so callers may
+// fall back in process or retry.
+func workerWritePassLocked(
+	ctx context.Context,
+	recoveryCtx context.Context,
+	cfg config.Config,
+	engine *sync.Engine,
+	database *db.DB,
+	lock *writeOwnerLock,
+	mode string,
+	onLine func(workerLine),
+) (workerResult, error) {
+	if err := closeWriterForPass(recoveryCtx, database, mode+" pass"); err != nil {
+		return workerResult{}, fmt.Errorf("%w: %w", errWorkerHandoff, err)
+	}
+	if err := lock.Release(); err != nil {
+		// The writer is still closed; restore it so the daemon keeps
+		// writing rather than stranding the archive read-only.
+		if rerr := restoreArchiveAccess(
+			recoveryCtx,
+			"reopen writer after failed "+mode+" lock release",
+			database.ReopenWriter,
+		); rerr != nil {
+			err = errors.Join(err, rerr)
+		}
+		return workerResult{}, fmt.Errorf(
+			"%w: release write lock for %s pass: %w", errWorkerHandoff, mode, err,
+		)
+	}
+
+	result, workerErr := launchSyncWorker(ctx, cfg, mode, onLine)
+
+	// Lock recovery must not die with the caller's context: foreground
+	// syncs pass the HTTP request context, and a client disconnect
+	// during contention would otherwise exit the retry loop with the
+	// writer closed and the lock unreacquired until restart. Recovery
+	// runs on the daemon-lifetime recoveryCtx: request cancellation is
+	// ignored, but daemon shutdown stops the retries so a persistent
+	// failure cannot block exit under the exclusive sync lock.
+	if err := reacquireWriteOwnerLock(recoveryCtx, lock, mode); err != nil {
+		return result, err
+	}
+	if err := restoreArchiveAccess(
+		recoveryCtx,
+		"reopen writer after "+mode+" pass",
+		database.ReopenWriter,
+	); err != nil {
+		return result, err
+	}
+	// Any worker that actually launched may have rewritten the durable skip
+	// cache (new entries for synced files, deleted hash-qualified keys for
+	// tombstoned sources) — even a failed or lost-result run can have
+	// committed before dying. Reload while the exclusive sync lock is still
+	// held: a queued watcher sync persists the in-memory snapshot wholesale,
+	// so a reload deferred past this lock would let it durably resurrect
+	// entries the worker removed. A spawn failure means no worker ran, so the
+	// in-memory state is kept as the freshest copy.
+	if !errors.Is(workerErr, errWorkerSpawn) {
+		if err := engine.ReloadSkipCache(); err != nil {
+			workerErr = errors.Join(workerErr, err)
+		}
+	}
+	return result, workerErr
+}
+
+// restoreArchiveAccess retries an archive-access restoration (writer reopen,
+// full reopen after a failed swap) with exponential backoff until it succeeds
+// or ctx is cancelled. Restoration is mandatory: abandoning it after one
+// failed attempt leaves the daemon running with every write endpoint failing
+// until restart, which is worse than a failed pass. Recovery sites call this
+// with the daemon-lifetime recovery context, so request cancellation cannot
+// abandon restoration but daemon shutdown still stops the retries.
+func restoreArchiveAccess(
+	ctx context.Context, what string, restore func() error,
+) error {
+	backoff := reacquireBackoffInitial
+	for {
+		err := restore()
+		if err == nil {
+			return nil
+		}
+		log.Printf("%s failed; retrying in %s: %v", what, backoff, err)
+		timer := time.NewTimer(backoff)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return fmt.Errorf("%s: %w", what, ctx.Err())
+		case <-timer.C:
+		}
+		backoff = min(backoff*2, reacquireBackoffMax)
+	}
+}
+
+// reacquireWriteOwnerLock retakes the write-owner lock after a worker pass,
+// retrying with exponential backoff until it succeeds or ctx is cancelled. A
+// lock briefly contended by another process is transient; giving up on the
+// first failure would leave the writer closed and every write 500ing until the
+// daemon restarts, so the loop keeps trying and logs each failure loudly. It
+// returns an error only when ctx is cancelled, since the writer stays closed.
+func reacquireWriteOwnerLock(
+	ctx context.Context, lock *writeOwnerLock, mode string,
+) error {
+	backoff := reacquireBackoffInitial
+	for {
+		if err := lock.Reacquire(); err == nil {
+			return nil
+		} else {
+			log.Printf(
+				"reacquire write lock after %s pass failed; retrying in %s: %v",
+				mode, backoff, err,
+			)
+		}
+		timer := time.NewTimer(backoff)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return fmt.Errorf(
+				"reacquire write lock after %s pass: %w", mode, ctx.Err(),
+			)
+		case <-timer.C:
+		}
+		backoff = min(backoff*2, reacquireBackoffMax)
+	}
+}
+
+// launchSyncWorkerProcess self-execs `sync-worker --mode=<mode>`, decodes the
+// child's NDJSON stdout, forwards every line to onLine, and enforces the parent
+// parse contract: exactly one valid terminal result with no malformed lines. It
+// returns the terminal result and a non-nil error on any protocol violation or
+// non-ok terminal status, regardless of the child's exit code.
+func launchSyncWorkerProcess(
+	ctx context.Context,
+	cfg config.Config,
+	mode string,
+	onLine func(workerLine),
+) (workerResult, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return workerResult{}, fmt.Errorf(
+			"%w: finding executable: %v", errWorkerSpawn, err,
+		)
+	}
+
+	cmd := exec.CommandContext(ctx, exe, syncWorkerChildArgs(os.Args[1:], mode)...)
+	// Config forwarding mirrors startServeBackgroundProcess: the child inherits
+	// the parent environment (per-agent dir overrides, AGENTSVIEW_* vars), plus
+	// the worker marker and the resolved data dir. syncWorkerChildArgs forwards
+	// the parent's serve config flags so CLI overrides also reach the child.
+	cmd.Env = append(os.Environ(), syncWorkerChildEnvVar+"=1")
+	if cfg.DataDir != "" {
+		cmd.Env = append(cmd.Env, "AGENTSVIEW_DATA_DIR="+cfg.DataDir)
+	}
+	cmd.Stderr = os.Stderr
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return workerResult{}, fmt.Errorf(
+			"%w: stdout pipe: %v", errWorkerSpawn, err,
+		)
+	}
+	if err := cmd.Start(); err != nil {
+		return workerResult{}, fmt.Errorf(
+			"%w: starting process: %v", errWorkerSpawn, err,
+		)
+	}
+
+	result, parseErr, waitErr := collectWorkerResult(cmd, stdout, onLine)
+
+	if parseErr != nil {
+		return result, fmt.Errorf("%s worker: %w", mode, parseErr)
+	}
+	if result.Status != "ok" || !result.DiscoveryComplete {
+		detail := result.Status
+		if result.Error != "" {
+			detail = fmt.Sprintf("%s (%s)", result.Status, result.Error)
+		}
+		return result, fmt.Errorf("%s worker pass reported %s", mode, detail)
+	}
+	if waitErr != nil {
+		return result, fmt.Errorf("%s worker process: %w", mode, waitErr)
+	}
+	return result, nil
+}
+
+// collectWorkerResult parses the worker's NDJSON stdout to completion, then
+// waits for the process to exit. Stdout must be fully consumed before Wait: a
+// scanner error (most likely a line beyond the workerLineMaxBytes cap) stops
+// parsing mid-stream, and calling Wait with output still unread would deadlock
+// — the child blocks writing to the full pipe and never exits. The remainder
+// is discarded instead, bounded by what the child actually writes, so the
+// protocol error surfaces alongside the worker's real exit status.
+func collectWorkerResult(
+	cmd *exec.Cmd, stdout io.Reader, onLine func(workerLine),
+) (result workerResult, parseErr, waitErr error) {
+	result, parseErr = readWorkerResult(stdout, onLine)
+	if parseErr != nil {
+		_, _ = io.Copy(io.Discard, stdout)
+	}
+	waitErr = cmd.Wait()
+	return result, parseErr, waitErr
+}
+
+// readWorkerResult scans the worker's NDJSON stdout, forwarding each decoded
+// line to onLine, and enforces the terminal-record contract: every non-blank
+// line must be a valid workerLine and exactly one must carry a Result. Any
+// malformed line, or a result count other than one, is a protocol error.
+func readWorkerResult(
+	r io.Reader, onLine func(workerLine),
+) (workerResult, error) {
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), workerLineMaxBytes)
+
+	var result workerResult
+	resultCount, malformed := 0, 0
+	for sc.Scan() {
+		raw := sc.Bytes()
+		if len(bytes.TrimSpace(raw)) == 0 {
+			continue
+		}
+		var line workerLine
+		if err := json.Unmarshal(raw, &line); err != nil {
+			malformed++
+			continue
+		}
+		if onLine != nil {
+			onLine(line)
+		}
+		if line.Result != nil {
+			resultCount++
+			result = *line.Result
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return result, fmt.Errorf("reading worker output: %w", err)
+	}
+	if malformed > 0 {
+		return result, fmt.Errorf(
+			"sync worker emitted %d malformed output line(s)", malformed,
+		)
+	}
+	if resultCount != 1 {
+		return result, fmt.Errorf(
+			"sync worker emitted %d terminal results, want exactly 1",
+			resultCount,
+		)
+	}
+	return result, nil
+}
+
+// syncWorkerChildArgs builds the child argv for the sync worker. It always
+// carries the mode, and forwards the serve config flags the parent daemon was
+// invoked with so CLI overrides reach the child identically to a serve
+// --background child. Re-emitting the parsed flags (rather than copying raw
+// tokens) drops serve-only lifecycle flags the worker does not accept and
+// normalizes every value to an unambiguous --name=value form.
+func syncWorkerChildArgs(parentArgs []string, mode string) []string {
+	args := []string{"sync-worker", "--mode", mode}
+	fs := pflag.NewFlagSet("sync-worker-forward", pflag.ContinueOnError)
+	fs.ParseErrorsAllowlist.UnknownFlags = true
+	config.RegisterServePFlags(fs)
+	// Parse ignores the leading `serve` subcommand token (a positional) and any
+	// serve-only flags (whitelisted as unknown); a parse error only means fewer
+	// forwarded flags, never a failed spawn.
+	_ = fs.Parse(parentArgs)
+	fs.Visit(func(f *pflag.Flag) {
+		args = append(args, "--"+f.Name+"="+f.Value.String())
+	})
+	return args
+}

--- a/cmd/agentsview/worker_pass_test.go
+++ b/cmd/agentsview/worker_pass_test.go
@@ -1,0 +1,968 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/sync"
+)
+
+// openTestWriteDB opens a writable DB and acquires the write-owner lock for cfg,
+// cleaning both up at test end.
+func openTestWriteDB(t *testing.T, cfg config.Config) (*db.DB, *writeOwnerLock) {
+	t.Helper()
+	database, lock, err := openWriteDB(context.Background(), cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { closeWriteDB(database, lock) })
+	return database, lock
+}
+
+// writeOneSession attempts a single write through the DB writer pool.
+func writeOneSession(database *db.DB) error {
+	return database.UpsertSession(db.Session{
+		ID:      "worker-pass-write",
+		Project: "handoff",
+		Machine: "local",
+		Agent:   "claude",
+	})
+}
+
+// assertWriteOwnerLockHeld verifies the write-owner flock for dataDir is held
+// by probing a competing acquisition, which must fail while the lock is held.
+func assertWriteOwnerLockHeld(t *testing.T, dataDir, msg string) {
+	t.Helper()
+	probe, err := tryAcquireWriteOwnerLock(dataDir)
+	if err == nil {
+		assert.NoError(t, probe.Close())
+	}
+	var held writeOwnerLockHeldError
+	assert.ErrorAs(t, err, &held, msg)
+}
+
+// requireWriteOwnerLockReleased verifies the write-owner flock for dataDir is
+// free by acquiring and immediately releasing a probe lock.
+func requireWriteOwnerLockReleased(t *testing.T, dataDir, msg string) {
+	t.Helper()
+	probe, err := tryAcquireWriteOwnerLock(dataDir)
+	require.NoError(t, err, msg)
+	require.NoError(t, probe.Close())
+}
+
+// stubLaunchSyncWorker swaps the launchSyncWorker seam for a test double and
+// restores it when the returned func runs.
+func stubLaunchSyncWorker(
+	t *testing.T,
+	fn func(
+		context.Context, config.Config, string, func(workerLine),
+	) (workerResult, error),
+) func() {
+	t.Helper()
+	prev := launchSyncWorker
+	launchSyncWorker = fn
+	return func() { launchSyncWorker = prev }
+}
+
+// stubCloseWriterFailure swaps the closeWriterForHandoff seam for a double
+// that reproduces the drain-timeout failure posture — the writer really is
+// closed (barrier active, this process keeps the flock) and an error is
+// returned — restoring the seam when the returned func runs.
+func stubCloseWriterFailure(t *testing.T) func() {
+	t.Helper()
+	prev := closeWriterForHandoff
+	closeWriterForHandoff = func(d *db.DB) error {
+		if err := d.CloseWriter(); err != nil {
+			return err
+		}
+		return errors.New("writer connection still in use after close")
+	}
+	return func() { closeWriterForHandoff = prev }
+}
+
+// TestRunWorkerWritePassRecoversWriterWhenCloseFails pins availability after a
+// failed writer close: the pass is abandoned — the worker never launches and
+// the write-owner flock is never released — but the writer must be reopened so
+// the daemon keeps serving writes instead of returning ErrWriterClosed until
+// restart. Reopening cannot admit a second writer because ownership was never
+// handed off.
+func TestRunWorkerWritePassRecoversWriterWhenCloseFails(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	database, lock := openTestWriteDB(t, cfg)
+	engine := sync.NewEngine(database, sync.EngineConfig{})
+	defer engine.Close()
+
+	restoreClose := stubCloseWriterFailure(t)
+	defer restoreClose()
+	restoreLaunch := stubLaunchSyncWorker(t, func(
+		context.Context, config.Config, string, func(workerLine),
+	) (workerResult, error) {
+		t.Error("worker must not launch after a failed writer close")
+		return workerResult{}, nil
+	})
+	defer restoreLaunch()
+
+	_, err := runWorkerWritePass(
+		context.Background(), context.Background(), cfg, engine, database,
+		lock, "audit", nil,
+	)
+	require.ErrorContains(t, err, "close writer for audit pass")
+	assertWriteOwnerLockHeld(t, cfg.DataDir,
+		"a failed close must keep the write-owner flock")
+	assert.NoError(t, writeOneSession(database),
+		"writes must recover without a daemon restart")
+}
+
+// TestRunWorkerResyncBuildRecoversWriterWhenCloseFails is the resync-build
+// arm of the same posture: a failed writer close abandons the build before
+// the worker launches, keeps ownership, and must restore write service.
+func TestRunWorkerResyncBuildRecoversWriterWhenCloseFails(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	database, _ := openTestWriteDB(t, cfg)
+	engine := sync.NewEngine(database, sync.EngineConfig{})
+	defer engine.Close()
+
+	restoreClose := stubCloseWriterFailure(t)
+	defer restoreClose()
+	restoreLaunch := stubLaunchSyncWorker(t, func(
+		context.Context, config.Config, string, func(workerLine),
+	) (workerResult, error) {
+		t.Error("worker must not launch after a failed writer close")
+		return workerResult{}, nil
+	})
+	defer restoreLaunch()
+
+	_, err, spawnFailed := runWorkerResyncBuild(
+		context.Background(), context.Background(), cfg, engine, database, nil,
+	)
+	require.False(t, spawnFailed,
+		"a close failure is not a spawn failure and must not trigger the in-process fallback")
+	require.ErrorContains(t, err, "close writer for resync build")
+	assertWriteOwnerLockHeld(t, cfg.DataDir,
+		"a failed close must keep the write-owner flock")
+	assert.NoError(t, writeOneSession(database),
+		"writes must recover without a daemon restart")
+}
+
+func TestRunWorkerWritePassYieldsWriteOwnership(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	database, lock := openTestWriteDB(t, cfg)
+	engine := sync.NewEngine(database, sync.EngineConfig{})
+	defer engine.Close()
+
+	restore := stubLaunchSyncWorker(t, func(
+		_ context.Context, _ config.Config, mode string, _ func(workerLine),
+	) (workerResult, error) {
+		assert.Equal(t, "audit", mode)
+		requireWriteOwnerLockReleased(t, cfg.DataDir, "flock released before spawn")
+		return workerResult{Status: "ok", DiscoveryComplete: true}, nil
+	})
+	defer restore()
+
+	result, err := runWorkerWritePass(
+		context.Background(), context.Background(), cfg, engine, database, lock, "audit", nil,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "ok", result.Status)
+	assertWriteOwnerLockHeld(t, cfg.DataDir, "flock reacquired after the worker")
+	assert.NoError(t, writeOneSession(database), "writer reopened")
+}
+
+// TestRunWorkerWritePassReloadsSkipCacheBeforeReleasingLock pins the skip-cache
+// reload into the pass's own exclusive section. Sync work queued behind the
+// pass — a watcher-driven changed-path sync persists the daemon's in-memory
+// skip cache wholesale — must only ever observe the post-worker state; if the
+// lock were released before the reload, that queued work could durably
+// resurrect entries the worker deleted.
+func TestRunWorkerWritePassReloadsSkipCacheBeforeReleasingLock(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	database, lock := openTestWriteDB(t, cfg)
+	hashKey := filepath.Join(t.TempDir(), "session.jsonl") + "?source_hash=unchanged"
+	require.NoError(t, database.ReplaceSkippedFiles(map[string]int64{hashKey: 123}))
+	engine := sync.NewEngine(database, sync.EngineConfig{})
+	defer engine.Close()
+	require.Contains(t, engine.SnapshotSkipCache(), hashKey)
+
+	queued := make(chan map[string]int64, 1)
+	restore := stubLaunchSyncWorker(t, func(
+		_ context.Context, workerCfg config.Config, _ string, _ func(workerLine),
+	) (workerResult, error) {
+		// The worker durably deletes the entry, exactly like a tombstoning
+		// audit pass.
+		workerDB, err := db.Open(workerCfg.DBPath)
+		require.NoError(t, err)
+		require.NoError(t, workerDB.ReplaceSkippedFiles(map[string]int64{}))
+		require.NoError(t, workerDB.Close())
+		// Queue competing exclusive work while the pass still holds the sync
+		// lock, then linger so it is blocked on the lock before the pass ends.
+		go func() {
+			_ = engine.RunExclusive(func() error {
+				queued <- engine.SnapshotSkipCache()
+				return nil
+			})
+		}()
+		time.Sleep(50 * time.Millisecond)
+		return workerResult{
+			Status: "ok", Tombstoned: 1, DiscoveryComplete: true,
+		}, nil
+	})
+	defer restore()
+
+	_, err := runWorkerWritePass(
+		context.Background(), context.Background(), cfg, engine, database, lock,
+		"audit", nil,
+	)
+	require.NoError(t, err)
+	assert.NotContains(t, <-queued, hashKey,
+		"work queued behind the pass must observe the reloaded skip cache, "+
+			"never the stale pre-worker snapshot")
+}
+
+// TestRunWorkerWritePassKeepsSkipCacheOnSpawnFailure pins the reload gate: when
+// no worker ever ran, the archive was not touched, so the daemon's in-memory
+// skip state (which may be ahead of the last persisted snapshot) must be kept
+// rather than clobbered by a reload.
+func TestRunWorkerWritePassKeepsSkipCacheOnSpawnFailure(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	database, lock := openTestWriteDB(t, cfg)
+	hashKey := filepath.Join(t.TempDir(), "session.jsonl") + "?source_hash=unchanged"
+	require.NoError(t, database.ReplaceSkippedFiles(map[string]int64{hashKey: 123}))
+	engine := sync.NewEngine(database, sync.EngineConfig{})
+	defer engine.Close()
+	require.Contains(t, engine.SnapshotSkipCache(), hashKey)
+	// Make the durable snapshot lag the in-memory state, as after a failed
+	// persist: a reload here would wrongly drop the in-memory entry.
+	require.NoError(t, database.ReplaceSkippedFiles(map[string]int64{}))
+
+	restore := stubLaunchSyncWorker(t, func(
+		_ context.Context, _ config.Config, _ string, _ func(workerLine),
+	) (workerResult, error) {
+		return workerResult{}, fmt.Errorf("%w: starting process: boom", errWorkerSpawn)
+	})
+	defer restore()
+
+	_, err := runWorkerWritePass(
+		context.Background(), context.Background(), cfg, engine, database, lock,
+		"audit", nil,
+	)
+	require.ErrorIs(t, err, errWorkerSpawn)
+	assert.Contains(t, engine.SnapshotSkipCache(), hashKey,
+		"a pass whose worker never ran must not reload away in-memory skip state")
+}
+
+func TestRunWorkerWritePassReacquiresOnWorkerFailure(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	database, lock := openTestWriteDB(t, cfg)
+	engine := sync.NewEngine(database, sync.EngineConfig{})
+	defer engine.Close()
+
+	workerErr := errors.New("worker boom")
+	restore := stubLaunchSyncWorker(t, func(
+		_ context.Context, _ config.Config, _ string, _ func(workerLine),
+	) (workerResult, error) {
+		return workerResult{Status: "failed"}, workerErr
+	})
+	defer restore()
+
+	result, err := runWorkerWritePass(
+		context.Background(), context.Background(), cfg, engine, database, lock, "audit", nil,
+	)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, workerErr, "worker error must propagate")
+	assert.Equal(t, "failed", result.Status)
+	assertWriteOwnerLockHeld(t, cfg.DataDir,
+		"flock reacquired even after worker failure")
+	assert.NoError(t, writeOneSession(database),
+		"writer reopened even after worker failure")
+}
+
+func TestRunWorkerWritePassRetriesReacquireUntilLockFree(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	database, lock := openTestWriteDB(t, cfg)
+	engine := sync.NewEngine(database, sync.EngineConfig{})
+	defer engine.Close()
+
+	prevInitial, prevMax := reacquireBackoffInitial, reacquireBackoffMax
+	reacquireBackoffInitial = 5 * time.Millisecond
+	reacquireBackoffMax = 20 * time.Millisecond
+	defer func() {
+		reacquireBackoffInitial, reacquireBackoffMax = prevInitial, prevMax
+	}()
+
+	closeErr := make(chan error, 1)
+	restore := stubLaunchSyncWorker(t, func(
+		_ context.Context, _ config.Config, _ string, _ func(workerLine),
+	) (workerResult, error) {
+		// The daemon released the flock for the pass; a contender grabs it and
+		// holds it briefly so the first reacquire attempts fail, then releases
+		// so the retry loop must recover instead of stranding the writer.
+		contender, err := tryAcquireWriteOwnerLock(cfg.DataDir)
+		require.NoError(t, err, "contender takes the freed lock")
+		go func() {
+			time.Sleep(40 * time.Millisecond)
+			closeErr <- contender.Close()
+		}()
+		return workerResult{Status: "ok", DiscoveryComplete: true}, nil
+	})
+	defer restore()
+
+	result, err := runWorkerWritePass(
+		context.Background(), context.Background(), cfg, engine, database, lock, "audit", nil,
+	)
+	require.NoError(t, err, "pass recovers once the contender releases the lock")
+	require.NoError(t, <-closeErr, "contender released the lock cleanly")
+	assert.Equal(t, "ok", result.Status)
+	assertWriteOwnerLockHeld(t, cfg.DataDir, "flock eventually reacquired")
+	assert.NoError(t, writeOneSession(database), "writer reopened after recovery")
+}
+
+// TestRunWorkerSyncPassRecordsSyncBookkeeping pins SyncThenRun parity for the
+// worker-backed foreground sync: the full SyncStats payload reaches the
+// caller, last-sync state feeds /sync/status, startup is reconciled, and the
+// "sync" event is emitted for subscribers.
+func TestRunWorkerSyncPassRecordsSyncBookkeeping(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	database, lock := openTestWriteDB(t, cfg)
+	em := &scopedEmitter{scopes: make(chan string, 4)}
+	engine := sync.NewEngine(database, sync.EngineConfig{Emitter: em})
+	defer engine.Close()
+
+	workerStats := sync.SyncStats{
+		TotalSessions:  5,
+		Synced:         3,
+		OrphanedCopied: 2,
+		Warnings:       []string{"one warning"},
+	}
+	restore := stubLaunchSyncWorker(t, func(
+		_ context.Context, _ config.Config, mode string, _ func(workerLine),
+	) (workerResult, error) {
+		assert.Equal(t, "sync", mode)
+		return workerResult{
+			Status: "ok", Synced: 3, DiscoveryComplete: true,
+			Stats: &workerStats,
+		}, nil
+	})
+	defer restore()
+
+	stats, ran, err := runWorkerSyncPass(
+		context.Background(), context.Background(), cfg, engine, database, lock, false, nil,
+	)
+	require.NoError(t, err)
+	assert.True(t, ran)
+	assert.Equal(t, 5, stats.TotalSessions,
+		"the full SyncStats payload must survive the worker protocol")
+	assert.Equal(t, 2, stats.OrphanedCopied)
+	assert.Equal(t, []string{"one warning"}, stats.Warnings)
+	assert.False(t, engine.LastSync().IsZero(),
+		"last-sync state must reflect the worker-backed pass")
+	assert.Equal(t, stats, engine.LastSyncStats())
+	assert.True(t, engine.StartupReconciled())
+	select {
+	case scope := <-em.scopes:
+		assert.Equal(t, "sync", scope)
+	default:
+		require.FailNow(t, "a worker-backed sync with changes must emit the sync event")
+	}
+}
+
+// TestRunWorkerSyncPassNoWorkerRecordsNothing pins first-attempt semantics for
+// every failure mode in which no worker process ran: a pre-launch writer-close
+// failure, a pre-launch lock-release failure, and a spawn failure. The pass
+// must report ran=false, record no startup reconciliation or last-sync state,
+// keep the OnStartupReconciled callback (watcher dispatch) closed, and leave
+// the archive writable so a retry or in-process fallback can run the first
+// real attempt.
+func TestRunWorkerSyncPassNoWorkerRecordsNothing(t *testing.T) {
+	tests := []struct {
+		name        string
+		failClose   bool
+		failRelease bool
+		failSpawn   bool
+		wantErrIs   error
+		wantErrText string
+	}{
+		{
+			name:        "writer close failure",
+			failClose:   true,
+			wantErrIs:   errWorkerHandoff,
+			wantErrText: "close writer for sync pass",
+		},
+		{
+			name:        "lock release failure",
+			failRelease: true,
+			wantErrIs:   errWorkerHandoff,
+			wantErrText: "release write lock for sync pass",
+		},
+		{
+			name:      "spawn failure",
+			failSpawn: true,
+			wantErrIs: errWorkerSpawn,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := testConfigWithClaudeFixture(t)
+			database, lock := openTestWriteDB(t, cfg)
+			reconciled := make(chan error, 1)
+			engine := sync.NewEngine(database, sync.EngineConfig{
+				OnStartupReconciled: func(_ sync.SyncStats, err error) {
+					reconciled <- err
+				},
+			})
+			defer engine.Close()
+
+			restoreClose := func() {}
+			if tt.failClose {
+				restoreClose = stubCloseWriterFailure(t)
+			}
+			defer restoreClose()
+			passLock := lock
+			if tt.failRelease {
+				// A nil inner flock makes Release fail after the writer close
+				// succeeded; the daemon's real flock stays held throughout.
+				passLock = &writeOwnerLock{}
+			}
+			restoreLaunch := stubLaunchSyncWorker(t, func(
+				context.Context, config.Config, string, func(workerLine),
+			) (workerResult, error) {
+				if tt.failSpawn {
+					return workerResult{}, fmt.Errorf(
+						"%w: starting process: boom", errWorkerSpawn,
+					)
+				}
+				t.Error("worker must not launch after a pre-launch handoff failure")
+				return workerResult{}, nil
+			})
+			defer restoreLaunch()
+
+			stats, ran, err := runWorkerSyncPass(
+				context.Background(), context.Background(), cfg, engine,
+				database, passLock, false, nil,
+			)
+			require.ErrorIs(t, err, tt.wantErrIs)
+			if tt.wantErrText != "" {
+				require.ErrorContains(t, err, tt.wantErrText)
+			}
+			assert.False(t, ran, "no worker ran, so the pass must report ran=false")
+			assert.Equal(t, sync.SyncStats{}, stats,
+				"a pass without a worker must not synthesize stats")
+			assert.False(t, engine.StartupReconciled(),
+				"startup must stay unreconciled when no worker ran")
+			assert.True(t, engine.LastSync().IsZero(),
+				"no last-sync bookkeeping without a worker")
+			assert.Equal(t, sync.SyncStats{}, engine.LastSyncStats(),
+				"no last-sync stats without a worker")
+			select {
+			case cbErr := <-reconciled:
+				require.FailNowf(t,
+					"startup must not be acknowledged when no worker ran",
+					"callback fired with: %v", cbErr)
+			default:
+			}
+			assertWriteOwnerLockHeld(t, cfg.DataDir,
+				"the daemon must keep write ownership across the failed pass")
+			assert.NoError(t, writeOneSession(database),
+				"writes must recover without a daemon restart")
+
+			// First-attempt semantics survive: a later pass over the intact
+			// state runs the worker and records reconciliation normally.
+			restoreClose()
+			restoreLaunch()
+			restoreRetry := stubLaunchSyncWorker(t, func(
+				context.Context, config.Config, string, func(workerLine),
+			) (workerResult, error) {
+				return workerResult{Status: "ok", DiscoveryComplete: true}, nil
+			})
+			defer restoreRetry()
+			_, ran, err = runWorkerSyncPass(
+				context.Background(), context.Background(), cfg, engine,
+				database, lock, false, nil,
+			)
+			require.NoError(t, err)
+			assert.True(t, ran, "the retry runs the first real worker pass")
+			assert.True(t, engine.StartupReconciled(),
+				"the successful retry must reconcile startup")
+			select {
+			case cbErr := <-reconciled:
+				assert.NoError(t, cbErr,
+					"the retry acknowledges startup without a prior failed attempt")
+			default:
+				require.FailNow(t, "a successful retry must acknowledge startup")
+			}
+		})
+	}
+}
+
+// TestRunWorkerSyncPassWorkerFailureStillRecords pins the ran-and-failed path:
+// a worker that launched and reported failure is surfaced as-is — ran stays
+// true, last-sync stats carry the aborted pass, and the startup attempt is
+// acknowledged (with its error) rather than re-run.
+func TestRunWorkerSyncPassWorkerFailureStillRecords(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	database, lock := openTestWriteDB(t, cfg)
+	reconciled := make(chan error, 1)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		OnStartupReconciled: func(_ sync.SyncStats, err error) {
+			reconciled <- err
+		},
+	})
+	defer engine.Close()
+
+	workerErr := errors.New("worker boom")
+	restore := stubLaunchSyncWorker(t, func(
+		context.Context, config.Config, string, func(workerLine),
+	) (workerResult, error) {
+		return workerResult{Status: "failed"}, workerErr
+	})
+	defer restore()
+
+	stats, ran, err := runWorkerSyncPass(
+		context.Background(), context.Background(), cfg, engine, database,
+		lock, false, nil,
+	)
+	require.ErrorIs(t, err, workerErr)
+	assert.True(t, ran, "a worker that launched and failed still ran")
+	assert.True(t, stats.Aborted,
+		"an incomplete worker pass must surface as aborted stats")
+	assert.Equal(t, stats, engine.LastSyncStats(),
+		"the failed pass must reach last-sync bookkeeping")
+	select {
+	case cbErr := <-reconciled:
+		assert.ErrorIs(t, cbErr, workerErr,
+			"the startup attempt is acknowledged with the worker's error")
+	default:
+		require.FailNow(t,
+			"a worker that ran must acknowledge the startup attempt")
+	}
+}
+
+// TestWorkerNeverRanClassifiesFallbackErrors pins the caller-side fallback
+// gate: only failures in which no worker process ran — spawn and pre-launch
+// handoff — may trigger the in-process fallback; a worker that ran and failed
+// must be surfaced without re-running.
+func TestWorkerNeverRanClassifiesFallbackErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{
+			name: "spawn failure",
+			err:  fmt.Errorf("%w: starting process: boom", errWorkerSpawn),
+			want: true,
+		},
+		{
+			name: "pre-launch handoff failure",
+			err:  fmt.Errorf("%w: close writer for sync pass: boom", errWorkerHandoff),
+			want: true,
+		},
+		{
+			name: "worker ran and failed",
+			err:  errors.New("sync worker pass reported failed"),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, workerNeverRan(tt.err))
+		})
+	}
+}
+
+// TestRunWorkerSyncPassLockHeldRecheckSkipsDuplicate is the regression for the
+// deferred-startup race: the timer fires while a foreground worker pass is
+// still running, so the pre-lock StartupReconciled check reads false. The
+// foreground pass records reconciliation before releasing the exclusive lock,
+// and the deferred pass rechecks the gate while holding it, so exactly one
+// archive-scale worker runs.
+func TestRunWorkerSyncPassLockHeldRecheckSkipsDuplicate(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	database, lock := openTestWriteDB(t, cfg)
+	engine := sync.NewEngine(database, sync.EngineConfig{})
+	defer engine.Close()
+
+	launches := make(chan struct{}, 2)
+	release := make(chan struct{})
+	restore := stubLaunchSyncWorker(t, func(
+		_ context.Context, _ config.Config, _ string, _ func(workerLine),
+	) (workerResult, error) {
+		launches <- struct{}{}
+		<-release
+		return workerResult{Status: "ok", Synced: 1, DiscoveryComplete: true}, nil
+	})
+	defer restore()
+
+	require.False(t, engine.StartupReconciled(),
+		"the deferred fallback's pre-lock gate must read false mid-race")
+
+	type passOutcome struct {
+		ran bool
+		err error
+	}
+	foreground := make(chan passOutcome, 1)
+	go func() {
+		_, ran, err := runWorkerSyncPass(
+			context.Background(), context.Background(), cfg, engine, database, lock, false, nil,
+		)
+		foreground <- passOutcome{ran: ran, err: err}
+	}()
+	<-launches // the foreground worker is running and holds the exclusive lock
+
+	deferred := make(chan passOutcome, 1)
+	go func() {
+		_, ran, err := runWorkerSyncPass(
+			context.Background(), context.Background(), cfg, engine, database, lock, true, nil,
+		)
+		deferred <- passOutcome{ran: ran, err: err}
+	}()
+	// Let the deferred pass reach the exclusive lock before the foreground
+	// worker finishes, then release the worker.
+	time.Sleep(100 * time.Millisecond)
+	close(release)
+
+	fg := <-foreground
+	require.NoError(t, fg.err)
+	assert.True(t, fg.ran)
+	df := <-deferred
+	require.NoError(t, df.err)
+	assert.False(t, df.ran,
+		"the deferred pass must skip after the foreground pass reconciled startup")
+	assert.Len(t, launches, 0,
+		"exactly one archive-scale worker may launch across the race")
+	assertWriteOwnerLockHeld(t, cfg.DataDir, "flock restored after both passes")
+	assert.NoError(t, writeOneSession(database), "writer restored after both passes")
+}
+
+func TestRunWorkerWritePassRecoversLockAfterRequestCancel(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	database, lock := openTestWriteDB(t, cfg)
+	engine := sync.NewEngine(database, sync.EngineConfig{})
+	defer engine.Close()
+
+	prevInitial, prevMax := reacquireBackoffInitial, reacquireBackoffMax
+	reacquireBackoffInitial = 5 * time.Millisecond
+	reacquireBackoffMax = 20 * time.Millisecond
+	defer func() {
+		reacquireBackoffInitial, reacquireBackoffMax = prevInitial, prevMax
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	closeErr := make(chan error, 1)
+	restore := stubLaunchSyncWorker(t, func(
+		_ context.Context, _ config.Config, _ string, _ func(workerLine),
+	) (workerResult, error) {
+		// The client disconnects mid-pass while a contender briefly holds the
+		// freed lock: recovery must still reacquire and reopen the writer.
+		contender, err := tryAcquireWriteOwnerLock(cfg.DataDir)
+		require.NoError(t, err, "contender takes the freed lock")
+		cancel()
+		go func() {
+			time.Sleep(40 * time.Millisecond)
+			closeErr <- contender.Close()
+		}()
+		return workerResult{Status: "ok", DiscoveryComplete: true}, nil
+	})
+	defer restore()
+
+	result, err := runWorkerWritePass(
+		ctx, context.Background(), cfg, engine, database, lock, "sync", nil,
+	)
+	require.NoError(t, err,
+		"recovery must survive request cancellation during contention")
+	require.NoError(t, <-closeErr, "contender released the lock cleanly")
+	assert.Equal(t, "ok", result.Status)
+	assertWriteOwnerLockHeld(t, cfg.DataDir,
+		"flock reacquired despite cancelled request")
+	assert.NoError(t, writeOneSession(database),
+		"writer reopened despite cancelled request")
+}
+
+func TestReacquireWriteOwnerLockStopsOnContextCancel(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	_, lock := openTestWriteDB(t, cfg)
+	require.NoError(t, lock.Release())
+
+	prevInitial := reacquireBackoffInitial
+	reacquireBackoffInitial = time.Hour // never elapses within the test
+	defer func() { reacquireBackoffInitial = prevInitial }()
+
+	// A contender holds the lock so every reacquire attempt fails.
+	contender, err := tryAcquireWriteOwnerLock(cfg.DataDir)
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, contender.Close()) }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err = reacquireWriteOwnerLock(ctx, lock, "audit")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestReadWorkerResultRequiresExactlyOneResult(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantErr   string
+		wantLines int
+	}{
+		{
+			name: "single result",
+			input: `{"progress":{"phase":"syncing"}}` + "\n" +
+				`{"result":{"status":"ok","discoveryComplete":true}}` + "\n",
+			wantLines: 2,
+		},
+		{
+			name:      "zero results is a protocol failure",
+			input:     `{"progress":{"phase":"syncing"}}` + "\n",
+			wantErr:   "0 terminal results",
+			wantLines: 1,
+		},
+		{
+			name: "duplicate results is a protocol failure",
+			input: `{"result":{"status":"ok","discoveryComplete":true}}` + "\n" +
+				`{"result":{"status":"ok","discoveryComplete":true}}` + "\n",
+			wantErr:   "2 terminal results",
+			wantLines: 2,
+		},
+		{
+			name: "malformed line is a protocol failure",
+			input: "not json\n" +
+				`{"result":{"status":"ok","discoveryComplete":true}}` + "\n",
+			wantErr:   "malformed",
+			wantLines: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			seen := 0
+			result, err := readWorkerResult(
+				strings.NewReader(tt.input),
+				func(workerLine) { seen++ },
+			)
+			assert.Equal(t, tt.wantLines, seen, "forwarded line count")
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, "ok", result.Status)
+			assert.True(t, result.DiscoveryComplete)
+		})
+	}
+}
+
+// TestOversizedWorkerOutputHelperProcess is the re-exec target for the
+// oversized-output regression test. Gated by env, it emits a line beyond the
+// parent's workerLineMaxBytes cap followed by far more output than any OS
+// pipe buffer holds, then exits 0.
+func TestOversizedWorkerOutputHelperProcess(t *testing.T) {
+	if os.Getenv("AGENTSVIEW_OVERSIZED_WORKER_HELPER") != "1" {
+		return
+	}
+	w := bufio.NewWriter(os.Stdout)
+	mustWrite := func(s string) {
+		_, err := w.WriteString(s)
+		require.NoError(t, err)
+	}
+	mustWrite(strings.Repeat("a", workerLineMaxBytes+1) + "\n")
+	filler := strings.Repeat("b", 1024) + "\n"
+	for range 512 {
+		mustWrite(filler)
+	}
+	mustWrite(`{"result":{"status":"ok","discoveryComplete":true}}` + "\n")
+	require.NoError(t, w.Flush())
+	os.Exit(0)
+}
+
+// TestCollectWorkerResultOversizedLineDoesNotDeadlock pins the drain-before-
+// Wait contract: an oversized line stops the scanner mid-stream, and the
+// remaining child output must be discarded before Wait — otherwise the child
+// blocks writing to the full stdout pipe, Wait blocks waiting for an exit
+// that cannot happen, and the sync pass hangs until daemon shutdown.
+func TestCollectWorkerResultOversizedLineDoesNotDeadlock(t *testing.T) {
+	cmd := exec.Command(
+		os.Args[0], "-test.run=^TestOversizedWorkerOutputHelperProcess$",
+	)
+	cmd.Env = append(os.Environ(), "AGENTSVIEW_OVERSIZED_WORKER_HELPER=1")
+	stdout, err := cmd.StdoutPipe()
+	require.NoError(t, err)
+	require.NoError(t, cmd.Start())
+
+	type outcome struct {
+		parseErr error
+		waitErr  error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		_, parseErr, waitErr := collectWorkerResult(cmd, stdout, nil)
+		done <- outcome{parseErr: parseErr, waitErr: waitErr}
+	}()
+	select {
+	case out := <-done:
+		require.ErrorIs(t, out.parseErr, bufio.ErrTooLong,
+			"the oversized line must surface as the scanner's protocol error")
+		assert.NoError(t, out.waitErr, "the drained child must exit cleanly")
+	case <-time.After(30 * time.Second):
+		// The wedged child dies on the closed pipe when the test binary exits.
+		t.Fatal("collectWorkerResult deadlocked: oversized output left the " +
+			"child blocked writing to a full, unread stdout pipe")
+	}
+}
+
+func TestSyncWorkerAcquiresWriteLockWhenDaemonYielded(t *testing.T) {
+	dataDir, cfg := writeDBConfigForTest(t)
+	t.Setenv(syncWorkerChildEnvVar, "1")
+	_, err := WriteDaemonRuntime(dataDir, "127.0.0.1", 9, "test", false)
+	require.NoError(t, err)
+	t.Cleanup(func() { RemoveDaemonRuntime(dataDir) })
+
+	// The daemon lives but has yielded: writer closed, write lock free.
+	database, lock, err := openWorkerWriteDB(cfg)
+	require.NoError(t, err,
+		"worker must acquire while a yielded daemon still lives")
+	closeWriteDB(database, lock)
+}
+
+// A sync-worker pass tears down through closeWriteDB (see
+// runSyncWorkerStartup): when the database close fails because a connection
+// never drained, the write-owner flock must be retained — releasing it would
+// let another process acquire writer ownership alongside the surviving
+// SQLite connection.
+func TestSyncWorkerTeardownKeepsWriteOwnerLockWhenCloseFails(t *testing.T) {
+	restore := db.SetCloseDrainTimeoutForTest(100 * time.Millisecond)
+	defer restore()
+	_, cfg := writeDBConfigForTest(t)
+
+	database, lock, err := openWorkerWriteDB(cfg)
+	require.NoError(t, err)
+
+	rows, err := database.Reader().Query("SELECT 1")
+	require.NoError(t, err, "hold a reader connection so Close cannot drain")
+
+	closeWriteDB(database, lock)
+	assertWriteOwnerLockHeld(t, cfg.DataDir,
+		"a failed database close must retain the write-owner flock")
+
+	require.NoError(t, rows.Close())
+	closeWriteDB(database, lock)
+	requireWriteOwnerLockReleased(t, cfg.DataDir,
+		"a successful close after the connection drains releases the flock")
+}
+
+func TestSyncWorkerRefusedWhenDaemonHoldsWriteLock(t *testing.T) {
+	dataDir, cfg := writeDBConfigForTest(t)
+	t.Setenv(syncWorkerChildEnvVar, "1")
+	_, err := WriteDaemonRuntime(dataDir, "127.0.0.1", 9, "test", false)
+	require.NoError(t, err)
+	t.Cleanup(func() { RemoveDaemonRuntime(dataDir) })
+	holdWriteOwnerLockForTest(t, dataDir) // daemon has NOT yielded the flock
+
+	_, _, err = openWorkerWriteDB(cfg)
+	require.Error(t, err,
+		"worker must be refused while the daemon still holds the write lock")
+	assert.ErrorContains(t, err, "write lock")
+}
+
+// A failed writer restoration must be retried, not logged and abandoned:
+// giving up leaves the daemon running with every write endpoint failing
+// until restart.
+func TestRestoreArchiveAccessRetriesUntilSuccess(t *testing.T) {
+	prevInitial := reacquireBackoffInitial
+	reacquireBackoffInitial = time.Millisecond
+	defer func() { reacquireBackoffInitial = prevInitial }()
+
+	attempts := 0
+	err := restoreArchiveAccess(
+		context.Background(), "test restore", func() error {
+			attempts++
+			if attempts < 3 {
+				return fmt.Errorf("attempt %d fails", attempts)
+			}
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 3, attempts,
+		"restoration must retry failures until it succeeds")
+}
+
+func TestRestoreArchiveAccessStopsOnContextCancel(t *testing.T) {
+	prevInitial := reacquireBackoffInitial
+	reacquireBackoffInitial = time.Hour // never elapses within the test
+	defer func() { reacquireBackoffInitial = prevInitial }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := restoreArchiveAccess(ctx, "test restore", func() error {
+		return fmt.Errorf("always fails")
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+// Persistent recovery failure must not outlive the daemon: recovery ignores
+// request cancellation but stops at daemon shutdown, so a held-forever lock
+// cannot block exit while the pass holds the engine's exclusive sync lock.
+func TestRunWorkerWritePassShutdownStopsPersistentRecovery(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	database, lock := openTestWriteDB(t, cfg)
+	engine := sync.NewEngine(database, sync.EngineConfig{})
+	defer engine.Close()
+
+	prevInitial, prevMax := reacquireBackoffInitial, reacquireBackoffMax
+	reacquireBackoffInitial = 5 * time.Millisecond
+	reacquireBackoffMax = 20 * time.Millisecond
+	defer func() {
+		reacquireBackoffInitial, reacquireBackoffMax = prevInitial, prevMax
+	}()
+
+	daemonCtx, shutdown := context.WithCancel(context.Background())
+	defer shutdown()
+	var contender *writeOwnerLock
+	restore := stubLaunchSyncWorker(t, func(
+		_ context.Context, _ config.Config, _ string, _ func(workerLine),
+	) (workerResult, error) {
+		// A contender takes the freed lock and never releases it, then the
+		// daemon shuts down while reacquisition is retrying.
+		taken, err := tryAcquireWriteOwnerLock(cfg.DataDir)
+		require.NoError(t, err, "contender takes the freed lock")
+		contender = taken
+		shutdown()
+		return workerResult{Status: "ok", DiscoveryComplete: true}, nil
+	})
+	defer restore()
+	defer func() {
+		if contender != nil {
+			assert.NoError(t, contender.Close())
+		}
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := runWorkerWritePass(
+			context.Background(), daemonCtx, cfg, engine, database, lock,
+			"sync", nil,
+		)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		require.Error(t, err,
+			"an unrecovered pass must surface its failure")
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("recovery kept retrying past daemon shutdown")
+	}
+}

--- a/cmd/agentsview/write_lock.go
+++ b/cmd/agentsview/write_lock.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -74,6 +75,35 @@ func (l *writeOwnerLock) Close() error {
 	}
 	if err := l.lock.Unlock(); err != nil {
 		return fmt.Errorf("releasing write lock %s: %w", l.path, err)
+	}
+	return nil
+}
+
+// Release yields the write lock for a worker maintenance pass while keeping the
+// lock handle so Reacquire can retake the same path. Unlike Close, the owner is
+// expected to reacquire.
+func (l *writeOwnerLock) Release() error {
+	if l == nil || l.lock == nil {
+		return errors.New("release on nil write lock")
+	}
+	if err := l.lock.Unlock(); err != nil {
+		return fmt.Errorf("releasing write lock %s: %w", l.path, err)
+	}
+	return nil
+}
+
+// Reacquire retakes the write lock after a worker maintenance pass. It fails if
+// another process grabbed the lock while it was released.
+func (l *writeOwnerLock) Reacquire() error {
+	if l == nil || l.lock == nil {
+		return errors.New("reacquire on nil write lock")
+	}
+	locked, err := l.lock.TryLock()
+	if err != nil {
+		return fmt.Errorf("reacquiring write lock %s: %w", l.path, err)
+	}
+	if !locked {
+		return writeOwnerLockHeldError{path: l.path}
 	}
 	return nil
 }

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -70,7 +70,12 @@ Grok section and remove the explicit registry exception in the coverage test.
   cost field is consumed; Agentsview prices the tokens from its catalog.
 - **Agentsview:** `internal/parser/claude.go` and
   `internal/parser/claude_provider.go`; local observations and fixtures are
-  the implementation evidence for fields not documented upstream.
+  the implementation evidence for fields not documented upstream. Reverified
+  2026-07-22 against local CLI transcripts: `type=attachment` records with
+  `attachment.type=queued_command` are written mid-stream, in file order
+  between consecutive `assistant` records that share one `message.id`, so a
+  queued command can fall inside a streaming run that straddles an incremental
+  sync boundary.
 
 ## OpenClaude (`openclaude`)
 
@@ -95,6 +100,13 @@ Grok section and remove the explicit registry exception in the coverage test.
 - **Agentsview:** `internal/parser/openclaude.go` plus the shared Claude parsing
   code in `internal/parser/claude.go`; the producer writes the same
   project-scoped JSONL family that the parser consumes.
+
+- **Project-directory layout reverified 2026-07-23:** the pinned session writer
+  creates project directories itself with `mkdir(recursive: true)` under
+  `<config home>/projects/<sanitized cwd>` and never creates symlinks.
+  Symlinked project directories are therefore a user-side arrangement, and
+  streaming discovery follows them only to match the legacy `Discover` walk
+  (`isDirOrSymlink`), not because the producer emits them.
 
 ## Cowork (`cowork`)
 

--- a/frontend/src/lib/api/client.test.ts
+++ b/frontend/src/lib/api/client.test.ts
@@ -127,6 +127,16 @@ describe("triggerSync SSE parsing", () => {
     expect(stats.total_sessions).toBe(3);
   });
 
+  it("should reject when the stream reports an error event", async () => {
+    const { handle } = startSync([
+      'event: error\ndata: {"error":"sync worker pass reported failed"}\n\n',
+    ]);
+
+    await expect(handle.done).rejects.toThrow(
+      "sync worker pass reported failed",
+    );
+  });
+
   it("should reject for non-ok responses", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
       ok: false,

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -130,6 +130,9 @@ function processFrame(
     onProgress?.(JSON.parse(data) as SyncProgress);
   } else if (event === "done") {
     return JSON.parse(data) as SyncStats;
+  } else if (event === "error") {
+    const payload = JSON.parse(data) as { error?: string };
+    throw new Error(payload.error ?? "Sync failed");
   }
   return undefined;
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -334,6 +334,11 @@ const (
 // the WAL because another connection still had pages pinned.
 var ErrWALCheckpointBusy = errors.New("wal checkpoint busy")
 
+// ErrWriterClosed reports that a write was attempted while the writer pool was
+// intentionally closed for a maintenance pass (a sync-worker handoff). Readers
+// keep serving; the writer returns once ReopenWriter runs.
+var ErrWriterClosed = errors.New("writer closed for maintenance pass")
+
 // DataVersionTooNewError reports that an archive was written by a newer
 // agentsview parser than the current binary understands.
 type DataVersionTooNewError struct {
@@ -493,14 +498,24 @@ END;
 // concurrent HTTP handler goroutines can safely read while
 // Reopen/CloseConnections swap the underlying *sql.DB.
 type DB struct {
-	path      string
-	writer    atomic.Pointer[sql.DB]
-	reader    atomic.Pointer[sql.DB]
-	mu        sync.Mutex // serializes writes
-	connMu    sync.RWMutex
-	retired   []*sql.DB // old pools kept open for in-flight reads
-	readOnly  bool
-	dataStale atomic.Bool // set by Open when user_version < dataVersion
+	path    string
+	writer  atomic.Pointer[sql.DB]
+	reader  atomic.Pointer[sql.DB]
+	mu      sync.Mutex // serializes writes
+	connMu  sync.RWMutex
+	retired []*sql.DB // old pools kept open for in-flight reads
+	// undrainedPools holds closed pools whose connections had not drained
+	// when CloseWriter or CloseConnections gave up. They must drain before
+	// a later close reports success, or write ownership could be released
+	// (or the database file replaced) while a connection still holds the
+	// file. Guarded by connMu.
+	undrainedPools []*sql.DB
+	readOnly       bool
+	// writerClosed is set while the writer pool is intentionally closed for a
+	// worker maintenance pass (CloseWriter). It lets write attempts report
+	// ErrWriterClosed instead of the generic read-only error.
+	writerClosed atomic.Bool
+	dataStale    atomic.Bool // set by Open when user_version < dataVersion
 
 	cursorMu     sync.RWMutex
 	cursorSecret []byte
@@ -603,6 +618,9 @@ func (w *writerHandle) current() (*sql.DB, error) {
 	}
 	db := w.owner.writer.Load()
 	if db == nil {
+		if w.owner.writerClosed.Load() {
+			return nil, ErrWriterClosed
+		}
 		return nil, ErrReadOnly
 	}
 	return db, nil
@@ -1631,6 +1649,10 @@ func schemaColumnMigrations() []schemaColumnMigration {
 			"ALTER TABLE sessions ADD COLUMN deleted_at TEXT",
 		},
 		{
+			"sessions", "deletion_cause",
+			"ALTER TABLE sessions ADD COLUMN deletion_cause TEXT",
+		},
+		{
 			"messages", "is_system",
 			"ALTER TABLE messages ADD COLUMN is_system INTEGER NOT NULL DEFAULT 0",
 		},
@@ -1879,6 +1901,14 @@ func schemaColumnMigrations() []schemaColumnMigration {
 		{
 			"sessions", "last_entry_uuid",
 			"ALTER TABLE sessions ADD COLUMN last_entry_uuid TEXT",
+		},
+		{
+			// Whether the Claude full parser fell back to linear
+			// processing for this file (NULL = unknown/legacy or
+			// non-Claude). Read by the incremental parser to skip
+			// fork detection on linear-bound transcripts.
+			"sessions", "claude_linear_parse",
+			"ALTER TABLE sessions ADD COLUMN claude_linear_parse INTEGER",
 		},
 		{
 			"messages", "thinking_text",
@@ -2473,14 +2503,46 @@ func (db *DB) createPartialIndexesLocked(w *writerHandle) error {
 		   AND model != '<synthetic>'`,
 		`CREATE INDEX IF NOT EXISTS idx_sessions_has_secret
 		 ON sessions(secret_leak_count) WHERE secret_leak_count > 0`,
-		`CREATE INDEX IF NOT EXISTS idx_sessions_agent_file_path_active
-		 ON sessions(agent, file_path)
-		 WHERE file_path IS NOT NULL AND deleted_at IS NULL`,
 	}
 	for _, ddl := range indexes {
 		if _, err := w.Exec(ddl); err != nil {
 			return fmt.Errorf("creating index: %w", err)
 		}
+	}
+	var sourceIndexColumns sql.NullString
+	if err := w.QueryRow(`
+		SELECT group_concat(name, ',')
+		FROM (
+			SELECT name
+			FROM pragma_index_info('idx_sessions_agent_file_path_active')
+			ORDER BY seqno
+		)`).Scan(&sourceIndexColumns); err != nil {
+		return fmt.Errorf("probing active session source index: %w", err)
+	}
+	var sourceIndexSQL sql.NullString
+	if err := w.QueryRow(`
+		SELECT sql FROM sqlite_master
+		WHERE type = 'index' AND name = 'idx_sessions_agent_file_path_active'
+	`).Scan(&sourceIndexSQL); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("reading active session source index: %w", err)
+	}
+	normalizedSourceIndexSQL := strings.ToLower(
+		strings.Join(strings.Fields(sourceIndexSQL.String), " "),
+	)
+	if sourceIndexColumns.String != "agent,file_path,id" ||
+		!strings.Contains(normalizedSourceIndexSQL,
+			"where file_path is not null and deleted_at is null") {
+		if _, err := w.Exec(
+			`DROP INDEX IF EXISTS idx_sessions_agent_file_path_active`,
+		); err != nil {
+			return fmt.Errorf("dropping legacy active session source index: %w", err)
+		}
+	}
+	if _, err := w.Exec(`
+		CREATE INDEX IF NOT EXISTS idx_sessions_agent_file_path_active
+		ON sessions(agent, file_path, id)
+		WHERE file_path IS NOT NULL AND deleted_at IS NULL`); err != nil {
+		return fmt.Errorf("creating active session source index: %w", err)
 	}
 	if _, err := w.Exec(
 		`DROP INDEX IF EXISTS idx_messages_usage_timestamp`,
@@ -3465,8 +3527,17 @@ func (db *DB) init() error {
 	return nil
 }
 
-// Close closes both writer and reader connections, plus any
-// retired pools left over from previous Reopen calls.
+// Close closes both writer and reader connections, plus any retired pools
+// left over from previous Reopen calls and any pools a failed CloseWriter or
+// CloseConnections left undrained.
+//
+// Like those methods, Close waits (bounded by closeDrainTimeout) for every
+// closed pool to actually drain: callers such as closeWriteDB release the
+// write-owner flock once Close returns, so reporting success while a
+// connection still holds the SQLite file would let another process acquire
+// writer ownership alongside the surviving connection. A drain timeout is an
+// error, and the undrained pools are retained so a retry cannot succeed
+// before they actually drain.
 func (db *DB) Close() error {
 	db.stopWALCheckpointLoop()
 	db.mu.Lock()
@@ -3475,6 +3546,8 @@ func (db *DB) Close() error {
 	r := db.rawReader()
 	retired := db.retired
 	db.retired = nil
+	undrained := db.undrainedPools
+	db.undrainedPools = nil
 	db.connMu.Unlock()
 	db.mu.Unlock()
 
@@ -3482,31 +3555,71 @@ func (db *DB) Close() error {
 	// the final connection closes, and the reader pool is mode=ro so its
 	// close cannot perform that checkpoint.
 	var errs []error
+	closed := make([]*sql.DB, 0, len(retired)+len(undrained)+2)
 	for _, p := range retired {
 		errs = append(errs, p.Close())
+		closed = append(closed, p)
 	}
+	// Pools a failed close left undrained are already closed; they still
+	// hold the file until drained, so Close must wait for them like every
+	// other pool.
+	closed = append(closed, undrained...)
 	if r != nil {
 		errs = append(errs, r.Close())
+		closed = append(closed, r)
 	}
 	if w != nil && w != r {
 		errs = append(errs, w.Close())
+		closed = append(closed, w)
+	}
+	if stillOpen := drainPools(closed); len(stillOpen) > 0 {
+		db.retainUndrainedPools(stillOpen)
+		errs = append(errs, fmt.Errorf(
+			"db connections still in use %v after close; "+
+				"write ownership is not safe to release",
+			closeDrainTimeout))
 	}
 	return errors.Join(errs...)
+}
+
+// closeDrainTimeout bounds how long CloseConnections and CloseWriter wait
+// for in-flight queries to release their pooled connections after the pools
+// are closed. The drain normally completes in microseconds; the bound only
+// limits a pathological stuck query. A variable so tests can exercise the
+// timeout path without waiting out the production bound.
+var closeDrainTimeout = 5 * time.Second
+
+// SetCloseDrainTimeoutForTest overrides closeDrainTimeout so tests outside
+// this package can exercise the drain-timeout failure path without waiting
+// out the production bound. It returns a func restoring the previous value.
+func SetCloseDrainTimeoutForTest(d time.Duration) (restore func()) {
+	prev := closeDrainTimeout
+	closeDrainTimeout = d
+	return func() { closeDrainTimeout = prev }
 }
 
 // CloseConnections closes both connections without reopening,
 // releasing file locks so the database file can be renamed.
 // Also drains any retired pools from previous Reopen calls.
 // Callers must call Reopen afterwards to restore service.
+//
+// sql.DB.Close does not wait for in-use connections: a query started before
+// the close keeps its driver connection (and file handle) until its rows are
+// released. On Windows SQLite opens the database without FILE_SHARE_DELETE,
+// so renaming over the file fails while any such handle survives. Because
+// this method's contract is that the file can be renamed afterwards, it
+// waits (bounded) for every closed pool to drain before returning.
 func (db *DB) CloseConnections() error {
 	if db.readOnly {
 		return ErrReadOnly
 	}
 	db.stopWALCheckpointLoop()
+	// db.mu stays held through the drain: a concurrent Reopen or
+	// ReopenWriter would open fresh handles on the same path, letting this
+	// method return "drained" while new handles still block the rename.
 	db.mu.Lock()
 	defer db.mu.Unlock()
 	db.connMu.Lock()
-	defer db.connMu.Unlock()
 
 	// Close the writer last: SQLite checkpoints and removes the WAL when
 	// the final connection closes, and the reader pool is mode=ro so its
@@ -3514,15 +3627,114 @@ func (db *DB) CloseConnections() error {
 	// WAL file after this returns, so a skipped checkpoint would lose
 	// every write still sitting in the log.
 	var errs []error
+	closed := make([]*sql.DB, 0,
+		len(db.retired)+len(db.undrainedPools)+2)
 	for _, p := range db.retired {
 		errs = append(errs, p.Close())
+		closed = append(closed, p)
 	}
-	errs = append(errs,
-		db.rawReader().Close(),
-		db.rawWriter().Close(),
-	)
+	// Pools a failed close left undrained are already closed; they still
+	// hold the file until drained, so the rename must wait for them like
+	// every other pool.
+	closed = append(closed, db.undrainedPools...)
+	db.undrainedPools = nil
+	r := db.rawReader()
+	errs = append(errs, r.Close())
+	closed = append(closed, r)
+	// The writer pool is nil when a worker maintenance pass has it closed.
+	// Guard the close so this lifecycle path can never nil-deref.
+	w := db.rawWriter()
+	if w != nil {
+		errs = append(errs, w.Close())
+		closed = append(closed, w)
+	}
 	db.retired = nil
+	db.connMu.Unlock()
+
+	// Drain with connMu released: queries racing the close fail fast on
+	// the closed pools instead of blocking behind connMu, and releasing an
+	// in-flight row never needs either lock. A drain timeout is an error:
+	// proceeding would let the caller delete the WAL and rename the
+	// database file while a connection still holds it, which breaks the
+	// swap on Windows and risks discarding uncheckpointed WAL data. The
+	// undrained pools are retained so a retry cannot succeed before they
+	// actually drain.
+	if undrained := drainPools(closed); len(undrained) > 0 {
+		db.retainUndrainedPools(undrained)
+		errs = append(errs, fmt.Errorf(
+			"db connections still in use %v after close; "+
+				"database file is not safe to replace",
+			closeDrainTimeout))
+	}
+
+	// A write barrier (CloseWriter) may have closed the writer pool earlier,
+	// leaving only read-only connections for this close — and a read-only
+	// close cannot perform the final checkpoint. Callers are entitled to
+	// rename the database file and delete its WAL sidecars afterwards, so any
+	// committed writes still sitting in the log must be folded into the main
+	// file before this method reports success.
+	if w == nil && errors.Join(errs...) == nil {
+		if cerr := checkpointWALWithoutWriter(db.path); cerr != nil {
+			errs = append(errs, cerr)
+		}
+	}
 	return errors.Join(errs...)
+}
+
+// checkpointWALWithoutWriter folds any remaining WAL into the main database
+// file via a short-lived writable connection, for a CloseConnections whose
+// writer pool was already closed by a write barrier. Closing the connection
+// afterwards removes the truncated sidecars, restoring the writer-last close
+// posture the method's contract promises.
+func checkpointWALWithoutWriter(path string) error {
+	if _, err := os.Stat(path + "-wal"); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stat wal before final checkpoint: %w", err)
+	}
+	conn, err := sql.Open("sqlite3", makeDSN(path, false))
+	if err != nil {
+		return fmt.Errorf("opening final checkpoint connection: %w", err)
+	}
+	defer conn.Close()
+	var busy, logPages, checkpointedPages int
+	if err := conn.QueryRow(
+		"PRAGMA wal_checkpoint(TRUNCATE)",
+	).Scan(&busy, &logPages, &checkpointedPages); err != nil {
+		return fmt.Errorf("final wal checkpoint: %w", err)
+	}
+	if busy != 0 {
+		return fmt.Errorf("final wal checkpoint: %w", ErrWALCheckpointBusy)
+	}
+	return nil
+}
+
+// drainPools waits until every connection in the already-closed pools has
+// been released, so the underlying file handles are gone and the database
+// file can be renamed on every platform. Gives up after closeDrainTimeout
+// and returns the pools that still had connections checked out.
+func drainPools(pools []*sql.DB) []*sql.DB {
+	deadline := time.Now().Add(closeDrainTimeout)
+	var undrained []*sql.DB
+	for _, p := range pools {
+		if !drainPoolUntil(p, deadline) {
+			undrained = append(undrained, p)
+		}
+	}
+	return undrained
+}
+
+// drainPoolUntil waits for every connection in the already-closed pool to be
+// released, reporting false if any survive past the deadline.
+func drainPoolUntil(p *sql.DB, deadline time.Time) bool {
+	for p.Stats().OpenConnections > 0 {
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	return true
 }
 
 // Reopen closes and reopens both connections to the same
@@ -3570,12 +3782,25 @@ func (db *DB) reopenLocked() error {
 	retired := append([]*sql.DB(nil), db.retired...)
 	oldWriter := db.writer.Swap(writer)
 	oldReader := db.reader.Swap(reader)
+	// Reopen fully restores the writer pool, so clear any writer-closed barrier
+	// a prior CloseWriter set. Without this a resync swap that ran behind the
+	// worker write barrier would reopen the pool yet keep rejecting writes.
+	db.writerClosed.Store(false)
 
 	// Retire the just-swapped pools. Concurrent readers that
 	// loaded the old pointer before the swap may still have
 	// in-flight queries; these pools will be closed on the
-	// next Reopen, CloseConnections, or Close call.
-	db.retired = []*sql.DB{oldWriter, oldReader}
+	// next Reopen, CloseConnections, or Close call. Skip a nil
+	// old writer: a Reopen that follows CloseWriter swaps out a
+	// nil pool, and retiring it would nil-deref on the next close.
+	var freshRetired []*sql.DB
+	if oldWriter != nil {
+		freshRetired = append(freshRetired, oldWriter)
+	}
+	if oldReader != nil {
+		freshRetired = append(freshRetired, oldReader)
+	}
+	db.retired = freshRetired
 	db.connMu.Unlock()
 
 	// Close pools from earlier reopens outside connMu. database/sql
@@ -3591,6 +3816,110 @@ func (db *DB) reopenLocked() error {
 	return nil
 }
 
+// CloseWriter closes the writer pool without touching the reader pool, so
+// read-only queries keep serving while a sync-worker owns the archive for a
+// maintenance pass. Writes attempted while closed return ErrWriterClosed. The
+// reader pool is mode=ro and cannot checkpoint, so it holds the WAL open across
+// the handoff; the worker attaches to the same WAL. Callers must call
+// ReopenWriter to restore write service.
+//
+// Failure posture: the writer pointer is swapped to nil (marking the barrier
+// active) before the old pool is closed, so if the close or drain fails the
+// barrier stays up and the undrained pool is retained. The caller must keep
+// the write-owner flock and must not hand ownership to a worker — a possible
+// double-writer racing the worker over the same archive is worse than a
+// failed pass. Because ownership is never released on this path, the caller
+// may restore write service with ReopenWriter: the surviving connection
+// belongs to this process, and a later CloseWriter must drain the retained
+// pool before it can succeed.
+func (db *DB) CloseWriter() error {
+	if db.readOnly {
+		return ErrReadOnly
+	}
+	db.stopWALCheckpointLoop()
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	db.connMu.Lock()
+	old := db.writer.Swap(nil)
+	db.writerClosed.Store(true)
+	pending := db.undrainedPools
+	db.undrainedPools = nil
+	db.connMu.Unlock()
+
+	if old != nil {
+		if err := old.Close(); err != nil {
+			db.retainUndrainedPools(append(pending, old))
+			return fmt.Errorf("closing writer pool: %w", err)
+		}
+		pending = append(pending, old)
+	}
+	// sql.DB.Close does not wait for checked-out connections: a stats or
+	// git-cache query that snapshotted the writer handle may still hold the
+	// single writer connection. The caller releases write ownership (the
+	// flock) once this returns, so an undrained connection would overlap
+	// with the worker's writes. Per the failure posture above, a drain
+	// timeout is an error: the pools that failed to drain are retained so a
+	// retry cannot report success while their connections survive, and the
+	// caller keeps the flock rather than risking a double writer.
+	if undrained := drainPools(pending); len(undrained) > 0 {
+		db.retainUndrainedPools(undrained)
+		return fmt.Errorf(
+			"writer connection still in use %v after close; "+
+				"keeping write ownership", closeDrainTimeout)
+	}
+	return nil
+}
+
+// retainUndrainedPools records closed-but-undrained pools so a later
+// CloseWriter or CloseConnections drains them before it may succeed.
+func (db *DB) retainUndrainedPools(pools []*sql.DB) {
+	db.connMu.Lock()
+	db.undrainedPools = append(db.undrainedPools, pools...)
+	db.connMu.Unlock()
+}
+
+// ReopenWriter reopens the writer pool after a worker maintenance pass. It
+// re-runs the writer-open half of Reopen (writable DSN, single connection,
+// configureWAL) and restarts the WAL checkpoint loop. The reader pool is left
+// untouched.
+func (db *DB) ReopenWriter() error {
+	if db.readOnly {
+		return ErrReadOnly
+	}
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	writer, err := sql.Open("sqlite3", makeDSN(db.path, false))
+	if err != nil {
+		return fmt.Errorf("reopening writer: %w", err)
+	}
+	writer.SetMaxOpenConns(1)
+	if err := configureWAL(writer); err != nil {
+		writer.Close()
+		return fmt.Errorf("configuring reopened wal: %w", err)
+	}
+
+	db.connMu.Lock()
+	old := db.writer.Swap(writer)
+	db.writerClosed.Store(false)
+	db.connMu.Unlock()
+
+	if old != nil {
+		if err := old.Close(); err != nil {
+			log.Printf("warning: closing stale writer pool: %v", err)
+		}
+	}
+	db.startWALCheckpointLoop()
+	return nil
+}
+
+// WriterClosed reports whether the writer pool is currently closed for a
+// maintenance pass. Callers that conditionally own the write barrier check it to
+// avoid double-closing or reopening a barrier an outer owner holds.
+func (db *DB) WriterClosed() bool {
+	return db.writerClosed.Load()
+}
+
 // Update executes fn within a write lock and transaction.
 // The transaction is committed if fn returns nil, rolled back
 // otherwise.
@@ -3598,6 +3927,12 @@ func (db *DB) Update(fn func(tx *sql.Tx) error) error {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
+	// Fail fast before handing out a raw *sql.Tx: while the writer is closed
+	// for a worker maintenance pass the pool pointer is nil, and a caller must
+	// see ErrWriterClosed rather than a transaction from a torn-down pool.
+	if db.writerClosed.Load() {
+		return ErrWriterClosed
+	}
 	tx, err := db.getWriter().Begin()
 	if err != nil {
 		return fmt.Errorf("beginning transaction: %w", err)

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -454,6 +454,83 @@ func Ptr[T any](v T) *T { return new(v) }
 
 // insertSession creates and upserts a session with sensible
 // defaults. Override any field via the opts functions.
+// seedOneSession inserts a single session so reader queries have a row to
+// return across a writer handoff.
+func seedOneSession(t *testing.T, d *DB) {
+	t.Helper()
+	insertSession(t, d, "writer-handoff-seed", "handoff")
+}
+
+// writeOneSession attempts a single write through the writer pool. It returns
+// the write error unchanged so callers can assert on ErrWriterClosed.
+func writeOneSession(d *DB) error {
+	return d.UpsertSession(Session{
+		ID:      "writer-handoff-write",
+		Project: "handoff",
+		Machine: defaultMachine,
+		Agent:   defaultAgent,
+	})
+}
+
+func TestCloseWriterKeepsReadersServing(t *testing.T) {
+	database := testDB(t)
+	seedOneSession(t, database)
+
+	require.NoError(t, database.CloseWriter())
+
+	rows, err := database.ListSessionsModifiedBetween(
+		context.Background(), "", "", nil, nil,
+	)
+	assert.NoError(t, err, "readers must survive a writer handoff")
+	assert.NotEmpty(t, rows, "seeded session must still be readable")
+
+	err = writeOneSession(database)
+	require.Error(t, err, "writes must fail cleanly while the writer is closed")
+	assert.ErrorIs(t, err, ErrWriterClosed)
+
+	require.NoError(t, database.ReopenWriter())
+	assert.NoError(t, writeOneSession(database),
+		"writer must accept writes again after ReopenWriter")
+}
+
+// TestCloseWriterFailsEveryWritePathCleanly proves the write barrier covers
+// every writer access, not just the writerHandle facade: the Update transaction
+// path and the real star/delete session mutations must all return
+// ErrWriterClosed without panicking while the writer is closed.
+func TestCloseWriterFailsEveryWritePathCleanly(t *testing.T) {
+	database := testDB(t)
+	insertSession(t, database, "barrier-session", "handoff")
+
+	require.NoError(t, database.CloseWriter())
+	t.Cleanup(func() { require.NoError(t, database.ReopenWriter()) })
+
+	t.Run("Update", func(t *testing.T) {
+		err := database.Update(func(tx *sql.Tx) error {
+			_, execErr := tx.Exec(
+				"UPDATE sessions SET first_message = ? WHERE id = ?",
+				"x", "barrier-session",
+			)
+			return execErr
+		})
+		require.ErrorIs(t, err, ErrWriterClosed)
+	})
+
+	t.Run("StarSession", func(t *testing.T) {
+		_, err := database.StarSession("barrier-session")
+		require.ErrorIs(t, err, ErrWriterClosed)
+	})
+
+	t.Run("DeleteSession", func(t *testing.T) {
+		err := database.DeleteSession("barrier-session")
+		require.ErrorIs(t, err, ErrWriterClosed)
+	})
+
+	t.Run("RestoreSession", func(t *testing.T) {
+		_, err := database.RestoreSession("barrier-session")
+		require.ErrorIs(t, err, ErrWriterClosed)
+	})
+}
+
 func insertSession(
 	t *testing.T, d *DB, id, project string,
 	opts ...func(*Session),
@@ -3443,6 +3520,115 @@ func TestWriteSessionIncrementalBlocksLinkedResultContent(t *testing.T) {
 	assert.Equal(t, "2", *idempotent.TranscriptRevision)
 }
 
+// A result-only link (empty SubagentSessionID, HasResult set) carries a
+// tool_result appended after its tool_use was stored. It must update
+// the stored call's result fields without touching an existing
+// subagent linkage, and no-op for unknown tool_use ids.
+func TestWriteSessionIncrementalResultOnlyLink(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "s1", "proj")
+	insertMessages(t, d, Message{
+		SessionID:  "s1",
+		Ordinal:    0,
+		Role:       "assistant",
+		HasToolUse: true,
+		ToolCalls: []ToolCall{{
+			SessionID:         "s1",
+			ToolName:          "Task",
+			Category:          "Task",
+			ToolUseID:         "toolu_linked",
+			SubagentSessionID: "agent-existing",
+		}, {
+			SessionID: "s1",
+			ToolName:  "Bash",
+			Category:  "Bash",
+			ToolUseID: "toolu_bash",
+		}},
+	})
+
+	update := IncrementalSessionUpdate{
+		MsgCount:    1,
+		NextOrdinal: 1,
+		SubagentLinks: []ToolCallSubagentLink{{
+			ToolUseID:        "toolu_bash",
+			ResultContent:    "late result",
+			ResultContentLen: len("late result"),
+			HasResult:        true,
+		}, {
+			ToolUseID:        "toolu_unknown",
+			ResultContent:    "orphan result",
+			ResultContentLen: len("orphan result"),
+			HasResult:        true,
+		}},
+	}
+	require.NoError(t, d.WriteSessionIncremental("s1", nil, update))
+
+	var subagent, content string
+	var contentLen int
+	require.NoError(t, d.Reader().QueryRow(`
+		SELECT COALESCE(subagent_session_id, ''), result_content_length,
+		       COALESCE(result_content, '')
+		FROM tool_calls
+		WHERE session_id = ? AND tool_use_id = ?`,
+		"s1", "toolu_bash",
+	).Scan(&subagent, &contentLen, &content))
+	assert.Empty(t, subagent)
+	assert.Equal(t, len("late result"), contentLen)
+	assert.Equal(t, "late result", content)
+
+	require.NoError(t, d.Reader().QueryRow(`
+		SELECT COALESCE(subagent_session_id, '')
+		FROM tool_calls
+		WHERE session_id = ? AND tool_use_id = ?`,
+		"s1", "toolu_linked",
+	).Scan(&subagent))
+	assert.Equal(t, "agent-existing", subagent,
+		"result-only link must not disturb other calls")
+}
+
+// claude_linear_parse round-trips through upsert and the incremental
+// lookup, stays NULL for legacy rows, and survives an upsert that
+// carries no verdict.
+func TestClaudeLinearParseRoundTrip(t *testing.T) {
+	d := testDB(t)
+
+	linear := true
+	sess := Session{
+		ID:                "s-linear",
+		Project:           "proj",
+		Machine:           "local",
+		Agent:             "claude",
+		FilePath:          new("/tmp/s-linear.jsonl"),
+		ClaudeLinearParse: &linear,
+	}
+	require.NoError(t, d.UpsertSession(sess))
+
+	info, ok := d.GetSessionForIncremental("/tmp/s-linear.jsonl")
+	require.True(t, ok)
+	require.NotNil(t, info.ClaudeLinearParse)
+	assert.True(t, *info.ClaudeLinearParse)
+
+	sess.ClaudeLinearParse = nil
+	require.NoError(t, d.UpsertSession(sess))
+	info, ok = d.GetSessionForIncremental("/tmp/s-linear.jsonl")
+	require.True(t, ok)
+	require.NotNil(t, info.ClaudeLinearParse,
+		"verdict-free upsert must keep the stored flag")
+	assert.True(t, *info.ClaudeLinearParse)
+
+	legacy := Session{
+		ID:       "s-legacy",
+		Project:  "proj",
+		Machine:  "local",
+		Agent:    "claude",
+		FilePath: new("/tmp/s-legacy.jsonl"),
+	}
+	require.NoError(t, d.UpsertSession(legacy))
+	info, ok = d.GetSessionForIncremental("/tmp/s-legacy.jsonl")
+	require.True(t, ok)
+	assert.Nil(t, info.ClaudeLinearParse)
+}
+
 func TestFTSBackfill(t *testing.T) {
 	dCheck := testDB(t)
 	requireFTS(t, dCheck)
@@ -3814,6 +4000,301 @@ func TestRepeatedReopenBoundsRetiredPools(t *testing.T) {
 	s, err := d.GetSession(context.Background(), "s1")
 	require.NoError(t, err, "GetSession")
 	assert.NotNil(t, s, "session s1 missing after repeated Reopen")
+}
+
+func TestCloseConnectionsWaitsForInFlightReads(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "s1", "proj")
+
+	rows, err := d.Reader().Query("SELECT id FROM sessions")
+	require.NoError(t, err, "Query")
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- d.CloseConnections() }()
+
+	// The open rows hold a reader connection with a live file
+	// handle. CloseConnections promises the database file can be
+	// renamed afterwards, which fails on Windows while any handle
+	// survives, so it must not return before the rows are released.
+	select {
+	case err := <-closeDone:
+		require.Failf(t, "CloseConnections returned early",
+			"returned while rows were still open: %v", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	require.NoError(t, rows.Err(), "rows.Err")
+	require.NoError(t, rows.Close(), "rows.Close")
+
+	select {
+	case err := <-closeDone:
+		require.NoError(t, err, "CloseConnections")
+	case <-time.After(2 * time.Second):
+		require.Fail(t,
+			"CloseConnections did not return after rows were released")
+	}
+
+	require.NoError(t, d.Reopen(), "Reopen")
+	s, err := d.GetSession(context.Background(), "s1")
+	require.NoError(t, err, "GetSession after Reopen")
+	assert.NotNil(t, s, "session s1 missing after Reopen")
+}
+
+func TestCloseConnectionsBlocksConcurrentReopen(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "s1", "proj")
+
+	rows, err := d.Reader().Query("SELECT id FROM sessions")
+	require.NoError(t, err, "Query")
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- d.CloseConnections() }()
+
+	// Once new reads fail fast the pools are closed, so
+	// CloseConnections holds db.mu and is draining the open rows.
+	require.Eventually(t, func() bool {
+		probe, err := d.Reader().Query("SELECT 1")
+		if err != nil {
+			return true
+		}
+		probe.Close()
+		return false
+	}, 2*time.Second, 5*time.Millisecond, "pools never closed")
+
+	reopenDone := make(chan error, 1)
+	go func() { reopenDone <- d.Reopen() }()
+
+	// Reopen must serialize behind the drain: fresh handles opened
+	// mid-drain would let CloseConnections return while the database
+	// file is still unrenameable on Windows.
+	select {
+	case err := <-reopenDone:
+		require.Failf(t, "Reopen returned early",
+			"returned while CloseConnections was draining: %v", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	require.NoError(t, rows.Close(), "rows.Close")
+
+	select {
+	case err := <-closeDone:
+		require.NoError(t, err, "CloseConnections")
+	case <-time.After(2 * time.Second):
+		require.Fail(t,
+			"CloseConnections did not return after rows were released")
+	}
+	select {
+	case err := <-reopenDone:
+		require.NoError(t, err, "Reopen")
+	case <-time.After(2 * time.Second):
+		require.Fail(t,
+			"Reopen did not return after CloseConnections finished")
+	}
+
+	s, err := d.GetSession(context.Background(), "s1")
+	require.NoError(t, err, "GetSession after Reopen")
+	assert.NotNil(t, s, "session s1 missing after Reopen")
+}
+
+func TestCloseWriterWaitsForInFlightWriterQuery(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "s1", "proj")
+
+	rows, err := d.getWriter().Query("SELECT id FROM sessions")
+	require.NoError(t, err, "Query")
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- d.CloseWriter() }()
+
+	// The open rows hold the single writer connection. CloseWriter's
+	// caller releases the write-ownership flock once it returns, so it
+	// must not return while that connection survives.
+	select {
+	case err := <-closeDone:
+		require.Failf(t, "CloseWriter returned early",
+			"returned while writer rows were still open: %v", err)
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	require.NoError(t, rows.Close(), "rows.Close")
+
+	select {
+	case err := <-closeDone:
+		require.NoError(t, err, "CloseWriter")
+	case <-time.After(2 * time.Second):
+		require.Fail(t,
+			"CloseWriter did not return after rows were released")
+	}
+
+	require.NoError(t, d.ReopenWriter(), "ReopenWriter")
+	s, err := d.GetSession(context.Background(), "s1")
+	require.NoError(t, err, "GetSession after ReopenWriter")
+	assert.NotNil(t, s, "session s1 missing after ReopenWriter")
+}
+
+func TestCloseWriterDrainTimeoutIsAnError(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "s1", "proj")
+
+	prev := closeDrainTimeout
+	closeDrainTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { closeDrainTimeout = prev })
+
+	rows, err := d.getWriter().Query("SELECT id FROM sessions")
+	require.NoError(t, err, "Query")
+	defer rows.Close()
+
+	// A connection that never drains must surface as an error so the
+	// caller keeps the flock instead of releasing write ownership while
+	// the connection is live.
+	err = d.CloseWriter()
+	require.Error(t, err,
+		"CloseWriter must fail while a writer connection is held")
+	assert.Contains(t, err.Error(), "still in use")
+
+	// A retry sees a nil writer pointer, but the undrained pool is
+	// retained: success here would release the flock while the original
+	// connection still holds the file.
+	err = d.CloseWriter()
+	require.Error(t, err,
+		"retried CloseWriter must keep failing while the connection is held")
+
+	// Once the connection is released the retry drains and succeeds.
+	require.NoError(t, rows.Close(), "rows.Close")
+	require.NoError(t, d.CloseWriter(),
+		"CloseWriter after release must drain the retained pool")
+	require.NoError(t, d.ReopenWriter(), "ReopenWriter")
+}
+
+// TestReopenWriterAfterFailedCloseRestoresWrites pins same-process recovery
+// from a drain-timeout CloseWriter failure. Ownership was never handed off
+// (the caller keeps the flock and launches no worker), so reopening the writer
+// restores service; the undrained pool stays retained, and a later CloseWriter
+// still refuses to succeed until that connection actually drains.
+func TestReopenWriterAfterFailedCloseRestoresWrites(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "s1", "proj")
+
+	prev := closeDrainTimeout
+	closeDrainTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { closeDrainTimeout = prev })
+
+	rows, err := d.getWriter().Query("SELECT id FROM sessions")
+	require.NoError(t, err, "Query")
+	defer rows.Close()
+
+	require.Error(t, d.CloseWriter(),
+		"CloseWriter must fail while a writer connection is held")
+	require.ErrorIs(t, d.Update(func(*sql.Tx) error { return nil }),
+		ErrWriterClosed, "the barrier stays active after the failed close")
+
+	require.NoError(t, d.ReopenWriter(), "ReopenWriter")
+	insertSession(t, d, "s2", "proj")
+
+	// The retained pool still holds a live connection: a later CloseWriter
+	// must keep failing so ownership is never released alongside it.
+	require.Error(t, d.CloseWriter(),
+		"CloseWriter must not succeed while the retained pool is undrained")
+	require.NoError(t, d.ReopenWriter(), "ReopenWriter after retried close")
+
+	require.NoError(t, rows.Close(), "rows.Close")
+	require.NoError(t, d.CloseWriter(),
+		"CloseWriter succeeds once the retained connection drained")
+	require.NoError(t, d.ReopenWriter(), "final ReopenWriter")
+}
+
+func TestCloseConnectionsDrainTimeoutIsAnError(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "s1", "proj")
+
+	prev := closeDrainTimeout
+	closeDrainTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { closeDrainTimeout = prev })
+
+	rows, err := d.Reader().Query("SELECT id FROM sessions")
+	require.NoError(t, err, "Query")
+	defer rows.Close()
+
+	// A connection that never drains must surface as an error: the resync
+	// swap deletes the WAL and renames the database file right after this
+	// returns, which is unsafe while a connection still holds the file.
+	err = d.CloseConnections()
+	require.Error(t, err,
+		"CloseConnections must fail while a reader connection is held")
+	assert.Contains(t, err.Error(), "still in use")
+
+	// The undrained pool is retained, so a retry keeps failing until the
+	// connection is actually released.
+	err = d.CloseConnections()
+	require.Error(t, err,
+		"retried CloseConnections must keep failing while the connection is held")
+
+	require.NoError(t, rows.Close(), "rows.Close")
+	require.NoError(t, d.CloseConnections(),
+		"CloseConnections after release must drain the retained pool")
+	require.NoError(t, d.Reopen(), "Reopen")
+
+	s, err := d.GetSession(context.Background(), "s1")
+	require.NoError(t, err, "GetSession after Reopen")
+	assert.NotNil(t, s, "session s1 missing after Reopen")
+}
+
+func TestCloseDrainsUndrainedPoolsBeforeSuccess(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "s1", "proj")
+
+	prev := closeDrainTimeout
+	closeDrainTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { closeDrainTimeout = prev })
+
+	rows, err := d.getWriter().Query("SELECT id FROM sessions")
+	require.NoError(t, err, "Query")
+	defer rows.Close()
+
+	// The open rows hold the single writer connection, so CloseWriter
+	// times out and retains the undrained writer pool.
+	err = d.CloseWriter()
+	require.Error(t, err,
+		"CloseWriter must fail while a writer connection is held")
+
+	// The final Close must not report success while the retained pool
+	// still holds the SQLite file: closeWriteDB releases the write-owner
+	// flock on a nil error, and another process could then acquire writer
+	// ownership alongside the surviving connection.
+	err = d.Close()
+	require.Error(t, err,
+		"Close must fail while the undrained writer pool survives")
+	assert.Contains(t, err.Error(), "still in use")
+
+	// Once the connection is released, the retained pool drains and the
+	// final Close succeeds.
+	require.NoError(t, rows.Close(), "rows.Close")
+	require.NoError(t, d.Close(),
+		"Close after release must drain the retained pool")
+}
+
+func TestCloseDrainTimeoutIsAnError(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "s1", "proj")
+
+	prev := closeDrainTimeout
+	closeDrainTimeout = 100 * time.Millisecond
+	t.Cleanup(func() { closeDrainTimeout = prev })
+
+	rows, err := d.Reader().Query("SELECT id FROM sessions")
+	require.NoError(t, err, "Query")
+	defer rows.Close()
+
+	// Close's own pools need the same drain guarantee as pools retained
+	// from earlier failed closes: a connection checked out by in-flight
+	// rows survives sql.DB.Close until it is returned to the pool.
+	err = d.Close()
+	require.Error(t, err,
+		"Close must fail while a reader connection is held")
+	assert.Contains(t, err.Error(), "still in use")
+
+	require.NoError(t, rows.Close(), "rows.Close")
+	require.NoError(t, d.Close(), "Close after release must succeed")
 }
 
 func TestCloseAfterCloseConnectionsReopen(t *testing.T) {
@@ -5393,6 +5874,41 @@ func TestSoftDeleteSessions(t *testing.T) {
 	n, err = d.SoftDeleteSessions(nil)
 	require.NoError(t, err, "SoftDeleteSessions nil")
 	assert.Equal(t, 0, n, "empty: rows=")
+}
+
+func TestSoftDeleteConvertsSourceMissingTombstonesToUserTrash(t *testing.T) {
+	d := testDB(t)
+	ctx := t.Context()
+	paths := map[string]string{
+		"single": filepath.Join(t.TempDir(), "single.jsonl"),
+		"batch":  filepath.Join(t.TempDir(), "batch.jsonl"),
+	}
+	for id, path := range paths {
+		insertSession(t, d, id, "proj", func(s *Session) {
+			s.Agent = "claude"
+			s.FilePath = &path
+		})
+		baselineSessionSource(t, d, defaultMachine, "claude", path)
+		changed, err := d.SoftDeleteSessionSourceOwnership(
+			ctx, defaultMachine, "claude", id, path,
+		)
+		require.NoError(t, err)
+		require.True(t, changed)
+	}
+
+	require.NoError(t, d.SoftDeleteSession("single"))
+	count, err := d.SoftDeleteSessions([]string{"batch"})
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	for id := range paths {
+		full, err := d.GetSessionFull(ctx, id)
+		require.NoError(t, err)
+		require.NotNil(t, full)
+		assert.Nil(t, full.DeletionCause,
+			"an explicit user deletion must replace the recoverable source tombstone")
+		assert.True(t, d.IsSessionTrashed(id))
+	}
 }
 
 func TestMetadataQueriesExcludeTrashed(t *testing.T) {

--- a/internal/db/messages_test.go
+++ b/internal/db/messages_test.go
@@ -250,7 +250,7 @@ func TestWriteSessionBatchCommitsGoodRowsAndSkipsBadRows(t *testing.T) {
 
 	health := 95
 	grade := "A"
-	result, err := d.WriteSessionBatch([]SessionBatchWrite{
+	writes := []SessionBatchWrite{
 		{
 			Session: Session{
 				ID:               "good",
@@ -328,12 +328,15 @@ func TestWriteSessionBatchCommitsGoodRowsAndSkipsBadRows(t *testing.T) {
 			},
 			DataVersion: CurrentDataVersion(),
 		},
-	})
+	}
+	writes[0], writes[1] = writes[1], writes[0]
+	result, err := d.WriteSessionBatch(writes)
 	require.NoError(t, err, "WriteSessionBatch")
 	require.Equal(t, 1, result.WrittenSessions, "WrittenSessions")
 	require.Equal(t, 2, result.WrittenMessages, "WrittenMessages")
 	require.Equal(t, 1, result.FailedSessions, "FailedSessions")
 	require.Equal(t, 2, result.ExcludedSessions, "ExcludedSessions")
+	assert.Equal(t, []int{1}, result.WrittenIndexes)
 
 	sess, err := d.GetSessionFull(context.Background(), "good")
 	require.NoError(t, err, "GetSessionFull good")

--- a/internal/db/orphaned.go
+++ b/internal/db/orphaned.go
@@ -453,15 +453,36 @@ func (d *DB) CopySessionMetadataFrom(
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	// Copy user-managed metadata from the quiesced old DB. deleted_at
-	// is copied for all rows. display_name is overlaid ONLY for
+	// Copy user-managed metadata from the quiesced old DB. User-owned
+	// deleted_at is copied for all rows. Recoverable source_missing state is
+	// already carried by the pre-sync trash/orphan copy and must not re-hide a
+	// row that the fresh sync revived after its source reappeared. display_name
+	// is overlaid ONLY for
 	// user-owned rows: the fresh DB already holds re-parsed session_name
 	// values, so agent-owned and cleared rows must keep the fresh value.
 	// Probe columns first so older source DBs don't abort.
 	hasDisplayName := oldDBHasColumn(ctx, tx, "sessions", "display_name")
 	hasDeletedAt := oldDBHasColumn(ctx, tx, "sessions", "deleted_at")
+	hasDeletionCause := oldDBHasColumn(ctx, tx, "sessions", "deletion_cause")
 
-	if hasDeletedAt {
+	if hasDeletedAt && hasDeletionCause {
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE main.sessions
+			SET deleted_at = CASE
+					WHEN old_s.deletion_cause = '`+deletionCauseSourceMissing+`'
+					THEN main.sessions.deleted_at
+					ELSE old_s.deleted_at
+				END,
+				deletion_cause = CASE
+					WHEN old_s.deletion_cause = '`+deletionCauseSourceMissing+`'
+					THEN main.sessions.deletion_cause
+					ELSE old_s.deletion_cause
+				END
+			FROM old_db.sessions old_s
+			WHERE main.sessions.id = old_s.id`); err != nil {
+			return fmt.Errorf("copying deletion state: %w", err)
+		}
+	} else if hasDeletedAt {
 		if _, err := tx.ExecContext(ctx, `
 			UPDATE main.sessions
 			SET deleted_at = old_s.deleted_at
@@ -731,7 +752,7 @@ func oldDBHasTable(
 
 // orphanSessionCols returns the comma-separated column list for
 // copying sessions from old_db, including display_name and
-// deleted_at only when the source schema has them.
+// deletion state only when the source schema has it.
 func orphanSessionCols(ctx context.Context, tx *sql.Tx) string {
 	cols := []string{
 		"id", "project", "machine", "agent", "first_message",
@@ -756,6 +777,9 @@ func orphanSessionCols(ctx context.Context, tx *sql.Tx) string {
 	}
 	if oldDBHasColumn(ctx, tx, "sessions", "deleted_at") {
 		cols = append(cols, "deleted_at")
+	}
+	if oldDBHasColumn(ctx, tx, "sessions", "deletion_cause") {
+		cols = append(cols, "deletion_cause")
 	}
 	cols = append(cols, "created_at")
 	for _, c := range []string{

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -18,6 +18,15 @@ CREATE TABLE IF NOT EXISTS sessions (
     file_mtime  INTEGER,
     next_ordinal INTEGER NOT NULL DEFAULT 0,
     last_entry_uuid TEXT,
+    -- SQLite-only sync bookkeeping: whether the Claude full parser fell
+    -- back to linear processing for this file (NULL = unknown/legacy or
+    -- non-Claude). Read by the incremental parser to skip fork
+    -- detection on linear-bound transcripts. Like next_ordinal and
+    -- last_entry_uuid, this is machine-local parse state deliberately
+    -- not mirrored to PostgreSQL or DuckDB: parsers never run against
+    -- those read-side stores, and any copy that drops it degrades to
+    -- the conservative NULL verdict (full parse re-derives it).
+    claude_linear_parse INTEGER,
     file_inode  INTEGER,
     file_device INTEGER,
     file_hash   TEXT,
@@ -69,6 +78,9 @@ CREATE TABLE IF NOT EXISTS sessions (
     -- mirrored to PG/DuckDB.
     last_write_incremental INTEGER NOT NULL DEFAULT 0,
     deleted_at  TEXT,
+    -- NULL remains the established user-trash representation; source_missing
+    -- is recoverable when the file reappears.
+    deletion_cause TEXT,
     created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
     termination_status TEXT,
     secret_leak_count INTEGER NOT NULL DEFAULT 0,
@@ -153,7 +165,6 @@ CREATE INDEX IF NOT EXISTS idx_sessions_parent
 CREATE INDEX IF NOT EXISTS idx_sessions_file_path
     ON sessions(file_path)
     WHERE file_path IS NOT NULL;
-
 -- Analytics indexes
 CREATE INDEX IF NOT EXISTS idx_sessions_started
     ON sessions(started_at);
@@ -509,6 +520,19 @@ CREATE TABLE IF NOT EXISTS skipped_files (
     file_path  TEXT PRIMARY KEY,
     file_mtime INTEGER NOT NULL
 );
+
+-- Machine-local watcher proof. This deliberately stays outside the shared
+-- session model: remote stores must not authorize source tombstones for paths
+-- they did not observe on this machine.
+CREATE TABLE IF NOT EXISTS local_session_source_baselines (
+    session_id TEXT PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+    machine    TEXT NOT NULL,
+    agent      TEXT NOT NULL,
+    file_path  TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_local_source_baselines_ownership
+    ON local_session_source_baselines(machine, agent, file_path, session_id);
 
 -- Remote skip cache: tracks file mtimes per remote host
 -- for SSH sync incremental optimization.

--- a/internal/db/session_batch.go
+++ b/internal/db/session_batch.go
@@ -28,6 +28,7 @@ type SessionBatchWrite struct {
 type SessionBatchResult struct {
 	WrittenSessions  int
 	WrittenMessages  int
+	WrittenIndexes   []int
 	ExcludedSessions int
 	ExcludedIDs      []string
 	FailedSessions   int
@@ -92,6 +93,7 @@ func (db *DB) WriteSessionBatch(
 			)
 			result.WrittenSessions++
 			result.WrittenMessages += messagesWritten
+			result.WrittenIndexes = append(result.WrittenIndexes, i)
 		case errors.Is(err, ErrSessionExcluded),
 			errors.Is(err, ErrSessionTrashed):
 			if rerr := rollbackSavepoint(tx, savepoint); rerr != nil {
@@ -143,7 +145,7 @@ func (db *DB) WriteSessionBatchAtomic(
 	defer func() { _ = tx.Rollback() }()
 	var pendingRecallRevocations recallEvidenceRevocationEvents
 
-	for _, write := range writes {
+	for i, write := range writes {
 		write = sanitizeSessionBatchWrite(write)
 		messagesWritten, err := writeOneSessionBatchTx(
 			tx,
@@ -153,6 +155,7 @@ func (db *DB) WriteSessionBatchAtomic(
 		if err != nil {
 			result.WrittenSessions = 0
 			result.WrittenMessages = 0
+			result.WrittenIndexes = nil
 			switch {
 			case errors.Is(err, ErrSessionExcluded),
 				errors.Is(err, ErrSessionTrashed):
@@ -169,12 +172,14 @@ func (db *DB) WriteSessionBatchAtomic(
 		}
 		result.WrittenSessions++
 		result.WrittenMessages += messagesWritten
+		result.WrittenIndexes = append(result.WrittenIndexes, i)
 	}
 
 	if len(beforeCommit) > 0 && beforeCommit[0] != nil {
 		if err := beforeCommit[0](); err != nil {
 			result.WrittenSessions = 0
 			result.WrittenMessages = 0
+			result.WrittenIndexes = nil
 			return result, err
 		}
 	}
@@ -302,11 +307,11 @@ func writeOneSessionBatchTx(
 	if excluded == 1 {
 		return 0, ErrSessionExcluded
 	}
-	var deletedAt sql.NullString
+	var deletedAt, deletionCause sql.NullString
 	err = tx.QueryRow(
-		"SELECT deleted_at FROM sessions WHERE id = ?",
+		"SELECT deleted_at, deletion_cause FROM sessions WHERE id = ?",
 		write.Session.ID,
-	).Scan(&deletedAt)
+	).Scan(&deletedAt, &deletionCause)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return 0, fmt.Errorf(
 			"checking trash for %s: %w",
@@ -314,11 +319,14 @@ func writeOneSessionBatchTx(
 		)
 	}
 	sessionExists := err == nil
-	if deletedAt.Valid {
+	if deletedAt.Valid &&
+		(!deletionCause.Valid || deletionCause.String != deletionCauseSourceMissing) {
 		return 0, ErrSessionTrashed
 	}
+	replaceMessages := write.ReplaceMessages ||
+		(deletionCause.Valid && deletionCause.String == deletionCauseSourceMissing)
 	replacementTranscriptChanged := false
-	if write.ReplaceMessages && sessionExists {
+	if replaceMessages && sessionExists {
 		stored, err := sessionMessagesTx(
 			context.Background(), tx, write.Session.ID,
 		)
@@ -354,7 +362,7 @@ func writeOneSessionBatchTx(
 
 	msgs := write.Messages
 	var pins []savedPin
-	if write.ReplaceMessages && sessionExists {
+	if replaceMessages && sessionExists {
 		pins, err = savePinsTx(tx, write.Session.ID)
 		if err != nil {
 			return 0, err
@@ -370,7 +378,7 @@ func writeOneSessionBatchTx(
 		msgs = messagesAfterOrdinal(msgs, maxOrd)
 	}
 	transcriptChanged := len(msgs) > 0
-	if write.ReplaceMessages && sessionExists {
+	if replaceMessages && sessionExists {
 		transcriptChanged = replacementTranscriptChanged
 	}
 
@@ -393,7 +401,7 @@ func writeOneSessionBatchTx(
 			return 0, err
 		}
 	}
-	if write.ReplaceMessages && sessionExists {
+	if replaceMessages && sessionExists {
 		if err := reconcileRecallEvidenceForSessionTx(
 			context.Background(),
 			tx,
@@ -403,7 +411,7 @@ func writeOneSessionBatchTx(
 			return 0, err
 		}
 	}
-	if write.ReplaceMessages {
+	if replaceMessages {
 		if err := restorePinsTx(tx, write.Session.ID, pins); err != nil {
 			return 0, err
 		}

--- a/internal/db/session_stats.go
+++ b/internal/db/session_stats.go
@@ -1500,10 +1500,15 @@ func (db *DB) computeOutcomeStats(
 	since := from.UTC().Format(time.RFC3339)
 	until := to.UTC().Format(time.RFC3339)
 	var cache *git.Cache
-	if db.ReadOnly() {
-		cache = git.NewReadOnlyCache(db.rawReader())
+	// Snapshot the writer pool once: CloseWriter can nil it concurrently for a
+	// worker maintenance pass, so a check-then-load would hand git.NewCache a nil
+	// *sql.DB and panic on first use. When the snapshot is nil (writer closed) or
+	// the store is read-only, fall back to the read-only cache: analytics keep
+	// computing from the reader without persisting git stats.
+	if writer := db.rawWriter(); !db.ReadOnly() && writer != nil {
+		cache = git.NewCache(writer)
 	} else {
-		cache = git.NewCache(db.rawWriter())
+		cache = git.NewReadOnlyCache(db.rawReader())
 	}
 	out := &StatsOutcomeStats{}
 	contributed := false

--- a/internal/db/session_stats_test.go
+++ b/internal/db/session_stats_test.go
@@ -2599,6 +2599,56 @@ func TestGetSessionStats_OutcomeStats_Happy(t *testing.T) {
 	assert.Nil(t, out.PRsMerged, "PRsMerged want nil (no GHToken)")
 }
 
+// TestOutcomeStatsWriterCloseRaceDoesNotPanic guards the writer snapshot in
+// computeOutcomeStats: closing the writer for a maintenance pass concurrently
+// with the git outcome-stats path must fall back to the read-only cache and
+// never hand git.NewCache a nil writer pool (which would panic on first use).
+func TestOutcomeStatsWriterCloseRaceDoesNotPanic(t *testing.T) {
+	skipIfNoGit(t)
+	d := testDB(t)
+	ctx := context.Background()
+	repo := statsOutcomeRepo(t)
+	insertSessionFixture(t, d, sessionFixture{
+		id: "race1", agent: "claude", userMsgs: 5,
+		startedAt: hoursAgo(5), cwd: repo,
+	})
+
+	done := make(chan struct{})
+	toggleErr := make(chan error, 1)
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			if err := d.CloseWriter(); err != nil {
+				toggleErr <- err
+				return
+			}
+			if err := d.ReopenWriter(); err != nil {
+				toggleErr <- err
+				return
+			}
+		}
+	})
+
+	for range 300 {
+		// Must never panic; a transient error while the writer is closed is fine.
+		_, _ = d.GetSessionStats(ctx, StatsFilter{
+			Since: "28d", IncludeGitOutcomes: true,
+		})
+	}
+	close(done)
+	wg.Wait()
+	select {
+	case err := <-toggleErr:
+		require.NoError(t, err, "writer toggling failed")
+	default:
+	}
+}
+
 // TestGetSessionStats_OutcomeStats_NoCwd verifies that sessions without
 // a recorded cwd leave OutcomeStats nil — a pure non-git workload must
 // not surface a fabricated all-zero outcome row. The JSON contract uses

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -28,6 +28,12 @@ var ErrSessionExcluded = errors.New("session excluded")
 // should surface a conflict instead of silently overwriting it.
 var ErrSessionTrashed = errors.New("session trashed")
 
+// deletionCauseSourceMissing marks a watcher-created tombstone. Unlike user
+// trash (the established NULL cause), it is cleared when the exact source is
+// parsed again. Mirror pushes preserve the cause so read backends can keep
+// recoverable source loss distinct from explicit user deletion.
+const deletionCauseSourceMissing = "source_missing"
+
 // sessionBaseCols is the column list for standard session queries
 // (list, get). Keep in sync with scanSessionRow.
 const sessionBaseCols = `id, project, machine, agent,
@@ -120,7 +126,7 @@ const sessionFullCols = `id, project, machine, agent,
 	transcript_fidelity,
 	parser_malformed_lines, is_truncated,
 	last_write_incremental,
-	deleted_at, termination_status, file_path, file_size, file_mtime,
+	deleted_at, deletion_cause, termination_status, file_path, file_size, file_mtime,
 	next_ordinal, last_entry_uuid,
 	file_inode, file_device,
 	file_hash, local_modified_at, transcript_revision, created_at`
@@ -331,12 +337,19 @@ type Session struct {
 	IsTruncated                 bool            `json:"is_truncated,omitempty"`
 
 	DeletedAt         *string `json:"deleted_at,omitempty"`
+	DeletionCause     *string `json:"-"`
 	TerminationStatus *string `json:"termination_status,omitempty"`
 	FilePath          *string `json:"file_path,omitempty"`
 	FileSize          *int64  `json:"file_size,omitempty"`
 	FileMtime         *int64  `json:"file_mtime,omitempty"`
 	NextOrdinal       int     `json:"-"`
 	LastEntryUUID     *string `json:"-"`
+	// ClaudeLinearParse is SQLite-only sync bookkeeping: whether the
+	// Claude full parser fell back to linear processing for this file
+	// (nil = unknown/legacy or non-Claude). Linearity is monotonic
+	// across appends, so the incremental parser skips fork detection
+	// for linear-bound transcripts. Not mirrored to PG/DuckDB.
+	ClaudeLinearParse *bool `json:"-"`
 	// LastWriteIncremental is SQLite-only sync bookkeeping (like
 	// NextOrdinal): true when the last write to this row went through
 	// the incremental-append path (updateSessionIncrementalTx) instead
@@ -1107,7 +1120,8 @@ func (db *DB) GetSessionFull(
 		&s.TranscriptFidelity,
 		&s.ParserMalformedLines, &s.IsTruncated,
 		&s.LastWriteIncremental,
-		&s.DeletedAt, &s.TerminationStatus, &s.FilePath, &s.FileSize,
+		&s.DeletedAt, &s.DeletionCause,
+		&s.TerminationStatus, &s.FilePath, &s.FileSize,
 		&s.FileMtime, &s.NextOrdinal, &s.LastEntryUUID,
 		&s.FileInode, &s.FileDevice,
 		&s.FileHash, &s.LocalModifiedAt,
@@ -1165,7 +1179,8 @@ func (db *DB) IsSessionExcluded(id string) bool {
 func (db *DB) IsSessionTrashed(id string) bool {
 	var n int
 	_ = db.getReader().QueryRow(
-		"SELECT 1 FROM sessions WHERE id = ? AND deleted_at IS NOT NULL", id,
+		"SELECT 1 FROM sessions WHERE id = ?"+
+			" AND deleted_at IS NOT NULL AND deletion_cause IS NULL", id,
 	).Scan(&n)
 	return n == 1
 }
@@ -1176,7 +1191,8 @@ func (db *DB) HasTrashedSessionByFilePath(path, agent string) bool {
 	var n int
 	_ = db.getReader().QueryRow(
 		"SELECT 1 FROM sessions"+
-			" WHERE file_path = ? AND agent = ? AND deleted_at IS NOT NULL"+
+			" WHERE file_path = ? AND agent = ?"+
+			" AND deleted_at IS NOT NULL AND deletion_cause IS NULL"+
 			" LIMIT 1",
 		path, agent,
 	).Scan(&n)
@@ -1284,16 +1300,16 @@ const insertSessionSQL = `
 			is_truncated,
 			last_write_incremental,
 			file_path, file_size, file_mtime,
-			next_ordinal, last_entry_uuid,
+			next_ordinal, last_entry_uuid, claude_linear_parse,
 			file_inode, file_device, file_hash
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 
 // insertSessionIfAbsentSQL inserts a session only when its id does not already
 // exist, leaving an existing row untouched.
 const insertSessionIfAbsentSQL = insertSessionSQL + `
 		ON CONFLICT(id) DO NOTHING`
 
-const upsertSessionSQL = insertSessionSQL + `
+const upsertSessionBaseSQL = insertSessionSQL + `
 		ON CONFLICT(id) DO UPDATE SET
 			project = excluded.project,
 			machine = excluded.machine,
@@ -1337,9 +1353,23 @@ const upsertSessionSQL = insertSessionSQL + `
 			file_mtime = excluded.file_mtime,
 			next_ordinal = excluded.next_ordinal,
 			last_entry_uuid = excluded.last_entry_uuid,
+			-- COALESCE keeps a known linearity verdict when a caller
+			-- upserts without one (e.g. non-parse session writers).
+			claude_linear_parse = COALESCE(
+				excluded.claude_linear_parse, sessions.claude_linear_parse),
 			file_inode = excluded.file_inode,
 			file_device = excluded.file_device,
 			file_hash = excluded.file_hash`
+
+const upsertSessionSQL = upsertSessionBaseSQL + `,
+			deleted_at = CASE
+				WHEN sessions.deletion_cause = '` + deletionCauseSourceMissing + `' THEN NULL
+				ELSE sessions.deleted_at
+			END,
+			deletion_cause = CASE
+				WHEN sessions.deletion_cause = '` + deletionCauseSourceMissing + `' THEN NULL
+				ELSE sessions.deletion_cause
+			END`
 
 func sessionIsAutomated(s Session) bool {
 	return s.IsAutomated ||
@@ -1369,7 +1399,7 @@ func upsertSessionArgs(s Session) []any {
 		// the stored messages; only a full message replacement clears it.
 		false,
 		s.FilePath, s.FileSize, s.FileMtime,
-		s.NextOrdinal, s.LastEntryUUID,
+		s.NextOrdinal, s.LastEntryUUID, s.ClaudeLinearParse,
 		s.FileInode, s.FileDevice, s.FileHash,
 	}
 }
@@ -1378,6 +1408,22 @@ func upsertSessionArgs(s Session) []any {
 // Sessions that were permanently deleted (in excluded_sessions)
 // or currently in the trash are rejected.
 func (db *DB) UpsertSession(s Session) error {
+	_, err := db.upsertSession(s, true)
+	return err
+}
+
+// UpsertSessionPendingContent inserts or updates the session row without
+// reviving a source-missing tombstone. Full content writers call
+// ReviveSourceMissingSession only after every required dependent write lands.
+// The returned bool reports whether the row was source-missing before the
+// upsert, so callers can replace rather than append its retained content.
+func (db *DB) UpsertSessionPendingContent(s Session) (bool, error) {
+	return db.upsertSession(s, false)
+}
+
+func (db *DB) upsertSession(
+	s Session, reviveSourceMissing bool,
+) (bool, error) {
 	_ = ValidateAndSanitize(&s, nil, nil)
 
 	db.mu.Lock()
@@ -1390,15 +1436,21 @@ func (db *DB) UpsertSession(s Session) error {
 		"SELECT 1 FROM excluded_sessions WHERE id = ?", s.ID,
 	).Scan(&excluded)
 	if excluded == 1 {
-		return ErrSessionExcluded
+		return false, ErrSessionExcluded
 	}
-	var trashed int
-	_ = db.getWriter().QueryRow(
-		"SELECT 1 FROM sessions WHERE id = ? AND deleted_at IS NOT NULL", s.ID,
-	).Scan(&trashed)
-	if trashed == 1 {
-		return ErrSessionTrashed
+	var deletedAt, deletionCause sql.NullString
+	err := db.getWriter().QueryRow(
+		"SELECT deleted_at, deletion_cause FROM sessions WHERE id = ?", s.ID,
+	).Scan(&deletedAt, &deletionCause)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return false, fmt.Errorf("checking trash for %s: %w", s.ID, err)
 	}
+	if deletedAt.Valid &&
+		(!deletionCause.Valid || deletionCause.String != deletionCauseSourceMissing) {
+		return false, ErrSessionTrashed
+	}
+	sourceMissing := deletionCause.Valid &&
+		deletionCause.String == deletionCauseSourceMissing
 
 	// data_version is intentionally NOT advanced here. The
 	// caller must call SetSessionDataVersion only after the
@@ -1407,12 +1459,31 @@ func (db *DB) UpsertSession(s Session) error {
 	// up-to-date and starve the rewrite on the next sync.
 	// New rows are seeded with 0 (the default) and bumped to
 	// the current version once their messages land.
-	_, err := db.getWriter().Exec(
-		upsertSessionSQL,
-		upsertSessionArgs(s)...,
-	)
+	query := upsertSessionBaseSQL
+	if reviveSourceMissing {
+		query = upsertSessionSQL
+	}
+	_, err = db.getWriter().Exec(query, upsertSessionArgs(s)...)
 	if err != nil {
-		return fmt.Errorf("upserting session %s: %w", s.ID, err)
+		return false, fmt.Errorf("upserting session %s: %w", s.ID, err)
+	}
+	return sourceMissing, nil
+}
+
+// ReviveSourceMissingSession makes a watcher-tombstoned session visible after
+// its replacement session row, messages, usage events, and data version have
+// all been persisted successfully. User trash is never affected.
+func (db *DB) ReviveSourceMissingSession(id string) error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	_, err := db.getWriter().Exec(`
+		UPDATE sessions
+		SET deleted_at = NULL,
+		    deletion_cause = NULL,
+		    local_modified_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+		WHERE id = ? AND deletion_cause = ?`, id, deletionCauseSourceMissing)
+	if err != nil {
+		return fmt.Errorf("reviving source-missing session %s: %w", id, err)
 	}
 	return nil
 }
@@ -1510,14 +1581,17 @@ func (db *DB) LinkSubagentSessions() error {
 	return nil
 }
 
-// GetSessionFileInfo returns file_size and file_mtime for a
-// session. Used for fast skip checks during sync.
+// GetSessionFileInfo returns file_size and file_mtime for a session. Used for
+// fast skip checks during sync. Recoverable source-missing tombstones are
+// excluded so an identical source restoration cannot be mistaken for fresh.
 func (db *DB) GetSessionFileInfo(
 	id string,
 ) (size int64, mtime int64, ok bool) {
 	var s, m sql.NullInt64
 	err := db.getReader().QueryRow(
-		"SELECT file_size, file_mtime FROM sessions WHERE id = ?",
+		"SELECT file_size, file_mtime FROM sessions WHERE id = ?"+
+			" AND (deletion_cause IS NULL"+
+			" OR deletion_cause <> '"+deletionCauseSourceMissing+"')",
 		id,
 	).Scan(&s, &m)
 	if err != nil {
@@ -1526,12 +1600,14 @@ func (db *DB) GetSessionFileInfo(
 	return s.Int64, m.Int64, true
 }
 
-// GetSessionFileHash returns file_hash for a session. The bool is false when
-// the session does not exist or the column is NULL.
+// GetSessionFileHash returns file_hash for a non-source-missing session. The
+// bool is false when no eligible session exists or the column is NULL.
 func (db *DB) GetSessionFileHash(id string) (hash string, ok bool) {
 	var h sql.NullString
 	err := db.getReader().QueryRow(
-		"SELECT file_hash FROM sessions WHERE id = ?",
+		"SELECT file_hash FROM sessions WHERE id = ?"+
+			" AND (deletion_cause IS NULL"+
+			" OR deletion_cause <> '"+deletionCauseSourceMissing+"')",
 		id,
 	).Scan(&h)
 	if err != nil || !h.Valid {
@@ -1799,6 +1875,7 @@ type IncrementalInfo struct {
 	FileMtime            int64
 	NextOrdinal          int
 	LastEntryUUID        string
+	ClaudeLinearParse    *bool
 	FileInode            int64
 	FileDevice           int64
 	MsgCount             int
@@ -1859,10 +1936,11 @@ func (db *DB) GetSessionForIncremental(
 	var info IncrementalInfo
 	var fs, fm, fi, fd sql.NullInt64
 	var firstMsg, lastEntryUUID sql.NullString
+	var linearParse sql.NullBool
 	err = db.getReader().QueryRow(
 		`SELECT id, project, machine, cwd, agent_label, entrypoint,
 			file_size, file_mtime,
-			next_ordinal, last_entry_uuid,
+			next_ordinal, last_entry_uuid, claude_linear_parse,
 			file_inode, file_device,
 			message_count, user_message_count,
 			first_message,
@@ -1875,7 +1953,8 @@ func (db *DB) GetSessionForIncremental(
 	).Scan(
 		&info.ID, &info.Project, &info.Machine, &info.Cwd,
 		&info.AgentLabel, &info.Entrypoint,
-		&fs, &fm, &info.NextOrdinal, &lastEntryUUID, &fi, &fd,
+		&fs, &fm, &info.NextOrdinal, &lastEntryUUID, &linearParse,
+		&fi, &fd,
 		&info.MsgCount, &info.UserMsgCount,
 		&firstMsg,
 		&info.TotalOutputTokens, &info.PeakContextTokens,
@@ -1889,6 +1968,9 @@ func (db *DB) GetSessionForIncremental(
 	}
 	if lastEntryUUID.Valid {
 		info.LastEntryUUID = lastEntryUUID.String
+	}
+	if linearParse.Valid {
+		info.ClaudeLinearParse = &linearParse.Bool
 	}
 	if fs.Valid {
 		info.FileSize = fs.Int64
@@ -2052,9 +2134,9 @@ func resetIncrementalMarkerTx(tx *sql.Tx, sessionID string) error {
 	return nil
 }
 
-// GetFileInfoByPath returns file_size and file_mtime for a
-// session identified by file_path. Used for codex/gemini files
-// where the session ID requires parsing.
+// GetFileInfoByPath returns file_size and file_mtime for a session identified
+// by file_path. Recoverable source-missing tombstones are excluded so a source
+// that returns with identical metadata cannot be skipped before revival.
 func (db *DB) GetFileInfoByPath(
 	path string,
 ) (size int64, mtime int64, ok bool) {
@@ -2062,6 +2144,8 @@ func (db *DB) GetFileInfoByPath(
 	err := db.getReader().QueryRow(
 		"SELECT file_size, file_mtime FROM sessions"+
 			" WHERE file_path = ?"+
+			" AND (deletion_cause IS NULL"+
+			" OR deletion_cause <> '"+deletionCauseSourceMissing+"')"+
 			" ORDER BY file_mtime DESC LIMIT 1",
 		path,
 	).Scan(&s, &m)
@@ -2117,8 +2201,8 @@ func (db *DB) GetSourceRepairStateByPath(
 	return project, dataVersion, fileSize, fileMtime, true
 }
 
-// GetFileHashByPath returns the stored file_hash for the session
-// matching file_path, preferring the most recently modified row.
+// GetFileHashByPath returns the stored file_hash for a non-source-missing
+// session matching file_path, preferring the most recently modified row.
 // The bool is false when no row exists or the column is NULL. Used
 // by the Shelley skip to compare a per-conversation content
 // fingerprint alongside file_mtime.
@@ -2127,6 +2211,8 @@ func (db *DB) GetFileHashByPath(path string) (hash string, ok bool) {
 	err := db.getReader().QueryRow(
 		"SELECT file_hash FROM sessions"+
 			" WHERE file_path = ?"+
+			" AND (deletion_cause IS NULL"+
+			" OR deletion_cause <> '"+deletionCauseSourceMissing+"')"+
 			" ORDER BY file_mtime DESC LIMIT 1",
 		path,
 	).Scan(&h)
@@ -2167,29 +2253,472 @@ func (db *DB) ListSessionIDsByFilePath(path, agent string) ([]string, error) {
 
 const storedSourcePathHintRootBatchSize = 100
 
+// StoredSourcePathHintScope identifies one affected stored-source prefix.
+// IncludeVirtualMembers is provider-declared ownership of path#member sources;
+// it must not be inferred from filename shape.
+type StoredSourcePathHintScope struct {
+	Path                  string
+	IncludeVirtualMembers bool
+}
+
+// WatchReconcileSourcePageSize bounds each watcher reconciliation ownership
+// page. The engine releases every page before requesting the next one, so its
+// live Go memory does not scale with the number of archived sessions.
+const WatchReconcileSourcePageSize = 128
+
+// watchReconcileOwnershipScopeBatchSize bounds the SQL expression and bind
+// parameter count independently of the number of configured provider roots.
+const watchReconcileOwnershipScopeBatchSize = 32
+
+// SessionSourceCursor is the complete keyset cursor for source ownership
+// pages. Agent is retained to prevent accidentally reusing a cursor across
+// independently ordered agent scans.
+type SessionSourceCursor struct {
+	Agent    string
+	FilePath string
+	ID       string
+}
+
+// SessionSourceOwnership is the exact active row identity used by watcher
+// reconciliation. Conditional tombstoning must match every field.
+type SessionSourceOwnership struct {
+	Machine  string
+	Agent    string
+	ID       string
+	FilePath string
+}
+
+// SessionSourcePath identifies an exact source path observed during a
+// successful local reconciliation. The baseline is deliberately path-exact:
+// callers must pass virtual member paths without splitting their suffixes.
+type SessionSourcePath struct {
+	Agent    string
+	FilePath string
+}
+
+func (o SessionSourceOwnership) Cursor() SessionSourceCursor {
+	return SessionSourceCursor{Agent: o.Agent, FilePath: o.FilePath, ID: o.ID}
+}
+
+// ListActiveSessionSourceOwnershipScopesPage returns one stable keyset page
+// across a provider's bounded physical scopes. Normalization deduplicates
+// repeated declarations before building the query.
+func (db *DB) ListActiveSessionSourceOwnershipScopesPage(
+	ctx context.Context,
+	machine string,
+	agent string,
+	scopes []StoredSourcePathHintScope,
+	after SessionSourceCursor,
+) ([]SessionSourceOwnership, error) {
+	scopes = normalizeStoredSourcePathHintScopes(scopes)
+	if machine == "" || agent == "" || len(scopes) == 0 {
+		return nil, nil
+	}
+	if after.Agent != "" && after.Agent != agent {
+		return nil, fmt.Errorf(
+			"source ownership cursor agent %q does not match %q", after.Agent, agent,
+		)
+	}
+	var ownership []SessionSourceOwnership
+	for start := 0; start < len(scopes); start += watchReconcileOwnershipScopeBatchSize {
+		end := min(start+watchReconcileOwnershipScopeBatchSize, len(scopes))
+		page, err := db.listActiveSessionSourceOwnershipScopeBatch(
+			ctx, machine, agent, scopes[start:end], after,
+		)
+		if err != nil {
+			return nil, err
+		}
+		ownership = mergeSessionSourceOwnershipPages(
+			ownership, page, WatchReconcileSourcePageSize,
+		)
+	}
+	return ownership, nil
+}
+
+func (db *DB) listActiveSessionSourceOwnershipScopeBatch(
+	ctx context.Context,
+	machine string,
+	agent string,
+	scopes []StoredSourcePathHintScope,
+	after SessionSourceCursor,
+) ([]SessionSourceOwnership, error) {
+	rootClauses := make([]string, 0, len(scopes))
+	args := []any{machine, agent}
+	for _, scope := range scopes {
+		root := scope.Path
+		likeRoot := sqliteLikeEscape(root)
+		rootClause := `(b.file_path = ? OR b.file_path LIKE ? ESCAPE '!')`
+		args = append(args, root, likeRoot+string(filepath.Separator)+"%")
+		if scope.IncludeVirtualMembers {
+			// Mirror storedSourcePathHintInRoot: a virtual member is the
+			// container plus '#' and a nonempty single segment. Nested stored
+			// paths such as root+"#backup/session.json" belong to other
+			// sources and must not be claimed (and later tombstoned) here.
+			rootClause = `(` + rootClause + ` OR (b.file_path > ? AND b.file_path < ?
+				AND b.file_path NOT LIKE ? ESCAPE '!'
+				AND b.file_path NOT LIKE ? ESCAPE '!'))`
+			args = append(args, root+"#", root+"$",
+				likeRoot+`#%/%`, likeRoot+`#%\%`)
+		}
+		rootClauses = append(rootClauses, rootClause)
+	}
+	rootClause := `(` + strings.Join(rootClauses, ` OR `) + `)`
+	args = append(args,
+		after.FilePath, after.FilePath, after.ID,
+		WatchReconcileSourcePageSize,
+	)
+	rows, err := db.getReader().QueryContext(ctx, `
+		SELECT s.machine, s.agent, s.id, s.file_path
+		FROM local_session_source_baselines AS b
+		JOIN sessions AS s
+		  ON s.id = b.session_id
+		 AND s.machine = b.machine
+		 AND s.agent = b.agent
+		 AND s.file_path = b.file_path
+		WHERE b.machine = ?
+		  AND b.agent = ?
+		  AND s.deleted_at IS NULL
+		  AND `+rootClause+`
+		  AND (b.file_path > ? OR (b.file_path = ? AND b.session_id > ?))
+		ORDER BY b.file_path, b.session_id
+		LIMIT ?`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("listing active session source ownership: %w", err)
+	}
+	defer rows.Close()
+
+	ownership := make([]SessionSourceOwnership, 0, WatchReconcileSourcePageSize)
+	for rows.Next() {
+		var item SessionSourceOwnership
+		if err := rows.Scan(
+			&item.Machine, &item.Agent, &item.ID, &item.FilePath,
+		); err != nil {
+			return nil, fmt.Errorf("scanning active session source ownership: %w", err)
+		}
+		ownership = append(ownership, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating active session source ownership: %w", err)
+	}
+	return ownership, nil
+}
+
+func mergeSessionSourceOwnershipPages(
+	left, right []SessionSourceOwnership,
+	limit int,
+) []SessionSourceOwnership {
+	// Every batch returns its first page after the same cursor. Keeping the
+	// smallest unique limit across those prefixes therefore produces the first
+	// global page without retaining work proportional to the number of scopes.
+	combined := make([]SessionSourceOwnership, 0, min(len(left)+len(right), limit*2))
+	combined = append(combined, left...)
+	combined = append(combined, right...)
+	sort.Slice(combined, func(i, j int) bool {
+		if combined[i].FilePath != combined[j].FilePath {
+			return combined[i].FilePath < combined[j].FilePath
+		}
+		return combined[i].ID < combined[j].ID
+	})
+	merged := combined[:0]
+	for _, item := range combined {
+		if len(merged) > 0 {
+			previous := merged[len(merged)-1]
+			if item.FilePath == previous.FilePath && item.ID == previous.ID {
+				continue
+			}
+		}
+		merged = append(merged, item)
+		if len(merged) == limit {
+			break
+		}
+	}
+	return merged
+}
+
+// BaselineActiveSessionSourcePaths marks exact active local ownerships as
+// observed. Callers pass one bounded discovery page or changed-path batch at a
+// time so this update never scales its live memory with the archive.
+func (db *DB) BaselineActiveSessionSourcePaths(
+	ctx context.Context,
+	machine string,
+	sources []SessionSourcePath,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if machine == "" || len(sources) == 0 {
+		return nil
+	}
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	tx, err := db.getWriter().BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("starting source baseline transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := baselineActiveSessionSourcePathsTx(
+		ctx, tx, machine, sources,
+	); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing source baseline transaction: %w", err)
+	}
+	return nil
+}
+
+// ReplaceActiveSessionSourceBaselines makes admitted the exact subset of a
+// bounded candidate page that carries deletion proof. Existing proof for
+// rejected candidates is removed in the same transaction that admits the
+// successful candidates.
+//
+// The replacement is a diff, not a rewrite: warm no-op syncs replay every
+// unchanged archived source as an admitted candidate each pass, so unchanged
+// admitted rows must not be touched. Only rejected pairs, missing or changed
+// admitted rows, and admitted-pair rows no longer backed by an active session
+// with the same ownership (moved or tombstoned sessions) produce writes.
+func (db *DB) ReplaceActiveSessionSourceBaselines(
+	ctx context.Context,
+	machine string,
+	candidates []SessionSourcePath,
+	admitted []SessionSourcePath,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if machine == "" || len(candidates) == 0 {
+		return nil
+	}
+	rejected := rejectedSourceCandidates(candidates, admitted)
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	tx, err := db.getWriter().BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("starting source baseline replacement transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := deleteSessionSourceBaselinesTx(
+		ctx, tx, machine, rejected, "", "rejected",
+	); err != nil {
+		return err
+	}
+	if err := baselineActiveSessionSourcePathsTx(
+		ctx, tx, machine, admitted,
+	); err != nil {
+		return err
+	}
+	if err := deleteSessionSourceBaselinesTx(
+		ctx, tx, machine, admitted, `
+			  AND NOT EXISTS (
+				SELECT 1 FROM sessions AS s
+				WHERE s.id = local_session_source_baselines.session_id
+				  AND s.machine = local_session_source_baselines.machine
+				  AND s.agent = local_session_source_baselines.agent
+				  AND s.file_path = local_session_source_baselines.file_path
+				  AND s.deleted_at IS NULL
+			  )`, "stale admitted",
+	); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing source baseline replacement: %w", err)
+	}
+	return nil
+}
+
+// rejectedSourceCandidates returns the candidates not admitted, preserving
+// candidate order. Admission is exact (agent, file_path) pair equality.
+func rejectedSourceCandidates(
+	candidates []SessionSourcePath, admitted []SessionSourcePath,
+) []SessionSourcePath {
+	admittedSet := make(map[SessionSourcePath]struct{}, len(admitted))
+	for _, source := range admitted {
+		admittedSet[source] = struct{}{}
+	}
+	rejected := make([]SessionSourcePath, 0, max(0, len(candidates)-len(admitted)))
+	for _, source := range candidates {
+		if _, ok := admittedSet[source]; ok {
+			continue
+		}
+		rejected = append(rejected, source)
+	}
+	return rejected
+}
+
+// deleteSessionSourceBaselinesTx removes baseline rows matching the sources'
+// (agent, file_path) pairs under machine, restricted by an optional extra
+// condition, chunked to stay under SQLite's bind-variable limit.
+func deleteSessionSourceBaselinesTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	machine string,
+	sources []SessionSourcePath,
+	condition string,
+	what string,
+) error {
+	for start := 0; start < len(sources); start += baselinePairChunk {
+		end := min(start+baselinePairChunk, len(sources))
+		filter, args, ok := buildSourcePairFilter(sources[start:end])
+		if !ok {
+			continue
+		}
+		execArgs := append([]any{machine}, args...)
+		if _, err := tx.ExecContext(ctx, `
+			DELETE FROM local_session_source_baselines
+			WHERE machine = ? AND `+filter+condition, execArgs...,
+		); err != nil {
+			return fmt.Errorf(
+				"removing %s session source baselines: %w", what, err,
+			)
+		}
+	}
+	return nil
+}
+
+// baselinePairChunk bounds how many (agent, file_path) pairs bind into one
+// set-based baseline statement. Warm no-op reconciliation replays a full
+// discovery page (up to reconciliationPageSize) of unchanged sources every
+// pass, so folding those per-source round trips into a handful of set-based
+// statements keeps the unchanged path from allocating one prepared-statement
+// exec per archived source. The chunk keeps the bind-variable count well under
+// SQLite's default limit regardless of the caller's page size.
+const baselinePairChunk = 200
+
+// buildSourcePairFilter renders a row-value IN clause matching each non-empty
+// (agent, file_path) pair and returns the SQL fragment plus its bind arguments
+// in pair order. It returns ok=false when the batch holds no usable pair.
+func buildSourcePairFilter(sources []SessionSourcePath) (string, []any, bool) {
+	args := make([]any, 0, len(sources)*2)
+	var sb strings.Builder
+	sb.Grow(len("(agent, file_path) IN (VALUES )") + len(sources)*len("(?,?),"))
+	sb.WriteString("(agent, file_path) IN (VALUES ")
+	for _, source := range sources {
+		if source.Agent == "" || source.FilePath == "" {
+			continue
+		}
+		if len(args) > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString("(?,?)")
+		args = append(args, source.Agent, source.FilePath)
+	}
+	if len(args) == 0 {
+		return "", nil, false
+	}
+	sb.WriteString(")")
+	return sb.String(), args, true
+}
+
+func baselineActiveSessionSourcePathsTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	machine string,
+	sources []SessionSourcePath,
+) error {
+	for start := 0; start < len(sources); start += baselinePairChunk {
+		end := min(start+baselinePairChunk, len(sources))
+		filter, args, ok := buildSourcePairFilter(sources[start:end])
+		if !ok {
+			continue
+		}
+		execArgs := append([]any{machine}, args...)
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO local_session_source_baselines
+				(session_id, machine, agent, file_path)
+			SELECT id, machine, agent, file_path
+			FROM sessions
+			WHERE machine = ? AND `+filter+`
+			  AND file_path IS NOT NULL AND deleted_at IS NULL
+			ON CONFLICT(session_id) DO UPDATE SET
+				machine = excluded.machine,
+				agent = excluded.agent,
+				file_path = excluded.file_path
+			WHERE local_session_source_baselines.machine IS NOT excluded.machine
+			   OR local_session_source_baselines.agent IS NOT excluded.agent
+			   OR local_session_source_baselines.file_path IS NOT excluded.file_path`,
+			execArgs...,
+		); err != nil {
+			return fmt.Errorf("baselining active session source paths: %w", err)
+		}
+	}
+	return nil
+}
+
+// SoftDeleteSessionSourceOwnership tombstones a session only while the row is
+// still owned by the exact agent and source observed by reconciliation.
+func (db *DB) SoftDeleteSessionSourceOwnership(
+	ctx context.Context,
+	machine string,
+	agent string,
+	id string,
+	filePath string,
+) (bool, error) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	result, err := db.getWriter().ExecContext(ctx, `
+		UPDATE sessions
+		SET deleted_at = strftime('%Y-%m-%dT%H:%M:%fZ','now'),
+		    deletion_cause = ?,
+		    local_modified_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+		WHERE machine = ? AND agent = ? AND id = ? AND file_path = ?
+		  AND deleted_at IS NULL
+		  AND EXISTS (
+			SELECT 1 FROM local_session_source_baselines AS b
+			WHERE b.session_id = sessions.id
+			  AND b.machine = sessions.machine
+			  AND b.agent = sessions.agent
+			  AND b.file_path = sessions.file_path
+		  )`,
+		deletionCauseSourceMissing, machine, agent, id, filePath,
+	)
+	if err != nil {
+		return false, fmt.Errorf("soft-deleting exact session source ownership: %w", err)
+	}
+	count, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("counting exact session source tombstone: %w", err)
+	}
+	return count > 0, nil
+}
+
 // ListStoredSourcePathHints returns active source paths for agent whose stored
-// file_path falls under any watched root. It is used by provider changed-path
-// comparison to avoid losing sessions when the changed path is a sidecar or a
-// root-scoped database event rather than the exact persisted source path.
+// file_path falls under any affected source prefix. It is used by provider
+// changed-path comparison to avoid losing sessions when the changed path is a
+// sidecar or database event rather than the exact persisted source path.
 func (db *DB) ListStoredSourcePathHints(
 	agent string,
-	roots []string,
+	scopes []StoredSourcePathHintScope,
 ) ([]string, error) {
+	return db.ListStoredSourcePathHintsContext(
+		context.Background(), agent, scopes,
+	)
+}
+
+// ListStoredSourcePathHintsContext is ListStoredSourcePathHints with
+// caller-controlled cancellation for watcher classification.
+func (db *DB) ListStoredSourcePathHintsContext(
+	ctx context.Context,
+	agent string,
+	scopes []StoredSourcePathHintScope,
+) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if agent == "" {
 		return nil, nil
 	}
-	roots = normalizeStoredSourcePathHintRoots(roots)
-	if len(roots) == 0 {
+	scopes = normalizeStoredSourcePathHintScopes(scopes)
+	if len(scopes) == 0 {
 		return nil, nil
 	}
 
 	seen := make(map[string]struct{})
 	var hints []string
-	for start := 0; start < len(roots); start += storedSourcePathHintRootBatchSize {
-		end := min(start+storedSourcePathHintRootBatchSize, len(roots))
-		batch := roots[start:end]
+	for start := 0; start < len(scopes); start += storedSourcePathHintRootBatchSize {
+		end := min(start+storedSourcePathHintRootBatchSize, len(scopes))
+		batch := scopes[start:end]
 		query, args := storedSourcePathHintQuery(agent, batch)
-		rows, err := db.getReader().Query(query, args...)
+		rows, err := db.getReader().QueryContext(ctx, query, args...)
 		if err != nil {
 			return nil, fmt.Errorf("listing stored source path hints: %w", err)
 		}
@@ -2220,53 +2749,61 @@ func (db *DB) ListStoredSourcePathHints(
 	return hints, nil
 }
 
-func normalizeStoredSourcePathHintRoots(roots []string) []string {
-	seen := make(map[string]struct{}, len(roots))
-	out := make([]string, 0, len(roots))
-	for _, root := range roots {
-		root = cleanStoredSourcePathHint(root)
-		if root == "" || root == "." {
+func normalizeStoredSourcePathHintScopes(
+	scopes []StoredSourcePathHintScope,
+) []StoredSourcePathHintScope {
+	byPath := make(map[string]bool, len(scopes))
+	for _, scope := range scopes {
+		path := cleanStoredSourcePathHint(scope.Path)
+		if path == "" || path == "." {
 			continue
 		}
-		if _, ok := seen[root]; ok {
-			continue
-		}
-		seen[root] = struct{}{}
-		out = append(out, root)
+		byPath[path] = byPath[path] || scope.IncludeVirtualMembers
 	}
-	sort.Strings(out)
+	out := make([]StoredSourcePathHintScope, 0, len(byPath))
+	for path, includeVirtualMembers := range byPath {
+		out = append(out, StoredSourcePathHintScope{
+			Path: path, IncludeVirtualMembers: includeVirtualMembers,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Path < out[j].Path
+	})
 	return out
 }
 
-func storedSourcePathHintQuery(agent string, roots []string) (string, []any) {
-	clauses := make([]string, 0, len(roots))
-	args := []any{agent}
-	for _, root := range roots {
-		root = cleanStoredSourcePathHint(root)
+func storedSourcePathHintQuery(
+	agent string,
+	scopes []StoredSourcePathHintScope,
+) (string, []any) {
+	selects := make([]string, 0, len(scopes)*3)
+	var args []any
+	appendSelect := func(predicate string, values ...any) {
+		selects = append(selects, `SELECT file_path
+			FROM sessions
+			WHERE agent = ?
+			  AND file_path IS NOT NULL
+			  AND deleted_at IS NULL
+			  AND `+predicate)
+		args = append(args, agent)
+		args = append(args, values...)
+	}
+	for _, scope := range scopes {
+		root := cleanStoredSourcePathHint(scope.Path)
 		if root == "" || root == "." {
 			continue
 		}
-		likeRoot := sqliteLikeEscape(root)
-		clauses = append(clauses,
-			`(file_path = ? OR
-			  file_path LIKE ? ESCAPE '!' OR
-			  file_path LIKE ? ESCAPE '!')`,
-		)
-		args = append(args,
-			root,
-			likeRoot+string(filepath.Separator)+"%",
-			likeRoot+"#%",
-		)
+		descendantPrefix, descendantEnd := activeSessionSourceBounds(root)
+		appendSelect(`file_path = ?`, root)
+		appendSelect(`file_path >= ? AND file_path < ?`, descendantPrefix, descendantEnd)
+		if scope.IncludeVirtualMembers {
+			appendSelect(`file_path >= ? AND file_path < ?`, root+"#", root+"$")
+		}
 	}
-	if len(clauses) == 0 {
+	if len(selects) == 0 {
 		return `SELECT file_path FROM sessions WHERE 0`, nil
 	}
-	query := `SELECT file_path
-		FROM sessions
-		WHERE agent = ?
-		  AND file_path IS NOT NULL
-		  AND deleted_at IS NULL
-		  AND (` + strings.Join(clauses, " OR ") + `)
+	query := `SELECT file_path FROM (` + strings.Join(selects, " UNION ALL ") + `)
 		ORDER BY file_path`
 	return query, args
 }
@@ -2275,30 +2812,29 @@ func cleanStoredSourcePathHint(path string) string {
 	return filepath.Clean(path)
 }
 
-func storedSourcePathHintInAnyRoot(path string, roots []string) bool {
-	for _, root := range roots {
-		if storedSourcePathHintInRoot(path, root) {
+func storedSourcePathHintInAnyRoot(
+	path string,
+	scopes []StoredSourcePathHintScope,
+) bool {
+	for _, scope := range scopes {
+		if storedSourcePathHintInRoot(path, scope) {
 			return true
 		}
 	}
 	return false
 }
 
-func storedSourcePathHintInRoot(path, root string) bool {
+func storedSourcePathHintInRoot(path string, scope StoredSourcePathHintScope) bool {
 	path = cleanStoredSourcePathHint(path)
-	root = cleanStoredSourcePathHint(root)
+	root := cleanStoredSourcePathHint(scope.Path)
 	if path == root || strings.HasPrefix(path, root+string(filepath.Separator)) {
 		return true
 	}
 	suffix, ok := strings.CutPrefix(path, root+"#")
 	return ok &&
-		storedSourcePathHintAllowsVirtualSuffix(root) &&
+		scope.IncludeVirtualMembers &&
 		suffix != "" &&
 		!strings.ContainsAny(suffix, `/\`)
-}
-
-func storedSourcePathHintAllowsVirtualSuffix(root string) bool {
-	return filepath.Ext(root) != ""
 }
 
 func sqliteLikeEscape(value string) string {
@@ -2308,14 +2844,15 @@ func sqliteLikeEscape(value string) string {
 	return value
 }
 
-// GetDataVersionByPath returns the minimum data_version for
-// sessions matching a file_path. Returns 0 when no session
-// exists for the path.
+// GetDataVersionByPath returns the minimum data_version for non-source-missing
+// sessions matching a file_path. Returns 0 when no eligible session exists.
 func (db *DB) GetDataVersionByPath(path string) int {
 	var v int
 	err := db.getReader().QueryRow(
 		"SELECT MIN(data_version) FROM sessions"+
-			" WHERE file_path = ?", path,
+			" WHERE file_path = ?"+
+			" AND (deletion_cause IS NULL"+
+			" OR deletion_cause <> '"+deletionCauseSourceMissing+"')", path,
 	).Scan(&v)
 	if err != nil {
 		return 0
@@ -2483,7 +3020,8 @@ func (db *DB) DeleteSessionIfTrashed(id string) (int64, error) {
 	res, err := tx.Exec(
 		`UPDATE sessions
 		 SET deleted_at = deleted_at
-		 WHERE id = ? AND deleted_at IS NOT NULL`,
+		 WHERE id = ? AND deleted_at IS NOT NULL
+		   AND deletion_cause IS NULL`,
 		id,
 	)
 	if err != nil {
@@ -2496,7 +3034,7 @@ func (db *DB) DeleteSessionIfTrashed(id string) (int64, error) {
 		return 0, nil
 	}
 	aliasIDs, err := sessionAliasIDsTx(
-		tx, "id = ? AND deleted_at IS NOT NULL", id,
+		tx, "id = ? AND deleted_at IS NOT NULL AND deletion_cause IS NULL", id,
 	)
 	if err != nil {
 		return 0, err
@@ -2509,7 +3047,8 @@ func (db *DB) DeleteSessionIfTrashed(id string) (int64, error) {
 	}
 
 	res, err = tx.Exec(
-		"DELETE FROM sessions WHERE id = ? AND deleted_at IS NOT NULL",
+		"DELETE FROM sessions WHERE id = ? AND deleted_at IS NOT NULL"+
+			" AND deletion_cause IS NULL",
 		id,
 	)
 	if err != nil {
@@ -2863,22 +3402,26 @@ func (db *DB) FindPruneCandidates(
 	return sessions, rows.Err()
 }
 
-// SoftDeleteSession marks a session as deleted by setting deleted_at.
+// SoftDeleteSession moves an active session to user trash. A recoverable
+// source-missing tombstone is converted to user trash so later source return
+// cannot revive a session the user explicitly removed.
 func (db *DB) SoftDeleteSession(id string) error {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 	_, err := db.getWriter().Exec(
 		`UPDATE sessions
 		 SET deleted_at = strftime('%Y-%m-%dT%H:%M:%fZ','now'),
+		     deletion_cause = NULL,
 		     local_modified_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
-		 WHERE id = ? AND deleted_at IS NULL`, id,
+		 WHERE id = ?
+		   AND (deleted_at IS NULL OR deletion_cause = '`+deletionCauseSourceMissing+`')`, id,
 	)
 	return err
 }
 
-// SoftDeleteSessions marks multiple sessions as deleted by setting
-// deleted_at. Sessions that are already soft-deleted are skipped.
-// Returns the count of newly deleted rows.
+// SoftDeleteSessions moves multiple sessions to user trash. Existing user
+// tombstones are skipped; recoverable source-missing tombstones are converted.
+// Returns the count of newly deleted or converted rows.
 func (db *DB) SoftDeleteSessions(ids []string) (int, error) {
 	if len(ids) == 0 {
 		return 0, nil
@@ -2908,8 +3451,10 @@ func (db *DB) SoftDeleteSessions(ids []string) (int, error) {
 		res, err := tx.Exec(
 			`UPDATE sessions
 			 SET deleted_at = strftime('%Y-%m-%dT%H:%M:%fZ','now'),
+			     deletion_cause = NULL,
 			     local_modified_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
-			 WHERE id IN (`+placeholders+`) AND deleted_at IS NULL`,
+			 WHERE id IN (`+placeholders+`)
+			   AND (deleted_at IS NULL OR deletion_cause = '`+deletionCauseSourceMissing+`')`,
 			args...,
 		)
 		if err != nil {
@@ -2931,17 +3476,37 @@ func (db *DB) SoftDeleteSessions(ids []string) (int, error) {
 func (db *DB) RestoreSession(id string) (int64, error) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
-	res, err := db.getWriter().Exec(
+	tx, err := db.getWriter().BeginTx(context.Background(), nil)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	res, err := tx.Exec(
 		`UPDATE sessions
 		 SET deleted_at = NULL,
+		     deletion_cause = NULL,
 		     local_modified_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
-		 WHERE id = ? AND deleted_at IS NOT NULL`,
+		 WHERE id = ? AND deleted_at IS NOT NULL
+		   AND deletion_cause IS NULL`,
 		id,
 	)
 	if err != nil {
 		return 0, err
 	}
-	n, _ := res.RowsAffected()
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	if n > 0 {
+		if _, err := tx.Exec(
+			"DELETE FROM local_session_source_baselines WHERE session_id = ?", id,
+		); err != nil {
+			return 0, err
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
 	return n, nil
 }
 
@@ -2966,6 +3531,7 @@ func (db *DB) ListTrashedSessions(
 ) ([]Session, error) {
 	query := "SELECT " + sessionBaseCols +
 		" FROM sessions WHERE deleted_at IS NOT NULL" +
+		" AND deletion_cause IS NULL" +
 		" ORDER BY deleted_at DESC LIMIT 500"
 	rows, err := db.getReader().QueryContext(ctx, query)
 	if err != nil {
@@ -2994,16 +3560,20 @@ func (db *DB) EmptyTrash() (int, error) {
 	if _, err := tx.Exec(
 		`UPDATE sessions
 		 SET deleted_at = deleted_at
-		 WHERE deleted_at IS NOT NULL`,
+		 WHERE deleted_at IS NOT NULL AND deletion_cause IS NULL`,
 	); err != nil {
 		return 0, fmt.Errorf("locking trashed sessions: %w", err)
 	}
 
-	aliasIDs, err := sessionAliasIDsTx(tx, "deleted_at IS NOT NULL")
+	aliasIDs, err := sessionAliasIDsTx(
+		tx, "deleted_at IS NOT NULL AND deletion_cause IS NULL",
+	)
 	if err != nil {
 		return 0, err
 	}
-	ids, err := sessionIDsTx(tx, "deleted_at IS NOT NULL")
+	ids, err := sessionIDsTx(
+		tx, "deleted_at IS NOT NULL AND deletion_cause IS NULL",
+	)
 	if err != nil {
 		return 0, err
 	}
@@ -3011,7 +3581,8 @@ func (db *DB) EmptyTrash() (int, error) {
 	// Record all trashed session IDs before deleting.
 	if _, err := tx.Exec(
 		`INSERT OR IGNORE INTO excluded_sessions (id)
-		 SELECT id FROM sessions WHERE deleted_at IS NOT NULL`,
+		 SELECT id FROM sessions
+		 WHERE deleted_at IS NOT NULL AND deletion_cause IS NULL`,
 	); err != nil {
 		return 0, fmt.Errorf("excluding trashed sessions: %w", err)
 	}
@@ -3031,7 +3602,8 @@ func (db *DB) EmptyTrash() (int, error) {
 		}
 	}
 	res, err := tx.Exec(
-		"DELETE FROM sessions WHERE deleted_at IS NOT NULL",
+		"DELETE FROM sessions WHERE deleted_at IS NOT NULL" +
+			" AND deletion_cause IS NULL",
 	)
 	if err != nil {
 		return 0, fmt.Errorf("emptying trash: %w", err)
@@ -3244,7 +3816,8 @@ func (db *DB) ListSessionsModifiedBetween(
 			&s.TranscriptFidelity,
 			&s.ParserMalformedLines, &s.IsTruncated,
 			&s.LastWriteIncremental,
-			&s.DeletedAt, &s.TerminationStatus, &s.FilePath, &s.FileSize,
+			&s.DeletedAt, &s.DeletionCause,
+			&s.TerminationStatus, &s.FilePath, &s.FileSize,
 			&s.FileMtime, &s.NextOrdinal, &s.LastEntryUUID,
 			&s.FileInode, &s.FileDevice,
 			&s.FileHash, &s.LocalModifiedAt,
@@ -3352,7 +3925,8 @@ func (db *DB) ListSessionsForMirrorWindow(
 			&s.TranscriptFidelity,
 			&s.ParserMalformedLines, &s.IsTruncated,
 			&s.LastWriteIncremental,
-			&s.DeletedAt, &s.TerminationStatus, &s.FilePath, &s.FileSize,
+			&s.DeletedAt, &s.DeletionCause,
+			&s.TerminationStatus, &s.FilePath, &s.FileSize,
 			&s.FileMtime, &s.NextOrdinal, &s.LastEntryUUID,
 			&s.FileInode, &s.FileDevice,
 			&s.FileHash, &s.LocalModifiedAt,

--- a/internal/db/skipped.go
+++ b/internal/db/skipped.go
@@ -81,3 +81,17 @@ func (db *DB) DeleteSkippedFile(path string) error {
 	)
 	return err
 }
+
+// DeleteSkippedFileAndPrefix removes one exact cache key and every variant
+// beginning with prefix. Sync uses this for hash-qualified source keys so a
+// tombstone cannot leave a durable sibling that survives process restart.
+func (db *DB) DeleteSkippedFileAndPrefix(path, prefix string) error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	_, err := db.getWriter().Exec(
+		`DELETE FROM skipped_files
+		 WHERE file_path = ? OR substr(file_path, 1, length(?)) = ?`,
+		path, prefix, prefix,
+	)
+	return err
+}

--- a/internal/db/source_path_exists.go
+++ b/internal/db/source_path_exists.go
@@ -1,0 +1,50 @@
+package db
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+const hasActiveSessionSourceBelowQuery = `
+	SELECT 1
+	FROM sessions
+	WHERE agent = ?
+	  AND file_path >= ?
+	  AND file_path < ?
+	  AND file_path IS NOT NULL
+	  AND deleted_at IS NULL
+	LIMIT 1`
+
+// HasActiveSessionSourceBelow reports whether the local archive contains an
+// active source beneath path for agent. This watcher lookup intentionally
+// remains on the writable SQLite DB rather than the server Store contract:
+// filesystem events and their source-path reconciliation are local-only state,
+// so PostgreSQL/Cockroach read backends cannot observe or service the query.
+func (db *DB) HasActiveSessionSourceBelow(agent, path string) (bool, error) {
+	lower, upper := activeSessionSourceBounds(path)
+	var one int
+	err := db.getReader().QueryRow(
+		hasActiveSessionSourceBelowQuery, agent, lower, upper,
+	).Scan(&one)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("checking active %s source below %q: %w", agent, path, err)
+	}
+	return true, nil
+}
+
+func activeSessionSourceBounds(path string) (lower, upper string) {
+	separator := byte(filepath.Separator)
+	lower = filepath.Clean(path)
+	if !strings.HasSuffix(lower, string(filepath.Separator)) {
+		lower += string(filepath.Separator)
+	}
+	upperBytes := []byte(lower)
+	upperBytes[len(upperBytes)-1] = separator + 1
+	return lower, string(upperBytes)
+}

--- a/internal/db/source_path_exists_test.go
+++ b/internal/db/source_path_exists_test.go
@@ -1,0 +1,107 @@
+package db
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasActiveSessionSourceBelow(t *testing.T) {
+	database := testDB(t)
+	base := filepath.Join(t.TempDir(), "sessions%_用户")
+	activePath := filepath.Join(base, "nested", "active.jsonl")
+	deletedPath := filepath.Join(base, "deleted", "gone.jsonl")
+	siblingPath := base + "-sibling" + string(filepath.Separator) + "other.jsonl"
+	otherAgentDir := filepath.Join(base, "only-other-agent")
+	otherAgentPath := filepath.Join(otherAgentDir, "session.jsonl")
+
+	for _, session := range []struct {
+		id, agent, path string
+	}{
+		{id: "active", agent: "codex", path: activePath},
+		{id: "deleted", agent: "codex", path: deletedPath},
+		{id: "sibling", agent: "codex", path: siblingPath},
+		{id: "other-agent", agent: "claude", path: otherAgentPath},
+	} {
+		path := session.path
+		insertSession(t, database, session.id, "project", func(s *Session) {
+			s.Agent = session.agent
+			s.FilePath = &path
+		})
+	}
+	require.NoError(t, database.SoftDeleteSession("deleted"))
+
+	tests := []struct {
+		name, agent, path string
+		want              bool
+	}{
+		{name: "active descendant", agent: "codex", path: base, want: true},
+		{name: "deleted descendant", agent: "codex", path: filepath.Join(base, "deleted")},
+		{name: "sibling prefix", agent: "codex", path: base + "-sib"},
+		{name: "other agent", agent: "codex", path: otherAgentDir},
+		{name: "path itself is not below", agent: "codex", path: activePath},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := database.HasActiveSessionSourceBelow(tc.agent, tc.path)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+
+	var positivePlan []string
+	for _, tc := range []struct {
+		name, path string
+		wantRows   []int
+	}{
+		{name: "positive prefix", path: base, wantRows: []int{1}},
+		{name: "negative prefix", path: filepath.Join(base, "absent")},
+	} {
+		t.Run(tc.name+" query shape", func(t *testing.T) {
+			lower, upper := activeSessionSourceBounds(tc.path)
+			rows, err := database.getReader().Query(
+				hasActiveSessionSourceBelowQuery,
+				"codex", lower, upper,
+			)
+			require.NoError(t, err)
+			var gotRows []int
+			for rows.Next() {
+				var one int
+				require.NoError(t, rows.Scan(&one))
+				gotRows = append(gotRows, one)
+			}
+			require.NoError(t, rows.Err())
+			require.NoError(t, rows.Close())
+			assert.Equal(t, tc.wantRows, gotRows,
+				"the prefix probe must return at most its one sentinel row")
+
+			planRows, err := database.getReader().Query(
+				"EXPLAIN QUERY PLAN "+hasActiveSessionSourceBelowQuery,
+				"codex", lower, upper,
+			)
+			require.NoError(t, err)
+			var plan []string
+			for planRows.Next() {
+				var id, parent, unused int
+				var detail string
+				require.NoError(t, planRows.Scan(&id, &parent, &unused, &detail))
+				plan = append(plan, detail)
+			}
+			require.NoError(t, planRows.Err())
+			require.NoError(t, planRows.Close())
+			assert.Condition(t, func() bool {
+				return strings.Contains(strings.Join(plan, "\n"),
+					"idx_sessions_agent_file_path_active (agent=? AND file_path>? AND file_path<?)")
+			}, "expected indexed agent/path range seek, plans: %v", plan)
+			if tc.wantRows != nil {
+				positivePlan = append([]string(nil), plan...)
+			} else {
+				assert.Equal(t, positivePlan, plan,
+					"positive and negative probes must use the same index seek")
+			}
+		})
+	}
+}

--- a/internal/db/source_path_hints_test.go
+++ b/internal/db/source_path_hints_test.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -32,10 +33,10 @@ func TestListStoredSourcePathHintsScopesByAgentAndRoot(t *testing.T) {
 	insertSessionWithSourcePath(t, d, "claude:deleted", "claude", deletedPath)
 	require.NoError(t, d.SoftDeleteSession("claude:deleted"))
 
-	got, err := d.ListStoredSourcePathHints("claude", []string{
+	got, err := d.ListStoredSourcePathHints("claude", storedSourcePathHintScopes(
 		filepath.Join(watchRoot, "."),
 		filepath.Join(root, "db2", "..", "db"),
-	})
+	))
 
 	require.NoError(t, err)
 	assert.Equal(t, []string{
@@ -66,10 +67,10 @@ func TestListStoredSourcePathHintsHandlesHashPathsAndVirtualSuffixes(t *testing.
 		t, d, "claude:hash-virtual-sibling", "claude", hashVirtualSibling,
 	)
 
-	got, err := d.ListStoredSourcePathHints("claude", []string{
-		hashRoot,
-		dbRoot,
-		plainRoot,
+	got, err := d.ListStoredSourcePathHints("claude", []StoredSourcePathHintScope{
+		{Path: hashRoot},
+		{Path: dbRoot, IncludeVirtualMembers: true},
+		{Path: plainRoot},
 	})
 
 	require.NoError(t, err)
@@ -77,6 +78,61 @@ func TestListStoredSourcePathHintsHandlesHashPathsAndVirtualSuffixes(t *testing.
 		hashChild,
 		virtualPath,
 	}, got)
+}
+
+func TestListStoredSourcePathHintsIncludesDeclaredExtensionlessVirtualMembers(t *testing.T) {
+	d := testDB(t)
+	base := t.TempDir()
+	container := filepath.Join(base, "conversation")
+	member := container + "#conversation-a"
+	sibling := container + "-sibling#conversation-b"
+	child := filepath.Join(container, "child.jsonl")
+	insertSessionWithSourcePath(t, d, "visualstudio-copilot:member", "visualstudio-copilot", member)
+	insertSessionWithSourcePath(t, d, "visualstudio-copilot:sibling", "visualstudio-copilot", sibling)
+	insertSessionWithSourcePath(t, d, "visualstudio-copilot:child", "visualstudio-copilot", child)
+
+	got, err := d.ListStoredSourcePathHints("visualstudio-copilot", []StoredSourcePathHintScope{{
+		Path: container, IncludeVirtualMembers: true,
+	}})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{member, child}, got)
+
+	ordinary, err := d.ListStoredSourcePathHints("visualstudio-copilot", []StoredSourcePathHintScope{{
+		Path: container,
+	}})
+	require.NoError(t, err)
+	assert.Equal(t, []string{child}, ordinary,
+		"ordinary prefixes must not claim hash-delimited siblings")
+}
+
+// TestListStoredSourcePathHintsLimitVirtualMembersToSingleSegments pins the
+// Go re-filter (storedSourcePathHintInRoot) that trims the deliberately wide
+// SQL virtual range [root+"#", root+"$") in storedSourcePathHintQuery: rows
+// with an empty or nested container suffix are ordinary paths owned by other
+// sources and must never surface as hints, or the changed-path force-replace
+// path (providerSourceSessionOwnershipsForForceReplace) could tombstone them.
+func TestListStoredSourcePathHintsLimitVirtualMembersToSingleSegments(t *testing.T) {
+	d := testDB(t)
+	root := t.TempDir()
+	stateDB := filepath.Join(root, "state.db")
+	member := stateDB + "#member1"
+	insertSessionWithSourcePath(t, d, "hermes:member", "hermes", member)
+	insertSessionWithSourcePath(
+		t, d, "hermes:nested-slash", "hermes", stateDB+"#backup/session.json",
+	)
+	insertSessionWithSourcePath(
+		t, d, "hermes:nested-backslash", "hermes", stateDB+`#a\b`,
+	)
+	insertSessionWithSourcePath(t, d, "hermes:empty-suffix", "hermes", stateDB+"#")
+
+	got, err := d.ListStoredSourcePathHints("hermes", []StoredSourcePathHintScope{{
+		Path: stateDB, IncludeVirtualMembers: true,
+	}})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{member}, got,
+		"nested and empty container suffixes are ordinary paths, not virtual members")
 }
 
 func TestListStoredSourcePathHintsEscapesLikeWildcards(t *testing.T) {
@@ -90,7 +146,7 @@ func TestListStoredSourcePathHintsEscapesLikeWildcards(t *testing.T) {
 	siblingPath := filepath.Join(base, "dbX!Yroot", "session.jsonl")
 	insertSessionWithSourcePath(t, d, "claude:wildcard-sibling", "claude", siblingPath)
 
-	got, err := d.ListStoredSourcePathHints("claude", []string{root})
+	got, err := d.ListStoredSourcePathHints("claude", storedSourcePathHintScopes(root))
 
 	require.NoError(t, err)
 	assert.Equal(t, []string{childPath}, got)
@@ -126,17 +182,17 @@ func TestListStoredSourcePathHintsBatchesRootsWithoutTruncating(t *testing.T) {
 	}
 	insertSessionsWithSourcePaths(t, d, seeds)
 
-	got, err := d.ListStoredSourcePathHints("claude", roots)
+	got, err := d.ListStoredSourcePathHints("claude", storedSourcePathHintScopes(roots...))
 
 	require.NoError(t, err)
 	assert.Equal(t, want, got)
 }
 
-func TestStoredSourcePathHintsLookupUsesAgentFilePathIndex(t *testing.T) {
+func TestStoredSourcePathHintsLookupUsesAgentFilePathRangeSeek(t *testing.T) {
 
 	d := testDB(t)
 	root := t.TempDir()
-	explainSQL, args := storedSourcePathHintQuery("claude", []string{root})
+	explainSQL, args := storedSourcePathHintQuery("claude", storedSourcePathHintScopes(root))
 	rows, err := d.getReader().Query("EXPLAIN QUERY PLAN "+explainSQL, args...)
 	require.NoError(t, err)
 	defer rows.Close()
@@ -150,11 +206,711 @@ func TestStoredSourcePathHintsLookupUsesAgentFilePathIndex(t *testing.T) {
 	}
 	require.NoError(t, rows.Err())
 
-	assert.Contains(
-		t,
-		strings.Join(details, "\n"),
-		"idx_sessions_agent_file_path_active",
+	plan := strings.Join(details, "\n")
+	assert.Contains(t, plan, "idx_sessions_agent_file_path_active")
+	assert.Contains(t, plan, "file_path>? AND file_path<?",
+		"hint lookup must seek affected path ranges, not scan every source for the agent")
+}
+
+func storedSourcePathHintScopes(paths ...string) []StoredSourcePathHintScope {
+	scopes := make([]StoredSourcePathHintScope, 0, len(paths))
+	for _, path := range paths {
+		scopes = append(scopes, StoredSourcePathHintScope{Path: path})
+	}
+	return scopes
+}
+
+func TestStoredSourcePathHintVirtualMemberLookupUsesBoundedRangeSeek(t *testing.T) {
+	d := testDB(t)
+	root := filepath.Join(t.TempDir(), "conversation")
+	explainSQL, args := storedSourcePathHintQuery("visualstudio-copilot", []StoredSourcePathHintScope{{
+		Path: root, IncludeVirtualMembers: true,
+	}})
+	rows, err := d.getReader().Query("EXPLAIN QUERY PLAN "+explainSQL, args...)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var details []string
+	for rows.Next() {
+		var id, parent, notused int
+		var detail string
+		require.NoError(t, rows.Scan(&id, &parent, &notused, &detail))
+		details = append(details, detail)
+	}
+	require.NoError(t, rows.Err())
+
+	plan := strings.Join(details, "\n")
+	assert.Contains(t, plan, "idx_sessions_agent_file_path_active")
+	assert.GreaterOrEqual(t, strings.Count(plan, "file_path>? AND file_path<?"), 2,
+		"directory children and virtual members must each use bounded seeks")
+}
+
+func TestListActiveSessionSourceOwnershipScopesPageUsesStableBoundedKeyset(t *testing.T) {
+	d := testDB(t)
+	root := t.TempDir()
+	seeds := make([]storedSourcePathSeed, 0, WatchReconcileSourcePageSize+3)
+	for i := range WatchReconcileSourcePageSize + 3 {
+		path := filepath.Join(root, fmt.Sprintf("source-%03d.jsonl", i/2))
+		seeds = append(seeds, storedSourcePathSeed{
+			id: fmt.Sprintf("session-%03d", i), agent: "claude", path: path,
+		})
+	}
+	insertSessionsWithSourcePaths(t, d, seeds)
+	require.NoError(t, d.BaselineActiveSessionSourcePaths(
+		t.Context(), defaultMachine, sourcePathsFromSeeds(seeds),
+	))
+
+	first, err := d.ListActiveSessionSourceOwnershipScopesPage(
+		t.Context(), defaultMachine, "claude",
+		[]StoredSourcePathHintScope{{Path: root}}, SessionSourceCursor{},
 	)
+	require.NoError(t, err)
+	require.Len(t, first, WatchReconcileSourcePageSize)
+	second, err := d.ListActiveSessionSourceOwnershipScopesPage(
+		t.Context(), defaultMachine, "claude",
+		[]StoredSourcePathHintScope{{Path: root}}, first[len(first)-1].Cursor(),
+	)
+	require.NoError(t, err)
+	require.Len(t, second, 3)
+
+	got := append(first, second...)
+	require.Len(t, got, len(seeds))
+	for i, ownership := range got {
+		assert.Equal(t, seeds[i].id, ownership.ID)
+		assert.Equal(t, seeds[i].path, ownership.FilePath)
+		assert.Equal(t, "claude", ownership.Agent)
+	}
+}
+
+func TestListActiveSessionSourceOwnershipScopesPagePagesVirtualMembersOnce(t *testing.T) {
+	d := testDB(t)
+	root := t.TempDir()
+	ownedRoot := filepath.Join(root, "z-owned")
+	stateDB := filepath.Join(ownedRoot, "state.db")
+	sessionsDir := filepath.Join(ownedRoot, "sessions")
+	seeds := make([]storedSourcePathSeed, 0, WatchReconcileSourcePageSize+4)
+	for i := range WatchReconcileSourcePageSize + 3 {
+		seeds = append(seeds, storedSourcePathSeed{
+			id:    fmt.Sprintf("hermes:%03d", i),
+			agent: "hermes",
+			path:  fmt.Sprintf("%s#member-%03d", stateDB, i),
+		})
+	}
+	seeds = append(seeds, storedSourcePathSeed{
+		id: "hermes:transcript", agent: "hermes",
+		path: filepath.Join(sessionsDir, "transcript.jsonl"),
+	})
+	unrelated := storedSourcePathSeed{
+		id: "hermes:unrelated", agent: "hermes",
+		path: filepath.Join(root, "other.db") + "#member",
+	}
+	insertSessionsWithSourcePaths(t, d, append(seeds, unrelated))
+	require.NoError(t, d.BaselineActiveSessionSourcePaths(
+		t.Context(), defaultMachine,
+		sourcePathsFromSeeds(append(seeds, unrelated)),
+	))
+
+	scopes := make([]StoredSourcePathHintScope, 0,
+		watchReconcileOwnershipScopeBatchSize+2)
+	for i := range watchReconcileOwnershipScopeBatchSize {
+		scopes = append(scopes, StoredSourcePathHintScope{
+			Path: filepath.Join(root, fmt.Sprintf("a-empty-scope-%02d", i)),
+		})
+	}
+	scopes = append(scopes,
+		StoredSourcePathHintScope{Path: stateDB, IncludeVirtualMembers: true},
+		StoredSourcePathHintScope{Path: sessionsDir},
+	)
+	normalizedScopes := normalizeStoredSourcePathHintScopes(scopes)
+	firstMatchingScope := len(normalizedScopes)
+	for i, scope := range normalizedScopes {
+		if scope.Path == stateDB || scope.Path == sessionsDir {
+			firstMatchingScope = i
+			break
+		}
+	}
+	require.GreaterOrEqual(t, firstMatchingScope,
+		watchReconcileOwnershipScopeBatchSize,
+		"all matching scopes must be outside the first SQL batch")
+	var got []SessionSourceOwnership
+	var cursor SessionSourceCursor
+	pageCount := 0
+	for {
+		page, err := d.ListActiveSessionSourceOwnershipScopesPage(
+			t.Context(), defaultMachine, "hermes", scopes, cursor,
+		)
+		require.NoError(t, err)
+		pageCount++
+		got = append(got, page...)
+		if len(page) < WatchReconcileSourcePageSize {
+			break
+		}
+		cursor = page[len(page)-1].Cursor()
+	}
+
+	require.Len(t, got, len(seeds),
+		"later batches must page each row once and keep sibling containers excluded")
+	assert.GreaterOrEqual(t, pageCount, 2,
+		"later-batch ownership must cross the global keyset page boundary")
+	gotIDs := make(map[string]struct{}, len(got))
+	for _, ownership := range got {
+		gotIDs[ownership.ID] = struct{}{}
+	}
+	for _, seed := range seeds {
+		assert.Contains(t, gotIDs, seed.id)
+	}
+	assert.NotContains(t, gotIDs, unrelated.id)
+}
+
+func TestListActiveSessionSourceOwnershipScopesPageBoundsSQLParameters(t *testing.T) {
+	d := testDB(t)
+	root := t.TempDir()
+	stateDB := filepath.Join(root, "zz-state.db")
+	seed := storedSourcePathSeed{
+		id: "hermes:member", agent: "hermes", path: stateDB + "#member",
+	}
+	insertSessionsWithSourcePaths(t, d, []storedSourcePathSeed{seed})
+	require.NoError(t, d.BaselineActiveSessionSourcePaths(
+		t.Context(), defaultMachine, sourcePathsFromSeeds([]storedSourcePathSeed{seed}),
+	))
+
+	const scopeCount = 8300 // More than 32,766 parameters in the unbatched query.
+	scopes := make([]StoredSourcePathHintScope, 0, scopeCount)
+	for i := range scopeCount - 1 {
+		scopes = append(scopes, StoredSourcePathHintScope{
+			Path:                  filepath.Join(root, fmt.Sprintf("aa-unrelated-%05d.db", i)),
+			IncludeVirtualMembers: true,
+		})
+	}
+	scopes = append(scopes, StoredSourcePathHintScope{
+		Path: stateDB, IncludeVirtualMembers: true,
+	})
+	normalizedScopes := normalizeStoredSourcePathHintScopes(scopes)
+	require.Equal(t, stateDB, normalizedScopes[len(normalizedScopes)-1].Path,
+		"the sole matching scope must remain in the final SQL batch")
+
+	page, err := d.ListActiveSessionSourceOwnershipScopesPage(
+		t.Context(), defaultMachine, "hermes", scopes, SessionSourceCursor{},
+	)
+	require.NoError(t, err)
+	require.Len(t, page, 1)
+	assert.Equal(t, seed.id, page[0].ID)
+}
+
+func TestListActiveSessionSourceOwnershipScopesPageLimitsVirtualMembersToSingleSegments(t *testing.T) {
+	d := testDB(t)
+	root := t.TempDir()
+	stateDB := filepath.Join(root, "state.db")
+	member := storedSourcePathSeed{
+		id: "hermes:member", agent: "hermes", path: stateDB + "#member1",
+	}
+	seeds := []storedSourcePathSeed{
+		member,
+		{id: "hermes:nested-slash", agent: "hermes", path: stateDB + "#backup/session.json"},
+		{id: "hermes:nested-backslash", agent: "hermes", path: stateDB + `#a\b`},
+		{id: "hermes:empty-suffix", agent: "hermes", path: stateDB + "#"},
+	}
+	insertSessionsWithSourcePaths(t, d, seeds)
+	require.NoError(t, d.BaselineActiveSessionSourcePaths(
+		t.Context(), defaultMachine, sourcePathsFromSeeds(seeds),
+	))
+
+	page, err := d.ListActiveSessionSourceOwnershipScopesPage(
+		t.Context(), defaultMachine, "hermes",
+		[]StoredSourcePathHintScope{{Path: stateDB, IncludeVirtualMembers: true}},
+		SessionSourceCursor{},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, page, 1,
+		"nested and empty container suffixes are ordinary paths, not virtual members")
+	assert.Equal(t, member.id, page[0].ID)
+	assert.Equal(t, member.path, page[0].FilePath)
+}
+
+func TestSourceBaselineRequiresObservedExactSameMachineOwnership(t *testing.T) {
+	d := testDB(t)
+	root := t.TempDir()
+	observed := filepath.Join(root, "observed.jsonl")
+	unobserved := filepath.Join(root, "historical.jsonl")
+	foreign := filepath.Join(root, "foreign.jsonl")
+	insertSessionWithSourcePath(t, d, "observed", "claude", observed)
+	insertSessionWithSourcePath(t, d, "historical", "claude", unobserved)
+	insertSessionWithSourcePath(t, d, "foreign", "claude", foreign, func(s *Session) {
+		s.Machine = "other-machine"
+	})
+
+	require.NoError(t, d.BaselineActiveSessionSourcePaths(
+		t.Context(), defaultMachine, []SessionSourcePath{
+			{Agent: "claude", FilePath: observed},
+			{Agent: "claude", FilePath: foreign},
+		},
+	))
+	page, err := d.ListActiveSessionSourceOwnershipScopesPage(
+		t.Context(), defaultMachine, "claude",
+		[]StoredSourcePathHintScope{{Path: root}}, SessionSourceCursor{},
+	)
+	require.NoError(t, err)
+	require.Len(t, page, 1)
+	assert.Equal(t, "observed", page[0].ID)
+	assert.Equal(t, defaultMachine, page[0].Machine)
+
+	changed, err := d.SoftDeleteSessionSourceOwnership(
+		t.Context(), defaultMachine, "claude", "historical", unobserved,
+	)
+	require.NoError(t, err)
+	assert.False(t, changed, "unobserved historical ownership must remain active")
+	changed, err = d.SoftDeleteSessionSourceOwnership(
+		t.Context(), defaultMachine, "claude", "foreign", foreign,
+	)
+	require.NoError(t, err)
+	assert.False(t, changed, "another machine cannot borrow the local baseline")
+	changed, err = d.SoftDeleteSessionSourceOwnership(
+		t.Context(), defaultMachine, "claude", "observed", observed,
+	)
+	require.NoError(t, err)
+	assert.True(t, changed)
+}
+
+func TestSourceBaselineDoesNotAuthorizeReassignedPath(t *testing.T) {
+	d := testDB(t)
+	root := t.TempDir()
+	oldPath := filepath.Join(root, "old.jsonl")
+	newPath := filepath.Join(root, "new.jsonl")
+	insertSessionWithSourcePath(t, d, "session", "claude", oldPath)
+	require.NoError(t, d.BaselineActiveSessionSourcePaths(
+		t.Context(), defaultMachine,
+		[]SessionSourcePath{{Agent: "claude", FilePath: oldPath}},
+	))
+	insertSessionWithSourcePath(t, d, "session", "claude", newPath)
+
+	changed, err := d.SoftDeleteSessionSourceOwnership(
+		t.Context(), defaultMachine, "claude", "session", newPath,
+	)
+	require.NoError(t, err)
+	assert.False(t, changed, "the old exact-path baseline must not authorize a new path")
+	require.NoError(t, d.BaselineActiveSessionSourcePaths(
+		t.Context(), defaultMachine,
+		[]SessionSourcePath{{Agent: "claude", FilePath: newPath}},
+	))
+	changed, err = d.SoftDeleteSessionSourceOwnership(
+		t.Context(), defaultMachine, "claude", "session", newPath,
+	)
+	require.NoError(t, err)
+	assert.True(t, changed)
+}
+
+func TestSourceBaselineTreatsVirtualAndLiteralHashPathsAsExact(t *testing.T) {
+	d := testDB(t)
+	root := t.TempDir()
+	literal := filepath.Join(root, "project#1", "session.jsonl")
+	virtual := filepath.Join(root, "container") + "#member"
+	insertSessionWithSourcePath(t, d, "literal", "claude", literal)
+	insertSessionWithSourcePath(t, d, "virtual", "aider", virtual)
+	require.NoError(t, d.BaselineActiveSessionSourcePaths(
+		t.Context(), defaultMachine, []SessionSourcePath{
+			{Agent: "claude", FilePath: literal},
+			{Agent: "aider", FilePath: virtual},
+		},
+	))
+
+	for id, want := range map[string]string{
+		"literal": literal,
+		"virtual": virtual,
+	} {
+		var got string
+		require.NoError(t, d.getReader().QueryRow(
+			"SELECT file_path FROM local_session_source_baselines WHERE session_id = ?", id,
+		).Scan(&got))
+		assert.Equal(t, want, got)
+	}
+}
+
+func TestSourceBaselineDoesNotRewriteAlreadyObservedOwnership(t *testing.T) {
+	d := testDB(t)
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	insertSessionWithSourcePath(t, d, "session", "claude", path)
+	_, err := d.getWriter().Exec(`
+		CREATE TABLE source_baseline_update_observer (updates INTEGER NOT NULL);
+		INSERT INTO source_baseline_update_observer VALUES (0);
+		CREATE TRIGGER observe_source_baseline_insert
+		AFTER INSERT ON local_session_source_baselines
+		BEGIN
+			UPDATE source_baseline_update_observer SET updates = updates + 1;
+		END;
+		CREATE TRIGGER observe_source_baseline_update
+		AFTER UPDATE ON local_session_source_baselines
+		BEGIN
+			UPDATE source_baseline_update_observer SET updates = updates + 1;
+		END`)
+	require.NoError(t, err)
+	source := []SessionSourcePath{{Agent: "claude", FilePath: path}}
+	require.NoError(t, d.BaselineActiveSessionSourcePaths(
+		t.Context(), defaultMachine, source,
+	))
+	require.NoError(t, d.BaselineActiveSessionSourcePaths(
+		t.Context(), defaultMachine, source,
+	))
+
+	var updates int
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT updates FROM source_baseline_update_observer",
+	).Scan(&updates))
+	assert.Equal(t, 1, updates,
+		"stable full syncs must not rewrite baseline rows or grow the WAL")
+}
+
+func TestRestoreSessionClearsSourceBaseline(t *testing.T) {
+	d := testDB(t)
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	insertSessionWithSourcePath(t, d, "session", "claude", path)
+	require.NoError(t, d.BaselineActiveSessionSourcePaths(
+		t.Context(), defaultMachine,
+		[]SessionSourcePath{{Agent: "claude", FilePath: path}},
+	))
+	require.NoError(t, d.SoftDeleteSession("session"))
+	restored, err := d.RestoreSession("session")
+	require.NoError(t, err)
+	require.EqualValues(t, 1, restored)
+
+	changed, err := d.SoftDeleteSessionSourceOwnership(
+		t.Context(), defaultMachine, "claude", "session", path,
+	)
+	require.NoError(t, err)
+	assert.False(t, changed,
+		"a user-restored archive row must remain visible until its source is observed again")
+}
+
+func TestSoftDeleteSessionSourceOwnershipRequiresExactCurrentOwner(t *testing.T) {
+	d := testDB(t)
+	root := t.TempDir()
+	oldPath := filepath.Join(root, "old.jsonl")
+	newPath := filepath.Join(root, "new.jsonl")
+	insertSessionWithSourcePath(t, d, "same-id", "claude", newPath)
+	insertSessionWithSourcePath(t, d, "other-agent", "codex", oldPath)
+	baselineSessionSource(t, d, defaultMachine, "claude", newPath)
+	baselineSessionSource(t, d, defaultMachine, "codex", oldPath)
+
+	deleted, err := d.SoftDeleteSessionSourceOwnership(
+		t.Context(), defaultMachine, "claude", "same-id", oldPath,
+	)
+	require.NoError(t, err)
+	assert.False(t, deleted, "a same-ID replacement at a new path is not the missing owner")
+	deleted, err = d.SoftDeleteSessionSourceOwnership(
+		t.Context(), defaultMachine, "claude", "other-agent", oldPath,
+	)
+	require.NoError(t, err)
+	assert.False(t, deleted, "another agent cannot be tombstoned through shared path ownership")
+	deleted, err = d.SoftDeleteSessionSourceOwnership(
+		t.Context(), defaultMachine, "claude", "same-id", newPath,
+	)
+	require.NoError(t, err)
+	assert.True(t, deleted)
+}
+
+func TestSourceMissingOwnershipDoesNotSatisfyFreshnessLookups(t *testing.T) {
+	d := testDB(t)
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	userDeletedPath := filepath.Join(t.TempDir(), "user-deleted.jsonl")
+	insertSessionWithSourcePath(t, d, "session", "claude", path)
+	insertSessionWithSourcePath(t, d, "user-deleted", "claude", userDeletedPath)
+	_, err := d.getWriter().Exec(
+		`UPDATE sessions
+		 SET file_size = 4096, file_mtime = 1234,
+		     file_hash = 'unchanged', data_version = ?
+		 WHERE id IN ('session', 'user-deleted')`,
+		CurrentDataVersion(),
+	)
+	require.NoError(t, err)
+	require.NoError(t, d.SoftDeleteSession("user-deleted"))
+	baselineSessionSource(t, d, defaultMachine, "claude", path)
+
+	changed, err := d.SoftDeleteSessionSourceOwnership(
+		t.Context(), defaultMachine, "claude", "session", path,
+	)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	_, _, ok := d.GetFileInfoByPath(path)
+	assert.False(t, ok)
+	_, ok = d.GetFileHashByPath(path)
+	assert.False(t, ok)
+	assert.Zero(t, d.GetDataVersionByPath(path))
+	_, _, _, _, ok = d.GetSourceRepairStateByPath(path)
+	assert.False(t, ok)
+	_, _, ok = d.GetSessionFileInfo("session")
+	assert.False(t, ok)
+	_, ok = d.GetSessionFileHash("session")
+	assert.False(t, ok)
+
+	storedSize, storedMtime, ok := d.GetFileInfoByPath(userDeletedPath)
+	assert.True(t, ok, "ordinary user trash still suppresses redundant source parsing")
+	assert.EqualValues(t, 4096, storedSize)
+	assert.EqualValues(t, 1234, storedMtime)
+	storedSize, storedMtime, ok = d.GetSessionFileInfo("user-deleted")
+	assert.True(t, ok, "ordinary user trash retains legacy ID freshness semantics")
+	assert.EqualValues(t, 4096, storedSize)
+	assert.EqualValues(t, 1234, storedMtime)
+	storedHash, ok := d.GetSessionFileHash("user-deleted")
+	assert.True(t, ok)
+	assert.Equal(t, "unchanged", storedHash)
+}
+
+func TestSharedPathSourceOwnershipPageAllocationsStayBoundedByPage(t *testing.T) {
+	seed := func(t *testing.T, count int) (*DB, string) {
+		t.Helper()
+		d := testDB(t)
+		root := t.TempDir()
+		sharedPath := filepath.Join(root, "shared.jsonl")
+		seeds := make([]storedSourcePathSeed, 0, count)
+		for i := range count {
+			seeds = append(seeds, storedSourcePathSeed{
+				id: fmt.Sprintf("session-%05d", i), agent: "claude",
+				path: sharedPath,
+			})
+		}
+		insertSessionsWithSourcePaths(t, d, seeds)
+		require.NoError(t, d.BaselineActiveSessionSourcePaths(
+			t.Context(), defaultMachine, sourcePathsFromSeeds(seeds),
+		))
+		return d, root
+	}
+	smallDB, smallRoot := seed(t, WatchReconcileSourcePageSize)
+	largeDB, largeRoot := seed(t, WatchReconcileSourcePageSize*20)
+
+	measure := func(database *DB, root string) float64 {
+		return testing.AllocsPerRun(10, func() {
+			page, err := database.ListActiveSessionSourceOwnershipScopesPage(
+				t.Context(), defaultMachine, "claude",
+				[]StoredSourcePathHintScope{{Path: root}}, SessionSourceCursor{},
+			)
+			require.NoError(t, err)
+			require.Len(t, page, WatchReconcileSourcePageSize)
+		})
+	}
+	smallAllocs := measure(smallDB, smallRoot)
+	largeAllocs := measure(largeDB, largeRoot)
+
+	assert.LessOrEqual(t, largeAllocs, smallAllocs+16,
+		"LIMIT must stop inside a large equal-path group without materializing it")
+}
+
+func TestActiveSessionSourceOwnershipPageUsesOrderedCoveringIndex(t *testing.T) {
+	d := testDB(t)
+	root := t.TempDir()
+	likeRoot := sqliteLikeEscape(root)
+	rows, err := d.getReader().Query(`
+		EXPLAIN QUERY PLAN
+		SELECT s.machine, s.agent, s.id, s.file_path
+		FROM local_session_source_baselines AS b
+		JOIN sessions AS s
+		  ON s.id = b.session_id
+		 AND s.machine = b.machine
+		 AND s.agent = b.agent
+		 AND s.file_path = b.file_path
+		WHERE b.machine = ?
+		  AND b.agent = ?
+		  AND s.deleted_at IS NULL
+		  AND (b.file_path = ? OR b.file_path LIKE ? ESCAPE '!')
+		  AND (b.file_path > ? OR (b.file_path = ? AND b.session_id > ?))
+		ORDER BY b.file_path, b.session_id
+		LIMIT ?`,
+		defaultMachine, "claude", root, likeRoot+string(filepath.Separator)+"%",
+		"", "", "", WatchReconcileSourcePageSize,
+	)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var details []string
+	for rows.Next() {
+		var id, parent, notused int
+		var detail string
+		require.NoError(t, rows.Scan(&id, &parent, &notused, &detail))
+		details = append(details, detail)
+	}
+	require.NoError(t, rows.Err())
+	plan := strings.Join(details, "\n")
+	assert.Contains(t, plan, "idx_local_source_baselines_ownership")
+	assert.NotContains(t, plan, "USE TEMP B-TREE",
+		"equal-path ownership rows must stream in id order before LIMIT")
+}
+
+func TestSessionSourceOwnershipAPIsHonorCanceledContext(t *testing.T) {
+	d := testDB(t)
+	root := t.TempDir()
+	path := filepath.Join(root, "session.jsonl")
+	insertSessionWithSourcePath(t, d, "session", "claude", path)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := d.ListActiveSessionSourceOwnershipScopesPage(
+		ctx, defaultMachine, "claude",
+		[]StoredSourcePathHintScope{{Path: root}}, SessionSourceCursor{},
+	)
+	require.ErrorIs(t, err, context.Canceled)
+	_, err = d.SoftDeleteSessionSourceOwnership(
+		ctx, defaultMachine, "claude", "session", path,
+	)
+	require.ErrorIs(t, err, context.Canceled)
+	active, err := d.GetSession(t.Context(), "session")
+	require.NoError(t, err)
+	assert.NotNil(t, active, "a canceled tombstone must not mutate the row")
+}
+
+func TestSourceMissingTombstoneRevivesThroughEverySessionUpsert(t *testing.T) {
+	tests := []struct {
+		name   string
+		upsert func(*testing.T, *DB, Session) error
+	}{
+		{
+			name: "single upsert",
+			upsert: func(t *testing.T, d *DB, session Session) error {
+				t.Helper()
+				return d.UpsertSession(session)
+			},
+		},
+		{
+			name: "atomic batch upsert",
+			upsert: func(t *testing.T, d *DB, session Session) error {
+				t.Helper()
+				result, err := d.WriteSessionBatchAtomic([]SessionBatchWrite{{
+					Session: session, DataVersion: CurrentDataVersion(),
+				}})
+				require.Equal(t, 1, result.WrittenSessions)
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := testDB(t)
+			root := t.TempDir()
+			path := filepath.Join(root, "session.jsonl")
+			insertSessionWithSourcePath(t, d, "session", "claude", path)
+			baselineSessionSource(t, d, defaultMachine, "claude", path)
+			changed, err := d.SoftDeleteSessionSourceOwnership(
+				t.Context(), defaultMachine, "claude", "session", path,
+			)
+			require.NoError(t, err)
+			require.True(t, changed)
+
+			var deletedAt, cause *string
+			require.NoError(t, d.getReader().QueryRow(
+				"SELECT deleted_at, deletion_cause FROM sessions WHERE id = ?",
+				"session",
+			).Scan(&deletedAt, &cause))
+			require.NotNil(t, deletedAt)
+			require.NotNil(t, cause)
+			assert.Equal(t, "source_missing", *cause)
+
+			err = tt.upsert(t, d, Session{
+				ID: "session", Project: "reappeared", Machine: defaultMachine,
+				Agent: "claude", FilePath: &path,
+			})
+			require.NoError(t, err)
+			require.NoError(t, d.getReader().QueryRow(
+				"SELECT deleted_at, deletion_cause FROM sessions WHERE id = ?",
+				"session",
+			).Scan(&deletedAt, &cause))
+			assert.Nil(t, deletedAt)
+			assert.Nil(t, cause)
+			active, err := d.GetSession(t.Context(), "session")
+			require.NoError(t, err)
+			require.NotNil(t, active)
+			assert.Equal(t, "reappeared", active.Project)
+		})
+	}
+}
+
+func TestWriteSessionBatchSourceMissingRevivalReplacesRetainedMessages(
+	t *testing.T,
+) {
+	d := testDB(t)
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	session := Session{
+		ID: "session", Project: "project", Machine: defaultMachine,
+		Agent: "claude", FilePath: &path, MessageCount: 1,
+	}
+	write := func(content string) {
+		t.Helper()
+		result, err := d.WriteSessionBatch([]SessionBatchWrite{{
+			Session: session,
+			Messages: []Message{{
+				SessionID: "session", Ordinal: 0, Role: "user", Content: content,
+			}},
+			DataVersion: CurrentDataVersion(),
+		}})
+		require.NoError(t, err)
+		require.Equal(t, 1, result.WrittenSessions)
+	}
+
+	write("old content")
+	baselineSessionSource(t, d, defaultMachine, "claude", path)
+	changed, err := d.SoftDeleteSessionSourceOwnership(
+		t.Context(), defaultMachine, "claude", "session", path,
+	)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	write("new content")
+	messages, err := d.GetAllMessages(t.Context(), "session")
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Equal(t, "new content", messages[0].Content,
+		"source-missing revival must override append-only batch hints")
+}
+
+func TestUserTrashRemainsRejectedByEverySessionUpsert(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "session", "project")
+	require.NoError(t, d.SoftDeleteSession("session"))
+
+	err := d.UpsertSession(Session{ID: "session", Project: "changed"})
+	require.ErrorIs(t, err, ErrSessionTrashed)
+	result, err := d.WriteSessionBatchAtomic([]SessionBatchWrite{{
+		Session:     Session{ID: "session", Project: "changed"},
+		DataVersion: CurrentDataVersion(),
+	}})
+	require.ErrorIs(t, err, ErrSessionTrashed)
+	assert.Equal(t, 1, result.ExcludedSessions)
+
+	var cause *string
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT deletion_cause FROM sessions WHERE id = ?", "session",
+	).Scan(&cause))
+	assert.Nil(t, cause, "legacy and user trash keep the established NULL cause")
+}
+
+func TestSourceMissingTombstoneIsNotUserTrash(t *testing.T) {
+	d := testDB(t)
+	root := t.TempDir()
+	missingPath := filepath.Join(root, "missing.jsonl")
+	userPath := filepath.Join(root, "user.jsonl")
+	insertSessionWithSourcePath(t, d, "missing", "claude", missingPath)
+	insertSessionWithSourcePath(t, d, "user", "claude", userPath)
+	baselineSessionSource(t, d, defaultMachine, "claude", missingPath)
+	changed, err := d.SoftDeleteSessionSourceOwnership(
+		t.Context(), defaultMachine, "claude", "missing", missingPath,
+	)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.NoError(t, d.SoftDeleteSession("user"))
+
+	assert.False(t, d.IsSessionTrashed("missing"))
+	assert.True(t, d.IsSessionTrashed("user"))
+	assert.False(t, d.HasTrashedSessionByFilePath(missingPath, "claude"))
+	assert.True(t, d.HasTrashedSessionByFilePath(userPath, "claude"))
+	trashed, err := d.ListTrashedSessions(t.Context())
+	require.NoError(t, err)
+	require.Len(t, trashed, 1)
+	assert.Equal(t, "user", trashed[0].ID)
+
+	emptied, err := d.EmptyTrash()
+	require.NoError(t, err)
+	assert.Equal(t, 1, emptied)
+	assert.False(t, d.IsSessionExcluded("missing"))
+	assertDeletionState(t, d, "missing", true, deletionCauseSourceMissing)
 }
 
 func insertSessionWithSourcePath(
@@ -178,6 +934,155 @@ type storedSourcePathSeed struct {
 	id    string
 	agent string
 	path  string
+}
+
+func sourcePathsFromSeeds(seeds []storedSourcePathSeed) []SessionSourcePath {
+	paths := make([]SessionSourcePath, 0, len(seeds))
+	for _, seed := range seeds {
+		paths = append(paths, SessionSourcePath{
+			Agent: seed.agent, FilePath: seed.path,
+		})
+	}
+	return paths
+}
+
+func baselineSessionSource(
+	t *testing.T, d *DB, machine string, agent string, path string,
+) {
+	t.Helper()
+	require.NoError(t, d.BaselineActiveSessionSourcePaths(
+		t.Context(), machine,
+		[]SessionSourcePath{{Agent: agent, FilePath: path}},
+	))
+}
+
+// totalWriterChanges reads the writer connection's cumulative count of rows
+// inserted, updated, or deleted. The writer pool holds a single connection,
+// so deltas measure exactly the rows a write path touched.
+func totalWriterChanges(t *testing.T, d *DB) int64 {
+	t.Helper()
+	var n int64
+	require.NoError(t,
+		d.getWriter().QueryRow("SELECT total_changes()").Scan(&n))
+	return n
+}
+
+// listBaselineOwnership returns every local_session_source_baselines row as
+// session_id -> (agent, file_path) for the machine.
+func listBaselineOwnership(
+	t *testing.T, d *DB, machine string,
+) map[string]SessionSourcePath {
+	t.Helper()
+	rows, err := d.Reader().Query(`
+		SELECT session_id, agent, file_path
+		FROM local_session_source_baselines WHERE machine = ?`, machine)
+	require.NoError(t, err)
+	defer rows.Close()
+	ownership := make(map[string]SessionSourcePath)
+	for rows.Next() {
+		var id string
+		var source SessionSourcePath
+		require.NoError(t, rows.Scan(&id, &source.Agent, &source.FilePath))
+		ownership[id] = source
+	}
+	require.NoError(t, rows.Err())
+	return ownership
+}
+
+// TestReplaceActiveSessionSourceBaselinesWarmPassWritesBounded pins the
+// AGENTS.md cardinality rule for the watcher-proof table: a warm no-op full
+// sync replays every unchanged source as an admitted candidate, and the
+// replacement must not rewrite their baseline rows — write work scales with
+// the changed batch, never the archive. Rejection (proof withdrawal) and
+// tombstoned-session cleanup must keep working in the same pass.
+func TestReplaceActiveSessionSourceBaselinesWarmPassWritesBounded(t *testing.T) {
+	for _, total := range []int{3, 2*baselinePairChunk + 7} {
+		t.Run(fmt.Sprintf("sessions-%d", total), func(t *testing.T) {
+			d := testDB(t)
+			root := t.TempDir()
+			seeds := make([]storedSourcePathSeed, 0, total)
+			for i := range total {
+				seeds = append(seeds, storedSourcePathSeed{
+					id:    fmt.Sprintf("claude:s-%04d", i),
+					agent: "claude",
+					path:  filepath.Join(root, fmt.Sprintf("s-%04d.jsonl", i)),
+				})
+			}
+			insertSessionsWithSourcePaths(t, d, seeds)
+			sources := sourcePathsFromSeeds(seeds)
+			require.NoError(t, d.ReplaceActiveSessionSourceBaselines(
+				t.Context(), defaultMachine, sources, sources,
+			))
+			require.Len(t, listBaselineOwnership(t, d, defaultMachine), total)
+
+			before := totalWriterChanges(t, d)
+			require.NoError(t, d.ReplaceActiveSessionSourceBaselines(
+				t.Context(), defaultMachine, sources, sources,
+			))
+			assert.Zero(t, totalWriterChanges(t, d)-before,
+				"a warm no-op pass must not rewrite unchanged baseline rows")
+
+			// One rejected source and one tombstoned session: the pass must
+			// withdraw exactly those two proofs, independent of archive size.
+			require.NoError(t, d.SoftDeleteSession(seeds[1].id))
+			before = totalWriterChanges(t, d)
+			require.NoError(t, d.ReplaceActiveSessionSourceBaselines(
+				t.Context(), defaultMachine, sources, sources[1:],
+			))
+			assert.Equal(t, int64(2), totalWriterChanges(t, d)-before,
+				"proof withdrawal must write only the changed rows")
+			ownership := listBaselineOwnership(t, d, defaultMachine)
+			assert.Len(t, ownership, total-2)
+			assert.NotContains(t, ownership, seeds[0].id,
+				"a rejected candidate must lose its deletion proof")
+			assert.NotContains(t, ownership, seeds[1].id,
+				"a tombstoned session must lose its deletion proof")
+		})
+	}
+}
+
+// TestReplaceActiveSessionSourceBaselinesReplacesMovedOwnership pins the
+// delete-then-readmit end state for changed ownership: when a session's stored
+// source moves, replacing the old and new pairs leaves exactly one baseline
+// row carrying the new ownership.
+func TestReplaceActiveSessionSourceBaselinesReplacesMovedOwnership(t *testing.T) {
+	d := testDB(t)
+	root := t.TempDir()
+	oldPath := filepath.Join(root, "old.jsonl")
+	newPath := filepath.Join(root, "new.jsonl")
+	insertSessionWithSourcePath(t, d, "claude:moved", "claude", oldPath)
+	oldSources := []SessionSourcePath{{Agent: "claude", FilePath: oldPath}}
+	require.NoError(t, d.ReplaceActiveSessionSourceBaselines(
+		t.Context(), defaultMachine, oldSources, oldSources,
+	))
+
+	insertSessionWithSourcePath(t, d, "claude:moved", "claude", newPath)
+	both := []SessionSourcePath{
+		{Agent: "claude", FilePath: oldPath},
+		{Agent: "claude", FilePath: newPath},
+	}
+	require.NoError(t, d.ReplaceActiveSessionSourceBaselines(
+		t.Context(), defaultMachine, both, both,
+	))
+
+	ownership := listBaselineOwnership(t, d, defaultMachine)
+	require.Len(t, ownership, 1)
+	assert.Equal(t, SessionSourcePath{Agent: "claude", FilePath: newPath},
+		ownership["claude:moved"],
+		"the baseline must follow the session to its new source")
+
+	// A move whose destination is outside the replaced page still withdraws
+	// the old proof: the row is no longer backed by a session with that
+	// exact ownership.
+	elsewhere := filepath.Join(root, "elsewhere.jsonl")
+	insertSessionWithSourcePath(t, d, "claude:moved", "claude", elsewhere)
+	require.NoError(t, d.ReplaceActiveSessionSourceBaselines(
+		t.Context(), defaultMachine,
+		[]SessionSourcePath{{Agent: "claude", FilePath: newPath}},
+		[]SessionSourcePath{{Agent: "claude", FilePath: newPath}},
+	))
+	assert.Empty(t, listBaselineOwnership(t, d, defaultMachine),
+		"proof for the vacated source must not outlive the move")
 }
 
 func insertSessionsWithSourcePaths(

--- a/internal/db/source_tombstone_migration_test.go
+++ b/internal/db/source_tombstone_migration_test.go
@@ -1,0 +1,223 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSourceBaselineSchemaUsesLocalCompanionTable(t *testing.T) {
+	d := testDB(t)
+	var sessionColumns int
+	require.NoError(t, d.getReader().QueryRow(`
+		SELECT count(*) FROM pragma_table_info('sessions')
+		WHERE name = 'source_baseline_path'`,
+	).Scan(&sessionColumns))
+	assert.Zero(t, sessionColumns,
+		"machine-local watcher proof must not expand the shared session model")
+
+	var baselineTables int
+	require.NoError(t, d.getReader().QueryRow(`
+		SELECT count(*) FROM sqlite_master
+		WHERE type = 'table' AND name = 'local_session_source_baselines'`,
+	).Scan(&baselineTables))
+	assert.Equal(t, 1, baselineTables)
+	var indexSQL string
+	require.NoError(t, d.getReader().QueryRow(`
+		SELECT sql FROM sqlite_master
+		WHERE type = 'index' AND name = 'idx_local_source_baselines_ownership'`,
+	).Scan(&indexSQL))
+	assert.Contains(t, strings.ToLower(strings.Join(strings.Fields(indexSQL), " ")),
+		"machine, agent, file_path, session_id")
+}
+
+func TestSourceTombstoneSchemaStartsAndMigratesWithoutDataLoss(t *testing.T) {
+	t.Run("new database", func(t *testing.T) {
+		d := testDB(t)
+		assertSourceTombstoneSchema(t, d)
+	})
+
+	t.Run("existing database", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "archive.db")
+		d := testDBAtPath(t, path, "pre-migration archive")
+		insertSession(t, d, "preserved", "project")
+		require.NoError(t, d.Close())
+
+		conn, err := sql.Open("sqlite3", path)
+		require.NoError(t, err)
+		_, err = conn.Exec("DROP INDEX IF EXISTS idx_sessions_agent_file_path_active")
+		require.NoError(t, err)
+		_, err = conn.Exec("DROP TABLE IF EXISTS local_session_source_baselines")
+		require.NoError(t, err)
+		var causeColumns int
+		require.NoError(t, conn.QueryRow(`
+			SELECT count(*) FROM pragma_table_info('sessions')
+			WHERE name = 'deletion_cause'`,
+		).Scan(&causeColumns))
+		if causeColumns > 0 {
+			_, err = conn.Exec("ALTER TABLE sessions DROP COLUMN deletion_cause")
+			require.NoError(t, err)
+		}
+		_, err = conn.Exec(`
+			CREATE INDEX idx_sessions_agent_file_path_active
+			ON sessions(agent, file_path)
+			WHERE file_path IS NOT NULL AND deleted_at IS NULL`)
+		require.NoError(t, err)
+		require.NoError(t, conn.Close())
+
+		migrated, err := Open(path)
+		require.NoError(t, err)
+		defer migrated.Close()
+		assertSourceTombstoneSchema(t, migrated)
+		preserved, err := migrated.GetSession(t.Context(), "preserved")
+		require.NoError(t, err)
+		assert.NotNil(t, preserved, "schema migration must preserve archive rows")
+		var baselines int
+		require.NoError(t, migrated.getReader().QueryRow(
+			"SELECT count(*) FROM local_session_source_baselines WHERE session_id = ?", "preserved",
+		).Scan(&baselines))
+		assert.Zero(t, baselines,
+			"migration must not make a historical row deletion-eligible")
+	})
+}
+
+func assertSourceTombstoneSchema(t *testing.T, d *DB) {
+	t.Helper()
+	var causeColumns int
+	require.NoError(t, d.getReader().QueryRow(`
+		SELECT count(*) FROM pragma_table_info('sessions')
+		WHERE name = 'deletion_cause'`,
+	).Scan(&causeColumns))
+	assert.Equal(t, 1, causeColumns)
+	var baselineColumns int
+	require.NoError(t, d.getReader().QueryRow(`
+		SELECT count(*) FROM pragma_table_info('sessions')
+		WHERE name = 'source_baseline_path'`,
+	).Scan(&baselineColumns))
+	assert.Zero(t, baselineColumns)
+
+	rows, err := d.getReader().Query(
+		"SELECT name FROM pragma_index_info('idx_sessions_agent_file_path_active') ORDER BY seqno",
+	)
+	require.NoError(t, err)
+	defer rows.Close()
+	var columns []string
+	for rows.Next() {
+		var column string
+		require.NoError(t, rows.Scan(&column))
+		columns = append(columns, column)
+	}
+	require.NoError(t, rows.Err())
+	assert.Equal(t, []string{"agent", "file_path", "id"}, columns)
+	var indexSQL string
+	require.NoError(t, d.getReader().QueryRow(`
+		SELECT sql FROM sqlite_master
+		WHERE type = 'index' AND name = 'idx_sessions_agent_file_path_active'
+	`).Scan(&indexSQL))
+	normalizedIndexSQL := strings.ToLower(strings.Join(strings.Fields(indexSQL), " "))
+	assert.Contains(t, normalizedIndexSQL,
+		"where file_path is not null and deleted_at is null")
+	var baselineIndexSQL string
+	require.NoError(t, d.getReader().QueryRow(`
+		SELECT sql FROM sqlite_master
+		WHERE type = 'index' AND name = 'idx_local_source_baselines_ownership'
+	`).Scan(&baselineIndexSQL))
+	assert.Contains(t,
+		strings.ToLower(strings.Join(strings.Fields(baselineIndexSQL), " ")),
+		"machine, agent, file_path, session_id",
+	)
+}
+
+func TestSourceMissingCauseSurvivesRebuildCopies(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	source := testDBAtPath(t, sourcePath, "source archive")
+	physicalPath := filepath.Join(dir, "missing.jsonl")
+	insertSessionWithSourcePath(t, source, "session", "claude", physicalPath)
+	baselineSessionSource(t, source, defaultMachine, "claude", physicalPath)
+	changed, err := source.SoftDeleteSessionSourceOwnership(
+		t.Context(), defaultMachine, "claude", "session", physicalPath,
+	)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.NoError(t, source.Close())
+
+	destination := testDBAtPath(t, filepath.Join(dir, "destination.db"), "destination archive")
+	defer destination.Close()
+	copied, err := destination.CopyTrashedDataFrom(sourcePath)
+	require.NoError(t, err)
+	assert.Equal(t, 1, copied)
+	assertDeletionState(t, destination, "session", true, "source_missing")
+}
+
+func TestSessionPushEnumerationIncludesDeletionCause(t *testing.T) {
+	d := testDB(t)
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	insertSessionWithSourcePath(t, d, "session", "claude", path)
+	baselineSessionSource(t, d, defaultMachine, "claude", path)
+	changed, err := d.SoftDeleteSessionSourceOwnership(
+		t.Context(), defaultMachine, "claude", "session", path,
+	)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	full, err := d.GetSessionFull(t.Context(), "session")
+	require.NoError(t, err)
+	require.NotNil(t, full)
+	require.NotNil(t, full.DeletionCause)
+	assert.Equal(t, "source_missing", *full.DeletionCause)
+
+	sessions, err := d.ListSessionsModifiedBetween(
+		t.Context(), "", "", nil, nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, sessions, 1)
+	require.NotNil(t, sessions[0].DeletionCause)
+	assert.Equal(t, "source_missing", *sessions[0].DeletionCause)
+}
+
+func TestRebuildMetadataDoesNotRehideReappearedSource(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	physicalPath := filepath.Join(dir, "session.jsonl")
+	source := testDBAtPath(t, sourcePath, "source archive")
+	insertSessionWithSourcePath(t, source, "session", "claude", physicalPath)
+	baselineSessionSource(t, source, defaultMachine, "claude", physicalPath)
+	changed, err := source.SoftDeleteSessionSourceOwnership(
+		t.Context(), defaultMachine, "claude", "session", physicalPath,
+	)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.NoError(t, source.Close())
+
+	destination := testDBAtPath(t, filepath.Join(dir, "destination.db"), "destination archive")
+	defer destination.Close()
+	insertSessionWithSourcePath(t, destination, "session", "claude", physicalPath)
+	require.NoError(t, destination.CopySessionMetadataFrom(sourcePath))
+	assertDeletionState(t, destination, "session", false, "")
+	active, err := destination.GetSession(context.Background(), "session")
+	require.NoError(t, err)
+	assert.NotNil(t, active)
+}
+
+func assertDeletionState(
+	t *testing.T, d *DB, id string, wantDeleted bool, wantCause string,
+) {
+	t.Helper()
+	var deletedAt, cause sql.NullString
+	require.NoError(t, d.getReader().QueryRow(
+		"SELECT deleted_at, deletion_cause FROM sessions WHERE id = ?", id,
+	).Scan(&deletedAt, &cause))
+	assert.Equal(t, wantDeleted, deletedAt.Valid)
+	if wantCause == "" {
+		assert.False(t, cause.Valid)
+		return
+	}
+	require.True(t, cause.Valid)
+	assert.Equal(t, wantCause, cause.String)
+}

--- a/internal/duckdb/mirror_watch.go
+++ b/internal/duckdb/mirror_watch.go
@@ -103,6 +103,11 @@ func (s *Store) checkMirrorReplacement(ctx context.Context, onEvent func(err err
 		return
 	}
 
+	if !s.beginReplacementCheck() {
+		return
+	}
+	defer s.retiring.Done()
+
 	conn, alias, err := openMirrorAlias(s.path)
 	if err != nil {
 		reportMirrorReplacementEvent(
@@ -176,22 +181,54 @@ func removeMirrorAlias(alias string) {
 	}
 }
 
+// beginReplacementCheck registers an in-flight mirror-replacement check on
+// s.retiring before the check opens any handle or alias, and rejects the
+// check once the Store is closed. Store.Close waits on s.retiring, so a
+// closing Store cannot return while a check is still opening or validating
+// a replacement — without this registration, a check racing Close would
+// create a fresh handle and reopen alias after Close already reported that
+// every handle is closed and every alias is gone (swapHandle's closed
+// branch discards them, but only after Close has returned). The caller must
+// call s.retiring.Done() when the check finishes.
+func (s *Store) beginReplacementCheck() bool {
+	s.handleMu.Lock()
+	defer s.handleMu.Unlock()
+	if s.closed {
+		return false
+	}
+	s.retiring.Add(1)
+	return true
+}
+
 // swapHandle installs the new handle and its backing alias under a write
 // lock, then closes the old handle and removes its alias (if any) after
 // releasing the lock. sql.DB.Close waits for connections currently in use
 // to be released before returning, so any query already running against
 // the old handle completes normally; only new queries see the
-// replacement.
+// replacement. The post-unlock retirement is registered on s.retiring so
+// Store.Close waits for it, and a swap that finds the Store already closed
+// discards its handle and alias instead of installing them into a Store
+// nothing will ever close again.
 func (s *Store) swapHandle(conn *sql.DB, alias string, info os.FileInfo) {
 	PrimeFileIdentity(info)
 	s.handleMu.Lock()
+	if s.closed {
+		s.handleMu.Unlock()
+		if err := conn.Close(); err != nil {
+			log.Printf("duckdb serve: closing mirror handle opened after Close: %v", err)
+		}
+		removeMirrorAlias(alias)
+		return
+	}
 	oldConn := s.duck
 	oldAlias := s.aliasPath
 	s.duck = conn
 	s.aliasPath = alias
 	s.fileInfo = info
+	s.retiring.Add(1)
 	s.handleMu.Unlock()
 
+	defer s.retiring.Done()
 	if err := oldConn.Close(); err != nil {
 		log.Printf("duckdb serve: closing replaced mirror handle: %v", err)
 	}

--- a/internal/duckdb/probe.go
+++ b/internal/duckdb/probe.go
@@ -236,7 +236,7 @@ func mirrorShapeIssueFromColumns(existing map[string]map[string]bool) string {
 // sourceDataVersion as-is, or must be rebuilt with rebuildMirror. A missing
 // file, a shape problem, a schema version mismatch in either direction, a
 // stale source data version, or a different push scope all require a
-// rebuild; there is no in-place migration path for mirror schema v4.
+// rebuild; there is no in-place migration path for the mirror schema.
 func (p MirrorProbe) NeedsRebuild(scope string, sourceDataVersion int) bool {
 	if !p.FileExists || !p.ShapeOK {
 		return true

--- a/internal/duckdb/push.go
+++ b/internal/duckdb/push.go
@@ -821,14 +821,14 @@ func (s *Sync) upsertSession(
 			duplicate_prompt_count, no_code_context_count,
 			runaway_tool_loop_count, data_version,
 			cwd, git_branch, source_session_id, source_version, transcript_fidelity,
-			parser_malformed_lines, is_truncated, deleted_at, created_at,
+			parser_malformed_lines, is_truncated, deleted_at, deletion_cause, created_at,
 			termination_status, secret_leak_count, secrets_rules_version,
 			agentsview_push_fingerprint
 		) VALUES (
 			?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 			?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
 			?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-			?, ?, ?, ?, ?, ?, ?, ?, ?
+			?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 		)`
 	query += `
 		ON CONFLICT(id) DO UPDATE SET
@@ -892,6 +892,7 @@ func (s *Sync) upsertSession(
 			parser_malformed_lines = excluded.parser_malformed_lines,
 			is_truncated = excluded.is_truncated,
 			deleted_at = excluded.deleted_at,
+			deletion_cause = excluded.deletion_cause,
 			created_at = excluded.created_at,
 			termination_status = excluded.termination_status,
 			secret_leak_count = excluded.secret_leak_count,
@@ -936,7 +937,7 @@ func sessionInsertArgs(sess db.Session, machine, fingerprint string) []any {
 		sess.DataVersion,
 		sess.Cwd, sess.GitBranch, sess.SourceSessionID,
 		sess.SourceVersion, sess.TranscriptFidelity, sess.ParserMalformedLines,
-		sess.IsTruncated, nilTime(sess.DeletedAt),
+		sess.IsTruncated, nilTime(sess.DeletedAt), nilString(sess.DeletionCause),
 		timeValue(sess.CreatedAt), nilString(sess.TerminationStatus),
 		sess.SecretLeakCount, sess.SecretsRulesVersion,
 		nilEmpty(fingerprint),

--- a/internal/duckdb/schema.go
+++ b/internal/duckdb/schema.go
@@ -13,8 +13,9 @@ import (
 // SchemaVersion is the version of the DuckDB mirror schema created by
 // createSchema. Mirror schema v4 is create-only: there are no in-place
 // migrations between versions. A version mismatch means the mirror file
-// must be rebuilt with 'agentsview duckdb push --full'.
-const SchemaVersion = 4
+// must be rebuilt with 'agentsview duckdb push --full'. v5 adds the
+// sessions.deletion_cause column on top of the v4 shape.
+const SchemaVersion = 5
 
 const schemaVersionMetadataKey = "agentsview_schema_version"
 
@@ -164,6 +165,7 @@ var mirrorTables = []tableSpec{
 			parser_malformed_lines INTEGER NOT NULL DEFAULT 0,
 			is_truncated BOOLEAN NOT NULL DEFAULT FALSE,
 			deleted_at TIMESTAMP,
+			deletion_cause TEXT,
 			created_at TIMESTAMP,
 			termination_status TEXT,
 			secret_leak_count INTEGER NOT NULL DEFAULT 0,
@@ -232,6 +234,7 @@ var mirrorTables = []tableSpec{
 			{"parser_malformed_lines", "parser_malformed_lines INTEGER NOT NULL DEFAULT 0"},
 			{"is_truncated", "is_truncated BOOLEAN NOT NULL DEFAULT FALSE"},
 			{"deleted_at", "deleted_at TIMESTAMP"},
+			{"deletion_cause", "deletion_cause TEXT"},
 			{"created_at", "created_at TIMESTAMP"},
 			{"termination_status", "termination_status TEXT"},
 			{"secret_leak_count", "secret_leak_count INTEGER NOT NULL DEFAULT 0"},
@@ -870,9 +873,9 @@ func parseMirrorMetadataInt64(key, value string) (int64, error) {
 }
 
 // CheckSchemaCompat verifies that the local DuckDB mirror file has the
-// required v4 tables, columns, and schema version. It does not mutate the
-// database. Mirror schema v4 is create-only, so a mismatch of any kind means
-// the mirror must be rebuilt rather than migrated in place.
+// required tables, columns, and schema version. It does not mutate the
+// database. The mirror schema is create-only, so a mismatch of any kind
+// means the mirror must be rebuilt rather than migrated in place.
 func CheckSchemaCompat(ctx context.Context, db *sql.DB) error {
 	return checkSchemaShapeCompat(ctx, db, localSchema)
 }

--- a/internal/duckdb/store.go
+++ b/internal/duckdb/store.go
@@ -42,6 +42,15 @@ type Store struct {
 	duck      *sql.DB
 	fileInfo  os.FileInfo
 	aliasPath string
+	closed    bool
+	// retiring tracks in-flight mirror-replacement checks, registered in
+	// beginReplacementCheck before a check opens anything and spanning
+	// swapHandle's tail cleanup (closing the replaced handle and removing
+	// its alias after the write lock is released). Close waits on it so
+	// "closed" means no check is still opening or validating a replacement,
+	// every retired handle is closed, and every alias this Store created is
+	// gone.
+	retiring sync.WaitGroup
 
 	quack          *quackClient
 	connectionKind duckDBConnectionKind
@@ -90,11 +99,29 @@ func (s *Store) DB() *sql.DB {
 	return s.duck
 }
 
+// Close closes the current handle and removes its backing alias, then waits
+// for any in-flight mirror-replacement check to finish — from opening and
+// validating a candidate replacement (see beginReplacementCheck) through
+// retiring the handle a swap replaced (see swapHandle). Without the wait,
+// Close could return while a check still held a freshly opened handle and
+// its reopen alias on disk. Close is idempotent; the closed flag also
+// rejects checks that have not started yet and tells a swap that loses the
+// race to Close to discard its freshly opened handle instead of installing
+// it.
 func (s *Store) Close() error {
 	s.handleMu.Lock()
-	defer s.handleMu.Unlock()
-	err := s.duck.Close()
-	removeMirrorAlias(s.aliasPath)
+	if s.closed {
+		s.handleMu.Unlock()
+		return nil
+	}
+	s.closed = true
+	conn := s.duck
+	alias := s.aliasPath
+	s.handleMu.Unlock()
+
+	err := conn.Close()
+	removeMirrorAlias(alias)
+	s.retiring.Wait()
 	return err
 }
 
@@ -273,7 +300,7 @@ const duckSessionCols = `id, project, machine, agent,
 	cwd, git_branch, source_session_id, source_version, transcript_fidelity,
 	parser_malformed_lines, is_truncated,
 	secret_leak_count, secrets_rules_version,
-	deleted_at, termination_status, transcript_revision`
+	deleted_at, deletion_cause, termination_status, transcript_revision`
 
 func scanSession(rs interface{ Scan(...any) error }) (db.Session, error) {
 	var s db.Session
@@ -307,7 +334,7 @@ func scanSession(rs interface{ Scan(...any) error }) (db.Session, error) {
 		&s.SourceSessionID, &s.SourceVersion, &s.TranscriptFidelity,
 		&s.ParserMalformedLines, &s.IsTruncated,
 		&s.SecretLeakCount, &s.SecretsRulesVersion,
-		&deletedAt, &s.TerminationStatus, &s.TranscriptRevision,
+		&deletedAt, &s.DeletionCause, &s.TerminationStatus, &s.TranscriptRevision,
 	)
 	if err != nil {
 		return s, err
@@ -613,6 +640,20 @@ func (s *Store) GetSessionFull(ctx context.Context, id string) (*db.Session, err
 		return nil, fmt.Errorf("getting duckdb full session: %w", err)
 	}
 	return &sess, nil
+}
+
+func (s *Store) ListTrashedSessions(ctx context.Context) ([]db.Session, error) {
+	rows, err := s.queryContext(ctx,
+		"SELECT "+duckSessionCols+
+			" FROM sessions WHERE deleted_at IS NOT NULL"+
+			" AND deletion_cause IS NULL"+
+			" ORDER BY deleted_at DESC LIMIT 500",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("listing duckdb trash: %w", err)
+	}
+	defer rows.Close()
+	return scanSessionRows(rows)
 }
 
 func (s *Store) GetChildSessions(ctx context.Context, parentID string) ([]db.Session, error) {

--- a/internal/duckdb/store_reopen_test.go
+++ b/internal/duckdb/store_reopen_test.go
@@ -276,6 +276,51 @@ func TestStoreConcurrentReadsNeverFailAcrossMirrorReplacements(t *testing.T) {
 		errDetail)
 }
 
+// TestStoreCloseWaitsForInFlightReplacementCheck races Store.Close against a
+// replacement check that is mid-open. The whole check registers with the
+// Store's lifecycle before it opens anything (see beginReplacementCheck), so
+// the moment Close returns no reopen alias may remain on disk and no handle
+// may be created afterward. Without that registration only swapHandle's tail
+// joined s.retiring, so Close could return while the check was still opening
+// or validating a replacement, leaving a fresh handle and alias to outlive
+// the "fully closed" contract. There is no delay-injection seam, so a tight
+// loop of real check/Close races provides the interleavings.
+func TestStoreCloseWaitsForInFlightReplacementCheck(t *testing.T) {
+	skipReopenTestOnWindows(t)
+	dir := t.TempDir()
+	srcA := filepath.Join(dir, "src-a.duckdb")
+	srcB := filepath.Join(dir, "src-b.duckdb")
+	buildMirrorFixture(t, srcA, "gen-a")
+	buildMirrorFixtureAt(t, srcB, "gen-b")
+	path := filepath.Join(dir, "m.duckdb")
+	require.NoError(t, os.Link(srcA, path))
+
+	// Each iteration replaces path with the source it is not currently
+	// hardlinked to, so the check always sees a changed file identity.
+	sources := [2]string{srcB, srcA}
+	for i := range 25 {
+		store, err := NewStore(path)
+		require.NoError(t, err)
+
+		tmp := filepath.Join(dir, fmt.Sprintf("swap-%d.duckdb", i))
+		require.NoError(t, os.Link(sources[i%2], tmp))
+		require.NoError(t, os.Rename(tmp, path))
+
+		checkDone := make(chan struct{})
+		go func() {
+			defer close(checkDone)
+			store.checkMirrorReplacement(context.Background(), nil)
+		}()
+		runtime.Gosched()
+		require.NoError(t, store.Close())
+		assert.Zero(t, countReopenAliasFiles(t, dir),
+			"Close must not return while a replacement check still holds a reopen alias (iteration %d)", i)
+		<-checkDone
+	}
+	assert.Zero(t, countReopenAliasFiles(t, dir),
+		"no reopen alias may survive once every check has finished")
+}
+
 // TestStoreAdoptsGoodMirrorAfterIncompatibleReplacement extends
 // TestStoreKeepsOldHandleWhenReplacementIncompatible: after the watcher
 // rejects one incompatible replacement and reports it via onEvent, it must

--- a/internal/duckdb/store_test.go
+++ b/internal/duckdb/store_test.go
@@ -294,6 +294,45 @@ func TestStoreGetStatsPreservesRootAndScopeFilters(t *testing.T) {
 	}, labels)
 }
 
+func TestStoreListTrashedSessionsOrdersNewestFirstAndCapsAt500(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+	require.NoError(t, createSchema(ctx, syncer.DB()))
+	duck := syncer.DB()
+	store := NewStoreFromDB(duck)
+
+	_, err := duck.ExecContext(ctx, `
+		INSERT INTO sessions (id, project, deleted_at)
+		SELECT 'trash-' || i, 'trash-parity',
+			TIMESTAMP '2026-01-01 00:00:00' + INTERVAL (i) SECOND
+		FROM range(600) t(i)`)
+	require.NoError(t, err)
+	// A recoverable source-missing tombstone newer than all user trash: if
+	// deletion_cause filtering regressed it would surface as the first row.
+	_, err = duck.ExecContext(ctx, `
+		INSERT INTO sessions (id, project, deleted_at, deletion_cause)
+		VALUES ('tombstone', 'trash-parity',
+			TIMESTAMP '2026-02-01 00:00:00', 'source_missing')`)
+	require.NoError(t, err)
+	_, err = duck.ExecContext(ctx,
+		`INSERT INTO sessions (id, project) VALUES ('active', 'trash-parity')`)
+	require.NoError(t, err)
+
+	trashed, err := store.ListTrashedSessions(ctx)
+	require.NoError(t, err)
+	// Same cap and ordering as the SQLite and PG stores: newest 500 by
+	// deleted_at, excluding active rows and source-missing tombstones.
+	require.Len(t, trashed, 500)
+	assert.Equal(t, "trash-599", trashed[0].ID)
+	assert.Equal(t, "trash-100", trashed[499].ID)
+	for i := 1; i < len(trashed); i++ {
+		require.NotNil(t, trashed[i].DeletedAt)
+		require.Less(t, *trashed[i].DeletedAt, *trashed[i-1].DeletedAt,
+			"trash must be ordered newest-first at index %d", i)
+	}
+}
+
 func TestStoreMessageIDJoinsAreSessionScoped(t *testing.T) {
 	ctx := context.Background()
 	store, fixture := newSyncedStore(t)

--- a/internal/duckdb/stubs.go
+++ b/internal/duckdb/stubs.go
@@ -15,14 +15,11 @@ func (s *Store) GetInsight(_ context.Context, _ int64) (*db.Insight, error) { re
 func (s *Store) GetCachedInsight(_ context.Context, _ string) (*db.Insight, error) {
 	return nil, nil
 }
-func (s *Store) RenameSession(_ string, _ *string) error        { return db.ErrReadOnly }
-func (s *Store) SoftDeleteSession(_ string) error               { return db.ErrReadOnly }
-func (s *Store) SoftDeleteSessions(_ []string) (int, error)     { return 0, db.ErrReadOnly }
-func (s *Store) RestoreSession(_ string) (int64, error)         { return 0, db.ErrReadOnly }
-func (s *Store) DeleteSessionIfTrashed(_ string) (int64, error) { return 0, db.ErrReadOnly }
-func (s *Store) ListTrashedSessions(_ context.Context) ([]db.Session, error) {
-	return []db.Session{}, nil
-}
+func (s *Store) RenameSession(_ string, _ *string) error               { return db.ErrReadOnly }
+func (s *Store) SoftDeleteSession(_ string) error                      { return db.ErrReadOnly }
+func (s *Store) SoftDeleteSessions(_ []string) (int, error)            { return 0, db.ErrReadOnly }
+func (s *Store) RestoreSession(_ string) (int64, error)                { return 0, db.ErrReadOnly }
+func (s *Store) DeleteSessionIfTrashed(_ string) (int64, error)        { return 0, db.ErrReadOnly }
 func (s *Store) EmptyTrash() (int, error)                              { return 0, db.ErrReadOnly }
 func (s *Store) UpsertSession(_ db.Session) error                      { return db.ErrReadOnly }
 func (s *Store) ReplaceSessionMessages(_ string, _ []db.Message) error { return db.ErrReadOnly }

--- a/internal/duckdb/sync.go
+++ b/internal/duckdb/sync.go
@@ -999,7 +999,7 @@ func duckSessionFingerprintFields(sess db.Session, machine string) []any {
 		sess.Cwd, sess.GitBranch, sess.SourceSessionID,
 		sess.SourceVersion, sess.TranscriptFidelity, sess.ParserMalformedLines,
 		nilString(sess.TranscriptRevision),
-		sess.IsTruncated, nilTime(sess.DeletedAt),
+		sess.IsTruncated, nilTime(sess.DeletedAt), nilString(sess.DeletionCause),
 		timeValue(sess.CreatedAt), nilString(sess.TerminationStatus),
 		sess.SecretLeakCount, sess.SecretsRulesVersion,
 	}

--- a/internal/duckdb/sync_test.go
+++ b/internal/duckdb/sync_test.go
@@ -983,6 +983,18 @@ func TestSyncPushReportsProgressAcrossBatchBoundaries(t *testing.T) {
 	assert.Equal(t, count, progress[duckSessionPushBatchSize].MessagesDone)
 }
 
+func TestDuckSessionFingerprintIncludesDeletionCause(t *testing.T) {
+	base := db.Session{ID: "session", Machine: "machine"}
+	withCause := base
+	cause := "source_missing"
+	withCause.DeletionCause = &cause
+
+	assert.NotEqual(t,
+		duckSessionFingerprintFields(base, base.Machine),
+		duckSessionFingerprintFields(withCause, withCause.Machine),
+	)
+}
+
 func TestDuckSessionFingerprintFieldsDiffer(t *testing.T) {
 	base := db.Session{
 		ID:               "sess-001",

--- a/internal/fsevents/bridge_darwin.c
+++ b/internal/fsevents/bridge_darwin.c
@@ -1,0 +1,134 @@
+#include "bridge_darwin.h"
+
+extern void goFSEventsCallback(
+    uintptr_t handle,
+    size_t count,
+    char **paths,
+    uint32_t *flags,
+    uint64_t *ids);
+
+static void avFSEventsCallback(
+    ConstFSEventStreamRef stream,
+    void *context,
+    size_t count,
+    void *eventPaths,
+    const FSEventStreamEventFlags *eventFlags,
+    const FSEventStreamEventId *eventIDs) {
+  (void)stream;
+  goFSEventsCallback(
+      (uintptr_t)context,
+      count,
+      (char **)eventPaths,
+      (uint32_t *)eventFlags,
+      (uint64_t *)eventIDs);
+}
+
+static void avFSEventsDrainCallback(void *context) {
+  (void)context;
+}
+
+AVFSEventsQueueRef avFSEventsQueueCreate(void) {
+  return dispatch_queue_create(
+      "agentsview.fsevents", DISPATCH_QUEUE_SERIAL);
+}
+
+void avFSEventsQueueRetain(AVFSEventsQueueRef queue) {
+  dispatch_retain(queue);
+}
+
+void avFSEventsQueueRelease(AVFSEventsQueueRef queue) {
+  dispatch_release(queue);
+}
+
+void avFSEventsQueueDrain(AVFSEventsQueueRef queue) {
+  dispatch_sync_f(queue, NULL, avFSEventsDrainCallback);
+}
+
+AVFSEventsStreamRef avFSEventsStreamCreate(
+    AVFSEventsQueueRef queue,
+    const char *root,
+    double latency,
+    uintptr_t handle) {
+  CFStringRef path = CFStringCreateWithFileSystemRepresentation(
+      kCFAllocatorDefault, root);
+  if (path == NULL) {
+    return NULL;
+  }
+
+  const void *values[] = {path};
+  CFArrayRef paths = CFArrayCreate(
+      kCFAllocatorDefault, values, 1, &kCFTypeArrayCallBacks);
+  if (paths == NULL) {
+    CFRelease(path);
+    return NULL;
+  }
+
+  FSEventStreamContext context = {
+      .version = 0,
+      .info = (void *)handle,
+      .retain = NULL,
+      .release = NULL,
+      .copyDescription = NULL,
+  };
+  FSEventStreamCreateFlags flags =
+      kFSEventStreamCreateFlagFileEvents |
+      kFSEventStreamCreateFlagWatchRoot;
+  FSEventStreamRef stream = FSEventStreamCreate(
+      kCFAllocatorDefault,
+      avFSEventsCallback,
+      &context,
+      paths,
+      kFSEventStreamEventIdSinceNow,
+      latency,
+      flags);
+
+  CFRelease(paths);
+  CFRelease(path);
+  if (stream == NULL) {
+    return NULL;
+  }
+
+  FSEventStreamSetDispatchQueue(stream, queue);
+  return stream;
+}
+
+bool avFSEventsStreamStart(AVFSEventsStreamRef stream) {
+  return FSEventStreamStart(stream);
+}
+
+void avFSEventsStreamStop(AVFSEventsStreamRef stream) {
+  FSEventStreamStop(stream);
+}
+
+void avFSEventsStreamInvalidate(AVFSEventsStreamRef stream) {
+  FSEventStreamInvalidate(stream);
+}
+
+void avFSEventsStreamRelease(AVFSEventsStreamRef stream) {
+  FSEventStreamRelease(stream);
+}
+
+void avFSEventsInvokeTestCallback(
+    uintptr_t handle,
+    size_t count,
+    const char *path,
+    uint32_t flags) {
+  char **paths = calloc(count, sizeof(char *));
+  uint32_t *eventFlags = calloc(count, sizeof(uint32_t));
+  uint64_t *eventIDs = calloc(count, sizeof(uint64_t));
+  if (paths == NULL || eventFlags == NULL || eventIDs == NULL) {
+    free(paths);
+    free(eventFlags);
+    free(eventIDs);
+    return;
+  }
+  for (size_t i = 0; i < count; i++) {
+    paths[i] = (char *)path;
+    eventFlags[i] = flags;
+    eventIDs[i] = i + 1;
+  }
+  goFSEventsCallback(handle, count, paths, eventFlags, eventIDs);
+  free(paths);
+  free(eventFlags);
+  free(eventIDs);
+}

--- a/internal/fsevents/bridge_darwin.h
+++ b/internal/fsevents/bridge_darwin.h
@@ -1,0 +1,34 @@
+#ifndef AGENTSVIEW_INTERNAL_FSEVENTS_BRIDGE_DARWIN_H
+#define AGENTSVIEW_INTERNAL_FSEVENTS_BRIDGE_DARWIN_H
+
+#include <CoreServices/CoreServices.h>
+#include <dispatch/dispatch.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef dispatch_queue_t AVFSEventsQueueRef;
+typedef FSEventStreamRef AVFSEventsStreamRef;
+
+AVFSEventsQueueRef avFSEventsQueueCreate(void);
+void avFSEventsQueueRetain(AVFSEventsQueueRef queue);
+void avFSEventsQueueRelease(AVFSEventsQueueRef queue);
+void avFSEventsQueueDrain(AVFSEventsQueueRef queue);
+
+AVFSEventsStreamRef avFSEventsStreamCreate(
+    AVFSEventsQueueRef queue,
+    const char *root,
+    double latency,
+    uintptr_t handle);
+bool avFSEventsStreamStart(AVFSEventsStreamRef stream);
+void avFSEventsStreamStop(AVFSEventsStreamRef stream);
+void avFSEventsStreamInvalidate(AVFSEventsStreamRef stream);
+void avFSEventsStreamRelease(AVFSEventsStreamRef stream);
+void avFSEventsInvokeTestCallback(
+    uintptr_t handle,
+    size_t count,
+    const char *path,
+    uint32_t flags);
+
+#endif

--- a/internal/fsevents/fsevents_darwin.go
+++ b/internal/fsevents/fsevents_darwin.go
@@ -1,0 +1,309 @@
+//go:build darwin && cgo
+
+package fsevents
+
+/*
+#cgo darwin LDFLAGS: -framework CoreServices
+#include "bridge_darwin.h"
+*/
+import "C"
+
+import (
+	"errors"
+	"runtime"
+	"runtime/cgo"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unsafe"
+)
+
+const (
+	callbackMaxEvents    = 8192
+	callbackMaxPathBytes = 2 << 20
+
+	eventFlagMustScanSubDirs EventFlags = 0x00000001
+	eventFlagUserDropped     EventFlags = 0x00000002
+	eventFlagKernelDropped   EventFlags = 0x00000004
+	eventFlagEventIDsWrapped EventFlags = 0x00000008
+	eventFlagItemCreated     EventFlags = 0x00000100
+)
+
+var (
+	errQueueUnavailable = errors.New("fsevents queue is unavailable")
+	errStreamClosed     = errors.New("fsevents stream is closed")
+)
+
+// Event is one file-system change delivered by FSEvents.
+type Event struct {
+	Path  string
+	ID    uint64
+	Flags EventFlags
+}
+
+// EventFlags contains the native flags associated with an Event.
+type EventFlags uint32
+
+// Queue owns a shared serial dispatch queue used by one or more streams.
+type Queue struct {
+	mu     sync.Mutex
+	native C.AVFSEventsQueueRef
+	refs   uint64
+}
+
+// Stream delivers events for one root on a shared Queue.
+type Stream struct {
+	mu     sync.Mutex
+	native C.AVFSEventsStreamRef
+	queue  *Queue
+	handle cgo.Handle
+	sink   func([]Event)
+	// callbackStats is an internal binding-boundary test observer. Production
+	// streams leave it nil.
+	callbackStats func(events, pathBytes int)
+	started       bool
+	stopping      atomic.Bool
+	closeOnce     sync.Once
+}
+
+// NewQueue creates a shared serial dispatch queue for FSEvents callbacks.
+func NewQueue() (*Queue, error) {
+	native := C.avFSEventsQueueCreate()
+	if native == nil {
+		return nil, errors.New("create FSEvents dispatch queue")
+	}
+	queue := &Queue{native: native, refs: 1}
+	runtime.SetFinalizer(queue, finalizeQueue)
+	return queue, nil
+}
+
+// NewStream creates a stream for root and schedules it on q.
+// The sink runs on q's serial callback queue and must not call Close
+// synchronously.
+func NewStream(q *Queue, root string, latency time.Duration, sink func([]Event)) (*Stream, error) {
+	if q == nil {
+		return nil, errors.New("fsevents queue is nil")
+	}
+	if root == "" {
+		return nil, errors.New("fsevents root is empty")
+	}
+	if latency < 0 {
+		return nil, errors.New("fsevents latency is negative")
+	}
+	if sink == nil {
+		return nil, errors.New("fsevents sink is nil")
+	}
+
+	nativeQueue, err := q.retain()
+	if err != nil {
+		return nil, err
+	}
+	stream := &Stream{queue: q, sink: sink}
+	stream.handle = cgo.NewHandle(stream)
+
+	cRoot := C.CString(root)
+	defer C.free(unsafe.Pointer(cRoot))
+	stream.native = C.avFSEventsStreamCreate(
+		nativeQueue,
+		cRoot,
+		C.double(latency.Seconds()),
+		C.uintptr_t(stream.handle),
+	)
+	if stream.native == nil {
+		stream.handle.Delete()
+		q.release()
+		return nil, errors.New("create FSEvents stream")
+	}
+	return stream, nil
+}
+
+// Start begins delivering events to the stream's sink.
+func (s *Stream) Start() error {
+	if s == nil {
+		return errStreamClosed
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.stopping.Load() || s.native == nil {
+		return errStreamClosed
+	}
+	if s.started {
+		return nil
+	}
+	if !bool(C.avFSEventsStreamStart(s.native)) {
+		return errors.New("start FSEvents stream")
+	}
+	s.started = true
+	return nil
+}
+
+// Close stops delivery, drains callback ownership, and releases the stream.
+func (s *Stream) Close() error {
+	if s == nil {
+		return nil
+	}
+	s.closeOnce.Do(func() {
+		s.stopping.Store(true)
+
+		s.mu.Lock()
+		native := s.native
+		queue := s.queue
+		started := s.started
+		s.mu.Unlock()
+		if native == nil {
+			return
+		}
+
+		if started {
+			C.avFSEventsStreamStop(native)
+		}
+		C.avFSEventsStreamInvalidate(native)
+		queue.drain()
+		C.avFSEventsStreamRelease(native)
+		s.handle.Delete()
+		queue.release()
+
+		s.mu.Lock()
+		s.native = nil
+		s.queue = nil
+		s.started = false
+		s.handle = 0
+		s.mu.Unlock()
+	})
+	return nil
+}
+
+func (q *Queue) retain() (C.AVFSEventsQueueRef, error) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.native == nil {
+		return nil, errQueueUnavailable
+	}
+	C.avFSEventsQueueRetain(q.native)
+	q.refs++
+	return q.native, nil
+}
+
+func (q *Queue) release() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.native == nil || q.refs <= 1 {
+		return
+	}
+	C.avFSEventsQueueRelease(q.native)
+	q.refs--
+}
+
+func (q *Queue) drain() {
+	q.mu.Lock()
+	native := q.native
+	q.mu.Unlock()
+	if native != nil {
+		C.avFSEventsQueueDrain(native)
+	}
+}
+
+func finalizeQueue(q *Queue) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.native == nil {
+		return
+	}
+	C.avFSEventsQueueRelease(q.native)
+	q.native = nil
+	q.refs = 0
+}
+
+//export goFSEventsCallback
+func goFSEventsCallback(
+	handle C.uintptr_t,
+	count C.size_t,
+	paths **C.char,
+	flags *C.uint32_t,
+	ids *C.uint64_t,
+) {
+	stream := cgo.Handle(handle).Value().(*Stream)
+	if stream.stopping.Load() || count == 0 {
+		return
+	}
+	if count > C.size_t(callbackMaxEvents) {
+		stream.deliverCallback(
+			[]Event{{Flags: eventFlagMustScanSubDirs}},
+			0,
+			0,
+		)
+		return
+	}
+	n := int(count)
+	if n < 0 || C.size_t(n) != count {
+		return
+	}
+
+	pathValues := unsafe.Slice(paths, n)
+	flagValues := unsafe.Slice(flags, n)
+	idValues := unsafe.Slice(ids, n)
+	events := make([]Event, 0, n)
+	copiedBytes := 0
+	for i := range n {
+		eventFlags := EventFlags(flagValues[i])
+		if eventFlags&(eventFlagMustScanSubDirs|
+			eventFlagUserDropped|
+			eventFlagKernelDropped|
+			eventFlagEventIDsWrapped) != 0 {
+			stream.deliverCallback(
+				[]Event{{Flags: eventFlagMustScanSubDirs}},
+				len(events),
+				copiedBytes,
+			)
+			return
+		}
+		remaining := callbackMaxPathBytes - copiedBytes
+		if pathValues[i] == nil {
+			stream.deliverCallback(
+				[]Event{{Flags: eventFlagMustScanSubDirs}},
+				len(events),
+				copiedBytes,
+			)
+			return
+		}
+		pathLen := int(C.strnlen(pathValues[i], C.size_t(remaining+1)))
+		if pathLen > remaining {
+			stream.deliverCallback(
+				[]Event{{Flags: eventFlagMustScanSubDirs}},
+				len(events),
+				copiedBytes,
+			)
+			return
+		}
+		events = append(events, Event{
+			Path:  C.GoStringN(pathValues[i], C.int(pathLen)),
+			ID:    uint64(idValues[i]),
+			Flags: eventFlags,
+		})
+		copiedBytes += pathLen
+	}
+	stream.deliverCallback(events, len(events), copiedBytes)
+}
+
+func (s *Stream) deliverCallback(events []Event, copiedEvents, copiedBytes int) {
+	if s.stopping.Load() {
+		return
+	}
+	if s.callbackStats != nil {
+		s.callbackStats(copiedEvents, copiedBytes)
+	}
+	s.sink(events)
+}
+
+func invokeTestCallback(stream *Stream, count int, path string, flags EventFlags) {
+	handle := cgo.NewHandle(stream)
+	defer handle.Delete()
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+	C.avFSEventsInvokeTestCallback(
+		C.uintptr_t(handle),
+		C.size_t(count),
+		cPath,
+		C.uint32_t(flags),
+	)
+}

--- a/internal/fsevents/fsevents_darwin_test.go
+++ b/internal/fsevents/fsevents_darwin_test.go
@@ -1,0 +1,272 @@
+//go:build darwin && cgo
+
+package fsevents
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const streamTestTimeout = 10 * time.Second
+
+func TestStreamCallbackBoundsNativeDelivery(t *testing.T) {
+	longPath := "/sessions/" + strings.Repeat("x", 300) + ".jsonl"
+	tests := []struct {
+		name       string
+		count      int
+		path       string
+		wantCopies int
+		wantBytes  int
+	}{
+		{
+			name:  "event count",
+			count: callbackMaxEvents + 1,
+			path:  "/sessions/event.jsonl",
+		},
+		{
+			name:       "path bytes",
+			count:      callbackMaxEvents,
+			path:       longPath,
+			wantCopies: callbackMaxPathBytes / len(longPath),
+			wantBytes:  (callbackMaxPathBytes / len(longPath)) * len(longPath),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var got []Event
+			var copiedEvents int
+			var copiedBytes int
+			stream := &Stream{
+				sink: func(events []Event) {
+					got = append([]Event(nil), events...)
+				},
+				callbackStats: func(events, bytes int) {
+					copiedEvents = events
+					copiedBytes = bytes
+				},
+			}
+
+			invokeTestCallback(stream, tc.count, tc.path, eventFlagItemCreated)
+
+			assert.Equal(t, []Event{{Flags: eventFlagMustScanSubDirs}}, got)
+			assert.Equal(t, tc.wantCopies, copiedEvents)
+			assert.Equal(t, tc.wantBytes, copiedBytes)
+			assert.LessOrEqual(t, copiedEvents, callbackMaxEvents)
+			assert.LessOrEqual(t, copiedBytes, callbackMaxPathBytes)
+		})
+	}
+}
+
+func TestStreamDeliversFileEvent(t *testing.T) {
+	root := t.TempDir()
+	events := make(chan Event, 16)
+	newTestStream(t, root, func(batch []Event) {
+		for _, event := range batch {
+			events <- event
+		}
+	})
+
+	path := filepath.Join(root, "created.txt")
+	require.NoError(t, os.WriteFile(path, []byte("created"), 0o600))
+	event := waitForPath(t, events, filepath.Join(canonicalPath(t, root), "created.txt"))
+
+	assert.NotZero(t, event.ID)
+	assert.NotZero(t, event.Flags&eventFlagItemCreated)
+}
+
+func TestStreamCloseIsConcurrentAndIdempotent(t *testing.T) {
+	stream := newTestStream(t, t.TempDir(), func([]Event) {})
+
+	const callers = 16
+	errs := make(chan error, callers)
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Go(func() {
+			errs <- stream.Close()
+		})
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		assert.NoError(t, err)
+	}
+	assert.NoError(t, stream.Close())
+}
+
+func TestStreamCloseWaitsForCallback(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(canonicalPath(t, root), "blocked.txt")
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	stream := newTestStream(t, root, func(batch []Event) {
+		for _, event := range batch {
+			if event.Path == path {
+				close(entered)
+				<-release
+				return
+			}
+		}
+	})
+
+	require.NoError(t, os.WriteFile(filepath.Join(root, "blocked.txt"), []byte("blocked"), 0o600))
+	requireReceive(t, entered)
+
+	closed := make(chan error, 1)
+	go func() {
+		closed <- stream.Close()
+	}()
+	assert.Never(t, func() bool {
+		return len(closed) != 0
+	}, 200*time.Millisecond, 10*time.Millisecond)
+
+	close(release)
+	require.NoError(t, requireReceive(t, closed))
+}
+
+func TestStreamCopiesCallbackData(t *testing.T) {
+	root := t.TempDir()
+	events := make(chan Event, 128)
+	stream := newTestStream(t, root, func(batch []Event) {
+		for _, event := range batch {
+			events <- event
+		}
+	})
+
+	firstPath := filepath.Join(root, "first.txt")
+	require.NoError(t, os.WriteFile(firstPath, []byte("first"), 0o600))
+	canonicalFirstPath := filepath.Join(canonicalPath(t, root), "first.txt")
+	first := waitForPath(t, events, canonicalFirstPath)
+
+	var lastPath string
+	for i := range 32 {
+		path := filepath.Join(root, fmt.Sprintf("reuse-%02d.txt", i))
+		require.NoError(t, os.WriteFile(path, []byte("reuse"), 0o600))
+		lastPath = path
+	}
+	waitForPath(t, events, filepath.Join(canonicalPath(t, root), filepath.Base(lastPath)))
+
+	assert.Equal(t, canonicalFirstPath, first.Path)
+	assert.NotZero(t, first.ID)
+	assert.NotZero(t, first.Flags)
+	assert.NoError(t, stream.Close())
+}
+
+func TestStreamHasNoCallbacksAfterCloseReturns(t *testing.T) {
+	root := t.TempDir()
+	events := make(chan Event, 16)
+	stream := newTestStream(t, root, func(batch []Event) {
+		for _, event := range batch {
+			events <- event
+		}
+	})
+
+	beforeClose := filepath.Join(root, "before-close.txt")
+	require.NoError(t, os.WriteFile(beforeClose, []byte("before"), 0o600))
+	waitForPath(t, events, filepath.Join(canonicalPath(t, root), "before-close.txt"))
+	require.NoError(t, stream.Close())
+	drainEvents(events)
+
+	afterClose := filepath.Join(root, "after-close.txt")
+	require.NoError(t, os.WriteFile(afterClose, []byte("after"), 0o600))
+	assert.Never(t, func() bool {
+		select {
+		case <-events:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 20*time.Millisecond)
+}
+
+func TestStreamClosingSharedQueueSiblingKeepsOtherStreamRunning(t *testing.T) {
+	queue, err := NewQueue()
+	require.NoError(t, err)
+
+	firstRoot := t.TempDir()
+	first, err := NewStream(queue, firstRoot, 500*time.Millisecond, func([]Event) {})
+	require.NoError(t, err)
+	require.NoError(t, first.Start())
+	t.Cleanup(func() { assert.NoError(t, first.Close()) })
+
+	secondRoot := t.TempDir()
+	events := make(chan Event, 16)
+	second, err := NewStream(queue, secondRoot, 500*time.Millisecond, func(batch []Event) {
+		for _, event := range batch {
+			events <- event
+		}
+	})
+	require.NoError(t, err)
+	require.NoError(t, second.Start())
+	t.Cleanup(func() { assert.NoError(t, second.Close()) })
+
+	require.NoError(t, first.Close())
+	path := filepath.Join(secondRoot, "sibling.txt")
+	require.NoError(t, os.WriteFile(path, []byte("sibling"), 0o600))
+	waitForPath(t, events, filepath.Join(canonicalPath(t, secondRoot), "sibling.txt"))
+}
+
+func newTestStream(t *testing.T, root string, sink func([]Event)) *Stream {
+	t.Helper()
+	queue, err := NewQueue()
+	require.NoError(t, err)
+	stream, err := NewStream(queue, root, 500*time.Millisecond, sink)
+	require.NoError(t, err)
+	require.NoError(t, stream.Start())
+	t.Cleanup(func() { assert.NoError(t, stream.Close()) })
+	return stream
+}
+
+func waitForPath(t *testing.T, events <-chan Event, path string) Event {
+	t.Helper()
+	timer := time.NewTimer(streamTestTimeout)
+	defer timer.Stop()
+	for {
+		select {
+		case event := <-events:
+			if event.Path == path {
+				return event
+			}
+		case <-timer.C:
+			require.FailNow(t, "timed out waiting for FSEvent", "path: %s", path)
+		}
+	}
+}
+
+func canonicalPath(t *testing.T, path string) string {
+	t.Helper()
+	canonical, err := filepath.EvalSymlinks(path)
+	require.NoError(t, err)
+	return canonical
+}
+
+func requireReceive[T any](t *testing.T, ch <-chan T) T {
+	t.Helper()
+	select {
+	case value := <-ch:
+		return value
+	case <-time.After(streamTestTimeout):
+		require.FailNow(t, "timed out waiting for channel value")
+		var zero T
+		return zero
+	}
+}
+
+func drainEvents(events <-chan Event) {
+	for {
+		select {
+		case <-events:
+		default:
+			return
+		}
+	}
+}

--- a/internal/parser/aider.go
+++ b/internal/parser/aider.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"bufio"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -596,22 +597,98 @@ func parseAiderRunWithID(
 	if err != nil {
 		return nil, nil, fmt.Errorf("stat %s: %w", path, err)
 	}
-	data, err := os.ReadFile(path)
+	run, found, err := scanAiderRun(path, idx)
 	if err != nil {
-		return nil, nil, fmt.Errorf("read %s: %w", path, err)
+		return nil, nil, err
 	}
-	runs := splitAiderRuns(string(data))
-	if idx < 0 || idx >= len(runs) {
+	if !found {
 		return nil, nil, nil
 	}
-	ordinals := aiderEqualHeaderOrdinals(runs)
+	ordinal, err := aiderHeaderOrdinalAt(path, idx, run.rawHeader)
+	if err != nil {
+		return nil, nil, err
+	}
 	sess, msgs := buildAiderRunSession(
-		path, idPath, machine, info, runs[idx], idx, ordinals[idx],
+		path, idPath, machine, info, run, idx, ordinal,
 	)
 	if sess == nil {
 		return nil, nil, nil
 	}
 	return sess, msgs, nil
+}
+
+func scanAiderRun(path string, target int) (aiderRun, bool, error) {
+	if target < 0 {
+		return aiderRun{}, false, nil
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return aiderRun{}, false, fmt.Errorf("read %s: %w", path, err)
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 64*1024), maxLineSize)
+	idx := -1
+	var run aiderRun
+	var body strings.Builder
+	for scanner.Scan() {
+		line := strings.TrimSuffix(scanner.Text(), "\r")
+		if strings.HasPrefix(line, aiderHeaderPrefix) {
+			if idx == target {
+				run.body = body.String()
+				return run, true, nil
+			}
+			idx++
+			if idx == target {
+				raw := strings.TrimSpace(
+					strings.TrimPrefix(line, aiderHeaderPrefix),
+				)
+				run = aiderRun{rawHeader: raw}
+				run.started, run.hasTime = parseAiderTimestamp(raw)
+				body.Reset()
+			}
+			continue
+		}
+		if idx == target {
+			body.WriteString(line)
+			body.WriteByte('\n')
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return aiderRun{}, false, fmt.Errorf("read %s: %w", path, err)
+	}
+	if idx == target {
+		run.body = body.String()
+		return run, true, nil
+	}
+	return aiderRun{}, false, nil
+}
+
+func aiderHeaderOrdinalAt(path string, target int, rawHeader string) (int, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 64*1024), maxLineSize)
+	idx, ordinal := -1, 0
+	for scanner.Scan() {
+		line := strings.TrimSuffix(scanner.Text(), "\r")
+		if !strings.HasPrefix(line, aiderHeaderPrefix) {
+			continue
+		}
+		idx++
+		if idx >= target {
+			break
+		}
+		if strings.TrimSpace(
+			strings.TrimPrefix(line, aiderHeaderPrefix),
+		) == rawHeader {
+			ordinal++
+		}
+	}
+	return ordinal, scanner.Err()
 }
 
 // parseAiderRuns reads a history file once and parses every run into its

--- a/internal/parser/aider_provider.go
+++ b/internal/parser/aider_provider.go
@@ -1,10 +1,18 @@
 package parser
 
 import (
+	"bufio"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
+	"strings"
+	"time"
 )
 
 // Aider appends every run to a single history file
@@ -27,11 +35,36 @@ func newAiderProviderFactory(def AgentDef) ProviderFactory {
 				AgentAider,
 				cfg.Roots,
 				WithContainerDiscovery(aiderDiscoverContainers),
+				WithStreamingSourceDiscovery(
+					func(ctx context.Context, root string, yield func(multiSessionMatch) error) error {
+						return streamAiderContainers(ctx, root, func(container string) error {
+							idPath := aiderIdentityForPath(container, identity)
+							if err := streamAiderRunIndexes(ctx, container, idPath, func(idx int, rawID string) error {
+								return yield(multiSessionMatch{
+									Path:      AiderVirtualPath(container, idx),
+									Container: container, MemberID: strconv.Itoa(idx),
+									ReconciliationIdentity: rawID,
+								})
+							}); err != nil {
+								return err
+							}
+							return nil
+						})
+					},
+				),
 				WithWatchRoots(aiderWatchRoots),
 				WithChangedPathClassifier(aiderClassifyPath),
 				WithMemberLookup(
 					func(root, rawID string) (multiSessionMatch, bool) {
 						return aiderFindMember(root, rawID, identity)
+					},
+				),
+				WithReconciliationIdentity(
+					func(ctx context.Context, match multiSessionMatch) (string, error) {
+						return aiderReconciliationIdentity(ctx, match, identity)
+					},
+					func(fullSessionID string) string {
+						return ProviderRawSessionIDFromFull(def, fullSessionID)
 					},
 				),
 				// A canonical remote-sync path (rewritten identity) must map
@@ -50,15 +83,15 @@ func newAiderProviderFactory(def AgentDef) ProviderFactory {
 						return aiderStoredMemberMatchesRawID(src, rawID, identity)
 					},
 				),
-				WithFingerprint(aiderFingerprintSource),
+				WithContextFingerprint(aiderFingerprintSourceContext),
 				WithContainerParse(
 					func(src multiSessionSource, req ParseRequest) ([]ParseResult, error) {
 						return aiderParseContainer(src, req.Machine, identity)
 					},
 				),
-				WithMemberParse(
-					func(src multiSessionSource, req ParseRequest) (*ParseResult, error) {
-						return aiderParseMember(src, req.Machine, identity)
+				WithContextMemberParse(
+					func(ctx context.Context, src multiSessionSource, req ParseRequest) (*ParseResult, error) {
+						return aiderParseMemberContext(ctx, src, req.Machine, identity)
 					},
 				),
 				// Every run shares the history file's content hash, so a write
@@ -67,6 +100,308 @@ func newAiderProviderFactory(def AgentDef) ProviderFactory {
 			)
 		},
 	)
+}
+
+// streamAiderContainers preserves Aider's rootless walk limits while reading
+// every directory in fixed-size batches. The legacy collecting discovery path
+// remains sorted for callers that request Discover; forced reconciliation uses
+// this direct traversal and never materializes the archive's container list.
+func streamAiderContainers(
+	ctx context.Context, root string, yield func(string) error,
+) error {
+	if root == "" {
+		return nil
+	}
+	root = filepath.Clean(root)
+	skipProtected := aiderShouldSkipProtectedHomeDirs(root, aiderHomeDir(), runtime.GOOS)
+	started := time.Now()
+	limits := discoveryTraversalLimitsFor(ctx)
+	maxDirs := aiderMaxDirs
+	if limits.maxDirs > 0 {
+		maxDirs = limits.maxDirs
+	}
+	maxFiles := aiderMaxFiles
+	if limits.maxFiles > 0 {
+		maxFiles = limits.maxFiles
+	}
+	expired := limits.expired
+	if expired == nil {
+		expired = func() bool { return time.Since(started) >= aiderWalkBudget }
+	}
+	dirs, files := 0, 0
+	var walk func(string, int) error
+	walk = func(dir string, depth int) error {
+		if expired() {
+			return DiscoveryIncompleteError{Provider: AgentAider, Reason: "time budget exceeded"}
+		}
+		dirs++
+		if dirs > maxDirs {
+			return DiscoveryIncompleteError{Provider: AgentAider, Reason: "directory limit exceeded"}
+		}
+		return streamDirectoryEntries(ctx, dir, func(entry os.DirEntry) error {
+			if expired() {
+				return DiscoveryIncompleteError{Provider: AgentAider, Reason: "time budget exceeded"}
+			}
+			if entry.Type()&os.ModeSymlink != 0 {
+				return nil
+			}
+			path := filepath.Join(dir, entry.Name())
+			if entry.IsDir() {
+				if depth == 0 && skipProtected {
+					if _, skip := aiderProtectedHomeDirs[entry.Name()]; skip {
+						return nil
+					}
+				}
+				if _, skip := aiderSkipDirs[entry.Name()]; skip {
+					return nil
+				}
+				if depth+1 > aiderMaxWalkDepth {
+					return nil
+				}
+				return walk(path, depth+1)
+			}
+			if entry.Name() != aiderHistoryFile {
+				return nil
+			}
+			if err := yield(path); err != nil {
+				return err
+			}
+			files++
+			if files >= maxFiles {
+				return DiscoveryIncompleteError{Provider: AgentAider, Reason: "file limit exceeded"}
+			}
+			return nil
+		})
+	}
+	return walk(root, 0)
+}
+
+func streamAiderRunIndexes(
+	ctx context.Context, path, idPath string, yield func(int, string) error,
+) error {
+	if reconciliationCacheAvailable(ctx) {
+		return streamAndCacheAiderRuns(ctx, path, idPath, yield)
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 64*1024), maxLineSize)
+	idx := 0
+	headerOrdinals := make(map[string]int)
+	for scanner.Scan() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		line := strings.TrimSuffix(scanner.Text(), "\r")
+		if after, ok := strings.CutPrefix(line, aiderHeaderPrefix); ok {
+			// splitAiderRuns trims the header before hashing; every
+			// scanner path must match or the same run gets a second ID.
+			rawHeader := strings.TrimSpace(after)
+			ordinal := headerOrdinals[rawHeader]
+			headerOrdinals[rawHeader]++
+			observeStreamingDiscoveryBuffer(ctx, 1)
+			rawID := aiderRawID(aiderIdentityPath(path, idPath), rawHeader, ordinal)
+			if err := yield(idx, rawID); err != nil {
+				return err
+			}
+			idx++
+		}
+	}
+	return scanner.Err()
+}
+
+type cachedAiderRun struct {
+	RawHeader string `json:"raw_header"`
+	Body      string `json:"body"`
+	Ordinal   int    `json:"ordinal"`
+}
+
+func aiderCachedRunKey(path string, idx int) string {
+	return "aider:run:" + AiderVirtualPath(filepath.Clean(path), idx)
+}
+
+func aiderCachedRunCountKey(path string) string {
+	return "aider:run-count:" + filepath.Clean(path)
+}
+
+func streamAndCacheAiderRuns(
+	ctx context.Context, path, idPath string, yield func(int, string) error,
+) error {
+	replayed, err := replayCachedAiderRuns(ctx, path, idPath, yield)
+	if err != nil {
+		return err
+	}
+	if replayed {
+		return nil
+	}
+	scanID, err := reconciliationCacheAddInt(ctx, "aider:scan")
+	if err != nil {
+		return err
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	observeSharedContainerScan(ctx)
+	hasher := sha256.New()
+	scanner := bufio.NewScanner(io.TeeReader(file, hasher))
+	scanner.Buffer(make([]byte, 64*1024), maxLineSize)
+	idx := -1
+	var rawHeader string
+	var body strings.Builder
+	flush := func() error {
+		if idx < 0 {
+			return nil
+		}
+		ordinal, err := reconciliationCacheAddInt(
+			ctx, "aider:header:"+strconv.Itoa(scanID)+":"+
+				filepath.Clean(path)+"\x00"+rawHeader,
+		)
+		if err != nil {
+			return err
+		}
+		encoded, err := json.Marshal(cachedAiderRun{
+			RawHeader: rawHeader, Body: body.String(), Ordinal: ordinal,
+		})
+		if err != nil {
+			return err
+		}
+		observeStreamingRetainedBytes(ctx, int64(len(encoded)))
+		err = reconciliationCachePut(ctx, aiderCachedRunKey(path, idx), string(encoded))
+		observeStreamingRetainedBytes(ctx, -int64(len(encoded)))
+		if err != nil {
+			return err
+		}
+		observeStreamingDiscoveryBuffer(ctx, 1)
+		rawID := aiderRawID(aiderIdentityPath(path, idPath), rawHeader, ordinal)
+		return yield(idx, rawID)
+	}
+	for scanner.Scan() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		line := strings.TrimSuffix(scanner.Text(), "\r")
+		if strings.HasPrefix(line, aiderHeaderPrefix) {
+			if err := flush(); err != nil {
+				return err
+			}
+			idx++
+			rawHeader = strings.TrimSpace(
+				strings.TrimPrefix(line, aiderHeaderPrefix),
+			)
+			body.Reset()
+			continue
+		}
+		if idx >= 0 {
+			body.WriteString(line)
+			body.WriteByte('\n')
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+	if err := flush(); err != nil {
+		return err
+	}
+	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	encoded, err := json.Marshal(SourceFingerprint{
+		Size: info.Size(), MTimeNS: info.ModTime().UnixNano(),
+		Hash: fmt.Sprintf("%x", hasher.Sum(nil)),
+	})
+	if err != nil {
+		return err
+	}
+	if err := reconciliationCachePut(
+		ctx, aiderCachedFingerprintKey(path), string(encoded),
+	); err != nil {
+		return err
+	}
+	return reconciliationCachePut(
+		ctx, aiderCachedRunCountKey(path), strconv.Itoa(idx+1),
+	)
+}
+
+func replayCachedAiderRuns(
+	ctx context.Context, path, idPath string, yield func(int, string) error,
+) (bool, error) {
+	encodedCount, found, err := reconciliationCacheGet(
+		ctx, aiderCachedRunCountKey(path),
+	)
+	if err != nil || !found {
+		return false, err
+	}
+	count, err := strconv.Atoi(encodedCount)
+	if err != nil || count < 0 {
+		return false, fmt.Errorf("decode cached aider run count %q", encodedCount)
+	}
+	for idx := range count {
+		encoded, runFound, err := reconciliationCacheGet(
+			ctx, aiderCachedRunKey(path, idx),
+		)
+		if err != nil {
+			return false, err
+		}
+		if !runFound {
+			return false, fmt.Errorf(
+				"cached aider run %d missing after completed scan", idx,
+			)
+		}
+		observeStreamingRetainedBytes(ctx, int64(len(encoded)))
+		var cached cachedAiderRun
+		if err := json.Unmarshal([]byte(encoded), &cached); err != nil {
+			observeStreamingRetainedBytes(ctx, -int64(len(encoded)))
+			return false, fmt.Errorf("decode cached aider run: %w", err)
+		}
+		observeStreamingDiscoveryBuffer(ctx, 1)
+		rawID := aiderRawID(
+			aiderIdentityPath(path, idPath), cached.RawHeader, cached.Ordinal,
+		)
+		err = yield(idx, rawID)
+		observeStreamingRetainedBytes(ctx, -int64(len(encoded)))
+		if err != nil {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+func aiderReconciliationIdentity(
+	ctx context.Context, match multiSessionMatch, identity func(string) string,
+) (string, error) {
+	idx, err := strconv.Atoi(match.MemberID)
+	if err != nil {
+		return "", fmt.Errorf("invalid aider run index %q: %w", match.MemberID, err)
+	}
+	encoded, found, err := reconciliationCacheGet(
+		ctx, aiderCachedRunKey(match.Container, idx),
+	)
+	if err != nil {
+		return "", err
+	}
+	if found {
+		var cached cachedAiderRun
+		if err := json.Unmarshal([]byte(encoded), &cached); err != nil {
+			return "", fmt.Errorf("decode cached aider run identity: %w", err)
+		}
+		return aiderRawID(
+			aiderIdentityPath(match.Container, aiderIdentityForPath(match.Container, identity)),
+			cached.RawHeader, cached.Ordinal,
+		), nil
+	}
+	rawID, ok := aiderRawIDAtWithID(
+		match.Container, aiderIdentityForPath(match.Container, identity), idx,
+	)
+	if !ok {
+		return "", nil
+	}
+	return rawID, nil
 }
 
 func aiderDiscoverContainers(root string) []string {
@@ -274,6 +609,29 @@ func aiderFingerprintSource(src multiSessionSource) (SourceFingerprint, error) {
 	}, nil
 }
 
+func aiderCachedFingerprintKey(path string) string {
+	return "aider:fingerprint:" + filepath.Clean(path)
+}
+
+func aiderFingerprintSourceContext(
+	ctx context.Context, src multiSessionSource,
+) (SourceFingerprint, error) {
+	encoded, found, err := reconciliationCacheGet(
+		ctx, aiderCachedFingerprintKey(src.Container),
+	)
+	if err != nil {
+		return SourceFingerprint{}, err
+	}
+	if !found {
+		return aiderFingerprintSource(src)
+	}
+	var fingerprint SourceFingerprint
+	if err := json.Unmarshal([]byte(encoded), &fingerprint); err != nil {
+		return SourceFingerprint{}, fmt.Errorf("decode cached aider fingerprint: %w", err)
+	}
+	return fingerprint, nil
+}
+
 func aiderParseMember(
 	src multiSessionSource, machine string, identity func(string) string,
 ) (*ParseResult, error) {
@@ -286,6 +644,43 @@ func aiderParseMember(
 	if err != nil {
 		return nil, err
 	}
+	if sess == nil {
+		return nil, nil
+	}
+	return &ParseResult{Session: *sess, Messages: msgs}, nil
+}
+
+func aiderParseMemberContext(
+	ctx context.Context, src multiSessionSource, machine string,
+	identity func(string) string,
+) (*ParseResult, error) {
+	idx, err := strconv.Atoi(src.MemberID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid aider run index %q: %w", src.MemberID, err)
+	}
+	encoded, found, err := reconciliationCacheGet(ctx, aiderCachedRunKey(src.Container, idx))
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return aiderParseMember(src, machine, identity)
+	}
+	observeStreamingRetainedBytes(ctx, int64(len(encoded)))
+	defer observeStreamingRetainedBytes(ctx, -int64(len(encoded)))
+	var cached cachedAiderRun
+	if err := json.Unmarshal([]byte(encoded), &cached); err != nil {
+		return nil, fmt.Errorf("decode cached aider run: %w", err)
+	}
+	info, err := os.Stat(src.Container)
+	if err != nil {
+		return nil, fmt.Errorf("stat %s: %w", src.Container, err)
+	}
+	run := aiderRun{rawHeader: cached.RawHeader, body: cached.Body}
+	run.started, run.hasTime = parseAiderTimestamp(cached.RawHeader)
+	sess, msgs := buildAiderRunSession(
+		src.Container, aiderIdentityForPath(src.Container, identity), machine,
+		info, run, idx, cached.Ordinal,
+	)
 	if sess == nil {
 		return nil, nil
 	}

--- a/internal/parser/aider_provider_test.go
+++ b/internal/parser/aider_provider_test.go
@@ -2,6 +2,8 @@ package parser
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,6 +12,47 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestAiderStreamingDiscoveryReportsTraversalLimits(t *testing.T) {
+	writeHistory := func(t *testing.T, root, project string) {
+		t.Helper()
+		dir := filepath.Join(root, project)
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, aiderHistoryFile),
+			[]byte("# aider chat started at 2026-07-14 12:00:00\n#### hello\nworld\n"),
+			0o600,
+		))
+	}
+
+	for _, tc := range []struct {
+		name   string
+		limits discoveryTraversalLimits
+		files  int
+		want   string
+	}{
+		{name: "time", limits: discoveryTraversalLimits{expired: func() bool { return true }}, files: 1, want: "time budget"},
+		{name: "directories", limits: discoveryTraversalLimits{maxDirs: 1}, files: 2, want: "directory limit"},
+		{name: "files", limits: discoveryTraversalLimits{maxFiles: 1}, files: 2, want: "file limit"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			for i := range tc.files {
+				writeHistory(t, root, fmt.Sprintf("project-%d", i))
+			}
+			provider, ok := NewProvider(AgentAider, ProviderConfig{Roots: []string{root}})
+			require.True(t, ok)
+			ctx := withDiscoveryTraversalLimits(t.Context(), tc.limits)
+
+			err := provider.(StreamingDiscoverer).DiscoverEach(ctx, func(SourceRef) error { return nil })
+
+			var incomplete DiscoveryIncompleteError
+			require.ErrorAs(t, err, &incomplete)
+			assert.Contains(t, err.Error(), tc.want)
+			assert.False(t, errors.Is(err, context.Canceled))
+		})
+	}
+}
 
 func TestAiderProviderFindSourceUsesCanonicalIdentity(t *testing.T) {
 	root := t.TempDir()

--- a/internal/parser/aider_test.go
+++ b/internal/parser/aider_test.go
@@ -718,3 +718,47 @@ func TestFindAiderSourceFile(t *testing.T) {
 	assert.Empty(t, findAiderSourceFile(root, "nonexistent-id"))
 	assert.Empty(t, findAiderSourceFile("", "anything"))
 }
+
+// A run header with trailing whitespace must resolve to one identity
+// everywhere: the canonical full split trims it before hashing, so the
+// single-run scanner and streamed discovery must trim it too, or the
+// same run gets a second session ID and the original is tombstoned
+// during reconciliation.
+func TestAiderTrailingWhitespaceHeaderKeepsOneIdentity(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "project", ".aider.chat.history.md")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	content := "# aider chat started at 2024-01-02 03:04:05 \n" +
+		"\n#### first prompt\nfirst answer\n" +
+		"# aider chat started at 2024-01-02 03:04:05 \n" +
+		"\n#### second prompt\nsecond answer\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	full, err := parseAiderRuns(path, "local")
+	require.NoError(t, err)
+	require.Len(t, full, 2)
+
+	for idx, want := range full {
+		sess, _, err := parseAiderRun(path, idx, "local")
+		require.NoError(t, err)
+		require.NotNil(t, sess)
+		assert.Equal(t, want.Session.ID, sess.ID,
+			"single-run scan must derive the same identity as the full split")
+	}
+
+	var streamed []string
+	require.NoError(t, streamAiderRunIndexes(
+		t.Context(), path, "",
+		func(_ int, rawID string) error {
+			streamed = append(streamed, rawID)
+			return nil
+		},
+	))
+	require.Len(t, streamed, 2)
+	for idx, want := range full {
+		assert.Equal(t, want.Session.ID, aiderIDPrefix+streamed[idx],
+			"streamed discovery must derive the same identity as the full split")
+	}
+}

--- a/internal/parser/antigravity_cli_provider.go
+++ b/internal/parser/antigravity_cli_provider.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -46,6 +47,10 @@ type antigravityCLIProvider struct {
 
 func (p *antigravityCLIProvider) Discover(ctx context.Context) ([]SourceRef, error) {
 	return p.sources.Discover(ctx)
+}
+
+func (p *antigravityCLIProvider) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	return p.sources.DiscoverEach(ctx, yield)
 }
 
 func (p *antigravityCLIProvider) WatchPlan(ctx context.Context) (WatchPlan, error) {
@@ -172,6 +177,52 @@ func (s antigravityCLISourceSet) Discover(ctx context.Context) ([]SourceRef, err
 	}
 	sortJSONLSources(sources)
 	return sources, nil
+}
+
+func (s antigravityCLISourceSet) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	for _, root := range s.roots {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		projects, err := newDiscoveryDiskMapForContext(ctx)
+		if err != nil {
+			return err
+		}
+		if err := projects.loadJSONL(
+			ctx, filepath.Join(root, "history.jsonl"), "conversationId", "workspace",
+		); err != nil {
+			return errors.Join(err, projects.close())
+		}
+		for _, subdir := range []string{"conversations", "implicit"} {
+			dir := filepath.Join(root, subdir)
+			err := streamDirectoryEntries(ctx, dir, func(entry os.DirEntry) error {
+				if entry.IsDir() {
+					return nil
+				}
+				_, ext, ok := antigravityCLIPathID(entry.Name())
+				if !ok || subdir == "implicit" && ext != ".pb" {
+					return nil
+				}
+				path := filepath.Join(dir, entry.Name())
+				rawID, ok := antigravityCLISessionIDForPath(root, path)
+				if !ok {
+					return nil
+				}
+				project, _, err := projects.get(ctx, strings.TrimPrefix(rawID, antigravityImplicitTag))
+				if err != nil {
+					return err
+				}
+				return yield(s.newSourceRef(root, path, rawID, project))
+			})
+			if err != nil {
+				return errors.Join(err, projects.close())
+			}
+		}
+		if err := projects.close(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // discoverSessions enumerates conversations/*.db, conversations/*.pb, and
@@ -545,7 +596,7 @@ func (s antigravityCLISourceSet) newSourceRef(
 ) SourceRef {
 	return SourceRef{
 		Provider:       AgentAntigravityCLI,
-		Key:            path,
+		Key:            id,
 		DisplayPath:    path,
 		FingerprintKey: path,
 		ProjectHint:    project,
@@ -664,6 +715,7 @@ func antigravityCLIWatchRootMatches(root, watchRoot string) bool {
 
 func antigravityCLIProviderCapabilities() Capabilities {
 	source := jsonlFileProviderSourceCapabilities()
+	source.StreamingDiscovery = CapabilitySupported
 	source.ForceReplaceOnParse = CapabilitySupported
 	return Capabilities{
 		Source: source,

--- a/internal/parser/antigravity_provider.go
+++ b/internal/parser/antigravity_provider.go
@@ -48,6 +48,10 @@ func (p *antigravityProvider) Discover(ctx context.Context) ([]SourceRef, error)
 	return p.sources.Discover(ctx)
 }
 
+func (p *antigravityProvider) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	return p.sources.DiscoverEach(ctx, yield)
+}
+
 func (p *antigravityProvider) WatchPlan(ctx context.Context) (WatchPlan, error) {
 	return p.sources.WatchPlan(ctx)
 }
@@ -158,6 +162,32 @@ func (s antigravitySourceSet) Discover(ctx context.Context) ([]SourceRef, error)
 	}
 	sortJSONLSources(sources)
 	return sources, nil
+}
+
+func (s antigravitySourceSet) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	for _, root := range s.roots {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		dir := filepath.Join(root, "conversations")
+		err := streamDirectoryEntries(ctx, dir, func(entry os.DirEntry) error {
+			name := entry.Name()
+			if entry.IsDir() || !strings.HasSuffix(name, ".db") ||
+				!IsValidSessionID(strings.TrimSuffix(name, ".db")) {
+				return nil
+			}
+			if source, ok := s.sourceRef(root, filepath.Join(dir, name), false); ok {
+				if err := yield(source); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // discoverSessionPaths returns one conversations/<uuid>.db path per IDE session
@@ -482,6 +512,7 @@ func antigravityWatchRootMatches(root, watchRoot string) bool {
 
 func antigravityProviderCapabilities() Capabilities {
 	source := jsonlFileProviderSourceCapabilities()
+	source.StreamingDiscovery = CapabilitySupported
 	source.ForceReplaceOnParse = CapabilitySupported
 	return Capabilities{
 		Source: source,

--- a/internal/parser/capabilities.go
+++ b/internal/parser/capabilities.go
@@ -27,17 +27,27 @@ type Capabilities struct {
 // provider.
 type SourceCapabilities struct {
 	DiscoverSources      CapabilitySupport
+	StreamingDiscovery   CapabilitySupport
 	WatchSources         CapabilitySupport
+	WatchRoots           CapabilitySupport
 	ClassifyChangedPath  CapabilitySupport
 	StoredSourceHints    CapabilitySupport
 	FindSource           CapabilitySupport
 	CompositeFingerprint CapabilitySupport
 	IncrementalAppend    CapabilitySupport
 	MultiSessionSource   CapabilitySupport
-	PerSessionErrors     CapabilitySupport
-	ExcludedSessions     CapabilitySupport
-	ForceReplaceOnParse  CapabilitySupport
-	VerifiedLocalStat    CapabilitySupport
+	// SharedContainerSource means streaming discovery emits multiple logical
+	// virtual members from one physical container and exact reconciliation
+	// rehydration is required to avoid reopening or rescanning that container.
+	SharedContainerSource CapabilitySupport
+	PerSessionErrors      CapabilitySupport
+	ExcludedSessions      CapabilitySupport
+	ForceReplaceOnParse   CapabilitySupport
+	VerifiedLocalStat     CapabilitySupport
+	// PersistentArchive means a vanished physical container must not tombstone
+	// its stored virtual members. A still-present container remains
+	// authoritative for member deletion.
+	PersistentArchive CapabilitySupport
 }
 
 // ContentCapabilities declares optional normalized content fields a provider

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -3,6 +3,7 @@
 package parser
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -99,7 +100,8 @@ func claudeParseWithExclusions(
 		foundParentSID  bool
 		lineIndex       int
 		malformedLines  int
-		lastLine        string
+		lastLineHasData bool
+		lastLineValid   bool
 		subagentMap     = map[string]string{}
 		globalStart     time.Time
 		globalEnd       time.Time
@@ -111,41 +113,41 @@ func claudeParseWithExclusions(
 	defer releaseLineReader(lr)
 	lastLineFailed := false
 	for {
-		line, ok := lr.next()
+		lineBytes, ok := lr.nextBytes()
 		if !ok {
 			break
 		}
-		lastLine = line
-		if !gjson.Valid(line) {
+		lastLineHasData = len(bytes.TrimSpace(lineBytes)) > 0
+		lastLineValid = gjson.ValidBytes(lineBytes)
+		if !lastLineValid {
 			malformedLines++
 			lastLineFailed = true
 			continue
 		}
-		line = resolveClaudePersistedToolResults(path, line)
 		lastLineFailed = false
 
-		entryType := gjson.Get(line, "type").Str
+		entryType := gjson.GetBytes(lineBytes, "type").Str
 		if agentLabel == "" {
-			if value := gjson.Get(line, "agentSetting").Str; strings.TrimSpace(value) != "" {
-				agentLabel = value
+			if value := gjson.GetBytes(lineBytes, "agentSetting").Str; strings.TrimSpace(value) != "" {
+				agentLabel = strings.Clone(value)
 			}
 		}
 		if entrypoint == "" {
-			if value := gjson.Get(line, "entrypoint").Str; strings.TrimSpace(value) != "" {
-				entrypoint = value
+			if value := gjson.GetBytes(lineBytes, "entrypoint").Str; strings.TrimSpace(value) != "" {
+				entrypoint = strings.Clone(value)
 			}
 		}
 
 		// Extract source version from first line that has it.
 		if sourceVersion == "" {
-			if v := gjson.Get(line, "version").Str; v != "" {
-				sourceVersion = v
+			if v := gjson.GetBytes(lineBytes, "version").Str; v != "" {
+				sourceVersion = strings.Clone(v)
 			}
 		}
 
 		// Track global timestamps from all lines for session
 		// bounds, including non-message events.
-		if ts := extractTimestamp(line); !ts.IsZero() {
+		if ts := extractTimestampBytes(lineBytes); !ts.IsZero() {
 			if globalStart.IsZero() || ts.Before(globalStart) {
 				globalStart = ts
 			}
@@ -156,8 +158,8 @@ func claudeParseWithExclusions(
 
 		// Collect queue-operation enqueue entries for subagent mapping.
 		if entryType == "queue-operation" {
-			if gjson.Get(line, "operation").Str == "enqueue" {
-				contentStr := gjson.Get(line, "content").Str
+			if gjson.GetBytes(lineBytes, "operation").Str == "enqueue" {
+				contentStr := gjson.GetBytes(lineBytes, "content").Str
 				if contentStr != "" {
 					tuid := gjson.Get(contentStr, "tool_use_id").Str
 					taskID := gjson.Get(contentStr, "task_id").Str
@@ -171,7 +173,7 @@ func claudeParseWithExclusions(
 						}
 					}
 					if tuid != "" && taskID != "" {
-						subagentMap[tuid] = "agent-" + taskID
+						subagentMap[strings.Clone(tuid)] = "agent-" + strings.Clone(taskID)
 					}
 				}
 			}
@@ -181,11 +183,11 @@ func claudeParseWithExclusions(
 		// Collect agent_progress events for subagent mapping.
 		// Claude Code v2.1+ emits these instead of queue-operation for Agent tool calls.
 		if entryType == "progress" {
-			if gjson.Get(line, "data.type").Str == "agent_progress" {
-				tuid := gjson.Get(line, "parentToolUseID").Str
-				agentID := gjson.Get(line, "data.agentId").Str
+			if gjson.GetBytes(lineBytes, "data.type").Str == "agent_progress" {
+				tuid := gjson.GetBytes(lineBytes, "parentToolUseID").Str
+				agentID := gjson.GetBytes(lineBytes, "data.agentId").Str
 				if tuid != "" && agentID != "" {
-					subagentMap[tuid] = "agent-" + agentID
+					subagentMap[strings.Clone(tuid)] = "agent-" + strings.Clone(agentID)
 				}
 			}
 			continue
@@ -195,7 +197,8 @@ func claudeParseWithExclusions(
 		// the user typed mid-tool-call. Other attachment types
 		// (e.g. task_reminder) are intentionally dropped.
 		if entryType == "attachment" {
-			if qc, ok := extractQueuedCommand(line); ok {
+			if qc, ok := extractQueuedCommand(string(lineBytes)); ok {
+				qc.prompt = strings.Clone(qc.prompt)
 				queuedCommands = append(queuedCommands, qc)
 			}
 			continue
@@ -205,9 +208,9 @@ func claudeParseWithExclusions(
 		// display name; last rename wins (empty arg clears it).
 		if entryType == "system" {
 			if name, ok := extractRenameName(
-				gjson.Get(line, "content").Str,
+				gjson.GetBytes(lineBytes, "content").Str,
 			); ok {
-				displayName = name
+				displayName = strings.Clone(name)
 			}
 			continue
 		}
@@ -215,15 +218,18 @@ func claudeParseWithExclusions(
 		if entryType != "user" && entryType != "assistant" {
 			continue
 		}
+		line := resolveClaudePersistedToolResults(
+			path, compactClaudeEntry(lineBytes),
+		)
 
 		// Collect subagent links and cwd/gitBranch from user entries.
 		if entryType == "user" {
 			collectToolResultAgentID(line, subagentMap)
 			if cwd == "" {
-				cwd = gjson.Get(line, "cwd").Str
+				cwd = strings.Clone(gjson.GetBytes(lineBytes, "cwd").Str)
 			}
 			if gitBranch == "" {
-				gitBranch = gjson.Get(line, "gitBranch").Str
+				gitBranch = strings.Clone(gjson.GetBytes(lineBytes, "gitBranch").Str)
 			}
 		}
 
@@ -231,11 +237,11 @@ func claudeParseWithExclusions(
 		// then check whether it differs from the file-derived
 		// ID to detect parent sessions.
 		if !foundParentSID {
-			if sid := gjson.Get(line, "sessionId").Str; sid != "" {
+			if sid := gjson.GetBytes(lineBytes, "sessionId").Str; sid != "" {
 				foundParentSID = true
-				sourceSessionID = sid
+				sourceSessionID = strings.Clone(sid)
 				if sid != sessionID {
-					parentSessionID = sid
+					parentSessionID = strings.Clone(sid)
 				}
 			}
 		}
@@ -254,7 +260,7 @@ func claudeParseWithExclusions(
 		entries = append(entries, dagEntry{
 			uuid:       uuid,
 			parentUuid: parentUuid,
-			entryType:  entryType,
+			entryType:  strings.Clone(entryType),
 			lineIndex:  lineIndex,
 			line:       line,
 			timestamp:  ts,
@@ -270,9 +276,8 @@ func claudeParseWithExclusions(
 	// AND the file did not end with a newline. A newline-
 	// terminated invalid line is just a complete malformed
 	// record, not a truncated write.
-	isTruncated := lastLine != "" &&
-		strings.TrimSpace(lastLine) != "" &&
-		!gjson.Valid(lastLine) &&
+	isTruncated := lastLineHasData &&
+		!lastLineValid &&
 		!fileEndsWithNewline(f, info.Size())
 
 	// Merge consecutive assistant entries that share the same
@@ -361,6 +366,151 @@ func claudeParseWithExclusions(
 	return kept, excluded, nil
 }
 
+type claudeCompactField struct {
+	name   string
+	result gjson.Result
+}
+
+func compactClaudeEntry(line []byte) string {
+	topFields := []claudeCompactField{
+		{name: "uuid"}, {name: "parentUuid"}, {name: "timestamp"},
+		{name: "isCompactSummary"}, {name: "isSidechain"},
+		{name: "isMeta"}, {name: "requestId"},
+	}
+	messageFields := []claudeCompactField{
+		{name: "content"}, {name: "id"}, {name: "stop_reason"},
+		{name: "model"}, {name: "usage"},
+	}
+	snapshotFields := []claudeCompactField{
+		{name: "timestamp"},
+	}
+	toolResultFields := []claudeCompactField{
+		{name: "agentId"}, {name: "persistedOutputPath"},
+	}
+
+	// Fill all field groups in a single pass over the entry. This runs
+	// for every retained message during a full parse, and one gjson
+	// scan per field made it the dominant per-line parse cost. Only the
+	// first occurrence of a key is kept, matching gjson.Get's
+	// duplicate-key behavior.
+	var seenMessage, seenSnapshot, seenToolResult bool
+	gjson.Parse(string(line)).ForEach(func(key, value gjson.Result) bool {
+		switch key.Str {
+		case "message":
+			if !seenMessage {
+				seenMessage = true
+				setClaudeCompactFields(messageFields, value)
+			}
+		case "snapshot":
+			if !seenSnapshot {
+				seenSnapshot = true
+				setClaudeCompactFields(snapshotFields, value)
+			}
+		case "toolUseResult":
+			if !seenToolResult {
+				seenToolResult = true
+				setClaudeCompactFields(toolResultFields, value)
+			}
+		default:
+			setClaudeCompactField(topFields, key.Str, value)
+		}
+		return true
+	})
+
+	var b strings.Builder
+	b.Grow(compactClaudeEntrySize(
+		topFields, snapshotFields, messageFields, toolResultFields,
+	))
+	b.WriteByte('{')
+	first := true
+	writeClaudeCompactFields(&b, &first, topFields)
+	writeClaudeCompactObject(&b, &first, "snapshot", snapshotFields)
+	writeClaudeCompactObject(&b, &first, "message", messageFields)
+	writeClaudeCompactObject(&b, &first, "toolUseResult", toolResultFields)
+	b.WriteByte('}')
+	return b.String()
+}
+
+// setClaudeCompactFields fills fields from the keys of an object
+// value, keeping the first occurrence of each key.
+func setClaudeCompactFields(fields []claudeCompactField, obj gjson.Result) {
+	if !obj.IsObject() {
+		return
+	}
+	obj.ForEach(func(key, value gjson.Result) bool {
+		setClaudeCompactField(fields, key.Str, value)
+		return true
+	})
+}
+
+func setClaudeCompactField(
+	fields []claudeCompactField, name string, value gjson.Result,
+) {
+	for i := range fields {
+		if fields[i].name == name && !fields[i].result.Exists() {
+			fields[i].result = value
+			return
+		}
+	}
+}
+
+func compactClaudeEntrySize(groups ...[]claudeCompactField) int {
+	size := 2
+	for _, fields := range groups {
+		for _, field := range fields {
+			if field.result.Exists() {
+				size += len(field.name) + len(field.result.Raw) + 4
+			}
+		}
+	}
+	return size
+}
+
+func writeClaudeCompactObject(
+	b *strings.Builder, first *bool, name string, fields []claudeCompactField,
+) {
+	hasFields := false
+	for _, field := range fields {
+		if field.result.Exists() {
+			hasFields = true
+			break
+		}
+	}
+	if !hasFields {
+		return
+	}
+	writeClaudeCompactSeparator(b, first)
+	b.WriteByte('"')
+	b.WriteString(name)
+	b.WriteString("\":{")
+	nestedFirst := true
+	writeClaudeCompactFields(b, &nestedFirst, fields)
+	b.WriteByte('}')
+}
+
+func writeClaudeCompactFields(
+	b *strings.Builder, first *bool, fields []claudeCompactField,
+) {
+	for _, field := range fields {
+		if !field.result.Exists() {
+			continue
+		}
+		writeClaudeCompactSeparator(b, first)
+		b.WriteByte('"')
+		b.WriteString(field.name)
+		b.WriteString("\":")
+		b.WriteString(field.result.Raw)
+	}
+}
+
+func writeClaudeCompactSeparator(b *strings.Builder, first *bool) {
+	if *first {
+		*first = false
+		return
+	}
+	b.WriteByte(',')
+}
+
 // lastAssistantStopReason returns the StopReason of the most
 // recent assistant message in the slice, or "" when there is
 // none. Used by Classify to decide between awaiting_user and
@@ -394,7 +544,8 @@ var ErrDAGDetected = fmt.Errorf(
 
 // ErrClaudeIncrementalNeedsFullParse signals that appended Claude
 // lines contain content the incremental path cannot stitch into
-// already-stored rows (currently same-message.id chunk merging).
+// already-stored rows (renames, late identity fields, and subagent-map
+// repairs for tool calls outside the append).
 var ErrClaudeIncrementalNeedsFullParse = fmt.Errorf(
 	"incremental parse: appended Claude lines require full parse",
 )
@@ -417,13 +568,38 @@ type claudeStoredIdentity struct {
 	entrypoint string
 }
 
+// claudeIncrementalScan carries the per-session stored state an
+// incremental parse needs beyond the file path and byte offset.
+type claudeIncrementalScan struct {
+	startOrdinal  int
+	lastEntryUUID string
+	stored        claudeStoredIdentity
+	// storedLinearParse mirrors the session's persisted
+	// claude_linear_parse flag: whether the last full parse fell back
+	// to linear processing (multi-root or unresolvable-parent DAG).
+	// Linearity is monotonic — appends can only add roots or
+	// unresolvable references, never repair them — so true lets the
+	// incremental path skip fork detection: the full parser processes
+	// such files in line order regardless of parent uuids. nil
+	// (unknown, legacy rows) or false keeps strict fork detection.
+	storedLinearParse *bool
+	// storedTailClaudeMessageID is the provider message id of the last
+	// stored assistant message for this session (empty when none), or
+	// nil when the call site cannot supply it. The queued-command
+	// masking fallback only matters when the appended assistant head
+	// continues exactly this message id; a fresh id cannot be a hidden
+	// continuation, so such appends stay incremental. nil keeps the
+	// conservative fallback.
+	storedTailClaudeMessageID *string
+}
+
 func claudeParseSessionFrom(
 	path string,
 	offset int64,
-	startOrdinal int,
-	lastEntryUUID string,
-	stored claudeStoredIdentity,
+	scan claudeIncrementalScan,
 ) ([]ParsedMessage, []ClaudeSubagentLink, time.Time, int64, error) {
+	startOrdinal := scan.startOrdinal
+	stored := scan.stored
 	var (
 		entries        []dagEntry
 		queuedCommands []claudeQueuedCommand
@@ -521,6 +697,19 @@ func claudeParseSessionFrom(
 		)
 	}
 
+	// Merge same-message.id streaming runs exactly as the full parser
+	// does before any DAG work. Merging swallows chunk uuids, which
+	// makes the merged entry's parent unresolvable — the same thing
+	// happens in the full parser's post-merge uuid set, driving such
+	// files to linear parsing. Runs that straddle a sync boundary are
+	// detected by the engine's LastClaudeMessageID check on the first
+	// appended assistant message; when a queued command would sort
+	// ahead of that head and mask the check, the parser itself falls
+	// back to a full parse (claudeQueuedCommandMasksSplitDetection).
+	if len(entries) > 1 {
+		entries = mergeClaudeAssistantMessageChunks(entries)
+	}
+
 	// A rename-only append produces no entries and no queued commands, so
 	// the empty-entries early return below would silently succeed. Check
 	// first and force a full parse so the display name is persisted.
@@ -542,27 +731,60 @@ func claudeParseSessionFrom(
 		return nil, nil, latestTS, consumed, nil
 	}
 
-	// Detect forks: if any entry's parentUuid doesn't
-	// match the previous entry's uuid, the appended data
-	// contains a branch that requires full DAG processing.
-	if hasDAGFork(entries, lastEntryUUID) {
+	// Fork detection only matters when the full parser would actually
+	// walk the DAG. parseLinear-bound files — multi-root or with
+	// unresolvable parents, which is every real CLI transcript whose
+	// chain routes through attachment/system lines — are processed in
+	// line order by the full parser too, so a linear append is exactly
+	// equivalent and chain breaks are irrelevant there. For
+	// DAG-resolvable or unknown (legacy) sessions, any break falls
+	// back to the full parser, which re-decides and persists the flag.
+	//
+	// Linearity is monotonic under the transcript's causal write
+	// order: a line's parentUuid always references an already-written
+	// line, and appended lines carry fresh uuids, so an append can
+	// never supply a previously-unresolved parent. The one
+	// append-visible way a file can move toward resolvability is a
+	// parentless entry adding a DAG root; guard that explicitly and
+	// let the full parser re-derive the verdict. The reverse drift —
+	// a DAG verdict flipping to linear — happens when an appended
+	// entry lacks a uuid, since the full parser only walks the DAG
+	// when every entry carries one; guard that in the DAG branch.
+	linearBound := scan.storedLinearParse != nil && *scan.storedLinearParse
+	dagBound := scan.storedLinearParse != nil && !*scan.storedLinearParse
+	if linearBound {
+		if appendAddsDAGRoot(entries) {
+			return nil, nil, time.Time{}, 0, ErrDAGDetected
+		}
+	} else if (dagBound || scan.lastEntryUUID != "") &&
+		appendMissingEntryUUID(entries) {
+		return nil, nil, time.Time{}, 0, ErrDAGDetected
+	} else if hasDAGFork(entries, scan.lastEntryUUID) {
 		return nil, nil, time.Time{}, 0, ErrDAGDetected
 	}
 
 	links := collectClaudeSubagentLinks(entries)
-
-	// same-message.id chunk merging still needs state the full parser
-	// builds across the whole file.
-	if needsClaudeFullParse(entries) {
-		return nil, nil, time.Time{}, 0,
-			ErrClaudeIncrementalNeedsFullParse
-	}
+	links = append(
+		links, collectClaudeUnmatchedToolResults(entries, links)...,
+	)
 
 	msgs, _, endedAt := extractMessagesFrom(
 		entries, startOrdinal,
 	)
 	annotateSubagentSessions(msgs, subagentMap)
 	if len(queuedCommands) > 0 {
+		// The engine's cross-sync split detection compares only the
+		// FIRST returned message's ClaudeMessageID against the stored
+		// tail. A queued command sorting ahead of an assistant head
+		// would mask a same-message.id continuation and let the stored
+		// partial response be appended a second time instead of
+		// replaced — fall back to a full parse instead.
+		if claudeQueuedCommandMasksSplitDetection(
+			msgs, queuedCommands, scan.storedTailClaudeMessageID,
+		) {
+			return nil, nil, time.Time{}, 0,
+				ErrClaudeIncrementalNeedsFullParse
+		}
 		msgs = mergeQueuedCommands(
 			msgs, queuedCommands, startOrdinal, queuedCommandMessage,
 		)
@@ -596,62 +818,71 @@ func claudeSessionIdentityUpdate(line string, stored claudeStoredIdentity) bool 
 		strings.TrimSpace(gjson.Get(line, "entrypoint").Str) != ""
 }
 
-// needsClaudeFullParse returns true when appended entries contain
-// a consecutive same-message.id assistant run whose chunks the full
-// parser merges into one message, or a tool_result that still refers to
-// a tool_use outside this append without a typed incremental linkage path.
-func needsClaudeFullParse(entries []dagEntry) bool {
-	toolUseIDs := make(map[string]struct{})
-	var prevAssistantMID string
+// collectClaudeUnmatchedToolResults returns result links for appended
+// tool_result blocks whose tool_use lives outside the appended window.
+// In-append results pair at write time and agentId-linked results are
+// already carried by collectClaudeSubagentLinks. isMeta carriers are
+// skipped: the full parser drops those lines entirely, so their result
+// content never reaches the stored tool call there either. Results
+// whose tool_use id is unknown to the store no-op at apply time,
+// matching the full parser's unpaired-result behavior.
+func collectClaudeUnmatchedToolResults(
+	entries []dagEntry, agentLinks []ClaudeSubagentLink,
+) []ClaudeSubagentLink {
+	linked := make(map[string]struct{}, len(agentLinks))
+	for _, l := range agentLinks {
+		linked[l.ToolUseID] = struct{}{}
+	}
+	appendedToolUse := make(map[string]struct{})
+	var out []ClaudeSubagentLink
 	for _, e := range entries {
-		if e.entryType == "user" {
-			link, hasLink := extractToolResultAgentIDLink(e.line)
+		if e.entryType == "assistant" {
 			content := gjson.Get(e.line, "message.content")
-			if content.IsArray() {
-				unmatched := false
-				content.ForEach(func(_, part gjson.Result) bool {
-					if part.Get("type").Str != "tool_result" {
-						return true
-					}
-					toolUseID := part.Get("tool_use_id").Str
-					if toolUseID == "" {
-						return true
-					}
-					if _, ok := toolUseIDs[toolUseID]; !ok &&
-						(!hasLink || toolUseID != link.ToolUseID) {
-						unmatched = true
-						return false
-					}
-					return true
-				})
-				if unmatched {
+			if !content.IsArray() {
+				continue
+			}
+			content.ForEach(func(_, part gjson.Result) bool {
+				if part.Get("type").Str != "tool_use" {
 					return true
 				}
-			}
-		}
-		if e.entryType == "assistant" {
-			mid := gjson.Get(e.line, "message.id").Str
-			if mid != "" && mid == prevAssistantMID {
+				if id := part.Get("id").Str; id != "" {
+					appendedToolUse[id] = struct{}{}
+				}
 				return true
-			}
-			content := gjson.Get(e.line, "message.content")
-			if content.IsArray() {
-				content.ForEach(func(_, part gjson.Result) bool {
-					if part.Get("type").Str != "tool_use" {
-						return true
-					}
-					if toolUseID := part.Get("id").Str; toolUseID != "" {
-						toolUseIDs[toolUseID] = struct{}{}
-					}
-					return true
-				})
-			}
-			prevAssistantMID = mid
+			})
 			continue
 		}
-		prevAssistantMID = ""
+		if e.entryType != "user" || gjson.Get(e.line, "isMeta").Bool() {
+			continue
+		}
+		content := gjson.Get(e.line, "message.content")
+		if !content.IsArray() {
+			continue
+		}
+		content.ForEach(func(_, part gjson.Result) bool {
+			if part.Get("type").Str != "tool_result" {
+				return true
+			}
+			result, ok := parseToolResult(part)
+			if !ok {
+				return true
+			}
+			if _, matched := appendedToolUse[result.ToolUseID]; matched {
+				return true
+			}
+			if _, hasAgentLink := linked[result.ToolUseID]; hasAgentLink {
+				return true
+			}
+			out = append(out, ClaudeSubagentLink{
+				ToolUseID:        result.ToolUseID,
+				ResultContentRaw: result.ContentRaw,
+				ResultContentLen: result.ContentLength,
+				HasResult:        true,
+			})
+			return true
+		})
 	}
-	return false
+	return out
 }
 
 func collectClaudeSubagentLinks(entries []dagEntry) []ClaudeSubagentLink {
@@ -709,11 +940,48 @@ func needsClaudeFullParseForSubagentMap(
 	return false
 }
 
+// appendAddsDAGRoot reports whether an appended message entry has a
+// uuid but no parentUuid, i.e. it would add a root to the session's
+// DAG. Root count is the only property of the stored linearity verdict
+// an append can move toward resolvability, so linear-bound sessions
+// fall back to a full parse (which re-derives the verdict) when one
+// appears.
+func appendAddsDAGRoot(entries []dagEntry) bool {
+	for _, e := range entries {
+		if e.uuid != "" && e.parentUuid == "" {
+			return true
+		}
+	}
+	return false
+}
+
+// appendMissingEntryUUID reports whether an appended message entry
+// lacks a uuid. The full parser only walks the DAG when every entry
+// carries a uuid (hasAnyUUID && allHaveUUID), so a uuid-less append
+// flips a DAG-resolvable transcript to linear processing — restoring
+// branches DAG processing had omitted. Sessions with a DAG verdict or
+// a uuid-carrying stored tip force a full parse so the stored
+// messages and the verdict are re-derived together. Linear-bound
+// sessions and unknown sessions with a uuid-less stored tip skip
+// this check: the former are already processed in line order, and
+// the latter already fail allHaveUUID, so a uuid-less append cannot
+// change the full parser's mode.
+func appendMissingEntryUUID(entries []dagEntry) bool {
+	for _, e := range entries {
+		if e.uuid == "" {
+			return true
+		}
+	}
+	return false
+}
+
 // hasDAGFork returns true if the entries contain a fork —
 // i.e. any entry whose parentUuid doesn't point to the
 // immediately preceding entry's uuid. Linear UUID chains
 // (each entry parenting the next) are safe for incremental
-// parsing; forks require full DAG processing.
+// parsing; forks require full DAG processing. Callers skip this
+// check entirely for parseLinear-bound sessions (see
+// claudeIncrementalScan.storedLinearParse).
 func hasDAGFork(entries []dagEntry, lastEntryUUID string) bool {
 	lastUUID := lastEntryUUID
 	for _, e := range entries {
@@ -910,18 +1178,20 @@ func parseLinear(
 	// the next real message instead of the command.
 	firstMsg, userCount := firstMessageAndUserCount(messages)
 
+	linear := true
 	sess := ParsedSession{
-		ID:               sessionID,
-		Project:          project,
-		Machine:          machine,
-		Agent:            AgentClaude,
-		ParentSessionID:  parentSessionID,
-		FirstMessage:     firstMsg,
-		StartedAt:        startedAt,
-		EndedAt:          endedAt,
-		MessageCount:     len(messages),
-		UserMessageCount: userCount,
-		File:             fileInfo,
+		ID:                sessionID,
+		Project:           project,
+		Machine:           machine,
+		Agent:             AgentClaude,
+		ParentSessionID:   parentSessionID,
+		FirstMessage:      firstMsg,
+		StartedAt:         startedAt,
+		EndedAt:           endedAt,
+		MessageCount:      len(messages),
+		UserMessageCount:  userCount,
+		File:              fileInfo,
+		ClaudeLinearParse: &linear,
 	}
 	meta.applyTo(&sess)
 	accumulateMessageTokenUsage(&sess, messages)
@@ -1076,19 +1346,21 @@ func parseDAG(
 			relType = RelFork
 		}
 
+		linear := false
 		sess := ParsedSession{
-			ID:               sid,
-			Project:          project,
-			Machine:          machine,
-			Agent:            AgentClaude,
-			ParentSessionID:  pSID,
-			RelationshipType: relType,
-			FirstMessage:     firstMsg,
-			StartedAt:        startedAt,
-			EndedAt:          endedAt,
-			MessageCount:     len(messages),
-			UserMessageCount: userCount,
-			File:             fileInfo,
+			ID:                sid,
+			Project:           project,
+			Machine:           machine,
+			Agent:             AgentClaude,
+			ParentSessionID:   pSID,
+			RelationshipType:  relType,
+			FirstMessage:      firstMsg,
+			StartedAt:         startedAt,
+			EndedAt:           endedAt,
+			MessageCount:      len(messages),
+			UserMessageCount:  userCount,
+			File:              fileInfo,
+			ClaudeLinearParse: &linear,
 		}
 		meta.applyTo(&sess)
 		accumulateMessageTokenUsage(&sess, messages)
@@ -1235,6 +1507,45 @@ func mergeQueuedCommands(
 		out[k].Ordinal = startOrdinal + k
 	}
 	return out
+}
+
+// claudeQueuedCommandMasksSplitDetection reports whether merging
+// queued commands would sort one ahead of a leading assistant message
+// that carries a provider message id. The engine's cross-sync split
+// detection (LastClaudeMessageID) inspects only the first appended
+// message, so a displaced assistant head would hide a same-message.id
+// continuation of the stored tail and duplicate the partial response.
+// Real CLI transcripts write queued_command attachments mid-stream,
+// between chunks of one response, so this masking is reachable
+// whenever the sync boundary falls inside such a run.
+//
+// Masking only matters when the head actually continues the stored
+// tail's message id: a fresh id is a new response, appending is correct
+// regardless of the queued command's sort position, and forcing a full
+// parse would make every routine queued-command turn scale with
+// transcript size. When the stored tail id is unavailable (nil) the
+// check stays conservative and treats any displaced head as masked.
+func claudeQueuedCommandMasksSplitDetection(
+	msgs []ParsedMessage,
+	queued []claudeQueuedCommand,
+	storedTailID *string,
+) bool {
+	if len(msgs) == 0 {
+		return false
+	}
+	head := msgs[0]
+	if head.Role != RoleAssistant || head.ClaudeMessageID == "" {
+		return false
+	}
+	if storedTailID != nil && head.ClaudeMessageID != *storedTailID {
+		return false
+	}
+	for _, qc := range queued {
+		if queuedBefore(qc, head) {
+			return true
+		}
+	}
+	return false
 }
 
 // queuedBefore reports whether a queued_command should sort before
@@ -1889,6 +2200,23 @@ func extractTimestamp(line string) time.Time {
 	ts := parseTimestamp(tsStr)
 	if ts.IsZero() {
 		snapTsStr := gjson.Get(line, "snapshot.timestamp").Str
+		ts = parseTimestamp(snapTsStr)
+		if ts.IsZero() {
+			if tsStr != "" {
+				logParseError(tsStr)
+			} else if snapTsStr != "" {
+				logParseError(snapTsStr)
+			}
+		}
+	}
+	return ts
+}
+
+func extractTimestampBytes(line []byte) time.Time {
+	tsStr := gjson.GetBytes(line, "timestamp").Str
+	ts := parseTimestamp(tsStr)
+	if ts.IsZero() {
+		snapTsStr := gjson.GetBytes(line, "snapshot.timestamp").Str
 		ts = parseTimestamp(snapTsStr)
 		if ts.IsZero() {
 			if tsStr != "" {

--- a/internal/parser/claude_compact_test.go
+++ b/internal/parser/claude_compact_test.go
@@ -1,0 +1,104 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompactClaudeEntry(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want string
+	}{
+		{
+			name: "assistant entry keeps whitelisted fields in fixed order",
+			line: `{"type":"assistant","uuid":"u1","parentUuid":"p1",` +
+				`"timestamp":"2026-01-02T03:04:05Z","cwd":"/tmp/x",` +
+				`"message":{"model":"m1","content":[{"type":"text","text":"hi"}],` +
+				`"id":"msg1","usage":{"input_tokens":1},"stop_reason":"end_turn"}}`,
+			want: `{"uuid":"u1","parentUuid":"p1",` +
+				`"timestamp":"2026-01-02T03:04:05Z",` +
+				`"message":{"content":[{"type":"text","text":"hi"}],` +
+				`"id":"msg1","stop_reason":"end_turn","model":"m1",` +
+				`"usage":{"input_tokens":1}}}`,
+		},
+		{
+			name: "missing groups and fields are omitted",
+			line: `{"uuid":"u2","sessionId":"s","gitBranch":"main"}`,
+			want: `{"uuid":"u2"}`,
+		},
+		{
+			name: "empty entry",
+			line: `{}`,
+			want: `{}`,
+		},
+		{
+			name: "null values are preserved",
+			line: `{"parentUuid":null,"isSidechain":false,"isMeta":true}`,
+			want: `{"parentUuid":null,"isSidechain":false,"isMeta":true}`,
+		},
+		{
+			name: "duplicate keys keep the first occurrence",
+			line: `{"uuid":"first","uuid":"second",` +
+				`"message":{"id":"m-first"},"message":{"id":"m-second"}}`,
+			want: `{"uuid":"first","message":{"id":"m-first"}}`,
+		},
+		{
+			name: "duplicate keys inside a group keep the first occurrence",
+			line: `{"message":{"model":"a","model":"b"}}`,
+			want: `{"message":{"model":"a"}}`,
+		},
+		{
+			name: "non-object message is dropped",
+			line: `{"uuid":"u3","message":"oops"}`,
+			want: `{"uuid":"u3"}`,
+		},
+		{
+			name: "snapshot and toolUseResult groups",
+			line: `{"uuid":"u4","snapshot":{"timestamp":"t1","extra":1},` +
+				`"toolUseResult":{"agentId":"a1",` +
+				`"persistedOutputPath":"/p","stdout":"noise"}}`,
+			want: `{"uuid":"u4","snapshot":{"timestamp":"t1"},` +
+				`"toolUseResult":{"agentId":"a1",` +
+				`"persistedOutputPath":"/p"}}`,
+		},
+		{
+			name: "requestId and compact summary flags",
+			line: `{"requestId":"req_1","isCompactSummary":true,` +
+				`"isSidechain":true}`,
+			want: `{"isCompactSummary":true,"isSidechain":true,` +
+				`"requestId":"req_1"}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, compactClaudeEntry([]byte(tt.line)))
+		})
+	}
+}
+
+// compactClaudeEntry runs once per retained message during a full
+// parse, so its per-call cost is a direct multiplier on archive-scale
+// sync CPU. Keep it single-pass; see the benchmark before adding
+// per-field gjson lookups.
+func BenchmarkCompactClaudeEntry(b *testing.B) {
+	line := []byte(`{"type":"assistant","uuid":"3f2a0d2e-1111-4222-8333-444455556666",` +
+		`"parentUuid":"9a8b7c6d-1111-4222-8333-444455556666",` +
+		`"timestamp":"2026-01-02T03:04:05.678Z","sessionId":"sess-1",` +
+		`"cwd":"/Users/test/code/project","gitBranch":"feature/x",` +
+		`"version":"2.1.0","requestId":"req_011CRnStkoAQ",` +
+		`"message":{"model":"claude-sonnet-4-20250514","id":"msg_01ABC",` +
+		`"type":"message","role":"assistant",` +
+		`"content":[{"type":"text","text":"Let me look at the sync engine and ` +
+		`figure out why the batch writer retries are not sharing one code path."},` +
+		`{"type":"tool_use","id":"toolu_42","name":"Read",` +
+		`"input":{"file_path":"internal/sync/engine.go"}}],` +
+		`"stop_reason":"tool_use","usage":{"input_tokens":1200,"output_tokens":340,` +
+		`"cache_creation_input_tokens":90,"cache_read_input_tokens":15000}}}`)
+	b.SetBytes(int64(len(line)))
+	for b.Loop() {
+		_ = compactClaudeEntry(line)
+	}
+}

--- a/internal/parser/claude_parser_test.go
+++ b/internal/parser/claude_parser_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -40,44 +39,10 @@ func callParseClaudeSessionFrom(
 func callParseClaudeSessionFromWithLinks(
 	path string, offset int64, startOrdinal int, lastEntryUUID string,
 ) ([]ParsedMessage, []ClaudeSubagentLink, time.Time, int64, error) {
-	fn := reflect.ValueOf(claudeParseSessionFrom)
-	args := []reflect.Value{
-		reflect.ValueOf(path),
-		reflect.ValueOf(offset),
-		reflect.ValueOf(startOrdinal),
-	}
-	if fn.Type().NumIn() >= 4 {
-		args = append(args, reflect.ValueOf(lastEntryUUID))
-	}
-	if fn.Type().NumIn() >= 5 {
-		args = append(args, reflect.ValueOf(claudeStoredIdentity{}))
-	}
-	out := fn.Call(args)
-
-	var msgs []ParsedMessage
-	if !out[0].IsNil() {
-		msgs = out[0].Interface().([]ParsedMessage)
-	}
-	var links []ClaudeSubagentLink
-	endedIdx := 1
-	consumedIdx := 2
-	errIdx := 3
-	if len(out) == 5 {
-		if !out[1].IsNil() {
-			links = out[1].Interface().([]ClaudeSubagentLink)
-		}
-		endedIdx = 2
-		consumedIdx = 3
-		errIdx = 4
-	}
-	endedAt := out[endedIdx].Interface().(time.Time)
-	consumed := out[consumedIdx].Interface().(int64)
-
-	var err error
-	if !out[errIdx].IsNil() {
-		err = out[errIdx].Interface().(error)
-	}
-	return msgs, links, endedAt, consumed, err
+	return claudeParseSessionFrom(path, offset, claudeIncrementalScan{
+		startOrdinal:  startOrdinal,
+		lastEntryUUID: lastEntryUUID,
+	})
 }
 
 // TestParseClaudeSession_UsageProbe verifies that sessions whose only
@@ -887,7 +852,11 @@ func TestParseClaudeSessionFrom_ReminderPrefixedCommand(t *testing.T) {
 	assert.Equal(t, "/clear", newMsgs[0].Content)
 }
 
-func TestParseClaudeSessionFrom_SystemReminderToolResultsFallBack(
+// A tool_result whose tool_use lives outside the appended window is
+// carried to the stored tool call as a typed result link instead of
+// forcing a full parse. The engine applies it through the same
+// tool-call update path as subagent links.
+func TestParseClaudeSessionFrom_ToolResultForStoredCallLinksIncrementally(
 	t *testing.T,
 ) {
 	t.Parallel()
@@ -908,9 +877,57 @@ func TestParseClaudeSessionFrom_SystemReminderToolResultsFallBack(
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	_, _, _, err = callParseClaudeSessionFrom(path, info.Size(), 2, "")
-	assert.ErrorIs(t, err, ErrClaudeIncrementalNeedsFullParse)
-	assert.True(t, IsIncrementalFullParseFallback(err))
+	_, links, _, _, err := callParseClaudeSessionFromWithLinks(
+		path, info.Size(), 2, "",
+	)
+	require.NoError(t, err)
+	require.Len(t, links, 1)
+	assert.Equal(t, "toolu_r", links[0].ToolUseID)
+	assert.Empty(t, links[0].SubagentSessionID)
+	assert.True(t, links[0].HasResult)
+	assert.Equal(t, "tool output", DecodeContent(links[0].ResultContentRaw))
+	assert.Equal(t, len("tool output"), links[0].ResultContentLen)
+}
+
+// A tool_result matched by a tool_use inside the same append pairs at
+// write time; no generic result link is emitted for it. An isMeta
+// carrier's result is dropped by the full parser too, so it emits no
+// link either.
+func TestParseClaudeSessionFrom_MatchedAndMetaToolResultsEmitNoLink(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	initial := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("hello", tsEarly),
+	)
+	path := createTestFile(t, "inc-matched-tool-result.jsonl", initial)
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+
+	appended := `{"type":"assistant","uuid":"a1","parentUuid":"pre",` +
+		`"timestamp":"` + tsEarlyS5 +
+		`","message":{"id":"msg_m","content":[{"type":"tool_use",` +
+		`"id":"toolu_in","name":"Bash","input":{"command":"ls"}}]}}` + "\n" +
+		`{"type":"user","uuid":"u2","parentUuid":"a1",` +
+		`"timestamp":"` + tsLate +
+		`","message":{"content":[{"type":"tool_result",` +
+		`"tool_use_id":"toolu_in","content":"in-append","is_error":false}]}}` + "\n" +
+		`{"type":"user","uuid":"u3","parentUuid":"u2","isMeta":true,` +
+		`"timestamp":"` + tsLate +
+		`","message":{"content":[{"type":"tool_result",` +
+		`"tool_use_id":"toolu_meta","content":"meta result","is_error":false}]}}` + "\n"
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.WriteString(appended)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	_, links, _, _, err := callParseClaudeSessionFromWithLinks(
+		path, info.Size(), 1, "",
+	)
+	require.NoError(t, err)
+	assert.Empty(t, links)
 }
 
 func TestParseClaudeSessionFrom_SkipsNonMessages(
@@ -1138,6 +1155,103 @@ func TestParseClaudeSessionFrom_DAGAcrossNonUUID(
 	assert.ErrorIs(t, err, ErrDAGDetected)
 }
 
+// Real CLI transcripts route the uuid chain through attachment and
+// system lines, so their full parses always fall back to linear
+// processing and the session is stored linear-bound. For such
+// sessions the incremental path must accept chain breaks (the full
+// parser ignores parent uuids there too); without a stored linearity
+// verdict it must stay conservative and fall back.
+func TestParseClaudeSessionFrom_LinearBoundSessionAcceptsChainBreaks(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		linearParse *bool
+		wantDAGErr  bool
+	}{
+		{
+			name:        "linear-bound session stays incremental",
+			linearParse: new(true),
+			wantDAGErr:  false,
+		},
+		{
+			name:        "unknown verdict stays conservative",
+			linearParse: nil,
+			wantDAGErr:  true,
+		},
+		{
+			name:        "dag-resolvable session falls back",
+			linearParse: new(false),
+			wantDAGErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := createTestFile(
+				t, "inc-linear-bound.jsonl",
+				testjsonl.JoinJSONL(
+					testjsonl.ClaudeUserJSON("hello", tsEarly),
+				),
+			)
+			info, err := os.Stat(path)
+			require.NoError(t, err)
+			offset := info.Size()
+
+			// Chain: attachment -> assistant -> system -> user,
+			// exactly as Claude Code writes it. The assistant's
+			// parent is the attachment uuid and the user's parent is
+			// the system uuid; neither is a message entry, so both
+			// breaks are unresolvable for the full parser too.
+			appended := `{"type":"attachment","uuid":"att-1",` +
+				`"parentUuid":"stored-tip",` +
+				`"timestamp":"` + tsEarlyS5 +
+				`","attachment":{"type":"task_reminder"}}` + "\n" +
+				`{"type":"assistant","uuid":"a1",` +
+				`"parentUuid":"att-1",` +
+				`"timestamp":"` + tsEarlyS5 +
+				`","message":{"content":[` +
+				`{"type":"text","text":"reply"}]}}` + "\n" +
+				`{"type":"system","uuid":"sys-1",` +
+				`"parentUuid":"a1",` +
+				`"timestamp":"` + tsLate +
+				`","content":"hook ran"}` + "\n" +
+				`{"type":"user","uuid":"u1",` +
+				`"parentUuid":"sys-1",` +
+				`"timestamp":"` + tsLate +
+				`","message":{"content":"done"}}` + "\n"
+
+			f, err := os.OpenFile(
+				path, os.O_APPEND|os.O_WRONLY, 0o644,
+			)
+			require.NoError(t, err)
+			_, err = f.WriteString(appended)
+			require.NoError(t, err)
+			require.NoError(t, f.Close())
+
+			newMsgs, _, _, _, perr := claudeParseSessionFrom(
+				path, offset, claudeIncrementalScan{
+					startOrdinal:      1,
+					lastEntryUUID:     "stored-tip",
+					storedLinearParse: tt.linearParse,
+				},
+			)
+			if tt.wantDAGErr {
+				assert.ErrorIs(t, perr, ErrDAGDetected)
+				return
+			}
+			require.NoError(t, perr)
+			require.Len(t, newMsgs, 2)
+			assert.Equal(t, RoleAssistant, newMsgs[0].Role)
+			assert.Equal(t, RoleUser, newMsgs[1].Role)
+		})
+	}
+}
+
 func TestParseClaudeSessionFrom_LinearUUID(
 	t *testing.T,
 ) {
@@ -1316,10 +1430,14 @@ func mustJSONString(t *testing.T, value string) string {
 }
 
 // Two appended assistant entries with the same message.id form a
-// run that the full parser merges into one message; the incremental
-// path would otherwise produce two separate stored messages, so it
-// must signal full-parse fallback.
-func TestParseClaudeSessionFrom_SameMessageIDFallsBack(t *testing.T) {
+// streaming run. The incremental path merges the run exactly as the
+// full parser does (mergeClaudeAssistantMessageChunks) and stays
+// incremental, producing one merged message. Runs that straddle a
+// sync boundary are caught by the engine's LastClaudeMessageID check
+// instead.
+func TestParseClaudeSessionFrom_SameMessageIDRunMergesIncrementally(
+	t *testing.T,
+) {
 	t.Parallel()
 
 	initial := testjsonl.JoinJSONL(
@@ -1343,18 +1461,409 @@ func TestParseClaudeSessionFrom_SameMessageIDFallsBack(t *testing.T) {
 		`"timestamp":"` + tsLate +
 		`","message":{"id":"msg_run","content":[` +
 		`{"type":"text","text":"Hi there"}]}}` + "\n"
+	// A user reply chained onto the run's last chunk must stay
+	// linear even though the merged entry's own parent uuid was
+	// swallowed by the merge.
+	u2 := `{"type":"user","uuid":"u2",` +
+		`"parentUuid":"a2",` +
+		`"timestamp":"` + tsLate +
+		`","message":{"content":"thanks"}}` + "\n"
 
 	f, err := os.OpenFile(
 		path, os.O_APPEND|os.O_WRONLY, 0o644,
 	)
 	require.NoError(t, err)
-	_, err = f.WriteString(a1 + a2)
+	_, err = f.WriteString(a1 + a2 + u2)
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
-	_, _, _, err = callParseClaudeSessionFrom(path, offset, 1, "")
-	assert.ErrorIs(t, err, ErrClaudeIncrementalNeedsFullParse)
-	assert.True(t, IsIncrementalFullParseFallback(err))
+	newMsgs, _, _, err := callParseClaudeSessionFrom(path, offset, 1, "")
+	require.NoError(t, err)
+	require.Len(t, newMsgs, 2)
+	assert.Equal(t, RoleAssistant, newMsgs[0].Role)
+	assert.Equal(t, "Hi there", newMsgs[0].Content)
+	assert.Equal(t, "msg_run", newMsgs[0].ClaudeMessageID)
+	assert.Equal(t, RoleUser, newMsgs[1].Role)
+}
+
+// A queued_command attachment can be written mid-stream, between
+// assistant chunks of one same-message.id response (observed in real
+// CLI transcripts). When the sync boundary falls inside that run, the
+// append window is [queued command, chunk, chunk] and the queued
+// command's earlier timestamp sorts it to position 0 of the returned
+// messages. The engine's cross-sync split detection compares only the
+// FIRST appended message's ClaudeMessageID against the stored tail, so
+// a masked head would append the continuation as a duplicate message.
+// The parser must fall back to a full parse instead.
+func TestParseClaudeSessionFrom_QueuedCommandBeforeContinuationFallsBack(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	chunk := func(uuid, parent, ts, text string) string {
+		return `{"type":"assistant","uuid":"` + uuid +
+			`","parentUuid":"` + parent +
+			`","timestamp":"` + ts +
+			`","message":{"id":"msg_split","content":[` +
+			`{"type":"text","text":"` + text + `"}]}}`
+	}
+
+	initial := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("hello", tsEarly),
+		chunk("a1", "u1", "2024-01-01T10:00:01Z", "Hel"),
+	)
+
+	parseFrom := func(
+		t *testing.T, appended string, storedTailID *string,
+	) ([]ParsedMessage, error) {
+		t.Helper()
+		path := createTestFile(
+			t, "inc-queued-boundary.jsonl", initial,
+		)
+		info, err := os.Stat(path)
+		require.NoError(t, err)
+		offset := info.Size()
+
+		f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+		require.NoError(t, err)
+		_, err = f.WriteString(appended)
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+
+		msgs, _, _, _, perr := claudeParseSessionFrom(
+			path, offset, claudeIncrementalScan{
+				startOrdinal:              2,
+				lastEntryUUID:             "a1",
+				storedLinearParse:         new(true),
+				storedTailClaudeMessageID: storedTailID,
+			},
+		)
+		return msgs, perr
+	}
+
+	maskingAppend := testjsonl.ClaudeQueuedCommandJSON(
+		"queued mid-stream", "2024-01-01T10:00:02Z",
+	) + "\n" +
+		chunk("a2", "a1", "2024-01-01T10:00:03Z", "Hello wo") + "\n" +
+		chunk("a3", "a2", "2024-01-01T10:00:04Z", "Hello world") + "\n"
+
+	t.Run("queued command masks continuation head", func(t *testing.T) {
+		t.Parallel()
+
+		_, perr := parseFrom(t, maskingAppend, new("msg_split"))
+		assert.ErrorIs(t, perr, ErrClaudeIncrementalNeedsFullParse,
+			"a queued command sorting ahead of a same-message.id "+
+				"continuation must force a full parse")
+	})
+
+	t.Run("unknown stored tail keeps the conservative fallback",
+		func(t *testing.T) {
+			t.Parallel()
+
+			_, perr := parseFrom(t, maskingAppend, nil)
+			assert.ErrorIs(t, perr, ErrClaudeIncrementalNeedsFullParse,
+				"without the stored tail id the parser cannot rule out "+
+					"a masked continuation and must fall back")
+		})
+
+	t.Run("queued command before a fresh-id response stays incremental",
+		func(t *testing.T) {
+			t.Parallel()
+
+			appended := testjsonl.ClaudeQueuedCommandJSON(
+				"queued routine", "2024-01-01T10:00:02Z",
+			) + "\n" +
+				`{"type":"assistant","uuid":"a2","parentUuid":"a1",` +
+				`"timestamp":"2024-01-01T10:00:03Z",` +
+				`"message":{"id":"msg_fresh","content":[` +
+				`{"type":"text","text":"fresh response"}]}}` + "\n"
+
+			msgs, perr := parseFrom(t, appended, new("msg_split"))
+			require.NoError(t, perr,
+				"a fresh-id head cannot be a hidden continuation of the "+
+					"stored tail, so the append must stay incremental")
+			require.Len(t, msgs, 2)
+			assert.Equal(t, "queued_command", msgs[0].SourceSubtype)
+			assert.Equal(t, "msg_fresh", msgs[1].ClaudeMessageID)
+		})
+
+	t.Run("full parse of the whole file keeps one merged message",
+		func(t *testing.T) {
+			t.Parallel()
+
+			content := initial + "\n" + testjsonl.JoinJSONL(
+				testjsonl.ClaudeQueuedCommandJSON(
+					"queued mid-stream", "2024-01-01T10:00:02Z",
+				),
+				chunk("a2", "a1", "2024-01-01T10:00:03Z", "Hello wo"),
+				chunk("a3", "a2", "2024-01-01T10:00:04Z", "Hello world"),
+			)
+			_, msgs := runClaudeParserTest(
+				t, "queued-boundary-full.jsonl", content,
+			)
+			require.Len(t, msgs, 3)
+			assert.Equal(t, RoleUser, msgs[0].Role)
+			assert.Equal(t, "queued_command", msgs[1].SourceSubtype)
+			assert.Equal(t, RoleAssistant, msgs[2].Role)
+			assert.Equal(t, "Hello world", msgs[2].Content,
+				"the run must collapse to one merged assistant message")
+			ids := 0
+			for _, m := range msgs {
+				if m.ClaudeMessageID == "msg_split" {
+					ids++
+				}
+			}
+			assert.Equal(t, 1, ids,
+				"msg_split must appear exactly once after a full parse")
+		})
+
+	t.Run("queued command after the run stays incremental",
+		func(t *testing.T) {
+			t.Parallel()
+
+			appended := chunk(
+				"a2", "a1", "2024-01-01T10:00:03Z", "Hello wo",
+			) + "\n" +
+				chunk("a3", "a2", "2024-01-01T10:00:04Z", "Hello world") +
+				"\n" + testjsonl.ClaudeQueuedCommandJSON(
+				"queued after", "2024-01-01T10:02:00Z",
+			) + "\n"
+
+			msgs, perr := parseFrom(t, appended, new("msg_split"))
+			require.NoError(t, perr)
+			require.Len(t, msgs, 2)
+			assert.Equal(t, RoleAssistant, msgs[0].Role)
+			assert.Equal(t, "msg_split", msgs[0].ClaudeMessageID,
+				"the continuation head must stay first so the engine's "+
+					"split check can see it")
+			assert.Equal(t, "queued_command", msgs[1].SourceSubtype)
+		})
+
+	t.Run("queued command before a user head stays incremental",
+		func(t *testing.T) {
+			t.Parallel()
+
+			appended := testjsonl.ClaudeQueuedCommandJSON(
+				"queued early", "2024-01-01T10:00:02Z",
+			) + "\n" +
+				`{"type":"user","uuid":"u2","parentUuid":"a1",` +
+				`"timestamp":"2024-01-01T10:00:03Z",` +
+				`"message":{"content":"next turn"}}` + "\n" +
+				`{"type":"assistant","uuid":"a2","parentUuid":"u2",` +
+				`"timestamp":"2024-01-01T10:00:04Z",` +
+				`"message":{"id":"msg_next","content":[` +
+				`{"type":"text","text":"fresh"}]}}` + "\n"
+
+			msgs, perr := parseFrom(t, appended, new("msg_split"))
+			require.NoError(t, perr)
+			require.Len(t, msgs, 3)
+			assert.Equal(t, "queued_command", msgs[0].SourceSubtype)
+			assert.Equal(t, "next turn", msgs[1].Content)
+			assert.Equal(t, "msg_next", msgs[2].ClaudeMessageID)
+		})
+}
+
+// An appended parentless entry adds a DAG root — the only property of
+// the stored linearity verdict an append can move toward
+// resolvability — so even a linear-bound session must fall back to a
+// full parse to re-derive the verdict.
+func TestParseClaudeSessionFrom_LinearBoundNewRootFallsBack(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	path := createTestFile(
+		t, "inc-linear-new-root.jsonl",
+		testjsonl.JoinJSONL(
+			testjsonl.ClaudeUserJSON("hello", tsEarly),
+		),
+	)
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	offset := info.Size()
+
+	appended := `{"type":"user","uuid":"root-2",` +
+		`"timestamp":"` + tsLate +
+		`","message":{"content":"parentless"}}` + "\n"
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.WriteString(appended)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	_, _, _, _, perr := claudeParseSessionFrom(
+		path, offset, claudeIncrementalScan{
+			startOrdinal:      1,
+			lastEntryUUID:     "stored-tip",
+			storedLinearParse: new(true),
+		},
+	)
+	assert.ErrorIs(t, perr, ErrDAGDetected)
+}
+
+// The full parser only walks the DAG when every message entry carries
+// a uuid, so a uuid-less append flips a DAG-resolvable transcript to
+// linear processing — restoring branches DAG processing had omitted.
+// DAG-resolvable or unknown sessions must fall back to a full parse on
+// a uuid-less append; linear-bound sessions stay incremental because
+// the full parser already processes them in line order.
+func TestParseClaudeSessionFrom_UUIDLessAppendFallsBackForDAGSessions(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name              string
+		storedLinearParse *bool
+		wantDAGFallback   bool
+	}{
+		{"unknown verdict", nil, true},
+		{"dag-bound", new(false), true},
+		{"linear-bound", new(true), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := createTestFile(
+				t, "inc-uuidless-append.jsonl",
+				testjsonl.JoinJSONL(
+					testjsonl.ClaudeUserJSON("hello", tsEarly),
+				),
+			)
+			info, err := os.Stat(path)
+			require.NoError(t, err)
+			offset := info.Size()
+
+			appended := `{"type":"user",` +
+				`"timestamp":"` + tsLate +
+				`","message":{"content":"no uuid on this line"}}` + "\n"
+			f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+			require.NoError(t, err)
+			_, err = f.WriteString(appended)
+			require.NoError(t, err)
+			require.NoError(t, f.Close())
+
+			msgs, _, _, _, perr := claudeParseSessionFrom(
+				path, offset, claudeIncrementalScan{
+					startOrdinal:      1,
+					lastEntryUUID:     "stored-tip",
+					storedLinearParse: tc.storedLinearParse,
+				},
+			)
+			if tc.wantDAGFallback {
+				assert.ErrorIs(t, perr, ErrDAGDetected)
+				return
+			}
+			require.NoError(t, perr)
+			require.Len(t, msgs, 1)
+			assert.Equal(t, "no uuid on this line", msgs[0].Content)
+		})
+	}
+}
+
+// Rewinding onto an entry that the full parser resolves in its DAG
+// but that never became a stored message row (a tool-result-only
+// carrier dropped by pairAndFilter, or an isMeta line) is still a real
+// fork. A DAG-resolvable session must therefore fall back to the full
+// parser on any chain break — the break's parent being absent from
+// stored messages proves nothing about the DAG.
+func TestParseClaudeSessionFrom_RewindOntoFilteredEntryFallsBack(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	// Fully resolvable single-root file: u1 <- a1 <- u2 <- a2, where
+	// u2 is a tool-result-only carrier that is filtered from stored
+	// messages but participates in the DAG.
+	initial := testjsonl.JoinJSONL(
+		`{"type":"user","uuid":"u1","timestamp":"`+tsEarly+
+			`","message":{"content":"go"}}`,
+		`{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"`+
+			tsEarlyS1+`","message":{"id":"msg_1","content":[{"type":"tool_use",`+
+			`"id":"toolu_1","name":"Bash","input":{"command":"ls"}}]}}`,
+		`{"type":"user","uuid":"u2","parentUuid":"a1","timestamp":"`+
+			tsEarlyS1+`","message":{"content":[{"type":"tool_result",`+
+			`"tool_use_id":"toolu_1","content":"out"}]}}`,
+		`{"type":"assistant","uuid":"a2","parentUuid":"u2","timestamp":"`+
+			tsEarlyS5+`","message":{"id":"msg_2","content":[`+
+			`{"type":"text","text":"first answer"}]}}`,
+	)
+	path := createTestFile(t, "inc-rewind-carrier.jsonl", initial)
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	offset := info.Size()
+
+	// Rewind: a3 branches from the carrier u2, forking away from a2.
+	appended := `{"type":"assistant","uuid":"a3","parentUuid":"u2",` +
+		`"timestamp":"` + tsLate + `","message":{"id":"msg_3","content":[` +
+		`{"type":"text","text":"retry answer"}]}}` + "\n"
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.WriteString(appended)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	_, _, _, _, perr := claudeParseSessionFrom(
+		path, offset, claudeIncrementalScan{
+			startOrdinal:      4,
+			lastEntryUUID:     "a2",
+			storedLinearParse: new(false),
+		},
+	)
+	assert.ErrorIs(t, perr, ErrDAGDetected)
+
+	// The full parse resolves the fork: u2 has children a2 and a3, and
+	// the small-gap retry heuristic follows the latest branch, so a2
+	// is dropped and a3 becomes the tail.
+	results, err := parseClaudeSession(path, "proj", "local")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.NotNil(t, results[0].Session.ClaudeLinearParse)
+	assert.False(t, *results[0].Session.ClaudeLinearParse)
+	var contents []string
+	for _, m := range results[0].Messages {
+		contents = append(contents, m.Content)
+	}
+	assert.NotContains(t, contents, "first answer")
+	assert.Contains(t, contents, "retry answer")
+}
+
+// The parser records its linearity verdict on the session: linear for
+// multi-root or unresolvable-parent files (every real CLI transcript
+// whose chain routes through attachment lines), DAG for resolvable
+// single-root files.
+func TestParseClaudeSession_RecordsLinearParseVerdict(t *testing.T) {
+	t.Parallel()
+
+	linearFile := testjsonl.JoinJSONL(
+		`{"type":"attachment","uuid":"att-1","timestamp":"`+tsEarly+
+			`","attachment":{"type":"task_reminder"}}`,
+		`{"type":"user","uuid":"u1","parentUuid":"att-1","timestamp":"`+
+			tsEarly+`","message":{"content":"hello"}}`,
+		`{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"`+
+			tsEarlyS1+`","message":{"content":[{"type":"text","text":"hi"}]}}`,
+	)
+	path := createTestFile(t, "verdict-linear.jsonl", linearFile)
+	results, err := parseClaudeSession(path, "proj", "local")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.NotNil(t, results[0].Session.ClaudeLinearParse)
+	assert.True(t, *results[0].Session.ClaudeLinearParse,
+		"attachment-parented chain must parse linearly")
+
+	dagFile := testjsonl.JoinJSONL(
+		`{"type":"user","uuid":"u1","timestamp":"`+tsEarly+
+			`","message":{"content":"hello"}}`,
+		`{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"`+
+			tsEarlyS1+`","message":{"content":[{"type":"text","text":"hi"}]}}`,
+	)
+	path = createTestFile(t, "verdict-dag.jsonl", dagFile)
+	results, err = parseClaudeSession(path, "proj", "local")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.NotNil(t, results[0].Session.ClaudeLinearParse)
+	assert.False(t, *results[0].Session.ClaudeLinearParse,
+		"single-root resolvable chain must record a DAG verdict")
 }
 
 func TestParseClaudeSessionFrom_QueueOperationOnlyFallsBack(t *testing.T) {

--- a/internal/parser/claude_provider.go
+++ b/internal/parser/claude_provider.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -45,6 +46,10 @@ type claudeProvider struct {
 
 func (p *claudeProvider) Discover(ctx context.Context) ([]SourceRef, error) {
 	return p.sources.Discover(ctx)
+}
+
+func (p *claudeProvider) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	return p.sources.DiscoverEach(ctx, yield)
 }
 
 func (p *claudeProvider) WatchPlan(ctx context.Context) (WatchPlan, error) {
@@ -159,16 +164,25 @@ func (p *claudeProvider) ParseIncremental(
 	newMsgs, links, endedAt, consumed, err := claudeParseSessionFrom(
 		path,
 		req.Offset,
-		req.StartOrdinal,
-		req.LastEntryUUID,
-		claudeStoredIdentity{
-			agentLabel: req.StoredAgentLabel,
-			entrypoint: req.StoredEntrypoint,
+		claudeIncrementalScan{
+			startOrdinal:  req.StartOrdinal,
+			lastEntryUUID: req.LastEntryUUID,
+			stored: claudeStoredIdentity{
+				agentLabel: req.StoredAgentLabel,
+				entrypoint: req.StoredEntrypoint,
+			},
+			storedLinearParse:         req.StoredClaudeLinearParse,
+			storedTailClaudeMessageID: req.StoredLastClaudeMessageID,
 		},
 	)
 	if err != nil {
 		if IsIncrementalFullParseFallback(err) || errorsIsClaudeDAG(err) {
-			return IncrementalOutcome{ForceReplace: IsIncrementalFullParseFallback(err)},
+			// Both fallbacks require a replacing write. Explicit
+			// fallbacks update already-stored rows; a detected DAG
+			// fork means the full parse may drop or re-branch stored
+			// messages (small-gap retries follow the latest child),
+			// which the append-only write path would silently retain.
+			return IncrementalOutcome{ForceReplace: true},
 				IncrementalNeedsFullParse, nil
 		}
 		return IncrementalOutcome{}, IncrementalNeedsFullParse, err
@@ -230,6 +244,78 @@ func (s claudeSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
 	}
 	sortJSONLSources(sources)
 	return sources, nil
+}
+
+func (s claudeSourceSet) DiscoverEach(
+	ctx context.Context, yield func(SourceRef) error,
+) error {
+	for _, root := range s.roots {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if strings.HasPrefix(root, "s3://") {
+			for _, file := range ClaudeProjectSessionFiles(root) {
+				source, ok := s.discoveredSourceRef(root, file)
+				if ok {
+					if err := yield(source); err != nil {
+						return err
+					}
+				}
+			}
+			continue
+		}
+		err := s.streamLocalRoot(ctx, root, yield)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s claudeSourceSet) streamLocalRoot(
+	ctx context.Context, root string, yield func(SourceRef) error,
+) error {
+	var incomplete error
+	err := streamDirectoryEntries(ctx, root, func(project os.DirEntry) error {
+		isProjectDir, dirErr := streamingDirCandidateOrIncomplete(
+			AgentClaude, "Claude project directory", project, root,
+		)
+		if dirErr != nil {
+			incomplete = errors.Join(incomplete, dirErr)
+			return nil
+		}
+		if !isProjectDir {
+			return nil
+		}
+		projectRoot := filepath.Join(root, project.Name())
+		err := streamDirectoryTreeRecursive(ctx, projectRoot, func(
+			path string, entry os.DirEntry,
+		) error {
+			if !strings.HasSuffix(entry.Name(), ".jsonl") {
+				return nil
+			}
+			source, ok := s.sourceRef(root, path)
+			if !ok {
+				return nil
+			}
+			return yield(source)
+		})
+		if err == nil {
+			return nil
+		}
+		if _, ok := discoveryYieldCause(err); ok {
+			return err
+		}
+		if ctx.Err() != nil {
+			return err
+		}
+		incomplete = errors.Join(incomplete, err)
+		return nil
+	})
+	if cause, ok := discoveryYieldCause(err); ok {
+		return cause
+	}
+	return errors.Join(incomplete, err)
 }
 
 // discoveredSourceRef builds the SourceRef for one enumerated Claude session
@@ -535,6 +621,7 @@ func claudeProviderCapabilities() Capabilities {
 	return Capabilities{
 		Source: SourceCapabilities{
 			DiscoverSources:      CapabilitySupported,
+			StreamingDiscovery:   CapabilitySupported,
 			WatchSources:         CapabilitySupported,
 			ClassifyChangedPath:  CapabilitySupported,
 			FindSource:           CapabilitySupported,

--- a/internal/parser/claude_provider_test.go
+++ b/internal/parser/claude_provider_test.go
@@ -2,8 +2,10 @@ package parser
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -172,6 +174,112 @@ func TestClaudeProviderDiscoversSymlinkedProjectDirectory(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok)
 	assert.Equal(t, subagentPath, found.DisplayPath)
+}
+
+// A followed project-directory symlink whose target cannot be resolved must
+// surface incomplete streaming discovery rather than reading as absent:
+// reconciliation treats a clean DiscoverEach as authoritative and would
+// tombstone every session beneath the symlink.
+func TestClaudeProviderStreamingDiscoveryPropagatesProjectSymlinkErrors(t *testing.T) {
+	discoverEach := func(t *testing.T, root string) ([]string, error) {
+		t.Helper()
+		provider, ok := NewProvider(AgentClaude, ProviderConfig{
+			Roots: []string{root},
+		})
+		require.True(t, ok)
+		discoverer, ok := provider.(StreamingDiscoverer)
+		require.True(t, ok)
+		var yielded []string
+		err := discoverer.DiscoverEach(t.Context(), func(source SourceRef) error {
+			yielded = append(yielded, source.DisplayPath)
+			return nil
+		})
+		return yielded, err
+	}
+	healthyPath := func(root string) string {
+		return filepath.Join(root, "-Users-dev-code-demo", "session-main.jsonl")
+	}
+
+	t.Run("dangling project symlink", func(t *testing.T) {
+		root := t.TempDir()
+		writeSourceFile(t, healthyPath(root), claudeProviderFixture("hello claude"))
+		target := filepath.Join(t.TempDir(), "linked-project")
+		require.NoError(t, os.MkdirAll(target, 0o755))
+		link := filepath.Join(root, "linked")
+		if err := os.Symlink(target, link); err != nil {
+			t.Skipf("symlink not supported: %v", err)
+		}
+		require.NoError(t, os.RemoveAll(target))
+
+		yielded, err := discoverEach(t, root)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, os.ErrNotExist)
+		var incomplete DiscoveryIncompleteError
+		assert.ErrorAs(t, err, &incomplete)
+		// The walker records the failure and continues with healthy siblings.
+		assert.Equal(t, []string{healthyPath(root)}, yielded)
+
+		require.NoError(t, os.Remove(link))
+		yielded, err = discoverEach(t, root)
+		require.NoError(t, err)
+		assert.Equal(t, []string{healthyPath(root)}, yielded)
+	})
+
+	t.Run("unstatable project symlink target", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("directory read permissions are not enforced on Windows")
+		}
+		if os.Geteuid() == 0 {
+			t.Skip("root bypasses directory permissions")
+		}
+		root := t.TempDir()
+		writeSourceFile(t, healthyPath(root), claudeProviderFixture("hello claude"))
+		targetParent := t.TempDir()
+		target := filepath.Join(targetParent, "linked-project")
+		require.NoError(t, os.MkdirAll(target, 0o755))
+		if err := os.Symlink(target, filepath.Join(root, "linked")); err != nil {
+			t.Skipf("symlink not supported: %v", err)
+		}
+		require.NoError(t, os.Chmod(targetParent, 0o000))
+		t.Cleanup(func() { _ = os.Chmod(targetParent, 0o755) })
+
+		yielded, err := discoverEach(t, root)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, os.ErrPermission)
+		var incomplete DiscoveryIncompleteError
+		assert.ErrorAs(t, err, &incomplete)
+		assert.Equal(t, []string{healthyPath(root)}, yielded)
+
+		require.NoError(t, os.Chmod(targetParent, 0o755))
+		yielded, err = discoverEach(t, root)
+		require.NoError(t, err)
+		assert.Equal(t, []string{healthyPath(root)}, yielded)
+	})
+}
+
+func TestClaudeProviderStreamingDiscoveryStopsAfterYieldError(t *testing.T) {
+	root := t.TempDir()
+	for _, project := range []string{"-Users-dev-code-one", "-Users-dev-code-two"} {
+		writeSourceFile(
+			t, filepath.Join(root, project, "session.jsonl"),
+			claudeProviderFixture("streamed"),
+		)
+	}
+	provider, ok := NewProvider(AgentClaude, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	discoverer, ok := provider.(StreamingDiscoverer)
+	require.True(t, ok)
+
+	stop := errors.New("stop discovery")
+	calls := 0
+	err := discoverer.DiscoverEach(t.Context(), func(SourceRef) error {
+		calls++
+		return stop
+	})
+	require.ErrorIs(t, err, stop)
+	assert.Equal(t, 1, calls)
 }
 
 func TestClaudeProviderParse(t *testing.T) {

--- a/internal/parser/claude_streaming_test.go
+++ b/internal/parser/claude_streaming_test.go
@@ -1,0 +1,86 @@
+package parser
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClaudeFullParseDoesNotAllocateDiscardedProgressBytes(t *testing.T) {
+	path := t.TempDir() + "/large.jsonl"
+	f, err := os.Create(path)
+	require.NoError(t, err)
+
+	const (
+		lineCount   = 32
+		paddingSize = 1 << 20
+	)
+	padding := strings.Repeat("x", paddingSize)
+	for i := range lineCount {
+		parent := ""
+		if i > 0 {
+			parent = fmt.Sprintf("u%d", i-1)
+		}
+		var record string
+		switch i {
+		case lineCount - 2:
+			record = fmt.Sprintf(
+				"{\"type\":\"assistant\",\"uuid\":\"u%d\",\"parentUuid\":\"%s\","+
+					"\"timestamp\":\"2026-01-01T00:00:%02dZ\",\"requestId\":\"req-1\","+
+					"\"message\":{\"id\":\"msg-1\",\"model\":\"model-1\","+
+					"\"usage\":{\"input_tokens\":4,\"output_tokens\":2},"+
+					"\"content\":[{\"type\":\"text\",\"text\":\"answer\"},"+
+					"{\"type\":\"tool_use\",\"id\":\"tool-1\",\"name\":\"Read\","+
+					"\"input\":{\"file_path\":\"notes.txt\"}}]},\"ignored\":\"%s\"}\n",
+				i, parent, i%60, padding,
+			)
+		case lineCount - 1:
+			record = fmt.Sprintf(
+				"{\"type\":\"user\",\"uuid\":\"u%d\",\"parentUuid\":\"%s\","+
+					"\"timestamp\":\"2026-01-01T00:00:%02dZ\","+
+					"\"message\":{\"content\":[{\"type\":\"tool_result\","+
+					"\"tool_use_id\":\"tool-1\",\"content\":\"result\"}]},"+
+					"\"ignored\":\"%s\"}\n",
+				i, parent, i%60, padding,
+			)
+		default:
+			record = fmt.Sprintf(
+				"{\"type\":\"progress\",\"timestamp\":\"2026-01-01T00:00:%02dZ\","+
+					"\"data\":{\"type\":\"hook_progress\",\"payload\":\"%s\"}}\n",
+				i%60, padding,
+			)
+		}
+		_, err = f.WriteString(record)
+		require.NoError(t, err)
+	}
+	require.NoError(t, f.Close())
+
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+	results, excluded, err := claudeParseWithExclusions(path, "project", "local")
+	require.NoError(t, err)
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+
+	require.Len(t, results, 1)
+	assert.Empty(t, excluded)
+	assert.Len(t, results[0].Messages, 2)
+	assistant := results[0].Messages[0]
+	assert.Equal(t, "model-1", assistant.Model)
+	assert.JSONEq(t, `{"input_tokens":4,"output_tokens":2}`, string(assistant.TokenUsage))
+	require.Len(t, assistant.ToolCalls, 1)
+	assert.Equal(t, `{"file_path":"notes.txt"}`, assistant.ToolCalls[0].InputJSON)
+	last := results[0].Messages[1]
+	require.Len(t, last.ToolResults, 1)
+	assert.Equal(t, `"result"`, last.ToolResults[0].ContentRaw)
+	allocated := after.TotalAlloc - before.TotalAlloc
+	assert.Less(t, allocated, uint64(lineCount*paddingSize/2),
+		"full parse should not copy ignored JSONL payload into the Go heap")
+	runtime.KeepAlive(results)
+}

--- a/internal/parser/claude_test.go
+++ b/internal/parser/claude_test.go
@@ -546,8 +546,11 @@ func TestClaudeIncrementalStoredIdentityAppendStaysIncremental(t *testing.T) {
 	require.NoError(t, f.Close())
 
 	msgs, _, _, _, parseErr := claudeParseSessionFrom(
-		path, info.Size(), 1, "u1",
-		claudeStoredIdentity{entrypoint: "cli"},
+		path, info.Size(), claudeIncrementalScan{
+			startOrdinal:  1,
+			lastEntryUUID: "u1",
+			stored:        claudeStoredIdentity{entrypoint: "cli"},
+		},
 	)
 	require.NoError(t, parseErr)
 	require.Len(t, msgs, 1)
@@ -593,8 +596,11 @@ func TestClaudeIncrementalNewIdentityFieldStillEscalates(t *testing.T) {
 	require.NoError(t, f.Close())
 
 	_, _, _, _, parseErr := claudeParseSessionFrom(
-		path, info.Size(), 1, "u1",
-		claudeStoredIdentity{entrypoint: "cli"},
+		path, info.Size(), claudeIncrementalScan{
+			startOrdinal:  1,
+			lastEntryUUID: "u1",
+			stored:        claudeStoredIdentity{entrypoint: "cli"},
+		},
 	)
 	require.Error(t, parseErr)
 	assert.True(t, IsIncrementalFullParseFallback(parseErr))

--- a/internal/parser/claw_provider.go
+++ b/internal/parser/claw_provider.go
@@ -58,6 +58,10 @@ func (p *openClawProvider) Discover(ctx context.Context) ([]SourceRef, error) {
 	return p.sources.Discover(ctx)
 }
 
+func (p *openClawProvider) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	return p.sources.DiscoverEach(ctx, yield)
+}
+
 func (p *openClawProvider) WatchPlan(ctx context.Context) (WatchPlan, error) {
 	return p.sources.WatchPlan(ctx)
 }
@@ -82,6 +86,12 @@ func (p *openClawProvider) Fingerprint(
 	source SourceRef,
 ) (SourceFingerprint, error) {
 	return p.sources.Fingerprint(ctx, source)
+}
+
+func (p *openClawProvider) ReconciliationSourceRank(
+	source SourceRef,
+) ReconciliationSourceRank {
+	return p.sources.reconciliationSourceRank(source)
 }
 
 func (p *openClawProvider) Parse(
@@ -137,6 +147,10 @@ func (p *qClawProvider) Discover(ctx context.Context) ([]SourceRef, error) {
 	return p.sources.Discover(ctx)
 }
 
+func (p *qClawProvider) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	return p.sources.DiscoverEach(ctx, yield)
+}
+
 func (p *qClawProvider) WatchPlan(ctx context.Context) (WatchPlan, error) {
 	return p.sources.WatchPlan(ctx)
 }
@@ -161,6 +175,12 @@ func (p *qClawProvider) Fingerprint(
 	source SourceRef,
 ) (SourceFingerprint, error) {
 	return p.sources.Fingerprint(ctx, source)
+}
+
+func (p *qClawProvider) ReconciliationSourceRank(
+	source SourceRef,
+) ReconciliationSourceRank {
+	return p.sources.reconciliationSourceRank(source)
 }
 
 func (p *qClawProvider) Parse(
@@ -219,6 +239,47 @@ func (s clawSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
 		return sources[i].Key < sources[j].Key
 	})
 	return sources, nil
+}
+
+func (s clawSourceSet) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	for _, root := range s.roots {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		err := streamDirectoryEntries(ctx, root, func(agent os.DirEntry) error {
+			if !IsValidSessionID(agent.Name()) {
+				return nil
+			}
+			isAgentDir, dirErr := streamingDirCandidateOrIncomplete(
+				s.spec.agent, "agent directory", agent, root,
+			)
+			if dirErr != nil {
+				return dirErr
+			}
+			if !isAgentDir {
+				return nil
+			}
+			dir := filepath.Join(root, agent.Name(), "sessions")
+			return streamDirectoryEntries(ctx, dir, func(entry os.DirEntry) error {
+				if entry.IsDir() || !s.spec.sessionFile(entry.Name()) ||
+					!IsValidSessionID(s.spec.sessionID(entry.Name())) {
+					return nil
+				}
+				source, ok := s.sourceRef(root, filepath.Join(dir, entry.Name()))
+				if !ok {
+					return nil
+				}
+				if info, infoErr := entry.Info(); infoErr == nil {
+					source.DiscoveryMTimeNS = info.ModTime().UnixNano()
+				}
+				return yield(source)
+			})
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (s clawSourceSet) WatchPlan(context.Context) (WatchPlan, error) {
@@ -424,7 +485,7 @@ func (s clawSourceSet) sourceRef(root string, path string) (SourceRef, bool) {
 	}
 	return SourceRef{
 		Provider:       s.spec.agent,
-		Key:            path,
+		Key:            rawID,
 		DisplayPath:    path,
 		FingerprintKey: path,
 		ProjectHint:    clawAgentIDFromRawID(rawID),
@@ -555,38 +616,47 @@ func (s clawSourceSet) sourcePathForRawID(root, rawID string) string {
 }
 
 func (s clawSourceSet) bestEntry(a, b os.DirEntry) os.DirEntry {
-	aActive := strings.HasSuffix(a.Name(), ".jsonl")
-	bActive := strings.HasSuffix(b.Name(), ".jsonl")
-	if aActive && !bActive {
-		return a
-	}
-	if bActive && !aActive {
-		return b
-	}
-	aTime := clawArchiveTime(a)
-	bTime := clawArchiveTime(b)
-	if !aTime.IsZero() && !bTime.IsZero() {
-		if bTime.After(aTime) {
-			return b
-		}
-		return a
-	}
-	if !aTime.IsZero() {
-		return a
-	}
-	if !bTime.IsZero() {
-		return b
-	}
-	ai, errA := a.Info()
-	bi, errB := b.Info()
-	if errA == nil && errB == nil && bi.ModTime().After(ai.ModTime()) {
+	aRank := clawDirEntryReconciliationRank(a)
+	bRank := clawDirEntryReconciliationRank(b)
+	if bRank.Class > aRank.Class ||
+		(bRank.Class == aRank.Class && bRank.Recency > aRank.Recency) {
 		return b
 	}
 	return a
 }
 
-func clawArchiveTime(e os.DirEntry) time.Time {
-	name := e.Name()
+func (s clawSourceSet) reconciliationSourceRank(
+	source SourceRef,
+) ReconciliationSourceRank {
+	path, ok := s.pathFromSource(source)
+	if !ok {
+		return ReconciliationSourceRank{}
+	}
+	return clawReconciliationSourceRank(
+		filepath.Base(path), source.DiscoveryMTimeNS,
+	)
+}
+
+func clawDirEntryReconciliationRank(entry os.DirEntry) ReconciliationSourceRank {
+	mtime := int64(0)
+	if info, err := entry.Info(); err == nil {
+		mtime = info.ModTime().UnixNano()
+	}
+	return clawReconciliationSourceRank(entry.Name(), mtime)
+}
+
+func clawReconciliationSourceRank(name string, mtime int64) ReconciliationSourceRank {
+	if strings.HasSuffix(name, ".jsonl") {
+		return ReconciliationSourceRank{Class: 2, Recency: mtime}
+	}
+	archiveTime := clawArchiveNameTime(name)
+	if !archiveTime.IsZero() {
+		return ReconciliationSourceRank{Class: 1, Recency: archiveTime.UnixNano()}
+	}
+	return ReconciliationSourceRank{Recency: mtime}
+}
+
+func clawArchiveNameTime(name string) time.Time {
 	idx := strings.Index(name, ".jsonl.")
 	if idx <= 0 {
 		return time.Time{}
@@ -676,8 +746,10 @@ func qClawProviderCapabilities() Capabilities {
 }
 
 func clawProviderCapabilities() Capabilities {
+	source := jsonlFileProviderSourceCapabilities()
+	source.StreamingDiscovery = CapabilitySupported
 	return Capabilities{
-		Source: jsonlFileProviderSourceCapabilities(),
+		Source: source,
 		Content: ContentCapabilities{
 			FirstMessage:         CapabilitySupported,
 			Thinking:             CapabilitySupported,

--- a/internal/parser/claw_provider_test.go
+++ b/internal/parser/claw_provider_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,6 +29,102 @@ func TestOpenClawProviderDiscoversSymlinkedAgentDirectory(t *testing.T) {
 func TestQClawProviderDiscoversSymlinkedAgentDirectory(t *testing.T) {
 	spec := qClawProviderTestSpec()
 	assertClawProviderDiscoversSymlinkedAgentDirectory(t, spec)
+}
+
+func TestOpenClawProviderStreamingDiscoveryPropagatesAgentSymlinkErrors(t *testing.T) {
+	spec := openClawProviderTestSpec()
+	assertClawProviderStreamingDiscoveryPropagatesAgentSymlinkErrors(t, spec)
+}
+
+func TestQClawProviderStreamingDiscoveryPropagatesAgentSymlinkErrors(t *testing.T) {
+	spec := qClawProviderTestSpec()
+	assertClawProviderStreamingDiscoveryPropagatesAgentSymlinkErrors(t, spec)
+}
+
+// A followed agent-directory symlink whose target cannot be resolved must
+// surface incomplete streaming discovery rather than reading as absent:
+// reconciliation treats a clean DiscoverEach as authoritative and would
+// tombstone every session beneath the symlink.
+func assertClawProviderStreamingDiscoveryPropagatesAgentSymlinkErrors(
+	t *testing.T, spec clawProviderTestSpec,
+) {
+	t.Helper()
+	discoverEach := func(t *testing.T, root string) ([]string, error) {
+		t.Helper()
+		provider, ok := NewProvider(spec.agent, ProviderConfig{
+			Roots: []string{root},
+		})
+		require.True(t, ok)
+		discoverer, ok := provider.(StreamingDiscoverer)
+		require.True(t, ok)
+		var yielded []string
+		err := discoverer.DiscoverEach(t.Context(), func(source SourceRef) error {
+			yielded = append(yielded, source.DisplayPath)
+			return nil
+		})
+		return yielded, err
+	}
+	writeHealthySession := func(t *testing.T, root string) string {
+		t.Helper()
+		path := filepath.Join(root, "main", "sessions", "abc-123.jsonl")
+		writeSourceFile(t, path, spec.fixture("abc-123", "healthy question"))
+		return path
+	}
+
+	t.Run("dangling agent symlink", func(t *testing.T) {
+		root := t.TempDir()
+		healthy := writeHealthySession(t, root)
+		target := filepath.Join(t.TempDir(), "linked-agent")
+		require.NoError(t, os.MkdirAll(target, 0o755))
+		link := filepath.Join(root, "linked")
+		if err := os.Symlink(target, link); err != nil {
+			t.Skipf("symlink not supported: %v", err)
+		}
+		require.NoError(t, os.RemoveAll(target))
+
+		_, err := discoverEach(t, root)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, os.ErrNotExist)
+		var incomplete DiscoveryIncompleteError
+		assert.ErrorAs(t, err, &incomplete)
+
+		require.NoError(t, os.Remove(link))
+		yielded, err := discoverEach(t, root)
+		require.NoError(t, err)
+		assert.Equal(t, []string{healthy}, yielded)
+	})
+
+	t.Run("unstatable agent symlink target", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("directory read permissions are not enforced on Windows")
+		}
+		if os.Geteuid() == 0 {
+			t.Skip("root bypasses directory permissions")
+		}
+		root := t.TempDir()
+		healthy := writeHealthySession(t, root)
+		targetParent := t.TempDir()
+		target := filepath.Join(targetParent, "linked-agent")
+		require.NoError(t, os.MkdirAll(target, 0o755))
+		if err := os.Symlink(target, filepath.Join(root, "linked")); err != nil {
+			t.Skipf("symlink not supported: %v", err)
+		}
+		require.NoError(t, os.Chmod(targetParent, 0o000))
+		t.Cleanup(func() { _ = os.Chmod(targetParent, 0o755) })
+
+		_, err := discoverEach(t, root)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, os.ErrPermission)
+		var incomplete DiscoveryIncompleteError
+		assert.ErrorAs(t, err, &incomplete)
+
+		require.NoError(t, os.Chmod(targetParent, 0o755))
+		yielded, err := discoverEach(t, root)
+		require.NoError(t, err)
+		assert.Equal(t, []string{healthy}, yielded)
+	})
 }
 
 func TestOpenClawProviderParse(t *testing.T) {

--- a/internal/parser/codex_provider.go
+++ b/internal/parser/codex_provider.go
@@ -54,6 +54,10 @@ func (p *codexProvider) Discover(ctx context.Context) ([]SourceRef, error) {
 	return p.sources.Discover(ctx)
 }
 
+func (p *codexProvider) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	return p.sources.DiscoverEach(ctx, yield)
+}
+
 func (p *codexProvider) WatchPlan(ctx context.Context) (WatchPlan, error) {
 	return p.sources.WatchPlan(ctx)
 }
@@ -295,6 +299,46 @@ func newCodexSourceSet(roots []string) codexSourceSet {
 
 func (s codexSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
 	return s.discover(ctx, func(string) bool { return true })
+}
+
+func (s codexSourceSet) DiscoverEach(
+	ctx context.Context, yield func(SourceRef) error,
+) error {
+	for _, root := range s.roots {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if strings.HasPrefix(root, "s3://") {
+			for _, file := range discoverCodexS3(root) {
+				if err := yield(s3SourceRefFromDiscoveredFile(file)); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+		err := streamDirectoryTree(ctx, root, func(path string, entry os.DirEntry) error {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if !isCodexSessionFilename(entry.Name()) {
+				return nil
+			}
+			source, ok := s.sourceRef(root, path, true)
+			if !ok {
+				if _, _, supported := CodexSessionPathInfo(root, path); supported {
+					source, ok = s.directPathSource(root, path, true)
+				}
+			}
+			if !ok {
+				return nil
+			}
+			return yield(source)
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (s codexSourceSet) discover(
@@ -707,6 +751,14 @@ func codexSourceKey(uuid string) string {
 	return string(AgentCodex) + ":" + uuid
 }
 
+// CodexSourceKey is the discovery identity of a Codex session UUID. Every
+// on-disk copy of a duplicated UUID shares this key, so the sync engine's
+// reconciliation index resolves same-UUID replacements with one bounded
+// lookup instead of an archive walk.
+func CodexSourceKey(uuid string) string {
+	return codexSourceKey(uuid)
+}
+
 func preferCodexSource(candidate, current SourceRef) bool {
 	cand := candidate.Opaque.(codexSource)
 	curr := current.Opaque.(codexSource)
@@ -757,6 +809,7 @@ func codexProviderCapabilities() Capabilities {
 	return Capabilities{
 		Source: SourceCapabilities{
 			DiscoverSources:      CapabilitySupported,
+			StreamingDiscovery:   CapabilitySupported,
 			WatchSources:         CapabilitySupported,
 			ClassifyChangedPath:  CapabilitySupported,
 			FindSource:           CapabilitySupported,

--- a/internal/parser/codex_provider_test.go
+++ b/internal/parser/codex_provider_test.go
@@ -1450,6 +1450,99 @@ func TestCodexProviderDiscoverDedupesLiveAndArchivedByUUID(t *testing.T) {
 	assert.NotEqual(t, archivedPath, discovered[0].DisplayPath)
 }
 
+func TestCodexProviderDiscoverEachYieldsDuplicateCandidates(t *testing.T) {
+	base := t.TempDir()
+	liveRoot := filepath.Join(base, "sessions")
+	archivedRoot := filepath.Join(base, "archived_sessions")
+	uuid := "019eb791-cf7d-75c1-8439-9ed74c1229e5"
+	livePath := writeCodexProviderSession(t, liveRoot, uuid, "live")
+	archivedPath := writeCodexProviderArchivedSession(t, archivedRoot, uuid, "archived")
+	provider, ok := NewProvider(AgentCodex, ProviderConfig{
+		Roots: []string{archivedRoot, liveRoot},
+	})
+	require.True(t, ok)
+	discoverer, ok := provider.(StreamingDiscoverer)
+	require.True(t, ok)
+
+	var paths []string
+	require.NoError(t, discoverer.DiscoverEach(t.Context(), func(source SourceRef) error {
+		paths = append(paths, source.DisplayPath)
+		return nil
+	}))
+
+	assert.ElementsMatch(t, []string{archivedPath, livePath}, paths)
+}
+
+func TestCodexProviderDiscoverEachIncludesNoncanonicalRollout(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(
+		root, "2026", "06", "11", "rollout-manually-restored.jsonl",
+	)
+	uuid := "019eb791-cf7d-75c1-8439-9ed74c1229ef"
+	content := testjsonl.JoinJSONL(
+		testjsonl.CodexSessionMetaJSON(
+			uuid, "/workspace/project-a", "codex_cli_rs", tsEarly,
+		),
+		testjsonl.CodexMsgJSON("user", "Restore this session", tsEarlyS1),
+	)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	provider, ok := NewProvider(AgentCodex, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	discovered, err := provider.Discover(t.Context())
+	require.NoError(t, err)
+	require.Len(t, discovered, 1)
+	changed, err := provider.SourcesForChangedPath(
+		t.Context(), ChangedPathRequest{Path: path, EventKind: "write"},
+	)
+	require.NoError(t, err)
+	require.Len(t, changed, 1)
+	discoverer, ok := provider.(StreamingDiscoverer)
+	require.True(t, ok)
+	var streamed []SourceRef
+	require.NoError(t, discoverer.DiscoverEach(
+		t.Context(), func(source SourceRef) error {
+			streamed = append(streamed, source)
+			return nil
+		},
+	))
+
+	assert.Equal(t, []string{path}, sourceDisplayPaths(discovered))
+	assert.Equal(t, []string{path}, sourceDisplayPaths(changed))
+	assert.Equal(t, []string{path}, sourceDisplayPaths(streamed),
+		"streaming discovery must preserve direct-path rollout fallback parity")
+}
+
+func TestCodexProviderDiscoverEachExcludesNoncanonicalRolloutOutsideSupportedLayouts(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	path := filepath.Join(
+		root, "arbitrary", "nesting", "rollout-manually-restored.jsonl",
+	)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o644))
+	provider, ok := NewProvider(AgentCodex, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	discovered, err := provider.Discover(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, discovered)
+	discoverer, ok := provider.(StreamingDiscoverer)
+	require.True(t, ok)
+	var streamed []SourceRef
+	require.NoError(t, discoverer.DiscoverEach(
+		t.Context(), func(source SourceRef) error {
+			streamed = append(streamed, source)
+			return nil
+		},
+	))
+
+	assert.Empty(t, streamed,
+		"streaming discovery must preserve slice discovery's layout boundary")
+}
+
 func TestCodexProviderFindSourcePinsExactArchivedDuplicate(t *testing.T) {
 	base := t.TempDir()
 	liveRoot := filepath.Join(base, "sessions")

--- a/internal/parser/commandcode_provider.go
+++ b/internal/parser/commandcode_provider.go
@@ -8,7 +8,10 @@ import (
 	"strings"
 )
 
-var _ Provider = (*commandCodeProvider)(nil)
+var (
+	_ Provider         = (*commandCodeProvider)(nil)
+	_ WatchRootPlanner = (*commandCodeProvider)(nil)
+)
 
 type commandCodeProviderFactory struct {
 	def AgentDef
@@ -47,8 +50,18 @@ func (p *commandCodeProvider) Discover(ctx context.Context) ([]SourceRef, error)
 	return p.sources.Discover(ctx)
 }
 
+func (p *commandCodeProvider) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	return p.sources.DiscoverEach(ctx, yield)
+}
+
 func (p *commandCodeProvider) WatchPlan(ctx context.Context) (WatchPlan, error) {
 	return p.sources.WatchPlan(ctx)
+}
+
+func (p *commandCodeProvider) WatchRoots(
+	ctx context.Context,
+) ([]WatchRoot, error) {
+	return p.sources.WatchRoots(ctx)
 }
 
 func (p *commandCodeProvider) SourcesForChangedPath(
@@ -136,6 +149,10 @@ func newCommandCodeSourceSet(roots []string) DirectoryJSONLSourceSet {
 		WithCompanionFiles(func(transcriptPath string) []string {
 			return []string{commandCodeMetaCompanionPath(transcriptPath)}
 		}),
+		WithCompanionTranscript(func(companionPath string) (string, bool) {
+			stem, ok := strings.CutSuffix(companionPath, ".meta.json")
+			return stem + ".jsonl", ok
+		}),
 		WithContentHashing(),
 	)
 }
@@ -198,8 +215,11 @@ func commandCodeCompanionInfo(path string) (os.FileInfo, bool, error) {
 }
 
 func commandCodeProviderCapabilities() Capabilities {
+	source := jsonlFileProviderSourceCapabilities()
+	source.StreamingDiscovery = CapabilitySupported
+	source.WatchRoots = CapabilitySupported
 	return Capabilities{
-		Source: jsonlFileProviderSourceCapabilities(),
+		Source: source,
 		Content: ContentCapabilities{
 			FirstMessage:       CapabilitySupported,
 			SessionName:        CapabilitySupported,

--- a/internal/parser/commandcode_provider_test.go
+++ b/internal/parser/commandcode_provider_test.go
@@ -57,6 +57,46 @@ func TestCommandCodeProviderSourceMethods(t *testing.T) {
 	assert.Equal(t, sourcePath, changed[0].DisplayPath)
 }
 
+func TestCommandCodeProviderWatchRootsStayBounded(t *testing.T) {
+	root := t.TempDir()
+	transcript := filepath.Join(root, "project", "session.jsonl")
+	writeSourceFile(t, transcript, "{}\n")
+	companionCalls := 0
+	provider := &commandCodeProvider{
+		ProviderBase: ProviderBase{
+			Def:  AgentDef{Type: AgentCommandCode},
+			Caps: commandCodeProviderCapabilities(),
+		},
+		sources: NewDirectoryJSONLSourceSet(
+			AgentCommandCode,
+			[]string{root},
+			WithCompanionFiles(func(path string) []string {
+				companionCalls++
+				return []string{commandCodeMetaCompanionPath(path)}
+			}),
+		),
+	}
+
+	assert.Equal(t, CapabilitySupported, provider.Capabilities().Source.WatchRoots)
+	assert.Implements(t, (*WatchRootPlanner)(nil), provider)
+	roots, err := ResolveWatchRoots(context.Background(), provider)
+	require.NoError(t, err)
+	assert.Equal(t, []WatchRoot{{
+		Path:        root,
+		Recursive:   true,
+		DebounceKey: string(AgentCommandCode) + ":jsonl:" + root,
+	}}, roots)
+	assert.Zero(t, companionCalls,
+		"bounded root scheduling must not discover transcript companions")
+
+	plan, err := provider.WatchPlan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, plan.Roots, 1)
+	assert.Contains(t, plan.Roots[0].IncludeGlobs, "session.meta.json")
+	assert.Equal(t, 1, companionCalls,
+		"legacy WatchPlan must retain companion glob discovery")
+}
+
 func TestCommandCodeProviderDiscoversSymlinkedProjectDirectory(t *testing.T) {
 	root := t.TempDir()
 	realProjectDir := filepath.Join(t.TempDir(), "real-project")

--- a/internal/parser/copilot_ide_provider_test.go
+++ b/internal/parser/copilot_ide_provider_test.go
@@ -757,6 +757,16 @@ func TestVisualStudioCopilotProviderDiscoversSymlinkedVS2026Dirs(
 	require.Len(t, discovered, 1)
 	assert.Equal(t, virtualPath, discovered[0].DisplayPath)
 
+	streaming, ok := provider.(StreamingDiscoverer)
+	require.True(t, ok)
+	var streamed []SourceRef
+	require.NoError(t, streaming.DiscoverEach(t.Context(), func(source SourceRef) error {
+		streamed = append(streamed, source)
+		return nil
+	}))
+	require.Len(t, streamed, 1)
+	assert.Equal(t, virtualPath, streamed[0].DisplayPath)
+
 	found, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
 		RawSessionID: conversationID,
 	})

--- a/internal/parser/copilot_provider.go
+++ b/internal/parser/copilot_provider.go
@@ -50,6 +50,10 @@ func (p *copilotProvider) Discover(ctx context.Context) ([]SourceRef, error) {
 	return p.sources.Discover(ctx)
 }
 
+func (p *copilotProvider) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	return p.sources.DiscoverEach(ctx, yield)
+}
+
 func (p *copilotProvider) WatchPlan(ctx context.Context) (WatchPlan, error) {
 	return p.sources.WatchPlan(ctx)
 }
@@ -151,6 +155,39 @@ func (s copilotSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
 	}
 	sortJSONLSources(sources)
 	return sources, nil
+}
+
+func (s copilotSourceSet) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	for _, root := range s.roots {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		stateDir := filepath.Join(root, copilotStateDir)
+		err := streamDirectoryEntries(ctx, stateDir, func(entry os.DirEntry) error {
+			name := entry.Name()
+			path := ""
+			if entry.IsDir() {
+				candidate := filepath.Join(stateDir, name, "events.jsonl")
+				if IsRegularFile(candidate) {
+					path = candidate
+				}
+			} else if stem, ok := strings.CutSuffix(name, ".jsonl"); ok {
+				if !IsRegularFile(filepath.Join(stateDir, stem, "events.jsonl")) {
+					path = filepath.Join(stateDir, name)
+				}
+			}
+			if path != "" {
+				if source, ok := s.sourceRef(root, path); ok {
+					return yield(source)
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // discoverSessionPaths finds all Copilot session file paths under
@@ -465,6 +502,7 @@ func copilotProviderCapabilities() Capabilities {
 	return Capabilities{
 		Source: SourceCapabilities{
 			DiscoverSources:      CapabilitySupported,
+			StreamingDiscovery:   CapabilitySupported,
 			WatchSources:         CapabilitySupported,
 			ClassifyChangedPath:  CapabilitySupported,
 			FindSource:           CapabilitySupported,

--- a/internal/parser/cortex_provider.go
+++ b/internal/parser/cortex_provider.go
@@ -7,7 +7,10 @@ import (
 	"strings"
 )
 
-var _ Provider = (*cortexProvider)(nil)
+var (
+	_ Provider         = (*cortexProvider)(nil)
+	_ WatchRootPlanner = (*cortexProvider)(nil)
+)
 
 type cortexProviderFactory struct {
 	def AgentDef
@@ -46,8 +49,18 @@ func (p *cortexProvider) Discover(ctx context.Context) ([]SourceRef, error) {
 	return p.sources.Discover(ctx)
 }
 
+func (p *cortexProvider) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	return p.sources.DiscoverEach(ctx, yield)
+}
+
 func (p *cortexProvider) WatchPlan(ctx context.Context) (WatchPlan, error) {
 	return p.sources.WatchPlan(ctx)
+}
+
+func (p *cortexProvider) WatchRoots(
+	ctx context.Context,
+) ([]WatchRoot, error) {
+	return p.sources.WatchRoots(ctx)
 }
 
 func (p *cortexProvider) SourcesForChangedPath(
@@ -126,6 +139,10 @@ func newCortexSourceSet(roots []string) JSONLSourceSet {
 		WithCompanionFiles(func(transcriptPath string) []string {
 			return []string{cortexHistoryCompanionPath(transcriptPath)}
 		}),
+		WithCompanionTranscript(func(companionPath string) (string, bool) {
+			stem, ok := strings.CutSuffix(companionPath, ".history.jsonl")
+			return stem + ".json", ok
+		}),
 		WithContentHashing(),
 	)
 }
@@ -149,8 +166,11 @@ func cortexHistoryCompanionPath(path string) string {
 }
 
 func cortexProviderCapabilities() Capabilities {
+	source := jsonlFileProviderSourceCapabilities()
+	source.StreamingDiscovery = CapabilitySupported
+	source.WatchRoots = CapabilitySupported
 	return Capabilities{
-		Source: jsonlFileProviderSourceCapabilities(),
+		Source: source,
 		Content: ContentCapabilities{
 			FirstMessage: CapabilitySupported,
 			SessionName:  CapabilitySupported,

--- a/internal/parser/cortex_provider_test.go
+++ b/internal/parser/cortex_provider_test.go
@@ -35,6 +35,46 @@ func TestCortexProviderCapabilities(t *testing.T) {
 	require.NotNil(t, provider)
 }
 
+func TestCortexProviderWatchRootsStayBounded(t *testing.T) {
+	root := t.TempDir()
+	transcript := filepath.Join(root, cortexTestUUID+".json")
+	writeSourceFile(t, transcript, "{}\n")
+	companionCalls := 0
+	provider := &cortexProvider{
+		ProviderBase: ProviderBase{
+			Def:  AgentDef{Type: AgentCortex},
+			Caps: cortexProviderCapabilities(),
+		},
+		sources: NewJSONLSourceSet(
+			AgentCortex,
+			[]string{root},
+			WithExtensions(".json"),
+			WithCompanionFiles(func(path string) []string {
+				companionCalls++
+				return []string{cortexHistoryCompanionPath(path)}
+			}),
+		),
+	}
+
+	assert.Equal(t, CapabilitySupported, provider.Capabilities().Source.WatchRoots)
+	assert.Implements(t, (*WatchRootPlanner)(nil), provider)
+	roots, err := ResolveWatchRoots(context.Background(), provider)
+	require.NoError(t, err)
+	assert.Equal(t, []WatchRoot{{
+		Path:        root,
+		DebounceKey: string(AgentCortex) + ":jsonl:" + root,
+	}}, roots)
+	assert.Zero(t, companionCalls,
+		"bounded root scheduling must not discover transcript companions")
+
+	plan, err := provider.WatchPlan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, plan.Roots, 1)
+	assert.Contains(t, plan.Roots[0].IncludeGlobs, cortexTestUUID+".history.jsonl")
+	assert.Equal(t, 1, companionCalls,
+		"legacy WatchPlan must retain companion glob discovery")
+}
+
 func TestCortexProviderSourceMethods(t *testing.T) {
 	root := t.TempDir()
 	otherID := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"

--- a/internal/parser/cowork.go
+++ b/internal/parser/cowork.go
@@ -5,6 +5,7 @@ package parser
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -61,6 +62,18 @@ func readCoworkMeta(path string) coworkMeta {
 	}
 	_ = json.Unmarshal(data, &meta)
 	return meta
+}
+
+func readCoworkMetaStrict(path string) (coworkMeta, error) {
+	var meta coworkMeta
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return meta, fmt.Errorf("read cowork metadata %s: %w", path, err)
+	}
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return meta, fmt.Errorf("decode cowork metadata %s: %w", path, err)
+	}
+	return meta, nil
 }
 
 // coworkProjectName derives a project grouping for a cowork session.

--- a/internal/parser/cowork_provider.go
+++ b/internal/parser/cowork_provider.go
@@ -1,6 +1,8 @@
 package parser
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -22,7 +24,7 @@ func newCoworkProviderFactory(def AgentDef) ProviderFactory {
 			return NewSingleFileSourceSet(
 				AgentCowork,
 				cfg.Roots,
-				WithFileDiscovery(coworkDiscoverFiles),
+				WithStreamingFileDiscovery(coworkDiscoverEach),
 				WithFileWatchRoots(coworkWatchRoots),
 				WithFileChangedPathClassifier(coworkClassifyPath),
 				WithFileLookup(coworkFindFile),
@@ -36,14 +38,124 @@ func newCoworkProviderFactory(def AgentDef) ProviderFactory {
 	)
 }
 
-func coworkDiscoverFiles(root string) []singleFileMatch {
-	var out []singleFileMatch
-	walkCoworkSessions(root, func(transcript string) {
-		if match, ok := coworkTranscriptMatch(root, transcript); ok {
-			out = append(out, match)
+func coworkDiscoverEach(
+	ctx context.Context, root string, yield func(singleFileMatch) error,
+) error {
+	var walk func(string) error
+	walk = func(dir string) error {
+		return streamDirectoryEntries(ctx, dir, func(entry os.DirEntry) error {
+			path := filepath.Join(dir, entry.Name())
+			if entry.IsDir() {
+				name := entry.Name()
+				if strings.HasPrefix(name, "local_") || name == "skills-plugin" ||
+					name == "node_modules" || name == ".git" {
+					return nil
+				}
+				return walk(path)
+			}
+			if !isCoworkMetaFileName(entry.Name()) {
+				return nil
+			}
+			meta, err := readCoworkMetaStrict(path)
+			if err != nil {
+				return err
+			}
+			if meta.CliSessionID == "" {
+				return nil
+			}
+			sessionDir := strings.TrimSuffix(path, ".json")
+			main, encDir, err := resolveCoworkSessionStreamed(ctx, sessionDir, meta.CliSessionID)
+			if err != nil {
+				return err
+			}
+			if main == "" {
+				return nil
+			}
+			if match, ok, matchErr := coworkTranscriptMatchStrict(root, main); matchErr != nil {
+				return matchErr
+			} else if ok {
+				if err := yield(match); err != nil {
+					return err
+				}
+			}
+			subagents := filepath.Join(encDir, meta.CliSessionID, "subagents")
+			return streamDirectoryTree(ctx, subagents, func(subPath string, sub os.DirEntry) error {
+				if !strings.HasPrefix(sub.Name(), "agent-") ||
+					!strings.HasSuffix(sub.Name(), ".jsonl") {
+					return nil
+				}
+				regular, statErr := streamingRegularFileCandidate(subPath)
+				if statErr != nil {
+					return fmt.Errorf("stat cowork subagent candidate %s: %w", subPath, statErr)
+				}
+				if !regular {
+					return nil
+				}
+				if match, ok, matchErr := coworkTranscriptMatchStrict(root, subPath); matchErr != nil {
+					return matchErr
+				} else if ok {
+					return yield(match)
+				}
+				return nil
+			})
+		})
+	}
+	return walk(root)
+}
+
+func resolveCoworkSessionStreamed(
+	ctx context.Context, sessionDir, cliSessionID string,
+) (main, encodedDir string, retErr error) {
+	if sessionDir == "" || !IsValidSessionID(cliSessionID) {
+		return "", "", nil
+	}
+	resolvedRoot, err := filepath.EvalSymlinks(sessionDir)
+	if err != nil {
+		if _, lstatErr := os.Lstat(sessionDir); errors.Is(lstatErr, os.ErrNotExist) {
+			return "", "", nil
 		}
+		return "", "", fmt.Errorf("resolve cowork session directory %s: %w", sessionDir, err)
+	}
+	projectsDir := filepath.Join(sessionDir, ".claude", "projects")
+	projectsInfo, err := os.Stat(projectsDir)
+	if err != nil {
+		return "", "", fmt.Errorf("stat cowork projects directory %s: %w", projectsDir, err)
+	}
+	if !projectsInfo.IsDir() {
+		return "", "", fmt.Errorf("stat cowork projects directory %s: not a directory", projectsDir)
+	}
+	err = streamDirectoryEntries(ctx, projectsDir, func(entry os.DirEntry) error {
+		candidateDir, candidateErr := streamingDirOrSymlinkCandidate(entry, projectsDir)
+		if candidateErr != nil {
+			return fmt.Errorf("stat cowork project candidate %s: %w",
+				filepath.Join(projectsDir, entry.Name()), candidateErr)
+		}
+		if !candidateDir {
+			return nil
+		}
+		dir := filepath.Join(projectsDir, entry.Name())
+		candidate := filepath.Join(dir, cliSessionID+".jsonl")
+		regular, statErr := streamingRegularFileCandidate(candidate)
+		if statErr != nil {
+			return fmt.Errorf("stat cowork transcript %s: %w", candidate, statErr)
+		}
+		if !regular {
+			return nil
+		}
+		resolved, resolveErr := filepath.EvalSymlinks(candidate)
+		if resolveErr != nil {
+			return fmt.Errorf("resolve cowork transcript %s: %w", candidate, resolveErr)
+		}
+		if isContainedIn(resolved, resolvedRoot) {
+			main, encodedDir = candidate, dir
+			return errStopStreamingDiscovery
+		}
+		return nil
 	})
-	return out
+	if errors.Is(err, errStopStreamingDiscovery) {
+		err = nil
+	}
+	return main, encodedDir, err
 }
 
 func coworkWatchRoots(roots []string) []WatchRoot {
@@ -105,6 +217,27 @@ func coworkTranscriptMatch(root, path string) (singleFileMatch, bool) {
 		Path:        path,
 		ProjectHint: coworkProjectName(readCoworkMeta(metaPath)),
 	}, true
+}
+
+func coworkTranscriptMatchStrict(
+	root, path string,
+) (singleFileMatch, bool, error) {
+	root = filepath.Clean(root)
+	path = filepath.Clean(path)
+	if _, ok := relUnder(root, path); !ok {
+		return singleFileMatch{}, false, nil
+	}
+	metaPath := coworkMetaPathForTranscript(path)
+	if metaPath == "" || !isCoworkTranscriptPath(root, path) {
+		return singleFileMatch{}, false, nil
+	}
+	meta, err := readCoworkMetaStrict(metaPath)
+	if err != nil {
+		return singleFileMatch{}, false, err
+	}
+	return singleFileMatch{
+		Path: path, ProjectHint: coworkProjectName(meta),
+	}, true, nil
 }
 
 func coworkFingerprintSource(
@@ -301,6 +434,7 @@ func coworkProviderCapabilities() Capabilities {
 	return Capabilities{
 		Source: SourceCapabilities{
 			DiscoverSources:      CapabilitySupported,
+			StreamingDiscovery:   CapabilitySupported,
 			WatchSources:         CapabilitySupported,
 			ClassifyChangedPath:  CapabilitySupported,
 			FindSource:           CapabilitySupported,

--- a/internal/parser/cowork_test.go
+++ b/internal/parser/cowork_test.go
@@ -158,6 +158,43 @@ func TestCoworkProviderDiscoversSessions(t *testing.T) {
 	assert.Equal(t, transcript, got[0], "DisplayPath")
 }
 
+func TestCoworkStreamingDiscoveryPropagatesMetadataErrors(t *testing.T) {
+	t.Run("decode", func(t *testing.T) {
+		root := t.TempDir()
+		dir := filepath.Join(root, "org", "workspace")
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		metaPath := filepath.Join(dir, "local_50000000-0000-4000-8000-000000000099.json")
+		require.NoError(t, os.WriteFile(metaPath, []byte("{"), 0o600))
+		provider := coworkProviderForRoot(t, root, "local")
+
+		err := provider.(StreamingDiscoverer).DiscoverEach(t.Context(), func(SourceRef) error {
+			return nil
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "decode cowork metadata")
+	})
+
+	t.Run("projects directory", func(t *testing.T) {
+		root := t.TempDir()
+		dir := filepath.Join(root, "org", "workspace")
+		base := "local_50000000-0000-4000-8000-000000000098"
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, base), 0o755))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, base+".json"),
+			[]byte(`{"cliSessionId":"c0000000-0000-4000-8000-000000000098"}`), 0o600,
+		))
+		provider := coworkProviderForRoot(t, root, "local")
+
+		err := provider.(StreamingDiscoverer).DiscoverEach(t.Context(), func(SourceRef) error {
+			return nil
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "stat cowork projects directory")
+	})
+}
+
 func TestCoworkProviderDiscoverIgnoresNoise(t *testing.T) {
 	root := t.TempDir()
 	wsDir := filepath.Join(root, "org", "ws")
@@ -439,6 +476,31 @@ func TestCoworkProviderDiscoverIncludesSubagents(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok, "find subagent source")
 	assert.Equal(t, subPath, found.DisplayPath)
+}
+
+func TestCoworkStreamingDiscoveryPropagatesSubagentCandidateStatError(t *testing.T) {
+	root := t.TempDir()
+	cli := "c0000000-0000-4000-8000-000000000096"
+	_, transcript := writeCoworkSession(t, root, coworkFixture{
+		org: "org", workspace: "ws",
+		sessionUUID:  "50000000-0000-4000-8000-000000000096",
+		cliSessionID: cli, encodedProject: "-sessions-demo",
+		transcriptLines: coworkTranscriptLines(cli),
+	})
+	subagents := filepath.Join(filepath.Dir(transcript), cli, "subagents")
+	require.NoError(t, os.MkdirAll(subagents, 0o755))
+	require.NoError(t, os.Symlink(
+		filepath.Join(root, "missing-subagent"),
+		filepath.Join(subagents, "agent-broken.jsonl"),
+	))
+	provider := coworkProviderForRoot(t, root, "local")
+
+	err := provider.(StreamingDiscoverer).DiscoverEach(t.Context(), func(SourceRef) error {
+		return nil
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stat cowork subagent candidate")
 }
 
 func TestResolveCoworkSessionRejectsSymlinkEscape(t *testing.T) {

--- a/internal/parser/cursor_provider.go
+++ b/internal/parser/cursor_provider.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -45,6 +46,10 @@ type cursorProvider struct {
 
 func (p *cursorProvider) Discover(ctx context.Context) ([]SourceRef, error) {
 	return p.sources.Discover(ctx)
+}
+
+func (p *cursorProvider) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	return p.sources.DiscoverEach(ctx, yield)
 }
 
 func (p *cursorProvider) WatchPlan(ctx context.Context) (WatchPlan, error) {
@@ -140,6 +145,153 @@ func (s cursorSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
 	}
 	sortJSONLSources(sources)
 	return sources, nil
+}
+
+func (s cursorSourceSet) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	for _, root := range s.roots {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		resolvedRoot, err := filepath.EvalSymlinks(root)
+		if err != nil {
+			if _, lstatErr := os.Lstat(root); errors.Is(lstatErr, os.ErrNotExist) {
+				continue
+			}
+			return fmt.Errorf("resolve cursor root %s: %w", root, err)
+		}
+		err = streamDirectoryEntries(ctx, root, func(project os.DirEntry) error {
+			if !project.IsDir() || project.Type()&os.ModeSymlink != 0 {
+				return nil
+			}
+			dir := filepath.Join(root, project.Name(), "agent-transcripts")
+			resolvedDir, resolveErr := filepath.EvalSymlinks(dir)
+			if errors.Is(resolveErr, os.ErrNotExist) {
+				if _, lstatErr := os.Lstat(dir); errors.Is(lstatErr, os.ErrNotExist) {
+					return nil
+				}
+				return fmt.Errorf("resolve cursor transcripts %s: %w", dir, resolveErr)
+			}
+			if resolveErr != nil {
+				return fmt.Errorf("resolve cursor transcripts %s: %w", dir, resolveErr)
+			}
+			if !isContainedIn(resolvedDir, resolvedRoot) {
+				return nil
+			}
+			return streamDirectoryEntries(ctx, dir, func(entry os.DirEntry) error {
+				path := ""
+				if entry.IsDir() {
+					base := filepath.Join(dir, entry.Name(), entry.Name())
+					jsonl, statErr := streamingRegularFileCandidate(base + ".jsonl")
+					if statErr != nil {
+						return fmt.Errorf("stat cursor candidate %s: %w", base+".jsonl", statErr)
+					}
+					txt, statErr := streamingRegularFileCandidate(base + ".txt")
+					if statErr != nil {
+						return fmt.Errorf("stat cursor candidate %s: %w", base+".txt", statErr)
+					}
+					if jsonl {
+						path = base + ".jsonl"
+					} else if txt {
+						path = base + ".txt"
+					}
+				} else if IsCursorTranscriptExt(entry.Name()) {
+					path = filepath.Join(dir, entry.Name())
+				}
+				if path == "" {
+					return nil
+				}
+				source, ok, sourceErr := s.streamingSourceRef(root, path)
+				if sourceErr != nil {
+					return sourceErr
+				}
+				if ok {
+					return yield(source)
+				}
+				return nil
+			})
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s cursorSourceSet) streamingSourceRef(
+	root, path string,
+) (SourceRef, bool, error) {
+	root = filepath.Clean(root)
+	path = filepath.Clean(path)
+	info, err := os.Stat(path)
+	if err != nil {
+		return SourceRef{}, false, fmt.Errorf("stat cursor transcript %s: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return SourceRef{}, false, nil
+	}
+	rawID, ok := cursorRawSessionIDFromPath(root, path)
+	if !ok {
+		return SourceRef{}, false, nil
+	}
+	projectDir, ok := cursorProjectDirFromPath(root, path)
+	if !ok {
+		return SourceRef{}, false, nil
+	}
+	selected, err := cursorFindSourceFileInProjectStrict(root, projectDir, rawID)
+	if err != nil {
+		return SourceRef{}, false, err
+	}
+	if selected == "" || !samePath(selected, path) {
+		return SourceRef{}, false, nil
+	}
+	project := DecodeCursorProjectDir(projectDir)
+	if project == "" {
+		project = "unknown"
+	}
+	return SourceRef{
+		Provider: AgentCursor, Key: path, DisplayPath: path,
+		FingerprintKey: path, ProjectHint: project,
+		Opaque: cursorSource{Root: root, Path: path},
+	}, true, nil
+}
+
+func cursorFindSourceFileInProjectStrict(
+	root, projectDir, rawID string,
+) (string, error) {
+	if root == "" || projectDir == "" || !IsValidSessionID(rawID) {
+		return "", nil
+	}
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return "", fmt.Errorf("resolve cursor root %s: %w", root, err)
+	}
+	transcriptsDir := filepath.Join(root, projectDir, "agent-transcripts")
+	for _, ext := range []string{".jsonl", ".txt"} {
+		target := rawID + ext
+		for _, candidate := range []string{
+			filepath.Join(transcriptsDir, rawID, target),
+			filepath.Join(transcriptsDir, target),
+		} {
+			info, statErr := os.Stat(candidate)
+			if errors.Is(statErr, os.ErrNotExist) {
+				continue
+			}
+			if statErr != nil {
+				return "", fmt.Errorf("stat cursor transcript %s: %w", candidate, statErr)
+			}
+			if !info.Mode().IsRegular() {
+				continue
+			}
+			resolved, resolveErr := filepath.EvalSymlinks(candidate)
+			if resolveErr != nil {
+				return "", fmt.Errorf("resolve cursor transcript %s: %w", candidate, resolveErr)
+			}
+			if isContainedIn(resolved, resolvedRoot) {
+				return candidate, nil
+			}
+		}
+	}
+	return "", nil
 }
 
 // discoverTranscriptPaths walks a Cursor projects root and returns the primary
@@ -590,6 +742,7 @@ func cursorProviderCapabilities() Capabilities {
 	return Capabilities{
 		Source: SourceCapabilities{
 			DiscoverSources:      CapabilitySupported,
+			StreamingDiscovery:   CapabilitySupported,
 			WatchSources:         CapabilitySupported,
 			ClassifyChangedPath:  CapabilitySupported,
 			FindSource:           CapabilitySupported,

--- a/internal/parser/cursor_provider_test.go
+++ b/internal/parser/cursor_provider_test.go
@@ -122,6 +122,74 @@ func TestCursorProviderSourceMethods(t *testing.T) {
 	assert.Empty(t, wrongRoot)
 }
 
+func TestCursorStreamingDiscoveryUsesCanonicalMixedLayoutPrecedence(t *testing.T) {
+	root := t.TempDir()
+	transcriptsDir := filepath.Join(
+		root, "Users-demo", "agent-transcripts",
+	)
+	flatJSONL := cursorProviderWriteJSONLTranscript(
+		t, transcriptsDir, "mixed.jsonl", "canonical flat source",
+	)
+	cursorProviderWriteTranscript(
+		t, transcriptsDir, filepath.Join("mixed", "mixed.txt"),
+		"older nested source",
+	)
+	provider, ok := NewProvider(AgentCursor, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	discovered, err := provider.Discover(t.Context())
+	require.NoError(t, err)
+	require.Len(t, discovered, 1)
+	assert.Equal(t, flatJSONL, discovered[0].DisplayPath)
+
+	var streamed []SourceRef
+	err = provider.(StreamingDiscoverer).DiscoverEach(
+		t.Context(), func(source SourceRef) error {
+			streamed = append(streamed, source)
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, streamed, 1)
+	assert.Equal(t, flatJSONL, streamed[0].DisplayPath)
+}
+
+func TestCursorStreamingDiscoveryPropagatesAuthoritativeResolutionErrors(t *testing.T) {
+	t.Run("configured root", func(t *testing.T) {
+		parent := t.TempDir()
+		root := filepath.Join(parent, "broken-root")
+		require.NoError(t, os.Symlink(filepath.Join(parent, "missing"), root))
+		provider, ok := NewProvider(AgentCursor, ProviderConfig{Roots: []string{root}})
+		require.True(t, ok)
+
+		err := provider.(StreamingDiscoverer).DiscoverEach(t.Context(), func(SourceRef) error {
+			return nil
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "resolve cursor root")
+	})
+
+	t.Run("project transcripts", func(t *testing.T) {
+		root := t.TempDir()
+		project := filepath.Join(root, "Users-demo")
+		require.NoError(t, os.MkdirAll(project, 0o755))
+		require.NoError(t, os.Symlink(
+			filepath.Join(root, "missing-transcripts"),
+			filepath.Join(project, "agent-transcripts"),
+		))
+		provider, ok := NewProvider(AgentCursor, ProviderConfig{Roots: []string{root}})
+		require.True(t, ok)
+
+		err := provider.(StreamingDiscoverer).DiscoverEach(t.Context(), func(SourceRef) error {
+			return nil
+		})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "resolve cursor transcripts")
+	})
+}
+
 func TestCursorProviderResolvesDuplicateStemsWithinProject(t *testing.T) {
 	root := t.TempDir()
 	firstProject := "Users-fiona-Documents-first"

--- a/internal/parser/db_backed_provider.go
+++ b/internal/parser/db_backed_provider.go
@@ -20,7 +20,8 @@ type dbBackedProviderSpec struct {
 	agent        AgentType
 	dbName       string
 	findDB       func(string) string
-	listMeta     func(string) ([]dbBackedSessionMeta, error)
+	streamMeta   func(context.Context, string, func(dbBackedSessionMeta) error) error
+	metaForID    func(context.Context, string, string) (dbBackedSessionMeta, bool, error)
 	parse        func(string, string, string) ([]ParseResult, error)
 	normalizeRaw func(string) string
 	caps         Capabilities
@@ -62,6 +63,12 @@ func (p *dbBackedProvider) Discover(ctx context.Context) ([]SourceRef, error) {
 	return p.sources.Discover(ctx)
 }
 
+func (p *dbBackedProvider) DiscoverEach(
+	ctx context.Context, yield func(SourceRef) error,
+) error {
+	return p.sources.DiscoverEach(ctx, yield)
+}
+
 func (p *dbBackedProvider) WatchPlan(ctx context.Context) (WatchPlan, error) {
 	return p.sources.WatchPlan(ctx)
 }
@@ -71,6 +78,12 @@ func (p *dbBackedProvider) SourcesForChangedPath(
 	req ChangedPathRequest,
 ) ([]SourceRef, error) {
 	return p.sources.SourcesForChangedPath(ctx, req)
+}
+
+func (p *dbBackedProvider) StoredSourceHintScopes(
+	req ChangedPathRequest,
+) []StoredSourceHintScope {
+	return p.sources.StoredSourceHintScopes(req)
 }
 
 func (p *dbBackedProvider) FindSource(
@@ -89,6 +102,26 @@ func (p *dbBackedProvider) Fingerprint(
 	source SourceRef,
 ) (SourceFingerprint, error) {
 	return p.sources.Fingerprint(ctx, source)
+}
+
+func (p *dbBackedProvider) PersistentArchiveSource(
+	path string, fullSessionID string,
+) (string, bool) {
+	rawSessionID := ProviderRawSessionIDFromFull(p.Def, fullSessionID)
+	if p.spec.normalizeRaw != nil {
+		rawSessionID = p.spec.normalizeRaw(rawSessionID)
+	}
+	for _, root := range p.sources.roots {
+		source, ok := p.sources.sourceRef(root, path, true)
+		if !ok {
+			continue
+		}
+		src, ok := p.sources.sourceFromRef(source)
+		if ok && rawSessionID != "" && src.SessionID == rawSessionID {
+			return src.DBPath, true
+		}
+	}
+	return "", false
 }
 
 func (p *dbBackedProvider) Parse(
@@ -175,21 +208,21 @@ func newDBBackedSourceSet(
 }
 
 func (s dbBackedSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
-	var sources []SourceRef
-	seen := make(map[string]struct{})
+	return collectDiscoveredSources(ctx, s.DiscoverEach)
+}
+
+func (s dbBackedSourceSet) DiscoverEach(
+	ctx context.Context, yield func(SourceRef) error,
+) error {
 	for _, root := range s.roots {
 		if err := ctx.Err(); err != nil {
-			return nil, err
+			return err
 		}
 		dbPath := s.spec.findDB(root)
 		if dbPath == "" {
 			continue
 		}
-		metas, err := s.spec.listMeta(dbPath)
-		if err != nil {
-			return nil, err
-		}
-		for _, meta := range metas {
+		err := s.spec.streamMeta(ctx, dbPath, func(meta dbBackedSessionMeta) error {
 			ref := s.newSourceRef(root, dbPath, meta.SessionID, meta.VirtualPath)
 			// Carry the per-session mtime captured here so parse-diff's --limit
 			// sampler can order these virtual "<db>#<sessionID>" sources by each
@@ -197,11 +230,13 @@ func (s dbBackedSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
 			// on-disk existence. Ordering metadata only: skip-cache and
 			// data-version freshness still resolve through Fingerprint.
 			ref.DiscoveryMTimeNS = meta.FileMtime
-			addJSONLSource(ref, &sources, seen)
+			return yield(ref)
+		})
+		if err != nil {
+			return err
 		}
 	}
-	sortJSONLSources(sources)
-	return sources, nil
+	return nil
 }
 
 func (s dbBackedSourceSet) WatchPlan(context.Context) (WatchPlan, error) {
@@ -235,18 +270,18 @@ func (s dbBackedSourceSet) SourcesForChangedPath(
 		if !ok {
 			continue
 		}
-		metas, err := s.spec.listMeta(dbPath)
-		if err != nil {
-			return nil, err
-		}
-		sources := make([]SourceRef, 0, len(metas))
-		seen := make(map[string]struct{}, len(metas))
-		for _, meta := range metas {
+		var sources []SourceRef
+		seen := make(map[string]struct{})
+		err := s.spec.streamMeta(ctx, dbPath, func(meta dbBackedSessionMeta) error {
 			addJSONLSource(
 				s.newSourceRef(root, dbPath, meta.SessionID, meta.VirtualPath),
 				&sources,
 				seen,
 			)
+			return nil
+		})
+		if err != nil {
+			return nil, err
 		}
 		for _, path := range req.StoredSourcePaths {
 			ref, ok := s.sourceRef(root, path, true)
@@ -263,6 +298,25 @@ func (s dbBackedSourceSet) SourcesForChangedPath(
 		return sources, nil
 	}
 	return nil, nil
+}
+
+func (s dbBackedSourceSet) StoredSourceHintScopes(
+	req ChangedPathRequest,
+) []StoredSourceHintScope {
+	for _, root := range s.roots {
+		if req.WatchRoot != "" && !samePath(req.WatchRoot, root) {
+			continue
+		}
+		if ref, ok := s.sourceRef(root, req.Path, true); ok {
+			return []StoredSourceHintScope{{Path: ref.DisplayPath}}
+		}
+		if dbPath, ok := s.dbPathForEvent(root, req.Path); ok {
+			return []StoredSourceHintScope{{
+				Path: dbPath, IncludeVirtualMembers: true,
+			}}
+		}
+	}
+	return nil
 }
 
 func (s dbBackedSourceSet) FindSource(
@@ -303,14 +357,12 @@ func (s dbBackedSourceSet) FindSource(
 		if dbPath == "" {
 			continue
 		}
-		metas, err := s.spec.listMeta(dbPath)
+		meta, found, err := s.spec.metaForID(ctx, dbPath, req.RawSessionID)
 		if err != nil {
 			return SourceRef{}, false, err
 		}
-		for _, meta := range metas {
-			if meta.SessionID == req.RawSessionID {
-				return s.newSourceRef(root, dbPath, meta.SessionID, meta.VirtualPath), true, nil
-			}
+		if found {
+			return s.newSourceRef(root, dbPath, meta.SessionID, meta.VirtualPath), true, nil
 		}
 	}
 	return SourceRef{}, false, nil
@@ -320,16 +372,11 @@ func (s dbBackedSourceSet) sourceExists(src dbBackedSource) (bool, error) {
 	if !IsRegularFile(src.DBPath) {
 		return false, nil
 	}
-	metas, err := s.spec.listMeta(src.DBPath)
+	_, found, err := s.spec.metaForID(context.Background(), src.DBPath, src.SessionID)
 	if err != nil {
 		return false, err
 	}
-	for _, meta := range metas {
-		if meta.SessionID == src.SessionID {
-			return true, nil
-		}
-	}
-	return false, nil
+	return found, nil
 }
 
 func (s dbBackedSourceSet) Fingerprint(
@@ -350,17 +397,15 @@ func (s dbBackedSourceSet) Fingerprint(
 		}
 		return SourceFingerprint{}, fmt.Errorf("stat %s: %w", src.DBPath, err)
 	}
-	metas, err := s.spec.listMeta(src.DBPath)
+	meta, found, err := s.spec.metaForID(ctx, src.DBPath, src.SessionID)
 	if err != nil {
 		return SourceFingerprint{}, err
 	}
-	for _, meta := range metas {
-		if meta.SessionID == src.SessionID {
-			return SourceFingerprint{
-				Key:     key,
-				MTimeNS: meta.FileMtime,
-			}, nil
-		}
+	if found {
+		return SourceFingerprint{
+			Key:     key,
+			MTimeNS: meta.FileMtime,
+		}, nil
 	}
 	return SourceFingerprint{Key: key}, nil
 }
@@ -462,13 +507,18 @@ func forgeProviderSpec() dbBackedProviderSpec {
 		agent:  AgentForge,
 		dbName: ForgeDBFilename,
 		findDB: forgeDBPath,
-		listMeta: func(dbPath string) ([]dbBackedSessionMeta, error) {
-			metas, err := ListForgeSessionMeta(dbPath)
-			out := make([]dbBackedSessionMeta, 0, len(metas))
-			for _, meta := range metas {
-				out = append(out, dbBackedSessionMeta(meta))
-			}
-			return out, err
+		streamMeta: func(
+			ctx context.Context, dbPath string, yield func(dbBackedSessionMeta) error,
+		) error {
+			return ForEachForgeSessionMeta(ctx, dbPath, func(meta ForgeSessionMeta) error {
+				return yield(dbBackedSessionMeta(meta))
+			})
+		},
+		metaForID: func(
+			ctx context.Context, dbPath, id string,
+		) (dbBackedSessionMeta, bool, error) {
+			meta, found, err := forgeSessionMeta(ctx, dbPath, id)
+			return dbBackedSessionMeta(meta), found, err
 		},
 		parse: func(dbPath, sessionID, machine string) ([]ParseResult, error) {
 			sess, msgs, err := parseForgeSession(dbPath, sessionID, machine)
@@ -493,13 +543,18 @@ func piebaldProviderSpec() dbBackedProviderSpec {
 		agent:  AgentPiebald,
 		dbName: PiebaldDBFilename,
 		findDB: piebaldDBPath,
-		listMeta: func(dbPath string) ([]dbBackedSessionMeta, error) {
-			metas, err := ListPiebaldSessionMeta(dbPath)
-			out := make([]dbBackedSessionMeta, 0, len(metas))
-			for _, meta := range metas {
-				out = append(out, dbBackedSessionMeta(meta))
-			}
-			return out, err
+		streamMeta: func(
+			ctx context.Context, dbPath string, yield func(dbBackedSessionMeta) error,
+		) error {
+			return ForEachPiebaldSessionMeta(ctx, dbPath, func(meta PiebaldSessionMeta) error {
+				return yield(dbBackedSessionMeta(meta))
+			})
+		},
+		metaForID: func(
+			ctx context.Context, dbPath, id string,
+		) (dbBackedSessionMeta, bool, error) {
+			meta, found, err := piebaldSessionMeta(ctx, dbPath, id)
+			return dbBackedSessionMeta(meta), found, err
 		},
 		parse: func(dbPath, sessionID, machine string) ([]ParseResult, error) {
 			return parsePiebaldSessionResults(dbPath, sessionID, machine)
@@ -524,13 +579,18 @@ func warpProviderSpec() dbBackedProviderSpec {
 		agent:  AgentWarp,
 		dbName: WarpDBFilename,
 		findDB: warpDBPath,
-		listMeta: func(dbPath string) ([]dbBackedSessionMeta, error) {
-			metas, err := ListWarpSessionMeta(dbPath)
-			out := make([]dbBackedSessionMeta, 0, len(metas))
-			for _, meta := range metas {
-				out = append(out, dbBackedSessionMeta(meta))
-			}
-			return out, err
+		streamMeta: func(
+			ctx context.Context, dbPath string, yield func(dbBackedSessionMeta) error,
+		) error {
+			return ForEachWarpSessionMeta(ctx, dbPath, func(meta WarpSessionMeta) error {
+				return yield(dbBackedSessionMeta(meta))
+			})
+		},
+		metaForID: func(
+			ctx context.Context, dbPath, id string,
+		) (dbBackedSessionMeta, bool, error) {
+			meta, found, err := warpSessionMeta(ctx, dbPath, id)
+			return dbBackedSessionMeta(meta), found, err
 		},
 		parse: func(dbPath, sessionID, machine string) ([]ParseResult, error) {
 			sess, msgs, err := parseWarpSession(dbPath, sessionID, machine)
@@ -545,9 +605,11 @@ func warpProviderSpec() dbBackedProviderSpec {
 
 func dbBackedSourceCapabilities(multiSession CapabilitySupport) SourceCapabilities {
 	source := jsonlFileProviderSourceCapabilities()
+	source.StreamingDiscovery = CapabilitySupported
 	source.StoredSourceHints = CapabilitySupported
 	source.MultiSessionSource = multiSession
 	source.ForceReplaceOnParse = CapabilitySupported
+	source.PersistentArchive = CapabilitySupported
 	return source
 }
 

--- a/internal/parser/devin.go
+++ b/internal/parser/devin.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -45,17 +46,28 @@ func devinDBPath(root string) string {
 // ListDevinSessionMeta returns lightweight metadata for all non-hidden Devin
 // sessions without parsing transcripts.
 func ListDevinSessionMeta(dbPath string) ([]DevinSessionMeta, error) {
+	var metas []DevinSessionMeta
+	err := ForEachDevinSessionMeta(context.Background(), dbPath, func(meta DevinSessionMeta) error {
+		metas = append(metas, meta)
+		return nil
+	})
+	return metas, err
+}
+
+func ForEachDevinSessionMeta(
+	ctx context.Context, dbPath string, yield func(DevinSessionMeta) error,
+) error {
 	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
-		return nil, nil
+		return nil
 	}
 
 	db, err := openDevinDB(dbPath)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer db.Close()
 
-	rows, err := db.Query(`
+	rows, err := db.QueryContext(ctx, `
 		SELECT id,
 		       COALESCE(title, ''),
 		       COALESCE(working_directory, ''),
@@ -68,11 +80,10 @@ func ListDevinSessionMeta(dbPath string) ([]DevinSessionMeta, error) {
 		 ORDER BY COALESCE(last_activity_at, created_at, 0) DESC, id DESC
 	`)
 	if err != nil {
-		return nil, fmt.Errorf("listing devin sessions: %w", err)
+		return fmt.Errorf("listing devin sessions: %w", err)
 	}
 	defer rows.Close()
 
-	var metas []DevinSessionMeta
 	for rows.Next() {
 		var meta DevinSessionMeta
 		var createdAtMS int64
@@ -87,7 +98,7 @@ func ListDevinSessionMeta(dbPath string) ([]DevinSessionMeta, error) {
 			&lastActivityMS,
 			&updatedAtMS,
 		); err != nil {
-			return nil, fmt.Errorf("scanning devin session meta: %w", err)
+			return fmt.Errorf("scanning devin session meta: %w", err)
 		}
 		meta.VirtualPath = VirtualSourcePath(dbPath, meta.RawSessionID)
 		meta.CreatedAt = devinUnixMilli(createdAtMS)
@@ -96,12 +107,15 @@ func ListDevinSessionMeta(dbPath string) ([]DevinSessionMeta, error) {
 		}
 		meta.UpdatedAt = devinUnixMilli(updatedAtMS)
 		meta.FileMtime = updatedAtMS * 1_000_000
-		metas = append(metas, meta)
+		observeStreamingDiscoveryBuffer(ctx, 1)
+		if err := yield(meta); err != nil {
+			return err
+		}
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterating devin sessions: %w", err)
+		return fmt.Errorf("iterating devin sessions: %w", err)
 	}
-	return metas, nil
+	return nil
 }
 
 func openDevinDB(dbPath string) (*sql.DB, error) {

--- a/internal/parser/devin_provider.go
+++ b/internal/parser/devin_provider.go
@@ -49,6 +49,10 @@ func (p *devinProvider) Discover(ctx context.Context) ([]SourceRef, error) {
 	return p.sources.Discover(ctx)
 }
 
+func (p *devinProvider) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	return p.sources.DiscoverEach(ctx, yield)
+}
+
 func (p *devinProvider) WatchPlan(ctx context.Context) (WatchPlan, error) {
 	return p.sources.WatchPlan(ctx)
 }
@@ -58,6 +62,12 @@ func (p *devinProvider) SourcesForChangedPath(
 	req ChangedPathRequest,
 ) ([]SourceRef, error) {
 	return p.sources.SourcesForChangedPath(ctx, req)
+}
+
+func (p *devinProvider) StoredSourceHintScopes(
+	req ChangedPathRequest,
+) []StoredSourceHintScope {
+	return p.sources.StoredSourceHintScopes(req)
 }
 
 func (p *devinProvider) FindSource(
@@ -168,6 +178,24 @@ func (s devinSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
 	return sources, nil
 }
 
+func (s devinSourceSet) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	for _, root := range s.roots {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		dbPath := devinDBPath(root)
+		if dbPath == "" {
+			continue
+		}
+		if err := ForEachDevinSessionMeta(ctx, dbPath, func(meta DevinSessionMeta) error {
+			return yield(s.newSourceRefWithMTime(root, dbPath, meta.RawSessionID, meta.FileMtime))
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (s devinSourceSet) WatchPlan(context.Context) (WatchPlan, error) {
 	roots := make([]WatchRoot, 0, len(s.roots)*2)
 	for _, root := range s.roots {
@@ -247,6 +275,33 @@ func (s devinSourceSet) SourcesForChangedPath(
 		}
 	}
 	return nil, nil
+}
+
+func (s devinSourceSet) StoredSourceHintScopes(
+	req ChangedPathRequest,
+) []StoredSourceHintScope {
+	for _, root := range s.roots {
+		if req.WatchRoot != "" &&
+			!samePath(req.WatchRoot, filepath.Join(root, "cli")) &&
+			!samePath(req.WatchRoot, filepath.Join(root, "cli", "transcripts")) {
+			continue
+		}
+		if ref, ok := s.sourceRef(root, req.Path, true); ok {
+			return []StoredSourceHintScope{{Path: ref.DisplayPath}}
+		}
+		if dbPath, ok := s.dbPathForEvent(root, req.Path); ok {
+			return []StoredSourceHintScope{{
+				Path: dbPath, IncludeVirtualMembers: true,
+			}}
+		}
+		if sessionID, ok := s.transcriptSessionIDForEvent(root, req.Path); ok {
+			dbPath := filepath.Join(root, "cli", devinDBFilename)
+			return []StoredSourceHintScope{{
+				Path: VirtualSourcePath(dbPath, sessionID),
+			}}
+		}
+	}
+	return nil
 }
 
 func (s devinSourceSet) FindSource(
@@ -573,8 +628,10 @@ func (s devinSource) virtualPath() string {
 }
 
 func devinProviderCapabilities() Capabilities {
+	source := dbBackedSourceCapabilities(CapabilityNotApplicable)
+	source.StreamingDiscovery = CapabilitySupported
 	return Capabilities{
-		Source: dbBackedSourceCapabilities(CapabilityNotApplicable),
+		Source: source,
 		Content: ContentCapabilities{
 			FirstMessage:         CapabilitySupported,
 			SessionName:          CapabilitySupported,

--- a/internal/parser/discovery.go
+++ b/internal/parser/discovery.go
@@ -290,7 +290,10 @@ func resolveOpenCodeFormatWatchRoots(
 	if info, err := os.Stat(root); err == nil && info.IsDir() {
 		return []string{root}
 	}
-	return nil
+	// Keep a deterministic logical root even before the provider is installed.
+	// Lifecycle-aware watcher backends can cover its creation from a bounded
+	// ancestor and avoid permanent archive-scale polling of absent defaults.
+	return []string{root}
 }
 
 func parseOpenCodeFormatVirtualPath(

--- a/internal/parser/discovery_disk_map.go
+++ b/internal/parser/discovery_disk_map.go
@@ -1,0 +1,430 @@
+package parser
+
+import (
+	"bufio"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+// discoveryDiskMap is a short-lived, disk-backed lookup used when discovery
+// metadata scales with archive cardinality. It avoids retaining project or
+// membership maps in the daemon heap while preserving O(1) lookups.
+type discoveryDiskMap struct {
+	path       string
+	db         *sql.DB
+	remove     func(string) error
+	queryError error
+}
+
+type discoveryDiskMapFaults struct {
+	queryError   error
+	cleanupError error
+}
+
+type discoveryDiskMapFaultsContextKey struct{}
+
+const discoveryDiskMapForEachQuery = `
+	SELECT key, value
+	FROM entries
+	ORDER BY key, ordinal
+`
+
+// WithDiscoveryDiskMapQueryError injects a disk-index query failure for
+// end-to-end reconciliation tests. Production callers never attach this value.
+func WithDiscoveryDiskMapQueryError(ctx context.Context, err error) context.Context {
+	faults, _ := ctx.Value(discoveryDiskMapFaultsContextKey{}).(discoveryDiskMapFaults)
+	faults.queryError = err
+	return context.WithValue(ctx, discoveryDiskMapFaultsContextKey{}, faults)
+}
+
+// WithDiscoveryDiskMapCleanupError injects temporary-index removal failure so
+// callers can prove cleanup errors keep reconciliation incomplete.
+func WithDiscoveryDiskMapCleanupError(ctx context.Context, err error) context.Context {
+	faults, _ := ctx.Value(discoveryDiskMapFaultsContextKey{}).(discoveryDiskMapFaults)
+	faults.cleanupError = err
+	return context.WithValue(ctx, discoveryDiskMapFaultsContextKey{}, faults)
+}
+
+func newDiscoveryDiskMapForContext(ctx context.Context) (*discoveryDiskMap, error) {
+	index, err := newDiscoveryDiskMap()
+	if err != nil {
+		return nil, err
+	}
+	faults, _ := ctx.Value(discoveryDiskMapFaultsContextKey{}).(discoveryDiskMapFaults)
+	index.queryError = faults.queryError
+	if faults.cleanupError != nil {
+		remove := index.remove
+		index.remove = func(path string) error {
+			if path == index.path {
+				return faults.cleanupError
+			}
+			return remove(path)
+		}
+	}
+	return index, nil
+}
+
+func newDiscoveryDiskMap() (*discoveryDiskMap, error) {
+	file, err := os.CreateTemp("", "agentsview-discovery-map-*.db")
+	if err != nil {
+		return nil, err
+	}
+	path := file.Name()
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
+		return nil, err
+	}
+	database, err := sql.Open("sqlite3", "file:"+sqliteURIPath(path)+"?_journal_mode=OFF&_synchronous=OFF")
+	if err != nil {
+		_ = os.Remove(path)
+		return nil, err
+	}
+	database.SetMaxOpenConns(1)
+	if _, err := database.Exec(`
+		CREATE TABLE entries (
+			key TEXT NOT NULL,
+			ordinal INTEGER NOT NULL,
+			value TEXT NOT NULL,
+			PRIMARY KEY (key, ordinal)
+		) WITHOUT ROWID;
+		CREATE TRIGGER entries_replace_tail
+		AFTER INSERT ON entries
+		WHEN NEW.ordinal = 0
+		BEGIN
+			DELETE FROM entries
+			WHERE key = NEW.key AND ordinal <> 0;
+		END;
+	`); err != nil {
+		_ = database.Close()
+		_ = os.Remove(path)
+		return nil, err
+	}
+	return &discoveryDiskMap{path: path, db: database, remove: os.Remove}, nil
+}
+
+func (m *discoveryDiskMap) loadJSONL(
+	ctx context.Context, path, keyField, valueField string,
+) error {
+	file, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	tx, err := m.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT OR REPLACE INTO entries (key, ordinal, value)
+		VALUES (?, 0, ?)
+	`)
+	if err != nil {
+		return err
+	}
+	defer stmt.Close()
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		line := scanner.Bytes()
+		key := gjson.GetBytes(line, keyField).String()
+		value := gjson.GetBytes(line, valueField).String()
+		if key == "" || value == "" {
+			continue
+		}
+		if _, err := stmt.ExecContext(ctx, key, value); err != nil {
+			return err
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("scan discovery metadata: %w", err)
+	}
+	return tx.Commit()
+}
+
+func (m *discoveryDiskMap) get(
+	ctx context.Context, key string,
+) (string, bool, error) {
+	if m.queryError != nil {
+		return "", false, m.queryError
+	}
+	rows, err := m.db.QueryContext(ctx, `
+		SELECT value
+		FROM entries
+		WHERE key = ?
+		ORDER BY ordinal
+	`, key)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return "", false, ctxErr
+		}
+		return "", false, fmt.Errorf("read discovery index key: %w", err)
+	}
+	defer rows.Close()
+	var value strings.Builder
+	found := false
+	for rows.Next() {
+		var part string
+		if err := rows.Scan(&part); err != nil {
+			return "", false, err
+		}
+		if found {
+			value.WriteByte('\n')
+		}
+		value.WriteString(part)
+		found = true
+	}
+	if err := rows.Err(); err != nil {
+		return "", false, err
+	}
+	return value.String(), found, nil
+}
+
+func (m *discoveryDiskMap) put(ctx context.Context, key, value string, replace bool) error {
+	if replace {
+		_, err := m.db.ExecContext(
+			ctx,
+			`INSERT OR REPLACE INTO entries (key, ordinal, value)
+			 VALUES (?, 0, ?)`,
+			key,
+			value,
+		)
+		return err
+	}
+	_, err := m.db.ExecContext(ctx, `
+		INSERT OR IGNORE INTO entries (key, ordinal, value)
+		VALUES (?, 0, ?)
+	`, key, value)
+	return err
+}
+
+func (m *discoveryDiskMap) putIfAbsent(
+	ctx context.Context, key, value string,
+) (bool, error) {
+	result, err := m.db.ExecContext(
+		ctx, `
+			INSERT OR IGNORE INTO entries (key, ordinal, value)
+			VALUES (?, 0, ?)
+		`, key, value,
+	)
+	if err != nil {
+		return false, err
+	}
+	rows, err := result.RowsAffected()
+	return rows > 0, err
+}
+
+func (m *discoveryDiskMap) append(ctx context.Context, key, value string) error {
+	_, err := m.db.ExecContext(ctx, `
+		INSERT INTO entries (key, ordinal, value)
+		VALUES (
+			?,
+			COALESCE((
+				SELECT ordinal + 1
+				FROM entries
+				WHERE key = ?
+				ORDER BY ordinal DESC
+				LIMIT 1
+			), 0),
+			?
+		)
+	`, key, key, value)
+	return err
+}
+
+func (m *discoveryDiskMap) forEach(
+	ctx context.Context, yield func(key, value string) error,
+) error {
+	if m.queryError != nil {
+		return m.queryError
+	}
+	rows, err := m.db.QueryContext(ctx, discoveryDiskMapForEachQuery)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	var currentKey string
+	var value strings.Builder
+	haveKey := false
+	havePart := false
+	yieldCurrent := func() error {
+		observeStreamingDiscoveryBuffer(ctx, 1)
+		return yield(currentKey, value.String())
+	}
+	for rows.Next() {
+		var key, part string
+		if err := rows.Scan(&key, &part); err != nil {
+			return err
+		}
+		if haveKey && key != currentKey {
+			if err := yieldCurrent(); err != nil {
+				return err
+			}
+			value.Reset()
+			havePart = false
+		}
+		if !haveKey || key != currentKey {
+			currentKey = key
+			haveKey = true
+		}
+		if havePart {
+			value.WriteByte('\n')
+		}
+		value.WriteString(part)
+		havePart = true
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	if !haveKey {
+		return nil
+	}
+	return yieldCurrent()
+}
+
+func (m *discoveryDiskMap) addGeminiPath(
+	ctx context.Context, absolutePath, name string, replace bool,
+) error {
+	project := ExtractProjectFromCwd(absolutePath)
+	if project == "" {
+		project = "unknown"
+	}
+	if err := m.put(ctx, geminiPathHash(absolutePath), project, replace); err != nil {
+		return err
+	}
+	if name != "" {
+		return m.put(ctx, name, project, replace)
+	}
+	return nil
+}
+
+func (m *discoveryDiskMap) loadGeminiConfig(ctx context.Context, root string) error {
+	// Trusted folders establish fallbacks; named projects overwrite them,
+	// matching BuildGeminiProjectMap's projects-first precedence.
+	if err := m.decodeGeminiTrustedFolders(ctx, filepath.Join(root, "trustedFolders.json")); err != nil {
+		return err
+	}
+	return m.decodeGeminiProjects(ctx, filepath.Join(root, "projects.json"))
+}
+
+func (m *discoveryDiskMap) decodeGeminiProjects(ctx context.Context, path string) error {
+	return decodeJSONObjectField(path, "projects", func(dec *json.Decoder) error {
+		for dec.More() {
+			key, err := dec.Token()
+			if err != nil {
+				return err
+			}
+			var name string
+			if err := dec.Decode(&name); err != nil {
+				return err
+			}
+			if err := m.addGeminiPath(ctx, key.(string), name, true); err != nil {
+				return err
+			}
+		}
+		_, err := dec.Token()
+		return err
+	})
+}
+
+func (m *discoveryDiskMap) decodeGeminiTrustedFolders(ctx context.Context, path string) error {
+	return decodeJSONArrayField(path, "trustedFolders", func(dec *json.Decoder) error {
+		for dec.More() {
+			var folder string
+			if err := dec.Decode(&folder); err != nil {
+				return err
+			}
+			if err := m.addGeminiPath(ctx, folder, "", false); err != nil {
+				return err
+			}
+		}
+		_, err := dec.Token()
+		return err
+	})
+}
+
+func decodeJSONObjectField(
+	path, field string, consume func(*json.Decoder) error,
+) error {
+	return decodeJSONField(path, field, json.Delim('{'), consume)
+}
+
+func decodeJSONArrayField(
+	path, field string, consume func(*json.Decoder) error,
+) error {
+	return decodeJSONField(path, field, json.Delim('['), consume)
+}
+
+func decodeJSONField(
+	path, field string, want json.Delim, consume func(*json.Decoder) error,
+) error {
+	file, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	dec := json.NewDecoder(file)
+	if _, err := dec.Token(); err != nil {
+		return err
+	}
+	for dec.More() {
+		name, err := dec.Token()
+		if err != nil {
+			return err
+		}
+		if name != field {
+			var discard json.RawMessage
+			if err := dec.Decode(&discard); err != nil {
+				return err
+			}
+			continue
+		}
+		delim, err := dec.Token()
+		if err != nil {
+			return err
+		}
+		if delim != want {
+			return fmt.Errorf("%s: unexpected %s shape", path, field)
+		}
+		return consume(dec)
+	}
+	return nil
+}
+
+func (m *discoveryDiskMap) close() error {
+	if m == nil {
+		return nil
+	}
+	var cleanupErr error
+	if err := m.db.Close(); err != nil {
+		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("close discovery index: %w", err))
+	}
+	remove := m.remove
+	if remove == nil {
+		remove = os.Remove
+	}
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		if err := remove(m.path + suffix); err != nil && !errors.Is(err, os.ErrNotExist) {
+			cleanupErr = errors.Join(cleanupErr,
+				fmt.Errorf("remove discovery index%s: %w", suffix, err))
+		}
+	}
+	return cleanupErr
+}

--- a/internal/parser/discovery_disk_map_test.go
+++ b/internal/parser/discovery_disk_map_test.go
@@ -1,0 +1,216 @@
+package parser
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscoveryDiskMapGetDistinguishesAbsenceAndFailure(t *testing.T) {
+	index, err := newDiscoveryDiskMap()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = os.Remove(index.path)
+		_ = os.Remove(index.path + "-wal")
+		_ = os.Remove(index.path + "-shm")
+	})
+
+	value, found, err := index.get(t.Context(), "missing")
+	require.NoError(t, err)
+	assert.False(t, found)
+	assert.Empty(t, value)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, _, err = index.get(ctx, "missing")
+	assert.ErrorIs(t, err, context.Canceled)
+
+	require.NoError(t, index.db.Close())
+	_, _, err = index.get(t.Context(), "missing")
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, context.Canceled)
+}
+
+func TestDiscoveryDiskMapCloseReportsCleanupFailure(t *testing.T) {
+	index, err := newDiscoveryDiskMap()
+	require.NoError(t, err)
+	injected := errors.New("remove discovery index failed")
+	index.remove = func(path string) error {
+		if path == index.path {
+			return injected
+		}
+		return os.Remove(path)
+	}
+	t.Cleanup(func() { _ = os.Remove(index.path) })
+
+	err = index.close()
+
+	assert.ErrorIs(t, err, injected)
+}
+
+func TestDiscoveryDiskMapAppendDoesNotRewriteAccumulatedValue(t *testing.T) {
+	index, err := newDiscoveryDiskMap()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, index.close()) })
+	_, err = index.db.Exec(`
+		CREATE TABLE IF NOT EXISTS appended_entries (
+			ordinal INTEGER PRIMARY KEY,
+			key TEXT NOT NULL,
+			value TEXT NOT NULL
+		);
+		CREATE TABLE append_write_cost (bytes INTEGER NOT NULL);
+		CREATE TRIGGER measure_append_insert
+		AFTER INSERT ON entries WHEN NEW.key = 'spans'
+		BEGIN
+			INSERT INTO append_write_cost VALUES (length(NEW.value));
+		END;
+		CREATE TRIGGER measure_append_update
+		AFTER UPDATE OF value ON entries WHEN NEW.key = 'spans'
+		BEGIN
+			INSERT INTO append_write_cost VALUES (length(NEW.value));
+		END;
+		CREATE TRIGGER measure_child_append_insert
+		AFTER INSERT ON appended_entries WHEN NEW.key = 'spans'
+		BEGIN
+			INSERT INTO append_write_cost VALUES (length(NEW.value));
+		END;
+	`)
+	require.NoError(t, err)
+
+	const spanCount = 64
+	values := make([]string, 0, spanCount)
+	var inputBytes int64
+	for i := range spanCount {
+		value := fmt.Sprintf("%03d:%s", i, strings.Repeat("x", 256))
+		values = append(values, value)
+		inputBytes += int64(len(value))
+		require.NoError(t, index.append(t.Context(), "spans", value))
+	}
+
+	got, found, err := index.get(t.Context(), "spans")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, values, strings.Split(got, "\n"),
+		"append retrieval must preserve insertion order")
+	var writtenValueBytes int64
+	require.NoError(t, index.db.QueryRow(
+		"SELECT COALESCE(SUM(bytes), 0) FROM append_write_cost",
+	).Scan(&writtenValueBytes))
+	assert.LessOrEqual(t, writtenValueBytes, inputBytes+spanCount-1,
+		"append work must stay linear in newly supplied value bytes")
+	assert.GreaterOrEqual(t, writtenValueBytes, inputBytes,
+		"the measurement must account for every appended value")
+}
+
+func TestDiscoveryDiskMapPutAndAppendPreserveMapSemantics(t *testing.T) {
+	newIndex := func(t *testing.T) *discoveryDiskMap {
+		t.Helper()
+		index, err := newDiscoveryDiskMap()
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, index.close()) })
+		return index
+	}
+
+	t.Run("put ignore keeps appended value", func(t *testing.T) {
+		index := newIndex(t)
+		require.NoError(t, index.append(t.Context(), "key", "first"))
+		require.NoError(t, index.append(t.Context(), "key", "second"))
+		require.NoError(t, index.put(t.Context(), "key", "replacement", false))
+
+		value, found, err := index.get(t.Context(), "key")
+		require.NoError(t, err)
+		require.True(t, found)
+		assert.Equal(t, "first\nsecond", value)
+	})
+
+	t.Run("put replace discards appended value", func(t *testing.T) {
+		index := newIndex(t)
+		require.NoError(t, index.append(t.Context(), "key", "first"))
+		require.NoError(t, index.append(t.Context(), "key", "second"))
+		require.NoError(t, index.put(t.Context(), "key", "replacement", true))
+
+		value, found, err := index.get(t.Context(), "key")
+		require.NoError(t, err)
+		require.True(t, found)
+		assert.Equal(t, "replacement", value)
+	})
+
+	t.Run("append extends put value", func(t *testing.T) {
+		index := newIndex(t)
+		require.NoError(t, index.put(t.Context(), "key", "first", true))
+		require.NoError(t, index.append(t.Context(), "key", "second"))
+
+		value, found, err := index.get(t.Context(), "key")
+		require.NoError(t, err)
+		require.True(t, found)
+		assert.Equal(t, "first\nsecond", value)
+	})
+
+	t.Run("put if absent sees appended value", func(t *testing.T) {
+		index := newIndex(t)
+		require.NoError(t, index.append(t.Context(), "key", "first"))
+		require.NoError(t, index.append(t.Context(), "key", "second"))
+		inserted, err := index.putIfAbsent(t.Context(), "key", "replacement")
+		require.NoError(t, err)
+		assert.False(t, inserted)
+
+		value, found, err := index.get(t.Context(), "key")
+		require.NoError(t, err)
+		require.True(t, found)
+		assert.Equal(t, "first\nsecond", value)
+	})
+}
+
+func TestDiscoveryDiskMapForEachIncludesAppendedValuesInKeyOrder(t *testing.T) {
+	index, err := newDiscoveryDiskMap()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, index.close()) })
+	require.NoError(t, index.append(t.Context(), "beta", "first"))
+	require.NoError(t, index.put(t.Context(), "alpha", "only", true))
+	require.NoError(t, index.append(t.Context(), "beta", "second"))
+
+	var got []string
+	require.NoError(t, index.forEach(t.Context(), func(key, value string) error {
+		got = append(got, key+"="+value)
+		return nil
+	}))
+
+	assert.Equal(t, []string{"alpha=only", "beta=first\nsecond"}, got)
+}
+
+func TestDiscoveryDiskMapForEachUsesStoredIndexOrder(t *testing.T) {
+	index, err := newDiscoveryDiskMap()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, index.close()) })
+	for i := range 256 {
+		key := fmt.Sprintf("key-%03d", i)
+		require.NoError(t, index.put(t.Context(), key, "base", true))
+		require.NoError(t, index.append(t.Context(), key, "appended"))
+	}
+	_, err = index.db.Exec("ANALYZE")
+	require.NoError(t, err)
+
+	rows, err := index.db.Query(
+		"EXPLAIN QUERY PLAN " + discoveryDiskMapForEachQuery,
+	)
+	require.NoError(t, err)
+	defer rows.Close()
+	var details []string
+	for rows.Next() {
+		var id, parent, unused int
+		var detail string
+		require.NoError(t, rows.Scan(&id, &parent, &unused, &detail))
+		details = append(details, detail)
+	}
+	require.NoError(t, rows.Err())
+	require.NotEmpty(t, details)
+	assert.NotContains(t, strings.ToUpper(strings.Join(details, "\n")),
+		"USE TEMP B-TREE",
+		"archive-wide iteration must stream in stored index order")
+}

--- a/internal/parser/forge.go
+++ b/internal/parser/forge.go
@@ -1,8 +1,10 @@
 package parser
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -40,41 +42,83 @@ func forgeDBPath(dir string) string {
 // conversations without parsing message bodies. Used by the sync
 // engine to detect which sessions have changed.
 func ListForgeSessionMeta(dbPath string) ([]ForgeSessionMeta, error) {
+	var metas []ForgeSessionMeta
+	err := ForEachForgeSessionMeta(
+		context.Background(), dbPath,
+		func(meta ForgeSessionMeta) error {
+			metas = append(metas, meta)
+			return nil
+		},
+	)
+	return metas, err
+}
+
+func ForEachForgeSessionMeta(
+	ctx context.Context, dbPath string, yield func(ForgeSessionMeta) error,
+) error {
 	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
-		return nil, nil
+		return nil
 	}
 
 	db, err := openForgeDB(dbPath)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer db.Close()
 
-	rows, err := db.Query(`
+	rows, err := db.QueryContext(ctx, `
 		SELECT conversation_id,
 		       COALESCE(updated_at, created_at)
 		FROM conversations
 		WHERE context IS NOT NULL
 	`)
 	if err != nil {
-		return nil, fmt.Errorf("listing forge conversations: %w", err)
+		return fmt.Errorf("listing forge conversations: %w", err)
 	}
 	defer rows.Close()
 
-	var metas []ForgeSessionMeta
 	for rows.Next() {
 		var id string
 		var updatedAt string
 		if err := rows.Scan(&id, &updatedAt); err != nil {
-			return nil, fmt.Errorf("scanning forge session meta: %w", err)
+			return fmt.Errorf("scanning forge session meta: %w", err)
 		}
-		metas = append(metas, ForgeSessionMeta{
+		observeStreamingDiscoveryBuffer(ctx, 1)
+		if err := yield(ForgeSessionMeta{
 			SessionID:   id,
-			VirtualPath: dbPath + "#" + id,
+			VirtualPath: VirtualSourcePath(dbPath, id),
 			FileMtime:   parseForgeTimestamp(updatedAt).UnixNano(),
-		})
+		}); err != nil {
+			return err
+		}
 	}
-	return metas, rows.Err()
+	return rows.Err()
+}
+
+func forgeSessionMeta(
+	ctx context.Context, dbPath, sessionID string,
+) (ForgeSessionMeta, bool, error) {
+	db, err := openForgeDB(dbPath)
+	if err != nil {
+		return ForgeSessionMeta{}, false, err
+	}
+	defer db.Close()
+	var updatedAt string
+	err = db.QueryRowContext(ctx, `
+		SELECT COALESCE(updated_at, created_at)
+		FROM conversations
+		WHERE conversation_id = ? AND context IS NOT NULL
+	`, sessionID).Scan(&updatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ForgeSessionMeta{}, false, nil
+	}
+	if err != nil {
+		return ForgeSessionMeta{}, false, err
+	}
+	return ForgeSessionMeta{
+		SessionID: sessionID, VirtualPath: VirtualSourcePath(dbPath, sessionID),
+		FileMtime: parseForgeTimestamp(updatedAt).UnixNano(),
+	}, true, nil
 }
 
 // parseForgeSession parses a single conversation by ID from the Forge database.
@@ -265,7 +309,10 @@ func buildForgeSession(c forgeConversationRow, dbPath, machine string) (*ParsedS
 		endedAt = startedAt
 	}
 
-	fileInfo := FileInfo{Path: dbPath + "#" + c.id, Mtime: endedAt.UnixNano()}
+	fileInfo := FileInfo{
+		Path:  VirtualSourcePath(dbPath, c.id),
+		Mtime: endedAt.UnixNano(),
+	}
 	if info, err := os.Stat(dbPath); err == nil {
 		fileInfo.Size = info.Size()
 		if fileInfo.Mtime == 0 {

--- a/internal/parser/gemini_copilot_provider_test.go
+++ b/internal/parser/gemini_copilot_provider_test.go
@@ -2,8 +2,10 @@ package parser
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -137,6 +139,153 @@ func TestGeminiProviderProjectMetadataChangesClassifyAndFingerprint(t *testing.T
 	fingerprintTwo, err := provider.Fingerprint(context.Background(), changed[0])
 	require.NoError(t, err)
 	assert.NotEqual(t, fingerprintOne.Hash, fingerprintTwo.Hash)
+
+	source := changed[0]
+
+	// Adding an entry that does not change this session's resolution
+	// must NOT change its fingerprint. Cover both metadata files:
+	// an unrelated projects.json alias, and an unrelated
+	// trustedFolders.json path.
+	writeUnrelatedProjectsEntry(t, root)
+	fingerprintThree := fingerprintSource(t, provider, source)
+	assert.Equal(t, fingerprintTwo.Hash, fingerprintThree.Hash,
+		"unrelated projects.json entries must not invalidate the session")
+	writeUnrelatedTrustedFolder(t, root)
+	fingerprintFour := fingerprintSource(t, provider, source)
+	assert.Equal(t, fingerprintTwo.Hash, fingerprintFour.Hash,
+		"unrelated trustedFolders.json entries must not invalidate the session")
+
+	// A trustedFolders.json entry that DOES change this session's resolved
+	// project (an old-layout hash directory that only trustedFolders.json,
+	// not projects.json, ever resolves) must invalidate the fingerprint.
+	hashSessionID := "gemini-hash-project"
+	hashProjectPath := "/Users/erin/code/hash-project"
+	hashDirName := geminiPathHash(hashProjectPath)
+	hashSourcePath := filepath.Join(
+		root,
+		"tmp",
+		hashDirName,
+		geminiChatsDir,
+		"session-2026-06-19T12-00-gemini-hash-project.json",
+	)
+	writeSourceFile(t, hashSourcePath, testjsonl.GeminiSessionJSON(
+		hashSessionID,
+		"hash-project",
+		tsEarly,
+		tsEarlyS5,
+		[]map[string]any{
+			testjsonl.GeminiUserMsg("u1", tsEarly, "hello gemini"),
+			testjsonl.GeminiAssistantMsg("a1", tsEarlyS5, "hi", nil),
+		},
+	))
+
+	hashFoundBefore, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
+		FullSessionID: "host~gemini:" + hashSessionID,
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "unknown", hashFoundBefore.ProjectHint)
+	fingerprintHashBefore := fingerprintSource(t, provider, hashFoundBefore)
+
+	writeSourceFile(t, filepath.Join(root, "trustedFolders.json"),
+		fmt.Sprintf(`{"trustedFolders":["%s"]}`, hashProjectPath))
+
+	hashFoundAfter, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
+		FullSessionID: "host~gemini:" + hashSessionID,
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "hash_project", hashFoundAfter.ProjectHint)
+	fingerprintHashAfter := fingerprintSource(t, provider, hashFoundAfter)
+	assert.NotEqual(t, fingerprintHashBefore.Hash, fingerprintHashAfter.Hash,
+		"a trustedFolders.json entry that changes this session's resolution must invalidate it")
+}
+
+// writeUnrelatedProjectsEntry rewrites projects.json to keep the existing
+// "alias" -> two resolution while adding an entry under a different alias
+// name. It must not affect any session resolved via the "alias" directory.
+func writeUnrelatedProjectsEntry(t *testing.T, root string) {
+	t.Helper()
+
+	writeSourceFile(t, filepath.Join(root, "projects.json"),
+		`{"projects":{"/Users/alice/code/two":"alias","/Users/carol/code/three":"other-alias"}}`)
+}
+
+// writeUnrelatedTrustedFolder writes trustedFolders.json with a path whose
+// hash does not match any session directory used in this test, so it must
+// not affect existing resolutions.
+func writeUnrelatedTrustedFolder(t *testing.T, root string) {
+	t.Helper()
+
+	writeSourceFile(t, filepath.Join(root, "trustedFolders.json"),
+		`{"trustedFolders":["/Users/dave/code/unrelated"]}`)
+}
+
+// fingerprintSource fingerprints source via provider, failing the test on error.
+func fingerprintSource(t *testing.T, provider Provider, source SourceRef) SourceFingerprint {
+	t.Helper()
+
+	fingerprint, err := provider.Fingerprint(context.Background(), source)
+	require.NoError(t, err)
+	return fingerprint
+}
+
+// TestGeminiProviderFingerprintMatchesReconstructedSource verifies that
+// Fingerprint produces the same hash whether it is called with the
+// discovery-built SourceRef (ProjectHint already populated) or with a bare
+// SourceRef reconstructed from just a path (as happens when a caller looks
+// up a source by stored file path without going through discovery). Both
+// must resolve the same on-disk project so a metadata-scoped fingerprint
+// cannot drift between the two callers.
+func TestGeminiProviderFingerprintMatchesReconstructedSource(t *testing.T) {
+	root := t.TempDir()
+	sessionID := "gemini-reconstructed"
+	writeSourceFile(t, filepath.Join(root, "projects.json"),
+		`{"projects":{"/Users/alice/code/reconstructed":"alias"}}`)
+	sourcePath := filepath.Join(
+		root,
+		"tmp",
+		"alias",
+		geminiChatsDir,
+		"session-2026-06-19T12-00-gemini-reconstructed.json",
+	)
+	writeSourceFile(t, sourcePath, testjsonl.GeminiSessionJSON(
+		sessionID,
+		"alias",
+		tsEarly,
+		tsEarlyS5,
+		[]map[string]any{
+			testjsonl.GeminiUserMsg("u1", tsEarly, "hello gemini"),
+			testjsonl.GeminiAssistantMsg("a1", tsEarlyS5, "hi", nil),
+		},
+	))
+
+	provider, ok := NewProvider(AgentGemini, ProviderConfig{
+		Roots:   []string{root},
+		Machine: "devbox",
+	})
+	require.True(t, ok)
+
+	discovered, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
+		FullSessionID: "host~gemini:" + sessionID,
+	})
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "reconstructed", discovered.ProjectHint)
+	discoveredFingerprint := fingerprintSource(t, provider, discovered)
+
+	// A bare SourceRef with no Opaque and no ProjectHint, as a caller would
+	// build from only a stored file path.
+	reconstructed := SourceRef{
+		Provider:       AgentGemini,
+		Key:            sourcePath,
+		DisplayPath:    sourcePath,
+		FingerprintKey: sourcePath,
+	}
+	reconstructedFingerprint := fingerprintSource(t, provider, reconstructed)
+
+	assert.Equal(t, discoveredFingerprint.Hash, reconstructedFingerprint.Hash,
+		"discovery-built and reconstructed sources must resolve the same project")
 }
 
 func TestGeminiProviderParse(t *testing.T) {
@@ -194,6 +343,96 @@ func TestGeminiProviderParse(t *testing.T) {
 	assert.Equal(t, "devbox", result.Result.Session.Machine)
 	assert.Equal(t, fingerprint.Hash, result.Result.Session.File.Hash)
 	assert.Len(t, result.Result.Messages, 2)
+}
+
+// A followed project-directory symlink whose target cannot be resolved must
+// surface incomplete streaming discovery rather than reading as absent:
+// reconciliation treats a clean DiscoverEach as authoritative and would
+// tombstone every session beneath the symlink.
+func TestGeminiProviderStreamingDiscoveryPropagatesProjectSymlinkErrors(t *testing.T) {
+	writeGeminiSession := func(t *testing.T, root, dir, id string) {
+		t.Helper()
+		path := filepath.Join(
+			root, "tmp", dir, geminiChatsDir,
+			"session-2026-06-19T12-00-"+id+".json",
+		)
+		writeSourceFile(t, path, testjsonl.GeminiSessionJSON(
+			id, dir, tsEarly, tsEarlyS5,
+			[]map[string]any{
+				testjsonl.GeminiUserMsg("u1", tsEarly, "hello gemini"),
+			},
+		))
+	}
+	discoverEach := func(t *testing.T, root string) ([]string, error) {
+		t.Helper()
+		provider, ok := NewProvider(AgentGemini, ProviderConfig{
+			Roots: []string{root},
+		})
+		require.True(t, ok)
+		discoverer, ok := provider.(StreamingDiscoverer)
+		require.True(t, ok)
+		var yielded []string
+		err := discoverer.DiscoverEach(t.Context(), func(source SourceRef) error {
+			yielded = append(yielded, source.DisplayPath)
+			return nil
+		})
+		return yielded, err
+	}
+
+	t.Run("dangling project symlink", func(t *testing.T) {
+		root := t.TempDir()
+		writeGeminiSession(t, root, "healthy-project", "healthy")
+		target := filepath.Join(t.TempDir(), "linked-project")
+		require.NoError(t, os.MkdirAll(target, 0o755))
+		link := filepath.Join(root, "tmp", "linked")
+		if err := os.Symlink(target, link); err != nil {
+			t.Skipf("symlink not supported: %v", err)
+		}
+		require.NoError(t, os.RemoveAll(target))
+
+		_, err := discoverEach(t, root)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, os.ErrNotExist)
+		var incomplete DiscoveryIncompleteError
+		assert.ErrorAs(t, err, &incomplete)
+
+		require.NoError(t, os.Remove(link))
+		yielded, err := discoverEach(t, root)
+		require.NoError(t, err)
+		assert.Len(t, yielded, 1)
+	})
+
+	t.Run("unstatable project symlink target", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("directory read permissions are not enforced on Windows")
+		}
+		if os.Geteuid() == 0 {
+			t.Skip("root bypasses directory permissions")
+		}
+		root := t.TempDir()
+		writeGeminiSession(t, root, "healthy-project", "healthy")
+		targetParent := t.TempDir()
+		target := filepath.Join(targetParent, "linked-project")
+		require.NoError(t, os.MkdirAll(target, 0o755))
+		if err := os.Symlink(target, filepath.Join(root, "tmp", "linked")); err != nil {
+			t.Skipf("symlink not supported: %v", err)
+		}
+		require.NoError(t, os.Chmod(targetParent, 0o000))
+		t.Cleanup(func() { _ = os.Chmod(targetParent, 0o755) })
+
+		_, err := discoverEach(t, root)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, os.ErrPermission)
+		var incomplete DiscoveryIncompleteError
+		assert.ErrorAs(t, err, &incomplete)
+
+		require.NoError(t, os.Chmod(targetParent, 0o755))
+		yielded, err := discoverEach(t, root)
+		require.NoError(t, err)
+		assert.Len(t, yielded, 1)
+	})
 }
 
 func TestCopilotProviderSourceMethods(t *testing.T) {

--- a/internal/parser/gemini_provider.go
+++ b/internal/parser/gemini_provider.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"hash"
 	"io"
@@ -48,6 +49,10 @@ type geminiProvider struct {
 
 func (p *geminiProvider) Discover(ctx context.Context) ([]SourceRef, error) {
 	return p.sources.Discover(ctx)
+}
+
+func (p *geminiProvider) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	return p.sources.DiscoverEach(ctx, yield)
 }
 
 func (p *geminiProvider) WatchPlan(ctx context.Context) (WatchPlan, error) {
@@ -140,6 +145,63 @@ func (s geminiSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
 	}
 	sortJSONLSources(sources)
 	return sources, nil
+}
+
+func (s geminiSourceSet) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	for _, root := range s.roots {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		projects, err := newDiscoveryDiskMapForContext(ctx)
+		if err != nil {
+			return err
+		}
+		if err := projects.loadGeminiConfig(ctx, root); err != nil {
+			return errors.Join(err, projects.close())
+		}
+		tmpDir := filepath.Join(root, "tmp")
+		err = streamDirectoryEntries(ctx, tmpDir, func(projectDir os.DirEntry) error {
+			isProjectDir, dirErr := streamingDirCandidateOrIncomplete(
+				AgentGemini, "Gemini project directory", projectDir, tmpDir,
+			)
+			if dirErr != nil {
+				return dirErr
+			}
+			if !isProjectDir {
+				return nil
+			}
+			project, _, err := projects.get(ctx, projectDir.Name())
+			if err != nil {
+				return err
+			}
+			if project == "" {
+				if isHexHash(projectDir.Name()) {
+					project = "unknown"
+				} else {
+					project = NormalizeName(projectDir.Name())
+				}
+			}
+			chatDir := filepath.Join(tmpDir, projectDir.Name(), geminiChatsDir)
+			return streamDirectoryEntries(ctx, chatDir, func(entry os.DirEntry) error {
+				if entry.IsDir() || !isGeminiSessionFilename(entry.Name()) {
+					return nil
+				}
+				path := filepath.Join(chatDir, entry.Name())
+				source, ok := s.sourceRefForPathWithProjectMap(
+					root, path, true, map[string]string{projectDir.Name(): project},
+				)
+				if ok {
+					return yield(source)
+				}
+				return nil
+			})
+		})
+		err = errors.Join(err, projects.close())
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (s geminiSourceSet) discoverRoot(
@@ -366,21 +428,45 @@ func (s geminiSourceSet) Fingerprint(
 	if err := addGeminiFingerprintPart(h, "session", path, info); err != nil {
 		return SourceFingerprint{}, err
 	}
-	for _, metadataPath := range geminiProjectMetadataPaths(root) {
-		metadataInfo, err := os.Stat(metadataPath)
-		if err != nil || metadataInfo.IsDir() {
-			continue
-		}
-		fingerprint.Size += metadataInfo.Size()
-		if mtime := metadataInfo.ModTime().UnixNano(); mtime > fingerprint.MTimeNS {
-			fingerprint.MTimeNS = mtime
-		}
-		if err := addGeminiFingerprintPart(h, "project", metadataPath, metadataInfo); err != nil {
-			return SourceFingerprint{}, err
-		}
+	if _, err := fmt.Fprintf(
+		h, "project\x00%s\x00",
+		s.resolvedProjectForFingerprint(root, path, source),
+	); err != nil {
+		return SourceFingerprint{}, err
 	}
 	fingerprint.Hash = fmt.Sprintf("%x", h.Sum(nil))
 	return fingerprint, nil
+}
+
+// geminiSessionDirHash extracts the tmp/<dirHash>/chats component that keys
+// the session's project resolution.
+func geminiSessionDirHash(root, path string) (string, bool) {
+	rel, ok := relUnder(filepath.Clean(root), filepath.Clean(path))
+	if !ok {
+		return "", false
+	}
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	if len(parts) != 4 || parts[0] != "tmp" || parts[2] != geminiChatsDir {
+		return "", false
+	}
+	return parts[1], true
+}
+
+// resolvedProjectForFingerprint returns the only metadata this session's
+// parse consumes: its resolved project name. Root-wide metadata files must
+// not leak into unrelated sessions' fingerprints (they used to
+// mass-invalidate the whole root on any edit).
+func (s geminiSourceSet) resolvedProjectForFingerprint(
+	root, path string, source SourceRef,
+) string {
+	if source.ProjectHint != "" {
+		return source.ProjectHint
+	}
+	dirHash, ok := geminiSessionDirHash(root, path)
+	if !ok {
+		return ""
+	}
+	return ResolveGeminiProject(dirHash, buildGeminiProjectMap(root))
 }
 
 func (s geminiSourceSet) pathFromSource(source SourceRef) (string, bool) {
@@ -461,11 +547,14 @@ func (s geminiSourceSet) sourceRefForPathWithProjectMap(
 // the project map once per root and tests can observe how often it runs.
 var buildGeminiProjectMap = BuildGeminiProjectMap
 
-func geminiProjectMetadataPaths(root string) []string {
-	return []string{
-		filepath.Join(root, "projects.json"),
-		filepath.Join(root, "trustedFolders.json"),
-	}
+// IsGeminiProjectMetadataFile reports whether path names one of the
+// root-level Gemini project-metadata files whose changes fan out to every
+// session under the root. The Gemini watch plan only emits these names from
+// the non-recursive root watch, so a basename check is sufficient for
+// callers without the root at hand.
+func IsGeminiProjectMetadataFile(path string) bool {
+	base := filepath.Base(path)
+	return base == "projects.json" || base == "trustedFolders.json"
 }
 
 func geminiProjectMetadataPath(root, path string) bool {
@@ -510,6 +599,7 @@ func geminiProviderCapabilities() Capabilities {
 	return Capabilities{
 		Source: SourceCapabilities{
 			DiscoverSources:      CapabilitySupported,
+			StreamingDiscovery:   CapabilitySupported,
 			WatchSources:         CapabilitySupported,
 			ClassifyChangedPath:  CapabilitySupported,
 			FindSource:           CapabilitySupported,

--- a/internal/parser/gptme_provider.go
+++ b/internal/parser/gptme_provider.go
@@ -49,6 +49,15 @@ func (p *gptmeProvider) Discover(ctx context.Context) ([]SourceRef, error) {
 	return p.filterSources(sources), nil
 }
 
+func (p *gptmeProvider) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	return p.sources.DiscoverEach(ctx, func(source SourceRef) error {
+		if !p.isSource(source) {
+			return nil
+		}
+		return yield(source)
+	})
+}
+
 func (p *gptmeProvider) WatchPlan(ctx context.Context) (WatchPlan, error) {
 	return p.sources.WatchPlan(ctx)
 }
@@ -267,6 +276,7 @@ func gptmeProviderCapabilities() Capabilities {
 	return Capabilities{
 		Source: SourceCapabilities{
 			DiscoverSources:      CapabilitySupported,
+			StreamingDiscovery:   CapabilitySupported,
 			WatchSources:         CapabilitySupported,
 			ClassifyChangedPath:  CapabilitySupported,
 			FindSource:           CapabilitySupported,

--- a/internal/parser/grok_provider.go
+++ b/internal/parser/grok_provider.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"os"
@@ -17,7 +18,7 @@ func newGrokProviderFactory(def AgentDef) ProviderFactory {
 			return NewSingleFileSourceSet(
 				AgentGrok,
 				cfg.Roots,
-				WithFileDiscovery(grokDiscoverFiles),
+				WithStreamingFileDiscovery(grokDiscoverEach),
 				WithFileWatchRoots(grokWatchRoots),
 				WithFileChangedPathClassifier(grokClassifyPath),
 				WithFileLookup(grokFindFile),
@@ -28,35 +29,41 @@ func newGrokProviderFactory(def AgentDef) ProviderFactory {
 	)
 }
 
-func grokDiscoverFiles(root string) []singleFileMatch {
-	entries, err := os.ReadDir(root)
-	if err != nil {
-		return nil
-	}
-	var out []singleFileMatch
-	for _, entry := range entries {
-		if !isDirOrSymlink(entry, root) {
-			continue
+func grokDiscoverEach(
+	ctx context.Context, root string, yield func(singleFileMatch) error,
+) error {
+	return streamDirectoryEntries(ctx, root, func(cwd os.DirEntry) error {
+		isCwdDir, dirErr := streamingDirCandidateOrIncomplete(
+			AgentGrok, "Grok cwd directory", cwd, root,
+		)
+		if dirErr != nil {
+			return dirErr
 		}
-		cwdRoot := filepath.Join(root, entry.Name())
-		sessionEntries, err := os.ReadDir(cwdRoot)
-		if err != nil {
-			continue
+		if !isCwdDir {
+			return nil
 		}
-		for _, sessionEntry := range sessionEntries {
-			if !isDirOrSymlink(sessionEntry, cwdRoot) ||
-				!IsValidSessionID(sessionEntry.Name()) {
-				continue
+		cwdRoot := filepath.Join(root, cwd.Name())
+		return streamDirectoryEntries(ctx, cwdRoot, func(session os.DirEntry) error {
+			if !IsValidSessionID(session.Name()) {
+				return nil
 			}
-			summaryPath := filepath.Join(
-				cwdRoot, sessionEntry.Name(), "summary.json",
+			isSessionDir, sessionErr := streamingDirCandidateOrIncomplete(
+				AgentGrok, "Grok session directory", session, cwdRoot,
 			)
-			if match, ok := grokStrictMatch(root, summaryPath); ok {
-				out = append(out, match)
+			if sessionErr != nil {
+				return sessionErr
 			}
-		}
-	}
-	return out
+			if !isSessionDir {
+				return nil
+			}
+			if match, ok := grokStrictMatch(
+				root, filepath.Join(cwdRoot, session.Name(), "summary.json"),
+			); ok {
+				return yield(match)
+			}
+			return nil
+		})
+	})
 }
 
 func grokWatchRoots(roots []string) []WatchRoot {

--- a/internal/parser/grok_test.go
+++ b/internal/parser/grok_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -304,6 +305,110 @@ func TestParseGrokChatHistoryDropsOrphanReasoning(t *testing.T) {
 			}
 		})
 	}
+}
+
+// A followed cwd- or session-directory symlink whose target cannot be
+// resolved must surface incomplete streaming discovery rather than reading as
+// absent: reconciliation treats a clean DiscoverEach as authoritative and
+// would tombstone every session beneath the symlink.
+func TestGrokProviderStreamingDiscoveryPropagatesDirectorySymlinkErrors(t *testing.T) {
+	discoverEach := func(t *testing.T, root string) ([]string, error) {
+		t.Helper()
+		provider := newGrokTestProvider(t, root)
+		discoverer, ok := provider.(StreamingDiscoverer)
+		require.True(t, ok)
+		var yielded []string
+		err := discoverer.DiscoverEach(t.Context(), func(source SourceRef) error {
+			yielded = append(yielded, source.DisplayPath)
+			return nil
+		})
+		return yielded, err
+	}
+	writeHealthySession := func(t *testing.T, root string) string {
+		t.Helper()
+		path := grokSummaryPath(root, "cwd-key", "sess-1")
+		writeGrokFixtureFile(t, path, `{"summary":"Healthy"}`)
+		return path
+	}
+
+	t.Run("dangling cwd symlink", func(t *testing.T) {
+		root := t.TempDir()
+		healthy := writeHealthySession(t, root)
+		target := filepath.Join(t.TempDir(), "linked-cwd")
+		require.NoError(t, os.MkdirAll(target, 0o755))
+		link := filepath.Join(root, "linked")
+		if err := os.Symlink(target, link); err != nil {
+			t.Skipf("symlink not supported: %v", err)
+		}
+		require.NoError(t, os.RemoveAll(target))
+
+		_, err := discoverEach(t, root)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, os.ErrNotExist)
+		var incomplete DiscoveryIncompleteError
+		assert.ErrorAs(t, err, &incomplete)
+
+		require.NoError(t, os.Remove(link))
+		yielded, err := discoverEach(t, root)
+		require.NoError(t, err)
+		assert.Equal(t, []string{healthy}, yielded)
+	})
+
+	t.Run("dangling session symlink", func(t *testing.T) {
+		root := t.TempDir()
+		healthy := writeHealthySession(t, root)
+		target := filepath.Join(t.TempDir(), "linked-session")
+		require.NoError(t, os.MkdirAll(target, 0o755))
+		link := filepath.Join(root, "cwd-key", "sess-linked")
+		if err := os.Symlink(target, link); err != nil {
+			t.Skipf("symlink not supported: %v", err)
+		}
+		require.NoError(t, os.RemoveAll(target))
+
+		_, err := discoverEach(t, root)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, os.ErrNotExist)
+		var incomplete DiscoveryIncompleteError
+		assert.ErrorAs(t, err, &incomplete)
+
+		require.NoError(t, os.Remove(link))
+		yielded, err := discoverEach(t, root)
+		require.NoError(t, err)
+		assert.Equal(t, []string{healthy}, yielded)
+	})
+
+	t.Run("unstatable cwd symlink target", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("directory read permissions are not enforced on Windows")
+		}
+		if os.Geteuid() == 0 {
+			t.Skip("root bypasses directory permissions")
+		}
+		root := t.TempDir()
+		healthy := writeHealthySession(t, root)
+		targetParent := t.TempDir()
+		target := filepath.Join(targetParent, "linked-cwd")
+		require.NoError(t, os.MkdirAll(target, 0o755))
+		if err := os.Symlink(target, filepath.Join(root, "linked")); err != nil {
+			t.Skipf("symlink not supported: %v", err)
+		}
+		require.NoError(t, os.Chmod(targetParent, 0o000))
+		t.Cleanup(func() { _ = os.Chmod(targetParent, 0o755) })
+
+		_, err := discoverEach(t, root)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, os.ErrPermission)
+		var incomplete DiscoveryIncompleteError
+		assert.ErrorAs(t, err, &incomplete)
+
+		require.NoError(t, os.Chmod(targetParent, 0o755))
+		yielded, err := discoverEach(t, root)
+		require.NoError(t, err)
+		assert.Equal(t, []string{healthy}, yielded)
+	})
 }
 
 func TestGrokProviderSummarySource(t *testing.T) {

--- a/internal/parser/hermes.go
+++ b/internal/parser/hermes.go
@@ -801,27 +801,50 @@ func readHermesStateMessagesForSession(
 func writeHermesStateSessionJSONL(
 	w io.Writer, stateDB, rawSessionID string,
 ) error {
+	ss, messages, selectedPath, err := readHermesStateSessionSource(
+		stateDB, rawSessionID,
+	)
+	if err != nil {
+		return err
+	}
+	if selectedPath != stateDB {
+		return copyHermesTranscriptFile(w, selectedPath)
+	}
+	return encodeHermesStateSessionJSONL(w, ss, messages)
+}
+
+func readHermesStateSessionSource(
+	stateDB, rawSessionID string,
+) (hermesStateSession, []hermesStateMessage, string, error) {
 	conn, err := sql.Open("sqlite3", "file:"+sqliteURIPath(stateDB)+"?mode=ro")
 	if err != nil {
-		return hermesStateLookupError{
+		return hermesStateSession{}, nil, "", hermesStateLookupError{
 			err: fmt.Errorf("open hermes state db: %w", err),
 		}
 	}
 	defer conn.Close()
+	return readHermesStateSessionSourceConn(conn, stateDB, rawSessionID)
+}
 
+// readHermesStateSessionSourceConn is readHermesStateSessionSource on an
+// already-open connection, so per-pass callers can reuse one state.db open
+// across every member instead of opening the database per session.
+func readHermesStateSessionSourceConn(
+	conn *sql.DB, stateDB, rawSessionID string,
+) (hermesStateSession, []hermesStateMessage, string, error) {
 	ss, found, err := readHermesStateSession(conn, rawSessionID)
 	if err != nil {
-		return hermesStateLookupError{err: err}
+		return hermesStateSession{}, nil, "", hermesStateLookupError{err: err}
 	}
 	if !found {
-		return fmt.Errorf(
+		return hermesStateSession{}, nil, "", fmt.Errorf(
 			"hermes session %s not found in %s: %w",
 			rawSessionID, stateDB, os.ErrNotExist,
 		)
 	}
 	messages, err := readHermesStateMessagesForSession(conn, rawSessionID)
 	if err != nil {
-		return hermesStateLookupError{err: err}
+		return hermesStateSession{}, nil, "", hermesStateLookupError{err: err}
 	}
 	selectedPath, _, _, _ := chooseHermesStateSessionSource(
 		ss,
@@ -831,10 +854,7 @@ func writeHermesStateSessionJSONL(
 		"",
 		"",
 	)
-	if selectedPath != stateDB {
-		return copyHermesTranscriptFile(w, selectedPath)
-	}
-	return encodeHermesStateSessionJSONL(w, ss, messages)
+	return ss, messages, selectedPath, nil
 }
 
 func copyHermesTranscriptFile(w io.Writer, path string) error {

--- a/internal/parser/hermes_provider.go
+++ b/internal/parser/hermes_provider.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"crypto/sha256"
 	"database/sql"
+	"encoding"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"hash"
@@ -54,6 +56,10 @@ func (p *hermesProvider) Discover(ctx context.Context) ([]SourceRef, error) {
 	return p.sources.Discover(ctx)
 }
 
+func (p *hermesProvider) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	return p.sources.DiscoverEach(ctx, yield)
+}
+
 func (p *hermesProvider) WatchPlan(ctx context.Context) (WatchPlan, error) {
 	return p.sources.WatchPlan(ctx)
 }
@@ -63,6 +69,43 @@ func (p *hermesProvider) SourcesForChangedPath(
 	req ChangedPathRequest,
 ) ([]SourceRef, error) {
 	return p.sources.SourcesForChangedPath(ctx, req)
+}
+
+func (p *hermesProvider) ReconciliationOwnershipScopes(
+	root string,
+) []StoredSourceHintScope {
+	return p.sources.ReconciliationOwnershipScopes(root)
+}
+
+func (p *hermesProvider) SourceForReconciliation(
+	ctx context.Context, path, project string,
+) (SourceRef, bool, error) {
+	return p.sources.SourceForReconciliation(ctx, path, project)
+}
+
+// ReconciliationAggregateMemberPaths maps an aggregate-owned state.db row to
+// the sources streamed discovery emits for that member: the virtual
+// state.db#<id> path for state-backed sessions and both transcript file
+// shapes for transcript-backed ones. Container discovery stamps every
+// session with the container path itself (see Parse), which always exists,
+// so a removed member would otherwise never trip the missing-path check.
+func (p *hermesProvider) ReconciliationAggregateMemberPaths(
+	path, fullSessionID string,
+) []string {
+	path = filepath.Clean(path)
+	if filepath.Base(path) != "state.db" {
+		return nil
+	}
+	rawID := strings.TrimPrefix(fullSessionID, "hermes:")
+	if rawID == fullSessionID || !IsValidSessionID(rawID) {
+		return nil
+	}
+	sessionsDir := filepath.Join(filepath.Dir(path), "sessions")
+	return []string{
+		VirtualSourcePath(path, rawID),
+		filepath.Join(sessionsDir, rawID+".jsonl"),
+		filepath.Join(sessionsDir, "session_"+rawID+".json"),
+	}
 }
 
 func (p *hermesProvider) FindSource(
@@ -128,14 +171,17 @@ func WriteHermesSessionJSONL(
 			rawSessionID, os.ErrNotExist,
 		)
 	}
-	path, ok := hp.sources.pathFromSource(source)
+	src, ok := hp.sources.sourceFromRef(source)
 	if !ok {
 		return fmt.Errorf("hermes source path unavailable")
 	}
-	if filepath.Base(path) == "state.db" {
-		return writeHermesStateSessionJSONL(w, path, rawSessionID)
+	if src.StateDB != "" && src.SessionID != "" {
+		return writeHermesStateSessionJSONL(w, src.StateDB, src.SessionID)
 	}
-	return copyHermesTranscriptFile(w, path)
+	if filepath.Base(src.Path) == "state.db" {
+		return writeHermesStateSessionJSONL(w, src.Path, rawSessionID)
+	}
+	return copyHermesTranscriptFile(w, src.Path)
 }
 
 func (p *hermesProvider) Parse(
@@ -145,11 +191,15 @@ func (p *hermesProvider) Parse(
 	if err := ctx.Err(); err != nil {
 		return ParseOutcome{}, err
 	}
-	path, ok := p.sources.pathFromSource(req.Source)
+	src, ok := p.sources.sourceFromRef(req.Source)
 	if !ok {
 		return ParseOutcome{}, fmt.Errorf("hermes source path unavailable")
 	}
+	path := src.Path
 	machine := firstNonEmptyJSONLString(req.Machine, p.Config.Machine)
+	if src.SessionID != "" {
+		return p.parseStateMember(ctx, src, req.Source.ProjectHint, machine, req.Fingerprint)
+	}
 	if filepath.Base(path) == "state.db" {
 		results, err := p.parseArchive(path, req.Source.ProjectHint, machine)
 		if err != nil {
@@ -202,9 +252,64 @@ func (p *hermesProvider) Parse(
 	}, nil
 }
 
+func (p *hermesProvider) parseStateMember(
+	ctx context.Context,
+	src hermesSource, project, machine string, fingerprint SourceFingerprint,
+) (ParseOutcome, error) {
+	conn, err := sql.Open("sqlite3", "file:"+sqliteURIPath(src.StateDB)+"?mode=ro")
+	if err != nil {
+		return ParseOutcome{}, fmt.Errorf("open hermes state db: %w", err)
+	}
+	defer conn.Close()
+	observeSharedContainerScan(ctx)
+	ss, found, err := readHermesStateSession(conn, src.SessionID)
+	if err != nil {
+		return ParseOutcome{}, err
+	}
+	if !found {
+		return ParseOutcome{ResultSetComplete: true, ForceReplace: true, SkipReason: SkipNoSession}, nil
+	}
+	messages, err := readHermesStateMessagesForSession(conn, src.SessionID)
+	if err != nil {
+		return ParseOutcome{}, err
+	}
+	result, ok := buildHermesStateResult(
+		ss, messages, filepath.Join(filepath.Dir(src.StateDB), "sessions"),
+		src.StateDB, project, machine,
+	)
+	if !ok {
+		return ParseOutcome{ResultSetComplete: true, ForceReplace: true, SkipReason: SkipNoSession}, nil
+	}
+	result.Session.File.Path = src.Path
+	if fingerprint.Hash != "" {
+		result.Session.File.Hash = fingerprint.Hash
+	}
+	// Store the fingerprint's freshness identity (state.db plus selected
+	// transcript) so the engine's stored size+mtime skip recognizes an
+	// unchanged member while the container is untouched. The stat is shared
+	// by every member, so after any sibling change the engine falls back to
+	// the per-member content hash stored above to keep unchanged members
+	// from reparsing (providerSourceHashFreshDespiteStat); without either
+	// identity every pass reparses every member and reconciliation work
+	// scales with total member count.
+	if fingerprint.Size > 0 {
+		result.Session.File.Size = fingerprint.Size
+	}
+	if fingerprint.MTimeNS > 0 {
+		result.Session.File.Mtime = fingerprint.MTimeNS
+	}
+	return ParseOutcome{
+		Results:           []ParseResultOutcome{{Result: result, DataVersion: DataVersionCurrent}},
+		ResultSetComplete: true,
+		ForceReplace:      true,
+	}, nil
+}
+
 type hermesSource struct {
-	Root string
-	Path string
+	Root      string
+	Path      string
+	StateDB   string
+	SessionID string
 }
 
 type hermesSourceSet struct {
@@ -224,10 +329,22 @@ func isHermesProfilesContainer(root string) bool {
 		filepath.Base(filepath.Dir(root)) == ".hermes"
 }
 
-func hermesProfileArchiveRoots(profilesRoot string) []string {
+// hermesProfileArchiveRoots expands a profiles container into its current
+// per-profile archive roots. A missing container simply means no profiles
+// exist yet; any other ReadDir failure (permissions, transient I/O) is
+// returned so callers report the expansion as incomplete discovery instead
+// of silently claiming zero profiles — ReconciliationOwnershipScopes still
+// claims the whole container, so a swallowed failure would let the engine
+// tombstone every stored hermes session under it as source_missing.
+func hermesProfileArchiveRoots(profilesRoot string) ([]string, error) {
 	entries, err := os.ReadDir(profilesRoot)
 	if err != nil {
-		return nil
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf(
+			"expand hermes profiles container %s: %w", profilesRoot, err,
+		)
 	}
 	roots := make([]string, 0, len(entries))
 	for _, entry := range entries {
@@ -236,19 +353,38 @@ func hermesProfileArchiveRoots(profilesRoot string) []string {
 		}
 		roots = append(roots, filepath.Join(profilesRoot, entry.Name()))
 	}
-	return roots
+	return roots, nil
 }
 
-func (s hermesSourceSet) expandedRoots() []string {
+// expandedRoots returns every discoverable archive root, expanding profiles
+// containers into their children. The returned roots always include every
+// root that did expand; a non-nil error joins the container expansion
+// failures so callers can act on the healthy subset while reporting the
+// failure as incomplete discovery rather than an authoritative empty scope.
+func (s hermesSourceSet) expandedRoots() ([]string, error) {
 	var roots []string
+	var expandErr error
 	for _, root := range s.roots {
 		if isHermesProfilesContainer(root) {
-			roots = append(roots, hermesProfileArchiveRoots(root)...)
+			profileRoots, err := hermesProfileArchiveRoots(root)
+			if err != nil {
+				expandErr = errors.Join(expandErr, err)
+			}
+			roots = append(roots, profileRoots...)
 			continue
 		}
 		roots = append(roots, root)
 	}
-	return roots
+	return roots, expandErr
+}
+
+// incompleteProfileExpansionError wraps a profiles-container expansion
+// failure in the DiscoveryIncompleteError taxonomy so the sync engine
+// retains reconciliation markers and retries instead of tombstoning.
+func incompleteProfileExpansionError(expandErr error) error {
+	return incompleteDiscoveryError(
+		AgentHermes, "expand profiles container", expandErr,
+	)
 }
 
 func hermesProfileRootForPath(profilesRoot, changedPath string) (string, bool) {
@@ -272,7 +408,8 @@ func hermesProfileRootForPath(profilesRoot, changedPath string) (string, bool) {
 func (s hermesSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
 	var sources []SourceRef
 	seen := make(map[string]struct{})
-	for _, root := range s.expandedRoots() {
+	roots, expandErr := s.expandedRoots()
+	for _, root := range roots {
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
@@ -285,7 +422,227 @@ func (s hermesSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
 		}
 	}
 	sortJSONLSources(sources)
+	if expandErr != nil {
+		return sources, incompleteProfileExpansionError(expandErr)
+	}
 	return sources, nil
+}
+
+func (s hermesSourceSet) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	var discoveryErr error
+	appendDiscoveryErr := func(err error) {
+		err = incompleteDiscoveryError(
+			AgentHermes, "stream configured root", err,
+		)
+		if discoveryErr == nil {
+			discoveryErr = err
+			return
+		}
+		discoveryErr = errors.Join(discoveryErr, err)
+	}
+	discoverTranscripts := func(root, sessionsDir, stateDB string) error {
+		return s.discoverTranscriptEach(
+			ctx, root, sessionsDir, stateDB, func(source SourceRef) error {
+				if err := yield(source); err != nil {
+					return discoveryYieldError{cause: err}
+				}
+				return nil
+			},
+		)
+	}
+	roots, expandErr := s.expandedRoots()
+	if expandErr != nil {
+		appendDiscoveryErr(expandErr)
+	}
+	for _, root := range roots {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if stateDB, sessionsDir, ok := hermesStatePaths(root); ok {
+			yieldedAny, err := s.discoverStateEach(ctx, root, stateDB, yield)
+			if err != nil {
+				if cause, ok := discoveryYieldCause(err); ok {
+					return cause
+				}
+				if yieldedAny || ctx.Err() != nil {
+					if ctxErr := ctx.Err(); ctxErr != nil {
+						return ctxErr
+					}
+					appendDiscoveryErr(err)
+					continue
+				}
+				log.Printf(
+					"hermes: state db discovery failed for %s: %v; "+
+						"falling back to transcripts",
+					stateDB, err,
+				)
+				stateErr := err
+				fallbackErr := discoverTranscripts(root, sessionsDir, "")
+				if cause, ok := discoveryYieldCause(fallbackErr); ok {
+					return cause
+				}
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return ctxErr
+				}
+				appendDiscoveryErr(stateErr)
+				if fallbackErr != nil {
+					appendDiscoveryErr(fallbackErr)
+				}
+				continue
+			}
+			if err := discoverTranscripts(root, sessionsDir, stateDB); err != nil {
+				if cause, ok := discoveryYieldCause(err); ok {
+					return cause
+				}
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return ctxErr
+				}
+				appendDiscoveryErr(err)
+				continue
+			}
+			continue
+		}
+		transcriptRoot := hermesTranscriptRoot(root)
+		if err := discoverTranscripts(root, transcriptRoot, ""); err != nil {
+			if cause, ok := discoveryYieldCause(err); ok {
+				return cause
+			}
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+			appendDiscoveryErr(err)
+			continue
+		}
+	}
+	return discoveryErr
+}
+
+func (s hermesSourceSet) discoverStateEach(
+	ctx context.Context, root, stateDB string, yield func(SourceRef) error,
+) (bool, error) {
+	conn, err := sql.Open("sqlite3", "file:"+sqliteURIPath(stateDB)+"?mode=ro")
+	if err != nil {
+		return false, fmt.Errorf("open hermes state db: %w", err)
+	}
+	defer conn.Close()
+	observeSharedContainerScan(ctx)
+	rows, err := conn.QueryContext(ctx, "SELECT id FROM sessions ORDER BY id")
+	if err != nil {
+		return false, fmt.Errorf("query hermes sessions: %w", err)
+	}
+	defer rows.Close()
+	yieldedAny := false
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return yieldedAny, fmt.Errorf("scan hermes session id: %w", err)
+		}
+		if !IsValidSessionID(id) {
+			continue
+		}
+		observeStreamingDiscoveryBuffer(ctx, 1)
+		yieldedAny = true
+		if err := yield(hermesStateMemberSourceRef(root, stateDB, id)); err != nil {
+			return yieldedAny, discoveryYieldError{cause: err}
+		}
+	}
+	return yieldedAny, rows.Err()
+}
+
+func (s hermesSourceSet) discoverTranscriptEach(
+	ctx context.Context, root, sessionsDir, stateDB string,
+	yield func(SourceRef) error,
+) error {
+	// One read-only connection and prepared statement serve every membership
+	// check in the pass; opening state.db per transcript file would scale
+	// reconciliation work with archive size instead of the changed batch.
+	// Opened lazily so transcript-free directories cost nothing.
+	var membership *hermesStateMembership
+	defer func() {
+		if membership != nil {
+			membership.Close()
+		}
+	}()
+	return streamDirectoryEntries(ctx, sessionsDir, func(entry os.DirEntry) error {
+		if entry.IsDir() {
+			return nil
+		}
+		name := entry.Name()
+		id := HermesSessionID(name)
+		if !IsValidSessionID(id) {
+			return nil
+		}
+		switch {
+		case strings.HasSuffix(name, ".jsonl"):
+		case strings.HasPrefix(name, "session_") && strings.HasSuffix(name, ".json"):
+			if IsRegularFile(filepath.Join(sessionsDir, id+".jsonl")) {
+				return nil
+			}
+		default:
+			return nil
+		}
+		if stateDB != "" {
+			if membership == nil {
+				opened, err := openHermesStateMembership(ctx, stateDB)
+				if err != nil {
+					return err
+				}
+				membership = opened
+			}
+			found, err := membership.Has(id)
+			if err != nil {
+				return err
+			}
+			if found {
+				return nil
+			}
+		}
+		ref, ok := hermesTranscriptSourceRef(root, filepath.Join(sessionsDir, name))
+		if !ok {
+			return nil
+		}
+		return yield(ref)
+	})
+}
+
+// hermesStateMembership answers "does state.db hold this session id" through
+// one read-only connection and prepared statement for a whole discovery pass.
+type hermesStateMembership struct {
+	conn *sql.DB
+	stmt *sql.Stmt
+}
+
+func openHermesStateMembership(
+	ctx context.Context, stateDB string,
+) (*hermesStateMembership, error) {
+	conn, err := sql.Open("sqlite3", "file:"+sqliteURIPath(stateDB)+"?mode=ro")
+	if err != nil {
+		return nil, fmt.Errorf("open hermes state db: %w", err)
+	}
+	observeSharedContainerScan(ctx)
+	stmt, err := conn.Prepare("SELECT 1 FROM sessions WHERE id = ? LIMIT 1")
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("prepare hermes session lookup: %w", err)
+	}
+	return &hermesStateMembership{conn: conn, stmt: stmt}, nil
+}
+
+func (m *hermesStateMembership) Has(rawID string) (bool, error) {
+	var found int
+	err := m.stmt.QueryRow(rawID).Scan(&found)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	return false, fmt.Errorf("query hermes session %s: %w", rawID, err)
+}
+
+func (m *hermesStateMembership) Close() {
+	m.stmt.Close()
+	m.conn.Close()
 }
 
 func (s hermesSourceSet) WatchPlan(context.Context) (WatchPlan, error) {
@@ -303,6 +660,91 @@ func (s hermesSourceSet) WatchPlan(context.Context) (WatchPlan, error) {
 		roots = append(roots, hermesWatchRoots(root)...)
 	}
 	return WatchPlan{Roots: roots}, nil
+}
+
+func (s hermesSourceSet) ReconciliationOwnershipScopes(
+	requestedRoot string,
+) []StoredSourceHintScope {
+	requestedRoot = filepath.Clean(requestedRoot)
+	requestedMatchRoot := absoluteHermesPath(requestedRoot)
+	var scopes []StoredSourceHintScope
+	for _, configuredRoot := range s.roots {
+		if !hermesPathWithinOrSame(
+			absoluteHermesPath(configuredRoot), requestedMatchRoot,
+		) {
+			continue
+		}
+		stateDB, sessionsDir, ok := hermesArchiveRootPaths(configuredRoot)
+		if !ok {
+			scopes = append(scopes, StoredSourceHintScope{Path: configuredRoot})
+			continue
+		}
+		if IsRegularFile(stateDB) {
+			scopes = append(scopes, StoredSourceHintScope{
+				Path: stateDB, IncludeVirtualMembers: true,
+			})
+		}
+		scopes = append(scopes, StoredSourceHintScope{Path: sessionsDir})
+	}
+	return scopes
+}
+
+func (s hermesSourceSet) SourceForReconciliation(
+	ctx context.Context, path, project string,
+) (SourceRef, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return SourceRef{}, false, err
+	}
+	path = filepath.Clean(path)
+	roots, expandErr := s.expandedRoots()
+	for _, root := range roots {
+		var source SourceRef
+		var ok bool
+		if _, _, virtual := ParseVirtualSourcePathForBase(path, "state.db"); virtual {
+			source, ok = s.sourceForChangedPath(root, path, false)
+		} else if stateDB, sessionsDir, archive := hermesStatePaths(root); archive {
+			switch {
+			case samePath(path, stateDB):
+				source, ok = hermesArchiveSourceRef(root, stateDB)
+			case hermesPathInTranscriptDir(sessionsDir, path) && IsRegularFile(path):
+				source, ok = hermesTranscriptSourceRef(root, path)
+			}
+		} else {
+			source, ok = s.sourceRef(root, path)
+		}
+		if !ok {
+			continue
+		}
+		if project != "" {
+			source.ProjectHint = project
+		}
+		return source, true, nil
+	}
+	if expandErr != nil {
+		// Not-found under a failed container expansion is not authoritative:
+		// the engine tombstones sessions whose reconciliation source cannot
+		// be resolved, so surface the failure and let it retry instead.
+		return SourceRef{}, false, incompleteProfileExpansionError(expandErr)
+	}
+	return SourceRef{}, false, nil
+}
+
+func absoluteHermesPath(path string) string {
+	cleaned := filepath.Clean(path)
+	abs, err := filepath.Abs(cleaned)
+	if err != nil {
+		return cleaned
+	}
+	return abs
+}
+
+func hermesPathWithinOrSame(path, root string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel == "." || rel != ".." &&
+		!strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 func (s hermesSourceSet) SourcesForChangedPath(
@@ -368,20 +810,30 @@ func (s hermesSourceSet) FindSource(
 	if err := ctx.Err(); err != nil {
 		return SourceRef{}, false, err
 	}
+	roots, expandErr := s.expandedRoots()
+	// Not-found is only authoritative when every profiles container
+	// expanded; otherwise return the expansion failure so callers retry
+	// instead of treating the source as gone.
+	notFound := func() (SourceRef, bool, error) {
+		if expandErr != nil {
+			return SourceRef{}, false, incompleteProfileExpansionError(expandErr)
+		}
+		return SourceRef{}, false, nil
+	}
 	for _, path := range []string{req.StoredFilePath, req.FingerprintKey} {
 		if path == "" {
 			continue
 		}
-		for _, root := range s.expandedRoots() {
+		for _, root := range roots {
 			if source, ok := s.sourceForPath(root, path); ok {
 				return source, true, nil
 			}
 		}
 	}
 	if req.RawSessionID == "" {
-		return SourceRef{}, false, nil
+		return notFound()
 	}
-	for _, root := range s.expandedRoots() {
+	for _, root := range roots {
 		if stateDB, _, ok := hermesStatePaths(root); ok &&
 			IsValidSessionID(req.RawSessionID) {
 			found, err := hermesStateDBHasSession(stateDB, req.RawSessionID)
@@ -397,9 +849,7 @@ func (s hermesSourceSet) FindSource(
 				)
 			case !found:
 			default:
-				if source, ok := s.sourceRef(root, stateDB); ok {
-					return source, true, nil
-				}
+				return hermesStateMemberSourceRef(root, stateDB, req.RawSessionID), true, nil
 			}
 		}
 		transcriptRoot := hermesTranscriptRoot(root)
@@ -411,7 +861,7 @@ func (s hermesSourceSet) FindSource(
 			return source, true, nil
 		}
 	}
-	return SourceRef{}, false, nil
+	return notFound()
 }
 
 type hermesStateLookupError struct {
@@ -454,9 +904,13 @@ func (s hermesSourceSet) Fingerprint(
 	if err := ctx.Err(); err != nil {
 		return SourceFingerprint{}, err
 	}
-	path, ok := s.pathFromSource(source)
+	src, ok := s.sourceFromRef(source)
 	if !ok {
 		return SourceFingerprint{}, fmt.Errorf("hermes source path unavailable")
+	}
+	path := src.Path
+	if src.SessionID != "" {
+		return hermesStateMemberFingerprint(ctx, source, src)
 	}
 	if filepath.Base(path) == "state.db" {
 		return hermesArchiveFingerprint(source, path)
@@ -480,28 +934,32 @@ func (s hermesSourceSet) Fingerprint(
 	}, nil
 }
 
-func (s hermesSourceSet) pathFromSource(source SourceRef) (string, bool) {
+func (s hermesSourceSet) sourceFromRef(source SourceRef) (hermesSource, bool) {
 	switch src := source.Opaque.(type) {
 	case hermesSource:
-		return src.Path, src.Path != ""
+		return src, src.Path != ""
 	case *hermesSource:
 		if src != nil && src.Path != "" {
-			return src.Path, true
+			return *src, true
 		}
 	}
+	// Expansion failures are not reportable through this boolean seam;
+	// callers (Fingerprint, Parse) already turn "not found" into an error
+	// the sync engine retries, so search only the roots that expanded.
+	roots, _ := s.expandedRoots()
 	for _, candidate := range []string{
 		source.DisplayPath,
 		source.FingerprintKey,
 		source.Key,
 	} {
-		for _, root := range s.expandedRoots() {
+		for _, root := range roots {
 			if ref, ok := s.sourceForPath(root, candidate); ok {
 				src := ref.Opaque.(hermesSource)
-				return src.Path, true
+				return src, true
 			}
 		}
 	}
-	return "", false
+	return hermesSource{}, false
 }
 
 func (s hermesSourceSet) sourceForPath(root, path string) (SourceRef, bool) {
@@ -515,6 +973,13 @@ func (s hermesSourceSet) sourceForChangedPath(
 ) (SourceRef, bool) {
 	root = filepath.Clean(root)
 	path = filepath.Clean(path)
+	if stateDB, sessionID, ok := ParseVirtualSourcePathForBase(path, "state.db"); ok {
+		if expected, _, valid := hermesArchivePathsForEvent(root, stateDB); valid &&
+			samePath(expected, stateDB) && IsValidSessionID(sessionID) {
+			return hermesStateMemberSourceRef(root, stateDB, sessionID), true
+		}
+		return SourceRef{}, false
+	}
 	if stateDB, sessionsDir, ok := hermesStatePaths(root); ok {
 		if hermesStatePathAffectsArchive(path, stateDB) ||
 			hermesPathInTranscriptDir(sessionsDir, path) {
@@ -566,6 +1031,15 @@ func hermesArchiveSourceRef(root, stateDB string) (SourceRef, bool) {
 			Path: stateDB,
 		},
 	}, true
+}
+
+func hermesStateMemberSourceRef(root, stateDB, sessionID string) SourceRef {
+	path := VirtualSourcePath(stateDB, sessionID)
+	return SourceRef{
+		Provider: AgentHermes, Key: path, DisplayPath: path, FingerprintKey: path,
+		Opaque: hermesSource{Root: filepath.Clean(root), Path: path,
+			StateDB: filepath.Clean(stateDB), SessionID: sessionID},
+	}
 }
 
 func hermesTranscriptSourceRef(root, path string) (SourceRef, bool) {
@@ -739,12 +1213,20 @@ func hermesArchiveFingerprint(source SourceRef, stateDB string) (SourceFingerpri
 		if walInfo.IsDir() {
 			return SourceFingerprint{}, fmt.Errorf("stat %s: source is a directory", walPath)
 		}
-		fingerprint.Size += walInfo.Size()
-		if mtime := walInfo.ModTime().UnixNano(); mtime > fingerprint.MTimeNS {
-			fingerprint.MTimeNS = mtime
-		}
-		if err := addHermesFingerprintPart(h, "wal", walPath, walInfo); err != nil {
-			return SourceFingerprint{}, err
+		// A zero-length WAL carries no committed frames and is created as a
+		// side effect of merely opening the database read-only (the parse
+		// itself creates one). Folding its mtime into the fingerprint would
+		// make the identity computed before a parse never match the one
+		// computed after it, so every subsequent sync re-parses an unchanged
+		// archive. Skip the empty WAL; any real commit gives it frames.
+		if walInfo.Size() > 0 {
+			fingerprint.Size += walInfo.Size()
+			if mtime := walInfo.ModTime().UnixNano(); mtime > fingerprint.MTimeNS {
+				fingerprint.MTimeNS = mtime
+			}
+			if err := addHermesFingerprintPart(h, "wal", walPath, walInfo); err != nil {
+				return SourceFingerprint{}, err
+			}
 		}
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return SourceFingerprint{}, fmt.Errorf("stat %s: %w", walPath, err)
@@ -767,6 +1249,230 @@ func hermesArchiveFingerprint(source SourceRef, stateDB string) (SourceFingerpri
 	return fingerprint, nil
 }
 
+func hermesStateMemberFingerprint(
+	ctx context.Context, source SourceRef, src hermesSource,
+) (SourceFingerprint, error) {
+	if !IsRegularFile(src.StateDB) {
+		return SourceFingerprint{Key: source.FingerprintKey}, nil
+	}
+	if reconciliationCacheAvailable(ctx) {
+		if h, selectedPath, ok := cachedHermesMemberCore(ctx, src); ok {
+			return hermesStateMemberFingerprintFinish(source, src, h, selectedPath)
+		}
+		// One bulk pass over state.db seeds every member's core, so the rest
+		// of the reconciliation fingerprints without reopening the database.
+		// Seeding failures fall through to the instrumented per-member open,
+		// which surfaces the underlying error with its usual handling.
+		if seedHermesMemberCores(ctx, src.StateDB) == nil {
+			if h, selectedPath, ok := cachedHermesMemberCore(ctx, src); ok {
+				return hermesStateMemberFingerprintFinish(source, src, h, selectedPath)
+			}
+		}
+	}
+	observeSharedContainerScan(ctx)
+	ss, messages, selectedPath, err := readHermesStateSessionSource(
+		src.StateDB, src.SessionID,
+	)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return SourceFingerprint{Key: source.FingerprintKey}, nil
+		}
+		return SourceFingerprint{}, err
+	}
+	h := sha256.New()
+	if err := addHermesStateSessionFingerprint(h, ss, messages); err != nil {
+		return SourceFingerprint{}, err
+	}
+	return hermesStateMemberFingerprintFinish(source, src, h, selectedPath)
+}
+
+func hermesStateMemberFingerprintFinish(
+	source SourceRef, src hermesSource, h hash.Hash, selectedPath string,
+) (SourceFingerprint, error) {
+	info, err := os.Stat(src.StateDB)
+	if err != nil {
+		return SourceFingerprint{}, err
+	}
+	fingerprint := SourceFingerprint{
+		Key:  firstNonEmptyJSONLString(source.FingerprintKey, source.Key, src.Path),
+		Size: info.Size(), MTimeNS: info.ModTime().UnixNano(),
+	}
+	if selectedPath != src.StateDB {
+		selectedInfo, err := os.Stat(selectedPath)
+		if err != nil {
+			return SourceFingerprint{}, fmt.Errorf("stat %s: %w", selectedPath, err)
+		}
+		fingerprint.Size += selectedInfo.Size()
+		fingerprint.MTimeNS = max(
+			fingerprint.MTimeNS, selectedInfo.ModTime().UnixNano(),
+		)
+		if err := addHermesFingerprintPart(
+			h, "selected-transcript", selectedPath, selectedInfo,
+		); err != nil {
+			return SourceFingerprint{}, err
+		}
+	}
+	fingerprint.Hash = fmt.Sprintf("%x", h.Sum(nil))
+	return fingerprint, nil
+}
+
+// hermesMemberFingerprintCore is the cached per-member fingerprint seed: the
+// sha256 digest state over the member's session row and messages, plus the
+// selected source path. seedHermesMemberCores computes it once per pass on a
+// shared state.db connection; the fingerprint path resumes the digest instead
+// of reopening the database, producing byte-identical hashes either way.
+type hermesMemberFingerprintCore struct {
+	HashState    []byte `json:"hash_state"`
+	SelectedPath string `json:"selected_path"`
+}
+
+func hermesMemberCoreCacheKey(fingerprintKey string) string {
+	return "hermes:member-core:" + fingerprintKey
+}
+
+// seedHermesMemberCores reads every state.db member once and caches each
+// member's fingerprint core for the rest of the pass. The per-reconciliation
+// once keeps the bulk read to one per state.db per pass even when parallel
+// fingerprint workers miss concurrently or a member read error leaves
+// individual entries unseeded.
+func seedHermesMemberCores(ctx context.Context, stateDB string) error {
+	return reconciliationCacheOnce(
+		ctx, "hermes:member-cores-seeded:"+stateDB,
+		func() error { return seedHermesMemberCoresLocked(ctx, stateDB) },
+	)
+}
+
+func seedHermesMemberCoresLocked(ctx context.Context, stateDB string) error {
+	idsConn, err := sql.Open("sqlite3", "file:"+sqliteURIPath(stateDB)+"?mode=ro")
+	if err != nil {
+		return fmt.Errorf("open hermes state db: %w", err)
+	}
+	defer idsConn.Close()
+	memberConn, err := sql.Open("sqlite3", "file:"+sqliteURIPath(stateDB)+"?mode=ro")
+	if err != nil {
+		return fmt.Errorf("open hermes member state db: %w", err)
+	}
+	defer memberConn.Close()
+	observeSharedContainerScan(ctx)
+	rows, err := idsConn.QueryContext(ctx, "SELECT id FROM sessions ORDER BY id")
+	if err != nil {
+		return fmt.Errorf("query hermes sessions: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return fmt.Errorf("scan hermes session id: %w", err)
+		}
+		if !IsValidSessionID(id) {
+			continue
+		}
+		retainedIDBytes := int64(len(id))
+		observeStreamingRetainedBytes(ctx, retainedIDBytes)
+		if err := cacheHermesMemberCore(
+			ctx, memberConn, stateDB, id, VirtualSourcePath(stateDB, id),
+		); err != nil {
+			observeStreamingRetainedBytes(ctx, -retainedIDBytes)
+			return err
+		}
+		observeStreamingRetainedBytes(ctx, -retainedIDBytes)
+	}
+	return rows.Err()
+}
+
+// cacheHermesMemberCore seeds one member's fingerprint core into the
+// per-pass reconciliation cache. Member read and digest-marshal problems are
+// left for the fingerprint path to surface through its established error
+// handling; only cache-write failures propagate.
+func cacheHermesMemberCore(
+	ctx context.Context, conn *sql.DB, stateDB, id, fingerprintKey string,
+) error {
+	ss, messages, selectedPath, err := readHermesStateSessionSourceConn(
+		conn, stateDB, id,
+	)
+	if err != nil {
+		return nil
+	}
+	h := sha256.New()
+	if err := addHermesStateSessionFingerprint(h, ss, messages); err != nil {
+		return nil
+	}
+	marshaler, ok := h.(encoding.BinaryMarshaler)
+	if !ok {
+		return nil
+	}
+	state, err := marshaler.MarshalBinary()
+	if err != nil {
+		return nil
+	}
+	payload, err := json.Marshal(hermesMemberFingerprintCore{
+		HashState: state, SelectedPath: selectedPath,
+	})
+	if err != nil {
+		return nil
+	}
+	return reconciliationCachePut(
+		ctx, hermesMemberCoreCacheKey(fingerprintKey), string(payload),
+	)
+}
+
+// cachedHermesMemberCore resumes a member's seeded digest from the per-pass
+// reconciliation cache. Any miss, decode failure, or unresumable digest falls
+// back to the instrumented per-member open path.
+func cachedHermesMemberCore(
+	ctx context.Context, src hermesSource,
+) (hash.Hash, string, bool) {
+	value, found, err := reconciliationCacheGet(
+		ctx, hermesMemberCoreCacheKey(src.Path),
+	)
+	if err != nil || !found {
+		return nil, "", false
+	}
+	var core hermesMemberFingerprintCore
+	if err := json.Unmarshal([]byte(value), &core); err != nil {
+		return nil, "", false
+	}
+	h := sha256.New()
+	unmarshaler, ok := h.(encoding.BinaryUnmarshaler)
+	if !ok || unmarshaler.UnmarshalBinary(core.HashState) != nil {
+		return nil, "", false
+	}
+	return h, core.SelectedPath, true
+}
+
+func addHermesStateSessionFingerprint(
+	h hash.Hash, ss hermesStateSession, messages []hermesStateMessage,
+) error {
+	if _, err := fmt.Fprintf(
+		h,
+		"state-member\x00%q\x00%q\x00%q\x00%q\x00%d\x00%d\x00%d\x00%d\x00%d\x00%d\x00%d\x00%d\x00%d\x00%t\x00%g\x00%t\x00%g\x00%q\x00%q\x00%q\x00%d\x00",
+		ss.id,
+		ss.source,
+		ss.model,
+		ss.parentSessionID,
+		ss.startedAt.UnixNano(),
+		ss.endedAt.UnixNano(),
+		ss.messageCount,
+		ss.inputTokens,
+		ss.outputTokens,
+		ss.cacheReadTokens,
+		ss.cacheWriteTokens,
+		ss.reasoningTokens,
+		ss.apiCallCount,
+		ss.estimatedCost.Valid,
+		ss.estimatedCost.Float64,
+		ss.actualCost.Valid,
+		ss.actualCost.Float64,
+		ss.costStatus,
+		ss.costSource,
+		ss.title,
+		len(messages),
+	); err != nil {
+		return err
+	}
+	return encodeHermesStateSessionJSONL(h, ss, messages)
+}
+
 // hermesArchiveEffectiveFileInfo returns the aggregate size and mtime of a
 // Hermes archive: the state.db, its WAL, and every transcript file in its
 // sessions directory. WAL-only commits and transcript-only changes both shift
@@ -781,7 +1487,11 @@ func hermesArchiveEffectiveFileInfo(stateDB string) (int64, int64) {
 	}
 	size := info.Size()
 	mtime := info.ModTime().UnixNano()
-	if walInfo, err := os.Stat(stateDB + "-wal"); err == nil && !walInfo.IsDir() {
+	// A zero-length WAL is a read-side artifact of opening the database and
+	// carries no committed frames; hermesArchiveFingerprint ignores it for the
+	// same reason, and the two aggregations must agree.
+	if walInfo, err := os.Stat(stateDB + "-wal"); err == nil &&
+		!walInfo.IsDir() && walInfo.Size() > 0 {
 		size += walInfo.Size()
 		if walMtime := walInfo.ModTime().UnixNano(); walMtime > mtime {
 			mtime = walMtime
@@ -862,6 +1572,7 @@ func hermesProviderCapabilities() Capabilities {
 	return Capabilities{
 		Source: SourceCapabilities{
 			DiscoverSources:      CapabilitySupported,
+			StreamingDiscovery:   CapabilitySupported,
 			WatchSources:         CapabilitySupported,
 			ClassifyChangedPath:  CapabilitySupported,
 			FindSource:           CapabilitySupported,

--- a/internal/parser/hermes_provider_test.go
+++ b/internal/parser/hermes_provider_test.go
@@ -2,10 +2,14 @@ package parser
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -127,7 +131,8 @@ func TestHermesProviderStateDBSourceMethods(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.True(t, ok)
-	assert.Equal(t, stateDB, found.DisplayPath)
+	memberPath := VirtualSourcePath(stateDB, "child")
+	assert.Equal(t, memberPath, found.DisplayPath)
 
 	stateInfo, err := os.Stat(stateDB)
 	require.NoError(t, err)
@@ -135,10 +140,9 @@ func TestHermesProviderStateDBSourceMethods(t *testing.T) {
 	require.NoError(t, err)
 	fingerprint, err := provider.Fingerprint(context.Background(), found)
 	require.NoError(t, err)
-	assert.Equal(t, stateDB, fingerprint.Key)
+	assert.Equal(t, memberPath, fingerprint.Key)
 	assert.Equal(t, stateInfo.Size()+transcriptInfo.Size(), fingerprint.Size)
-	assert.Equal(
-		t,
+	assert.Equal(t,
 		max(stateInfo.ModTime().UnixNano(), transcriptInfo.ModTime().UnixNano()),
 		fingerprint.MTimeNS,
 	)
@@ -187,6 +191,506 @@ func TestHermesProviderStateDBSourceMethods(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, changed, 1)
 	assert.Equal(t, stateDB, changed[0].DisplayPath)
+}
+
+func TestHermesStreamingDiscoveryYieldsFallbackAndReportsUnreadableStateDB(
+	t *testing.T,
+) {
+	tests := []struct {
+		name    string
+		setupDB func(*testing.T, string)
+	}{
+		{
+			name: "malformed database",
+			setupDB: func(t *testing.T, path string) {
+				t.Helper()
+				writeSourceFile(t, path, "not a sqlite database")
+			},
+		},
+		{
+			name: "incompatible schema",
+			setupDB: func(t *testing.T, path string) {
+				t.Helper()
+				conn, err := sql.Open("sqlite3", path)
+				require.NoError(t, err)
+				_, err = conn.Exec("CREATE TABLE unrelated (id TEXT PRIMARY KEY)")
+				require.NoError(t, err)
+				require.NoError(t, conn.Close())
+			},
+		},
+		{
+			name: "first row scan failure",
+			setupDB: func(t *testing.T, path string) {
+				t.Helper()
+				conn, err := sql.Open("sqlite3", path)
+				require.NoError(t, err)
+				_, err = conn.Exec(`
+					CREATE TABLE sessions (id TEXT);
+					INSERT INTO sessions (id) VALUES (NULL);
+				`)
+				require.NoError(t, err)
+				require.NoError(t, conn.Close())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			sessionsDir := filepath.Join(root, "sessions")
+			require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+			tt.setupDB(t, filepath.Join(root, "state.db"))
+			jsonlPath := filepath.Join(sessionsDir, "orphan.jsonl")
+			writeSourceFile(t, jsonlPath, hermesProviderJSONLFixture("question"))
+			writeSourceFile(t, filepath.Join(sessionsDir, "session_orphan.json"),
+				hermesProviderJSONFixture("duplicate"))
+			jsonPath := filepath.Join(sessionsDir, "session_jsononly.json")
+			writeSourceFile(t, jsonPath, hermesProviderJSONFixture("json question"))
+
+			provider, ok := NewProvider(AgentHermes, ProviderConfig{Roots: []string{root}})
+			require.True(t, ok)
+			found, ok, err := provider.FindSource(t.Context(), FindSourceRequest{
+				RawSessionID: "orphan",
+			})
+			require.NoError(t, err)
+			require.True(t, ok)
+			assert.Equal(t, jsonlPath, found.DisplayPath,
+				"FindSource establishes transcript fallback parity")
+
+			discoverer, ok := provider.(StreamingDiscoverer)
+			require.True(t, ok)
+			var paths []string
+			err = discoverer.DiscoverEach(t.Context(), func(source SourceRef) error {
+				paths = append(paths, source.DisplayPath)
+				return nil
+			})
+
+			require.Error(t, err,
+				"transcript fallback must not make the state scope authoritative")
+			assert.ElementsMatch(t, []string{jsonlPath, jsonPath}, paths)
+			assert.Len(t, paths, 2,
+				"JSONL and legacy JSON copies of one session must yield once")
+		})
+	}
+}
+
+func TestHermesStreamingDiscoveryPreservesStateYieldError(t *testing.T) {
+	root := t.TempDir()
+	sessionsDir := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+	createHermesStateDB(t, root)
+	writeSourceFile(t, filepath.Join(sessionsDir, "orphan.jsonl"),
+		hermesProviderJSONLFixture("orphan question"))
+	provider, ok := NewProvider(AgentHermes, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	discoverer, ok := provider.(StreamingDiscoverer)
+	require.True(t, ok)
+	wantErr := errors.New("stop streaming")
+	calls := 0
+
+	err := discoverer.DiscoverEach(t.Context(), func(SourceRef) error {
+		calls++
+		return wantErr
+	})
+
+	require.ErrorIs(t, err, wantErr)
+	assert.Equal(t, 1, calls,
+		"a state callback failure must not restart transcript discovery")
+}
+
+func TestHermesStreamingFallbackErrorPrecedence(t *testing.T) {
+	newDiscoverer := func(t *testing.T) StreamingDiscoverer {
+		t.Helper()
+		root := t.TempDir()
+		sessionsDir := filepath.Join(root, "sessions")
+		require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+		writeSourceFile(t, filepath.Join(root, "state.db"), "not a sqlite database")
+		writeSourceFile(t, filepath.Join(sessionsDir, "orphan.jsonl"),
+			hermesProviderJSONLFixture("orphan question"))
+		writeSourceFile(t, filepath.Join(sessionsDir, "session_orphan.json"),
+			hermesProviderJSONFixture("duplicate legacy question"))
+		provider, ok := NewProvider(AgentHermes, ProviderConfig{Roots: []string{root}})
+		require.True(t, ok)
+		discoverer, ok := provider.(StreamingDiscoverer)
+		require.True(t, ok)
+		return discoverer
+	}
+
+	t.Run("yield error", func(t *testing.T) {
+		discoverer := newDiscoverer(t)
+		wantErr := errors.New("stop transcript fallback")
+		calls := 0
+
+		err := discoverer.DiscoverEach(t.Context(), func(SourceRef) error {
+			calls++
+			return wantErr
+		})
+
+		assert.Same(t, wantErr, err,
+			"callback failure must take precedence over state incompleteness")
+		assert.Equal(t, 1, calls,
+			"fallback deduplication must not invoke the callback for legacy JSON")
+	})
+
+	t.Run("context cancellation", func(t *testing.T) {
+		discoverer := newDiscoverer(t)
+		ctx, cancel := context.WithCancel(t.Context())
+		ctx = withStreamingDirectoryReader(ctx, func(
+			ctx context.Context, _ string, _ func(os.DirEntry) error,
+		) error {
+			cancel()
+			return ctx.Err()
+		})
+
+		err := discoverer.DiscoverEach(ctx, func(SourceRef) error { return nil })
+
+		assert.Equal(t, context.Canceled, err,
+			"cancellation must take precedence over state incompleteness")
+	})
+
+	t.Run("transcript traversal error", func(t *testing.T) {
+		discoverer := newDiscoverer(t)
+		fallbackErr := errors.New("read transcript directory")
+		ctx := withStreamingDirectoryReader(t.Context(), func(
+			context.Context, string, func(os.DirEntry) error,
+		) error {
+			return fallbackErr
+		})
+
+		err := discoverer.DiscoverEach(ctx, func(SourceRef) error { return nil })
+
+		require.ErrorIs(t, err, fallbackErr)
+		assert.Contains(t, err.Error(), "query hermes sessions",
+			"joined error must retain the original state failure")
+	})
+}
+
+func TestHermesStreamingFallbackContinuesAcrossRoots(t *testing.T) {
+	malformedRoot := t.TempDir()
+	malformedSessions := filepath.Join(malformedRoot, "sessions")
+	require.NoError(t, os.MkdirAll(malformedSessions, 0o755))
+	writeSourceFile(t, filepath.Join(malformedRoot, "state.db"), "not a sqlite database")
+	malformedTranscript := filepath.Join(malformedSessions, "first.jsonl")
+	writeSourceFile(t, malformedTranscript, hermesProviderJSONLFixture("first fallback"))
+
+	incompatibleRoot := t.TempDir()
+	incompatibleSessions := filepath.Join(incompatibleRoot, "sessions")
+	require.NoError(t, os.MkdirAll(incompatibleSessions, 0o755))
+	conn, err := sql.Open("sqlite3", filepath.Join(incompatibleRoot, "state.db"))
+	require.NoError(t, err)
+	_, err = conn.Exec("CREATE TABLE unrelated (id TEXT PRIMARY KEY)")
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+	incompatibleTranscript := filepath.Join(incompatibleSessions, "second.jsonl")
+	writeSourceFile(t, incompatibleTranscript, hermesProviderJSONLFixture("second fallback"))
+
+	provider, ok := NewProvider(AgentHermes, ProviderConfig{
+		Roots: []string{malformedRoot, incompatibleRoot},
+	})
+	require.True(t, ok)
+	discoverer, ok := provider.(StreamingDiscoverer)
+	require.True(t, ok)
+	var paths []string
+
+	err = discoverer.DiscoverEach(t.Context(), func(source SourceRef) error {
+		paths = append(paths, source.DisplayPath)
+		return nil
+	})
+
+	require.Error(t, err)
+	assert.ElementsMatch(t, []string{malformedTranscript, incompatibleTranscript}, paths,
+		"a failed root must not prevent safe fallback discovery for later roots")
+	assert.Contains(t, err.Error(), "file is not a database")
+	assert.Contains(t, err.Error(), "no such table: sessions")
+}
+
+func TestHermesStreamingTranscriptFailureContinuesLaterRoots(t *testing.T) {
+	failedRoot := t.TempDir()
+	healthyRoot := t.TempDir()
+	healthyPath := filepath.Join(healthyRoot, "healthy.jsonl")
+	writeSourceFile(t, healthyPath, hermesProviderJSONLFixture("healthy root"))
+	discoveryErr := errors.New("read failed transcript root")
+	ctx := withStreamingDirectoryReader(t.Context(), func(
+		ctx context.Context, dir string, yield func(os.DirEntry) error,
+	) error {
+		if samePath(dir, failedRoot) {
+			return discoveryErr
+		}
+		return streamDirectoryEntriesDirect(ctx, dir, yield)
+	})
+	provider, ok := NewProvider(AgentHermes, ProviderConfig{
+		Roots: []string{failedRoot, healthyRoot},
+	})
+	require.True(t, ok)
+	var paths []string
+
+	err := provider.(StreamingDiscoverer).DiscoverEach(
+		ctx, func(source SourceRef) error {
+			paths = append(paths, source.DisplayPath)
+			return nil
+		},
+	)
+
+	require.ErrorIs(t, err, discoveryErr)
+	var incomplete DiscoveryIncompleteError
+	require.ErrorAs(t, err, &incomplete)
+	assert.Equal(t, AgentHermes, incomplete.Provider)
+	assert.Equal(t, []string{healthyPath}, paths,
+		"a root-local transcript failure must not starve later roots")
+}
+
+// TestHermesProfilesContainerEnumerationFailureIsIncompleteDiscovery guards
+// the reconciliation tombstoning path: hermesProfileArchiveRoots used to
+// convert every os.ReadDir failure into an empty profile list, so a
+// transient permission or I/O failure on the profiles container made
+// discovery look authoritatively empty while ReconciliationOwnershipScopes
+// still claimed the whole container — and the engine tombstoned every
+// stored hermes session under it as source_missing. Enumeration failures
+// must surface as DiscoveryIncompleteError so the engine retains
+// reconciliation markers and retries instead.
+func TestHermesProfilesContainerEnumerationFailureIsIncompleteDiscovery(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory-permission read failures are not portable to Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+
+	profilesRoot := filepath.Join(t.TempDir(), ".hermes", "profiles")
+	profileRoot := filepath.Join(profilesRoot, "research")
+	require.NoError(t, os.MkdirAll(profileRoot, 0o755))
+	createHermesStateDB(t, profileRoot)
+
+	healthyRoot := t.TempDir()
+	healthyPath := filepath.Join(healthyRoot, "healthy.jsonl")
+	writeSourceFile(t, healthyPath, hermesProviderJSONLFixture("healthy root"))
+
+	provider, ok := NewProvider(AgentHermes, ProviderConfig{
+		Roots: []string{profilesRoot, healthyRoot},
+	})
+	require.True(t, ok)
+
+	require.NoError(t, os.Chmod(profilesRoot, 0o000))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chmod(profilesRoot, 0o755))
+	})
+
+	var paths []string
+	err := provider.(StreamingDiscoverer).DiscoverEach(
+		t.Context(), func(source SourceRef) error {
+			paths = append(paths, source.DisplayPath)
+			return nil
+		},
+	)
+	var incomplete DiscoveryIncompleteError
+	require.ErrorAs(t, err, &incomplete,
+		"an unreadable profiles container must make streamed discovery incomplete, not empty")
+	assert.Equal(t, AgentHermes, incomplete.Provider)
+	assert.Equal(t, []string{healthyPath}, paths,
+		"a failed profiles container must not starve other configured roots")
+
+	_, err = provider.Discover(t.Context())
+	require.ErrorAs(t, err, &incomplete,
+		"an unreadable profiles container must make batch discovery incomplete, not empty")
+
+	resolver, ok := provider.(ReconciliationSourceResolver)
+	require.True(t, ok)
+	_, found, err := resolver.SourceForReconciliation(
+		t.Context(), filepath.Join(profileRoot, "state.db"), "",
+	)
+	assert.False(t, found)
+	require.ErrorAs(t, err, &incomplete,
+		"not-found under a failed container expansion must not be authoritative")
+}
+
+func TestHermesStreamingArchiveTranscriptFailureContinuesLaterRoots(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		state func(*testing.T, string)
+	}{
+		{
+			name: "after state discovery",
+			state: func(t *testing.T, root string) {
+				createHermesStateDB(t, root)
+			},
+		},
+		{
+			name: "during state fallback",
+			state: func(t *testing.T, root string) {
+				writeSourceFile(t, filepath.Join(root, "state.db"), "not sqlite")
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			failedRoot := t.TempDir()
+			failedSessions := filepath.Join(failedRoot, "sessions")
+			require.NoError(t, os.MkdirAll(failedSessions, 0o755))
+			tc.state(t, failedRoot)
+			healthyRoot := t.TempDir()
+			healthyPath := filepath.Join(healthyRoot, "healthy.jsonl")
+			writeSourceFile(t, healthyPath, hermesProviderJSONLFixture("healthy root"))
+			discoveryErr := errors.New("read failed archive transcripts")
+			ctx := withStreamingDirectoryReader(t.Context(), func(
+				ctx context.Context, dir string, yield func(os.DirEntry) error,
+			) error {
+				if samePath(dir, failedSessions) {
+					return discoveryErr
+				}
+				return streamDirectoryEntriesDirect(ctx, dir, yield)
+			})
+			provider, ok := NewProvider(AgentHermes, ProviderConfig{
+				Roots: []string{failedRoot, healthyRoot},
+			})
+			require.True(t, ok)
+			var paths []string
+
+			err := provider.(StreamingDiscoverer).DiscoverEach(
+				ctx, func(source SourceRef) error {
+					paths = append(paths, source.DisplayPath)
+					return nil
+				},
+			)
+
+			require.ErrorIs(t, err, discoveryErr)
+			assert.Contains(t, paths, healthyPath,
+				"an archive transcript failure must not starve later roots")
+		})
+	}
+}
+
+func TestHermesSourceForReconciliationPreservesOrdinaryTranscript(t *testing.T) {
+	root := t.TempDir()
+	sessionsDir := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+	createHermesStateDB(t, root)
+	transcriptPath := filepath.Join(sessionsDir, "orphan.jsonl")
+	writeSourceFile(t, transcriptPath, hermesProviderJSONLFixture("orphan question"))
+
+	provider, ok := NewProvider(AgentHermes, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	resolver, ok := provider.(ReconciliationSourceResolver)
+	require.True(t, ok)
+	source, found, err := resolver.SourceForReconciliation(
+		t.Context(), transcriptPath, "project",
+	)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, transcriptPath, source.DisplayPath)
+	assert.Equal(t, transcriptPath, source.FingerprintKey)
+	assert.Equal(t, "project", source.ProjectHint)
+}
+
+func TestHermesStateMemberFingerprintIncludesSelectedTranscriptMetadata(t *testing.T) {
+	root := t.TempDir()
+	sessionsDir := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+	createHermesStateDB(t, root)
+	transcriptPath := filepath.Join(sessionsDir, "session_child.json")
+	writeSourceFile(t, transcriptPath, hermesProviderJSONFixture("transcript question"))
+	transcriptTime := time.Now().Add(2 * time.Second).Truncate(time.Second)
+	require.NoError(t, os.Chtimes(transcriptPath, transcriptTime, transcriptTime))
+	stateDB := filepath.Join(root, "state.db")
+
+	provider, ok := NewProvider(AgentHermes, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	source, found, err := provider.FindSource(context.Background(), FindSourceRequest{
+		RawSessionID: "child",
+	})
+	require.NoError(t, err)
+	require.True(t, found)
+
+	fingerprint, err := provider.Fingerprint(context.Background(), source)
+	require.NoError(t, err)
+	stateInfo, err := os.Stat(stateDB)
+	require.NoError(t, err)
+	transcriptInfo, err := os.Stat(transcriptPath)
+	require.NoError(t, err)
+	assert.Equal(t, stateInfo.Size()+transcriptInfo.Size(), fingerprint.Size)
+	assert.Equal(t, transcriptInfo.ModTime().UnixNano(), fingerprint.MTimeNS)
+}
+
+// TestHermesArchiveFingerprintIgnoresEmptyWAL pins fingerprint determinism
+// across a parse: opening state.db read-only creates a zero-length -wal as a
+// side effect, and if its mtime entered the fingerprint, the identity stored
+// before a parse would never match the one computed after it, so every sync
+// would re-parse an unchanged archive. A WAL with committed frames must still
+// change the fingerprint.
+func TestHermesArchiveFingerprintIgnoresEmptyWAL(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "sessions"), 0o755))
+	createHermesStateDB(t, root)
+	stateDB := filepath.Join(root, "state.db")
+
+	provider, ok := NewProvider(AgentHermes, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	discovered, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, discovered, 1)
+	require.Equal(t, stateDB, discovered[0].DisplayPath)
+
+	before, err := provider.Fingerprint(context.Background(), discovered[0])
+	require.NoError(t, err)
+
+	walPath := stateDB + "-wal"
+	require.NoError(t, os.WriteFile(walPath, nil, 0o644))
+	walTime := time.Now().Add(2 * time.Second).Truncate(time.Second)
+	require.NoError(t, os.Chtimes(walPath, walTime, walTime))
+
+	after, err := provider.Fingerprint(context.Background(), discovered[0])
+	require.NoError(t, err)
+	assert.Equal(t, before.Size, after.Size,
+		"a zero-length WAL must not change the archive size")
+	assert.Equal(t, before.MTimeNS, after.MTimeNS,
+		"a zero-length WAL's mtime must not change the archive freshness")
+	assert.Equal(t, before.Hash, after.Hash,
+		"a zero-length WAL must not change the archive hash")
+
+	require.NoError(t, os.WriteFile(walPath, []byte("wal frames"), 0o644))
+	committedTime := walTime.Add(2 * time.Second)
+	require.NoError(t, os.Chtimes(walPath, committedTime, committedTime))
+
+	committed, err := provider.Fingerprint(context.Background(), discovered[0])
+	require.NoError(t, err)
+	assert.Equal(t, before.Size+int64(len("wal frames")), committed.Size,
+		"a WAL with frames must add its size to the archive fingerprint")
+	assert.Equal(t, committedTime.UnixNano(), committed.MTimeNS,
+		"a WAL with frames must advance the archive freshness")
+	assert.NotEqual(t, before.Hash, committed.Hash,
+		"a WAL with frames must change the archive hash")
+}
+
+func TestHermesStateMemberFingerprintIncludesStateMetadataWhenTranscriptWins(t *testing.T) {
+	root := t.TempDir()
+	sessionsDir := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+	createHermesStateDB(t, root)
+	transcriptPath := filepath.Join(sessionsDir, "session_child.json")
+	writeSourceFile(t, transcriptPath, hermesProviderJSONFixture("transcript question"))
+	stateDB := filepath.Join(root, "state.db")
+
+	provider, ok := NewProvider(AgentHermes, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	source, found, err := provider.FindSource(context.Background(), FindSourceRequest{
+		RawSessionID: "child",
+	})
+	require.NoError(t, err)
+	require.True(t, found)
+	before, err := provider.Fingerprint(context.Background(), source)
+	require.NoError(t, err)
+	stateInfo, err := os.Stat(stateDB)
+	require.NoError(t, err)
+
+	conn, err := sql.Open("sqlite3", stateDB)
+	require.NoError(t, err)
+	_, err = conn.Exec("UPDATE sessions SET title = ? WHERE id = ?", "Other Session", "child")
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+	require.NoError(t, os.Chtimes(stateDB, stateInfo.ModTime(), stateInfo.ModTime()))
+	after, err := provider.Fingerprint(context.Background(), source)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, before.Hash, after.Hash,
+		"state metadata used by parsing must participate even when transcript messages win")
 }
 
 func TestHermesProviderArchiveWatchRoots(t *testing.T) {
@@ -328,6 +832,50 @@ func TestHermesProfileChangedPathAllocationsStayBounded(t *testing.T) {
 	largeAllocs := measure(t, 1000)
 	assert.LessOrEqual(t, largeAllocs, smallAllocs*2,
 		"Hermes profile events must not scan unrelated profiles")
+}
+
+func TestHermesMemberCoreSeedRetainedIDBytesStayBounded(t *testing.T) {
+	measure := func(t *testing.T, sessionCount int) int64 {
+		t.Helper()
+		root := t.TempDir()
+		createHermesStateDB(t, root)
+		stateDB := filepath.Join(root, "state.db")
+		conn, err := sql.Open("sqlite3", stateDB)
+		require.NoError(t, err)
+		_, err = conn.Exec("DELETE FROM messages; DELETE FROM sessions")
+		require.NoError(t, err)
+		for i := range sessionCount {
+			id := fmt.Sprintf("member-%06d", i)
+			_, err = conn.Exec(`INSERT INTO sessions
+				(id, source, started_at, estimated_cost_usd, actual_cost_usd)
+				VALUES (?, 'cli', ?, 0, 0)`, id, i)
+			require.NoError(t, err)
+			_, err = conn.Exec(`INSERT INTO messages
+				(session_id, role, content, timestamp)
+				VALUES (?, 'user', 'hello', ?)`, id, i)
+			require.NoError(t, err)
+		}
+		require.NoError(t, conn.Close())
+
+		var retained, peak int64
+		ctx := WithStreamingRetainedBytesObserver(t.Context(), func(delta int64) {
+			retained += delta
+			peak = max(peak, retained)
+		})
+		ctx, cleanup, err := WithReconciliationCache(ctx)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, cleanup()) })
+
+		require.NoError(t, seedHermesMemberCoresLocked(ctx, stateDB))
+		assert.Zero(t, retained, "seeded IDs must be released before the pass returns")
+		return peak
+	}
+
+	small := measure(t, 3)
+	large := measure(t, 300)
+	assert.Positive(t, small, "the retained-ID allocation boundary must be observed")
+	assert.LessOrEqual(t, large, small*2,
+		"peak retained ID bytes must not scale with Hermes archive cardinality")
 }
 
 func TestHermesProviderArchiveWatchRootsBeforeArchiveComplete(t *testing.T) {

--- a/internal/parser/hermes_test.go
+++ b/internal/parser/hermes_test.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"database/sql"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -359,6 +360,57 @@ func TestWriteHermesSessionJSONL_FallsBackWhenStoredStateDBMissesSession(t *test
 		"child",
 	))
 	assert.Contains(t, buf.String(), "state db only has one message")
+}
+
+func TestWriteHermesSessionJSONL_FallsBackToStateMemberWhenStoredSourceMissing(
+	t *testing.T,
+) {
+	missingRoot := t.TempDir()
+	fallbackRoot := t.TempDir()
+	fallbackSessions := filepath.Join(fallbackRoot, "sessions")
+	require.NoError(t, os.MkdirAll(fallbackSessions, 0o755))
+	createHermesStateDB(t, fallbackRoot)
+
+	var buf strings.Builder
+	require.NoError(t, WriteHermesSessionJSONL(
+		&buf,
+		VirtualSourcePath(filepath.Join(missingRoot, "state.db"), "child"),
+		[]string{fallbackSessions},
+		"child",
+	))
+
+	out := buf.String()
+	assert.Contains(t, out, `"role":"session_meta"`)
+	assert.Contains(t, out, "state db only has one message")
+	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
+		var record map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &record))
+	}
+}
+
+func TestWriteHermesSessionJSONL_PreservesHashInTranscriptPath(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "state.db#profile")
+	sessionsDir := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+	body := strings.Join([]string{
+		`{"role":"session_meta","model":"gpt-4","timestamp":"2026-04-03T15:27:00Z"}`,
+		`{"role":"user","content":"hash path transcript","timestamp":"2026-04-03T15:28:00Z"}`,
+		"",
+	}, "\n")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sessionsDir, "child.jsonl"),
+		[]byte(body),
+		0o644,
+	))
+
+	var buf strings.Builder
+	require.NoError(t, WriteHermesSessionJSONL(
+		&buf,
+		VirtualSourcePath(filepath.Join(t.TempDir(), "state.db"), "child"),
+		[]string{sessionsDir},
+		"child",
+	))
+	assert.Equal(t, body, buf.String())
 }
 
 func TestWriteHermesSessionJSONL_FallsBackToTranscriptWhenStateDBMissesSessionInSameRoot(t *testing.T) {

--- a/internal/parser/jsonl_source_set.go
+++ b/internal/parser/jsonl_source_set.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -110,6 +111,11 @@ type JSONLSourceSetOptions struct {
 	// providers describe companions once as transcript->companions and the base
 	// drives watch, freshness, and changed-path mapping from that single hook.
 	CompanionFiles func(transcriptPath string) []string
+
+	// CompanionTranscript is the inverse of CompanionFiles: it derives the
+	// owning transcript path from a changed sidecar path so companion events
+	// resolve without scanning the archive. See WithCompanionTranscript.
+	CompanionTranscript func(companionPath string) (string, bool)
 }
 
 // JSONLSourceSet discovers, watches, locates, and fingerprints JSONL-like
@@ -157,22 +163,45 @@ func jsonlSourceSetFromOptions(
 
 // Discover returns stable, deduped source references for configured roots.
 func (s JSONLSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
-	var sources []SourceRef
-	seen := make(map[string]struct{})
+	return collectDiscoveredSources(ctx, s.DiscoverEach)
+}
+
+func (s JSONLSourceSet) DiscoverEach(
+	ctx context.Context, yield func(SourceRef) error,
+) error {
+	var incomplete error
 	for _, root := range s.roots {
 		if err := ctx.Err(); err != nil {
-			return nil, err
+			return err
 		}
 		info, err := os.Stat(root)
-		if err != nil || !info.IsDir() {
+		if errors.Is(err, os.ErrNotExist) {
 			continue
 		}
-		if err := s.discoverDir(ctx, root, root, &sources, seen); err != nil {
-			return nil, err
+		if err != nil {
+			incomplete = errors.Join(incomplete, incompleteDiscoveryError(
+				s.provider, "stat JSONL root "+root, err,
+			))
+			continue
+		}
+		if !info.IsDir() {
+			err := fmt.Errorf("not a directory")
+			incomplete = errors.Join(incomplete, incompleteDiscoveryError(
+				s.provider, "stat JSONL root "+root, err,
+			))
+			continue
+		}
+		if err := s.discoverDirEach(ctx, root, root, yield); err != nil {
+			if cause, ok := discoveryYieldCause(err); ok {
+				return cause
+			}
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			incomplete = errors.Join(incomplete, err)
 		}
 	}
-	sortJSONLSources(sources)
-	return sources, nil
+	return incomplete
 }
 
 // WatchPlan returns one watch root for each configured JSONL root. When a
@@ -197,6 +226,26 @@ func (s JSONLSourceSet) WatchPlan(ctx context.Context) (WatchPlan, error) {
 		})
 	}
 	return WatchPlan{Roots: roots}, nil
+}
+
+// WatchRoots returns configured root metadata without discovering transcripts
+// or enumerating companion basenames. WatchPlan remains archive-aware for
+// parser callers that still consume include globs.
+func (s JSONLSourceSet) WatchRoots(
+	ctx context.Context,
+) ([]WatchRoot, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	roots := make([]WatchRoot, 0, len(s.roots))
+	for _, root := range s.roots {
+		roots = append(roots, WatchRoot{
+			Path:        root,
+			Recursive:   s.options.Recursive,
+			DebounceKey: string(s.provider) + ":jsonl:" + root,
+		})
+	}
+	return roots, nil
 }
 
 // companionGlobs enumerates the distinct sidecar basenames across all
@@ -274,6 +323,33 @@ func (s JSONLSourceSet) SourcesForChangedPath(
 		}
 	}
 	return []SourceRef{source}, nil
+}
+
+// SourceForReconciliation rebuilds an exact source that streaming discovery
+// already admitted. It deliberately avoids changed-path classification, whose
+// duplicate-resolution fallback can rediscover the entire archive once per
+// candidate during streamed reconciliation.
+func (s JSONLSourceSet) SourceForReconciliation(
+	ctx context.Context, path, _ string,
+) (SourceRef, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return SourceRef{}, false, err
+	}
+	path = filepath.Clean(path)
+	info, err := s.sourcePathInfo(path)
+	if err != nil || !info.Mode().IsRegular() {
+		return SourceRef{}, false, nil
+	}
+	for _, root := range s.roots {
+		if !s.pathAllowedByRoot(root, path) ||
+			!s.sourcePathAllowedByDescendPath(root, path) ||
+			!s.pathIncluded(root, path) {
+			continue
+		}
+		source, ok := s.sourceRef(root, path, info)
+		return source, ok, nil
+	}
+	return SourceRef{}, false, nil
 }
 
 // FindSource resolves persisted source hints or a raw filename-stem session ID.
@@ -497,57 +573,87 @@ func (s JSONLSourceSet) Parse(
 }
 
 var (
-	_ SourceSet = JSONLSourceSet{}
-	_ SourceSet = DirectoryJSONLSourceSet{}
+	_ SourceSet           = JSONLSourceSet{}
+	_ WatchRootPlanner    = JSONLSourceSet{}
+	_ StreamingDiscoverer = JSONLSourceSet{}
+	_ SourceSet           = DirectoryJSONLSourceSet{}
+	_ WatchRootPlanner    = DirectoryJSONLSourceSet{}
 )
 
-func (s JSONLSourceSet) discoverDir(
+func (s JSONLSourceSet) discoverDirEach(
 	ctx context.Context,
 	root string,
 	dir string,
-	sources *[]SourceRef,
-	seen map[string]struct{},
+	yield func(SourceRef) error,
 ) error {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			return ctxErr
-		}
-		return nil
-	}
-	for _, entry := range entries {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
+	var incomplete error
+	err := streamDirectoryEntries(ctx, dir, func(entry os.DirEntry) error {
 		path := filepath.Join(dir, entry.Name())
-		if s.shouldDescend(entry, dir) {
+		descend, descendErr := s.shouldDescend(entry, dir)
+		if descendErr != nil {
+			incomplete = errors.Join(incomplete, incompleteDiscoveryError(
+				s.provider, "resolve symlinked JSONL directory "+path, descendErr,
+			))
+			return nil
+		}
+		if descend {
 			if s.options.Recursive && s.descendPathIncluded(root, path) {
-				if err := s.discoverDir(
-					ctx, root, path, sources, seen,
-				); err != nil {
-					return err
+				if err := s.discoverDirEach(ctx, root, path, yield); err != nil {
+					if _, ok := discoveryYieldCause(err); ok || ctx.Err() != nil {
+						return err
+					}
+					incomplete = errors.Join(incomplete, err)
 				}
 			}
-			continue
+			return nil
 		}
 		info, err := s.sourceFileInfo(entry, path)
-		if err != nil || !info.Mode().IsRegular() {
-			continue
+		if err != nil {
+			incomplete = errors.Join(incomplete, incompleteDiscoveryError(
+				s.provider, "stat JSONL source "+path, err,
+			))
+			return nil
+		}
+		if !info.Mode().IsRegular() {
+			return nil
 		}
 		source, ok := s.sourceRef(root, path, info)
 		if !ok {
-			continue
+			return nil
 		}
-		addJSONLSource(source, sources, seen)
+		if err := yield(source); err != nil {
+			return discoveryYieldError{cause: err}
+		}
+		return nil
+	})
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
 	}
-	return nil
+	if err != nil {
+		if _, ok := discoveryYieldCause(err); ok {
+			return err
+		}
+		incomplete = errors.Join(incomplete, incompleteDiscoveryError(
+			s.provider, "read JSONL directory "+dir, err,
+		))
+	}
+	return incomplete
 }
 
-func (s JSONLSourceSet) shouldDescend(entry os.DirEntry, dir string) bool {
+// shouldDescend reports whether recursive discovery should descend into
+// entry. A followed symlink whose target cannot be statted returns an error
+// rather than false: silently treating it as absent would let reconciliation
+// read an authoritative-empty discovery and tombstone the sessions beneath it.
+func (s JSONLSourceSet) shouldDescend(
+	entry os.DirEntry, dir string,
+) (bool, error) {
 	if entry.IsDir() {
-		return true
+		return true, nil
 	}
-	return s.options.FollowSymlinkDirs && isDirOrSymlink(entry, dir)
+	if !s.options.FollowSymlinkDirs {
+		return false, nil
+	}
+	return streamingDirOrSymlinkCandidate(entry, dir)
 }
 
 func (s JSONLSourceSet) sourceFileInfo(
@@ -628,9 +734,11 @@ func (s JSONLSourceSet) sourceForMissingPath(
 }
 
 // sourceForCompanionPath resolves a changed sidecar path back to the transcript
-// source that owns it. It scans discovered transcripts and returns the one whose
-// CompanionFiles list contains the changed path, so a companion write triggers a
-// re-parse of its transcript.
+// source that owns it, so a companion write triggers a re-parse of its
+// transcript. With a configured CompanionTranscript inverse, the owning
+// transcript is derived directly and resolved through the same per-path lookup
+// a transcript event uses; without one, it falls back to scanning discovered
+// transcripts for the one whose CompanionFiles list contains the changed path.
 func (s JSONLSourceSet) sourceForCompanionPath(
 	ctx context.Context,
 	path string,
@@ -639,6 +747,22 @@ func (s JSONLSourceSet) sourceForCompanionPath(
 		return SourceRef{}, false, nil
 	}
 	path = filepath.Clean(path)
+	if s.options.CompanionTranscript != nil {
+		transcript, ok := s.options.CompanionTranscript(path)
+		if !ok {
+			return SourceRef{}, false, nil
+		}
+		transcript = filepath.Clean(transcript)
+		// The forward hook stays authoritative: a path the transcript does
+		// not claim as a companion must not remap to it.
+		if !slices.ContainsFunc(
+			s.options.CompanionFiles(transcript),
+			func(companion string) bool { return samePath(companion, path) },
+		) {
+			return SourceRef{}, false, nil
+		}
+		return s.sourceForPath(ctx, transcript)
+	}
 	sources, err := s.Discover(ctx)
 	if err != nil {
 		return SourceRef{}, false, err
@@ -738,6 +862,13 @@ func (s JSONLSourceSet) discoveredSourceForCandidate(
 	ctx context.Context,
 	candidate SourceRef,
 ) (SourceRef, bool, error) {
+	if s.options.Key == nil {
+		// Keys default to the absolute source path, so they are unique by
+		// construction: discovery cannot hold a different preferred ref for
+		// this key, and scanning the archive would only re-derive candidate.
+		// Skipping it keeps per-event work bounded by the changed path.
+		return candidate, true, nil
+	}
 	discovered, err := s.Discover(ctx)
 	if err != nil {
 		return SourceRef{}, false, err

--- a/internal/parser/jsonl_source_set_companion_test.go
+++ b/internal/parser/jsonl_source_set_companion_test.go
@@ -2,8 +2,10 @@ package parser
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -114,6 +116,38 @@ func TestJSONLSourceSetCompanionChangedPathMapsToTranscript(t *testing.T) {
 	assert.Equal(t, transcript, src.Path)
 }
 
+func TestJSONLSourceSetCompanionWatchRootsStayBoundedByConfiguredRoots(t *testing.T) {
+	measure := func(t *testing.T, transcriptCount int) (int, float64) {
+		t.Helper()
+		root := t.TempDir()
+		for i := range transcriptCount {
+			transcript := filepath.Join(root, fmt.Sprintf("session-%04d.jsonl", i))
+			writeFile(t, transcript, "{}\n")
+			writeFile(t, transcript+".meta", "meta")
+		}
+		set := NewJSONLSourceSet(
+			AgentClaude,
+			[]string{root},
+			WithCompanionFiles(companionFor),
+		)
+
+		var roots []WatchRoot
+		allocs := testing.AllocsPerRun(20, func() {
+			var err error
+			roots, err = set.WatchRoots(context.Background())
+			require.NoError(t, err)
+		})
+		return len(roots), allocs
+	}
+
+	smallRoots, smallAllocs := measure(t, 1)
+	largeRoots, largeAllocs := measure(t, 500)
+	assert.Equal(t, smallRoots, largeRoots,
+		"root-plan cardinality must depend on configured roots, not transcripts")
+	assert.Equal(t, smallAllocs, largeAllocs,
+		"root planning allocations must not scale with transcript companions")
+}
+
 func TestJSONLSourceSetCompanionWatchPlanIncludesCompanionGlob(t *testing.T) {
 	ctx := context.Background()
 	root := t.TempDir()
@@ -153,4 +187,104 @@ func TestJSONLSourceSetWithoutCompanionsUnaffected(t *testing.T) {
 	// Without a companion hook the fingerprint size is exactly the transcript
 	// size, confirming the companion folding is inert when unconfigured.
 	assert.Equal(t, info.Size(), fp.Size)
+}
+
+// A companion event must resolve its owning transcript by inverse path
+// derivation, not by scanning every discovered transcript's companion list —
+// per-event work must stay bounded by the changed batch, not archive size.
+func TestJSONLSourceSetCompanionChangedPathSkipsForwardScan(t *testing.T) {
+	measure := func(t *testing.T, transcriptCount int) int {
+		t.Helper()
+		root := t.TempDir()
+		for i := range transcriptCount {
+			transcript := filepath.Join(root, fmt.Sprintf("session-%04d.jsonl", i))
+			writeFile(t, transcript, "{}\n")
+			writeFile(t, transcript+".meta", "meta")
+		}
+		forwardCalls := 0
+		set := NewJSONLSourceSet(
+			AgentClaude,
+			[]string{root},
+			WithCompanionFiles(func(transcriptPath string) []string {
+				forwardCalls++
+				return companionFor(transcriptPath)
+			}),
+			WithCompanionTranscript(func(companionPath string) (string, bool) {
+				transcript, ok := strings.CutSuffix(companionPath, ".meta")
+				return transcript, ok
+			}),
+		)
+
+		companion := filepath.Join(root, "session-0000.jsonl.meta")
+		changed, err := set.SourcesForChangedPath(context.Background(), ChangedPathRequest{
+			Path:      companion,
+			EventKind: "write",
+			WatchRoot: root,
+		})
+		require.NoError(t, err)
+		require.Len(t, changed, 1)
+		src, ok := changed[0].Opaque.(JSONLSource)
+		require.True(t, ok)
+		assert.Equal(t, filepath.Join(root, "session-0000.jsonl"), src.Path)
+		return forwardCalls
+	}
+
+	small := measure(t, 2)
+	large := measure(t, 40)
+	assert.Equal(t, small, large,
+		"companion mapping must not fan the forward hook out over the archive")
+	assert.LessOrEqual(t, small, 1,
+		"the forward hook is at most a single consistency check per event")
+}
+
+// Changed-path resolution must not materialize the archive: with the default
+// path-derived keys, the discovered set cannot hold a different preferred ref
+// for a candidate, so per-event work stays bounded by the changed path for
+// both transcript and companion events.
+func TestJSONLSourceSetChangedPathSkipsArchiveDiscovery(t *testing.T) {
+	measure := func(t *testing.T, transcriptCount int) (int, int) {
+		t.Helper()
+		root := t.TempDir()
+		for i := range transcriptCount {
+			transcript := filepath.Join(root, fmt.Sprintf("session-%04d.jsonl", i))
+			writeFile(t, transcript, "{}\n")
+			writeFile(t, transcript+".meta", "meta")
+		}
+		includeChecks := 0
+		set := NewJSONLSourceSet(
+			AgentClaude,
+			[]string{root},
+			WithIncludePath(func(root, path string) bool {
+				includeChecks++
+				return true
+			}),
+			WithCompanionFiles(companionFor),
+			WithCompanionTranscript(func(companionPath string) (string, bool) {
+				transcript, ok := strings.CutSuffix(companionPath, ".meta")
+				return transcript, ok
+			}),
+		)
+
+		resolve := func(path string) {
+			changed, err := set.SourcesForChangedPath(
+				context.Background(),
+				ChangedPathRequest{Path: path, EventKind: "write", WatchRoot: root},
+			)
+			require.NoError(t, err)
+			require.Len(t, changed, 1)
+		}
+		transcript := filepath.Join(root, "session-0000.jsonl")
+		resolve(transcript)
+		transcriptChecks := includeChecks
+		includeChecks = 0
+		resolve(transcript + ".meta")
+		return transcriptChecks, includeChecks
+	}
+
+	smallTranscript, smallCompanion := measure(t, 2)
+	largeTranscript, largeCompanion := measure(t, 40)
+	assert.Equal(t, smallTranscript, largeTranscript,
+		"transcript events must not scan the archive")
+	assert.Equal(t, smallCompanion, largeCompanion,
+		"companion events must not scan the archive")
 }

--- a/internal/parser/jsonl_source_set_options.go
+++ b/internal/parser/jsonl_source_set_options.go
@@ -142,3 +142,15 @@ func WithForceReplace() JSONLOption {
 func WithCompanionFiles(fn func(transcriptPath string) []string) JSONLOption {
 	return func(o *JSONLSourceSetOptions) { o.CompanionFiles = fn }
 }
+
+// WithCompanionTranscript registers the inverse of WithCompanionFiles: given a
+// changed sidecar path, derive the owning transcript path directly. With the
+// inverse configured, a companion event resolves through the same per-path
+// lookup as a transcript event instead of scanning every discovered
+// transcript's companion list, keeping per-event work bounded by the changed
+// batch. Return ok=false when the path is not a recognizable companion.
+func WithCompanionTranscript(
+	fn func(companionPath string) (transcriptPath string, ok bool),
+) JSONLOption {
+	return func(o *JSONLSourceSetOptions) { o.CompanionTranscript = fn }
+}

--- a/internal/parser/jsonl_source_set_test.go
+++ b/internal/parser/jsonl_source_set_test.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -54,6 +55,169 @@ func TestJSONLSourceSetDiscoverRecursiveStableSources(t *testing.T) {
 		assert.IsType(t, JSONLSource{}, source.Opaque)
 	}
 }
+
+func TestJSONLSourceSetStreamingDiscoveryPropagatesTraversalErrors(t *testing.T) {
+	t.Run("configured root is not a directory", func(t *testing.T) {
+		root := filepath.Join(t.TempDir(), "root.jsonl")
+		writeSourceFile(t, root, "{}\n")
+		set := NewJSONLSourceSet(AgentCodex, []string{root})
+
+		err := set.DiscoverEach(t.Context(), func(SourceRef) error { return nil })
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a directory")
+	})
+
+	t.Run("followed source stat", func(t *testing.T) {
+		root := t.TempDir()
+		require.NoError(t, os.Symlink(
+			filepath.Join(root, "missing-target"), filepath.Join(root, "a-broken.jsonl"),
+		))
+		writeSourceFile(t, filepath.Join(root, "z-healthy.jsonl"), "{}\n")
+		set := NewJSONLSourceSet(
+			AgentCodex, []string{root}, WithFollowSymlinkFiles(),
+		)
+		var yielded []string
+
+		err := set.DiscoverEach(t.Context(), func(source SourceRef) error {
+			yielded = append(yielded, source.DisplayPath)
+			return nil
+		})
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, os.ErrNotExist)
+		var incomplete DiscoveryIncompleteError
+		assert.ErrorAs(t, err, &incomplete)
+		assert.Equal(t, []string{filepath.Join(root, "z-healthy.jsonl")}, yielded)
+	})
+
+	t.Run("followed directory symlink stat", func(t *testing.T) {
+		root := t.TempDir()
+		target := filepath.Join(t.TempDir(), "linked-dir")
+		require.NoError(t, os.MkdirAll(target, 0o755))
+		link := filepath.Join(root, "a-linked")
+		if err := os.Symlink(target, link); err != nil {
+			t.Skipf("symlink not supported: %v", err)
+		}
+		require.NoError(t, os.RemoveAll(target))
+		writeSourceFile(t, filepath.Join(root, "z-healthy.jsonl"), "{}\n")
+		// No exported option follows directory symlinks without also
+		// following file symlinks, whose own stat failure would mask
+		// the directory-descent path under test; build the
+		// directory-only configuration directly.
+		set := jsonlSourceSetFromOptions(AgentCodex, []string{root},
+			JSONLSourceSetOptions{Recursive: true, FollowSymlinkDirs: true})
+		var yielded []string
+
+		err := set.DiscoverEach(t.Context(), func(source SourceRef) error {
+			yielded = append(yielded, source.DisplayPath)
+			return nil
+		})
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, os.ErrNotExist)
+		var incomplete DiscoveryIncompleteError
+		assert.ErrorAs(t, err, &incomplete)
+		assert.Equal(t, []string{filepath.Join(root, "z-healthy.jsonl")}, yielded)
+	})
+
+	t.Run("entry info race continues healthy sibling", func(t *testing.T) {
+		root := t.TempDir()
+		healthy := filepath.Join(root, "z-healthy.jsonl")
+		writeSourceFile(t, healthy, "{}\n")
+		ctx := withStreamingDirectoryReader(t.Context(), func(
+			_ context.Context, _ string, yield func(os.DirEntry) error,
+		) error {
+			if err := yield(failingInfoDirEntry{
+				name: "a-vanished.jsonl", err: os.ErrNotExist,
+			}); err != nil {
+				return err
+			}
+			entries, err := os.ReadDir(root)
+			if err != nil {
+				return err
+			}
+			return yield(entries[0])
+		})
+		set := NewJSONLSourceSet(AgentCodex, []string{root})
+		var yielded []string
+
+		err := set.DiscoverEach(ctx, func(source SourceRef) error {
+			yielded = append(yielded, source.DisplayPath)
+			return nil
+		})
+
+		assert.ErrorIs(t, err, os.ErrNotExist)
+		var incomplete DiscoveryIncompleteError
+		assert.ErrorAs(t, err, &incomplete)
+		assert.Equal(t, []string{healthy}, yielded)
+	})
+
+	t.Run("nested directory read continues healthy sibling", func(t *testing.T) {
+		root := t.TempDir()
+		nested := filepath.Join(root, "a-nested")
+		require.NoError(t, os.Mkdir(nested, 0o755))
+		healthy := filepath.Join(root, "z-healthy.jsonl")
+		writeSourceFile(t, healthy, "{}\n")
+		injected := errors.New("nested directory read failed")
+		ctx := withStreamingDirectoryReader(t.Context(), func(
+			ctx context.Context, dir string, yield func(os.DirEntry) error,
+		) error {
+			if samePath(dir, nested) {
+				return injected
+			}
+			entries, err := os.ReadDir(dir)
+			if err != nil {
+				return err
+			}
+			for _, entry := range entries {
+				if err := yield(entry); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		set := NewJSONLSourceSet(AgentCodex, []string{root}, WithRecursive())
+		var yielded []string
+
+		err := set.DiscoverEach(ctx, func(source SourceRef) error {
+			yielded = append(yielded, source.DisplayPath)
+			return nil
+		})
+
+		assert.ErrorIs(t, err, injected)
+		var incomplete DiscoveryIncompleteError
+		assert.ErrorAs(t, err, &incomplete)
+		assert.Equal(t, []string{healthy}, yielded)
+	})
+
+	t.Run("yield error aborts immediately", func(t *testing.T) {
+		root := t.TempDir()
+		writeSourceFile(t, filepath.Join(root, "a.jsonl"), "{}\n")
+		writeSourceFile(t, filepath.Join(root, "b.jsonl"), "{}\n")
+		set := NewJSONLSourceSet(AgentCodex, []string{root})
+		injected := errors.New("stop consumer")
+		calls := 0
+
+		err := set.DiscoverEach(t.Context(), func(SourceRef) error {
+			calls++
+			return injected
+		})
+
+		assert.ErrorIs(t, err, injected)
+		assert.Equal(t, 1, calls)
+	})
+}
+
+type failingInfoDirEntry struct {
+	name string
+	err  error
+}
+
+func (entry failingInfoDirEntry) Name() string               { return entry.name }
+func (failingInfoDirEntry) IsDir() bool                      { return false }
+func (failingInfoDirEntry) Type() os.FileMode                { return 0 }
+func (entry failingInfoDirEntry) Info() (os.FileInfo, error) { return nil, entry.err }
 
 func TestJSONLSourceSetShallowDiscoveryAndFilters(t *testing.T) {
 	root := t.TempDir()
@@ -155,6 +319,37 @@ func TestJSONLSourceSetWatchChangedPathFindAndFingerprint(t *testing.T) {
 	assert.Equal(t, info.Size(), fingerprint.Size)
 	assert.Equal(t, info.ModTime().UnixNano(), fingerprint.MTimeNS)
 	assert.Equal(t, fmt.Sprintf("%x", sha256.Sum256([]byte(content))), fingerprint.Hash)
+}
+
+func TestJSONLSourceSetWatchRootsReturnsBoundedMetadata(t *testing.T) {
+	root := t.TempDir()
+	otherRoot := filepath.Join(t.TempDir(), "sessions")
+	companionCalls := 0
+	sources := NewJSONLSourceSet(
+		AgentCodex,
+		[]string{root, otherRoot},
+		WithRecursive(),
+		WithCompanionFiles(func(transcriptPath string) []string {
+			companionCalls++
+			return []string{transcriptPath + ".meta"}
+		}),
+	)
+
+	roots, err := sources.WatchRoots(context.Background())
+	require.NoError(t, err)
+	require.Len(t, roots, 2)
+	assert.Equal(t, WatchRoot{
+		Path:        root,
+		Recursive:   true,
+		DebounceKey: string(AgentCodex) + ":jsonl:" + root,
+	}, roots[0])
+	assert.Equal(t, WatchRoot{
+		Path:        otherRoot,
+		Recursive:   true,
+		DebounceKey: string(AgentCodex) + ":jsonl:" + otherRoot,
+	}, roots[1])
+	assert.Zero(t, companionCalls,
+		"root scheduling must not enumerate transcripts or companions")
 }
 
 func TestJSONLSourceSetChangedPathClassifiesDeletedFiles(t *testing.T) {

--- a/internal/parser/kilo_legacy_test.go
+++ b/internal/parser/kilo_legacy_test.go
@@ -366,7 +366,7 @@ func TestParseKiloLegacySessionMCPResponsePairs(t *testing.T) {
 		{"ts": 1700000000000, "type": "say", "say": "text",
 			"text": "Use MCP"},
 		{"ts": 1700000001000, "type": "ask",
-			"ask": "use_mcp_server",
+			"ask":  "use_mcp_server",
 			"text": `{"type":"use_mcp_tool","serverName":"brave","toolName":"search","arguments":"{\"query\":\"agentsview\"}"}`},
 		{"ts": 1700000002000, "type": "say",
 			"say":  "mcp_server_response",
@@ -404,7 +404,7 @@ func TestParseKiloLegacySessionMCPUseMcpToolShape(t *testing.T) {
 		{"ts": 1700000000000, "type": "say", "say": "text",
 			"text": "Use MCP"},
 		{"ts": 1700000001000, "type": "ask",
-			"ask": "use_mcp_server",
+			"ask":  "use_mcp_server",
 			"text": `{"type":"use_mcp_tool","serverName":"chrome-devtools","toolName":"take_snapshot","arguments":"{\"verbose\":false}"}`},
 		{"ts": 1700000002000, "type": "say",
 			"say":  "mcp_server_response",
@@ -1065,7 +1065,7 @@ func TestParseKiloLegacySessionCodebaseSearchResultPairs(t *testing.T) {
 		{Timestamp: 1688836852000, Type: "ask", Ask: "tool",
 			Text: `{"tool":"codebaseSearch","query":"find foo","path":null}`},
 		{Timestamp: 1688836853000, Type: "say",
-			Say: "codebase_search_result",
+			Say:  "codebase_search_result",
 			Text: `{"tool":"codebaseSearch","content":{"query":"find foo","results":[{"filePath":"src/foo.ts","score":0.9}]}}`},
 	}
 	mustWriteJSON(t, filepath.Join(taskDir, "ui_messages.json"), msgs)
@@ -1107,7 +1107,7 @@ func TestParseKiloLegacySessionCodebaseSearchResultStandalone(t *testing.T) {
 	msgs := []kiloLegacyMessage{
 		{Timestamp: 1688836851000, Type: "say", Say: "text", Text: "task"},
 		{Timestamp: 1688836852000, Type: "say",
-			Say: "codebase_search_result",
+			Say:  "codebase_search_result",
 			Text: `{"tool":"codebaseSearch","content":{"query":"orphan","results":[]}}`},
 	}
 	mustWriteJSON(t, filepath.Join(taskDir, "ui_messages.json"), msgs)

--- a/internal/parser/kiro_provider.go
+++ b/internal/parser/kiro_provider.go
@@ -49,6 +49,10 @@ func (p *kiroProvider) Discover(ctx context.Context) ([]SourceRef, error) {
 	return p.sources.Discover(ctx)
 }
 
+func (p *kiroProvider) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	return p.sources.DiscoverEach(ctx, yield)
+}
+
 func (p *kiroProvider) WatchPlan(ctx context.Context) (WatchPlan, error) {
 	return p.sources.WatchPlan(ctx)
 }
@@ -58,6 +62,12 @@ func (p *kiroProvider) SourcesForChangedPath(
 	req ChangedPathRequest,
 ) ([]SourceRef, error) {
 	return p.sources.SourcesForChangedPath(ctx, req)
+}
+
+func (p *kiroProvider) StoredSourceHintScopes(
+	req ChangedPathRequest,
+) []StoredSourceHintScope {
+	return p.sources.StoredSourceHintScopes(req)
 }
 
 func (p *kiroProvider) FindSource(
@@ -73,6 +83,24 @@ func (p *kiroProvider) Fingerprint(
 	source SourceRef,
 ) (SourceFingerprint, error) {
 	return p.sources.Fingerprint(ctx, source)
+}
+
+func (p *kiroProvider) PersistentArchiveSource(
+	path string, fullSessionID string,
+) (string, bool) {
+	rawSessionID := ProviderRawSessionIDFromFull(p.Def, fullSessionID)
+	for _, root := range p.sources.roots {
+		source, ok := p.sources.sourceRef(root, path, true)
+		if !ok {
+			continue
+		}
+		src, ok := p.sources.sourceFromRef(source)
+		if ok && src.Kind == kiroSourceSQLiteSession &&
+			rawSessionID != "" && src.SessionID == rawSessionID {
+			return src.DBPath, true
+		}
+	}
+	return "", false
 }
 
 func (p *kiroProvider) Parse(
@@ -305,6 +333,51 @@ func (s kiroSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
 	return sources, nil
 }
 
+func (s kiroSourceSet) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	for _, root := range s.roots {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if dbPath := kiroSQLiteDBPath(root); dbPath != "" {
+			store, err := OpenKiroSQLiteStore(dbPath)
+			if err != nil {
+				return err
+			}
+			err = store.ForEachSessionMeta(ctx, func(meta KiroSQLiteSessionMeta) error {
+				source := s.newSourceRef(
+					root, meta.VirtualPath, dbPath, meta.SessionID,
+					kiroSourceSQLiteSession,
+				)
+				source.DiscoveryMTimeNS = meta.FileMtime
+				return yield(source)
+			})
+			closeErr := store.Close()
+			if err != nil {
+				return err
+			}
+			if closeErr != nil {
+				return closeErr
+			}
+		}
+		if err := streamDirectoryEntries(ctx, root, func(entry os.DirEntry) error {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".jsonl") {
+				return nil
+			}
+			path := filepath.Join(root, entry.Name())
+			if s.legacyPathShadowed(path) {
+				return nil
+			}
+			if source, ok := s.sourceRef(root, path, false); ok {
+				return yield(source)
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (s kiroSourceSet) WatchPlan(context.Context) (WatchPlan, error) {
 	roots := make([]WatchRoot, 0, len(s.roots))
 	for _, root := range s.roots {
@@ -341,6 +414,34 @@ func (s kiroSourceSet) SourcesForChangedPath(
 		return sources, nil
 	}
 	return nil, nil
+}
+
+func (s kiroSourceSet) StoredSourceHintScopes(
+	req ChangedPathRequest,
+) []StoredSourceHintScope {
+	for _, root := range s.roots {
+		if req.WatchRoot != "" && !samePath(req.WatchRoot, root) {
+			continue
+		}
+		source, ok := s.sourceRefForChangedPath(root, req.Path)
+		if !ok {
+			continue
+		}
+		src, ok := s.sourceFromRef(source)
+		if !ok {
+			return nil
+		}
+		switch src.Kind {
+		case kiroSourceSQLiteDB:
+			return []StoredSourceHintScope{{
+				Path: src.DBPath, IncludeVirtualMembers: true,
+			}}
+		case kiroSourceSQLiteSession, kiroSourceLegacyJSONL:
+			return []StoredSourceHintScope{{Path: src.Path}}
+		}
+		return nil
+	}
+	return nil
 }
 
 // changedPathTombstones emits a per-session source for every stored Kiro SQLite
@@ -549,6 +650,9 @@ func (s kiroSourceSet) sourceRef(
 ) (SourceRef, bool) {
 	root = filepath.Clean(root)
 	path = filepath.Clean(path)
+	if kiroLegacyPathUnderRoot(root, path) && IsRegularFile(path) {
+		return s.newSourceRef(root, path, "", "", kiroSourceLegacyJSONL), true
+	}
 	if dbPath, sessionID, ok := kiroSQLiteVirtualPathParts(path); ok {
 		if !kiroDBUnderRoot(root, dbPath, !allowMissing) {
 			return SourceRef{}, false
@@ -573,6 +677,9 @@ func (s kiroSourceSet) sourceRefForChangedPath(root, path string) (SourceRef, bo
 	}
 	root = filepath.Clean(root)
 	path = filepath.Clean(path)
+	if kiroLegacyPathUnderRoot(root, path) {
+		return s.newSourceRef(root, path, "", "", kiroSourceLegacyJSONL), true
+	}
 	if dbPath, sessionID, ok := kiroSQLiteVirtualPathParts(path); ok {
 		if !kiroDBUnderRoot(root, dbPath, false) {
 			return SourceRef{}, false
@@ -581,9 +688,6 @@ func (s kiroSourceSet) sourceRefForChangedPath(root, path string) (SourceRef, bo
 	}
 	if dbPath, ok := kiroDBPathForEvent(root, path); ok {
 		return s.newSourceRef(root, dbPath, dbPath, "", kiroSourceSQLiteDB), true
-	}
-	if kiroLegacyPathUnderRoot(root, path) {
-		return s.newSourceRef(root, path, "", "", kiroSourceLegacyJSONL), true
 	}
 	return SourceRef{}, false
 }
@@ -669,10 +773,12 @@ func kiroLegacyPathUnderRoot(root, path string) bool {
 
 func kiroProviderCapabilities() Capabilities {
 	source := jsonlFileProviderSourceCapabilities()
+	source.StreamingDiscovery = CapabilitySupported
 	source.StoredSourceHints = CapabilitySupported
 	source.MultiSessionSource = CapabilitySupported
 	source.PerSessionErrors = CapabilitySupported
 	source.ForceReplaceOnParse = CapabilitySupported
+	source.PersistentArchive = CapabilitySupported
 	return Capabilities{
 		Source: source,
 		Content: ContentCapabilities{

--- a/internal/parser/kiro_sqlite.go
+++ b/internal/parser/kiro_sqlite.go
@@ -1,11 +1,11 @@
 package parser
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"time"
 
@@ -135,46 +135,60 @@ func ListKiroSQLiteSessionMeta(
 // ListSessionMeta returns one metadata row per logical conversation
 // using the store's existing SQLite handle.
 func (s *KiroSQLiteStore) ListSessionMeta() ([]KiroSQLiteSessionMeta, error) {
+	var metas []KiroSQLiteSessionMeta
+	err := s.ForEachSessionMeta(context.Background(), func(meta KiroSQLiteSessionMeta) error {
+		metas = append(metas, meta)
+		return nil
+	})
+	return metas, err
+}
+
+// ForEachSessionMeta streams one metadata row per logical conversation using
+// the store's existing SQLite handle. The query orders rows so callers never
+// need an archive-sized Go slice or membership map.
+func (s *KiroSQLiteStore) ForEachSessionMeta(
+	ctx context.Context, yield func(KiroSQLiteSessionMeta) error,
+) error {
 	if s == nil || s.db == nil {
-		return nil, fmt.Errorf("kiro sqlite store is closed")
+		return fmt.Errorf("kiro sqlite store is closed")
 	}
-	rows, err := s.db.Query(`
+	rows, err := s.db.QueryContext(ctx, `
 		SELECT conversation_id, MAX(updated_at)
 		  FROM conversations_v2
 		 GROUP BY conversation_id
+		 ORDER BY conversation_id
 	`)
 	if err != nil {
-		return nil, fmt.Errorf(
+		return fmt.Errorf(
 			"listing kiro sqlite sessions: %w", err,
 		)
 	}
 	defer rows.Close()
 
-	var metas []KiroSQLiteSessionMeta
 	for rows.Next() {
 		var id string
 		var updatedAt int64
 		if err := rows.Scan(&id, &updatedAt); err != nil {
-			return nil, fmt.Errorf(
+			return fmt.Errorf(
 				"scanning kiro sqlite session meta: %w", err,
 			)
 		}
 		if id == "" {
 			continue
 		}
-		metas = append(metas, KiroSQLiteSessionMeta{
+		observeStreamingDiscoveryBuffer(ctx, 1)
+		if err := yield(KiroSQLiteSessionMeta{
 			SessionID:   id,
 			VirtualPath: KiroSQLiteVirtualPath(s.dbPath, id),
 			FileMtime:   updatedAt * 1_000_000,
-		})
+		}); err != nil {
+			return err
+		}
 	}
 	if err := rows.Err(); err != nil {
-		return nil, err
+		return err
 	}
-	sort.Slice(metas, func(i, j int) bool {
-		return metas[i].SessionID < metas[j].SessionID
-	})
-	return metas, nil
+	return nil
 }
 
 // KiroSQLiteSessionIDs returns the set of current-store logical

--- a/internal/parser/linereader.go
+++ b/internal/parser/linereader.go
@@ -80,15 +80,27 @@ func releaseLineReader(lr *lineReader) {
 // or ("", false) at EOF or read error. After the loop, call Err()
 // to distinguish EOF from I/O failure.
 func (lr *lineReader) next() (string, bool) {
+	line, ok := lr.nextBytes()
+	if !ok {
+		return "", false
+	}
+	return string(line), true
+}
+
+// nextBytes returns the next line as storage borrowed from the reader. The
+// bytes remain valid only until the next call. Callers that retain a line must
+// copy it; callers that only classify or discard it can avoid allocating a
+// string proportional to the source record.
+func (lr *lineReader) nextBytes() ([]byte, bool) {
 	for {
-		line, err := lr.readLine()
+		line, err := lr.readLineBytes()
 		if err != nil {
 			if err != io.EOF {
 				lr.err = err
 			}
-			return "", false
+			return nil, false
 		}
-		if line != "" {
+		if len(line) != 0 {
 			return line, true
 		}
 		// Empty line or skipped oversized line — continue.
@@ -111,7 +123,7 @@ func (lr *lineReader) updateBytesRead() {
 	}
 }
 
-func (lr *lineReader) readLine() (string, error) {
+func (lr *lineReader) readLineBytes() ([]byte, error) {
 	lr.buf = lr.buf[:0]
 	oversized := false
 
@@ -122,13 +134,13 @@ func (lr *lineReader) readLine() (string, error) {
 				lr.updateBytesRead()
 				break
 			}
-			return "", err
+			return nil, err
 		}
 
 		if oversized {
 			if !isPrefix {
 				lr.updateBytesRead()
-				return "", nil // done skipping
+				return nil, nil // done skipping
 			}
 			continue
 		}
@@ -139,9 +151,9 @@ func (lr *lineReader) readLine() (string, error) {
 		if len(lr.buf) == 0 && !isPrefix {
 			lr.updateBytesRead()
 			if len(chunk) > lr.maxLen {
-				return "", nil
+				return nil, nil
 			}
-			return string(chunk), nil
+			return chunk, nil
 		}
 
 		lr.buf = append(lr.buf, chunk...)
@@ -151,7 +163,7 @@ func (lr *lineReader) readLine() (string, error) {
 			lr.buf = lr.buf[:0]
 			if !isPrefix {
 				lr.updateBytesRead()
-				return "", nil
+				return nil, nil
 			}
 			continue
 		}
@@ -162,7 +174,7 @@ func (lr *lineReader) readLine() (string, error) {
 		}
 	}
 
-	return string(lr.buf), nil
+	return lr.buf, nil
 }
 
 // readJSONLFrom opens a JSONL file, seeks to offset, and

--- a/internal/parser/multi_session_container.go
+++ b/internal/parser/multi_session_container.go
@@ -35,10 +35,12 @@ type multiSessionSource struct {
 // physical container and, for a member, its ID. ProjectHint is surfaced on the
 // SourceRef for providers that attribute a project at discovery time.
 type multiSessionMatch struct {
-	Path        string
-	Container   string
-	MemberID    string
-	ProjectHint string
+	Path                   string
+	Container              string
+	MemberID               string
+	ReconciliationIdentity string
+	ProjectHint            string
+	DiscoveryMTimeNS       int64
 }
 
 type multiSessionConfig struct {
@@ -50,6 +52,7 @@ type multiSessionConfig struct {
 	// discovery time rather than one source per container. Mutually exclusive
 	// with discoverContainers.
 	discoverSources func(root string) []multiSessionMatch
+	discoverEach    func(context.Context, string, func(multiSessionMatch) error) error
 	// watchRoots returns the provider WatchPlan roots for the configured roots.
 	watchRoots func(roots []string) []WatchRoot
 	// classifyPath maps a stored or changed path to its container/member.
@@ -58,13 +61,22 @@ type multiSessionConfig struct {
 	classifyPath func(root, path string, allowMissing bool) (multiSessionMatch, bool)
 	// findMember resolves a raw session ID to its member match under one root.
 	findMember func(root, rawID string) (multiSessionMatch, bool)
+	// reconciliationIdentity restores the stable SourceRef key for an exact
+	// member reconstructed from its stored path. Optional; positional sources
+	// use the reconciliation cache to avoid rescanning their container.
+	reconciliationIdentity func(context.Context, multiSessionMatch) (string, error)
+	// storedReconciliationIdentity derives the matching identity from a stored
+	// full session ID. It is paired with reconciliationIdentity so the engine
+	// does not need provider-specific identity policy.
+	storedReconciliationIdentity func(string) string
 	// storedPathFallback resolves a stored path that classifyPath could not
 	// match directly (for example a canonical remote-sync path that must be
 	// mapped back onto a local container). Optional.
 	storedPathFallback func(root, path string) (multiSessionMatch, bool)
 	// fingerprint returns the source freshness fingerprint (Size/MTime/Hash);
 	// the base supplies the Key.
-	fingerprint func(src multiSessionSource) (SourceFingerprint, error)
+	fingerprint        func(src multiSessionSource) (SourceFingerprint, error)
+	fingerprintContext func(context.Context, multiSessionSource) (SourceFingerprint, error)
 	// parseContainerOutcome optionally builds the full container outcome
 	// directly, for providers that need container-level completeness or
 	// no-session semantics beyond a flat []ParseResult.
@@ -74,7 +86,8 @@ type multiSessionConfig struct {
 	// per-request hints such as req.Source.ProjectHint.
 	parseContainer func(src multiSessionSource, req ParseRequest) ([]ParseResult, error)
 	// parseMember parses a single member; a nil result is a clean no-session.
-	parseMember func(src multiSessionSource, req ParseRequest) (*ParseResult, error)
+	parseMember        func(src multiSessionSource, req ParseRequest) (*ParseResult, error)
+	parseMemberContext func(context.Context, multiSessionSource, ParseRequest) (*ParseResult, error)
 	// memberPresent reports whether a source still exists for RequireFreshSource
 	// lookups. Optional; the default treats every source as present.
 	memberPresent func(src multiSessionSource) bool
@@ -101,17 +114,19 @@ func multiSessionContainerSourceCapabilities(
 	storedSourceHints CapabilitySupport,
 ) SourceCapabilities {
 	return SourceCapabilities{
-		DiscoverSources:      CapabilitySupported,
-		WatchSources:         CapabilitySupported,
-		ClassifyChangedPath:  CapabilitySupported,
-		StoredSourceHints:    storedSourceHints,
-		FindSource:           CapabilitySupported,
-		CompositeFingerprint: compositeFingerprint,
-		IncrementalAppend:    CapabilityNotApplicable,
-		MultiSessionSource:   CapabilitySupported,
-		PerSessionErrors:     CapabilityNotApplicable,
-		ExcludedSessions:     CapabilityNotApplicable,
-		ForceReplaceOnParse:  CapabilitySupported,
+		DiscoverSources:       CapabilitySupported,
+		StreamingDiscovery:    CapabilitySupported,
+		WatchSources:          CapabilitySupported,
+		ClassifyChangedPath:   CapabilitySupported,
+		StoredSourceHints:     storedSourceHints,
+		FindSource:            CapabilitySupported,
+		CompositeFingerprint:  compositeFingerprint,
+		IncrementalAppend:     CapabilityNotApplicable,
+		MultiSessionSource:    CapabilitySupported,
+		SharedContainerSource: CapabilitySupported,
+		PerSessionErrors:      CapabilityNotApplicable,
+		ExcludedSessions:      CapabilityNotApplicable,
+		ForceReplaceOnParse:   CapabilitySupported,
 	}
 }
 
@@ -123,6 +138,12 @@ func WithSourceDiscovery(
 	fn func(root string) []multiSessionMatch,
 ) MultiSessionOption {
 	return func(c *multiSessionConfig) { c.discoverSources = fn }
+}
+
+func WithStreamingSourceDiscovery(
+	fn func(context.Context, string, func(multiSessionMatch) error) error,
+) MultiSessionOption {
+	return func(c *multiSessionConfig) { c.discoverEach = fn }
 }
 
 func WithWatchRoots(fn func(roots []string) []WatchRoot) MultiSessionOption {
@@ -141,6 +162,16 @@ func WithMemberLookup(
 	return func(c *multiSessionConfig) { c.findMember = fn }
 }
 
+func WithReconciliationIdentity(
+	fn func(context.Context, multiSessionMatch) (string, error),
+	stored func(string) string,
+) MultiSessionOption {
+	return func(c *multiSessionConfig) {
+		c.reconciliationIdentity = fn
+		c.storedReconciliationIdentity = stored
+	}
+}
+
 func WithStoredPathFallback(
 	fn func(root, path string) (multiSessionMatch, bool),
 ) MultiSessionOption {
@@ -151,6 +182,12 @@ func WithFingerprint(
 	fn func(src multiSessionSource) (SourceFingerprint, error),
 ) MultiSessionOption {
 	return func(c *multiSessionConfig) { c.fingerprint = fn }
+}
+
+func WithContextFingerprint(
+	fn func(context.Context, multiSessionSource) (SourceFingerprint, error),
+) MultiSessionOption {
+	return func(c *multiSessionConfig) { c.fingerprintContext = fn }
 }
 
 func WithContainerParse(
@@ -169,6 +206,12 @@ func WithMemberParse(
 	fn func(src multiSessionSource, req ParseRequest) (*ParseResult, error),
 ) MultiSessionOption {
 	return func(c *multiSessionConfig) { c.parseMember = fn }
+}
+
+func WithContextMemberParse(
+	fn func(context.Context, multiSessionSource, ParseRequest) (*ParseResult, error),
+) MultiSessionOption {
+	return func(c *multiSessionConfig) { c.parseMemberContext = fn }
 }
 
 func WithMemberPresence(fn func(src multiSessionSource) bool) MultiSessionOption {
@@ -201,7 +244,7 @@ func NewMultiSessionContainerSourceSet(
 		opt(&cfg)
 	}
 	switch {
-	case cfg.discoverContainers == nil && cfg.discoverSources == nil:
+	case cfg.discoverContainers == nil && cfg.discoverSources == nil && cfg.discoverEach == nil:
 		panic("multi-session container: missing WithContainerDiscovery or WithSourceDiscovery")
 	case cfg.watchRoots == nil:
 		panic("multi-session container: missing WithWatchRoots")
@@ -209,11 +252,11 @@ func NewMultiSessionContainerSourceSet(
 		panic("multi-session container: missing WithChangedPathClassifier")
 	case cfg.findMember == nil:
 		panic("multi-session container: missing WithMemberLookup")
-	case cfg.fingerprint == nil:
+	case cfg.fingerprint == nil && cfg.fingerprintContext == nil:
 		panic("multi-session container: missing WithFingerprint")
 	case cfg.parseContainer == nil && cfg.parseContainerOutcome == nil:
 		panic("multi-session container: missing WithContainerParse or WithContainerParseOutcome")
-	case cfg.parseMember == nil:
+	case cfg.parseMember == nil && cfg.parseMemberContext == nil:
 		panic("multi-session container: missing WithMemberParse")
 	}
 	return multiSessionContainerSourceSet{
@@ -239,14 +282,43 @@ func (s multiSessionContainerSourceSet) Discover(
 			return nil, err
 		}
 		for _, match := range s.discoverMatches(root) {
-			if match.Path == "" {
-				continue
+			if match.Path != "" {
+				addJSONLSource(s.sourceRef(root, match), &sources, seen)
 			}
-			addJSONLSource(s.sourceRef(root, match), &sources, seen)
 		}
 	}
 	sortJSONLSources(sources)
 	return sources, nil
+}
+
+func (s multiSessionContainerSourceSet) DiscoverEach(
+	ctx context.Context, yield func(SourceRef) error,
+) error {
+	for _, root := range s.roots {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if s.cfg.discoverEach != nil {
+			if err := s.cfg.discoverEach(ctx, root, func(match multiSessionMatch) error {
+				if match.Path == "" {
+					return nil
+				}
+				return yield(s.sourceRef(root, match))
+			}); err != nil {
+				return err
+			}
+			continue
+		}
+		for _, match := range s.discoverMatches(root) {
+			if match.Path == "" {
+				continue
+			}
+			if err := yield(s.sourceRef(root, match)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // discoverMatches yields the discovery matches for one root: either the
@@ -302,6 +374,77 @@ func (s multiSessionContainerSourceSet) SourcesForChangedPath(
 		return sources, nil
 	}
 	return nil, nil
+}
+
+func (s multiSessionContainerSourceSet) StoredSourceHintScopes(
+	req ChangedPathRequest,
+) []StoredSourceHintScope {
+	for _, root := range s.roots {
+		match, ok := s.cfg.classifyPath(root, req.Path, true)
+		if !ok || match.Container == "" {
+			continue
+		}
+		if match.MemberID != "" && match.Path != "" {
+			return []StoredSourceHintScope{{Path: match.Path}}
+		}
+		return []StoredSourceHintScope{{
+			Path: match.Container, IncludeVirtualMembers: true,
+		}}
+	}
+	return nil
+}
+
+func (s multiSessionContainerSourceSet) SourceForReconciliation(
+	ctx context.Context, path, project string,
+) (SourceRef, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return SourceRef{}, false, err
+	}
+	for _, root := range s.roots {
+		match, ok := s.cfg.classifyPath(root, path, false)
+		if !ok {
+			continue
+		}
+		if project != "" {
+			match.ProjectHint = project
+		}
+		if s.cfg.reconciliationIdentity != nil {
+			identity, err := s.cfg.reconciliationIdentity(ctx, match)
+			if err != nil {
+				return SourceRef{}, false, err
+			}
+			match.ReconciliationIdentity = identity
+		}
+		return s.sourceRef(root, match), true, nil
+	}
+	return SourceRef{}, false, nil
+}
+
+func (s multiSessionContainerSourceSet) PersistentArchiveSource(
+	path string, fullSessionID string,
+) (string, bool) {
+	def, ok := AgentByType(s.agent)
+	if !ok {
+		return "", false
+	}
+	rawSessionID := ProviderRawSessionIDFromFull(def, fullSessionID)
+	for _, root := range s.roots {
+		match, ok := s.cfg.classifyPath(root, path, true)
+		if ok && match.MemberID != "" && match.MemberID == rawSessionID &&
+			match.Container != "" {
+			return match.Container, true
+		}
+	}
+	return "", false
+}
+
+func (s multiSessionContainerSourceSet) ReconciliationMemberIdentity(
+	fullSessionID string,
+) string {
+	if s.cfg.storedReconciliationIdentity == nil {
+		return ""
+	}
+	return s.cfg.storedReconciliationIdentity(fullSessionID)
 }
 
 // changedPathTombstones emits a per-member source for every stored member that
@@ -462,7 +605,13 @@ func (s multiSessionContainerSourceSet) Fingerprint(
 	if !ok {
 		return SourceFingerprint{}, fmt.Errorf("%s source path unavailable", s.agent)
 	}
-	fingerprint, err := s.cfg.fingerprint(src)
+	var fingerprint SourceFingerprint
+	var err error
+	if s.cfg.fingerprintContext != nil {
+		fingerprint, err = s.cfg.fingerprintContext(ctx, src)
+	} else {
+		fingerprint, err = s.cfg.fingerprint(src)
+	}
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) &&
 			multiSessionSourceOwnsContainer(src) {
@@ -478,11 +627,17 @@ func (s multiSessionContainerSourceSet) Fingerprint(
 }
 
 func (s multiSessionContainerSourceSet) parse(
-	src multiSessionSource, req ParseRequest,
+	ctx context.Context, src multiSessionSource, req ParseRequest,
 ) (ParseOutcome, error) {
 	fingerprintHash := req.Fingerprint.Hash
 	if src.MemberID != "" {
-		result, err := s.cfg.parseMember(src, req)
+		var result *ParseResult
+		var err error
+		if s.cfg.parseMemberContext != nil {
+			result, err = s.cfg.parseMemberContext(ctx, src, req)
+		} else {
+			result, err = s.cfg.parseMember(src, req)
+		}
 		if err != nil {
 			return ParseOutcome{}, err
 		}
@@ -609,12 +764,14 @@ func (s multiSessionContainerSourceSet) sourceRef(
 	root string, match multiSessionMatch,
 ) SourceRef {
 	return SourceRef{
-		Provider:       s.agent,
-		Key:            match.Path,
-		DisplayPath:    match.Path,
-		FingerprintKey: match.Path,
-		ProjectHint:    match.ProjectHint,
-		Opaque:         match.toSource(root),
+		Provider:               s.agent,
+		Key:                    match.Path,
+		DisplayPath:            match.Path,
+		FingerprintKey:         match.Path,
+		ReconciliationIdentity: match.ReconciliationIdentity,
+		ProjectHint:            match.ProjectHint,
+		DiscoveryMTimeNS:       match.DiscoveryMTimeNS,
+		Opaque:                 match.toSource(root),
 	}
 }
 
@@ -670,7 +827,7 @@ func (s multiSessionContainerSourceSet) Parse(
 	if !ok {
 		return ParseOutcome{}, fmt.Errorf("%s source path unavailable", s.agent)
 	}
-	return s.parse(src, req)
+	return s.parse(ctx, src, req)
 }
 
 // NewMultiSessionProviderFactory builds a ProviderFactory for a multi-session

--- a/internal/parser/openclaude.go
+++ b/internal/parser/openclaude.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -37,6 +38,7 @@ func openClaudeProviderCapabilities() Capabilities {
 	return Capabilities{
 		Source: SourceCapabilities{
 			DiscoverSources:      CapabilitySupported,
+			StreamingDiscovery:   CapabilitySupported,
 			WatchSources:         CapabilitySupported,
 			ClassifyChangedPath:  CapabilitySupported,
 			FindSource:           CapabilitySupported,
@@ -86,6 +88,72 @@ func (s openClaudeSourceSet) Discover(ctx context.Context) ([]SourceRef, error) 
 	}
 	sortJSONLSources(sources)
 	return sources, nil
+}
+
+func (s openClaudeSourceSet) DiscoverEach(
+	ctx context.Context, yield func(SourceRef) error,
+) error {
+	for _, root := range s.roots {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := s.streamLocalRoot(ctx, root, yield); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// streamLocalRoot enumerates one local projects root. Project directories
+// resolve through streamingDirCandidateOrIncomplete so followed symlinked
+// projects are descended exactly as Discover's isDirOrSymlink walk does, and
+// a symlink whose target cannot be resolved surfaces DiscoveryIncompleteError
+// instead of reading as absent: reconciliation treats a clean DiscoverEach as
+// authoritative and would tombstone every session beneath the symlink.
+func (s openClaudeSourceSet) streamLocalRoot(
+	ctx context.Context, root string, yield func(SourceRef) error,
+) error {
+	var incomplete error
+	err := streamDirectoryEntries(ctx, root, func(project os.DirEntry) error {
+		isProjectDir, dirErr := streamingDirCandidateOrIncomplete(
+			AgentOpenClaude, "OpenClaude project directory", project, root,
+		)
+		if dirErr != nil {
+			incomplete = errors.Join(incomplete, dirErr)
+			return nil
+		}
+		if !isProjectDir {
+			return nil
+		}
+		projectRoot := filepath.Join(root, project.Name())
+		err := streamDirectoryTreeRecursive(ctx, projectRoot, func(
+			path string, entry os.DirEntry,
+		) error {
+			if !strings.HasSuffix(entry.Name(), ".jsonl") {
+				return nil
+			}
+			source, ok := s.sourceRef(root, path)
+			if !ok {
+				return nil
+			}
+			return yield(source)
+		})
+		if err == nil {
+			return nil
+		}
+		if _, ok := discoveryYieldCause(err); ok {
+			return err
+		}
+		if ctx.Err() != nil {
+			return err
+		}
+		incomplete = errors.Join(incomplete, err)
+		return nil
+	})
+	if cause, ok := discoveryYieldCause(err); ok {
+		return cause
+	}
+	return errors.Join(incomplete, err)
 }
 
 func (s openClaudeSourceSet) discoveredSourceRef(

--- a/internal/parser/openclaude_test.go
+++ b/internal/parser/openclaude_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -491,4 +492,135 @@ func TestOpenClaudeDiscoverParseSubagentRelationship(t *testing.T) {
 	assert.Equal(t, "openclaude:agent-worker", result.Session.ID)
 	assert.Equal(t, "openclaude:parent-123", result.Session.ParentSessionID)
 	assert.Equal(t, RelSubagent, result.Session.RelationshipType)
+}
+
+func openClaudeDiscoverEach(t *testing.T, root string) ([]string, error) {
+	t.Helper()
+	provider, ok := NewProvider(AgentOpenClaude, ProviderConfig{
+		Roots: []string{root},
+	})
+	require.True(t, ok)
+	discoverer, ok := provider.(StreamingDiscoverer)
+	require.True(t, ok)
+	var yielded []string
+	err := discoverer.DiscoverEach(t.Context(), func(source SourceRef) error {
+		yielded = append(yielded, source.DisplayPath)
+		return nil
+	})
+	return yielded, err
+}
+
+// Discover follows symlinked project directories (ClaudeProjectSessionFiles
+// resolves entries through isDirOrSymlink), so streaming discovery must too:
+// reconciliation treats a clean DiscoverEach as authoritative, and skipping a
+// symlinked project would tombstone every session beneath it.
+func TestOpenClaudeDiscoverEachFollowsSymlinkedProjectDirectory(t *testing.T) {
+	root := t.TempDir()
+	targetRoot := t.TempDir()
+	projectDir := "-Users-dev-code-demo"
+	targetProject := filepath.Join(targetRoot, projectDir)
+	linkedProject := filepath.Join(root, projectDir)
+	linkedPath := filepath.Join(linkedProject, "session-linked.jsonl")
+	regularPath := filepath.Join(
+		root, "regular-project", "session-regular.jsonl",
+	)
+	writeSourceFile(
+		t,
+		filepath.Join(targetProject, "session-linked.jsonl"),
+		claudeProviderFixture("from symlink"),
+	)
+	writeSourceFile(t, regularPath, claudeProviderFixture("regular"))
+	if err := os.Symlink(targetProject, linkedProject); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	provider, ok := NewProvider(AgentOpenClaude, ProviderConfig{
+		Roots: []string{root},
+	})
+	require.True(t, ok)
+	discovered, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.ElementsMatch(
+		t, []string{linkedPath, regularPath}, sourceDisplayPaths(discovered),
+	)
+
+	streamed, err := openClaudeDiscoverEach(t, root)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{linkedPath, regularPath}, streamed,
+		"DiscoverEach must find the same sessions as Discover "+
+			"for symlinked project directories")
+}
+
+// A followed project-directory symlink whose target cannot be resolved must
+// surface incomplete streaming discovery rather than reading as absent:
+// reconciliation treats a clean DiscoverEach as authoritative and would
+// tombstone every session beneath the symlink.
+func TestOpenClaudeStreamingDiscoveryPropagatesProjectSymlinkErrors(
+	t *testing.T,
+) {
+	healthyPath := func(root string) string {
+		return filepath.Join(root, "-Users-dev-code-demo", "session-main.jsonl")
+	}
+
+	t.Run("dangling project symlink", func(t *testing.T) {
+		root := t.TempDir()
+		writeSourceFile(
+			t, healthyPath(root), claudeProviderFixture("hello openclaude"),
+		)
+		target := filepath.Join(t.TempDir(), "linked-project")
+		require.NoError(t, os.MkdirAll(target, 0o755))
+		link := filepath.Join(root, "linked")
+		if err := os.Symlink(target, link); err != nil {
+			t.Skipf("symlink not supported: %v", err)
+		}
+		require.NoError(t, os.RemoveAll(target))
+
+		yielded, err := openClaudeDiscoverEach(t, root)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, os.ErrNotExist)
+		var incomplete DiscoveryIncompleteError
+		assert.ErrorAs(t, err, &incomplete)
+		// The walker records the failure and continues with healthy siblings.
+		assert.Equal(t, []string{healthyPath(root)}, yielded)
+
+		require.NoError(t, os.Remove(link))
+		yielded, err = openClaudeDiscoverEach(t, root)
+		require.NoError(t, err)
+		assert.Equal(t, []string{healthyPath(root)}, yielded)
+	})
+
+	t.Run("unstatable project symlink target", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("directory read permissions are not enforced on Windows")
+		}
+		if os.Geteuid() == 0 {
+			t.Skip("root bypasses directory permissions")
+		}
+		root := t.TempDir()
+		writeSourceFile(
+			t, healthyPath(root), claudeProviderFixture("hello openclaude"),
+		)
+		targetParent := t.TempDir()
+		target := filepath.Join(targetParent, "linked-project")
+		require.NoError(t, os.MkdirAll(target, 0o755))
+		if err := os.Symlink(target, filepath.Join(root, "linked")); err != nil {
+			t.Skipf("symlink not supported: %v", err)
+		}
+		require.NoError(t, os.Chmod(targetParent, 0o000))
+		t.Cleanup(func() { _ = os.Chmod(targetParent, 0o755) })
+
+		yielded, err := openClaudeDiscoverEach(t, root)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, os.ErrPermission)
+		var incomplete DiscoveryIncompleteError
+		assert.ErrorAs(t, err, &incomplete)
+		assert.Equal(t, []string{healthyPath(root)}, yielded)
+
+		require.NoError(t, os.Chmod(targetParent, 0o755))
+		yielded, err = openClaudeDiscoverEach(t, root)
+		require.NoError(t, err)
+		assert.Equal(t, []string{healthyPath(root)}, yielded)
+	})
 }

--- a/internal/parser/opencode.go
+++ b/internal/parser/opencode.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"context"
 	"crypto/sha256"
 	"database/sql"
 	"encoding/json"
@@ -61,44 +62,65 @@ func OpenCodeSQLiteSessionExists(dbPath, sessionID string) bool {
 func ListOpenCodeSessionMeta(
 	dbPath string,
 ) ([]OpenCodeSessionMeta, error) {
+	var metas []OpenCodeSessionMeta
+	err := ForEachOpenCodeSessionMeta(
+		context.Background(), dbPath,
+		func(meta OpenCodeSessionMeta) error {
+			metas = append(metas, meta)
+			return nil
+		},
+	)
+	return metas, err
+}
+
+// ForEachOpenCodeSessionMeta streams lightweight session rows directly from
+// SQLite. The callback runs while the read-only query is open and receives one
+// row at a time; callers must not retain database-owned values.
+func ForEachOpenCodeSessionMeta(
+	ctx context.Context,
+	dbPath string,
+	yield func(OpenCodeSessionMeta) error,
+) error {
 	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
-		return nil, nil
+		return nil
 	}
 
 	db, err := openOpenCodeDB(dbPath)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer db.Close()
 
-	rows, err := db.Query(
+	rows, err := db.QueryContext(ctx,
 		"SELECT id, time_updated FROM session",
 	)
 	if err != nil {
-		return nil, fmt.Errorf(
+		return fmt.Errorf(
 			"listing opencode sessions: %w", err,
 		)
 	}
 	defer rows.Close()
 
-	var metas []OpenCodeSessionMeta
 	for rows.Next() {
 		var id string
 		var timeUpdated int64
 		if err := rows.Scan(
 			&id, &timeUpdated,
 		); err != nil {
-			return nil, fmt.Errorf(
+			return fmt.Errorf(
 				"scanning opencode session meta: %w", err,
 			)
 		}
-		metas = append(metas, OpenCodeSessionMeta{
+		observeStreamingDiscoveryBuffer(ctx, 1)
+		if err := yield(OpenCodeSessionMeta{
 			SessionID:   id,
 			VirtualPath: dbPath + "#" + id,
 			FileMtime:   timeUpdated * 1_000_000,
-		})
+		}); err != nil {
+			return err
+		}
 	}
-	return metas, rows.Err()
+	return rows.Err()
 }
 
 // parseOpenCodeDBSession parses a single session by ID from the

--- a/internal/parser/opencode_provider.go
+++ b/internal/parser/opencode_provider.go
@@ -83,6 +83,10 @@ func (p *openCodeFormatProvider) Discover(ctx context.Context) ([]SourceRef, err
 	return p.sources.Discover(ctx)
 }
 
+func (p *openCodeFormatProvider) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	return p.sources.DiscoverEach(ctx, yield)
+}
+
 func (p *openCodeFormatProvider) WatchPlan(ctx context.Context) (WatchPlan, error) {
 	return p.sources.WatchPlan(ctx)
 }
@@ -92,6 +96,12 @@ func (p *openCodeFormatProvider) SourcesForChangedPath(
 	req ChangedPathRequest,
 ) ([]SourceRef, error) {
 	return p.sources.SourcesForChangedPath(ctx, req)
+}
+
+func (p *openCodeFormatProvider) SourceForReconciliation(
+	ctx context.Context, path, project string,
+) (SourceRef, bool, error) {
+	return p.sources.SourceForReconciliation(ctx, path, project)
 }
 
 func (p *openCodeFormatProvider) FindSource(
@@ -165,53 +175,71 @@ func (p *openCodeFormatProvider) Parse(
 // the OpenCode storage and SQLite readers, then relabel the result onto
 // their own agent and ID prefix.
 type openCodeProviderSpec struct {
-	agent       AgentType
-	format      openCodeFormat
-	dbName      string
-	listSQLite  func(string) ([]OpenCodeSessionMeta, error)
-	sourceMtime func(string) (int64, error)
-	relabel     func(*ParsedSession)
+	agent        AgentType
+	format       openCodeFormat
+	dbName       string
+	listSQLite   func(string) ([]OpenCodeSessionMeta, error)
+	streamSQLite func(context.Context, string, func(OpenCodeSessionMeta) error) error
+	sourceMtime  func(string) (int64, error)
+	relabel      func(*ParsedSession)
 }
 
 func openCodeProviderSpecForAgent(agent AgentType) openCodeProviderSpec {
 	switch agent {
 	case AgentOpenCode:
 		return openCodeProviderSpec{
-			agent:       AgentOpenCode,
-			format:      openCodeFmt,
-			dbName:      openCodeFmt.dbName,
-			listSQLite:  ListOpenCodeSessionMeta,
-			sourceMtime: OpenCodeSourceMtime,
+			agent:        AgentOpenCode,
+			format:       openCodeFmt,
+			dbName:       openCodeFmt.dbName,
+			listSQLite:   ListOpenCodeSessionMeta,
+			streamSQLite: ForEachOpenCodeSessionMeta,
+			sourceMtime:  OpenCodeSourceMtime,
 		}
 	case AgentKilo:
 		return openCodeProviderSpec{
-			agent:       AgentKilo,
-			format:      kiloFmt,
-			dbName:      kiloFmt.dbName,
-			listSQLite:  ListKiloSessionMeta,
-			sourceMtime: KiloSourceMtime,
-			relabel:     relabelOpenCodeSessionAsKilo,
+			agent:        AgentKilo,
+			format:       kiloFmt,
+			dbName:       kiloFmt.dbName,
+			listSQLite:   ListKiloSessionMeta,
+			streamSQLite: streamOpenCodeSessionMetaAs(KiloSQLiteVirtualPath),
+			sourceMtime:  KiloSourceMtime,
+			relabel:      relabelOpenCodeSessionAsKilo,
 		}
 	case AgentMiMoCode:
 		return openCodeProviderSpec{
-			agent:       AgentMiMoCode,
-			format:      mimoFmt,
-			dbName:      mimoFmt.dbName,
-			listSQLite:  ListMiMoCodeSessionMeta,
-			sourceMtime: MiMoCodeSourceMtime,
-			relabel:     relabelOpenCodeSessionAsMiMoCode,
+			agent:        AgentMiMoCode,
+			format:       mimoFmt,
+			dbName:       mimoFmt.dbName,
+			listSQLite:   ListMiMoCodeSessionMeta,
+			streamSQLite: streamOpenCodeSessionMetaAs(MiMoCodeSQLiteVirtualPath),
+			sourceMtime:  MiMoCodeSourceMtime,
+			relabel:      relabelOpenCodeSessionAsMiMoCode,
 		}
 	case AgentIcodemate:
 		return openCodeProviderSpec{
-			agent:       AgentIcodemate,
-			format:      icodemateFmt,
-			dbName:      icodemateFmt.dbName,
-			listSQLite:  ListIcodemateSessionMeta,
-			sourceMtime: IcodemateSourceMtime,
-			relabel:     relabelOpenCodeSessionAsIcodemate,
+			agent:        AgentIcodemate,
+			format:       icodemateFmt,
+			dbName:       icodemateFmt.dbName,
+			listSQLite:   ListIcodemateSessionMeta,
+			streamSQLite: streamOpenCodeSessionMetaAs(IcodemateSQLiteVirtualPath),
+			sourceMtime:  IcodemateSourceMtime,
+			relabel:      relabelOpenCodeSessionAsIcodemate,
 		}
 	default:
 		return openCodeProviderSpec{}
+	}
+}
+
+func streamOpenCodeSessionMetaAs(
+	virtualPath func(string, string) string,
+) func(context.Context, string, func(OpenCodeSessionMeta) error) error {
+	return func(
+		ctx context.Context, dbPath string, yield func(OpenCodeSessionMeta) error,
+	) error {
+		return ForEachOpenCodeSessionMeta(ctx, dbPath, func(meta OpenCodeSessionMeta) error {
+			meta.VirtualPath = virtualPath(dbPath, meta.SessionID)
+			return yield(meta)
+		})
 	}
 }
 
@@ -354,6 +382,179 @@ func (s openCodeFormatSourceSet) Discover(ctx context.Context) ([]SourceRef, err
 	return sources, nil
 }
 
+func (s openCodeFormatSourceSet) DiscoverEach(
+	ctx context.Context, yield func(SourceRef) error,
+) error {
+	var incomplete error
+	wrappedYield := func(source SourceRef) error {
+		if err := yield(source); err != nil {
+			return discoveryYieldError{cause: err}
+		}
+		return nil
+	}
+	for _, root := range s.roots {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		continuable, err := s.discoverRootEach(ctx, root, wrappedYield)
+		if err == nil {
+			continue
+		}
+		if cause, ok := discoveryYieldCause(err); ok {
+			return cause
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		if continuable {
+			incomplete = errors.Join(incomplete, err)
+			continue
+		}
+		if incomplete == nil {
+			return err
+		}
+		return errors.Join(incomplete, err)
+	}
+	return incomplete
+}
+
+type openCodeDiscoveryMapError struct{ cause error }
+
+func (err openCodeDiscoveryMapError) Error() string { return err.cause.Error() }
+func (err openCodeDiscoveryMapError) Unwrap() error { return err.cause }
+
+func (s openCodeFormatSourceSet) discoverRootEach(
+	ctx context.Context, root string, yield func(SourceRef) error,
+) (continuable bool, retErr error) {
+	src := s.spec.resolve(root)
+	hasSQLite := src.DBPath != "" && IsRegularFile(src.DBPath)
+	var storageIDs *discoveryDiskMap
+	if src.Mode == OpenCodeSourceStorage && hasSQLite {
+		var err error
+		storageIDs, err = newDiscoveryDiskMapForContext(ctx)
+		if err != nil {
+			return false, err
+		}
+		defer func() {
+			if cleanupErr := storageIDs.close(); cleanupErr != nil {
+				continuable = false
+				retErr = errors.Join(retErr, cleanupErr)
+			}
+		}()
+	}
+	if src.Mode == OpenCodeSourceStorage {
+		if err := s.discoverStorageEach(ctx, root, src, storageIDs, yield); err != nil {
+			var mapErr openCodeDiscoveryMapError
+			if errors.As(err, &mapErr) {
+				return false, err
+			}
+			return true, incompleteDiscoveryError(
+				s.spec.agent, "stream storage "+src.SessionRoot, err,
+			)
+		}
+	}
+	if !hasSQLite {
+		return false, nil
+	}
+	var callbackErr error
+	var membershipErr error
+	err := s.spec.streamSQLite(ctx, src.DBPath, func(meta OpenCodeSessionMeta) error {
+		if storageIDs != nil {
+			_, exists, err := storageIDs.get(ctx, meta.SessionID)
+			if err != nil {
+				membershipErr = err
+				return err
+			}
+			if exists {
+				return nil
+			}
+		}
+		source, ok := s.sqliteSourceRefFromMeta(root, meta)
+		if !ok {
+			return nil
+		}
+		callbackErr = yield(source)
+		return callbackErr
+	})
+	if callbackErr != nil {
+		return false, callbackErr
+	}
+	if membershipErr != nil {
+		return false, membershipErr
+	}
+	if err == nil {
+		return false, nil
+	}
+	if ctx.Err() != nil {
+		return false, err
+	}
+	if src.Mode == OpenCodeSourceStorage {
+		return true, incompleteDiscoveryError(
+			s.spec.agent, "stream SQLite "+src.DBPath, err,
+		)
+	}
+	return true, incompleteDiscoveryError(
+		s.spec.agent, "stream SQLite "+src.DBPath, err,
+	)
+}
+
+func (s openCodeFormatSourceSet) discoverStorageEach(
+	ctx context.Context,
+	root string,
+	src OpenCodeSource,
+	storageIDs *discoveryDiskMap,
+	yield func(SourceRef) error,
+) error {
+	var callbackErr error
+	err := streamDirectoryEntries(ctx, src.SessionRoot, func(project os.DirEntry) error {
+		isProjectDir, dirErr := streamingDirCandidateOrIncomplete(
+			s.spec.agent, "project directory", project, src.SessionRoot,
+		)
+		if dirErr != nil {
+			return dirErr
+		}
+		if !isProjectDir {
+			return nil
+		}
+		projectDir := filepath.Join(src.SessionRoot, project.Name())
+		err := streamDirectoryEntries(ctx, projectDir, func(entry os.DirEntry) error {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+				return nil
+			}
+			path := filepath.Join(projectDir, entry.Name())
+			source, ok := s.sourceRef(root, path, false)
+			if !ok {
+				return nil
+			}
+			if storageIDs != nil {
+				id := strings.TrimSuffix(entry.Name(), ".json")
+				if id != "" {
+					if err := storageIDs.put(ctx, id, id, false); err != nil {
+						return openCodeDiscoveryMapError{cause: err}
+					}
+				}
+			}
+			source.ProjectHint = openCodeSessionProject(path)
+			callbackErr = yield(source)
+			return callbackErr
+		})
+		if callbackErr != nil {
+			return callbackErr
+		}
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if callbackErr != nil {
+		return callbackErr
+	}
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	return err
+}
+
 func (s openCodeFormatSourceSet) WatchPlan(context.Context) (WatchPlan, error) {
 	roots := make([]WatchRoot, 0, len(s.roots))
 	for _, root := range s.roots {
@@ -380,6 +581,19 @@ func (s openCodeFormatSourceSet) SourcesForChangedPath(
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
+	if dbPath, _, virtual := s.spec.parseVirtual(req.Path); virtual {
+		for _, root := range s.roots {
+			if _, under := relUnder(root, dbPath); !under {
+				continue
+			}
+			source, ok, err := s.canonicalVirtualSource(ctx, root, req.Path)
+			if err != nil || !ok {
+				return nil, err
+			}
+			return []SourceRef{source}, nil
+		}
+		return nil, nil
+	}
 	pathExists := true
 	if _, err := os.Stat(req.Path); err != nil {
 		if !os.IsNotExist(err) {
@@ -396,6 +610,59 @@ func (s openCodeFormatSourceSet) SourcesForChangedPath(
 		}
 	}
 	return nil, nil
+}
+
+func (s openCodeFormatSourceSet) SourceForReconciliation(
+	ctx context.Context, path, project string,
+) (SourceRef, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return SourceRef{}, false, err
+	}
+	for _, root := range s.roots {
+		source, ok := s.sourceRef(root, path, false)
+		if !ok {
+			continue
+		}
+		if project != "" {
+			source.ProjectHint = project
+		}
+		return source, true, nil
+	}
+	return SourceRef{}, false, nil
+}
+
+var errOpenCodeCanonicalSourceFound = errors.New("opencode canonical source found")
+
+func (s openCodeFormatSourceSet) canonicalVirtualSource(
+	ctx context.Context, root, virtualPath string,
+) (SourceRef, bool, error) {
+	_, sessionID, ok := s.spec.parseVirtual(virtualPath)
+	if !ok {
+		return SourceRef{}, false, nil
+	}
+	src := s.spec.resolve(root)
+	if src.Mode == OpenCodeSourceStorage {
+		var found SourceRef
+		err := streamDirectoryEntries(ctx, src.SessionRoot, func(project os.DirEntry) error {
+			if !isDirOrSymlink(project, src.SessionRoot) {
+				return nil
+			}
+			path := filepath.Join(src.SessionRoot, project.Name(), sessionID+".json")
+			if source, ok := s.sourceRef(root, path, false); ok {
+				found = source
+				return errOpenCodeCanonicalSourceFound
+			}
+			return nil
+		})
+		switch {
+		case errors.Is(err, errOpenCodeCanonicalSourceFound):
+			return found, true, nil
+		case ctx.Err() != nil:
+			return SourceRef{}, false, ctx.Err()
+		}
+	}
+	source, ok := s.sourceRef(root, virtualPath, false)
+	return source, ok, nil
 }
 
 func (s openCodeFormatSourceSet) FindSource(
@@ -837,16 +1104,18 @@ func findOpenCodeProviderStorageSessionIDByMessageID(
 func openCodeFormatProviderCapabilities() Capabilities {
 	return Capabilities{
 		Source: SourceCapabilities{
-			DiscoverSources:      CapabilitySupported,
-			WatchSources:         CapabilitySupported,
-			ClassifyChangedPath:  CapabilitySupported,
-			FindSource:           CapabilitySupported,
-			CompositeFingerprint: CapabilitySupported,
-			IncrementalAppend:    CapabilityNotApplicable,
-			MultiSessionSource:   CapabilityNotApplicable,
-			PerSessionErrors:     CapabilityNotApplicable,
-			ExcludedSessions:     CapabilityNotApplicable,
-			ForceReplaceOnParse:  CapabilityNotApplicable,
+			DiscoverSources:       CapabilitySupported,
+			StreamingDiscovery:    CapabilitySupported,
+			WatchSources:          CapabilitySupported,
+			ClassifyChangedPath:   CapabilitySupported,
+			FindSource:            CapabilitySupported,
+			CompositeFingerprint:  CapabilitySupported,
+			IncrementalAppend:     CapabilityNotApplicable,
+			MultiSessionSource:    CapabilityNotApplicable,
+			SharedContainerSource: CapabilitySupported,
+			PerSessionErrors:      CapabilityNotApplicable,
+			ExcludedSessions:      CapabilityNotApplicable,
+			ForceReplaceOnParse:   CapabilityNotApplicable,
 		},
 		Content: ContentCapabilities{
 			FirstMessage:         CapabilitySupported,

--- a/internal/parser/opencode_provider_test.go
+++ b/internal/parser/opencode_provider_test.go
@@ -3,6 +3,8 @@ package parser
 import (
 	"context"
 	"database/sql"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -12,6 +14,365 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestOpenCodeHybridStreamingDiscoveryReportsIncompleteSQLiteFailure(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	storagePath := writeOpenCodeProviderStorageSession(
+		t, root, "session", "ses_storage", "project", "Storage",
+	)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "opencode.db"), []byte("not sqlite"), 0o600,
+	))
+	provider, ok := NewProvider(AgentOpenCode, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	discovered, err := provider.Discover(t.Context())
+	require.NoError(t, err)
+	requireSourcePathsMatch(t, discovered, []string{storagePath})
+	var streamed []SourceRef
+	err = provider.(StreamingDiscoverer).DiscoverEach(
+		t.Context(), func(source SourceRef) error {
+			streamed = append(streamed, source)
+			return nil
+		},
+	)
+	require.Error(t, err)
+	var incomplete DiscoveryIncompleteError
+	require.ErrorAs(t, err, &incomplete)
+	assert.Equal(t, AgentOpenCode, incomplete.Provider)
+	assert.ErrorContains(t, err, "SQLite")
+	requireSourcePathsMatch(t, streamed, []string{storagePath})
+	assert.Equal(t, discovered, streamed,
+		"incomplete streaming discovery must still expose valid storage sources")
+}
+
+func TestOpenCodeHybridStreamingIncompleteRootContinuesLaterRoots(t *testing.T) {
+	setup := func(t *testing.T) (Provider, string, string) {
+		t.Helper()
+		incompleteRoot := t.TempDir()
+		storagePath := writeOpenCodeProviderStorageSession(
+			t, incompleteRoot, "session", "ses_storage", "project", "Storage",
+		)
+		require.NoError(t, os.WriteFile(
+			filepath.Join(incompleteRoot, "opencode.db"), []byte("not sqlite"), 0o600,
+		))
+		healthyRoot := t.TempDir()
+		dbPath, seeder, db := newTestDBAt(
+			t, filepath.Join(healthyRoot, "opencode.db"),
+		)
+		t.Cleanup(func() { require.NoError(t, db.Close()) })
+		seeder.AddProject("prj_1", "/workspace/healthy")
+		seeder.AddSession(
+			"ses_healthy", "prj_1", "", "Healthy", 1700000000000, 1700000010000,
+		)
+		provider, ok := NewProvider(AgentOpenCode, ProviderConfig{
+			Roots: []string{incompleteRoot, healthyRoot},
+		})
+		require.True(t, ok)
+		return provider, storagePath,
+			OpenCodeSQLiteVirtualPath(dbPath, "ses_healthy")
+	}
+
+	t.Run("returns accumulated incomplete error after later success", func(t *testing.T) {
+		provider, storagePath, healthyPath := setup(t)
+		var paths []string
+
+		err := provider.(StreamingDiscoverer).DiscoverEach(
+			t.Context(), func(source SourceRef) error {
+				paths = append(paths, source.DisplayPath)
+				return nil
+			},
+		)
+
+		require.Error(t, err)
+		var incomplete DiscoveryIncompleteError
+		require.ErrorAs(t, err, &incomplete)
+		assert.Equal(t, []string{storagePath, healthyPath}, paths)
+	})
+
+	t.Run("later callback error takes precedence", func(t *testing.T) {
+		provider, storagePath, healthyPath := setup(t)
+		sentinel := errors.New("stop on later root")
+		var paths []string
+
+		err := provider.(StreamingDiscoverer).DiscoverEach(
+			t.Context(), func(source SourceRef) error {
+				paths = append(paths, source.DisplayPath)
+				if source.DisplayPath == healthyPath {
+					return sentinel
+				}
+				return nil
+			},
+		)
+
+		assert.Equal(t, sentinel, err,
+			"a later callback error must replace accumulated incompleteness")
+		assert.Equal(t, []string{storagePath, healthyPath}, paths)
+	})
+}
+
+func TestOpenCodeStreamingPartialSQLiteFailureContinuesLaterRoots(t *testing.T) {
+	partialRoot := t.TempDir()
+	partialDB := filepath.Join(partialRoot, "opencode.db")
+	require.NoError(t, os.WriteFile(partialDB, []byte("streamed by test"), 0o600))
+	healthyRoot := t.TempDir()
+	healthyDB := filepath.Join(healthyRoot, "opencode.db")
+	require.NoError(t, os.WriteFile(healthyDB, []byte("streamed by test"), 0o600))
+	partialPath := OpenCodeSQLiteVirtualPath(partialDB, "ses_partial")
+	healthyPath := OpenCodeSQLiteVirtualPath(healthyDB, "ses_healthy")
+	sentinel := errors.New("SQLite row stream failed")
+	var streamedDBs []string
+	spec := openCodeProviderSpecForAgent(AgentOpenCode)
+	spec.streamSQLite = func(
+		_ context.Context,
+		dbPath string,
+		yield func(OpenCodeSessionMeta) error,
+	) error {
+		streamedDBs = append(streamedDBs, dbPath)
+		switch {
+		case samePath(dbPath, partialDB):
+			if err := yield(OpenCodeSessionMeta{
+				SessionID: "ses_partial", VirtualPath: partialPath,
+			}); err != nil {
+				return err
+			}
+			return sentinel
+		case samePath(dbPath, healthyDB):
+			return yield(OpenCodeSessionMeta{
+				SessionID: "ses_healthy", VirtualPath: healthyPath,
+			})
+		default:
+			return fmt.Errorf("unexpected SQLite path %q", dbPath)
+		}
+	}
+	sources := newOpenCodeFormatSourceSet(
+		[]string{partialRoot, healthyRoot}, spec,
+	)
+	var paths []string
+
+	err := sources.DiscoverEach(t.Context(), func(source SourceRef) error {
+		paths = append(paths, source.DisplayPath)
+		return nil
+	})
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, sentinel)
+	var incomplete DiscoveryIncompleteError
+	require.ErrorAs(t, err, &incomplete)
+	assert.Equal(t, AgentOpenCode, incomplete.Provider)
+	assert.Equal(t, []string{partialPath, healthyPath}, paths,
+		"a partial row stream must retain its yield and continue later roots")
+	assert.Equal(t, []string{partialDB, healthyDB}, streamedDBs,
+		"the later configured root must still be traversed")
+}
+
+func TestOpenCodeStreamingStorageFailureContinuesLaterRoots(t *testing.T) {
+	failedRoot := t.TempDir()
+	writeOpenCodeProviderStorageSession(
+		t, failedRoot, "session", "ses_failed", "project", "Failed",
+	)
+	failedStorageRoot := filepath.Join(failedRoot, "storage", "session")
+	healthyRoot := t.TempDir()
+	dbPath, seeder, db := newTestDBAt(
+		t, filepath.Join(healthyRoot, "opencode.db"),
+	)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	seeder.AddProject("prj_1", "/workspace/healthy")
+	seeder.AddSession(
+		"ses_healthy", "prj_1", "", "Healthy", 1700000000000, 1700000010000,
+	)
+	healthyPath := OpenCodeSQLiteVirtualPath(dbPath, "ses_healthy")
+	discoveryErr := errors.New("read failed storage root")
+	ctx := withStreamingDirectoryReader(t.Context(), func(
+		ctx context.Context, dir string, yield func(os.DirEntry) error,
+	) error {
+		if samePath(dir, failedStorageRoot) {
+			return discoveryErr
+		}
+		return streamDirectoryEntriesDirect(ctx, dir, yield)
+	})
+	provider, ok := NewProvider(AgentOpenCode, ProviderConfig{
+		Roots: []string{failedRoot, healthyRoot},
+	})
+	require.True(t, ok)
+	var paths []string
+
+	err := provider.(StreamingDiscoverer).DiscoverEach(
+		ctx, func(source SourceRef) error {
+			paths = append(paths, source.DisplayPath)
+			return nil
+		},
+	)
+
+	require.ErrorIs(t, err, discoveryErr)
+	var incomplete DiscoveryIncompleteError
+	require.ErrorAs(t, err, &incomplete)
+	assert.Equal(t, AgentOpenCode, incomplete.Provider)
+	assert.Equal(t, []string{healthyPath}, paths,
+		"a root-local storage failure must not starve later roots")
+}
+
+func TestOpenCodeStreamingSQLiteOnlyFailureContinuesLaterRoots(t *testing.T) {
+	failedRoot := t.TempDir()
+	failedDB := filepath.Join(failedRoot, "opencode.db")
+	require.NoError(t, os.WriteFile(failedDB, []byte("not sqlite"), 0o600))
+	healthyRoot := t.TempDir()
+	dbPath, seeder, db := newTestDBAt(
+		t, filepath.Join(healthyRoot, "opencode.db"),
+	)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	seeder.AddProject("prj_1", "/workspace/healthy")
+	seeder.AddSession(
+		"ses_healthy", "prj_1", "", "Healthy", 1700000000000, 1700000010000,
+	)
+	healthyPath := OpenCodeSQLiteVirtualPath(dbPath, "ses_healthy")
+	provider, ok := NewProvider(AgentOpenCode, ProviderConfig{
+		Roots: []string{failedRoot, healthyRoot},
+	})
+	require.True(t, ok)
+	var paths []string
+
+	err := provider.(StreamingDiscoverer).DiscoverEach(
+		t.Context(), func(source SourceRef) error {
+			paths = append(paths, source.DisplayPath)
+			return nil
+		},
+	)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "file is not a database")
+	var incomplete DiscoveryIncompleteError
+	require.ErrorAs(t, err, &incomplete)
+	assert.Equal(t, AgentOpenCode, incomplete.Provider)
+	assert.Equal(t, []string{healthyPath}, paths,
+		"a root-local SQLite failure must not starve later roots")
+}
+
+func TestOpenCodeSQLiteOnlyStreamingDiscoveryPropagatesSQLiteFailure(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "opencode.db"), []byte("not sqlite"), 0o600,
+	))
+	provider, ok := NewProvider(AgentOpenCode, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	_, err := provider.Discover(t.Context())
+	require.Error(t, err)
+	err = provider.(StreamingDiscoverer).DiscoverEach(
+		t.Context(), func(SourceRef) error { return nil },
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SQLite")
+}
+
+func TestOpenCodeHybridStreamingDiscoveryPropagatesNestedStorageFailure(t *testing.T) {
+	root := t.TempDir()
+	writeOpenCodeProviderStorageSession(
+		t, root, "session", "ses_storage", "project", "Storage",
+	)
+	projectDir := filepath.Join(root, "storage", "session", "global")
+	injected := errors.New("nested storage read failed")
+	ctx := withStreamingDirectoryReader(t.Context(), func(
+		ctx context.Context, dir string, yield func(os.DirEntry) error,
+	) error {
+		if samePath(dir, projectDir) {
+			return injected
+		}
+		return streamDirectoryEntriesDirect(ctx, dir, yield)
+	})
+	provider, ok := NewProvider(AgentOpenCode, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+
+	err := provider.(StreamingDiscoverer).DiscoverEach(
+		ctx, func(SourceRef) error { return nil },
+	)
+
+	assert.ErrorIs(t, err, injected)
+}
+
+// A followed project-directory symlink whose target cannot be resolved must
+// surface incomplete streaming discovery rather than reading as absent:
+// reconciliation treats a clean DiscoverEach as authoritative and would
+// tombstone every session beneath the symlink.
+func TestOpenCodeStorageStreamingDiscoveryPropagatesProjectSymlinkErrors(t *testing.T) {
+	discoverEach := func(t *testing.T, root string) ([]string, error) {
+		t.Helper()
+		provider, ok := NewProvider(AgentOpenCode, ProviderConfig{
+			Roots: []string{root},
+		})
+		require.True(t, ok)
+		discoverer, ok := provider.(StreamingDiscoverer)
+		require.True(t, ok)
+		var yielded []string
+		err := discoverer.DiscoverEach(t.Context(), func(source SourceRef) error {
+			yielded = append(yielded, source.DisplayPath)
+			return nil
+		})
+		return yielded, err
+	}
+
+	t.Run("dangling project symlink", func(t *testing.T) {
+		root := t.TempDir()
+		healthy := writeOpenCodeProviderStorageSession(
+			t, root, "session", "ses_healthy", "project", "Healthy",
+		)
+		target := filepath.Join(t.TempDir(), "linked-project")
+		require.NoError(t, os.MkdirAll(target, 0o755))
+		link := filepath.Join(root, "storage", "session", "linked")
+		if err := os.Symlink(target, link); err != nil {
+			t.Skipf("symlink not supported: %v", err)
+		}
+		require.NoError(t, os.RemoveAll(target))
+
+		_, err := discoverEach(t, root)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, os.ErrNotExist)
+		var incomplete DiscoveryIncompleteError
+		assert.ErrorAs(t, err, &incomplete)
+
+		require.NoError(t, os.Remove(link))
+		yielded, err := discoverEach(t, root)
+		require.NoError(t, err)
+		assert.Equal(t, []string{healthy}, yielded)
+	})
+
+	t.Run("unstatable project symlink target", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("directory read permissions are not enforced on Windows")
+		}
+		if os.Geteuid() == 0 {
+			t.Skip("root bypasses directory permissions")
+		}
+		root := t.TempDir()
+		healthy := writeOpenCodeProviderStorageSession(
+			t, root, "session", "ses_healthy", "project", "Healthy",
+		)
+		targetParent := t.TempDir()
+		target := filepath.Join(targetParent, "linked-project")
+		require.NoError(t, os.MkdirAll(target, 0o755))
+		link := filepath.Join(root, "storage", "session", "linked")
+		if err := os.Symlink(target, link); err != nil {
+			t.Skipf("symlink not supported: %v", err)
+		}
+		require.NoError(t, os.Chmod(targetParent, 0o000))
+		t.Cleanup(func() { _ = os.Chmod(targetParent, 0o755) })
+
+		_, err := discoverEach(t, root)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, os.ErrPermission)
+		var incomplete DiscoveryIncompleteError
+		assert.ErrorAs(t, err, &incomplete)
+
+		require.NoError(t, os.Chmod(targetParent, 0o755))
+		yielded, err := discoverEach(t, root)
+		require.NoError(t, err)
+		assert.Equal(t, []string{healthy}, yielded)
+	})
+}
 
 func TestOpenCodeProviderStorageSourceMethods(t *testing.T) {
 
@@ -144,6 +505,22 @@ func TestOpenCodeProviderSQLiteSourceMethods(t *testing.T) {
 	require.NoError(t, err)
 	requireSourcePathsMatch(t, discovered, fixture.AllVirtualPaths)
 	requireContainsSourcePath(t, discovered, virtualPath)
+	maxBuffered := 0
+	streamed := make([]SourceRef, 0, len(fixture.AllVirtualPaths))
+	streamCtx := WithStreamingDiscoveryBufferObserver(
+		context.Background(),
+		func(buffered int) { maxBuffered = max(maxBuffered, buffered) },
+	)
+	require.NoError(t, provider.(StreamingDiscoverer).DiscoverEach(
+		streamCtx,
+		func(source SourceRef) error {
+			streamed = append(streamed, source)
+			return nil
+		},
+	))
+	requireSourcePathsMatch(t, streamed, fixture.AllVirtualPaths)
+	assert.Equal(t, 1, maxBuffered,
+		"SQLite discovery must expose one rows.Next source at a time")
 
 	changed, err := provider.SourcesForChangedPath(
 		context.Background(),
@@ -151,6 +528,13 @@ func TestOpenCodeProviderSQLiteSourceMethods(t *testing.T) {
 	)
 	require.NoError(t, err)
 	requireSourcePathsMatch(t, changed, fixture.AllVirtualPaths)
+
+	changed, err = provider.SourcesForChangedPath(
+		context.Background(),
+		ChangedPathRequest{Path: virtualPath, EventKind: "write", WatchRoot: root},
+	)
+	require.NoError(t, err)
+	requireSourcePathsMatch(t, changed, []string{virtualPath})
 
 	found, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
 		FullSessionID: "host~opencode:" + fixture.TargetSessionID,
@@ -376,10 +760,16 @@ func TestOpenCodeProviderHybridDiscoveryFiltersSQLiteDuplicate(t *testing.T) {
 	discovered, err := provider.Discover(context.Background())
 	require.NoError(t, err)
 	require.Len(t, discovered, 2)
-	assert.ElementsMatch(t, []string{storagePath, virtualOnly}, []string{
-		discovered[0].DisplayPath,
-		discovered[1].DisplayPath,
-	})
+	wantPaths := []string{storagePath, virtualOnly}
+	requireSourcePathsMatch(t, discovered, wantPaths)
+	var streamed []SourceRef
+	require.NoError(t, provider.(StreamingDiscoverer).DiscoverEach(
+		t.Context(), func(source SourceRef) error {
+			streamed = append(streamed, source)
+			return nil
+		},
+	))
+	requireSourcePathsMatch(t, streamed, wantPaths)
 
 	found, ok, err := provider.FindSource(context.Background(), FindSourceRequest{
 		StoredFilePath: OpenCodeSQLiteVirtualPath(dbPath, "ses_dup"),
@@ -388,6 +778,197 @@ func TestOpenCodeProviderHybridDiscoveryFiltersSQLiteDuplicate(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok)
 	assert.Equal(t, storagePath, found.DisplayPath)
+
+	changed, err := provider.SourcesForChangedPath(
+		context.Background(),
+		ChangedPathRequest{
+			Path:      OpenCodeSQLiteVirtualPath(dbPath, "ses_dup"),
+			EventKind: "write",
+			WatchRoot: root,
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, changed, 1)
+	assert.Equal(t, storagePath, changed[0].DisplayPath,
+		"a storage source that appears before rehydration remains canonical")
+}
+
+func TestOpenCodeHybridStreamingDedupUsesStorageTraversalSnapshot(t *testing.T) {
+	root := t.TempDir()
+	storagePath := writeOpenCodeProviderStorageSession(
+		t, root, "session", "ses_storage", "storage-app", "Storage Session",
+	)
+	dbPath, seeder, db := newTestDBAt(t, filepath.Join(root, "opencode.db"))
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	seeder.AddProject("prj_1", "/home/user/code/sqlite-app")
+	seeder.AddSession(
+		"ses_sqlite", "prj_1", "", "SQLite", 1700000000000, 1700000010000,
+	)
+	virtualPath := OpenCodeSQLiteVirtualPath(dbPath, "ses_sqlite")
+	lateStoragePath := filepath.Join(
+		root, "storage", "session", "global", "ses_sqlite.json",
+	)
+	storageRoot := filepath.Join(root, "storage", "session")
+	lateAdds := 0
+	ctx := withStreamingDirectoryReader(t.Context(), func(
+		ctx context.Context, dir string, yield func(os.DirEntry) error,
+	) error {
+		if err := streamDirectoryEntriesDirect(ctx, dir, yield); err != nil {
+			return err
+		}
+		if !samePath(dir, storageRoot) {
+			return nil
+		}
+		lateAdds++
+		return os.WriteFile(lateStoragePath, []byte("{}"), 0o600)
+	})
+	provider, ok := NewProvider(
+		AgentOpenCode, ProviderConfig{Roots: []string{root}},
+	)
+	require.True(t, ok)
+	var paths []string
+
+	err := provider.(StreamingDiscoverer).DiscoverEach(
+		ctx, func(source SourceRef) error {
+			paths = append(paths, source.DisplayPath)
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, lateAdds,
+		"the late storage file must be added after the storage snapshot completes")
+	assert.Equal(t, []string{storagePath, virtualPath}, paths,
+		"deduplication must use the same storage snapshot that was yielded")
+}
+
+func TestOpenCodeHybridStreamingRetainedHeapDoesNotScaleWithStorageArchive(
+	t *testing.T,
+) {
+	measureRetainedHeap := func(storageSessions int) uint64 {
+		t.Helper()
+		root := t.TempDir()
+		sessionDir := filepath.Join(root, "storage", "session", "global")
+		require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+		for i := range storageSessions {
+			name := fmt.Sprintf(
+				"ses_%05d_%s.json", i, strings.Repeat("x", 160),
+			)
+			require.NoError(t, os.WriteFile(
+				filepath.Join(sessionDir, name), []byte("{}"), 0o600,
+			))
+		}
+		dbPath, seeder, db := newTestDBAt(t, filepath.Join(root, "opencode.db"))
+		seeder.AddProject("prj_1", "/home/user/code/sqlite-app")
+		seeder.AddSession(
+			"ses_sqlite", "prj_1", "", "SQLite", 1700000000000, 1700000010000,
+		)
+		provider, ok := NewProvider(
+			AgentOpenCode, ProviderConfig{Roots: []string{root}},
+		)
+		require.True(t, ok)
+		virtualPath := OpenCodeSQLiteVirtualPath(dbPath, "ses_sqlite")
+
+		runtime.GC()
+		var before runtime.MemStats
+		runtime.ReadMemStats(&before)
+		var retained uint64
+		measured := false
+		err := provider.(StreamingDiscoverer).DiscoverEach(
+			t.Context(), func(source SourceRef) error {
+				if source.DisplayPath != virtualPath {
+					return nil
+				}
+				measured = true
+				runtime.GC()
+				var during runtime.MemStats
+				runtime.ReadMemStats(&during)
+				if during.HeapAlloc > before.HeapAlloc {
+					retained = during.HeapAlloc - before.HeapAlloc
+				}
+				return nil
+			},
+		)
+		require.NoError(t, err)
+		require.True(t, measured,
+			"retained heap must be sampled at the SQLite virtual source")
+		require.NoError(t, db.Close())
+		return retained
+	}
+
+	const retainedGrowthLimit = 256 * 1024
+	smallRetained := measureRetainedHeap(16)
+	largeRetained := measureRetainedHeap(4096)
+	assert.LessOrEqual(t, largeRetained, smallRetained+retainedGrowthLimit,
+		"hybrid deduplication must not retain storage IDs on the Go heap")
+}
+
+func TestOpenCodeHybridStreamingDiskMembershipFailuresPropagate(t *testing.T) {
+	tests := []struct {
+		name   string
+		inject func(context.Context, error) context.Context
+	}{
+		{name: "query", inject: WithDiscoveryDiskMapQueryError},
+		{name: "cleanup", inject: WithDiscoveryDiskMapCleanupError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeOpenCodeProviderStorageSession(
+				t, root, "session", "ses_storage", "storage-app", "Storage Session",
+			)
+			_, seeder, db := newTestDBAt(t, filepath.Join(root, "opencode.db"))
+			t.Cleanup(func() { require.NoError(t, db.Close()) })
+			seeder.AddProject("prj_1", "/home/user/code/sqlite-app")
+			seeder.AddSession(
+				"ses_sqlite", "prj_1", "", "SQLite", 1700000000000, 1700000010000,
+			)
+			provider, ok := NewProvider(
+				AgentOpenCode, ProviderConfig{Roots: []string{root}},
+			)
+			require.True(t, ok)
+			injected := errors.New("injected disk membership " + tt.name)
+
+			err := provider.(StreamingDiscoverer).DiscoverEach(
+				tt.inject(t.Context(), injected), func(SourceRef) error { return nil },
+			)
+
+			require.ErrorIs(t, err, injected)
+		})
+	}
+}
+
+func TestOpenCodeHybridStreamingDiscoveryPropagatesSQLiteCallbackError(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	storagePath := writeOpenCodeProviderStorageSession(
+		t, root, "session", "ses_storage", "storage-app", "Storage Session",
+	)
+	dbPath, seeder, db := newTestDBAt(t, filepath.Join(root, "opencode.db"))
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	seeder.AddProject("prj_1", "/home/user/code/sqlite-app")
+	seeder.AddSession(
+		"ses_sqlite", "prj_1", "", "SQLite", 1700000000000, 1700000010000,
+	)
+	virtualPath := OpenCodeSQLiteVirtualPath(dbPath, "ses_sqlite")
+	provider, ok := NewProvider(AgentOpenCode, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	sentinel := errors.New("stop after SQLite source")
+	var yielded []string
+
+	err := provider.(StreamingDiscoverer).DiscoverEach(
+		t.Context(), func(source SourceRef) error {
+			yielded = append(yielded, source.DisplayPath)
+			if source.DisplayPath == virtualPath {
+				return sentinel
+			}
+			return nil
+		},
+	)
+
+	require.ErrorIs(t, err, sentinel)
+	assert.Equal(t, []string{storagePath, virtualPath}, yielded)
 }
 
 func TestOpenCodeProviderDiscoveryToleratesCorruptSQLiteDB(t *testing.T) {

--- a/internal/parser/openhands_provider.go
+++ b/internal/parser/openhands_provider.go
@@ -47,6 +47,10 @@ func (p *openHandsProvider) Discover(ctx context.Context) ([]SourceRef, error) {
 	return p.sources.Discover(ctx)
 }
 
+func (p *openHandsProvider) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	return p.sources.DiscoverEach(ctx, yield)
+}
+
 func (p *openHandsProvider) WatchPlan(ctx context.Context) (WatchPlan, error) {
 	return p.sources.WatchPlan(ctx)
 }
@@ -148,6 +152,29 @@ func (s openHandsSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
 	}
 	sortJSONLSources(sources)
 	return sources, nil
+}
+
+func (s openHandsSourceSet) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	for _, root := range s.roots {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		err := streamDirectoryEntries(ctx, root, func(entry os.DirEntry) error {
+			if !entry.IsDir() || !IsValidSessionID(entry.Name()) {
+				return nil
+			}
+			if source, ok := s.sourceRef(root, filepath.Join(root, entry.Name())); ok {
+				if err := yield(source); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (s openHandsSourceSet) WatchPlan(context.Context) (WatchPlan, error) {
@@ -393,6 +420,7 @@ func openHandsProviderCapabilities() Capabilities {
 	return Capabilities{
 		Source: SourceCapabilities{
 			DiscoverSources:      CapabilitySupported,
+			StreamingDiscovery:   CapabilitySupported,
 			WatchSources:         CapabilitySupported,
 			ClassifyChangedPath:  CapabilitySupported,
 			FindSource:           CapabilitySupported,

--- a/internal/parser/pi_provider.go
+++ b/internal/parser/pi_provider.go
@@ -51,6 +51,16 @@ func (p *piProvider) Discover(ctx context.Context) ([]SourceRef, error) {
 	return p.filterDiscoveredSources(sources), nil
 }
 
+func (p *piProvider) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	return p.sources.DiscoverEach(ctx, func(source SourceRef) error {
+		src, ok := source.Opaque.(JSONLSource)
+		if !ok || !IsPiSessionFile(src.Path) {
+			return nil
+		}
+		return yield(source)
+	})
+}
+
 func (p *piProvider) WatchPlan(ctx context.Context) (WatchPlan, error) {
 	return p.sources.WatchPlan(ctx)
 }
@@ -284,7 +294,7 @@ func piSessionIDFromPath(root, path string) string {
 }
 
 func piProviderCapabilities() Capabilities {
-	return Capabilities{
+	caps := Capabilities{
 		Source: jsonlFileProviderSourceCapabilities(),
 		Content: ContentCapabilities{
 			FirstMessage:         CapabilitySupported,
@@ -298,4 +308,6 @@ func piProviderCapabilities() Capabilities {
 			Model:                CapabilitySupported,
 		},
 	}
+	caps.Source.StreamingDiscovery = CapabilitySupported
+	return caps
 }

--- a/internal/parser/piebald.go
+++ b/internal/parser/piebald.go
@@ -1,8 +1,10 @@
 package parser
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -36,17 +38,31 @@ func piebaldDBPath(dir string) string {
 
 // ListPiebaldSessionMeta returns lightweight metadata for all non-empty chats.
 func ListPiebaldSessionMeta(dbPath string) ([]PiebaldSessionMeta, error) {
+	var metas []PiebaldSessionMeta
+	err := ForEachPiebaldSessionMeta(
+		context.Background(), dbPath,
+		func(meta PiebaldSessionMeta) error {
+			metas = append(metas, meta)
+			return nil
+		},
+	)
+	return metas, err
+}
+
+func ForEachPiebaldSessionMeta(
+	ctx context.Context, dbPath string, yield func(PiebaldSessionMeta) error,
+) error {
 	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
-		return nil, nil
+		return nil
 	}
 
 	db, err := openPiebaldDB(dbPath)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer db.Close()
 
-	rows, err := db.Query(`
+	rows, err := db.QueryContext(ctx, `
 		SELECT id,
 		       COALESCE(updated_at, created_at)
 		FROM chats
@@ -54,24 +70,54 @@ func ListPiebaldSessionMeta(dbPath string) ([]PiebaldSessionMeta, error) {
 		  AND message_count > 0
 	`)
 	if err != nil {
-		return nil, fmt.Errorf("listing piebald chats: %w", err)
+		return fmt.Errorf("listing piebald chats: %w", err)
 	}
 	defer rows.Close()
 
-	var metas []PiebaldSessionMeta
 	for rows.Next() {
 		var id int64
 		var updatedAt string
 		if err := rows.Scan(&id, &updatedAt); err != nil {
-			return nil, fmt.Errorf("scanning piebald chat meta: %w", err)
+			return fmt.Errorf("scanning piebald chat meta: %w", err)
 		}
-		metas = append(metas, PiebaldSessionMeta{
+		observeStreamingDiscoveryBuffer(ctx, 1)
+		if err := yield(PiebaldSessionMeta{
 			SessionID:   fmt.Sprintf("%d", id),
 			VirtualPath: fmt.Sprintf("%s#%d", dbPath, id),
 			FileMtime:   parsePiebaldTimestamp(updatedAt).UnixNano(),
-		})
+		}); err != nil {
+			return err
+		}
 	}
-	return metas, rows.Err()
+	return rows.Err()
+}
+
+func piebaldSessionMeta(
+	ctx context.Context, dbPath, sessionID string,
+) (PiebaldSessionMeta, bool, error) {
+	db, err := openPiebaldDB(dbPath)
+	if err != nil {
+		return PiebaldSessionMeta{}, false, err
+	}
+	defer db.Close()
+	var id int64
+	var updatedAt string
+	err = db.QueryRowContext(ctx, `
+		SELECT id, COALESCE(updated_at, created_at)
+		FROM chats
+		WHERE id = ? AND COALESCE(is_deleted, 0) = 0 AND message_count > 0
+	`, sessionID).Scan(&id, &updatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return PiebaldSessionMeta{}, false, nil
+	}
+	if err != nil {
+		return PiebaldSessionMeta{}, false, err
+	}
+	idString := fmt.Sprintf("%d", id)
+	return PiebaldSessionMeta{
+		SessionID: idString, VirtualPath: VirtualSourcePath(dbPath, idString),
+		FileMtime: parsePiebaldTimestamp(updatedAt).UnixNano(),
+	}, true, nil
 }
 
 // parsePiebaldSessionResults parses a single Piebald chat and any large

--- a/internal/parser/posit_assistant_provider.go
+++ b/internal/parser/posit_assistant_provider.go
@@ -76,6 +76,10 @@ func (p *positAssistantProvider) Discover(ctx context.Context) ([]SourceRef, err
 	return p.sources.Discover(ctx)
 }
 
+func (p *positAssistantProvider) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	return p.sources.DiscoverEach(ctx, yield)
+}
+
 func (p *positAssistantProvider) WatchPlan(ctx context.Context) (WatchPlan, error) {
 	return p.sources.WatchPlan(ctx)
 }
@@ -201,6 +205,57 @@ func (s positAssistantSourceSet) Discover(ctx context.Context) ([]SourceRef, err
 	}
 	sortJSONLSources(sources)
 	return sources, nil
+}
+
+func (s positAssistantSourceSet) DiscoverEach(
+	ctx context.Context, yield func(SourceRef) error,
+) error {
+	for _, root := range s.roots {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		err := streamDirectoryEntries(ctx, root, func(workspace os.DirEntry) error {
+			if !workspace.IsDir() {
+				return nil
+			}
+			wsDir := filepath.Join(root, workspace.Name())
+			project, cwd := positAssistantWorkspaceProject(wsDir)
+			return streamDirectoryEntries(ctx, wsDir, func(entry os.DirEntry) error {
+				if entry.IsDir() {
+					return s.yieldConversationSources(ctx, root, filepath.Join(wsDir, entry.Name()), project, cwd, yield)
+				}
+				return nil
+			})
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s positAssistantSourceSet) yieldConversationSources(
+	ctx context.Context, root, convDir, project, cwd string,
+	yield func(SourceRef) error,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if !IsValidSessionID(filepath.Base(convDir)) {
+		return nil
+	}
+	convPath := filepath.Join(convDir, positAssistantConversationFile)
+	if IsRegularFile(convPath) {
+		if err := yield(s.newSourceRef(root, convPath, project, cwd)); err != nil {
+			return err
+		}
+	}
+	return streamDirectoryEntries(ctx, filepath.Join(convDir, positAssistantSubagentsDir), func(sub os.DirEntry) error {
+		if sub.IsDir() {
+			return s.yieldConversationSources(ctx, root, filepath.Join(convDir, positAssistantSubagentsDir, sub.Name()), project, cwd, yield)
+		}
+		return nil
+	})
 }
 
 // collectConversationSources adds convDir as a source when it holds a
@@ -1017,6 +1072,7 @@ func positAssistantProviderCapabilities() Capabilities {
 	return Capabilities{
 		Source: SourceCapabilities{
 			DiscoverSources:      CapabilitySupported,
+			StreamingDiscovery:   CapabilitySupported,
 			WatchSources:         CapabilitySupported,
 			ClassifyChangedPath:  CapabilitySupported,
 			FindSource:           CapabilitySupported,

--- a/internal/parser/positron_provider.go
+++ b/internal/parser/positron_provider.go
@@ -47,6 +47,10 @@ func (p *positronProvider) Discover(ctx context.Context) ([]SourceRef, error) {
 	return p.sources.Discover(ctx)
 }
 
+func (p *positronProvider) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	return p.sources.DiscoverEach(ctx, yield)
+}
+
 func (p *positronProvider) WatchPlan(ctx context.Context) (WatchPlan, error) {
 	return p.sources.WatchPlan(ctx)
 }
@@ -203,6 +207,34 @@ func (s positronSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
 	}
 	sortJSONLSources(sources)
 	return sources, nil
+}
+
+func (s positronSourceSet) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	for _, root := range s.roots {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		workspaceRoot := filepath.Join(root, "workspaceStorage")
+		err := streamDirectoryEntries(ctx, workspaceRoot, func(entry os.DirEntry) error {
+			if !entry.IsDir() {
+				return nil
+			}
+			project := positronWorkspaceProject(root, entry.Name())
+			chatDir := filepath.Join(workspaceRoot, entry.Name(), "chatSessions")
+			return streamVSCodeSessionFiles(ctx, chatDir, project, AgentPositron, func(file DiscoveredFile) error {
+				source, ok := s.sourceRefWithProject(root, file.Path, file.Project)
+				if !ok {
+					return nil
+				}
+				source.ProjectHint = file.Project
+				return yield(source)
+			})
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // discoverSessions finds all chat session files under a Positron User
@@ -567,6 +599,7 @@ func positronProviderCapabilities() Capabilities {
 	return Capabilities{
 		Source: SourceCapabilities{
 			DiscoverSources:      CapabilitySupported,
+			StreamingDiscovery:   CapabilitySupported,
 			WatchSources:         CapabilitySupported,
 			ClassifyChangedPath:  CapabilitySupported,
 			FindSource:           CapabilitySupported,

--- a/internal/parser/provider.go
+++ b/internal/parser/provider.go
@@ -9,6 +9,7 @@ import (
 const (
 	ProviderFeatureFingerprint = "fingerprint"
 	ProviderFeatureParse       = "parse"
+	ProviderFeatureWatchRoots  = "watch roots"
 )
 
 // ErrUnsupportedProviderFeature identifies optional provider behavior that is
@@ -93,6 +94,84 @@ type Provider interface {
 	) (IncrementalOutcome, IncrementalStatus, error)
 }
 
+// ReconciliationSourceResolver rebuilds the exact source emitted by streaming
+// discovery without routing the virtual path back through changed-path
+// classification. Shared-container providers use it to avoid rescanning every
+// member in the container once per spool page/member.
+type ReconciliationSourceResolver interface {
+	SourceForReconciliation(
+		context.Context, string, string,
+	) (SourceRef, bool, error)
+}
+
+// ReconciliationSourceRank is compared lexicographically after configured-root
+// priority when authoritative discovery finds duplicate logical sources.
+type ReconciliationSourceRank struct {
+	Class   int64
+	Recency int64
+}
+
+// ReconciliationSourceRanker declares provider-specific duplicate ordering so
+// authoritative reconciliation selects the same source as FindSource.
+type ReconciliationSourceRanker interface {
+	ReconciliationSourceRank(SourceRef) ReconciliationSourceRank
+}
+
+// ReconciliationMemberIdentityResolver derives the stable logical-member
+// identity stored in a full session ID. Providers whose virtual paths can be
+// reused declare this alongside SourceRef.ReconciliationIdentity so the engine
+// can validate both the path and the member during authoritative discovery.
+type ReconciliationMemberIdentityResolver interface {
+	ReconciliationMemberIdentity(fullSessionID string) string
+}
+
+// ReconciliationAggregateMemberResolver maps an ownership row whose stored
+// FilePath is a still-present multi-member container to the source paths
+// streamed discovery may emit for that member. Container discovery records
+// the container path itself for every member, so a removed member never
+// trips the missing-path stat; the engine verifies such rows against
+// streamed membership explicitly and tombstones rows none of the candidate
+// paths represent. Returning nil opts the row out of the check.
+type ReconciliationAggregateMemberResolver interface {
+	ReconciliationAggregateMemberPaths(
+		filePath string, fullSessionID string,
+	) []string
+}
+
+// PersistentArchiveSourceResolver validates that a stored source belongs to a
+// provider-specific persistent container and returns its physical path. The
+// engine must not infer this policy from provider-neutral virtual-path syntax:
+// hybrid providers can also own ordinary files whose paths contain the same
+// delimiter.
+type PersistentArchiveSourceResolver interface {
+	PersistentArchiveSource(
+		path string, fullSessionID string,
+	) (physicalPath string, ok bool)
+}
+
+// StoredSourceHintScope identifies one bounded stored-path prefix. Providers
+// explicitly declare virtual-member ownership because filename shape cannot
+// distinguish extensionless containers from ordinary paths.
+type StoredSourceHintScope struct {
+	Path                  string
+	IncludeVirtualMembers bool
+}
+
+// StoredSourceHintScopeProvider derives the stored-source scopes that can
+// affect one changed path without reading the archive database.
+type StoredSourceHintScopeProvider interface {
+	StoredSourceHintScopes(ChangedPathRequest) []StoredSourceHintScope
+}
+
+// ReconciliationOwnershipScopeProvider maps one logical configured root to
+// the bounded stored-source scopes it physically owns. Providers whose stored
+// identities are virtual members of a sibling container use this to keep
+// deletion ownership paging within that container without broadening the scan
+// to the provider's full archive.
+type ReconciliationOwnershipScopeProvider interface {
+	ReconciliationOwnershipScopes(root string) []StoredSourceHintScope
+}
+
 // ProviderBase is embedded by concrete providers to make optional source
 // methods callable with zero-value no-op behavior.
 type ProviderBase struct {
@@ -174,6 +253,11 @@ type SourceRef struct {
 	// file_path values unless a documented provider-specific transition handles
 	// old rows.
 	FingerprintKey string
+	// ReconciliationIdentity is an optional stable logical-member identity used
+	// with DisplayPath to distinguish virtual sources whose positional path can
+	// later be reused by a different member. It is never persisted as source
+	// metadata and is consumed only by authoritative discovery reconciliation.
+	ReconciliationIdentity string
 	// ProjectHint is advisory metadata for UI grouping and may be empty.
 	ProjectHint string
 	// DiscoveryMTimeNS is an optional per-source modification time in Unix
@@ -203,6 +287,54 @@ type SourceRef struct {
 // fields are fallback compatibility only.
 type WatchPlan struct {
 	Roots []WatchRoot
+}
+
+// WatchRootPlanner is the optional bounded scheduling surface for providers
+// and source sets. Unlike WatchPlan, it returns only watcher root metadata and
+// must not discover sources to derive parser-only include globs.
+type WatchRootPlanner interface {
+	WatchRoots(context.Context) ([]WatchRoot, error)
+}
+
+// ResolveWatchRoots returns the bounded root-planning capability when a
+// provider advertises it. Providers that have not migrated yet retain their
+// WatchPlan behavior, but parser-only include/exclude globs are never carried
+// into watcher scheduling.
+func ResolveWatchRoots(
+	ctx context.Context,
+	provider Provider,
+) ([]WatchRoot, error) {
+	if provider.Capabilities().Source.WatchRoots == CapabilitySupported {
+		planner, ok := provider.(WatchRootPlanner)
+		if !ok {
+			return nil, UnsupportedProviderFeatureError{
+				Provider: provider.Definition().Type,
+				Feature:  ProviderFeatureWatchRoots,
+			}
+		}
+		roots, err := planner.WatchRoots(ctx)
+		if err != nil {
+			return nil, err
+		}
+		return watchRootMetadata(roots), nil
+	}
+	plan, err := provider.WatchPlan(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return watchRootMetadata(plan.Roots), nil
+}
+
+func watchRootMetadata(roots []WatchRoot) []WatchRoot {
+	out := make([]WatchRoot, 0, len(roots))
+	for _, root := range roots {
+		out = append(out, WatchRoot{
+			Path:        root.Path,
+			Recursive:   root.Recursive,
+			DebounceKey: root.DebounceKey,
+		})
+	}
+	return out
 }
 
 // WatchRoot is one filesystem root the engine should watch. Recursive roots
@@ -369,6 +501,22 @@ type IncrementalRequest struct {
 	// value could fill a still-empty stored field.
 	StoredAgentLabel string
 	StoredEntrypoint string
+	// StoredClaudeLinearParse mirrors the session's persisted
+	// claude_linear_parse flag: whether the last full parse fell back
+	// to linear processing. Linearity is monotonic across appends, so
+	// a true value lets the Claude incremental parser skip fork
+	// detection — the full parser processes such files in line order
+	// regardless of parent uuids. nil (unknown, legacy rows) or false
+	// keeps strict fork detection.
+	StoredClaudeLinearParse *bool
+	// StoredLastClaudeMessageID is the provider message id of the last
+	// stored assistant message for this session (empty when none), or
+	// nil when the call site cannot supply it. The Claude incremental
+	// parser uses it to keep routine queued-command appends
+	// incremental: the queued-command masking fallback fires only when
+	// the appended assistant head continues exactly this message id.
+	// nil keeps the conservative fallback.
+	StoredLastClaudeMessageID *string
 }
 
 // IncrementalOutcome is the append-only parse output.

--- a/internal/parser/provider_capabilities.go
+++ b/internal/parser/provider_capabilities.go
@@ -1,5 +1,10 @@
 package parser
 
+func withWatchRootPlanningCapability(caps Capabilities) Capabilities {
+	caps.Source.WatchRoots = CapabilitySupported
+	return caps
+}
+
 func jsonlFileProviderSourceCapabilities() SourceCapabilities {
 	return SourceCapabilities{
 		DiscoverSources:      CapabilitySupported,

--- a/internal/parser/provider_capabilities_test.go
+++ b/internal/parser/provider_capabilities_test.go
@@ -1,0 +1,343 @@
+package parser
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProviderCapabilitiesWatchRootsDefaultUnsupported(t *testing.T) {
+	assert.Equal(t, CapabilityUnsupported, (SourceCapabilities{}).WatchRoots)
+}
+
+func TestProviderCapabilitiesStreamingDiscoveryDefaultUnsupported(t *testing.T) {
+	assert.Equal(t, CapabilityUnsupported, (SourceCapabilities{}).StreamingDiscovery)
+}
+
+func TestProviderCapabilitiesPersistentArchiveDefaultUnsupported(t *testing.T) {
+	assert.Equal(t, CapabilityUnsupported, (SourceCapabilities{}).PersistentArchive)
+}
+
+func TestWatchSourceProvidersDiscoverEachDirectly(t *testing.T) {
+	for _, factory := range ProviderFactories() {
+		t.Run(string(factory.Definition().Type), func(t *testing.T) {
+			caps := factory.Capabilities().Source
+			if caps.WatchSources != CapabilitySupported ||
+				caps.DiscoverSources != CapabilitySupported {
+				t.Skip("provider does not participate in watched discovery")
+			}
+			assert.Equal(t, CapabilitySupported, caps.StreamingDiscovery)
+			assert.Equal(t, CapabilitySupported, caps.WatchSources)
+			assert.Equal(t, CapabilitySupported, caps.DiscoverSources)
+			provider := factory.NewProvider(ProviderConfig{Roots: []string{t.TempDir()}})
+			_, ok := provider.(StreamingDiscoverer)
+			assert.True(t, ok)
+			if caps.SharedContainerSource == CapabilitySupported {
+				_, exact := provider.(ReconciliationSourceResolver)
+				assert.True(t, exact,
+					"every shared-container streaming provider must advertise exact rehydration")
+			}
+			if ok {
+				require.NoError(t, provider.(StreamingDiscoverer).DiscoverEach(
+					t.Context(), func(SourceRef) error { return nil },
+				))
+			}
+		})
+	}
+}
+
+func TestSourceSetProviderDiscoverEachDoesNotCallCollectingDiscover(t *testing.T) {
+	sources := &streamingSourceSetTestDouble{}
+	provider := &SourceSetProvider{
+		ProviderBase: ProviderBase{Def: AgentDef{Type: "stream-test"}},
+		sources:      sources,
+	}
+
+	var got []SourceRef
+	err := provider.DiscoverEach(t.Context(), func(source SourceRef) error {
+		got = append(got, source)
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []SourceRef{{Provider: "stream-test", Key: "one"}}, got)
+	assert.Zero(t, sources.discoverCalls)
+}
+
+func TestSourceSetFactoryDowngradesStreamingForCollectingSourceSet(t *testing.T) {
+	factory := NewSourceSetFactory(
+		AgentDef{Type: "non-streaming-source-set"},
+		Capabilities{},
+		func(ProviderConfig) SourceSet { return nonStreamingSourceSetTestDouble{} },
+	)
+
+	assert.Equal(t, CapabilitySupported,
+		factory.Capabilities().Source.StreamingDiscovery)
+	assert.Equal(t, CapabilityUnsupported,
+		factory.NewProvider(ProviderConfig{}).Capabilities().Source.StreamingDiscovery)
+}
+
+func TestProviderMigrationRejectsSourceSetWrapperWithoutUnderlyingStreaming(t *testing.T) {
+	factory := NewSourceSetFactory(
+		AgentDef{Type: "invalid-source-set-streaming"},
+		Capabilities{Source: SourceCapabilities{
+			DiscoverSources: CapabilitySupported,
+			FindSource:      CapabilitySupported,
+		}},
+		func(ProviderConfig) SourceSet { return nonStreamingSourceSetTestDouble{} },
+	)
+
+	err := ValidateProviderMigrationModes(
+		[]ProviderFactory{factory},
+		map[AgentType]ProviderMigrationMode{
+			"invalid-source-set-streaming": ProviderMigrationProviderAuthoritative,
+		},
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "underlying source set")
+}
+
+func TestProviderMigrationRejectsStreamingCapabilityWithoutInterface(t *testing.T) {
+	factory := testProviderFactory{
+		def: AgentDef{Type: "invalid-streaming-provider"},
+		caps: Capabilities{Source: SourceCapabilities{
+			DiscoverSources:    CapabilitySupported,
+			FindSource:         CapabilitySupported,
+			StreamingDiscovery: CapabilitySupported,
+		}},
+	}
+
+	err := ValidateProviderMigrationModes(
+		[]ProviderFactory{factory},
+		map[AgentType]ProviderMigrationMode{
+			"invalid-streaming-provider": ProviderMigrationProviderAuthoritative,
+		},
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "StreamingDiscoverer")
+}
+
+func TestProviderMigrationRejectsSharedContainerWithoutExactRehydration(t *testing.T) {
+	factory := streamingWithoutExactFactory{testProviderFactory{
+		def: AgentDef{Type: "invalid-shared-container-provider"}, caps: Capabilities{Source: SourceCapabilities{
+			DiscoverSources:       CapabilitySupported,
+			FindSource:            CapabilitySupported,
+			StreamingDiscovery:    CapabilitySupported,
+			SharedContainerSource: CapabilitySupported,
+		}},
+	}}
+
+	err := ValidateProviderMigrationModes(
+		[]ProviderFactory{factory},
+		map[AgentType]ProviderMigrationMode{
+			"invalid-shared-container-provider": ProviderMigrationProviderAuthoritative,
+		},
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exact reconciliation rehydration")
+}
+
+func TestSourceSetFactoryDowngradesAndRejectsMissingExactRehydration(t *testing.T) {
+	factory := NewSourceSetFactory(
+		AgentDef{Type: "invalid-shared-source-set"},
+		Capabilities{Source: SourceCapabilities{
+			DiscoverSources:       CapabilitySupported,
+			FindSource:            CapabilitySupported,
+			SharedContainerSource: CapabilitySupported,
+		}},
+		func(ProviderConfig) SourceSet { return &streamingSourceSetTestDouble{} },
+	)
+	provider := factory.NewProvider(ProviderConfig{})
+
+	assert.Equal(t, CapabilityUnsupported,
+		provider.Capabilities().Source.SharedContainerSource)
+	err := ValidateProviderMigrationModes(
+		[]ProviderFactory{factory},
+		map[AgentType]ProviderMigrationMode{
+			"invalid-shared-source-set": ProviderMigrationProviderAuthoritative,
+		},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "underlying source set")
+	assert.Contains(t, err.Error(), "exact reconciliation rehydration")
+}
+
+func TestProviderCapabilitiesRequireWatchRootPlanner(t *testing.T) {
+	provider := &watchRootCapabilityTestProvider{
+		ProviderBase: ProviderBase{
+			Def: AgentDef{Type: "watch-root-test"},
+			Caps: Capabilities{Source: SourceCapabilities{
+				WatchRoots: CapabilitySupported,
+			}},
+		},
+		plan: WatchPlan{Roots: []WatchRoot{{Path: "/fallback"}}},
+	}
+
+	_, err := ResolveWatchRoots(context.Background(), provider)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnsupportedProviderFeature)
+	assert.Zero(t, provider.watchPlanCalls,
+		"a false capability advertisement must not silently take the legacy path")
+}
+
+func TestProviderCapabilitiesFallbackWatchPlanRetainsOnlyRootMetadata(t *testing.T) {
+	provider := &watchRootCapabilityTestProvider{
+		ProviderBase: ProviderBase{Def: AgentDef{Type: "legacy-watch-root-test"}},
+		plan: WatchPlan{Roots: []WatchRoot{{
+			Path:         "/sessions",
+			Recursive:    true,
+			IncludeGlobs: []string{"*.jsonl"},
+			ExcludeGlobs: []string{"*.tmp"},
+			DebounceKey:  "legacy:sessions",
+		}}},
+	}
+
+	roots, err := ResolveWatchRoots(context.Background(), provider)
+	require.NoError(t, err)
+	assert.Equal(t, []WatchRoot{{
+		Path:        "/sessions",
+		Recursive:   true,
+		DebounceKey: "legacy:sessions",
+	}}, roots)
+	assert.Equal(t, 1, provider.watchPlanCalls)
+}
+
+func TestProviderCapabilitiesSourceSetAdapterImplementsWatchRootPlanner(t *testing.T) {
+	root := filepath.Clean("/sessions")
+	factory := NewSourceSetFactory(
+		AgentDef{Type: "source-set-watch-root-test"},
+		Capabilities{},
+		func(cfg ProviderConfig) SourceSet {
+			return NewJSONLSourceSet("source-set-watch-root-test", cfg.Roots)
+		},
+	)
+	provider := factory.NewProvider(ProviderConfig{Roots: []string{root}})
+
+	assert.Equal(t, CapabilitySupported, provider.Capabilities().Source.WatchRoots)
+	planner, ok := provider.(WatchRootPlanner)
+	require.True(t, ok)
+	roots, err := planner.WatchRoots(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []WatchRoot{{
+		Path:        root,
+		DebounceKey: "source-set-watch-root-test:jsonl:" + root,
+	}}, roots)
+}
+
+type watchRootCapabilityTestProvider struct {
+	ProviderBase
+	plan           WatchPlan
+	watchPlanCalls int
+}
+
+type streamingSourceSetTestDouble struct {
+	discoverCalls int
+}
+
+type streamingWithoutExactFactory struct{ testProviderFactory }
+
+func (factory streamingWithoutExactFactory) NewProvider(cfg ProviderConfig) Provider {
+	return &streamingWithoutExactProvider{testProvider: testProvider{ProviderBase: ProviderBase{
+		Def: factory.def, Caps: factory.caps, Config: cfg.Clone(),
+	}}}
+}
+
+type streamingWithoutExactProvider struct{ testProvider }
+
+func (*streamingWithoutExactProvider) DiscoverEach(
+	context.Context, func(SourceRef) error,
+) error {
+	return nil
+}
+
+type nonStreamingSourceSetTestDouble struct{}
+
+func (nonStreamingSourceSetTestDouble) Discover(context.Context) ([]SourceRef, error) {
+	return nil, nil
+}
+
+func (nonStreamingSourceSetTestDouble) WatchPlan(context.Context) (WatchPlan, error) {
+	return WatchPlan{}, nil
+}
+
+func (nonStreamingSourceSetTestDouble) SourcesForChangedPath(
+	context.Context, ChangedPathRequest,
+) ([]SourceRef, error) {
+	return nil, nil
+}
+
+func (nonStreamingSourceSetTestDouble) FindSource(
+	context.Context, FindSourceRequest,
+) (SourceRef, bool, error) {
+	return SourceRef{}, false, nil
+}
+
+func (nonStreamingSourceSetTestDouble) Fingerprint(
+	context.Context, SourceRef,
+) (SourceFingerprint, error) {
+	return SourceFingerprint{}, nil
+}
+
+func (nonStreamingSourceSetTestDouble) Parse(
+	context.Context, ParseRequest,
+) (ParseOutcome, error) {
+	return ParseOutcome{}, nil
+}
+
+func (s *streamingSourceSetTestDouble) Discover(context.Context) ([]SourceRef, error) {
+	s.discoverCalls++
+	return nil, errors.New("collecting discovery must not be called")
+}
+
+func (s *streamingSourceSetTestDouble) DiscoverEach(
+	_ context.Context, yield func(SourceRef) error,
+) error {
+	return yield(SourceRef{Provider: "stream-test", Key: "one"})
+}
+
+func (*streamingSourceSetTestDouble) WatchPlan(context.Context) (WatchPlan, error) {
+	return WatchPlan{}, nil
+}
+
+func (*streamingSourceSetTestDouble) SourcesForChangedPath(
+	context.Context, ChangedPathRequest,
+) ([]SourceRef, error) {
+	return nil, nil
+}
+
+func (*streamingSourceSetTestDouble) FindSource(
+	context.Context, FindSourceRequest,
+) (SourceRef, bool, error) {
+	return SourceRef{}, false, nil
+}
+
+func (*streamingSourceSetTestDouble) Fingerprint(
+	context.Context, SourceRef,
+) (SourceFingerprint, error) {
+	return SourceFingerprint{}, nil
+}
+
+func (*streamingSourceSetTestDouble) Parse(
+	context.Context, ParseRequest,
+) (ParseOutcome, error) {
+	return ParseOutcome{}, nil
+}
+
+func (p *watchRootCapabilityTestProvider) WatchPlan(context.Context) (WatchPlan, error) {
+	p.watchPlanCalls++
+	return p.plan, nil
+}
+
+func (p *watchRootCapabilityTestProvider) Parse(
+	context.Context,
+	ParseRequest,
+) (ParseOutcome, error) {
+	return ParseOutcome{}, nil
+}

--- a/internal/parser/provider_migration.go
+++ b/internal/parser/provider_migration.go
@@ -126,6 +126,39 @@ func validateProviderMigrationMode(
 				def.Type, mode,
 			)
 		}
+		if caps.StreamingDiscovery == CapabilitySupported {
+			provider := factory.NewProvider(ProviderConfig{})
+			if sourceSetProvider, ok := provider.(*SourceSetProvider); ok {
+				if _, ok := sourceSetProvider.sources.(StreamingDiscoverer); !ok {
+					return fmt.Errorf(
+						"%s: streaming discovery capability requires underlying source set StreamingDiscoverer",
+						def.Type,
+					)
+				}
+			}
+			if _, ok := provider.(StreamingDiscoverer); !ok {
+				return fmt.Errorf(
+					"%s: streaming discovery capability requires StreamingDiscoverer",
+					def.Type,
+				)
+			}
+			if caps.SharedContainerSource == CapabilitySupported {
+				if sourceSetProvider, ok := provider.(*SourceSetProvider); ok {
+					if _, ok := sourceSetProvider.sources.(ReconciliationSourceResolver); !ok {
+						return fmt.Errorf(
+							"%s: shared-container streaming requires underlying source set exact reconciliation rehydration",
+							def.Type,
+						)
+					}
+				}
+				if _, ok := provider.(ReconciliationSourceResolver); !ok {
+					return fmt.Errorf(
+						"%s: shared-container streaming requires exact reconciliation rehydration",
+						def.Type,
+					)
+				}
+			}
+		}
 	case ProviderMigrationImportOnly:
 		if !isImportOnlyAgentType(def.Type) {
 			return fmt.Errorf(

--- a/internal/parser/provider_streaming_scale_test.go
+++ b/internal/parser/provider_streaming_scale_test.go
@@ -1,0 +1,200 @@
+package parser
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDatabaseAndContainerProvidersStreamLargeArchives(t *testing.T) {
+	const sessions = 130
+
+	tests := []struct {
+		name  string
+		setup func(*testing.T) Provider
+	}{
+		{name: "aider", setup: func(t *testing.T) Provider {
+			root := t.TempDir()
+			for i := range sessions {
+				dir := filepath.Join(root, fmt.Sprintf("project-%03d", i))
+				require.NoError(t, os.MkdirAll(dir, 0o755))
+				require.NoError(t, os.WriteFile(
+					filepath.Join(dir, aiderHistoryFile),
+					[]byte("# aider chat started at 2026-07-14 12:00:00\n#### hello\nworld\n"),
+					0o600,
+				))
+			}
+			provider, ok := NewProvider(AgentAider, ProviderConfig{Roots: []string{root}})
+			require.True(t, ok)
+			return provider
+		}},
+		{name: "kiro", setup: func(t *testing.T) Provider {
+			dbPath, db := newKiroSQLiteTestDB(t)
+			for i := range sessions {
+				seedKiroSQLiteSession(t, db, "/tmp/project", fmt.Sprintf("session-%03d", i),
+					`{"conversation_id":"ignored"}`, 1, int64(i+1))
+			}
+			provider, ok := NewProvider(AgentKiro, ProviderConfig{Roots: []string{filepath.Dir(dbPath)}})
+			require.True(t, ok)
+			return provider
+		}},
+		{name: "hermes", setup: func(t *testing.T) Provider {
+			root := t.TempDir()
+			createHermesStateDB(t, root)
+			db, err := sql.Open("sqlite3", filepath.Join(root, "state.db"))
+			require.NoError(t, err)
+			for i := 1; i < sessions; i++ {
+				id := fmt.Sprintf("session-%03d", i)
+				_, err = db.Exec(`INSERT INTO sessions
+					(id, source, started_at, estimated_cost_usd, actual_cost_usd)
+					VALUES (?, 'cli', ?, 0, 0)`, id, i)
+				require.NoError(t, err)
+				_, err = db.Exec(`INSERT INTO messages (session_id, role, content, timestamp)
+					VALUES (?, 'user', 'hello', ?)`, id, i)
+				require.NoError(t, err)
+			}
+			require.NoError(t, db.Close())
+			provider, ok := NewProvider(AgentHermes, ProviderConfig{Roots: []string{root}})
+			require.True(t, ok)
+			return provider
+		}},
+		{name: "visualstudio-copilot", setup: func(t *testing.T) Provider {
+			root := t.TempDir()
+			path := filepath.Join(root, "20260714T120000_00000000_VSGitHubCopilot_traces.jsonl")
+			var data strings.Builder
+			for i := range sessions {
+				id := fmt.Sprintf("00000000-0000-0000-0000-%012x", i)
+				data.WriteString(vsCopilotTraceLineJSON(id, "chat", "1", "2", map[string]string{
+					"gen_ai.operation.name": "chat",
+				}))
+				data.WriteByte('\n')
+			}
+			require.NoError(t, os.WriteFile(path, []byte(data.String()), 0o600))
+			provider, ok := NewProvider(AgentVSCopilot, ProviderConfig{Roots: []string{root}})
+			require.True(t, ok)
+			return provider
+		}},
+		{name: "windsurf", setup: func(t *testing.T) Provider {
+			root := filepath.Join(t.TempDir(), "Windsurf", "User")
+			dbPath := filepath.Join(root, "workspaceStorage", "workspace", windsurfStateDBName)
+			require.NoError(t, os.MkdirAll(filepath.Dir(dbPath), 0o755))
+			chat := windsurfChatData{Tabs: make([]windsurfChatTab, 0, sessions)}
+			for i := range sessions {
+				chat.Tabs = append(chat.Tabs, windsurfChatTab{
+					TabID:   fmt.Sprintf("session-%03d", i),
+					Bubbles: []windsurfChatBubble{{Type: "user", Text: "hello"}},
+				})
+			}
+			payload, err := json.Marshal(chat)
+			require.NoError(t, err)
+			writeWindsurfStateDB(t, dbPath, string(payload))
+			provider, ok := NewProvider(AgentWindsurf, ProviderConfig{Roots: []string{root}})
+			require.True(t, ok)
+			return provider
+		}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			provider := tc.setup(t)
+			streaming, ok := provider.(StreamingDiscoverer)
+			require.True(t, ok)
+			maxBuffered := 0
+			ctx := WithStreamingDiscoveryBufferObserver(t.Context(), func(buffered int) {
+				maxBuffered = max(maxBuffered, buffered)
+			})
+			count := 0
+			err := streaming.DiscoverEach(ctx, func(SourceRef) error {
+				count++
+				return nil
+			})
+			require.NoError(t, err)
+			assert.Equal(t, sessions, count)
+			assert.LessOrEqual(t, maxBuffered, streamingDirectoryBatchSize)
+
+			stop := errors.New("stop after first source")
+			err = streaming.DiscoverEach(context.Background(), func(SourceRef) error {
+				return stop
+			})
+			require.ErrorIs(t, err, stop)
+		})
+	}
+}
+
+func TestSharedContainerReconciliationCacheAvoidsPerMemberRescans(t *testing.T) {
+	const sessions = 300
+	for _, tc := range []struct {
+		name  string
+		setup func(*testing.T) Provider
+	}{
+		{name: "visualstudio-copilot", setup: func(t *testing.T) Provider {
+			root := t.TempDir()
+			path := filepath.Join(root, "20260714T120000_00000000_VSGitHubCopilot_traces.jsonl")
+			var data strings.Builder
+			for i := range sessions {
+				id := fmt.Sprintf("00000000-0000-0000-0000-%012x", i)
+				data.WriteString(vsCopilotTraceLineJSON(id, "chat", "1", "2", map[string]string{
+					"gen_ai.operation.name": "chat",
+				}))
+				data.WriteByte('\n')
+			}
+			require.NoError(t, os.WriteFile(path, []byte(data.String()), 0o600))
+			provider, ok := NewProvider(AgentVSCopilot, ProviderConfig{Roots: []string{root}})
+			require.True(t, ok)
+			return provider
+		}},
+		{name: "windsurf", setup: func(t *testing.T) Provider {
+			root := filepath.Join(t.TempDir(), "Windsurf", "User")
+			dbPath := filepath.Join(root, "workspaceStorage", "workspace", windsurfStateDBName)
+			require.NoError(t, os.MkdirAll(filepath.Dir(dbPath), 0o755))
+			chat := windsurfChatData{Tabs: make([]windsurfChatTab, 0, sessions)}
+			for i := range sessions {
+				chat.Tabs = append(chat.Tabs, windsurfChatTab{
+					TabID: fmt.Sprintf("session-%03d", i),
+					Bubbles: []windsurfChatBubble{
+						{Type: "user", Text: "hello"},
+						{Type: "assistant", Text: "world"},
+					},
+				})
+			}
+			payload, err := json.Marshal(chat)
+			require.NoError(t, err)
+			writeWindsurfStateDB(t, dbPath, string(payload))
+			provider, ok := NewProvider(AgentWindsurf, ProviderConfig{Roots: []string{root}})
+			require.True(t, ok)
+			return provider
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			provider := tc.setup(t)
+			scans := 0
+			ctx := WithSharedContainerScanObserver(t.Context(), func() { scans++ })
+			ctx, cleanup, err := WithReconciliationCache(ctx)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, cleanup()) })
+			var sources []SourceRef
+			err = provider.(StreamingDiscoverer).DiscoverEach(ctx, func(source SourceRef) error {
+				sources = append(sources, source)
+				return nil
+			})
+			require.NoError(t, err)
+			require.Len(t, sources, sessions)
+			for _, source := range sources {
+				fingerprint, err := provider.Fingerprint(ctx, source)
+				require.NoError(t, err)
+				_, err = provider.Parse(ctx, ParseRequest{Source: source, Fingerprint: fingerprint})
+				require.NoError(t, err)
+			}
+			assert.Equal(t, 1, scans)
+		})
+	}
+}

--- a/internal/parser/provider_test.go
+++ b/internal/parser/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -167,10 +168,49 @@ func TestStoredSourceHintCapabilitiesMatchConsumers(t *testing.T) {
 		got := factory.Capabilities().Source.StoredSourceHints
 		if wantSupported[agent] {
 			assert.Equalf(t, CapabilitySupported, got, "%s consumes stored path hints", agent)
+			provider := factory.NewProvider(ProviderConfig{})
+			assert.Equalf(t, CapabilitySupported,
+				provider.Capabilities().Source.StoredSourceHints,
+				"%s configured provider consumes stored path hints", agent)
+			assert.Implementsf(t, (*StoredSourceHintScopeProvider)(nil), provider,
+				"%s must scope stored hints before the engine queries them", agent)
 		} else {
 			assert.Equalf(t, CapabilityUnsupported, got, "%s must not schedule stored path hints", agent)
 		}
 	}
+}
+
+func TestStoredSourceHintScopesDistinguishContainersFromExactMembers(t *testing.T) {
+	root := t.TempDir()
+	forge, ok := NewProvider(AgentForge, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	forgeScopes := forge.(StoredSourceHintScopeProvider)
+	dbPath := filepath.Join(root, ForgeDBFilename)
+	assert.Equal(t, []StoredSourceHintScope{{
+		Path: dbPath, IncludeVirtualMembers: true,
+	}}, forgeScopes.StoredSourceHintScopes(ChangedPathRequest{
+		Path: dbPath + "-wal", WatchRoot: root,
+	}))
+	virtualPath := VirtualSourcePath(dbPath, "conversation-a")
+	assert.Equal(t, []StoredSourceHintScope{{Path: virtualPath}},
+		forgeScopes.StoredSourceHintScopes(ChangedPathRequest{
+			Path: virtualPath, WatchRoot: root,
+		}))
+
+	visualStudio, ok := NewProvider(AgentVSCopilot, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	visualStudioScopes := visualStudio.(StoredSourceHintScopeProvider)
+	conversationID := "4a8f63f6-7626-4416-a874-fc7bd2c3f005"
+	container := filepath.Join(
+		root, ".vs", "SampleApp", "copilot-chat", "thread", "sessions",
+		conversationID,
+	)
+	assert.Equal(t, []StoredSourceHintScope{{
+		Path: container, IncludeVirtualMembers: true,
+	}}, visualStudioScopes.StoredSourceHintScopes(ChangedPathRequest{Path: container}))
+	member := VisualStudioCopilotVirtualPath(container, conversationID)
+	assert.Equal(t, []StoredSourceHintScope{{Path: member}},
+		visualStudioScopes.StoredSourceHintScopes(ChangedPathRequest{Path: member}))
 }
 
 func TestVerifiedLocalStatCapabilitiesMatchConsumers(t *testing.T) {
@@ -255,7 +295,8 @@ func TestProviderMigrationModesRestrictImportOnlyMode(t *testing.T) {
 }
 
 type testProviderFactory struct {
-	def AgentDef
+	def  AgentDef
+	caps Capabilities
 }
 
 func (f testProviderFactory) Definition() AgentDef {
@@ -263,13 +304,14 @@ func (f testProviderFactory) Definition() AgentDef {
 }
 
 func (f testProviderFactory) Capabilities() Capabilities {
-	return Capabilities{}
+	return f.caps
 }
 
 func (f testProviderFactory) NewProvider(cfg ProviderConfig) Provider {
 	return &testProvider{
 		ProviderBase: ProviderBase{
 			Def:    cloneAgentDef(f.def),
+			Caps:   f.caps,
 			Config: cfg.Clone(),
 		},
 	}

--- a/internal/parser/qoder_provider.go
+++ b/internal/parser/qoder_provider.go
@@ -26,6 +26,7 @@ func newQoderSourceSet(roots []string) JSONLSourceSet {
 		WithParseFile(qoderParseFile),
 		WithForceReplace(),
 		WithCompanionFiles(qoderCompanionFiles),
+		WithCompanionTranscript(qoderCompanionTranscript),
 	)
 }
 
@@ -128,6 +129,11 @@ func qoderCompanionFiles(path string) []string {
 		return []string{stem + "-session.json"}
 	}
 	return nil
+}
+
+func qoderCompanionTranscript(companionPath string) (string, bool) {
+	stem, ok := strings.CutSuffix(companionPath, "-session.json")
+	return stem + ".jsonl", ok
 }
 
 func qoderProviderCapabilities() Capabilities {

--- a/internal/parser/reasonix_provider.go
+++ b/internal/parser/reasonix_provider.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"io"
@@ -23,7 +24,7 @@ func newReasonixProviderFactory(def AgentDef) ProviderFactory {
 			return NewSingleFileSourceSet(
 				AgentReasonix,
 				cfg.Roots,
-				WithFileDiscovery(reasonixDiscoverFiles),
+				WithStreamingFileDiscovery(reasonixDiscoverEach),
 				WithFileWatchRoots(
 					func(roots []string) []WatchRoot {
 						return reasonixWatchRoots(roots, watchSubdirs)
@@ -38,16 +39,18 @@ func newReasonixProviderFactory(def AgentDef) ProviderFactory {
 	)
 }
 
-func reasonixDiscoverFiles(root string) []singleFileMatch {
-	sessions := discoverReasonixSessions(root)
-	out := make([]singleFileMatch, 0, len(sessions))
-	for _, df := range sessions {
-		out = append(out, singleFileMatch{
-			Path:        filepath.Clean(df.Path),
-			ProjectHint: df.Project,
-		})
-	}
-	return out
+func reasonixDiscoverEach(
+	ctx context.Context, root string, yield func(singleFileMatch) error,
+) error {
+	return streamDirectoryTree(ctx, root, func(path string, entry os.DirEntry) error {
+		if !strings.HasSuffix(entry.Name(), ".jsonl") {
+			return nil
+		}
+		if match, ok := reasonixClassifyPath(root, path, false); ok {
+			return yield(match)
+		}
+		return nil
+	})
 }
 
 func reasonixWatchRoots(roots, watchSubdirs []string) []WatchRoot {
@@ -257,6 +260,7 @@ func reasonixProviderCapabilities() Capabilities {
 	return Capabilities{
 		Source: SourceCapabilities{
 			DiscoverSources:      CapabilitySupported,
+			StreamingDiscovery:   CapabilitySupported,
 			WatchSources:         CapabilitySupported,
 			ClassifyChangedPath:  CapabilitySupported,
 			FindSource:           CapabilitySupported,

--- a/internal/parser/reconciliation_cache.go
+++ b/internal/parser/reconciliation_cache.go
@@ -1,0 +1,93 @@
+package parser
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+type reconciliationCache struct {
+	index *discoveryDiskMap
+	onces sync.Map
+}
+
+type reconciliationOnceCell struct {
+	once sync.Once
+	err  error
+}
+
+type reconciliationCacheContextKey struct{}
+
+// WithReconciliationCache attaches one disk-backed cache whose lifetime is the
+// complete reconciliation, including all spool pages and parse workers.
+func WithReconciliationCache(
+	ctx context.Context,
+) (context.Context, func() error, error) {
+	index, err := newDiscoveryDiskMapForContext(ctx)
+	if err != nil {
+		return ctx, nil, err
+	}
+	cache := &reconciliationCache{index: index}
+	return context.WithValue(ctx, reconciliationCacheContextKey{}, cache), index.close, nil
+}
+
+func reconciliationCachePut(ctx context.Context, key, value string) error {
+	cache, _ := ctx.Value(reconciliationCacheContextKey{}).(*reconciliationCache)
+	if cache == nil {
+		return nil
+	}
+	return cache.index.put(ctx, key, value, true)
+}
+
+func reconciliationCacheAvailable(ctx context.Context) bool {
+	cache, _ := ctx.Value(reconciliationCacheContextKey{}).(*reconciliationCache)
+	return cache != nil
+}
+
+func reconciliationCacheGet(ctx context.Context, key string) (string, bool, error) {
+	cache, _ := ctx.Value(reconciliationCacheContextKey{}).(*reconciliationCache)
+	if cache == nil {
+		return "", false, nil
+	}
+	return cache.index.get(ctx, key)
+}
+
+// reconciliationCacheOnce runs fn at most once per key for the lifetime of
+// the reconciliation's cache, serializing concurrent callers so parallel
+// fingerprint workers do not repeat one shared seeding pass. Every caller of
+// the same key observes fn's error. Without a cache in ctx, fn runs directly.
+func reconciliationCacheOnce(
+	ctx context.Context, key string, fn func() error,
+) error {
+	cache, _ := ctx.Value(reconciliationCacheContextKey{}).(*reconciliationCache)
+	if cache == nil {
+		return fn()
+	}
+	cell, _ := cache.onces.LoadOrStore(key, &reconciliationOnceCell{})
+	entry := cell.(*reconciliationOnceCell)
+	entry.once.Do(func() { entry.err = fn() })
+	return entry.err
+}
+
+func reconciliationCacheAppend(ctx context.Context, key, value string) error {
+	cache, _ := ctx.Value(reconciliationCacheContextKey{}).(*reconciliationCache)
+	if cache == nil {
+		return nil
+	}
+	return cache.index.append(ctx, key, value)
+}
+
+func reconciliationCacheAddInt(ctx context.Context, key string) (int, error) {
+	cache, _ := ctx.Value(reconciliationCacheContextKey{}).(*reconciliationCache)
+	if cache == nil {
+		return 0, errors.New("reconciliation cache unavailable")
+	}
+	var next int
+	err := cache.index.db.QueryRowContext(ctx, `
+		INSERT INTO entries (key, ordinal, value) VALUES (?, 0, '1')
+		ON CONFLICT(key, ordinal) DO UPDATE
+		SET value = CAST(value AS INTEGER) + 1
+		RETURNING CAST(value AS INTEGER)
+	`, key).Scan(&next)
+	return next - 1, err
+}

--- a/internal/parser/reconciliation_cache_test.go
+++ b/internal/parser/reconciliation_cache_test.go
@@ -1,0 +1,25 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReconciliationCacheAddIntIncrementsEachKeyIndependently(t *testing.T) {
+	ctx, cleanup, err := WithReconciliationCache(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, cleanup()) })
+
+	first, err := reconciliationCacheAddInt(ctx, "first")
+	require.NoError(t, err)
+	second, err := reconciliationCacheAddInt(ctx, "first")
+	require.NoError(t, err)
+	other, err := reconciliationCacheAddInt(ctx, "other")
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, first)
+	assert.Equal(t, 1, second)
+	assert.Equal(t, 0, other)
+}

--- a/internal/parser/roocode.go
+++ b/internal/parser/roocode.go
@@ -1347,41 +1347,6 @@ func parseRooCodeToolCall(text string, ordinal int) *ParsedToolCall {
 	return tc
 }
 
-// discoverRooCodeSessions finds all task directories under a RooCode root.
-// root is the globalStorage directory (e.g. ~/Library/.../rooveterinaryinc.roo-cline).
-// Sessions live under <root>/tasks/<taskId>/.
-func discoverRooCodeSessions(root string) []rooCodeSessionDir {
-	tasksDir := filepath.Join(root, "tasks")
-	entries, err := os.ReadDir(tasksDir)
-	if err != nil {
-		return nil
-	}
-
-	var dirs []rooCodeSessionDir
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		// Skip the _index.json file directory marker.
-		if strings.HasPrefix(entry.Name(), "_") {
-			continue
-		}
-		taskDir := filepath.Join(tasksDir, entry.Name())
-		if !IsRegularFile(filepath.Join(taskDir, "history_item.json")) {
-			continue
-		}
-		dirs = append(dirs, rooCodeSessionDir{
-			Path: taskDir,
-		})
-	}
-	return dirs
-}
-
-// rooCodeSessionDir holds a discovered RooCode task directory path.
-type rooCodeSessionDir struct {
-	Path string
-}
-
 // rooCodeFingerprintSource computes a composite fingerprint from
 // history_item.json and ui_messages.json for freshness detection.
 func rooCodeFingerprintSource(path string) (SourceFingerprint, error) {

--- a/internal/parser/roocode_provider.go
+++ b/internal/parser/roocode_provider.go
@@ -1,6 +1,8 @@
 package parser
 
 import (
+	"context"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -16,9 +18,7 @@ func newRooCodeProviderFactory(def AgentDef) ProviderFactory {
 			return NewSingleFileSourceSet(
 				def.Type,
 				cfg.Roots,
-				WithFileDiscovery(func(root string) []singleFileMatch {
-					return rooCodeDiscoverFiles(root)
-				}),
+				WithStreamingFileDiscovery(rooCodeDiscoverEach),
 				WithFileWatchRoots(func(roots []string) []WatchRoot {
 					return rooCodeWatchRoots(roots)
 				}),
@@ -41,20 +41,26 @@ func newRooCodeProviderFactory(def AgentDef) ProviderFactory {
 	)
 }
 
-// rooCodeDiscoverFiles finds all RooCode session directories under a root.
-// root is the globalStorage directory; sessions live under <root>/tasks/<taskId>/.
-func rooCodeDiscoverFiles(root string) []singleFileMatch {
-	dirs := discoverRooCodeSessions(root)
-	matches := make([]singleFileMatch, 0, len(dirs))
-	for _, d := range dirs {
-		historyPath := filepath.Join(d.Path, "history_item.json")
-		if IsRegularFile(historyPath) {
-			matches = append(matches, singleFileMatch{
-				Path: historyPath,
-			})
+// rooCodeDiscoverEach streams the RooCode session sources under a root.
+// root is the globalStorage directory; sessions live under
+// <root>/tasks/<taskId>/history_item.json. A missing tasks directory is a
+// legitimately empty scope, but any other traversal failure propagates so the
+// sync engine treats the scope as incomplete instead of tombstoning every
+// baselined session against an authoritative empty enumeration.
+func rooCodeDiscoverEach(
+	ctx context.Context, root string, yield func(singleFileMatch) error,
+) error {
+	tasksDir := filepath.Join(root, "tasks")
+	return streamDirectoryEntries(ctx, tasksDir, func(entry os.DirEntry) error {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), "_") {
+			return nil
 		}
-	}
-	return matches
+		historyPath := filepath.Join(tasksDir, entry.Name(), "history_item.json")
+		if !IsRegularFile(historyPath) {
+			return nil
+		}
+		return yield(singleFileMatch{Path: historyPath})
+	})
 }
 
 // rooCodeWatchRoots creates watch plans for each root.

--- a/internal/parser/roocode_provider_test.go
+++ b/internal/parser/roocode_provider_test.go
@@ -1,0 +1,113 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeRooCodeDiscoveryTask(t *testing.T, root, taskID string) string {
+	t.Helper()
+	taskDir := filepath.Join(root, "tasks", taskID)
+	require.NoError(t, os.MkdirAll(taskDir, 0o755))
+	historyPath := filepath.Join(taskDir, "history_item.json")
+	require.NoError(t, os.WriteFile(
+		historyPath, []byte(`{"id":"`+taskID+`"}`), 0o644,
+	))
+	return historyPath
+}
+
+func rooCodeDiscoverPaths(t *testing.T, provider Provider) ([]string, error) {
+	t.Helper()
+	discoverer, ok := provider.(StreamingDiscoverer)
+	require.True(t, ok)
+	var paths []string
+	err := discoverer.DiscoverEach(t.Context(), func(source SourceRef) error {
+		paths = append(paths, source.DisplayPath)
+		return nil
+	})
+	return paths, err
+}
+
+// TestRooCodeDiscoveryUnreadableTasksDirFails guards the reconciliation
+// tombstoning path: discovery used to convert every os.ReadDir failure on
+// <root>/tasks into an empty successful enumeration, so a transient
+// permission or I/O failure made the provider-authoritative scope look
+// empty and the engine tombstoned every baselined RooCode session under it.
+// Traversal failures must propagate so the failed scope stays incomplete.
+func TestRooCodeDiscoveryUnreadableTasksDirFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory-permission read failures are not portable to Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+
+	root := t.TempDir()
+	historyPath := writeRooCodeDiscoveryTask(t, root, "task-1")
+	tasksDir := filepath.Join(root, "tasks")
+
+	provider, ok := NewProvider(AgentRooCode, ProviderConfig{
+		Roots: []string{root},
+	})
+	require.True(t, ok)
+
+	paths, err := rooCodeDiscoverPaths(t, provider)
+	require.NoError(t, err)
+	require.Equal(t, []string{historyPath}, paths,
+		"a readable tasks directory must enumerate its sessions")
+
+	require.NoError(t, os.Chmod(tasksDir, 0o000))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chmod(tasksDir, 0o755))
+	})
+
+	paths, err = rooCodeDiscoverPaths(t, provider)
+	require.Error(t, err,
+		"an unreadable tasks directory must not stream an authoritative empty discovery")
+	assert.ErrorIs(t, err, os.ErrPermission)
+	assert.Empty(t, paths)
+
+	_, err = provider.Discover(t.Context())
+	require.Error(t, err,
+		"an unreadable tasks directory must not collect an authoritative empty discovery")
+}
+
+// A root without a tasks directory is a legitimately empty scope, not a
+// failure: discovery completes with no sources and no error.
+func TestRooCodeDiscoveryMissingTasksDirIsEmptyComplete(t *testing.T) {
+	provider, ok := NewProvider(AgentRooCode, ProviderConfig{
+		Roots: []string{t.TempDir()},
+	})
+	require.True(t, ok)
+
+	paths, err := rooCodeDiscoverPaths(t, provider)
+	require.NoError(t, err)
+	assert.Empty(t, paths)
+}
+
+// Discovery skips non-directory entries, underscore-prefixed metadata
+// directories, and task directories without a history_item.json.
+func TestRooCodeDiscoverySkipsNonSessionEntries(t *testing.T) {
+	root := t.TempDir()
+	historyPath := writeRooCodeDiscoveryTask(t, root, "task-1")
+	tasksDir := filepath.Join(root, "tasks")
+	require.NoError(t, os.MkdirAll(filepath.Join(tasksDir, "_index"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(tasksDir, "no-history"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(tasksDir, "stray.json"), []byte("{}"), 0o644,
+	))
+
+	provider, ok := NewProvider(AgentRooCode, ProviderConfig{
+		Roots: []string{root},
+	})
+	require.True(t, ok)
+
+	paths, err := rooCodeDiscoverPaths(t, provider)
+	require.NoError(t, err)
+	assert.Equal(t, []string{historyPath}, paths)
+}

--- a/internal/parser/shelley.go
+++ b/internal/parser/shelley.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"context"
 	"database/sql"
 	"encoding/binary"
 	"encoding/json"
@@ -219,8 +220,44 @@ func shelleyFingerprint(h hash.Hash64) string {
 func ListShelleyConversationMetas(
 	conn *sql.DB, dbPath string,
 ) ([]ShelleyConversationMeta, error) {
-	rows, err := conn.Query(
-		`SELECT c.conversation_id, COALESCE(c.slug, ''),
+	var metas []ShelleyConversationMeta
+	err := ForEachShelleyConversationMeta(context.Background(), conn, dbPath, func(meta ShelleyConversationMeta) error {
+		metas = append(metas, meta)
+		return nil
+	})
+	return metas, err
+}
+
+func ForEachShelleyConversationMeta(
+	ctx context.Context, conn *sql.DB, dbPath string,
+	yield func(ShelleyConversationMeta) error,
+) error {
+	return forEachShelleyConversationMetaQuery(ctx, conn, dbPath, "", nil, yield)
+}
+
+// ShelleyConversationMetaByID reads only one conversation's metadata. It is
+// used by per-member fingerprinting so an exact rehydrate never scans or
+// materializes the rest of the archive.
+func ShelleyConversationMetaByID(
+	ctx context.Context, conn *sql.DB, dbPath, conversationID string,
+) (ShelleyConversationMeta, bool, error) {
+	var meta ShelleyConversationMeta
+	found := false
+	err := forEachShelleyConversationMetaQuery(
+		ctx, conn, dbPath, " WHERE c.conversation_id = ?", []any{conversationID},
+		func(candidate ShelleyConversationMeta) error {
+			meta, found = candidate, true
+			return nil
+		},
+	)
+	return meta, found, err
+}
+
+func forEachShelleyConversationMetaQuery(
+	ctx context.Context, conn *sql.DB, dbPath, where string, args []any,
+	yield func(ShelleyConversationMeta) error,
+) error {
+	query := `SELECT c.conversation_id, COALESCE(c.slug, ''),
 		        COALESCE(c.user_initiated, 1),
 		        COALESCE(c.created_at, ''), COALESCE(c.updated_at, ''),
 		        COALESCE(c.cwd, ''), COALESCE(c.parent_conversation_id, ''),
@@ -230,25 +267,26 @@ func ListShelleyConversationMetas(
 		        COALESCE(m.usage_data, ''), COALESCE(m.created_at, '')
 		   FROM conversations c
 		   JOIN messages m ON m.conversation_id = c.conversation_id
-		  ORDER BY c.conversation_id, m.sequence_id`,
-	)
+		` + where + `
+		  ORDER BY c.conversation_id, m.sequence_id`
+	rows, err := conn.QueryContext(ctx, query, args...)
 	if err != nil {
-		return nil, fmt.Errorf("listing shelley conversations: %w", err)
+		return fmt.Errorf("listing shelley conversations: %w", err)
 	}
 	defer rows.Close()
 
 	var (
-		metas []ShelleyConversationMeta
 		curID string
 		conv  shelleyConversationRow
 	)
 	h := fnv.New64a()
-	flush := func() {
+	flush := func() error {
 		// curID is "" before the first row; IsValidSessionID rejects it.
 		if !IsValidSessionID(curID) {
-			return
+			return nil
 		}
-		metas = append(metas, ShelleyConversationMeta{
+		observeStreamingDiscoveryBuffer(ctx, 1)
+		return yield(ShelleyConversationMeta{
 			RawID:       curID,
 			VirtualPath: ShelleyVirtualPath(dbPath, curID),
 			FileMtime:   parseTimestamp(conv.updatedAt).UnixNano(),
@@ -267,18 +305,22 @@ func ListShelleyConversationMetas(
 			&msg.sequenceID, &msg.msgType, &msg.llmData,
 			&msg.userData, &msg.usageData, &msg.createdAt,
 		); err != nil {
-			return nil, fmt.Errorf("scanning shelley conversation meta: %w", err)
+			return fmt.Errorf("scanning shelley conversation meta: %w", err)
 		}
 		rowConv.userInitiated = userInitiated != 0
 		if rowConv.conversationID != curID {
-			flush()
+			if err := flush(); err != nil {
+				return err
+			}
 			curID, conv, h = rowConv.conversationID, rowConv, fnv.New64a()
 			shelleyDigestConversation(h, conv)
 		}
 		shelleyDigestMessage(h, msg)
 	}
-	flush()
-	return metas, rows.Err()
+	if err := flush(); err != nil {
+		return err
+	}
+	return rows.Err()
 }
 
 // ShelleySourceMtime resolves the per-conversation change signal for a

--- a/internal/parser/shelley_provider.go
+++ b/internal/parser/shelley_provider.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -21,6 +22,7 @@ func newShelleyProviderFactory(def AgentDef) ProviderFactory {
 				AgentShelley,
 				cfg.Roots,
 				WithContainerDiscovery(shelleyDiscoverContainers),
+				WithStreamingSourceDiscovery(shelleyDiscoverEach),
 				WithWatchRoots(shelleyWatchRoots),
 				WithChangedPathClassifier(shelleyClassifyPath),
 				WithMemberLookup(shelleyFindMember),
@@ -33,6 +35,25 @@ func newShelleyProviderFactory(def AgentDef) ProviderFactory {
 			)
 		},
 	)
+}
+
+func shelleyDiscoverEach(
+	ctx context.Context, root string, yield func(multiSessionMatch) error,
+) error {
+	dbPath := shelleyDBPath(root)
+	if dbPath == "" {
+		return nil
+	}
+	conn, err := OpenShelleyDB(dbPath)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	return ForEachShelleyConversationMeta(ctx, conn, dbPath, func(meta ShelleyConversationMeta) error {
+		return yield(multiSessionMatch{
+			Path: meta.VirtualPath, Container: dbPath, MemberID: meta.RawID,
+		})
+	})
 }
 
 func shelleyDiscoverContainers(root string) []string {
@@ -133,14 +154,13 @@ func shelleyFingerprintSource(src multiSessionSource) (SourceFingerprint, error)
 		return SourceFingerprint{}, err
 	}
 	defer conn.Close()
-	metas, err := ListShelleyConversationMetas(conn, src.Container)
+	meta, found, err := ShelleyConversationMetaByID(
+		context.Background(), conn, src.Container, src.MemberID,
+	)
 	if err != nil {
 		return SourceFingerprint{}, err
 	}
-	for _, meta := range metas {
-		if meta.RawID != src.MemberID {
-			continue
-		}
+	if found {
 		fingerprint.MTimeNS = meta.FileMtime
 		fingerprint.Hash = meta.Fingerprint
 		return fingerprint, nil
@@ -265,11 +285,13 @@ func parseShelleyVirtualPath(path string) (string, string, bool) {
 }
 
 func shelleyProviderCapabilities() Capabilities {
+	source := multiSessionContainerSourceCapabilities(
+		CapabilitySupported,
+		CapabilitySupported,
+	)
+	source.PersistentArchive = CapabilitySupported
 	return Capabilities{
-		Source: multiSessionContainerSourceCapabilities(
-			CapabilitySupported,
-			CapabilitySupported,
-		),
+		Source: source,
 		Content: ContentCapabilities{
 			FirstMessage:         CapabilitySupported,
 			SessionName:          CapabilitySupported,

--- a/internal/parser/single_file_source_set.go
+++ b/internal/parser/single_file_source_set.go
@@ -41,6 +41,7 @@ func (m singleFileMatch) toSource(root string) singleFileSource {
 type singleFileConfig struct {
 	// discoverFiles returns the source files under one root.
 	discoverFiles func(root string) []singleFileMatch
+	discoverEach  func(context.Context, string, func(singleFileMatch) error) error
 	// watchRoots returns the provider WatchPlan roots for the configured roots.
 	watchRoots func(roots []string) []WatchRoot
 	// classifyPath maps a stored or changed path (including a sidecar event) to
@@ -69,6 +70,12 @@ func WithFileDiscovery(
 	fn func(root string) []singleFileMatch,
 ) SingleFileOption {
 	return func(c *singleFileConfig) { c.discoverFiles = fn }
+}
+
+func WithStreamingFileDiscovery(
+	fn func(context.Context, string, func(singleFileMatch) error) error,
+) SingleFileOption {
+	return func(c *singleFileConfig) { c.discoverEach = fn }
 }
 
 func WithFileWatchRoots(
@@ -118,7 +125,7 @@ func NewSingleFileSourceSet(
 		opt(&cfg)
 	}
 	switch {
-	case cfg.discoverFiles == nil:
+	case cfg.discoverFiles == nil && cfg.discoverEach == nil:
 		panic("single-file source set: missing WithFileDiscovery")
 	case cfg.watchRoots == nil:
 		panic("single-file source set: missing WithFileWatchRoots")
@@ -149,27 +156,52 @@ var _ SourceSet = singleFileSourceSet{}
 func (s singleFileSourceSet) Discover(
 	ctx context.Context,
 ) ([]SourceRef, error) {
-	var sources []SourceRef
-	seen := make(map[string]struct{})
+	return collectDiscoveredSources(ctx, s.DiscoverEach)
+}
+
+func (s singleFileSourceSet) DiscoverEach(
+	ctx context.Context, yield func(SourceRef) error,
+) error {
 	for _, root := range s.roots {
 		if err := ctx.Err(); err != nil {
-			return nil, err
+			return err
+		}
+		if s.cfg.discoverEach != nil {
+			if err := s.cfg.discoverEach(ctx, root, func(match singleFileMatch) error {
+				if match.Path == "" {
+					return nil
+				}
+				return yield(s.sourceRef(root, match))
+			}); err != nil {
+				return err
+			}
+			continue
 		}
 		for _, match := range s.cfg.discoverFiles(root) {
 			if match.Path == "" {
 				continue
 			}
-			addJSONLSource(s.sourceRef(root, match), &sources, seen)
+			if err := yield(s.sourceRef(root, match)); err != nil {
+				return err
+			}
 		}
 	}
-	sortJSONLSources(sources)
-	return sources, nil
+	return nil
 }
 
 func (s singleFileSourceSet) WatchPlan(
 	context.Context,
 ) (WatchPlan, error) {
 	return WatchPlan{Roots: s.cfg.watchRoots(s.roots)}, nil
+}
+
+func (s singleFileSourceSet) WatchRoots(
+	ctx context.Context,
+) ([]WatchRoot, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return watchRootMetadata(s.cfg.watchRoots(s.roots)), nil
 }
 
 func (s singleFileSourceSet) SourcesForChangedPath(

--- a/internal/parser/single_file_source_set_test.go
+++ b/internal/parser/single_file_source_set_test.go
@@ -83,3 +83,48 @@ func TestSingleFileFindSourceRejectsStaleStoredPath(t *testing.T) {
 	assert.Equal(t, stalePath, src2.DisplayPath,
 		"without RequireFreshSource the stored-path hint is honored unchanged")
 }
+
+func TestSingleFileWatchRootsDropsParserOnlyGlobs(t *testing.T) {
+	root := t.TempDir()
+	want := WatchRoot{
+		Path:        filepath.Join(root, "sessions"),
+		Recursive:   true,
+		DebounceKey: "reasonix:sessions",
+	}
+	set := NewSingleFileSourceSet(
+		AgentReasonix,
+		[]string{root},
+		WithFileDiscovery(func(string) []singleFileMatch { return nil }),
+		WithFileWatchRoots(func([]string) []WatchRoot {
+			withParserGlobs := want
+			withParserGlobs.IncludeGlobs = []string{"*.jsonl", "*.meta"}
+			withParserGlobs.ExcludeGlobs = []string{"*.tmp"}
+			return []WatchRoot{withParserGlobs}
+		}),
+		WithFileChangedPathClassifier(
+			func(string, string, bool) (singleFileMatch, bool) {
+				return singleFileMatch{}, false
+			},
+		),
+		WithFileLookup(func(string, string) (singleFileMatch, bool) {
+			return singleFileMatch{}, false
+		}),
+		WithFileFingerprint(func(singleFileSource) (SourceFingerprint, error) {
+			return SourceFingerprint{}, nil
+		}),
+		WithFileParse(func(singleFileSource, ParseRequest) ([]ParseResult, []string, error) {
+			return nil, nil, nil
+		}),
+	)
+
+	roots, err := set.WatchRoots(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []WatchRoot{want}, roots)
+
+	plan, err := set.WatchPlan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, plan.Roots, 1)
+	assert.Equal(t, []string{"*.jsonl", "*.meta"}, plan.Roots[0].IncludeGlobs,
+		"parser callers must retain the existing include globs")
+	assert.Equal(t, []string{"*.tmp"}, plan.Roots[0].ExcludeGlobs)
+}

--- a/internal/parser/source_set.go
+++ b/internal/parser/source_set.go
@@ -55,12 +55,40 @@ type SourceSetProvider struct {
 	sources SourceSet
 }
 
+var _ StreamingDiscoverer = (*SourceSetProvider)(nil)
+
 func (p *SourceSetProvider) Discover(ctx context.Context) ([]SourceRef, error) {
 	return p.sources.Discover(ctx)
 }
 
+func (p *SourceSetProvider) DiscoverEach(
+	ctx context.Context, yield func(SourceRef) error,
+) error {
+	discoverer, ok := p.sources.(StreamingDiscoverer)
+	if !ok {
+		return UnsupportedProviderFeatureError{
+			Provider: p.Def.Type,
+			Feature:  "streaming discovery",
+		}
+	}
+	return discoverer.DiscoverEach(ctx, yield)
+}
+
 func (p *SourceSetProvider) WatchPlan(ctx context.Context) (WatchPlan, error) {
 	return p.sources.WatchPlan(ctx)
+}
+
+func (p *SourceSetProvider) WatchRoots(
+	ctx context.Context,
+) ([]WatchRoot, error) {
+	if planner, ok := p.sources.(WatchRootPlanner); ok {
+		return planner.WatchRoots(ctx)
+	}
+	plan, err := p.sources.WatchPlan(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return watchRootMetadata(plan.Roots), nil
 }
 
 func (p *SourceSetProvider) SourcesForChangedPath(
@@ -68,6 +96,16 @@ func (p *SourceSetProvider) SourcesForChangedPath(
 	req ChangedPathRequest,
 ) ([]SourceRef, error) {
 	return p.sources.SourcesForChangedPath(ctx, req)
+}
+
+func (p *SourceSetProvider) StoredSourceHintScopes(
+	req ChangedPathRequest,
+) []StoredSourceHintScope {
+	resolver, ok := p.sources.(StoredSourceHintScopeProvider)
+	if !ok {
+		return nil
+	}
+	return resolver.StoredSourceHintScopes(req)
 }
 
 func (p *SourceSetProvider) FindSource(
@@ -94,6 +132,36 @@ func (p *SourceSetProvider) Parse(
 	return p.sources.Parse(ctx, req)
 }
 
+func (p *SourceSetProvider) SourceForReconciliation(
+	ctx context.Context, path, project string,
+) (SourceRef, bool, error) {
+	resolver, ok := p.sources.(ReconciliationSourceResolver)
+	if !ok {
+		return SourceRef{}, false, nil
+	}
+	return resolver.SourceForReconciliation(ctx, path, project)
+}
+
+func (p *SourceSetProvider) ReconciliationMemberIdentity(
+	fullSessionID string,
+) string {
+	resolver, ok := p.sources.(ReconciliationMemberIdentityResolver)
+	if !ok {
+		return ""
+	}
+	return resolver.ReconciliationMemberIdentity(fullSessionID)
+}
+
+func (p *SourceSetProvider) PersistentArchiveSource(
+	path string, fullSessionID string,
+) (string, bool) {
+	resolver, ok := p.sources.(PersistentArchiveSourceResolver)
+	if !ok {
+		return "", false
+	}
+	return resolver.PersistentArchiveSource(path, fullSessionID)
+}
+
 // SourceSetFactory is the generic ProviderFactory for any SourceSet-backed
 // provider. build constructs the SourceSet from the cloned per-provider config
 // (roots, machine, path rewriter), so a base captures whatever config it needs
@@ -104,14 +172,19 @@ type SourceSetFactory struct {
 	build func(cfg ProviderConfig) SourceSet
 }
 
+// NewSourceSetFactory advertises StreamingDiscovery up front because every
+// source-set base streams. A wrapper still cannot invent streaming for a
+// collecting source set: NewProvider downgrades the capability when the built
+// SourceSet does not implement StreamingDiscoverer.
 func NewSourceSetFactory(
 	def AgentDef,
 	caps Capabilities,
 	build func(cfg ProviderConfig) SourceSet,
 ) ProviderFactory {
+	caps.Source.StreamingDiscovery = CapabilitySupported
 	return SourceSetFactory{
 		def:   cloneAgentDef(def),
-		caps:  caps,
+		caps:  withWatchRootPlanningCapability(caps),
 		build: build,
 	}
 }
@@ -126,12 +199,23 @@ func (f SourceSetFactory) Capabilities() Capabilities {
 
 func (f SourceSetFactory) NewProvider(cfg ProviderConfig) Provider {
 	cfg = cfg.Clone()
+	sources := f.build(cfg)
+	caps := f.caps
+	if _, ok := sources.(StreamingDiscoverer); !ok {
+		caps.Source.StreamingDiscovery = CapabilityUnsupported
+	}
+	if _, ok := sources.(ReconciliationSourceResolver); !ok {
+		caps.Source.SharedContainerSource = CapabilityUnsupported
+	}
+	if _, ok := sources.(StoredSourceHintScopeProvider); !ok {
+		caps.Source.StoredSourceHints = CapabilityUnsupported
+	}
 	return &SourceSetProvider{
 		ProviderBase: ProviderBase{
 			Def:    cloneAgentDef(f.def),
-			Caps:   f.caps,
+			Caps:   caps,
 			Config: cfg,
 		},
-		sources: f.build(cfg),
+		sources: sources,
 	}
 }

--- a/internal/parser/streaming_discovery.go
+++ b/internal/parser/streaming_discovery.go
@@ -1,0 +1,362 @@
+package parser
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+const streamingDirectoryBatchSize = 64
+
+var errStopStreamingDiscovery = errors.New("stop streaming discovery")
+
+// DiscoveryIncompleteError reports a bounded traversal that stopped before it
+// could authoritatively enumerate its configured scope. Callers must retain the
+// watcher reconciliation marker and retry rather than acknowledging a partial
+// result.
+type DiscoveryIncompleteError struct {
+	Provider AgentType
+	Reason   string
+}
+
+func (err DiscoveryIncompleteError) Error() string {
+	if err.Provider == "" {
+		return "discovery incomplete: " + err.Reason
+	}
+	return string(err.Provider) + " discovery incomplete: " + err.Reason
+}
+
+type discoveryIncompleteCause struct {
+	incomplete DiscoveryIncompleteError
+	cause      error
+}
+
+func (err discoveryIncompleteCause) Error() string { return err.incomplete.Error() }
+func (err discoveryIncompleteCause) Unwrap() []error {
+	return []error{err.incomplete, err.cause}
+}
+
+type discoveryYieldError struct{ cause error }
+
+func (err discoveryYieldError) Error() string { return err.cause.Error() }
+func (err discoveryYieldError) Unwrap() error { return err.cause }
+
+func incompleteDiscoveryError(
+	provider AgentType, reason string, cause error,
+) error {
+	var incomplete DiscoveryIncompleteError
+	if errors.As(cause, &incomplete) {
+		return cause
+	}
+	return discoveryIncompleteCause{
+		incomplete: DiscoveryIncompleteError{
+			Provider: provider,
+			Reason:   reason + ": " + cause.Error(),
+		},
+		cause: cause,
+	}
+}
+
+func discoveryYieldCause(err error) (error, bool) {
+	var yieldErr discoveryYieldError
+	if !errors.As(err, &yieldErr) {
+		return nil, false
+	}
+	return yieldErr.cause, true
+}
+
+type discoveryTraversalLimits struct {
+	maxDirs  int
+	maxFiles int
+	expired  func() bool
+}
+
+type discoveryTraversalLimitsContextKey struct{}
+
+func withDiscoveryTraversalLimits(
+	ctx context.Context, limits discoveryTraversalLimits,
+) context.Context {
+	return context.WithValue(ctx, discoveryTraversalLimitsContextKey{}, limits)
+}
+
+func discoveryTraversalLimitsFor(ctx context.Context) discoveryTraversalLimits {
+	limits, _ := ctx.Value(discoveryTraversalLimitsContextKey{}).(discoveryTraversalLimits)
+	return limits
+}
+
+type streamingDirectoryReader func(
+	context.Context, string, func(os.DirEntry) error,
+) error
+
+type streamingDirectoryReaderContextKey struct{}
+
+func withStreamingDirectoryReader(
+	ctx context.Context, reader streamingDirectoryReader,
+) context.Context {
+	return context.WithValue(ctx, streamingDirectoryReaderContextKey{}, reader)
+}
+
+type streamingDiscoveryBufferObserverKey struct{}
+type streamingRetainedBytesObserverKey struct{}
+type sharedContainerScanObserverKey struct{}
+type reconciliationRetainedMemberObserverKey struct{}
+
+// WithStreamingDiscoveryBufferObserver attaches instrumentation to direct
+// provider discovery. Providers report actual bounded read/source batches at
+// the allocation boundary rather than letting the sync engine infer them from
+// its downstream spool page size.
+func WithStreamingDiscoveryBufferObserver(
+	ctx context.Context, observe func(int),
+) context.Context {
+	return context.WithValue(ctx, streamingDiscoveryBufferObserverKey{}, observe)
+}
+
+func observeStreamingDiscoveryBuffer(ctx context.Context, buffered int) {
+	if buffered <= 0 {
+		return
+	}
+	if observe, ok := ctx.Value(streamingDiscoveryBufferObserverKey{}).(func(int)); ok {
+		observe(buffered)
+	}
+}
+
+// WithStreamingRetainedBytesObserver records provider-owned byte buffers by
+// lifetime. Providers call the observer with a positive delta when a bounded
+// chunk or decoded member becomes live and the matching negative delta when it
+// is released. The sync engine aggregates concurrent workers into a real peak,
+// rather than treating a row count as a proxy for memory.
+func WithStreamingRetainedBytesObserver(
+	ctx context.Context, observe func(int64),
+) context.Context {
+	return context.WithValue(ctx, streamingRetainedBytesObserverKey{}, observe)
+}
+
+func observeStreamingRetainedBytes(ctx context.Context, delta int64) {
+	if delta == 0 {
+		return
+	}
+	if observe, ok := ctx.Value(streamingRetainedBytesObserverKey{}).(func(int64)); ok {
+		observe(delta)
+	}
+}
+
+// conservativeDecodedRetainedBytes charges enough space for the encoded
+// member, transient encoded copies, decoded strings/slices/maps, and fixed Go
+// object overhead. It intentionally overestimates provider-owned live bytes;
+// reconciliation metrics must never present payload length as actual retained
+// memory when decoded builders and copies coexist with it.
+func conservativeDecodedRetainedBytes(encoded int64) int64 {
+	if encoded <= 0 {
+		return 0
+	}
+	return encoded*4 + 4*1024
+}
+
+// WithReconciliationRetainedMemberObserver observes a worker after it has
+// charged one cached shared-container member and before it decodes that member.
+// Tests use this operation boundary to prove concurrent aggregate retention;
+// production callers normally leave it unset.
+func WithReconciliationRetainedMemberObserver(
+	ctx context.Context, observe func(AgentType, int64),
+) context.Context {
+	return context.WithValue(ctx, reconciliationRetainedMemberObserverKey{}, observe)
+}
+
+func observeReconciliationRetainedMember(
+	ctx context.Context, provider AgentType, retained int64,
+) {
+	if observe, ok := ctx.Value(reconciliationRetainedMemberObserverKey{}).(func(AgentType, int64)); ok {
+		observe(provider, retained)
+	}
+}
+
+func streamingRegularFileCandidate(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		if _, lstatErr := os.Lstat(path); lstatErr == nil {
+			return false, err
+		} else if !errors.Is(lstatErr, os.ErrNotExist) {
+			return false, lstatErr
+		}
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return info.Mode().IsRegular(), nil
+}
+
+func streamingDirOrSymlinkCandidate(
+	entry os.DirEntry, parentDir string,
+) (bool, error) {
+	if entry.IsDir() {
+		return true, nil
+	}
+	if entry.Type()&os.ModeSymlink == 0 {
+		return false, nil
+	}
+	info, err := os.Stat(filepath.Join(parentDir, entry.Name()))
+	if err != nil {
+		return false, err
+	}
+	return info.IsDir(), nil
+}
+
+// streamingDirCandidateOrIncomplete resolves whether entry is a directory or
+// a followed directory symlink during streaming discovery. A followed symlink
+// whose target cannot be resolved (dangling link, unreadable parent) surfaces
+// DiscoveryIncompleteError instead of reading as absent: reconciliation
+// treats a clean streaming discovery as authoritative and would tombstone
+// every session beneath the symlink.
+func streamingDirCandidateOrIncomplete(
+	provider AgentType, what string, entry os.DirEntry, parentDir string,
+) (bool, error) {
+	ok, err := streamingDirOrSymlinkCandidate(entry, parentDir)
+	if err != nil {
+		return false, incompleteDiscoveryError(
+			provider,
+			"resolve "+what+" "+filepath.Join(parentDir, entry.Name()),
+			err,
+		)
+	}
+	return ok, nil
+}
+
+// WithSharedContainerScanObserver counts physical shared-container traversals.
+// Tests use it to distinguish one discovery scan from per-member rescans.
+func WithSharedContainerScanObserver(
+	ctx context.Context, observe func(),
+) context.Context {
+	return context.WithValue(ctx, sharedContainerScanObserverKey{}, observe)
+}
+
+func observeSharedContainerScan(ctx context.Context) {
+	if observe, ok := ctx.Value(sharedContainerScanObserverKey{}).(func()); ok {
+		observe()
+	}
+}
+
+// streamDirectoryEntries reads a directory in fixed-size batches. os.ReadDir
+// and filepath.WalkDir retain every entry in one directory so a single flat
+// archive can defeat an otherwise streaming provider walker.
+func streamDirectoryEntries(
+	ctx context.Context, dir string, yield func(os.DirEntry) error,
+) error {
+	if reader, ok := ctx.Value(streamingDirectoryReaderContextKey{}).(streamingDirectoryReader); ok {
+		return reader(ctx, dir, yield)
+	}
+	return streamDirectoryEntriesDirect(ctx, dir, yield)
+}
+
+func streamDirectoryEntriesDirect(
+	ctx context.Context, dir string, yield func(os.DirEntry) error,
+) error {
+	file, err := os.Open(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	defer file.Close()
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		entries, readErr := file.ReadDir(streamingDirectoryBatchSize)
+		observeStreamingDiscoveryBuffer(ctx, len(entries))
+		for _, entry := range entries {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if err := yield(entry); err != nil {
+				return err
+			}
+		}
+		switch {
+		case readErr == nil:
+			continue
+		case errors.Is(readErr, io.EOF):
+			return nil
+		default:
+			return readErr
+		}
+	}
+}
+
+// streamDirectoryTree walks a directory without filepath.WalkDir's
+// whole-directory name sort. Only one fixed-size ReadDir batch per active
+// directory and the directory-depth recursion stack are retained.
+func streamDirectoryTree(
+	ctx context.Context,
+	root string,
+	yield func(path string, entry os.DirEntry) error,
+) error {
+	err := streamDirectoryTreeRecursive(ctx, root, yield)
+	if cause, ok := discoveryYieldCause(err); ok {
+		return cause
+	}
+	return err
+}
+
+func streamDirectoryTreeRecursive(
+	ctx context.Context,
+	root string,
+	yield func(path string, entry os.DirEntry) error,
+) error {
+	var incomplete error
+	err := streamDirectoryEntries(ctx, root, func(entry os.DirEntry) error {
+		path := filepath.Join(root, entry.Name())
+		if entry.IsDir() {
+			err := streamDirectoryTreeRecursive(ctx, path, yield)
+			if err == nil {
+				return nil
+			}
+			if _, ok := discoveryYieldCause(err); ok || ctx.Err() != nil {
+				return err
+			}
+			incomplete = errors.Join(incomplete, err)
+			return nil
+		}
+		if err := yield(path, entry); err != nil {
+			return discoveryYieldError{cause: err}
+		}
+		return nil
+	})
+	if err != nil {
+		if _, ok := discoveryYieldCause(err); ok || ctx.Err() != nil {
+			return err
+		}
+		incomplete = errors.Join(incomplete, incompleteDiscoveryError(
+			"", "read directory "+root, err,
+		))
+	}
+	return incomplete
+}
+
+// StreamingDiscoverer incrementally yields source references without retaining
+// the provider's full discovery result in memory. Implementations must walk
+// their source directly; calling Discover from DiscoverEach defeats the
+// capability's bounded-memory contract.
+type StreamingDiscoverer interface {
+	DiscoverEach(context.Context, func(SourceRef) error) error
+}
+
+func collectDiscoveredSources(
+	ctx context.Context,
+	discover func(context.Context, func(SourceRef) error) error,
+) ([]SourceRef, error) {
+	var sources []SourceRef
+	seen := make(map[string]struct{})
+	err := discover(ctx, func(source SourceRef) error {
+		addJSONLSource(source, &sources, seen)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sortJSONLSources(sources)
+	return sources, nil
+}

--- a/internal/parser/streaming_discovery_test.go
+++ b/internal/parser/streaming_discovery_test.go
@@ -1,0 +1,116 @@
+package parser
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreamDirectoryTreeContinuesAfterUnreadableSubtree(t *testing.T) {
+	root := t.TempDir()
+	nested := filepath.Join(root, "a-nested")
+	require.NoError(t, os.Mkdir(nested, 0o755))
+	healthy := filepath.Join(root, "z-healthy.jsonl")
+	require.NoError(t, os.WriteFile(healthy, []byte("{}\n"), 0o600))
+	injected := errors.New("subtree unavailable")
+	ctx := withStreamingDirectoryReader(t.Context(), func(
+		ctx context.Context, dir string, yield func(os.DirEntry) error,
+	) error {
+		if samePath(dir, nested) {
+			return injected
+		}
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return err
+		}
+		for _, entry := range entries {
+			if err := yield(entry); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	var yielded []string
+
+	err := streamDirectoryTree(ctx, root, func(path string, _ os.DirEntry) error {
+		yielded = append(yielded, path)
+		return nil
+	})
+
+	assert.ErrorIs(t, err, injected)
+	var incomplete DiscoveryIncompleteError
+	assert.ErrorAs(t, err, &incomplete)
+	assert.Equal(t, []string{healthy}, yielded)
+}
+
+func TestStreamDirectoryTreeYieldErrorAbortsImmediately(t *testing.T) {
+	root := t.TempDir()
+	for _, name := range []string{"a.jsonl", "b.jsonl"} {
+		require.NoError(t, os.WriteFile(
+			filepath.Join(root, name), []byte("{}\n"), 0o600,
+		))
+	}
+	injected := errors.New("stop consumer")
+	calls := 0
+
+	err := streamDirectoryTree(t.Context(), root, func(
+		string, os.DirEntry,
+	) error {
+		calls++
+		return injected
+	})
+
+	assert.ErrorIs(t, err, injected)
+	assert.Equal(t, 1, calls)
+}
+
+func TestStreamDirectoryEntriesBoundsUnderlyingReadBatch(t *testing.T) {
+	dir := t.TempDir()
+	for i := range 300 {
+		path := filepath.Join(dir, fmt.Sprintf("entry-%03d", i))
+		require.NoError(t, os.WriteFile(path, nil, 0o600))
+	}
+	maxBuffered := 0
+	ctx := WithStreamingDiscoveryBufferObserver(
+		t.Context(),
+		func(buffered int) { maxBuffered = max(maxBuffered, buffered) },
+	)
+	count := 0
+
+	err := streamDirectoryEntries(ctx, dir, func(os.DirEntry) error {
+		count++
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 300, count)
+	assert.Positive(t, maxBuffered)
+	assert.LessOrEqual(t, maxBuffered, streamingDirectoryBatchSize)
+}
+
+func TestStreamDirectoryEntriesStopsAfterMidTraversalCancellation(t *testing.T) {
+	dir := t.TempDir()
+	for i := range streamingDirectoryBatchSize * 3 {
+		path := filepath.Join(dir, fmt.Sprintf("entry-%03d", i))
+		require.NoError(t, os.WriteFile(path, nil, 0o600))
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	count := 0
+
+	err := streamDirectoryEntries(ctx, dir, func(os.DirEntry) error {
+		count++
+		if count == streamingDirectoryBatchSize+1 {
+			cancel()
+		}
+		return nil
+	})
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, streamingDirectoryBatchSize+1, count)
+}

--- a/internal/parser/trae_provider.go
+++ b/internal/parser/trae_provider.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"database/sql"
 	"encoding/json"
@@ -21,6 +22,7 @@ func newTraeProviderFactory(def AgentDef) ProviderFactory {
 	return NewMultiSessionProviderFactory(def, traeProviderCapabilities(), func(cfg ProviderConfig) multiSessionContainerSourceSet {
 		return NewMultiSessionContainerSourceSet(AgentTrae, cfg.Roots,
 			WithContainerDiscovery(traeDiscoverContainers),
+			WithStreamingSourceDiscovery(traeDiscoverEach),
 			WithWatchRoots(traeWatchRoots),
 			WithChangedPathClassifier(traeClassifyPath),
 			WithMemberLookup(traeFindMember),
@@ -34,6 +36,37 @@ func newTraeProviderFactory(def AgentDef) ProviderFactory {
 }
 
 type traeDB struct{ path, project string }
+
+func traeDiscoverEach(
+	ctx context.Context, root string, yield func(multiSessionMatch) error,
+) error {
+	workspace := filepath.Join(filepath.Clean(root), "workspaceStorage")
+	if err := streamDirectoryEntries(ctx, workspace, func(entry os.DirEntry) error {
+		if !entry.IsDir() {
+			return nil
+		}
+		path := filepath.Join(workspace, entry.Name(), traeStateDBName)
+		regular, err := streamingRegularFileCandidate(path)
+		if err != nil {
+			return err
+		}
+		if !regular {
+			return nil
+		}
+		return yield(traeMatch(path, ""))
+	}); err != nil {
+		return err
+	}
+	global := filepath.Join(filepath.Clean(root), "globalStorage", traeStateDBName)
+	regular, err := streamingRegularFileCandidate(global)
+	if err != nil {
+		return err
+	}
+	if !regular {
+		return nil
+	}
+	return yield(traeMatch(global, ""))
+}
 
 func traeDiscoverContainers(root string) []string {
 	dbs := traeDBs(root)

--- a/internal/parser/trae_provider_test.go
+++ b/internal/parser/trae_provider_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -104,6 +106,66 @@ func TestTraeWorkspaceGlobalDiscoveryAndParsing(t *testing.T) {
 	}
 }
 
+func TestTraeStreamingDiscoveryBoundsWorkspaceAndStopsEarly(t *testing.T) {
+	const workspaces = streamingDirectoryBatchSize*2 + 3
+	root := t.TempDir()
+	workspaceRoot := filepath.Join(root, "workspaceStorage")
+	for i := range workspaces {
+		path := filepath.Join(
+			workspaceRoot, fmt.Sprintf("workspace-%03d", i), traeStateDBName,
+		)
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, nil, 0o600))
+	}
+	provider, ok := NewProvider(AgentTrae, ProviderConfig{Roots: []string{root}})
+	require.True(t, ok)
+	streaming, ok := provider.(StreamingDiscoverer)
+	require.True(t, ok)
+	maxBuffered := 0
+	ctx := WithStreamingDiscoveryBufferObserver(t.Context(), func(buffered int) {
+		maxBuffered = max(maxBuffered, buffered)
+	})
+	count := 0
+
+	err := streaming.DiscoverEach(ctx, func(SourceRef) error {
+		count++
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, workspaces, count)
+	assert.Positive(t, maxBuffered,
+		"Trae discovery must report its bounded directory batches")
+	assert.LessOrEqual(t, maxBuffered, streamingDirectoryBatchSize)
+
+	stop := errors.New("stop after first source")
+	visited := 0
+	ctx = withStreamingDirectoryReader(t.Context(), func(
+		ctx context.Context, dir string, yield func(os.DirEntry) error,
+	) error {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return err
+		}
+		for _, entry := range entries {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			visited++
+			if err := yield(entry); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+
+	err = streaming.DiscoverEach(ctx, func(SourceRef) error { return stop })
+
+	assert.ErrorIs(t, err, stop)
+	assert.Equal(t, 1, visited,
+		"consumer stop must halt the workspace traversal immediately")
+}
+
 func TestTraeWatchChangedPathAndVirtualLookup(t *testing.T) {
 	root := t.TempDir()
 	dbPath := filepath.Join(root, "globalStorage", traeStateDBName)
@@ -134,6 +196,42 @@ func TestTraeWatchChangedPathAndVirtualLookup(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, changed, 1)
 	}
+}
+
+// Watcher sidecar events (workspace.json, -wal) must scope stored-source
+// hints to the owning state.vscdb container, not the whole watch root, so
+// changed-path hint queries stay bounded by the affected container.
+func TestTraeStoredSourceHintScopesResolveEventToContainer(t *testing.T) {
+	root := t.TempDir()
+	workspaceDB := filepath.Join(
+		root, "workspaceStorage", "hash-a", traeStateDBName,
+	)
+	globalDB := filepath.Join(root, "globalStorage", traeStateDBName)
+	writeTraeDB(t, workspaceDB, traeFixtureValue(t), "")
+	writeTraeDB(t, globalDB, traeFixtureValue(t), "")
+	factory, ok := ProviderFactoryByType(AgentTrae)
+	require.True(t, ok)
+	provider := factory.NewProvider(ProviderConfig{Roots: []string{root}})
+	resolver, ok := provider.(StoredSourceHintScopeProvider)
+	require.True(t, ok, "trae provider must resolve stored-source hint scopes")
+
+	workspaceScopes := resolver.StoredSourceHintScopes(ChangedPathRequest{
+		Path: filepath.Join(
+			root, "workspaceStorage", "hash-a", "workspace.json",
+		),
+		WatchRoot: filepath.Join(root, "workspaceStorage"),
+	})
+	require.Len(t, workspaceScopes, 1)
+	assert.Equal(t, workspaceDB, workspaceScopes[0].Path)
+	assert.True(t, workspaceScopes[0].IncludeVirtualMembers)
+
+	globalScopes := resolver.StoredSourceHintScopes(ChangedPathRequest{
+		Path:      globalDB + "-wal",
+		WatchRoot: filepath.Join(root, "globalStorage"),
+	})
+	require.Len(t, globalScopes, 1)
+	assert.Equal(t, globalDB, globalScopes[0].Path)
+	assert.True(t, globalScopes[0].IncludeVirtualMembers)
 }
 
 func TestTraeWorkspaceChangedPathAndRawExport(t *testing.T) {

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -81,6 +81,12 @@ type AgentDef struct {
 	FileBased         bool     // false for DB-backed agents
 	Usage             UsageCapabilities
 
+	// PeriodicReconcile opts the agent into the scheduled scoped
+	// reconciliation because its declared watch coverage is shallow and
+	// subdirectory changes are invisible to the watcher. Expensive
+	// scheduling inputs default to unsupported.
+	PeriodicReconcile bool
+
 	// WatchRootsFunc resolves the directories to watch for live
 	// updates under a configured root, for agents whose watch
 	// targets depend on the on-disk layout rather than a static
@@ -243,14 +249,15 @@ var Registry = []AgentDef{
 		Usage:       UsageCapabilities{NoPerMessageTokenData: true},
 	},
 	{
-		Type:         AgentOpenHands,
-		DisplayName:  "OpenHands CLI",
-		EnvVar:       "OPENHANDS_CONVERSATIONS_DIR",
-		ConfigKey:    "openhands_dirs",
-		DefaultDirs:  []string{".openhands/conversations"},
-		IDPrefix:     "openhands:",
-		FileBased:    true,
-		ShallowWatch: true,
+		Type:              AgentOpenHands,
+		DisplayName:       "OpenHands CLI",
+		EnvVar:            "OPENHANDS_CONVERSATIONS_DIR",
+		ConfigKey:         "openhands_dirs",
+		DefaultDirs:       []string{".openhands/conversations"},
+		IDPrefix:          "openhands:",
+		FileBased:         true,
+		ShallowWatch:      true,
+		PeriodicReconcile: true,
 	},
 	{
 		Type:        AgentCursor,
@@ -736,13 +743,14 @@ var Registry = []AgentDef{
 		// roots; watch those roots shallowly and rely on the 15-minute
 		// periodic sync to pick up new repos' history files. Aider history
 		// is append-mostly, so this is an acceptable latency tradeoff.
-		Type:         AgentAider,
-		DisplayName:  "Aider",
-		EnvVar:       "AIDER_DIR",
-		ConfigKey:    "aider_dirs",
-		IDPrefix:     "aider:",
-		FileBased:    true,
-		ShallowWatch: true,
+		Type:              AgentAider,
+		DisplayName:       "Aider",
+		EnvVar:            "AIDER_DIR",
+		ConfigKey:         "aider_dirs",
+		IDPrefix:          "aider:",
+		FileBased:         true,
+		ShallowWatch:      true,
+		PeriodicReconcile: true,
 	},
 	{
 		Type:         AgentReasonix,
@@ -995,6 +1003,14 @@ type ParsedSession struct {
 	// ended. Empty string = unknown (parser did not classify, or
 	// agent format does not yet support classification).
 	TerminationStatus TerminationStatus
+
+	// ClaudeLinearParse reports whether the Claude full parser fell
+	// back to linear processing for this session's file (multi-root or
+	// unresolvable-parent uuid DAG). Linearity is monotonic across
+	// appends, so the incremental parser skips fork detection for
+	// linear-bound sessions. Only set by the Claude parser; nil for
+	// all other agents.
+	ClaudeLinearParse *bool
 
 	TotalOutputTokens    int
 	PeakContextTokens    int

--- a/internal/parser/types_test.go
+++ b/internal/parser/types_test.go
@@ -655,6 +655,28 @@ func TestCoworkRegistryEntry(t *testing.T) {
 		"Cowork root contains large local_* working trees that discovery skips")
 }
 
+func TestPeriodicReconcileCapability(t *testing.T) {
+	optedIn := map[AgentType]bool{}
+	for _, def := range Registry {
+		optedIn[def.Type] = def.PeriodicReconcile
+	}
+	// Shallow-watched providers rely on scheduled reconciliation because
+	// subdirectory changes are invisible to their shallow watch coverage.
+	assert.True(t, optedIn[AgentOpenHands])
+	assert.True(t, optedIn[AgentAider])
+	// Cowork's provider WatchPlan registers its root recursively
+	// (coworkWatchRoots Recursive:true overrides legacy ShallowWatch), so
+	// scheduled reconciliation would redundantly rescan the whole archive.
+	assert.False(t, optedIn[AgentCowork])
+	// Recursive session roots must NOT opt in: their shallow roots are
+	// supplemental (codex_provider.go WatchPlan registers Recursive:true),
+	// so scheduled reconciliation would rescan the whole session tree.
+	assert.False(t, optedIn[AgentCodex])
+	assert.False(t, optedIn[AgentHermes])
+	assert.False(t, optedIn[AgentClaude])
+	assert.False(t, optedIn[AgentGemini])
+}
+
 func TestAgentByPrefixCowork(t *testing.T) {
 	def, ok := AgentByPrefix("cowork:c0000000-0000-4000-8000-000000000001")
 	require.True(t, ok, "cowork-prefixed ID should resolve")
@@ -979,8 +1001,20 @@ func TestResolveOpenCodeWatchRootsSQLite(t *testing.T) {
 
 func TestResolveOpenCodeWatchRootsMissingRoot(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "missing")
-	got := ResolveOpenCodeWatchRoots(root)
-	assert.Nil(t, got, "ResolveOpenCodeWatchRoots()")
+	for _, tc := range []struct {
+		name    string
+		resolve func(string) []string
+	}{
+		{name: "opencode", resolve: ResolveOpenCodeWatchRoots},
+		{name: "kilo", resolve: ResolveKiloWatchRoots},
+		{name: "mimocode", resolve: ResolveMiMoCodeWatchRoots},
+		{name: "icodemate", resolve: ResolveIcodemateWatchRoots},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, []string{root}, tc.resolve(root),
+				"missing roots need a deterministic lifecycle watch plan")
+		})
+	}
 }
 
 func TestParseOpenCodeSQLiteVirtualPath(t *testing.T) {

--- a/internal/parser/vibe_provider.go
+++ b/internal/parser/vibe_provider.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -21,7 +22,7 @@ func newVibeProviderFactory(def AgentDef) ProviderFactory {
 			return NewSingleFileSourceSet(
 				AgentVibe,
 				cfg.Roots,
-				WithFileDiscovery(vibeDiscoverFiles),
+				WithStreamingFileDiscovery(vibeDiscoverEach),
 				WithFileWatchRoots(vibeWatchRoots),
 				WithFileChangedPathClassifier(vibeClassifyPath),
 				WithFileLookup(vibeFindFile),
@@ -32,38 +33,28 @@ func newVibeProviderFactory(def AgentDef) ProviderFactory {
 	)
 }
 
-func vibeDiscoverFiles(root string) []singleFileMatch {
-	var out []singleFileMatch
-	for _, path := range discoverVibeSessionPaths(root) {
-		if match, ok := vibeStrictMatch(root, path); ok {
-			out = append(out, match)
-		}
-	}
-	return out
-}
-
-// discoverVibeSessionPaths finds all Vibe messages.jsonl paths under root.
-// Symlinked session directories are followed (matching the watcher), but only
-// session_-prefixed directories that hold a regular messages.jsonl qualify.
-func discoverVibeSessionPaths(root string) []string {
-	entries, err := os.ReadDir(root)
-	if err != nil {
-		return nil
-	}
-	var paths []string
-	for _, entry := range entries {
-		if !isDirOrSymlink(entry, root) {
-			continue
-		}
+func vibeDiscoverEach(
+	ctx context.Context, root string, yield func(singleFileMatch) error,
+) error {
+	return streamDirectoryEntries(ctx, root, func(entry os.DirEntry) error {
 		if !isVibeSessionDirName(entry.Name()) {
-			continue
+			return nil
 		}
-		messagesPath := filepath.Join(root, entry.Name(), "messages.jsonl")
-		if isVibeMessagesFile(messagesPath) {
-			paths = append(paths, messagesPath)
+		isSessionDir, dirErr := streamingDirCandidateOrIncomplete(
+			AgentVibe, "Vibe session directory", entry, root,
+		)
+		if dirErr != nil {
+			return dirErr
 		}
-	}
-	return paths
+		if !isSessionDir {
+			return nil
+		}
+		path := filepath.Join(root, entry.Name(), "messages.jsonl")
+		if match, ok := vibeStrictMatch(root, path); ok {
+			return yield(match)
+		}
+		return nil
+	})
 }
 
 func vibeWatchRoots(roots []string) []WatchRoot {
@@ -280,6 +271,7 @@ func vibeProviderCapabilities() Capabilities {
 	return Capabilities{
 		Source: SourceCapabilities{
 			DiscoverSources:      CapabilitySupported,
+			StreamingDiscovery:   CapabilitySupported,
 			WatchSources:         CapabilitySupported,
 			ClassifyChangedPath:  CapabilitySupported,
 			FindSource:           CapabilitySupported,

--- a/internal/parser/vibe_provider_test.go
+++ b/internal/parser/vibe_provider_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -181,6 +182,92 @@ func TestVibeProviderDiscoversSymlinkedSessionDirectory(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok)
 	assert.Equal(t, sourcePath, found.DisplayPath)
+}
+
+// A followed session-directory symlink whose target cannot be resolved must
+// surface incomplete streaming discovery rather than reading as absent:
+// reconciliation treats a clean DiscoverEach as authoritative and would
+// tombstone every session beneath the symlink.
+func TestVibeProviderStreamingDiscoveryPropagatesSessionSymlinkErrors(t *testing.T) {
+	discoverEach := func(t *testing.T, root string) ([]string, error) {
+		t.Helper()
+		provider, ok := NewProvider(AgentVibe, ProviderConfig{
+			Roots: []string{root},
+		})
+		require.True(t, ok)
+		discoverer, ok := provider.(StreamingDiscoverer)
+		require.True(t, ok)
+		var yielded []string
+		err := discoverer.DiscoverEach(t.Context(), func(source SourceRef) error {
+			yielded = append(yielded, source.DisplayPath)
+			return nil
+		})
+		return yielded, err
+	}
+	writeHealthySession := func(t *testing.T, root string) string {
+		t.Helper()
+		path := filepath.Join(
+			root, "session_20260613_123456_healthy", "messages.jsonl",
+		)
+		writeSourceFile(t, path, vibeProviderMessagesFixture("healthy question"))
+		return path
+	}
+
+	t.Run("dangling session symlink", func(t *testing.T) {
+		root := t.TempDir()
+		healthy := writeHealthySession(t, root)
+		target := filepath.Join(t.TempDir(), "linked-session")
+		require.NoError(t, os.MkdirAll(target, 0o755))
+		link := filepath.Join(root, "session_20260613_123456_linked")
+		if err := os.Symlink(target, link); err != nil {
+			t.Skipf("symlink not supported: %v", err)
+		}
+		require.NoError(t, os.RemoveAll(target))
+
+		_, err := discoverEach(t, root)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, os.ErrNotExist)
+		var incomplete DiscoveryIncompleteError
+		assert.ErrorAs(t, err, &incomplete)
+
+		require.NoError(t, os.Remove(link))
+		yielded, err := discoverEach(t, root)
+		require.NoError(t, err)
+		assert.Equal(t, []string{healthy}, yielded)
+	})
+
+	t.Run("unstatable session symlink target", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("directory read permissions are not enforced on Windows")
+		}
+		if os.Geteuid() == 0 {
+			t.Skip("root bypasses directory permissions")
+		}
+		root := t.TempDir()
+		healthy := writeHealthySession(t, root)
+		targetParent := t.TempDir()
+		target := filepath.Join(targetParent, "linked-session")
+		require.NoError(t, os.MkdirAll(target, 0o755))
+		link := filepath.Join(root, "session_20260613_123456_linked")
+		if err := os.Symlink(target, link); err != nil {
+			t.Skipf("symlink not supported: %v", err)
+		}
+		require.NoError(t, os.Chmod(targetParent, 0o000))
+		t.Cleanup(func() { _ = os.Chmod(targetParent, 0o755) })
+
+		_, err := discoverEach(t, root)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, os.ErrPermission)
+		var incomplete DiscoveryIncompleteError
+		assert.ErrorAs(t, err, &incomplete)
+
+		require.NoError(t, os.Chmod(targetParent, 0o755))
+		yielded, err := discoverEach(t, root)
+		require.NoError(t, err)
+		assert.Equal(t, []string{healthy}, yielded)
+	})
 }
 
 func TestVibeProviderParse(t *testing.T) {

--- a/internal/parser/visualstudio_copilot.go
+++ b/internal/parser/visualstudio_copilot.go
@@ -2,6 +2,8 @@ package parser
 
 import (
 	"bufio"
+	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -130,19 +132,10 @@ func ResolveSourceFilePath(storedPath string) string {
 	if dbPath, _, ok := SplitWindsurfVirtualPath(storedPath); ok {
 		return dbPath
 	}
+	if dbPath, _, ok := ParseVirtualSourcePathForBase(storedPath, "state.db"); ok {
+		return dbPath
+	}
 	return storedPath
-}
-
-type vsCopilotTraceLine struct {
-	ResourceSpans []vsCopilotResourceSpan `json:"resourceSpans"`
-}
-
-type vsCopilotResourceSpan struct {
-	ScopeSpans []vsCopilotScopeSpan `json:"scopeSpans"`
-}
-
-type vsCopilotScopeSpan struct {
-	Spans []vsCopilotSpan `json:"spans"`
 }
 
 type vsCopilotSpan struct {
@@ -186,22 +179,24 @@ func parseVisualStudioCopilotConversation(
 		return nil, nil, fmt.Errorf("stat %s: %w", tracePath, err)
 	}
 
-	// Fingerprint every sibling trace file before reading spans. A
-	// conversation's transcript is rebuilt from all siblings, so the stored
-	// size/mtime must span them; computing it first means a sibling appended
-	// during the read shows up as a change on the next sync rather than being
-	// hidden behind a fingerprint that already counts it.
-	compositeSize, compositeMtime := VisualStudioCopilotTraceFingerprint(
-		tracePath,
-	)
-
 	spans, err := visualStudioCopilotConversationSpans(tracePath, conversationID)
 	if err != nil {
 		return nil, nil, err
 	}
+	return buildVisualStudioCopilotConversationFromSpans(
+		tracePath, conversationID, project, machine, spans,
+	)
+}
+
+func buildVisualStudioCopilotConversationFromSpans(
+	tracePath, conversationID, project, machine string, spans []vsCopilotSpan,
+) (*ParsedSession, []ParsedMessage, error) {
 	if len(spans) == 0 {
 		return nil, nil, nil
 	}
+	// Fingerprint every sibling before using the discovery cache. If any file
+	// changed, the next reconciliation invalidates the persisted fingerprint.
+	compositeSize, compositeMtime := VisualStudioCopilotTraceFingerprint(tracePath)
 
 	messages := visualStudioCopilotTraceMessages(spans)
 	if len(messages) == 0 {
@@ -250,18 +245,13 @@ func parseVisualStudioCopilotConversation(
 func visualStudioCopilotConversationSpans(
 	tracePath, conversationID string,
 ) ([]vsCopilotSpan, error) {
-	own, err := readVisualStudioCopilotTraceSpans(tracePath)
+	own, err := readVisualStudioCopilotConversationTraceSpans(
+		tracePath, conversationID,
+	)
 	if err != nil {
 		return nil, err
 	}
-	var spans []vsCopilotSpan
-	for _, span := range own {
-		if sameVisualStudioCopilotConversationID(
-			span.attrMap["gen_ai.conversation.id"], conversationID,
-		) {
-			spans = append(spans, span)
-		}
-	}
+	spans := own
 	siblingSpans, err := visualStudioCopilotSiblingTraceSpans(
 		tracePath, conversationID,
 	)
@@ -277,26 +267,190 @@ func visualStudioCopilotConversationSpans(
 // is returned rather than reported as an empty file, so callers do not mistake
 // an unreadable file for one with no conversations.
 func VisualStudioCopilotFileConversationIDs(path string) ([]string, error) {
-	spans, err := readVisualStudioCopilotTraceSpans(path)
-	if err != nil {
-		return nil, err
-	}
 	seen := map[string]struct{}{}
 	var ids []string
-	for _, span := range spans {
+	err := ForEachVisualStudioCopilotFileConversationID(
+		context.Background(), path, func(id string) error {
+			if _, ok := seen[id]; ok {
+				return nil
+			}
+			seen[id] = struct{}{}
+			ids = append(ids, id)
+			return nil
+		})
+	return ids, err
+}
+
+// ForEachVisualStudioCopilotFileConversationID scans one trace line at a time
+// and yields conversation IDs without retaining all spans from the trace.
+func ForEachVisualStudioCopilotFileConversationID(
+	ctx context.Context, path string, yield func(string) error,
+) error {
+	return forEachVisualStudioCopilotTraceSpan(ctx, path, func(span vsCopilotSpan) error {
 		id := canonicalVisualStudioCopilotConversationID(
-			span.attrMap["gen_ai.conversation.id"],
+			vsCopilotTraceAttrs(span.Attributes)["gen_ai.conversation.id"],
 		)
 		if id == "" {
-			continue
+			return nil
 		}
-		if _, ok := seen[id]; ok {
-			continue
-		}
-		seen[id] = struct{}{}
-		ids = append(ids, id)
+		observeStreamingDiscoveryBuffer(ctx, 1)
+		return yield(id)
+	})
+}
+
+// forEachVisualStudioCopilotTraceSpan decodes a JSONL trace one span at a
+// time. It never materializes a whole trace line, resourceSpans array, or
+// scopeSpans array, so a single large OTLP export remains bounded by the
+// decoder's fixed input window plus one span.
+func forEachVisualStudioCopilotTraceSpan(
+	ctx context.Context, path string, yield func(vsCopilotSpan) error,
+) error {
+	observeSharedContainerScan(ctx)
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", path, err)
 	}
-	return ids, nil
+	defer f.Close()
+	hasher := sha256.New()
+	dec := json.NewDecoder(io.LimitReader(io.TeeReader(f, hasher), 1<<62))
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		token, err := dec.Token()
+		if errors.Is(err, io.EOF) {
+			info, statErr := f.Stat()
+			if statErr != nil {
+				return statErr
+			}
+			encoded, marshalErr := json.Marshal(SourceFingerprint{
+				Size: info.Size(), MTimeNS: info.ModTime().UnixNano(),
+				Hash: fmt.Sprintf("%x", hasher.Sum(nil)),
+			})
+			if marshalErr != nil {
+				return marshalErr
+			}
+			return reconciliationCachePut(
+				ctx, vsCopilotCachedFingerprintKey(path), string(encoded),
+			)
+		}
+		if err != nil {
+			return fmt.Errorf("decode %s: %w", path, err)
+		}
+		if token != json.Delim('{') {
+			return fmt.Errorf("decode %s: expected trace object", path)
+		}
+		if err := decodeVisualStudioCopilotTraceObject(ctx, dec, yield); err != nil {
+			return fmt.Errorf("decode %s: %w", path, err)
+		}
+	}
+}
+
+func decodeVisualStudioCopilotTraceObject(
+	ctx context.Context, dec *json.Decoder, yield func(vsCopilotSpan) error,
+) error {
+	for dec.More() {
+		name, err := dec.Token()
+		if err != nil {
+			return err
+		}
+		if name != "resourceSpans" {
+			if err := skipJSONValue(dec); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := decodeVisualStudioCopilotObjectArray(
+			dec, "scopeSpans", func() error {
+				return decodeVisualStudioCopilotObjectArray(
+					dec, "spans", func() error {
+						return decodeVisualStudioCopilotSpanArray(ctx, dec, yield)
+					},
+				)
+			},
+		); err != nil {
+			return err
+		}
+	}
+	_, err := dec.Token()
+	return err
+}
+
+func decodeVisualStudioCopilotSpanArray(
+	ctx context.Context, dec *json.Decoder, yield func(vsCopilotSpan) error,
+) error {
+	open, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	if open != json.Delim('[') {
+		return fmt.Errorf("spans: expected array")
+	}
+	var decoderRetained int64
+	defer func() { observeStreamingRetainedBytes(ctx, -decoderRetained) }()
+	for dec.More() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		start := dec.InputOffset()
+		var span vsCopilotSpan
+		if err := dec.Decode(&span); err != nil {
+			return err
+		}
+		encodedBytes := dec.InputOffset() - start
+		if encodedBytes > decoderRetained {
+			observeStreamingRetainedBytes(ctx, encodedBytes-decoderRetained)
+			decoderRetained = encodedBytes
+		}
+		retained := conservativeDecodedRetainedBytes(encodedBytes)
+		observeStreamingRetainedBytes(ctx, retained)
+		if err := yield(span); err != nil {
+			observeStreamingRetainedBytes(ctx, -retained)
+			return err
+		}
+		observeStreamingRetainedBytes(ctx, -retained)
+	}
+	_, err = dec.Token()
+	return err
+}
+
+func decodeVisualStudioCopilotObjectArray(
+	dec *json.Decoder, nestedField string, consumeNested func() error,
+) error {
+	open, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	if open != json.Delim('[') {
+		return fmt.Errorf("%s parent: expected array", nestedField)
+	}
+	for dec.More() {
+		open, err := dec.Token()
+		if err != nil {
+			return err
+		}
+		if open != json.Delim('{') {
+			return fmt.Errorf("%s parent: expected object", nestedField)
+		}
+		for dec.More() {
+			name, err := dec.Token()
+			if err != nil {
+				return err
+			}
+			if name == nestedField {
+				if err := consumeNested(); err != nil {
+					return err
+				}
+			} else if err := skipJSONValue(dec); err != nil {
+				return err
+			}
+		}
+		if _, err := dec.Token(); err != nil {
+			return err
+		}
+	}
+	_, err = dec.Token()
+	return err
 }
 
 // WriteVisualStudioCopilotConversationJSONL streams the trace data for one
@@ -557,49 +711,28 @@ func visualStudioCopilotSpanConversationID(span json.RawMessage) string {
 	return ""
 }
 
-func readVisualStudioCopilotTraceSpans(
-	path string,
+func readVisualStudioCopilotConversationTraceSpans(
+	path, conversationID string,
 ) ([]vsCopilotSpan, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("read %s: %w", path, err)
-	}
-	defer f.Close()
-
 	var spans []vsCopilotSpan
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, 64*1024), 256*1024*1024)
-	lineNo := 0
-	for scanner.Scan() {
-		lineNo++
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
-			continue
-		}
-		var trace vsCopilotTraceLine
-		if err := json.Unmarshal([]byte(line), &trace); err != nil {
-			return nil, fmt.Errorf(
-				"decode %s line %d: %w", path, lineNo, err,
-			)
-		}
-		for _, resourceSpan := range trace.ResourceSpans {
-			for _, scopeSpan := range resourceSpan.ScopeSpans {
-				for _, span := range scopeSpan.Spans {
-					span.attrMap = vsCopilotTraceAttrs(span.Attributes)
-					span.start = parseUnixNano(span.StartTimeUnixNano)
-					span.end = parseUnixNano(span.EndTimeUnixNano)
-					if span.attrMap["gen_ai.conversation.id"] == "" {
-						continue
-					}
-					spans = append(spans, span)
-				}
+	err := forEachVisualStudioCopilotTraceSpan(
+		context.Background(), path, func(span vsCopilotSpan) error {
+			prepareVisualStudioCopilotSpan(&span)
+			if sameVisualStudioCopilotConversationID(
+				span.attrMap["gen_ai.conversation.id"], conversationID,
+			) {
+				spans = append(spans, span)
 			}
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("scan %s: %w", path, err)
-	}
-	return spans, nil
+			return nil
+		},
+	)
+	return spans, err
+}
+
+func prepareVisualStudioCopilotSpan(span *vsCopilotSpan) {
+	span.attrMap = vsCopilotTraceAttrs(span.Attributes)
+	span.start = parseUnixNano(span.StartTimeUnixNano)
+	span.end = parseUnixNano(span.EndTimeUnixNano)
 }
 
 // visualStudioCopilotSiblingTraceSpans collects spans for one conversation from
@@ -623,17 +756,13 @@ func visualStudioCopilotSiblingTraceSpans(
 		if sibling == path {
 			continue
 		}
-		candidateSpans, err := readVisualStudioCopilotTraceSpans(sibling)
+		candidateSpans, err := readVisualStudioCopilotConversationTraceSpans(
+			sibling, conversationID,
+		)
 		if err != nil {
 			return nil, err
 		}
-		for _, span := range candidateSpans {
-			if sameVisualStudioCopilotConversationID(
-				span.attrMap["gen_ai.conversation.id"], conversationID,
-			) {
-				spans = append(spans, span)
-			}
-		}
+		spans = append(spans, candidateSpans...)
 	}
 	return spans, nil
 }

--- a/internal/parser/visualstudio_copilot_provider.go
+++ b/internal/parser/visualstudio_copilot_provider.go
@@ -1,6 +1,10 @@
 package parser
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
@@ -28,17 +32,307 @@ func newVisualStudioCopilotProviderFactory(def AgentDef) ProviderFactory {
 				AgentVSCopilot,
 				cfg.Roots,
 				WithSourceDiscovery(vsCopilotDiscoverSources),
+				WithStreamingSourceDiscovery(vsCopilotDiscoverEach),
 				WithWatchRoots(vsCopilotWatchRoots),
 				WithChangedPathClassifier(vsCopilotClassifyPath),
 				WithMemberLookup(vsCopilotFindMember),
-				WithFingerprint(vsCopilotFingerprintSource),
+				WithContextFingerprint(vsCopilotFingerprintSourceContext),
 				WithContainerParse(vsCopilotParseContainer),
-				WithMemberParse(vsCopilotParseMember),
+				WithContextMemberParse(vsCopilotParseMemberContext),
 				// Every conversation in a trace shares the trace's content hash.
 				WithContainerHashStamping(),
 			)
 		},
 	)
+}
+
+type vsCopilotDiskCandidate struct {
+	Path    string `json:"path"`
+	MTimeNS int64  `json:"mtime_ns"`
+}
+
+// vsCopilotRootComposite memoizes the shared sibling trace fingerprint for
+// one discovery pass. Every trace file in the pass lives in the same
+// directory, so the composite (summed size, max mtime) is identical for all
+// of them; computing it once keeps discovery linear instead of re-listing
+// and re-statting the directory per trace file. The zero value is ready to
+// use and covers exactly one pass.
+type vsCopilotRootComposite struct {
+	done  bool
+	size  int64
+	mtime int64
+	err   error
+}
+
+func (c *vsCopilotRootComposite) fingerprint(
+	tracePath string,
+) (size, mtime int64, err error) {
+	if !c.done {
+		c.done = true
+		c.size, c.mtime, c.err =
+			VisualStudioCopilotTraceFingerprintStrict(tracePath)
+	}
+	return c.size, c.mtime, c.err
+}
+
+// vsCopilotDiscoverEach externalizes the conversation-to-canonical-file index
+// to a temporary SQLite table. Trace and VS 2026 trees are read in fixed-size
+// directory batches; only one decoded trace line is resident at a time.
+func vsCopilotDiscoverEach(
+	ctx context.Context, root string, yield func(multiSessionMatch) error,
+) (retErr error) {
+	index, err := newDiscoveryDiskMapForContext(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		retErr = errors.Join(retErr, index.close())
+	}()
+	remember := func(id, path string, mtimeNS int64) error {
+		current, found, err := index.get(ctx, id)
+		if err != nil {
+			return err
+		}
+		if found {
+			var candidate vsCopilotDiskCandidate
+			if json.Unmarshal([]byte(current), &candidate) == nil &&
+				(candidate.MTimeNS > mtimeNS ||
+					(candidate.MTimeNS == mtimeNS && candidate.Path >= path)) {
+				return nil
+			}
+		}
+		encoded, err := json.Marshal(vsCopilotDiskCandidate{Path: path, MTimeNS: mtimeNS})
+		if err != nil {
+			return err
+		}
+		return index.put(ctx, id, string(encoded), true)
+	}
+	root = filepath.Clean(root)
+	var composite vsCopilotRootComposite
+	err = streamDirectoryEntries(ctx, root, func(entry os.DirEntry) error {
+		if entry.IsDir() || !isVisualStudioCopilotTraceFileName(entry.Name()) {
+			return nil
+		}
+		path := filepath.Join(root, entry.Name())
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		err = forEachVisualStudioCopilotTraceSpan(ctx, path, func(span vsCopilotSpan) error {
+			id := canonicalVisualStudioCopilotConversationID(
+				vsCopilotTraceAttrs(span.Attributes)["gen_ai.conversation.id"],
+			)
+			if id == "" {
+				return nil
+			}
+			encoded, err := json.Marshal(span)
+			if err != nil {
+				return err
+			}
+			if err := reconciliationCacheAppend(
+				ctx, vsCopilotCachedSpansKey(root, id), string(encoded),
+			); err != nil {
+				return err
+			}
+			return remember(id, path, info.ModTime().UnixNano())
+		})
+		if err != nil {
+			return err
+		}
+		encoded, found, err := reconciliationCacheGet(
+			ctx, vsCopilotCachedFingerprintKey(path),
+		)
+		if err != nil || !found {
+			return err
+		}
+		var fingerprint SourceFingerprint
+		if err := json.Unmarshal([]byte(encoded), &fingerprint); err != nil {
+			return err
+		}
+		fingerprint.Size, fingerprint.MTimeNS, err = composite.fingerprint(path)
+		if err != nil {
+			return err
+		}
+		encodedBytes, err := json.Marshal(fingerprint)
+		if err != nil {
+			return err
+		}
+		return reconciliationCachePut(
+			ctx, vsCopilotCachedFingerprintKey(path), string(encodedBytes),
+		)
+	})
+	if err != nil {
+		return err
+	}
+	if err := streamVisualStudioCopilotVS2026Sessions(ctx, root, remember); err != nil {
+		return err
+	}
+	return index.forEach(ctx, func(id, value string) error {
+		var candidate vsCopilotDiskCandidate
+		if err := json.Unmarshal([]byte(value), &candidate); err != nil {
+			return err
+		}
+		return yield(multiSessionMatch{
+			Path:      VisualStudioCopilotVirtualPath(candidate.Path, id),
+			Container: candidate.Path, MemberID: id,
+			ProjectHint: "visualstudio", DiscoveryMTimeNS: candidate.MTimeNS,
+		})
+	})
+}
+
+// streamVisualStudioCopilotVS2026Sessions follows only the fixed VS 2026
+// layout. Expected directory symlinks are safe because traversal has a bounded
+// logical depth, and every directory is read through fixed-size batches.
+func streamVisualStudioCopilotVS2026Sessions(
+	ctx context.Context,
+	root string,
+	remember func(id, path string, mtimeNS int64) error,
+) error {
+	switch visualStudioCopilotVS2026RootKind(root) {
+	case visualStudioCopilotVS2026SessionsRoot:
+		return streamVisualStudioCopilotVS2026SessionDirectory(ctx, root, remember)
+	case visualStudioCopilotVS2026ThreadRoot:
+		return streamVisualStudioCopilotVS2026ThreadRoot(ctx, root, remember)
+	case visualStudioCopilotVS2026CopilotChatRoot:
+		return streamVisualStudioCopilotVS2026CopilotChatRoot(ctx, root, remember)
+	case visualStudioCopilotVS2026VSRoot:
+		return streamVisualStudioCopilotVS2026VSRoot(ctx, root, remember)
+	default:
+		vsRoot, ok, err := streamVisualStudioCopilotChildDir(ctx, root, ".vs")
+		if err != nil || !ok {
+			return err
+		}
+		return streamVisualStudioCopilotVS2026VSRoot(ctx, vsRoot, remember)
+	}
+}
+
+func streamVisualStudioCopilotVS2026VSRoot(
+	ctx context.Context,
+	vsRoot string,
+	remember func(id, path string, mtimeNS int64) error,
+) error {
+	return streamVisualStudioCopilotDirectoryCandidates(ctx, vsRoot, func(solutionRoot string) error {
+		copilotChatRoot, ok, err := streamVisualStudioCopilotChildDir(
+			ctx, solutionRoot, "copilot-chat",
+		)
+		if err != nil || !ok {
+			return err
+		}
+		return streamVisualStudioCopilotVS2026CopilotChatRoot(
+			ctx, copilotChatRoot, remember,
+		)
+	})
+}
+
+func streamVisualStudioCopilotVS2026CopilotChatRoot(
+	ctx context.Context,
+	copilotChatRoot string,
+	remember func(id, path string, mtimeNS int64) error,
+) error {
+	return streamVisualStudioCopilotDirectoryCandidates(ctx, copilotChatRoot, func(threadRoot string) error {
+		return streamVisualStudioCopilotVS2026ThreadRoot(ctx, threadRoot, remember)
+	})
+}
+
+func streamVisualStudioCopilotVS2026ThreadRoot(
+	ctx context.Context,
+	threadRoot string,
+	remember func(id, path string, mtimeNS int64) error,
+) error {
+	sessionsRoot, ok, err := streamVisualStudioCopilotChildDir(ctx, threadRoot, "sessions")
+	if err != nil || !ok {
+		return err
+	}
+	return streamVisualStudioCopilotVS2026SessionDirectory(ctx, sessionsRoot, remember)
+}
+
+func streamVisualStudioCopilotVS2026SessionDirectory(
+	ctx context.Context,
+	sessionsRoot string,
+	remember func(id, path string, mtimeNS int64) error,
+) error {
+	return streamDirectoryEntries(ctx, sessionsRoot, func(entry os.DirEntry) error {
+		if entry.IsDir() || !isVisualStudioCopilotVS2026SessionFileName(entry.Name()) {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		path := filepath.Join(sessionsRoot, entry.Name())
+		return remember(
+			canonicalVisualStudioCopilotConversationID(entry.Name()),
+			path,
+			info.ModTime().UnixNano(),
+		)
+	})
+}
+
+func streamVisualStudioCopilotDirectoryCandidates(
+	ctx context.Context,
+	parent string,
+	visit func(string) error,
+) error {
+	return streamDirectoryEntries(ctx, parent, func(entry os.DirEntry) error {
+		candidate, err := streamingDirOrSymlinkCandidate(entry, parent)
+		if err != nil {
+			return fmt.Errorf(
+				"stat Visual Studio Copilot directory candidate %s: %w",
+				filepath.Join(parent, entry.Name()), err,
+			)
+		}
+		if !candidate {
+			return nil
+		}
+		return visit(filepath.Join(parent, entry.Name()))
+	})
+}
+
+func streamVisualStudioCopilotChildDir(
+	ctx context.Context,
+	parent string,
+	name string,
+) (string, bool, error) {
+	var fallback string
+	err := streamDirectoryEntries(ctx, parent, func(entry os.DirEntry) error {
+		if !strings.EqualFold(entry.Name(), name) {
+			return nil
+		}
+		candidate, err := streamingDirOrSymlinkCandidate(entry, parent)
+		if err != nil {
+			return fmt.Errorf(
+				"stat Visual Studio Copilot directory %s: %w",
+				filepath.Join(parent, entry.Name()), err,
+			)
+		}
+		if !candidate {
+			return nil
+		}
+		path := filepath.Join(parent, entry.Name())
+		if entry.Name() == name {
+			fallback = path
+			return errStopStreamingDiscovery
+		}
+		if fallback == "" || path < fallback {
+			fallback = path
+		}
+		return nil
+	})
+	if errors.Is(err, errStopStreamingDiscovery) {
+		return fallback, true, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return fallback, fallback != "", nil
+}
+
+func vsCopilotCachedSpansKey(root, conversationID string) string {
+	return "visualstudio-copilot:spans:" + filepath.Clean(root) + "\x00" +
+		canonicalVisualStudioCopilotConversationID(conversationID)
 }
 
 // vsCopilotDiscoverSources emits one match per conversation (virtual path) plus
@@ -589,6 +883,29 @@ func vsCopilotFingerprintSource(
 	}, nil
 }
 
+func vsCopilotCachedFingerprintKey(path string) string {
+	return "visualstudio-copilot:fingerprint:" + filepath.Clean(path)
+}
+
+func vsCopilotFingerprintSourceContext(
+	ctx context.Context, src multiSessionSource,
+) (SourceFingerprint, error) {
+	encoded, found, err := reconciliationCacheGet(
+		ctx, vsCopilotCachedFingerprintKey(src.Container),
+	)
+	if err != nil {
+		return SourceFingerprint{}, err
+	}
+	if !found {
+		return vsCopilotFingerprintSource(src)
+	}
+	var fingerprint SourceFingerprint
+	if err := json.Unmarshal([]byte(encoded), &fingerprint); err != nil {
+		return SourceFingerprint{}, fmt.Errorf("decode cached Visual Studio Copilot fingerprint: %w", err)
+	}
+	return fingerprint, nil
+}
+
 func vsCopilotParseMember(
 	src multiSessionSource, req ParseRequest,
 ) (*ParseResult, error) {
@@ -601,6 +918,41 @@ func vsCopilotParseMember(
 	}
 	if sess == nil {
 		return nil, nil
+	}
+	return &ParseResult{Session: *sess, Messages: msgs}, nil
+}
+
+func vsCopilotParseMemberContext(
+	ctx context.Context, src multiSessionSource, req ParseRequest,
+) (*ParseResult, error) {
+	encoded, found, err := reconciliationCacheGet(
+		ctx, vsCopilotCachedSpansKey(src.Root, src.MemberID),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if !found || isVisualStudioCopilotVS2026SessionPath(src.Container) {
+		return vsCopilotParseMember(src, req)
+	}
+	retained := conservativeDecodedRetainedBytes(int64(len(encoded)))
+	observeStreamingRetainedBytes(ctx, retained)
+	defer observeStreamingRetainedBytes(ctx, -retained)
+	observeReconciliationRetainedMember(ctx, AgentVSCopilot, retained)
+	var spans []vsCopilotSpan
+	for line := range strings.SplitSeq(encoded, "\n") {
+		var span vsCopilotSpan
+		if err := json.Unmarshal([]byte(line), &span); err != nil {
+			return nil, fmt.Errorf("decode cached Visual Studio Copilot span: %w", err)
+		}
+		prepareVisualStudioCopilotSpan(&span)
+		spans = append(spans, span)
+	}
+	project := firstNonEmptyJSONLString(req.Source.ProjectHint, "visualstudio")
+	sess, msgs, err := buildVisualStudioCopilotConversationFromSpans(
+		src.Container, src.MemberID, project, req.Machine, spans,
+	)
+	if err != nil || sess == nil {
+		return nil, err
 	}
 	return &ParseResult{Session: *sess, Messages: msgs}, nil
 }

--- a/internal/parser/visualstudio_copilot_test.go
+++ b/internal/parser/visualstudio_copilot_test.go
@@ -1919,3 +1919,34 @@ func mustJSON(t *testing.T, value any) []byte {
 	require.NoError(t, err)
 	return data
 }
+
+// Every trace file in a discovery pass shares one directory, so the
+// composite sibling fingerprint must be computed once per pass — not
+// re-enumerated per trace file, which is quadratic in rotated-trace
+// count. The memo proves reuse by ignoring filesystem changes after
+// the first computation.
+func TestVSCopilotRootCompositeComputesOnce(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	first := filepath.Join(dir, "a_VSGitHubCopilot_traces.jsonl")
+	second := filepath.Join(dir, "b_VSGitHubCopilot_traces.jsonl")
+	require.NoError(t, os.WriteFile(first, []byte("one"), 0o644))
+	require.NoError(t, os.WriteFile(second, []byte("two"), 0o644))
+
+	var composite vsCopilotRootComposite
+	size, mtime, err := composite.fingerprint(first)
+	require.NoError(t, err)
+	assert.Equal(t, int64(len("one")+len("two")), size)
+
+	// A sibling appearing mid-pass must not change the memoized value.
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "c_VSGitHubCopilot_traces.jsonl"),
+		[]byte("three"), 0o644,
+	))
+	sizeAgain, mtimeAgain, err := composite.fingerprint(second)
+	require.NoError(t, err)
+	assert.Equal(t, size, sizeAgain,
+		"second lookup must reuse the per-pass composite, not re-enumerate")
+	assert.Equal(t, mtime, mtimeAgain)
+}

--- a/internal/parser/vscode_copilot_provider.go
+++ b/internal/parser/vscode_copilot_provider.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -47,6 +48,10 @@ type vscodeCopilotProvider struct {
 
 func (p *vscodeCopilotProvider) Discover(ctx context.Context) ([]SourceRef, error) {
 	return p.sources.Discover(ctx)
+}
+
+func (p *vscodeCopilotProvider) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	return p.sources.DiscoverEach(ctx, yield)
 }
 
 func (p *vscodeCopilotProvider) WatchPlan(ctx context.Context) (WatchPlan, error) {
@@ -153,6 +158,77 @@ func (s vscodeCopilotSourceSet) Discover(ctx context.Context) ([]SourceRef, erro
 	}
 	sortJSONLSources(sources)
 	return sources, nil
+}
+
+func (s vscodeCopilotSourceSet) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	for _, root := range s.roots {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		yieldDir := func(dir, project string) error {
+			return streamVSCodeSessionFiles(ctx, dir, project, AgentVSCodeCopilot, func(file DiscoveredFile) error {
+				source, ok := s.sourceRefWithProject(root, file.Path, file.Project)
+				if !ok {
+					return nil
+				}
+				source.ProjectHint = file.Project
+				return yield(source)
+			})
+		}
+		workspaceRoot := filepath.Join(root, "workspaceStorage")
+		if err := streamDirectoryEntries(ctx, workspaceRoot, func(entry os.DirEntry) error {
+			if !entry.IsDir() {
+				return nil
+			}
+			hashPath := filepath.Join(workspaceRoot, entry.Name())
+			project := readVSCodeWorkspaceManifest(hashPath)
+			if project == "" {
+				project = "unknown"
+			}
+			return yieldDir(filepath.Join(hashPath, "chatSessions"), project)
+		}); err != nil {
+			return err
+		}
+		for _, subdir := range []string{
+			"globalStorage/emptyWindowChatSessions",
+			"globalStorage/transferredChatSessions",
+		} {
+			if err := yieldDir(filepath.Join(root, subdir), "empty-window"); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func streamVSCodeSessionFiles(
+	ctx context.Context, dir, project string, agent AgentType,
+	yield func(DiscoveredFile) error,
+) error {
+	err := streamDirectoryEntries(ctx, dir, func(entry os.DirEntry) error {
+		if entry.IsDir() {
+			return nil
+		}
+		name := entry.Name()
+		ext := filepath.Ext(name)
+		if ext != ".json" && ext != ".jsonl" {
+			return nil
+		}
+		stem := strings.TrimSuffix(name, ext)
+		if !IsValidSessionID(stem) {
+			return nil
+		}
+		if ext == ".json" && IsRegularFile(filepath.Join(dir, stem+".jsonl")) {
+			return nil
+		}
+		return yield(DiscoveredFile{
+			Path: filepath.Join(dir, name), Project: project, Agent: agent,
+		})
+	})
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
 }
 
 // discoverSessionFiles traverses the VSCode workspaceStorage directory to find
@@ -647,6 +723,7 @@ func vscodeCopilotProviderCapabilities() Capabilities {
 	return Capabilities{
 		Source: SourceCapabilities{
 			DiscoverSources:      CapabilitySupported,
+			StreamingDiscovery:   CapabilitySupported,
 			WatchSources:         CapabilitySupported,
 			ClassifyChangedPath:  CapabilitySupported,
 			FindSource:           CapabilitySupported,

--- a/internal/parser/warp.go
+++ b/internal/parser/warp.go
@@ -1,8 +1,10 @@
 package parser
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -27,46 +29,87 @@ type WarpSessionMeta struct {
 func ListWarpSessionMeta(
 	dbPath string,
 ) ([]WarpSessionMeta, error) {
+	var metas []WarpSessionMeta
+	err := ForEachWarpSessionMeta(
+		context.Background(), dbPath,
+		func(meta WarpSessionMeta) error {
+			metas = append(metas, meta)
+			return nil
+		},
+	)
+	return metas, err
+}
+
+func ForEachWarpSessionMeta(
+	ctx context.Context, dbPath string, yield func(WarpSessionMeta) error,
+) error {
 	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
-		return nil, nil
+		return nil
 	}
 
 	db, err := openWarpDB(dbPath)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer db.Close()
 
-	rows, err := db.Query(
+	rows, err := db.QueryContext(ctx,
 		`SELECT conversation_id, last_modified_at
 		 FROM agent_conversations`,
 	)
 	if err != nil {
-		return nil, fmt.Errorf(
+		return fmt.Errorf(
 			"listing warp conversations: %w", err,
 		)
 	}
 	defer rows.Close()
 
-	var metas []WarpSessionMeta
 	for rows.Next() {
 		var id string
 		var lastModified string
 		if err := rows.Scan(
 			&id, &lastModified,
 		); err != nil {
-			return nil, fmt.Errorf(
+			return fmt.Errorf(
 				"scanning warp session meta: %w", err,
 			)
 		}
 		mtime := parseWarpTimestamp(lastModified).UnixNano()
-		metas = append(metas, WarpSessionMeta{
+		observeStreamingDiscoveryBuffer(ctx, 1)
+		if err := yield(WarpSessionMeta{
 			SessionID:   id,
-			VirtualPath: dbPath + "#" + id,
+			VirtualPath: VirtualSourcePath(dbPath, id),
 			FileMtime:   mtime,
-		})
+		}); err != nil {
+			return err
+		}
 	}
-	return metas, rows.Err()
+	return rows.Err()
+}
+
+func warpSessionMeta(
+	ctx context.Context, dbPath, sessionID string,
+) (WarpSessionMeta, bool, error) {
+	db, err := openWarpDB(dbPath)
+	if err != nil {
+		return WarpSessionMeta{}, false, err
+	}
+	defer db.Close()
+	var lastModified string
+	err = db.QueryRowContext(ctx, `
+		SELECT last_modified_at FROM agent_conversations
+		WHERE conversation_id = ?
+	`, sessionID).Scan(&lastModified)
+	if errors.Is(err, sql.ErrNoRows) {
+		return WarpSessionMeta{}, false, nil
+	}
+	if err != nil {
+		return WarpSessionMeta{}, false, err
+	}
+	return WarpSessionMeta{
+		SessionID: sessionID, VirtualPath: VirtualSourcePath(dbPath, sessionID),
+		FileMtime: parseWarpTimestamp(lastModified).UnixNano(),
+	}, true, nil
 }
 
 // parseWarpSession parses a single conversation by ID from
@@ -278,7 +321,7 @@ func buildWarpSession(
 		MessageCount:     len(parsed),
 		UserMessageCount: userCount,
 		File: FileInfo{
-			Path:  dbPath + "#" + c.id,
+			Path:  VirtualSourcePath(dbPath, c.id),
 			Mtime: parseWarpTimestamp(c.lastModifiedAt).UnixNano(),
 		},
 	}

--- a/internal/parser/windsurf_provider.go
+++ b/internal/parser/windsurf_provider.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -66,6 +67,10 @@ func (p *windsurfProvider) Discover(ctx context.Context) ([]SourceRef, error) {
 	return p.sources.Discover(ctx)
 }
 
+func (p *windsurfProvider) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	return p.sources.DiscoverEach(ctx, yield)
+}
+
 func (p *windsurfProvider) WatchPlan(ctx context.Context) (WatchPlan, error) {
 	return p.sources.WatchPlan(ctx)
 }
@@ -75,6 +80,18 @@ func (p *windsurfProvider) SourcesForChangedPath(
 	req ChangedPathRequest,
 ) ([]SourceRef, error) {
 	return p.sources.SourcesForChangedPath(ctx, req)
+}
+
+func (p *windsurfProvider) StoredSourceHintScopes(
+	req ChangedPathRequest,
+) []StoredSourceHintScope {
+	return p.sources.StoredSourceHintScopes(req)
+}
+
+func (p *windsurfProvider) SourceForReconciliation(
+	ctx context.Context, path, project string,
+) (SourceRef, bool, error) {
+	return p.sources.SourceForReconciliation(ctx, path, project)
 }
 
 func (p *windsurfProvider) FindSource(
@@ -113,8 +130,8 @@ func (p *windsurfProvider) Parse(
 		return ParseOutcome{}, fmt.Errorf("stat %s: %w", src.DBPath, err)
 	}
 	machine := firstNonEmptyJSONLString(req.Machine, p.Config.Machine)
-	sess, msgs, err := parseWindsurfSession(
-		src.DBPath, src.SessionID, src.Project, machine, src.VirtualPath,
+	sess, msgs, err := parseWindsurfSessionContext(
+		ctx, src.DBPath, src.SessionID, src.Project, machine, src.VirtualPath,
 	)
 	if err == sql.ErrNoRows {
 		return ParseOutcome{
@@ -192,6 +209,102 @@ func (s windsurfSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
 	return sources, nil
 }
 
+func (s windsurfSourceSet) DiscoverEach(ctx context.Context, yield func(SourceRef) error) error {
+	for _, root := range s.roots {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		workspaceRoot := windsurfWorkspaceRoot(root)
+		if err := streamDirectoryEntries(ctx, workspaceRoot, func(entry os.DirEntry) error {
+			if !entry.IsDir() {
+				return nil
+			}
+			dbPath := filepath.Join(workspaceRoot, entry.Name(), windsurfStateDBName)
+			info, err := os.Stat(dbPath)
+			if os.IsNotExist(err) {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			if info.IsDir() {
+				return nil
+			}
+			project := windsurfWorkspaceProject(dbPath)
+			manifestPath := windsurfWorkspaceManifestPath(dbPath)
+			manifest, err := os.ReadFile(manifestPath)
+			manifestExists := err == nil
+			if errors.Is(err, os.ErrNotExist) {
+				manifest = nil
+				err = nil
+			}
+			if err != nil {
+				return err
+			}
+			manifestRetained := int64(len(manifest))
+			observeStreamingRetainedBytes(ctx, manifestRetained)
+			defer observeStreamingRetainedBytes(ctx, -manifestRetained)
+			var manifestInfo os.FileInfo
+			if manifestExists {
+				manifestInfo, err = os.Stat(manifestPath)
+				if err != nil {
+					return err
+				}
+			}
+			ids, err := newDiscoveryDiskMapForContext(ctx)
+			if err != nil {
+				return err
+			}
+			err = forEachWindsurfSessionRecord(ctx, dbPath, func(record windsurfSessionRecord) error {
+				inserted, err := ids.putIfAbsent(ctx, record.SessionID, record.SessionID)
+				if err != nil {
+					return err
+				}
+				if !inserted {
+					return nil
+				}
+				if err := reconciliationCachePut(
+					ctx, windsurfCachedRecordKey(dbPath, record.SessionID), string(record.Data),
+				); err != nil {
+					return err
+				}
+				h := sha256.New()
+				_, _ = h.Write(record.Data)
+				_, _ = h.Write(manifest)
+				mtime := info.ModTime().UnixNano()
+				if manifestInfo != nil {
+					mtime = max(mtime, manifestInfo.ModTime().UnixNano())
+				}
+				encoded, err := json.Marshal(SourceFingerprint{
+					Size: int64(len(record.Data) + len(manifest)), MTimeNS: mtime,
+					Hash: fmt.Sprintf("%x", h.Sum(nil)),
+				})
+				if err != nil {
+					return err
+				}
+				if err := reconciliationCachePut(
+					ctx, windsurfCachedFingerprintKey(dbPath, record.SessionID), string(encoded),
+				); err != nil {
+					return err
+				}
+				return nil
+			})
+			if err == nil {
+				err = ids.forEach(ctx, func(id, _ string) error {
+					ref := s.newSourceRef(root, dbPath, id, project)
+					ref.DiscoveryMTimeNS = info.ModTime().UnixNano()
+					return yield(ref)
+				})
+			}
+			err = errors.Join(err, ids.close())
+			return err
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (s windsurfSourceSet) WatchPlan(context.Context) (WatchPlan, error) {
 	roots := make([]WatchRoot, 0, len(s.roots))
 	for _, root := range s.roots {
@@ -214,6 +327,17 @@ func (s windsurfSourceSet) SourcesForChangedPath(
 		return nil, err
 	}
 	for _, root := range s.roots {
+		if ref, ok := s.sourceRef(root, req.Path); ok {
+			src := ref.Opaque.(windsurfSource)
+			exists, err := windsurfDBHasSession(src.DBPath, src.SessionID)
+			if err != nil {
+				return nil, err
+			}
+			if exists {
+				return []SourceRef{ref}, nil
+			}
+			return nil, nil
+		}
 		dbPath, ok := s.dbPathForEvent(root, req)
 		if !ok {
 			continue
@@ -242,6 +366,48 @@ func (s windsurfSourceSet) SourcesForChangedPath(
 		return sources, nil
 	}
 	return nil, nil
+}
+
+func (s windsurfSourceSet) StoredSourceHintScopes(
+	req ChangedPathRequest,
+) []StoredSourceHintScope {
+	for _, root := range s.roots {
+		if ref, ok := s.sourceRef(root, req.Path); ok {
+			return []StoredSourceHintScope{{Path: ref.DisplayPath}}
+		}
+		if dbPath, ok := s.dbPathForEvent(root, req); ok {
+			return []StoredSourceHintScope{{
+				Path: dbPath, IncludeVirtualMembers: true,
+			}}
+		}
+	}
+	return nil
+}
+
+// SourceForReconciliation reconstructs an already-discovered virtual member
+// without reopening or scanning the shared workspace database. Discovery is
+// authoritative for member existence and populates the reconciliation cache;
+// parsing consumes that exact cached member later in the same operation.
+func (s windsurfSourceSet) SourceForReconciliation(
+	ctx context.Context, path, project string,
+) (SourceRef, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return SourceRef{}, false, err
+	}
+	for _, root := range s.roots {
+		ref, ok := s.sourceRef(root, path)
+		if !ok {
+			continue
+		}
+		if project != "" {
+			ref.ProjectHint = project
+			source := ref.Opaque.(windsurfSource)
+			source.Project = project
+			ref.Opaque = source
+		}
+		return ref, true, nil
+	}
+	return SourceRef{}, false, nil
 }
 
 func (s windsurfSourceSet) FindSource(
@@ -278,14 +444,12 @@ func (s windsurfSourceSet) FindSource(
 	}
 	for _, root := range s.roots {
 		for _, db := range s.workspaceDBs(root) {
-			records, err := listWindsurfSessionRecords(db.DBPath)
+			exists, err := windsurfDBHasSession(db.DBPath, req.RawSessionID)
 			if err != nil {
 				return SourceRef{}, false, err
 			}
-			for _, record := range records {
-				if record.SessionID == req.RawSessionID {
-					return s.newSourceRef(root, db.DBPath, record.SessionID, db.Project), true, nil
-				}
+			if exists {
+				return s.newSourceRef(root, db.DBPath, req.RawSessionID, db.Project), true, nil
 			}
 		}
 	}
@@ -316,21 +480,57 @@ func (s windsurfSourceSet) Fingerprint(
 		}
 		return SourceFingerprint{}, fmt.Errorf("stat %s: %w", src.DBPath, err)
 	}
+	if encoded, found, err := reconciliationCacheGet(
+		ctx, windsurfCachedFingerprintKey(src.DBPath, src.SessionID),
+	); err != nil {
+		return SourceFingerprint{}, err
+	} else if found {
+		var fingerprint SourceFingerprint
+		if err := json.Unmarshal([]byte(encoded), &fingerprint); err != nil {
+			return SourceFingerprint{}, fmt.Errorf("decode cached windsurf fingerprint: %w", err)
+		}
+		fingerprint.Key = firstNonEmptyJSONLString(
+			source.FingerprintKey, source.Key, src.VirtualPath,
+		)
+		return fingerprint, nil
+	}
 	workspacePath := windsurfWorkspaceManifestPath(src.DBPath)
-	combined := antigravityCLICombinedFileInfo(
-		info,
-		src.DBPath+"-wal",
-		workspacePath,
-	)
-	hash, err := windsurfSourceHash(src.DBPath, workspacePath)
+	record, err := loadWindsurfSessionRecord(src.DBPath, src.SessionID)
+	if err == sql.ErrNoRows {
+		return SourceFingerprint{Key: source.FingerprintKey}, nil
+	}
 	if err != nil {
 		return SourceFingerprint{}, err
 	}
+	h := sha256.New()
+	_, _ = h.Write(record.Data)
+	size := int64(len(record.Data))
+	mtime := info.ModTime().UnixNano()
+	if IsRegularFile(workspacePath) {
+		manifestInfo, err := os.Stat(workspacePath)
+		if err != nil {
+			return SourceFingerprint{}, err
+		}
+		manifest, err := os.Open(workspacePath)
+		if err != nil {
+			return SourceFingerprint{}, err
+		}
+		_, copyErr := io.Copy(h, manifest)
+		closeErr := manifest.Close()
+		if copyErr != nil {
+			return SourceFingerprint{}, copyErr
+		}
+		if closeErr != nil {
+			return SourceFingerprint{}, closeErr
+		}
+		size += manifestInfo.Size()
+		mtime = max(mtime, manifestInfo.ModTime().UnixNano())
+	}
 	return SourceFingerprint{
 		Key:     firstNonEmptyJSONLString(source.FingerprintKey, source.Key, src.VirtualPath),
-		Size:    combined.Size(),
-		MTimeNS: combined.ModTime().UnixNano(),
-		Hash:    hash,
+		Size:    size,
+		MTimeNS: mtime,
+		Hash:    fmt.Sprintf("%x", h.Sum(nil)),
 	}, nil
 }
 
@@ -557,23 +757,249 @@ func readWindsurfChatValues(dbPath string) ([]windsurfChatValue, error) {
 	return values, nil
 }
 
-func windsurfDBHasSession(dbPath, sessionID string) (bool, error) {
-	records, err := listWindsurfSessionRecords(dbPath)
-	if err != nil {
-		return false, err
+func forEachWindsurfSessionRecord(
+	ctx context.Context, dbPath string, yield func(windsurfSessionRecord) error,
+) error {
+	observeSharedContainerScan(ctx)
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		return nil
 	}
-	for _, record := range records {
-		if record.SessionID == sessionID {
-			return true, nil
+	db, err := openWindsurfDB(dbPath)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	for _, key := range windsurfChatDataKeys {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		var exists int
+		err := db.QueryRowContext(ctx,
+			`SELECT 1 FROM ItemTable WHERE key = ?`, key,
+		).Scan(&exists)
+		if err == sql.ErrNoRows {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("read windsurf chat data: %w", err)
+		}
+		reader := &windsurfSQLiteValueReader{ctx: ctx, db: db, key: key}
+		if err := forEachWindsurfRecordFromReader(
+			ctx, reader, windsurfFallbackSessionID(dbPath), yield,
+		); err != nil {
+			return err
 		}
 	}
-	return false, nil
+	return nil
 }
 
-func parseWindsurfSession(
-	dbPath, sessionID, project, machine, virtualPath string,
+const windsurfSQLiteReadChunk = 64 * 1024
+
+type windsurfSQLiteValueReader struct {
+	ctx    context.Context
+	db     *sql.DB
+	key    string
+	offset int64
+}
+
+func (reader *windsurfSQLiteValueReader) Read(p []byte) (int, error) {
+	if err := reader.ctx.Err(); err != nil {
+		return 0, err
+	}
+	if len(p) == 0 {
+		return 0, nil
+	}
+	limit := min(len(p), windsurfSQLiteReadChunk)
+	var chunk []byte
+	err := reader.db.QueryRowContext(
+		reader.ctx,
+		`SELECT substr(CAST(value AS BLOB), ?, ?) FROM ItemTable WHERE key = ?`,
+		reader.offset+1, limit, reader.key,
+	).Scan(&chunk)
+	if errors.Is(err, sql.ErrNoRows) || err == nil && len(chunk) == 0 {
+		return 0, io.EOF
+	}
+	if err != nil {
+		return 0, fmt.Errorf("read windsurf chat data chunk: %w", err)
+	}
+	observeStreamingRetainedBytes(reader.ctx, int64(len(chunk)))
+	n := copy(p, chunk)
+	observeStreamingRetainedBytes(reader.ctx, -int64(len(chunk)))
+	reader.offset += int64(n)
+	return n, nil
+}
+
+func forEachWindsurfRecordFromReader(
+	ctx context.Context, reader io.Reader, fallbackSessionID string,
+	yield func(windsurfSessionRecord) error,
+) error {
+	dec := json.NewDecoder(reader)
+	delim, err := dec.Token()
+	if err != nil {
+		return fmt.Errorf("parse windsurf chatdata: %w", err)
+	}
+	if delim != json.Delim('{') {
+		return fmt.Errorf("parse windsurf chatdata: expected object")
+	}
+	var session vscodeCopilotSession
+	hasRequests := false
+	for dec.More() {
+		name, err := dec.Token()
+		if err != nil {
+			return err
+		}
+		switch name {
+		case "version":
+			err = dec.Decode(&session.Version)
+		case "sessionId":
+			err = dec.Decode(&session.SessionID)
+		case "creationDate":
+			err = dec.Decode(&session.CreationDate)
+		case "lastMessageDate":
+			err = dec.Decode(&session.LastMessageDate)
+		case "customTitle":
+			err = dec.Decode(&session.CustomTitle)
+		case "requests":
+			hasRequests = true
+			err = dec.Decode(&session.Requests)
+		case "tabs":
+			err = decodeWindsurfTabs(ctx, dec, yield)
+		default:
+			if err := skipJSONValue(dec); err != nil {
+				return err
+			}
+		}
+		if err != nil {
+			return fmt.Errorf("parse windsurf chatdata %s: %w", name, err)
+		}
+	}
+	if _, err := dec.Token(); err != nil {
+		return err
+	}
+	if !hasRequests || len(session.Requests) == 0 {
+		return nil
+	}
+	if session.SessionID == "" {
+		session.SessionID = fallbackSessionID
+	}
+	payload, err := json.Marshal(session)
+	if err != nil {
+		return err
+	}
+	observeStreamingDiscoveryBuffer(ctx, 1)
+	observeStreamingRetainedBytes(ctx, int64(len(payload)))
+	defer observeStreamingRetainedBytes(ctx, -int64(len(payload)))
+	return yield(windsurfSessionRecord{SessionID: session.SessionID, Data: payload})
+}
+
+func decodeWindsurfTabs(
+	ctx context.Context, dec *json.Decoder,
+	yield func(windsurfSessionRecord) error,
+) error {
+	open, err := dec.Token()
+	if err != nil || open != json.Delim('[') {
+		return fmt.Errorf("expected array")
+	}
+	var decoderRetained int64
+	defer func() { observeStreamingRetainedBytes(ctx, -decoderRetained) }()
+	for dec.More() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		start := dec.InputOffset()
+		var tab windsurfChatTab
+		if err := dec.Decode(&tab); err != nil {
+			return fmt.Errorf("parse windsurf chat tab: %w", err)
+		}
+		encodedBytes := dec.InputOffset() - start
+		if encodedBytes > decoderRetained {
+			observeStreamingRetainedBytes(ctx, encodedBytes-decoderRetained)
+			decoderRetained = encodedBytes
+		}
+		decodedRetained := conservativeDecodedRetainedBytes(encodedBytes)
+		observeStreamingRetainedBytes(ctx, decodedRetained)
+		session, ok := tab.toVSCodeSession()
+		if !ok {
+			observeStreamingRetainedBytes(ctx, -decodedRetained)
+			continue
+		}
+		payload, err := json.Marshal(session)
+		if err != nil {
+			observeStreamingRetainedBytes(ctx, -decodedRetained)
+			return err
+		}
+		observeStreamingDiscoveryBuffer(ctx, 1)
+		observeStreamingRetainedBytes(ctx, int64(len(payload)))
+		if err := yield(windsurfSessionRecord{SessionID: session.SessionID, Data: payload}); err != nil {
+			observeStreamingRetainedBytes(ctx, -int64(len(payload)))
+			observeStreamingRetainedBytes(ctx, -decodedRetained)
+			return err
+		}
+		observeStreamingRetainedBytes(ctx, -int64(len(payload)))
+		observeStreamingRetainedBytes(ctx, -decodedRetained)
+	}
+	_, err = dec.Token()
+	return err
+}
+
+func skipJSONValue(dec *json.Decoder) error {
+	token, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	delim, ok := token.(json.Delim)
+	if !ok || (delim != '{' && delim != '[') {
+		return nil
+	}
+	for dec.More() {
+		if delim == '{' {
+			if _, err := dec.Token(); err != nil {
+				return err
+			}
+		}
+		if err := skipJSONValue(dec); err != nil {
+			return err
+		}
+	}
+	_, err = dec.Token()
+	return err
+}
+
+func windsurfDBHasSession(dbPath, sessionID string) (bool, error) {
+	_, err := loadWindsurfSessionRecord(dbPath, sessionID)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	return err == nil, err
+}
+
+func windsurfCachedRecordKey(dbPath, sessionID string) string {
+	return "windsurf:record:" + VirtualSourcePath(filepath.Clean(dbPath), sessionID)
+}
+
+func windsurfCachedFingerprintKey(dbPath, sessionID string) string {
+	return "windsurf:fingerprint:" + VirtualSourcePath(filepath.Clean(dbPath), sessionID)
+}
+
+func parseWindsurfSessionContext(
+	ctx context.Context, dbPath, sessionID, project, machine, virtualPath string,
 ) (*ParsedSession, []ParsedMessage, error) {
-	record, err := loadWindsurfSessionRecord(dbPath, sessionID)
+	encoded, found, err := reconciliationCacheGet(
+		ctx, windsurfCachedRecordKey(dbPath, sessionID),
+	)
+	var record windsurfSessionRecord
+	if err != nil {
+		return nil, nil, err
+	}
+	if found {
+		record = windsurfSessionRecord{SessionID: sessionID, Data: []byte(encoded)}
+		retained := conservativeDecodedRetainedBytes(int64(len(encoded)))
+		observeStreamingRetainedBytes(ctx, retained)
+		defer observeStreamingRetainedBytes(ctx, -retained)
+		observeReconciliationRetainedMember(ctx, AgentWindsurf, retained)
+	} else {
+		record, err = loadWindsurfSessionRecord(dbPath, sessionID)
+	}
 	if err != nil {
 		return nil, nil, err
 	}
@@ -615,14 +1041,20 @@ func parseWindsurfSession(
 func loadWindsurfSessionRecord(
 	dbPath, sessionID string,
 ) (windsurfSessionRecord, error) {
-	records, err := listWindsurfSessionRecords(dbPath)
+	var found windsurfSessionRecord
+	errFound := errors.New("windsurf session found")
+	err := forEachWindsurfSessionRecord(context.Background(), dbPath, func(record windsurfSessionRecord) error {
+		if record.SessionID != sessionID {
+			return nil
+		}
+		found = record
+		return errFound
+	})
+	if errors.Is(err, errFound) {
+		return found, nil
+	}
 	if err != nil {
 		return windsurfSessionRecord{}, err
-	}
-	for _, record := range records {
-		if record.SessionID == sessionID {
-			return record, nil
-		}
 	}
 	return windsurfSessionRecord{}, sql.ErrNoRows
 }
@@ -893,49 +1325,22 @@ func windsurfWorkspaceProject(dbPath string) string {
 	return project
 }
 
-func windsurfSourceHash(dbPath, workspacePath string) (string, error) {
-	h := sha256.New()
-	if IsRegularFile(dbPath) {
-		values, err := readWindsurfChatValues(dbPath)
-		if err != nil {
-			return "", err
-		}
-		for _, value := range values {
-			_, _ = h.Write([]byte("chat"))
-			_, _ = h.Write([]byte{0})
-			_, _ = h.Write([]byte(value.Key))
-			_, _ = h.Write([]byte{0})
-			_, _ = h.Write([]byte(value.Value))
-			_, _ = h.Write([]byte{0})
-		}
-	}
-	if workspacePath != "" && IsRegularFile(workspacePath) {
-		hash, err := hashJSONLSourceFile(workspacePath)
-		if err != nil {
-			return "", err
-		}
-		_, _ = h.Write([]byte("workspace"))
-		_, _ = h.Write([]byte{0})
-		_, _ = h.Write([]byte(hash))
-		_, _ = h.Write([]byte{0})
-	}
-	return fmt.Sprintf("%x", h.Sum(nil)), nil
-}
-
 func windsurfProviderCapabilities() Capabilities {
 	return Capabilities{
 		Source: SourceCapabilities{
-			DiscoverSources:      CapabilitySupported,
-			WatchSources:         CapabilitySupported,
-			ClassifyChangedPath:  CapabilitySupported,
-			StoredSourceHints:    CapabilitySupported,
-			FindSource:           CapabilitySupported,
-			CompositeFingerprint: CapabilitySupported,
-			IncrementalAppend:    CapabilityNotApplicable,
-			MultiSessionSource:   CapabilityNotApplicable,
-			PerSessionErrors:     CapabilityNotApplicable,
-			ExcludedSessions:     CapabilityNotApplicable,
-			ForceReplaceOnParse:  CapabilitySupported,
+			DiscoverSources:       CapabilitySupported,
+			StreamingDiscovery:    CapabilitySupported,
+			WatchSources:          CapabilitySupported,
+			ClassifyChangedPath:   CapabilitySupported,
+			StoredSourceHints:     CapabilitySupported,
+			FindSource:            CapabilitySupported,
+			CompositeFingerprint:  CapabilitySupported,
+			IncrementalAppend:     CapabilityNotApplicable,
+			MultiSessionSource:    CapabilityNotApplicable,
+			SharedContainerSource: CapabilitySupported,
+			PerSessionErrors:      CapabilityNotApplicable,
+			ExcludedSessions:      CapabilityNotApplicable,
+			ForceReplaceOnParse:   CapabilitySupported,
 		},
 		Content: ContentCapabilities{
 			FirstMessage:         CapabilitySupported,

--- a/internal/parser/windsurf_provider_test.go
+++ b/internal/parser/windsurf_provider_test.go
@@ -59,6 +59,83 @@ func TestWindsurfProviderDiscoversAndParsesWorkspaceSQLiteChat(t *testing.T) {
 	assert.Equal(t, "Use the existing parser.", result.Messages[1].Content)
 }
 
+func TestWindsurfProviderStreamingDiscoveryKeepsFirstDuplicateSession(t *testing.T) {
+	firstPayload := windsurfVSCodeSessionJSON(
+		"duplicate-session",
+		"Question from the first key",
+		"Answer from the first key.",
+	)
+	root, dbPath := windsurfProviderFixture(t, firstPayload)
+	insertWindsurfStateRow(
+		t,
+		dbPath,
+		"aiChat.chatdata",
+		windsurfVSCodeSessionJSON(
+			"duplicate-session",
+			"Question from the second key",
+			"Answer from the second key.",
+		),
+	)
+	provider := newTestWindsurfProvider(root)
+	baselineRoot, _ := windsurfProviderFixture(t, firstPayload)
+	baselineProvider := newTestWindsurfProvider(baselineRoot)
+	baselineSources, err := baselineProvider.Discover(t.Context())
+	require.NoError(t, err)
+	require.Len(t, baselineSources, 1)
+	baselineFingerprint, err := baselineProvider.Fingerprint(t.Context(), baselineSources[0])
+	require.NoError(t, err)
+
+	ctx, cleanup, err := WithReconciliationCache(t.Context())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, cleanup()) })
+	var sources []SourceRef
+	err = provider.(StreamingDiscoverer).DiscoverEach(ctx, func(source SourceRef) error {
+		sources = append(sources, source)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	fingerprint, err := provider.Fingerprint(ctx, sources[0])
+	require.NoError(t, err)
+	assert.Equal(t, baselineFingerprint.Hash, fingerprint.Hash)
+	assert.Equal(t, baselineFingerprint.Size, fingerprint.Size)
+
+	out, err := provider.Parse(ctx, ParseRequest{
+		Source:      sources[0],
+		Fingerprint: fingerprint,
+	})
+	require.NoError(t, err)
+	require.Len(t, out.Results, 1)
+	messages := out.Results[0].Result.Messages
+	require.Len(t, messages, 2)
+	assert.Equal(t, "Question from the first key", messages[0].Content)
+	assert.Equal(t, "Answer from the first key.", messages[1].Content)
+}
+
+func TestWindsurfProviderRehydratesExactVirtualSourceWithoutContainerFanout(t *testing.T) {
+	root, dbPath := windsurfProviderFixture(t, windsurfVSCodeSessionJSON(
+		"windsurf-exact", "Exact?", "Exact.",
+	))
+	provider := newTestWindsurfProvider(root)
+	virtualPath := dbPath + "#windsurf-exact"
+
+	resolver, ok := provider.(ReconciliationSourceResolver)
+	require.True(t, ok)
+	source, found, err := resolver.SourceForReconciliation(
+		t.Context(), virtualPath, "spooled-project",
+	)
+
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, virtualPath, source.DisplayPath)
+	assert.Equal(t, "spooled-project", source.ProjectHint)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, _, err = resolver.SourceForReconciliation(ctx, virtualPath, "")
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
 func TestWindsurfProviderFingerprintHashIsContentBased(t *testing.T) {
 	payload := windsurfVSCodeSessionJSON(
 		"windsurf-session-hash",

--- a/internal/parser/zcode.go
+++ b/internal/parser/zcode.go
@@ -1,11 +1,11 @@
 package parser
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -69,8 +69,17 @@ func zcodeProviderSpec() dbBackedProviderSpec {
 		agent:  AgentZCode,
 		dbName: zcodeDBName,
 		findDB: zcodeDBPath,
-		listMeta: func(dbPath string) ([]dbBackedSessionMeta, error) {
-			return listZCodeSessionMeta(dbPath)
+		streamMeta: func(
+			ctx context.Context,
+			dbPath string,
+			yield func(dbBackedSessionMeta) error,
+		) error {
+			return forEachZCodeSessionMeta(ctx, dbPath, yield)
+		},
+		metaForID: func(
+			ctx context.Context, dbPath, sessionID string,
+		) (dbBackedSessionMeta, bool, error) {
+			return zcodeSessionMeta(ctx, dbPath, sessionID)
 		},
 		parse: func(dbPath, sessionID, machine string) ([]ParseResult, error) {
 			result, err := parseZCodeSession(dbPath, sessionID, machine)
@@ -150,17 +159,19 @@ func ZCodeSQLiteSourceMtime(path string) (int64, error) {
 	return zcodeSessionFileMtime(dbPath, db, row), nil
 }
 
-func listZCodeSessionMeta(dbPath string) ([]dbBackedSessionMeta, error) {
+func forEachZCodeSessionMeta(
+	ctx context.Context, dbPath string, yield func(dbBackedSessionMeta) error,
+) error {
 	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
-		return nil, nil
+		return nil
 	}
 	db, err := openZCodeDB(dbPath)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer db.Close()
 
-	rows, err := db.Query(`
+	rows, err := db.QueryContext(ctx, `
 		SELECT id,
 		       project_id,
 		       workspace_id,
@@ -172,32 +183,55 @@ func listZCodeSessionMeta(dbPath string) ([]dbBackedSessionMeta, error) {
 		 ORDER BY COALESCE(time_updated, time_created), id
 	`)
 	if err != nil {
-		return nil, fmt.Errorf("listing zcode sessions: %w", err)
+		return fmt.Errorf("listing zcode sessions: %w", err)
 	}
 	defer rows.Close()
 
-	var metas []dbBackedSessionMeta
 	for rows.Next() {
 		row, err := scanZCodeSessionRow(rows)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		if row.id == "" {
 			continue
 		}
-		metas = append(metas, dbBackedSessionMeta{
+		observeStreamingDiscoveryBuffer(ctx, 1)
+		if err := yield(dbBackedSessionMeta{
 			SessionID:   row.id,
 			VirtualPath: ZCodeSQLiteVirtualPath(dbPath, row.id),
 			FileMtime:   zcodeSessionFileMtime(dbPath, db, row),
-		})
+		}); err != nil {
+			return err
+		}
 	}
 	if err := rows.Err(); err != nil {
-		return nil, err
+		return err
 	}
-	sort.Slice(metas, func(i, j int) bool {
-		return metas[i].SessionID < metas[j].SessionID
-	})
-	return metas, nil
+	return nil
+}
+
+func zcodeSessionMeta(
+	ctx context.Context, dbPath, sessionID string,
+) (dbBackedSessionMeta, bool, error) {
+	db, err := openZCodeDB(dbPath)
+	if err != nil {
+		return dbBackedSessionMeta{}, false, err
+	}
+	defer db.Close()
+	row, err := loadZCodeSessionRow(db, sessionID)
+	if err == sql.ErrNoRows {
+		return dbBackedSessionMeta{}, false, nil
+	}
+	if err != nil {
+		return dbBackedSessionMeta{}, false, err
+	}
+	if err := ctx.Err(); err != nil {
+		return dbBackedSessionMeta{}, false, err
+	}
+	return dbBackedSessionMeta{
+		SessionID: row.id, VirtualPath: ZCodeSQLiteVirtualPath(dbPath, row.id),
+		FileMtime: zcodeSessionFileMtime(dbPath, db, row),
+	}, true, nil
 }
 
 func parseZCodeSession(dbPath, sessionID, machine string) (*ParseResult, error) {

--- a/internal/parser/zed.go
+++ b/internal/parser/zed.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -85,33 +86,47 @@ type ZedThreadMeta struct {
 // mtimes before deciding whether to parse, sharing the same connection as the
 // subsequent parseZedThreadFromDB loop to avoid a second DB open.
 func ListZedThreadMetas(conn *sql.DB, dbPath string) ([]ZedThreadMeta, error) {
-	rows, err := conn.Query(
+	var metas []ZedThreadMeta
+	err := ForEachZedThreadMeta(context.Background(), conn, dbPath, func(meta ZedThreadMeta) error {
+		metas = append(metas, meta)
+		return nil
+	})
+	return metas, err
+}
+
+func ForEachZedThreadMeta(
+	ctx context.Context, conn *sql.DB, dbPath string,
+	yield func(ZedThreadMeta) error,
+) error {
+	rows, err := conn.QueryContext(ctx,
 		`SELECT id, COALESCE(updated_at, '')
 		   FROM threads
 		  WHERE COALESCE(parent_id, '') = ''
 		  ORDER BY updated_at, id`,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("listing zed thread metas: %w", err)
+		return fmt.Errorf("listing zed thread metas: %w", err)
 	}
 	defer rows.Close()
 
-	var metas []ZedThreadMeta
 	for rows.Next() {
 		var id, updatedAt string
 		if err := rows.Scan(&id, &updatedAt); err != nil {
-			return nil, fmt.Errorf("scanning zed thread meta: %w", err)
+			return fmt.Errorf("scanning zed thread meta: %w", err)
 		}
 		if !IsValidSessionID(id) {
 			continue
 		}
-		metas = append(metas, ZedThreadMeta{
+		observeStreamingDiscoveryBuffer(ctx, 1)
+		if err := yield(ZedThreadMeta{
 			RawID:       id,
 			VirtualPath: ZedSQLiteVirtualPath(dbPath, id),
 			FileMtime:   parseTimestamp(updatedAt).UnixNano(),
-		})
+		}); err != nil {
+			return err
+		}
 	}
-	return metas, rows.Err()
+	return rows.Err()
 }
 
 // parseZedThreadFromDB queries and parses one thread using an already-open

--- a/internal/parser/zed_provider.go
+++ b/internal/parser/zed_provider.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -23,6 +24,7 @@ func newZedProviderFactory(def AgentDef) ProviderFactory {
 				AgentZed,
 				cfg.Roots,
 				WithContainerDiscovery(zedDiscoverContainers),
+				WithStreamingSourceDiscovery(zedDiscoverEach),
 				WithWatchRoots(zedWatchRoots),
 				WithChangedPathClassifier(zedClassifyPath),
 				WithMemberLookup(zedFindMember),
@@ -33,6 +35,26 @@ func newZedProviderFactory(def AgentDef) ProviderFactory {
 			)
 		},
 	)
+}
+
+func zedDiscoverEach(
+	ctx context.Context, root string, yield func(multiSessionMatch) error,
+) error {
+	containers := zedDiscoverContainers(root)
+	if len(containers) == 0 {
+		return nil
+	}
+	dbPath := containers[0]
+	conn, err := OpenZedDB(dbPath)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	return ForEachZedThreadMeta(ctx, conn, dbPath, func(meta ZedThreadMeta) error {
+		return yield(multiSessionMatch{
+			Path: meta.VirtualPath, Container: dbPath, MemberID: meta.RawID,
+		})
+	})
 }
 
 func zedDiscoverContainers(root string) []string {
@@ -276,11 +298,13 @@ func parseZedVirtualPath(path string) (string, string, bool) {
 }
 
 func zedProviderCapabilities() Capabilities {
+	source := multiSessionContainerSourceCapabilities(
+		CapabilitySupported,
+		CapabilitySupported,
+	)
+	source.PersistentArchive = CapabilitySupported
 	return Capabilities{
-		Source: multiSessionContainerSourceCapabilities(
-			CapabilitySupported,
-			CapabilitySupported,
-		),
+		Source: source,
 		Content: ContentCapabilities{
 			FirstMessage:         CapabilitySupported,
 			SessionName:          CapabilitySupported,

--- a/internal/postgres/deletion_cause_pgtest_test.go
+++ b/internal/postgres/deletion_cause_pgtest_test.go
@@ -1,0 +1,50 @@
+//go:build pgtest
+
+package postgres
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStoreReadsDeletionCauseAndUserDeleteConvertsSourceTombstones(t *testing.T) {
+	pgURL := testPGURL(t)
+	ensureStoreSchema(t, pgURL)
+
+	store, err := NewStore(pgURL, testSchema, true)
+	require.NoError(t, err)
+	defer store.Close()
+
+	_, err = store.DB().Exec(`
+		INSERT INTO sessions (
+			id, machine, project, agent, message_count,
+			user_message_count, deleted_at, deletion_cause
+		) VALUES
+			('source-single', 'machine', 'project', 'claude', 1, 1,
+			 NOW(), 'source_missing'),
+			('source-batch', 'machine', 'project', 'claude', 1, 1,
+			 NOW(), 'source_missing')`)
+	require.NoError(t, err)
+
+	full, err := store.GetSessionFull(t.Context(), "source-single")
+	require.NoError(t, err)
+	require.NotNil(t, full)
+	require.NotNil(t, full.DeletionCause)
+	assert.Equal(t, "source_missing", *full.DeletionCause)
+
+	require.NoError(t, store.SoftDeleteSession("source-single"))
+	count, err := store.SoftDeleteSessions([]string{"source-batch"})
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	for _, id := range []string{"source-single", "source-batch"} {
+		var cause *string
+		require.NoError(t, store.DB().QueryRow(
+			`SELECT deletion_cause FROM sessions WHERE id = $1`, id,
+		).Scan(&cause))
+		assert.Nil(t, cause,
+			"an explicit user deletion must replace the recoverable source tombstone")
+	}
+}

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -1562,6 +1562,7 @@ func sessionPushFingerprint(
 		stringValue(sess.StartedAt),
 		stringValue(sess.EndedAt),
 		stringValue(sess.DeletedAt),
+		stringValue(sess.DeletionCause),
 		fmt.Sprintf("%d", sess.MessageCount),
 		fmt.Sprintf("%d", sess.UserMessageCount),
 		fmt.Sprintf("%t", sess.IsAutomated),
@@ -1748,7 +1749,7 @@ func (s *Sync) pushSession(
 			id, machine, owner_marker, project, agent,
 			first_message, display_name, source_display_name,
 			session_name, created_at, started_at, ended_at,
-			deleted_at, source_deleted_at,
+			deleted_at, source_deleted_at, deletion_cause,
 			message_count, user_message_count,
 			total_output_tokens, peak_context_tokens,
 			has_total_output_tokens, has_peak_context_tokens,
@@ -1778,20 +1779,20 @@ func (s *Sync) pushSession(
 			)
 			SELECT
 				$1, $2, $3, $4, $5, $6, $7, $8,
-				$9, $10, $11, $12, $13, $14,
-				$15, $16, $17, $18,
-			$19, $20, $21, $22,
-			$23, $24, $25, $26, $27, $28, $29,
-			$30, $31,
-			$32, $33, $34, $35,
-			$36, $37, $38, $39,
-			$40,
-			$41, $42,
-			$43,
-			$44, $45, $46, $47,
-			$48, $49,
-				$50, $51, $52, $53, $54, $55, $56, $57, $58, $59,
-				$60, $61,
+				$9, $10, $11, $12, $13, $14, $15,
+				$16, $17, $18, $19,
+			$20, $21, $22, $23,
+			$24, $25, $26, $27, $28, $29, $30,
+			$31, $32,
+			$33, $34, $35, $36,
+			$37, $38, $39, $40,
+			$41,
+			$42, $43,
+			$44,
+			$45, $46, $47, $48,
+			$49, $50,
+				$51, $52, $53, $54, $55, $56, $57, $58, $59, $60,
+				$61, $62,
 				NOW()
 			WHERE NOT EXISTS (
 				SELECT 1 FROM excluded_sessions WHERE id = $1
@@ -1818,6 +1819,11 @@ func (s *Sync) pushSession(
 				WHEN sessions.deleted_at IS DISTINCT FROM
 					sessions.source_deleted_at THEN sessions.deleted_at
 				ELSE EXCLUDED.deleted_at
+			END,
+			deletion_cause = CASE
+				WHEN sessions.deleted_at IS DISTINCT FROM
+					sessions.source_deleted_at THEN sessions.deletion_cause
+				ELSE EXCLUDED.deletion_cause
 			END,
 			source_deleted_at = EXCLUDED.deleted_at,
 			message_count = EXCLUDED.message_count,
@@ -1872,7 +1878,7 @@ func (s *Sync) pushSession(
 					OR sessions.machine = 'local'
 					OR sessions.machine = ''
 					OR sessions.machine IN (
-					SELECT jsonb_array_elements_text($62::jsonb)
+						SELECT jsonb_array_elements_text($63::jsonb)
 					))
 			)
 			OR sessions.owner_marker = EXCLUDED.owner_marker)
@@ -1894,6 +1900,7 @@ func (s *Sync) pushSession(
 			OR sessions.started_at IS DISTINCT FROM EXCLUDED.started_at
 			OR sessions.ended_at IS DISTINCT FROM EXCLUDED.ended_at
 			OR sessions.source_deleted_at IS DISTINCT FROM EXCLUDED.deleted_at
+			OR sessions.deletion_cause IS DISTINCT FROM EXCLUDED.deletion_cause
 			OR sessions.message_count IS DISTINCT FROM EXCLUDED.message_count
 			OR sessions.user_message_count IS DISTINCT FROM EXCLUDED.user_message_count
 			OR sessions.total_output_tokens IS DISTINCT FROM EXCLUDED.total_output_tokens
@@ -1951,6 +1958,7 @@ func (s *Sync) pushSession(
 		nilStrTS(sess.EndedAt),
 		nilStrTS(sess.DeletedAt),
 		nilStrTS(sess.DeletedAt),
+		nilStr(sess.DeletionCause),
 		sess.MessageCount, sess.UserMessageCount,
 		sess.TotalOutputTokens, sess.PeakContextTokens,
 		sess.HasTotalOutputTokens, sess.HasPeakContextTokens,

--- a/internal/postgres/push_pgtest_test.go
+++ b/internal/postgres/push_pgtest_test.go
@@ -803,6 +803,134 @@ func TestPushPreservesPGServeLocalCurationFields(t *testing.T) {
 		"source-owned fields should still update")
 }
 
+func TestPushPreservesRecoverableWatcherTombstonesAcrossPG(t *testing.T) {
+	pgURL := testPGURL(t)
+	const schema = "agentsview_push_source_missing_test"
+	pg, err := Open(pgURL, schema, true)
+	require.NoError(t, err)
+	defer pg.Close()
+	_, err = pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	})
+	require.NoError(t, EnsureSchema(t.Context(), pg, schema))
+
+	local, err := db.Open(filepath.Join(t.TempDir(), "local.db"))
+	require.NoError(t, err)
+	defer local.Close()
+	syncer := &Sync{
+		pg: pg, local: local, machine: "test-machine",
+		schema: schema, schemaDone: true,
+	}
+	paths := map[string]string{}
+	for _, id := range []string{
+		"source-revive", "source-protected", "user-delete", "user-empty",
+	} {
+		path := filepath.Join(t.TempDir(), id+".jsonl")
+		paths[id] = path
+		mtime := time.Now().UnixNano()
+		require.NoError(t, local.UpsertSession(db.Session{
+			ID: id, Project: "project", Machine: "test-machine", Agent: "claude",
+			CreatedAt: "2026-07-14T00:00:00Z", FilePath: &path, FileMtime: &mtime,
+		}))
+	}
+	_, err = syncer.Push(t.Context(), false, nil)
+	require.NoError(t, err, "initial push")
+
+	store, err := NewStore(pgURL, schema, true)
+	require.NoError(t, err)
+	defer store.Close()
+	for _, id := range []string{"user-delete", "user-empty"} {
+		require.NoError(t, store.SoftDeleteSession(id), "PG user trash %s", id)
+	}
+	sources := make([]db.SessionSourcePath, 0, len(paths))
+	for _, path := range paths {
+		sources = append(sources, db.SessionSourcePath{
+			Agent: "claude", FilePath: path,
+		})
+	}
+	require.NoError(t, local.BaselineActiveSessionSourcePaths(
+		t.Context(), "test-machine", sources,
+	))
+	for id, path := range paths {
+		changed, tombstoneErr := local.SoftDeleteSessionSourceOwnership(
+			t.Context(), "test-machine", "claude", id, path,
+		)
+		require.NoError(t, tombstoneErr)
+		require.True(t, changed)
+	}
+	_, err = syncer.Push(t.Context(), false, nil)
+	require.NoError(t, err, "push source-missing state")
+
+	for _, id := range []string{"source-revive", "source-protected"} {
+		active, getErr := store.GetSession(t.Context(), id)
+		require.NoError(t, getErr)
+		assert.Nil(t, active, "%s must remain hidden while its source is missing", id)
+		var deleted bool
+		var cause sql.NullString
+		require.NoError(t, pg.QueryRow(`
+			SELECT deleted_at IS NOT NULL, deletion_cause
+			FROM sessions WHERE id = $1`, id,
+		).Scan(&deleted, &cause))
+		assert.True(t, deleted)
+		require.True(t, cause.Valid)
+		assert.Equal(t, "source_missing", cause.String)
+	}
+	trashed, err := store.ListTrashedSessions(t.Context())
+	require.NoError(t, err)
+	trashIDs := sessionIDs(trashed)
+	assert.NotContains(t, trashIDs, "source-revive")
+	assert.NotContains(t, trashIDs, "source-protected")
+	assert.Contains(t, trashIDs, "user-delete")
+	assert.Contains(t, trashIDs, "user-empty")
+
+	restored, err := store.RestoreSession("source-protected")
+	require.NoError(t, err)
+	assert.Zero(t, restored, "PG restore must refuse watcher tombstones")
+	deleted, err := store.DeleteSessionIfTrashed("source-protected")
+	require.NoError(t, err)
+	assert.Zero(t, deleted, "PG permanent delete must refuse watcher tombstones")
+	deleted, err = store.DeleteSessionIfTrashed("user-delete")
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, deleted, "ordinary PG user trash remains deletable")
+
+	for _, id := range []string{"source-revive", "user-empty"} {
+		path := paths[id]
+		mtime := time.Now().UnixNano()
+		require.NoError(t, local.UpsertSession(db.Session{
+			ID: id, Project: "project", Machine: "test-machine", Agent: "claude",
+			CreatedAt: "2026-07-14T00:00:00Z", FilePath: &path, FileMtime: &mtime,
+		}), "revive local source %s", id)
+	}
+	_, err = syncer.Push(t.Context(), false, nil)
+	require.NoError(t, err, "push local source revival")
+
+	active, err := store.GetSession(t.Context(), "source-revive")
+	require.NoError(t, err)
+	require.NotNil(t, active, "recoverable source must become visible after revival")
+	var deletedAt sql.NullTime
+	var cause sql.NullString
+	require.NoError(t, pg.QueryRow(`
+		SELECT deleted_at, deletion_cause
+		FROM sessions WHERE id = 'source-revive'`,
+	).Scan(&deletedAt, &cause))
+	assert.False(t, deletedAt.Valid)
+	assert.False(t, cause.Valid)
+
+	trashed, err = store.ListTrashedSessions(t.Context())
+	require.NoError(t, err)
+	assert.Contains(t, sessionIDs(trashed), "user-empty",
+		"newer PG user trash must survive an older local revival")
+	emptied, err := store.EmptyTrash()
+	require.NoError(t, err)
+	assert.Equal(t, 1, emptied)
+	protected, err := store.GetSessionFull(t.Context(), "source-protected")
+	require.NoError(t, err)
+	assert.NotNil(t, protected,
+		"EmptyTrash must not purge a still-missing recoverable source")
+}
+
 func TestPushPreservesPGServePermanentDeletes(t *testing.T) {
 	pgURL := testPGURL(t)
 

--- a/internal/postgres/push_test.go
+++ b/internal/postgres/push_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -653,6 +654,52 @@ func TestPushSessionRechecksExclusionAfterSuccessfulUpsert(t *testing.T) {
 	require.NoError(t, tx.Rollback(), "Rollback")
 }
 
+func TestPushSessionCarriesDeletionCauseInStableParameterOrder(t *testing.T) {
+	state := &pushSessionProbeState{}
+	pg := newPushSessionProbeDB(t, state)
+	tx, err := pg.BeginTx(t.Context(), nil)
+	require.NoError(t, err)
+	deletedAt := "2026-07-14T12:34:56Z"
+	cause := "source_missing"
+
+	err = (&Sync{machine: "push-machine"}).pushSession(
+		t.Context(), tx,
+		db.Session{
+			ID: "session", Project: "project", Machine: "push-machine",
+			Agent: "claude", CreatedAt: "2026-01-01T00:00:00Z",
+			DeletedAt: &deletedAt, DeletionCause: &cause,
+		},
+		"marker", nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, state.upsertArgs, 63)
+	assert.IsType(t, time.Time{}, state.upsertArgs[12].Value)
+	assert.IsType(t, time.Time{}, state.upsertArgs[13].Value)
+	assert.Equal(t, cause, state.upsertArgs[14].Value)
+	assert.Equal(t, "[]", state.upsertArgs[62].Value)
+
+	query := strings.ToLower(strings.Join(strings.Fields(state.upsertQuery), " "))
+	assert.Contains(t, query,
+		"deleted_at, source_deleted_at, deletion_cause")
+	assert.Contains(t, query,
+		"when sessions.deleted_at is distinct from sessions.source_deleted_at then sessions.deletion_cause else excluded.deletion_cause")
+	assert.Contains(t, query,
+		"sessions.deletion_cause is distinct from excluded.deletion_cause")
+	require.NoError(t, tx.Rollback())
+}
+
+func TestSessionPushFingerprintIncludesDeletionCause(t *testing.T) {
+	base := db.Session{ID: "session", Machine: "machine"}
+	withCause := base
+	cause := "source_missing"
+	withCause.DeletionCause = &cause
+
+	assert.NotEqual(t,
+		sessionPushFingerprint(base, base.Machine, "", "", ""),
+		sessionPushFingerprint(withCause, withCause.Machine, "", "", ""),
+	)
+}
+
 func TestPushSessionStoresVibeFallbackAlias(t *testing.T) {
 	state := &pushSessionProbeState{aliases: map[string]string{}}
 	pg := newPushSessionProbeDB(t, state)
@@ -828,6 +875,8 @@ type pushSessionProbeState struct {
 	aliases             map[string]string
 	excludedIDs         map[string]bool
 	existingExcluded    map[string]bool
+	upsertQuery         string
+	upsertArgs          []driver.NamedValue
 }
 
 var (
@@ -898,6 +947,8 @@ func (c *pushSessionProbeConn) ExecContext(
 	switch {
 	case strings.Contains(normalized, "insert into sessions"):
 		c.state.upserts++
+		c.state.upsertQuery = query
+		c.state.upsertArgs = append([]driver.NamedValue(nil), args...)
 		return driver.RowsAffected(1), nil
 	case strings.Contains(normalized, "delete from sessions") &&
 		strings.Contains(normalized, "id = any($1)"):

--- a/internal/postgres/schema.go
+++ b/internal/postgres/schema.go
@@ -29,6 +29,13 @@ type columnMigration struct {
 
 // coreDDL creates the tables and indexes. It uses unqualified
 // names because Open() sets search_path to the target schema.
+//
+// The sessions table deliberately omits SQLite's machine-local sync
+// bookkeeping cluster (next_ordinal, last_entry_uuid,
+// claude_linear_parse, last_write_incremental): parsers never run
+// against this read-side store, so mirroring those columns would be
+// inert plumbing. Their absence from push SQL and
+// sessionPushFingerprint is intentional.
 const coreDDL = `
 CREATE TABLE IF NOT EXISTS sync_metadata (
     key   TEXT PRIMARY KEY,
@@ -52,6 +59,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     ended_at           TIMESTAMPTZ,
     deleted_at         TIMESTAMPTZ,
     source_deleted_at  TIMESTAMPTZ,
+    deletion_cause     TEXT,
     message_count      INT NOT NULL DEFAULT 0,
     user_message_count INT NOT NULL DEFAULT 0,
     parent_session_id  TEXT,
@@ -474,6 +482,11 @@ func EnsureSchema(
 			"sessions", "source_deleted_at",
 			`source_deleted_at TIMESTAMPTZ`,
 			"adding sessions.source_deleted_at",
+		},
+		{
+			"sessions", "deletion_cause",
+			`deletion_cause TEXT`,
+			"adding sessions.deletion_cause",
 		},
 		{
 			"sessions", "total_output_tokens",
@@ -1851,7 +1864,7 @@ func CheckSchemaCompat(
 	rows.Close()
 
 	rows, err = db.QueryContext(ctx,
-		`SELECT source_display_name, source_deleted_at
+		`SELECT source_display_name, source_deleted_at, deletion_cause
 		 FROM sessions LIMIT 0`)
 	if err != nil {
 		return fmt.Errorf(

--- a/internal/postgres/schema_pgtest_test.go
+++ b/internal/postgres/schema_pgtest_test.go
@@ -23,6 +23,41 @@ func cleanSchemaTestPG(t *testing.T, pgURL string) {
 	)
 }
 
+func TestSessionDeletionCauseSchemaMigrationPreservesRows(t *testing.T) {
+	pgURL := testPGURL(t)
+	cleanSchemaTestPG(t, pgURL)
+	t.Cleanup(func() { cleanSchemaTestPG(t, pgURL) })
+	pg, err := Open(pgURL, schemaTestSchema, true)
+	require.NoError(t, err)
+	defer pg.Close()
+	require.NoError(t, EnsureSchema(t.Context(), pg, schemaTestSchema))
+
+	var exists bool
+	require.NoError(t, pg.QueryRow(`
+		SELECT EXISTS (
+			SELECT 1 FROM information_schema.columns
+			WHERE table_schema = $1 AND table_name = 'sessions'
+			  AND column_name = 'deletion_cause'
+		)`, schemaTestSchema).Scan(&exists))
+	require.True(t, exists, "fresh schema must include sessions.deletion_cause")
+	_, err = pg.Exec(`
+		INSERT INTO sessions (id, machine, project, agent, deleted_at)
+		VALUES ('preserved-trash', 'machine', 'project', 'claude', NOW())`)
+	require.NoError(t, err)
+	_, err = pg.Exec(`ALTER TABLE sessions DROP COLUMN deletion_cause`)
+	require.NoError(t, err)
+
+	require.NoError(t, EnsureSchema(t.Context(), pg, schemaTestSchema))
+	var deleted bool
+	var cause sql.NullString
+	require.NoError(t, pg.QueryRow(`
+		SELECT deleted_at IS NOT NULL, deletion_cause
+		FROM sessions WHERE id = 'preserved-trash'`,
+	).Scan(&deleted, &cause))
+	assert.True(t, deleted, "migration must preserve legacy user trash")
+	assert.False(t, cause.Valid, "legacy user trash must retain a NULL cause")
+}
+
 // TestSecretFindingsSchema verifies that EnsureSchema creates the
 // secret_findings table with all required columns, and that the
 // sessions table has the secret_leak_count and

--- a/internal/postgres/schema_test.go
+++ b/internal/postgres/schema_test.go
@@ -281,6 +281,12 @@ func (s *schemaProbeState) alterTableExecCount() int {
 	return len(s.alterTableExecs)
 }
 
+func (s *schemaProbeState) alterTableSQL() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return strings.Join(s.alterTableExecs, "\n")
+}
+
 func (s *schemaProbeState) execCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -358,6 +364,43 @@ func TestEnsureSchemaBatchesColumnIntrospection(t *testing.T) {
 
 	assert.Equal(t, 1, state.informationQueryCount(),
 		"information_schema.columns queries")
+}
+
+func TestEnsureSchemaMigratesSessionDeletionCause(t *testing.T) {
+	pg, state := newSchemaProbeDB(t, map[string][]string{
+		"sessions": {
+			"owner_marker", "created_at", "deleted_at",
+			"source_display_name", "source_deleted_at",
+			"total_output_tokens", "peak_context_tokens",
+			"has_total_output_tokens", "has_peak_context_tokens",
+			"is_automated", "tool_failure_signal_count", "tool_retry_count",
+			"edit_churn_count", "consecutive_failure_max", "outcome",
+			"outcome_confidence", "ended_with_role", "final_failure_streak",
+			"signals_pending_since", "compaction_count",
+			"mid_task_compaction_count", "context_pressure_max", "health_score",
+			"health_grade", "has_tool_calls", "has_context_data", "data_version",
+			"cwd", "quality_signal_version", "short_prompt_count",
+			"unstructured_start", "missing_success_criteria_count",
+			"missing_verification_count", "duplicate_prompt_count",
+			"no_code_context_count", "runaway_tool_loop_count", "git_branch",
+			"source_session_id", "source_version", "parser_malformed_lines",
+			"is_truncated", "termination_status", "secret_leak_count",
+			"secrets_rules_version", "session_name",
+		},
+		"messages": {
+			"model", "token_usage", "context_tokens", "output_tokens",
+			"has_context_tokens", "has_output_tokens", "claude_message_id",
+			"claude_request_id", "source_type", "source_subtype", "source_uuid",
+			"source_parent_uuid", "is_sidechain", "is_compact_boundary",
+			"thinking_text",
+		},
+		"tool_calls": {"call_index", "file_path"},
+	})
+
+	require.NoError(t, EnsureSchema(t.Context(), pg, "agentsview"))
+
+	assert.Contains(t, state.alterTableSQL(),
+		"ADD COLUMN IF NOT EXISTS deletion_cause TEXT")
 }
 
 func TestEnsureSchemaBackfillsCurationBaselinesWhenAdded(t *testing.T) {
@@ -565,6 +608,20 @@ func TestCheckSchemaCompatRequiresCurationBaselineColumns(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "sessions table missing curation columns")
+}
+
+func TestCheckSchemaCompatRequiresDeletionCause(t *testing.T) {
+	pg, state := newSchemaProbeDB(t, nil)
+	state.queryErrors = []schemaProbeQueryError{{
+		contains: "deletion_cause",
+		err: errors.New(
+			`ERROR: column "deletion_cause" does not exist (SQLSTATE 42703)`),
+	}}
+
+	err := CheckSchemaCompat(t.Context(), pg)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sessions table missing required columns")
 }
 
 func TestCheckSchemaCompatRequiresExcludedSessions(t *testing.T) {

--- a/internal/postgres/sessions.go
+++ b/internal/postgres/sessions.go
@@ -71,7 +71,7 @@ const pgSessionCols = `id, project, machine, agent,
 	cwd, git_branch, source_session_id, source_version,
 	transcript_fidelity, parser_malformed_lines, is_truncated,
 	secret_leak_count, secrets_rules_version,
-	deleted_at, termination_status, transcript_revision`
+	deleted_at, deletion_cause, termination_status, transcript_revision`
 
 // paramBuilder generates numbered PostgreSQL placeholders.
 type paramBuilder struct {
@@ -231,7 +231,7 @@ func scanPGSession(
 		&s.SourceSessionID, &s.SourceVersion,
 		&s.TranscriptFidelity, &s.ParserMalformedLines, &s.IsTruncated,
 		&s.SecretLeakCount, &s.SecretsRulesVersion,
-		&deletedAt, &s.TerminationStatus, &s.TranscriptRevision,
+		&deletedAt, &s.DeletionCause, &s.TerminationStatus, &s.TranscriptRevision,
 	)
 	if err != nil {
 		return s, err

--- a/internal/postgres/store.go
+++ b/internal/postgres/store.go
@@ -15,6 +15,11 @@ import (
 // Compile-time check: *Store satisfies db.Store.
 var _ db.Store = (*Store)(nil)
 
+// deletionCauseSourceMissing mirrors the recoverable watcher-tombstone cause
+// written by the SQLite archive (internal/db). Kept package-local because the
+// db package does not export it.
+const deletionCauseSourceMissing = "source_missing"
+
 // NewStore opens a PostgreSQL connection using the shared Open()
 // helper and returns a Store.
 // When allowInsecure is true, non-loopback connections without
@@ -400,13 +405,16 @@ func (s *Store) RenameSession(
 	return nil
 }
 
-// SoftDeleteSession moves a session to the trash.
+// SoftDeleteSession moves a session to user trash, including conversion from
+// a recoverable source-missing tombstone.
 func (s *Store) SoftDeleteSession(id string) error {
 	_, err := s.pg.Exec(
 		`UPDATE sessions
 		 SET deleted_at = NOW(),
+		     deletion_cause = NULL,
 		     updated_at = NOW()
-		 WHERE id = $1 AND deleted_at IS NULL`,
+		 WHERE id = $1
+		   AND (deleted_at IS NULL OR deletion_cause = '`+deletionCauseSourceMissing+`')`,
 		id,
 	)
 	if err != nil {
@@ -417,7 +425,8 @@ func (s *Store) SoftDeleteSession(id string) error {
 	return nil
 }
 
-// SoftDeleteSessions moves multiple sessions to the trash.
+// SoftDeleteSessions moves multiple sessions to user trash, including
+// conversion from recoverable source-missing tombstones.
 func (s *Store) SoftDeleteSessions(ids []string) (int, error) {
 	if len(ids) == 0 {
 		return 0, nil
@@ -434,9 +443,11 @@ func (s *Store) SoftDeleteSessions(ids []string) (int, error) {
 		res, err := s.pg.Exec(
 			`UPDATE sessions
 			 SET deleted_at = NOW(),
+			     deletion_cause = NULL,
 			     updated_at = NOW()
 			 WHERE id IN (`+strings.Join(placeholders, ",")+
-				`) AND deleted_at IS NULL`,
+				`)
+			   AND (deleted_at IS NULL OR deletion_cause = '`+deletionCauseSourceMissing+`')`,
 			pb.args...,
 		)
 		if err != nil {
@@ -456,8 +467,10 @@ func (s *Store) RestoreSession(id string) (int64, error) {
 	res, err := s.pg.Exec(
 		`UPDATE sessions
 		 SET deleted_at = NULL,
+		     deletion_cause = NULL,
 		     updated_at = NOW()
-		 WHERE id = $1 AND deleted_at IS NOT NULL`,
+		 WHERE id = $1 AND deleted_at IS NOT NULL
+		   AND deletion_cause IS NULL`,
 		id,
 	)
 	if err != nil {
@@ -487,7 +500,9 @@ func (s *Store) DeleteSessionIfTrashed(
 	defer func() { _ = tx.Rollback() }()
 
 	sessionIDs, excludedIDs, err := readPGTrashedSessionExclusions(
-		ctx, tx, "s.id = $1 AND s.deleted_at IS NOT NULL", id,
+		ctx, tx,
+		"s.id = $1 AND s.deleted_at IS NOT NULL AND s.deletion_cause IS NULL",
+		id,
 	)
 	if err != nil {
 		return 0, mapPGWriteError(
@@ -533,6 +548,7 @@ func (s *Store) ListTrashedSessions(
 	rows, err := s.pg.QueryContext(ctx,
 		"SELECT "+pgSessionCols+
 			" FROM sessions WHERE deleted_at IS NOT NULL"+
+			" AND deletion_cause IS NULL"+
 			" ORDER BY deleted_at DESC LIMIT 500",
 	)
 	if err != nil {
@@ -552,7 +568,7 @@ func (s *Store) EmptyTrash() (int, error) {
 	defer func() { _ = tx.Rollback() }()
 
 	sessionIDs, excludedIDs, err := readPGTrashedSessionExclusions(
-		ctx, tx, "s.deleted_at IS NOT NULL",
+		ctx, tx, "s.deleted_at IS NOT NULL AND s.deletion_cause IS NULL",
 	)
 	if err != nil {
 		return 0, mapPGWriteError("locking trashed sessions", err)
@@ -652,7 +668,8 @@ func deletePGTrashedSessionRows(
 	}
 	res, err := tx.ExecContext(ctx,
 		`DELETE FROM sessions
-		 WHERE id = ANY($1) AND deleted_at IS NOT NULL`,
+		 WHERE id = ANY($1) AND deleted_at IS NOT NULL
+		   AND deletion_cause IS NULL`,
 		ids,
 	)
 	if err != nil {

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -418,11 +418,60 @@ func handleHumaContextError(err error) error {
 	return nil
 }
 
+// writerClosedRetryAfterSeconds is the Retry-After hint returned when a write is
+// rejected because the archive writer is closed for a maintenance pass. The
+// barrier window ranges from seconds (sync/audit) to minutes (resync build), so
+// this is a modest floor: a well-behaved client backs off at least this long.
+const writerClosedRetryAfterSeconds = "5"
+
+// handleHumaReadOnly maps a non-writable-archive error to the right HTTP status:
+// a remote-mode read-only store is a permanent 501, while a writer closed for a
+// maintenance pass is a transient 503 with Retry-After so clients retry once the
+// barrier lifts. It returns nil for any other error. Read endpoints never
+// produce ErrWriterClosed, so folding it in here is safe for every call site.
 func handleHumaReadOnly(err error) error {
 	if errors.Is(err, db.ErrReadOnly) {
 		return apiError(http.StatusNotImplemented, "not available in remote mode")
 	}
+	if errors.Is(err, db.ErrWriterClosed) {
+		return writerClosedError()
+	}
 	return nil
+}
+
+// writerClosedError is the 503 + Retry-After response for a write rejected while
+// the archive writer is closed for a maintenance pass.
+func writerClosedError() error {
+	return huma.ErrorWithHeaders(
+		apiError(
+			http.StatusServiceUnavailable,
+			"archive is briefly read-only for a maintenance pass; retry shortly",
+		),
+		http.Header{"Retry-After": []string{writerClosedRetryAfterSeconds}},
+	)
+}
+
+// rejectWriterClosedWrite fails a write endpoint before its stream body opens
+// while the archive writer is closed for a maintenance pass, so clients see
+// the 503 + Retry-After instead of an HTTP-200 SSE error event or a generic
+// 500 (mirrors the push handlers' pre-stream gate).
+func (s *Server) rejectWriterClosedWrite() error {
+	if local, ok := s.db.(*db.DB); ok && local.WriterClosed() {
+		return writerClosedError()
+	}
+	return nil
+}
+
+// serializeArchiveWrite runs work under the daemon engine's exclusive lock —
+// the same mutex a worker pass holds while the writer is closed — so a write
+// that passed the pre-stream writer gate cannot race a maintenance pass
+// closing the writer mid-operation. Servers without a daemon engine have no
+// worker passes to serialize with, so work runs directly.
+func (s *Server) serializeArchiveWrite(work func() error) error {
+	if s.engine != nil {
+		return s.engine.RunExclusive(work)
+	}
+	return work()
 }
 
 func serverError(err error) error {

--- a/internal/server/huma_routes_import.go
+++ b/internal/server/huma_routes_import.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"os"
@@ -10,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/danielgtaylor/huma/v2"
+	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/importer"
 )
 
@@ -44,6 +46,9 @@ func (s *Server) humaImportClaudeAI(
 	if s.db.ReadOnly() {
 		return nil, apiError(http.StatusNotImplemented,
 			"import not available in read-only mode")
+	}
+	if err := s.rejectWriterClosedWrite(); err != nil {
+		return nil, err
 	}
 	file := in.RawBody.Data().File
 	if !file.IsSet {
@@ -97,8 +102,16 @@ func (s *Server) importClaudeAIFromFileWithCallbacks(
 		return importer.ImportStats{}, err
 	}
 	defer cleanup()
-	stats, err := importer.ImportClaudeAI(ctx, s.db, reader, cb)
+	var stats importer.ImportStats
+	err = s.serializeArchiveWrite(func() error {
+		var importErr error
+		stats, importErr = importer.ImportClaudeAI(ctx, s.db, reader, cb)
+		return importErr
+	})
 	if err != nil {
+		if errors.Is(err, db.ErrWriterClosed) {
+			return importer.ImportStats{}, writerClosedError()
+		}
 		return importer.ImportStats{}, apiError(http.StatusInternalServerError,
 			"import failed: "+err.Error())
 	}
@@ -157,6 +170,9 @@ func (s *Server) humaImportChatGPT(
 	if s.db.ReadOnly() {
 		return nil, apiError(http.StatusNotImplemented,
 			"import not available in read-only mode")
+	}
+	if err := s.rejectWriterClosedWrite(); err != nil {
+		return nil, err
 	}
 	file := in.RawBody.Data().File
 	if !file.IsSet {
@@ -221,9 +237,17 @@ func (s *Server) importChatGPTFromFile(
 			"failed to extract zip: "+err.Error())
 	}
 	defer cleanup()
-	stats, err := importer.ImportChatGPT(ctx, s.db, dir,
-		filepath.Join(s.cfg.DataDir, "assets"), cb)
+	var stats importer.ImportStats
+	err = s.serializeArchiveWrite(func() error {
+		var importErr error
+		stats, importErr = importer.ImportChatGPT(ctx, s.db, dir,
+			filepath.Join(s.cfg.DataDir, "assets"), cb)
+		return importErr
+	})
 	if err != nil {
+		if errors.Is(err, db.ErrWriterClosed) {
+			return importer.ImportStats{}, writerClosedError()
+		}
 		return importer.ImportStats{}, apiError(http.StatusInternalServerError,
 			"import failed: "+err.Error())
 	}

--- a/internal/server/huma_routes_insights.go
+++ b/internal/server/huma_routes_insights.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -196,6 +197,9 @@ func (s *Server) humaGenerateInsight(
 	if !supportsInsightGeneration(s.db) {
 		return nil, apiError(http.StatusNotImplemented,
 			"insight generation is not available in read-only mode")
+	}
+	if err := s.rejectWriterClosedWrite(); err != nil {
+		return nil, err
 	}
 	req := in.Body
 	if !validInsightTypes[req.Type] {
@@ -428,19 +432,26 @@ func (s *Server) humaGenerateInsight(
 		if req.Prompt != "" {
 			promptPtr = &req.Prompt
 		}
-		id, err := s.db.InsertInsight(db.Insight{
-			Type:     req.Type,
-			DateFrom: req.DateFrom,
-			DateTo:   req.DateTo,
-			Project:  project,
-			Agent:    result.Agent,
-			Model:    model,
-			Prompt:   promptPtr,
-			Content:  result.Content,
+		var id int64
+		err = s.serializeArchiveWrite(func() error {
+			var insertErr error
+			id, insertErr = s.db.InsertInsight(db.Insight{
+				Type:     req.Type,
+				DateFrom: req.DateFrom,
+				DateTo:   req.DateTo,
+				Project:  project,
+				Agent:    result.Agent,
+				Model:    model,
+				Prompt:   promptPtr,
+				Content:  result.Content,
+			})
+			return insertErr
 		})
 		if err != nil {
 			log.Printf("insight insert error: %v", err)
-			sendJSON("error", map[string]string{"message": "failed to save insight"})
+			sendJSON("error", map[string]string{
+				"message": insightSaveErrorMessage(err),
+			})
 			return
 		}
 		saved, err := s.db.GetInsight(hctx.Context(), id)
@@ -453,6 +464,16 @@ func (s *Server) humaGenerateInsight(
 		}
 		sendJSON("done", saved)
 	}}, nil
+}
+
+// insightSaveErrorMessage names a failed insight save for the SSE error event.
+// A writer closed for a maintenance pass is transient and worth telling the
+// client to retry; anything else stays a generic failure.
+func insightSaveErrorMessage(err error) string {
+	if errors.Is(err, db.ErrWriterClosed) {
+		return "archive is briefly read-only for a maintenance pass; retry shortly"
+	}
+	return "failed to save insight"
 }
 
 func insightSessionDate(session *db.Session) string {

--- a/internal/server/huma_routes_push.go
+++ b/internal/server/huma_routes_push.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -14,6 +15,7 @@ import (
 	"go.kenn.io/agentsview/internal/db"
 	duckdbsync "go.kenn.io/agentsview/internal/duckdb"
 	"go.kenn.io/agentsview/internal/postgres"
+	syncpkg "go.kenn.io/agentsview/internal/sync"
 )
 
 // pushProgressLogInterval bounds how often the daemon-side push handlers log
@@ -118,6 +120,12 @@ func runPushStream[T any](
 	}
 	result, err := run(nil)
 	if err != nil {
+		if errors.Is(err, db.ErrWriterClosed) {
+			hctx.SetHeader("Retry-After", writerClosedRetryAfterSeconds)
+			writeHumaJSON(hctx, http.StatusServiceUnavailable,
+				map[string]string{"error": err.Error()})
+			return
+		}
 		writeHumaJSON(hctx, http.StatusInternalServerError,
 			map[string]string{"error": err.Error()})
 		return
@@ -258,6 +266,38 @@ func duckDBPushSyncOptions(req daemonPushRequest) duckdbsync.SyncOptions {
 	}
 }
 
+// syncThenRunForPush brings the local archive current and then runs the push
+// work serialized against sync passes. Full and stale-archive pushes are
+// archive-scale: with the worker-backed resync runner wired they route the
+// rebuild through the worker (matching /api/v1/resync and the pre-session-sync
+// resync) instead of running an in-process resync in the long-lived daemon,
+// and the push work then runs under the engine's exclusive sync lock — after
+// the deferred-signal flush — so it still observes the post-rebuild archive
+// and stays serialized against watcher and periodic syncs. Per-batch pushes
+// (not full, archive current) keep the in-process SyncThenRun path: their
+// catch-up sync's parse work is bounded by the changed batch via the skip
+// cache. Without a runner (tests, remote-mode-less setups) every case keeps
+// the in-process SyncThenRun path.
+func (s *Server) syncThenRunForPush(
+	ctx context.Context,
+	engine *syncpkg.Engine,
+	local *db.DB,
+	full bool,
+	work func(forceFull bool) error,
+) error {
+	if s.localResyncRunner == nil || (!full && !local.NeedsResync()) {
+		_, err := engine.SyncThenRun(ctx, full, nil, work)
+		return err
+	}
+	if _, err := s.runResyncWithFallback(ctx, engine, nil); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return engine.RunExclusiveFlushed(func() error { return work(true) })
+}
+
 func (s *Server) humaPGPush(
 	ctx context.Context,
 	in *daemonPushInput,
@@ -271,6 +311,12 @@ func (s *Server) humaPGPush(
 	local, err := s.localPushTarget()
 	if err != nil {
 		return nil, err
+	}
+	// Reject before the stream body flushes a 200: SSE clients (the daemon
+	// CLI always negotiates SSE) must see the 503 + Retry-After, not a
+	// generic error event.
+	if local.WriterClosed() {
+		return nil, writerClosedError()
 	}
 	pgCfg, err := s.pgPushConfig(in.Body)
 	if err != nil {
@@ -291,7 +337,7 @@ func (s *Server) humaPGPush(
 				newPGPushProgressLogger(), streamProgress,
 			)
 			var result postgres.PushResult
-			_, err := engine.SyncThenRun(ctx, body.Full, nil,
+			err := s.syncThenRunForPush(ctx, engine, local, body.Full,
 				func(forceFull bool) error {
 					if refreshErr := s.ensurePricing(ctx, local); refreshErr != nil {
 						if ctxErr := ctx.Err(); ctxErr != nil {
@@ -342,6 +388,11 @@ func (s *Server) humaDuckDBPush(
 	if err != nil {
 		return nil, err
 	}
+	// Reject before the stream body flushes a 200 so SSE clients see the
+	// 503 + Retry-After (mirrors humaPGPush).
+	if local.WriterClosed() {
+		return nil, writerClosedError()
+	}
 	duckCfg, err := s.duckDBPushConfig(in.Body)
 	if err != nil {
 		return nil, apiError(http.StatusBadRequest, err.Error())
@@ -361,7 +412,7 @@ func (s *Server) humaDuckDBPush(
 				newDuckDBPushProgressLogger(), streamProgress,
 			)
 			var result duckdbsync.PushResult
-			_, err := engine.SyncThenRun(ctx, body.Full, nil,
+			err := s.syncThenRunForPush(ctx, engine, local, body.Full,
 				func(forceFull bool) error {
 					var pushErr error
 					result, pushErr = duckdbsync.Push(

--- a/internal/server/huma_routes_push_internal_test.go
+++ b/internal/server/huma_routes_push_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -18,6 +19,7 @@ import (
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/postgres"
+	syncpkg "go.kenn.io/agentsview/internal/sync"
 )
 
 // stubVectorPushSource is a no-op postgres.VectorPushSource: the gating test
@@ -410,6 +412,179 @@ func TestPushRoutesAreStreaming(t *testing.T) {
 		require.Contains(t, op.Responses, "200", path)
 		assertStreamingResponseContent(t, op.Responses["200"].Content)
 	}
+}
+
+// TestPushRoutesReturn503WhileWriterClosedForSSE pins that a push during the
+// write barrier is rejected before the stream body flushes a 200: the daemon
+// CLI always negotiates SSE, so the 503 + Retry-After must be decided up
+// front rather than emitted as a generic SSE error event.
+func TestPushRoutesReturn503WhileWriterClosedForSSE(t *testing.T) {
+	s := testServer(t, 30*time.Second)
+	database := s.db.(*db.DB)
+	require.NoError(t, database.CloseWriter())
+	defer func() { assert.NoError(t, database.ReopenWriter()) }()
+
+	for _, path := range []string{"/api/v1/push/pg", "/api/v1/push/duckdb"} {
+		req := httptest.NewRequest(
+			http.MethodPost, path, strings.NewReader(`{"full":false}`),
+		)
+		req.Host = "127.0.0.1:0"
+		req.RemoteAddr = "127.0.0.1:1234"
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "text/event-stream")
+		req.Header.Set("Origin", "http://127.0.0.1:0")
+		w := httptest.NewRecorder()
+		s.Handler().ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusServiceUnavailable, w.Code,
+			"%s body: %s", path, w.Body.String())
+		assert.Equal(t, "5", w.Header().Get("Retry-After"),
+			"%s: a writer-closed push must advertise Retry-After", path)
+	}
+}
+
+// TestSyncThenRunForPushWorkerRunnerRouting pins the daemon push coordinator:
+// with the worker-backed resync runner wired, full and stale-archive pushes
+// run the worker build-and-swap instead of an in-process archive-scale pass
+// (the on-disk session must NOT land in the archive, proving no direct
+// sync/resync ran in process), and the push work still runs afterwards with a
+// full push forced. Per-batch pushes and runner-less servers keep the
+// in-process SyncThenRun path, whose sync does land the session.
+func TestSyncThenRunForPushWorkerRunnerRouting(t *testing.T) {
+	tests := []struct {
+		name          string
+		stale         bool
+		full          bool
+		wireRunner    bool
+		wantRunner    int
+		wantForceFull bool
+		wantSessions  int
+	}{
+		{
+			name:          "full push routes through worker resync runner",
+			full:          true,
+			wireRunner:    true,
+			wantRunner:    1,
+			wantForceFull: true,
+			wantSessions:  0,
+		},
+		{
+			name:          "stale archive push routes through worker resync runner",
+			stale:         true,
+			wireRunner:    true,
+			wantRunner:    1,
+			wantForceFull: true,
+			wantSessions:  0,
+		},
+		{
+			name:         "per-batch push stays in process",
+			wireRunner:   true,
+			wantRunner:   0,
+			wantSessions: 1,
+		},
+		{
+			name:          "full push without runner falls back in process",
+			full:          true,
+			wantForceFull: true,
+			wantSessions:  1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runnerCalls := 0
+			workCalls := 0
+			var opts []syncRouteFixtureOption
+			if tt.stale {
+				opts = append(opts, withStaleDB())
+			}
+			if tt.wireRunner {
+				opts = append(opts, withLocalResyncRunner(func(
+					context.Context, func(syncpkg.Progress),
+				) (syncpkg.SyncStats, error) {
+					runnerCalls++
+					assert.Zero(t, workCalls,
+						"the worker pass must complete before the push runs")
+					return syncpkg.SyncStats{}, nil
+				}))
+			}
+			f := newSyncRouteFixture(t, opts...)
+			f.writeClaudeSession(t, "proj/session.jsonl", "push coordinator")
+			engine := f.srv.syncEngineForLocal(f.db)
+			t.Cleanup(engine.Close)
+
+			err := f.srv.syncThenRunForPush(
+				context.Background(), engine, f.db, tt.full,
+				func(forceFull bool) error {
+					workCalls++
+					assert.Equal(t, tt.wantForceFull, forceFull)
+					return nil
+				},
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantRunner, runnerCalls)
+			assert.Equal(t, 1, workCalls, "push work must run exactly once")
+			assertSessionCount(t, f.db, tt.wantSessions)
+		})
+	}
+}
+
+// TestSyncThenRunForPushRunnerErrorSkipsPush pins the failure contract: a
+// worker resync pass that ran and reported failure surfaces its error and the
+// push never runs against the unrebuilt archive.
+func TestSyncThenRunForPushRunnerErrorSkipsPush(t *testing.T) {
+	f := newSyncRouteFixture(t, withLocalResyncRunner(func(
+		context.Context, func(syncpkg.Progress),
+	) (syncpkg.SyncStats, error) {
+		return syncpkg.SyncStats{}, errors.New("resync build reported failed")
+	}))
+	engine := f.srv.syncEngineForLocal(f.db)
+	t.Cleanup(engine.Close)
+
+	err := f.srv.syncThenRunForPush(
+		context.Background(), engine, f.db, true,
+		func(bool) error {
+			require.FailNow(t, "push work must not run after a failed worker pass")
+			return nil
+		},
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resync build reported failed")
+}
+
+// TestPGPushFullRoutesResyncThroughWorkerRunner is the handler-level twin of
+// the coordinator table test: a full pg push over HTTP invokes the wired
+// worker resync runner and never runs the archive-scale pass in process (the
+// on-disk session must not land in the archive).
+func TestPGPushFullRoutesResyncThroughWorkerRunner(t *testing.T) {
+	runnerCalls := 0
+	f := newSyncRouteFixture(t, withLocalResyncRunner(func(
+		context.Context, func(syncpkg.Progress),
+	) (syncpkg.SyncStats, error) {
+		runnerCalls++
+		return syncpkg.SyncStats{}, nil
+	}))
+	f.writeClaudeSession(t, "proj/session.jsonl", "full push worker routing")
+	f.srv.ensurePricing = func(context.Context, *db.DB) error { return nil }
+
+	w := serveJSON(t, f.handler, http.MethodPost, "/api/v1/push/pg",
+		map[string]any{
+			"full": true,
+			"pg": map[string]any{
+				"url":            "postgres://nobody:nobody@127.0.0.1:1/test?sslmode=disable",
+				"schema":         "agentsview",
+				"machine_name":   "test",
+				"allow_insecure": false,
+			},
+		})
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code,
+		"the push itself fails against the unreachable target; body: %s",
+		w.Body.String())
+	assert.Equal(t, 1, runnerCalls,
+		"a full push must run the worker-backed resync pass")
+	assertSessionCount(t, f.db, 0)
 }
 
 // TestNewPushProgressStreamSenderThrottles pins the SSE fan-out throttle: the

--- a/internal/server/huma_routes_sync.go
+++ b/internal/server/huma_routes_sync.go
@@ -202,28 +202,85 @@ func (s *Server) humaTriggerSync(
 	if err != nil {
 		return nil, err
 	}
+	if err := s.rejectStaleArchiveForSync(); err != nil {
+		return nil, err
+	}
 	return &huma.StreamResponse{Body: func(hctx huma.Context) {
 		stream, ok := newHumaSSEStream(hctx)
 		if !ok {
-			stats := s.runSyncWithResyncFallback(ctx, engine, nil)
+			stats, err := s.runSyncWithResyncFallback(ctx, engine, nil)
+			if err != nil {
+				writeHumaJSON(hctx, http.StatusInternalServerError,
+					apiErrorResponse{Message: err.Error()})
+				return
+			}
 			writeHumaJSON(hctx, http.StatusOK, stats)
 			return
 		}
-		stats := s.runSyncWithResyncFallback(ctx, engine, func(p syncpkg.Progress) {
+		stats, err := s.runSyncWithResyncFallback(ctx, engine, func(p syncpkg.Progress) {
 			stream.SendJSON("progress", p)
 		})
+		if err != nil {
+			stream.SendJSON("error", map[string]string{"error": err.Error()})
+			return
+		}
 		stream.SendJSON("done", stats)
 	}}, nil
+}
+
+// ResyncRequiredHeader marks a /sync rejection that requires a full resync, so
+// the CLI can retry through /api/v1/resync instead of surfacing a raw HTTP
+// error. The body remains the human-readable explanation.
+const ResyncRequiredHeader = "X-Agentsview-Resync-Required"
+
+// rejectStaleArchiveForSync fails a worker-backed /sync when the archive's data
+// version changed, because the worker sync pass refuses to swap a stale archive
+// under the live daemon. It points the caller at /resync, which rebuilds through
+// the resync-build flow; it deliberately does not auto-trigger a resync. The
+// in-process path (no worker runner) safely resyncs a stale archive itself, so
+// the gate only applies when the worker-backed runner is wired.
+func (s *Server) rejectStaleArchiveForSync() error {
+	if s.localSyncRunner == nil {
+		return nil
+	}
+	local, ok := s.db.(*db.DB)
+	if !ok || !local.NeedsResync() {
+		return nil
+	}
+	return huma.ErrorWithHeaders(
+		apiError(
+			http.StatusConflict,
+			"archive data version changed; POST /api/v1/resync to rebuild the "+
+				"archive before syncing",
+		),
+		http.Header{ResyncRequiredHeader: []string{"true"}},
+	)
 }
 
 func (s *Server) runSyncWithResyncFallback(
 	ctx context.Context, engine *syncpkg.Engine,
 	progress func(syncpkg.Progress),
-) syncpkg.SyncStats {
+) (syncpkg.SyncStats, error) {
+	if s.localSyncRunner != nil {
+		// The worker-backed "sync" runner refuses a stale-version archive rather
+		// than swap it under the live daemon (see runSyncWorkerStartup); callers
+		// gate on NeedsResync before reaching here and route rebuilds through the
+		// resync-build flow. It only returns an error when the worker ran and
+		// reported failure, so propagate it to the caller instead of reporting
+		// the failed pass as a successful sync.
+		stats, err := s.localSyncRunner(ctx, progress)
+		if err != nil {
+			if ctx.Err() == nil {
+				log.Printf("foreground local sync: %v", err)
+			}
+			return stats, err
+		}
+		return stats, nil
+	}
 	stats, _ := engine.SyncThenRun(
 		ctx, false, progress, func(bool) error { return nil },
 	)
-	return stats
+	return stats, nil
 }
 
 func (s *Server) humaTriggerResync(
@@ -237,13 +294,22 @@ func (s *Server) humaTriggerResync(
 	return &huma.StreamResponse{Body: func(hctx huma.Context) {
 		stream, ok := newHumaSSEStream(hctx)
 		if !ok {
-			stats := s.runResyncWithFallback(ctx, engine, nil)
+			stats, err := s.runResyncWithFallback(ctx, engine, nil)
+			if err != nil {
+				writeHumaJSON(hctx, http.StatusInternalServerError,
+					apiErrorResponse{Message: err.Error()})
+				return
+			}
 			writeHumaJSON(hctx, http.StatusOK, stats)
 			return
 		}
-		stats := s.runResyncWithFallback(ctx, engine, func(p syncpkg.Progress) {
+		stats, err := s.runResyncWithFallback(ctx, engine, func(p syncpkg.Progress) {
 			stream.SendJSON("progress", p)
 		})
+		if err != nil {
+			stream.SendJSON("error", map[string]string{"error": err.Error()})
+			return
+		}
 		stream.SendJSON("done", stats)
 	}}, nil
 }
@@ -251,11 +317,25 @@ func (s *Server) humaTriggerResync(
 func (s *Server) runResyncWithFallback(
 	ctx context.Context, engine *syncpkg.Engine,
 	progress func(syncpkg.Progress),
-) syncpkg.SyncStats {
+) (syncpkg.SyncStats, error) {
+	if s.localResyncRunner != nil {
+		// The worker-backed runner builds the replacement archive in a child
+		// process behind a write barrier and swaps it in. It only returns an
+		// error when the worker ran and reported failure, so propagate it to
+		// the caller instead of reporting the failed pass as a success.
+		stats, err := s.localResyncRunner(ctx, progress)
+		if err != nil {
+			if ctx.Err() == nil {
+				log.Printf("foreground resync: %v", err)
+			}
+			return stats, err
+		}
+		return stats, nil
+	}
 	stats, _ := engine.SyncThenRun(
 		ctx, true, progress, func(bool) error { return nil },
 	)
-	return stats
+	return stats, nil
 }
 
 func (s *Server) humaSyncRemotes(
@@ -786,6 +866,8 @@ func (s *Server) resyncBeforeSessionSync(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	s.runResyncWithFallback(ctx, engine, nil)
+	if _, err := s.runResyncWithFallback(ctx, engine, nil); err != nil {
+		return err
+	}
 	return ctx.Err()
 }

--- a/internal/server/huma_routes_sync_internal_test.go
+++ b/internal/server/huma_routes_sync_internal_test.go
@@ -39,16 +39,26 @@ type syncRouteFixture struct {
 }
 
 type syncRouteFixtureConfig struct {
-	stale       bool
-	remoteHosts []config.RemoteHost
-	broadcaster *Broadcaster
-	engine      *syncpkg.Engine
+	stale        bool
+	remoteHosts  []config.RemoteHost
+	broadcaster  *Broadcaster
+	engine       *syncpkg.Engine
+	syncRunner   LocalSyncRunner
+	resyncRunner LocalResyncRunner
 }
 
 type syncRouteFixtureOption func(*syncRouteFixtureConfig)
 
 func withStaleDB() syncRouteFixtureOption {
 	return func(c *syncRouteFixtureConfig) { c.stale = true }
+}
+
+func withLocalSyncRunner(r LocalSyncRunner) syncRouteFixtureOption {
+	return func(c *syncRouteFixtureConfig) { c.syncRunner = r }
+}
+
+func withLocalResyncRunner(r LocalResyncRunner) syncRouteFixtureOption {
+	return func(c *syncRouteFixtureConfig) { c.resyncRunner = r }
 }
 
 func withRemoteHosts(hosts ...config.RemoteHost) syncRouteFixtureOption {
@@ -102,6 +112,13 @@ func newSyncRouteFixture(
 	var serverOptions []Option
 	if cfg.broadcaster != nil {
 		serverOptions = append(serverOptions, WithBroadcaster(cfg.broadcaster))
+	}
+	if cfg.syncRunner != nil {
+		serverOptions = append(serverOptions, WithLocalSyncRunner(cfg.syncRunner))
+	}
+	if cfg.resyncRunner != nil {
+		serverOptions = append(serverOptions,
+			WithLocalResyncRunner(cfg.resyncRunner))
 	}
 	srv := New(serverConfig, database, cfg.engine, serverOptions...)
 	return &syncRouteFixture{
@@ -1212,6 +1229,66 @@ func TestHumaTriggerSyncLocalNoSyncResyncsStaleDB(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
 	assert.False(t, f.db.NeedsResync())
 	assertOnlySessionFirstMessageContains(t, f.db, "stale no sync route")
+}
+
+// TestHumaTriggerSyncWorkerBackedRejectsStaleArchive pins the new UX: with the
+// worker-backed runner wired, /sync on a stale archive returns 409 pointing at
+// /resync and never runs the runner, since the worker refuses to swap the
+// archive under the live daemon.
+func TestHumaTriggerSyncWorkerBackedRejectsStaleArchive(t *testing.T) {
+	ran := false
+	f := newSyncRouteFixture(t, withStaleDB(), withLocalSyncRunner(
+		func(context.Context, func(syncpkg.Progress)) (syncpkg.SyncStats, error) {
+			ran = true
+			return syncpkg.SyncStats{}, nil
+		},
+	))
+	require.True(t, f.db.NeedsResync())
+
+	w := serveJSON(t, f.handler, http.MethodPost, "/api/v1/sync", nil)
+
+	require.Equal(t, http.StatusConflict, w.Code, "body: %s", w.Body.String())
+	assert.Contains(t, w.Body.String(), "resync")
+	assert.Equal(t, "true", w.Header().Get(ResyncRequiredHeader),
+		"the rejection must carry the machine-readable resync signal for the CLI")
+	assert.False(t, ran, "the worker-backed runner must not run for a stale archive")
+	assert.True(t, f.db.NeedsResync(), "a rejected sync must not resync")
+}
+
+// TestHumaTriggerSyncWorkerRunnerErrorRejectsStream pins the failure UX: a
+// worker-backed runner that ran and reported failure must surface an SSE
+// "error" event (or an error status without SSE) instead of a "done" event
+// that makes the failed pass look successful.
+func TestHumaTriggerSyncWorkerRunnerErrorRejectsStream(t *testing.T) {
+	f := newSyncRouteFixture(t, withLocalSyncRunner(
+		func(context.Context, func(syncpkg.Progress)) (syncpkg.SyncStats, error) {
+			return syncpkg.SyncStats{}, errors.New("sync worker pass reported failed")
+		},
+	))
+
+	w := serveJSON(t, f.handler, http.MethodPost, "/api/v1/sync", nil)
+
+	body := w.Body.String()
+	assert.Contains(t, body, "event: error")
+	assert.Contains(t, body, "sync worker pass reported failed")
+	assert.NotContains(t, body, "event: done",
+		"a failed worker pass must not be reported as a completed sync")
+}
+
+func TestHumaTriggerResyncWorkerRunnerErrorRejectsStream(t *testing.T) {
+	f := newSyncRouteFixture(t, withLocalResyncRunner(
+		func(context.Context, func(syncpkg.Progress)) (syncpkg.SyncStats, error) {
+			return syncpkg.SyncStats{}, errors.New("resync build reported failed")
+		},
+	))
+
+	w := serveJSON(t, f.handler, http.MethodPost, "/api/v1/resync", nil)
+
+	body := w.Body.String()
+	assert.Contains(t, body, "event: error")
+	assert.Contains(t, body, "resync build reported failed")
+	assert.NotContains(t, body, "event: done",
+		"a failed worker resync must not be reported as a completed resync")
 }
 
 func TestForegroundSyncReleasesDeferredStartupMaintenance(t *testing.T) {

--- a/internal/server/import_test.go
+++ b/internal/server/import_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/importer"
 )
 
@@ -65,6 +66,49 @@ func TestHandleImportClaudeAI(t *testing.T) {
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&stats))
 	assert.Equal(t, 1, stats.Imported)
 	assert.Zero(t, stats.Updated)
+}
+
+// TestHandleImportRejectsWriterClosedBeforeStream pins the maintenance-mode
+// UX: while a worker pass holds the write barrier, import requests fail before
+// the stream body opens with the transient 503 + Retry-After instead of a
+// misleading 500 or an HTTP-200 SSE error event.
+func TestHandleImportRejectsWriterClosedBeforeStream(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		path     string
+		filename string
+	}{
+		{name: "claude-ai", path: "/api/v1/import/claude-ai", filename: "conversations.json"},
+		{name: "chatgpt", path: "/api/v1/import/chatgpt", filename: "export.zip"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := testServer(t, 5*time.Second)
+			local, ok := srv.db.(*db.DB)
+			require.True(t, ok)
+			require.NoError(t, local.CloseWriter())
+			t.Cleanup(func() { require.NoError(t, local.ReopenWriter()) })
+
+			var body bytes.Buffer
+			writer := multipart.NewWriter(&body)
+			part, err := writer.CreateFormFile("file", tt.filename)
+			require.NoError(t, err)
+			_, _ = part.Write([]byte("[]"))
+			writer.Close()
+
+			req := httptest.NewRequest(http.MethodPost, tt.path, &body)
+			req.Header.Set("Content-Type", writer.FormDataContentType())
+			req.Header.Set("Accept", "text/event-stream")
+			rec := httptest.NewRecorder()
+			srv.mux.ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusServiceUnavailable, rec.Code,
+				"body: %s", rec.Body.String())
+			assert.Equal(t, writerClosedRetryAfterSeconds,
+				rec.Header().Get("Retry-After"))
+			assert.NotContains(t, rec.Body.String(), "event:",
+				"the rejection must not open an SSE stream")
+		})
+	}
 }
 
 func TestHandleImportChatGPT_RequiresZip(t *testing.T) {

--- a/internal/server/insights.go
+++ b/internal/server/insights.go
@@ -321,29 +321,34 @@ func (s *Server) generateCannedInsight(
 		promptPtr = &req.Prompt
 	}
 
-	id, err := s.db.InsertInsight(db.Insight{
-		Type:            insight.CannedType,
-		DateFrom:        req.DateFrom,
-		DateTo:          req.DateTo,
-		Project:         project,
-		Agent:           result.Agent,
-		Model:           modelPtr,
-		Prompt:          promptPtr,
-		Content:         insight.RenderCannedMarkdown(envelope, prov),
-		Kind:            string(kind),
-		SchemaVersion:   insight.CannedSchemaVersion,
-		TemplateID:      prov.TemplateID,
-		TemplateVersion: prov.TemplateVersion,
-		AggregateHash:   aggregateHash,
-		CacheKey:        cacheKey,
-		CacheStatus:     "fresh",
-		ProvenanceJSON:  string(provJSON),
-		StructuredJSON:  string(structuredJSON),
+	var id int64
+	err = s.serializeArchiveWrite(func() error {
+		var insertErr error
+		id, insertErr = s.db.InsertInsight(db.Insight{
+			Type:            insight.CannedType,
+			DateFrom:        req.DateFrom,
+			DateTo:          req.DateTo,
+			Project:         project,
+			Agent:           result.Agent,
+			Model:           modelPtr,
+			Prompt:          promptPtr,
+			Content:         insight.RenderCannedMarkdown(envelope, prov),
+			Kind:            string(kind),
+			SchemaVersion:   insight.CannedSchemaVersion,
+			TemplateID:      prov.TemplateID,
+			TemplateVersion: prov.TemplateVersion,
+			AggregateHash:   aggregateHash,
+			CacheKey:        cacheKey,
+			CacheStatus:     "fresh",
+			ProvenanceJSON:  string(provJSON),
+			StructuredJSON:  string(structuredJSON),
+		})
+		return insertErr
 	})
 	if err != nil {
 		log.Printf("canned insight insert error: %v", err)
 		sendJSON("error", map[string]string{
-			"message": "failed to save insight",
+			"message": insightSaveErrorMessage(err),
 		})
 		return
 	}

--- a/internal/server/insights_internal_test.go
+++ b/internal/server/insights_internal_test.go
@@ -2,13 +2,40 @@ package server
 
 import (
 	"context"
+	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/agentsview/internal/db"
 )
+
+// TestGenerateInsightRejectsWriterClosedBeforeStream pins the maintenance-mode
+// UX: while a worker pass holds the write barrier, insight generation fails at
+// request time with the transient 503 + Retry-After instead of running for
+// minutes and then failing to save.
+func TestGenerateInsightRejectsWriterClosedBeforeStream(t *testing.T) {
+	srv := testServer(t, 5*time.Second)
+	local, ok := srv.db.(*db.DB)
+	require.True(t, ok)
+	require.NoError(t, local.CloseWriter())
+	t.Cleanup(func() { require.NoError(t, local.ReopenWriter()) })
+
+	w := serveJSON(t, srv.Handler(), http.MethodPost, "/api/v1/insights/generate",
+		map[string]any{
+			"type":      "daily_activity",
+			"date_from": "2026-01-01",
+			"date_to":   "2026-01-01",
+		})
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code,
+		"body: %s", w.Body.String())
+	assert.Equal(t, writerClosedRetryAfterSeconds, w.Header().Get("Retry-After"))
+	assert.NotContains(t, w.Body.String(), "event:",
+		"the rejection must not open an SSE stream")
+}
 
 // TestActivityRangeSummaryUsesRequestTimezone confirms the insight activity
 // summary resolves its window in the request timezone, so a non-UTC viewer's

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -134,6 +134,14 @@ type Server struct {
 	// push phase skipped, e.g. when [vector] is disabled.
 	vectorPushSource postgres.VectorPushSource
 
+	// localSyncRunner, when set, backs the foreground local-sync HTTP handler
+	// with the worker-backed pass instead of running SyncThenRun in process.
+	localSyncRunner LocalSyncRunner
+
+	// localResyncRunner, when set, backs the foreground full-resync HTTP handler
+	// with the worker-backed build-and-swap instead of an in-process resync.
+	localResyncRunner LocalResyncRunner
+
 	ensurePricing func(context.Context, *db.DB) error
 }
 
@@ -324,6 +332,34 @@ func WithSessionMutationNotifier(fn func()) Option {
 // /debug/pprof/ for live profiling of a running daemon.
 func WithPprof(enabled bool) Option {
 	return func(s *Server) { s.pprofEnabled = enabled }
+}
+
+// LocalSyncRunner runs the daemon's foreground local sync, streaming progress
+// to the optional callback and returning the resulting stats. When injected,
+// the sync HTTP handler routes through it (the worker-backed path) instead of
+// running the archive-scale sync in the daemon process.
+type LocalSyncRunner func(
+	ctx context.Context, progress func(sync.Progress),
+) (sync.SyncStats, error)
+
+// WithLocalSyncRunner injects the worker-backed foreground sync runner. Nil (the
+// default) keeps the in-process SyncThenRun path, which server tests rely on.
+func WithLocalSyncRunner(r LocalSyncRunner) Option {
+	return func(s *Server) { s.localSyncRunner = r }
+}
+
+// LocalResyncRunner runs the daemon's foreground full resync, streaming progress
+// to the optional callback and returning the resulting stats. When injected, the
+// resync HTTP handler routes through it (the worker-backed build-and-swap)
+// instead of running the archive-scale resync in the daemon process.
+type LocalResyncRunner func(
+	ctx context.Context, progress func(sync.Progress),
+) (sync.SyncStats, error)
+
+// WithLocalResyncRunner injects the worker-backed foreground resync runner. Nil
+// (the default) keeps the in-process SyncThenRun resync path.
+func WithLocalResyncRunner(r LocalResyncRunner) Option {
+	return func(s *Server) { s.localResyncRunner = r }
 }
 
 func (s *Server) humaConfig() huma.Config {

--- a/internal/server/starred_test.go
+++ b/internal/server/starred_test.go
@@ -40,6 +40,22 @@ func (te *testEnv) requestJSON(
 	return w
 }
 
+func TestStarSessionReturns503WhileWriterClosed(t *testing.T) {
+	te := setup(t)
+	te.seedSession(t, "s1", "alpha", 2)
+
+	// Close the writer to simulate the maintenance-pass barrier window while the
+	// daemon's worker rebuilds the archive; readers keep serving.
+	require.NoError(t, te.db.CloseWriter())
+	defer func() { assert.NoError(t, te.db.ReopenWriter()) }()
+
+	w := te.put(t, "/api/v1/sessions/s1/star", `{}`)
+	require.Equal(t, http.StatusServiceUnavailable, w.Code,
+		"body: %s", w.Body.String())
+	assert.Equal(t, "5", w.Header().Get("Retry-After"),
+		"a writer-closed write must advertise Retry-After")
+}
+
 func TestStarredHandlers(t *testing.T) {
 	te := setup(t)
 	te.seedSession(t, "s1", "alpha", 2)

--- a/internal/sync/aider_reconciliation_test.go
+++ b/internal/sync/aider_reconciliation_test.go
@@ -1,0 +1,173 @@
+package sync
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/parser"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReconcileWatchRootsAiderOverlappingRootsReuseStableRunIdentity(t *testing.T) {
+	root := t.TempDir()
+	repo := filepath.Join(root, "repo")
+	require.NoError(t, os.MkdirAll(repo, 0o755))
+	historyPath := filepath.Join(repo, parser.AiderHistoryFileName())
+	require.NoError(t, os.WriteFile(
+		historyPath,
+		[]byte("# aider chat started at 2026-06-09 14:01:00\n#### prompt\nanswer\n"),
+		0o644,
+	))
+	expectedRawID, ok := parser.AiderRawIDAt(historyPath, 0)
+	require.True(t, ok)
+	expectedID := "aider:" + expectedRawID
+
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentAider: {root, repo},
+		},
+		Machine: "test-machine",
+	})
+	t.Cleanup(engine.Close)
+
+	require.NoError(t, engine.ReconcileWatchRoots(t.Context(), []string{root}, false))
+
+	active, err := database.GetSession(t.Context(), expectedID)
+	require.NoError(t, err)
+	assert.NotNil(t, active, "the physical run keeps its parser-derived identity")
+	page, err := database.ListSessions(t.Context(), db.SessionFilter{
+		Agent: string(parser.AgentAider), Limit: 10,
+	})
+	require.NoError(t, err)
+	activeIDs := make([]string, 0, len(page.Sessions))
+	for _, session := range page.Sessions {
+		activeIDs = append(activeIDs, session.ID)
+	}
+	assert.Equal(t, []string{expectedID}, activeIDs,
+		"overlapping roots must produce exactly one active Aider session")
+	assert.Equal(t, 1, engine.LastReconciliationResult().Metrics.SharedContainerScans)
+}
+
+func TestReconcileWatchRootsAiderScansOneLargeContainerOnce(t *testing.T) {
+	root := t.TempDir()
+	repo := filepath.Join(root, "repo")
+	require.NoError(t, os.MkdirAll(repo, 0o755))
+	var history strings.Builder
+	for i := range 600 {
+		history.WriteString("# aider chat started at 2026-06-09 14:01:00\n")
+		history.WriteString("#### prompt ")
+		history.WriteString(strings.Repeat("x", i%17+1))
+		history.WriteString("\nanswer\n")
+	}
+	require.NoError(t, os.WriteFile(
+		filepath.Join(repo, parser.AiderHistoryFileName()),
+		[]byte(history.String()), 0o644,
+	))
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentAider: {root}},
+		Machine:   "test-machine",
+	})
+	defer engine.Close()
+
+	require.NoError(t, engine.ReconcileWatchRoots(t.Context(), []string{root}, false))
+
+	result := engine.LastReconciliationResult()
+	assert.True(t, result.Complete)
+	assert.Equal(t, 1, result.Metrics.SharedContainerScans)
+	assert.Positive(t, result.Metrics.MaxProviderRetainedBytes)
+	assert.Less(t, result.Metrics.MaxProviderRetainedBytes, int64(1<<20))
+}
+
+func TestReconcileWatchRootsAiderTombstonesDeletedVirtualRun(t *testing.T) {
+	root := t.TempDir()
+	repo := filepath.Join(root, "repo")
+	require.NoError(t, os.MkdirAll(repo, 0o755))
+	historyPath := filepath.Join(repo, parser.AiderHistoryFileName())
+	firstRun := "# aider chat started at 2026-06-09 14:01:00\n" +
+		"#### keep this run\nkept answer\n"
+	secondRun := "# aider chat started at 2026-06-09 15:30:00\n" +
+		"#### delete this run\ndeleted answer\n"
+	require.NoError(t, os.WriteFile(historyPath, []byte(firstRun+secondRun), 0o644))
+	survivingRawID, ok := parser.AiderRawIDAt(historyPath, 0)
+	require.True(t, ok)
+	deletedRawID, ok := parser.AiderRawIDAt(historyPath, 1)
+	require.True(t, ok)
+	survivingID := "aider:" + survivingRawID
+	deletedID := "aider:" + deletedRawID
+
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentAider: {root}},
+		Machine:   "test-machine",
+	})
+	t.Cleanup(engine.Close)
+	require.Equal(t, 2, engine.SyncAll(t.Context(), nil).Synced)
+	require.NoError(t, os.WriteFile(historyPath, []byte(firstRun), 0o644))
+
+	require.NoError(t, engine.ReconcileWatchRoots(t.Context(), []string{root}, false))
+
+	active, err := database.GetSession(t.Context(), deletedID)
+	require.NoError(t, err)
+	assert.Nil(t, active)
+	archived, err := database.GetSessionFull(t.Context(), deletedID)
+	require.NoError(t, err)
+	require.NotNil(t, archived)
+	require.NotNil(t, archived.DeletionCause)
+	assert.Equal(t, "source_missing", *archived.DeletionCause)
+	surviving, err := database.GetSession(t.Context(), survivingID)
+	require.NoError(t, err)
+	assert.NotNil(t, surviving)
+}
+
+func TestReconcileWatchRootsAiderTombstonesDeletedRunWhenPositionIsReused(t *testing.T) {
+	root := t.TempDir()
+	repo := filepath.Join(root, "repo")
+	require.NoError(t, os.MkdirAll(repo, 0o755))
+	historyPath := filepath.Join(repo, parser.AiderHistoryFileName())
+	runs := []string{
+		"# aider chat started at 2026-06-09 14:01:00\n#### first run\nfirst answer\n",
+		"# aider chat started at 2026-06-09 15:30:00\n#### deleted run\ndeleted answer\n",
+		"# aider chat started at 2026-06-09 16:45:00\n#### shifted run\nshifted answer\n",
+	}
+	require.NoError(t, os.WriteFile(historyPath, []byte(strings.Join(runs, "")), 0o644))
+	deletedRawID, ok := parser.AiderRawIDAt(historyPath, 1)
+	require.True(t, ok)
+	shiftedRawID, ok := parser.AiderRawIDAt(historyPath, 2)
+	require.True(t, ok)
+	deletedID := "aider:" + deletedRawID
+	shiftedID := "aider:" + shiftedRawID
+
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentAider: {root}},
+		Machine:   "test-machine",
+	})
+	t.Cleanup(engine.Close)
+	require.Equal(t, 3, engine.SyncAll(t.Context(), nil).Synced)
+	require.NoError(t, os.WriteFile(historyPath, []byte(runs[0]+runs[2]), 0o644))
+
+	require.NoError(t, engine.ReconcileWatchRoots(t.Context(), []string{root}, false))
+
+	deleted, err := database.GetSession(t.Context(), deletedID)
+	require.NoError(t, err)
+	assert.Nil(t, deleted)
+	archived, err := database.GetSessionFull(t.Context(), deletedID)
+	require.NoError(t, err)
+	require.NotNil(t, archived)
+	require.NotNil(t, archived.DeletionCause)
+	assert.Equal(t, "source_missing", *archived.DeletionCause)
+	shifted, err := database.GetSessionFull(t.Context(), shiftedID)
+	require.NoError(t, err)
+	require.NotNil(t, shifted)
+	assert.Nil(t, shifted.DeletedAt)
+	require.NotNil(t, shifted.FilePath)
+	assert.Equal(t, parser.AiderVirtualPath(historyPath, 1), *shifted.FilePath)
+}

--- a/internal/sync/antigravity_cli_integration_test.go
+++ b/internal/sync/antigravity_cli_integration_test.go
@@ -383,6 +383,7 @@ func TestSyncEngineAntigravityCLI_DBFallbackRetries(t *testing.T) {
 		TotalSessions: 2,
 		Synced:        2,
 		Skipped:       0,
+		Failed:        2,
 		Anomalies:     agyCLIUnknownSchemaAnomaly(1),
 	})
 
@@ -406,6 +407,7 @@ func TestSyncEngineAntigravityCLI_DBFallbackRetries(t *testing.T) {
 		TotalSessions: 2,
 		Synced:        2,
 		Skipped:       0,
+		Failed:        2,
 		Anomalies:     agyCLIUnknownSchemaAnomaly(1),
 	})
 	assert.Less(t, env.db.GetSessionDataVersion(malformedSessionID), db.CurrentDataVersion(),
@@ -417,6 +419,7 @@ func TestSyncEngineAntigravityCLI_DBFallbackRetries(t *testing.T) {
 		TotalSessions: 2,
 		Synced:        2,
 		Skipped:       0,
+		Failed:        2,
 		Anomalies:     agyCLIUnknownSchemaAnomaly(1),
 	})
 	assert.Less(t, env.db.GetSessionDataVersion(malformedSessionID), db.CurrentDataVersion(),
@@ -457,6 +460,7 @@ func TestSyncEngineAntigravityCLI_NeedsRetryReplacesCurrentMessages(t *testing.T
 		TotalSessions: 1,
 		Synced:        1,
 		Skipped:       0,
+		Failed:        1,
 	})
 
 	assertSessionMessageCount(t, env.db, sessionID, 1)

--- a/internal/sync/classify_cortex_test.go
+++ b/internal/sync/classify_cortex_test.go
@@ -75,7 +75,7 @@ func TestClassifyOnePath_Cortex(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			files := eng.classifyPaths([]string{tt.path})
+			files := requireClassifyPaths(t, eng, []string{tt.path})
 			if !tt.want {
 				assert.Empty(t, files)
 				return

--- a/internal/sync/classify_kimi_test.go
+++ b/internal/sync/classify_kimi_test.go
@@ -97,7 +97,7 @@ func TestEngineClassifyKimiPaths(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			files := eng.classifyPaths([]string{tt.path})
+			files := requireClassifyPaths(t, eng, []string{tt.path})
 			if !tt.want {
 				assert.Empty(t, files)
 				return

--- a/internal/sync/classify_openhands_test.go
+++ b/internal/sync/classify_openhands_test.go
@@ -84,7 +84,7 @@ func TestClassifyOnePath_OpenHands(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			files := eng.classifyPaths([]string{tt.path})
+			files := requireClassifyPaths(t, eng, []string{tt.path})
 			if !tt.want {
 				assert.Empty(t, files)
 				return

--- a/internal/sync/companion_reconciliation_test.go
+++ b/internal/sync/companion_reconciliation_test.go
@@ -1,0 +1,54 @@
+package sync
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/parser"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReconcileWatchRootsCommandCodeCompanionOnlyChangeReparsesOwner(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "project")
+	require.NoError(t, os.MkdirAll(project, 0o755))
+	transcript := filepath.Join(project, "sess_123.jsonl")
+	meta := filepath.Join(project, "sess_123.meta.json")
+	require.NoError(t, os.WriteFile(transcript, []byte(
+		`{"id":"m1","timestamp":"2026-06-01T10:00:00Z","sessionId":"sess_123","role":"user","content":[{"type":"text","text":"Inspect logs"}],"metadata":{"version":2,"cwd":"/workspace/project"}}`+"\n"+
+			`{"id":"m2","timestamp":"2026-06-01T10:00:01Z","sessionId":"sess_123","role":"assistant","content":[{"type":"text","text":"Done"}],"metadata":{"version":2}}`+"\n",
+	), 0o644))
+	require.NoError(t, os.WriteFile(meta, []byte(`{"title":"Original title"}`), 0o644))
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentCommandCode: {root}},
+		Machine:   "test-machine",
+	})
+	defer engine.Close()
+
+	require.NoError(t, engine.ReconcileWatchRoots(t.Context(), []string{root}, false))
+	before, err := database.GetSessionFull(t.Context(), "commandcode:sess_123")
+	require.NoError(t, err)
+	require.NotNil(t, before)
+	require.NotNil(t, before.SessionName)
+	assert.Equal(t, "Original title", *before.SessionName)
+
+	require.NoError(t, os.WriteFile(meta, []byte(`{"title":"Companion-only rename"}`), 0o644))
+	future := time.Now().Add(time.Second)
+	require.NoError(t, os.Chtimes(meta, future, future))
+	require.NoError(t, engine.ReconcileWatchRoots(t.Context(), []string{root}, false))
+
+	after, err := database.GetSessionFull(t.Context(), "commandcode:sess_123")
+	require.NoError(t, err)
+	require.NotNil(t, after)
+	require.NotNil(t, after.SessionName)
+	assert.Equal(t, "Companion-only rename", *after.SessionName)
+	active, err := database.GetSession(t.Context(), "commandcode:sess_123")
+	require.NoError(t, err)
+	assert.NotNil(t, active, "companion-only reconciliation must not tombstone its owner")
+}

--- a/internal/sync/cwd_filter_integration_test.go
+++ b/internal/sync/cwd_filter_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/dbtest"
 	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/sync"
@@ -125,6 +126,136 @@ func TestSyncEngineCwdPrefixFilterBlocksIncrementalAppend(t *testing.T) {
 	// store the appended message; the archived rows stay untouched.
 	assertSessionMessageCount(t, env.db, "outside-append", 2)
 	assertMessageRoles(t, env.db, "outside-append", "user", "assistant")
+}
+
+func TestReconcileWatchRootsCwdFilteredSourceRevokesDeletionProof(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	env := &testEnv{db: dbtest.OpenTestDB(t), claudeDir: t.TempDir()}
+	env.engine = sync.NewEngine(env.db, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {env.claudeDir},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(func() { env.engine.Close() })
+
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, "Outside", "/workspace/personal/blog").
+		AddClaudeAssistant(tsEarlyS5, "ok").
+		String()
+	path := env.writeClaudeSessionForProject(
+		t, "/workspace/personal/blog", "outside-reconcile.jsonl", content,
+	)
+	allowedContent := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, "Inside", "/workspace/work/project").
+		AddClaudeAssistant(tsEarlyS5, "ok").
+		String()
+	allowedPath := env.writeClaudeSessionForProject(
+		t, "/workspace/work/project", "inside-reconcile.jsonl", allowedContent,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+	assertSessionMessageCount(t, env.db, "outside-reconcile", 2)
+	assertSessionMessageCount(t, env.db, "inside-reconcile", 2)
+
+	ownership, err := env.db.ListActiveSessionSourceOwnershipScopesPage(
+		context.Background(), "local", string(parser.AgentClaude),
+		[]db.StoredSourcePathHintScope{{Path: env.claudeDir}},
+		db.SessionSourceCursor{},
+	)
+	require.NoError(t, err)
+	require.Len(t, ownership, 2,
+		"initial successful sync must establish deletion proof")
+
+	// Truncate the source so reconciliation must parse it and evaluate the
+	// newly configured allow-list instead of taking the unchanged-source skip.
+	filtered := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, "Outside", "/workspace/personal/blog").
+		String()
+	require.NoError(t, os.WriteFile(path, []byte(filtered), 0o644))
+
+	env.engine.Close()
+	env.engine = sync.NewEngine(env.db, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {env.claudeDir},
+		},
+		Machine:            "local",
+		IncludeCwdPrefixes: []string{"/workspace/work"},
+	})
+	require.NoError(t, env.engine.ReconcileWatchRootsAfterLostEvents(
+		context.Background(), []string{env.claudeDir}, false,
+	))
+
+	ownership, err = env.db.ListActiveSessionSourceOwnershipScopesPage(
+		context.Background(), "local", string(parser.AgentClaude),
+		[]db.StoredSourcePathHintScope{{Path: env.claudeDir}},
+		db.SessionSourceCursor{},
+	)
+	require.NoError(t, err)
+	require.Len(t, ownership, 1,
+		"only the CWD-admitted source may retain deletion proof")
+	assert.Equal(t, allowedPath, ownership[0].FilePath)
+	assertSessionMessageCount(t, env.db, "outside-reconcile", 2)
+	assertSessionMessageCount(t, env.db, "inside-reconcile", 2)
+
+	require.NoError(t, os.Remove(path))
+	require.NoError(t, env.engine.ReconcileWatchRootsAfterLostEvents(
+		context.Background(), []string{env.claudeDir}, false,
+	))
+	assertSessionMessageCount(t, env.db, "outside-reconcile", 2)
+	assertSessionMessageCount(t, env.db, "inside-reconcile", 2)
+}
+
+func TestSyncAllCwdFilterChangeRevokesSkippedSourceDeletionProof(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	env := &testEnv{db: dbtest.OpenTestDB(t), claudeDir: t.TempDir()}
+	newEngine := func(prefixes []string) *sync.Engine {
+		return sync.NewEngine(env.db, sync.EngineConfig{
+			AgentDirs: map[parser.AgentType][]string{
+				parser.AgentClaude: {env.claudeDir},
+			},
+			Machine:            "local",
+			IncludeCwdPrefixes: prefixes,
+		})
+	}
+
+	env.engine = newEngine(nil)
+	t.Cleanup(func() { env.engine.Close() })
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, "Outside", "/workspace/personal/blog").
+		AddClaudeAssistant(tsEarlyS5, "ok").
+		String()
+	path := env.writeClaudeSessionForProject(
+		t, "/workspace/personal/blog", "outside-periodic.jsonl", content,
+	)
+	env.engine.SyncAll(t.Context(), nil)
+	assertSessionMessageCount(t, env.db, "outside-periodic", 2)
+
+	// Restart with a newly restrictive filter, leaving the source unchanged so
+	// ordinary discovery takes its freshness-skip path. The skipped source must
+	// lose the deletion proof established before the filter changed.
+	env.engine.Close()
+	env.engine = newEngine([]string{"/workspace/work"})
+	env.engine.SyncAll(t.Context(), nil)
+	ownership, err := env.db.ListActiveSessionSourceOwnershipScopesPage(
+		t.Context(), "local", string(parser.AgentClaude),
+		[]db.StoredSourcePathHintScope{{Path: env.claudeDir}},
+		db.SessionSourceCursor{},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, ownership,
+		"an unchanged source rejected by the new CWD filter must lose deletion proof")
+
+	require.NoError(t, os.Remove(path))
+	require.NoError(t, env.engine.ReconcileWatchRoots(
+		t.Context(), []string{env.claudeDir}, false,
+	))
+	assertSessionMessageCount(t, env.db, "outside-periodic", 2)
 }
 
 // A full resync where the cwd allow-list vetoes every discovered

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -7,12 +7,14 @@ import (
 	"log"
 	"maps"
 	"os"
+	pathpkg "path"
 	"path/filepath"
 	"runtime"
 	"slices"
 	"strconv"
 	"strings"
 	gosync "sync"
+	"sync/atomic"
 	"time"
 
 	"go.kenn.io/agentsview/internal/db"
@@ -37,6 +39,147 @@ const (
 )
 
 var errSessionPreserved = errors.New("session preserved")
+
+type reconciliationMetricsContextKey struct{}
+type reconciliationBaselineContextKey struct{}
+type deferGlobalLinkContextKey struct{}
+
+type reconciliationBaselineTracker struct {
+	sources map[db.SessionSourcePath]struct{}
+}
+
+func newReconciliationBaselineTracker() *reconciliationBaselineTracker {
+	return &reconciliationBaselineTracker{
+		sources: make(map[db.SessionSourcePath]struct{}, reconciliationPageSize),
+	}
+}
+
+func reconciliationBaselineTrackerFor(
+	ctx context.Context,
+) *reconciliationBaselineTracker {
+	tracker, _ := ctx.Value(reconciliationBaselineContextKey{}).(*reconciliationBaselineTracker)
+	return tracker
+}
+
+func (tracker *reconciliationBaselineTracker) add(
+	source db.SessionSourcePath,
+) {
+	if source.Agent == "" || source.FilePath == "" {
+		return
+	}
+	tracker.sources[source] = struct{}{}
+}
+
+func (tracker *reconciliationBaselineTracker) list() []db.SessionSourcePath {
+	sources := make([]db.SessionSourcePath, 0, len(tracker.sources))
+	for source := range tracker.sources {
+		sources = append(sources, source)
+	}
+	return sources
+}
+
+type reconciliationRuntimeMetrics struct {
+	mu                       gosync.Mutex
+	maxProvider              int
+	maxRehydrated            int
+	workerResults            int
+	maxWorkerResults         int
+	maxPendingWrites         int
+	globalLinkPasses         int
+	providerRetainedBytes    int64
+	maxProviderRetainedBytes int64
+	sharedContainerScans     int
+	openCodeSQLiteParses     int
+	codexReplacementBuilds   int
+}
+
+func reconciliationRuntimeMetricsFor(ctx context.Context) *reconciliationRuntimeMetrics {
+	metrics, _ := ctx.Value(reconciliationMetricsContextKey{}).(*reconciliationRuntimeMetrics)
+	return metrics
+}
+
+func (metrics *reconciliationRuntimeMetrics) providerBuffered(buffered int) {
+	metrics.mu.Lock()
+	metrics.maxProvider = max(metrics.maxProvider, buffered)
+	metrics.mu.Unlock()
+}
+
+func (metrics *reconciliationRuntimeMetrics) rehydrated(count int) {
+	metrics.mu.Lock()
+	metrics.maxRehydrated = max(metrics.maxRehydrated, count)
+	metrics.mu.Unlock()
+}
+
+func (metrics *reconciliationRuntimeMetrics) workerQueued(delta int) {
+	metrics.mu.Lock()
+	metrics.workerResults += delta
+	metrics.maxWorkerResults = max(metrics.maxWorkerResults, metrics.workerResults)
+	metrics.mu.Unlock()
+}
+
+func (metrics *reconciliationRuntimeMetrics) pendingWrites(count int) {
+	metrics.mu.Lock()
+	metrics.maxPendingWrites = max(metrics.maxPendingWrites, count)
+	metrics.mu.Unlock()
+}
+
+func (metrics *reconciliationRuntimeMetrics) globalLinkPass() {
+	metrics.mu.Lock()
+	metrics.globalLinkPasses++
+	metrics.mu.Unlock()
+}
+
+func (metrics *reconciliationRuntimeMetrics) providerRetained(delta int64) {
+	metrics.mu.Lock()
+	metrics.providerRetainedBytes += delta
+	metrics.maxProviderRetainedBytes = max(
+		metrics.maxProviderRetainedBytes,
+		metrics.providerRetainedBytes,
+	)
+	metrics.mu.Unlock()
+}
+
+func (metrics *reconciliationRuntimeMetrics) sharedContainerScan() {
+	metrics.mu.Lock()
+	metrics.sharedContainerScans++
+	metrics.mu.Unlock()
+}
+
+func (metrics *reconciliationRuntimeMetrics) openCodeSQLiteParse() {
+	metrics.mu.Lock()
+	metrics.openCodeSQLiteParses++
+	metrics.mu.Unlock()
+}
+
+// codexReplacementIndexBuild counts one per-pass Codex replacement index
+// build. Unlike the other recorders it tolerates a nil receiver because it
+// is reached from tombstone passes that run outside streamed reconciliation,
+// where no runtime metrics are in the context.
+func (metrics *reconciliationRuntimeMetrics) codexReplacementIndexBuild() {
+	if metrics == nil {
+		return
+	}
+	metrics.mu.Lock()
+	metrics.codexReplacementBuilds++
+	metrics.mu.Unlock()
+}
+
+func (metrics *reconciliationRuntimeMetrics) snapshot(
+	spool ReconciliationMetrics,
+) ReconciliationMetrics {
+	metrics.mu.Lock()
+	defer metrics.mu.Unlock()
+	spool.MaxProviderBuffered = metrics.maxProvider
+	spool.MaxRehydratedSources = metrics.maxRehydrated
+	spool.MaxWorkerResults = metrics.maxWorkerResults
+	spool.MaxPendingWrites = metrics.maxPendingWrites
+	spool.GlobalLinkPasses = metrics.globalLinkPasses
+	spool.MaxProviderRetainedBytes = metrics.maxProviderRetainedBytes
+	spool.SharedContainerScans = metrics.sharedContainerScans
+	spool.OpenCodeSQLiteParses = metrics.openCodeSQLiteParses
+	spool.CodexReplacementIndexBuilds = metrics.codexReplacementBuilds
+	return spool
+}
 
 func isIntentionalSessionSkip(err error) bool {
 	return errors.Is(err, db.ErrSessionExcluded) ||
@@ -90,6 +233,10 @@ type EngineConfig struct {
 	// still takes syncMu after it is released so later syncs and resyncs
 	// cannot overlap its database access.
 	DeferStartupMaintenance bool
+	// OnStartupReconciled runs once, after syncMu is released, when a full
+	// startup discovery completed authoritatively. Failed, cancelled, and
+	// aborted attempts leave it eligible for a later successful owner.
+	OnStartupReconciled func(SyncStats, error)
 	// ProviderFactories and ProviderMigrationModes select which concrete
 	// providers own discovery and parsing for their agents. Nil uses the
 	// parser package registry/manifest.
@@ -99,7 +246,8 @@ type EngineConfig struct {
 
 // Engine orchestrates session file discovery and sync.
 type Engine struct {
-	db *db.DB
+	db    *db.DB
+	lstat func(string) (os.FileInfo, error)
 	// archiveStore is the database holding previously archived
 	// sessions for the preserve guards in prepareSessionWrite.
 	// During a resync/rebuild it points at the original DB while
@@ -138,11 +286,37 @@ type Engine struct {
 	emitter                 Emitter
 	providerFactories       map[parser.AgentType]parser.ProviderFactory
 	providerMigrationModes  map[parser.AgentType]parser.ProviderMigrationMode
+	providerWatchRootsMu    gosync.Mutex
+	providerWatchRoots      map[parser.AgentType][]parser.WatchRoot
 	projectIdentityMu       gosync.Mutex
 	projectIdentityCache    map[string]projectIdentityCacheEntry
 	projectIdentityWritten  map[string]struct{}
 	startupMaintenanceOnce  gosync.Once
 	startupMaintenanceReady chan struct{}
+	startupReconciledOnce   gosync.Once
+	startupReconciledReady  chan struct{}
+	startupAttemptOnce      gosync.Once
+	startupAttemptReady     chan struct{}
+	startupReconciledStats  SyncStats
+	startupReconciledErr    error
+	startupCallbackOnce     gosync.Once
+	onStartupReconciled     func(SyncStats, error)
+	// writeBatchOverride is a test seam for exercising reconciliation archive
+	// write failures after discovery and parse have succeeded.
+	writeBatchOverride func([]pendingWrite, syncWriteMode, bool) (int, int, int, int)
+	// workerCountOverride is a test seam for exercising the production worker
+	// floor and cap independently of the host CPU count.
+	workerCountOverride  int
+	parseRetentionOnce   gosync.Once
+	parseRetentionBudget *parseRetentionBudget
+	bulkRetentionOnce    gosync.Once
+	bulkRetentionBudget  *parseRetentionBudget
+	// activeRetention points at the budget the in-flight pass admits parses
+	// through. Bulk archive passes (full sync, resync rebuild, remote import)
+	// install the unthrottled bulk budget for their duration; when nil,
+	// incremental paths (watcher, scoped/periodic syncs, reconciliation
+	// pages, single-session syncs) use the bounded default budget.
+	activeRetention atomic.Pointer[parseRetentionBudget]
 
 	// forceParse disables every stored-state skip (skip cache,
 	// size/mtime/data_version checks, incremental JSONL deltas) so
@@ -203,6 +377,33 @@ type Engine struct {
 	verifiedSourceEpoch      uint64
 	verifiedSourcePass       uint64
 	verifiedSourceActivePass uint64
+
+	reconciliationMu           gosync.RWMutex
+	lastReconciliation         ReconciliationResult
+	reconciliationSpoolFactory func(string) (reconciliationSpoolStore, error)
+}
+
+// ReconciliationResult is the structured acknowledgement for the most recent
+// watcher-forced reconciliation attempt.
+type ReconciliationResult struct {
+	Complete         bool
+	Aborted          bool
+	ProviderFailures int
+	Metrics          ReconciliationMetrics
+}
+
+// LastReconciliationResult returns a snapshot of the latest watcher-forced
+// reconciliation acknowledgement.
+func (e *Engine) LastReconciliationResult() ReconciliationResult {
+	e.reconciliationMu.RLock()
+	defer e.reconciliationMu.RUnlock()
+	return e.lastReconciliation
+}
+
+func (e *Engine) setLastReconciliationResult(result ReconciliationResult) {
+	e.reconciliationMu.Lock()
+	e.lastReconciliation = result
+	e.reconciliationMu.Unlock()
 }
 
 // PhaseStats returns the engine's phase counter. The values reflect only
@@ -282,6 +483,7 @@ func NewEngine(
 
 	e := &Engine{
 		db:                      database,
+		lstat:                   os.Lstat,
 		agentDirs:               dirs,
 		machine:                 cfg.Machine,
 		blockedResultCategories: blockedCategorySet(cfg.BlockedResultCategories),
@@ -296,9 +498,16 @@ func NewEngine(
 		emitter:                 cfg.Emitter,
 		providerFactories:       providerFactoryMap(providerFactories),
 		providerMigrationModes:  providerModes,
+		providerWatchRoots:      make(map[parser.AgentType][]parser.WatchRoot),
 		projectIdentityCache:    make(map[string]projectIdentityCacheEntry),
 		projectIdentityWritten:  make(map[string]struct{}),
 		startupMaintenanceReady: make(chan struct{}),
+		startupReconciledReady:  make(chan struct{}),
+		startupAttemptReady:     make(chan struct{}),
+		onStartupReconciled:     cfg.OnStartupReconciled,
+		reconciliationSpoolFactory: func(path string) (reconciliationSpoolStore, error) {
+			return newReconciliationSpool(path)
+		},
 	}
 	if !cfg.DeferStartupMaintenance {
 		e.ReleaseStartupMaintenance()
@@ -571,7 +780,17 @@ func (e *Engine) Machine() string {
 
 type syncJob struct {
 	processResult
-	path string
+	agent          parser.AgentType
+	path           string
+	retentionLease *parseRetentionLease
+}
+
+func (j *syncJob) releaseRetention() {
+	if j == nil {
+		return
+	}
+	j.retentionLease.Release()
+	j.retentionLease = nil
 }
 
 func (j syncJob) skipCacheKey() string {
@@ -590,7 +809,7 @@ func (r processResult) skipCacheKey(path string) string {
 // Paths that don't match known session file patterns are
 // silently ignored.
 func (e *Engine) SyncPaths(paths []string) {
-	e.SyncPathsContext(context.Background(), paths)
+	_ = e.SyncPathsContext(context.Background(), paths)
 }
 
 // SyncPathsContext is SyncPaths with caller-controlled cancellation. The
@@ -598,16 +817,22 @@ func (e *Engine) SyncPaths(paths []string) {
 // path waits for the in-flight onChange callback, so a watcher-driven sync
 // that ignored SIGTERM would hold shutdown until a service manager's kill
 // timeout instead of aborting between files like every other sync path.
-func (e *Engine) SyncPathsContext(ctx context.Context, paths []string) {
+func (e *Engine) SyncPathsContext(ctx context.Context, paths []string) error {
 	if e.refuseWriteInForceParse("SyncPaths") {
-		return
+		return nil
+	}
+	missingPaths := make([]string, 0, len(paths))
+	for _, path := range paths {
+		if _, err := e.lstatSource(path); os.IsNotExist(err) {
+			missingPaths = append(missingPaths, path)
+		}
 	}
 	// Capture container states before classifyPaths lists any session rows,
 	// matching the capture-before-discovery ordering of full syncs.
 	preContainerStates := e.captureSQLiteContainerStates(paths)
-	files := e.classifyPaths(paths)
-	if len(files) == 0 {
-		return
+	files, classificationErr := e.classifyPaths(ctx, paths)
+	if len(files) == 0 && len(missingPaths) == 0 {
+		return classificationErr
 	}
 
 	e.syncMu.Lock()
@@ -616,8 +841,10 @@ func (e *Engine) SyncPathsContext(ctx context.Context, paths []string) {
 	// critical section or deadlock by re-entering sync code. The
 	// stats variable is captured by the closure and populated below.
 	var stats SyncStats
+	var tombstoned int
 	defer func() {
-		if stats.Synced > 0 {
+		if stats.Synced > 0 || tombstoned > 0 ||
+			stats.sourceMissingTombstoned > 0 {
 			e.emit("sessions")
 		}
 	}()
@@ -642,6 +869,16 @@ func (e *Engine) SyncPathsContext(ctx context.Context, paths []string) {
 	e.finishSQLiteContainerPass(true, false)
 	e.anomalies.applyTo(&stats)
 	e.persistSkipCache()
+	complete := classificationErr == nil && ctx.Err() == nil &&
+		!stats.Aborted && stats.Failed == 0 &&
+		stats.providerFailures == 0
+	if complete && len(missingPaths) > 0 {
+		var err error
+		tombstoned, err = e.tombstoneMissingWatchSourcesLocked(ctx, missingPaths, nil)
+		if err != nil {
+			return fmt.Errorf("watcher source tombstone: %w", err)
+		}
+	}
 
 	e.mu.Lock()
 	e.lastSync = time.Now()
@@ -653,16 +890,28 @@ func (e *Engine) SyncPathsContext(ctx context.Context, paths []string) {
 			"sync: %d file(s) updated", stats.Synced,
 		)
 	}
+	if err := errors.Join(classificationErr, ctx.Err()); err != nil {
+		return err
+	}
+	if !complete {
+		return fmt.Errorf(
+			"changed-path sync incomplete: %d source or archive failures",
+			stats.Failed,
+		)
+	}
+	return nil
 }
 
 // classifyPaths maps changed file system paths to
 // parser.DiscoveredFile structs, filtering out paths that don't
 // match known session file patterns.
 func (e *Engine) classifyPaths(
+	ctx context.Context,
 	paths []string,
-) []parser.DiscoveredFile {
+) ([]parser.DiscoveredFile, error) {
 	seen := make(map[string]int, len(paths))
 	files := make([]parser.DiscoveredFile, 0, len(paths))
+	var classificationErr error
 	for _, p := range paths {
 		// Codex resolved-index events map to potentially several session
 		// sources and must classify even when the event path was deleted, so
@@ -671,7 +920,14 @@ func (e *Engine) classifyPaths(
 		// history.jsonl), are owned by each provider-authoritative
 		// SourcesForChangedPath via classifyProviderChangedPath.
 		dfs := e.classifyCodexIndexPath(p)
-		dfs = append(dfs, e.classifyProviderChangedPath(p)...)
+		providerFiles, err := e.classifyProviderChangedPath(ctx, p)
+		if err != nil {
+			classificationErr = errors.Join(
+				classificationErr,
+				fmt.Errorf("classify changed path %q: %w", p, err),
+			)
+		}
+		dfs = append(dfs, providerFiles...)
 		for _, df := range dfs {
 			e.invalidateVerifiedDiscoveredSource(df)
 			key := string(df.Agent) + "\x00" + df.Path
@@ -685,7 +941,7 @@ func (e *Engine) classifyPaths(
 	}
 	files = e.expandClaudeDuplicateCandidates(files)
 	files = dedupeDiscoveredFiles(files)
-	return e.dedupeClaudeDiscoveredFiles(files)
+	return e.dedupeClaudeDiscoveredFiles(files), classificationErr
 }
 
 func mergeChangedPathDiscoveredFile(
@@ -704,11 +960,12 @@ func mergeChangedPathDiscoveredFile(
 }
 
 func (e *Engine) classifyProviderChangedPath(
+	ctx context.Context,
 	path string,
-) []parser.DiscoveredFile {
-	ctx := context.Background()
+) ([]parser.DiscoveredFile, error) {
 	eventKind := providerChangedPathEventKind(path)
 	var files []parser.DiscoveredFile
+	var classificationErr error
 	seen := map[string]struct{}{}
 
 	agents := make([]parser.AgentType, 0, len(e.providerFactories))
@@ -750,49 +1007,71 @@ func (e *Engine) classifyProviderChangedPath(
 			Machine: e.machine,
 		})
 		def := provider.Definition()
-		watchRoots := providerChangedPathWatchRoots(ctx, provider, roots)
+		watchRoots, err := e.providerChangedPathWatchRoots(
+			ctx, agentType, provider, roots,
+		)
+		if err != nil {
+			classificationErr = errors.Join(
+				classificationErr,
+				fmt.Errorf(
+					"%s provider changed-path watch roots for %q: %w",
+					def.Type, path, err,
+				),
+			)
+			continue
+		}
 		// Every SourcesForChangedPath implementation resolves the
 		// changed path within the provider's configured roots or plan
-		// watch roots (stored-path hints are already scoped to the
-		// watch root by the query), so an agent whose roots cannot
+		// watch roots (stored-path hints are scoped to the affected
+		// container before the query), so an agent whose roots cannot
 		// contain the path never claims it. Skip it before the
-		// per-root stored-hint DB queries, which otherwise run for
+		// provider-owned stored-hint DB queries, which otherwise run for
 		// every registered agent on every watcher event.
 		if !changedPathWithinAnyRoot(path, roots) &&
 			!changedPathWithinAnyRoot(path, watchRoots) {
 			continue
 		}
 		for _, watchRoot := range watchRoots {
-			var storedSourcePaths []string
+			request := parser.ChangedPathRequest{
+				Path:      path,
+				EventKind: eventKind,
+				WatchRoot: watchRoot,
+			}
 			if provider.Capabilities().Source.StoredSourceHints == parser.CapabilitySupported {
-				var err error
-				storedSourcePaths, err = e.db.ListStoredSourcePathHints(
-					string(def.Type),
-					providerChangedPathStoredHintRoots(
-						agentType, watchRoot, path,
-					),
-				)
-				if err != nil {
-					log.Printf(
-						"%s provider changed-path stored hints: %v",
-						def.Type, err,
+				if resolver, ok := provider.(parser.StoredSourceHintScopeProvider); ok {
+					scopes := storedSourceDBHintScopes(
+						resolver.StoredSourceHintScopes(request),
 					)
+					if len(scopes) > 0 {
+						request.StoredSourcePaths, err = e.db.ListStoredSourcePathHintsContext(
+							ctx, string(def.Type),
+							scopes,
+						)
+						if err != nil {
+							classificationErr = errors.Join(
+								classificationErr,
+								fmt.Errorf(
+									"%s provider changed-path stored hints for %q: %w",
+									def.Type, path, err,
+								),
+							)
+							continue
+						}
+					}
 				}
 			}
 			sources, err := provider.SourcesForChangedPath(
 				ctx,
-				parser.ChangedPathRequest{
-					Path:              path,
-					EventKind:         eventKind,
-					WatchRoot:         watchRoot,
-					StoredSourcePaths: storedSourcePaths,
-				},
+				request,
 			)
 			if err != nil {
 				if !errors.Is(err, parser.ErrUnsupportedProviderFeature) {
-					log.Printf(
-						"%s provider changed-path classification: %v",
-						def.Type, err,
+					classificationErr = errors.Join(
+						classificationErr,
+						fmt.Errorf(
+							"%s provider changed-path classification for %q: %w",
+							def.Type, path, err,
+						),
 					)
 				}
 				continue
@@ -813,7 +1092,8 @@ func (e *Engine) classifyProviderChangedPath(
 				if eventKind == "remove" &&
 					filepath.Clean(sourcePath) == filepath.Clean(path) &&
 					!parser.IsRegularFile(sourcePath) &&
-					!providerDeletedPhysicalSQLiteSource(agent, sourcePath) {
+					!providerDeletedPhysicalSQLiteSource(agent, sourcePath) &&
+					!providerVirtualSourceContainerExists(sourcePath) {
 					continue
 				}
 				seen[key] = struct{}{}
@@ -837,42 +1117,80 @@ func (e *Engine) classifyProviderChangedPath(
 			}
 		}
 	}
-	return files
+	return files, classificationErr
 }
 
-func providerChangedPathWatchRoots(
+func storedSourceDBHintScopes(
+	scopes []parser.StoredSourceHintScope,
+) []db.StoredSourcePathHintScope {
+	out := make([]db.StoredSourcePathHintScope, 0, len(scopes))
+	for _, scope := range scopes {
+		out = append(out, db.StoredSourcePathHintScope{
+			Path: scope.Path, IncludeVirtualMembers: scope.IncludeVirtualMembers,
+		})
+	}
+	return out
+}
+
+func (e *Engine) providerChangedPathWatchRoots(
 	ctx context.Context,
+	agent parser.AgentType,
 	provider parser.Provider,
 	roots []string,
-) []string {
-	plan, err := provider.WatchPlan(ctx)
-	if err == nil && len(plan.Roots) > 0 {
-		watchRoots := make([]string, 0, len(plan.Roots))
-		seen := make(map[string]struct{}, len(plan.Roots))
-		for _, root := range plan.Roots {
-			path := filepath.Clean(root.Path)
-			if path == "" || path == "." {
-				continue
-			}
-			if _, ok := seen[path]; ok {
-				continue
-			}
-			seen[path] = struct{}{}
-			watchRoots = append(watchRoots, path)
-		}
-		if len(watchRoots) > 0 {
-			return watchRoots
-		}
+) ([]string, error) {
+	e.providerWatchRootsMu.Lock()
+	defer e.providerWatchRootsMu.Unlock()
+	if cached, ok := e.providerWatchRoots[agent]; ok {
+		return watchRootPaths(cached), nil
 	}
-	watchRoots := make([]string, 0, len(roots))
+
+	resolved, err := parser.ResolveWatchRoots(ctx, provider)
+	if err != nil {
+		return nil, fmt.Errorf("resolve %s provider watch roots: %w", agent, err)
+	}
+	resolved = normalizedProviderWatchRoots(resolved)
+	if len(resolved) == 0 {
+		resolved = make([]parser.WatchRoot, 0, len(roots))
+		for _, root := range roots {
+			resolved = append(resolved, parser.WatchRoot{Path: root})
+		}
+		resolved = normalizedProviderWatchRoots(resolved)
+	}
+	if e.providerWatchRoots == nil {
+		e.providerWatchRoots = make(map[parser.AgentType][]parser.WatchRoot)
+	}
+	e.providerWatchRoots[agent] = resolved
+	return watchRootPaths(resolved), nil
+}
+
+func normalizedProviderWatchRoots(
+	roots []parser.WatchRoot,
+) []parser.WatchRoot {
+	normalized := make([]parser.WatchRoot, 0, len(roots))
+	seen := make(map[string]struct{}, len(roots))
 	for _, root := range roots {
-		root = filepath.Clean(root)
-		if root == "" || root == "." {
+		path := filepath.Clean(root.Path)
+		if path == "" || path == "." {
 			continue
 		}
-		watchRoots = append(watchRoots, root)
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		root.Path = path
+		root.IncludeGlobs = nil
+		root.ExcludeGlobs = nil
+		normalized = append(normalized, root)
 	}
-	return watchRoots
+	return normalized
+}
+
+func watchRootPaths(roots []parser.WatchRoot) []string {
+	paths := make([]string, 0, len(roots))
+	for _, root := range roots {
+		paths = append(paths, root.Path)
+	}
+	return paths
 }
 
 func providerChangedPathForceParse(
@@ -905,6 +1223,17 @@ func providerChangedPathForceParse(
 			isOpenCodeFormatStoragePath(agent, sourcePath) {
 			return false
 		}
+		// Gemini project-metadata events fan out to every session under
+		// the root. Each session's fingerprint hashes its resolved
+		// project metadata, so the hash-aware freshness check re-parses
+		// only sessions whose resolved project changed; a forced parse
+		// would rewrite the whole archive on every metadata edit. Remove
+		// events keep the force so deletion still re-emits.
+		if eventKind != "remove" &&
+			agent == parser.AgentGemini &&
+			parser.IsGeminiProjectMetadataFile(eventPath) {
+			return false
+		}
 		return true
 	}
 	return eventKind == "remove" &&
@@ -929,39 +1258,16 @@ func providerVirtualSourceBackedByEvent(sourcePath, eventPath string) bool {
 			eventPath == filepath.Join(filepath.Dir(dbPath), "workspace.json"))
 }
 
-func providerChangedPathStoredHintRoots(
-	agent parser.AgentType,
-	watchRoot string,
-	path string,
-) []string {
-	watchRoot = filepath.Clean(watchRoot)
-	if agent != parser.AgentTrae {
-		return []string{watchRoot}
-	}
-	root := filepath.Dir(watchRoot)
-	dbPath, ok := parser.TraeDBPathForEvent(root, path)
-	if !ok {
-		return []string{watchRoot}
-	}
-	return []string{dbPath}
-}
-
 func providerChangedPathEventKind(path string) string {
 	if path == "" {
 		return ""
 	}
-	// A virtual source path (e.g. a SQLite per-session path
-	// "<db>#<sessionID>") is never a real file. Resolve it to its physical
-	// container so an existence check reflects whether the backing store is
-	// present rather than always reporting the synthetic path as removed.
-	statPath := path
-	if container, _, ok := parser.ParseVirtualSourcePath(path); ok {
-		statPath = container
+	if _, err := os.Lstat(path); err == nil {
+		return "write"
+	} else if !os.IsNotExist(err) {
+		return "write"
 	}
-	if _, err := os.Lstat(statPath); err != nil && os.IsNotExist(err) {
-		return "remove"
-	}
-	return "write"
+	return "remove"
 }
 
 func providerDiscoveredPath(source parser.SourceRef) string {
@@ -975,6 +1281,11 @@ func providerDiscoveredPath(source parser.SourceRef) string {
 		}
 	}
 	return ""
+}
+
+func providerVirtualSourceContainerExists(path string) bool {
+	container := validatedProviderSourceStatPath(path)
+	return container != path && parser.IsRegularFile(container)
 }
 
 func providerDeletedPhysicalSQLiteSource(
@@ -1168,6 +1479,10 @@ const shelleyDBFile = "shelley.db"
 // form the temp database path during resync.
 const resyncTempSuffix = "-resync"
 
+// closeWriterForResyncBarrier indirects db.CloseWriter so tests can inject a
+// barrier-establishment failure.
+var closeWriterForResyncBarrier = func(d *db.DB) error { return d.CloseWriter() }
+
 // ResyncAll builds a fresh database from scratch, syncs all
 // sessions into it, copies insights from the old DB, then
 // atomically swaps the files and reopens the original DB
@@ -1235,6 +1550,7 @@ func (e *Engine) ResyncAll(
 		return SyncStats{}
 	}
 	e.syncMu.Lock()
+	defer e.notifyStartupReconciled()
 	// Defers LIFO: Unlock runs before emit.
 	defer func() {
 		if stats.Synced > 0 {
@@ -1243,6 +1559,7 @@ func (e *Engine) ResyncAll(
 	}()
 	defer e.syncMu.Unlock()
 	defer e.clearCurrentProgress()
+	defer func() { e.recordStartupReconciled(ctx, stats, nil) }()
 
 	return e.resyncAllLocked(ctx, onProgress)
 }
@@ -1280,6 +1597,7 @@ func (e *Engine) resyncAllWithOptionsAndOperations(
 		return SyncStats{}, nil
 	}
 	e.syncMu.Lock()
+	defer e.notifyStartupReconciled()
 	defer func() {
 		if stats.Synced > 0 && !stats.Aborted {
 			e.emit("sync")
@@ -1287,17 +1605,136 @@ func (e *Engine) resyncAllWithOptionsAndOperations(
 	}()
 	defer e.syncMu.Unlock()
 	defer e.clearCurrentProgress()
+	defer func() { e.recordStartupReconciled(ctx, stats, err) }()
 	opts.includePhaseDiagnostics = true
 	return e.resyncAllWithOptionsLocked(
 		ctx, onProgress, opts, ops,
 	)
 }
 
+// resyncAllWithOptionsLocked rebuilds the archive in place: it builds a fresh
+// replacement at the temp path, swaps it into the live file, then re-baselines
+// the caches that referenced the old database. The caller holds syncMu. The
+// extracted methods (ResyncBuild, SwapResyncDatabase, ResetCachesAfterSwap) let
+// the daemon run the heavy build in a worker process behind a write barrier and
+// perform only the swap tail itself.
 func (e *Engine) resyncAllWithOptionsLocked(
 	ctx context.Context, onProgress ProgressFunc, opts RebuildOptions,
 	ops rebuildOperations,
 ) (stats SyncStats, retErr error) {
 	ops = ops.withDefaults()
+
+	// Hold the write barrier for the whole in-process build-and-swap window. The
+	// build reads the original while it stays open, and the swap's
+	// CloseConnections runs only after the copies, so without the barrier a
+	// direct write (star/delete/restore) that bypasses syncMu could land in the
+	// original between the copies and the rename and be discarded by the swap.
+	// The barrier rejects such writes with ErrWriterClosed instead. The worker
+	// arm holds this barrier at the daemon layer (runWorkerResyncBuild) and calls
+	// ResyncBuild directly, so it never reaches this method; this arm covers the
+	// in-process fallback, CLI --full, worker startup, and unified rebuilds. Only
+	// engage it when this call owns the barrier, so an outer owner is not
+	// double-closed or prematurely reopened.
+	ownedBarrier := false
+	swapStageReached := false
+	defer func() {
+		// The successful swap's Reopen already restored the writer and cleared
+		// the barrier; recover here only when we still own a closed writer
+		// (barrier-close failure, build abort, or a swap whose own recovery
+		// failed). A failure before the swap stage never touched the reader
+		// pool, so ReopenWriter alone restores service; a post-CloseConnections
+		// failure may have closed the reader pool too, so only a full Reopen
+		// restores reads.
+		if !ownedBarrier || !e.db.WriterClosed() {
+			return
+		}
+		if swapStageReached {
+			if rerr := e.db.Reopen(); rerr != nil {
+				log.Printf("resync: recovery reopen after barrier: %v", rerr)
+				retErr = errors.Join(
+					retErr, fmt.Errorf("recovery reopen: %w", rerr),
+				)
+			}
+			return
+		}
+		if rerr := e.db.ReopenWriter(); rerr != nil {
+			log.Printf("resync: reopen writer after barrier: %v", rerr)
+			retErr = errors.Join(
+				retErr, fmt.Errorf("reopen writer after barrier: %w", rerr),
+			)
+		}
+	}()
+	if !e.db.WriterClosed() {
+		// Own the barrier before attempting the close: CloseWriter's failure
+		// posture still leaves the writer closed (undrained pool retained
+		// inside db), and the deferred recovery above must reopen it so the
+		// daemon does not fail every write until restart. Reopening is safe —
+		// this in-process arm never releases write ownership.
+		ownedBarrier = true
+		if cerr := closeWriterForResyncBarrier(e.db); cerr != nil {
+			// Building on a half-established barrier would swap while the
+			// retained connection could still write to the original. Abort
+			// before building and let the deferred reopen restore service.
+			stats.Aborted = true
+			stats.Warnings = append(stats.Warnings, fmt.Sprintf(
+				"resync aborted: close writer for barrier: %v", cerr,
+			))
+			e.setLastSyncStats(stats)
+			return stats, fmt.Errorf(
+				"resync: close writer for barrier: %w", cerr,
+			)
+		}
+	}
+
+	// Snapshot the pre-build skip state. A successful build leaves the
+	// in-memory skip cache holding the replacement's fresh entries (persisted
+	// into the replacement, not the original), so a swap failure that discards
+	// the replacement must restore this snapshot: replacement-only entries
+	// would otherwise suppress syncing sources whose data never reached the
+	// still-live original archive.
+	e.skipMu.Lock()
+	preBuildSkipCache := e.skipCache
+	preBuildSkipHashKeys := e.skipHashKeys
+	e.skipMu.Unlock()
+
+	stats, err := e.resyncBuildLocked(ctx, onProgress, opts, ops)
+	if err != nil || stats.Aborted {
+		return stats, err
+	}
+	swapStageReached = true
+	installed, swapErr := e.swapResyncDatabaseLocked(
+		ctx, onProgress, e.ResyncTempPath(), ops, &stats,
+	)
+	if swapErr != nil {
+		if !installed {
+			// The original archive is still in place; drop the discarded
+			// replacement's skip entries. A post-install failure keeps the
+			// fresh cache: the replacement is the live archive there.
+			e.skipMu.Lock()
+			e.skipCache = preBuildSkipCache
+			e.skipHashKeys = preBuildSkipHashKeys
+			e.skipMu.Unlock()
+		}
+		e.setLastSyncStats(stats)
+		return stats, swapErr
+	}
+	if err := e.ResetCachesAfterSwap(); err != nil {
+		log.Printf("resync: reset caches after swap: %v", err)
+	}
+	e.setLastSyncStats(stats)
+	return stats, nil
+}
+
+// resyncBuildLocked builds a complete replacement archive at the temp path from
+// the current sources plus any contributors, copies preserved state (orphans,
+// insights, recall, user metadata) from the original, persists the fresh skip
+// cache into the replacement, and closes it. It reads the original but never
+// closes or swaps it; the caller performs the swap. The caller holds syncMu and
+// guarantees the original receives no writes for the duration.
+func (e *Engine) resyncBuildLocked(
+	ctx context.Context, onProgress ProgressFunc, opts RebuildOptions,
+	ops rebuildOperations,
+) (stats SyncStats, retErr error) {
 	reportResyncProgress := func(p Progress) {
 		p.Resync = true
 		if p.Phase == PhaseSyncing && p.Detail == "" {
@@ -1586,9 +2023,6 @@ func (e *Engine) resyncAllWithOptionsLocked(
 				newDB.Close()
 				removeTempDB(tempPath)
 				restoreSkipCache()
-				if reopenErr := origDB.Reopen(); reopenErr != nil {
-					log.Printf("resync: contributor failure recovery reopen: %v", reopenErr)
-				}
 				stats.Aborted = true
 				stats.Warnings = append(stats.Warnings, fmt.Sprintf(
 					"resync contributor %q failed: %v",
@@ -1640,40 +2074,15 @@ func (e *Engine) resyncAllWithOptionsLocked(
 		return stats, nil
 	}
 
-	// 4. Close origDB connections first to quiesce writes,
-	// then copy insights into newDB (which is still open).
-	// This ensures no insight writes land in the old DB
-	// after the copy.
-	reportResyncPhase(
-		PhaseCopyingMetadata,
-		"Closing current database before final copy",
-		"",
-	)
-	if err := origDB.CloseConnections(); err != nil {
-		log.Printf("resync: close orig db: %v", err)
-		stats.Aborted = true
-		stats.Warnings = append(stats.Warnings,
-			"close before swap failed: "+err.Error(),
-		)
-		newDB.Close()
-		removeTempDB(tempPath)
-		restoreSkipCache()
-		// Connections may be partially closed; reopen to
-		// restore service before returning.
-		if rerr := origDB.Reopen(); rerr != nil {
-			log.Printf("resync: recovery reopen: %v", rerr)
-		}
-		e.mu.Lock()
-		e.lastSyncStats = stats
-		e.mu.Unlock()
-		return stats, err
-	}
-
-	// Re-copy excluded session IDs now that origDB is quiesced.
-	// This catches any permanent deletes that occurred during
-	// the sync window (between the pre-sync copy and now).
-	// Also purge any sessions that were synced into newDB
-	// before the exclusion was recorded.
+	// Copy preserved state from the original into the replacement. The caller
+	// guarantees the original is quiesced: the in-process swap owns the final
+	// CloseConnections, and the worker path runs behind the daemon's write
+	// barrier. These ATTACH reads therefore see a consistent committed snapshot
+	// without the build closing the original here.
+	//
+	// Re-copy excluded session IDs to catch permanent deletes recorded during
+	// the sync window, and purge any sessions synced into newDB before the
+	// exclusion was recorded.
 	reportResyncPhase(
 		PhaseCopyingMetadata,
 		"Copying sync metadata",
@@ -1694,9 +2103,6 @@ func (e *Engine) resyncAllWithOptionsLocked(
 		newDB.Close()
 		removeTempDB(tempPath)
 		restoreSkipCache()
-		if rerr := origDB.Reopen(); rerr != nil {
-			log.Printf("resync: recovery reopen: %v", rerr)
-		}
 		e.mu.Lock()
 		e.lastSyncStats = stats
 		e.mu.Unlock()
@@ -1720,9 +2126,6 @@ func (e *Engine) resyncAllWithOptionsLocked(
 		newDB.Close()
 		removeTempDB(tempPath)
 		restoreSkipCache()
-		if rerr := origDB.Reopen(); rerr != nil {
-			log.Printf("resync: recovery reopen: %v", rerr)
-		}
 		e.mu.Lock()
 		e.lastSyncStats = stats
 		e.mu.Unlock()
@@ -1771,9 +2174,6 @@ func (e *Engine) resyncAllWithOptionsLocked(
 		newDB.Close()
 		removeTempDB(tempPath)
 		restoreSkipCache()
-		if rerr := origDB.Reopen(); rerr != nil {
-			log.Printf("resync: recovery reopen: %v", rerr)
-		}
 		e.mu.Lock()
 		e.lastSyncStats = stats
 		e.mu.Unlock()
@@ -1808,9 +2208,6 @@ func (e *Engine) resyncAllWithOptionsLocked(
 		newDB.Close()
 		removeTempDB(tempPath)
 		restoreSkipCache()
-		if rerr := origDB.Reopen(); rerr != nil {
-			log.Printf("resync: recovery reopen: %v", rerr)
-		}
 		e.mu.Lock()
 		e.lastSyncStats = stats
 		e.mu.Unlock()
@@ -1836,9 +2233,6 @@ func (e *Engine) resyncAllWithOptionsLocked(
 		newDB.Close()
 		removeTempDB(tempPath)
 		restoreSkipCache()
-		if rerr := origDB.Reopen(); rerr != nil {
-			log.Printf("resync: recovery reopen: %v", rerr)
-		}
 		e.mu.Lock()
 		e.lastSyncStats = stats
 		e.mu.Unlock()
@@ -1897,14 +2291,75 @@ func (e *Engine) resyncAllWithOptionsLocked(
 		)
 	}
 
-	// 5. Close newDB and swap files, then reopen origDB.
-	reportResyncPhase(
-		PhaseSwappingDatabase,
-		"Swapping rebuilt database into place",
-		"",
-	)
-	newDB.Close()
+	// Persist the fresh skip state into the replacement so the post-swap engine
+	// loads warm state: this engine after an in-process swap, or the daemon
+	// after a worker build. Then close the replacement so its file is complete
+	// on disk for the caller's rename. A failed close means a connection still
+	// holds the replacement and committed rows may sit uncheckpointed in its
+	// WAL; the swap renames only the main file and deletes that WAL, so
+	// proceeding would install an archive missing those rows. Abort instead.
+	e.persistSkipCacheInto(newDB)
+	if err := newDB.Close(); err != nil {
+		log.Printf("resync: close replacement db: %v", err)
+		stats.Aborted = true
+		stats.Warnings = append(stats.Warnings,
+			"replacement close failed, aborting swap: "+err.Error(),
+		)
+		removeTempDB(tempPath)
+		restoreSkipCache()
+		e.mu.Lock()
+		e.lastSyncStats = stats
+		e.mu.Unlock()
+		return stats, err
+	}
+	return stats, nil
+}
 
+// swapResyncDatabaseLocked installs a built replacement archive at tempPath over
+// the original: it closes the original's connections (quiescing and
+// checkpointing it), removes the WAL sidecars, renames the replacement into
+// place, reopens the active handle, marks data current, and checkpoints. Every
+// failure appends a warning to stats and marks it aborted; recoverable failures
+// reopen the original so it keeps serving. The installed result reports whether
+// the rename replaced the original, so callers can tell pre-install failures
+// (original still live) from post-install ones. The caller holds syncMu.
+func (e *Engine) swapResyncDatabaseLocked(
+	ctx context.Context, onProgress ProgressFunc, tempPath string,
+	ops rebuildOperations, stats *SyncStats,
+) (installed bool, err error) {
+	ops = ops.withDefaults()
+	origDB := e.db
+	origPath := origDB.Path()
+	reportResyncPhase := func(phase Phase, detail string) {
+		e.reportProgress(onProgress, Progress{
+			Phase: phase, Detail: detail, Resync: true,
+		})
+	}
+
+	// Close the original to quiesce writes and checkpoint its WAL before the
+	// rename. The worker path already holds the daemon's write barrier; the
+	// in-process path relies on this close for the same guarantee.
+	reportResyncPhase(PhaseCopyingMetadata, "Closing current database before swap")
+	if err := origDB.CloseConnections(); err != nil {
+		log.Printf("resync: close orig db: %v", err)
+		stats.Aborted = true
+		stats.Warnings = append(stats.Warnings,
+			"close before swap failed: "+err.Error(),
+		)
+		removeTempDB(tempPath)
+		// Connections may be partially closed; reopen to restore service.
+		if rerr := origDB.Reopen(); rerr != nil {
+			log.Printf("resync: recovery reopen: %v", rerr)
+			return false, errors.Join(err, fmt.Errorf("recovery reopen: %w", rerr))
+		}
+		return false, err
+	}
+
+	reportResyncPhase(PhaseSwappingDatabase, "Swapping rebuilt database into place")
+	// CloseConnections checkpointed the original (including the
+	// barrier-closed-writer case), so its remaining sidecars are stale files
+	// whose removal cannot discard data, and a failed rename below reopens a
+	// complete original.
 	removeWAL(origPath)
 
 	if err := os.Rename(tempPath, origPath); err != nil {
@@ -1914,50 +2369,125 @@ func (e *Engine) resyncAllWithOptionsLocked(
 			"resync swap failed: "+err.Error(),
 		)
 		removeTempDB(tempPath)
-		restoreSkipCache()
 		// Restore service even on rename failure.
 		if rerr := origDB.Reopen(); rerr != nil {
 			log.Printf("resync: recovery reopen: %v", rerr)
+			return false, errors.Join(err, fmt.Errorf("recovery reopen: %w", rerr))
 		}
-		e.mu.Lock()
-		e.lastSyncStats = stats
-		e.mu.Unlock()
-		return stats, err
+		return false, err
 	}
 	removeWAL(tempPath)
 
 	if err := ops.reopen(origDB); err != nil {
 		log.Printf("resync: reopen db: %v", err)
-		stats.Aborted = true
+		// The replacement is already renamed into place; a failed reopen
+		// leaves both pools closed and every read failing until restart, so
+		// retry before surfacing the failure.
+		if rerr := ops.reopen(origDB); rerr != nil {
+			log.Printf("resync: recovery reopen: %v", rerr)
+			stats.Aborted = true
+			stats.Warnings = append(stats.Warnings,
+				"resync swap completed but reopening active database failed: "+
+					err.Error(),
+			)
+			return true, errors.Join(err, fmt.Errorf("recovery reopen: %w", rerr))
+		}
+		log.Printf("resync: reopen recovered on retry")
 		stats.Warnings = append(stats.Warnings,
-			"resync swap completed but reopening active database failed: "+
-				err.Error(),
+			"resync reopen required a retry: "+err.Error(),
 		)
-		e.mu.Lock()
-		e.lastSyncStats = stats
-		e.mu.Unlock()
-		return stats, err
-	} else {
-		origDB.MarkDataCurrent()
-		if err := origDB.CheckpointWALTruncateWithRetry(ctx); err != nil {
-			if errors.Is(err, db.ErrWALCheckpointBusy) {
-				log.Printf("resync: wal checkpoint busy")
-			} else {
-				log.Printf("resync: wal checkpoint: %v", err)
-			}
+	}
+	origDB.MarkDataCurrent()
+	if err := origDB.CheckpointWALTruncateWithRetry(ctx); err != nil {
+		if errors.Is(err, db.ErrWALCheckpointBusy) {
+			log.Printf("resync: wal checkpoint busy")
+		} else {
+			log.Printf("resync: wal checkpoint: %v", err)
 		}
 	}
+	return true, nil
+}
 
-	// 6. Persist skip cache into the new DB.
-	e.persistSkipCache()
+// ResyncTempPath returns the path where a resync build stages its replacement
+// archive: the active database path with the resync temp suffix appended.
+func (e *Engine) ResyncTempPath() string {
+	return e.db.Path() + resyncTempSuffix
+}
 
+// ResyncBuild builds a complete replacement archive at ResyncTempPath (including
+// orphan and metadata copy phases and skip-state persistence) using read-only
+// access to the original archive. The caller must guarantee the original
+// receives no writes while it runs; the daemon holds the write barrier and the
+// worker opens the original read-only. It does not swap or reopen anything.
+func (e *Engine) ResyncBuild(
+	ctx context.Context, onProgress ProgressFunc,
+) (string, SyncStats, error) {
+	if e.refuseWriteInForceParse("ResyncBuild") {
+		return "", SyncStats{}, nil
+	}
+	e.syncMu.Lock()
+	defer e.syncMu.Unlock()
+	defer e.clearCurrentProgress()
+	stats, err := e.resyncBuildLocked(
+		ctx, onProgress, RebuildOptions{}, productionRebuildOperations,
+	)
+	return e.ResyncTempPath(), stats, err
+}
+
+// SwapResyncDatabase installs a replacement archive built at tempPath: it closes
+// connections, removes WAL sidecars, renames, reopens, marks data current, and
+// checkpoints. It is the daemon's swap tail after a worker build. The caller
+// serializes it against sync (the daemon holds the write barrier).
+func (e *Engine) SwapResyncDatabase(tempPath string) error {
+	var stats SyncStats
+	_, err := e.swapResyncDatabaseLocked(
+		context.Background(), nil, tempPath, productionRebuildOperations, &stats,
+	)
+	return err
+}
+
+// ResetCachesAfterSwap re-baselines every parent-side cache keyed to the
+// replaced database: it clears the trusted SQLite containers, trusted OpenCode
+// storage sessions, and verified sources, then reloads the skip cache from the
+// swapped archive so the engine carries warm skip state. skipFingerprints is
+// reset to empty, matching engine construction (fingerprints are recomputed on
+// the next sync, never persisted). The caller invokes it immediately after a
+// successful SwapResyncDatabase.
+func (e *Engine) ResetCachesAfterSwap() error {
+	e.clearTrustedSQLiteContainers()
+	e.clearTrustedOpenCodeStorageSessions()
+	e.clearVerifiedSources()
+	return e.ReloadSkipCache()
+}
+
+// ReloadSkipCache replaces the in-memory skip state with the durable archive
+// state. Worker-backed passes call it after reacquiring write ownership because
+// the child may have removed cache entries while tombstoning missing sources.
+// The caller must serialize this with other engine sync work.
+func (e *Engine) ReloadSkipCache() error {
+	skipCache := make(map[string]int64)
+	if !e.ephemeral {
+		loaded, err := e.db.LoadSkippedFiles()
+		if err != nil {
+			return fmt.Errorf("reloading skip cache after swap: %w", err)
+		}
+		skipCache = loaded
+	}
+	skipHashKeys, _ := normalizeSourceHashSkipCache(skipCache, nil)
+
+	e.skipMu.Lock()
+	e.skipCache = skipCache
+	e.skipHashKeys = skipHashKeys
+	e.skipFingerprints = make(map[string]string)
+	e.skipMu.Unlock()
+	return nil
+}
+
+// setLastSyncStats records the most recent sync/resync outcome under e.mu.
+func (e *Engine) setLastSyncStats(stats SyncStats) {
 	e.mu.Lock()
 	e.lastSyncStats = stats
 	e.mu.Unlock()
-
-	// Emission happens via the deferred closure above, after
-	// syncMu is released.
-	return
 }
 
 // removeTempDB removes a temp database and its WAL/SHM files.
@@ -2076,6 +2606,7 @@ func (e *Engine) SyncThenRun(
 		return SyncStats{}, nil
 	}
 	e.syncMu.Lock()
+	defer e.notifyStartupReconciled()
 	// Defers run LIFO: Unlock runs before emit.
 	defer func() {
 		if stats.Synced > 0 {
@@ -2084,6 +2615,7 @@ func (e *Engine) SyncThenRun(
 	}()
 	defer e.syncMu.Unlock()
 	defer e.clearCurrentProgress()
+	defer func() { e.recordStartupReconciled(ctx, stats, err) }()
 	stats, err = e.syncThenRunLocked(ctx, full, onProgress, work)
 	if err == nil {
 		// Release while syncMu is still held. A timed fallback that was
@@ -2161,6 +2693,7 @@ func (e *Engine) SyncThenRunWithRebuild(
 		return SyncStats{}, nil
 	}
 	e.syncMu.Lock()
+	defer e.notifyStartupReconciled()
 	defer func() {
 		if stats.Synced > 0 && !stats.Aborted {
 			e.emit("sync")
@@ -2175,6 +2708,7 @@ func (e *Engine) SyncThenRunWithRebuild(
 		}
 	}()
 	defer e.clearCurrentProgress()
+	defer func() { e.recordStartupReconciled(ctx, stats, retErr) }()
 
 	didResync := full || e.db.NeedsResync()
 	if didResync {
@@ -2230,6 +2764,131 @@ func (e *Engine) ReleaseStartupMaintenance() {
 	})
 }
 
+func (e *Engine) notifyStartupReconciled() {
+	if e.onStartupReconciled == nil || e.startupReconciledReady == nil {
+		return
+	}
+	select {
+	case <-e.startupAttemptReady:
+	default:
+		return
+	}
+	e.startupCallbackOnce.Do(func() {
+		e.onStartupReconciled(e.startupReconciledStats, e.startupReconciledErr)
+	})
+}
+
+func (e *Engine) recordStartupReconciled(
+	ctx context.Context, stats SyncStats, err error,
+) {
+	if ctx.Err() != nil {
+		return
+	}
+	e.startupAttemptOnce.Do(func() {
+		e.startupReconciledStats = stats
+		if err != nil {
+			e.startupReconciledErr = err
+		} else if !stats.AuthoritativeDiscoveryComplete() {
+			e.startupReconciledErr = fmt.Errorf(
+				"startup discovery incomplete: %d provider failures",
+				stats.providerFailures,
+			)
+		}
+		if e.startupAttemptReady != nil {
+			close(e.startupAttemptReady)
+		}
+	})
+	if !startupReconciliationSucceeded(ctx, stats, err) {
+		return
+	}
+	e.startupReconciledOnce.Do(func() {
+		if e.startupReconciledReady != nil {
+			close(e.startupReconciledReady)
+		}
+	})
+}
+
+func startupReconciliationSucceeded(
+	ctx context.Context, stats SyncStats, err error,
+) bool {
+	return err == nil && ctx.Err() == nil &&
+		stats.AuthoritativeDiscoveryComplete()
+}
+
+// RecordStartupReconciled acknowledges a startup pass performed out of process
+// by a sync worker. The daemon calls it after opening the archive, starting the
+// watcher in collecting mode, and running the bounded gap reconciliation, so it
+// reproduces the in-process path's completion semantics: it records last-sync
+// bookkeeping and the attempt (unblocking the OnStartupReconciled gate),
+// releases startup maintenance, fires the OnStartupReconciled callback that
+// transitions the watcher out of collecting mode, and emits the "sync" event
+// when the pass changed data.
+//
+// stats carries the worker's discovery outcome (Aborted false means discovery
+// was authoritative); err is the gap reconciliation error, nil when the gap
+// pass completed. The reconciliation steps are sync.Once-guarded, so calling
+// this after — or concurrently with — an in-process fallback that already
+// acknowledged startup is a no-op rather than a double-release; the last-sync
+// bookkeeping and emit re-run per pass by design.
+func (e *Engine) RecordStartupReconciled(stats SyncStats, err error) {
+	e.RecordStartupReconciledExclusive(stats, err)
+	e.FinishStartupReconciled(stats)
+}
+
+// RecordStartupReconciledExclusive is RecordStartupReconciled's lock-held
+// half. Callers inside RunExclusive use it so the startup-reconciliation gate
+// closes before the exclusive lock is released; a deferred fallback waiting on
+// that lock then observes the completed pass instead of launching a duplicate
+// archive-scale worker. FinishStartupReconciled completes the tail that must
+// run outside the lock.
+func (e *Engine) RecordStartupReconciledExclusive(stats SyncStats, err error) {
+	e.mu.Lock()
+	if err == nil && !stats.Aborted {
+		e.lastSync = time.Now()
+	}
+	e.lastSyncStats = stats
+	e.mu.Unlock()
+	e.recordStartupReconciled(context.Background(), stats, err)
+	e.ReleaseStartupMaintenance()
+}
+
+// FinishStartupReconciled fires the completion tail that the in-process defers
+// run after releasing syncMu: the "sync" emit for a pass that changed data,
+// then the OnStartupReconciled callback. Emitting under the exclusive lock
+// could let an Emitter widen the critical section or deadlock by re-entering
+// sync code, so this must be called after RunExclusive returns.
+func (e *Engine) FinishStartupReconciled(stats SyncStats) {
+	if stats.Synced > 0 {
+		e.emit("sync")
+	}
+	e.notifyStartupReconciled()
+}
+
+// StartupReconciled reports whether a startup pass has already completed
+// authoritatively: the startupReconciledReady gate closes only on a successful
+// reconciliation, matching RunStartupSyncFallback's own re-run gate. The
+// deferred fallback consults it to skip a redundant worker pass when a
+// foreground request already drove startup reconciliation. A failed or aborted
+// attempt does not close the gate, so retries still proceed.
+func (e *Engine) StartupReconciled() bool {
+	if e.startupReconciledReady == nil {
+		return true
+	}
+	select {
+	case <-e.startupReconciledReady:
+		return true
+	default:
+		return false
+	}
+}
+
+// AuthoritativeDiscoveryComplete reports whether a full discovery pass
+// completed without cancellation, safety abort, or provider listing failure.
+// Individual parser warnings do not make discovery incomplete.
+func (stats SyncStats) AuthoritativeDiscoveryComplete() bool {
+	return !stats.Aborted && stats.providerFailures == 0
+}
+
 // RunStartupMaintenance waits for the daemon-launching foreground sync, then
 // runs work under the same mutex used by sync and resync database swaps.
 func (e *Engine) RunStartupMaintenance(
@@ -2255,6 +2914,7 @@ func (e *Engine) RunStartupSyncFallback(
 		return SyncStats{}, false, nil
 	}
 	e.syncMu.Lock()
+	defer e.notifyStartupReconciled()
 	// Defers run LIFO: Unlock runs before emit.
 	defer func() {
 		if stats.Synced > 0 {
@@ -2263,10 +2923,11 @@ func (e *Engine) RunStartupSyncFallback(
 	}()
 	defer e.syncMu.Unlock()
 	defer e.clearCurrentProgress()
+	defer func() { e.recordStartupReconciled(ctx, stats, err) }()
 
-	if e.startupMaintenanceReady != nil {
+	if e.startupReconciledReady != nil {
 		select {
-		case <-e.startupMaintenanceReady:
+		case <-e.startupReconciledReady:
 			return SyncStats{}, false, nil
 		default:
 		}
@@ -2294,6 +2955,24 @@ func (e *Engine) RunExclusive(work func() error) error {
 	return work()
 }
 
+// RunExclusiveFlushed runs work while holding the exclusive sync lock, after
+// flushing deferred signal recomputes inline. It is the push half of
+// SyncThenRun for daemon push routes whose sync or resync already ran through
+// the worker-backed pass: work scans and pushes SQLite rows, so pending
+// recomputes must land first or pushed sessions could carry stale
+// signal/secret fields.
+func (e *Engine) RunExclusiveFlushed(work func() error) error {
+	if e.refuseWriteInForceParse("RunExclusiveFlushed") {
+		return errors.New(
+			"RunExclusiveFlushed refused on report-only parse-diff engine",
+		)
+	}
+	e.syncMu.Lock()
+	defer e.syncMu.Unlock()
+	e.signalSched.flushAllInline()
+	return work()
+}
+
 // SyncAll discovers and syncs all session files from all agents.
 func (e *Engine) SyncAll(
 	ctx context.Context, onProgress ProgressFunc,
@@ -2302,6 +2981,7 @@ func (e *Engine) SyncAll(
 		return SyncStats{}
 	}
 	e.syncMu.Lock()
+	defer e.notifyStartupReconciled()
 	// Defers run LIFO: Unlock runs before the emit closure so
 	// Emitter implementations cannot widen the syncMu critical
 	// section or deadlock by re-entering sync code.
@@ -2312,37 +2992,1314 @@ func (e *Engine) SyncAll(
 	}()
 	defer e.syncMu.Unlock()
 	defer e.clearCurrentProgress()
+	defer func() { e.recordStartupReconciled(ctx, stats, ctx.Err()) }()
 	stats = e.syncAllLocked(
 		ctx, onProgress, time.Time{}, nil, syncWriteDefault, true, false,
 	)
 	return
 }
 
-// SyncAllAfterWatcherOverflow performs a full discovery pass after the watcher
-// coalesced too many distinct paths to retain them individually. A routine
-// SyncAll is insufficient here: the discarded paths may be the only signal for
-// same-stat rewrites. Clear event-sensitive trust and force every discovered
-// file through its authoritative parse path before rebuilding those caches.
-func (e *Engine) SyncAllAfterWatcherOverflow(
-	ctx context.Context, onProgress ProgressFunc,
-) (stats SyncStats) {
-	if e.refuseWriteInForceParse("SyncAllAfterWatcherOverflow") {
-		return SyncStats{}
+// HasActiveSessionSourceBelow checks only the exact configured agent that owns
+// the rename event's logical watch root.
+func (e *Engine) HasActiveSessionSourceBelow(agent, path string) (bool, error) {
+	return e.db.HasActiveSessionSourceBelow(agent, path)
+}
+
+// ReconcileWatchRoots runs authoritative discovery for a bounded set of watch
+// roots, or every configured source after an overflow or unscoped recovery.
+// A failed or incomplete discovery is returned to the watcher so its marker is
+// retained and retried rather than acknowledged prematurely.
+func (e *Engine) ReconcileWatchRoots(
+	ctx context.Context, roots []string, full bool,
+) error {
+	return e.reconcileWatchRoots(ctx, roots, full, false)
+}
+
+// ReconcileWatchRootsWithStats is ReconcileWatchRoots plus the pass outcome:
+// the archive-audit worker uses it so synced and tombstoned counts reach the
+// daemon through the worker protocol.
+func (e *Engine) ReconcileWatchRootsWithStats(
+	ctx context.Context, roots []string, full bool,
+) (SyncStats, int, error) {
+	return e.reconcileScopedWatchRoots(ctx, "", roots, full, false)
+}
+
+func (e *Engine) reconcileWatchRoots(
+	ctx context.Context, roots []string, full, force bool,
+) error {
+	_, _, err := e.reconcileScopedWatchRoots(ctx, "", roots, full, force)
+	return err
+}
+
+// ReconcileProviderRoots reconciles the given roots for a single provider. It
+// bypasses the cross-provider expansion in logicalRootsForWatchRoots and
+// restricts both discovery and deletion to that provider, so a shallow-watched
+// agent's scheduled pass never enumerates or tombstones another agent's
+// sessions under an overlapping root.
+func (e *Engine) ReconcileProviderRoots(
+	ctx context.Context, agent parser.AgentType, roots []string,
+) error {
+	if agent == "" {
+		return e.reconcileWatchRoots(ctx, roots, false, false)
+	}
+	_, _, err := e.reconcileScopedWatchRoots(ctx, agent, roots, false, false)
+	return err
+}
+
+func (e *Engine) reconcileScopedWatchRoots(
+	ctx context.Context, agent parser.AgentType, roots []string, full, force bool,
+) (SyncStats, int, error) {
+	var logicalRoots []string
+	var excludedRemoteRoots int
+	if agent == "" {
+		logicalRoots, excludedRemoteRoots = e.localReconciliationRoots(roots, full)
+	} else {
+		logicalRoots, excludedRemoteRoots = e.agentReconciliationRoots(agent, roots)
+	}
+	if !full && len(roots) > 0 && len(logicalRoots) == 0 && excludedRemoteRoots > 0 {
+		e.setLastReconciliationResult(ReconciliationResult{
+			Complete: true,
+			Metrics:  ReconciliationMetrics{ExcludedRemoteRoots: excludedRemoteRoots},
+		})
+		return SyncStats{}, 0, nil
+	}
+	stats, metrics, tombstoned, err := e.reconcileWatchRootsStreamed(
+		ctx, agent, logicalRoots, full, force,
+	)
+	metrics.ExcludedRemoteRoots = excludedRemoteRoots
+	if stats.Synced > 0 || tombstoned > 0 {
+		e.emit("sessions")
+	}
+	complete := err == nil && ctx.Err() == nil && !stats.Aborted &&
+		stats.Failed == 0 && stats.providerFailures == 0
+	if err == nil && !complete {
+		err = errors.New("watch root reconciliation aborted")
+	}
+	e.setLastReconciliationResult(ReconciliationResult{
+		Complete:         complete,
+		Aborted:          !complete,
+		ProviderFailures: stats.providerFailures,
+		Metrics:          metrics,
+	})
+	return stats, tombstoned, err
+}
+
+// ReconcileWatchRootsAfterLostEvents is the watcher-overflow entrypoint. It is
+// separate from ordinary full-scope reconciliation so directory renames do not
+// force unchanged sources through their parse paths.
+func (e *Engine) ReconcileWatchRootsAfterLostEvents(
+	ctx context.Context, roots []string, full bool,
+) error {
+	return e.reconcileWatchRoots(ctx, roots, full, true)
+}
+
+// ReconciliationRootsForAgent returns every configured root for one provider.
+// Directory rename events use the complete provider scope because FSEvents may
+// report only one endpoint of a move between that provider's roots.
+func (e *Engine) ReconciliationRootsForAgent(agent string) []string {
+	return append([]string(nil), e.agentDirs[parser.AgentType(agent)]...)
+}
+
+func (e *Engine) reconcileWatchRootsStreamed(
+	ctx context.Context, agent parser.AgentType, roots []string, full, force bool,
+) (stats SyncStats, metrics ReconciliationMetrics, tombstoned int, retErr error) {
+	if err := ctx.Err(); err != nil {
+		return SyncStats{Aborted: true}, metrics, 0, err
 	}
 	e.syncMu.Lock()
+	defer e.syncMu.Unlock()
+	if force {
+		e.clearWatcherOverflowCaches()
+	}
+	e.phaseStats.Reset()
+	e.anomalies.reset()
+	defer func() { e.anomalies.applyTo(&stats) }()
+	runtimeMetrics := &reconciliationRuntimeMetrics{}
+	ctx = context.WithValue(ctx, reconciliationMetricsContextKey{}, runtimeMetrics)
+	ctx = parser.WithStreamingDiscoveryBufferObserver(ctx, runtimeMetrics.providerBuffered)
+	ctx = parser.WithStreamingRetainedBytesObserver(ctx, runtimeMetrics.providerRetained)
+	ctx = parser.WithSharedContainerScanObserver(ctx, runtimeMetrics.sharedContainerScan)
+	ctx = context.WithValue(ctx, deferGlobalLinkContextKey{}, true)
+	var closeProviderCache func() error
+	ctx, closeProviderCache, err := parser.WithReconciliationCache(ctx)
+	if err != nil {
+		stats.Aborted = true
+		return stats, metrics, 0, err
+	}
 	defer func() {
-		if stats.Synced > 0 {
-			e.emit("sessions")
+		if cleanupErr := closeProviderCache(); cleanupErr != nil {
+			stats.Aborted = true
+			stats.providerFailures++
+			retErr = errors.Join(retErr, cleanupErr)
 		}
 	}()
-	defer e.syncMu.Unlock()
-	defer e.clearCurrentProgress()
+	mergeMetrics := func(spoolMetrics ReconciliationMetrics) ReconciliationMetrics {
+		return runtimeMetrics.snapshot(spoolMetrics)
+	}
 
-	e.clearWatcherOverflowCaches()
-	stats = e.syncAllLocked(
-		ctx, onProgress, time.Time{}, nil, syncWriteDefault, true, true,
+	spool, err := e.reconciliationSpoolFactory(e.db.Path())
+	if err != nil {
+		stats.Aborted = true
+		return stats, metrics, 0, err
+	}
+	cleaned := false
+	defer func() {
+		if !cleaned {
+			_ = spool.CloseAndRemove()
+		}
+	}()
+
+	scope := newRootSyncScope(roots)
+	if full {
+		scope = nil
+	} else if scope != nil {
+		scope.agent = agent
+	}
+	preContainerStates := e.captureSQLiteContainerStates(nil)
+	providers, completedScopes, failedRoots, failures, discoveryErr, err := e.streamReconciliationCandidates(
+		ctx, scope, spool,
 	)
-	return
+	stats.providerFailures = failures
+	if err != nil {
+		stats.Aborted = true
+		metrics = mergeMetrics(spool.Metrics())
+		if cleanupErr := spool.CloseAndRemove(); cleanupErr != nil {
+			err = errors.Join(err, cleanupErr)
+		}
+		cleaned = true
+		return stats, metrics, 0, err
+	}
+	baselineEligibleProviders := make(map[parser.AgentType]struct{}, len(completedScopes))
+	for _, completed := range completedScopes {
+		baselineEligibleProviders[completed.agent] = struct{}{}
+	}
+	e.beginStreamingSQLiteContainerPass(preContainerStates)
+	e.finishStreamingSQLiteContainerDiscovery()
+	defer func() {
+		e.finishSQLiteContainerPass(
+			retErr != nil || stats.Aborted || stats.Failed > 0 || stats.providerFailures > 0,
+			scope == nil,
+		)
+	}()
+
+	var verifiedPass uint64
+	if scope == nil && e.pathRewriter == nil {
+		verifiedPass = e.beginVerifiedSourcePass()
+		defer func() {
+			e.finishVerifiedSourcePass(
+				verifiedPass,
+				retErr == nil && !stats.Aborted && stats.providerFailures == 0,
+			)
+		}()
+	}
+	var cursor reconciliationCursor
+	for {
+		if err := ctx.Err(); err != nil {
+			stats.Aborted = true
+			retErr = err
+			break
+		}
+		page, err := spool.Page(ctx, cursor, reconciliationPageSize)
+		if err != nil {
+			stats.Aborted = true
+			retErr = err
+			break
+		}
+		if len(page) == 0 {
+			break
+		}
+		for _, candidate := range page {
+			e.noteSQLiteContainerDiscovery(parser.DiscoveredFile{
+				Agent: candidate.Provider,
+				Path:  candidate.Path,
+			})
+		}
+		files, err := e.rehydrateReconciliationPage(ctx, page, providers, force)
+		if err != nil {
+			stats.Aborted = ctx.Err() != nil
+			stats.providerFailures++
+			retErr = err
+			break
+		}
+		runtimeMetrics.rehydrated(len(files))
+		if verifiedPass != 0 {
+			e.markVerifiedDiscoveredSources(files)
+		}
+		baselineTracker := newReconciliationBaselineTracker()
+		pageCtx := context.WithValue(
+			ctx, reconciliationBaselineContextKey{}, baselineTracker,
+		)
+		pageStats := e.collectAndBatch(
+			pageCtx, e.startWorkers(pageCtx, files), len(files), len(files), nil,
+			syncWriteDefault,
+		)
+		mergeReconciliationSyncStats(&stats, pageStats)
+		if pageStats.Aborted || pageStats.Failed > 0 {
+			stats.Aborted = true
+			retErr = fmt.Errorf(
+				"watch root reconciliation failed processing page: %d failures",
+				pageStats.Failed,
+			)
+			break
+		}
+		baselineCandidates, baselineAdmitted := eligibleReconciliationBaselines(
+			page, baselineTracker.list(), baselineEligibleProviders,
+		)
+		if err := e.baselineReconciliationCandidates(
+			ctx, baselineCandidates, baselineAdmitted,
+		); err != nil {
+			stats.RecordFailed()
+			stats.Aborted = true
+			retErr = err
+			break
+		}
+		cursor = page[len(page)-1].Cursor()
+	}
+
+	// Page writes committed cleanly when the paging loop finished without an
+	// error or a failed write; provider discovery failures are layered on
+	// below and must not suppress work that only depends on committed writes.
+	if retErr == nil && stats.Failed == 0 && !stats.Aborted {
+		// Batch-level linking was deferred to this global pass, so run it
+		// whenever the committed page writes succeeded — including partial
+		// provider failures. Sessions from healthy providers are already in
+		// the archive, and a permanently failing unrelated provider must not
+		// leave their subagent relationships missing indefinitely. Linking
+		// runs before the incomplete-reconciliation error is built: a
+		// linking failure blocks the completed scopes' tombstoning below, so
+		// those scopes must join the retry roots rather than staying stale.
+		if err := e.linkSubagentSessions(ctx); err != nil {
+			stats.RecordFailed()
+			stats.Aborted = true
+			retErr = fmt.Errorf(
+				"link subagent sessions after reconciliation: %w", err,
+			)
+		}
+	}
+	canTombstoneCompletedScopes := retErr == nil && failures > 0
+	if failures > 0 {
+		retryRoots := append([]string(nil), failedRoots...)
+		if retErr != nil {
+			for _, completed := range completedScopes {
+				retryRoots = append(retryRoots, completed.roots...)
+			}
+			slices.Sort(retryRoots)
+			retryRoots = slices.Compact(retryRoots)
+		}
+		incomplete := &incompleteReconciliationError{
+			failures:  failures,
+			roots:     retryRoots,
+			completed: completedScopes,
+			cause:     discoveryErr,
+		}
+		if retErr == nil {
+			retErr = incomplete
+		} else {
+			retErr = errors.Join(incomplete, retErr)
+		}
+	}
+	if retErr == nil && stats.Failed > 0 {
+		stats.Aborted = true
+		retErr = fmt.Errorf(
+			"watch root reconciliation failed: %d source or archive failures",
+			stats.Failed,
+		)
+	}
+	if retErr == nil {
+		e.persistSkipCache()
+		e.mu.Lock()
+		e.lastSync = time.Now()
+		e.lastSyncStats = stats
+		e.mu.Unlock()
+	}
+	if retErr == nil && ctx.Err() == nil && !stats.Aborted &&
+		stats.Failed == 0 && stats.providerFailures == 0 {
+		tombstoned, retErr = e.tombstoneMissingWatchSourcesForAgentLocked(
+			ctx, roots, agent, spool,
+		)
+	} else if canTombstoneCompletedScopes && ctx.Err() == nil &&
+		!stats.Aborted && stats.Failed == 0 {
+		var incomplete *incompleteReconciliationError
+		if errors.As(retErr, &incomplete) && len(incomplete.completed) > 0 {
+			tombstoned, retErr = e.tombstoneCompletedReconciliationScopesLocked(
+				ctx, spool, incomplete,
+			)
+		}
+	}
+	metrics = mergeMetrics(spool.Metrics())
+	if cleanupErr := spool.CloseAndRemove(); cleanupErr != nil {
+		stats.Aborted = true
+		retErr = errors.Join(retErr, cleanupErr)
+	}
+	cleaned = true
+	return stats, metrics, tombstoned, retErr
+}
+
+func (e *Engine) tombstoneCompletedReconciliationScopesLocked(
+	ctx context.Context,
+	spool reconciliationSpoolStore,
+	incomplete *incompleteReconciliationError,
+) (deleted int, retErr error) {
+	for _, scope := range incomplete.completed {
+		count, err := e.tombstoneMissingWatchSourcesForAgentLocked(
+			ctx, scope.roots, scope.agent, spool,
+		)
+		deleted += count
+		if err == nil {
+			continue
+		}
+		retryRoots := append([]string(nil), incomplete.roots...)
+		for _, completed := range incomplete.completed {
+			retryRoots = append(retryRoots, completed.roots...)
+		}
+		slices.Sort(retryRoots)
+		retryRoots = slices.Compact(retryRoots)
+		return deleted, &incompleteReconciliationError{
+			failures: incomplete.failures,
+			roots:    retryRoots,
+			cause:    errors.Join(incomplete, err),
+		}
+	}
+	return deleted, incomplete
+}
+
+func (e *Engine) baselineReconciliationCandidates(
+	ctx context.Context,
+	candidates []reconciliationCandidate,
+	admitted []db.SessionSourcePath,
+) error {
+	sources := make([]db.SessionSourcePath, 0, len(candidates))
+	for _, candidate := range candidates {
+		sources = append(sources, db.SessionSourcePath{
+			Agent:    string(candidate.Provider),
+			FilePath: e.effectiveSourcePath(candidate.Path),
+		})
+	}
+	if err := e.db.ReplaceActiveSessionSourceBaselines(
+		ctx, e.machine, sources, admitted,
+	); err != nil {
+		return fmt.Errorf("reconcile source baseline page: %w", err)
+	}
+	return nil
+}
+
+func eligibleReconciliationBaselines(
+	candidates []reconciliationCandidate,
+	admitted []db.SessionSourcePath,
+	eligibleProviders map[parser.AgentType]struct{},
+) ([]reconciliationCandidate, []db.SessionSourcePath) {
+	eligibleCandidates := make([]reconciliationCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		if _, eligible := eligibleProviders[candidate.Provider]; !eligible {
+			continue
+		}
+		eligibleCandidates = append(eligibleCandidates, candidate)
+	}
+	eligibleAdmitted := make([]db.SessionSourcePath, 0, len(admitted))
+	for _, source := range admitted {
+		if _, eligible := eligibleProviders[parser.AgentType(source.Agent)]; eligible {
+			eligibleAdmitted = append(eligibleAdmitted, source)
+		}
+	}
+	return eligibleCandidates, eligibleAdmitted
+}
+
+func (e *Engine) streamReconciliationCandidates(
+	ctx context.Context, scope *rootSyncScope, spool reconciliationSpoolStore,
+) (
+	map[parser.AgentType]parser.Provider,
+	[]reconciliationProviderScope,
+	[]string,
+	int,
+	error,
+	error,
+) {
+	providers := make(map[parser.AgentType]parser.Provider)
+	var completedScopes []reconciliationProviderScope
+	var failedRoots []string
+	var failures int
+	var discoveryErr error
+	agents := make([]parser.AgentType, 0, len(e.providerFactories))
+	for agent := range e.providerFactories {
+		agents = append(agents, agent)
+	}
+	slices.SortFunc(agents, func(a, b parser.AgentType) int {
+		return strings.Compare(string(a), string(b))
+	})
+	for _, agent := range agents {
+		if e.providerMigrationModes[agent] != parser.ProviderMigrationProviderAuthoritative {
+			continue
+		}
+		if !scope.matchesAgent(agent) {
+			continue
+		}
+		roots := slices.DeleteFunc(append([]string(nil), e.agentDirs[agent]...), func(root string) bool {
+			return isRemoteReconciliationRoot(root) || !scope.includes(root)
+		})
+		if len(roots) == 0 {
+			continue
+		}
+		factory := e.providerFactories[agent]
+		if factory == nil {
+			continue
+		}
+		provider := factory.NewProvider(parser.ProviderConfig{
+			Roots: roots, Machine: e.machine, PathRewriter: e.pathRewriter,
+		})
+		providers[agent] = provider
+		if provider.Capabilities().Source.StreamingDiscovery != parser.CapabilitySupported {
+			failures++
+			failedRoots = append(failedRoots, roots...)
+			log.Printf("%s provider discovery: streaming discovery unsupported", agent)
+			continue
+		}
+		discoverer, ok := provider.(parser.StreamingDiscoverer)
+		if !ok {
+			failures++
+			failedRoots = append(failedRoots, roots...)
+			continue
+		}
+		watchRoots, err := parser.ResolveWatchRoots(ctx, provider)
+		if err != nil {
+			failures++
+			failedRoots = append(failedRoots, roots...)
+			discoveryErr = errors.Join(discoveryErr, fmt.Errorf(
+				"%s provider watch roots: %w", agent, err,
+			))
+			continue
+		}
+		var spoolErr error
+		err = discoverer.DiscoverEach(ctx, func(source parser.SourceRef) error {
+			candidate, ok := e.reconciliationCandidate(provider, source, roots, watchRoots)
+			if !ok {
+				return nil
+			}
+			spoolErr = spool.Add(ctx, candidate)
+			return spoolErr
+		})
+		if err != nil {
+			if spoolErr != nil {
+				return providers, completedScopes, failedRoots, failures, discoveryErr, spoolErr
+			}
+			if ctx.Err() != nil {
+				return providers, completedScopes, failedRoots, failures, discoveryErr, ctx.Err()
+			}
+			log.Printf("%s provider streaming discovery: %v", agent, err)
+			failures++
+			failedRoots = append(failedRoots, roots...)
+			discoveryErr = errors.Join(discoveryErr, fmt.Errorf(
+				"%s provider streaming discovery: %w", agent, err,
+			))
+			continue
+		}
+		completedScopes = append(completedScopes, reconciliationProviderScope{
+			agent: agent,
+			roots: append([]string(nil), roots...),
+		})
+	}
+	slices.Sort(failedRoots)
+	failedRoots = slices.Compact(failedRoots)
+	return providers, completedScopes, failedRoots, failures, discoveryErr, nil
+}
+
+type reconciliationProviderScope struct {
+	agent parser.AgentType
+	roots []string
+}
+
+type incompleteReconciliationError struct {
+	failures  int
+	roots     []string
+	completed []reconciliationProviderScope
+	cause     error
+}
+
+func (e *incompleteReconciliationError) Error() string {
+	return fmt.Sprintf(
+		"watch root reconciliation incomplete: %d provider discoveries failed",
+		e.failures,
+	)
+}
+
+func (e *incompleteReconciliationError) Unwrap() error { return e.cause }
+
+func (e *incompleteReconciliationError) ReconciliationRetryRoots() []string {
+	return append([]string(nil), e.roots...)
+}
+
+func (e *Engine) reconciliationCandidate(
+	provider parser.Provider, source parser.SourceRef, roots []string,
+	watchRoots []parser.WatchRoot,
+) (reconciliationCandidate, bool) {
+	path := providerDiscoveredPath(source)
+	if path == "" || isRemoteReconciliationRoot(path) {
+		return reconciliationCandidate{}, false
+	}
+	agent := source.Provider
+	if agent == "" {
+		agent = provider.Definition().Type
+	}
+	identity := reconciliationSourceIdentity(agent, source)
+	if identity == "" {
+		return reconciliationCandidate{}, false
+	}
+	root := reconciliationWatchRoot(path, watchRoots, roots)
+	preference1, preference2, preference3 := int64(0), int64(0), int64(0)
+	statPath := validatedProviderSourceStatPath(path)
+	if agent == parser.AgentClaude {
+		if info, err := os.Stat(statPath); err == nil {
+			preference1 = info.Size()
+			preference2 = info.ModTime().UnixNano()
+			fullID := applyIDPrefixToID(e.idPrefix, identity)
+			storedPath := e.db.GetSessionFilePath(fullID)
+			storedSize, storedMtime, stored := e.db.GetSessionFileInfo(fullID)
+			if stored && e.effectiveSourcePath(path) == storedPath &&
+				storedSize == info.Size() && storedMtime == info.ModTime().UnixNano() &&
+				e.db.GetSessionDataVersion(fullID) >= db.CurrentDataVersion() {
+				preference3 = 1
+			}
+		}
+	}
+	if agent == parser.AgentCodex && codexLayoutForPath(path) == parser.CodexLayoutDated {
+		preference1 = 1
+	}
+	if isOpenCodeFormatAgent(agent) {
+		if statPath == path {
+			preference1 = 1
+		}
+	} else if agent != parser.AgentClaude && agent != parser.AgentCodex {
+		for i, configured := range roots {
+			if samePathOrDescendant(statPath, configured) {
+				preference1 = int64(len(roots) - i)
+				break
+			}
+		}
+	}
+	if ranker, ok := provider.(parser.ReconciliationSourceRanker); ok {
+		rank := ranker.ReconciliationSourceRank(source)
+		preference2 = rank.Class
+		preference3 = rank.Recency
+	}
+	if agent == parser.AgentAntigravityCLI {
+		preference2 = boolPreference(strings.HasSuffix(path, ".db"))
+	}
+	return reconciliationCandidate{
+		Provider: agent, Identity: identity, Path: path,
+		StoredPath: canonicalReconciliationSourceIdentity(
+			e.effectiveSourcePath(path),
+		), MemberIdentity: source.ReconciliationIdentity, WatchRoot: root,
+		Project: source.ProjectHint, Preference1: preference1,
+		Preference2: preference2, Preference3: preference3,
+	}, true
+}
+
+func boolPreference(value bool) int64 {
+	if value {
+		return 1
+	}
+	return 0
+}
+
+func reconciliationSourceIdentity(agent parser.AgentType, source parser.SourceRef) string {
+	if agent == parser.AgentClaude {
+		return claudeSessionIDFromPath(providerDiscoveredPath(source))
+	}
+	if isOpenCodeFormatAgent(agent) {
+		path := providerDiscoveredPath(source)
+		if statPath := validatedProviderSourceStatPath(path); statPath != path {
+			_, sessionID, _ := parser.ParseVirtualSourcePath(path)
+			return sessionID
+		}
+		if strings.EqualFold(filepath.Ext(path), ".json") {
+			return strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+		}
+	}
+	for _, candidate := range []string{source.Key, source.FingerprintKey, source.DisplayPath} {
+		if candidate != "" {
+			return canonicalReconciliationSourceIdentity(candidate)
+		}
+	}
+	return ""
+}
+
+func isOpenCodeFormatAgent(agent parser.AgentType) bool {
+	switch agent {
+	case parser.AgentOpenCode, parser.AgentKilo, parser.AgentMiMoCode, parser.AgentIcodemate:
+		return true
+	default:
+		return false
+	}
+}
+
+func reconciliationWatchRoot(
+	path string, watchRoots []parser.WatchRoot, configuredRoots []string,
+) string {
+	statPath := validatedProviderSourceStatPath(path)
+	best := ""
+	for _, root := range watchRoots {
+		if samePathOrDescendant(statPath, root.Path) && len(root.Path) > len(best) {
+			best = root.Path
+		}
+	}
+	if best != "" {
+		return best
+	}
+	for _, root := range configuredRoots {
+		if samePathOrDescendant(statPath, root) && len(root) > len(best) {
+			best = root
+		}
+	}
+	return best
+}
+
+func (e *Engine) rehydrateReconciliationPage(
+	ctx context.Context, page []reconciliationCandidate,
+	providers map[parser.AgentType]parser.Provider, force bool,
+) ([]parser.DiscoveredFile, error) {
+	files := make([]parser.DiscoveredFile, 0, len(page))
+	for _, candidate := range page {
+		provider := providers[candidate.Provider]
+		if provider == nil {
+			return nil, fmt.Errorf("rehydrate %s source: provider unavailable", candidate.Provider)
+		}
+		if resolver, ok := provider.(parser.ReconciliationSourceResolver); ok {
+			source, found, err := resolver.SourceForReconciliation(
+				ctx, candidate.Path, candidate.Project,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("rehydrate %s source %s: %w", candidate.Provider, candidate.Path, err)
+			}
+			if found && reconciliationSourceIdentity(candidate.Provider, source) == candidate.Identity {
+				files = append(files, parser.DiscoveredFile{
+					Path: candidate.Path, Project: source.ProjectHint,
+					Agent: candidate.Provider, ForceParse: force,
+					ProviderSource: &source, ProviderProcess: true,
+				})
+				continue
+			}
+		}
+		sources, err := provider.SourcesForChangedPath(ctx, parser.ChangedPathRequest{
+			Path: candidate.Path, EventKind: "write", WatchRoot: candidate.WatchRoot,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("rehydrate %s source %s: %w", candidate.Provider, candidate.Path, err)
+		}
+		var matched *parser.SourceRef
+		for i := range sources {
+			if reconciliationSourceIdentity(candidate.Provider, sources[i]) == candidate.Identity &&
+				sameReconciliationSourcePath(providerDiscoveredPath(sources[i]), candidate.Path) {
+				matched = &sources[i]
+				break
+			}
+		}
+		if matched == nil {
+			return nil, fmt.Errorf("rehydrate %s source %s: canonical source not found", candidate.Provider, candidate.Path)
+		}
+		source := *matched
+		files = append(files, parser.DiscoveredFile{
+			Path: candidate.Path, Project: source.ProjectHint,
+			Agent: candidate.Provider, ForceParse: force,
+			ProviderSource: &source, ProviderProcess: true,
+		})
+	}
+	return files, nil
+}
+
+func canonicalReconciliationSourceIdentity(value string) string {
+	if _, err := os.Lstat(value); err == nil || !os.IsNotExist(err) {
+		if looksLikeReconciliationPath(value) {
+			return canonicalReconciliationPath(value)
+		}
+		return value
+	}
+	container, member, virtual := parser.ParseVirtualSourcePath(value)
+	if virtual {
+		return canonicalReconciliationPath(container) + "#" + member
+	}
+	if looksLikeReconciliationPath(value) {
+		return canonicalReconciliationPath(value)
+	}
+	return value
+}
+
+// validatedProviderSourceStatPath resolves synthetic member syntax only after
+// an exact physical-path check failed. Callers use it exclusively for paths
+// emitted or reconstructed by a provider, which supplies the validation that a
+// provider-neutral '#' split cannot establish on its own.
+func validatedProviderSourceStatPath(value string) string {
+	if _, err := os.Lstat(value); err == nil || !os.IsNotExist(err) {
+		return value
+	}
+	if container, _, virtual := parser.ParseVirtualSourcePath(value); virtual {
+		return container
+	}
+	return value
+}
+
+func looksLikeReconciliationPath(value string) bool {
+	return filepath.IsAbs(value) || strings.ContainsAny(value, `/\`) || isWindowsPath(value)
+}
+
+func isWindowsPath(value string) bool {
+	return len(value) >= 3 && ((value[0] >= 'A' && value[0] <= 'Z') ||
+		(value[0] >= 'a' && value[0] <= 'z')) && value[1] == ':' &&
+		(value[2] == '\\' || value[2] == '/') || strings.HasPrefix(value, `\\`)
+}
+
+func canonicalReconciliationPath(value string) string {
+	if isWindowsPath(value) {
+		return strings.ToLower(pathpkg.Clean(strings.ReplaceAll(value, `\`, "/")))
+	}
+	return filepath.Clean(value)
+}
+
+func sameReconciliationSourcePath(left, right string) bool {
+	return canonicalReconciliationSourceIdentity(left) ==
+		canonicalReconciliationSourceIdentity(right)
+}
+
+// aggregateOwnedMemberGone reports whether an ownership row whose stored
+// FilePath is a still-present multi-member container has lost its member.
+// Container discovery records the container path itself for every member,
+// so a removed member never trips the missing-path stat; compare the row
+// against the streamed pass's membership instead. The check requires a
+// spool and full provider-root coverage — absence from a partial stream
+// proves nothing — and providers opt in via
+// parser.ReconciliationAggregateMemberResolver.
+func aggregateOwnedMemberGone(
+	ctx context.Context,
+	spool reconciliationSpoolStore,
+	provider parser.Provider,
+	agent parser.AgentType,
+	ownership db.SessionSourceOwnership,
+	allProviderRootsCovered bool,
+) (bool, error) {
+	if spool == nil || provider == nil || !allProviderRootsCovered {
+		return false, nil
+	}
+	resolver, ok := provider.(parser.ReconciliationAggregateMemberResolver)
+	if !ok {
+		return false, nil
+	}
+	memberPaths := resolver.ReconciliationAggregateMemberPaths(
+		ownership.FilePath, ownership.ID,
+	)
+	if len(memberPaths) == 0 {
+		return false, nil
+	}
+	for _, path := range memberPaths {
+		present, err := spool.ContainsSource(
+			ctx, agent, canonicalReconciliationSourceIdentity(path),
+		)
+		if err != nil {
+			return false, fmt.Errorf(
+				"lookup %s aggregate member %s: %w",
+				agent, ownership.FilePath, err,
+			)
+		}
+		if present {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// reconciliationReplacementIdentity is the discovery identity a surviving
+// same-session duplicate of the missing stored path would carry in the
+// reconciliation index. Empty for agents whose stored paths cannot be
+// replaced by a differently-located copy.
+func reconciliationReplacementIdentity(
+	agent parser.AgentType, storedPath string,
+) string {
+	switch agent {
+	case parser.AgentClaude:
+		return claudeSessionIDFromPath(storedPath)
+	case parser.AgentCodex:
+		uuid := parser.CodexSessionUUIDFromFilename(filepath.Base(storedPath))
+		if uuid == "" {
+			return ""
+		}
+		return parser.CodexSourceKey(uuid)
+	default:
+		return ""
+	}
+}
+
+func mergeReconciliationSyncStats(dst *SyncStats, src SyncStats) {
+	dst.TotalSessions += src.TotalSessions
+	dst.Synced += src.Synced
+	dst.Skipped += src.Skipped
+	dst.Failed += src.Failed
+	dst.filesOK += src.filesOK
+	dst.filesDiscovered += src.filesDiscovered
+	dst.nonContainerDiscovered += src.nonContainerDiscovered
+	dst.messagesIndexed += src.messagesIndexed
+	dst.parserExcludedFiles += src.parserExcludedFiles
+	dst.parserExcludedIDs = append(dst.parserExcludedIDs, src.parserExcludedIDs...)
+	dst.cwdFilteredSessions += src.cwdFilteredSessions
+	dst.cwdFilteredFiles += src.cwdFilteredFiles
+	dst.Aborted = dst.Aborted || src.Aborted
+}
+
+func (e *Engine) tombstoneMissingWatchSourcesLocked(
+	ctx context.Context,
+	roots []string,
+	spool reconciliationSpoolStore,
+) (deleted int, retErr error) {
+	return e.tombstoneMissingWatchSourcesForAgentLocked(ctx, roots, "", spool)
+}
+
+func (e *Engine) tombstoneMissingWatchSourcesForAgentLocked(
+	ctx context.Context,
+	roots []string,
+	agentFilter parser.AgentType,
+	spool reconciliationSpoolStore,
+) (deleted int, retErr error) {
+	if e.pathRewriter != nil {
+		// Remote imports rewrite extraction paths to canonical stored paths in
+		// one direction only. Without a stored-to-local inverse, stat and
+		// provider lookup cannot authoritatively prove source loss.
+		return 0, nil
+	}
+	for agent, dirs := range e.agentDirs {
+		if agentFilter != "" && agent != agentFilter {
+			continue
+		}
+		var provider parser.Provider
+		var replacementIndex reconciliationSpoolStore
+		ownsReplacementIndex := false
+		allProviderRootsCovered := reconciliationCoversConfiguredRoots(roots, dirs)
+		if factory := e.providerFactories[agent]; factory != nil {
+			provider = factory.NewProvider(parser.ProviderConfig{
+				Roots: e.agentDirs[agent], Machine: e.machine,
+				PathRewriter: e.pathRewriter,
+			})
+		}
+		for _, root := range roots {
+			if !slices.ContainsFunc(dirs, func(dir string) bool {
+				return samePathOrDescendant(cleanRootPath(dir), cleanRootPath(root)) ||
+					samePathOrDescendant(cleanRootPath(root), cleanRootPath(dir))
+			}) {
+				continue
+			}
+			ownershipScopes := []parser.StoredSourceHintScope{{Path: root}}
+			if resolver, ok := provider.(parser.ReconciliationOwnershipScopeProvider); ok {
+				if resolved := resolver.ReconciliationOwnershipScopes(root); len(resolved) > 0 {
+					ownershipScopes = resolved
+				}
+			}
+			var cursor db.SessionSourceCursor
+			for {
+				if err := ctx.Err(); err != nil {
+					return deleted, err
+				}
+				page, err := e.db.ListActiveSessionSourceOwnershipScopesPage(
+					ctx, e.machine, string(agent),
+					storedSourceDBHintScopes(ownershipScopes), cursor,
+				)
+				if err != nil {
+					return deleted, fmt.Errorf(
+						"list %s watch source ownership: %w", agent, err,
+					)
+				}
+				if len(page) == 0 {
+					break
+				}
+				missingByPath := make(map[string]bool, len(page))
+				for _, ownership := range page {
+					statPath := ownership.FilePath
+					persistentMemberContainerExists := false
+					missing, ok := missingByPath[statPath]
+					if !ok {
+						_, statErr := e.lstatSource(statPath)
+						missing = os.IsNotExist(statErr)
+						missingByPath[statPath] = missing
+					}
+					if !missing {
+						gone, checkErr := aggregateOwnedMemberGone(
+							ctx, spool, provider, agent, ownership,
+							allProviderRootsCovered,
+						)
+						if checkErr != nil {
+							return deleted, checkErr
+						}
+						if !gone {
+							continue
+						}
+						// The container still exists but the streamed pass no
+						// longer yields this member; tombstone directly — the
+						// guards below all assume a vanished stored path.
+						changed, err := e.tombstoneSessionSourceOwnership(
+							ctx, ownership.Machine, ownership.Agent,
+							ownership.ID, ownership.FilePath,
+						)
+						if err != nil {
+							return deleted, fmt.Errorf(
+								"tombstone %s session %s after watch reconciliation: %w",
+								agent, ownership.ID, err,
+							)
+						}
+						if changed {
+							deleted++
+						}
+						continue
+					}
+					// A vanished tracked copy with a surviving same-identity
+					// duplicate is a replacement, not a deletion; the next sync
+					// re-points the session at the survivor. Claude keys
+					// replacements by the session ID in the filename; a Codex
+					// UUID can exist as both a live dated copy and a flat
+					// archived copy sharing one discovery identity. Both resolve
+					// through a bounded per-source index lookup: the streamed
+					// pass's spool when it covers every configured root, else a
+					// lazily built disk-backed index (at most one per pass).
+					replacementIdentity := reconciliationReplacementIdentity(
+						agent, ownership.FilePath,
+					)
+					if replacementIdentity != "" && provider != nil {
+						if replacementIndex == nil {
+							if spool != nil {
+								if !allProviderRootsCovered {
+									// A scoped pass cannot prove that a same-identity
+									// replacement does not exist under another configured root.
+									continue
+								}
+								replacementIndex = spool
+							} else {
+								replacementIndex, err = e.buildReconciliationReplacementIndex(
+									ctx, provider, dirs,
+								)
+								if err != nil {
+									return deleted, fmt.Errorf(
+										"index %s reconciliation replacements: %w", agent, err,
+									)
+								}
+								if agent == parser.AgentCodex {
+									reconciliationRuntimeMetricsFor(ctx).
+										codexReplacementIndexBuild()
+								}
+								ownsReplacementIndex = true
+								defer func() {
+									if ownsReplacementIndex {
+										retErr = errors.Join(
+											retErr, replacementIndex.CloseAndRemove(),
+										)
+									}
+								}()
+							}
+						}
+						replacement, found, lookupErr := replacementIndex.Candidate(
+							ctx, agent, replacementIdentity,
+						)
+						if lookupErr != nil {
+							return deleted, fmt.Errorf(
+								"lookup %s reconciliation replacement: %w", agent, lookupErr,
+							)
+						}
+						if found && !sameReconciliationSourcePath(
+							replacement.Path, ownership.FilePath,
+						) {
+							continue
+						}
+					}
+					persistentArchive := provider != nil && provider.Capabilities().Source.PersistentArchive == parser.CapabilitySupported
+					if persistentArchive {
+						resolver, ok := provider.(parser.PersistentArchiveSourceResolver)
+						if ok {
+							physicalPath, valid := resolver.PersistentArchiveSource(
+								statPath, ownership.ID,
+							)
+							if valid {
+								if !allProviderRootsCovered {
+									// A scoped pass cannot prove that this member does not
+									// exist in a persistent container under another root.
+									continue
+								}
+								if _, statErr := e.lstatSource(physicalPath); statErr != nil {
+									// A vanished or unreadable persistent container cannot
+									// authoritatively prove that an archived member was deleted.
+									continue
+								}
+								if spool == nil {
+									continue
+								}
+								present, lookupErr := spool.ContainsSource(
+									ctx, agent,
+									canonicalReconciliationSourceIdentity(ownership.FilePath),
+								)
+								if lookupErr != nil {
+									return deleted, fmt.Errorf(
+										"lookup %s persistent member %s: %w",
+										agent, ownership.FilePath, lookupErr,
+									)
+								}
+								if present {
+									continue
+								}
+								persistentMemberContainerExists = true
+							}
+						}
+					} else if resolver, ok := provider.(parser.ReconciliationSourceResolver); ok {
+						source, found, err := resolver.SourceForReconciliation(
+							ctx, statPath, "",
+						)
+						if err != nil {
+							return deleted, fmt.Errorf(
+								"validate %s source %s during watch reconciliation: %w",
+								agent, statPath, err,
+							)
+						}
+						if found {
+							_, _, virtual := parser.ParseVirtualSourcePath(
+								providerDiscoveredPath(source),
+							)
+							if virtual && !allProviderRootsCovered {
+								// A scoped pass cannot prove that the same logical
+								// member did not move to another configured root.
+								continue
+							}
+							if spool == nil || !virtual {
+								continue
+							}
+							identity := ""
+							identityResolver, resolvesIdentity := provider.(parser.ReconciliationMemberIdentityResolver)
+							if resolvesIdentity {
+								identity = identityResolver.ReconciliationMemberIdentity(
+									ownership.ID,
+								)
+							}
+							present, lookupErr := spool.ContainsSourceIdentity(
+								ctx, agent,
+								canonicalReconciliationSourceIdentity(ownership.FilePath),
+								identity,
+							)
+							if lookupErr != nil {
+								return deleted, fmt.Errorf(
+									"lookup %s virtual member %s: %w",
+									agent, ownership.FilePath, lookupErr,
+								)
+							}
+							if present {
+								continue
+							}
+						}
+					}
+					if !persistentMemberContainerExists {
+						missing, ok = missingByPath[statPath]
+						if !ok {
+							_, statErr := e.lstatSource(statPath)
+							missing = os.IsNotExist(statErr)
+							missingByPath[statPath] = missing
+						}
+						if !missing {
+							continue
+						}
+					}
+					changed, err := e.tombstoneSessionSourceOwnership(
+						ctx, ownership.Machine, ownership.Agent,
+						ownership.ID, ownership.FilePath,
+					)
+					if err != nil {
+						return deleted, fmt.Errorf(
+							"tombstone %s session %s after watch reconciliation: %w",
+							agent, ownership.ID, err,
+						)
+					}
+					if changed {
+						deleted++
+					}
+				}
+				cursor = page[len(page)-1].Cursor()
+				if len(page) < db.WatchReconcileSourcePageSize {
+					break
+				}
+			}
+		}
+	}
+	return deleted, nil
+}
+
+func (e *Engine) tombstoneSessionSourceOwnership(
+	ctx context.Context, machine, agent, id, filePath string,
+) (bool, error) {
+	// Clear durable freshness state first. If this fails, leave the session
+	// active so a later reconciliation can retry the cache invalidation and
+	// tombstone as one recoverable operation.
+	if _, err := e.clearSkipPersistent(filePath); err != nil {
+		return false, fmt.Errorf("clear source skip cache: %w", err)
+	}
+	changed, err := e.db.SoftDeleteSessionSourceOwnership(
+		ctx, machine, agent, id, filePath,
+	)
+	if err != nil || !changed {
+		return changed, err
+	}
+	// The skip family was removed before the database transition. Drop the
+	// remaining source trust so a byte-identical return is reverified and can
+	// revive the tombstoned row.
+	e.invalidateVerifiedSource(filePath)
+	return true, nil
+}
+
+func reconciliationCoversConfiguredRoots(requested, configured []string) bool {
+	for _, configuredRoot := range configured {
+		if isRemoteReconciliationRoot(configuredRoot) ||
+			!slices.ContainsFunc(requested, func(requestedRoot string) bool {
+				return samePathOrDescendant(
+					cleanRootPath(configuredRoot), cleanRootPath(requestedRoot),
+				)
+			}) {
+			return false
+		}
+	}
+	return true
+}
+
+func (e *Engine) buildReconciliationReplacementIndex(
+	ctx context.Context, provider parser.Provider, configuredRoots []string,
+) (result reconciliationSpoolStore, retErr error) {
+	discoverer, ok := provider.(parser.StreamingDiscoverer)
+	if !ok || provider.Capabilities().Source.StreamingDiscovery != parser.CapabilitySupported {
+		return nil, errors.New("provider does not support streaming discovery")
+	}
+	watchRoots, err := parser.ResolveWatchRoots(ctx, provider)
+	if err != nil {
+		return nil, err
+	}
+	spool, err := e.reconciliationSpoolFactory(e.db.Path())
+	if err != nil {
+		return nil, err
+	}
+	keep := false
+	defer func() {
+		if !keep {
+			retErr = errors.Join(retErr, spool.CloseAndRemove())
+		}
+	}()
+	err = discoverer.DiscoverEach(ctx, func(source parser.SourceRef) error {
+		candidate, admitted := e.reconciliationCandidate(
+			provider, source, configuredRoots, watchRoots,
+		)
+		if !admitted {
+			return nil
+		}
+		return spool.Add(ctx, candidate)
+	})
+	if err != nil {
+		return nil, err
+	}
+	keep = true
+	return spool, nil
+}
+
+func (e *Engine) lstatSource(path string) (os.FileInfo, error) {
+	if e.lstat != nil {
+		return e.lstat(path)
+	}
+	return os.Lstat(path)
+}
+
+func (e *Engine) logicalRootsForWatchRoots(roots []string) []string {
+	var logical []string
+	for _, root := range roots {
+		cleanedRoot := cleanRootPath(root)
+		matched := false
+		for _, dirs := range e.agentDirs {
+			for _, dir := range dirs {
+				cleanedDir := cleanRootPath(dir)
+				if !samePathOrDescendant(cleanedRoot, cleanedDir) &&
+					!samePathOrDescendant(cleanedDir, cleanedRoot) {
+					continue
+				}
+				if !slices.Contains(logical, cleanedDir) {
+					logical = append(logical, cleanedDir)
+				}
+				matched = true
+			}
+		}
+		if !matched && !slices.Contains(logical, cleanedRoot) {
+			logical = append(logical, cleanedRoot)
+		}
+	}
+	return logical
+}
+
+// logicalRootsForAgentWatchRoots resolves the given roots against one agent's
+// configured dirs only. Unlike logicalRootsForWatchRoots it never crosses into
+// another provider's dirs, so an overlapping ancestor root cannot drag other
+// providers into a scoped reconciliation.
+func (e *Engine) logicalRootsForAgentWatchRoots(
+	agent parser.AgentType, roots []string,
+) []string {
+	dirs := e.agentDirs[agent]
+	var logical []string
+	for _, root := range roots {
+		cleanedRoot := cleanRootPath(root)
+		matched := false
+		for _, dir := range dirs {
+			cleanedDir := cleanRootPath(dir)
+			if !samePathOrDescendant(cleanedRoot, cleanedDir) &&
+				!samePathOrDescendant(cleanedDir, cleanedRoot) {
+				continue
+			}
+			if !slices.Contains(logical, cleanedDir) {
+				logical = append(logical, cleanedDir)
+			}
+			matched = true
+		}
+		if !matched && !slices.Contains(logical, cleanedRoot) {
+			logical = append(logical, cleanedRoot)
+		}
+	}
+	return logical
+}
+
+// agentReconciliationRoots restricts the requested roots to a single agent's
+// configured dirs and excludes remote object roots, mirroring
+// localReconciliationRoots but without the cross-provider expansion.
+func (e *Engine) agentReconciliationRoots(
+	agent parser.AgentType, roots []string,
+) ([]string, int) {
+	local := make([]string, 0, len(roots))
+	remote := 0
+	for _, root := range roots {
+		if isRemoteReconciliationRoot(root) {
+			remote++
+			continue
+		}
+		local = append(local, root)
+	}
+	return e.logicalRootsForAgentWatchRoots(agent, local), remote
+}
+
+// localReconciliationRoots expands a full watcher recovery to every configured
+// local root before tombstoning. Remote object roots are owned by the remote
+// sync path: local reconciliation neither enumerates nor tombstones them, and
+// reports the exclusion explicitly in its result metrics.
+func (e *Engine) localReconciliationRoots(
+	roots []string, full bool,
+) ([]string, int) {
+	requested := append([]string(nil), roots...)
+	if full {
+		requested = requested[:0]
+		for _, dirs := range e.agentDirs {
+			requested = append(requested, dirs...)
+		}
+	}
+	local := make([]string, 0, len(requested))
+	remote := make(map[string]struct{})
+	for _, root := range requested {
+		if isRemoteReconciliationRoot(root) {
+			remote[root] = struct{}{}
+			continue
+		}
+		local = append(local, root)
+	}
+	return e.logicalRootsForWatchRoots(local), len(remote)
+}
+
+func isRemoteReconciliationRoot(root string) bool {
+	return strings.HasPrefix(strings.ToLower(root), "s3://")
 }
 
 // SyncAllSince syncs only files whose mtime is at or after
@@ -2399,6 +4356,10 @@ func (e *Engine) SyncRootsSince(
 
 type rootSyncScope struct {
 	roots []string
+	// agent, when non-empty, restricts discovery to a single provider so a
+	// scoped reconciliation cannot drag other providers into the pass through
+	// ancestor/descendant root overlap. Zero value matches every agent.
+	agent parser.AgentType
 }
 
 func newRootSyncScope(roots []string) *rootSyncScope {
@@ -2441,6 +4402,16 @@ func (s *rootSyncScope) includesAny(dirs []string) bool {
 	return slices.ContainsFunc(dirs, s.includes)
 }
 
+// matchesAgent reports whether the given provider is in scope. An unscoped
+// scope (nil) or one without an agent filter matches every provider; an
+// agent-filtered scope matches only that provider.
+func (s *rootSyncScope) matchesAgent(agent parser.AgentType) bool {
+	if s == nil || s.agent == "" {
+		return true
+	}
+	return s.agent == agent
+}
+
 func cleanRootPath(path string) string {
 	cleaned := filepath.Clean(path)
 	abs, err := filepath.Abs(cleaned)
@@ -2480,6 +4451,14 @@ func (e *Engine) syncAllLocked(
 	// Fold the per-run anomaly accumulator into the returned stats on
 	// every exit path so the CLI sync summary can surface them.
 	defer func() { e.anomalies.applyTo(&stats) }()
+
+	// A whole-archive pass (resync rebuild, full/initial sync, remote
+	// import) is bulk work: it parses at full parallelism and frees its
+	// retained memory once at the end. Cutoff- or root-scoped passes are
+	// steady-state daemon churn and keep the bounded retention budget.
+	if writeMode == syncWriteBulk || (since.IsZero() && scope == nil) {
+		defer e.beginBulkRetentionPass()()
+	}
 
 	t0 := time.Now()
 
@@ -2581,13 +4560,6 @@ func (e *Engine) syncAllLocked(
 	)
 
 	progressTotal := len(all)
-	tDBCount := time.Now()
-	dbBackedCount := e.countDBBackedSessions(ctx, scope)
-	progressTotal += dbBackedCount
-	log.Printf(
-		"counted %d db-backed sessions in %s",
-		dbBackedCount, time.Since(tDBCount).Round(time.Millisecond),
-	)
 	e.reportProgress(onProgress, Progress{
 		Phase:         PhaseSyncing,
 		SessionsTotal: progressTotal,
@@ -2605,6 +4577,7 @@ func (e *Engine) syncAllLocked(
 	stats = e.collectAndBatch(
 		ctx, results, len(all), progressTotal, onProgress, writeMode,
 	)
+	stats.providerFailures = providerFailures
 	for range providerFailures {
 		stats.RecordFailed()
 	}
@@ -2650,14 +4623,14 @@ func (e *Engine) syncAllLocked(
 		MessagesIndexed: stats.messagesIndexed,
 	}
 
-	advanceDBProgress := func(total int, pending []pendingWrite) {
+	advanceDBProgress := func(total, indexedMessages int) {
 		if total == 0 {
 			return
 		}
+		progressTotal += total
+		dbProgress.SessionsTotal = progressTotal
 		dbProgress.SessionsDone += total
-		for _, pw := range pending {
-			dbProgress.MessagesIndexed += len(pw.msgs)
-		}
+		dbProgress.MessagesIndexed += indexedMessages
 		stats.messagesIndexed = dbProgress.MessagesIndexed
 		e.reportProgress(onProgress, dbProgress)
 	}
@@ -2711,7 +4684,6 @@ func (e *Engine) syncAllLocked(
 			return stats
 		}
 	}
-
 	// Link subagent child sessions to their parents after all DB-backed
 	// agent writes (including provider-authoritative Forge, Piebald, and ZCode).
 	// LinkSubagentSessions is idempotent — its WHERE filter and partial index
@@ -2749,7 +4721,7 @@ func (e *Engine) syncAllLocked(
 	e.lastSyncStats = persisted
 	e.mu.Unlock()
 
-	if recordSyncState && providerFailures == 0 {
+	if recordSyncState && stats.providerFailures == 0 {
 		e.recordSyncFinished()
 	}
 	// Emission happens in SyncAll / SyncAllSince after syncMu is
@@ -2786,6 +4758,9 @@ func (e *Engine) discoverProviderSources(
 		if mode != parser.ProviderMigrationProviderAuthoritative {
 			continue
 		}
+		if !scope.matchesAgent(agentType) {
+			continue
+		}
 		roots := e.agentDirs[agentType]
 		if len(roots) == 0 {
 			continue
@@ -2807,6 +4782,12 @@ func (e *Engine) discoverProviderSources(
 			Roots:   filteredRoots,
 			Machine: e.machine,
 		})
+		// Shared-database providers are streamed source-by-source by their
+		// dedicated sync phase. Calling Discover here would build an archive-sized
+		// slice only to discard it, then traverse the same database again.
+		if processFileUsesProvider(agentType) {
+			continue
+		}
 		tDiscover := time.Now()
 		sources, err := provider.Discover(ctx)
 		// Log only providers whose discovery is slow enough to matter, so a
@@ -2823,29 +4804,21 @@ func (e *Engine) discoverProviderSources(
 			failures++
 			continue
 		}
-		currentSources := providerSourcePathSet(sources)
-		forceParseSources := map[string]struct{}{}
+		forceParseSource := func(string) bool { return false }
 		if agentType == parser.AgentVSCopilot {
-			missingSources, forceSources :=
+			// Only Visual Studio Copilot recovery consumes the discovered
+			// path set; building it for every provider would allocate an
+			// archive-sized map per full discovery.
+			currentSources := providerSourcePathSet(sources)
+			missingSources, forceParseSources :=
 				e.visualStudioCopilotMissingVS2026PollSources(
 					ctx, provider, filteredRoots, currentSources,
 				)
 			sources = append(sources, missingSources...)
-			maps.Copy(forceParseSources, forceSources)
-		}
-		forceParseSource := func(sourcePath string) bool {
-			_, ok := forceParseSources[filepath.Clean(sourcePath)]
-			return ok
-		}
-		// Forge, Piebald, Warp, and ZCode are DB-backed providers: a shared SQLite
-		// DB hosts every session. Full-sync change detection and counting
-		// run through their dedicated provider-driven DB sync phase
-		// (syncProviderDBBacked), not the per-source discovery list, so a
-		// full sync re-counts only changed sessions exactly as the legacy
-		// path did. The watcher path still classifies their changes through
-		// classifyProviderChangedPath.
-		if processFileUsesProvider(agentType) {
-			continue
+			forceParseSource = func(sourcePath string) bool {
+				_, ok := forceParseSources[filepath.Clean(sourcePath)]
+				return ok
+			}
 		}
 		def := provider.Definition()
 		for _, source := range sources {
@@ -2910,13 +4883,19 @@ func (e *Engine) visualStudioCopilotMissingVS2026PollSources(
 	roots []string,
 	currentSources map[string]struct{},
 ) ([]parser.SourceRef, map[string]struct{}) {
-	watchRoots := providerChangedPathWatchRoots(ctx, provider, roots)
 	var out []parser.SourceRef
 	seenHints := make(map[string]struct{})
 	forceParseSources := make(map[string]struct{})
+	watchRoots, err := e.providerChangedPathWatchRoots(
+		ctx, parser.AgentVSCopilot, provider, roots,
+	)
+	if err != nil {
+		log.Printf("%s provider poll watch roots: %v", parser.AgentVSCopilot, err)
+		return out, forceParseSources
+	}
 	for _, watchRoot := range watchRoots {
 		hints, err := e.db.ListStoredSourcePathHints(
-			string(parser.AgentVSCopilot), []string{watchRoot},
+			string(parser.AgentVSCopilot), []db.StoredSourcePathHintScope{{Path: watchRoot}},
 		)
 		if err != nil {
 			log.Printf(
@@ -3681,76 +5660,15 @@ func shelleyDBCompositeMtime(dbPath string) (int64, error) {
 	return maxMtime, nil
 }
 
-func (e *Engine) countDBBackedProgressTotal(
-	agent parser.AgentType, scope *rootSyncScope,
-) int {
-	if processFileUsesProvider(agent) {
-		return e.countProviderDBBackedSessions(
-			context.Background(), agent, scope,
-		)
-	}
-	return 0
-}
-
-// countProviderDBBackedSessions counts every session a DB-backed provider
-// (Forge, Piebald, Warp) currently exposes, via provider discovery. It feeds
-// the progress total so the DB-backed family contributes the same fixed count
-// the legacy countOne*Sessions helpers did.
-func (e *Engine) countProviderDBBackedSessions(
-	ctx context.Context, agent parser.AgentType, scope *rootSyncScope,
-) int {
-	roots := make([]string, 0, len(e.agentDirs[agent]))
-	for _, dir := range e.agentDirs[agent] {
-		if dir == "" || !scope.includes(dir) {
-			continue
-		}
-		roots = append(roots, dir)
-	}
-	if len(roots) == 0 {
-		return 0
-	}
-	factory, ok := e.providerFactories[agent]
-	if !ok || factory == nil {
-		return 0
-	}
-	provider := factory.NewProvider(parser.ProviderConfig{
-		Roots:   roots,
-		Machine: e.machine,
-	})
-	sources, err := provider.Discover(ctx)
-	if err != nil {
-		log.Printf("%s provider session count: %v", agent, err)
-		return 0
-	}
-	return len(sources)
-}
-
-func (e *Engine) countDBBackedSessions(
-	ctx context.Context, scope *rootSyncScope,
-) int {
-	if ctx.Err() != nil {
-		return 0
-	}
-	total := 0
-	for _, agent := range []parser.AgentType{
-		parser.AgentWarp,
-		parser.AgentForge,
-		parser.AgentPiebald,
-		parser.AgentZCode,
-	} {
-		total += e.countDBBackedProgressTotal(agent, scope)
-	}
-	return total
-}
-
 // syncProviderDBBacked enumerates a DB-backed provider's sources, parses only
-// the changed ones through the provider facade, and returns their pending
-// writes. Change detection compares the provider fingerprint mtime against the
-// stored source mtime and requires the stored data version to be current,
-// reproducing the legacy *PendingSessionIDs behavior.
+// the changed ones through the provider facade, and flushes each source before
+// parsing the next. Change detection compares the provider fingerprint mtime
+// against the stored source mtime and requires the stored data version to be
+// current, reproducing the legacy *PendingSessionIDs behavior.
 func (e *Engine) syncProviderDBBacked(
 	ctx context.Context, agent parser.AgentType, scope *rootSyncScope,
-) []pendingWrite {
+	flush func([]pendingWrite) bool,
+) (int, int, error) {
 	roots := make([]string, 0, len(e.agentDirs[agent]))
 	for _, dir := range e.agentDirs[agent] {
 		if dir == "" || !scope.includes(dir) {
@@ -3759,34 +5677,58 @@ func (e *Engine) syncProviderDBBacked(
 		roots = append(roots, dir)
 	}
 	if len(roots) == 0 {
-		return nil
+		return 0, 0, nil
 	}
 	factory, ok := e.providerFactories[agent]
 	if !ok || factory == nil {
-		return nil
+		return 0, 0, nil
 	}
 	provider := factory.NewProvider(parser.ProviderConfig{
 		Roots:   roots,
 		Machine: e.machine,
 	})
-	sources, err := provider.Discover(ctx)
-	if err != nil {
-		log.Printf("sync %s: %v", agent, err)
+	discoverer, ok := provider.(parser.StreamingDiscoverer)
+	if !ok || provider.Capabilities().Source.StreamingDiscovery != parser.CapabilitySupported {
+		return 0, 0, fmt.Errorf("sync %s: provider lacks streaming discovery", agent)
+	}
+	baselines := make([]db.SessionSourcePath, 0, reconciliationPageSize)
+	flushBaselines := func() error {
+		if len(baselines) == 0 {
+			return nil
+		}
+		if err := e.db.BaselineActiveSessionSourcePaths(
+			ctx, e.machine, baselines,
+		); err != nil {
+			return fmt.Errorf("baseline %s streaming sources: %w", agent, err)
+		}
+		baselines = baselines[:0]
+		return nil
+	}
+	queueBaseline := func(source parser.SourceRef) error {
+		path := providerDiscoveredPath(source)
+		if path == "" {
+			return nil
+		}
+		baselines = append(baselines, db.SessionSourcePath{
+			Agent: string(agent), FilePath: e.effectiveSourcePath(path),
+		})
+		if len(baselines) == reconciliationPageSize {
+			return flushBaselines()
+		}
 		return nil
 	}
 
-	var pending []pendingWrite
-	for _, source := range sources {
-		if ctx.Err() != nil {
-			break
-		}
+	discovered, sourceFailures := 0, 0
+	err := discoverer.DiscoverEach(ctx, func(source parser.SourceRef) error {
+		discovered++
 		fingerprint, err := provider.Fingerprint(ctx, source)
 		if err != nil {
 			log.Printf("sync %s fingerprint: %v", agent, err)
-			continue
+			sourceFailures++
+			return nil
 		}
 		if e.providerDBBackedSourceFresh(source, fingerprint) {
-			continue
+			return queueBaseline(source)
 		}
 		outcome, err := provider.Parse(ctx, parser.ParseRequest{
 			Source:      source,
@@ -3795,17 +5737,41 @@ func (e *Engine) syncProviderDBBacked(
 		})
 		if err != nil {
 			log.Printf("sync %s parse: %v", agent, err)
-			continue
+			sourceFailures++
+			return nil
 		}
+		complete := providerOutcomeAllowsCleanSkipCache(outcome)
+		if !complete {
+			sourceFailures++
+		}
+		pending := make([]pendingWrite, 0, len(outcome.Results))
 		for _, result := range outcome.Results {
 			pending = append(pending, pendingWrite{
 				sess:        result.Result.Session,
 				msgs:        result.Result.Messages,
 				usageEvents: result.Result.UsageEvents,
+				needsRetry:  !complete,
 			})
 		}
+		if len(pending) > 0 && !flush(pending) {
+			complete = false
+		}
+		if complete {
+			if err := queueBaseline(source); err != nil {
+				return err
+			}
+		}
+		return ctx.Err()
+	})
+	if err != nil {
+		log.Printf("sync %s: %v", agent, err)
+		return discovered, sourceFailures, err
 	}
-	return pending
+	if err := flushBaselines(); err != nil {
+		log.Printf("sync %s: %v", agent, err)
+		return discovered, sourceFailures, err
+	}
+	return discovered, sourceFailures, nil
 }
 
 // providerDBBackedSourceFresh reports whether a DB-backed provider source is
@@ -3858,55 +5824,93 @@ func (e *Engine) syncProviderDBBackedAgent(
 	ctx context.Context, agent parser.AgentType, label string,
 	writeMode syncWriteMode, verbose bool, scope *rootSyncScope,
 	stats *SyncStats,
-	advanceDBProgress func(total int, pending []pendingWrite),
+	advanceDBProgress func(total, indexedMessages int),
 ) bool {
 	start := time.Now()
-	pending := e.syncProviderDBBacked(ctx, agent, scope)
 	useWorktreeResolver := agent != parser.AgentPiebald
-	if len(pending) > 0 {
-		stats.TotalSessions += len(pending)
+	resolveWorktreeProject := e.loadWorktreeProjectResolver()
+	var pendingCount, indexedMessages, written int
+	var writeDuration time.Duration
+	flush := func(pending []pendingWrite) bool {
+		complete := true
+		pendingCount += len(pending)
+		for _, pw := range pending {
+			indexedMessages += len(pw.msgs)
+		}
 		tWrite := time.Now()
-		var written int
 		if writeMode == syncWriteBulk {
-			var failedWrites, cwdFiltered int
-			written, _, failedWrites, cwdFiltered = e.writeBatch(
-				pending, writeMode, true,
-			)
-			for range failedWrites {
+			var outcome writeBatchOutcome
+			if e.writeBatchOverride != nil {
+				batchWritten, batchMessages, failedWrites, cwdFiltered :=
+					e.writeBatchOverride(pending, writeMode, true)
+				outcome = writeBatchOutcome{
+					writtenSessions: batchWritten,
+					writtenMessages: batchMessages,
+					failedSessions:  failedWrites,
+					cwdFiltered:     cwdFiltered,
+				}
+				complete = failedWrites == 0 && cwdFiltered == 0 &&
+					batchWritten == len(pending)
+			} else {
+				outcome = e.writeBatchWithOutcome(pending, writeMode, true)
+				for _, wasWritten := range outcome.written {
+					if !wasWritten {
+						complete = false
+						break
+					}
+				}
+			}
+			written += outcome.writtenSessions
+			for range outcome.failedSessions {
 				stats.RecordFailed()
 			}
-			stats.cwdFilteredSessions += cwdFiltered
+			stats.cwdFilteredSessions += outcome.cwdFiltered
 		} else {
-			resolveWorktreeProject := e.loadWorktreeProjectResolver()
 			for _, pw := range pending {
 				if ctx.Err() != nil {
+					complete = false
 					break
 				}
 				var err error
 				if useWorktreeResolver {
-					err = e.writeSessionFullWithResolver(
-						pw, resolveWorktreeProject,
-					)
+					err = e.writeSessionFullWithResolver(pw, resolveWorktreeProject)
 				} else {
 					err = e.writeSessionFull(pw)
 				}
 				switch {
 				case err == nil:
 					written++
-				case isIntentionalSessionSkip(err),
-					errors.Is(err, errSessionPreserved):
+				case isIntentionalSessionSkip(err), errors.Is(err, errSessionPreserved):
 					// Intentional skip, not a failure.
+					complete = false
 				default:
+					complete = false
 					stats.RecordFailed()
 				}
 			}
 		}
+		writeDuration += time.Since(tWrite)
+		return complete
+	}
+	discovered, sourceFailures, discoveryErr := e.syncProviderDBBacked(
+		ctx, agent, scope, flush,
+	)
+	stats.providerFailures += sourceFailures
+	for range sourceFailures {
+		stats.RecordFailed()
+	}
+	if discoveryErr != nil {
+		stats.providerFailures++
+		stats.RecordFailed()
+	}
+	if pendingCount > 0 {
+		stats.TotalSessions += pendingCount
 		stats.RecordSynced(written)
 		if verbose {
 			log.Printf(
 				"%s write: %d sessions in %s",
-				label, len(pending),
-				time.Since(tWrite).Round(time.Millisecond),
+				label, pendingCount,
+				writeDuration.Round(time.Millisecond),
 			)
 		}
 	}
@@ -3916,7 +5920,7 @@ func (e *Engine) syncProviderDBBackedAgent(
 			label, time.Since(start).Round(time.Millisecond),
 		)
 	}
-	advanceDBProgress(e.countDBBackedProgressTotal(agent, scope), pending)
+	advanceDBProgress(discovered, indexedMessages)
 	return ctx.Err() != nil
 }
 
@@ -3928,29 +5932,43 @@ func (e *Engine) startWorkers(
 	ctx context.Context,
 	files []parser.DiscoveredFile,
 ) <-chan syncJob {
-	workers := min(max(runtime.NumCPU(), 2), maxWorkers)
-	buffer := max(workers*2, 1)
+	// Cap fan-out and channel buffers by the batch: a single-path
+	// watcher sync needs one worker and one result slot, not a
+	// CPU-scaled pool with page-sized buffers of grown syncJob values.
+	workers := min(e.workerCount(), max(len(files), 1))
+	buffer := min(max(workers*2, 1), max(len(files), 1))
 
 	jobs := make(chan parser.DiscoveredFile, buffer)
 	results := make(chan syncJob, buffer)
+	runtimeMetrics := reconciliationRuntimeMetricsFor(ctx)
+	emitResult := func(result syncJob) {
+		if runtimeMetrics != nil {
+			runtimeMetrics.workerQueued(1)
+		}
+		results <- result
+	}
 
 	var wg gosync.WaitGroup
 	for range workers {
 		wg.Go(func() {
 			for file := range jobs {
 				if ctx.Err() != nil {
-					results <- syncJob{
+					emitResult(syncJob{
 						processResult: processResult{
 							err: ctx.Err(),
 						},
-						path: file.Path,
-					}
+						agent: file.Agent,
+						path:  file.Path,
+					})
 					continue
 				}
-				results <- syncJob{
-					processResult: e.processFile(ctx, file),
-					path:          file.Path,
-				}
+				result := e.processFile(ctx, file)
+				emitResult(syncJob{
+					processResult:  result,
+					agent:          file.Agent,
+					path:           file.Path,
+					retentionLease: result.retentionLease,
+				})
 			}
 		})
 	}
@@ -3964,6 +5982,43 @@ func (e *Engine) startWorkers(
 		close(results)
 	}()
 	return results
+}
+
+func (e *Engine) retentionBudget() *parseRetentionBudget {
+	if active := e.activeRetention.Load(); active != nil {
+		return active
+	}
+	e.parseRetentionOnce.Do(func() {
+		if e.parseRetentionBudget == nil {
+			e.parseRetentionBudget = newParseRetentionBudget(defaultParseRetentionBytes)
+		}
+	})
+	return e.parseRetentionBudget
+}
+
+// beginBulkRetentionPass installs the unthrottled bulk retention budget for
+// the duration of an archive-scale pass and returns the restore func the
+// caller must defer. Bulk passes (full sync, resync rebuild, remote import
+// processing) run at full worker parallelism; the memory they retain is
+// returned to the OS by the end-of-pass scavenge instead of being bounded
+// per source. The caller holds syncMu, so no other pass can observe the
+// switched budget.
+func (e *Engine) beginBulkRetentionPass() func() {
+	e.bulkRetentionOnce.Do(func() {
+		if e.bulkRetentionBudget == nil {
+			e.bulkRetentionBudget = newBulkParseRetentionBudget()
+		}
+	})
+	e.activeRetention.Store(e.bulkRetentionBudget)
+	return func() { e.activeRetention.Store(nil) }
+}
+
+func (e *Engine) workerCount() int {
+	workers := runtime.NumCPU()
+	if e.workerCountOverride > 0 {
+		workers = e.workerCountOverride
+	}
+	return min(max(workers, 2), maxWorkers)
 }
 
 // collectAndBatch drains the results channel, batches
@@ -3989,15 +6044,141 @@ func (e *Engine) collectAndBatch(
 	}
 
 	var pending []pendingWrite
+	var pendingLeases []*parseRetentionLease
+	// Size baseline bookkeeping by the batch, capped at one flush page:
+	// a single-path watcher sync must not pay for page-sized structures
+	// (a 256-entry map of struct keys dominates the per-append B/op).
+	// Appends and map inserts still grow past the hint when providers
+	// fan one changed file out to multiple sessions.
+	baselineHint := min(total, reconciliationPageSize)
+	baselineCandidates := make([]db.SessionSourcePath, 0, baselineHint)
+	baselineAdmitted := make([]db.SessionSourcePath, 0, baselineHint)
+	baselineAdmission := make(map[db.SessionSourcePath]bool, baselineHint)
+	runtimeMetrics := reconciliationRuntimeMetricsFor(ctx)
+	flushBaselineSources := func() {
+		if len(baselineCandidates) == 0 {
+			return
+		}
+		baselineAdmitted = baselineAdmitted[:0]
+		for _, source := range baselineCandidates {
+			if baselineAdmission[source] {
+				baselineAdmitted = append(baselineAdmitted, source)
+			}
+		}
+		// ReplaceActiveSessionSourceBaselines only reads baselineAdmitted
+		// synchronously within this call (db.baselineActiveSessionSourcePathsTx
+		// iterates it while binding statement params); it does not retain the
+		// slice, so reusing the same backing array across flushes is safe.
+		if err := e.db.ReplaceActiveSessionSourceBaselines(
+			ctx, e.machine, baselineCandidates, baselineAdmitted,
+		); err != nil {
+			log.Printf("replace successful non-write source baselines: %v", err)
+			stats.RecordFailed()
+			e.poisonSQLiteContainerPass()
+		}
+		baselineCandidates = baselineCandidates[:0]
+		clear(baselineAdmission)
+	}
+	baselineProcessedSource := func(job syncJob, admitted bool) {
+		source := db.SessionSourcePath{
+			Agent: string(job.agent), FilePath: e.effectiveSourcePath(job.path),
+		}
+		if source.Agent == "" || source.FilePath == "" {
+			return
+		}
+		if tracker := reconciliationBaselineTrackerFor(ctx); tracker != nil {
+			if admitted {
+				tracker.add(source)
+			}
+			return
+		}
+		if runtimeMetrics != nil {
+			return
+		}
+		if previous, duplicate := baselineAdmission[source]; duplicate {
+			baselineAdmission[source] = previous && admitted
+			return
+		}
+		baselineAdmission[source] = admitted
+		baselineCandidates = append(baselineCandidates, source)
+		if len(baselineCandidates) == reconciliationPageSize {
+			flushBaselineSources()
+		}
+	}
+	flushPending := func() {
+		if len(pending) == 0 {
+			return
+		}
+		func() {
+			defer releaseParseRetentionLeases(pendingLeases)
+			var outcome writeBatchOutcome
+			if e.writeBatchOverride != nil {
+				writtenSessions, writtenMessages, failedSessions, cwdFiltered :=
+					e.writeBatchOverride(pending, writeMode, false)
+				outcome = writeBatchOutcome{
+					writtenSessions: writtenSessions,
+					writtenMessages: writtenMessages,
+					failedSessions:  failedSessions,
+					cwdFiltered:     cwdFiltered,
+					written:         make([]bool, len(pending)),
+				}
+				if failedSessions == 0 && cwdFiltered == 0 &&
+					writtenSessions == len(pending) {
+					for i := range outcome.written {
+						outcome.written[i] = true
+					}
+				}
+			} else {
+				outcome = e.writeBatchWithOutcome(pending, writeMode, false)
+			}
+			if err := e.baselinePendingWriteSources(
+				ctx, pending, outcome.written,
+			); err != nil {
+				log.Printf("baseline parsed session sources: %v", err)
+				outcome.failedSessions++
+			}
+			stats.RecordSynced(outcome.writtenSessions)
+			for range outcome.failedSessions {
+				stats.RecordFailed()
+			}
+			if outcome.failedSessions > 0 {
+				e.poisonSQLiteContainerPass()
+			}
+			e.promoteOpenCodeStorageTrustAfterWrite(
+				pending, outcome.writtenSessions, outcome.failedSessions,
+				outcome.cwdFiltered,
+			)
+			stats.cwdFilteredSessions += outcome.cwdFiltered
+			progress.MessagesIndexed += outcome.writtenMessages
+			stats.messagesIndexed = progress.MessagesIndexed
+		}()
+		pending = pending[:0]
+		pendingLeases = pendingLeases[:0]
+	}
 
+	budget := e.retentionBudget()
+	defer budget.scavengeIfNeeded()
 	for i := range total {
 		var r syncJob
-		select {
-		case <-ctx.Done():
-			stats.Aborted = true
-			drainResults(results, total-i)
-			goto flush
-		case r = <-results:
+		for {
+			var pressure <-chan struct{}
+			if len(pending) > 0 {
+				pressure = budget.pressureSignal()
+			}
+			select {
+			case <-ctx.Done():
+				stats.Aborted = true
+				drainResults(results, total-i)
+				goto flush
+			case <-pressure:
+				flushPending()
+				continue
+			case r = <-results:
+				if runtimeMetrics != nil {
+					runtimeMetrics.workerQueued(-1)
+				}
+			}
+			break
 		}
 
 		if r.err != nil {
@@ -4006,6 +6187,7 @@ func (e *Engine) collectAndBatch(
 			// ctx.Done() branch above.
 			if ctx.Err() != nil {
 				stats.Aborted = true
+				r.releaseRetention()
 				drainResults(results, total-i-1)
 				goto flush
 			}
@@ -4015,7 +6197,11 @@ func (e *Engine) collectAndBatch(
 				e.cacheSkip(r.skipCacheKey(), r.mtime, r.sourceFingerprint)
 			}
 			log.Printf("sync error: %v", r.err)
+			r.releaseRetention()
 			continue
+		}
+		for range r.providerFailureCount {
+			stats.RecordFailed()
 		}
 		if r.skip {
 			if r.cacheSkip && r.mtime != 0 && !r.noCacheSkip {
@@ -4023,8 +6209,19 @@ func (e *Engine) collectAndBatch(
 			}
 			stats.RecordSkip()
 			e.noteSQLiteContainerResult(r.path, true)
+			if r.providerFailureCount == 0 {
+				admitted, err := e.skippedSourceAllowsCwdFilter(ctx, r)
+				if err != nil {
+					log.Printf("check skipped source cwd admission: %v", err)
+					stats.RecordFailed()
+					e.poisonSQLiteContainerPass()
+				} else {
+					baselineProcessedSource(r, admitted)
+				}
+			}
 			progress.SessionsDone++
 			e.reportProgress(onProgress, progress)
+			r.releaseRetention()
 			continue
 		}
 		excludedSessionIDs := e.applyIDPrefixToSessionIDs(
@@ -4047,6 +6244,7 @@ func (e *Engine) collectAndBatch(
 				log.Printf("delete parser-excluded sessions: %v", err)
 				stats.RecordFailed()
 				e.noteSQLiteContainerResult(r.path, false)
+				r.releaseRetention()
 				continue
 			}
 			stats.parserExcludedIDs = append(
@@ -4054,8 +6252,40 @@ func (e *Engine) collectAndBatch(
 				excludedSessionIDs...,
 			)
 		}
+		// Virtual members that vanished from a still-existing shared
+		// container are tombstoned with their exact source ownership,
+		// matching the reconciliation audit, instead of hard-deleted.
+		// The cwd-filter freeze applies exactly as it does to parser
+		// exclusions above.
+		if len(r.sourceMissingMembers) > 0 &&
+			e.sourceAllowsParserExclusions(r.processResult) {
+			tombstoneErr := error(nil)
+			for _, member := range r.sourceMissingMembers {
+				changed, err := e.tombstoneSessionSourceOwnership(
+					ctx, e.machine, string(r.agent),
+					member.sessionID, member.filePath,
+				)
+				if err != nil {
+					tombstoneErr = err
+					break
+				}
+				if changed {
+					stats.sourceMissingTombstoned++
+				}
+			}
+			if tombstoneErr != nil {
+				log.Printf(
+					"tombstone source-missing members: %v", tombstoneErr,
+				)
+				stats.RecordFailed()
+				e.noteSQLiteContainerResult(r.path, false)
+				r.releaseRetention()
+				continue
+			}
+		}
 		if len(r.results) == 0 && r.incremental == nil {
-			if len(r.excludedSessionIDs) > 0 {
+			if len(r.excludedSessionIDs) > 0 ||
+				len(r.sourceMissingMembers) > 0 {
 				stats.filesOK++
 				stats.parserExcludedFiles++
 			}
@@ -4063,8 +6293,15 @@ func (e *Engine) collectAndBatch(
 				e.cacheSkip(r.skipCacheKey(), r.mtime, r.sourceFingerprint)
 			}
 			e.noteSQLiteContainerResult(r.path, true)
+			if r.providerFailureCount == 0 &&
+				e.sourceAllowsParserExclusions(r.processResult) {
+				baselineProcessedSource(r, true)
+			} else if r.providerFailureCount == 0 {
+				baselineProcessedSource(r, false)
+			}
 			progress.SessionsDone++
 			e.reportProgress(onProgress, progress)
+			r.releaseRetention()
 			continue
 		}
 		if r.cacheSkip {
@@ -4092,8 +6329,12 @@ func (e *Engine) collectAndBatch(
 		)
 		if vetoed > 0 && len(allowed) == 0 {
 			stats.cwdFilteredFiles++
+			if r.providerFailureCount == 0 {
+				baselineProcessedSource(r, false)
+			}
 			progress.SessionsDone++
 			e.reportProgress(onProgress, progress)
+			r.releaseRetention()
 			continue
 		}
 
@@ -4101,25 +6342,43 @@ func (e *Engine) collectAndBatch(
 			if err := e.writeIncremental(r.incremental); err != nil {
 				log.Printf("%v", err)
 				stats.RecordFailed()
+				r.releaseRetention()
 				continue
 			}
 			stats.RecordSynced(1)
+			if r.providerFailureCount == 0 {
+				baselineProcessedSource(r, true)
+			}
 			progress.MessagesIndexed += len(
 				r.incremental.msgs,
 			)
 			stats.messagesIndexed = progress.MessagesIndexed
+			r.releaseRetention()
 		} else {
 			for _, pr := range allowed {
+				needsRetry := r.providerFailureCount > 0 ||
+					r.needsRetryForSession(pr.Session.ID)
 				pending = append(pending, pendingWrite{
 					sess:              pr.Session,
 					msgs:              pr.Messages,
 					usageEvents:       pr.UsageEvents,
-					needsRetry:        r.needsRetryForSession(pr.Session.ID),
+					needsRetry:        needsRetry,
 					forceReplace:      r.forceReplace,
+					baselineEligible:  vetoed == 0 && r.providerFailureCount == 0 && !needsRetry,
 					storageTrustPath:  r.storageTrustPath,
 					storageTrustState: r.storageTrustState,
 					storageTrustSnap:  r.storageTrustSnap,
 				})
+				if runtimeMetrics != nil {
+					runtimeMetrics.pendingWrites(len(pending))
+				}
+			}
+			if r.retentionLease != nil {
+				pendingLeases = append(pendingLeases, r.retentionLease)
+				r.retentionLease = nil
+			}
+			if len(pending) >= batchSize || budget.underPressure() {
+				flushPending()
 			}
 			// A Kiro SQLite store is discovered as one container source
 			// but fans out into one session per row, so `total` counted it
@@ -4135,55 +6394,22 @@ func (e *Engine) collectAndBatch(
 			}
 		}
 
-		if len(pending) >= batchSize {
-			writtenSessions, writtenMessages, failedWrites, cwdFiltered :=
-				e.writeBatch(pending, writeMode, false)
-			stats.RecordSynced(writtenSessions)
-			for range failedWrites {
-				stats.RecordFailed()
-			}
-			// Batch write failures cannot be attributed to individual
-			// sessions, so they block every container promotion this pass.
-			if failedWrites > 0 {
-				e.poisonSQLiteContainerPass()
-			}
-			e.promoteOpenCodeStorageTrustAfterWrite(
-				pending, writtenSessions, failedWrites, cwdFiltered,
-			)
-			stats.cwdFilteredSessions += cwdFiltered
-			progress.MessagesIndexed += writtenMessages
-			stats.messagesIndexed = progress.MessagesIndexed
-			pending = pending[:0]
-		}
-
 		progress.SessionsDone++
 		e.reportProgress(onProgress, progress)
 	}
 
 flush:
-	if len(pending) > 0 {
-		writtenSessions, writtenMessages, failedWrites, cwdFiltered :=
-			e.writeBatch(pending, writeMode, false)
-		stats.RecordSynced(writtenSessions)
-		for range failedWrites {
-			stats.RecordFailed()
-		}
-		if failedWrites > 0 {
-			e.poisonSQLiteContainerPass()
-		}
-		e.promoteOpenCodeStorageTrustAfterWrite(
-			pending, writtenSessions, failedWrites, cwdFiltered,
-		)
-		stats.cwdFilteredSessions += cwdFiltered
-		progress.MessagesIndexed += writtenMessages
-		stats.messagesIndexed = progress.MessagesIndexed
-	}
+	flushPending()
+	flushBaselineSources()
 
 	// Link subagent child sessions to their parents via
 	// tool_calls.subagent_session_id references. Run once
 	// after all batches to avoid repeated full-table scans.
-	if err := e.db.LinkSubagentSessions(); err != nil {
-		log.Printf("link subagent sessions: %v", err)
+	if deferred, _ := ctx.Value(deferGlobalLinkContextKey{}).(bool); !deferred {
+		if err := e.linkSubagentSessions(ctx); err != nil {
+			log.Printf("link subagent sessions: %v", err)
+			stats.RecordFailed()
+		}
 	}
 
 	// PhaseDone is emitted by syncAllLocked after DB-backed
@@ -4191,11 +6417,121 @@ flush:
 	return stats
 }
 
+func (e *Engine) baselinePendingWriteSources(
+	ctx context.Context, pending []pendingWrite, written []bool,
+) error {
+	eligible := make(
+		map[db.SessionSourcePath]bool,
+		min(len(pending), reconciliationPageSize),
+	)
+	for i, write := range pending {
+		path := e.effectiveSourcePath(write.sess.File.Path)
+		source := db.SessionSourcePath{
+			Agent: string(write.sess.Agent), FilePath: path,
+		}
+		if source.Agent == "" || source.FilePath == "" {
+			continue
+		}
+		if _, seen := eligible[source]; !seen {
+			eligible[source] = true
+		}
+		if !write.baselineEligible || i >= len(written) || !written[i] {
+			eligible[source] = false
+		}
+	}
+
+	candidates := make([]db.SessionSourcePath, 0, len(eligible))
+	admitted := make([]db.SessionSourcePath, 0, len(eligible))
+	tracker := reconciliationBaselineTrackerFor(ctx)
+	for source, ok := range eligible {
+		candidates = append(candidates, source)
+		if !ok {
+			continue
+		}
+		if tracker != nil {
+			tracker.add(source)
+			continue
+		}
+		admitted = append(admitted, source)
+	}
+	if tracker != nil || len(candidates) == 0 {
+		return nil
+	}
+
+	sources := make([]db.SessionSourcePath, 0, reconciliationPageSize)
+	admittedSet := make(map[db.SessionSourcePath]struct{}, len(admitted))
+	for _, source := range admitted {
+		admittedSet[source] = struct{}{}
+	}
+	flush := func() error {
+		if len(sources) == 0 {
+			return nil
+		}
+		pageAdmitted := make([]db.SessionSourcePath, 0, len(sources))
+		for _, source := range sources {
+			if _, ok := admittedSet[source]; ok {
+				pageAdmitted = append(pageAdmitted, source)
+			}
+		}
+		if err := e.db.ReplaceActiveSessionSourceBaselines(
+			ctx, e.machine, sources, pageAdmitted,
+		); err != nil {
+			return fmt.Errorf("replace parsed source baseline batch: %w", err)
+		}
+		sources = sources[:0]
+		return nil
+	}
+	for _, source := range candidates {
+		sources = append(sources, source)
+		if len(sources) == reconciliationPageSize {
+			if err := flush(); err != nil {
+				return err
+			}
+		}
+	}
+	return flush()
+}
+
+// skippedSourceAllowsCwdFilter determines whether an unchanged source may
+// retain deletion proof after a configuration restart. A freshness skip has no
+// parser output to run through sourceAllowsParserExclusions, so use the active
+// archived rows for that exact source as the admission evidence instead.
+func (e *Engine) skippedSourceAllowsCwdFilter(
+	ctx context.Context, job syncJob,
+) (bool, error) {
+	if e.cwdFilter.empty() {
+		return true, nil
+	}
+	path := e.effectiveSourcePath(job.path)
+	ids, err := e.db.ListSessionIDsByFilePath(path, string(job.agent))
+	if err != nil {
+		return false, err
+	}
+	for _, id := range ids {
+		session, err := e.db.GetSession(ctx, id)
+		if err != nil {
+			return false, err
+		}
+		if session != nil && !e.cwdFilter.allows(session.Cwd) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (e *Engine) linkSubagentSessions(ctx context.Context) error {
+	if runtimeMetrics := reconciliationRuntimeMetricsFor(ctx); runtimeMetrics != nil {
+		runtimeMetrics.globalLinkPass()
+	}
+	return e.db.LinkSubagentSessions()
+}
+
 // drainResults consumes remaining items from the results
 // channel so that worker goroutines can exit and be collected.
 func drainResults(results <-chan syncJob, remaining int) {
 	for range remaining {
-		<-results
+		job := <-results
+		job.releaseRetention()
 	}
 }
 
@@ -4233,9 +6569,23 @@ type sessionParseError struct {
 	err         error
 }
 
+// sourceMissingMember identifies one stored session whose virtual member
+// source vanished from a still-existing shared container. The write seam
+// tombstones its exact source ownership (deletion_cause = source_missing,
+// revivable) instead of hard-deleting it as a parser exclusion.
+type sourceMissingMember struct {
+	sessionID string
+	filePath  string
+}
+
 type processResult struct {
 	results            []parser.ParseResult
 	excludedSessionIDs []string
+	// sourceMissingMembers carries stored sessions whose virtual member
+	// source no longer exists inside a still-present shared container
+	// (e.g. a Windsurf conversation deleted from state.vscdb). They must
+	// be tombstoned, never routed through DeleteParserExcludedSessions.
+	sourceMissingMembers []sourceMissingMember
 	// sessionErrs carries per-session parse failures from the
 	// shared-db fan-out loops. Normal sync logs and skips these;
 	// parse-diff (forceParse) surfaces them as DiffParseError report
@@ -4273,6 +6623,10 @@ type processResult struct {
 	// suppressPresenceSweep marks an incomplete source result where
 	// missing stored sessions are expected rather than parser drift.
 	suppressPresenceSweep bool
+	// providerFailureCount carries non-fatal partial outcome failures through
+	// valid partial writes. Reconciliation may persist the valid results, but
+	// must not acknowledge the pass as complete.
+	providerFailureCount int
 	// storageTrustPath/State/Snap carry an OpenCode-family storage
 	// session's pre-parse stat signature and invalidation snapshot to
 	// the write path, which promotes it once the session's batch is
@@ -4281,6 +6635,13 @@ type processResult struct {
 	storageTrustPath  string
 	storageTrustState string
 	storageTrustSnap  storageTrustSnapshot
+	// retentionLease bounds the memory retained by this result's parsed
+	// data. It is acquired at the parse seams (provider parse, incremental
+	// parse, legacy/S3 parse) and only ever set on a result carrying parsed
+	// data; skip results carry none. The worker loop copies it onto
+	// syncJob.retentionLease, which is released exactly once via
+	// releaseRetention or the pendingLeases flush.
+	retentionLease *parseRetentionLease
 }
 
 func (r processResult) needsRetryForSession(sessionID string) bool {
@@ -4445,17 +6806,6 @@ func (e *Engine) processProviderFile(
 		return processResult{skip: true}, true
 	}
 
-	// Processing a file-backed storage session makes (or confirms) the
-	// storage copy as the archive's canonical content for its ID, so a
-	// same-ID SQLite row in this root's container is no longer backed by
-	// what its trusted membership verified. Drop it so a storage copy
-	// that appears and disappears entirely between full passes still
-	// forces the re-exposed row to re-verify (see
-	// dropTrustedSQLiteContainerSessionForStorage).
-	if sessionPath := e.openCodeStorageSessionPath(file); sessionPath != "" {
-		e.dropTrustedSQLiteContainerSessionForStorage(file.Agent, sessionPath)
-	}
-
 	// OpenCode-family file-backed storage gate: when the session's
 	// per-file stat signature matches the last verified pass, its parse
 	// inputs are unchanged, so skip before re-reading the whole message
@@ -4568,7 +6918,7 @@ func (e *Engine) processProviderFile(
 			errors.Is(err, os.ErrNotExist) {
 			return processResult{
 				excludedSessionIDs: e.providerSourceSessionIDsForForceReplace(
-					file.Agent,
+					provider,
 					source,
 				),
 				forceReplace: true,
@@ -4678,6 +7028,19 @@ func (e *Engine) processProviderFile(
 		}, true
 	}
 
+	// Provider parse seam: every gate above returns a lease-free skip. From
+	// here the provider parses the source, so acquire the retention lease that
+	// bounds the parsed payload and attach it to every result carrying that
+	// data. A result still classified as a skip below releases it immediately.
+	lease, err := e.retentionBudget().acquire(ctx, parseRetentionSourceBytes(file))
+	if err != nil {
+		return processResult{err: err}, true
+	}
+	if runtimeMetrics := reconciliationRuntimeMetricsFor(ctx); runtimeMetrics != nil {
+		if _, _, ok := sqliteContainerSourceForFile(file); ok {
+			runtimeMetrics.openCodeSQLiteParse()
+		}
+	}
 	outcome, err := provider.Parse(ctx, parser.ParseRequest{
 		Source:      source,
 		Fingerprint: fingerprint,
@@ -4686,11 +7049,12 @@ func (e *Engine) processProviderFile(
 	})
 	if err != nil {
 		return processResult{
-			err:         err,
-			mtime:       fingerprint.MTimeNS,
-			cacheSkip:   cacheSkip,
-			cacheKey:    cacheKey,
-			noCacheSkip: true,
+			err:            err,
+			mtime:          fingerprint.MTimeNS,
+			cacheSkip:      cacheSkip,
+			cacheKey:       cacheKey,
+			noCacheSkip:    true,
+			retentionLease: lease,
 		}, true
 	}
 	if err := validateProviderOutcome(
@@ -4700,32 +7064,62 @@ func (e *Engine) processProviderFile(
 		outcome,
 	); err != nil {
 		return processResult{
-			err:         err,
-			mtime:       fingerprint.MTimeNS,
-			cacheSkip:   cacheSkip,
-			cacheKey:    cacheKey,
-			noCacheSkip: true,
+			err:            err,
+			mtime:          fingerprint.MTimeNS,
+			cacheSkip:      cacheSkip,
+			cacheKey:       cacheKey,
+			noCacheSkip:    true,
+			retentionLease: lease,
 		}, true
 	}
 	applyProviderFingerprintFileInfo(file.Agent, fingerprint, outcome.Results)
 	cleanCache := providerOutcomeAllowsCleanSkipCache(outcome)
+	providerFailureCount := len(outcome.SourceErrors)
+	if !outcome.ResultSetComplete {
+		providerFailureCount++
+	}
 	if outcome.SkipReason != parser.SkipNone {
 		excludedSessionIDs := append([]string(nil), outcome.ExcludedSessionIDs...)
+		var missingMembers []sourceMissingMember
 		if outcome.ForceReplace && outcome.ResultSetComplete {
-			excludedSessionIDs = append(
-				excludedSessionIDs,
-				e.providerSourceSessionIDsForForceReplace(file.Agent, source)...,
+			owned := e.providerSourceSessionOwnershipsForForceReplace(
+				provider, source,
 			)
+			if e.pathRewriter == nil &&
+				providerVirtualSourceContainerExists(file.Path) {
+				// The provider re-resolved this exact virtual member against a
+				// still-present shared container and it yields no session: the
+				// member was removed from the container, not the container from
+				// disk. Hard-deleting here would destroy rows the reconciliation
+				// audit preserves as revivable source-missing tombstones, so
+				// carry the stored ownership to the tombstone seam instead.
+				missingMembers = owned
+			} else {
+				for _, member := range owned {
+					excludedSessionIDs = append(excludedSessionIDs, member.sessionID)
+				}
+			}
 		}
-		return processResult{
-			skip:               !outcome.ForceReplace,
-			excludedSessionIDs: excludedSessionIDs,
-			mtime:              fingerprint.MTimeNS,
-			cacheSkip:          cacheSkip,
-			cacheKey:           cacheKey,
-			noCacheSkip:        !cleanCache,
-			forceReplace:       outcome.ForceReplace,
-		}, true
+		skipRes := processResult{
+			skip:                  !outcome.ForceReplace,
+			excludedSessionIDs:    excludedSessionIDs,
+			sourceMissingMembers:  missingMembers,
+			mtime:                 fingerprint.MTimeNS,
+			cacheSkip:             cacheSkip,
+			cacheKey:              cacheKey,
+			noCacheSkip:           !cleanCache,
+			forceReplace:          outcome.ForceReplace,
+			suppressPresenceSweep: !outcome.ResultSetComplete,
+			providerFailureCount:  providerFailureCount,
+		}
+		// A SkipReason outcome without a force-replace carries no parsed data,
+		// so it stays a lease-free skip; a force-replace is parse-bearing.
+		if skipRes.skip {
+			lease.Release()
+		} else {
+			skipRes.retentionLease = lease
+		}
+		return skipRes, true
 	}
 
 	parsedResults := parseOutcomeResults(outcome.Results)
@@ -4739,6 +7133,8 @@ func (e *Engine) processProviderFile(
 		noCacheSkip:           !cleanCache,
 		forceReplace:          outcome.ForceReplace || incForceReplace,
 		suppressPresenceSweep: !outcome.ResultSetComplete,
+		providerFailureCount:  providerFailureCount,
+		retentionLease:        lease,
 	}
 	// Incremental-append providers (Claude and Codex) need the stored file
 	// identity so a later sync can detect an atomic file replacement
@@ -4752,6 +7148,7 @@ func (e *Engine) processProviderFile(
 				res.retrySessionIDs = make(map[string]bool)
 			}
 			res.retrySessionIDs[result.Result.Session.ID] = true
+			res.providerFailureCount++
 		}
 	}
 	if e.forceParse || file.ForceParse {
@@ -4852,9 +7249,26 @@ func (e *Engine) dropUnchangedSharedSQLiteResults(
 }
 
 func (e *Engine) providerSourceSessionIDsForForceReplace(
-	agent parser.AgentType,
+	provider parser.Provider,
 	source parser.SourceRef,
 ) []string {
+	members := e.providerSourceSessionOwnershipsForForceReplace(provider, source)
+	ids := make([]string, 0, len(members))
+	for _, member := range members {
+		ids = append(ids, member.sessionID)
+	}
+	return ids
+}
+
+// providerSourceSessionOwnershipsForForceReplace lists the stored active
+// sessions owned by a force-replaced source, paired with the exact stored
+// file path each row is tracked under, so callers can either hard-delete
+// them as parser exclusions or tombstone their exact source ownership.
+func (e *Engine) providerSourceSessionOwnershipsForForceReplace(
+	provider parser.Provider,
+	source parser.SourceRef,
+) []sourceMissingMember {
+	agent := provider.Definition().Type
 	root := ""
 	for _, candidate := range []string{source.DisplayPath, source.FingerprintKey, source.Key} {
 		if candidate != "" {
@@ -4865,16 +7279,26 @@ func (e *Engine) providerSourceSessionIDsForForceReplace(
 	if root == "" {
 		return nil
 	}
-	if e.pathRewriter != nil {
-		root = e.pathRewriter(root)
+	scopes := []parser.StoredSourceHintScope{{Path: root}}
+	if resolver, ok := provider.(parser.StoredSourceHintScopeProvider); ok {
+		if resolved := resolver.StoredSourceHintScopes(parser.ChangedPathRequest{Path: root}); len(resolved) > 0 {
+			scopes = resolved
+		}
 	}
-	sourcePaths, err := e.db.ListStoredSourcePathHints(string(agent), []string{root})
+	if e.pathRewriter != nil {
+		for i := range scopes {
+			scopes[i].Path = e.pathRewriter(scopes[i].Path)
+		}
+	}
+	sourcePaths, err := e.db.ListStoredSourcePathHints(
+		string(agent), storedSourceDBHintScopes(scopes),
+	)
 	if err != nil {
 		log.Printf("list provider force-replace source hints: %v", err)
 		return nil
 	}
 	seen := make(map[string]struct{})
-	var ids []string
+	var members []sourceMissingMember
 	for _, sourcePath := range sourcePaths {
 		pathIDs, err := e.db.ListSessionIDsByFilePath(sourcePath, string(agent))
 		if err != nil {
@@ -4886,10 +7310,13 @@ func (e *Engine) providerSourceSessionIDsForForceReplace(
 				continue
 			}
 			seen[id] = struct{}{}
-			ids = append(ids, id)
+			members = append(members, sourceMissingMember{
+				sessionID: id,
+				filePath:  sourcePath,
+			})
 		}
 	}
-	return ids
+	return members
 }
 
 // applyProviderFilePathPolicies reproduces the DB-aware, file-path-scoped
@@ -5078,9 +7505,15 @@ func providerProcessCacheKeyWithHash(
 	return key + "?source_hash=" + fingerprint.Hash
 }
 
+// Hermes is deliberately absent: its skip keys must stay plain paths so the
+// remote import's exact-file mapping (a profile's state.db in ExtraFiles) can
+// translate the persisted entry back to the remote path. Same-mtime content
+// changes are still caught by providerFingerprintHashRequiredForFreshness,
+// which compares the fingerprint hash against the stored row.
 func providerFingerprintHashInCacheKey(agent parser.AgentType) bool {
 	switch agent {
-	case parser.AgentClaude, parser.AgentCodex, parser.AgentDevin, parser.AgentQoder, parser.AgentWindsurf:
+	case parser.AgentClaude, parser.AgentCodex, parser.AgentDevin,
+		parser.AgentQoder, parser.AgentWindsurf:
 		return true
 	default:
 		return false
@@ -5092,7 +7525,8 @@ func providerFingerprintHashInCacheKey(agent parser.AgentType) bool {
 // older hash siblings so hot append-only files retain only one content version.
 func providerFingerprintHashRequiredForFreshness(agent parser.AgentType) bool {
 	switch agent {
-	case parser.AgentClaude, parser.AgentCodex, parser.AgentDevin, parser.AgentQoder, parser.AgentWindsurf:
+	case parser.AgentClaude, parser.AgentCodex, parser.AgentDevin, parser.AgentHermes,
+		parser.AgentQoder, parser.AgentWindsurf, parser.AgentGemini:
 		return true
 	default:
 		return false
@@ -5372,13 +7806,27 @@ func (e *Engine) cacheSkip(
 // clearSkip removes a skip-cache entry when a file produces a valid session.
 // Its work count has the same cardinality-regression role as cacheSkip's.
 func (e *Engine) clearSkip(path string) int {
+	work, err := e.clearSkipPersistent(path)
+	if err != nil {
+		log.Printf("clearing persisted skip cache for %s: %v", path, err)
+	}
+	return work
+}
+
+func (e *Engine) clearSkipPersistent(path string) (int, error) {
 	e.skipMu.Lock()
 	work := e.removeSkipHashSiblingsLocked(path)
 	delete(e.skipCache, path)
 	delete(e.skipFingerprints, path)
 	e.skipMu.Unlock()
-	_ = e.db.DeleteSkippedFile(path)
-	return work
+	if e.ephemeral {
+		return work, nil
+	}
+	base, _, _ := strings.Cut(path, sourceHashSkipMarker)
+	err := e.db.DeleteSkippedFileAndPrefix(
+		base, base+sourceHashSkipMarker,
+	)
+	return work, err
 }
 
 func (e *Engine) removeSkipHashSiblingsLocked(path string) int {
@@ -5466,6 +7914,13 @@ func (e *Engine) SnapshotSkipCache() map[string]int64 {
 // database so skipped files survive process restarts.
 // Returns the number of entries persisted.
 func (e *Engine) persistSkipCache() int {
+	return e.persistSkipCacheInto(e.db)
+}
+
+// persistSkipCacheInto writes the current skip cache into target. A resync build
+// persists into the replacement database (not the active one) so the post-swap
+// engine reloads warm skip state.
+func (e *Engine) persistSkipCacheInto(target *db.DB) int {
 	if e.ephemeral {
 		return 0
 	}
@@ -5474,7 +7929,7 @@ func (e *Engine) persistSkipCache() int {
 	maps.Copy(snapshot, e.skipCache)
 	e.skipMu.RUnlock()
 
-	if err := e.db.ReplaceSkippedFiles(snapshot); err != nil {
+	if err := target.ReplaceSkippedFiles(snapshot); err != nil {
 		log.Printf("persisting skip cache: %v", err)
 	}
 	return len(snapshot)
@@ -5496,9 +7951,12 @@ func (e *Engine) shouldSkipFile(
 // file metadata already matches its current fingerprint, so a reparse would be
 // a no-op. It compares the DB-stored file_size/file_mtime for the source's
 // path against the fingerprint and requires a current data_version, mirroring
-// shouldSkipByPath for the provider-authoritative runtime. A source with no
-// stored row, an empty key, or a non-fingerprint identity (no size, e.g. a
-// tombstone) never matches and therefore reparses.
+// shouldSkipByPath for the provider-authoritative runtime. For providers whose
+// fingerprint stat is a shared container's (see
+// providerFingerprintHashEstablishesFreshness), a matching stored content hash
+// establishes freshness even when the stat moved. A source with no stored row,
+// an empty key, or a non-fingerprint identity (no size, e.g. a tombstone)
+// never matches and therefore reparses.
 func (e *Engine) providerSourceUnchangedInDB(
 	source parser.SourceRef,
 	fingerprint parser.SourceFingerprint,
@@ -5518,9 +7976,12 @@ func (e *Engine) providerSourceUnchangedInDB(
 		return false
 	}
 	if storedSize != fingerprint.Size || storedMtime != fingerprint.MTimeNS {
-		return false
-	}
-	if !e.providerFingerprintHashMatchesDB(source.Provider, lookupPath, fingerprint) {
+		if !e.providerSourceHashFreshDespiteStat(
+			source.Provider, lookupPath, fingerprint,
+		) {
+			return false
+		}
+	} else if !e.providerFingerprintHashMatchesDB(source.Provider, lookupPath, fingerprint) {
 		return false
 	}
 	// A stale stored project (e.g. a generated roborev CI worktree name)
@@ -5541,6 +8002,37 @@ func (e *Engine) providerFingerprintHashMatchesDB(
 ) bool {
 	if fingerprint.Hash == "" || !providerFingerprintHashRequiredForFreshness(agent) {
 		return true
+	}
+	storedHash, ok := e.db.GetFileHashByPath(lookupPath)
+	return ok && storedHash == fingerprint.Hash
+}
+
+// providerFingerprintHashEstablishesFreshness reports whether a matching
+// stored fingerprint hash alone proves a source unchanged when its stored
+// size/mtime no longer match. Hermes state members inherit their shared
+// container's stat (state.db size and mtime), so any single-member change
+// invalidates every member's stat identity; the per-member hash covers the
+// member's full parse input (session row, messages, selected transcript), so
+// a matching stored hash bounds re-parse and rewrite work to the changed
+// members instead of the whole archive. Providers whose fingerprint stat is
+// per-source stay stat-gated: a stat mismatch there means real change.
+func providerFingerprintHashEstablishesFreshness(agent parser.AgentType) bool {
+	return agent == parser.AgentHermes
+}
+
+// providerSourceHashFreshDespiteStat is the stat-mismatch arm of
+// providerSourceUnchangedInDB. Unlike providerFingerprintHashMatchesDB, an
+// absent hash can never establish freshness here: the stat already disagrees,
+// so only a positive content match may skip. GetFileHashByPath excludes
+// recoverable source-missing tombstones, so a returning member still revives
+// through a full parse.
+func (e *Engine) providerSourceHashFreshDespiteStat(
+	agent parser.AgentType,
+	lookupPath string,
+	fingerprint parser.SourceFingerprint,
+) bool {
+	if fingerprint.Hash == "" || !providerFingerprintHashEstablishesFreshness(agent) {
+		return false
 	}
 	storedHash, ok := e.db.GetFileHashByPath(lookupPath)
 	return ok && storedHash == fingerprint.Hash
@@ -5641,6 +8133,14 @@ func (e *Engine) providerSingleSessionFresh(
 	if e.pathRewriter != nil {
 		lookupPath = e.pathRewriter(path)
 	}
+	fullID := applyIDPrefixToID(e.idPrefix, sessionID)
+	if e.db.GetSessionFilePath(fullID) != lookupPath {
+		// A directory rename can preserve size, mtime, inode, and content.
+		// Freshness by session ID alone would keep the vanished source path
+		// forever instead of parsing the discovered destination and updating
+		// source ownership.
+		return 0, false, false, false
+	}
 	// statPath is the on-disk file the stat came from: lookupPath when it
 	// resolves (local sync, where lookupPath == path), otherwise the physical
 	// source path (remote sync rewrites path to a non-local logical key). The
@@ -5661,12 +8161,12 @@ func (e *Engine) providerSingleSessionFresh(
 		return 0, false, true, false
 	}
 	contentChanged, contentVerified := e.providerIncrementalContentChanged(
-		e.idPrefix+sessionID, statPath, info,
+		fullID, statPath, info,
 	)
 	if contentChanged {
 		return 0, false, true, contentVerified
 	}
-	sess, _ := e.db.GetSession(ctx, e.idPrefix+sessionID)
+	sess, _ := e.db.GetSession(ctx, fullID)
 	return info.ModTime().UnixNano(), sess != nil &&
 		sess.Project != "" &&
 		!parser.NeedsProjectReparse(sess.Project), false, contentVerified
@@ -5681,7 +8181,7 @@ func (e *Engine) providerIncrementalIdentityChanged(
 		// the temp inode is expected to change between identical downloads.
 		return false
 	}
-	curInode, curDevice := getFileIdentity(info)
+	curInode, curDevice := getFileIdentity(lookupPath, info)
 	return e.db.FileIdentityChanged(lookupPath, curInode, curDevice)
 }
 
@@ -5755,12 +8255,13 @@ func (e *Engine) providerSourceFreshBeforeFingerprint(
 		if e.shouldSkipByPath(path, effectiveInfo) {
 			return mtime, true
 		}
-	// Gemini is deliberately absent here. Its fingerprint is composite (the
-	// session file plus projects.json and trustedFolders.json), so a
-	// pre-fingerprint skip keyed only on the session file's size and mtime
-	// would skip a session whose project metadata changed while the transcript
-	// did not, leaving a stale project on scheduled syncs. Gemini relies on the
-	// post-fingerprint skip cache instead, whose mtime folds in the composite.
+	// Gemini is deliberately absent here. Its fingerprint hash folds in the
+	// session's resolved project name, so a pre-fingerprint skip keyed only on
+	// the session file's size and mtime would skip a session whose project
+	// metadata changed while the transcript did not, leaving a stale project
+	// on scheduled syncs. Gemini relies on the post-fingerprint DB hash check
+	// instead (providerFingerprintHashRequiredForFreshness), which catches a
+	// resolved-project change even when size and mtime are unchanged.
 	case parser.AgentCopilot:
 		mtime := copilotEffectiveMtime(path, info)
 		effectiveInfo := fakeSnapshotInfo{
@@ -5830,7 +8331,7 @@ func (e *Engine) stampProviderFileIdentity(
 	if err != nil {
 		return
 	}
-	inode, device := getFileIdentity(info)
+	inode, device := getFileIdentity(path, info)
 	for i := range results {
 		if results[i].Session.File.Inode != 0 ||
 			results[i].Session.File.Device != 0 {
@@ -5892,18 +8393,29 @@ func (e *Engine) tryProviderIncrementalAppend(
 	parseFn := func(
 		_ string, inc *db.IncrementalInfo,
 	) ([]parser.ParsedMessage, []parser.ClaudeSubagentLink, time.Time, int64, *string, error) {
+		// The Claude parser needs the stored tail's provider message id
+		// so its queued-command masking fallback fires only for a real
+		// same-message.id continuation; without it, every routine queued
+		// command followed by a fresh response would force a full parse.
+		var storedLastClaudeMessageID *string
+		if provider.Definition().Type == parser.AgentClaude {
+			id := e.db.LastClaudeMessageID(inc.ID)
+			storedLastClaudeMessageID = &id
+		}
 		outcome, status, perr := provider.ParseIncremental(
 			ctx,
 			parser.IncrementalRequest{
-				Source:           source,
-				Fingerprint:      fingerprint,
-				SessionID:        inc.ID,
-				Offset:           inc.FileSize,
-				StartOrdinal:     inc.NextOrdinal,
-				Machine:          e.machine,
-				LastEntryUUID:    inc.LastEntryUUID,
-				StoredAgentLabel: inc.AgentLabel,
-				StoredEntrypoint: inc.Entrypoint,
+				Source:                    source,
+				Fingerprint:               fingerprint,
+				SessionID:                 inc.ID,
+				Offset:                    inc.FileSize,
+				StartOrdinal:              inc.NextOrdinal,
+				Machine:                   e.machine,
+				LastEntryUUID:             inc.LastEntryUUID,
+				StoredAgentLabel:          inc.AgentLabel,
+				StoredEntrypoint:          inc.Entrypoint,
+				StoredClaudeLinearParse:   inc.ClaudeLinearParse,
+				StoredLastClaudeMessageID: storedLastClaudeMessageID,
 			},
 		)
 		if perr != nil {
@@ -5917,9 +8429,11 @@ func (e *Engine) tryProviderIncrementalAppend(
 				return nil, nil, time.Time{}, 0, nil,
 					parser.ErrClaudeIncrementalNeedsFullParse
 			}
-			// A plain full-parse fallback (e.g. DAG detected):
-			// return a non-fallback error so the helper runs a
-			// normal full parse without forceReplace.
+			// A plain full-parse fallback without a replace request.
+			// The Claude provider always sets ForceReplace on its
+			// fallbacks (a DAG fork can drop or re-branch stored
+			// rows), so this branch serves providers that only need
+			// an append-preserving full parse.
 			return nil, nil, time.Time{}, 0, nil, parser.ErrDAGDetected
 		case parser.IncrementalNoNewData:
 			return nil, nil, time.Time{}, 0, nil, nil
@@ -5934,7 +8448,7 @@ func (e *Engine) tryProviderIncrementalAppend(
 		}
 	}
 
-	return e.tryIncrementalJSONL(file, info, file.Agent, parseFn)
+	return e.tryIncrementalJSONL(ctx, file, info, file.Agent, parseFn)
 }
 
 // incrementalParseFunc reads new JSONL lines from a file
@@ -5954,6 +8468,7 @@ type incrementalParseFunc func(
 // to full parse when the file maps to multiple DB sessions
 // (e.g. Claude DAG forks).
 func (e *Engine) tryIncrementalJSONL(
+	ctx context.Context,
 	file parser.DiscoveredFile,
 	info os.FileInfo,
 	agent parser.AgentType,
@@ -6017,9 +8532,9 @@ func (e *Engine) tryIncrementalJSONL(
 	// back to a full parse so we don't append on top of stale
 	// state. Only check when both sides have a known identity
 	// (non-zero); zeros mean the data is missing or the
-	// platform doesn't expose inode/device (Windows).
+	// filesystem does not expose a stable identity.
 	if e.pathRewriter == nil && inc.FileInode != 0 && inc.FileDevice != 0 {
-		curInode, curDevice := getFileIdentity(info)
+		curInode, curDevice := getFileIdentity(file.Path, info)
 		if curInode != 0 && curDevice != 0 &&
 			(curInode != inc.FileInode ||
 				curDevice != inc.FileDevice) {
@@ -6068,10 +8583,23 @@ func (e *Engine) tryIncrementalJSONL(
 		incMtime = parser.CodexEffectiveMtime(file.Path, incMtime)
 	}
 
+	// Incremental parse seam: every gate above returns a lease-free decline.
+	// From here parseFn reads and parses the appended bytes, so acquire the
+	// retention lease that bounds the parsed payload. It is attached to the
+	// incremental results below and released on every decline (fall-through to
+	// a full parse re-acquires at the provider parse seam) or skip return.
+	lease, leaseErr := e.retentionBudget().acquire(
+		ctx, parseRetentionSourceBytes(file),
+	)
+	if leaseErr != nil {
+		return processResult{err: leaseErr}, true
+	}
+
 	newMsgs, links, endedAt, consumed, terminationStatus, err := parseFn(
 		file.Path, inc,
 	)
 	if err != nil {
+		lease.Release()
 		if parser.IsIncrementalFullParseFallback(err) {
 			log.Printf(
 				"incremental %s %s: %v (explicit full parse fallback)",
@@ -6137,6 +8665,7 @@ func (e *Engine) tryIncrementalJSONL(
 					hasTotalOutputTokens: inc.HasTotalOutputTokens,
 					hasPeakContextTokens: inc.HasPeakContextTokens,
 				},
+				retentionLease: lease,
 			}, true
 		}
 		// A larger source with no complete record consumed is an unfinished
@@ -6144,6 +8673,7 @@ func (e *Engine) tryIncrementalJSONL(
 		// the persisted cursor unchanged and suppress the mtime skip entry so a
 		// completed record is retried even when the writer restores the same
 		// filesystem timestamp.
+		lease.Release()
 		return processResult{skip: true, noCacheSkip: true}, true
 	}
 
@@ -6168,6 +8698,7 @@ func (e *Engine) tryIncrementalJSONL(
 						" message.id with stored tail, full parse",
 					agent, file.Path,
 				)
+				lease.Release()
 				return processResult{forceReplace: true}, false
 			}
 		}
@@ -6227,6 +8758,7 @@ func (e *Engine) tryIncrementalJSONL(
 			hasTotalOutputTokens: hasTotalOut,
 			hasPeakContextTokens: hasPeakCtx,
 		},
+		retentionLease: lease,
 	}, true
 }
 
@@ -6906,12 +9438,23 @@ type pendingWrite struct {
 	usageEvents  []parser.ParsedUsageEvent
 	needsRetry   bool
 	forceReplace bool
+	// baselineEligible is set by collectAndBatch only when the complete source
+	// outcome is safe to make deletion-eligible after this write succeeds.
+	baselineEligible bool
 	// storageTrustPath/State/Snap promote the session's OpenCode
 	// storage-gate trust after its batch is confirmed fully written.
 	// Empty for everything else.
 	storageTrustPath  string
 	storageTrustState string
 	storageTrustSnap  storageTrustSnapshot
+}
+
+type writeBatchOutcome struct {
+	writtenSessions int
+	writtenMessages int
+	failedSessions  int
+	cwdFiltered     int
+	written         []bool
 }
 
 func dataVersionForWrite(pw pendingWrite) int {
@@ -6971,18 +9514,29 @@ func (e *Engine) writeBatch(
 	writeMode syncWriteMode,
 	forceReplace bool,
 ) (writtenSessions, writtenMessages, failedSessions, cwdFiltered int) {
+	outcome := e.writeBatchWithOutcome(batch, writeMode, forceReplace)
+	return outcome.writtenSessions, outcome.writtenMessages,
+		outcome.failedSessions, outcome.cwdFiltered
+}
+
+func (e *Engine) writeBatchWithOutcome(
+	batch []pendingWrite,
+	writeMode syncWriteMode,
+	forceReplace bool,
+) writeBatchOutcome {
 	if writeMode == syncWriteBulk {
-		return e.writeBatchBulk(batch, forceReplace)
+		return e.writeBatchBulkWithOutcome(batch, forceReplace)
 	}
 
+	outcome := writeBatchOutcome{written: make([]bool, len(batch))}
 	resolveWorktreeProject := e.loadWorktreeProjectResolver()
-	for _, pw := range batch {
+	for i, pw := range batch {
 		s, msgs, verdict := e.prepareSessionWrite(
 			pw, resolveWorktreeProject,
 		)
 		if verdict != sessionWriteOK {
 			if verdict == sessionWriteCwdFiltered {
-				cwdFiltered++
+				outcome.cwdFiltered++
 			}
 			continue
 		}
@@ -6999,14 +9553,13 @@ func (e *Engine) writeBatch(
 			stale = true
 		}
 
-		// UpsertSession first: the session row must exist
-		// before messages can be inserted (FK constraint).
-		// This is safe because writeBatch runs full parses
-		// that always recompute all columns. For
-		// incremental updates (writeIncremental), messages
-		// are written first since the session already
-		// exists.
-		if err := e.db.UpsertSession(s); err != nil {
+		// The session row must exist before messages can be inserted (FK
+		// constraint), but a source-missing row stays tombstoned until every
+		// dependent write succeeds below. For incremental updates
+		// (writeIncremental), messages are written first since the session
+		// already exists.
+		revivingSourceMissing, err := e.db.UpsertSessionPendingContent(s)
+		if err != nil {
 			if isIntentionalSessionSkip(err) {
 				if pw.sess.File.Path != "" {
 					e.cacheSkip(
@@ -7018,7 +9571,7 @@ func (e *Engine) writeBatch(
 				continue
 			}
 			log.Printf("upsert session %s: %v", s.ID, err)
-			failedSessions++
+			outcome.failedSessions++
 			continue
 		}
 		if err := e.writeProjectIdentityObservation(
@@ -7031,7 +9584,7 @@ func (e *Engine) writeBatch(
 		}
 
 		replaceMessages := shouldReplaceFullParseMessages(
-			pw, forceReplace, stale,
+			pw, forceReplace, stale, revivingSourceMissing,
 		)
 
 		update, findings := computeSignalsAndSecrets(s, msgs)
@@ -7047,7 +9600,7 @@ func (e *Engine) writeBatch(
 				"write messages for %s: %v",
 				s.ID, werr,
 			)
-			failedSessions++
+			outcome.failedSessions++
 			continue
 		}
 		if err := e.db.ReplaceSessionUsageEvents(
@@ -7057,21 +9610,22 @@ func (e *Engine) writeBatch(
 				"write usage events for %s: %v",
 				s.ID, err,
 			)
-			failedSessions++
+			outcome.failedSessions++
 			continue
 		}
 
-		// Advance data_version only after the message write
-		// succeeded. UpsertSession deliberately does not
-		// touch this column so a transient write failure
-		// won't leave the session marked at the current
-		// parser version with stale messages.
+		// Advance data_version only after the message and usage writes
+		// succeeded. The pending upsert deliberately does not touch this
+		// column, and the source-missing tombstone is cleared only after this
+		// succeeds, so an old current version cannot hide a failed rewrite.
 		if err := e.db.SetSessionDataVersion(
 			s.ID, dataVersionForWrite(pw),
 		); err != nil {
 			log.Printf(
 				"set data_version for %s: %v", s.ID, err,
 			)
+			outcome.failedSessions++
+			continue
 		}
 
 		if !replaceMessages {
@@ -7087,10 +9641,16 @@ func (e *Engine) writeBatch(
 				log.Printf("signals: update %s: %v", s.ID, err)
 			}
 		}
-		writtenSessions++
-		writtenMessages += len(msgs)
+		if err := e.db.ReviveSourceMissingSession(s.ID); err != nil {
+			log.Printf("revive source-missing session %s: %v", s.ID, err)
+			outcome.failedSessions++
+			continue
+		}
+		outcome.writtenSessions++
+		outcome.writtenMessages += len(msgs)
+		outcome.written[i] = true
 	}
-	return writtenSessions, writtenMessages, failedSessions, cwdFiltered
+	return outcome
 }
 
 // sessionWriteVerdict says whether prepareSessionWrite produced a
@@ -7921,14 +10481,16 @@ type localGitIdentity struct {
 	worktreeKind   export.WorktreeRelationship
 }
 
-func (e *Engine) writeBatchBulk(
+func (e *Engine) writeBatchBulkWithOutcome(
 	batch []pendingWrite, forceReplace bool,
-) (writtenSessions, writtenMessages, failedSessions, cwdFiltered int) {
+) writeBatchOutcome {
+	outcome := writeBatchOutcome{written: make([]bool, len(batch))}
 	writes := make([]db.SessionBatchWrite, 0, len(batch))
+	pendingIndexes := make([]int, 0, len(batch))
 	sources := make(map[string]batchSourceFile, len(batch))
 	resolveWorktreeProject := e.loadWorktreeProjectResolver()
 
-	for _, pw := range batch {
+	for pendingIndex, pw := range batch {
 		tPrep := time.Now()
 		s, msgs, verdict := e.prepareSessionWrite(
 			pw, resolveWorktreeProject,
@@ -7936,12 +10498,12 @@ func (e *Engine) writeBatchBulk(
 		e.phaseStats.PrepNanos.Add(int64(time.Since(tPrep)))
 		if verdict != sessionWriteOK {
 			if verdict == sessionWriteCwdFiltered {
-				cwdFiltered++
+				outcome.cwdFiltered++
 			}
 			continue
 		}
 		replaceMessages := shouldReplaceFullParseMessages(
-			pw, forceReplace, false,
+			pw, forceReplace, false, false,
 		)
 		tScan := time.Now()
 		update, findings := computeSignalsAndSecrets(s, msgs)
@@ -7958,6 +10520,7 @@ func (e *Engine) writeBatchBulk(
 			DataVersion:     dataVersionForWrite(pw),
 			ReplaceMessages: replaceMessages,
 		})
+		pendingIndexes = append(pendingIndexes, pendingIndex)
 		if pw.sess.File.Path != "" {
 			sources[s.ID] = batchSourceFile{
 				path:        pw.sess.File.Path,
@@ -7967,7 +10530,7 @@ func (e *Engine) writeBatchBulk(
 		}
 	}
 	if len(writes) == 0 {
-		return 0, 0, 0, cwdFiltered
+		return outcome
 	}
 
 	tWrite := time.Now()
@@ -7978,7 +10541,13 @@ func (e *Engine) writeBatchBulk(
 	e.phaseStats.BatchedWrites.Add(int64(result.WrittenSessions))
 	if err != nil {
 		log.Printf("write session batch: %v", err)
-		return 0, 0, len(writes), cwdFiltered
+		outcome.failedSessions = len(writes)
+		return outcome
+	}
+	for _, writtenIndex := range result.WrittenIndexes {
+		if writtenIndex >= 0 && writtenIndex < len(pendingIndexes) {
+			outcome.written[pendingIndexes[writtenIndex]] = true
+		}
 	}
 	for _, id := range result.ExcludedIDs {
 		if source, ok := sources[id]; ok && source.path != "" {
@@ -7990,10 +10559,10 @@ func (e *Engine) writeBatchBulk(
 	for _, err := range result.Errors {
 		log.Printf("write session batch: %v", err)
 	}
-	return result.WrittenSessions,
-		result.WrittenMessages,
-		result.FailedSessions,
-		cwdFiltered
+	outcome.writtenSessions = result.WrittenSessions
+	outcome.writtenMessages = result.WrittenMessages
+	outcome.failedSessions = result.FailedSessions
+	return outcome
 }
 
 func identityObservationOrZero(
@@ -8337,9 +10906,10 @@ func remoteNameFromGitConfigSection(section string) string {
 }
 
 func shouldReplaceFullParseMessages(
-	pw pendingWrite, forceReplace, stale bool,
+	pw pendingWrite, forceReplace, stale, revivingSourceMissing bool,
 ) bool {
 	return forceReplace || pw.forceReplace || pw.needsRetry || stale ||
+		revivingSourceMissing ||
 		pw.sess.Agent == parser.AgentCowork ||
 		isOpenCodeFormatStorageAgent(pw.sess.Agent) ||
 		pw.sess.Agent == parser.AgentVSCopilot ||
@@ -8589,7 +11159,8 @@ func (e *Engine) writeSessionFullWithResolver(
 	if verdict != sessionWriteOK {
 		return errSessionPreserved
 	}
-	if err := e.db.UpsertSession(s); err != nil {
+	_, err := e.db.UpsertSessionPendingContent(s)
+	if err != nil {
 		if isIntentionalSessionSkip(err) {
 			if pw.sess.File.Path != "" {
 				e.cacheSkip(
@@ -8629,6 +11200,11 @@ func (e *Engine) writeSessionFullWithResolver(
 		log.Printf(
 			"set data_version for %s: %v", s.ID, err,
 		)
+		return err
+	}
+	if err := e.db.ReviveSourceMissingSession(s.ID); err != nil {
+		log.Printf("revive source-missing session %s: %v", s.ID, err)
+		return err
 	}
 
 	return nil
@@ -8991,14 +11567,15 @@ func toDBSession(pw pendingWrite) db.Session {
 		// not persist this field; the caller bumps it via
 		// SetSessionDataVersion only after the message
 		// rewrite succeeds.
-		FilePath:      strPtr(pw.sess.File.Path),
-		FileSize:      int64Ptr(pw.sess.File.Size),
-		FileMtime:     int64Ptr(pw.sess.File.Mtime),
-		NextOrdinal:   nextParsedOrdinal(0, pw.msgs),
-		LastEntryUUID: strPtr(lastParsedSourceUUID("", pw.msgs)),
-		FileInode:     int64Ptr(pw.sess.File.Inode),
-		FileDevice:    int64Ptr(pw.sess.File.Device),
-		FileHash:      strPtr(pw.sess.File.Hash),
+		FilePath:          strPtr(pw.sess.File.Path),
+		FileSize:          int64Ptr(pw.sess.File.Size),
+		FileMtime:         int64Ptr(pw.sess.File.Mtime),
+		NextOrdinal:       nextParsedOrdinal(0, pw.msgs),
+		LastEntryUUID:     strPtr(lastParsedSourceUUID("", pw.msgs)),
+		ClaudeLinearParse: pw.sess.ClaudeLinearParse,
+		FileInode:         int64Ptr(pw.sess.File.Inode),
+		FileDevice:        int64Ptr(pw.sess.File.Device),
+		FileHash:          strPtr(pw.sess.File.Hash),
 	}
 	db.ApplyParsedSessionIdentity(&s, pw.sess)
 	if pw.sess.FirstMessage != "" {
@@ -9610,7 +12187,7 @@ func applyProviderFingerprintFileInfo(
 	fingerprint parser.SourceFingerprint,
 	results []parser.ParseResultOutcome,
 ) {
-	if agent != parser.AgentDevin {
+	if agent != parser.AgentDevin && agent != parser.AgentHermes {
 		return
 	}
 	for i := range results {
@@ -9820,6 +12397,8 @@ func (e *Engine) SyncSingleSessionContext(
 	}
 
 	res := e.processFile(ctx, file)
+	defer e.retentionBudget().scavengeIfNeeded()
+	defer res.retentionLease.Release()
 	if res.err != nil {
 		if res.cacheSkip && res.mtime != 0 && !res.noCacheSkip {
 			e.cacheSkip(res.skipCacheKey(path), res.mtime, res.sourceFingerprint)
@@ -9852,6 +12431,24 @@ func (e *Engine) SyncSingleSessionContext(
 			)
 		}
 	}
+	// A virtual member gone from a still-existing shared container is
+	// tombstoned with its exact source ownership, mirroring
+	// collectAndBatch, so a single-session resync preserves the archive
+	// row as a revivable source-missing tombstone.
+	if len(res.sourceMissingMembers) > 0 &&
+		e.sourceAllowsParserExclusions(res) {
+		for _, member := range res.sourceMissingMembers {
+			if _, err := e.tombstoneSessionSourceOwnership(
+				ctx, e.machine, string(file.Agent),
+				member.sessionID, member.filePath,
+			); err != nil {
+				return fmt.Errorf(
+					"tombstone source-missing member %s: %w",
+					member.sessionID, err,
+				)
+			}
+		}
+	}
 
 	// Handle incremental updates from processFile (e.g.
 	// append-only JSONL that was already synced).
@@ -9869,10 +12466,11 @@ func (e *Engine) SyncSingleSessionContext(
 	for _, pr := range res.results {
 		if err := e.writeSessionFull(
 			pendingWrite{
-				sess:        pr.Session,
-				msgs:        pr.Messages,
-				usageEvents: pr.UsageEvents,
-				needsRetry:  res.needsRetryForSession(pr.Session.ID),
+				sess:         pr.Session,
+				msgs:         pr.Messages,
+				usageEvents:  pr.UsageEvents,
+				needsRetry:   res.needsRetryForSession(pr.Session.ID),
+				forceReplace: res.forceReplace,
 			},
 		); err != nil &&
 			!isIntentionalSessionSkip(err) &&

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -1,6 +1,7 @@
 package sync_test
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"database/sql"
@@ -1324,9 +1325,11 @@ func TestWatcherOverflowReverifiesSameStatOpenCodeStorage(t *testing.T) {
 	require.Equal(t, partInfo.Size(), rewrittenInfo.Size())
 	require.Equal(t, partInfo.ModTime(), rewrittenInfo.ModTime())
 
-	stats = env.engine.SyncAllAfterWatcherOverflow(context.Background(), nil)
-	require.False(t, stats.Aborted)
-	assert.Equal(t, 1, stats.Synced,
+	err = env.engine.ReconcileWatchRootsAfterLostEvents(context.Background(), nil, true)
+	require.NoError(t, err)
+	result := env.engine.LastReconciliationResult()
+	assert.True(t, result.Complete)
+	assert.Equal(t, 1, result.Metrics.MaxRehydratedSources,
 		"overflow recovery must reparse event-sensitive storage sessions")
 	assertMessageContent(t, env.db, sessionID, "modified prompt")
 }
@@ -1414,10 +1417,10 @@ func TestSyncEngineKiroSQLiteUpdatePaths(t *testing.T) {
 	ks.updateSession(t, "malformed-session", malformedPayload, 1779015640000)
 	// Kiro is provider-authoritative: the database is rediscovered and
 	// re-parsed (TotalSessions counts the source), but the malformed payload
-	// yields no parseable session, so nothing is written and the previously
-	// archived session is preserved.
+	// yields no parseable session, so the source is reported failed and the
+	// previously archived session is preserved.
 	runSyncAndAssert(t, env.engine, sync.SyncStats{
-		TotalSessions: 1, Synced: 0, Skipped: 0,
+		TotalSessions: 1, Synced: 0, Skipped: 0, Failed: 1,
 	})
 	assertSessionMessageCount(t, env.db, "kiro:malformed-session", 4)
 }
@@ -1653,6 +1656,803 @@ func TestSyncEngineIntegration(t *testing.T) {
 	// FindSourceFile
 	src := env.engine.FindSourceFile("test-session")
 	assert.NotEmpty(t, src, "FindSourceFile returned empty")
+}
+
+func TestReconcileWatchRootsTombstonesSessionsBelowDeletedRoot(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentClaude)
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, "Hello").
+		AddClaudeAssistant(tsEarlyS5, "Hi there!").
+		String()
+	deletedRoot := filepath.Join(env.claudeDir, "deleted-project")
+	env.writeSession(t, deletedRoot, "deleted-root-session.jsonl", content)
+	require.Equal(t, 1, env.engine.SyncAll(t.Context(), nil).Synced)
+	stored, err := env.db.GetSession(t.Context(), "deleted-root-session")
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+
+	require.NoError(t, os.RemoveAll(deletedRoot))
+	require.NoError(t, env.engine.ReconcileWatchRoots(
+		t.Context(), []string{env.claudeDir}, false,
+	))
+
+	gone, err := env.db.GetSession(t.Context(), "deleted-root-session")
+	require.NoError(t, err)
+	assert.Nil(t, gone,
+		"authoritative watch-root reconciliation must tombstone stored descendants")
+}
+
+func TestReconcileWatchRootsFullNilTombstonesEveryConfiguredLocalRoot(t *testing.T) {
+	for _, total := range []int{3, 300} {
+		t.Run(fmt.Sprintf("sessions-%d", total), func(t *testing.T) {
+			env := setupSingleAgentTestEnv(t, parser.AgentClaude)
+			paths := make([]string, 0, total)
+			for i := range total {
+				content := testjsonl.NewSessionBuilder().
+					AddClaudeUser(tsEarly, fmt.Sprintf("session %d", i)).
+					String()
+				paths = append(paths, env.writeClaudeSession(
+					t, "full-project", fmt.Sprintf("full-%03d.jsonl", i), content,
+				))
+			}
+			require.Equal(t, total, env.engine.SyncAll(t.Context(), nil).Synced)
+			for _, path := range paths[1:] {
+				require.NoError(t, os.Remove(path))
+			}
+
+			require.NoError(t, env.engine.ReconcileWatchRoots(t.Context(), nil, true))
+
+			kept, err := env.db.GetSession(t.Context(), "full-000")
+			require.NoError(t, err)
+			require.NotNil(t, kept, "the one retained local source must stay active")
+			for i := 1; i < total; i++ {
+				gone, err := env.db.GetSession(t.Context(), fmt.Sprintf("full-%03d", i))
+				require.NoError(t, err)
+				assert.Nil(t, gone, "full reconciliation must tombstone missing source %d", i)
+			}
+		})
+	}
+}
+
+func TestReconcileWatchRootsFullExcludesAndPreservesRemoteRoots(t *testing.T) {
+	localRoot := t.TempDir()
+	remoteRoot := "s3://example-bucket/machine/raw/claude"
+	env := setupTestEnv(t, WithClaudeDirs([]string{localRoot, remoteRoot}))
+	localContent := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, "local session").
+		String()
+	env.writeClaudeSession(t, "local-project", "local-session.jsonl", localContent)
+	remotePath := remoteRoot + "/project/remote-session.jsonl"
+	require.NoError(t, env.db.UpsertSession(db.Session{
+		ID: "remote-session", Agent: string(parser.AgentClaude),
+		Project: "remote-project", Machine: "remote", FilePath: &remotePath,
+	}))
+
+	require.NoError(t, env.engine.ReconcileWatchRoots(t.Context(), nil, true))
+
+	local, err := env.db.GetSession(t.Context(), "local-session")
+	require.NoError(t, err)
+	require.NotNil(t, local, "local discovery must still run")
+	remote, err := env.db.GetSession(t.Context(), "remote-session")
+	require.NoError(t, err)
+	require.NotNil(t, remote, "local watcher recovery must preserve remote ownership")
+	assert.Equal(t, 1,
+		env.engine.LastReconciliationResult().Metrics.ExcludedRemoteRoots)
+}
+
+func TestReconcileWatchRootsPreservesSameIDReplacementAtNewPath(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentClaude)
+	initial := testjsonl.NewSessionBuilder().AddClaudeUser(tsEarly, "old").String()
+	oldPath := env.writeClaudeSession(t, "old-project", "moved-session.jsonl", initial)
+	require.Equal(t, 1, env.engine.SyncAll(t.Context(), nil).Synced)
+
+	require.NoError(t, os.Remove(oldPath))
+	replacement := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, "replacement").
+		AddClaudeAssistant(tsEarlyS5, "still active").
+		String()
+	newPath := env.writeClaudeSession(t, "new-project", "moved-session.jsonl", replacement)
+	require.NoError(t, env.engine.ReconcileWatchRoots(
+		t.Context(), []string{env.claudeDir}, false,
+	))
+
+	active, err := env.db.GetSession(t.Context(), "moved-session")
+	require.NoError(t, err)
+	require.NotNil(t, active)
+	assert.Equal(t, newPath, env.db.GetSessionFilePath("moved-session"))
+	assertSessionMessageCount(t, env.db, "moved-session", 2)
+}
+
+func TestReconcileWatchRootsClaudeDiscoversSymlinkedProjectAndSubagent(t *testing.T) {
+	root := t.TempDir()
+	targetRoot := t.TempDir()
+	projectDir := "-Users-dev-code-demo"
+	sourceProject := filepath.Join(root, projectDir)
+	targetProject := filepath.Join(targetRoot, projectDir)
+	mainPath := filepath.Join(sourceProject, "session-main.jsonl")
+	subagentPath := filepath.Join(
+		sourceProject, "session-main", "subagents", "jobs", "job-1",
+		"agent-linked.jsonl",
+	)
+	mainContent := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, "main through symlink").String()
+	subagentContent := testjsonl.NewSessionBuilder().
+		AddClaudeUser(tsEarly, "subagent through symlink").String()
+	require.NoError(t, os.MkdirAll(filepath.Dir(
+		filepath.Join(targetProject, "session-main.jsonl")), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(targetProject, "session-main.jsonl"),
+		[]byte(mainContent), 0o644,
+	))
+	require.NoError(t, os.MkdirAll(filepath.Dir(filepath.Join(
+		targetProject, "session-main", "subagents", "jobs", "job-1",
+		"agent-linked.jsonl",
+	)), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(
+		targetProject, "session-main", "subagents", "jobs", "job-1",
+		"agent-linked.jsonl",
+	), []byte(subagentContent), 0o644))
+	if err := os.Symlink(targetProject, sourceProject); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {root}},
+		Machine:   "local",
+	})
+	t.Cleanup(engine.Close)
+
+	require.NoError(t, engine.ReconcileWatchRoots(t.Context(), []string{root}, false))
+	mainSession, err := database.GetSession(t.Context(), "session-main")
+	require.NoError(t, err)
+	require.NotNil(t, mainSession)
+	subagentSession, err := database.GetSession(t.Context(), "agent-linked")
+	require.NoError(t, err)
+	require.NotNil(t, subagentSession)
+	assert.Equal(t, mainPath, database.GetSessionFilePath("session-main"))
+	assert.Equal(t, subagentPath, database.GetSessionFilePath("agent-linked"))
+}
+
+func TestReconcileWatchRootsPreservesPersistentClaudeDuplicatePreference(t *testing.T) {
+	liveDir := t.TempDir()
+	archiveDir := t.TempDir()
+	env := setupTestEnv(t, WithClaudeDirs([]string{liveDir, archiveDir}))
+	content := testjsonl.NewSessionBuilder().AddClaudeUser(tsEarly, "duplicate").String()
+	livePath := env.writeSession(
+		t, liveDir, filepath.Join("live-project", "persistent-duplicate.jsonl"), content,
+	)
+	archivePath := env.writeSession(
+		t, archiveDir, filepath.Join("archive-project", "persistent-duplicate.jsonl"), content,
+	)
+	older := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	newer := older.Add(time.Second)
+	require.NoError(t, os.Chtimes(livePath, older, older))
+	require.NoError(t, os.Chtimes(archivePath, newer, newer))
+	require.Equal(t, 1, env.engine.SyncAll(t.Context(), nil).Synced)
+	assert.Equal(t, archivePath, env.db.GetSessionFilePath("persistent-duplicate"))
+
+	require.NoError(t, os.Remove(archivePath))
+	require.NoError(t, env.engine.ReconcileWatchRoots(
+		t.Context(), []string{archiveDir}, false,
+	))
+
+	active, err := env.db.GetSession(t.Context(), "persistent-duplicate")
+	require.NoError(t, err)
+	require.NotNil(t, active)
+	assert.Equal(t, livePath, env.engine.FindSourceFile("persistent-duplicate"),
+		"the surviving duplicate remains the resolvable preferred source")
+}
+
+func TestReconcileWatchRootsClaudeStoredPreferenceRequiresExactCurrentContent(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		invalidate func(*testing.T, *testEnv, string, time.Time)
+	}{
+		{
+			name: "hash mismatch",
+			invalidate: func(t *testing.T, _ *testEnv, path string, mtime time.Time) {
+				raw, err := os.ReadFile(path)
+				require.NoError(t, err)
+				changed := bytes.Replace(raw, []byte("duplicate"), []byte("changed!!"), 1)
+				require.Equal(t, len(raw), len(changed))
+				require.NoError(t, os.WriteFile(path, changed, 0o600))
+				require.NoError(t, os.Chtimes(path, mtime, mtime))
+			},
+		},
+		{
+			name: "stale data version",
+			invalidate: func(t *testing.T, env *testEnv, _ string, _ time.Time) {
+				require.NoError(t, env.db.SetSessionDataVersion("exact-current", 0))
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			liveDir := t.TempDir()
+			archiveDir := t.TempDir()
+			env := setupTestEnv(t, WithClaudeDirs([]string{liveDir, archiveDir}))
+			content := testjsonl.NewSessionBuilder().AddClaudeUser(tsEarly, "duplicate").String()
+			livePath := env.writeSession(
+				t, liveDir, filepath.Join("live", "exact-current.jsonl"), content,
+			)
+			archivePath := env.writeSession(
+				t, archiveDir, filepath.Join("archive", "exact-current.jsonl"), content,
+			)
+			base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+			require.NoError(t, os.Chtimes(livePath, base, base))
+			archiveMtime := base.Add(time.Second)
+			require.NoError(t, os.Chtimes(archivePath, archiveMtime, archiveMtime))
+			require.Equal(t, 1, env.engine.SyncAll(t.Context(), nil).Synced)
+			assert.Equal(t, archivePath, env.db.GetSessionFilePath("exact-current"))
+
+			tc.invalidate(t, env, archivePath, archiveMtime)
+			newLiveMtime := archiveMtime.Add(time.Second)
+			require.NoError(t, os.Chtimes(livePath, newLiveMtime, newLiveMtime))
+			require.NoError(t, env.engine.ReconcileWatchRoots(
+				t.Context(), []string{liveDir, archiveDir}, false,
+			))
+
+			assert.Equal(t, livePath, env.db.GetSessionFilePath("exact-current"))
+		})
+	}
+}
+
+func TestReconcileWatchRootsPreservesCodexLiveDuplicatePreference(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentCodex)
+	uuid := "b7c8d9e0-7890-4123-8abc-456789012345"
+	content := testjsonl.NewSessionBuilder().
+		AddCodexMeta(tsEarly, uuid, "/workspace/project", "user").
+		AddCodexMessage(tsEarlyS1, "user", "prefer the live transcript").
+		String()
+	livePath := env.writeCodexSession(
+		t, filepath.Join("2026", "07", "14"),
+		"rollout-2026-07-14T12-00-00-"+uuid+".jsonl", content,
+	)
+	env.writeSession(
+		t, env.codexDir,
+		"rollout-2026-07-14T13-00-00-"+uuid+".jsonl", content,
+	)
+
+	require.NoError(t, env.engine.ReconcileWatchRoots(
+		t.Context(), []string{env.codexDir}, false,
+	))
+
+	assert.Equal(t, livePath, env.db.GetSessionFilePath("codex:"+uuid))
+}
+
+func TestReconcileWatchRootsOpenClawUsesCanonicalArchiveOrdering(t *testing.T) {
+	root := t.TempDir()
+	sessionsDir := filepath.Join(root, "main", "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+	content := strings.Join([]string{
+		`{"type":"session","version":3,"id":"archive-order","timestamp":"2026-02-25T10:00:00Z","cwd":"/workspace/project"}`,
+		`{"type":"message","id":"m1","timestamp":"2026-02-25T10:00:01Z","message":{"role":"user","content":[{"type":"text","text":"canonical archive"}],"timestamp":"2026-02-25T10:00:01Z"}}`,
+	}, "\n") + "\n"
+	filenameOlder := filepath.Join(
+		sessionsDir,
+		"archive-order.jsonl.deleted.2026-01-01T00-00-00.000Z",
+	)
+	filenameNewer := filepath.Join(
+		sessionsDir,
+		"archive-order.jsonl.deleted.2026-03-01T00-00-00.000Z",
+	)
+	require.NoError(t, os.WriteFile(filenameOlder, []byte(content), 0o644))
+	require.NoError(t, os.WriteFile(filenameNewer, []byte(content), 0o644))
+	mtimeOlder := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	mtimeNewer := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(filenameOlder, mtimeOlder, mtimeOlder))
+	require.NoError(t, os.Chtimes(filenameNewer, mtimeNewer, mtimeNewer))
+
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentOpenClaw: {root}},
+		Machine:   "local",
+	})
+	t.Cleanup(engine.Close)
+
+	require.NoError(t, engine.ReconcileWatchRoots(t.Context(), []string{root}, false))
+	assert.Equal(t, filenameNewer,
+		database.GetSessionFilePath("openclaw:main:archive-order"))
+}
+
+func TestReconcileWatchRootsOpenCodeHybridPrefersCanonicalStorageSource(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentOpenCode)
+	const sessionID = "hybrid-reconcile"
+	storage := createOpenCodeStorageFixture(t, env.opencodeDir)
+	storagePath := storage.addSession(
+		t, "global", sessionID, "/workspace/storage", "Storage source",
+		1704067200000, 1704067205000,
+	)
+	storage.addMessage(t, sessionID, "storage-message", "assistant", 1704067201000, nil)
+	storage.addTextPart(
+		t, sessionID, "storage-message", "storage-part",
+		"canonical storage content", 1704067201000,
+	)
+
+	sqlite := createOpenCodeDB(t, env.opencodeDir)
+	sqlite.addProject(t, "project", "/workspace/sqlite")
+	sqlite.addSession(t, sessionID, "project", 1704067200000, 1704067209000)
+	sqlite.addMessage(t, "sqlite-message", sessionID, "assistant", 1704067201000)
+	sqlite.addTextPart(
+		t, "sqlite-part", sessionID, "sqlite-message",
+		"noncanonical sqlite content", 1704067201000,
+	)
+
+	require.NoError(t, env.engine.ReconcileWatchRoots(
+		t.Context(), []string{env.opencodeDir}, false,
+	))
+
+	assert.Equal(t, storagePath, env.db.GetSessionFilePath("opencode:"+sessionID))
+	assertMessageContent(t, env.db, "opencode:"+sessionID, "canonical storage content")
+}
+
+func TestReconcileWatchRootsOpenCodeHybridUnreadableSQLiteWithholdsTombstones(
+	t *testing.T,
+) {
+	env := setupSingleAgentTestEnv(t, parser.AgentOpenCode)
+	const priorID = "sqlite-prior"
+	sqlite := createOpenCodeDB(t, env.opencodeDir)
+	sqlite.addProject(t, "project", "/workspace/sqlite")
+	sqlite.addSession(t, priorID, "project", 1704067200000, 1704067209000)
+	sqlite.addMessage(t, "prior-message", priorID, "assistant", 1704067201000)
+	sqlite.addTextPart(
+		t, "prior-part", priorID, "prior-message", "prior sqlite content",
+		1704067201000,
+	)
+	require.NoError(t, env.engine.ReconcileWatchRoots(
+		t.Context(), []string{env.opencodeDir}, false,
+	))
+	assertMessageContent(t, env.db, "opencode:"+priorID, "prior sqlite content")
+
+	storage := createOpenCodeStorageFixture(t, env.opencodeDir)
+	const storageID = "storage-partial"
+	storagePath := storage.addSession(
+		t, "global", storageID, "/workspace/storage", "Storage partial",
+		1704067210000, 1704067215000,
+	)
+	storage.addMessage(t, storageID, "storage-message", "assistant", 1704067211000, nil)
+	storage.addTextPart(
+		t, storageID, "storage-message", "storage-part", "partial storage content",
+		1704067211000,
+	)
+	require.NoError(t, sqlite.db.Close())
+	require.NoError(t, os.WriteFile(sqlite.path, []byte("not sqlite"), 0o600))
+
+	err := env.engine.ReconcileWatchRoots(
+		t.Context(), []string{env.opencodeDir}, false,
+	)
+
+	require.Error(t, err)
+	var incomplete parser.DiscoveryIncompleteError
+	require.ErrorAs(t, err, &incomplete)
+	assert.Equal(t, parser.AgentOpenCode, incomplete.Provider)
+	result := env.engine.LastReconciliationResult()
+	assert.False(t, result.Complete)
+	assert.True(t, result.Aborted)
+	assert.Positive(t, result.ProviderFailures)
+	assert.Equal(t, storagePath, env.db.GetSessionFilePath("opencode:"+storageID),
+		"storage candidates yielded before the SQLite failure must still commit")
+	assertMessageContent(t, env.db, "opencode:"+storageID, "partial storage content")
+	prior, getErr := env.db.GetSessionFull(t.Context(), "opencode:"+priorID)
+	require.NoError(t, getErr)
+	require.NotNil(t, prior)
+	assert.Nil(t, prior.DeletionCause,
+		"incomplete SQLite discovery must withhold tombstone authority")
+	var retry interface {
+		error
+		ReconciliationRetryRoots() []string
+	}
+	require.ErrorAs(t, err, &retry)
+	assert.Equal(t, []string{env.opencodeDir}, retry.ReconciliationRetryRoots())
+
+	require.NoError(t, os.Remove(sqlite.path))
+	restored := createOpenCodeDB(t, env.opencodeDir)
+	restored.addProject(t, "project", "/workspace/sqlite")
+	require.NoError(t, env.engine.ReconcileWatchRoots(
+		t.Context(), []string{env.opencodeDir}, false,
+	))
+	prior, getErr = env.db.GetSessionFull(t.Context(), "opencode:"+priorID)
+	require.NoError(t, getErr)
+	require.NotNil(t, prior)
+	require.NotNil(t, prior.DeletionCause)
+	assert.Equal(t, "source_missing", *prior.DeletionCause,
+		"a successful retry may tombstone the now-authoritatively missing SQLite source")
+}
+
+func TestReconcileWatchRootsOpenCodeHybridCardinalityAndIdleGate(t *testing.T) {
+	const rows = 300
+	env := setupSingleAgentTestEnv(t, parser.AgentOpenCode)
+	storage := createOpenCodeStorageFixture(t, env.opencodeDir)
+	shadowPath := storage.addSession(
+		t, "global", "hybrid-0000", "/workspace/storage", "Storage shadow",
+		1704067200000, 1704067205000,
+	)
+	storage.addMessage(t, "hybrid-0000", "storage-message", "assistant", 1704067201000, nil)
+	storage.addTextPart(
+		t, "hybrid-0000", "storage-message", "storage-part",
+		"canonical storage content", 1704067201000,
+	)
+	sqlite := createOpenCodeDB(t, env.opencodeDir)
+	sqlite.addProject(t, "project", "/workspace/sqlite")
+	for i := range rows {
+		sessionID := fmt.Sprintf("hybrid-%04d", i)
+		messageID := fmt.Sprintf("message-%04d", i)
+		partID := fmt.Sprintf("part-%04d", i)
+		updated := int64(1704067209000)
+		if i == 0 {
+			updated = time.Now().Add(time.Hour).UnixMilli()
+		}
+		sqlite.addSession(t, sessionID, "project", 1704067200000, updated)
+		sqlite.addMessage(t, messageID, sessionID, "assistant", 1704067201000)
+		sqlite.addTextPart(t, partID, sessionID, messageID,
+			"sqlite content "+sessionID, 1704067201000)
+	}
+
+	require.NoError(t, env.engine.ReconcileWatchRoots(
+		t.Context(), []string{env.opencodeDir}, false,
+	))
+	first := env.engine.LastReconciliationResult()
+	assert.True(t, first.Complete)
+	assert.Equal(t, rows-1, first.Metrics.OpenCodeSQLiteParses,
+		"the storage-shadowed row must not be parsed from SQLite")
+	assert.Equal(t, shadowPath, env.db.GetSessionFilePath("opencode:hybrid-0000"))
+	assertMessageContent(t, env.db, "opencode:hybrid-0000", "canonical storage content")
+
+	require.NoError(t, env.engine.ReconcileWatchRoots(
+		t.Context(), []string{env.opencodeDir}, false,
+	))
+	idle := env.engine.LastReconciliationResult()
+	assert.True(t, idle.Complete)
+	assert.Zero(t, idle.Metrics.OpenCodeSQLiteParses,
+		"an unchanged trusted shared container must gate every row before parse")
+	assert.LessOrEqual(t, idle.Metrics.MaxSpoolPageRows, 256)
+
+	require.NoError(t, os.Remove(shadowPath))
+	require.NoError(t, env.engine.ReconcileWatchRoots(
+		t.Context(), []string{env.opencodeDir}, false,
+	))
+	unshadowed := env.engine.LastReconciliationResult()
+	assert.True(t, unshadowed.Complete)
+	assert.Equal(t, 1, unshadowed.Metrics.OpenCodeSQLiteParses,
+		"the newly exposed SQLite row must bypass the unchanged-container gate")
+	assertMessageContent(t, env.db, "opencode:hybrid-0000", "sqlite content hybrid-0000")
+}
+
+func TestReconcileWatchRootsScopesDiscoveryToRequestedRoot(t *testing.T) {
+	requested := t.TempDir()
+	unrelated := t.TempDir()
+	env := setupTestEnv(t, WithClaudeDirs([]string{requested, unrelated}))
+	content := testjsonl.NewSessionBuilder().AddClaudeUser(tsEarly, "scoped").String()
+	env.writeSession(t, requested, filepath.Join("project", "requested.jsonl"), content)
+	env.writeSession(t, unrelated, filepath.Join("project", "unrelated.jsonl"), content)
+
+	require.NoError(t, env.engine.ReconcileWatchRoots(
+		t.Context(), []string{requested}, false,
+	))
+
+	requestedSession, err := env.db.GetSession(t.Context(), "requested")
+	require.NoError(t, err)
+	assert.NotNil(t, requestedSession)
+	unrelatedSession, err := env.db.GetSession(t.Context(), "unrelated")
+	require.NoError(t, err)
+	assert.Nil(t, unrelatedSession)
+}
+
+func TestReconcileWatchRootsBoundsDiscoveryPagesAcrossArchiveCardinality(t *testing.T) {
+	for _, tc := range []struct {
+		count              int
+		wantMaxPage        int
+		wantProviderBuffer int
+	}{
+		{count: 3, wantMaxPage: 3, wantProviderBuffer: 3},
+		{count: 300, wantMaxPage: 256, wantProviderBuffer: 64},
+	} {
+		t.Run(fmt.Sprintf("sessions-%d", tc.count), func(t *testing.T) {
+			env := setupSingleAgentTestEnv(t, parser.AgentClaude)
+			content := testjsonl.NewSessionBuilder().
+				AddClaudeUser(tsEarly, "bounded reconciliation").
+				String()
+			for i := 0; i < tc.count; i++ {
+				env.writeClaudeSession(
+					t, "project", fmt.Sprintf("bounded-%04d.jsonl", i), content,
+				)
+			}
+
+			require.NoError(t, env.engine.ReconcileWatchRoots(
+				t.Context(), []string{env.claudeDir}, false,
+			))
+
+			result := env.engine.LastReconciliationResult()
+			assert.True(t, result.Complete)
+			assert.False(t, result.Aborted)
+			assert.Equal(t, tc.wantMaxPage, result.Metrics.MaxSpoolPageRows)
+			assert.Equal(t, tc.wantMaxPage, result.Metrics.MaxRehydratedSources)
+			assert.Equal(t, tc.wantProviderBuffer, result.Metrics.MaxProviderBuffered)
+			assert.LessOrEqual(t, result.Metrics.MaxWorkerResults, 24)
+			assert.LessOrEqual(t, result.Metrics.MaxPendingWrites, 100)
+			assert.Positive(t, result.Metrics.MaxWorkerResults)
+			assert.Positive(t, result.Metrics.MaxPendingWrites)
+			assert.Equal(t, 1, result.Metrics.GlobalLinkPasses,
+				"global subagent linking must run once after every reconciliation page")
+			stored, err := env.db.GetSession(t.Context(), "bounded-0000")
+			require.NoError(t, err)
+			assert.NotNil(t, stored)
+		})
+	}
+}
+
+func TestColdArchiveChangedPathAndReconciliationAreCardinalityBounded(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	type outcome struct {
+		appendStats      sync.SyncStats
+		replacementStats sync.SyncStats
+		deleted          bool
+		oldRenamePrefix  bool
+		newRenamePrefix  bool
+	}
+	var outcomes []outcome
+	for _, tc := range []struct {
+		name      string
+		coldFiles int
+	}{
+		{name: "small", coldFiles: 3},
+		{name: "large", coldFiles: 300},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			env := setupSingleAgentTestEnv(t, parser.AgentClaude)
+			changed := testjsonl.NewSessionBuilder().
+				AddClaudeUser(tsEarly, "changed session").
+				String()
+			changedPath := env.writeClaudeSession(
+				t, "active", "changed-session.jsonl", changed,
+			)
+			cold := testjsonl.NewSessionBuilder().
+				AddClaudeUser(tsEarly, "cold session").
+				String()
+			for i := range tc.coldFiles {
+				env.writeClaudeSession(
+					t,
+					fmt.Sprintf("cold-%03d", i),
+					fmt.Sprintf("cold-%03d.jsonl", i),
+					cold,
+				)
+			}
+
+			env.engine.SyncPathsContext(t.Context(), []string{changedPath})
+			stored, err := env.db.GetSession(t.Context(), "changed-session")
+			require.NoError(t, err)
+			require.NotNil(t, stored)
+			coldStored, err := env.db.GetSession(t.Context(), "cold-000")
+			require.NoError(t, err)
+			assert.Nil(t, coldStored,
+				"changed-path sync must not classify an unchanged cold archive")
+
+			appendFile, err := os.OpenFile(changedPath, os.O_APPEND|os.O_WRONLY, 0)
+			require.NoError(t, err)
+			_, err = appendFile.WriteString(testjsonl.NewSessionBuilder().
+				AddClaudeAssistant(tsEarlyS5, "appended answer").
+				String())
+			require.NoError(t, err)
+			require.NoError(t, appendFile.Close())
+			env.engine.SyncPathsContext(t.Context(), []string{changedPath})
+			appendStats := env.engine.LastSyncStats()
+			assert.Equal(t, 1, appendStats.TotalSessions)
+			assert.Equal(t, 1, appendStats.Synced)
+			assertSessionMessageCount(t, env.db, "changed-session", 2)
+
+			replacement := testjsonl.NewSessionBuilder().
+				AddClaudeUser(tsEarly, "atomic replacement").
+				AddClaudeAssistant(tsEarlyS5, "replacement answer").
+				String()
+			temp, err := os.CreateTemp(filepath.Dir(changedPath), ".replacement-*")
+			require.NoError(t, err)
+			_, err = temp.WriteString(replacement)
+			require.NoError(t, err)
+			require.NoError(t, temp.Close())
+			require.NoError(t, os.Rename(temp.Name(), changedPath))
+			env.engine.SyncPathsContext(t.Context(), []string{changedPath})
+			replacementStats := env.engine.LastSyncStats()
+			assert.Equal(t, 1, replacementStats.TotalSessions)
+			assert.Equal(t, 1, replacementStats.Synced)
+			assertMessageContent(
+				t, env.db, "changed-session", "atomic replacement", "replacement answer",
+			)
+
+			moveContent := testjsonl.NewSessionBuilder().
+				AddClaudeUser(tsEarly, "directory rename").
+				String()
+			oldDir := filepath.Join(env.claudeDir, "rename-source")
+			oldPath := env.writeSession(t, oldDir, "directory-move.jsonl", moveContent)
+			env.engine.SyncPathsContext(t.Context(), []string{oldPath})
+			newDir := filepath.Join(env.claudeDir, "rename-destination")
+			require.NoError(t, os.Rename(oldDir, newDir))
+
+			require.NoError(t, env.engine.ReconcileWatchRoots(
+				t.Context(), []string{env.claudeDir}, false,
+			))
+			result := env.engine.LastReconciliationResult()
+			assert.True(t, result.Complete)
+			assert.False(t, result.Aborted)
+			assert.LessOrEqual(t, result.Metrics.MaxSpoolPageRows, 256)
+			assert.LessOrEqual(t, result.Metrics.MaxProviderBuffered, 64)
+			assert.LessOrEqual(t, result.Metrics.MaxRehydratedSources, 256)
+			assert.LessOrEqual(t, result.Metrics.MaxWorkerResults, 24)
+			assert.LessOrEqual(t, result.Metrics.MaxPendingWrites, 100)
+			assert.Equal(t, 1, result.Metrics.GlobalLinkPasses)
+			assert.Equal(t,
+				filepath.Join(newDir, "directory-move.jsonl"),
+				env.db.GetSessionFilePath("directory-move"),
+			)
+			oldRenamePrefix, err := env.db.HasActiveSessionSourceBelow(
+				string(parser.AgentClaude), oldDir,
+			)
+			require.NoError(t, err)
+			newRenamePrefix, err := env.db.HasActiveSessionSourceBelow(
+				string(parser.AgentClaude), newDir,
+			)
+			require.NoError(t, err)
+			assert.False(t, oldRenamePrefix,
+				"one reconciliation must retire source-side ownership after a directory rename")
+			assert.True(t, newRenamePrefix,
+				"one reconciliation must activate destination ownership after a directory rename")
+
+			require.NoError(t, os.Remove(changedPath))
+			require.NoError(t, env.engine.ReconcileWatchRoots(
+				t.Context(), []string{env.claudeDir}, false,
+			))
+			deletedSession, err := env.db.GetSession(t.Context(), "changed-session")
+			require.NoError(t, err)
+			deleted := deletedSession == nil
+			assert.True(t, deleted,
+				"authoritative reconciliation must tombstone the deleted source")
+
+			outcomes = append(outcomes, outcome{
+				appendStats: appendStats, replacementStats: replacementStats,
+				deleted: deleted, oldRenamePrefix: oldRenamePrefix,
+				newRenamePrefix: newRenamePrefix,
+			})
+		})
+	}
+	require.Len(t, outcomes, 2)
+	assert.Equal(t, outcomes[0], outcomes[1],
+		"changed-path classification, deletion, and rename ownership must not scale with cold cardinality")
+}
+
+func TestReconcileWatchRootsPreservesSessionWhenPersistentBackingDatabaseDisappears(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := createShelleyMainDB(t, dir)
+	engine, database := newShelleyEngine(t, dir)
+	require.Equal(t, 1, engine.SyncAll(t.Context(), nil).Synced)
+	require.NoError(t, os.Remove(dbPath))
+
+	require.NoError(t, engine.ReconcileWatchRoots(t.Context(), []string{dir}, false))
+
+	stored, err := database.GetSession(t.Context(), "shelley:cMAIN1")
+	require.NoError(t, err)
+	require.NotNil(t, stored,
+		"a vanished backing database must not erase the persistent SQLite archive")
+	assert.Equal(t, "shelley:cMAIN1", stored.ID)
+}
+
+func TestReconcileWatchRootsKiroPreservesOnlySQLiteSourcesWithHashPaths(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "kiro#archive")
+	require.NoError(t, os.Mkdir(root, 0o700))
+	env := setupSingleAgentTestEnvWithDirs(t, parser.AgentKiro, []string{root})
+	ks := createKiroSQLiteDB(t, root)
+	ks.addSession(
+		t, "/home/user/code/kiro-app", "sqlite-session",
+		readKiroSQLiteFixture(t, "standard_payload.json"),
+		1779012000000, 1779012030000,
+	)
+	ks.close(t)
+	const legacyID = "legacy#session"
+	writeLegacyKiroSession(t, root, legacyID, "legacy should be tombstoned")
+
+	stats := env.engine.SyncAll(t.Context(), nil)
+	require.False(t, stats.Aborted)
+	require.Equal(t, 2, stats.Synced)
+	require.NoError(t, os.Remove(ks.path))
+	require.NoError(t, os.Remove(filepath.Join(root, legacyID+".jsonl")))
+	require.NoError(t, os.Remove(filepath.Join(root, legacyID+".json")))
+
+	require.NoError(t, env.engine.ReconcileWatchRoots(
+		t.Context(), []string{root}, false,
+	))
+
+	sqliteSession, err := env.db.GetSession(t.Context(), "kiro:sqlite-session")
+	require.NoError(t, err)
+	assert.NotNil(t, sqliteSession,
+		"a vanished Kiro SQLite store must preserve its archived members")
+	legacySession, err := env.db.GetSession(t.Context(), "kiro:"+legacyID)
+	require.NoError(t, err)
+	assert.Nil(t, legacySession,
+		"an ordinary Kiro JSONL source must tombstone even when its root and filename contain #")
+}
+
+func TestReconcileWatchRootsKiroSQLiteBasenameJSONLRemainsLegacy(t *testing.T) {
+	root := t.TempDir()
+	env := setupSingleAgentTestEnvWithDirs(t, parser.AgentKiro, []string{root})
+	ks := createKiroSQLiteDB(t, root)
+	ks.addSession(
+		t, "/home/user/code/kiro-app", "sqlite-session",
+		readKiroSQLiteFixture(t, "standard_payload.json"),
+		1779012000000, 1779012030000,
+	)
+	ks.close(t)
+	legacyIDs := []string{
+		"data.sqlite3#legacy",
+		"data.sqlite3-copy#legacy",
+		"data.sqlite3-wal#legacy",
+		"data.sqlite30#legacy",
+		"other.sqlite3#legacy",
+	}
+	for _, id := range legacyIDs {
+		writeLegacyKiroSession(t, root, id, "legacy basename collision")
+	}
+
+	stats := env.engine.SyncAll(t.Context(), nil)
+	require.False(t, stats.Aborted)
+	require.Equal(t, 6, stats.Synced)
+	for _, id := range legacyIDs {
+		stored, err := env.db.GetSession(t.Context(), "kiro:"+id)
+		require.NoError(t, err)
+		require.NotNil(t, stored, "legacy source %s must sync as JSONL", id)
+	}
+
+	require.NoError(t, os.Remove(ks.path))
+	for _, id := range legacyIDs {
+		require.NoError(t, os.Remove(filepath.Join(root, id+".jsonl")))
+		require.NoError(t, os.Remove(filepath.Join(root, id+".json")))
+	}
+	require.NoError(t, env.engine.ReconcileWatchRoots(
+		t.Context(), []string{root}, false,
+	))
+
+	sqliteSession, err := env.db.GetSession(t.Context(), "kiro:sqlite-session")
+	require.NoError(t, err)
+	assert.NotNil(t, sqliteSession,
+		"the real Kiro SQLite member must survive a vanished container")
+	for _, id := range legacyIDs {
+		stored, err := env.db.GetSession(t.Context(), "kiro:"+id)
+		require.NoError(t, err)
+		assert.Nil(t, stored, "deleted legacy source %s must tombstone", id)
+	}
+}
+
+func TestOrdinarySyncPreservesPersistentArchiveAfterSourceDeletion(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentClaude)
+	content := testjsonl.NewSessionBuilder().AddClaudeUser(tsEarly, "archived").String()
+	path := env.writeClaudeSession(t, "archive-project", "persistent-archive.jsonl", content)
+	require.Equal(t, 1, env.engine.SyncAll(t.Context(), nil).Synced)
+	require.NoError(t, os.Remove(path))
+
+	env.engine.SyncAll(t.Context(), nil)
+
+	active, err := env.db.GetSession(t.Context(), "persistent-archive")
+	require.NoError(t, err)
+	assert.NotNil(t, active,
+		"ordinary sync preserves the archive; only watcher reconciliation tombstones")
+}
+
+func TestWatcherPathDeletionTombstonesPersistentArchiveSource(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentClaude)
+	content := testjsonl.NewSessionBuilder().AddClaudeUser(tsEarly, "archived").String()
+	path := env.writeClaudeSession(t, "archive-project", "watcher-delete.jsonl", content)
+	require.Equal(t, 1, env.engine.SyncAll(t.Context(), nil).Synced)
+	require.NoError(t, os.Remove(path))
+
+	env.engine.SyncPathsContext(t.Context(), []string{path})
+
+	active, err := env.db.GetSession(t.Context(), "watcher-delete")
+	require.NoError(t, err)
+	assert.Nil(t, active, "watcher deletion must hide the missing source")
+	archived, err := env.db.GetSessionFull(t.Context(), "watcher-delete")
+	require.NoError(t, err)
+	require.NotNil(t, archived, "watcher deletion must retain the archive row")
+	assert.NotNil(t, archived.DeletedAt)
 }
 
 func TestSyncEngineWorktreesShareProject(t *testing.T) {
@@ -2783,7 +3583,8 @@ func TestSyncEngineProgress(t *testing.T) {
 	})
 
 	assert.NotZero(t, progressCalls, "expected progress callbacks")
-	assert.Equal(t, 4, firstTotal, "first progress total = %d, want 4", firstTotal)
+	assert.Equal(t, 3, firstTotal,
+		"the initial total contains file sources before streamed DB discovery")
 	assert.Equal(t, 4, last.SessionsDone, "last progress = %d/%d, want 4/4", last.SessionsDone, last.SessionsTotal)
 	assert.Equal(t, 4, last.SessionsTotal, "last progress = %d/%d, want 4/4", last.SessionsDone, last.SessionsTotal)
 	requireProgressDoneOnce(t, events, 4)
@@ -2805,7 +3606,8 @@ func TestSyncEngineProgress(t *testing.T) {
 		events = append(events, p)
 	})
 	assert.NotZero(t, progressCalls, "expected progress callbacks on second sync")
-	assert.Equal(t, 4, firstTotal, "second first progress total = %d, want 4", firstTotal)
+	assert.Equal(t, 3, firstTotal,
+		"the initial total contains file sources before streamed DB discovery")
 	assert.Equal(t, 4, last.SessionsDone, "second last progress = %d/%d, want 4/4", last.SessionsDone, last.SessionsTotal)
 	assert.Equal(t, 4, last.SessionsTotal, "second last progress = %d/%d, want 4/4", last.SessionsDone, last.SessionsTotal)
 	requireProgressDoneOnce(t, events, 4)
@@ -4394,6 +5196,134 @@ func TestSyncAllSinceCodexIndexRefreshDoesNotShadowChangedArchivedDuplicate(t *t
 		assert.Equal(t, "Renamed title", *sess.SessionName)
 	}
 	assertSessionMessageCount(t, env.db, "codex:"+uuid, 2)
+}
+
+func TestReconcileWatchRootsCodexPreservesLiveDuplicateOfRemovedArchivedCopy(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	codexDir := filepath.Join(root, "sessions")
+	archivedDir := filepath.Join(root, "archived_sessions")
+	require.NoError(t, os.MkdirAll(codexDir, 0o755))
+	require.NoError(t, os.MkdirAll(archivedDir, 0o755))
+	env := setupTestEnv(t, WithCodexDirs([]string{codexDir, archivedDir}))
+
+	uuid := "f7a8b9ca-7890-1234-ef01-456789012345"
+	content := testjsonl.NewSessionBuilder().
+		AddCodexMeta(tsEarly, uuid, "/home/user/code/api", "user").
+		AddCodexMessage(tsEarlyS1, "user", "Duplicated copy").
+		String()
+
+	// Only the archived copy exists at first sync, so the DB tracks it.
+	archivedPath := env.writeSession(
+		t, archivedDir, "rollout-2026-05-04T14-31-58-"+uuid+".jsonl", content,
+	)
+	require.Equal(t, 1, env.engine.SyncAll(t.Context(), nil).Synced)
+	require.Equal(t, archivedPath, env.db.GetSessionFilePath("codex:"+uuid))
+
+	// The tracked archived copy vanishes while a live dated duplicate remains.
+	livePath := env.writeCodexSession(
+		t, filepath.Join("2026", "05", "04"),
+		"rollout-2026-05-04T02-10-04-"+uuid+".jsonl", content,
+	)
+	require.NoError(t, os.Remove(archivedPath))
+	require.NoError(t, env.engine.ReconcileWatchRoots(
+		t.Context(), []string{archivedDir}, false,
+	))
+
+	active, err := env.db.GetSession(t.Context(), "codex:"+uuid)
+	require.NoError(t, err)
+	require.NotNil(t, active,
+		"a surviving same-UUID duplicate is a replacement, not a deletion")
+
+	// With every copy gone, reconciliation must still tombstone.
+	require.NoError(t, os.Remove(livePath))
+	require.NoError(t, env.engine.ReconcileWatchRoots(
+		t.Context(), []string{codexDir, archivedDir}, false,
+	))
+	tombstoned, err := env.db.GetSession(t.Context(), "codex:"+uuid)
+	require.NoError(t, err)
+	assert.Nil(t, tombstoned,
+		"deleting the last on-disk copy must still tombstone the session")
+}
+
+func TestReconcileWatchRootsCodexReplacementIndexBuildsOncePerPass(
+	t *testing.T,
+) {
+	for _, tc := range []struct {
+		name      string
+		extraLive int
+	}{
+		{"small archive", 2},
+		{"large archive", 40},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			codexDir := filepath.Join(root, "sessions")
+			archivedDir := filepath.Join(root, "archived_sessions")
+			require.NoError(t, os.MkdirAll(codexDir, 0o755))
+			require.NoError(t, os.MkdirAll(archivedDir, 0o755))
+			env := setupTestEnv(t, WithCodexDirs([]string{codexDir, archivedDir}))
+
+			uuidFor := func(i int) string {
+				return fmt.Sprintf("f7a8b9ca-7890-1234-ef01-4567890123%02d", i)
+			}
+			contentFor := func(uuid string) string {
+				return testjsonl.NewSessionBuilder().
+					AddCodexMeta(tsEarly, uuid, "/home/user/code/api", "user").
+					AddCodexMessage(tsEarlyS1, "user", "Copy "+uuid).
+					String()
+			}
+			// Unrelated live sessions scale the archive; per-pass
+			// replacement work must not scale with them.
+			for i := 10; i < 10+tc.extraLive; i++ {
+				env.writeCodexSession(
+					t, filepath.Join("2026", "05", "04"),
+					"rollout-2026-05-04T01-00-00-"+uuidFor(i)+".jsonl",
+					contentFor(uuidFor(i)),
+				)
+			}
+			archived := make([]string, 3)
+			for i := range archived {
+				archived[i] = env.writeSession(
+					t, archivedDir,
+					"rollout-2026-05-04T14-31-58-"+uuidFor(i)+".jsonl",
+					contentFor(uuidFor(i)),
+				)
+			}
+			require.Equal(
+				t, 3+tc.extraLive, env.engine.SyncAll(t.Context(), nil).Synced,
+			)
+
+			// Every archived copy vanishes; only the first has a
+			// surviving live duplicate.
+			env.writeCodexSession(
+				t, filepath.Join("2026", "05", "04"),
+				"rollout-2026-05-04T02-10-04-"+uuidFor(0)+".jsonl",
+				contentFor(uuidFor(0)),
+			)
+			for _, path := range archived {
+				require.NoError(t, os.Remove(path))
+			}
+			require.NoError(t, env.engine.ReconcileWatchRoots(
+				t.Context(), []string{codexDir, archivedDir}, false,
+			))
+
+			preserved, err := env.db.GetSession(t.Context(), "codex:"+uuidFor(0))
+			require.NoError(t, err)
+			assert.NotNil(t, preserved,
+				"the duplicate-backed session must survive")
+			for i := 1; i < 3; i++ {
+				gone, err := env.db.GetSession(t.Context(), "codex:"+uuidFor(i))
+				require.NoError(t, err)
+				assert.Nil(t, gone,
+					"sessions with no surviving copy must tombstone")
+			}
+			result := env.engine.LastReconciliationResult()
+			assert.Equal(t, 0, result.Metrics.CodexReplacementIndexBuilds,
+				"a streamed pass must answer replacement lookups from the discovery spool without an extra archive walk")
+		})
+	}
 }
 
 func TestSyncPathsCodexIndexEventRefreshesStoredDuplicate(t *testing.T) {
@@ -9807,9 +10737,6 @@ func TestIncrementalSync_ClaudeProgressOnlyRepairsStoredSubagentMapping(
 // sync engine detects the identity change and falls back to a
 // full parse instead of treating the new content as an append.
 func TestIncrementalSync_ClaudeFileReplaced(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("identity tracking is a no-op on Windows")
-	}
 	env := setupTestEnv(t)
 
 	original := testjsonl.JoinJSONL(
@@ -9891,9 +10818,6 @@ func TestIncrementalSync_ClaudeTruncatedFileReplacesStoredMessages(t *testing.T)
 }
 
 func TestIncrementalSync_ClaudeSameSizeFileReplaceUsesFullParse(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("identity tracking is a no-op on Windows")
-	}
 	env := setupTestEnv(t)
 
 	original := testjsonl.JoinJSONL(
@@ -9925,9 +10849,6 @@ func TestIncrementalSync_ClaudeSameSizeFileReplaceUsesFullParse(t *testing.T) {
 func TestIncrementalSync_ClaudeSameSizeSameMtimeFileReplaceUsesFullParse(
 	t *testing.T,
 ) {
-	if runtime.GOOS == "windows" {
-		t.Skip("identity tracking is a no-op on Windows")
-	}
 	env := setupTestEnv(t)
 
 	original := testjsonl.JoinJSONL(
@@ -9976,9 +10897,6 @@ func TestIncrementalSync_ClaudeSameSizeSameMtimeFileReplaceUsesFullParse(
 func TestIncrementalSync_ClaudeForkSameSizeSameMtimeFileReplaceUsesFullParse(
 	t *testing.T,
 ) {
-	if runtime.GOOS == "windows" {
-		t.Skip("identity tracking is a no-op on Windows")
-	}
 	env := setupTestEnv(t)
 
 	original := testjsonl.NewSessionBuilder().
@@ -10051,9 +10969,6 @@ func TestIncrementalSync_ClaudeForkSameSizeSameMtimeFileReplaceUsesFullParse(
 }
 
 func TestIncrementalSync_ClaudePathRewriterIgnoresTempInodeChange(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("identity tracking is a no-op on Windows")
-	}
 	db := dbtest.OpenTestDB(t)
 	firstRoot := t.TempDir()
 	secondRoot := t.TempDir()
@@ -10118,10 +11033,6 @@ func TestIncrementalSync_ClaudePathRewriterIgnoresTempInodeChange(t *testing.T) 
 // content guard hashes the materialized download, so an unchanged copy must
 // still skip while a genuine same-size same-mtime rewrite must full-parse.
 func TestIncrementalSync_ClaudePathRewriterSameSizeSameMtimeRewrite(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("identity tracking is a no-op on Windows")
-	}
-
 	original := testjsonl.JoinJSONL(
 		testjsonl.ClaudeUserJSON("first", tsZero),
 		testjsonl.ClaudeAssistantJSON("alpha", tsZeroS5),
@@ -10279,9 +11190,6 @@ func TestIncrementalSync_ClaudeSameSizeInPlaceRewriteClearsStaleRows(t *testing.
 func TestIncrementalSync_ClaudeSameSizeSameMtimeInPlaceRewriteUsesFullParse(
 	t *testing.T,
 ) {
-	if runtime.GOOS == "windows" {
-		t.Skip("identity tracking is a no-op on Windows")
-	}
 	env := setupSingleAgentTestEnv(t, parser.AgentClaude)
 
 	original := testjsonl.JoinJSONL(
@@ -10506,6 +11414,164 @@ func TestIncrementalSync_ClaudeAgentIDLinksIncrementally(t *testing.T) {
 	assert.Equal(t, len("done"), msgs[1].ToolCalls[0].ResultContentLength)
 }
 
+// A plain tool_result (no toolUseResult.agentId) appended after its
+// tool_use was stored must stay on the incremental path: the parser
+// emits a result-only link, the stored tool_call gains the result
+// content, and the tool-result-only carrier line is not stored as a
+// message (parity with the full parser's pairAndFilter).
+func TestIncrementalSync_ClaudePlainToolResultLinksIncrementally(
+	t *testing.T,
+) {
+	env := setupTestEnv(t)
+
+	initial := testjsonl.JoinJSONL(
+		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"u1","message":{"content":"go"},"cwd":"/tmp"}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:00:01Z","uuid":"a1","parentUuid":"u1","message":{"id":"msg_one","content":[{"type":"tool_use","id":"toolu_plain","name":"Bash","input":{"command":"ls"}}],"stop_reason":"tool_use"}}`,
+	)
+	path := env.writeClaudeSession(
+		t, "proj-plain-result", "parent-plain-result.jsonl", initial,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+
+	var assistantMessageID int64
+	require.NoError(t, env.db.Reader().QueryRow(`
+		SELECT id
+		FROM messages
+		WHERE session_id = ? AND ordinal = 1`,
+		"parent-plain-result",
+	).Scan(&assistantMessageID), "query message id before append")
+
+	toolResult := `{"type":"user","timestamp":"2024-01-01T10:00:02Z","uuid":"r1","parentUuid":"a1","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_plain","content":"file-a\nfile-b"}]}}`
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err, "open for append")
+	_, writeErr := f.WriteString(toolResult + "\n")
+	require.NoError(t, f.Close(), "close append")
+	require.NoError(t, writeErr, "append")
+
+	env.engine.SyncPaths([]string{path})
+
+	var gotMessageID int64
+	require.NoError(t, env.db.Reader().QueryRow(`
+		SELECT id
+		FROM messages
+		WHERE session_id = ? AND ordinal = 1`,
+		"parent-plain-result",
+	).Scan(&gotMessageID), "query message id after append")
+	assert.Equal(t, assistantMessageID, gotMessageID,
+		"assistant row must survive the append (incremental, not replace)")
+
+	msgs := fetchMessages(t, env.db, "parent-plain-result")
+	require.Len(t, msgs, 2,
+		"tool-result-only carrier must not be stored as a message")
+	require.Len(t, msgs[1].ToolCalls, 1)
+	assert.Equal(t, "file-a\nfile-b", msgs[1].ToolCalls[0].ResultContent)
+	assert.Equal(t, len("file-a\nfile-b"),
+		msgs[1].ToolCalls[0].ResultContentLength)
+}
+
+// Rewinding onto an entry that the full parser resolves in its DAG
+// but that never became a stored message row (here a tool-result-only
+// carrier dropped by pairAndFilter) must trigger a full parse, not a
+// linear append: the full parser treats the branch as a small-gap
+// retry and drops the superseded answer.
+func TestIncrementalSync_ClaudeRewindOntoFilteredCarrierFullParses(
+	t *testing.T,
+) {
+	env := setupTestEnv(t)
+
+	initial := testjsonl.JoinJSONL(
+		`{"type":"user","uuid":"u1","timestamp":"2024-01-01T10:00:00Z","message":{"content":"go"},"cwd":"/tmp"}`,
+		`{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2024-01-01T10:00:01Z","message":{"id":"msg_1","content":[{"type":"tool_use","id":"toolu_1","name":"Bash","input":{"command":"ls"}}]}}`,
+		`{"type":"user","uuid":"u2","parentUuid":"a1","timestamp":"2024-01-01T10:00:02Z","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"out"}]}}`,
+		`{"type":"assistant","uuid":"a2","parentUuid":"u2","timestamp":"2024-01-01T10:00:03Z","message":{"id":"msg_2","content":[{"type":"text","text":"first answer"}]}}`,
+	)
+	path := env.writeClaudeSession(
+		t, "proj-rewind", "parent-rewind.jsonl", initial,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+
+	// The carrier u2 is filtered from stored messages but resolvable
+	// in the full parser's DAG.
+	msgs := fetchMessages(t, env.db, "parent-rewind")
+	require.Len(t, msgs, 3, "carrier must not be stored")
+
+	appended := `{"type":"assistant","uuid":"a3","parentUuid":"u2","timestamp":"2024-01-01T10:01:00Z","message":{"id":"msg_3","content":[{"type":"text","text":"retry answer"}]}}`
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err, "open for append")
+	_, writeErr := f.WriteString(appended + "\n")
+	require.NoError(t, f.Close(), "close append")
+	require.NoError(t, writeErr, "append")
+
+	env.engine.SyncPaths([]string{path})
+
+	msgs = fetchMessages(t, env.db, "parent-rewind")
+	var contents []string
+	for _, m := range msgs {
+		contents = append(contents, m.Content)
+	}
+	assert.NotContains(t, contents, "first answer",
+		"full parse follows the retry branch and drops the old answer")
+	assert.Contains(t, contents, "retry answer")
+}
+
+// A linear-bound session (chain routed through an attachment line, as
+// every real CLI transcript is) keeps appending incrementally across
+// chain breaks: the stored claude_linear_parse verdict tells the
+// incremental parser that the full parser ignores parent uuids for
+// this file.
+func TestIncrementalSync_ClaudeLinearBoundChainBreakStaysIncremental(
+	t *testing.T,
+) {
+	env := setupTestEnv(t)
+
+	initial := testjsonl.JoinJSONL(
+		`{"type":"attachment","uuid":"att-0","timestamp":"2024-01-01T10:00:00Z","attachment":{"type":"task_reminder"}}`,
+		`{"type":"user","uuid":"u1","parentUuid":"att-0","timestamp":"2024-01-01T10:00:00Z","message":{"content":"go"},"cwd":"/tmp"}`,
+		`{"type":"assistant","uuid":"a1","parentUuid":"u1","timestamp":"2024-01-01T10:00:01Z","message":{"id":"msg_1","content":[{"type":"text","text":"hi"}]}}`,
+	)
+	path := env.writeClaudeSession(
+		t, "proj-linear-bound", "parent-linear-bound.jsonl", initial,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+
+	var assistantMessageID int64
+	require.NoError(t, env.db.Reader().QueryRow(`
+		SELECT id
+		FROM messages
+		WHERE session_id = ? AND ordinal = 1`,
+		"parent-linear-bound",
+	).Scan(&assistantMessageID), "query message id before append")
+
+	// The appended chain routes through a fresh attachment whose
+	// parent lives in the stored region — a chain break for the
+	// incremental parser, invisible to the full parser.
+	appended := testjsonl.JoinJSONL(
+		`{"type":"attachment","uuid":"att-1","parentUuid":"a1","timestamp":"2024-01-01T10:01:00Z","attachment":{"type":"task_reminder"}}`,
+		`{"type":"user","uuid":"u2","parentUuid":"att-1","timestamp":"2024-01-01T10:01:01Z","message":{"content":"next"}}`,
+	)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err, "open for append")
+	_, writeErr := f.WriteString(appended)
+	require.NoError(t, f.Close(), "close append")
+	require.NoError(t, writeErr, "append")
+
+	env.engine.SyncPaths([]string{path})
+
+	var gotMessageID int64
+	require.NoError(t, env.db.Reader().QueryRow(`
+		SELECT id
+		FROM messages
+		WHERE session_id = ? AND ordinal = 1`,
+		"parent-linear-bound",
+	).Scan(&gotMessageID), "query message id after append")
+	assert.Equal(t, assistantMessageID, gotMessageID,
+		"append must stay on the incremental path (no row replacement)")
+
+	msgs := fetchMessages(t, env.db, "parent-linear-bound")
+	require.Len(t, msgs, 3)
+	assert.Equal(t, "next", msgs[2].Content)
+}
+
 func TestIncrementalSync_ClaudeAgentIDLinkUsesRemotePrefix(t *testing.T) {
 	claudeDir := t.TempDir()
 	database := dbtest.OpenTestDB(t)
@@ -10688,7 +11754,7 @@ func TestIncrementalSync_ClaudeAgentIDMissingToolCallAdvancesCursor(t *testing.T
 	)
 	env.engine.SyncAll(context.Background(), nil)
 
-	appended := `{"type":"user","isMeta":true,"timestamp":"2024-01-01T10:00:01Z","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_missing","content":"done"}]},"toolUseResult":{"status":"completed","agentId":"missingchild"}}` + "\n"
+	appended := `{"type":"user","isMeta":true,"timestamp":"2024-01-01T10:00:01Z","uuid":"r1","parentUuid":"u1","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_missing","content":"done"}]},"toolUseResult":{"status":"completed","agentId":"missingchild"}}` + "\n"
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
 	require.NoError(t, err, "open for append")
 	_, writeErr := f.WriteString(appended)
@@ -11307,8 +12373,9 @@ func TestWatcherOverflowReloadsSameStatCodexIndexTitle(t *testing.T) {
 	require.Equal(t, indexInfo.Size(), rewrittenInfo.Size())
 	require.Equal(t, indexInfo.ModTime(), rewrittenInfo.ModTime())
 
-	stats := env.engine.SyncAllAfterWatcherOverflow(context.Background(), nil)
-	require.False(t, stats.Aborted)
+	require.NoError(t, env.engine.ReconcileWatchRootsAfterLostEvents(
+		context.Background(), nil, true,
+	))
 	after, err := env.db.GetSessionFull(context.Background(), "codex:"+uuid)
 	require.NoError(t, err)
 	require.NotNil(t, after)

--- a/internal/sync/engine_resync_split_test.go
+++ b/internal/sync/engine_resync_split_test.go
@@ -1,0 +1,395 @@
+package sync
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/testjsonl"
+)
+
+// newResyncSplitEngine builds an engine over a fresh archive with three synced
+// Claude sessions. It returns the engine, its database, and the source root so
+// callers can delete a source file and drive a resync.
+func newResyncSplitEngine(t *testing.T) (*Engine, *db.DB, string) {
+	t.Helper()
+	root := t.TempDir()
+	database, err := db.Open(filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {root}},
+		Machine:   "local",
+	})
+	t.Cleanup(engine.Close)
+
+	for _, name := range []string{"keep0", "keep1", "orphan"} {
+		path := filepath.Join(root, "project", name+".jsonl")
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		content := testjsonl.NewSessionBuilder().
+			AddClaudeUser("2026-01-01T00:00:00Z", "hello "+name).
+			AddClaudeAssistant("2026-01-01T00:00:01Z", "hi "+name).
+			String()
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	}
+	require.Equal(t, 3, engine.SyncAll(context.Background(), nil).Synced)
+	return engine, database, root
+}
+
+// TestResyncBuildThenSwapMatchesResyncAll drives the split resync path
+// end-to-end: build the replacement, swap it in, reset caches. It must preserve
+// an orphan session whose source file was deleted, clean up the temp file, and
+// hand off warm skip state so an immediate sync is a no-op.
+func TestResyncBuildThenSwapMatchesResyncAll(t *testing.T) {
+	e, database, root := newResyncSplitEngine(t)
+	require.NoError(t, os.Remove(filepath.Join(root, "project", "orphan.jsonl")))
+
+	tempPath, stats, err := e.ResyncBuild(context.Background(), nil)
+	require.NoError(t, err)
+	require.False(t, stats.Aborted)
+	require.FileExists(t, tempPath)
+
+	require.NoError(t, e.SwapResyncDatabase(tempPath))
+	require.NoError(t, e.ResetCachesAfterSwap())
+
+	assert.False(t, database.NeedsResync())
+	orphan, err := database.GetSession(context.Background(), "orphan")
+	require.NoError(t, err)
+	require.NotNil(t, orphan, "orphan sessions must survive the split resync")
+	assert.Positive(t, stats.TotalSessions)
+	assert.NoFileExists(t, tempPath)
+
+	warm := e.SyncAll(context.Background(), nil)
+	assert.Zero(t, warm.Synced, "persisted skip state must survive the swap")
+}
+
+// TestSwapWindowRejectsDirectWrites proves the write barrier: with the writer
+// closed a direct star write is rejected with ErrWriterClosed, and the rejected
+// write is absent from the rebuilt archive after the swap.
+func TestSwapWindowRejectsDirectWrites(t *testing.T) {
+	e, database, _ := newResyncSplitEngine(t)
+
+	require.NoError(t, database.CloseWriter())
+	_, starErr := database.StarSession("keep0")
+	assert.ErrorIs(t, starErr, db.ErrWriterClosed,
+		"a direct write during the barrier window must be rejected")
+
+	// The build reads the original and writes only the replacement, so it
+	// proceeds while the writer is closed. The swap reopens the writer.
+	tempPath, _, err := e.ResyncBuild(context.Background(), nil)
+	require.NoError(t, err)
+	require.NoError(t, e.SwapResyncDatabase(tempPath))
+	require.NoError(t, e.ResetCachesAfterSwap())
+
+	starred, err := database.ListStarredSessionIDs(context.Background())
+	require.NoError(t, err)
+	assert.NotContains(t, starred, "keep0",
+		"a rejected write must not appear in the swapped archive")
+
+	// The writer is usable again after the swap reopened it.
+	ok, err := database.StarSession("keep0")
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+// TestResyncAbortsWhenBarrierCannotBeEstablished pins the CloseWriter failure
+// posture: a resync that cannot establish a clean write barrier must abort
+// before building instead of proceeding toward an unsafe swap, and the original
+// archive must be left untouched.
+func TestResyncAbortsWhenBarrierCannotBeEstablished(t *testing.T) {
+	e, database, _ := newResyncSplitEngine(t)
+
+	prev := closeWriterForResyncBarrier
+	closeWriterForResyncBarrier = func(*db.DB) error {
+		return errors.New("barrier boom")
+	}
+	defer func() { closeWriterForResyncBarrier = prev }()
+
+	stats := e.ResyncAll(context.Background(), nil)
+	assert.True(t, stats.Aborted, "resync must abort without a clean barrier")
+	require.NotEmpty(t, stats.Warnings)
+	assert.Contains(t, stats.Warnings[0], "close writer for barrier")
+	assert.Zero(t, stats.Synced, "no build may run without the barrier")
+
+	page, err := database.ListSessions(context.Background(), db.SessionFilter{})
+	require.NoError(t, err)
+	assert.Len(t, page.Sessions, 3, "original archive must be untouched")
+	assert.NoFileExists(t, e.ResyncTempPath(),
+		"no replacement build may be left behind")
+}
+
+// TestResyncBarrierCloseFailureRestoresWriter pins recovery after the abort in
+// TestResyncAbortsWhenBarrierCannotBeEstablished: CloseWriter's failure posture
+// leaves the writer closed (barrier active, undrained pool retained), and the
+// aborted resync must reopen it so the daemon keeps serving writes instead of
+// returning ErrWriterClosed until restart. Reopening is safe — this process
+// never released write ownership.
+func TestResyncBarrierCloseFailureRestoresWriter(t *testing.T) {
+	e, database, _ := newResyncSplitEngine(t)
+
+	prev := closeWriterForResyncBarrier
+	closeWriterForResyncBarrier = func(d *db.DB) error {
+		// Reproduce the drain-timeout posture: the writer really closes,
+		// then the failure is reported.
+		if err := d.CloseWriter(); err != nil {
+			return err
+		}
+		return errors.New("barrier boom")
+	}
+	defer func() { closeWriterForResyncBarrier = prev }()
+
+	stats := e.ResyncAll(context.Background(), nil)
+	require.True(t, stats.Aborted, "resync must abort without a clean barrier")
+
+	ok, err := database.StarSession("keep0")
+	require.NoError(t, err,
+		"writes must recover after the aborted resync without a restart")
+	assert.True(t, ok)
+}
+
+// TestResyncAbortsWhenReplacementCloseFails pins the replacement-close failure
+// posture: when the freshly built temp database cannot drain its connections,
+// committed rows may still sit uncheckpointed in the temp WAL. The build must
+// surface the close error and abort the swap — renaming only the main file and
+// deleting the temp WAL would discard those rows from the installed archive.
+// The original archive stays in place and keeps serving reads and writes.
+func TestResyncAbortsWhenReplacementCloseFails(t *testing.T) {
+	e, database, _ := newResyncSplitEngine(t)
+	restore := db.SetCloseDrainTimeoutForTest(100 * time.Millisecond)
+	defer restore()
+
+	// Pin a connection on the replacement from inside the build (the FTS
+	// rebuild hook is the last ops seam that sees the open temp DB), so the
+	// build's final Close cannot drain.
+	var pinned *sql.Rows
+	stats, err := e.resyncAllWithOptionsAndOperations(
+		context.Background(), nil, RebuildOptions{}, rebuildOperations{
+			rebuildFTS: func(newDB *db.DB) error {
+				if err := newDB.RebuildFTS(); err != nil {
+					return err
+				}
+				rows, qerr := newDB.Reader().Query("SELECT 1")
+				if qerr != nil {
+					return qerr
+				}
+				pinned = rows
+				return nil
+			},
+		},
+	)
+	require.Error(t, err,
+		"an undrained replacement close must abort the resync with an error")
+	assert.True(t, stats.Aborted)
+	require.NotEmpty(t, stats.Warnings)
+	assert.Contains(t, stats.Warnings[len(stats.Warnings)-1], "aborting swap")
+
+	// The original archive was not swapped and still serves reads and writes.
+	page, listErr := database.ListSessions(context.Background(), db.SessionFilter{})
+	require.NoError(t, listErr)
+	assert.Len(t, page.Sessions, 3, "original archive must be untouched")
+	ok, starErr := database.StarSession("keep0")
+	require.NoError(t, starErr,
+		"writes must recover after the aborted resync without a restart")
+	assert.True(t, ok)
+
+	require.NotNil(t, pinned, "the FTS hook must have pinned a connection")
+	require.NoError(t, pinned.Close())
+}
+
+// newResyncSwapFailureEngine builds an engine over a Claude root with two
+// synced sessions plus an empty Kimi root. The Kimi root lets failed-swap
+// tests stage a source whose skip-cache identity is purely path+mtime (Kimi
+// uses neither hash-keyed skip entries nor hash-based freshness healing), so a
+// wrongly retained replacement-build skip entry is observable.
+func newResyncSwapFailureEngine(t *testing.T) (*Engine, *db.DB, string) {
+	t.Helper()
+	claudeRoot := t.TempDir()
+	kimiRoot := t.TempDir()
+	database, err := db.Open(filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {claudeRoot},
+			parser.AgentKimi:   {kimiRoot},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+
+	for _, name := range []string{"keep0", "keep1"} {
+		path := filepath.Join(claudeRoot, "project", name+".jsonl")
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		content := testjsonl.NewSessionBuilder().
+			AddClaudeUser("2026-01-01T00:00:00Z", "hello "+name).
+			AddClaudeAssistant("2026-01-01T00:00:01Z", "hi "+name).
+			String()
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	}
+	require.Equal(t, 2, engine.SyncAll(context.Background(), nil).Synced)
+	return engine, database, kimiRoot
+}
+
+// writeKimiGhost stages a Kimi wire.jsonl that parses to no sessions, so the
+// next resync build records a fresh in-memory skip entry for it. It returns
+// the transcript path, the session ID a real session at that path would get,
+// and the file mtime the skip entry will be keyed on.
+func writeKimiGhost(t *testing.T, kimiRoot string) (string, string, time.Time) {
+	t.Helper()
+	workdir := "wd_kimi-code_057f5c09ee3f"
+	sessionDir := "session_cf2c3d74-c9d2-4ae4-95b7-d1d817298382"
+	wirePath := filepath.Join(
+		kimiRoot, workdir, sessionDir, "agents", "main", "wire.jsonl",
+	)
+	require.NoError(t, os.MkdirAll(filepath.Dir(wirePath), 0o755))
+	require.NoError(t, os.WriteFile(wirePath, []byte(
+		`{"type": "metadata", "protocol_version": "1.3"}`+"\n",
+	), 0o644))
+	info, err := os.Stat(wirePath)
+	require.NoError(t, err)
+	sessionID := "kimi:" + workdir + ":main:" + sessionDir
+	return wirePath, sessionID, info.ModTime()
+}
+
+// requireGhostSyncsAfterFailedSwap rewrites the ghost with a real session at
+// the pre-resync mtime and requires the next pass to sync it. The discarded
+// replacement's skip entry (path at that mtime) was never persisted in the
+// original archive, so it must not survive the failed swap and suppress the
+// source.
+func requireGhostSyncsAfterFailedSwap(
+	t *testing.T, e *Engine, database *db.DB,
+	wirePath, sessionID string, mtime time.Time,
+) {
+	t.Helper()
+	session := `{"type": "metadata", "protocol_version": "1.3"}` + "\n" +
+		`{"timestamp": 1704067200.0, "message": {"type": "TurnBegin", ` +
+		`"payload": {"user_input": [{"type": "text", "text": "Hello Kimi"}]}}}` + "\n" +
+		`{"timestamp": 1704067202.0, "message": {"type": "TurnEnd", "payload": {}}}` + "\n"
+	require.NoError(t, os.WriteFile(wirePath, []byte(session), 0o644))
+	require.NoError(t, os.Chtimes(wirePath, mtime, mtime))
+
+	synced := e.SyncAll(context.Background(), nil)
+	require.False(t, synced.Aborted)
+	sess, err := database.GetSession(context.Background(), sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, sess,
+		"a skip entry from the discarded replacement build must not "+
+			"suppress syncing this source into the original archive")
+}
+
+// TestResyncSwapRenameFailureRestoresSkipCache pins the rename-failure posture
+// of the in-process swap: when the replacement cannot be renamed into place,
+// the engine reopens the original archive, and the in-memory skip cache must
+// return to its pre-build state. Keeping the replacement build's entries would
+// suppress sources whose data never reached the original.
+func TestResyncSwapRenameFailureRestoresSkipCache(t *testing.T) {
+	e, database, kimiRoot := newResyncSwapFailureEngine(t)
+	wirePath, sessionID, mtime := writeKimiGhost(t, kimiRoot)
+
+	var removed atomic.Bool
+	stats := e.ResyncAll(context.Background(), func(p Progress) {
+		if p.Phase == PhaseSwappingDatabase &&
+			removed.CompareAndSwap(false, true) {
+			// Deleting the staged replacement makes the swap's os.Rename
+			// fail after the original database is already closed.
+			require.NoError(t, os.Remove(e.ResyncTempPath()))
+		}
+	})
+	require.True(t, removed.Load(), "the swap phase must have been reached")
+	require.True(t, stats.Aborted, "a failed rename must abort the resync")
+	require.NotEmpty(t, stats.Warnings)
+	assert.Contains(t, stats.Warnings[len(stats.Warnings)-1],
+		"resync swap failed")
+
+	// The original archive is still in place and serving.
+	page, err := database.ListSessions(context.Background(), db.SessionFilter{})
+	require.NoError(t, err)
+	assert.Len(t, page.Sessions, 2, "original archive must be untouched")
+
+	requireGhostSyncsAfterFailedSwap(t, e, database, wirePath, sessionID, mtime)
+}
+
+// TestResyncSwapCloseFailureRestoresSkipCache pins the close-failure posture
+// of the in-process swap: when the original database cannot drain its
+// connections before the rename, the swap aborts pre-install and the original
+// is reopened. As with the rename failure, the replacement build's skip cache
+// must not survive against the original archive.
+func TestResyncSwapCloseFailureRestoresSkipCache(t *testing.T) {
+	e, database, kimiRoot := newResyncSwapFailureEngine(t)
+	wirePath, sessionID, mtime := writeKimiGhost(t, kimiRoot)
+
+	restore := db.SetCloseDrainTimeoutForTest(100 * time.Millisecond)
+	defer restore()
+
+	// Pin a reader connection on the original so its pre-swap
+	// CloseConnections cannot drain and the swap aborts before the rename.
+	pinned, err := database.Reader().Query("SELECT 1")
+	require.NoError(t, err)
+	pinnedOpen := true
+	defer func() {
+		if pinnedOpen {
+			require.NoError(t, pinned.Close())
+		}
+	}()
+
+	stats := e.ResyncAll(context.Background(), nil)
+	require.True(t, stats.Aborted,
+		"a failed close before the swap must abort the resync")
+	require.NotEmpty(t, stats.Warnings)
+	assert.Contains(t, stats.Warnings[len(stats.Warnings)-1],
+		"close before swap failed")
+
+	require.NoError(t, pinned.Close())
+	pinnedOpen = false
+
+	// The original archive is still in place and serving.
+	page, err := database.ListSessions(context.Background(), db.SessionFilter{})
+	require.NoError(t, err)
+	assert.Len(t, page.Sessions, 2, "original archive must be untouched")
+
+	requireGhostSyncsAfterFailedSwap(t, e, database, wirePath, sessionID, mtime)
+}
+
+// TestInProcessResyncRejectsConcurrentDirectWrite is the regression for the
+// in-process fallback barrier. It fires a direct write (StarSession) during the
+// reclassify phase, which runs after every preserved-state copy and before the
+// swap's rename. Without the barrier that write lands in the original and is
+// discarded by the swap (silently lost); with it the write is rejected with
+// ErrWriterClosed. The progress hook blocks the resync until the write returns,
+// so the write is guaranteed to land inside that window.
+func TestInProcessResyncRejectsConcurrentDirectWrite(t *testing.T) {
+	e, database, _ := newResyncSplitEngine(t)
+
+	var starErr error
+	var fired atomic.Bool
+	done := make(chan struct{})
+	onProgress := func(p Progress) {
+		if p.Phase == PhaseReclassifying && fired.CompareAndSwap(false, true) {
+			go func() {
+				_, starErr = database.StarSession("keep0")
+				close(done)
+			}()
+			<-done
+		}
+	}
+
+	stats := e.ResyncAll(context.Background(), onProgress)
+	require.False(t, stats.Aborted)
+	require.True(t, fired.Load(), "the concurrent write must have fired mid-resync")
+
+	assert.ErrorIs(t, starErr, db.ErrWriterClosed,
+		"a direct write in the copy-to-swap window must be rejected, not lost")
+	starred, err := database.ListStarredSessionIDs(context.Background())
+	require.NoError(t, err)
+	assert.NotContains(t, starred, "keep0",
+		"a rejected write must not silently land in the swapped archive")
+}

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -29,6 +30,2590 @@ import (
 func openTestDB(t *testing.T) *db.DB {
 	t.Helper()
 	return dbtest.OpenTestDB(t)
+}
+
+func requireClassifyPaths(
+	t *testing.T, engine *Engine, paths []string,
+) []parser.DiscoveredFile {
+	t.Helper()
+	files, err := engine.classifyPaths(t.Context(), paths)
+	require.NoError(t, err)
+	return files
+}
+
+func requireClassifyProviderChangedPath(
+	t *testing.T, engine *Engine, path string,
+) []parser.DiscoveredFile {
+	t.Helper()
+	files, err := engine.classifyProviderChangedPath(t.Context(), path)
+	require.NoError(t, err)
+	return files
+}
+
+func TestClaudeIDFreshnessRejectsSourceMissingTombstone(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	missingPath := filepath.Join(root, "missing.jsonl")
+	userDeletedPath := filepath.Join(root, "user-deleted.jsonl")
+	size := int64(4096)
+	mtime := int64(1234)
+	hash := "unchanged"
+	for _, session := range []db.Session{
+		{
+			ID: "missing", Agent: string(parser.AgentClaude), Project: "project",
+			Machine:  "local",
+			FilePath: &missingPath, FileSize: &size, FileMtime: &mtime,
+			FileHash: &hash, DataVersion: db.CurrentDataVersion(),
+		},
+		{
+			ID: "user-deleted", Agent: string(parser.AgentClaude), Project: "project",
+			Machine:  "local",
+			FilePath: &userDeletedPath, FileSize: &size, FileMtime: &mtime,
+			FileHash: &hash, DataVersion: db.CurrentDataVersion(),
+		},
+	} {
+		require.NoError(t, database.UpsertSession(session))
+		require.NoError(t, database.SetSessionDataVersion(
+			session.ID, db.CurrentDataVersion(),
+		))
+	}
+	require.NoError(t, database.BaselineActiveSessionSourcePaths(
+		t.Context(), "local", []db.SessionSourcePath{{
+			Agent: string(parser.AgentClaude), FilePath: missingPath,
+		}},
+	))
+	changed, err := database.SoftDeleteSessionSourceOwnership(
+		t.Context(), "local", string(parser.AgentClaude), "missing", missingPath,
+	)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.NoError(t, database.SoftDeleteSession("user-deleted"))
+	engine := &Engine{db: database}
+	info := fakeSnapshotInfo{fName: "restored.jsonl", fSize: size, fMtime: mtime}
+	storedSize, storedMtime, ok := database.GetSessionFileInfo("user-deleted")
+	require.True(t, ok)
+	require.Equal(t, size, storedSize)
+	require.Equal(t, mtime, storedMtime)
+	storedHash, ok := database.GetSessionFileHash("user-deleted")
+	require.True(t, ok)
+	require.Equal(t, hash, storedHash)
+	require.Equal(t, db.CurrentDataVersion(), database.GetSessionDataVersion("user-deleted"))
+
+	assert.False(t, engine.shouldSkipFileWithPrefix(
+		"", "missing", info, hash,
+	), "a byte-identical restored source must be reparsed and revived")
+	assert.True(t, engine.shouldSkipFileWithPrefix(
+		"", "user-deleted", info, hash,
+	), "ordinary user trash keeps the established freshness behavior")
+}
+
+func TestClassifyProviderChangedPathWatchRootPlanCached(t *testing.T) {
+	root := t.TempDir()
+	var watchRootsCalls atomic.Int32
+	var watchPlanCalls atomic.Int32
+	capabilities := parser.Capabilities{Source: parser.SourceCapabilities{
+		WatchRoots:          parser.CapabilitySupported,
+		ClassifyChangedPath: parser.CapabilitySupported,
+	}}
+	factory := watchRootCountingFactory{
+		capabilities:    capabilities,
+		watchRootsCalls: &watchRootsCalls,
+		watchPlanCalls:  &watchPlanCalls,
+	}
+	engine := &Engine{
+		agentDirs: map[parser.AgentType][]string{
+			watchRootCountingAgent: {root},
+		},
+		providerFactories: map[parser.AgentType]parser.ProviderFactory{
+			watchRootCountingAgent: factory,
+		},
+		providerMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			watchRootCountingAgent: parser.ProviderMigrationProviderAuthoritative,
+		},
+	}
+
+	for i := range 1000 {
+		path := filepath.Join(root, "archive", fmt.Sprintf("session-%04d.jsonl", i))
+		assert.Empty(t, requireClassifyProviderChangedPath(t, engine, path))
+	}
+
+	assert.Equal(t, int32(1), watchRootsCalls.Load(),
+		"the engine-lifetime cache must resolve provider roots once")
+	assert.Zero(t, watchPlanCalls.Load(),
+		"supported root planning must not call the archive-aware watch plan")
+}
+
+const watchRootCountingAgent parser.AgentType = "watch-root-counting"
+
+type watchRootCountingFactory struct {
+	capabilities    parser.Capabilities
+	watchRootsCalls *atomic.Int32
+	watchPlanCalls  *atomic.Int32
+}
+
+func (f watchRootCountingFactory) Definition() parser.AgentDef {
+	return parser.AgentDef{Type: watchRootCountingAgent}
+}
+
+func (f watchRootCountingFactory) Capabilities() parser.Capabilities {
+	return f.capabilities
+}
+
+func (f watchRootCountingFactory) NewProvider(
+	cfg parser.ProviderConfig,
+) parser.Provider {
+	return &watchRootCountingProvider{
+		ProviderBase: parser.ProviderBase{
+			Def:    f.Definition(),
+			Caps:   f.capabilities,
+			Config: cfg.Clone(),
+		},
+		watchRootsCalls: f.watchRootsCalls,
+		watchPlanCalls:  f.watchPlanCalls,
+	}
+}
+
+type watchRootCountingProvider struct {
+	parser.ProviderBase
+	watchRootsCalls *atomic.Int32
+	watchPlanCalls  *atomic.Int32
+}
+
+func (p *watchRootCountingProvider) WatchRoots(
+	context.Context,
+) ([]parser.WatchRoot, error) {
+	p.watchRootsCalls.Add(1)
+	return []parser.WatchRoot{{Path: p.Config.Roots[0], Recursive: true}}, nil
+}
+
+func (p *watchRootCountingProvider) WatchPlan(
+	context.Context,
+) (parser.WatchPlan, error) {
+	p.watchPlanCalls.Add(1)
+	return parser.WatchPlan{Roots: []parser.WatchRoot{{
+		Path: p.Config.Roots[0], Recursive: true,
+	}}}, nil
+}
+
+func (p *watchRootCountingProvider) Parse(
+	context.Context,
+	parser.ParseRequest,
+) (parser.ParseOutcome, error) {
+	return parser.ParseOutcome{}, nil
+}
+
+type failingDBBackedProvider struct {
+	parser.ProviderBase
+	err        error
+	failOnCall int32
+	calls      atomic.Int32
+}
+
+func (p *failingDBBackedProvider) Discover(context.Context) ([]parser.SourceRef, error) {
+	if p.calls.Add(1) == p.failOnCall {
+		return nil, p.err
+	}
+	return nil, nil
+}
+
+func (p *failingDBBackedProvider) DiscoverEach(
+	_ context.Context, _ func(parser.SourceRef) error,
+) error {
+	if p.calls.Add(1) == p.failOnCall {
+		return p.err
+	}
+	return nil
+}
+
+func (p *failingDBBackedProvider) Capabilities() parser.Capabilities {
+	caps := p.ProviderBase.Capabilities()
+	caps.Source.StreamingDiscovery = parser.CapabilitySupported
+	return caps
+}
+
+func (p *failingDBBackedProvider) Parse(
+	context.Context, parser.ParseRequest,
+) (parser.ParseOutcome, error) {
+	return parser.ParseOutcome{}, nil
+}
+
+type failingDBBackedFactory struct{ provider *failingDBBackedProvider }
+
+func (f failingDBBackedFactory) Definition() parser.AgentDef {
+	return f.provider.Definition()
+}
+
+func observeSourceBaselineAttempts(t *testing.T, database *db.DB) func() int {
+	t.Helper()
+	raw, err := sql.Open("sqlite3", database.Path())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, raw.Close()) })
+	_, err = raw.Exec(`
+		CREATE TABLE source_baseline_attempt_observer (attempts INTEGER NOT NULL);
+		INSERT INTO source_baseline_attempt_observer VALUES (0);
+		CREATE TRIGGER observe_source_baseline_attempt
+		BEFORE INSERT ON local_session_source_baselines
+		BEGIN
+			UPDATE source_baseline_attempt_observer SET attempts = attempts + 1;
+		END;
+	`)
+	require.NoError(t, err)
+	return func() int {
+		var attempts int
+		require.NoError(t, raw.QueryRow(
+			"SELECT attempts FROM source_baseline_attempt_observer",
+		).Scan(&attempts))
+		return attempts
+	}
+}
+
+func TestSyncAllBaselinesSuccessfulSkipDespiteUnrelatedProviderFailure(t *testing.T) {
+	database := openTestDB(t)
+	claudeRoot := filepath.Join(t.TempDir(), "claude")
+	path := filepath.Join(claudeRoot, "project", "successful-skip.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(
+		path,
+		[]byte(testjsonl.NewSessionBuilder().
+			AddClaudeUser("2024-01-01T00:00:00Z", "keep me eligible").
+			String()),
+		0o644,
+	))
+	claudeFactory, ok := parser.ProviderFactoryByType(parser.AgentClaude)
+	require.True(t, ok)
+	failing := failingDBBackedProvider{
+		ProviderBase: parser.ProviderBase{Def: parser.AgentDef{
+			Type: parser.AgentWarp, DisplayName: "Warp", FileBased: false,
+		}},
+		err: errors.New("unrelated provider unavailable"), failOnCall: 2,
+	}
+	warpRoot := t.TempDir()
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {claudeRoot},
+			parser.AgentWarp:   {warpRoot},
+		},
+		Machine: "local",
+		ProviderFactories: []parser.ProviderFactory{
+			claudeFactory, failingDBBackedFactory{provider: &failing},
+		},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			parser.AgentClaude: parser.ProviderMigrationProviderAuthoritative,
+			parser.AgentWarp:   parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+
+	first := engine.SyncAll(t.Context(), nil)
+	require.Equal(t, 1, first.Synced)
+	raw, err := sql.Open("sqlite3", database.Path())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, raw.Close()) })
+	_, err = raw.Exec("DELETE FROM local_session_source_baselines")
+	require.NoError(t, err)
+
+	second := engine.SyncAll(t.Context(), nil)
+
+	assert.Positive(t, second.Failed, "the unrelated provider must fail this pass")
+	assert.Positive(t, second.Skipped, "the unchanged Claude source must skip successfully")
+	ownership, err := database.ListActiveSessionSourceOwnershipScopesPage(
+		t.Context(), "local", string(parser.AgentClaude),
+		[]db.StoredSourcePathHintScope{{Path: claudeRoot}},
+		db.SessionSourceCursor{},
+	)
+	require.NoError(t, err)
+	require.Len(t, ownership, 1,
+		"a successful skipped source must acquire baseline eligibility independently")
+	assert.Equal(t, path, ownership[0].FilePath)
+}
+
+func TestReconcileWatchRootsAfterLostEventsBaselinesParsedSourceOnce(t *testing.T) {
+	database := openTestDB(t)
+	claudeRoot := filepath.Join(t.TempDir(), "claude")
+	path := filepath.Join(claudeRoot, "project", "forced.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(
+		path,
+		[]byte(testjsonl.NewSessionBuilder().
+			AddClaudeUser("2024-01-01T00:00:00Z", "force parse once").
+			String()),
+		0o644,
+	))
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {claudeRoot},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+	baselineAttempts := observeSourceBaselineAttempts(t, database)
+
+	require.NoError(t, engine.ReconcileWatchRootsAfterLostEvents(
+		t.Context(), nil, true,
+	))
+
+	active, err := database.GetSession(t.Context(), "forced")
+	require.NoError(t, err)
+	require.NotNil(t, active, "overflow recovery must parse the source")
+	assert.Equal(t, 1, baselineAttempts(),
+		"a successfully parsed source must not be baselined again archive-wide")
+}
+
+func TestSyncPathsBaselinesParsedSourceOnce(t *testing.T) {
+	database := openTestDB(t)
+	claudeRoot := filepath.Join(t.TempDir(), "claude")
+	path := filepath.Join(claudeRoot, "project", "changed.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(
+		path,
+		[]byte(testjsonl.NewSessionBuilder().
+			AddClaudeUser("2024-01-01T00:00:00Z", "changed path").
+			String()),
+		0o644,
+	))
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {claudeRoot},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+	baselineAttempts := observeSourceBaselineAttempts(t, database)
+
+	require.NoError(t, engine.SyncPathsContext(t.Context(), []string{path}))
+
+	assert.Equal(t, 1, baselineAttempts(),
+		"a changed-path parse must baseline its source exactly once")
+}
+
+func TestReconcileWatchRootsBaselinesParsedSourceOnce(t *testing.T) {
+	database := openTestDB(t)
+	claudeRoot := filepath.Join(t.TempDir(), "claude")
+	path := filepath.Join(claudeRoot, "project", "reconciled.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(
+		path,
+		[]byte(testjsonl.NewSessionBuilder().
+			AddClaudeUser("2024-01-01T00:00:00Z", "reconciled path").
+			String()),
+		0o644,
+	))
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {claudeRoot},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+	baselineAttempts := observeSourceBaselineAttempts(t, database)
+
+	require.NoError(t, engine.ReconcileWatchRoots(
+		t.Context(), []string{claudeRoot}, false,
+	))
+
+	assert.Equal(t, 1, baselineAttempts(),
+		"a reconciled parse must use only the candidate-page baseline")
+}
+
+type directStreamingProvider struct {
+	parser.ProviderBase
+	discoverCalls atomic.Int32
+	parseCalls    atomic.Int32
+	source        *parser.SourceRef
+	parseErr      error
+	parseOutcome  parser.ParseOutcome
+	fingerprint   parser.SourceFingerprint
+}
+
+func (provider *directStreamingProvider) Discover(context.Context) ([]parser.SourceRef, error) {
+	provider.discoverCalls.Add(1)
+	return nil, errors.New("collecting discovery must not run")
+}
+
+func (provider *directStreamingProvider) DiscoverEach(
+	ctx context.Context, yield func(parser.SourceRef) error,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if provider.source != nil {
+		return yield(*provider.source)
+	}
+	return nil
+}
+
+func (*directStreamingProvider) WatchPlan(context.Context) (parser.WatchPlan, error) {
+	return parser.WatchPlan{}, nil
+}
+
+func (provider *directStreamingProvider) SourcesForChangedPath(
+	_ context.Context, req parser.ChangedPathRequest,
+) ([]parser.SourceRef, error) {
+	if provider.source != nil && provider.source.DisplayPath == req.Path {
+		return []parser.SourceRef{*provider.source}, nil
+	}
+	return nil, nil
+}
+
+func (provider *directStreamingProvider) Fingerprint(
+	context.Context, parser.SourceRef,
+) (parser.SourceFingerprint, error) {
+	return provider.fingerprint, nil
+}
+
+func (provider *directStreamingProvider) Parse(
+	context.Context, parser.ParseRequest,
+) (parser.ParseOutcome, error) {
+	provider.parseCalls.Add(1)
+	return provider.parseOutcome, provider.parseErr
+}
+
+type directStreamingFactory struct{ provider *directStreamingProvider }
+
+func (factory directStreamingFactory) Definition() parser.AgentDef {
+	return factory.provider.Definition()
+}
+
+func (factory directStreamingFactory) Capabilities() parser.Capabilities {
+	return factory.provider.Capabilities()
+}
+
+func newChangedPathOutcomeEngine(
+	t *testing.T,
+	agent parser.AgentType,
+	outcome func(string) parser.ParseOutcome,
+) (*db.DB, *Engine, *directStreamingProvider, string, string) {
+	t.Helper()
+	database := openTestDB(t)
+	root := t.TempDir()
+	path := filepath.Join(root, "source.jsonl")
+	require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o600))
+	source := parser.SourceRef{
+		Provider: agent, Key: path, DisplayPath: path, FingerprintKey: path,
+	}
+	provider := &directStreamingProvider{
+		ProviderBase: parser.ProviderBase{
+			Def: parser.AgentDef{Type: agent, FileBased: true},
+			Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+				DiscoverSources:    parser.CapabilitySupported,
+				StreamingDiscovery: parser.CapabilitySupported,
+				WatchSources:       parser.CapabilitySupported,
+				FindSource:         parser.CapabilitySupported,
+			}},
+		},
+		source: &source, parseOutcome: outcome(path),
+	}
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{agent: {root}},
+		Machine:   "local",
+		ProviderFactories: []parser.ProviderFactory{
+			directStreamingFactory{provider: provider},
+		},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			agent: parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+	return database, engine, provider, root, path
+}
+
+func seedActiveBaselineSource(
+	t *testing.T,
+	database *db.DB,
+	agent parser.AgentType,
+	id string,
+	path string,
+) {
+	t.Helper()
+	size := int64(1)
+	mtime := int64(1)
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: id, Agent: string(agent), Project: "project", Machine: "local",
+		FilePath: &path, FileSize: &size, FileMtime: &mtime,
+	}))
+	require.NoError(t, database.SetSessionDataVersion(id, db.CurrentDataVersion()))
+}
+
+func TestSyncPathsWriteFailureDoesNotBaselineExistingActiveSource(t *testing.T) {
+	const agent parser.AgentType = "baseline-write-failure"
+	const sessionID = "existing-write-failure"
+	database, engine, _, root, path := newChangedPathOutcomeEngine(
+		t, agent, func(path string) parser.ParseOutcome {
+			started := time.Unix(1704067200, 0)
+			return parser.ParseOutcome{
+				Results: []parser.ParseResultOutcome{{
+					Result: parser.ParseResult{Session: parser.ParsedSession{
+						ID: sessionID, Agent: agent, Project: "project", Machine: "local",
+						StartedAt: started, EndedAt: started,
+						File: parser.FileInfo{Path: path},
+					}},
+					DataVersion: parser.DataVersionCurrent,
+				}},
+				ResultSetComplete: true,
+			}
+		},
+	)
+	seedActiveBaselineSource(t, database, agent, sessionID, path)
+	engine.writeBatchOverride = func(
+		batch []pendingWrite, _ syncWriteMode, _ bool,
+	) (int, int, int, int) {
+		return 0, 0, len(batch), 0
+	}
+
+	err := engine.SyncPathsContext(t.Context(), []string{path})
+
+	require.ErrorContains(t, err, "changed-path sync incomplete")
+	assert.Equal(t, 1, engine.LastSyncStats().Failed,
+		"the injected archive write must fail")
+	ownership, ownershipErr := database.ListActiveSessionSourceOwnershipScopesPage(
+		t.Context(), "local", string(agent),
+		[]db.StoredSourcePathHintScope{{Path: root}}, db.SessionSourceCursor{},
+	)
+	require.NoError(t, ownershipErr)
+	assert.Empty(t, ownership,
+		"a failed write must not make an existing source deletion-eligible")
+}
+
+func TestSyncPathsPartialSkipDoesNotBaselineExistingActiveSource(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		outcome func(string) parser.ParseOutcome
+	}{
+		{
+			name: "source error",
+			outcome: func(path string) parser.ParseOutcome {
+				return parser.ParseOutcome{
+					SourceErrors: []parser.SourceError{{
+						SourceKey: path, SessionID: "existing-partial-skip",
+						Err: errors.New("member parse failed"),
+					}},
+					ResultSetComplete: true,
+					SkipReason:        parser.SkipNoSession,
+				}
+			},
+		},
+		{
+			name: "incomplete result set",
+			outcome: func(string) parser.ParseOutcome {
+				return parser.ParseOutcome{
+					ResultSetComplete: false,
+					SkipReason:        parser.SkipNoSession,
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			const agent parser.AgentType = "baseline-partial-skip"
+			const sessionID = "existing-partial-skip"
+			database, engine, _, root, path := newChangedPathOutcomeEngine(
+				t, agent, tc.outcome,
+			)
+			seedActiveBaselineSource(t, database, agent, sessionID, path)
+
+			err := engine.SyncPathsContext(t.Context(), []string{path})
+
+			require.ErrorContains(t, err, "changed-path sync incomplete")
+			assert.Equal(t, 1, engine.LastSyncStats().Failed,
+				"the provider's partial skip must keep the pass incomplete")
+			ownership, ownershipErr := database.ListActiveSessionSourceOwnershipScopesPage(
+				t.Context(), "local", string(agent),
+				[]db.StoredSourcePathHintScope{{Path: root}},
+				db.SessionSourceCursor{},
+			)
+			require.NoError(t, ownershipErr)
+			assert.Empty(t, ownership,
+				"a partial skip must not make an existing source deletion-eligible")
+		})
+	}
+}
+
+func TestSyncPathsPartialResultRemainsRetryableOnSecondPass(t *testing.T) {
+	const agent parser.AgentType = "baseline-partial-result"
+	const sessionID = "partial-result"
+	database, engine, provider, root, path := newChangedPathOutcomeEngine(
+		t, agent, func(path string) parser.ParseOutcome {
+			started := time.Unix(1704067200, 0)
+			return parser.ParseOutcome{
+				Results: []parser.ParseResultOutcome{{
+					Result: parser.ParseResult{Session: parser.ParsedSession{
+						ID: sessionID, Agent: agent, Project: "project", Machine: "local",
+						StartedAt: started, EndedAt: started,
+						File: parser.FileInfo{
+							Path: path, Size: 3, Mtime: 2, Hash: "partial-fingerprint",
+						},
+					}},
+					DataVersion: parser.DataVersionCurrent,
+				}},
+				SourceErrors: []parser.SourceError{{
+					SourceKey: path, SessionID: sessionID,
+					Err: errors.New("injected partial member failure"),
+				}},
+				ResultSetComplete: true,
+			}
+		},
+	)
+	provider.fingerprint = parser.SourceFingerprint{
+		Key: path, Size: 3, MTimeNS: 2, Hash: "partial-fingerprint",
+	}
+
+	for pass := 1; pass <= 2; pass++ {
+		err := engine.SyncPathsContext(t.Context(), []string{path})
+		require.ErrorContains(t, err, "changed-path sync incomplete")
+		assert.Equal(t, 1, engine.LastSyncStats().Failed,
+			"pass %d must report the partial source", pass)
+		stored, getErr := database.GetSession(t.Context(), sessionID)
+		require.NoError(t, getErr)
+		require.NotNil(t, stored, "the valid partial result must remain persisted")
+		size, mtime, found := database.GetFileInfoByPath(path)
+		require.True(t, found)
+		assert.Equal(t, int64(3), size)
+		assert.Equal(t, int64(2), mtime)
+		assert.Less(t, stored.DataVersion, db.CurrentDataVersion(),
+			"the partial source must remain retryable")
+		ownership, ownershipErr := database.ListActiveSessionSourceOwnershipScopesPage(
+			t.Context(), "local", string(agent),
+			[]db.StoredSourcePathHintScope{{Path: root}}, db.SessionSourceCursor{},
+		)
+		require.NoError(t, ownershipErr)
+		assert.Empty(t, ownership,
+			"pass %d must not baseline the partial source", pass)
+	}
+	assert.Equal(t, int32(2), provider.parseCalls.Load(),
+		"the unchanged fingerprint must be reparsed after the partial result")
+}
+
+func TestCollectAndBatchBaselinesHealthySourceBesideFailedSource(t *testing.T) {
+	const agent parser.AgentType = "baseline-batch-outcomes"
+	database := openTestDB(t)
+	root := t.TempDir()
+	healthyPath := filepath.Join(root, "healthy.jsonl")
+	failedPath := filepath.Join(root, "failed.jsonl")
+	seedActiveBaselineSource(t, database, agent, "healthy", healthyPath)
+	seedActiveBaselineSource(t, database, agent, "failed", failedPath)
+	raw, err := sql.Open("sqlite3", database.Path())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, raw.Close()) })
+	_, err = raw.Exec(`
+		CREATE TRIGGER fail_selected_baseline_write
+		BEFORE INSERT ON sessions
+		WHEN NEW.project = 'failed-project'
+		BEGIN
+			SELECT RAISE(FAIL, 'injected source write failure');
+		END;
+	`)
+	require.NoError(t, err)
+	engine := NewEngine(database, EngineConfig{Machine: "local"})
+	t.Cleanup(engine.Close)
+	results := make(chan syncJob, 2)
+	started := time.Unix(1704067200, 0)
+	for _, source := range []struct {
+		path    string
+		project string
+	}{
+		{path: failedPath, project: "failed-project"},
+		{path: healthyPath, project: "healthy-project"},
+	} {
+		results <- syncJob{
+			agent: agent,
+			path:  source.path,
+			processResult: processResult{results: []parser.ParseResult{{
+				Session: parser.ParsedSession{
+					ID: "duplicate", Agent: agent, Project: source.project, Machine: "local",
+					StartedAt: started, EndedAt: started,
+					File: parser.FileInfo{Path: source.path},
+				},
+			}}},
+		}
+	}
+	close(results)
+
+	stats := engine.collectAndBatch(
+		t.Context(), results, 2, 2, nil, syncWriteBulk,
+	)
+
+	assert.Equal(t, 1, stats.Synced)
+	assert.Equal(t, 1, stats.Failed)
+	ownership, err := database.ListActiveSessionSourceOwnershipScopesPage(
+		t.Context(), "local", string(agent),
+		[]db.StoredSourcePathHintScope{{Path: root}}, db.SessionSourceCursor{},
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, ownership)
+	for _, row := range ownership {
+		assert.Equal(t, healthyPath, row.FilePath,
+			"the failed source must not baseline beside the successful duplicate ID")
+	}
+}
+
+type manyStreamingProvider struct {
+	parser.ProviderBase
+	sources       []parser.SourceRef
+	discoverCalls atomic.Int32
+	streamCalls   atomic.Int32
+}
+
+func (provider *manyStreamingProvider) Discover(
+	context.Context,
+) ([]parser.SourceRef, error) {
+	provider.discoverCalls.Add(1)
+	return append([]parser.SourceRef(nil), provider.sources...), nil
+}
+
+func (provider *manyStreamingProvider) DiscoverEach(
+	ctx context.Context, yield func(parser.SourceRef) error,
+) error {
+	provider.streamCalls.Add(1)
+	for _, source := range provider.sources {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := yield(source); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (provider *manyStreamingProvider) SourceForReconciliation(
+	ctx context.Context, path, project string,
+) (parser.SourceRef, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return parser.SourceRef{}, false, err
+	}
+	for _, source := range provider.sources {
+		if source.DisplayPath == path {
+			source.ProjectHint = project
+			return source, true, nil
+		}
+	}
+	return parser.SourceRef{}, false, nil
+}
+
+func (*manyStreamingProvider) WatchPlan(context.Context) (parser.WatchPlan, error) {
+	return parser.WatchPlan{}, nil
+}
+
+func (*manyStreamingProvider) Parse(
+	_ context.Context, req parser.ParseRequest,
+) (parser.ParseOutcome, error) {
+	path := req.Source.DisplayPath
+	id := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	started := time.Unix(1704067200, 0)
+	return parser.ParseOutcome{
+		Results: []parser.ParseResultOutcome{{
+			Result: parser.ParseResult{Session: parser.ParsedSession{
+				ID: id, Agent: req.Source.Provider, Project: "project", Machine: "local",
+				StartedAt: started, EndedAt: started, File: parser.FileInfo{Path: path},
+			}},
+			DataVersion: parser.DataVersionCurrent,
+		}},
+		ResultSetComplete: true,
+	}, nil
+}
+
+func (*manyStreamingProvider) Fingerprint(
+	context.Context, parser.SourceRef,
+) (parser.SourceFingerprint, error) {
+	return parser.SourceFingerprint{Hash: "stable"}, nil
+}
+
+type manyStreamingFactory struct{ provider *manyStreamingProvider }
+
+func (factory manyStreamingFactory) Definition() parser.AgentDef {
+	return factory.provider.Definition()
+}
+
+func (factory manyStreamingFactory) Capabilities() parser.Capabilities {
+	return factory.provider.Capabilities()
+}
+
+func (factory manyStreamingFactory) NewProvider(parser.ProviderConfig) parser.Provider {
+	return factory.provider
+}
+
+func (factory directStreamingFactory) NewProvider(parser.ProviderConfig) parser.Provider {
+	return factory.provider
+}
+
+type baselineDBBackedProvider struct {
+	parser.ProviderBase
+	sources           []parser.SourceRef
+	fingerprintErrKey string
+	parseErrKey       string
+	outcomes          map[string]parser.ParseOutcome
+	fingerprintCalls  map[string]int
+	parseCalls        map[string]int
+}
+
+func (provider *baselineDBBackedProvider) DiscoverEach(
+	ctx context.Context, yield func(parser.SourceRef) error,
+) error {
+	for _, source := range provider.sources {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := yield(source); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (provider *baselineDBBackedProvider) Fingerprint(
+	_ context.Context, source parser.SourceRef,
+) (parser.SourceFingerprint, error) {
+	provider.fingerprintCalls[source.Key]++
+	if source.Key == provider.fingerprintErrKey {
+		return parser.SourceFingerprint{}, errors.New("injected fingerprint failure")
+	}
+	return parser.SourceFingerprint{
+		Key: source.FingerprintKey, MTimeNS: 2, Hash: "changed",
+	}, nil
+}
+
+func (provider *baselineDBBackedProvider) Parse(
+	_ context.Context, req parser.ParseRequest,
+) (parser.ParseOutcome, error) {
+	provider.parseCalls[req.Source.Key]++
+	if req.Source.Key == provider.parseErrKey {
+		return parser.ParseOutcome{}, errors.New("injected parse failure")
+	}
+	return provider.outcomes[req.Source.Key], nil
+}
+
+type baselineDBBackedFactory struct{ provider *baselineDBBackedProvider }
+
+func (factory baselineDBBackedFactory) Definition() parser.AgentDef {
+	return factory.provider.Definition()
+}
+
+func (factory baselineDBBackedFactory) Capabilities() parser.Capabilities {
+	return factory.provider.Capabilities()
+}
+
+func (factory baselineDBBackedFactory) NewProvider(
+	parser.ProviderConfig,
+) parser.Provider {
+	return factory.provider
+}
+
+func TestSyncProviderDBBackedBaselinesOnlyCompleteSuccessfulSources(t *testing.T) {
+	for _, tc := range []struct {
+		name                 string
+		configure            func(*baselineDBBackedProvider, string)
+		failWrite            bool
+		wantStaleWrite       bool
+		wantProviderFailures int
+		wantFailedParseCalls int
+	}{
+		{
+			name:                 "fingerprint failure",
+			wantProviderFailures: 1,
+			configure: func(provider *baselineDBBackedProvider, failedPath string) {
+				provider.fingerprintErrKey = failedPath
+			},
+		},
+		{
+			name:                 "parse failure",
+			wantProviderFailures: 1,
+			wantFailedParseCalls: 2,
+			configure: func(provider *baselineDBBackedProvider, failedPath string) {
+				provider.parseErrKey = failedPath
+			},
+		},
+		{
+			name:                 "source error",
+			wantStaleWrite:       true,
+			wantProviderFailures: 1,
+			wantFailedParseCalls: 2,
+			configure: func(provider *baselineDBBackedProvider, failedPath string) {
+				outcome := provider.outcomes[failedPath]
+				outcome.SourceErrors = []parser.SourceError{{
+					SourceKey: failedPath, SessionID: "failed",
+					Err: errors.New("injected member failure"),
+				}}
+				provider.outcomes[failedPath] = outcome
+			},
+		},
+		{
+			name:                 "incomplete result set",
+			wantStaleWrite:       true,
+			wantProviderFailures: 1,
+			wantFailedParseCalls: 2,
+			configure: func(provider *baselineDBBackedProvider, failedPath string) {
+				outcome := provider.outcomes[failedPath]
+				outcome.ResultSetComplete = false
+				provider.outcomes[failedPath] = outcome
+			},
+		},
+		{
+			name:                 "result needs retry",
+			wantStaleWrite:       true,
+			wantProviderFailures: 1,
+			wantFailedParseCalls: 2,
+			configure: func(provider *baselineDBBackedProvider, failedPath string) {
+				outcome := provider.outcomes[failedPath]
+				outcome.Results[0].DataVersion = parser.DataVersionNeedsRetry
+				provider.outcomes[failedPath] = outcome
+			},
+		},
+		{name: "write failure", failWrite: true, wantFailedParseCalls: 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			const agent parser.AgentType = "baseline-db-backed"
+			database := openTestDB(t)
+			root := t.TempDir()
+			healthyPath := filepath.Join(root, "healthy.db")
+			failedPath := filepath.Join(root, "failed.db")
+			seedActiveBaselineSource(t, database, agent, "healthy", healthyPath)
+			seedActiveBaselineSource(t, database, agent, "failed", failedPath)
+			started := time.Unix(1704067200, 0)
+			outcome := func(id, path string) parser.ParseOutcome {
+				return parser.ParseOutcome{
+					Results: []parser.ParseResultOutcome{{
+						Result: parser.ParseResult{Session: parser.ParsedSession{
+							ID: id, Agent: agent, Project: "project", Machine: "local",
+							StartedAt: started, EndedAt: started,
+							File: parser.FileInfo{Path: path, Mtime: 2},
+						}},
+						DataVersion: parser.DataVersionCurrent,
+					}},
+					ResultSetComplete: true,
+				}
+			}
+			provider := &baselineDBBackedProvider{
+				ProviderBase: parser.ProviderBase{
+					Def: parser.AgentDef{Type: agent, FileBased: false},
+					Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+						StreamingDiscovery: parser.CapabilitySupported,
+					}},
+				},
+				sources: []parser.SourceRef{
+					{Provider: agent, Key: healthyPath, DisplayPath: healthyPath, FingerprintKey: healthyPath},
+					{Provider: agent, Key: failedPath, DisplayPath: failedPath, FingerprintKey: failedPath},
+				},
+				outcomes: map[string]parser.ParseOutcome{
+					healthyPath: outcome("healthy", healthyPath),
+					failedPath:  outcome("failed", failedPath),
+				},
+				fingerprintCalls: make(map[string]int),
+				parseCalls:       make(map[string]int),
+			}
+			if tc.configure != nil {
+				tc.configure(provider, failedPath)
+			}
+			if tc.failWrite {
+				raw, err := sql.Open("sqlite3", database.Path())
+				require.NoError(t, err)
+				t.Cleanup(func() { require.NoError(t, raw.Close()) })
+				_, err = raw.Exec(`
+					CREATE TRIGGER fail_selected_db_backed_write
+					BEFORE INSERT ON sessions
+					WHEN NEW.id = 'failed'
+					BEGIN
+						SELECT RAISE(FAIL, 'injected db-backed write failure');
+					END;
+				`)
+				require.NoError(t, err)
+			}
+			engine := NewEngine(database, EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{agent: {root}},
+				Machine:   "local",
+				ProviderFactories: []parser.ProviderFactory{
+					baselineDBBackedFactory{provider: provider},
+				},
+				ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+					agent: parser.ProviderMigrationProviderAuthoritative,
+				},
+			})
+			t.Cleanup(engine.Close)
+			writeMode := syncWriteDefault
+			if tc.failWrite {
+				writeMode = syncWriteBulk
+			}
+
+			for pass := 1; pass <= 2; pass++ {
+				stats := SyncStats{}
+				aborted := engine.syncProviderDBBackedAgent(
+					t.Context(), agent, string(agent), writeMode, false,
+					newRootSyncScope([]string{root}), &stats, func(int, int) {},
+				)
+
+				assert.False(t, aborted)
+				assert.Equal(t, 1, stats.Failed, "pass %d must report the failed source", pass)
+				assert.Equal(t, tc.wantProviderFailures, stats.providerFailures,
+					"pass %d provider failure count", pass)
+				ownership, err := database.ListActiveSessionSourceOwnershipScopesPage(
+					t.Context(), "local", string(agent),
+					[]db.StoredSourcePathHintScope{{Path: root}},
+					db.SessionSourceCursor{},
+				)
+				require.NoError(t, err)
+				require.Len(t, ownership, 1,
+					"pass %d must leave only the healthy source baselined", pass)
+				assert.Equal(t, healthyPath, ownership[0].FilePath)
+				if tc.wantStaleWrite {
+					_, mtime, found := database.GetFileInfoByPath(failedPath)
+					require.True(t, found)
+					assert.Equal(t, int64(2), mtime,
+						"the valid result from the unclean source must be persisted")
+					assert.Less(t, database.GetDataVersionByPath(failedPath),
+						db.CurrentDataVersion(),
+						"the persisted partial result must remain retryable")
+				}
+			}
+			assert.Equal(t, 2, provider.fingerprintCalls[failedPath])
+			assert.Equal(t, tc.wantFailedParseCalls, provider.parseCalls[failedPath],
+				"the failed source must not become fresh after an unclean pass")
+			assert.Equal(t, 1, provider.parseCalls[healthyPath],
+				"the clean source should use the fresh shortcut on the second pass")
+		})
+	}
+}
+
+func TestSyncProviderDBBackedAgentFlushesEachSourceBeforeParsingNext(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	const sourceCount = reconciliationPageSize + 1
+	sources := make([]parser.SourceRef, sourceCount)
+	for i := range sources {
+		path := filepath.Join(root, fmt.Sprintf("session-%02d.db", i))
+		sources[i] = parser.SourceRef{
+			Provider: parser.AgentWarp, Key: path,
+			DisplayPath: path, FingerprintKey: path,
+		}
+	}
+	provider := &manyStreamingProvider{
+		ProviderBase: parser.ProviderBase{
+			Def: parser.AgentDef{
+				Type: parser.AgentWarp, DisplayName: "Warp", FileBased: false,
+			},
+			Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+				StreamingDiscovery: parser.CapabilitySupported,
+			}},
+		},
+		sources: sources,
+	}
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentWarp: {root}},
+		Machine:   "local",
+		ProviderFactories: []parser.ProviderFactory{
+			manyStreamingFactory{provider},
+		},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			parser.AgentWarp: parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+	maxPending := 0
+	writeCalls := 0
+	engine.writeBatchOverride = func(
+		batch []pendingWrite, mode syncWriteMode, force bool,
+	) (int, int, int, int) {
+		writeCalls++
+		maxPending = max(maxPending, len(batch))
+		return engine.writeBatch(batch, mode, force)
+	}
+	stats := SyncStats{}
+	progressTotal := 0
+
+	aborted := engine.syncProviderDBBackedAgent(
+		t.Context(), parser.AgentWarp, "warp", syncWriteBulk, false,
+		newRootSyncScope([]string{root}), &stats,
+		func(total, _ int) { progressTotal += total },
+	)
+
+	assert.False(t, aborted)
+	assert.Equal(t, 1, maxPending,
+		"each source must be flushed before the next source is parsed")
+	assert.Equal(t, sourceCount, writeCalls)
+	assert.Equal(t, sourceCount, stats.TotalSessions)
+	assert.Equal(t, sourceCount, stats.Synced)
+	assert.Equal(t, sourceCount, progressTotal)
+	assert.Zero(t, provider.discoverCalls.Load(),
+		"DB-backed background sync must not materialize the provider archive")
+	assert.Equal(t, int32(1), provider.streamCalls.Load(),
+		"progress accounting must reuse the sync traversal")
+	for i := range sourceCount {
+		id := fmt.Sprintf("session-%02d", i)
+		stored, err := database.GetSession(t.Context(), id)
+		require.NoError(t, err)
+		assert.NotNil(t, stored, "session %s must be persisted", id)
+	}
+	var cursor db.SessionSourceCursor
+	baselineCount := 0
+	for {
+		page, err := database.ListActiveSessionSourceOwnershipScopesPage(
+			t.Context(), "local", string(parser.AgentWarp),
+			[]db.StoredSourcePathHintScope{{Path: root}}, cursor,
+		)
+		require.NoError(t, err)
+		if len(page) == 0 {
+			break
+		}
+		baselineCount += len(page)
+		cursor = page[len(page)-1].Cursor()
+	}
+	assert.Equal(t, sourceCount, baselineCount,
+		"streamed sources must acquire exact ownership proof across page boundaries")
+}
+
+func TestSyncAllStreamsDBBackedDiscoveryExactlyOnce(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	path := filepath.Join(root, "session.db")
+	provider := &manyStreamingProvider{
+		ProviderBase: parser.ProviderBase{
+			Def: parser.AgentDef{Type: parser.AgentWarp, DisplayName: "Warp"},
+			Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+				StreamingDiscovery: parser.CapabilitySupported,
+			}},
+		},
+		sources: []parser.SourceRef{{
+			Provider: parser.AgentWarp, Key: path,
+			DisplayPath: path, FingerprintKey: path,
+		}},
+	}
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentWarp: {root}},
+		Machine:   "local",
+		ProviderFactories: []parser.ProviderFactory{
+			manyStreamingFactory{provider},
+		},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			parser.AgentWarp: parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+
+	stats := engine.SyncAll(t.Context(), nil)
+
+	assert.False(t, stats.Aborted)
+	assert.Zero(t, provider.discoverCalls.Load(),
+		"full sync must never materialize DB-backed discovery")
+	assert.Equal(t, int32(1), provider.streamCalls.Load(),
+		"full sync must count and process sources in one traversal")
+	stored, err := database.GetSession(t.Context(), "session")
+	require.NoError(t, err)
+	assert.NotNil(t, stored)
+}
+
+type storedHintScopeProvider struct {
+	parser.ProviderBase
+	container string
+}
+
+func (p *storedHintScopeProvider) StoredSourceHintScopes(
+	req parser.ChangedPathRequest,
+) []parser.StoredSourceHintScope {
+	if req.Path != p.container {
+		return nil
+	}
+	return []parser.StoredSourceHintScope{{
+		Path: p.container, IncludeVirtualMembers: true,
+	}}
+}
+
+func (*storedHintScopeProvider) Parse(
+	context.Context, parser.ParseRequest,
+) (parser.ParseOutcome, error) {
+	return parser.ParseOutcome{}, nil
+}
+
+func TestProviderForceReplaceRewritesResolvedMultiSessionHintScopes(t *testing.T) {
+	database := openTestDB(t)
+	container := filepath.Join(t.TempDir(), "archive")
+	remoteContainer := "host:" + container
+	for _, id := range []string{"remote-a", "remote-b"} {
+		path := remoteContainer + "#" + id
+		require.NoError(t, database.UpsertSession(db.Session{
+			ID: id, Agent: "scope-provider", Project: "project", Machine: "host",
+			FilePath: &path,
+		}))
+	}
+	provider := &storedHintScopeProvider{
+		ProviderBase: parser.ProviderBase{
+			Def: parser.AgentDef{Type: "scope-provider"},
+		},
+		container: container,
+	}
+	engine := &Engine{
+		db:           database,
+		pathRewriter: func(path string) string { return "host:" + path },
+	}
+
+	ids := engine.providerSourceSessionIDsForForceReplace(provider, parser.SourceRef{
+		Provider: "scope-provider", DisplayPath: container,
+	})
+
+	assert.ElementsMatch(t, []string{"remote-a", "remote-b"}, ids)
+}
+
+func TestProviderChangedPathEventKindTreatsExistingHashPathAsPhysical(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session#literal.jsonl")
+	require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o600))
+
+	assert.Equal(t, "write", providerChangedPathEventKind(path))
+}
+
+func TestReconcileWatchRootsNeverCallsDiscoverSliceFallback(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	provider := &directStreamingProvider{ProviderBase: parser.ProviderBase{
+		Def: parser.AgentDef{Type: "direct-streaming"},
+		Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+			DiscoverSources:    parser.CapabilitySupported,
+			StreamingDiscovery: parser.CapabilitySupported,
+			WatchSources:       parser.CapabilitySupported,
+			FindSource:         parser.CapabilitySupported,
+		}},
+	}}
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{"direct-streaming": {root}},
+		Machine:   "local",
+		ProviderFactories: []parser.ProviderFactory{
+			directStreamingFactory{provider: provider},
+		},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			"direct-streaming": parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+
+	require.NoError(t, engine.ReconcileWatchRoots(t.Context(), []string{root}, false))
+	assert.Zero(t, provider.discoverCalls.Load())
+}
+
+func TestReconcileWatchRootsRehydratesJSONLSourcesWithLinearTraversal(t *testing.T) {
+	const sourceCount = 24
+	const agent parser.AgentType = "bounded-jsonl"
+	root := t.TempDir()
+	for i := range sourceCount {
+		path := filepath.Join(root, fmt.Sprintf("session-%02d.jsonl", i))
+		require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o600))
+	}
+	var includeCalls atomic.Int32
+	factory := parser.NewSourceSetFactory(
+		parser.AgentDef{Type: agent, IDPrefix: string(agent) + ":", FileBased: true},
+		parser.Capabilities{Source: parser.SourceCapabilities{
+			DiscoverSources:    parser.CapabilitySupported,
+			StreamingDiscovery: parser.CapabilitySupported,
+			WatchSources:       parser.CapabilitySupported,
+			FindSource:         parser.CapabilitySupported,
+		}},
+		func(cfg parser.ProviderConfig) parser.SourceSet {
+			return parser.NewJSONLSourceSet(agent, cfg.Roots,
+				parser.WithInclude(func(string, os.FileInfo) bool {
+					includeCalls.Add(1)
+					return true
+				}),
+				parser.WithParseFile(func(
+					_ context.Context, path string, _ parser.ParseRequest,
+				) ([]parser.ParseResult, []string, error) {
+					started := time.Unix(1704067200, 0)
+					return []parser.ParseResult{{Session: parser.ParsedSession{
+						ID: string(agent) + ":" +
+							strings.TrimSuffix(filepath.Base(path), filepath.Ext(path)),
+						Agent: agent, Project: "project", Machine: "local",
+						StartedAt: started, EndedAt: started,
+						File: parser.FileInfo{Path: path},
+					}}}, nil, nil
+				}),
+			)
+		},
+	)
+	database := openTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs:         map[parser.AgentType][]string{agent: {root}},
+		Machine:           "local",
+		ProviderFactories: []parser.ProviderFactory{factory},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			agent: parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+
+	require.NoError(t, engine.ReconcileWatchRoots(t.Context(), []string{root}, false))
+
+	assert.Equal(t, int32(sourceCount*2), includeCalls.Load(),
+		"one discovery and one exact rehydration check are allowed per source")
+	for i := range sourceCount {
+		id := fmt.Sprintf("%s:session-%02d", agent, i)
+		session, err := database.GetSession(t.Context(), id)
+		require.NoError(t, err)
+		assert.NotNil(t, session, "reconciliation must persist %s", id)
+	}
+}
+
+func TestReconcileWatchRootsParseFailureCannotAcknowledgeComplete(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	path := filepath.Join(root, "session.jsonl")
+	require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o600))
+	source := parser.SourceRef{
+		Provider: "direct-streaming", Key: path,
+		DisplayPath: path, FingerprintKey: path,
+	}
+	parseErr := errors.New("injected parse failure")
+	provider := &directStreamingProvider{
+		ProviderBase: parser.ProviderBase{
+			Def: parser.AgentDef{Type: "direct-streaming", FileBased: true},
+			Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+				DiscoverSources:    parser.CapabilitySupported,
+				StreamingDiscovery: parser.CapabilitySupported,
+				WatchSources:       parser.CapabilitySupported,
+				FindSource:         parser.CapabilitySupported,
+			}},
+		},
+		source: &source, parseErr: parseErr,
+	}
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{"direct-streaming": {root}},
+		Machine:   "local",
+		ProviderFactories: []parser.ProviderFactory{
+			directStreamingFactory{provider: provider},
+		},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			"direct-streaming": parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+
+	err := engine.ReconcileWatchRoots(t.Context(), []string{root}, false)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed")
+	result := engine.LastReconciliationResult()
+	assert.False(t, result.Complete)
+	assert.True(t, result.Aborted)
+}
+
+func TestReconcileWatchRootsPartialProviderOutcomesCannotAcknowledgeComplete(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		outcome parser.ParseOutcome
+	}{
+		{
+			name: "source error",
+			outcome: parser.ParseOutcome{
+				SourceErrors: []parser.SourceError{{
+					SessionID: "partial", Err: errors.New("member parse failed"),
+				}},
+				ResultSetComplete: true,
+			},
+		},
+		{
+			name: "incomplete result set",
+			outcome: parser.ParseOutcome{
+				ResultSetComplete: false,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			database := openTestDB(t)
+			root := t.TempDir()
+			path := filepath.Join(root, "partial.jsonl")
+			require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o600))
+			source := parser.SourceRef{
+				Provider: "partial-streaming", Key: path,
+				DisplayPath: path, FingerprintKey: path,
+			}
+			provider := &directStreamingProvider{
+				ProviderBase: parser.ProviderBase{
+					Def: parser.AgentDef{Type: "partial-streaming", FileBased: true},
+					Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+						DiscoverSources:    parser.CapabilitySupported,
+						StreamingDiscovery: parser.CapabilitySupported,
+						WatchSources:       parser.CapabilitySupported,
+						FindSource:         parser.CapabilitySupported,
+					}},
+				},
+				source: &source, parseOutcome: tc.outcome,
+			}
+			engine := NewEngine(database, EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{"partial-streaming": {root}},
+				Machine:   "local",
+				ProviderFactories: []parser.ProviderFactory{
+					directStreamingFactory{provider: provider},
+				},
+				ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+					"partial-streaming": parser.ProviderMigrationProviderAuthoritative,
+				},
+			})
+			t.Cleanup(engine.Close)
+
+			err := engine.ReconcileWatchRoots(t.Context(), []string{root}, false)
+			require.Error(t, err)
+			result := engine.LastReconciliationResult()
+			assert.False(t, result.Complete)
+			assert.True(t, result.Aborted)
+		})
+	}
+}
+
+func TestReconcileWatchRootsCwdFilteredZeroResultRevokesDeletionProof(t *testing.T) {
+	const agent parser.AgentType = "cwd-filtered-zero-result"
+	const sessionID = "outside-session"
+	database := openTestDB(t)
+	root := t.TempDir()
+	path := filepath.Join(root, "outside.jsonl")
+	require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o600))
+	source := parser.SourceRef{
+		Provider: agent, Key: path, DisplayPath: path, FingerprintKey: path,
+	}
+	started := time.Unix(1704067200, 0)
+	provider := &directStreamingProvider{
+		ProviderBase: parser.ProviderBase{
+			Def: parser.AgentDef{Type: agent, FileBased: true},
+			Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+				DiscoverSources:    parser.CapabilitySupported,
+				StreamingDiscovery: parser.CapabilitySupported,
+				WatchSources:       parser.CapabilitySupported,
+				FindSource:         parser.CapabilitySupported,
+			}},
+		},
+		source: &source,
+		parseOutcome: parser.ParseOutcome{
+			Results: []parser.ParseResultOutcome{{
+				Result: parser.ParseResult{Session: parser.ParsedSession{
+					ID: sessionID, Agent: agent, Project: "outside", Machine: "local",
+					Cwd: "/workspace/personal", StartedAt: started, EndedAt: started,
+					File: parser.FileInfo{Path: path},
+				}},
+				DataVersion: parser.DataVersionCurrent,
+			}},
+			ResultSetComplete: true,
+		},
+	}
+	newEngine := func(includeCwdPrefixes []string) *Engine {
+		return NewEngine(database, EngineConfig{
+			AgentDirs:          map[parser.AgentType][]string{agent: {root}},
+			Machine:            "local",
+			IncludeCwdPrefixes: includeCwdPrefixes,
+			ProviderFactories: []parser.ProviderFactory{
+				directStreamingFactory{provider: provider},
+			},
+			ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+				agent: parser.ProviderMigrationProviderAuthoritative,
+			},
+		})
+	}
+
+	engine := newEngine(nil)
+	t.Cleanup(engine.Close)
+	require.NoError(t, engine.ReconcileWatchRootsAfterLostEvents(
+		t.Context(), []string{root}, false,
+	))
+	engine.Close()
+	active, err := database.GetSession(t.Context(), sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, active, "initial reconciliation must archive the session")
+	ownership, err := database.ListActiveSessionSourceOwnershipScopesPage(
+		t.Context(), "local", string(agent),
+		[]db.StoredSourcePathHintScope{{Path: root}}, db.SessionSourceCursor{},
+	)
+	require.NoError(t, err)
+	require.Len(t, ownership, 1,
+		"initial reconciliation must establish deletion proof")
+
+	provider.parseOutcome = parser.ParseOutcome{
+		ResultSetComplete: true,
+		ForceReplace:      true,
+		SkipReason:        parser.SkipNoSession,
+	}
+	engine = newEngine([]string{"/workspace/work"})
+	t.Cleanup(engine.Close)
+	require.NoError(t, engine.ReconcileWatchRootsAfterLostEvents(
+		t.Context(), []string{root}, false,
+	))
+	ownership, err = database.ListActiveSessionSourceOwnershipScopesPage(
+		t.Context(), "local", string(agent),
+		[]db.StoredSourcePathHintScope{{Path: root}}, db.SessionSourceCursor{},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, ownership,
+		"a CWD-rejected zero-result source must lose deletion proof")
+
+	require.NoError(t, os.Remove(path))
+	provider.source = nil
+	require.NoError(t, engine.ReconcileWatchRootsAfterLostEvents(
+		t.Context(), []string{root}, false,
+	))
+	active, err = database.GetSession(t.Context(), sessionID)
+	require.NoError(t, err)
+	assert.NotNil(t, active,
+		"removing the filtered source must preserve the archived session")
+}
+
+func TestReconcileWatchRootsArchiveWriteFailureCannotAcknowledgeComplete(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	path := filepath.Join(root, "write-failure.jsonl")
+	require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o600))
+	source := parser.SourceRef{
+		Provider: "write-failure-streaming", Key: path,
+		DisplayPath: path, FingerprintKey: path,
+	}
+	provider := &directStreamingProvider{
+		ProviderBase: parser.ProviderBase{
+			Def: parser.AgentDef{Type: "write-failure-streaming", FileBased: true},
+			Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+				DiscoverSources: parser.CapabilitySupported, StreamingDiscovery: parser.CapabilitySupported,
+				WatchSources: parser.CapabilitySupported, FindSource: parser.CapabilitySupported,
+			}},
+		},
+		source: &source,
+		parseOutcome: parser.ParseOutcome{
+			Results: []parser.ParseResultOutcome{{
+				Result: parser.ParseResult{Session: parser.ParsedSession{
+					ID: "write-failure:session", Agent: "write-failure-streaming",
+					Project: "project", Machine: "local",
+					StartedAt: time.Unix(1704067200, 0), EndedAt: time.Unix(1704067201, 0),
+					File: parser.FileInfo{Path: path},
+				}},
+				DataVersion: parser.DataVersionCurrent,
+			}},
+			ResultSetComplete: true,
+		},
+	}
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{"write-failure-streaming": {root}},
+		Machine:   "local", ProviderFactories: []parser.ProviderFactory{
+			directStreamingFactory{provider: provider},
+		},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			"write-failure-streaming": parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+	engine.writeBatchOverride = func(batch []pendingWrite, _ syncWriteMode, _ bool) (int, int, int, int) {
+		return 0, 0, len(batch), 0
+	}
+
+	err := engine.ReconcileWatchRoots(t.Context(), []string{root}, false)
+
+	require.Error(t, err)
+	result := engine.LastReconciliationResult()
+	assert.False(t, result.Complete)
+	assert.True(t, result.Aborted)
+}
+
+func TestReconcileWatchRootsOpenCodeGateSkipsUnchangedContainerInConstantState(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	containerPath := filepath.Join(root, "opencode.db")
+	container, err := sql.Open("sqlite3", containerPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, container.Close()) })
+	_, err = container.Exec("CREATE TABLE session (id TEXT PRIMARY KEY)")
+	require.NoError(t, err)
+	path := containerPath + "#ses-gated"
+	source := parser.SourceRef{
+		Provider: parser.AgentOpenCode, Key: path,
+		DisplayPath: path, FingerprintKey: path,
+	}
+	provider := &directStreamingProvider{
+		ProviderBase: parser.ProviderBase{
+			Def: parser.AgentDef{Type: parser.AgentOpenCode},
+			Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+				DiscoverSources:    parser.CapabilitySupported,
+				StreamingDiscovery: parser.CapabilitySupported,
+				WatchSources:       parser.CapabilitySupported,
+				FindSource:         parser.CapabilitySupported,
+			}},
+		},
+		source: &source,
+		parseOutcome: parser.ParseOutcome{
+			Results: []parser.ParseResultOutcome{{
+				Result: parser.ParseResult{Session: parser.ParsedSession{
+					ID: "opencode:ses-gated", Agent: parser.AgentOpenCode,
+					Project: "project", Machine: "local",
+					StartedAt: time.Unix(1704067200, 0),
+					EndedAt:   time.Unix(1704067201, 0),
+					File:      parser.FileInfo{Path: path},
+				}},
+				DataVersion: parser.DataVersionCurrent,
+			}},
+			ResultSetComplete: true,
+		},
+	}
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentOpenCode: {root}},
+		Machine:   "local",
+		ProviderFactories: []parser.ProviderFactory{
+			directStreamingFactory{provider: provider},
+		},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			parser.AgentOpenCode: parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+
+	require.NoError(t, engine.ReconcileWatchRoots(t.Context(), []string{root}, false))
+	require.NoError(t, engine.ReconcileWatchRoots(t.Context(), []string{root}, false))
+	require.NoError(t, engine.ReconcileWatchRoots(t.Context(), nil, true))
+	assert.Equal(t, int32(1), provider.parseCalls.Load(),
+		"authoritative discovery must not force-parse an unchanged trusted container")
+}
+
+func (f failingDBBackedFactory) Capabilities() parser.Capabilities {
+	return f.provider.Capabilities()
+}
+
+func (f failingDBBackedFactory) NewProvider(parser.ProviderConfig) parser.Provider {
+	return f.provider
+}
+
+func TestReconcileWatchRootsFailsWhenDBBackedDiscoveryFails(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	discoveryErr := errors.New("provider database unavailable")
+	provider := failingDBBackedProvider{
+		ProviderBase: parser.ProviderBase{Def: parser.AgentDef{
+			Type: parser.AgentWarp, DisplayName: "Warp", FileBased: false,
+		}},
+		err: discoveryErr, failOnCall: 1,
+	}
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentWarp: {root}},
+		Machine:   "local",
+		ProviderFactories: []parser.ProviderFactory{
+			failingDBBackedFactory{provider: &provider},
+		},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			parser.AgentWarp: parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+
+	err := engine.ReconcileWatchRoots(context.Background(), []string{root}, false)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "provider discoveries failed")
+	assert.Equal(t, int32(1), provider.calls.Load())
+}
+
+func TestReconcileWatchRootsFailsWhenFileDiscoveryFails(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	provider := failingDBBackedProvider{
+		ProviderBase: parser.ProviderBase{Def: parser.AgentDef{
+			Type: parser.AgentCowork, DisplayName: "Cowork", FileBased: true,
+		}},
+		err: errors.New("source listing unavailable"), failOnCall: 1,
+	}
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentCowork: {root}},
+		Machine:   "local",
+		ProviderFactories: []parser.ProviderFactory{
+			failingDBBackedFactory{provider: &provider},
+		},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			parser.AgentCowork: parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+
+	err := engine.ReconcileWatchRoots(context.Background(), []string{root}, false)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "provider discoveries failed")
+}
+
+func TestReconcileWatchRootsCancellationIsAbortedAndCleansSpool(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {root}},
+		Machine:   "local",
+	})
+	t.Cleanup(engine.Close)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := engine.ReconcileWatchRoots(ctx, []string{root}, false)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	result := engine.LastReconciliationResult()
+	assert.True(t, result.Aborted)
+	assert.False(t, result.Complete)
+	matches, globErr := filepath.Glob(filepath.Join(filepath.Dir(database.Path()), ".agentsview-reconcile-*.db*"))
+	require.NoError(t, globErr)
+	assert.Empty(t, matches)
+}
+
+func TestReconcileWatchRootsCancellationAfterSpoolCreationCleansSpool(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {root}},
+		Machine:   "local",
+	})
+	t.Cleanup(engine.Close)
+	ctx, cancel := context.WithCancel(t.Context())
+	var scratchPath string
+	engine.reconciliationSpoolFactory = func(path string) (reconciliationSpoolStore, error) {
+		spool, err := newReconciliationSpool(path)
+		if err != nil {
+			return nil, err
+		}
+		scratchPath = spool.path
+		cancel()
+		return spool, nil
+	}
+
+	err := engine.ReconcileWatchRoots(ctx, []string{root}, false)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		_, statErr := os.Stat(scratchPath + suffix)
+		assert.ErrorIs(t, statErr, os.ErrNotExist)
+	}
+}
+
+func TestReconcileWatchRootsCancellationDuringLaterSpoolPage(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	const agent parser.AgentType = "paged-cancel"
+	sources := make([]parser.SourceRef, 300)
+	for i := range sources {
+		path := filepath.Join(root, fmt.Sprintf("session-%03d.fixture", i))
+		require.NoError(t, os.WriteFile(path, []byte("fixture"), 0o600))
+		sources[i] = parser.SourceRef{
+			Provider: agent, Key: path, DisplayPath: path, FingerprintKey: path,
+		}
+	}
+	provider := &manyStreamingProvider{
+		ProviderBase: parser.ProviderBase{
+			Def: parser.AgentDef{Type: agent, FileBased: true},
+			Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+				DiscoverSources:    parser.CapabilitySupported,
+				StreamingDiscovery: parser.CapabilitySupported,
+				WatchSources:       parser.CapabilitySupported,
+			}},
+		},
+		sources: sources,
+	}
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{agent: {root}}, Machine: "local",
+		ProviderFactories: []parser.ProviderFactory{manyStreamingFactory{provider}},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			agent: parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+	ctx, cancel := context.WithCancel(t.Context())
+	engine.reconciliationSpoolFactory = func(path string) (reconciliationSpoolStore, error) {
+		spool, err := newReconciliationSpool(path)
+		if err != nil {
+			return nil, err
+		}
+		return &cancelOnLaterPageSpool{reconciliationSpoolStore: spool, cancel: cancel}, nil
+	}
+
+	err := engine.ReconcileWatchRoots(ctx, []string{root}, false)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	result := engine.LastReconciliationResult()
+	assert.True(t, result.Aborted)
+	assert.Equal(t, reconciliationPageSize, result.Metrics.MaxSpoolPageRows)
+}
+
+func TestReconcileWatchRootsPartialSecondPageArchiveWriteFailure(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	const agent parser.AgentType = "paged-write-failure"
+	sources := make([]parser.SourceRef, 300)
+	for i := range sources {
+		path := filepath.Join(root, fmt.Sprintf("session-%03d.fixture", i))
+		require.NoError(t, os.WriteFile(path, []byte("fixture"), 0o600))
+		sources[i] = parser.SourceRef{
+			Provider: agent, Key: path, DisplayPath: path, FingerprintKey: path,
+		}
+	}
+	provider := &manyStreamingProvider{
+		ProviderBase: parser.ProviderBase{
+			Def: parser.AgentDef{Type: agent, FileBased: true},
+			Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+				DiscoverSources:    parser.CapabilitySupported,
+				StreamingDiscovery: parser.CapabilitySupported,
+				WatchSources:       parser.CapabilitySupported,
+			}},
+		},
+		sources: sources,
+	}
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{agent: {root}}, Machine: "local",
+		ProviderFactories: []parser.ProviderFactory{manyStreamingFactory{provider}},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			agent: parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+	writeCalls := 0
+	engine.writeBatchOverride = func(
+		batch []pendingWrite, mode syncWriteMode, force bool,
+	) (int, int, int, int) {
+		writeCalls++
+		if writeCalls == 4 {
+			return 0, 0, len(batch), 0
+		}
+		return engine.writeBatch(batch, mode, force)
+	}
+
+	err := engine.ReconcileWatchRoots(t.Context(), []string{root}, false)
+
+	require.Error(t, err)
+	assert.Equal(t, 4, writeCalls, "failure must occur in the second spool page")
+	result := engine.LastReconciliationResult()
+	assert.True(t, result.Aborted)
+	assert.False(t, result.Complete)
+	firstPage, getErr := database.GetSession(t.Context(), "session-000")
+	require.NoError(t, getErr)
+	require.NotNil(t, firstPage, "completed first-page writes must be durable")
+	failedPage, getErr := database.GetSession(t.Context(), "session-256")
+	require.NoError(t, getErr)
+	assert.Nil(t, failedPage, "failed second-page batch must not be acknowledged")
+}
+
+func TestCanonicalReconciliationSourceIdentityWindowsCollisions(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		left     string
+		right    string
+		wantSame bool
+	}{
+		{
+			name:  "drive casing and separators",
+			left:  `C:\Users\Demo\Sessions\one.jsonl`,
+			right: `c:/users/demo/sessions/one.jsonl`, wantSame: true,
+		},
+		{
+			name:  "different volumes",
+			left:  `C:\Users\Demo\Sessions\one.jsonl`,
+			right: `D:\Users\Demo\Sessions\one.jsonl`, wantSame: false,
+		},
+		{
+			name:  "virtual container identity",
+			left:  `C:\Users\Demo\state.vscdb#session-one`,
+			right: `c:/users/demo/state.vscdb#session-one`, wantSame: true,
+		},
+		{
+			name:  "virtual member remains distinct",
+			left:  `C:\Users\Demo\state.vscdb#session-one`,
+			right: `c:/users/demo/state.vscdb#session-two`, wantSame: false,
+		},
+		{
+			name:  "posix casing remains distinct",
+			left:  `/Users/Demo/session.jsonl`,
+			right: `/users/demo/session.jsonl`, wantSame: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.wantSame, sameReconciliationSourcePath(tc.left, tc.right))
+		})
+	}
+}
+
+type cancelOnLaterPageSpool struct {
+	reconciliationSpoolStore
+	cancel context.CancelFunc
+}
+
+func (spool *cancelOnLaterPageSpool) Page(
+	ctx context.Context, cursor reconciliationCursor, limit int,
+) ([]reconciliationCandidate, error) {
+	if cursor.Identity != "" {
+		spool.cancel()
+	}
+	return spool.reconciliationSpoolStore.Page(ctx, cursor, limit)
+}
+
+func TestReconcileWatchRootsRemoteOnlyIncrementalScopeIsBoundedNoOp(t *testing.T) {
+	database := openTestDB(t)
+	localRoot := t.TempDir()
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {localRoot, "s3://bucket/machine/claude"},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+	engine.reconciliationSpoolFactory = func(string) (reconciliationSpoolStore, error) {
+		t.Fatal("remote-only incremental reconciliation enumerated local sources")
+		return nil, nil
+	}
+
+	err := engine.ReconcileWatchRoots(
+		t.Context(), []string{"s3://bucket/machine/claude"}, false,
+	)
+
+	require.NoError(t, err)
+	result := engine.LastReconciliationResult()
+	assert.True(t, result.Complete)
+	assert.False(t, result.Aborted)
+	assert.Equal(t, 1, result.Metrics.ExcludedRemoteRoots)
+}
+
+func TestReconcileWatchRootsAuthoritativeIOErrorsDoNotFalseTombstone(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		agent parser.AgentType
+		setup func(*testing.T, string) string
+	}{
+		{
+			name: "cursor transcript resolution", agent: parser.AgentCursor,
+			setup: func(t *testing.T, root string) string {
+				project := filepath.Join(root, "Users-demo")
+				require.NoError(t, os.MkdirAll(project, 0o755))
+				require.NoError(t, os.Symlink(
+					filepath.Join(root, "missing-transcripts"),
+					filepath.Join(project, "agent-transcripts"),
+				))
+				return filepath.Join(project, "agent-transcripts", "session.jsonl")
+			},
+		},
+		{
+			name: "cowork metadata read", agent: parser.AgentCowork,
+			setup: func(t *testing.T, root string) string {
+				dir := filepath.Join(root, "org", "workspace")
+				require.NoError(t, os.MkdirAll(dir, 0o755))
+				require.NoError(t, os.WriteFile(
+					filepath.Join(dir, "local_50000000-0000-4000-8000-000000000099.json"),
+					[]byte("{"), 0o600,
+				))
+				return filepath.Join(dir, "local_50000000-0000-4000-8000-000000000099", "session.jsonl")
+			},
+		},
+		{
+			name: "cursor candidate stat", agent: parser.AgentCursor,
+			setup: func(t *testing.T, root string) string {
+				transcripts := filepath.Join(root, "Users-demo", "agent-transcripts")
+				nested := filepath.Join(transcripts, "session")
+				require.NoError(t, os.MkdirAll(nested, 0o755))
+				candidate := filepath.Join(nested, "session.jsonl")
+				require.NoError(t, os.Symlink(filepath.Join(root, "missing-cursor"), candidate))
+				return candidate
+			},
+		},
+		{
+			name: "cowork candidate stat", agent: parser.AgentCowork,
+			setup: func(t *testing.T, root string) string {
+				const sessionDir = "local_50000000-0000-4000-8000-000000000097"
+				const cli = "c0000000-0000-4000-8000-000000000097"
+				workspace := filepath.Join(root, "org", "workspace")
+				project := filepath.Join(
+					workspace, sessionDir, ".claude", "projects", "-sessions-demo",
+				)
+				require.NoError(t, os.MkdirAll(project, 0o755))
+				require.NoError(t, os.WriteFile(
+					filepath.Join(workspace, sessionDir+".json"),
+					[]byte(`{"cliSessionId":"`+cli+`"}`), 0o600,
+				))
+				require.NoError(t, os.WriteFile(
+					filepath.Join(project, cli+".jsonl"), []byte("{}\n"), 0o600,
+				))
+				subagents := filepath.Join(project, cli, "subagents")
+				require.NoError(t, os.MkdirAll(subagents, 0o755))
+				candidate := filepath.Join(subagents, "agent-broken.jsonl")
+				require.NoError(t, os.Symlink(filepath.Join(root, "missing-cowork"), candidate))
+				return candidate
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			database := openTestDB(t)
+			root := t.TempDir()
+			storedPath := tc.setup(t, root)
+			id := "preserved-" + string(tc.agent)
+			require.NoError(t, database.UpsertSession(db.Session{
+				ID: id, Agent: string(tc.agent), Project: "project", Machine: "local",
+				FilePath: &storedPath,
+			}))
+			engine := NewEngine(database, EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{tc.agent: {root}}, Machine: "local",
+			})
+			t.Cleanup(engine.Close)
+
+			err := engine.ReconcileWatchRoots(t.Context(), []string{root}, false)
+
+			require.Error(t, err)
+			result := engine.LastReconciliationResult()
+			assert.False(t, result.Complete)
+			assert.True(t, result.Aborted)
+			stored, getErr := database.GetSession(t.Context(), id)
+			require.NoError(t, getErr)
+			require.NotNil(t, stored, "authoritative I/O failure must not tombstone")
+		})
+	}
+}
+
+func TestReconcileWatchRootsSpoolErrorsAbortAndCleanScratchFiles(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		failWrite bool
+	}{
+		{name: "write", failWrite: true},
+		{name: "query"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			database := openTestDB(t)
+			root := t.TempDir()
+			require.NoError(t, os.MkdirAll(filepath.Join(root, "project"), 0o755))
+			require.NoError(t, os.WriteFile(
+				filepath.Join(root, "project", "session.jsonl"), []byte("{}\n"), 0o644,
+			))
+			engine := NewEngine(database, EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {root}},
+				Machine:   "local",
+			})
+			t.Cleanup(engine.Close)
+			injected := errors.New("injected spool " + tc.name + " failure")
+			var scratchPath string
+			engine.reconciliationSpoolFactory = func(path string) (reconciliationSpoolStore, error) {
+				spool, err := newReconciliationSpool(path)
+				if err != nil {
+					return nil, err
+				}
+				scratchPath = spool.path
+				return &failingReconciliationSpool{
+					reconciliationSpoolStore: spool,
+					err:                      injected,
+					failWrite:                tc.failWrite,
+				}, nil
+			}
+
+			err := engine.ReconcileWatchRoots(t.Context(), []string{root}, false)
+
+			require.ErrorIs(t, err, injected)
+			result := engine.LastReconciliationResult()
+			assert.True(t, result.Aborted)
+			assert.False(t, result.Complete)
+			for _, suffix := range []string{"", "-wal", "-shm"} {
+				_, statErr := os.Stat(scratchPath + suffix)
+				assert.ErrorIs(t, statErr, os.ErrNotExist)
+			}
+		})
+	}
+}
+
+type failingReconciliationSpool struct {
+	reconciliationSpoolStore
+	err       error
+	failWrite bool
+}
+
+type cleanupErrorReconciliationSpool struct {
+	reconciliationSpoolStore
+	err error
+}
+
+func (spool *cleanupErrorReconciliationSpool) CloseAndRemove() error {
+	cleanupErr := spool.reconciliationSpoolStore.CloseAndRemove()
+	return errors.Join(spool.err, cleanupErr)
+}
+
+func TestReconciliationReplacementIndexReportsDiscoveryAndCleanupErrors(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	discoveryErr := errors.New("replacement discovery failed")
+	cleanupErr := errors.New("replacement cleanup failed")
+	provider := &failingDBBackedProvider{
+		ProviderBase: parser.ProviderBase{
+			Def:    parser.AgentDef{Type: parser.AgentClaude, FileBased: true},
+			Config: parser.ProviderConfig{Roots: []string{root}},
+		},
+		err: discoveryErr, failOnCall: 1,
+	}
+	engine := NewEngine(database, EngineConfig{Machine: "local"})
+	t.Cleanup(engine.Close)
+	engine.reconciliationSpoolFactory = func(path string) (reconciliationSpoolStore, error) {
+		spool, err := newReconciliationSpool(path)
+		if err != nil {
+			return nil, err
+		}
+		return &cleanupErrorReconciliationSpool{
+			reconciliationSpoolStore: spool,
+			err:                      cleanupErr,
+		}, nil
+	}
+
+	index, err := engine.buildReconciliationReplacementIndex(
+		t.Context(), provider, []string{root},
+	)
+
+	assert.Nil(t, index)
+	assert.ErrorIs(t, err, discoveryErr)
+	assert.ErrorIs(t, err, cleanupErr)
+}
+
+func (spool *failingReconciliationSpool) Add(
+	ctx context.Context, candidate reconciliationCandidate,
+) error {
+	if spool.failWrite {
+		return spool.err
+	}
+	return spool.reconciliationSpoolStore.Add(ctx, candidate)
+}
+
+func (spool *failingReconciliationSpool) Page(
+	context.Context, reconciliationCursor, int,
+) ([]reconciliationCandidate, error) {
+	if !spool.failWrite {
+		return nil, spool.err
+	}
+	return nil, errors.New("unexpected page after write failure")
+}
+
+// tombstoneMissingWatchSourcesUnderSyncLock mirrors the production
+// changed-path pass, which holds syncMu while calling the locked tombstone
+// variant with no reconciliation spool (see the missing-path branch of
+// SyncPathsContext in engine.go).
+func tombstoneMissingWatchSourcesUnderSyncLock(
+	ctx context.Context, engine *Engine, roots []string,
+) (int, error) {
+	engine.syncMu.Lock()
+	defer engine.syncMu.Unlock()
+	return engine.tombstoneMissingWatchSourcesLocked(ctx, roots, nil)
+}
+
+func TestTombstoneMissingWatchSourcesScopesSharedPathByAgent(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	shared := filepath.Join(root, "shared.jsonl")
+	for _, session := range []db.Session{
+		{ID: "claude-shared", Agent: "claude", Project: "project", Machine: "local", FilePath: &shared},
+		{ID: "codex-shared", Agent: "codex", Project: "project", Machine: "local", FilePath: &shared},
+	} {
+		require.NoError(t, database.UpsertSession(session))
+	}
+	require.NoError(t, database.BaselineActiveSessionSourcePaths(
+		t.Context(), "local", []db.SessionSourcePath{
+			{Agent: "claude", FilePath: shared},
+			{Agent: "codex", FilePath: shared},
+		},
+	))
+	engine := &Engine{
+		db: database, machine: "local",
+		agentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {root},
+			parser.AgentCodex:  {root},
+		},
+	}
+
+	deleted, err := tombstoneMissingWatchSourcesUnderSyncLock(
+		t.Context(), engine, []string{root},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 2, deleted)
+	for _, id := range []string{"claude-shared", "codex-shared"} {
+		active, err := database.GetSession(t.Context(), id)
+		require.NoError(t, err)
+		assert.Nil(t, active)
+	}
+}
+
+// The spool-less tombstone path (watcher missing-path passes) must keep the
+// same replacement semantics through the lazily built disk-backed index: a
+// missing tracked copy with a surviving same-UUID duplicate is preserved,
+// and a copy with no survivor is tombstoned.
+func TestTombstoneMissingWatchSourcesCodexReplacementFallback(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	codexDir := filepath.Join(root, "sessions")
+	archivedDir := filepath.Join(root, "archived_sessions")
+	require.NoError(t, os.MkdirAll(codexDir, 0o755))
+	require.NoError(t, os.MkdirAll(archivedDir, 0o755))
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodex: {codexDir, archivedDir},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+
+	duplicated := "f7a8b9ca-7890-1234-ef01-456789012300"
+	solo := "f7a8b9ca-7890-1234-ef01-456789012301"
+	contentFor := func(uuid string) string {
+		return testjsonl.NewSessionBuilder().
+			AddCodexMeta(
+				"2026-05-04T14:00:00Z", uuid, "/home/user/code/api",
+				"codex_cli_rs",
+			).
+			AddCodexMessage("2026-05-04T14:00:01Z", "user", "Copy "+uuid).
+			String()
+	}
+	duplicatedArchived := filepath.Join(
+		archivedDir, "rollout-2026-05-04T14-31-58-"+duplicated+".jsonl",
+	)
+	soloArchived := filepath.Join(
+		archivedDir, "rollout-2026-05-04T14-31-58-"+solo+".jsonl",
+	)
+	require.NoError(t, os.WriteFile(
+		duplicatedArchived, []byte(contentFor(duplicated)), 0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		soloArchived, []byte(contentFor(solo)), 0o644,
+	))
+	require.Equal(t, 2, engine.SyncAll(t.Context(), nil).Synced)
+
+	liveDir := filepath.Join(codexDir, "2026", "05", "04")
+	require.NoError(t, os.MkdirAll(liveDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(
+			liveDir, "rollout-2026-05-04T02-10-04-"+duplicated+".jsonl",
+		),
+		[]byte(contentFor(duplicated)), 0o644,
+	))
+	require.NoError(t, os.Remove(duplicatedArchived))
+	require.NoError(t, os.Remove(soloArchived))
+
+	deleted, err := tombstoneMissingWatchSourcesUnderSyncLock(
+		t.Context(), engine, []string{codexDir, archivedDir},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, deleted)
+
+	preserved, err := database.GetSession(t.Context(), "codex:"+duplicated)
+	require.NoError(t, err)
+	assert.NotNil(t, preserved,
+		"a surviving same-UUID duplicate is a replacement, not a deletion")
+	gone, err := database.GetSession(t.Context(), "codex:"+solo)
+	require.NoError(t, err)
+	assert.Nil(t, gone,
+		"a missing copy with no survivor must tombstone")
+}
+
+func TestTombstoneMissingWatchSourcesPaginatesLargeArchive(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	total := db.WatchReconcileSourcePageSize*3 + 17
+	sources := make([]db.SessionSourcePath, 0, total)
+	for i := range total {
+		path := filepath.Join(root, fmt.Sprintf("source-%04d.jsonl", i))
+		require.NoError(t, database.UpsertSession(db.Session{
+			ID: fmt.Sprintf("session-%04d", i), Agent: "claude",
+			Project: "project", Machine: "local", FilePath: &path,
+		}))
+		sources = append(sources, db.SessionSourcePath{
+			Agent: "claude", FilePath: path,
+		})
+	}
+	require.NoError(t, database.BaselineActiveSessionSourcePaths(
+		t.Context(), "local", sources,
+	))
+	engine := &Engine{
+		db: database, machine: "local",
+		agentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {root},
+		},
+	}
+
+	deleted, err := tombstoneMissingWatchSourcesUnderSyncLock(
+		t.Context(), engine, []string{root},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, total, deleted,
+		"reconciliation must advance across every fixed-size ownership page")
+}
+
+func TestTombstoneMissingWatchSourcesDoesNotRediscoverEachOwnership(t *testing.T) {
+	for _, total := range []int{1, db.WatchReconcileSourcePageSize} {
+		t.Run(fmt.Sprintf("sessions-%d", total), func(t *testing.T) {
+			database := openTestDB(t)
+			root := t.TempDir()
+			sources := make([]db.SessionSourcePath, 0, total)
+			for i := range total {
+				path := filepath.Join(root, fmt.Sprintf("missing-%04d.jsonl", i))
+				require.NoError(t, database.UpsertSession(db.Session{
+					ID: fmt.Sprintf("cowork:missing-%04d", i), Agent: string(parser.AgentCowork),
+					Project: "project", Machine: "local", FilePath: &path,
+				}))
+				sources = append(sources, db.SessionSourcePath{
+					Agent: string(parser.AgentCowork), FilePath: path,
+				})
+			}
+			require.NoError(t, database.BaselineActiveSessionSourcePaths(
+				t.Context(), "local", sources,
+			))
+			provider := &lookupSourceProvider{ProviderBase: parser.ProviderBase{
+				Def: parser.AgentDef{
+					Type: parser.AgentCowork, IDPrefix: "cowork:", FileBased: true,
+				},
+			}}
+			engine := &Engine{
+				db: database, machine: "local",
+				agentDirs: map[parser.AgentType][]string{
+					parser.AgentCowork: {root},
+				},
+				providerFactories: providerFactoryMap([]parser.ProviderFactory{
+					lookupSourceFactory{provider: provider},
+				}),
+			}
+
+			deleted, err := tombstoneMissingWatchSourcesUnderSyncLock(
+				t.Context(), engine, []string{root},
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, total, deleted)
+			assert.Empty(t, provider.findRequests,
+				"authoritative reconciliation must not rescan the archive per missing row")
+		})
+	}
+}
+
+func TestTombstoneMissingWatchSourcesDoesNotInferUnvalidatedVirtualPaths(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	container := filepath.Join(root, "sessions.db")
+	wantPaths := make(map[string]struct{}, db.WatchReconcileSourcePageSize)
+	sources := make([]db.SessionSourcePath, 0, db.WatchReconcileSourcePageSize)
+	for i := range db.WatchReconcileSourcePageSize {
+		virtualPath := parser.VirtualSourcePath(
+			container, fmt.Sprintf("session-%03d", i),
+		)
+		wantPaths[virtualPath] = struct{}{}
+		require.NoError(t, database.UpsertSession(db.Session{
+			ID: fmt.Sprintf("session-%03d", i), Agent: "claude",
+			Project: "project", Machine: "local", FilePath: &virtualPath,
+		}))
+		sources = append(sources, db.SessionSourcePath{
+			Agent: "claude", FilePath: virtualPath,
+		})
+	}
+	require.NoError(t, database.BaselineActiveSessionSourcePaths(
+		t.Context(), "local", sources,
+	))
+	var statCalls atomic.Int32
+	engine := &Engine{
+		db: database, machine: "local",
+		agentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {root},
+		},
+		lstat: func(path string) (os.FileInfo, error) {
+			statCalls.Add(1)
+			_, expected := wantPaths[path]
+			assert.True(t, expected, "only the exact stored path may be checked")
+			delete(wantPaths, path)
+			return nil, os.ErrNotExist
+		},
+	}
+
+	deleted, err := tombstoneMissingWatchSourcesUnderSyncLock(
+		t.Context(), engine, []string{root},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, db.WatchReconcileSourcePageSize, deleted)
+	assert.Equal(t, int32(db.WatchReconcileSourcePageSize), statCalls.Load())
+	assert.Empty(t, wantPaths,
+		"provider-neutral reconciliation must not reinterpret '#' as virtual syntax")
+}
+
+func TestReconcileWatchRootsRevivesRecreatedSourceMissingSession(t *testing.T) {
+	fx := newEngineFixture(t)
+	t.Cleanup(fx.engine.Close)
+	path := fx.writeClaudeSession(t, "project", "session.jsonl", "first")
+
+	require.NoError(t, fx.engine.ReconcileWatchRoots(
+		t.Context(), []string{fx.claudeDir}, false,
+	))
+	active, err := fx.db.GetSession(t.Context(), "session")
+	require.NoError(t, err)
+	require.NotNil(t, active)
+
+	require.NoError(t, os.Remove(path))
+	require.NoError(t, fx.engine.ReconcileWatchRoots(
+		t.Context(), []string{fx.claudeDir}, false,
+	))
+	active, err = fx.db.GetSession(t.Context(), "session")
+	require.NoError(t, err)
+	assert.Nil(t, active, "missing source is hidden after reconciliation")
+
+	fx.writeClaudeSession(t, "project", "session.jsonl", "recreated")
+	require.NoError(t, fx.engine.ReconcileWatchRoots(
+		t.Context(), []string{fx.claudeDir}, false,
+	))
+	active, err = fx.db.GetSession(t.Context(), "session")
+	require.NoError(t, err)
+	require.NotNil(t, active, "same source must become visible after recreation")
+	require.NotNil(t, active.FirstMessage)
+	assert.Equal(t, "recreated", *active.FirstMessage)
+	messages, err := fx.db.GetAllMessages(t.Context(), "session")
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Equal(t, "recreated", messages[0].Content,
+		"revival must replace message rows left by the deleted source")
+}
+
+func TestReconcileWatchRootsRevivesByteIdenticalSourceWithWarmSkipCache(
+	t *testing.T,
+) {
+	fx := newEngineFixture(t)
+	t.Cleanup(func() { fx.engine.Close() })
+	path := fx.writeClaudeSession(t, "project", "session.jsonl", "unchanged")
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	originalInfo, err := os.Stat(path)
+	require.NoError(t, err)
+
+	require.NoError(t, fx.engine.ReconcileWatchRoots(
+		t.Context(), []string{fx.claudeDir}, false,
+	))
+	storedHash, ok := fx.db.GetFileHashByPath(path)
+	require.True(t, ok)
+	cacheKey := providerProcessCacheKeyWithHash(
+		path, parser.AgentClaude, parser.SourceFingerprint{Hash: storedHash},
+	)
+	fx.engine.cacheSkip(cacheKey, originalInfo.ModTime().UnixNano())
+	assert.Equal(t, 1, fx.engine.persistSkipCache(),
+		"the restart regression requires a persisted hash-qualified skip")
+
+	require.NoError(t, os.Remove(path))
+	require.NoError(t, fx.engine.ReconcileWatchRoots(
+		t.Context(), []string{fx.claudeDir}, false,
+	))
+	active, err := fx.db.GetSession(t.Context(), "session")
+	require.NoError(t, err)
+	assert.Nil(t, active, "missing source is hidden after reconciliation")
+
+	fx.engine.Close()
+	fx.engineWithEmitter(nil)
+
+	require.NoError(t, os.WriteFile(path, content, 0o644))
+	require.NoError(t, os.Chtimes(path, originalInfo.ModTime(), originalInfo.ModTime()))
+	require.NoError(t, fx.engine.ReconcileWatchRoots(
+		t.Context(), []string{fx.claudeDir}, false,
+	))
+
+	active, err = fx.db.GetSession(t.Context(), "session")
+	require.NoError(t, err)
+	require.NotNil(t, active,
+		"a source-missing tombstone must not retain a cache entry that hides restoration")
+	require.NotNil(t, active.FirstMessage)
+	assert.Equal(t, "unchanged", *active.FirstMessage)
+}
+
+func TestReconcileWatchRootsPreservesHistoricalRowsUntilExactSourceObserved(
+	t *testing.T,
+) {
+	fx := newEngineFixture(t)
+	t.Cleanup(fx.engine.Close)
+	historicalPath := filepath.Join(
+		fx.claudeDir, "historical", "already-pruned.jsonl",
+	)
+	require.NoError(t, fx.db.UpsertSession(db.Session{
+		ID:       "historical",
+		Project:  "archive",
+		Machine:  "local",
+		Agent:    string(parser.AgentClaude),
+		FilePath: &historicalPath,
+	}))
+	observedPath := fx.writeClaudeSession(
+		t, "project", "observed.jsonl", "currently present",
+	)
+
+	require.NoError(t, fx.engine.ReconcileWatchRoots(
+		t.Context(), []string{fx.claudeDir}, false,
+	))
+	historical, err := fx.db.GetSession(t.Context(), "historical")
+	require.NoError(t, err)
+	require.NotNil(t, historical,
+		"the first local observation must preserve pre-existing archive rows")
+	observed, err := fx.db.GetSession(t.Context(), "observed")
+	require.NoError(t, err)
+	require.NotNil(t, observed)
+
+	require.NoError(t, os.Remove(observedPath))
+	require.NoError(t, fx.engine.ReconcileWatchRoots(
+		t.Context(), []string{fx.claudeDir}, false,
+	))
+	historical, err = fx.db.GetSession(t.Context(), "historical")
+	require.NoError(t, err)
+	require.NotNil(t, historical,
+		"a never-observed historical row must remain in the persistent archive")
+	observed, err = fx.db.GetSession(t.Context(), "observed")
+	require.NoError(t, err)
+	assert.Nil(t, observed,
+		"a source observed by the prior pass becomes deletion-eligible")
+}
+
+func TestReconciliationSourceBaselineUsesStoredPathRewrite(t *testing.T) {
+	database := openTestDB(t)
+	localPath := filepath.Join(t.TempDir(), "session.jsonl")
+	storedPath := "host:" + localPath
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "session", Project: "project", Machine: "host",
+		Agent: "claude", FilePath: &storedPath,
+	}))
+	engine := &Engine{
+		db: database, machine: "host",
+		pathRewriter: func(path string) string { return "host:" + path },
+	}
+
+	require.NoError(t, engine.baselineReconciliationCandidates(
+		t.Context(), []reconciliationCandidate{{
+			Provider: parser.AgentClaude, Identity: "session", Path: localPath,
+		}}, []db.SessionSourcePath{{Agent: "claude", FilePath: storedPath}},
+	))
+	changed, err := database.SoftDeleteSessionSourceOwnership(
+		t.Context(), "host", "claude", "session", storedPath,
+	)
+	require.NoError(t, err)
+	assert.True(t, changed,
+		"the local candidate must baseline the path form stored by remote sync")
+}
+
+func TestTombstoneMissingWatchSourcesPreservesOneWayRewrittenOwnership(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	localPath := filepath.Join(root, "source", "session.jsonl")
+	storedPath := filepath.Join(root, "canonical", "session.jsonl")
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "remote~session", Project: "project", Machine: "remote",
+		Agent: string(parser.AgentClaude), FilePath: &storedPath,
+	}))
+	require.NoError(t, database.BaselineActiveSessionSourcePaths(
+		t.Context(), "remote", []db.SessionSourcePath{{
+			Agent: string(parser.AgentClaude), FilePath: storedPath,
+		}},
+	))
+	engine := &Engine{
+		db: database, machine: "remote",
+		agentDirs: map[parser.AgentType][]string{parser.AgentClaude: {root}},
+		pathRewriter: func(path string) string {
+			require.Equal(t, localPath, path)
+			return storedPath
+		},
+	}
+
+	deleted, err := tombstoneMissingWatchSourcesUnderSyncLock(
+		t.Context(), engine, []string{root},
+	)
+	require.NoError(t, err)
+	assert.Zero(t, deleted,
+		"one-way path rewriting cannot authoritatively prove remote source loss")
+	stored, err := database.GetSession(t.Context(), "remote~session")
+	require.NoError(t, err)
+	assert.NotNil(t, stored)
+}
+
+func TestSyncPathsBaselinesPresentSourceBeforeLaterDelete(t *testing.T) {
+	fx := newEngineFixture(t)
+	t.Cleanup(fx.engine.Close)
+	path := fx.writeClaudeSession(t, "project", "incremental.jsonl", "present")
+
+	fx.engine.SyncPathsContext(t.Context(), []string{path})
+	active, err := fx.db.GetSession(t.Context(), "incremental")
+	require.NoError(t, err)
+	require.NotNil(t, active)
+
+	require.NoError(t, os.Remove(path))
+	fx.engine.SyncPathsContext(t.Context(), []string{path})
+	active, err = fx.db.GetSession(t.Context(), "incremental")
+	require.NoError(t, err)
+	assert.Nil(t, active,
+		"a later watcher delete may tombstone the exact previously observed path")
 }
 
 func TestStartupMaintenanceWaitsForForegroundSyncAndSerializesLaterSyncs(
@@ -154,6 +2739,202 @@ func TestStartupSyncFallbackRunsWhenForegroundSyncNeverArrives(t *testing.T) {
 	}, time.Second, 10*time.Millisecond,
 		"fallback completion must release startup maintenance")
 	require.NoError(t, <-maintenanceDone)
+}
+
+func TestStartupReconciledCallbackRunsOnceAfterSyncLockRelease(t *testing.T) {
+	database := openTestDB(t)
+	callbackDone := make(chan struct{})
+	var calls atomic.Int32
+	var engine *Engine
+	engine = NewEngine(database, EngineConfig{
+		Machine: "local",
+		OnStartupReconciled: func(stats SyncStats, err error) {
+			require.NoError(t, err)
+			assert.False(t, stats.Aborted)
+			require.NoError(t, engine.RunExclusive(func() error { return nil }),
+				"callback must run after syncMu is released")
+			calls.Add(1)
+			close(callbackDone)
+		},
+	})
+	t.Cleanup(engine.Close)
+
+	stats := engine.SyncAll(t.Context(), nil)
+	assert.False(t, stats.Aborted)
+	requireReceiveWithin(t, callbackDone, time.Second)
+	engine.SyncAll(t.Context(), nil)
+	assert.Equal(t, int32(1), calls.Load())
+}
+
+func TestStartupReconciledCallbackReportsIncompleteDiscoveryOnce(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	provider := failingDBBackedProvider{
+		ProviderBase: parser.ProviderBase{Def: parser.AgentDef{
+			Type: parser.AgentCowork, DisplayName: "Cowork", FileBased: true,
+		}},
+		err: errors.New("source listing unavailable"), failOnCall: 1,
+	}
+	type callbackResult struct {
+		stats SyncStats
+		err   error
+	}
+	reconciled := make(chan callbackResult, 1)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentCowork: {root}},
+		Machine:   "local",
+		ProviderFactories: []parser.ProviderFactory{
+			failingDBBackedFactory{provider: &provider},
+		},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			parser.AgentCowork: parser.ProviderMigrationProviderAuthoritative,
+		},
+		OnStartupReconciled: func(stats SyncStats, err error) {
+			reconciled <- callbackResult{stats: stats, err: err}
+		},
+	})
+	t.Cleanup(engine.Close)
+
+	failed := engine.SyncAll(t.Context(), nil)
+	assert.Greater(t, failed.Failed, 0)
+	first := requireReceiveWithin(t, reconciled, time.Second)
+	require.Error(t, first.err)
+	assert.False(t, first.stats.AuthoritativeDiscoveryComplete())
+
+	succeeded := engine.SyncAll(t.Context(), nil)
+	assert.Zero(t, succeeded.Failed)
+	select {
+	case duplicate := <-reconciled:
+		require.Fail(t, "startup attempt callback ran more than once", "%+v", duplicate)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestStartupSyncFallbackUsesSuccessSignalNotMaintenanceRelease(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	provider := failingDBBackedProvider{
+		ProviderBase: parser.ProviderBase{Def: parser.AgentDef{
+			Type: parser.AgentCowork, DisplayName: "Cowork", FileBased: true,
+		}},
+		err: errors.New("source listing unavailable"), failOnCall: 1,
+	}
+	reconciled := make(chan struct{}, 1)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs:               map[parser.AgentType][]string{parser.AgentCowork: {root}},
+		Machine:                 "local",
+		DeferStartupMaintenance: true,
+		ProviderFactories: []parser.ProviderFactory{
+			failingDBBackedFactory{provider: &provider},
+		},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			parser.AgentCowork: parser.ProviderMigrationProviderAuthoritative,
+		},
+		OnStartupReconciled: func(SyncStats, error) {
+			reconciled <- struct{}{}
+		},
+	})
+	t.Cleanup(engine.Close)
+
+	failed, err := engine.SyncThenRun(
+		t.Context(), false, nil, func(bool) error { return nil },
+	)
+	require.NoError(t, err)
+	assert.False(t, failed.AuthoritativeDiscoveryComplete())
+
+	_, ran, err := engine.RunStartupSyncFallback(t.Context(), nil)
+	require.NoError(t, err)
+	assert.True(t, ran,
+		"maintenance release from an incomplete foreground attempt must not skip fallback")
+	select {
+	case <-reconciled:
+	case <-time.After(time.Second):
+		require.FailNow(t, "successful fallback did not reconcile startup")
+	}
+}
+
+func TestStartupReconciledCallbackOwnersRetainFailureForLaterSuccess(t *testing.T) {
+	tests := []struct {
+		name    string
+		fail    func(context.Context, *Engine)
+		succeed func(context.Context, *Engine)
+	}{
+		{
+			name: "foreground SyncThenRun",
+			fail: func(ctx context.Context, engine *Engine) {
+				cancelled, cancel := context.WithCancel(ctx)
+				cancel()
+				_, err := engine.SyncThenRun(cancelled, false, nil,
+					func(bool) error { return nil })
+				require.ErrorIs(t, err, context.Canceled)
+			},
+			succeed: func(ctx context.Context, engine *Engine) {
+				_, err := engine.SyncThenRun(ctx, false, nil,
+					func(bool) error { return nil })
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "startup fallback",
+			fail: func(ctx context.Context, engine *Engine) {
+				cancelled, cancel := context.WithCancel(ctx)
+				cancel()
+				_, ran, err := engine.RunStartupSyncFallback(cancelled, nil)
+				assert.True(t, ran)
+				require.ErrorIs(t, err, context.Canceled)
+			},
+			succeed: func(ctx context.Context, engine *Engine) {
+				_, err := engine.SyncThenRun(ctx, false, nil,
+					func(bool) error { return nil })
+				require.NoError(t, err)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			database := openTestDB(t)
+			reconciled := make(chan struct{}, 1)
+			engine := NewEngine(database, EngineConfig{
+				Machine:                 "local",
+				DeferStartupMaintenance: true,
+				OnStartupReconciled: func(SyncStats, error) {
+					reconciled <- struct{}{}
+				},
+			})
+			t.Cleanup(engine.Close)
+
+			tt.fail(t.Context(), engine)
+			select {
+			case <-reconciled:
+				require.Fail(t, "failed owner opened startup gate")
+			case <-time.After(50 * time.Millisecond):
+			}
+			tt.succeed(t.Context(), engine)
+			requireReceiveWithin(t, reconciled, time.Second)
+		})
+	}
+}
+
+func TestStartupReconciledCallbackReportsAbortedResyncAttempt(t *testing.T) {
+	database := openTestDB(t)
+	missingPath := filepath.Join(t.TempDir(), "missing.jsonl")
+	dbtest.SeedSession(t, database, "existing", "proj", func(s *db.Session) {
+		s.FilePath = &missingPath
+	})
+	reconciled := make(chan error, 1)
+	engine := NewEngine(database, EngineConfig{
+		OnStartupReconciled: func(stats SyncStats, err error) {
+			assert.True(t, stats.Aborted)
+			reconciled <- err
+		},
+	})
+	t.Cleanup(engine.Close)
+
+	resync := engine.ResyncAll(t.Context(), nil)
+	assert.True(t, resync.Aborted)
+	require.Error(t, requireReceiveWithin(t, reconciled, time.Second))
+	fallback := engine.SyncAll(t.Context(), nil)
+	assert.False(t, fallback.Aborted)
 }
 
 func TestStartupSyncFallbackSkipsAfterForegroundSyncCompletes(t *testing.T) {
@@ -1910,6 +4691,93 @@ func TestWriteBatchQwenPawReplacesMessages(t *testing.T) {
 		"rewritten content must reach existing message rows")
 }
 
+func TestWriteBatchFailedReplacementKeepsSourceMissingSessionRetryable(t *testing.T) {
+	database := openTestDB(t)
+	e := &Engine{db: database}
+	path := filepath.Join(t.TempDir(), "session.json")
+	ts := time.Unix(1700000000, 0).UTC()
+	mkWrite := func(content, hash string, mtime int64) pendingWrite {
+		return pendingWrite{
+			sess: parser.ParsedSession{
+				ID: "qwenpaw:retry-revival", Project: "default", Machine: "local",
+				Agent: parser.AgentQwenPaw, StartedAt: ts, EndedAt: ts,
+				MessageCount: 1,
+				File: parser.FileInfo{
+					Path: path, Size: int64(len(content)), Mtime: mtime, Hash: hash,
+				},
+			},
+			msgs: []parser.ParsedMessage{{
+				Ordinal: 0, Role: parser.RoleUser, Content: content, Timestamp: ts,
+			}},
+		}
+	}
+
+	initial := mkWrite("old content", "old-hash", 1)
+	written, _, failed, _ := e.writeBatch(
+		[]pendingWrite{initial}, syncWriteDefault, false,
+	)
+	require.Equal(t, 1, written)
+	require.Zero(t, failed)
+	require.NoError(t, database.BaselineActiveSessionSourcePaths(
+		t.Context(), "local", []db.SessionSourcePath{{
+			Agent: string(parser.AgentQwenPaw), FilePath: path,
+		}},
+	))
+	changed, err := database.SoftDeleteSessionSourceOwnership(
+		t.Context(), "local", string(parser.AgentQwenPaw),
+		"qwenpaw:retry-revival", path,
+	)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	raw, err := sql.Open("sqlite3", database.Path())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, raw.Close()) })
+	_, err = raw.Exec(`
+		CREATE TRIGGER fail_retry_revival_message
+		BEFORE INSERT ON messages
+		WHEN NEW.session_id = 'qwenpaw:retry-revival'
+		BEGIN
+			SELECT RAISE(FAIL, 'injected replacement failure');
+		END;
+	`)
+	require.NoError(t, err)
+
+	retry := mkWrite("new content", "new-hash", 2)
+	written, _, failed, _ = e.writeBatch(
+		[]pendingWrite{retry}, syncWriteDefault, false,
+	)
+	assert.Zero(t, written)
+	assert.Equal(t, 1, failed)
+	active, err := database.GetSession(t.Context(), "qwenpaw:retry-revival")
+	require.NoError(t, err)
+	assert.Nil(t, active,
+		"a failed content replacement must not revive the source-missing row")
+	info := fakeSnapshotInfo{
+		fName: filepath.Base(path), fSize: int64(len("new content")), fMtime: 2,
+	}
+	assert.False(t, e.shouldSkipFileWithPrefix(
+		"", "qwenpaw:retry-revival", info, "new-hash",
+	), "the failed replacement must remain eligible for an unchanged retry")
+
+	_, err = raw.Exec("DROP TRIGGER fail_retry_revival_message")
+	require.NoError(t, err)
+	written, _, failed, _ = e.writeBatch(
+		[]pendingWrite{retry}, syncWriteDefault, false,
+	)
+	require.Equal(t, 1, written)
+	require.Zero(t, failed)
+	active, err = database.GetSession(t.Context(), "qwenpaw:retry-revival")
+	require.NoError(t, err)
+	require.NotNil(t, active)
+	messages, err := database.GetMessages(
+		t.Context(), "qwenpaw:retry-revival", 0, 10, true,
+	)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Equal(t, "new content", messages[0].Content)
+}
+
 // TestSyncSingleSession_QwenPawPreservesWorkspaceFromDB covers the
 // case where a QwenPaw session's stored DB file_path points outside
 // any currently configured QWENPAW_DIR (e.g. the root was removed or
@@ -2882,7 +5750,7 @@ func TestStampProviderFileIdentityPreservesProviderSnapshotIdentity(t *testing.T
 	require.NoError(t, os.WriteFile(path, []byte("old snapshot\n"), 0o600))
 	oldInfo, err := os.Stat(path)
 	require.NoError(t, err)
-	oldInode, oldDevice := getFileIdentity(oldInfo)
+	oldInode, oldDevice := getFileIdentity(path, oldInfo)
 
 	replacementPath := path + ".replacement"
 	require.NoError(t, os.WriteFile(replacementPath, []byte("new pathname\n"), 0o600))
@@ -2892,11 +5760,11 @@ func TestStampProviderFileIdentityPreservesProviderSnapshotIdentity(t *testing.T
 	require.NoError(t, os.Rename(replacementPath, path))
 	replacementInfo, err := os.Stat(path)
 	require.NoError(t, err)
-	replacementInode, replacementDevice := getFileIdentity(replacementInfo)
+	replacementInode, replacementDevice := getFileIdentity(path, replacementInfo)
 
-	// Platforms without file identity report 0/0. Use a provider-owned token
-	// there so this still proves that an authoritative nonzero result is not
-	// erased merely because a later path stat cannot supply an identity.
+	// If the filesystem cannot provide identity, use a provider-owned token so
+	// this still proves that an authoritative nonzero result is not erased
+	// merely because a later path stat cannot supply an identity.
 	authoritativeInode, authoritativeDevice := oldInode, oldDevice
 	if authoritativeInode == 0 && authoritativeDevice == 0 {
 		authoritativeInode, authoritativeDevice = 101, 202
@@ -4267,7 +7135,7 @@ func TestEngine_ClassifyOnePathClaudeStatPermissionErrorStillClassifies(
 	// the provider's changed-path handling rather than the legacy
 	// classifyOnePath Claude block. A transient stat-permission error
 	// must still classify the path by shape so the change is not dropped.
-	files := engine.classifyPaths([]string{path})
+	files := requireClassifyPaths(t, engine, []string{path})
 	require.Len(t, files, 1, "expected path to classify despite stat permission error")
 	assert.Equal(t, path, files[0].Path)
 	assert.Equal(t, parser.AgentClaude, files[0].Agent)
@@ -4304,7 +7172,7 @@ func TestEngine_ClassifyPathsDedupesOpenCodeChildPaths(t *testing.T) {
 		require.NoError(t, os.WriteFile(path, []byte(content), 0o644), "WriteFile(%q)", path)
 	}
 
-	files := engine.classifyPaths([]string{
+	files := requireClassifyPaths(t, engine, []string{
 		messagePath,
 		partPath,
 	})
@@ -4343,7 +7211,7 @@ func TestEngine_ClassifyPathsOpenCodeRemovedMessageDir(
 	messageDir := filepath.Dir(messagePath)
 	require.NoError(t, os.RemoveAll(messageDir), "RemoveAll(%q)", messageDir)
 
-	files := engine.classifyPaths([]string{messageDir})
+	files := requireClassifyPaths(t, engine, []string{messageDir})
 	require.Len(t, files, 1)
 	assert.Equal(t, sessionPath, files[0].Path)
 }
@@ -4371,7 +7239,7 @@ func TestEngine_ClassifyPathsOpenCodeSQLiteWALFile(
 	require.NoError(t, err, "Stat(%q)", walPath)
 	require.Greater(t, walInfo.Size(), int64(32), "WAL must contain transaction frames")
 
-	files := engine.classifyPaths([]string{walPath})
+	files := requireClassifyPaths(t, engine, []string{walPath})
 	require.Len(t, files, 1)
 	assert.Equal(t,
 		parser.OpenCodeSQLiteVirtualPath(dbPath, "ses_wal"),
@@ -4461,7 +7329,7 @@ func TestEngine_ClassifyPathsOpenCodeRemovedMessageFile(
 
 	require.NoError(t, os.Remove(messagePath), "Remove(%q)", messagePath)
 
-	files := engine.classifyPaths([]string{messagePath})
+	files := requireClassifyPaths(t, engine, []string{messagePath})
 	require.Len(t, files, 1)
 	assert.Equal(t, sessionPath, files[0].Path)
 }
@@ -4512,7 +7380,7 @@ func TestEngine_ClassifyPathsOpenCodeFamilyRemovedSessionFile(
 			)
 			require.NoError(t, os.Remove(sessionPath), "Remove(%q)", sessionPath)
 
-			files := engine.classifyPaths([]string{sessionPath})
+			files := requireClassifyPaths(t, engine, []string{sessionPath})
 			assert.Empty(t, files)
 		})
 	}
@@ -4555,7 +7423,7 @@ func TestEngine_ClassifyPathsProviderRemoveKeepsDeletedSQLiteSources(
 			dbPath := tt.path(root)
 			require.NoFileExists(t, dbPath)
 
-			files := engine.classifyPaths([]string{dbPath})
+			files := requireClassifyPaths(t, engine, []string{dbPath})
 			require.Len(t, files, 1)
 			assert.Equal(t, dbPath, files[0].Path)
 			assert.Equal(t, tt.agent, files[0].Agent)
@@ -4649,7 +7517,7 @@ func TestEngine_ClassifyPathsOpenCodeRemovedPartDir(
 	partDir := filepath.Dir(partPath)
 	require.NoError(t, os.RemoveAll(partDir), "RemoveAll(%q)", partDir)
 
-	files := engine.classifyPaths([]string{partDir})
+	files := requireClassifyPaths(t, engine, []string{partDir})
 	require.Len(t, files, 1)
 	assert.Equal(t, sessionPath, files[0].Path)
 }
@@ -4689,7 +7557,7 @@ func TestEngine_ClassifyPathsOpenCodeRemovedPartFile(
 
 	require.NoError(t, os.Remove(partPath), "Remove(%q)", partPath)
 
-	files := engine.classifyPaths([]string{partPath})
+	files := requireClassifyPaths(t, engine, []string{partPath})
 	require.Len(t, files, 1)
 	assert.Equal(t, sessionPath, files[0].Path)
 }
@@ -4730,14 +7598,14 @@ func TestEngine_ClassifyPathsQwenPawRejectsColon(t *testing.T) {
 	colonSubdir := write("default", "sessions", "sub:bad", "ok.json")
 	colonStem := write("default", "sessions", "foo:bar.json")
 
-	files := engine.classifyPaths([]string{rootPath, subPath})
+	files := requireClassifyPaths(t, engine, []string{rootPath, subPath})
 	require.Len(t, files, 2)
 	for _, f := range files {
 		assert.Equal(t, parser.AgentQwenPaw, f.Agent)
 		assert.Equal(t, "default", f.Project)
 	}
 
-	got := engine.classifyPaths([]string{
+	got := requireClassifyPaths(t, engine, []string{
 		colonWorkspace, colonSubdir, colonStem,
 	})
 	assert.Empty(t, got,
@@ -4761,7 +7629,7 @@ func TestEngine_ClassifyPathsQwenSession(t *testing.T) {
 	sessionPath := filepath.Join(chatsDir, sessionID+".jsonl")
 	require.NoError(t, os.WriteFile(sessionPath, []byte("{}\n"), 0o644), "WriteFile(%q)", sessionPath)
 
-	files := engine.classifyPaths([]string{sessionPath})
+	files := requireClassifyPaths(t, engine, []string{sessionPath})
 	require.Len(t, files, 1, "len(files) = %d, want 1 (%v)", len(files), files)
 	assert.Equal(t, sessionPath, files[0].Path)
 	assert.Equal(t, parser.AgentQwen, files[0].Agent)
@@ -4781,7 +7649,7 @@ func TestEngine_ClassifyPathsQwenSession(t *testing.T) {
 		require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755), "MkdirAll(%q)", p)
 		require.NoError(t, os.WriteFile(p, []byte("{}"), 0o644), "WriteFile(%q)", p)
 	}
-	got := engine.classifyPaths(bogus)
+	got := requireClassifyPaths(t, engine, bogus)
 	assert.Empty(t, got, "expected no Qwen classifications for %v, got %v", bogus, got)
 }
 
@@ -4799,7 +7667,7 @@ func TestEngine_ClassifyPathsDeepSeekTUISession(t *testing.T) {
 	sessionPath := filepath.Join(deepSeekDir, sessionID+".json")
 	dbtest.WriteTestFile(t, sessionPath, []byte("{}"))
 
-	files := engine.classifyPaths([]string{sessionPath})
+	files := requireClassifyPaths(t, engine, []string{sessionPath})
 	require.Len(t, files, 1, "len(files) = %d, want 1 (%v)", len(files), files)
 	assert.Equal(t, sessionPath, files[0].Path)
 	assert.Equal(t, parser.AgentDeepSeekTUI, files[0].Agent)
@@ -4818,7 +7686,7 @@ func TestEngine_ClassifyPathsDeepSeekTUISession(t *testing.T) {
 		require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755), "MkdirAll(%q)", p)
 		dbtest.WriteTestFile(t, p, []byte("{}"))
 	}
-	got := engine.classifyPaths(bogus)
+	got := requireClassifyPaths(t, engine, bogus)
 	assert.Empty(t, got, "expected no DeepSeek TUI classifications for %v, got %v", bogus, got)
 }
 
@@ -4838,7 +7706,7 @@ func TestEngine_ClassifyPathsCommandCodeSession(t *testing.T) {
 	sessionPath := filepath.Join(projectDir, sessionID+".jsonl")
 	dbtest.WriteTestFile(t, sessionPath, []byte("{}\n"))
 
-	files := engine.classifyPaths([]string{sessionPath})
+	files := requireClassifyPaths(t, engine, []string{sessionPath})
 	require.Len(t, files, 1, "len(files) = %d, want 1 (%v)", len(files), files)
 	assert.Equal(t, sessionPath, files[0].Path)
 	assert.Equal(t, parser.AgentCommandCode, files[0].Agent)
@@ -4859,12 +7727,12 @@ func TestEngine_ClassifyPathsCommandCodeSession(t *testing.T) {
 		require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755), "MkdirAll(%q)", p)
 		dbtest.WriteTestFile(t, p, []byte("{}"))
 	}
-	got := engine.classifyPaths(bogus)
+	got := requireClassifyPaths(t, engine, bogus)
 	assert.Empty(t, got, "expected no Command Code classifications for %v, got %v", bogus, got)
 
 	metaPath := filepath.Join(projectDir, sessionID+".meta.json")
 	dbtest.WriteTestFile(t, metaPath, []byte("{}"))
-	files = engine.classifyPaths([]string{metaPath})
+	files = requireClassifyPaths(t, engine, []string{metaPath})
 	require.Len(t, files, 1, "len(files) = %d, want 1 (%v)", len(files), files)
 	assert.Equal(t, sessionPath, files[0].Path)
 	assert.Equal(t, parser.AgentCommandCode, files[0].Agent)
@@ -4886,7 +7754,7 @@ func TestEngine_ClassifyPathsQClawSession(t *testing.T) {
 	sessionPath := filepath.Join(sessionsDir, sessionID+".jsonl")
 	dbtest.WriteTestFile(t, sessionPath, []byte("{}\n"))
 
-	files := engine.classifyPaths([]string{sessionPath})
+	files := requireClassifyPaths(t, engine, []string{sessionPath})
 	require.Len(t, files, 1, "len(files) = %d, want 1 (%v)", len(files), files)
 	assert.Equal(t, sessionPath, files[0].Path)
 	assert.Equal(t, parser.AgentQClaw, files[0].Agent)
@@ -4900,7 +7768,7 @@ func TestEngine_ClassifyPathsQClawSession(t *testing.T) {
 	for _, p := range bogus {
 		dbtest.WriteTestFile(t, p, []byte("{}"))
 	}
-	got := engine.classifyPaths(bogus)
+	got := requireClassifyPaths(t, engine, bogus)
 	assert.Empty(t, got, "expected no QClaw classifications for %v, got %v", bogus, got)
 }
 
@@ -4926,11 +7794,11 @@ func TestEngine_ClassifyPathsQClawArchivedSession(t *testing.T) {
 	dbtest.WriteTestFile(t, active, []byte("{}\n"))
 	dbtest.WriteTestFile(t, archived, []byte("{}\n"))
 
-	got := engine.classifyPaths([]string{archived})
+	got := requireClassifyPaths(t, engine, []string{archived})
 	require.Empty(t, got, "expected archived file shadowed by active to be ignored, got %v", got)
 
 	require.NoError(t, os.Remove(active), "Remove(%q)", active)
-	files := engine.classifyPaths([]string{archived})
+	files := requireClassifyPaths(t, engine, []string{archived})
 	require.Len(t, files, 1, "len(files) = %d, want 1 (%v)", len(files), files)
 	assert.Equal(t, archived, files[0].Path)
 	assert.Equal(t, parser.AgentQClaw, files[0].Agent)
@@ -4953,7 +7821,7 @@ func TestEngine_ClassifyOnePathReasonixProjectBareMeta(t *testing.T) {
 	dbtest.WriteTestFile(t, sessionPath, []byte(`{"role":"user","content":"hi"}`))
 	dbtest.WriteTestFile(t, metaPath, []byte(`{"model":"claude"}`))
 
-	files := engine.classifyPaths([]string{metaPath})
+	files := requireClassifyPaths(t, engine, []string{metaPath})
 	require.Len(t, files, 1, "expected Reasonix sidecar to classify")
 	assert.Equal(t, sessionPath, files[0].Path)
 	assert.Equal(t, "proj", files[0].Project)
@@ -4976,7 +7844,7 @@ func TestEngine_ClassifyOnePathReasonixDeletedMeta(t *testing.T) {
 	metaPath := sessionPath + ".meta"
 	dbtest.WriteTestFile(t, sessionPath, []byte(`{"role":"user","content":"hi"}`))
 
-	files := engine.classifyPaths([]string{metaPath})
+	files := requireClassifyPaths(t, engine, []string{metaPath})
 	require.Len(t, files, 1, "expected deleted Reasonix sidecar to classify")
 	assert.Equal(t, sessionPath, files[0].Path)
 	assert.Equal(t, "proj", files[0].Project)
@@ -4997,7 +7865,7 @@ func TestEngine_ClassifyOnePathReasonixDeletedTranscriptIgnored(t *testing.T) {
 		reasonixDir, "projects", "proj", "sessions", "session-123.jsonl",
 	)
 
-	files := engine.classifyPaths([]string{sessionPath})
+	files := requireClassifyPaths(t, engine, []string{sessionPath})
 	assert.Empty(t, files, "expected deleted Reasonix transcript to be ignored")
 }
 
@@ -5857,7 +8725,7 @@ func TestEngine_ClassifyPathsProviderRemoveSkipsMissingGeminiSource(
 	dbtest.WriteTestFile(t, sessionPath, []byte("{}"))
 	require.NoError(t, os.Remove(sessionPath), "Remove(%q)", sessionPath)
 
-	files := engine.classifyPaths([]string{sessionPath})
+	files := requireClassifyPaths(t, engine, []string{sessionPath})
 	assert.Empty(t, files)
 }
 
@@ -5884,9 +8752,54 @@ func TestEngine_ClassifyPathsProviderSidecarKeepsExistingGeminiSources(
 	)
 	dbtest.WriteTestFile(t, sessionPath, []byte("{}"))
 
-	files := engine.classifyPaths([]string{projectsPath})
+	files := requireClassifyPaths(t, engine, []string{projectsPath})
 	require.Len(t, files, 1)
 	assert.Equal(t, sessionPath, files[0].Path)
 	assert.Equal(t, parser.AgentGemini, files[0].Agent)
-	assert.True(t, files[0].ForceParse)
+	assert.False(t, files[0].ForceParse,
+		"metadata fan-out relies on hash-aware freshness, not forced parses")
+}
+
+func TestProviderChangedPathForceParseGeminiMetadata(t *testing.T) {
+	sessionPath := filepath.Join("root", "tmp", "alias", "chats", "session-1.json")
+	tests := []struct {
+		name      string
+		eventPath string
+		eventKind string
+		want      bool
+	}{
+		{
+			name:      "projects.json write fan-out is not forced",
+			eventPath: filepath.Join("root", "projects.json"),
+			eventKind: "write",
+			want:      false,
+		},
+		{
+			name:      "trustedFolders.json write fan-out is not forced",
+			eventPath: filepath.Join("root", "trustedFolders.json"),
+			eventKind: "write",
+			want:      false,
+		},
+		{
+			name:      "projects.json remove keeps the force",
+			eventPath: filepath.Join("root", "projects.json"),
+			eventKind: "remove",
+			want:      true,
+		},
+		{
+			name:      "session event for another session stays forced",
+			eventPath: filepath.Join("root", "tmp", "alias", "chats", "session-2.json"),
+			eventKind: "write",
+			want:      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := providerChangedPathForceParse(
+				parser.AgentGemini, sessionPath, tt.eventPath, tt.eventKind,
+				parser.ProviderMigrationProviderAuthoritative,
+			)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }

--- a/internal/sync/forge_integration_test.go
+++ b/internal/sync/forge_integration_test.go
@@ -3,6 +3,7 @@ package sync_test
 import (
 	"database/sql"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -10,6 +11,7 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/sync"
 )
 
@@ -23,7 +25,12 @@ func createForgeDB(t *testing.T, dir string) *forgeTestDB {
 	path := filepath.Join(dir, ".forge.db")
 	d, err := sql.Open("sqlite3", path)
 	require.NoError(t, err, "opening forge test db")
-	t.Cleanup(func() { d.Close() })
+	fixture := &forgeTestDB{path: path, db: d}
+	t.Cleanup(func() {
+		if fixture.db != nil {
+			_ = fixture.db.Close()
+		}
+	})
 
 	schema := `
 		CREATE TABLE conversations (
@@ -38,7 +45,13 @@ func createForgeDB(t *testing.T, dir string) *forgeTestDB {
 	`
 	_, err = d.Exec(schema)
 	require.NoError(t, err, "creating forge schema")
-	return &forgeTestDB{path: path, db: d}
+	return fixture
+}
+
+func (f *forgeTestDB) close(t *testing.T) {
+	t.Helper()
+	require.NoError(t, f.db.Close())
+	f.db = nil
 }
 
 func (f *forgeTestDB) mustExec(t *testing.T, msg, query string, args ...any) {
@@ -181,6 +194,109 @@ func TestSyncEngineForgeBulkSync(t *testing.T) {
 	)
 
 	runSyncAndAssert(t, env.engine, sync.SyncStats{TotalSessions: 0, Synced: 0, Skipped: 0})
+}
+
+func TestReconcileWatchRootsGenericDBBackedProviderPreservesArchive(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentForge)
+	forge := createForgeDB(t, env.forgeDir)
+	forge.addConversation(
+		t,
+		"persistent-archive",
+		"Persistent Forge Archive",
+		forgeTestContext("Preserve this prompt.", "Preserved."),
+		"2026-05-02 09:58:15.741021507",
+		"2026-05-02 10:00:16.848497543",
+		`{"input_tokens":360,"output_tokens":55,"cached_input_tokens":85}`,
+	)
+	forge.close(t)
+	require.Equal(t, 1, env.engine.SyncAll(t.Context(), nil).Synced)
+	require.NoError(t, os.Remove(forge.path))
+
+	require.NoError(t, env.engine.ReconcileWatchRoots(
+		t.Context(), []string{env.forgeDir}, false,
+	))
+
+	sess, err := env.db.GetSession(t.Context(), "forge:persistent-archive")
+	require.NoError(t, err)
+	assert.NotNil(t, sess,
+		"the generic DB-backed provider must preserve members after its SQLite archive vanishes")
+}
+
+func TestReconcileWatchRootsForgeDeletedMemberTombstonesSession(t *testing.T) {
+	env := setupSingleAgentTestEnv(t, parser.AgentForge)
+	forge := createForgeDB(t, env.forgeDir)
+	for _, id := range []string{"deleted-member", "surviving-member"} {
+		forge.addConversation(
+			t, id, id,
+			forgeTestContext("Prompt for "+id, "Answer for "+id),
+			"2026-05-02 09:58:15.741021507",
+			"2026-05-02 10:00:16.848497543",
+			`{"input_tokens":1,"output_tokens":1,"cached_input_tokens":0}`,
+		)
+	}
+	require.Equal(t, 2, env.engine.SyncAll(t.Context(), nil).Synced)
+	beforeDelete, err := env.db.GetSessionFull(t.Context(), "forge:deleted-member")
+	require.NoError(t, err)
+	require.NotNil(t, beforeDelete)
+	forge.mustExec(t, "delete Forge conversation",
+		"DELETE FROM conversations WHERE conversation_id = ?", "deleted-member")
+
+	require.NoError(t, env.engine.ReconcileWatchRoots(
+		t.Context(), []string{env.forgeDir}, false,
+	))
+
+	deleted, err := env.db.GetSession(t.Context(), "forge:deleted-member")
+	require.NoError(t, err)
+	assert.Nil(t, deleted,
+		"full sync must baseline dedicated streaming sources for later reconciliation")
+	archived, err := env.db.GetSessionFull(t.Context(), "forge:deleted-member")
+	require.NoError(t, err)
+	require.NotNil(t, archived)
+	require.NotNil(t, archived.DeletedAt)
+	require.NotNil(t, archived.DeletionCause)
+	assert.Equal(t, "source_missing", *archived.DeletionCause)
+	assert.Equal(t, beforeDelete.MessageCount, archived.MessageCount,
+		"source loss must retain the archived transcript")
+	surviving, err := env.db.GetSession(t.Context(), "forge:surviving-member")
+	require.NoError(t, err)
+	assert.NotNil(t, surviving)
+}
+
+func TestReconcileWatchRootsForgeScopedPassPreservesUnscannedReplacement(t *testing.T) {
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+	env := setupSingleAgentTestEnvWithDirs(
+		t, parser.AgentForge, []string{rootA, rootB},
+	)
+	forgeA := createForgeDB(t, rootA)
+	forgeA.addConversation(
+		t, "moved-member", "Moved member",
+		forgeTestContext("original prompt", "original answer"),
+		"2026-05-02 09:58:15.741021507",
+		"2026-05-02 10:00:16.848497543",
+		`{"input_tokens":1,"output_tokens":1,"cached_input_tokens":0}`,
+	)
+	require.Equal(t, 1, env.engine.SyncAll(t.Context(), nil).Synced)
+
+	forgeB := createForgeDB(t, rootB)
+	forgeB.addConversation(
+		t, "moved-member", "Moved member",
+		forgeTestContext("replacement prompt", "replacement answer"),
+		"2026-05-02 09:58:15.741021507",
+		"2026-05-02 10:01:16.848497543",
+		`{"input_tokens":2,"output_tokens":2,"cached_input_tokens":0}`,
+	)
+	forgeA.mustExec(t, "remove original Forge conversation",
+		"DELETE FROM conversations WHERE conversation_id = ?", "moved-member")
+
+	require.NoError(t, env.engine.ReconcileWatchRoots(
+		t.Context(), []string{rootA}, false,
+	))
+
+	active, err := env.db.GetSession(t.Context(), "forge:moved-member")
+	require.NoError(t, err)
+	assert.NotNil(t, active,
+		"a scoped pass cannot prove absence below an unscanned provider root")
 }
 
 func TestSyncSingleSessionForge(t *testing.T) {

--- a/internal/sync/hermes_archive_test.go
+++ b/internal/sync/hermes_archive_test.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/dbtest"
 	"go.kenn.io/agentsview/internal/parser"
 )
@@ -146,6 +148,41 @@ func TestHermesProfileCreatedAfterEngineInitializationIsDiscovered(t *testing.T)
 	assert.Equal(t, "state db message", *session.FirstMessage)
 }
 
+func TestReconcileHermesProfilesRootPreservesActiveMembers(t *testing.T) {
+	profilesRoot := filepath.Join(t.TempDir(), ".hermes", "profiles")
+	profileRoot := filepath.Join(profilesRoot, "research")
+	require.NoError(t, os.MkdirAll(profileRoot, 0o755))
+	stateDB := writeHermesArchiveStateDB(t, profileRoot)
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentHermes: {profilesRoot},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+
+	require.Equal(t, 1, engine.SyncAll(t.Context(), nil).Synced)
+	require.NoError(t, database.BaselineActiveSessionSourcePaths(
+		t.Context(), "local", []db.SessionSourcePath{{
+			Agent: string(parser.AgentHermes), FilePath: stateDB,
+		}},
+	))
+
+	require.NoError(t, engine.ReconcileWatchRoots(
+		t.Context(), []string{profilesRoot}, false,
+	))
+
+	result := engine.LastReconciliationResult()
+	assert.True(t, result.Complete)
+	active, err := database.GetSession(t.Context(), "hermes:child")
+	require.NoError(t, err)
+	require.NotNil(t, active,
+		"authoritative discovery of the profiles container must retain its members")
+	require.NotNil(t, active.FirstMessage)
+	assert.Equal(t, "state db message", *active.FirstMessage)
+}
+
 // TestProcessFileHermesArchiveSkipCacheUsesAggregateMtime confirms the
 // provider-authoritative processFile path keys the skip cache on the aggregate
 // archive mtime (state.db plus direct transcripts), so a cached entry stamped
@@ -161,14 +198,39 @@ func TestProcessFileHermesArchiveSkipCacheUsesAggregateMtime(t *testing.T) {
 
 	_, wantMtime := hermesArchiveAggregateFileInfo(t, stateDB)
 
-	engine := NewEngine(dbtest.OpenTestDB(t), EngineConfig{
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
 		AgentDirs: map[parser.AgentType][]string{
 			parser.AgentHermes: {filepath.Join(root, "sessions")},
 		},
 		Machine: "local",
 	})
+	provider, ok := parser.NewProvider(parser.AgentHermes, parser.ProviderConfig{
+		Roots: []string{filepath.Join(root, "sessions")},
+	})
+	require.True(t, ok)
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	fingerprint, err := provider.Fingerprint(context.Background(), sources[0])
+	require.NoError(t, err)
+	initial := engine.processFile(context.Background(), parser.DiscoveredFile{
+		Path: stateDB, Agent: parser.AgentHermes,
+	})
+	require.NoError(t, initial.err)
+	require.NotEmpty(t, initial.results)
+	pending := make([]pendingWrite, 0, len(initial.results))
+	for _, result := range initial.results {
+		pending = append(pending, pendingWrite{
+			sess: result.Session, msgs: result.Messages,
+		})
+	}
+	_, _, failed, _ := engine.writeBatch(pending, syncWriteDefault, true)
+	require.Zero(t, failed)
 	engine.InjectSkipCache(map[string]int64{
-		stateDB: wantMtime,
+		providerProcessCacheKeyWithHash(
+			stateDB, parser.AgentHermes, fingerprint,
+		): wantMtime,
 	})
 
 	res := engine.processFile(context.Background(), parser.DiscoveredFile{
@@ -335,12 +397,547 @@ func openHermesArchiveWALWriter(t *testing.T, stateDB string) *sql.DB {
 	return writer
 }
 
+func TestReconcileHermesStateMemberDetectsSameStatTranscriptRewrite(t *testing.T) {
+	root := t.TempDir()
+	stateDB := writeHermesArchiveStateDB(t, root)
+	sessionsDir := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+	transcriptPath := filepath.Join(sessionsDir, "session_child.json")
+	writeTranscript := func(message string) {
+		require.NoError(t, os.WriteFile(transcriptPath, []byte(`{
+			"platform":"cli",
+			"session_start":"2026-05-14T10:00:00Z",
+			"last_updated":"2026-05-14T10:02:00Z",
+			"messages":[
+				{"role":"user","content":"`+message+`","timestamp":"2026-05-14T10:01:00Z"},
+				{"role":"assistant","content":"Done.","timestamp":"2026-05-14T10:02:00Z"}
+			]
+		}`), 0o644))
+	}
+	writeTranscript("original prompt")
+
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentHermes: {sessionsDir},
+		},
+		Machine: "local",
+	})
+	assertMessages := func(want ...string) {
+		messages, err := database.GetMessages(
+			context.Background(), "hermes:child", 0, len(want), true,
+		)
+		require.NoError(t, err)
+		require.Len(t, messages, len(want))
+		for i := range want {
+			assert.Equal(t, want[i], messages[i].Content)
+		}
+	}
+	require.NoError(t, engine.ReconcileWatchRoots(context.Background(), nil, true))
+	assertMessages("original prompt", "Done.")
+
+	provider, ok := parser.NewProvider(parser.AgentHermes, parser.ProviderConfig{
+		Roots: []string{sessionsDir},
+	})
+	require.True(t, ok)
+	source, found, err := provider.FindSource(context.Background(), parser.FindSourceRequest{
+		RawSessionID: "child",
+	})
+	require.NoError(t, err)
+	require.True(t, found)
+	fingerprint, err := provider.Fingerprint(context.Background(), source)
+	require.NoError(t, err)
+	memberPath := parser.VirtualSourcePath(stateDB, "child")
+	storedSize, storedMtime, found := database.GetFileInfoByPath(memberPath)
+	require.True(t, found)
+	assert.Equal(t, fingerprint.Size, storedSize)
+	assert.Equal(t, fingerprint.MTimeNS, storedMtime)
+	storedHash, found := database.GetFileHashByPath(memberPath)
+	require.True(t, found)
+	assert.Equal(t, fingerprint.Hash, storedHash)
+
+	transcriptInfo, err := os.Stat(transcriptPath)
+	require.NoError(t, err)
+	writeTranscript("modified prompt")
+	require.NoError(t, os.Chtimes(
+		transcriptPath, transcriptInfo.ModTime(), transcriptInfo.ModTime(),
+	))
+	rewrittenInfo, err := os.Stat(transcriptPath)
+	require.NoError(t, err)
+	require.Equal(t, transcriptInfo.Size(), rewrittenInfo.Size())
+	require.Equal(t, transcriptInfo.ModTime(), rewrittenInfo.ModTime())
+
+	require.NoError(t, engine.ReconcileWatchRoots(context.Background(), nil, true))
+	assertMessages("modified prompt", "Done.")
+}
+
+func TestReconcileHermesDefaultSessionsRootTombstonesRemovedStateMember(t *testing.T) {
+	root := t.TempDir()
+	stateDB := writeHermesArchiveStateDB(t, root)
+	sessionsDir := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentHermes: {sessionsDir},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+
+	require.NoError(t, engine.ReconcileWatchRootsAfterLostEvents(
+		t.Context(), []string{sessionsDir}, false,
+	))
+	stored, err := database.GetSession(t.Context(), "hermes:child")
+	require.NoError(t, err)
+	require.NotNil(t, stored, "initial reconciliation must store the state member")
+
+	conn, err := sql.Open("sqlite3", stateDB)
+	require.NoError(t, err)
+	_, err = conn.ExecContext(t.Context(), "DELETE FROM sessions WHERE id = 'child'")
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	require.NoError(t, engine.ReconcileWatchRootsAfterLostEvents(
+		t.Context(), []string{sessionsDir}, false,
+	))
+	stored, err = database.GetSession(t.Context(), "hermes:child")
+	require.NoError(t, err)
+	assert.Nil(t, stored,
+		"authoritative reconciliation must tombstone a removed state.db member")
+}
+
+// Streamed discovery must open state.db a bounded number of times per pass:
+// once to stream members and once for the transcript membership check — not
+// once per transcript file, which scales reconciliation work with archive
+// size instead of the changed batch.
+func TestReconcileHermesStateDBOpensBoundedPerPass(t *testing.T) {
+	scansFor := func(t *testing.T, transcripts int) int {
+		root := t.TempDir()
+		writeHermesArchiveStateDB(t, root)
+		sessionsDir := filepath.Join(root, "sessions")
+		require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+		for i := range transcripts {
+			require.NoError(t, os.WriteFile(
+				filepath.Join(sessionsDir, fmt.Sprintf("transcript-%03d.jsonl", i)),
+				[]byte(`{"type":"user_message","content":"hi","timestamp":"2026-05-14T10:00:00Z"}`+"\n"),
+				0o644,
+			))
+		}
+
+		database := dbtest.OpenTestDB(t)
+		engine := NewEngine(database, EngineConfig{
+			AgentDirs: map[parser.AgentType][]string{
+				parser.AgentHermes: {sessionsDir},
+			},
+			Machine: "local",
+		})
+		t.Cleanup(engine.Close)
+		require.NoError(t, engine.ReconcileWatchRootsAfterLostEvents(
+			t.Context(), []string{sessionsDir}, false,
+		))
+		return engine.LastReconciliationResult().Metrics.SharedContainerScans
+	}
+
+	small := scansFor(t, 2)
+	large := scansFor(t, 30)
+	assert.Positive(t, small, "state.db opens must be instrumented")
+	assert.Equal(t, small, large,
+		"state.db opens must not scale with transcript count")
+}
+
+// Fingerprinting streamed state members must not open state.db once per
+// member: a warm pass over an unchanged archive re-fingerprints every member,
+// so per-pass opens must stay constant as the member count grows.
+func TestReconcileHermesStateMemberFingerprintOpensBoundedPerPass(
+	t *testing.T,
+) {
+	scansFor := func(t *testing.T, members int) int {
+		root := t.TempDir()
+		stateDB := writeHermesArchiveStateDB(t, root)
+		sessionsDir := filepath.Join(root, "sessions")
+		require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+		conn, err := sql.Open("sqlite3", stateDB)
+		require.NoError(t, err)
+		for i := range members {
+			_, err = conn.ExecContext(t.Context(), `
+				INSERT INTO sessions (
+					id, source, model, started_at, ended_at, message_count
+				) VALUES (?, 'discord', 'gpt-5.4', 1778767900.0, 1778768000.0, 1)
+			`, fmt.Sprintf("member-%03d", i))
+			require.NoError(t, err)
+			_, err = conn.ExecContext(t.Context(), `
+				INSERT INTO messages (session_id, role, content, timestamp)
+				VALUES (?, 'user', 'hello', 1778767910.0)
+			`, fmt.Sprintf("member-%03d", i))
+			require.NoError(t, err)
+		}
+		require.NoError(t, conn.Close())
+
+		database := dbtest.OpenTestDB(t)
+		engine := NewEngine(database, EngineConfig{
+			AgentDirs: map[parser.AgentType][]string{
+				parser.AgentHermes: {sessionsDir},
+			},
+			Machine: "local",
+		})
+		t.Cleanup(engine.Close)
+		// First pass stores every member (per-member parse work is bounded
+		// by the changed batch); the warm second pass is fingerprint-only.
+		require.NoError(t, engine.ReconcileWatchRoots(
+			t.Context(), []string{sessionsDir}, false,
+		))
+		require.NoError(t, engine.ReconcileWatchRoots(
+			t.Context(), []string{sessionsDir}, false,
+		))
+		return engine.LastReconciliationResult().Metrics.SharedContainerScans
+	}
+
+	small := scansFor(t, 2)
+	large := scansFor(t, 30)
+	assert.Positive(t, small, "state.db opens must be instrumented")
+	assert.Equal(t, small, large,
+		"warm-pass state.db opens must not scale with member count")
+}
+
+// A change to one state.db member moves the shared container stat that every
+// member's fingerprint inherits, so stored size+mtime freshness fails for all
+// of them. The per-member content hash must then establish freshness: only
+// the changed member re-parses and rewrites, keeping per-change work bounded
+// by the changed batch instead of total archive size. Member deletion must
+// keep tombstoning at the same cardinality.
+func TestReconcileHermesSiblingMemberChangeBoundsUnchangedMemberWork(
+	t *testing.T,
+) {
+	passFor := func(t *testing.T, members int) (synced, scans int) {
+		root := t.TempDir()
+		stateDB := writeHermesArchiveStateDB(t, root)
+		sessionsDir := filepath.Join(root, "sessions")
+		require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+		conn, err := sql.Open("sqlite3", stateDB)
+		require.NoError(t, err)
+		for i := range members {
+			_, err = conn.ExecContext(t.Context(), `
+				INSERT INTO sessions (
+					id, source, model, started_at, ended_at, message_count
+				) VALUES (?, 'discord', 'gpt-5.4', 1778767900.0, 1778768000.0, 1)
+			`, fmt.Sprintf("member-%03d", i))
+			require.NoError(t, err)
+			_, err = conn.ExecContext(t.Context(), `
+				INSERT INTO messages (session_id, role, content, timestamp)
+				VALUES (?, 'user', 'hello', 1778767910.0)
+			`, fmt.Sprintf("member-%03d", i))
+			require.NoError(t, err)
+		}
+		require.NoError(t, conn.Close())
+
+		database := dbtest.OpenTestDB(t)
+		engine := NewEngine(database, EngineConfig{
+			AgentDirs: map[parser.AgentType][]string{
+				parser.AgentHermes: {sessionsDir},
+			},
+			Machine: "local",
+		})
+		t.Cleanup(engine.Close)
+		require.NoError(t, engine.ReconcileWatchRoots(
+			t.Context(), []string{sessionsDir}, false,
+		))
+
+		// Change exactly one member; the shared container stat moves for all.
+		conn, err = sql.Open("sqlite3", stateDB)
+		require.NoError(t, err)
+		_, err = conn.ExecContext(t.Context(),
+			"UPDATE messages SET content = 'changed sibling' WHERE session_id = 'child'",
+		)
+		require.NoError(t, err)
+		require.NoError(t, conn.Close())
+		bumped := time.Now().Add(2 * time.Second).Truncate(time.Second)
+		require.NoError(t, os.Chtimes(stateDB, bumped, bumped))
+
+		stats, _, err := engine.ReconcileWatchRootsWithStats(
+			t.Context(), []string{sessionsDir}, false,
+		)
+		require.NoError(t, err)
+		scans = engine.LastReconciliationResult().Metrics.SharedContainerScans
+
+		// Deletion must keep tombstoning through the hash-freshness path.
+		conn, err = sql.Open("sqlite3", stateDB)
+		require.NoError(t, err)
+		_, err = conn.ExecContext(t.Context(),
+			"DELETE FROM sessions WHERE id = 'member-000'",
+		)
+		require.NoError(t, err)
+		_, err = conn.ExecContext(t.Context(),
+			"DELETE FROM messages WHERE session_id = 'member-000'",
+		)
+		require.NoError(t, err)
+		require.NoError(t, conn.Close())
+		require.NoError(t, engine.ReconcileWatchRoots(
+			t.Context(), []string{sessionsDir}, false,
+		))
+		removed, err := database.GetSession(t.Context(), "hermes:member-000")
+		require.NoError(t, err)
+		assert.Nil(t, removed, "removed member must tombstone")
+		survivor, err := database.GetSession(t.Context(), "hermes:member-001")
+		require.NoError(t, err)
+		assert.NotNil(t, survivor, "surviving members must stay active")
+
+		return stats.Synced, scans
+	}
+
+	smallSynced, smallScans := passFor(t, 2)
+	largeSynced, largeScans := passFor(t, 30)
+	assert.Equal(t, 1, smallSynced,
+		"only the changed member may re-sync after a sibling change")
+	assert.Equal(t, smallSynced, largeSynced,
+		"sibling-change writes must not scale with member count")
+	assert.Positive(t, smallScans, "state.db opens must be instrumented")
+	assert.Equal(t, smallScans, largeScans,
+		"sibling-change state.db opens must not scale with member count")
+}
+
+// Aggregate discovery (SyncAll) and streamed reconciliation must agree on
+// per-member source identity: a state.db member synced through SyncAll and
+// then removed without a watcher event must still be tombstoned by the
+// audit's streamed reconciliation, while surviving members stay active.
+func TestReconcileHermesSyncAllSeededStateMemberRemovalTombstones(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	stateDB := writeHermesArchiveStateDB(t, root)
+	sessionsDir := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+
+	conn, err := sql.Open("sqlite3", stateDB)
+	require.NoError(t, err)
+	_, err = conn.ExecContext(t.Context(), `
+		INSERT INTO sessions (
+			id, source, model, started_at, ended_at, message_count
+		) VALUES (
+			'survivor', 'discord', 'gpt-5.4', 1778767900.0, 1778768000.0, 1
+		);
+		INSERT INTO messages (
+			session_id, role, content, timestamp
+		) VALUES (
+			'survivor', 'user', 'still here', 1778767910.0
+		);
+	`)
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentHermes: {sessionsDir},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+
+	require.Positive(t, engine.SyncAll(t.Context(), nil).Synced)
+	stored, err := database.GetSession(t.Context(), "hermes:child")
+	require.NoError(t, err)
+	require.NotNil(t, stored, "SyncAll must store the state member")
+
+	conn, err = sql.Open("sqlite3", stateDB)
+	require.NoError(t, err)
+	_, err = conn.ExecContext(
+		t.Context(), "DELETE FROM sessions WHERE id = 'child'",
+	)
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	require.NoError(t, engine.ReconcileWatchRootsAfterLostEvents(
+		t.Context(), []string{sessionsDir}, false,
+	))
+	removed, err := database.GetSession(t.Context(), "hermes:child")
+	require.NoError(t, err)
+	assert.Nil(t, removed,
+		"audit reconciliation must tombstone a SyncAll-seeded removed member")
+	survivor, err := database.GetSession(t.Context(), "hermes:survivor")
+	require.NoError(t, err)
+	assert.NotNil(t, survivor,
+		"surviving state members must stay active")
+}
+
+func TestReconcileHermesRelativeSessionsRootTombstonesRemovedStateMember(
+	t *testing.T,
+) {
+	workingDir := t.TempDir()
+	t.Chdir(workingDir)
+	root := filepath.Join(workingDir, "archive")
+	require.NoError(t, os.MkdirAll(root, 0o755))
+	stateDB := writeHermesArchiveStateDB(t, root)
+	sessionsDir := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+	relativeSessionsDir, err := filepath.Rel(workingDir, sessionsDir)
+	require.NoError(t, err)
+	require.False(t, filepath.IsAbs(relativeSessionsDir))
+
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentHermes: {relativeSessionsDir},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+	require.NoError(t, engine.ReconcileWatchRootsAfterLostEvents(
+		t.Context(), []string{sessionsDir}, false,
+	))
+	stored, err := database.GetSession(t.Context(), "hermes:child")
+	require.NoError(t, err)
+	require.NotNil(t, stored, "initial reconciliation must store the state member")
+
+	conn, err := sql.Open("sqlite3", stateDB)
+	require.NoError(t, err)
+	_, err = conn.ExecContext(t.Context(), "DELETE FROM sessions WHERE id = 'child'")
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	require.NoError(t, engine.ReconcileWatchRootsAfterLostEvents(
+		t.Context(), []string{sessionsDir}, false,
+	))
+	stored, err = database.GetSession(t.Context(), "hermes:child")
+	require.NoError(t, err)
+	assert.Nil(t, stored,
+		"absolute reconciliation scope must cover a configured relative root")
+}
+
+func TestReconcileHermesDefaultSessionsRootPreservesMissingStateDBArchive(t *testing.T) {
+	root := t.TempDir()
+	stateDB := writeHermesArchiveStateDB(t, root)
+	sessionsDir := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentHermes: {sessionsDir},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+	require.NoError(t, engine.ReconcileWatchRootsAfterLostEvents(
+		t.Context(), []string{sessionsDir}, false,
+	))
+
+	require.NoError(t, os.Remove(stateDB))
+	require.NoError(t, engine.ReconcileWatchRootsAfterLostEvents(
+		t.Context(), []string{sessionsDir}, false,
+	))
+	stored, err := database.GetSession(t.Context(), "hermes:child")
+	require.NoError(t, err)
+	assert.NotNil(t, stored,
+		"a missing persistent state.db cannot prove its archived members were deleted")
+}
+
+func TestReconcileHermesUnreadableStateDBSyncsTranscriptsWithoutTombstones(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	stateDB := writeHermesArchiveStateDB(t, root)
+	sessionsDir := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentHermes: {sessionsDir},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+	require.NoError(t, engine.ReconcileWatchRootsAfterLostEvents(
+		t.Context(), []string{sessionsDir}, false,
+	))
+	stored, err := database.GetSession(t.Context(), "hermes:child")
+	require.NoError(t, err)
+	require.NotNil(t, stored, "initial reconciliation must store the state member")
+
+	require.NoError(t, os.WriteFile(stateDB, []byte("not a sqlite database"), 0o600))
+	jsonlPath := filepath.Join(sessionsDir, "orphan.jsonl")
+	require.NoError(t, os.WriteFile(jsonlPath, []byte(
+		`{"role":"session_meta","platform":"cli","timestamp":"2026-05-14T10:00:00Z"}`+"\n"+
+			`{"role":"user","content":"fallback transcript","timestamp":"2026-05-14T10:01:00Z"}`+"\n"+
+			`{"role":"assistant","content":"Done.","timestamp":"2026-05-14T10:02:00Z"}`+"\n",
+	), 0o600))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sessionsDir, "session_orphan.json"),
+		[]byte(`{
+			"platform":"cli",
+			"session_start":"2026-05-14T10:00:00Z",
+			"last_updated":"2026-05-14T10:02:00Z",
+			"messages":[
+				{"role":"user","content":"duplicate legacy transcript","timestamp":"2026-05-14T10:01:00Z"}
+			]
+		}`),
+		0o600,
+	))
+
+	err = engine.ReconcileWatchRootsAfterLostEvents(
+		t.Context(), []string{sessionsDir}, false,
+	)
+
+	require.Error(t, err, "unreadable state discovery must keep the scope incomplete")
+	result := engine.LastReconciliationResult()
+	assert.False(t, result.Complete)
+	assert.Equal(t, 1, result.ProviderFailures)
+	stored, getErr := database.GetSession(t.Context(), "hermes:child")
+	require.NoError(t, getErr)
+	assert.NotNil(t, stored,
+		"incomplete state discovery must not tombstone archived state-only sessions")
+	fallback, getErr := database.GetSession(t.Context(), "hermes:orphan")
+	require.NoError(t, getErr)
+	require.NotNil(t, fallback,
+		"transcript fallback candidates must still be processed before retry")
+	assert.Equal(t, jsonlPath, database.GetSessionFilePath("hermes:orphan"),
+		"JSONL must remain canonical when a legacy JSON duplicate exists")
+}
+
+func TestReconcileHermesScopedRootPreservesStateMemberMovedToAnotherRoot(t *testing.T) {
+	firstRoot := t.TempDir()
+	secondRoot := t.TempDir()
+	firstStateDB := writeHermesArchiveStateDB(t, firstRoot)
+	firstSessions := filepath.Join(firstRoot, "sessions")
+	secondSessions := filepath.Join(secondRoot, "sessions")
+	require.NoError(t, os.MkdirAll(firstSessions, 0o755))
+	require.NoError(t, os.MkdirAll(secondSessions, 0o755))
+
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentHermes: {firstSessions, secondSessions},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+	require.NoError(t, engine.ReconcileWatchRootsAfterLostEvents(
+		t.Context(), nil, true,
+	))
+
+	writeHermesArchiveStateDB(t, secondRoot)
+	conn, err := sql.Open("sqlite3", firstStateDB)
+	require.NoError(t, err)
+	_, err = conn.ExecContext(t.Context(), "DELETE FROM sessions WHERE id = 'child'")
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	require.NoError(t, engine.ReconcileWatchRootsAfterLostEvents(
+		t.Context(), []string{firstSessions}, false,
+	))
+	stored, err := database.GetSession(t.Context(), "hermes:child")
+	require.NoError(t, err)
+	assert.NotNil(t, stored,
+		"a scoped pass cannot disprove the same virtual member under another root")
+}
+
 func writeHermesArchiveStateDB(t *testing.T, root string) string {
 	t.Helper()
 	stateDB := filepath.Join(root, "state.db")
 	conn, err := sql.Open("sqlite3", stateDB)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = conn.Close() })
 
 	_, err = conn.Exec(`
 		CREATE TABLE sessions (
@@ -401,5 +998,6 @@ func writeHermesArchiveStateDB(t *testing.T, root string) string {
 		);
 	`)
 	require.NoError(t, err)
+	require.NoError(t, conn.Close())
 	return stateDB
 }

--- a/internal/sync/identity.go
+++ b/internal/sync/identity.go
@@ -10,7 +10,7 @@ import (
 // getFileIdentity extracts inode and device numbers from a
 // file's stat info on Unix systems. Returns zeros if the
 // stat data is unavailable in the expected form.
-func getFileIdentity(info os.FileInfo) (inode, device int64) {
+func getFileIdentity(_ string, info os.FileInfo) (inode, device int64) {
 	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
 		return int64(stat.Ino), int64(stat.Dev)
 	}

--- a/internal/sync/identity_windows.go
+++ b/internal/sync/identity_windows.go
@@ -2,14 +2,28 @@
 
 package sync
 
-import "os"
+import (
+	"os"
 
-// getFileIdentity returns zeros on Windows. Native file
-// identity (NTFS FileID + volume serial) requires the
-// GetFileInformationByHandle API; treating identity as
-// unknown here disables the identity-changed check and
-// falls back to size/mtime, which is the pre-existing
-// behavior.
-func getFileIdentity(info os.FileInfo) (inode, device int64) {
-	return 0, 0
+	"golang.org/x/sys/windows"
+)
+
+// getFileIdentity returns the stable file index and volume serial exposed by
+// Windows. Together they distinguish an atomic replacement from an append,
+// even when the replacement is larger than the stored source.
+func getFileIdentity(path string, _ os.FileInfo) (inode, device int64) {
+	file, err := os.Open(path)
+	if err != nil {
+		return 0, 0
+	}
+	defer file.Close()
+
+	var info windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(
+		windows.Handle(file.Fd()), &info,
+	); err != nil {
+		return 0, 0
+	}
+	fileIndex := uint64(info.FileIndexHigh)<<32 | uint64(info.FileIndexLow)
+	return int64(fileIndex), int64(info.VolumeSerialNumber)
 }

--- a/internal/sync/opencode_container_gate.go
+++ b/internal/sync/opencode_container_gate.go
@@ -3,9 +3,11 @@
 package sync
 
 import (
+	"maps"
 	"path/filepath"
 	"strings"
 
+	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/parser"
 )
 
@@ -62,16 +64,12 @@ func sqliteContainerPathForResultPath(path string) string {
 }
 
 // trustedSQLiteContainer is a container's state at the end of the last pass
-// that verified every one of its discovered sessions, together with exactly
-// which session IDs that pass discovered. The set matters in hybrid roots:
-// discovery drops SQLite rows shadowed by a same-ID storage JSON, so the
-// discoverable row set can grow — a storage JSON removed while the DB is
-// untouched exposes its row — without the container state changing. A
-// source may therefore gate-skip only when its session ID was part of the
-// verified set; a newly exposed row misses the set and parses.
+// that verified every one of its discovered sessions. Per-session membership
+// is checked against the persistent archive's canonical source path instead
+// of retaining an archive-sized Go set: a newly unshadowed SQLite row still
+// has its storage JSON path in the archive and therefore cannot gate-skip.
 type trustedSQLiteContainer struct {
-	state    parser.SQLiteContainerState
-	sessions map[string]struct{}
+	state parser.SQLiteContainerState
 }
 
 // sqliteContainerPass tracks one sync pass's view of every OpenCode-family
@@ -82,7 +80,6 @@ type trustedSQLiteContainer struct {
 type sqliteContainerPass struct {
 	captured   map[string]parser.SQLiteContainerState
 	discovered map[string]int
-	sessions   map[string]map[string]struct{}
 	completed  map[string]int
 	failed     map[string]bool
 	poisoned   bool
@@ -184,35 +181,55 @@ func (e *Engine) beginSQLiteContainerPass(
 		e.containerMu.Unlock()
 		return
 	}
-	var pass *sqliteContainerPass
+	e.beginStreamingSQLiteContainerPass(preStates)
 	for _, file := range files {
-		dbPath, sessionID, ok := sqliteContainerSourceForFile(file)
-		if !ok {
-			continue
-		}
-		if pass == nil {
-			pass = &sqliteContainerPass{
-				captured:   make(map[string]parser.SQLiteContainerState),
-				discovered: make(map[string]int),
-				sessions:   make(map[string]map[string]struct{}),
-				completed:  make(map[string]int),
-				failed:     make(map[string]bool),
-			}
-		}
-		pass.discovered[dbPath]++
-		if pass.sessions[dbPath] == nil {
-			pass.sessions[dbPath] = make(map[string]struct{})
-		}
-		pass.sessions[dbPath][sessionID] = struct{}{}
-		if _, seen := pass.captured[dbPath]; seen || pass.failed[dbPath] {
-			continue
-		}
-		if state, ok := preStates[dbPath]; ok {
-			pass.captured[dbPath] = state
-		} else {
-			pass.failed[dbPath] = true
-		}
+		e.noteSQLiteContainerDiscovery(file)
 	}
+	e.finishStreamingSQLiteContainerDiscovery()
+}
+
+func (e *Engine) beginStreamingSQLiteContainerPass(
+	preStates map[string]parser.SQLiteContainerState,
+) {
+	if e.forceParse {
+		e.containerMu.Lock()
+		e.containerPass = nil
+		e.containerMu.Unlock()
+		return
+	}
+	pass := &sqliteContainerPass{
+		captured:   make(map[string]parser.SQLiteContainerState, len(preStates)),
+		discovered: make(map[string]int),
+		completed:  make(map[string]int),
+		failed:     make(map[string]bool),
+	}
+	maps.Copy(pass.captured, preStates)
+	e.containerMu.Lock()
+	e.containerPass = pass
+	e.containerMu.Unlock()
+}
+
+func (e *Engine) noteSQLiteContainerDiscovery(file parser.DiscoveredFile) {
+	dbPath, _, ok := sqliteContainerSourceForFile(file)
+	if !ok {
+		return
+	}
+	e.containerMu.Lock()
+	defer e.containerMu.Unlock()
+	pass := e.containerPass
+	if pass == nil {
+		return
+	}
+	pass.discovered[dbPath]++
+	if _, captured := pass.captured[dbPath]; !captured {
+		pass.failed[dbPath] = true
+	}
+}
+
+func (e *Engine) finishStreamingSQLiteContainerDiscovery() {
+	e.containerMu.Lock()
+	defer e.containerMu.Unlock()
+	pass := e.containerPass
 	if pass != nil {
 		for dbPath, pre := range pass.captured {
 			if post, ok := statSQLiteContainerState(dbPath); ok &&
@@ -223,9 +240,6 @@ func (e *Engine) beginSQLiteContainerPass(
 			pass.failed[dbPath] = true
 		}
 	}
-	e.containerMu.Lock()
-	e.containerPass = pass
-	e.containerMu.Unlock()
 }
 
 // sqliteContainerSourceFresh reports whether a discovered file belongs to a
@@ -244,20 +258,23 @@ func (e *Engine) sqliteContainerSourceFresh(file parser.DiscoveredFile) bool {
 		return false
 	}
 	e.containerMu.Lock()
-	defer e.containerMu.Unlock()
 	if e.containerPass == nil {
+		e.containerMu.Unlock()
 		return false
 	}
 	current, ok := e.containerPass.captured[dbPath]
 	if !ok {
+		e.containerMu.Unlock()
 		return false
 	}
 	trusted, ok := e.trustedSQLiteContainers[dbPath]
+	e.containerMu.Unlock()
 	if !ok || current != trusted.state {
 		return false
 	}
-	_, verified := trusted.sessions[sessionID]
-	return verified
+	fullID := applyIDPrefixToID(e.idPrefix, string(file.Agent)+":"+sessionID)
+	return e.db.GetSessionDataVersion(fullID) >= db.CurrentDataVersion() &&
+		e.db.GetSessionFilePath(fullID) == e.effectiveSourcePath(file.Path)
 }
 
 // noteSQLiteContainerResult records a processed file's outcome for
@@ -295,7 +312,12 @@ func (e *Engine) poisonSQLiteContainerPass() {
 
 // finishSQLiteContainerPass promotes the pass's captured container states
 // to trusted for every container whose discovered sessions all completed
-// without errors, retries, or write failures. incomplete marks passes that
+// without errors, retries, or write failures. Promotion requires at least
+// one discovered session: scoped passes capture every configured container
+// (captureSQLiteContainerStates(nil)) but discover only in-scope sources,
+// so an out-of-scope container ends the pass at completed == discovered ==
+// 0 having verified nothing — trusting its freshly captured state would
+// gate-skip changes that were never parsed. incomplete marks passes that
 // must never promote (aborted, cancelled, or discovery failures whose
 // provider cannot be attributed).
 //
@@ -303,10 +325,9 @@ func (e *Engine) poisonSQLiteContainerPass() {
 // root (full syncs, as opposed to changed-path or scoped-root passes).
 // Such a pass is authoritative for which rows are discoverable, so a
 // trusted container it discovered no sources for — fully shadowed by
-// storage JSONs, or gone — loses its trusted entry: the entry's session
-// set is no longer being maintained, and stale membership would otherwise
-// gate-skip a row re-exposed later by a storage removal that leaves the
-// DB untouched.
+// storage JSONs, or gone — loses its trusted entry. Per-session archive-path
+// checks protect newly re-exposed rows; removing the unused container trust
+// here also keeps the compact state map aligned with current discovery.
 func (e *Engine) finishSQLiteContainerPass(incomplete, fullDiscovery bool) {
 	e.containerMu.Lock()
 	defer e.containerMu.Unlock()
@@ -329,7 +350,8 @@ func (e *Engine) finishSQLiteContainerPass(incomplete, fullDiscovery bool) {
 		if pass.failed[dbPath] {
 			continue
 		}
-		if pass.completed[dbPath] != pass.discovered[dbPath] {
+		if pass.discovered[dbPath] == 0 ||
+			pass.completed[dbPath] != pass.discovered[dbPath] {
 			continue
 		}
 		if e.trustedSQLiteContainers == nil {
@@ -337,41 +359,8 @@ func (e *Engine) finishSQLiteContainerPass(incomplete, fullDiscovery bool) {
 				make(map[string]trustedSQLiteContainer)
 		}
 		e.trustedSQLiteContainers[dbPath] = trustedSQLiteContainer{
-			state:    state,
-			sessions: pass.sessions[dbPath],
+			state: state,
 		}
-	}
-}
-
-// dropTrustedSQLiteContainerSessionForStorage removes a processed storage
-// session's ID from its root's trusted container membership. From the
-// moment a file-backed storage session is processed, the archive's
-// canonical copy for that ID is the storage one, so a same-ID SQLite row —
-// even under an unchanged container state — no longer matches what its
-// membership verified. Without this, a storage JSON that arrives and
-// disappears entirely between full passes (both legs via watcher
-// changed-path syncs, which never re-promote containers) would leave the
-// stale membership in place, and the re-exposed row would gate-skip
-// forever while the archive kept the interim storage copy. The next fully
-// verified pass re-adds the ID once the row is actually re-verified.
-func (e *Engine) dropTrustedSQLiteContainerSessionForStorage(
-	agent parser.AgentType, sessionPath string,
-) {
-	// sessionPath is root/storage/<sessionSubdir>/<project>/<id>.json,
-	// mirroring the root derivation in StatOpenCodeStorageSessionState.
-	sessionID := strings.TrimSuffix(filepath.Base(sessionPath), ".json")
-	if sessionID == "" {
-		return
-	}
-	root := filepath.Dir(filepath.Dir(filepath.Dir(filepath.Dir(sessionPath))))
-	src := resolveOpenCodeFormatSource(agent, root)
-	if src.DBPath == "" {
-		return
-	}
-	e.containerMu.Lock()
-	defer e.containerMu.Unlock()
-	if trusted, ok := e.trustedSQLiteContainers[src.DBPath]; ok {
-		delete(trusted.sessions, sessionID)
 	}
 }
 

--- a/internal/sync/opencode_container_gate_internal_test.go
+++ b/internal/sync/opencode_container_gate_internal_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/parser"
 )
 
@@ -69,10 +70,6 @@ func TestSQLiteContainerPassPromotesOnlyPreDiscoveryCaptures(t *testing.T) {
 		trusted := e.trustedSQLiteContainers[dbPath]
 		assert.Equal(t, pre, trusted.state,
 			"trusted state must be exactly the pre-discovery capture")
-		assert.Equal(t,
-			map[string]struct{}{"ses-1": {}, "ses-2": {}},
-			trusted.sessions,
-			"trusted set must be exactly the verified session IDs")
 	})
 }
 
@@ -116,7 +113,7 @@ func TestSQLiteContainerPassFailsOnCaptureDiscoveryMismatch(t *testing.T) {
 	// The container is trusted at the pre-discovery state, as after a
 	// fully verified idle pass.
 	e.trustedSQLiteContainers = map[string]trustedSQLiteContainer{
-		dbPath: {state: pre, sessions: map[string]struct{}{"ses-1": {}}},
+		dbPath: {state: pre},
 	}
 
 	// The container changes inside the capture-discovery window.
@@ -148,7 +145,8 @@ func TestSQLiteContainerPassFailsOnCaptureDiscoveryMismatch(t *testing.T) {
 // pass discovered, and only those may gate-skip; a newly exposed row was
 // never verified against the archive and must parse.
 func TestSQLiteContainerGateParsesNewlyUnshadowedSession(t *testing.T) {
-	e := &Engine{}
+	archive := openTestDB(t)
+	e := &Engine{db: archive}
 	dbPath, _ := newContainerTestDB(t)
 	state, ok := parser.StatSQLiteContainerState(dbPath)
 	require.True(t, ok, "container state must be readable")
@@ -157,6 +155,15 @@ func TestSQLiteContainerGateParsesNewlyUnshadowedSession(t *testing.T) {
 	// shadowed by its storage JSON at the time.
 	verified := parser.DiscoveredFile{
 		Agent: parser.AgentOpenCode, Path: dbPath + "#ses-1",
+	}
+	verifiedPath := verified.Path
+	replacementPath := filepath.Join(t.TempDir(), "ses-2.json")
+	for _, session := range []db.Session{
+		{ID: "opencode:ses-1", Agent: "opencode", Project: "project", Machine: "local", FilePath: &verifiedPath},
+		{ID: "opencode:ses-2", Agent: "opencode", Project: "project", Machine: "local", FilePath: &replacementPath},
+	} {
+		require.NoError(t, archive.UpsertSession(session))
+		require.NoError(t, archive.SetSessionDataVersion(session.ID, db.CurrentDataVersion()))
 	}
 	e.beginSQLiteContainerPass(
 		[]parser.DiscoveredFile{verified},
@@ -181,6 +188,69 @@ func TestSQLiteContainerGateParsesNewlyUnshadowedSession(t *testing.T) {
 		"a newly exposed row must parse despite the unchanged container")
 }
 
+// TestSQLiteContainerScopedPassDoesNotPromoteUndiscoveredContainer pins the
+// promotion precondition: a pass may only trust a container it actually
+// verified, meaning it discovered (and completed) at least one of its
+// sessions. Scoped reconciliations and scoped syncs capture every configured
+// container's state up front (captureSQLiteContainerStates(nil)) but discover
+// only in-scope sources, so an out-of-scope container ends the pass with
+// discovered == completed == 0. Promoting its freshly captured state would
+// mark a change that was never parsed as verified, and the next covering
+// pass would gate-skip the changed sessions, leaving the archive stale.
+func TestSQLiteContainerScopedPassDoesNotPromoteUndiscoveredContainer(t *testing.T) {
+	archive := openTestDB(t)
+	e := &Engine{db: archive}
+	dbPath, conn := newContainerTestDB(t)
+	pre, ok := parser.StatSQLiteContainerState(dbPath)
+	require.True(t, ok, "container state must be readable")
+
+	file := parser.DiscoveredFile{
+		Agent: parser.AgentOpenCode, Path: dbPath + "#ses-1",
+	}
+	filePath := file.Path
+	session := db.Session{
+		ID: "opencode:ses-1", Agent: "opencode", Project: "project",
+		Machine: "local", FilePath: &filePath,
+	}
+	require.NoError(t, archive.UpsertSession(session))
+	require.NoError(t, archive.SetSessionDataVersion(
+		session.ID, db.CurrentDataVersion(),
+	))
+
+	// A fully verified pass trusts the container at its current state.
+	e.beginSQLiteContainerPass(
+		[]parser.DiscoveredFile{file},
+		map[string]parser.SQLiteContainerState{dbPath: pre},
+	)
+	e.noteSQLiteContainerResult(file.Path, true)
+	e.finishSQLiteContainerPass(false, true)
+	require.Contains(t, e.trustedSQLiteContainers, dbPath)
+
+	// The container changes after the verified pass.
+	_, err := conn.Exec("INSERT INTO session (id) VALUES ('ses-1')")
+	require.NoError(t, err, "write session after the verified pass")
+	changed, ok := parser.StatSQLiteContainerState(dbPath)
+	require.True(t, ok, "changed container state must be readable")
+	require.NotEqual(t, pre, changed,
+		"the write must change the container state")
+
+	// A scoped pass elsewhere captures every configured container but
+	// discovers none of this one's sessions.
+	e.beginSQLiteContainerPass(
+		nil, map[string]parser.SQLiteContainerState{dbPath: changed},
+	)
+	e.finishSQLiteContainerPass(false, false)
+
+	// The next covering pass must parse the changed session, not gate-skip
+	// it against a state that was never verified.
+	e.beginSQLiteContainerPass(
+		[]parser.DiscoveredFile{file},
+		map[string]parser.SQLiteContainerState{dbPath: changed},
+	)
+	assert.False(t, e.sqliteContainerSourceFresh(file),
+		"a container changed while out of scope must not gate-skip after a scoped pass")
+}
+
 // TestSQLiteContainerFullPassDropsUndiscoveredTrust pins the stale-trust
 // cleanup: a complete full-discovery pass that finds no sources for a
 // trusted container (fully shadowed by storage JSONs, or gone) must drop
@@ -192,9 +262,7 @@ func TestSQLiteContainerGateParsesNewlyUnshadowedSession(t *testing.T) {
 func TestSQLiteContainerFullPassDropsUndiscoveredTrust(t *testing.T) {
 	trusted := func() map[string]trustedSQLiteContainer {
 		return map[string]trustedSQLiteContainer{
-			"/data/opencode.db": {
-				sessions: map[string]struct{}{"ses-1": {}},
-			},
+			"/data/opencode.db": {},
 		}
 	}
 

--- a/internal/sync/parse_retention.go
+++ b/internal/sync/parse_retention.go
@@ -1,0 +1,159 @@
+package sync
+
+import (
+	"context"
+	"os"
+	"runtime/debug"
+	gosync "sync"
+	"sync/atomic"
+
+	"go.kenn.io/agentsview/internal/parser"
+	"golang.org/x/sync/semaphore"
+)
+
+const (
+	defaultParseRetentionBytes      = int64(64 << 20)
+	parseRetentionFixedBytes        = int64(64 << 10)
+	parseRetentionMultiplier        = int64(4)
+	parseRetentionScavengeThreshold = int64(16 << 20)
+)
+
+type parseRetentionBudget struct {
+	capacity int64
+	// weighted is nil for the bulk budget, which admits every parse
+	// immediately so archive-scale passes run at full worker parallelism.
+	weighted        *semaphore.Weighted
+	pressure        chan struct{}
+	waiters         atomic.Int64
+	scavengePending atomic.Bool
+	scavenge        func()
+	acquired        atomic.Int64 // total successful acquisitions, for tests
+}
+
+func newParseRetentionBudget(capacity int64) *parseRetentionBudget {
+	if capacity <= 0 {
+		capacity = defaultParseRetentionBytes
+	}
+	return &parseRetentionBudget{
+		capacity: capacity,
+		weighted: semaphore.NewWeighted(capacity),
+		pressure: make(chan struct{}, 1),
+		scavenge: debug.FreeOSMemory,
+	}
+}
+
+// newBulkParseRetentionBudget returns the budget archive-scale passes use
+// (full sync, resync rebuild, remote import processing). It never throttles
+// parse admission: peak memory during a bulk pass is bounded by worker
+// parallelism, not by a byte budget. Instead it releases the pass's retained
+// memory back to the OS in one scavenge once the pass completes, keeping the
+// long-running daemon's settled footprint low without serializing the pass.
+func newBulkParseRetentionBudget() *parseRetentionBudget {
+	return &parseRetentionBudget{
+		pressure: make(chan struct{}, 1),
+		scavenge: debug.FreeOSMemory,
+	}
+}
+
+func (budget *parseRetentionBudget) acquire(
+	ctx context.Context, sourceBytes int64,
+) (*parseRetentionLease, error) {
+	if budget.weighted == nil {
+		// Bulk pass: admit immediately and remember that parsed payloads
+		// were retained so the end-of-pass scavenge runs exactly once.
+		budget.scavengePending.Store(true)
+		budget.acquired.Add(1)
+		return &parseRetentionLease{}, nil
+	}
+	weight := budget.weight(sourceBytes)
+	if budget.weighted.TryAcquire(weight) {
+		budget.noteKnownLargeSource(sourceBytes)
+		budget.acquired.Add(1)
+		return &parseRetentionLease{budget: budget, weight: weight}, nil
+	}
+	budget.waiters.Add(1)
+	defer budget.waiters.Add(-1)
+	select {
+	case budget.pressure <- struct{}{}:
+	default:
+	}
+	if err := budget.weighted.Acquire(ctx, weight); err != nil {
+		return nil, err
+	}
+	budget.noteKnownLargeSource(sourceBytes)
+	budget.acquired.Add(1)
+	return &parseRetentionLease{budget: budget, weight: weight}, nil
+}
+
+func (budget *parseRetentionBudget) noteKnownLargeSource(sourceBytes int64) {
+	if sourceBytes >= parseRetentionScavengeThreshold {
+		budget.scavengePending.Store(true)
+	}
+}
+
+func (budget *parseRetentionBudget) scavengeIfNeeded() {
+	if budget == nil || !budget.scavengePending.Swap(false) || budget.scavenge == nil {
+		return
+	}
+	budget.scavenge()
+}
+
+func (budget *parseRetentionBudget) pressureSignal() <-chan struct{} {
+	if budget == nil {
+		return nil
+	}
+	return budget.pressure
+}
+
+func (budget *parseRetentionBudget) underPressure() bool {
+	return budget != nil && budget.waiters.Load() > 0
+}
+
+func (budget *parseRetentionBudget) weight(sourceBytes int64) int64 {
+	if sourceBytes <= 0 {
+		return budget.capacity
+	}
+	if sourceBytes >= (budget.capacity-parseRetentionFixedBytes)/parseRetentionMultiplier {
+		return budget.capacity
+	}
+	return parseRetentionFixedBytes + sourceBytes*parseRetentionMultiplier
+}
+
+type parseRetentionLease struct {
+	budget *parseRetentionBudget
+	weight int64
+	once   gosync.Once
+}
+
+func (lease *parseRetentionLease) Release() {
+	if lease == nil || lease.budget == nil || lease.weight <= 0 {
+		return
+	}
+	lease.once.Do(func() {
+		lease.budget.weighted.Release(lease.weight)
+	})
+}
+
+func releaseParseRetentionLeases(leases []*parseRetentionLease) {
+	for _, lease := range leases {
+		lease.Release()
+	}
+}
+
+func parseRetentionSourceBytes(file parser.DiscoveredFile) int64 {
+	if file.SourceSize > 0 {
+		return file.SourceSize
+	}
+	path := file.Path
+	if file.ProviderSource != nil {
+		if providerPath := providerDiscoveredPath(*file.ProviderSource); providerPath != "" {
+			path = providerPath
+		}
+	}
+	path = validatedProviderSourceStatPath(path)
+	info, err := os.Stat(path)
+	if err != nil || !info.Mode().IsRegular() {
+		return 0
+	}
+	return info.Size()
+}

--- a/internal/sync/parse_retention_test.go
+++ b/internal/sync/parse_retention_test.go
@@ -1,0 +1,436 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/testjsonl"
+)
+
+// newWarmBenchEngine builds a small already-synced Claude archive and
+// returns an engine watching it, mirroring the fixture shape
+// BenchmarkSyncAllWarmNoop uses. Five sessions exercise the per-source
+// skip gates a warm no-op pass runs.
+func newWarmBenchEngine(t *testing.T) (*Engine, context.Context) {
+	t.Helper()
+	dir := t.TempDir()
+	proj := filepath.Join(dir, "warm-project")
+	require.NoError(t, os.MkdirAll(proj, 0o755))
+	for s := range 5 {
+		builder := testjsonl.NewSessionBuilder()
+		for m := 0; m < 6; m += 2 {
+			ts := fmt.Sprintf("2026-06-20T10:%02d:00Z", m)
+			builder.AddClaudeUser(ts, fmt.Sprintf(
+				"user message %d in session %d", m, s,
+			))
+			builder.AddClaudeAssistant(ts, fmt.Sprintf(
+				"assistant reply %d in session %d", m, s,
+			))
+		}
+		path := filepath.Join(proj, fmt.Sprintf("warm-%04d.jsonl", s))
+		require.NoError(t, os.WriteFile(
+			path, []byte(builder.String()), 0o644,
+		))
+	}
+	engine := NewEngine(openTestDB(t), EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {dir},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+	return engine, context.Background()
+}
+
+func TestWarmNoopSyncAcquiresNoRetentionLeases(t *testing.T) {
+	e, ctx := newWarmBenchEngine(t)
+	e.SyncAll(ctx, nil) // cold pass parses, acquires leases
+	require.NotNil(t, e.bulkRetentionBudget,
+		"a full sync pass must run under the bulk retention budget")
+	before := e.bulkRetentionBudget.acquired.Load()
+	require.Positive(t, before, "cold pass must acquire bulk leases")
+	stats := e.SyncAll(ctx, nil) // warm pass: everything skips
+	require.Equal(t, 0, stats.Synced)
+	assert.Equal(t, before, e.bulkRetentionBudget.acquired.Load(),
+		"warm no-op pass must not acquire parse-retention leases")
+}
+
+func TestFullSyncPassIsUnthrottledAndScavengesOnce(t *testing.T) {
+	e, ctx := newWarmBenchEngine(t)
+	var scavenges int
+	e.bulkRetentionBudget = newBulkParseRetentionBudget()
+	e.bulkRetentionBudget.scavenge = func() { scavenges++ }
+
+	e.SyncAll(ctx, nil) // cold pass parses every source
+	acquired := e.bulkRetentionBudget.acquired.Load()
+	require.Positive(t, acquired,
+		"full pass must admit parses through the bulk budget")
+	if e.parseRetentionBudget != nil {
+		assert.Zero(t, e.parseRetentionBudget.acquired.Load(),
+			"full pass must not consume the bounded daemon budget")
+	}
+	assert.Equal(t, 1, scavenges,
+		"a parse-bearing bulk pass must release memory once at the end")
+
+	stats := e.SyncAll(ctx, nil) // warm pass: everything skips
+	require.Equal(t, 0, stats.Synced)
+	assert.Equal(t, 1, scavenges,
+		"a warm no-op pass must not force another scavenge")
+	assert.Nil(t, e.activeRetention.Load(),
+		"bulk budget must be uninstalled after the pass")
+}
+
+func TestScopedSyncKeepsBoundedRetentionBudget(t *testing.T) {
+	e, ctx := newWarmBenchEngine(t)
+	cutoff := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	stats := e.SyncAllSince(ctx, cutoff, nil) // cutoff-scoped daemon churn
+	require.Positive(t, stats.Synced)
+	require.NotNil(t, e.parseRetentionBudget,
+		"a cutoff-scoped pass must use the bounded budget")
+	assert.Positive(t, e.parseRetentionBudget.acquired.Load(),
+		"scoped pass parses must be admitted by the bounded budget")
+	assert.Nil(t, e.bulkRetentionBudget,
+		"a cutoff-scoped pass must not create the bulk budget")
+}
+
+func TestBulkParseRetentionBudgetNeverBlocks(t *testing.T) {
+	budget := newBulkParseRetentionBudget()
+	first, err := budget.acquire(t.Context(), defaultParseRetentionBytes)
+	require.NoError(t, err)
+	second, err := budget.acquire(t.Context(), defaultParseRetentionBytes)
+	require.NoError(t, err)
+	assert.False(t, budget.underPressure(),
+		"bulk admissions must never report pressure")
+	first.Release()
+	second.Release()
+	assert.Equal(t, int64(2), budget.acquired.Load())
+}
+
+func TestBulkParseRetentionBudgetScavengesOncePerParseBearingPass(t *testing.T) {
+	budget := newBulkParseRetentionBudget()
+	var scavenges int
+	budget.scavenge = func() { scavenges++ }
+
+	budget.scavengeIfNeeded()
+	assert.Zero(t, scavenges, "a pass with no parses must not scavenge")
+
+	lease, err := budget.acquire(t.Context(), 1)
+	require.NoError(t, err)
+	lease.Release()
+	budget.scavengeIfNeeded()
+	budget.scavengeIfNeeded()
+	assert.Equal(t, 1, scavenges,
+		"one parse-bearing pass needs exactly one end-of-pass scavenge")
+}
+
+func TestParseRetentionBudgetBoundsConcurrentSourceWeight(t *testing.T) {
+	budget := newParseRetentionBudget(defaultParseRetentionBytes)
+	first, err := budget.acquire(t.Context(), 7<<20)
+	require.NoError(t, err)
+	second, err := budget.acquire(t.Context(), 7<<20)
+	require.NoError(t, err)
+	t.Cleanup(first.Release)
+	t.Cleanup(second.Release)
+
+	acquired := make(chan *parseRetentionLease, 1)
+	go func() {
+		lease, acquireErr := budget.acquire(t.Context(), 7<<20)
+		if acquireErr == nil {
+			acquired <- lease
+		}
+	}()
+
+	select {
+	case lease := <-acquired:
+		lease.Release()
+		t.Fatal("third parse admitted above the weighted retention limit")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	first.Release()
+	select {
+	case lease := <-acquired:
+		lease.Release()
+	case <-time.After(time.Second):
+		t.Fatal("third parse was not admitted after capacity was released")
+	}
+}
+
+func TestParseRetentionBudgetRunsOversizedSourceExclusively(t *testing.T) {
+	budget := newParseRetentionBudget(defaultParseRetentionBytes)
+	oversized, err := budget.acquire(t.Context(), defaultParseRetentionBytes)
+	require.NoError(t, err)
+	t.Cleanup(oversized.Release)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+	_, err = budget.acquire(ctx, 1)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+
+	oversized.Release()
+	lease, err := budget.acquire(t.Context(), 1)
+	require.NoError(t, err)
+	lease.Release()
+}
+
+func TestParseRetentionBudgetScavengesOnceAfterKnownLargeSource(t *testing.T) {
+	budget := newParseRetentionBudget(defaultParseRetentionBytes)
+	var scavenges int
+	budget.scavenge = func() { scavenges++ }
+
+	unknown, err := budget.acquire(t.Context(), 0)
+	require.NoError(t, err)
+	unknown.Release()
+	budget.scavengeIfNeeded()
+	assert.Zero(t, scavenges, "unknown sources must not force GC on every virtual event")
+
+	large, err := budget.acquire(t.Context(), parseRetentionScavengeThreshold)
+	require.NoError(t, err)
+	large.Release()
+	budget.scavengeIfNeeded()
+	budget.scavengeIfNeeded()
+	assert.Equal(t, 1, scavenges, "one large batch needs one post-write scavenge")
+}
+
+func TestCollectAndBatchRetainsParseLeaseThroughWrite(t *testing.T) {
+	engine := NewEngine(openTestDB(t), EngineConfig{Machine: "local"})
+	t.Cleanup(engine.Close)
+	budget := newParseRetentionBudget(defaultParseRetentionBytes)
+	lease, err := budget.acquire(t.Context(), defaultParseRetentionBytes)
+	require.NoError(t, err)
+
+	writeEntered := make(chan struct{})
+	allowWrite := make(chan struct{})
+	engine.writeBatchOverride = func(
+		batch []pendingWrite, _ syncWriteMode, _ bool,
+	) (int, int, int, int) {
+		assert.Len(t, batch, 1)
+		close(writeEntered)
+		<-allowWrite
+		return len(batch), 0, 0, 0
+	}
+	results := make(chan syncJob, 1)
+	results <- syncJob{
+		path:           "/sessions/one.jsonl",
+		retentionLease: lease,
+		processResult: processResult{results: []parser.ParseResult{{
+			Session: parser.ParsedSession{ID: "one", Agent: parser.AgentClaude},
+		}}},
+	}
+	close(results)
+	done := make(chan struct{})
+	go func() {
+		engine.collectAndBatch(
+			t.Context(), results, 1, 1, nil, syncWriteDefault,
+		)
+		close(done)
+	}()
+	<-writeEntered
+
+	secondAcquired := make(chan *parseRetentionLease, 1)
+	go func() {
+		second, acquireErr := budget.acquire(t.Context(), 1)
+		if acquireErr == nil {
+			secondAcquired <- second
+		}
+	}()
+	select {
+	case second := <-secondAcquired:
+		second.Release()
+		t.Fatal("next parse admitted while the prior parse payload was being written")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(allowWrite)
+	select {
+	case second := <-secondAcquired:
+		second.Release()
+	case <-time.After(time.Second):
+		t.Fatal("parse lease was not released after the database write completed")
+	}
+	<-done
+}
+
+func TestDrainResultsReleasesParseLeases(t *testing.T) {
+	budget := newParseRetentionBudget(defaultParseRetentionBytes)
+	lease, err := budget.acquire(t.Context(), defaultParseRetentionBytes)
+	require.NoError(t, err)
+	results := make(chan syncJob, 1)
+	results <- syncJob{retentionLease: lease}
+	close(results)
+
+	drainResults(results, 1)
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	next, err := budget.acquire(ctx, defaultParseRetentionBytes)
+	require.NoError(t, err)
+	next.Release()
+}
+
+func TestCollectAndBatchKeepsFanoutUnderOneLeaseUntilOneWrite(t *testing.T) {
+	engine := NewEngine(openTestDB(t), EngineConfig{Machine: "local"})
+	t.Cleanup(engine.Close)
+	budget := newParseRetentionBudget(defaultParseRetentionBytes)
+	lease, err := budget.acquire(t.Context(), defaultParseRetentionBytes)
+	require.NoError(t, err)
+
+	parsed := make([]parser.ParseResult, batchSize+1)
+	for i := range parsed {
+		parsed[i].Session = parser.ParsedSession{
+			ID: fmt.Sprintf("fanout-%03d", i), Agent: parser.AgentKiro,
+		}
+	}
+	var batchLengths []int
+	engine.writeBatchOverride = func(
+		batch []pendingWrite, _ syncWriteMode, _ bool,
+	) (int, int, int, int) {
+		batchLengths = append(batchLengths, len(batch))
+		return len(batch), 0, 0, 0
+	}
+	results := make(chan syncJob, 1)
+	results <- syncJob{
+		path:           "/sessions/data.sqlite3",
+		retentionLease: lease,
+		processResult:  processResult{results: parsed},
+	}
+	close(results)
+
+	stats := engine.collectAndBatch(
+		t.Context(), results, 1, 1, nil, syncWriteDefault,
+	)
+
+	assert.Equal(t, []int{batchSize + 1}, batchLengths)
+	assert.Equal(t, batchSize+1, stats.Synced)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	next, err := budget.acquire(ctx, defaultParseRetentionBytes)
+	require.NoError(t, err)
+	next.Release()
+}
+
+func TestStartWorkersFlushesBelowBatchUnderAdmissionPressure(t *testing.T) {
+	const agent parser.AgentType = "retention-test"
+	provider := &directStreamingProvider{
+		ProviderBase: parser.ProviderBase{Def: parser.AgentDef{Type: agent}},
+		parseOutcome: parser.ParseOutcome{
+			Results: []parser.ParseResultOutcome{{
+				Result: parser.ParseResult{Session: parser.ParsedSession{
+					ID: "retention-test:session", Agent: agent,
+				}},
+			}},
+			ResultSetComplete: true,
+		},
+	}
+	engine := NewEngine(openTestDB(t), EngineConfig{
+		Machine:           "local",
+		ProviderFactories: []parser.ProviderFactory{directStreamingFactory{provider}},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			agent: parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+	engine.workerCountOverride = 2
+	var writes int
+	engine.writeBatchOverride = func(
+		batch []pendingWrite, _ syncWriteMode, _ bool,
+	) (int, int, int, int) {
+		writes++
+		return len(batch), 0, 0, 0
+	}
+
+	files := make([]parser.DiscoveredFile, 2)
+	for i := range files {
+		path := filepath.Join(t.TempDir(), fmt.Sprintf("large-%d.jsonl", i))
+		file, err := os.Create(path)
+		require.NoError(t, err)
+		require.NoError(t, file.Truncate(20<<20))
+		require.NoError(t, file.Close())
+		source := parser.SourceRef{
+			Provider: agent, Key: path, DisplayPath: path, FingerprintKey: path,
+		}
+		files[i] = parser.DiscoveredFile{
+			Path: path, Agent: agent, ProviderSource: &source,
+			ProviderProcess: true, ForceParse: true,
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	stats := engine.collectAndBatch(
+		ctx, engine.startWorkers(ctx, files), len(files), len(files), nil,
+		syncWriteDefault,
+	)
+
+	assert.False(t, stats.Aborted)
+	assert.Equal(t, 2, stats.Synced)
+	assert.Equal(t, 2, writes,
+		"each exclusive result must flush before the next parse is admitted")
+}
+
+func TestStartWorkersCancellationReleasesAdmissionWaiters(t *testing.T) {
+	const agent parser.AgentType = "retention-cancel-test"
+	provider := &directStreamingProvider{
+		ProviderBase: parser.ProviderBase{Def: parser.AgentDef{Type: agent}},
+		parseOutcome: parser.ParseOutcome{
+			Results: []parser.ParseResultOutcome{{
+				Result: parser.ParseResult{Session: parser.ParsedSession{
+					ID: "retention-cancel-test:session", Agent: agent,
+				}},
+			}},
+			ResultSetComplete: true,
+		},
+	}
+	engine := NewEngine(openTestDB(t), EngineConfig{
+		Machine:           "local",
+		ProviderFactories: []parser.ProviderFactory{directStreamingFactory{provider}},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			agent: parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+	engine.workerCountOverride = 2
+	budget := newParseRetentionBudget(defaultParseRetentionBytes)
+	engine.parseRetentionBudget = budget
+
+	holder, err := budget.acquire(t.Context(), defaultParseRetentionBytes)
+	require.NoError(t, err)
+	files := make([]parser.DiscoveredFile, 2)
+	for i := range files {
+		// A provider-authoritative, force-parsed source reaches the provider
+		// parse seam where the lease is acquired; a trivial file would return
+		// through a skip gate before the admission wait now that acquisition
+		// follows the gates.
+		path := filepath.Join(t.TempDir(), fmt.Sprintf("waiting-%d.jsonl", i))
+		require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o600))
+		source := parser.SourceRef{
+			Provider: agent, Key: path, DisplayPath: path, FingerprintKey: path,
+		}
+		files[i] = parser.DiscoveredFile{
+			Path: path, Agent: agent, ProviderSource: &source,
+			ProviderProcess: true, ForceParse: true,
+		}
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	results := engine.startWorkers(ctx, files)
+	require.Eventually(t, budget.underPressure, time.Second, time.Millisecond,
+		"workers must reach the admission wait before cancellation")
+	cancel()
+
+	for range files {
+		job := <-results
+		assert.ErrorIs(t, job.err, context.Canceled)
+		job.releaseRetention()
+	}
+	holder.Release()
+	next, err := budget.acquire(t.Context(), defaultParseRetentionBytes)
+	require.NoError(t, err, "canceled waiters must not leak weighted capacity")
+	next.Release()
+}

--- a/internal/sync/parsediff.go
+++ b/internal/sync/parsediff.go
@@ -49,6 +49,7 @@ func NewDiffEngine(database *db.DB, cfg EngineConfig) *Engine {
 func (e *Engine) ParseDiff(ctx context.Context, opts ParseDiffOptions) (*ParseDiffReport, error) {
 	e.syncMu.Lock()
 	defer e.syncMu.Unlock()
+	defer e.retentionBudget().scavengeIfNeeded()
 
 	resolved, err := e.resolveParseDiffAgents(opts.Agents)
 	if err != nil {
@@ -148,11 +149,13 @@ func (e *Engine) ParseDiff(ctx context.Context, opts ParseDiffOptions) (*ParseDi
 			// Workers emit ctx.Err() for files skipped after
 			// cancellation.
 			cancel()
+			r.releaseRetention()
 			drainResults(results, total-i-1)
 			return nil, ctx.Err()
 		}
 		if r.incremental != nil {
 			cancel()
+			r.releaseRetention()
 			drainResults(results, total-i-1)
 			return nil, fmt.Errorf(
 				"parse-diff: internal error: incremental parse of %s "+
@@ -164,9 +167,11 @@ func (e *Engine) ParseDiff(ctx context.Context, opts ParseDiffOptions) (*ParseDi
 			visited, resolver, &presencePaths,
 		); err != nil {
 			cancel()
+			r.releaseRetention()
 			drainResults(results, total-i-1)
 			return nil, err
 		}
+		r.releaseRetention()
 		if opts.Progress != nil {
 			opts.Progress(i+1, total)
 		}
@@ -898,6 +903,26 @@ func (e *Engine) parseDiffCollectFile(
 			FilePath:          job.path,
 			Class:             DiffExcluded,
 			Reason:            "parser exclusion (would delete)",
+			StoredDataVersion: stored.DataVersion,
+		})
+		report.Totals.ExcludedByParser++
+	}
+
+	// Virtual members gone from a still-existing shared container are
+	// tombstone-bound on a real sync; mark them visited so the presence
+	// sweep does not misreport them as parser drift.
+	for _, member := range job.sourceMissingMembers {
+		stored := storedByID[member.sessionID]
+		if stored == nil {
+			continue
+		}
+		visited[stored.ID] = true
+		report.Sessions = append(report.Sessions, SessionDiff{
+			SessionID:         stored.ID,
+			Agent:             stored.Agent,
+			FilePath:          member.filePath,
+			Class:             DiffExcluded,
+			Reason:            "member source missing (would tombstone)",
 			StoredDataVersion: stored.DataVersion,
 		})
 		report.Totals.ExcludedByParser++

--- a/internal/sync/perf_invariant_test.go
+++ b/internal/sync/perf_invariant_test.go
@@ -2,9 +2,11 @@ package sync
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	gosync "sync"
 	"testing"
 
@@ -29,6 +31,150 @@ import (
 //   - The count-based seam tests in internal/parser
 //     (discovery_workspace_manifest_test.go, antigravity/gemini
 //     provider tests) pin O(roots) discovery work (#912).
+
+// coworkCorpusSession identifies one written Cowork session and its on-disk
+// artifacts so a test can delete the source and assert tombstoning.
+type coworkCorpusSession struct {
+	id             string
+	sessionDir     string
+	metaPath       string
+	transcriptPath string
+}
+
+// writeCoworkCorpus writes n Cowork sessions under root (metadata plus a
+// per-session Claude-format transcript) and returns their identifiers.
+func writeCoworkCorpus(t *testing.T, root string, n int) []coworkCorpusSession {
+	t.Helper()
+	workspaceDir := filepath.Join(root, "org", "workspace")
+	require.NoError(t, os.MkdirAll(workspaceDir, 0o755))
+	sessions := make([]coworkCorpusSession, 0, n)
+	for i := range n {
+		uuid := fmt.Sprintf("0b4eea33-0000-4000-8000-%012d", i)
+		cliID := fmt.Sprintf("3021ea26-0000-4000-8000-%012d", i)
+		sessionDirName := "local_" + uuid
+		metaPath := filepath.Join(workspaceDir, sessionDirName+".json")
+		meta := map[string]any{
+			"sessionId":      sessionDirName,
+			"cliSessionId":   cliID,
+			"title":          fmt.Sprintf("session %d", i),
+			"createdAt":      int64(1_700_000_000_000),
+			"lastActivityAt": int64(1_700_000_001_000),
+		}
+		data, err := json.Marshal(meta)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(metaPath, data, 0o644))
+
+		projectDir := filepath.Join(
+			workspaceDir, sessionDirName, ".claude", "projects", "-sessions-demo",
+		)
+		require.NoError(t, os.MkdirAll(projectDir, 0o755))
+		transcriptPath := filepath.Join(projectDir, cliID+".jsonl")
+		lines := []string{
+			`{"type":"user","uuid":"u1","parentUuid":null,` +
+				`"sessionId":"` + cliID + `","cwd":"/sessions/test",` +
+				`"timestamp":"2026-03-01T10:00:00.000Z",` +
+				`"message":{"role":"user","content":"hello there"}}`,
+			`{"type":"assistant","uuid":"a1","parentUuid":"u1",` +
+				`"sessionId":"` + cliID + `","timestamp":"2026-03-01T10:00:05.000Z",` +
+				`"message":{"role":"assistant","id":"msg_1",` +
+				`"model":"claude-sonnet-4-6","stop_reason":"end_turn",` +
+				`"content":[{"type":"text","text":"hi back"}],` +
+				`"usage":{"input_tokens":10,"output_tokens":5}}}`,
+		}
+		require.NoError(t, os.WriteFile(
+			transcriptPath, []byte(strings.Join(lines, "\n")+"\n"), 0o644))
+		sessions = append(sessions, coworkCorpusSession{
+			id:             "cowork:" + cliID,
+			sessionDir:     filepath.Join(workspaceDir, sessionDirName),
+			metaPath:       metaPath,
+			transcriptPath: transcriptPath,
+		})
+	}
+	return sessions
+}
+
+// TestScheduledReconcileWorkIsClaudeCardinalityIndependent pins the background
+// invariant for the scheduled scoped pass: reconciling an opted-in provider
+// (Cowork) does the same work regardless of how large an unrelated provider's
+// archive is, and still tombstones a deleted Cowork source within scope.
+func TestScheduledReconcileWorkIsClaudeCardinalityIndependent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	const coworkCount = 5
+	observed := make(map[int]int)
+	for _, claudeCount := range []int{5, 500} {
+		t.Run(fmt.Sprintf("claude_%d", claudeCount), func(t *testing.T) {
+			base := t.TempDir()
+			coworkDir := filepath.Join(base, "cowork")
+			claudeDir := filepath.Join(base, "claude")
+			require.NoError(t, os.MkdirAll(coworkDir, 0o755))
+			require.NoError(t, os.MkdirAll(claudeDir, 0o755))
+			writeCoworkCorpus(t, coworkDir, coworkCount)
+			writeClaudeCorpus(t, claudeDir, claudeCount)
+
+			database := openTestDB(t)
+			engine := NewEngine(database, EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{
+					parser.AgentCowork: {coworkDir},
+					parser.AgentClaude: {claudeDir},
+				},
+				Machine: "local",
+			})
+			t.Cleanup(engine.Close)
+			require.Equal(t, coworkCount+claudeCount,
+				engine.SyncAll(context.Background(), nil).Synced)
+
+			require.NoError(t, engine.ReconcileProviderRoots(
+				context.Background(), parser.AgentCowork, []string{coworkDir}))
+			observed[claudeCount] =
+				engine.LastReconciliationResult().Metrics.MaxRehydratedSources
+		})
+	}
+	assert.Equal(t, observed[5], observed[500],
+		"scheduled reconcile work must not grow with an unrelated provider's archive")
+
+	t.Run("deletion_preserved", func(t *testing.T) {
+		base := t.TempDir()
+		coworkDir := filepath.Join(base, "cowork")
+		claudeDir := filepath.Join(base, "claude")
+		require.NoError(t, os.MkdirAll(coworkDir, 0o755))
+		require.NoError(t, os.MkdirAll(claudeDir, 0o755))
+		cowork := writeCoworkCorpus(t, coworkDir, coworkCount)
+		claudeIDs := writeClaudeCorpus(t, claudeDir, coworkCount)
+
+		database := openTestDB(t)
+		engine := NewEngine(database, EngineConfig{
+			AgentDirs: map[parser.AgentType][]string{
+				parser.AgentCowork: {coworkDir},
+				parser.AgentClaude: {claudeDir},
+			},
+			Machine: "local",
+		})
+		t.Cleanup(engine.Close)
+		require.Equal(t, 2*coworkCount,
+			engine.SyncAll(context.Background(), nil).Synced)
+
+		require.NoError(t, os.RemoveAll(cowork[2].sessionDir))
+		require.NoError(t, os.Remove(cowork[2].metaPath))
+
+		require.NoError(t, engine.ReconcileProviderRoots(
+			context.Background(), parser.AgentCowork, []string{coworkDir}))
+
+		deleted, err := database.GetSessionFull(context.Background(), cowork[2].id)
+		require.NoError(t, err)
+		require.NotNil(t, deleted)
+		require.NotNil(t, deleted.DeletionCause)
+		assert.Equal(t, "source_missing", *deleted.DeletionCause)
+		for _, id := range claudeIDs {
+			active, err := database.GetSession(context.Background(), id)
+			require.NoError(t, err)
+			assert.NotNil(t, active,
+				"Cowork-scoped pass must not tombstone Claude sources")
+		}
+	})
+}
 
 func TestSourceHashSkipMutationWorkIsArchiveCardinalityIndependent(t *testing.T) {
 	type workCounts struct {

--- a/internal/sync/progress.go
+++ b/internal/sync/progress.go
@@ -66,8 +66,13 @@ type SyncStats struct {
 	// run and is omitted from the summary.
 	Anomalies AnomalyStats `json:"anomalies,omitzero"`
 
-	filesOK         int // unexported: file-level success counter
-	filesDiscovered int // file-based total, excludes DB-backed agents
+	filesOK int // unexported: file-level success counter
+	// sourceMissingTombstoned counts stored virtual members tombstoned
+	// during this run because their member source vanished from a
+	// still-existing shared container. Changed-path syncs use it to emit
+	// a sessions event even when nothing else was written.
+	sourceMissingTombstoned int
+	filesDiscovered         int // file-based total, excludes DB-backed agents
 	// nonContainerDiscovered counts discovered files that are not part of
 	// a self-preserving container store (OpenCode-format storage and its
 	// SQLite virtual paths). The resync empty-discovery guard uses it so a
@@ -77,6 +82,7 @@ type SyncStats struct {
 	messagesIndexed        int // unexported: progress message counter
 	parserExcludedFiles    int // file-level intentional parser exclusions
 	parserExcludedIDs      []string
+	providerFailures       int // authoritative discoveries that did not complete
 	// cwdFilteredSessions counts sessions vetoed by the
 	// sync_include_cwd_prefixes allow-list. The resync abort guard uses
 	// it so a run where every discovered session is filtered reads as

--- a/internal/sync/provider_process_test.go
+++ b/internal/sync/provider_process_test.go
@@ -104,7 +104,7 @@ func TestProcessFileProviderForgeVirtualSource(t *testing.T) {
 		Machine: "devbox",
 	})
 
-	files := engine.classifyProviderChangedPath(dbPath)
+	files := requireClassifyProviderChangedPath(t, engine, dbPath)
 	require.Len(t, files, 1)
 	assert.Equal(t, dbPath+"#conv-001", files[0].Path)
 	assert.Equal(t, parser.AgentForge, files[0].Agent)
@@ -287,7 +287,7 @@ func TestProcessFileProviderZCodeVirtualSource(t *testing.T) {
 		Machine: "devbox",
 	})
 
-	files := engine.classifyProviderChangedPath(dbPath)
+	files := requireClassifyProviderChangedPath(t, engine, dbPath)
 	require.Len(t, files, 1)
 	assert.Equal(t, dbPath+"#session-001", files[0].Path)
 	assert.Equal(t, parser.AgentZCode, files[0].Agent)

--- a/internal/sync/qoder_test.go
+++ b/internal/sync/qoder_test.go
@@ -34,21 +34,21 @@ func TestEngineClassifyQoderPaths(t *testing.T) {
 		require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o644))
 	}
 
-	files := engine.classifyPaths([]string{mainPath})
+	files := requireClassifyPaths(t, engine, []string{mainPath})
 	require.Len(t, files, 1, "main path did not classify")
 	got := files[0]
 	assert.Equal(t, mainPath, got.Path)
 	assert.Equal(t, "project", got.Project)
 	assert.Equal(t, parser.AgentQoder, got.Agent)
 
-	files = engine.classifyPaths([]string{subPath})
+	files = requireClassifyPaths(t, engine, []string{subPath})
 	require.Len(t, files, 1, "subagent path did not classify")
 	got = files[0]
 	assert.Equal(t, subPath, got.Path)
 	assert.Equal(t, "project", got.Project)
 	assert.Equal(t, parser.AgentQoder, got.Agent)
 
-	files = engine.classifyPaths([]string{sidecarPath})
+	files = requireClassifyPaths(t, engine, []string{sidecarPath})
 	require.Len(t, files, 1, "sidecar path did not map to transcript")
 	got = files[0]
 	assert.Equal(t, mainPath, got.Path)
@@ -56,7 +56,7 @@ func TestEngineClassifyQoderPaths(t *testing.T) {
 	assert.Equal(t, parser.AgentQoder, got.Agent)
 
 	for _, path := range []string{statsPath, rootAgentPath, nestedPath} {
-		files = engine.classifyPaths([]string{path})
+		files = requireClassifyPaths(t, engine, []string{path})
 		assert.Emptyf(t, files, "%s classified as %+v", path, files)
 	}
 }
@@ -75,7 +75,7 @@ func TestEngineClassifyQoderProjectNamedSubagentsAsMainSession(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
 	require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o644))
 
-	files := engine.classifyPaths([]string{path})
+	files := requireClassifyPaths(t, engine, []string{path})
 	require.Len(t, files, 1, "path did not classify")
 	got := files[0]
 	assert.Equal(t, path, got.Path)

--- a/internal/sync/rebuild_contributor_test.go
+++ b/internal/sync/rebuild_contributor_test.go
@@ -270,9 +270,55 @@ func TestResyncContributorPostSwapReopenFailureReturnsCoordinatorError(t *testin
 	assert.Empty(t, emitter.got(), "failed reopen published a successful sync")
 	assert.True(t, engine.LastSyncStats().Aborted)
 
-	// The rename already completed. Restore the handle and prove the rebuilt
-	// file is now the active archive even though publication failed.
-	require.NoError(t, database.Reopen())
+	// The rename already completed and the barrier recovery performed a full
+	// reopen, so the rebuilt file must serve reads and writes without a
+	// manual Reopen — a writer-only recovery would leave every read on a
+	// closed pool until restart.
+	assert.False(t, database.WriterClosed(),
+		"barrier recovery must restore the writer")
+	session, getErr := database.GetSession(context.Background(), "session")
+	require.NoError(t, getErr)
+	require.NotNil(t, session)
+}
+
+// TestResyncContributorPostSwapReopenRecoversOnRetry pins the retry: a
+// transient reopen failure after the rename must not fail the resync — the
+// swap retries the reopen and completes, recording the retry as a warning.
+func TestResyncContributorPostSwapReopenRecoversOnRetry(t *testing.T) {
+	root := t.TempDir()
+	database, err := db.Open(filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentClaude: {root}},
+		Machine:   "local",
+	})
+	t.Cleanup(engine.Close)
+	path := filepath.Join(root, "project", "session.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(testjsonl.NewSessionBuilder().
+		AddClaudeUser("2026-01-01T00:00:00Z", "reopen retry fixture").String()), 0o644))
+
+	var reopenCalls int
+	stats, err := engine.resyncAllWithOptionsAndOperations(
+		context.Background(), nil, RebuildOptions{}, rebuildOperations{
+			rebuildFTS: productionRebuildOperations.rebuildFTS,
+			reopen: func(database *db.DB) error {
+				reopenCalls++
+				if reopenCalls == 1 {
+					return errors.New("transient reopen failure")
+				}
+				return database.Reopen()
+			},
+		},
+	)
+
+	require.NoError(t, err)
+	assert.False(t, stats.Aborted)
+	assert.Equal(t, 2, reopenCalls)
+	assert.Contains(t, stats.Warnings,
+		"resync reopen required a retry: transient reopen failure")
+	assert.False(t, database.WriterClosed())
 	session, getErr := database.GetSession(context.Background(), "session")
 	require.NoError(t, getErr)
 	require.NotNil(t, session)

--- a/internal/sync/reconcile_provider_roots_test.go
+++ b/internal/sync/reconcile_provider_roots_test.go
@@ -1,0 +1,152 @@
+package sync
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	gosync "sync"
+	"testing"
+
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/testjsonl"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeAiderRepoSession writes one Aider history file with a single run under
+// <root>/<repo> and returns the derived session ID.
+func writeAiderRepoSession(t *testing.T, root, repo, prompt string) (path, id string) {
+	t.Helper()
+	repoDir := filepath.Join(root, repo)
+	require.NoError(t, os.MkdirAll(repoDir, 0o755))
+	path = filepath.Join(repoDir, parser.AiderHistoryFileName())
+	body := "# aider chat started at 2026-06-09 14:01:00\n#### " + prompt + "\nanswer\n"
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
+	rawID, ok := parser.AiderRawIDAt(path, 0)
+	require.True(t, ok)
+	return path, "aider:" + rawID
+}
+
+// writeClaudeCorpus writes n minimal Claude sessions under dir and returns
+// their derived session IDs.
+func writeClaudeCorpus(t *testing.T, dir string, n int) []string {
+	t.Helper()
+	ids := make([]string, 0, n)
+	for i := range n {
+		name := fmt.Sprintf("claude-%04d", i)
+		path := filepath.Join(dir, "project", name+".jsonl")
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(
+			testjsonl.NewSessionBuilder().
+				AddClaudeUser("2024-01-01T00:00:00Z", fmt.Sprintf("hi %d", i)).
+				String(),
+		), 0o644))
+		ids = append(ids, name)
+	}
+	return ids
+}
+
+// lstatRecorder wraps os.Lstat and records every path stat-checked so a scoped
+// reconciliation can prove it never enumerated another provider's sources.
+type lstatRecorder struct {
+	mu    gosync.Mutex
+	paths []string
+}
+
+func (r *lstatRecorder) stat(path string) (os.FileInfo, error) {
+	r.mu.Lock()
+	r.paths = append(r.paths, path)
+	r.mu.Unlock()
+	return os.Lstat(path)
+}
+
+func (r *lstatRecorder) countUnder(dir string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	count := 0
+	for _, p := range r.paths {
+		if samePathOrDescendant(cleanRootPath(p), cleanRootPath(dir)) {
+			count++
+		}
+	}
+	return count
+}
+
+func TestReconcileProviderRootsDoesNotExpandAcrossProviders(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	base := t.TempDir()
+	aiderRoot := filepath.Join(base, "aider")
+	// claudeDir is a descendant of aiderRoot: the overlap that
+	// logicalRootsForWatchRoots would otherwise expand across providers.
+	claudeDir := filepath.Join(aiderRoot, "claude")
+	require.NoError(t, os.MkdirAll(claudeDir, 0o755))
+
+	const aiderCount = 5
+	aiderIDs := make([]string, 0, aiderCount)
+	aiderPaths := make([]string, 0, aiderCount)
+	for i := range aiderCount {
+		path, id := writeAiderRepoSession(
+			t, aiderRoot, fmt.Sprintf("repo%d", i), fmt.Sprintf("prompt %d", i),
+		)
+		aiderIDs = append(aiderIDs, id)
+		aiderPaths = append(aiderPaths, path)
+	}
+	claudeIDs := writeClaudeCorpus(t, claudeDir, 100)
+
+	database := openTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentAider:  {aiderRoot},
+			parser.AgentClaude: {claudeDir},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+
+	require.Equal(t, aiderCount+len(claudeIDs),
+		engine.SyncAll(t.Context(), nil).Synced, "cold pass ingests every source")
+
+	// Delete one Aider source under the opted-in root; the scoped pass must
+	// tombstone it exactly as a full pass would.
+	require.NoError(t, os.Remove(aiderPaths[2]))
+
+	rec := &lstatRecorder{}
+	engine.lstat = rec.stat
+
+	require.NoError(t, engine.ReconcileProviderRoots(
+		t.Context(), parser.AgentAider, []string{aiderRoot}))
+
+	// Deletion within scope is preserved.
+	deleted, err := database.GetSessionFull(t.Context(), aiderIDs[2])
+	require.NoError(t, err)
+	require.NotNil(t, deleted)
+	require.NotNil(t, deleted.DeletionCause)
+	assert.Equal(t, "source_missing", *deleted.DeletionCause)
+
+	// Surviving Aider sources stay active.
+	for i, id := range aiderIDs {
+		if i == 2 {
+			continue
+		}
+		active, err := database.GetSession(t.Context(), id)
+		require.NoError(t, err)
+		assert.NotNil(t, active, "surviving Aider session must remain active")
+	}
+
+	// No Claude session may be tombstoned by an Aider-scoped pass.
+	for _, id := range claudeIDs {
+		active, err := database.GetSession(t.Context(), id)
+		require.NoError(t, err)
+		assert.NotNil(t, active, "agent-scoped pass must not tombstone another provider")
+	}
+
+	// The scoped pass must not enumerate Claude sources: no stat under
+	// claudeDir, and rehydration bounded by the Aider corpus.
+	assert.Zero(t, rec.countUnder(claudeDir),
+		"agent-scoped reconciliation must not stat other providers' sources")
+	assert.LessOrEqual(t, engine.LastReconciliationResult().Metrics.MaxRehydratedSources,
+		aiderCount, "rehydration must stay bounded by the scoped provider's corpus")
+}

--- a/internal/sync/reconciliation_spool.go
+++ b/internal/sync/reconciliation_spool.go
@@ -1,0 +1,411 @@
+package sync
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+const reconciliationPageSize = 256
+
+type reconciliationCandidate struct {
+	Provider       parser.AgentType
+	Identity       string
+	Path           string
+	StoredPath     string
+	MemberIdentity string
+	WatchRoot      string
+	Project        string
+	Preference1    int64
+	Preference2    int64
+	Preference3    int64
+}
+
+func (candidate reconciliationCandidate) Cursor() reconciliationCursor {
+	return reconciliationCursor{
+		Provider: candidate.Provider,
+		Identity: candidate.Identity,
+	}
+}
+
+type reconciliationCursor struct {
+	Provider parser.AgentType
+	Identity string
+}
+
+// ReconciliationMetrics reports the largest bounded batches retained while a
+// watcher-forced reconciliation was running.
+type ReconciliationMetrics struct {
+	MaxSpoolPageRows         int
+	MaxProviderBuffered      int
+	MaxRehydratedSources     int
+	MaxWorkerResults         int
+	MaxPendingWrites         int
+	ExcludedRemoteRoots      int
+	GlobalLinkPasses         int
+	MaxProviderRetainedBytes int64
+	SharedContainerScans     int
+	OpenCodeSQLiteParses     int
+	// CodexReplacementIndexBuilds counts uuid-to-path replacement index
+	// builds during missing-path tombstoning. A streamed pass answers
+	// replacement lookups from its discovery spool, so this stays zero;
+	// only a spool-less pass builds the fallback index, at most once
+	// regardless of how many Codex sources vanished.
+	CodexReplacementIndexBuilds int
+}
+
+type reconciliationSpool struct {
+	path string
+	db   *sql.DB
+
+	mu      sync.Mutex
+	closed  bool
+	sealed  bool
+	metrics ReconciliationMetrics
+}
+
+type reconciliationSpoolStore interface {
+	Add(context.Context, reconciliationCandidate) error
+	Candidate(context.Context, parser.AgentType, string) (reconciliationCandidate, bool, error)
+	ContainsSource(context.Context, parser.AgentType, string) (bool, error)
+	ContainsSourceIdentity(context.Context, parser.AgentType, string, string) (bool, error)
+	Page(context.Context, reconciliationCursor, int) ([]reconciliationCandidate, error)
+	Metrics() ReconciliationMetrics
+	CloseAndRemove() error
+}
+
+func (spool *reconciliationSpool) Candidate(
+	ctx context.Context, provider parser.AgentType, identity string,
+) (reconciliationCandidate, bool, error) {
+	if err := spool.seal(ctx); err != nil {
+		return reconciliationCandidate{}, false, err
+	}
+	var candidate reconciliationCandidate
+	var providerName string
+	err := spool.db.QueryRowContext(ctx, `
+		SELECT provider, identity, path, stored_path, member_identity, watch_root, project,
+		       preference_1, preference_2, preference_3
+		FROM candidates
+		WHERE provider = ? AND identity = ?
+	`, string(provider), identity).Scan(
+		&providerName, &candidate.Identity, &candidate.Path, &candidate.StoredPath,
+		&candidate.MemberIdentity,
+		&candidate.WatchRoot, &candidate.Project,
+		&candidate.Preference1, &candidate.Preference2,
+		&candidate.Preference3,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return reconciliationCandidate{}, false, nil
+	}
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return reconciliationCandidate{}, false, ctxErr
+		}
+		return reconciliationCandidate{}, false, fmt.Errorf(
+			"query reconciliation candidate: %w", err,
+		)
+	}
+	candidate.Provider = parser.AgentType(providerName)
+	return candidate, true, nil
+}
+
+func (spool *reconciliationSpool) ContainsSource(
+	ctx context.Context, provider parser.AgentType, storedPath string,
+) (bool, error) {
+	if err := spool.seal(ctx); err != nil {
+		return false, err
+	}
+	var found int
+	err := spool.db.QueryRowContext(ctx, `
+		SELECT 1
+		FROM candidates
+		WHERE provider = ? AND stored_path = ?
+		LIMIT 1
+	`, string(provider), storedPath).Scan(&found)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return false, ctxErr
+		}
+		return false, fmt.Errorf("query reconciliation source membership: %w", err)
+	}
+	return true, nil
+}
+
+func (spool *reconciliationSpool) ContainsSourceIdentity(
+	ctx context.Context, provider parser.AgentType, storedPath, identity string,
+) (bool, error) {
+	if err := spool.seal(ctx); err != nil {
+		return false, err
+	}
+	var found int
+	err := spool.db.QueryRowContext(ctx, `
+		SELECT 1
+		FROM candidates
+		WHERE provider = ? AND stored_path = ? AND member_identity = ?
+		LIMIT 1
+	`, string(provider), storedPath, identity).Scan(&found)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return false, ctxErr
+		}
+		return false, fmt.Errorf("query reconciliation source identity membership: %w", err)
+	}
+	return true, nil
+}
+
+func newReconciliationSpool(archivePath string) (*reconciliationSpool, error) {
+	dir := filepath.Dir(archivePath)
+	file, err := os.CreateTemp(dir, ".agentsview-reconcile-*.db")
+	if err != nil {
+		return nil, fmt.Errorf("create reconciliation spool: %w", err)
+	}
+	path := file.Name()
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
+		return nil, fmt.Errorf("close reconciliation spool placeholder: %w", err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		_ = os.Remove(path)
+		return nil, fmt.Errorf("secure reconciliation spool: %w", err)
+	}
+
+	dsn := reconciliationSpoolDSN(path)
+	database, err := sql.Open("sqlite3", dsn)
+	if err != nil {
+		_ = os.Remove(path)
+		return nil, fmt.Errorf("open reconciliation spool: %w", err)
+	}
+	database.SetMaxOpenConns(1)
+	spool := &reconciliationSpool{path: path, db: database}
+	if err := spool.initialize(); err != nil {
+		_ = spool.CloseAndRemove()
+		return nil, err
+	}
+	return spool, nil
+}
+
+func reconciliationSpoolDSN(path string) string {
+	uri := ""
+	switch {
+	case windowsDrivePath(path):
+		slashPath := "/" + strings.ReplaceAll(path, `\`, "/")
+		uri = "file:" + (&url.URL{Path: slashPath}).EscapedPath()
+	case strings.HasPrefix(path, `\\`):
+		// SQLite rejects non-local file URI authorities unless built with
+		// SQLITE_ALLOW_URI_AUTHORITY. The ordinary Windows filename preserves
+		// UNC semantics without requiring that optional compile-time feature.
+		return path
+	default:
+		uri = "file:" + (&url.URL{Path: path}).EscapedPath()
+	}
+	return uri
+}
+
+func windowsDrivePath(path string) bool {
+	if len(path) < 3 || path[1] != ':' || (path[2] != '\\' && path[2] != '/') {
+		return false
+	}
+	return path[0] >= 'A' && path[0] <= 'Z' || path[0] >= 'a' && path[0] <= 'z'
+}
+
+func (spool *reconciliationSpool) initialize() error {
+	_, err := spool.db.Exec(`
+		PRAGMA busy_timeout = 5000;
+		PRAGMA journal_mode = WAL;
+		PRAGMA synchronous = NORMAL;
+		PRAGMA temp_store = FILE;
+		CREATE TABLE candidates (
+			provider TEXT NOT NULL,
+			identity TEXT NOT NULL,
+			path TEXT NOT NULL,
+			stored_path TEXT NOT NULL,
+			member_identity TEXT NOT NULL,
+			watch_root TEXT NOT NULL,
+			project TEXT NOT NULL,
+			preference_1 INTEGER NOT NULL,
+			preference_2 INTEGER NOT NULL,
+			preference_3 INTEGER NOT NULL,
+			PRIMARY KEY (provider, identity)
+		) WITHOUT ROWID;
+		CREATE INDEX candidates_by_stored_path
+			ON candidates(provider, stored_path, member_identity);
+		BEGIN IMMEDIATE;
+	`)
+	if err != nil {
+		return fmt.Errorf("initialize reconciliation spool: %w", err)
+	}
+	return nil
+}
+
+func (spool *reconciliationSpool) Add(
+	ctx context.Context, candidate reconciliationCandidate,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	spool.mu.Lock()
+	sealed := spool.sealed
+	spool.mu.Unlock()
+	if sealed {
+		return errors.New("reconciliation spool is sealed")
+	}
+	_, err := spool.db.ExecContext(ctx, `
+		INSERT INTO candidates (
+			provider, identity, path, stored_path, member_identity, watch_root, project,
+			preference_1, preference_2, preference_3
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(provider, identity) DO UPDATE SET
+			path = excluded.path,
+			stored_path = excluded.stored_path,
+			member_identity = excluded.member_identity,
+			watch_root = excluded.watch_root,
+			project = excluded.project,
+			preference_1 = excluded.preference_1,
+			preference_2 = excluded.preference_2,
+			preference_3 = excluded.preference_3
+		WHERE excluded.preference_1 > candidates.preference_1
+		   OR (excluded.preference_1 = candidates.preference_1
+		       AND excluded.preference_2 > candidates.preference_2)
+		   OR (excluded.preference_1 = candidates.preference_1
+		       AND excluded.preference_2 = candidates.preference_2
+		       AND excluded.preference_3 > candidates.preference_3)
+		   OR (excluded.preference_1 = candidates.preference_1
+		       AND excluded.preference_2 = candidates.preference_2
+		       AND excluded.preference_3 = candidates.preference_3
+		       AND excluded.path < candidates.path)
+	`, string(candidate.Provider), candidate.Identity, candidate.Path,
+		candidate.StoredPath, candidate.MemberIdentity,
+		candidate.WatchRoot, candidate.Project, candidate.Preference1,
+		candidate.Preference2, candidate.Preference3)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return fmt.Errorf("write reconciliation candidate: %w", err)
+	}
+	return nil
+}
+
+func (spool *reconciliationSpool) Page(
+	ctx context.Context, after reconciliationCursor, limit int,
+) ([]reconciliationCandidate, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if err := spool.seal(ctx); err != nil {
+		return nil, err
+	}
+	if limit <= 0 || limit > reconciliationPageSize {
+		limit = reconciliationPageSize
+	}
+	rows, err := spool.db.QueryContext(ctx, `
+		SELECT provider, identity, path, stored_path, member_identity, watch_root, project,
+		       preference_1, preference_2, preference_3
+		FROM candidates
+		WHERE provider > ? OR (provider = ? AND identity > ?)
+		ORDER BY provider, identity
+		LIMIT ?
+	`, string(after.Provider), string(after.Provider), after.Identity, limit)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		return nil, fmt.Errorf("query reconciliation candidates: %w", err)
+	}
+	defer rows.Close()
+
+	page := make([]reconciliationCandidate, 0, limit)
+	for rows.Next() {
+		var candidate reconciliationCandidate
+		var provider string
+		if err := rows.Scan(
+			&provider, &candidate.Identity, &candidate.Path, &candidate.StoredPath,
+			&candidate.MemberIdentity,
+			&candidate.WatchRoot, &candidate.Project,
+			&candidate.Preference1, &candidate.Preference2,
+			&candidate.Preference3,
+		); err != nil {
+			return nil, fmt.Errorf("scan reconciliation candidate: %w", err)
+		}
+		candidate.Provider = parser.AgentType(provider)
+		page = append(page, candidate)
+	}
+	if err := rows.Err(); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		return nil, fmt.Errorf("iterate reconciliation candidates: %w", err)
+	}
+	spool.mu.Lock()
+	spool.metrics.MaxSpoolPageRows = max(spool.metrics.MaxSpoolPageRows, len(page))
+	spool.mu.Unlock()
+	return page, nil
+}
+
+func (spool *reconciliationSpool) seal(ctx context.Context) error {
+	spool.mu.Lock()
+	if spool.sealed {
+		spool.mu.Unlock()
+		return nil
+	}
+	spool.mu.Unlock()
+	if _, err := spool.db.ExecContext(ctx, "COMMIT"); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return fmt.Errorf("commit reconciliation candidates: %w", err)
+	}
+	spool.mu.Lock()
+	spool.sealed = true
+	spool.mu.Unlock()
+	return nil
+}
+
+func (spool *reconciliationSpool) Metrics() ReconciliationMetrics {
+	spool.mu.Lock()
+	defer spool.mu.Unlock()
+	return spool.metrics
+}
+
+func (spool *reconciliationSpool) closeDB() error {
+	spool.mu.Lock()
+	if spool.closed {
+		spool.mu.Unlock()
+		return nil
+	}
+	spool.closed = true
+	sealed := spool.sealed
+	spool.mu.Unlock()
+	if !sealed {
+		_, _ = spool.db.Exec("ROLLBACK")
+	}
+	return spool.db.Close()
+}
+
+func (spool *reconciliationSpool) CloseAndRemove() error {
+	closeErr := spool.closeDB()
+	var removeErr error
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		if err := os.Remove(spool.path + suffix); err != nil &&
+			!errors.Is(err, os.ErrNotExist) && removeErr == nil {
+			removeErr = err
+		}
+	}
+	return errors.Join(closeErr, removeErr)
+}

--- a/internal/sync/reconciliation_spool_test.go
+++ b/internal/sync/reconciliation_spool_test.go
@@ -1,0 +1,167 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+func TestReconciliationSpoolSelectsPreferredCandidateInSQL(t *testing.T) {
+	archivePath := filepath.Join(t.TempDir(), "sessions.db")
+	spool, err := newReconciliationSpool(archivePath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, spool.CloseAndRemove()) })
+
+	ctx := t.Context()
+	require.NoError(t, spool.Add(ctx, reconciliationCandidate{
+		Provider: parser.AgentClaude, Identity: "same", Path: "/sessions/old.jsonl",
+		StoredPath:  "remote:/sessions/old.jsonl",
+		Preference1: 100, Preference2: 1,
+	}))
+	require.NoError(t, spool.Add(ctx, reconciliationCandidate{
+		Provider: parser.AgentClaude, Identity: "same", Path: "/sessions/new.jsonl",
+		StoredPath: "remote:/sessions/new.jsonl", MemberIdentity: "stable",
+		Preference1: 200, Preference2: 2,
+	}))
+	require.NoError(t, spool.Add(ctx, reconciliationCandidate{
+		Provider: parser.AgentCodex, Identity: "uuid", Path: "/archived/rollout-uuid.jsonl",
+		Preference1: 0,
+	}))
+	require.NoError(t, spool.Add(ctx, reconciliationCandidate{
+		Provider: parser.AgentCodex, Identity: "uuid", Path: "/sessions/2026/07/14/rollout-uuid.jsonl",
+		Preference1: 1,
+	}))
+
+	page, err := spool.Page(ctx, reconciliationCursor{}, reconciliationPageSize)
+	require.NoError(t, err)
+	require.Len(t, page, 2)
+	assert.Equal(t, "/sessions/new.jsonl", page[0].Path)
+	assert.Equal(t, "remote:/sessions/new.jsonl", page[0].StoredPath)
+	assert.Equal(t, "/sessions/2026/07/14/rollout-uuid.jsonl", page[1].Path)
+	present, err := spool.ContainsSource(
+		ctx, parser.AgentClaude, "remote:/sessions/new.jsonl",
+	)
+	require.NoError(t, err)
+	assert.True(t, present)
+	present, err = spool.ContainsSource(
+		ctx, parser.AgentClaude, "remote:/sessions/old.jsonl",
+	)
+	require.NoError(t, err)
+	assert.False(t, present,
+		"membership must follow the preferred candidate selected by the spool")
+	present, err = spool.ContainsSourceIdentity(
+		ctx, parser.AgentClaude, "remote:/sessions/new.jsonl", "stable",
+	)
+	require.NoError(t, err)
+	assert.True(t, present)
+	present, err = spool.ContainsSourceIdentity(
+		ctx, parser.AgentClaude, "remote:/sessions/new.jsonl", "different",
+	)
+	require.NoError(t, err)
+	assert.False(t, present,
+		"path reuse by a different identity must not prove source membership")
+}
+
+func TestReconciliationSpoolDSNEscapesPortablePaths(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "posix special characters",
+			path: "/tmp/archive #?%/reconcile.db",
+			want: "file:/tmp/archive%20%23%3F%25/reconcile.db",
+		},
+		{
+			name: "windows drive",
+			path: `C:\Data\archive #?%\reconcile.db`,
+			want: "file:/C:/Data/archive%20%23%3F%25/reconcile.db",
+		},
+		{
+			name: "windows UNC",
+			path: `\\server\share\archive #%\reconcile.db`,
+			want: `\\server\share\archive #%\reconcile.db`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, reconciliationSpoolDSN(tc.path))
+		})
+	}
+}
+
+func TestReconciliationSpoolPagesStayBoundedAndCleanup(t *testing.T) {
+	dir := t.TempDir()
+	spool, err := newReconciliationSpool(filepath.Join(dir, "sessions.db"))
+	require.NoError(t, err)
+	path := spool.path
+	assert.Equal(t, dir, filepath.Dir(path))
+
+	for i := range reconciliationPageSize*3 + 17 {
+		require.NoError(t, spool.Add(t.Context(), reconciliationCandidate{
+			Provider: parser.AgentClaude,
+			Identity: assertSessionIdentity(i),
+			Path:     filepath.Join(dir, assertSessionIdentity(i)+".jsonl"),
+		}))
+	}
+
+	var cursor reconciliationCursor
+	var total int
+	for {
+		page, err := spool.Page(t.Context(), cursor, reconciliationPageSize)
+		require.NoError(t, err)
+		assert.LessOrEqual(t, len(page), reconciliationPageSize)
+		if len(page) == 0 {
+			break
+		}
+		total += len(page)
+		cursor = page[len(page)-1].Cursor()
+	}
+	assert.Equal(t, reconciliationPageSize*3+17, total)
+	assert.Equal(t, reconciliationPageSize, spool.Metrics().MaxSpoolPageRows)
+
+	require.NoError(t, spool.CloseAndRemove())
+	for _, suffix := range []string{"", "-wal", "-shm"} {
+		_, err := os.Stat(path + suffix)
+		assert.ErrorIs(t, err, os.ErrNotExist)
+	}
+}
+
+func TestReconciliationSpoolCancellationAndClosedErrors(t *testing.T) {
+	spool, err := newReconciliationSpool(filepath.Join(t.TempDir(), "sessions.db"))
+	require.NoError(t, err)
+	path := spool.path
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	assert.ErrorIs(t, spool.Add(ctx, reconciliationCandidate{
+		Provider: parser.AgentClaude, Identity: "cancelled", Path: "/cancelled",
+	}), context.Canceled)
+
+	require.NoError(t, spool.closeDB())
+	err = spool.Add(t.Context(), reconciliationCandidate{
+		Provider: parser.AgentClaude, Identity: "closed", Path: "/closed",
+	})
+	assert.Error(t, err)
+	assert.False(t, errors.Is(err, context.Canceled))
+	_, err = spool.Page(t.Context(), reconciliationCursor{}, reconciliationPageSize)
+	assert.Error(t, err)
+
+	require.NoError(t, spool.CloseAndRemove())
+	_, err = os.Stat(path)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func assertSessionIdentity(i int) string {
+	return fmt.Sprintf("session-%06d", i)
+}

--- a/internal/sync/s3.go
+++ b/internal/sync/s3.go
@@ -240,32 +240,40 @@ func (e *Engine) processS3Session(
 	if err != nil {
 		return processResult{err: err}
 	}
+	// Legacy/S3 parse seam: the per-agent skip gates above return lease-free,
+	// so acquire the retention lease that bounds the materialized-and-parsed
+	// payload just before the object is fetched and parsed. Every result from
+	// here carries the lease; releaseRetention frees it after consumption.
+	lease, err := e.retentionBudget().acquire(ctx, parseRetentionSourceBytes(file))
+	if err != nil {
+		return processResult{err: err}
+	}
 	rc, err := fetchS3Object(file.Path)
 	if err != nil {
-		return processResult{err: err, noCacheSkip: true}
+		return processResult{err: err, noCacheSkip: true, retentionLease: lease}
 	}
 	defer rc.Close()
 	dir, err := os.MkdirTemp("", "avs3-")
 	if err != nil {
-		return processResult{err: err, noCacheSkip: true}
+		return processResult{err: err, noCacheSkip: true, retentionLease: lease}
 	}
 	defer os.RemoveAll(dir)
 	tmp := filepath.Join(dir, relPath)
 	if err := os.MkdirAll(filepath.Dir(tmp), 0o755); err != nil {
-		return processResult{err: err, noCacheSkip: true}
+		return processResult{err: err, noCacheSkip: true, retentionLease: lease}
 	}
 	f, err := os.Create(tmp)
 	if err != nil {
-		return processResult{err: err, noCacheSkip: true}
+		return processResult{err: err, noCacheSkip: true, retentionLease: lease}
 	}
 	// Stream the object straight to disk so a large session never has to be
 	// held whole in memory.
 	if _, err := io.Copy(f, rc); err != nil {
 		f.Close()
-		return processResult{err: err, noCacheSkip: true}
+		return processResult{err: err, noCacheSkip: true, retentionLease: lease}
 	}
 	if err := f.Close(); err != nil {
-		return processResult{err: err, noCacheSkip: true}
+		return processResult{err: err, noCacheSkip: true, retentionLease: lease}
 	}
 	hydratedToolResults := false
 	sawPersistedToolResults := false
@@ -273,14 +281,14 @@ func (e *Engine) processS3Session(
 	case parser.AgentClaude:
 		rewrote, sawPersisted, err := hydrateS3ClaudeToolResults(tmp, file.Path)
 		if err != nil {
-			return processResult{err: err, noCacheSkip: true}
+			return processResult{err: err, noCacheSkip: true, retentionLease: lease}
 		}
 		hydratedToolResults = rewrote
 		sawPersistedToolResults = sawPersisted
 	case parser.AgentCodex:
 		indexPath, err := hydrateS3CodexSessionIndex(tmp, file.Path)
 		if err != nil {
-			return processResult{err: err, noCacheSkip: true}
+			return processResult{err: err, noCacheSkip: true, retentionLease: lease}
 		}
 		if indexPath != "" {
 			defer parser.EvictCodexSessionIndex(indexPath)
@@ -288,7 +296,7 @@ func (e *Engine) processS3Session(
 	}
 	res, err := e.parseMaterializedS3Source(ctx, file, dir, tmp)
 	if err != nil {
-		return processResult{err: err, noCacheSkip: true}
+		return processResult{err: err, noCacheSkip: true, retentionLease: lease}
 	}
 	// Record the real s3:// source on each parsed session rather than the
 	// transient temp path (which is deleted on return), so the stored source
@@ -308,6 +316,7 @@ func (e *Engine) processS3Session(
 	res.excludedSessionIDs = applyIDPrefixToIDs(
 		idPrefix, res.excludedSessionIDs,
 	)
+	res.retentionLease = lease
 	return res
 }
 

--- a/internal/sync/s3_source_test.go
+++ b/internal/sync/s3_source_test.go
@@ -1347,3 +1347,145 @@ func TestFilterFilesByMtimeAppliesCutoffToProviderDiscoveredClaudeS3(t *testing.
 	assert.Empty(t, got,
 		"an unchanged old provider-discovered Claude S3 object must be cut off")
 }
+
+// scopeRecordingS3Factory is a Claude provider factory whose discovery emits a
+// fixed s3:// source and records the roots each provider was constructed with,
+// so a scoped pass's root filtering is observable.
+type scopeRecordingS3Factory struct {
+	source parser.SourceRef
+	roots  [][]string
+}
+
+func (f *scopeRecordingS3Factory) Definition() parser.AgentDef {
+	return parser.AgentDef{
+		Type:        parser.AgentClaude,
+		DisplayName: "Claude Code",
+		FileBased:   true,
+	}
+}
+
+func (f *scopeRecordingS3Factory) Capabilities() parser.Capabilities {
+	return parser.Capabilities{
+		Source: parser.SourceCapabilities{
+			DiscoverSources: parser.CapabilitySupported,
+		},
+	}
+}
+
+func (f *scopeRecordingS3Factory) NewProvider(
+	cfg parser.ProviderConfig,
+) parser.Provider {
+	f.roots = append(f.roots, append([]string(nil), cfg.Roots...))
+	return scopeRecordingS3Provider{
+		ProviderBase: parser.ProviderBase{
+			Def:  f.Definition(),
+			Caps: f.Capabilities(),
+		},
+		source: f.source,
+	}
+}
+
+type scopeRecordingS3Provider struct {
+	parser.ProviderBase
+	source parser.SourceRef
+}
+
+func (p scopeRecordingS3Provider) Discover(
+	context.Context,
+) ([]parser.SourceRef, error) {
+	return []parser.SourceRef{p.source}, nil
+}
+
+func (p scopeRecordingS3Provider) FindSource(
+	context.Context, parser.FindSourceRequest,
+) (parser.SourceRef, bool, error) {
+	return parser.SourceRef{}, false, nil
+}
+
+func (p scopeRecordingS3Provider) Fingerprint(
+	context.Context, parser.SourceRef,
+) (parser.SourceFingerprint, error) {
+	return parser.SourceFingerprint{}, nil
+}
+
+func (p scopeRecordingS3Provider) Parse(
+	context.Context, parser.ParseRequest,
+) (parser.ParseOutcome, error) {
+	return parser.ParseOutcome{}, nil
+}
+
+// TestSyncRootsSinceScopedRemoteRootSyncsNewObject covers the seam the
+// daemon's periodic remote-source pass relies on: SyncRootsSince scoped to a
+// configured s3:// root discovers and syncs a new remote object, and the
+// provider is constructed with only the remote root so the pass never walks
+// the provider's local roots.
+func TestSyncRootsSinceScopedRemoteRootSyncsNewObject(t *testing.T) {
+	database := openTestDB(t)
+	localRoot := t.TempDir()
+	const remoteRoot = "s3://bucket/remote-box/raw/claude"
+	const uri = remoteRoot + "/test-proj/new-session.jsonl"
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUser("2024-01-01T00:00:00Z", "Hello from S3").
+		AddClaudeAssistant("2024-01-01T00:00:05Z", "Hi.").
+		String()
+	mtime := time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC).UnixNano()
+
+	oldFetch := fetchS3Object
+	oldStat := statS3Object
+	t.Cleanup(func() {
+		fetchS3Object = oldFetch
+		statS3Object = oldStat
+	})
+	fetchS3Object = func(got string) (io.ReadCloser, error) {
+		require.Equal(t, uri, got)
+		return io.NopCloser(strings.NewReader(content)), nil
+	}
+	statS3Object = func(string) (parser.S3Object, error) {
+		return parser.S3Object{}, missingS3ObjectError()
+	}
+
+	factory := &scopeRecordingS3Factory{source: parser.SourceRef{
+		Provider:       parser.AgentClaude,
+		Key:            uri,
+		DisplayPath:    uri,
+		FingerprintKey: uri,
+		ProjectHint:    "test-proj",
+		Opaque: parser.S3DiscoveredSource{
+			URI:         uri,
+			Project:     "test-proj",
+			Machine:     "remote-box",
+			Size:        int64(len(content)),
+			MtimeNS:     mtime,
+			Fingerprint: "s3:fingerprint:new-session",
+		},
+	}}
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {localRoot, remoteRoot},
+		},
+		Machine:           "local",
+		ProviderFactories: []parser.ProviderFactory{factory},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			parser.AgentClaude: parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+
+	stats := engine.SyncRootsSince(
+		context.Background(), []string{remoteRoot}, time.Time{}, nil,
+	)
+
+	assert.Equal(t, 1, stats.Synced, "the new S3 object must sync")
+	assert.Zero(t, stats.Failed)
+	require.Equal(t, [][]string{{remoteRoot}}, factory.roots,
+		"the scoped pass must construct the provider with only the remote root")
+	sess, err := database.GetSessionFull(
+		context.Background(), "remote-box~new-session",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, sess, "the synced S3 session must be queryable")
+	assert.Equal(t, "remote-box", sess.Machine)
+	require.NotNil(t, sess.FilePath)
+	assert.Equal(t, uri, *sess.FilePath,
+		"the stored source must be the s3:// URI, not a temp path")
+}

--- a/internal/sync/signal_schedule_test.go
+++ b/internal/sync/signal_schedule_test.go
@@ -557,6 +557,33 @@ func TestSyncThenRunFlushesSignalsBeforeWork(t *testing.T) {
 		"work must observe flushed signal fields before pushing")
 }
 
+// TestRunExclusiveFlushedFlushesSignalsBeforeWork mirrors the worker-backed
+// daemon push path: the sync ran in a worker process, so the push half runs
+// through RunExclusiveFlushed and must still observe flushed signal fields.
+func TestRunExclusiveFlushedFlushesSignalsBeforeWork(t *testing.T) {
+	fx := newEngineFixture(t)
+	path := fx.writeClaudeSession(t, "proj", "sig-flush-excl.jsonl", "hello")
+	fx.engine.SyncAll(context.Background(), nil)
+	sid := fx.sessionIDFor(t, path)
+
+	fx.appendClaudeMessage(t, path, "key AKIA7QHWN2DKR4FYPLJM leaked")
+	fx.engine.SyncPaths([]string{path})
+	require.Equal(t, 1, secretLeakCount(t, fx, sid))
+	fx.appendClaudeMessage(t, path, "key AKIA9XKQV3ZTN8WMB2RC leaked")
+	fx.engine.SyncPaths([]string{path})
+	require.Equal(t, 1, secretLeakCount(t, fx, sid),
+		"second write within interval should defer the recompute")
+
+	var seen int
+	err := fx.engine.RunExclusiveFlushed(func() error {
+		seen = secretLeakCount(t, fx, sid)
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, seen,
+		"work must observe flushed signal fields before pushing")
+}
+
 func TestSignalSchedulerRealTimerFlushes(t *testing.T) {
 	var mu sync.Mutex
 	var runs int

--- a/internal/sync/stored_source_hints_test.go
+++ b/internal/sync/stored_source_hints_test.go
@@ -14,7 +14,6 @@ import (
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/dbtest"
 	"go.kenn.io/agentsview/internal/parser"
-	"go.kenn.io/agentsview/internal/testjsonl"
 )
 
 type hintRecordingFactory struct {
@@ -55,6 +54,14 @@ func (p *hintRecordingProvider) SourcesForChangedPath(
 	}}, nil
 }
 
+func (p *hintRecordingProvider) StoredSourceHintScopes(
+	req parser.ChangedPathRequest,
+) []parser.StoredSourceHintScope {
+	return []parser.StoredSourceHintScope{{
+		Path: req.Path, IncludeVirtualMembers: true,
+	}}
+}
+
 func (p *hintRecordingProvider) Parse(context.Context, parser.ParseRequest) (parser.ParseOutcome, error) {
 	return parser.ParseOutcome{}, nil
 }
@@ -72,7 +79,7 @@ func TestClassifyProviderChangedPathSchedulesStoredSourceHintsByCapability(t *te
 			root := t.TempDir()
 			changedPath := filepath.Join(root, "container.db")
 			require.NoError(t, os.WriteFile(changedPath, []byte("fixture"), 0o600))
-			persistedPath := filepath.Join(root, "archive", "stored#member")
+			persistedPath := changedPath + "#stored"
 			database := dbtest.OpenTestDB(t)
 			require.NoError(t, database.UpsertSession(db.Session{
 				ID: "hint-agent:stored", Agent: "hint-agent", Project: "fixture",
@@ -94,7 +101,7 @@ func TestClassifyProviderChangedPathSchedulesStoredSourceHintsByCapability(t *te
 				},
 			}
 
-			files := engine.classifyProviderChangedPath(changedPath)
+			files := requireClassifyProviderChangedPath(t, engine, changedPath)
 
 			require.Len(t, files, 1)
 			require.Len(t, seen, 1)
@@ -107,81 +114,50 @@ func TestClassifyProviderChangedPathSchedulesStoredSourceHintsByCapability(t *te
 	}
 }
 
-func TestProviderChangedPathStoredHintRootsTraeScopesToContainer(t *testing.T) {
-	root := t.TempDir()
-	workspaceWatchRoot := filepath.Join(root, "workspaceStorage")
-	globalWatchRoot := filepath.Join(root, "globalStorage")
-
-	workspaceManifest := filepath.Join(
-		workspaceWatchRoot, "hash-a", "workspace.json",
-	)
-	require.NoError(t, os.MkdirAll(filepath.Dir(workspaceManifest), 0o755))
-	assert.Equal(
-		t,
-		[]string{filepath.Join(workspaceWatchRoot, "hash-a", "state.vscdb")},
-		providerChangedPathStoredHintRoots(
-			parser.AgentTrae, workspaceWatchRoot, workspaceManifest,
-		),
-	)
-
-	globalDB := filepath.Join(globalWatchRoot, "state.vscdb")
-	require.NoError(t, os.MkdirAll(filepath.Dir(globalDB), 0o755))
-	assert.Equal(
-		t,
-		[]string{globalDB},
-		providerChangedPathStoredHintRoots(
-			parser.AgentTrae, globalWatchRoot, globalDB+"-wal",
-		),
-	)
-}
-
-func TestClassifyCodexChangedPathAllocationsStayBounded(t *testing.T) {
+func TestClassifyStoredHintProviderChangedPathAllocationsStayBoundedByContainer(t *testing.T) {
 	measure := func(t *testing.T, hintCount int) float64 {
 		t.Helper()
-		root := t.TempDir()
-		path := filepath.Join(root, "rollout-2026-07-11T10-00-00-alloc.jsonl")
-		content := testjsonl.JoinJSONL(
-			testjsonl.CodexSessionMetaJSON(
-				"alloc", "/workspace/agentsview", "codex_cli_rs", "2026-07-11T10:00:00Z",
-			),
-			testjsonl.CodexMsgJSON("user", "measure allocations", "2026-07-11T10:00:01Z"),
-		)
-		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+		root := filepath.Join(t.TempDir(), "Windsurf", "User")
+		path := filepath.Join(root, "workspaceStorage", "changed", "state.vscdb")
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		writeSyncWindsurfStateDB(t, path, windsurfSyncPayload("live", "reply"))
 		database := dbtest.OpenTestDB(t)
 		for i := range hintCount {
-			hint := filepath.Join(root, "archive", fmt.Sprintf("%04d.jsonl", i))
+			hint := fmt.Sprintf("%s-archive-%04d#archived", path, i)
 			require.NoError(t, database.UpsertSession(db.Session{
-				ID: fmt.Sprintf("codex:hint-%04d", i), Agent: string(parser.AgentCodex),
+				ID: fmt.Sprintf("windsurf:hint-%04d", i), Agent: string(parser.AgentWindsurf),
 				Project: "archive", Machine: "local", FilePath: strPtr(hint),
 			}))
 		}
 		engine := &Engine{
 			db: database, machine: "local",
-			agentDirs:         map[parser.AgentType][]string{parser.AgentCodex: {root}},
+			agentDirs:         map[parser.AgentType][]string{parser.AgentWindsurf: {root}},
 			providerFactories: providerFactoryMap(parser.ProviderFactories()),
 			providerMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
-				parser.AgentCodex: parser.ProviderMigrationProviderAuthoritative,
+				parser.AgentWindsurf: parser.ProviderMigrationProviderAuthoritative,
 			},
 		}
-		warm := engine.classifyProviderChangedPath(path)
+		warm := requireClassifyProviderChangedPath(t, engine, path)
 		require.Len(t, warm, 1)
-		assert.Equal(t, path, warm[0].Path)
-		assert.Equal(t, parser.AgentCodex, warm[0].Agent)
+		assert.Equal(t, path+"#live", warm[0].Path)
+		assert.Equal(t, parser.AgentWindsurf, warm[0].Agent)
 
 		var got []parser.DiscoveredFile
+		var classifyErr error
 		allocs := testing.AllocsPerRun(5, func() {
-			got = engine.classifyProviderChangedPath(path)
+			got, classifyErr = engine.classifyProviderChangedPath(t.Context(), path)
 		})
+		require.NoError(t, classifyErr)
 		require.Len(t, got, 1)
-		assert.Equal(t, path, got[0].Path)
-		assert.Equal(t, parser.AgentCodex, got[0].Agent)
+		assert.Equal(t, path+"#live", got[0].Path)
+		assert.Equal(t, parser.AgentWindsurf, got[0].Agent)
 		return allocs
 	}
 
 	smallAllocs := measure(t, 10)
 	largeAllocs := measure(t, 2000)
 	assert.LessOrEqual(t, largeAllocs, smallAllocs*2,
-		"stored archives must not scale Codex changed-path allocations")
+		"unrelated stored containers must not scale changed-path allocations")
 }
 
 func TestClassifyProviderChangedPathPreservesHintDependentTombstones(t *testing.T) {
@@ -200,7 +176,7 @@ func TestClassifyProviderChangedPathPreservesHintDependentTombstones(t *testing.
 				_, err = conn.Exec(`DELETE FROM conversations WHERE conversation_id = 'conv-001'`)
 				require.NoError(t, err)
 				require.NoError(t, conn.Close())
-				return root, path, path + "#conv-001"
+				return root, path + "-wal", path + "#conv-001"
 			},
 		},
 		{
@@ -217,7 +193,7 @@ func TestClassifyProviderChangedPathPreservesHintDependentTombstones(t *testing.
 					folder_paths TEXT, folder_paths_order TEXT, created_at TEXT)`)
 				require.NoError(t, err)
 				require.NoError(t, store.Close())
-				return root, path, parser.ZedSQLiteVirtualPath(path, "deleted")
+				return root, path + "-shm", parser.ZedSQLiteVirtualPath(path, "deleted")
 			},
 		},
 		{
@@ -232,7 +208,7 @@ func TestClassifyProviderChangedPathPreservesHintDependentTombstones(t *testing.
 				_, err = conn.Exec(`DELETE FROM sessions WHERE id = 'deleted'`)
 				require.NoError(t, err)
 				require.NoError(t, conn.Close())
-				return root, path, path + "#deleted"
+				return root, path + "-wal", path + "#deleted"
 			},
 		},
 		{
@@ -259,7 +235,7 @@ func TestClassifyProviderChangedPathPreservesHintDependentTombstones(t *testing.
 				_, err = store.Exec(`DELETE FROM conversations_v2 WHERE conversation_id = 'deleted'`)
 				require.NoError(t, err)
 				require.NoError(t, store.Close())
-				return root, path, parser.KiroSQLiteVirtualPath(path, "deleted")
+				return root, path + "-shm", parser.KiroSQLiteVirtualPath(path, "deleted")
 			},
 		},
 		{
@@ -270,7 +246,9 @@ func TestClassifyProviderChangedPathPreservesHintDependentTombstones(t *testing.
 				require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
 				writeSyncWindsurfStateDB(t, path, windsurfSyncPayload("deleted", "reply"))
 				updateSyncWindsurfStateDB(t, path, `{}`)
-				return root, path, path + "#deleted"
+				manifestPath := filepath.Join(filepath.Dir(path), "workspace.json")
+				require.NoError(t, os.WriteFile(manifestPath, []byte(`{"folder":"fixture"}`), 0o600))
+				return root, manifestPath, path + "#deleted"
 			},
 		},
 		{
@@ -306,7 +284,7 @@ func TestClassifyProviderChangedPathPreservesHintDependentTombstones(t *testing.
 				},
 			}
 
-			files := engine.classifyProviderChangedPath(changedPath)
+			files := requireClassifyProviderChangedPath(t, engine, changedPath)
 			var tombstone parser.DiscoveredFile
 			for _, file := range files {
 				if file.Path == deletedPath {

--- a/internal/sync/test_helpers_test.go
+++ b/internal/sync/test_helpers_test.go
@@ -283,8 +283,19 @@ func createKiroSQLiteDB(t *testing.T, dir string) *kiroSQLiteTestDB {
 	)
 	d, err := sql.Open("sqlite3", path)
 	require.NoError(t, err, "opening kiro sqlite test db")
-	t.Cleanup(func() { d.Close() })
-	return &kiroSQLiteTestDB{path: path, db: d}
+	fixture := &kiroSQLiteTestDB{path: path, db: d}
+	t.Cleanup(func() {
+		if fixture.db != nil {
+			_ = fixture.db.Close()
+		}
+	})
+	return fixture
+}
+
+func (k *kiroSQLiteTestDB) close(t *testing.T) {
+	t.Helper()
+	require.NoError(t, k.db.Close())
+	k.db = nil
 }
 
 func copySQLiteSchemaTemplate(

--- a/internal/sync/trae_integration_test.go
+++ b/internal/sync/trae_integration_test.go
@@ -246,7 +246,10 @@ func TestProcessFileProviderTraeWALWatcherEventDropsUnchangedSibling(t *testing.
 		traeSyncSession("steady", "steady reply"),
 	}, info.ModTime())
 
-	classified := engine.classifyPaths([]string{path + "-wal"})
+	classified, err := engine.classifyPaths(
+		context.Background(), []string{path + "-wal"},
+	)
+	require.NoError(t, err)
 	require.Len(t, classified, 1)
 	assert.Equal(t, path, classified[0].Path)
 	assert.Equal(t, parser.AgentTrae, classified[0].Agent)
@@ -284,7 +287,10 @@ func TestProcessFileProviderTraeRemovedWALSidecarDoesNotForceParse(t *testing.T)
 	require.Equal(t, 1, written)
 	require.Equal(t, 0, failed)
 
-	classified := engine.classifyPaths([]string{path + "-wal"})
+	classified, err := engine.classifyPaths(
+		context.Background(), []string{path + "-wal"},
+	)
+	require.NoError(t, err)
 	require.Len(t, classified, 1)
 	assert.Equal(t, path, classified[0].Path)
 	assert.False(t, classified[0].ForceParse)

--- a/internal/sync/verified_source_gate.go
+++ b/internal/sync/verified_source_gate.go
@@ -184,7 +184,7 @@ func (e *Engine) verifiedProviderSourceState(
 	if !ok {
 		return verifiedSourceCapture{}, 0, false, false
 	}
-	inode, device := getFileIdentity(info)
+	inode, device := getFileIdentity(path, info)
 	mtime := info.ModTime().UnixNano()
 	sidecar := verifiedSourceSignature{}
 	if provider.Definition().Type == parser.AgentCodex {
@@ -202,7 +202,7 @@ func (e *Engine) verifiedProviderSourceState(
 				if !reliable {
 					return verifiedSourceCapture{}, 0, false, false
 				}
-				indexInode, indexDevice := getFileIdentity(indexInfo)
+				indexInode, indexDevice := getFileIdentity(indexPath, indexInfo)
 				sidecar.sidecarSize = indexInfo.Size()
 				sidecar.sidecarMtime = indexInfo.ModTime().UnixNano()
 				sidecar.sidecarInode = indexInode

--- a/internal/sync/verified_source_gate_integration_test.go
+++ b/internal/sync/verified_source_gate_integration_test.go
@@ -283,7 +283,7 @@ func TestVerifiedSourceGateRechecksAfterStatAndWatcherInvalidation(t *testing.T)
 	assert.Equal(t, 2, provider.fingerprintCalls,
 		"same-size rewrite with restored mtime must deep-verify")
 
-	classified := engine.classifyPaths([]string{file.Path})
+	classified := requireClassifyPaths(t, engine, []string{file.Path})
 	require.Len(t, classified, 1)
 	res := engine.processFile(context.Background(), classified[0])
 	require.NoError(t, res.err)

--- a/internal/sync/visualstudio_copilot_integration_test.go
+++ b/internal/sync/visualstudio_copilot_integration_test.go
@@ -3,10 +3,12 @@ package sync_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -42,6 +44,180 @@ func vsCopilotTraceLine(
 		`","endTimeUnixNano":"` + end +
 		`","attributes":[` + strings.Join(allAttrs, ",") +
 		`]}]}]}]}`
+}
+
+func TestReconcileWatchRootsPreservesVisualStudioCopilotSessionBehindSymlinkedVSRoot(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	conversationID := "5bc5f6d7-9a6e-4f9c-8f3c-b7be2e7d9f20"
+	vsRoot := filepath.Join(root, ".vs")
+	sessionPath := filepath.Join(
+		vsRoot, "SampleApp", "copilot-chat", "thread", "sessions",
+		conversationID,
+	)
+	require.NoError(t, os.MkdirAll(filepath.Dir(sessionPath), 0o755))
+	require.NoError(t, os.WriteFile(sessionPath, []byte(vsCopilotTraceLine(
+		conversationID, "span", "chat gpt-5.5", "1781293600000000000",
+		"1781293610000000000", map[string]string{
+			"gen_ai.operation.name": "chat",
+			"gen_ai.input.messages": `[{"role":"user","parts":[{"type":"text","content":"Run the tests."}]}]`,
+		},
+	)+"\n"), 0o600))
+
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentVSCopilot: {root}},
+		Machine:   "local",
+	})
+	t.Cleanup(engine.Close)
+
+	stats := engine.SyncAll(t.Context(), nil)
+	require.False(t, stats.Aborted)
+	require.Equal(t, 1, stats.Synced)
+	sessionID := "visualstudio-copilot:" + conversationID
+	stored, err := database.GetSession(t.Context(), sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+
+	targetVSRoot := filepath.Join(t.TempDir(), "vs-data")
+	require.NoError(t, os.Rename(vsRoot, targetVSRoot))
+	if err := os.Symlink(targetVSRoot, vsRoot); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	require.NoError(t, engine.ReconcileWatchRoots(t.Context(), []string{root}, false))
+	active, err := database.GetSession(t.Context(), sessionID)
+	require.NoError(t, err)
+	assert.NotNil(t, active,
+		"authoritative reconciliation must preserve a session behind a directory symlink")
+}
+
+func TestReconcileWatchRootsVisualStudioCopilot300MembersUsesOneBoundedScan(t *testing.T) {
+	const members = 300
+	root := t.TempDir()
+	tracePath := filepath.Join(
+		root, "20260714T120000_00000000_VSGitHubCopilot_traces.jsonl",
+	)
+	var data strings.Builder
+	for i := range members {
+		id := fmt.Sprintf("00000000-0000-0000-0000-%012x", i)
+		data.WriteString(vsCopilotTraceLine(
+			id, fmt.Sprintf("span-%03d", i), "chat gpt-5.5", "1781293620000000000",
+			"1781293630000000000", map[string]string{
+				"gen_ai.operation.name": "chat",
+				"gen_ai.input.messages": strings.Repeat("bounded prompt ", 300),
+			},
+		))
+		data.WriteByte('\n')
+	}
+	require.NoError(t, os.WriteFile(tracePath, []byte(data.String()), 0o600))
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentVSCopilot: {root}},
+		Machine:   "local",
+	})
+	t.Cleanup(engine.Close)
+
+	// Production uses at least two workers and caps above this desired overlap,
+	// so this target cannot exceed the workers available on low-CPU hosts.
+	overlapTarget := min(4, max(runtime.NumCPU(), 2))
+	require.GreaterOrEqual(t, overlapTarget, 2)
+	probe := newVSRetainedOverlapProbe(parser.AgentVSCopilot, overlapTarget)
+	ctx := parser.WithReconciliationRetainedMemberObserver(t.Context(), probe.observe)
+	done := make(chan error, 1)
+	go func() {
+		done <- engine.ReconcileWatchRoots(ctx, []string{root}, false)
+	}()
+	probe.waitAndRelease(t)
+	require.NoError(t, <-done)
+
+	result := engine.LastReconciliationResult()
+	assert.True(t, result.Complete)
+	assert.Equal(t, 1, result.Metrics.SharedContainerScans)
+	assert.Equal(t, 256, result.Metrics.MaxSpoolPageRows)
+	assert.Positive(t, result.Metrics.MaxProviderRetainedBytes)
+	assert.GreaterOrEqual(t, probe.maxActive.Load(), int32(overlapTarget))
+	assert.GreaterOrEqual(t, result.Metrics.MaxProviderRetainedBytes, probe.maxBytes.Load(),
+		"aggregate metric must include every concurrently retained worker member")
+	assert.Less(t, result.Metrics.MaxProviderRetainedBytes, int64(data.Len())/2,
+		"concurrent provider retention must stay bounded by members, not the container")
+	lastID := fmt.Sprintf("visualstudio-copilot:00000000-0000-0000-0000-%012x", members-1)
+	stored, err := database.GetSession(t.Context(), lastID)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+}
+
+type vsRetainedOverlapProbe struct {
+	provider  parser.AgentType
+	target    int
+	arrived   chan struct{}
+	release   chan struct{}
+	active    atomic.Int32
+	liveBytes atomic.Int64
+	maxActive atomic.Int32
+	maxBytes  atomic.Int64
+}
+
+func newVSRetainedOverlapProbe(
+	provider parser.AgentType, target int,
+) *vsRetainedOverlapProbe {
+	return &vsRetainedOverlapProbe{
+		provider: provider, target: target,
+		arrived: make(chan struct{}, target), release: make(chan struct{}),
+	}
+}
+
+func (probe *vsRetainedOverlapProbe) observe(provider parser.AgentType, retained int64) {
+	if provider != probe.provider || retained <= 0 {
+		return
+	}
+	active := probe.active.Add(1)
+	liveBytes := probe.liveBytes.Add(retained)
+	vsAtomicMaxInt32(&probe.maxActive, active)
+	vsAtomicMaxInt64(&probe.maxBytes, liveBytes)
+	select {
+	case probe.arrived <- struct{}{}:
+	case <-probe.release:
+	}
+	<-probe.release
+	probe.liveBytes.Add(-retained)
+	probe.active.Add(-1)
+}
+
+func (probe *vsRetainedOverlapProbe) waitAndRelease(t *testing.T) {
+	t.Helper()
+	defer func() {
+		select {
+		case <-probe.release:
+		default:
+			close(probe.release)
+		}
+	}()
+	for range probe.target {
+		select {
+		case <-probe.arrived:
+		case <-time.After(30 * time.Second):
+			t.Fatal("timed out waiting for concurrent retained members")
+		}
+	}
+	close(probe.release)
+}
+
+func vsAtomicMaxInt32(value *atomic.Int32, candidate int32) {
+	for current := value.Load(); candidate > current; current = value.Load() {
+		if value.CompareAndSwap(current, candidate) {
+			return
+		}
+	}
+}
+
+func vsAtomicMaxInt64(value *atomic.Int64, candidate int64) {
+	for current := value.Load(); candidate > current; current = value.Load() {
+		if value.CompareAndSwap(current, candidate) {
+			return
+		}
+	}
 }
 
 // TestSyncEngineVisualStudioCopilotMultipleConversationsPerFile verifies that a
@@ -284,6 +460,45 @@ func TestSyncRootsSinceVisualStudioCopilotPollTombstonesDeletedVS2026Session(
 	require.NoError(t, err)
 	assert.Nil(t, gone,
 		"unwatched polling must tombstone deleted VS 2026 session files")
+}
+
+func TestSyncPathsVisualStudioCopilotTombstonesDeletedVS2026Session(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	root := t.TempDir()
+	conversationID := "4a8f63f6-7626-4416-a874-fc7bd2c3f005"
+	sessionID := "visualstudio-copilot:" + conversationID
+	sessionPath := filepath.Join(
+		root, ".vs", "SampleApp", "copilot-chat", "thread", "sessions",
+		conversationID,
+	)
+	require.NoError(t, os.MkdirAll(filepath.Dir(sessionPath), 0o755))
+	require.NoError(t, os.WriteFile(sessionPath, []byte(
+		vsCopilotTraceLine(conversationID, "d1", "chat gpt-5.5",
+			"1781293600000000000", "1781293610000000000",
+			map[string]string{
+				"gen_ai.operation.name": "chat",
+				"gen_ai.input.messages": `[{"role":"user","parts":[{"type":"text","content":"Hello."}]}]`,
+			})+"\n"), 0o644))
+
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentVSCopilot: {root},
+		},
+		Machine: "local",
+	})
+	require.NotZero(t, engine.SyncAll(context.Background(), nil).Synced)
+	assertSessionMessageCount(t, database, sessionID, 1)
+
+	require.NoError(t, os.Remove(sessionPath))
+	engine.SyncPathsContext(context.Background(), []string{sessionPath})
+
+	gone, err := database.GetSession(context.Background(), sessionID)
+	require.NoError(t, err)
+	assert.Nil(t, gone,
+		"an extensionless container event must tombstone its stored virtual member")
 }
 
 func TestSyncRootsSinceVisualStudioCopilotPollPreservesVS2026SessionWhenRootMissing(

--- a/internal/sync/vnode_observer_darwin.go
+++ b/internal/sync/vnode_observer_darwin.go
@@ -1,0 +1,199 @@
+//go:build darwin && cgo
+
+package sync
+
+import (
+	"fmt"
+	"path/filepath"
+	gosync "sync"
+
+	"golang.org/x/sys/unix"
+)
+
+// vnodeObserver watches directories for entry-level changes using one
+// EVFILT_VNODE descriptor per directory. It exists for missing-root
+// ancestors, where fsnotify's kqueue backend would open one descriptor per
+// directory entry. Content changes to files inside the directory are
+// deliberately out of scope: ancestors only need create/remove/rename of
+// entries, and the lifecycle loop re-evaluates state on every wake.
+type vnodeObserver struct {
+	mu     gosync.Mutex
+	kq     int
+	fds    map[string]int
+	paths  map[int]string
+	wake   func()
+	closed bool
+	done   chan struct{}
+	// wakeR/wakeW form a self-pipe registered with EVFILT_READ. Close writes a
+	// byte to interrupt run()'s blocked Kevent: unlike closing the kqueue
+	// mid-syscall, which Darwin does not guarantee to interrupt, a pipe write
+	// always fires the read filter.
+	wakeR int
+	wakeW int
+	// closeDone closes when the first Close finishes tearing down, so
+	// concurrent Close calls wait for the teardown instead of returning while
+	// descriptors are still live.
+	closeDone chan struct{}
+}
+
+func newVnodeObserver(wake func()) (*vnodeObserver, error) {
+	kq, err := unix.Kqueue()
+	if err != nil {
+		return nil, fmt.Errorf("create ancestor kqueue: %w", err)
+	}
+	var pipeFds [2]int
+	if err := unix.Pipe(pipeFds[:]); err != nil {
+		_ = unix.Close(kq)
+		return nil, fmt.Errorf("create ancestor wake pipe: %w", err)
+	}
+	closeAll := func() {
+		_ = unix.Close(pipeFds[0])
+		_ = unix.Close(pipeFds[1])
+		_ = unix.Close(kq)
+	}
+	for _, fd := range pipeFds {
+		unix.CloseOnExec(fd)
+	}
+	// Nonblocking write end: Close's wake write must never block on a full
+	// pipe; a pending byte already guarantees the wake.
+	if err := unix.SetNonblock(pipeFds[1], true); err != nil {
+		closeAll()
+		return nil, fmt.Errorf("configure ancestor wake pipe: %w", err)
+	}
+	// Register the wake pipe before run() blocks so Close can interrupt the
+	// blocked Kevent deterministically.
+	shutdown := unix.Kevent_t{}
+	unix.SetKevent(&shutdown, pipeFds[0], unix.EVFILT_READ, unix.EV_ADD)
+	if _, err := unix.Kevent(kq, []unix.Kevent_t{shutdown}, nil, nil); err != nil {
+		closeAll()
+		return nil, fmt.Errorf("register ancestor shutdown event: %w", err)
+	}
+	o := &vnodeObserver{
+		kq:        kq,
+		fds:       make(map[string]int),
+		paths:     make(map[int]string),
+		wake:      wake,
+		done:      make(chan struct{}),
+		wakeR:     pipeFds[0],
+		wakeW:     pipeFds[1],
+		closeDone: make(chan struct{}),
+	}
+	go o.run()
+	return o, nil
+}
+
+func (o *vnodeObserver) Add(path string) error {
+	path = filepath.Clean(path)
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.closed {
+		return fmt.Errorf("vnode observer closed")
+	}
+	if _, exists := o.fds[path]; exists {
+		return nil
+	}
+	fd, err := unix.Open(path, unix.O_EVTONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return fmt.Errorf("open ancestor %s: %w", path, err)
+	}
+	ev := unix.Kevent_t{}
+	unix.SetKevent(&ev, fd, unix.EVFILT_VNODE, unix.EV_ADD|unix.EV_CLEAR)
+	ev.Fflags = unix.NOTE_WRITE | unix.NOTE_DELETE |
+		unix.NOTE_RENAME | unix.NOTE_REVOKE
+	if _, err := unix.Kevent(o.kq, []unix.Kevent_t{ev}, nil, nil); err != nil {
+		_ = unix.Close(fd)
+		return fmt.Errorf("register ancestor %s: %w", path, err)
+	}
+	o.fds[path] = fd
+	o.paths[fd] = path
+	return nil
+}
+
+func (o *vnodeObserver) Remove(path string) error {
+	path = filepath.Clean(path)
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	fd, exists := o.fds[path]
+	if !exists {
+		return nil
+	}
+	delete(o.fds, path)
+	delete(o.paths, fd)
+	// Closing the fd removes its kevent registration.
+	return unix.Close(fd)
+}
+
+func (o *vnodeObserver) Close() error {
+	o.mu.Lock()
+	if o.closed {
+		o.mu.Unlock()
+		<-o.closeDone
+		return nil
+	}
+	o.closed = true
+	o.mu.Unlock()
+	defer close(o.closeDone)
+
+	// Wake run()'s blocked Kevent through the self-pipe, retrying interrupted
+	// writes. EAGAIN means the pipe already holds an unread wake byte, so the
+	// wake is guaranteed either way; a pipe write to a descriptor we own has
+	// no other failure mode while the read end is open. Wait for run() to
+	// return before closing the descriptors it reads, so no in-flight event
+	// fires after shutdown.
+	for {
+		if _, err := unix.Write(o.wakeW, []byte{0}); err != unix.EINTR {
+			break
+		}
+	}
+	<-o.done
+
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	for path, fd := range o.fds {
+		_ = unix.Close(fd)
+		delete(o.fds, path)
+		delete(o.paths, fd)
+	}
+	_ = unix.Close(o.wakeR)
+	_ = unix.Close(o.wakeW)
+	if err := unix.Close(o.kq); err != nil {
+		return fmt.Errorf("closing ancestor kqueue: %w", err)
+	}
+	return nil
+}
+
+func (o *vnodeObserver) watchedCount() int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return len(o.fds)
+}
+
+func (o *vnodeObserver) run() {
+	defer close(o.done)
+	events := make([]unix.Kevent_t, 8)
+	for {
+		n, err := unix.Kevent(o.kq, nil, events, nil)
+		if err == unix.EINTR {
+			continue
+		}
+		if err != nil {
+			return // kq closed
+		}
+		shutdown := false
+		vnodeEvents := false
+		for i := range n {
+			if events[i].Filter == unix.EVFILT_READ &&
+				int(events[i].Ident) == o.wakeR {
+				shutdown = true
+			} else {
+				vnodeEvents = true
+			}
+		}
+		if vnodeEvents {
+			o.wake()
+		}
+		if shutdown {
+			return
+		}
+	}
+}

--- a/internal/sync/vnode_observer_darwin_test.go
+++ b/internal/sync/vnode_observer_darwin_test.go
@@ -1,0 +1,118 @@
+//go:build darwin && cgo
+
+package sync
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVnodeObserverWakesOnEntryCreation(t *testing.T) {
+	dir := t.TempDir()
+	woke := make(chan struct{}, 1)
+	o, err := newVnodeObserver(func() {
+		select {
+		case woke <- struct{}{}:
+		default:
+		}
+	})
+	require.NoError(t, err)
+	defer o.Close()
+	require.NoError(t, o.Add(dir))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "child"), 0o755))
+	select {
+	case <-woke:
+	case <-time.After(30 * time.Second):
+		t.Fatal("no wake after directory entry creation")
+	}
+}
+
+func TestVnodeObserverUsesOneDescriptorRegardlessOfEntries(t *testing.T) {
+	dir := t.TempDir()
+	for i := range 200 {
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, fmt.Sprintf("f%03d", i)), nil, 0o644))
+	}
+	o, err := newVnodeObserver(func() {})
+	require.NoError(t, err)
+	defer o.Close()
+	require.NoError(t, o.Add(dir))
+	assert.Equal(t, 1, o.watchedCount(),
+		"observer must hold one descriptor per directory, not per entry")
+}
+
+// TestVnodeObserverCloseInterruptsBlockedRun proves Close synchronizes with the
+// run loop: it writes the self-pipe wake so the blocked Kevent returns, Close
+// waits for run() to exit, and no goroutine is left blocked on the kqueue.
+func TestVnodeObserverCloseInterruptsBlockedRun(t *testing.T) {
+	dir := t.TempDir()
+	o, err := newVnodeObserver(func() {})
+	require.NoError(t, err)
+	require.NoError(t, o.Add(dir))
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- o.Close() }()
+	select {
+	case err := <-closeDone:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("Close did not return; the blocked run loop was not interrupted")
+	}
+	select {
+	case <-o.done:
+	case <-time.After(time.Second):
+		t.Fatal("run loop still active after Close returned")
+	}
+}
+
+// TestVnodeObserverConcurrentCloseWaitsForTeardown proves a concurrent second
+// Close does not return before the first finishes: every Close returns only
+// after run() exited and the descriptors are torn down.
+func TestVnodeObserverConcurrentCloseWaitsForTeardown(t *testing.T) {
+	dir := t.TempDir()
+	o, err := newVnodeObserver(func() {})
+	require.NoError(t, err)
+	require.NoError(t, o.Add(dir))
+
+	const closers = 4
+	results := make(chan error, closers)
+	for range closers {
+		go func() { results <- o.Close() }()
+	}
+	for range closers {
+		select {
+		case err := <-results:
+			require.NoError(t, err)
+			select {
+			case <-o.done:
+			default:
+				t.Fatal("Close returned while the run loop was still active")
+			}
+			select {
+			case <-o.closeDone:
+			default:
+				t.Fatal("Close returned before teardown completed")
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatal("concurrent Close did not return")
+		}
+	}
+	assert.Equal(t, 0, o.watchedCount())
+}
+
+func TestVnodeObserverRemoveAndCloseAreIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	o, err := newVnodeObserver(func() {})
+	require.NoError(t, err)
+	require.NoError(t, o.Add(dir))
+	require.NoError(t, o.Remove(dir))
+	require.NoError(t, o.Remove(dir)) // second remove is a no-op
+	require.NoError(t, o.Close())
+	require.NoError(t, o.Close())
+}

--- a/internal/sync/watch_backend.go
+++ b/internal/sync/watch_backend.go
@@ -1,0 +1,183 @@
+package sync
+
+import "slices"
+
+// WatchScope identifies one configured provider root whose changes are covered
+// by a logical watcher root. A physical root may cover multiple configured
+// directories or providers, so registration must preserve every exact scope.
+type WatchScope struct {
+	Agent   string
+	SyncDir string
+}
+
+// WatchRoot is one desired logical watcher root. Exists describes startup
+// state, not whether the root remains desired: missing roots stay in the plan
+// so a lifecycle-aware backend can establish ancestor coverage later.
+type WatchRoot struct {
+	Path      string
+	Recursive bool
+	Exists    bool
+	Scopes    []WatchScope
+}
+
+// RegisterRoots passes the complete desired root plan to the watcher before
+// its backend starts. The current fsnotify backend activates existing roots;
+// later lifecycle-aware backends can also retain pending missing roots without
+// changing the daemon-side plan contract.
+func (w *Watcher) RegisterRoots(
+	roots []WatchRoot,
+	recursiveBudget int,
+) []RecursiveWatchResult {
+	for _, root := range roots {
+		for _, scope := range root.Scopes {
+			if scope.SyncDir != "" {
+				w.registeredSyncRoots = append(w.registeredSyncRoots, scope.SyncDir)
+			}
+		}
+	}
+	slices.Sort(w.registeredSyncRoots)
+	w.registeredSyncRoots = slices.Compact(w.registeredSyncRoots)
+	if observer, ok := w.backend.(watchRootPlanObserver); ok {
+		observer.setWatchRootPlan(roots)
+	}
+	if backend, ok := w.backend.(completeRootPlanBackend); ok {
+		for _, root := range roots {
+			agents := make([]string, 0, len(root.Scopes))
+			for _, scope := range root.Scopes {
+				if scope.Agent != "" && !slices.Contains(agents, scope.Agent) {
+					agents = append(agents, scope.Agent)
+				}
+			}
+			w.SetRootAgents(root.Path, agents)
+		}
+		return backend.RegisterRoots(roots, recursiveBudget)
+	}
+	results := make([]RecursiveWatchResult, len(roots))
+	remaining := recursiveBudget
+	for i, root := range roots {
+		agents := make([]string, 0, len(root.Scopes))
+		for _, scope := range root.Scopes {
+			if scope.Agent != "" && !slices.Contains(agents, scope.Agent) {
+				agents = append(agents, scope.Agent)
+			}
+		}
+		w.SetRootAgents(root.Path, agents)
+		if !root.Exists {
+			continue
+		}
+		if !root.Recursive {
+			err := w.backend.AddShallow(root.Path)
+			results[i].Err = err
+			if err == nil {
+				results[i].Watched = 1
+			} else {
+				results[i].Unwatched = 1
+			}
+			continue
+		}
+		results[i] = w.backend.AddRecursive(root.Path, remaining)
+		remaining -= results[i].Watched
+	}
+	return results
+}
+
+type backendItemType uint8
+
+const (
+	backendItemUnknown backendItemType = iota
+	backendItemFile
+	backendItemDirectory
+)
+
+type backendOp uint8
+
+const backendOpUnknown backendOp = 0
+
+const (
+	backendOpCreate backendOp = 1 << iota
+	backendOpWrite
+	backendOpRemove
+	backendOpRename
+	backendOpReconcileRootChange
+	backendOpFullSync
+)
+
+type backendEvent struct {
+	Path      string
+	Root      string
+	Op        backendOp
+	ItemType  backendItemType
+	Lifecycle backendLifecycleToken
+}
+
+type backendLifecycleGate interface {
+	acknowledgeLifecycle(uint64)
+}
+
+type backendLifecycleToken struct {
+	gate       backendLifecycleGate
+	generation uint64
+}
+
+func (t backendLifecycleToken) valid() bool { return t.gate != nil }
+
+type watchBackend interface {
+	Events() <-chan backendEvent
+	Errors() <-chan error
+	AddRecursive(root string, budget int) RecursiveWatchResult
+	AddShallow(root string) error
+	Remove(root string) error
+	Start() error
+	Stop()
+	Name() string
+}
+
+// directBackendEventSink lets a native callback publish a complete native
+// delivery through the watcher's bounded handoff. Implementations must return
+// promptly without waiting for consumer ownership. Capacity overflow becomes
+// one authoritative full-sync marker; ordinary consumer activity does not.
+// Control workers use RetainAuthoritative when the marker must carry a durable
+// lifecycle acknowledgement token.
+type directBackendEventSink interface {
+	TryAccumulate(func(add func(backendEvent) bool) bool) bool
+	RetainAuthoritative(backendLifecycleToken)
+}
+
+// directEventBackend is implemented by backends whose native delivery already
+// provides burst coalescing. Binding the direct sink also tells Watcher not to
+// add its Go batch delay after the native latency; the dispatch floor remains.
+type directEventBackend interface {
+	bindEventSink(directBackendEventSink)
+}
+
+// coverageDegradationBackend accepts runtime roots that must be transferred to
+// a completeness backstop before native recursive coverage can be retired.
+type coverageDegradationBackend interface {
+	bindCoverageDegraded(func([]string) error)
+}
+
+// watchRootPlanObserver retains logical-root to configured-scope ownership for
+// backends that can lose coverage after startup and must transfer the exact
+// affected scopes to polling.
+type watchRootPlanObserver interface {
+	setWatchRootPlan([]WatchRoot)
+}
+
+// createdSubtreePathFilter marks portable backends whose directory-create
+// events need a bounded userspace walk to surface files that existed before
+// the new subtree entered a watched root. Native direct-callback backends do
+// not implement this contract, so their callbacks never perform filesystem
+// work.
+type createdSubtreePathFilter interface {
+	shouldEnumerateCreatedSubtree(root, path string) bool
+	includeCreatedSubtreePath(root, path string) bool
+}
+
+// pollingOwnershipBackend reports independently keyed polling obligations so
+// overlapping configured roots cannot release one another's coverage.
+type pollingOwnershipBackend interface {
+	bindPollingOwnership(
+		func(PollingObligation) error,
+		func(string) error,
+	)
+}

--- a/internal/sync/watch_backend_factory_darwin.go
+++ b/internal/sync/watch_backend_factory_darwin.go
@@ -726,7 +726,14 @@ func translateFSEvent(root string, event fsevents.Event) (backendEvent, bool) {
 }
 
 func (b *darwinWatchBackend) forwardKqueue() {
-	defer b.finish()
+	// The lifecycle goroutine also produces on b.errors, so the shared output
+	// channels must not close until it has exited. Start always launches the
+	// lifecycle goroutine before this one, and Stop closes b.stop, so the join
+	// below cannot block forever.
+	defer func() {
+		<-b.lifecycleDone
+		b.finish()
+	}()
 	events := b.kqueue.Events()
 	errorsCh := b.kqueue.Errors()
 	for events != nil || errorsCh != nil {

--- a/internal/sync/watch_backend_factory_darwin.go
+++ b/internal/sync/watch_backend_factory_darwin.go
@@ -1,0 +1,2003 @@
+//go:build darwin && cgo
+
+package sync
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.kenn.io/agentsview/internal/fsevents"
+)
+
+const (
+	darwinFSEventsLatency = 500 * time.Millisecond
+
+	fseventFlagMustScanSubDirs fsevents.EventFlags = 0x00000001
+	fseventFlagUserDropped     fsevents.EventFlags = 0x00000002
+	fseventFlagKernelDropped   fsevents.EventFlags = 0x00000004
+	fseventFlagEventIDsWrapped fsevents.EventFlags = 0x00000008
+	fseventFlagRootChanged     fsevents.EventFlags = 0x00000020
+	fseventFlagItemCreated     fsevents.EventFlags = 0x00000100
+	fseventFlagItemRemoved     fsevents.EventFlags = 0x00000200
+	fseventFlagItemRenamed     fsevents.EventFlags = 0x00000800
+	fseventFlagItemModified    fsevents.EventFlags = 0x00001000
+	fseventFlagItemIsFile      fsevents.EventFlags = 0x00010000
+	fseventFlagItemIsDir       fsevents.EventFlags = 0x00020000
+)
+
+const darwinRootSignalLoss uint32 = 1
+
+const (
+	darwinRetryInitial       = 100 * time.Millisecond
+	darwinRetryMax           = 5 * time.Second
+	darwinFallbackPollingKey = "watcher-fallback"
+)
+
+// darwinFallbackPollPlan preserves one physical watch plan's path-to-scope
+// mapping for global fallback polling. Each plan becomes its own polling
+// obligation with the physical path as Probe: a nested physical root (Gemini's
+// <root>/tmp) can be missing while its configured scope <root> exists, and a
+// probe on the collapsed scope roots would let authoritative reconciliation
+// tombstone every session under the absent subtree.
+type darwinFallbackPollPlan struct {
+	path  string
+	roots []string
+}
+
+// darwinFallbackPollingObligationKey names the per-plan fallback obligation so
+// each plan can be registered and released independently.
+func darwinFallbackPollingObligationKey(path string) string {
+	return darwinFallbackPollingKey + ":" + path
+}
+
+// appendFallbackPollPlan adds a plan's scope roots under its physical path,
+// merging into an existing entry for the same path.
+func appendFallbackPollPlan(
+	plans []darwinFallbackPollPlan, path string, scopes []WatchScope,
+) []darwinFallbackPollPlan {
+	roots := appendWatchScopeRoots(nil, scopes)
+	if len(roots) == 0 {
+		return plans
+	}
+	for i := range plans {
+		if plans[i].path == path {
+			merged := plans[i].roots
+			for _, root := range roots {
+				if !slices.Contains(merged, root) {
+					merged = append(merged, root)
+				}
+			}
+			slices.Sort(merged)
+			plans[i].roots = merged
+			return plans
+		}
+	}
+	plans = append(plans, darwinFallbackPollPlan{path: path, roots: roots})
+	slices.SortFunc(plans, func(a, b darwinFallbackPollPlan) int {
+		return strings.Compare(a.path, b.path)
+	})
+	return plans
+}
+
+type darwinBackendLifecycle uint8
+
+const (
+	darwinBackendNew darwinBackendLifecycle = iota
+	darwinBackendRunning
+	darwinBackendStopped
+)
+
+type darwinWatchRoot struct {
+	logicalPath string
+	nativePath  string
+	recursive   bool
+	state       *darwinLogicalRoot
+	generation  uint64
+}
+
+type darwinRootSnapshot struct {
+	roots []darwinWatchRoot
+}
+
+type darwinStream interface {
+	Start() error
+	Close() error
+}
+
+type darwinLogicalRoot struct {
+	plan              WatchRoot
+	active            bool
+	ancestor          string
+	stream            darwinStream
+	backend           *darwinWatchBackend
+	signal            atomic.Uint32
+	phase             darwinRootPhase
+	generation        uint64
+	acknowledged      atomic.Uint64
+	open              atomic.Bool
+	currentGeneration atomic.Uint64
+	lossRequested     bool
+	retryAt           time.Time
+	retryDelay        time.Duration
+}
+
+type darwinRootPhase uint8
+
+const (
+	darwinRootPending darwinRootPhase = iota
+	darwinRootLossCollecting
+	darwinRootActivationCollecting
+	darwinRootOpen
+	darwinRootPolling
+)
+
+type darwinFallbackPhase uint32
+
+const (
+	darwinFallbackInactive darwinFallbackPhase = iota
+	darwinFallbackCollecting
+	darwinFallbackReconciling
+	darwinFallbackOpen
+	darwinFallbackRecovering
+)
+
+type darwinFallbackReason uint32
+
+const (
+	darwinFallbackReasonNone darwinFallbackReason = iota
+	darwinFallbackStreamCreate
+	darwinFallbackStreamStart
+	darwinFallbackNativeDrop
+	darwinFallbackLifecycle
+	darwinFallbackKqueueStart
+)
+
+type darwinReconcileRequest struct {
+	scopes []WatchScope
+	token  backendLifecycleToken
+}
+
+func (s *darwinLogicalRoot) acknowledgeLifecycle(generation uint64) {
+	for {
+		current := s.acknowledged.Load()
+		if current >= generation || s.acknowledged.CompareAndSwap(current, generation) {
+			break
+		}
+	}
+	s.backend.signalLifecycle()
+}
+
+func (s *darwinLogicalRoot) isOpen(generation uint64) bool {
+	return s.open.Load() && generation == s.currentGeneration.Load()
+}
+
+type darwinWatchBackend struct {
+	kqueue   *fsnotifyBackend
+	queue    *fsevents.Queue
+	latency  time.Duration
+	excludes []string
+
+	events        chan backendEvent
+	errors        chan error
+	stop          chan struct{}
+	done          chan struct{}
+	lifecycleWake chan struct{}
+	lifecycleDone chan struct{}
+
+	sink               directBackendEventSink
+	onCoverageDegraded func([]string) error
+	onPollingRequired  func(PollingObligation) error
+	onPollingReleased  func(string) error
+
+	mu        sync.Mutex
+	lifecycle darwinBackendLifecycle
+	streams   map[string]darwinStream
+	logical   map[string]*darwinLogicalRoot
+	shallow   map[string]int
+	ancestors map[string]int
+	roots     atomic.Pointer[darwinRootSnapshot]
+
+	newStream              func(string, func([]fsevents.Event)) (darwinStream, error)
+	pathIsDirectory        func(string) bool
+	lstat                  func(string) (os.FileInfo, error)
+	stat                   func(string) (os.FileInfo, error)
+	addShallow             func(string) error
+	removeShallow          func(string) error
+	addAncestor            func(string) error
+	removeAncestor         func(string) error
+	vnode                  *vnodeObserver
+	startKqueue            func() error
+	transitions            sync.WaitGroup
+	workerStarted          bool
+	forwardStarted         bool
+	retryInitial           time.Duration
+	retryMax               time.Duration
+	fallbackPrepared       bool
+	fallbackPollPlans      []darwinFallbackPollPlan
+	fallbackRetryAt        time.Time
+	fallbackRetryDelay     time.Duration
+	fallbackDegradedLogged bool
+	fallbackPollingOwned   bool
+	fallbackPollingKeyed   bool
+	fallbackGeneration     uint64
+	fallbackAcknowledged   atomic.Uint64
+	fallbackReason         atomic.Uint32
+	fallbackPhase          atomic.Uint32
+	fallbackRecoveryFailed atomic.Bool
+	nativeOpen             atomic.Bool
+	fallbackEventsMu       sync.Mutex
+	fallbackEvents         map[backendEvent]struct{}
+	fallbackEventBytes     int
+	fallbackEventsFull     bool
+	nativeDrops            boundedCounter
+	pendingBatchOverflows  boundedCounter
+	rootTransitions        boundedCounter
+	fallbackActivations    boundedCounter
+
+	stopOnce   sync.Once
+	finishOnce sync.Once
+}
+
+// The created-subtree contract enables bounded discovery for directory-create
+// events forwarded by the kqueue fallback. Native FSEvents deliveries bypass
+// Watcher.loop through the direct sink, so this method never puts filesystem
+// work on the FSEvents callback queue.
+func (b *darwinWatchBackend) includeCreatedSubtreePath(root, path string) bool {
+	return !shouldExcludeForRoot(b.excludes, path, root)
+}
+
+func (b *darwinWatchBackend) shouldEnumerateCreatedSubtree(root, path string) bool {
+	snapshot := b.roots.Load()
+	owner, ok := snapshot.mostSpecificRoot(path)
+	return ok && owner.recursive && owner.logicalPath == filepath.Clean(root)
+}
+
+func newWatchBackend(excludes []string) (watchBackend, error) {
+	return newDarwinWatchBackend(excludes, darwinFSEventsLatency)
+}
+
+func newDarwinWatchBackend(
+	excludes []string,
+	latency time.Duration,
+) (*darwinWatchBackend, error) {
+	kqueue, err := newFSNotifyBackend(excludes)
+	if err != nil {
+		return nil, err
+	}
+	queue, err := fsevents.NewQueue()
+	if err != nil {
+		kqueue.Stop()
+		return nil, err
+	}
+	backend := &darwinWatchBackend{
+		kqueue:        kqueue,
+		queue:         queue,
+		latency:       latency,
+		excludes:      normalizeExcludePatterns(excludes),
+		events:        make(chan backendEvent),
+		errors:        make(chan error),
+		stop:          make(chan struct{}),
+		done:          make(chan struct{}),
+		lifecycleWake: make(chan struct{}, 1),
+		lifecycleDone: make(chan struct{}),
+		streams:       make(map[string]darwinStream),
+		logical:       make(map[string]*darwinLogicalRoot),
+		shallow:       make(map[string]int),
+		retryInitial:  darwinRetryInitial,
+		retryMax:      darwinRetryMax,
+	}
+	backend.newStream = func(root string, sink func([]fsevents.Event)) (darwinStream, error) {
+		return fsevents.NewStream(backend.queue, root, backend.latency, sink)
+	}
+	backend.lstat = os.Lstat
+	backend.stat = os.Stat
+	backend.pathIsDirectory = pathIsDirectory
+	backend.addShallow = backend.kqueue.AddShallow
+	backend.removeShallow = backend.kqueue.Remove
+	backend.ancestors = make(map[string]int)
+	backend.addAncestor = backend.observeAncestor
+	backend.removeAncestor = backend.unobserveAncestor
+	backend.startKqueue = backend.kqueue.Start
+	backend.fallbackEvents = make(map[backendEvent]struct{})
+	backend.nativeOpen.Store(true)
+	backend.roots.Store(&darwinRootSnapshot{})
+	return backend, nil
+}
+
+func (b *darwinWatchBackend) Events() <-chan backendEvent { return b.events }
+func (b *darwinWatchBackend) Errors() <-chan error        { return b.errors }
+
+func (b *darwinWatchBackend) bindEventSink(sink directBackendEventSink) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.sink = sink
+}
+
+func (b *darwinWatchBackend) bindCoverageDegraded(callback func([]string) error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.onCoverageDegraded = callback
+}
+
+func (b *darwinWatchBackend) bindPollingOwnership(
+	required func(PollingObligation) error,
+	released func(string) error,
+) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.onPollingRequired = required
+	b.onPollingReleased = released
+}
+
+func (b *darwinWatchBackend) fallbackPhaseValue() darwinFallbackPhase {
+	return darwinFallbackPhase(b.fallbackPhase.Load())
+}
+
+// RegisterRoots installs the complete provider-root plan. Missing logical
+// roots retain shallow coverage on only their nearest existing ancestor.
+func (b *darwinWatchBackend) RegisterRoots(
+	roots []WatchRoot,
+	recursiveBudget int,
+) []RecursiveWatchResult {
+	results := make([]RecursiveWatchResult, len(roots))
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	isDirectory := b.pathIsDirectory
+	if isDirectory == nil {
+		isDirectory = pathIsDirectory
+	}
+	streamCreationFailed := false
+	for i, plan := range roots {
+		plan.Path = filepath.Clean(plan.Path)
+		plan.Scopes = append([]WatchScope(nil), plan.Scopes...)
+		if b.lifecycle == darwinBackendStopped {
+			results[i] = RecursiveWatchResult{
+				Unwatched: 1, Err: errors.New("darwin watch backend is stopped"),
+			}
+			continue
+		}
+		if _, exists := b.logical[plan.Path]; exists {
+			results[i].Watched = 1
+			continue
+		}
+		state := &darwinLogicalRoot{plan: plan, backend: b}
+		b.logical[plan.Path] = state
+		if isDirectory(plan.Path) {
+			if streamCreationFailed && plan.Recursive {
+				continue
+			}
+			if err := b.activateRootLocked(state); err != nil {
+				if plan.Recursive {
+					streamCreationFailed = true
+					b.requestFallback(darwinFallbackStreamCreate)
+					continue
+				}
+				delete(b.logical, plan.Path)
+				results[i] = RecursiveWatchResult{Unwatched: 1, Err: err}
+				continue
+			}
+			results[i] = RecursiveWatchResult{
+				Watched:                   1,
+				MissingRootLifecycleOwned: !plan.Exists,
+			}
+			continue
+		}
+		ancestor := nearestExistingAncestor(plan.Path)
+		if ancestor == "" {
+			delete(b.logical, plan.Path)
+			results[i] = RecursiveWatchResult{
+				Unwatched: 1, Err: fmt.Errorf("no existing ancestor for %q", plan.Path),
+			}
+			continue
+		}
+		if err := b.acquireAncestorLocked(ancestor); err != nil {
+			delete(b.logical, plan.Path)
+			results[i] = RecursiveWatchResult{Unwatched: 1, Err: err}
+			continue
+		}
+		state.ancestor = ancestor
+		results[i] = RecursiveWatchResult{
+			Watched:                   1,
+			MissingRootLifecycleOwned: true,
+		}
+	}
+	if streamCreationFailed {
+		b.prepareStartupFallbackLocked(roots, results)
+	}
+	return results
+}
+
+func (b *darwinWatchBackend) prepareStartupFallbackLocked(
+	roots []WatchRoot,
+	results []RecursiveWatchResult,
+) {
+	for root, stream := range b.streams {
+		_ = stream.Close()
+		delete(b.streams, root)
+		b.removeRootLocked(root, true)
+	}
+	var pollPlans []darwinFallbackPollPlan
+	for i, plan := range roots {
+		plan.Path = filepath.Clean(plan.Path)
+		if !plan.Recursive {
+			continue
+		}
+		pollPlans = appendFallbackPollPlan(pollPlans, plan.Path, plan.Scopes)
+		results[i] = RecursiveWatchResult{Watched: 1}
+		state := b.logical[plan.Path]
+		if state != nil {
+			state.active = false
+			state.stream = nil
+			state.open.Store(false)
+		}
+	}
+	b.fallbackPrepared = true
+	b.fallbackPollPlans = pollPlans
+	b.fallbackPhase.Store(uint32(darwinFallbackCollecting))
+	b.nativeOpen.Store(false)
+}
+
+func (b *darwinWatchBackend) AddRecursive(root string, _ int) RecursiveWatchResult {
+	root = filepath.Clean(root)
+	nativeRoot := canonicalWatchRoot(root)
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.lifecycle == darwinBackendStopped {
+		return RecursiveWatchResult{Unwatched: 1, Err: errors.New("darwin watch backend is stopped")}
+	}
+	if _, exists := b.streams[root]; exists {
+		return RecursiveWatchResult{Watched: 1}
+	}
+	registration := darwinWatchRoot{
+		logicalPath: root,
+		nativePath:  nativeRoot,
+		recursive:   true,
+	}
+	stream, err := b.newStream(root, func(events []fsevents.Event) {
+		b.consumeFSEvents(registration, events)
+	})
+	if err != nil {
+		return RecursiveWatchResult{Unwatched: 1, Err: err}
+	}
+	b.streams[root] = stream
+	b.storeRootLocked(registration)
+	if b.lifecycle == darwinBackendRunning {
+		if err := stream.Start(); err != nil {
+			delete(b.streams, root)
+			b.removeRootLocked(root, true)
+			_ = stream.Close()
+			return RecursiveWatchResult{Unwatched: 1, Err: err}
+		}
+	}
+	return RecursiveWatchResult{Watched: 1}
+}
+
+func (b *darwinWatchBackend) AddShallow(root string) error {
+	root = filepath.Clean(root)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.lifecycle == darwinBackendStopped {
+		return errors.New("darwin watch backend is stopped")
+	}
+	if err := b.acquireShallowLocked(root); err != nil {
+		return err
+	}
+	b.storeRootLocked(darwinWatchRoot{
+		logicalPath: root,
+		nativePath:  canonicalWatchRoot(root),
+	})
+	return nil
+}
+
+func (b *darwinWatchBackend) Remove(root string) error {
+	root = filepath.Clean(root)
+	b.mu.Lock()
+	stream := b.streams[root]
+	if stream != nil {
+		delete(b.streams, root)
+		b.removeRootLocked(root, true)
+		b.mu.Unlock()
+		return stream.Close()
+	}
+	b.removeRootLocked(root, false)
+	err := b.releaseShallowLocked(root)
+	b.mu.Unlock()
+	return err
+}
+
+func (b *darwinWatchBackend) Start() error {
+	b.mu.Lock()
+	if b.lifecycle == darwinBackendRunning {
+		b.mu.Unlock()
+		return nil
+	}
+	if b.lifecycle == darwinBackendStopped {
+		b.mu.Unlock()
+		return errors.New("darwin watch backend is stopped")
+	}
+	if b.sink == nil {
+		b.mu.Unlock()
+		return errors.New("darwin watch backend has no event sink")
+	}
+	b.lifecycle = darwinBackendRunning
+	b.workerStarted = true
+	go b.lifecycleLoop()
+	kqueueErr := b.startKqueue()
+	if kqueueErr == nil {
+		b.forwardStarted = true
+		go b.forwardKqueue()
+	} else {
+		if b.fallbackPrepared {
+			for _, state := range b.logical {
+				b.fallbackPollPlans = appendFallbackPollPlan(
+					b.fallbackPollPlans, state.plan.Path, state.plan.Scopes,
+				)
+			}
+		}
+		previous := darwinFallbackReason(b.fallbackReason.Swap(
+			uint32(darwinFallbackKqueueStart),
+		))
+		if previous == darwinFallbackReasonNone {
+			b.fallbackActivations.Inc()
+		}
+		b.signalLifecycle()
+	}
+	if b.fallbackPhaseValue() == darwinFallbackInactive {
+		b.nativeOpen.Store(true)
+	}
+	for _, stream := range b.streams {
+		if err := stream.Start(); err != nil {
+			b.requestFallback(darwinFallbackStreamStart)
+			break
+		}
+	}
+	b.mu.Unlock()
+	b.signalLifecycle()
+	return nil
+}
+
+func (b *darwinWatchBackend) Stop() {
+	b.stopOnce.Do(func() {
+		b.mu.Lock()
+		wasRunning := b.lifecycle == darwinBackendRunning
+		workerStarted := b.workerStarted
+		forwardStarted := b.forwardStarted
+		b.lifecycle = darwinBackendStopped
+		streams := make([]darwinStream, 0, len(b.streams))
+		for _, stream := range b.streams {
+			streams = append(streams, stream)
+		}
+		clear(b.streams)
+		close(b.stop)
+		b.mu.Unlock()
+
+		for _, stream := range streams {
+			_ = stream.Close()
+		}
+		b.kqueue.Stop()
+		if b.vnode != nil {
+			_ = b.vnode.Close()
+		}
+		b.transitions.Wait()
+		if workerStarted {
+			<-b.lifecycleDone
+		}
+		if !wasRunning || !forwardStarted {
+			b.finish()
+		}
+	})
+	<-b.done
+}
+
+func (b *darwinWatchBackend) Name() string { return "fsevents+kqueue" }
+
+func (b *darwinWatchBackend) consumeFSEvents(
+	registration darwinWatchRoot,
+	events []fsevents.Event,
+) {
+	if nativeDeliveryRequestsFallback(events) {
+		b.nativeDrops.Inc()
+		b.requestFallback(darwinFallbackNativeDrop)
+		return
+	}
+	if !b.nativeOpen.Load() && b.fallbackPhaseValue() != darwinFallbackInactive {
+		return
+	}
+	if registration.state != nil && nativeDeliveryReportsRootLoss(registration, events) {
+		if b.fallbackPhaseValue() == darwinFallbackRecovering {
+			b.requestFallback(darwinFallbackLifecycle)
+			return
+		}
+		registration.state.signal.Or(darwinRootSignalLoss)
+		b.signalLifecycle()
+		return
+	}
+	sink := b.sink
+	if sink == nil {
+		return
+	}
+	if registration.state != nil &&
+		!registration.state.isOpen(registration.generation) {
+		b.accumulateReconcile(registration.state.plan.Scopes, backendLifecycleToken{
+			gate: registration.state, generation: registration.generation,
+		})
+		return
+	}
+	sink.TryAccumulate(func(add func(backendEvent) bool) bool {
+		meaningful := false
+		snapshot := b.roots.Load()
+		for _, event := range events {
+			event.Path = logicalFSEventPath(registration, event.Path)
+			translated, relevant := translateFSEvent(registration.logicalPath, event)
+			if !relevant {
+				continue
+			}
+			owner, ok := snapshot.mostSpecificRecursiveRoot(translated.Path)
+			if !ok || !owner.recursive || owner.logicalPath != registration.logicalPath {
+				continue
+			}
+			if translated.Op&backendOpReconcileRootChange == 0 &&
+				shouldExcludeForRoot(b.excludes, translated.Path, owner.logicalPath) {
+				continue
+			}
+			// FSEvents accompanies descendant changes with an ordinary modified
+			// event for the watched directory itself. The descendant file event is
+			// the changed-path work; retaining the root event would defeat subtree
+			// exclusions and schedule redundant root scans. Authoritative
+			// RootChanged events already map to reconciliation and remain intact.
+			if translated.Path == owner.logicalPath &&
+				translated.Op&backendOpReconcileRootChange == 0 {
+				continue
+			}
+			translated.Root = owner.logicalPath
+			meaningful = true
+			if !add(translated) {
+				return true
+			}
+		}
+		return meaningful
+	})
+}
+
+func nativeDeliveryRequestsFallback(events []fsevents.Event) bool {
+	for _, event := range events {
+		if event.Flags&(fseventFlagMustScanSubDirs|
+			fseventFlagUserDropped|
+			fseventFlagKernelDropped|
+			fseventFlagEventIDsWrapped) != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// translateFSEvent maps a native FSEvents delivery to a backend event. Drop
+// and rescan flags never reach translation: consumeFSEvents diverts them to
+// fallback via nativeDeliveryRequestsFallback before translating.
+func translateFSEvent(root string, event fsevents.Event) (backendEvent, bool) {
+	flags := event.Flags
+	itemType := backendItemUnknown
+	switch {
+	case flags&fseventFlagItemIsFile != 0:
+		itemType = backendItemFile
+	case flags&fseventFlagItemIsDir != 0:
+		itemType = backendItemDirectory
+	}
+	if flags&fseventFlagRootChanged != 0 {
+		return backendEvent{
+			Path:     filepath.Clean(event.Path),
+			Root:     filepath.Clean(root),
+			Op:       backendOpReconcileRootChange,
+			ItemType: itemType,
+		}, true
+	}
+
+	var op backendOp
+	if flags&fseventFlagItemCreated != 0 {
+		op |= backendOpCreate
+	}
+	if flags&fseventFlagItemModified != 0 {
+		op |= backendOpWrite
+	}
+	if flags&fseventFlagItemRemoved != 0 {
+		op |= backendOpRemove
+	}
+	if flags&fseventFlagItemRenamed != 0 {
+		op |= backendOpRename
+	}
+	if op == backendOpUnknown {
+		return backendEvent{}, false
+	}
+	return backendEvent{
+		Path:     filepath.Clean(event.Path),
+		Root:     filepath.Clean(root),
+		Op:       op,
+		ItemType: itemType,
+	}, true
+}
+
+func (b *darwinWatchBackend) forwardKqueue() {
+	defer b.finish()
+	events := b.kqueue.Events()
+	errorsCh := b.kqueue.Errors()
+	for events != nil || errorsCh != nil {
+		select {
+		case <-b.stop:
+			return
+		case event, ok := <-events:
+			if !ok {
+				events = nil
+				continue
+			}
+			event, dispatch := b.handleKqueueEvent(event)
+			if dispatch {
+				select {
+				case b.events <- event:
+				case <-b.stop:
+					return
+				}
+			}
+		case err, ok := <-errorsCh:
+			if !ok {
+				errorsCh = nil
+				continue
+			}
+			select {
+			case b.errors <- err:
+			case <-b.stop:
+				return
+			}
+		}
+	}
+}
+
+func nativeDeliveryReportsRootLoss(
+	registration darwinWatchRoot,
+	events []fsevents.Event,
+) bool {
+	for _, event := range events {
+		if event.Flags&fseventFlagRootChanged != 0 {
+			return true
+		}
+		path := logicalFSEventPath(registration, event.Path)
+		if filepath.Clean(path) == registration.logicalPath &&
+			event.Flags&(fseventFlagItemRemoved|fseventFlagItemRenamed) != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func (b *darwinWatchBackend) signalLifecycle() {
+	select {
+	case b.lifecycleWake <- struct{}{}:
+	default:
+	}
+}
+
+func (b *darwinWatchBackend) requestFallback(reason darwinFallbackReason) {
+	if reason == darwinFallbackReasonNone {
+		return
+	}
+	if b.fallbackPhaseValue() == darwinFallbackRecovering {
+		b.fallbackRecoveryFailed.Store(true)
+		b.signalLifecycle()
+		return
+	}
+	if b.fallbackReason.CompareAndSwap(
+		uint32(darwinFallbackReasonNone), uint32(reason),
+	) {
+		b.fallbackActivations.Inc()
+		b.signalLifecycle()
+	}
+}
+
+func (b *darwinWatchBackend) acknowledgeLifecycle(generation uint64) {
+	for {
+		current := b.fallbackAcknowledged.Load()
+		if current >= generation ||
+			b.fallbackAcknowledged.CompareAndSwap(current, generation) {
+			break
+		}
+	}
+	b.signalLifecycle()
+}
+
+func (b *darwinWatchBackend) lifecycleLoop() {
+	defer close(b.lifecycleDone)
+	for {
+		delay, retry := b.nextLifecycleRetry()
+		var timer *time.Timer
+		var timerC <-chan time.Time
+		if retry {
+			timer = time.NewTimer(delay)
+			timerC = timer.C
+		}
+		select {
+		case <-b.stop:
+			if timer != nil {
+				timer.Stop()
+			}
+			return
+		case <-b.lifecycleWake:
+			if timer != nil {
+				timer.Stop()
+			}
+			b.processLifecycleSignals()
+		case <-timerC:
+			b.processLifecycleRetry()
+		}
+	}
+}
+
+func (b *darwinWatchBackend) processLifecycleSignals() {
+	b.processLifecycle(true)
+}
+
+func (b *darwinWatchBackend) processLifecycleRetry() {
+	b.processLifecycle(false)
+}
+
+func (b *darwinWatchBackend) processLifecycle(checkPending bool) {
+	if b.processFallbackTransition() {
+		return
+	}
+	var requests []darwinReconcileRequest
+	var releasedPolling []string
+	now := time.Now()
+	b.mu.Lock()
+	if b.lifecycle == darwinBackendStopped {
+		b.mu.Unlock()
+		return
+	}
+	for _, state := range b.logical {
+		lossSignaled := state.signal.Swap(0)&darwinRootSignalLoss != 0
+		if lossSignaled {
+			state.lossRequested = true
+		}
+		if state.lossRequested && state.active &&
+			(lossSignaled || b.retryDueLocked(state, now)) {
+			ancestor := nearestExistingAncestor(filepath.Dir(state.plan.Path))
+			if ancestor == "" {
+				requests = append(requests, darwinReconcileRequest{scopes: state.plan.Scopes})
+				b.scheduleRetryLocked(state, now)
+				continue
+			}
+			if err := b.acquireAncestorLocked(ancestor); err != nil {
+				b.reportErrorLocked(fmt.Errorf("cover lost watch root: %w", err))
+				b.requestFallback(darwinFallbackLifecycle)
+				requests = append(requests, darwinReconcileRequest{scopes: state.plan.Scopes})
+				b.scheduleRetryLocked(state, now)
+				continue
+			}
+			if err := b.installRootPollingLocked(state); err != nil {
+				b.reportErrorLocked(fmt.Errorf(
+					"install polling coverage for lost root %s: %w",
+					state.plan.Path, err,
+				))
+				b.requestFallback(darwinFallbackLifecycle)
+				requests = append(requests, darwinReconcileRequest{scopes: state.plan.Scopes})
+				b.scheduleRetryLocked(state, now)
+				continue
+			}
+			oldAncestor := state.ancestor
+			stream := state.stream
+			state.active = false
+			state.ancestor = ancestor
+			state.stream = nil
+			state.lossRequested = false
+			state.generation++
+			state.currentGeneration.Store(state.generation)
+			state.open.Store(false)
+			state.phase = darwinRootLossCollecting
+			b.rootTransitions.Inc()
+			if state.plan.Recursive {
+				delete(b.streams, state.plan.Path)
+				b.removeRootLocked(state.plan.Path, true)
+			} else {
+				b.removeRootLocked(state.plan.Path, false)
+				if oldAncestor != "" {
+					_ = b.releaseShallowLocked(oldAncestor)
+				}
+			}
+			if stream != nil {
+				_ = stream.Close()
+			}
+			token := backendLifecycleToken{gate: state, generation: state.generation}
+			requests = append(requests, darwinReconcileRequest{
+				scopes: state.plan.Scopes, token: token,
+			})
+			b.scheduleRetryLocked(state, now)
+			continue
+		}
+
+		if state.phase == darwinRootLossCollecting {
+			if state.acknowledged.Load() >= state.generation {
+				state.phase = darwinRootPending
+				b.resetRetryLocked(state)
+			} else if b.retryDueLocked(state, now) {
+				requests = append(requests, darwinReconcileRequest{
+					scopes: state.plan.Scopes,
+					token:  backendLifecycleToken{gate: state, generation: state.generation},
+				})
+				b.scheduleRetryLocked(state, now)
+			}
+			if state.phase == darwinRootLossCollecting {
+				continue
+			}
+		}
+		if state.phase == darwinRootActivationCollecting &&
+			state.acknowledged.Load() >= state.generation {
+			state.phase = darwinRootOpen
+			b.rootTransitions.Inc()
+			state.open.Store(true)
+			b.resetRetryLocked(state)
+			releasedPolling = append(releasedPolling, state.plan.Path)
+		}
+		if state.phase == darwinRootActivationCollecting {
+			if b.retryDueLocked(state, now) {
+				requests = append(requests, darwinReconcileRequest{
+					scopes: state.plan.Scopes,
+					token:  backendLifecycleToken{gate: state, generation: state.generation},
+				})
+				b.scheduleRetryLocked(state, now)
+			}
+			continue
+		}
+		if state.phase != darwinRootPending ||
+			(!checkPending && !b.retryDueLocked(state, now)) {
+			continue
+		}
+
+		info, lstatErr := b.lstat(state.plan.Path)
+		if lstatErr == nil && state.plan.Recursive && info.Mode()&os.ModeSymlink != 0 {
+			if b.requireRootPollingLocked(state, now) {
+				requests = append(requests, darwinReconcileRequest{scopes: state.plan.Scopes})
+			}
+			continue
+		}
+		ancestor := nearestExistingAncestor(state.plan.Path)
+		if ancestor == "" ||
+			(ancestor == state.ancestor && ancestor != state.plan.Path) {
+			b.schedulePendingRetryLocked(state, now)
+			continue
+		}
+		old := state.ancestor
+		if ancestor == state.plan.Path {
+			linkInfo, linkErr := b.lstat(state.plan.Path)
+			if linkErr == nil && state.plan.Recursive &&
+				linkInfo.Mode()&os.ModeSymlink != 0 {
+				if b.requireRootPollingLocked(state, now) {
+					requests = append(requests, darwinReconcileRequest{scopes: state.plan.Scopes})
+				}
+				continue
+			}
+			info, statErr := b.stat(state.plan.Path)
+			if statErr != nil || !info.IsDir() {
+				b.schedulePendingRetryLocked(state, now)
+				continue
+			}
+			if err := b.activateRootLocked(state); err != nil {
+				b.reportErrorLocked(fmt.Errorf("activate watch root: %w", err))
+				b.requestFallback(darwinFallbackLifecycle)
+				requests = append(requests, darwinReconcileRequest{scopes: state.plan.Scopes})
+				b.scheduleRetryLocked(state, now)
+				continue
+			}
+			requests = append(requests, darwinReconcileRequest{
+				scopes: state.plan.Scopes,
+				token:  backendLifecycleToken{gate: state, generation: state.generation},
+			})
+			b.scheduleRetryLocked(state, now)
+		} else {
+			if err := b.acquireAncestorLocked(ancestor); err != nil {
+				b.reportErrorLocked(fmt.Errorf("advance watch root: %w", err))
+				b.requestFallback(darwinFallbackLifecycle)
+				requests = append(requests, darwinReconcileRequest{scopes: state.plan.Scopes})
+				b.scheduleRetryLocked(state, now)
+				continue
+			}
+			state.ancestor = ancestor
+			requests = append(requests, darwinReconcileRequest{scopes: state.plan.Scopes})
+			b.schedulePendingRetryLocked(state, now)
+		}
+		if old != "" {
+			_ = b.releaseAncestorLocked(old)
+		}
+	}
+	releaseCallback := b.onPollingReleased
+	b.mu.Unlock()
+	if releaseCallback != nil {
+		for _, key := range releasedPolling {
+			if err := releaseCallback(key); err != nil {
+				log.Printf("watcher: release polling obligation %q: %v", key, err)
+			}
+		}
+	}
+	for _, request := range requests {
+		b.accumulateReconcile(request.scopes, request.token)
+	}
+}
+
+func (b *darwinWatchBackend) requireRootPollingLocked(
+	state *darwinLogicalRoot,
+	now time.Time,
+) bool {
+	if err := b.installRootPollingLocked(state); err != nil {
+		b.reportErrorLocked(fmt.Errorf("install polling coverage for %s: %w", state.plan.Path, err))
+		b.schedulePendingRetryLocked(state, now)
+		return false
+	}
+	state.phase = darwinRootPolling
+	b.resetRetryLocked(state)
+	return true
+}
+
+func (b *darwinWatchBackend) installRootPollingLocked(
+	state *darwinLogicalRoot,
+) error {
+	roots := appendWatchScopeRoots(nil, state.plan.Scopes)
+	if b.onPollingRequired != nil {
+		return b.onPollingRequired(PollingObligation{
+			Key: state.plan.Path, Roots: roots, Probe: state.plan.Path,
+		})
+	}
+	if b.onCoverageDegraded != nil {
+		return b.onCoverageDegraded(roots)
+	}
+	return nil
+}
+
+func (b *darwinWatchBackend) processFallbackTransition() bool {
+	phase := b.fallbackPhaseValue()
+	reason := darwinFallbackReason(b.fallbackReason.Load())
+	if phase == darwinFallbackInactive && reason == darwinFallbackReasonNone {
+		return false
+	}
+	if phase == darwinFallbackRecovering {
+		b.processNativeRecoveryHandoff()
+		return true
+	}
+	if phase == darwinFallbackOpen {
+		b.processNativeRecoveryRetry()
+		return b.fallbackPhaseValue() != darwinFallbackOpen
+	}
+	if phase == darwinFallbackReconciling {
+		b.mu.Lock()
+		generation := b.fallbackGeneration
+		b.mu.Unlock()
+		if b.fallbackAcknowledged.Load() >= generation {
+			b.openFallbackDispatch()
+		}
+		return true
+	}
+
+	now := time.Now()
+	b.mu.Lock()
+	if !b.fallbackRetryAt.IsZero() && now.Before(b.fallbackRetryAt) {
+		b.mu.Unlock()
+		return true
+	}
+	prepared := b.fallbackPrepared
+	b.mu.Unlock()
+	if !prepared {
+		b.prepareRuntimeFallback()
+	}
+
+	b.mu.Lock()
+	pollPlans := append([]darwinFallbackPollPlan(nil), b.fallbackPollPlans...)
+	pollingOwned := b.fallbackPollingOwned
+	b.mu.Unlock()
+	if len(pollPlans) > 0 {
+		var err error
+		if !pollingOwned {
+			err = b.requireFallbackPolling(pollPlans)
+		}
+		if err != nil {
+			b.mu.Lock()
+			if !b.fallbackDegradedLogged {
+				log.Printf(
+					"watcher: backend=%s fallback=%s polling registration failed root_count=%d",
+					b.Name(), fallbackReasonLabel(reason), len(pollPlans),
+				)
+				b.fallbackDegradedLogged = true
+			}
+			b.scheduleFallbackRetryLocked(now)
+			b.mu.Unlock()
+			return true
+		}
+		b.mu.Lock()
+		b.fallbackPollingOwned = true
+		b.mu.Unlock()
+	}
+
+	b.beginFallbackReconciliation()
+	return true
+}
+
+func (b *darwinWatchBackend) prepareRuntimeFallback() {
+	b.mu.Lock()
+	if b.fallbackPrepared {
+		b.mu.Unlock()
+		return
+	}
+	b.fallbackPhase.Store(uint32(darwinFallbackCollecting))
+	b.rootTransitions.Inc()
+	var pollPlans []darwinFallbackPollPlan
+	for _, state := range b.logical {
+		pollPlans = appendFallbackPollPlan(
+			pollPlans, state.plan.Path, state.plan.Scopes,
+		)
+	}
+	b.fallbackPollPlans = pollPlans
+	b.fallbackPrepared = true
+	b.mu.Unlock()
+}
+
+func (b *darwinWatchBackend) beginFallbackReconciliation() {
+	b.fallbackEventsMu.Lock()
+	clear(b.fallbackEvents)
+	b.fallbackEventBytes = 0
+	b.fallbackEventsFull = false
+	b.fallbackPhase.Store(uint32(darwinFallbackReconciling))
+	b.fallbackEventsMu.Unlock()
+	b.rootTransitions.Inc()
+	b.nativeOpen.Store(false)
+
+	b.mu.Lock()
+	streams := make([]darwinStream, 0, len(b.streams))
+	for root, stream := range b.streams {
+		streams = append(streams, stream)
+		delete(b.streams, root)
+		b.removeRootLocked(root, true)
+	}
+	for _, state := range b.logical {
+		state.stream = nil
+		state.open.Store(false)
+		if state.plan.Recursive {
+			state.active = false
+		}
+	}
+	b.fallbackGeneration++
+	generation := b.fallbackGeneration
+	b.fallbackRetryAt = time.Time{}
+	b.fallbackRetryDelay = 0
+	b.mu.Unlock()
+	for _, stream := range streams {
+		_ = stream.Close()
+	}
+
+	sink := b.sink
+	if sink != nil {
+		sink.RetainAuthoritative(backendLifecycleToken{
+			gate: b, generation: generation,
+		})
+	}
+}
+
+func (b *darwinWatchBackend) openFallbackDispatch() {
+	// Kqueue startup can fail after an earlier stream failure selected fallback.
+	// Refresh the reason so that unrecoverable kqueue failure dominates the
+	// retry policy even if the lifecycle worker observed the earlier reason.
+	reason := darwinFallbackReason(b.fallbackReason.Load())
+	b.fallbackEventsMu.Lock()
+	sink := b.sink
+	if sink != nil && (b.fallbackEventsFull || len(b.fallbackEvents) > 0) {
+		sink.TryAccumulate(func(add func(backendEvent) bool) bool {
+			if b.fallbackEventsFull {
+				add(backendEvent{Op: backendOpFullSync})
+				return true
+			}
+			for event := range b.fallbackEvents {
+				if !add(event) {
+					break
+				}
+			}
+			return true
+		})
+	}
+	clear(b.fallbackEvents)
+	b.fallbackEventBytes = 0
+	b.fallbackEventsFull = false
+	b.fallbackPhase.Store(uint32(darwinFallbackOpen))
+	b.fallbackEventsMu.Unlock()
+	b.rootTransitions.Inc()
+
+	b.mu.Lock()
+	if reason == darwinFallbackKqueueStart {
+		b.fallbackRetryAt = time.Time{}
+		b.fallbackRetryDelay = 0
+	} else {
+		b.scheduleFallbackRetryLocked(time.Now())
+	}
+	pollRoots := len(b.fallbackPollPlans)
+	b.mu.Unlock()
+	log.Printf(
+		"watcher: backend=%s fallback=%s reconcile=full polling_roots=%d native_drops=%d pending_overflows=%d root_transitions=%d fallback_activations=%d",
+		b.Name(), fallbackReasonLabel(reason), pollRoots,
+		b.nativeDrops.Load(), b.pendingBatchOverflows.Load(),
+		b.rootTransitions.Load(), b.fallbackActivations.Load(),
+	)
+}
+
+// requireFallbackPolling registers one polling obligation per physical watch
+// plan, with the plan's path as Probe, so a missing physical subtree defers
+// its scope roots instead of letting authoritative reconciliation tombstone
+// the sessions under it. Registration is idempotent per key, so a partial
+// failure is safe to retry with the full plan set.
+func (b *darwinWatchBackend) requireFallbackPolling(
+	plans []darwinFallbackPollPlan,
+) error {
+	b.mu.Lock()
+	required := b.onPollingRequired
+	degraded := b.onCoverageDegraded
+	b.mu.Unlock()
+	if required != nil {
+		for _, plan := range plans {
+			if err := required(PollingObligation{
+				Key:   darwinFallbackPollingObligationKey(plan.path),
+				Roots: plan.roots,
+				Probe: plan.path,
+			}); err != nil {
+				return err
+			}
+		}
+		b.mu.Lock()
+		b.fallbackPollingKeyed = true
+		b.mu.Unlock()
+		return nil
+	}
+	if degraded != nil {
+		// The degraded callback carries no probe and its only darwin consumers
+		// (the PG push loops) widen non-authoritative push polling; the
+		// daemon's authoritative reconciliation consumer always registers
+		// keyed obligations above. Handing over every scope root here keeps
+		// that coverage, and stat-gating on a one-shot registration would
+		// silently drop a scope forever if its physical path is briefly
+		// absent.
+		var roots []string
+		for _, plan := range plans {
+			for _, root := range plan.roots {
+				if !slices.Contains(roots, root) {
+					roots = append(roots, root)
+				}
+			}
+		}
+		slices.Sort(roots)
+		return degraded(roots)
+	}
+	return errors.New("no degraded coverage owner")
+}
+
+type darwinRecoveryStream struct {
+	state        *darwinLogicalRoot
+	registration darwinWatchRoot
+	stream       darwinStream
+	started      bool
+}
+
+func (b *darwinWatchBackend) processNativeRecoveryRetry() {
+	now := time.Now()
+	b.mu.Lock()
+	if !b.fallbackRetryAt.IsZero() && now.Before(b.fallbackRetryAt) {
+		b.mu.Unlock()
+		return
+	}
+	b.mu.Unlock()
+	if err := b.beginNativeRecovery(now); err != nil {
+		b.mu.Lock()
+		b.reportErrorLocked(fmt.Errorf("recover native watch streams: %w", err))
+		b.scheduleFallbackRetryLocked(now)
+		b.mu.Unlock()
+	}
+}
+
+func (b *darwinWatchBackend) beginNativeRecovery(now time.Time) error {
+	b.mu.Lock()
+	if b.lifecycle == darwinBackendStopped ||
+		b.fallbackPhaseValue() != darwinFallbackOpen {
+		b.mu.Unlock()
+		return nil
+	}
+	if darwinFallbackReason(b.fallbackReason.Load()) == darwinFallbackKqueueStart {
+		b.fallbackRetryAt = time.Time{}
+		b.fallbackRetryDelay = 0
+		b.mu.Unlock()
+		return nil
+	}
+	recovering := make([]darwinRecoveryStream, 0, len(b.logical))
+	var skipped []*darwinLogicalRoot
+	for _, state := range b.logical {
+		if !state.plan.Recursive {
+			continue
+		}
+		linkInfo, linkErr := b.lstat(state.plan.Path)
+		if linkErr != nil || linkInfo.Mode()&os.ModeSymlink != 0 {
+			skipped = append(skipped, state)
+			continue
+		}
+		info, statErr := b.stat(state.plan.Path)
+		if statErr != nil || !info.IsDir() {
+			skipped = append(skipped, state)
+			continue
+		}
+		if state.stream != nil && state.active {
+			recovering = append(recovering, darwinRecoveryStream{
+				state: state,
+				registration: darwinWatchRoot{
+					logicalPath: state.plan.Path,
+					nativePath:  canonicalWatchRoot(state.plan.Path),
+					recursive:   true,
+					state:       state,
+					generation:  state.generation,
+				},
+				stream:  state.stream,
+				started: true,
+			})
+			continue
+		}
+		generation := state.generation + 1
+		registration := darwinWatchRoot{
+			logicalPath: state.plan.Path,
+			nativePath:  canonicalWatchRoot(state.plan.Path),
+			recursive:   true,
+			state:       state,
+			generation:  generation,
+		}
+		stream, err := b.newStream(state.plan.Path, func(events []fsevents.Event) {
+			b.consumeFSEvents(registration, events)
+		})
+		if err != nil {
+			b.mu.Unlock()
+			for _, candidate := range recovering {
+				if !candidate.started {
+					_ = candidate.stream.Close()
+				}
+			}
+			return err
+		}
+		recovering = append(recovering, darwinRecoveryStream{
+			state: state, registration: registration, stream: stream,
+		})
+	}
+	for _, state := range skipped {
+		if err := b.installRootPollingLocked(state); err != nil {
+			b.mu.Unlock()
+			for _, candidate := range recovering {
+				if !candidate.started {
+					_ = candidate.stream.Close()
+				}
+			}
+			return fmt.Errorf("transfer fallback polling for %s: %w", state.plan.Path, err)
+		}
+		linkInfo, linkErr := b.lstat(state.plan.Path)
+		if linkErr == nil && linkInfo.Mode()&os.ModeSymlink != 0 {
+			state.phase = darwinRootPolling
+			b.resetRetryLocked(state)
+		} else {
+			state.phase = darwinRootPending
+			b.schedulePendingRetryLocked(state, now)
+		}
+	}
+	if len(recovering) == 0 {
+		for _, state := range b.logical {
+			if state.phase == darwinRootPending ||
+				state.phase == darwinRootLossCollecting ||
+				state.phase == darwinRootActivationCollecting ||
+				(!state.plan.Recursive && !state.active) {
+				b.scheduleFallbackRetryLocked(now)
+				b.mu.Unlock()
+				return nil
+			}
+		}
+		b.fallbackGeneration++
+		generation := b.fallbackGeneration
+		b.fallbackRetryAt = time.Time{}
+		b.fallbackRetryDelay = 0
+		b.fallbackRecoveryFailed.Store(false)
+		b.fallbackPhase.Store(uint32(darwinFallbackRecovering))
+		b.nativeOpen.Store(true)
+		b.mu.Unlock()
+		if b.sink != nil {
+			b.sink.RetainAuthoritative(backendLifecycleToken{
+				gate: b, generation: generation,
+			})
+		}
+		return nil
+	}
+
+	b.fallbackGeneration++
+	generation := b.fallbackGeneration
+	b.fallbackRetryAt = time.Time{}
+	b.fallbackRetryDelay = 0
+	b.fallbackRecoveryFailed.Store(false)
+	b.fallbackPhase.Store(uint32(darwinFallbackRecovering))
+	// Keep newly-started streams closed to dispatch until every stream owns
+	// coverage. Changes during startup precede the authoritative marker below
+	// and are therefore included by that reconciliation.
+	b.nativeOpen.Store(false)
+	for _, candidate := range recovering {
+		state := candidate.state
+		state.generation = candidate.registration.generation
+		state.currentGeneration.Store(state.generation)
+		state.acknowledged.Store(state.generation)
+		state.phase = darwinRootOpen
+		state.active = true
+		state.ancestor = ""
+		state.stream = candidate.stream
+		state.open.Store(true)
+		b.streams[state.plan.Path] = candidate.stream
+		b.storeRootLocked(candidate.registration)
+	}
+	for _, candidate := range recovering {
+		if candidate.started {
+			continue
+		}
+		if err := candidate.stream.Start(); err != nil {
+			streams := b.abortNativeRecoveryLocked(now)
+			b.mu.Unlock()
+			for _, stream := range streams {
+				_ = stream.Close()
+			}
+			return err
+		}
+	}
+	failed := b.fallbackRecoveryFailed.Load()
+	b.mu.Unlock()
+	if failed {
+		b.abortNativeRecovery(now)
+		return errors.New("native stream failed during recovery startup")
+	}
+	// Open native accumulation only after all streams have started, then queue
+	// the authoritative marker immediately. Any event that wins this small
+	// ordering window happened before reconciliation begins; events after the
+	// marker is taken remain pending behind the serialized callback.
+	b.nativeOpen.Store(true)
+	if b.sink != nil {
+		b.sink.RetainAuthoritative(backendLifecycleToken{
+			gate: b, generation: generation,
+		})
+	}
+	return nil
+}
+
+func (b *darwinWatchBackend) processNativeRecoveryHandoff() {
+	if b.fallbackRecoveryFailed.Load() {
+		b.abortNativeRecovery(time.Now())
+		return
+	}
+	b.mu.Lock()
+	generation := b.fallbackGeneration
+	if b.fallbackAcknowledged.Load() < generation {
+		b.mu.Unlock()
+		return
+	}
+	pollingOwned := b.fallbackPollingOwned
+	pollingKeyed := b.fallbackPollingKeyed
+	release := b.onPollingReleased
+	releasePlans := append([]darwinFallbackPollPlan(nil), b.fallbackPollPlans...)
+	b.mu.Unlock()
+
+	if pollingOwned && pollingKeyed && release != nil {
+		for _, plan := range releasePlans {
+			key := darwinFallbackPollingObligationKey(plan.path)
+			if err := release(key); err != nil {
+				b.mu.Lock()
+				b.reportErrorLocked(fmt.Errorf("release fallback polling: %w", err))
+				b.scheduleFallbackRetryLocked(time.Now())
+				b.mu.Unlock()
+				return
+			}
+		}
+	}
+
+	b.mu.Lock()
+	if b.fallbackRecoveryFailed.Load() {
+		pollPlans := append([]darwinFallbackPollPlan(nil), b.fallbackPollPlans...)
+		b.mu.Unlock()
+		if len(pollPlans) > 0 {
+			if err := b.requireFallbackPolling(pollPlans); err != nil {
+				b.mu.Lock()
+				b.reportErrorLocked(fmt.Errorf("restore fallback polling: %w", err))
+				b.scheduleFallbackRetryLocked(time.Now())
+				b.mu.Unlock()
+				return
+			}
+		}
+		b.mu.Lock()
+		streams := b.abortNativeRecoveryLocked(time.Now())
+		b.mu.Unlock()
+		for _, stream := range streams {
+			_ = stream.Close()
+		}
+		return
+	}
+	b.fallbackPollingOwned = false
+	b.fallbackPollingKeyed = false
+	b.fallbackPrepared = false
+	b.fallbackDegradedLogged = false
+	b.fallbackPollPlans = nil
+	b.fallbackRetryAt = time.Time{}
+	b.fallbackRetryDelay = 0
+	b.fallbackReason.Store(uint32(darwinFallbackReasonNone))
+	b.fallbackPhase.Store(uint32(darwinFallbackInactive))
+	b.nativeOpen.Store(true)
+	b.rootTransitions.Inc()
+	b.mu.Unlock()
+	if b.fallbackRecoveryFailed.Swap(false) {
+		b.requestFallback(darwinFallbackNativeDrop)
+		return
+	}
+	// Recovery handoff takes priority in the lifecycle loop. Wake it once more
+	// so root-local signals accumulated during fallback are processed normally.
+	b.signalLifecycle()
+}
+
+func (b *darwinWatchBackend) abortNativeRecovery(now time.Time) {
+	b.mu.Lock()
+	streams := b.abortNativeRecoveryLocked(now)
+	b.mu.Unlock()
+	for _, stream := range streams {
+		_ = stream.Close()
+	}
+}
+
+func (b *darwinWatchBackend) abortNativeRecoveryLocked(now time.Time) []darwinStream {
+	streams := make([]darwinStream, 0, len(b.streams))
+	for root, stream := range b.streams {
+		streams = append(streams, stream)
+		delete(b.streams, root)
+		b.removeRootLocked(root, true)
+	}
+	for _, state := range b.logical {
+		if !state.plan.Recursive {
+			continue
+		}
+		state.active = false
+		state.stream = nil
+		state.open.Store(false)
+	}
+	b.fallbackRecoveryFailed.Store(false)
+	b.fallbackPhase.Store(uint32(darwinFallbackOpen))
+	b.nativeOpen.Store(false)
+	b.scheduleFallbackRetryLocked(now)
+	return streams
+}
+
+func (b *darwinWatchBackend) scheduleFallbackRetryLocked(now time.Time) {
+	if b.fallbackRetryDelay == 0 {
+		b.fallbackRetryDelay = b.retryInitial
+	} else {
+		b.fallbackRetryDelay = min(b.fallbackRetryDelay*2, b.retryMax)
+	}
+	b.fallbackRetryAt = now.Add(b.fallbackRetryDelay)
+}
+
+func appendWatchScopeRoots(roots []string, scopes []WatchScope) []string {
+	for _, scope := range scopes {
+		if scope.SyncDir != "" && !slices.Contains(roots, filepath.Clean(scope.SyncDir)) {
+			roots = append(roots, filepath.Clean(scope.SyncDir))
+		}
+	}
+	slices.Sort(roots)
+	return roots
+}
+
+func fallbackReasonLabel(reason darwinFallbackReason) string {
+	switch reason {
+	case darwinFallbackStreamCreate:
+		return "stream-create"
+	case darwinFallbackStreamStart:
+		return "stream-start"
+	case darwinFallbackNativeDrop:
+		return "native-drop"
+	case darwinFallbackLifecycle:
+		return "lifecycle"
+	case darwinFallbackKqueueStart:
+		return "kqueue-start"
+	default:
+		return "unknown"
+	}
+}
+
+func (b *darwinWatchBackend) nextLifecycleRetry() (time.Duration, bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	earliest := b.fallbackRetryAt
+	if b.fallbackPhaseValue() == darwinFallbackInactive &&
+		darwinFallbackReason(b.fallbackReason.Load()) == darwinFallbackReasonNone {
+		for _, state := range b.logical {
+			if state.retryAt.IsZero() {
+				continue
+			}
+			if earliest.IsZero() || state.retryAt.Before(earliest) {
+				earliest = state.retryAt
+			}
+		}
+	}
+	if earliest.IsZero() {
+		return 0, false
+	}
+	return max(time.Until(earliest), 0), true
+}
+
+func (b *darwinWatchBackend) retryDueLocked(
+	state *darwinLogicalRoot,
+	now time.Time,
+) bool {
+	return state.retryAt.IsZero() || !now.Before(state.retryAt)
+}
+
+func (b *darwinWatchBackend) scheduleRetryLocked(
+	state *darwinLogicalRoot,
+	now time.Time,
+) {
+	if state.retryDelay == 0 {
+		state.retryDelay = b.retryInitial
+	} else {
+		state.retryDelay = min(state.retryDelay*2, b.retryMax)
+	}
+	state.retryAt = now.Add(state.retryDelay)
+}
+
+func (b *darwinWatchBackend) schedulePendingRetryLocked(
+	state *darwinLogicalRoot,
+	now time.Time,
+) {
+	if !state.retryAt.IsZero() && now.Before(state.retryAt) {
+		return
+	}
+	b.scheduleRetryLocked(state, now)
+}
+
+func (b *darwinWatchBackend) resetRetryLocked(state *darwinLogicalRoot) {
+	state.retryAt = time.Time{}
+	state.retryDelay = 0
+}
+
+// handleKqueueEvent advances pending roots before the native event can reach
+// the watcher. The resulting scope reconciliation is authoritative, so the
+// component-creation event itself does not need a second dispatch.
+func (b *darwinWatchBackend) handleKqueueEvent(
+	event backendEvent,
+) (backendEvent, bool) {
+	snapshot := b.roots.Load()
+	owner, ok := snapshot.mostSpecificRoot(event.Path)
+	if ok {
+		event.Root = owner.logicalPath
+	}
+	if b.collectFallbackEvent(event) {
+		return backendEvent{}, false
+	}
+	if b.fallbackPhaseValue() == darwinFallbackOpen {
+		if !ok {
+			return backendEvent{}, false
+		}
+		return event, true
+	}
+	if ok && !owner.recursive && event.Path == owner.logicalPath &&
+		event.Op&(backendOpRemove|backendOpRename) != 0 && owner.state != nil {
+		owner.state.signal.Or(darwinRootSignalLoss)
+	}
+	b.signalLifecycle()
+	if !ok || owner.recursive ||
+		(owner.state != nil && !owner.state.isOpen(owner.generation)) {
+		return backendEvent{}, false
+	}
+	return event, true
+}
+
+func (b *darwinWatchBackend) collectFallbackEvent(event backendEvent) bool {
+	b.fallbackEventsMu.Lock()
+	defer b.fallbackEventsMu.Unlock()
+	phase := b.fallbackPhaseValue()
+	if phase != darwinFallbackCollecting && phase != darwinFallbackReconciling {
+		return false
+	}
+	if b.fallbackEventsFull || event.Op == backendOpUnknown {
+		return true
+	}
+	if _, exists := b.fallbackEvents[event]; exists {
+		return true
+	}
+	bytes := len(event.Path) + len(event.Root)
+	if len(b.fallbackEvents)+1 > defaultWatchBatchMaxEntries ||
+		b.fallbackEventBytes+bytes > defaultWatchBatchMaxPathBytes {
+		clear(b.fallbackEvents)
+		b.fallbackEventBytes = 0
+		b.fallbackEventsFull = true
+		b.pendingBatchOverflows.Inc()
+		return true
+	}
+	b.fallbackEvents[event] = struct{}{}
+	b.fallbackEventBytes += bytes
+	return true
+}
+
+func (b *darwinWatchBackend) activateRootLocked(state *darwinLogicalRoot) error {
+	root := state.plan.Path
+	state.generation++
+	state.currentGeneration.Store(state.generation)
+	state.acknowledged.Store(state.generation)
+	state.open.Store(b.lifecycle != darwinBackendRunning)
+	if b.lifecycle == darwinBackendRunning {
+		state.phase = darwinRootActivationCollecting
+		state.acknowledged.Store(state.generation - 1)
+	} else {
+		state.phase = darwinRootOpen
+	}
+	registration := darwinWatchRoot{
+		logicalPath: root,
+		nativePath:  canonicalWatchRoot(root),
+		recursive:   state.plan.Recursive,
+		state:       state,
+		generation:  state.generation,
+	}
+	if !state.plan.Recursive {
+		if err := b.acquireShallowLocked(root); err != nil {
+			state.phase = darwinRootPending
+			state.open.Store(false)
+			return err
+		}
+		state.active = true
+		state.ancestor = root
+		b.storeRootLocked(registration)
+		return nil
+	}
+	stream, err := b.newStream(root, func(events []fsevents.Event) {
+		b.consumeFSEvents(registration, events)
+	})
+	if err != nil {
+		state.phase = darwinRootPending
+		state.open.Store(false)
+		return err
+	}
+	b.streams[root] = stream
+	b.storeRootLocked(registration)
+	if b.lifecycle == darwinBackendRunning {
+		if err := stream.Start(); err != nil {
+			delete(b.streams, root)
+			b.removeRootLocked(root, true)
+			_ = stream.Close()
+			state.phase = darwinRootPending
+			state.open.Store(false)
+			return err
+		}
+	}
+	state.active = true
+	state.ancestor = ""
+	state.stream = stream
+	return nil
+}
+
+func (b *darwinWatchBackend) acquireShallowLocked(path string) error {
+	path = filepath.Clean(path)
+	if b.shallow[path] > 0 {
+		b.shallow[path]++
+		return nil
+	}
+	if err := b.addShallow(path); err != nil {
+		return err
+	}
+	b.shallow[path] = 1
+	return nil
+}
+
+func (b *darwinWatchBackend) releaseShallowLocked(path string) error {
+	path = filepath.Clean(path)
+	refs := b.shallow[path]
+	if refs == 0 {
+		return nil
+	}
+	if refs > 1 {
+		b.shallow[path] = refs - 1
+		return nil
+	}
+	delete(b.shallow, path)
+	return b.removeShallow(path)
+}
+
+// observeAncestor lazily creates the single-descriptor vnode observer on the
+// first ancestor add, so daemons with no missing roots hold no kqueue.
+func (b *darwinWatchBackend) observeAncestor(path string) error {
+	if b.vnode == nil {
+		observer, err := newVnodeObserver(b.signalLifecycle)
+		if err != nil {
+			return err
+		}
+		b.vnode = observer
+	}
+	return b.vnode.Add(path)
+}
+
+func (b *darwinWatchBackend) unobserveAncestor(path string) error {
+	if b.vnode == nil {
+		return nil
+	}
+	return b.vnode.Remove(path)
+}
+
+func (b *darwinWatchBackend) acquireAncestorLocked(path string) error {
+	path = filepath.Clean(path)
+	if b.ancestors[path] > 0 {
+		b.ancestors[path]++
+		return nil
+	}
+	if err := b.addAncestor(path); err != nil {
+		return err
+	}
+	b.ancestors[path] = 1
+	return nil
+}
+
+func (b *darwinWatchBackend) releaseAncestorLocked(path string) error {
+	path = filepath.Clean(path)
+	refs := b.ancestors[path]
+	if refs == 0 {
+		return nil
+	}
+	if refs > 1 {
+		b.ancestors[path] = refs - 1
+		return nil
+	}
+	delete(b.ancestors, path)
+	return b.removeAncestor(path)
+}
+
+func (b *darwinWatchBackend) accumulateReconcile(
+	scopes []WatchScope,
+	token backendLifecycleToken,
+) {
+	sink := b.sink
+	if sink == nil {
+		return
+	}
+	sink.TryAccumulate(func(add func(backendEvent) bool) bool {
+		meaningful := false
+		seen := make(map[string]struct{}, len(scopes))
+		for _, scope := range scopes {
+			root := filepath.Clean(scope.SyncDir)
+			if scope.SyncDir == "" {
+				continue
+			}
+			if _, exists := seen[root]; exists {
+				continue
+			}
+			seen[root] = struct{}{}
+			meaningful = true
+			if !add(backendEvent{
+				Root: root, Op: backendOpReconcileRootChange, Lifecycle: token,
+			}) {
+				return true
+			}
+		}
+		return meaningful
+	})
+}
+
+func (b *darwinWatchBackend) reportErrorLocked(err error) {
+	select {
+	case b.errors <- err:
+	default:
+	}
+}
+
+func pathIsDirectory(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info != nil && info.IsDir()
+}
+
+func nearestExistingAncestor(path string) string {
+	path = filepath.Clean(path)
+	for {
+		if pathIsDirectory(path) {
+			return path
+		}
+		parent := filepath.Dir(path)
+		if parent == path {
+			return ""
+		}
+		path = parent
+	}
+}
+
+func (b *darwinWatchBackend) finish() {
+	b.finishOnce.Do(func() {
+		close(b.events)
+		close(b.errors)
+		close(b.done)
+	})
+}
+
+func (b *darwinWatchBackend) storeRootLocked(root darwinWatchRoot) {
+	current := b.roots.Load()
+	next := &darwinRootSnapshot{roots: append([]darwinWatchRoot(nil), current.roots...)}
+	for i := range next.roots {
+		if next.roots[i].logicalPath == root.logicalPath &&
+			next.roots[i].recursive == root.recursive {
+			next.roots[i] = root
+			b.roots.Store(next)
+			return
+		}
+	}
+	next.roots = append(next.roots, root)
+	b.roots.Store(next)
+}
+
+func (b *darwinWatchBackend) removeRootLocked(root string, recursive bool) {
+	current := b.roots.Load()
+	next := &darwinRootSnapshot{roots: slices.DeleteFunc(
+		append([]darwinWatchRoot(nil), current.roots...),
+		func(candidate darwinWatchRoot) bool {
+			return candidate.logicalPath == root && candidate.recursive == recursive
+		},
+	)}
+	b.roots.Store(next)
+}
+
+func (s *darwinRootSnapshot) mostSpecificRoot(path string) (darwinWatchRoot, bool) {
+	if s == nil {
+		return darwinWatchRoot{}, false
+	}
+	clean := filepath.Clean(path)
+	var best darwinWatchRoot
+	for _, root := range s.roots {
+		if !pathAtOrBelow(root.logicalPath, clean) {
+			continue
+		}
+		if best.logicalPath == "" || len(root.logicalPath) > len(best.logicalPath) ||
+			(len(root.logicalPath) == len(best.logicalPath) && root.recursive) {
+			best = root
+		}
+	}
+	return best, best.logicalPath != ""
+}
+
+// mostSpecificRecursiveRoot selects ownership among native recursive streams.
+// Shallow kqueue registrations can be nested within a recursive root, but they
+// cover only their direct directory and must not shadow descendant FSEvents.
+func (s *darwinRootSnapshot) mostSpecificRecursiveRoot(path string) (darwinWatchRoot, bool) {
+	if s == nil {
+		return darwinWatchRoot{}, false
+	}
+	clean := filepath.Clean(path)
+	var best darwinWatchRoot
+	for _, root := range s.roots {
+		if !root.recursive || !pathAtOrBelow(root.logicalPath, clean) {
+			continue
+		}
+		if best.logicalPath == "" || len(root.logicalPath) > len(best.logicalPath) {
+			best = root
+		}
+	}
+	return best, best.logicalPath != ""
+}
+
+func canonicalWatchRoot(root string) string {
+	canonical, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return root
+	}
+	return filepath.Clean(canonical)
+}
+
+func logicalFSEventPath(root darwinWatchRoot, path string) string {
+	path = filepath.Clean(path)
+	if root.nativePath == root.logicalPath || !pathAtOrBelow(root.nativePath, path) {
+		return path
+	}
+	rel, err := filepath.Rel(root.nativePath, path)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return path
+	}
+	return filepath.Join(root.logicalPath, rel)
+}

--- a/internal/sync/watch_backend_factory_other.go
+++ b/internal/sync/watch_backend_factory_other.go
@@ -1,0 +1,7 @@
+//go:build !darwin
+
+package sync
+
+func newWatchBackend(excludes []string) (watchBackend, error) {
+	return newFSNotifyBackend(excludes)
+}

--- a/internal/sync/watch_backend_fsnotify.go
+++ b/internal/sync/watch_backend_fsnotify.go
@@ -1,0 +1,706 @@
+package sync
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"math"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"syscall"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+type fsnotifyBackend struct {
+	watcher           *fsnotify.Watcher
+	errorInput        <-chan error
+	watchOps          fsnotifyWatchOps
+	events            chan backendEvent
+	errors            chan error
+	excludes          []string
+	roots             []string
+	recursive         []string
+	shallow           []string
+	rootsMu           sync.RWMutex
+	watchMu           sync.Mutex
+	watchOwners       map[string]map[string]struct{}
+	watchBudgetCost   map[string]int
+	runtimeBudget     int
+	rootScopes        map[string][]string
+	degradedRoots     map[string]struct{}
+	onPollingRequired func(PollingObligation) error
+	lifecycleMu       sync.Mutex
+	lifecycle         fsnotifyBackendLifecycle
+	stop              chan struct{}
+	done              chan struct{}
+	finishOnce        sync.Once
+}
+
+type fsnotifyWatchOps interface {
+	Add(path string) error
+	Remove(path string) error
+}
+
+type fsnotifyBackendLifecycle uint8
+
+const (
+	fsnotifyBackendNew fsnotifyBackendLifecycle = iota
+	fsnotifyBackendRunning
+	fsnotifyBackendStopped
+)
+
+func newFSNotifyBackend(excludes []string) (*fsnotifyBackend, error) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+	return &fsnotifyBackend{
+		watcher:         watcher,
+		errorInput:      watcher.Errors,
+		watchOps:        watcher,
+		events:          make(chan backendEvent),
+		errors:          make(chan error, 1),
+		excludes:        normalizeExcludePatterns(excludes),
+		watchOwners:     make(map[string]map[string]struct{}),
+		watchBudgetCost: make(map[string]int),
+		rootScopes:      make(map[string][]string),
+		degradedRoots:   make(map[string]struct{}),
+		stop:            make(chan struct{}),
+		done:            make(chan struct{}),
+	}, nil
+}
+
+func (b *fsnotifyBackend) Events() <-chan backendEvent { return b.events }
+func (b *fsnotifyBackend) Errors() <-chan error        { return b.errors }
+
+func (b *fsnotifyBackend) AddRecursive(root string, budget int) RecursiveWatchResult {
+	b.watchMu.Lock()
+	defer b.watchMu.Unlock()
+
+	var result RecursiveWatchResult
+	root = filepath.Clean(root)
+	b.addRecursiveRoot(root)
+
+	remaining := budget
+	result.Err = filepath.WalkDir(root,
+		func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				// WalkDir surfaces errors only for the root stat and failed
+				// directory reads, so this subtree's descendants get no
+				// native watches. Count it as degraded coverage — the owning
+				// logical root then gains a polling obligation instead of
+				// the result appearing fully watched — and keep walking the
+				// accessible remainder.
+				result.Unwatched++
+				return nil
+			}
+			if !d.IsDir() {
+				return nil
+			}
+			// Skip entire excluded subtrees, but always keep the root.
+			if path != root && b.shouldExcludeForRoot(path, root) {
+				return filepath.SkipDir
+			}
+			if remaining <= 0 {
+				result.BudgetExhausted = true
+				return filepath.SkipAll
+			}
+			if addErr := b.watchOps.Add(path); addErr != nil {
+				result.Unwatched++
+				if isWatchResourceExhaustion(addErr) {
+					result.ResourceExhausted = true
+					result.ResourceExhaustedAt = path
+					return filepath.SkipAll
+				}
+				return nil
+			}
+			b.watchBudgetCost[path]++
+			b.addWatchOwner(path, root)
+			remaining--
+			result.Watched++
+			return nil
+		})
+	if errors.Is(result.Err, filepath.SkipAll) {
+		result.Err = nil
+	}
+	b.runtimeBudget = max(remaining, 0)
+	return result
+}
+
+func (b *fsnotifyBackend) setWatchRootPlan(roots []WatchRoot) {
+	b.watchMu.Lock()
+	defer b.watchMu.Unlock()
+	b.rootScopes = make(map[string][]string, len(roots))
+	for _, root := range roots {
+		path := filepath.Clean(root.Path)
+		for _, scope := range root.Scopes {
+			if scope.SyncDir != "" {
+				b.rootScopes[path] = append(b.rootScopes[path], scope.SyncDir)
+			}
+		}
+		slices.Sort(b.rootScopes[path])
+		b.rootScopes[path] = slices.Compact(b.rootScopes[path])
+	}
+}
+
+func (b *fsnotifyBackend) bindPollingOwnership(
+	required func(PollingObligation) error,
+	_ func(string) error,
+) {
+	b.watchMu.Lock()
+	defer b.watchMu.Unlock()
+	b.onPollingRequired = required
+}
+
+func (b *fsnotifyBackend) AddShallow(root string) error {
+	b.watchMu.Lock()
+	defer b.watchMu.Unlock()
+
+	root = filepath.Clean(root)
+	if err := b.watchOps.Add(root); err != nil {
+		return err
+	}
+	b.addShallowRoot(root)
+	b.addWatchOwner(root, root)
+	return nil
+}
+
+func (b *fsnotifyBackend) Remove(root string) error {
+	b.watchMu.Lock()
+	defer b.watchMu.Unlock()
+
+	root = filepath.Clean(root)
+	b.rootsMu.Lock()
+	wasRecursive := slices.Contains(b.recursive, root)
+	wasShallow := slices.Contains(b.shallow, root)
+	if !wasRecursive && !wasShallow {
+		b.rootsMu.Unlock()
+		return fmt.Errorf("%w: %s", fsnotify.ErrNonExistentWatch, root)
+	}
+	b.recursive = slices.DeleteFunc(b.recursive, func(candidate string) bool {
+		return candidate == root
+	})
+	b.shallow = slices.DeleteFunc(b.shallow, func(candidate string) bool {
+		return candidate == root
+	})
+	b.roots = slices.DeleteFunc(b.roots, func(candidate string) bool {
+		return candidate == root
+	})
+	b.rootsMu.Unlock()
+
+	ownedPaths := make([]string, 0)
+	for path, owners := range b.watchOwners {
+		if _, owned := owners[root]; owned {
+			ownedPaths = append(ownedPaths, path)
+		}
+	}
+	slices.Sort(ownedPaths)
+	var removeErrs []error
+	for _, path := range ownedPaths {
+		owners := b.watchOwners[path]
+		delete(owners, root)
+		if len(owners) > 0 {
+			continue
+		}
+		delete(b.watchOwners, path)
+		if err := b.watchOps.Remove(path); err != nil &&
+			!errors.Is(err, fsnotify.ErrNonExistentWatch) {
+			removeErrs = append(removeErrs,
+				fmt.Errorf("remove native watch %q: %w", path, err))
+		}
+		b.reclaimWatchBudgetLocked(path)
+	}
+	return errors.Join(removeErrs...)
+}
+
+func (b *fsnotifyBackend) Start() error {
+	b.lifecycleMu.Lock()
+	defer b.lifecycleMu.Unlock()
+	if b.lifecycle != fsnotifyBackendNew {
+		return nil
+	}
+	b.lifecycle = fsnotifyBackendRunning
+	go b.loop()
+	return nil
+}
+
+func (b *fsnotifyBackend) Stop() {
+	b.lifecycleMu.Lock()
+	if b.lifecycle == fsnotifyBackendStopped {
+		done := b.done
+		b.lifecycleMu.Unlock()
+		<-done
+		return
+	}
+	wasRunning := b.lifecycle == fsnotifyBackendRunning
+	b.lifecycle = fsnotifyBackendStopped
+	close(b.stop)
+	_ = b.watcher.Close()
+	if !wasRunning {
+		b.finish()
+	}
+	done := b.done
+	b.lifecycleMu.Unlock()
+	<-done
+}
+
+func (b *fsnotifyBackend) Name() string { return "fsnotify" }
+
+func (b *fsnotifyBackend) loop() {
+	defer b.finish()
+	for {
+		select {
+		case <-b.stop:
+			return
+		case event, ok := <-b.watcher.Events:
+			if !ok {
+				return
+			}
+			translated, relevant := b.translateEvent(event)
+			if !relevant {
+				continue
+			}
+			select {
+			case b.events <- translated:
+			case <-b.stop:
+				return
+			}
+		case err, ok := <-b.errorInput:
+			if !ok {
+				return
+			}
+			if errors.Is(err, fsnotify.ErrEventOverflow) {
+				select {
+				case b.events <- backendEvent{Op: backendOpFullSync}:
+				case <-b.stop:
+					return
+				}
+				continue
+			}
+			select {
+			case b.errors <- err:
+			case <-b.stop:
+				return
+			}
+		}
+	}
+}
+
+func (b *fsnotifyBackend) finish() {
+	b.finishOnce.Do(func() {
+		close(b.events)
+		close(b.errors)
+		close(b.done)
+	})
+}
+
+func (b *fsnotifyBackend) translateEvent(event fsnotify.Event) (backendEvent, bool) {
+	op := translateFSNotifyOp(event.Op)
+	if op == backendOpUnknown {
+		return backendEvent{}, false
+	}
+
+	itemType := backendItemUnknown
+	if op&(backendOpRemove|backendOpRename) != 0 {
+		removed, lostRoots := b.forgetRemovedSubtree(event.Name)
+		if removed {
+			itemType = backendItemDirectory
+		}
+		b.requireRuntimePolling(lostRoots)
+	}
+	if op&backendOpCreate != 0 {
+		var excluded bool
+		itemType, excluded = b.watchCreatedPath(event.Name)
+		if excluded {
+			return backendEvent{}, false
+		}
+	}
+	root, _ := b.mostSpecificContainingRoot(event.Name)
+
+	return backendEvent{
+		Path:     filepath.Clean(event.Name),
+		Root:     root,
+		Op:       op,
+		ItemType: itemType,
+	}, true
+}
+
+func translateFSNotifyOp(op fsnotify.Op) backendOp {
+	var translated backendOp
+	if op&fsnotify.Create != 0 {
+		translated |= backendOpCreate
+	}
+	if op&fsnotify.Write != 0 {
+		translated |= backendOpWrite
+	}
+	if op&fsnotify.Remove != 0 {
+		translated |= backendOpRemove
+	}
+	if op&fsnotify.Rename != 0 {
+		translated |= backendOpRename
+	}
+	return translated
+}
+
+// watchCreatedPath classifies a created path and adds it to the watch list when
+// it is an included directory.
+func (b *fsnotifyBackend) watchCreatedPath(path string) (backendItemType, bool) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return backendItemUnknown, false
+	}
+	if !info.IsDir() {
+		return backendItemFile, false
+	}
+
+	b.watchMu.Lock()
+	if b.isUnderShallowRoot(path) {
+		b.watchMu.Unlock()
+		return backendItemDirectory, false
+	}
+	if b.shouldExclude(path) {
+		b.watchMu.Unlock()
+		return backendItemDirectory, true
+	}
+	owners := b.recursiveOwnersForPath(path)
+	if len(owners) == 0 {
+		b.watchMu.Unlock()
+		return backendItemDirectory, false
+	}
+	degraded := b.addRuntimeSubtreeLocked(path, owners)
+	b.watchMu.Unlock()
+	b.requireRuntimePolling(degraded)
+	return backendItemDirectory, false
+}
+
+// addRuntimeSubtreeLocked recursively covers a newly created or moved-in
+// directory without exceeding the startup recursive-watch budget. Caller holds
+// watchMu. Any incomplete owner is returned for scoped polling handoff.
+func (b *fsnotifyBackend) addRuntimeSubtreeLocked(
+	path string,
+	owners []string,
+) []string {
+	degraded := make(map[string]struct{})
+	_ = filepath.WalkDir(path, func(current string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			for _, root := range owners {
+				degraded[root] = struct{}{}
+			}
+			return filepath.SkipAll
+		}
+		if !entry.IsDir() {
+			return nil
+		}
+		currentOwners := make([]string, 0, len(owners))
+		for _, root := range owners {
+			if !b.shouldExcludeForRoot(current, root) {
+				currentOwners = append(currentOwners, root)
+			}
+		}
+		if len(currentOwners) == 0 {
+			return filepath.SkipDir
+		}
+		if len(b.watchOwners[current]) == 0 {
+			if b.runtimeBudget <= 0 {
+				for _, root := range currentOwners {
+					degraded[root] = struct{}{}
+				}
+				return filepath.SkipAll
+			}
+			if err := b.watchOps.Add(current); err != nil {
+				for _, root := range currentOwners {
+					degraded[root] = struct{}{}
+				}
+				return filepath.SkipAll
+			}
+			b.watchBudgetCost[current]++
+			b.runtimeBudget--
+		}
+		for _, root := range currentOwners {
+			b.addWatchOwner(current, root)
+		}
+		return nil
+	})
+	roots := make([]string, 0, len(degraded))
+	for root := range degraded {
+		roots = append(roots, root)
+	}
+	slices.Sort(roots)
+	return roots
+}
+
+// forgetRemovedSubtree clears native-watch ownership invalidated by a
+// directory remove or rename event. Budget is tied to active native watches,
+// so churn can reuse slots without growing the ownership ledger forever.
+func (b *fsnotifyBackend) forgetRemovedSubtree(path string) (bool, []string) {
+	b.watchMu.Lock()
+	defer b.watchMu.Unlock()
+
+	path = filepath.Clean(path)
+	removed := make([]string, 0)
+	lostRoots := make(map[string]struct{})
+	for watched := range b.watchOwners {
+		if pathAtOrBelow(path, watched) {
+			removed = append(removed, watched)
+			for owner := range b.watchOwners[watched] {
+				if pathAtOrBelow(path, owner) {
+					lostRoots[owner] = struct{}{}
+				}
+			}
+		}
+	}
+	if len(removed) == 0 {
+		return false, nil
+	}
+	slices.Sort(removed)
+	for _, watched := range removed {
+		delete(b.watchOwners, watched)
+		if err := b.watchOps.Remove(watched); err != nil &&
+			!errors.Is(err, fsnotify.ErrNonExistentWatch) {
+			b.reportError(fmt.Errorf(
+				"remove invalidated native watch %q: %w", watched, err,
+			))
+		}
+		b.reclaimWatchBudgetLocked(watched)
+	}
+	roots := make([]string, 0, len(lostRoots))
+	for root := range lostRoots {
+		roots = append(roots, root)
+	}
+	slices.Sort(roots)
+	return true, roots
+}
+
+func (b *fsnotifyBackend) reclaimWatchBudgetLocked(path string) {
+	cost := b.watchBudgetCost[path]
+	delete(b.watchBudgetCost, path)
+	if cost > math.MaxInt-b.runtimeBudget {
+		b.runtimeBudget = math.MaxInt
+		return
+	}
+	b.runtimeBudget += cost
+}
+
+func (b *fsnotifyBackend) requireRuntimePolling(roots []string) {
+	for _, root := range roots {
+		b.watchMu.Lock()
+		if _, already := b.degradedRoots[root]; already {
+			b.watchMu.Unlock()
+			continue
+		}
+		required := b.onPollingRequired
+		scopes := append([]string(nil), b.rootScopes[root]...)
+		b.watchMu.Unlock()
+		if len(scopes) == 0 {
+			scopes = []string{root}
+		}
+		if required == nil {
+			b.reportError(fmt.Errorf(
+				"fsnotify coverage degraded for %s without polling callback", root,
+			))
+			continue
+		}
+		if err := required(PollingObligation{
+			Key: "fsnotify-runtime:" + root, Roots: scopes, Probe: root,
+		}); err != nil {
+			b.reportError(fmt.Errorf(
+				"transfer fsnotify coverage for %s to polling: %w", root, err,
+			))
+			continue
+		}
+		b.watchMu.Lock()
+		b.degradedRoots[root] = struct{}{}
+		b.watchMu.Unlock()
+	}
+}
+
+func (b *fsnotifyBackend) reportError(err error) {
+	select {
+	case b.errors <- err:
+	default:
+	}
+}
+
+func normalizeExcludePatterns(patterns []string) []string {
+	if len(patterns) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(patterns))
+	for _, pattern := range patterns {
+		pattern = strings.TrimSpace(filepath.Clean(pattern))
+		if pattern == "" || pattern == "." {
+			continue
+		}
+		if !slices.Contains(out, pattern) {
+			out = append(out, pattern)
+		}
+	}
+	return out
+}
+
+func (b *fsnotifyBackend) addRecursiveRoot(root string) {
+	b.rootsMu.Lock()
+	defer b.rootsMu.Unlock()
+	if !slices.Contains(b.roots, root) {
+		b.roots = append(b.roots, root)
+	}
+	if !slices.Contains(b.recursive, root) {
+		b.recursive = append(b.recursive, root)
+	}
+}
+
+func (b *fsnotifyBackend) addShallowRoot(root string) {
+	b.rootsMu.Lock()
+	defer b.rootsMu.Unlock()
+	if !slices.Contains(b.shallow, root) {
+		b.shallow = append(b.shallow, root)
+	}
+	if !slices.Contains(b.roots, root) {
+		b.roots = append(b.roots, root)
+	}
+}
+
+// isUnderShallowRoot reports whether path's most specific containing watch
+// root is a shallow root. A path that also sits under a more specific
+// recursive root is not shadowed, so new subdirectories are still watched.
+func (b *fsnotifyBackend) isUnderShallowRoot(path string) bool {
+	root, ok := b.mostSpecificContainingRoot(path)
+	if !ok {
+		return false
+	}
+	b.rootsMu.RLock()
+	defer b.rootsMu.RUnlock()
+	return slices.Contains(b.shallow, root) && !slices.Contains(b.recursive, root)
+}
+
+func pathAtOrBelow(root, path string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel == "." ||
+		(rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}
+
+func (b *fsnotifyBackend) recursiveOwnersForPath(path string) []string {
+	b.rootsMu.RLock()
+	defer b.rootsMu.RUnlock()
+	owners := make([]string, 0, len(b.recursive))
+	for _, root := range b.recursive {
+		if _, degraded := b.degradedRoots[root]; degraded {
+			continue
+		}
+		if pathAtOrBelow(root, path) && !b.shouldExcludeForRoot(path, root) {
+			owners = append(owners, root)
+		}
+	}
+	return owners
+}
+
+// addWatchOwner records ownership only after the native Add succeeds. Caller
+// holds watchMu, which serializes the native watch and its ownership ledger.
+func (b *fsnotifyBackend) addWatchOwner(path, root string) {
+	owners := b.watchOwners[path]
+	if owners == nil {
+		owners = make(map[string]struct{})
+		b.watchOwners[path] = owners
+	}
+	owners[root] = struct{}{}
+}
+
+func (b *fsnotifyBackend) shouldExclude(path string) bool {
+	if len(b.excludes) == 0 {
+		return false
+	}
+	root, ok := b.mostSpecificContainingRoot(path)
+	if !ok {
+		return false
+	}
+	return b.shouldExcludeForRoot(path, root)
+}
+
+func (b *fsnotifyBackend) shouldExcludeForRoot(path string, root string) bool {
+	return shouldExcludeForRoot(b.excludes, path, root)
+}
+
+func (b *fsnotifyBackend) includeCreatedSubtreePath(root, path string) bool {
+	return !b.shouldExcludeForRoot(path, root)
+}
+
+func (b *fsnotifyBackend) shouldEnumerateCreatedSubtree(root, path string) bool {
+	b.rootsMu.RLock()
+	defer b.rootsMu.RUnlock()
+	return slices.Contains(b.recursive, filepath.Clean(root)) &&
+		pathAtOrBelow(root, path)
+}
+
+func shouldExcludeForRoot(excludes []string, path string, root string) bool {
+	if len(excludes) == 0 {
+		return false
+	}
+	clean := filepath.Clean(path)
+	root = filepath.Clean(root)
+	rel, err := filepath.Rel(root, clean)
+	if err != nil {
+		return false
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	rel = filepath.Clean(rel)
+	if rel == "." {
+		return false
+	}
+	parts := strings.Split(rel, string(filepath.Separator))
+
+	for _, pattern := range excludes {
+		if strings.Contains(pattern, string(filepath.Separator)) {
+			if ok, _ := filepath.Match(pattern, rel); ok {
+				return true
+			}
+			continue
+		}
+		for _, part := range parts {
+			if ok, _ := filepath.Match(pattern, part); ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (b *fsnotifyBackend) mostSpecificContainingRoot(path string) (string, bool) {
+	b.rootsMu.RLock()
+	defer b.rootsMu.RUnlock()
+
+	if len(b.roots) == 0 {
+		return "", false
+	}
+
+	clean := filepath.Clean(path)
+	var best string
+	for _, root := range b.roots {
+		rel, err := filepath.Rel(root, clean)
+		if err != nil {
+			continue
+		}
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			continue
+		}
+		if best == "" || len(root) > len(best) {
+			best = root
+		}
+	}
+	if best == "" {
+		return "", false
+	}
+	return best, true
+}
+
+func isWatchResourceExhaustion(err error) bool {
+	return errors.Is(err, syscall.EMFILE) || errors.Is(err, syscall.ENOSPC)
+}

--- a/internal/sync/watch_backend_fsnotify_test.go
+++ b/internal/sync/watch_backend_fsnotify_test.go
@@ -1,0 +1,588 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"math"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testFSNotifyBackend(t *testing.T) *fsnotifyBackend {
+	t.Helper()
+	backend, err := newFSNotifyBackend(nil)
+	require.NoError(t, err)
+	t.Cleanup(backend.Stop)
+	return backend
+}
+
+func TestFSNotifyBackendOverflowRequestsLostEventRecovery(t *testing.T) {
+	backend := testFSNotifyBackend(t)
+	errorInput := make(chan error, 1)
+	backend.errorInput = errorInput
+	require.NoError(t, backend.Start())
+	errorInput <- fsnotify.ErrEventOverflow
+
+	pending := newPendingWatchBatch(8, 1_000)
+	event := requireReceiveWithin(t, backend.Events(), time.Second)
+	pending.AddBackendEvent(event)
+	batch, ok := pending.Take()
+
+	require.True(t, ok)
+	assert.Equal(t, WatchBatch{FullSync: true, LostEvents: true}, batch)
+}
+
+func TestFSNotifyBackendOrdinaryErrorRemainsAnError(t *testing.T) {
+	backend := testFSNotifyBackend(t)
+	errorInput := make(chan error, 1)
+	backend.errorInput = errorInput
+	require.NoError(t, backend.Start())
+	sentinel := errors.New("ordinary fsnotify failure")
+	errorInput <- sentinel
+
+	select {
+	case event := <-backend.Events():
+		assert.Fail(t, "ordinary error emitted a watch event", "event: %+v", event)
+	case err := <-backend.Errors():
+		require.ErrorIs(t, err, sentinel)
+	case <-time.After(time.Second):
+		require.FailNow(t, "fsnotify backend did not emit ordinary error")
+	}
+	assert.Never(t, func() bool {
+		select {
+		case <-backend.Events():
+			return true
+		default:
+			return false
+		}
+	}, 50*time.Millisecond, time.Millisecond,
+		"ordinary errors must not request lost-event recovery")
+}
+
+func TestFSNotifyBackendRemoveShallowRootClearsOwnership(t *testing.T) {
+	backend := testFSNotifyBackend(t)
+	base := t.TempDir()
+	removedRoot := filepath.Join(base, "shallow")
+	require.NoError(t, os.Mkdir(removedRoot, 0o755))
+	require.NoError(t, backend.AddShallow(removedRoot))
+	require.NoError(t, backend.Remove(removedRoot))
+
+	result := backend.AddRecursive(base, math.MaxInt)
+	require.NoError(t, result.Err)
+	newDir := filepath.Join(removedRoot, "new")
+	require.NoError(t, os.Mkdir(newDir, 0o755))
+	itemType, excluded := backend.watchCreatedPath(newDir)
+	assert.Equal(t, backendItemDirectory, itemType)
+	assert.False(t, excluded)
+	assert.Contains(t, backend.watcher.WatchList(), newDir,
+		"removed shallow ownership must not suppress recursive auto-watch")
+
+	err := backend.Remove(removedRoot)
+	require.ErrorIs(t, err, fsnotify.ErrNonExistentWatch)
+}
+
+func TestFSNotifyBackendRemoveRecursiveRootRemovesDescendantWatches(t *testing.T) {
+	backend := testFSNotifyBackend(t)
+	root := t.TempDir()
+	descendant := filepath.Join(root, "child", "nested")
+	require.NoError(t, os.MkdirAll(descendant, 0o755))
+	result := backend.AddRecursive(root, math.MaxInt)
+	require.NoError(t, result.Err)
+	require.Equal(t, 3, result.Watched)
+
+	require.NoError(t, backend.Remove(root))
+	assert.Empty(t, backend.watcher.WatchList())
+}
+
+func TestFSNotifyBackendRemovePreservesOverlappingRecursiveRoot(t *testing.T) {
+	backend := testFSNotifyBackend(t)
+	parent := t.TempDir()
+	sibling := filepath.Join(parent, "sibling")
+	child := filepath.Join(parent, "child")
+	nested := filepath.Join(child, "nested")
+	for _, path := range []string{sibling, nested} {
+		require.NoError(t, os.MkdirAll(path, 0o755))
+	}
+	require.NoError(t, backend.AddRecursive(parent, math.MaxInt).Err)
+	require.NoError(t, backend.AddRecursive(child, math.MaxInt).Err)
+
+	require.NoError(t, backend.Remove(parent))
+	watched := backend.watcher.WatchList()
+	slices.Sort(watched)
+	want := []string{child, nested}
+	slices.Sort(want)
+	assert.Equal(t, want, watched)
+}
+
+func TestFSNotifyBackendRemoveDoesNotInheritExcludedParentOwnership(t *testing.T) {
+	backend, err := newFSNotifyBackend([]string{"venv"})
+	require.NoError(t, err)
+	t.Cleanup(backend.Stop)
+	parent := t.TempDir()
+	nestedRoot := filepath.Join(parent, "venv", "project")
+	nestedDir := filepath.Join(nestedRoot, "sessions")
+	require.NoError(t, os.MkdirAll(nestedDir, 0o755))
+
+	require.NoError(t, backend.AddRecursive(parent, math.MaxInt).Err)
+	require.NoError(t, backend.AddRecursive(nestedRoot, math.MaxInt).Err)
+	require.NoError(t, backend.Remove(nestedRoot))
+	assert.Equal(t, []string{parent}, backend.watcher.WatchList(),
+		"excluded parent root must not own explicit nested-root watches")
+
+	require.NoError(t, backend.Start())
+	nestedFile := filepath.Join(nestedDir, "session.jsonl")
+	require.NoError(t, os.WriteFile(nestedFile, []byte("x"), 0o644))
+	assertBackendPathNotEmitted(t, backend.Events(), nestedFile, 100*time.Millisecond)
+}
+
+func TestFSNotifyBackendRemoveDoesNotInheritBudgetSkippedParentOwnership(t *testing.T) {
+	backend := testFSNotifyBackend(t)
+	parent := t.TempDir()
+	nestedRoot := filepath.Join(parent, "nested")
+	nestedDir := filepath.Join(nestedRoot, "sessions")
+	require.NoError(t, os.MkdirAll(nestedDir, 0o755))
+
+	result := backend.AddRecursive(parent, 1)
+	require.NoError(t, result.Err)
+	require.True(t, result.BudgetExhausted)
+	require.NoError(t, backend.AddRecursive(nestedRoot, math.MaxInt).Err)
+	require.NoError(t, backend.Remove(nestedRoot))
+	assert.Equal(t, []string{parent}, backend.watcher.WatchList(),
+		"budget-skipped parent root must not own explicit nested-root watches")
+}
+
+type blockingRemoveWatchOps struct {
+	watcher       *fsnotify.Watcher
+	removeStarted chan struct{}
+	allowRemove   chan struct{}
+	addCalled     chan struct{}
+	removeOnce    sync.Once
+	addOnce       sync.Once
+}
+
+type failPathWatchOps struct {
+	watcher  *fsnotify.Watcher
+	failPath string
+	err      error
+}
+
+func (w *failPathWatchOps) Add(path string) error {
+	if filepath.Clean(path) == filepath.Clean(w.failPath) {
+		return w.err
+	}
+	return w.watcher.Add(path)
+}
+
+func (w *failPathWatchOps) Remove(path string) error {
+	return w.watcher.Remove(path)
+}
+
+func TestFSNotifyBackendRuntimeBudgetDegradesExactScopesToPolling(t *testing.T) {
+	backend := testFSNotifyBackend(t)
+	root := t.TempDir()
+	syncDir := filepath.Join(root, "logical-sessions")
+	polling := make(chan PollingObligation, 1)
+	watcher, err := newWatcherWithBackendOptions(
+		0, 0, func(context.Context, WatchBatch) error { return nil },
+		backend, 8, 1_000,
+		WatcherOptions{OnPollingRequired: func(obligation PollingObligation) error {
+			polling <- obligation
+			return nil
+		}},
+	)
+	require.NoError(t, err)
+	results := watcher.RegisterRoots([]WatchRoot{{
+		Path: root, Recursive: true, Exists: true,
+		Scopes: []WatchScope{{Agent: "claude", SyncDir: syncDir}},
+	}}, 1)
+	require.Len(t, results, 1)
+	require.Equal(t, 1, results[0].Watched)
+	require.NoError(t, backend.Start())
+
+	created := filepath.Join(root, "created-after-startup")
+	require.NoError(t, os.Mkdir(created, 0o755))
+	obligation := requireReceiveWithin(t, polling, time.Second)
+	assert.NotEmpty(t, obligation.Key)
+	assert.Equal(t, []string{syncDir}, obligation.Roots)
+	assert.NotContains(t, backend.watcher.WatchList(), created)
+}
+
+func TestFSNotifyBackendRuntimeDirectoryChurnReclaimsWatchBudget(t *testing.T) {
+	backend := testFSNotifyBackend(t)
+	root := t.TempDir()
+	result := backend.AddRecursive(root, 2)
+	require.NoError(t, result.Err)
+	require.Equal(t, 1, result.Watched)
+	require.NoError(t, backend.Start())
+
+	created := filepath.Join(root, "recreated")
+	for iteration := range 2 {
+		require.NoError(t, os.Mkdir(created, 0o755))
+		waitForBackendEvent(t, backend.Events(), created, backendOpCreate)
+		assert.Contains(t, backend.watcher.WatchList(), created)
+
+		require.NoError(t, os.Remove(created))
+		waitForBackendEvent(t, backend.Events(), created, backendOpRemove|backendOpRename)
+		assert.NotContains(t, backend.watcher.WatchList(), created)
+		backend.watchMu.Lock()
+		_, retained := backend.watchOwners[created]
+		budget := backend.runtimeBudget
+		backend.watchMu.Unlock()
+		assert.False(t, retained, "removed directory ownership must be pruned")
+		assert.Equal(t, 1, budget,
+			"removed native watch must return its runtime budget slot")
+		if iteration == 1 {
+			break
+		}
+	}
+}
+
+func TestFSNotifyBackendRootLossTransfersExactScopeToPolling(t *testing.T) {
+	backend := testFSNotifyBackend(t)
+	root := t.TempDir()
+	child := filepath.Join(root, "ordinary-child")
+	require.NoError(t, os.Mkdir(child, 0o755))
+	syncDir := filepath.Join(root, "logical-sessions")
+	polling := make(chan PollingObligation, 1)
+	watcher, err := newWatcherWithBackendOptions(
+		0, 0, func(context.Context, WatchBatch) error { return nil },
+		backend, 8, 1_000,
+		WatcherOptions{OnPollingRequired: func(obligation PollingObligation) error {
+			polling <- obligation
+			return nil
+		}},
+	)
+	require.NoError(t, err)
+	results := watcher.RegisterRoots([]WatchRoot{{
+		Path: root, Recursive: true, Exists: true,
+		Scopes: []WatchScope{{Agent: "claude", SyncDir: syncDir}},
+	}}, 4)
+	require.Len(t, results, 1)
+	require.Equal(t, 2, results[0].Watched)
+
+	childEvent, relevant := backend.translateEvent(fsnotify.Event{
+		Name: child, Op: fsnotify.Remove,
+	})
+	require.True(t, relevant)
+	assert.Equal(t, backendItemDirectory, childEvent.ItemType)
+	select {
+	case obligation := <-polling:
+		assert.Fail(t, "ordinary descendant loss must not degrade its configured root",
+			"unexpected obligation: %+v", obligation)
+	default:
+	}
+
+	event, relevant := backend.translateEvent(fsnotify.Event{
+		Name: root, Op: fsnotify.Remove,
+	})
+	require.True(t, relevant)
+	assert.Equal(t, backendItemDirectory, event.ItemType)
+	obligation := requireReceiveWithin(t, polling, time.Second)
+	assert.Equal(t, "fsnotify-runtime:"+root, obligation.Key)
+	assert.Equal(t, []string{syncDir}, obligation.Roots)
+	assert.Empty(t, backend.watcher.WatchList())
+}
+
+func waitForBackendEvent(
+	t *testing.T,
+	events <-chan backendEvent,
+	path string,
+	wantOp backendOp,
+) backendEvent {
+	t.Helper()
+	deadline := time.NewTimer(time.Second)
+	defer deadline.Stop()
+	for {
+		select {
+		case event := <-events:
+			if filepath.Clean(event.Path) == filepath.Clean(path) && event.Op&wantOp != 0 {
+				return event
+			}
+		case <-deadline.C:
+			t.Fatalf("backend event %v for %s was not observed", wantOp, path)
+		}
+	}
+}
+
+func TestFSNotifyBackendRuntimeAddFailureDegradesExactScopesToPolling(t *testing.T) {
+	backend := testFSNotifyBackend(t)
+	root := t.TempDir()
+	syncDir := filepath.Join(root, "logical-sessions")
+	polling := make(chan PollingObligation, 1)
+	watcher, err := newWatcherWithBackendOptions(
+		0, 0, func(context.Context, WatchBatch) error { return nil },
+		backend, 8, 1_000,
+		WatcherOptions{OnPollingRequired: func(obligation PollingObligation) error {
+			polling <- obligation
+			return nil
+		}},
+	)
+	require.NoError(t, err)
+	results := watcher.RegisterRoots([]WatchRoot{{
+		Path: root, Recursive: true, Exists: true,
+		Scopes: []WatchScope{{Agent: "claude", SyncDir: syncDir}},
+	}}, 4)
+	require.Len(t, results, 1)
+	require.Equal(t, 1, results[0].Watched)
+
+	created := filepath.Join(root, "unwatchable")
+	require.NoError(t, os.Mkdir(created, 0o755))
+	backend.watchOps = &failPathWatchOps{
+		watcher: backend.watcher, failPath: created, err: syscall.ENOSPC,
+	}
+	itemType, excluded := backend.watchCreatedPath(created)
+	assert.Equal(t, backendItemDirectory, itemType)
+	assert.False(t, excluded)
+	obligation := requireReceiveWithin(t, polling, time.Second)
+	assert.Equal(t, []string{syncDir}, obligation.Roots)
+	assert.NotContains(t, backend.watcher.WatchList(), created)
+}
+
+func TestFSNotifyBackendRuntimeDegradationPreservesOverlappingRootScopes(t *testing.T) {
+	backend := testFSNotifyBackend(t)
+	parent := t.TempDir()
+	nested := filepath.Join(parent, "nested")
+	require.NoError(t, os.Mkdir(nested, 0o755))
+	parentScope := filepath.Join(parent, "parent-sessions")
+	nestedScope := filepath.Join(parent, "nested-sessions")
+	polling := make(chan PollingObligation, 2)
+	watcher, err := newWatcherWithBackendOptions(
+		0, 0, func(context.Context, WatchBatch) error { return nil },
+		backend, 8, 1_000,
+		WatcherOptions{OnPollingRequired: func(obligation PollingObligation) error {
+			polling <- obligation
+			return nil
+		}},
+	)
+	require.NoError(t, err)
+	results := watcher.RegisterRoots([]WatchRoot{
+		{
+			Path: parent, Recursive: true, Exists: true,
+			Scopes: []WatchScope{{Agent: "claude", SyncDir: parentScope}},
+		},
+		{
+			Path: nested, Recursive: true, Exists: true,
+			Scopes: []WatchScope{{Agent: "cursor", SyncDir: nestedScope}},
+		},
+	}, 3)
+	require.Len(t, results, 2)
+	require.Zero(t, backend.runtimeBudget)
+
+	created := filepath.Join(nested, "created-after-startup")
+	require.NoError(t, os.Mkdir(created, 0o755))
+	itemType, excluded := backend.watchCreatedPath(created)
+	assert.Equal(t, backendItemDirectory, itemType)
+	assert.False(t, excluded)
+	first := requireReceiveWithin(t, polling, time.Second)
+	second := requireReceiveWithin(t, polling, time.Second)
+	obligations := map[string][]string{
+		first.Key:  first.Roots,
+		second.Key: second.Roots,
+	}
+	assert.Equal(t, []string{parentScope}, obligations["fsnotify-runtime:"+parent])
+	assert.Equal(t, []string{nestedScope}, obligations["fsnotify-runtime:"+nested])
+}
+
+func TestFSNotifyBackendRuntimeCreateRecursivelyWatchesMovedSubtree(t *testing.T) {
+	backend := testFSNotifyBackend(t)
+	parent := t.TempDir()
+	root := filepath.Join(parent, "watched")
+	source := filepath.Join(parent, "incoming")
+	deepSource := filepath.Join(source, "nested")
+	require.NoError(t, os.MkdirAll(root, 0o755))
+	require.NoError(t, os.MkdirAll(deepSource, 0o755))
+	result := backend.AddRecursive(root, 8)
+	require.NoError(t, result.Err)
+	require.Equal(t, 1, result.Watched)
+
+	moved := filepath.Join(root, "moved")
+	require.NoError(t, os.Rename(source, moved))
+	itemType, excluded := backend.watchCreatedPath(moved)
+	assert.Equal(t, backendItemDirectory, itemType)
+	assert.False(t, excluded)
+	require.NoError(t, backend.Start())
+
+	deepFile := filepath.Join(moved, "nested", "session.jsonl")
+	require.NoError(t, os.WriteFile(deepFile, []byte("changed"), 0o644))
+	deadline := time.NewTimer(time.Second)
+	defer deadline.Stop()
+	for {
+		select {
+		case event := <-backend.Events():
+			if filepath.Clean(event.Path) == filepath.Clean(deepFile) {
+				assert.NotEqual(t, backendOpUnknown, event.Op)
+				return
+			}
+		case <-deadline.C:
+			t.Fatal("deep write under moved subtree was not observed")
+		}
+	}
+}
+
+func (w *blockingRemoveWatchOps) Add(path string) error {
+	w.addOnce.Do(func() { close(w.addCalled) })
+	return w.watcher.Add(path)
+}
+
+func (w *blockingRemoveWatchOps) Remove(path string) error {
+	w.removeOnce.Do(func() { close(w.removeStarted) })
+	<-w.allowRemove
+	return w.watcher.Remove(path)
+}
+
+func TestFSNotifyBackendConcurrentAddWaitsForRemoveOwnershipDecision(t *testing.T) {
+	backend := testFSNotifyBackend(t)
+	root := t.TempDir()
+	require.NoError(t, backend.AddShallow(root))
+	barrier := &blockingRemoveWatchOps{
+		watcher:       backend.watcher,
+		removeStarted: make(chan struct{}),
+		allowRemove:   make(chan struct{}),
+		addCalled:     make(chan struct{}),
+	}
+	backend.watchOps = barrier
+
+	removeErr := make(chan error, 1)
+	go func() { removeErr <- backend.Remove(root) }()
+	select {
+	case <-barrier.removeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("Remove did not reach native-watch barrier")
+	}
+
+	addErr := make(chan error, 1)
+	go func() { addErr <- backend.AddShallow(root) }()
+	addReachedWhileRemoveBlocked := false
+	select {
+	case <-barrier.addCalled:
+		addReachedWhileRemoveBlocked = true
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(barrier.allowRemove)
+	require.NoError(t, <-removeErr)
+	require.NoError(t, <-addErr)
+	assert.False(t, addReachedWhileRemoveBlocked,
+		"native Add must wait for Remove's ownership decision")
+	assert.Contains(t, backend.watcher.WatchList(), root,
+		"the newly retained logical root must keep its native watch")
+}
+
+func assertBackendPathNotEmitted(
+	t *testing.T, events <-chan backendEvent, path string, duration time.Duration,
+) {
+	t.Helper()
+	deadline := time.NewTimer(duration)
+	defer deadline.Stop()
+	for {
+		select {
+		case event := <-events:
+			if !assert.NotEqual(t, path, event.Path) {
+				return
+			}
+		case <-deadline.C:
+			return
+		}
+	}
+}
+
+func TestFSNotifyBackendLifecycleStopBeforeStartReturns(t *testing.T) {
+	backend := testFSNotifyBackend(t)
+	stopped := make(chan struct{})
+	go func() {
+		backend.Stop()
+		close(stopped)
+	}()
+	select {
+	case <-stopped:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("fsnotify backend Stop blocked before Start")
+	}
+	require.NoError(t, backend.Start())
+	backend.Stop()
+}
+
+func TestFSNotifyBackendLifecycleRepeatedStartAndStop(t *testing.T) {
+	backend := testFSNotifyBackend(t)
+	require.NoError(t, backend.Start())
+	require.NoError(t, backend.Start())
+	backend.Stop()
+	backend.Stop()
+}
+
+func TestFSNotifyBackendLifecycleStartStopRace(t *testing.T) {
+	for range 100 {
+		backend := testFSNotifyBackend(t)
+		start := make(chan struct{})
+		startErr := make(chan error, 1)
+		var calls sync.WaitGroup
+		calls.Add(2)
+		go func() {
+			defer calls.Done()
+			<-start
+			startErr <- backend.Start()
+		}()
+		go func() {
+			defer calls.Done()
+			<-start
+			backend.Stop()
+		}()
+		close(start)
+		done := make(chan struct{})
+		go func() {
+			calls.Wait()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("fsnotify backend concurrent Start and Stop deadlocked")
+		}
+		require.NoError(t, <-startErr)
+		backend.Stop()
+	}
+}
+
+// alwaysAddWatchOps accepts every watch so a test can isolate traversal
+// failures from watch-registration failures.
+type alwaysAddWatchOps struct{}
+
+func (alwaysAddWatchOps) Add(string) error    { return nil }
+func (alwaysAddWatchOps) Remove(string) error { return nil }
+
+// An unreadable directory leaves its descendants without native watches even
+// though its own watch registered. Startup traversal must report that as
+// degraded coverage so the owning logical root gains a polling obligation
+// instead of appearing fully watched.
+func TestFSNotifyBackendAddRecursiveCountsUnreadableSubtreeAsUnwatched(
+	t *testing.T,
+) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory read permissions are not enforced on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+	backend := testFSNotifyBackend(t)
+	backend.watchOps = alwaysAddWatchOps{}
+	root := t.TempDir()
+	unreadable := filepath.Join(root, "unreadable")
+	require.NoError(t, os.MkdirAll(filepath.Join(unreadable, "hidden"), 0o755))
+	require.NoError(t, os.Chmod(unreadable, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(unreadable, 0o755) })
+
+	result := backend.AddRecursive(root, 100)
+
+	require.NoError(t, result.Err)
+	assert.Positive(t, result.Unwatched,
+		"an unenumerable subtree must count as degraded coverage")
+}

--- a/internal/sync/watch_failure_test.go
+++ b/internal/sync/watch_failure_test.go
@@ -1,0 +1,745 @@
+package sync
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+type reconciliationRetryRootError interface {
+	error
+	ReconciliationRetryRoots() []string
+}
+
+type partialFailureStreamingProvider struct {
+	*directStreamingProvider
+	discoveryErr error
+}
+
+func (provider *partialFailureStreamingProvider) DiscoverEach(
+	ctx context.Context, yield func(parser.SourceRef) error,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if provider.source != nil {
+		if err := yield(*provider.source); err != nil {
+			return err
+		}
+	}
+	return provider.discoveryErr
+}
+
+type partialFailureStreamingFactory struct {
+	provider *partialFailureStreamingProvider
+}
+
+func (factory partialFailureStreamingFactory) Definition() parser.AgentDef {
+	return factory.provider.Definition()
+}
+
+func (factory partialFailureStreamingFactory) Capabilities() parser.Capabilities {
+	return factory.provider.Capabilities()
+}
+
+func (factory partialFailureStreamingFactory) NewProvider(
+	cfg parser.ProviderConfig,
+) parser.Provider {
+	factory.provider.Config = cfg.Clone()
+	return factory.provider
+}
+
+type fingerprintCountingProvider struct {
+	*directStreamingProvider
+	fingerprintCalls int
+}
+
+type changedPathFailureProvider struct {
+	parser.ProviderBase
+	root              string
+	watchPlanErr      error
+	classificationErr error
+	storedHintScopes  bool
+	contextValue      any
+	sourceCalls       int
+}
+
+func (p *changedPathFailureProvider) WatchPlan(
+	context.Context,
+) (parser.WatchPlan, error) {
+	if p.watchPlanErr != nil {
+		return parser.WatchPlan{}, p.watchPlanErr
+	}
+	return parser.WatchPlan{Roots: []parser.WatchRoot{{Path: p.root}}}, nil
+}
+
+func (p *changedPathFailureProvider) SourcesForChangedPath(
+	ctx context.Context, _ parser.ChangedPathRequest,
+) ([]parser.SourceRef, error) {
+	p.sourceCalls++
+	p.contextValue = ctx.Value(changedPathContextKey{})
+	return nil, p.classificationErr
+}
+
+func (p *changedPathFailureProvider) StoredSourceHintScopes(
+	req parser.ChangedPathRequest,
+) []parser.StoredSourceHintScope {
+	if !p.storedHintScopes {
+		return nil
+	}
+	return []parser.StoredSourceHintScope{{Path: req.Path}}
+}
+
+func (*changedPathFailureProvider) Parse(
+	context.Context, parser.ParseRequest,
+) (parser.ParseOutcome, error) {
+	return parser.ParseOutcome{}, nil
+}
+
+type changedPathFailureFactory struct {
+	provider *changedPathFailureProvider
+}
+
+func (f changedPathFailureFactory) Definition() parser.AgentDef {
+	return f.provider.Definition()
+}
+
+func (f changedPathFailureFactory) Capabilities() parser.Capabilities {
+	return f.provider.Capabilities()
+}
+
+func (f changedPathFailureFactory) NewProvider(
+	cfg parser.ProviderConfig,
+) parser.Provider {
+	f.provider.Config = cfg.Clone()
+	return f.provider
+}
+
+type changedPathContextKey struct{}
+
+func newChangedPathFailureEngine(
+	t *testing.T,
+	database *db.DB,
+	root string,
+	provider *changedPathFailureProvider,
+) *Engine {
+	t.Helper()
+	provider.root = root
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{"changed-path-failure": {root}},
+		Machine:   "local",
+		ProviderFactories: []parser.ProviderFactory{
+			changedPathFailureFactory{provider: provider},
+		},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			"changed-path-failure": parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+	return engine
+}
+
+func (p *fingerprintCountingProvider) Fingerprint(
+	context.Context, parser.SourceRef,
+) (parser.SourceFingerprint, error) {
+	p.fingerprintCalls++
+	return parser.SourceFingerprint{Hash: "stored-hash"}, nil
+}
+
+func TestSyncPathsContextPropagatesChangedPathClassificationFailure(
+	t *testing.T,
+) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	changedPath := filepath.Join(root, "replacement.jsonl")
+	missingPath := filepath.Join(root, "previous.jsonl")
+	require.NoError(t, os.WriteFile(changedPath, []byte("{}\n"), 0o600))
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "previous", Agent: "changed-path-failure", Project: "project",
+		Machine: "local", FilePath: &missingPath,
+	}))
+	require.NoError(t, database.BaselineActiveSessionSourcePaths(
+		t.Context(), "local", []db.SessionSourcePath{{
+			Agent: "changed-path-failure", FilePath: missingPath,
+		}},
+	))
+	wantErr := errors.New("changed-path classification failed")
+	provider := &changedPathFailureProvider{
+		ProviderBase: parser.ProviderBase{
+			Def: parser.AgentDef{Type: "changed-path-failure", FileBased: true},
+		},
+		classificationErr: wantErr,
+	}
+	engine := newChangedPathFailureEngine(t, database, root, provider)
+	ctx := context.WithValue(t.Context(), changedPathContextKey{}, "caller")
+
+	err := engine.SyncPathsContext(ctx, []string{changedPath, missingPath})
+
+	require.ErrorIs(t, err, wantErr)
+	assert.Equal(t, "caller", provider.contextValue,
+		"changed-path classification must receive the watcher context")
+	stored, getErr := database.GetSession(t.Context(), "previous")
+	require.NoError(t, getErr)
+	assert.NotNil(t, stored,
+		"a classification failure must suppress missing-source tombstones")
+}
+
+func TestSyncPathsContextPropagatesChangedPathWatchRootFailure(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	changedPath := filepath.Join(root, "session.jsonl")
+	require.NoError(t, os.WriteFile(changedPath, []byte("{}\n"), 0o600))
+	wantErr := errors.New("watch root resolution failed")
+	provider := &changedPathFailureProvider{
+		ProviderBase: parser.ProviderBase{
+			Def: parser.AgentDef{Type: "changed-path-failure", FileBased: true},
+		},
+		watchPlanErr: wantErr,
+	}
+	engine := newChangedPathFailureEngine(t, database, root, provider)
+
+	err := engine.SyncPathsContext(t.Context(), []string{changedPath})
+
+	require.ErrorIs(t, err, wantErr)
+	assert.Zero(t, provider.sourceCalls,
+		"classification must stop when its watch-root plan is unresolved")
+}
+
+func TestSyncPathsContextPropagatesStoredHintCancellation(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	changedPath := filepath.Join(root, "container.db")
+	require.NoError(t, os.WriteFile(changedPath, []byte("fixture"), 0o600))
+	provider := &changedPathFailureProvider{
+		ProviderBase: parser.ProviderBase{
+			Def: parser.AgentDef{Type: "changed-path-failure", FileBased: true},
+			Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+				StoredSourceHints: parser.CapabilitySupported,
+			}},
+		},
+		storedHintScopes: true,
+	}
+	engine := newChangedPathFailureEngine(t, database, root, provider)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	err := engine.SyncPathsContext(ctx, []string{changedPath})
+
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Zero(t, provider.sourceCalls,
+		"provider classification must not run without its requested stored hints")
+}
+
+func TestSyncPathsContextDoesNotTombstoneAfterIncompleteReplacement(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	changedPath := filepath.Join(root, "replacement.jsonl")
+	missingPath := filepath.Join(root, "previous.jsonl")
+	require.NoError(t, os.WriteFile(changedPath, []byte("{}\n"), 0o600))
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "previous", Agent: "watch-failure", Project: "project",
+		Machine: "local", FilePath: &missingPath,
+	}))
+	source := parser.SourceRef{
+		Provider: "watch-failure", Key: changedPath,
+		DisplayPath: changedPath, FingerprintKey: changedPath,
+	}
+	provider := &directStreamingProvider{
+		ProviderBase: parser.ProviderBase{
+			Def: parser.AgentDef{Type: "watch-failure", FileBased: true},
+			Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+				DiscoverSources: parser.CapabilitySupported,
+				WatchSources:    parser.CapabilitySupported,
+				FindSource:      parser.CapabilitySupported,
+			}},
+		},
+		source:   &source,
+		parseErr: errors.New("replacement parse failed"),
+	}
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{"watch-failure": {root}},
+		Machine:   "local",
+		ProviderFactories: []parser.ProviderFactory{
+			directStreamingFactory{provider: provider},
+		},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			"watch-failure": parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+
+	err := engine.SyncPathsContext(t.Context(), []string{changedPath, missingPath})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "incomplete")
+	stored, getErr := database.GetSession(t.Context(), "previous")
+	require.NoError(t, getErr)
+	assert.NotNil(t, stored,
+		"a failed replacement must not hide the previous archived session")
+}
+
+func TestReconcileWatchRootsCommitsHealthyProvidersAndScopesFailedRetry(t *testing.T) {
+	database := openTestDB(t)
+	healthyRoot := t.TempDir()
+	failedRoot := t.TempDir()
+	healthyPath := filepath.Join(healthyRoot, "session.jsonl")
+	healthyMissingPath := filepath.Join(healthyRoot, "removed.jsonl")
+	require.NoError(t, os.WriteFile(healthyPath, []byte("{}\n"), 0o600))
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "healthy-removed", Agent: "healthy-stream", Project: "project",
+		Machine: "local", FilePath: &healthyMissingPath,
+	}))
+	require.NoError(t, database.BaselineActiveSessionSourcePaths(
+		t.Context(), "local", []db.SessionSourcePath{{
+			Agent: "healthy-stream", FilePath: healthyMissingPath,
+		}},
+	))
+	healthySource := parser.SourceRef{
+		Provider: "healthy-stream", Key: healthyPath,
+		DisplayPath: healthyPath, FingerprintKey: healthyPath,
+	}
+	started := time.Unix(1704067200, 0)
+	healthy := &directStreamingProvider{
+		ProviderBase: parser.ProviderBase{
+			Def: parser.AgentDef{Type: "healthy-stream", FileBased: true},
+			Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+				DiscoverSources:    parser.CapabilitySupported,
+				StreamingDiscovery: parser.CapabilitySupported,
+				WatchSources:       parser.CapabilitySupported,
+				FindSource:         parser.CapabilitySupported,
+			}},
+		},
+		source: &healthySource,
+		parseOutcome: parser.ParseOutcome{
+			Results: []parser.ParseResultOutcome{{
+				Result: parser.ParseResult{Session: parser.ParsedSession{
+					ID: "healthy-session", Agent: "healthy-stream",
+					Project: "project", Machine: "local",
+					StartedAt: started, EndedAt: started,
+					File: parser.FileInfo{Path: healthyPath},
+				}},
+				DataVersion: parser.DataVersionCurrent,
+			}},
+			ResultSetComplete: true,
+		},
+	}
+	failed := &failingDBBackedProvider{
+		ProviderBase: parser.ProviderBase{Def: parser.AgentDef{
+			Type: "failed-stream", FileBased: true,
+		}},
+		err: errors.New("permission denied"), failOnCall: 1,
+	}
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			"healthy-stream": {healthyRoot},
+			"failed-stream":  {failedRoot},
+		},
+		Machine: "local",
+		ProviderFactories: []parser.ProviderFactory{
+			directStreamingFactory{provider: healthy},
+			failingDBBackedFactory{provider: failed},
+		},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			"healthy-stream": parser.ProviderMigrationProviderAuthoritative,
+			"failed-stream":  parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+
+	// Seed a pending subagent relationship among already-committed sessions:
+	// the global linking pass must still run when only an unrelated provider's
+	// discovery failed, or the relationship stays missing indefinitely.
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "link-parent", Agent: "healthy-stream", Project: "project",
+		Machine: "local",
+	}))
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "link-child", Agent: "healthy-stream", Project: "project",
+		Machine: "local",
+	}))
+	require.NoError(t, database.InsertMessages([]db.Message{{
+		SessionID: "link-parent", Ordinal: 0, Role: "assistant",
+		Content: "spawning subagent", HasToolUse: true,
+		ToolCalls: []db.ToolCall{{
+			ToolName: "subagent", Category: "Task",
+			SubagentSessionID: "link-child",
+		}},
+	}}))
+
+	err := engine.ReconcileWatchRoots(context.Background(), nil, true)
+
+	require.Error(t, err)
+	stored, getErr := database.GetSession(t.Context(), "healthy-session")
+	require.NoError(t, getErr)
+	assert.NotNil(t, stored,
+		"one provider failure must not discard healthy provider candidates")
+	linked, getErr := database.GetSession(t.Context(), "link-child")
+	require.NoError(t, getErr)
+	require.NotNil(t, linked)
+	assert.Equal(t, "subagent", linked.RelationshipType,
+		"partial provider failure must not suppress the global subagent linking pass")
+	if assert.NotNil(t, linked.ParentSessionID) {
+		assert.Equal(t, "link-parent", *linked.ParentSessionID)
+	}
+	removed, getErr := database.GetSessionFull(t.Context(), "healthy-removed")
+	require.NoError(t, getErr)
+	require.NotNil(t, removed)
+	require.NotNil(t, removed.DeletionCause)
+	assert.Equal(t, "source_missing", *removed.DeletionCause,
+		"a failed provider must not discard healthy-scope deletion coverage")
+	var retryErr reconciliationRetryRootError
+	require.ErrorAs(t, err, &retryErr)
+	assert.Equal(t, []string{failedRoot}, retryErr.ReconciliationRetryRoots())
+}
+
+// TestReconcileWatchRootsLinkingFailureExpandsRetryToCompletedScopes pins the
+// combined-failure retry scope: when the deferred subagent-linking pass fails
+// alongside a provider discovery failure, the completed healthy scopes are not
+// tombstoned, so they must join the retry roots instead of staying stale
+// indefinitely behind a retry that only re-runs the failed provider.
+func TestReconcileWatchRootsLinkingFailureExpandsRetryToCompletedScopes(t *testing.T) {
+	database := openTestDB(t)
+	healthyRoot := t.TempDir()
+	failedRoot := t.TempDir()
+	healthyPath := filepath.Join(healthyRoot, "session.jsonl")
+	require.NoError(t, os.WriteFile(healthyPath, []byte("{}\n"), 0o600))
+	healthySource := parser.SourceRef{
+		Provider: "healthy-stream", Key: healthyPath,
+		DisplayPath: healthyPath, FingerprintKey: healthyPath,
+	}
+	started := time.Unix(1704067200, 0)
+	healthy := &directStreamingProvider{
+		ProviderBase: parser.ProviderBase{
+			Def: parser.AgentDef{Type: "healthy-stream", FileBased: true},
+			Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+				DiscoverSources:    parser.CapabilitySupported,
+				StreamingDiscovery: parser.CapabilitySupported,
+				WatchSources:       parser.CapabilitySupported,
+				FindSource:         parser.CapabilitySupported,
+			}},
+		},
+		source: &healthySource,
+		parseOutcome: parser.ParseOutcome{
+			Results: []parser.ParseResultOutcome{{
+				Result: parser.ParseResult{Session: parser.ParsedSession{
+					ID: "healthy-session", Agent: "healthy-stream",
+					Project: "project", Machine: "local",
+					StartedAt: started, EndedAt: started,
+					File: parser.FileInfo{Path: healthyPath},
+				}},
+				DataVersion: parser.DataVersionCurrent,
+			}},
+			ResultSetComplete: true,
+		},
+	}
+	failed := &failingDBBackedProvider{
+		ProviderBase: parser.ProviderBase{Def: parser.AgentDef{
+			Type: "failed-stream", FileBased: true,
+		}},
+		err: errors.New("permission denied"), failOnCall: 1,
+	}
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			"healthy-stream": {healthyRoot},
+			"failed-stream":  {failedRoot},
+		},
+		Machine: "local",
+		ProviderFactories: []parser.ProviderFactory{
+			directStreamingFactory{provider: healthy},
+			failingDBBackedFactory{provider: failed},
+		},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			"healthy-stream": parser.ProviderMigrationProviderAuthoritative,
+			"failed-stream":  parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+
+	// Seed a pending link so the global linking pass performs an update, and
+	// make that update fail: only linking transitions relationship_type to
+	// "subagent", so page writes are unaffected.
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "link-parent", Agent: "healthy-stream", Project: "project",
+		Machine: "local",
+	}))
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "link-child", Agent: "healthy-stream", Project: "project",
+		Machine: "local",
+	}))
+	require.NoError(t, database.InsertMessages([]db.Message{{
+		SessionID: "link-parent", Ordinal: 0, Role: "assistant",
+		Content: "spawning subagent", HasToolUse: true,
+		ToolCalls: []db.ToolCall{{
+			ToolName: "subagent", Category: "Task",
+			SubagentSessionID: "link-child",
+		}},
+	}}))
+	raw, err := sql.Open("sqlite3", database.Path())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, raw.Close()) })
+	_, err = raw.Exec(`
+		CREATE TRIGGER fail_subagent_link
+		BEFORE UPDATE OF relationship_type ON sessions
+		WHEN NEW.relationship_type = 'subagent'
+		BEGIN
+			SELECT RAISE(FAIL, 'injected linking failure');
+		END;
+	`)
+	require.NoError(t, err)
+
+	err = engine.ReconcileWatchRoots(context.Background(), nil, true)
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "link subagent sessions")
+	var retryErr reconciliationRetryRootError
+	require.ErrorAs(t, err, &retryErr)
+	assert.ElementsMatch(t, []string{failedRoot, healthyRoot},
+		retryErr.ReconciliationRetryRoots(),
+		"a linking failure blocks completed-scope tombstoning, so those "+
+			"scopes must join the retry roots")
+	stored, getErr := database.GetSession(t.Context(), "healthy-session")
+	require.NoError(t, getErr)
+	assert.NotNil(t, stored,
+		"the linking failure must not discard committed healthy sessions")
+}
+
+func TestReconcileWatchRootsRetainsPartialFailedProviderWithoutDeletionProof(t *testing.T) {
+	database := openTestDB(t)
+	failedRoot := t.TempDir()
+	healthyRoot := t.TempDir()
+	failedPath := filepath.Join(failedRoot, "partial.jsonl")
+	failedMissingPath := filepath.Join(failedRoot, "missing.jsonl")
+	healthyPath := filepath.Join(healthyRoot, "session.jsonl")
+	healthyMissingPath := filepath.Join(healthyRoot, "missing.jsonl")
+	for _, path := range []string{failedPath, healthyPath} {
+		require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o600))
+	}
+	for _, session := range []db.Session{
+		{
+			ID: "failed-missing", Agent: "partial-failure", Project: "project",
+			Machine: "local", FilePath: &failedMissingPath,
+		},
+		{
+			ID: "healthy-missing", Agent: "partial-healthy", Project: "project",
+			Machine: "local", FilePath: &healthyMissingPath,
+		},
+	} {
+		require.NoError(t, database.UpsertSession(session))
+	}
+	require.NoError(t, database.BaselineActiveSessionSourcePaths(
+		t.Context(), "local", []db.SessionSourcePath{
+			{Agent: "partial-failure", FilePath: failedMissingPath},
+			{Agent: "partial-healthy", FilePath: healthyMissingPath},
+		},
+	))
+
+	started := time.Unix(1704067200, 0)
+	newProvider := func(agent parser.AgentType, path, id string) *directStreamingProvider {
+		source := parser.SourceRef{
+			Provider: agent, Key: path, DisplayPath: path, FingerprintKey: path,
+		}
+		return &directStreamingProvider{
+			ProviderBase: parser.ProviderBase{
+				Def: parser.AgentDef{Type: agent, FileBased: true},
+				Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+					DiscoverSources:    parser.CapabilitySupported,
+					StreamingDiscovery: parser.CapabilitySupported,
+					WatchSources:       parser.CapabilitySupported,
+					FindSource:         parser.CapabilitySupported,
+				}},
+			},
+			source: &source,
+			parseOutcome: parser.ParseOutcome{
+				Results: []parser.ParseResultOutcome{{
+					Result: parser.ParseResult{Session: parser.ParsedSession{
+						ID: id, Agent: agent, Project: "project", Machine: "local",
+						StartedAt: started, EndedAt: started,
+						File: parser.FileInfo{Path: path},
+					}},
+					DataVersion: parser.DataVersionCurrent,
+				}},
+				ResultSetComplete: true,
+			},
+		}
+	}
+	discoveryErr := errors.New("partial provider discovery failed")
+	failed := &partialFailureStreamingProvider{
+		directStreamingProvider: newProvider("partial-failure", failedPath, "partial-session"),
+		discoveryErr:            discoveryErr,
+	}
+	healthy := newProvider("partial-healthy", healthyPath, "healthy-session")
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			"partial-failure": {failedRoot},
+			"partial-healthy": {healthyRoot},
+		},
+		Machine: "local",
+		ProviderFactories: []parser.ProviderFactory{
+			partialFailureStreamingFactory{provider: failed},
+			directStreamingFactory{provider: healthy},
+		},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			"partial-failure": parser.ProviderMigrationProviderAuthoritative,
+			"partial-healthy": parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+
+	err := engine.ReconcileWatchRoots(t.Context(), nil, true)
+
+	require.ErrorIs(t, err, discoveryErr)
+	var retryErr reconciliationRetryRootError
+	require.ErrorAs(t, err, &retryErr)
+	assert.Equal(t, []string{failedRoot}, retryErr.ReconciliationRetryRoots())
+	partial, getErr := database.GetSession(t.Context(), "partial-session")
+	require.NoError(t, getErr)
+	assert.NotNil(t, partial, "a valid source yielded before discovery failure must persist")
+	failedMissing, getErr := database.GetSessionFull(t.Context(), "failed-missing")
+	require.NoError(t, getErr)
+	require.NotNil(t, failedMissing)
+	assert.Nil(t, failedMissing.DeletionCause,
+		"an incomplete provider scope must not tombstone missing sources")
+	failedOwnership, listErr := database.ListActiveSessionSourceOwnershipScopesPage(
+		t.Context(), "local", "partial-failure",
+		[]db.StoredSourcePathHintScope{{Path: failedRoot}}, db.SessionSourceCursor{},
+	)
+	require.NoError(t, listErr)
+	require.Len(t, failedOwnership, 1,
+		"an incomplete provider scope must neither add nor remove deletion proof")
+	assert.Equal(t, failedMissingPath, failedOwnership[0].FilePath)
+
+	healthyStored, getErr := database.GetSession(t.Context(), "healthy-session")
+	require.NoError(t, getErr)
+	assert.NotNil(t, healthyStored)
+	healthyMissing, getErr := database.GetSessionFull(t.Context(), "healthy-missing")
+	require.NoError(t, getErr)
+	require.NotNil(t, healthyMissing)
+	require.NotNil(t, healthyMissing.DeletionCause)
+	assert.Equal(t, "source_missing", *healthyMissing.DeletionCause,
+		"an independent completed scope must retain deletion coverage")
+	healthyOwnership, listErr := database.ListActiveSessionSourceOwnershipScopesPage(
+		t.Context(), "local", "partial-healthy",
+		[]db.StoredSourcePathHintScope{{Path: healthyRoot}}, db.SessionSourceCursor{},
+	)
+	require.NoError(t, listErr)
+	require.Len(t, healthyOwnership, 1)
+	assert.Equal(t, healthyPath, healthyOwnership[0].FilePath,
+		"an independent completed scope must baseline its admitted source")
+}
+
+func TestReconcileWatchRootsJoinsProviderAndLaterProcessingFailures(t *testing.T) {
+	database := openTestDB(t)
+	failedRoot := t.TempDir()
+	healthyRoot := t.TempDir()
+	healthyPath := filepath.Join(healthyRoot, "session.jsonl")
+	require.NoError(t, os.WriteFile(healthyPath, []byte("{}\n"), 0o600))
+	discoveryErr := errors.New("provider discovery failed")
+	laterErr := errors.New("reconciliation page failed")
+	failed := &failingDBBackedProvider{
+		ProviderBase: parser.ProviderBase{Def: parser.AgentDef{
+			Type: "join-failed", FileBased: true,
+		}},
+		err: discoveryErr, failOnCall: 1,
+	}
+	healthySource := parser.SourceRef{
+		Provider: "join-healthy", Key: healthyPath,
+		DisplayPath: healthyPath, FingerprintKey: healthyPath,
+	}
+	healthy := &directStreamingProvider{
+		ProviderBase: parser.ProviderBase{
+			Def: parser.AgentDef{Type: "join-healthy", FileBased: true},
+			Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+				StreamingDiscovery: parser.CapabilitySupported,
+			}},
+		},
+		source: &healthySource,
+	}
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			"join-failed":  {failedRoot},
+			"join-healthy": {healthyRoot},
+		},
+		Machine: "local",
+		ProviderFactories: []parser.ProviderFactory{
+			failingDBBackedFactory{provider: failed},
+			directStreamingFactory{provider: healthy},
+		},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			"join-failed":  parser.ProviderMigrationProviderAuthoritative,
+			"join-healthy": parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+	engine.reconciliationSpoolFactory = func(path string) (reconciliationSpoolStore, error) {
+		spool, err := newReconciliationSpool(path)
+		if err != nil {
+			return nil, err
+		}
+		return &failingReconciliationSpool{
+			reconciliationSpoolStore: spool,
+			err:                      laterErr,
+		}, nil
+	}
+
+	err := engine.ReconcileWatchRoots(t.Context(), nil, true)
+
+	require.ErrorIs(t, err, discoveryErr)
+	assert.ErrorIs(t, err, laterErr)
+	var retryErr reconciliationRetryRootError
+	require.ErrorAs(t, err, &retryErr)
+	assert.ElementsMatch(t, []string{failedRoot, healthyRoot},
+		retryErr.ReconciliationRetryRoots(),
+		"a later global processing failure must retry every uncommitted provider scope")
+}
+
+func TestReconciliationCandidateDoesNotHashStableClaudeSource(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	path := filepath.Join(root, "stable-session.jsonl")
+	require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o600))
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	size := info.Size()
+	mtime := info.ModTime().UnixNano()
+	hash := "stored-hash"
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "stable-session", Agent: string(parser.AgentClaude),
+		Project: "project", Machine: "local", FilePath: &path,
+		FileSize: &size, FileMtime: &mtime, FileHash: &hash,
+		DataVersion: db.CurrentDataVersion(),
+	}))
+	require.NoError(t, database.SetSessionDataVersion(
+		"stable-session", db.CurrentDataVersion(),
+	))
+	storedSize, storedMtime, stored := database.GetSessionFileInfo("stable-session")
+	require.True(t, stored)
+	assert.Equal(t, size, storedSize)
+	assert.Equal(t, mtime, storedMtime)
+	assert.Equal(t, db.CurrentDataVersion(), database.GetSessionDataVersion("stable-session"))
+	base := &directStreamingProvider{ProviderBase: parser.ProviderBase{
+		Def: parser.AgentDef{Type: parser.AgentClaude, FileBased: true},
+	}}
+	provider := &fingerprintCountingProvider{directStreamingProvider: base}
+	engine := &Engine{db: database}
+	source := parser.SourceRef{
+		Provider: parser.AgentClaude, Key: path,
+		DisplayPath: path, FingerprintKey: path,
+	}
+
+	_, admitted := engine.reconciliationCandidate(
+		provider, source, []string{root}, nil,
+	)
+
+	assert.True(t, admitted)
+	assert.Zero(t, provider.fingerprintCalls,
+		"duplicate preference must not hash every unchanged Claude transcript")
+}

--- a/internal/sync/watcher.go
+++ b/internal/sync/watcher.go
@@ -1,9 +1,9 @@
 package sync
 
 import (
+	"context"
 	"errors"
 	"fmt"
-	"io/fs"
 	"log"
 	"math"
 	"os"
@@ -11,19 +11,21 @@ import (
 	"slices"
 	"strings"
 	"sync"
-	"syscall"
+	"sync/atomic"
 	"time"
-
-	"github.com/fsnotify/fsnotify"
 )
 
 type RecursiveWatchResult struct {
-	Watched             int
-	Unwatched           int
-	Err                 error
-	BudgetExhausted     bool
-	ResourceExhausted   bool
-	ResourceExhaustedAt string
+	Watched   int
+	Unwatched int
+	Err       error
+	// MissingRootLifecycleOwned reports that the backend has durable native
+	// coverage for a root reported missing in the startup plan. Callers do not
+	// need a periodic polling obligation while this ownership is active.
+	MissingRootLifecycleOwned bool
+	BudgetExhausted           bool
+	ResourceExhausted         bool
+	ResourceExhaustedAt       string
 }
 
 const (
@@ -34,12 +36,67 @@ const (
 	defaultWatchBatchMaxPathBytes = 2 << 20
 )
 
+type WatchItemType uint8
+
+const (
+	ItemIsUnknown WatchItemType = iota
+	ItemIsFile
+	ItemIsDir
+)
+
+type WatchRename struct {
+	Path     string
+	Root     string
+	Agent    string
+	ItemType WatchItemType
+}
+
 // WatchBatch describes one serialized watcher callback. FullSync is an
-// explicit overflow signal: Paths is empty and the consumer must rescan all
-// configured sources so coalescing never silently drops a changed path.
+// explicit overflow signal: retained strings are empty and the consumer must
+// rescan all configured sources so coalescing never silently drops a change.
+// LostEvents distinguishes overflow recovery from an ordinary authoritative
+// reconciliation so freshness shortcuts can be invalidated only when needed.
 type WatchBatch struct {
-	Paths    []string
-	FullSync bool
+	Paths           []string
+	Renames         []WatchRename
+	ReconcileRoots  []string
+	FullSync        bool
+	LostEvents      bool
+	lifecycleTokens []backendLifecycleToken
+}
+
+type WatchCallback func(context.Context, WatchBatch) error
+
+// PollingObligation identifies one independently releasable reason that a set
+// of configured roots needs authoritative polling coverage.
+type PollingObligation struct {
+	Key   string
+	Roots []string
+	// Probe is the physical watcher path whose availability gates this
+	// obligation's reconciliation Roots. For nested provider roots (e.g.
+	// Gemini's <root>/tmp) the physical path differs from the configured
+	// reconciliation scope; probing the scope instead would let polling
+	// authoritatively reconcile a present <root> while the missing physical
+	// subtree holds every session, tombstoning all of them. Empty means the
+	// Roots themselves are the physical paths to probe.
+	Probe string
+}
+
+// WatcherOptions configures runtime ownership handoffs that are not needed by
+// portable watcher backends.
+type WatcherOptions struct {
+	OnCoverageDegraded func([]string) error
+	OnPollingRequired  func(PollingObligation) error
+	OnPollingReleased  func(string) error
+}
+
+// WatchRetryError carries the authoritative reconciliation scope selected by a
+// callback after it classifies a batch. The watcher consumes only FullSync and
+// ReconcileRoots from WatchRetryBatch; ordinary paths and rename metadata are
+// never replayed through this protocol.
+type WatchRetryError interface {
+	error
+	WatchRetryBatch() WatchBatch
 }
 
 // pendingWatchBatch bounds retained strings by both unique path count and the
@@ -47,50 +104,310 @@ type WatchBatch struct {
 // limit. Once either limit would be exceeded, individual paths are discarded
 // in favor of one full-sync marker until Take resets the accumulator.
 type pendingWatchBatch struct {
-	paths        map[string]struct{}
-	pathBytes    int
-	maxEntries   int
-	maxPathBytes int
-	fullSync     bool
+	paths          map[string]struct{}
+	renames        map[WatchRename]struct{}
+	backendRenames map[pendingBackendRename]struct{}
+	roots          map[string]struct{}
+	strings        map[string]struct{}
+	lifecycle      map[backendLifecycleToken]struct{}
+	pathBytes      int
+	maxEntries     int
+	maxPathBytes   int
+	fullSync       bool
+	lostEvents     bool
+	onOverflow     func()
+}
+
+type pendingBackendRename struct {
+	Path     string
+	Root     string
+	ItemType backendItemType
 }
 
 func newPendingWatchBatch(maxEntries, maxPathBytes int) *pendingWatchBatch {
 	return &pendingWatchBatch{
-		paths:        make(map[string]struct{}),
-		maxEntries:   maxEntries,
-		maxPathBytes: maxPathBytes,
+		paths:          make(map[string]struct{}),
+		renames:        make(map[WatchRename]struct{}),
+		backendRenames: make(map[pendingBackendRename]struct{}),
+		roots:          make(map[string]struct{}),
+		strings:        make(map[string]struct{}),
+		lifecycle:      make(map[backendLifecycleToken]struct{}),
+		maxEntries:     maxEntries,
+		maxPathBytes:   maxPathBytes,
 	}
 }
 
 func (p *pendingWatchBatch) Empty() bool {
-	return !p.fullSync && len(p.paths) == 0
+	return !p.fullSync && len(p.paths) == 0 && len(p.renames) == 0 &&
+		len(p.backendRenames) == 0 && len(p.roots) == 0 && len(p.lifecycle) == 0
 }
 
 func (p *pendingWatchBatch) Add(path string) {
-	if p.fullSync {
-		return
-	}
 	if _, exists := p.paths[path]; exists {
 		return
 	}
-	if len(p.paths)+1 > p.maxEntries ||
-		p.pathBytes+len(path) > p.maxPathBytes {
-		clear(p.paths)
-		p.pathBytes = 0
-		p.fullSync = true
+	if !p.retainStrings(path) {
 		return
 	}
 	p.paths[path] = struct{}{}
-	p.pathBytes += len(path)
+}
+
+// AddCreatedSubtreePath retains one file found under a newly created
+// directory while reserving enough capacity for the owning-root fallback. If
+// the file would consume that reserve, the root is retained instead and the
+// caller stops enumerating. Unrelated pending work can still exhaust even the
+// reserve, in which case the existing full-sync overflow contract applies.
+func (p *pendingWatchBatch) AddCreatedSubtreePath(path, root string) bool {
+	if p.fullSync {
+		return false
+	}
+	if _, exists := p.paths[path]; exists {
+		return true
+	}
+	if root == "" || p.canRetainStrings(path, root) {
+		p.Add(path)
+		return !p.fullSync
+	}
+	p.AddReconcileRoot(root)
+	return false
+}
+
+func (p *pendingWatchBatch) AddRename(rename WatchRename) {
+	if rename.Path == "" {
+		return
+	}
+	if _, exists := p.renames[rename]; exists {
+		return
+	}
+	if len(p.renames)+1 > p.maxEntries {
+		p.overflow()
+		return
+	}
+	if !p.retainStrings(rename.Path, rename.Root, rename.Agent) {
+		return
+	}
+	p.renames[rename] = struct{}{}
+}
+
+func (p *pendingWatchBatch) AddReconcileRoot(root string) {
+	if root == "" {
+		return
+	}
+	if _, exists := p.roots[root]; exists {
+		return
+	}
+	if !p.retainStrings(root) {
+		return
+	}
+	p.roots[root] = struct{}{}
+}
+
+func (p *pendingWatchBatch) AddBackendEvent(event backendEvent) bool {
+	if event.Op == backendOpUnknown {
+		return !p.fullSync
+	}
+	wasFullSync := p.fullSync
+	// Lifecycle acknowledgement remains necessary after a batch has already
+	// been promoted to authoritative reconciliation. Record the token first so
+	// sustained overflow cannot strand a backend gate.
+	if event.Lifecycle.valid() {
+		p.AddLifecycle(event.Lifecycle)
+	}
+	if event.Op&backendOpFullSync != 0 {
+		p.AddFullSync()
+		return false
+	}
+	if event.Op&backendOpReconcileRootChange != 0 {
+		root := event.Root
+		if root == "" {
+			root = event.Path
+		}
+		p.AddReconcileRoot(root)
+	}
+	if event.Op&backendOpRename != 0 {
+		rename := pendingBackendRename{
+			Path:     event.Path,
+			Root:     event.Root,
+			ItemType: event.ItemType,
+		}
+		if rename.Path == "" {
+			return wasFullSync || !p.fullSync
+		}
+		if _, exists := p.backendRenames[rename]; exists {
+			return true
+		}
+		if !p.retainStrings(rename.Path, rename.Root) {
+			return false
+		}
+		p.backendRenames[rename] = struct{}{}
+		return wasFullSync || !p.fullSync
+	}
+	if event.Op&backendOpReconcileRootChange == 0 && event.Path != "" {
+		p.Add(event.Path)
+	}
+	return wasFullSync || !p.fullSync
+}
+
+func (p *pendingWatchBatch) AddLifecycle(token backendLifecycleToken) {
+	if !token.valid() {
+		return
+	}
+	if _, exists := p.lifecycle[token]; exists {
+		return
+	}
+	if len(p.strings)+len(p.lifecycle)+1 > p.maxEntries {
+		p.overflow()
+		if len(p.lifecycle)+1 > p.maxEntries {
+			return
+		}
+	}
+	p.lifecycle[token] = struct{}{}
+}
+
+func (p *pendingWatchBatch) AddFullSync() {
+	p.makeFullSync(true)
+}
+
+// retainFullSync adds a retry marker without discarding newer fine-grained
+// work that arrived while the failed authoritative callback was running.
+func (p *pendingWatchBatch) retainFullSync() {
+	p.fullSync = true
+}
+
+// merge retains another bounded accumulator's observable work. The source is
+// immutable for the duration of the call, which lets native callbacks publish
+// through an atomic handoff while the watcher drains the primary accumulator.
+func (p *pendingWatchBatch) merge(other *pendingWatchBatch) {
+	if other == nil {
+		return
+	}
+	if other.fullSync {
+		p.makeFullSync(other.lostEvents)
+	}
+	for path := range other.paths {
+		p.Add(path)
+	}
+	for rename := range other.renames {
+		p.AddRename(rename)
+	}
+	for rename := range other.backendRenames {
+		p.AddBackendEvent(backendEvent{
+			Path: rename.Path, Root: rename.Root,
+			Op: backendOpRename, ItemType: rename.ItemType,
+		})
+	}
+	for root := range other.roots {
+		p.AddReconcileRoot(root)
+	}
+	for token := range other.lifecycle {
+		p.AddLifecycle(token)
+	}
+}
+
+func (p *pendingWatchBatch) retainStrings(values ...string) bool {
+	additionalEntries, additionalBytes := p.retainedStringCost(values...)
+	if len(p.strings)+additionalEntries > p.maxEntries ||
+		p.pathBytes+additionalBytes > p.maxPathBytes {
+		p.overflow()
+		return false
+	}
+	for _, value := range values {
+		if value != "" {
+			p.strings[value] = struct{}{}
+		}
+	}
+	p.pathBytes += additionalBytes
+	return true
+}
+
+func (p *pendingWatchBatch) canRetainStrings(values ...string) bool {
+	additionalEntries, additionalBytes := p.retainedStringCost(values...)
+	return len(p.strings)+additionalEntries <= p.maxEntries &&
+		p.pathBytes+additionalBytes <= p.maxPathBytes
+}
+
+func (p *pendingWatchBatch) retainedStringCost(values ...string) (int, int) {
+	additionalEntries := 0
+	additionalBytes := 0
+	for i, value := range values {
+		if value == "" {
+			continue
+		}
+		if _, exists := p.strings[value]; exists {
+			continue
+		}
+		duplicate := slices.Contains(values[:i], value)
+		if duplicate {
+			continue
+		}
+		additionalEntries++
+		additionalBytes += len(value)
+	}
+	return additionalEntries, additionalBytes
+}
+
+func (p *pendingWatchBatch) overflow() {
+	if !p.fullSync && p.onOverflow != nil {
+		p.onOverflow()
+	}
+	p.makeFullSync(true)
+}
+
+func (p *pendingWatchBatch) makeFullSync(lostEvents bool) {
+	clear(p.paths)
+	clear(p.renames)
+	clear(p.backendRenames)
+	clear(p.roots)
+	clear(p.strings)
+	p.pathBytes = 0
+	p.fullSync = true
+	p.lostEvents = p.lostEvents || lostEvents
 }
 
 func (p *pendingWatchBatch) Take() (WatchBatch, bool) {
+	return p.TakeWithRootAgents(nil)
+}
+
+func (p *pendingWatchBatch) TakeWithRootAgents(
+	agentsForRoot func(string) []string,
+) (WatchBatch, bool) {
 	if p.Empty() {
 		return WatchBatch{}, false
 	}
 	if p.fullSync {
 		p.fullSync = false
-		return WatchBatch{FullSync: true}, true
+		lostEvents := p.lostEvents
+		p.lostEvents = false
+		tokens := p.takeLifecycleTokens()
+		return WatchBatch{
+			FullSync: true, LostEvents: lostEvents, lifecycleTokens: tokens,
+		}, true
+	}
+	for rename := range p.backendRenames {
+		agents := []string{""}
+		if agentsForRoot != nil {
+			agents = agentsForRoot(rename.Root)
+			if len(agents) == 0 {
+				agents = []string{""}
+			}
+		}
+		for _, agent := range agents {
+			p.AddRename(WatchRename{
+				Path:     rename.Path,
+				Root:     rename.Root,
+				Agent:    agent,
+				ItemType: watchItemType(rename.ItemType),
+			})
+			if p.fullSync {
+				p.fullSync = false
+				lostEvents := p.lostEvents
+				p.lostEvents = false
+				tokens := p.takeLifecycleTokens()
+				return WatchBatch{
+					FullSync: true, LostEvents: lostEvents, lifecycleTokens: tokens,
+				}, true
+			}
+		}
 	}
 
 	paths := make([]string, 0, len(p.paths))
@@ -98,30 +415,240 @@ func (p *pendingWatchBatch) Take() (WatchBatch, bool) {
 		paths = append(paths, path)
 	}
 	slices.Sort(paths)
+	renames := make([]WatchRename, 0, len(p.renames))
+	for rename := range p.renames {
+		renames = append(renames, rename)
+	}
+	slices.SortFunc(renames, func(a, b WatchRename) int {
+		if c := strings.Compare(a.Path, b.Path); c != 0 {
+			return c
+		}
+		if c := strings.Compare(a.Root, b.Root); c != 0 {
+			return c
+		}
+		if c := strings.Compare(a.Agent, b.Agent); c != 0 {
+			return c
+		}
+		return int(a.ItemType) - int(b.ItemType)
+	})
+	roots := make([]string, 0, len(p.roots))
+	for root := range p.roots {
+		roots = append(roots, root)
+	}
+	slices.Sort(roots)
 	clear(p.paths)
+	clear(p.renames)
+	clear(p.backendRenames)
+	clear(p.roots)
+	clear(p.strings)
+	tokens := p.takeLifecycleTokens()
 	p.pathBytes = 0
-	return WatchBatch{Paths: paths}, true
+	lostEvents := p.lostEvents
+	p.lostEvents = false
+	return WatchBatch{
+		Paths: paths, Renames: renames, ReconcileRoots: roots,
+		LostEvents: lostEvents, lifecycleTokens: tokens,
+	}, true
 }
 
-// Watcher uses fsnotify to watch session directories for changes and triggers
-// serialized callbacks with short-burst batching and a dispatch floor.
-type Watcher struct {
-	onChange     func(batch WatchBatch)
-	watcher      *fsnotify.Watcher
-	batchDelay   time.Duration
-	minInterval  time.Duration
-	maxEntries   int
-	maxPathBytes int
-	excludes     []string
-	roots        []string
-	shallow      []string
-	rootsMu      sync.RWMutex
-	dispatchMu   sync.Mutex
-	stopping     bool
-	stop         chan struct{}
-	done         chan struct{}
-	stopOnce     sync.Once
+func (p *pendingWatchBatch) takeLifecycleTokens() []backendLifecycleToken {
+	if len(p.lifecycle) == 0 {
+		return nil
+	}
+	tokens := make([]backendLifecycleToken, 0, len(p.lifecycle))
+	for token := range p.lifecycle {
+		tokens = append(tokens, token)
+	}
+	clear(p.lifecycle)
+	return tokens
 }
+
+type watchEventSink struct {
+	mu        sync.Mutex
+	pending   *pendingWatchBatch
+	handoff   atomic.Pointer[pendingWatchBatch]
+	overflows boundedCounter
+	wake      chan struct{}
+}
+
+type boundedCounter struct {
+	value atomic.Uint32
+}
+
+func (c *boundedCounter) Add(delta uint32) {
+	for delta > 0 {
+		current := c.value.Load()
+		if current == math.MaxUint32 {
+			return
+		}
+		remaining := math.MaxUint32 - current
+		increment := min(delta, remaining)
+		if c.value.CompareAndSwap(current, current+increment) {
+			return
+		}
+	}
+}
+
+func (c *boundedCounter) Inc() { c.Add(1) }
+
+func (c *boundedCounter) Load() uint32 { return c.value.Load() }
+
+func newWatchEventSink(maxEntries, maxPathBytes int) *watchEventSink {
+	sink := &watchEventSink{
+		pending: newPendingWatchBatch(maxEntries, maxPathBytes),
+		wake:    make(chan struct{}, 1),
+	}
+	sink.pending.onOverflow = sink.overflows.Inc
+	return sink
+}
+
+func (s *watchEventSink) TryAccumulate(
+	accumulate func(add func(backendEvent) bool) bool,
+) bool {
+	batch := newPendingWatchBatch(s.pending.maxEntries, s.pending.maxPathBytes)
+	batch.onOverflow = s.overflows.Inc
+	meaningful := accumulate(batch.AddBackendEvent)
+	if batch.Empty() {
+		return true
+	}
+	s.publishHandoff(batch)
+	if meaningful {
+		s.signal()
+	}
+	return true
+}
+
+func (s *watchEventSink) Add(event backendEvent) {
+	s.mu.Lock()
+	s.absorbHandoff()
+	s.pending.AddBackendEvent(event)
+	s.mu.Unlock()
+}
+
+func (s *watchEventSink) AddCreatedSubtreePath(path, root string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.absorbHandoff()
+	return s.pending.AddCreatedSubtreePath(path, root)
+}
+
+// RetainAuthoritative records a lifecycle-bearing full reconciliation through
+// the same lock-free bounded handoff used by native callbacks.
+func (s *watchEventSink) RetainAuthoritative(token backendLifecycleToken) {
+	batch := newPendingWatchBatch(s.pending.maxEntries, s.pending.maxPathBytes)
+	batch.AddFullSync()
+	batch.AddLifecycle(token)
+	s.publishHandoff(batch)
+	s.signal()
+}
+
+func (s *watchEventSink) Empty() bool {
+	if s.handoff.Load() != nil {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.pending.Empty()
+}
+
+func (s *watchEventSink) Take(
+	agentsForRoot func(string) []string,
+) (WatchBatch, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.absorbHandoff()
+	return s.pending.TakeWithRootAgents(agentsForRoot)
+}
+
+func (s *watchEventSink) RetainRetry(retry WatchBatch) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.absorbHandoff()
+	retainWatchRetry(s.pending, retry)
+}
+
+func (s *watchEventSink) publishHandoff(batch *pendingWatchBatch) {
+	for {
+		current := s.handoff.Load()
+		if current == nil {
+			if s.handoff.CompareAndSwap(nil, batch) {
+				return
+			}
+			continue
+		}
+
+		merged := newPendingWatchBatch(current.maxEntries, current.maxPathBytes)
+		merged.merge(current)
+		merged.merge(batch)
+		capacityOverflow := !current.fullSync && !batch.fullSync && merged.fullSync
+		if s.handoff.CompareAndSwap(current, merged) {
+			if capacityOverflow {
+				s.overflows.Inc()
+			}
+			return
+		}
+	}
+}
+
+// absorbHandoff runs only while mu is held. Native callbacks never acquire mu:
+// they publish one independently bounded accumulator and return immediately.
+func (s *watchEventSink) absorbHandoff() bool {
+	batch := s.handoff.Swap(nil)
+	if batch == nil {
+		return false
+	}
+	s.pending.merge(batch)
+	return true
+}
+
+func (s *watchEventSink) signal() {
+	select {
+	case s.wake <- struct{}{}:
+	default:
+	}
+}
+
+// Watcher schedules backend changes into serialized callbacks with short-burst
+// batching and a dispatch floor.
+type Watcher struct {
+	onChange            WatchCallback
+	onCoverageDegraded  func([]string) error
+	callbackCtx         context.Context
+	callbackCancel      context.CancelFunc
+	backend             watchBackend
+	eventSink           *watchEventSink
+	batchDelay          time.Duration
+	minInterval         time.Duration
+	maxEntries          int
+	dispatchEnabled     atomic.Bool
+	dispatchMu          sync.Mutex
+	rootAgentsMu        sync.RWMutex
+	rootAgents          map[string][]string
+	registeredSyncRoots []string
+	stopping            bool
+	lifecycleMu         sync.Mutex
+	lifecycle           watcherLifecycle
+	startErr            error
+	stop                chan struct{}
+	done                chan struct{}
+	backendStopOnce     sync.Once
+	doneOnce            sync.Once
+}
+
+// completeRootPlanBackend owns lifecycle coverage for roots that may not
+// exist yet. Portable backends continue using Watcher's per-root fallback.
+type completeRootPlanBackend interface {
+	RegisterRoots([]WatchRoot, int) []RecursiveWatchResult
+}
+
+type watcherLifecycle uint8
+
+const (
+	watcherNew watcherLifecycle = iota
+	watcherCollecting
+	watcherDispatching
+	watcherStopped
+)
 
 // NewWatcher creates a file watcher that uses delay for both batching and the
 // minimum interval between callbacks.
@@ -145,6 +672,24 @@ func NewWatcherWithInterval(
 	)
 }
 
+// NewWatcherWithCallback creates a watcher whose serialized callback reports
+// whether an authoritative reconciliation succeeded. Failed reconciliation
+// markers remain pending for a later callback attempt.
+func NewWatcherWithCallback(
+	batchDelay, minInterval time.Duration,
+	onChange WatchCallback, excludes []string, options WatcherOptions,
+) (*Watcher, error) {
+	backend, err := newWatchBackend(excludes)
+	if err != nil {
+		return nil, err
+	}
+	return newWatcherWithBackendOptions(
+		batchDelay, minInterval, onChange, backend,
+		defaultWatchBatchMaxEntries, defaultWatchBatchMaxPathBytes,
+		options,
+	)
+}
+
 func newWatcherWithLimits(
 	batchDelay, minInterval time.Duration,
 	onChange func(batch WatchBatch), excludes []string,
@@ -154,23 +699,98 @@ func newWatcherWithLimits(
 		return nil, fmt.Errorf("onChange callback is nil: %w", os.ErrInvalid)
 	}
 
-	fsw, err := fsnotify.NewWatcher()
+	backend, err := newWatchBackend(excludes)
 	if err != nil {
 		return nil, err
 	}
+	return newWatcherWithBackend(
+		batchDelay,
+		minInterval,
+		func(_ context.Context, batch WatchBatch) error {
+			for _, rename := range batch.Renames {
+				if !slices.Contains(batch.Paths, rename.Path) {
+					batch.Paths = append(batch.Paths, rename.Path)
+				}
+			}
+			slices.Sort(batch.Paths)
+			onChange(batch)
+			return nil
+		},
+		backend,
+		maxEntries,
+		maxPathBytes,
+	)
+}
 
+func newWatcherWithBackend(
+	batchDelay, minInterval time.Duration,
+	onChange WatchCallback, backend watchBackend,
+	maxEntries, maxPathBytes int,
+) (*Watcher, error) {
+	return newWatcherWithBackendOptions(
+		batchDelay, minInterval, onChange, backend, maxEntries, maxPathBytes,
+		WatcherOptions{},
+	)
+}
+
+func newWatcherWithBackendOptions(
+	batchDelay, minInterval time.Duration,
+	onChange WatchCallback, backend watchBackend,
+	maxEntries, maxPathBytes int,
+	options WatcherOptions,
+) (*Watcher, error) {
+	if onChange == nil {
+		return nil, fmt.Errorf("onChange callback is nil: %w", os.ErrInvalid)
+	}
+	if backend == nil {
+		return nil, fmt.Errorf("watch backend is nil: %w", os.ErrInvalid)
+	}
+
+	callbackCtx, callbackCancel := context.WithCancel(context.Background())
 	w := &Watcher{
-		onChange:     onChange,
-		watcher:      fsw,
-		batchDelay:   batchDelay,
-		minInterval:  minInterval,
-		maxEntries:   maxEntries,
-		maxPathBytes: maxPathBytes,
-		excludes:     normalizeExcludePatterns(excludes),
-		stop:         make(chan struct{}),
-		done:         make(chan struct{}),
+		onChange:           onChange,
+		onCoverageDegraded: options.OnCoverageDegraded,
+		callbackCtx:        callbackCtx,
+		callbackCancel:     callbackCancel,
+		backend:            backend,
+		eventSink:          newWatchEventSink(maxEntries, maxPathBytes),
+		batchDelay:         batchDelay,
+		minInterval:        minInterval,
+		maxEntries:         maxEntries,
+		rootAgents:         make(map[string][]string),
+		stop:               make(chan struct{}),
+		done:               make(chan struct{}),
+	}
+	if direct, ok := backend.(directEventBackend); ok {
+		direct.bindEventSink(w.eventSink)
+	}
+	if degraded, ok := backend.(coverageDegradationBackend); ok {
+		degraded.bindCoverageDegraded(options.OnCoverageDegraded)
+	}
+	if ownership, ok := backend.(pollingOwnershipBackend); ok {
+		ownership.bindPollingOwnership(
+			options.OnPollingRequired, options.OnPollingReleased,
+		)
 	}
 	return w, nil
+}
+
+// SetRootAgents records the exact configured agents that own a logical watch
+// root. It must be called before Start for roots whose rename events need
+// indexed descendant classification.
+func (w *Watcher) SetRootAgents(root string, agents []string) {
+	w.rootAgentsMu.Lock()
+	defer w.rootAgentsMu.Unlock()
+	owners := append([]string(nil), agents...)
+	slices.Sort(owners)
+	owners = slices.Compact(owners)
+	w.rootAgents[filepath.Clean(root)] = owners
+}
+
+func (w *Watcher) agentsForRoot(root string) []string {
+	w.rootAgentsMu.RLock()
+	defer w.rootAgentsMu.RUnlock()
+	return append([]string(nil), w.rootAgents[filepath.Clean(root)]...)
 }
 
 // WatchRecursive walks a directory tree and adds all
@@ -187,48 +807,7 @@ func (w *Watcher) WatchRecursive(root string) (watched int, unwatched int, err e
 // exhaustion, so the caller can degrade the rest of the tree to
 // polling without continuing to traverse it.
 func (w *Watcher) WatchRecursiveBudgeted(root string, budget int) RecursiveWatchResult {
-	var result RecursiveWatchResult
-	root = filepath.Clean(root)
-	w.addRoot(root)
-
-	remaining := budget
-	result.Err = filepath.WalkDir(root,
-		func(path string, d fs.DirEntry, err error) error {
-			if err != nil {
-				return nil // skip inaccessible dirs
-			}
-			if !d.IsDir() {
-				return nil
-			}
-			// Skip entire excluded subtrees, but always keep the root.
-			if path != root && w.shouldExcludeForRoot(path, root) {
-				return filepath.SkipDir
-			}
-			if remaining <= 0 {
-				result.BudgetExhausted = true
-				return filepath.SkipAll
-			}
-			if addErr := w.watcher.Add(path); addErr != nil {
-				result.Unwatched++
-				if isWatchResourceExhaustion(addErr) {
-					result.ResourceExhausted = true
-					result.ResourceExhaustedAt = path
-					return filepath.SkipAll
-				}
-				return nil
-			}
-			remaining--
-			result.Watched++
-			return nil
-		})
-	if errors.Is(result.Err, filepath.SkipAll) {
-		result.Err = nil
-	}
-	return result
-}
-
-func isWatchResourceExhaustion(err error) bool {
-	return errors.Is(err, syscall.EMFILE) || errors.Is(err, syscall.ENOSPC)
+	return w.backend.AddRecursive(root, budget)
 }
 
 // WatchShallow adds only the root directory to the watch list,
@@ -236,49 +815,156 @@ func isWatchResourceExhaustion(err error) bool {
 // with many subdirectories where periodic sync handles changes.
 // Returns true if the directory was successfully watched.
 func (w *Watcher) WatchShallow(root string) bool {
-	root = filepath.Clean(root)
-	w.addRoot(root)
-	w.addShallowRoot(root)
-	return w.watcher.Add(root) == nil
+	return w.backend.AddShallow(root) == nil
 }
 
-// Start begins processing file events in a goroutine.
-func (w *Watcher) Start() {
+// Start begins processing file events and dispatching callbacks. Callers that
+// need to cover a startup scan use StartCollecting followed by OpenDispatch.
+func (w *Watcher) Start() error {
+	return w.start(true)
+}
+
+// StartCollecting begins draining the native backend into the bounded event
+// sink without invoking callbacks.
+func (w *Watcher) StartCollecting() error {
+	return w.start(false)
+}
+
+func (w *Watcher) start(openDispatch bool) error {
+	w.lifecycleMu.Lock()
+	defer w.lifecycleMu.Unlock()
+	if w.lifecycle == watcherCollecting && openDispatch {
+		w.lifecycle = watcherDispatching
+		w.dispatchEnabled.Store(true)
+		w.eventSink.signal()
+		return nil
+	}
+	if w.lifecycle != watcherNew {
+		return w.startErr
+	}
+	if err := w.backend.Start(); err != nil {
+		w.lifecycle = watcherStopped
+		w.beginStopping()
+		w.stopBackend()
+		w.finish()
+		if w.onCoverageDegraded != nil && len(w.registeredSyncRoots) > 0 {
+			err = errors.Join(err, w.onCoverageDegraded(w.registeredSyncRoots))
+		}
+		w.startErr = fmt.Errorf("starting %s backend: %w", w.backend.Name(), err)
+		log.Printf("watcher: %v", w.startErr)
+		return w.startErr
+	}
+	w.lifecycle = watcherCollecting
 	go w.loop()
+	if openDispatch {
+		w.lifecycle = watcherDispatching
+		w.dispatchEnabled.Store(true)
+	}
+	return nil
+}
+
+// QueueRetryBatch enqueues a retry batch into the watcher's event sink
+// through the same retention path a failed callback uses, preserving the
+// batch's LostEvents value: an ordinary queued full sync must not clear
+// freshness caches the way a watcher-overflow full sync does. During
+// collecting mode the batch dispatches when OpenDispatch fires; afterwards it
+// dispatches like any backend event and follows the callback retry machinery
+// on failure. The daemon uses it to hand a failed startup gap reconciliation
+// to the watcher instead of leaving the affected roots undiscovered until an
+// unrelated event, manual sync, or audit.
+func (w *Watcher) QueueRetryBatch(batch WatchBatch) {
+	if !batch.FullSync && len(batch.ReconcileRoots) == 0 &&
+		len(batch.Paths) == 0 {
+		return
+	}
+	w.eventSink.RetainRetry(batch)
+	w.eventSink.signal()
+}
+
+// OpenDispatch transitions a collecting watcher to callback dispatch. It is
+// idempotent and has no effect after Stop.
+func (w *Watcher) OpenDispatch() {
+	w.lifecycleMu.Lock()
+	defer w.lifecycleMu.Unlock()
+	if w.lifecycle != watcherCollecting {
+		return
+	}
+	w.lifecycle = watcherDispatching
+	w.dispatchEnabled.Store(true)
+	w.eventSink.signal()
 }
 
 // Stop stops the watcher and waits for it to finish.
 func (w *Watcher) Stop() {
-	w.stopOnce.Do(func() {
-		w.dispatchMu.Lock()
-		w.stopping = true
-		close(w.stop)
-		w.dispatchMu.Unlock()
-		<-w.done
-		w.watcher.Close()
-	})
+	w.lifecycleMu.Lock()
+	if w.lifecycle == watcherStopped {
+		done := w.done
+		w.lifecycleMu.Unlock()
+		<-done
+		return
+	}
+	wasRunning := w.lifecycle == watcherCollecting ||
+		w.lifecycle == watcherDispatching
+	w.lifecycle = watcherStopped
+	w.dispatchEnabled.Store(false)
+	w.beginStopping()
+	w.stopBackend()
+	if !wasRunning {
+		w.finish()
+	}
+	done := w.done
+	w.lifecycleMu.Unlock()
+	<-done
+}
+
+func (w *Watcher) beginStopping() {
+	w.dispatchMu.Lock()
+	defer w.dispatchMu.Unlock()
+	if w.stopping {
+		return
+	}
+	w.stopping = true
+	w.callbackCancel()
+	close(w.stop)
+}
+
+func (w *Watcher) stopBackend() {
+	w.backendStopOnce.Do(w.backend.Stop)
+}
+
+func (w *Watcher) finish() {
+	w.doneOnce.Do(func() { close(w.done) })
 }
 
 func (w *Watcher) loop() {
 	batches := make(chan WatchBatch)
-	callbackDone := make(chan time.Time, 1)
+	type callbackResult struct {
+		batch     WatchBatch
+		startedAt time.Time
+		err       error
+	}
+	callbackDone := make(chan callbackResult, 1)
 	var worker sync.WaitGroup
 	worker.Go(func() {
 		for batch := range batches {
 			if batch.FullSync {
-				log.Printf("watcher: pending path limit exceeded, triggering full sync")
+				log.Printf(
+					"watcher: authoritative full sync requested (pending overflows=%d)",
+					w.eventSink.overflows.Load(),
+				)
 			} else {
 				log.Printf("watcher: %d file(s) changed, triggering sync", len(batch.Paths))
 			}
 			startedAt := time.Now()
-			w.onChange(batch)
-			callbackDone <- startedAt
+			err := w.onChange(w.callbackCtx, batch)
+			callbackDone <- callbackResult{batch: batch, startedAt: startedAt, err: err}
 		}
 	})
 
-	pending := newPendingWatchBatch(w.maxEntries, w.maxPathBytes)
 	var firstPendingAt time.Time
+	pendingDelay := w.batchDelay
 	var lastDispatch time.Time
+	consecutiveFailures := 0
 	var timer *time.Timer
 	var timerC <-chan time.Time
 	callbackBusy := false
@@ -294,14 +980,15 @@ func (w *Watcher) loop() {
 		stopTimer()
 		close(batches)
 		worker.Wait()
-		close(w.done)
+		w.finish()
 	}()
 
 	schedule := func() {
-		if callbackBusy || pending.Empty() || timerC != nil {
+		if !w.dispatchEnabled.Load() || callbackBusy ||
+			w.eventSink.Empty() || timerC != nil {
 			return
 		}
-		deadline := firstPendingAt.Add(w.batchDelay)
+		deadline := firstPendingAt.Add(pendingDelay)
 		if !lastDispatch.IsZero() {
 			floor := lastDispatch.Add(w.minInterval)
 			if floor.After(deadline) {
@@ -313,7 +1000,7 @@ func (w *Watcher) loop() {
 	}
 
 	dispatch := func() bool {
-		if callbackBusy || pending.Empty() {
+		if !w.dispatchEnabled.Load() || callbackBusy || w.eventSink.Empty() {
 			return true
 		}
 		w.dispatchMu.Lock()
@@ -321,11 +1008,12 @@ func (w *Watcher) loop() {
 		if w.stopping {
 			return false
 		}
-		batch, ok := pending.Take()
+		batch, ok := w.eventSink.Take(w.agentsForRoot)
 		if !ok {
 			return true
 		}
 		firstPendingAt = time.Time{}
+		pendingDelay = w.batchDelay
 		callbackBusy = true
 		batches <- batch
 		return true
@@ -343,21 +1031,35 @@ func (w *Watcher) loop() {
 		case <-w.stop:
 			return
 
-		case event, ok := <-w.watcher.Events:
+		case event, ok := <-w.backend.Events():
 			if !ok {
 				return
 			}
-			path, relevant := w.handleEvent(event)
-			if !relevant {
+			if event.Op == backendOpUnknown ||
+				(event.Path == "" && event.Op&backendOpFullSync == 0) {
 				continue
 			}
-			if pending.Empty() {
+			if w.eventSink.Empty() {
 				firstPendingAt = time.Now()
+				pendingDelay = w.batchDelay
 			}
-			pending.Add(path)
+			w.accumulateBackendEvent(event)
 			schedule()
 
-		case err, ok := <-w.watcher.Errors:
+		case <-w.eventSink.wake:
+			if w.eventSink.Empty() {
+				continue
+			}
+			if firstPendingAt.IsZero() {
+				firstPendingAt = time.Now()
+			}
+			pendingDelay = 0
+			if timerC != nil {
+				stopTimer()
+			}
+			schedule()
+
+		case err, ok := <-w.backend.Errors():
 			if !ok {
 				return
 			}
@@ -375,170 +1077,198 @@ func (w *Watcher) loop() {
 				return
 			}
 
-		case startedAt := <-callbackDone:
-			lastDispatch = startedAt
+		case result := <-callbackDone:
 			callbackBusy = false
+			if result.err != nil {
+				lastDispatch = time.Now()
+				consecutiveFailures++
+				log.Printf("watcher callback: %v", result.err)
+				wasEmpty := w.eventSink.Empty()
+				retryRetained := false
+				if retry, ok := callbackRetryBatch(result.err); ok {
+					retry.lifecycleTokens = append(
+						[]backendLifecycleToken(nil), result.batch.lifecycleTokens...,
+					)
+					w.eventSink.RetainRetry(retry)
+					retryRetained = true
+				} else {
+					switch {
+					case result.batch.FullSync:
+						w.eventSink.RetainRetry(WatchBatch{
+							FullSync:        true,
+							LostEvents:      result.batch.LostEvents,
+							lifecycleTokens: result.batch.lifecycleTokens,
+						})
+						retryRetained = true
+					case renameBatchNeedsFullRetry(result.batch.Renames):
+						// Classification did not report its result, so an ambiguous
+						// rename must conservatively retain full reconciliation.
+						w.eventSink.RetainRetry(WatchBatch{
+							FullSync:        true,
+							LostEvents:      result.batch.LostEvents,
+							lifecycleTokens: result.batch.lifecycleTokens,
+						})
+						retryRetained = true
+					case len(result.batch.ReconcileRoots) > 0:
+						w.eventSink.RetainRetry(WatchBatch{
+							ReconcileRoots:  result.batch.ReconcileRoots,
+							LostEvents:      result.batch.LostEvents,
+							lifecycleTokens: result.batch.lifecycleTokens,
+						})
+						retryRetained = true
+					}
+				}
+				if !retryRetained {
+					consecutiveFailures = 0
+				}
+				if wasEmpty && !w.eventSink.Empty() {
+					firstPendingAt = time.Now()
+					pendingDelay = watcherRetryDelay(
+						max(w.batchDelay, w.minInterval), consecutiveFailures,
+					)
+				}
+			} else {
+				lastDispatch = result.startedAt
+				consecutiveFailures = 0
+				for _, token := range result.batch.lifecycleTokens {
+					token.gate.acknowledgeLifecycle(token.generation)
+				}
+			}
 			schedule()
 		}
 	}
 }
 
-// handleEvent processes a single fsnotify event, auto-watching
-// newly created directories and returning relevant changed paths.
-func (w *Watcher) handleEvent(event fsnotify.Event) (string, bool) {
-	if event.Op&(fsnotify.Write|
-		fsnotify.Create|
-		fsnotify.Remove|
-		fsnotify.Rename) == 0 {
-		return "", false
+func (w *Watcher) accumulateBackendEvent(event backendEvent) {
+	filter, enumerate := w.backend.(createdSubtreePathFilter)
+	if !enumerate || event.Op&backendOpCreate == 0 ||
+		event.Op&(backendOpRemove|backendOpRename) != 0 ||
+		event.ItemType != backendItemDirectory ||
+		!filter.shouldEnumerateCreatedSubtree(event.Root, event.Path) {
+		w.eventSink.Add(event)
+		return
 	}
-
-	if event.Op&fsnotify.Create != 0 {
-		isDir, excluded := w.watchIfDir(event.Name)
-		if isDir && excluded {
-			return "", false
+	root := event.Root
+	if root == "" {
+		root = event.Path
+	}
+	// Preserve the directory-create event itself for behavior parity with the
+	// portable backend. Descendant enumeration supplements that event; it does
+	// not replace the path that caused the backend to install new watches.
+	w.eventSink.Add(event)
+	visits := 0
+	visitBudgetExceeded := false
+	canceled := false
+	err := filepath.WalkDir(event.Path, func(
+		path string, entry os.DirEntry, walkErr error,
+	) error {
+		if w.callbackCtx.Err() != nil {
+			canceled = true
+			return filepath.SkipAll
 		}
-	}
-
-	return filepath.Clean(event.Name), true
-}
-
-// watchIfDir adds a path to the watch list if it is a directory.
-// Returns whether path is a directory and whether it was excluded.
-func (w *Watcher) watchIfDir(path string) (isDir bool, excluded bool) {
-	info, err := os.Stat(path)
-	if err != nil || !info.IsDir() {
-		return false, false
-	}
-	if w.isUnderShallowRoot(path) {
-		return true, false
-	}
-	if w.shouldExclude(path) {
-		return true, true
-	}
-	_ = w.watcher.Add(path)
-	return true, false
-}
-
-func normalizeExcludePatterns(patterns []string) []string {
-	if len(patterns) == 0 {
+		if walkErr != nil {
+			return walkErr
+		}
+		visits++
+		if visits > w.maxEntries {
+			visitBudgetExceeded = true
+			return filepath.SkipAll
+		}
+		if path == event.Path {
+			return nil
+		}
+		if !filter.includeCreatedSubtreePath(root, path) {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if !w.eventSink.AddCreatedSubtreePath(path, root) {
+			return filepath.SkipAll
+		}
 		return nil
+	})
+	if canceled || w.callbackCtx.Err() != nil {
+		return
 	}
-	out := make([]string, 0, len(patterns))
-	for _, p := range patterns {
-		p = strings.TrimSpace(filepath.Clean(p))
-		if p == "" || p == "." {
-			continue
-		}
-		if !slices.Contains(out, p) {
-			out = append(out, p)
-		}
-	}
-	return out
-}
-
-func (w *Watcher) addRoot(root string) {
-	w.rootsMu.Lock()
-	defer w.rootsMu.Unlock()
-	if !slices.Contains(w.roots, root) {
-		w.roots = append(w.roots, root)
+	if visitBudgetExceeded || err != nil {
+		w.eventSink.Add(backendEvent{
+			Path: root, Root: root, Op: backendOpReconcileRootChange,
+		})
 	}
 }
 
-func (w *Watcher) addShallowRoot(root string) {
-	w.rootsMu.Lock()
-	defer w.rootsMu.Unlock()
-	if !slices.Contains(w.shallow, root) {
-		w.shallow = append(w.shallow, root)
+func callbackRetryBatch(err error) (WatchBatch, bool) {
+	var retryErr WatchRetryError
+	if !errors.As(err, &retryErr) {
+		return WatchBatch{}, false
+	}
+	retry := retryErr.WatchRetryBatch()
+	if retry.FullSync {
+		return WatchBatch{FullSync: true, LostEvents: retry.LostEvents}, true
+	}
+	if len(retry.Paths) == 0 && len(retry.ReconcileRoots) == 0 {
+		return WatchBatch{}, false
+	}
+	return WatchBatch{
+		Paths:          append([]string(nil), retry.Paths...),
+		ReconcileRoots: append([]string(nil), retry.ReconcileRoots...),
+		LostEvents:     retry.LostEvents,
+	}, true
+}
+
+func retainWatchRetry(pending *pendingWatchBatch, retry WatchBatch) {
+	if retry.FullSync {
+		pending.retainFullSync()
+	} else {
+		for _, path := range retry.Paths {
+			pending.Add(path)
+		}
+		for _, root := range retry.ReconcileRoots {
+			pending.AddReconcileRoot(root)
+		}
+	}
+	pending.lostEvents = pending.lostEvents || retry.LostEvents
+	for _, token := range retry.lifecycleTokens {
+		pending.AddLifecycle(token)
 	}
 }
 
-// isUnderShallowRoot reports whether path's most specific containing watch
-// root is a shallow root. A path that also sits under a more specific
-// recursive root (for example a new sessions/YYYY/MM/DD directory beneath a
-// recursive sessions root that itself lives inside a shallow parent root) is
-// NOT shadowed, so auto-watching still adds new subdirectories of recursive
-// roots.
-func (w *Watcher) isUnderShallowRoot(path string) bool {
-	root, ok := w.mostSpecificContainingRoot(path)
-	if !ok {
-		return false
+const watcherRetryMaxDelay = 2 * time.Minute
+
+func watcherRetryDelay(base time.Duration, failures int) time.Duration {
+	if failures <= 0 {
+		return 0
 	}
-	w.rootsMu.RLock()
-	defer w.rootsMu.RUnlock()
-	return slices.Contains(w.shallow, root)
+	if base <= 0 {
+		base = time.Millisecond
+	}
+	delay := base
+	for range failures - 1 {
+		if delay >= watcherRetryMaxDelay/2 {
+			return watcherRetryMaxDelay
+		}
+		delay *= 2
+	}
+	return min(delay, watcherRetryMaxDelay)
 }
 
-func (w *Watcher) shouldExclude(path string) bool {
-	if len(w.excludes) == 0 {
-		return false
-	}
-	root, ok := w.mostSpecificContainingRoot(path)
-	if !ok {
-		return false
-	}
-	return w.shouldExcludeForRoot(path, root)
+func renameBatchNeedsFullRetry(renames []WatchRename) bool {
+	return slices.ContainsFunc(renames, func(rename WatchRename) bool {
+		return rename.ItemType != ItemIsFile
+	})
 }
 
-func (w *Watcher) shouldExcludeForRoot(path string, root string) bool {
-	if len(w.excludes) == 0 {
-		return false
+func watchItemType(itemType backendItemType) WatchItemType {
+	switch itemType {
+	case backendItemFile:
+		return ItemIsFile
+	case backendItemDirectory:
+		return ItemIsDir
+	default:
+		return ItemIsUnknown
 	}
-	clean := filepath.Clean(path)
-	root = filepath.Clean(root)
-	rel, err := filepath.Rel(root, clean)
-	if err != nil {
-		return false
-	}
-	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return false
-	}
-	rel = filepath.Clean(rel)
-	if rel == "." {
-		return false
-	}
-	parts := strings.Split(rel, string(filepath.Separator))
-
-	for _, pat := range w.excludes {
-		if strings.Contains(pat, string(filepath.Separator)) {
-			if ok, _ := filepath.Match(pat, rel); ok {
-				return true
-			}
-			continue
-		}
-		for _, part := range parts {
-			if ok, _ := filepath.Match(pat, part); ok {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func (w *Watcher) mostSpecificContainingRoot(path string) (string, bool) {
-	w.rootsMu.RLock()
-	defer w.rootsMu.RUnlock()
-
-	if len(w.roots) == 0 {
-		return "", false
-	}
-
-	clean := filepath.Clean(path)
-	var best string
-	for _, root := range w.roots {
-		rel, err := filepath.Rel(root, clean)
-		if err != nil {
-			continue
-		}
-		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-			continue
-		}
-		if best == "" || len(root) > len(best) {
-			best = root
-		}
-	}
-	if best == "" {
-		return "", false
-	}
-	return best, true
 }

--- a/internal/sync/watcher_darwin_test.go
+++ b/internal/sync/watcher_darwin_test.go
@@ -1571,6 +1571,70 @@ func TestDarwinWatcherFallbackKeepsPollingUntilNativeRetrySucceeds(t *testing.T)
 	assert.Equal(t, int32(3), attempts.Load())
 }
 
+// TestDarwinWatcherStopDuringRecoveryReleaseDoesNotPanic stops the watcher
+// while the recovery handoff is inside its polling-release callback, which
+// runs with the backend mutex released. The lifecycle goroutine reports the
+// release failure on the shared error channel after the callback returns, so
+// the kqueue forwarder must not close that channel until the lifecycle
+// goroutine has exited; a premature close panics with a send on a closed
+// channel.
+func TestDarwinWatcherStopDuringRecoveryReleaseDoesNotPanic(t *testing.T) {
+	root := t.TempDir()
+	backend, err := newDarwinWatchBackend(nil, 20*time.Millisecond)
+	require.NoError(t, err)
+	backend.retryInitial = 5 * time.Millisecond
+	backend.retryMax = 10 * time.Millisecond
+
+	backend.newStream = func(_ string, _ func([]fsevents.Event)) (darwinStream, error) {
+		return &handoffRecordingStream{}, nil
+	}
+	releaseEntered := make(chan struct{})
+	stopStarted := make(chan struct{})
+	var releaseCalls atomic.Int32
+	batches := make(chan WatchBatch, 8)
+	watcher, err := newWatcherWithBackendOptions(
+		0, 0, func(_ context.Context, batch WatchBatch) error {
+			batches <- batch
+			return nil
+		}, backend, defaultWatchBatchMaxEntries, defaultWatchBatchMaxPathBytes,
+		WatcherOptions{
+			OnPollingRequired: func(PollingObligation) error { return nil },
+			OnPollingReleased: func(string) error {
+				if releaseCalls.Add(1) > 1 {
+					return nil
+				}
+				close(releaseEntered)
+				<-stopStarted
+				// Give the kqueue forwarder time to observe the stop signal
+				// and run its shutdown path before the release failure is
+				// reported on the shared error channel.
+				time.Sleep(200 * time.Millisecond)
+				return errors.New("release failed during shutdown")
+			},
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(watcher.Stop)
+	results := watcher.RegisterRoots([]WatchRoot{{
+		Path: root, Recursive: true, Exists: true,
+		Scopes: []WatchScope{{Agent: "agent-a", SyncDir: root}},
+	}}, 10)
+	require.Equal(t, []RecursiveWatchResult{{Watched: 1}}, results)
+	require.NoError(t, watcher.Start())
+
+	backend.requestFallback(darwinFallbackNativeDrop)
+	waitForDarwinBatch(t, batches, func(batch WatchBatch) bool { return batch.FullSync })
+	requireReceiveWithin(t, releaseEntered, 30*time.Second)
+
+	stopDone := make(chan struct{})
+	go func() {
+		watcher.Stop()
+		close(stopDone)
+	}()
+	close(stopStarted)
+	requireReceiveWithin(t, stopDone, 30*time.Second)
+}
+
 func TestDarwinWatcherFallbackTransfersMissingRootPollingBeforeRecovery(t *testing.T) {
 	parent := t.TempDir()
 	present := filepath.Join(parent, "present")

--- a/internal/sync/watcher_darwin_test.go
+++ b/internal/sync/watcher_darwin_test.go
@@ -1,0 +1,2524 @@
+//go:build darwin && cgo
+
+package sync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"go.kenn.io/agentsview/internal/fsevents"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFSEventsFlagMapping(t *testing.T) {
+	const (
+		mustScanSubDirs = uint32(0x00000001)
+		userDropped     = uint32(0x00000002)
+		kernelDropped   = uint32(0x00000004)
+		eventIDsWrapped = uint32(0x00000008)
+		rootChanged     = uint32(0x00000020)
+		itemCreated     = uint32(0x00000100)
+		itemRemoved     = uint32(0x00000200)
+		inodeMetaMod    = uint32(0x00000400)
+		itemRenamed     = uint32(0x00000800)
+		itemModified    = uint32(0x00001000)
+		itemIsFile      = uint32(0x00010000)
+		itemIsDir       = uint32(0x00020000)
+	)
+
+	root := "/sessions"
+	path := "/sessions/2026/07/session.jsonl"
+	tests := []struct {
+		name     string
+		flags    uint32
+		want     backendEvent
+		relevant bool
+		fallback bool
+	}{
+		{name: "ItemCreated", flags: itemCreated, want: backendEvent{Path: path, Root: root, Op: backendOpCreate}, relevant: true},
+		{name: "ItemModified", flags: itemModified, want: backendEvent{Path: path, Root: root, Op: backendOpWrite}, relevant: true},
+		{name: "ItemRemoved", flags: itemRemoved, want: backendEvent{Path: path, Root: root, Op: backendOpRemove}, relevant: true},
+		{name: "ItemRenamed", flags: itemRenamed, want: backendEvent{Path: path, Root: root, Op: backendOpRename}, relevant: true},
+		{name: "ItemIsFile", flags: itemRenamed | itemIsFile, want: backendEvent{Path: path, Root: root, Op: backendOpRename, ItemType: backendItemFile}, relevant: true},
+		{name: "ItemIsDir", flags: itemRenamed | itemIsDir, want: backendEvent{Path: path, Root: root, Op: backendOpRename, ItemType: backendItemDirectory}, relevant: true},
+		{name: "RootChanged", flags: rootChanged, want: backendEvent{Path: path, Root: root, Op: backendOpReconcileRootChange}, relevant: true},
+		{name: "MustScanSubDirs", flags: mustScanSubDirs, fallback: true},
+		{name: "UserDropped", flags: userDropped, fallback: true},
+		{name: "KernelDropped", flags: kernelDropped, fallback: true},
+		{name: "EventIdsWrapped", flags: eventIDsWrapped, fallback: true},
+		{name: "dropped with operation", flags: userDropped | itemCreated | itemIsFile, fallback: true},
+		{name: "metadata only", flags: inodeMetaMod, relevant: false},
+		{name: "metadata with operation", flags: inodeMetaMod | itemCreated | itemIsFile, want: backendEvent{Path: path, Root: root, Op: backendOpCreate, ItemType: backendItemFile}, relevant: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			events := []fsevents.Event{{
+				Path:  path,
+				Flags: fsevents.EventFlags(tc.flags),
+			}}
+
+			assert.Equal(t, tc.fallback, nativeDeliveryRequestsFallback(events))
+			if tc.fallback {
+				// consumeFSEvents diverts drop and rescan flags to fallback
+				// before translation, so these flags never reach
+				// translateFSEvent.
+				return
+			}
+
+			got, relevant := translateFSEvent(root, events[0])
+			assert.Equal(t, tc.relevant, relevant)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestDarwinWatcherNativeSinkCollapsesBlockedConsumerOverflow(t *testing.T) {
+	backend := newDarwinDirectTestBackend()
+	batches := make(chan WatchBatch, 3)
+	consumerEntered := make(chan struct{})
+	releaseConsumer := make(chan struct{})
+	watcher, err := newWatcherWithBackend(
+		0,
+		0,
+		func(_ context.Context, batch WatchBatch) error {
+			batches <- batch
+			if !batch.FullSync {
+				close(consumerEntered)
+				<-releaseConsumer
+			}
+			return nil
+		},
+		backend,
+		defaultWatchBatchMaxEntries,
+		defaultWatchBatchMaxPathBytes,
+	)
+	require.NoError(t, err)
+	watcher.Start()
+	t.Cleanup(watcher.Stop)
+
+	require.True(t, backend.emit([]backendEvent{{
+		Path: "/sessions/first.jsonl",
+		Root: "/sessions",
+		Op:   backendOpWrite,
+	}}))
+	requireReceiveWithin(t, consumerEntered, time.Second)
+
+	const eventCount = defaultWatchBatchMaxEntries + 1024
+	padding := strings.Repeat("x", 256)
+	events := make([]backendEvent, 0, eventCount)
+	for i := range eventCount {
+		events = append(events, backendEvent{
+			Path: fmt.Sprintf("/sessions/%05d-%s.jsonl", i, padding),
+			Root: "/sessions",
+			Op:   backendOpWrite,
+		})
+	}
+
+	nativeReturned := make(chan bool, 1)
+	go func() {
+		nativeReturned <- backend.emit(events)
+	}()
+	assert.True(t, requireReceiveWithin(t, nativeReturned, time.Second),
+		"native sink must acquire the idle pending accumulator")
+
+	handoff := watcher.eventSink.handoff.Load()
+	require.NotNil(t, handoff)
+	assert.True(t, handoff.fullSync)
+	assert.LessOrEqual(t, len(handoff.strings), defaultWatchBatchMaxEntries)
+	assert.LessOrEqual(t, handoff.pathBytes, defaultWatchBatchMaxPathBytes)
+
+	first := requireReceiveWithin(t, batches, time.Second)
+	assert.Equal(t, WatchBatch{
+		Paths:          []string{"/sessions/first.jsonl"},
+		Renames:        []WatchRename{},
+		ReconcileRoots: []string{},
+	}, first)
+	close(releaseConsumer)
+	second := requireReceiveWithin(t, batches, time.Second)
+	assert.Equal(t, WatchBatch{FullSync: true, LostEvents: true}, second)
+	assert.Never(t, func() bool { return len(batches) != 0 }, 100*time.Millisecond, 10*time.Millisecond)
+}
+
+func TestDarwinWatcherNativeSinkContentionUsesBoundedHandoff(t *testing.T) {
+	backend := newDarwinDirectTestBackend()
+	batches := make(chan WatchBatch, 1)
+	watcher, err := newWatcherWithBackend(
+		0,
+		0,
+		func(_ context.Context, batch WatchBatch) error {
+			batches <- batch
+			return nil
+		},
+		backend,
+		defaultWatchBatchMaxEntries,
+		defaultWatchBatchMaxPathBytes,
+	)
+	require.NoError(t, err)
+	watcher.Start()
+	t.Cleanup(watcher.Stop)
+
+	watcher.eventSink.mu.Lock()
+	nativeReturned := make(chan bool, 1)
+	go func() {
+		nativeReturned <- backend.emit([]backendEvent{{
+			Path: "/sessions/contended.jsonl",
+			Root: "/sessions",
+			Op:   backendOpWrite,
+		}})
+	}()
+	assert.True(t, requireReceiveWithin(t, nativeReturned, time.Second),
+		"a contended callback must not wait for accumulator ownership")
+	watcher.eventSink.mu.Unlock()
+
+	assert.Equal(t, WatchBatch{
+		Paths:          []string{"/sessions/contended.jsonl"},
+		Renames:        []WatchRename{},
+		ReconcileRoots: []string{},
+	},
+		requireReceiveWithin(t, batches, time.Second))
+	assert.Zero(t, watcher.eventSink.overflows.Load(),
+		"ordinary consumer mutex contention is not a capacity overflow")
+}
+
+func TestDarwinWatcherMeaningfulNativeDeliveryAdvancesKqueueTimer(t *testing.T) {
+	const batchDelay = 300 * time.Millisecond
+	backend := newDarwinDirectTestBackend()
+	batches := make(chan WatchBatch, 1)
+	watcher, err := newWatcherWithBackend(
+		batchDelay,
+		0,
+		func(_ context.Context, batch WatchBatch) error {
+			batches <- batch
+			return nil
+		},
+		backend,
+		defaultWatchBatchMaxEntries,
+		defaultWatchBatchMaxPathBytes,
+	)
+	require.NoError(t, err)
+	watcher.Start()
+	t.Cleanup(watcher.Stop)
+
+	backend.sendKqueue(t, backendEvent{
+		Path: "/sessions/kqueue.jsonl",
+		Root: "/sessions",
+		Op:   backendOpWrite,
+	})
+	time.Sleep(20 * time.Millisecond)
+	nativeAt := time.Now()
+	require.True(t, backend.emit([]backendEvent{{
+		Path: "/sessions/native.jsonl",
+		Root: "/sessions",
+		Op:   backendOpWrite,
+	}}))
+
+	batch := requireReceiveWithin(t, batches, 150*time.Millisecond)
+	assert.ElementsMatch(t, []string{
+		"/sessions/kqueue.jsonl",
+		"/sessions/native.jsonl",
+	}, batch.Paths)
+	assert.Less(t, time.Since(nativeAt), 150*time.Millisecond)
+}
+
+func TestWatchEventSinkFilteredNativeDeliveryDoesNotWakePendingKqueue(t *testing.T) {
+	sink := newWatchEventSink(
+		defaultWatchBatchMaxEntries,
+		defaultWatchBatchMaxPathBytes,
+	)
+	sink.Add(backendEvent{
+		Path: "/sessions/kqueue.jsonl",
+		Root: "/sessions",
+		Op:   backendOpWrite,
+	})
+
+	require.True(t, sink.TryAccumulate(func(func(backendEvent) bool) bool {
+		return false
+	}))
+	select {
+	case <-sink.wake:
+		require.Fail(t, "filtered native delivery woke unrelated kqueue work")
+	default:
+	}
+}
+
+func TestDarwinWatcherFilteredNativeDeliveryPreservesKqueueTimer(t *testing.T) {
+	const batchDelay = 180 * time.Millisecond
+	backend := newDarwinDirectTestBackend()
+	dispatched := make(chan time.Time, 1)
+	watcher, err := newWatcherWithBackend(
+		batchDelay,
+		0,
+		func(_ context.Context, _ WatchBatch) error {
+			dispatched <- time.Now()
+			return nil
+		},
+		backend,
+		defaultWatchBatchMaxEntries,
+		defaultWatchBatchMaxPathBytes,
+	)
+	require.NoError(t, err)
+	watcher.Start()
+	t.Cleanup(watcher.Stop)
+
+	queuedAt := time.Now()
+	backend.sendKqueue(t, backendEvent{
+		Path: "/sessions/kqueue.jsonl",
+		Root: "/sessions",
+		Op:   backendOpWrite,
+	})
+	time.Sleep(20 * time.Millisecond)
+	require.True(t, backend.emitFiltered())
+
+	select {
+	case <-dispatched:
+		require.Fail(t, "filtered native delivery advanced the kqueue timer")
+	case <-time.After(80 * time.Millisecond):
+	}
+	dispatchedAt := requireReceiveWithin(t, dispatched, 250*time.Millisecond)
+	assert.GreaterOrEqual(t, dispatchedAt.Sub(queuedAt), 140*time.Millisecond)
+}
+
+func TestDarwinWatcherFileLifecycleAndNativeLatency(t *testing.T) {
+	root := t.TempDir()
+	watcher, batches := newDarwinTestWatcher(t, root, nil, darwinFSEventsLatency)
+	watcher.Start()
+
+	path := filepath.Join(root, "session.jsonl")
+	createdAt := time.Now()
+	require.NoError(t, os.WriteFile(path, []byte("created"), 0o600))
+	created := waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+		return slices.Contains(batch.Paths, path)
+	})
+	deliveryElapsed := time.Since(createdAt)
+	t.Logf("500ms FSEvents create delivery elapsed: %s", deliveryElapsed.Round(time.Millisecond))
+	assert.Less(t, deliveryElapsed, 900*time.Millisecond,
+		"native latency must not be followed by the configured 500ms Go batch delay")
+	assert.False(t, created.FullSync)
+
+	require.NoError(t, os.WriteFile(path, []byte("modified"), 0o600))
+	modified := waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+		return slices.Contains(batch.Paths, path)
+	})
+	assert.False(t, modified.FullSync)
+
+	renamedPath := filepath.Join(root, "renamed.jsonl")
+	require.NoError(t, os.Rename(path, renamedPath))
+	renamed := waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+		return slices.ContainsFunc(batch.Renames, func(rename WatchRename) bool {
+			return rename.Path == path || rename.Path == renamedPath
+		})
+	})
+	assert.False(t, renamed.FullSync)
+	assert.Empty(t, renamed.ReconcileRoots)
+	for _, rename := range renamed.Renames {
+		assert.Equal(t, ItemIsFile, rename.ItemType)
+	}
+
+	require.NoError(t, os.Remove(renamedPath))
+	removed := waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+		return slices.Contains(batch.Paths, renamedPath) ||
+			slices.ContainsFunc(batch.Renames, func(rename WatchRename) bool {
+				return rename.Path == renamedPath
+			})
+	})
+	assert.False(t, removed.FullSync)
+	assert.Empty(t, removed.ReconcileRoots)
+}
+
+func TestDarwinWatcherColdArchiveCardinalityUsesOneRecursiveStream(t *testing.T) {
+	type observation struct {
+		streams            int
+		roots              int
+		logicalRoots       int
+		shallowRoots       int
+		nativeDescriptors  int
+		appendPaths        int
+		appendRenames      int
+		replacementPaths   int
+		replacementRenames int
+	}
+	var observations []observation
+	for _, tc := range []struct {
+		name      string
+		coldFiles int
+	}{
+		{name: "small", coldFiles: 3},
+		{name: "large", coldFiles: 300},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			activeDir := filepath.Join(root, "active")
+			require.NoError(t, os.Mkdir(activeDir, 0o700))
+			changedPath := filepath.Join(activeDir, "changed-session.jsonl")
+			require.NoError(t, os.WriteFile(
+				changedPath, []byte("{\"type\":\"user\"}\n"), 0o600,
+			))
+			for i := range tc.coldFiles {
+				dir := filepath.Join(root, fmt.Sprintf("cold-%03d", i))
+				require.NoError(t, os.Mkdir(dir, 0o700))
+				require.NoError(t, os.WriteFile(
+					filepath.Join(dir, fmt.Sprintf("cold-%03d.jsonl", i)),
+					[]byte("{\"type\":\"user\"}\n"),
+					0o600,
+				))
+			}
+
+			backend, err := newDarwinWatchBackend(nil, 20*time.Millisecond)
+			require.NoError(t, err)
+			watcher, batches := newDarwinTestWatcherWithBackend(t, backend)
+			results := watcher.RegisterRoots([]WatchRoot{{
+				Path: root, Recursive: true, Exists: true,
+				Scopes: []WatchScope{{Agent: "claude", SyncDir: root}},
+			}}, 1)
+			require.Len(t, results, 1)
+			require.NoError(t, results[0].Err)
+			require.Equal(t, 1, results[0].Watched)
+			watcher.Start()
+			// A post-start barrier separates any filesystem history FSEvents was
+			// still coalescing from the append measured below.
+			barrierPath := filepath.Join(root, ".stream-ready")
+			require.NoError(t, os.WriteFile(barrierPath, []byte("ready"), 0o600))
+			waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+				return slices.Contains(batch.Paths, barrierPath)
+			})
+
+			backend.mu.Lock()
+			got := observation{
+				streams:           len(backend.streams),
+				roots:             len(backend.roots.Load().roots),
+				logicalRoots:      len(backend.logical),
+				shallowRoots:      len(backend.shallow),
+				nativeDescriptors: len(backend.kqueue.watcher.WatchList()),
+			}
+			backend.mu.Unlock()
+			assert.Equal(t, 1, got.streams)
+			assert.Equal(t, 1, got.roots)
+			assert.Equal(t, 1, got.logicalRoots)
+			assert.Zero(t, got.shallowRoots)
+			assert.Zero(t, got.nativeDescriptors,
+				"recursive FSEvents coverage must not allocate per-file kqueue descriptors")
+
+			appendFile, err := os.OpenFile(changedPath, os.O_APPEND|os.O_WRONLY, 0)
+			require.NoError(t, err)
+			_, err = appendFile.WriteString("{\"type\":\"assistant\"}\n")
+			require.NoError(t, err)
+			require.NoError(t, appendFile.Close())
+			appendBatch := waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+				return slices.Contains(batch.Paths, changedPath)
+			})
+			assert.False(t, appendBatch.FullSync)
+			assert.Empty(t, appendBatch.ReconcileRoots)
+			assert.Empty(t, appendBatch.Renames)
+			assert.Equal(t, []string{changedPath}, appendBatch.Paths)
+			got.appendPaths = len(appendBatch.Paths)
+			got.appendRenames = len(appendBatch.Renames)
+
+			tempPath := filepath.Join(activeDir, ".changed-session.tmp")
+			require.NoError(t, os.WriteFile(
+				tempPath,
+				[]byte("{\"type\":\"user\",\"replacement\":true}\n"),
+				0o600,
+			))
+			require.NoError(t, os.Rename(tempPath, changedPath))
+			replacementBatch := waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+				return slices.Contains(batch.Paths, changedPath) ||
+					slices.ContainsFunc(batch.Renames, func(rename WatchRename) bool {
+						return rename.Path == changedPath
+					})
+			})
+			assert.False(t, replacementBatch.FullSync)
+			assert.Empty(t, replacementBatch.ReconcileRoots,
+				"atomic file replacement must remain a changed-path sync")
+			got.replacementPaths = len(replacementBatch.Paths)
+			got.replacementRenames = len(replacementBatch.Renames)
+			assert.Positive(t, got.replacementPaths+got.replacementRenames,
+				"atomic replacement must emit bounded changed-path work")
+			assert.LessOrEqual(t, got.replacementPaths+got.replacementRenames, 2,
+				"one atomic replacement must not fan out with cold archive cardinality")
+			for _, rename := range replacementBatch.Renames {
+				if rename.Path == changedPath {
+					assert.Equal(t, ItemIsFile, rename.ItemType)
+				}
+			}
+			assert.Never(t, func() bool {
+				select {
+				case batch := <-batches:
+					return batch.FullSync || len(batch.ReconcileRoots) > 0
+				default:
+					return false
+				}
+			}, 250*time.Millisecond, 10*time.Millisecond,
+				"atomic file replacement must not queue reconciliation")
+
+			backend.mu.Lock()
+			assert.Equal(t, got.streams, len(backend.streams))
+			assert.Equal(t, got.roots, len(backend.roots.Load().roots))
+			assert.Equal(t, got.logicalRoots, len(backend.logical))
+			assert.Equal(t, got.shallowRoots, len(backend.shallow))
+			assert.Equal(t, got.nativeDescriptors, len(backend.kqueue.watcher.WatchList()))
+			backend.mu.Unlock()
+			observations = append(observations, got)
+		})
+	}
+	require.Len(t, observations, 2)
+	assert.Equal(t, observations[0], observations[1],
+		"recursive native state and append/replacement work must not scale with cold files or directories")
+}
+
+func TestDarwinWatcherDirectoryRenameCarriesFullSyncMetadata(t *testing.T) {
+	root := t.TempDir()
+	watcher, batches := newDarwinTestWatcher(t, root, nil, 50*time.Millisecond)
+	watcher.Start()
+
+	dir := filepath.Join(root, "before")
+	require.NoError(t, os.Mkdir(dir, 0o700))
+	waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+		return slices.Contains(batch.Paths, dir)
+	})
+
+	renamedDir := filepath.Join(root, "after")
+	require.NoError(t, os.Rename(dir, renamedDir))
+	batch := waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+		return slices.ContainsFunc(batch.Renames, func(rename WatchRename) bool {
+			return rename.Path == renamedDir && rename.Root == root &&
+				rename.ItemType == ItemIsDir
+		})
+	})
+
+	assert.False(t, batch.FullSync)
+	assert.Empty(t, batch.ReconcileRoots)
+}
+
+func TestDarwinWatcherExcludesRecursiveEvents(t *testing.T) {
+	root := t.TempDir()
+	excluded := filepath.Join(root, ".git")
+	require.NoError(t, os.Mkdir(excluded, 0o700))
+	watcher, batches := newDarwinTestWatcher(
+		t, root, []string{".git"}, 50*time.Millisecond,
+	)
+	watcher.Start()
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(excluded, "config"),
+		[]byte("excluded"),
+		0o600,
+	))
+	assert.Never(t, func() bool {
+		select {
+		case batch := <-batches:
+			t.Logf("unexpected excluded batch: %#v", batch)
+			return true
+		default:
+			return false
+		}
+	}, 400*time.Millisecond, 10*time.Millisecond)
+}
+
+func TestDarwinWatcherExcludedDirectoryRenameIsFiltered(t *testing.T) {
+	root := t.TempDir()
+	backend, err := newDarwinWatchBackend([]string{".git"}, 50*time.Millisecond)
+	require.NoError(t, err)
+	watcher, batches := newDarwinTestWatcherWithBackend(t, backend)
+	result := watcher.WatchRecursiveBudgeted(root, 1)
+	require.NoError(t, result.Err)
+	watcher.Start()
+
+	backend.consumeFSEvents(darwinWatchRoot{
+		logicalPath: root,
+		nativePath:  canonicalWatchRoot(root),
+		recursive:   true,
+	}, []fsevents.Event{{
+		Path:  filepath.Join(root, ".git"),
+		Flags: fseventFlagItemRenamed | fseventFlagItemIsDir,
+	}})
+
+	assert.Never(t, func() bool {
+		select {
+		case batch := <-batches:
+			t.Logf("unexpected excluded rename batch: %#v", batch)
+			return true
+		default:
+			return false
+		}
+	}, 200*time.Millisecond, 10*time.Millisecond)
+}
+
+func TestDarwinWatcherStopsMappingAfterAccumulatorOverflow(t *testing.T) {
+	root := t.TempDir()
+	sink := &stopAfterOneDirectSink{}
+	backend := &darwinWatchBackend{sink: sink}
+	backend.roots.Store(&darwinRootSnapshot{roots: []darwinWatchRoot{{
+		logicalPath: root,
+		nativePath:  canonicalWatchRoot(root),
+		recursive:   true,
+	}}})
+	registration := darwinWatchRoot{
+		logicalPath: root,
+		nativePath:  canonicalWatchRoot(root),
+		recursive:   true,
+	}
+
+	backend.consumeFSEvents(registration, []fsevents.Event{
+		{Path: filepath.Join(root, "first.jsonl"), Flags: fseventFlagItemModified},
+		{Path: filepath.Join(root, "second.jsonl"), Flags: fseventFlagItemModified},
+	})
+
+	assert.True(t, sink.meaningful)
+	assert.Equal(t, 1, sink.added)
+	assert.Equal(t, filepath.Join(root, "first.jsonl"), sink.event.Path)
+}
+
+func TestDarwinWatcherMostSpecificRecursiveRootOwnsRename(t *testing.T) {
+	parent := t.TempDir()
+	nested := filepath.Join(parent, "nested")
+	renamedPath := filepath.Join(nested, "after.jsonl")
+	sink := &stopAfterOneDirectSink{}
+	backend := &darwinWatchBackend{sink: sink}
+	backend.roots.Store(&darwinRootSnapshot{roots: []darwinWatchRoot{
+		{logicalPath: parent, nativePath: parent, recursive: true},
+		{logicalPath: nested, nativePath: nested, recursive: true},
+	}})
+	event := []fsevents.Event{{
+		Path: renamedPath, Flags: fseventFlagItemRenamed | fseventFlagItemIsFile,
+	}}
+
+	backend.consumeFSEvents(darwinWatchRoot{
+		logicalPath: parent, nativePath: parent, recursive: true,
+	}, event)
+	assert.Zero(t, sink.added, "the parent stream must not own a nested-root rename")
+	backend.consumeFSEvents(darwinWatchRoot{
+		logicalPath: nested, nativePath: nested, recursive: true,
+	}, event)
+
+	assert.True(t, sink.meaningful)
+	assert.Equal(t, 1, sink.added)
+	assert.Equal(t, backendEvent{
+		Path: renamedPath, Root: nested, Op: backendOpRename, ItemType: backendItemFile,
+	}, sink.event)
+}
+
+func TestDarwinWatcherNestedShallowRootDoesNotShadowRecursiveStream(t *testing.T) {
+	parent := t.TempDir()
+	shallow := filepath.Join(parent, "metadata")
+	changedPath := filepath.Join(shallow, "nested", "session.jsonl")
+	sink := &stopAfterOneDirectSink{}
+	backend := &darwinWatchBackend{sink: sink}
+	backend.roots.Store(&darwinRootSnapshot{roots: []darwinWatchRoot{
+		{logicalPath: parent, nativePath: parent, recursive: true},
+		{logicalPath: shallow, nativePath: shallow, recursive: false},
+	}})
+
+	backend.consumeFSEvents(darwinWatchRoot{
+		logicalPath: parent, nativePath: parent, recursive: true,
+	}, []fsevents.Event{{
+		Path: changedPath, Flags: fseventFlagItemModified | fseventFlagItemIsFile,
+	}})
+
+	assert.True(t, sink.meaningful)
+	assert.Equal(t, 1, sink.added)
+	assert.Equal(t, backendEvent{
+		Path: changedPath, Root: parent, Op: backendOpWrite, ItemType: backendItemFile,
+	}, sink.event)
+}
+
+type recordingDarwinStream struct {
+	root  string
+	trace *[]string
+	close chan struct{}
+}
+
+func (s *recordingDarwinStream) Start() error {
+	*s.trace = append(*s.trace, "stream-start:"+s.root)
+	return nil
+}
+
+func (s *recordingDarwinStream) Close() error {
+	*s.trace = append(*s.trace, "stream-close:"+s.root)
+	if s.close != nil {
+		close(s.close)
+	}
+	return nil
+}
+
+func newDarwinLifecycleTestWatcher(
+	t *testing.T,
+	trace *[]string,
+) (*darwinWatchBackend, *Watcher) {
+	t.Helper()
+	backend, err := newDarwinWatchBackend(nil, 50*time.Millisecond)
+	require.NoError(t, err)
+	backend.newStream = func(root string, _ func([]fsevents.Event)) (darwinStream, error) {
+		*trace = append(*trace, "stream-new:"+root)
+		return &recordingDarwinStream{root: root, trace: trace}, nil
+	}
+	addTrace := func(path string) error {
+		*trace = append(*trace, "shallow-add:"+path)
+		return nil
+	}
+	removeTrace := func(path string) error {
+		*trace = append(*trace, "shallow-remove:"+path)
+		return nil
+	}
+	backend.addShallow = addTrace
+	backend.removeShallow = removeTrace
+	backend.addAncestor = addTrace
+	backend.removeAncestor = removeTrace
+	watcher, err := newWatcherWithBackend(
+		0, 0, func(context.Context, WatchBatch) error { return nil },
+		backend, defaultWatchBatchMaxEntries, defaultWatchBatchMaxPathBytes,
+	)
+	require.NoError(t, err)
+	t.Cleanup(watcher.Stop)
+	return backend, watcher
+}
+
+func setDarwinLifecycleRunningForTest(t *testing.T, backend *darwinWatchBackend) {
+	t.Helper()
+	backend.lifecycle = darwinBackendRunning
+	t.Cleanup(func() {
+		backend.mu.Lock()
+		if backend.lifecycle == darwinBackendRunning {
+			backend.lifecycle = darwinBackendNew
+		}
+		backend.mu.Unlock()
+	})
+}
+
+func TestDarwinWatcherHybridRegistrationUsesShallowAndPendingCoverage(t *testing.T) {
+	ancestor := t.TempDir()
+	shallow := filepath.Join(ancestor, "metadata")
+	require.NoError(t, os.Mkdir(shallow, 0o700))
+	pendingOne := filepath.Join(ancestor, "state", "sessions")
+	pendingTwo := filepath.Join(ancestor, "state", "archive")
+	var trace []string
+	_, watcher := newDarwinLifecycleTestWatcher(t, &trace)
+
+	results := watcher.RegisterRoots([]WatchRoot{
+		{Path: shallow, Exists: true, Scopes: []WatchScope{{Agent: "agent-a", SyncDir: shallow}}},
+		{Path: pendingOne, Recursive: true, Scopes: []WatchScope{{Agent: "agent-b", SyncDir: ancestor}}},
+		{Path: pendingTwo, Recursive: true, Scopes: []WatchScope{{Agent: "agent-c", SyncDir: ancestor}}},
+	}, 10)
+
+	require.Len(t, results, 3)
+	assert.Equal(t, []RecursiveWatchResult{
+		{Watched: 1},
+		{Watched: 1, MissingRootLifecycleOwned: true},
+		{Watched: 1, MissingRootLifecycleOwned: true},
+	}, results)
+	assert.Equal(t, []string{
+		"shallow-add:" + shallow,
+		"shallow-add:" + ancestor,
+	}, trace, "an explicit shallow root never creates a stream and pending roots share one ancestor watch")
+}
+
+func TestDarwinWatcherRegistrationOwnsRootCreatedAfterCollection(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "sessions")
+	plan := WatchRoot{
+		Path: root, Recursive: true, Exists: false,
+		Scopes: []WatchScope{{Agent: "agent-a", SyncDir: parent}},
+	}
+	var trace []string
+	backend, watcher := newDarwinLifecycleTestWatcher(t, &trace)
+	backend.pathIsDirectory = func(path string) bool {
+		require.Equal(t, root, path)
+		require.NoError(t, os.Mkdir(root, 0o700))
+		return false
+	}
+
+	results := watcher.RegisterRoots([]WatchRoot{plan}, 10)
+
+	require.Equal(t, []RecursiveWatchResult{{
+		Watched: 1, MissingRootLifecycleOwned: true,
+	}}, results)
+	assert.Equal(t, []string{"shallow-add:" + root}, trace,
+		"the registration race initially acquires bounded root coverage")
+
+	backend.processLifecycle(true)
+
+	assert.Equal(t, []string{
+		"shallow-add:" + root,
+		"stream-new:" + root,
+		"shallow-remove:" + root,
+	}, trace, "the pending root advances into native recursive coverage")
+}
+
+func TestDarwinWatcherPendingRootRetriesWithoutNativeKqueueDelivery(t *testing.T) {
+	ancestor := t.TempDir()
+	root := filepath.Join(ancestor, "state", "sessions")
+	backend, err := newDarwinWatchBackend(nil, 20*time.Millisecond)
+	require.NoError(t, err)
+	backend.retryInitial = 10 * time.Millisecond
+	backend.retryMax = 20 * time.Millisecond
+	backend.startKqueue = func() error { return nil }
+
+	missingChecked := make(chan struct{})
+	var missingCheckedOnce sync.Once
+	backend.lstat = func(path string) (os.FileInfo, error) {
+		info, statErr := os.Lstat(path)
+		if path == root && os.IsNotExist(statErr) {
+			missingCheckedOnce.Do(func() { close(missingChecked) })
+		}
+		return info, statErr
+	}
+	streamStarted := make(chan struct{})
+	var streamStartedOnce sync.Once
+	backend.newStream = func(string, func([]fsevents.Event)) (darwinStream, error) {
+		return &handoffRecordingStream{start: func() {
+			streamStartedOnce.Do(func() { close(streamStarted) })
+		}}, nil
+	}
+
+	watcher, batches := newDarwinTestWatcherWithBackend(t, backend)
+	results := watcher.RegisterRoots([]WatchRoot{{
+		Path: root, Recursive: true, Exists: true,
+		Scopes: []WatchScope{{Agent: "agent-a", SyncDir: ancestor}},
+	}}, 10)
+	require.Equal(t, []RecursiveWatchResult{{
+		Watched: 1, MissingRootLifecycleOwned: true,
+	}}, results)
+	watcher.Start()
+
+	requireReceiveWithin(t, missingChecked, time.Second)
+	require.NoError(t, os.MkdirAll(root, 0o700))
+	requireReceiveWithin(t, streamStarted, time.Second)
+	batch := waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+		return slices.Contains(batch.ReconcileRoots, ancestor)
+	})
+	assert.Equal(t, []string{ancestor}, batch.ReconcileRoots)
+	assert.Empty(t, batch.Paths)
+}
+
+func TestDarwinWatcherMissingIntermediateMovesCoverageBeforeRelease(t *testing.T) {
+	ancestor := t.TempDir()
+	intermediate := filepath.Join(ancestor, "state")
+	root := filepath.Join(intermediate, "sessions")
+	var trace []string
+	backend, watcher := newDarwinLifecycleTestWatcher(t, &trace)
+	watcher.RegisterRoots([]WatchRoot{{
+		Path: root, Recursive: true,
+		Scopes: []WatchScope{{Agent: "agent-a", SyncDir: ancestor}},
+	}}, 10)
+	require.NoError(t, os.Mkdir(intermediate, 0o700))
+
+	_, dispatch := backend.handleKqueueEvent(backendEvent{
+		Path: intermediate, Op: backendOpCreate, ItemType: backendItemDirectory,
+	})
+	backend.processLifecycleSignals()
+
+	assert.False(t, dispatch, "the scope reconciliation subsumes the component creation")
+	assert.Equal(t, []string{
+		"shallow-add:" + ancestor,
+		"shallow-add:" + intermediate,
+		"shallow-remove:" + ancestor,
+	}, trace)
+	batch, ok := watcher.eventSink.Take(watcher.agentsForRoot)
+	require.True(t, ok)
+	assert.Equal(t, []string{ancestor}, batch.ReconcileRoots)
+}
+
+func TestDarwinWatcherMissingRootStartsCollectingBeforeReleaseAndDispatch(t *testing.T) {
+	ancestor := t.TempDir()
+	root := filepath.Join(ancestor, "sessions")
+	var trace []string
+	backend, watcher := newDarwinLifecycleTestWatcher(t, &trace)
+	watcher.RegisterRoots([]WatchRoot{{
+		Path: root, Recursive: true,
+		Scopes: []WatchScope{{Agent: "agent-a", SyncDir: ancestor}},
+	}}, 10)
+	setDarwinLifecycleRunningForTest(t, backend)
+	require.NoError(t, os.Mkdir(root, 0o700))
+
+	_, dispatch := backend.handleKqueueEvent(backendEvent{
+		Path: root, Op: backendOpCreate, ItemType: backendItemDirectory,
+	})
+	backend.processLifecycleSignals()
+
+	assert.False(t, dispatch)
+	assert.Equal(t, []string{
+		"shallow-add:" + ancestor,
+		"stream-new:" + root,
+		"stream-start:" + root,
+		"shallow-remove:" + ancestor,
+	}, trace)
+	batch, ok := watcher.eventSink.Take(watcher.agentsForRoot)
+	require.True(t, ok)
+	assert.Equal(t, []string{ancestor}, batch.ReconcileRoots,
+		"transition reconciliation uses configured syncDir scopes")
+}
+
+func TestDarwinWatcherHybridHandoffRetainsWritesFromEveryPhase(t *testing.T) {
+	ancestor := t.TempDir()
+	root := filepath.Join(ancestor, "sessions")
+	paths := []string{
+		filepath.Join(root, "during-stream-start.jsonl"),
+		filepath.Join(root, "during-shallow-release.jsonl"),
+	}
+	var trace []string
+	backend, watcher := newDarwinLifecycleTestWatcher(t, &trace)
+	backend.newStream = func(streamRoot string, _ func([]fsevents.Event)) (darwinStream, error) {
+		return &handoffRecordingStream{
+			start: func() {
+				watcher.eventSink.Add(backendEvent{Path: paths[0], Root: streamRoot, Op: backendOpWrite})
+			},
+		}, nil
+	}
+	backend.removeAncestor = func(path string) error {
+		watcher.eventSink.Add(backendEvent{Path: paths[1], Root: root, Op: backendOpWrite})
+		return nil
+	}
+	watcher.RegisterRoots([]WatchRoot{{
+		Path: root, Recursive: true,
+		Scopes: []WatchScope{{Agent: "agent-a", SyncDir: ancestor}},
+	}}, 10)
+	setDarwinLifecycleRunningForTest(t, backend)
+	require.NoError(t, os.Mkdir(root, 0o700))
+
+	backend.handleKqueueEvent(backendEvent{
+		Path: root, Op: backendOpCreate, ItemType: backendItemDirectory,
+	})
+	backend.processLifecycleSignals()
+
+	batch, ok := watcher.eventSink.Take(watcher.agentsForRoot)
+	require.True(t, ok)
+	assert.ElementsMatch(t, paths, batch.Paths)
+	assert.Equal(t, []string{ancestor}, batch.ReconcileRoots)
+}
+
+func TestDarwinWatcherRootDeletionBridgesTeardownAndRecreation(t *testing.T) {
+	ancestor := t.TempDir()
+	root := filepath.Join(ancestor, "sessions")
+	require.NoError(t, os.Mkdir(root, 0o700))
+	var trace []string
+	backend, watcher := newDarwinLifecycleTestWatcher(t, &trace)
+	closed := make(chan struct{}, 1)
+	streamCount := 0
+	backend.newStream = func(streamRoot string, _ func([]fsevents.Event)) (darwinStream, error) {
+		streamCount++
+		return &recordingDarwinStream{
+			root: streamRoot, trace: &trace,
+			close: func() chan struct{} {
+				if streamCount == 1 {
+					return closed
+				}
+				return nil
+			}(),
+		}, nil
+	}
+	watcher.RegisterRoots([]WatchRoot{{
+		Path: root, Recursive: true,
+		Scopes: []WatchScope{{Agent: "agent-a", SyncDir: ancestor}},
+	}}, 10)
+	setDarwinLifecycleRunningForTest(t, backend)
+	require.NoError(t, os.Remove(root))
+
+	backend.consumeFSEvents(darwinWatchRoot{
+		logicalPath: root, nativePath: root, recursive: true,
+		state: backend.logical[root], generation: backend.logical[root].generation,
+	}, []fsevents.Event{{Path: root, Flags: fseventFlagRootChanged}})
+	backend.processLifecycleSignals()
+	requireReceiveWithin(t, closed, time.Second)
+	requireReceiveWithin(t, watcher.eventSink.wake, time.Second)
+	batch, ok := watcher.eventSink.Take(watcher.agentsForRoot)
+	require.True(t, ok)
+	assert.Equal(t, []string{ancestor}, batch.ReconcileRoots,
+		"authoritative scope reconciliation tombstones the disappeared root")
+	assert.Less(t,
+		slices.Index(trace, "shallow-add:"+ancestor),
+		slices.Index(trace, "stream-close:"+root),
+		"ancestor coverage must precede stream teardown")
+	for _, token := range batch.lifecycleTokens {
+		token.gate.acknowledgeLifecycle(token.generation)
+	}
+	backend.processLifecycleSignals()
+
+	require.NoError(t, os.Mkdir(root, 0o700))
+	backend.handleKqueueEvent(backendEvent{
+		Path: root, Op: backendOpCreate, ItemType: backendItemDirectory,
+	})
+	backend.processLifecycleSignals()
+	batch, ok = watcher.eventSink.Take(watcher.agentsForRoot)
+	require.True(t, ok)
+	assert.Equal(t, []string{ancestor}, batch.ReconcileRoots)
+	start := slices.Index(trace, "stream-start:"+root)
+	release := slices.Index(trace, "shallow-remove:"+ancestor)
+	assert.NotEqual(t, -1, start)
+	assert.NotEqual(t, -1, release)
+	assert.Less(t, start, release, "recreated root collects before ancestor release")
+}
+
+func TestDarwinWatcherRootDeletionHandoffRetainsWrites(t *testing.T) {
+	ancestor := t.TempDir()
+	root := filepath.Join(ancestor, "sessions")
+	require.NoError(t, os.Mkdir(root, 0o700))
+	var trace []string
+	backend, watcher := newDarwinLifecycleTestWatcher(t, &trace)
+	paths := []string{
+		filepath.Join(root, "during-ancestor-add.jsonl"),
+		filepath.Join(root, "during-stream-close.jsonl"),
+	}
+	backend.addAncestor = func(string) error {
+		watcher.eventSink.Add(backendEvent{Path: paths[0], Root: root, Op: backendOpWrite})
+		return nil
+	}
+	closed := make(chan struct{})
+	backend.newStream = func(string, func([]fsevents.Event)) (darwinStream, error) {
+		return &handoffRecordingStream{close: func() {
+			watcher.eventSink.Add(backendEvent{Path: paths[1], Root: root, Op: backendOpWrite})
+			close(closed)
+		}}, nil
+	}
+	watcher.RegisterRoots([]WatchRoot{{
+		Path: root, Recursive: true,
+		Scopes: []WatchScope{{Agent: "agent-a", SyncDir: ancestor}},
+	}}, 10)
+	setDarwinLifecycleRunningForTest(t, backend)
+	require.NoError(t, os.Remove(root))
+
+	backend.consumeFSEvents(darwinWatchRoot{
+		logicalPath: root, nativePath: root, recursive: true,
+		state: backend.logical[root], generation: backend.logical[root].generation,
+	}, []fsevents.Event{{Path: root, Flags: fseventFlagRootChanged}})
+	backend.processLifecycleSignals()
+	requireReceiveWithin(t, closed, time.Second)
+	requireReceiveWithin(t, watcher.eventSink.wake, time.Second)
+	batch, ok := watcher.eventSink.Take(watcher.agentsForRoot)
+	require.True(t, ok)
+	assert.ElementsMatch(t, paths, batch.Paths)
+	assert.Equal(t, []string{ancestor}, batch.ReconcileRoots)
+}
+
+func TestDarwinWatcherMissingRootAncestorAvoidsPerEntryWatch(t *testing.T) {
+	ancestor := t.TempDir()
+	for i := range 50 {
+		require.NoError(t, os.WriteFile(
+			filepath.Join(ancestor, fmt.Sprintf("entry%02d", i)), nil, 0o644))
+	}
+	backend, err := newDarwinWatchBackend(nil, time.Millisecond)
+	require.NoError(t, err)
+	defer backend.Stop()
+	var shallowAdds []string
+	backend.addShallow = func(path string) error {
+		shallowAdds = append(shallowAdds, path)
+		return nil
+	}
+	missing := filepath.Join(ancestor, "provider", "sessions")
+	results := backend.RegisterRoots(
+		[]WatchRoot{{Path: missing, Recursive: true}}, 1024)
+	require.Len(t, results, 1)
+	require.True(t, results[0].MissingRootLifecycleOwned)
+	assert.Empty(t, shallowAdds,
+		"ancestor coverage must not use the per-entry kqueue shallow watch")
+	require.NotNil(t, backend.vnode)
+	assert.Equal(t, 1, backend.vnode.watchedCount())
+}
+
+func TestDarwinWatcherMissingRootRealCreationDeletionRecreation(t *testing.T) {
+	ancestor := t.TempDir()
+	intermediate := filepath.Join(ancestor, "state")
+	root := filepath.Join(intermediate, "sessions")
+	backend, err := newDarwinWatchBackend(nil, 20*time.Millisecond)
+	require.NoError(t, err)
+	watcher, batches := newDarwinTestWatcherWithBackend(t, backend)
+	results := watcher.RegisterRoots([]WatchRoot{{
+		Path: root, Recursive: true,
+		Scopes: []WatchScope{{Agent: "agent-a", SyncDir: ancestor}},
+	}}, 10)
+	require.Equal(t, RecursiveWatchResult{
+		Watched: 1, MissingRootLifecycleOwned: true,
+	}, results[0])
+	watcher.Start()
+
+	require.NoError(t, os.Mkdir(intermediate, 0o700))
+	waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+		return slices.Contains(batch.ReconcileRoots, ancestor)
+	})
+	require.NoError(t, os.Mkdir(root, 0o700))
+	waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+		return slices.Contains(batch.ReconcileRoots, ancestor)
+	})
+	first := filepath.Join(root, "first.jsonl")
+	require.NoError(t, os.WriteFile(first, []byte("first"), 0o600))
+	waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+		return slices.Contains(batch.Paths, first)
+	})
+
+	require.NoError(t, os.RemoveAll(root))
+	waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+		return slices.Contains(batch.ReconcileRoots, ancestor)
+	})
+	require.NoError(t, os.Mkdir(root, 0o700))
+	waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+		return slices.Contains(batch.ReconcileRoots, ancestor)
+	})
+	second := filepath.Join(root, "second.jsonl")
+	require.NoError(t, os.WriteFile(second, []byte("second"), 0o600))
+	waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+		return slices.Contains(batch.Paths, second)
+	})
+}
+
+func TestDarwinWatcherRootShallowRenameAndRecreation(t *testing.T) {
+	ancestor := t.TempDir()
+	root := filepath.Join(ancestor, "metadata")
+	require.NoError(t, os.Mkdir(root, 0o700))
+	backend, err := newDarwinWatchBackend(nil, 20*time.Millisecond)
+	require.NoError(t, err)
+	watcher, batches := newDarwinTestWatcherWithBackend(t, backend)
+	results := watcher.RegisterRoots([]WatchRoot{{
+		Path:   root,
+		Exists: true,
+		Scopes: []WatchScope{{Agent: "agent-a", SyncDir: ancestor}},
+	}}, 10)
+	require.Equal(t, RecursiveWatchResult{Watched: 1}, results[0])
+	watcher.Start()
+
+	first := filepath.Join(root, "first.json")
+	require.NoError(t, os.WriteFile(first, []byte("first"), 0o600))
+	waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+		return slices.Contains(batch.Paths, first)
+	})
+	moved := filepath.Join(ancestor, "metadata-old")
+	require.NoError(t, os.Rename(root, moved))
+	waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+		return slices.Contains(batch.ReconcileRoots, ancestor)
+	})
+	require.NoError(t, os.Mkdir(root, 0o700))
+	waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+		return slices.Contains(batch.ReconcileRoots, ancestor)
+	})
+	second := filepath.Join(root, "second.json")
+	require.NoError(t, os.WriteFile(second, []byte("second"), 0o600))
+	waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+		return slices.Contains(batch.Paths, second)
+	})
+}
+
+func TestDarwinWatcherNativeCallbackDoesNotWaitForLifecycleLock(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "sessions")
+	require.NoError(t, os.Mkdir(root, 0o700))
+	backend, err := newDarwinWatchBackend(nil, 20*time.Millisecond)
+	require.NoError(t, err)
+	var nativeSink func([]fsevents.Event)
+	backend.newStream = func(_ string, sink func([]fsevents.Event)) (darwinStream, error) {
+		nativeSink = sink
+		return &handoffRecordingStream{}, nil
+	}
+	watcher, _ := newDarwinTestWatcherWithBackend(t, backend)
+	results := watcher.RegisterRoots([]WatchRoot{{
+		Path: root, Recursive: true, Exists: true,
+		Scopes: []WatchScope{{Agent: "agent-a", SyncDir: filepath.Dir(root)}},
+	}}, 10)
+	require.Equal(t, RecursiveWatchResult{Watched: 1}, results[0])
+	require.NoError(t, os.Remove(root))
+	var lifecycleCalls atomic.Int32
+	countCall := func(string) error {
+		lifecycleCalls.Add(1)
+		return nil
+	}
+	backend.addShallow = countCall
+	backend.removeShallow = countCall
+	backend.addAncestor = countCall
+	backend.removeAncestor = countCall
+	backend.newStream = func(string, func([]fsevents.Event)) (darwinStream, error) {
+		lifecycleCalls.Add(1)
+		return &handoffRecordingStream{}, nil
+	}
+
+	backend.mu.Lock()
+	returned := make(chan struct{})
+	go func() {
+		nativeSink([]fsevents.Event{{Path: root, Flags: fseventFlagRootChanged}})
+		close(returned)
+	}()
+
+	select {
+	case <-returned:
+		assert.Zero(t, lifecycleCalls.Load(),
+			"native delivery must only signal deferred lifecycle work")
+		backend.mu.Unlock()
+	case <-time.After(100 * time.Millisecond):
+		backend.mu.Unlock()
+		require.FailNow(t, "native callback waited for lifecycle ownership")
+	}
+}
+
+func TestDarwinWatcherHybridTransitionDoesNotSuppressOtherShallowRootEvent(t *testing.T) {
+	shallow := t.TempDir()
+	pending := filepath.Join(shallow, "sessions")
+	var trace []string
+	backend, watcher := newDarwinLifecycleTestWatcher(t, &trace)
+	results := watcher.RegisterRoots([]WatchRoot{
+		{Path: shallow, Exists: true, Scopes: []WatchScope{{Agent: "agent-a", SyncDir: shallow}}},
+		{Path: pending, Recursive: true, Scopes: []WatchScope{{Agent: "agent-b", SyncDir: shallow}}},
+	}, 10)
+	require.Equal(t, []RecursiveWatchResult{
+		{Watched: 1},
+		{Watched: 1, MissingRootLifecycleOwned: true},
+	}, results)
+	require.NoError(t, os.Mkdir(pending, 0o700))
+
+	event, dispatch := backend.handleKqueueEvent(backendEvent{
+		Path: pending, Op: backendOpCreate, ItemType: backendItemDirectory,
+	})
+
+	assert.True(t, dispatch, "root B lifecycle work must not consume root A's ordinary event")
+	assert.Equal(t, shallow, event.Root)
+}
+
+func TestDarwinWatcherRootChangedRetiresRecursiveStreamAcrossABA(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "sessions")
+	require.NoError(t, os.Mkdir(root, 0o700))
+	backend, err := newDarwinWatchBackend(nil, 20*time.Millisecond)
+	require.NoError(t, err)
+	closed := make(chan struct{})
+	var nativeSink func([]fsevents.Event)
+	backend.newStream = func(_ string, sink func([]fsevents.Event)) (darwinStream, error) {
+		nativeSink = sink
+		return &handoffRecordingStream{close: func() {
+			select {
+			case closed <- struct{}{}:
+			default:
+			}
+		}}, nil
+	}
+	watcher, _ := newDarwinTestWatcherWithBackend(t, backend)
+	results := watcher.RegisterRoots([]WatchRoot{{
+		Path: root, Recursive: true, Exists: true,
+		Scopes: []WatchScope{{Agent: "agent-a", SyncDir: filepath.Dir(root)}},
+	}}, 10)
+	require.Equal(t, RecursiveWatchResult{Watched: 1}, results[0])
+	watcher.Start()
+
+	nativeSink([]fsevents.Event{{Path: root, Flags: fseventFlagRootChanged}})
+
+	requireReceiveWithin(t, closed, time.Second)
+}
+
+func TestDarwinWatcherCollectingGateWaitsForSuccessfulReconciliation(t *testing.T) {
+	ancestor := t.TempDir()
+	root := filepath.Join(ancestor, "sessions")
+	backend, err := newDarwinWatchBackend(nil, 20*time.Millisecond)
+	require.NoError(t, err)
+	var nativeSink func([]fsevents.Event)
+	backend.newStream = func(_ string, sink func([]fsevents.Event)) (darwinStream, error) {
+		nativeSink = sink
+		return &handoffRecordingStream{}, nil
+	}
+	firstEntered := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	releaseSuccess := make(chan struct{})
+	successReturned := make(chan struct{})
+	calls := make(chan WatchBatch, 8)
+	var attempts atomic.Int32
+	watcher, err := newWatcherWithBackend(
+		0, 0,
+		func(_ context.Context, batch WatchBatch) error {
+			calls <- batch
+			switch attempts.Add(1) {
+			case 1:
+				close(firstEntered)
+				<-releaseFirst
+				return errors.New("reconciliation unavailable")
+			case 2:
+				<-releaseSuccess
+				close(successReturned)
+			}
+			return nil
+		},
+		backend, defaultWatchBatchMaxEntries, defaultWatchBatchMaxPathBytes,
+	)
+	require.NoError(t, err)
+	t.Cleanup(watcher.Stop)
+	results := watcher.RegisterRoots([]WatchRoot{{
+		Path: root, Recursive: true, Exists: true,
+		Scopes: []WatchScope{{Agent: "agent-a", SyncDir: ancestor}},
+	}}, 10)
+	require.Equal(t, RecursiveWatchResult{
+		Watched: 1, MissingRootLifecycleOwned: true,
+	}, results[0])
+	watcher.Start()
+	require.NoError(t, os.Mkdir(root, 0o700))
+	backend.handleKqueueEvent(backendEvent{
+		Path: root, Op: backendOpCreate, ItemType: backendItemDirectory,
+	})
+	requireReceiveWithin(t, firstEntered, time.Second)
+
+	path := filepath.Join(root, "during-collecting.jsonl")
+	nativeSink([]fsevents.Event{{Path: path, Flags: fseventFlagItemModified | fseventFlagItemIsFile}})
+	close(releaseFirst)
+	_ = requireReceiveWithin(t, calls, time.Second)
+	second := requireReceiveWithin(t, calls, time.Second)
+	assert.Empty(t, second.Paths,
+		"ordinary paths must remain gated while exact reconciliation is retrying")
+	assert.Equal(t, []string{ancestor}, second.ReconcileRoots)
+	close(releaseSuccess)
+	requireReceiveWithin(t, successReturned, time.Second)
+}
+
+func TestDarwinWatcherRootChangedABAReplacesRecursiveCoverageAfterTombstone(t *testing.T) {
+	ancestor := t.TempDir()
+	root := filepath.Join(ancestor, "sessions")
+	require.NoError(t, os.Mkdir(root, 0o700))
+	backend, err := newDarwinWatchBackend(nil, 20*time.Millisecond)
+	require.NoError(t, err)
+	sinks := make(chan func([]fsevents.Event), 2)
+	closed := make(chan struct{}, 1)
+	backend.newStream = func(_ string, sink func([]fsevents.Event)) (darwinStream, error) {
+		sinks <- sink
+		return &handoffRecordingStream{close: func() { closed <- struct{}{} }}, nil
+	}
+	watcher, batches := newDarwinTestWatcherWithBackend(t, backend)
+	results := watcher.RegisterRoots([]WatchRoot{{
+		Path: root, Recursive: true, Exists: true,
+		Scopes: []WatchScope{{Agent: "agent-a", SyncDir: ancestor}},
+	}}, 10)
+	require.Equal(t, RecursiveWatchResult{Watched: 1}, results[0])
+	initialSink := requireReceiveWithin(t, sinks, time.Second)
+	watcher.Start()
+
+	initialSink([]fsevents.Event{{Path: root, Flags: fseventFlagRootChanged}})
+	requireReceiveWithin(t, closed, time.Second)
+	waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+		return slices.Contains(batch.ReconcileRoots, ancestor)
+	})
+	replacementSink := requireReceiveWithin(t, sinks, time.Second)
+	waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+		return slices.Contains(batch.ReconcileRoots, ancestor)
+	})
+	require.Eventually(t, func() bool {
+		backend.mu.Lock()
+		defer backend.mu.Unlock()
+		return backend.logical[root].open.Load()
+	}, 5*time.Second, time.Millisecond)
+	path := filepath.Join(root, "after-aba.jsonl")
+	replacementSink([]fsevents.Event{{Path: path, Flags: fseventFlagItemModified | fseventFlagItemIsFile}})
+	waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+		return slices.Contains(batch.Paths, path)
+	})
+}
+
+func TestDarwinWatcherShallowRenameABAReplacesCoverage(t *testing.T) {
+	ancestor := t.TempDir()
+	root := filepath.Join(ancestor, "metadata")
+	require.NoError(t, os.Mkdir(root, 0o700))
+	var trace []string
+	backend, watcher := newDarwinLifecycleTestWatcher(t, &trace)
+	batches := make(chan WatchBatch, 8)
+	watcher.onChange = func(_ context.Context, batch WatchBatch) error {
+		batches <- batch
+		return nil
+	}
+	results := watcher.RegisterRoots([]WatchRoot{{
+		Path:   root,
+		Exists: true,
+		Scopes: []WatchScope{{Agent: "agent-a", SyncDir: ancestor}},
+	}}, 10)
+	require.Equal(t, RecursiveWatchResult{Watched: 1}, results[0])
+	initialGeneration := backend.logical[root].generation
+	watcher.Start()
+
+	backend.handleKqueueEvent(backendEvent{
+		Path: root, Root: root, Op: backendOpRename, ItemType: backendItemDirectory,
+	})
+
+	waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+		return slices.Contains(batch.ReconcileRoots, ancestor)
+	})
+	require.Eventually(t, func() bool {
+		backend.mu.Lock()
+		defer backend.mu.Unlock()
+		state := backend.logical[root]
+		return state != nil && state.generation > initialGeneration &&
+			state.ancestor == root && state.active && state.open.Load()
+	}, 5*time.Second, time.Millisecond)
+	watcher.Stop()
+	assert.Contains(t, trace, "shallow-remove:"+root)
+	assert.Contains(t, trace, "shallow-add:"+ancestor)
+	assert.Contains(t, trace, "shallow-add:"+root)
+}
+
+type retryDarwinStream struct {
+	startErr error
+	sink     func([]fsevents.Event)
+}
+
+func (s *retryDarwinStream) Start() error { return s.startErr }
+func (s *retryDarwinStream) Close() error { return nil }
+
+func TestDarwinWatcherRuntimeStreamAcquisitionFailureFallsBack(t *testing.T) {
+	for _, failure := range []string{"new", "start"} {
+		t.Run(failure, func(t *testing.T) {
+			ancestor := t.TempDir()
+			root := filepath.Join(ancestor, "sessions")
+			backend, err := newDarwinWatchBackend(nil, 20*time.Millisecond)
+			require.NoError(t, err)
+			backend.retryInitial = time.Millisecond
+			backend.retryMax = 5 * time.Millisecond
+			var attempts atomic.Int32
+			var latestSink atomic.Pointer[func([]fsevents.Event)]
+			backend.newStream = func(_ string, sink func([]fsevents.Event)) (darwinStream, error) {
+				attempt := attempts.Add(1)
+				if failure == "new" && attempt == 1 {
+					return nil, errors.New("stream unavailable")
+				}
+				latestSink.Store(&sink)
+				stream := &retryDarwinStream{sink: sink}
+				if failure == "start" && attempt == 1 {
+					stream.startErr = errors.New("start unavailable")
+				}
+				return stream, nil
+			}
+			batches := make(chan WatchBatch, 8)
+			watcher, err := newWatcherWithBackendOptions(
+				0, 0, func(_ context.Context, batch WatchBatch) error {
+					batches <- batch
+					return nil
+				}, backend, defaultWatchBatchMaxEntries, defaultWatchBatchMaxPathBytes,
+				WatcherOptions{OnCoverageDegraded: func([]string) error { return nil }},
+			)
+			require.NoError(t, err)
+			t.Cleanup(watcher.Stop)
+			results := watcher.RegisterRoots([]WatchRoot{{
+				Path: root, Recursive: true,
+				Scopes: []WatchScope{{Agent: "agent-a", SyncDir: ancestor}},
+			}}, 10)
+			require.Equal(t, RecursiveWatchResult{
+				Watched: 1, MissingRootLifecycleOwned: true,
+			}, results[0])
+			require.NoError(t, watcher.Start())
+			require.NoError(t, os.Mkdir(root, 0o700))
+			backend.signalLifecycle()
+
+			waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+				return batch.FullSync
+			})
+			require.Eventually(t, func() bool {
+				return backend.fallbackPhaseValue() == darwinFallbackInactive
+			}, time.Second, time.Millisecond)
+			assert.Equal(t, int32(2), attempts.Load(), "native coverage is retried once")
+			require.Eventually(t, watcher.eventSink.Empty, time.Second, time.Millisecond,
+				"fallback handoff markers must drain before steady-state delivery")
+			path := filepath.Join(root, "after-retry.jsonl")
+			sink := latestSink.Load()
+			require.NotNil(t, sink)
+			(*sink)([]fsevents.Event{{
+				Path: path, Flags: fseventFlagItemModified | fseventFlagItemIsFile,
+			}})
+			waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+				return slices.Contains(batch.Paths, path)
+			})
+		})
+	}
+}
+
+func TestDarwinWatcherFallbackRecoversNativeStreamsAndReleasesPolling(t *testing.T) {
+	root := t.TempDir()
+	backend, err := newDarwinWatchBackend(nil, 20*time.Millisecond)
+	require.NoError(t, err)
+	backend.retryInitial = 5 * time.Millisecond
+	backend.retryMax = 10 * time.Millisecond
+
+	var sinksMu sync.Mutex
+	var sinks []func([]fsevents.Event)
+	backend.newStream = func(_ string, sink func([]fsevents.Event)) (darwinStream, error) {
+		sinksMu.Lock()
+		sinks = append(sinks, sink)
+		sinksMu.Unlock()
+		return &handoffRecordingStream{}, nil
+	}
+	polling := make(chan PollingObligation, 2)
+	released := make(chan string, 1)
+	batches := make(chan WatchBatch, 8)
+	watcher, err := newWatcherWithBackendOptions(
+		0, 0, func(_ context.Context, batch WatchBatch) error {
+			batches <- batch
+			return nil
+		}, backend, defaultWatchBatchMaxEntries, defaultWatchBatchMaxPathBytes,
+		WatcherOptions{
+			OnCoverageDegraded: func(roots []string) error {
+				polling <- PollingObligation{Key: "watcher-fallback", Roots: roots}
+				return nil
+			},
+			OnPollingRequired: func(obligation PollingObligation) error {
+				polling <- obligation
+				return nil
+			},
+			OnPollingReleased: func(key string) error {
+				released <- key
+				return nil
+			},
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(watcher.Stop)
+	results := watcher.RegisterRoots([]WatchRoot{{
+		Path: root, Recursive: true, Exists: true,
+		Scopes: []WatchScope{{Agent: "agent-a", SyncDir: root}},
+	}}, 10)
+	require.Equal(t, []RecursiveWatchResult{{Watched: 1}}, results)
+	require.NoError(t, watcher.Start())
+
+	sinksMu.Lock()
+	require.Len(t, sinks, 1)
+	initialSink := sinks[0]
+	sinksMu.Unlock()
+	initialSink([]fsevents.Event{{Flags: fseventFlagKernelDropped}})
+
+	assert.Equal(t, PollingObligation{
+		Key:   darwinFallbackPollingObligationKey(root),
+		Roots: []string{root},
+		Probe: root,
+	}, requireReceiveWithin(t, polling, time.Second))
+	waitForDarwinBatch(t, batches, func(batch WatchBatch) bool { return batch.FullSync })
+	assert.Equal(t, darwinFallbackPollingObligationKey(root),
+		requireReceiveWithin(t, released, time.Second))
+	require.Eventually(t, func() bool {
+		return backend.fallbackPhaseValue() == darwinFallbackInactive &&
+			darwinFallbackReason(backend.fallbackReason.Load()) == darwinFallbackReasonNone
+	}, time.Second, time.Millisecond)
+	sinksMu.Lock()
+	require.Len(t, sinks, 2)
+	recoveredSink := sinks[1]
+	sinksMu.Unlock()
+	changed := filepath.Join(root, "after-recovery.jsonl")
+	recoveredSink([]fsevents.Event{{
+		Path: changed, Flags: fseventFlagItemModified | fseventFlagItemIsFile,
+	}})
+	batch := waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+		return slices.Contains(batch.Paths, changed)
+	})
+	assert.Contains(t, batch.Paths, changed)
+}
+
+func TestDarwinWatcherFallbackKeepsPollingUntilNativeRetrySucceeds(t *testing.T) {
+	root := t.TempDir()
+	backend, err := newDarwinWatchBackend(nil, 20*time.Millisecond)
+	require.NoError(t, err)
+	backend.retryInitial = 40 * time.Millisecond
+	backend.retryMax = 40 * time.Millisecond
+
+	failedRecovery := make(chan struct{})
+	var attempts atomic.Int32
+	backend.newStream = func(_ string, _ func([]fsevents.Event)) (darwinStream, error) {
+		switch attempts.Add(1) {
+		case 2:
+			close(failedRecovery)
+			return nil, errors.New("temporary stream create failure")
+		default:
+			return &handoffRecordingStream{}, nil
+		}
+	}
+	polling := make(chan PollingObligation, 1)
+	released := make(chan string, 1)
+	batches := make(chan WatchBatch, 8)
+	watcher, err := newWatcherWithBackendOptions(
+		0, 0, func(_ context.Context, batch WatchBatch) error {
+			batches <- batch
+			return nil
+		}, backend, defaultWatchBatchMaxEntries, defaultWatchBatchMaxPathBytes,
+		WatcherOptions{
+			OnPollingRequired: func(obligation PollingObligation) error {
+				polling <- obligation
+				return nil
+			},
+			OnPollingReleased: func(key string) error {
+				released <- key
+				return nil
+			},
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(watcher.Stop)
+	results := watcher.RegisterRoots([]WatchRoot{{
+		Path: root, Recursive: true, Exists: true,
+		Scopes: []WatchScope{{SyncDir: root}},
+	}}, 10)
+	require.Equal(t, []RecursiveWatchResult{{Watched: 1}}, results)
+	require.NoError(t, watcher.Start())
+
+	backend.requestFallback(darwinFallbackNativeDrop)
+	assert.Equal(t, PollingObligation{
+		Key:   darwinFallbackPollingObligationKey(root),
+		Roots: []string{root},
+		Probe: root,
+	}, requireReceiveWithin(t, polling, time.Second))
+	waitForDarwinBatch(t, batches, func(batch WatchBatch) bool { return batch.FullSync })
+	requireReceiveWithin(t, failedRecovery, time.Second)
+	select {
+	case key := <-released:
+		require.Fail(t, "polling released after failed native recovery", key)
+	default:
+	}
+
+	assert.Equal(t, darwinFallbackPollingObligationKey(root),
+		requireReceiveWithin(t, released, time.Second))
+	require.Eventually(t, func() bool {
+		return backend.fallbackPhaseValue() == darwinFallbackInactive
+	}, time.Second, time.Millisecond)
+	assert.Equal(t, int32(3), attempts.Load())
+}
+
+func TestDarwinWatcherFallbackTransfersMissingRootPollingBeforeRecovery(t *testing.T) {
+	parent := t.TempDir()
+	present := filepath.Join(parent, "present")
+	missing := filepath.Join(parent, "missing")
+	require.NoError(t, os.Mkdir(present, 0o700))
+	backend, err := newDarwinWatchBackend(nil, 20*time.Millisecond)
+	require.NoError(t, err)
+	backend.retryInitial = 5 * time.Millisecond
+	backend.retryMax = 10 * time.Millisecond
+	backend.newStream = func(string, func([]fsevents.Event)) (darwinStream, error) {
+		return &handoffRecordingStream{}, nil
+	}
+
+	polling := make(chan PollingObligation, 4)
+	released := make(chan string, 4)
+	batches := make(chan WatchBatch, 8)
+	watcher, err := newWatcherWithBackendOptions(
+		0, 0, func(_ context.Context, batch WatchBatch) error {
+			batches <- batch
+			return nil
+		}, backend, defaultWatchBatchMaxEntries, defaultWatchBatchMaxPathBytes,
+		WatcherOptions{
+			OnPollingRequired: func(obligation PollingObligation) error {
+				polling <- obligation
+				return nil
+			},
+			OnPollingReleased: func(key string) error {
+				released <- key
+				return nil
+			},
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(watcher.Stop)
+	results := watcher.RegisterRoots([]WatchRoot{
+		{
+			Path: present, Recursive: true, Exists: true,
+			Scopes: []WatchScope{{SyncDir: present}},
+		},
+		{
+			Path: missing, Recursive: true,
+			Scopes: []WatchScope{{SyncDir: missing}},
+		},
+	}, 10)
+	require.Equal(t, []RecursiveWatchResult{
+		{Watched: 1},
+		{Watched: 1, MissingRootLifecycleOwned: true},
+	}, results)
+	require.NoError(t, watcher.Start())
+
+	backend.requestFallback(darwinFallbackNativeDrop)
+	assert.Equal(t, PollingObligation{
+		Key:   darwinFallbackPollingObligationKey(missing),
+		Roots: []string{missing},
+		Probe: missing,
+	}, requireReceiveWithin(t, polling, time.Second),
+		"each watch plan owns its own fallback obligation probed on its path")
+	assert.Equal(t, PollingObligation{
+		Key:   darwinFallbackPollingObligationKey(present),
+		Roots: []string{present},
+		Probe: present,
+	}, requireReceiveWithin(t, polling, time.Second))
+	waitForDarwinBatch(t, batches, func(batch WatchBatch) bool { return batch.FullSync })
+	assert.Equal(t,
+		PollingObligation{Key: missing, Roots: []string{missing}, Probe: missing},
+		requireReceiveWithin(t, polling, time.Second),
+		"the skipped root must own polling before generic fallback polling is released")
+	assert.Equal(t, darwinFallbackPollingObligationKey(missing),
+		requireReceiveWithin(t, released, time.Second))
+	assert.Equal(t, darwinFallbackPollingObligationKey(present),
+		requireReceiveWithin(t, released, time.Second))
+	require.Eventually(t, func() bool {
+		backend.mu.Lock()
+		defer backend.mu.Unlock()
+		state := backend.logical[missing]
+		return backend.fallbackPhaseValue() == darwinFallbackInactive &&
+			state != nil && state.phase == darwinRootPending && state.ancestor == parent
+	}, time.Second, time.Millisecond)
+
+	require.NoError(t, os.Mkdir(missing, 0o700))
+	backend.signalLifecycle()
+	assert.Equal(t, missing, requireReceiveWithin(t, released, time.Second),
+		"native activation releases the transferred root-specific polling obligation")
+}
+
+func TestDarwinWatcherStartupCreateFailureSelectsRecursiveFallbackOnce(t *testing.T) {
+	parent := t.TempDir()
+	first := filepath.Join(parent, "first")
+	second := filepath.Join(parent, "second")
+	missing := filepath.Join(parent, "missing")
+	require.NoError(t, os.Mkdir(first, 0o700))
+	require.NoError(t, os.Mkdir(second, 0o700))
+	backend, err := newDarwinWatchBackend(nil, 20*time.Millisecond)
+	require.NoError(t, err)
+	var creates atomic.Int32
+	backend.newStream = func(string, func([]fsevents.Event)) (darwinStream, error) {
+		creates.Add(1)
+		return nil, errors.New("stream create unavailable")
+	}
+	watcher, err := newWatcherWithBackendOptions(
+		0, 0, func(context.Context, WatchBatch) error { return nil }, backend,
+		defaultWatchBatchMaxEntries, defaultWatchBatchMaxPathBytes, WatcherOptions{},
+	)
+	require.NoError(t, err)
+	t.Cleanup(watcher.Stop)
+
+	results := watcher.RegisterRoots([]WatchRoot{
+		{Path: first, Recursive: true, Exists: true, Scopes: []WatchScope{{SyncDir: first}}},
+		{Path: second, Recursive: true, Exists: true, Scopes: []WatchScope{{SyncDir: second}}},
+		{Path: missing, Recursive: true, Scopes: []WatchScope{{SyncDir: missing}}},
+	}, 1)
+
+	assert.Equal(t, []RecursiveWatchResult{
+		{Watched: 1},
+		{Watched: 1},
+		{Watched: 1},
+	}, results)
+	assert.Equal(t, int32(1), creates.Load(), "one failed stream selects global fallback")
+	assert.Equal(t, []darwinFallbackPollPlan{
+		{path: first, roots: []string{first}},
+		{path: missing, roots: []string{missing}},
+		{path: second, roots: []string{second}},
+	}, backend.fallbackPollPlans)
+	assert.Equal(t, uint32(1), backend.fallbackActivations.Load())
+}
+
+func TestDarwinWatcherStartupFallbackRetainsMissingShallowRootLifecycle(t *testing.T) {
+	parent := t.TempDir()
+	recursive := filepath.Join(parent, "recursive")
+	missingShallow := filepath.Join(parent, "metadata")
+	require.NoError(t, os.Mkdir(recursive, 0o700))
+	backend, err := newDarwinWatchBackend(nil, 20*time.Millisecond)
+	require.NoError(t, err)
+	var creates atomic.Int32
+	backend.newStream = func(string, func([]fsevents.Event)) (darwinStream, error) {
+		if creates.Add(1) == 1 {
+			return nil, errors.New("initial stream unavailable")
+		}
+		return &handoffRecordingStream{}, nil
+	}
+	polling := make(chan PollingObligation, 1)
+	batches := make(chan WatchBatch, 8)
+	watcher, err := newWatcherWithBackendOptions(
+		0, 0, func(_ context.Context, batch WatchBatch) error {
+			batches <- batch
+			return nil
+		}, backend, defaultWatchBatchMaxEntries, defaultWatchBatchMaxPathBytes,
+		WatcherOptions{OnPollingRequired: func(obligation PollingObligation) error {
+			polling <- obligation
+			return nil
+		}},
+	)
+	require.NoError(t, err)
+	t.Cleanup(watcher.Stop)
+	results := watcher.RegisterRoots([]WatchRoot{
+		{
+			Path: recursive, Recursive: true, Exists: true,
+			Scopes: []WatchScope{{SyncDir: recursive}},
+		},
+		{
+			Path:   missingShallow,
+			Scopes: []WatchScope{{SyncDir: missingShallow}},
+		},
+	}, 10)
+	assert.Equal(t, []RecursiveWatchResult{
+		{Watched: 1},
+		{Watched: 1, MissingRootLifecycleOwned: true},
+	}, results)
+	assert.Equal(t, 1, backend.ancestors[parent],
+		"startup fallback must retain the missing shallow root's ancestor watch")
+	require.NoError(t, watcher.Start())
+	requireReceiveWithin(t, polling, time.Second)
+	waitForDarwinBatch(t, batches, func(batch WatchBatch) bool { return batch.FullSync })
+
+	require.NoError(t, os.Mkdir(missingShallow, 0o700))
+	backend.signalLifecycle()
+	require.Eventually(t, func() bool {
+		backend.mu.Lock()
+		defer backend.mu.Unlock()
+		state := backend.logical[missingShallow]
+		return state != nil && state.active && state.phase == darwinRootOpen &&
+			backend.shallow[missingShallow] == 1
+	}, time.Second, time.Millisecond)
+	changed := filepath.Join(missingShallow, "session.jsonl")
+	sent := make(chan struct{})
+	go func() {
+		backend.kqueue.events <- backendEvent{Path: changed, Op: backendOpWrite}
+		close(sent)
+	}()
+	batch := waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+		return slices.Contains(batch.Paths, changed)
+	})
+	requireReceiveWithin(t, sent, time.Second)
+	assert.Contains(t, batch.Paths, changed)
+}
+
+func TestDarwinWatcherStartupStreamStartFailureFallsBack(t *testing.T) {
+	root := t.TempDir()
+	backend, err := newDarwinWatchBackend(nil, 20*time.Millisecond)
+	require.NoError(t, err)
+	var creates atomic.Int32
+	backend.newStream = func(string, func([]fsevents.Event)) (darwinStream, error) {
+		creates.Add(1)
+		return &retryDarwinStream{startErr: errors.New("stream start unavailable")}, nil
+	}
+	batches := make(chan WatchBatch, 2)
+	watcher, err := newWatcherWithBackendOptions(
+		0, 0, func(_ context.Context, batch WatchBatch) error {
+			batches <- batch
+			return nil
+		}, backend, defaultWatchBatchMaxEntries, defaultWatchBatchMaxPathBytes,
+		WatcherOptions{OnCoverageDegraded: func([]string) error { return nil }},
+	)
+	require.NoError(t, err)
+	t.Cleanup(watcher.Stop)
+	results := watcher.RegisterRoots([]WatchRoot{{
+		Path: root, Recursive: true, Exists: true,
+		Scopes: []WatchScope{{SyncDir: root}},
+	}}, 10)
+	require.Equal(t, []RecursiveWatchResult{{Watched: 1}}, results)
+
+	watcher.Start()
+	waitForDarwinBatch(t, batches, func(batch WatchBatch) bool { return batch.FullSync })
+	require.Eventually(t, func() bool {
+		return backend.fallbackPhaseValue() == darwinFallbackOpen
+	}, time.Second, time.Millisecond)
+	assert.Eventually(t, func() bool { return creates.Load() >= 2 }, time.Second, time.Millisecond,
+		"native stream start is retried while polling remains active")
+	assert.Equal(t, uint32(1), backend.fallbackActivations.Load())
+}
+
+func TestDarwinWatcherStartupFallbackKqueueFailurePollsEveryScope(t *testing.T) {
+	root := t.TempDir()
+	backend, err := newDarwinWatchBackend(nil, 20*time.Millisecond)
+	require.NoError(t, err)
+	backend.newStream = func(string, func([]fsevents.Event)) (darwinStream, error) {
+		return nil, errors.New("stream create unavailable")
+	}
+	backend.startKqueue = func() error { return errors.New("kqueue unavailable") }
+	coverage := make(chan []string, 1)
+	watcher, err := newWatcherWithBackendOptions(
+		0, 0, func(context.Context, WatchBatch) error { return nil }, backend,
+		defaultWatchBatchMaxEntries, defaultWatchBatchMaxPathBytes,
+		WatcherOptions{OnCoverageDegraded: func(roots []string) error {
+			coverage <- append([]string(nil), roots...)
+			return nil
+		}},
+	)
+	require.NoError(t, err)
+	t.Cleanup(watcher.Stop)
+	results := watcher.RegisterRoots([]WatchRoot{{
+		Path: root, Recursive: true, Exists: true,
+		Scopes: []WatchScope{{SyncDir: root}},
+	}}, 10)
+	require.Equal(t, []RecursiveWatchResult{{Watched: 1}}, results)
+
+	watcher.Start()
+	assert.Equal(t, []string{root}, requireReceiveWithin(t, coverage, time.Second))
+	require.Eventually(t, func() bool {
+		return backend.fallbackPhaseValue() == darwinFallbackOpen
+	}, time.Second, time.Millisecond)
+	_, retry := backend.nextLifecycleRetry()
+	assert.False(t, retry,
+		"an unrecoverable kqueue start failure must not wake the lifecycle loop forever")
+}
+
+func TestDarwinWatcherRuntimeFallbackOrdersCoverageAndRetainsReconciliation(t *testing.T) {
+	for _, reconcileErr := range []error{
+		errors.New("reconciliation unavailable"),
+		context.Canceled,
+	} {
+		t.Run(reconcileErr.Error(), func(t *testing.T) {
+			root := filepath.Join(t.TempDir(), "sessions")
+			require.NoError(t, os.Mkdir(root, 0o700))
+			afterInvalidation := filepath.Join(root, "after-invalidation.jsonl")
+			duringReconcile := filepath.Join(root, "during-reconcile.jsonl")
+			backend, err := newDarwinWatchBackend(nil, 20*time.Millisecond)
+			require.NoError(t, err)
+			backend.retryInitial = time.Second
+			backend.retryMax = time.Second
+			var nativeSink func([]fsevents.Event)
+			order := make(chan string, 16)
+			closed := make(chan struct{})
+			invalidationDispatch := make(chan bool, 1)
+			reconcileDispatch := make(chan bool, 1)
+			backend.newStream = func(_ string, sink func([]fsevents.Event)) (darwinStream, error) {
+				nativeSink = sink
+				return &handoffRecordingStream{close: func() {
+					order <- "invalidate"
+					_, dispatch := backend.handleKqueueEvent(backendEvent{
+						Path: afterInvalidation, Op: backendOpWrite,
+					})
+					invalidationDispatch <- dispatch
+					close(closed)
+				}}, nil
+			}
+			coverageCalls := atomic.Int32{}
+			batches := make(chan WatchBatch, 16)
+			firstReconcile := make(chan struct{})
+			releaseRetry := make(chan struct{})
+			var releaseRetryOnce sync.Once
+			allowRetry := func() { releaseRetryOnce.Do(func() { close(releaseRetry) }) }
+			var attempts atomic.Int32
+			watcher, err := newWatcherWithBackendOptions(
+				0, time.Millisecond,
+				func(_ context.Context, batch WatchBatch) error {
+					batches <- batch
+					if !batch.FullSync {
+						return nil
+					}
+					order <- "reconcile"
+					attempt := attempts.Add(1)
+					if attempt == 1 {
+						_, dispatch := backend.handleKqueueEvent(backendEvent{
+							Path: duringReconcile, Op: backendOpWrite,
+						})
+						reconcileDispatch <- dispatch
+						close(firstReconcile)
+						return reconcileErr
+					}
+					<-releaseRetry
+					return nil
+				},
+				backend, defaultWatchBatchMaxEntries, defaultWatchBatchMaxPathBytes,
+				WatcherOptions{OnCoverageDegraded: func(roots []string) error {
+					coverageCalls.Add(1)
+					order <- "poll"
+					return nil
+				}},
+			)
+			require.NoError(t, err)
+			t.Cleanup(watcher.Stop)
+			t.Cleanup(allowRetry)
+			results := watcher.RegisterRoots([]WatchRoot{{
+				Path: root, Recursive: true, Exists: true,
+				Scopes: []WatchScope{{Agent: "agent-a", SyncDir: root}},
+			}}, 10)
+			require.Equal(t, []RecursiveWatchResult{{Watched: 1}}, results)
+			watcher.Start()
+
+			before := filepath.Join(root, "before-fallback.jsonl")
+			nativeSink([]fsevents.Event{{
+				Path: before, Flags: fseventFlagItemModified | fseventFlagItemIsFile,
+			}})
+			waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+				return slices.Contains(batch.Paths, before)
+			})
+
+			nativeSink([]fsevents.Event{{Flags: fseventFlagKernelDropped}})
+			requireReceiveWithin(t, firstReconcile, time.Second)
+			requireReceiveWithin(t, closed, time.Second)
+			assert.False(t, requireReceiveWithin(t, invalidationDispatch, time.Second))
+			assert.False(t, requireReceiveWithin(t, reconcileDispatch, time.Second))
+			retry := waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+				return batch.FullSync && attempts.Load() == 2
+			})
+			assert.True(t, retry.FullSync)
+			assert.Equal(t, darwinFallbackReconciling, backend.fallbackPhaseValue())
+			assert.Equal(t, int32(2), attempts.Load())
+			assert.Equal(t, int32(1), coverageCalls.Load())
+			allowRetry()
+			require.Eventually(t, func() bool {
+				return backend.fallbackPhaseValue() == darwinFallbackOpen
+			}, time.Second, time.Millisecond)
+
+			retained := waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+				return slices.Contains(batch.Paths, duringReconcile)
+			})
+			assert.ElementsMatch(t, []string{
+				afterInvalidation,
+				duringReconcile,
+			}, retained.Paths)
+			assert.Equal(t, int32(2), attempts.Load(), "one retained marker retries until success")
+			assert.Equal(t, uint32(1), backend.fallbackActivations.Load())
+			assert.Equal(t, uint32(1), backend.nativeDrops.Load())
+
+			gotOrder := make([]string, 0, 4)
+			for len(gotOrder) < 4 {
+				gotOrder = append(gotOrder, requireReceiveWithin(t, order, time.Second))
+			}
+			assert.Equal(t, []string{"poll", "invalidate", "reconcile", "reconcile"}, gotOrder)
+		})
+	}
+}
+
+func TestDarwinWatcherFallbackLifecycleTokenSurvivesSinkContention(t *testing.T) {
+	backend, err := newDarwinWatchBackend(nil, 20*time.Millisecond)
+	require.NoError(t, err)
+	t.Cleanup(backend.Stop)
+	sink := newWatchEventSink(
+		defaultWatchBatchMaxEntries,
+		defaultWatchBatchMaxPathBytes,
+	)
+	backend.bindEventSink(sink)
+
+	sink.mu.Lock()
+	backend.beginFallbackReconciliation()
+	nativeAccepted := sink.TryAccumulate(func(add func(backendEvent) bool) bool {
+		return add(backendEvent{Path: "/native.jsonl", Op: backendOpWrite})
+	})
+	sink.mu.Unlock()
+
+	assert.True(t, nativeAccepted, "contended native delivery must remain nonblocking")
+	batch, ok := sink.Take(nil)
+	require.True(t, ok)
+	assert.True(t, batch.FullSync)
+	require.Len(t, batch.lifecycleTokens, 1)
+	assert.Same(t, backend, batch.lifecycleTokens[0].gate)
+	assert.Equal(t, uint64(1), batch.lifecycleTokens[0].generation)
+	batch.lifecycleTokens[0].gate.acknowledgeLifecycle(
+		batch.lifecycleTokens[0].generation,
+	)
+	assert.Equal(t, uint64(1), backend.fallbackAcknowledged.Load())
+}
+
+func TestDarwinWatcherRuntimeFallbackWaitsForPollingRegistration(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "sessions")
+	require.NoError(t, os.Mkdir(root, 0o700))
+	backend, err := newDarwinWatchBackend(nil, 20*time.Millisecond)
+	require.NoError(t, err)
+	var nativeSink func([]fsevents.Event)
+	invalidated := make(chan struct{}, 1)
+	backend.newStream = func(_ string, sink func([]fsevents.Event)) (darwinStream, error) {
+		nativeSink = sink
+		return &handoffRecordingStream{close: func() { invalidated <- struct{}{} }}, nil
+	}
+	allowPolling := make(chan struct{})
+	coverageCalls := make(chan []string, 2)
+	var attempts atomic.Int32
+	watcher, err := newWatcherWithBackendOptions(
+		0, 0, func(context.Context, WatchBatch) error { return nil }, backend,
+		defaultWatchBatchMaxEntries, defaultWatchBatchMaxPathBytes,
+		WatcherOptions{OnCoverageDegraded: func(roots []string) error {
+			coverageCalls <- append([]string(nil), roots...)
+			if attempts.Add(1) == 1 {
+				return errors.New("poll coordinator stopped")
+			}
+			<-allowPolling
+			return nil
+		}},
+	)
+	require.NoError(t, err)
+	t.Cleanup(watcher.Stop)
+	watcher.RegisterRoots([]WatchRoot{{
+		Path: root, Recursive: true, Exists: true,
+		Scopes: []WatchScope{{SyncDir: root}},
+	}}, 10)
+	backend.retryInitial = time.Millisecond
+	backend.retryMax = 2 * time.Millisecond
+	watcher.Start()
+
+	nativeSink([]fsevents.Event{{Flags: fseventFlagUserDropped}})
+	assert.Equal(t, []string{root}, requireReceiveWithin(t, coverageCalls, time.Second))
+	assert.Equal(t, []string{root}, requireReceiveWithin(t, coverageCalls, time.Second))
+	select {
+	case <-invalidated:
+		require.FailNow(t, "FSEvents invalidated before polling owned the uncovered root")
+	default:
+	}
+	close(allowPolling)
+	requireReceiveWithin(t, invalidated, time.Second)
+	assert.Equal(t, int32(2), attempts.Load())
+}
+
+func TestDarwinWatcherFallbackNativeCallbackDoesNotRunPolling(t *testing.T) {
+	root := t.TempDir()
+	backend, err := newDarwinWatchBackend(nil, 20*time.Millisecond)
+	require.NoError(t, err)
+	var nativeSink func([]fsevents.Event)
+	backend.newStream = func(_ string, sink func([]fsevents.Event)) (darwinStream, error) {
+		nativeSink = sink
+		return &handoffRecordingStream{}, nil
+	}
+	pollingEntered := make(chan struct{})
+	releasePolling := make(chan struct{})
+	watcher, err := newWatcherWithBackendOptions(
+		0, 0, func(context.Context, WatchBatch) error { return nil }, backend,
+		defaultWatchBatchMaxEntries, defaultWatchBatchMaxPathBytes,
+		WatcherOptions{OnCoverageDegraded: func([]string) error {
+			close(pollingEntered)
+			<-releasePolling
+			return nil
+		}},
+	)
+	require.NoError(t, err)
+	t.Cleanup(watcher.Stop)
+	watcher.RegisterRoots([]WatchRoot{{
+		Path: root, Recursive: true, Exists: true,
+		Scopes: []WatchScope{{SyncDir: root}},
+	}}, 10)
+	watcher.Start()
+
+	returned := make(chan struct{})
+	go func() {
+		nativeSink([]fsevents.Event{{Flags: fseventFlagKernelDropped}})
+		close(returned)
+	}()
+	requireReceiveWithin(t, returned, 100*time.Millisecond)
+	requireReceiveWithin(t, pollingEntered, time.Second)
+	close(releasePolling)
+}
+
+func TestDarwinWatcherKqueueStartFailureFallbackPollsBeforeInvalidation(t *testing.T) {
+	root := t.TempDir()
+	shallow := filepath.Join(root, "shallow")
+	require.NoError(t, os.Mkdir(shallow, 0o700))
+	backend, err := newDarwinWatchBackend(nil, 20*time.Millisecond)
+	require.NoError(t, err)
+	backend.startKqueue = func() error { return errors.New("kqueue unavailable") }
+	var nativeSink func([]fsevents.Event)
+	pollingOwned := atomic.Bool{}
+	invalidated := make(chan struct{})
+	invalidatedWithPolling := make(chan bool, 1)
+	coverage := make(chan []string, 1)
+	backend.newStream = func(_ string, sink func([]fsevents.Event)) (darwinStream, error) {
+		nativeSink = sink
+		return &handoffRecordingStream{close: func() {
+			invalidatedWithPolling <- pollingOwned.Load()
+			close(invalidated)
+		}}, nil
+	}
+	batches := make(chan WatchBatch, 2)
+	watcher, err := newWatcherWithBackendOptions(
+		0, 0, func(_ context.Context, batch WatchBatch) error {
+			batches <- batch
+			return nil
+		}, backend, defaultWatchBatchMaxEntries, defaultWatchBatchMaxPathBytes,
+		WatcherOptions{OnCoverageDegraded: func(roots []string) error {
+			coverage <- append([]string(nil), roots...)
+			pollingOwned.Store(true)
+			return nil
+		}},
+	)
+	require.NoError(t, err)
+	t.Cleanup(watcher.Stop)
+	watcher.RegisterRoots([]WatchRoot{
+		{
+			Path: root, Recursive: true, Exists: true,
+			Scopes: []WatchScope{{SyncDir: root}},
+		},
+		{
+			Path: shallow, Exists: true,
+			Scopes: []WatchScope{{SyncDir: shallow}},
+		},
+	}, 10)
+	watcher.Start()
+
+	require.NotNil(t, nativeSink)
+	assert.Equal(t, []string{root, shallow}, requireReceiveWithin(t, coverage, time.Second))
+	requireReceiveWithin(t, invalidated, time.Second)
+	assert.True(t, requireReceiveWithin(t, invalidatedWithPolling, time.Second))
+	waitForDarwinBatch(t, batches, func(batch WatchBatch) bool { return batch.FullSync })
+	require.Eventually(t, func() bool {
+		return backend.fallbackPhaseValue() == darwinFallbackOpen
+	}, time.Second, time.Millisecond)
+}
+
+func TestDarwinWatcherLifecycleFailureFallsBackToPolling(t *testing.T) {
+	ancestor := t.TempDir()
+	intermediate := filepath.Join(ancestor, "state")
+	root := filepath.Join(intermediate, "sessions")
+	backend, err := newDarwinWatchBackend(nil, 20*time.Millisecond)
+	require.NoError(t, err)
+	backend.retryInitial = time.Millisecond
+	backend.retryMax = 5 * time.Millisecond
+	var attempts atomic.Int32
+	backend.addAncestor = func(path string) error {
+		if path == intermediate && attempts.Add(1) == 1 {
+			return errors.New("descriptor unavailable")
+		}
+		return nil
+	}
+	backend.removeAncestor = func(string) error { return nil }
+	coverage := make(chan []string, 1)
+	batches := make(chan WatchBatch, 8)
+	watcher, err := newWatcherWithBackendOptions(
+		0, 0, func(_ context.Context, batch WatchBatch) error {
+			batches <- batch
+			return nil
+		}, backend, defaultWatchBatchMaxEntries, defaultWatchBatchMaxPathBytes,
+		WatcherOptions{OnCoverageDegraded: func(roots []string) error {
+			coverage <- append([]string(nil), roots...)
+			return nil
+		}},
+	)
+	require.NoError(t, err)
+	t.Cleanup(watcher.Stop)
+	results := watcher.RegisterRoots([]WatchRoot{{
+		Path: root, Recursive: true,
+		Scopes: []WatchScope{{Agent: "agent-a", SyncDir: ancestor}},
+	}}, 10)
+	require.Equal(t, RecursiveWatchResult{
+		Watched: 1, MissingRootLifecycleOwned: true,
+	}, results[0])
+	watcher.Start()
+	require.NoError(t, os.Mkdir(intermediate, 0o700))
+	backend.signalLifecycle()
+
+	assert.Equal(t, []string{ancestor}, requireReceiveWithin(t, coverage, time.Second))
+	waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+		return batch.FullSync
+	})
+	require.Eventually(t, func() bool {
+		return backend.fallbackPhaseValue() == darwinFallbackOpen
+	}, time.Second, time.Millisecond)
+	assert.Equal(t, int32(1), attempts.Load())
+}
+
+func TestDarwinWatcherShallowLifecycleFailureFallbackPollsScope(t *testing.T) {
+	ancestor := t.TempDir()
+	intermediate := filepath.Join(ancestor, "state")
+	root := filepath.Join(intermediate, "sessions")
+	backend, err := newDarwinWatchBackend(nil, 20*time.Millisecond)
+	require.NoError(t, err)
+	backend.retryInitial = time.Millisecond
+	backend.retryMax = 5 * time.Millisecond
+	backend.addAncestor = func(path string) error {
+		if path == intermediate {
+			return errors.New("descriptor unavailable")
+		}
+		return nil
+	}
+	backend.removeAncestor = func(string) error { return nil }
+	coverage := make(chan []string, 1)
+	watcher, err := newWatcherWithBackendOptions(
+		0, 0, func(context.Context, WatchBatch) error { return nil }, backend,
+		defaultWatchBatchMaxEntries, defaultWatchBatchMaxPathBytes,
+		WatcherOptions{OnCoverageDegraded: func(roots []string) error {
+			coverage <- append([]string(nil), roots...)
+			return nil
+		}},
+	)
+	require.NoError(t, err)
+	t.Cleanup(watcher.Stop)
+	results := watcher.RegisterRoots([]WatchRoot{{
+		Path:   root,
+		Scopes: []WatchScope{{Agent: "agent-a", SyncDir: ancestor}},
+	}}, 10)
+	require.Equal(t, RecursiveWatchResult{
+		Watched: 1, MissingRootLifecycleOwned: true,
+	}, results[0])
+	watcher.Start()
+	require.NoError(t, os.Mkdir(intermediate, 0o700))
+	backend.signalLifecycle()
+
+	assert.Equal(t, []string{ancestor}, requireReceiveWithin(t, coverage, time.Second))
+}
+
+func TestDarwinWatcherMissingRecursiveSymlinkStaysPolled(t *testing.T) {
+	ancestor := t.TempDir()
+	root := filepath.Join(ancestor, "sessions")
+	target := t.TempDir()
+	backend, err := newDarwinWatchBackend(nil, 20*time.Millisecond)
+	require.NoError(t, err)
+	backend.retryInitial = time.Millisecond
+	backend.retryMax = 5 * time.Millisecond
+	var streamCalls atomic.Int32
+	backend.newStream = func(string, func([]fsevents.Event)) (darwinStream, error) {
+		streamCalls.Add(1)
+		return &handoffRecordingStream{}, nil
+	}
+	required := make(chan PollingObligation, 1)
+	batches := make(chan WatchBatch, 8)
+	watcher, err := newWatcherWithBackendOptions(
+		0, 0, func(_ context.Context, batch WatchBatch) error {
+			batches <- batch
+			return nil
+		}, backend, defaultWatchBatchMaxEntries, defaultWatchBatchMaxPathBytes,
+		WatcherOptions{OnPollingRequired: func(obligation PollingObligation) error {
+			required <- obligation
+			return nil
+		}},
+	)
+	require.NoError(t, err)
+	t.Cleanup(watcher.Stop)
+	results := watcher.RegisterRoots([]WatchRoot{{
+		Path: root, Recursive: true,
+		Scopes: []WatchScope{{Agent: "agent-a", SyncDir: ancestor}},
+	}}, 10)
+	require.Equal(t, RecursiveWatchResult{
+		Watched: 1, MissingRootLifecycleOwned: true,
+	}, results[0])
+	var firstRootInspection atomic.Bool
+	symlinkResult := make(chan error, 1)
+	backend.lstat = func(path string) (os.FileInfo, error) {
+		if path == root && firstRootInspection.CompareAndSwap(false, true) {
+			symlinkResult <- os.Symlink(target, root)
+			return nil, os.ErrNotExist
+		}
+		return os.Lstat(path)
+	}
+	watcher.Start()
+	backend.signalLifecycle()
+	require.NoError(t, requireReceiveWithin(t, symlinkResult, time.Second))
+
+	waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+		return slices.Contains(batch.ReconcileRoots, ancestor)
+	})
+	assert.Equal(t,
+		PollingObligation{Key: root, Roots: []string{ancestor}, Probe: root},
+		requireReceiveWithin(t, required, time.Second))
+	require.True(t, firstRootInspection.Load())
+	backend.mu.Lock()
+	phase := backend.logical[root].phase
+	backend.mu.Unlock()
+	assert.Equal(t, darwinRootPolling, phase)
+	assert.Zero(t, streamCalls.Load(),
+		"a recursive symlink is owned by configured polling, not a native stream")
+}
+
+func TestDarwinWatcherMissingShallowSymlinkActivatesAndRestoresCoverage(t *testing.T) {
+	ancestor := t.TempDir()
+	root := filepath.Join(ancestor, "sessions")
+	target := t.TempDir()
+	backend, err := newDarwinWatchBackend(nil, 20*time.Millisecond)
+	require.NoError(t, err)
+	backend.retryInitial = time.Millisecond
+	backend.retryMax = 5 * time.Millisecond
+	restored := make(chan []string, 1)
+	batches := make(chan WatchBatch, 4)
+	watcher, err := newWatcherWithBackendOptions(
+		0, 0, func(_ context.Context, batch WatchBatch) error {
+			batches <- batch
+			return nil
+		}, backend, defaultWatchBatchMaxEntries, defaultWatchBatchMaxPathBytes,
+		WatcherOptions{OnPollingReleased: func(key string) error {
+			restored <- []string{key}
+			return nil
+		}},
+	)
+	require.NoError(t, err)
+	t.Cleanup(watcher.Stop)
+	results := watcher.RegisterRoots([]WatchRoot{{
+		Path:   root,
+		Scopes: []WatchScope{{Agent: "agent-a", SyncDir: ancestor}},
+	}}, 10)
+	require.Equal(t, RecursiveWatchResult{
+		Watched: 1, MissingRootLifecycleOwned: true,
+	}, results[0])
+	require.NoError(t, watcher.Start())
+	require.NoError(t, os.Symlink(target, root))
+	backend.signalLifecycle()
+
+	waitForDarwinBatch(t, batches, func(batch WatchBatch) bool {
+		return slices.Contains(batch.ReconcileRoots, ancestor)
+	})
+	assert.Equal(t, []string{root}, requireReceiveWithin(t, restored, time.Second))
+	require.Eventually(t, func() bool {
+		backend.mu.Lock()
+		defer backend.mu.Unlock()
+		state := backend.logical[root]
+		return state != nil && state.active && state.phase == darwinRootOpen
+	}, time.Second, time.Millisecond)
+}
+
+func TestDarwinWatcherPendingLossWinsOverActivationAcknowledgement(t *testing.T) {
+	ancestor := t.TempDir()
+	root := filepath.Join(ancestor, "sessions")
+	backend, err := newDarwinWatchBackend(nil, 20*time.Millisecond)
+	require.NoError(t, err)
+	backend.lifecycle = darwinBackendRunning
+	backend.addAncestor = func(string) error { return nil }
+	backend.removeAncestor = func(string) error { return nil }
+	required := make(chan PollingObligation, 1)
+	backend.onPollingRequired = func(obligation PollingObligation) error {
+		required <- obligation
+		return nil
+	}
+	closed := make(chan struct{}, 1)
+	stream := &handoffRecordingStream{close: func() { closed <- struct{}{} }}
+	state := &darwinLogicalRoot{
+		plan: WatchRoot{
+			Path: root, Recursive: true,
+			Scopes: []WatchScope{{Agent: "agent-a", SyncDir: ancestor}},
+		},
+		active:     true,
+		stream:     stream,
+		phase:      darwinRootActivationCollecting,
+		generation: 1,
+		retryAt:    time.Now().Add(time.Hour),
+	}
+	state.currentGeneration.Store(1)
+	state.acknowledged.Store(1)
+	state.signal.Or(darwinRootSignalLoss)
+	backend.logical[root] = state
+	backend.streams[root] = stream
+
+	backend.processLifecycleSignals()
+
+	assert.Equal(t, darwinRootLossCollecting, state.phase)
+	assert.False(t, state.active)
+	assert.Equal(t,
+		PollingObligation{Key: root, Roots: []string{ancestor}, Probe: root},
+		requireReceiveWithin(t, required, time.Second))
+	requireReceiveWithin(t, closed, time.Second)
+}
+
+type handoffRecordingStream struct {
+	start func()
+	close func()
+}
+
+func (s *handoffRecordingStream) Start() error {
+	if s.start != nil {
+		s.start()
+	}
+	return nil
+}
+
+func (s *handoffRecordingStream) Close() error {
+	if s.close != nil {
+		s.close()
+	}
+	return nil
+}
+
+type darwinDirectTestBackend struct {
+	events chan backendEvent
+	errors chan error
+	sink   directBackendEventSink
+}
+
+type stopAfterOneDirectSink struct {
+	added      int
+	event      backendEvent
+	meaningful bool
+}
+
+func (s *stopAfterOneDirectSink) TryAccumulate(
+	accumulate func(func(backendEvent) bool) bool,
+) bool {
+	s.meaningful = accumulate(func(event backendEvent) bool {
+		s.added++
+		s.event = event
+		return false
+	})
+	return true
+}
+
+func (s *stopAfterOneDirectSink) RetainAuthoritative(token backendLifecycleToken) {
+	s.added++
+	s.event = backendEvent{Op: backendOpFullSync, Lifecycle: token}
+	s.meaningful = true
+}
+
+func newDarwinDirectTestBackend() *darwinDirectTestBackend {
+	return &darwinDirectTestBackend{
+		events: make(chan backendEvent),
+		errors: make(chan error),
+	}
+}
+
+func (b *darwinDirectTestBackend) Events() <-chan backendEvent { return b.events }
+func (b *darwinDirectTestBackend) Errors() <-chan error        { return b.errors }
+func (b *darwinDirectTestBackend) AddRecursive(string, int) RecursiveWatchResult {
+	return RecursiveWatchResult{}
+}
+func (b *darwinDirectTestBackend) AddShallow(string) error { return nil }
+func (b *darwinDirectTestBackend) Remove(string) error     { return nil }
+func (b *darwinDirectTestBackend) Start() error            { return nil }
+func (b *darwinDirectTestBackend) Stop()                   {}
+func (b *darwinDirectTestBackend) Name() string            { return "darwin-direct-test" }
+func (b *darwinDirectTestBackend) bindEventSink(sink directBackendEventSink) {
+	b.sink = sink
+}
+
+func (b *darwinDirectTestBackend) emit(events []backendEvent) bool {
+	return b.sink.TryAccumulate(func(add func(backendEvent) bool) bool {
+		for _, event := range events {
+			if !add(event) {
+				return true
+			}
+		}
+		return len(events) > 0
+	})
+}
+
+func (b *darwinDirectTestBackend) emitFiltered() bool {
+	return b.sink.TryAccumulate(func(func(backendEvent) bool) bool {
+		return false
+	})
+}
+
+func (b *darwinDirectTestBackend) sendKqueue(t *testing.T, event backendEvent) {
+	t.Helper()
+	sent := make(chan struct{})
+	go func() {
+		b.events <- event
+		close(sent)
+	}()
+	requireReceiveWithin(t, sent, time.Second)
+}
+
+func newDarwinTestWatcher(
+	t *testing.T,
+	root string,
+	excludes []string,
+	latency time.Duration,
+) (*Watcher, <-chan WatchBatch) {
+	t.Helper()
+	backend, err := newDarwinWatchBackend(excludes, latency)
+	require.NoError(t, err)
+	watcher, batches := newDarwinTestWatcherWithBackend(t, backend)
+	result := watcher.WatchRecursiveBudgeted(root, 1)
+	require.NoError(t, result.Err)
+	require.Equal(t, 1, result.Watched)
+	return watcher, batches
+}
+
+func newDarwinTestWatcherWithBackend(
+	t *testing.T,
+	backend *darwinWatchBackend,
+) (*Watcher, <-chan WatchBatch) {
+	t.Helper()
+	batches := make(chan WatchBatch, 32)
+	watcher, err := newWatcherWithBackend(
+		500*time.Millisecond,
+		20*time.Millisecond,
+		func(_ context.Context, batch WatchBatch) error {
+			batches <- batch
+			return nil
+		},
+		backend,
+		defaultWatchBatchMaxEntries,
+		defaultWatchBatchMaxPathBytes,
+	)
+	require.NoError(t, err)
+	t.Cleanup(watcher.Stop)
+	return watcher, batches
+}
+
+func waitForDarwinBatch(
+	t *testing.T,
+	batches <-chan WatchBatch,
+	match func(WatchBatch) bool,
+) WatchBatch {
+	t.Helper()
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+	for {
+		select {
+		case batch := <-batches:
+			if match(batch) {
+				return batch
+			}
+		case <-timer.C:
+			require.FailNow(t, "timed out waiting for matching Darwin watcher batch")
+			return WatchBatch{}
+		}
+	}
+}

--- a/internal/sync/watcher_test.go
+++ b/internal/sync/watcher_test.go
@@ -1,7 +1,11 @@
 package sync
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"slices"
@@ -17,9 +21,339 @@ import (
 
 const watcherTestTimeout = 5 * time.Second
 
+func requireReceiveWithin[T any](t *testing.T, ch <-chan T, timeout time.Duration) T {
+	t.Helper()
+	select {
+	case value := <-ch:
+		return value
+	case <-time.After(timeout):
+		require.FailNow(t, "timed out waiting for channel value")
+		var zero T
+		return zero
+	}
+}
+
 type watcherCall struct {
 	paths []string
 	at    time.Time
+}
+
+type recordingLifecycleGate struct {
+	acknowledged chan uint64
+}
+
+func (g *recordingLifecycleGate) acknowledgeLifecycle(generation uint64) {
+	g.acknowledged <- generation
+}
+
+func TestWatcherAcknowledgesLifecycleOnlyAfterSuccessfulReconciliation(t *testing.T) {
+	backend := newFakeWatchBackend()
+	gate := &recordingLifecycleGate{acknowledged: make(chan uint64, 1)}
+	calls := make(chan WatchBatch, 2)
+	releaseSuccess := make(chan struct{})
+	var attempts atomic.Int32
+	w, err := newWatcherWithBackend(
+		0, 0,
+		func(_ context.Context, batch WatchBatch) error {
+			calls <- batch
+			if attempts.Add(1) == 1 {
+				return errors.New("reconciliation unavailable")
+			}
+			<-releaseSuccess
+			return nil
+		},
+		backend, 16, 1_000,
+	)
+	require.NoError(t, err)
+	w.Start()
+	t.Cleanup(w.Stop)
+
+	backend.sendBackendEvent(t, backendEvent{
+		Path: "/sync", Root: "/sync", Op: backendOpReconcileRootChange,
+		Lifecycle: backendLifecycleToken{gate: gate, generation: 7},
+	})
+	first := requireReceiveWithin(t, calls, time.Second)
+	assert.Equal(t, []string{"/sync"}, first.ReconcileRoots)
+	select {
+	case generation := <-gate.acknowledged:
+		require.Fail(t, "failed reconciliation acknowledged lifecycle", generation)
+	case <-time.After(50 * time.Millisecond):
+	}
+	second := requireReceiveWithin(t, calls, time.Second)
+	assert.Equal(t, []string{"/sync"}, second.ReconcileRoots)
+	close(releaseSuccess)
+	assert.Equal(t, uint64(7), requireReceiveWithin(t, gate.acknowledged, time.Second))
+}
+
+func TestWatcherLifecycleCollectsBeforeDispatchOpens(t *testing.T) {
+	backend := newFakeWatchBackend()
+	calls := make(chan WatchBatch, 1)
+	w, err := newWatcherWithBackend(
+		0, 0,
+		func(_ context.Context, batch WatchBatch) error {
+			calls <- batch
+			return nil
+		},
+		backend, 2, 1_000,
+	)
+	require.NoError(t, err)
+	w.StartCollecting()
+	t.Cleanup(w.Stop)
+
+	backend.sendEvent(t, "/sessions/one.jsonl")
+	backend.sendEvent(t, "/sessions/two.jsonl")
+	backend.sendEvent(t, "/sessions/overflow.jsonl")
+	assert.Never(t, func() bool {
+		select {
+		case <-calls:
+			return true
+		default:
+			return false
+		}
+	}, 50*time.Millisecond, 5*time.Millisecond,
+		"collecting must not invoke the callback")
+
+	w.OpenDispatch()
+	batch := requireReceiveWithin(t, calls, time.Second)
+	assert.True(t, batch.FullSync,
+		"bounded startup accumulation must retain an authoritative marker")
+}
+
+// TestWatcherQueueRetryBatchDispatchesQueuedRoots pins the startup-gap retry
+// handoff: a batch queued during collecting mode dispatches once OpenDispatch
+// fires, carrying its reconcile roots into the normal callback (and thus
+// retry) machinery, and a full-sync batch queues the authoritative marker.
+func TestWatcherQueueRetryBatchDispatchesQueuedRoots(t *testing.T) {
+	backend := newFakeWatchBackend()
+	calls := make(chan WatchBatch, 1)
+	w, err := newWatcherWithBackend(
+		0, 0,
+		func(_ context.Context, batch WatchBatch) error {
+			calls <- batch
+			return nil
+		},
+		backend, 8, 1_000,
+	)
+	require.NoError(t, err)
+	w.StartCollecting()
+	t.Cleanup(w.Stop)
+
+	w.QueueRetryBatch(WatchBatch{ReconcileRoots: []string{"/gap-root"}})
+	assert.Never(t, func() bool {
+		select {
+		case <-calls:
+			return true
+		default:
+			return false
+		}
+	}, 50*time.Millisecond, 5*time.Millisecond,
+		"collecting must not invoke the callback")
+
+	w.OpenDispatch()
+	batch := requireReceiveWithin(t, calls, time.Second)
+	assert.Equal(t, []string{"/gap-root"}, batch.ReconcileRoots)
+	assert.False(t, batch.FullSync)
+	assert.False(t, batch.LostEvents)
+
+	w.QueueRetryBatch(WatchBatch{FullSync: true})
+	batch = requireReceiveWithin(t, calls, time.Second)
+	assert.True(t, batch.FullSync)
+	assert.False(t, batch.LostEvents,
+		"a queued ordinary full sync must not clear freshness caches like a "+
+			"watcher-overflow full sync")
+}
+
+func TestWatcherLifecycleDispatchingDeliversNewEvents(t *testing.T) {
+	backend := newFakeWatchBackend()
+	calls := make(chan WatchBatch, 1)
+	w, err := newWatcherWithBackend(
+		0, 0,
+		func(_ context.Context, batch WatchBatch) error {
+			calls <- batch
+			return nil
+		},
+		backend, 8, 1_000,
+	)
+	require.NoError(t, err)
+	w.StartCollecting()
+	w.OpenDispatch()
+	t.Cleanup(w.Stop)
+
+	backend.sendEvent(t, "/sessions/live.jsonl")
+	batch := requireReceiveWithin(t, calls, time.Second)
+	assert.Equal(t, []string{"/sessions/live.jsonl"}, batch.Paths)
+}
+
+func TestWatcherLifecycleStoppedRejectsCollectionAndDispatch(t *testing.T) {
+	backend := newFakeWatchBackend()
+	calls := make(chan WatchBatch, 1)
+	w, err := newWatcherWithBackend(
+		0, 0,
+		func(_ context.Context, batch WatchBatch) error {
+			calls <- batch
+			return nil
+		},
+		backend, 8, 1_000,
+	)
+	require.NoError(t, err)
+	w.Stop()
+
+	w.StartCollecting()
+	w.OpenDispatch()
+	assert.Zero(t, backend.startCalls.Load())
+	select {
+	case batch := <-calls:
+		require.Fail(t, "stopped watcher dispatched a batch", "%+v", batch)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+type fakeWatchBackend struct {
+	events           chan backendEvent
+	errors           chan error
+	started          chan struct{}
+	stopped          chan struct{}
+	startErr         error
+	recursiveRoots   []string
+	recursiveBudgets []int
+	shallowRoots     []string
+	includeSubtree   func(root, path string) bool
+
+	startOnce  sync.Once
+	stopOnce   sync.Once
+	startCalls atomic.Int32
+	stopCalls  atomic.Int32
+}
+
+func newFakeWatchBackend() *fakeWatchBackend {
+	return &fakeWatchBackend{
+		events:  make(chan backendEvent),
+		errors:  make(chan error),
+		started: make(chan struct{}),
+		stopped: make(chan struct{}),
+	}
+}
+
+func (b *fakeWatchBackend) Events() <-chan backendEvent { return b.events }
+func (b *fakeWatchBackend) Errors() <-chan error        { return b.errors }
+func (b *fakeWatchBackend) AddRecursive(root string, budget int) RecursiveWatchResult {
+	b.recursiveRoots = append(b.recursiveRoots, root)
+	b.recursiveBudgets = append(b.recursiveBudgets, budget)
+	return RecursiveWatchResult{Watched: 1}
+}
+func (b *fakeWatchBackend) AddShallow(root string) error {
+	b.shallowRoots = append(b.shallowRoots, root)
+	return nil
+}
+func (b *fakeWatchBackend) Remove(string) error { return nil }
+func (b *fakeWatchBackend) Start() error {
+	b.startCalls.Add(1)
+	b.startOnce.Do(func() { close(b.started) })
+	return b.startErr
+}
+func (b *fakeWatchBackend) Stop() {
+	b.stopCalls.Add(1)
+	b.stopOnce.Do(func() { close(b.stopped) })
+}
+func (b *fakeWatchBackend) Name() string { return "fake" }
+
+func (b *fakeWatchBackend) includeCreatedSubtreePath(root, path string) bool {
+	return b.includeSubtree == nil || b.includeSubtree(root, path)
+}
+
+func (b *fakeWatchBackend) shouldEnumerateCreatedSubtree(_, _ string) bool {
+	return true
+}
+
+func TestWatcherRegisterRootsPreservesCompleteLogicalPlanBeforeStart(t *testing.T) {
+	backend := newFakeWatchBackend()
+	w, err := newWatcherWithBackend(
+		0, 0, func(context.Context, WatchBatch) error { return nil },
+		backend, 8, 1_000,
+	)
+	require.NoError(t, err)
+	t.Cleanup(w.Stop)
+
+	results := w.RegisterRoots([]WatchRoot{
+		{
+			Path: "/shared", Recursive: true, Exists: true,
+			Scopes: []WatchScope{
+				{Agent: "codex", SyncDir: "/sessions"},
+				{Agent: "claude", SyncDir: "/projects"},
+			},
+		},
+		{
+			Path: "/missing", Recursive: true, Exists: false,
+			Scopes: []WatchScope{{Agent: "devin", SyncDir: "/state"}},
+		},
+		{
+			Path: "/shallow", Recursive: false, Exists: true,
+			Scopes: []WatchScope{{Agent: "gemini", SyncDir: "/metadata"}},
+		},
+	}, 7)
+
+	assert.Zero(t, backend.startCalls.Load(), "roots must register before backend start")
+	assert.Equal(t, []string{"/shared"}, backend.recursiveRoots)
+	assert.Equal(t, []int{7}, backend.recursiveBudgets)
+	assert.Equal(t, []string{"/shallow"}, backend.shallowRoots)
+	assert.Equal(t, []string{"claude", "codex"}, w.agentsForRoot("/shared"))
+	assert.Equal(t, []string{"devin"}, w.agentsForRoot("/missing"),
+		"missing logical roots must retain rename ownership")
+	require.Len(t, results, 3)
+	assert.Equal(t, 1, results[0].Watched)
+	assert.Zero(t, results[1].Watched, "missing root must not activate current backend")
+	assert.Equal(t, 1, results[2].Watched)
+}
+
+func (b *fakeWatchBackend) sendEvent(t *testing.T, path string) {
+	t.Helper()
+	b.sendBackendEvent(t, backendEvent{Path: path, Op: backendOpWrite})
+}
+
+func (b *fakeWatchBackend) sendBackendEvent(t *testing.T, event backendEvent) {
+	t.Helper()
+	select {
+	case b.events <- event:
+	case <-time.After(watcherTestTimeout):
+		t.Fatalf("scheduler did not drain backend event for %q", event.Path)
+	}
+}
+
+func (b *fakeWatchBackend) sendError(t *testing.T, err error) {
+	t.Helper()
+	select {
+	case b.errors <- err:
+	case <-time.After(watcherTestTimeout):
+		t.Fatalf("scheduler did not drain backend error %q", err)
+	}
+}
+
+func startFakeWatcherWithLimits(
+	t *testing.T,
+	backend *fakeWatchBackend,
+	onChange func(WatchBatch),
+	maxEntries, maxPathBytes int,
+) *Watcher {
+	t.Helper()
+	w, err := newWatcherWithBackend(
+		0,
+		0,
+		func(_ context.Context, batch WatchBatch) error {
+			onChange(batch)
+			return nil
+		},
+		backend,
+		maxEntries,
+		maxPathBytes,
+	)
+	require.NoError(t, err, "newWatcherWithBackend")
+	w.Start()
+	select {
+	case <-backend.started:
+	case <-time.After(watcherTestTimeout):
+		t.Fatal("watch backend did not start")
+	}
+	return w
 }
 
 func startTestWatcherWithIntervalsNoCleanup(
@@ -34,29 +368,6 @@ func startTestWatcherWithIntervalsNoCleanup(
 		nil,
 	)
 	require.NoError(t, err, "NewWatcherWithInterval")
-	_, _, err = w.WatchRecursive(dir)
-	require.NoError(t, err, "WatchRecursive")
-	w.Start()
-	return w, dir
-}
-
-func startTestWatcherWithBatchLimitsNoCleanup(
-	t *testing.T,
-	onChange func(WatchBatch),
-	batchDelay, minInterval time.Duration,
-	maxEntries, maxPathBytes int,
-) (*Watcher, string) {
-	t.Helper()
-	dir := t.TempDir()
-	w, err := newWatcherWithLimits(
-		batchDelay,
-		minInterval,
-		onChange,
-		nil,
-		maxEntries,
-		maxPathBytes,
-	)
-	require.NoError(t, err, "newWatcherWithLimits")
 	_, _, err = w.WatchRecursive(dir)
 	require.NoError(t, err, "WatchRecursive")
 	w.Start()
@@ -104,14 +415,37 @@ func receiveWatcherCall(t *testing.T, calls <-chan watcherCall) watcherCall {
 	}
 }
 
-func receivePaths(t *testing.T, calls <-chan []string) []string {
+func waitForPath(t *testing.T, calls <-chan []string, path string) {
 	t.Helper()
-	select {
-	case paths := <-calls:
-		return paths
-	case <-time.After(watcherTestTimeout):
-		t.Fatal("timed out waiting for watcher callback")
-		return nil
+	deadline := time.NewTimer(watcherTestTimeout)
+	defer deadline.Stop()
+	for {
+		select {
+		case paths := <-calls:
+			if slices.Contains(paths, path) {
+				return
+			}
+		case <-deadline.C:
+			t.Fatalf("timed out waiting for watcher path %q", path)
+		}
+	}
+}
+
+func assertPathNotEmitted(
+	t *testing.T, calls <-chan []string, path string, duration time.Duration,
+) {
+	t.Helper()
+	deadline := time.NewTimer(duration)
+	defer deadline.Stop()
+	for {
+		select {
+		case paths := <-calls:
+			if !assert.NotContains(t, paths, path) {
+				return
+			}
+		case <-deadline.C:
+			return
+		}
 	}
 }
 
@@ -143,19 +477,6 @@ func startTestWatcher(
 	w, dir := startTestWatcherNoCleanup(t, onChange, 50*time.Millisecond)
 	t.Cleanup(func() { w.Stop() })
 	return w, dir
-}
-
-// pollUntil dynamically polls a condition to avoid hardcoded sleeps.
-func pollUntil(t *testing.T, condition func() bool) {
-	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		if condition() {
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	t.Fatal("pollUntil: condition not met within deadline")
 }
 
 func TestPendingWatchBatchOverflowsByEntryCount(t *testing.T) {
@@ -211,6 +532,156 @@ func TestPendingWatchBatchTakeResetsBounds(t *testing.T) {
 	require.True(t, ok)
 	assert.False(t, second.FullSync)
 	assert.Equal(t, []string{"/sessions/b.jsonl"}, second.Paths)
+}
+
+func TestPendingWatchBatchBoundsAllRetainedMetadata(t *testing.T) {
+	path := "/sessions/a.jsonl"
+	root := "/sessions"
+	pending := newPendingWatchBatch(3, 10_000)
+
+	pending.Add(path)
+	pending.AddRename(WatchRename{
+		Path:     "/sessions/b.jsonl",
+		Root:     root,
+		ItemType: ItemIsFile,
+	})
+	pending.AddReconcileRoot("/other")
+
+	batch, ok := pending.Take()
+	require.True(t, ok)
+	assert.Equal(t, WatchBatch{FullSync: true, LostEvents: true}, batch,
+		"overflow must discard every retained string")
+}
+
+func TestPendingWatchBatchBoundsMixedMetadataBytesIndependently(t *testing.T) {
+	path := "/sessions/a.jsonl"
+	renamePath := "/sessions/b.jsonl"
+	root := "/sessions"
+	otherRoot := "/other"
+	agent := "codex"
+	pending := newPendingWatchBatch(
+		10, len(path)+len(renamePath)+len(root)+len(agent)+len(otherRoot)-1,
+	)
+
+	pending.Add(path)
+	pending.AddRename(WatchRename{
+		Path: renamePath, Root: root, Agent: agent, ItemType: ItemIsFile,
+	})
+	pending.AddReconcileRoot(otherRoot)
+
+	batch, ok := pending.Take()
+	require.True(t, ok)
+	assert.Equal(t, WatchBatch{FullSync: true, LostEvents: true}, batch,
+		"byte overflow must discard every retained string")
+}
+
+func TestPendingWatchBatchDeduplicatesRenameAndRootMetadata(t *testing.T) {
+	rename := WatchRename{
+		Path:     "/sessions/a.jsonl",
+		Root:     "/sessions",
+		ItemType: ItemIsFile,
+	}
+	pending := newPendingWatchBatch(3, len(rename.Path)+len(rename.Root))
+
+	pending.AddRename(rename)
+	pending.AddRename(rename)
+	pending.AddReconcileRoot(rename.Root)
+	pending.AddReconcileRoot(rename.Root)
+
+	batch, ok := pending.Take()
+	require.True(t, ok)
+	assert.False(t, batch.FullSync)
+	assert.Equal(t, []WatchRename{rename}, batch.Renames)
+	assert.Equal(t, []string{rename.Root}, batch.ReconcileRoots)
+}
+
+func TestPendingWatchBatchMetadataByteOverflowClearsStrings(t *testing.T) {
+	rename := WatchRename{
+		Path:     "/sessions/用户.jsonl",
+		Root:     "/sessions",
+		ItemType: ItemIsUnknown,
+	}
+	pending := newPendingWatchBatch(10, len(rename.Path)+len(rename.Root)-1)
+
+	pending.AddRename(rename)
+
+	batch, ok := pending.Take()
+	require.True(t, ok)
+	assert.Equal(t, WatchBatch{FullSync: true, LostEvents: true}, batch)
+}
+
+func TestPendingWatchBatchRootCountOverflowEmitsOnlyFullSync(t *testing.T) {
+	pending := newPendingWatchBatch(1, 1_000)
+
+	pending.AddReconcileRoot("/sessions-a")
+	pending.AddReconcileRoot("/sessions-b")
+
+	batch, ok := pending.Take()
+	require.True(t, ok)
+	assert.Equal(t, WatchBatch{FullSync: true, LostEvents: true}, batch)
+}
+
+func TestWatchEventSinkCountsOnlyCapacityOverflowAsOverflow(t *testing.T) {
+	sink := newWatchEventSink(1, 1024)
+	sink.Add(backendEvent{Op: backendOpFullSync})
+	assert.Zero(t, sink.overflows.Load(), "authoritative reconciliation is not overflow")
+	_, ok := sink.Take(nil)
+	require.True(t, ok)
+
+	sink.Add(backendEvent{Path: "first", Op: backendOpWrite})
+	sink.Add(backendEvent{Path: "second", Op: backendOpWrite})
+	assert.Equal(t, uint32(1), sink.overflows.Load())
+}
+
+func TestPendingWatchBatchFullSyncPreservesLifecycleMarkers(t *testing.T) {
+	gate := &recordingLifecycleGate{acknowledged: make(chan uint64, 1)}
+	token := backendLifecycleToken{gate: gate, generation: 9}
+	pending := newPendingWatchBatch(2, 1024)
+	pending.AddBackendEvent(backendEvent{
+		Root: "/sync", Op: backendOpReconcileRootChange, Lifecycle: token,
+	})
+
+	pending.AddFullSync()
+	pending.AddFullSync()
+	batch, ok := pending.Take()
+
+	require.True(t, ok)
+	assert.True(t, batch.FullSync)
+	assert.Equal(t, []backendLifecycleToken{token}, batch.lifecycleTokens)
+}
+
+func TestPendingWatchBatchFullSyncRetainsLaterLifecycleMarkers(t *testing.T) {
+	gate := &recordingLifecycleGate{acknowledged: make(chan uint64, 1)}
+	token := backendLifecycleToken{gate: gate, generation: 10}
+	pending := newPendingWatchBatch(2, 1024)
+	pending.AddFullSync()
+
+	pending.AddBackendEvent(backendEvent{
+		Root: "/sync", Op: backendOpReconcileRootChange, Lifecycle: token,
+	})
+	batch, ok := pending.Take()
+
+	require.True(t, ok)
+	assert.True(t, batch.FullSync)
+	assert.Equal(t, []backendLifecycleToken{token}, batch.lifecycleTokens,
+		"a lifecycle gate must remain acknowledgeable after full reconciliation")
+}
+
+func TestWatchEventSinkRetainsConcurrentAuthoritativeLifecycleMarkers(t *testing.T) {
+	firstGate := &recordingLifecycleGate{acknowledged: make(chan uint64, 1)}
+	secondGate := &recordingLifecycleGate{acknowledged: make(chan uint64, 1)}
+	first := backendLifecycleToken{gate: firstGate, generation: 11}
+	second := backendLifecycleToken{gate: secondGate, generation: 12}
+	sink := newWatchEventSink(2, 1024)
+
+	sink.RetainAuthoritative(first)
+	sink.RetainAuthoritative(second)
+	batch, ok := sink.Take(nil)
+
+	require.True(t, ok)
+	assert.True(t, batch.FullSync)
+	assert.ElementsMatch(t, []backendLifecycleToken{first, second}, batch.lifecycleTokens,
+		"separate lifecycle gates must not overwrite one another")
 }
 
 func TestWatcherBatchesPathsAndEnforcesDispatchFloor(t *testing.T) {
@@ -316,21 +787,18 @@ func TestWatcherSustainedWritesProgress(t *testing.T) {
 		"sustained writes did not make bounded progress")
 }
 
-func TestWatcherContinuesIntakeDuringCallback(t *testing.T) {
-	const (
-		batchDelay  = 30 * time.Millisecond
-		minInterval = 120 * time.Millisecond
-	)
+func TestWatcherSchedulerContinuesIntakeWithOnePendingAccumulator(t *testing.T) {
 	started := make(chan struct{})
 	release := make(chan struct{})
 	var releaseOnce sync.Once
 	releaseCallback := func() { releaseOnce.Do(func() { close(release) }) }
-	calls := make(chan []string, 4)
+	calls := make(chan WatchBatch, 4)
 	var callCount atomic.Int32
 	var concurrent atomic.Int32
 	var maxConcurrent atomic.Int32
 
-	w, dir := startTestWatcherWithIntervals(t, func(paths []string) {
+	backend := newFakeWatchBackend()
+	w := startFakeWatcherWithLimits(t, backend, func(batch WatchBatch) {
 		current := concurrent.Add(1)
 		updateMax(&maxConcurrent, current)
 		defer concurrent.Add(-1)
@@ -339,151 +807,787 @@ func TestWatcherContinuesIntakeDuringCallback(t *testing.T) {
 			close(started)
 			<-release
 		}
-		calls <- paths
-	}, batchDelay, minInterval)
-	t.Cleanup(releaseCallback)
+		calls <- batch
+	}, 8, 1_000)
+	t.Cleanup(func() {
+		releaseCallback()
+		w.Stop()
+	})
 
-	firstPath := filepath.Join(dir, "first.jsonl")
-	require.NoError(t, os.WriteFile(firstPath, []byte("first"), 0o644))
+	backend.sendEvent(t, "/sessions/first.jsonl")
 	select {
 	case <-started:
 	case <-time.After(watcherTestTimeout):
 		t.Fatal("timed out waiting for the first callback to start")
 	}
 
-	duringCallbackPath := filepath.Join(dir, "during-callback")
-	require.NoError(t, os.Mkdir(duringCallbackPath, 0o755))
-	require.Eventually(t, func() bool {
-		return slices.Contains(w.watcher.WatchList(), duringCallbackPath)
-	}, time.Second, 10*time.Millisecond,
-		"watcher did not drain the directory event while callback was blocked")
+	backend.sendEvent(t, "/sessions/during-callback.jsonl")
 	assert.Never(t, func() bool {
 		return callCount.Load() > 1
-	}, minInterval+batchDelay, 5*time.Millisecond,
+	}, 50*time.Millisecond, 5*time.Millisecond,
 		"a second callback started while the first callback was blocked")
 	releaseCallback()
 
-	firstBatch := receivePaths(t, calls)
-	secondBatch := receivePaths(t, calls)
-	assert.Contains(t, firstBatch, firstPath)
-	assert.Contains(t, secondBatch, duringCallbackPath)
+	firstBatch := receiveWatchBatch(t, calls)
+	secondBatch := receiveWatchBatch(t, calls)
+	assert.Equal(t, []string{"/sessions/first.jsonl"}, firstBatch.Paths)
+	assert.Equal(t, []string{"/sessions/during-callback.jsonl"}, secondBatch.Paths)
 	assert.Equal(t, int32(1), maxConcurrent.Load(),
 		"watcher callbacks must remain serialized")
 }
 
-func TestWatcherOverflowRunsFullSyncThenRetainsLaterBatch(t *testing.T) {
-	const (
-		batchDelay  = 20 * time.Millisecond
-		minInterval = 80 * time.Millisecond
-		maxEntries  = 2
-	)
-	firstRelease := make(chan struct{})
-	fullSyncRelease := make(chan struct{})
-	var releaseFirstOnce sync.Once
-	var releaseFullSyncOnce sync.Once
-	releaseFirst := func() { releaseFirstOnce.Do(func() { close(firstRelease) }) }
-	releaseFullSync := func() {
-		releaseFullSyncOnce.Do(func() { close(fullSyncRelease) })
+func TestWatcherOverflowCollapsesPathAndByteLimitsToOneFullSync(t *testing.T) {
+	tests := []struct {
+		name         string
+		maxEntries   int
+		maxPathBytes int
+		paths        []string
+	}{
+		{
+			name:         "path count",
+			maxEntries:   2,
+			maxPathBytes: 1_000,
+			paths:        []string{"/sessions/a", "/sessions/b", "/sessions/c"},
+		},
+		{
+			name:         "path bytes",
+			maxEntries:   10,
+			maxPathBytes: len("/sessions/a"),
+			paths:        []string{"/sessions/a", "/sessions/b"},
+		},
 	}
 
-	calls := make(chan WatchBatch, 4)
-	var callCount atomic.Int32
-	var concurrent atomic.Int32
-	var maxConcurrent atomic.Int32
-	w, dir := startTestWatcherWithBatchLimitsNoCleanup(
-		t,
-		func(batch WatchBatch) {
-			current := concurrent.Add(1)
-			updateMax(&maxConcurrent, current)
-			defer concurrent.Add(-1)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			firstRelease := make(chan struct{})
+			var releaseOnce sync.Once
+			release := func() { releaseOnce.Do(func() { close(firstRelease) }) }
+			calls := make(chan WatchBatch, 4)
+			var callCount atomic.Int32
+			backend := newFakeWatchBackend()
+			w := startFakeWatcherWithLimits(t, backend, func(batch WatchBatch) {
+				calls <- batch
+				if callCount.Add(1) == 1 {
+					<-firstRelease
+				}
+			}, tt.maxEntries, tt.maxPathBytes)
+			t.Cleanup(func() {
+				release()
+				w.Stop()
+			})
 
-			call := callCount.Add(1)
-			calls <- batch
-			switch call {
-			case 1:
-				<-firstRelease
-			case 2:
-				<-fullSyncRelease
+			backend.sendEvent(t, "/r")
+			first := receiveWatchBatch(t, calls)
+			assert.Equal(t, []string{"/r"}, first.Paths)
+
+			for _, path := range tt.paths {
+				backend.sendEvent(t, path)
 			}
+			assert.Equal(t, int32(1), callCount.Load(),
+				"worker handoff must not queue another callback while one executes")
+
+			release()
+			overflow := receiveWatchBatch(t, calls)
+			assert.True(t, overflow.FullSync)
+			assert.Empty(t, overflow.Paths)
+			assert.Equal(t, int32(2), callCount.Load(),
+				"one overflow marker should replace all retained paths")
+		})
+	}
+}
+
+func TestWatcherCarriesRenameAndRootMetadata(t *testing.T) {
+	backend := newFakeWatchBackend()
+	calls := make(chan WatchBatch, 2)
+	w, err := newWatcherWithBackend(
+		0, 0,
+		func(_ context.Context, batch WatchBatch) error {
+			calls <- batch
+			return nil
 		},
-		batchDelay,
-		minInterval,
-		maxEntries,
-		1_000_000,
+		backend, 8, 1_000,
 	)
-	t.Cleanup(func() {
-		releaseFirst()
-		releaseFullSync()
-		w.Stop()
+	require.NoError(t, err)
+	w.SetRootAgents("/sessions", []string{"codex", "claude"})
+	w.Start()
+	t.Cleanup(w.Stop)
+
+	backend.sendBackendEvent(t, backendEvent{
+		Path:     "/sessions/renamed",
+		Root:     "/sessions",
+		Op:       backendOpRename,
+		ItemType: backendItemDirectory,
+	})
+	renameBatch := receiveWatchBatch(t, calls)
+	assert.Equal(t, []WatchRename{
+		{
+			Path:     "/sessions/renamed",
+			Root:     "/sessions",
+			Agent:    "claude",
+			ItemType: ItemIsDir,
+		},
+		{
+			Path:     "/sessions/renamed",
+			Root:     "/sessions",
+			Agent:    "codex",
+			ItemType: ItemIsDir,
+		},
+	}, renameBatch.Renames)
+	assert.Empty(t, renameBatch.Paths)
+
+	backend.sendBackendEvent(t, backendEvent{
+		Path: "/sessions", Root: "/sessions", Op: backendOpReconcileRootChange,
+	})
+	reconcileBatch := receiveWatchBatch(t, calls)
+	assert.Equal(t, []string{"/sessions"}, reconcileBatch.ReconcileRoots)
+	assert.Empty(t, reconcileBatch.Paths)
+}
+
+func TestWatcherDiscoversPrepopulatedCreatedDirectory(t *testing.T) {
+	backend := newFakeWatchBackend()
+	calls := make(chan WatchBatch, 1)
+	root := t.TempDir()
+	created := filepath.Join(root, "imported")
+	nested := filepath.Join(created, "nested")
+	restored := filepath.Join(nested, "session.jsonl")
+	require.NoError(t, os.MkdirAll(nested, 0o755))
+	require.NoError(t, os.WriteFile(restored, []byte("restored"), 0o600))
+	w, err := newWatcherWithBackend(
+		0, 0,
+		func(_ context.Context, batch WatchBatch) error {
+			calls <- batch
+			return nil
+		},
+		backend, 8, 1_000,
+	)
+	require.NoError(t, err)
+	w.Start()
+	t.Cleanup(w.Stop)
+
+	backend.sendBackendEvent(t, backendEvent{
+		Path:     created,
+		Root:     root,
+		Op:       backendOpCreate,
+		ItemType: backendItemDirectory,
 	})
 
-	firstPath := filepath.Join(dir, "first")
-	require.NoError(t, os.Mkdir(firstPath, 0o755))
-	firstBatch := receiveWatchBatch(t, calls)
-	assert.False(t, firstBatch.FullSync)
-	assert.Equal(t, []string{firstPath}, firstBatch.Paths)
+	batch := receiveWatchBatch(t, calls)
+	assert.Equal(t, []string{created, restored}, batch.Paths)
+	assert.Empty(t, batch.ReconcileRoots)
+}
 
-	var overflowPaths []string
-	for _, name := range []string{"overflow-a", "overflow-b", "overflow-c"} {
-		path := filepath.Join(dir, name)
-		overflowPaths = append(overflowPaths, path)
-		require.NoError(t, os.Mkdir(path, 0o755))
+func TestWatcherCreatedDirectoryDiscoveryHonorsBackendExclusions(t *testing.T) {
+	backend := newFakeWatchBackend()
+	backend.includeSubtree = func(root, path string) bool {
+		return !shouldExcludeForRoot([]string{"node_modules"}, path, root)
 	}
-	require.Eventually(t, func() bool {
-		return slices.Contains(w.watcher.WatchList(), overflowPaths[2])
-	}, time.Second, 10*time.Millisecond,
-		"watcher did not drain the overflowing event stream")
-	assert.Equal(t, int32(1), callCount.Load(),
-		"a callback started while the first callback was blocked")
+	calls := make(chan WatchBatch, 1)
+	root := t.TempDir()
+	created := filepath.Join(root, "imported")
+	included := filepath.Join(created, "session.jsonl")
+	excluded := filepath.Join(created, "node_modules", "cached.jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(excluded), 0o755))
+	require.NoError(t, os.WriteFile(included, []byte("included"), 0o600))
+	require.NoError(t, os.WriteFile(excluded, []byte("excluded"), 0o600))
+	w, err := newWatcherWithBackend(
+		0, 0,
+		func(_ context.Context, batch WatchBatch) error {
+			calls <- batch
+			return nil
+		},
+		backend, 8, 1_000,
+	)
+	require.NoError(t, err)
+	w.Start()
+	t.Cleanup(w.Stop)
 
-	releaseFirst()
-	overflowBatch := receiveWatchBatch(t, calls)
-	assert.True(t, overflowBatch.FullSync)
-	assert.Empty(t, overflowBatch.Paths)
+	backend.sendBackendEvent(t, backendEvent{
+		Path: created, Root: root,
+		Op:       backendOpCreate,
+		ItemType: backendItemDirectory,
+	})
 
-	laterPath := filepath.Join(dir, "after-overflow-dispatch")
-	require.NoError(t, os.Mkdir(laterPath, 0o755))
-	require.Eventually(t, func() bool {
-		return slices.Contains(w.watcher.WatchList(), laterPath)
-	}, time.Second, 10*time.Millisecond,
-		"watcher did not drain an event while full sync was blocked")
-	assert.Equal(t, int32(2), callCount.Load(),
-		"a callback started while full sync was blocked")
+	batch := receiveWatchBatch(t, calls)
+	assert.Equal(t, []string{created, included}, batch.Paths)
+	assert.NotContains(t, batch.Paths, excluded)
+}
 
-	releaseFullSync()
-	laterBatch := receiveWatchBatch(t, calls)
-	assert.False(t, laterBatch.FullSync)
-	assert.Equal(t, []string{laterPath}, laterBatch.Paths)
-	assert.Equal(t, int32(1), maxConcurrent.Load(),
-		"watcher callbacks must remain serialized")
+func TestWatcherCreatedDirectoryDiscoveryOverflowReconcilesOwningRoot(t *testing.T) {
+	backend := newFakeWatchBackend()
+	calls := make(chan WatchBatch, 1)
+	root := t.TempDir()
+	created := filepath.Join(root, "imported")
+	require.NoError(t, os.MkdirAll(created, 0o755))
+	for i := range 4 {
+		path := filepath.Join(created, fmt.Sprintf("session-%d.jsonl", i))
+		require.NoError(t, os.WriteFile(path, []byte("restored"), 0o600))
+	}
+	w, err := newWatcherWithBackend(
+		0, 0,
+		func(_ context.Context, batch WatchBatch) error {
+			calls <- batch
+			return nil
+		},
+		backend, 3, 10_000,
+	)
+	require.NoError(t, err)
+	w.Start()
+	t.Cleanup(w.Stop)
+
+	backend.sendBackendEvent(t, backendEvent{
+		Path: created, Root: root,
+		Op:       backendOpCreate,
+		ItemType: backendItemDirectory,
+	})
+
+	batch := receiveWatchBatch(t, calls)
+	assert.False(t, batch.FullSync)
+	assert.Equal(t, []string{root}, batch.ReconcileRoots)
+	assert.LessOrEqual(t, len(batch.Paths), 2)
+}
+
+func TestWatcherCreatedDirectoryVisitOverflowReconcilesOwningRoot(t *testing.T) {
+	backend := newFakeWatchBackend()
+	calls := make(chan WatchBatch, 1)
+	root := t.TempDir()
+	created := filepath.Join(root, "imported")
+	require.NoError(t, os.MkdirAll(created, 0o755))
+	for i := range 4 {
+		require.NoError(t, os.Mkdir(
+			filepath.Join(created, fmt.Sprintf("directory-%d", i)), 0o755,
+		))
+	}
+	w, err := newWatcherWithBackend(
+		0, 0,
+		func(_ context.Context, batch WatchBatch) error {
+			calls <- batch
+			return nil
+		},
+		backend, 3, 10_000,
+	)
+	require.NoError(t, err)
+	w.Start()
+	t.Cleanup(w.Stop)
+
+	backend.sendBackendEvent(t, backendEvent{
+		Path: created, Root: root,
+		Op:       backendOpCreate,
+		ItemType: backendItemDirectory,
+	})
+
+	batch := receiveWatchBatch(t, calls)
+	assert.False(t, batch.FullSync)
+	assert.Equal(t, []string{created}, batch.Paths)
+	assert.Equal(t, []string{root}, batch.ReconcileRoots)
+}
+
+func TestWatcherStopInterruptsCreatedDirectoryTraversal(t *testing.T) {
+	backend := newFakeWatchBackend()
+	root := t.TempDir()
+	created := filepath.Join(root, "imported")
+	require.NoError(t, os.MkdirAll(created, 0o755))
+	for i := range 200 {
+		require.NoError(t, os.Mkdir(
+			filepath.Join(created, fmt.Sprintf("directory-%03d", i)), 0o755,
+		))
+	}
+	firstVisit := make(chan struct{})
+	releaseFirstVisit := make(chan struct{})
+	secondVisit := make(chan struct{})
+	releaseSecondVisit := make(chan struct{})
+	var visits atomic.Int32
+	backend.includeSubtree = func(_, _ string) bool {
+		switch visits.Add(1) {
+		case 1:
+			close(firstVisit)
+			<-releaseFirstVisit
+		case 2:
+			close(secondVisit)
+			<-releaseSecondVisit
+		}
+		return true
+	}
+	w, err := newWatcherWithBackend(
+		0, 0, func(context.Context, WatchBatch) error { return nil },
+		backend, 512, 100_000,
+	)
+	require.NoError(t, err)
+	w.Start()
+
+	backend.sendBackendEvent(t, backendEvent{
+		Path: created, Root: root,
+		Op:       backendOpCreate,
+		ItemType: backendItemDirectory,
+	})
+	select {
+	case <-firstVisit:
+	case <-time.After(watcherTestTimeout):
+		require.FailNow(t, "created-directory traversal did not start")
+	}
+
+	stopped := make(chan struct{})
+	go func() {
+		w.Stop()
+		close(stopped)
+	}()
+	select {
+	case <-backend.stopped:
+	case <-time.After(watcherTestTimeout):
+		require.FailNow(t, "watcher backend did not receive Stop")
+	}
+	close(releaseFirstVisit)
+
+	traversalContinued := false
+	select {
+	case <-stopped:
+	case <-secondVisit:
+		traversalContinued = true
+		close(releaseSecondVisit)
+		<-stopped
+	case <-time.After(watcherTestTimeout):
+		close(releaseSecondVisit)
+		require.FailNow(t, "watcher Stop did not finish")
+	}
+	assert.False(t, traversalContinued,
+		"created subtree traversal visited another entry after Stop")
+}
+
+func TestWatcherRetriesFailedReconciliationMarker(t *testing.T) {
+	backend := newFakeWatchBackend()
+	calls := make(chan WatchBatch, 2)
+	var attempts atomic.Int32
+	w, err := newWatcherWithBackend(
+		0, 10*time.Millisecond,
+		func(_ context.Context, batch WatchBatch) error {
+			calls <- batch
+			if attempts.Add(1) == 1 {
+				return errors.New("discovery incomplete")
+			}
+			return nil
+		},
+		backend, 8, 1_000,
+	)
+	require.NoError(t, err)
+	w.Start()
+	t.Cleanup(w.Stop)
+
+	backend.sendBackendEvent(t, backendEvent{
+		Path: "/sessions", Root: "/sessions", Op: backendOpReconcileRootChange,
+	})
+	first := receiveWatchBatch(t, calls)
+	second := receiveWatchBatch(t, calls)
+	assert.Equal(t, []string{"/sessions"}, first.ReconcileRoots)
+	assert.Equal(t, first, second, "failed reconciliation must retain one retry marker")
+}
+
+func TestRetriedFullSyncPreservesChangesArrivingDuringCallback(t *testing.T) {
+	pending := newPendingWatchBatch(8, 1_000)
+	pending.Add("/sessions/new.jsonl")
+
+	retainWatchRetry(pending, WatchBatch{FullSync: true})
+	full, ok := pending.Take()
+	require.True(t, ok)
+	assert.Equal(t, WatchBatch{FullSync: true}, full)
+	changed, ok := pending.Take()
+	require.True(t, ok)
+	assert.Equal(t, []string{"/sessions/new.jsonl"}, changed.Paths)
+}
+
+func TestRetriedLostEventReconciliationPreservesRecoveryMode(t *testing.T) {
+	pending := newPendingWatchBatch(8, 1_000)
+
+	retainWatchRetry(pending, WatchBatch{
+		ReconcileRoots: []string{"/sessions"},
+		LostEvents:     true,
+	})
+	batch, ok := pending.Take()
+
+	require.True(t, ok)
+	assert.Equal(t, WatchBatch{
+		Paths:          []string{},
+		Renames:        []WatchRename{},
+		ReconcileRoots: []string{"/sessions"},
+		LostEvents:     true,
+	}, batch)
+}
+
+func TestWatcherRetryDelayUsesBoundedExponentialBackoff(t *testing.T) {
+	assert.Equal(t, 5*time.Second, watcherRetryDelay(5*time.Second, 1))
+	assert.Equal(t, 10*time.Second, watcherRetryDelay(5*time.Second, 2))
+	assert.Equal(t, watcherRetryMaxDelay, watcherRetryDelay(5*time.Second, 20))
+	assert.Equal(t, time.Millisecond, watcherRetryDelay(0, 1))
+	assert.Zero(t, watcherRetryDelay(time.Second, 0))
+}
+
+func TestWatcherRetryFloorStartsWhenFailedCallbackCompletes(t *testing.T) {
+	backend := newFakeWatchBackend()
+	const retryFloor = 40 * time.Millisecond
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	firstCompleted := make(chan time.Time, 1)
+	secondStarted := make(chan time.Time, 1)
+	var attempts atomic.Int32
+	w, err := newWatcherWithBackend(
+		0, retryFloor,
+		func(_ context.Context, _ WatchBatch) error {
+			if attempts.Add(1) == 1 {
+				close(firstStarted)
+				<-releaseFirst
+				firstCompleted <- time.Now()
+				return retryScopedWatchError{retry: WatchBatch{
+					ReconcileRoots: []string{"/sessions"},
+				}}
+			}
+			secondStarted <- time.Now()
+			return nil
+		},
+		backend, 8, 1_000,
+	)
+	require.NoError(t, err)
+	w.Start()
+	t.Cleanup(w.Stop)
+
+	backend.sendBackendEvent(t, backendEvent{
+		Path: "/sessions", Root: "/sessions", Op: backendOpReconcileRootChange,
+	})
+	requireReceiveWithin(t, firstStarted, time.Second)
+	time.Sleep(retryFloor + 10*time.Millisecond)
+	close(releaseFirst)
+	completedAt := requireReceiveWithin(t, firstCompleted, time.Second)
+	retriedAt := requireReceiveWithin(t, secondStarted, time.Second)
+
+	assert.GreaterOrEqual(t, retriedAt.Sub(completedAt), retryFloor,
+		"a slow failure must not make its retry immediately eligible")
+}
+
+func TestWatcherDoesNotReplayOrdinaryBatchOnCallbackError(t *testing.T) {
+	backend := newFakeWatchBackend()
+	var attempts atomic.Int32
+	w, err := newWatcherWithBackend(
+		0, 0,
+		func(_ context.Context, _ WatchBatch) error {
+			attempts.Add(1)
+			return errors.New("ordinary sync error")
+		},
+		backend, 8, 1_000,
+	)
+	require.NoError(t, err)
+	w.Start()
+	t.Cleanup(w.Stop)
+
+	backend.sendEvent(t, "/sessions/a.jsonl")
+	require.Eventually(t, func() bool { return attempts.Load() == 1 },
+		watcherTestTimeout, 5*time.Millisecond)
+	assert.Never(t, func() bool { return attempts.Load() > 1 },
+		50*time.Millisecond, 5*time.Millisecond)
+}
+
+func TestWatcherDoesNotReplayKnownFileRenameOnCallbackError(t *testing.T) {
+	backend := newFakeWatchBackend()
+	var attempts atomic.Int32
+	w, err := newWatcherWithBackend(
+		0, 0,
+		func(_ context.Context, _ WatchBatch) error {
+			attempts.Add(1)
+			return errors.New("changed-path sync error")
+		},
+		backend, 8, 1_000,
+	)
+	require.NoError(t, err)
+	w.SetRootAgents("/sessions", []string{"codex"})
+	w.Start()
+	t.Cleanup(w.Stop)
+
+	backend.sendBackendEvent(t, backendEvent{
+		Path: "/sessions/a.jsonl", Root: "/sessions",
+		Op: backendOpRename, ItemType: backendItemFile,
+	})
+	require.Eventually(t, func() bool { return attempts.Load() == 1 },
+		watcherTestTimeout, 5*time.Millisecond)
+	assert.Never(t, func() bool { return attempts.Load() > 1 },
+		50*time.Millisecond, 5*time.Millisecond)
+}
+
+func TestWatcherMixedFileRenameErrorRetriesOnlyRootMarker(t *testing.T) {
+	backend := newFakeWatchBackend()
+	calls := make(chan WatchBatch, 2)
+	var attempts atomic.Int32
+	w, err := newWatcherWithBackend(
+		0, 10*time.Millisecond,
+		func(_ context.Context, batch WatchBatch) error {
+			calls <- batch
+			if attempts.Add(1) == 1 {
+				return errors.New("root discovery incomplete")
+			}
+			return nil
+		},
+		backend, 8, 1_000,
+	)
+	require.NoError(t, err)
+	w.SetRootAgents("/sessions", []string{"codex"})
+	w.Start()
+	t.Cleanup(w.Stop)
+
+	backend.sendBackendEvent(t, backendEvent{
+		Path: "/sessions/a.jsonl", Root: "/sessions",
+		Op:       backendOpRename | backendOpReconcileRootChange,
+		ItemType: backendItemFile,
+	})
+	first := receiveWatchBatch(t, calls)
+	second := receiveWatchBatch(t, calls)
+	require.Len(t, first.Renames, 1)
+	assert.Equal(t, ItemIsFile, first.Renames[0].ItemType)
+	assert.Equal(t, []string{"/sessions"}, first.ReconcileRoots)
+	assert.False(t, second.FullSync)
+	assert.Empty(t, second.Paths)
+	assert.Empty(t, second.Renames)
+	assert.Equal(t, []string{"/sessions"}, second.ReconcileRoots)
+}
+
+func TestWatcherDirectoryRenameErrorRetriesFullSync(t *testing.T) {
+	backend := newFakeWatchBackend()
+	calls := make(chan WatchBatch, 2)
+	var attempts atomic.Int32
+	w, err := newWatcherWithBackend(
+		0, 10*time.Millisecond,
+		func(_ context.Context, batch WatchBatch) error {
+			calls <- batch
+			if attempts.Add(1) == 1 {
+				return errors.New("full discovery incomplete")
+			}
+			return nil
+		},
+		backend, 8, 1_000,
+	)
+	require.NoError(t, err)
+	w.SetRootAgents("/sessions", []string{"codex"})
+	w.Start()
+	t.Cleanup(w.Stop)
+
+	backend.sendBackendEvent(t, backendEvent{
+		Path: "/sessions/renamed", Root: "/sessions",
+		Op: backendOpRename, ItemType: backendItemDirectory,
+	})
+	first := receiveWatchBatch(t, calls)
+	second := receiveWatchBatch(t, calls)
+	require.Len(t, first.Renames, 1)
+	assert.Equal(t, ItemIsDir, first.Renames[0].ItemType)
+	assert.Equal(t, WatchBatch{FullSync: true}, second)
+}
+
+type retryScopedWatchError struct {
+	retry WatchBatch
+}
+
+func (e retryScopedWatchError) Error() string { return "authoritative reconciliation failed" }
+
+func (e retryScopedWatchError) WatchRetryBatch() WatchBatch { return e.retry }
+
+func TestWatcherPreservesLostEventsWhenFullRetryNarrowsToRoots(t *testing.T) {
+	backend := newFakeWatchBackend()
+	calls := make(chan WatchBatch, 2)
+	var attempts atomic.Int32
+	w, err := newWatcherWithBackend(
+		0, 10*time.Millisecond,
+		func(_ context.Context, batch WatchBatch) error {
+			calls <- batch
+			if attempts.Add(1) == 1 {
+				return retryScopedWatchError{retry: WatchBatch{
+					ReconcileRoots: []string{"/sessions"},
+					LostEvents:     true,
+				}}
+			}
+			return nil
+		},
+		backend, 8, 1_000,
+	)
+	require.NoError(t, err)
+	w.Start()
+	t.Cleanup(w.Stop)
+
+	backend.sendBackendEvent(t, backendEvent{Op: backendOpFullSync})
+	first := receiveWatchBatch(t, calls)
+	second := receiveWatchBatch(t, calls)
+
+	assert.Equal(t, WatchBatch{FullSync: true, LostEvents: true}, first)
+	assert.Empty(t, second.Paths)
+	assert.Empty(t, second.Renames)
+	assert.Equal(t, []string{"/sessions"}, second.ReconcileRoots)
+	assert.True(t, second.LostEvents)
+}
+
+func TestWatcherPreservesLostEventsWhenAmbiguousRenameRetryPromotesToFullSync(t *testing.T) {
+	backend := newFakeWatchBackend()
+	calls := make(chan WatchBatch, 3)
+	releaseFirst := make(chan struct{})
+	var attempts atomic.Int32
+	w, err := newWatcherWithBackend(
+		0, 100*time.Millisecond,
+		func(_ context.Context, batch WatchBatch) error {
+			calls <- batch
+			switch attempts.Add(1) {
+			case 1:
+				<-releaseFirst
+				return retryScopedWatchError{retry: WatchBatch{
+					ReconcileRoots: []string{"/sessions"},
+					LostEvents:     true,
+				}}
+			case 2:
+				return errors.New("rename classification failed")
+			default:
+				return nil
+			}
+		},
+		backend, 8, 1_000,
+	)
+	require.NoError(t, err)
+	w.SetRootAgents("/sessions", []string{"codex"})
+	w.Start()
+	t.Cleanup(w.Stop)
+
+	backend.sendBackendEvent(t, backendEvent{Op: backendOpFullSync})
+	first := receiveWatchBatch(t, calls)
+	backend.sendBackendEvent(t, backendEvent{
+		Path: "/sessions/renamed", Root: "/sessions",
+		Op: backendOpRename, ItemType: backendItemUnknown,
+	})
+	close(releaseFirst)
+	second := receiveWatchBatch(t, calls)
+	third := receiveWatchBatch(t, calls)
+
+	assert.Equal(t, WatchBatch{FullSync: true, LostEvents: true}, first)
+	require.Len(t, second.Renames, 1)
+	assert.Equal(t, ItemIsUnknown, second.Renames[0].ItemType)
+	assert.Equal(t, []string{"/sessions"}, second.ReconcileRoots)
+	assert.True(t, second.LostEvents)
+	assert.Equal(t, WatchBatch{FullSync: true, LostEvents: true}, third)
+}
+
+func TestWatcherUsesCallbackReconciliationScopeForRetry(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		retry WatchBatch
+	}{
+		{
+			name:  "classified ordinary rename retries roots",
+			retry: WatchBatch{ReconcileRoots: []string{"/sessions", "/sessions"}},
+		},
+		{
+			name:  "classified authoritative rename retries full sync",
+			retry: WatchBatch{FullSync: true},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			backend := newFakeWatchBackend()
+			calls := make(chan WatchBatch, 2)
+			var attempts atomic.Int32
+			w, err := newWatcherWithBackend(
+				0, 10*time.Millisecond,
+				func(_ context.Context, batch WatchBatch) error {
+					calls <- batch
+					if attempts.Add(1) == 1 {
+						return retryScopedWatchError{retry: tc.retry}
+					}
+					return nil
+				},
+				backend, 8, 1_000,
+			)
+			require.NoError(t, err)
+			w.SetRootAgents("/sessions", []string{"codex"})
+			w.Start()
+			t.Cleanup(w.Stop)
+
+			backend.sendBackendEvent(t, backendEvent{
+				Path: "/sessions/renamed", Root: "/sessions",
+				Op:       backendOpRename | backendOpReconcileRootChange,
+				ItemType: backendItemUnknown,
+			})
+			first := receiveWatchBatch(t, calls)
+			second := receiveWatchBatch(t, calls)
+			require.Len(t, first.Renames, 1)
+			assert.Equal(t, ItemIsUnknown, first.Renames[0].ItemType)
+			if tc.retry.FullSync {
+				assert.Equal(t, WatchBatch{FullSync: true}, second)
+			} else {
+				assert.False(t, second.FullSync)
+				assert.Empty(t, second.Paths)
+				assert.Empty(t, second.Renames)
+				assert.Equal(t, []string{"/sessions"}, second.ReconcileRoots)
+			}
+		})
+	}
+}
+
+func TestWatcherUsesCallbackChangedPathsForRetry(t *testing.T) {
+	backend := newFakeWatchBackend()
+	calls := make(chan WatchBatch, 2)
+	var attempts atomic.Int32
+	w, err := newWatcherWithBackend(
+		0, 10*time.Millisecond,
+		func(_ context.Context, batch WatchBatch) error {
+			calls <- batch
+			if attempts.Add(1) == 1 {
+				return retryScopedWatchError{retry: WatchBatch{Paths: []string{
+					"/sessions/changed.jsonl",
+					"/sessions/changed.jsonl",
+				}}}
+			}
+			return nil
+		},
+		backend, 8, 1_000,
+	)
+	require.NoError(t, err)
+	w.Start()
+	t.Cleanup(w.Stop)
+
+	backend.sendEvent(t, "/sessions/changed.jsonl")
+	first := receiveWatchBatch(t, calls)
+	second := receiveWatchBatch(t, calls)
+
+	assert.Equal(t, []string{"/sessions/changed.jsonl"}, first.Paths)
+	assert.Equal(t, []string{"/sessions/changed.jsonl"}, second.Paths,
+		"a failed changed-path sync must retry the exact bounded path")
+	assert.False(t, second.FullSync)
+}
+
+func TestRetainWatchRetryPathOverflowPromotesFullSync(t *testing.T) {
+	pending := newPendingWatchBatch(1, 1_000)
+
+	retainWatchRetry(pending, WatchBatch{Paths: []string{
+		"/sessions/one.jsonl",
+		"/sessions/two.jsonl",
+	}})
+	batch, ok := pending.Take()
+
+	require.True(t, ok)
+	assert.Equal(t, WatchBatch{FullSync: true, LostEvents: true}, batch,
+		"retry paths use the normal bounded accumulator")
 }
 
 func TestWatcherStopCancelsPendingCallback(t *testing.T) {
-	const batchDelay = 300 * time.Millisecond
-	calls := make(chan []string, 1)
-	w, dir := startTestWatcherWithIntervalsNoCleanup(
-		t, func(paths []string) { calls <- paths }, batchDelay, time.Second,
+	backend := newFakeWatchBackend()
+	calls := make(chan WatchBatch, 1)
+	w, err := newWatcherWithBackend(
+		300*time.Millisecond, time.Second, func(_ context.Context, batch WatchBatch) error {
+			calls <- batch
+			return nil
+		},
+		backend, 8, 1_000,
 	)
-	t.Cleanup(w.Stop)
-
-	pendingPath := filepath.Join(dir, "pending")
-	require.NoError(t, os.Mkdir(pendingPath, 0o755))
-	require.Eventually(t, func() bool {
-		return slices.Contains(w.watcher.WatchList(), pendingPath)
-	}, time.Second, 10*time.Millisecond,
-		"watcher did not process the pending directory event")
-	pendingNestedPath := filepath.Join(pendingPath, "nested")
-	require.NoError(t, os.Mkdir(pendingNestedPath, 0o755))
-	require.Eventually(t, func() bool {
-		return slices.Contains(w.watcher.WatchList(), pendingNestedPath)
-	}, time.Second, 10*time.Millisecond,
-		"watcher did not finish processing the pending directory event")
+	require.NoError(t, err)
+	w.Start()
+	backend.sendEvent(t, "/sessions/pending.jsonl")
 
 	w.Stop()
 	select {
-	case paths := <-calls:
-		t.Fatalf("callback ran after Stop with paths %v", paths)
-	case <-time.After(batchDelay + 50*time.Millisecond):
+	case <-backend.stopped:
+	case <-time.After(watcherTestTimeout):
+		t.Fatal("watch backend was not stopped")
+	}
+	select {
+	case batch := <-calls:
+		t.Fatalf("callback ran after Stop with batch %+v", batch)
+	case <-time.After(350 * time.Millisecond):
 	}
 }
 
@@ -494,37 +1598,26 @@ func TestWatcherStopWaitsForRunningCallbackAndDiscardsPending(t *testing.T) {
 	releaseCallback := func() { releaseOnce.Do(func() { close(release) }) }
 	var calls atomic.Int32
 
-	w, dir := startTestWatcherWithIntervalsNoCleanup(t, func([]string) {
+	backend := newFakeWatchBackend()
+	w := startFakeWatcherWithLimits(t, backend, func(WatchBatch) {
 		if calls.Add(1) == 1 {
 			close(started)
 			<-release
 		}
-	}, 30*time.Millisecond, 100*time.Millisecond)
+	}, 8, 1_000)
 	t.Cleanup(func() {
 		releaseCallback()
 		w.Stop()
 	})
 
-	require.NoError(t,
-		os.WriteFile(filepath.Join(dir, "running.jsonl"), []byte("running"), 0o644))
+	backend.sendEvent(t, "/sessions/running.jsonl")
 	select {
 	case <-started:
 	case <-time.After(watcherTestTimeout):
 		t.Fatal("timed out waiting for the first callback to start")
 	}
 
-	queuedPath := filepath.Join(dir, "queued")
-	require.NoError(t, os.Mkdir(queuedPath, 0o755))
-	require.Eventually(t, func() bool {
-		return slices.Contains(w.watcher.WatchList(), queuedPath)
-	}, time.Second, 10*time.Millisecond,
-		"watcher did not retain the second event while callback was blocked")
-	queuedNestedPath := filepath.Join(queuedPath, "nested")
-	require.NoError(t, os.Mkdir(queuedNestedPath, 0o755))
-	require.Eventually(t, func() bool {
-		return slices.Contains(w.watcher.WatchList(), queuedNestedPath)
-	}, time.Second, 10*time.Millisecond,
-		"watcher did not finish retaining the second event")
+	backend.sendEvent(t, "/sessions/queued.jsonl")
 
 	stopStarted := make(chan struct{})
 	stopped := make(chan struct{})
@@ -548,6 +1641,25 @@ func TestWatcherStopWaitsForRunningCallbackAndDiscardsPending(t *testing.T) {
 	}
 	assert.Equal(t, int32(1), calls.Load(),
 		"Stop must discard the queued second callback")
+}
+
+func TestWatcherSchedulerBackendErrorsRemainDrainable(t *testing.T) {
+	previousLogOutput := log.Writer()
+	log.SetOutput(io.Discard)
+	t.Cleanup(func() { log.SetOutput(previousLogOutput) })
+
+	backend := newFakeWatchBackend()
+	var calls atomic.Int32
+	w := startFakeWatcherWithLimits(t, backend, func(WatchBatch) {
+		calls.Add(1)
+	}, 8, 1_000)
+	t.Cleanup(w.Stop)
+
+	for i := range 1_000 {
+		backend.sendError(t, fmt.Errorf("backend error %d", i))
+	}
+
+	assert.Zero(t, calls.Load(), "backend errors must not schedule callbacks")
 }
 
 func TestWatcherCallsOnChange(t *testing.T) {
@@ -576,17 +1688,16 @@ func TestWatcherCallsOnChange(t *testing.T) {
 func TestWatcherAutoWatchesNewDirs(t *testing.T) {
 	pathsCh := make(chan []string, 10)
 
-	w, dir := startTestWatcher(t, func(paths []string) {
+	_, dir := startTestWatcher(t, func(paths []string) {
 		pathsCh <- paths
 	})
 
 	subdir := filepath.Join(dir, "newdir")
 	require.NoError(t, os.Mkdir(subdir, 0o755))
 
-	// Wait for fsnotify to process the mkdir and add the watch
-	pollUntil(t, func() bool {
-		return slices.Contains(w.watcher.WatchList(), subdir)
-	})
+	// Delivery of the directory create means the backend has completed its
+	// auto-watch decision before handing the event to the scheduler.
+	waitForPath(t, pathsCh, subdir)
 
 	nestedPath := filepath.Join(subdir, "nested.jsonl")
 	require.NoError(t, os.WriteFile(nestedPath, []byte("nested"), 0o644))
@@ -619,6 +1730,119 @@ func TestWatcherStopIsClean(t *testing.T) {
 	case <-stopped:
 	case <-time.After(5 * time.Second):
 		t.Fatal("Stop() did not return in time")
+	}
+}
+
+func TestWatcherLifecycleStopBeforeStartReturns(t *testing.T) {
+	backend := newFakeWatchBackend()
+	w, err := newWatcherWithBackend(
+		0, 0, func(context.Context, WatchBatch) error { return nil }, backend, 8, 1_000,
+	)
+	require.NoError(t, err)
+
+	stopped := make(chan struct{})
+	go func() {
+		w.Stop()
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Stop blocked before Start")
+	}
+	w.Start()
+	w.Stop()
+	assert.Zero(t, backend.startCalls.Load(), "Start after Stop must be a no-op")
+	assert.Equal(t, int32(1), backend.stopCalls.Load())
+}
+
+func TestWatcherLifecycleStartFailureReturnsErrorAndDegradesRegisteredScopes(t *testing.T) {
+	backend := newFakeWatchBackend()
+	startErr := errors.New("start failed")
+	backend.startErr = startErr
+	degraded := make(chan []string, 1)
+	w, err := newWatcherWithBackendOptions(
+		0, 0, func(context.Context, WatchBatch) error { return nil }, backend, 8, 1_000,
+		WatcherOptions{OnCoverageDegraded: func(roots []string) error {
+			degraded <- append([]string(nil), roots...)
+			return nil
+		}},
+	)
+	require.NoError(t, err)
+	w.RegisterRoots([]WatchRoot{
+		{Path: "/watch-b", Scopes: []WatchScope{{SyncDir: "/scope-b"}}},
+		{Path: "/watch-a", Scopes: []WatchScope{
+			{SyncDir: "/scope-b"}, {SyncDir: "/scope-a"},
+		}},
+	}, 8)
+
+	err = w.Start()
+	assert.ErrorIs(t, err, startErr)
+	assert.Equal(t, []string{"/scope-a", "/scope-b"},
+		requireReceiveWithin(t, degraded, time.Second))
+	select {
+	case <-backend.stopped:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("failed Start did not stop its backend")
+	}
+	w.Stop()
+	assert.Error(t, w.Start(), "a stopped watcher must keep surfacing startup failure")
+	assert.Equal(t, int32(1), backend.startCalls.Load())
+	assert.Equal(t, int32(1), backend.stopCalls.Load())
+}
+
+func TestWatcherLifecycleRepeatedStartStartsOnce(t *testing.T) {
+	backend := newFakeWatchBackend()
+	w, err := newWatcherWithBackend(
+		0, 0, func(context.Context, WatchBatch) error { return nil }, backend, 8, 1_000,
+	)
+	require.NoError(t, err)
+
+	w.Start()
+	w.Start()
+	require.Equal(t, int32(1), backend.startCalls.Load())
+	w.Stop()
+	assert.Equal(t, int32(1), backend.stopCalls.Load())
+}
+
+func TestWatcherLifecycleStartStopRace(t *testing.T) {
+	for range 100 {
+		backend := newFakeWatchBackend()
+		w, err := newWatcherWithBackend(
+			0, 0, func(context.Context, WatchBatch) error { return nil }, backend, 8, 1_000,
+		)
+		require.NoError(t, err)
+
+		start := make(chan struct{})
+		var calls sync.WaitGroup
+		calls.Add(2)
+		go func() {
+			defer calls.Done()
+			<-start
+			w.Start()
+		}()
+		go func() {
+			defer calls.Done()
+			<-start
+			w.Stop()
+		}()
+		close(start)
+
+		done := make(chan struct{})
+		go func() {
+			calls.Wait()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("concurrent Start and Stop deadlocked")
+		}
+		w.Start()
+		w.Stop()
+		assert.LessOrEqual(t, backend.startCalls.Load(), int32(1))
+		assert.Equal(t, int32(1), backend.stopCalls.Load())
 	}
 }
 
@@ -737,10 +1961,7 @@ func TestWatcherHandlesRemoveAndRename(t *testing.T) {
 }
 
 func TestWatchRecursive_ExcludesDirectoryNames(t *testing.T) {
-	w, err := NewWatcher(time.Second, func(WatchBatch) {}, []string{".git", "node_modules"})
-	require.NoError(t, err, "NewWatcher")
-	w.Start()
-	t.Cleanup(func() { w.Stop() })
+	w := newFSNotifyTestWatcher(t, []string{".git", "node_modules"})
 
 	root := t.TempDir()
 	included := filepath.Join(root, "project", "src")
@@ -750,15 +1971,10 @@ func TestWatchRecursive_ExcludesDirectoryNames(t *testing.T) {
 		require.NoError(t, os.MkdirAll(p, 0o755), "MkdirAll(%s)", p)
 	}
 
-	_, _, err = w.WatchRecursive(root)
+	watched, unwatched, err := w.WatchRecursive(root)
 	require.NoError(t, err, "WatchRecursive")
-
-	got := w.watcher.WatchList()
-	assert.NotContains(t, got, filepath.Join(root, "project", ".git"),
-		".git should be excluded from watch list")
-	assert.NotContains(t, got, filepath.Join(root, "project", "node_modules"),
-		"node_modules should be excluded from watch list")
-	assert.Contains(t, got, included, "expected included dir in watch list")
+	assert.Equal(t, 3, watched, "only root, project, and src should be watched")
+	assert.Zero(t, unwatched)
 }
 
 func TestWatchRecursiveBudget_DegradesWhenBudgetExhausted(t *testing.T) {
@@ -767,10 +1983,7 @@ func TestWatchRecursiveBudget_DegradesWhenBudgetExhausted(t *testing.T) {
 		require.NoError(t, os.MkdirAll(filepath.Join(root, fmt.Sprintf("dir-%d", i)), 0o755))
 	}
 
-	w, err := NewWatcher(time.Second, func(WatchBatch) {}, nil)
-	require.NoError(t, err, "NewWatcher")
-	w.Start()
-	t.Cleanup(func() { w.Stop() })
+	w := newFSNotifyTestWatcher(t, nil)
 
 	result := w.WatchRecursiveBudgeted(root, 3)
 	assert.Equal(t, 3, result.Watched)
@@ -798,21 +2011,14 @@ func TestWatcherAutoWatchesNewDirs_RespectsExcludes(t *testing.T) {
 
 	gitDir := filepath.Join(root, ".git")
 	require.NoError(t, os.Mkdir(gitDir, 0o755), "Mkdir(.git)")
-
-	time.Sleep(100 * time.Millisecond)
-	assert.NotContains(t, w.watcher.WatchList(), gitDir,
-		"newly created excluded dir should not be watched")
+	barrier := filepath.Join(root, "included-barrier")
+	require.NoError(t, os.Mkdir(barrier, 0o755), "Mkdir(barrier)")
+	waitForPath(t, pathsCh, barrier)
 
 	fileInGit := filepath.Join(gitDir, "config")
 	require.NoError(t, os.WriteFile(fileInGit, []byte("x"), 0o644))
 
-	select {
-	case paths := <-pathsCh:
-		assert.NotContains(t, paths, fileInGit,
-			"changes inside excluded dir should not trigger onChange")
-	case <-time.After(200 * time.Millisecond):
-		// no events from excluded dir; expected
-	}
+	assertPathNotEmitted(t, pathsCh, fileInGit, 200*time.Millisecond)
 }
 
 func TestWatcherShallowRootDoesNotAutoWatchNewDirs(t *testing.T) {
@@ -837,8 +2043,10 @@ func TestWatcherShallowRootDoesNotAutoWatchNewDirs(t *testing.T) {
 	case <-time.After(250 * time.Millisecond):
 		t.Fatal("timed out waiting for shallow root create event")
 	}
-	assert.NotContains(t, w.watcher.WatchList(), localDir,
-		"shallow root descendant should not be auto-watched")
+
+	nested := filepath.Join(localDir, "nested.jsonl")
+	require.NoError(t, os.WriteFile(nested, []byte("x"), 0o644))
+	assertPathNotEmitted(t, pathsCh, nested, 100*time.Millisecond)
 }
 
 // A shallow parent root (e.g. Codex's .codex) must not shadow a recursive
@@ -871,9 +2079,7 @@ func TestWatcherShallowParentDoesNotShadowRecursiveChild(t *testing.T) {
 	// even though it also sits inside the shallow parent root.
 	dateDir := filepath.Join(child, "2026-06-16")
 	require.NoError(t, os.Mkdir(dateDir, 0o755), "Mkdir(dateDir)")
-	pollUntil(t, func() bool {
-		return slices.Contains(w.watcher.WatchList(), dateDir)
-	})
+	waitForPath(t, pathsCh, dateDir)
 
 	sessionFile := filepath.Join(dateDir, "rollout.jsonl")
 	require.NoError(t, os.WriteFile(sessionFile, []byte("x"), 0o644))
@@ -891,34 +2097,24 @@ func TestWatcherShallowParentDoesNotShadowRecursiveChild(t *testing.T) {
 	}
 	require.True(t, found,
 		"file in a new date dir under the recursive child must trigger onChange")
-	assert.NotContains(t, w.watcher.WatchList(), logDir,
-		"sibling dir under the shallow parent must not be auto-watched")
 }
 
 func TestWatchRecursive_RootUnderExcludedAncestorStillWatchesDescendants(t *testing.T) {
-	w, err := NewWatcher(time.Second, func(WatchBatch) {}, []string{"venv"})
-	require.NoError(t, err, "NewWatcher")
-	w.Start()
-	t.Cleanup(func() { w.Stop() })
+	w := newFSNotifyTestWatcher(t, []string{"venv"})
 
 	base := t.TempDir()
 	root := filepath.Join(base, "venv", "project")
 	included := filepath.Join(root, "src")
 	require.NoError(t, os.MkdirAll(included, 0o755), "MkdirAll(%s)", included)
 
-	_, _, err = w.WatchRecursive(root)
+	watched, unwatched, err := w.WatchRecursive(root)
 	require.NoError(t, err, "WatchRecursive")
-
-	got := w.watcher.WatchList()
-	assert.Contains(t, got, root, "expected root in watch list")
-	assert.Contains(t, got, included, "expected included dir in watch list")
+	assert.Equal(t, 2, watched, "root and descendant should both be watched")
+	assert.Zero(t, unwatched)
 }
 
 func TestWatchRecursive_ExcludesSlashPatternRelativeToRoot(t *testing.T) {
-	w, err := NewWatcher(time.Second, func(WatchBatch) {}, []string{"foo/bar"})
-	require.NoError(t, err, "NewWatcher")
-	w.Start()
-	t.Cleanup(func() { w.Stop() })
+	w := newFSNotifyTestWatcher(t, []string{"foo/bar"})
 
 	root := t.TempDir()
 	excluded := filepath.Join(root, "foo", "bar")
@@ -927,19 +2123,14 @@ func TestWatchRecursive_ExcludesSlashPatternRelativeToRoot(t *testing.T) {
 		require.NoError(t, os.MkdirAll(p, 0o755), "MkdirAll(%s)", p)
 	}
 
-	_, _, err = w.WatchRecursive(root)
+	watched, unwatched, err := w.WatchRecursive(root)
 	require.NoError(t, err, "WatchRecursive")
-
-	got := w.watcher.WatchList()
-	assert.NotContains(t, got, excluded, "expected %s to be excluded", excluded)
-	assert.Contains(t, got, includedSibling, "expected %s to be included", includedSibling)
+	assert.Equal(t, 3, watched, "root, foo, and foo/baz should be watched")
+	assert.Zero(t, unwatched)
 }
 
 func TestWatchRecursive_OverlappingRoots_UsesMostSpecificRoot(t *testing.T) {
-	w, err := NewWatcher(time.Second, func(WatchBatch) {}, []string{"venv"})
-	require.NoError(t, err, "NewWatcher")
-	w.Start()
-	t.Cleanup(func() { w.Stop() })
+	w := newFSNotifyTestWatcher(t, []string{"venv"})
 
 	base := t.TempDir()
 	parentRoot := filepath.Join(base, "workspace")
@@ -949,14 +2140,17 @@ func TestWatchRecursive_OverlappingRoots_UsesMostSpecificRoot(t *testing.T) {
 		require.NoError(t, os.MkdirAll(p, 0o755), "MkdirAll(%s)", p)
 	}
 
-	_, _, err = w.WatchRecursive(parentRoot)
+	parentWatched, parentUnwatched, err := w.WatchRecursive(parentRoot)
 	require.NoError(t, err, "WatchRecursive(parent)")
-	_, _, err = w.WatchRecursive(nestedRoot)
-	require.NoError(t, err, "WatchRecursive(nested)")
+	assert.Equal(t, 1, parentWatched,
+		"the excluded venv subtree should be skipped from the parent root")
+	assert.Zero(t, parentUnwatched)
 
-	got := w.watcher.WatchList()
-	assert.Contains(t, got, nestedRoot, "expected nested root in watch list")
-	assert.Contains(t, got, included, "expected included dir in watch list")
+	nestedWatched, nestedUnwatched, err := w.WatchRecursive(nestedRoot)
+	require.NoError(t, err, "WatchRecursive(nested)")
+	assert.Equal(t, 2, nestedWatched,
+		"the nested root and descendant should use the nested exclusion scope")
+	assert.Zero(t, nestedUnwatched)
 }
 
 func TestWatcherExcludedCreateDir_DoesNotTriggerOnChange(t *testing.T) {
@@ -991,4 +2185,22 @@ func TestNewWatcher_NilOnChange(t *testing.T) {
 
 	expectedMsg := "onChange callback is nil"
 	assert.Equal(t, expectedMsg+": "+os.ErrInvalid.Error(), err.Error())
+}
+
+func newFSNotifyTestWatcher(t *testing.T, excludes []string) *Watcher {
+	t.Helper()
+	backend, err := newFSNotifyBackend(excludes)
+	require.NoError(t, err)
+	w, err := newWatcherWithBackend(
+		time.Second,
+		time.Second,
+		func(context.Context, WatchBatch) error { return nil },
+		backend,
+		defaultWatchBatchMaxEntries,
+		defaultWatchBatchMaxPathBytes,
+	)
+	require.NoError(t, err)
+	w.Start()
+	t.Cleanup(w.Stop)
+	return w
 }

--- a/internal/sync/windsurf_integration_test.go
+++ b/internal/sync/windsurf_integration_test.go
@@ -3,8 +3,13 @@ package sync
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,6 +19,285 @@ import (
 	"go.kenn.io/agentsview/internal/dbtest"
 	"go.kenn.io/agentsview/internal/parser"
 )
+
+func TestReconcileWatchRootsWindsurf300MembersUsesOneExactBoundedScan(t *testing.T) {
+	const members = 300
+	root := filepath.Join(t.TempDir(), "Windsurf", "User")
+	workspaceDir := filepath.Join(root, "workspaceStorage", "workspace-hash")
+	require.NoError(t, os.MkdirAll(workspaceDir, 0o755))
+	manifest, err := json.Marshal(map[string]string{
+		"folder": "file:///work/demo", "padding": strings.Repeat("m", 1<<20),
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(workspaceDir, "workspace.json"), manifest, 0o600,
+	))
+	dbPath := filepath.Join(workspaceDir, "state.vscdb")
+	type bubble struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	type tab struct {
+		ID      string   `json:"tabId"`
+		Bubbles []bubble `json:"bubbles"`
+	}
+	payload := struct {
+		Tabs []tab `json:"tabs"`
+	}{Tabs: make([]tab, members)}
+	for i := range members {
+		payload.Tabs[i] = tab{
+			ID: fmt.Sprintf("session-%03d", i),
+			Bubbles: []bubble{
+				{Type: "user", Text: strings.Repeat("question ", 2048)},
+				{Type: "assistant", Text: "bounded answer"},
+			},
+		}
+	}
+	encoded, err := json.Marshal(payload)
+	require.NoError(t, err)
+	writeSyncWindsurfStateDB(t, dbPath, string(encoded))
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentWindsurf: {root}},
+		Machine:   "local",
+	})
+	engine.workerCountOverride = 2
+	t.Cleanup(engine.Close)
+
+	overlapTarget := min(4, engine.workerCount())
+	require.Equal(t, 2, overlapTarget)
+	probe := newRetainedOverlapProbe(parser.AgentWindsurf, overlapTarget)
+	ctx := parser.WithReconciliationRetainedMemberObserver(t.Context(), probe.observe)
+	done := make(chan error, 1)
+	go func() {
+		done <- engine.ReconcileWatchRoots(ctx, []string{root}, false)
+	}()
+	probe.waitAndRelease(t)
+	require.NoError(t, <-done)
+
+	result := engine.LastReconciliationResult()
+	assert.True(t, result.Complete)
+	assert.Equal(t, 1, result.Metrics.SharedContainerScans,
+		"exact rehydration must not rescan the container per member")
+	assert.Equal(t, reconciliationPageSize, result.Metrics.MaxSpoolPageRows)
+	assert.Positive(t, result.Metrics.MaxProviderRetainedBytes)
+	assert.GreaterOrEqual(t, probe.maxActive.Load(), int32(overlapTarget))
+	assert.GreaterOrEqual(t, result.Metrics.MaxProviderRetainedBytes, probe.maxBytes.Load(),
+		"aggregate metric must include every concurrently retained worker member")
+	assert.GreaterOrEqual(t, result.Metrics.MaxProviderRetainedBytes, int64(len(manifest)),
+		"workspace manifest must be charged for its discovery lifetime")
+	assert.Less(t, result.Metrics.MaxProviderRetainedBytes, int64(len(encoded))/2,
+		"concurrent provider retention must stay bounded by members, not the container")
+	stored, getErr := database.GetSession(t.Context(), "windsurf:session-299")
+	require.NoError(t, getErr)
+	require.NotNil(t, stored)
+}
+
+func TestReconcileWatchRootsWindsurfTombstonesDeletedVirtualMember(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "Windsurf", "User")
+	workspaceDir := filepath.Join(root, "workspaceStorage", "workspace-hash")
+	require.NoError(t, os.MkdirAll(workspaceDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(workspaceDir, "workspace.json"),
+		[]byte(`{"folder":"file:///work/demo"}`), 0o600,
+	))
+	dbPath := filepath.Join(workspaceDir, "state.vscdb")
+	writeSyncWindsurfStateDB(t, dbPath, windsurfTabsPayload(t,
+		"surviving-member", "deleted-member",
+	))
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentWindsurf: {root}},
+		Machine:   "local",
+	})
+	t.Cleanup(engine.Close)
+	require.Equal(t, 2, engine.SyncAll(t.Context(), nil).Synced)
+	updateSyncWindsurfStateDB(t, dbPath, windsurfTabsPayload(t, "surviving-member"))
+
+	require.NoError(t, engine.ReconcileWatchRoots(t.Context(), []string{root}, false))
+
+	active, err := database.GetSession(t.Context(), "windsurf:deleted-member")
+	require.NoError(t, err)
+	assert.Nil(t, active)
+	archived, err := database.GetSessionFull(t.Context(), "windsurf:deleted-member")
+	require.NoError(t, err)
+	require.NotNil(t, archived)
+	require.NotNil(t, archived.DeletionCause)
+	assert.Equal(t, "source_missing", *archived.DeletionCause)
+	surviving, err := database.GetSession(t.Context(), "windsurf:surviving-member")
+	require.NoError(t, err)
+	assert.NotNil(t, surviving)
+}
+
+func TestSyncPathsWindsurfTombstonesRemovedVirtualMember(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "Windsurf", "User")
+	workspaceDir := filepath.Join(root, "workspaceStorage", "workspace-hash")
+	require.NoError(t, os.MkdirAll(workspaceDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(workspaceDir, "workspace.json"),
+		[]byte(`{"folder":"file:///work/demo"}`), 0o600,
+	))
+	dbPath := filepath.Join(workspaceDir, "state.vscdb")
+	writeSyncWindsurfStateDB(t, dbPath, windsurfTabsPayload(t,
+		"surviving-member", "removed-member",
+	))
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentWindsurf: {root}},
+		Machine:   "local",
+	})
+	t.Cleanup(engine.Close)
+	require.Equal(t, 2, engine.SyncAll(t.Context(), nil).Synced)
+
+	// The container file still exists; only one member row is removed,
+	// exactly what the watcher sees after Windsurf deletes a conversation.
+	updateSyncWindsurfStateDB(t, dbPath, windsurfTabsPayload(t, "surviving-member"))
+
+	require.NoError(t, engine.SyncPathsContext(t.Context(), []string{dbPath}))
+
+	active, err := database.GetSession(t.Context(), "windsurf:removed-member")
+	require.NoError(t, err)
+	assert.Nil(t, active, "removed member must not stay active")
+	archived, err := database.GetSessionFull(t.Context(), "windsurf:removed-member")
+	require.NoError(t, err)
+	require.NotNil(t, archived,
+		"removed member must be preserved in the archive, not hard-deleted")
+	require.NotNil(t, archived.DeletionCause)
+	assert.Equal(t, "source_missing", *archived.DeletionCause)
+	surviving, err := database.GetSession(t.Context(), "windsurf:surviving-member")
+	require.NoError(t, err)
+	assert.NotNil(t, surviving)
+}
+
+func windsurfTabsPayload(t *testing.T, sessionIDs ...string) string {
+	t.Helper()
+	type bubble struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	type tab struct {
+		ID      string   `json:"tabId"`
+		Bubbles []bubble `json:"bubbles"`
+	}
+	payload := struct {
+		Tabs []tab `json:"tabs"`
+	}{Tabs: make([]tab, len(sessionIDs))}
+	for i, sessionID := range sessionIDs {
+		payload.Tabs[i] = tab{
+			ID: sessionID,
+			Bubbles: []bubble{
+				{Type: "user", Text: "question for " + sessionID},
+				{Type: "assistant", Text: "answer for " + sessionID},
+			},
+		}
+	}
+	encoded, err := json.Marshal(payload)
+	require.NoError(t, err)
+	return string(encoded)
+}
+
+type retainedOverlapProbe struct {
+	provider  parser.AgentType
+	target    int
+	arrived   chan struct{}
+	release   chan struct{}
+	active    atomic.Int32
+	liveBytes atomic.Int64
+	maxActive atomic.Int32
+	maxBytes  atomic.Int64
+}
+
+func newRetainedOverlapProbe(provider parser.AgentType, target int) *retainedOverlapProbe {
+	return &retainedOverlapProbe{
+		provider: provider, target: target,
+		arrived: make(chan struct{}, target), release: make(chan struct{}),
+	}
+}
+
+func (probe *retainedOverlapProbe) observe(provider parser.AgentType, retained int64) {
+	if provider != probe.provider || retained <= 0 {
+		return
+	}
+	active := probe.active.Add(1)
+	liveBytes := probe.liveBytes.Add(retained)
+	atomicMaxInt32(&probe.maxActive, active)
+	atomicMaxInt64(&probe.maxBytes, liveBytes)
+	select {
+	case probe.arrived <- struct{}{}:
+	case <-probe.release:
+	}
+	<-probe.release
+	probe.liveBytes.Add(-retained)
+	probe.active.Add(-1)
+}
+
+func (probe *retainedOverlapProbe) waitAndRelease(t *testing.T) {
+	t.Helper()
+	defer func() {
+		select {
+		case <-probe.release:
+		default:
+			close(probe.release)
+		}
+	}()
+	for range probe.target {
+		select {
+		case <-probe.arrived:
+		case <-time.After(30 * time.Second):
+			t.Fatal("timed out waiting for concurrent retained members")
+		}
+	}
+	close(probe.release)
+}
+
+func atomicMaxInt32(value *atomic.Int32, candidate int32) {
+	for current := value.Load(); candidate > current; current = value.Load() {
+		if value.CompareAndSwap(current, candidate) {
+			return
+		}
+	}
+}
+
+func atomicMaxInt64(value *atomic.Int64, candidate int64) {
+	for current := value.Load(); candidate > current; current = value.Load() {
+		if value.CompareAndSwap(current, candidate) {
+			return
+		}
+	}
+}
+
+func TestReconcileWatchRootsWindsurfDiskIndexFailuresStayIncomplete(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		inject func(context.Context, error) context.Context
+	}{
+		{name: "query", inject: parser.WithDiscoveryDiskMapQueryError},
+		{name: "cleanup", inject: parser.WithDiscoveryDiskMapCleanupError},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := filepath.Join(t.TempDir(), "Windsurf", "User")
+			workspaceDir := filepath.Join(root, "workspaceStorage", "workspace-hash")
+			require.NoError(t, os.MkdirAll(workspaceDir, 0o755))
+			dbPath := filepath.Join(workspaceDir, "state.vscdb")
+			writeSyncWindsurfStateDB(t, dbPath, windsurfSyncPayload("fault-session", "reply"))
+			database := dbtest.OpenTestDB(t)
+			engine := NewEngine(database, EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{parser.AgentWindsurf: {root}},
+			})
+			defer engine.Close()
+			injected := errors.New("injected discovery index " + tc.name)
+			ctx := tc.inject(t.Context(), injected)
+
+			err := engine.ReconcileWatchRoots(ctx, []string{root}, false)
+
+			require.ErrorIs(t, err, injected)
+			result := engine.LastReconciliationResult()
+			assert.False(t, result.Complete)
+			assert.True(t, result.Aborted)
+			assert.Positive(t, result.ProviderFailures)
+		})
+	}
+}
 
 func TestSourceMtimeWindsurfUsesProviderFingerprint(t *testing.T) {
 	root := filepath.Join(t.TempDir(), "Windsurf", "User")

--- a/internal/sync/workbuddy_test.go
+++ b/internal/sync/workbuddy_test.go
@@ -35,21 +35,21 @@ func TestEngineClassifyWorkBuddyPaths(t *testing.T) {
 		require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o644))
 	}
 
-	files := engine.classifyPaths([]string{mainPath})
+	files := requireClassifyPaths(t, engine, []string{mainPath})
 	require.Len(t, files, 1, "main path did not classify")
 	got := files[0]
 	assert.Equal(t, mainPath, got.Path)
 	assert.Equal(t, "proj", got.Project)
 	assert.Equal(t, parser.AgentWorkBuddy, got.Agent)
 
-	files = engine.classifyPaths([]string{subPath})
+	files = requireClassifyPaths(t, engine, []string{subPath})
 	require.Len(t, files, 1, "subagent path did not classify")
 	got = files[0]
 	assert.Equal(t, subPath, got.Path)
 	assert.Equal(t, "proj", got.Project)
 	assert.Equal(t, parser.AgentWorkBuddy, got.Agent)
 
-	files = engine.classifyPaths([]string{toolPath})
+	files = requireClassifyPaths(t, engine, []string{toolPath})
 	assert.Empty(t, files, "tool result classified as %+v", files)
 }
 
@@ -67,7 +67,7 @@ func TestEngineClassifyWorkBuddyProjectNamedSubagentsAsMainSession(t *testing.T)
 	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
 	require.NoError(t, os.WriteFile(path, []byte("{}\n"), 0o644))
 
-	files := engine.classifyPaths([]string{path})
+	files := requireClassifyPaths(t, engine, []string{path})
 	require.Len(t, files, 1, "path did not classify")
 	got := files[0]
 	assert.Equal(t, path, got.Path)

--- a/internal/sync/zed_integration_test.go
+++ b/internal/sync/zed_integration_test.go
@@ -130,6 +130,88 @@ func TestSyncPathsZedDeletedPhysicalDBPreservesSessions(t *testing.T) {
 	assert.Equal(t, "zed:exists", sess.ID)
 }
 
+func TestReconcileWatchRootsZedDeletedPhysicalDBPreservesSessions(t *testing.T) {
+	zedDir := t.TempDir()
+	dbPath := filepath.Join(zedDir, "threads", "threads.db")
+	createZedThreadsDB(t, dbPath, []zedThreadFixture{{
+		id:        "archived-thread",
+		summary:   "Archived thread",
+		updatedAt: "2026-06-09T02:30:00Z",
+		dataType:  "json",
+		data:      []byte(`{"messages":[{"User":{"content":[{"Text":"hello"}]}}]}`),
+	}})
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentZed: {zedDir},
+		},
+		Machine: "local",
+	})
+	require.Equal(t, 1, engine.SyncAll(t.Context(), nil).Synced)
+	require.NoError(t, os.Remove(dbPath))
+
+	require.NoError(t, engine.ReconcileWatchRoots(
+		t.Context(), []string{zedDir}, false,
+	))
+
+	sess, err := database.GetSession(t.Context(), "zed:archived-thread")
+	require.NoError(t, err)
+	assert.NotNil(t, sess,
+		"reconciliation must preserve an archived Zed member when threads.db vanishes")
+}
+
+func TestReconcileWatchRootsZedDeletedMemberTombstonesSession(t *testing.T) {
+	zedDir := t.TempDir()
+	dbPath := filepath.Join(zedDir, "threads", "threads.db")
+	createZedThreadsDB(t, dbPath, []zedThreadFixture{
+		{
+			id: "deleted-thread", summary: "Deleted thread",
+			updatedAt: "2026-06-09T02:30:00Z", dataType: "json",
+			data: []byte(`{"messages":[{"User":{"content":[{"Text":"gone"}]}}]}`),
+		},
+		{
+			id: "surviving-thread", summary: "Surviving thread",
+			updatedAt: "2026-06-09T02:31:00Z", dataType: "json",
+			data: []byte(`{"messages":[{"User":{"content":[{"Text":"kept"}]}}]}`),
+		},
+	})
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentZed: {zedDir}},
+		Machine:   "local",
+	})
+	require.Equal(t, 2, engine.SyncAll(t.Context(), nil).Synced)
+	beforeDelete, err := database.GetSessionFull(t.Context(), "zed:deleted-thread")
+	require.NoError(t, err)
+	require.NotNil(t, beforeDelete)
+
+	zedDB, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = zedDB.Exec("DELETE FROM threads WHERE id = ?", "deleted-thread")
+	require.NoError(t, err)
+	require.NoError(t, zedDB.Close())
+
+	require.NoError(t, engine.ReconcileWatchRoots(
+		t.Context(), []string{zedDir}, false,
+	))
+
+	deleted, err := database.GetSession(t.Context(), "zed:deleted-thread")
+	require.NoError(t, err)
+	assert.Nil(t, deleted,
+		"a present authoritative container must retire a missing virtual member")
+	archived, err := database.GetSessionFull(t.Context(), "zed:deleted-thread")
+	require.NoError(t, err)
+	require.NotNil(t, archived)
+	require.NotNil(t, archived.DeletedAt)
+	require.NotNil(t, archived.DeletionCause)
+	assert.Equal(t, "source_missing", *archived.DeletionCause)
+	assert.Equal(t, beforeDelete.MessageCount, archived.MessageCount,
+		"source loss must retain the archived transcript")
+	surviving, err := database.GetSession(t.Context(), "zed:surviving-thread")
+	require.NoError(t, err)
+	assert.NotNil(t, surviving)
+}
+
 func TestSyncSingleSessionZedMissingThreadReturnsNotFound(t *testing.T) {
 
 	zedDir := t.TempDir()


### PR DESCRIPTION
## Why

On macOS, recursive kqueue watching kept state proportional to every file in a long-lived archive. Passive daemon memory therefore grew with archive size, while broad polling and recovery scans could keep CPU and I/O active.

## What changed

- Active recursive Darwin roots use native FSEvents, so passive watcher state scales with configured roots rather than stored files. Callback queues retain the existing path and byte limits.
- Discovery and authoritative reconciliation stream through disk-backed pages. Provider enumeration, duplicate selection, ordered aggregation, Trae workspace discovery, and Hermes profile/member discovery no longer require archive-sized Go maps or repeated value concatenation.
- Watcher overflow, directory lifecycle events, fallback coverage, and polling retain bounded retry scopes where correctness permits. Non-Darwin fsnotify coverage applies the same watch budget to newly created and moved-in subtrees.
- Missing-source deletion is conservative and recoverable. Only complete machine-local provider scopes establish deletion proof, including virtual members in multi-session containers, and scheduled reconciliation defers scopes whose physical roots are unavailable. Tombstones durably invalidate base and hash-qualified skip entries before hiding a session, and audit workers refresh the daemon cache so byte-identical restored files are parsed and revived across workers and restarts.
- Source revival replaces stale content before becoming visible, and provider-specific discovery preserves canonical identities across symlinks, overlapping roots, expanded Hermes profile archives, and mixed filesystem/SQLite layouts.

## Failure behavior

Root-local discovery failures may still yield valid sessions and do not block later configured roots. Those partial candidates can be stored, but the failed provider scope cannot add baselines or tombstone missing sessions; independent healthy providers remain authoritative. Callback, cancellation, temporary-store, and cleanup failures stop immediately, and the watcher retains the affected roots for retry.

True event loss or ownerless recovery can still require global authoritative reconciliation. Runtime watcher fallback and low-frequency reconciliation remain available for filesystems without reliable native events.

Focused macOS FSEvents CI runs only on trusted pushes to `main` through the self-hosted runner group.
