### PR TITLE
feat(recall): extraction generation store, client, and prompt profiles

### DIFF
--- a/internal/db/recall.go
+++ b/internal/db/recall.go
@@ -234,6 +234,9 @@ func (db *DB) CopyRecallEntriesFrom(sourcePath string) error {
 	if err := copyRecallQueryEventsFromAttachedTx(ctx, tx); err != nil {
 		return err
 	}
+	if err := copyRecallExtractStateFromAttachedTx(ctx, tx); err != nil {
+		return err
+	}
 
 	res, err := tx.ExecContext(ctx, `
 		INSERT OR IGNORE INTO recall_entries (

--- a/internal/db/recall_extract.go
+++ b/internal/db/recall_extract.go
@@ -387,13 +387,24 @@ func (db *DB) AdvanceExtractCursor(
 	)
 }
 
+// ExtractFailure identifies the exact progress state a worker observed
+// when it failed, so a stale worker cannot demote fresher state.
+type ExtractFailure struct {
+	SessionID      string
+	Fingerprint    string
+	ExpectedDigest string
+	ExpectedCursor int
+	LastError      string
+}
+
 // MarkExtractProgressFailed records a failure without losing the resume
 // point: the cursor stays where it was so a retry continues, not restarts.
-// A row that already reached done is left untouched: the failure comes from
-// a worker that raced completion, not from the completed extraction.
+// The update applies only when the stored digest, cursor, and non-done
+// state all match what the failing worker observed; anything else means
+// another worker moved the row on, and the failure is reported as
+// ErrStaleExtractProgress instead of demoting newer progress.
 func (db *DB) MarkExtractProgressFailed(
-	ctx context.Context,
-	sessionID, fingerprint, expectedDigest, lastError string,
+	ctx context.Context, failure ExtractFailure,
 ) error {
 	if err := db.requireWritable(); err != nil {
 		return err
@@ -409,45 +420,56 @@ func (db *DB) MarkExtractProgressFailed(
 			updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
 		WHERE session_id = ? AND generation_fingerprint = ?
 		  AND content_digest = ?
+		  AND unit_cursor = ?
 		  AND state != ?`,
-		ExtractProgressFailed, lastError, sessionID, fingerprint,
-		expectedDigest, ExtractProgressDone,
+		ExtractProgressFailed, failure.LastError,
+		failure.SessionID, failure.Fingerprint,
+		failure.ExpectedDigest, failure.ExpectedCursor,
+		ExtractProgressDone,
 	)
 	if err != nil {
 		return fmt.Errorf(
 			"marking extract progress failed for session %s: %w",
-			sessionID, err,
+			failure.SessionID, err,
 		)
 	}
 	affected, err := result.RowsAffected()
 	if err != nil {
 		return fmt.Errorf(
 			"marking extract progress failed for session %s: %w",
-			sessionID, err,
+			failure.SessionID, err,
 		)
 	}
 	if affected > 0 {
 		return nil
 	}
-	progress, ok, err := db.ExtractProgress(ctx, sessionID, fingerprint)
+	progress, ok, err := db.ExtractProgress(
+		ctx, failure.SessionID, failure.Fingerprint,
+	)
 	if err != nil {
 		return err
 	}
 	if !ok {
 		return fmt.Errorf(
 			"no extract progress row for session %s under generation %s",
-			sessionID, fingerprint,
+			failure.SessionID, failure.Fingerprint,
 		)
 	}
 	if progress.State == ExtractProgressDone {
 		return fmt.Errorf(
 			"session %s is already done under generation %s: %w",
-			sessionID, fingerprint, ErrStaleExtractProgress,
+			failure.SessionID, failure.Fingerprint, ErrStaleExtractProgress,
+		)
+	}
+	if progress.ContentDigest != failure.ExpectedDigest {
+		return fmt.Errorf(
+			"failing session %s past digest change: %w",
+			failure.SessionID, ErrStaleExtractProgress,
 		)
 	}
 	return fmt.Errorf(
-		"failing session %s past digest change: %w",
-		sessionID, ErrStaleExtractProgress,
+		"failing session %s behind cursor %d: %w",
+		failure.SessionID, progress.UnitCursor, ErrStaleExtractProgress,
 	)
 }
 

