### PR TITLE
fix(duckdb): fail fast on unresponsive remote Quack attach

### DIFF
--- a/docs/duckdb.md
+++ b/docs/duckdb.md
@@ -130,6 +130,7 @@ url = "quack:127.0.0.1:9494"
 token = "..."
 machine_name = "my-laptop"
 allow_insecure = false
+attach_timeout = "20s"
 projects = ["alpha", "beta"]
 # or: exclude_projects = ["scratch"]
 ```
@@ -141,17 +142,27 @@ projects = ["alpha", "beta"]
 | `token`            |                                 | Quack authentication token                                                                  |
 | `machine_name`     | OS hostname                     | Identifies the pushing machine                                                              |
 | `allow_insecure`   | `false`                         | Allow plain-HTTP Quack beyond loopback                                                      |
+| `attach_timeout`   | `20s`                           | Bound on a remote Quack `ATTACH` (and its TCP preflight); `0` uses the default, a negative value disables the guard |
 | `projects`         |                                 | Array of project names to include in push                                                   |
 | `exclude_projects` |                                 | Array of project names to exclude from push                                                 |
 
+When a remote Quack `url` is configured, `duckdb status` and `duckdb serve`
+first make a bounded TCP dial to the endpoint and then run the `ATTACH` under a
+watchdog, so an unreachable or unresponsive server fails fast with a clear
+error instead of hanging indefinitely. Because the `ATTACH` executes inside
+the DuckDB extension (CGO, which Go cannot interrupt), a timed-out attach may
+leak the underlying connection until the process exits; the command still
+returns promptly.
+
 Environment variables override the config file:
 
-| Variable                    | Description                   |
-| --------------------------- | ----------------------------- |
-| `AGENTSVIEW_DUCKDB_PATH`    | Local DuckDB mirror file path |
-| `AGENTSVIEW_DUCKDB_URL`     | Remote Quack endpoint URL for status and serve (read side only) |
-| `AGENTSVIEW_DUCKDB_TOKEN`   | Quack authentication token    |
-| `AGENTSVIEW_DUCKDB_MACHINE` | Machine name override         |
+| Variable                           | Description                   |
+| ---------------------------------- | ----------------------------- |
+| `AGENTSVIEW_DUCKDB_PATH`           | Local DuckDB mirror file path |
+| `AGENTSVIEW_DUCKDB_URL`            | Remote Quack endpoint URL for status and serve (read side only) |
+| `AGENTSVIEW_DUCKDB_TOKEN`          | Quack authentication token    |
+| `AGENTSVIEW_DUCKDB_MACHINE`        | Machine name override         |
+| `AGENTSVIEW_DUCKDB_ATTACH_TIMEOUT` | Remote attach timeout (Go duration, e.g. `20s`; `0` default, negative disables) |
 
 ## Limitations
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -102,13 +102,18 @@ var pgConfigKeys = map[string]struct{}{
 
 // DuckDBConfig holds DuckDB mirror and Quack connection settings.
 type DuckDBConfig struct {
-	Path            string   `toml:"path" json:"path"`
-	URL             string   `toml:"url" json:"url"`
-	Token           string   `toml:"token" json:"token,omitempty"`
-	MachineName     string   `toml:"machine_name" json:"machine_name"`
-	AllowInsecure   bool     `toml:"allow_insecure" json:"allow_insecure"`
-	Projects        []string `toml:"projects" json:"projects,omitempty"`
-	ExcludeProjects []string `toml:"exclude_projects" json:"exclude_projects,omitempty"`
+	Path          string `toml:"path" json:"path"`
+	URL           string `toml:"url" json:"url"`
+	Token         string `toml:"token" json:"token,omitempty"`
+	MachineName   string `toml:"machine_name" json:"machine_name"`
+	AllowInsecure bool   `toml:"allow_insecure" json:"allow_insecure"`
+	// AttachTimeout bounds how long a remote Quack ATTACH (and its cheap TCP
+	// preflight) may run before the client gives up, so an unresponsive
+	// endpoint fails fast instead of hanging forever. Zero selects the
+	// package default; a negative value disables the guard.
+	AttachTimeout   time.Duration `toml:"attach_timeout" json:"attach_timeout,omitempty"`
+	Projects        []string      `toml:"projects" json:"projects,omitempty"`
+	ExcludeProjects []string      `toml:"exclude_projects" json:"exclude_projects,omitempty"`
 }
 
 // VectorConfig holds settings for the optional local semantic-search
@@ -1143,6 +1148,9 @@ func (c *Config) applyConfigTOML(data string) error {
 	if file.DuckDB.AllowInsecure {
 		c.DuckDB.AllowInsecure = true
 	}
+	if file.DuckDB.AttachTimeout != 0 && c.DuckDB.AttachTimeout == 0 {
+		c.DuckDB.AttachTimeout = file.DuckDB.AttachTimeout
+	}
 	if file.DuckDB.Projects != nil && c.DuckDB.Projects == nil {
 		c.DuckDB.Projects = file.DuckDB.Projects
 	}
@@ -1423,6 +1431,16 @@ func (c *Config) loadEnv() {
 	}
 	if v := os.Getenv("AGENTSVIEW_DUCKDB_MACHINE"); v != "" {
 		c.DuckDB.MachineName = v
+	}
+	if v := os.Getenv("AGENTSVIEW_DUCKDB_ATTACH_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			c.DuckDB.AttachTimeout = d
+		} else {
+			log.Printf(
+				"warning: invalid AGENTSVIEW_DUCKDB_ATTACH_TIMEOUT %q: %v",
+				v, err,
+			)
+		}
 	}
 	if v := os.Getenv("AGENTSVIEW_DISABLE_UPDATE_CHECK"); v != "" {
 		c.DisableUpdateCheck = v == "1" || v == "true"

--- a/internal/duckdb/attach_timeout_test.go
+++ b/internal/duckdb/attach_timeout_test.go
@@ -1,0 +1,212 @@
+package duckdb
+
+import (
+	"errors"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveAttachTimeout(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured time.Duration
+		want       time.Duration
+	}{
+		{"zero selects default", 0, DefaultAttachTimeout},
+		{"negative disables", -1, 0},
+		{"negative duration disables", -5 * time.Second, 0},
+		{"positive used as-is", 3 * time.Second, 3 * time.Second},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, resolveAttachTimeout(tt.configured))
+		})
+	}
+}
+
+func TestQuackDialAddress(t *testing.T) {
+	tests := []struct {
+		name   string
+		rawURL string
+		want   string
+		wantOK bool
+	}{
+		{"native host:port", "quack:127.0.0.1:9494", "127.0.0.1:9494", true},
+		{"native localhost", "quack:localhost:8765", "localhost:8765", true},
+		{
+			"native with userinfo",
+			"quack:user:pass@192.0.2.5:9494",
+			"192.0.2.5:9494",
+			true,
+		},
+		{
+			"native with query and fragment",
+			"quack:127.0.0.1:9494?foo=bar#frag",
+			"127.0.0.1:9494",
+			true,
+		},
+		{"native ipv6", "quack:[::1]:9494", "[::1]:9494", true},
+		{"native missing port", "quack:example.com", "", false},
+		{
+			"http default port",
+			"quack:http://example.com/db",
+			"example.com:80",
+			true,
+		},
+		{
+			"https default port",
+			"quack:https://example.com/db",
+			"example.com:443",
+			true,
+		},
+		{
+			"http explicit port",
+			"quack:http://example.com:9000/db",
+			"example.com:9000",
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := quackDialAddress(tt.rawURL)
+			assert.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+// closedLoopbackPort returns a loopback host:port that nothing is listening on
+// by opening and immediately closing a listener.
+func closedLoopbackPort(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err, "allocate probe listener")
+	addr := ln.Addr().String()
+	require.NoError(t, ln.Close(), "close probe listener")
+	return addr
+}
+
+// unresponsiveListener accepts connections and holds them open without ever
+// writing a byte, simulating a server stuck in (for example) an SSL handshake.
+func unresponsiveListener(t *testing.T) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err, "start unresponsive listener")
+	var (
+		mu    sync.Mutex
+		conns []net.Conn
+	)
+	go func() {
+		for {
+			conn, acceptErr := ln.Accept()
+			if acceptErr != nil {
+				return
+			}
+			// Never respond; just keep the connection open.
+			mu.Lock()
+			conns = append(conns, conn)
+			mu.Unlock()
+		}
+	}()
+	t.Cleanup(func() {
+		_ = ln.Close()
+		mu.Lock()
+		defer mu.Unlock()
+		for _, c := range conns {
+			_ = c.Close()
+		}
+	})
+	return ln
+}
+
+func TestPreflightQuackDial(t *testing.T) {
+	t.Run("closed port fails fast", func(t *testing.T) {
+		addr := closedLoopbackPort(t)
+		start := time.Now()
+		err := preflightQuackDial("quack:"+addr, time.Second)
+		require.Error(t, err)
+		assert.Less(t, time.Since(start), time.Second)
+		assert.Contains(t, err.Error(), "connecting to quack endpoint")
+	})
+
+	t.Run("listening port passes", func(t *testing.T) {
+		ln := unresponsiveListener(t)
+		err := preflightQuackDial("quack:"+ln.Addr().String(), time.Second)
+		assert.NoError(t, err)
+	})
+
+	t.Run("undeterminable address skips check", func(t *testing.T) {
+		// No port: no dial target can be derived, so preflight is a no-op.
+		assert.NoError(t, preflightQuackDial("quack:example.com", time.Second))
+	})
+}
+
+func TestRunWithAttachTimeout(t *testing.T) {
+	t.Run("times out on unresponsive server", func(t *testing.T) {
+		ln := unresponsiveListener(t)
+		timeout := 150 * time.Millisecond
+		start := time.Now()
+		err := runWithAttachTimeout(
+			"quack:"+ln.Addr().String(), timeout, func() error {
+				// Faithfully reproduce the hang: connect (accepted) then
+				// block on a read that never returns because the server
+				// never responds.
+				conn, dialErr := net.Dial("tcp", ln.Addr().String())
+				if dialErr != nil {
+					return dialErr
+				}
+				defer conn.Close()
+				buf := make([]byte, 1)
+				_, readErr := conn.Read(buf)
+				return readErr
+			},
+		)
+		elapsed := time.Since(start)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "timed out")
+		assert.Contains(t, err.Error(), "attach_timeout")
+		assert.Less(t, elapsed, time.Second, "should give up near the timeout")
+		assert.GreaterOrEqual(t, elapsed, timeout)
+	})
+
+	t.Run("returns attach result when it completes", func(t *testing.T) {
+		assert.NoError(t, runWithAttachTimeout("quack:host", time.Second, func() error {
+			return nil
+		}))
+		sentinel := errors.New("attach boom")
+		err := runWithAttachTimeout("quack:host", time.Second, func() error {
+			return sentinel
+		})
+		assert.ErrorIs(t, err, sentinel)
+	})
+
+	t.Run("disabled timeout runs inline", func(t *testing.T) {
+		sentinel := errors.New("inline boom")
+		err := runWithAttachTimeout("quack:host", 0, func() error {
+			return sentinel
+		})
+		assert.ErrorIs(t, err, sentinel)
+	})
+}
+
+func TestOpenQuackClientPreflightFailsFast(t *testing.T) {
+	// A closed loopback port makes the TCP preflight fail before the quack
+	// extension is even loaded, so an unreachable endpoint returns promptly
+	// instead of hanging.
+	addr := closedLoopbackPort(t)
+	start := time.Now()
+	client, err := openQuackClient(
+		"quack:"+addr, "token", false, 2*time.Second,
+	)
+	require.Error(t, err)
+	assert.Nil(t, client)
+	assert.Less(t, time.Since(start), 2*time.Second)
+	assert.Contains(t, err.Error(), "connecting to quack endpoint")
+}

--- a/internal/duckdb/connect.go
+++ b/internal/duckdb/connect.go
@@ -11,11 +11,32 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 
 	"go.kenn.io/agentsview/internal/config"
 )
 
 const quackAttachmentName = "agentsview_remote"
+
+// DefaultAttachTimeout bounds a remote Quack ATTACH (and its TCP preflight)
+// when the caller does not configure an explicit timeout. Native non-loopback
+// attach can silently upgrade to an SSL handshake and hang indefinitely
+// against a plain-HTTP listener, so agentsview enforces its own deadline.
+const DefaultAttachTimeout = 20 * time.Second
+
+// resolveAttachTimeout maps a configured attach timeout to an effective
+// duration. Zero selects DefaultAttachTimeout; a negative value disables the
+// guard (returns 0); a positive value is used as-is.
+func resolveAttachTimeout(configured time.Duration) time.Duration {
+	switch {
+	case configured == 0:
+		return DefaultAttachTimeout
+	case configured < 0:
+		return 0
+	default:
+		return configured
+	}
+}
 
 // Open opens a local DuckDB file read-write for the agentsview mirror
 // backend. Only push paths use it: DuckDB's write lock is exclusive across
@@ -276,7 +297,9 @@ func isMissingDuckDBTable(err error) bool {
 // Store's unqualified read queries work for both local and remote modes.
 func NewStoreFromConfig(cfg config.DuckDBConfig) (*Store, error) {
 	if cfg.URL != "" {
-		return NewQuackStore(cfg.URL, cfg.Token, cfg.AllowInsecure)
+		return NewQuackStore(
+			cfg.URL, cfg.Token, cfg.AllowInsecure, cfg.AttachTimeout,
+		)
 	}
 	return NewStore(cfg.Path)
 }
@@ -293,9 +316,13 @@ func ValidatePushTarget(cfg config.DuckDBConfig) error {
 	return nil
 }
 
-// NewQuackStore attaches a remote DuckDB exposed over Quack.
-func NewQuackStore(rawURL, token string, allowInsecure bool) (*Store, error) {
-	client, err := openQuackClient(rawURL, token, allowInsecure)
+// NewQuackStore attaches a remote DuckDB exposed over Quack. attachTimeout
+// bounds the ATTACH; zero selects DefaultAttachTimeout and a negative value
+// disables the guard.
+func NewQuackStore(
+	rawURL, token string, allowInsecure bool, attachTimeout time.Duration,
+) (*Store, error) {
+	client, err := openQuackClient(rawURL, token, allowInsecure, attachTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -314,10 +341,21 @@ type quackClient struct {
 }
 
 func openQuackClient(
-	rawURL, token string, allowInsecure bool,
+	rawURL, token string, allowInsecure bool, attachTimeout time.Duration,
 ) (*quackClient, error) {
 	if err := ValidateQuackClientURL(rawURL, token, allowInsecure); err != nil {
 		return nil, err
+	}
+	timeout := resolveAttachTimeout(attachTimeout)
+	// Cheap TCP preflight before ATTACH: catches unreachable or blackholed
+	// endpoints in a bounded time even when the extension would otherwise
+	// hang. A successful dial only proves the port accepts connections; the
+	// watchdog below still guards a server that accepts but never responds
+	// (e.g. a stalled SSL handshake).
+	if timeout > 0 {
+		if err := preflightQuackDial(rawURL, timeout); err != nil {
+			return nil, err
+		}
 	}
 	conn, err := openDuckDB("")
 	if err != nil {
@@ -343,11 +381,107 @@ func openQuackClient(
 		rawURL: rawURL,
 		token:  token,
 	}
-	if err := client.attach(context.Background()); err != nil {
+	if err := runWithAttachTimeout(rawURL, timeout, func() error {
+		return client.attach(context.Background())
+	}); err != nil {
 		conn.Close()
 		return nil, err
 	}
 	return client, nil
+}
+
+// preflightQuackDial performs a bounded TCP dial against the host:port encoded
+// in a quack URL before ATTACH. It returns nil (skips the check) when no
+// definite host:port can be derived, leaving the attach watchdog as the guard.
+func preflightQuackDial(rawURL string, timeout time.Duration) error {
+	addr, ok := quackDialAddress(rawURL)
+	if !ok {
+		return nil
+	}
+	conn, err := net.DialTimeout("tcp", addr, timeout)
+	if err != nil {
+		return fmt.Errorf(
+			"connecting to quack endpoint %s: %w",
+			RedactQuackURL(rawURL), err,
+		)
+	}
+	return conn.Close()
+}
+
+// runWithAttachTimeout runs attach and enforces timeout. A non-positive
+// timeout runs attach inline with no guard. On timeout it returns an error
+// naming the endpoint and the timeout knob.
+//
+// The ATTACH executes inside the DuckDB C (CGO) extension, which cannot be
+// interrupted from Go: on timeout the attach goroutine and the client
+// connection it holds may leak. That is acceptable here because callers treat
+// a failed attach as fatal and the process is about to exit; the alternative
+// is hanging forever.
+func runWithAttachTimeout(
+	rawURL string, timeout time.Duration, attach func() error,
+) error {
+	if timeout <= 0 {
+		return attach()
+	}
+	// Buffered so the goroutine can always send and exit even after we have
+	// stopped waiting, avoiding a permanently blocked send.
+	done := make(chan error, 1)
+	go func() { done <- attach() }()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case err := <-done:
+		return err
+	case <-timer.C:
+		return fmt.Errorf(
+			"attaching quack endpoint %s timed out after %s; the server did "+
+				"not respond (set [duckdb].attach_timeout or "+
+				"AGENTSVIEW_DUCKDB_ATTACH_TIMEOUT, or a negative value to "+
+				"disable)",
+			RedactQuackURL(rawURL), timeout,
+		)
+	}
+}
+
+// quackDialAddress extracts a host:port TCP dial target from a quack URL for a
+// preflight reachability check. It returns ok=false when no definite host:port
+// can be derived (for example a native URL without an explicit port).
+func quackDialAddress(rawURL string) (string, bool) {
+	transport := strings.TrimPrefix(rawURL, "quack:")
+	if strings.HasPrefix(transport, "http://") ||
+		strings.HasPrefix(transport, "https://") {
+		u, err := neturl.Parse(transport)
+		if err != nil || u.Hostname() == "" {
+			return "", false
+		}
+		port := u.Port()
+		if port == "" {
+			if u.Scheme == "https" {
+				port = "443"
+			} else {
+				port = "80"
+			}
+		}
+		return net.JoinHostPort(u.Hostname(), port), true
+	}
+	transport = strings.SplitN(transport, "#", 2)[0]
+	transport = strings.SplitN(transport, "?", 2)[0]
+	if _, rest, ok := strings.Cut(transport, "://"); ok {
+		transport = rest
+	}
+	transport = strings.TrimPrefix(transport, "//")
+	authority := transport
+	if i := strings.IndexByte(authority, '/'); i >= 0 {
+		authority = authority[:i]
+	}
+	if at := strings.LastIndex(authority, "@"); at >= 0 {
+		authority = authority[at+1:]
+	}
+	host, port, err := net.SplitHostPort(authority)
+	if err != nil || host == "" || port == "" {
+		return "", false
+	}
+	return net.JoinHostPort(host, port), true
 }
 
 func (q *quackClient) DB() *sql.DB { return q.duck }

--- a/internal/duckdb/driver_windows_arm64_test.go
+++ b/internal/duckdb/driver_windows_arm64_test.go
@@ -17,7 +17,7 @@ func TestOpenReportsUnsupportedPlatform(t *testing.T) {
 }
 
 func TestNewQuackStoreReportsUnsupportedPlatform(t *testing.T) {
-	store, err := NewQuackStore("quack:localhost:8765", "token", false)
+	store, err := NewQuackStore("quack:localhost:8765", "token", false, 0)
 	require.Error(t, err)
 	assert.Nil(t, store)
 	assert.ErrorIs(t, err, errUnsupportedPlatform)

--- a/internal/duckdb/quack_smoke_duckdbtest_test.go
+++ b/internal/duckdb/quack_smoke_duckdbtest_test.go
@@ -157,7 +157,7 @@ func TestQuackStoreReattachesAfterServerRestart(t *testing.T) {
 	)
 	require.NoError(t, err, "insert seed row")
 
-	store, err := NewQuackStore(uri, token, false)
+	store, err := NewQuackStore(uri, token, false, 0)
 	require.NoError(t, err, "open quack store")
 	t.Cleanup(func() {
 		require.NoError(t, store.Close(), "close quack store")
@@ -207,7 +207,7 @@ func TestQuackStoreReattachesAfterFailedReattach(t *testing.T) {
 	)
 	require.NoError(t, err, "insert seed row")
 
-	store, err := NewQuackStore(uri, token, false)
+	store, err := NewQuackStore(uri, token, false, 0)
 	require.NoError(t, err, "open quack store")
 	t.Cleanup(func() {
 		require.NoError(t, store.Close(), "close quack store")
@@ -259,7 +259,7 @@ func TestQuackStoreAnalyticsDashboardReads(t *testing.T) {
 
 	openQuackMirrorServer(t, ctx, path, uri, token)
 
-	store, err := NewQuackStore(uri, token, false)
+	store, err := NewQuackStore(uri, token, false, 0)
 	require.NoError(t, err, "open Quack-backed store")
 	t.Cleanup(func() {
 		require.NoError(t, store.Close(), "close Quack-backed store")


### PR DESCRIPTION
A native Quack attach (`quack:HOST:PORT`) against an unresponsive endpoint
hangs indefinitely — observed in practice when the target is reachable at
the TCP level but never completes the protocol handshake (for example a
plain-HTTP listener on a non-loopback address, which the extension contacts
over TLS). Because the hang is inside the DuckDB extension, every command
that attaches a remote mirror (`duckdb push`, `duckdb status`,
`duckdb serve` with a remote URL) blocks forever with no error.

This makes the remote attach path fail fast instead:

- A TCP preflight (`net.DialTimeout`) against the host:port extracted from
  the quack URL catches unreachable or blackholed endpoints before the
  extension is even loaded. The address extraction handles the native
  `quack:host:port` form, IPv6 brackets, userinfo, and URL-scheme forms
  with default ports.
- A watchdog around the ATTACH itself runs the statement in a goroutine and
  selects on completion versus a timer, returning an error that names the
  endpoint and the timeout knob. This covers the observed repro shape:
  TCP connects, then the handshake stalls.

The timeout is configurable as `[duckdb].attach_timeout` /
`AGENTSVIEW_DUCKDB_ATTACH_TIMEOUT`, defaulting to 20s. A negative value
disables the guard; zero means "use the default" because a TOML duration
zero-value is indistinguishable from unset.

Tradeoffs: a timed-out ATTACH may leak its goroutine and connection, since
the extension call cannot be interrupted from Go — accepted and documented
in a code comment, as callers treat a failed attach as fatal. Scope is the
initial attach only; the existing stale-connection reattach retry path
during a live session is unchanged. Local file opens are untouched.

Where to look: `internal/duckdb/connect.go` (`preflightQuackDial`,
`runWithAttachTimeout`, `openQuackClient`), the knob registration in
`internal/config/config.go`, and `docs/duckdb.md` for the documentation.
