### PR TITLE
feat(usage): roll up subagent cost in session header

### DIFF
--- a/docs/session-api.md
+++ b/docs/session-api.md
@@ -626,6 +626,13 @@ only honored on a localhost-bound daemon.
 Per-session token usage and cost estimate. Output shape is
 stable for the fields shown below; new fields may be added.
 
+The REST endpoint is `GET /api/v1/sessions/{id}/usage`. Add
+`?rollup=true` there to include the selected session's explicit
+`subagent` descendants recursively. `breakdown=true` remains scoped to
+the selected session; descendant usage is loaded as totals only. The CLI
+subcommand keeps its existing own-session output and does not expose the
+rollup fields below.
+
 ```bash
 agentsview session usage <id> [--format json]
 ```
@@ -675,6 +682,9 @@ agentsview session usage <id> [--format json]
 | `breakdown_count`     | Number of per-step usage rows in the session; always populated       |
 | `breakdown`           | Per-step usage rows, in session order; CLI JSON always includes them (added in 0.37.1) |
 | `server_running`      | `true` when the report came from an already-running daemon           |
+| `rollup_cost_usd`      | REST only, with `rollup=true`; present only when `has_rollup_cost` is true, then carries the complete cost across the root and explicit subagent descendants |
+| `has_rollup_cost`      | REST only, with `rollup=true`; true only when at least one contributing row exists and every contributing row is priced |
+| `rollup_subagent_count`| REST only, with `rollup=true`; count of reachable explicit subagent descendants, including those without usage rows |
 
 Each `breakdown` row carries the fields shown in the example:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -800,6 +800,13 @@ two decimals, and larger costs as whole dollars. The badge is
 hidden when the session has no token data or its models have
 no pricing.
 
+When the selected session has explicit `subagent` descendants, the
+automatic header request adds `rollup=true`. A complete priced aggregate
+shows a localized total marker and the descendant count. If any contributing
+row is unpriced, the header keeps the root session's own cost when available
+and does not label it as a total. Sessions without explicit subagent
+descendants keep the existing badge.
+
 As of 0.37.1, sessions with per-step usage rows also show a
 **step count** next to the token summary. Click it to expand a
 per-step breakdown: each row lists the prompt or usage event,

