### PR TITLE
fix(duckdb): render named string kinds in remote push arguments

### DIFF
--- a/internal/duckdb/project_identity_upsert.go
+++ b/internal/duckdb/project_identity_upsert.go
@@ -152,8 +152,9 @@ func upsertSessionProjectIdentitySnapshots(
 				archiveID, databaseGeneration, obs.SessionID,
 				obs.Project, obs.Machine, obs.RootPath, obs.GitRemote,
 				obs.GitRemoteName, obs.RepositoryPath, obs.WorktreeName,
-				obs.WorktreeRootPath, obs.WorktreeRelationship, obs.CheckoutState,
-				obs.GitBranch, obs.RemoteResolution, obs.RemoteCandidateCount,
+				obs.WorktreeRootPath, string(obs.WorktreeRelationship),
+				string(obs.CheckoutState),
+				obs.GitBranch, string(obs.RemoteResolution), obs.RemoteCandidateCount,
 				obs.ObservedAt, obs.NormalizedRemote, obs.KeySource, obs.Key,
 			)
 		}
@@ -258,8 +259,9 @@ func upsertProjectIdentityObservation(
 		obs.SourceArchiveID, obs.SourceArchiveSalt,
 		obs.Project, obs.Machine, obs.RootPath, obs.GitRemote,
 		obs.GitRemoteName, obs.RepositoryPath, obs.WorktreeName,
-		obs.WorktreeRootPath, obs.WorktreeRelationship, obs.CheckoutState,
-		obs.GitBranch, obs.RemoteResolution, obs.RemoteCandidateCount,
+		obs.WorktreeRootPath, string(obs.WorktreeRelationship),
+		string(obs.CheckoutState),
+		obs.GitBranch, string(obs.RemoteResolution), obs.RemoteCandidateCount,
 		obs.ObservedAt, obs.NormalizedRemote, obs.KeySource, obs.Key,
 	); err != nil {
 		return fmt.Errorf("upserting duckdb project identity observation: %w", err)

--- a/internal/duckdb/push.go
+++ b/internal/duckdb/push.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"fmt"
+	"reflect"
 	"slices"
 	"sort"
 	"strconv"
@@ -1215,7 +1216,29 @@ func duckValueLiteral(v any) (string, error) {
 			value.UTC().Format("2006-01-02 15:04:05.999999"),
 		), nil
 	default:
-		return "", fmt.Errorf("unsupported duckdb remote argument type %T", v)
+		// Mirror database/sql's default parameter converter so named kinds
+		// (export.WorktreeRelationship and friends) render the same way on
+		// the remote transport as they bind on the local mirror path.
+		rv := reflect.ValueOf(v)
+		switch rv.Kind() {
+		case reflect.String:
+			return duckRemoteStringLiteral(rv.String())
+		case reflect.Bool:
+			if rv.Bool() {
+				return "TRUE", nil
+			}
+			return "FALSE", nil
+		case reflect.Int, reflect.Int8, reflect.Int16,
+			reflect.Int32, reflect.Int64:
+			return strconv.FormatInt(rv.Int(), 10), nil
+		case reflect.Uint, reflect.Uint8, reflect.Uint16,
+			reflect.Uint32, reflect.Uint64:
+			return strconv.FormatUint(rv.Uint(), 10), nil
+		case reflect.Float32, reflect.Float64:
+			return strconv.FormatFloat(rv.Float(), 'g', -1, 64), nil
+		default:
+			return "", fmt.Errorf("unsupported duckdb remote argument type %T", v)
+		}
 	}
 }
 

