### PR TITLE
feat(recall): extraction segmenter with a turn-granular first strategy

### DIFF
--- a/internal/recall/extract/segment.go
+++ b/internal/recall/extract/segment.go
@@ -1,0 +1,157 @@
+// Package extract derives distillation work units from session transcripts.
+//
+// A Segmenter turns a session's messages into an ordered list of units, each
+// destined for one model call. Derivation must be deterministic: resume
+// cursors index into the unit list, and entry identity embeds the unit index,
+// so replaying a session after a restart or upgrade must yield the same units
+// in the same order. A segmenter's name and parameters identify its output
+// alongside the prompt and model configuration, so different segmentation
+// strategies build separate, comparable corpora instead of mixing.
+package extract
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// PromptRole names the kind of prompt a unit should be distilled with.
+type PromptRole string
+
+const (
+	// RoleIntent marks a unit carrying what the user asked for.
+	RoleIntent PromptRole = "intent"
+	// RoleAction marks a unit carrying what the assistant did.
+	RoleAction PromptRole = "action"
+	// RoleGeneric marks a unit for strategies that do not distinguish
+	// speaker roles and use a single prompt.
+	RoleGeneric PromptRole = "generic"
+)
+
+// Message is the minimal transcript row a segmenter consumes. Callers adapt
+// their storage rows to it; ordinals must be the session's message ordinals
+// so unit evidence ranges point back into the transcript.
+type Message struct {
+	Ordinal  int
+	Role     string
+	Content  string
+	IsSystem bool
+}
+
+// Unit is one model call's worth of transcript, with the ordinal range it
+// covers as evidence provenance.
+type Unit struct {
+	Role         PromptRole
+	Text         string
+	OrdinalStart int
+	OrdinalEnd   int
+}
+
+// Segmenter derives units from a session deterministically. Name and Params
+// identify the strategy and its knobs; both become part of the extraction
+// configuration's identity. PromptRoles declares which prompt kinds the
+// strategy emits so prompt resolution can be validated up front.
+type Segmenter interface {
+	Name() string
+	Params() map[string]any
+	PromptRoles() []PromptRole
+	Units(messages []Message) []Unit
+}
+
+// TurnsV1 segments at user/assistant turn granularity: each non-system user
+// message becomes one intent unit, and each run of assistant messages between
+// user messages is packed into action units of at most MaxWindowChars
+// characters (counted as Unicode code points). A single assistant message
+// larger than the budget becomes its own oversized unit; the extraction
+// client is responsible for splitting text that exceeds the model context.
+type TurnsV1 struct {
+	MaxWindowChars int
+}
+
+// Name implements Segmenter.
+func (TurnsV1) Name() string { return "turns-v1" }
+
+// Params implements Segmenter.
+func (s TurnsV1) Params() map[string]any {
+	return map[string]any{"max_window_chars": s.MaxWindowChars}
+}
+
+// PromptRoles implements Segmenter.
+func (TurnsV1) PromptRoles() []PromptRole {
+	return []PromptRole{RoleIntent, RoleAction}
+}
+
+// Units implements Segmenter.
+func (s TurnsV1) Units(messages []Message) []Unit {
+	var units []Unit
+	var run []ordinalBlock
+	for _, message := range messages {
+		if message.IsSystem {
+			continue
+		}
+		content := strings.TrimSpace(message.Content)
+		if content == "" {
+			continue
+		}
+		switch message.Role {
+		case "user":
+			units = packRun(run, s.MaxWindowChars, units)
+			run = nil
+			units = append(units, Unit{
+				Role: RoleIntent,
+				Text: fmt.Sprintf("USER MESSAGE (ordinal %d):\n%s",
+					message.Ordinal, content),
+				OrdinalStart: message.Ordinal,
+				OrdinalEnd:   message.Ordinal,
+			})
+		case "assistant":
+			run = append(run, ordinalBlock{
+				ordinal: message.Ordinal,
+				text: fmt.Sprintf("[%d] ASSISTANT:\n%s",
+					message.Ordinal, content),
+			})
+		}
+	}
+	return packRun(run, s.MaxWindowChars, units)
+}
+
+type ordinalBlock struct {
+	ordinal int
+	text    string
+}
+
+// packRun appends action units built from consecutive assistant blocks,
+// starting a new unit whenever adding a block would exceed maxChars. Length
+// is counted in code points so the boundary decisions match regardless of
+// how the text is encoded.
+func packRun(blocks []ordinalBlock, maxChars int, units []Unit) []Unit {
+	var current []ordinalBlock
+	currentChars := 0
+	flush := func() {
+		if len(current) == 0 {
+			return
+		}
+		texts := make([]string, 0, len(current))
+		for _, block := range current {
+			texts = append(texts, block.text)
+		}
+		units = append(units, Unit{
+			Role:         RoleAction,
+			Text:         strings.Join(texts, "\n\n"),
+			OrdinalStart: current[0].ordinal,
+			OrdinalEnd:   current[len(current)-1].ordinal,
+		})
+	}
+	for _, block := range blocks {
+		blockChars := utf8.RuneCountInString(block.text)
+		if len(current) > 0 && currentChars+blockChars > maxChars {
+			flush()
+			current = nil
+			currentChars = 0
+		}
+		current = append(current, block)
+		currentChars += blockChars + 2
+	}
+	flush()
+	return units
+}

