### PR TITLE
fix(duckdb): reject quack http/https client URL forms with an actionable error

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,10 +168,13 @@ docker run --rm -p 127.0.0.1:9494:9494 \
     --allow-insecure
 
 # Serve the web UI from a remote Quack endpoint.
+# The client url uses the native quack:HOST:PORT form; the Quack extension
+# does not accept quack:http:// or quack:https:// urls. A non-loopback host
+# needs --allow-insecure.
 docker run --rm -p 127.0.0.1:8080:8080 \
-  -e AGENTSVIEW_DUCKDB_URL='quack:https://duckdb.example.com' \
+  -e AGENTSVIEW_DUCKDB_URL='quack:duckdb.example.com:9494' \
   -e AGENTSVIEW_DUCKDB_TOKEN="$QUACK_TOKEN" \
-  ghcr.io/kenn-io/agentsview:latest duckdb serve
+  ghcr.io/kenn-io/agentsview:latest duckdb serve --allow-insecure
 ```
 
 Keep Quack on loopback or behind TLS. Plain HTTP Quack on a non-loopback bind

--- a/cmd/agentsview/duckdb_test.go
+++ b/cmd/agentsview/duckdb_test.go
@@ -127,7 +127,7 @@ func TestArchiveWriteBackendDuckDBPushAbsolutizesRelativeDaemonPath(t *testing.T
 
 func TestArchiveWriteBackendDuckDBPushPostsRemoteURLToDaemon(t *testing.T) {
 	duckCfg := config.DuckDBConfig{
-		URL:           "quack:https://duck.example.test",
+		URL:           "quack:127.0.0.1:9494",
 		Token:         "quack-token",
 		AllowInsecure: true,
 	}
@@ -173,7 +173,7 @@ func TestArchiveWriteBackendDuckDBPushWatchReResolvesDaemon(t *testing.T) {
 		var req daemonPushRequest
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
 		require.NotNil(t, req.DuckDB)
-		assert.Equal(t, "quack:https://duck.example.test", req.DuckDB.URL)
+		assert.Equal(t, "quack:127.0.0.1:9494", req.DuckDB.URL)
 		assert.Equal(t, "secret", req.DuckDB.Token)
 		writeTestJSON(t, w, duckdbsync.PushResult{SessionsPushed: 1})
 	})
@@ -187,7 +187,7 @@ func TestArchiveWriteBackendDuckDBPushWatchReResolvesDaemon(t *testing.T) {
 		var req daemonPushRequest
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
 		require.NotNil(t, req.DuckDB)
-		assert.Equal(t, "quack:https://duck.example.test", req.DuckDB.URL)
+		assert.Equal(t, "quack:127.0.0.1:9494", req.DuckDB.URL)
 		assert.Equal(t, "secret", req.DuckDB.Token)
 		writeTestJSON(t, w, duckdbsync.PushResult{SessionsPushed: 1})
 	})
@@ -199,7 +199,7 @@ func TestArchiveWriteBackendDuckDBPushWatchReResolvesDaemon(t *testing.T) {
 	err := backend.DuckDBPushWatch(
 		ctx,
 		config.DuckDBConfig{
-			URL:   "quack:https://duck.example.test",
+			URL:   "quack:127.0.0.1:9494",
 			Token: "secret",
 		},
 		DuckDBPushConfig{},

--- a/docs/duckdb.md
+++ b/docs/duckdb.md
@@ -76,10 +76,16 @@ agentsview duckdb quack serve \
   --token "$AGENTSVIEW_DUCKDB_TOKEN"
 
 # Machine B (or another terminal): serve the UI from that endpoint
-AGENTSVIEW_DUCKDB_URL='quack:http://127.0.0.1:9494' \
+AGENTSVIEW_DUCKDB_URL='quack:127.0.0.1:9494' \
 AGENTSVIEW_DUCKDB_TOKEN="$AGENTSVIEW_DUCKDB_TOKEN" \
 agentsview duckdb serve
 ```
+
+The client `url` uses the native `quack:HOST:PORT` form. The Quack extension
+attaches only that authority form; URL-scheme forms such as
+`quack:http://HOST:PORT` are rejected at attach time, so AgentsView refuses them
+up front. A non-loopback client host requires `allow_insecure` (Quack speaks
+plain HTTP — put it behind TLS, a VPN, or an SSH tunnel first).
 
 `duckdb quack serve` flags:
 
