### PR TITLE
fix(server): add timeout response detail

### DIFF
--- a/internal/server/helpers_internal_test.go
+++ b/internal/server/helpers_internal_test.go
@@ -61,7 +61,7 @@ func withHandlerDelay(d time.Duration) Option {
 // a JSON body containing "request timed out" and the correct
 // Content-Type header.
 func assertTimeoutResponse(
-	t *testing.T, resp *http.Response,
+	t *testing.T, resp *http.Response, detailSubstrings ...string,
 ) {
 	t.Helper()
 	require.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
@@ -74,7 +74,12 @@ func assertTimeoutResponse(
 	var je jsonError
 	require.NoError(t, json.Unmarshal(body, &je),
 		"body is not valid JSON; body=%q", string(body))
+	t.Logf("timeout body: %s", string(body))
 	require.Equal(t, "request timed out", je.Error)
+	require.NotEmpty(t, je.Detail)
+	for _, want := range detailSubstrings {
+		require.Contains(t, je.Detail, want)
+	}
 	require.Equal(t, "application/json", resp.Header.Get("Content-Type"))
 }
 

--- a/internal/server/huma_routes.go
+++ b/internal/server/huma_routes.go
@@ -393,7 +393,10 @@ func (s *Server) humaTimeout() func(*huma.Operation) {
 					next(huma.WithContext(humago.NewContext(ctx.Operation(), r, w), r.Context()))
 				}),
 				s.cfg.WriteTimeout,
-				`{"error":"request timed out"}`,
+				timeoutErrorBody(
+					req.Method+" "+req.URL.Path,
+					s.cfg.WriteTimeout,
+				),
 			)
 			tw := &contentTypeWrapper{
 				ResponseWriter: writer,

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -2,26 +2,40 @@ package server
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"time"
 )
 
 // jsonError is the standard JSON error response.
 type jsonError struct {
-	Error string `json:"error"`
+	Error  string `json:"error"`
+	Detail string `json:"detail,omitempty"`
+}
+
+func timeoutErrorBody(
+	operation string, timeout time.Duration,
+) string {
+	if operation == "" {
+		operation = "request"
+	}
+	msgBytes, _ := json.Marshal(jsonError{
+		Error: "request timed out",
+		Detail: fmt.Sprintf(
+			"%s did not finish writing a response within the %s write timeout; the request or backing store is likely too slow. Retry, narrow the query, or raise --write-timeout if this request is expected to run longer.",
+			operation, timeout,
+		),
+	})
+	return string(msgBytes)
 }
 
 // withTimeout applies a write timeout to standard handlers.
 // It uses http.TimeoutHandler but ensures the response is
 // JSON with correct headers.
 func (s *Server) withTimeout(
+	operation string,
 	h http.HandlerFunc,
 ) http.Handler {
-	msgBytes, _ := json.Marshal(
-		jsonError{Error: "request timed out"},
-	)
-	msg := string(msgBytes)
-
 	inner := h
 	if s.handlerDelay > 0 {
 		delay := s.handlerDelay
@@ -39,7 +53,8 @@ func (s *Server) withTimeout(
 	}
 
 	handler := http.TimeoutHandler(
-		inner, s.cfg.WriteTimeout, msg,
+		inner, s.cfg.WriteTimeout,
+		timeoutErrorBody(operation, s.cfg.WriteTimeout),
 	)
 
 	return http.HandlerFunc(

--- a/internal/server/middleware_internal_test.go
+++ b/internal/server/middleware_internal_test.go
@@ -12,12 +12,12 @@ import (
 // A non-positive write timeout must disable the deadline instead of wrapping the
 // handler in http.TimeoutHandler with a 0 duration, which would fire immediately
 // and 503 every request.
-func TestWithTimeout_NonPositiveDisablesDeadline(t *testing.T) {
+func TestWithTimeout_DisabledTimeout(t *testing.T) {
 	t.Parallel()
 	s := testServer(t, 0)
 
 	called := false
-	h := s.withTimeout(func(w http.ResponseWriter, _ *http.Request) {
+	h := s.withTimeout("GET /api/v1/recall/entries", func(w http.ResponseWriter, _ *http.Request) {
 		called = true
 		w.WriteHeader(http.StatusOK)
 	})

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -120,13 +120,14 @@ func TestMiddlewareTimeout(t *testing.T) {
 		name        string
 		path        string
 		wantTimeout bool
+		wantDetail  []string
 		wantStatus  int // Only checked if wantTimeout is false
 	}{
-		{"Wrapped_ListSessions", "/api/v1/sessions", true, 0},
-		{"Wrapped_GetStats", "/api/v1/stats", true, 0},
-		{"Unwrapped_SearchContent", "/api/v1/search/content?pattern=needle", false, http.StatusOK},
-		{"Unwrapped_ExportSession", "/api/v1/sessions/invalid-id/export", false, http.StatusNotFound},
-		{"Unwrapped_SPA", "/", false, http.StatusOK},
+		{"Wrapped_ListSessions", "/api/v1/sessions", true, []string{"GET /api/v1/sessions", "10ms", "--write-timeout"}, 0},
+		{"Wrapped_GetStats", "/api/v1/stats", true, []string{"GET /api/v1/stats", "10ms", "--write-timeout"}, 0},
+		{"Unwrapped_SearchContent", "/api/v1/search/content?pattern=needle", false, nil, http.StatusOK},
+		{"Unwrapped_ExportSession", "/api/v1/sessions/invalid-id/export", false, nil, http.StatusNotFound},
+		{"Unwrapped_SPA", "/", false, nil, http.StatusOK},
 	}
 
 	for _, tt := range tests {
@@ -137,7 +138,7 @@ func TestMiddlewareTimeout(t *testing.T) {
 			defer resp.Body.Close()
 
 			if tt.wantTimeout {
-				assertTimeoutResponse(t, resp)
+				assertTimeoutResponse(t, resp, tt.wantDetail...)
 			} else {
 				assert.False(t, isTimeoutResponse(t, resp),
 					"%s: unexpected timeout for unwrapped route", tt.path)

--- a/internal/server/recall_eval_ingest.go
+++ b/internal/server/recall_eval_ingest.go
@@ -36,7 +36,10 @@ type evalTrajectoryIngestRequest struct {
 func (s *Server) registerEvalIngestRoutes() {
 	s.mux.Handle(
 		"POST /api/v1/recall/eval/trajectories",
-		s.withTimeout(s.handleIngestEvalTrajectory),
+		s.withTimeout(
+			"POST /api/v1/recall/eval/trajectories",
+			s.handleIngestEvalTrajectory,
+		),
 	)
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -342,10 +342,22 @@ func (s *Server) routes() {
 		s.mux.HandleFunc("/debug/pprof/trace", httppprof.Trace)
 	}
 
-	s.mux.Handle("GET /api/v1/recall/entries", s.withTimeout(s.handleListRecallEntries))
-	s.mux.Handle("GET /api/v1/recall/entries/{id}", s.withTimeout(s.handleGetRecallEntry))
-	s.mux.Handle("POST /api/v1/recall/query", s.withTimeout(s.handleQueryRecallEntries))
-	s.mux.Handle("POST /api/v1/recall/import", s.withTimeout(s.handleImportRecallEntries))
+	s.mux.Handle("GET /api/v1/recall/entries", s.withTimeout(
+		"GET /api/v1/recall/entries",
+		s.handleListRecallEntries,
+	))
+	s.mux.Handle("GET /api/v1/recall/entries/{id}", s.withTimeout(
+		"GET /api/v1/recall/entries/{id}",
+		s.handleGetRecallEntry,
+	))
+	s.mux.Handle("POST /api/v1/recall/query", s.withTimeout(
+		"POST /api/v1/recall/query",
+		s.handleQueryRecallEntries,
+	))
+	s.mux.Handle("POST /api/v1/recall/import", s.withTimeout(
+		"POST /api/v1/recall/import",
+		s.handleImportRecallEntries,
+	))
 	s.registerEvalIngestRoutes()
 
 	// SPA fallback: serve embedded frontend

--- a/internal/server/timeout_custom_test.go
+++ b/internal/server/timeout_custom_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -16,6 +17,7 @@ func TestWithTimeout(t *testing.T) {
 
 	tests := []struct {
 		name           string
+		operation      string
 		timeout        time.Duration
 		handler        http.HandlerFunc
 		wantStatus     int
@@ -25,18 +27,27 @@ func TestWithTimeout(t *testing.T) {
 		assertResponse func(t *testing.T, resp *http.Response)
 	}{
 		{
-			name:    "timeout",
-			timeout: 10 * time.Millisecond,
+			name:      "timeout",
+			operation: "GET /test",
+			timeout:   10 * time.Millisecond,
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				time.Sleep(50 * time.Millisecond)
 				w.WriteHeader(http.StatusOK)
 				w.Write([]byte("too slow"))
 			},
-			assertResponse: assertTimeoutResponse,
+			assertResponse: func(t *testing.T, resp *http.Response) {
+				assertTimeoutResponse(
+					t, resp,
+					"GET /test",
+					"10ms",
+					"--write-timeout",
+				)
+			},
 		},
 		{
-			name:    "success",
-			timeout: 100 * time.Millisecond,
+			name:      "success",
+			operation: "GET /test",
+			timeout:   100 * time.Millisecond,
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("X-Custom", "value")
 				w.WriteHeader(http.StatusCreated)
@@ -53,7 +64,7 @@ func TestWithTimeout(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			s := newTestServerMinimal(t, tt.timeout)
-			wrapped := s.withTimeout(tt.handler)
+			wrapped := s.withTimeout(tt.operation, tt.handler)
 
 			req := httptest.NewRequest(http.MethodGet, "/", nil)
 			w := httptest.NewRecorder()
@@ -80,4 +91,20 @@ func TestWithTimeout(t *testing.T) {
 			assert.Equal(t, tt.wantBody, string(body))
 		})
 	}
+}
+
+func TestTimeoutBodyParity(t *testing.T) {
+	t.Parallel()
+
+	operation := "GET /api/v1/sessions"
+	timeout := 30 * time.Second
+
+	msg := timeoutErrorBody(operation, timeout)
+
+	var je jsonError
+	require.NoError(t, json.Unmarshal([]byte(msg), &je))
+	assert.Equal(t, "request timed out", je.Error)
+	assert.Contains(t, je.Detail, operation)
+	assert.Contains(t, je.Detail, "30s")
+	assert.Contains(t, je.Detail, "--write-timeout")
 }


### PR DESCRIPTION
agentsview's write-timeout wrappers currently cut requests off with the same bare `{"error":"request timed out"}` body, which leaves an operator guessing whether the failure came from the server's write budget, the query shape, or an upstream timeout. This adds one shared timeout-body helper in `internal/server` and uses it from both the standard handler wrapper and the Huma wrapper, so 503 timeout responses keep the existing top-level error string for compatibility but now include a `detail` field that names the timed-out operation, the configured write-timeout duration, and the `--write-timeout` remedy.

The typed `apiErrorResponse` vocabulary and the separate 504 `gateway timeout` path stay unchanged, and the sync route remains intentionally unwrapped, so the diff only changes the fixed 503 body and the tests that pin it. The issue report and the merged write-timeout configurability work from https://github.com/kenn-io/agentsview/pull/1148 set the scope for this slice, and the docs-only sibling PR https://github.com/kenn-io/agentsview/pull/1174 remains the other open part of #1147.

Refs #1147