--- a/internal/recall/extract/segment_test.go
+++ b/internal/recall/extract/segment_test.go
@@ -1,0 +1,110 @@
+package extract
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+type goldenFixture struct {
+	MaxWindowChars int `json:"max_window_chars"`
+	Messages       []struct {
+		Ordinal  int    `json:"ordinal"`
+		Role     string `json:"role"`
+		Content  string `json:"content"`
+		IsSystem int    `json:"is_system"`
+	} `json:"messages"`
+	Units []struct {
+		Kind         string `json:"kind"`
+		Text         string `json:"text"`
+		OrdinalStart int    `json:"ordinal_start"`
+		OrdinalEnd   int    `json:"ordinal_end"`
+	} `json:"units"`
+}
+
+// TestTurnsV1GoldenParity asserts that the segmenter reproduces the pinned
+// golden units exactly. Resume cursors and entry identity both depend on this
+// determinism, so any divergence here is a correctness bug, not a style
+// choice.
+func TestTurnsV1GoldenParity(t *testing.T) {
+	raw, err := os.ReadFile("testdata/turnsv1_golden.json")
+	if err != nil {
+		t.Fatalf("reading golden fixtures: %v", err)
+	}
+	var fixtures map[string]goldenFixture
+	if err := json.Unmarshal(raw, &fixtures); err != nil {
+		t.Fatalf("parsing golden fixtures: %v", err)
+	}
+	if len(fixtures) == 0 {
+		t.Fatal("no fixtures found")
+	}
+	for name, fixture := range fixtures {
+		t.Run(name, func(t *testing.T) {
+			segmenter := TurnsV1{MaxWindowChars: fixture.MaxWindowChars}
+			messages := make([]Message, 0, len(fixture.Messages))
+			for _, m := range fixture.Messages {
+				messages = append(messages, Message{
+					Ordinal:  m.Ordinal,
+					Role:     m.Role,
+					Content:  m.Content,
+					IsSystem: m.IsSystem != 0,
+				})
+			}
+			units := segmenter.Units(messages)
+			if len(units) != len(fixture.Units) {
+				t.Fatalf("unit count = %d, want %d", len(units), len(fixture.Units))
+			}
+			for i, want := range fixture.Units {
+				got := units[i]
+				if string(got.Role) != roleForKind(t, want.Kind) {
+					t.Errorf("unit %d role = %q, want kind %q", i, got.Role, want.Kind)
+				}
+				if got.Text != want.Text {
+					t.Errorf("unit %d text mismatch:\ngot:  %q\nwant: %q", i, got.Text, want.Text)
+				}
+				if got.OrdinalStart != want.OrdinalStart || got.OrdinalEnd != want.OrdinalEnd {
+					t.Errorf("unit %d ordinals = (%d,%d), want (%d,%d)",
+						i, got.OrdinalStart, got.OrdinalEnd, want.OrdinalStart, want.OrdinalEnd)
+				}
+			}
+		})
+	}
+}
+
+func roleForKind(t *testing.T, kind string) string {
+	t.Helper()
+	switch kind {
+	case "intent":
+		return string(RoleIntent)
+	case "action_run":
+		return string(RoleAction)
+	default:
+		t.Fatalf("unknown fixture unit kind %q", kind)
+		return ""
+	}
+}
+
+func TestTurnsV1Identity(t *testing.T) {
+	segmenter := TurnsV1{MaxWindowChars: 50000}
+	if segmenter.Name() != "turns-v1" {
+		t.Errorf("Name() = %q, want turns-v1", segmenter.Name())
+	}
+	params := segmenter.Params()
+	if params["max_window_chars"] != 50000 {
+		t.Errorf("Params()[max_window_chars] = %v, want 50000", params["max_window_chars"])
+	}
+}
+
+func TestTurnsV1PromptRoles(t *testing.T) {
+	roles := TurnsV1{MaxWindowChars: 50000}.PromptRoles()
+	if len(roles) != 2 || roles[0] != RoleIntent || roles[1] != RoleAction {
+		t.Errorf("PromptRoles() = %v, want [intent action]", roles)
+	}
+}
+
+func TestTurnsV1EmptySession(t *testing.T) {
+	units := TurnsV1{MaxWindowChars: 50000}.Units(nil)
+	if len(units) != 0 {
+		t.Errorf("Units(nil) = %d units, want 0", len(units))
+	}
+}

