### PR TITLE
feat(duckdb): add duckdb compact to reclaim mirror free space

### DIFF
--- a/cmd/agentsview/cli.go
+++ b/cmd/agentsview/cli.go
@@ -716,8 +716,25 @@ func newDuckDBCommand() *cobra.Command {
 	cmd.AddCommand(newDuckDBPushCommand())
 	cmd.AddCommand(newDuckDBStatusCommand())
 	cmd.AddCommand(newDuckDBServeCommand())
+	cmd.AddCommand(newDuckDBCompactCommand())
 	cmd.AddCommand(newDuckDBQuackCommand())
 	return cmd
+}
+
+func newDuckDBCompactCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "compact",
+		Short: "Reclaim free space in the DuckDB mirror file",
+		Long: "Rewrite the local DuckDB mirror into a fresh file to reclaim the " +
+			"allocated-but-free blocks that accumulate from repeated pushes, then " +
+			"atomically swap it into place. The mirror must not be in use by " +
+			"another process such as 'duckdb serve' or 'duckdb push --watch'.",
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			runDuckDBCompact()
+		},
+	}
 }
 
 func newDuckDBPushCommand() *cobra.Command {

--- a/cmd/agentsview/duckdb.go
+++ b/cmd/agentsview/duckdb.go
@@ -237,6 +237,74 @@ func runDuckDBStatus() {
 	fmt.Printf("DuckDB messages: %d\n", status.DuckDBMessages)
 }
 
+func runDuckDBCompact() {
+	appCfg, err := config.LoadMinimal()
+	if err != nil {
+		log.Fatalf("loading config: %v", err)
+	}
+	if err := os.MkdirAll(appCfg.DataDir, 0o755); err != nil {
+		log.Fatalf("creating data dir: %v", err)
+	}
+	setupLogFile(appCfg.DataDir)
+
+	duckCfg, err := appCfg.ResolveDuckDB()
+	if err != nil {
+		fatal("duckdb compact: %v", err)
+	}
+	if duckCfg.URL != "" {
+		fatal("duckdb compact: only local mirror files can be compacted, " +
+			"not remote Quack endpoints")
+	}
+	if duckCfg.Path == "" {
+		fatal("duckdb compact: mirror path is not configured")
+	}
+
+	ctx, stop := signal.NotifyContext(
+		context.Background(), duckDBLongRunningSignals()...,
+	)
+	defer stop()
+
+	fmt.Printf("Compacting DuckDB mirror: %s\n", duckCfg.Path)
+	result, err := duckdbsync.Compact(ctx, duckCfg.Path)
+	if err != nil {
+		fatal("duckdb compact: %v", err)
+	}
+	writeDuckDBCompactResult(os.Stdout, result)
+}
+
+func writeDuckDBCompactResult(w io.Writer, result duckdbsync.CompactResult) {
+	reclaimed := result.BeforeFileBytes - result.AfterFileBytes
+	fmt.Fprintf(
+		w,
+		"File size:   %s -> %s (reclaimed %s)\n",
+		formatBytes(result.BeforeFileBytes),
+		formatBytes(result.AfterFileBytes),
+		formatBytes(reclaimed),
+	)
+	fmt.Fprintf(
+		w,
+		"Free blocks: %d -> %d (%s -> %s allocated-but-free)\n",
+		result.Before.FreeBlocks,
+		result.After.FreeBlocks,
+		formatBytes(result.Before.FreeBytes()),
+		formatBytes(result.After.FreeBytes()),
+	)
+	fmt.Fprintf(
+		w,
+		"Blocks:      %d used / %d total -> %d used / %d total\n",
+		result.Before.UsedBlocks, result.Before.TotalBlocks,
+		result.After.UsedBlocks, result.After.TotalBlocks,
+	)
+	fmt.Fprintf(
+		w,
+		"Verified %d tables; sessions=%d, messages=%d\n",
+		len(result.RowCounts),
+		result.RowCounts["sessions"],
+		result.RowCounts["messages"],
+	)
+	fmt.Fprintf(w, "Done in %s\n", result.Duration.Round(time.Millisecond))
+}
+
 func loadDuckDBServeConfig(cmd *cobra.Command) (config.Config, string, error) {
 	basePath, err := cmd.Flags().GetString("base-path")
 	if err != nil {

--- a/cmd/agentsview/duckdb_test.go
+++ b/cmd/agentsview/duckdb_test.go
@@ -274,6 +274,33 @@ func TestWriteDuckDBPushDiagnosticsIncludesAgentBreakdown(t *testing.T) {
 	assert.Contains(t, got, "DuckDB push wrote: sessions 3 (claude=2, codex=1), messages 7")
 }
 
+func TestWriteDuckDBCompactResultReportsReclaimedSpace(t *testing.T) {
+	var out bytes.Buffer
+
+	writeDuckDBCompactResult(&out, duckdbsync.CompactResult{
+		Path:            "/tmp/agentsview.duckdb",
+		BeforeFileBytes: 1167 << 20,
+		AfterFileBytes:  635 << 20,
+		Before: duckdbsync.DuckDBSizeStats{
+			BlockSize: 262144, TotalBlocks: 4669, UsedBlocks: 2539, FreeBlocks: 2130,
+		},
+		After: duckdbsync.DuckDBSizeStats{
+			BlockSize: 262144, TotalBlocks: 2539, UsedBlocks: 2539, FreeBlocks: 0,
+		},
+		RowCounts: map[string]int64{
+			"sessions": 6000, "messages": 120000, "tool_calls": 42,
+		},
+		Duration: 3200 * time.Millisecond,
+	})
+
+	got := out.String()
+	assert.Contains(t, got, "reclaimed 532.0 MB")
+	assert.Contains(t, got, "Free blocks: 2130 -> 0")
+	assert.Contains(t, got, "sessions=6000, messages=120000")
+	assert.Contains(t, got, "Verified 3 tables")
+	assert.Contains(t, got, "Done in 3.2s")
+}
+
 func TestWriteDuckDBQuackServeStartupDoesNotPrintToken(t *testing.T) {
 	var out bytes.Buffer
 	const token = "plain-quack-secret-token"

--- a/docs/duckdb.md
+++ b/docs/duckdb.md
@@ -32,6 +32,9 @@ agentsview duckdb serve
 
 # Keep the mirror current in the foreground
 agentsview duckdb push --watch
+
+# Reclaim free space that accumulates from repeated pushes
+agentsview duckdb compact
 ```
 
 `duckdb push` accepts the same project-filter and foreground watcher flags as
@@ -61,6 +64,44 @@ and `duckdb serve`.
 [`pg serve`](/pg-sync/#agentsview-pg-serve) (`--host`, `--port`, `--base-path`,
 proxy and TLS flags) and is read-only in the same way — no uploads, file
 watching, or local sync.
+
+## Reclaiming Space
+
+DuckDB never shrinks its database file on its own. Every `duckdb push` deletes
+and re-inserts changed sessions and rewrites the affected row groups, and the
+freed blocks stay allocated inside the file. Under steady-state `--watch` or a
+cron push loop, the mirror grows past its live size and only a rebuild reclaims
+the difference. On one measured ~6k-session archive a single `duckdb push
+--full` produced a 1167 MiB file whose live data was only 635 MiB — 46% of the
+file was allocated-but-free blocks.
+
+`duckdb compact` reclaims that space in place:
+
+```bash
+agentsview duckdb compact
+```
+
+It copies the mirror into a fresh file alongside the original
+(`sessions.duckdb.compact`), verifies that every table has the same row count in
+both files, and only then atomically swaps the new file over the original. The
+original is never deleted or truncated before the verified swap, and on any
+failure the temporary file is removed and the original is left untouched. The
+command reports the before/after file size, reclaimed bytes, and block stats.
+
+Compaction takes DuckDB's single-writer file lock for the duration of the copy.
+Stop any `duckdb serve` or `duckdb push --watch` process against the same mirror
+first; otherwise `compact` fails with a clear error rather than risking
+corruption. Compaction only applies to a local mirror file, not a remote Quack
+endpoint (`[duckdb].url`). A good cadence is to run `duckdb compact` periodically
+alongside a cron push, or whenever `duckdb status` and the on-disk file size have
+drifted far apart.
+
+!!! note "Text columns are stored uncompressed"
+    DuckDB stores the large text columns of the mirror — `messages.content`,
+    `tool_calls.result_content`, `tool_calls.input_json`, and
+    `tool_result_events.content` — Uncompressed. The columnar win over SQLite is
+    in index and fixed-width column cost, not text compression, so the compacted
+    file is not dramatically smaller than the live data it contains.
 
 ## Quack Remote Access
 

--- a/internal/duckdb/compact.go
+++ b/internal/duckdb/compact.go
@@ -1,0 +1,333 @@
+package duckdb
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+// compactSrcCatalog and compactDstCatalog are the ATTACH aliases used while
+// copying the mirror into a fresh file. They are fixed identifiers so the
+// COPY FROM DATABASE statement never has to interpolate the auto-derived
+// catalog name of the mirror file.
+const (
+	compactSrcCatalog = "compact_src"
+	compactDstCatalog = "compact_dst"
+)
+
+// compactTempSuffix is appended to the mirror path to form the fresh file that
+// compaction builds alongside the original before the atomic swap.
+const compactTempSuffix = ".compact"
+
+// DuckDBSizeStats summarizes the block accounting for a DuckDB database file.
+type DuckDBSizeStats struct {
+	BlockSize   int64
+	TotalBlocks int64
+	UsedBlocks  int64
+	FreeBlocks  int64
+}
+
+// FreeBytes returns the allocated-but-unused space implied by the free block
+// count. DuckDB never shrinks its file on its own, so this is the space a
+// compaction pass can reclaim.
+func (s DuckDBSizeStats) FreeBytes() int64 {
+	return s.FreeBlocks * s.BlockSize
+}
+
+// CompactResult reports what a Compact call reclaimed.
+type CompactResult struct {
+	Path            string
+	BeforeFileBytes int64
+	AfterFileBytes  int64
+	Before          DuckDBSizeStats
+	After           DuckDBSizeStats
+	RowCounts       map[string]int64
+	Duration        time.Duration
+}
+
+// Compact rewrites the local DuckDB mirror at path into a fresh file to reclaim
+// the allocated-but-free blocks that accumulate from push-time churn, then
+// atomically swaps the new file over the original.
+//
+// The original is never deleted or truncated before a verified swap: Compact
+// copies the entire database (schema plus data) into a temp file alongside the
+// original, checks that every mirror table has the same row count in both
+// files, and only then renames the temp file over the original. On any failure
+// the temp file is removed and the original is left untouched.
+//
+// Compact takes DuckDB's single-writer file lock on the original for the
+// duration of the copy. If another process (for example `duckdb serve` or
+// `duckdb push --watch`) holds the file, Compact fails with a clear error
+// rather than risking corruption.
+func Compact(ctx context.Context, path string) (CompactResult, error) {
+	if strings.TrimSpace(path) == "" {
+		return CompactResult{}, fmt.Errorf("duckdb path is required")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return CompactResult{}, fmt.Errorf(
+				"duckdb mirror file does not exist: %s", path,
+			)
+		}
+		return CompactResult{}, fmt.Errorf("stat duckdb mirror: %w", err)
+	}
+	if info.IsDir() {
+		return CompactResult{}, fmt.Errorf(
+			"duckdb mirror path is a directory: %s", path,
+		)
+	}
+
+	start := time.Now()
+	tempPath := path + compactTempSuffix
+	// Clear any leftover temp file (and its WAL sidecar) from a previous
+	// crashed run so ATTACH creates a fresh, empty destination.
+	if err := removeDuckDBFile(tempPath); err != nil {
+		return CompactResult{}, err
+	}
+
+	result, err := compactInto(ctx, path, tempPath)
+	if err != nil {
+		// Best-effort cleanup; never touch the original on failure.
+		_ = removeDuckDBFile(tempPath)
+		return CompactResult{}, err
+	}
+
+	if statErr := statFileBytes(tempPath, &result.AfterFileBytes); statErr != nil {
+		_ = removeDuckDBFile(tempPath)
+		return CompactResult{}, statErr
+	}
+	result.BeforeFileBytes = info.Size()
+
+	// Atomic swap: rename the compacted file over the original. On POSIX this
+	// replaces the inode atomically; a running reader keeps the old inode.
+	if err := os.Rename(tempPath, path); err != nil {
+		_ = removeDuckDBFile(tempPath)
+		return CompactResult{}, fmt.Errorf(
+			"swapping compacted duckdb mirror into place: %w", err,
+		)
+	}
+	// The compacted file is fully checkpointed and self-contained. Remove any
+	// stale WAL that belonged to the old file so a later open does not replay
+	// it against the new file.
+	if err := os.Remove(path + ".wal"); err != nil && !os.IsNotExist(err) {
+		return CompactResult{}, fmt.Errorf(
+			"removing stale duckdb WAL after compaction: %w", err,
+		)
+	}
+
+	result.Path = path
+	result.Duration = time.Since(start)
+	return result, nil
+}
+
+// compactInto opens the mirror at srcPath with the exclusive file lock, copies
+// its full contents into a fresh file at dstPath, and verifies that every
+// mirror table survived the copy with an identical row count. It does not swap
+// files; the caller owns the atomic rename.
+func compactInto(
+	ctx context.Context, srcPath, dstPath string,
+) (CompactResult, error) {
+	orchestrator, err := openDuckDB("")
+	if err != nil {
+		return CompactResult{}, fmt.Errorf(
+			"opening duckdb compaction connection: %w", err,
+		)
+	}
+	orchestrator.SetMaxOpenConns(1)
+	orchestrator.SetMaxIdleConns(1)
+	defer orchestrator.Close()
+	if err := configureDuckDBThreads(orchestrator); err != nil {
+		return CompactResult{}, err
+	}
+
+	// Pin a single connection so the ATTACH state persists across statements.
+	conn, err := orchestrator.Conn(ctx)
+	if err != nil {
+		return CompactResult{}, fmt.Errorf(
+			"pinning duckdb compaction connection: %w", err,
+		)
+	}
+	defer conn.Close()
+
+	// A read-write ATTACH takes DuckDB's single-writer lock on the mirror.
+	if _, err := conn.ExecContext(ctx,
+		fmt.Sprintf("ATTACH %s AS %s", duckLiteral(srcPath), compactSrcCatalog),
+	); err != nil {
+		return CompactResult{}, wrapCompactAttachError(srcPath, err)
+	}
+	if _, err := conn.ExecContext(ctx,
+		fmt.Sprintf("ATTACH %s AS %s", duckLiteral(dstPath), compactDstCatalog),
+	); err != nil {
+		return CompactResult{}, fmt.Errorf(
+			"attaching compacted duckdb destination: %w", err,
+		)
+	}
+
+	before, err := readAttachedDuckDBSize(ctx, conn, compactSrcCatalog)
+	if err != nil {
+		return CompactResult{}, err
+	}
+
+	if _, err := conn.ExecContext(ctx, fmt.Sprintf(
+		"COPY FROM DATABASE %s TO %s", compactSrcCatalog, compactDstCatalog,
+	)); err != nil {
+		return CompactResult{}, fmt.Errorf("copying duckdb mirror: %w", err)
+	}
+
+	rowCounts, err := verifyCompactRowCounts(ctx, conn)
+	if err != nil {
+		return CompactResult{}, err
+	}
+
+	// Fold the destination WAL into the file so its block accounting and the
+	// on-disk size reflect the final compacted state before the swap.
+	if _, err := conn.ExecContext(ctx,
+		"CHECKPOINT "+compactDstCatalog,
+	); err != nil {
+		return CompactResult{}, fmt.Errorf(
+			"checkpointing compacted duckdb mirror: %w", err,
+		)
+	}
+
+	after, err := readAttachedDuckDBSize(ctx, conn, compactDstCatalog)
+	if err != nil {
+		return CompactResult{}, err
+	}
+
+	// Detach both catalogs and release the source lock before the caller
+	// renames the file. Detaching the destination flushes it to disk.
+	if _, err := conn.ExecContext(ctx, "DETACH "+compactDstCatalog); err != nil {
+		return CompactResult{}, fmt.Errorf(
+			"detaching compacted duckdb destination: %w", err,
+		)
+	}
+	if _, err := conn.ExecContext(ctx, "DETACH "+compactSrcCatalog); err != nil {
+		return CompactResult{}, fmt.Errorf(
+			"detaching duckdb source: %w", err,
+		)
+	}
+
+	return CompactResult{
+		Before:    before,
+		After:     after,
+		RowCounts: rowCounts,
+	}, nil
+}
+
+// verifyCompactRowCounts asserts that every mirror table has the same row count
+// in the source and destination catalogs. It returns the per-table counts from
+// the freshly compacted destination.
+func verifyCompactRowCounts(
+	ctx context.Context, conn *sql.Conn,
+) (map[string]int64, error) {
+	srcCounts := make(map[string]int64, len(mirrorTables))
+	dstCounts := make(map[string]int64, len(mirrorTables))
+	for _, table := range mirrorTables {
+		var srcCount, dstCount int64
+		if err := conn.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM "+compactSrcCatalog+"."+table.name,
+		).Scan(&srcCount); err != nil {
+			return nil, fmt.Errorf(
+				"counting source rows in %s: %w", table.name, err,
+			)
+		}
+		if err := conn.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM "+compactDstCatalog+"."+table.name,
+		).Scan(&dstCount); err != nil {
+			return nil, fmt.Errorf(
+				"counting compacted rows in %s: %w", table.name, err,
+			)
+		}
+		srcCounts[table.name] = srcCount
+		dstCounts[table.name] = dstCount
+	}
+	if err := compareCompactRowCounts(srcCounts, dstCounts); err != nil {
+		return nil, err
+	}
+	return dstCounts, nil
+}
+
+// compareCompactRowCounts reports the first table whose original and compacted
+// row counts disagree. A mismatch means the copy dropped or duplicated rows and
+// the compacted file must not be swapped in.
+func compareCompactRowCounts(src, dst map[string]int64) error {
+	for _, table := range mirrorTables {
+		srcCount, dstCount := src[table.name], dst[table.name]
+		if srcCount != dstCount {
+			return fmt.Errorf(
+				"compaction verification failed for %s: original has %d rows, compacted has %d",
+				table.name, srcCount, dstCount,
+			)
+		}
+	}
+	return nil
+}
+
+func readAttachedDuckDBSize(
+	ctx context.Context, conn *sql.Conn, catalog string,
+) (DuckDBSizeStats, error) {
+	var stats DuckDBSizeStats
+	// pragma_database_size() returns wal_size/database_size as human-formatted
+	// strings, so only the plain integer block columns are read here.
+	if err := conn.QueryRowContext(ctx, `
+		SELECT block_size, total_blocks, used_blocks, free_blocks
+		FROM pragma_database_size()
+		WHERE database_name = ?`,
+		catalog,
+	).Scan(
+		&stats.BlockSize, &stats.TotalBlocks,
+		&stats.UsedBlocks, &stats.FreeBlocks,
+	); err != nil {
+		return DuckDBSizeStats{}, fmt.Errorf(
+			"reading duckdb size for %s: %w", catalog, err,
+		)
+	}
+	return stats, nil
+}
+
+func wrapCompactAttachError(path string, err error) error {
+	if isDuckDBFileLockError(err) {
+		return fmt.Errorf(
+			"duckdb mirror %s is in use by another process; stop 'duckdb serve' "+
+				"or 'duckdb push --watch' before compacting: %w",
+			path, err,
+		)
+	}
+	return fmt.Errorf("attaching duckdb source %s: %w", path, err)
+}
+
+func isDuckDBFileLockError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "could not set lock") ||
+		strings.Contains(msg, "conflicting lock") ||
+		strings.Contains(msg, "file is already open") ||
+		strings.Contains(msg, "already open in")
+}
+
+// removeDuckDBFile removes a DuckDB database file and its WAL sidecar, treating
+// a missing file as success.
+func removeDuckDBFile(path string) error {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing duckdb file %s: %w", path, err)
+	}
+	if err := os.Remove(path + ".wal"); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing duckdb WAL %s.wal: %w", path, err)
+	}
+	return nil
+}
+
+func statFileBytes(path string, dst *int64) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat compacted duckdb mirror: %w", err)
+	}
+	*dst = info.Size()
+	return nil
+}

--- a/internal/duckdb/compact_duckdbtest_test.go
+++ b/internal/duckdb/compact_duckdbtest_test.go
@@ -1,0 +1,209 @@
+//go:build duckdbtest && !(windows && arm64)
+
+package duckdb
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/duckdb/duckdb-go/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/db"
+)
+
+// snapshotMirrorCounts opens the mirror file, reads the row count of every
+// mirror table, and closes it again. The file must not be held open elsewhere.
+func snapshotMirrorCounts(
+	t *testing.T, ctx context.Context, path string,
+) map[string]int64 {
+	t.Helper()
+	conn, err := Open(path)
+	require.NoError(t, err, "open mirror for snapshot")
+	defer func() {
+		require.NoError(t, conn.Close(), "close mirror snapshot connection")
+	}()
+	return readMirrorCounts(t, ctx, conn)
+}
+
+func readMirrorCounts(
+	t *testing.T, ctx context.Context, conn *sql.DB,
+) map[string]int64 {
+	t.Helper()
+	counts := make(map[string]int64, len(mirrorTables))
+	for _, table := range mirrorTables {
+		var n int64
+		require.NoError(t,
+			conn.QueryRowContext(ctx,
+				"SELECT COUNT(*) FROM "+table.name,
+			).Scan(&n),
+			"count rows in %s", table.name,
+		)
+		counts[table.name] = n
+	}
+	return counts
+}
+
+func churnMirror(t *testing.T, ctx context.Context, local *db.DB, path string) {
+	t.Helper()
+	syncer, err := New(path, local, "test-machine", SyncOptions{})
+	require.NoError(t, err, "open sync for churn")
+	defer func() {
+		require.NoError(t, syncer.Close(), "close churn sync")
+	}()
+	require.NoError(t, local.SetSyncState(
+		syncer.transcriptRevisionBackfillKey(), "1",
+	))
+	_, err = syncer.Push(ctx, true, nil)
+	require.NoError(t, err, "initial churn push")
+
+	// Rewrite the alpha session several times. Each full re-push deletes and
+	// re-inserts the session's rows, which is the delete/upsert + row-group
+	// rewrite pattern that leaves allocated-but-free blocks behind.
+	for i := 0; i < 5; i++ {
+		ts := "2026-01-10T02:0" + string(rune('0'+i)) + ":00.000Z"
+		_, err = local.WriteSessionBatchAtomic([]db.SessionBatchWrite{{
+			Session: syncSession(
+				"duck-sync-alpha", "alpha", "alpha churn", ts, 2,
+			),
+			Messages: []db.Message{
+				syncMessage("duck-sync-alpha", 0, "user", "alpha churn", ts),
+				syncMessage(
+					"duck-sync-alpha", 1, "assistant",
+					"alpha churn assistant body", ts,
+					db.ToolCall{
+						ToolName:  "search",
+						Category:  "search",
+						SkillName: "duck-search",
+						ToolUseID: "tool-alpha",
+						InputJSON: `{"query":"churn"}`,
+						ResultEvents: []db.ToolResultEvent{{
+							Source:        "tool",
+							Status:        "complete",
+							Content:       "churn result",
+							Timestamp:     ts,
+							EventIndex:    0,
+							ContentLength: len("churn result"),
+						}},
+					},
+				),
+			},
+			DataVersion:     i + 2,
+			ReplaceMessages: true,
+		}})
+		require.NoError(t, err, "churn rewrite %d", i)
+		_, err = syncer.Push(ctx, true, nil)
+		require.NoError(t, err, "churn push %d", i)
+	}
+}
+
+func TestCompactPreservesRowsAndProducesUsableFile(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	seedDuckDBSyncFixture(t, local)
+	path := filepath.Join(t.TempDir(), "mirror.duckdb")
+
+	churnMirror(t, ctx, local, path)
+
+	before := snapshotMirrorCounts(t, ctx, path)
+	require.Equal(t, int64(2), before["sessions"], "fixture seeds two sessions")
+	require.Greater(t, before["messages"], int64(0))
+
+	result, err := Compact(ctx, path)
+	require.NoError(t, err, "compact mirror")
+
+	assert.Equal(t, path, result.Path)
+	assert.Equal(t, len(mirrorTables), len(result.RowCounts))
+	assert.Equal(t, before["sessions"], result.RowCounts["sessions"])
+	assert.Equal(t, before["messages"], result.RowCounts["messages"])
+	assert.Positive(t, result.BeforeFileBytes)
+	assert.Positive(t, result.AfterFileBytes)
+
+	after := snapshotMirrorCounts(t, ctx, path)
+	assert.Equal(t, before, after, "every table must survive compaction")
+
+	// No temp artifacts should be left behind.
+	for _, suffix := range []string{".compact", ".compact.wal", ".wal"} {
+		_, statErr := os.Stat(path + suffix)
+		assert.Truef(t, os.IsNotExist(statErr),
+			"expected %s to be absent after compaction", path+suffix)
+	}
+
+	// The compacted file must be usable through the read store.
+	store, err := NewStore(path)
+	require.NoError(t, err, "open compacted mirror as store")
+	defer func() {
+		require.NoError(t, store.Close(), "close store")
+	}()
+	page, err := store.ListSessions(ctx, db.SessionFilter{Limit: 10})
+	require.NoError(t, err, "list sessions from compacted mirror")
+	assert.Len(t, page.Sessions, 2)
+
+	msgs, err := store.GetMessages(ctx, "duck-sync-alpha", 0, 10, true)
+	require.NoError(t, err, "read messages from compacted mirror")
+	assert.NotEmpty(t, msgs)
+
+	stars, err := store.ListStarredSessionIDs(ctx)
+	require.NoError(t, err, "read starred sessions from compacted mirror")
+	assert.Equal(t, []string{"duck-sync-alpha"}, stars)
+}
+
+func TestCompactMissingFileReturnsClearError(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "does-not-exist.duckdb")
+
+	_, err := Compact(ctx, path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not exist")
+
+	_, statErr := os.Stat(path)
+	assert.True(t, os.IsNotExist(statErr),
+		"missing file must not be created by compact")
+}
+
+// TestCompactFailedCopyLeavesOriginalUntouched drives the failure path where
+// the fresh file cannot be built (here the parent directory is read-only, so
+// the temp destination cannot be created). The original must be byte- and
+// row-identical afterward and no temp artifact may be left behind. This is the
+// same "return before the swap, clean up temp" path a verification mismatch or
+// an in-use lock on another process would take.
+func TestCompactFailedCopyLeavesOriginalUntouched(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	seedDuckDBSyncFixture(t, local)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mirror.duckdb")
+
+	churnMirror(t, ctx, local, path)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err, "stat original before compact")
+	beforeCounts := snapshotMirrorCounts(t, ctx, path)
+
+	// Make the mirror's directory read-only so the temp destination file
+	// cannot be created, forcing compaction to fail before any swap.
+	require.NoError(t, os.Chmod(dir, 0o500), "make mirror dir read-only")
+	t.Cleanup(func() {
+		require.NoError(t, os.Chmod(dir, 0o700), "restore mirror dir perms")
+	})
+
+	_, err = Compact(ctx, path)
+	require.Error(t, err, "compact must fail when the temp file cannot be built")
+
+	// Restore write access so the follow-up assertions can reopen the file.
+	require.NoError(t, os.Chmod(dir, 0o700), "restore mirror dir perms")
+
+	afterInfo, err := os.Stat(path)
+	require.NoError(t, err, "stat original after failed compact")
+	assert.Equal(t, info.Size(), afterInfo.Size(),
+		"original file size must be unchanged")
+	assert.Equal(t, beforeCounts, snapshotMirrorCounts(t, ctx, path),
+		"original rows must be unchanged after a failed compact")
+
+	_, statErr := os.Stat(path + ".compact")
+	assert.True(t, os.IsNotExist(statErr),
+		"temp file must be cleaned up after a failed compact")
+}

--- a/internal/duckdb/compact_test.go
+++ b/internal/duckdb/compact_test.go
@@ -1,0 +1,56 @@
+package duckdb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompareCompactRowCountsMatch(t *testing.T) {
+	src := map[string]int64{}
+	dst := map[string]int64{}
+	for i, table := range mirrorTables {
+		src[table.name] = int64(i)
+		dst[table.name] = int64(i)
+	}
+	require.NoError(t, compareCompactRowCounts(src, dst))
+}
+
+func TestCompareCompactRowCountsDetectsMismatch(t *testing.T) {
+	require.NotEmpty(t, mirrorTables, "mirror tables must be defined")
+	src := map[string]int64{}
+	dst := map[string]int64{}
+	for _, table := range mirrorTables {
+		src[table.name] = 7
+		dst[table.name] = 7
+	}
+	// Drop a row from one table in the compacted copy.
+	target := mirrorTables[0].name
+	dst[target] = 6
+
+	err := compareCompactRowCounts(src, dst)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "compaction verification failed")
+	assert.Contains(t, err.Error(), target)
+	assert.Contains(t, err.Error(), "original has 7 rows, compacted has 6")
+}
+
+func TestIsDuckDBFileLockError(t *testing.T) {
+	assert.False(t, isDuckDBFileLockError(nil))
+	assert.True(t, isDuckDBFileLockError(
+		assertError("IO Error: Could not set lock on file"),
+	))
+	assert.True(t, isDuckDBFileLockError(
+		assertError("Conflicting lock is held in /proc/123"),
+	))
+	assert.False(t, isDuckDBFileLockError(
+		assertError("some unrelated error"),
+	))
+}
+
+type stringError string
+
+func (e stringError) Error() string { return string(e) }
+
+func assertError(msg string) error { return stringError(msg) }


### PR DESCRIPTION
DuckDB never returns free blocks to the filesystem, so a mirror that is
pushed repeatedly accumulates allocated-but-free space from delete/upsert
churn and row-group rewrites. On a ~6k-session archive, a single
`duckdb push --full` left a 1167 MiB `sessions.duckdb` where 46% (2130 of
4669 256KiB blocks per `PRAGMA database_size`) was free space; steady-state
watch/cron pushing only grows the file until a manual rebuild.

This adds `agentsview duckdb compact`, which rebuilds the mirror into a
fresh file and swaps it in atomically:

- An in-memory orchestrator connection attaches the mirror read-write and a
  fresh `<path>.compact` temp file, then runs `COPY FROM DATABASE` to copy
  schema, data, and indexes.
- Every mirror table's row count is verified identical between the two
  catalogs before anything is swapped. Only on a clean verify does it
  CHECKPOINT the destination and `os.Rename` it over the original — the
  same temp-build-then-atomic-swap shape as the SQLite resync path. Any
  failure removes the temp file and leaves the original untouched.
- After a successful swap it removes a leftover `<path>.wal`, which belongs
  to the old file, so a later open cannot replay a stale WAL against the
  compacted database.
- The read-write attach takes DuckDB's cross-process file lock, so a
  concurrent `duckdb serve` / `push --watch` produces a clear
  "in use by another process" error instead of corruption. Remote Quack
  URLs are rejected up front; only local mirror files can be compacted.
- The command reports before/after file size, reclaimed bytes, and
  used/free block counts.

Tradeoffs and limitations: compaction needs enough free disk for a second
copy of the live data; a second handle in the same process does not trip
DuckDB's lock (in-process shared instance), so the lock protection is
cross-process, which is the case that matters for the CLI; concurrent
compact invocations collide on the fixed temp name and the second one fails
on the source lock.

Where to look: `internal/duckdb/compact.go` for the copy/verify/swap logic,
`cmd/agentsview/duckdb.go` for the subcommand wiring, and `docs/duckdb.md`
("Reclaiming Space") for the user-facing guidance, including a note that the
large text columns are stored uncompressed so the columnar win is index
cost rather than text compression.
