### PR TITLE
feat(usage): expose daily machine breakdowns

### DIFF
--- a/cmd/agentsview/usage_test.go
+++ b/cmd/agentsview/usage_test.go
@@ -107,6 +107,13 @@ func TestUsageDailyBreakdownGolden(t *testing.T) {
 		_, err = cmd.ExecuteC()
 	})
 	require.NoError(t, err, "usage daily json breakdown golden command")
+	var report db.DailyUsageResult
+	require.NoError(t, json.Unmarshal([]byte(stdout), &report))
+	require.NotEmpty(t, report.Daily)
+	for _, daily := range report.Daily {
+		require.Len(t, daily.MachineBreakdowns, 1)
+		assert.Equal(t, "golden-host", daily.MachineBreakdowns[0].MachineName)
+	}
 
 	assertGoldenBytes(t, "usage_daily_breakdown_v2.json", []byte(stdout))
 }
@@ -1119,6 +1126,7 @@ func TestFormatDailyUsageJSON(t *testing.T) {
 		"date", "inputTokens", "outputTokens",
 		"cacheCreationTokens", "cacheReadTokens",
 		"totalCost", "modelsUsed", "modelBreakdowns",
+		"machineBreakdowns",
 	}
 	for _, f := range wantFields {
 		assert.Contains(t, daily[0], f,

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -377,7 +377,7 @@ agentsview usage daily [flags]
 | `--until`     |               | End of window, a duration like `28d` or a `YYYY-MM-DD` date, inclusive   |
 | `--all`       | `false`       | Scan all history; overrides the default 30-day window                    |
 | `--agent`     |               | Filter by agent name                                                     |
-| `--breakdown` | `false`       | Show indented per-model rows under each day                              |
+| `--breakdown` | `false`       | Show per-model rows and populate detailed JSON breakdown arrays          |
 | `--offline`   | `false`       | Skip the LiteLLM pricing fetch; use embedded fallback                    |
 | `--no-sync`   | `false`       | Skip the on-demand sync pass before querying                             |
 | `--timezone`  | system        | IANA timezone name for date bucketing                                    |

--- a/docs/token-usage.md
+++ b/docs/token-usage.md
@@ -554,7 +554,17 @@ to X" still works.
         }
       ],
       "projectBreakdowns": [],