@@ -107,7 +113,7 @@ DuckDB settings live in a `[duckdb]` section of `~/.agentsview/config.toml`:
 ```toml
 [duckdb]
 path = "~/.agentsview/sessions.duckdb"
-url = "quack:http://127.0.0.1:9494"
+url = "quack:127.0.0.1:9494"
 token = "..."
 machine_name = "my-laptop"
 allow_insecure = false

--- a/internal/duckdb/connect.go
+++ b/internal/duckdb/connect.go
@@ -617,31 +617,25 @@ func ValidateQuackClientURL(rawURL, token string, allowInsecure bool) error {
 		)
 	}
 	transport := strings.TrimPrefix(rawURL, "quack:")
-	if !strings.HasPrefix(transport, "http://") &&
-		!strings.HasPrefix(transport, "https://") {
-		host, err := quackURIHost(rawURL)
-		if err != nil {
-			return err
-		}
-		if !allowInsecure && !isLoopbackHost(host) {
-			return fmt.Errorf(
-				"duckdb native quack url host must be loopback unless allow_insecure is set",
-			)
-		}
-		return nil
-	}
-	u, err := neturl.Parse(transport)
-	if err != nil || u.Scheme == "" || u.Host == "" {
+	if strings.HasPrefix(transport, "http://") ||
+		strings.HasPrefix(transport, "https://") {
+		// The Quack extension parses the string after "quack:" as a native
+		// HOST:PORT authority and rejects URL-scheme forms at ATTACH time
+		// with "Invalid Port". Reject them here with an actionable message
+		// instead of surfacing the cryptic extension error.
 		return fmt.Errorf(
-			"duckdb quack url must include an http:// or https:// endpoint",
+			"duckdb quack url must use the native form quack:HOST:PORT; " +
+				"the Quack extension does not accept http:// or https:// " +
+				"client urls",
 		)
 	}
-	if u.Scheme != "http" && u.Scheme != "https" {
-		return fmt.Errorf("duckdb quack url must use http or https")
+	host, err := quackURIHost(rawURL)
+	if err != nil {
+		return err
 	}
-	if u.Scheme == "http" && !allowInsecure && !isLoopbackHost(u.Hostname()) {
+	if !allowInsecure && !isLoopbackHost(host) {
 		return fmt.Errorf(
-			"duckdb quack url uses plain HTTP for a non-loopback host; use https or set allow_insecure",
+			"duckdb native quack url host must be loopback unless allow_insecure is set",
 		)
 	}
 	return nil

--- a/internal/duckdb/connect_test.go
+++ b/internal/duckdb/connect_test.go
@@ -19,9 +19,10 @@ func TestValidateQuackClientURL(t *testing.T) {
 		wantErr       string
 	}{
 		{
-			name:  "loopback http allowed",
-			url:   "quack:http://127.0.0.1:9494",
-			token: "secret",
+			name:    "loopback http url rejected",
+			url:     "quack:http://127.0.0.1:9494",
+			token:   "secret",
+			wantErr: "native form quack:HOST:PORT",
 		},
 		{
 			name:  "native loopback hostport allowed",
@@ -34,15 +35,23 @@ func TestValidateQuackClientURL(t *testing.T) {
 			token: "secret",
 		},
 		{
-			name:  "https remote allowed",
-			url:   "quack:https://duck.example.com",
-			token: "secret",
+			name:    "https url rejected",
+			url:     "quack:https://duck.example.com",
+			token:   "secret",
+			wantErr: "native form quack:HOST:PORT",
 		},
 		{
-			name:          "explicit insecure remote allowed",
+			name:          "http url rejected even with allow_insecure",
 			url:           "quack:http://duck.example.com",
 			token:         "secret",
 			allowInsecure: true,
+			wantErr:       "native form quack:HOST:PORT",
+		},
+		{
+			name:    "http url rejection names the scheme forms",
+			url:     "quack:http://127.0.0.1:9494",
+			token:   "secret",
+			wantErr: "http:// or https://",
 		},
 		{
 			name:    "native remote rejected",
@@ -57,15 +66,9 @@ func TestValidateQuackClientURL(t *testing.T) {
 			allowInsecure: true,
 		},
 		{
-			name:    "token required",
+			name:    "token required before scheme check",
 			url:     "quack:http://127.0.0.1:9494",
 			wantErr: "token is required",
-		},
-		{
-			name:    "plain remote rejected",
-			url:     "quack:http://duck.example.com",
-			token:   "secret",
-			wantErr: "plain HTTP",
 		},
 		{
 			name:    "quack scheme required",

--- a/internal/duckdb/quack_url_form_duckdbtest_test.go
+++ b/internal/duckdb/quack_url_form_duckdbtest_test.go
@@ -1,0 +1,62 @@
+//go:build duckdbtest && !(windows && arm64)
+
+package duckdb
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestQuackClientURLFormAttachBehavior pins the upstream Quack extension
+// behavior that ValidateQuackClientURL relies on: the extension accepts the
+// native quack:HOST:PORT authority but rejects URL-scheme (http:// / https://)
+// forms at ATTACH time with "Invalid Port". agentsview rejects the URL-scheme
+// forms up front (see ValidateQuackClientURL) precisely because the extension
+// cannot parse them; if a future Quack version starts accepting them, this
+// test flags that the validator can be revisited.
+func TestQuackClientURLFormAttachBehavior(t *testing.T) {
+	ctx := context.Background()
+	port := freeTCPPort(t)
+	nativeURI := "quack:127.0.0.1:" + port
+	const token = "agentsview-duckdbtest-token-urlform"
+
+	path := filepath.Join(t.TempDir(), "agentsview-quack-urlform.duckdb")
+	openQuackMirrorServer(t, ctx, path, nativeURI, token)
+
+	client, err := sql.Open("duckdb", "")
+	require.NoError(t, err, "open client DuckDB")
+	client.SetMaxOpenConns(1)
+	client.SetMaxIdleConns(1)
+	t.Cleanup(func() {
+		require.NoError(t, client.Close(), "close client DuckDB")
+	})
+	_, err = client.ExecContext(ctx, "LOAD quack")
+	require.NoError(t, err, "load quack extension in client")
+
+	attach := func(alias, uri string) error {
+		_, err := client.ExecContext(ctx, fmt.Sprintf(
+			`ATTACH '%s' AS %s (TOKEN '%s')`, uri, alias, token,
+		))
+		return err
+	}
+
+	// Native HOST:PORT form is the working, documented client URL.
+	require.NoError(t, attach("native_db", nativeURI),
+		"native quack:HOST:PORT form must attach")
+
+	// URL-scheme forms are rejected by the extension at ATTACH time. This is
+	// the failure ValidateQuackClientURL pre-empts.
+	httpErr := attach("http_db", "quack:http://127.0.0.1:"+port)
+	require.Error(t, httpErr, "http:// client url form must fail at ATTACH")
+	assert.Contains(t, httpErr.Error(), "Invalid Port")
+
+	httpsErr := attach("https_db", "quack:https://127.0.0.1:"+port)
+	require.Error(t, httpsErr, "https:// client url form must fail at ATTACH")
+	assert.Contains(t, httpsErr.Error(), "Invalid Port")
+}


### PR DESCRIPTION
`docs/duckdb.md` documented `quack:http://host:port` as a client URL form
for remote push/status/serve, and `README.md` showed a `quack:https://...`
example — but the Quack extension rejects both URL-scheme forms at ATTACH
time with `Invalid Input Error: Invalid Port`: it parses everything after
`quack:` as a native `HOST:PORT` authority and cannot parse a scheme.
`ValidateQuackClientURL` accepted these forms, so users only ever saw the
cryptic extension error. Verified against current main with a live
`quack serve`: the native loopback form attaches, both `http://` and
`https://` forms fail identically.

Changes:

- `ValidateQuackClientURL` now rejects `quack:http://` and `quack:https://`
  up front with an actionable message naming the working native form. The
  existing native/loopback/`allow_insecure` acceptance behavior is
  unchanged, and the token check still fires first.
- `docs/duckdb.md` and `README.md` examples are corrected to the native
  form, with a short explanation that only the native authority form works.
- A `duckdbtest`-tagged regression test pins the upstream extension
  behavior (native form attaches; URL-scheme forms fail with
  `Invalid Port`), so if a future extension version starts accepting
  URL-scheme client URLs, the pin fails and the validator can be relaxed
  deliberately.

A deliberate non-fix: the URL-scheme forms are not silently translated into
the native form, because the extension upgrades non-loopback native attach
to HTTPS — translating `quack:http://HOST:PORT` would change transport
semantics behind the user's back (plain HTTP requested, TLS attempted). The
broader `allow_insecure` naming question for TLS-fronted remotes is left as
a separate follow-up.

Where to look: the scheme rejection in `internal/duckdb/connect.go`
(`ValidateQuackClientURL`), its table tests in `connect_test.go`, and the
behavior pin in `internal/duckdb/quack_url_form_duckdbtest_test.go`.
