### PR TITLE
feat(vector): support role-aware embedding prefixes

### DIFF
--- a/cmd/agentsview/embed_scheduler.go
+++ b/cmd/agentsview/embed_scheduler.go
@@ -400,7 +400,7 @@ func setupVectorServing(
 		return vectorServing{}, fmt.Errorf("opening vectors.db: %w", err)
 	}
 
-	encoders, err := vectorEncoderSet(cfg.Vector.Embeddings)
+	encoders, err := vectorDocumentEncoderSet(cfg.Vector.Embeddings)
 	if err != nil {
 		ix.Close()
 		_ = lock.Close()
@@ -408,7 +408,12 @@ func setupVectorServing(
 	}
 	// Search-time query encoding always uses the default server; builds may
 	// pick any named entry via BuildRequest.Using.
-	queryEnc := encoders.ByName[encoders.Default].Encode
+	queryEnc, err := newVectorQueryEncoder(cfg.Vector.Embeddings, "")
+	if err != nil {
+		ix.Close()
+		_ = lock.Close()
+		return vectorServing{}, err
+	}
 
 	backstop, err := time.ParseDuration(cfg.Vector.Embed.BackstopInterval)
 	if err != nil {
@@ -482,7 +487,7 @@ func installDirectVectorSearcher(cfg config.Config, d *db.DB) func() error {
 		return nil
 	}
 	// Query encoding uses the default server.
-	enc, err := newVectorEncoder(cfg.Vector.Embeddings, "")
+	enc, err := newVectorQueryEncoder(cfg.Vector.Embeddings, "")
 	if err != nil {
 		ix.Close()
 		log.Printf(

--- a/cmd/agentsview/embed_scheduler_test.go
+++ b/cmd/agentsview/embed_scheduler_test.go
@@ -499,7 +499,7 @@ func TestSearcherAdapterVersionMismatchedIndexReturnsSemanticUnavailable(t *test
 	require.NoError(t, err, "read-only Open must succeed against a mismatched vectors.db")
 	defer ix.Close()
 
-	enc, err := newVectorEncoder(cfg.Vector.Embeddings, "")
+	enc, err := newVectorQueryEncoder(cfg.Vector.Embeddings, "")
 	require.NoError(t, err)
 	adapter := newSearcherAdapter(ix, enc, vectorGeneration(cfg.Vector.Embeddings))
 

--- a/cmd/agentsview/embeddings.go
+++ b/cmd/agentsview/embeddings.go
@@ -252,6 +252,16 @@ func vectorGeneration(c config.VectorEmbeddingsConfig) kitvec.Generation {
 	if c.InputSuffix != "" {
 		params["input_suffix"] = c.InputSuffix
 	}
+	// Role-aware prefixes join only when set so the empty defaults preserve
+	// every generation fingerprint created before these keys existed. The
+	// query and document recipe is fingerprinted as one unit: changing either
+	// requires a new generation before semantic search resumes.
+	if c.QueryPrefix != "" {
+		params["query_prefix"] = c.QueryPrefix
+	}
+	if c.DocumentPrefix != "" {
+		params["document_prefix"] = c.DocumentPrefix
+	}
 	// request_dimensions likewise joins only when enabled. Reduced vectors
 	// are renormalized prefixes, not byte-identical to a native embedding of
 	// the same length, so flipping the flag must cut a new generation even
@@ -268,8 +278,10 @@ func vectorGeneration(c config.VectorEmbeddingsConfig) kitvec.Generation {
 
 // newVectorEncoder builds the OpenAI-compatible embeddings encoder for one
 // named server ("" means the default), combining the global model identity
-// with that server's transport settings.
-func newVectorEncoder(c config.VectorEmbeddingsConfig, serverName string) (kitvec.EncodeFunc, error) {
+// and caller-selected role prefix with that server's transport settings.
+func newVectorEncoder(
+	c config.VectorEmbeddingsConfig, serverName, inputPrefix string,
+) (kitvec.EncodeFunc, error) {
 	name, server, err := c.Server(serverName)
 	if err != nil {
 		return nil, err
@@ -287,19 +299,37 @@ func newVectorEncoder(c config.VectorEmbeddingsConfig, serverName string) (kitve
 		RequestDimensions: c.RequestDimensions,
 		Timeout:           timeout,
 		MaxRetries:        server.MaxRetries,
+		InputPrefix:       inputPrefix,
 		InputSuffix:       c.InputSuffix,
 	}), nil
 }
 
-// vectorEncoderSet builds one encoder per configured embeddings server, so
-// a Manager can run any build against the server the request names.
-func vectorEncoderSet(c config.VectorEmbeddingsConfig) (vector.EncoderSet, error) {
+// newVectorQueryEncoder builds the default or named server encoder used only
+// for search queries.
+func newVectorQueryEncoder(
+	c config.VectorEmbeddingsConfig, serverName string,
+) (kitvec.EncodeFunc, error) {
+	return newVectorEncoder(c, serverName, c.QueryPrefix)
+}
+
+// newVectorDocumentEncoder builds the default or named server encoder used
+// only for document builds and repairs.
+func newVectorDocumentEncoder(
+	c config.VectorEmbeddingsConfig, serverName string,
+) (kitvec.EncodeFunc, error) {
+	return newVectorEncoder(c, serverName, c.DocumentPrefix)
+}
+
+// vectorDocumentEncoderSet builds one document encoder per configured
+// embeddings server, so a Manager can run any build against the server the
+// request names without sharing the query recipe.
+func vectorDocumentEncoderSet(c config.VectorEmbeddingsConfig) (vector.EncoderSet, error) {
 	set := vector.EncoderSet{
 		Default: c.ResolvedDefaultServer(),
 		ByName:  make(map[string]vector.ManagedEncoder, len(c.Servers)),
 	}
 	for name, server := range c.Servers {
-		enc, err := newVectorEncoder(c, name)
+		enc, err := newVectorDocumentEncoder(c, name)
 		if err != nil {
 			return vector.EncoderSet{}, err
 		}
@@ -427,7 +457,7 @@ func runEmbeddingsBuildDirect(
 	}
 	defer ix.Close()
 
-	encoders, err := vectorEncoderSet(cfg.Vector.Embeddings)
+	encoders, err := vectorDocumentEncoderSet(cfg.Vector.Embeddings)
 	if err != nil {
 		return err
 	}

--- a/cmd/agentsview/embeddings_test.go
+++ b/cmd/agentsview/embeddings_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -114,10 +115,9 @@ func seedEmbeddableArchiveWithAutomated(t *testing.T, dataDir string) {
 // TestVectorGenerationParams asserts vectorGeneration's Params map carries
 // exactly the three run_v1 fingerprint keys the plan requires, with
 // chunk_overlap_chars derived from vector.ChunkOverlap so a future change to
-// that formula cannot silently drift from the fingerprint. An empty
-// input_suffix must be absent from the map (not present as ""), so configs
-// written before the key existed keep their fingerprints; a non-empty suffix
-// joins the fingerprint and cuts a new generation.
+// that formula cannot silently drift from the fingerprint. Empty affixes must
+// be absent from the map (not present as ""), so configs written before these
+// keys existed keep their fingerprints; non-empty affixes cut a new generation.
 func TestVectorGenerationParams(t *testing.T) {
 	c := config.VectorEmbeddingsConfig{
 		Model:         "test-model",
@@ -134,6 +134,7 @@ func TestVectorGenerationParams(t *testing.T) {
 		"doc_unit_scheme":     "run_v1",
 		"chunk_overlap_chars": strconv.Itoa(vector.ChunkOverlap(4000)),
 	}, gen.Params)
+	baselineFingerprint := gen.Fingerprint()
 
 	c.InputSuffix = "<|endoftext|>"
 	gen = vectorGeneration(c)
@@ -143,6 +144,35 @@ func TestVectorGenerationParams(t *testing.T) {
 		"chunk_overlap_chars": strconv.Itoa(vector.ChunkOverlap(4000)),
 		"input_suffix":        "<|endoftext|>",
 	}, gen.Params)
+	assert.NotEqual(t, baselineFingerprint, gen.Fingerprint(),
+		"adding an input suffix cuts a new generation")
+
+	suffixFingerprint := gen.Fingerprint()
+	c.QueryPrefix = "task: search result | query: "
+	gen = vectorGeneration(c)
+	assert.Equal(t, map[string]string{
+		"max_input_chars":     "4000",
+		"doc_unit_scheme":     "run_v1",
+		"chunk_overlap_chars": strconv.Itoa(vector.ChunkOverlap(4000)),
+		"input_suffix":        "<|endoftext|>",
+		"query_prefix":        "task: search result | query: ",
+	}, gen.Params)
+	assert.NotEqual(t, suffixFingerprint, gen.Fingerprint(),
+		"adding a query prefix cuts a new generation")
+
+	queryFingerprint := gen.Fingerprint()
+	c.DocumentPrefix = "title: none | text: "
+	gen = vectorGeneration(c)
+	assert.Equal(t, map[string]string{
+		"max_input_chars":     "4000",
+		"doc_unit_scheme":     "run_v1",
+		"chunk_overlap_chars": strconv.Itoa(vector.ChunkOverlap(4000)),
+		"input_suffix":        "<|endoftext|>",
+		"query_prefix":        "task: search result | query: ",
+		"document_prefix":     "title: none | text: ",
+	}, gen.Params)
+	assert.NotEqual(t, queryFingerprint, gen.Fingerprint(),
+		"adding a document prefix cuts a new generation")
 
 	// request_dimensions follows the same only-when-set rule, and enabling it
 	// must change the fingerprint even at an unchanged dimension value, so
@@ -156,6 +186,8 @@ func TestVectorGenerationParams(t *testing.T) {
 		"doc_unit_scheme":     "run_v1",
 		"chunk_overlap_chars": strconv.Itoa(vector.ChunkOverlap(4000)),
 		"input_suffix":        "<|endoftext|>",
+		"query_prefix":        "task: search result | query: ",
+		"document_prefix":     "title: none | text: ",
 		"request_dimensions":  "true",
 	}, gen.Params)
 	assert.NotEqual(t, nativeFingerprint, gen.Fingerprint(),
@@ -341,6 +373,72 @@ func TestEmbeddingsBuildDirectEndToEnd(t *testing.T) {
 
 	assert.Contains(t, out.String(), "Embedded 2 documents (2 chunks), skipped 0, stale 0")
 	assert.Contains(t, out.String(), "Generation activated.")
+}
+
+// TestRoleAwarePrefixesReachBuildAndSearch exercises the user-visible role
+// split through a real direct build, vectors.db, and SQLite semantic search.
+// The embeddings server observes document-prefixed build inputs and a
+// query-prefixed search input, with the shared suffix applied last.
+func TestRoleAwarePrefixesReachBuildAndSearch(t *testing.T) {
+	dataDir := t.TempDir()
+	seedEmbeddableArchive(t, dataDir)
+
+	var mu sync.Mutex
+	var captured []string
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Input []string `json:"input"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		mu.Lock()
+		captured = append(captured, req.Input...)
+		mu.Unlock()
+
+		data := make([]map[string]any, len(req.Input))
+		for i := range req.Input {
+			data[i] = map[string]any{
+				"index": i, "embedding": []float32{1, 2, 3},
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"data": data}))
+	}))
+	defer stub.Close()
+
+	cfg := vectorTestConfig(dataDir)
+	server := cfg.Vector.Embeddings.Servers["local"]
+	server.Endpoint = stub.URL + "/v1"
+	cfg.Vector.Embeddings.Servers["local"] = server
+	cfg.Vector.Embeddings.QueryPrefix = "query: "
+	cfg.Vector.Embeddings.DocumentPrefix = "document: "
+	cfg.Vector.Embeddings.InputSuffix = "<eos>"
+
+	var buildOut bytes.Buffer
+	require.NoError(t, runEmbeddingsBuildDirect(
+		context.Background(), &buildOut, cfg, vector.BuildRequest{}))
+
+	database := dbtest.OpenTestDBAt(t, filepath.Join(dataDir, "sessions.db"))
+	closeVector := installDirectVectorSearcher(cfg, database)
+	require.NotNil(t, closeVector)
+	t.Cleanup(func() { require.NoError(t, closeVector()) })
+
+	result, err := database.SearchContent(context.Background(), db.ContentSearchFilter{
+		Pattern:        "find greeting",
+		Mode:           "semantic",
+		Limit:          5,
+		IncludeOneShot: true,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Matches,
+		"semantic search should return the indexed session")
+
+	mu.Lock()
+	got := append([]string(nil), captured...)
+	mu.Unlock()
+	require.Len(t, got, 3, "two indexed units and one search query should be encoded")
+	assert.Contains(t, got, "document: hello there<eos>")
+	assert.Contains(t, got, "document: hi back\n\nand a follow-up thought<eos>")
+	assert.Contains(t, got, "query: find greeting<eos>")
 }
 
 func TestRunDirectBuildPrintsFailedAttemptResult(t *testing.T) {

--- a/cmd/agentsview/pg_vector_search.go
+++ b/cmd/agentsview/pg_vector_search.go
@@ -104,7 +104,7 @@ func wirePGVectorSearch(
 		return nil
 	}
 
-	enc, err := newVectorEncoder(appCfg.Vector.Embeddings, "")
+	enc, err := newVectorQueryEncoder(appCfg.Vector.Embeddings, "")
 	if err != nil {
 		return fmt.Errorf("building query encoder: %w", err)
 	}

--- a/docs/semantic-search-internals.md
+++ b/docs/semantic-search-internals.md
@@ -178,20 +178,21 @@ The vector index moves through kit's generation lifecycle: **building → active
 retired**. A generation's fingerprint is derived from `model` + `dimension` +
 the params map
 `{max_input_chars, doc_unit_scheme: "run_v1", chunk_overlap_chars}`
-(`vectorGeneration` in `cmd/agentsview/embeddings.go`), plus `input_suffix` and
-`request_dimensions` when configured — an unset value is omitted from the map
-rather than included as `""`/`false`, so configs written before those keys
-existed keep their fingerprints. `chunk_overlap_chars` is computed by
-`vector.ChunkOverlap` — `max_input_chars * 15 / 100` — the same function `Open`
-uses for kit's `SplitOptions`, so the split behavior and its fingerprint can
-never drift apart. Changing any input — the model, the dimension, whether
-reduced output dimensions are requested, the chunking cap, the input suffix, the
-overlap formula, or the document-unit scheme — produces a different fingerprint
-and cuts a new generation. Which `[vector.embeddings.servers.<name>]` entry
-encoded a document is deliberately *not* a fingerprint input: every server
-serves the same globally-configured model, so their vectors are interchangeable
-and a build may switch servers (`embeddings build --using <name>`) without
-invalidating the generation.
+(`vectorGeneration` in `cmd/agentsview/embeddings.go`), plus `query_prefix`,
+`document_prefix`, `input_suffix`, and `request_dimensions` when configured —
+an unset value is omitted from the map rather than included as `""`/`false`, so
+configs written before those keys existed keep their fingerprints.
+`chunk_overlap_chars` is computed by `vector.ChunkOverlap` —
+`max_input_chars * 15 / 100` — the same function `Open` uses for kit's
+`SplitOptions`, so the split behavior and its fingerprint can never drift
+apart. Changing any input — the model, the dimension, whether reduced output
+dimensions are requested, the chunking cap, either role prefix, the input
+suffix, the overlap formula, or the document-unit scheme — produces a
+different fingerprint and cuts a new generation. Which
+`[vector.embeddings.servers.<name>]` entry encoded a document is deliberately
+*not* a fingerprint input: every server serves the same globally-configured
+model, so their vectors are interchangeable and a build may switch servers
+(`embeddings build --using <name>`) without invalidating the generation.
 
 - `embeddings build` (incremental): mirror refresh, then fill whatever the
   active generation is missing.
@@ -210,6 +211,12 @@ invalidating the generation.
 Unit content is chunked by kit's `Split` with `MaxRunes = max_input_chars`
 (default 8192) and `Overlap = ChunkOverlap(max_input_chars)` — 15% of the cap:
 1228 runes at the default, 375 at a 2500 cap.
+
+The configured `document_prefix` and shared `input_suffix` are applied to each
+chunk only after splitting. Search queries use `query_prefix` plus the same
+suffix. Affix lengths therefore do not reduce the splitter's `MaxRunes`; an
+operator targeting a strict model context limit must leave enough headroom in
+`max_input_chars`.
 
 A hit on a run document is **anchored** to one member message: the member whose
 rune span contains the matched chunk's center rune,

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -35,6 +35,8 @@ include_automated = false         # default; automated sessions (e.g. roborev) a
 model = "nomic-embed-text"
 dimension = 768                   # every returned vector must have this length
 max_input_chars = 8192            # per-chunk rune cap (default 8192)
+query_prefix = "search_query: "    # prepended only to search queries
+document_prefix = "search_document: " # prepended only to indexed document chunks
 # request_dimensions = true      # ask for Matryoshka-reduced vectors of exactly `dimension` (see below)
 # input_suffix = "<|endoftext|>"  # appended to every embedded text; default empty (see below)
 default_server = "local"          # server used for query encoding and unnamed builds
@@ -60,11 +62,11 @@ parse. Restart the daemon (or run a CLI command) after editing the file.
 ### Named embeddings servers
 
 Model identity — `model`, `dimension`, `request_dimensions`, `max_input_chars`,
-`input_suffix` — is global: every server in the `servers` table must serve that
-same model, so vectors produced by any of them are interchangeable and land in
-the same generation. What varies per server is transport and capacity:
-`endpoint`, `api_key_env`, `timeout`, `max_retries`, `batch_size`, and
-`concurrency`.
+`query_prefix`, `document_prefix`, and `input_suffix` — is global: every server
+in the `servers` table must serve that same model and input recipe, so vectors
+produced by any of them are interchangeable and land in the same generation.
+What varies per server is transport and capacity: `endpoint`, `api_key_env`,
+`timeout`, `max_retries`, `batch_size`, and `concurrency`.
 
 This split exists so you can encode search queries against a fast local server
 while offloading bulk index builds to a bigger remote machine:
@@ -106,6 +108,44 @@ endpoint has spare parallel capacity, or set it to 1 to send one request at a
 time. Responses are requested in the compact base64 encoding automatically (with
 a transparent fallback for servers that reject or ignore `encoding_format`),
 which cuts response transfer roughly 4x on slow links.
+
+### Role-aware task prefixes
+
+Some embedding models are trained with different input instructions for search
+queries and indexed documents. `query_prefix` is prepended only when AgentsView
+embeds a search query; `document_prefix` is prepended to every document chunk
+during manual, scheduled, and repair builds. Both default to empty, preserving
+the input bytes and generation fingerprints produced by older configurations.
+
+EmbeddingGemma's ordinary retrieval recipe without document titles is:
+
+```toml
+[vector.embeddings]
+model = "embeddinggemma"
+dimension = 768
+query_prefix = "task: search result | query: "
+document_prefix = "title: none | text: "
+```
+
+Nomic uses `search_query: ` and `search_document: `, as shown in the initial
+configuration example. E5 models commonly use `query: ` and `passage: `.
+Models such as Qwen3-Embedding that recommend an instruction only for queries
+can leave `document_prefix` unset.
+
+Prefixes are applied after document content is chunked, so
+`max_input_chars` limits the original chunk rather than the final affixed
+request. If the embedding endpoint has a strict context limit, leave enough
+headroom for the configured prefix and suffix. When an endpoint explicitly
+rejects an input for exceeding its token or context limit, AgentsView logs the
+rejection and skip-stamps that document for the generation so one oversized
+input cannot block the rest of the archive. Lower `max_input_chars` and rebuild
+to include it.
+
+Both prefixes are part of the generation fingerprint. Adding, removing, or
+changing either one creates a new generation and re-embeds the archive on the
+next build. This intentionally treats the query/document recipe as one
+reproducible embedding configuration, even though changing only
+`query_prefix` would not alter stored document vectors.
 
 `input_suffix` is appended verbatim to every text sent to the endpoint —
 documents at build time and queries at search time — for models that expect a
@@ -371,7 +411,7 @@ modes deliberately rebuild or reconcile broader index state.
 runs, see [What gets embedded](#what-gets-embedded-units-not-messages)) into
 `vectors.db`, then fills whatever the active generation is missing.
 `--full-rebuild` re-embeds every document: if the target fingerprint (derived
-from `model`, `dimension`, `max_input_chars`, `input_suffix` when set, the
+from `model`, `dimension`, `max_input_chars`, configured input affixes, the
 document-unit scheme, and the derived chunk overlap) differs from the active
 generation, it cuts a new **generation**; if the fingerprint is unchanged, it
 instead resets and refills the active generation in place rather than cutting a

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -133,11 +133,11 @@ type VectorConfig struct {
 // every server must share — and the named servers that can encode it.
 //
 // Model identity (model, dimension, request_dimensions, max_input_chars,
-// input_suffix) is deliberately global rather than per-server: it joins the
-// generation fingerprint, and query vectors are only comparable to stored
-// document vectors from the same space. Servers differ only in transport and
-// capacity, so a build run on any server produces vectors every other
-// server's queries can search.
+// query_prefix, document_prefix, input_suffix) is deliberately global rather
+// than per-server: it joins the generation fingerprint, and query vectors are
+// only comparable to stored document vectors from the same space. Servers
+// differ only in transport and capacity, so a build run on any server produces
+// vectors every other server's queries can search.
 type VectorEmbeddingsConfig struct {
 	Model     string `toml:"model" json:"model"`
 	Dimension int    `toml:"dimension" json:"dimension"`
@@ -153,6 +153,13 @@ type VectorEmbeddingsConfig struct {
 	// MaxInputChars caps the rune length of each chunk sent for
 	// embedding. Default 8192.
 	MaxInputChars int `toml:"max_input_chars" json:"max_input_chars"`
+	// QueryPrefix is prepended verbatim to search queries before embedding.
+	// It allows instruction-tuned models to distinguish queries from indexed
+	// documents. Changing it cuts a new vector generation. Default empty.
+	QueryPrefix string `toml:"query_prefix" json:"query_prefix,omitempty"`
+	// DocumentPrefix is prepended verbatim to every document chunk before
+	// embedding. Changing it cuts a new vector generation. Default empty.
+	DocumentPrefix string `toml:"document_prefix" json:"document_prefix,omitempty"`
 	// InputSuffix is appended verbatim to every text sent for embedding
 	// (documents and queries alike). Some models expect a terminator the
 	// serving layer does not add — e.g. Qwen3-Embedding under llama.cpp
@@ -1142,7 +1149,13 @@ func (c *Config) applyConfigTOML(data string) error {
 	if meta.IsDefined("vector", "embeddings", "max_input_chars") {
 		c.Vector.Embeddings.MaxInputChars = file.Vector.Embeddings.MaxInputChars
 	}
-	if file.Vector.Embeddings.InputSuffix != "" {
+	if meta.IsDefined("vector", "embeddings", "query_prefix") {
+		c.Vector.Embeddings.QueryPrefix = file.Vector.Embeddings.QueryPrefix
+	}
+	if meta.IsDefined("vector", "embeddings", "document_prefix") {
+		c.Vector.Embeddings.DocumentPrefix = file.Vector.Embeddings.DocumentPrefix
+	}
+	if meta.IsDefined("vector", "embeddings", "input_suffix") {
 		c.Vector.Embeddings.InputSuffix = file.Vector.Embeddings.InputSuffix
 	}
 	if file.Vector.Embeddings.DefaultServer != "" {

--- a/internal/config/config_vector_test.go
+++ b/internal/config/config_vector_test.go
@@ -303,9 +303,31 @@ func TestVectorConfigTOMLLoad(t *testing.T) {
 		assert.Equal(t, 8192, cfg.Vector.Embeddings.MaxInputChars, "unset max_input_chars keeps default")
 		assert.Equal(t, "24h", cfg.Vector.Embed.BackstopInterval, "unset backstop_interval keeps default")
 		assert.False(t, cfg.Vector.IncludeAutomated, "unset include_automated keeps the false default")
+		assert.Empty(t, cfg.Vector.Embeddings.QueryPrefix, "unset query_prefix defaults to empty")
+		assert.Empty(t, cfg.Vector.Embeddings.DocumentPrefix,
+			"unset document_prefix defaults to empty")
 		assert.Empty(t, cfg.Vector.Embeddings.InputSuffix, "unset input_suffix defaults to empty")
 		assert.False(t, cfg.Vector.Embeddings.RequestDimensions,
 			"unset request_dimensions keeps the false default")
+	})
+
+	t.Run("role prefixes load verbatim", func(t *testing.T) {
+		cfg := loadMinimalWithConfig(t, map[string]any{
+			"vector": map[string]any{
+				"enabled": true,
+				"embeddings": map[string]any{
+					"model":           "embeddinggemma",
+					"dimension":       768,
+					"query_prefix":    "task: search result | query: ",
+					"document_prefix": "title: none | text: ",
+					"servers":         minimalServers(),
+				},
+			},
+		})
+		assert.Equal(t, "task: search result | query: ",
+			cfg.Vector.Embeddings.QueryPrefix)
+		assert.Equal(t, "title: none | text: ",
+			cfg.Vector.Embeddings.DocumentPrefix)
 	})
 
 	t.Run("request_dimensions true is loaded", func(t *testing.T) {

--- a/internal/vector/encoder.go
+++ b/internal/vector/encoder.go
@@ -44,6 +44,10 @@ type EncoderConfig struct {
 	// MaxRetries is the maximum total attempts on 429/5xx/network errors
 	// (4xx fails fast); values <= 0 mean one attempt.
 	MaxRetries int
+	// InputPrefix is prepended verbatim to every input text before it is
+	// sent. Callers use distinct encoder instances when query and document
+	// inputs require different task instructions. Empty means no prefix.
+	InputPrefix string
 	// InputSuffix is appended verbatim to every input text before it is
 	// sent, for models that expect a terminator the serving layer does not
 	// add (e.g. "<|endoftext|>" for Qwen3-Embedding under llama.cpp).
@@ -271,14 +275,14 @@ func NewEncoder(cfg EncoderConfig) kitvec.EncodeFunc {
 }
 
 // marshalRequest builds the request body, applying the configured input
-// suffix and, unless the encoder has downgraded to float mode, asking for
+// affixes and, unless the encoder has downgraded to float mode, asking for
 // base64 embeddings.
 func (ec *encoderClient) marshalRequest(texts []string) ([]byte, error) {
 	inputs := texts
-	if ec.cfg.InputSuffix != "" {
+	if ec.cfg.InputPrefix != "" || ec.cfg.InputSuffix != "" {
 		inputs = make([]string, len(texts))
 		for i, t := range texts {
-			inputs[i] = t + ec.cfg.InputSuffix
+			inputs[i] = ec.cfg.InputPrefix + t + ec.cfg.InputSuffix
 		}
 	}
 	body := embeddingsRequestBody{Model: ec.cfg.Model, Input: inputs}

--- a/internal/vector/encoder_test.go
+++ b/internal/vector/encoder_test.go
@@ -293,10 +293,10 @@ func TestEncoderFallsBackToFloatsWhenBase64Rejected(t *testing.T) {
 	assert.Equal(t, int32(2), floatRequests.Load())
 }
 
-// TestEncoderInputSuffixAppended asserts a configured InputSuffix is appended
-// to every input in the request body, while the returned vectors still map
-// back to the original (unsuffixed) texts by index.
-func TestEncoderInputSuffixAppended(t *testing.T) {
+// TestEncoderInputAffixesApplied asserts configured affixes surround every
+// input in the request body without mutating the caller's text slice, while
+// returned vectors still map back to the original texts by index.
+func TestEncoderInputAffixesApplied(t *testing.T) {
 	var gotReq embeddingsRequest
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -318,13 +318,20 @@ func TestEncoderInputSuffixAppended(t *testing.T) {
 		Dimension:   3,
 		Timeout:     5 * time.Second,
 		MaxRetries:  1,
+		InputPrefix: "title: none | text: ",
 		InputSuffix: "<|endoftext|>",
 	})
 
-	out, err := enc(context.Background(), []string{"hello", "world"})
+	texts := []string{"hello", "world"}
+	out, err := enc(context.Background(), texts)
 	require.NoError(t, err)
 
-	assert.Equal(t, []string{"hello<|endoftext|>", "world<|endoftext|>"}, gotReq.Input)
+	assert.Equal(t, []string{
+		"title: none | text: hello<|endoftext|>",
+		"title: none | text: world<|endoftext|>",
+	}, gotReq.Input)
+	assert.Equal(t, []string{"hello", "world"}, texts,
+		"applying affixes must not mutate caller input")
 	require.Len(t, out, 2)
 	assert.Equal(t, []float32{1, 2, 3}, out[0])
 	assert.Equal(t, []float32{4, 5, 6}, out[1])


### PR DESCRIPTION
Adds optional query_prefix and document_prefix settings to the global embedding recipe. Document builds and repairs use the document prefix, while direct SQLite, daemon, and PostgreSQL semantic queries use the query prefix; the existing input_suffix remains shared and is applied last.

Empty prefixes preserve existing request bytes and generation fingerprints. Non-empty prefixes participate in the fingerprint so serving cannot mix role recipes, with documentation covering EmbeddingGemma, Nomic, E5, chunk-size headroom, and rebuild behavior.

Closes #1171.