--- a/internal/recall/extract/testdata/turnsv1_golden.json
+++ b/internal/recall/extract/testdata/turnsv1_golden.json
@@ -1,0 +1,265 @@
+{
+ "alternation": {
+  "max_window_chars": 100000,
+  "messages": [
+   {
+    "ordinal": 0,
+    "role": "user",
+    "content": "please fix the login bug",
+    "is_system": 0
+   },
+   {
+    "ordinal": 1,
+    "role": "assistant",
+    "content": "looking at auth.py",
+    "is_system": 0
+   },
+   {
+    "ordinal": 2,
+    "role": "assistant",
+    "content": "patched session timeout",
+    "is_system": 0
+   },
+   {
+    "ordinal": 3,
+    "role": "user",
+    "content": "now add a test",
+    "is_system": 0
+   },
+   {
+    "ordinal": 4,
+    "role": "assistant",
+    "content": "added test_login.py",
+    "is_system": 0
+   }
+  ],
+  "units": [
+   {
+    "kind": "intent",
+    "text": "USER MESSAGE (ordinal 0):\nplease fix the login bug",
+    "ordinal_start": 0,
+    "ordinal_end": 0
+   },
+   {
+    "kind": "action_run",
+    "text": "[1] ASSISTANT:\nlooking at auth.py\n\n[2] ASSISTANT:\npatched session timeout",
+    "ordinal_start": 1,
+    "ordinal_end": 2
+   },
+   {
+    "kind": "intent",
+    "text": "USER MESSAGE (ordinal 3):\nnow add a test",
+    "ordinal_start": 3,
+    "ordinal_end": 3
+   },
+   {
+    "kind": "action_run",
+    "text": "[4] ASSISTANT:\nadded test_login.py",
+    "ordinal_start": 4,
+    "ordinal_end": 4
+   }
+  ]
+ },
+ "system_and_empty_skips": {
+  "max_window_chars": 100000,
+  "messages": [
+   {
+    "ordinal": 0,
+    "role": "user",
+    "content": "injected reminder",
+    "is_system": 1
+   },
+   {
+    "ordinal": 1,
+    "role": "user",
+    "content": "real request",
+    "is_system": 0
+   },
+   {
+    "ordinal": 2,
+    "role": "assistant",
+    "content": "   ",
+    "is_system": 0
+   },
+   {
+    "ordinal": 3,
+    "role": "assistant",
+    "content": "did the work",
+    "is_system": 0
+   },
+   {
+    "ordinal": 4,
+    "role": "assistant",
+    "content": "system noise",
+    "is_system": 1
+   },
+   {
+    "ordinal": 5,
+    "role": "assistant",
+    "content": "more work",
+    "is_system": 0
+   }
+  ],
+  "units": [
+   {
+    "kind": "intent",
+    "text": "USER MESSAGE (ordinal 1):\nreal request",
+    "ordinal_start": 1,
+    "ordinal_end": 1
+   },
+   {
+    "kind": "action_run",
+    "text": "[3] ASSISTANT:\ndid the work\n\n[5] ASSISTANT:\nmore work",
+    "ordinal_start": 3,
+    "ordinal_end": 5
+   }
+  ]
+ },
+ "packing_and_oversize": {
+  "max_window_chars": 400,
+  "messages": [
+   {
+    "ordinal": 0,
+    "role": "user",
+    "content": "go",
+    "is_system": 0
+   },
+   {
+    "ordinal": 1,
+    "role": "assistant",
+    "content": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "is_system": 0
+   },
+   {
+    "ordinal": 2,
+    "role": "assistant",
+    "content": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "is_system": 0
+   },
+   {
+    "ordinal": 3,
+    "role": "assistant",
+    "content": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "is_system": 0
+   },
+   {
+    "ordinal": 4,
+    "role": "assistant",
+    "content": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "is_system": 0
+   }
+  ],
+  "units": [
+   {
+    "kind": "intent",
+    "text": "USER MESSAGE (ordinal 0):\ngo",
+    "ordinal_start": 0,
+    "ordinal_end": 0
+   },
+   {
+    "kind": "action_run",
+    "text": "[1] ASSISTANT:\naaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n\n[2] ASSISTANT:\nbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "ordinal_start": 1,
+    "ordinal_end": 2
+   },
+   {
+    "kind": "action_run",
+    "text": "[3] ASSISTANT:\ncccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "ordinal_start": 3,
+    "ordinal_end": 3
+   },
+   {
+    "kind": "action_run",
+    "text": "[4] ASSISTANT:\ndddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "ordinal_start": 4,
+    "ordinal_end": 4
+   }
+  ]
+ },
+ "leading_run_no_user": {
+  "max_window_chars": 100000,
+  "messages": [
+   {
+    "ordinal": 0,
+    "role": "assistant",
+    "content": "resumed work without a user turn",
+    "is_system": 0
+   },
+   {
+    "ordinal": 1,
+    "role": "user",
+    "content": "continue",
+    "is_system": 0
+   },
+   {
+    "ordinal": 2,
+    "role": "assistant",
+    "content": "done",
+    "is_system": 0
+   }
+  ],
+  "units": [
+   {
+    "kind": "action_run",
+    "text": "[0] ASSISTANT:\nresumed work without a user turn",
+    "ordinal_start": 0,
+    "ordinal_end": 0
+   },
+   {
+    "kind": "intent",
+    "text": "USER MESSAGE (ordinal 1):\ncontinue",
+    "ordinal_start": 1,
+    "ordinal_end": 1
+   },
+   {
+    "kind": "action_run",
+    "text": "[2] ASSISTANT:\ndone",
+    "ordinal_start": 2,
+    "ordinal_end": 2
+   }
+  ]
+ },
+ "unicode_content": {
+  "max_window_chars": 60,
+  "messages": [
+   {
+    "ordinal": 0,
+    "role": "user",
+    "content": "héllo wörld — fix the café bug",
+    "is_system": 0
+   },
+   {
+    "ordinal": 1,
+    "role": "assistant",
+    "content": "cafécafécafécafécafécafécafécafécafécafécafécafé",
+    "is_system": 0
+   },
+   {
+    "ordinal": 2,
+    "role": "assistant",
+    "content": "naïvenaïvenaïvenaïvenaïvenaïvenaïvenaïvenaïvenaïvenaïvenaïve",
+    "is_system": 0
+   }
+  ],
+  "units": [
+   {
+    "kind": "intent",
+    "text": "USER MESSAGE (ordinal 0):\nhéllo wörld — fix the café bug",
+    "ordinal_start": 0,
+    "ordinal_end": 0
+   },
+   {
+    "kind": "action_run",
+    "text": "[1] ASSISTANT:\ncafécafécafécafécafécafécafécafécafécafécafécafé",
+    "ordinal_start": 1,
+    "ordinal_end": 1
+   },
+   {
+    "kind": "action_run",
+    "text": "[2] ASSISTANT:\nnaïvenaïvenaïvenaïvenaïvenaïvenaïvenaïvenaïvenaïvenaïvenaïve",
+    "ordinal_start": 2,
+    "ordinal_end": 2
+   }
+  ]
+ }
+}