--- a/internal/db/recall_extract.go
+++ b/internal/db/recall_extract.go
@@ -1,0 +1,480 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Extraction generation states. A generation is one distillation
+// configuration's corpus; at most one is active at a time.
+const (
+	ExtractGenerationBuilding = "building"
+	ExtractGenerationActive   = "active"
+	ExtractGenerationRetired  = "retired"
+)
+
+// Extraction progress states for one (session, generation) pair.
+const (
+	ExtractProgressPending = "pending"
+	ExtractProgressPartial = "partial"
+	ExtractProgressDone    = "done"
+	ExtractProgressFailed  = "failed"
+)
+
+// ErrStaleExtractProgress reports a cursor or failure update that no longer
+// matches the stored row: the session's content digest changed (the row was
+// reset for re-extraction) or the cursor would regress. Workers treat it as
+// "re-read the row and re-derive units", never as data loss.
+var ErrStaleExtractProgress = errors.New("extract progress is stale")
+
+// ExtractGeneration is one row of the extraction generation registry.
+type ExtractGeneration struct {
+	Fingerprint string `json:"fingerprint"`
+	State       string `json:"state"`
+	Model       string `json:"model"`
+	Segmenter   string `json:"segmenter"`
+	ParamsJSON  string `json:"params_json"`
+	CreatedAt   string `json:"created_at"`
+	UpdatedAt   string `json:"updated_at"`
+}
+
+// ExtractProgress is the resume state for one session under one generation.
+// UnitCursor counts completed units of the session's deterministic unit
+// list; a restart resumes at the cursor instead of re-extracting.
+type ExtractProgress struct {
+	SessionID             string `json:"session_id"`
+	GenerationFingerprint string `json:"generation_fingerprint"`
+	UnitCursor            int    `json:"unit_cursor"`
+	UnitsTotal            int    `json:"units_total"`
+	State                 string `json:"state"`
+	ContentDigest         string `json:"content_digest"`
+	LastError             string `json:"last_error,omitempty"`
+	UpdatedAt             string `json:"updated_at"`
+}
+
+// EnsureExtractGeneration registers a generation if its fingerprint is new
+// and returns the stored row. An existing fingerprint wins: the caller's
+// metadata is ignored so a re-registration can never mutate a corpus's
+// recorded identity.
+func (db *DB) EnsureExtractGeneration(
+	ctx context.Context, gen ExtractGeneration,
+) (ExtractGeneration, error) {
+	var zero ExtractGeneration
+	if err := db.requireWritable(); err != nil {
+		return zero, err
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	gen.Fingerprint = strings.TrimSpace(gen.Fingerprint)
+	if gen.Fingerprint == "" {
+		return zero, fmt.Errorf("extract generation fingerprint is required")
+	}
+	if strings.TrimSpace(gen.Model) == "" {
+		return zero, fmt.Errorf("extract generation model is required")
+	}
+	if strings.TrimSpace(gen.Segmenter) == "" {
+		return zero, fmt.Errorf("extract generation segmenter is required")
+	}
+	if gen.ParamsJSON == "" {
+		gen.ParamsJSON = "{}"
+	}
+	_, err := db.getWriter().ExecContext(ctx, `
+		INSERT INTO recall_extract_generations
+			(fingerprint, state, model, segmenter, params_json)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(fingerprint) DO NOTHING`,
+		gen.Fingerprint, ExtractGenerationBuilding,
+		gen.Model, gen.Segmenter, gen.ParamsJSON,
+	)
+	if err != nil {
+		return zero, fmt.Errorf(
+			"registering extract generation %s: %w", gen.Fingerprint, err,
+		)
+	}
+	return db.extractGenerationByFingerprint(ctx, gen.Fingerprint)
+}
+
+// ExtractGenerations lists all registered generations, newest first.
+func (db *DB) ExtractGenerations(
+	ctx context.Context,
+) ([]ExtractGeneration, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	rows, err := db.getReader().QueryContext(ctx, `
+		SELECT fingerprint, state, model, segmenter, params_json,
+		       created_at, updated_at
+		FROM recall_extract_generations
+		ORDER BY created_at DESC, fingerprint`)
+	if err != nil {
+		return nil, fmt.Errorf("listing extract generations: %w", err)
+	}
+	defer rows.Close()
+	var generations []ExtractGeneration
+	for rows.Next() {
+		var gen ExtractGeneration
+		if err := rows.Scan(
+			&gen.Fingerprint, &gen.State, &gen.Model, &gen.Segmenter,
+			&gen.ParamsJSON, &gen.CreatedAt, &gen.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scanning extract generation: %w", err)
+		}
+		generations = append(generations, gen)
+	}
+	return generations, rows.Err()
+}
+
+// ActivateExtractGeneration makes the identified generation active and
+// retires whichever generation was previously active, in one transaction so
+// two generations can never be active simultaneously.
+func (db *DB) ActivateExtractGeneration(
+	ctx context.Context, fingerprint string,
+) error {
+	if err := db.requireWritable(); err != nil {
+		return err
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	tx, err := db.getWriter().BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("beginning generation activation: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	result, err := tx.ExecContext(ctx, `
+		UPDATE recall_extract_generations
+		SET state = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+		WHERE fingerprint = ?`,
+		ExtractGenerationActive, fingerprint,
+	)
+	if err != nil {
+		return fmt.Errorf("activating generation %s: %w", fingerprint, err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("activating generation %s: %w", fingerprint, err)
+	}
+	if affected == 0 {
+		return fmt.Errorf("extract generation %s not found", fingerprint)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE recall_extract_generations
+		SET state = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+		WHERE state = ? AND fingerprint != ?`,
+		ExtractGenerationRetired, ExtractGenerationActive, fingerprint,
+	); err != nil {
+		return fmt.Errorf("retiring previous active generation: %w", err)
+	}
+	return tx.Commit()
+}
+
+// RetireExtractGeneration retires a generation. Retiring the active
+// generation is refused without force, because it leaves recall with no
+// machine-distilled corpus to serve.
+func (db *DB) RetireExtractGeneration(
+	ctx context.Context, fingerprint string, force bool,
+) error {
+	if err := db.requireWritable(); err != nil {
+		return err
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	// One conditional statement so the active-state check and the state
+	// change cannot interleave with a concurrent activation.
+	result, err := db.getWriter().ExecContext(ctx, `
+		UPDATE recall_extract_generations
+		SET state = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+		WHERE fingerprint = ? AND (? OR state != ?)`,
+		ExtractGenerationRetired, fingerprint, force, ExtractGenerationActive,
+	)
+	if err != nil {
+		return fmt.Errorf("retiring generation %s: %w", fingerprint, err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("retiring generation %s: %w", fingerprint, err)
+	}
+	if affected > 0 {
+		return nil
+	}
+	if _, err := db.extractGenerationByFingerprint(ctx, fingerprint); err != nil {
+		return err
+	}
+	return fmt.Errorf(
+		"generation %s is active; retiring it leaves no distilled corpus "+
+			"to serve (use force to retire anyway)", fingerprint,
+	)
+}
+
+func (db *DB) extractGenerationByFingerprint(
+	ctx context.Context, fingerprint string,
+) (ExtractGeneration, error) {
+	var gen ExtractGeneration
+	err := db.getReader().QueryRowContext(ctx, `
+		SELECT fingerprint, state, model, segmenter, params_json,
+		       created_at, updated_at
+		FROM recall_extract_generations
+		WHERE fingerprint = ?`, fingerprint,
+	).Scan(
+		&gen.Fingerprint, &gen.State, &gen.Model, &gen.Segmenter,
+		&gen.ParamsJSON, &gen.CreatedAt, &gen.UpdatedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return gen, fmt.Errorf("extract generation %s not found", fingerprint)
+	}
+	if err != nil {
+		return gen, fmt.Errorf("reading generation %s: %w", fingerprint, err)
+	}
+	return gen, nil
+}
+
+// UpsertExtractProgress ensures a progress row exists for the session under
+// the generation. A matching content digest keeps existing progress; a
+// changed digest resets the row to pending at cursor zero so the grown
+// session is re-segmented and topped up.
+func (db *DB) UpsertExtractProgress(
+	ctx context.Context,
+	sessionID, fingerprint, contentDigest string,
+	unitsTotal int,
+) (ExtractProgress, error) {
+	var zero ExtractProgress
+	if err := db.requireWritable(); err != nil {
+		return zero, err
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	_, err := db.getWriter().ExecContext(ctx, `
+		INSERT INTO recall_extract_progress
+			(session_id, generation_fingerprint, unit_cursor, units_total,
+			 state, content_digest)
+		VALUES (?, ?, 0, ?, ?, ?)
+		ON CONFLICT(session_id, generation_fingerprint) DO UPDATE SET
+			unit_cursor = CASE
+				WHEN recall_extract_progress.content_digest = excluded.content_digest
+				THEN recall_extract_progress.unit_cursor ELSE 0 END,
+			units_total = CASE
+				WHEN recall_extract_progress.content_digest = excluded.content_digest
+				THEN recall_extract_progress.units_total ELSE excluded.units_total END,
+			state = CASE
+				WHEN recall_extract_progress.content_digest = excluded.content_digest
+				THEN recall_extract_progress.state ELSE ? END,
+			content_digest = excluded.content_digest,
+			last_error = CASE
+				WHEN recall_extract_progress.content_digest = excluded.content_digest
+				THEN recall_extract_progress.last_error ELSE '' END,
+			updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')`,
+		sessionID, fingerprint, unitsTotal, ExtractProgressPending,
+		contentDigest, ExtractProgressPending,
+	)
+	if err != nil {
+		return zero, fmt.Errorf(
+			"upserting extract progress for session %s: %w", sessionID, err,
+		)
+	}
+	progress, ok, err := db.ExtractProgress(ctx, sessionID, fingerprint)
+	if err != nil {
+		return zero, err
+	}
+	if !ok {
+		return zero, fmt.Errorf(
+			"extract progress for session %s vanished after upsert", sessionID,
+		)
+	}
+	return progress, nil
+}
+
+// AdvanceExtractCursor records that units before cursor are complete,
+// marking the row done when the cursor reaches the unit total. The update
+// only applies when expectedDigest still matches the row and the cursor
+// moves forward within bounds, so a worker that raced a digest reset gets
+// ErrStaleExtractProgress instead of overwriting fresh state.
+func (db *DB) AdvanceExtractCursor(
+	ctx context.Context,
+	sessionID, fingerprint, expectedDigest string,
+	cursor int,
+) error {
+	if err := db.requireWritable(); err != nil {
+		return err
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	result, err := db.getWriter().ExecContext(ctx, `
+		UPDATE recall_extract_progress
+		SET unit_cursor = ?,
+			state = CASE WHEN ? >= units_total THEN ? ELSE ? END,
+			last_error = '',
+			updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+		WHERE session_id = ? AND generation_fingerprint = ?
+		  AND content_digest = ?
+		  AND unit_cursor <= ?
+		  AND ? <= units_total`,
+		cursor, cursor, ExtractProgressDone, ExtractProgressPartial,
+		sessionID, fingerprint, expectedDigest, cursor, cursor,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"advancing extract cursor for session %s: %w", sessionID, err,
+		)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf(
+			"advancing extract cursor for session %s: %w", sessionID, err,
+		)
+	}
+	if affected > 0 {
+		return nil
+	}
+	progress, ok, err := db.ExtractProgress(ctx, sessionID, fingerprint)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf(
+			"no extract progress row for session %s under generation %s",
+			sessionID, fingerprint,
+		)
+	}
+	if cursor > progress.UnitsTotal {
+		return fmt.Errorf(
+			"cursor %d exceeds %d units for session %s",
+			cursor, progress.UnitsTotal, sessionID,
+		)
+	}
+	return fmt.Errorf(
+		"advancing session %s past digest change or cursor regression: %w",
+		sessionID, ErrStaleExtractProgress,
+	)
+}
+
+// MarkExtractProgressFailed records a failure without losing the resume
+// point: the cursor stays where it was so a retry continues, not restarts.
+func (db *DB) MarkExtractProgressFailed(
+	ctx context.Context,
+	sessionID, fingerprint, expectedDigest, lastError string,
+) error {
+	if err := db.requireWritable(); err != nil {
+		return err
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	result, err := db.getWriter().ExecContext(ctx, `
+		UPDATE recall_extract_progress
+		SET state = ?, last_error = ?,
+			updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+		WHERE session_id = ? AND generation_fingerprint = ?
+		  AND content_digest = ?`,
+		ExtractProgressFailed, lastError, sessionID, fingerprint,
+		expectedDigest,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"marking extract progress failed for session %s: %w",
+			sessionID, err,
+		)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf(
+			"marking extract progress failed for session %s: %w",
+			sessionID, err,
+		)
+	}
+	if affected == 0 {
+		return fmt.Errorf(
+			"failing session %s past digest change: %w",
+			sessionID, ErrStaleExtractProgress,
+		)
+	}
+	return nil
+}
+
+// ExtractProgress reads the progress row for one session and generation.
+func (db *DB) ExtractProgress(
+	ctx context.Context, sessionID, fingerprint string,
+) (ExtractProgress, bool, error) {
+	var progress ExtractProgress
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	err := db.getReader().QueryRowContext(ctx, `
+		SELECT session_id, generation_fingerprint, unit_cursor, units_total,
+		       state, content_digest, last_error, updated_at
+		FROM recall_extract_progress
+		WHERE session_id = ? AND generation_fingerprint = ?`,
+		sessionID, fingerprint,
+	).Scan(
+		&progress.SessionID, &progress.GenerationFingerprint,
+		&progress.UnitCursor, &progress.UnitsTotal, &progress.State,
+		&progress.ContentDigest, &progress.LastError, &progress.UpdatedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return progress, false, nil
+	}
+	if err != nil {
+		return progress, false, fmt.Errorf(
+			"reading extract progress for session %s: %w", sessionID, err,
+		)
+	}
+	return progress, true, nil
+}
+
+// copyRecallExtractStateFromAttachedTx carries the extraction generation
+// registry and per-session resume cursors across a full resync. Without it a
+// rebuild silently discards the active generation and every cursor, forcing
+// a full re-extraction. Progress rows are filtered to sessions present in
+// the rebuilt DB, mirroring the entry copy. Archives written by releases
+// without these tables are tolerated.
+func copyRecallExtractStateFromAttachedTx(
+	ctx context.Context, tx *sql.Tx,
+) error {
+	generationsExist, err := attachedRecallTableExistsTx(
+		ctx, tx, "recall_extract_generations",
+	)
+	if err != nil {
+		return err
+	}
+	if !generationsExist {
+		return nil
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT OR IGNORE INTO recall_extract_generations (
+			fingerprint, state, model, segmenter, params_json,
+			created_at, updated_at
+		)
+		SELECT fingerprint, state, model, segmenter, params_json,
+		       created_at, updated_at
+		FROM old_db.recall_extract_generations`); err != nil {
+		return fmt.Errorf("copying extract generations: %w", err)
+	}
+	progressExists, err := attachedRecallTableExistsTx(
+		ctx, tx, "recall_extract_progress",
+	)
+	if err != nil {
+		return err
+	}
+	if !progressExists {
+		return nil
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT OR IGNORE INTO recall_extract_progress (
+			session_id, generation_fingerprint, unit_cursor, units_total,
+			state, content_digest, last_error, updated_at
+		)
+		SELECT session_id, generation_fingerprint, unit_cursor, units_total,
+		       state, content_digest, last_error, updated_at
+		FROM old_db.recall_extract_progress
+		WHERE session_id IN (SELECT id FROM main.sessions)`); err != nil {
+		return fmt.Errorf("copying extract progress: %w", err)
+	}
+	return nil
+}

--- a/internal/db/recall_extract.go
+++ b/internal/db/recall_extract.go
@@ -365,6 +365,16 @@ func (db *DB) AdvanceExtractCursor(
 			sessionID, fingerprint,
 		)
 	}
+	// Digest mismatch outranks the bounds check: after a reset to fewer
+	// units a stale worker's cursor may exceed the new total, and it must
+	// still get the typed stale error that tells it to re-read the row and
+	// re-derive units.
+	if progress.ContentDigest != expectedDigest {
+		return fmt.Errorf(
+			"advancing session %s past digest change: %w",
+			sessionID, ErrStaleExtractProgress,
+		)
+	}
 	if cursor > progress.UnitsTotal {
 		return fmt.Errorf(
 			"cursor %d exceeds %d units for session %s",
@@ -372,7 +382,7 @@ func (db *DB) AdvanceExtractCursor(
 		)
 	}
 	return fmt.Errorf(
-		"advancing session %s past digest change or cursor regression: %w",
+		"advancing session %s past cursor regression: %w",
 		sessionID, ErrStaleExtractProgress,
 	)
 }

--- a/internal/db/recall_extract.go
+++ b/internal/db/recall_extract.go
@@ -313,8 +313,11 @@ func (db *DB) UpsertExtractProgress(
 // AdvanceExtractCursor records that units before cursor are complete,
 // marking the row done when the cursor reaches the unit total. The update
 // only applies when expectedDigest still matches the row and the cursor
-// moves forward within bounds, so a worker that raced a digest reset gets
-// ErrStaleExtractProgress instead of overwriting fresh state.
+// strictly advances within bounds, so a worker that raced a digest reset
+// gets ErrStaleExtractProgress instead of overwriting fresh state. A
+// replay of an already-recorded cursor is an accepted no-op: it completed
+// nothing new, so it must not touch the row's state or error — in
+// particular it cannot resurrect a failed row.
 func (db *DB) AdvanceExtractCursor(
 	ctx context.Context,
 	sessionID, fingerprint, expectedDigest string,
@@ -336,7 +339,7 @@ func (db *DB) AdvanceExtractCursor(
 			updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
 		WHERE session_id = ? AND generation_fingerprint = ?
 		  AND content_digest = ?
-		  AND unit_cursor <= ?
+		  AND unit_cursor < ?
 		  AND ? <= units_total`,
 		cursor, cursor, ExtractProgressDone, ExtractProgressPartial,
 		sessionID, fingerprint, expectedDigest, cursor, cursor,
@@ -380,6 +383,9 @@ func (db *DB) AdvanceExtractCursor(
 			"cursor %d exceeds %d units for session %s",
 			cursor, progress.UnitsTotal, sessionID,
 		)
+	}
+	if cursor == progress.UnitCursor {
+		return nil
 	}
 	return fmt.Errorf(
 		"advancing session %s past cursor regression: %w",

--- a/internal/db/recall_extract.go
+++ b/internal/db/recall_extract.go
@@ -66,6 +66,8 @@ func (db *DB) EnsureExtractGeneration(
 	if err := db.requireWritable(); err != nil {
 		return zero, err
 	}
+	db.mu.Lock()
+	defer db.mu.Unlock()
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -137,6 +139,8 @@ func (db *DB) ActivateExtractGeneration(
 	if err := db.requireWritable(); err != nil {
 		return err
 	}
+	db.mu.Lock()
+	defer db.mu.Unlock()
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -182,6 +186,8 @@ func (db *DB) RetireExtractGeneration(
 	if err := db.requireWritable(); err != nil {
 		return err
 	}
+	db.mu.Lock()
+	defer db.mu.Unlock()
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -247,6 +253,8 @@ func (db *DB) UpsertExtractProgress(
 	if err := db.requireWritable(); err != nil {
 		return zero, err
 	}
+	db.mu.Lock()
+	defer db.mu.Unlock()
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -303,6 +311,8 @@ func (db *DB) AdvanceExtractCursor(
 	if err := db.requireWritable(); err != nil {
 		return err
 	}
+	db.mu.Lock()
+	defer db.mu.Unlock()
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -357,6 +367,8 @@ func (db *DB) AdvanceExtractCursor(
 
 // MarkExtractProgressFailed records a failure without losing the resume
 // point: the cursor stays where it was so a retry continues, not restarts.
+// A row that already reached done is left untouched: the failure comes from
+// a worker that raced completion, not from the completed extraction.
 func (db *DB) MarkExtractProgressFailed(
 	ctx context.Context,
 	sessionID, fingerprint, expectedDigest, lastError string,
@@ -364,6 +376,8 @@ func (db *DB) MarkExtractProgressFailed(
 	if err := db.requireWritable(); err != nil {
 		return err
 	}
+	db.mu.Lock()
+	defer db.mu.Unlock()
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -372,9 +386,10 @@ func (db *DB) MarkExtractProgressFailed(
 		SET state = ?, last_error = ?,
 			updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
 		WHERE session_id = ? AND generation_fingerprint = ?
-		  AND content_digest = ?`,
+		  AND content_digest = ?
+		  AND state != ?`,
 		ExtractProgressFailed, lastError, sessionID, fingerprint,
-		expectedDigest,
+		expectedDigest, ExtractProgressDone,
 	)
 	if err != nil {
 		return fmt.Errorf(
@@ -389,13 +404,29 @@ func (db *DB) MarkExtractProgressFailed(
 			sessionID, err,
 		)
 	}
-	if affected == 0 {
+	if affected > 0 {
+		return nil
+	}
+	progress, ok, err := db.ExtractProgress(ctx, sessionID, fingerprint)
+	if err != nil {
+		return err
+	}
+	if !ok {
 		return fmt.Errorf(
-			"failing session %s past digest change: %w",
-			sessionID, ErrStaleExtractProgress,
+			"no extract progress row for session %s under generation %s",
+			sessionID, fingerprint,
 		)
 	}
-	return nil
+	if progress.State == ExtractProgressDone {
+		return fmt.Errorf(
+			"session %s is already done under generation %s: %w",
+			sessionID, fingerprint, ErrStaleExtractProgress,
+		)
+	}
+	return fmt.Errorf(
+		"failing session %s past digest change: %w",
+		sessionID, ErrStaleExtractProgress,
+	)
 }
 
 // ExtractProgress reads the progress row for one session and generation.

--- a/internal/db/recall_extract.go
+++ b/internal/db/recall_extract.go
@@ -243,7 +243,9 @@ func (db *DB) extractGenerationByFingerprint(
 // UpsertExtractProgress ensures a progress row exists for the session under
 // the generation. A matching content digest keeps existing progress; a
 // changed digest resets the row to pending at cursor zero so the grown
-// session is re-segmented and topped up.
+// session is re-segmented and topped up. A session with zero units has
+// nothing to extract, so its row lands directly in done — no worker will
+// ever advance a cursor over an empty unit list.
 func (db *DB) UpsertExtractProgress(
 	ctx context.Context,
 	sessionID, fingerprint, contentDigest string,
@@ -253,10 +255,20 @@ func (db *DB) UpsertExtractProgress(
 	if err := db.requireWritable(); err != nil {
 		return zero, err
 	}
+	if unitsTotal < 0 {
+		return zero, fmt.Errorf(
+			"units total %d for session %s must not be negative",
+			unitsTotal, sessionID,
+		)
+	}
 	db.mu.Lock()
 	defer db.mu.Unlock()
 	if ctx == nil {
 		ctx = context.Background()
+	}
+	initialState := ExtractProgressPending
+	if unitsTotal == 0 {
+		initialState = ExtractProgressDone
 	}
 	_, err := db.getWriter().ExecContext(ctx, `
 		INSERT INTO recall_extract_progress
@@ -278,8 +290,8 @@ func (db *DB) UpsertExtractProgress(
 				WHEN recall_extract_progress.content_digest = excluded.content_digest
 				THEN recall_extract_progress.last_error ELSE '' END,
 			updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')`,
-		sessionID, fingerprint, unitsTotal, ExtractProgressPending,
-		contentDigest, ExtractProgressPending,
+		sessionID, fingerprint, unitsTotal, initialState,
+		contentDigest, initialState,
 	)
 	if err != nil {
 		return zero, fmt.Errorf(

--- a/internal/db/recall_extract_test.go
+++ b/internal/db/recall_extract_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -305,4 +306,82 @@ func TestCopyRecallEntriesFromToleratesSourceWithoutExtractTables(t *testing.T) 
 	dst := testDB(t)
 	require.NoError(t, dst.CopyRecallEntriesFrom(srcPath),
 		"archives from releases without extraction tables must still resync")
+}
+
+func TestMarkExtractProgressFailedRejectsDoneRow(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	seedExtractSession(t, d, "sess-1")
+	_, err := d.EnsureExtractGeneration(ctx, ExtractGeneration{
+		Fingerprint: "fp-a", Model: "m", Segmenter: "turns-v1",
+	})
+	require.NoError(t, err)
+	_, err = d.UpsertExtractProgress(ctx, "sess-1", "fp-a", "digest-1", 2)
+	require.NoError(t, err)
+	require.NoError(t, d.AdvanceExtractCursor(ctx, "sess-1", "fp-a", "digest-1", 2))
+
+	err = d.MarkExtractProgressFailed(ctx, "sess-1", "fp-a", "digest-1", "late worker")
+	require.ErrorIs(t, err, ErrStaleExtractProgress,
+		"a completed row must not be demoted to failed")
+
+	progress, _, err := d.ExtractProgress(ctx, "sess-1", "fp-a")
+	require.NoError(t, err)
+	assert.Equal(t, ExtractProgressDone, progress.State)
+	assert.Equal(t, 2, progress.UnitCursor)
+	assert.Empty(t, progress.LastError)
+}
+
+func TestExtractMutationsWaitForDBMutex(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	seedExtractSession(t, d, "sess-1")
+	_, err := d.EnsureExtractGeneration(ctx, ExtractGeneration{
+		Fingerprint: "fp-a", Model: "m", Segmenter: "turns-v1",
+	})
+	require.NoError(t, err)
+	_, err = d.UpsertExtractProgress(ctx, "sess-1", "fp-a", "digest-1", 2)
+	require.NoError(t, err)
+
+	// Every mutation below is valid regardless of the order the map yields
+	// them in: the progress row exists with digest-1 and never reaches done.
+	mutations := map[string]func() error{
+		"EnsureExtractGeneration": func() error {
+			_, err := d.EnsureExtractGeneration(ctx, ExtractGeneration{
+				Fingerprint: "fp-b", Model: "m", Segmenter: "turns-v1",
+			})
+			return err
+		},
+		"ActivateExtractGeneration": func() error {
+			return d.ActivateExtractGeneration(ctx, "fp-a")
+		},
+		"RetireExtractGeneration": func() error {
+			return d.RetireExtractGeneration(ctx, "fp-a", true)
+		},
+		"UpsertExtractProgress": func() error {
+			_, err := d.UpsertExtractProgress(ctx, "sess-1", "fp-a", "digest-1", 2)
+			return err
+		},
+		"AdvanceExtractCursor": func() error {
+			return d.AdvanceExtractCursor(ctx, "sess-1", "fp-a", "digest-1", 1)
+		},
+		"MarkExtractProgressFailed": func() error {
+			return d.MarkExtractProgressFailed(ctx, "sess-1", "fp-a", "digest-1", "x")
+		},
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			d.mu.Lock()
+			done := make(chan error, 1)
+			go func() { done <- mutate() }()
+			select {
+			case <-done:
+				d.mu.Unlock()
+				t.Fatal("mutation completed while db.mu was held; " +
+					"CloseConnections relies on db.mu to quiesce writes")
+			case <-time.After(100 * time.Millisecond):
+			}
+			d.mu.Unlock()
+			require.NoError(t, <-done)
+		})
+	}
 }

--- a/internal/db/recall_extract_test.go
+++ b/internal/db/recall_extract_test.go
@@ -385,3 +385,27 @@ func TestExtractMutationsWaitForDBMutex(t *testing.T) {
 		})
 	}
 }
+
+func TestUpsertExtractProgressZeroUnitsCompletesImmediately(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	seedExtractSession(t, d, "sess-1")
+	_, err := d.EnsureExtractGeneration(ctx, ExtractGeneration{
+		Fingerprint: "fp-a", Model: "m", Segmenter: "turns-v1",
+	})
+	require.NoError(t, err)
+
+	progress, err := d.UpsertExtractProgress(ctx, "sess-1", "fp-a", "digest-1", 0)
+	require.NoError(t, err)
+	assert.Equal(t, ExtractProgressDone, progress.State,
+		"a session with no units has nothing left to extract")
+	assert.Equal(t, 0, progress.UnitCursor)
+
+	progress, err = d.UpsertExtractProgress(ctx, "sess-1", "fp-a", "digest-2", 0)
+	require.NoError(t, err)
+	assert.Equal(t, ExtractProgressDone, progress.State,
+		"a digest reset to zero units must also complete immediately")
+
+	_, err = d.UpsertExtractProgress(ctx, "sess-1", "fp-a", "digest-3", -1)
+	require.Error(t, err, "negative unit totals must be refused")
+}

--- a/internal/db/recall_extract_test.go
+++ b/internal/db/recall_extract_test.go
@@ -159,9 +159,13 @@ func TestExtractProgressFailureKeepsCursor(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, d.AdvanceExtractCursor(ctx, "sess-1", "fp-a", "digest-1", 2))
 
-	require.NoError(t, d.MarkExtractProgressFailed(
-		ctx, "sess-1", "fp-a", "digest-1", "endpoint unreachable",
-	))
+	require.NoError(t, d.MarkExtractProgressFailed(ctx, ExtractFailure{
+		SessionID:      "sess-1",
+		Fingerprint:    "fp-a",
+		ExpectedDigest: "digest-1",
+		ExpectedCursor: 2,
+		LastError:      "endpoint unreachable",
+	}))
 	progress, ok, err := d.ExtractProgress(ctx, "sess-1", "fp-a")
 	require.NoError(t, err)
 	require.True(t, ok)
@@ -237,7 +241,12 @@ func TestMarkExtractProgressFailedRejectsStaleDigest(t *testing.T) {
 	_, err = d.UpsertExtractProgress(ctx, "sess-1", "fp-a", "digest-2", 6)
 	require.NoError(t, err)
 
-	err = d.MarkExtractProgressFailed(ctx, "sess-1", "fp-a", "digest-1", "boom")
+	err = d.MarkExtractProgressFailed(ctx, ExtractFailure{
+		SessionID:      "sess-1",
+		Fingerprint:    "fp-a",
+		ExpectedDigest: "digest-1",
+		LastError:      "boom",
+	})
 	require.ErrorIs(t, err, ErrStaleExtractProgress)
 
 	progress, _, err := d.ExtractProgress(ctx, "sess-1", "fp-a")
@@ -320,7 +329,13 @@ func TestMarkExtractProgressFailedRejectsDoneRow(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, d.AdvanceExtractCursor(ctx, "sess-1", "fp-a", "digest-1", 2))
 
-	err = d.MarkExtractProgressFailed(ctx, "sess-1", "fp-a", "digest-1", "late worker")
+	err = d.MarkExtractProgressFailed(ctx, ExtractFailure{
+		SessionID:      "sess-1",
+		Fingerprint:    "fp-a",
+		ExpectedDigest: "digest-1",
+		ExpectedCursor: 2,
+		LastError:      "late worker",
+	})
 	require.ErrorIs(t, err, ErrStaleExtractProgress,
 		"a completed row must not be demoted to failed")
 
@@ -365,7 +380,19 @@ func TestExtractMutationsWaitForDBMutex(t *testing.T) {
 			return d.AdvanceExtractCursor(ctx, "sess-1", "fp-a", "digest-1", 1)
 		},
 		"MarkExtractProgressFailed": func() error {
-			return d.MarkExtractProgressFailed(ctx, "sess-1", "fp-a", "digest-1", "x")
+			// The advance subtest may or may not have run yet, so observe
+			// the stored cursor the way a real worker would.
+			progress, _, err := d.ExtractProgress(ctx, "sess-1", "fp-a")
+			if err != nil {
+				return err
+			}
+			return d.MarkExtractProgressFailed(ctx, ExtractFailure{
+				SessionID:      "sess-1",
+				Fingerprint:    "fp-a",
+				ExpectedDigest: "digest-1",
+				ExpectedCursor: progress.UnitCursor,
+				LastError:      "x",
+			})
 		},
 	}
 	for name, mutate := range mutations {
@@ -434,4 +461,34 @@ func TestAdvanceExtractCursorStaleAfterShrinkingReset(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, progress.UnitCursor)
 	assert.Equal(t, "digest-2", progress.ContentDigest)
+}
+
+func TestMarkExtractProgressFailedRejectsAdvancedCursor(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	seedExtractSession(t, d, "sess-1")
+	_, err := d.EnsureExtractGeneration(ctx, ExtractGeneration{
+		Fingerprint: "fp-a", Model: "m", Segmenter: "turns-v1",
+	})
+	require.NoError(t, err)
+	_, err = d.UpsertExtractProgress(ctx, "sess-1", "fp-a", "digest-1", 4)
+	require.NoError(t, err)
+	require.NoError(t, d.AdvanceExtractCursor(ctx, "sess-1", "fp-a", "digest-1", 2))
+
+	err = d.MarkExtractProgressFailed(ctx, ExtractFailure{
+		SessionID:      "sess-1",
+		Fingerprint:    "fp-a",
+		ExpectedDigest: "digest-1",
+		ExpectedCursor: 1,
+		LastError:      "worker that lost the race",
+	})
+	require.ErrorIs(t, err, ErrStaleExtractProgress,
+		"a failure from a worker behind the stored cursor must not demote "+
+			"newer progress")
+
+	progress, _, err := d.ExtractProgress(ctx, "sess-1", "fp-a")
+	require.NoError(t, err)
+	assert.Equal(t, ExtractProgressPartial, progress.State)
+	assert.Equal(t, 2, progress.UnitCursor)
+	assert.Empty(t, progress.LastError)
 }

--- a/internal/db/recall_extract_test.go
+++ b/internal/db/recall_extract_test.go
@@ -409,3 +409,29 @@ func TestUpsertExtractProgressZeroUnitsCompletesImmediately(t *testing.T) {
 	_, err = d.UpsertExtractProgress(ctx, "sess-1", "fp-a", "digest-3", -1)
 	require.Error(t, err, "negative unit totals must be refused")
 }
+
+func TestAdvanceExtractCursorStaleAfterShrinkingReset(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	seedExtractSession(t, d, "sess-1")
+	_, err := d.EnsureExtractGeneration(ctx, ExtractGeneration{
+		Fingerprint: "fp-a", Model: "m", Segmenter: "turns-v1",
+	})
+	require.NoError(t, err)
+	_, err = d.UpsertExtractProgress(ctx, "sess-1", "fp-a", "digest-1", 10)
+	require.NoError(t, err)
+	require.NoError(t, d.AdvanceExtractCursor(ctx, "sess-1", "fp-a", "digest-1", 7))
+
+	_, err = d.UpsertExtractProgress(ctx, "sess-1", "fp-a", "digest-2", 4)
+	require.NoError(t, err)
+
+	err = d.AdvanceExtractCursor(ctx, "sess-1", "fp-a", "digest-1", 8)
+	require.ErrorIs(t, err, ErrStaleExtractProgress,
+		"a stale worker beyond the shrunken total must get the typed stale "+
+			"error that triggers re-read, not a bounds error")
+
+	progress, _, err := d.ExtractProgress(ctx, "sess-1", "fp-a")
+	require.NoError(t, err)
+	assert.Equal(t, 0, progress.UnitCursor)
+	assert.Equal(t, "digest-2", progress.ContentDigest)
+}

--- a/internal/db/recall_extract_test.go
+++ b/internal/db/recall_extract_test.go
@@ -1,0 +1,308 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func seedExtractSession(t *testing.T, d *DB, id string) {
+	t.Helper()
+	require.NoError(t, d.UpsertSession(Session{
+		ID:      id,
+		Project: "proj",
+		Machine: defaultMachine,
+		Agent:   defaultAgent,
+	}))
+}
+
+func TestExtractGenerationEnsureIsIdempotent(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	first, err := d.EnsureExtractGeneration(ctx, ExtractGeneration{
+		Fingerprint: "fp-a",
+		Model:       "model-x",
+		Segmenter:   "turns-v1",
+		ParamsJSON:  `{"max_window_chars":50000}`,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ExtractGenerationBuilding, first.State)
+
+	again, err := d.EnsureExtractGeneration(ctx, ExtractGeneration{
+		Fingerprint: "fp-a",
+		Model:       "model-y",
+		Segmenter:   "other",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "model-x", again.Model, "existing row wins")
+	assert.Equal(t, "turns-v1", again.Segmenter)
+
+	generations, err := d.ExtractGenerations(ctx)
+	require.NoError(t, err)
+	require.Len(t, generations, 1)
+}
+
+func TestExtractGenerationActivateKeepsSingleActive(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	for _, fp := range []string{"fp-a", "fp-b"} {
+		_, err := d.EnsureExtractGeneration(ctx, ExtractGeneration{
+			Fingerprint: fp, Model: "m", Segmenter: "turns-v1",
+		})
+		require.NoError(t, err)
+	}
+	require.NoError(t, d.ActivateExtractGeneration(ctx, "fp-a"))
+	require.NoError(t, d.ActivateExtractGeneration(ctx, "fp-b"))
+
+	generations, err := d.ExtractGenerations(ctx)
+	require.NoError(t, err)
+	states := map[string]string{}
+	for _, gen := range generations {
+		states[gen.Fingerprint] = gen.State
+	}
+	assert.Equal(t, ExtractGenerationRetired, states["fp-a"])
+	assert.Equal(t, ExtractGenerationActive, states["fp-b"])
+
+	err = d.ActivateExtractGeneration(ctx, "fp-missing")
+	assert.Error(t, err, "unknown fingerprint must refuse")
+}
+
+func TestExtractGenerationRetireActiveRequiresForce(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	_, err := d.EnsureExtractGeneration(ctx, ExtractGeneration{
+		Fingerprint: "fp-a", Model: "m", Segmenter: "turns-v1",
+	})
+	require.NoError(t, err)
+	require.NoError(t, d.ActivateExtractGeneration(ctx, "fp-a"))
+
+	err = d.RetireExtractGeneration(ctx, "fp-a", false)
+	require.Error(t, err, "retiring the active generation needs force")
+
+	require.NoError(t, d.RetireExtractGeneration(ctx, "fp-a", true))
+	generations, err := d.ExtractGenerations(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, ExtractGenerationRetired, generations[0].State)
+}
+
+func TestExtractProgressLifecycle(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	seedExtractSession(t, d, "sess-1")
+	_, err := d.EnsureExtractGeneration(ctx, ExtractGeneration{
+		Fingerprint: "fp-a", Model: "m", Segmenter: "turns-v1",
+	})
+	require.NoError(t, err)
+
+	progress, err := d.UpsertExtractProgress(ctx, "sess-1", "fp-a", "digest-1", 4)
+	require.NoError(t, err)
+	assert.Equal(t, ExtractProgressPending, progress.State)
+	assert.Equal(t, 0, progress.UnitCursor)
+	assert.Equal(t, 4, progress.UnitsTotal)
+
+	require.NoError(t, d.AdvanceExtractCursor(ctx, "sess-1", "fp-a", "digest-1", 2))
+	progress, ok, err := d.ExtractProgress(ctx, "sess-1", "fp-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, ExtractProgressPartial, progress.State)
+	assert.Equal(t, 2, progress.UnitCursor)
+
+	require.NoError(t, d.AdvanceExtractCursor(ctx, "sess-1", "fp-a", "digest-1", 4))
+	progress, _, err = d.ExtractProgress(ctx, "sess-1", "fp-a")
+	require.NoError(t, err)
+	assert.Equal(t, ExtractProgressDone, progress.State)
+}
+
+func TestExtractProgressUpsertResetsOnDigestChange(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	seedExtractSession(t, d, "sess-1")
+	_, err := d.EnsureExtractGeneration(ctx, ExtractGeneration{
+		Fingerprint: "fp-a", Model: "m", Segmenter: "turns-v1",
+	})
+	require.NoError(t, err)
+
+	_, err = d.UpsertExtractProgress(ctx, "sess-1", "fp-a", "digest-1", 4)
+	require.NoError(t, err)
+	require.NoError(t, d.AdvanceExtractCursor(ctx, "sess-1", "fp-a", "digest-1", 4))
+
+	same, err := d.UpsertExtractProgress(ctx, "sess-1", "fp-a", "digest-1", 4)
+	require.NoError(t, err)
+	assert.Equal(t, ExtractProgressDone, same.State, "same digest keeps progress")
+	assert.Equal(t, 4, same.UnitCursor)
+
+	grown, err := d.UpsertExtractProgress(ctx, "sess-1", "fp-a", "digest-2", 6)
+	require.NoError(t, err)
+	assert.Equal(t, ExtractProgressPending, grown.State, "digest change resets")
+	assert.Equal(t, 0, grown.UnitCursor)
+	assert.Equal(t, 6, grown.UnitsTotal)
+	assert.Equal(t, "digest-2", grown.ContentDigest)
+}
+
+func TestExtractProgressFailureKeepsCursor(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	seedExtractSession(t, d, "sess-1")
+	_, err := d.EnsureExtractGeneration(ctx, ExtractGeneration{
+		Fingerprint: "fp-a", Model: "m", Segmenter: "turns-v1",
+	})
+	require.NoError(t, err)
+	_, err = d.UpsertExtractProgress(ctx, "sess-1", "fp-a", "digest-1", 4)
+	require.NoError(t, err)
+	require.NoError(t, d.AdvanceExtractCursor(ctx, "sess-1", "fp-a", "digest-1", 2))
+
+	require.NoError(t, d.MarkExtractProgressFailed(
+		ctx, "sess-1", "fp-a", "digest-1", "endpoint unreachable",
+	))
+	progress, ok, err := d.ExtractProgress(ctx, "sess-1", "fp-a")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, ExtractProgressFailed, progress.State)
+	assert.Equal(t, 2, progress.UnitCursor, "failure keeps the resume point")
+	assert.Equal(t, "endpoint unreachable", progress.LastError)
+}
+
+func TestExtractProgressUnknownSessionRefused(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	_, err := d.EnsureExtractGeneration(ctx, ExtractGeneration{
+		Fingerprint: "fp-a", Model: "m", Segmenter: "turns-v1",
+	})
+	require.NoError(t, err)
+
+	_, err = d.UpsertExtractProgress(ctx, "sess-missing", "fp-a", "digest-1", 4)
+	assert.Error(t, err, "progress rows require an existing session")
+}
+
+func TestAdvanceExtractCursorRejectsStaleDigest(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	seedExtractSession(t, d, "sess-1")
+	_, err := d.EnsureExtractGeneration(ctx, ExtractGeneration{
+		Fingerprint: "fp-a", Model: "m", Segmenter: "turns-v1",
+	})
+	require.NoError(t, err)
+	_, err = d.UpsertExtractProgress(ctx, "sess-1", "fp-a", "digest-2", 6)
+	require.NoError(t, err)
+
+	err = d.AdvanceExtractCursor(ctx, "sess-1", "fp-a", "digest-1", 3)
+	require.ErrorIs(t, err, ErrStaleExtractProgress,
+		"a worker holding the old digest must not overwrite reset progress")
+
+	progress, _, err := d.ExtractProgress(ctx, "sess-1", "fp-a")
+	require.NoError(t, err)
+	assert.Equal(t, 0, progress.UnitCursor, "stale advance must not move the cursor")
+	assert.Equal(t, ExtractProgressPending, progress.State)
+}
+
+func TestAdvanceExtractCursorIsMonotonicAndBounded(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	seedExtractSession(t, d, "sess-1")
+	_, err := d.EnsureExtractGeneration(ctx, ExtractGeneration{
+		Fingerprint: "fp-a", Model: "m", Segmenter: "turns-v1",
+	})
+	require.NoError(t, err)
+	_, err = d.UpsertExtractProgress(ctx, "sess-1", "fp-a", "digest-1", 4)
+	require.NoError(t, err)
+	require.NoError(t, d.AdvanceExtractCursor(ctx, "sess-1", "fp-a", "digest-1", 3))
+
+	err = d.AdvanceExtractCursor(ctx, "sess-1", "fp-a", "digest-1", 2)
+	require.ErrorIs(t, err, ErrStaleExtractProgress, "cursor must not regress")
+
+	err = d.AdvanceExtractCursor(ctx, "sess-1", "fp-a", "digest-1", 5)
+	require.Error(t, err, "cursor past units_total must be refused")
+
+	progress, _, err := d.ExtractProgress(ctx, "sess-1", "fp-a")
+	require.NoError(t, err)
+	assert.Equal(t, 3, progress.UnitCursor)
+}
+
+func TestMarkExtractProgressFailedRejectsStaleDigest(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	seedExtractSession(t, d, "sess-1")
+	_, err := d.EnsureExtractGeneration(ctx, ExtractGeneration{
+		Fingerprint: "fp-a", Model: "m", Segmenter: "turns-v1",
+	})
+	require.NoError(t, err)
+	_, err = d.UpsertExtractProgress(ctx, "sess-1", "fp-a", "digest-2", 6)
+	require.NoError(t, err)
+
+	err = d.MarkExtractProgressFailed(ctx, "sess-1", "fp-a", "digest-1", "boom")
+	require.ErrorIs(t, err, ErrStaleExtractProgress)
+
+	progress, _, err := d.ExtractProgress(ctx, "sess-1", "fp-a")
+	require.NoError(t, err)
+	assert.Equal(t, ExtractProgressPending, progress.State,
+		"stale failure must not clobber reset progress")
+}
+
+func TestCopyRecallEntriesFromCarriesExtractState(t *testing.T) {
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "src.db")
+	src, err := Open(srcPath)
+	require.NoError(t, err)
+	ctx := context.Background()
+	seedExtractSession(t, src, "sess-1")
+	seedExtractSession(t, src, "sess-gone")
+	_, err = src.EnsureExtractGeneration(ctx, ExtractGeneration{
+		Fingerprint: "fp-a", Model: "m", Segmenter: "turns-v1",
+		ParamsJSON: `{"max_window_chars":50000}`,
+	})
+	require.NoError(t, err)
+	require.NoError(t, src.ActivateExtractGeneration(ctx, "fp-a"))
+	_, err = src.UpsertExtractProgress(ctx, "sess-1", "fp-a", "digest-1", 4)
+	require.NoError(t, err)
+	require.NoError(t, src.AdvanceExtractCursor(ctx, "sess-1", "fp-a", "digest-1", 2))
+	_, err = src.UpsertExtractProgress(ctx, "sess-gone", "fp-a", "digest-9", 3)
+	require.NoError(t, err)
+	src.Close()
+
+	dst := testDB(t)
+	seedExtractSession(t, dst, "sess-1") // sess-gone not re-synced
+
+	require.NoError(t, dst.CopyRecallEntriesFrom(srcPath))
+
+	generations, err := dst.ExtractGenerations(ctx)
+	require.NoError(t, err)
+	require.Len(t, generations, 1, "resync must carry the generation registry")
+	assert.Equal(t, ExtractGenerationActive, generations[0].State)
+	assert.Equal(t, `{"max_window_chars":50000}`, generations[0].ParamsJSON)
+
+	progress, ok, err := dst.ExtractProgress(ctx, "sess-1", "fp-a")
+	require.NoError(t, err)
+	require.True(t, ok, "resync must carry resume cursors")
+	assert.Equal(t, 2, progress.UnitCursor)
+	assert.Equal(t, ExtractProgressPartial, progress.State)
+
+	_, ok, err = dst.ExtractProgress(ctx, "sess-gone", "fp-a")
+	require.NoError(t, err)
+	assert.False(t, ok, "progress for sessions absent from the new DB is dropped")
+}
+
+func TestCopyRecallEntriesFromToleratesSourceWithoutExtractTables(t *testing.T) {
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "src.db")
+	src, err := Open(srcPath)
+	require.NoError(t, err)
+	src.Close()
+	conn, err := sql.Open("sqlite3", srcPath)
+	require.NoError(t, err)
+	_, err = conn.Exec("DROP TABLE recall_extract_progress")
+	require.NoError(t, err)
+	_, err = conn.Exec("DROP TABLE recall_extract_generations")
+	require.NoError(t, err)
+	conn.Close()
+
+	dst := testDB(t)
+	require.NoError(t, dst.CopyRecallEntriesFrom(srcPath),
+		"archives from releases without extraction tables must still resync")
+}

--- a/internal/db/recall_extract_test.go
+++ b/internal/db/recall_extract_test.go
@@ -492,3 +492,33 @@ func TestMarkExtractProgressFailedRejectsAdvancedCursor(t *testing.T) {
 	assert.Equal(t, 2, progress.UnitCursor)
 	assert.Empty(t, progress.LastError)
 }
+
+func TestAdvanceExtractCursorReplayKeepsFailureState(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	seedExtractSession(t, d, "sess-1")
+	_, err := d.EnsureExtractGeneration(ctx, ExtractGeneration{
+		Fingerprint: "fp-a", Model: "m", Segmenter: "turns-v1",
+	})
+	require.NoError(t, err)
+	_, err = d.UpsertExtractProgress(ctx, "sess-1", "fp-a", "digest-1", 4)
+	require.NoError(t, err)
+	require.NoError(t, d.AdvanceExtractCursor(ctx, "sess-1", "fp-a", "digest-1", 2))
+	require.NoError(t, d.MarkExtractProgressFailed(ctx, ExtractFailure{
+		SessionID:      "sess-1",
+		Fingerprint:    "fp-a",
+		ExpectedDigest: "digest-1",
+		ExpectedCursor: 2,
+		LastError:      "boom",
+	}))
+
+	// A delayed duplicate of the cursor-2 advance completed no new unit;
+	// it must be an accepted no-op, not resurrect the failed row.
+	require.NoError(t, d.AdvanceExtractCursor(ctx, "sess-1", "fp-a", "digest-1", 2))
+
+	progress, _, err := d.ExtractProgress(ctx, "sess-1", "fp-a")
+	require.NoError(t, err)
+	assert.Equal(t, ExtractProgressFailed, progress.State)
+	assert.Equal(t, 2, progress.UnitCursor)
+	assert.Equal(t, "boom", progress.LastError)
+}

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -419,6 +419,45 @@ CREATE TABLE IF NOT EXISTS recall_query_exposures (
 CREATE INDEX IF NOT EXISTS idx_recall_query_exposures_entry
     ON recall_query_exposures(entry_id);
 
+-- One extraction generation per distillation configuration: the fingerprint
+-- digests everything that changes output (model, segmenter identity, prompt
+-- digests, request shape). At most one generation is active at a time;
+-- changing configuration creates a new generation rather than mixing corpora.
+CREATE TABLE IF NOT EXISTS recall_extract_generations (
+    fingerprint TEXT PRIMARY KEY,
+    state       TEXT NOT NULL DEFAULT 'building'
+        CHECK (state IN ('building', 'active', 'retired')),
+    model       TEXT NOT NULL,
+    segmenter   TEXT NOT NULL,
+    params_json TEXT NOT NULL DEFAULT '{}',
+    created_at  TEXT NOT NULL
+        DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    updated_at  TEXT NOT NULL
+        DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+
+-- Per-session extraction progress for one generation. unit_cursor counts
+-- completed units of the session's deterministic unit list, so a daemon
+-- restart resumes mid-session; content_digest detects sessions that grew
+-- after extraction so they can be reset and topped up.
+CREATE TABLE IF NOT EXISTS recall_extract_progress (
+    session_id             TEXT NOT NULL
+        REFERENCES sessions(id) ON DELETE CASCADE,
+    generation_fingerprint TEXT NOT NULL
+        REFERENCES recall_extract_generations(fingerprint) ON DELETE CASCADE,
+    unit_cursor    INTEGER NOT NULL DEFAULT 0,
+    units_total    INTEGER NOT NULL DEFAULT 0,
+    state          TEXT NOT NULL DEFAULT 'pending'
+        CHECK (state IN ('pending', 'partial', 'done', 'failed')),
+    content_digest TEXT NOT NULL DEFAULT '',
+    last_error     TEXT NOT NULL DEFAULT '',
+    updated_at     TEXT NOT NULL
+        DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    PRIMARY KEY (session_id, generation_fingerprint)
+);
+CREATE INDEX IF NOT EXISTS idx_recall_extract_progress_state
+    ON recall_extract_progress(generation_fingerprint, state);
+
 -- Pinned messages table
 CREATE TABLE IF NOT EXISTS pinned_messages (
     id          INTEGER PRIMARY KEY,

--- a/internal/recall/extract/client.go
+++ b/internal/recall/extract/client.go
@@ -538,12 +538,15 @@ func parseRetryAfter(value string) time.Duration {
 
 // isContextOverflowDetail reports whether a 400 body identifies an
 // input-length error. A structured error code is unambiguous; otherwise
-// the message must pair a length subject (context, prompt, input, token)
-// with an overflow term (exceed, too long/large, maximum), so validation
-// errors that merely mention the subject — "context window must be an
-// integer" — do not match. A phrasing this misses fails the unit with the
-// server's message intact, which is recoverable by configuration; the
-// reverse mistake would send the caller splitting units in a useless loop.
+// the message must pair an input-side subject (context, prompt, input)
+// with an overflow term (exceed, too long/large, maximum). Bare "token" is
+// deliberately not a subject: output-budget rejections like "max_tokens
+// exceeds the maximum allowed value" would match it, and splitting the
+// input cannot fix an invalid output limit — while every genuine overflow
+// phrasing also names the prompt, input, or context. A phrasing this
+// misses fails the unit with the server's message intact, which is
+// recoverable by configuration; the reverse mistake would send the caller
+// splitting units in a useless loop.
 func isContextOverflowDetail(body string) bool {
 	lower := strings.ToLower(body)
 	codes := []string{
@@ -555,7 +558,7 @@ func isContextOverflowDetail(body string) bool {
 			return true
 		}
 	}
-	subjects := []string{"context", "prompt", "input", "token"}
+	subjects := []string{"context", "prompt", "input"}
 	overflowTerms := []string{"exceed", "too long", "too large", "maximum"}
 	hasSubject := slices.ContainsFunc(subjects, func(subject string) bool {
 		return strings.Contains(lower, subject)

--- a/internal/recall/extract/client.go
+++ b/internal/recall/extract/client.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"maps"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -17,23 +18,36 @@ import (
 // same text can never succeed.
 var ErrContextOverflow = errors.New("unit text overflows the model context")
 
-// ErrPersistentTruncation reports output that stayed truncated even after
-// the compact retry. Like an overflow, the only recovery is splitting the
-// unit into smaller pieces.
+// ErrPersistentTruncation reports output the client cannot recover: the
+// token budget truncated a unit large enough to split (splitting preserves
+// every entry, so no compact retry is attempted), or a unit at the compact
+// floor stayed truncated even after the compact retry. Like an overflow,
+// the recovery is splitting the unit into smaller pieces.
 var ErrPersistentTruncation = errors.New(
-	"model output stays truncated at the token budget",
+	"model output truncated at the token budget",
 )
 
 // errTruncated is the per-request truncation signal that
-// DistillWithRecovery converts into a compact retry.
+// DistillWithRecovery converts into a split signal or a compact retry.
 var errTruncated = errors.New("model output truncated")
 
-// compactSuffix is appended on the truncation retry. Sampling at
-// temperature zero makes a same-input retry deterministic, so the retry
-// must change the input instead of hoping for different output.
+// errPermanentRequest marks a server rejection that retrying the same
+// request can never fix (wrong model name, malformed field).
+var errPermanentRequest = errors.New("model server rejected the request")
+
+// compactSuffix is appended on the truncation retry of a unit too small to
+// split. Sampling at temperature zero makes a same-input retry
+// deterministic, so the retry must change the input instead of hoping for
+// different output; capping the entry count is acceptable only here, where
+// splitting cannot recover the lost entries anyway.
 const compactSuffix = "\n\nIMPORTANT: the output budget is tight for this " +
 	"window. Return at most 4 entries, each with a body of at most 2 " +
 	"sentences."
+
+// extractionProtocolVersion feeds the generation fingerprint. Bump it when
+// the response schema or the recovery behavior changes in a way that alters
+// extraction output for an identical configuration.
+const extractionProtocolVersion = 1
 
 // Entry is one distilled memory entry as the model produces it.
 type Entry struct {
@@ -86,11 +100,17 @@ var entrySchema = map[string]any{
 // Client distills unit text into entries through an OpenAI-compatible chat
 // completion endpoint with constrained decoding.
 type Client struct {
-	BaseURL    string
-	Model      string
-	MaxTokens  int
-	HTTPClient *http.Client
-	Request    RequestShape
+	BaseURL string
+	Model   string
+	// CompactFloorChars bounds the compact retry: a truncated unit longer
+	// than this returns ErrPersistentTruncation immediately so the caller
+	// splits it without losing entries; a unit at or below it (too small
+	// for splitting to help) gets one compact retry first. Callers set it
+	// to SplitFloorChars of their window budget; zero disables the compact
+	// retry entirely.
+	CompactFloorChars int
+	HTTPClient        *http.Client
+	Request           RequestShape
 }
 
 func (c *Client) httpClient() *http.Client {
@@ -102,14 +122,22 @@ func (c *Client) httpClient() *http.Client {
 
 // DistillWithRecovery runs one unit through the model with the recovery
 // ladder: transient failures are retried up to maxAttempts per phase;
-// truncated output triggers exactly one compact retry (temperature-zero
-// sampling makes same-input retries useless); truncation that survives the
-// compact retry surfaces as ErrPersistentTruncation and a context overflow
-// as ErrContextOverflow — both mean "split this unit", which the caller
-// owns because it also owns unit identity.
+// truncated output on a unit at or below CompactFloorChars triggers exactly
+// one compact retry (temperature-zero sampling makes same-input retries
+// useless); truncation on a splittable unit, or truncation that survives
+// the compact retry, surfaces as ErrPersistentTruncation and a context
+// overflow as ErrContextOverflow — both mean "split this unit", which the
+// caller owns because it also owns unit identity.
 func (c *Client) DistillWithRecovery(
 	ctx context.Context, systemPrompt, text string, maxAttempts int,
 ) ([]Entry, Usage, error) {
+	if c.Request.MaxTokens <= 0 {
+		return nil, Usage{}, fmt.Errorf(
+			"extraction request max_tokens must be positive; the profile or "+
+				"configuration must set it (got %d)", c.Request.MaxTokens,
+		)
+	}
+	compactAllowed := len(text) <= c.CompactFloorChars
 	for _, compact := range []bool{false, true} {
 		var lastErr error
 		truncated := false
@@ -118,7 +146,8 @@ func (c *Client) DistillWithRecovery(
 			if err == nil {
 				return entries, usage, nil
 			}
-			if errors.Is(err, ErrContextOverflow) {
+			if errors.Is(err, ErrContextOverflow) ||
+				errors.Is(err, errPermanentRequest) {
 				return nil, Usage{}, err
 			}
 			if errors.Is(err, errTruncated) {
@@ -135,6 +164,9 @@ func (c *Client) DistillWithRecovery(
 				"distilling unit after %d attempts: %w", maxAttempts, lastErr,
 			)
 		}
+		if !compactAllowed {
+			break
+		}
 	}
 	return nil, Usage{}, fmt.Errorf(
 		"unit of %d chars: %w", len(text), ErrPersistentTruncation,
@@ -150,7 +182,7 @@ func (c *Client) distill(
 	}
 	payload := map[string]any{
 		"model":       c.Model,
-		"max_tokens":  c.MaxTokens,
+		"max_tokens":  c.Request.MaxTokens,
 		"temperature": c.Request.Temperature,
 		"messages": []map[string]string{
 			{"role": "system", "content": systemPrompt},
@@ -189,15 +221,22 @@ func (c *Client) distill(
 		return nil, Usage{}, fmt.Errorf("reading distill response: %w", err)
 	}
 	if response.StatusCode == http.StatusBadRequest {
-		// Chat servers answer 400 when the prompt exceeds the context
-		// window; character budgets overshoot because token density
-		// varies across content.
 		detail := string(raw)
 		if len(detail) > 200 {
 			detail = detail[:200]
 		}
+		// Chat servers answer 400 both for prompts that exceed the context
+		// window (character budgets overshoot because token density varies
+		// across content) and for genuinely bad requests; only the former
+		// is recoverable by splitting the unit.
+		if isContextOverflowDetail(string(raw)) {
+			return nil, Usage{}, fmt.Errorf(
+				"%d-char unit: %w: %s", len(userText), ErrContextOverflow,
+				detail,
+			)
+		}
 		return nil, Usage{}, fmt.Errorf(
-			"%d-char unit: %w: %s", len(userText), ErrContextOverflow, detail,
+			"%w (HTTP 400): %s", errPermanentRequest, detail,
 		)
 	}
 	if response.StatusCode != http.StatusOK {
@@ -224,7 +263,7 @@ func (c *Client) distill(
 	choice := parsed.Choices[0]
 	if choice.FinishReason == "length" {
 		return nil, Usage{}, fmt.Errorf(
-			"at max_tokens=%d: %w", c.MaxTokens, errTruncated,
+			"at max_tokens=%d: %w", c.Request.MaxTokens, errTruncated,
 		)
 	}
 	if choice.Message.Content == "" {
@@ -243,6 +282,20 @@ func (c *Client) distill(
 		return nil, Usage{}, fmt.Errorf("parsing distilled entries: %w", err)
 	}
 	return out.Entries, parsed.Usage, nil
+}
+
+// isContextOverflowDetail reports whether a 400 body identifies an
+// input-length error. Chat servers phrase it differently ("maximum context
+// length", "context_length_exceeded", "prompt is too long", "input length
+// exceeds"), but all name the context or the input being too long.
+func isContextOverflowDetail(body string) bool {
+	lower := strings.ToLower(body)
+	for _, marker := range []string{"context", "too long", "input length"} {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 // SplitFloorChars is the smallest unit size worth splitting further. A unit

--- a/internal/recall/extract/client.go
+++ b/internal/recall/extract/client.go
@@ -537,30 +537,33 @@ func parseRetryAfter(value string) time.Duration {
 }
 
 // isContextOverflowDetail reports whether a 400 body identifies an
-// input-length error. The markers are specific phrasings chat servers use
-// for exceeded input, not lone words like "context" that also appear in
-// unrelated rejections. A phrasing this list misses fails the unit with the
+// input-length error. A structured error code is unambiguous; otherwise
+// the message must pair a length subject (context, prompt, input, token)
+// with an overflow term (exceed, too long/large, maximum), so validation
+// errors that merely mention the subject — "context window must be an
+// integer" — do not match. A phrasing this misses fails the unit with the
 // server's message intact, which is recoverable by configuration; the
 // reverse mistake would send the caller splitting units in a useless loop.
 func isContextOverflowDetail(body string) bool {
 	lower := strings.ToLower(body)
-	markers := []string{
+	codes := []string{
 		"context_length_exceeded",
-		"maximum context length",
-		"context length",
-		"context window",
-		"context size",
-		"prompt is too long",
-		"input is too long",
-		"input length",
-		"too many tokens",
+		"exceed_context_size_error",
 	}
-	for _, marker := range markers {
-		if strings.Contains(lower, marker) {
+	for _, code := range codes {
+		if strings.Contains(lower, code) {
 			return true
 		}
 	}
-	return false
+	subjects := []string{"context", "prompt", "input", "token"}
+	overflowTerms := []string{"exceed", "too long", "too large", "maximum"}
+	hasSubject := slices.ContainsFunc(subjects, func(subject string) bool {
+		return strings.Contains(lower, subject)
+	})
+	hasOverflowTerm := slices.ContainsFunc(overflowTerms, func(term string) bool {
+		return strings.Contains(lower, term)
+	})
+	return hasSubject && hasOverflowTerm
 }
 
 // SplitFloorChars is the smallest unit size worth splitting further. A unit

--- a/internal/recall/extract/client.go
+++ b/internal/recall/extract/client.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 // ErrContextOverflow reports a prompt the server rejected as too large for
@@ -137,7 +138,10 @@ func (c *Client) DistillWithRecovery(
 				"configuration must set it (got %d)", c.Request.MaxTokens,
 		)
 	}
-	compactAllowed := len(text) <= c.CompactFloorChars
+	// Rune count, not byte length: segmentation budgets count code points,
+	// so the floor must measure units the same way.
+	unitChars := utf8.RuneCountInString(text)
+	compactAllowed := unitChars <= c.CompactFloorChars
 	for _, compact := range []bool{false, true} {
 		var lastErr error
 		truncated := false
@@ -169,7 +173,7 @@ func (c *Client) DistillWithRecovery(
 		}
 	}
 	return nil, Usage{}, fmt.Errorf(
-		"unit of %d chars: %w", len(text), ErrPersistentTruncation,
+		"unit of %d chars: %w", unitChars, ErrPersistentTruncation,
 	)
 }
 
@@ -204,7 +208,8 @@ func (c *Client) distill(
 	}
 	request, err := http.NewRequestWithContext(
 		ctx, http.MethodPost,
-		c.BaseURL+"/chat/completions", bytes.NewReader(body),
+		strings.TrimRight(c.BaseURL, "/")+"/chat/completions",
+		bytes.NewReader(body),
 	)
 	if err != nil {
 		return nil, Usage{}, fmt.Errorf("building distill request: %w", err)
@@ -231,8 +236,8 @@ func (c *Client) distill(
 		// is recoverable by splitting the unit.
 		if isContextOverflowDetail(string(raw)) {
 			return nil, Usage{}, fmt.Errorf(
-				"%d-char unit: %w: %s", len(userText), ErrContextOverflow,
-				detail,
+				"%d-char unit: %w: %s",
+				utf8.RuneCountInString(userText), ErrContextOverflow, detail,
 			)
 		}
 		return nil, Usage{}, fmt.Errorf(
@@ -285,12 +290,25 @@ func (c *Client) distill(
 }
 
 // isContextOverflowDetail reports whether a 400 body identifies an
-// input-length error. Chat servers phrase it differently ("maximum context
-// length", "context_length_exceeded", "prompt is too long", "input length
-// exceeds"), but all name the context or the input being too long.
+// input-length error. The markers are specific phrasings chat servers use
+// for exceeded input, not lone words like "context" that also appear in
+// unrelated rejections. A phrasing this list misses fails the unit with the
+// server's message intact, which is recoverable by configuration; the
+// reverse mistake would send the caller splitting units in a useless loop.
 func isContextOverflowDetail(body string) bool {
 	lower := strings.ToLower(body)
-	for _, marker := range []string{"context", "too long", "input length"} {
+	markers := []string{
+		"context_length_exceeded",
+		"maximum context length",
+		"context length",
+		"context window",
+		"context size",
+		"prompt is too long",
+		"input is too long",
+		"input length",
+		"too many tokens",
+	}
+	for _, marker := range markers {
 		if strings.Contains(lower, marker) {
 			return true
 		}

--- a/internal/recall/extract/client.go
+++ b/internal/recall/extract/client.go
@@ -549,7 +549,20 @@ func isContextOverflowDetail(body string) bool {
 			strings.Contains(lower, "context size") ||
 			strings.Contains(lower, "context window")
 	}
-	subjects := []string{"context", "prompt", "input"}
+	// Length-specific input phrasings are unambiguous on their own.
+	lengthPhrases := []string{
+		"input is too long", "input too long",
+		"input is too large", "input too large",
+	}
+	if slices.ContainsFunc(lengthPhrases, func(phrase string) bool {
+		return strings.Contains(lower, phrase)
+	}) {
+		return true
+	}
+	// Bare "input" is deliberately not a subject: servers prefix arbitrary
+	// validation errors with "Input validation error:", which would pair
+	// with the overflow term of any out-of-range parameter.
+	subjects := []string{"context", "prompt"}
 	overflowTerms := []string{"exceed", "too long", "too large", "maximum"}
 	hasSubject := slices.ContainsFunc(subjects, func(subject string) bool {
 		return strings.Contains(lower, subject)

--- a/internal/recall/extract/client.go
+++ b/internal/recall/extract/client.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"maps"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -33,8 +34,32 @@ var ErrPersistentTruncation = errors.New(
 var errTruncated = errors.New("model output truncated")
 
 // errPermanentRequest marks a server rejection that retrying the same
-// request can never fix (wrong model name, malformed field).
+// request can never fix (wrong model name, bad credentials, malformed
+// field).
 var errPermanentRequest = errors.New("model server rejected the request")
+
+// transientError marks a failure worth retrying: network errors, timeouts,
+// rate limits, and server errors. RetryAfter carries the server's requested
+// delay, zero when it gave none.
+type transientError struct {
+	err        error
+	retryAfter time.Duration
+}
+
+func (e *transientError) Error() string { return e.err.Error() }
+func (e *transientError) Unwrap() error { return e.err }
+
+// reservedRequestKeys are payload fields the client owns. ExtraBody must
+// not shadow them: a profile smuggling max_tokens or response_format
+// through the extra body would bypass validation and desynchronize the
+// generation fingerprint from the request actually sent.
+var reservedRequestKeys = []string{
+	"model", "messages", "max_tokens", "temperature", "response_format",
+}
+
+// maxRetryDelay caps the wait between transient retries, whether from
+// backoff growth or an excessive Retry-After header.
+const maxRetryDelay = 30 * time.Second
 
 // compactSuffix is appended on the truncation retry of a unit too small to
 // split. Sampling at temperature zero makes a same-input retry
@@ -103,10 +128,14 @@ var entrySchema = map[string]any{
 // parameter lives in Request so it is covered by the generation
 // fingerprint.
 type Client struct {
-	BaseURL    string
-	Model      string
-	HTTPClient *http.Client
-	Request    RequestShape
+	BaseURL string
+	Model   string
+	// RetryBackoff seeds the exponential wait between transient retries;
+	// zero means 500ms. It shapes latency, not output, so it stays outside
+	// RequestShape and the fingerprint.
+	RetryBackoff time.Duration
+	HTTPClient   *http.Client
+	Request      RequestShape
 }
 
 func (c *Client) httpClient() *http.Client {
@@ -116,8 +145,17 @@ func (c *Client) httpClient() *http.Client {
 	return &http.Client{Timeout: 10 * time.Minute}
 }
 
+func (c *Client) retryBackoff() time.Duration {
+	if c.RetryBackoff > 0 {
+		return c.RetryBackoff
+	}
+	return 500 * time.Millisecond
+}
+
 // DistillWithRecovery runs one unit through the model with the recovery
-// ladder: transient failures are retried up to maxAttempts per phase;
+// ladder: transient failures (network errors, timeouts, rate limits,
+// server errors) are retried up to maxAttempts per phase with exponential
+// backoff honoring Retry-After, while permanent rejections fail fast;
 // truncated output on a unit at or below the compact floor triggers exactly
 // one compact retry (temperature-zero sampling makes same-input retries
 // useless); truncation on a splittable unit, or truncation that survives
@@ -135,6 +173,14 @@ func (c *Client) DistillWithRecovery(
 				"configuration must set it (got %d)", c.Request.MaxTokens,
 		)
 	}
+	for _, key := range reservedRequestKeys {
+		if _, ok := c.Request.ExtraBody[key]; ok {
+			return nil, total, fmt.Errorf(
+				"extra body must not set reserved request field %q; use the "+
+					"dedicated configuration for it", key,
+			)
+		}
+	}
 	// Rune count, not byte length: segmentation budgets count code points,
 	// so the floor must measure units the same way.
 	unitChars := utf8.RuneCountInString(text)
@@ -142,25 +188,39 @@ func (c *Client) DistillWithRecovery(
 	for _, compact := range []bool{false, true} {
 		var lastErr error
 		truncated := false
-		for range maxAttempts {
+		for attempt := range maxAttempts {
 			entries, usage, err := c.distill(ctx, systemPrompt, text, compact)
 			total.PromptTokens += usage.PromptTokens
 			total.CompletionTokens += usage.CompletionTokens
 			if err == nil {
 				return entries, total, nil
 			}
-			if errors.Is(err, ErrContextOverflow) ||
-				errors.Is(err, errPermanentRequest) {
-				return nil, total, err
-			}
 			if errors.Is(err, errTruncated) {
 				truncated = true
 				break
 			}
-			if ctx.Err() != nil {
-				return nil, total, ctx.Err()
+			var transient *transientError
+			if !errors.As(err, &transient) {
+				return nil, total, err
 			}
 			lastErr = err
+			if attempt+1 >= maxAttempts {
+				break
+			}
+			delay := transient.retryAfter
+			if delay <= 0 {
+				delay = c.retryBackoff() << attempt
+			}
+			if delay > maxRetryDelay {
+				delay = maxRetryDelay
+			}
+			timer := time.NewTimer(delay)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return nil, total, ctx.Err()
+			case <-timer.C:
+			}
 		}
 		if !truncated {
 			return nil, total, fmt.Errorf(
@@ -200,8 +260,12 @@ func (c *Client) distill(
 			},
 		},
 	}
-	maps.Copy(payload, c.Request.ExtraBody)
-	body, err := json.Marshal(payload)
+	// Extras first, client-owned fields last: even if validation of
+	// reserved keys were bypassed, the extra body could not shadow them.
+	merged := make(map[string]any, len(c.Request.ExtraBody)+len(payload))
+	maps.Copy(merged, c.Request.ExtraBody)
+	maps.Copy(merged, payload)
+	body, err := json.Marshal(merged)
 	if err != nil {
 		return nil, Usage{}, fmt.Errorf("encoding distill request: %w", err)
 	}
@@ -217,12 +281,16 @@ func (c *Client) distill(
 
 	response, err := c.httpClient().Do(request)
 	if err != nil {
-		return nil, Usage{}, fmt.Errorf("posting distill request: %w", err)
+		return nil, Usage{}, &transientError{
+			err: fmt.Errorf("posting distill request: %w", err),
+		}
 	}
 	defer func() { _ = response.Body.Close() }()
 	raw, err := io.ReadAll(io.LimitReader(response.Body, 16<<20))
 	if err != nil {
-		return nil, Usage{}, fmt.Errorf("reading distill response: %w", err)
+		return nil, Usage{}, &transientError{
+			err: fmt.Errorf("reading distill response: %w", err),
+		}
 	}
 	if response.StatusCode == http.StatusBadRequest {
 		detail := string(raw)
@@ -244,8 +312,24 @@ func (c *Client) distill(
 		)
 	}
 	if response.StatusCode != http.StatusOK {
-		return nil, Usage{}, fmt.Errorf(
+		statusErr := fmt.Errorf(
 			"distill request failed with HTTP %d", response.StatusCode,
+		)
+		if isTransientStatus(response.StatusCode) {
+			return nil, Usage{}, &transientError{
+				err: statusErr,
+				retryAfter: parseRetryAfter(
+					response.Header.Get("Retry-After"),
+				),
+			}
+		}
+		detail := string(raw)
+		if len(detail) > 200 {
+			detail = detail[:200]
+		}
+		return nil, Usage{}, fmt.Errorf(
+			"%w (HTTP %d): %s", errPermanentRequest,
+			response.StatusCode, detail,
 		)
 	}
 
@@ -258,11 +342,17 @@ func (c *Client) distill(
 		} `json:"choices"`
 		Usage Usage `json:"usage"`
 	}
+	// A 200 with an unreadable or choiceless body is a glitch in transit or
+	// in the serving layer, not a property of the input, so it retries.
 	if err := json.Unmarshal(raw, &parsed); err != nil {
-		return nil, Usage{}, fmt.Errorf("parsing distill response: %w", err)
+		return nil, Usage{}, &transientError{
+			err: fmt.Errorf("parsing distill response: %w", err),
+		}
 	}
 	if len(parsed.Choices) == 0 {
-		return nil, Usage{}, fmt.Errorf("distill response has no choices")
+		return nil, Usage{}, &transientError{
+			err: fmt.Errorf("distill response has no choices"),
+		}
 	}
 	// From here the server reports token usage even when the attempt fails,
 	// so error returns carry parsed.Usage for the caller's accounting.
@@ -288,6 +378,36 @@ func (c *Client) distill(
 		return nil, parsed.Usage, fmt.Errorf("parsing distilled entries: %w", err)
 	}
 	return out.Entries, parsed.Usage, nil
+}
+
+// isTransientStatus reports whether an HTTP status is worth retrying:
+// timeouts, rate limits, and server-side errors. Other non-200 statuses
+// (auth failures, missing routes, validation rejections) are deterministic
+// for the same request and fail fast.
+func isTransientStatus(status int) bool {
+	return status == http.StatusRequestTimeout ||
+		status == http.StatusTooManyRequests ||
+		status >= 500
+}
+
+// parseRetryAfter reads a Retry-After header in either the delay-seconds or
+// HTTP-date form, returning zero for absent or unparseable values.
+func parseRetryAfter(value string) time.Duration {
+	if value == "" {
+		return 0
+	}
+	if seconds, err := strconv.Atoi(value); err == nil {
+		if seconds > 0 {
+			return time.Duration(seconds) * time.Second
+		}
+		return 0
+	}
+	if when, err := http.ParseTime(value); err == nil {
+		if delay := time.Until(when); delay > 0 {
+			return delay
+		}
+	}
+	return 0
 }
 
 // isContextOverflowDetail reports whether a 400 body identifies an

--- a/internal/recall/extract/client.go
+++ b/internal/recall/extract/client.go
@@ -1,0 +1,262 @@
+package extract
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"time"
+)
+
+// ErrContextOverflow reports a prompt the server rejected as too large for
+// the model context. The unit must be split before retrying; retrying the
+// same text can never succeed.
+var ErrContextOverflow = errors.New("unit text overflows the model context")
+
+// ErrPersistentTruncation reports output that stayed truncated even after
+// the compact retry. Like an overflow, the only recovery is splitting the
+// unit into smaller pieces.
+var ErrPersistentTruncation = errors.New(
+	"model output stays truncated at the token budget",
+)
+
+// errTruncated is the per-request truncation signal that
+// DistillWithRecovery converts into a compact retry.
+var errTruncated = errors.New("model output truncated")
+
+// compactSuffix is appended on the truncation retry. Sampling at
+// temperature zero makes a same-input retry deterministic, so the retry
+// must change the input instead of hoping for different output.
+const compactSuffix = "\n\nIMPORTANT: the output budget is tight for this " +
+	"window. Return at most 4 entries, each with a body of at most 2 " +
+	"sentences."
+
+// Entry is one distilled memory entry as the model produces it.
+type Entry struct {
+	Type     string   `json:"type"`
+	Title    string   `json:"title"`
+	Body     string   `json:"body"`
+	Entities []string `json:"entities"`
+}
+
+// Usage reports token consumption for one model call.
+type Usage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+}
+
+// entrySchema constrains decoding so the model can only produce parseable
+// entries; validation failures become server-side sampling constraints
+// instead of client-side parse errors.
+var entrySchema = map[string]any{
+	"type": "object",
+	"properties": map[string]any{
+		"entries": map[string]any{
+			"type": "array",
+			"items": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"type": map[string]any{
+						"type": "string",
+						"enum": []string{
+							"fact", "decision", "procedure",
+							"warning", "preference", "open_question",
+						},
+					},
+					"title": map[string]any{"type": "string"},
+					"body":  map[string]any{"type": "string"},
+					"entities": map[string]any{
+						"type":  "array",
+						"items": map[string]any{"type": "string"},
+					},
+				},
+				"required":             []string{"type", "title", "body", "entities"},
+				"additionalProperties": false,
+			},
+		},
+	},
+	"required":             []string{"entries"},
+	"additionalProperties": false,
+}
+
+// Client distills unit text into entries through an OpenAI-compatible chat
+// completion endpoint with constrained decoding.
+type Client struct {
+	BaseURL    string
+	Model      string
+	MaxTokens  int
+	HTTPClient *http.Client
+	Request    RequestShape
+}
+
+func (c *Client) httpClient() *http.Client {
+	if c.HTTPClient != nil {
+		return c.HTTPClient
+	}
+	return &http.Client{Timeout: 10 * time.Minute}
+}
+
+// DistillWithRecovery runs one unit through the model with the recovery
+// ladder: transient failures are retried up to maxAttempts per phase;
+// truncated output triggers exactly one compact retry (temperature-zero
+// sampling makes same-input retries useless); truncation that survives the
+// compact retry surfaces as ErrPersistentTruncation and a context overflow
+// as ErrContextOverflow — both mean "split this unit", which the caller
+// owns because it also owns unit identity.
+func (c *Client) DistillWithRecovery(
+	ctx context.Context, systemPrompt, text string, maxAttempts int,
+) ([]Entry, Usage, error) {
+	for _, compact := range []bool{false, true} {
+		var lastErr error
+		truncated := false
+		for range maxAttempts {
+			entries, usage, err := c.distill(ctx, systemPrompt, text, compact)
+			if err == nil {
+				return entries, usage, nil
+			}
+			if errors.Is(err, ErrContextOverflow) {
+				return nil, Usage{}, err
+			}
+			if errors.Is(err, errTruncated) {
+				truncated = true
+				break
+			}
+			if ctx.Err() != nil {
+				return nil, Usage{}, ctx.Err()
+			}
+			lastErr = err
+		}
+		if !truncated {
+			return nil, Usage{}, fmt.Errorf(
+				"distilling unit after %d attempts: %w", maxAttempts, lastErr,
+			)
+		}
+	}
+	return nil, Usage{}, fmt.Errorf(
+		"unit of %d chars: %w", len(text), ErrPersistentTruncation,
+	)
+}
+
+func (c *Client) distill(
+	ctx context.Context, systemPrompt, text string, compact bool,
+) ([]Entry, Usage, error) {
+	userText := text
+	if compact {
+		userText += compactSuffix
+	}
+	payload := map[string]any{
+		"model":       c.Model,
+		"max_tokens":  c.MaxTokens,
+		"temperature": c.Request.Temperature,
+		"messages": []map[string]string{
+			{"role": "system", "content": systemPrompt},
+			{"role": "user", "content": userText},
+		},
+		"response_format": map[string]any{
+			"type": "json_schema",
+			"json_schema": map[string]any{
+				"name":   "session_readout",
+				"strict": true,
+				"schema": entrySchema,
+			},
+		},
+	}
+	maps.Copy(payload, c.Request.ExtraBody)
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, Usage{}, fmt.Errorf("encoding distill request: %w", err)
+	}
+	request, err := http.NewRequestWithContext(
+		ctx, http.MethodPost,
+		c.BaseURL+"/chat/completions", bytes.NewReader(body),
+	)
+	if err != nil {
+		return nil, Usage{}, fmt.Errorf("building distill request: %w", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+
+	response, err := c.httpClient().Do(request)
+	if err != nil {
+		return nil, Usage{}, fmt.Errorf("posting distill request: %w", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	raw, err := io.ReadAll(io.LimitReader(response.Body, 16<<20))
+	if err != nil {
+		return nil, Usage{}, fmt.Errorf("reading distill response: %w", err)
+	}
+	if response.StatusCode == http.StatusBadRequest {
+		// Chat servers answer 400 when the prompt exceeds the context
+		// window; character budgets overshoot because token density
+		// varies across content.
+		detail := string(raw)
+		if len(detail) > 200 {
+			detail = detail[:200]
+		}
+		return nil, Usage{}, fmt.Errorf(
+			"%d-char unit: %w: %s", len(userText), ErrContextOverflow, detail,
+		)
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, Usage{}, fmt.Errorf(
+			"distill request failed with HTTP %d", response.StatusCode,
+		)
+	}
+
+	var parsed struct {
+		Choices []struct {
+			FinishReason string `json:"finish_reason"`
+			Message      struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+		Usage Usage `json:"usage"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return nil, Usage{}, fmt.Errorf("parsing distill response: %w", err)
+	}
+	if len(parsed.Choices) == 0 {
+		return nil, Usage{}, fmt.Errorf("distill response has no choices")
+	}
+	choice := parsed.Choices[0]
+	if choice.FinishReason == "length" {
+		return nil, Usage{}, fmt.Errorf(
+			"at max_tokens=%d: %w", c.MaxTokens, errTruncated,
+		)
+	}
+	if choice.Message.Content == "" {
+		// Empty content with a normal finish reason means the token budget
+		// went somewhere invisible (typically hidden reasoning the request
+		// shape should have disabled).
+		return nil, Usage{}, fmt.Errorf(
+			"distill response content is empty; check the model profile's " +
+				"request shape",
+		)
+	}
+	var out struct {
+		Entries []Entry `json:"entries"`
+	}
+	if err := json.Unmarshal([]byte(choice.Message.Content), &out); err != nil {
+		return nil, Usage{}, fmt.Errorf("parsing distilled entries: %w", err)
+	}
+	return out.Entries, parsed.Usage, nil
+}
+
+// SplitFloorChars is the smallest unit size worth splitting further. A unit
+// below this floor that still overflows or truncates is not a size problem,
+// so the error should surface instead of recursing forever. The floor
+// scales down with the window budget so small-window configurations can
+// still split.
+func SplitFloorChars(maxWindowChars int) int {
+	floor := maxWindowChars / 8
+	if floor > 2000 {
+		return 2000
+	}
+	if floor < 1 {
+		return 1
+	}
+	return floor
+}

--- a/internal/recall/extract/client.go
+++ b/internal/recall/extract/client.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"maps"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -89,6 +90,12 @@ type Usage struct {
 	CompletionTokens int `json:"completion_tokens"`
 }
 
+// entryTypes is the closed set of entry kinds, shared by the request
+// schema and the client-side validation of what actually came back.
+var entryTypes = []string{
+	"fact", "decision", "procedure", "warning", "preference", "open_question",
+}
+
 // entrySchema constrains decoding so the model can only produce parseable
 // entries; validation failures become server-side sampling constraints
 // instead of client-side parse errors.
@@ -102,10 +109,7 @@ var entrySchema = map[string]any{
 				"properties": map[string]any{
 					"type": map[string]any{
 						"type": "string",
-						"enum": []string{
-							"fact", "decision", "procedure",
-							"warning", "preference", "open_question",
-						},
+						"enum": entryTypes,
 					},
 					"title": map[string]any{"type": "string"},
 					"body":  map[string]any{"type": "string"},
@@ -371,13 +375,68 @@ func (c *Client) distill(
 				"request shape",
 		)
 	}
+	entries, err := parseEntries(choice.Message.Content)
+	if err != nil {
+		// The server was asked for constrained decoding, so a violation
+		// means it did not enforce the schema; at temperature zero that is
+		// deterministic and not worth retrying.
+		return nil, parsed.Usage, fmt.Errorf(
+			"distilled content violates the response schema (does the "+
+				"server enforce json_schema?): %w", err,
+		)
+	}
+	return entries, parsed.Usage, nil
+}
+
+// parseEntries decodes and validates distilled content against the same
+// constraints entrySchema requests: an entries array must be present,
+// unknown fields are rejected, and every entry needs a known type, a
+// non-blank title and body, and an entities array.
+func parseEntries(content string) ([]Entry, error) {
+	decoder := json.NewDecoder(strings.NewReader(content))
+	decoder.DisallowUnknownFields()
 	var out struct {
-		Entries []Entry `json:"entries"`
+		Entries *[]struct {
+			Type     string    `json:"type"`
+			Title    string    `json:"title"`
+			Body     string    `json:"body"`
+			Entities *[]string `json:"entities"`
+		} `json:"entries"`
 	}
-	if err := json.Unmarshal([]byte(choice.Message.Content), &out); err != nil {
-		return nil, parsed.Usage, fmt.Errorf("parsing distilled entries: %w", err)
+	if err := decoder.Decode(&out); err != nil {
+		return nil, err
 	}
-	return out.Entries, parsed.Usage, nil
+	if decoder.More() {
+		return nil, fmt.Errorf("trailing data after the entries object")
+	}
+	if out.Entries == nil {
+		return nil, fmt.Errorf("entries array is missing")
+	}
+	entries := make([]Entry, 0, len(*out.Entries))
+	for i, raw := range *out.Entries {
+		if !slices.Contains(entryTypes, raw.Type) {
+			return nil, fmt.Errorf(
+				"entry %d: type %q is not one of %s",
+				i, raw.Type, strings.Join(entryTypes, ", "),
+			)
+		}
+		if strings.TrimSpace(raw.Title) == "" {
+			return nil, fmt.Errorf("entry %d: title is blank", i)
+		}
+		if strings.TrimSpace(raw.Body) == "" {
+			return nil, fmt.Errorf("entry %d: body is blank", i)
+		}
+		if raw.Entities == nil {
+			return nil, fmt.Errorf("entry %d: entities array is missing", i)
+		}
+		entries = append(entries, Entry{
+			Type:     raw.Type,
+			Title:    raw.Title,
+			Body:     raw.Body,
+			Entities: *raw.Entities,
+		})
+	}
+	return entries, nil
 }
 
 // isTransientStatus reports whether an HTTP status is worth retrying:

--- a/internal/recall/extract/client.go
+++ b/internal/recall/extract/client.go
@@ -74,7 +74,8 @@ const compactSuffix = "\n\nIMPORTANT: the output budget is tight for this " +
 // extractionProtocolVersion feeds the generation fingerprint. Bump it when
 // the response schema or the recovery behavior changes in a way that alters
 // extraction output for an identical configuration.
-const extractionProtocolVersion = 1
+// v2: minLength constraints on entry title and body.
+const extractionProtocolVersion = 2
 
 // Entry is one distilled memory entry as the model produces it.
 type Entry struct {
@@ -111,8 +112,8 @@ var entrySchema = map[string]any{
 						"type": "string",
 						"enum": entryTypes,
 					},
-					"title": map[string]any{"type": "string"},
-					"body":  map[string]any{"type": "string"},
+					"title": map[string]any{"type": "string", "minLength": 1},
+					"body":  map[string]any{"type": "string", "minLength": 1},
 					"entities": map[string]any{
 						"type":  "array",
 						"items": map[string]any{"type": "string"},
@@ -390,53 +391,119 @@ func (c *Client) distill(
 
 // parseEntries decodes and validates distilled content against the same
 // constraints entrySchema requests: an entries array must be present,
-// unknown fields are rejected, and every entry needs a known type, a
-// non-blank title and body, and an entities array.
+// keys are matched exactly (Go's struct decoding is case-insensitive, so
+// this walks raw messages instead), unknown keys, nulls, and trailing data
+// are rejected, and every entry needs a known type, a non-blank title and
+// body, and an entities array of strings.
 func parseEntries(content string) ([]Entry, error) {
-	decoder := json.NewDecoder(strings.NewReader(content))
-	decoder.DisallowUnknownFields()
-	var out struct {
-		Entries *[]struct {
-			Type     string    `json:"type"`
-			Title    string    `json:"title"`
-			Body     string    `json:"body"`
-			Entities *[]string `json:"entities"`
-		} `json:"entries"`
-	}
-	if err := decoder.Decode(&out); err != nil {
+	top, err := strictObject(json.RawMessage(content), []string{"entries"})
+	if err != nil {
 		return nil, err
 	}
-	if decoder.More() {
-		return nil, fmt.Errorf("trailing data after the entries object")
+	rawEntries, err := strictArray(top["entries"], "entries")
+	if err != nil {
+		return nil, err
 	}
-	if out.Entries == nil {
-		return nil, fmt.Errorf("entries array is missing")
-	}
-	entries := make([]Entry, 0, len(*out.Entries))
-	for i, raw := range *out.Entries {
-		if !slices.Contains(entryTypes, raw.Type) {
+	entryKeys := []string{"type", "title", "body", "entities"}
+	entries := make([]Entry, 0, len(rawEntries))
+	for i, rawEntry := range rawEntries {
+		fields, err := strictObject(rawEntry, entryKeys)
+		if err != nil {
+			return nil, fmt.Errorf("entry %d: %w", i, err)
+		}
+		var entry Entry
+		if entry.Type, err = strictString(fields["type"], "type"); err != nil {
+			return nil, fmt.Errorf("entry %d: %w", i, err)
+		}
+		if !slices.Contains(entryTypes, entry.Type) {
 			return nil, fmt.Errorf(
 				"entry %d: type %q is not one of %s",
-				i, raw.Type, strings.Join(entryTypes, ", "),
+				i, entry.Type, strings.Join(entryTypes, ", "),
 			)
 		}
-		if strings.TrimSpace(raw.Title) == "" {
+		if entry.Title, err = strictString(fields["title"], "title"); err != nil {
+			return nil, fmt.Errorf("entry %d: %w", i, err)
+		}
+		if strings.TrimSpace(entry.Title) == "" {
 			return nil, fmt.Errorf("entry %d: title is blank", i)
 		}
-		if strings.TrimSpace(raw.Body) == "" {
+		if entry.Body, err = strictString(fields["body"], "body"); err != nil {
+			return nil, fmt.Errorf("entry %d: %w", i, err)
+		}
+		if strings.TrimSpace(entry.Body) == "" {
 			return nil, fmt.Errorf("entry %d: body is blank", i)
 		}
-		if raw.Entities == nil {
-			return nil, fmt.Errorf("entry %d: entities array is missing", i)
+		rawEntities, err := strictArray(fields["entities"], "entities")
+		if err != nil {
+			return nil, fmt.Errorf("entry %d: %w", i, err)
 		}
-		entries = append(entries, Entry{
-			Type:     raw.Type,
-			Title:    raw.Title,
-			Body:     raw.Body,
-			Entities: *raw.Entities,
-		})
+		entry.Entities = make([]string, 0, len(rawEntities))
+		for j, rawEntity := range rawEntities {
+			entity, err := strictString(rawEntity, "entity")
+			if err != nil {
+				return nil, fmt.Errorf("entry %d, entity %d: %w", i, j, err)
+			}
+			entry.Entities = append(entry.Entities, entity)
+		}
+		entries = append(entries, entry)
 	}
 	return entries, nil
+}
+
+// strictObject unmarshals data as a JSON object holding exactly the given
+// keys, matched case-sensitively. json.Unmarshal already rejects trailing
+// data after the value.
+func strictObject(
+	data json.RawMessage, keys []string,
+) (map[string]json.RawMessage, error) {
+	if isJSONNull(data) {
+		return nil, fmt.Errorf("expected an object, got null")
+	}
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(data, &object); err != nil {
+		return nil, err
+	}
+	for _, key := range keys {
+		if _, ok := object[key]; !ok {
+			return nil, fmt.Errorf("required key %q is missing", key)
+		}
+	}
+	for key := range object {
+		if !slices.Contains(keys, key) {
+			return nil, fmt.Errorf("unknown key %q", key)
+		}
+	}
+	return object, nil
+}
+
+func strictArray(
+	data json.RawMessage, name string,
+) ([]json.RawMessage, error) {
+	if isJSONNull(data) {
+		return nil, fmt.Errorf("%s must be an array, got null", name)
+	}
+	var list []json.RawMessage
+	if err := json.Unmarshal(data, &list); err != nil {
+		return nil, fmt.Errorf("%s must be an array: %w", name, err)
+	}
+	return list, nil
+}
+
+func strictString(data json.RawMessage, name string) (string, error) {
+	if isJSONNull(data) {
+		return "", fmt.Errorf("%s must be a string, got null", name)
+	}
+	var value string
+	if err := json.Unmarshal(data, &value); err != nil {
+		return "", fmt.Errorf("%s must be a string: %w", name, err)
+	}
+	return value, nil
+}
+
+// isJSONNull matters because json.Unmarshal treats null as a no-op for
+// maps, slices, and strings instead of reporting a type mismatch.
+func isJSONNull(data json.RawMessage) bool {
+	return string(bytes.TrimSpace(data)) == "null"
 }
 
 // isTransientStatus reports whether an HTTP status is worth retrying:

--- a/internal/recall/extract/client.go
+++ b/internal/recall/extract/client.go
@@ -331,7 +331,8 @@ func (c *Client) distill(
 		}
 	}
 	if len(parsed.Choices) == 0 {
-		return nil, Usage{}, &transientError{
+		// The body parsed, so its usage is real cost even without choices.
+		return nil, parsed.Usage, &transientError{
 			err: fmt.Errorf("distill response has no choices"),
 		}
 	}
@@ -563,6 +564,7 @@ func isContextOverflowDetail(body string) bool {
 		"input is too long", "input too long",
 		"input is too large", "input too large",
 		"prompt is too long", "prompt too long",
+		"prompt is too large", "prompt too large",
 	}) {
 		return true
 	}

--- a/internal/recall/extract/client.go
+++ b/internal/recall/extract/client.go
@@ -99,19 +99,14 @@ var entrySchema = map[string]any{
 }
 
 // Client distills unit text into entries through an OpenAI-compatible chat
-// completion endpoint with constrained decoding.
+// completion endpoint with constrained decoding. Every output-affecting
+// parameter lives in Request so it is covered by the generation
+// fingerprint.
 type Client struct {
-	BaseURL string
-	Model   string
-	// CompactFloorChars bounds the compact retry: a truncated unit longer
-	// than this returns ErrPersistentTruncation immediately so the caller
-	// splits it without losing entries; a unit at or below it (too small
-	// for splitting to help) gets one compact retry first. Callers set it
-	// to SplitFloorChars of their window budget; zero disables the compact
-	// retry entirely.
-	CompactFloorChars int
-	HTTPClient        *http.Client
-	Request           RequestShape
+	BaseURL    string
+	Model      string
+	HTTPClient *http.Client
+	Request    RequestShape
 }
 
 func (c *Client) httpClient() *http.Client {
@@ -123,17 +118,19 @@ func (c *Client) httpClient() *http.Client {
 
 // DistillWithRecovery runs one unit through the model with the recovery
 // ladder: transient failures are retried up to maxAttempts per phase;
-// truncated output on a unit at or below CompactFloorChars triggers exactly
+// truncated output on a unit at or below the compact floor triggers exactly
 // one compact retry (temperature-zero sampling makes same-input retries
 // useless); truncation on a splittable unit, or truncation that survives
 // the compact retry, surfaces as ErrPersistentTruncation and a context
 // overflow as ErrContextOverflow — both mean "split this unit", which the
-// caller owns because it also owns unit identity.
+// caller owns because it also owns unit identity. The returned Usage sums
+// every attempt, successful or not, so recovery costs are accounted.
 func (c *Client) DistillWithRecovery(
 	ctx context.Context, systemPrompt, text string, maxAttempts int,
 ) ([]Entry, Usage, error) {
+	var total Usage
 	if c.Request.MaxTokens <= 0 {
-		return nil, Usage{}, fmt.Errorf(
+		return nil, total, fmt.Errorf(
 			"extraction request max_tokens must be positive; the profile or "+
 				"configuration must set it (got %d)", c.Request.MaxTokens,
 		)
@@ -141,30 +138,32 @@ func (c *Client) DistillWithRecovery(
 	// Rune count, not byte length: segmentation budgets count code points,
 	// so the floor must measure units the same way.
 	unitChars := utf8.RuneCountInString(text)
-	compactAllowed := unitChars <= c.CompactFloorChars
+	compactAllowed := unitChars <= c.Request.CompactFloorChars
 	for _, compact := range []bool{false, true} {
 		var lastErr error
 		truncated := false
 		for range maxAttempts {
 			entries, usage, err := c.distill(ctx, systemPrompt, text, compact)
+			total.PromptTokens += usage.PromptTokens
+			total.CompletionTokens += usage.CompletionTokens
 			if err == nil {
-				return entries, usage, nil
+				return entries, total, nil
 			}
 			if errors.Is(err, ErrContextOverflow) ||
 				errors.Is(err, errPermanentRequest) {
-				return nil, Usage{}, err
+				return nil, total, err
 			}
 			if errors.Is(err, errTruncated) {
 				truncated = true
 				break
 			}
 			if ctx.Err() != nil {
-				return nil, Usage{}, ctx.Err()
+				return nil, total, ctx.Err()
 			}
 			lastErr = err
 		}
 		if !truncated {
-			return nil, Usage{}, fmt.Errorf(
+			return nil, total, fmt.Errorf(
 				"distilling unit after %d attempts: %w", maxAttempts, lastErr,
 			)
 		}
@@ -172,7 +171,7 @@ func (c *Client) DistillWithRecovery(
 			break
 		}
 	}
-	return nil, Usage{}, fmt.Errorf(
+	return nil, total, fmt.Errorf(
 		"unit of %d chars: %w", unitChars, ErrPersistentTruncation,
 	)
 }
@@ -265,9 +264,11 @@ func (c *Client) distill(
 	if len(parsed.Choices) == 0 {
 		return nil, Usage{}, fmt.Errorf("distill response has no choices")
 	}
+	// From here the server reports token usage even when the attempt fails,
+	// so error returns carry parsed.Usage for the caller's accounting.
 	choice := parsed.Choices[0]
 	if choice.FinishReason == "length" {
-		return nil, Usage{}, fmt.Errorf(
+		return nil, parsed.Usage, fmt.Errorf(
 			"at max_tokens=%d: %w", c.Request.MaxTokens, errTruncated,
 		)
 	}
@@ -275,7 +276,7 @@ func (c *Client) distill(
 		// Empty content with a normal finish reason means the token budget
 		// went somewhere invisible (typically hidden reasoning the request
 		// shape should have disabled).
-		return nil, Usage{}, fmt.Errorf(
+		return nil, parsed.Usage, fmt.Errorf(
 			"distill response content is empty; check the model profile's " +
 				"request shape",
 		)
@@ -284,7 +285,7 @@ func (c *Client) distill(
 		Entries []Entry `json:"entries"`
 	}
 	if err := json.Unmarshal([]byte(choice.Message.Content), &out); err != nil {
-		return nil, Usage{}, fmt.Errorf("parsing distilled entries: %w", err)
+		return nil, parsed.Usage, fmt.Errorf("parsing distilled entries: %w", err)
 	}
 	return out.Entries, parsed.Usage, nil
 }

--- a/internal/recall/extract/client.go
+++ b/internal/recall/extract/client.go
@@ -343,6 +343,15 @@ func (c *Client) distill(
 			"at max_tokens=%d: %w", c.Request.MaxTokens, errTruncated,
 		)
 	}
+	if choice.FinishReason != "stop" {
+		// A filtered or otherwise cut-off response can still carry valid
+		// JSON with fewer entries; only "stop" means the model finished.
+		// Deterministic for the same input, so it fails fast.
+		return nil, parsed.Usage, fmt.Errorf(
+			"distill response finished with %q instead of completing; "+
+				"refusing possibly incomplete entries", choice.FinishReason,
+		)
+	}
 	if choice.Message.Content == "" {
 		// Empty content with a normal finish reason means the token budget
 		// went somewhere invisible (typically hidden reasoning the request
@@ -561,8 +570,11 @@ func isContextOverflowDetail(body string) bool {
 	}
 	// Bare "input" is deliberately not a subject: servers prefix arbitrary
 	// validation errors with "Input validation error:", which would pair
-	// with the overflow term of any out-of-range parameter.
-	subjects := []string{"context", "prompt"}
+	// with the overflow term of any out-of-range parameter. The
+	// length-qualified forms "input length" and "input tokens" are safe
+	// subjects — paired with an overflow term they describe the input's
+	// size, while "invalid input length parameter" has no overflow term.
+	subjects := []string{"context", "prompt", "input length", "input tokens"}
 	overflowTerms := []string{"exceed", "too long", "too large", "maximum"}
 	hasSubject := slices.ContainsFunc(subjects, func(subject string) bool {
 		return strings.Contains(lower, subject)

--- a/internal/recall/extract/client.go
+++ b/internal/recall/extract/client.go
@@ -543,46 +543,46 @@ func isContextOverflowDetail(body string) bool {
 			return true
 		}
 	}
-	// Output-budget validation names the parameter ("Input validation
-	// error: max_tokens exceeds the maximum allowed value") and often
-	// carries both a subject and an overflow term; unless the message also
-	// names the context length explicitly, splitting the input cannot fix
-	// it, so it is not an overflow.
-	outputBudgetParams := []string{
-		"max_tokens", "max_new_tokens", "max_completion_tokens",
+	containsAny := func(needles []string) bool {
+		return slices.ContainsFunc(needles, func(needle string) bool {
+			return strings.Contains(lower, needle)
+		})
 	}
-	if slices.ContainsFunc(outputBudgetParams, func(param string) bool {
-		return strings.Contains(lower, param)
-	}) {
-		return strings.Contains(lower, "context length") ||
-			strings.Contains(lower, "context size") ||
-			strings.Contains(lower, "context window")
-	}
-	// Length-specific input phrasings are unambiguous on their own.
-	lengthPhrases := []string{
+	hasOverflowTerm := containsAny(
+		[]string{"exceed", "too long", "too large", "maximum"},
+	)
+	// Explicit input-side length evidence wins outright — including
+	// combined-budget messages like "input tokens plus max_tokens exceed
+	// the model maximum", which splitting the input does fix. Bare "input"
+	// and bare "prompt" are deliberately not subjects: servers prefix
+	// arbitrary validation errors with "Input validation error:", and
+	// parameter names like prompt_logprobs would pair with any overflow
+	// term. Length-qualified forms are safe — "invalid input length
+	// parameter" has no overflow term.
+	if containsAny([]string{
 		"input is too long", "input too long",
 		"input is too large", "input too large",
-	}
-	if slices.ContainsFunc(lengthPhrases, func(phrase string) bool {
-		return strings.Contains(lower, phrase)
+		"prompt is too long", "prompt too long",
 	}) {
 		return true
 	}
-	// Bare "input" is deliberately not a subject: servers prefix arbitrary
-	// validation errors with "Input validation error:", which would pair
-	// with the overflow term of any out-of-range parameter. The
-	// length-qualified forms "input length" and "input tokens" are safe
-	// subjects — paired with an overflow term they describe the input's
-	// size, while "invalid input length parameter" has no overflow term.
-	subjects := []string{"context", "prompt", "input length", "input tokens"}
-	overflowTerms := []string{"exceed", "too long", "too large", "maximum"}
-	hasSubject := slices.ContainsFunc(subjects, func(subject string) bool {
-		return strings.Contains(lower, subject)
-	})
-	hasOverflowTerm := slices.ContainsFunc(overflowTerms, func(term string) bool {
-		return strings.Contains(lower, term)
-	})
-	return hasSubject && hasOverflowTerm
+	if hasOverflowTerm && containsAny([]string{
+		"input length", "input tokens", "prompt length", "prompt tokens",
+	}) {
+		return true
+	}
+	// With no input-side evidence, a message naming an output-budget
+	// parameter is a configuration error — even "max_tokens exceeds the
+	// context window" is not fixed by splitting the input.
+	if containsAny([]string{
+		"max_tokens", "max_new_tokens", "max_completion_tokens",
+	}) {
+		return false
+	}
+	// Bare "context" paired with an overflow term covers the common server
+	// phrasings: "maximum context length is ...", "exceeds the available
+	// context size".
+	return hasOverflowTerm && strings.Contains(lower, "context")
 }
 
 // SplitFloorChars is the smallest unit size worth splitting further. A unit

--- a/internal/recall/extract/client.go
+++ b/internal/recall/extract/client.go
@@ -22,16 +22,17 @@ import (
 var ErrContextOverflow = errors.New("unit text overflows the model context")
 
 // ErrPersistentTruncation reports output the client cannot recover: the
-// token budget truncated a unit large enough to split (splitting preserves
-// every entry, so no compact retry is attempted), or a unit at the compact
-// floor stayed truncated even after the compact retry. Like an overflow,
-// the recovery is splitting the unit into smaller pieces.
+// token budget truncated the unit's entries. Splitting the unit preserves
+// every entry, so the caller splits until SplitFloorChars; a unit at the
+// floor that still truncates needs a larger max_tokens, and the error says
+// so. There is deliberately no retry that caps the entry count: a capped
+// response looks complete while silently dropping entries.
 var ErrPersistentTruncation = errors.New(
 	"model output truncated at the token budget",
 )
 
 // errTruncated is the per-request truncation signal that
-// DistillWithRecovery converts into a split signal or a compact retry.
+// DistillWithRecovery converts into the typed split signal.
 var errTruncated = errors.New("model output truncated")
 
 // errPermanentRequest marks a server rejection that retrying the same
@@ -62,20 +63,12 @@ var reservedRequestKeys = []string{
 // backoff growth or an excessive Retry-After header.
 const maxRetryDelay = 30 * time.Second
 
-// compactSuffix is appended on the truncation retry of a unit too small to
-// split. Sampling at temperature zero makes a same-input retry
-// deterministic, so the retry must change the input instead of hoping for
-// different output; capping the entry count is acceptable only here, where
-// splitting cannot recover the lost entries anyway.
-const compactSuffix = "\n\nIMPORTANT: the output budget is tight for this " +
-	"window. Return at most 4 entries, each with a body of at most 2 " +
-	"sentences."
-
 // extractionProtocolVersion feeds the generation fingerprint. Bump it when
 // the response schema or the recovery behavior changes in a way that alters
 // extraction output for an identical configuration.
 // v2: minLength constraints on entry title and body.
-const extractionProtocolVersion = 2
+// v3: truncation always splits; the entry-capped compact retry is gone.
+const extractionProtocolVersion = 3
 
 // Entry is one distilled memory entry as the model produces it.
 type Entry struct {
@@ -159,15 +152,12 @@ func (c *Client) retryBackoff() time.Duration {
 
 // DistillWithRecovery runs one unit through the model with the recovery
 // ladder: transient failures (network errors, timeouts, rate limits,
-// server errors) are retried up to maxAttempts per phase with exponential
-// backoff honoring Retry-After, while permanent rejections fail fast;
-// truncated output on a unit at or below the compact floor triggers exactly
-// one compact retry (temperature-zero sampling makes same-input retries
-// useless); truncation on a splittable unit, or truncation that survives
-// the compact retry, surfaces as ErrPersistentTruncation and a context
-// overflow as ErrContextOverflow — both mean "split this unit", which the
-// caller owns because it also owns unit identity. The returned Usage sums
-// every attempt, successful or not, so recovery costs are accounted.
+// server errors) are retried up to maxAttempts with exponential backoff
+// honoring Retry-After, while permanent rejections fail fast; truncated
+// output surfaces as ErrPersistentTruncation and a context overflow as
+// ErrContextOverflow — both mean "split this unit", which the caller owns
+// because it also owns unit identity. The returned Usage sums every
+// attempt, successful or not, so recovery costs are accounted.
 func (c *Client) DistillWithRecovery(
 	ctx context.Context, systemPrompt, text string, maxAttempts int,
 ) ([]Entry, Usage, error) {
@@ -186,75 +176,61 @@ func (c *Client) DistillWithRecovery(
 			)
 		}
 	}
-	// Rune count, not byte length: segmentation budgets count code points,
-	// so the floor must measure units the same way.
-	unitChars := utf8.RuneCountInString(text)
-	compactAllowed := unitChars <= c.Request.CompactFloorChars
-	for _, compact := range []bool{false, true} {
-		var lastErr error
-		truncated := false
-		for attempt := range maxAttempts {
-			entries, usage, err := c.distill(ctx, systemPrompt, text, compact)
-			total.PromptTokens += usage.PromptTokens
-			total.CompletionTokens += usage.CompletionTokens
-			if err == nil {
-				return entries, total, nil
-			}
-			if errors.Is(err, errTruncated) {
-				truncated = true
-				break
-			}
-			var transient *transientError
-			if !errors.As(err, &transient) {
-				return nil, total, err
-			}
-			lastErr = err
-			if attempt+1 >= maxAttempts {
-				break
-			}
-			delay := transient.retryAfter
-			if delay <= 0 {
-				delay = c.retryBackoff() << attempt
-			}
-			if delay > maxRetryDelay {
-				delay = maxRetryDelay
-			}
-			timer := time.NewTimer(delay)
-			select {
-			case <-ctx.Done():
-				timer.Stop()
-				return nil, total, ctx.Err()
-			case <-timer.C:
-			}
+	var lastErr error
+	for attempt := range maxAttempts {
+		entries, usage, err := c.distill(ctx, systemPrompt, text)
+		total.PromptTokens += usage.PromptTokens
+		total.CompletionTokens += usage.CompletionTokens
+		if err == nil {
+			return entries, total, nil
 		}
-		if !truncated {
+		if errors.Is(err, errTruncated) {
+			// Rune count, not byte length: split budgets count code points.
 			return nil, total, fmt.Errorf(
-				"distilling unit after %d attempts: %w", maxAttempts, lastErr,
+				"unit of %d chars at max_tokens=%d (split the unit, or raise "+
+					"max_tokens if it is already at the split floor): %w",
+				utf8.RuneCountInString(text), c.Request.MaxTokens,
+				ErrPersistentTruncation,
 			)
 		}
-		if !compactAllowed {
+		var transient *transientError
+		if !errors.As(err, &transient) {
+			return nil, total, err
+		}
+		lastErr = err
+		if attempt+1 >= maxAttempts {
 			break
+		}
+		delay := transient.retryAfter
+		if delay <= 0 {
+			delay = c.retryBackoff() << attempt
+		}
+		if delay > maxRetryDelay {
+			delay = maxRetryDelay
+		}
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, total, ctx.Err()
+		case <-timer.C:
 		}
 	}
 	return nil, total, fmt.Errorf(
-		"unit of %d chars: %w", unitChars, ErrPersistentTruncation,
+		"distilling unit after %d attempts: %w", maxAttempts, lastErr,
 	)
 }
 
 func (c *Client) distill(
-	ctx context.Context, systemPrompt, text string, compact bool,
+	ctx context.Context, systemPrompt, text string,
 ) ([]Entry, Usage, error) {
-	userText := text
-	if compact {
-		userText += compactSuffix
-	}
 	payload := map[string]any{
 		"model":       c.Model,
 		"max_tokens":  c.Request.MaxTokens,
 		"temperature": c.Request.Temperature,
 		"messages": []map[string]string{
 			{"role": "system", "content": systemPrompt},
-			{"role": "user", "content": userText},
+			{"role": "user", "content": text},
 		},
 		"response_format": map[string]any{
 			"type": "json_schema",
@@ -309,7 +285,7 @@ func (c *Client) distill(
 		if isContextOverflowDetail(string(raw)) {
 			return nil, Usage{}, fmt.Errorf(
 				"%d-char unit: %w: %s",
-				utf8.RuneCountInString(userText), ErrContextOverflow, detail,
+				utf8.RuneCountInString(text), ErrContextOverflow, detail,
 			)
 		}
 		return nil, Usage{}, fmt.Errorf(
@@ -557,6 +533,21 @@ func isContextOverflowDetail(body string) bool {
 		if strings.Contains(lower, code) {
 			return true
 		}
+	}
+	// Output-budget validation names the parameter ("Input validation
+	// error: max_tokens exceeds the maximum allowed value") and often
+	// carries both a subject and an overflow term; unless the message also
+	// names the context length explicitly, splitting the input cannot fix
+	// it, so it is not an overflow.
+	outputBudgetParams := []string{
+		"max_tokens", "max_new_tokens", "max_completion_tokens",
+	}
+	if slices.ContainsFunc(outputBudgetParams, func(param string) bool {
+		return strings.Contains(lower, param)
+	}) {
+		return strings.Contains(lower, "context length") ||
+			strings.Contains(lower, "context size") ||
+			strings.Contains(lower, "context window")
 	}
 	subjects := []string{"context", "prompt", "input"}
 	overflowTerms := []string{"exceed", "too long", "too large", "maximum"}

--- a/internal/recall/extract/client_test.go
+++ b/internal/recall/extract/client_test.go
@@ -436,14 +436,21 @@ func TestClientRejectsSchemaViolatingContent(t *testing.T) {
 	// advancing progress with silently lost or malformed entries. At
 	// temperature zero the violation is deterministic, so no retry.
 	cases := map[string]string{
-		"empty object":     `{}`,
-		"null":             `null`,
-		"top-level array":  `[]`,
-		"unknown type":     `{"entries":[{"type":"story","title":"t","body":"b","entities":[]}]}`,
-		"blank title":      `{"entries":[{"type":"fact","title":" ","body":"b","entities":[]}]}`,
-		"blank body":       `{"entries":[{"type":"fact","title":"t","body":"","entities":[]}]}`,
-		"missing entities": `{"entries":[{"type":"fact","title":"t","body":"b"}]}`,
-		"unknown field":    `{"entries":[{"type":"fact","title":"t","body":"b","entities":[],"extra":1}]}`,
+		"empty object":        `{}`,
+		"null":                `null`,
+		"top-level array":     `[]`,
+		"unknown type":        `{"entries":[{"type":"story","title":"t","body":"b","entities":[]}]}`,
+		"blank title":         `{"entries":[{"type":"fact","title":" ","body":"b","entities":[]}]}`,
+		"blank body":          `{"entries":[{"type":"fact","title":"t","body":"","entities":[]}]}`,
+		"missing entities":    `{"entries":[{"type":"fact","title":"t","body":"b"}]}`,
+		"unknown field":       `{"entries":[{"type":"fact","title":"t","body":"b","entities":[],"extra":1}]}`,
+		"case-mismatched key": `{"Entries":[]}`,
+		"null entries":        `{"entries":null}`,
+		"null entry":          `{"entries":[null]}`,
+		"null title":          `{"entries":[{"type":"fact","title":null,"body":"b","entities":[]}]}`,
+		"null entity element": `{"entries":[{"type":"fact","title":"t","body":"b","entities":["a",null]}]}`,
+		"non-string entity":   `{"entries":[{"type":"fact","title":"t","body":"b","entities":[1]}]}`,
+		"trailing delimiter":  `{"entries":[]}]`,
 	}
 	for name, content := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/recall/extract/client_test.go
+++ b/internal/recall/extract/client_test.go
@@ -86,12 +86,13 @@ func testClient(url string) *Client {
 	return &Client{
 		BaseURL: url,
 		Model:   "test-model",
-		// The compact floor covers the short unit texts these tests send, so
-		// truncation exercises the compact retry unless a test says otherwise.
-		CompactFloorChars: 64,
 		Request: RequestShape{
 			Temperature: 0,
 			MaxTokens:   100,
+			// The compact floor covers the short unit texts these tests
+			// send, so truncation exercises the compact retry unless a
+			// test says otherwise.
+			CompactFloorChars: 64,
 			ExtraBody: map[string]any{
 				"chat_template_kwargs": map[string]any{
 					"enable_thinking": false,
@@ -255,7 +256,7 @@ func TestClientCompactRetryOnTruncation(t *testing.T) {
 	}, &requests)
 	defer server.Close()
 
-	entries, _, err := testClient(server.URL).DistillWithRecovery(
+	entries, usage, err := testClient(server.URL).DistillWithRecovery(
 		context.Background(), "p", "unit text", 3,
 	)
 	if err != nil {
@@ -271,6 +272,9 @@ func TestClientCompactRetryOnTruncation(t *testing.T) {
 	if !strings.Contains(second["content"].(string), "output budget is tight") {
 		t.Fatal("compact retry must append the compact instruction")
 	}
+	if usage.PromptTokens != 14 || usage.CompletionTokens != 6 {
+		t.Fatalf("usage = %+v, want both attempts accounted (14/6)", usage)
+	}
 }
 
 func TestClientPersistentTruncationIsTyped(t *testing.T) {
@@ -281,7 +285,7 @@ func TestClientPersistentTruncationIsTyped(t *testing.T) {
 	}, &requests)
 	defer server.Close()
 
-	_, _, err := testClient(server.URL).DistillWithRecovery(
+	_, usage, err := testClient(server.URL).DistillWithRecovery(
 		context.Background(), "p", "text", 3,
 	)
 	if !errors.Is(err, ErrPersistentTruncation) {
@@ -290,6 +294,10 @@ func TestClientPersistentTruncationIsTyped(t *testing.T) {
 	if len(requests) != 2 {
 		t.Fatalf("requests = %d, want 2 (below the floor: one compact retry)",
 			len(requests))
+	}
+	if usage.PromptTokens != 14 || usage.CompletionTokens != 6 {
+		t.Fatalf("usage = %+v, want truncated attempts accounted (14/6)",
+			usage)
 	}
 }
 

--- a/internal/recall/extract/client_test.go
+++ b/internal/recall/extract/client_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 type scriptedResponse struct {
@@ -86,6 +87,8 @@ func testClient(url string) *Client {
 	return &Client{
 		BaseURL: url,
 		Model:   "test-model",
+		// Keep transient-retry backoff out of test wall-clock time.
+		RetryBackoff: time.Millisecond,
 		Request: RequestShape{
 			Temperature: 0,
 			MaxTokens:   100,
@@ -328,6 +331,7 @@ func TestClientRetriesTransientErrors(t *testing.T) {
 	var requests []map[string]any
 	server := newScriptedServer(t, []scriptedResponse{
 		{status: http.StatusInternalServerError},
+		{status: http.StatusTooManyRequests},
 		{finishReason: "stop", content: entriesJSON(t, "ok")},
 	}, &requests)
 	defer server.Close()
@@ -338,18 +342,80 @@ func TestClientRetriesTransientErrors(t *testing.T) {
 	if err != nil || len(entries) != 1 {
 		t.Fatalf("entries=%v err=%v", entries, err)
 	}
+	if len(requests) != 3 {
+		t.Fatalf("requests = %d, want 3 (5xx and 429 are transient)",
+			len(requests))
+	}
+}
+
+func TestClientPermanentHTTPStatusFailsFast(t *testing.T) {
+	// 401/403/404 will not fix themselves; retrying burns the budget and
+	// hides the configuration problem behind attempt noise.
+	var requests []map[string]any
+	server := newScriptedServer(t, []scriptedResponse{
+		{status: http.StatusUnauthorized},
+	}, &requests)
+	defer server.Close()
+
+	_, _, err := testClient(server.URL).DistillWithRecovery(
+		context.Background(), "p", "text", 3,
+	)
+	if err == nil {
+		t.Fatal("unauthorized must be an error")
+	}
+	if len(requests) != 1 {
+		t.Fatalf("requests = %d, want 1 (permanent statuses are not retried)",
+			len(requests))
+	}
+}
+
+func TestClientRejectsReservedExtraBodyKeys(t *testing.T) {
+	// A profile or override smuggling max_tokens through the extra body
+	// would bypass validation and desynchronize the generation fingerprint
+	// from the request actually sent.
+	var requests []map[string]any
+	server := newScriptedServer(t, nil, &requests)
+	defer server.Close()
+
+	client := testClient(server.URL)
+	client.Request.ExtraBody = map[string]any{"max_tokens": 5}
+	_, _, err := client.DistillWithRecovery(
+		context.Background(), "p", "text", 3,
+	)
+	if err == nil || !strings.Contains(err.Error(), "max_tokens") {
+		t.Fatalf("err = %v, want reserved-key rejection naming the key", err)
+	}
+	if len(requests) != 0 {
+		t.Fatalf("requests = %d, want 0 (rejected before any call)",
+			len(requests))
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	if got := parseRetryAfter("2"); got != 2*time.Second {
+		t.Fatalf("parseRetryAfter(2) = %v", got)
+	}
+	future := time.Now().Add(5 * time.Second).UTC().Format(http.TimeFormat)
+	got := parseRetryAfter(future)
+	if got <= 0 || got > 5*time.Second {
+		t.Fatalf("parseRetryAfter(http-date) = %v", got)
+	}
+	for _, value := range []string{"", "garbage", "-3"} {
+		if got := parseRetryAfter(value); got != 0 {
+			t.Fatalf("parseRetryAfter(%q) = %v, want 0", value, got)
+		}
+	}
 }
 
 func TestClientEmptyContentIsError(t *testing.T) {
 	// A model that burns its budget on hidden reasoning returns empty
 	// content with finish_reason stop; that must surface as an error, not
-	// as zero entries.
+	// as zero entries — and at temperature zero a same-input retry gives
+	// the same emptiness, so it must not be retried.
 	var requests []map[string]any
-	responses := make([]scriptedResponse, 3)
-	for i := range responses {
-		responses[i] = scriptedResponse{finishReason: "stop", content: ""}
-	}
-	server := newScriptedServer(t, responses, &requests)
+	server := newScriptedServer(t, []scriptedResponse{
+		{finishReason: "stop", content: ""},
+	}, &requests)
 	defer server.Close()
 
 	_, _, err := testClient(server.URL).DistillWithRecovery(
@@ -357,6 +423,10 @@ func TestClientEmptyContentIsError(t *testing.T) {
 	)
 	if err == nil {
 		t.Fatal("empty content must be an error")
+	}
+	if len(requests) != 1 {
+		t.Fatalf("requests = %d, want 1 (deterministic emptiness is not retried)",
+			len(requests))
 	}
 }
 

--- a/internal/recall/extract/client_test.go
+++ b/internal/recall/extract/client_test.go
@@ -92,10 +92,6 @@ func testClient(url string) *Client {
 		Request: RequestShape{
 			Temperature: 0,
 			MaxTokens:   100,
-			// The compact floor covers the short unit texts these tests
-			// send, so truncation exercises the compact retry unless a
-			// test says otherwise.
-			CompactFloorChars: 64,
 			ExtraBody: map[string]any{
 				"chat_template_kwargs": map[string]any{
 					"enable_thinking": false,
@@ -155,27 +151,28 @@ func TestClientTrailingSlashBaseURL(t *testing.T) {
 	}
 }
 
-func TestClientCompactFloorCountsRunesNotBytes(t *testing.T) {
-	// Segmentation budgets count code points, so the compact floor must
-	// too: 40 three-byte runes are 120 bytes but still one unsplittable
-	// 40-rune unit under the 64-rune floor, and must get the compact retry.
+func TestClientTruncationIsTypedSplitSignal(t *testing.T) {
+	// Truncation is never retried or compacted: any retry that caps the
+	// entry count would look complete while silently dropping entries, so
+	// the only recovery is the caller splitting the unit.
 	var requests []map[string]any
 	server := newScriptedServer(t, []scriptedResponse{
 		{finishReason: "length", content: ""},
-		{finishReason: "stop", content: entriesJSON(t, "compact")},
 	}, &requests)
 	defer server.Close()
 
-	text := strings.Repeat("日", 40)
-	entries, _, err := testClient(server.URL).DistillWithRecovery(
-		context.Background(), "p", text, 3,
+	_, usage, err := testClient(server.URL).DistillWithRecovery(
+		context.Background(), "p", "unit text", 3,
 	)
-	if err != nil {
-		t.Fatalf("DistillWithRecovery: %v", err)
+	if !errors.Is(err, ErrPersistentTruncation) {
+		t.Fatalf("err = %v, want ErrPersistentTruncation", err)
 	}
-	if len(entries) != 1 || len(requests) != 2 {
-		t.Fatalf("entries=%d requests=%d, want compact retry to run",
-			len(entries), len(requests))
+	if len(requests) != 1 {
+		t.Fatalf("requests = %d, want 1 (truncation is deterministic)",
+			len(requests))
+	}
+	if usage.PromptTokens != 7 || usage.CompletionTokens != 3 {
+		t.Fatalf("usage = %+v, want the truncated attempt accounted", usage)
 	}
 }
 
@@ -251,39 +248,12 @@ func TestClientBadRequestOtherThanOverflowIsPermanent(t *testing.T) {
 	}
 }
 
-func TestClientCompactRetryOnTruncation(t *testing.T) {
+func TestClientTruncationAfterTransientRetryAccountsUsage(t *testing.T) {
+	// A transient failure followed by truncation must surface the split
+	// signal with the usage of every attempt that reported it.
 	var requests []map[string]any
 	server := newScriptedServer(t, []scriptedResponse{
-		{finishReason: "length", content: ""},
-		{finishReason: "stop", content: entriesJSON(t, "compact")},
-	}, &requests)
-	defer server.Close()
-
-	entries, usage, err := testClient(server.URL).DistillWithRecovery(
-		context.Background(), "p", "unit text", 3,
-	)
-	if err != nil {
-		t.Fatalf("DistillWithRecovery: %v", err)
-	}
-	if len(entries) != 1 {
-		t.Fatalf("entries = %+v", entries)
-	}
-	if len(requests) != 2 {
-		t.Fatalf("requests = %d, want 2 (truncation triggers one compact retry)", len(requests))
-	}
-	second := requests[1]["messages"].([]any)[1].(map[string]any)
-	if !strings.Contains(second["content"].(string), "output budget is tight") {
-		t.Fatal("compact retry must append the compact instruction")
-	}
-	if usage.PromptTokens != 14 || usage.CompletionTokens != 6 {
-		t.Fatalf("usage = %+v, want both attempts accounted (14/6)", usage)
-	}
-}
-
-func TestClientPersistentTruncationIsTyped(t *testing.T) {
-	var requests []map[string]any
-	server := newScriptedServer(t, []scriptedResponse{
-		{finishReason: "length", content: ""},
+		{status: http.StatusInternalServerError},
 		{finishReason: "length", content: ""},
 	}, &requests)
 	defer server.Close()
@@ -295,35 +265,11 @@ func TestClientPersistentTruncationIsTyped(t *testing.T) {
 		t.Fatalf("err = %v, want ErrPersistentTruncation", err)
 	}
 	if len(requests) != 2 {
-		t.Fatalf("requests = %d, want 2 (below the floor: one compact retry)",
-			len(requests))
+		t.Fatalf("requests = %d, want 2 (one transient retry, then "+
+			"truncation)", len(requests))
 	}
-	if usage.PromptTokens != 14 || usage.CompletionTokens != 6 {
-		t.Fatalf("usage = %+v, want truncated attempts accounted (14/6)",
-			usage)
-	}
-}
-
-func TestClientTruncationAboveFloorSplitsInsteadOfCompacting(t *testing.T) {
-	// The compact retry caps the entry count, so on a unit large enough to
-	// split it would silently drop entries; truncation must surface the
-	// typed split signal without a compact attempt.
-	var requests []map[string]any
-	server := newScriptedServer(t, []scriptedResponse{
-		{finishReason: "length", content: ""},
-	}, &requests)
-	defer server.Close()
-
-	longText := strings.Repeat("dense unit text ", 32)
-	_, _, err := testClient(server.URL).DistillWithRecovery(
-		context.Background(), "p", longText, 3,
-	)
-	if !errors.Is(err, ErrPersistentTruncation) {
-		t.Fatalf("err = %v, want ErrPersistentTruncation", err)
-	}
-	if len(requests) != 1 {
-		t.Fatalf("requests = %d, want 1 (no compact retry above the floor)",
-			len(requests))
+	if usage.PromptTokens != 7 || usage.CompletionTokens != 3 {
+		t.Fatalf("usage = %+v, want the truncated attempt accounted", usage)
 	}
 }
 
@@ -413,6 +359,7 @@ func TestIsContextOverflowDetail(t *testing.T) {
 		`max_tokens must be a positive integer`,
 		`max_tokens exceeds the maximum allowed value`,
 		`max_new_tokens exceeds the model limit`,
+		`Input validation error: max_tokens exceeds the maximum allowed value`,
 		`model "test-model" not found`,
 	}
 	for _, body := range notOverflow {

--- a/internal/recall/extract/client_test.go
+++ b/internal/recall/extract/client_test.go
@@ -346,6 +346,7 @@ func TestIsContextOverflowDetail(t *testing.T) {
 		`input is too large for the model context`,
 		`input length 5000 exceeds maximum 4096`,
 		`input tokens (6000) exceed the model maximum`,
+		`input tokens plus max_tokens exceed the model maximum`,
 	}
 	for _, body := range overflow {
 		if !isContextOverflowDetail(body) {
@@ -364,6 +365,8 @@ func TestIsContextOverflowDetail(t *testing.T) {
 		`Input validation error: max_tokens exceeds the maximum allowed value`,
 		`Input validation error: temperature exceeds the maximum allowed value`,
 		`invalid input: repetition_penalty exceeds maximum`,
+		`prompt_logprobs exceeds maximum allowed value`,
+		`max_tokens (5000) exceeds the context window (4096)`,
 		`model "test-model" not found`,
 	}
 	for _, body := range notOverflow {

--- a/internal/recall/extract/client_test.go
+++ b/internal/recall/extract/client_test.go
@@ -360,6 +360,8 @@ func TestIsContextOverflowDetail(t *testing.T) {
 		`max_tokens exceeds the maximum allowed value`,
 		`max_new_tokens exceeds the model limit`,
 		`Input validation error: max_tokens exceeds the maximum allowed value`,
+		`Input validation error: temperature exceeds the maximum allowed value`,
+		`invalid input: repetition_penalty exceeds maximum`,
 		`model "test-model" not found`,
 	}
 	for _, body := range notOverflow {

--- a/internal/recall/extract/client_test.go
+++ b/internal/recall/extract/client_test.go
@@ -25,6 +25,9 @@ func newScriptedServer(
 	var index atomic.Int64
 	return httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/chat/completions" {
+				t.Errorf("request path = %q, want /chat/completions", r.URL.Path)
+			}
 			var payload map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 				t.Errorf("decoding request: %v", err)
@@ -129,6 +132,68 @@ func TestClientDistillParsesEntriesAndSendsShape(t *testing.T) {
 	}
 	if _, ok := payload["response_format"]; !ok {
 		t.Fatal("constrained decoding must be requested")
+	}
+}
+
+func TestClientTrailingSlashBaseURL(t *testing.T) {
+	var requests []map[string]any
+	server := newScriptedServer(t, []scriptedResponse{
+		{finishReason: "stop", content: entriesJSON(t, "one")},
+	}, &requests)
+	defer server.Close()
+
+	client := testClient(server.URL + "/")
+	entries, _, err := client.DistillWithRecovery(
+		context.Background(), "p", "text", 3,
+	)
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("entries=%v err=%v", entries, err)
+	}
+}
+
+func TestClientCompactFloorCountsRunesNotBytes(t *testing.T) {
+	// Segmentation budgets count code points, so the compact floor must
+	// too: 40 three-byte runes are 120 bytes but still one unsplittable
+	// 40-rune unit under the 64-rune floor, and must get the compact retry.
+	var requests []map[string]any
+	server := newScriptedServer(t, []scriptedResponse{
+		{finishReason: "length", content: ""},
+		{finishReason: "stop", content: entriesJSON(t, "compact")},
+	}, &requests)
+	defer server.Close()
+
+	text := strings.Repeat("日", 40)
+	entries, _, err := testClient(server.URL).DistillWithRecovery(
+		context.Background(), "p", text, 3,
+	)
+	if err != nil {
+		t.Fatalf("DistillWithRecovery: %v", err)
+	}
+	if len(entries) != 1 || len(requests) != 2 {
+		t.Fatalf("entries=%d requests=%d, want compact retry to run",
+			len(entries), len(requests))
+	}
+}
+
+func TestClientBadRequestMentioningContextIsNotOverflow(t *testing.T) {
+	// "context" alone must not classify as overflow: 400s for unrelated
+	// problems can mention the word without describing an input-length
+	// error, and splitting the unit would loop uselessly.
+	var requests []map[string]any
+	server := newScriptedServer(t, []scriptedResponse{
+		{
+			status: http.StatusBadRequest,
+			errorBody: `{"error":{"message":"unknown field ` +
+				`\"chat_template_kwargs\" in request context"}}`,
+		},
+	}, &requests)
+	defer server.Close()
+
+	_, _, err := testClient(server.URL).DistillWithRecovery(
+		context.Background(), "p", "text", 3,
+	)
+	if err == nil || errors.Is(err, ErrContextOverflow) {
+		t.Fatalf("err = %v, must be a permanent non-overflow error", err)
 	}
 }
 

--- a/internal/recall/extract/client_test.go
+++ b/internal/recall/extract/client_test.go
@@ -411,6 +411,8 @@ func TestIsContextOverflowDetail(t *testing.T) {
 		`invalid input length parameter`,
 		`unknown field "context_size" in request`,
 		`max_tokens must be a positive integer`,
+		`max_tokens exceeds the maximum allowed value`,
+		`max_new_tokens exceeds the model limit`,
 		`model "test-model" not found`,
 	}
 	for _, body := range notOverflow {

--- a/internal/recall/extract/client_test.go
+++ b/internal/recall/extract/client_test.go
@@ -17,6 +17,7 @@ type scriptedResponse struct {
 	finishReason string
 	content      string
 	errorBody    string
+	noChoices    bool
 }
 
 func newScriptedServer(
@@ -50,14 +51,18 @@ func newScriptedServer(
 				_, _ = w.Write([]byte(errorBody))
 				return
 			}
+			choices := []map[string]any{{
+				"finish_reason": resp.finishReason,
+				"message": map[string]any{
+					"role":    "assistant",
+					"content": resp.content,
+				},
+			}}
+			if resp.noChoices {
+				choices = nil
+			}
 			body := map[string]any{
-				"choices": []map[string]any{{
-					"finish_reason": resp.finishReason,
-					"message": map[string]any{
-						"role":    "assistant",
-						"content": resp.content,
-					},
-				}},
+				"choices": choices,
 				"usage": map[string]any{
 					"prompt_tokens":     7,
 					"completion_tokens": 3,
@@ -347,6 +352,8 @@ func TestIsContextOverflowDetail(t *testing.T) {
 		`input length 5000 exceeds maximum 4096`,
 		`input tokens (6000) exceed the model maximum`,
 		`input tokens plus max_tokens exceed the model maximum`,
+		`prompt is too large for this model`,
+		`prompt too large: reduce the input`,
 	}
 	for _, body := range overflow {
 		if !isContextOverflowDetail(body) {
@@ -389,6 +396,31 @@ func TestParseRetryAfter(t *testing.T) {
 		if got := parseRetryAfter(value); got != 0 {
 			t.Fatalf("parseRetryAfter(%q) = %v, want 0", value, got)
 		}
+	}
+}
+
+func TestClientChoicelessResponseAccountsUsageAcrossRetry(t *testing.T) {
+	// A choiceless 200 still reports token usage; the retry that recovers
+	// from it must not drop that cost from the accounting.
+	var requests []map[string]any
+	server := newScriptedServer(t, []scriptedResponse{
+		{noChoices: true},
+		{finishReason: "stop", content: entriesJSON(t, "ok")},
+	}, &requests)
+	defer server.Close()
+
+	entries, usage, err := testClient(server.URL).DistillWithRecovery(
+		context.Background(), "p", "text", 3,
+	)
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("entries=%v err=%v", entries, err)
+	}
+	if len(requests) != 2 {
+		t.Fatalf("requests = %d, want 2 (choiceless responses retry)",
+			len(requests))
+	}
+	if usage.PromptTokens != 14 || usage.CompletionTokens != 6 {
+		t.Fatalf("usage = %+v, want both attempts accounted (14/6)", usage)
 	}
 }
 

--- a/internal/recall/extract/client_test.go
+++ b/internal/recall/extract/client_test.go
@@ -344,6 +344,8 @@ func TestIsContextOverflowDetail(t *testing.T) {
 		`the request exceeds the available context size`,
 		`prompt is too long: 20000 tokens > 16000 maximum`,
 		`input is too large for the model context`,
+		`input length 5000 exceeds maximum 4096`,
+		`input tokens (6000) exceed the model maximum`,
 	}
 	for _, body := range overflow {
 		if !isContextOverflowDetail(body) {
@@ -384,6 +386,28 @@ func TestParseRetryAfter(t *testing.T) {
 		if got := parseRetryAfter(value); got != 0 {
 			t.Fatalf("parseRetryAfter(%q) = %v, want 0", value, got)
 		}
+	}
+}
+
+func TestClientNonStopFinishReasonIsError(t *testing.T) {
+	// A content-filtered or otherwise cut-off response can still carry
+	// valid JSON with fewer (or zero) entries; accepting it would advance
+	// progress over silently lost facts. Only "stop" means complete.
+	var requests []map[string]any
+	server := newScriptedServer(t, []scriptedResponse{
+		{finishReason: "content_filter", content: entriesJSON(t, "partial")},
+	}, &requests)
+	defer server.Close()
+
+	_, _, err := testClient(server.URL).DistillWithRecovery(
+		context.Background(), "p", "text", 3,
+	)
+	if err == nil || !strings.Contains(err.Error(), "content_filter") {
+		t.Fatalf("err = %v, want an error naming the finish reason", err)
+	}
+	if len(requests) != 1 {
+		t.Fatalf("requests = %d, want 1 (a filtered response is "+
+			"deterministic)", len(requests))
 	}
 }
 

--- a/internal/recall/extract/client_test.go
+++ b/internal/recall/extract/client_test.go
@@ -1,0 +1,224 @@
+package extract
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+type scriptedResponse struct {
+	status       int
+	finishReason string
+	content      string
+}
+
+func newScriptedServer(
+	t *testing.T, responses []scriptedResponse, requests *[]map[string]any,
+) *httptest.Server {
+	t.Helper()
+	var index atomic.Int64
+	return httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			var payload map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Errorf("decoding request: %v", err)
+			}
+			*requests = append(*requests, payload)
+			i := int(index.Add(1)) - 1
+			if i >= len(responses) {
+				t.Errorf("unexpected request %d", i)
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			resp := responses[i]
+			if resp.status != 0 && resp.status != http.StatusOK {
+				w.WriteHeader(resp.status)
+				_, _ = w.Write([]byte(`{"error":"scripted"}`))
+				return
+			}
+			body := map[string]any{
+				"choices": []map[string]any{{
+					"finish_reason": resp.finishReason,
+					"message": map[string]any{
+						"role":    "assistant",
+						"content": resp.content,
+					},
+				}},
+				"usage": map[string]any{
+					"prompt_tokens":     7,
+					"completion_tokens": 3,
+				},
+			}
+			_ = json.NewEncoder(w).Encode(body)
+		}))
+}
+
+func entriesJSON(t *testing.T, titles ...string) string {
+	t.Helper()
+	entries := make([]map[string]any, 0, len(titles))
+	for _, title := range titles {
+		entries = append(entries, map[string]any{
+			"type": "fact", "title": title, "body": "b",
+			"entities": []string{},
+		})
+	}
+	raw, err := json.Marshal(map[string]any{"entries": entries})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(raw)
+}
+
+func testClient(url string) *Client {
+	return &Client{
+		BaseURL:   url,
+		Model:     "test-model",
+		MaxTokens: 100,
+		Request: RequestShape{
+			Temperature: 0,
+			ExtraBody: map[string]any{
+				"chat_template_kwargs": map[string]any{
+					"enable_thinking": false,
+				},
+			},
+		},
+	}
+}
+
+func TestClientDistillParsesEntriesAndSendsShape(t *testing.T) {
+	var requests []map[string]any
+	server := newScriptedServer(t, []scriptedResponse{
+		{finishReason: "stop", content: entriesJSON(t, "one", "two")},
+	}, &requests)
+	defer server.Close()
+
+	entries, usage, err := testClient(server.URL).DistillWithRecovery(
+		context.Background(), "system prompt", "unit text", 3,
+	)
+	if err != nil {
+		t.Fatalf("DistillWithRecovery: %v", err)
+	}
+	if len(entries) != 2 || entries[0].Title != "one" {
+		t.Fatalf("entries = %+v", entries)
+	}
+	if usage.PromptTokens != 7 || usage.CompletionTokens != 3 {
+		t.Fatalf("usage = %+v", usage)
+	}
+	payload := requests[0]
+	if payload["temperature"] != float64(0) {
+		t.Fatalf("temperature = %v", payload["temperature"])
+	}
+	if _, ok := payload["chat_template_kwargs"]; !ok {
+		t.Fatal("extra body must be merged into the request")
+	}
+	if _, ok := payload["response_format"]; !ok {
+		t.Fatal("constrained decoding must be requested")
+	}
+}
+
+func TestClientContextOverflowIsTyped(t *testing.T) {
+	var requests []map[string]any
+	server := newScriptedServer(t, []scriptedResponse{
+		{status: http.StatusBadRequest},
+	}, &requests)
+	defer server.Close()
+
+	_, _, err := testClient(server.URL).DistillWithRecovery(
+		context.Background(), "p", "text", 3,
+	)
+	if !errors.Is(err, ErrContextOverflow) {
+		t.Fatalf("err = %v, want ErrContextOverflow", err)
+	}
+}
+
+func TestClientCompactRetryOnTruncation(t *testing.T) {
+	var requests []map[string]any
+	server := newScriptedServer(t, []scriptedResponse{
+		{finishReason: "length", content: ""},
+		{finishReason: "stop", content: entriesJSON(t, "compact")},
+	}, &requests)
+	defer server.Close()
+
+	entries, _, err := testClient(server.URL).DistillWithRecovery(
+		context.Background(), "p", "unit text", 3,
+	)
+	if err != nil {
+		t.Fatalf("DistillWithRecovery: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("entries = %+v", entries)
+	}
+	if len(requests) != 2 {
+		t.Fatalf("requests = %d, want 2 (truncation triggers one compact retry)", len(requests))
+	}
+	second := requests[1]["messages"].([]any)[1].(map[string]any)
+	if !strings.Contains(second["content"].(string), "output budget is tight") {
+		t.Fatal("compact retry must append the compact instruction")
+	}
+}
+
+func TestClientPersistentTruncationIsTyped(t *testing.T) {
+	var requests []map[string]any
+	server := newScriptedServer(t, []scriptedResponse{
+		{finishReason: "length", content: ""},
+		{finishReason: "length", content: ""},
+	}, &requests)
+	defer server.Close()
+
+	_, _, err := testClient(server.URL).DistillWithRecovery(
+		context.Background(), "p", "text", 3,
+	)
+	if !errors.Is(err, ErrPersistentTruncation) {
+		t.Fatalf("err = %v, want ErrPersistentTruncation", err)
+	}
+}
+
+func TestClientRetriesTransientErrors(t *testing.T) {
+	var requests []map[string]any
+	server := newScriptedServer(t, []scriptedResponse{
+		{status: http.StatusInternalServerError},
+		{finishReason: "stop", content: entriesJSON(t, "ok")},
+	}, &requests)
+	defer server.Close()
+
+	entries, _, err := testClient(server.URL).DistillWithRecovery(
+		context.Background(), "p", "text", 3,
+	)
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("entries=%v err=%v", entries, err)
+	}
+}
+
+func TestClientEmptyContentIsError(t *testing.T) {
+	// A model that burns its budget on hidden reasoning returns empty
+	// content with finish_reason stop; that must surface as an error, not
+	// as zero entries.
+	var requests []map[string]any
+	responses := make([]scriptedResponse, 3)
+	for i := range responses {
+		responses[i] = scriptedResponse{finishReason: "stop", content: ""}
+	}
+	server := newScriptedServer(t, responses, &requests)
+	defer server.Close()
+
+	_, _, err := testClient(server.URL).DistillWithRecovery(
+		context.Background(), "p", "text", 3,
+	)
+	if err == nil {
+		t.Fatal("empty content must be an error")
+	}
+}
+
+func TestSplitFloorChars(t *testing.T) {
+	if got := SplitFloorChars(50000); got != 2000 {
+		t.Fatalf("SplitFloorChars(50000) = %d, want 2000", got)
+	}
+	if got := SplitFloorChars(800); got != 100 {
+		t.Fatalf("SplitFloorChars(800) = %d, want 100", got)
+	}
+}

--- a/internal/recall/extract/client_test.go
+++ b/internal/recall/extract/client_test.go
@@ -391,6 +391,35 @@ func TestClientRejectsReservedExtraBodyKeys(t *testing.T) {
 	}
 }
 
+func TestIsContextOverflowDetail(t *testing.T) {
+	overflow := []string{
+		`{"error":{"code":"context_length_exceeded"}}`,
+		`This model's maximum context length is 32768 tokens.`,
+		`the request exceeds the available context size`,
+		`prompt is too long: 20000 tokens > 16000 maximum`,
+		`input is too large for the model context`,
+	}
+	for _, body := range overflow {
+		if !isContextOverflowDetail(body) {
+			t.Errorf("must classify as overflow: %q", body)
+		}
+	}
+	// A length-related noun alone is not an overflow: these are validation
+	// errors that splitting the unit can never fix.
+	notOverflow := []string{
+		`{"error":{"message":"context window must be an integer"}}`,
+		`invalid input length parameter`,
+		`unknown field "context_size" in request`,
+		`max_tokens must be a positive integer`,
+		`model "test-model" not found`,
+	}
+	for _, body := range notOverflow {
+		if isContextOverflowDetail(body) {
+			t.Errorf("must not classify as overflow: %q", body)
+		}
+	}
+}
+
 func TestParseRetryAfter(t *testing.T) {
 	if got := parseRetryAfter("2"); got != 2*time.Second {
 		t.Fatalf("parseRetryAfter(2) = %v", got)

--- a/internal/recall/extract/client_test.go
+++ b/internal/recall/extract/client_test.go
@@ -430,6 +430,64 @@ func TestClientEmptyContentIsError(t *testing.T) {
 	}
 }
 
+func TestClientRejectsSchemaViolatingContent(t *testing.T) {
+	// Constrained decoding is requested, but not every server enforces it;
+	// content that violates the schema must fail the unit instead of
+	// advancing progress with silently lost or malformed entries. At
+	// temperature zero the violation is deterministic, so no retry.
+	cases := map[string]string{
+		"empty object":     `{}`,
+		"null":             `null`,
+		"top-level array":  `[]`,
+		"unknown type":     `{"entries":[{"type":"story","title":"t","body":"b","entities":[]}]}`,
+		"blank title":      `{"entries":[{"type":"fact","title":" ","body":"b","entities":[]}]}`,
+		"blank body":       `{"entries":[{"type":"fact","title":"t","body":"","entities":[]}]}`,
+		"missing entities": `{"entries":[{"type":"fact","title":"t","body":"b"}]}`,
+		"unknown field":    `{"entries":[{"type":"fact","title":"t","body":"b","entities":[],"extra":1}]}`,
+	}
+	for name, content := range cases {
+		t.Run(name, func(t *testing.T) {
+			var requests []map[string]any
+			server := newScriptedServer(t, []scriptedResponse{
+				{finishReason: "stop", content: content},
+			}, &requests)
+			defer server.Close()
+
+			entries, _, err := testClient(server.URL).DistillWithRecovery(
+				context.Background(), "p", "text", 3,
+			)
+			if err == nil {
+				t.Fatalf("content %q must be rejected, got entries %+v",
+					content, entries)
+			}
+			if len(requests) != 1 {
+				t.Fatalf("requests = %d, want 1 (schema violations are "+
+					"deterministic)", len(requests))
+			}
+		})
+	}
+}
+
+func TestClientAcceptsEmptyEntriesArray(t *testing.T) {
+	// A unit can legitimately yield nothing; an explicit empty array is
+	// schema-valid and distinct from a response that lacks the array.
+	var requests []map[string]any
+	server := newScriptedServer(t, []scriptedResponse{
+		{finishReason: "stop", content: `{"entries":[]}`},
+	}, &requests)
+	defer server.Close()
+
+	entries, _, err := testClient(server.URL).DistillWithRecovery(
+		context.Background(), "p", "text", 3,
+	)
+	if err != nil {
+		t.Fatalf("DistillWithRecovery: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("entries = %+v, want none", entries)
+	}
+}
+
 func TestSplitFloorChars(t *testing.T) {
 	if got := SplitFloorChars(50000); got != 2000 {
 		t.Fatalf("SplitFloorChars(50000) = %d, want 2000", got)

--- a/internal/recall/extract/client_test.go
+++ b/internal/recall/extract/client_test.go
@@ -15,6 +15,7 @@ type scriptedResponse struct {
 	status       int
 	finishReason string
 	content      string
+	errorBody    string
 }
 
 func newScriptedServer(
@@ -38,7 +39,11 @@ func newScriptedServer(
 			resp := responses[i]
 			if resp.status != 0 && resp.status != http.StatusOK {
 				w.WriteHeader(resp.status)
-				_, _ = w.Write([]byte(`{"error":"scripted"}`))
+				errorBody := resp.errorBody
+				if errorBody == "" {
+					errorBody = `{"error":"scripted"}`
+				}
+				_, _ = w.Write([]byte(errorBody))
 				return
 			}
 			body := map[string]any{
@@ -76,11 +81,14 @@ func entriesJSON(t *testing.T, titles ...string) string {
 
 func testClient(url string) *Client {
 	return &Client{
-		BaseURL:   url,
-		Model:     "test-model",
-		MaxTokens: 100,
+		BaseURL: url,
+		Model:   "test-model",
+		// The compact floor covers the short unit texts these tests send, so
+		// truncation exercises the compact retry unless a test says otherwise.
+		CompactFloorChars: 64,
 		Request: RequestShape{
 			Temperature: 0,
+			MaxTokens:   100,
 			ExtraBody: map[string]any{
 				"chat_template_kwargs": map[string]any{
 					"enable_thinking": false,
@@ -113,6 +121,9 @@ func TestClientDistillParsesEntriesAndSendsShape(t *testing.T) {
 	if payload["temperature"] != float64(0) {
 		t.Fatalf("temperature = %v", payload["temperature"])
 	}
+	if payload["max_tokens"] != float64(100) {
+		t.Fatalf("max_tokens = %v", payload["max_tokens"])
+	}
 	if _, ok := payload["chat_template_kwargs"]; !ok {
 		t.Fatal("extra body must be merged into the request")
 	}
@@ -124,7 +135,11 @@ func TestClientDistillParsesEntriesAndSendsShape(t *testing.T) {
 func TestClientContextOverflowIsTyped(t *testing.T) {
 	var requests []map[string]any
 	server := newScriptedServer(t, []scriptedResponse{
-		{status: http.StatusBadRequest},
+		{
+			status: http.StatusBadRequest,
+			errorBody: `{"error":{"message":"This model's maximum context ` +
+				`length is 32768 tokens."}}`,
+		},
 	}, &requests)
 	defer server.Close()
 
@@ -133,6 +148,37 @@ func TestClientContextOverflowIsTyped(t *testing.T) {
 	)
 	if !errors.Is(err, ErrContextOverflow) {
 		t.Fatalf("err = %v, want ErrContextOverflow", err)
+	}
+}
+
+func TestClientBadRequestOtherThanOverflowIsPermanent(t *testing.T) {
+	// A 400 for a wrong model name or malformed field must not masquerade as
+	// an overflow (which would make the caller split the unit), and it will
+	// not fix itself, so it must not burn the transient retry budget either.
+	var requests []map[string]any
+	server := newScriptedServer(t, []scriptedResponse{
+		{
+			status:    http.StatusBadRequest,
+			errorBody: `{"error":{"message":"model \"test-model\" not found"}}`,
+		},
+	}, &requests)
+	defer server.Close()
+
+	_, _, err := testClient(server.URL).DistillWithRecovery(
+		context.Background(), "p", "text", 3,
+	)
+	if err == nil {
+		t.Fatal("bad request must be an error")
+	}
+	if errors.Is(err, ErrContextOverflow) {
+		t.Fatalf("err = %v, must not be ErrContextOverflow", err)
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("err = %v, must carry the server detail", err)
+	}
+	if len(requests) != 1 {
+		t.Fatalf("requests = %d, want 1 (bad requests are not retried)",
+			len(requests))
 	}
 }
 
@@ -175,6 +221,33 @@ func TestClientPersistentTruncationIsTyped(t *testing.T) {
 	)
 	if !errors.Is(err, ErrPersistentTruncation) {
 		t.Fatalf("err = %v, want ErrPersistentTruncation", err)
+	}
+	if len(requests) != 2 {
+		t.Fatalf("requests = %d, want 2 (below the floor: one compact retry)",
+			len(requests))
+	}
+}
+
+func TestClientTruncationAboveFloorSplitsInsteadOfCompacting(t *testing.T) {
+	// The compact retry caps the entry count, so on a unit large enough to
+	// split it would silently drop entries; truncation must surface the
+	// typed split signal without a compact attempt.
+	var requests []map[string]any
+	server := newScriptedServer(t, []scriptedResponse{
+		{finishReason: "length", content: ""},
+	}, &requests)
+	defer server.Close()
+
+	longText := strings.Repeat("dense unit text ", 32)
+	_, _, err := testClient(server.URL).DistillWithRecovery(
+		context.Background(), "p", longText, 3,
+	)
+	if !errors.Is(err, ErrPersistentTruncation) {
+		t.Fatalf("err = %v, want ErrPersistentTruncation", err)
+	}
+	if len(requests) != 1 {
+		t.Fatalf("requests = %d, want 1 (no compact retry above the floor)",
+			len(requests))
 	}
 }
 

--- a/internal/recall/extract/prompts.go
+++ b/internal/recall/extract/prompts.go
@@ -58,14 +58,24 @@ func basePrompts() map[PromptRole]string {
 	}
 }
 
-// RequestShape carries the model-dependent request parameters that change
-// extraction output. ExtraBody is merged into the request top-level, giving
-// server-specific knobs (template arguments, sampling controls) a home
-// without the client knowing about any particular server.
+// RequestShape carries every model-dependent parameter that changes
+// extraction output — what is sent to the server (temperature, token
+// budget, extra body) and how the client recovers from truncation (the
+// compact floor). Keeping them in one fingerprinted struct means no output-
+// affecting knob can change without producing a new generation. ExtraBody
+// is merged into the request top-level, giving server-specific knobs
+// (template arguments, sampling controls) a home without the client
+// knowing about any particular server.
 type RequestShape struct {
-	Temperature float64        `json:"temperature"`
-	MaxTokens   int            `json:"max_tokens"`
-	ExtraBody   map[string]any `json:"extra_body,omitempty"`
+	Temperature float64 `json:"temperature"`
+	MaxTokens   int     `json:"max_tokens"`
+	// CompactFloorChars bounds the compact retry: a truncated unit longer
+	// than this (in code points) surfaces a split error so no entries are
+	// lost; a unit at or below it (too small for splitting to help) gets
+	// one entry-capped compact retry. Callers set it to SplitFloorChars of
+	// their window budget; zero disables the compact retry entirely.
+	CompactFloorChars int            `json:"compact_floor_chars"`
+	ExtraBody         map[string]any `json:"extra_body,omitempty"`
 }
 
 // Profile bundles the prompt variants and request shape a family of models

--- a/internal/recall/extract/prompts.go
+++ b/internal/recall/extract/prompts.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 )
@@ -121,12 +122,14 @@ const defaultMaxTokens = 4096
 
 // ResolveProfile picks the profile for a model. An explicit name wins and
 // must exist; otherwise the model name selects a profile by prefix, falling
-// back to the base profile.
+// back to the base profile. The returned profile is a deep copy: callers
+// merge configuration into it, and none of that may write through to the
+// built-in registry.
 func ResolveProfile(explicit, model string) (Profile, error) {
 	if explicit != "" {
 		for _, profile := range builtinProfiles {
 			if profile.Name == explicit {
-				return profile, nil
+				return profile.clone(), nil
 			}
 		}
 		names := make([]string, 0, len(builtinProfiles))
@@ -142,11 +145,46 @@ func ResolveProfile(explicit, model string) (Profile, error) {
 	for _, profile := range builtinProfiles {
 		for _, prefix := range profile.MatchPrefixes {
 			if strings.HasPrefix(lowerModel, prefix) {
-				return profile, nil
+				return profile.clone(), nil
 			}
 		}
 	}
 	return ResolveProfile("base", model)
+}
+
+func (p Profile) clone() Profile {
+	out := p
+	out.MatchPrefixes = slices.Clone(p.MatchPrefixes)
+	out.Prompts = maps.Clone(p.Prompts)
+	if p.Request.ExtraBody != nil {
+		out.Request.ExtraBody = cloneJSONMap(p.Request.ExtraBody)
+	}
+	return out
+}
+
+// cloneJSONMap deep-copies the JSON-shaped values profiles carry: nested
+// maps and slices are duplicated, scalars pass through.
+func cloneJSONMap(m map[string]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for key, item := range m {
+		out[key] = cloneJSONValue(item)
+	}
+	return out
+}
+
+func cloneJSONValue(value any) any {
+	switch v := value.(type) {
+	case map[string]any:
+		return cloneJSONMap(v)
+	case []any:
+		out := make([]any, len(v))
+		for i, item := range v {
+			out[i] = cloneJSONValue(item)
+		}
+		return out
+	default:
+		return v
+	}
 }
 
 // PromptsFor resolves the effective prompt per role: user overrides win,

--- a/internal/recall/extract/prompts.go
+++ b/internal/recall/extract/prompts.go
@@ -224,14 +224,26 @@ func LoadPromptOverrides(dir string) (map[PromptRole]string, error) {
 	return overrides, nil
 }
 
-// Fingerprint digests everything that changes extraction output: the model,
-// the segmentation strategy and its parameters, the resolved prompts, the
-// request shape (including the output token budget), and the extraction
-// protocol version covering the response schema and recovery behavior baked
-// into this binary. Two configurations with the same fingerprint produce
-// interchangeable corpora; any difference is a new generation.
+// ModelIdentity names what produces the output: the model, and optionally
+// a deployment label distinguishing servers that expose different weights
+// under the same model name. The label is deliberately not the endpoint
+// URL: moving a deployment to a new address or port does not change its
+// output, and hashing the URL would orphan the whole corpus on every move.
+// Leave Deployment empty when the model name alone identifies the weights.
+type ModelIdentity struct {
+	Model      string `json:"model"`
+	Deployment string `json:"deployment,omitempty"`
+}
+
+// Fingerprint digests everything that changes extraction output: the model
+// identity (name plus optional deployment label), the segmentation strategy
+// and its parameters, the resolved prompts, the request shape (including
+// the output token budget), and the extraction protocol version covering
+// the response schema and recovery behavior baked into this binary. Two
+// configurations with the same fingerprint produce interchangeable corpora;
+// any difference is a new generation.
 func Fingerprint(
-	model string,
+	model ModelIdentity,
 	segmenter Segmenter,
 	prompts map[PromptRole]string,
 	request RequestShape,
@@ -243,7 +255,7 @@ func Fingerprint(
 	}
 	identity := struct {
 		Protocol      int               `json:"protocol"`
-		Model         string            `json:"model"`
+		Model         ModelIdentity     `json:"model"`
 		Segmenter     string            `json:"segmenter"`
 		Params        map[string]any    `json:"params"`
 		PromptDigests map[string]string `json:"prompt_digests"`

--- a/internal/recall/extract/prompts.go
+++ b/internal/recall/extract/prompts.go
@@ -64,6 +64,7 @@ func basePrompts() map[PromptRole]string {
 // without the client knowing about any particular server.
 type RequestShape struct {
 	Temperature float64        `json:"temperature"`
+	MaxTokens   int            `json:"max_tokens"`
 	ExtraBody   map[string]any `json:"extra_body,omitempty"`
 }
 
@@ -89,6 +90,7 @@ var builtinProfiles = []Profile{
 		MatchPrefixes: []string{"qwen"},
 		Request: RequestShape{
 			Temperature: 0,
+			MaxTokens:   defaultMaxTokens,
 			ExtraBody: map[string]any{
 				"chat_template_kwargs": map[string]any{
 					"enable_thinking": false,
@@ -98,9 +100,14 @@ var builtinProfiles = []Profile{
 	},
 	{
 		Name:    "base",
-		Request: RequestShape{Temperature: 0},
+		Request: RequestShape{Temperature: 0, MaxTokens: defaultMaxTokens},
 	},
 }
+
+// defaultMaxTokens is the built-in profiles' output budget: generous enough
+// for a dense window's worth of entries without letting a runaway response
+// occupy the server indefinitely. Configuration can override it per model.
+const defaultMaxTokens = 4096
 
 // ResolveProfile picks the profile for a model. An explicit name wins and
 // must exist; otherwise the model name selects a profile by prefix, falling
@@ -170,8 +177,10 @@ func LoadPromptOverrides(dir string) (map[PromptRole]string, error) {
 }
 
 // Fingerprint digests everything that changes extraction output: the model,
-// the segmentation strategy and its parameters, the resolved prompts, and
-// the request shape. Two configurations with the same fingerprint produce
+// the segmentation strategy and its parameters, the resolved prompts, the
+// request shape (including the output token budget), and the extraction
+// protocol version covering the response schema and recovery behavior baked
+// into this binary. Two configurations with the same fingerprint produce
 // interchangeable corpora; any difference is a new generation.
 func Fingerprint(
 	model string,
@@ -185,12 +194,14 @@ func Fingerprint(
 		promptDigests[string(role)] = hex.EncodeToString(sum[:])
 	}
 	identity := struct {
+		Protocol      int               `json:"protocol"`
 		Model         string            `json:"model"`
 		Segmenter     string            `json:"segmenter"`
 		Params        map[string]any    `json:"params"`
 		PromptDigests map[string]string `json:"prompt_digests"`
 		Request       RequestShape      `json:"request"`
 	}{
+		Protocol:      extractionProtocolVersion,
 		Model:         model,
 		Segmenter:     segmenter.Name(),
 		Params:        segmenter.Params(),

--- a/internal/recall/extract/prompts.go
+++ b/internal/recall/extract/prompts.go
@@ -1,0 +1,219 @@
+package extract
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Base prompts shipped in the binary. They work for instruction-following
+// models with no configuration; model profiles and user override files
+// replace them per role when a model needs different phrasing.
+const (
+	baseIntentPrompt = `You distill one user message from a coding-agent session into memory entries for a keyword search index. The text is what the human asked the agent to do, or their feedback on work in progress.
+
+Extract entries capturing the user's intent: the task requested, its targets and constraints (files, repos, branches, tools, APIs, versions, deadlines), corrections or feedback on prior work, standing preferences about how work should be done, and stated success criteria. Emit one entry per distinct item - the count should follow the content, so a one-line instruction may yield a single entry while a detailed request yields several. Do not pad.
+
+Rules:
+- Each entry must stand alone without the surrounding session.
+- Quote exact file paths, commands, identifiers, and values verbatim.
+- type: 'fact' for the requested task and stated context, 'preference' for standing user preferences about tools or workflow, 'open_question' for things the user left undecided.
+- title: one specific sentence, at most 120 characters.
+- body: 1-3 dense sentences with the exact identifiers and values.
+- entities: the exact searchable strings (file paths, function names, commands, project names) the entry is about.`
+
+	baseActionPrompt = `You distill one segment of a coding agent's recorded work (its replies, file edits, commands, and their results) into memory entries for a keyword search index.
+
+Record BOTH what the agent did and what it learned. Emit one entry per distinct item - the count should follow the content, so a short segment may yield one or two entries while a dense one yields many. Do not pad and do not stop early when more distinct items remain.
+
+- 'procedure': a sequence of steps that accomplished something, with the exact commands, files, and values used, and its outcome.
+- 'fact' (state change): how the code or system changed - "X went from A to B" - with the exact before and after values.
+- 'fact' (finding): concrete facts learned about the codebase or environment: where things live, how components connect, config values, versions, schema shapes, API behaviors, test results. Record these generously even when they are incidental to the task - a future search may need any of them, so incidental findings are wanted content, not padding.
+- 'decision': alternatives the agent proposed or considered, and why one was chosen or rejected.
+- 'warning': errors hit, failing commands, pitfalls or gotchas discovered.
+
+Rules:
+- Each entry must stand alone without the session transcript.
+- Quote exact file paths, commands, error messages, and values verbatim.
+- Record outcomes explicitly: what succeeded and what failed.
+- title: one specific sentence, at most 120 characters.
+- body: 1-4 dense sentences with the exact identifiers and values.
+- entities: the exact searchable strings (file paths, function names, commands, error strings, URLs) the entry is about.`
+)
+
+// basePrompts returns the embedded defaults for every prompt role. The
+// generic role reuses the action prompt: it records both sides of the
+// conversation for strategies that do not split by speaker.
+func basePrompts() map[PromptRole]string {
+	return map[PromptRole]string{
+		RoleIntent:  baseIntentPrompt,
+		RoleAction:  baseActionPrompt,
+		RoleGeneric: baseActionPrompt,
+	}
+}
+
+// RequestShape carries the model-dependent request parameters that change
+// extraction output. ExtraBody is merged into the request top-level, giving
+// server-specific knobs (template arguments, sampling controls) a home
+// without the client knowing about any particular server.
+type RequestShape struct {
+	Temperature float64        `json:"temperature"`
+	ExtraBody   map[string]any `json:"extra_body,omitempty"`
+}
+
+// Profile bundles the prompt variants and request shape a family of models
+// needs. Profiles are data: adding support for a model family is a new
+// entry here or a user override, not new code.
+type Profile struct {
+	Name string
+	// MatchPrefixes selects this profile automatically when the configured
+	// model name starts with one of these (case-insensitive).
+	MatchPrefixes []string
+	// Prompts overrides base prompts per role; absent roles keep the base.
+	Prompts map[PromptRole]string
+	Request RequestShape
+}
+
+var builtinProfiles = []Profile{
+	{
+		Name: "qwen",
+		// These models interleave hidden reasoning by default; with
+		// constrained decoding that burns the whole token budget before
+		// any content is produced, so the template must disable it.
+		MatchPrefixes: []string{"qwen"},
+		Request: RequestShape{
+			Temperature: 0,
+			ExtraBody: map[string]any{
+				"chat_template_kwargs": map[string]any{
+					"enable_thinking": false,
+				},
+			},
+		},
+	},
+	{
+		Name:    "base",
+		Request: RequestShape{Temperature: 0},
+	},
+}
+
+// ResolveProfile picks the profile for a model. An explicit name wins and
+// must exist; otherwise the model name selects a profile by prefix, falling
+// back to the base profile.
+func ResolveProfile(explicit, model string) (Profile, error) {
+	if explicit != "" {
+		for _, profile := range builtinProfiles {
+			if profile.Name == explicit {
+				return profile, nil
+			}
+		}
+		names := make([]string, 0, len(builtinProfiles))
+		for _, profile := range builtinProfiles {
+			names = append(names, profile.Name)
+		}
+		return Profile{}, fmt.Errorf(
+			"unknown extraction prompt profile %q (have: %s)",
+			explicit, strings.Join(names, ", "),
+		)
+	}
+	lowerModel := strings.ToLower(model)
+	for _, profile := range builtinProfiles {
+		for _, prefix := range profile.MatchPrefixes {
+			if strings.HasPrefix(lowerModel, prefix) {
+				return profile, nil
+			}
+		}
+	}
+	return ResolveProfile("base", model)
+}
+
+// PromptsFor resolves the effective prompt per role: user overrides win,
+// then the profile's variants, then the embedded base prompts.
+func PromptsFor(
+	profile Profile, overrides map[PromptRole]string,
+) map[PromptRole]string {
+	prompts := basePrompts()
+	maps.Copy(prompts, profile.Prompts)
+	maps.Copy(prompts, overrides)
+	return prompts
+}
+
+// LoadPromptOverrides reads per-role prompt files (intent.txt, action.txt,
+// generic.txt) from a directory. Missing files are simply not overridden;
+// an empty file is an error because it would silently blank a prompt.
+func LoadPromptOverrides(dir string) (map[PromptRole]string, error) {
+	overrides := map[PromptRole]string{}
+	for _, role := range []PromptRole{RoleIntent, RoleAction, RoleGeneric} {
+		path := filepath.Join(dir, string(role)+".txt")
+		raw, err := os.ReadFile(path)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("reading prompt override %s: %w", path, err)
+		}
+		prompt := strings.TrimSpace(string(raw))
+		if prompt == "" {
+			return nil, fmt.Errorf(
+				"prompt override %s is empty; delete the file to use the "+
+					"default prompt", path,
+			)
+		}
+		overrides[role] = prompt
+	}
+	return overrides, nil
+}
+
+// Fingerprint digests everything that changes extraction output: the model,
+// the segmentation strategy and its parameters, the resolved prompts, and
+// the request shape. Two configurations with the same fingerprint produce
+// interchangeable corpora; any difference is a new generation.
+func Fingerprint(
+	model string,
+	segmenter Segmenter,
+	prompts map[PromptRole]string,
+	request RequestShape,
+) (string, error) {
+	promptDigests := map[string]string{}
+	for role, prompt := range prompts {
+		sum := sha256.Sum256([]byte(prompt))
+		promptDigests[string(role)] = hex.EncodeToString(sum[:])
+	}
+	identity := struct {
+		Model         string            `json:"model"`
+		Segmenter     string            `json:"segmenter"`
+		Params        map[string]any    `json:"params"`
+		PromptDigests map[string]string `json:"prompt_digests"`
+		Request       RequestShape      `json:"request"`
+	}{
+		Model:         model,
+		Segmenter:     segmenter.Name(),
+		Params:        segmenter.Params(),
+		PromptDigests: promptDigests,
+		Request:       request,
+	}
+	// encoding/json writes map keys in sorted order, which makes the
+	// encoding canonical for the JSON-shaped values profiles carry.
+	canonical, err := json.Marshal(identity)
+	if err != nil {
+		return "", fmt.Errorf("encoding extraction identity: %w", err)
+	}
+	sum := sha256.Sum256(canonical)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// ProfileNames lists the built-in profiles for error messages and doctor
+// output, sorted for stable display.
+func ProfileNames() []string {
+	names := make([]string, 0, len(builtinProfiles))
+	for _, profile := range builtinProfiles {
+		names = append(names, profile.Name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/recall/extract/prompts.go
+++ b/internal/recall/extract/prompts.go
@@ -59,24 +59,16 @@ func basePrompts() map[PromptRole]string {
 	}
 }
 
-// RequestShape carries every model-dependent parameter that changes
-// extraction output — what is sent to the server (temperature, token
-// budget, extra body) and how the client recovers from truncation (the
-// compact floor). Keeping them in one fingerprinted struct means no output-
-// affecting knob can change without producing a new generation. ExtraBody
-// is merged into the request top-level, giving server-specific knobs
-// (template arguments, sampling controls) a home without the client
-// knowing about any particular server.
+// RequestShape carries every model-dependent request parameter that
+// changes extraction output. Keeping them in one fingerprinted struct
+// means no output-affecting knob can change without producing a new
+// generation. ExtraBody is merged into the request top-level, giving
+// server-specific knobs (template arguments, sampling controls) a home
+// without the client knowing about any particular server.
 type RequestShape struct {
-	Temperature float64 `json:"temperature"`
-	MaxTokens   int     `json:"max_tokens"`
-	// CompactFloorChars bounds the compact retry: a truncated unit longer
-	// than this (in code points) surfaces a split error so no entries are
-	// lost; a unit at or below it (too small for splitting to help) gets
-	// one entry-capped compact retry. Callers set it to SplitFloorChars of
-	// their window budget; zero disables the compact retry entirely.
-	CompactFloorChars int            `json:"compact_floor_chars"`
-	ExtraBody         map[string]any `json:"extra_body,omitempty"`
+	Temperature float64        `json:"temperature"`
+	MaxTokens   int            `json:"max_tokens"`
+	ExtraBody   map[string]any `json:"extra_body,omitempty"`
 }
 
 // Profile bundles the prompt variants and request shape a family of models

--- a/internal/recall/extract/prompts_test.go
+++ b/internal/recall/extract/prompts_test.go
@@ -48,6 +48,39 @@ func TestResolveProfileExplicitWinsAndUnknownErrors(t *testing.T) {
 	}
 }
 
+func TestResolveProfileCopiesAreIsolated(t *testing.T) {
+	// Resolved profiles get mutated by callers (merging config, editing
+	// request shape); that must never write through to the built-in
+	// registry and corrupt later resolutions.
+	first, err := ResolveProfile("", "qwen3.6-27b-mtp")
+	if err != nil {
+		t.Fatalf("ResolveProfile: %v", err)
+	}
+	kwargs, ok := first.Request.ExtraBody["chat_template_kwargs"].(map[string]any)
+	if !ok {
+		t.Fatal("qwen profile must carry chat_template_kwargs")
+	}
+	kwargs["enable_thinking"] = true
+	first.Request.ExtraBody["injected"] = "x"
+	first.MatchPrefixes[0] = "mutated"
+
+	second, err := ResolveProfile("", "qwen3.6-27b-mtp")
+	if err != nil {
+		t.Fatalf("ResolveProfile after mutation: %v", err)
+	}
+	if second.Name != "qwen" {
+		t.Fatalf("profile = %q, prefix mutation must not leak into registry",
+			second.Name)
+	}
+	if _, ok := second.Request.ExtraBody["injected"]; ok {
+		t.Fatal("top-level extra-body mutation leaked into registry")
+	}
+	secondKwargs := second.Request.ExtraBody["chat_template_kwargs"].(map[string]any)
+	if secondKwargs["enable_thinking"] != false {
+		t.Fatal("nested extra-body mutation leaked into registry")
+	}
+}
+
 func TestPromptsForMergesProfileAndOverrides(t *testing.T) {
 	base, err := ResolveProfile("base", "m")
 	if err != nil {

--- a/internal/recall/extract/prompts_test.go
+++ b/internal/recall/extract/prompts_test.go
@@ -118,12 +118,13 @@ func TestFingerprintIsStableAndSensitive(t *testing.T) {
 	seg := TurnsV1{MaxWindowChars: 50000}
 	prompts := PromptsFor(mustProfile(t, "base"), nil)
 	shape := RequestShape{Temperature: 0}
+	id := ModelIdentity{Model: "model-x"}
 
-	a, err := Fingerprint("model-x", seg, prompts, shape)
+	a, err := Fingerprint(id, seg, prompts, shape)
 	if err != nil {
 		t.Fatalf("Fingerprint: %v", err)
 	}
-	b, err := Fingerprint("model-x", seg, prompts, shape)
+	b, err := Fingerprint(id, seg, prompts, shape)
 	if err != nil {
 		t.Fatalf("Fingerprint: %v", err)
 	}
@@ -131,18 +132,28 @@ func TestFingerprintIsStableAndSensitive(t *testing.T) {
 		t.Fatalf("fingerprint not stable: %s vs %s", a, b)
 	}
 
-	changedModel, _ := Fingerprint("model-y", seg, prompts, shape)
+	changedModel, _ := Fingerprint(
+		ModelIdentity{Model: "model-y"}, seg, prompts, shape,
+	)
 	if changedModel == a {
 		t.Fatal("model change must change the fingerprint")
 	}
+	changedDeployment, _ := Fingerprint(
+		ModelIdentity{Model: "model-x", Deployment: "gpu-b"},
+		seg, prompts, shape,
+	)
+	if changedDeployment == a {
+		t.Fatal("deployment label change must change the fingerprint: two " +
+			"deployments can serve different weights under one model name")
+	}
 	changedSeg, _ := Fingerprint(
-		"model-x", TurnsV1{MaxWindowChars: 40000}, prompts, shape,
+		id, TurnsV1{MaxWindowChars: 40000}, prompts, shape,
 	)
 	if changedSeg == a {
 		t.Fatal("segmenter parameter change must change the fingerprint")
 	}
 	changedPrompt, _ := Fingerprint(
-		"model-x", seg,
+		id, seg,
 		PromptsFor(mustProfile(t, "base"),
 			map[PromptRole]string{RoleIntent: "edited"}),
 		shape,
@@ -151,13 +162,13 @@ func TestFingerprintIsStableAndSensitive(t *testing.T) {
 		t.Fatal("prompt change must change the fingerprint")
 	}
 	changedTokens, _ := Fingerprint(
-		"model-x", seg, prompts, RequestShape{Temperature: 0, MaxTokens: 512},
+		id, seg, prompts, RequestShape{Temperature: 0, MaxTokens: 512},
 	)
 	if changedTokens == a {
 		t.Fatal("max_tokens change must change the fingerprint")
 	}
 	changedFloor, _ := Fingerprint(
-		"model-x", seg, prompts,
+		id, seg, prompts,
 		RequestShape{Temperature: 0, CompactFloorChars: 128},
 	)
 	if changedFloor == a {

--- a/internal/recall/extract/prompts_test.go
+++ b/internal/recall/extract/prompts_test.go
@@ -167,14 +167,6 @@ func TestFingerprintIsStableAndSensitive(t *testing.T) {
 	if changedTokens == a {
 		t.Fatal("max_tokens change must change the fingerprint")
 	}
-	changedFloor, _ := Fingerprint(
-		id, seg, prompts,
-		RequestShape{Temperature: 0, CompactFloorChars: 128},
-	)
-	if changedFloor == a {
-		t.Fatal("compact floor change must change the fingerprint: it " +
-			"decides between capped compact output and splitting")
-	}
 }
 
 func mustProfile(t *testing.T, name string) Profile {

--- a/internal/recall/extract/prompts_test.go
+++ b/internal/recall/extract/prompts_test.go
@@ -1,0 +1,125 @@
+package extract
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveProfileMatchesModelName(t *testing.T) {
+	profile, err := ResolveProfile("", "qwen3.6-27b-mtp")
+	if err != nil {
+		t.Fatalf("ResolveProfile: %v", err)
+	}
+	if profile.Name != "qwen" {
+		t.Fatalf("profile = %q, want qwen", profile.Name)
+	}
+	body, ok := profile.Request.ExtraBody["chat_template_kwargs"]
+	if !ok {
+		t.Fatal("qwen profile must carry chat_template_kwargs")
+	}
+	kwargs, ok := body.(map[string]any)
+	if !ok || kwargs["enable_thinking"] != false {
+		t.Fatalf("qwen profile must disable thinking, got %v", body)
+	}
+}
+
+func TestResolveProfileFallsBackToBase(t *testing.T) {
+	profile, err := ResolveProfile("", "some-foundation-model")
+	if err != nil {
+		t.Fatalf("ResolveProfile: %v", err)
+	}
+	if profile.Name != "base" {
+		t.Fatalf("profile = %q, want base", profile.Name)
+	}
+}
+
+func TestResolveProfileExplicitWinsAndUnknownErrors(t *testing.T) {
+	profile, err := ResolveProfile("base", "qwen3.6-27b-mtp")
+	if err != nil || profile.Name != "base" {
+		t.Fatalf("explicit base: profile=%v err=%v", profile.Name, err)
+	}
+	if _, err := ResolveProfile("nonexistent", "m"); err == nil {
+		t.Fatal("unknown explicit profile must error")
+	}
+}
+
+func TestPromptsForMergesProfileAndOverrides(t *testing.T) {
+	base, err := ResolveProfile("base", "m")
+	if err != nil {
+		t.Fatalf("ResolveProfile: %v", err)
+	}
+	prompts := PromptsFor(base, map[PromptRole]string{RoleIntent: "override"})
+	if prompts[RoleIntent] != "override" {
+		t.Fatalf("override must win, got %q", prompts[RoleIntent])
+	}
+	if prompts[RoleAction] == "" {
+		t.Fatal("unoverridden roles keep the base prompt")
+	}
+}
+
+func TestLoadPromptOverridesReadsRoleFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(
+		filepath.Join(dir, "intent.txt"), []byte("custom intent\n"), 0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	overrides, err := LoadPromptOverrides(dir)
+	if err != nil {
+		t.Fatalf("LoadPromptOverrides: %v", err)
+	}
+	if overrides[RoleIntent] != "custom intent" {
+		t.Fatalf("intent override = %q", overrides[RoleIntent])
+	}
+	if _, ok := overrides[RoleAction]; ok {
+		t.Fatal("absent files must not produce overrides")
+	}
+}
+
+func TestFingerprintIsStableAndSensitive(t *testing.T) {
+	seg := TurnsV1{MaxWindowChars: 50000}
+	prompts := PromptsFor(mustProfile(t, "base"), nil)
+	shape := RequestShape{Temperature: 0}
+
+	a, err := Fingerprint("model-x", seg, prompts, shape)
+	if err != nil {
+		t.Fatalf("Fingerprint: %v", err)
+	}
+	b, err := Fingerprint("model-x", seg, prompts, shape)
+	if err != nil {
+		t.Fatalf("Fingerprint: %v", err)
+	}
+	if a != b {
+		t.Fatalf("fingerprint not stable: %s vs %s", a, b)
+	}
+
+	changedModel, _ := Fingerprint("model-y", seg, prompts, shape)
+	if changedModel == a {
+		t.Fatal("model change must change the fingerprint")
+	}
+	changedSeg, _ := Fingerprint(
+		"model-x", TurnsV1{MaxWindowChars: 40000}, prompts, shape,
+	)
+	if changedSeg == a {
+		t.Fatal("segmenter parameter change must change the fingerprint")
+	}
+	changedPrompt, _ := Fingerprint(
+		"model-x", seg,
+		PromptsFor(mustProfile(t, "base"),
+			map[PromptRole]string{RoleIntent: "edited"}),
+		shape,
+	)
+	if changedPrompt == a {
+		t.Fatal("prompt change must change the fingerprint")
+	}
+}
+
+func mustProfile(t *testing.T, name string) Profile {
+	t.Helper()
+	profile, err := ResolveProfile(name, "")
+	if err != nil {
+		t.Fatalf("ResolveProfile(%s): %v", name, err)
+	}
+	return profile
+}

--- a/internal/recall/extract/prompts_test.go
+++ b/internal/recall/extract/prompts_test.go
@@ -123,6 +123,14 @@ func TestFingerprintIsStableAndSensitive(t *testing.T) {
 	if changedTokens == a {
 		t.Fatal("max_tokens change must change the fingerprint")
 	}
+	changedFloor, _ := Fingerprint(
+		"model-x", seg, prompts,
+		RequestShape{Temperature: 0, CompactFloorChars: 128},
+	)
+	if changedFloor == a {
+		t.Fatal("compact floor change must change the fingerprint: it " +
+			"decides between capped compact output and splitting")
+	}
 }
 
 func mustProfile(t *testing.T, name string) Profile {

--- a/internal/recall/extract/prompts_test.go
+++ b/internal/recall/extract/prompts_test.go
@@ -32,6 +32,10 @@ func TestResolveProfileFallsBackToBase(t *testing.T) {
 	if profile.Name != "base" {
 		t.Fatalf("profile = %q, want base", profile.Name)
 	}
+	if profile.Request.MaxTokens <= 0 {
+		t.Fatalf("base profile MaxTokens = %d, must be a working default",
+			profile.Request.MaxTokens)
+	}
 }
 
 func TestResolveProfileExplicitWinsAndUnknownErrors(t *testing.T) {
@@ -112,6 +116,12 @@ func TestFingerprintIsStableAndSensitive(t *testing.T) {
 	)
 	if changedPrompt == a {
 		t.Fatal("prompt change must change the fingerprint")
+	}
+	changedTokens, _ := Fingerprint(
+		"model-x", seg, prompts, RequestShape{Temperature: 0, MaxTokens: 512},
+	)
+	if changedTokens == a {
+		t.Fatal("max_tokens change must change the fingerprint")
 	}
 }
 


### PR DESCRIPTION
Second slice of the automatic recall extraction pipeline, after the #1158 segmenter: the persistence layer that makes long extraction runs safe to interrupt, and the model-facing client that turns one unit into entries.

**Generation registry** (`recall_extract_generations`) — an extraction run is keyed by a fingerprint digesting everything that changes its output: the model identity (name plus optional deployment label), segmentation strategy and parameters, resolved prompt contents, request shape including the output token budget, and a protocol version covering the response schema and recovery behavior baked into the binary. Same fingerprint → interchangeable corpora; any difference → a new generation, so reconfiguration never mixes entries produced under different settings. States are `building → active → retired`, with activation and retire performed as single atomic statements (no check-then-update races), and `EnsureExtractGeneration` idempotent so a restarting daemon re-registers safely.

**Resumable progress store** (`recall_extract_progress`) — one row per (session, generation) carrying a unit cursor, unit total, and content digest of the session's derived units. Because unit derivation and candidate ids are deterministic, a daemon killed mid-session resumes from the cursor and re-upserts at worst one unit's entries. If a session's content digest changes (new messages arrived), the upsert resets the cursor instead of silently extracting against stale unit boundaries; a session with zero units lands directly in done. Cursor advancement requires the caller's expected digest and enforces monotonic, bounded cursors; failure marking additionally requires the cursor the worker observed, and a completed row can never be demoted — a worker that lost any race gets a typed `ErrStaleExtractProgress` instead of corrupting the row. Every mutation holds the database write mutex so connection swaps during resync quiesce cleanly, and full resync carries both tables across via the existing attached-copy path, tolerating older archives that predate them.

**Extraction client** (`DistillWithRecovery`) — one unit per call through an OpenAI-compatible chat endpoint with strict JSON-schema decoding, enforced again client-side (exact keys, no nulls, typed fields, closed type enum) so a server that ignores `json_schema` cannot advance progress over silently lost entries. Failures are classified: network errors, timeouts, rate limits, and server errors retry with exponential backoff honoring `Retry-After`; permanent rejections fail fast; an HTTP 400 whose body names a context-length problem is a typed `ErrContextOverflow`; truncated output surfaces immediately as `ErrPersistentTruncation`. Both typed errors mean "split this unit" — splitting belongs to the caller, which owns unit identity, and preserves every entry. There is deliberately no retry that caps the entry count: a capped response looks complete while silently dropping entries. Token usage is summed across every attempt, successful or not.

**Prompt profiles** — three layers resolved most-specific-first: embedded base prompts per unit role (zero config works), built-in model-family profiles bundling prompt variants with request shape (the `qwen` profile disables hidden reasoning via template arguments — under constrained decoding it otherwise consumes the entire token budget before any content), and per-role override files (`intent.txt`/`action.txt`/`generic.txt`; an empty file is an error rather than a silently blanked prompt). Resolutions are deep copies, so caller mutation cannot corrupt the registry.

Nothing schedules extraction yet; the manager that wires segmenter → client → store together, plus CLI and configuration, is the next slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)