--- a/internal/duckdb/quack_smoke_duckdbtest_test.go
+++ b/internal/duckdb/quack_smoke_duckdbtest_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/export"
 )
 
 func TestQuackLoopbackAttachRoundTrip(t *testing.T) {
@@ -471,6 +472,21 @@ func TestQuackClientSyncPushWritesThroughAttachment(t *testing.T) {
 
 	local := newLocalDB(t)
 	fixture := seedDuckDBSyncFixture(t, local)
+	// An observation with a git remote takes the stale-fallback DELETE
+	// branch of upsertProjectIdentityObservation, which routes typed enum
+	// arguments through the remote statement renderer.
+	require.NoError(t, local.UpsertProjectIdentityObservation(ctx,
+		export.ProjectIdentityObservation{
+			Project:              "alpha",
+			Machine:              "quack-client",
+			RootPath:             "/repo/alpha",
+			GitRemote:            "https://github.com/acme/alpha.git",
+			GitRemoteName:        "origin",
+			WorktreeRelationship: export.WorktreeMain,
+			CheckoutState:        export.CheckoutBranch,
+			ObservedAt:           time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC),
+		},
+	), "seed project identity observation with git remote")
 	require.NoError(t, local.InsertCursorUsageEvents([]db.CursorUsageEvent{
 		{
 			OccurredAt:       "2026-01-10T00:03:00Z",
@@ -550,6 +566,10 @@ func TestQuackClientSyncPushWritesThroughAttachment(t *testing.T) {
 	assert.Equal(t, "quack-client", machine)
 	assertDuckDBCount(t, server, "messages", 3)
 	assertDuckDBCount(t, server, "cursor_usage_events", 2)
+	assertDuckDBCountWhere(t, server,
+		"source_project_identity_observations",
+		"git_remote != ?", "", 1,
+	)
 	assertDuckDBIndexExists(t, server, "tool_calls", "idx_tool_calls_file_path")
 
 	alphaState := readDuckMirrorSessionState(t, ctx, server, fixture.alphaID)

--- a/internal/duckdb/sync_test.go
+++ b/internal/duckdb/sync_test.go
@@ -1172,6 +1172,53 @@ func TestDuckValueLiteralFormatsNullableNumericPointers(t *testing.T) {
 	}
 }
 
+func TestDuckSQLWithArgsExecutesNamedStringKinds(t *testing.T) {
+	ctx := context.Background()
+	duck := openTestDuckDB(t)
+
+	stmt, err := duckSQLWithArgs(
+		`SELECT ?, ?, ?`,
+		export.WorktreeLinked,
+		export.CheckoutBranch,
+		export.ProjectResolutionAmbiguous,
+	)
+	require.NoError(t, err)
+
+	var relationship, checkout, resolution string
+	require.NoError(t, duck.QueryRowContext(ctx, stmt).
+		Scan(&relationship, &checkout, &resolution))
+	assert.Equal(t, string(export.WorktreeLinked), relationship)
+	assert.Equal(t, string(export.CheckoutBranch), checkout)
+	assert.Equal(t, string(export.ProjectResolutionAmbiguous), resolution)
+}
+
+func TestDuckValueLiteralFormatsNamedScalarKinds(t *testing.T) {
+	type namedInt int32
+	type namedUint uint16
+	type namedFloat float64
+	type namedBool bool
+
+	tests := []struct {
+		name string
+		in   any
+		want string
+	}{
+		{name: "named int", in: namedInt(-7), want: "-7"},
+		{name: "named uint", in: namedUint(42), want: "42"},
+		{name: "named float", in: namedFloat(0.875), want: "0.875"},
+		{name: "named bool true", in: namedBool(true), want: "TRUE"},
+		{name: "named bool false", in: namedBool(false), want: "FALSE"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := duckValueLiteral(tt.in)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestSessionFingerprintsStoreDigestOnly(t *testing.T) {
 	ctx := context.Background()
 	local := newLocalDB(t)


### PR DESCRIPTION
Since #1075, every remote Quack push that carries project identity data fails with:

```
fatal: duckdb push: syncing duckdb project identity observation ...: upserting duckdb project identity observation: unsupported duckdb remote argument type export.WorktreeRelationship
```

`internal/duckdb/project_identity_upsert.go` passes `export.WorktreeRelationship`, `export.CheckoutState`, and `export.ProjectResolution` values (named string types) as statement arguments. On the local mirror path these bind fine because `database/sql`'s default parameter converter unwraps named kinds via reflection, but the remote Quack transport renders mutations through `duckValueLiteral`, whose type switch only accepts exact `string`/numeric/bool/time types — so only remote pushes break, and they break on the first observation.

Two commits:

- Convert the named string fields at the observation/snapshot insert call sites.
- Teach `duckValueLiteral` the same fallback `database/sql` applies locally: reflect on named string, bool, integer, and float kinds and render the underlying value. This also covers the stale root-fallback `DELETE`, which passes `export.ProjectResolutionAmbiguous` as a typed enum and still failed with call-site conversions alone, and it keeps the remote renderer from silently diverging again the next time a named type is added to a push argument list.

The Quack push test now seeds an observation with a git remote so the `DELETE` branch is exercised through the remote renderer (it previously only covered remote-less observations, which is how the gap survived), and unit tests cover named scalar kinds in the renderer directly.

Reviewers should look at the `default` case of `duckValueLiteral` in `internal/duckdb/push.go`: the fallback deliberately mirrors `driver.DefaultParameterConverter` semantics rather than whitelisting the specific `export` types, trading a little strictness for parity with the local path.