### PR TITLE
fix(parser): track Hermes skill_view usage

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -308,7 +308,9 @@ const projectIdentityRemoteScrubCompletedKey = "project_identity_remote_scrub_v1
 // and entrypoint fields on existing Claude rows.)
 // (67: Antigravity CLI reader metadata. Re-parsing populates parent_session_id
 // and relationship_type from agyReader.parentCascadeId in trajectory sidecars.)
-const dataVersion = 67
+// (68: Hermes skill_view metadata. Re-parsing populates tool_calls.skill_name
+// for existing Hermes sessions so historical skill usage appears in analytics.)
+const dataVersion = 68
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -930,9 +930,9 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 		"expected tool_result_events table after reopen")
 }
 
-func TestCurrentDataVersionAntigravityParentLinks(t *testing.T) {
-	assert.Equal(t, 67, CurrentDataVersion(),
-		"Antigravity parent-link parsing requires a data version bump")
+func TestCurrentDataVersionHermesSkillName(t *testing.T) {
+	assert.Equal(t, 68, CurrentDataVersion(),
+		"Hermes skill-name parsing requires a data version bump")
 }
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {
 	d := testDB(t)

--- a/internal/parser/hermes.go
+++ b/internal/parser/hermes.go
@@ -55,6 +55,28 @@ type hermesStateMessage struct {
 	codexMessageItems   string
 }
 
+func parseHermesToolCall(tc gjson.Result) (ParsedToolCall, bool) {
+	name := tc.Get("function.name").Str
+	if name == "" {
+		name = tc.Get("name").Str
+	}
+	if name == "" {
+		return ParsedToolCall{}, false
+	}
+
+	inputJSON := tc.Get("function.arguments").Str
+	toolCall := ParsedToolCall{
+		ToolUseID: tc.Get("id").Str,
+		ToolName:  name,
+		Category:  NormalizeToolCategory(name),
+		InputJSON: inputJSON,
+	}
+	if name == "skill_view" {
+		toolCall.SkillName = gjson.Get(inputJSON, "name").Str
+	}
+	return toolCall, true
+}
+
 // parseArchive parses a Hermes root directory. If a state.db is present, it
 // uses that database for session metadata and usage while selecting the richest
 // available message stream. Without state.db it falls back to the
@@ -227,14 +249,8 @@ func parseHermesJSONLSession(path, project, machine string) (*ParsedSession, []P
 			tcArray := gjson.Get(line, "tool_calls")
 			if tcArray.IsArray() {
 				tcArray.ForEach(func(_, tc gjson.Result) bool {
-					name := tc.Get("function.name").Str
-					if name != "" {
-						toolCalls = append(toolCalls, ParsedToolCall{
-							ToolUseID: tc.Get("id").Str,
-							ToolName:  name,
-							Category:  NormalizeToolCategory(name),
-							InputJSON: tc.Get("function.arguments").Str,
-						})
+					if toolCall, ok := parseHermesToolCall(tc); ok {
+						toolCalls = append(toolCalls, toolCall)
 					}
 					return true
 				})
@@ -427,14 +443,8 @@ func parseHermesJSONSession(path, project, machine string) (*ParsedSession, []Pa
 			tcArray := msg.Get("tool_calls")
 			if tcArray.IsArray() {
 				tcArray.ForEach(func(_, tc gjson.Result) bool {
-					name := tc.Get("function.name").Str
-					if name != "" {
-						toolCalls = append(toolCalls, ParsedToolCall{
-							ToolUseID: tc.Get("id").Str,
-							ToolName:  name,
-							Category:  NormalizeToolCategory(name),
-							InputJSON: tc.Get("function.arguments").Str,
-						})
+					if toolCall, ok := parseHermesToolCall(tc); ok {
+						toolCalls = append(toolCalls, toolCall)
 					}
 					return true
 				})
@@ -1095,17 +1105,8 @@ func convertHermesStateMessages(
 			if gjson.Valid(hm.toolCalls) {
 				gjson.Parse(hm.toolCalls).ForEach(
 					func(_, tc gjson.Result) bool {
-						name := tc.Get("function.name").Str
-						if name == "" {
-							name = tc.Get("name").Str
-						}
-						if name != "" {
-							toolCalls = append(toolCalls, ParsedToolCall{
-								ToolUseID: tc.Get("id").Str,
-								ToolName:  name,
-								Category:  NormalizeToolCategory(name),
-								InputJSON: tc.Get("function.arguments").Str,
-							})
+						if toolCall, ok := parseHermesToolCall(tc); ok {
+							toolCalls = append(toolCalls, toolCall)
 						}
 						return true
 					},

--- a/internal/parser/hermes.go
+++ b/internal/parser/hermes.go
@@ -55,6 +55,25 @@ type hermesStateMessage struct {
 	codexMessageItems   string
 }
 
+func hermesToolInputJSON(tc gjson.Result) string {
+	for _, path := range []string{"function.arguments", "arguments", "input"} {
+		input := tc.Get(path)
+		if !input.Exists() {
+			continue
+		}
+		if input.Type == gjson.String {
+			if input.Str == "" {
+				continue
+			}
+			return input.Str
+		}
+		if input.Raw != "" {
+			return input.Raw
+		}
+	}
+	return ""
+}
+
 func parseHermesToolCall(tc gjson.Result) (ParsedToolCall, bool) {
 	name := tc.Get("function.name").Str
 	if name == "" {
@@ -64,7 +83,7 @@ func parseHermesToolCall(tc gjson.Result) (ParsedToolCall, bool) {
 		return ParsedToolCall{}, false
 	}
 
-	inputJSON := tc.Get("function.arguments").Str
+	inputJSON := hermesToolInputJSON(tc)
 	toolCall := ParsedToolCall{
 		ToolUseID: tc.Get("id").Str,
 		ToolName:  name,

--- a/internal/parser/hermes_test.go
+++ b/internal/parser/hermes_test.go
@@ -809,6 +809,62 @@ func TestParseHermesSession_JSONL_ToolCalls(t *testing.T) {
 	)
 }
 
+func TestParseHermesSkillViewSetsSkillName(t *testing.T) {
+	const skillName = "debugging"
+	const skillToolCall = `{"id":"skill-1","function":{"name":"skill_view","arguments":"{\"name\":\"debugging\"}"}}`
+
+	t.Run("JSONL transcript", func(t *testing.T) {
+		content := strings.Join([]string{
+			`{"role":"session_meta","timestamp":"2026-04-03T15:00:00.000000"}`,
+			`{"role":"user","content":"Debug this","timestamp":"2026-04-03T15:00:01.000000"}`,
+			`{"role":"assistant","content":"","tool_calls":[` + skillToolCall + `],"timestamp":"2026-04-03T15:00:02.000000"}`,
+		}, "\n")
+
+		_, msgs := runHermesJSONLTest(t, "", content)
+		require.Len(t, msgs, 2)
+		require.Len(t, msgs[1].ToolCalls, 1)
+		assert.Equal(t, skillName, msgs[1].ToolCalls[0].SkillName)
+	})
+
+	t.Run("JSON transcript", func(t *testing.T) {
+		content := `{
+			"messages": [
+				{"role":"user","content":"Debug this","timestamp":"2026-04-03T15:00:01.000000"},
+				{"role":"assistant","content":"","tool_calls":[` + skillToolCall + `],"timestamp":"2026-04-03T15:00:02.000000"}
+			]
+		}`
+
+		_, msgs := runHermesJSONTest(t, "", content)
+		require.Len(t, msgs, 2)
+		require.Len(t, msgs[1].ToolCalls, 1)
+		assert.Equal(t, skillName, msgs[1].ToolCalls[0].SkillName)
+	})
+
+	t.Run("state database", func(t *testing.T) {
+		root := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(root, "sessions"), 0o755))
+		createHermesStateDB(t, root)
+
+		db, err := sql.Open("sqlite3", filepath.Join(root, "state.db"))
+		require.NoError(t, err)
+		_, err = db.Exec(`
+			INSERT INTO messages (
+				session_id, role, content, tool_calls, timestamp
+			) VALUES (
+				'child', 'assistant', '', ?, 1778767211.0
+			)`, `[`+skillToolCall+`]`)
+		require.NoError(t, err)
+		require.NoError(t, db.Close())
+
+		results, err := parseHermesTestArchive(t, root, "", "local")
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		require.Len(t, results[0].Messages, 2)
+		require.Len(t, results[0].Messages[1].ToolCalls, 1)
+		assert.Equal(t, skillName, results[0].Messages[1].ToolCalls[0].SkillName)
+	})
+}
+
 func TestParseHermesSession_JSONL_MultipleToolCalls(t *testing.T) {
 	content := strings.Join([]string{
 		`{"role":"session_meta","timestamp":"2026-04-03T15:00:00.000000"}`,

--- a/internal/parser/hermes_test.go
+++ b/internal/parser/hermes_test.go
@@ -865,6 +865,54 @@ func TestParseHermesSkillViewSetsSkillName(t *testing.T) {
 	})
 }
 
+func TestParseHermesSkillViewInputEncodings(t *testing.T) {
+	testCases := []struct {
+		name     string
+		toolCall string
+	}{
+		{
+			name:     "nested string arguments",
+			toolCall: `{"id":"skill-1","function":{"name":"skill_view","arguments":"{\"name\":\"debugging\"}"}}`,
+		},
+		{
+			name:     "nested object arguments",
+			toolCall: `{"id":"skill-1","function":{"name":"skill_view","arguments":{"name":"debugging"}}}`,
+		},
+		{
+			name:     "top-level string arguments",
+			toolCall: `{"id":"skill-1","name":"skill_view","arguments":"{\"name\":\"debugging\"}"}`,
+		},
+		{
+			name:     "top-level object arguments",
+			toolCall: `{"id":"skill-1","name":"skill_view","arguments":{"name":"debugging"}}`,
+		},
+		{
+			name:     "top-level string input",
+			toolCall: `{"id":"skill-1","name":"skill_view","input":"{\"name\":\"debugging\"}"}`,
+		},
+		{
+			name:     "top-level object input",
+			toolCall: `{"id":"skill-1","name":"skill_view","input":{"name":"debugging"}}`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			content := strings.Join([]string{
+				`{"role":"session_meta","timestamp":"2026-04-03T15:00:00.000000"}`,
+				`{"role":"user","content":"Debug this","timestamp":"2026-04-03T15:00:01.000000"}`,
+				`{"role":"assistant","content":"","tool_calls":[` + testCase.toolCall + `],"timestamp":"2026-04-03T15:00:02.000000"}`,
+			}, "\n")
+
+			_, msgs := runHermesJSONLTest(t, "", content)
+			require.Len(t, msgs, 2)
+			require.Len(t, msgs[1].ToolCalls, 1)
+			assert.JSONEq(t, `{"name":"debugging"}`, msgs[1].ToolCalls[0].InputJSON)
+			assert.Equal(t, "debugging", msgs[1].ToolCalls[0].SkillName)
+		})
+	}
+}
+
 func TestParseHermesSession_JSONL_MultipleToolCalls(t *testing.T) {
 	content := strings.Join([]string{
 		`{"role":"session_meta","timestamp":"2026-04-03T15:00:00.000000"}`,


### PR DESCRIPTION
## Summary
- centralize Hermes tool-call parsing across JSONL, JSON, and `state.db` sources
- preserve Hermes tool input from nested or top-level `arguments`/`input`, in string or object form
- populate `ParsedToolCall.SkillName` from `skill_view` arguments
- bump the parser data version so historical Hermes sessions are reparsed and backfilled
- add regression coverage for all three Hermes input paths and the data-version bump

## Problem
Hermes records skill loads as `skill_view` tool calls with a JSON-string `name` argument. The parser preserved the tool call and its input, but never populated `SkillName`, so skill analytics always reported no data for Hermes sessions.

Existing sessions also need a data-version resync; otherwise unchanged Hermes sessions already stored at the previous parser version would remain without skill metadata.

## Test plan
- `go test -tags fts5 ./internal/db ./internal/parser -run '^(TestCurrentDataVersionHermesSkillName|TestParseHermesSkillViewSetsSkillName)$' -count=1 -v`
- `go test -tags fts5 ./internal/db ./internal/parser -count=1`
- `make vet`
- `make test-short` (all packages passed except the unrelated, filesystem-sensitive `TestFileChangeTimeDetectsSameStatRewrite`, independently reproducible as intermittent)
