### PR TITLE
docs(pg): document pg serve deployment guardrails

### DIFF
--- a/docs/pg-sync.md
+++ b/docs/pg-sync.md
@@ -387,6 +387,24 @@ the analytics and usage queries to perform well on CockroachDB
 aggregation, batched pricing writes) without changing any
 report semantics on PostgreSQL or SQLite.
 
+In a multi-tenant deployment behind PostgreSQL row-level
+security, slow analytics or usage panels usually point at the
+policy shape rather than at agentsview itself. The read-side
+queries are already session-id-shaped, so expose child rows
+through a set-based predicate such as `session_id IN (SELECT
+...)`, not a per-row `SECURITY DEFINER` call that runs once
+per scanned row. If shared-dataset aggregates still need more
+time, raise the API deadline with `--write-timeout`; the
+[Remote Access](/remote-access/#slow-aggregates-behind-a-proxy)
+page covers the flag and the larger troubleshooting path.
+
+When a reverse proxy reaches the backend by an internal
+hostname or service name, keep `--public-url` on the browser
+origin and add the proxy's upstream origin with
+`--public-origin`. The forwarded-access contract and
+troubleshooting details live in
+[Remote Access](/remote-access/#public-url-and-trusted-origins).
+
 !!! warning
     Query-parameter tokens can leak through server logs, browser
     history, and Referer headers. Prefer the `Authorization`
@@ -425,6 +443,14 @@ agentsview pg serve \
 # Requires require_auth = true; only use behind a VPN or on a
 # private LAN because tokens cross the wire in cleartext.
 agentsview pg serve --host 0.0.0.0 --port 8080
+
+# External reverse proxy under a subpath; the browser origin
+# and the proxy's upstream origin are different.
+agentsview pg serve \
+  --host 0.0.0.0 \
+  --base-path /agentsview \
+  --public-url https://console.example.com \
+  --public-origin http://agentsview:8080
 ```
 
 ---
@@ -536,12 +562,12 @@ A typical team setup:
 # Developer A's machine
 agentsview pg service install
 
-# Team server
+# Team server behind an external reverse proxy
 agentsview pg serve \
-  --proxy caddy \
-  --public-url https://viewer.team.internal \
-  --tls-cert /etc/certs/viewer.pem \
-  --tls-key /etc/certs/viewer-key.pem
+  --host 0.0.0.0 \
+  --base-path /agentsview \
+  --public-url https://console.example.com \
+  --public-origin http://agentsview:8080
 ```
 
 ---


### PR DESCRIPTION
`pg serve` documentation currently lists the shared-database flags and proxy setup, but it leaves two deployment guardrails implicit. Large multi-tenant aggregates can spend their time inside the database's row-level-security policy rather than in agentsview itself, and reverse proxies that reach the backend by internal service hostname need that upstream origin on the trusted-origin allowlist.

This adds the missing pg-serve guidance to `docs/pg-sync.md`. The page now points operators at set-based session-id membership policies for RLS-scoped read roles, ties slow aggregate panels to `--write-timeout` and the existing remote-access deadline note, and shows the internal-upstream-host case where `--public-origin` covers the proxy's backend origin while `--public-url` stays the browser origin. `pg serve` behavior, auth flow, and the shared forwarded-access contract stay unchanged.

The RLS policy shape and internal-host proxy case came from @Technophobe01's issue report, and the configurable timeout portion already landed separately in https://github.com/kenn-io/agentsview/pull/1148. The timeout-response body improvement remains follow-up server work.

Refs #1147
