### PR TITLE
feat(recall): extraction client with recovery ladder and model prompt profiles

### DIFF
--- a/internal/recall/extract/client.go
+++ b/internal/recall/extract/client.go
@@ -1,0 +1,262 @@
+package extract
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"time"
+)
+
+// ErrContextOverflow reports a prompt the server rejected as too large for
+// the model context. The unit must be split before retrying; retrying the
+// same text can never succeed.
+var ErrContextOverflow = errors.New("unit text overflows the model context")
+
+// ErrPersistentTruncation reports output that stayed truncated even after
+// the compact retry. Like an overflow, the only recovery is splitting the
+// unit into smaller pieces.
+var ErrPersistentTruncation = errors.New(
+	"model output stays truncated at the token budget",
+)
+
+// errTruncated is the per-request truncation signal that
+// DistillWithRecovery converts into a compact retry.
+var errTruncated = errors.New("model output truncated")
+
+// compactSuffix is appended on the truncation retry. Sampling at
+// temperature zero makes a same-input retry deterministic, so the retry
+// must change the input instead of hoping for different output.
+const compactSuffix = "\n\nIMPORTANT: the output budget is tight for this " +
+	"window. Return at most 4 entries, each with a body of at most 2 " +
+	"sentences."
+
+// Entry is one distilled memory entry as the model produces it.
+type Entry struct {
+	Type     string   `json:"type"`
+	Title    string   `json:"title"`
+	Body     string   `json:"body"`
+	Entities []string `json:"entities"`
+}
+
+// Usage reports token consumption for one model call.
+type Usage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+}
+
+// entrySchema constrains decoding so the model can only produce parseable
+// entries; validation failures become server-side sampling constraints
+// instead of client-side parse errors.
+var entrySchema = map[string]any{
+	"type": "object",
+	"properties": map[string]any{
+		"entries": map[string]any{
+			"type": "array",
+			"items": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"type": map[string]any{
+						"type": "string",
+						"enum": []string{
+							"fact", "decision", "procedure",
+							"warning", "preference", "open_question",
+						},
+					},
+					"title": map[string]any{"type": "string"},
+					"body":  map[string]any{"type": "string"},
+					"entities": map[string]any{
+						"type":  "array",
+						"items": map[string]any{"type": "string"},
+					},
+				},
+				"required":             []string{"type", "title", "body", "entities"},
+				"additionalProperties": false,
+			},
+		},
+	},
+	"required":             []string{"entries"},
+	"additionalProperties": false,
+}
+
+// Client distills unit text into entries through an OpenAI-compatible chat
+// completion endpoint with constrained decoding.
+type Client struct {
+	BaseURL    string
+	Model      string
+	MaxTokens  int
+	HTTPClient *http.Client
+	Request    RequestShape
+}
+
+func (c *Client) httpClient() *http.Client {
+	if c.HTTPClient != nil {
+		return c.HTTPClient
+	}
+	return &http.Client{Timeout: 10 * time.Minute}
+}
+
+// DistillWithRecovery runs one unit through the model with the recovery
+// ladder: transient failures are retried up to maxAttempts per phase;
+// truncated output triggers exactly one compact retry (temperature-zero
+// sampling makes same-input retries useless); truncation that survives the
+// compact retry surfaces as ErrPersistentTruncation and a context overflow
+// as ErrContextOverflow — both mean "split this unit", which the caller
+// owns because it also owns unit identity.
+func (c *Client) DistillWithRecovery(
+	ctx context.Context, systemPrompt, text string, maxAttempts int,
+) ([]Entry, Usage, error) {
+	for _, compact := range []bool{false, true} {
+		var lastErr error
+		truncated := false
+		for range maxAttempts {
+			entries, usage, err := c.distill(ctx, systemPrompt, text, compact)
+			if err == nil {
+				return entries, usage, nil
+			}
+			if errors.Is(err, ErrContextOverflow) {
+				return nil, Usage{}, err
+			}
+			if errors.Is(err, errTruncated) {
+				truncated = true
+				break
+			}
+			if ctx.Err() != nil {
+				return nil, Usage{}, ctx.Err()
+			}
+			lastErr = err
+		}
+		if !truncated {
+			return nil, Usage{}, fmt.Errorf(
+				"distilling unit after %d attempts: %w", maxAttempts, lastErr,
+			)
+		}
+	}
+	return nil, Usage{}, fmt.Errorf(
+		"unit of %d chars: %w", len(text), ErrPersistentTruncation,
+	)
+}
+
+func (c *Client) distill(
+	ctx context.Context, systemPrompt, text string, compact bool,
+) ([]Entry, Usage, error) {
+	userText := text
+	if compact {
+		userText += compactSuffix
+	}
+	payload := map[string]any{
+		"model":       c.Model,
+		"max_tokens":  c.MaxTokens,
+		"temperature": c.Request.Temperature,
+		"messages": []map[string]string{
+			{"role": "system", "content": systemPrompt},
+			{"role": "user", "content": userText},
+		},
+		"response_format": map[string]any{
+			"type": "json_schema",
+			"json_schema": map[string]any{
+				"name":   "session_readout",
+				"strict": true,
+				"schema": entrySchema,
+			},
+		},
+	}
+	maps.Copy(payload, c.Request.ExtraBody)
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, Usage{}, fmt.Errorf("encoding distill request: %w", err)
+	}
+	request, err := http.NewRequestWithContext(
+		ctx, http.MethodPost,
+		c.BaseURL+"/chat/completions", bytes.NewReader(body),
+	)
+	if err != nil {
+		return nil, Usage{}, fmt.Errorf("building distill request: %w", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+
+	response, err := c.httpClient().Do(request)
+	if err != nil {
+		return nil, Usage{}, fmt.Errorf("posting distill request: %w", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+	raw, err := io.ReadAll(io.LimitReader(response.Body, 16<<20))
+	if err != nil {
+		return nil, Usage{}, fmt.Errorf("reading distill response: %w", err)
+	}
+	if response.StatusCode == http.StatusBadRequest {
+		// Chat servers answer 400 when the prompt exceeds the context
+		// window; character budgets overshoot because token density
+		// varies across content.
+		detail := string(raw)
+		if len(detail) > 200 {
+			detail = detail[:200]
+		}
+		return nil, Usage{}, fmt.Errorf(
+			"%d-char unit: %w: %s", len(userText), ErrContextOverflow, detail,
+		)
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, Usage{}, fmt.Errorf(
+			"distill request failed with HTTP %d", response.StatusCode,
+		)
+	}
+
+	var parsed struct {
+		Choices []struct {
+			FinishReason string `json:"finish_reason"`
+			Message      struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+		Usage Usage `json:"usage"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return nil, Usage{}, fmt.Errorf("parsing distill response: %w", err)
+	}
+	if len(parsed.Choices) == 0 {
+		return nil, Usage{}, fmt.Errorf("distill response has no choices")
+	}
+	choice := parsed.Choices[0]
+	if choice.FinishReason == "length" {
+		return nil, Usage{}, fmt.Errorf(
+			"at max_tokens=%d: %w", c.MaxTokens, errTruncated,
+		)
+	}
+	if choice.Message.Content == "" {
+		// Empty content with a normal finish reason means the token budget
+		// went somewhere invisible (typically hidden reasoning the request
+		// shape should have disabled).
+		return nil, Usage{}, fmt.Errorf(
+			"distill response content is empty; check the model profile's " +
+				"request shape",
+		)
+	}
+	var out struct {
+		Entries []Entry `json:"entries"`
+	}
+	if err := json.Unmarshal([]byte(choice.Message.Content), &out); err != nil {
+		return nil, Usage{}, fmt.Errorf("parsing distilled entries: %w", err)
+	}
+	return out.Entries, parsed.Usage, nil
+}
+
+// SplitFloorChars is the smallest unit size worth splitting further. A unit
+// below this floor that still overflows or truncates is not a size problem,
+// so the error should surface instead of recursing forever. The floor
+// scales down with the window budget so small-window configurations can
+// still split.
+func SplitFloorChars(maxWindowChars int) int {
+	floor := maxWindowChars / 8
+	if floor > 2000 {
+		return 2000
+	}
+	if floor < 1 {
+		return 1
+	}
+	return floor
+}

--- a/internal/recall/extract/client_test.go
+++ b/internal/recall/extract/client_test.go
@@ -1,0 +1,224 @@
+package extract
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+type scriptedResponse struct {
+	status       int
+	finishReason string
+	content      string
+}
+
+func newScriptedServer(
+	t *testing.T, responses []scriptedResponse, requests *[]map[string]any,
+) *httptest.Server {
+	t.Helper()
+	var index atomic.Int64
+	return httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			var payload map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Errorf("decoding request: %v", err)
+			}
+			*requests = append(*requests, payload)
+			i := int(index.Add(1)) - 1
+			if i >= len(responses) {
+				t.Errorf("unexpected request %d", i)
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			resp := responses[i]
+			if resp.status != 0 && resp.status != http.StatusOK {
+				w.WriteHeader(resp.status)
+				_, _ = w.Write([]byte(`{"error":"scripted"}`))
+				return
+			}
+			body := map[string]any{
+				"choices": []map[string]any{{
+					"finish_reason": resp.finishReason,
+					"message": map[string]any{
+						"role":    "assistant",
+						"content": resp.content,
+					},
+				}},
+				"usage": map[string]any{
+					"prompt_tokens":     7,
+					"completion_tokens": 3,
+				},
+			}
+			_ = json.NewEncoder(w).Encode(body)
+		}))
+}
+
+func entriesJSON(t *testing.T, titles ...string) string {
+	t.Helper()
+	entries := make([]map[string]any, 0, len(titles))
+	for _, title := range titles {
+		entries = append(entries, map[string]any{
+			"type": "fact", "title": title, "body": "b",
+			"entities": []string{},
+		})
+	}
+	raw, err := json.Marshal(map[string]any{"entries": entries})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(raw)
+}
+
+func testClient(url string) *Client {
+	return &Client{
+		BaseURL:   url,
+		Model:     "test-model",
+		MaxTokens: 100,
+		Request: RequestShape{
+			Temperature: 0,
+			ExtraBody: map[string]any{
+				"chat_template_kwargs": map[string]any{
+					"enable_thinking": false,
+				},
+			},
+		},
+	}
+}
+
+func TestClientDistillParsesEntriesAndSendsShape(t *testing.T) {
+	var requests []map[string]any
+	server := newScriptedServer(t, []scriptedResponse{
+		{finishReason: "stop", content: entriesJSON(t, "one", "two")},
+	}, &requests)
+	defer server.Close()
+
+	entries, usage, err := testClient(server.URL).DistillWithRecovery(
+		context.Background(), "system prompt", "unit text", 3,
+	)
+	if err != nil {
+		t.Fatalf("DistillWithRecovery: %v", err)
+	}
+	if len(entries) != 2 || entries[0].Title != "one" {
+		t.Fatalf("entries = %+v", entries)
+	}
+	if usage.PromptTokens != 7 || usage.CompletionTokens != 3 {
+		t.Fatalf("usage = %+v", usage)
+	}
+	payload := requests[0]
+	if payload["temperature"] != float64(0) {
+		t.Fatalf("temperature = %v", payload["temperature"])
+	}
+	if _, ok := payload["chat_template_kwargs"]; !ok {
+		t.Fatal("extra body must be merged into the request")
+	}
+	if _, ok := payload["response_format"]; !ok {
+		t.Fatal("constrained decoding must be requested")
+	}
+}
+
+func TestClientContextOverflowIsTyped(t *testing.T) {
+	var requests []map[string]any
+	server := newScriptedServer(t, []scriptedResponse{
+		{status: http.StatusBadRequest},
+	}, &requests)
+	defer server.Close()
+
+	_, _, err := testClient(server.URL).DistillWithRecovery(
+		context.Background(), "p", "text", 3,
+	)
+	if !errors.Is(err, ErrContextOverflow) {
+		t.Fatalf("err = %v, want ErrContextOverflow", err)
+	}
+}
+
+func TestClientCompactRetryOnTruncation(t *testing.T) {
+	var requests []map[string]any
+	server := newScriptedServer(t, []scriptedResponse{
+		{finishReason: "length", content: ""},
+		{finishReason: "stop", content: entriesJSON(t, "compact")},
+	}, &requests)
+	defer server.Close()
+
+	entries, _, err := testClient(server.URL).DistillWithRecovery(
+		context.Background(), "p", "unit text", 3,
+	)
+	if err != nil {
+		t.Fatalf("DistillWithRecovery: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("entries = %+v", entries)
+	}
+	if len(requests) != 2 {
+		t.Fatalf("requests = %d, want 2 (truncation triggers one compact retry)", len(requests))
+	}
+	second := requests[1]["messages"].([]any)[1].(map[string]any)
+	if !strings.Contains(second["content"].(string), "output budget is tight") {
+		t.Fatal("compact retry must append the compact instruction")
+	}
+}
+
+func TestClientPersistentTruncationIsTyped(t *testing.T) {
+	var requests []map[string]any
+	server := newScriptedServer(t, []scriptedResponse{
+		{finishReason: "length", content: ""},
+		{finishReason: "length", content: ""},
+	}, &requests)
+	defer server.Close()
+
+	_, _, err := testClient(server.URL).DistillWithRecovery(
+		context.Background(), "p", "text", 3,
+	)
+	if !errors.Is(err, ErrPersistentTruncation) {
+		t.Fatalf("err = %v, want ErrPersistentTruncation", err)
+	}
+}
+
+func TestClientRetriesTransientErrors(t *testing.T) {
+	var requests []map[string]any
+	server := newScriptedServer(t, []scriptedResponse{
+		{status: http.StatusInternalServerError},
+		{finishReason: "stop", content: entriesJSON(t, "ok")},
+	}, &requests)
+	defer server.Close()
+
+	entries, _, err := testClient(server.URL).DistillWithRecovery(
+		context.Background(), "p", "text", 3,
+	)
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("entries=%v err=%v", entries, err)
+	}
+}
+
+func TestClientEmptyContentIsError(t *testing.T) {
+	// A model that burns its budget on hidden reasoning returns empty
+	// content with finish_reason stop; that must surface as an error, not
+	// as zero entries.
+	var requests []map[string]any
+	responses := make([]scriptedResponse, 3)
+	for i := range responses {
+		responses[i] = scriptedResponse{finishReason: "stop", content: ""}
+	}
+	server := newScriptedServer(t, responses, &requests)
+	defer server.Close()
+
+	_, _, err := testClient(server.URL).DistillWithRecovery(
+		context.Background(), "p", "text", 3,
+	)
+	if err == nil {
+		t.Fatal("empty content must be an error")
+	}
+}
+
+func TestSplitFloorChars(t *testing.T) {
+	if got := SplitFloorChars(50000); got != 2000 {
+		t.Fatalf("SplitFloorChars(50000) = %d, want 2000", got)
+	}
+	if got := SplitFloorChars(800); got != 100 {
+		t.Fatalf("SplitFloorChars(800) = %d, want 100", got)
+	}
+}

--- a/internal/recall/extract/prompts.go
+++ b/internal/recall/extract/prompts.go
@@ -1,0 +1,219 @@
+package extract
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Base prompts shipped in the binary. They work for instruction-following
+// models with no configuration; model profiles and user override files
+// replace them per role when a model needs different phrasing.
+const (
+	baseIntentPrompt = `You distill one user message from a coding-agent session into memory entries for a keyword search index. The text is what the human asked the agent to do, or their feedback on work in progress.
+
+Extract entries capturing the user's intent: the task requested, its targets and constraints (files, repos, branches, tools, APIs, versions, deadlines), corrections or feedback on prior work, standing preferences about how work should be done, and stated success criteria. Emit one entry per distinct item - the count should follow the content, so a one-line instruction may yield a single entry while a detailed request yields several. Do not pad.
+
+Rules:
+- Each entry must stand alone without the surrounding session.
+- Quote exact file paths, commands, identifiers, and values verbatim.
+- type: 'fact' for the requested task and stated context, 'preference' for standing user preferences about tools or workflow, 'open_question' for things the user left undecided.
+- title: one specific sentence, at most 120 characters.
+- body: 1-3 dense sentences with the exact identifiers and values.
+- entities: the exact searchable strings (file paths, function names, commands, project names) the entry is about.`
+
+	baseActionPrompt = `You distill one segment of a coding agent's recorded work (its replies, file edits, commands, and their results) into memory entries for a keyword search index.
+
+Record BOTH what the agent did and what it learned. Emit one entry per distinct item - the count should follow the content, so a short segment may yield one or two entries while a dense one yields many. Do not pad and do not stop early when more distinct items remain.
+
+- 'procedure': a sequence of steps that accomplished something, with the exact commands, files, and values used, and its outcome.
+- 'fact' (state change): how the code or system changed - "X went from A to B" - with the exact before and after values.
+- 'fact' (finding): concrete facts learned about the codebase or environment: where things live, how components connect, config values, versions, schema shapes, API behaviors, test results. Record these generously even when they are incidental to the task - a future search may need any of them, so incidental findings are wanted content, not padding.
+- 'decision': alternatives the agent proposed or considered, and why one was chosen or rejected.
+- 'warning': errors hit, failing commands, pitfalls or gotchas discovered.
+
+Rules:
+- Each entry must stand alone without the session transcript.
+- Quote exact file paths, commands, error messages, and values verbatim.
+- Record outcomes explicitly: what succeeded and what failed.
+- title: one specific sentence, at most 120 characters.
+- body: 1-4 dense sentences with the exact identifiers and values.
+- entities: the exact searchable strings (file paths, function names, commands, error strings, URLs) the entry is about.`
+)
+
+// basePrompts returns the embedded defaults for every prompt role. The
+// generic role reuses the action prompt: it records both sides of the
+// conversation for strategies that do not split by speaker.
+func basePrompts() map[PromptRole]string {
+	return map[PromptRole]string{
+		RoleIntent:  baseIntentPrompt,
+		RoleAction:  baseActionPrompt,
+		RoleGeneric: baseActionPrompt,
+	}
+}
+
+// RequestShape carries the model-dependent request parameters that change
+// extraction output. ExtraBody is merged into the request top-level, giving
+// server-specific knobs (template arguments, sampling controls) a home
+// without the client knowing about any particular server.
+type RequestShape struct {
+	Temperature float64        `json:"temperature"`
+	ExtraBody   map[string]any `json:"extra_body,omitempty"`
+}
+
+// Profile bundles the prompt variants and request shape a family of models
+// needs. Profiles are data: adding support for a model family is a new
+// entry here or a user override, not new code.
+type Profile struct {
+	Name string
+	// MatchPrefixes selects this profile automatically when the configured
+	// model name starts with one of these (case-insensitive).
+	MatchPrefixes []string
+	// Prompts overrides base prompts per role; absent roles keep the base.
+	Prompts map[PromptRole]string
+	Request RequestShape
+}
+
+var builtinProfiles = []Profile{
+	{
+		Name: "qwen",
+		// These models interleave hidden reasoning by default; with
+		// constrained decoding that burns the whole token budget before
+		// any content is produced, so the template must disable it.
+		MatchPrefixes: []string{"qwen"},
+		Request: RequestShape{
+			Temperature: 0,
+			ExtraBody: map[string]any{
+				"chat_template_kwargs": map[string]any{
+					"enable_thinking": false,
+				},
+			},
+		},
+	},
+	{
+		Name:    "base",
+		Request: RequestShape{Temperature: 0},
+	},
+}
+
+// ResolveProfile picks the profile for a model. An explicit name wins and
+// must exist; otherwise the model name selects a profile by prefix, falling
+// back to the base profile.
+func ResolveProfile(explicit, model string) (Profile, error) {
+	if explicit != "" {
+		for _, profile := range builtinProfiles {
+			if profile.Name == explicit {
+				return profile, nil
+			}
+		}
+		names := make([]string, 0, len(builtinProfiles))
+		for _, profile := range builtinProfiles {
+			names = append(names, profile.Name)
+		}
+		return Profile{}, fmt.Errorf(
+			"unknown extraction prompt profile %q (have: %s)",
+			explicit, strings.Join(names, ", "),
+		)
+	}
+	lowerModel := strings.ToLower(model)
+	for _, profile := range builtinProfiles {
+		for _, prefix := range profile.MatchPrefixes {
+			if strings.HasPrefix(lowerModel, prefix) {
+				return profile, nil
+			}
+		}
+	}
+	return ResolveProfile("base", model)
+}
+
+// PromptsFor resolves the effective prompt per role: user overrides win,
+// then the profile's variants, then the embedded base prompts.
+func PromptsFor(
+	profile Profile, overrides map[PromptRole]string,
+) map[PromptRole]string {
+	prompts := basePrompts()
+	maps.Copy(prompts, profile.Prompts)
+	maps.Copy(prompts, overrides)
+	return prompts
+}
+
+// LoadPromptOverrides reads per-role prompt files (intent.txt, action.txt,
+// generic.txt) from a directory. Missing files are simply not overridden;
+// an empty file is an error because it would silently blank a prompt.
+func LoadPromptOverrides(dir string) (map[PromptRole]string, error) {
+	overrides := map[PromptRole]string{}
+	for _, role := range []PromptRole{RoleIntent, RoleAction, RoleGeneric} {
+		path := filepath.Join(dir, string(role)+".txt")
+		raw, err := os.ReadFile(path)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("reading prompt override %s: %w", path, err)
+		}
+		prompt := strings.TrimSpace(string(raw))
+		if prompt == "" {
+			return nil, fmt.Errorf(
+				"prompt override %s is empty; delete the file to use the "+
+					"default prompt", path,
+			)
+		}
+		overrides[role] = prompt
+	}
+	return overrides, nil
+}
+
+// Fingerprint digests everything that changes extraction output: the model,
+// the segmentation strategy and its parameters, the resolved prompts, and
+// the request shape. Two configurations with the same fingerprint produce
+// interchangeable corpora; any difference is a new generation.
+func Fingerprint(
+	model string,
+	segmenter Segmenter,
+	prompts map[PromptRole]string,
+	request RequestShape,
+) (string, error) {
+	promptDigests := map[string]string{}
+	for role, prompt := range prompts {
+		sum := sha256.Sum256([]byte(prompt))
+		promptDigests[string(role)] = hex.EncodeToString(sum[:])
+	}
+	identity := struct {
+		Model         string            `json:"model"`
+		Segmenter     string            `json:"segmenter"`
+		Params        map[string]any    `json:"params"`
+		PromptDigests map[string]string `json:"prompt_digests"`
+		Request       RequestShape      `json:"request"`
+	}{
+		Model:         model,
+		Segmenter:     segmenter.Name(),
+		Params:        segmenter.Params(),
+		PromptDigests: promptDigests,
+		Request:       request,
+	}
+	// encoding/json writes map keys in sorted order, which makes the
+	// encoding canonical for the JSON-shaped values profiles carry.
+	canonical, err := json.Marshal(identity)
+	if err != nil {
+		return "", fmt.Errorf("encoding extraction identity: %w", err)
+	}
+	sum := sha256.Sum256(canonical)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// ProfileNames lists the built-in profiles for error messages and doctor
+// output, sorted for stable display.
+func ProfileNames() []string {
+	names := make([]string, 0, len(builtinProfiles))
+	for _, profile := range builtinProfiles {
+		names = append(names, profile.Name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/recall/extract/prompts_test.go
+++ b/internal/recall/extract/prompts_test.go
@@ -1,0 +1,125 @@
+package extract
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveProfileMatchesModelName(t *testing.T) {
+	profile, err := ResolveProfile("", "qwen3.6-27b-mtp")
+	if err != nil {
+		t.Fatalf("ResolveProfile: %v", err)
+	}
+	if profile.Name != "qwen" {
+		t.Fatalf("profile = %q, want qwen", profile.Name)
+	}
+	body, ok := profile.Request.ExtraBody["chat_template_kwargs"]
+	if !ok {
+		t.Fatal("qwen profile must carry chat_template_kwargs")
+	}
+	kwargs, ok := body.(map[string]any)
+	if !ok || kwargs["enable_thinking"] != false {
+		t.Fatalf("qwen profile must disable thinking, got %v", body)
+	}
+}
+
+func TestResolveProfileFallsBackToBase(t *testing.T) {
+	profile, err := ResolveProfile("", "some-foundation-model")
+	if err != nil {
+		t.Fatalf("ResolveProfile: %v", err)
+	}
+	if profile.Name != "base" {
+		t.Fatalf("profile = %q, want base", profile.Name)
+	}
+}
+
+func TestResolveProfileExplicitWinsAndUnknownErrors(t *testing.T) {
+	profile, err := ResolveProfile("base", "qwen3.6-27b-mtp")
+	if err != nil || profile.Name != "base" {
+		t.Fatalf("explicit base: profile=%v err=%v", profile.Name, err)
+	}
+	if _, err := ResolveProfile("nonexistent", "m"); err == nil {
+		t.Fatal("unknown explicit profile must error")
+	}
+}
+
+func TestPromptsForMergesProfileAndOverrides(t *testing.T) {
+	base, err := ResolveProfile("base", "m")
+	if err != nil {
+		t.Fatalf("ResolveProfile: %v", err)
+	}
+	prompts := PromptsFor(base, map[PromptRole]string{RoleIntent: "override"})
+	if prompts[RoleIntent] != "override" {
+		t.Fatalf("override must win, got %q", prompts[RoleIntent])
+	}
+	if prompts[RoleAction] == "" {
+		t.Fatal("unoverridden roles keep the base prompt")
+	}
+}
+
+func TestLoadPromptOverridesReadsRoleFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(
+		filepath.Join(dir, "intent.txt"), []byte("custom intent\n"), 0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	overrides, err := LoadPromptOverrides(dir)
+	if err != nil {
+		t.Fatalf("LoadPromptOverrides: %v", err)
+	}
+	if overrides[RoleIntent] != "custom intent" {
+		t.Fatalf("intent override = %q", overrides[RoleIntent])
+	}
+	if _, ok := overrides[RoleAction]; ok {
+		t.Fatal("absent files must not produce overrides")
+	}
+}
+
+func TestFingerprintIsStableAndSensitive(t *testing.T) {
+	seg := TurnsV1{MaxWindowChars: 50000}
+	prompts := PromptsFor(mustProfile(t, "base"), nil)
+	shape := RequestShape{Temperature: 0}
+
+	a, err := Fingerprint("model-x", seg, prompts, shape)
+	if err != nil {
+		t.Fatalf("Fingerprint: %v", err)
+	}
+	b, err := Fingerprint("model-x", seg, prompts, shape)
+	if err != nil {
+		t.Fatalf("Fingerprint: %v", err)
+	}
+	if a != b {
+		t.Fatalf("fingerprint not stable: %s vs %s", a, b)
+	}
+
+	changedModel, _ := Fingerprint("model-y", seg, prompts, shape)
+	if changedModel == a {
+		t.Fatal("model change must change the fingerprint")
+	}
+	changedSeg, _ := Fingerprint(
+		"model-x", TurnsV1{MaxWindowChars: 40000}, prompts, shape,
+	)
+	if changedSeg == a {
+		t.Fatal("segmenter parameter change must change the fingerprint")
+	}
+	changedPrompt, _ := Fingerprint(
+		"model-x", seg,
+		PromptsFor(mustProfile(t, "base"),
+			map[PromptRole]string{RoleIntent: "edited"}),
+		shape,
+	)
+	if changedPrompt == a {
+		t.Fatal("prompt change must change the fingerprint")
+	}
+}
+
+func mustProfile(t *testing.T, name string) Profile {
+	t.Helper()
+	profile, err := ResolveProfile(name, "")
+	if err != nil {
+		t.Fatalf("ResolveProfile(%s): %v", name, err)
+	}
+	return profile
+}


### PR DESCRIPTION
Third piece of the automatic recall extraction pipeline, after #1158 (segmenter) and #1159 (registry + progress store). This adds the model-facing half: the client that turns one unit into entries, and the prompt/profile layer that makes model differences configuration instead of code.

**Client (`DistillWithRecovery`)** — one unit per call through an OpenAI-compatible chat endpoint with strict JSON-schema decoding, so malformed output becomes a server-side sampling constraint rather than a client-side parse error. The recovery ladder matches how these servers fail in practice:
- transient errors retry up to a bound;
- truncated output (`finish_reason: length`) gets exactly one compact retry — at temperature zero a same-input retry is deterministic, so the retry changes the input instead;
- a context overflow (HTTP 400) or truncation that survives the compact retry returns a typed error (`ErrContextOverflow` / `ErrPersistentTruncation`) meaning "split this unit" — splitting belongs to the caller, which owns unit identity. `SplitFloorChars` bounds that recursion;
- empty content with a normal finish reason is an explicit error pointing at the request shape (the token budget went somewhere invisible), never silently zero entries.

**Prompt profiles** — three layers resolved most-specific-first: embedded base prompts per unit role (intent/action/generic, so zero config works), built-in model profiles bundling prompt variants with request shape (the `qwen` profile, matched by model-name prefix, disables hidden reasoning via template arguments — under constrained decoding it otherwise consumes the entire token budget before any content), and per-role override files (`intent.txt`/`action.txt`/`generic.txt`; an empty file is an error rather than a silently blanked prompt).

**Fingerprint** — digests model, segmenter identity and parameters, resolved prompt contents, and request shape into the identity the generation registry (#1159) keys corpora by. Editing a prompt file or switching models yields a new fingerprint, so reconfiguration creates a new comparable generation instead of mixing entries produced under different settings.

Nothing calls the package yet; the extraction manager and configuration wiring are the next slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)