-      "agentBreakdowns": []
+      "agentBreakdowns": [],
+      "machineBreakdowns": [
+        {
+          "machineName": "build-host",
+          "inputTokens": 33410,
+          "outputTokens": 142805,
+          "cacheCreationTokens": 301223,
+          "cacheReadTokens": 2984511,
+          "cost": 9.6052
+        }
+      ]
     }
   ],
   "totals": {
@@ -569,9 +579,10 @@ to X" still works.
 
 `modelsUsed` is sorted by cost within each day, so the most expensive model
 appears first. Daily entries always emit `modelBreakdowns`, `projectBreakdowns`,
-and `agentBreakdowns` as arrays; empty breakdowns are `[]`, not omitted.
-`modelBreakdowns` always includes a row per model, regardless of whether
-`--breakdown` was passed; the flag only controls terminal table output.
+`agentBreakdowns`, and `machineBreakdowns` as arrays; empty breakdowns are `[]`,
+not omitted. `modelBreakdowns` always includes a row per model. The other three
+arrays are populated when `--breakdown` is passed; the flag also controls
+per-model terminal table output.
 
 ### JSON Contract
 

--- a/frontend/src/lib/api/generated/index.ts
+++ b/frontend/src/lib/api/generated/index.ts
@@ -51,6 +51,7 @@ export type { DbHeatmapResponse } from './models/DbHeatmapResponse';
 export type { DbHourOfWeekCell } from './models/DbHourOfWeekCell';
 export type { DbHourOfWeekResponse } from './models/DbHourOfWeekResponse';
 export type { DbInsight } from './models/DbInsight';
+export type { DbMachineBreakdown } from './models/DbMachineBreakdown';
 export type { DbMessage } from './models/DbMessage';
 export type { DbModelBreakdown } from './models/DbModelBreakdown';
 export type { DbPeakContextDistribution } from './models/DbPeakContextDistribution';

--- a/frontend/src/lib/api/generated/models/DbMachineBreakdown.ts
+++ b/frontend/src/lib/api/generated/models/DbMachineBreakdown.ts
@@ -2,17 +2,11 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export type DbDailyUsageEntry = {
-  agentBreakdowns: any[] | null;
+export type DbMachineBreakdown = {
   cacheCreationTokens: number;
   cacheReadTokens: number;
-  date: string;
+  cost: number;
   inputTokens: number;
-  machineBreakdowns: any[] | null;
-  modelBreakdowns: any[] | null;
-  modelsUsed: any[] | null;
+  machineName: string;
   outputTokens: number;
-  projectBreakdowns: any[] | null;
-  totalCost: number;
 };
-

--- a/frontend/src/lib/api/types/usage.ts
+++ b/frontend/src/lib/api/types/usage.ts
@@ -38,6 +38,15 @@ export interface AgentBreakdown {
   cost: number;
 }
 
+export interface MachineBreakdown {
+  machineName: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationTokens: number;
+  cacheReadTokens: number;
+  cost: number;
+}
+
 export interface DailyUsageEntry {
   date: string;
   inputTokens: number;
@@ -49,6 +58,7 @@ export interface DailyUsageEntry {
   modelBreakdowns?: ModelBreakdown[];
   projectBreakdowns?: ProjectBreakdown[];
   agentBreakdowns?: AgentBreakdown[];
+  machineBreakdowns?: MachineBreakdown[];
 }
 
 export interface ProjectTotal {

--- a/internal/db/usage.go
+++ b/internal/db/usage.go
@@ -479,7 +479,8 @@ SELECT
 	m.source_uuid,
 	'' AS usage_dedup_key,
 	s.project,
-	s.agent
+	s.agent,
+	s.machine
 FROM messages m
 JOIN sessions s ON m.session_id = s.id
 WHERE %s
@@ -507,7 +508,8 @@ SELECT
 		ELSE ue.session_id || ':' || ue.source || ':id:' || ue.id
 	END AS usage_dedup_key,
 	s.project,
-	s.agent
+	s.agent,
+	s.machine
 FROM usage_events ue
 JOIN sessions s ON s.id = ue.session_id
 WHERE %s`
@@ -534,7 +536,8 @@ SELECT
 	m.source_uuid,
 	'' AS usage_dedup_key,
 	s.project,
-	s.agent
+	s.agent,
+	s.machine
 FROM %s m
 JOIN sessions s ON m.session_id = s.id
 WHERE %s`
@@ -561,7 +564,8 @@ SELECT
 		ELSE ue.session_id || ':' || ue.source || ':id:' || ue.id
 	END AS usage_dedup_key,
 	s.project,
-	s.agent
+	s.agent,
+	s.machine
 FROM %s ue
 JOIN sessions s ON s.id = ue.session_id
 WHERE %s`
@@ -694,6 +698,7 @@ type dailyUsageScanRow struct {
 	usageDedupKey            string
 	project                  string
 	agent                    string
+	machine                  string
 }
 
 type topSessionMetadata struct {
@@ -745,6 +750,16 @@ func usageRowSelect() string {
 }
 
 func dailyUsageRowSelectFromRows(rowsSQL string) string {
+	return dailyUsageRowSelectFromRowsWithMachine(rowsSQL, false)
+}
+
+func dailyUsageRowSelectFromRowsWithMachine(
+	rowsSQL string, includeMachine bool,
+) string {
+	machineColumn := ""
+	if includeMachine {
+		machineColumn = ",\n\tu.machine"
+	}
 	return `
 SELECT
 	u.session_id,
@@ -764,7 +779,7 @@ SELECT
 	u.source_uuid,
 	u.usage_dedup_key,
 	u.project,
-	u.agent
+	u.agent` + machineColumn + `
 FROM (` + rowsSQL + `) u
 WHERE 1=1`
 }
@@ -942,7 +957,8 @@ SELECT
 	'' AS source_uuid,
 	cu.dedup_key AS usage_dedup_key,
 	'' AS project,
-	'cursor' AS agent
+	'cursor' AS agent,
+	'' AS machine
 FROM cursor_usage_events cu
 WHERE %s`
 
@@ -1046,8 +1062,14 @@ func scanUsageRow(rows *sql.Rows) (usageScanRow, error) {
 }
 
 func scanDailyUsageRow(rows *sql.Rows) (dailyUsageScanRow, error) {
+	return scanDailyUsageRowWithMachine(rows, false)
+}
+
+func scanDailyUsageRowWithMachine(
+	rows *sql.Rows, includeMachine bool,
+) (dailyUsageScanRow, error) {
 	var r dailyUsageScanRow
-	err := rows.Scan(
+	dest := []any{
 		&r.sessionID,
 		&r.messageOrdinal,
 		&r.usageSource,
@@ -1066,7 +1088,11 @@ func scanDailyUsageRow(rows *sql.Rows) (dailyUsageScanRow, error) {
 		&r.usageDedupKey,
 		&r.project,
 		&r.agent,
-	)
+	}
+	if includeMachine {
+		dest = append(dest, &r.machine)
+	}
+	err := rows.Scan(dest...)
 	return r, err
 }
 
@@ -1525,6 +1551,7 @@ type DailyUsageEntry struct {
 	ModelBreakdowns     []ModelBreakdown   `json:"modelBreakdowns"`
 	ProjectBreakdowns   []ProjectBreakdown `json:"projectBreakdowns"`
 	AgentBreakdowns     []AgentBreakdown   `json:"agentBreakdowns"`
+	MachineBreakdowns   []MachineBreakdown `json:"machineBreakdowns"`
 }
 
 func (e DailyUsageEntry) MarshalJSON() ([]byte, error) {
@@ -1541,6 +1568,9 @@ func (e DailyUsageEntry) MarshalJSON() ([]byte, error) {
 	}
 	if out.AgentBreakdowns == nil {
 		out.AgentBreakdowns = []AgentBreakdown{}
+	}
+	if out.MachineBreakdowns == nil {
+		out.MachineBreakdowns = []MachineBreakdown{}
 	}
 	return json.Marshal(out)
 }
@@ -1569,6 +1599,16 @@ type ProjectBreakdown struct {
 // AgentBreakdown is the per-agent slice of a day's usage.
 type AgentBreakdown struct {
 	Agent               string  `json:"agent"`
+	InputTokens         int     `json:"inputTokens"`
+	OutputTokens        int     `json:"outputTokens"`
+	CacheCreationTokens int     `json:"cacheCreationTokens"`
+	CacheReadTokens     int     `json:"cacheReadTokens"`
+	Cost                float64 `json:"cost"`
+}
+
+// MachineBreakdown is the per-source-machine slice of a day's usage.
+type MachineBreakdown struct {
+	MachineName         string  `json:"machineName"`
 	InputTokens         int     `json:"inputTokens"`
 	OutputTokens        int     `json:"outputTokens"`
 	CacheCreationTokens int     `json:"cacheCreationTokens"`
@@ -1786,7 +1826,7 @@ func (db *DB) GetDailyUsage(
 	// Pad by +/-14h to cover all timezone offsets; the actual
 	// date filtering happens post-query via localDate.
 	query, args := dailyUsageRowsSQLForBounds(f, usageBoundsForFilter(f), db.hasCursorUsageTable())
-	query = dailyUsageRowSelectFromRows(query)
+	query = dailyUsageRowSelectFromRowsWithMachine(query, f.Breakdowns)
 	query += ` ORDER BY u.ts ASC, u.session_id ASC,
 		COALESCE(u.message_ordinal, -1) ASC`
 
@@ -1802,6 +1842,7 @@ func (db *DB) GetDailyUsage(
 		date    string
 		project string
 		agent   string
+		machine string
 		model   string
 	}
 	type bucket struct {
@@ -1829,7 +1870,7 @@ func (db *DB) GetDailyUsage(
 	var totalSavings float64
 
 	for rows.Next() {
-		r, scanErr := scanDailyUsageRow(rows)
+		r, scanErr := scanDailyUsageRowWithMachine(rows, f.Breakdowns)
 		if scanErr != nil {
 			return DailyUsageResult{},
 				fmt.Errorf("scanning daily usage row: %w", scanErr)
@@ -1874,7 +1915,7 @@ func (db *DB) GetDailyUsage(
 
 		key := accumKey{
 			date: date, project: r.project,
-			agent: r.agent, model: r.model,
+			agent: r.agent, machine: r.machine, model: r.model,
 		}
 		b, ok := accum[key]
 		if !ok {
@@ -2052,6 +2093,7 @@ func (db *DB) GetDailyUsage(
 		models   map[string]bucket
 		projects map[string]bucket
 		agents   map[string]bucket
+		machines map[string]bucket
 	}
 	days := make(map[string]*dayMaps, 64)
 	for key, b := range accum {
@@ -2061,6 +2103,7 @@ func (db *DB) GetDailyUsage(
 				models:   make(map[string]bucket, 4),
 				projects: make(map[string]bucket, 8),
 				agents:   make(map[string]bucket, 4),
+				machines: make(map[string]bucket, 4),
 			}
 			days[key.date] = dm
 		}
@@ -2087,6 +2130,14 @@ func (db *DB) GetDailyUsage(
 		cur.cacheRd += b.cacheRd
 		cur.cost += b.cost
 		dm.agents[key.agent] = cur
+
+		cur = dm.machines[key.machine]
+		cur.inputTok += b.inputTok
+		cur.outputTok += b.outputTok
+		cur.cacheCr += b.cacheCr
+		cur.cacheRd += b.cacheRd
+		cur.cost += b.cost
+		dm.machines[key.machine] = cur
 	}
 
 	dateKeys := make([]string, 0, len(days))
@@ -2186,6 +2237,27 @@ func (db *DB) GetDailyUsage(
 			return abd[i].Agent < abd[j].Agent
 		})
 		entry.AgentBreakdowns = abd
+
+		machineBreakdowns := make(
+			[]MachineBreakdown, 0, len(dm.machines),
+		)
+		for machine, b := range dm.machines {
+			machineBreakdowns = append(machineBreakdowns, MachineBreakdown{
+				MachineName:         machine,
+				InputTokens:         b.inputTok,
+				OutputTokens:        b.outputTok,
+				CacheCreationTokens: b.cacheCr,
+				CacheReadTokens:     b.cacheRd,
+				Cost:                b.cost,
+			})
+		}
+		sort.Slice(machineBreakdowns, func(i, j int) bool {
+			if machineBreakdowns[i].Cost != machineBreakdowns[j].Cost {
+				return machineBreakdowns[i].Cost > machineBreakdowns[j].Cost
+			}
+			return machineBreakdowns[i].MachineName < machineBreakdowns[j].MachineName
+		})
+		entry.MachineBreakdowns = machineBreakdowns
 
 		daily = append(daily, entry)
 

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log"
 	"math"
@@ -1522,6 +1523,74 @@ func TestDailyUsageEntryBreakdownSlicesMarshalAsEmptyArrays(t *testing.T) {
 	assert.Equal(t, []any{}, got["modelBreakdowns"])
 	assert.Equal(t, []any{}, got["projectBreakdowns"])
 	assert.Equal(t, []any{}, got["agentBreakdowns"])
+	assert.Equal(t, []any{}, got["machineBreakdowns"])
+}
+
+func TestGetDailyUsageMachineBreakdowns(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	require.NoError(t, d.UpsertModelPricing([]ModelPricing{{
+		ModelPattern:  "model-a",
+		InputPerMTok:  1,
+		OutputPerMTok: 5,
+	}}))
+
+	type machineUsage struct {
+		name         string
+		inputTokens  int
+		outputTokens int
+	}
+	fixtures := []machineUsage{
+		{name: "host-a", inputTokens: 2000, outputTokens: 200},
+		{name: "host-b", inputTokens: 1000, outputTokens: 100},
+	}
+	for i, fixture := range fixtures {
+		sessionID := fmt.Sprintf("machine-breakdown-%d", i)
+		insertSession(t, d, sessionID, "project-a", func(s *Session) {
+			s.Machine = fixture.name
+			s.Agent = "claude"
+			s.StartedAt = Ptr("2026-07-15T10:00:00Z")
+		})
+		insertMessages(t, d, Message{
+			SessionID: sessionID,
+			Ordinal:   0,
+			Role:      "assistant",
+			Timestamp: "2026-07-15T10:30:00Z",
+			Model:     "model-a",
+			TokenUsage: json.RawMessage(fmt.Sprintf(
+				`{"input_tokens":%d,"output_tokens":%d}`,
+				fixture.inputTokens, fixture.outputTokens,
+			)),
+		})
+	}
+
+	result, err := d.GetDailyUsage(ctx, UsageFilter{
+		From:       "2026-07-15",
+		To:         "2026-07-15",
+		Timezone:   "UTC",
+		Breakdowns: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Daily, 1)
+	day := result.Daily[0]
+	require.Len(t, day.MachineBreakdowns, 2)
+	assert.Equal(t, "host-a", day.MachineBreakdowns[0].MachineName)
+	assert.Equal(t, 2000, day.MachineBreakdowns[0].InputTokens)
+	assert.Equal(t, 200, day.MachineBreakdowns[0].OutputTokens)
+	assert.InDelta(t, 0.003, day.MachineBreakdowns[0].Cost, 1e-9)
+	assert.Equal(t, "host-b", day.MachineBreakdowns[1].MachineName)
+	assert.Equal(t, 1000, day.MachineBreakdowns[1].InputTokens)
+	assert.Equal(t, 100, day.MachineBreakdowns[1].OutputTokens)
+	assert.InDelta(t, 0.0015, day.MachineBreakdowns[1].Cost, 1e-9)
+	assert.InDelta(t, day.TotalCost,
+		day.MachineBreakdowns[0].Cost+day.MachineBreakdowns[1].Cost, 1e-9)
+
+	fastResult, err := d.GetDailyUsage(ctx, UsageFilter{
+		From: "2026-07-15", To: "2026-07-15", Timezone: "UTC",
+	})
+	require.NoError(t, err)
+	require.Len(t, fastResult.Daily, 1)
+	assert.Empty(t, fastResult.Daily[0].MachineBreakdowns)
 }
 
 func TestGetDailyUsageAgentBreakdowns(t *testing.T) {

--- a/internal/duckdb/analytics_usage.go
+++ b/internal/duckdb/analytics_usage.go
@@ -3465,6 +3465,7 @@ type duckUsageAggregateRow struct {
 	sessionID     string
 	project       string
 	agent         string
+	machine       string
 	model         string
 	displayName   string
 	startedAt     string
@@ -3606,8 +3607,16 @@ func (s *Store) dailyUsageAggregateRows(
 	ctx context.Context, f db.UsageFilter,
 ) ([]duckUsageAggregateRow, error) {
 	cte, args := duckDailyUsageCTE(f)
+	machineSelect := "'' AS machine"
+	machineGroup := ""
+	machineOrder := ""
+	if f.Breakdowns {
+		machineSelect = "machine"
+		machineGroup = ", machine"
+		machineOrder = ", machine ASC"
+	}
 	query := cte + `
-		SELECT local_date, project, agent, model,
+		SELECT local_date, project, agent, ` + machineSelect + `, model,
 			SUM(input_tokens_norm) AS input_tokens,
 			SUM(output_tokens_norm) AS output_tokens,
 			SUM(cache_create_norm) AS cache_creation_tokens,
@@ -3624,8 +3633,8 @@ func (s *Store) dailyUsageAggregateRows(
 				COALESCE(SUM(cost_usd), 0) AS explicit_cost,
 				COUNT(cost_usd) AS reported_cost_rows
 		FROM usage_localized
-		GROUP BY local_date, project, agent, model
-		ORDER BY local_date ASC, project ASC, agent ASC, model ASC`
+		GROUP BY local_date, project, agent` + machineGroup + `, model
+		ORDER BY local_date ASC, project ASC, agent ASC` + machineOrder + `, model ASC`
 	rows, err := s.queryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("querying duckdb daily usage aggregates: %w", err)
@@ -3635,7 +3644,7 @@ func (s *Store) dailyUsageAggregateRows(
 	for rows.Next() {
 		var r duckUsageAggregateRow
 		if err := rows.Scan(
-			&r.date, &r.project, &r.agent, &r.model,
+			&r.date, &r.project, &r.agent, &r.machine, &r.model,
 			&r.inputTok, &r.outputTok, &r.cacheCr, &r.cacheRd,
 			&r.billableInput, &r.billableOutput, &r.billableReason,
 			&r.billableCacheCr, &r.billableCacheRd,
@@ -3664,13 +3673,17 @@ func (s *Store) GetDailyUsage(
 		date    string
 		project string
 		agent   string
+		machine string
 		model   string
 	}
 	accum := map[usageAccumKey]*duckUsageBucket{}
 	projectLabels := map[string]bool{}
 	totalSavings := 0.0
 	for _, r := range rows {
-		key := usageAccumKey{date: r.date, project: r.project, agent: r.agent, model: r.model}
+		key := usageAccumKey{
+			date: r.date, project: r.project, agent: r.agent,
+			machine: r.machine, model: r.model,
+		}
 		if r.project != "" {
 			projectLabels[r.project] = true
 		}
@@ -3700,6 +3713,7 @@ func (s *Store) GetDailyUsage(
 		models   map[string]duckUsageBucket
 		projects map[string]duckUsageBucket
 		agents   map[string]duckUsageBucket
+		machines map[string]duckUsageBucket
 	}
 	days := map[string]*dayMaps{}
 	for key, b := range accum {
@@ -3709,6 +3723,7 @@ func (s *Store) GetDailyUsage(
 				models:   map[string]duckUsageBucket{},
 				projects: map[string]duckUsageBucket{},
 				agents:   map[string]duckUsageBucket{},
+				machines: map[string]duckUsageBucket{},
 			}
 			days[key.date] = day
 		}
@@ -3716,6 +3731,7 @@ func (s *Store) GetDailyUsage(
 		if f.Breakdowns {
 			addUsageBucket(day.projects, key.project, *b)
 			addUsageBucket(day.agents, key.agent, *b)
+			addUsageBucket(day.machines, key.machine, *b)
 		}
 	}
 
@@ -3766,6 +3782,20 @@ func (s *Store) GetDailyUsage(
 					CacheReadTokens:     b.cacheRd,
 					Cost:                roundCost(b.cost),
 				})
+			}
+			for _, machine := range sortedUsageBucketKeys(day.machines) {
+				b := day.machines[machine]
+				entry.MachineBreakdowns = append(
+					entry.MachineBreakdowns,
+					db.MachineBreakdown{
+						MachineName:         machine,
+						InputTokens:         b.inputTok,
+						OutputTokens:        b.outputTok,
+						CacheCreationTokens: b.cacheCr,
+						CacheReadTokens:     b.cacheRd,
+						Cost:                roundCost(b.cost),
+					},
+				)
 			}
 		}
 		entry.TotalCost = roundCost(entry.TotalCost)

--- a/internal/duckdb/store_test.go
+++ b/internal/duckdb/store_test.go
@@ -2794,8 +2794,17 @@ func TestDailyUsageBreakdownsAndCacheSavings(t *testing.T) {
 		CacheReadPerMTok:     0.5,
 	}}))
 	sessionID := "duck-usage-breakdowns"
+	primarySession := syncSession(
+		sessionID, "alpha", "usage first", "2026-01-17T00:00:00.000Z", 1,
+	)
+	primarySession.Machine = "host-a"
+	secondaryID := "duck-usage-breakdowns-secondary"
+	secondarySession := syncSession(
+		secondaryID, "alpha", "usage second", "2026-01-17T00:02:00.000Z", 1,
+	)
+	secondarySession.Machine = "host-b"
 	_, err := local.WriteSessionBatchAtomic([]db.SessionBatchWrite{{
-		Session:  syncSession(sessionID, "alpha", "usage first", "2026-01-17T00:00:00.000Z", 1),
+		Session:  primarySession,
 		Messages: []db.Message{syncMessage(sessionID, 0, "user", "usage first", "2026-01-17T00:00:00.000Z")},
 		UsageEvents: []db.UsageEvent{{
 			Source:               "hermes",
@@ -2808,11 +2817,32 @@ func TestDailyUsageBreakdownsAndCacheSavings(t *testing.T) {
 		}},
 		DataVersion:     1,
 		ReplaceMessages: true,
+	}, {
+		Session:  secondarySession,
+		Messages: []db.Message{syncMessage(secondaryID, 0, "user", "usage second", "2026-01-17T00:02:00.000Z")},
+		UsageEvents: []db.UsageEvent{{
+			Source:       "hermes",
+			Model:        "claude-test",
+			InputTokens:  2,
+			OutputTokens: 1,
+			OccurredAt:   "2026-01-17T00:03:00.000Z",
+			DedupKey:     "breakdown-secondary",
+		}},
+		DataVersion:     1,
+		ReplaceMessages: true,
 	}})
 	require.NoError(t, err)
 
 	syncer := newInMemoryTestSync(t, local, SyncOptions{})
 	_, err = syncer.Push(ctx, true, nil)
+	require.NoError(t, err)
+	_, err = syncer.DB().ExecContext(ctx, `
+		UPDATE sessions
+		SET machine = CASE id
+			WHEN ? THEN 'host-a'
+			WHEN ? THEN 'host-b'
+			ELSE machine
+		END`, sessionID, secondaryID)
 	require.NoError(t, err)
 	store := NewStoreFromDB(syncer.DB())
 
@@ -2827,8 +2857,13 @@ func TestDailyUsageBreakdownsAndCacheSavings(t *testing.T) {
 	require.Len(t, day.ModelBreakdowns, 1)
 	require.Len(t, day.ProjectBreakdowns, 1)
 	require.Len(t, day.AgentBreakdowns, 1)
+	require.Len(t, day.MachineBreakdowns, 2)
 	assert.Equal(t, "alpha", day.ProjectBreakdowns[0].Project)
 	assert.Equal(t, "claude", day.AgentBreakdowns[0].Agent)
+	assert.Equal(t, "host-a", day.MachineBreakdowns[0].MachineName)
+	assert.Equal(t, "host-b", day.MachineBreakdowns[1].MachineName)
+	assert.InDelta(t, day.TotalCost,
+		day.MachineBreakdowns[0].Cost+day.MachineBreakdowns[1].Cost, 0.000001)
 	assert.InDelta(t, 0.00001, got.Totals.CacheSavings, 0.000001)
 
 	noCounts, err := store.GetDailyUsage(ctx, db.UsageFilter{

--- a/internal/postgres/usage.go
+++ b/internal/postgres/usage.go
@@ -314,7 +314,8 @@ SELECT
 	m.source_uuid,
 	'' AS usage_dedup_key,
 	s.project,
-	s.agent
+	s.agent,
+	s.machine
 FROM messages m
 JOIN sessions s ON m.session_id = s.id
 WHERE %s
@@ -342,7 +343,8 @@ SELECT
 		ELSE ue.session_id || ':' || ue.source || ':id:' || ue.id
 	END AS usage_dedup_key,
 	s.project,
-	s.agent
+	s.agent,
+	s.machine
 FROM usage_events ue
 JOIN sessions s ON s.id = ue.session_id
 WHERE %s`
@@ -366,7 +368,8 @@ SELECT
 	m.source_uuid,
 	'' AS usage_dedup_key,
 	s.project,
-	s.agent
+	s.agent,
+	s.machine
 FROM %s m
 JOIN sessions s ON m.session_id = s.id
 WHERE %s`
@@ -393,7 +396,8 @@ SELECT
 		ELSE ue.session_id || ':' || ue.source || ':id:' || ue.id
 	END AS usage_dedup_key,
 	s.project,
-	s.agent
+	s.agent,
+	s.machine
 FROM %s ue
 JOIN sessions s ON s.id = ue.session_id
 WHERE %s`
@@ -525,6 +529,7 @@ type pgDailyUsageScanRow struct {
 	usageDedupKey            string
 	project                  string
 	agent                    string
+	machine                  string
 }
 
 type pgTopSessionMetadata struct {
@@ -575,6 +580,16 @@ func pgUsageRowSelect() string {
 }
 
 func pgDailyUsageRowSelectFromRows(rowsSQL string) string {
+	return pgDailyUsageRowSelectFromRowsWithMachine(rowsSQL, false)
+}
+
+func pgDailyUsageRowSelectFromRowsWithMachine(
+	rowsSQL string, includeMachine bool,
+) string {
+	machineColumn := ""
+	if includeMachine {
+		machineColumn = ",\n\tu.machine"
+	}
 	return `
 SELECT
 	u.session_id,
@@ -594,7 +609,7 @@ SELECT
 	u.source_uuid,
 	u.usage_dedup_key,
 	u.project,
-	u.agent
+	u.agent` + machineColumn + `
 FROM (` + rowsSQL + `) u
 WHERE 1=1`
 }
@@ -739,7 +754,8 @@ SELECT
 	'' AS source_uuid,
 	cu.dedup_key AS usage_dedup_key,
 	'' AS project,
-	'cursor' AS agent
+	'cursor' AS agent,
+	'' AS machine
 FROM cursor_usage_events cu
 WHERE %s`
 
@@ -798,7 +814,7 @@ func pgDailyUsageRowQuery(pb *paramBuilder, f db.UsageFilter, hasCursorTable boo
 			rowsSQL += "\n\nUNION ALL\n\n" + cursorRowsSQL
 		}
 	}
-	return pgDailyUsageRowSelectFromRows(rowsSQL)
+	return pgDailyUsageRowSelectFromRowsWithMachine(rowsSQL, f.Breakdowns)
 }
 
 func pgTopSessionsUsageRowQuery(pb *paramBuilder, f db.UsageFilter) string {
@@ -839,8 +855,14 @@ func scanPGUsageRow(rows *sql.Rows) (pgUsageScanRow, error) {
 }
 
 func scanPGDailyUsageRow(rows *sql.Rows) (pgDailyUsageScanRow, error) {
+	return scanPGDailyUsageRowWithMachine(rows, false)
+}
+
+func scanPGDailyUsageRowWithMachine(
+	rows *sql.Rows, includeMachine bool,
+) (pgDailyUsageScanRow, error) {
 	var r pgDailyUsageScanRow
-	err := rows.Scan(
+	dest := []any{
 		&r.sessionID,
 		&r.messageOrdinal,
 		&r.usageSource,
@@ -859,7 +881,11 @@ func scanPGDailyUsageRow(rows *sql.Rows) (pgDailyUsageScanRow, error) {
 		&r.usageDedupKey,
 		&r.project,
 		&r.agent,
-	)
+	}
+	if includeMachine {
+		dest = append(dest, &r.machine)
+	}
+	err := rows.Scan(dest...)
 	return r, err
 }
 
@@ -1265,6 +1291,7 @@ func (s *Store) GetDailyUsage(
 		date    string
 		project string
 		agent   string
+		machine string
 		model   string
 	}
 	type bucket struct {
@@ -1284,7 +1311,7 @@ func (s *Store) GetDailyUsage(
 	var totalSavings float64
 
 	for rows.Next() {
-		r, scanErr := scanPGDailyUsageRow(rows)
+		r, scanErr := scanPGDailyUsageRowWithMachine(rows, f.Breakdowns)
 		if scanErr != nil {
 			return db.DailyUsageResult{},
 				fmt.Errorf("scanning daily usage row: %w", scanErr)
@@ -1326,7 +1353,7 @@ func (s *Store) GetDailyUsage(
 
 		key := accumKey{
 			date: date, project: r.project,
-			agent: r.agent, model: r.model,
+			agent: r.agent, machine: r.machine, model: r.model,
 		}
 		b, ok := accum[key]
 		if !ok {
@@ -1488,6 +1515,7 @@ func (s *Store) GetDailyUsage(
 		models   map[string]bucket
 		projects map[string]bucket
 		agents   map[string]bucket
+		machines map[string]bucket
 	}
 	days := make(map[string]*dayMaps, 64)
 	for key, b := range accum {
@@ -1497,6 +1525,7 @@ func (s *Store) GetDailyUsage(
 				models:   make(map[string]bucket, 4),
 				projects: make(map[string]bucket, 8),
 				agents:   make(map[string]bucket, 4),
+				machines: make(map[string]bucket, 4),
 			}
 			days[key.date] = dm
 		}
@@ -1523,6 +1552,14 @@ func (s *Store) GetDailyUsage(
 		cur.cacheRd += b.cacheRd
 		cur.cost += b.cost
 		dm.agents[key.agent] = cur
+
+		cur = dm.machines[key.machine]
+		cur.inputTok += b.inputTok
+		cur.outputTok += b.outputTok
+		cur.cacheCr += b.cacheCr
+		cur.cacheRd += b.cacheRd
+		cur.cost += b.cost
+		dm.machines[key.machine] = cur
 	}
 
 	dateKeys := make([]string, 0, len(days))
@@ -1610,6 +1647,27 @@ func (s *Store) GetDailyUsage(
 			return abd[i].Agent < abd[j].Agent
 		})
 		entry.AgentBreakdowns = abd
+
+		machineBreakdowns := make(
+			[]db.MachineBreakdown, 0, len(dm.machines),
+		)
+		for machine, b := range dm.machines {
+			machineBreakdowns = append(machineBreakdowns, db.MachineBreakdown{
+				MachineName:         machine,
+				InputTokens:         b.inputTok,
+				OutputTokens:        b.outputTok,
+				CacheCreationTokens: b.cacheCr,
+				CacheReadTokens:     b.cacheRd,
+				Cost:                b.cost,
+			})
+		}
+		sort.Slice(machineBreakdowns, func(i, j int) bool {
+			if machineBreakdowns[i].Cost != machineBreakdowns[j].Cost {
+				return machineBreakdowns[i].Cost > machineBreakdowns[j].Cost
+			}
+			return machineBreakdowns[i].MachineName < machineBreakdowns[j].MachineName
+		})
+		entry.MachineBreakdowns = machineBreakdowns
 
 		daily = append(daily, entry)
 		totals.InputTokens += entry.InputTokens

--- a/internal/postgres/usage_pgtest_test.go
+++ b/internal/postgres/usage_pgtest_test.go
@@ -86,9 +86,9 @@ func TestStoreGetDailyUsageWithBreakdowns(t *testing.T) {
 			id, machine, project, agent, started_at,
 			message_count, user_message_count
 		) VALUES
-			('usage-breakdown-001', 'test-machine', 'proj-a', 'claude',
+			('usage-breakdown-001', 'host-a', 'proj-a', 'claude',
 			 '2026-03-12T10:00:00Z'::timestamptz, 1, 1),
-			('usage-breakdown-002', 'test-machine', 'proj-b', 'codex',
+			('usage-breakdown-002', 'host-b', 'proj-b', 'codex',
 			 '2026-03-12T11:00:00Z'::timestamptz, 1, 1)`)
 	require.NoError(t, err, "insert sessions")
 	_, err = store.DB().ExecContext(ctx, `
@@ -120,6 +120,11 @@ func TestStoreGetDailyUsageWithBreakdowns(t *testing.T) {
 	assert.Len(t, day.ProjectBreakdowns, 2)
 	assert.Len(t, day.AgentBreakdowns, 2)
 	assert.Len(t, day.ModelBreakdowns, 2)
+	require.Len(t, day.MachineBreakdowns, 2)
+	assert.Equal(t, "host-a", day.MachineBreakdowns[0].MachineName)
+	assert.Equal(t, "host-b", day.MachineBreakdowns[1].MachineName)
+	assert.InDelta(t, day.TotalCost,
+		day.MachineBreakdowns[0].Cost+day.MachineBreakdowns[1].Cost, 1e-9)
 	assert.Greater(t, day.TotalCost, 0.0)
 
 	noCounts, err := store.GetDailyUsage(ctx, db.UsageFilter{

--- a/internal/postgres/usage_unit_test.go
+++ b/internal/postgres/usage_unit_test.go
@@ -336,6 +336,26 @@ func TestPGUsageRowQueryPushesDateBoundsIntoUnion(t *testing.T) {
 	assert.Equal(t, "2024-07-01T13:59:59Z", pb.args[1])
 }
 
+func TestPGDailyUsageDetailedQuerySelectsMachine(t *testing.T) {
+	detailedParams := &paramBuilder{}
+	detailed := strings.ToLower(pgDailyUsageRowQuery(
+		detailedParams,
+		db.UsageFilter{
+			From: "2026-07-15", To: "2026-07-15", Breakdowns: true,
+		},
+		false,
+	))
+	assert.Contains(t, detailed, "u.machine")
+
+	fastParams := &paramBuilder{}
+	fast := strings.ToLower(pgDailyUsageRowQuery(
+		fastParams,
+		db.UsageFilter{From: "2026-07-15", To: "2026-07-15"},
+		false,
+	))
+	assert.NotContains(t, fast, "u.machine")
+}
+
 func TestPGBoundedDailyUsageRowsCTEProjectsReasoningTokens(t *testing.T) {
 	pb := &paramBuilder{}
 	f := db.UsageFilter{

--- a/testdata/golden/usage_daily_breakdown_v2.json
+++ b/testdata/golden/usage_daily_breakdown_v2.json
@@ -98,6 +98,16 @@
           "cacheReadTokens": 0,
           "cost": 0.0042
         }
+      ],
+      "machineBreakdowns": [
+        {
+          "machineName": "golden-host",
+          "inputTokens": 300,
+          "outputTokens": 60,
+          "cacheCreationTokens": 0,
+          "cacheReadTokens": 0,
+          "cost": 0.0042
+        }
       ]
     },
     {
@@ -134,6 +144,16 @@
       "agentBreakdowns": [
         {
           "agent": "codex",
+          "inputTokens": 800,
+          "outputTokens": 160,
+          "cacheCreationTokens": 0,
+          "cacheReadTokens": 0,
+          "cost": 0.00288
+        }
+      ],
+      "machineBreakdowns": [
+        {
+          "machineName": "golden-host",
           "inputTokens": 800,
           "outputTokens": 160,
           "cacheCreationTokens": 0,
@@ -207,6 +227,16 @@
           "cacheCreationTokens": 80,
           "cacheReadTokens": 400,
           "cost": 0.00476
+        }
+      ],
+      "machineBreakdowns": [
+        {
+          "machineName": "golden-host",
+          "inputTokens": 1500,
+          "outputTokens": 300,
+          "cacheCreationTokens": 80,
+          "cacheReadTokens": 400,
+          "cost": 0.01726
         }
       ]
     }

--- a/testdata/golden/usage_daily_v2.json
+++ b/testdata/golden/usage_daily_v2.json
@@ -79,7 +79,8 @@
         }
       ],
       "projectBreakdowns": [],
-      "agentBreakdowns": []
+      "agentBreakdowns": [],
+      "machineBreakdowns": []
     },
     {
       "date": "2026-07-02",
@@ -102,7 +103,8 @@
         }
       ],
       "projectBreakdowns": [],
-      "agentBreakdowns": []
+      "agentBreakdowns": [],
+      "machineBreakdowns": []
     },
     {
       "date": "2026-07-03",
@@ -134,7 +136,8 @@
         }
       ],
       "projectBreakdowns": [],
-      "agentBreakdowns": []
+      "agentBreakdowns": [],
+      "machineBreakdowns": []
     }
   ],
   "totals": {


### PR DESCRIPTION
## Why

Daily usage consumers can already group cost by model, project, and agent, but they cannot distinguish work collected from multiple source machines even though sessions retain that identity. Downstream dashboards therefore have to collapse machine attribution or reconstruct it outside the supported usage contract.

## What changes

The version 2 daily usage response now includes an additive machineBreakdowns array. Detailed queries populate it from the stored session machine label across SQLite, PostgreSQL, and DuckDB; ordinary queries keep the array empty and avoid machine-level grouping. Results follow the existing breakdown ordering and token/cost shape so consumers can add machine grouping without a parallel endpoint or schema bump.

The CLI goldens, usage documentation, and generated frontend contract make the new field explicit. SQLite and DuckDB behavior is exercised locally; PostgreSQL query parity has unit coverage, while the live PostgreSQL integration case requires TEST_PG_URL and was unavailable in this environment.