### PR DESCRIPTION
The recall subsystem stores typed, provenance-backed entries, but nothing in the binary produces them from the session archive yet — `recall extract` is a dry-run preview, and the LLM-backed Insights feature has drifted down the page. The natural next step is to distill finished sessions into recall entries automatically; this PR adds the first piece of that pipeline.

`internal/recall/extract` introduces `Segmenter`: a strategy that deterministically derives distillation units (one model call each) from a session transcript. Determinism is the load-bearing contract — resume cursors index into the unit list and entry identity embeds the unit index, so replaying a session after a daemon restart or upgrade must yield identical units. A segmenter's name and parameters identify its output, letting alternative strategies build separate, comparable corpora instead of mixing.

`TurnsV1` is the first strategy: each non-system user message becomes an `intent` unit; runs of assistant messages between user turns are packed into `action` units within a code-point budget; every unit carries the message-ordinal range it covers as evidence provenance. Strategies declare their prompt roles, so a later size-based strategy can run with a single generic prompt.

Golden fixtures pin the segmentation output. The parity suite covers turn alternation, system and empty-message skips, packing and oversized messages, sessions that open mid-assistant-run, and non-ASCII budget counting (budgets count code points, not bytes).

No behavior change: nothing calls the package yet. Follow-ups add the progress/watermark store, the extraction manager, and the model/prompt configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)