### PR TITLE
fix(duckdb): point remote schema-incompatible errors at the server

### DIFF
--- a/cmd/agentsview/duckdb.go
+++ b/cmd/agentsview/duckdb.go
@@ -305,8 +305,11 @@ func runDuckDBServe(appCfg config.Config, basePath string) {
 		schemaErr = duckdbsync.CheckSchemaCompatViaQuack(ctx, store.DB())
 	}
 	if schemaErr != nil {
-		fatal("duckdb serve: schema incompatible: %v\n"+
-			"Run 'agentsview duckdb push --full' to repopulate the mirror.", schemaErr)
+		if duckCfg.URL == "" {
+			fatal("duckdb serve: schema incompatible: %v\n"+
+				"Run 'agentsview duckdb push --full' to repopulate the mirror.", schemaErr)
+		}
+		fatal("duckdb serve: schema incompatible: %v", schemaErr)
 	}
 
 	rtOpts := serveRuntimeOptions{

--- a/internal/duckdb/schema.go
+++ b/internal/duckdb/schema.go
@@ -669,7 +669,7 @@ func ensureSchema(ctx context.Context, db *sql.DB, opts schemaOptions) error {
 		}
 	}
 	if !opts.createIndexes {
-		if err := checkSchemaShapeCompat(ctx, db); err != nil {
+		if err := checkSchemaShapeCompat(ctx, db, remoteSchema); err != nil {
 			return err
 		}
 		return checkSchemaRepairsViaQuack(ctx, db)
@@ -1113,7 +1113,7 @@ func columnDefaultLiteral(def string) (string, bool) {
 // CheckSchemaCompat verifies that the DuckDB mirror has the required
 // read/push tables and columns. It does not mutate the database.
 func CheckSchemaCompat(ctx context.Context, db *sql.DB) error {
-	if err := checkSchemaShapeCompat(ctx, db); err != nil {
+	if err := checkSchemaShapeCompat(ctx, db, localSchema); err != nil {
 		return err
 	}
 	pendingRepairs, err := pendingSchemaRepairs(ctx, db)
@@ -1124,13 +1124,26 @@ func CheckSchemaCompat(ctx context.Context, db *sql.DB) error {
 }
 
 func CheckSchemaCompatViaQuack(ctx context.Context, db *sql.DB) error {
-	if err := checkSchemaShapeCompat(ctx, db); err != nil {
+	if err := checkSchemaShapeCompat(ctx, db, remoteSchema); err != nil {
 		return err
 	}
 	return checkSchemaRepairsViaQuack(ctx, db)
 }
 
-func checkSchemaShapeCompat(ctx context.Context, db *sql.DB) error {
+// schemaLocation says whether a compat failure is against the local mirror
+// file (which `agentsview duckdb push` migrates in place) or a remote Quack
+// server (which only migrates its own schema at startup, so the operator has
+// to upgrade the server binary).
+type schemaLocation bool
+
+const (
+	localSchema  schemaLocation = false
+	remoteSchema schemaLocation = true
+)
+
+func checkSchemaShapeCompat(
+	ctx context.Context, db *sql.DB, location schemaLocation,
+) error {
 	existing, err := loadColumns(ctx, db)
 	if err != nil {
 		return err
@@ -1150,6 +1163,14 @@ func checkSchemaShapeCompat(ctx context.Context, db *sql.DB) error {
 	}
 	if len(missing) > 0 {
 		sort.Strings(missing)
+		if location == remoteSchema {
+			return fmt.Errorf(
+				"duckdb schema incompatible; the DuckDB server is on an "+
+					"older AgentsView build; upgrade and restart the DuckDB "+
+					"server so it migrates its schema at startup; missing: %s",
+				strings.Join(missing, ", "),
+			)
+		}
 		return fmt.Errorf(
 			"duckdb schema incompatible; run agentsview duckdb push to migrate; missing: %s",
 			strings.Join(missing, ", "),
@@ -1178,6 +1199,14 @@ func checkSchemaShapeCompat(ctx context.Context, db *sql.DB) error {
 		)
 	}
 	if got < SchemaVersion {
+		if location == remoteSchema {
+			return fmt.Errorf(
+				"duckdb schema incompatible; server schema version %d is "+
+					"older than required %d; upgrade and restart the DuckDB "+
+					"server so it migrates its schema at startup",
+				got, SchemaVersion,
+			)
+		}
 		return fmt.Errorf(
 			"duckdb schema incompatible; version %d is older than required %d",
 			got, SchemaVersion,

--- a/internal/duckdb/schema.go
+++ b/internal/duckdb/schema.go
@@ -1120,7 +1120,7 @@ func CheckSchemaCompat(ctx context.Context, db *sql.DB) error {
 	if err != nil {
 		return err
 	}
-	return schemaRepairError(pendingRepairs)
+	return schemaRepairError(pendingRepairs, localSchema)
 }
 
 func CheckSchemaCompatViaQuack(ctx context.Context, db *sql.DB) error {
@@ -1183,6 +1183,14 @@ func checkSchemaShapeCompat(
 		schemaVersionMetadataKey,
 	).Scan(&version)
 	if errors.Is(err, sql.ErrNoRows) {
+		if location == remoteSchema {
+			return fmt.Errorf(
+				"duckdb schema incompatible; missing %s in sync_metadata; "+
+					"upgrade and restart the DuckDB server so it migrates "+
+					"its schema at startup",
+				schemaVersionMetadataKey,
+			)
+		}
 		return fmt.Errorf(
 			"duckdb schema incompatible; missing %s in sync_metadata",
 			schemaVersionMetadataKey,
@@ -1228,7 +1236,7 @@ func checkSchemaRepairsViaQuack(ctx context.Context, db *sql.DB) error {
 	if err != nil {
 		return err
 	}
-	return schemaRepairError(pendingRepairs)
+	return schemaRepairError(pendingRepairs, remoteSchema)
 }
 
 func pendingSchemaRepairs(ctx context.Context, db *sql.DB) ([]string, error) {
@@ -1257,11 +1265,21 @@ func collectSchemaRepairIssues(rows *sql.Rows) ([]string, error) {
 	return pendingRepairs, nil
 }
 
-func schemaRepairError(pendingRepairs []string) error {
+func schemaRepairError(
+	pendingRepairs []string, location schemaLocation,
+) error {
 	if len(pendingRepairs) == 0 {
 		return nil
 	}
 	sort.Strings(pendingRepairs)
+	if location == remoteSchema {
+		return fmt.Errorf(
+			"duckdb schema incompatible; the DuckDB server has pending "+
+				"schema repairs; upgrade and restart the DuckDB server so "+
+				"it migrates its schema at startup; pending repairs: %s",
+			strings.Join(pendingRepairs, ", "),
+		)
+	}
 	return fmt.Errorf(
 		"duckdb schema incompatible; run full DuckDB schema migration on the base database; pending repairs: %s",
 		strings.Join(pendingRepairs, ", "),

--- a/internal/duckdb/schema_test.go
+++ b/internal/duckdb/schema_test.go
@@ -378,6 +378,75 @@ func TestCheckSchemaCompatPassesAfterEnsureSchema(t *testing.T) {
 	require.NoError(t, CheckSchemaCompat(ctx, db), "CheckSchemaCompat")
 }
 
+func TestCheckSchemaCompatViaQuackReportsServerBehindOnMissingColumns(
+	t *testing.T,
+) {
+	ctx := context.Background()
+	db := openTestDuckDB(t)
+	_, err := db.ExecContext(ctx,
+		`CREATE TABLE sessions (
+			id TEXT PRIMARY KEY,
+			machine TEXT NOT NULL,
+			project TEXT NOT NULL,
+			agent TEXT NOT NULL
+		)`,
+	)
+	require.NoError(t, err, "simulate older server schema")
+
+	err = CheckSchemaCompatViaQuack(ctx, db)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sessions.entrypoint")
+	assert.Contains(t, err.Error(), "older AgentsView build",
+		"remote incompat must point at the server build")
+	assert.Contains(t, err.Error(), "upgrade and restart the DuckDB server",
+		"remote incompat must tell the operator the fix")
+	assert.NotContains(t, err.Error(),
+		"run agentsview duckdb push to migrate",
+		"push cannot migrate a remote server schema")
+}
+
+func TestCheckSchemaCompatKeepsLocalMigrationHintOnMissingColumns(
+	t *testing.T,
+) {
+	ctx := context.Background()
+	db := openTestDuckDB(t)
+	_, err := db.ExecContext(ctx,
+		`CREATE TABLE sessions (
+			id TEXT PRIMARY KEY,
+			machine TEXT NOT NULL,
+			project TEXT NOT NULL,
+			agent TEXT NOT NULL
+		)`,
+	)
+	require.NoError(t, err, "simulate stale local mirror")
+
+	err = CheckSchemaCompat(ctx, db)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sessions.entrypoint")
+	assert.Contains(t, err.Error(), "run agentsview duckdb push to migrate",
+		"local mirrors migrate through push")
+	assert.NotContains(t, err.Error(), "older AgentsView build")
+}
+
+func TestCheckSchemaCompatViaQuackReportsServerBehindOnOldVersion(
+	t *testing.T,
+) {
+	ctx := context.Background()
+	db := openTestDuckDB(t)
+	require.NoError(t, EnsureSchema(ctx, db), "EnsureSchema")
+	_, err := db.ExecContext(ctx,
+		`UPDATE sync_metadata SET value = '1' WHERE key = ?`,
+		schemaVersionMetadataKey,
+	)
+	require.NoError(t, err, "simulate older server schema version")
+
+	err = CheckSchemaCompatViaQuack(ctx, db)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "older than required")
+	assert.Contains(t, err.Error(), "upgrade and restart the DuckDB server",
+		"remote version skew must tell the operator the fix")
+}
+
 // TestEnsureSchemaCreatesToolCallsFilePathIndex verifies the DuckDB mirror
 // builds idx_tool_calls_file_path, the parity counterpart to SQLite's
 // Recent Edits index. DuckDB has no partial indexes, so it omits the

--- a/internal/duckdb/schema_test.go
+++ b/internal/duckdb/schema_test.go
@@ -447,6 +447,43 @@ func TestCheckSchemaCompatViaQuackReportsServerBehindOnOldVersion(
 		"remote version skew must tell the operator the fix")
 }
 
+func TestCheckSchemaCompatViaQuackReportsServerBehindOnMissingVersionRow(
+	t *testing.T,
+) {
+	ctx := context.Background()
+	db := openTestDuckDB(t)
+	require.NoError(t, EnsureSchema(ctx, db), "EnsureSchema")
+	_, err := db.ExecContext(ctx,
+		`DELETE FROM sync_metadata WHERE key = ?`,
+		schemaVersionMetadataKey,
+	)
+	require.NoError(t, err, "simulate server without a schema version row")
+
+	err = CheckSchemaCompatViaQuack(ctx, db)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), schemaVersionMetadataKey)
+	assert.Contains(t, err.Error(), "upgrade and restart the DuckDB server",
+		"remote missing version row must tell the operator the fix")
+}
+
+func TestSchemaRepairErrorPointsRemoteRepairsAtServer(t *testing.T) {
+	require.NoError(t, schemaRepairError(nil, remoteSchema))
+
+	err := schemaRepairError([]string{"messages.id primary key"}, remoteSchema)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "messages.id primary key")
+	assert.Contains(t, err.Error(), "upgrade and restart the DuckDB server",
+		"remote pending repairs must tell the operator the fix")
+	assert.NotContains(t, err.Error(),
+		"run full DuckDB schema migration on the base database")
+
+	err = schemaRepairError([]string{"messages.id primary key"}, localSchema)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(),
+		"run full DuckDB schema migration on the base database",
+		"local pending repairs keep the base-database hint")
+}
+
 // TestEnsureSchemaCreatesToolCallsFilePathIndex verifies the DuckDB mirror
 // builds idx_tool_calls_file_path, the parity counterpart to SQLite's
 // Recent Edits index. DuckDB has no partial indexes, so it omits the


### PR DESCRIPTION
When a Quack client finds the remote schema behind, every error path told the operator to fix it locally: "run `agentsview duckdb push` to migrate" for missing columns, "run full DuckDB schema migration on the base database" for pending repairs, and `duckdb serve` appended "run `duckdb push --full` to repopulate the mirror". None of those can work against a remote server — `ensureSchema` deliberately skips `ALTER TABLE` for Quack connections, and the server migrates its own schema at startup — so the hint sent the operator in a circle. This came up in practice as a follow-on to #1161: once the named-type rendering was fixed, the next failure a stale server produces is exactly this message.

This threads a `schemaLocation` through `checkSchemaShapeCompat` and `schemaRepairError` so every remote incompatibility path — missing columns, missing `agentsview_schema_version` row, older schema version, and pending repairs — says the DuckDB server is on an older AgentsView build and needs an upgrade and restart. Local mirror failures keep their existing hints, which are correct there, and tests pin both variants so the messages can't silently converge again. The read-serve startup fatal drops its repopulate suffix for remote URLs for the same reason.

Reviewers should look at the `schemaLocation` type in `internal/duckdb/schema.go`: it is a named bool rather than a full enum, chosen to keep the plumbing minimal for a two-way distinction that only affects error text.