### PR TITLE
feat(sync): add machine-labeled session sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,29 @@ March 2026), which shares that same database. *Kilo (legacy)* is the legacy
 RooCode-derived VS Code extension that wrote per-task JSON under
 `kilocode.kilo-code/tasks/`.
 
+## Filesystem Session Sync
+
+One primary AgentsView instance can ingest native agent session directories
+copied or mounted from other machines without PostgreSQL:
+
+```toml
+[[session_sources]]
+agent = "copilot"
+dir = "/srv/session-archive/buildbox/copilot"
+machine = "buildbox"
+```
+
+Structured sources are additive to existing `copilot_dirs`,
+`claude_project_dirs`, and other per-agent settings. They label sessions by
+source machine without namespacing native session IDs. Transport source session
+files only -- never copy `sessions.db` or its WAL files. Machine labels are
+captured at first ingestion; ordinary sync and `agentsview sync --full` preserve
+the stored label. Changing attribution for existing sessions is not currently
+supported.
+
+See the [Filesystem Session Sync guide](https://agentsview.io/filesystem-sync/)
+for Git, rsync, shared-mount, freshness, and operational guidance.
+
 ## PostgreSQL Sync
 
 Push session data to a shared PostgreSQL instance for team dashboards:
@@ -633,6 +656,7 @@ Full docs at **[agentsview.io](https://agentsview.io)**:
 [Usage Guide](https://agentsview.io/usage/) --
 [CLI Reference](https://agentsview.io/commands/) --
 [Configuration](https://agentsview.io/configuration/) --
+[Filesystem Sync](https://agentsview.io/filesystem-sync/) --
 [Architecture](https://agentsview.io/architecture/)
 
 ______________________________________________________________________

--- a/cmd/agentsview/archive_query_backend.go
+++ b/cmd/agentsview/archive_query_backend.go
@@ -250,6 +250,7 @@ func (b localArchiveQueryBackend) SessionUsage(
 	if known && !b.skipFreshData {
 		engine := sync.NewEngine(b.database, sync.EngineConfig{
 			AgentDirs:               b.cfg.AgentDirs,
+			SourceMachines:          b.cfg.SourceMachines,
 			IncludeCwdPrefixes:      b.cfg.SyncIncludeCwdPrefixes,
 			Machine:                 b.cfg.LocalMachineName,
 			BlockedResultCategories: b.cfg.ResultContentBlockedCategories,

--- a/cmd/agentsview/archive_write_backend.go
+++ b/cmd/agentsview/archive_write_backend.go
@@ -936,6 +936,7 @@ func (b *localArchiveWriteBackend) DuckDBPushWatch(
 
 	engine := syncpkg.NewEngine(b.database, syncpkg.EngineConfig{
 		AgentDirs:               b.appCfg.AgentDirs,
+		SourceMachines:          b.appCfg.SourceMachines,
 		IncludeCwdPrefixes:      b.appCfg.SyncIncludeCwdPrefixes,
 		Machine:                 b.appCfg.LocalMachineName,
 		BlockedResultCategories: b.appCfg.ResultContentBlockedCategories,

--- a/cmd/agentsview/archive_write_backend.go
+++ b/cmd/agentsview/archive_write_backend.go
@@ -1054,6 +1054,7 @@ func (b *localArchiveWriteBackend) PGPushWatch(
 
 	engine := syncpkg.NewEngine(b.database, syncpkg.EngineConfig{
 		AgentDirs:               b.appCfg.AgentDirs,
+		SourceMachines:          b.appCfg.SourceMachines,
 		IncludeCwdPrefixes:      b.appCfg.SyncIncludeCwdPrefixes,
 		Machine:                 b.appCfg.LocalMachineName,
 		BlockedResultCategories: b.appCfg.ResultContentBlockedCategories,

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -296,6 +296,7 @@ func runServe(cfg config.Config, opts serveOptions) {
 		var onStartupReconciled func(sync.SyncStats, error)
 		engine = sync.NewEngine(database, sync.EngineConfig{
 			AgentDirs:               cfg.AgentDirs,
+			SourceMachines:          cfg.SourceMachines,
 			IncludeCwdPrefixes:      cfg.SyncIncludeCwdPrefixes,
 			Machine:                 cfg.LocalMachineName,
 			BlockedResultCategories: cfg.ResultContentBlockedCategories,

--- a/cmd/agentsview/parse_diff.go
+++ b/cmd/agentsview/parse_diff.go
@@ -127,6 +127,7 @@ func doParseDiff(cfg ParseDiffConfig) (failed bool) {
 
 	engine := sync.NewDiffEngine(database, sync.EngineConfig{
 		AgentDirs:               appCfg.AgentDirs,
+		SourceMachines:          appCfg.SourceMachines,
 		IncludeCwdPrefixes:      appCfg.SyncIncludeCwdPrefixes,
 		Machine:                 appCfg.LocalMachineName,
 		BlockedResultCategories: appCfg.ResultContentBlockedCategories,

--- a/cmd/agentsview/session_sync.go
+++ b/cmd/agentsview/session_sync.go
@@ -74,6 +74,7 @@ func syncService(
 	}
 	engine := sync.NewEngine(d, sync.EngineConfig{
 		AgentDirs:          cfg.AgentDirs,
+		SourceMachines:     cfg.SourceMachines,
 		IncludeCwdPrefixes: cfg.SyncIncludeCwdPrefixes,
 		Machine:            cfg.LocalMachineName,
 	})

--- a/cmd/agentsview/sync.go
+++ b/cmd/agentsview/sync.go
@@ -933,6 +933,7 @@ func coordinateLocalSync(
 
 	engine := sync.NewEngine(database, sync.EngineConfig{
 		AgentDirs:               appCfg.AgentDirs,
+		SourceMachines:          appCfg.SourceMachines,
 		IncludeCwdPrefixes:      appCfg.SyncIncludeCwdPrefixes,
 		Machine:                 appCfg.LocalMachineName,
 		BlockedResultCategories: appCfg.ResultContentBlockedCategories,

--- a/cmd/agentsview/sync_worker.go
+++ b/cmd/agentsview/sync_worker.go
@@ -360,6 +360,7 @@ func openWorkerWriteDB(cfg config.Config) (*db.DB, *writeOwnerLock, error) {
 func workerEngineConfig(cfg config.Config) sync.EngineConfig {
 	return sync.EngineConfig{
 		AgentDirs:               cfg.AgentDirs,
+		SourceMachines:          cfg.SourceMachines,
 		IncludeCwdPrefixes:      cfg.SyncIncludeCwdPrefixes,
 		Machine:                 cfg.LocalMachineName,
 		BlockedResultCategories: cfg.ResultContentBlockedCategories,

--- a/cmd/agentsview/sync_worker_test.go
+++ b/cmd/agentsview/sync_worker_test.go
@@ -99,6 +99,28 @@ func TestSyncWorkerStartupModeSyncsAndEmitsTerminalResult(t *testing.T) {
 		"public SyncStats fields must survive the NDJSON protocol")
 }
 
+func TestSyncWorkerStartupUsesConfiguredSourceMachine(t *testing.T) {
+	cfg := testConfigWithClaudeFixture(t)
+	claudeRoot := cfg.AgentDirs[parser.AgentClaude][0]
+	cfg.SourceMachines = map[parser.AgentType]map[string]string{
+		parser.AgentClaude: {claudeRoot: "archivebox"},
+	}
+
+	var out bytes.Buffer
+	require.NoError(t, runSyncWorker(cfg, "startup", &out))
+	assert.Equal(t, "ok", decodeSingleResult(t, &out).Status)
+
+	database, err := db.OpenReadOnly(cfg.DBPath)
+	require.NoError(t, err)
+	defer database.Close()
+	page, err := database.ListSessions(context.Background(), db.SessionFilter{})
+	require.NoError(t, err)
+	require.Len(t, page.Sessions, 3)
+	for _, sess := range page.Sessions {
+		assert.Equal(t, "archivebox", sess.Machine)
+	}
+}
+
 func TestSyncWorkerReportsAbortAsFailure(t *testing.T) {
 	cfg := testConfigWithClaudeFixture(t)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/agentsview/usage.go
+++ b/cmd/agentsview/usage.go
@@ -312,6 +312,7 @@ func ensureFreshData(
 	if database.NeedsResync() {
 		engine := sync.NewEngine(database, sync.EngineConfig{
 			AgentDirs:          appCfg.AgentDirs,
+			SourceMachines:     appCfg.SourceMachines,
 			IncludeCwdPrefixes: appCfg.SyncIncludeCwdPrefixes,
 			Machine:            appCfg.LocalMachineName,
 		})
@@ -336,6 +337,7 @@ func ensureFreshData(
 
 	engine := sync.NewEngine(database, sync.EngineConfig{
 		AgentDirs:          appCfg.AgentDirs,
+		SourceMachines:     appCfg.SourceMachines,
 		IncludeCwdPrefixes: appCfg.SyncIncludeCwdPrefixes,
 		Machine:            appCfg.LocalMachineName,
 	})

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -77,6 +77,7 @@ daemon_idle_timeout = "20m"
 | `[vector]`                          | Opt-in semantic-search index; model settings live in `[vector.embeddings]`, named endpoints in `[vector.embeddings.servers.<name>]`, embedding schedule in `[vector.embed]` — see [Semantic Search](/semantic-search/#enabling-vector) for every key |
 | `[recall.extract]`                  | Opt-in model-backed recall extraction; named endpoints in `[recall.extract.servers.<name>]`, prompt selection in `[recall.extract.prompts]`, request overrides in `[recall.extract.request]` — see [Recall](/recall/#automatic-extraction)           |
 | `[[remote_hosts]]`                  | Remote machines synced by a bare `agentsview sync` — see [CLI Reference](/commands/#agentsview-sync)                                                                                                                                                 |
+| `[[session_sources]]`               | Additional filesystem session roots with per-root machine labels — see [Filesystem Session Sync](/filesystem-sync/)                                                                                                                                  |
 | `[automated]`                       | Custom automated-session patterns — see [Automated Session Detection](#automated-session-detection)                                                                                                                                                  |
 | `[custom_model_pricing]`            | Per-model price overrides for usage reports — see [Custom Model Pricing](/token-usage/#custom-model-pricing)                                                                                                                                         |
 
@@ -654,6 +655,32 @@ these take precedence over the single-directory environment variable and the
 default path.
 
 All listed directories are discovered, watched, and synced independently.
+
+### Machine-Labeled Filesystem Sources
+
+Use `[[session_sources]]` when a root was produced on another machine and
+transported to this AgentsView host:
+
+```toml
+[[session_sources]]
+agent = "copilot"
+dir = "/srv/session-archive/buildbox/copilot"
+machine = "buildbox"
+```
+
+The fields are `agent`, `dir`, and optional `machine`. Entries are additive to
+the per-agent arrays, defaults, and environment variables above. Exact duplicate
+roots are deduplicated; a structured entry supplies the machine label when it
+duplicates a shorthand root. An omitted `machine` uses the local hostname.
+
+Machine attribution is captured when each session is first ingested. Changing
+an entry's `machine` value affects newly discovered sessions but does not
+relabel existing sessions during ordinary syncs or `agentsview sync --full`.
+Changing attribution for existing sessions is not currently supported.
+
+See [Filesystem Session Sync](/filesystem-sync/) for multi-machine examples,
+transport safety, ID deduplication, watcher behavior, and the comparison with
+PostgreSQL.
 
 ### S3-Compatible Session Sources
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -669,7 +669,7 @@ machine = "buildbox"
 ```
 
 The fields are `agent`, `dir`, and optional `machine`. Entries are additive to
-the per-agent arrays, defaults, and environment variables above. Exact duplicate
+the per-agent arrays, defaults, and environment variables above. Equivalent
 roots are deduplicated; a structured entry supplies the machine label when it
 duplicates a shorthand root. An omitted `machine` uses the local hostname.
 

--- a/docs/filesystem-sync.md
+++ b/docs/filesystem-sync.md
@@ -1,0 +1,169 @@
+______________________________________________________________________
+
+## title: Filesystem Session Sync description: View sessions from multiple machines by transporting native agent session directories to one AgentsView instance
+
+AgentsView can label filesystem session roots with the machine that produced
+them. This supports a simple multi-machine topology without PostgreSQL:
+
+1. Each source machine writes its normal agent session files.
+1. Git, rsync, a file-copy job, or a shared filesystem transports those native
+   layouts out of band.
+1. One primary AgentsView instance scans the received roots into its local
+   SQLite archive.
+
+This is a **primary-viewer topology**. Use [PostgreSQL sync](/pg-sync/) instead
+when several viewers need a shared live database or a read-only database-backed
+endpoint.
+
+## Configure Session Sources
+
+Add one `[[session_sources]]` table per received agent root:
+
+```toml
+[[session_sources]]
+agent = "copilot"
+dir = "/srv/session-archive/buildbox/copilot"
+machine = "buildbox"
+
+[[session_sources]]
+agent = "claude"
+dir = "/srv/session-archive/buildbox/claude/projects"
+machine = "buildbox"
+
+[[session_sources]]
+agent = "codex"
+dir = "/srv/session-archive/laptop/codex/sessions"
+machine = "laptop"
+```
+
+`agent` must be a supported AgentsView parser name. `dir` must be a filesystem
+root in that agent's native layout. `machine` uses the same machine label shown
+in session filters and configured by `[pg].machine_name`. If `machine` is
+omitted, AgentsView uses the primary viewer's hostname.
+
+Existing per-agent arrays and environment variables remain supported. Structured
+sources are additive:
+
+```toml
+copilot_dirs = ["/home/viewer/.copilot"]
+
+[[session_sources]]
+agent = "copilot"
+dir = "/srv/session-archive/buildbox/copilot"
+machine = "buildbox"
+```
+
+AgentsView normalizes roots for duplicate comparison. Legacy per-agent settings
+and structured entries retain their original path spelling. When a structured
+source names the same root as a per-agent array, default, or environment
+variable, the structured entry supplies the machine label.
+
+`session_sources` accepts filesystem roots only. Keep using the existing
+Claude/Codex per-agent arrays for `s3://` roots; S3 ingestion has established
+machine-derived ID-prefix behavior that differs from filesystem labeling. Native
+SQLite-backed agent stores are supported when `dir` points at their filesystem
+root.
+
+## Transport Rules
+
+Sync the **source agent's session files and native directory layout**. Never
+copy AgentsView's `sessions.db`, `sessions.db-wal`, `sessions.db-shm`, or
+`vectors.db`. Those files belong to the primary viewer and copying a live SQLite
+database or WAL can corrupt or fork the archive.
+
+For every destination source tree:
+
+- Have one writer. Multiple transport jobs must not update the same tree.
+- Transfer into a staging path, then rename or switch the completed tree into
+  place when possible.
+- Preserve filenames, relative paths, and companion metadata files.
+- Avoid exposing partially copied files. AgentsView retries changed files, but
+  atomic publication prevents transient parse errors and incomplete sessions.
+- Treat the primary copy as read-only input to AgentsView.
+
+## Transport Examples
+
+The transport is independent of AgentsView. These examples show the directory
+shape; adapt scheduling and authentication to your environment.
+
+### Git
+
+Commit native session trees on the source machine, pull into a staging checkout
+on the primary machine, then atomically replace the published checkout:
+
+```text
+session-archive/
+├── buildbox/
+│   ├── claude/projects/...
+│   └── copilot/session-state/...
+└── laptop/
+    └── codex/sessions/...
+```
+
+Git is most suitable for modest archives where commit history is useful. Avoid
+running AgentsView against a checkout while `git pull` is rewriting it; publish
+a completed checkout or worktree instead. Session files can contain prompts,
+tool output, and source excerpts, so use access controls appropriate for
+sensitive data.
+
+### rsync or File Copy
+
+Copy each machine into its own destination tree. `--delay-updates` reduces the
+window in which completed files appear partially updated:
+
+```bash
+rsync -a --delete --delay-updates \
+  source-host:/home/user/.copilot/ \
+  /srv/session-archive/buildbox/copilot/
+```
+
+For transports without delayed updates, copy to a sibling staging directory and
+rename it into place. Do not let two sources use the same destination tree.
+
+### NFS or Shared Mount
+
+Mount each source machine's exported session directory on the primary viewer,
+preferably read-only:
+
+```toml
+[[session_sources]]
+agent = "claude"
+dir = "/mnt/sessions/buildbox/claude/projects"
+machine = "buildbox"
+
+[[session_sources]]
+agent = "copilot"
+dir = "/mnt/sessions/laptop/copilot"
+machine = "laptop"
+```
+
+Shared mounts remove the copy step, but freshness and watcher behavior depend on
+the filesystem. Some network filesystems do not deliver local filesystem events
+reliably; the periodic sync remains the backstop.
+
+## Identity, Filtering, and Freshness
+
+- The machine label is stored per discovered source root. Filter sessions by
+  `machine` in the session browser, API, and analytics views.
+- A session keeps the machine label it received when it was first ingested.
+  Editing a source's `machine` value affects newly discovered sessions but does
+  not retroactively relabel existing ones, even when their source files later
+  change. `agentsview sync --full` also preserves the stored label. Changing
+  attribution for existing sessions is not currently supported.
+- Filesystem machine labels do **not** namespace session IDs. If the same native
+  session is copied into two configured roots, AgentsView continues to
+  deduplicate it by the agent's native session ID.
+- A newly transported or changed file is normally detected by the filesystem
+  watcher. AgentsView also performs a full periodic sync every 15 minutes.
+- Roots that cannot be watched fall back to polling, as described under
+  [Large Watch Trees](/configuration/#large-watch-trees).
+- A machine label changes attribution, not source identity or conflict
+  resolution. Do not intentionally place different sessions with the same native
+  ID in separate roots.
+- Deleting a transported source file does not automatically erase the archived
+  session. The local SQLite database is a persistent archive; use pruning tools
+  when removal is intended.
+
+Filesystem sync is intentionally simple: one primary AgentsView owns the archive
+and UI. PostgreSQL remains the better fit for independently running AgentsView
+instances that must contribute to or read from a shared live store.

--- a/docs/filesystem-sync.md
+++ b/docs/filesystem-sync.md
@@ -56,9 +56,10 @@ machine = "buildbox"
 
 AgentsView compares roots as absolute, cleaned paths and ignores case on
 Windows. Legacy per-agent settings and structured entries retain their original
-path spelling. When a structured source names the same root as a per-agent
-array, default, or environment variable, the structured entry supplies the
-machine label.
+path spelling, except that a leading `~/` is expanded to the current home
+directory before scanning. When a structured source names the same root as a
+per-agent array, default, or environment variable, the structured entry
+supplies the machine label.
 
 `session_sources` accepts filesystem roots only. Keep using the existing
 Claude/Codex per-agent arrays for `s3://` roots; S3 ingestion has established

--- a/docs/filesystem-sync.md
+++ b/docs/filesystem-sync.md
@@ -54,10 +54,11 @@ dir = "/srv/session-archive/buildbox/copilot"
 machine = "buildbox"
 ```
 
-AgentsView normalizes roots for duplicate comparison. Legacy per-agent settings
-and structured entries retain their original path spelling. When a structured
-source names the same root as a per-agent array, default, or environment
-variable, the structured entry supplies the machine label.
+AgentsView compares roots as absolute, cleaned paths and ignores case on
+Windows. Legacy per-agent settings and structured entries retain their original
+path spelling. When a structured source names the same root as a per-agent
+array, default, or environment variable, the structured entry supplies the
+machine label.
 
 `session_sources` accepts filesystem roots only. Keep using the existing
 Claude/Codex per-agent arrays for `s3://` roots; S3 ingestion has established

--- a/docs/filesystem-sync.md
+++ b/docs/filesystem-sync.md
@@ -1,6 +1,7 @@
-______________________________________________________________________
-
-## title: Filesystem Session Sync description: View sessions from multiple machines by transporting native agent session directories to one AgentsView instance
+---
+title: Filesystem Session Sync
+description: View sessions from multiple machines by transporting native agent session directories to one AgentsView instance
+---
 
 AgentsView can label filesystem session roots with the machine that produced
 them. This supports a simple multi-machine topology without PostgreSQL:

--- a/docs/index.md
+++ b/docs/index.md
@@ -185,8 +185,9 @@ See [Activity](/activity/) for the full reference.
 AgentsView reads the session files that your
 [AI coding agents](/configuration/#session-discovery) leave on your machine and
 gives you a local-first desktop and web app to work with them. By default
-everything stays on your machine. Optionally, [PostgreSQL sync](/pg-sync/) can
-push session data to a shared database for team or multi-machine setups.
+everything stays on your machine. For multi-machine use, a primary viewer can
+read [out-of-band filesystem copies](/filesystem-sync/), or
+[PostgreSQL sync](/pg-sync/) can push session data to a shared database.
 
 <div class="grid cards" markdown>
 

--- a/docs/superpowers/plans/2026-07-31-immutable-session-source-attribution.md
+++ b/docs/superpowers/plans/2026-07-31-immutable-session-source-attribution.md
@@ -1,0 +1,334 @@
+# Immutable Session Source Attribution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (- [ ]) syntax for tracking.
+
+**Goal:** Finish PR #1170 as a filesystem-only source-label feature whose
+machine attribution is immutable after first ingestion.
+
+**Architecture:** Existing archive rows are authoritative for machine
+attribution, including during refreshes and full database rebuilds. Source
+configuration supplies a label only when a session is new. Comparison-only path
+cleanup is separate from stored path spelling, and the already-merged DuckDB
+implementation remains owned by main.
+
+**Tech Stack:** Go, SQLite/FTS5, TOML configuration, filesystem-backed parser
+providers, testify, Git, and Markdown.
+
+## Global Constraints
+
+- Preserve behavior and query-shape parity between SQLite and PostgreSQL where
+  both backends participate; this change does not add PostgreSQL behavior.
+- Never delete, recreate, or destructively migrate the persistent SQLite
+  archive.
+- Keep watcher and periodic sync work bounded by the changed batch.
+- Keep session_sources filesystem-only and additive to legacy source arrays.
+- Preserve native session-ID deduplication.
+- Use testify for all new or modified Go assertions.
+- Every behavior test must assert persisted or returned behavior and fail before
+  its production fix is applied.
+- Run go fmt ./... and go vet ./... after Go changes.
+- Do not push or change branches as part of this local implementation.
+
+______________________________________________________________________
+
+### Task 1: Synchronize main and remove duplicate DuckDB work
+
+**Files:**
+
+- Merge: current origin/main
+- Restore from origin/main: internal/duckdb/connect.go
+- Restore from origin/main: internal/duckdb/probe.go
+- Restore from origin/main: internal/duckdb/push.go
+- Restore from origin/main: internal/duckdb/rebuild.go
+- Restore from origin/main: internal/duckdb/schema.go
+- Restore from origin/main: internal/duckdb/sync.go
+- Restore from origin/main: internal/duckdb/sync_test.go
+
+**Interfaces:**
+
+- Consumes: merged PR #1302 on origin/main
+
+- Produces: a branch with no DuckDB diff relative to its updated base
+
+- [ ] **Step 1: Fetch and merge current main without changing branches**
+
+  ```
+    git fetch origin main
+    git merge --no-commit --no-ff origin/main
+  ```
+
+  Inspect every conflict before resolving it.
+
+- [ ] **Step 2: Resolve DuckDB files to origin/main**
+
+  Use the origin/main versions of all seven DuckDB files. Resolve other
+  conflicts by preserving current-main behavior plus the filesystem-source
+  feature.
+
+- [ ] **Step 3: Verify the DuckDB overlap is gone**
+
+  ```
+    git diff --exit-code origin/main -- internal/duckdb
+  ```
+
+  Expected: no output.
+
+- [ ] **Step 4: Commit the synchronization**
+
+  ```
+    git commit -m "merge: sync machine source branch with main"
+  ```
+
+______________________________________________________________________
+
+### Task 2: Protect immutable attribution with observable sync tests
+
+**Files:**
+
+- Modify: internal/sync/session_source_machine_test.go
+- Modify: internal/sync/provider_process_test.go
+- Modify: internal/db/source_path_hints_test.go
+- Modify: cmd/agentsview/sync_worker_test.go when full-resync coverage belongs
+  at the command boundary after the merge
+
+**Interfaces:**
+
+- Consumes: Engine.SyncAllSince, Engine.SyncPathsContext, provider-backed
+  writes, and the full-resync archive-copy path
+
+- Produces: regression coverage that reads persisted session rows and identity
+  state after configured labels change
+
+- [ ] **Step 1: Write or revise the active-session regression**
+
+  Create a session under a root labeled oldbox, sync it, change the configured
+  root label to newbox, modify the file, sync again, and assert the persisted
+  session still reports oldbox. The production mutation this catches is
+  assigning the currently configured label on an existing-row upsert.
+
+- [ ] **Step 2: Run the active-session test and verify RED**
+
+  ```
+    CGO_ENABLED=1 go test -tags fts5 ./internal/sync \
+      -run 'Test.*Machine.*Immutable' -count=1
+  ```
+
+  Expected: FAIL because an existing write path still adopts newbox.
+
+- [ ] **Step 3: Write or revise trash and full-resync regressions**
+
+  Trash a labeled session, change its configured root label, and run both an
+  ordinary source refresh and the command full-resync path. Assert the session,
+  trash timestamp, project-identity snapshot, and observation retain oldbox. The
+  production mutation this catches is any machine-only update during trash
+  handling or orphan copying.
+
+- [ ] **Step 4: Run the new cases and verify RED**
+
+  ```
+    CGO_ENABLED=1 go test -tags fts5 ./internal/sync ./cmd/agentsview \
+      -run 'Test.*(Trashed|FullResync).*Machine' -count=1
+  ```
+
+  Expected: at least one assertion sees newbox before production cleanup.
+
+- [ ] **Step 5: Confirm newly discovered sessions use the current label**
+
+  After changing the configured label, add a second session and assert its
+  stored machine is newbox while the first remains oldbox.
+
+______________________________________________________________________
+
+### Task 3: Remove continuous reattribution machinery
+
+**Files:**
+
+- Modify: internal/sync/engine.go
+- Modify: internal/db/sessions.go
+- Modify: internal/db/orphaned.go
+- Modify: internal/db/schema.sql
+- Modify: internal/db/source_path_hints_test.go
+- Modify: internal/sync/session_source_machine_test.go
+- Modify: internal/sync/provider_process_test.go
+
+**Interfaces:**
+
+- Removes: DB.UpdateTrashedSessionMachine
+
+- Removes: DB.UpdateTrashedSessionMachineByPath
+
+- Removes: DB.ListActiveSessionSourceOwnershipScopesAllMachinesPage
+
+- Removes: idx_local_source_baselines_source
+
+- Preserves: existing row machine values through upsert and archive copy
+
+- [ ] **Step 1: Remove machine-only trash updates and their call sites**
+
+  Delete both database methods and the engine calls that invoke them during
+  cached-skip, provider, batch, and full-resync paths. Do not replace them with
+  a different relabel mechanism.
+
+- [ ] **Step 2: Remove the all-machines baseline query and index**
+
+  Return watcher reconciliation to the machine-scoped ownership query. Remove
+  query-plan tests that exist only for the private implementation, retaining
+  behavior tests for move and delete tombstoning.
+
+- [ ] **Step 3: Make full-resync archive copy preserve stored attribution**
+
+  Remove snapshot and observation SQL whose only purpose is adopting a newly
+  configured label. Ensure copied sessions remain authoritative before parser
+  writes are considered.
+
+- [ ] **Step 4: Run focused tests and verify GREEN**
+
+  ```
+    CGO_ENABLED=1 go test -tags fts5 \
+      ./internal/db ./internal/sync ./cmd/agentsview \
+      -run 'Machine|SourceOwnership|FullResync|SessionSource' -count=1
+  ```
+
+  Expected: PASS, including active, trash, full-resync, move, and delete cases.
+
+______________________________________________________________________
+
+### Task 4: Preserve path spelling and clear lint
+
+**Files:**
+
+- Modify: internal/config/config.go
+- Modify: internal/config/config_test.go
+- Modify: internal/sync/session_source_machine_test.go
+
+**Interfaces:**
+
+- Consumes: normalizeSessionSourceDir and sessionSourceComparisonKey
+
+- Produces: stored trimmed path spelling plus cleaned comparison keys
+
+- [ ] **Step 1: Add a failing platform-neutral spelling test**
+
+  Pass a structured directory containing dot segments and assert
+  ResolveSessionSources retains the trimmed input string while deduplicating it
+  against an equivalent legacy root through the comparison key. The production
+  mutation this catches is returning filepath.Clean(value) from
+  normalizeSessionSourceDir.
+
+- [ ] **Step 2: Run the config test and verify RED**
+
+  ```
+    CGO_ENABLED=1 go test -tags fts5 ./internal/config \
+      -run 'Test.*SessionSource.*Spelling' -count=1
+  ```
+
+  Expected: FAIL because the stored structured source path is cleaned.
+
+- [ ] **Step 3: Return validated spelling from normalization**
+
+  Keep whitespace trimming and NUL/empty validation, but return value. Continue
+  calling filepath.Clean only from sessionSourceComparisonKey.
+
+- [ ] **Step 4: Replace repeated string concatenation in the sync test**
+
+  Use one strings.Builder with Grow in
+  TestMachineForPathUsesNormalizedRootSpecificity. This is test maintenance only
+  and needs no new behavior test.
+
+- [ ] **Step 5: Verify GREEN and lint**
+
+  ```
+    CGO_ENABLED=1 go test -tags fts5 ./internal/config ./internal/sync \
+      -run 'SessionSource|MachineForPath' -count=1
+    make lint
+  ```
+
+______________________________________________________________________
+
+### Task 5: Align documentation and pull-request copy
+
+**Files:**
+
+- Modify: README.md
+- Modify: docs/configuration.md
+- Modify: docs/filesystem-sync.md
+- Prepare: replacement body for PR #1170
+
+**Interfaces:**
+
+- Consumes: the immutable first-ingestion contract
+
+- Produces: user guidance with no retroactive-relabel or DuckDB claim
+
+- [ ] **Step 1: Rewrite user documentation**
+
+  State that configuration changes affect only newly discovered sessions and
+  that ordinary sync plus sync --full preserve stored labels. Describe
+  retroactive relabeling as unsupported; do not promise a command.
+
+- [ ] **Step 2: Draft the synchronized PR description**
+
+  Summarize structured filesystem sources, additive configuration, immutable
+  attribution, native-ID deduplication, and the S3 exclusion. Remove the DuckDB
+  section and retroactive-rebuild language.
+
+- [ ] **Step 3: Review prose for contradictions**
+
+  Read the README, both guides, and draft together. Confirm every description of
+  label changes and full sync states the same behavior.
+
+______________________________________________________________________
+
+### Task 6: Final verification and commit
+
+**Files:** all files changed by Tasks 1-5
+
+**Interfaces:**
+
+- Produces: a clean, committed worktree ready for the PR author's fork
+
+- [ ] **Step 1: Format and vet**
+
+  ```
+    go fmt ./...
+    go vet ./...
+  ```
+
+- [ ] **Step 2: Run the Go suites**
+
+  ```
+    make test-short
+    make test
+  ```
+
+- [ ] **Step 3: Run repository lint**
+
+  ```
+    make lint
+  ```
+
+- [ ] **Step 4: Inspect the final diff and private-data scrub**
+
+  ```
+    git diff --check
+    git diff --stat origin/main...HEAD
+    git diff origin/main...HEAD
+  ```
+
+  Confirm the changed lines contain no private paths, identities, or
+  infrastructure names.
+
+- [ ] **Step 5: Commit the completed cleanup**
+
+  ```
+    git add README.md docs cmd internal
+    git commit -m "fix(sync): keep source attribution immutable"
+  ```
+
+- [ ] **Step 6: Report the handoff**
+
+  Report commit IDs, tests run, remaining environmental limitations, and the
+  fact that no push or PR mutation was performed.

--- a/docs/superpowers/plans/2026-08-01-source-attribution-normalization.md
+++ b/docs/superpowers/plans/2026-08-01-source-attribution-normalization.md
@@ -1,0 +1,48 @@
+# Source Attribution Normalization Implementation Plan
+
+> Continue the accepted immutable-attribution design in
+> `docs/superpowers/specs/2026-07-31-immutable-session-source-attribution-design.md`.
+
+**Goal:** Resolve a session's immutable machine attribution once, before any
+project or ownership consumer runs, and keep warm DB-backed reconciliation
+set-based.
+
+## 1. Pin the regressions
+
+- Add a write-path test where a stored session under machine A is reparsed from
+  relabeled machine B while its checkout is unavailable. The durable project
+  identity must still be recovered under A.
+- Strengthen the relabel reconciliation test so an admitted A source paired
+  with a configured B candidate retains deletion proof under A and is later
+  tombstoned.
+- Add a warm DB-backed test showing that one discovery page performs one
+  attribution lookup regardless of the number of fresh sources, including a
+  shared source containing sessions from multiple machines.
+
+## 2. Normalize pending writes before consumers
+
+- Add a bounded SQLite query that loads stored session machines by stable,
+  prefixed session ID.
+- Normalize every pending write to its stored machine when one exists, or keep
+  its configured machine for first ingestion.
+- Run normalization before unavailable-project recovery, worktree mapping,
+  baseline admission, and persistence in both batch and single-session paths.
+- Remove the late `prepareSessionWrite` lookup and the `persistedMachine` side
+  channel.
+
+## 3. Make source attribution set-based
+
+- Add a bounded SQLite query returning every distinct active
+  `(machine, agent, file_path)` attribution for a page of discovered sources.
+- Replace the per-source `storedSourceMachine` lookup with one query per
+  discovery page, retaining all machines represented inside shared sources.
+- Make baseline replacement iterate the union of candidate and admitted
+  machines so a stored A admission cannot be dropped merely because the
+  configured candidate says B.
+
+## 4. Verify and deliver
+
+- Run the focused DB and sync tests, then `go fmt ./...`, `go vet ./...`, and
+  the repository's relevant broader checks.
+- Review the final diff, scrub public text for private data, and create one
+  focused follow-up commit. Do not push.

--- a/docs/superpowers/specs/2026-07-31-immutable-session-source-attribution-design.md
+++ b/docs/superpowers/specs/2026-07-31-immutable-session-source-attribution-design.md
@@ -1,0 +1,115 @@
+# Immutable Session Source Attribution Design
+
+## Summary
+
+Machine-labeled filesystem sources will assign a session's machine when that
+session is first ingested. Once persisted, the label is immutable: ordinary
+sync, watcher refresh, provider refresh, trash handling, and `sync --full`
+preserve the stored value. Editing a configured source label affects only
+sessions not already present in the archive.
+
+This cleanup also removes DuckDB work that has already landed independently,
+preserves user-entered path spelling on every platform, and updates the
+documentation to describe the narrower contract.
+
+## Goals
+
+- Keep `[[session_sources]]` as an additive filesystem-source configuration.
+- Assign configured machine labels to newly discovered sessions.
+- Preserve a stored machine label through every later write and archive rebuild.
+- Preserve trash, source-missing, curation, and project-identity behavior.
+- Keep periodic and watcher work bounded by the changed batch.
+- Preserve configured path spelling while using cleaned paths only for
+  comparison.
+- Remove the DuckDB overlap now provided by merged PR #1302.
+
+## Non-goals
+
+- Relabeling sessions already stored in the archive.
+- Adding a one-shot relabel command.
+- Supporting S3 roots through `session_sources`.
+- Changing native session-ID deduplication.
+- Changing PostgreSQL ownership or identity semantics.
+
+## Approaches Considered
+
+### Immutable attribution after ingestion
+
+This is the selected approach. Existing rows remain authoritative whenever a
+session is refreshed or copied through a full rebuild. It removes continuous
+reattribution state and makes configuration changes safe and predictable.
+
+### Continue targeted reattribution fixes
+
+This would repair each newly discovered writer, trash path, snapshot path, and
+reconciliation edge independently. The branch history shows that this expands
+the persistent-archive surface and repeatedly creates new consistency bugs, so
+it is rejected.
+
+### Add an explicit relabel migration now
+
+A one-shot command could eventually update sessions and dependent identity state
+transactionally. It is deferred because it needs its own invariants, design, and
+recovery tests; it is not required to ship labeled ingestion.
+
+## Storage and Sync Contract
+
+New sessions receive the machine resolved from their originating configured
+filesystem root. An upsert for an existing session must retain the database
+row's machine instead of adopting a newly configured label. Full resync copies
+existing archive rows and metadata into the replacement database and retains
+their stored machine labels, including trashed and source-missing sessions.
+
+Because relabeling is not part of sync, the engine no longer needs machine-only
+updates for trashed sessions, an all-machines baseline scan, or a second
+baseline index keyed without machine. Watch reconciliation continues to use the
+stored ownership baseline for the machine that originally admitted the session.
+
+## Configuration Contract
+
+`normalizeSessionSourceDir` validates and trims a structured source directory
+but does not rewrite its separators or spelling. A separate comparison key may
+use `filepath.Clean` to deduplicate equivalent roots on the current platform.
+Legacy arrays, environment-derived paths, and structured entries therefore
+retain the spelling supplied by the user while comparisons remain normalized.
+
+## DuckDB Boundary
+
+The branch drops every DuckDB change relative to current `main`. Merged PR #1302
+already preserves source-machine attribution, includes the fingerprint change,
+removes publisher-machine filtering where required, and bumps the disposable
+mirror schema. This PR does not duplicate or modify that behavior.
+
+## Documentation
+
+The README and filesystem/configuration guides will say that a label is fixed at
+first ingestion. `sync --full` preserves it and is not a relabel operation. The
+pull request description should cover only filesystem source configuration and
+immutable source attribution; its DuckDB and retroactive-relabel claims must be
+removed.
+
+## Testing
+
+Behavior tests will use real temporary archives and filesystem fixtures to show
+that:
+
+- changing a configured label does not change an existing active session;
+- changing a label does not change a trashed session;
+- `sync --full` retains the stored label while preserving archive state;
+- a newly discovered session receives the new configured label;
+- moving or deleting files still produces the expected watcher reconciliation;
+- structured Windows-style path spelling is retained while duplicate comparison
+  stays normalized;
+- the branch compiles without the removed reattribution methods and query.
+
+Focused config, database, sync, and command tests run first. The final gate is
+`go fmt ./...`, `go vet ./...`, the full Go test suite, and repository lint when
+practical.
+
+## Compatibility and Rollout
+
+No new database schema or data-version migration is required for immutable
+attribution. Existing archives keep their current labels. Users who change a
+source label see that label only on sessions discovered afterward. A future
+explicit relabel command can build on this stable contract without making
+configuration reloads destructive.

--- a/docs/superpowers/specs/2026-07-31-immutable-session-source-attribution-design.md
+++ b/docs/superpowers/specs/2026-07-31-immutable-session-source-attribution-design.md
@@ -69,9 +69,10 @@ stored ownership baseline for the machine that originally admitted the session.
 
 `normalizeSessionSourceDir` validates and trims a structured source directory
 but does not rewrite its separators or spelling. A separate comparison key may
-use `filepath.Clean` to deduplicate equivalent roots on the current platform.
-Legacy arrays, environment-derived paths, and structured entries therefore
-retain the spelling supplied by the user while comparisons remain normalized.
+use an absolute, cleaned path and case-fold it on Windows to deduplicate
+equivalent roots on the current platform. Legacy arrays, environment-derived
+paths, and structured entries therefore retain the spelling supplied by the
+user while comparisons remain normalized.
 
 ## DuckDB Boundary
 

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -34,6 +34,7 @@ nav = [
   {"Recall (Experimental)" = "recall.md"},
   {"Remote Access" = "remote-access.md"},
   {"Artifact Folder Sync" = "artifact-sync.md"},
+  {"Filesystem Session Sync" = "filesystem-sync.md"},
   {"PostgreSQL Sync" = "pg-sync.md"},
   {"DuckDB Mirror" = "duckdb.md"},
   {"Changelog" = "changelog.md"},

--- a/internal/artifact/sync.go
+++ b/internal/artifact/sync.go
@@ -149,6 +149,7 @@ func SyncWithRepository(
 	}
 	result.ReceivedArtifacts = exchanged.Received
 	result.PublishedArtifacts = exchanged.Published
+	result.Quarantined += exchanged.Quarantined
 
 	importMore, err := drainArtifactSyncImports(
 		ctx,

--- a/internal/artifact/sync_test.go
+++ b/internal/artifact/sync_test.go
@@ -368,6 +368,43 @@ func TestArtifactSyncQuarantinesInvalidCheckpointInFolderAndDocbank(
 	assert.ErrorIs(t, err, ErrArtifactNotFound)
 }
 
+func TestArtifactSyncCountsTransportQuarantine(t *testing.T) {
+	t.Parallel()
+
+	target := t.TempDir()
+	transport, err := OpenFolderTransport(target, FolderTransportOptions{})
+	require.NoError(t, err)
+	require.NoError(t, transport.Close())
+
+	origin := "peer-a1b2c3"
+	body := []byte(`{"v":2}`)
+	ref := testContentRef(t, origin, KindManifests, body, ".json")
+	wire, err := ToWireRef(ref)
+	require.NoError(t, err)
+	wireDirectory := filepath.Join(target, origin, string(KindManifests))
+	require.NoError(t, os.MkdirAll(wireDirectory, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(wireDirectory, wire.Name),
+		[]byte("not zstd"),
+		0o600,
+	))
+	appendFolderJournalTestEntry(t, target, Entry{
+		Ref: ref, Identity: identityForBytes(t, body),
+	})
+
+	repository, err := OpenRepository(t.Context(), t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, repository.Close()) })
+	result, err := SyncWithRepository(
+		t.Context(),
+		testDB(t),
+		repository,
+		SyncOptions{Target: target, Origin: "local-d4e5f6"},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Quarantined)
+}
+
 func TestCoordinatedQuarantineDropsStaleLocalAfterRemoteReplacement(
 	t *testing.T,
 ) {

--- a/internal/artifact/transport.go
+++ b/internal/artifact/transport.go
@@ -20,9 +20,10 @@ type Transport interface {
 
 // ExchangeResult reports the logical effects of one transport exchange.
 type ExchangeResult struct {
-	Received  int
-	Published int
-	More      bool
+	Received    int
+	Published   int
+	Quarantined int
+	More        bool
 }
 
 // FolderTransportOptions configures a bounded folder exchange. RepairPublished

--- a/internal/artifact/transport_folder_pull.go
+++ b/internal/artifact/transport_folder_pull.go
@@ -132,7 +132,7 @@ func (t *folderTransport) pullJournalEventLocked(
 	if err != nil {
 		return err
 	}
-	_, err = t.pullWireEntryLocked(
+	outcome, err := t.pullWireEntryLocked(
 		ctx,
 		store,
 		kindRoot,
@@ -142,6 +142,9 @@ func (t *folderTransport) pullJournalEventLocked(
 		&expected,
 		result,
 	)
+	if outcome.Quarantined {
+		result.Quarantined++
+	}
 	return err
 }
 
@@ -209,7 +212,7 @@ func (t *folderTransport) pullOriginLocked(
 			kindRoot,
 			".",
 			func(entry os.DirEntry) error {
-				_, err := t.pullWireEntryLocked(
+				outcome, err := t.pullWireEntryLocked(
 					ctx,
 					store,
 					kindRoot,
@@ -219,6 +222,9 @@ func (t *folderTransport) pullOriginLocked(
 					nil,
 					result,
 				)
+				if outcome.Quarantined {
+					result.Quarantined++
+				}
 				return err
 			},
 		)

--- a/internal/artifact/transport_folder_test.go
+++ b/internal/artifact/transport_folder_test.go
@@ -577,7 +577,7 @@ func TestFolderTransportQuarantinesCompleteCorruptWireAndContinues(t *testing.T)
 		testFolderPublishOrigin,
 	)
 	require.NoError(t, err)
-	assert.Equal(t, ExchangeResult{Received: 1}, result)
+	assert.Equal(t, ExchangeResult{Received: 1, Quarantined: 1}, result)
 	assert.NoFileExists(t, corruptPath)
 	quarantined, err := filepath.Glob(corruptPath + folderCorruptSeparator + "*")
 	require.NoError(t, err)
@@ -632,7 +632,7 @@ func TestFolderTransportQuarantineLetsFreshConsumerAdvanceWhenArtifactExistsLoca
 		t.Context(), store, testFolderPublishOrigin,
 	)
 	require.NoError(t, err)
-	assert.Equal(t, ExchangeResult{Received: 1}, result)
+	assert.Equal(t, ExchangeResult{Received: 1, Quarantined: 1}, result)
 	assertArtifactBody(t, store, ref, localBody)
 	require.NoError(t, transport.Close())
 
@@ -693,7 +693,7 @@ func TestFolderTransportWritesRejectionBeforeQuarantiningWire(t *testing.T) {
 	transport.quarantineEntry = nil
 	result, err := transport.Exchange(t.Context(), store, testFolderPublishOrigin)
 	require.NoError(t, err)
-	assert.Equal(t, ExchangeResult{}, result)
+	assert.Equal(t, ExchangeResult{Quarantined: 1}, result)
 	assert.NoFileExists(t, wirePath)
 	quarantined, err := filepath.Glob(wirePath + folderCorruptSeparator + "*")
 	require.NoError(t, err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,7 +15,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"slices"
 	"sort"
 	"strconv"
@@ -1965,14 +1964,7 @@ func sessionSourceComparisonKey(dir string) (string, error) {
 	if strings.HasPrefix(strings.ToLower(dir), "s3://") {
 		return dir, nil
 	}
-	key, err := filepath.Abs(dir)
-	if err != nil {
-		return "", fmt.Errorf("resolving dir %q: %w", dir, err)
-	}
-	if runtime.GOOS == "windows" {
-		key = strings.ToLower(key)
-	}
-	return key, nil
+	return pathutil.LocalComparisonKey(dir)
 }
 
 func normalizeSessionSourceDir(raw string) (string, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1965,7 +1965,16 @@ func normalizeSessionSourceDir(raw string) (string, error) {
 	if strings.ContainsRune(value, '\x00') {
 		return "", fmt.Errorf("dir %q contains a NUL byte", raw)
 	}
-	return value, nil
+	// Structured sources resolve after expandLocalPaths has already expanded
+	// the legacy per-agent arrays, so expand here too. Without it a "~/..."
+	// root is never scanned and cannot deduplicate against, or relabel, the
+	// equivalent expanded legacy root. This resolves the path only; separator
+	// and case spelling are still left exactly as configured.
+	expanded, err := pathutil.ExpandHome(value)
+	if err != nil {
+		return "", fmt.Errorf("expanding dir %q: %w", raw, err)
+	}
+	return expanded, nil
 }
 
 func resolvePublicURL(value string, proxyCfg ProxyConfig) (string, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"slices"
 	"sort"
 	"strconv"
@@ -1846,7 +1847,12 @@ func (c *Config) resolveSessionSources() error {
 			if value == "" {
 				continue
 			}
-			key := sessionSourceComparisonKey(value)
+			key, err := sessionSourceComparisonKey(value)
+			if err != nil {
+				return fmt.Errorf(
+					"resolve %s session source %q: %w", def.Type, value, err,
+				)
+			}
 			if _, ok := seen[key]; ok {
 				continue
 			}
@@ -1913,7 +1919,12 @@ func (c *Config) resolveSessionSources() error {
 			seen = make(map[string]rootState)
 			rootsByAgent[agent] = seen
 		}
-		key := sessionSourceComparisonKey(dir)
+		key, err := sessionSourceComparisonKey(dir)
+		if err != nil {
+			problems = append(problems,
+				fmt.Sprintf("entry %d (%s): %v", entry, agent, err))
+			continue
+		}
 		state, duplicate := seen[key]
 		if duplicate {
 			state.machine = machine
@@ -1950,11 +1961,18 @@ func (c *Config) resolveSessionSources() error {
 	return nil
 }
 
-func sessionSourceComparisonKey(dir string) string {
+func sessionSourceComparisonKey(dir string) (string, error) {
 	if strings.HasPrefix(strings.ToLower(dir), "s3://") {
-		return dir
+		return dir, nil
 	}
-	return filepath.Clean(dir)
+	key, err := filepath.Abs(dir)
+	if err != nil {
+		return "", fmt.Errorf("resolving dir %q: %w", dir, err)
+	}
+	if runtime.GOOS == "windows" {
+		key = strings.ToLower(key)
+	}
+	return key, nil
 }
 
 func normalizeSessionSourceDir(raw string) (string, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -469,6 +469,20 @@ type RemoteHost struct {
 	Interval  time.Duration   `toml:"interval,omitempty" json:"interval,omitempty"`
 }
 
+// SessionSource adds one agent session root with optional machine attribution.
+// Legacy per-agent directory settings are resolved into the same root set.
+type SessionSource struct {
+	Agent   parser.AgentType `toml:"agent" json:"agent"`
+	Dir     string           `toml:"dir" json:"dir"`
+	Machine string           `toml:"machine,omitempty" json:"machine,omitempty"`
+}
+
+type sessionSourceConfig struct {
+	Agent   string  `toml:"agent"`
+	Dir     string  `toml:"dir"`
+	Machine *string `toml:"machine"`
+}
+
 // Config holds all application configuration.
 type Config struct {
 	Host                 string                 `json:"host" toml:"host"`
@@ -511,6 +525,12 @@ type Config struct {
 	// directories. Single-dir agents store a one-element
 	// slice; unconfigured agents use nil.
 	AgentDirs map[parser.AgentType][]string `json:"-" toml:"-"`
+
+	// SessionSources contains resolved structured sources. SourceMachines maps
+	// each effective configured root to its machine label for sync.
+	SessionSources       []SessionSource                        `json:"-" toml:"-"`
+	SourceMachines       map[parser.AgentType]map[string]string `json:"-" toml:"-"`
+	sessionSourceConfigs []sessionSourceConfig
 
 	// agentDirSource tracks how each agent's dirs were
 	// set so loadFile doesn't override env-set values.
@@ -765,6 +785,7 @@ func Default() (Config, error) {
 		LocalMachineName:               hostname,
 		AgentDirs:                      agentDirs,
 		agentDirSource:                 agentDirSource,
+		SourceMachines:                 make(map[parser.AgentType]map[string]string),
 		WatchExcludePatterns:           []string{".git", "node_modules", "__pycache__", ".venv", "venv", "vendor", ".next"},
 		ResultContentBlockedCategories: []string{"Read", "Glob"},
 		EventsCoalesceInterval:         10 * time.Second,
@@ -1080,6 +1101,7 @@ func (c *Config) applyConfigTOML(data string) error {
 		DaemonIdleTimeout              time.Duration              `toml:"daemon_idle_timeout"`
 		CustomModelPricing             map[string]CustomModelRate `toml:"custom_model_pricing"`
 		RemoteHosts                    []RemoteHost               `toml:"remote_hosts"`
+		SessionSources                 []sessionSourceConfig      `toml:"session_sources"`
 	}
 	meta, err := toml.Decode(data, &file)
 	if err != nil {
@@ -1320,6 +1342,9 @@ func (c *Config) applyConfigTOML(data string) error {
 			}
 		}
 		c.RemoteHosts = hosts
+	}
+	if meta.IsDefined("session_sources") {
+		c.sessionSourceConfigs = append([]sessionSourceConfig(nil), file.SessionSources...)
 	}
 
 	// Parse config-file dir arrays for agents that have a
@@ -1771,6 +1796,9 @@ func finalize(cfg *Config) error {
 	if strings.TrimSpace(cfg.LocalMachineName) == "" {
 		return fmt.Errorf("identify local sync machine: hostname is empty")
 	}
+	if err := cfg.resolveSessionSources(); err != nil {
+		return err
+	}
 	if err := normalizeProxyConfig(&cfg.Proxy); err != nil {
 		return err
 	}
@@ -1800,6 +1828,144 @@ func finalize(cfg *Config) error {
 		return err
 	}
 	return nil
+}
+
+func (c *Config) resolveSessionSources() error {
+	type rootState struct {
+		dir     string
+		machine string
+	}
+
+	resolved := make([]SessionSource, 0)
+	rootsByAgent := make(map[parser.AgentType]map[string]rootState, len(c.AgentDirs))
+	for _, def := range parser.Registry {
+		seen := make(map[string]rootState)
+		dirs := make([]string, 0, len(c.AgentDirs[def.Type]))
+		for _, rawDir := range c.AgentDirs[def.Type] {
+			value := strings.TrimSpace(rawDir)
+			if value == "" {
+				continue
+			}
+			key := sessionSourceComparisonKey(value)
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = rootState{
+				dir:     value,
+				machine: c.LocalMachineName,
+			}
+			dirs = append(dirs, value)
+		}
+		c.AgentDirs[def.Type] = dirs
+		rootsByAgent[def.Type] = seen
+	}
+
+	var problems []string
+	for i, input := range c.sessionSourceConfigs {
+		entry := i + 1
+		agent := parser.AgentType(strings.TrimSpace(strings.ToLower(input.Agent)))
+		if agent == "" {
+			problems = append(problems,
+				fmt.Sprintf("entry %d: agent is required", entry))
+			continue
+		}
+		if _, ok := parser.AgentByType(agent); !ok {
+			problems = append(problems,
+				fmt.Sprintf("entry %d: unknown agent %q; use a registered parser name such as claude, codex, or copilot", entry, input.Agent))
+			continue
+		}
+		factory, hasFactory := parser.ProviderFactoryByType(agent)
+		if !hasFactory ||
+			factory.Capabilities().Source.DiscoverSources != parser.CapabilitySupported {
+			problems = append(problems,
+				fmt.Sprintf("entry %d (%s): session_sources requires a discoverable filesystem provider; %s is import-only", entry, agent, agent))
+			continue
+		}
+		rawDir := strings.TrimSpace(input.Dir)
+		if strings.HasPrefix(strings.ToLower(rawDir), "s3://") {
+			problems = append(problems,
+				fmt.Sprintf("entry %d (%s): dir %q is an S3 root; session_sources supports filesystem roots only, so configure S3 through the existing per-agent directory setting", entry, agent, input.Dir))
+			continue
+		}
+		dir, err := normalizeSessionSourceDir(input.Dir)
+		if err != nil {
+			problems = append(problems,
+				fmt.Sprintf("entry %d (%s): %v", entry, agent, err))
+			continue
+		}
+		machine := c.LocalMachineName
+		if input.Machine != nil {
+			machine = strings.TrimSpace(*input.Machine)
+			if machine == "" {
+				problems = append(problems,
+					fmt.Sprintf("entry %d (%s): machine must not be empty when set", entry, agent))
+				continue
+			}
+			if machine == "local" {
+				problems = append(problems,
+					fmt.Sprintf("entry %d (%s): machine %q is reserved for legacy local attribution; use the actual machine name or omit machine", entry, agent, machine))
+				continue
+			}
+		}
+
+		seen := rootsByAgent[agent]
+		if seen == nil {
+			seen = make(map[string]rootState)
+			rootsByAgent[agent] = seen
+		}
+		key := sessionSourceComparisonKey(dir)
+		state, duplicate := seen[key]
+		if duplicate {
+			state.machine = machine
+			seen[key] = state
+		} else {
+			seen[key] = rootState{
+				dir:     dir,
+				machine: machine,
+			}
+			c.AgentDirs[agent] = append(c.AgentDirs[agent], dir)
+		}
+		c.agentDirSource[agent] = dirFile
+		resolved = append(resolved, SessionSource{
+			Agent: agent, Dir: dir, Machine: machine,
+		})
+	}
+	if len(problems) > 0 {
+		return fmt.Errorf("session_sources: %s", strings.Join(problems, "; "))
+	}
+
+	sourceMachines := make(map[parser.AgentType]map[string]string, len(rootsByAgent))
+	for agent, roots := range rootsByAgent {
+		machines := make(map[string]string, len(roots))
+		for _, state := range roots {
+			if strings.HasPrefix(strings.ToLower(state.dir), "s3://") {
+				continue
+			}
+			machines[state.dir] = state.machine
+		}
+		sourceMachines[agent] = machines
+	}
+	c.SessionSources = resolved
+	c.SourceMachines = sourceMachines
+	return nil
+}
+
+func sessionSourceComparisonKey(dir string) string {
+	if strings.HasPrefix(strings.ToLower(dir), "s3://") {
+		return dir
+	}
+	return filepath.Clean(dir)
+}
+
+func normalizeSessionSourceDir(raw string) (string, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return "", fmt.Errorf("dir is required")
+	}
+	if strings.ContainsRune(value, '\x00') {
+		return "", fmt.Errorf("dir %q contains a NUL byte", raw)
+	}
+	return value, nil
 }
 
 func resolvePublicURL(value string, proxyCfg ProxyConfig) (string, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -814,6 +814,193 @@ func TestLoadFile_ReadsDirArrays(t *testing.T) {
 	assert.True(t, cfg.IsUserConfigured(parser.AgentAider))
 }
 
+func TestLoadFileSessionSourcesAreAdditiveAndOverrideDuplicateMachine(t *testing.T) {
+	f := newConfigFixture(t)
+	f.WriteConfigText(t, `
+copilot_dirs = ["/sessions/local", "/sessions/duplicate/."]
+
+[[session_sources]]
+agent = "copilot"
+dir = "/sessions/archive"
+machine = "buildbox"
+
+[[session_sources]]
+agent = "copilot"
+dir = "/sessions/duplicate"
+machine = "archivebox"
+`)
+
+	cfg := f.LoadMinimal(t)
+
+	assert.Equal(t, []string{
+		"/sessions/local",
+		"/sessions/duplicate/.",
+		"/sessions/archive",
+	}, cfg.ResolveDirs(parser.AgentCopilot))
+	assert.Equal(t, cfg.LocalMachineName,
+		cfg.SourceMachines[parser.AgentCopilot]["/sessions/local"])
+	assert.Equal(t, "archivebox",
+		cfg.SourceMachines[parser.AgentCopilot]["/sessions/duplicate/."])
+	assert.Equal(t, "buildbox",
+		cfg.SourceMachines[parser.AgentCopilot]["/sessions/archive"])
+	assert.True(t, cfg.IsUserConfigured(parser.AgentCopilot))
+}
+
+func TestLoadFileSessionSourcePreservesConfiguredPathSpelling(t *testing.T) {
+	f := newConfigFixture(t)
+	f.WriteConfigText(t, `
+[[session_sources]]
+agent = "copilot"
+dir = "/sessions/archive/."
+machine = "archivebox"
+`)
+
+	cfg := f.LoadMinimal(t)
+
+	require.Len(t, cfg.SessionSources, 1)
+	assert.Equal(t, "/sessions/archive/.", cfg.SessionSources[0].Dir)
+	assert.Contains(t, cfg.ResolveDirs(parser.AgentCopilot), "/sessions/archive/.")
+	assert.Equal(t, "archivebox",
+		cfg.SourceMachines[parser.AgentCopilot]["/sessions/archive/."])
+}
+
+func TestLoadFileSessionSourcesRemainAdditiveToEnvDirs(t *testing.T) {
+	f := newConfigFixture(t)
+	t.Setenv("COPILOT_DIR", "/sessions/from-env")
+	f.WriteConfigText(t, `
+copilot_dirs = ["/sessions/from-config"]
+
+[[session_sources]]
+agent = "copilot"
+dir = "/sessions/from-archive"
+machine = "archivebox"
+`)
+
+	cfg := f.LoadMinimal(t)
+
+	assert.Equal(t, []string{
+		"/sessions/from-env",
+		"/sessions/from-archive",
+	}, cfg.ResolveDirs(parser.AgentCopilot))
+	assert.Equal(t, cfg.LocalMachineName,
+		cfg.SourceMachines[parser.AgentCopilot]["/sessions/from-env"])
+	assert.Equal(t, "archivebox",
+		cfg.SourceMachines[parser.AgentCopilot]["/sessions/from-archive"])
+}
+
+func TestLoadFileSessionSourcesPreserveLegacyS3Roots(t *testing.T) {
+	cfg := loadMinimalWithConfig(t, map[string]any{
+		"claude_project_dirs": []string{"s3://session-archive/claude"},
+	})
+
+	assert.Equal(t, []string{"s3://session-archive/claude"},
+		cfg.ResolveDirs(parser.AgentClaude))
+	assert.NotContains(t, cfg.SourceMachines[parser.AgentClaude],
+		"s3://session-archive/claude")
+}
+
+func TestLoadFileSessionSourceDefaultsMachineToHostname(t *testing.T) {
+	cfg := loadMinimalWithConfig(t, map[string]any{
+		"session_sources": []map[string]any{{
+			"agent": "copilot",
+			"dir":   "/sessions/archive",
+		}},
+	})
+
+	require.NotEmpty(t, cfg.LocalMachineName)
+	assert.Equal(t, cfg.LocalMachineName,
+		cfg.SourceMachines[parser.AgentCopilot]["/sessions/archive"])
+	require.Len(t, cfg.SessionSources, 1)
+	assert.Equal(t, cfg.LocalMachineName, cfg.SessionSources[0].Machine)
+}
+
+func TestLoadFileSessionSourceValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  string
+		wantErr string
+	}{
+		{
+			name: "unknown agent",
+			config: `
+[[session_sources]]
+agent = "not-an-agent"
+dir = "/sessions/archive"
+`,
+			wantErr: `session_sources: entry 1: unknown agent "not-an-agent"`,
+		},
+		{
+			name: "empty dir",
+			config: `
+[[session_sources]]
+agent = "copilot"
+dir = " "
+`,
+			wantErr: "entry 1 (copilot): dir is required",
+		},
+		{
+			name: "empty explicit machine",
+			config: `
+[[session_sources]]
+agent = "copilot"
+dir = "/sessions/archive"
+machine = " "
+`,
+			wantErr: "entry 1 (copilot): machine must not be empty when set",
+		},
+		{
+			name: "reserved local machine",
+			config: `
+[[session_sources]]
+agent = "copilot"
+dir = "/sessions/archive"
+machine = "local"
+`,
+			wantErr: `entry 1 (copilot): machine "local" is reserved`,
+		},
+		{
+			name: "chatgpt import-only provider",
+			config: `
+[[session_sources]]
+agent = "chatgpt"
+dir = "/sessions/archive"
+`,
+			wantErr: "entry 1 (chatgpt): session_sources requires a discoverable filesystem provider; chatgpt is import-only",
+		},
+		{
+			name: "claude-ai import-only provider",
+			config: `
+[[session_sources]]
+agent = "claude-ai"
+dir = "/sessions/archive"
+`,
+			wantErr: "entry 1 (claude-ai): session_sources requires a discoverable filesystem provider; claude-ai is import-only",
+		},
+		{
+			name: "s3 root",
+			config: `
+[[session_sources]]
+agent = "copilot"
+dir = "s3://session-archive/copilot"
+machine = "buildbox"
+`,
+			wantErr: "session_sources supports filesystem roots only",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newConfigFixture(t)
+			f.WriteConfigText(t, tt.config)
+
+			err := f.LoadMinimalErr(t)
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
 func TestResolveDirs(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2338,3 +2338,25 @@ machine = "archivebox"
 	assert.Equal(t, "archivebox", cfg.SourceMachines[parser.AgentCopilot][want],
 		"the structured entry must relabel the root it deduplicates onto")
 }
+
+func TestLoadFileSessionSourceAbsoluteDirDeduplicatesRelativeLegacyRoot(t *testing.T) {
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	relative := filepath.Join("testdata", "session-source-alias")
+	absolute := filepath.Join(cwd, relative)
+
+	cfg := loadMinimalWithConfig(t, map[string]any{
+		"copilot_dirs": []string{relative},
+		"session_sources": []map[string]any{{
+			"agent":   "copilot",
+			"dir":     absolute,
+			"machine": "archivebox",
+		}},
+	})
+
+	assert.Equal(t, []string{relative}, cfg.ResolveDirs(parser.AgentCopilot),
+		"equivalent roots must retain one scan path")
+	assert.Equal(t, map[string]string{relative: "archivebox"},
+		cfg.SourceMachines[parser.AgentCopilot],
+		"the structured entry must relabel the equivalent legacy root")
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2291,3 +2291,50 @@ func TestValidateArtifactOriginID(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadFileSessionSourceExpandsHomeRelativeDir(t *testing.T) {
+	f := newConfigFixture(t)
+	f.WriteConfigText(t, `
+[[session_sources]]
+agent = "copilot"
+dir = "~/sessions/archive"
+machine = "archivebox"
+`)
+
+	cfg := f.LoadMinimal(t)
+
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+	want := filepath.Join(home, "sessions", "archive")
+
+	require.Len(t, cfg.SessionSources, 1)
+	assert.Equal(t, want, cfg.SessionSources[0].Dir,
+		"a structured root must be expanded or it is never scanned")
+	assert.Contains(t, cfg.ResolveDirs(parser.AgentCopilot), want)
+	assert.Equal(t, "archivebox", cfg.SourceMachines[parser.AgentCopilot][want])
+	assert.NotContains(t, cfg.ResolveDirs(parser.AgentCopilot), "~/sessions/archive")
+}
+
+func TestLoadFileSessionSourceHomeRelativeDirDeduplicatesExpandedLegacyRoot(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+	want := filepath.Join(home, "sessions", "archive")
+
+	f := newConfigFixture(t)
+	f.WriteConfigText(t, `
+copilot_dirs = ["~/sessions/archive"]
+
+[[session_sources]]
+agent = "copilot"
+dir = "~/sessions/archive"
+machine = "archivebox"
+`)
+
+	cfg := f.LoadMinimal(t)
+
+	dirs := cfg.ResolveDirs(parser.AgentCopilot)
+	assert.Equal(t, []string{want}, dirs,
+		"the structured root must collapse onto the equivalent legacy root")
+	assert.Equal(t, "archivebox", cfg.SourceMachines[parser.AgentCopilot][want],
+		"the structured entry must relabel the root it deduplicates onto")
+}

--- a/internal/db/project_identity_test.go
+++ b/internal/db/project_identity_test.go
@@ -81,6 +81,63 @@ func TestProjectIdentityPublicationRevisionTracksSnapshotChanges(t *testing.T) {
 	assert.Greater(t, afterDelete, afterInsert)
 }
 
+func TestCopySessionMetadataPreservesRecordedMachineAttribution(
+	t *testing.T,
+) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	source := testDBAtPath(t, sourcePath, "source")
+	require.NoError(t, source.UpsertSession(Session{
+		ID: "resynced-session", Project: "app",
+		Machine: "oldbox", Agent: "claude",
+	}))
+	require.NoError(t, source.UpsertProjectIdentityObservation(
+		t.Context(), export.ProjectIdentityObservation{
+			SessionID: "resynced-session", Project: "app", Machine: "oldbox",
+			RootPath: "/workspace/app", ObservedAt: time.Now().UTC(),
+		},
+	))
+	require.NoError(t, source.Close())
+
+	destinationPath := filepath.Join(dir, "destination.db")
+	destination := testDBAtPath(t, destinationPath, "destination")
+	t.Cleanup(func() { _ = destination.Close() })
+	require.NoError(t, destination.UpsertSession(Session{
+		ID: "resynced-session", Project: "app",
+		Machine: "newbox", Agent: "claude",
+	}))
+	require.NoError(t, destination.UpsertProjectIdentityObservation(
+		t.Context(), export.ProjectIdentityObservation{
+			SessionID: "resynced-session", Project: "app", Machine: "newbox",
+			RootPath: "/workspace/app", ObservedAt: time.Now().UTC(),
+		},
+	))
+
+	require.NoError(t, destination.CopySessionMetadataFrom(sourcePath))
+
+	session, err := destination.GetSessionFull(
+		t.Context(), "resynced-session",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, session)
+	assert.Equal(t, "newbox", session.Machine)
+	snapshots, err := destination.ListSessionProjectIdentitySnapshots(
+		t.Context(),
+	)
+	require.NoError(t, err)
+	require.Len(t, snapshots, 1)
+	assert.Equal(t, "oldbox", snapshots[0].Machine)
+	observations, err := destination.ListProjectIdentityObservations(
+		t.Context(), []string{"app"},
+	)
+	require.NoError(t, err)
+	require.Len(t, observations, 2)
+	assert.ElementsMatch(t, []string{"newbox", "oldbox"}, []string{
+		observations[0].Machine,
+		observations[1].Machine,
+	})
+}
+
 func TestSessionProjectIdentitySnapshotPreservesFirstRootKeyUntilRemoteEvidence(
 	t *testing.T,
 ) {

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -2472,8 +2472,8 @@ func (db *DB) ListSessionIDsByFilePath(path, agent string) ([]string, error) {
 
 const sessionMachineBatchSize = 500
 
-// SessionWriteIdentity is the stored ownership evidence needed before a sync
-// write can reuse an existing native session ID.
+// SessionWriteIdentity is the stored evidence used to decide whether a copied
+// source may reuse the session's machine for local project identity discovery.
 type SessionWriteIdentity struct {
 	Machine  string
 	Agent    string
@@ -2481,7 +2481,7 @@ type SessionWriteIdentity struct {
 	FileHash string
 }
 
-// ListSessionWriteIdentitiesByID returns stored ownership evidence for each
+// ListSessionWriteIdentitiesByID returns stored source evidence for each
 // requested session, including tombstoned rows that may be revived by a later
 // successful parse. Requests are chunked below SQLite's bind-variable limit.
 func (db *DB) ListSessionWriteIdentitiesByID(

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -2472,17 +2472,26 @@ func (db *DB) ListSessionIDsByFilePath(path, agent string) ([]string, error) {
 
 const sessionMachineBatchSize = 500
 
-// ListSessionMachinesByID returns the stored machine attribution for each
+// SessionWriteIdentity is the stored ownership evidence needed before a sync
+// write can reuse an existing native session ID.
+type SessionWriteIdentity struct {
+	Machine  string
+	Agent    string
+	FilePath string
+	FileHash string
+}
+
+// ListSessionWriteIdentitiesByID returns stored ownership evidence for each
 // requested session, including tombstoned rows that may be revived by a later
 // successful parse. Requests are chunked below SQLite's bind-variable limit.
-func (db *DB) ListSessionMachinesByID(
+func (db *DB) ListSessionWriteIdentitiesByID(
 	ctx context.Context,
 	ids []string,
-) (map[string]string, error) {
+) (map[string]SessionWriteIdentity, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	machines := make(map[string]string, len(ids))
+	identities := make(map[string]SessionWriteIdentity, len(ids))
 	unique := make([]string, 0, len(ids))
 	seen := make(map[string]struct{}, len(ids))
 	for _, id := range ids {
@@ -2504,28 +2513,53 @@ func (db *DB) ListSessionMachinesByID(
 			args[i] = id
 		}
 		rows, err := db.getReader().QueryContext(ctx, `
-			SELECT id, machine
+			SELECT id, machine, agent,
+			       COALESCE(file_path, ''), COALESCE(file_hash, '')
 			FROM sessions
 			WHERE id IN (`+placeholders+`)
 			ORDER BY id`, args...)
 		if err != nil {
-			return nil, fmt.Errorf("listing session machines by ID: %w", err)
+			return nil, fmt.Errorf("listing session write identities by ID: %w", err)
 		}
 		for rows.Next() {
-			var id, machine string
-			if err := rows.Scan(&id, &machine); err != nil {
+			var id string
+			var identity SessionWriteIdentity
+			if err := rows.Scan(
+				&id, &identity.Machine, &identity.Agent,
+				&identity.FilePath, &identity.FileHash,
+			); err != nil {
 				_ = rows.Close()
-				return nil, fmt.Errorf("scanning session machine by ID: %w", err)
+				return nil, fmt.Errorf(
+					"scanning session write identity by ID: %w", err,
+				)
 			}
-			machines[id] = machine
+			identities[id] = identity
 		}
 		if err := rows.Err(); err != nil {
 			_ = rows.Close()
-			return nil, fmt.Errorf("iterating session machines by ID: %w", err)
+			return nil, fmt.Errorf("iterating session write identities by ID: %w", err)
 		}
 		if err := rows.Close(); err != nil {
-			return nil, fmt.Errorf("closing session machines by ID: %w", err)
+			return nil, fmt.Errorf("closing session write identities by ID: %w", err)
 		}
+	}
+	return identities, nil
+}
+
+// ListSessionMachinesByID returns the stored machine attribution for each
+// requested session, including tombstoned rows that may be revived by a later
+// successful parse. Requests are chunked below SQLite's bind-variable limit.
+func (db *DB) ListSessionMachinesByID(
+	ctx context.Context,
+	ids []string,
+) (map[string]string, error) {
+	identities, err := db.ListSessionWriteIdentitiesByID(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+	machines := make(map[string]string, len(ids))
+	for id, identity := range identities {
+		machines[id] = identity.Machine
 	}
 	return machines, nil
 }

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -2667,8 +2667,9 @@ func (o SessionSourceOwnership) Cursor() SessionSourceCursor {
 }
 
 // ListActiveSessionSourceOwnershipScopesPage returns one stable keyset page
-// across a provider's bounded physical scopes. Normalization deduplicates
-// repeated declarations before building the query.
+// across a provider's bounded physical scopes. Machine is an exact stored key,
+// including the empty key retained by legacy sessions. Normalization
+// deduplicates repeated declarations before building the query.
 func (db *DB) ListActiveSessionSourceOwnershipScopesPage(
 	ctx context.Context,
 	machine string,
@@ -2677,7 +2678,7 @@ func (db *DB) ListActiveSessionSourceOwnershipScopesPage(
 	after SessionSourceCursor,
 ) ([]SessionSourceOwnership, error) {
 	scopes = normalizeStoredSourcePathHintScopes(scopes)
-	if machine == "" || agent == "" || len(scopes) == 0 {
+	if agent == "" || len(scopes) == 0 {
 		return nil, nil
 	}
 	if after.Agent != "" && after.Agent != agent {
@@ -2808,8 +2809,9 @@ func mergeSessionSourceOwnershipPages(
 }
 
 // BaselineActiveSessionSourcePaths marks exact active local ownerships as
-// observed. Callers pass one bounded discovery page or changed-path batch at a
-// time so this update never scales its live memory with the archive.
+// observed. Machine is an exact stored key, including the empty key retained by
+// legacy sessions. Callers pass one bounded discovery page or changed-path
+// batch at a time so this update never scales its live memory with the archive.
 func (db *DB) BaselineActiveSessionSourcePaths(
 	ctx context.Context,
 	machine string,
@@ -2818,7 +2820,7 @@ func (db *DB) BaselineActiveSessionSourcePaths(
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	if machine == "" || len(sources) == 0 {
+	if len(sources) == 0 {
 		return nil
 	}
 	db.mu.Lock()
@@ -2840,9 +2842,10 @@ func (db *DB) BaselineActiveSessionSourcePaths(
 }
 
 // ReplaceActiveSessionSourceBaselines makes admitted the exact subset of a
-// bounded candidate page that carries deletion proof. Existing proof for
-// rejected candidates is removed in the same transaction that admits the
-// successful candidates.
+// bounded candidate page that carries deletion proof. Machine is an exact
+// stored key, including the empty key retained by legacy sessions. Existing
+// proof for rejected candidates is removed in the same transaction that admits
+// the successful candidates.
 //
 // The replacement is a diff, not a rewrite: warm no-op syncs replay every
 // unchanged archived source as an admitted candidate each pass, so unchanged
@@ -2858,7 +2861,7 @@ func (db *DB) ReplaceActiveSessionSourceBaselines(
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	if machine == "" || len(candidates) == 0 {
+	if len(candidates) == 0 {
 		return nil
 	}
 	rejected := rejectedSourceCandidates(candidates, admitted)

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -2470,6 +2470,66 @@ func (db *DB) ListSessionIDsByFilePath(path, agent string) ([]string, error) {
 	return ids, nil
 }
 
+const sessionMachineBatchSize = 500
+
+// ListSessionMachinesByID returns the stored machine attribution for each
+// requested session, including tombstoned rows that may be revived by a later
+// successful parse. Requests are chunked below SQLite's bind-variable limit.
+func (db *DB) ListSessionMachinesByID(
+	ctx context.Context,
+	ids []string,
+) (map[string]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	machines := make(map[string]string, len(ids))
+	unique := make([]string, 0, len(ids))
+	seen := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		if _, exists := seen[id]; exists {
+			continue
+		}
+		seen[id] = struct{}{}
+		unique = append(unique, id)
+	}
+	for start := 0; start < len(unique); start += sessionMachineBatchSize {
+		end := min(start+sessionMachineBatchSize, len(unique))
+		batch := unique[start:end]
+		placeholders := strings.TrimSuffix(strings.Repeat("?,", len(batch)), ",")
+		args := make([]any, len(batch))
+		for i, id := range batch {
+			args[i] = id
+		}
+		rows, err := db.getReader().QueryContext(ctx, `
+			SELECT id, machine
+			FROM sessions
+			WHERE id IN (`+placeholders+`)
+			ORDER BY id`, args...)
+		if err != nil {
+			return nil, fmt.Errorf("listing session machines by ID: %w", err)
+		}
+		for rows.Next() {
+			var id, machine string
+			if err := rows.Scan(&id, &machine); err != nil {
+				_ = rows.Close()
+				return nil, fmt.Errorf("scanning session machine by ID: %w", err)
+			}
+			machines[id] = machine
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("iterating session machines by ID: %w", err)
+		}
+		if err := rows.Close(); err != nil {
+			return nil, fmt.Errorf("closing session machines by ID: %w", err)
+		}
+	}
+	return machines, nil
+}
+
 const descendantSessionRootBatchSize = 100
 
 // ListActiveDescendantSessionSourcePaths returns the source paths of active
@@ -2590,6 +2650,14 @@ type SessionSourceOwnership struct {
 // successful local reconciliation. The baseline is deliberately path-exact:
 // callers must pass virtual member paths without splitting their suffixes.
 type SessionSourcePath struct {
+	Agent    string
+	FilePath string
+}
+
+// SessionSourceAttribution is one distinct immutable machine label represented
+// by active sessions at an exact provider source.
+type SessionSourceAttribution struct {
+	Machine  string
 	Agent    string
 	FilePath string
 }
@@ -2911,6 +2979,75 @@ func buildSourcePairFilter(sources []SessionSourcePath) (string, []any, bool) {
 	}
 	sb.WriteString(")")
 	return sb.String(), args, true
+}
+
+// ListActiveSessionSourceAttributions returns every distinct machine label
+// represented by active rows at the requested exact sources. A shared provider
+// database may contain sessions admitted under multiple immutable labels, so
+// the result is intentionally not collapsed to one machine per path.
+func (db *DB) ListActiveSessionSourceAttributions(
+	ctx context.Context,
+	sources []SessionSourcePath,
+) ([]SessionSourceAttribution, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	seen := make(map[SessionSourceAttribution]struct{})
+	for start := 0; start < len(sources); start += baselinePairChunk {
+		end := min(start+baselinePairChunk, len(sources))
+		filter, args, ok := buildSourcePairFilter(sources[start:end])
+		if !ok {
+			continue
+		}
+		rows, err := db.getReader().QueryContext(ctx, `
+			SELECT DISTINCT machine, agent, file_path
+			FROM sessions
+			WHERE `+filter+`
+			  AND file_path IS NOT NULL
+			  AND deleted_at IS NULL`, args...)
+		if err != nil {
+			return nil, fmt.Errorf("listing active session source attributions: %w", err)
+		}
+		for rows.Next() {
+			var attribution SessionSourceAttribution
+			if err := rows.Scan(
+				&attribution.Machine,
+				&attribution.Agent,
+				&attribution.FilePath,
+			); err != nil {
+				_ = rows.Close()
+				return nil, fmt.Errorf(
+					"scanning active session source attribution: %w", err,
+				)
+			}
+			seen[attribution] = struct{}{}
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf(
+				"iterating active session source attributions: %w", err,
+			)
+		}
+		if err := rows.Close(); err != nil {
+			return nil, fmt.Errorf(
+				"closing active session source attributions: %w", err,
+			)
+		}
+	}
+	attributions := make([]SessionSourceAttribution, 0, len(seen))
+	for attribution := range seen {
+		attributions = append(attributions, attribution)
+	}
+	sort.Slice(attributions, func(i, j int) bool {
+		if attributions[i].Machine != attributions[j].Machine {
+			return attributions[i].Machine < attributions[j].Machine
+		}
+		if attributions[i].Agent != attributions[j].Agent {
+			return attributions[i].Agent < attributions[j].Agent
+		}
+		return attributions[i].FilePath < attributions[j].FilePath
+	})
+	return attributions, nil
 }
 
 func baselineActiveSessionSourcePathsTx(

--- a/internal/db/source_path_hints_test.go
+++ b/internal/db/source_path_hints_test.go
@@ -1041,6 +1041,40 @@ func TestReplaceActiveSessionSourceBaselinesWarmPassWritesBounded(t *testing.T) 
 	}
 }
 
+func TestListActiveSessionSourceAttributionsReturnsEveryMachine(t *testing.T) {
+	d := testDB(t)
+	root := t.TempDir()
+	sharedPath := filepath.Join(root, "shared.db")
+	unrelatedPath := filepath.Join(root, "unrelated.db")
+	for _, seed := range []struct {
+		id      string
+		machine string
+		path    string
+	}{
+		{id: "shared-a", machine: "machine-a", path: sharedPath},
+		{id: "shared-b", machine: "machine-b", path: sharedPath},
+		{id: "unrelated", machine: "machine-c", path: unrelatedPath},
+	} {
+		path := seed.path
+		require.NoError(t, d.UpsertSession(Session{
+			ID: seed.id, Project: "project", Machine: seed.machine,
+			Agent: "shared-provider", FilePath: &path,
+		}))
+	}
+
+	got, err := d.ListActiveSessionSourceAttributions(
+		t.Context(), []SessionSourcePath{{
+			Agent: "shared-provider", FilePath: sharedPath,
+		}},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, []SessionSourceAttribution{
+		{Machine: "machine-a", Agent: "shared-provider", FilePath: sharedPath},
+		{Machine: "machine-b", Agent: "shared-provider", FilePath: sharedPath},
+	}, got)
+}
+
 // TestReplaceActiveSessionSourceBaselinesReplacesMovedOwnership pins the
 // delete-then-readmit end state for changed ownership: when a session's stored
 // source moves, replacing the old and new pairs leaves exactly one baseline

--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -79,6 +79,71 @@ func (db *DB) FileBackedSessionCountForSource(
 	return db.fileBackedSessionCount(ctx, machine, idPrefix, true)
 }
 
+// FileBackedSessionCountForRebuildOwner returns the protected root-session
+// count owned by the local rebuild phase. Current, empty, and legacy local
+// machine values cover archives created before source baselines; exact
+// baseline rows preserve ownership after a structured root is relabeled.
+// Contributor namespaces and agents whose source format can legitimately move
+// between storage backends are excluded by the coordinator.
+func (db *DB) FileBackedSessionCountForRebuildOwner(
+	ctx context.Context,
+	localMachine string,
+	excludedIDPrefixes []string,
+	excludedAgents []string,
+) (int, error) {
+	conditions := []string{`(
+		machine = ? OR machine = '' OR machine = 'local' OR EXISTS (
+			SELECT 1
+			FROM local_session_source_baselines AS b
+			WHERE b.session_id = sessions.id
+			  AND b.machine = sessions.machine
+			  AND b.agent = sessions.agent
+			  AND b.file_path = sessions.file_path
+		)
+	)`}
+	args := nonSourceBackedAgentArgs()
+	args = append(args, localMachine)
+	seenPrefixes := make(map[string]struct{}, len(excludedIDPrefixes))
+	for _, prefix := range excludedIDPrefixes {
+		if prefix == "" {
+			continue
+		}
+		if _, seen := seenPrefixes[prefix]; seen {
+			continue
+		}
+		seenPrefixes[prefix] = struct{}{}
+		conditions = append(conditions, `substr(id, 1, length(?)) <> ?`)
+		args = append(args, prefix, prefix)
+	}
+	seenAgents := make(map[string]struct{}, len(excludedAgents))
+	for _, agent := range excludedAgents {
+		if agent == "" {
+			continue
+		}
+		if _, seen := seenAgents[agent]; seen {
+			continue
+		}
+		seenAgents[agent] = struct{}{}
+		conditions = append(conditions, `agent <> ?`)
+		args = append(args, agent)
+	}
+
+	var count int
+	err := db.getReader().QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM sessions
+		 WHERE agent NOT IN (`+nonSourceBackedAgentPlaceholders()+`)
+		 AND `+rootSessionFilter+`
+		 AND `+strings.Join(conditions, "\n AND "),
+		args...,
+	).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf(
+			"counting local rebuild-owned file sessions: %w", err,
+		)
+	}
+	return count, nil
+}
+
 func (db *DB) fileBackedSessionCount(
 	ctx context.Context, machine, idPrefix string, scoped bool,
 ) (int, error) {

--- a/internal/parser/discovery.go
+++ b/internal/parser/discovery.go
@@ -54,7 +54,7 @@ type DiscoveredFile struct {
 	Path        string
 	Project     string    // pre-extracted project name
 	Agent       AgentType // which agent this file belongs to
-	Machine     string    // source machine (set for s3:// sources; empty = host machine)
+	Machine     string    // source machine override; empty = engine default
 	SourceSize  int64     // source object size for s3:// sources
 	SourceMtime int64     // source object mtime for s3:// sources, UnixNano
 	// SourceFingerprint is a durable object fingerprint for s3:// sources.

--- a/internal/parser/hermes_provider.go
+++ b/internal/parser/hermes_provider.go
@@ -1262,6 +1262,7 @@ func hermesArchiveSourceRef(root, stateDB string) (SourceRef, bool) {
 	stateDB = filepath.Clean(stateDB)
 	return SourceRef{
 		Provider:       AgentHermes,
+		ConfiguredRoot: root,
 		Key:            stateDB,
 		DisplayPath:    stateDB,
 		FingerprintKey: stateDB,
@@ -1275,7 +1276,11 @@ func hermesArchiveSourceRef(root, stateDB string) (SourceRef, bool) {
 func hermesStateMemberSourceRef(root, stateDB, sessionID string) SourceRef {
 	path := VirtualSourcePath(stateDB, sessionID)
 	return SourceRef{
-		Provider: AgentHermes, Key: path, DisplayPath: path, FingerprintKey: path,
+		Provider:       AgentHermes,
+		ConfiguredRoot: filepath.Clean(root),
+		Key:            path,
+		DisplayPath:    path,
+		FingerprintKey: path,
 		Opaque: hermesSource{Root: filepath.Clean(root), Path: path,
 			StateDB: filepath.Clean(stateDB), SessionID: sessionID},
 	}
@@ -1286,6 +1291,7 @@ func hermesTranscriptSourceRef(root, path string) (SourceRef, bool) {
 	path = filepath.Clean(path)
 	return SourceRef{
 		Provider:       AgentHermes,
+		ConfiguredRoot: root,
 		Key:            path,
 		DisplayPath:    path,
 		FingerprintKey: path,

--- a/internal/parser/provider.go
+++ b/internal/parser/provider.go
@@ -576,6 +576,10 @@ type SourceRef struct {
 	// Provider identifies the provider that created this source and must match
 	// the provider instance used for subsequent operations.
 	Provider AgentType
+	// ConfiguredRoot preserves the configured root that produced this source.
+	// It may differ from the canonical source path when a provider collapses a
+	// directory onto a sibling container file.
+	ConfiguredRoot string
 	// Key is stable within the provider across process restarts. It is suitable
 	// for dedupe and diagnostics, but not necessarily for DB freshness checks.
 	Key string

--- a/internal/pathutil/home.go
+++ b/internal/pathutil/home.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 )
 
 // ExpandHome replaces a leading home shorthand ("~" or "~/") with the
@@ -25,4 +27,17 @@ func ExpandHome(path string) (string, error) {
 		return home, nil
 	}
 	return filepath.Join(home, path[2:]), nil
+}
+
+// LocalComparisonKey returns an absolute path key for comparing local paths.
+// It preserves case-sensitive platforms and folds case on Windows.
+func LocalComparisonKey(path string) (string, error) {
+	key, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolving path %q: %w", path, err)
+	}
+	if runtime.GOOS == "windows" {
+		key = strings.ToLower(key)
+	}
+	return key, nil
 }

--- a/internal/remotesync/resolve.go
+++ b/internal/remotesync/resolve.go
@@ -34,6 +34,7 @@ func ResolveTargets(cfg config.Config) TargetSet {
 			// lose its identity in transit, so keep it as a local archive input
 			// instead of advertising it for remote sync.
 			if !isLocalRemoteSyncSource(cfg, def.Type, dir) {
+				forbiddenRoots = appendUniqueForbiddenRoot(forbiddenRoots, dir)
 				continue
 			}
 			if def.Type == parser.AgentHermes {

--- a/internal/remotesync/resolve.go
+++ b/internal/remotesync/resolve.go
@@ -29,6 +29,13 @@ func ResolveTargets(cfg config.Config) TargetSet {
 			continue
 		}
 		for _, dir := range resolvedDirs {
+			// Remote imports assign the serving host to every transported root.
+			// A structured root attributed to another machine would therefore
+			// lose its identity in transit, so keep it as a local archive input
+			// instead of advertising it for remote sync.
+			if !isLocalRemoteSyncSource(cfg, def.Type, dir) {
+				continue
+			}
 			if def.Type == parser.AgentHermes {
 				hermesDirs, hermesFiles := resolveHermesTargets(dir)
 				if len(hermesDirs) > 0 {
@@ -96,6 +103,13 @@ func ResolveTargets(cfg config.Config) TargetSet {
 	return filterForbiddenTargets(TargetSet{
 		Dirs: dirs, Files: files, ExtraFiles: extra, ForbiddenRoots: forbiddenRoots,
 	})
+}
+
+func isLocalRemoteSyncSource(
+	cfg config.Config, agent parser.AgentType, dir string,
+) bool {
+	machine, ok := cfg.SourceMachines[agent][dir]
+	return !ok || machine == "" || machine == cfg.LocalMachineName
 }
 
 // filterForbiddenTargets drops resolved targets that lie inside a forbidden

--- a/internal/remotesync/resolve_test.go
+++ b/internal/remotesync/resolve_test.go
@@ -29,10 +29,14 @@ func TestResolveTargetsExcludesNonLocalStructuredSessionSources(t *testing.T) {
 	dataDir := filepath.Join(home, "data")
 	localRoot := filepath.Join(home, "local-copilot")
 	localStructuredRoot := filepath.Join(home, "local-structured-copilot")
-	foreignRoot := filepath.Join(home, "foreign-copilot")
+	foreignRoot := filepath.Join(localRoot, "foreign-copilot")
 	for _, dir := range []string{dataDir, localRoot, localStructuredRoot, foreignRoot} {
 		require.NoError(t, os.MkdirAll(dir, 0o755))
 	}
+	localSession := filepath.Join(localRoot, "local.jsonl")
+	foreignSession := filepath.Join(foreignRoot, "foreign.jsonl")
+	require.NoError(t, os.WriteFile(localSession, []byte("local\n"), 0o600))
+	require.NoError(t, os.WriteFile(foreignSession, []byte("foreign\n"), 0o600))
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
@@ -67,6 +71,16 @@ machine = %q
 		targets.Dirs[parser.AgentCopilot])
 	assert.NotContains(t, targets.Dirs[parser.AgentCopilot], foreignRoot,
 		"a source attributed to another machine must not be re-exported as local")
+	assert.Contains(t, targets.ForbiddenRoots, foreignRoot)
+	manifest, err := remotesync.BuildManifest(targets)
+	require.NoError(t, err)
+	var manifestPaths []string
+	for _, file := range manifest.Files {
+		manifestPaths = append(manifestPaths, file.Path)
+	}
+	assert.Contains(t, manifestPaths, localSession)
+	assert.NotContains(t, manifestPaths, foreignSession,
+		"an allowed ancestor must not re-export its nested foreign source")
 }
 
 func TestResolveTargetsFiltersAndIncludesSpecialFiles(t *testing.T) {

--- a/internal/remotesync/resolve_test.go
+++ b/internal/remotesync/resolve_test.go
@@ -3,6 +3,7 @@ package remotesync_test
 import (
 	"archive/tar"
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -18,6 +19,55 @@ import (
 	"go.kenn.io/agentsview/internal/remotesync"
 	"go.kenn.io/agentsview/internal/ssh"
 )
+
+func TestResolveTargetsExcludesNonLocalStructuredSessionSources(t *testing.T) {
+	localMachine, err := os.Hostname()
+	require.NoError(t, err)
+	require.NotEmpty(t, localMachine)
+	foreignMachine := localMachine + "-archive"
+	home := t.TempDir()
+	dataDir := filepath.Join(home, "data")
+	localRoot := filepath.Join(home, "local-copilot")
+	localStructuredRoot := filepath.Join(home, "local-structured-copilot")
+	foreignRoot := filepath.Join(home, "foreign-copilot")
+	for _, dir := range []string{dataDir, localRoot, localStructuredRoot, foreignRoot} {
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("AGENTSVIEW_DATA_DIR", dataDir)
+	for _, def := range parser.Registry {
+		if def.EnvVar != "" {
+			t.Setenv(def.EnvVar, "")
+		}
+	}
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dataDir, "config.toml"),
+		fmt.Appendf(nil, `
+copilot_dirs = [%q]
+
+[[session_sources]]
+agent = "copilot"
+dir = %q
+
+[[session_sources]]
+agent = "copilot"
+dir = %q
+machine = %q
+`, localRoot, localStructuredRoot, foreignRoot, foreignMachine),
+		0o600,
+	))
+
+	cfg, err := config.LoadMinimal()
+	require.NoError(t, err)
+	require.Equal(t, localMachine, cfg.LocalMachineName)
+	targets := remotesync.ResolveTargets(cfg)
+
+	assert.ElementsMatch(t, []string{localRoot, localStructuredRoot},
+		targets.Dirs[parser.AgentCopilot])
+	assert.NotContains(t, targets.Dirs[parser.AgentCopilot], foreignRoot,
+		"a source attributed to another machine must not be re-exported as local")
+}
 
 func TestResolveTargetsFiltersAndIncludesSpecialFiles(t *testing.T) {
 	root := t.TempDir()

--- a/internal/server/huma_routes_sync.go
+++ b/internal/server/huma_routes_sync.go
@@ -186,6 +186,7 @@ func (s *Server) syncEngineForLocal(local *db.DB) *syncpkg.Engine {
 	}
 	s.onDemandEngine = syncpkg.NewEngine(local, syncpkg.EngineConfig{
 		AgentDirs:               s.cfg.AgentDirs,
+		SourceMachines:          s.cfg.SourceMachines,
 		IncludeCwdPrefixes:      s.cfg.SyncIncludeCwdPrefixes,
 		Machine:                 s.cfg.LocalMachineName,
 		BlockedResultCategories: s.cfg.ResultContentBlockedCategories,

--- a/internal/sync/cwd_filter_integration_test.go
+++ b/internal/sync/cwd_filter_integration_test.go
@@ -214,17 +214,20 @@ func TestSyncAllCwdFilterChangeRevokesSkippedSourceDeletionProof(t *testing.T) {
 	}
 
 	env := &testEnv{db: dbtest.OpenTestDB(t), claudeDir: t.TempDir()}
-	newEngine := func(prefixes []string) *sync.Engine {
+	newEngine := func(sourceMachine string, prefixes []string) *sync.Engine {
 		return sync.NewEngine(env.db, sync.EngineConfig{
 			AgentDirs: map[parser.AgentType][]string{
 				parser.AgentClaude: {env.claudeDir},
+			},
+			SourceMachines: map[parser.AgentType]map[string]string{
+				parser.AgentClaude: {env.claudeDir: sourceMachine},
 			},
 			Machine:            "local",
 			IncludeCwdPrefixes: prefixes,
 		})
 	}
 
-	env.engine = newEngine(nil)
+	env.engine = newEngine("archivebox", nil)
 	t.Cleanup(func() { env.engine.Close() })
 	content := testjsonl.NewSessionBuilder().
 		AddClaudeUser(tsEarly, "Outside", "/workspace/personal/blog").
@@ -240,10 +243,10 @@ func TestSyncAllCwdFilterChangeRevokesSkippedSourceDeletionProof(t *testing.T) {
 	// ordinary discovery takes its freshness-skip path. The skipped source must
 	// lose the deletion proof established before the filter changed.
 	env.engine.Close()
-	env.engine = newEngine([]string{"/workspace/work"})
+	env.engine = newEngine("renamedbox", []string{"/workspace/work"})
 	env.engine.SyncAll(t.Context(), nil)
 	ownership, err := env.db.ListActiveSessionSourceOwnershipScopesPage(
-		t.Context(), "local", string(parser.AgentClaude),
+		t.Context(), "archivebox", string(parser.AgentClaude),
 		[]db.StoredSourcePathHintScope{{Path: env.claudeDir}},
 		db.SessionSourceCursor{},
 	)

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -10750,8 +10750,9 @@ type sessionMachineReader interface {
 
 // normalizePendingWriteMachines resolves immutable attribution before any
 // consumer can make a project, worktree, baseline, or persistence decision.
-// Existing sessions keep the archive's machine; first ingestions retain the
-// configured machine already stamped by discovery and parsing.
+// Existing sessions keep the archive's machine. For a new ID represented more
+// than once in the batch, every copy uses the first pending write's configured
+// machine so later upserts cannot rewrite its first-ingestion attribution.
 func (e *Engine) normalizePendingWriteMachines(
 	ctx context.Context,
 	batch []pendingWrite,
@@ -10786,7 +10787,11 @@ func (e *Engine) normalizePendingWriteMachines(
 	if err != nil {
 		return batch, fmt.Errorf("load immutable session machines: %w", err)
 	}
-	for id, machine := range machines {
+	for _, id := range ids {
+		machine := machines[id]
+		if machine == "" {
+			machine = batch[indexes[id][0]].sess.Machine
+		}
 		if machine == "" {
 			continue
 		}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -20,6 +20,7 @@ import (
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/export"
 	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/pathutil"
 	"go.kenn.io/agentsview/internal/secrets"
 	"go.kenn.io/agentsview/internal/signals"
 	"go.kenn.io/agentsview/internal/timeutil"
@@ -616,11 +617,17 @@ func (e *Engine) machineForPath(agent parser.AgentType, path string) string {
 func (e *Engine) configuredMachineForPath(
 	agent parser.AgentType, path string,
 ) (string, bool) {
-	path = filepath.Clean(path)
+	path, err := pathutil.LocalComparisonKey(path)
+	if err != nil {
+		return "", false
+	}
 	bestRoot := ""
 	machine := ""
 	for root, candidate := range e.sourceMachines[agent] {
-		cleanRoot := filepath.Clean(root)
+		cleanRoot, err := pathutil.LocalComparisonKey(root)
+		if err != nil {
+			continue
+		}
 		if !pathWithinRoot(path, cleanRoot) || len(cleanRoot) <= len(bestRoot) {
 			continue
 		}
@@ -669,13 +676,19 @@ func (e *Engine) reconciliationOwnershipMachines(
 	// Map iteration is unordered; sort so the query sequence is deterministic.
 	slices.Sort(configured)
 	for _, root := range roots {
-		clean := filepath.Clean(root)
-		add(e.machineForPath(agent, clean))
+		add(e.machineForPath(agent, root))
+		clean, err := pathutil.LocalComparisonKey(root)
+		if err != nil {
+			continue
+		}
 		// A reconciliation scope is a watched directory, which may sit above
 		// (or below) the labeled root itself — a container file such as
 		// Hermes's state.db is configured directly but watched via its parent.
 		for _, cfg := range configured {
-			cleanCfg := filepath.Clean(cfg)
+			cleanCfg, err := pathutil.LocalComparisonKey(cfg)
+			if err != nil {
+				continue
+			}
 			if pathWithinRoot(cleanCfg, clean) || pathWithinRoot(clean, cleanCfg) {
 				add(e.sourceMachines[agent][cfg])
 			}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -71,6 +71,8 @@ type reconciliationBaselineTracker struct {
 }
 
 type machineSessionSource struct {
+	// Machine is an exact stored ownership key. Empty remains valid for
+	// sessions written before machine attribution was introduced.
 	Machine string
 	Source  db.SessionSourcePath
 }
@@ -117,8 +119,7 @@ func reconciliationBaselineTrackerFor(
 func (tracker *reconciliationBaselineTracker) add(
 	source machineSessionSource,
 ) {
-	if source.Machine == "" ||
-		source.Source.Agent == "" || source.Source.FilePath == "" {
+	if source.Source.Agent == "" || source.Source.FilePath == "" {
 		return
 	}
 	tracker.sources[source] = struct{}{}
@@ -663,7 +664,7 @@ func (e *Engine) reconciliationOwnershipMachines(
 	seen := make(map[string]bool, len(roots)+len(archiveMachines)+1)
 	machines := make([]string, 0, len(roots)+len(archiveMachines)+1)
 	add := func(machine string) {
-		if machine == "" || seen[machine] {
+		if seen[machine] {
 			return
 		}
 		seen[machine] = true
@@ -1417,7 +1418,7 @@ func (e *Engine) expandOmnigentInheritedMetadataSources(
 		seenParents[parentID] = struct{}{}
 		machine := e.machineForProviderSource(agent, source, sourcePath)
 		if session, err := e.db.GetSession(ctx, parentID); err == nil &&
-			session != nil && session.Machine != "" {
+			session != nil {
 			machine = session.Machine
 		}
 		if _, exists := parentsByMachine[machine]; !exists {
@@ -4105,8 +4106,7 @@ func (e *Engine) replaceActiveSessionSourceBaselinesByMachine(
 		byMachine map[string]map[db.SessionSourcePath]struct{},
 		source machineSessionSource,
 	) {
-		if source.Machine == "" ||
-			source.Source.Agent == "" || source.Source.FilePath == "" {
+		if source.Source.Agent == "" || source.Source.FilePath == "" {
 			return
 		}
 		if byMachine[source.Machine] == nil {
@@ -7172,7 +7172,7 @@ func (e *Engine) collectAndBatch(
 				Agent: string(job.agent), FilePath: e.effectiveSourcePath(job.path),
 			},
 		}
-		return source, source.Machine != "" &&
+		return source,
 			source.Source.Agent != "" && source.Source.FilePath != ""
 	}
 	flushBaselineSources := func() {
@@ -7629,8 +7629,7 @@ func (e *Engine) baselinePendingWriteSources(
 				Agent: string(write.sess.Agent), FilePath: path,
 			},
 		}
-		if source.Machine == "" ||
-			source.Source.Agent == "" || source.Source.FilePath == "" {
+		if source.Source.Agent == "" || source.Source.FilePath == "" {
 			continue
 		}
 		if _, seen := eligible[source]; !seen {
@@ -8611,7 +8610,7 @@ func (e *Engine) providerSourceSessionOwnershipsForForceReplace(
 			seen[id] = struct{}{}
 			machine := e.machineForProviderSource(agent, source, sourcePath)
 			if session, err := e.db.GetSession(context.Background(), id); err == nil &&
-				session != nil && session.Machine != "" {
+				session != nil {
 				machine = session.Machine
 			}
 			members = append(members, sourceMissingMember{

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -2121,12 +2121,33 @@ func (e *Engine) resyncBuildLocked(
 	rebuildOldFileSessions := oldFileSessions
 	contributorOldFileSessions := make([]int, len(opts.Contributors))
 	if len(opts.Contributors) > 0 {
-		localOldFileSessions, err = e.protectedFileSessionCount(
-			origDB, e.machine, "", e.machine != "",
-		)
-		if err != nil {
-			log.Printf("resync: get old local file count: %v", err)
-			localOldFileSessions = 1
+		localMachines := map[string]bool{}
+		if e.machine != "" {
+			localMachines[e.machine] = true
+		}
+		for _, roots := range e.sourceMachines {
+			for _, machine := range roots {
+				if machine != "" {
+					localMachines[machine] = true
+				}
+			}
+		}
+		if len(localMachines) > 0 {
+			localOldFileSessions = 0
+			for machine := range localMachines {
+				count, countErr := e.protectedFileSessionCount(
+					origDB, machine, "", true,
+				)
+				if countErr != nil {
+					log.Printf(
+						"resync: get old local machine %q file count: %v",
+						machine, countErr,
+					)
+					localOldFileSessions = 1
+					break
+				}
+				localOldFileSessions += count
+			}
 		}
 		for i, contributor := range opts.Contributors {
 			count, countErr := e.protectedFileSessionCount(
@@ -2142,8 +2163,11 @@ func (e *Engine) resyncBuildLocked(
 				count = 1
 			}
 			contributorOldFileSessions[i] = count
-			if contributor.Config.Machine == e.machine &&
-				contributor.Config.IDPrefix != "" {
+			// A structured local root may use a historical machine label, while a
+			// contributor is owned by its ID namespace. Remove a contributor only
+			// when its machine was included in the local attribution count.
+			if contributor.Config.IDPrefix != "" &&
+				(len(localMachines) == 0 || localMachines[contributor.Config.Machine]) {
 				localOldFileSessions -= count
 				if localOldFileSessions < 0 {
 					localOldFileSessions = 0

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -10863,6 +10863,32 @@ func (e *Engine) normalizePendingWriteMachines(
 	if err != nil {
 		return batch, fmt.Errorf("load immutable session machines: %w", err)
 	}
+	// A rebuild reads preexisting attribution from archiveStore while writing
+	// into e.db. An ID first seen earlier in this rebuild is absent from the old
+	// archive, so consult the replacement before treating it as a new ingestion.
+	if e.archiveStore != nil {
+		unresolved := make([]string, 0, len(ids))
+		for _, id := range ids {
+			if machines[id] == "" {
+				unresolved = append(unresolved, id)
+			}
+		}
+		if len(unresolved) > 0 {
+			replacementMachines, err := e.db.ListSessionMachinesByID(
+				ctx, unresolved,
+			)
+			if err != nil {
+				return batch, fmt.Errorf(
+					"load replacement session machines: %w", err,
+				)
+			}
+			for id, machine := range replacementMachines {
+				if machine != "" {
+					machines[id] = machine
+				}
+			}
+		}
+	}
 	for _, id := range ids {
 		machine := machines[id]
 		if machine == "" {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -646,10 +646,10 @@ func (e *Engine) machineForProviderSource(
 // under, so a root that has since been relabeled still needs its older machine
 // queried or its deletions would never be discovered.
 func (e *Engine) reconciliationOwnershipMachines(
-	agent parser.AgentType, roots []string,
+	agent parser.AgentType, roots []string, archiveMachines []string,
 ) []string {
-	seen := make(map[string]bool, len(roots)+1)
-	machines := make([]string, 0, len(roots)+1)
+	seen := make(map[string]bool, len(roots)+len(archiveMachines)+1)
+	machines := make([]string, 0, len(roots)+len(archiveMachines)+1)
 	add := func(machine string) {
 		if machine == "" || seen[machine] {
 			return
@@ -679,6 +679,13 @@ func (e *Engine) reconciliationOwnershipMachines(
 	// Unlabeled roots, and rows admitted before a label existed, are stored
 	// under the local machine, so it always stays in the query set.
 	add(e.machine)
+	// A label the user has since edited away is still stored on the rows it
+	// admitted, and is no longer derivable from configuration. The archive's
+	// own machine list is small and closes that gap; each entry still queries
+	// through the (machine, agent, file_path) ownership index.
+	for _, machine := range archiveMachines {
+		add(machine)
+	}
 	return machines
 }
 
@@ -1370,11 +1377,16 @@ func (e *Engine) expandOmnigentInheritedMetadataSources(
 	}
 	agent := provider.Definition().Type
 	seenSources := make(map[string]struct{}, len(sources))
-	parentIDs := make([]string, 0, len(sources))
 	seenParents := make(map[string]struct{}, len(sources))
+	// A descendant is stored under the machine its parent was admitted under,
+	// which is not necessarily the local one, so group the lookup by each
+	// parent's stored attribution instead of assuming e.machine.
+	parentsByMachine := make(map[string][]string, 1)
+	machineOrder := make([]string, 0, 1)
 	for _, source := range sources {
-		if path := providerDiscoveredPath(source); path != "" {
-			seenSources[path] = struct{}{}
+		sourcePath := providerDiscoveredPath(source)
+		if sourcePath != "" {
+			seenSources[sourcePath] = struct{}{}
 		}
 		rawID, found := parser.OmnigentMemberSessionID(source)
 		if !found {
@@ -1385,16 +1397,28 @@ func (e *Engine) expandOmnigentInheritedMetadataSources(
 			continue
 		}
 		seenParents[parentID] = struct{}{}
-		parentIDs = append(parentIDs, parentID)
+		machine := e.machineForProviderSource(agent, source, sourcePath)
+		if session, err := e.db.GetSession(ctx, parentID); err == nil &&
+			session != nil && session.Machine != "" {
+			machine = session.Machine
+		}
+		if _, exists := parentsByMachine[machine]; !exists {
+			machineOrder = append(machineOrder, machine)
+		}
+		parentsByMachine[machine] = append(parentsByMachine[machine], parentID)
 	}
-	if len(parentIDs) == 0 {
+	if len(machineOrder) == 0 {
 		return sources, nil
 	}
-	paths, err := e.db.ListActiveDescendantSessionSourcePaths(
-		ctx, e.machine, string(agent), parentIDs,
-	)
-	if err != nil {
-		return nil, err
+	var paths []string
+	for _, machine := range machineOrder {
+		machinePaths, err := e.db.ListActiveDescendantSessionSourcePaths(
+			ctx, machine, string(agent), parentsByMachine[machine],
+		)
+		if err != nil {
+			return nil, err
+		}
+		paths = append(paths, machinePaths...)
 	}
 	for _, path := range paths {
 		if _, exists := seenSources[path]; exists {
@@ -4767,6 +4791,12 @@ func (e *Engine) tombstoneMissingWatchSourceScopesLocked(
 		}
 		scopesByAgent[scope.agent] = append(scopesByAgent[scope.agent], scope)
 	}
+	// Read once per pass, not per scope: the list is bounded by how many
+	// machines the archive holds, which is independent of its session count.
+	archiveMachines, err := e.db.GetMachines(ctx, false, false)
+	if err != nil {
+		return 0, fmt.Errorf("list archive machines for watch reconciliation: %w", err)
+	}
 	for _, agent := range agents {
 		agentScopes := scopesByAgent[agent]
 		var provider parser.Provider
@@ -4787,7 +4817,9 @@ func (e *Engine) tombstoneMissingWatchSourceScopesLocked(
 			// A scope proves absence for its own roots, but a stored row carries
 			// the machine it was admitted under. Query every machine those roots
 			// can hold so a relabeled root still reconciles its older rows.
-			ownershipMachines := e.reconciliationOwnershipMachines(agent, scope.roots)
+			ownershipMachines := e.reconciliationOwnershipMachines(
+				agent, scope.roots, archiveMachines,
+			)
 			if len(ownershipMachines) == 0 {
 				continue
 			}
@@ -7242,7 +7274,7 @@ func (e *Engine) collectAndBatch(
 					continue
 				}
 				changed, err := e.tombstoneSessionSourceOwnership(
-					ctx, e.machine, string(r.agent),
+					ctx, member.machine, string(r.agent),
 					member.sessionID, member.filePath,
 				)
 				if err != nil {
@@ -13885,7 +13917,7 @@ func (e *Engine) SyncSingleSessionContext(
 				continue
 			}
 			if _, err := e.tombstoneSessionSourceOwnership(
-				ctx, e.machine, string(file.Agent),
+				ctx, member.machine, string(file.Agent),
 				member.sessionID, member.filePath,
 			); err != nil {
 				return fmt.Errorf(

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -10895,17 +10895,16 @@ func (e *Engine) normalizePendingWriteMachines(
 					"load replacement session machines: %w", err,
 				)
 			}
-			for id, machine := range replacementMachines {
-				machines[id] = machine
-			}
+			maps.Copy(machines, replacementMachines)
 		}
 	}
 	for _, id := range ids {
 		machine, exists := machines[id]
-		if !exists {
-			machine = batch[indexes[id][0]].sess.Machine
-		}
 		for _, i := range indexes[id] {
+			if !exists {
+				machine = batch[i].sess.Machine
+				exists = true
+			}
 			batch[i].sess.Machine = machine
 		}
 	}
@@ -11023,7 +11022,7 @@ func (e *Engine) preserveUnavailableSourceProjects(
 		}
 		sess := batch[i].sess
 		if sess.ID == "" || sess.Cwd == "" ||
-			sess.Machine != e.machine ||
+			!e.isLocalMachineAttribution(sess.Machine) ||
 			!safeLocalAbsolutePath(sess.Cwd) ||
 			export.IsAutomountNamespacePath(runtime.GOOS, filepath.Clean(sess.Cwd)) {
 			batch[i].sourceProjectResolved = true
@@ -11076,6 +11075,12 @@ func (e *Engine) preserveUnavailableSourceProjects(
 		}
 	}
 	return batch, nil
+}
+
+// isLocalMachineAttribution recognizes the legacy "local" sentinel as this
+// machine without rewriting the immutable value stored with the session.
+func (e *Engine) isLocalMachineAttribution(machine string) bool {
+	return machine == "local" || machine == e.machine
 }
 
 func pathContains(root, path string) bool {
@@ -12263,7 +12268,8 @@ func (e *Engine) cachedProjectIdentity(machine, rootPath string) projectIdentity
 	// wakes the /home automounter — with tens of thousands of remote
 	// sessions and a one-minute cache TTL that becomes a sustained
 	// automountd/opendirectoryd CPU storm.
-	if e.idPrefix == "" && e.pathRewriter == nil && machine == e.machine {
+	if e.idPrefix == "" && e.pathRewriter == nil &&
+		e.isLocalMachineAttribution(machine) {
 		if normalized, ok, err := export.NormalizeRootPath(rootPath); err == nil && ok {
 			identity.rootPath = normalized
 		}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -360,8 +360,8 @@ type Engine struct {
 	// writeBatchOverride is a test seam for exercising reconciliation archive
 	// write failures after discovery and parse have succeeded.
 	writeBatchOverride func([]pendingWrite, syncWriteMode, bool) (int, int, int, int)
-	// sourceAttributionLookupOverride observes or replaces the bounded source
-	// attribution query in DB-backed sync tests.
+	// sourceAttributionLookupOverride observes or replaces bounded source
+	// attribution queries in sync tests.
 	sourceAttributionLookupOverride func(
 		context.Context, []db.SessionSourcePath,
 	) ([]db.SessionSourceAttribution, error)
@@ -4045,6 +4045,13 @@ func (e *Engine) baselineReconciliationCandidates(
 			},
 		})
 	}
+	var err error
+	sources, admitted, err = e.expandSourceBaselinesByStoredAttribution(
+		ctx, sources, admitted,
+	)
+	if err != nil {
+		return fmt.Errorf("load reconciliation source attributions: %w", err)
+	}
 	if err := e.replaceActiveSessionSourceBaselinesByMachine(
 		ctx, sources, admitted,
 	); err != nil {
@@ -6655,6 +6662,68 @@ func (e *Engine) listActiveSessionSourceAttributions(
 	return e.db.ListActiveSessionSourceAttributions(ctx, sources)
 }
 
+// expandSourceBaselinesByStoredAttribution applies one source-level admission
+// decision to every immutable machine currently represented at that source.
+// This is for no-write outcomes, where there is no normalized pending session
+// to carry the stored machine through baseline replacement.
+func (e *Engine) expandSourceBaselinesByStoredAttribution(
+	ctx context.Context,
+	candidates []machineSessionSource,
+	admitted []machineSessionSource,
+) ([]machineSessionSource, []machineSessionSource, error) {
+	requestedSet := make(map[db.SessionSourcePath]struct{}, len(candidates))
+	requested := make([]db.SessionSourcePath, 0, len(candidates))
+	candidateSet := make(map[machineSessionSource]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		candidateSet[candidate] = struct{}{}
+		if candidate.Source.Agent == "" || candidate.Source.FilePath == "" {
+			continue
+		}
+		if _, exists := requestedSet[candidate.Source]; exists {
+			continue
+		}
+		requestedSet[candidate.Source] = struct{}{}
+		requested = append(requested, candidate.Source)
+	}
+	if len(requested) == 0 {
+		return candidates, admitted, nil
+	}
+
+	admittedSources := make(map[db.SessionSourcePath]struct{}, len(admitted))
+	admittedSet := make(map[machineSessionSource]struct{}, len(admitted))
+	for _, source := range admitted {
+		admittedSources[source.Source] = struct{}{}
+		admittedSet[source] = struct{}{}
+	}
+	attributions, err := e.listActiveSessionSourceAttributions(ctx, requested)
+	if err != nil {
+		return candidates, admitted, err
+	}
+	for _, attribution := range attributions {
+		source := machineSessionSource{
+			Machine: attribution.Machine,
+			Source: db.SessionSourcePath{
+				Agent: attribution.Agent, FilePath: attribution.FilePath,
+			},
+		}
+		if _, requested := requestedSet[source.Source]; !requested {
+			continue
+		}
+		if _, exists := candidateSet[source]; !exists {
+			candidateSet[source] = struct{}{}
+			candidates = append(candidates, source)
+		}
+		if _, sourceAdmitted := admittedSources[source.Source]; !sourceAdmitted {
+			continue
+		}
+		if _, exists := admittedSet[source]; !exists {
+			admittedSet[source] = struct{}{}
+			admitted = append(admitted, source)
+		}
+	}
+	return candidates, admitted, nil
+}
+
 // syncProviderDBBacked enumerates a DB-backed provider's sources, parses only
 // the changed ones through the provider facade, and flushes each source before
 // parsing the next. Change detection compares the provider fingerprint mtime
@@ -7114,9 +7183,16 @@ func (e *Engine) collectAndBatch(
 			}
 			delete(baselineCacheWrites, source)
 		}
-		if err := e.replaceActiveSessionSourceBaselinesByMachine(
-			ctx, baselineCandidates, baselineAdmitted,
-		); err != nil {
+		resolvedCandidates, resolvedAdmitted, err :=
+			e.expandSourceBaselinesByStoredAttribution(
+				ctx, baselineCandidates, baselineAdmitted,
+			)
+		if err == nil {
+			err = e.replaceActiveSessionSourceBaselinesByMachine(
+				ctx, resolvedCandidates, resolvedAdmitted,
+			)
+		}
+		if err != nil {
 			log.Printf("replace successful non-write source baselines: %v", err)
 			stats.RecordFailed()
 			e.poisonSQLiteContainerPass()

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -689,6 +689,30 @@ func (e *Engine) reconciliationOwnershipMachines(
 	return machines
 }
 
+// storedSourceMachine returns the machine an already-ingested session at path
+// was admitted under, or "" when the archive holds none. Attribution is
+// immutable, so a stored row outranks the configured label whenever the two
+// disagree. It short-circuits unless the agent actually has labeled roots, so
+// the common unlabeled setup adds no per-source queries.
+func (e *Engine) storedSourceMachine(
+	agent parser.AgentType, path string,
+) string {
+	if len(e.sourceMachines[agent]) == 0 || path == "" {
+		return ""
+	}
+	ids, err := e.db.ListSessionIDsByFilePath(path, string(agent))
+	if err != nil {
+		return ""
+	}
+	for _, id := range ids {
+		session, err := e.db.GetSession(context.Background(), id)
+		if err == nil && session != nil && session.Machine != "" {
+			return session.Machine
+		}
+	}
+	return ""
+}
+
 func pathWithinRoot(path, root string) bool {
 	root = filepath.Clean(root)
 	rel, err := filepath.Rel(root, path)
@@ -4501,6 +4525,7 @@ func (e *Engine) rehydrateReconciliationPage(
 				files = append(files, parser.DiscoveredFile{
 					Path: candidate.Path, Project: source.ProjectHint,
 					Agent: candidate.Provider, ForceParse: forceCandidate,
+					Machine:        candidate.Machine,
 					ProviderSource: &source, ProviderProcess: true,
 				})
 				continue
@@ -4527,6 +4552,10 @@ func (e *Engine) rehydrateReconciliationPage(
 		files = append(files, parser.DiscoveredFile{
 			Path: candidate.Path, Project: source.ProjectHint,
 			Agent: candidate.Provider, ForceParse: forceCandidate,
+			// Carry the candidate's stored attribution: recomputing it from the
+			// physical path is wrong for providers whose source can sit outside
+			// the labeled root it was configured under.
+			Machine:        candidate.Machine,
 			ProviderSource: &source, ProviderProcess: true,
 		})
 	}
@@ -6656,10 +6685,17 @@ func (e *Engine) syncProviderDBBacked(
 		if path == "" {
 			return nil
 		}
+		storedPath := e.effectiveSourcePath(path)
+		machine := e.machineForProviderSource(agent, source, path)
+		// An already-ingested session keeps the label it was admitted under,
+		// so the baseline must follow the row rather than current config.
+		if stored := e.storedSourceMachine(agent, storedPath); stored != "" {
+			machine = stored
+		}
 		baselines = append(baselines, machineSessionSource{
-			Machine: e.machineForProviderSource(agent, source, path),
+			Machine: machine,
 			Source: db.SessionSourcePath{
-				Agent: string(agent), FilePath: e.effectiveSourcePath(path),
+				Agent: string(agent), FilePath: storedPath,
 			},
 		})
 		if len(baselines) == reconciliationPageSize {
@@ -7463,8 +7499,14 @@ func (e *Engine) baselinePendingWriteSources(
 	)
 	for i, write := range pending {
 		path := e.effectiveSourcePath(write.sess.File.Path)
+		// Key on what was persisted, not on what the parser proposed: an
+		// already-ingested session keeps its original label through a relabel.
+		machine := write.persistedMachine
+		if machine == "" {
+			machine = write.sess.Machine
+		}
 		source := machineSessionSource{
-			Machine: write.sess.Machine,
+			Machine: machine,
 			Source: db.SessionSourcePath{
 				Agent: string(write.sess.Agent), FilePath: path,
 			},
@@ -10663,6 +10705,12 @@ type pendingWrite struct {
 	// baselineEligible is set by collectAndBatch only when the complete source
 	// outcome is safe to make deletion-eligible after this write succeeds.
 	baselineEligible bool
+	// persistedMachine is the machine the session was actually written under.
+	// prepareSessionWrite preserves an existing archive row's attribution, so
+	// after a label edit this differs from sess.Machine. Ownership baselines
+	// must key on it or they land under a machine no session row holds, and
+	// the source can never be tombstoned when it later disappears.
+	persistedMachine string
 	// storageTrustPath/State/Snap promote the session's OpenCode
 	// storage-gate trust after its batch is confirmed fully written.
 	// Empty for everything else.
@@ -10912,6 +10960,7 @@ func (e *Engine) writeBatchWithOutcome(
 			}
 			continue
 		}
+		batch[i].persistedMachine = s.Machine
 
 		// Detect stale parser version BEFORE UpsertSession
 		// overwrites it. Existing message rows from an
@@ -11887,6 +11936,7 @@ func (e *Engine) writeBatchBulkWithOutcome(
 			}
 			continue
 		}
+		batch[pendingIndex].persistedMachine = s.Machine
 		replaceMessages := shouldReplaceFullParseMessages(
 			pw, forceReplace, false, false,
 		)

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -360,6 +360,11 @@ type Engine struct {
 	// writeBatchOverride is a test seam for exercising reconciliation archive
 	// write failures after discovery and parse have succeeded.
 	writeBatchOverride func([]pendingWrite, syncWriteMode, bool) (int, int, int, int)
+	// sourceAttributionLookupOverride observes or replaces the bounded source
+	// attribution query in DB-backed sync tests.
+	sourceAttributionLookupOverride func(
+		context.Context, []db.SessionSourcePath,
+	) ([]db.SessionSourceAttribution, error)
 	// workerCountOverride is a test seam for exercising the production worker
 	// floor and cap independently of the host CPU count.
 	workerCountOverride  int
@@ -687,30 +692,6 @@ func (e *Engine) reconciliationOwnershipMachines(
 		add(machine)
 	}
 	return machines
-}
-
-// storedSourceMachine returns the machine an already-ingested session at path
-// was admitted under, or "" when the archive holds none. Attribution is
-// immutable, so a stored row outranks the configured label whenever the two
-// disagree. It short-circuits unless the agent actually has labeled roots, so
-// the common unlabeled setup adds no per-source queries.
-func (e *Engine) storedSourceMachine(
-	agent parser.AgentType, path string,
-) string {
-	if len(e.sourceMachines[agent]) == 0 || path == "" {
-		return ""
-	}
-	ids, err := e.db.ListSessionIDsByFilePath(path, string(agent))
-	if err != nil {
-		return ""
-	}
-	for _, id := range ids {
-		session, err := e.db.GetSession(context.Background(), id)
-		if err == nil && session != nil && session.Machine != "" {
-			return session.Machine
-		}
-	}
-	return ""
 }
 
 func pathWithinRoot(path, root string) bool {
@@ -4098,21 +4079,49 @@ func (e *Engine) replaceActiveSessionSourceBaselinesByMachine(
 	candidates []machineSessionSource,
 	admitted []machineSessionSource,
 ) error {
-	candidatesByMachine := make(map[string][]db.SessionSourcePath)
-	admittedByMachine := make(map[string][]db.SessionSourcePath)
+	candidatesByMachine := make(map[string]map[db.SessionSourcePath]struct{})
+	admittedByMachine := make(map[string]map[db.SessionSourcePath]struct{})
+	add := func(
+		byMachine map[string]map[db.SessionSourcePath]struct{},
+		source machineSessionSource,
+	) {
+		if source.Machine == "" ||
+			source.Source.Agent == "" || source.Source.FilePath == "" {
+			return
+		}
+		if byMachine[source.Machine] == nil {
+			byMachine[source.Machine] = make(map[db.SessionSourcePath]struct{})
+		}
+		byMachine[source.Machine][source.Source] = struct{}{}
+	}
 	for _, source := range candidates {
-		candidatesByMachine[source.Machine] = append(
-			candidatesByMachine[source.Machine], source.Source,
-		)
+		add(candidatesByMachine, source)
 	}
 	for _, source := range admitted {
-		admittedByMachine[source.Machine] = append(
-			admittedByMachine[source.Machine], source.Source,
-		)
+		add(admittedByMachine, source)
+		// An admitted source may carry immutable attribution that differs from
+		// the currently configured candidate. Make it a candidate under its own
+		// machine so replacement visits that machine as well.
+		add(candidatesByMachine, source)
 	}
-	for machine, sources := range candidatesByMachine {
+	machines := make([]string, 0, len(candidatesByMachine))
+	for machine := range candidatesByMachine {
+		machines = append(machines, machine)
+	}
+	slices.Sort(machines)
+	for _, machine := range machines {
+		sources := make([]db.SessionSourcePath, 0, len(candidatesByMachine[machine]))
+		for source := range candidatesByMachine[machine] {
+			sources = append(sources, source)
+		}
+		admittedSources := make(
+			[]db.SessionSourcePath, 0, len(admittedByMachine[machine]),
+		)
+		for source := range admittedByMachine[machine] {
+			admittedSources = append(admittedSources, source)
+		}
 		if err := e.db.ReplaceActiveSessionSourceBaselines(
-			ctx, machine, sources, admittedByMachine[machine],
+			ctx, machine, sources, admittedSources,
 		); err != nil {
 			return err
 		}
@@ -6636,6 +6645,16 @@ func shelleyDBCompositeMtime(dbPath string) (int64, error) {
 	return maxMtime, nil
 }
 
+func (e *Engine) listActiveSessionSourceAttributions(
+	ctx context.Context,
+	sources []db.SessionSourcePath,
+) ([]db.SessionSourceAttribution, error) {
+	if e.sourceAttributionLookupOverride != nil {
+		return e.sourceAttributionLookupOverride(ctx, sources)
+	}
+	return e.db.ListActiveSessionSourceAttributions(ctx, sources)
+}
+
 // syncProviderDBBacked enumerates a DB-backed provider's sources, parses only
 // the changed ones through the provider facade, and flushes each source before
 // parsing the next. Change detection compares the provider fingerprint mtime
@@ -6672,8 +6691,27 @@ func (e *Engine) syncProviderDBBacked(
 		if len(baselines) == 0 {
 			return nil
 		}
+		sources := make([]db.SessionSourcePath, 0, len(baselines))
+		for _, candidate := range baselines {
+			sources = append(sources, candidate.Source)
+		}
+		attributions, err := e.listActiveSessionSourceAttributions(ctx, sources)
+		if err != nil {
+			return fmt.Errorf(
+				"load %s streaming source attributions: %w", agent, err,
+			)
+		}
+		admitted := make([]machineSessionSource, 0, len(attributions))
+		for _, attribution := range attributions {
+			admitted = append(admitted, machineSessionSource{
+				Machine: attribution.Machine,
+				Source: db.SessionSourcePath{
+					Agent: attribution.Agent, FilePath: attribution.FilePath,
+				},
+			})
+		}
 		if err := e.replaceActiveSessionSourceBaselinesByMachine(
-			ctx, baselines, baselines,
+			ctx, baselines, admitted,
 		); err != nil {
 			return fmt.Errorf("baseline %s streaming sources: %w", agent, err)
 		}
@@ -6687,11 +6725,6 @@ func (e *Engine) syncProviderDBBacked(
 		}
 		storedPath := e.effectiveSourcePath(path)
 		machine := e.machineForProviderSource(agent, source, path)
-		// An already-ingested session keeps the label it was admitted under,
-		// so the baseline must follow the row rather than current config.
-		if stored := e.storedSourceMachine(agent, storedPath); stored != "" {
-			machine = stored
-		}
 		baselines = append(baselines, machineSessionSource{
 			Machine: machine,
 			Source: db.SessionSourcePath{
@@ -7412,7 +7445,9 @@ func (e *Engine) collectAndBatch(
 			}
 			stats.RecordSynced(1)
 			if r.providerFailureCount == 0 {
-				baselineProcessedSource(r, true)
+				baselineJob := r
+				baselineJob.machine = r.incremental.machine
+				baselineProcessedSource(baselineJob, true)
 			}
 			progress.MessagesIndexed += len(
 				r.incremental.msgs,
@@ -7499,14 +7534,8 @@ func (e *Engine) baselinePendingWriteSources(
 	)
 	for i, write := range pending {
 		path := e.effectiveSourcePath(write.sess.File.Path)
-		// Key on what was persisted, not on what the parser proposed: an
-		// already-ingested session keeps its original label through a relabel.
-		machine := write.persistedMachine
-		if machine == "" {
-			machine = write.sess.Machine
-		}
 		source := machineSessionSource{
-			Machine: machine,
+			Machine: write.sess.Machine,
 			Source: db.SessionSourcePath{
 				Agent: string(write.sess.Agent), FilePath: path,
 			},
@@ -10705,18 +10734,67 @@ type pendingWrite struct {
 	// baselineEligible is set by collectAndBatch only when the complete source
 	// outcome is safe to make deletion-eligible after this write succeeds.
 	baselineEligible bool
-	// persistedMachine is the machine the session was actually written under.
-	// prepareSessionWrite preserves an existing archive row's attribution, so
-	// after a label edit this differs from sess.Machine. Ownership baselines
-	// must key on it or they land under a machine no session row holds, and
-	// the source can never be tombstoned when it later disappears.
-	persistedMachine string
 	// storageTrustPath/State/Snap promote the session's OpenCode
 	// storage-gate trust after its batch is confirmed fully written.
 	// Empty for everything else.
 	storageTrustPath  string
 	storageTrustState string
 	storageTrustSnap  storageTrustSnapshot
+}
+
+type sessionMachineReader interface {
+	ListSessionMachinesByID(
+		context.Context, []string,
+	) (map[string]string, error)
+}
+
+// normalizePendingWriteMachines resolves immutable attribution before any
+// consumer can make a project, worktree, baseline, or persistence decision.
+// Existing sessions keep the archive's machine; first ingestions retain the
+// configured machine already stamped by discovery and parsing.
+func (e *Engine) normalizePendingWriteMachines(
+	ctx context.Context,
+	batch []pendingWrite,
+) ([]pendingWrite, error) {
+	indexes := make(map[string][]int, len(batch))
+	ids := make([]string, 0, len(batch))
+	for i := range batch {
+		if batch[i].sess.ID == "" {
+			continue
+		}
+		id := applyIDPrefixToID(e.idPrefix, batch[i].sess.ID)
+		if _, exists := indexes[id]; !exists {
+			ids = append(ids, id)
+		}
+		indexes[id] = append(indexes[id], i)
+	}
+	if len(ids) == 0 {
+		return batch, nil
+	}
+
+	var archive any = e.db
+	if e.archiveStore != nil {
+		archive = e.archiveStore
+	}
+	reader, ok := archive.(sessionMachineReader)
+	if !ok {
+		return batch, fmt.Errorf(
+			"archive %T does not support session machine lookup", archive,
+		)
+	}
+	machines, err := reader.ListSessionMachinesByID(ctx, ids)
+	if err != nil {
+		return batch, fmt.Errorf("load immutable session machines: %w", err)
+	}
+	for id, machine := range machines {
+		if machine == "" {
+			continue
+		}
+		for _, i := range indexes[id] {
+			batch[i].sess.Machine = machine
+		}
+	}
+	return batch, nil
 }
 
 type writeBatchOutcome struct {
@@ -10932,6 +11010,18 @@ func (e *Engine) writeBatchWithOutcome(
 	forceReplace bool,
 ) writeBatchOutcome {
 	var err error
+	batch, err = e.normalizePendingWriteMachines(
+		context.Background(), batch,
+	)
+	if err != nil {
+		log.Printf("normalize pending write machines: %v", err)
+		outcome := writeBatchOutcome{written: make([]bool, len(batch))}
+		for _, pw := range batch {
+			e.markStaleFailedMemberWrite(pw)
+		}
+		outcome.failedSessions = len(batch)
+		return outcome
+	}
 	batch, err = e.preserveUnavailableSourceProjects(
 		context.Background(), batch,
 	)
@@ -10960,8 +11050,6 @@ func (e *Engine) writeBatchWithOutcome(
 			}
 			continue
 		}
-		batch[i].persistedMachine = s.Machine
-
 		// Detect stale parser version BEFORE UpsertSession
 		// overwrites it. Existing message rows from an
 		// older parser lack new metadata columns, and newly
@@ -11097,20 +11185,6 @@ func (e *Engine) prepareSessionWrite(
 		pw.sess.CountsAuthoritative,
 	)
 	e.applyRemoteRewrites(&s, msgs)
-	// Machine attribution is assigned when a session is first ingested.
-	// Ordinary reparses and appends must not rewrite it when configuration
-	// changes. During a rebuild, archiveStore points at the original archive
-	// while e.db is the fresh replacement, so the same rule survives sync
-	// --full without a second reattribution pass.
-	archive := e.archiveStore
-	if archive == nil {
-		archive = e.db
-	}
-	if stored, err := archive.GetSessionFull(
-		context.Background(), s.ID,
-	); err == nil && stored != nil && stored.Machine != "" {
-		s.Machine = stored.Machine
-	}
 	if s.Cwd != "" && resolveWorktreeProject != nil {
 		if mapped, ok := resolveWorktreeProject(
 			s.Machine, s.Cwd, s.Project,
@@ -11936,7 +12010,6 @@ func (e *Engine) writeBatchBulkWithOutcome(
 			}
 			continue
 		}
-		batch[pendingIndex].persistedMachine = s.Machine
 		replaceMessages := shouldReplaceFullParseMessages(
 			pw, forceReplace, false, false,
 		)
@@ -12639,8 +12712,14 @@ func (e *Engine) writeSessionFullWithResolver(
 	pw pendingWrite,
 	resolveWorktreeProject worktreeProjectResolver,
 ) error {
-	preserved, err := e.preserveUnavailableSourceProjects(
+	normalized, err := e.normalizePendingWriteMachines(
 		context.Background(), []pendingWrite{pw},
+	)
+	if err != nil {
+		return err
+	}
+	preserved, err := e.preserveUnavailableSourceProjects(
+		context.Background(), normalized,
 	)
 	if err != nil {
 		return err

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -65,13 +65,18 @@ type passEpilogueEligibility struct {
 }
 
 type reconciliationBaselineTracker struct {
-	sources     map[db.SessionSourcePath]struct{}
+	sources     map[machineSessionSource]struct{}
 	cacheWrites map[string]skipCacheWrite
+}
+
+type machineSessionSource struct {
+	Machine string
+	Source  db.SessionSourcePath
 }
 
 func newReconciliationBaselineTracker() *reconciliationBaselineTracker {
 	return &reconciliationBaselineTracker{
-		sources:     make(map[db.SessionSourcePath]struct{}, reconciliationPageSize),
+		sources:     make(map[machineSessionSource]struct{}, reconciliationPageSize),
 		cacheWrites: make(map[string]skipCacheWrite),
 	}
 }
@@ -109,16 +114,17 @@ func reconciliationBaselineTrackerFor(
 }
 
 func (tracker *reconciliationBaselineTracker) add(
-	source db.SessionSourcePath,
+	source machineSessionSource,
 ) {
-	if source.Agent == "" || source.FilePath == "" {
+	if source.Machine == "" ||
+		source.Source.Agent == "" || source.Source.FilePath == "" {
 		return
 	}
 	tracker.sources[source] = struct{}{}
 }
 
-func (tracker *reconciliationBaselineTracker) list() []db.SessionSourcePath {
-	sources := make([]db.SessionSourcePath, 0, len(tracker.sources))
+func (tracker *reconciliationBaselineTracker) list() []machineSessionSource {
+	sources := make([]machineSessionSource, 0, len(tracker.sources))
 	for source := range tracker.sources {
 		sources = append(sources, source)
 	}
@@ -249,6 +255,7 @@ type Emitter interface {
 // engine, replacing per-agent positional parameters.
 type EngineConfig struct {
 	AgentDirs               map[parser.AgentType][]string
+	SourceMachines          map[parser.AgentType]map[string]string
 	Machine                 string
 	BlockedResultCategories []string
 	// IncludeCwdPrefixes, when non-empty, restricts ingestion to
@@ -302,6 +309,7 @@ type Engine struct {
 	// e.db points at the fresh one; nil means e.db is the archive.
 	archiveStore            db.Store
 	agentDirs               map[parser.AgentType][]string
+	sourceMachines          map[parser.AgentType]map[string]string
 	machine                 string
 	blockedResultCategories map[string]bool
 	cwdFilter               cwdPrefixFilter
@@ -520,6 +528,10 @@ func NewEngine(
 	for k, v := range cfg.AgentDirs {
 		dirs[k] = append([]string(nil), v...)
 	}
+	sourceMachines := make(map[parser.AgentType]map[string]string, len(cfg.SourceMachines))
+	for agent, roots := range cfg.SourceMachines {
+		sourceMachines[agent] = maps.Clone(roots)
+	}
 	providerFactories := parser.ProviderFactories()
 	if cfg.ProviderFactories != nil {
 		providerFactories = cfg.ProviderFactories
@@ -534,6 +546,7 @@ func NewEngine(
 		stat:                    os.Stat,
 		lstat:                   os.Lstat,
 		agentDirs:               dirs,
+		sourceMachines:          sourceMachines,
 		machine:                 cfg.Machine,
 		blockedResultCategories: blockedCategorySet(cfg.BlockedResultCategories),
 		cwdFilter:               newCwdPrefixFilter(cfg.IncludeCwdPrefixes),
@@ -586,6 +599,96 @@ func NewEngine(
 		},
 	)
 	return e
+}
+
+func (e *Engine) machineForPath(agent parser.AgentType, path string) string {
+	if machine, ok := e.configuredMachineForPath(agent, path); ok {
+		return machine
+	}
+	return e.machine
+}
+
+func (e *Engine) configuredMachineForPath(
+	agent parser.AgentType, path string,
+) (string, bool) {
+	path = filepath.Clean(path)
+	bestRoot := ""
+	machine := ""
+	for root, candidate := range e.sourceMachines[agent] {
+		cleanRoot := filepath.Clean(root)
+		if !pathWithinRoot(path, cleanRoot) || len(cleanRoot) <= len(bestRoot) {
+			continue
+		}
+		bestRoot = cleanRoot
+		machine = candidate
+	}
+	return machine, bestRoot != ""
+}
+
+func (e *Engine) machineForFile(file parser.DiscoveredFile) string {
+	if file.Machine != "" {
+		return file.Machine
+	}
+	return e.machineForPath(file.Agent, file.Path)
+}
+
+func (e *Engine) machineForProviderSource(
+	agent parser.AgentType, source parser.SourceRef, fallbackPath string,
+) string {
+	if source.ConfiguredRoot != "" {
+		return e.machineForPath(agent, source.ConfiguredRoot)
+	}
+	return e.machineForPath(agent, fallbackPath)
+}
+
+// reconciliationOwnershipMachines returns the distinct machines whose stored
+// ownership rows can fall inside roots. A row keeps the machine it was admitted
+// under, so a root that has since been relabeled still needs its older machine
+// queried or its deletions would never be discovered.
+func (e *Engine) reconciliationOwnershipMachines(
+	agent parser.AgentType, roots []string,
+) []string {
+	seen := make(map[string]bool, len(roots)+1)
+	machines := make([]string, 0, len(roots)+1)
+	add := func(machine string) {
+		if machine == "" || seen[machine] {
+			return
+		}
+		seen[machine] = true
+		machines = append(machines, machine)
+	}
+	configured := make([]string, 0, len(e.sourceMachines[agent]))
+	for root := range e.sourceMachines[agent] {
+		configured = append(configured, root)
+	}
+	// Map iteration is unordered; sort so the query sequence is deterministic.
+	slices.Sort(configured)
+	for _, root := range roots {
+		clean := filepath.Clean(root)
+		add(e.machineForPath(agent, clean))
+		// A reconciliation scope is a watched directory, which may sit above
+		// (or below) the labeled root itself — a container file such as
+		// Hermes's state.db is configured directly but watched via its parent.
+		for _, cfg := range configured {
+			cleanCfg := filepath.Clean(cfg)
+			if pathWithinRoot(cleanCfg, clean) || pathWithinRoot(clean, cleanCfg) {
+				add(e.sourceMachines[agent][cfg])
+			}
+		}
+	}
+	// Unlabeled roots, and rows admitted before a label existed, are stored
+	// under the local machine, so it always stays in the query set.
+	add(e.machine)
+	return machines
+}
+
+func pathWithinRoot(path, root string) bool {
+	root = filepath.Clean(root)
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 // Close flushes any pending debounced signal recomputes and stops
@@ -831,6 +934,7 @@ type syncJob struct {
 	processResult
 	agent          parser.AgentType
 	path           string
+	machine        string
 	retentionLease *parseRetentionLease
 }
 
@@ -1024,6 +1128,9 @@ func mergeChangedPathDiscoveredFile(
 	current.ProviderProcess = current.ProviderProcess || next.ProviderProcess
 	if current.Project == "" {
 		current.Project = next.Project
+	}
+	if current.Machine == "" {
+		current.Machine = next.Machine
 	}
 	if current.ProviderSource == nil && next.ProviderSource != nil {
 		current.ProviderSource = next.ProviderSource
@@ -1229,6 +1336,11 @@ func (e *Engine) classifyProviderChangedPath(
 					ForceParse:      providerChangedPathForceParse(agent, sourcePath, path, eventKind, mode),
 					ProviderSource:  &sourceCopy,
 					ProviderProcess: mode == parser.ProviderMigrationProviderAuthoritative,
+				}
+				if !isS3SourcePath(sourcePath) {
+					discovered.Machine = e.machineForProviderSource(
+						agent, source, sourcePath,
+					)
 				}
 				// A watcher event names a concrete change even when the
 				// session's stat signature cannot see it (a same-size,
@@ -3892,17 +4004,20 @@ func (e *Engine) tombstoneCompletedReconciliationScopesLocked(
 func (e *Engine) baselineReconciliationCandidates(
 	ctx context.Context,
 	candidates []reconciliationCandidate,
-	admitted []db.SessionSourcePath,
+	admitted []machineSessionSource,
 ) error {
-	sources := make([]db.SessionSourcePath, 0, len(candidates))
+	sources := make([]machineSessionSource, 0, len(candidates))
 	for _, candidate := range candidates {
-		sources = append(sources, db.SessionSourcePath{
-			Agent:    string(candidate.Provider),
-			FilePath: e.effectiveSourcePath(candidate.Path),
+		sources = append(sources, machineSessionSource{
+			Machine: candidate.Machine,
+			Source: db.SessionSourcePath{
+				Agent:    string(candidate.Provider),
+				FilePath: e.effectiveSourcePath(candidate.Path),
+			},
 		})
 	}
-	if err := e.db.ReplaceActiveSessionSourceBaselines(
-		ctx, e.machine, sources, admitted,
+	if err := e.replaceActiveSessionSourceBaselinesByMachine(
+		ctx, sources, admitted,
 	); err != nil {
 		return fmt.Errorf("reconcile source baseline page: %w", err)
 	}
@@ -3911,9 +4026,9 @@ func (e *Engine) baselineReconciliationCandidates(
 
 func eligibleReconciliationBaselines(
 	candidates []reconciliationCandidate,
-	admitted []db.SessionSourcePath,
+	admitted []machineSessionSource,
 	eligibleProviders map[parser.AgentType]struct{},
-) ([]reconciliationCandidate, []db.SessionSourcePath) {
+) ([]reconciliationCandidate, []machineSessionSource) {
 	eligibleCandidates := make([]reconciliationCandidate, 0, len(candidates))
 	for _, candidate := range candidates {
 		if _, eligible := eligibleProviders[candidate.Provider]; !eligible {
@@ -3921,13 +4036,40 @@ func eligibleReconciliationBaselines(
 		}
 		eligibleCandidates = append(eligibleCandidates, candidate)
 	}
-	eligibleAdmitted := make([]db.SessionSourcePath, 0, len(admitted))
+	eligibleAdmitted := make([]machineSessionSource, 0, len(admitted))
 	for _, source := range admitted {
-		if _, eligible := eligibleProviders[parser.AgentType(source.Agent)]; eligible {
+		if _, eligible := eligibleProviders[parser.AgentType(source.Source.Agent)]; eligible {
 			eligibleAdmitted = append(eligibleAdmitted, source)
 		}
 	}
 	return eligibleCandidates, eligibleAdmitted
+}
+
+func (e *Engine) replaceActiveSessionSourceBaselinesByMachine(
+	ctx context.Context,
+	candidates []machineSessionSource,
+	admitted []machineSessionSource,
+) error {
+	candidatesByMachine := make(map[string][]db.SessionSourcePath)
+	admittedByMachine := make(map[string][]db.SessionSourcePath)
+	for _, source := range candidates {
+		candidatesByMachine[source.Machine] = append(
+			candidatesByMachine[source.Machine], source.Source,
+		)
+	}
+	for _, source := range admitted {
+		admittedByMachine[source.Machine] = append(
+			admittedByMachine[source.Machine], source.Source,
+		)
+	}
+	for machine, sources := range candidatesByMachine {
+		if err := e.db.ReplaceActiveSessionSourceBaselines(
+			ctx, machine, sources, admittedByMachine[machine],
+		); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (e *Engine) streamReconciliationCandidates(
@@ -4247,6 +4389,7 @@ func (e *Engine) reconciliationCandidate(
 		StoredPath: canonicalReconciliationSourceIdentity(
 			e.effectiveSourcePath(path),
 		), MemberIdentity: source.ReconciliationIdentity, WatchRoot: root,
+		Machine: e.machineForProviderSource(agent, source, path),
 		Project: source.ProjectHint, Preference1: preference1,
 		Preference2: preference2, Preference3: preference3,
 	}, true
@@ -4641,13 +4784,22 @@ func (e *Engine) tombstoneMissingWatchSourceScopesLocked(
 			if len(ownershipScopes) == 0 {
 				continue
 			}
+			// A scope proves absence for its own roots, but a stored row carries
+			// the machine it was admitted under. Query every machine those roots
+			// can hold so a relabeled root still reconciles its older rows.
+			ownershipMachines := e.reconciliationOwnershipMachines(agent, scope.roots)
+			if len(ownershipMachines) == 0 {
+				continue
+			}
+			queryIndex := 0
 			var cursor db.SessionSourceCursor
-			for {
+			for queryIndex < len(ownershipMachines) {
+				ownershipMachine := ownershipMachines[queryIndex]
 				if err := ctx.Err(); err != nil {
 					return deleted, err
 				}
 				page, err := e.db.ListActiveSessionSourceOwnershipScopesPage(
-					ctx, e.machine, string(agent),
+					ctx, ownershipMachine, string(agent),
 					ownershipScopes, cursor,
 				)
 				if err != nil {
@@ -4656,7 +4808,9 @@ func (e *Engine) tombstoneMissingWatchSourceScopesLocked(
 					)
 				}
 				if len(page) == 0 {
-					break
+					queryIndex++
+					cursor = db.SessionSourceCursor{}
+					continue
 				}
 				missingByPath := make(map[string]bool, len(page))
 				for _, ownership := range page {
@@ -4954,7 +5108,8 @@ func (e *Engine) tombstoneMissingWatchSourceScopesLocked(
 				}
 				cursor = page[len(page)-1].Cursor()
 				if len(page) < db.WatchReconcileSourcePageSize {
-					break
+					queryIndex++
+					cursor = db.SessionSourceCursor{}
 				}
 			}
 		}
@@ -5573,6 +5728,11 @@ func (e *Engine) discoverProviderSources(
 				ProviderSource:  &sourceCopy,
 				ProviderProcess: true,
 			}
+			if !isS3SourcePath(sourcePath) {
+				discovered.Machine = e.machineForProviderSource(
+					agent, source, sourcePath,
+				)
+			}
 			if forceParseSource(sourcePath) {
 				discovered.ForceParse = true
 			}
@@ -5791,6 +5951,7 @@ func (e *Engine) expandCodexProviderDuplicates(
 			out = append(out, parser.DiscoveredFile{
 				Path:            dup,
 				Agent:           parser.AgentCodex,
+				Machine:         e.machineForPath(parser.AgentCodex, dup),
 				ProviderProcess: true,
 				ProviderSource:  e.codexPinnedProviderSource(dup),
 			})
@@ -6445,13 +6606,13 @@ func (e *Engine) syncProviderDBBacked(
 	if !ok || provider.Capabilities().Source.StreamingDiscovery != parser.CapabilitySupported {
 		return 0, 0, fmt.Errorf("sync %s: provider lacks streaming discovery", agent)
 	}
-	baselines := make([]db.SessionSourcePath, 0, reconciliationPageSize)
+	baselines := make([]machineSessionSource, 0, reconciliationPageSize)
 	flushBaselines := func() error {
 		if len(baselines) == 0 {
 			return nil
 		}
-		if err := e.db.BaselineActiveSessionSourcePaths(
-			ctx, e.machine, baselines,
+		if err := e.replaceActiveSessionSourceBaselinesByMachine(
+			ctx, baselines, baselines,
 		); err != nil {
 			return fmt.Errorf("baseline %s streaming sources: %w", agent, err)
 		}
@@ -6463,8 +6624,11 @@ func (e *Engine) syncProviderDBBacked(
 		if path == "" {
 			return nil
 		}
-		baselines = append(baselines, db.SessionSourcePath{
-			Agent: string(agent), FilePath: e.effectiveSourcePath(path),
+		baselines = append(baselines, machineSessionSource{
+			Machine: e.machineForProviderSource(agent, source, path),
+			Source: db.SessionSourcePath{
+				Agent: string(agent), FilePath: e.effectiveSourcePath(path),
+			},
 		})
 		if len(baselines) == reconciliationPageSize {
 			return flushBaselines()
@@ -6481,13 +6645,16 @@ func (e *Engine) syncProviderDBBacked(
 			sourceFailures++
 			return nil
 		}
+		machine := e.machineForProviderSource(
+			agent, source, providerDiscoveredPath(source),
+		)
 		if e.providerDBBackedSourceFresh(source, fingerprint) {
 			return queueBaseline(source)
 		}
 		outcome, err := provider.Parse(ctx, parser.ParseRequest{
 			Source:      source,
 			Fingerprint: fingerprint,
-			Machine:     e.machine,
+			Machine:     machine,
 		})
 		if err != nil {
 			log.Printf("sync %s parse: %v", agent, err)
@@ -6711,8 +6878,9 @@ func (e *Engine) startWorkers(
 						processResult: processResult{
 							err: ctx.Err(),
 						},
-						agent: file.Agent,
-						path:  file.Path,
+						agent:   file.Agent,
+						path:    file.Path,
+						machine: e.machineForFile(file),
 					})
 					continue
 				}
@@ -6721,6 +6889,7 @@ func (e *Engine) startWorkers(
 					processResult:  result,
 					agent:          file.Agent,
 					path:           file.Path,
+					machine:        e.machineForFile(file),
 					retentionLease: result.retentionLease,
 				})
 			}
@@ -6801,7 +6970,7 @@ func (e *Engine) collectAndBatch(
 	var pendingLeases []*parseRetentionLease
 	var pendingCacheWrites []skipCacheWrite
 	baselineCacheWrites := make(
-		map[db.SessionSourcePath]map[string]skipCacheWrite,
+		map[machineSessionSource]map[string]skipCacheWrite,
 	)
 	// Size baseline bookkeeping by the batch, capped at one flush page:
 	// a single-path watcher sync must not pay for page-sized structures
@@ -6809,15 +6978,19 @@ func (e *Engine) collectAndBatch(
 	// Appends and map inserts still grow past the hint when providers
 	// fan one changed file out to multiple sessions.
 	baselineHint := min(total, reconciliationPageSize)
-	baselineCandidates := make([]db.SessionSourcePath, 0, baselineHint)
-	baselineAdmitted := make([]db.SessionSourcePath, 0, baselineHint)
-	baselineAdmission := make(map[db.SessionSourcePath]bool, baselineHint)
+	baselineCandidates := make([]machineSessionSource, 0, baselineHint)
+	baselineAdmitted := make([]machineSessionSource, 0, baselineHint)
+	baselineAdmission := make(map[machineSessionSource]bool, baselineHint)
 	runtimeMetrics := reconciliationRuntimeMetricsFor(ctx)
-	baselineSourceForJob := func(job syncJob) (db.SessionSourcePath, bool) {
-		source := db.SessionSourcePath{
-			Agent: string(job.agent), FilePath: e.effectiveSourcePath(job.path),
+	baselineSourceForJob := func(job syncJob) (machineSessionSource, bool) {
+		source := machineSessionSource{
+			Machine: job.machine,
+			Source: db.SessionSourcePath{
+				Agent: string(job.agent), FilePath: e.effectiveSourcePath(job.path),
+			},
 		}
-		return source, source.Agent != "" && source.FilePath != ""
+		return source, source.Machine != "" &&
+			source.Source.Agent != "" && source.Source.FilePath != ""
 	}
 	flushBaselineSources := func() {
 		if len(baselineCandidates) == 0 {
@@ -6840,8 +7013,8 @@ func (e *Engine) collectAndBatch(
 			}
 			delete(baselineCacheWrites, source)
 		}
-		if err := e.db.ReplaceActiveSessionSourceBaselines(
-			ctx, e.machine, baselineCandidates, baselineAdmitted,
+		if err := e.replaceActiveSessionSourceBaselinesByMachine(
+			ctx, baselineCandidates, baselineAdmitted,
 		); err != nil {
 			log.Printf("replace successful non-write source baselines: %v", err)
 			stats.RecordFailed()
@@ -7253,15 +7426,19 @@ func (e *Engine) baselinePendingWriteSources(
 	ctx context.Context, pending []pendingWrite, written []bool,
 ) error {
 	eligible := make(
-		map[db.SessionSourcePath]bool,
+		map[machineSessionSource]bool,
 		min(len(pending), reconciliationPageSize),
 	)
 	for i, write := range pending {
 		path := e.effectiveSourcePath(write.sess.File.Path)
-		source := db.SessionSourcePath{
-			Agent: string(write.sess.Agent), FilePath: path,
+		source := machineSessionSource{
+			Machine: write.sess.Machine,
+			Source: db.SessionSourcePath{
+				Agent: string(write.sess.Agent), FilePath: path,
+			},
 		}
-		if source.Agent == "" || source.FilePath == "" {
+		if source.Machine == "" ||
+			source.Source.Agent == "" || source.Source.FilePath == "" {
 			continue
 		}
 		if _, seen := eligible[source]; !seen {
@@ -7272,8 +7449,8 @@ func (e *Engine) baselinePendingWriteSources(
 		}
 	}
 
-	candidates := make([]db.SessionSourcePath, 0, len(eligible))
-	admitted := make([]db.SessionSourcePath, 0, len(eligible))
+	candidates := make([]machineSessionSource, 0, len(eligible))
+	admitted := make([]machineSessionSource, 0, len(eligible))
 	tracker := reconciliationBaselineTrackerFor(ctx)
 	for source, ok := range eligible {
 		candidates = append(candidates, source)
@@ -7290,38 +7467,12 @@ func (e *Engine) baselinePendingWriteSources(
 		return nil
 	}
 
-	sources := make([]db.SessionSourcePath, 0, reconciliationPageSize)
-	admittedSet := make(map[db.SessionSourcePath]struct{}, len(admitted))
-	for _, source := range admitted {
-		admittedSet[source] = struct{}{}
+	if err := e.replaceActiveSessionSourceBaselinesByMachine(
+		ctx, candidates, admitted,
+	); err != nil {
+		return fmt.Errorf("replace parsed source baseline batch: %w", err)
 	}
-	flush := func() error {
-		if len(sources) == 0 {
-			return nil
-		}
-		pageAdmitted := make([]db.SessionSourcePath, 0, len(sources))
-		for _, source := range sources {
-			if _, ok := admittedSet[source]; ok {
-				pageAdmitted = append(pageAdmitted, source)
-			}
-		}
-		if err := e.db.ReplaceActiveSessionSourceBaselines(
-			ctx, e.machine, sources, pageAdmitted,
-		); err != nil {
-			return fmt.Errorf("replace parsed source baseline batch: %w", err)
-		}
-		sources = sources[:0]
-		return nil
-	}
-	for _, source := range candidates {
-		sources = append(sources, source)
-		if len(sources) == reconciliationPageSize {
-			if err := flush(); err != nil {
-				return err
-			}
-		}
-	}
-	return flush()
+	return nil
 }
 
 // skippedSourceAllowsCwdFilter determines whether an unchanged source may
@@ -7409,6 +7560,7 @@ type sessionParseError struct {
 type sourceMissingMember struct {
 	sessionID string
 	filePath  string
+	machine   string
 }
 
 type processResult struct {
@@ -7662,9 +7814,10 @@ func (e *Engine) processProviderFile(
 			err: fmt.Errorf("provider not found for agent type: %s", file.Agent),
 		}, true
 	}
+	machine := e.machineForFile(file)
 	provider := factory.NewProvider(parser.ProviderConfig{
 		Roots:        e.agentDirs[file.Agent],
-		Machine:      e.machine,
+		Machine:      machine,
 		PathRewriter: e.pathRewriter,
 	})
 
@@ -7690,6 +7843,16 @@ func (e *Engine) processProviderFile(
 			),
 		}, true
 	}
+	if source.ConfiguredRoot != "" {
+		if sourceMachine, ok := e.configuredMachineForPath(
+			file.Agent, source.ConfiguredRoot,
+		); ok {
+			machine = sourceMachine
+		}
+	} else if file.Machine == "" {
+		machine = e.machineForProviderSource(file.Agent, source, file.Path)
+	}
+	file.Machine = machine
 	providerSemantics := provider.Capabilities().Sync
 
 	// SyncSingleSession resolves a single session by ID and carries the
@@ -7955,7 +8118,7 @@ func (e *Engine) processProviderFile(
 	outcome, err := provider.Parse(ctx, parser.ParseRequest{
 		Source:      source,
 		Fingerprint: fingerprint,
-		Machine:     e.machine,
+		Machine:     machine,
 		ForceParse:  e.forceParse || file.ForceParse,
 	})
 	if err != nil {
@@ -8254,9 +8417,15 @@ func (e *Engine) providerSourceSessionOwnershipsForForceReplace(
 				continue
 			}
 			seen[id] = struct{}{}
+			machine := e.machineForProviderSource(agent, source, sourcePath)
+			if session, err := e.db.GetSession(context.Background(), id); err == nil &&
+				session != nil && session.Machine != "" {
+				machine = session.Machine
+			}
 			members = append(members, sourceMissingMember{
 				sessionID: id,
 				filePath:  sourcePath,
+				machine:   machine,
 			})
 		}
 	}
@@ -8582,7 +8751,9 @@ func (e *Engine) shouldSkipProviderSource(
 	if e.pathRewriter != nil {
 		lookupPath = e.pathRewriter(lookupPath)
 	}
-	storedSize, storedMtime, ok := e.db.GetFileInfoByPath(lookupPath)
+	storedSize, storedMtime, ok := e.db.GetFileInfoByPath(
+		lookupPath,
+	)
 	if !ok {
 		return false
 	}
@@ -9049,9 +9220,7 @@ func (e *Engine) shouldSkipByPath(
 	if e.pathRewriter != nil {
 		lookupPath = e.pathRewriter(path)
 	}
-	storedSize, storedMtime, ok := e.db.GetFileInfoByPath(
-		lookupPath,
-	)
+	storedSize, storedMtime, ok := e.db.GetFileInfoByPath(lookupPath)
 	if !ok {
 		return false
 	}
@@ -9408,7 +9577,7 @@ func (e *Engine) tryProviderIncrementalAppend(
 				SessionID:                 inc.ID,
 				Offset:                    inc.FileSize,
 				StartOrdinal:              inc.NextOrdinal,
-				Machine:                   e.machine,
+				Machine:                   inc.Machine,
 				LastEntryUUID:             inc.LastEntryUUID,
 				StoredAgentLabel:          inc.AgentLabel,
 				StoredEntrypoint:          inc.Entrypoint,
@@ -9932,8 +10101,9 @@ func (e *Engine) classifyCodexIndexPath(
 		for _, root := range sessionRoots {
 			if src := e.codexSourceFileForUUID(root, uuid); src != "" {
 				candidates = append(candidates, parser.DiscoveredFile{
-					Path:  src,
-					Agent: parser.AgentCodex,
+					Path:    src,
+					Agent:   parser.AgentCodex,
+					Machine: e.machineForPath(parser.AgentCodex, src),
 				})
 			}
 		}
@@ -10846,6 +11016,20 @@ func (e *Engine) prepareSessionWrite(
 		pw.sess.CountsAuthoritative,
 	)
 	e.applyRemoteRewrites(&s, msgs)
+	// Machine attribution is assigned when a session is first ingested.
+	// Ordinary reparses and appends must not rewrite it when configuration
+	// changes. During a rebuild, archiveStore points at the original archive
+	// while e.db is the fresh replacement, so the same rule survives sync
+	// --full without a second reattribution pass.
+	archive := e.archiveStore
+	if archive == nil {
+		archive = e.db
+	}
+	if stored, err := archive.GetSessionFull(
+		context.Background(), s.ID,
+	); err == nil && stored != nil && stored.Machine != "" {
+		s.Machine = stored.Machine
+	}
 	if s.Cwd != "" && resolveWorktreeProject != nil {
 		if mapped, ok := resolveWorktreeProject(
 			s.Machine, s.Cwd, s.Project,
@@ -13109,9 +13293,10 @@ func (e *Engine) findProviderSourceFile(
 	// chat source. Confirm the requested fork is actually produced before
 	// treating the chat source as a hit, mirroring the legacy parse-verify.
 	if providerSessionIsFork(def, sessionID, rawSessionID) {
+		machine := e.machineForPath(def.Type, providerDiscoveredPath(source))
 		outcome, err := provider.Parse(ctx, parser.ParseRequest{
 			Source:  source,
-			Machine: e.machine,
+			Machine: machine,
 		})
 		if err != nil || !providerOutcomeContainsSession(outcome, sessionID) {
 			return ""
@@ -13168,9 +13353,10 @@ func (e *Engine) providerSessionSourceMtime(
 	// A fork session ID resolves to its base chat source. Confirm the
 	// requested fork exists before treating the chat mtime as authoritative.
 	if providerSessionIsFork(def, sessionID, rawSessionID) {
+		machine := e.machineForPath(def.Type, providerDiscoveredPath(source))
 		outcome, err := provider.Parse(ctx, parser.ParseRequest{
 			Source:  source,
-			Machine: e.machine,
+			Machine: machine,
 		})
 		if err != nil || !providerOutcomeContainsSession(outcome, sessionID) {
 			return 0
@@ -13529,6 +13715,9 @@ func (e *Engine) SyncSingleSessionContext(
 		ForceParse: true,
 	}
 	e.hydrateS3DiscoveredFile(ctx, sessionID, &file)
+	if file.Machine == "" && !isS3SourcePath(file.Path) {
+		file.Machine = e.machineForPath(file.Agent, file.Path)
+	}
 	if e.shouldCacheSkip(file) {
 		e.clearSkip(path)
 	}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -10823,9 +10823,11 @@ type pendingWrite struct {
 	usageEvents  []parser.ParsedUsageEvent
 	needsRetry   bool
 	forceReplace bool
-	// sourceConflict rejects a native ID collision across distinct source
-	// ownerships before project discovery or persistence can trust it.
-	sourceConflict bool
+	// sourceIdentityUnverified marks a copy that shares a native session ID
+	// without matching the stored machine, source path, or content hash. The
+	// copy still follows native-ID deduplication, but it cannot borrow the
+	// stored attribution for local filesystem identity discovery.
+	sourceIdentityUnverified bool
 	// sourceProjectResolved marks writes whose parser project has already
 	// been reconciled with durable identity for an unavailable local cwd.
 	sourceProjectResolved bool
@@ -10855,7 +10857,7 @@ func (e *Engine) pendingWriteIdentity(pw pendingWrite) db.SessionWriteIdentity {
 	}
 }
 
-func sessionWriteIdentitiesCompatible(
+func sessionWriteIdentitySupportsStoredAttribution(
 	left, right db.SessionWriteIdentity,
 ) bool {
 	if left.Agent != right.Agent {
@@ -10874,9 +10876,9 @@ func sessionWriteIdentitiesCompatible(
 
 // normalizePendingWriteMachines resolves immutable attribution before any
 // consumer can make a project, worktree, baseline, or persistence decision.
-// Existing sessions keep the archive's machine. A cross-machine copy may reuse
-// the ID only when it is the same source path or has the same content hash;
-// divergent copies are rejected before local project discovery or persistence.
+// Existing sessions keep the archive's machine. Native IDs continue to
+// deduplicate across copied roots, while unverified copies cannot borrow the
+// stored attribution for local filesystem identity discovery.
 func (e *Engine) normalizePendingWriteMachines(
 	ctx context.Context,
 	batch []pendingWrite,
@@ -10942,30 +10944,20 @@ func (e *Engine) normalizePendingWriteMachines(
 		if exists {
 			for _, i := range matchingIndexes {
 				incoming := e.pendingWriteIdentity(batch[i])
-				if !sessionWriteIdentitiesCompatible(stored, incoming) {
-					batch[i].sourceConflict = true
-					continue
-				}
+				batch[i].sourceIdentityUnverified =
+					!sessionWriteIdentitySupportsStoredAttribution(stored, incoming)
 				batch[i].sess.Machine = stored.Machine
 			}
 			continue
 		}
 
 		first := e.pendingWriteIdentity(batch[matchingIndexes[0]])
-		compatible := true
-		for _, i := range matchingIndexes[1:] {
-			if !sessionWriteIdentitiesCompatible(
-				first, e.pendingWriteIdentity(batch[i]),
-			) {
-				compatible = false
-				break
-			}
-		}
 		for _, i := range matchingIndexes {
-			batch[i].sourceConflict = !compatible
-			if compatible {
-				batch[i].sess.Machine = first.Machine
-			}
+			batch[i].sourceIdentityUnverified =
+				!sessionWriteIdentitySupportsStoredAttribution(
+					first, e.pendingWriteIdentity(batch[i]),
+				)
+			batch[i].sess.Machine = first.Machine
 		}
 	}
 	return batch, nil
@@ -11082,6 +11074,7 @@ func (e *Engine) preserveUnavailableSourceProjects(
 		}
 		sess := batch[i].sess
 		if sess.ID == "" || sess.Cwd == "" ||
+			batch[i].sourceIdentityUnverified ||
 			!e.isLocalMachineAttribution(sess.Machine) ||
 			!safeLocalAbsolutePath(sess.Cwd) ||
 			export.IsAutomountNamespacePath(runtime.GOOS, filepath.Clean(sess.Cwd)) {
@@ -11127,7 +11120,7 @@ func (e *Engine) preserveUnavailableSourceProjects(
 		}
 		for _, i := range indexes[id] {
 			sess := &batch[i].sess
-			if snapshot.Machine != sess.Machine ||
+			if !e.sameLocalMachineAttribution(snapshot.Machine, sess.Machine) ||
 				!pathContains(snapshot.RootPath, sess.Cwd) {
 				continue
 			}
@@ -11137,10 +11130,15 @@ func (e *Engine) preserveUnavailableSourceProjects(
 	return batch, nil
 }
 
-// isLocalMachineAttribution recognizes the legacy "local" sentinel as this
-// machine without rewriting the immutable value stored with the session.
+// isLocalMachineAttribution recognizes empty and the legacy "local" sentinel
+// as this machine without rewriting the immutable stored value.
 func (e *Engine) isLocalMachineAttribution(machine string) bool {
-	return machine == "local" || machine == e.machine
+	return machine == "" || machine == "local" || machine == e.machine
+}
+
+func (e *Engine) sameLocalMachineAttribution(left, right string) bool {
+	return left == right ||
+		(e.isLocalMachineAttribution(left) && e.isLocalMachineAttribution(right))
 }
 
 func pathContains(root, path string) bool {
@@ -11221,11 +11219,6 @@ func (e *Engine) writeBatchWithOutcome(
 	outcome := writeBatchOutcome{written: make([]bool, len(batch))}
 	resolveWorktreeProject := e.loadWorktreeProjectResolver()
 	for i, pw := range batch {
-		if pw.sourceConflict {
-			log.Printf("reject divergent source collision for session %s", pw.sess.ID)
-			outcome.failedSessions++
-			continue
-		}
 		s, msgs, verdict := e.prepareSessionWrite(
 			pw, resolveWorktreeProject,
 		)
@@ -11253,9 +11246,7 @@ func (e *Engine) writeBatchWithOutcome(
 		// (writeIncremental), messages are written first since the session
 		// already exists.
 		revivingSourceMissing, err :=
-			e.upsertSessionPendingContentWithProjectIdentity(
-				s, pw.sess.Project,
-			)
+			e.upsertSessionPendingContentForWrite(pw, s)
 		if err != nil {
 			if isIntentionalSessionSkip(err) {
 				if pw.sess.File.Path != "" {
@@ -11370,7 +11361,8 @@ func (e *Engine) prepareSessionWrite(
 		pw.sess.CountsAuthoritative,
 	)
 	e.applyRemoteRewrites(&s, msgs)
-	if s.Cwd != "" && resolveWorktreeProject != nil {
+	if !pw.sourceIdentityUnverified &&
+		s.Cwd != "" && resolveWorktreeProject != nil {
 		if mapped, ok := resolveWorktreeProject(
 			s.Machine, s.Cwd, s.Project,
 		); ok {
@@ -12184,11 +12176,6 @@ func (e *Engine) writeBatchBulkWithOutcome(
 	resolveWorktreeProject := e.loadWorktreeProjectResolver()
 
 	for pendingIndex, pw := range batch {
-		if pw.sourceConflict {
-			log.Printf("reject divergent source collision for session %s", pw.sess.ID)
-			outcome.failedSessions++
-			continue
-		}
 		tPrep := time.Now()
 		s, msgs, verdict := e.prepareSessionWrite(
 			pw, resolveWorktreeProject,
@@ -12212,7 +12199,7 @@ func (e *Engine) writeBatchBulkWithOutcome(
 			Messages:    msgs,
 			UsageEvents: e.usageEventsForWrite(s.ID, pw.usageEvents),
 			IdentityObservation: identityObservationOrZero(
-				e.projectIdentityObservation(s),
+				e.projectIdentityObservationForWrite(pw, s),
 			),
 			IdentitySnapshotProject: &snapshotProject,
 			Signals:                 update,
@@ -12317,6 +12304,16 @@ func (e *Engine) projectIdentityObservation(
 		obs.CheckoutState, obs.GitBranch = readGitCheckout(cached.gitDir)
 	}
 	return obs, true
+}
+
+func (e *Engine) projectIdentityObservationForWrite(
+	pw pendingWrite,
+	s db.Session,
+) (export.ProjectIdentityObservation, bool) {
+	if pw.sourceIdentityUnverified {
+		return export.ProjectIdentityObservation{}, false
+	}
+	return e.projectIdentityObservation(s)
 }
 
 func (e *Engine) cachedProjectIdentity(machine, rootPath string) projectIdentityCacheEntry {
@@ -12425,6 +12422,18 @@ func (e *Engine) upsertSessionPendingContentWithProjectIdentity(
 	}
 	return e.db.UpsertSessionPendingContentWithProjectIdentity(
 		s, obs, snapshotProject,
+	)
+}
+
+func (e *Engine) upsertSessionPendingContentForWrite(
+	pw pendingWrite,
+	s db.Session,
+) (bool, error) {
+	if pw.sourceIdentityUnverified {
+		return e.db.UpsertSessionPendingContent(s)
+	}
+	return e.upsertSessionPendingContentWithProjectIdentity(
+		s, pw.sess.Project,
 	)
 }
 
@@ -12909,11 +12918,6 @@ func (e *Engine) writeSessionFullWithResolver(
 	if err != nil {
 		return err
 	}
-	if normalized[0].sourceConflict {
-		return fmt.Errorf(
-			"session %s has divergent source ownership", pw.sess.ID,
-		)
-	}
 	preserved, err := e.preserveUnavailableSourceProjects(
 		context.Background(), normalized,
 	)
@@ -12927,9 +12931,7 @@ func (e *Engine) writeSessionFullWithResolver(
 	if verdict != sessionWriteOK {
 		return errSessionPreserved
 	}
-	_, err = e.upsertSessionPendingContentWithProjectIdentity(
-		s, pw.sess.Project,
-	)
+	_, err = e.upsertSessionPendingContentForWrite(pw, s)
 	if err != nil {
 		if isIntentionalSessionSkip(err) {
 			if pw.sess.File.Path != "" {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -2121,33 +2121,26 @@ func (e *Engine) resyncBuildLocked(
 	rebuildOldFileSessions := oldFileSessions
 	contributorOldFileSessions := make([]int, len(opts.Contributors))
 	if len(opts.Contributors) > 0 {
-		localMachines := map[string]bool{}
-		if e.machine != "" {
-			localMachines[e.machine] = true
-		}
-		for _, roots := range e.sourceMachines {
-			for _, machine := range roots {
-				if machine != "" {
-					localMachines[machine] = true
-				}
-			}
-		}
-		if len(localMachines) > 0 {
-			localOldFileSessions = 0
-			for machine := range localMachines {
-				count, countErr := e.protectedFileSessionCount(
-					origDB, machine, "", true,
+		contributorPrefixes := make([]string, 0, len(opts.Contributors))
+		for _, contributor := range opts.Contributors {
+			if contributor.Config.IDPrefix != "" {
+				contributorPrefixes = append(
+					contributorPrefixes, contributor.Config.IDPrefix,
 				)
-				if countErr != nil {
-					log.Printf(
-						"resync: get old local machine %q file count: %v",
-						machine, countErr,
-					)
-					localOldFileSessions = 1
-					break
-				}
-				localOldFileSessions += count
 			}
+		}
+		excludedAgents := []string{
+			string(parser.AgentOpenCode),
+			string(parser.AgentKilo),
+			string(parser.AgentMiMoCode),
+			string(parser.AgentIcodemate),
+		}
+		localOldFileSessions, err = origDB.FileBackedSessionCountForRebuildOwner(
+			context.Background(), e.machine, contributorPrefixes, excludedAgents,
+		)
+		if err != nil {
+			log.Printf("resync: get old local rebuild file count: %v", err)
+			localOldFileSessions = 1
 		}
 		for i, contributor := range opts.Contributors {
 			count, countErr := e.protectedFileSessionCount(
@@ -2163,16 +2156,6 @@ func (e *Engine) resyncBuildLocked(
 				count = 1
 			}
 			contributorOldFileSessions[i] = count
-			// A structured local root may use a historical machine label, while a
-			// contributor is owned by its ID namespace. Remove a contributor only
-			// when its machine was included in the local attribution count.
-			if contributor.Config.IDPrefix != "" &&
-				(len(localMachines) == 0 || localMachines[contributor.Config.Machine]) {
-				localOldFileSessions -= count
-				if localOldFileSessions < 0 {
-					localOldFileSessions = 0
-				}
-			}
 		}
 		rebuildOldFileSessions = localOldFileSessions
 		for _, count := range contributorOldFileSessions {
@@ -10840,6 +10823,9 @@ type pendingWrite struct {
 	usageEvents  []parser.ParsedUsageEvent
 	needsRetry   bool
 	forceReplace bool
+	// sourceConflict rejects a native ID collision across distinct source
+	// ownerships before project discovery or persistence can trust it.
+	sourceConflict bool
 	// sourceProjectResolved marks writes whose parser project has already
 	// been reconciled with durable identity for an unavailable local cwd.
 	sourceProjectResolved bool
@@ -10854,17 +10840,43 @@ type pendingWrite struct {
 	storageTrustSnap  storageTrustSnapshot
 }
 
-type sessionMachineReader interface {
-	ListSessionMachinesByID(
+type sessionWriteIdentityReader interface {
+	ListSessionWriteIdentitiesByID(
 		context.Context, []string,
-	) (map[string]string, error)
+	) (map[string]db.SessionWriteIdentity, error)
+}
+
+func (e *Engine) pendingWriteIdentity(pw pendingWrite) db.SessionWriteIdentity {
+	return db.SessionWriteIdentity{
+		Machine:  pw.sess.Machine,
+		Agent:    string(pw.sess.Agent),
+		FilePath: e.effectiveSourcePath(pw.sess.File.Path),
+		FileHash: pw.sess.File.Hash,
+	}
+}
+
+func sessionWriteIdentitiesCompatible(
+	left, right db.SessionWriteIdentity,
+) bool {
+	if left.Agent != right.Agent {
+		return false
+	}
+	if left.Machine == right.Machine {
+		return true
+	}
+	if left.FilePath != "" && right.FilePath != "" &&
+		sameReconciliationSourcePath(left.FilePath, right.FilePath) {
+		return true
+	}
+	return left.FileHash != "" && right.FileHash != "" &&
+		left.FileHash == right.FileHash
 }
 
 // normalizePendingWriteMachines resolves immutable attribution before any
 // consumer can make a project, worktree, baseline, or persistence decision.
-// Existing sessions keep the archive's machine. For a new ID represented more
-// than once in the batch, every copy uses the first pending write's configured
-// machine so later upserts cannot rewrite its first-ingestion attribution.
+// Existing sessions keep the archive's machine. A cross-machine copy may reuse
+// the ID only when it is the same source path or has the same content hash;
+// divergent copies are rejected before local project discovery or persistence.
 func (e *Engine) normalizePendingWriteMachines(
 	ctx context.Context,
 	batch []pendingWrite,
@@ -10889,15 +10901,15 @@ func (e *Engine) normalizePendingWriteMachines(
 	if e.archiveStore != nil {
 		archive = e.archiveStore
 	}
-	reader, ok := archive.(sessionMachineReader)
+	reader, ok := archive.(sessionWriteIdentityReader)
 	if !ok {
 		return batch, fmt.Errorf(
-			"archive %T does not support session machine lookup", archive,
+			"archive %T does not support session write identity lookup", archive,
 		)
 	}
-	machines, err := reader.ListSessionMachinesByID(ctx, ids)
+	identities, err := reader.ListSessionWriteIdentitiesByID(ctx, ids)
 	if err != nil {
-		return batch, fmt.Errorf("load immutable session machines: %w", err)
+		return batch, fmt.Errorf("load immutable session write identities: %w", err)
 	}
 	// A rebuild reads preexisting attribution from archiveStore while writing
 	// into e.db. An ID first seen earlier in this rebuild is absent from the old
@@ -10905,30 +10917,55 @@ func (e *Engine) normalizePendingWriteMachines(
 	if e.archiveStore != nil {
 		unresolved := make([]string, 0, len(ids))
 		for _, id := range ids {
-			if _, exists := machines[id]; !exists {
+			if _, exists := identities[id]; !exists {
 				unresolved = append(unresolved, id)
 			}
 		}
 		if len(unresolved) > 0 {
-			replacementMachines, err := e.db.ListSessionMachinesByID(
+			replacementIdentities, err := e.db.ListSessionWriteIdentitiesByID(
 				ctx, unresolved,
 			)
 			if err != nil {
 				return batch, fmt.Errorf(
-					"load replacement session machines: %w", err,
+					"load replacement session write identities: %w", err,
 				)
 			}
-			maps.Copy(machines, replacementMachines)
+			maps.Copy(identities, replacementIdentities)
 		}
 	}
 	for _, id := range ids {
-		machine, exists := machines[id]
-		for _, i := range indexes[id] {
-			if !exists {
-				machine = batch[i].sess.Machine
-				exists = true
+		matchingIndexes := indexes[id]
+		if len(matchingIndexes) == 0 {
+			continue
+		}
+		stored, exists := identities[id]
+		if exists {
+			for _, i := range matchingIndexes {
+				incoming := e.pendingWriteIdentity(batch[i])
+				if !sessionWriteIdentitiesCompatible(stored, incoming) {
+					batch[i].sourceConflict = true
+					continue
+				}
+				batch[i].sess.Machine = stored.Machine
 			}
-			batch[i].sess.Machine = machine
+			continue
+		}
+
+		first := e.pendingWriteIdentity(batch[matchingIndexes[0]])
+		compatible := true
+		for _, i := range matchingIndexes[1:] {
+			if !sessionWriteIdentitiesCompatible(
+				first, e.pendingWriteIdentity(batch[i]),
+			) {
+				compatible = false
+				break
+			}
+		}
+		for _, i := range matchingIndexes {
+			batch[i].sourceConflict = !compatible
+			if compatible {
+				batch[i].sess.Machine = first.Machine
+			}
 		}
 	}
 	return batch, nil
@@ -11184,6 +11221,11 @@ func (e *Engine) writeBatchWithOutcome(
 	outcome := writeBatchOutcome{written: make([]bool, len(batch))}
 	resolveWorktreeProject := e.loadWorktreeProjectResolver()
 	for i, pw := range batch {
+		if pw.sourceConflict {
+			log.Printf("reject divergent source collision for session %s", pw.sess.ID)
+			outcome.failedSessions++
+			continue
+		}
 		s, msgs, verdict := e.prepareSessionWrite(
 			pw, resolveWorktreeProject,
 		)
@@ -12142,6 +12184,11 @@ func (e *Engine) writeBatchBulkWithOutcome(
 	resolveWorktreeProject := e.loadWorktreeProjectResolver()
 
 	for pendingIndex, pw := range batch {
+		if pw.sourceConflict {
+			log.Printf("reject divergent source collision for session %s", pw.sess.ID)
+			outcome.failedSessions++
+			continue
+		}
 		tPrep := time.Now()
 		s, msgs, verdict := e.prepareSessionWrite(
 			pw, resolveWorktreeProject,
@@ -12198,7 +12245,7 @@ func (e *Engine) writeBatchBulkWithOutcome(
 		for _, pw := range pendingByID {
 			e.markStaleFailedMemberWrite(pw)
 		}
-		outcome.failedSessions = len(writes)
+		outcome.failedSessions += len(writes)
 		return outcome
 	}
 	for _, writtenIndex := range result.WrittenIndexes {
@@ -12223,7 +12270,7 @@ func (e *Engine) writeBatchBulkWithOutcome(
 	}
 	outcome.writtenSessions = result.WrittenSessions
 	outcome.writtenMessages = result.WrittenMessages
-	outcome.failedSessions = result.FailedSessions
+	outcome.failedSessions += result.FailedSessions
 	return outcome
 }
 
@@ -12861,6 +12908,11 @@ func (e *Engine) writeSessionFullWithResolver(
 	)
 	if err != nil {
 		return err
+	}
+	if normalized[0].sourceConflict {
+		return fmt.Errorf(
+			"session %s has divergent source ownership", pw.sess.ID,
+		)
 	}
 	preserved, err := e.preserveUnavailableSourceProjects(
 		context.Background(), normalized,

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1397,11 +1397,8 @@ func (e *Engine) expandOmnigentInheritedMetadataSources(
 	agent := provider.Definition().Type
 	seenSources := make(map[string]struct{}, len(sources))
 	seenParents := make(map[string]struct{}, len(sources))
-	// A descendant is stored under the machine its parent was admitted under,
-	// which is not necessarily the local one, so group the lookup by each
-	// parent's stored attribution instead of assuming e.machine.
-	parentsByMachine := make(map[string][]string, 1)
-	machineOrder := make([]string, 0, 1)
+	parentIDs := make([]string, 0, len(sources))
+	configuredMachines := make(map[string]string, len(sources))
 	for _, source := range sources {
 		sourcePath := providerDiscoveredPath(source)
 		if sourcePath != "" {
@@ -1416,18 +1413,32 @@ func (e *Engine) expandOmnigentInheritedMetadataSources(
 			continue
 		}
 		seenParents[parentID] = struct{}{}
-		machine := e.machineForProviderSource(agent, source, sourcePath)
-		if session, err := e.db.GetSession(ctx, parentID); err == nil &&
-			session != nil {
-			machine = session.Machine
+		parentIDs = append(parentIDs, parentID)
+		configuredMachines[parentID] = e.machineForProviderSource(
+			agent, source, sourcePath,
+		)
+	}
+	if len(parentIDs) == 0 {
+		return sources, nil
+	}
+	storedMachines, err := e.db.ListSessionMachinesByID(ctx, parentIDs)
+	if err != nil {
+		return nil, fmt.Errorf("list omnigent parent session machines: %w", err)
+	}
+	// A descendant is stored under the machine its parent was admitted under,
+	// which is not necessarily the local one, so group the lookup by each
+	// parent's stored attribution instead of assuming e.machine.
+	parentsByMachine := make(map[string][]string, 1)
+	machineOrder := make([]string, 0, 1)
+	for _, parentID := range parentIDs {
+		machine := configuredMachines[parentID]
+		if stored, exists := storedMachines[parentID]; exists {
+			machine = stored
 		}
 		if _, exists := parentsByMachine[machine]; !exists {
 			machineOrder = append(machineOrder, machine)
 		}
 		parentsByMachine[machine] = append(parentsByMachine[machine], parentID)
-	}
-	if len(machineOrder) == 0 {
-		return sources, nil
 	}
 	var paths []string
 	for _, machine := range machineOrder {
@@ -8131,7 +8142,7 @@ func (e *Engine) processProviderFile(
 			errors.Is(err, os.ErrNotExist) {
 			excludedSessionIDs, ownershipErr :=
 				e.providerSourceSessionIDsForForceReplace(
-					provider, source,
+					ctx, provider, source,
 				)
 			if ownershipErr != nil {
 				return processResult{
@@ -8359,7 +8370,7 @@ func (e *Engine) processProviderFile(
 		if outcome.ForceReplace && outcome.ResultSetComplete {
 			owned, ownershipErr :=
 				e.providerSourceSessionOwnershipsForForceReplace(
-					provider, source,
+					ctx, provider, source,
 				)
 			if ownershipErr != nil {
 				return processResult{
@@ -8418,7 +8429,7 @@ func (e *Engine) processProviderFile(
 		outcome.ResultSetComplete && len(outcome.SourceErrors) == 0 {
 		missingMembers, err =
 			e.providerSourceMissingSessionOwnershipsForCompleteResult(
-				provider, source, parsedResults,
+				ctx, provider, source, parsedResults,
 			)
 		if err != nil {
 			return processResult{
@@ -8546,11 +8557,12 @@ func (e *Engine) dropUnchangedSharedSQLiteResults(
 }
 
 func (e *Engine) providerSourceSessionIDsForForceReplace(
+	ctx context.Context,
 	provider parser.Provider,
 	source parser.SourceRef,
 ) ([]string, error) {
 	members, err := e.providerSourceSessionOwnershipsForForceReplace(
-		provider, source,
+		ctx, provider, source,
 	)
 	if err != nil {
 		return nil, err
@@ -8567,6 +8579,7 @@ func (e *Engine) providerSourceSessionIDsForForceReplace(
 // file path each row is tracked under, so callers can either hard-delete
 // them as parser exclusions or tombstone their exact source ownership.
 func (e *Engine) providerSourceSessionOwnershipsForForceReplace(
+	ctx context.Context,
 	provider parser.Provider,
 	source parser.SourceRef,
 ) ([]sourceMissingMember, error) {
@@ -8602,6 +8615,7 @@ func (e *Engine) providerSourceSessionOwnershipsForForceReplace(
 	}
 	seen := make(map[string]struct{})
 	var members []sourceMissingMember
+	var sessionIDs []string
 	for _, sourcePath := range sourcePaths {
 		pathIDs, err := e.db.ListSessionIDsByFilePath(sourcePath, string(agent))
 		if err != nil {
@@ -8615,22 +8629,32 @@ func (e *Engine) providerSourceSessionOwnershipsForForceReplace(
 				continue
 			}
 			seen[id] = struct{}{}
-			machine := e.machineForProviderSource(agent, source, sourcePath)
-			if session, err := e.db.GetSession(context.Background(), id); err == nil &&
-				session != nil {
-				machine = session.Machine
-			}
 			members = append(members, sourceMissingMember{
 				sessionID: id,
 				filePath:  sourcePath,
-				machine:   machine,
+				machine: e.machineForProviderSource(
+					agent, source, sourcePath,
+				),
 			})
+			sessionIDs = append(sessionIDs, id)
+		}
+	}
+	storedMachines, err := e.db.ListSessionMachinesByID(ctx, sessionIDs)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"list provider force-replace session machines: %w", err,
+		)
+	}
+	for i := range members {
+		if machine, exists := storedMachines[members[i].sessionID]; exists {
+			members[i].machine = machine
 		}
 	}
 	return members, nil
 }
 
 func (e *Engine) providerSourceMissingSessionOwnershipsForCompleteResult(
+	ctx context.Context,
 	provider parser.Provider,
 	source parser.SourceRef,
 	results []parser.ParseResult,
@@ -8643,7 +8667,7 @@ func (e *Engine) providerSourceMissingSessionOwnershipsForCompleteResult(
 		}
 	}
 	stored, err := e.providerSourceSessionOwnershipsForForceReplace(
-		provider, source,
+		ctx, provider, source,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -10882,7 +10882,7 @@ func (e *Engine) normalizePendingWriteMachines(
 	if e.archiveStore != nil {
 		unresolved := make([]string, 0, len(ids))
 		for _, id := range ids {
-			if machines[id] == "" {
+			if _, exists := machines[id]; !exists {
 				unresolved = append(unresolved, id)
 			}
 		}
@@ -10896,19 +10896,14 @@ func (e *Engine) normalizePendingWriteMachines(
 				)
 			}
 			for id, machine := range replacementMachines {
-				if machine != "" {
-					machines[id] = machine
-				}
+				machines[id] = machine
 			}
 		}
 	}
 	for _, id := range ids {
-		machine := machines[id]
-		if machine == "" {
+		machine, exists := machines[id]
+		if !exists {
 			machine = batch[indexes[id][0]].sess.Machine
-		}
-		if machine == "" {
-			continue
 		}
 		for _, i := range indexes[id] {
 			batch[i].sess.Machine = machine

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -237,6 +237,36 @@ func TestWriteBatchRelabelRecoversUnavailableSourceProject(t *testing.T) {
 		"project recovery must use the stored machine before the checkout lookup")
 }
 
+func TestWriteBatchDuplicateNewSessionIDKeepsFirstMachine(t *testing.T) {
+	const sessionID = "copied-session"
+	database := openTestDB(t)
+	engine := NewEngine(database, EngineConfig{Machine: "local-machine"})
+	t.Cleanup(engine.Close)
+	startedAt := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	writes := []pendingWrite{
+		{sess: parser.ParsedSession{
+			ID: sessionID, Project: "first-copy", Machine: "machine-z",
+			Agent: parser.AgentCopilot, StartedAt: startedAt, EndedAt: startedAt,
+			File: parser.FileInfo{Path: "/sources/a/session.jsonl"},
+		}},
+		{sess: parser.ParsedSession{
+			ID: sessionID, Project: "second-copy", Machine: "machine-a",
+			Agent: parser.AgentCopilot, StartedAt: startedAt, EndedAt: startedAt,
+			File: parser.FileInfo{Path: "/sources/b/session.jsonl"},
+		}},
+	}
+
+	outcome := engine.writeBatchWithOutcome(writes, syncWriteDefault, true)
+
+	require.Equal(t, 2, outcome.writtenSessions)
+	require.Zero(t, outcome.failedSessions)
+	stored, err := database.GetSessionFull(t.Context(), sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	assert.Equal(t, "machine-z", stored.Machine,
+		"every same-batch copy must use the machine of the first ingestion")
+}
+
 func TestClaudeIDFreshnessRejectsSourceMissingTombstone(t *testing.T) {
 	database := openTestDB(t)
 	root := t.TempDir()

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -293,12 +293,12 @@ func TestWriteBatchDuplicateNewSessionIDKeepsFirstMachine(t *testing.T) {
 		{sess: parser.ParsedSession{
 			ID: sessionID, Project: "first-copy", Machine: "machine-z",
 			Agent: parser.AgentCopilot, StartedAt: startedAt, EndedAt: startedAt,
-			File: parser.FileInfo{Path: "/sources/a/session.jsonl"},
+			File: parser.FileInfo{Path: "/sources/a/session.jsonl", Hash: "same-copy"},
 		}},
 		{sess: parser.ParsedSession{
 			ID: sessionID, Project: "second-copy", Machine: "machine-a",
 			Agent: parser.AgentCopilot, StartedAt: startedAt, EndedAt: startedAt,
-			File: parser.FileInfo{Path: "/sources/b/session.jsonl"},
+			File: parser.FileInfo{Path: "/sources/b/session.jsonl", Hash: "same-copy"},
 		}},
 	}
 
@@ -313,6 +313,53 @@ func TestWriteBatchDuplicateNewSessionIDKeepsFirstMachine(t *testing.T) {
 		"every same-batch copy must use the machine of the first ingestion")
 }
 
+func TestWriteBatchRejectsDivergentForeignSessionIDCollision(t *testing.T) {
+	const sessionID = "shared-native-id"
+	database := openTestDB(t)
+	engine := NewEngine(database, EngineConfig{Machine: "local-machine"})
+	t.Cleanup(engine.Close)
+	startedAt := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	write := func(machine, project, path, hash, content string) pendingWrite {
+		return pendingWrite{
+			sess: parser.ParsedSession{
+				ID: sessionID, Project: project, Machine: machine,
+				Agent: parser.AgentCopilot, Cwd: filepath.Dir(path),
+				StartedAt: startedAt, EndedAt: startedAt, MessageCount: 1,
+				File: parser.FileInfo{Path: path, Hash: hash},
+			},
+			msgs: []parser.ParsedMessage{{
+				Ordinal: 0, Role: parser.RoleUser, Content: content,
+				Timestamp: startedAt,
+			}},
+		}
+	}
+	localPath := filepath.Join(t.TempDir(), "local.jsonl")
+	foreignPath := filepath.Join(t.TempDir(), "foreign.jsonl")
+	initial := engine.writeBatchWithOutcome([]pendingWrite{
+		write("local-machine", "local-project", localPath, "local-hash", "local content"),
+	}, syncWriteDefault, true)
+	require.Equal(t, 1, initial.writtenSessions)
+	require.Zero(t, initial.failedSessions)
+
+	collision := engine.writeBatchWithOutcome([]pendingWrite{
+		write("foreign-machine", "foreign-project", foreignPath, "foreign-hash", "foreign content"),
+	}, syncWriteDefault, true)
+
+	assert.Zero(t, collision.writtenSessions)
+	assert.Equal(t, 1, collision.failedSessions)
+	stored, err := database.GetSessionFull(t.Context(), sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	assert.Equal(t, "local-machine", stored.Machine)
+	assert.Equal(t, "local-project", stored.Project)
+	require.NotNil(t, stored.FilePath)
+	assert.Equal(t, localPath, *stored.FilePath)
+	messages, err := database.GetAllMessages(t.Context(), sessionID)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Equal(t, "local content", messages[0].Content)
+}
+
 func TestWriteBatchResyncDuplicateIDKeepsFirstReplacementMachine(t *testing.T) {
 	const sessionID = "copied-across-resync-batches"
 	original := openTestDB(t)
@@ -325,7 +372,7 @@ func TestWriteBatchResyncDuplicateIDKeepsFirstReplacementMachine(t *testing.T) {
 		return pendingWrite{sess: parser.ParsedSession{
 			ID: sessionID, Project: project, Machine: machine,
 			Agent: parser.AgentCopilot, StartedAt: startedAt, EndedAt: startedAt,
-			File: parser.FileInfo{Path: path},
+			File: parser.FileInfo{Path: path, Hash: "same-copy"},
 		}}
 	}
 
@@ -352,7 +399,7 @@ func TestWriteBatchExistingEmptyMachineRemainsEmpty(t *testing.T) {
 	database := openTestDB(t)
 	require.NoError(t, database.UpsertSession(db.Session{
 		ID: sessionID, Project: "legacy", Machine: "",
-		Agent: string(parser.AgentCopilot),
+		Agent: string(parser.AgentCopilot), FilePath: strPtr("/sources/session.jsonl"),
 	}))
 	engine := NewEngine(database, EngineConfig{Machine: "local-machine"})
 	t.Cleanup(engine.Close)
@@ -380,7 +427,7 @@ func TestWriteBatchResyncReplacementEmptyMachineRemainsEmpty(t *testing.T) {
 	replacement := openTestDB(t)
 	require.NoError(t, replacement.UpsertSession(db.Session{
 		ID: sessionID, Project: "legacy", Machine: "",
-		Agent: string(parser.AgentCopilot),
+		Agent: string(parser.AgentCopilot), FilePath: strPtr("/sources/session.jsonl"),
 	}))
 	engine := NewEngine(replacement, EngineConfig{Machine: "local-machine"})
 	engine.archiveStore = original

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -186,6 +186,57 @@ func TestPreserveUnavailableSourceProjectsUsesDurableSnapshot(
 	}
 }
 
+func TestWriteBatchRelabelRecoversUnavailableSourceProject(t *testing.T) {
+	const (
+		sessionID       = "relabel-unavailable-source"
+		originalProject = "resolved-project"
+		fallbackProject = "parser-fallback"
+		storedMachine   = "local-machine"
+		configuredLabel = "renamed-machine"
+		idPrefix        = "remote~"
+	)
+	database := openTestDB(t)
+	root := filepath.Join(t.TempDir(), "missing-checkout")
+	cwd := filepath.Join(root, "nested")
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	recordedAt := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	storedSessionID := applyIDPrefixToID(idPrefix, sessionID)
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: storedSessionID, Project: originalProject, Machine: storedMachine,
+		Agent: string(parser.AgentClaude), Cwd: cwd, FilePath: &path,
+	}))
+	require.NoError(t, database.UpsertProjectIdentityObservationWithSnapshotProject(
+		t.Context(), export.ProjectIdentityObservation{
+			SessionID: storedSessionID, Project: originalProject, Machine: storedMachine,
+			RootPath: root, GitRemote: "https://example.com/team/project.git",
+			RemoteResolution: export.ProjectResolutionResolved,
+			ObservedAt:       recordedAt,
+		}, originalProject,
+	))
+	engine := NewEngine(database, EngineConfig{
+		Machine: storedMachine, IDPrefix: idPrefix,
+	})
+	t.Cleanup(engine.Close)
+
+	outcome := engine.writeBatchWithOutcome([]pendingWrite{{
+		sess: parser.ParsedSession{
+			ID: sessionID, Project: fallbackProject, Machine: configuredLabel,
+			Agent: parser.AgentClaude, Cwd: cwd,
+			StartedAt: recordedAt, EndedAt: recordedAt,
+			File: parser.FileInfo{Path: path, Mtime: recordedAt.UnixNano()},
+		},
+	}}, syncWriteDefault, true)
+
+	require.Equal(t, 1, outcome.writtenSessions)
+	stored, err := database.GetSessionFull(t.Context(), storedSessionID)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	assert.Equal(t, storedMachine, stored.Machine,
+		"a relabel must not rewrite immutable machine attribution")
+	assert.Equal(t, originalProject, stored.Project,
+		"project recovery must use the stored machine before the checkout lookup")
+}
+
 func TestClaudeIDFreshnessRejectsSourceMissingTombstone(t *testing.T) {
 	database := openTestDB(t)
 	root := t.TempDir()
@@ -1271,6 +1322,160 @@ func TestSyncProviderDBBackedBaselinesOnlyCompleteSuccessfulSources(t *testing.T
 				"the clean source should use the fresh shortcut on the second pass")
 		})
 	}
+}
+
+func TestSyncProviderDBBackedBatchesWarmSourceAttributionLookup(t *testing.T) {
+	for _, sourceCount := range []int{1, 100} {
+		t.Run(fmt.Sprintf("sources-%d", sourceCount), func(t *testing.T) {
+			const agent parser.AgentType = "warm-db-backed"
+			database := openTestDB(t)
+			root := t.TempDir()
+			sources := make([]parser.SourceRef, sourceCount)
+			for i := range sourceCount {
+				path := filepath.Join(root, fmt.Sprintf("session-%03d.db", i))
+				sources[i] = parser.SourceRef{
+					Provider: agent, Key: path,
+					DisplayPath: path, FingerprintKey: path,
+				}
+				mtime := int64(2)
+				require.NoError(t, database.UpsertSession(db.Session{
+					ID: fmt.Sprintf("session-%03d", i), Project: "project",
+					Machine: "local", Agent: string(agent),
+					FilePath: &path, FileMtime: &mtime,
+				}))
+				require.NoError(t, database.SetSessionDataVersion(
+					fmt.Sprintf("session-%03d", i), db.CurrentDataVersion(),
+				))
+			}
+			provider := &baselineDBBackedProvider{
+				ProviderBase: parser.ProviderBase{
+					Def: parser.AgentDef{Type: agent, FileBased: false},
+					Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+						StreamingDiscovery: parser.CapabilitySupported,
+					}},
+				},
+				sources:          sources,
+				outcomes:         make(map[string]parser.ParseOutcome),
+				fingerprintCalls: make(map[string]int),
+				parseCalls:       make(map[string]int),
+			}
+			engine := NewEngine(database, EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{agent: {root}},
+				SourceMachines: map[parser.AgentType]map[string]string{
+					agent: {root: "local"},
+				},
+				Machine: "local",
+				ProviderFactories: []parser.ProviderFactory{
+					baselineDBBackedFactory{provider: provider},
+				},
+				ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+					agent: parser.ProviderMigrationProviderAuthoritative,
+				},
+			})
+			t.Cleanup(engine.Close)
+			lookupCalls := 0
+			engine.sourceAttributionLookupOverride = func(
+				ctx context.Context, requested []db.SessionSourcePath,
+			) ([]db.SessionSourceAttribution, error) {
+				lookupCalls++
+				assert.Len(t, requested, sourceCount)
+				return database.ListActiveSessionSourceAttributions(ctx, requested)
+			}
+			stats := SyncStats{}
+
+			aborted := engine.syncProviderDBBackedAgent(
+				t.Context(), agent, string(agent), syncWriteBulk, false,
+				newRootSyncScope([]string{root}), &stats, func(int, int) {},
+			)
+
+			assert.False(t, aborted)
+			assert.Equal(t, 1, lookupCalls,
+				"one warm discovery page must use one attribution lookup")
+			assert.Empty(t, provider.parseCalls,
+				"current warm sources must not be reparsed")
+		})
+	}
+}
+
+func TestSyncProviderDBBackedBaselinesEveryStoredMachineForSharedSource(
+	t *testing.T,
+) {
+	const agent parser.AgentType = "shared-db-backed"
+	database := openTestDB(t)
+	root := t.TempDir()
+	path := filepath.Join(root, "shared.db")
+	mtime := int64(2)
+	for _, seed := range []struct {
+		id      string
+		machine string
+	}{
+		{id: "shared-a", machine: "machine-a"},
+		{id: "shared-b", machine: "machine-b"},
+	} {
+		require.NoError(t, database.UpsertSession(db.Session{
+			ID: seed.id, Project: "project", Machine: seed.machine,
+			Agent: string(agent), FilePath: &path, FileMtime: &mtime,
+		}))
+		require.NoError(t, database.SetSessionDataVersion(
+			seed.id, db.CurrentDataVersion(),
+		))
+	}
+	provider := &baselineDBBackedProvider{
+		ProviderBase: parser.ProviderBase{
+			Def: parser.AgentDef{Type: agent, FileBased: false},
+			Caps: parser.Capabilities{Source: parser.SourceCapabilities{
+				StreamingDiscovery: parser.CapabilitySupported,
+			}},
+		},
+		sources: []parser.SourceRef{{
+			Provider: agent, Key: path,
+			DisplayPath: path, FingerprintKey: path,
+		}},
+		outcomes:         make(map[string]parser.ParseOutcome),
+		fingerprintCalls: make(map[string]int),
+		parseCalls:       make(map[string]int),
+	}
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{agent: {root}},
+		SourceMachines: map[parser.AgentType]map[string]string{
+			agent: {root: "renamed-machine"},
+		},
+		Machine: "local",
+		ProviderFactories: []parser.ProviderFactory{
+			baselineDBBackedFactory{provider: provider},
+		},
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			agent: parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+	stats := SyncStats{}
+
+	aborted := engine.syncProviderDBBackedAgent(
+		t.Context(), agent, string(agent), syncWriteBulk, false,
+		newRootSyncScope([]string{root}), &stats, func(int, int) {},
+	)
+
+	assert.False(t, aborted)
+	for _, machine := range []string{"machine-a", "machine-b"} {
+		ownership, err := database.ListActiveSessionSourceOwnershipScopesPage(
+			t.Context(), machine, string(agent),
+			[]db.StoredSourcePathHintScope{{Path: root}},
+			db.SessionSourceCursor{},
+		)
+		require.NoError(t, err)
+		require.Len(t, ownership, 1,
+			"shared source must keep proof for %s", machine)
+		assert.Equal(t, path, ownership[0].FilePath)
+	}
+	configured, err := database.ListActiveSessionSourceOwnershipScopesPage(
+		t.Context(), "renamed-machine", string(agent),
+		[]db.StoredSourcePathHintScope{{Path: root}},
+		db.SessionSourceCursor{},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, configured,
+		"configured relabel must not replace stored source attribution")
 }
 
 func TestSyncProviderDBBackedAgentFlushesEachSourceBeforeParsingNext(t *testing.T) {

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -110,6 +110,7 @@ func TestPreserveUnavailableSourceProjectsUsesDurableSnapshot(
 		makeSource    bool
 		statErr       error
 		idPrefix      string
+		emptyMachine  bool
 	}{
 		{
 			name:          "missing source",
@@ -129,6 +130,11 @@ func TestPreserveUnavailableSourceProjectsUsesDurableSnapshot(
 			parsedProject: "parser-fallback",
 			idPrefix:      "remote~",
 		},
+		{
+			name:          "empty legacy machine",
+			parsedProject: "parser-fallback",
+			emptyMachine:  true,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			const (
@@ -136,6 +142,14 @@ func TestPreserveUnavailableSourceProjectsUsesDurableSnapshot(
 				originalProject = "resolved-project"
 				machine         = "test-machine"
 			)
+			attributedMachine := machine
+			if tc.emptyMachine {
+				attributedMachine = ""
+			}
+			snapshotMachine := attributedMachine
+			if snapshotMachine == "" {
+				snapshotMachine = machine
+			}
 			database := openTestDB(t)
 			root := filepath.Join(t.TempDir(), "checkout")
 			cwd := filepath.Join(root, "nested")
@@ -144,14 +158,15 @@ func TestPreserveUnavailableSourceProjectsUsesDurableSnapshot(
 				require.NoError(t, os.MkdirAll(cwd, 0o755))
 			}
 			require.NoError(t, database.UpsertSession(db.Session{
-				ID: storedSessionID, Project: originalProject, Machine: machine,
-				Agent: string(parser.AgentClaude), Cwd: cwd,
+				ID: storedSessionID, Project: originalProject,
+				Machine: attributedMachine,
+				Agent:   string(parser.AgentClaude), Cwd: cwd,
 			}))
 			require.NoError(t,
 				database.UpsertProjectIdentityObservationWithSnapshotProject(
 					t.Context(), export.ProjectIdentityObservation{
 						SessionID: storedSessionID, Project: originalProject,
-						Machine: machine, RootPath: root,
+						Machine: snapshotMachine, RootPath: root,
 						GitRemote:        "https://example.com/team/project.git",
 						RemoteResolution: export.ProjectResolutionResolved,
 						ObservedAt: time.Date(
@@ -172,8 +187,9 @@ func TestPreserveUnavailableSourceProjectsUsesDurableSnapshot(
 
 			result, err := engine.preserveUnavailableSourceProjects(
 				t.Context(), []pendingWrite{{sess: parser.ParsedSession{
-					ID: sessionID, Project: tc.parsedProject, Machine: machine,
-					Agent: parser.AgentClaude, Cwd: cwd,
+					ID: sessionID, Project: tc.parsedProject,
+					Machine: attributedMachine,
+					Agent:   parser.AgentClaude, Cwd: cwd,
 				}}},
 			)
 			require.NoError(t, err)
@@ -313,7 +329,7 @@ func TestWriteBatchDuplicateNewSessionIDKeepsFirstMachine(t *testing.T) {
 		"every same-batch copy must use the machine of the first ingestion")
 }
 
-func TestWriteBatchRejectsDivergentForeignSessionIDCollision(t *testing.T) {
+func TestWriteBatchUnverifiedCopyKeepsStoredIdentitySnapshot(t *testing.T) {
 	const sessionID = "shared-native-id"
 	database := openTestDB(t)
 	engine := NewEngine(database, EngineConfig{Machine: "local-machine"})
@@ -341,23 +357,28 @@ func TestWriteBatchRejectsDivergentForeignSessionIDCollision(t *testing.T) {
 	require.Equal(t, 1, initial.writtenSessions)
 	require.Zero(t, initial.failedSessions)
 
-	collision := engine.writeBatchWithOutcome([]pendingWrite{
+	copyWrite := engine.writeBatchWithOutcome([]pendingWrite{
 		write("foreign-machine", "foreign-project", foreignPath, "foreign-hash", "foreign content"),
-	}, syncWriteDefault, true)
+	}, syncWriteBulk, true)
 
-	assert.Zero(t, collision.writtenSessions)
-	assert.Equal(t, 1, collision.failedSessions)
+	assert.Equal(t, 1, copyWrite.writtenSessions)
+	assert.Zero(t, copyWrite.failedSessions)
 	stored, err := database.GetSessionFull(t.Context(), sessionID)
 	require.NoError(t, err)
 	require.NotNil(t, stored)
 	assert.Equal(t, "local-machine", stored.Machine)
-	assert.Equal(t, "local-project", stored.Project)
+	assert.Equal(t, "foreign-project", stored.Project)
 	require.NotNil(t, stored.FilePath)
-	assert.Equal(t, localPath, *stored.FilePath)
+	assert.Equal(t, foreignPath, *stored.FilePath)
 	messages, err := database.GetAllMessages(t.Context(), sessionID)
 	require.NoError(t, err)
 	require.Len(t, messages, 1)
-	assert.Equal(t, "local content", messages[0].Content)
+	assert.Equal(t, "foreign content", messages[0].Content)
+	snapshots, err := database.ListSessionProjectIdentitySnapshots(t.Context())
+	require.NoError(t, err)
+	require.Len(t, snapshots, 1)
+	assert.Equal(t, "local-project", snapshots[0].Project,
+		"an unverified copy must not rewrite local filesystem identity evidence")
 }
 
 func TestWriteBatchResyncDuplicateIDKeepsFirstReplacementMachine(t *testing.T) {

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -301,6 +301,62 @@ func TestWriteBatchResyncDuplicateIDKeepsFirstReplacementMachine(t *testing.T) {
 		"a later rebuild batch must retain the first replacement write's machine")
 }
 
+func TestWriteBatchExistingEmptyMachineRemainsEmpty(t *testing.T) {
+	const sessionID = "legacy-empty-machine"
+	database := openTestDB(t)
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: sessionID, Project: "legacy", Machine: "",
+		Agent: string(parser.AgentCopilot),
+	}))
+	engine := NewEngine(database, EngineConfig{Machine: "local-machine"})
+	t.Cleanup(engine.Close)
+	startedAt := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+
+	outcome := engine.writeBatchWithOutcome([]pendingWrite{{
+		sess: parser.ParsedSession{
+			ID: sessionID, Project: "refreshed", Machine: "archivebox",
+			Agent: parser.AgentCopilot, StartedAt: startedAt, EndedAt: startedAt,
+			File: parser.FileInfo{Path: "/sources/session.jsonl"},
+		},
+	}}, syncWriteDefault, true)
+
+	require.Equal(t, 1, outcome.writtenSessions)
+	stored, err := database.GetSessionFull(t.Context(), sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	assert.Empty(t, stored.Machine,
+		"refreshing a legacy row must retain its stored empty attribution")
+}
+
+func TestWriteBatchResyncReplacementEmptyMachineRemainsEmpty(t *testing.T) {
+	const sessionID = "replacement-empty-machine"
+	original := openTestDB(t)
+	replacement := openTestDB(t)
+	require.NoError(t, replacement.UpsertSession(db.Session{
+		ID: sessionID, Project: "legacy", Machine: "",
+		Agent: string(parser.AgentCopilot),
+	}))
+	engine := NewEngine(replacement, EngineConfig{Machine: "local-machine"})
+	engine.archiveStore = original
+	t.Cleanup(engine.Close)
+	startedAt := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+
+	outcome := engine.writeBatchWithOutcome([]pendingWrite{{
+		sess: parser.ParsedSession{
+			ID: sessionID, Project: "refreshed", Machine: "archivebox",
+			Agent: parser.AgentCopilot, StartedAt: startedAt, EndedAt: startedAt,
+			File: parser.FileInfo{Path: "/sources/session.jsonl"},
+		},
+	}}, syncWriteDefault, true)
+
+	require.Equal(t, 1, outcome.writtenSessions)
+	stored, err := replacement.GetSessionFull(t.Context(), sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	assert.Empty(t, stored.Machine,
+		"a rebuild must retain an empty attribution already in the replacement")
+}
+
 func TestClaudeIDFreshnessRejectsSourceMissingTombstone(t *testing.T) {
 	database := openTestDB(t)
 	root := t.TempDir()

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -2780,7 +2780,11 @@ func TestReconciliationSourceBaselineUsesStoredPathRewrite(t *testing.T) {
 	require.NoError(t, engine.baselineReconciliationCandidates(
 		t.Context(), []reconciliationCandidate{{
 			Provider: parser.AgentClaude, Identity: "session", Path: localPath,
-		}}, []db.SessionSourcePath{{Agent: "claude", FilePath: storedPath}},
+			Machine: "host",
+		}}, []machineSessionSource{{
+			Machine: "host",
+			Source:  db.SessionSourcePath{Agent: "claude", FilePath: storedPath},
+		}},
 	))
 	changed, err := database.SoftDeleteSessionSourceOwnership(
 		t.Context(), "host", "claude", "session", storedPath,
@@ -6141,8 +6145,9 @@ func TestProcessFileSkipCacheReparsesStaleCodexProject(t *testing.T) {
 	}
 
 	res := e.processFile(context.Background(), parser.DiscoveredFile{
-		Agent: parser.AgentCodex,
-		Path:  path,
+		Agent:   parser.AgentCodex,
+		Path:    path,
+		Machine: "host",
 	})
 	require.NoError(t, res.err)
 	require.False(t, res.skip,
@@ -6485,8 +6490,9 @@ func TestProcessFileCodexDBFreshSkipIsNotCached(t *testing.T) {
 	}
 
 	res := e.processFile(context.Background(), parser.DiscoveredFile{
-		Agent: parser.AgentCodex,
-		Path:  path,
+		Agent:   parser.AgentCodex,
+		Path:    path,
+		Machine: "host",
 	})
 	require.NoError(t, res.err)
 	require.True(t, res.skip)

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -267,6 +267,40 @@ func TestWriteBatchDuplicateNewSessionIDKeepsFirstMachine(t *testing.T) {
 		"every same-batch copy must use the machine of the first ingestion")
 }
 
+func TestWriteBatchResyncDuplicateIDKeepsFirstReplacementMachine(t *testing.T) {
+	const sessionID = "copied-across-resync-batches"
+	original := openTestDB(t)
+	replacement := openTestDB(t)
+	engine := NewEngine(replacement, EngineConfig{Machine: "local-machine"})
+	engine.archiveStore = original
+	t.Cleanup(engine.Close)
+	startedAt := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	write := func(machine, project, path string) pendingWrite {
+		return pendingWrite{sess: parser.ParsedSession{
+			ID: sessionID, Project: project, Machine: machine,
+			Agent: parser.AgentCopilot, StartedAt: startedAt, EndedAt: startedAt,
+			File: parser.FileInfo{Path: path},
+		}}
+	}
+
+	first := engine.writeBatchWithOutcome([]pendingWrite{
+		write("machine-a", "first-copy", "/sources/a/session.jsonl"),
+	}, syncWriteDefault, true)
+	require.Equal(t, 1, first.writtenSessions)
+	require.Zero(t, first.failedSessions)
+	second := engine.writeBatchWithOutcome([]pendingWrite{
+		write("machine-b", "second-copy", "/sources/b/session.jsonl"),
+	}, syncWriteDefault, true)
+	require.Equal(t, 1, second.writtenSessions)
+	require.Zero(t, second.failedSessions)
+
+	stored, err := replacement.GetSessionFull(t.Context(), sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	assert.Equal(t, "machine-a", stored.Machine,
+		"a later rebuild batch must retain the first replacement write's machine")
+}
+
 func TestClaudeIDFreshnessRejectsSourceMissingTombstone(t *testing.T) {
 	database := openTestDB(t)
 	root := t.TempDir()

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -1883,12 +1883,23 @@ func TestProviderForceReplaceRewritesResolvedMultiSessionHintScopes(t *testing.T
 		pathRewriter: func(path string) string { return "host:" + path },
 	}
 
-	ids, err := engine.providerSourceSessionIDsForForceReplace(provider, parser.SourceRef{
-		Provider: "scope-provider", DisplayPath: container,
-	})
+	ids, err := engine.providerSourceSessionIDsForForceReplace(
+		t.Context(), provider, parser.SourceRef{
+			Provider: "scope-provider", DisplayPath: container,
+		},
+	)
 
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"remote-a", "remote-b"}, ids)
+
+	canceled, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err = engine.providerSourceSessionIDsForForceReplace(
+		canceled, provider, parser.SourceRef{
+			Provider: "scope-provider", DisplayPath: container,
+		},
+	)
+	require.ErrorContains(t, err, "list provider force-replace session machines")
 }
 
 func TestProviderChangedPathEventKindTreatsExistingHashPathAsPhysical(t *testing.T) {

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -237,6 +237,52 @@ func TestWriteBatchRelabelRecoversUnavailableSourceProject(t *testing.T) {
 		"project recovery must use the stored machine before the checkout lookup")
 }
 
+func TestWriteBatchLegacyLocalRecoversUnavailableSourceProject(t *testing.T) {
+	const (
+		sessionID       = "legacy-local-unavailable-source"
+		originalProject = "resolved-project"
+		fallbackProject = "parser-fallback"
+		currentMachine  = "current-machine"
+	)
+	database := openTestDB(t)
+	root := filepath.Join(t.TempDir(), "missing-checkout")
+	cwd := filepath.Join(root, "nested")
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	recordedAt := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: sessionID, Project: originalProject, Machine: "local",
+		Agent: string(parser.AgentClaude), Cwd: cwd, FilePath: &path,
+	}))
+	require.NoError(t, database.UpsertProjectIdentityObservationWithSnapshotProject(
+		t.Context(), export.ProjectIdentityObservation{
+			SessionID: sessionID, Project: originalProject, Machine: "local",
+			RootPath: root, GitRemote: "https://example.com/team/project.git",
+			RemoteResolution: export.ProjectResolutionResolved,
+			ObservedAt:       recordedAt,
+		}, originalProject,
+	))
+	engine := NewEngine(database, EngineConfig{Machine: currentMachine})
+	t.Cleanup(engine.Close)
+
+	outcome := engine.writeBatchWithOutcome([]pendingWrite{{
+		sess: parser.ParsedSession{
+			ID: sessionID, Project: fallbackProject, Machine: currentMachine,
+			Agent: parser.AgentClaude, Cwd: cwd,
+			StartedAt: recordedAt, EndedAt: recordedAt,
+			File: parser.FileInfo{Path: path, Mtime: recordedAt.UnixNano()},
+		},
+	}}, syncWriteDefault, true)
+
+	require.Equal(t, 1, outcome.writtenSessions)
+	stored, err := database.GetSessionFull(t.Context(), sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	assert.Equal(t, "local", stored.Machine,
+		"legacy attribution must remain immutable")
+	assert.Equal(t, originalProject, stored.Project,
+		"legacy local attribution must still use local project recovery")
+}
+
 func TestWriteBatchDuplicateNewSessionIDKeepsFirstMachine(t *testing.T) {
 	const sessionID = "copied-session"
 	database := openTestDB(t)
@@ -5391,6 +5437,40 @@ func TestProjectIdentityObservationSkipsDiscoveryForRemoteMachine(t *testing.T) 
 		"foreign-machine cwd must not be probed for a local git identity")
 	assert.Equal(t, cwd, observations[0].RootPath,
 		"root path must stay the raw cwd, not a locally resolved git root")
+}
+
+func TestProjectIdentityObservationDiscoversForLegacyLocalMachine(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(root, ".git"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, ".git", "config"),
+		[]byte("[remote \"origin\"]\n\turl = https://github.com/acme/remote.git\n"),
+		0o644,
+	))
+	cwd := filepath.Join(root, "subdir")
+	require.NoError(t, os.Mkdir(cwd, 0o755))
+	engine := NewEngine(database, EngineConfig{Machine: "current-machine"})
+	t.Cleanup(engine.Close)
+
+	require.NoError(t, engine.writeProjectIdentityObservation(
+		t.Context(), db.Session{
+			ID: "identity-legacy-local", Project: "legacy-local-project",
+			Machine: "local", Agent: "codex", Cwd: cwd,
+			StartedAt: strPtr(time.Now().UTC().Format(time.RFC3339Nano)),
+		},
+	))
+
+	observations, err := database.ListProjectIdentityObservations(
+		t.Context(), []string{"legacy-local-project"},
+	)
+	require.NoError(t, err)
+	require.Len(t, observations, 1)
+	assert.Equal(t, "https://github.com/acme/remote.git",
+		observations[0].GitRemote,
+		"legacy local attribution must still discover local git identity")
+	assert.Equal(t, "local", observations[0].Machine,
+		"discovery must not rewrite persisted attribution")
 }
 
 func TestProjectIdentitySafeLocalAbsolutePathHandlesWindowsDriveRootsByOS(t *testing.T) {

--- a/internal/sync/hermes_archive_test.go
+++ b/internal/sync/hermes_archive_test.go
@@ -482,7 +482,10 @@ func TestReconcileHermesDefaultSessionsRootTombstonesRemovedStateMember(t *testi
 		AgentDirs: map[parser.AgentType][]string{
 			parser.AgentHermes: {sessionsDir},
 		},
-		Machine: "local",
+		SourceMachines: map[parser.AgentType]map[string]string{
+			parser.AgentHermes: {sessionsDir: "archivebox"},
+		},
+		Machine: "localbox",
 	})
 	t.Cleanup(engine.Close)
 
@@ -492,6 +495,10 @@ func TestReconcileHermesDefaultSessionsRootTombstonesRemovedStateMember(t *testi
 	stored, err := database.GetSession(t.Context(), "hermes:child")
 	require.NoError(t, err)
 	require.NotNil(t, stored, "initial reconciliation must store the state member")
+	assert.Equal(t, "archivebox", stored.Machine)
+	require.NoError(t, engine.ReconcileWatchRootsAfterLostEvents(
+		t.Context(), []string{sessionsDir}, false,
+	))
 
 	conn, err := sql.Open("sqlite3", stateDB)
 	require.NoError(t, err)
@@ -558,6 +565,44 @@ func TestReconcileHermesScopedArchiveTombstonesRemovedStateMember(
 	require.NoError(t, err)
 	assert.NotNil(t, survivor,
 		"the unrequested root's sessions are untouched")
+}
+
+func TestReconcileHermesLabeledStateDBRootTombstonesRemovedMember(t *testing.T) {
+	root := t.TempDir()
+	stateDB := writeHermesArchiveStateDB(t, root)
+
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentHermes: {stateDB},
+		},
+		SourceMachines: map[parser.AgentType]map[string]string{
+			parser.AgentHermes: {stateDB: "archivebox"},
+		},
+		Machine: "localbox",
+	})
+	t.Cleanup(engine.Close)
+
+	require.NoError(t, engine.ReconcileWatchRootsAfterLostEvents(
+		t.Context(), []string{root}, false,
+	))
+	stored, err := database.GetSession(t.Context(), "hermes:child")
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	assert.Equal(t, "archivebox", stored.Machine)
+
+	conn, err := sql.Open("sqlite3", stateDB)
+	require.NoError(t, err)
+	_, err = conn.ExecContext(t.Context(), "DELETE FROM sessions WHERE id = 'child'")
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	require.NoError(t, engine.ReconcileWatchRootsAfterLostEvents(
+		t.Context(), []string{root}, false,
+	))
+	stored, err = database.GetSession(t.Context(), "hermes:child")
+	require.NoError(t, err)
+	assert.Nil(t, stored)
 }
 
 // Streamed discovery must open state.db a bounded number of times per pass:

--- a/internal/sync/hermes_integration_test.go
+++ b/internal/sync/hermes_integration_test.go
@@ -1,6 +1,7 @@
 package sync_test
 
 import (
+	"context"
 	"database/sql"
 	"os"
 	"path/filepath"
@@ -14,6 +15,86 @@ import (
 	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/sync"
 )
+
+func TestSyncAllAttributesHermesSiblingStateDBFromSessionsRoot(t *testing.T) {
+	root := t.TempDir()
+	sessionsRoot := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsRoot, 0o755))
+	writeHermesSyncStateDB(t, root)
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentHermes: {sessionsRoot},
+		},
+		SourceMachines: map[parser.AgentType]map[string]string{
+			parser.AgentHermes: {sessionsRoot: "archivebox"},
+		},
+		Machine: "localbox",
+	})
+
+	stats := engine.SyncAll(context.Background(), nil)
+
+	require.Equal(t, 1, stats.Synced)
+	sess, err := database.GetSessionFull(context.Background(), "hermes:child")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, "archivebox", sess.Machine)
+	require.NotNil(t, sess.FilePath)
+	assert.Equal(t, filepath.Join(root, "state.db"), *sess.FilePath)
+}
+
+func TestSyncPathsAttributesHermesSiblingStateDBFromSessionsRoot(t *testing.T) {
+	root := t.TempDir()
+	sessionsRoot := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsRoot, 0o755))
+	stateDB := writeHermesSyncStateDB(t, root)
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentHermes: {sessionsRoot},
+		},
+		SourceMachines: map[parser.AgentType]map[string]string{
+			parser.AgentHermes: {sessionsRoot: "archivebox"},
+		},
+		Machine: "localbox",
+	})
+
+	engine.SyncPathsContext(context.Background(), []string{stateDB})
+
+	sess, err := database.GetSessionFull(context.Background(), "hermes:child")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, "archivebox", sess.Machine)
+}
+
+func TestSyncSingleSessionAttributesHermesSiblingStateDBFromSessionsRoot(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	sessionsRoot := filepath.Join(root, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsRoot, 0o755))
+	writeHermesSyncStateDB(t, root)
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentHermes: {sessionsRoot},
+		},
+		SourceMachines: map[parser.AgentType]map[string]string{
+			parser.AgentHermes: {sessionsRoot: "archivebox"},
+		},
+		Machine: "localbox",
+	})
+
+	require.Equal(t, 1, engine.SyncAll(t.Context(), nil).Synced)
+	require.NoError(t, engine.SyncSingleSessionContext(
+		t.Context(), "hermes:child",
+	))
+
+	sess, err := database.GetSessionFull(t.Context(), "hermes:child")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, "archivebox", sess.Machine)
+}
 
 func TestSyncPathsHermesStateDBEventRefreshesArchive(t *testing.T) {
 	if testing.Short() {

--- a/internal/sync/provider_process_test.go
+++ b/internal/sync/provider_process_test.go
@@ -122,6 +122,150 @@ func TestProcessFileProviderForgeVirtualSource(t *testing.T) {
 	assert.Len(t, res.results[0].Messages, 2)
 }
 
+func TestProviderChangedPathUsesSourceMachine(t *testing.T) {
+	root := t.TempDir()
+	dbPath := writeProcessProviderForgeDB(t, root)
+	database := openTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentForge: {root},
+		},
+		SourceMachines: map[parser.AgentType]map[string]string{
+			parser.AgentForge: {root: "archivebox"},
+		},
+		Machine: "localbox",
+	})
+
+	files, err := engine.classifyProviderChangedPath(t.Context(), dbPath)
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Equal(t, "archivebox", files[0].Machine)
+
+	res := engine.processFile(context.Background(), files[0])
+
+	require.NoError(t, res.err)
+	require.Len(t, res.results, 1)
+	assert.Equal(t, "archivebox", res.results[0].Session.Machine)
+	assert.Equal(t, "forge:conv-001", res.results[0].Session.ID)
+
+	engine.SyncPathsContext(context.Background(), []string{dbPath})
+	sess, err := database.GetSessionFull(context.Background(), "forge:conv-001")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, "archivebox", sess.Machine)
+}
+
+func TestProviderPeriodicSyncUsesSourceMachine(t *testing.T) {
+	root := t.TempDir()
+	writeProcessProviderForgeDB(t, root)
+	database := openTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentForge: {root},
+		},
+		SourceMachines: map[parser.AgentType]map[string]string{
+			parser.AgentForge: {root: "archivebox"},
+		},
+		Machine: "localbox",
+	})
+
+	stats := engine.SyncAll(context.Background(), nil)
+
+	assert.False(t, stats.Aborted)
+	sess, err := database.GetSessionFull(context.Background(), "forge:conv-001")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, "archivebox", sess.Machine)
+}
+
+func TestProviderPeriodicSyncPreservesFreshDBBackedSourceMachine(t *testing.T) {
+	root := t.TempDir()
+	writeProcessProviderForgeDB(t, root)
+	database := openTestDB(t)
+	newEngine := func(machine string) *Engine {
+		return NewEngine(database, EngineConfig{
+			AgentDirs: map[parser.AgentType][]string{
+				parser.AgentForge: {root},
+			},
+			SourceMachines: map[parser.AgentType]map[string]string{
+				parser.AgentForge: {root: machine},
+			},
+			Machine: "localbox",
+		})
+	}
+
+	first := newEngine("oldbox").SyncAll(context.Background(), nil)
+	require.Equal(t, 1, first.Synced)
+	second := newEngine("newbox").SyncAll(context.Background(), nil)
+	require.Zero(t, second.Synced)
+
+	sess, err := database.GetSessionFull(context.Background(), "forge:conv-001")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, "oldbox", sess.Machine)
+	assert.Equal(t, 2, sess.MessageCount)
+}
+
+func TestProviderPeriodicSyncPreservesTrashedDBBackedSourceMachine(t *testing.T) {
+	root := t.TempDir()
+	writeProcessProviderForgeDB(t, root)
+	database := openTestDB(t)
+	newEngine := func(machine string) *Engine {
+		return NewEngine(database, EngineConfig{
+			AgentDirs: map[parser.AgentType][]string{
+				parser.AgentForge: {root},
+			},
+			SourceMachines: map[parser.AgentType]map[string]string{
+				parser.AgentForge: {root: machine},
+			},
+			Machine: "localbox",
+		})
+	}
+
+	require.Equal(t, 1, newEngine("oldbox").SyncAll(t.Context(), nil).Synced)
+	require.NoError(t, database.SoftDeleteSession("forge:conv-001"))
+	require.Zero(t, newEngine("newbox").SyncAll(t.Context(), nil).Synced)
+
+	active, err := database.GetSession(t.Context(), "forge:conv-001")
+	require.NoError(t, err)
+	assert.Nil(t, active)
+	trashed, err := database.GetSessionFull(t.Context(), "forge:conv-001")
+	require.NoError(t, err)
+	require.NotNil(t, trashed)
+	assert.Equal(t, "oldbox", trashed.Machine)
+	assert.NotNil(t, trashed.DeletedAt)
+	assert.Nil(t, trashed.DeletionCause)
+	assert.Zero(t, newEngine("newbox").SyncAll(t.Context(), nil).Synced)
+}
+
+func TestProviderResyncPreservesTrashedDBBackedSourceMachine(t *testing.T) {
+	root := t.TempDir()
+	writeProcessProviderForgeDB(t, root)
+	database := openTestDB(t)
+	newEngine := func(machine string) *Engine {
+		return NewEngine(database, EngineConfig{
+			AgentDirs: map[parser.AgentType][]string{
+				parser.AgentForge: {root},
+			},
+			SourceMachines: map[parser.AgentType]map[string]string{
+				parser.AgentForge: {root: machine},
+			},
+			Machine: "localbox",
+		})
+	}
+
+	require.Equal(t, 1, newEngine("oldbox").SyncAll(t.Context(), nil).Synced)
+	require.NoError(t, database.SoftDeleteSession("forge:conv-001"))
+	stats := newEngine("newbox").ResyncAll(t.Context(), nil)
+	require.False(t, stats.Aborted)
+
+	trashed, err := database.GetSessionFull(t.Context(), "forge:conv-001")
+	require.NoError(t, err)
+	require.NotNil(t, trashed)
+	assert.Equal(t, "oldbox", trashed.Machine)
+	assert.NotNil(t, trashed.DeletedAt)
+}
+
 func TestProcessFileProviderSkipsStoredFreshSource(t *testing.T) {
 
 	root := t.TempDir()

--- a/internal/sync/provider_sync_semantics_test.go
+++ b/internal/sync/provider_sync_semantics_test.go
@@ -440,16 +440,20 @@ func TestOmnigentCompleteResultOwnershipTombstonesAndRevivesMissingMember(
 		},
 		{
 			ID: "omnigent:missing", Agent: string(parser.AgentOmnigent),
-			Machine: "devbox", FilePath: &missingPath,
+			Machine: "", FilePath: &missingPath,
 		},
 	} {
 		require.NoError(t, database.UpsertSession(seed))
 	}
 	require.NoError(t, database.BaselineActiveSessionSourcePaths(
-		t.Context(), "devbox", []db.SessionSourcePath{
-			{Agent: string(parser.AgentOmnigent), FilePath: keptPath},
-			{Agent: string(parser.AgentOmnigent), FilePath: missingPath},
-		},
+		t.Context(), "devbox", []db.SessionSourcePath{{
+			Agent: string(parser.AgentOmnigent), FilePath: keptPath,
+		}},
+	))
+	require.NoError(t, database.BaselineActiveSessionSourcePaths(
+		t.Context(), "", []db.SessionSourcePath{{
+			Agent: string(parser.AgentOmnigent), FilePath: missingPath,
+		}},
 	))
 	provider, source := newContainerSemanticProvider(
 		container, fingerprint, parser.ParseOutcome{
@@ -477,6 +481,7 @@ func TestOmnigentCompleteResultOwnershipTombstonesAndRevivesMissingMember(
 	archived, err := database.GetSessionFull(t.Context(), "omnigent:missing")
 	require.NoError(t, err)
 	require.NotNil(t, archived)
+	assert.Empty(t, archived.Machine)
 	require.NotNil(t, archived.DeletionCause)
 	assert.Equal(t, "source_missing", *archived.DeletionCause)
 
@@ -502,7 +507,8 @@ func TestOmnigentCompleteResultOwnershipTombstonesAndRevivesMissingMember(
 
 	revived, err := database.GetSession(t.Context(), "omnigent:missing")
 	require.NoError(t, err)
-	assert.NotNil(t, revived)
+	require.NotNil(t, revived)
+	assert.Empty(t, revived.Machine)
 }
 
 func TestCompleteResultOwnershipReadFailureAbortsWithoutCaching(
@@ -610,13 +616,13 @@ func TestOmnigentDependentSourceExpansionPreservesEngineIDPrefixing(
 	require.NoError(t, database.UpsertSession(db.Session{
 		ID:       parentID,
 		Agent:    string(parser.AgentOmnigent),
-		Machine:  "local",
+		Machine:  "",
 		FilePath: &rootPath,
 	}))
 	require.NoError(t, database.UpsertSession(db.Session{
 		ID:              "remote~omnigent:child",
 		Agent:           string(parser.AgentOmnigent),
-		Machine:         "local",
+		Machine:         "",
 		ParentSessionID: &parentID,
 		FilePath:        &childPath,
 	}))

--- a/internal/sync/provider_sync_semantics_test.go
+++ b/internal/sync/provider_sync_semantics_test.go
@@ -638,6 +638,13 @@ func TestOmnigentDependentSourceExpansionPreservesEngineIDPrefixing(
 
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []parser.SourceRef{rootSource, childSource}, expanded)
+
+	canceled, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err = engine.expandOmnigentInheritedMetadataSources(
+		canceled, provider, []parser.SourceRef{rootSource},
+	)
+	require.ErrorContains(t, err, "list omnigent parent session machines")
 }
 
 // TestBaselineFailureDoesNotPromoteSkipCache pins the omnigent-only cache

--- a/internal/sync/rebuild_contributor_test.go
+++ b/internal/sync/rebuild_contributor_test.go
@@ -247,13 +247,14 @@ func TestResyncAbortsWhenLabeledLocalSourceDisappearsAlongsideHealthyContributor
 	require.NoError(t, err)
 	require.NotNil(t, local)
 	require.Equal(t, "archive-host", local.Machine)
+	engine.sourceMachines[parser.AgentClaude][localRoot] = "renamed-archive-host"
 	require.NoError(t, os.Remove(localPath))
 
 	stats, err := engine.ResyncAllWithOptions(context.Background(), nil, options)
 
 	require.NoError(t, err)
 	assert.True(t, stats.Aborted,
-		"a healthy contributor must not mask an empty labeled local source")
+		"a healthy contributor must not mask a relabeled local source")
 	local, err = database.GetSession(context.Background(), "local")
 	require.NoError(t, err)
 	assert.NotNil(t, local, "aborted rebuild must preserve labeled local history")

--- a/internal/sync/rebuild_contributor_test.go
+++ b/internal/sync/rebuild_contributor_test.go
@@ -202,6 +202,66 @@ func TestResyncAbortsWhenContributorLosesHistoricalSource(t *testing.T) {
 	assert.NotNil(t, remote, "aborted rebuild must preserve the active archive")
 }
 
+func TestResyncAbortsWhenLabeledLocalSourceDisappearsAlongsideHealthyContributor(
+	t *testing.T,
+) {
+	localRoot := t.TempDir()
+	remoteRoot := t.TempDir()
+	localPath := filepath.Join(localRoot, "local", "local.jsonl")
+	remotePath := filepath.Join(remoteRoot, "remote", "remote.jsonl")
+	for path, content := range map[string]string{
+		localPath:  "labeled local source",
+		remotePath: "healthy contributor source",
+	} {
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(testjsonl.NewSessionBuilder().
+			AddClaudeUser("2026-01-01T00:00:00Z", content).String()), 0o644))
+	}
+	database, err := db.Open(filepath.Join(t.TempDir(), "archive.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {localRoot},
+		},
+		SourceMachines: map[parser.AgentType]map[string]string{
+			parser.AgentClaude: {localRoot: "archive-host"},
+		},
+		Machine: "collector-host",
+	})
+	t.Cleanup(engine.Close)
+	options := RebuildOptions{Contributors: []RebuildContributor{{
+		Name: "remote-host",
+		Config: EngineConfig{
+			AgentDirs: map[parser.AgentType][]string{
+				parser.AgentClaude: {remoteRoot},
+			},
+			Machine: "remote-host", IDPrefix: "remote-host~", Ephemeral: true,
+		},
+	}}}
+
+	initial, err := engine.ResyncAllWithOptions(context.Background(), nil, options)
+	require.NoError(t, err)
+	require.False(t, initial.Aborted, "initial rebuild aborted: %+v", initial)
+	local, err := database.GetSession(context.Background(), "local")
+	require.NoError(t, err)
+	require.NotNil(t, local)
+	require.Equal(t, "archive-host", local.Machine)
+	require.NoError(t, os.Remove(localPath))
+
+	stats, err := engine.ResyncAllWithOptions(context.Background(), nil, options)
+
+	require.NoError(t, err)
+	assert.True(t, stats.Aborted,
+		"a healthy contributor must not mask an empty labeled local source")
+	local, err = database.GetSession(context.Background(), "local")
+	require.NoError(t, err)
+	assert.NotNil(t, local, "aborted rebuild must preserve labeled local history")
+	remote, err := database.GetSession(context.Background(), "remote-host~remote")
+	require.NoError(t, err)
+	assert.NotNil(t, remote, "aborted rebuild must preserve contributor history")
+}
+
 func TestResyncDoesNotTreatSameNamedContributorAsLocalHistory(t *testing.T) {
 	localRoot := t.TempDir()
 	remoteRoot := t.TempDir()

--- a/internal/sync/reconciliation_spool.go
+++ b/internal/sync/reconciliation_spool.go
@@ -25,6 +25,7 @@ type reconciliationCandidate struct {
 	StoredPath     string
 	MemberIdentity string
 	WatchRoot      string
+	Machine        string
 	Project        string
 	Preference1    int64
 	Preference2    int64
@@ -93,14 +94,14 @@ func (spool *reconciliationSpool) Candidate(
 	var candidate reconciliationCandidate
 	var providerName string
 	err := spool.db.QueryRowContext(ctx, `
-		SELECT provider, identity, path, stored_path, member_identity, watch_root, project,
+		SELECT provider, identity, path, stored_path, member_identity, watch_root, machine, project,
 		       preference_1, preference_2, preference_3
 		FROM candidates
 		WHERE provider = ? AND identity = ?
 	`, string(provider), identity).Scan(
 		&providerName, &candidate.Identity, &candidate.Path, &candidate.StoredPath,
 		&candidate.MemberIdentity,
-		&candidate.WatchRoot, &candidate.Project,
+		&candidate.WatchRoot, &candidate.Machine, &candidate.Project,
 		&candidate.Preference1, &candidate.Preference2,
 		&candidate.Preference3,
 	)
@@ -237,6 +238,7 @@ func (spool *reconciliationSpool) initialize() error {
 			stored_path TEXT NOT NULL,
 			member_identity TEXT NOT NULL,
 			watch_root TEXT NOT NULL,
+			machine TEXT NOT NULL,
 			project TEXT NOT NULL,
 			preference_1 INTEGER NOT NULL,
 			preference_2 INTEGER NOT NULL,
@@ -267,14 +269,15 @@ func (spool *reconciliationSpool) Add(
 	}
 	_, err := spool.db.ExecContext(ctx, `
 		INSERT INTO candidates (
-			provider, identity, path, stored_path, member_identity, watch_root, project,
-			preference_1, preference_2, preference_3
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			provider, identity, path, stored_path, member_identity, watch_root, machine,
+			project, preference_1, preference_2, preference_3
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(provider, identity) DO UPDATE SET
 			path = excluded.path,
 			stored_path = excluded.stored_path,
 			member_identity = excluded.member_identity,
 			watch_root = excluded.watch_root,
+			machine = excluded.machine,
 			project = excluded.project,
 			preference_1 = excluded.preference_1,
 			preference_2 = excluded.preference_2,
@@ -291,7 +294,7 @@ func (spool *reconciliationSpool) Add(
 		       AND excluded.path < candidates.path)
 	`, string(candidate.Provider), candidate.Identity, candidate.Path,
 		candidate.StoredPath, candidate.MemberIdentity,
-		candidate.WatchRoot, candidate.Project, candidate.Preference1,
+		candidate.WatchRoot, candidate.Machine, candidate.Project, candidate.Preference1,
 		candidate.Preference2, candidate.Preference3)
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
@@ -315,7 +318,7 @@ func (spool *reconciliationSpool) Page(
 		limit = reconciliationPageSize
 	}
 	rows, err := spool.db.QueryContext(ctx, `
-		SELECT provider, identity, path, stored_path, member_identity, watch_root, project,
+		SELECT provider, identity, path, stored_path, member_identity, watch_root, machine, project,
 		       preference_1, preference_2, preference_3
 		FROM candidates
 		WHERE provider > ? OR (provider = ? AND identity > ?)
@@ -337,7 +340,7 @@ func (spool *reconciliationSpool) Page(
 		if err := rows.Scan(
 			&provider, &candidate.Identity, &candidate.Path, &candidate.StoredPath,
 			&candidate.MemberIdentity,
-			&candidate.WatchRoot, &candidate.Project,
+			&candidate.WatchRoot, &candidate.Machine, &candidate.Project,
 			&candidate.Preference1, &candidate.Preference2,
 			&candidate.Preference3,
 		); err != nil {

--- a/internal/sync/reconciliation_spool_test.go
+++ b/internal/sync/reconciliation_spool_test.go
@@ -23,12 +23,13 @@ func TestReconciliationSpoolSelectsPreferredCandidateInSQL(t *testing.T) {
 	ctx := t.Context()
 	require.NoError(t, spool.Add(ctx, reconciliationCandidate{
 		Provider: parser.AgentClaude, Identity: "same", Path: "/sessions/old.jsonl",
-		StoredPath:  "remote:/sessions/old.jsonl",
+		StoredPath: "remote:/sessions/old.jsonl", Machine: "old-machine",
 		Preference1: 100, Preference2: 1,
 	}))
 	require.NoError(t, spool.Add(ctx, reconciliationCandidate{
 		Provider: parser.AgentClaude, Identity: "same", Path: "/sessions/new.jsonl",
 		StoredPath: "remote:/sessions/new.jsonl", MemberIdentity: "stable",
+		Machine:     "new-machine",
 		Preference1: 200, Preference2: 2,
 	}))
 	require.NoError(t, spool.Add(ctx, reconciliationCandidate{
@@ -45,6 +46,7 @@ func TestReconciliationSpoolSelectsPreferredCandidateInSQL(t *testing.T) {
 	require.Len(t, page, 2)
 	assert.Equal(t, "/sessions/new.jsonl", page[0].Path)
 	assert.Equal(t, "remote:/sessions/new.jsonl", page[0].StoredPath)
+	assert.Equal(t, "new-machine", page[0].Machine)
 	assert.Equal(t, "/sessions/2026/07/14/rollout-uuid.jsonl", page[1].Path)
 	present, err := spool.ContainsSource(
 		ctx, parser.AgentClaude, "remote:/sessions/new.jsonl",

--- a/internal/sync/roocode_freshness_test.go
+++ b/internal/sync/roocode_freshness_test.go
@@ -52,7 +52,7 @@ func TestRooCodeFreshBeforeFingerprintUsesCompositeStat(t *testing.T) {
 		sess.ID, db.CurrentDataVersion(),
 	))
 
-	engine := &Engine{db: database}
+	engine := &Engine{db: database, machine: "local"}
 	source := parser.SourceRef{DisplayPath: historyPath}
 	file := parser.DiscoveredFile{
 		Agent: parser.AgentRooCode,

--- a/internal/sync/session_source_machine_test.go
+++ b/internal/sync/session_source_machine_test.go
@@ -100,6 +100,23 @@ func TestMachineForPathUsesNormalizedRootSpecificity(t *testing.T) {
 	))
 }
 
+func TestMachineForPathMatchesAbsolutePathToRelativeRoot(t *testing.T) {
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	relativeRoot := filepath.Join("testdata", "relative-session-source")
+	engine := &Engine{
+		sourceMachines: map[parser.AgentType]map[string]string{
+			parser.AgentClaude: {relativeRoot: "archivebox"},
+		},
+		machine: "localbox",
+	}
+
+	assert.Equal(t, "archivebox", engine.machineForPath(
+		parser.AgentClaude,
+		filepath.Join(cwd, relativeRoot, "session.jsonl"),
+	))
+}
+
 func TestReconcileWatchRootsTombstonesMissingLabeledFilesystemSession(
 	t *testing.T,
 ) {

--- a/internal/sync/session_source_machine_test.go
+++ b/internal/sync/session_source_machine_test.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"database/sql"
 	"os"
 	"path/filepath"
 	"strings"
@@ -487,13 +488,34 @@ func TestReconcileTombstonesAfterSourceLabelChange(t *testing.T) {
 	require.False(t, first.SyncAll(context.Background(), nil).Aborted)
 
 	require.Equal(t, "archivebox", activeSessionMachines(t, database)["archive-session"])
+	// Model an archive admitted before deletion-proof baselines existed. The
+	// relabeled reconciliation must recreate proof under the stored machine,
+	// not only visit the configured candidate machine.
+	require.NoError(t, database.Update(func(tx *sql.Tx) error {
+		_, err := tx.Exec(
+			"DELETE FROM local_session_source_baselines WHERE session_id = ?",
+			"archive-session",
+		)
+		return err
+	}))
+	appendSessionSourceClaudeMessage(t, archivePath)
 
 	// The user edits the label. Existing rows keep "archivebox" by design.
 	relabeled := newEngine("renamedbox")
 	t.Cleanup(relabeled.Close)
-	require.False(t, relabeled.SyncAll(context.Background(), nil).Aborted)
+	require.NoError(t, relabeled.ReconcileWatchRootsAfterLostEvents(
+		context.Background(), []string{archiveRoot}, false,
+	))
 	assert.Equal(t, "archivebox", activeSessionMachines(t, database)["archive-session"],
 		"an edited label must not rewrite an already-ingested session")
+	ownership, err := database.ListActiveSessionSourceOwnershipScopesPage(
+		context.Background(), "archivebox", string(parser.AgentClaude),
+		[]db.StoredSourcePathHintScope{{Path: archiveRoot}},
+		db.SessionSourceCursor{},
+	)
+	require.NoError(t, err)
+	require.Len(t, ownership, 1,
+		"reconciliation must restore deletion proof under stored attribution")
 
 	// Now delete the source and reconcile under the new label.
 	require.NoError(t, os.Remove(archivePath))

--- a/internal/sync/session_source_machine_test.go
+++ b/internal/sync/session_source_machine_test.go
@@ -460,3 +460,63 @@ func writeSessionSourceClaudeFile(t *testing.T, root, name string) string {
 	require.NoError(t, os.WriteFile(path, []byte(builder.String()), 0o600))
 	return path
 }
+
+// TestReconcileTombstonesAfterSourceLabelChange pins the deletion path across a
+// configuration edit. Attribution is immutable, so a session admitted under the
+// old label keeps it; reconciliation must therefore query stored attribution
+// rather than the currently configured label, or the delete is never noticed.
+func TestReconcileTombstonesAfterSourceLabelChange(t *testing.T) {
+	archiveRoot := t.TempDir()
+	archivePath := writeSessionSourceClaudeFile(t, archiveRoot, "archive-session.jsonl")
+	database := openTestDB(t)
+
+	newEngine := func(machine string) *Engine {
+		return NewEngine(database, EngineConfig{
+			AgentDirs: map[parser.AgentType][]string{
+				parser.AgentClaude: {archiveRoot},
+			},
+			SourceMachines: map[parser.AgentType]map[string]string{
+				parser.AgentClaude: {archiveRoot: machine},
+			},
+			Machine: "localbox",
+		})
+	}
+
+	first := newEngine("archivebox")
+	t.Cleanup(first.Close)
+	require.False(t, first.SyncAll(context.Background(), nil).Aborted)
+
+	require.Equal(t, "archivebox", activeSessionMachines(t, database)["archive-session"])
+
+	// The user edits the label. Existing rows keep "archivebox" by design.
+	relabeled := newEngine("renamedbox")
+	t.Cleanup(relabeled.Close)
+	require.False(t, relabeled.SyncAll(context.Background(), nil).Aborted)
+	assert.Equal(t, "archivebox", activeSessionMachines(t, database)["archive-session"],
+		"an edited label must not rewrite an already-ingested session")
+
+	// Now delete the source and reconcile under the new label.
+	require.NoError(t, os.Remove(archivePath))
+	require.NoError(t, relabeled.ReconcileWatchRootsAfterLostEvents(
+		context.Background(), []string{archiveRoot}, false,
+	))
+
+	assert.NotContains(t, activeSessionMachines(t, database), "archive-session",
+		"a removed source must be tombstoned even though its stored label "+
+			"no longer matches the configured one")
+}
+
+// activeSessionMachines returns the stored machine of every active session,
+// keyed by session ID.
+func activeSessionMachines(t *testing.T, database *db.DB) map[string]string {
+	t.Helper()
+	page, err := database.ListSessions(context.Background(), db.SessionFilter{
+		Limit: 100,
+	})
+	require.NoError(t, err)
+	out := make(map[string]string, len(page.Sessions))
+	for _, session := range page.Sessions {
+		out[session.ID] = session.Machine
+	}
+	return out
+}

--- a/internal/sync/session_source_machine_test.go
+++ b/internal/sync/session_source_machine_test.go
@@ -545,6 +545,70 @@ func TestReconcileTombstonesAfterSourceLabelChange(t *testing.T) {
 			"no longer matches the configured one")
 }
 
+func TestReconcileTombstonesLegacyEmptyMachineSession(t *testing.T) {
+	root := t.TempDir()
+	path := writeSessionSourceClaudeFile(t, root, "legacy-empty-machine.jsonl")
+	database := openTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {root},
+		},
+		SourceMachines: map[parser.AgentType]map[string]string{
+			parser.AgentClaude: {root: "archivebox"},
+		},
+		Machine: "localbox",
+	})
+	t.Cleanup(engine.Close)
+	require.False(t, engine.SyncAll(t.Context(), nil).Aborted)
+
+	// Model a session admitted before machine attribution and deletion-proof
+	// baselines existed. Refreshing it must retain the empty attribution while
+	// recreating deletion proof for that exact stored ownership key.
+	require.NoError(t, database.Update(func(tx *sql.Tx) error {
+		if _, err := tx.Exec(
+			"UPDATE sessions SET machine = '' WHERE id = ?",
+			"legacy-empty-machine",
+		); err != nil {
+			return err
+		}
+		_, err := tx.Exec(
+			"DELETE FROM local_session_source_baselines WHERE session_id = ?",
+			"legacy-empty-machine",
+		)
+		return err
+	}))
+	appendSessionSourceClaudeMessage(t, path)
+	require.NoError(t, engine.ReconcileWatchRootsAfterLostEvents(
+		t.Context(), []string{root}, false,
+	))
+	machine, exists := activeSessionMachines(t, database)["legacy-empty-machine"]
+	require.True(t, exists)
+	assert.Empty(t, machine)
+	ownership, err := database.ListActiveSessionSourceOwnershipScopesPage(
+		t.Context(), "", string(parser.AgentClaude),
+		[]db.StoredSourcePathHintScope{{Path: root}},
+		db.SessionSourceCursor{},
+	)
+	require.NoError(t, err)
+	require.Len(t, ownership, 1,
+		"refresh must restore deletion proof for the empty stored machine key")
+
+	require.NoError(t, os.Remove(path))
+	require.NoError(t, engine.ReconcileWatchRootsAfterLostEvents(
+		t.Context(), []string{root}, false,
+	))
+
+	active, err := database.GetSession(t.Context(), "legacy-empty-machine")
+	require.NoError(t, err)
+	assert.Nil(t, active)
+	archived, err := database.GetSessionFull(t.Context(), "legacy-empty-machine")
+	require.NoError(t, err)
+	require.NotNil(t, archived)
+	assert.Empty(t, archived.Machine)
+	require.NotNil(t, archived.DeletionCause)
+	assert.Equal(t, "source_missing", *archived.DeletionCause)
+}
+
 // activeSessionMachines returns the stored machine of every active session,
 // keyed by session ID.
 func activeSessionMachines(t *testing.T, database *db.DB) map[string]string {

--- a/internal/sync/session_source_machine_test.go
+++ b/internal/sync/session_source_machine_test.go
@@ -1,0 +1,462 @@
+package sync
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/testjsonl"
+)
+
+func TestSyncAllAttributesFilesystemSessionsPerRoot(t *testing.T) {
+	localRoot := t.TempDir()
+	archiveRoot := t.TempDir()
+	writeSessionSourceClaudeFile(t, localRoot, "local-session.jsonl")
+	writeSessionSourceClaudeFile(t, archiveRoot, "archive-session.jsonl")
+	database := openTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {localRoot, archiveRoot},
+		},
+		SourceMachines: map[parser.AgentType]map[string]string{
+			parser.AgentClaude: {
+				localRoot:   "localbox",
+				archiveRoot: "archivebox",
+			},
+		},
+		Machine: "localbox",
+	})
+
+	stats := engine.SyncAll(context.Background(), nil)
+
+	assert.False(t, stats.Aborted)
+	page, err := database.ListSessions(context.Background(), db.SessionFilter{
+		Limit: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, page.Sessions, 2)
+	machines := map[string]string{}
+	for _, sess := range page.Sessions {
+		machines[sess.ID] = sess.Machine
+	}
+	assert.Equal(t, "localbox", machines["local-session"])
+	assert.Equal(t, "archivebox", machines["archive-session"])
+}
+
+func TestSyncPathsAttributesFilesystemSessionFromChangedRoot(t *testing.T) {
+	root := t.TempDir()
+	path := writeSessionSourceClaudeFile(t, root, "watched-session.jsonl")
+	database := openTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {root},
+		},
+		SourceMachines: map[parser.AgentType]map[string]string{
+			parser.AgentClaude: {root: "archivebox"},
+		},
+		Machine: "localbox",
+	})
+
+	engine.SyncPathsContext(context.Background(), []string{path})
+
+	sess, err := database.GetSessionFull(context.Background(), "watched-session")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, "archivebox", sess.Machine)
+}
+
+func TestMachineForPathUsesNormalizedRootSpecificity(t *testing.T) {
+	parent := t.TempDir()
+	nested := filepath.Join(parent, "nested")
+	var legacyParent strings.Builder
+	legacyParent.Grow(len(parent) + 20)
+	legacyParent.WriteString(parent)
+	for range 10 {
+		legacyParent.WriteByte(byte(filepath.Separator))
+		legacyParent.WriteByte('.')
+	}
+	legacyParentPath := legacyParent.String()
+	require.Greater(t, len(legacyParentPath), len(nested))
+	engine := &Engine{
+		sourceMachines: map[parser.AgentType]map[string]string{
+			parser.AgentClaude: {
+				legacyParentPath: "parentbox",
+				nested:           "nestedbox",
+			},
+		},
+		machine: "localbox",
+	}
+
+	assert.Equal(t, "nestedbox", engine.machineForPath(
+		parser.AgentClaude, filepath.Join(nested, "session.jsonl"),
+	))
+}
+
+func TestReconcileWatchRootsTombstonesMissingLabeledFilesystemSession(
+	t *testing.T,
+) {
+	root := t.TempDir()
+	path := writeSessionSourceClaudeFile(t, root, "missing-session.jsonl")
+	database := openTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {root},
+		},
+		SourceMachines: map[parser.AgentType]map[string]string{
+			parser.AgentClaude: {root: "archivebox"},
+		},
+		Machine: "localbox",
+	})
+
+	require.Equal(t, 1, engine.SyncAll(t.Context(), nil).Synced)
+	require.NoError(t, os.Remove(path))
+	require.NoError(t, engine.ReconcileWatchRoots(
+		t.Context(), []string{root}, false,
+	))
+
+	active, err := database.GetSession(t.Context(), "missing-session")
+	require.NoError(t, err)
+	assert.Nil(t, active)
+	archived, err := database.GetSessionFull(t.Context(), "missing-session")
+	require.NoError(t, err)
+	require.NotNil(t, archived)
+	assert.Equal(t, "archivebox", archived.Machine)
+	require.NotNil(t, archived.DeletionCause)
+	assert.Equal(t, "source_missing", *archived.DeletionCause)
+}
+
+func TestSyncAllSincePreservesIngestedFilesystemMachine(t *testing.T) {
+	root := t.TempDir()
+	writeSessionSourceClaudeFile(t, root, "ingested-machine.jsonl")
+	database := openTestDB(t)
+	newEngine := func(machine string) *Engine {
+		return NewEngine(database, EngineConfig{
+			AgentDirs: map[parser.AgentType][]string{
+				parser.AgentClaude: {root},
+			},
+			SourceMachines: map[parser.AgentType]map[string]string{
+				parser.AgentClaude: {root: machine},
+			},
+			Machine: "localbox",
+		})
+	}
+
+	first := newEngine("oldbox").SyncAll(context.Background(), nil)
+	require.Equal(t, 1, first.Synced)
+	second := newEngine("newbox").SyncAllSince(
+		context.Background(), time.Now().Add(time.Hour), nil,
+	)
+	require.Zero(t, second.Synced)
+
+	sess, err := database.GetSessionFull(
+		context.Background(), "ingested-machine",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, "oldbox", sess.Machine)
+	assert.Equal(t, 2, sess.MessageCount)
+	assert.False(t, sess.LastWriteIncremental)
+	snapshots, err := database.ListSessionProjectIdentitySnapshots(
+		t.Context(),
+	)
+	require.NoError(t, err)
+	require.Len(t, snapshots, 1)
+	assert.Equal(t, "oldbox", snapshots[0].Machine)
+	observations, err := database.ListProjectIdentityObservations(
+		t.Context(), []string{sess.Project},
+	)
+	require.NoError(t, err)
+	require.Len(t, observations, 1)
+	assert.Equal(t, "oldbox", observations[0].Machine)
+}
+
+func TestSyncAllSincePreservesTrashedSessionMachine(t *testing.T) {
+	root := t.TempDir()
+	writeSessionSourceClaudeFile(t, root, "trashed-machine.jsonl")
+	database := openTestDB(t)
+	newEngine := func(machine string) *Engine {
+		return NewEngine(database, EngineConfig{
+			AgentDirs: map[parser.AgentType][]string{
+				parser.AgentClaude: {root},
+			},
+			SourceMachines: map[parser.AgentType]map[string]string{
+				parser.AgentClaude: {root: machine},
+			},
+			Machine: "localbox",
+		})
+	}
+
+	require.Equal(t, 1, newEngine("oldbox").SyncAll(t.Context(), nil).Synced)
+	require.NoError(t, database.SoftDeleteSession("trashed-machine"))
+
+	stats := newEngine("newbox").SyncAllSince(
+		t.Context(), time.Now().Add(time.Hour), nil,
+	)
+	require.Zero(t, stats.Synced)
+	active, err := database.GetSession(t.Context(), "trashed-machine")
+	require.NoError(t, err)
+	assert.Nil(t, active)
+	trashed, err := database.GetSessionFull(
+		t.Context(), "trashed-machine",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, trashed)
+	assert.Equal(t, "oldbox", trashed.Machine)
+	assert.NotNil(t, trashed.DeletedAt)
+	assert.Nil(t, trashed.DeletionCause)
+}
+
+func TestResyncAllPreservesSourceMachineIdentityAttribution(t *testing.T) {
+	root := t.TempDir()
+	writeSessionSourceClaudeFile(t, root, "resynced-identity.jsonl")
+	database := openTestDB(t)
+	newEngine := func(machine string) *Engine {
+		return NewEngine(database, EngineConfig{
+			AgentDirs: map[parser.AgentType][]string{
+				parser.AgentClaude: {root},
+			},
+			SourceMachines: map[parser.AgentType]map[string]string{
+				parser.AgentClaude: {root: machine},
+			},
+			Machine: "localbox",
+		})
+	}
+
+	require.Equal(t, 1, newEngine("oldbox").SyncAll(t.Context(), nil).Synced)
+	stats := newEngine("newbox").ResyncAll(t.Context(), nil)
+	require.False(t, stats.Aborted)
+
+	session, err := database.GetSessionFull(t.Context(), "resynced-identity")
+	require.NoError(t, err)
+	require.NotNil(t, session)
+	assert.Equal(t, "oldbox", session.Machine)
+	snapshots, err := database.ListSessionProjectIdentitySnapshots(t.Context())
+	require.NoError(t, err)
+	require.Len(t, snapshots, 1)
+	assert.Equal(t, "oldbox", snapshots[0].Machine)
+	observations, err := database.ListProjectIdentityObservations(
+		t.Context(), []string{session.Project},
+	)
+	require.NoError(t, err)
+	require.Len(t, observations, 1)
+	assert.Equal(t, "oldbox", observations[0].Machine)
+}
+
+func TestResyncAllPreservesTrashedSessionMachine(t *testing.T) {
+	root := t.TempDir()
+	writeSessionSourceClaudeFile(t, root, "resynced-trash.jsonl")
+	database := openTestDB(t)
+	newEngine := func(machine string) *Engine {
+		return NewEngine(database, EngineConfig{
+			AgentDirs: map[parser.AgentType][]string{
+				parser.AgentClaude: {root},
+			},
+			SourceMachines: map[parser.AgentType]map[string]string{
+				parser.AgentClaude: {root: machine},
+			},
+			Machine: "localbox",
+		})
+	}
+
+	require.Equal(t, 1, newEngine("oldbox").SyncAll(t.Context(), nil).Synced)
+	require.NoError(t, database.SoftDeleteSession("resynced-trash"))
+	stats := newEngine("newbox").ResyncAll(t.Context(), nil)
+	require.False(t, stats.Aborted)
+
+	active, err := database.GetSession(t.Context(), "resynced-trash")
+	require.NoError(t, err)
+	assert.Nil(t, active)
+	trashed, err := database.GetSessionFull(t.Context(), "resynced-trash")
+	require.NoError(t, err)
+	require.NotNil(t, trashed)
+	assert.Equal(t, "oldbox", trashed.Machine)
+	assert.NotNil(t, trashed.DeletedAt)
+}
+
+func TestIncrementalAppendPreservesIngestedSourceMachine(t *testing.T) {
+	root := t.TempDir()
+	path := writeSessionSourceClaudeFile(t, root, "incremental-machine.jsonl")
+	database := openTestDB(t)
+	newEngine := func(machine string) *Engine {
+		return NewEngine(database, EngineConfig{
+			AgentDirs: map[parser.AgentType][]string{
+				parser.AgentClaude: {root},
+			},
+			SourceMachines: map[parser.AgentType]map[string]string{
+				parser.AgentClaude: {root: machine},
+			},
+			Machine: "localbox",
+		})
+	}
+
+	first := newEngine("oldbox").SyncAll(context.Background(), nil)
+	require.Equal(t, 1, first.Synced)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	require.NoError(t, err)
+	_, err = f.WriteString(testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON(
+			"appended message", "2026-07-01T10:00:02Z",
+		),
+	))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	second := newEngine("newbox").SyncAll(context.Background(), nil)
+	require.Equal(t, 1, second.Synced)
+
+	sess, err := database.GetSessionFull(
+		context.Background(), "incremental-machine",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, "oldbox", sess.Machine)
+	assert.Equal(t, 3, sess.MessageCount)
+	assert.True(t, sess.LastWriteIncremental)
+}
+
+func TestFullReparsePreservesIngestedSourceMachine(t *testing.T) {
+	root := t.TempDir()
+	path := writeSessionSourceClaudeFile(t, root, "reparsed-machine.jsonl")
+	database := openTestDB(t)
+	newEngine := func(machine string) *Engine {
+		return NewEngine(database, EngineConfig{
+			AgentDirs: map[parser.AgentType][]string{
+				parser.AgentClaude: {root},
+			},
+			SourceMachines: map[parser.AgentType]map[string]string{
+				parser.AgentClaude: {root: machine},
+			},
+			Machine: "localbox",
+		})
+	}
+
+	require.Equal(t, 1, newEngine("oldbox").SyncAll(t.Context(), nil).Synced)
+	builder := testjsonl.NewSessionBuilder()
+	builder.AddClaudeUser("2026-07-01T10:01:00Z", "replacement")
+	require.NoError(t, os.WriteFile(path, []byte(builder.String()), 0o600))
+
+	require.Equal(t, 1, newEngine("newbox").SyncAll(t.Context(), nil).Synced)
+	session, err := database.GetSessionFull(t.Context(), "reparsed-machine")
+	require.NoError(t, err)
+	require.NotNil(t, session)
+	assert.Equal(t, "oldbox", session.Machine)
+	assert.Equal(t, 1, session.MessageCount)
+	snapshots, err := database.ListSessionProjectIdentitySnapshots(t.Context())
+	require.NoError(t, err)
+	require.Len(t, snapshots, 1)
+	assert.Equal(t, "oldbox", snapshots[0].Machine)
+}
+
+func TestIncompleteIncrementalAppendPreservesIngestedSourceMachine(t *testing.T) {
+	root := t.TempDir()
+	path := writeSessionSourceClaudeFile(t, root, "partial-machine.jsonl")
+	database := openTestDB(t)
+	newEngine := func(machine string) *Engine {
+		return NewEngine(database, EngineConfig{
+			AgentDirs: map[parser.AgentType][]string{
+				parser.AgentClaude: {root},
+			},
+			SourceMachines: map[parser.AgentType]map[string]string{
+				parser.AgentClaude: {root: machine},
+			},
+			Machine: "localbox",
+		})
+	}
+
+	require.Equal(t, 1, newEngine("oldbox").SyncAll(t.Context(), nil).Synced)
+	before, err := database.GetSessionFull(t.Context(), "partial-machine")
+	require.NoError(t, err)
+	require.NotNil(t, before)
+
+	completeLine := testjsonl.ClaudeUserJSON(
+		"completed later", "2026-07-01T10:00:02Z",
+	)
+	partialAt := len(completeLine) / 2
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	require.NoError(t, err)
+	_, err = f.WriteString(completeLine[:partialAt])
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	second := newEngine("newbox").SyncAll(t.Context(), nil)
+	require.Zero(t, second.Synced)
+	after, err := database.GetSessionFull(t.Context(), "partial-machine")
+	require.NoError(t, err)
+	require.NotNil(t, after)
+	assert.Equal(t, "oldbox", after.Machine)
+	assert.Equal(t, before.FileSize, after.FileSize)
+	assert.Equal(t, before.FileMtime, after.FileMtime)
+	assert.Equal(t, before.FileHash, after.FileHash)
+	assert.Equal(t, before.NextOrdinal, after.NextOrdinal)
+	assert.Equal(t, before.LastEntryUUID, after.LastEntryUUID)
+	assert.Equal(t, before.MessageCount, after.MessageCount)
+	assert.Equal(t, before.LastWriteIncremental, after.LastWriteIncremental)
+
+	f, err = os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	require.NoError(t, err)
+	_, err = f.WriteString(completeLine[partialAt:] + "\n")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	require.Equal(t, 1, newEngine("newbox").SyncAll(t.Context(), nil).Synced)
+
+	completed, err := database.GetSessionFull(t.Context(), "partial-machine")
+	require.NoError(t, err)
+	require.NotNil(t, completed)
+	assert.Equal(t, "oldbox", completed.Machine)
+	assert.Equal(t, before.MessageCount+1, completed.MessageCount)
+	assert.True(t, completed.LastWriteIncremental)
+}
+
+func TestCopiedFilesystemSessionKeepsNativeIDDeduplication(t *testing.T) {
+	firstRoot := t.TempDir()
+	secondRoot := t.TempDir()
+	firstPath := writeSessionSourceClaudeFile(t, firstRoot, "copied-session.jsonl")
+	secondProject := filepath.Join(secondRoot, "project")
+	require.NoError(t, os.MkdirAll(secondProject, 0o755))
+	data, err := os.ReadFile(firstPath)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(secondProject, "copied-session.jsonl"), data, 0o600,
+	))
+	database := openTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {firstRoot, secondRoot},
+		},
+		SourceMachines: map[parser.AgentType]map[string]string{
+			parser.AgentClaude: {
+				firstRoot:  "firstbox",
+				secondRoot: "secondbox",
+			},
+		},
+		Machine: "localbox",
+	})
+
+	engine.SyncAll(context.Background(), nil)
+
+	page, err := database.ListSessions(context.Background(), db.SessionFilter{
+		Limit: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, page.Sessions, 1)
+	assert.Equal(t, "copied-session", page.Sessions[0].ID)
+}
+
+func writeSessionSourceClaudeFile(t *testing.T, root, name string) string {
+	t.Helper()
+	project := filepath.Join(root, "project")
+	require.NoError(t, os.MkdirAll(project, 0o755))
+	builder := testjsonl.NewSessionBuilder()
+	builder.AddClaudeUser("2026-07-01T10:00:00Z", "hello")
+	builder.AddClaudeAssistant("2026-07-01T10:00:01Z", "hi")
+	path := filepath.Join(project, name)
+	require.NoError(t, os.WriteFile(path, []byte(builder.String()), 0o600))
+	return path
+}

--- a/internal/sync/session_source_machine_test.go
+++ b/internal/sync/session_source_machine_test.go
@@ -520,3 +520,74 @@ func activeSessionMachines(t *testing.T, database *db.DB) map[string]string {
 	}
 	return out
 }
+
+// TestBaselineFollowsPersistedMachineAfterRelabel pins the ownership baseline
+// to the machine a session was actually written under. prepareSessionWrite
+// preserves the original label, so keying the baseline off the freshly parsed
+// (configured) machine strands it under a machine no session row holds, and the
+// source can never be tombstoned once it disappears.
+func TestBaselineFollowsPersistedMachineAfterRelabel(t *testing.T) {
+	archiveRoot := t.TempDir()
+	archivePath := writeSessionSourceClaudeFile(t, archiveRoot, "archive-session.jsonl")
+	database := openTestDB(t)
+
+	newEngine := func(machine string) *Engine {
+		return NewEngine(database, EngineConfig{
+			AgentDirs: map[parser.AgentType][]string{
+				parser.AgentClaude: {archiveRoot},
+			},
+			SourceMachines: map[parser.AgentType]map[string]string{
+				parser.AgentClaude: {archiveRoot: machine},
+			},
+			Machine: "localbox",
+		})
+	}
+
+	first := newEngine("archivebox")
+	t.Cleanup(first.Close)
+	require.False(t, first.SyncAll(context.Background(), nil).Aborted)
+
+	// Append to the source so the relabeled pass actually reparses and rewrites
+	// it. An unchanged file is skipped, which never exercises the write path.
+	appendSessionSourceClaudeMessage(t, archivePath)
+
+	// Relabel the root and resync. The session keeps "archivebox"; the baseline
+	// must land there too, not under the newly configured "renamedbox".
+	relabeled := newEngine("renamedbox")
+	t.Cleanup(relabeled.Close)
+	require.False(t, relabeled.SyncAll(context.Background(), nil).Aborted)
+
+	require.Equal(t, "archivebox",
+		activeSessionMachines(t, database)["archive-session"])
+
+	ownershipFor := func(machine string) []db.SessionSourceOwnership {
+		rows, err := database.ListActiveSessionSourceOwnershipScopesPage(
+			context.Background(), machine, string(parser.AgentClaude),
+			[]db.StoredSourcePathHintScope{{Path: archiveRoot}},
+			db.SessionSourceCursor{},
+		)
+		require.NoError(t, err)
+		return rows
+	}
+
+	stranded := ownershipFor("renamedbox")
+	assert.Empty(t, stranded,
+		"the baseline must not be keyed under a label no session row holds")
+
+	owned := ownershipFor("archivebox")
+	require.Len(t, owned, 1,
+		"the baseline must follow the persisted machine")
+	assert.Equal(t, archivePath, owned[0].FilePath)
+}
+
+// appendSessionSourceClaudeMessage grows an existing Claude transcript so the
+// next sync sees a changed source instead of skipping it.
+func appendSessionSourceClaudeMessage(t *testing.T, path string) {
+	t.Helper()
+	builder := testjsonl.NewSessionBuilder()
+	builder.AddClaudeUser("2026-07-01T10:00:00Z", "hello")
+	builder.AddClaudeAssistant("2026-07-01T10:00:01Z", "hi")
+	builder.AddClaudeUser("2026-07-01T10:00:02Z", "more")
+	builder.AddClaudeAssistant("2026-07-01T10:00:03Z", "sure")
+	require.NoError(t, os.WriteFile(path, []byte(builder.String()), 0o600))
+}


### PR DESCRIPTION
Add filesystem-only `[[session_sources]]` entries with `agent`, `dir`, and
optional `machine`. Structured sources are additive to existing per-agent
directory arrays, defaults, and environment variables; when roots overlap, the
structured entry supplies the machine label. Configured paths keep the spelling
the user wrote them in, and a separate cleaned comparison key collapses
equivalent roots, so Windows-style entries survive a config round-trip.

A session's machine is resolved from the configured root that produced it and
is assigned once, when the session is first ingested. After that the label is
immutable: ordinary periodic, watcher-driven, incremental, provider-backed, and
single-session syncs all retain the stored value rather than adopting a newly
configured one. `agentsview sync --full` preserves stored labels while
rebuilding the archive; it is not a relabel operation. Changing a configured
label therefore affects only sessions discovered afterward, which makes editing
configuration safe rather than destructive. Filesystem labels do not namespace
native session IDs.

Because relabeling is no longer part of sync, this removes the machine-only
update for trashed sessions, the all-machines baseline scan, and the ownership
baseline index keyed without machine. Watch reconciliation still uses the
baseline for the machine that originally admitted a session, so per-event work
stays bounded by the changed batch.

An earlier revision of this branch chased reattribution through each new writer,
trash path, snapshot path, and reconciliation edge. That approach kept widening
the persistent-archive surface and reintroducing consistency bugs, so it was
replaced with the ingestion-time contract above. A one-shot relabel command is
deliberately deferred: it needs its own invariants and recovery tests, and it is
not required to ship labeled ingestion.

The filesystem sync guide documents Git, rsync/file copy, and NFS/shared-mount
topologies, including atomic publication, archive ownership, freshness,
native-ID deduplication, label-change behavior, and when PostgreSQL is a better
fit.

`session_sources` intentionally rejects `s3://` roots. Existing Claude and Codex
S3 configuration and behavior remain unchanged through their existing per-agent
settings.

Reviewers should start at `internal/sync/engine.go`, where machine resolution
and the preserve-on-upsert rule live, then `internal/config/config.go` for
parsing and path handling. `docs/superpowers/specs/` carries the design
rationale.

This branch contains no DuckDB changes. Mirror source-machine attribution
already landed in #1302, and this PR neither duplicates nor modifies it.