--- a/frontend/e2e/navigation.spec.ts
+++ b/frontend/e2e/navigation.spec.ts
@@ -79,7 +79,7 @@ test.describe("Navigation", () => {
     }
 
     const fallback = page.locator(
-      '.session-item:not([data-session-id="test-session-mixed-content-7"])',
+      '.session-item:visible:not([data-session-id="test-session-mixed-content-7"])',
     ).first();
     await fallback.click();
     await expect(page.locator(".cost-badge")).toContainText("$1.00");

--- a/frontend/e2e/navigation.spec.ts
+++ b/frontend/e2e/navigation.spec.ts
@@ -31,6 +31,61 @@ test.describe("Navigation", () => {
     await expect(sp.exportBtn).toContainText("Export CSV");
   });
 
+  test("subagent cost rollup", async ({ page }, testInfo) => {
+    await page.route("**/api/v1/sessions/*/usage**", async (route) => {
+      const rollup = new URL(route.request().url()).searchParams.get("rollup");
+      const complete = route.request().url().includes("test-session-mixed-content-7");
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          session_id: "test-session-mixed-content-7",
+          agent: "claude",
+          project: "project",
+          total_output_tokens: 0,
+          peak_context_tokens: 0,
+          has_token_data: false,
+          cost_usd: 1,
+          has_cost: true,
+          models: [],
+          unpriced_models: [],
+          breakdown_count: 0,
+          breakdown: [],
+          server_running: true,
+          ...(rollup === "true"
+            ? {
+                has_rollup_cost: complete,
+                ...(complete ? { rollup_cost_usd: 3 } : {}),
+                rollup_subagent_count: 1,
+              }
+            : {}),
+        }),
+      });
+    });
+
+    const selected = page.locator('.session-item[data-session-id="test-session-mixed-content-7"]');
+    await selected.click();
+    for (const width of [1280, 768, 400]) {
+      await page.setViewportSize({ width, height: 800 });
+      await expect(page.locator(".cost-badge")).toContainText("Total");
+      await expect(page.locator(".cost-badge")).toContainText("$3.00");
+      await expect(page.locator(".cost-badge")).toHaveAttribute(
+        "title",
+        "Total cost including 1 subagent",
+      );
+      await page.screenshot({
+        path: testInfo.outputPath(`subagent-cost-rollup-${width}.png`),
+      });
+    }
+
+    const fallback = page.locator(
+      '.session-item:not([data-session-id="test-session-mixed-content-7"])',
+    ).first();
+    await fallback.click();
+    await expect(page.locator(".cost-badge")).toContainText("$1.00");
+    await expect(page.locator(".cost-badge")).not.toContainText("Total");
+  });
+
   test("Shift+J and Shift+K navigate visible user prompts", async ({ page }, testInfo) => {
     const sessionId = "test-session-mixed-content-7";
     const session = page.locator(`.session-item[data-session-id="${sessionId}"]`);

--- a/frontend/e2e/navigation.spec.ts
+++ b/frontend/e2e/navigation.spec.ts
@@ -78,6 +78,7 @@ test.describe("Navigation", () => {
       });
     }
 
+    await page.setViewportSize({ width: 1280, height: 800 });
     const fallback = page.locator(
       '.session-item:visible:not([data-session-id="test-session-mixed-content-7"])',
     ).first();

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -164,6 +164,23 @@
   "session_breadcrumb_copy_session_id_value": "Copy session ID: {id}",
   "session_breadcrumb_copied": "Copied!",
   "session_breadcrumb_estimated_session_cost": "Estimated session cost",
+  "session_breadcrumb_total_cost": "Total",
+  "session_breadcrumb_total_cost_title": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=one": "Total cost including {countLabel} subagent",
+        "countPlural=other": "Total cost including {countLabel} subagents"
+      }
+    }
+  ],
   "session_breadcrumb_usage_breakdown_title": "Session usage breakdown",
   "session_breadcrumb_usage_breakdown_loading": "Loading usage...",
   "session_breadcrumb_usage_breakdown_steps": [

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -164,6 +164,23 @@
   "session_breadcrumb_copy_session_id_value": "Copier l'ID de la session : {id}",
   "session_breadcrumb_copied": "Copié !",
   "session_breadcrumb_estimated_session_cost": "Coût estimé de la session",
+  "session_breadcrumb_total_cost": "Total",
+  "session_breadcrumb_total_cost_title": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=one": "Coût total avec {countLabel} sous-agent",
+        "countPlural=other": "Coût total avec {countLabel} sous-agents"
+      }
+    }
+  ],
   "session_breadcrumb_usage_breakdown_title": "Détail de la consommation de la session",
   "session_breadcrumb_usage_breakdown_loading": "Chargement de la consommation...",
   "session_breadcrumb_usage_breakdown_steps": [

--- a/frontend/messages/ko.json
+++ b/frontend/messages/ko.json
@@ -161,6 +161,23 @@
   "session_breadcrumb_copy_session_id_value": "세션 ID 복사: {id}",
   "session_breadcrumb_copied": "복사됨!",
   "session_breadcrumb_estimated_session_cost": "예상 세션 비용",
+  "session_breadcrumb_total_cost": "합계",
+  "session_breadcrumb_total_cost_title": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=one": "하위 에이전트 {countLabel}개를 포함한 총 비용",
+        "countPlural=other": "하위 에이전트 {countLabel}개를 포함한 총 비용"
+      }
+    }
+  ],
   "session_breadcrumb_usage_breakdown_title": "세션 사용량 상세",
   "session_breadcrumb_usage_breakdown_loading": "사용량 불러오는 중...",
   "session_breadcrumb_usage_breakdown_steps": [

--- a/frontend/messages/zh-CN.json
+++ b/frontend/messages/zh-CN.json
@@ -161,6 +161,23 @@
   "session_breadcrumb_copy_session_id_value": "复制会话 ID：{id}",
   "session_breadcrumb_copied": "已复制！",
   "session_breadcrumb_estimated_session_cost": "预估会话成本",
+  "session_breadcrumb_total_cost": "总计",
+  "session_breadcrumb_total_cost_title": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=one": "包含 {countLabel} 个子代理的总成本",
+        "countPlural=other": "包含 {countLabel} 个子代理的总成本"
+      }
+    }
+  ],
   "session_breadcrumb_usage_breakdown_title": "会话用量明细",
   "session_breadcrumb_usage_breakdown_loading": "正在加载用量数据...",
   "session_breadcrumb_usage_breakdown_steps": [

--- a/frontend/messages/zh-TW.json
+++ b/frontend/messages/zh-TW.json
@@ -161,6 +161,23 @@
   "session_breadcrumb_copy_session_id_value": "複製會話 ID：{id}",
   "session_breadcrumb_copied": "已複製！",
   "session_breadcrumb_estimated_session_cost": "預估會話成本",
+  "session_breadcrumb_total_cost": "總計",
+  "session_breadcrumb_total_cost_title": [
+    {
+      "declarations": [
+        "input count",
+        "input countLabel",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=one": "包含 {countLabel} 個子代理的總成本",
+        "countPlural=other": "包含 {countLabel} 個子代理的總成本"
+      }
+    }
+  ],
   "session_breadcrumb_usage_breakdown_title": "會話用量明細",
   "session_breadcrumb_usage_breakdown_loading": "正在載入用量數據...",
   "session_breadcrumb_usage_breakdown_steps": [

--- a/frontend/src/lib/api/generated/models/SessionUsageResponse.ts
+++ b/frontend/src/lib/api/generated/models/SessionUsageResponse.ts
@@ -9,10 +9,13 @@ export type SessionUsageResponse = {
   breakdown_count: number;
   cost_usd: number;
   has_cost: boolean;
+  has_rollup_cost?: boolean;
   has_token_data: boolean;
   models: any[] | null;
   peak_context_tokens: number;
   project: string;
+  rollup_cost_usd?: number;
+  rollup_subagent_count?: number;
   server_running: boolean;
   session_id: string;
   total_output_tokens: number;

--- a/frontend/src/lib/api/generated/services/SessionsService.ts
+++ b/frontend/src/lib/api/generated/services/SessionsService.ts
@@ -1189,6 +1189,7 @@ export class SessionsService {
   public static getApiV1SessionsIdUsage({
     id,
     breakdown,
+    rollup,
   }: {
     /**
      * Session ID
@@ -1198,6 +1199,10 @@ export class SessionsService {
      * Include per-step breakdown rows
      */
     breakdown?: boolean,
+    /**
+     * Include explicit subagent descendant costs
+     */
+    rollup?: boolean,
   }): CancelablePromise<SessionUsageResponse> {
     return __request(OpenAPI, {
       method: 'GET',
@@ -1207,6 +1212,7 @@ export class SessionsService {
       },
       query: {
         'breakdown': breakdown,
+        'rollup': rollup,
       },
       errors: {
         400: `Bad Request`,

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.svelte
@@ -165,6 +165,8 @@
   });
 
   let sessionCost = $state<number | null>(null);
+  let sessionCostIsRollup = $state(false);
+  let sessionRollupSubagentCount = $state(0);
   let sessionUsageBreakdownCount = $state(0);
   let sessionUsageBreakdown = $state<SessionUsageBreakdownEntry[]>([]);
   // Key of the last successful usage fetch. Cost depends on more
@@ -178,15 +180,36 @@
   let costSessionId: string | null = null;
   let breakdownFetchKey: string | null = null;
 
+  function childUsageFetchKey(parentId: string): string {
+    return Array.from(sessions.childSessions.values())
+      .filter((child) => child.parent_session_id === parentId)
+      .map((child) =>
+        [
+          child.id,
+          child.relationship_type ?? "",
+          child.transcript_revision ?? "",
+          child.message_count ?? 0,
+          child.total_output_tokens ?? 0,
+          child.peak_context_tokens ?? 0,
+          child.ended_at ?? "",
+        ].join("\t")
+      )
+      .sort()
+      .join("\n");
+  }
+
   function usageFetchKey(s: Session): string {
     return [
       s.id,
+      s.transcript_revision ?? "",
       s.total_output_tokens ?? 0,
       s.peak_context_tokens ?? 0,
       s.has_total_output_tokens ?? "",
       s.has_peak_context_tokens ?? "",
       s.message_count ?? 0,
       s.ended_at ?? "",
+      sessions.activeSessionUsageVersion,
+      childUsageFetchKey(s.id),
     ].join("\n");
   }
 
@@ -203,6 +226,8 @@
     if (!session) {
       costRead.cancel();
       sessionCost = null;
+      sessionCostIsRollup = false;
+      sessionRollupSubagentCount = 0;
       resetUsageBreakdown();
       costFetchKey = null;
       costSessionId = null;
@@ -216,6 +241,8 @@
       // the early return below while another session's request is
       // still in flight.
       sessionCost = null;
+      sessionCostIsRollup = false;
+      sessionRollupSubagentCount = 0;
       resetUsageBreakdown();
       costFetchKey = null;
     }
@@ -224,13 +251,20 @@
     costSessionId = id;
     configureGeneratedClient();
     callGenerated(
-      () => SessionsService.getApiV1SessionsIdUsage({ id }),
+      () => SessionsService.getApiV1SessionsIdUsage({ id, rollup: true }),
       signal,
     )
       .then((res) => {
         if (!costRead.isCurrent(signal)) return;
         costFetchKey = key;
-        sessionCost = res.has_cost ? res.cost_usd : null;
+        sessionRollupSubagentCount = res.rollup_subagent_count ?? 0;
+        sessionCostIsRollup =
+          sessionRollupSubagentCount > 0 && res.has_rollup_cost === true;
+        sessionCost = sessionCostIsRollup
+          ? (res.rollup_cost_usd ?? null)
+          : res.has_cost
+            ? res.cost_usd
+            : null;
         sessionUsageBreakdownCount = res.breakdown_count ?? 0;
       })
       .catch((e) => {
@@ -287,6 +321,14 @@
 
   let sessionCostLabel = $derived(
     sessionCost !== null ? formatCost(sessionCost) : null,
+  );
+  let sessionCostTitle = $derived(
+        sessionCostIsRollup
+      ? m.session_breadcrumb_total_cost_title({
+          count: sessionRollupSubagentCount,
+          countLabel: sessionRollupSubagentCount.toLocaleString(),
+        })
+      : m.session_breadcrumb_estimated_session_cost(),
   );
   // Menu rows render only while open, so the collapsed dropdown
   // stays DOM-free.
@@ -979,8 +1021,12 @@
         </details>
       {/if}
       {#if sessionCostLabel}
-        <span class="cost-badge" title={m.session_breadcrumb_estimated_session_cost()}>
-          {sessionCostLabel}
+        <span class="cost-badge" title={sessionCostTitle}>
+          {#if sessionCostIsRollup}
+            {m.session_breadcrumb_total_cost()}: {sessionCostLabel}
+          {:else}
+            {sessionCostLabel}
+          {/if}
         </span>
       {/if}
       {#if mainModel}

--- a/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
+++ b/frontend/src/lib/components/layout/SessionBreadcrumb.test.ts
@@ -7,6 +7,7 @@ import SessionBreadcrumb from "./SessionBreadcrumb.svelte";
 import type { Message, Session } from "../../api/types.js";
 import { OpenersService, SessionsService } from "../../api/generated/index";
 import { messages } from "../../stores/messages.svelte.js";
+import { sessions } from "../../stores/sessions.svelte.js";
 import { setLocale } from "../../i18n/index.js";
 import { router } from "../../stores/router.svelte.js";
 import { copyToClipboard } from "../../utils/clipboard.js";
@@ -94,6 +95,9 @@ interface SessionUsage {
   has_token_data: boolean;
   cost_usd: number;
   has_cost: boolean;
+  rollup_cost_usd?: number;
+  has_rollup_cost?: boolean;
+  rollup_subagent_count?: number;
   models: string[];
   unpriced_models: string[];
   breakdown_count: number;
@@ -187,6 +191,9 @@ beforeEach(() => {
   sessionsService.getApiV1SessionsIdDirectory.mockReset().mockResolvedValue({ path: "" });
   sessionsService.getApiV1SessionsIdUsage.mockReset().mockResolvedValue(makeUsage());
   sessionsService.postApiV1SessionsIdResume.mockReset();
+  sessions.activeSessionId = null;
+  sessions.activeSessionUsageVersion = 0;
+  sessions.childSessions = new Map();
 });
 
 afterEach(() => {
@@ -1140,6 +1147,58 @@ describe("SessionBreadcrumb", () => {
       unmount(component);
     });
 
+    it("renders a total badge for a complete subagent rollup", async () => {
+      sessionsService.getApiV1SessionsIdUsage.mockResolvedValue(
+        makeUsage({
+          has_cost: true,
+          cost_usd: 1,
+          has_rollup_cost: true,
+          rollup_cost_usd: 3,
+          rollup_subagent_count: 2,
+        }),
+      );
+
+      const component = mount(SessionBreadcrumb, {
+        target: document.body,
+        props: { session: makeSession("claude"), onBack: () => {} },
+      });
+
+      await vi.waitFor(() => {
+        expect(document.querySelector(".cost-badge")?.textContent).toContain("$3.00");
+      });
+      expect(document.querySelector(".cost-badge")?.getAttribute("title")).toBe(
+        "Total cost including 2 subagents",
+      );
+      expect(document.querySelector(".cost-badge")?.textContent).toContain("Total");
+      expect(sessionsService.getApiV1SessionsIdUsage).toHaveBeenCalledWith({
+        id: "run:123456789abcdef",
+        rollup: true,
+      });
+      unmount(component);
+    });
+
+    it("keeps the root cost when the rollup is incomplete", async () => {
+      sessionsService.getApiV1SessionsIdUsage.mockResolvedValue(
+        makeUsage({
+          has_cost: true,
+          cost_usd: 1,
+          has_rollup_cost: false,
+          rollup_subagent_count: 1,
+        }),
+      );
+
+      const component = mount(SessionBreadcrumb, {
+        target: document.body,
+        props: { session: makeSession("claude"), onBack: () => {} },
+      });
+
+      await vi.waitFor(() => {
+        expect(document.querySelector(".cost-badge")?.textContent?.trim()).toBe("$1.00");
+      });
+      expect(document.querySelector(".cost-badge")?.textContent).not.toContain("Total");
+      unmount(component);
+    });
+
     it("renders the cost badge between the token badges and the model badge", async () => {
       sessionsService.getApiV1SessionsIdUsage.mockResolvedValue(
         makeUsage({ has_cost: true, cost_usd: 4.12 }),
@@ -1292,6 +1351,7 @@ describe("SessionBreadcrumb", () => {
       expect(sessionsService.getApiV1SessionsIdUsage).toHaveBeenCalledTimes(1);
       expect(sessionsService.getApiV1SessionsIdUsage).toHaveBeenCalledWith({
         id: "run:123456789abcdef",
+        rollup: true,
       });
 
       await openUsageBreakdown();
@@ -1665,6 +1725,78 @@ describe("SessionBreadcrumb", () => {
       expect(document.querySelector(".cost-badge")?.textContent?.trim()).toBe("$3.50");
 
       component.$destroy();
+    });
+
+    it("refetches rollup cost when active session usage freshness changes", async () => {
+      sessionsService.getApiV1SessionsIdUsage
+        .mockResolvedValueOnce(
+          makeUsage({
+            has_cost: true,
+            cost_usd: 1,
+            has_rollup_cost: true,
+            rollup_cost_usd: 3,
+            rollup_subagent_count: 1,
+          }),
+        )
+        .mockResolvedValueOnce(
+          makeUsage({
+            has_cost: true,
+            cost_usd: 1,
+            has_rollup_cost: true,
+            rollup_cost_usd: 5,
+            rollup_subagent_count: 1,
+          }),
+        );
+
+      sessions.activeSessionId = "run:123456789abcdef";
+
+      const component = createClassComponent({
+        component: SessionBreadcrumb,
+        target: document.body,
+        props: {
+          session: makeSession("claude"),
+          onBack: () => {},
+        },
+      });
+
+      await vi.waitFor(() => {
+        expect(document.querySelector(".cost-badge")?.textContent).toContain("$3.00");
+      });
+
+      sessions.activeSessionUsageVersion = 1;
+      await flushPromises();
+
+      await vi.waitFor(() => {
+        expect(document.querySelector(".cost-badge")?.textContent).toContain("$5.00");
+      });
+      expect(sessionsService.getApiV1SessionsIdUsage).toHaveBeenCalledTimes(2);
+
+      component.$destroy();
+    });
+
+    it("uses singular total-cost copy for one subagent", async () => {
+      sessionsService.getApiV1SessionsIdUsage.mockResolvedValue(
+        makeUsage({
+          has_cost: true,
+          cost_usd: 1,
+          has_rollup_cost: true,
+          rollup_cost_usd: 3,
+          rollup_subagent_count: 1,
+        }),
+      );
+
+      const component = mount(SessionBreadcrumb, {
+        target: document.body,
+        props: { session: makeSession("claude"), onBack: () => {} },
+      });
+
+      await vi.waitFor(() => {
+        expect(document.querySelector(".cost-badge")?.getAttribute("title")).toBe(
+          "Total cost including 1 subagent",
+        );
+      });
+
+      unmount(component);
     });
   });
 });

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -1296,6 +1296,7 @@ class SessionsStore {
       () => {
         this.load();
         this.refreshActiveChildSessions();
+        this.bumpActiveSessionUsageVersion();
       },
       SAFETY_NET_REFRESH_MS,
     );

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -1293,7 +1293,10 @@ class SessionsStore {
       this.handleLiveRefreshEvent(event);
     });
     this.safetyNetTimer = setInterval(
-      () => { this.load(); },
+      () => {
+        this.load();
+        this.refreshActiveChildSessions();
+      },
       SAFETY_NET_REFRESH_MS,
     );
   }

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -241,6 +241,7 @@ class SessionsStore {
   agents: AgentInfo[] = $state([]);
   machines: string[] = $state([]);
   activeSessionId: string | null = $state(null);
+  activeSessionUsageVersion: number = $state(0);
   childSessions: Map<string, Session> = $state(new Map());
   nextCursor: string | null = $state(null);
   total: number = $state(0);
@@ -710,6 +711,7 @@ class SessionsStore {
     this.refreshRead.cancel();
     this.childSessionsRead.cancel();
     this.activeSessionId = id;
+    this.activeSessionUsageVersion = 0;
     this.refreshVersion++;
     this.childSessionsVersion++;
   }
@@ -1299,10 +1301,14 @@ class SessionsStore {
   private handleLiveRefreshEvent(event: DataChangedEvent) {
     if (event.scope === "messages") {
       this.invalidateHydratedSessionDetails();
+      this.bumpActiveSessionUsageVersion();
+      this.refreshActiveChildSessions();
       return;
     }
     if (event.scope === "sessions" || event.scope === "sync") {
       this.scheduleIndexRefresh();
+      this.bumpActiveSessionUsageVersion();
+      this.refreshActiveChildSessions();
     }
   }
 
@@ -1315,6 +1321,17 @@ class SessionsStore {
       this.liveRefreshTimer = null;
       this.load();
     }, LIVE_REFRESH_DEBOUNCE_MS);
+  }
+
+  private refreshActiveChildSessions() {
+    const id = this.activeSessionId;
+    if (!id) return;
+    void this.loadChildSessions(id);
+  }
+
+  private bumpActiveSessionUsageVersion() {
+    if (!this.activeSessionId) return;
+    this.activeSessionUsageVersion++;
   }
 
   private routeSignal(): AbortSignal {

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -3040,7 +3040,7 @@ describe("SessionsStore live refresh", () => {
       expect(sessions.childSessions.get("child")?.total_output_tokens).toBe(9);
     });
     expect(SessionsService.getApiV1SessionsIdChildren).toHaveBeenCalledTimes(2);
-    expect(sessions.activeSessionUsageVersion).toBe(0);
+    expect(sessions.activeSessionUsageVersion).toBe(1);
 
     detach();
     spy.mockRestore();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -3003,6 +3003,50 @@ describe("SessionsStore live refresh", () => {
     vi.useRealTimers();
   });
 
+  it("refreshes active child sessions on the 5-minute safety-net interval", async () => {
+    vi.useFakeTimers();
+    const { events } = await import("./events.svelte.js");
+    const spy = vi
+      .spyOn(events, "subscribe")
+      .mockReturnValue(() => {});
+
+    vi.mocked(SessionsService.getApiV1SessionsIdChildren)
+      .mockResolvedValueOnce([
+        makeSession({
+          id: "child",
+          parent_session_id: "root",
+          total_output_tokens: 1,
+        }),
+      ] as Session[])
+      .mockResolvedValueOnce([
+        makeSession({
+          id: "child",
+          parent_session_id: "root",
+          total_output_tokens: 9,
+        }),
+      ] as Session[]);
+
+    const sessions = createSessionsStore();
+    const detach = sessions.attachSidebar();
+    sessions.activeSessionId = "root";
+    await sessions.load();
+    await sessions.loadChildSessions("root");
+    expect(sessions.childSessions.get("child")?.total_output_tokens).toBe(1);
+    expect(sessions.activeSessionUsageVersion).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+
+    await vi.waitFor(() => {
+      expect(sessions.childSessions.get("child")?.total_output_tokens).toBe(9);
+    });
+    expect(SessionsService.getApiV1SessionsIdChildren).toHaveBeenCalledTimes(2);
+    expect(sessions.activeSessionUsageVersion).toBe(0);
+
+    detach();
+    spy.mockRestore();
+    vi.useRealTimers();
+  });
+
   it("dispose() unsubscribes and clears the safety-net timer", async () => {
     vi.useFakeTimers();
     const { events } = await import("./events.svelte.js");

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -13,6 +13,7 @@ import {
   filtersToParams,
   splitExcludeProjectParam,
 } from "./sessions.svelte.js";
+import { SessionsService } from "../api/generated/index";
 import { starred } from "./starred.svelte.js";
 import { yokedDates } from "./yokedDates.svelte.js";
 import type { Filters } from "./sessions.svelte.js";
@@ -2900,6 +2901,51 @@ describe("SessionsStore live refresh", () => {
     expect(api.getSidebarSessionIndex).toHaveBeenCalledTimes(1);
     expect(api.getSession).toHaveBeenCalledTimes(2);
     expect(sessions.sessions[0]!.first_message).toBe("second hydrate");
+
+    detach();
+    spy.mockRestore();
+  });
+
+  it("messages events refresh active child sessions", async () => {
+    const { events } = await import("./events.svelte.js");
+    let registered: ((e: { scope: string }) => void) | null = null;
+    const spy = vi
+      .spyOn(events, "subscribe")
+      .mockImplementation((fn) => {
+        registered = fn as (e: { scope: string }) => void;
+        return () => {};
+      });
+
+    vi.mocked(SessionsService.getApiV1SessionsIdChildren)
+      .mockResolvedValueOnce([
+        makeSession({
+          id: "child",
+          parent_session_id: "root",
+          transcript_revision: "child-rev-1",
+        }),
+      ] as Session[])
+      .mockResolvedValueOnce([
+        makeSession({
+          id: "child",
+          parent_session_id: "root",
+          transcript_revision: "child-rev-2",
+        }),
+      ] as Session[]);
+
+    const sessions = createSessionsStore();
+    const detach = sessions.attachSidebar();
+    sessions.activeSessionId = "root";
+    await sessions.loadChildSessions("root");
+    expect(sessions.childSessions.get("child")?.transcript_revision).toBe("child-rev-1");
+    expect(sessions.activeSessionUsageVersion).toBe(0);
+
+    registered!({ scope: "messages" });
+
+    await vi.waitFor(() => {
+      expect(sessions.childSessions.get("child")?.transcript_revision).toBe("child-rev-2");
+    });
+    expect(SessionsService.getApiV1SessionsIdChildren).toHaveBeenCalledTimes(2);
+    expect(sessions.activeSessionUsageVersion).toBe(1);
 
     detach();
     spy.mockRestore();

--- a/internal/activity/activity.go
+++ b/internal/activity/activity.go
@@ -58,6 +58,8 @@ type UsageRow struct {
 	Timestamp       string // ts, RFC3339 or ""
 	OutputTokens    int
 	Cost            float64
+	Priced          bool
+	Contributes     bool
 	Agent           string
 	ClaudeMessageID string
 	ClaudeRequestID string

--- a/internal/db/activityreport.go
+++ b/internal/db/activityreport.go
@@ -93,15 +93,138 @@ func (db *DB) GetActivityReport(
 
 // GetSessionUsageRows returns the backend-priced usage rows for the supplied
 // sessions, with the same cross-session deduplication as activity reports.
+type sqliteSessionUsageOrderedRow struct {
+	scan    usageScanRow
+	ts      time.Time
+	validTS bool
+	ordinal int64
+}
+
 func (db *DB) GetSessionUsageRows(
 	ctx context.Context, ids []string,
 ) ([]activity.UsageRow, error) {
-	end := time.Date(9999, time.December, 31, 23, 59, 59, 0, time.UTC)
-	rows, _, err := db.activityReportUsage(ctx, ids,
-		"0001-01-01T00:00:00Z", "9999-12-31T23:59:59Z", activity.Query{
-			RangeStart: time.Time{}, RangeEnd: end, EffectiveEnd: end,
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	pricing, err := db.loadPricingMap(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("loading pricing: %w", err)
+	}
+	rateResolver := export.NewPricingResolver(pricing)
+	sessionOrder := make(map[string]int, len(ids))
+	for i, id := range ids {
+		sessionOrder[id] = i
+	}
+	var rowsAcc []sqliteSessionUsageOrderedRow
+	err = queryChunked(ids, func(chunk []string) error {
+		ph, args := inPlaceholders(chunk)
+		query := usageRowSelect() + ` AND u.session_id IN ` + ph
+		rows, queryErr := db.getReader().QueryContext(ctx, query, args...)
+		if queryErr != nil {
+			return fmt.Errorf("querying session usage rows: %w", queryErr)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			r, scanErr := scanUsageRow(rows)
+			if scanErr != nil {
+				return fmt.Errorf("scanning session usage rows: %w", scanErr)
+			}
+			ordinal := int64(-1)
+			if r.messageOrdinal.Valid {
+				ordinal = r.messageOrdinal.Int64
+			}
+			parsedTS, tsErr := parseTimestamp(r.ts)
+			rowsAcc = append(rowsAcc, sqliteSessionUsageOrderedRow{
+				scan:    r,
+				ts:      parsedTS,
+				validTS: tsErr == nil,
+				ordinal: ordinal,
+			})
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.SliceStable(rowsAcc, func(i, j int) bool {
+		return sqliteSessionUsageRowLess(rowsAcc[i], rowsAcc[j], sessionOrder)
+	})
+	seen := make(map[usageDedupToken]struct{})
+	out := make([]activity.UsageRow, 0, len(rowsAcc))
+	for _, o := range rowsAcc {
+		r := o.scan
+		if key, ok := usageDedupTokenForRow(
+			r.usageSource, r.agent, r.claudeMessageID,
+			r.claudeRequestID, r.sourceUUID, r.usageDedupKey,
+		); ok {
+			if _, dup := seen[key]; dup {
+				continue
+			}
+			seen[key] = struct{}{}
+		}
+		_, outputTok, _, _, _ := sqliteSessionUsageRowTokens(r)
+		cost, priced, contributes := sessionRowCost(r, rateResolver)
+		out = append(out, activity.UsageRow{
+			SessionID:       r.sessionID,
+			Model:           r.model,
+			Timestamp:       r.ts,
+			OutputTokens:    outputTok,
+			Cost:            cost,
+			Priced:          priced,
+			Contributes:     contributes,
+			Agent:           r.agent,
+			ClaudeMessageID: r.claudeMessageID,
+			ClaudeRequestID: r.claudeRequestID,
+			SourceUUID:      r.sourceUUID,
+			UsageDedupKey:   r.usageDedupKey,
 		})
-	return rows, err
+	}
+	return out, nil
+}
+
+func sqliteSessionUsageRowTokens(
+	r usageScanRow,
+) (inputTok, outputTok, cacheCrTok, cacheRdTok, reasoningTok int) {
+	if r.usageSource == "message" {
+		return clampedUsageTokenCountersWithReasoning(r.tokenJSON)
+	}
+	inputTok, outputTok, cacheCrTok, cacheRdTok = usageEventRowTokens(
+		r.usageSource,
+		r.inputTokens, r.outputTokens,
+		r.cacheCreationInputTokens, r.cacheReadInputTokens,
+	)
+	return inputTok, outputTok, cacheCrTok, cacheRdTok, r.reasoningTokens
+}
+
+func sqliteSessionUsageRowLess(
+	a, b sqliteSessionUsageOrderedRow,
+	sessionOrder map[string]int,
+) bool {
+	if a.validTS && b.validTS {
+		if !a.ts.Equal(b.ts) {
+			return a.ts.Before(b.ts)
+		}
+	} else if a.validTS != b.validTS {
+		return a.validTS
+	}
+	if a.scan.ts != b.scan.ts {
+		return a.scan.ts < b.scan.ts
+	}
+	if ai, ok := sessionOrder[a.scan.sessionID]; ok {
+		if bi, ok := sessionOrder[b.scan.sessionID]; ok && ai != bi {
+			return ai < bi
+		}
+	}
+	if a.scan.sessionID != b.scan.sessionID {
+		return a.scan.sessionID < b.scan.sessionID
+	}
+	if a.ordinal != b.ordinal {
+		return a.ordinal < b.ordinal
+	}
+	if a.scan.usageSource != b.scan.usageSource {
+		return a.scan.usageSource < b.scan.usageSource
+	}
+	return a.scan.usageDedupKey < b.scan.usageDedupKey
 }
 
 func activityReportProjectLabels(

--- a/internal/db/activityreport.go
+++ b/internal/db/activityreport.go
@@ -91,6 +91,19 @@ func (db *DB) GetActivityReport(
 	return report, nil
 }
 
+// GetSessionUsageRows returns the backend-priced usage rows for the supplied
+// sessions, with the same cross-session deduplication as activity reports.
+func (db *DB) GetSessionUsageRows(
+	ctx context.Context, ids []string,
+) ([]activity.UsageRow, error) {
+	end := time.Date(9999, time.December, 31, 23, 59, 59, 0, time.UTC)
+	rows, _, err := db.activityReportUsage(ctx, ids,
+		"0001-01-01T00:00:00Z", "9999-12-31T23:59:59Z", activity.Query{
+			RangeStart: time.Time{}, RangeEnd: end, EffectiveEnd: end,
+		})
+	return rows, err
+}
+
 func activityReportProjectLabels(
 	sessions []activity.SessionMeta,
 ) []string {
@@ -334,10 +347,13 @@ func (db *DB) activityReportUsage(
 		if !mask[i] {
 			continue
 		}
-		_, outputTok, _, _, cost, _ := dailyUsageAmounts(o.scan, rateResolver)
+		_, outputTok, _, _, _, _ := dailyUsageAmounts(o.scan, rateResolver)
+		cost, priced, contributes := sqliteActivityReportRowStatus(o.scan, rateResolver)
 		row := o.row
 		row.OutputTokens = outputTok
 		row.Cost = cost
+		row.Priced = priced
+		row.Contributes = contributes
 		out = append(out, row)
 	}
 	block, err := rateResolver.BuildBlock()
@@ -345,4 +361,38 @@ func (db *DB) activityReportUsage(
 		return nil, nil, fmt.Errorf("building pricing block: %w", err)
 	}
 	return out, &block, nil
+}
+
+func sqliteActivityReportRowStatus(
+	r dailyUsageScanRow, pricing *export.PricingResolver,
+) (cost float64, priced, contributes bool) {
+	var inTok, outTok, crTok, rdTok int
+	reasoningTok := r.reasoningTokens
+	if r.usageSource == "message" {
+		inTok, outTok, crTok, rdTok, reasoningTok =
+			clampedUsageTokenCountersWithReasoning(r.tokenJSON)
+	} else {
+		inTok, outTok, crTok, rdTok = usageEventRowTokens(
+			r.usageSource,
+			r.inputTokens, r.outputTokens,
+			r.cacheCreationInputTokens, r.cacheReadInputTokens)
+	}
+
+	if r.costUSD.Valid {
+		pricing.RecordReported(r.model, pricing.Lookup(r.model))
+		return r.costUSD.Float64, true, true
+	}
+	if inTok == 0 && outTok == 0 && reasoningTok == 0 &&
+		crTok == 0 && rdTok == 0 {
+		return 0, true, false
+	}
+	lookup := pricing.Lookup(r.model)
+	if !lookup.OK {
+		pricing.RecordComputed(r.model, lookup)
+		return 0, false, true
+	}
+	cost = lookup.Rates.CostForTokens(
+		inTok, outTok, reasoningTok, crTok, rdTok)
+	pricing.RecordComputed(r.model, lookup)
+	return cost, true, true
 }

--- a/internal/duckdb/activityreport.go
+++ b/internal/duckdb/activityreport.go
@@ -165,7 +165,7 @@ func (s *Store) GetSessionUsageRows(
 	queryArgs = append(queryArgs, args...)
 	cte, queryArgs := duckUsageCTEFromRaw(db.UsageFilter{}, rawSQL, queryArgs)
 	query := cte + `
-		SELECT session_id, message_ordinal, CAST(ts AS VARCHAR), source, model,
+		SELECT session_id, message_ordinal, ts, source, model,
 			agent, claude_message_id, claude_request_id, source_uuid,
 			usage_dedup_key, input_tokens_norm, output_tokens_norm,
 			cache_create_norm, cache_read_norm, reasoning_tokens_norm, cost_usd
@@ -178,8 +178,9 @@ func (s *Store) GetSessionUsageRows(
 	var rowsAcc []duckSessionUsageOrderedRow
 	for rows.Next() {
 		var r duckActivityReportUsageRow
+		var ts any
 		if err := rows.Scan(
-			&r.sessionID, &r.messageOrdinal, &r.ts, &r.source, &r.model,
+			&r.sessionID, &r.messageOrdinal, &ts, &r.source, &r.model,
 			&r.agent, &r.claudeMessageID, &r.claudeRequestID, &r.sourceUUID,
 			&r.usageDedupKey,
 			&r.inputTok, &r.outputTok, &r.cacheCr, &r.cacheRd,
@@ -187,6 +188,7 @@ func (s *Store) GetSessionUsageRows(
 		); err != nil {
 			return nil, fmt.Errorf("scanning duckdb session usage rows: %w", err)
 		}
+		r.ts = formatDBTime(ts)
 		ordinal := int64(-1)
 		if o, ok := duckUsageOrdinal(r.messageOrdinal); ok {
 			ordinal = o

--- a/internal/duckdb/activityreport.go
+++ b/internal/duckdb/activityreport.go
@@ -86,6 +86,19 @@ func (s *Store) GetActivityReport(
 	return report, nil
 }
 
+// GetSessionUsageRows returns the backend-priced usage rows for the supplied
+// sessions, with the same cross-session deduplication as activity reports.
+func (s *Store) GetSessionUsageRows(
+	ctx context.Context, ids []string,
+) ([]activity.UsageRow, error) {
+	end := time.Date(9999, time.December, 31, 23, 59, 59, 0, time.UTC)
+	rows, _, err := s.activityReportUsage(ctx, ids,
+		"0001-01-01T00:00:00Z", "9999-12-31T23:59:59Z", activity.Query{
+			RangeStart: time.Time{}, RangeEnd: end, EffectiveEnd: end,
+		})
+	return rows, err
+}
+
 func activityReportProjectLabels(sessions []activity.SessionMeta) []string {
 	set := make(map[string]bool, len(sessions))
 	for _, session := range sessions {
@@ -344,9 +357,11 @@ func (s *Store) activityReportUsage(
 		if !mask[i] {
 			continue
 		}
-		_, cost := duckActivityReportRowCost(o.scan, rateResolver)
+		_, cost, priced, contributes := duckActivityReportRowStatus(o.scan, rateResolver)
 		row := o.row
 		row.Cost = cost
+		row.Priced = priced
+		row.Contributes = contributes
 		out = append(out, row)
 	}
 	block, err := rateResolver.BuildBlock()
@@ -448,20 +463,33 @@ func duckActivityReportUsageQuery(inClause string) string {
 			AND ts <= CAST(? AS TIMESTAMP)`, inClause, db.MaxPlausibleTokens)
 }
 
-// duckActivityReportRowCost computes one usage row's cost the same way
+// duckActivityReportRowStatus computes one usage row's cost and pricing state the same way
 // GetDailyUsage does: an explicit cost_usd wins, otherwise the per-model
 // rates price the normalized token amounts. Billable amounts equal the
 // normalized amounts when there is no explicit cost (mirroring the
 // billable_* SQL in dailyUsageAggregateRows). It returns the cache
 // savings delta and the cost.
-func duckActivityReportRowCost(
+func duckActivityReportRowStatus(
 	r duckActivityReportUsageRow, pricing *export.PricingResolver,
-) (savings, cost float64) {
+) (savings, cost float64, priced, contributes bool) {
 	var explicitCost float64
 	var billableInput, billableOutput, billableReasoning, billableCacheCr, billableCacheRd int
 	if r.costUSD != nil {
 		explicitCost = *r.costUSD
+		priced = true
+		contributes = true
+	} else if r.inputTok != 0 || r.outputTok != 0 || r.reasoningTok != 0 ||
+		r.cacheCr != 0 || r.cacheRd != 0 {
+		contributes = true
+		lookup := pricing.Lookup(r.model)
+		priced = lookup.OK
+		billableInput = r.inputTok
+		billableOutput = r.outputTok
+		billableReasoning = r.reasoningTok
+		billableCacheCr = r.cacheCr
+		billableCacheRd = r.cacheRd
 	} else {
+		priced = true
 		billableInput = r.inputTok
 		billableOutput = r.outputTok
 		billableReasoning = r.reasoningTok
@@ -477,7 +505,7 @@ func duckActivityReportRowCost(
 		r.costUSD != nil,
 		pricing,
 	)
-	return savings, cost
+	return savings, cost, priced, contributes
 }
 
 // duckUsageOrdinal extracts a non-negative message ordinal from a

--- a/internal/duckdb/activityreport.go
+++ b/internal/duckdb/activityreport.go
@@ -88,15 +88,194 @@ func (s *Store) GetActivityReport(
 
 // GetSessionUsageRows returns the backend-priced usage rows for the supplied
 // sessions, with the same cross-session deduplication as activity reports.
+type duckSessionUsageOrderedRow struct {
+	scan    duckActivityReportUsageRow
+	ts      time.Time
+	validTS bool
+	ordinal int64
+}
+
 func (s *Store) GetSessionUsageRows(
 	ctx context.Context, ids []string,
 ) ([]activity.UsageRow, error) {
-	end := time.Date(9999, time.December, 31, 23, 59, 59, 0, time.UTC)
-	rows, _, err := s.activityReportUsage(ctx, ids,
-		"0001-01-01T00:00:00Z", "9999-12-31T23:59:59Z", activity.Query{
-			RangeStart: time.Time{}, RangeEnd: end, EffectiveEnd: end,
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	pricing, err := s.loadPricing(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("loading duckdb pricing: %w", err)
+	}
+	rateResolver := export.NewPricingResolver(duckPricingRows(pricing))
+	sessionOrder := make(map[string]int, len(ids))
+	for i, id := range ids {
+		sessionOrder[id] = i
+	}
+	args, placeholders := stringInArgs(ids)
+	inClause := strings.Join(placeholders, ",")
+	rawSQL := fmt.Sprintf(`
+		SELECT m.session_id AS session_id, m.ordinal AS message_ordinal,
+			'message' AS source, COALESCE(m.timestamp, s.started_at) AS ts,
+			m.model AS model, m.token_usage AS token_json,
+			m.claude_message_id AS claude_message_id,
+			m.claude_request_id AS claude_request_id,
+			m.source_uuid AS source_uuid,
+			'' AS usage_dedup_key,
+			0 AS input_tokens, 0 AS output_tokens,
+			0 AS cache_create, 0 AS cache_read,
+			COALESCE(TRY_CAST(json_extract_string(m.token_usage, '$.reasoning_tokens') AS BIGINT), 0) AS reasoning_tokens,
+			NULL AS cost_usd,
+			s.project AS project, s.agent AS agent, s.machine AS machine,
+			s.user_message_count AS user_message_count, s.is_automated AS is_automated,
+			COALESCE(s.display_name, s.session_name, s.first_message, s.project, s.id) AS display_name,
+			s.started_at AS started_at,
+			COALESCE(s.ended_at, s.started_at, s.created_at) AS activity_at
+		FROM messages m
+		JOIN sessions s ON s.id = m.session_id
+		WHERE %s
+			AND s.id IN (%s)
+		UNION ALL
+		SELECT ue.session_id AS session_id, ue.message_ordinal AS message_ordinal,
+			ue.source AS source, COALESCE(ue.occurred_at, s.started_at) AS ts,
+			ue.model AS model, '' AS token_json,
+			'' AS claude_message_id, '' AS claude_request_id,
+			'' AS source_uuid,
+			CASE
+				WHEN ue.dedup_key != '' THEN ue.session_id || ':' || ue.source || ':' || ue.dedup_key
+				ELSE ue.session_id || ':' || ue.source || ':id:' || CAST(ue.id AS VARCHAR)
+			END AS usage_dedup_key,
+			ue.input_tokens AS input_tokens, ue.output_tokens AS output_tokens,
+			ue.cache_creation_input_tokens AS cache_create,
+			ue.cache_read_input_tokens AS cache_read,
+			ue.reasoning_tokens AS reasoning_tokens,
+			ue.cost_usd AS cost_usd,
+			s.project AS project, s.agent AS agent, s.machine AS machine,
+			s.user_message_count AS user_message_count, s.is_automated AS is_automated,
+			COALESCE(s.display_name, s.session_name, s.first_message, s.project, s.id) AS display_name,
+			s.started_at AS started_at,
+			COALESCE(s.ended_at, s.started_at, s.created_at) AS activity_at
+		FROM usage_events ue
+		JOIN sessions s ON s.id = ue.session_id
+		WHERE %s
+			AND s.id IN (%s)`,
+		duckUsageMessageEligibility, inClause,
+		duckUsageEventEligibility, inClause,
+	)
+	queryArgs := make([]any, 0, len(args)*2)
+	queryArgs = append(queryArgs, args...)
+	queryArgs = append(queryArgs, args...)
+	cte, queryArgs := duckUsageCTEFromRaw(db.UsageFilter{}, rawSQL, queryArgs)
+	query := cte + `
+		SELECT session_id, message_ordinal, CAST(ts AS VARCHAR), source, model,
+			agent, claude_message_id, claude_request_id, source_uuid,
+			usage_dedup_key, input_tokens_norm, output_tokens_norm,
+			cache_create_norm, cache_read_norm, reasoning_tokens_norm, cost_usd
+		FROM usage_normalized`
+	rows, err := s.queryContext(ctx, query, queryArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("querying duckdb session usage rows: %w", err)
+	}
+	defer rows.Close()
+	var rowsAcc []duckSessionUsageOrderedRow
+	for rows.Next() {
+		var r duckActivityReportUsageRow
+		if err := rows.Scan(
+			&r.sessionID, &r.messageOrdinal, &r.ts, &r.source, &r.model,
+			&r.agent, &r.claudeMessageID, &r.claudeRequestID, &r.sourceUUID,
+			&r.usageDedupKey,
+			&r.inputTok, &r.outputTok, &r.cacheCr, &r.cacheRd,
+			&r.reasoningTok, &r.costUSD,
+		); err != nil {
+			return nil, fmt.Errorf("scanning duckdb session usage rows: %w", err)
+		}
+		ordinal := int64(-1)
+		if o, ok := duckUsageOrdinal(r.messageOrdinal); ok {
+			ordinal = o
+		}
+		parsedTS, ok := parseTimestamp(r.ts)
+		rowsAcc = append(rowsAcc, duckSessionUsageOrderedRow{
+			scan:    r,
+			ts:      parsedTS,
+			validTS: ok,
+			ordinal: ordinal,
 		})
-	return rows, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating duckdb session usage rows: %w", err)
+	}
+	sort.SliceStable(rowsAcc, func(i, j int) bool {
+		return duckSessionUsageRowLess(rowsAcc[i], rowsAcc[j], sessionOrder)
+	})
+	seen := make(map[string]struct{})
+	out := make([]activity.UsageRow, 0, len(rowsAcc))
+	for _, o := range rowsAcc {
+		r := o.scan
+		if key, ok := duckSessionUsageDedupKey(r); ok {
+			if _, dup := seen[key]; dup {
+				continue
+			}
+			seen[key] = struct{}{}
+		}
+		_, cost, priced, contributes := duckActivityReportRowStatus(r, rateResolver)
+		out = append(out, activity.UsageRow{
+			SessionID:       r.sessionID,
+			Model:           r.model,
+			Timestamp:       r.ts,
+			OutputTokens:    r.outputTok,
+			Cost:            cost,
+			Priced:          priced,
+			Contributes:     contributes,
+			Agent:           r.agent,
+			ClaudeMessageID: r.claudeMessageID,
+			ClaudeRequestID: r.claudeRequestID,
+			SourceUUID:      r.sourceUUID,
+			UsageDedupKey:   r.usageDedupKey,
+		})
+	}
+	return out, nil
+}
+
+func duckSessionUsageDedupKey(r duckActivityReportUsageRow) (string, bool) {
+	if r.claudeMessageID != "" && r.claudeRequestID != "" {
+		return "claude:" + r.claudeMessageID + ":" + r.claudeRequestID, true
+	}
+	if r.source == "message" && r.agent != "" && r.sourceUUID != "" {
+		return "source:" + r.agent + ":" + r.sourceUUID, true
+	}
+	if r.usageDedupKey != "" {
+		return "usage:" + r.usageDedupKey, true
+	}
+	return "", false
+}
+
+func duckSessionUsageRowLess(
+	a, b duckSessionUsageOrderedRow,
+	sessionOrder map[string]int,
+) bool {
+	if a.validTS && b.validTS {
+		if !a.ts.Equal(b.ts) {
+			return a.ts.Before(b.ts)
+		}
+	} else if a.validTS != b.validTS {
+		return a.validTS
+	}
+	if a.scan.ts != b.scan.ts {
+		return a.scan.ts < b.scan.ts
+	}
+	if ai, ok := sessionOrder[a.scan.sessionID]; ok {
+		if bi, ok := sessionOrder[b.scan.sessionID]; ok && ai != bi {
+			return ai < bi
+		}
+	}
+	if a.scan.sessionID != b.scan.sessionID {
+		return a.scan.sessionID < b.scan.sessionID
+	}
+	if a.ordinal != b.ordinal {
+		return a.ordinal < b.ordinal
+	}
+	if a.scan.source != b.scan.source {
+		return a.scan.source < b.scan.source
+	}
+	return a.scan.usageDedupKey < b.scan.usageDedupKey
 }
 
 func activityReportProjectLabels(sessions []activity.SessionMeta) []string {

--- a/internal/duckdb/store_test.go
+++ b/internal/duckdb/store_test.go
@@ -2922,6 +2922,47 @@ func TestStoreSessionUsageRollupParity(t *testing.T) {
 	assert.InDelta(t, 0.000066, rollup.CostUSD, 1e-12)
 }
 
+func TestStoreSessionUsageRollupIncludesUntimedRows(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	require.NoError(t, local.UpsertModelPricing([]db.ModelPricing{{
+		ModelPattern: "claude-test", InputPerMTok: 3, OutputPerMTok: 15,
+	}}))
+	root := syncSession("duck-rollup-untimed-root", "alpha", "root", "2026-01-10T00:00:00.000Z", 1)
+	child := syncSession("duck-rollup-untimed-child", "alpha", "child", "2026-01-10T01:00:00.000Z", 1)
+	parentID := root.ID
+	child.ParentSessionID = &parentID
+	child.RelationshipType = "subagent"
+	rootMessage := syncMessage(root.ID, 0, "assistant", "root", "")
+	childMessage := syncMessage(child.ID, 0, "assistant", "child", "")
+	_, err := local.WriteSessionBatchAtomic([]db.SessionBatchWrite{
+		{
+			Session:         root,
+			Messages:        []db.Message{rootMessage},
+			DataVersion:     1,
+			ReplaceMessages: true,
+		},
+		{
+			Session:         child,
+			Messages:        []db.Message{childMessage},
+			DataVersion:     1,
+			ReplaceMessages: true,
+		},
+	})
+	require.NoError(t, err)
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+	_, err = syncer.Push(ctx, true, nil)
+	require.NoError(t, err)
+
+	rollup, err := service.GetSessionUsageRollup(
+		ctx, NewStoreFromDB(syncer.DB()), root.ID, false,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, rollup.SubagentCount)
+	require.True(t, rollup.HasCost)
+	assert.InDelta(t, 0.000066, rollup.CostUSD, 1e-12)
+}
+
 // TestDuckGetAnalyticsSkillsAggregatesAcrossWeeks exercises the SQL
 // pushdown path: COUNT(*) aggregation per message timestamp and trend
 // buckets spread across the weeks a skill was actually used.

--- a/internal/duckdb/store_test.go
+++ b/internal/duckdb/store_test.go
@@ -2890,13 +2890,23 @@ func TestStoreSessionUsageRollupParity(t *testing.T) {
 		ModelPattern: "claude-test", InputPerMTok: 3, OutputPerMTok: 15,
 	}}))
 	root := syncSession("duck-rollup-root", "alpha", "root", "2026-01-10T00:00:00.000Z", 1)
+	continuation := syncSession("duck-rollup-continuation", "alpha", "continuation", "2026-01-10T00:30:00.000Z", 0)
 	child := syncSession("duck-rollup-child", "alpha", "child", "2026-01-10T01:00:00.000Z", 1)
 	parentID := root.ID
-	child.ParentSessionID = &parentID
+	continuationParentID := continuation.ID
+	continuation.ParentSessionID = &parentID
+	continuation.RelationshipType = "continuation"
+	child.ParentSessionID = &continuationParentID
 	child.RelationshipType = "subagent"
+	rootMessage := syncMessage(root.ID, 0, "assistant", "root", *root.StartedAt)
+	childMessage := syncMessage(child.ID, 0, "assistant", "child", *child.StartedAt)
+	childUnique := syncMessage(child.ID, 1, "assistant", "child unique", "2026-01-10T01:05:00.000Z")
+	rootMessage.ClaudeMessageID, rootMessage.ClaudeRequestID = "duck-rollup-shared", "duck-rollup-request"
+	childMessage.ClaudeMessageID, childMessage.ClaudeRequestID = "duck-rollup-shared", "duck-rollup-request"
 	_, err := local.WriteSessionBatchAtomic([]db.SessionBatchWrite{
-		{Session: root, Messages: []db.Message{syncMessage(root.ID, 0, "assistant", "root", *root.StartedAt)}, DataVersion: 1, ReplaceMessages: true},
-		{Session: child, Messages: []db.Message{syncMessage(child.ID, 0, "assistant", "child", *child.StartedAt)}, DataVersion: 1, ReplaceMessages: true},
+		{Session: root, Messages: []db.Message{rootMessage}, DataVersion: 1, ReplaceMessages: true},
+		{Session: continuation, DataVersion: 1, ReplaceMessages: true},
+		{Session: child, Messages: []db.Message{childMessage, childUnique}, DataVersion: 1, ReplaceMessages: true},
 	})
 	require.NoError(t, err)
 	syncer := newInMemoryTestSync(t, local, SyncOptions{})

--- a/internal/duckdb/store_test.go
+++ b/internal/duckdb/store_test.go
@@ -20,6 +20,7 @@ import (
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/export"
 	pricingpkg "go.kenn.io/agentsview/internal/pricing"
+	"go.kenn.io/agentsview/internal/service"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -2880,6 +2881,35 @@ func TestGetChildSessionsOrderedByStartedAt(t *testing.T) {
 	assert.Equal(t,
 		[]string{"duck-child-early", "duck-child-late"},
 		duckSessionIDs(children))
+}
+
+func TestStoreSessionUsageRollupParity(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	require.NoError(t, local.UpsertModelPricing([]db.ModelPricing{{
+		ModelPattern: "claude-test", InputPerMTok: 3, OutputPerMTok: 15,
+	}}))
+	root := syncSession("duck-rollup-root", "alpha", "root", "2026-01-10T00:00:00.000Z", 1)
+	child := syncSession("duck-rollup-child", "alpha", "child", "2026-01-10T01:00:00.000Z", 1)
+	parentID := root.ID
+	child.ParentSessionID = &parentID
+	child.RelationshipType = "subagent"
+	_, err := local.WriteSessionBatchAtomic([]db.SessionBatchWrite{
+		{Session: root, Messages: []db.Message{syncMessage(root.ID, 0, "assistant", "root", *root.StartedAt)}, DataVersion: 1, ReplaceMessages: true},
+		{Session: child, Messages: []db.Message{syncMessage(child.ID, 0, "assistant", "child", *child.StartedAt)}, DataVersion: 1, ReplaceMessages: true},
+	})
+	require.NoError(t, err)
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+	_, err = syncer.Push(ctx, true, nil)
+	require.NoError(t, err)
+
+	rollup, err := service.GetSessionUsageRollup(
+		ctx, NewStoreFromDB(syncer.DB()), root.ID, false,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, rollup.SubagentCount)
+	require.True(t, rollup.HasCost)
+	assert.InDelta(t, 0.000066, rollup.CostUSD, 1e-12)
 }
 
 // TestDuckGetAnalyticsSkillsAggregatesAcrossWeeks exercises the SQL

--- a/internal/duckdb/store_test.go
+++ b/internal/duckdb/store_test.go
@@ -2963,6 +2963,48 @@ func TestStoreSessionUsageRollupIncludesUntimedRows(t *testing.T) {
 	assert.InDelta(t, 0.000066, rollup.CostUSD, 1e-12)
 }
 
+func TestStoreSessionUsageRollupHandlesNullMessageAndSessionTimestamps(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	require.NoError(t, local.UpsertModelPricing([]db.ModelPricing{{
+		ModelPattern: "claude-test", InputPerMTok: 3, OutputPerMTok: 15,
+	}}))
+	root := syncSession("duck-rollup-null-ts-root", "alpha", "root", "2026-01-10T00:00:00.000Z", 1)
+	child := syncSession("duck-rollup-null-ts-child", "alpha", "child", "2026-01-10T01:00:00.000Z", 1)
+	parentID := root.ID
+	child.ParentSessionID = &parentID
+	child.RelationshipType = "subagent"
+	child.StartedAt = nil
+	rootMessage := syncMessage(root.ID, 0, "assistant", "root", *root.StartedAt)
+	childMessage := syncMessage(child.ID, 0, "assistant", "child", "")
+	_, err := local.WriteSessionBatchAtomic([]db.SessionBatchWrite{
+		{
+			Session:         root,
+			Messages:        []db.Message{rootMessage},
+			DataVersion:     1,
+			ReplaceMessages: true,
+		},
+		{
+			Session:         child,
+			Messages:        []db.Message{childMessage},
+			DataVersion:     1,
+			ReplaceMessages: true,
+		},
+	})
+	require.NoError(t, err)
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+	_, err = syncer.Push(ctx, true, nil)
+	require.NoError(t, err)
+
+	rollup, err := service.GetSessionUsageRollup(
+		ctx, NewStoreFromDB(syncer.DB()), root.ID, false,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, rollup.SubagentCount)
+	require.True(t, rollup.HasCost)
+	assert.InDelta(t, 0.000066, rollup.CostUSD, 1e-12)
+}
+
 // TestDuckGetAnalyticsSkillsAggregatesAcrossWeeks exercises the SQL
 // pushdown path: COUNT(*) aggregation per message timestamp and trend
 // buckets spread across the weeks a skill was actually used.

--- a/internal/postgres/activityreport.go
+++ b/internal/postgres/activityreport.go
@@ -89,15 +89,136 @@ func (s *Store) GetActivityReport(
 
 // GetSessionUsageRows returns the backend-priced usage rows for the supplied
 // sessions, with the same cross-session deduplication as activity reports.
+type pgSessionUsageOrderedRow struct {
+	scan    pgUsageScanRow
+	tsText  string
+	ordinal int64
+}
+
 func (s *Store) GetSessionUsageRows(
 	ctx context.Context, ids []string,
 ) ([]activity.UsageRow, error) {
-	end := time.Date(9999, time.December, 31, 23, 59, 59, 0, time.UTC)
-	rows, _, err := s.activityReportUsage(ctx, ids,
-		"0001-01-01T00:00:00Z", "9999-12-31T23:59:59Z", activity.Query{
-			RangeStart: time.Time{}, RangeEnd: end, EffectiveEnd: end,
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	pricing, err := s.loadPricingMap(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("loading pg pricing: %w", err)
+	}
+	rateResolver := export.NewPricingResolver(pricing)
+	sessionOrder := make(map[string]int, len(ids))
+	for i, id := range ids {
+		sessionOrder[id] = i
+	}
+	var rowsAcc []pgSessionUsageOrderedRow
+	err = pgQueryChunked(ids, func(chunk []string) error {
+		pb := &paramBuilder{}
+		ph := pgInPlaceholders(chunk, pb)
+		query := pgUsageRowSelect() + " AND u.session_id IN " + ph
+		rows, queryErr := s.pg.QueryContext(ctx, query, pb.args...)
+		if queryErr != nil {
+			return fmt.Errorf("querying pg session usage rows: %w", queryErr)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			r, scanErr := scanPGUsageRow(rows)
+			if scanErr != nil {
+				return fmt.Errorf(
+					"scanning pg session usage rows: %w", scanErr)
+			}
+			ordinal := int64(-1)
+			if r.messageOrdinal.Valid {
+				ordinal = r.messageOrdinal.Int64
+			}
+			rowsAcc = append(rowsAcc, pgSessionUsageOrderedRow{
+				scan:    r,
+				tsText:  startedAtString(r.ts),
+				ordinal: ordinal,
+			})
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.SliceStable(rowsAcc, func(i, j int) bool {
+		return pgSessionUsageRowLess(rowsAcc[i], rowsAcc[j], sessionOrder)
+	})
+	seen := make(map[pgUsageDedupToken]struct{})
+	out := make([]activity.UsageRow, 0, len(rowsAcc))
+	for _, o := range rowsAcc {
+		r := o.scan
+		if key, ok := pgUsageDedupTokenForRow(
+			r.usageSource, r.agent, r.claudeMessageID,
+			r.claudeRequestID, r.sourceUUID, r.usageDedupKey,
+		); ok {
+			if _, dup := seen[key]; dup {
+				continue
+			}
+			seen[key] = struct{}{}
+		}
+		_, outputTok, _, _, _, _ := pgDailyUsageAmounts(
+			pgDailyUsageScanRow{
+				usageSource:              r.usageSource,
+				tokenJSON:                r.tokenJSON,
+				inputTokens:              r.inputTokens,
+				outputTokens:             r.outputTokens,
+				cacheCreationInputTokens: r.cacheCreationInputTokens,
+				cacheReadInputTokens:     r.cacheReadInputTokens,
+				reasoningTokens:          r.reasoningTokens,
+				costUSD:                  r.costUSD,
+				model:                    r.model,
+			},
+			rateResolver,
+		)
+		cost, priced, contributes := pgSessionRowCost(r, rateResolver)
+		out = append(out, activity.UsageRow{
+			SessionID:       r.sessionID,
+			Model:           r.model,
+			Timestamp:       o.tsText,
+			OutputTokens:    outputTok,
+			Cost:            cost,
+			Priced:          priced,
+			Contributes:     contributes,
+			Agent:           r.agent,
+			ClaudeMessageID: r.claudeMessageID,
+			ClaudeRequestID: r.claudeRequestID,
+			SourceUUID:      r.sourceUUID,
+			UsageDedupKey:   r.usageDedupKey,
 		})
-	return rows, err
+	}
+	return out, nil
+}
+
+func pgSessionUsageRowLess(
+	a, b pgSessionUsageOrderedRow,
+	sessionOrder map[string]int,
+) bool {
+	if a.scan.ts.Valid && b.scan.ts.Valid {
+		if !a.scan.ts.Time.Equal(b.scan.ts.Time) {
+			return a.scan.ts.Time.Before(b.scan.ts.Time)
+		}
+	} else if a.scan.ts.Valid != b.scan.ts.Valid {
+		return a.scan.ts.Valid
+	}
+	if a.tsText != b.tsText {
+		return a.tsText < b.tsText
+	}
+	if ai, ok := sessionOrder[a.scan.sessionID]; ok {
+		if bi, ok := sessionOrder[b.scan.sessionID]; ok && ai != bi {
+			return ai < bi
+		}
+	}
+	if a.scan.sessionID != b.scan.sessionID {
+		return a.scan.sessionID < b.scan.sessionID
+	}
+	if a.ordinal != b.ordinal {
+		return a.ordinal < b.ordinal
+	}
+	if a.scan.usageSource != b.scan.usageSource {
+		return a.scan.usageSource < b.scan.usageSource
+	}
+	return a.scan.usageDedupKey < b.scan.usageDedupKey
 }
 
 func activityReportProjectLabels(sessions []activity.SessionMeta) []string {

--- a/internal/postgres/activityreport.go
+++ b/internal/postgres/activityreport.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/tidwall/gjson"
 	"go.kenn.io/agentsview/internal/activity"
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/export"
@@ -84,6 +85,19 @@ func (s *Store) GetActivityReport(
 	activity.SanitizeProjectLabels(&report, projects)
 	report.Projects = export.ProjectMapForWire(projects)
 	return report, nil
+}
+
+// GetSessionUsageRows returns the backend-priced usage rows for the supplied
+// sessions, with the same cross-session deduplication as activity reports.
+func (s *Store) GetSessionUsageRows(
+	ctx context.Context, ids []string,
+) ([]activity.UsageRow, error) {
+	end := time.Date(9999, time.December, 31, 23, 59, 59, 0, time.UTC)
+	rows, _, err := s.activityReportUsage(ctx, ids,
+		"0001-01-01T00:00:00Z", "9999-12-31T23:59:59Z", activity.Query{
+			RangeStart: time.Time{}, RangeEnd: end, EffectiveEnd: end,
+		})
+	return rows, err
 }
 
 func activityReportProjectLabels(sessions []activity.SessionMeta) []string {
@@ -325,10 +339,13 @@ func (s *Store) activityReportUsage(
 		if !mask[i] {
 			continue
 		}
-		_, outputTok, _, _, cost, _ := pgDailyUsageAmounts(o.scan, rateResolver)
+		_, outputTok, _, _, _, _ := pgDailyUsageAmounts(o.scan, rateResolver)
+		cost, priced, contributes := pgActivityReportRowStatus(o.scan, rateResolver)
 		row := o.row
 		row.OutputTokens = outputTok
 		row.Cost = cost
+		row.Priced = priced
+		row.Contributes = contributes
 		out = append(out, row)
 	}
 	block, err := rateResolver.BuildBlock()
@@ -336,4 +353,42 @@ func (s *Store) activityReportUsage(
 		return nil, nil, fmt.Errorf("building pricing block: %w", err)
 	}
 	return out, &block, nil
+}
+
+func pgActivityReportRowStatus(
+	r pgDailyUsageScanRow, pricing *export.PricingResolver,
+) (cost float64, priced, contributes bool) {
+	var inTok, outTok, crTok, rdTok int
+	reasoningTok := r.reasoningTokens
+	if r.usageSource == "message" {
+		usage := gjson.Parse(r.tokenJSON)
+		inTok = pgTokenJSONCount(usage, "input_tokens")
+		outTok = pgTokenJSONCount(usage, "output_tokens")
+		crTok = pgTokenJSONCount(usage, "cache_creation_input_tokens")
+		rdTok = pgTokenJSONCount(usage, "cache_read_input_tokens")
+		reasoningTok = pgTokenJSONCount(usage, "reasoning_tokens")
+	} else {
+		inTok, outTok, crTok, rdTok = pgUsageEventRowTokens(
+			r.usageSource,
+			r.inputTokens, r.outputTokens,
+			r.cacheCreationInputTokens, r.cacheReadInputTokens)
+	}
+
+	if r.costUSD.Valid {
+		pricing.RecordReported(r.model, pricing.Lookup(r.model))
+		return r.costUSD.Float64, true, true
+	}
+	if inTok == 0 && outTok == 0 && reasoningTok == 0 &&
+		crTok == 0 && rdTok == 0 {
+		return 0, true, false
+	}
+	lookup := pricing.Lookup(r.model)
+	if !lookup.OK {
+		pricing.RecordComputed(r.model, lookup)
+		return 0, false, true
+	}
+	cost = lookup.Rates.CostForTokens(
+		inTok, outTok, reasoningTok, crTok, rdTok)
+	pricing.RecordComputed(r.model, lookup)
+	return cost, true, true
 }

--- a/internal/postgres/usage_pgtest_test.go
+++ b/internal/postgres/usage_pgtest_test.go
@@ -263,15 +263,17 @@ func TestStoreSessionUsageRollupParity(t *testing.T) {
 			user_message_count, parent_session_id, relationship_type
 		) VALUES
 			('pg-rollup-root', 'test', 'project', 'codex', '2026-03-12T10:00:00Z', 1, 1, NULL, 'root'),
-			('pg-rollup-child', 'test', 'project', 'codex', '2026-03-12T10:01:00Z', 1, 1, 'pg-rollup-root', 'subagent')`)
+			('pg-rollup-continuation', 'test', 'project', 'codex', '2026-03-12T10:01:00Z', 0, 0, 'pg-rollup-root', 'continuation'),
+			('pg-rollup-child', 'test', 'project', 'codex', '2026-03-12T10:02:00Z', 1, 1, 'pg-rollup-continuation', 'subagent')`)
 	require.NoError(t, err)
 	_, err = store.DB().ExecContext(ctx, `
 		INSERT INTO messages (
 			session_id, ordinal, role, content, timestamp, content_length,
-			model, token_usage
+			model, token_usage, claude_message_id, claude_request_id
 		) VALUES
-			('pg-rollup-root', 0, 'assistant', 'root', '2026-03-12T10:00:00Z', 4, 'gpt-5.1', '{"input_tokens":1000,"output_tokens":500}'),
-			('pg-rollup-child', 0, 'assistant', 'child', '2026-03-12T10:01:00Z', 5, 'gpt-5.1', '{"input_tokens":1000,"output_tokens":500}')`)
+			('pg-rollup-root', 0, 'assistant', 'root', '2026-03-12T10:00:00Z', 4, 'gpt-5.1', '{"input_tokens":1000,"output_tokens":500}', 'pg-rollup-shared', 'pg-rollup-request'),
+			('pg-rollup-child', 0, 'assistant', 'child', '2026-03-12T10:02:00Z', 5, 'gpt-5.1', '{"input_tokens":1000,"output_tokens":500}', 'pg-rollup-shared', 'pg-rollup-request'),
+			('pg-rollup-child', 1, 'assistant', 'child unique', '2026-03-12T10:03:00Z', 12, 'gpt-5.1', '{"input_tokens":1000,"output_tokens":500}', 'pg-rollup-unique', 'pg-rollup-unique-request')`)
 	require.NoError(t, err)
 
 	rollup, err := service.GetSessionUsageRollup(ctx, store, "pg-rollup-root", false)

--- a/internal/postgres/usage_pgtest_test.go
+++ b/internal/postgres/usage_pgtest_test.go
@@ -283,6 +283,39 @@ func TestStoreSessionUsageRollupParity(t *testing.T) {
 	assert.InDelta(t, 0.021, rollup.CostUSD, 1e-9)
 }
 
+func TestStoreSessionUsageRollupIncludesUntimedRows(t *testing.T) {
+	_, store := prepareUsageSchema(t, "agentsview_session_usage_rollup_untimed_test")
+	ctx := context.Background()
+	_, err := store.DB().ExecContext(ctx, `
+		INSERT INTO model_pricing (
+			model_pattern, input_per_mtok, output_per_mtok,
+			cache_creation_per_mtok, cache_read_per_mtok, updated_at
+		) VALUES ('gpt-5.1', 3, 15, 3.75, 0.30, 'seed')`)
+	require.NoError(t, err)
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, project, agent, started_at, message_count,
+			user_message_count, parent_session_id, relationship_type
+		) VALUES
+			('pg-rollup-untimed-root', 'test', 'project', 'codex', '2026-03-12T10:00:00Z', 1, 1, NULL, 'root'),
+			('pg-rollup-untimed-child', 'test', 'project', 'codex', '2026-03-12T10:02:00Z', 1, 1, 'pg-rollup-untimed-root', 'subagent')`)
+	require.NoError(t, err)
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO messages (
+			session_id, ordinal, role, content, timestamp, content_length,
+			model, token_usage
+		) VALUES
+			('pg-rollup-untimed-root', 0, 'assistant', 'root', NULL, 4, 'gpt-5.1', '{"input_tokens":1000,"output_tokens":500}'),
+			('pg-rollup-untimed-child', 0, 'assistant', 'child', NULL, 5, 'gpt-5.1', '{"input_tokens":1000,"output_tokens":500}')`)
+	require.NoError(t, err)
+
+	rollup, err := service.GetSessionUsageRollup(ctx, store, "pg-rollup-untimed-root", false)
+	require.NoError(t, err)
+	require.Equal(t, 1, rollup.SubagentCount)
+	require.True(t, rollup.HasCost)
+	assert.InDelta(t, 0.021, rollup.CostUSD, 1e-9)
+}
+
 func TestStoreGetSessionUsageDedupesSourceUUIDWhenClaudePairIncomplete(t *testing.T) {
 	_, store := prepareUsageSchema(t, "agentsview_session_usage_source_uuid_test")
 

--- a/internal/postgres/usage_pgtest_test.go
+++ b/internal/postgres/usage_pgtest_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/service"
 )
 
 func prepareUsageSchema(
@@ -245,6 +246,39 @@ func TestStoreGetSessionUsagePricedModel(t *testing.T) {
 	assert.Equal(t, 300, entry.CacheReadInputTokens)
 	assert.True(t, entry.HasCost)
 	assert.InDelta(t, 0.01134, entry.CostUSD, 1e-9)
+}
+
+func TestStoreSessionUsageRollupParity(t *testing.T) {
+	_, store := prepareUsageSchema(t, "agentsview_session_usage_rollup_test")
+	ctx := context.Background()
+	_, err := store.DB().ExecContext(ctx, `
+		INSERT INTO model_pricing (
+			model_pattern, input_per_mtok, output_per_mtok,
+			cache_creation_per_mtok, cache_read_per_mtok, updated_at
+		) VALUES ('gpt-5.1', 3, 15, 3.75, 0.30, 'seed')`)
+	require.NoError(t, err)
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, project, agent, started_at, message_count,
+			user_message_count, parent_session_id, relationship_type
+		) VALUES
+			('pg-rollup-root', 'test', 'project', 'codex', '2026-03-12T10:00:00Z', 1, 1, NULL, 'root'),
+			('pg-rollup-child', 'test', 'project', 'codex', '2026-03-12T10:01:00Z', 1, 1, 'pg-rollup-root', 'subagent')`)
+	require.NoError(t, err)
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO messages (
+			session_id, ordinal, role, content, timestamp, content_length,
+			model, token_usage
+		) VALUES
+			('pg-rollup-root', 0, 'assistant', 'root', '2026-03-12T10:00:00Z', 4, 'gpt-5.1', '{"input_tokens":1000,"output_tokens":500}'),
+			('pg-rollup-child', 0, 'assistant', 'child', '2026-03-12T10:01:00Z', 5, 'gpt-5.1', '{"input_tokens":1000,"output_tokens":500}')`)
+	require.NoError(t, err)
+
+	rollup, err := service.GetSessionUsageRollup(ctx, store, "pg-rollup-root", false)
+	require.NoError(t, err)
+	require.Equal(t, 1, rollup.SubagentCount)
+	require.True(t, rollup.HasCost)
+	assert.InDelta(t, 0.021, rollup.CostUSD, 1e-9)
 }
 
 func TestStoreGetSessionUsageDedupesSourceUUIDWhenClaudePairIncomplete(t *testing.T) {

--- a/internal/server/huma_routes_sessions.go
+++ b/internal/server/huma_routes_sessions.go
@@ -357,25 +357,29 @@ func (s *Server) humaSessionTiming(
 }
 
 type sessionUsageResponse struct {
-	SessionID         string                          `json:"session_id"`
-	Agent             string                          `json:"agent"`
-	Project           string                          `json:"project"`
-	TotalOutputTokens int                             `json:"total_output_tokens"`
-	PeakContextTokens int                             `json:"peak_context_tokens"`
-	HasTokenData      bool                            `json:"has_token_data"`
-	CostUSD           float64                         `json:"cost_usd"`
-	HasCost           bool                            `json:"has_cost"`
-	AICredits         float64                         `json:"ai_credits,omitempty"`
-	Models            []string                        `json:"models"`
-	UnpricedModels    []string                        `json:"unpriced_models"`
-	BreakdownCount    int                             `json:"breakdown_count"`
-	Breakdown         []sessionUsageBreakdownResponse `json:"breakdown"`
-	ServerRunning     bool                            `json:"server_running"`
+	SessionID           string                          `json:"session_id"`
+	Agent               string                          `json:"agent"`
+	Project             string                          `json:"project"`
+	TotalOutputTokens   int                             `json:"total_output_tokens"`
+	PeakContextTokens   int                             `json:"peak_context_tokens"`
+	HasTokenData        bool                            `json:"has_token_data"`
+	CostUSD             float64                         `json:"cost_usd"`
+	HasCost             bool                            `json:"has_cost"`
+	AICredits           float64                         `json:"ai_credits,omitempty"`
+	Models              []string                        `json:"models"`
+	UnpricedModels      []string                        `json:"unpriced_models"`
+	BreakdownCount      int                             `json:"breakdown_count"`
+	Breakdown           []sessionUsageBreakdownResponse `json:"breakdown"`
+	ServerRunning       bool                            `json:"server_running"`
+	RollupCostUSD       *float64                        `json:"rollup_cost_usd,omitempty"`
+	HasRollupCost       *bool                           `json:"has_rollup_cost,omitempty"`
+	RollupSubagentCount *int                            `json:"rollup_subagent_count,omitempty"`
 }
 
 type sessionUsageInput struct {
 	ID        string `path:"id" required:"true" doc:"Session ID"`
 	Breakdown bool   `query:"breakdown" doc:"Include per-step breakdown rows"`
+	Rollup    bool   `query:"rollup" doc:"Include explicit subagent descendant costs"`
 }
 
 type sessionUsageBreakdownResponse struct {
@@ -455,6 +459,25 @@ func (s *Server) humaSessionUsage(
 	ctx context.Context,
 	in *sessionUsageInput,
 ) (*jsonOutput[sessionUsageResponse], error) {
+	if in.Rollup {
+		rollup, err := service.GetSessionUsageRollup(ctx, s.db, in.ID, in.Breakdown)
+		if err != nil {
+			if handled := handleHumaContextError(err); handled != nil {
+				return nil, handled
+			}
+			return nil, &sessionUsageError{Status: http.StatusInternalServerError, Body: sessionUsageErrorBody{Code: "usage_query_failed", Message: "failed to query session usage"}}
+		}
+		if rollup == nil {
+			return nil, &sessionUsageError{Status: http.StatusNotFound, Body: sessionUsageErrorBody{Code: "session_not_found", Message: "session not found"}}
+		}
+		body := newSessionUsageHumaResponse(rollup.Usage)
+		if rollup.HasCost {
+			body.RollupCostUSD = &rollup.CostUSD
+		}
+		body.HasRollupCost = &rollup.HasCost
+		body.RollupSubagentCount = &rollup.SubagentCount
+		return &jsonOutput[sessionUsageResponse]{Body: body}, nil
+	}
 	usage, err := s.db.GetSessionUsage(ctx, in.ID, in.Breakdown)
 	if err != nil {
 		if handled := handleHumaContextError(err); handled != nil {

--- a/internal/server/session_usage_test.go
+++ b/internal/server/session_usage_test.go
@@ -85,6 +85,100 @@ func TestHandleSessionUsage_PricedSession(t *testing.T) {
 	}, got["breakdown"], "breakdown rows with ?breakdown=true")
 }
 
+func TestHandleSessionUsage_RollsUpExplicitSubagents(t *testing.T) {
+	te := setup(t)
+	seedSessionUsagePricing(t, te.db)
+	te.seedSession(t, "root-rollup", "project", 1, func(s *db.Session) {
+		s.Agent = "codex"
+	})
+	te.seedSession(t, "child-rollup", "project", 1, func(s *db.Session) {
+		s.Agent = "codex"
+		parent := "root-rollup"
+		s.ParentSessionID = &parent
+		s.RelationshipType = "subagent"
+	})
+	te.seedMessages(t, "root-rollup", 1, func(_ int, m *db.Message) {
+		m.Role, m.Model = "assistant", "gpt-5.1"
+		m.TokenUsage = json.RawMessage(`{"input_tokens":1000,"output_tokens":500}`)
+	})
+	te.seedMessages(t, "child-rollup", 1, func(_ int, m *db.Message) {
+		m.Role, m.Model = "assistant", "gpt-5.1"
+		m.TokenUsage = json.RawMessage(`{"input_tokens":1000,"output_tokens":500}`)
+	})
+
+	w := te.get(t, "/api/v1/sessions/root-rollup/usage?rollup=true")
+	assertStatus(t, w, http.StatusOK)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, float64(1), got["rollup_subagent_count"])
+	assert.Equal(t, true, got["has_rollup_cost"])
+	assert.InDelta(t, 0.021, got["rollup_cost_usd"], 1e-9)
+}
+
+func TestHandleSessionUsage_RollupBreakdownIncludesRootRows(t *testing.T) {
+	te := setup(t)
+	seedSessionUsagePricing(t, te.db)
+	te.seedSession(t, "root-rollup-breakdown", "project", 1, func(s *db.Session) {
+		s.Agent = "codex"
+	})
+	te.seedSession(t, "child-rollup-breakdown", "project", 1, func(s *db.Session) {
+		s.Agent = "codex"
+		parent := "root-rollup-breakdown"
+		s.ParentSessionID = &parent
+		s.RelationshipType = "subagent"
+	})
+	te.seedMessages(t, "root-rollup-breakdown", 1, func(_ int, m *db.Message) {
+		m.Role, m.Model = "assistant", "gpt-5.1"
+		m.TokenUsage = json.RawMessage(`{"input_tokens":1000,"output_tokens":500}`)
+	})
+	te.seedMessages(t, "child-rollup-breakdown", 1, func(_ int, m *db.Message) {
+		m.Role, m.Model = "assistant", "gpt-5.1"
+		m.TokenUsage = json.RawMessage(`{"input_tokens":1000,"output_tokens":500}`)
+	})
+
+	w := te.get(t, "/api/v1/sessions/root-rollup-breakdown/usage?rollup=true&breakdown=true")
+	assertStatus(t, w, http.StatusOK)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, float64(1), got["rollup_subagent_count"])
+	assert.Equal(t, float64(1), got["breakdown_count"])
+	assert.Len(t, got["breakdown"], 1)
+}
+
+func TestHandleSessionUsage_IncompleteRollupOmitsPartialCost(t *testing.T) {
+	te := setup(t)
+	seedSessionUsagePricing(t, te.db)
+	te.seedSession(t, "root-rollup-incomplete", "project", 1, func(s *db.Session) {
+		s.Agent = "codex"
+	})
+	te.seedSession(t, "child-rollup-incomplete", "project", 1, func(s *db.Session) {
+		s.Agent = "codex"
+		parent := "root-rollup-incomplete"
+		s.ParentSessionID = &parent
+		s.RelationshipType = "subagent"
+	})
+	te.seedMessages(t, "root-rollup-incomplete", 1, func(_ int, m *db.Message) {
+		m.Role, m.Model = "assistant", "gpt-5.1"
+		m.TokenUsage = json.RawMessage(`{"input_tokens":1000,"output_tokens":500}`)
+	})
+	te.seedMessages(t, "child-rollup-incomplete", 1, func(_ int, m *db.Message) {
+		m.Role, m.Model = "assistant", "unknown-rollup-model"
+		m.TokenUsage = json.RawMessage(`{"input_tokens":1000,"output_tokens":500}`)
+	})
+
+	w := te.get(t, "/api/v1/sessions/root-rollup-incomplete/usage?rollup=true")
+	assertStatus(t, w, http.StatusOK)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, float64(1), got["rollup_subagent_count"])
+	assert.Equal(t, false, got["has_rollup_cost"])
+	_, hasRollupCost := got["rollup_cost_usd"]
+	assert.False(t, hasRollupCost)
+	assert.InDelta(t, 0.0105, got["cost_usd"], 1e-9)
+}
+
 func TestHandleSessionUsage_NoTokenOrCostData(t *testing.T) {
 	te := setup(t)
 	te.seedSession(t, "codex:usage-empty", "quiet-project", 1,
@@ -187,11 +281,28 @@ func TestHandleSessionUsage_NotFound(t *testing.T) {
 	assertSessionUsageError(t, w, "session_not_found", "session not found")
 }
 
+func TestHandleSessionUsage_RollupNotFound(t *testing.T) {
+	te := setup(t)
+
+	w := te.get(t, "/api/v1/sessions/missing/usage?rollup=true")
+	assertStatus(t, w, http.StatusNotFound)
+	assertSessionUsageError(t, w, "session_not_found", "session not found")
+}
+
 func TestHandleSessionUsage_DBError(t *testing.T) {
 	te := setup(t)
 	require.NoError(t, te.db.Close())
 
 	w := te.get(t, "/api/v1/sessions/codex:usage-error/usage")
+	assertStatus(t, w, http.StatusInternalServerError)
+	assertSessionUsageError(t, w, "usage_query_failed", "failed to query session usage")
+}
+
+func TestHandleSessionUsage_RollupDBError(t *testing.T) {
+	te := setup(t)
+	require.NoError(t, te.db.Close())
+
+	w := te.get(t, "/api/v1/sessions/codex:usage-error/usage?rollup=true")
 	assertStatus(t, w, http.StatusInternalServerError)
 	assertSessionUsageError(t, w, "usage_query_failed", "failed to query session usage")
 }

--- a/internal/server/session_usage_test.go
+++ b/internal/server/session_usage_test.go
@@ -146,6 +146,44 @@ func TestHandleSessionUsage_RollupBreakdownIncludesRootRows(t *testing.T) {
 	assert.Len(t, got["breakdown"], 1)
 }
 
+func TestHandleSessionUsage_RollupTraversesContinuationAndDedupesSharedRows(t *testing.T) {
+	te := setup(t)
+	seedSessionUsagePricing(t, te.db)
+	te.seedSession(t, "root-rollup-rework", "project", 1, func(s *db.Session) {
+		s.Agent = "codex"
+	})
+	te.seedSession(t, "continuation-rollup-rework", "project", 1, func(s *db.Session) {
+		parent := "root-rollup-rework"
+		s.ParentSessionID = &parent
+		s.RelationshipType = "continuation"
+	})
+	te.seedSession(t, "nested-rollup-rework", "project", 2, func(s *db.Session) {
+		parent := "continuation-rollup-rework"
+		s.ParentSessionID = &parent
+		s.RelationshipType = "subagent"
+	})
+	for _, id := range []string{"root-rollup-rework", "nested-rollup-rework"} {
+		te.seedMessages(t, id, 2, func(i int, m *db.Message) {
+			m.Role, m.Model = "assistant", "gpt-5.1"
+			m.ClaudeMessageID = "shared-rollup-message"
+			m.ClaudeRequestID = "shared-rollup-request"
+			m.TokenUsage = json.RawMessage(`{"input_tokens":1000,"output_tokens":500}`)
+			if id == "nested-rollup-rework" && i == 1 {
+				m.ClaudeMessageID = "unique-rollup-message"
+				m.ClaudeRequestID = "unique-rollup-request"
+			}
+		})
+	}
+
+	w := te.get(t, "/api/v1/sessions/root-rollup-rework/usage?rollup=true")
+	assertStatus(t, w, http.StatusOK)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, float64(1), got["rollup_subagent_count"])
+	assert.Equal(t, true, got["has_rollup_cost"])
+	assert.InDelta(t, 0.021, got["rollup_cost_usd"], 1e-9)
+}
+
 func TestHandleSessionUsage_IncompleteRollupOmitsPartialCost(t *testing.T) {
 	te := setup(t)
 	seedSessionUsagePricing(t, te.db)

--- a/internal/server/session_usage_test.go
+++ b/internal/server/session_usage_test.go
@@ -184,6 +184,71 @@ func TestHandleSessionUsage_RollupTraversesContinuationAndDedupesSharedRows(t *t
 	assert.InDelta(t, 0.021, got["rollup_cost_usd"], 1e-9)
 }
 
+func TestHandleSessionUsage_RollupIncludesUntimedSubagentUsage(t *testing.T) {
+	te := setup(t)
+	seedSessionUsagePricing(t, te.db)
+	te.seedSession(t, "root-rollup-untimed", "project", 1, func(s *db.Session) {
+		s.Agent = "codex"
+	})
+	te.seedSession(t, "child-rollup-untimed", "project", 1, func(s *db.Session) {
+		s.Agent = "codex"
+		parent := "root-rollup-untimed"
+		s.ParentSessionID = &parent
+		s.RelationshipType = "subagent"
+	})
+	te.seedMessages(t, "root-rollup-untimed", 1, func(_ int, m *db.Message) {
+		m.Role, m.Model = "assistant", "gpt-5.1"
+		m.Timestamp = ""
+		m.TokenUsage = json.RawMessage(`{"input_tokens":1000,"output_tokens":500}`)
+	})
+	te.seedMessages(t, "child-rollup-untimed", 1, func(_ int, m *db.Message) {
+		m.Role, m.Model = "assistant", "gpt-5.1"
+		m.Timestamp = ""
+		m.TokenUsage = json.RawMessage(`{"input_tokens":1000,"output_tokens":500}`)
+	})
+
+	w := te.get(t, "/api/v1/sessions/root-rollup-untimed/usage?rollup=true")
+	assertStatus(t, w, http.StatusOK)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, float64(1), got["rollup_subagent_count"])
+	assert.Equal(t, true, got["has_rollup_cost"])
+	assert.InDelta(t, 0.021, got["rollup_cost_usd"], 1e-9)
+}
+
+func TestHandleSessionUsage_RollupPrefersRootForSharedDuplicateAtSameTimestamp(t *testing.T) {
+	te := setup(t)
+	seedSessionUsagePricing(t, te.db)
+	te.seedSession(t, "z-root-rollup-attribution", "project", 1, func(s *db.Session) {
+		s.Agent = "codex"
+	})
+	te.seedSession(t, "a-child-rollup-attribution", "project", 1, func(s *db.Session) {
+		s.Agent = "codex"
+		parent := "z-root-rollup-attribution"
+		s.ParentSessionID = &parent
+		s.RelationshipType = "subagent"
+	})
+	for _, id := range []string{"z-root-rollup-attribution", "a-child-rollup-attribution"} {
+		te.seedMessages(t, id, 1, func(_ int, m *db.Message) {
+			m.Role, m.Model = "assistant", "gpt-5.1"
+			m.Timestamp = "2026-03-12T10:00:00Z"
+			m.ClaudeMessageID = "shared-rollup-attribution"
+			m.ClaudeRequestID = "shared-rollup-attribution-request"
+			m.TokenUsage = json.RawMessage(`{"input_tokens":1000,"output_tokens":500}`)
+		})
+	}
+
+	w := te.get(t, "/api/v1/sessions/z-root-rollup-attribution/usage?rollup=true")
+	assertStatus(t, w, http.StatusOK)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, float64(1), got["rollup_subagent_count"])
+	assert.Equal(t, false, got["has_rollup_cost"])
+	_, hasRollupCost := got["rollup_cost_usd"]
+	assert.False(t, hasRollupCost)
+	assert.InDelta(t, 0.0105, got["cost_usd"], 1e-9)
+}
+
 func TestHandleSessionUsage_IncompleteRollupOmitsPartialCost(t *testing.T) {
 	te := setup(t)
 	seedSessionUsagePricing(t, te.db)

--- a/internal/service/session_usage_rollup.go
+++ b/internal/service/session_usage_rollup.go
@@ -3,8 +3,13 @@ package service
 import (
 	"context"
 
+	"go.kenn.io/agentsview/internal/activity"
 	"go.kenn.io/agentsview/internal/db"
 )
+
+type sessionUsageRowsProvider interface {
+	GetSessionUsageRows(context.Context, []string) ([]activity.UsageRow, error)
+}
 
 // SessionUsageRollup combines a root session's usage with explicit subagent
 // descendants. SubagentCount includes descendants without usage rows.
@@ -28,23 +33,7 @@ func GetSessionUsageRollup(
 	out := &SessionUsageRollup{Usage: root}
 	visited := map[string]struct{}{rootID: {}}
 	queue := []string{rootID}
-	subagentContributing := false
-	allPriced := true
-	totalCostUSD := 0.0
-	addUsage := func(usage *db.SessionUsage, isSubagent bool) {
-		if usage.BreakdownCount == 0 {
-			return
-		}
-		if isSubagent {
-			subagentContributing = true
-		}
-		if usage.HasCost {
-			totalCostUSD += usage.CostUSD
-		} else {
-			allPriced = false
-		}
-	}
-	addUsage(root, false)
+	usageIDs := []string{rootID}
 
 	for len(queue) > 0 {
 		parentID := queue[0]
@@ -58,19 +47,74 @@ func GetSessionUsageRollup(
 				continue
 			}
 			visited[child.ID] = struct{}{}
-			if child.RelationshipType != "subagent" {
-				continue
-			}
-			out.SubagentCount++
-			usage, err := store.GetSessionUsage(ctx, child.ID, false)
-			if err != nil {
-				return nil, err
-			}
-			if usage != nil {
-				addUsage(usage, true)
+			if child.RelationshipType == "subagent" {
+				out.SubagentCount++
+				usageIDs = append(usageIDs, child.ID)
 			}
 			queue = append(queue, child.ID)
 		}
+	}
+	subagentContributing := false
+	allPriced := true
+	totalCostUSD := 0.0
+	if provider, ok := store.(sessionUsageRowsProvider); ok {
+		rows, err := provider.GetSessionUsageRows(ctx, usageIDs)
+		if err != nil {
+			return nil, err
+		}
+		if rows != nil {
+			for _, row := range rows {
+				if !row.Contributes {
+					continue
+				}
+				if row.SessionID != rootID {
+					subagentContributing = true
+				}
+				if !row.Priced {
+					allPriced = false
+					continue
+				}
+				totalCostUSD += row.Cost
+			}
+		} else {
+			if root.BreakdownCount > 0 && !root.HasCost {
+				allPriced = false
+			}
+			for _, id := range usageIDs[1:] {
+				usage, err := store.GetSessionUsage(ctx, id, false)
+				if err != nil {
+					return nil, err
+				}
+				if usage != nil && usage.BreakdownCount > 0 {
+					subagentContributing = true
+					if usage.HasCost {
+						totalCostUSD += usage.CostUSD
+					} else {
+						allPriced = false
+					}
+				}
+			}
+			totalCostUSD += root.CostUSD
+		}
+	} else {
+		if root.BreakdownCount > 0 && !root.HasCost {
+			allPriced = false
+		}
+		for _, id := range usageIDs[1:] {
+			usage, err := store.GetSessionUsage(ctx, id, false)
+			if err != nil {
+				return nil, err
+			}
+			if usage != nil && usage.BreakdownCount > 0 {
+				subagentContributing = true
+				if usage.HasCost {
+					totalCostUSD += usage.CostUSD
+				} else {
+					allPriced = false
+				}
+			}
+		}
+		totalCostUSD += root.CostUSD
 	}
 	out.HasCost = subagentContributing && allPriced
 	if out.HasCost {

--- a/internal/service/session_usage_rollup.go
+++ b/internal/service/session_usage_rollup.go
@@ -77,48 +77,51 @@ func GetSessionUsageRollup(
 				totalCostUSD += row.Cost
 			}
 		} else {
-			if root.BreakdownCount > 0 && !root.HasCost {
-				allPriced = false
-			}
-			for _, id := range usageIDs[1:] {
-				usage, err := store.GetSessionUsage(ctx, id, false)
-				if err != nil {
-					return nil, err
-				}
-				if usage != nil && usage.BreakdownCount > 0 {
-					subagentContributing = true
-					if usage.HasCost {
-						totalCostUSD += usage.CostUSD
-					} else {
-						allPriced = false
-					}
-				}
-			}
-			totalCostUSD += root.CostUSD
-		}
-	} else {
-		if root.BreakdownCount > 0 && !root.HasCost {
-			allPriced = false
-		}
-		for _, id := range usageIDs[1:] {
-			usage, err := store.GetSessionUsage(ctx, id, false)
+			subagentContributing, totalCostUSD, allPriced, err =
+				sumRollupUsageFallback(ctx, store, root, usageIDs)
 			if err != nil {
 				return nil, err
 			}
-			if usage != nil && usage.BreakdownCount > 0 {
-				subagentContributing = true
-				if usage.HasCost {
-					totalCostUSD += usage.CostUSD
-				} else {
-					allPriced = false
-				}
-			}
 		}
-		totalCostUSD += root.CostUSD
+	} else {
+		subagentContributing, totalCostUSD, allPriced, err =
+			sumRollupUsageFallback(ctx, store, root, usageIDs)
+		if err != nil {
+			return nil, err
+		}
 	}
 	out.HasCost = subagentContributing && allPriced
 	if out.HasCost {
 		out.CostUSD = totalCostUSD
 	}
 	return out, nil
+}
+
+func sumRollupUsageFallback(
+	ctx context.Context,
+	store db.Store,
+	root *db.SessionUsage,
+	usageIDs []string,
+) (subagentContributing bool, totalCostUSD float64, allPriced bool, err error) {
+	allPriced = true
+	if root.BreakdownCount > 0 && !root.HasCost {
+		allPriced = false
+	}
+	for _, id := range usageIDs[1:] {
+		usage, getErr := store.GetSessionUsage(ctx, id, false)
+		if getErr != nil {
+			return false, 0, false, getErr
+		}
+		if usage == nil || usage.BreakdownCount == 0 {
+			continue
+		}
+		subagentContributing = true
+		if usage.HasCost {
+			totalCostUSD += usage.CostUSD
+		} else {
+			allPriced = false
+		}
+	}
+	totalCostUSD += root.CostUSD
+	return subagentContributing, totalCostUSD, allPriced, nil
 }

--- a/internal/service/session_usage_rollup.go
+++ b/internal/service/session_usage_rollup.go
@@ -1,0 +1,80 @@
+package service
+
+import (
+	"context"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+// SessionUsageRollup combines a root session's usage with explicit subagent
+// descendants. SubagentCount includes descendants without usage rows.
+type SessionUsageRollup struct {
+	Usage         *db.SessionUsage
+	CostUSD       float64
+	HasCost       bool
+	SubagentCount int
+}
+
+// GetSessionUsageRollup returns the root usage and the complete priced cost of
+// every reachable session whose stored relationship_type is "subagent".
+func GetSessionUsageRollup(
+	ctx context.Context, store db.Store, rootID string, includeBreakdown bool,
+) (*SessionUsageRollup, error) {
+	root, err := store.GetSessionUsage(ctx, rootID, includeBreakdown)
+	if err != nil || root == nil {
+		return nil, err
+	}
+
+	out := &SessionUsageRollup{Usage: root}
+	visited := map[string]struct{}{rootID: {}}
+	queue := []string{rootID}
+	subagentContributing := false
+	allPriced := true
+	totalCostUSD := 0.0
+	addUsage := func(usage *db.SessionUsage, isSubagent bool) {
+		if usage.BreakdownCount == 0 {
+			return
+		}
+		if isSubagent {
+			subagentContributing = true
+		}
+		if usage.HasCost {
+			totalCostUSD += usage.CostUSD
+		} else {
+			allPriced = false
+		}
+	}
+	addUsage(root, false)
+
+	for len(queue) > 0 {
+		parentID := queue[0]
+		queue = queue[1:]
+		children, err := store.GetChildSessions(ctx, parentID)
+		if err != nil {
+			return nil, err
+		}
+		for _, child := range children {
+			if _, ok := visited[child.ID]; ok {
+				continue
+			}
+			visited[child.ID] = struct{}{}
+			if child.RelationshipType != "subagent" {
+				continue
+			}
+			out.SubagentCount++
+			usage, err := store.GetSessionUsage(ctx, child.ID, false)
+			if err != nil {
+				return nil, err
+			}
+			if usage != nil {
+				addUsage(usage, true)
+			}
+			queue = append(queue, child.ID)
+		}
+	}
+	out.HasCost = subagentContributing && allPriced
+	if out.HasCost {
+		out.CostUSD = totalCostUSD
+	}
+	return out, nil
+}

--- a/internal/service/session_usage_rollup_test.go
+++ b/internal/service/session_usage_rollup_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/activity"
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/service"
 )
@@ -16,6 +17,17 @@ type rollupStore struct {
 	children map[string][]db.Session
 	usageErr map[string]error
 	childErr map[string]error
+	rows     []activity.UsageRow
+	rowsErr  error
+}
+
+func (s *rollupStore) GetSessionUsageRows(
+	_ context.Context, _ []string,
+) ([]activity.UsageRow, error) {
+	if s.rows == nil {
+		return nil, nil
+	}
+	return s.rows, s.rowsErr
 }
 
 func (s *rollupStore) GetSessionUsage(
@@ -149,4 +161,48 @@ func TestGetSessionUsageRollupReturnsChildUsageError(t *testing.T) {
 	got, err := service.GetSessionUsageRollup(context.Background(), store, "root", false)
 	require.Nil(t, got)
 	require.EqualError(t, err, "child usage failed")
+}
+
+func TestGetSessionUsageRollupTraversesNonSubagentAndDedupesRowsAcrossSessions(t *testing.T) {
+	store := &rollupStore{
+		usages: map[string]*db.SessionUsage{
+			"root":   {SessionID: "root", HasCost: true, CostUSD: 1, BreakdownCount: 1},
+			"nested": {SessionID: "nested", HasCost: true, CostUSD: 2, BreakdownCount: 2},
+		},
+		children: map[string][]db.Session{
+			"root":         {{ID: "continuation", RelationshipType: "continuation"}},
+			"continuation": {{ID: "nested", RelationshipType: "subagent"}},
+		},
+		rows: []activity.UsageRow{
+			{SessionID: "root", Cost: 1, Priced: true, Contributes: true, ClaudeMessageID: "shared", ClaudeRequestID: "request"},
+			{SessionID: "nested", Cost: 2, Priced: true, Contributes: true, ClaudeMessageID: "unique", ClaudeRequestID: "request"},
+		},
+	}
+
+	got, err := service.GetSessionUsageRollup(context.Background(), store, "root", false)
+	require.NoError(t, err)
+	require.Equal(t, 1, got.SubagentCount)
+	require.True(t, got.HasCost)
+	require.Equal(t, 3.0, got.CostUSD)
+}
+
+func TestGetSessionUsageRollupDoesNotLabelDedupedRootCostAsTotal(t *testing.T) {
+	store := &rollupStore{
+		usages: map[string]*db.SessionUsage{
+			"root":   {SessionID: "root", HasCost: true, CostUSD: 1, BreakdownCount: 1},
+			"nested": {SessionID: "nested", HasCost: true, CostUSD: 1, BreakdownCount: 1},
+		},
+		children: map[string][]db.Session{
+			"root": {{ID: "nested", RelationshipType: "subagent"}},
+		},
+		rows: []activity.UsageRow{
+			{SessionID: "root", Cost: 1, Priced: true, Contributes: true, ClaudeMessageID: "shared", ClaudeRequestID: "request"},
+		},
+	}
+
+	got, err := service.GetSessionUsageRollup(context.Background(), store, "root", false)
+	require.NoError(t, err)
+	require.Equal(t, 1, got.SubagentCount)
+	require.False(t, got.HasCost)
+	require.Zero(t, got.CostUSD)
 }

--- a/internal/service/session_usage_rollup_test.go
+++ b/internal/service/session_usage_rollup_test.go
@@ -1,0 +1,152 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/service"
+)
+
+type rollupStore struct {
+	db.Store
+	usages   map[string]*db.SessionUsage
+	children map[string][]db.Session
+	usageErr map[string]error
+	childErr map[string]error
+}
+
+func (s *rollupStore) GetSessionUsage(
+	_ context.Context, id string, _ bool,
+) (*db.SessionUsage, error) {
+	if err := s.usageErr[id]; err != nil {
+		return nil, err
+	}
+	return s.usages[id], nil
+}
+
+func (s *rollupStore) GetChildSessions(
+	_ context.Context, id string,
+) ([]db.Session, error) {
+	if err := s.childErr[id]; err != nil {
+		return nil, err
+	}
+	return s.children[id], nil
+}
+
+func TestGetSessionUsageRollupIncludesOnlyPricedSubagentsOnce(t *testing.T) {
+	store := &rollupStore{
+		usages: map[string]*db.SessionUsage{
+			"root": {SessionID: "root", HasCost: true, CostUSD: 1, BreakdownCount: 1},
+			"a":    {SessionID: "a", HasCost: true, CostUSD: 2, BreakdownCount: 1},
+			"b":    {SessionID: "b", HasCost: true, CostUSD: 4, BreakdownCount: 1},
+			"u":    {SessionID: "u", HasCost: false, BreakdownCount: 1},
+		},
+		children: map[string][]db.Session{
+			"root": {
+				{ID: "a", RelationshipType: "subagent"},
+				{ID: "fork", RelationshipType: "fork"},
+				{ID: "continuation", RelationshipType: "continuation"},
+				{ID: "a", RelationshipType: "subagent"},
+			},
+			"a": {{ID: "b", RelationshipType: "subagent"}, {ID: "root", RelationshipType: "subagent"}},
+			"b": {{ID: "u", RelationshipType: "subagent"}},
+		},
+	}
+
+	got, err := service.GetSessionUsageRollup(context.Background(), store, "root", false)
+	require.NoError(t, err)
+	require.Equal(t, 3, got.SubagentCount)
+	require.Zero(t, got.CostUSD)
+	require.False(t, got.HasCost, "unpriced contributing row must make the aggregate incomplete")
+}
+
+func TestGetSessionUsageRollupIncludesNestedPricedSubagents(t *testing.T) {
+	store := &rollupStore{
+		usages: map[string]*db.SessionUsage{
+			"root": {SessionID: "root", HasCost: true, CostUSD: 1, BreakdownCount: 1},
+			"a":    {SessionID: "a", HasCost: true, CostUSD: 2, BreakdownCount: 1},
+			"b":    {SessionID: "b", HasCost: true, CostUSD: 4, BreakdownCount: 1},
+		},
+		children: map[string][]db.Session{
+			"root": {{ID: "a", RelationshipType: "subagent"}},
+			"a":    {{ID: "b", RelationshipType: "subagent"}},
+		},
+	}
+
+	got, err := service.GetSessionUsageRollup(context.Background(), store, "root", false)
+	require.NoError(t, err)
+	require.Equal(t, 2, got.SubagentCount)
+	require.Equal(t, 7.0, got.CostUSD)
+	require.True(t, got.HasCost)
+}
+
+func TestGetSessionUsageRollupCountsEmptySubagentAndTerminatesCycle(t *testing.T) {
+	store := &rollupStore{
+		usages: map[string]*db.SessionUsage{
+			"root": {SessionID: "root"},
+		},
+		children: map[string][]db.Session{
+			"root":  {{ID: "empty", RelationshipType: "subagent"}},
+			"empty": {{ID: "root", RelationshipType: "subagent"}},
+		},
+	}
+
+	got, err := service.GetSessionUsageRollup(context.Background(), store, "root", false)
+	require.NoError(t, err)
+	require.Equal(t, 1, got.SubagentCount)
+	require.False(t, got.HasCost)
+}
+
+func TestGetSessionUsageRollupRequiresContributingSubagentForHasCost(t *testing.T) {
+	store := &rollupStore{
+		usages: map[string]*db.SessionUsage{
+			"root":  {SessionID: "root", HasCost: true, CostUSD: 1, BreakdownCount: 1},
+			"empty": {SessionID: "empty"},
+		},
+		children: map[string][]db.Session{
+			"root": {{ID: "empty", RelationshipType: "subagent"}},
+		},
+	}
+
+	got, err := service.GetSessionUsageRollup(context.Background(), store, "root", false)
+	require.NoError(t, err)
+	require.Equal(t, 1, got.SubagentCount)
+	require.Zero(t, got.CostUSD)
+	require.False(t, got.HasCost, "root-only priced usage must not be labeled as a total")
+}
+
+func TestGetSessionUsageRollupReturnsChildSessionError(t *testing.T) {
+	store := &rollupStore{
+		usages: map[string]*db.SessionUsage{
+			"root": {SessionID: "root", HasCost: true, CostUSD: 1, BreakdownCount: 1},
+		},
+		childErr: map[string]error{
+			"root": errors.New("child lookup failed"),
+		},
+	}
+
+	got, err := service.GetSessionUsageRollup(context.Background(), store, "root", false)
+	require.Nil(t, got)
+	require.EqualError(t, err, "child lookup failed")
+}
+
+func TestGetSessionUsageRollupReturnsChildUsageError(t *testing.T) {
+	store := &rollupStore{
+		usages: map[string]*db.SessionUsage{
+			"root": {SessionID: "root", HasCost: true, CostUSD: 1, BreakdownCount: 1},
+		},
+		children: map[string][]db.Session{
+			"root": {{ID: "child", RelationshipType: "subagent"}},
+		},
+		usageErr: map[string]error{
+			"child": errors.New("child usage failed"),
+		},
+	}
+
+	got, err := service.GetSessionUsageRollup(context.Background(), store, "root", false)
+	require.Nil(t, got)
+	require.EqualError(t, err, "child usage failed")
+}


### PR DESCRIPTION
Session headers currently price only the open transcript, so delegated work remains hidden unless each subagent is opened separately.

This adds an opt-in subagent rollup to the existing session-usage response and uses it for the header badge when the selected session has explicit subagent descendants. The rollup walks the stored child-session graph, traverses bridge nodes such as continuations and forks, and aggregates the root plus explicit subagents under one shared dedup scope per backend, so replayed usage rows contribute once across SQLite, PostgreSQL, and DuckDB and shared duplicates stay attributed deterministically.

Fork and continuation usage stays outside the displayed total, but traversal continues through those bridge nodes so nested explicit subagents still contribute. Untimed or unparseable usage rows now participate in the rollup wherever `GetSessionUsage` already includes them. Replayed rows, deleted sessions, duplicate links, and incomplete pricing also stay outside the total marker, while the existing own-session cost and per-step breakdown remain available when a complete rollup is unavailable.

The header marks a value as total only when at least one subagent contributes to a complete priced rollup. The requested at-a-glance placement came from [@travis-jorge's report and screenshot](https://github.com/kenn-io/agentsview/issues/1139).

Closes #1139
