### PR TITLE
parser(hermes): snapshot profiles and deprecate SSH remote sync

### DIFF
--- a/cmd/agentsview/cli.go
+++ b/cmd/agentsview/cli.go
@@ -334,15 +334,15 @@ func newSyncCommand() *cobra.Command {
 	)
 	cmd.Flags().StringVar(
 		&cfg.Host, "host", "",
-		"SSH hostname for remote sync",
+		"SSH hostname for deprecated remote sync",
 	)
 	cmd.Flags().StringVar(
 		&cfg.User, "user", "",
-		"SSH user for remote sync",
+		"SSH user for deprecated remote sync",
 	)
 	cmd.Flags().IntVar(
 		&cfg.Port, "port", 0,
-		"SSH port for remote sync (default: 22)",
+		"SSH port for deprecated remote sync (default: 22)",
 	)
 	cmd.Flags().StringVar(
 		&cfg.CPUProfile, "cpuprofile", "",

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -1072,6 +1072,24 @@ func TestCollectWatchRootsHermesSessionsWatchesStateDBParent(t *testing.T) {
 	assert.Equal(t, []string{sessionsDir}, roots[1].dirs)
 }
 
+func TestCollectWatchRootsWatchesHermesProfilesContainerRecursively(t *testing.T) {
+	profilesRoot := filepath.Join(t.TempDir(), ".hermes", "profiles")
+	require.NoError(t, os.MkdirAll(profilesRoot, 0o755))
+	cfg := config.Config{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentHermes: {profilesRoot},
+		},
+	}
+
+	roots, unwatchedDirs := collectWatchRoots(cfg)
+
+	require.Empty(t, unwatchedDirs)
+	require.Len(t, roots, 1)
+	assert.Equal(t, profilesRoot, roots[0].root)
+	assert.False(t, roots[0].shallow)
+	assert.Equal(t, []string{profilesRoot}, roots[0].dirs)
+}
+
 func TestCollectWatchRootsUsesCoworkProviderRecursiveRoot(t *testing.T) {
 	root := t.TempDir()
 	cfg := config.Config{

--- a/cmd/agentsview/serve_background_test.go
+++ b/cmd/agentsview/serve_background_test.go
@@ -1387,8 +1387,7 @@ func TestEnsureBackgroundServeChecksTooNewDatabaseAfterStartupWait(
 	}
 	t.Cleanup(func() { startServeBackgroundProcessForEnsure = oldStartProcess })
 
-	MarkDaemonStarting(dir)
-	t.Cleanup(func() { UnmarkDaemonStarting(dir) })
+	unlockStart := holdExternalDaemonStartLock(t, dir)
 	oldHost, oldPort := testPingServer(t)
 	errCh := make(chan error, 1)
 	go func() {
@@ -1398,7 +1397,7 @@ func TestEnsureBackgroundServeChecksTooNewDatabaseAfterStartupWait(
 			withRuntimeVersion("1.0.0"),
 			withRuntimeAPIVersion(0),
 		))
-		UnmarkDaemonStarting(dir)
+		unlockStart()
 		errCh <- err
 	}()
 
@@ -1509,8 +1508,7 @@ func TestEnsureBackgroundServeReplacesIncompatibleDaemonAfterStartupWait(
 		RemoveDaemonRuntime(dir)
 	})
 
-	MarkDaemonStarting(dir)
-	t.Cleanup(func() { UnmarkDaemonStarting(dir) })
+	unlockStart := holdExternalDaemonStartLock(t, dir)
 	oldHost, oldPort := testPingServer(t)
 	errCh := make(chan error, 1)
 	go func() {
@@ -1520,7 +1518,7 @@ func TestEnsureBackgroundServeReplacesIncompatibleDaemonAfterStartupWait(
 			withRuntimeVersion("1.0.0"),
 			withRuntimeAPIVersion(0),
 		))
-		UnmarkDaemonStarting(dir)
+		unlockStart()
 		errCh <- err
 	}()
 

--- a/cmd/agentsview/sync.go
+++ b/cmd/agentsview/sync.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	stdsync "sync"
 	"time"
 
 	"go.kenn.io/agentsview/internal/config"
@@ -365,6 +366,12 @@ func runRemoteSyncTransportWithCleanup(
 ) (remotesync.SyncStats, error) {
 	switch rh.Transport {
 	case "", config.RemoteTransportSSH:
+		sshRemoteSyncDeprecationWarningOnce.Do(func() {
+			log.Printf(
+				"warning: SSH remote sync is deprecated and receives only critical fixes; " +
+					"use HTTP remote sync instead",
+			)
+		})
 		return runSSHRemoteSync(ctx, appCfg, database, rh, full)
 	case config.RemoteTransportHTTP:
 		if !acquireHTTPCleanup {
@@ -379,6 +386,8 @@ func runRemoteSyncTransportWithCleanup(
 		)
 	}
 }
+
+var sshRemoteSyncDeprecationWarningOnce = new(stdsync.Once)
 
 var httpRemoteCleanupRegistry = new(remotesync.CleanupRegistry)
 

--- a/cmd/agentsview/sync_test.go
+++ b/cmd/agentsview/sync_test.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	stdsync "sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -80,6 +81,33 @@ func newDirectSyncFixture(t *testing.T) (config.Config, *db.DB) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, database.Close()) })
 	return cfg, database
+}
+
+func TestRunRemoteSyncTransportWarnsOnceForDeprecatedSSH(t *testing.T) {
+	logs := captureLogOutput(t)
+	originalOnce := sshRemoteSyncDeprecationWarningOnce
+	sshRemoteSyncDeprecationWarningOnce = new(stdsync.Once)
+	t.Cleanup(func() { sshRemoteSyncDeprecationWarningOnce = originalOnce })
+
+	originalSSH := runSSHRemoteSync
+	runSSHRemoteSync = func(
+		context.Context, config.Config, *db.DB, config.RemoteHost, bool,
+	) (remotesync.SyncStats, error) {
+		return remotesync.SyncStats{}, nil
+	}
+	t.Cleanup(func() { runSSHRemoteSync = originalSSH })
+
+	for range 2 {
+		_, err := runRemoteSyncTransport(
+			context.Background(), config.Config{}, nil,
+			config.RemoteHost{Host: "legacy-host"}, false,
+		)
+		require.NoError(t, err)
+	}
+
+	const warning = "SSH remote sync is deprecated"
+	assert.Equal(t, 1, strings.Count(logs.String(), warning))
+	assert.Contains(t, logs.String(), "use HTTP remote sync instead")
 }
 
 func isolateDirectCLISources(t *testing.T) {
@@ -626,7 +654,7 @@ func TestDoSyncConfiguredFullUnifiedHTTPUsesManifestDeltaAndOrderedProgress(
 			var err error
 			if requested.DeltaFiles != nil {
 				err = remotesync.WriteArchiveFiles(
-					w, targets.DeltaAllowedRoots(), requested.DeltaFiles,
+					w, targets, requested.DeltaFiles,
 				)
 			} else {
 				err = remotesync.WriteArchive(w, requested.TargetSet)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -188,9 +188,9 @@ agentsview sync [flags]
 | Flag     | Default | Description                                    |
 | -------- | ------- | ---------------------------------------------- |
 | `--full` | `false` | Force a full resync regardless of data version |
-| `--host` |         | SSH hostname for remote sync                   |
-| `--user` |         | SSH username for remote sync                   |
-| `--port` | `22`    | SSH port for remote sync                       |
+| `--host` |         | SSH hostname for deprecated remote sync        |
+| `--user` |         | SSH username for deprecated remote sync        |
+| `--port` | `22`    | SSH port for deprecated remote sync            |
 
 **Examples:**
 
@@ -208,7 +208,8 @@ error. If the local daemon has a matching configured `[[remote_hosts]]` entry,
 the daemon uses that stored entry and its configured transport. Otherwise,
 `--host` performs an ad hoc SSH sync: it resolves the supported agent session
 directories on the remote machine, transfers the source session data locally,
-and indexes it into your local archive.
+and indexes it into your local archive. SSH remote sync is deprecated and
+receives only critical fixes; use configured HTTP remote sync for new setups.
 
 Local sync can also read configured Claude and Codex roots from S3-compatible
 object storage. Add `s3://` entries to `claude_project_dirs` or
@@ -257,8 +258,9 @@ reporting, and the command exits non-zero if any host failed. See
 the local daemon knows a configured host with that identity, it uses the stored
 entry and transport so HTTP hosts can be selected by host name. Without a
 matching configured host, `--host` remains an ad hoc SSH sync. SSH remote sync
-is non-interactive in both forms — it requires key-based passwordless SSH and
-never prompts for a password.
+is deprecated and receives only critical fixes. It remains non-interactive in
+both forms — it requires key-based passwordless SSH and never prompts for a
+password. Prefer configured HTTP remote sync.
 
 HTTP remote sync requires a reachable remote daemon, preferably over a private
 network such as Tailscale, and remote archive endpoints always require bearer

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -151,7 +151,9 @@ the same machine can duplicate sessions, while reusing it for another machine
 can reuse stale state. A configured HTTP host can be selected later with
 `agentsview sync --host <name>`, but ad hoc HTTP remotes are not supported;
 without a matching configured host, `--host` remains an SSH remote sync. HTTP
-failures are summarized with actionable messages for common cases such as token
+remote sync is the recommended transport. SSH remote sync is deprecated and
+receives only critical fixes. HTTP failures are summarized with actionable
+messages for common cases such as token
 rejection, missing remote archive endpoints, connection refusal, DNS failures,
 and timeouts.
 

--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -163,8 +163,8 @@ concurrent syncs of that host from the same data directory.
 The mirror adds an on-disk copy of the remote session sources to the collector,
 in addition to the indexed database. Budget roughly the size of each remote
 host's syncable source corpus for it. Incremental transfer applies only to the
-HTTP transport; SSH remote sync continues to copy a full session tree on each
-run.
+HTTP transport. SSH remote sync is deprecated, receives only critical fixes,
+and continues to copy a full session tree on each run.
 
 ### How A Sync Works
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -417,12 +417,14 @@ type CustomModelRate struct {
 type RemoteTransport string
 
 const (
+	// RemoteTransportSSH is retained for compatibility but deprecated. New
+	// remote sync configurations should use RemoteTransportHTTP.
 	RemoteTransportSSH  RemoteTransport = "ssh"
 	RemoteTransportHTTP RemoteTransport = "http"
 )
 
 // RemoteHost describes one target for config-driven `agentsview sync`
-// fan-out. Host is required. SSH remotes may set User and Port
+// fan-out. Host is required. Deprecated SSH remotes may set User and Port
 // (Port 0 means the ssh default of 22). HTTP remotes must set URL
 // and Token. A zero/empty Interval disables periodic remote
 // sync for this host.
@@ -699,6 +701,15 @@ func Default() (Config, error) {
 				continue
 			}
 			dirs[i] = filepath.Join(home, rel)
+		}
+		// Keep the Hermes profiles container as a stable provider root. The
+		// provider enumerates its children on every discovery pass, so profiles
+		// created after startup become visible without rebuilding Config or the
+		// sync engine. Env/config overrides still replace all default roots.
+		if def.Type == parser.AgentHermes && root == "" {
+			dirs = append(dirs,
+				filepath.Join(home, ".hermes", "profiles"),
+			)
 		}
 		agentDirs[def.Type] = dirs
 		agentDirSource[def.Type] = dirDefault

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -50,6 +50,12 @@ func setupTestEnv(t *testing.T) string {
 	return dir
 }
 
+func setTestHome(t *testing.T, home string) {
+	t.Helper()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+}
+
 type configFixture struct {
 	Dir string
 }
@@ -321,6 +327,43 @@ func TestDefault_IncludesDevinLocalShareRoots(t *testing.T) {
 	assert.True(t, strings.HasSuffix(dirs[0], filepath.Join("Library", "Application Support", "devin")), "dirs[0] = %q", dirs[0])
 	assert.True(t, strings.HasSuffix(dirs[1], filepath.Join(".local", "share", "devin")), "dirs[1] = %q", dirs[1])
 	assert.False(t, cfg.IsUserConfigured(parser.AgentDevin))
+}
+
+func TestDefault_IncludesHermesProfilesRoot(t *testing.T) {
+	home := t.TempDir()
+	setTestHome(t, home)
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".hermes", "sessions"), 0o755))
+
+	cfg, err := Default()
+	require.NoError(t, err)
+	dirs := cfg.ResolveDirs(parser.AgentHermes)
+
+	assert.Contains(t, dirs, filepath.Join(home, ".hermes", "sessions"))
+	assert.Contains(t, dirs, filepath.Join(home, ".hermes", "profiles"))
+}
+
+func TestDefault_HermesNoProfilesDirIsSafe(t *testing.T) {
+	home := t.TempDir()
+	setTestHome(t, home)
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".hermes", "sessions"), 0o755))
+	cfg, err := Default()
+	require.NoError(t, err)
+	dirs := cfg.ResolveDirs(parser.AgentHermes)
+	assert.Contains(t, dirs, filepath.Join(home, ".hermes", "sessions"))
+	assert.Contains(t, dirs, filepath.Join(home, ".hermes", "profiles"))
+}
+
+func TestDefault_HermesEnvReplacesDefaultAndProfilesRoots(t *testing.T) {
+	home := t.TempDir()
+	setTestHome(t, home)
+	custom := filepath.Join(t.TempDir(), "hermes-sessions")
+	t.Setenv("HERMES_SESSIONS_DIR", custom)
+
+	cfg, err := Default()
+	require.NoError(t, err)
+	cfg.loadEnv()
+
+	assert.Equal(t, []string{custom}, cfg.ResolveDirs(parser.AgentHermes))
 }
 
 func TestLoadEnv_OverridesDataDir(t *testing.T) {

--- a/internal/parser/hermes_provider.go
+++ b/internal/parser/hermes_provider.go
@@ -215,10 +215,64 @@ func newHermesSourceSet(roots []string) hermesSourceSet {
 	return hermesSourceSet{roots: cleanJSONLRoots(roots)}
 }
 
+// The default Hermes roots include the stable profiles container rather than
+// its current children. Expanding direct children during discovery lets a
+// long-running provider see profiles created after initialization.
+func isHermesProfilesContainer(root string) bool {
+	root = filepath.Clean(root)
+	return filepath.Base(root) == "profiles" &&
+		filepath.Base(filepath.Dir(root)) == ".hermes"
+}
+
+func hermesProfileArchiveRoots(profilesRoot string) []string {
+	entries, err := os.ReadDir(profilesRoot)
+	if err != nil {
+		return nil
+	}
+	roots := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() || entry.Type()&os.ModeSymlink != 0 {
+			continue
+		}
+		roots = append(roots, filepath.Join(profilesRoot, entry.Name()))
+	}
+	return roots
+}
+
+func (s hermesSourceSet) expandedRoots() []string {
+	var roots []string
+	for _, root := range s.roots {
+		if isHermesProfilesContainer(root) {
+			roots = append(roots, hermesProfileArchiveRoots(root)...)
+			continue
+		}
+		roots = append(roots, root)
+	}
+	return roots
+}
+
+func hermesProfileRootForPath(profilesRoot, changedPath string) (string, bool) {
+	profilesRoot = filepath.Clean(profilesRoot)
+	changedPath = filepath.Clean(changedPath)
+	rel, err := filepath.Rel(profilesRoot, changedPath)
+	if err != nil || rel == "." || rel == ".." ||
+		strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	name := rel
+	if before, _, ok := strings.Cut(rel, string(filepath.Separator)); ok {
+		name = before
+	}
+	if name == "" || name == "." || name == ".." {
+		return "", false
+	}
+	return filepath.Join(profilesRoot, name), true
+}
+
 func (s hermesSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
 	var sources []SourceRef
 	seen := make(map[string]struct{})
-	for _, root := range s.roots {
+	for _, root := range s.expandedRoots() {
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
@@ -237,6 +291,15 @@ func (s hermesSourceSet) Discover(ctx context.Context) ([]SourceRef, error) {
 func (s hermesSourceSet) WatchPlan(context.Context) (WatchPlan, error) {
 	roots := make([]WatchRoot, 0, len(s.roots))
 	for _, root := range s.roots {
+		if isHermesProfilesContainer(root) {
+			roots = append(roots, WatchRoot{
+				Path:         root,
+				Recursive:    true,
+				IncludeGlobs: []string{"state.db", "state.db-wal", "*.jsonl", "session_*.json"},
+				DebounceKey:  string(AgentHermes) + ":profiles:" + root,
+			})
+			continue
+		}
 		roots = append(roots, hermesWatchRoots(root)...)
 	}
 	return WatchPlan{Roots: roots}, nil
@@ -253,6 +316,19 @@ func (s hermesSourceSet) SourcesForChangedPath(
 	if req.WatchRoot != "" {
 		watchRoot := filepath.Clean(req.WatchRoot)
 		for _, root := range s.roots {
+			if isHermesProfilesContainer(root) && samePath(root, watchRoot) {
+				profileRoot, ok := hermesProfileRootForPath(root, req.Path)
+				if !ok {
+					return nil, nil
+				}
+				source, ok := s.sourceForChangedPath(
+					profileRoot, req.Path, allowMissing,
+				)
+				if ok {
+					return []SourceRef{source}, nil
+				}
+				return nil, nil
+			}
 			if !hermesWatchRootMatches(root, watchRoot) {
 				continue
 			}
@@ -264,6 +340,19 @@ func (s hermesSourceSet) SourcesForChangedPath(
 		return nil, nil
 	}
 	for _, root := range s.roots {
+		if isHermesProfilesContainer(root) {
+			profileRoot, ok := hermesProfileRootForPath(root, req.Path)
+			if !ok {
+				continue
+			}
+			source, ok := s.sourceForChangedPath(
+				profileRoot, req.Path, allowMissing,
+			)
+			if ok {
+				return []SourceRef{source}, nil
+			}
+			continue
+		}
 		source, ok := s.sourceForChangedPath(root, req.Path, allowMissing)
 		if ok {
 			return []SourceRef{source}, nil
@@ -283,7 +372,7 @@ func (s hermesSourceSet) FindSource(
 		if path == "" {
 			continue
 		}
-		for _, root := range s.roots {
+		for _, root := range s.expandedRoots() {
 			if source, ok := s.sourceForPath(root, path); ok {
 				return source, true, nil
 			}
@@ -292,7 +381,7 @@ func (s hermesSourceSet) FindSource(
 	if req.RawSessionID == "" {
 		return SourceRef{}, false, nil
 	}
-	for _, root := range s.roots {
+	for _, root := range s.expandedRoots() {
 		if stateDB, _, ok := hermesStatePaths(root); ok &&
 			IsValidSessionID(req.RawSessionID) {
 			found, err := hermesStateDBHasSession(stateDB, req.RawSessionID)
@@ -405,7 +494,7 @@ func (s hermesSourceSet) pathFromSource(source SourceRef) (string, bool) {
 		source.FingerprintKey,
 		source.Key,
 	} {
-		for _, root := range s.roots {
+		for _, root := range s.expandedRoots() {
 			if ref, ok := s.sourceForPath(root, candidate); ok {
 				src := ref.Opaque.(hermesSource)
 				return src.Path, true
@@ -427,14 +516,16 @@ func (s hermesSourceSet) sourceForChangedPath(
 	root = filepath.Clean(root)
 	path = filepath.Clean(path)
 	if stateDB, sessionsDir, ok := hermesStatePaths(root); ok {
-		if samePath(path, stateDB) || hermesPathInTranscriptDir(sessionsDir, path) {
+		if hermesStatePathAffectsArchive(path, stateDB) ||
+			hermesPathInTranscriptDir(sessionsDir, path) {
 			return hermesArchiveSourceRef(root, stateDB)
 		}
 		return SourceRef{}, false
 	}
 	if allowMissing {
 		if stateDB, sessionsDir, ok := hermesArchivePathsForEvent(root, path); ok &&
-			(samePath(path, stateDB) || hermesPathInTranscriptDir(sessionsDir, path)) {
+			(hermesStatePathAffectsArchive(path, stateDB) ||
+				hermesPathInTranscriptDir(sessionsDir, path)) {
 			return hermesArchiveSourceRef(root, stateDB)
 		}
 		transcriptRoot := hermesTranscriptRoot(root)
@@ -443,6 +534,10 @@ func (s hermesSourceSet) sourceForChangedPath(
 		}
 	}
 	return s.sourceRef(root, path)
+}
+
+func hermesStatePathAffectsArchive(path, stateDB string) bool {
+	return samePath(path, stateDB) || samePath(path, stateDB+"-wal")
 }
 
 func (s hermesSourceSet) sourceRef(root, path string) (SourceRef, bool) {
@@ -494,7 +589,7 @@ func hermesWatchRoots(root string) []WatchRoot {
 		watchRoots := []WatchRoot{{
 			Path:         filepath.Dir(stateDB),
 			Recursive:    false,
-			IncludeGlobs: []string{"state.db"},
+			IncludeGlobs: []string{"state.db", "state.db-wal"},
 			DebounceKey:  string(AgentHermes) + ":archive:" + root,
 		}}
 		watchRoots = append(watchRoots, WatchRoot{
@@ -508,7 +603,7 @@ func hermesWatchRoots(root string) []WatchRoot {
 	return []WatchRoot{{
 		Path:         root,
 		Recursive:    true,
-		IncludeGlobs: []string{"state.db", "*.jsonl", "session_*.json"},
+		IncludeGlobs: []string{"state.db", "state.db-wal", "*.jsonl", "session_*.json"},
 		DebounceKey:  string(AgentHermes) + ":sessions:" + root,
 	}}
 }
@@ -639,6 +734,21 @@ func hermesArchiveFingerprint(source SourceRef, stateDB string) (SourceFingerpri
 	if err := addHermesFingerprintPart(h, "state", stateDB, stateInfo); err != nil {
 		return SourceFingerprint{}, err
 	}
+	walPath := stateDB + "-wal"
+	if walInfo, err := os.Stat(walPath); err == nil {
+		if walInfo.IsDir() {
+			return SourceFingerprint{}, fmt.Errorf("stat %s: source is a directory", walPath)
+		}
+		fingerprint.Size += walInfo.Size()
+		if mtime := walInfo.ModTime().UnixNano(); mtime > fingerprint.MTimeNS {
+			fingerprint.MTimeNS = mtime
+		}
+		if err := addHermesFingerprintPart(h, "wal", walPath, walInfo); err != nil {
+			return SourceFingerprint{}, err
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return SourceFingerprint{}, fmt.Errorf("stat %s: %w", walPath, err)
+	}
 	_, sessionsDir, _ := hermesStatePaths(stateDB)
 	for _, file := range discoverHermesTranscriptFiles(sessionsDir) {
 		info, err := os.Stat(file.Path)
@@ -658,10 +768,10 @@ func hermesArchiveFingerprint(source SourceRef, stateDB string) (SourceFingerpri
 }
 
 // hermesArchiveEffectiveFileInfo returns the aggregate size and mtime of a
-// Hermes archive: the state.db plus every transcript file in its sessions
-// directory. It reproduces the legacy engine's hermesArchiveEffectiveInfo so a
-// transcript-only change shifts the stored archive freshness even though the
-// state.db itself is unchanged. The transcript set matches the legacy
+// Hermes archive: the state.db, its WAL, and every transcript file in its
+// sessions directory. WAL-only commits and transcript-only changes both shift
+// the stored archive freshness even though state.db itself is unchanged. The
+// transcript set matches the legacy
 // hermesArchiveTranscriptFiles: every .jsonl and session_*.json file directly
 // under the sessions directory, without the .jsonl/.json dedup used elsewhere.
 func hermesArchiveEffectiveFileInfo(stateDB string) (int64, int64) {
@@ -671,6 +781,12 @@ func hermesArchiveEffectiveFileInfo(stateDB string) (int64, int64) {
 	}
 	size := info.Size()
 	mtime := info.ModTime().UnixNano()
+	if walInfo, err := os.Stat(stateDB + "-wal"); err == nil && !walInfo.IsDir() {
+		size += walInfo.Size()
+		if walMtime := walInfo.ModTime().UnixNano(); walMtime > mtime {
+			mtime = walMtime
+		}
+	}
 	_, sessionsDir, ok := hermesStatePaths(stateDB)
 	if !ok {
 		return size, mtime

--- a/internal/parser/hermes_provider_test.go
+++ b/internal/parser/hermes_provider_test.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -30,7 +31,7 @@ func TestHermesProviderTranscriptSourceMethods(t *testing.T) {
 	require.Len(t, plan.Roots, 1)
 	assert.Equal(t, root, plan.Roots[0].Path)
 	assert.True(t, plan.Roots[0].Recursive)
-	assert.Equal(t, []string{"state.db", "*.jsonl", "session_*.json"}, plan.Roots[0].IncludeGlobs)
+	assert.Equal(t, []string{"state.db", "state.db-wal", "*.jsonl", "session_*.json"}, plan.Roots[0].IncludeGlobs)
 
 	discovered, err := provider.Discover(context.Background())
 	require.NoError(t, err)
@@ -111,7 +112,7 @@ func TestHermesProviderStateDBSourceMethods(t *testing.T) {
 	require.Len(t, plan.Roots, 2)
 	assert.Equal(t, root, plan.Roots[0].Path)
 	assert.False(t, plan.Roots[0].Recursive)
-	assert.Equal(t, []string{"state.db"}, plan.Roots[0].IncludeGlobs)
+	assert.Equal(t, []string{"state.db", "state.db-wal"}, plan.Roots[0].IncludeGlobs)
 	assert.Equal(t, sessionsDir, plan.Roots[1].Path)
 	assert.True(t, plan.Roots[1].Recursive)
 	assert.Equal(t, []string{"*.jsonl", "session_*.json"}, plan.Roots[1].IncludeGlobs)
@@ -216,7 +217,7 @@ func TestHermesProviderArchiveWatchRoots(t *testing.T) {
 			require.Len(t, plan.Roots, 2)
 			assert.Equal(t, root, plan.Roots[0].Path)
 			assert.False(t, plan.Roots[0].Recursive)
-			assert.Equal(t, []string{"state.db"}, plan.Roots[0].IncludeGlobs)
+			assert.Equal(t, []string{"state.db", "state.db-wal"}, plan.Roots[0].IncludeGlobs)
 			assert.Equal(t, sessionsDir, plan.Roots[1].Path)
 			assert.True(t, plan.Roots[1].Recursive)
 			assert.Equal(t, []string{"*.jsonl", "session_*.json"}, plan.Roots[1].IncludeGlobs)
@@ -230,6 +231,103 @@ func TestHermesProviderArchiveWatchRoots(t *testing.T) {
 			assert.Equal(t, stateDB, changed[0].DisplayPath)
 		})
 	}
+}
+
+func TestHermesProviderDiscoversProfileCreatedAfterInitialization(t *testing.T) {
+	profilesRoot := filepath.Join(t.TempDir(), ".hermes", "profiles")
+	require.NoError(t, os.MkdirAll(profilesRoot, 0o755))
+
+	provider, ok := NewProvider(AgentHermes, ProviderConfig{
+		Roots:   []string{profilesRoot},
+		Machine: "devbox",
+	})
+	require.True(t, ok)
+
+	plan, err := provider.WatchPlan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, plan.Roots, 1)
+	assert.Equal(t, profilesRoot, plan.Roots[0].Path)
+	assert.True(t, plan.Roots[0].Recursive)
+
+	before, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, before)
+
+	profileRoot := filepath.Join(profilesRoot, "research")
+	require.NoError(t, os.MkdirAll(profileRoot, 0o755))
+	createHermesStateDB(t, profileRoot)
+	stateDB := filepath.Join(profileRoot, "state.db")
+
+	after, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, after, 1)
+	assert.Equal(t, stateDB, after[0].DisplayPath)
+
+	changed, err := provider.SourcesForChangedPath(
+		context.Background(),
+		ChangedPathRequest{
+			Path:      stateDB,
+			EventKind: "create",
+			WatchRoot: profilesRoot,
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, changed, 1)
+	assert.Equal(t, stateDB, changed[0].DisplayPath)
+
+	require.NoError(t, os.Remove(stateDB))
+	removed, err := provider.SourcesForChangedPath(
+		context.Background(),
+		ChangedPathRequest{
+			Path:      stateDB,
+			EventKind: "remove",
+			WatchRoot: profilesRoot,
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, removed, 1)
+	assert.Equal(t, stateDB, removed[0].DisplayPath)
+}
+
+func TestHermesProfileChangedPathAllocationsStayBounded(t *testing.T) {
+	measure := func(t *testing.T, profileCount int) float64 {
+		t.Helper()
+		profilesRoot := filepath.Join(t.TempDir(), ".hermes", "profiles")
+		for i := range profileCount {
+			require.NoError(t, os.MkdirAll(filepath.Join(
+				profilesRoot, fmt.Sprintf("archive-%04d", i),
+			), 0o755))
+		}
+		targetRoot := filepath.Join(profilesRoot, "current")
+		targetPath := filepath.Join(targetRoot, "sessions", "child.jsonl")
+		writeSourceFile(t, targetPath, hermesProviderJSONLFixture("bounded"))
+		provider, ok := NewProvider(AgentHermes, ProviderConfig{
+			Roots: []string{profilesRoot},
+		})
+		require.True(t, ok)
+
+		request := ChangedPathRequest{
+			Path: targetPath, EventKind: "write", WatchRoot: profilesRoot,
+		}
+		warm, err := provider.SourcesForChangedPath(context.Background(), request)
+		require.NoError(t, err)
+		require.Len(t, warm, 1)
+		assert.Equal(t, targetPath, warm[0].DisplayPath)
+
+		return testing.AllocsPerRun(20, func() {
+			sources, sourceErr := provider.SourcesForChangedPath(
+				context.Background(), request,
+			)
+			if sourceErr != nil || len(sources) != 1 {
+				panic("Hermes changed-path classification failed")
+			}
+		})
+	}
+
+	smallAllocs := measure(t, 10)
+	largeAllocs := measure(t, 1000)
+	assert.LessOrEqual(t, largeAllocs, smallAllocs*2,
+		"Hermes profile events must not scan unrelated profiles")
 }
 
 func TestHermesProviderArchiveWatchRootsBeforeArchiveComplete(t *testing.T) {
@@ -252,7 +350,7 @@ func TestHermesProviderArchiveWatchRootsBeforeArchiveComplete(t *testing.T) {
 		require.Len(t, plan.Roots, 2)
 		assert.Equal(t, root, plan.Roots[0].Path)
 		assert.False(t, plan.Roots[0].Recursive)
-		assert.Equal(t, []string{"state.db"}, plan.Roots[0].IncludeGlobs)
+		assert.Equal(t, []string{"state.db", "state.db-wal"}, plan.Roots[0].IncludeGlobs)
 		assert.Equal(t, sessionsDir, plan.Roots[1].Path)
 		assert.True(t, plan.Roots[1].Recursive)
 		assert.Equal(t, []string{"*.jsonl", "session_*.json"}, plan.Roots[1].IncludeGlobs)
@@ -283,7 +381,7 @@ func TestHermesProviderArchiveWatchRootsBeforeArchiveComplete(t *testing.T) {
 		require.Len(t, plan.Roots, 2)
 		assert.Equal(t, root, plan.Roots[0].Path)
 		assert.False(t, plan.Roots[0].Recursive)
-		assert.Equal(t, []string{"state.db"}, plan.Roots[0].IncludeGlobs)
+		assert.Equal(t, []string{"state.db", "state.db-wal"}, plan.Roots[0].IncludeGlobs)
 		assert.Equal(t, sessionsDir, plan.Roots[1].Path)
 		assert.True(t, plan.Roots[1].Recursive)
 		assert.Equal(t, []string{"*.jsonl", "session_*.json"}, plan.Roots[1].IncludeGlobs)
@@ -316,7 +414,7 @@ func TestHermesProviderArchiveWatchRootsBeforeArchiveComplete(t *testing.T) {
 		require.Len(t, plan.Roots, 2)
 		assert.Equal(t, root, plan.Roots[0].Path)
 		assert.False(t, plan.Roots[0].Recursive)
-		assert.Equal(t, []string{"state.db"}, plan.Roots[0].IncludeGlobs)
+		assert.Equal(t, []string{"state.db", "state.db-wal"}, plan.Roots[0].IncludeGlobs)
 		assert.Equal(t, sessionsDir, plan.Roots[1].Path)
 		assert.True(t, plan.Roots[1].Recursive)
 		assert.Equal(t, []string{"*.jsonl", "session_*.json"}, plan.Roots[1].IncludeGlobs)

--- a/internal/remotesync/archive.go
+++ b/internal/remotesync/archive.go
@@ -14,12 +14,33 @@ import (
 
 func WriteArchive(w io.Writer, targets TargetSet) error {
 	tw := tar.NewWriter(w)
+	hermesSQLite := make(map[string]string)
+	for _, stateDB := range hermesStateDBTargets(targets) {
+		for _, path := range hermesSQLitePaths(stateDB) {
+			hermesSQLite[path] = stateDB
+		}
+	}
+	writtenHermesState := make(map[string]struct{})
+	writePath := func(path string, optional bool) error {
+		clean := filepath.Clean(path)
+		if stateDB, ok := hermesSQLite[clean]; ok {
+			if _, written := writtenHermesState[stateDB]; written {
+				return nil
+			}
+			writtenHermesState[stateDB] = struct{}{}
+			return writeHermesStateDBSnapshot(tw, stateDB)
+		}
+		if optional {
+			return writeOptionalArchiveFile(tw, path)
+		}
+		return writeArchivePath(tw, path)
+	}
 	for agent, dirs := range targets.Dirs {
 		if _, fileScoped := targets.Files[agent]; fileScoped {
 			continue
 		}
 		for _, root := range dirs {
-			if err := writeArchivePath(tw, root); err != nil {
+			if err := writePath(root, false); err != nil {
 				return err
 			}
 		}
@@ -36,13 +57,13 @@ func WriteArchive(w io.Writer, targets TargetSet) error {
 			// missing: the archive races live agents deleting tasks,
 			// and validation deliberately authorizes session-shaped
 			// files that vanished after target resolution.
-			if err := writeOptionalArchivePath(tw, path); err != nil {
+			if err := writePath(path, true); err != nil {
 				return err
 			}
 		}
 	}
 	for _, path := range targets.ExtraFiles {
-		if err := writeArchivePath(tw, path); err != nil {
+		if err := writePath(path, true); err != nil {
 			return err
 		}
 	}
@@ -51,6 +72,32 @@ func WriteArchive(w io.Writer, targets TargetSet) error {
 	}
 	return nil
 }
+
+func writeHermesStateDBSnapshot(tw *tar.Writer, stateDB string) error {
+	_, modTime, exists := hermesSQLiteSnapshotIdentity(stateDB)
+	if !exists {
+		return nil
+	}
+	tmpDir, err := os.MkdirTemp("", "agentsview-hermes-snapshot-*")
+	if err != nil {
+		return fmt.Errorf("create hermes snapshot dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	snapshotPath := filepath.Join(tmpDir, "state.db")
+	if err := writeHermesSnapshotFile(snapshotPath, stateDB); err != nil {
+		return fmt.Errorf("snapshot hermes database %q: %w", stateDB, err)
+	}
+	if err := os.Chtimes(snapshotPath, modTime, modTime); err != nil {
+		return fmt.Errorf("stamp hermes database snapshot: %w", err)
+	}
+	info, err := os.Stat(snapshotPath)
+	if err != nil {
+		return fmt.Errorf("stat hermes database snapshot: %w", err)
+	}
+	return writeArchiveFileAs(tw, stateDB, snapshotPath, info)
+}
+
+var writeHermesSnapshotFile = writeSQLiteSnapshot
 
 func writeWindsurfArchiveFiles(tw *tar.Writer, files []string) error {
 	seen := make(map[string]struct{}, len(files))
@@ -68,7 +115,7 @@ func writeWindsurfArchiveFiles(tw *tar.Writer, files []string) error {
 			parser.WindsurfStateDBName + "-shm":
 			continue
 		case "workspace.json":
-			if err := writeOptionalArchivePath(tw, path); err != nil {
+			if err := writeOptionalArchiveFile(tw, path); err != nil {
 				return err
 			}
 		default:
@@ -126,7 +173,7 @@ func windsurfArchiveModTime(info os.FileInfo, dbPath string) time.Time {
 	return mtime
 }
 
-func writeOptionalArchivePath(tw *tar.Writer, path string) error {
+func writeOptionalArchiveFile(tw *tar.Writer, path string) error {
 	info, err := os.Lstat(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -134,13 +181,10 @@ func writeOptionalArchivePath(tw *tar.Writer, path string) error {
 		}
 		return fmt.Errorf("stat archive path %q: %w", path, err)
 	}
-	if info.Mode()&os.ModeSymlink != 0 {
+	if !info.Mode().IsRegular() {
 		return nil
 	}
-	if !info.IsDir() {
-		return writeArchiveFile(tw, path, info)
-	}
-	return writeArchivePath(tw, path)
+	return writeArchiveFile(tw, path, info)
 }
 
 func writeArchivePath(tw *tar.Writer, root string) error {
@@ -285,18 +329,36 @@ func writeArchiveHeader(
 // the next manifest. writeArchivePath is unsuitable here because it
 // fails on a missing root.
 //
-// The allowedRoots re-resolution is defense in depth: callers validate
+// The allowed-target re-resolution is defense in depth: callers validate
 // the file list before reaching here, but the path handed to the
 // filesystem is rebuilt from the trusted root plus a filepath.IsLocal
 // validated relative component, so a client-supplied string can never
 // escape the resolved targets, even if a future caller forgets to
 // validate.
-func WriteArchiveFiles(w io.Writer, allowedRoots, files []string) error {
+func WriteArchiveFiles(w io.Writer, allowed TargetSet, files []string) error {
 	tw := tar.NewWriter(w)
+	allowedRoots := allowed.DeltaAllowedRoots()
+	hermesStateDBs := make(map[string]struct{})
+	for _, stateDB := range hermesStateDBTargets(allowed) {
+		hermesStateDBs[filepath.Clean(stateDB)] = struct{}{}
+	}
+	writtenHermesState := make(map[string]struct{})
 	for _, path := range files {
 		local, ok := resolveDeltaFilePath(allowedRoots, path)
 		if !ok {
 			continue
+		}
+		if stateDB, isHermesSQLite := hermesStateDBForArchivePath(local); isHermesSQLite {
+			stateDB = filepath.Clean(stateDB)
+			if _, allowed := hermesStateDBs[stateDB]; allowed {
+				if _, written := writtenHermesState[stateDB]; !written {
+					writtenHermesState[stateDB] = struct{}{}
+					if err := writeHermesStateDBSnapshot(tw, stateDB); err != nil {
+						return err
+					}
+				}
+				continue
+			}
 		}
 		info, err := os.Lstat(local)
 		if err != nil {

--- a/internal/remotesync/archive_test.go
+++ b/internal/remotesync/archive_test.go
@@ -4,10 +4,12 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"database/sql"
 	"errors"
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -104,25 +106,169 @@ func TestWriteArchiveIgnoresBytesAppendedAfterHeader(t *testing.T) {
 	assert.Equal(t, "old", string(body))
 }
 
-func TestWriteArchiveDoesNotFinalizeAfterPathError(t *testing.T) {
+func TestWriteArchiveToleratesMissingExtraFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "session.jsonl")
 	missing := filepath.Join(dir, "missing.jsonl")
 	require.NoError(t, os.WriteFile(path, []byte("body"), 0o644))
 
 	var buf bytes.Buffer
-	err := WriteArchive(&buf, TargetSet{
+	require.NoError(t, WriteArchive(&buf, TargetSet{
 		ExtraFiles: []string{path, missing},
-	})
+	}))
+	archiveBytes := slices.Clone(buf.Bytes())
 
-	require.Error(t, err)
 	tr := tar.NewReader(&buf)
 	hdr, err := tr.Next()
 	require.NoError(t, err)
 	assert.Equal(t, archiveNameForTest(t, path), hdr.Name)
 	_, err = io.ReadAll(tr)
 	require.NoError(t, err)
-	assert.False(t, hasTarEndMarker(buf.Bytes()))
+	_, err = tr.Next()
+	assert.ErrorIs(t, err, io.EOF)
+	assert.True(t, hasTarEndMarker(archiveBytes))
+}
+
+func TestWriteArchiveSkipsDirectoryValuedExtraFile(t *testing.T) {
+	root := t.TempDir()
+	extraDir := filepath.Join(root, "state.db-wal")
+	require.NoError(t, os.Mkdir(extraDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(extraDir, "credential.txt"), []byte("secret"), 0o600,
+	))
+
+	var buf bytes.Buffer
+	require.NoError(t, WriteArchive(&buf, TargetSet{
+		ExtraFiles: []string{extraDir},
+	}))
+
+	_, err := tar.NewReader(&buf).Next()
+	assert.ErrorIs(t, err, io.EOF)
+}
+
+func TestHermesArchivesSnapshotWALCommitBeforeCheckpoint(t *testing.T) {
+	tests := []struct {
+		name  string
+		write func(io.Writer, string) error
+	}{
+		{
+			name: "full archive",
+			write: func(w io.Writer, stateDB string) error {
+				return WriteArchive(w, TargetSet{
+					Dirs: map[parser.AgentType][]string{
+						parser.AgentHermes: {stateDB},
+					},
+					ExtraFiles: hermesTestSidecars(stateDB),
+				})
+			},
+		},
+		{
+			name: "delta archive",
+			write: func(w io.Writer, stateDB string) error {
+				wal := stateDB + "-wal"
+				allowed := TargetSet{
+					Dirs: map[parser.AgentType][]string{
+						parser.AgentHermes: {stateDB},
+					},
+					ExtraFiles: hermesTestSidecars(stateDB),
+				}
+				return WriteArchiveFiles(w, allowed, []string{stateDB, wal})
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stateDB := filepath.Join(t.TempDir(), "profile", "state.db")
+			require.NoError(t, os.MkdirAll(filepath.Dir(stateDB), 0o755))
+			writeHermesImportStateDB(t, stateDB)
+			writer, err := sql.Open("sqlite3", stateDB)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = writer.Close() })
+			var journalMode string
+			require.NoError(t,
+				writer.QueryRow(`PRAGMA journal_mode = WAL`).Scan(&journalMode))
+			assert.Equal(t, "wal", journalMode)
+			_, err = writer.Exec(`PRAGMA wal_autocheckpoint = 0`)
+			require.NoError(t, err)
+			_, err = writer.Exec(`
+				UPDATE sessions
+				SET title = 'Committed in WAL'
+				WHERE id = 'database-only'
+			`)
+			require.NoError(t, err)
+			wal := stateDB + "-wal"
+			require.FileExists(t, wal)
+
+			stateInfo, err := os.Stat(stateDB)
+			require.NoError(t, err)
+			archiveWriter := newBlockAfterBytesWriter(512 + stateInfo.Size())
+			errCh := make(chan error, 1)
+			go func() { errCh <- tt.write(archiveWriter, stateDB) }()
+
+			select {
+			case <-archiveWriter.blocked:
+			case <-time.After(backgroundWaitTimeout):
+				require.FailNow(t, "archive did not finish its first database entry")
+			}
+			_, checkpointErr := writer.Exec(`PRAGMA wal_checkpoint(TRUNCATE)`)
+			require.NoError(t, checkpointErr)
+			require.NoError(t, writer.Close())
+			if removeErr := os.Remove(wal); !os.IsNotExist(removeErr) {
+				require.NoError(t, removeErr)
+			}
+			close(archiveWriter.proceed)
+			require.NoError(t, <-errCh)
+
+			extracted := t.TempDir()
+			_, err = ExtractTarStream(
+				context.Background(), bytes.NewReader(archiveWriter.Bytes()), extracted,
+			)
+			require.NoError(t, err)
+			extractedDB, err := safeRemappedRemotePath(extracted, stateDB)
+			require.NoError(t, err)
+			snapshot, err := sql.Open("sqlite3", extractedDB)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, snapshot.Close()) })
+			var title string
+			require.NoError(t, snapshot.QueryRow(`
+				SELECT title FROM sessions WHERE id = 'database-only'
+			`).Scan(&title))
+			assert.Equal(t, "Committed in WAL", title)
+			assert.NoFileExists(t, extractedDB+"-wal")
+			assert.NoFileExists(t, extractedDB+"-shm")
+		})
+	}
+}
+
+func TestWriteArchivePropagatesAdvertisedHermesSnapshotFailure(t *testing.T) {
+	stateDB := filepath.Join(t.TempDir(), "profile", "state.db")
+	require.NoError(t, os.MkdirAll(filepath.Dir(stateDB), 0o755))
+	writeHermesImportStateDB(t, stateDB)
+
+	wantErr := errors.New("forced sqlite backup failure")
+	originalSnapshot := writeHermesSnapshotFile
+	writeHermesSnapshotFile = func(dstPath, srcPath string) error {
+		assert.NotEmpty(t, dstPath)
+		assert.Equal(t, stateDB, srcPath)
+		return wantErr
+	}
+	t.Cleanup(func() { writeHermesSnapshotFile = originalSnapshot })
+
+	var archive bytes.Buffer
+	err := WriteArchive(&archive, TargetSet{
+		Dirs: map[parser.AgentType][]string{parser.AgentHermes: {stateDB}},
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+	assert.Contains(t, err.Error(), "snapshot hermes database")
+}
+
+func hermesTestSidecars(stateDB string) []string {
+	return []string{
+		stateDB + "-wal",
+		stateDB + "-shm",
+		stateDB + "-journal",
+	}
 }
 
 func archiveNameForTest(t *testing.T, p string) string {
@@ -135,12 +281,12 @@ func archiveNameForTest(t *testing.T, p string) string {
 func TestExtractTarStreamRejectsArchiveWithoutEndMarker(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "session.jsonl")
-	missing := filepath.Join(dir, "missing.jsonl")
+	invalid := filepath.Join(dir, "invalid\x00path")
 	require.NoError(t, os.WriteFile(path, []byte("body"), 0o644))
 
 	var buf bytes.Buffer
 	err := WriteArchive(&buf, TargetSet{
-		ExtraFiles: []string{path, missing},
+		ExtraFiles: []string{path, invalid},
 	})
 	require.Error(t, err)
 	require.False(t, hasTarEndMarker(buf.Bytes()))
@@ -202,6 +348,45 @@ type blockAfterFirstTarHeaderWriter struct {
 	mu            sync.Mutex
 	total         int
 	blocked       bool
+}
+
+type blockAfterBytesWriter struct {
+	buf     bytes.Buffer
+	blocked chan struct{}
+	proceed chan struct{}
+	blockAt int64
+	total   int64
+	once    sync.Once
+	mu      sync.Mutex
+}
+
+func newBlockAfterBytesWriter(blockAt int64) *blockAfterBytesWriter {
+	return &blockAfterBytesWriter{
+		blocked: make(chan struct{}),
+		proceed: make(chan struct{}),
+		blockAt: blockAt,
+	}
+}
+
+func (w *blockAfterBytesWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	n, err := w.buf.Write(p)
+	w.total += int64(n)
+	shouldBlock := w.total >= w.blockAt
+	w.mu.Unlock()
+	if shouldBlock {
+		w.once.Do(func() {
+			close(w.blocked)
+			<-w.proceed
+		})
+	}
+	return n, err
+}
+
+func (w *blockAfterBytesWriter) Bytes() []byte {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return slices.Clone(w.buf.Bytes())
 }
 
 func newBlockAfterFirstTarHeaderWriter() *blockAfterFirstTarHeaderWriter {
@@ -284,7 +469,9 @@ func TestWriteArchiveFilesSkipsVanishedAndSymlinks(t *testing.T) {
 	gone := filepath.Join(dir, "gone.jsonl")
 
 	var buf bytes.Buffer
-	require.NoError(t, WriteArchiveFiles(&buf, []string{dir}, []string{gone, link, keep}))
+	require.NoError(t, WriteArchiveFiles(&buf, TargetSet{
+		Dirs: map[parser.AgentType][]string{parser.AgentClaude: {dir}},
+	}, []string{gone, link, keep}))
 
 	names := []string{}
 	tr := tar.NewReader(&buf)
@@ -308,7 +495,9 @@ func TestWriteArchiveFilesSkipsFilesOutsideAllowedRoots(t *testing.T) {
 	require.NoError(t, os.WriteFile(outside, []byte("secret"), 0o644))
 
 	var buf bytes.Buffer
-	require.NoError(t, WriteArchiveFiles(&buf, []string{allowed}, []string{inside, outside}))
+	require.NoError(t, WriteArchiveFiles(&buf, TargetSet{
+		Dirs: map[parser.AgentType][]string{parser.AgentClaude: {allowed}},
+	}, []string{inside, outside}))
 
 	names := []string{}
 	tr := tar.NewReader(&buf)
@@ -322,6 +511,27 @@ func TestWriteArchiveFilesSkipsFilesOutsideAllowedRoots(t *testing.T) {
 	}
 	require.Len(t, names, 1, "only the file inside the allowed root is streamed")
 	assert.Contains(t, names[0], "s.jsonl")
+}
+
+func TestWriteArchiveFilesPreservesNonHermesStateDB(t *testing.T) {
+	root := t.TempDir()
+	stateDB := filepath.Join(root, "nested", "state.db")
+	require.NoError(t, os.MkdirAll(filepath.Dir(stateDB), 0o755))
+	require.NoError(t, os.WriteFile(stateDB, []byte("raw non-Hermes state"), 0o644))
+
+	var buf bytes.Buffer
+	require.NoError(t, WriteArchiveFiles(&buf, TargetSet{
+		Dirs:       map[parser.AgentType][]string{parser.AgentClaude: {root}},
+		ExtraFiles: []string{stateDB},
+	}, []string{stateDB}))
+
+	tr := tar.NewReader(&buf)
+	hdr, err := tr.Next()
+	require.NoError(t, err)
+	assert.Equal(t, archiveNameForTest(t, stateDB), hdr.Name)
+	body, err := io.ReadAll(tr)
+	require.NoError(t, err)
+	assert.Equal(t, "raw non-Hermes state", string(body))
 }
 
 func TestResolveDeltaFilePath(t *testing.T) {

--- a/internal/remotesync/http.go
+++ b/internal/remotesync/http.go
@@ -226,6 +226,9 @@ func (hs HTTPSync) downloadIntoMirror(
 			)
 		}
 	}()
+	if err := RemoveMirrorFetchFiles(mirrorRoot, fetch); err != nil {
+		return err
+	}
 	if err := archive.extract(ctx, mirrorRoot, hs.Progress, extractLabel); err != nil {
 		return fmt.Errorf("extract archive into mirror: %w", err)
 	}

--- a/internal/remotesync/http_test.go
+++ b/internal/remotesync/http_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -860,7 +861,7 @@ func newMirrorTestRemote(t *testing.T) *mirrorTestRemote {
 			}
 			if req.DeltaFiles != nil {
 				require.NoError(t, WriteArchiveFiles(
-					w, remote.targets.DeltaAllowedRoots(), req.DeltaFiles))
+					w, remote.targets, req.DeltaFiles))
 			} else {
 				require.NoError(t, WriteArchive(w, req.TargetSet))
 			}
@@ -974,6 +975,148 @@ func TestHTTPSyncMirrorSecondSyncTransfersOnlyDelta(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, remote.archiveRequests, 2)
 	assert.Equal(t, 0, stats.SessionsSynced)
+}
+
+func TestHTTPSyncMirrorRemovesSidecarThatVanishesDuringDeltaArchive(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	base := time.Date(2026, 7, 8, 10, 0, 0, 123456789, time.UTC)
+	remote.writeSession(t, "a.jsonl", base, "session a")
+	remote.writeSession(t, "b.jsonl", base, "session b")
+	remote.writeSession(t, "c.jsonl", base, "session c")
+	wal := filepath.Join(filepath.Dir(remote.dir), "state.db-wal")
+	require.NoError(t, os.WriteFile(wal, []byte("first wal"), 0o644))
+	require.NoError(t, os.Chtimes(wal, base, base))
+	remote.targets.ExtraFiles = []string{wal}
+	dataDir := t.TempDir()
+	_, hs := newMirrorSync(t, remote, dataDir)
+
+	prepared, err := hs.Prepare(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, prepared.Close())
+	localWAL, err := safeRemappedRemotePath(MirrorDir(dataDir, "devbox"), wal)
+	require.NoError(t, err)
+	require.FileExists(t, localWAL)
+
+	require.NoError(t, os.WriteFile(wal, []byte("second wal"), 0o644))
+	require.NoError(t, os.Chtimes(wal, base.Add(time.Second), base.Add(time.Second)))
+	remote.onArchive = func(req ArchiveRequest) {
+		if assert.Equal(t, []string{wal}, req.DeltaFiles) {
+			assert.NoError(t, os.Remove(wal))
+		}
+	}
+
+	prepared, err = hs.Prepare(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, prepared.Close())
+	assert.NoFileExists(t, localWAL)
+}
+
+func TestHTTPSyncMirrorRefreshesStateDBWhenWALVanishesDuringDeltaArchive(t *testing.T) {
+	remote := newMirrorTestRemote(t)
+	profileRoot := filepath.Join(filepath.Dir(remote.dir), "hermes-profile")
+	sessionsDir := filepath.Join(profileRoot, "sessions")
+	stateDB := filepath.Join(profileRoot, "state.db")
+	stateWAL := stateDB + "-wal"
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+	writeHermesImportStateDB(t, stateDB)
+	for i := range 3 {
+		require.NoError(t, os.WriteFile(
+			filepath.Join(sessionsDir, fmt.Sprintf("padding-%d.txt", i)),
+			[]byte("manifest padding\n"),
+			0o644,
+		))
+	}
+	remote.targets = TargetSet{
+		Dirs: map[parser.AgentType][]string{
+			parser.AgentHermes: {sessionsDir},
+		},
+		ExtraFiles: []string{stateDB, stateWAL},
+	}
+
+	writer, err := sql.Open("sqlite3", stateDB)
+	require.NoError(t, err)
+	writer.SetMaxOpenConns(1)
+	var writerCloseOnce stdsync.Once
+	var writerCloseErr error
+	closeWriter := func() error {
+		writerCloseOnce.Do(func() { writerCloseErr = writer.Close() })
+		return writerCloseErr
+	}
+	t.Cleanup(func() { require.NoError(t, closeWriter()) })
+	var journalMode string
+	require.NoError(t, writer.QueryRow(`PRAGMA journal_mode = WAL`).Scan(&journalMode))
+	assert.Equal(t, "wal", journalMode)
+	_, err = writer.Exec(`PRAGMA wal_autocheckpoint = 0`)
+	require.NoError(t, err)
+	_, err = writer.Exec(`PRAGMA user_version = 1`)
+	require.NoError(t, err)
+	require.FileExists(t, stateWAL)
+
+	dataDir := t.TempDir()
+	database, hs := newMirrorSync(t, remote, dataDir)
+	stats, err := hs.Run(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.SessionsSynced)
+	baseline, err := database.GetSession(
+		context.Background(), "devbox~hermes:database-only",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, baseline)
+	require.NotNil(t, baseline.DisplayName)
+	assert.Equal(t, "Database-only profile", *baseline.DisplayName)
+
+	stateBefore, err := os.Stat(stateDB)
+	require.NoError(t, err)
+	_, err = writer.Exec(`
+		UPDATE sessions
+		SET title = 'Checkpointed profile'
+		WHERE id = 'database-only'
+	`)
+	require.NoError(t, err)
+	require.FileExists(t, stateWAL)
+	stateAfter, err := os.Stat(stateDB)
+	require.NoError(t, err)
+	assert.Equal(t, stateBefore.Size(), stateAfter.Size())
+	assert.Equal(t, stateBefore.ModTime(), stateAfter.ModTime(),
+		"the metadata update must remain WAL-only before the second manifest")
+
+	checkpointResult := make(chan error, 1)
+	remote.onArchive = func(ArchiveRequest) {
+		_, checkpointErr := writer.Exec(`PRAGMA wal_checkpoint(TRUNCATE)`)
+		checkpointErr = errors.Join(checkpointErr, closeWriter())
+		if removeErr := os.Remove(stateWAL); !os.IsNotExist(removeErr) {
+			checkpointErr = errors.Join(checkpointErr, removeErr)
+		}
+		checkpointResult <- checkpointErr
+	}
+
+	stats, err = hs.Run(context.Background())
+	require.NoError(t, err)
+	select {
+	case checkpointErr := <-checkpointResult:
+		require.NoError(t, checkpointErr)
+	case <-time.After(backgroundWaitTimeout):
+		require.FailNow(t, "archive hook did not checkpoint the Hermes database")
+	}
+	require.Len(t, remote.archiveRequests, 2)
+	assert.Equal(t, []string{stateDB}, remote.archiveRequests[1].DeltaFiles)
+	localWAL, err := safeRemappedRemotePath(MirrorDir(dataDir, "devbox"), stateWAL)
+	require.NoError(t, err)
+	assert.NoFileExists(t, localWAL)
+
+	refreshed, err := database.GetSession(
+		context.Background(), "devbox~hermes:database-only",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, refreshed)
+	require.NotNil(t, refreshed.DisplayName)
+	assert.Equal(t, "Checkpointed profile", *refreshed.DisplayName)
+
+	stats, err = hs.Run(context.Background())
+	require.NoError(t, err)
+	assert.Zero(t, stats.SessionsSynced)
+	assert.Len(t, remote.archiveRequests, 2,
+		"an unchanged standalone snapshot must match the consolidated manifest")
 }
 
 func TestHTTPSyncFallsBackToLegacyWhenManifestMissing(t *testing.T) {

--- a/internal/remotesync/import.go
+++ b/internal/remotesync/import.go
@@ -80,6 +80,23 @@ func newImportLayout(targets TargetSet, root string) (importLayout, error) {
 			layout.paths.localDirs = append(layout.paths.localDirs, local)
 		}
 	}
+	// Extra files (e.g. a Hermes profile's state.db and its SQLite
+	// companions) are transferred alongside the transcript dirs but are
+	// not enumerated in Dirs. Without an exact mapping here, the archive's
+	// authoritative fingerprint path (state.db) has no remote translation:
+	// the skip-cache entry is discarded after every import, forcing a full
+	// re-fingerprint, and the fallback path rewriter stores synthetic
+	// paths like /__drive_C/... instead of the original remote path on
+	// Windows/UNC remotes. Registering each extra file as its own
+	// remote->local pair fixes both the skip cache and the rewriter.
+	for _, remoteFile := range targets.ExtraFiles {
+		local, err := safeRemappedRemotePath(root, remoteFile)
+		if err != nil {
+			return importLayout{}, err
+		}
+		layout.paths.remoteDirs = append(layout.paths.remoteDirs, remoteFile)
+		layout.paths.localDirs = append(layout.paths.localDirs, local)
+	}
 	return layout, nil
 }
 

--- a/internal/remotesync/import_test.go
+++ b/internal/remotesync/import_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -209,6 +210,219 @@ func TestImporterImportsExtractedRemoteFiles(t *testing.T) {
 	require.NotNil(t, full)
 	require.NotNil(t, full.FilePath)
 	assert.Contains(t, *full.FilePath, "devbox:/home/wes/.claude/projects/test-project/session.jsonl")
+}
+
+func TestImporterImportsHermesDatabaseOnlySession(t *testing.T) {
+	database, err := db.Open(filepath.Join(t.TempDir(), "test.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+
+	extracted := t.TempDir()
+	remoteSessionsDir := "/home/remote/.hermes/profiles/research/sessions"
+	remoteStateDB := "/home/remote/.hermes/profiles/research/state.db"
+	localStateDB := remappedRemotePath(extracted, remoteStateDB)
+	require.NoError(t, os.MkdirAll(filepath.Dir(localStateDB), 0o755))
+	require.NoError(t, os.MkdirAll(
+		remappedRemotePath(extracted, remoteSessionsDir), 0o755,
+	))
+	writeHermesImportStateDB(t, localStateDB)
+
+	stats, err := Importer{
+		Host: "devbox",
+		DB:   database,
+	}.ImportExtracted(context.Background(), TargetSet{
+		Dirs: map[parser.AgentType][]string{
+			parser.AgentHermes: {remoteSessionsDir},
+		},
+	}, extracted)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.SessionsSynced)
+	session, err := database.GetSession(
+		context.Background(), "devbox~hermes:database-only",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, session)
+	require.NotNil(t, session.DisplayName)
+	assert.Equal(t, "Database-only profile", *session.DisplayName)
+	require.NotNil(t, session.ParentSessionID)
+	assert.Equal(t, "devbox~hermes:parent", *session.ParentSessionID)
+	assert.Equal(t, 70, session.TotalOutputTokens)
+	assert.Equal(t, 320, session.PeakContextTokens)
+}
+
+func writeHermesImportStateDB(t *testing.T, path string) {
+	t.Helper()
+	stateDB, err := sql.Open("sqlite3", path)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, stateDB.Close()) }()
+
+	_, err = stateDB.Exec(`
+		CREATE TABLE sessions (
+			id TEXT PRIMARY KEY,
+			source TEXT NOT NULL,
+			model TEXT,
+			parent_session_id TEXT,
+			started_at REAL NOT NULL,
+			ended_at REAL,
+			message_count INTEGER DEFAULT 0,
+			input_tokens INTEGER DEFAULT 0,
+			output_tokens INTEGER DEFAULT 0,
+			cache_read_tokens INTEGER DEFAULT 0,
+			cache_write_tokens INTEGER DEFAULT 0,
+			reasoning_tokens INTEGER DEFAULT 0,
+			estimated_cost_usd REAL,
+			actual_cost_usd REAL,
+			cost_status TEXT,
+			cost_source TEXT,
+			title TEXT,
+			api_call_count INTEGER DEFAULT 0
+		);
+		CREATE TABLE messages (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			session_id TEXT NOT NULL,
+			role TEXT NOT NULL,
+			content TEXT,
+			tool_call_id TEXT,
+			tool_calls TEXT,
+			timestamp REAL NOT NULL,
+			finish_reason TEXT,
+			reasoning TEXT,
+			reasoning_content TEXT,
+			reasoning_details TEXT,
+			codex_reasoning_items TEXT,
+			codex_message_items TEXT
+		);
+		INSERT INTO sessions (
+			id, source, model, parent_session_id, started_at, ended_at,
+			message_count, input_tokens, output_tokens, cache_read_tokens,
+			title
+		) VALUES (
+			'database-only', 'cli', 'gpt-5.4', 'parent',
+			1778767200.0, 1778767800.0, 1, 300, 70, 20,
+			'Database-only profile'
+		);
+		INSERT INTO messages (session_id, role, content, timestamp)
+		VALUES ('database-only', 'user', 'database-only message', 1778767210.0);
+	`)
+	require.NoError(t, err)
+}
+
+// TestImporterMapsHermesStateDBExtraFileAndRefreshesWALChanges verifies both
+// remote archive path translation and repeated-import freshness. A committed
+// WAL-only metadata update must invalidate the skip entry even though the main
+// state.db file remains unchanged.
+func TestImporterMapsHermesStateDBExtraFileAndRefreshesWALChanges(t *testing.T) {
+	database, err := db.Open(filepath.Join(t.TempDir(), "test.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+
+	extracted := t.TempDir()
+	remoteSessionsDir := "/home/remote/.hermes/profiles/research/sessions"
+	remoteStateDB := "/home/remote/.hermes/profiles/research/state.db"
+	localStateDB := remappedRemotePath(extracted, remoteStateDB)
+	require.NoError(t, os.MkdirAll(filepath.Dir(localStateDB), 0o755))
+	require.NoError(t, os.MkdirAll(
+		remappedRemotePath(extracted, remoteSessionsDir), 0o755,
+	))
+	writeHermesImportStateDB(t, localStateDB)
+	writer := openHermesImportWALWriter(t, localStateDB)
+	remoteStateWAL := remoteStateDB + "-wal"
+
+	targets := TargetSet{
+		Dirs: map[parser.AgentType][]string{
+			parser.AgentHermes: {remoteSessionsDir},
+		},
+		ExtraFiles: []string{remoteStateDB, remoteStateWAL},
+	}
+
+	stats, err := Importer{
+		Host: "devbox",
+		DB:   database,
+	}.ImportExtracted(context.Background(), targets, extracted)
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.SessionsSynced)
+
+	full, err := database.GetSessionFull(
+		context.Background(), "devbox~hermes:database-only",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, full)
+	require.NotNil(t, full.FilePath)
+	assert.Equal(t, "devbox:"+remoteStateDB, *full.FilePath,
+		"state.db extra file must map to its original remote path")
+	assert.NotContains(t, *full.FilePath, extracted,
+		"the import must not leak the local extraction dir into FilePath")
+
+	// A second import of the unchanged archive must skip the state.db and
+	// persist its skip entry keyed by the remote path. Without the
+	// extra-file mapping the local temp path cannot be translated back, so
+	// the entry is silently dropped and the archive is re-fingerprinted on
+	// every subsequent sync.
+	second, err := Importer{
+		Host: "devbox",
+		DB:   database,
+	}.ImportExtracted(context.Background(), targets, extracted)
+	require.NoError(t, err)
+	assert.Zero(t, second.SessionsSynced,
+		"unchanged state.db must not re-sync on the second import")
+
+	remoteCache, err := database.LoadRemoteSkippedFiles("devbox")
+	require.NoError(t, err)
+	require.NotEmpty(t, remoteCache,
+		"the state.db skip entry must survive the import, not be discarded")
+	_, ok := remoteCache[remoteStateDB]
+	assert.True(t, ok,
+		"skip cache must key the state.db entry by its remote path, got %v",
+		remoteCache)
+
+	stateBefore, err := os.Stat(localStateDB)
+	require.NoError(t, err)
+	_, err = writer.Exec(`
+		UPDATE sessions
+		SET title = 'WAL-refreshed profile'
+		WHERE id = 'database-only'
+	`)
+	require.NoError(t, err)
+	localStateWAL := remappedRemotePath(extracted, remoteStateWAL)
+	require.FileExists(t, localStateWAL)
+	stateAfter, err := os.Stat(localStateDB)
+	require.NoError(t, err)
+	assert.Equal(t, stateBefore.Size(), stateAfter.Size())
+	assert.Equal(t, stateBefore.ModTime(), stateAfter.ModTime(),
+		"the committed update must remain WAL-only for this regression")
+	walTime := stateAfter.ModTime().Add(2 * time.Second)
+	require.NoError(t, os.Chtimes(localStateWAL, walTime, walTime))
+
+	changed, err := Importer{
+		Host: "devbox",
+		DB:   database,
+	}.ImportExtracted(context.Background(), targets, extracted)
+	require.NoError(t, err)
+	assert.Equal(t, 1, changed.SessionsSynced,
+		"a WAL-only commit must invalidate the remote archive skip entry")
+	refreshed, err := database.GetSession(
+		context.Background(), "devbox~hermes:database-only",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, refreshed)
+	require.NotNil(t, refreshed.DisplayName)
+	assert.Equal(t, "WAL-refreshed profile", *refreshed.DisplayName)
+}
+
+func openHermesImportWALWriter(t *testing.T, stateDB string) *sql.DB {
+	t.Helper()
+	writer, err := sql.Open("sqlite3", stateDB)
+	require.NoError(t, err)
+	writer.SetMaxOpenConns(1)
+	t.Cleanup(func() { require.NoError(t, writer.Close()) })
+
+	var journalMode string
+	require.NoError(t, writer.QueryRow(`PRAGMA journal_mode = WAL`).Scan(&journalMode))
+	assert.Equal(t, "wal", journalMode)
+	_, err = writer.Exec(`PRAGMA wal_autocheckpoint = 0`)
+	require.NoError(t, err)
+	return writer
 }
 
 func TestRemotePathMappingHandlesWindowsDrivePath(t *testing.T) {

--- a/internal/remotesync/manifest.go
+++ b/internal/remotesync/manifest.go
@@ -41,6 +41,13 @@ func BuildManifest(targets TargetSet) (Manifest, error) {
 			"manifest not supported for sanitized file-scoped agents")
 	}
 	m := Manifest{Files: []ManifestEntry{}}
+	hermesStateDBs := hermesStateDBTargets(targets)
+	hermesSQLite := make(map[string]struct{}, len(hermesStateDBs)*4)
+	for _, stateDB := range hermesStateDBs {
+		for _, path := range hermesSQLitePaths(stateDB) {
+			hermesSQLite[path] = struct{}{}
+		}
+	}
 	add := func(path string, info os.FileInfo) {
 		m.Files = append(m.Files, ManifestEntry{
 			Path:    path,
@@ -66,6 +73,9 @@ func BuildManifest(targets TargetSet) (Manifest, error) {
 			continue
 		}
 		for _, root := range dirs {
+			if _, ok := hermesSQLite[filepath.Clean(root)]; ok {
+				continue
+			}
 			if err := manifestWalk(root, add); err != nil {
 				return Manifest{}, err
 			}
@@ -73,14 +83,28 @@ func BuildManifest(targets TargetSet) (Manifest, error) {
 	}
 	for _, files := range targets.Files {
 		for _, path := range files {
+			if _, ok := hermesSQLite[filepath.Clean(path)]; ok {
+				continue
+			}
 			if err := addLstat(path); err != nil {
 				return Manifest{}, err
 			}
 		}
 	}
 	for _, path := range targets.ExtraFiles {
+		if _, ok := hermesSQLite[filepath.Clean(path)]; ok {
+			continue
+		}
 		if err := addLstat(path); err != nil {
 			return Manifest{}, err
+		}
+	}
+	for _, stateDB := range hermesStateDBs {
+		size, modTime, exists := hermesSQLiteSnapshotIdentity(stateDB)
+		if exists {
+			m.Files = append(m.Files, ManifestEntry{
+				Path: stateDB, Size: size, MtimeNS: modTime.UnixNano(),
+			})
 		}
 	}
 	sort.Slice(m.Files, func(i, j int) bool {

--- a/internal/remotesync/manifest_test.go
+++ b/internal/remotesync/manifest_test.go
@@ -1,6 +1,12 @@
 package remotesync
 
 import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -60,4 +66,90 @@ func TestBuildManifestRejectsFileScopedAgents(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "file-scoped")
+}
+
+func TestHermesManifestMatchesStandaloneDatabaseSnapshot(t *testing.T) {
+	stateDB := filepath.Join(t.TempDir(), "profile", "state.db")
+	require.NoError(t, os.MkdirAll(filepath.Dir(stateDB), 0o755))
+	sessionsDir := filepath.Join(filepath.Dir(stateDB), "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+	writeHermesImportStateDB(t, stateDB)
+	writer, err := sql.Open("sqlite3", stateDB)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = writer.Close() })
+	var journalMode string
+	require.NoError(t,
+		writer.QueryRow(`PRAGMA journal_mode = WAL`).Scan(&journalMode))
+	assert.Equal(t, "wal", journalMode)
+	_, err = writer.Exec(`PRAGMA wal_autocheckpoint = 0`)
+	require.NoError(t, err)
+	_, err = writer.Exec(`
+		UPDATE sessions
+		SET title = 'Manifest includes WAL commit'
+		WHERE id = 'database-only'
+	`)
+	require.NoError(t, err)
+	wal := stateDB + "-wal"
+	require.FileExists(t, wal)
+	walTime := time.Now().Add(2 * time.Second)
+	require.NoError(t, os.Chtimes(wal, walTime, walTime))
+	targets := TargetSet{
+		Dirs: map[parser.AgentType][]string{
+			parser.AgentHermes: {sessionsDir},
+		},
+		ExtraFiles: append([]string{stateDB}, hermesTestSidecars(stateDB)...),
+	}
+
+	manifest, err := BuildManifest(targets)
+	require.NoError(t, err)
+	require.Len(t, manifest.Files, 1)
+	assert.Equal(t, stateDB, manifest.Files[0].Path)
+
+	var archive bytes.Buffer
+	require.NoError(t, WriteArchive(&archive, targets))
+	extracted := t.TempDir()
+	_, err = ExtractTarStream(context.Background(), &archive, extracted)
+	require.NoError(t, err)
+	extractedDB, err := safeRemappedRemotePath(extracted, stateDB)
+	require.NoError(t, err)
+	info, err := os.Stat(extractedDB)
+	require.NoError(t, err)
+	assert.Equal(t, manifest.Files[0].Size, info.Size())
+	assert.Equal(t, manifest.Files[0].MtimeNS, info.ModTime().UnixNano())
+}
+
+func TestInvalidHermesStateDBDoesNotBlockTranscriptArchive(t *testing.T) {
+	profile := t.TempDir()
+	sessionsDir := filepath.Join(profile, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+	transcript := filepath.Join(sessionsDir, "session.json")
+	require.NoError(t, os.WriteFile(transcript, []byte(`{"id":"session"}`), 0o644))
+	stateDB := filepath.Join(profile, "state.db")
+	require.NoError(t, os.WriteFile(stateDB, []byte("not sqlite"), 0o644))
+	targets := TargetSet{
+		Dirs: map[parser.AgentType][]string{
+			parser.AgentHermes: {sessionsDir},
+		},
+		ExtraFiles: append([]string{stateDB}, hermesTestSidecars(stateDB)...),
+	}
+
+	manifest, err := BuildManifest(targets)
+	require.NoError(t, err)
+	require.Len(t, manifest.Files, 1)
+	assert.Equal(t, transcript, manifest.Files[0].Path)
+
+	var archive bytes.Buffer
+	require.NoError(t, WriteArchive(&archive, targets))
+	tr := tar.NewReader(&archive)
+	var names []string
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+		names = append(names, hdr.Name)
+	}
+	assert.Contains(t, names, archiveNameForTest(t, transcript))
+	assert.NotContains(t, names, archiveNameForTest(t, stateDB))
 }

--- a/internal/remotesync/mirror.go
+++ b/internal/remotesync/mirror.go
@@ -184,6 +184,31 @@ func RemoveMirrorTypeConflicts(mirrorRoot string, fetch []string) error {
 	return nil
 }
 
+// RemoveMirrorFetchFiles evicts the old mirror copy of each requested file
+// after its replacement archive has downloaded successfully. A live remote
+// file can disappear after the manifest advertised it; archive writers omit
+// that vanished file, and removing the old copy ensures it cannot remain as a
+// stale SQLite sidecar. The next extraction restores every file that was
+// actually present in the downloaded archive.
+func RemoveMirrorFetchFiles(mirrorRoot string, fetch []string) error {
+	for _, remotePath := range fetch {
+		local, err := safeRemappedRemotePath(mirrorRoot, remotePath)
+		if err != nil {
+			return fmt.Errorf("fetch path %q: %w", remotePath, err)
+		}
+		if local == mirrorRoot || !within(mirrorRoot, local) {
+			return fmt.Errorf(
+				"mirror fetch eviction %q escapes mirror root %q", local, mirrorRoot,
+			)
+		}
+		if err := os.Remove(local); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("evict mirror file %q: %w", local, err)
+		}
+		pruneEmptyMirrorDirs(mirrorRoot, filepath.Dir(local))
+	}
+	return nil
+}
+
 // pruneEmptyMirrorDirs best-effort removes now-empty directories from
 // dir upward, never including the mirror root itself. os.Remove fails
 // on a non-empty directory, which terminates the walk.

--- a/internal/remotesync/resolve.go
+++ b/internal/remotesync/resolve.go
@@ -21,6 +21,18 @@ func ResolveTargets(cfg config.Config) TargetSet {
 			continue
 		}
 		for _, dir := range cfg.ResolveDirs(def.Type) {
+			if def.Type == parser.AgentHermes {
+				hermesDirs, hermesFiles := resolveHermesTargets(dir)
+				if len(hermesDirs) > 0 {
+					dirs[def.Type] = append(dirs[def.Type], hermesDirs...)
+				}
+				for _, file := range hermesFiles {
+					if !slices.Contains(extra, file) {
+						extra = append(extra, file)
+					}
+				}
+				continue
+			}
 			if def.Type == parser.AgentAider {
 				targets := resolveAiderTargets(dir)
 				if len(targets) > 0 {
@@ -59,6 +71,97 @@ func ResolveTargets(cfg config.Config) TargetSet {
 		}
 	}
 	return TargetSet{Dirs: dirs, Files: files, ExtraFiles: extra}
+}
+
+func resolveHermesTargets(root string) ([]string, []string) {
+	root = filepath.Clean(root)
+	if filepath.Base(root) != "profiles" ||
+		filepath.Base(filepath.Dir(root)) != ".hermes" {
+		return resolveHermesArchiveTarget(root, !isHermesNamedProfileRoot(root))
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, nil
+	}
+	var dirs []string
+	var files []string
+	for _, entry := range entries {
+		if !entry.IsDir() || entry.Type()&os.ModeSymlink != 0 {
+			continue
+		}
+		profileDirs, profileFiles := resolveHermesArchiveTarget(
+			filepath.Join(root, entry.Name()), false,
+		)
+		dirs = append(dirs, profileDirs...)
+		files = append(files, profileFiles...)
+	}
+	return dirs, files
+}
+
+func isHermesNamedProfileRoot(root string) bool {
+	parent := filepath.Dir(filepath.Clean(root))
+	return filepath.Base(parent) == "profiles" &&
+		filepath.Base(filepath.Dir(parent)) == ".hermes"
+}
+
+func resolveHermesArchiveTarget(root string, allowFlat bool) ([]string, []string) {
+	root = filepath.Clean(root)
+	sessionsDir := filepath.Join(root, "sessions")
+	stateDB := filepath.Join(root, "state.db")
+	if allowFlat {
+		switch filepath.Base(root) {
+		case "sessions":
+			sessionsDir = root
+			stateDB = filepath.Join(filepath.Dir(root), "state.db")
+		case "state.db":
+			sessionsDir = filepath.Join(filepath.Dir(root), "sessions")
+			stateDB = root
+		}
+	}
+
+	if info, err := os.Stat(sessionsDir); err == nil && info.IsDir() {
+		return []string{sessionsDir}, hermesStateFiles(stateDB, true)
+	}
+	if regularRemoteSyncFile(stateDB) {
+		return []string{stateDB}, hermesStateFiles(stateDB, false)
+	}
+	if allowFlat && hasHermesTranscriptFile(root) {
+		return []string{root}, nil
+	}
+	return nil, nil
+}
+
+func hasHermesTranscriptFile(root string) bool {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return false
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || entry.Type()&os.ModeSymlink != 0 {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".jsonl") &&
+			(!strings.HasPrefix(name, "session_") || !strings.HasSuffix(name, ".json")) {
+			continue
+		}
+		if regularRemoteSyncFile(filepath.Join(root, name)) {
+			return true
+		}
+	}
+	return false
+}
+
+// hermesStateFiles returns stable, narrowly scoped allowlist paths. SQLite
+// companions are transient, so their presence must not change the target set
+// between the targets, manifest, and archive requests. Archive and manifest
+// writers treat absent entries as optional.
+func hermesStateFiles(stateDB string, includeDB bool) []string {
+	files := []string{stateDB + "-wal", stateDB + "-shm", stateDB + "-journal"}
+	if includeDB {
+		files = append([]string{stateDB}, files...)
+	}
+	return files
 }
 
 func resolveAgentHasOnDiskSource(def parser.AgentDef) bool {

--- a/internal/remotesync/resolve_test.go
+++ b/internal/remotesync/resolve_test.go
@@ -98,6 +98,83 @@ func TestResolveTargetsExcludesTraeProfile(t *testing.T) {
 	assert.Equal(t, []string{claudeRoot}, targets.Dirs[parser.AgentClaude])
 }
 
+func TestResolveTargetsExpandsHermesProfilesWithDatabaseFiles(t *testing.T) {
+	profilesRoot := filepath.Join(t.TempDir(), ".hermes", "profiles")
+	withSessions := filepath.Join(profilesRoot, "research")
+	databaseOnly := filepath.Join(profilesRoot, "database-only")
+	require.NoError(t, os.MkdirAll(filepath.Join(withSessions, "sessions"), 0o755))
+	require.NoError(t, os.MkdirAll(databaseOnly, 0o755))
+	for _, path := range []string{
+		filepath.Join(withSessions, "state.db"),
+		filepath.Join(withSessions, "state.db-wal"),
+		filepath.Join(withSessions, "state.db-shm"),
+		filepath.Join(withSessions, "state.db-journal"),
+		filepath.Join(databaseOnly, "state.db"),
+	} {
+		require.NoError(t, os.WriteFile(path, []byte("sqlite"), 0o644))
+	}
+
+	targets := remotesync.ResolveTargets(config.Config{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentHermes: {profilesRoot},
+		},
+	})
+
+	assert.ElementsMatch(t, []string{
+		filepath.Join(withSessions, "sessions"),
+		filepath.Join(databaseOnly, "state.db"),
+	}, targets.Dirs[parser.AgentHermes])
+	assert.ElementsMatch(t, []string{
+		filepath.Join(withSessions, "state.db"),
+		filepath.Join(withSessions, "state.db-wal"),
+		filepath.Join(withSessions, "state.db-shm"),
+		filepath.Join(withSessions, "state.db-journal"),
+		filepath.Join(databaseOnly, "state.db-wal"),
+		filepath.Join(databaseOnly, "state.db-shm"),
+		filepath.Join(databaseOnly, "state.db-journal"),
+	}, targets.ExtraFiles)
+}
+
+func TestResolveTargetsIncludesFlatCustomHermesRoot(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "custom", "hermes-archive")
+	require.NoError(t, os.MkdirAll(root, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "child.jsonl"), []byte("{}\n"), 0o644,
+	))
+
+	targets := remotesync.ResolveTargets(config.Config{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentHermes: {root},
+		},
+	})
+
+	assert.Equal(t, []string{root}, targets.Dirs[parser.AgentHermes])
+	assert.Empty(t, targets.ExtraFiles)
+}
+
+func TestResolveTargetsSkipsSessionlessHermesProfileCredentials(t *testing.T) {
+	profileRoot := filepath.Join(t.TempDir(), ".hermes", "profiles", "sessions")
+	require.NoError(t, os.MkdirAll(profileRoot, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(profileRoot, ".env"), []byte("TOKEN=secret\n"), 0o600,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(profileRoot, "auth.json"), []byte(`{"token":"secret"}`), 0o600,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(profileRoot, "debug.jsonl"), []byte("not a session\n"), 0o600,
+	))
+
+	targets := remotesync.ResolveTargets(config.Config{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentHermes: {profileRoot},
+		},
+	})
+
+	assert.NotContains(t, targets.Dirs, parser.AgentHermes)
+	assert.Empty(t, targets.ExtraFiles)
+}
+
 func TestResolveTargetsSkipsAiderHomeRoot(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("os.UserHomeDir does not use HOME on Windows")
@@ -502,7 +579,7 @@ func TestRooCodeRemoteSyncExportsOnlySessionFiles(t *testing.T) {
 	require.True(t, ok, "a curated transcript must validate as a delta request")
 	var delta bytes.Buffer
 	require.NoError(t, remotesync.WriteArchiveFiles(
-		&delta, targets.DeltaAllowedRoots(), files))
+		&delta, targets, files))
 	deltaNames := []string{}
 	dr := tar.NewReader(&delta)
 	for {
@@ -593,7 +670,7 @@ func TestRooCodeRemoteSyncToleratesVanishedSessionFile(t *testing.T) {
 		"a vanished session file must validate as a delta request")
 	var delta bytes.Buffer
 	require.NoError(t, remotesync.WriteArchiveFiles(
-		&delta, freshServerTargets.DeltaAllowedRoots(), files))
+		&delta, freshServerTargets, files))
 	dr := tar.NewReader(&delta)
 	_, err = dr.Next()
 	assert.Equal(t, io.EOF, err, "the vanished file streams nothing")

--- a/internal/remotesync/sqlite_snapshot.go
+++ b/internal/remotesync/sqlite_snapshot.go
@@ -1,0 +1,200 @@
+package remotesync
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/mattn/go-sqlite3"
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+const sqliteSnapshotBusyTimeoutMS = 5000
+
+func writeSQLiteSnapshot(dstPath, srcPath string) (err error) {
+	if err := os.Remove(dstPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("replace sqlite snapshot: %w", err)
+	}
+	src, err := sql.Open("sqlite3", sqliteReadOnlyDSN(srcPath))
+	if err != nil {
+		return fmt.Errorf("open sqlite snapshot source: %w", err)
+	}
+	defer func() { err = errors.Join(err, src.Close()) }()
+	dst, err := sql.Open("sqlite3", dstPath)
+	if err != nil {
+		return fmt.Errorf("open sqlite snapshot destination: %w", err)
+	}
+	complete := false
+	defer func() {
+		err = errors.Join(err, dst.Close())
+		if !complete {
+			_ = os.Remove(dstPath)
+		}
+	}()
+
+	srcConn, err := src.Conn(context.Background())
+	if err != nil {
+		return fmt.Errorf("connect sqlite snapshot source: %w", err)
+	}
+	defer func() { err = errors.Join(err, srcConn.Close()) }()
+	dstConn, err := dst.Conn(context.Background())
+	if err != nil {
+		return fmt.Errorf("connect sqlite snapshot destination: %w", err)
+	}
+	defer func() { err = errors.Join(err, dstConn.Close()) }()
+
+	err = dstConn.Raw(func(dstDriver any) error {
+		dstSQLite, ok := dstDriver.(*sqlite3.SQLiteConn)
+		if !ok {
+			return fmt.Errorf("sqlite snapshot destination is %T", dstDriver)
+		}
+		return srcConn.Raw(func(srcDriver any) error {
+			srcSQLite, ok := srcDriver.(*sqlite3.SQLiteConn)
+			if !ok {
+				return fmt.Errorf("sqlite snapshot source is %T", srcDriver)
+			}
+			backup, err := dstSQLite.Backup("main", srcSQLite, "main")
+			if err != nil {
+				return fmt.Errorf("start sqlite online backup: %w", err)
+			}
+			done, stepErr := backup.Step(-1)
+			finishErr := backup.Finish()
+			if stepErr != nil || finishErr != nil {
+				return fmt.Errorf(
+					"copy sqlite online backup: %w",
+					errors.Join(stepErr, finishErr),
+				)
+			}
+			if !done {
+				return fmt.Errorf("copy sqlite online backup: backup incomplete")
+			}
+			return nil
+		})
+	})
+	if err != nil {
+		return err
+	}
+	if _, err := dstConn.ExecContext(
+		context.Background(), `PRAGMA journal_mode = DELETE`,
+	); err != nil {
+		return fmt.Errorf("finalize standalone sqlite snapshot: %w", err)
+	}
+	complete = true
+	return nil
+}
+
+func sqliteSnapshotIdentity(path string) (int64, time.Time, bool, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, time.Time{}, false, nil
+		}
+		return 0, time.Time{}, false, fmt.Errorf("stat sqlite database %q: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return 0, time.Time{}, false, nil
+	}
+	conn, err := sql.Open("sqlite3", sqliteReadOnlyDSN(path))
+	if err != nil {
+		return 0, time.Time{}, false, fmt.Errorf("open sqlite database %q: %w", path, err)
+	}
+	defer conn.Close()
+	var pageSize, pageCount int64
+	if err := conn.QueryRow(`PRAGMA page_size`).Scan(&pageSize); err != nil {
+		return 0, time.Time{}, false, fmt.Errorf("read sqlite page size %q: %w", path, err)
+	}
+	if err := conn.QueryRow(`PRAGMA page_count`).Scan(&pageCount); err != nil {
+		return 0, time.Time{}, false, fmt.Errorf("read sqlite page count %q: %w", path, err)
+	}
+	return pageSize * pageCount, sqliteSnapshotModTime(path, info.ModTime()), true, nil
+}
+
+// hermesSQLiteSnapshotIdentity treats an unusable state database as an
+// optional missing archive component. Hermes transcripts remain independently
+// useful, and a later sync can retry the database after the writer repairs or
+// replaces it.
+func hermesSQLiteSnapshotIdentity(path string) (int64, time.Time, bool) {
+	size, modTime, exists, err := sqliteSnapshotIdentity(path)
+	if err != nil {
+		return 0, time.Time{}, false
+	}
+	return size, modTime, exists
+}
+
+func sqliteSnapshotModTime(stateDB string, modTime time.Time) time.Time {
+	for _, suffix := range []string{"-wal", "-journal"} {
+		info, err := os.Lstat(stateDB + suffix)
+		if err == nil && info.Mode().IsRegular() && info.ModTime().After(modTime) {
+			modTime = info.ModTime()
+		}
+	}
+	return modTime
+}
+
+func sqliteReadOnlyDSN(path string) string {
+	escaped := strings.NewReplacer(
+		"%", "%25",
+		"?", "%3F",
+		"#", "%23",
+	).Replace(path)
+	return fmt.Sprintf(
+		"file:%s?mode=ro&_busy_timeout=%d", escaped, sqliteSnapshotBusyTimeoutMS,
+	)
+}
+
+func hermesStateDBTargets(targets TargetSet) []string {
+	extraFiles := make(map[string]struct{}, len(targets.ExtraFiles))
+	for _, path := range targets.ExtraFiles {
+		extraFiles[filepath.Clean(path)] = struct{}{}
+	}
+	seen := make(map[string]struct{})
+	for _, root := range targets.Dirs[parser.AgentHermes] {
+		clean := filepath.Clean(root)
+		switch filepath.Base(clean) {
+		case "state.db":
+			seen[clean] = struct{}{}
+		case "sessions":
+			stateDB := filepath.Join(filepath.Dir(clean), "state.db")
+			if _, ok := extraFiles[stateDB]; ok {
+				seen[stateDB] = struct{}{}
+			}
+		}
+	}
+	paths := make([]string, 0, len(seen))
+	for path := range seen {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func hermesSQLitePaths(stateDB string) []string {
+	return []string{
+		filepath.Clean(stateDB),
+		filepath.Clean(stateDB + "-wal"),
+		filepath.Clean(stateDB + "-shm"),
+		filepath.Clean(stateDB + "-journal"),
+	}
+}
+
+func hermesStateDBForArchivePath(path string) (string, bool) {
+	path = filepath.Clean(path)
+	switch filepath.Base(path) {
+	case "state.db":
+		return path, true
+	case "state.db-wal":
+		return strings.TrimSuffix(path, "-wal"), true
+	case "state.db-shm":
+		return strings.TrimSuffix(path, "-shm"), true
+	case "state.db-journal":
+		return strings.TrimSuffix(path, "-journal"), true
+	default:
+		return "", false
+	}
+}

--- a/internal/remotesync/types.go
+++ b/internal/remotesync/types.go
@@ -98,8 +98,8 @@ func (t TargetSet) SplitFileScoped() (dirScoped, fileScoped TargetSet) {
 // their raw directory is never a prefix root, so settings and caches
 // stay unreachable), plus the extra files. Sanitized file-scoped
 // agents (Windsurf) contribute nothing because their raw tree is
-// never delta-streamed. WriteArchiveFiles re-checks each requested
-// file against these roots before reading it.
+// never delta-streamed. WriteArchiveFiles uses these roots while
+// retaining the TargetSet's agent ownership information.
 func (t TargetSet) DeltaAllowedRoots() []string {
 	roots := make([]string, 0, len(t.Dirs)+len(t.Files)+len(t.ExtraFiles))
 	for agent, dirs := range t.Dirs {

--- a/internal/server/huma_routes_remote_sync.go
+++ b/internal/server/huma_routes_remote_sync.go
@@ -126,7 +126,7 @@ func (s *Server) remoteSyncArchiveHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	var err error
 	if deltaMode {
-		err = remotesync.WriteArchiveFiles(out, allowed.DeltaAllowedRoots(), files)
+		err = remotesync.WriteArchiveFiles(out, allowed, files)
 	} else {
 		err = remotesync.WriteArchive(out, archiveTargets)
 	}

--- a/internal/server/huma_routes_remote_sync_internal_test.go
+++ b/internal/server/huma_routes_remote_sync_internal_test.go
@@ -107,6 +107,239 @@ func TestRemoteSyncArchiveStreamsTar(t *testing.T) {
 	}
 }
 
+func TestRemoteSyncHermesSessionlessProfileCannotExposeCredentials(t *testing.T) {
+	dir := t.TempDir()
+	database := dbtest.OpenTestDBAt(t, filepath.Join(dir, "test.db"))
+	profileRoot := filepath.Join(dir, ".hermes", "profiles", "empty")
+	require.NoError(t, os.MkdirAll(profileRoot, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(profileRoot, ".env"), []byte("TOKEN=secret\n"), 0o600,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(profileRoot, "auth.json"), []byte(`{"token":"secret"}`), 0o600,
+	))
+	srv := New(config.Config{
+		Host:        "127.0.0.1",
+		Port:        8080,
+		DataDir:     dir,
+		DBPath:      filepath.Join(dir, "test.db"),
+		AuthToken:   "remote-token",
+		RequireAuth: false,
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentHermes: {profileRoot},
+		},
+	}, database, nil)
+	handler := srv.Handler()
+
+	targetReq := httptest.NewRequest(http.MethodGet, "/api/v1/remote-sync/targets", nil)
+	targetReq.Header.Set("Authorization", "Bearer remote-token")
+	targetW := httptest.NewRecorder()
+	handler.ServeHTTP(targetW, targetReq)
+	require.Equal(t, http.StatusOK, targetW.Code, "body: %s", targetW.Body.String())
+	var targets remotesync.TargetSet
+	require.NoError(t, json.Unmarshal(targetW.Body.Bytes(), &targets))
+	assert.NotContains(t, targets.Dirs, parser.AgentHermes)
+	assert.Empty(t, targets.ExtraFiles)
+
+	payload, err := json.Marshal(remotesync.TargetSet{
+		Dirs: map[parser.AgentType][]string{parser.AgentHermes: {profileRoot}},
+	})
+	require.NoError(t, err)
+	archiveReq := httptest.NewRequest(
+		http.MethodPost, "/api/v1/remote-sync/archive", bytes.NewReader(payload),
+	)
+	archiveReq.Header.Set("Authorization", "Bearer remote-token")
+	archiveReq.Header.Set("Content-Type", "application/json")
+	archiveW := httptest.NewRecorder()
+	handler.ServeHTTP(archiveW, archiveReq)
+
+	assert.Equal(t, http.StatusForbidden, archiveW.Code)
+	assert.NotContains(t, archiveW.Body.String(), "secret")
+}
+
+func TestRemoteSyncHermesFlatCustomRootStreamsTranscripts(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	database := dbtest.OpenTestDBAt(t, dbPath)
+	root := filepath.Join(dir, "custom", "hermes-archive")
+	require.NoError(t, os.MkdirAll(root, 0o755))
+	sessionPath := filepath.Join(root, "child.jsonl")
+	require.NoError(t, os.WriteFile(sessionPath, []byte("{}\n"), 0o644))
+	srv := New(config.Config{
+		Host:        "127.0.0.1",
+		Port:        8080,
+		DataDir:     dir,
+		DBPath:      dbPath,
+		AuthToken:   "remote-token",
+		RequireAuth: false,
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentHermes: {root},
+		},
+	}, database, nil)
+	handler := srv.Handler()
+
+	targetReq := httptest.NewRequest(http.MethodGet, "/api/v1/remote-sync/targets", nil)
+	targetReq.Header.Set("Authorization", "Bearer remote-token")
+	targetW := httptest.NewRecorder()
+	handler.ServeHTTP(targetW, targetReq)
+	require.Equal(t, http.StatusOK, targetW.Code, "body: %s", targetW.Body.String())
+	var targets remotesync.TargetSet
+	require.NoError(t, json.Unmarshal(targetW.Body.Bytes(), &targets))
+	require.Equal(t, []string{root}, targets.Dirs[parser.AgentHermes])
+
+	payload, err := json.Marshal(targets)
+	require.NoError(t, err)
+	archiveReq := httptest.NewRequest(
+		http.MethodPost, "/api/v1/remote-sync/archive", bytes.NewReader(payload),
+	)
+	archiveReq.Header.Set("Authorization", "Bearer remote-token")
+	archiveReq.Header.Set("Content-Type", "application/json")
+	archiveW := httptest.NewRecorder()
+	handler.ServeHTTP(archiveW, archiveReq)
+
+	require.Equal(t, http.StatusOK, archiveW.Code, "body: %s", archiveW.Body.String())
+	assert.True(t, hasTarEntrySuffix(tarEntries(t, archiveW.Body.Bytes()), "child.jsonl"))
+}
+
+func TestRemoteSyncHermesSidecarRemovalRaces(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(*testing.T, http.Handler, remotesync.TargetSet, string, func())
+	}{
+		{
+			name: "between targets and manifest",
+			run: func(
+				t *testing.T, handler http.Handler, targets remotesync.TargetSet,
+				_ string, removeWAL func(),
+			) {
+				removeWAL()
+				payload, err := json.Marshal(targets)
+				require.NoError(t, err)
+				req := httptest.NewRequest(
+					http.MethodPost, "/api/v1/remote-sync/manifest", bytes.NewReader(payload),
+				)
+				req.Header.Set("Authorization", "Bearer remote-token")
+				req.Header.Set("Content-Type", "application/json")
+				w := httptest.NewRecorder()
+				handler.ServeHTTP(w, req)
+				assert.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+			},
+		},
+		{
+			name: "between manifest and archive",
+			run: func(
+				t *testing.T, handler http.Handler, targets remotesync.TargetSet,
+				wal string, removeWAL func(),
+			) {
+				manifestPayload, err := json.Marshal(targets)
+				require.NoError(t, err)
+				manifestReq := httptest.NewRequest(
+					http.MethodPost, "/api/v1/remote-sync/manifest",
+					bytes.NewReader(manifestPayload),
+				)
+				manifestReq.Header.Set("Authorization", "Bearer remote-token")
+				manifestReq.Header.Set("Content-Type", "application/json")
+				manifestW := httptest.NewRecorder()
+				handler.ServeHTTP(manifestW, manifestReq)
+				require.Equal(t, http.StatusOK, manifestW.Code,
+					"body: %s", manifestW.Body.String())
+
+				removeWAL()
+				archivePayload, err := json.Marshal(remotesync.ArchiveRequest{
+					TargetSet:  targets,
+					DeltaFiles: []string{wal},
+				})
+				require.NoError(t, err)
+				archiveReq := httptest.NewRequest(
+					http.MethodPost, "/api/v1/remote-sync/archive",
+					bytes.NewReader(archivePayload),
+				)
+				archiveReq.Header.Set("Authorization", "Bearer remote-token")
+				archiveReq.Header.Set("Content-Type", "application/json")
+				archiveW := httptest.NewRecorder()
+				handler.ServeHTTP(archiveW, archiveReq)
+				assert.Equal(t, http.StatusOK, archiveW.Code,
+					"body: %s", archiveW.Body.String())
+				entries := tarEntries(t, archiveW.Body.Bytes())
+				assert.True(t, hasTarEntrySuffix(entries, "state.db"))
+				assert.False(t, hasTarEntrySuffix(entries, "state.db-wal"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, targets, wal, removeWAL := newHermesRemoteSyncServer(t)
+			assert.Contains(t, targets.ExtraFiles, wal)
+			tt.run(t, handler, targets, wal, removeWAL)
+		})
+	}
+}
+
+func newHermesRemoteSyncServer(
+	t *testing.T,
+) (http.Handler, remotesync.TargetSet, string, func()) {
+	t.Helper()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	database := dbtest.OpenTestDBAt(t, dbPath)
+	profileRoot := filepath.Join(dir, ".hermes", "profiles", "research")
+	sessionsDir := filepath.Join(profileRoot, "sessions")
+	require.NoError(t, os.MkdirAll(sessionsDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sessionsDir, "session.json"), []byte(`{}`), 0o644,
+	))
+	stateDB := filepath.Join(profileRoot, "state.db")
+	stateConn, err := sql.Open("sqlite3", stateDB)
+	require.NoError(t, err)
+	stateConn.SetMaxOpenConns(1)
+	stateConnClosed := false
+	t.Cleanup(func() {
+		if !stateConnClosed {
+			require.NoError(t, stateConn.Close())
+		}
+	})
+	_, err = stateConn.Exec(`CREATE TABLE sessions (id TEXT PRIMARY KEY)`)
+	require.NoError(t, err)
+	_, err = stateConn.Exec(`PRAGMA journal_mode=WAL`)
+	require.NoError(t, err)
+	_, err = stateConn.Exec(`PRAGMA wal_autocheckpoint=0`)
+	require.NoError(t, err)
+	_, err = stateConn.Exec(`INSERT INTO sessions (id) VALUES ('wal-session')`)
+	require.NoError(t, err)
+	wal := stateDB + "-wal"
+	require.FileExists(t, wal)
+	removeWAL := func() {
+		_, err := stateConn.Exec(`PRAGMA wal_checkpoint(TRUNCATE)`)
+		require.NoError(t, err)
+		require.NoError(t, stateConn.Close())
+		stateConnClosed = true
+		if err := os.Remove(wal); !os.IsNotExist(err) {
+			require.NoError(t, err)
+		}
+	}
+	srv := New(config.Config{
+		Host:        "127.0.0.1",
+		Port:        8080,
+		DataDir:     dir,
+		DBPath:      dbPath,
+		AuthToken:   "remote-token",
+		RequireAuth: false,
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentHermes: {profileRoot},
+		},
+	}, database, nil)
+	handler := srv.Handler()
+	targetReq := httptest.NewRequest(http.MethodGet, "/api/v1/remote-sync/targets", nil)
+	targetReq.Header.Set("Authorization", "Bearer remote-token")
+	targetW := httptest.NewRecorder()
+	handler.ServeHTTP(targetW, targetReq)
+	require.Equal(t, http.StatusOK, targetW.Code, "body: %s", targetW.Body.String())
+	var targets remotesync.TargetSet
+	require.NoError(t, json.Unmarshal(targetW.Body.Bytes(), &targets))
+	return handler, targets, wal, removeWAL
+}
+
 // newWindsurfRemoteSyncServer builds a remote-sync server whose only
 // agent is Windsurf (a file-scoped, sanitized agent). It returns the
 // handler, the resolved targets the client would see, and the raw

--- a/internal/server/huma_routes_sync_internal_test.go
+++ b/internal/server/huma_routes_sync_internal_test.go
@@ -619,7 +619,7 @@ func TestRunRemoteSyncRequestUnifiedHTTPUsesMirrorDeltaAndBulkRebuild(t *testing
 				err = remotesync.WriteArchive(w, request.TargetSet)
 			} else {
 				err = remotesync.WriteArchiveFiles(
-					w, targets.DeltaAllowedRoots(), request.DeltaFiles,
+					w, targets, request.DeltaFiles,
 				)
 			}
 			if err != nil {

--- a/internal/ssh/resolve.go
+++ b/internal/ssh/resolve.go
@@ -141,6 +141,57 @@ func buildResolveScript() string {
 			"fi; " +
 			"[ -d \"$target\" ] && printf '%s\\000' \"$agent:$target\"; " +
 			"}\n" +
+			"av_emit_extra_file() { " +
+			"file=\"$1\"; " +
+			"[ -f \"$file\" ] && printf '%s\\000' \"" + resolveFilePrefix + ":$file\"; " +
+			"}\n" +
+			"av_has_hermes_transcript() { " +
+			"av_hermes_transcript_dir=\"$1\"; " +
+			"[ -d \"$av_hermes_transcript_dir\" ] || return 1; " +
+			"for av_hermes_transcript in \"$av_hermes_transcript_dir\"/*.jsonl \"$av_hermes_transcript_dir\"/session_*.json; do " +
+			"[ -f \"$av_hermes_transcript\" ] && return 0; done; return 1; " +
+			"}\n" +
+			"av_emit_hermes_target() { " +
+			"target=\"$1\"; " +
+			"av_hermes_allow_flat=\"${2:-1}\"; " +
+			"while [ \"$target\" != \"/\" ] && [ \"${target%/}\" != \"$target\" ]; do target=\"${target%/}\"; done; " +
+			"av_hermes_parent=\"${target%/*}\"; av_hermes_grandparent=\"${av_hermes_parent%/*}\"; " +
+			"if [ \"${av_hermes_parent##*/}\" = profiles ] && [ \"${av_hermes_grandparent##*/}\" = .hermes ]; then av_hermes_allow_flat=0; fi; " +
+			"if [ \"$av_hermes_allow_flat\" -eq 0 ]; then " +
+			"av_hermes_root=\"$target\"; av_hermes_sessions=\"$target/sessions\"; " +
+			"else case \"$target\" in " +
+			"*/sessions) av_hermes_root=\"${target%/*}\"; av_hermes_sessions=\"$target\";; " +
+			"*/state.db) av_hermes_root=\"${target%/*}\"; av_hermes_sessions=\"$av_hermes_root/sessions\";; " +
+			"*) av_hermes_root=\"$target\"; av_hermes_sessions=\"$target/sessions\";; " +
+			"esac; fi; " +
+			"av_hermes_state=\"$av_hermes_root/state.db\"; " +
+			"if [ -d \"$av_hermes_sessions\" ]; then " +
+			"av_emit_target \"" + string(parser.AgentHermes) + "\" \"$av_hermes_sessions\"; " +
+			"for av_hermes_file in \"$av_hermes_state\" \"$av_hermes_state-wal\" \"$av_hermes_state-shm\" \"$av_hermes_state-journal\"; do " +
+			"av_emit_extra_file \"$av_hermes_file\"; done; " +
+			"elif [ -f \"$av_hermes_state\" ]; then " +
+			"printf '%s\\000' \"" + string(parser.AgentHermes) + ":$av_hermes_state\"; " +
+			"for av_hermes_file in \"$av_hermes_state-wal\" \"$av_hermes_state-shm\" \"$av_hermes_state-journal\"; do " +
+			"av_emit_extra_file \"$av_hermes_file\"; done; " +
+			"elif [ \"$av_hermes_allow_flat\" -eq 1 ] && av_has_hermes_transcript \"$target\"; then " +
+			"av_emit_target \"" + string(parser.AgentHermes) + "\" \"$target\"; fi; " +
+			"}\n" +
+			"av_emit_hermes_profiles() { " +
+			"av_hermes_profiles=\"$1\"; " +
+			"for av_hermes_prof in \"$av_hermes_profiles\"/*; do " +
+			"[ -L \"$av_hermes_prof\" ] && continue; " +
+			"[ -d \"$av_hermes_prof\" ] || continue; " +
+			"av_emit_hermes_target \"$av_hermes_prof\" 0; " +
+			"done; " +
+			"}\n" +
+			"av_emit_hermes_dir() { " +
+			"dir=\"$1\"; [ -n \"$dir\" ] || dir=\"$2\"; " +
+			"while [ \"$dir\" != \"/\" ] && [ \"${dir%/}\" != \"$dir\" ]; do dir=\"${dir%/}\"; done; " +
+			"av_hermes_parent=\"${dir%/*}\"; " +
+			"if [ \"${dir##*/}\" = profiles ] && [ \"${av_hermes_parent##*/}\" = .hermes ]; then " +
+			"av_emit_hermes_profiles \"$dir\"; return; fi; " +
+			"av_emit_hermes_target \"$dir\"; " +
+			"}\n" +
 			"av_emit_dir() { " +
 			"dir=\"$1\"; " +
 			"[ -n \"$dir\" ] || dir=\"$2\"; " +
@@ -181,6 +232,13 @@ func buildResolveScript() string {
 		}
 		for _, rel := range def.DefaultDirs {
 			defaultDir := "$HOME/" + rel
+			if def.Type == parser.AgentHermes {
+				fmt.Fprintf(&b,
+					"av_emit_hermes_dir \"%s\" \"%s\"\n",
+					remoteEnvExpansion(def.EnvVar), defaultDir,
+				)
+				continue
+			}
 			if def.DefaultRootEnvVar != "" {
 				rootTail := remoteDefaultRootTail(rel)
 				rootSuffix := ""
@@ -207,6 +265,16 @@ func buildResolveScript() string {
 			if def.Type == parser.AgentCodex {
 				b.WriteString("av_emit_codex_index\n")
 			}
+		}
+		// Hermes named defaults are replacements, not additions, when the
+		// sessions override is set. Each emitted profile includes its state DB
+		// and live SQLite companions as well as transcript sessions.
+		if def.Type == parser.AgentHermes {
+			fmt.Fprintf(&b,
+				"if [ -z \"%s\" ]; then "+
+					"av_emit_hermes_profiles \"$HOME/.hermes/profiles\"; fi\n",
+				remoteEnvExpansion(def.EnvVar),
+			)
 		}
 	}
 	// Ensure exit 0 — the last [ -d ]/[ -f ] test may fail if that

--- a/internal/ssh/resolve_test.go
+++ b/internal/ssh/resolve_test.go
@@ -3,6 +3,7 @@ package ssh
 import (
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -143,6 +144,207 @@ func hasSuffix(paths []string, suffix string) bool {
 		}
 	}
 	return false
+}
+
+// TestResolveScriptIncludesHermesNamedProfiles verifies the remote resolve
+// script discovers Hermes named-profile session dirs and database files, not
+// just the default profile.
+func TestResolveScriptIncludesHermesNamedProfiles(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".hermes", "sessions"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(home, ".hermes", "state.db"), []byte("sqlite"), 0o644,
+	))
+	orchestratorRoot := filepath.Join(home, ".hermes", "profiles", "orchestrator")
+	researchRoot := filepath.Join(home, ".hermes", "profiles", "research")
+	require.NoError(t, os.MkdirAll(filepath.Join(orchestratorRoot, "sessions"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(researchRoot, "sessions"), 0o755))
+	for _, path := range []string{
+		filepath.Join(orchestratorRoot, "state.db"),
+		filepath.Join(orchestratorRoot, "state.db-wal"),
+		filepath.Join(orchestratorRoot, "state.db-shm"),
+		filepath.Join(orchestratorRoot, "state.db-journal"),
+		filepath.Join(researchRoot, "state.db"),
+	} {
+		require.NoError(t, os.WriteFile(path, []byte("sqlite"), 0o644))
+	}
+
+	out := runResolveScriptForTest(t, "HOME="+home)
+	dirs, extraFiles := parseResolvedDirs(string(out))
+
+	assert.Truef(t, hasSuffix(dirs[parser.AgentHermes], ".hermes/sessions"),
+		"default profile sessions dir should resolve, got %v", dirs[parser.AgentHermes])
+	assert.Truef(t, hasSuffix(dirs[parser.AgentHermes], ".hermes/profiles/orchestrator/sessions"),
+		"orchestrator profile sessions dir should resolve, got %v", dirs[parser.AgentHermes])
+	assert.Truef(t, hasSuffix(dirs[parser.AgentHermes], ".hermes/profiles/research/sessions"),
+		"research profile sessions dir should resolve, got %v", dirs[parser.AgentHermes])
+	assert.True(t, hasSuffix(extraFiles, ".hermes/profiles/orchestrator/state.db"))
+	assert.True(t, hasSuffix(extraFiles, ".hermes/profiles/orchestrator/state.db-wal"))
+	assert.True(t, hasSuffix(extraFiles, ".hermes/profiles/orchestrator/state.db-shm"))
+	assert.True(t, hasSuffix(extraFiles, ".hermes/profiles/orchestrator/state.db-journal"))
+	assert.True(t, hasSuffix(extraFiles, ".hermes/profiles/research/state.db"))
+	assert.True(t, hasSuffix(extraFiles, ".hermes/state.db"))
+}
+
+func TestResolveScriptHermesOverrideReplacesNamedProfiles(t *testing.T) {
+	home := filepath.ToSlash(t.TempDir())
+	profileSessions := path.Join(
+		home, ".hermes", "profiles", "research", "sessions",
+	)
+	customRoot := path.Join(home, "custom-hermes")
+	customSessions := path.Join(customRoot, "sessions")
+	require.NoError(t, os.MkdirAll(profileSessions, 0o755))
+	require.NoError(t, os.MkdirAll(customSessions, 0o755))
+	require.NoError(t, os.WriteFile(
+		path.Join(customRoot, "state.db"), []byte("sqlite"), 0o644,
+	))
+
+	out := runResolveScriptForTest(t,
+		"HOME="+home,
+		"HERMES_SESSIONS_DIR="+customSessions,
+	)
+	dirs, extraFiles := parseResolvedDirs(string(out))
+
+	assert.Equal(t, []string{customSessions}, dirs[parser.AgentHermes])
+	assert.Equal(t, []string{path.Join(customRoot, "state.db")}, extraFiles)
+}
+
+func TestResolveScriptHermesProfilesContainerOverrideEnumeratesProfiles(t *testing.T) {
+	home := filepath.ToSlash(t.TempDir())
+	profilesRoot := path.Join(home, ".hermes", "profiles")
+	researchRoot := path.Join(profilesRoot, "research")
+	researchSessions := path.Join(researchRoot, "sessions")
+	researchStateDB := path.Join(researchRoot, "state.db")
+	databaseOnlyRoot := path.Join(profilesRoot, "database-only")
+	databaseOnlyStateDB := path.Join(databaseOnlyRoot, "state.db")
+	require.NoError(t, os.MkdirAll(researchSessions, 0o755))
+	require.NoError(t, os.MkdirAll(databaseOnlyRoot, 0o755))
+	require.NoError(t, os.WriteFile(researchStateDB, []byte("sqlite"), 0o644))
+	require.NoError(t, os.WriteFile(databaseOnlyStateDB, []byte("sqlite"), 0o644))
+
+	outsideRoot := filepath.ToSlash(path.Join(t.TempDir(), "outside-profile"))
+	require.NoError(t, os.MkdirAll(path.Join(outsideRoot, "sessions"), 0o755))
+	require.NoError(t, os.Symlink(outsideRoot, path.Join(profilesRoot, "linked")))
+
+	out := runResolveScriptForTest(t,
+		"HOME="+home,
+		"HERMES_SESSIONS_DIR="+profilesRoot,
+	)
+	dirs, extraFiles := parseResolvedDirs(string(out))
+
+	assert.ElementsMatch(t, []string{researchSessions, databaseOnlyStateDB},
+		dirs[parser.AgentHermes])
+	assert.Equal(t, []string{researchStateDB}, extraFiles)
+}
+
+func TestResolveScriptHermesTrailingSlashOverrideIncludesStateDB(t *testing.T) {
+	home := filepath.ToSlash(t.TempDir())
+	customRoot := path.Join(home, "custom-hermes")
+	customSessions := path.Join(customRoot, "sessions")
+	require.NoError(t, os.MkdirAll(filepath.FromSlash(customSessions), 0o755))
+	stateDB := path.Join(customRoot, "state.db")
+	require.NoError(t, os.WriteFile(filepath.FromSlash(stateDB), []byte("sqlite"), 0o644))
+
+	out := runResolveScriptForTest(t,
+		"HOME="+home,
+		"HERMES_SESSIONS_DIR="+customSessions+"/",
+	)
+	dirs, extraFiles := parseResolvedDirs(string(out))
+
+	assert.Equal(t, []string{customSessions}, dirs[parser.AgentHermes])
+	assert.Equal(t, []string{stateDB}, extraFiles)
+}
+
+func TestResolveScriptIncludesFlatCustomHermesRoot(t *testing.T) {
+	home := t.TempDir()
+	customRoot := filepath.Join(home, "custom", "hermes-archive")
+	require.NoError(t, os.MkdirAll(customRoot, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(customRoot, "child.jsonl"), []byte("{}\n"), 0o644,
+	))
+
+	out := runResolveScriptForTest(t,
+		"HOME="+home,
+		"HERMES_SESSIONS_DIR="+customRoot,
+	)
+	dirs, extraFiles := parseResolvedDirs(string(out))
+
+	assert.Equal(t, []string{customRoot}, dirs[parser.AgentHermes])
+	assert.Empty(t, extraFiles)
+}
+
+func TestResolveScriptIncludesHermesDatabaseOnlyProfile(t *testing.T) {
+	home := filepath.ToSlash(t.TempDir())
+	profileRoot := path.Join(home, ".hermes", "profiles", "database-only")
+	require.NoError(t, os.MkdirAll(profileRoot, 0o755))
+	stateDB := path.Join(profileRoot, "state.db")
+	require.NoError(t, os.WriteFile(stateDB, []byte("sqlite"), 0o644))
+
+	out := runResolveScriptForTest(t, "HOME="+home)
+	dirs, _ := parseResolvedDirs(string(out))
+
+	assert.Truef(t, hasSuffix(
+		dirs[parser.AgentHermes], ".hermes/profiles/database-only/state.db",
+	), "database-only profile should resolve, got %v", dirs[parser.AgentHermes])
+}
+
+func TestResolveScriptSkipsSessionlessHermesProfileCredentials(t *testing.T) {
+	home := t.TempDir()
+	profileRoot := filepath.Join(home, ".hermes", "profiles", "sessions")
+	require.NoError(t, os.MkdirAll(profileRoot, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(profileRoot, ".env"), []byte("TOKEN=secret\n"), 0o600,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(profileRoot, "auth.json"), []byte(`{"token":"secret"}`), 0o600,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(profileRoot, "debug.jsonl"), []byte("not a session\n"), 0o600,
+	))
+
+	out := runResolveScriptForTest(t, "HOME="+home)
+	dirs, extraFiles := parseResolvedDirs(string(out))
+
+	assert.NotContains(t, dirs[parser.AgentHermes], profileRoot)
+	assert.NotContains(t, extraFiles, filepath.Join(profileRoot, ".env"))
+	assert.NotContains(t, extraFiles, filepath.Join(profileRoot, "auth.json"))
+}
+
+func TestResolveScriptSkipsSymlinkedHermesProfile(t *testing.T) {
+	home := t.TempDir()
+	profilesRoot := filepath.Join(home, ".hermes", "profiles")
+	require.NoError(t, os.MkdirAll(profilesRoot, 0o755))
+	outsideRoot := filepath.Join(t.TempDir(), "outside-profile")
+	outsideSessions := filepath.Join(outsideRoot, "sessions")
+	require.NoError(t, os.MkdirAll(outsideSessions, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(outsideSessions, "credential.jsonl"), []byte("secret\n"), 0o600,
+	))
+	profileLink := filepath.Join(profilesRoot, "linked")
+	require.NoError(t, os.Symlink(outsideRoot, profileLink))
+
+	out := runResolveScriptForTest(t, "HOME="+home)
+	dirs, extraFiles := parseResolvedDirs(string(out))
+
+	assert.NotContains(t, dirs[parser.AgentHermes], filepath.Join(profileLink, "sessions"))
+	assert.Empty(t, extraFiles)
+}
+
+// TestResolveScriptSkipsMissingHermesProfiles verifies that when no profiles/
+// dir exists, the glob expands to nothing emittable (av_emit_target's [ -d ]
+// guard drops the non-existent path) — so only the default profile resolves.
+func TestResolveScriptSkipsMissingHermesProfiles(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".hermes", "sessions"), 0o755))
+
+	out := runResolveScriptForTest(t, "HOME="+home)
+	dirs, _ := parseResolvedDirs(string(out))
+
+	assert.Truef(t, hasSuffix(dirs[parser.AgentHermes], ".hermes/sessions"),
+		"default profile sessions dir should resolve, got %v", dirs[parser.AgentHermes])
+	// The unexpanded glob must never leak through as a literal path.
+	assert.Falsef(t, hasSuffix(dirs[parser.AgentHermes], "profiles/*/sessions"),
+		"unexpanded glob must not be emitted, got %v", dirs[parser.AgentHermes])
 }
 
 // TestResolveScriptSkipsMissingCodexIndex verifies that a missing index

--- a/internal/ssh/ssh.go
+++ b/internal/ssh/ssh.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -134,6 +135,12 @@ func runSSHScriptStream(
 				Host:   host,
 				Stderr: strings.TrimSpace(stderr.String()),
 				Err:    waitErr,
+			}
+		}
+		for line := range strings.SplitSeq(strings.TrimSpace(stderr.String()), "\n") {
+			line = strings.TrimSpace(line)
+			if line != "" {
+				fmt.Fprintf(os.Stderr, "  SSH %s: %s\n", host, line)
 			}
 		}
 		return nil

--- a/internal/ssh/sync.go
+++ b/internal/ssh/sync.go
@@ -16,6 +16,9 @@ type SyncStats = remotesync.SyncStats
 
 // RemoteSync orchestrates pulling session data from a remote
 // host over SSH, parsing it, and writing it to the local DB.
+//
+// SSH remote sync is a deprecated compatibility transport that receives only
+// critical fixes. New configurations should use HTTP remote sync.
 type RemoteSync struct {
 	Host                    string
 	User                    string

--- a/internal/ssh/transfer.go
+++ b/internal/ssh/transfer.go
@@ -2,10 +2,13 @@ package ssh
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"os"
+	"path"
+	"sort"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -25,41 +28,191 @@ func buildTarCommand(
 	files map[parser.AgentType][]string,
 	extraFiles []string,
 ) string {
-	var paths []string
+	hermesStateDBs := hermesSSHStateDBs(dirs, extraFiles)
+	hermesSQLite := make(map[string]struct{}, len(hermesStateDBs)*4)
+	for _, stateDB := range hermesStateDBs {
+		for _, suffix := range []string{"", "-wal", "-shm", "-journal"} {
+			hermesSQLite[path.Clean(stateDB+suffix)] = struct{}{}
+		}
+	}
+	paths := make([]string, 0)
+	addPath := func(remotePath string) {
+		if _, isHermesSQLite := hermesSQLite[path.Clean(remotePath)]; isHermesSQLite {
+			return
+		}
+		if archivePath := tarListPath(remotePath); archivePath != "" {
+			paths = append(paths, archivePath)
+		}
+	}
 	for agent, agentDirs := range dirs {
 		if _, fileScoped := files[agent]; fileScoped {
 			continue
 		}
 		for _, d := range agentDirs {
-			if path := tarListPath(d); path != "" {
-				paths = append(paths, shellQuote(path))
-			}
+			addPath(d)
 		}
 	}
 	for _, agentFiles := range files {
 		for _, f := range agentFiles {
-			if path := tarListPath(f); path != "" {
-				paths = append(paths, shellQuote(path))
-			}
+			addPath(f)
 		}
 	}
 	for _, f := range extraFiles {
-		if path := tarListPath(f); path != "" {
-			paths = append(paths, shellQuote(path))
-		}
+		addPath(f)
 	}
+	if len(hermesStateDBs) > 0 {
+		return buildPythonSnapshotTarCommand(paths, hermesStateDBs)
+	}
+	return buildPlainTarCommand(paths)
+}
+
+func buildPlainTarCommand(paths []string) string {
 	var b strings.Builder
 	b.WriteString("set -e\n")
 	b.WriteString("av_emit_tar_path() { [ -e \"/$1\" ] || return 0; printf '%s\\n' \"$1\"; }\n")
 	b.WriteString("{\n")
 	b.WriteString(":\n")
-	for _, path := range paths {
+	for _, archivePath := range paths {
 		b.WriteString("av_emit_tar_path ")
-		b.WriteString(path)
+		b.WriteString(shellQuote(archivePath))
 		b.WriteByte('\n')
 	}
 	b.WriteString("} | tar cf - -C / -T -\n")
 	return b.String()
+}
+
+func hermesSSHStateDBs(
+	dirs map[parser.AgentType][]string,
+	extraFiles []string,
+) []string {
+	extra := make(map[string]struct{}, len(extraFiles))
+	for _, remotePath := range extraFiles {
+		extra[path.Clean(remotePath)] = struct{}{}
+	}
+	seen := make(map[string]struct{})
+	for _, remotePath := range dirs[parser.AgentHermes] {
+		clean := path.Clean(remotePath)
+		switch path.Base(clean) {
+		case "state.db":
+			seen[clean] = struct{}{}
+		case "sessions":
+			stateDB := path.Join(path.Dir(clean), "state.db")
+			if _, ok := extra[stateDB]; ok {
+				seen[stateDB] = struct{}{}
+			}
+		}
+	}
+	stateDBs := make([]string, 0, len(seen))
+	for stateDB := range seen {
+		stateDBs = append(stateDBs, stateDB)
+	}
+	sort.Strings(stateDBs)
+	return stateDBs
+}
+
+func buildPythonSnapshotTarCommand(paths, stateDBs []string) string {
+	type sqliteArchivePath struct {
+		Source  string `json:"source"`
+		Archive string `json:"archive"`
+	}
+	databases := make([]sqliteArchivePath, 0, len(stateDBs))
+	for _, stateDB := range stateDBs {
+		archivePath := tarListPath(stateDB)
+		if archivePath == "" {
+			continue
+		}
+		databases = append(databases, sqliteArchivePath{
+			Source: stateDB, Archive: archivePath,
+		})
+	}
+	pathsJSON, _ := json.Marshal(paths)
+	databasesJSON, _ := json.Marshal(databases)
+	fallback := buildPlainTarCommand(paths)
+	var fallbackWarnings strings.Builder
+	for _, database := range databases {
+		fallbackWarnings.WriteString("  printf '%s\\n' ")
+		fallbackWarnings.WriteString(shellQuote(
+			"warning: skipped Hermes state.db snapshot: " + database.Source +
+				": Python 3 with SQLite backup support is unavailable",
+		))
+		fallbackWarnings.WriteString(" >&2\n")
+	}
+	return fmt.Sprintf(`set -e
+av_python=$(command -v python3 || true)
+if [ -n "$av_python" ] && "$av_python" -c 'import json, os, pathlib, sqlite3, stat, sys, tarfile, tempfile; raise SystemExit(0 if sys.version_info >= (3, 7) and hasattr(sqlite3.Connection, "backup") else 1)' >/dev/null 2>&1; then
+"$av_python" - <<'PY'
+import json
+import os
+import pathlib
+import sqlite3
+import stat
+import sys
+import tarfile
+import tempfile
+
+paths = json.loads(%q)
+databases = json.loads(%q)
+
+def warn_skipped(source_path, reason):
+    print("warning: skipped Hermes state.db snapshot: {}: {}".format(source_path, reason), file=sys.stderr)
+
+with tarfile.open(fileobj=sys.stdout.buffer, mode="w|") as archive:
+    for archive_path in paths:
+        source_path = "/" + archive_path[2:] if archive_path.startswith("./") else archive_path
+        if not os.path.lexists(source_path):
+            continue
+        try:
+            archive.add(source_path, arcname=archive_path, recursive=True)
+        except FileNotFoundError:
+            continue
+    for item in databases:
+        source_path = item["source"]
+        try:
+            source_info = os.lstat(source_path)
+        except OSError as exc:
+            warn_skipped(source_path, exc)
+            continue
+        if not stat.S_ISREG(source_info.st_mode):
+            warn_skipped(source_path, "not a regular file")
+            continue
+        sidecars = []
+        unsafe_sidecar = None
+        for suffix in ("-wal", "-shm", "-journal"):
+            try:
+                sidecar_info = os.lstat(source_path + suffix)
+            except FileNotFoundError:
+                continue
+            except OSError as exc:
+                unsafe_sidecar = "cannot inspect {}: {}".format(source_path + suffix, exc)
+                break
+            if not stat.S_ISREG(sidecar_info.st_mode):
+                unsafe_sidecar = "{} is not a regular file".format(source_path + suffix)
+                break
+            sidecars.append((suffix, sidecar_info))
+        if unsafe_sidecar:
+            warn_skipped(source_path, unsafe_sidecar)
+            continue
+        try:
+            with tempfile.TemporaryDirectory(prefix="agentsview-hermes-snapshot-") as tmp:
+                snapshot_path = os.path.join(tmp, "state.db")
+                source_uri = pathlib.Path(source_path).as_uri() + "?mode=ro"
+                with sqlite3.connect(source_uri, uri=True) as source_db:
+                    with sqlite3.connect(snapshot_path) as snapshot_db:
+                        source_db.backup(snapshot_db)
+                        snapshot_db.execute("PRAGMA journal_mode = DELETE")
+                mtime_ns = source_info.st_mtime_ns
+                for suffix, sidecar_info in sidecars:
+                    if suffix in ("-wal", "-journal"):
+                        mtime_ns = max(mtime_ns, sidecar_info.st_mtime_ns)
+                os.utime(snapshot_path, ns=(mtime_ns, mtime_ns))
+                archive.add(snapshot_path, arcname=item["archive"], recursive=False)
+        except (OSError, sqlite3.Error, tarfile.TarError, ValueError) as exc:
+            warn_skipped(source_path, exc)
+            continue
+PY
+else
+%s%sfi
+`, string(pathsJSON), string(databasesJSON), fallbackWarnings.String(), fallback)
 }
 
 func tarListPath(path string) string {

--- a/internal/ssh/transfer_test.go
+++ b/internal/ssh/transfer_test.go
@@ -3,6 +3,8 @@ package ssh
 import (
 	"archive/tar"
 	"bytes"
+	"context"
+	"database/sql"
 	"io"
 	"os"
 	"os/exec"
@@ -14,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/remotesync"
 )
 
 func TestBuildTarCommand(t *testing.T) {
@@ -130,6 +133,247 @@ func TestBuildTarCommandSkipsMissingFileScopedPath(t *testing.T) {
 	names := tarNames(t, archive)
 	assert.Contains(t, names, archivePathForTest(stateDB))
 	assert.NotContains(t, names, archivePathForTest(missingWAL))
+}
+
+func TestBuildTarCommandSnapshotsHermesStateDBWithoutSidecars(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("remote snapshot script uses POSIX paths; local Windows paths are not representative")
+	}
+	root := t.TempDir()
+	stateDB := filepath.Join(root, "profile", "state.db")
+	require.NoError(t, os.MkdirAll(filepath.Dir(stateDB), 0o755))
+	writer, err := sql.Open("sqlite3", stateDB)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = writer.Close() })
+	_, err = writer.Exec(`
+		CREATE TABLE sessions (id TEXT PRIMARY KEY, title TEXT);
+		INSERT INTO sessions (id, title) VALUES ('session', 'Main database');
+	`)
+	require.NoError(t, err)
+	var journalMode string
+	require.NoError(t,
+		writer.QueryRow(`PRAGMA journal_mode = WAL`).Scan(&journalMode))
+	assert.Equal(t, "wal", journalMode)
+	_, err = writer.Exec(`PRAGMA wal_autocheckpoint = 0`)
+	require.NoError(t, err)
+	_, err = writer.Exec(`UPDATE sessions SET title = 'Committed in WAL'`)
+	require.NoError(t, err)
+	wal := stateDB + "-wal"
+	shm := stateDB + "-shm"
+	require.FileExists(t, wal)
+
+	script := buildTarCommand(
+		map[parser.AgentType][]string{parser.AgentHermes: {stateDB}},
+		nil,
+		[]string{wal, shm, stateDB + "-journal"},
+	)
+	cmd := exec.Command("sh")
+	cmd.Stdin = strings.NewReader(script)
+	archive, err := cmd.CombinedOutput()
+	require.NoError(t, err, "snapshot command output: %s", archive)
+	names := tarNames(t, archive)
+	assert.Equal(t, []string{archivePathForTest(stateDB)}, names)
+
+	extracted := t.TempDir()
+	_, err = remotesync.ExtractTarStream(
+		context.Background(), bytes.NewReader(archive), extracted,
+	)
+	require.NoError(t, err)
+	extractedDB := filepath.Join(extracted, strings.TrimPrefix(stateDB, "/"))
+	snapshot, err := sql.Open("sqlite3", extractedDB)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, snapshot.Close()) })
+	var title string
+	require.NoError(t,
+		snapshot.QueryRow(`SELECT title FROM sessions WHERE id = 'session'`).Scan(&title))
+	assert.Equal(t, "Committed in WAL", title)
+}
+
+func TestBuildTarCommandRejectsSymlinkedHermesSQLitePaths(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("remote snapshot script uses POSIX symlinks and paths")
+	}
+	t.Run("database", func(t *testing.T) {
+		root := t.TempDir()
+		externalDB := filepath.Join(root, "outside.db")
+		writeSSHTestSQLiteDB(t, externalDB)
+		stateDB := filepath.Join(root, "profile", "state.db")
+		require.NoError(t, os.MkdirAll(filepath.Dir(stateDB), 0o755))
+		require.NoError(t, os.Symlink(externalDB, stateDB))
+
+		script := buildTarCommand(
+			map[parser.AgentType][]string{parser.AgentHermes: {stateDB}},
+			nil, nil,
+		)
+		cmd := exec.Command("sh")
+		cmd.Stdin = strings.NewReader(script)
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		archive, err := cmd.Output()
+		require.NoError(t, err, "snapshot command stderr: %s", stderr.String())
+		assert.Empty(t, tarNames(t, archive))
+		assert.Contains(t, stderr.String(), stateDB)
+	})
+
+	t.Run("sidecar", func(t *testing.T) {
+		root := t.TempDir()
+		stateDB := filepath.Join(root, "profile", "state.db")
+		require.NoError(t, os.MkdirAll(filepath.Dir(stateDB), 0o755))
+		writeSSHTestSQLiteDB(t, stateDB)
+		external := filepath.Join(root, "outside-wal")
+		require.NoError(t, os.WriteFile(external, []byte("outside"), 0o644))
+		wal := stateDB + "-wal"
+		require.NoError(t, os.Symlink(external, wal))
+
+		script := buildTarCommand(
+			map[parser.AgentType][]string{parser.AgentHermes: {stateDB}},
+			nil, []string{wal},
+		)
+		cmd := exec.Command("sh")
+		cmd.Stdin = strings.NewReader(script)
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		archive, err := cmd.Output()
+		require.NoError(t, err, "snapshot command stderr: %s", stderr.String())
+		assert.Empty(t, tarNames(t, archive))
+		assert.Contains(t, stderr.String(), stateDB)
+		assert.Contains(t, stderr.String(), wal)
+	})
+}
+
+func TestBuildTarCommandSkipsFailedHermesSnapshotAndKeepsOtherData(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("remote snapshot script uses POSIX paths; local Windows paths are not representative")
+	}
+	root := t.TempDir()
+	badProfile := filepath.Join(root, "0-bad")
+	goodProfile := filepath.Join(root, "1-good")
+	badSessions := filepath.Join(badProfile, "sessions")
+	goodSessions := filepath.Join(goodProfile, "sessions")
+	require.NoError(t, os.MkdirAll(badSessions, 0o755))
+	require.NoError(t, os.MkdirAll(goodSessions, 0o755))
+	badTranscript := filepath.Join(badSessions, "bad.jsonl")
+	goodTranscript := filepath.Join(goodSessions, "good.jsonl")
+	require.NoError(t, os.WriteFile(badTranscript, []byte("bad transcript"), 0o644))
+	require.NoError(t, os.WriteFile(goodTranscript, []byte("good transcript"), 0o644))
+	badStateDB := filepath.Join(badProfile, "state.db")
+	goodStateDB := filepath.Join(goodProfile, "state.db")
+	require.NoError(t, os.WriteFile(badStateDB, []byte("not sqlite"), 0o644))
+	writeSSHTestSQLiteDB(t, goodStateDB)
+
+	script := buildTarCommand(
+		map[parser.AgentType][]string{
+			parser.AgentHermes: {badSessions, goodSessions},
+		},
+		nil, []string{badStateDB, goodStateDB},
+	)
+	cmd := exec.Command("sh")
+	cmd.Stdin = strings.NewReader(script)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	archive, err := cmd.Output()
+	require.NoError(t, err, "snapshot command stderr: %s", stderr.String())
+	names := tarNames(t, archive)
+	assert.Contains(t, names, archivePathForTest(badTranscript))
+	assert.Contains(t, names, archivePathForTest(goodTranscript))
+	assert.Contains(t, names, archivePathForTest(goodStateDB))
+	assert.NotContains(t, names, archivePathForTest(badStateDB))
+	assert.Contains(t, stderr.String(), badStateDB)
+	assert.NotContains(t, stderr.String(), goodStateDB)
+}
+
+func TestBuildTarCommandWithoutPythonKeepsTranscriptsAndOtherAgents(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("remote snapshot script uses POSIX paths; local Windows paths are not representative")
+	}
+	root := t.TempDir()
+	hermesSessions := filepath.Join(root, "hermes", "sessions")
+	hermesTranscript := filepath.Join(hermesSessions, "session.jsonl")
+	hermesStateDB := filepath.Join(root, "hermes", "state.db")
+	claudeDir := filepath.Join(root, "claude", "projects")
+	claudeTranscript := filepath.Join(claudeDir, "session.jsonl")
+	require.NoError(t, os.MkdirAll(hermesSessions, 0o755))
+	require.NoError(t, os.MkdirAll(claudeDir, 0o755))
+	require.NoError(t, os.WriteFile(hermesTranscript, []byte("{}\n"), 0o644))
+	require.NoError(t, os.WriteFile(claudeTranscript, []byte("{}\n"), 0o644))
+	writeSSHTestSQLiteDB(t, hermesStateDB)
+
+	script := buildTarCommand(
+		map[parser.AgentType][]string{
+			parser.AgentHermes: {hermesSessions},
+			parser.AgentClaude: {claudeDir},
+		},
+		nil, []string{hermesStateDB},
+	)
+	tarPath, err := exec.LookPath("tar")
+	require.NoError(t, err)
+	remoteBin := t.TempDir()
+	require.NoError(t, os.Symlink(tarPath, filepath.Join(remoteBin, "tar")))
+
+	cmd := exec.Command("sh")
+	cmd.Env = []string{"PATH=" + remoteBin}
+	cmd.Stdin = strings.NewReader(script)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	archive, err := cmd.Output()
+	require.NoError(t, err, "snapshot command stderr: %s", stderr.String())
+	names := tarNames(t, archive)
+	assert.Contains(t, names, archivePathForTest(hermesTranscript))
+	assert.Contains(t, names, archivePathForTest(claudeTranscript))
+	assert.NotContains(t, names, archivePathForTest(hermesStateDB))
+	assert.Contains(t, stderr.String(), "Python 3")
+	assert.Contains(t, stderr.String(), hermesStateDB)
+}
+
+func TestDownloadAndExtractReportsSuccessfulSSHStderr(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake SSH transport uses a POSIX shell")
+	}
+	var archive bytes.Buffer
+	archiveWriter := tar.NewWriter(&archive)
+	require.NoError(t, archiveWriter.Close())
+	archivePath := filepath.Join(t.TempDir(), "archive.tar")
+	require.NoError(t, os.WriteFile(archivePath, archive.Bytes(), 0o600))
+
+	catPath, err := exec.LookPath("cat")
+	require.NoError(t, err)
+	fakeBin := t.TempDir()
+	fakeSSH := filepath.Join(fakeBin, "ssh")
+	fakeScript := "#!/bin/sh\n" +
+		shellQuote(catPath) + " >/dev/null\n" +
+		"printf '%s\\n' 'warning: skipped Hermes state.db snapshot: /remote/state.db' >&2\n" +
+		shellQuote(catPath) + " " + shellQuote(archivePath) + "\n"
+	require.NoError(t, os.WriteFile(fakeSSH, []byte(fakeScript), 0o700))
+	t.Setenv("PATH", fakeBin)
+
+	originalStderr := os.Stderr
+	stderrReader, stderrWriter, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = stderrWriter
+	extracted, syncErr := downloadAndExtract(
+		context.Background(), "remote", "", 0, nil, nil, nil, nil,
+	)
+	closeErr := stderrWriter.Close()
+	os.Stderr = originalStderr
+	warnings, readErr := io.ReadAll(stderrReader)
+	require.NoError(t, stderrReader.Close())
+	if extracted != "" {
+		t.Cleanup(func() { require.NoError(t, os.RemoveAll(extracted)) })
+	}
+
+	require.NoError(t, syncErr)
+	require.NoError(t, closeErr)
+	require.NoError(t, readErr)
+	assert.Contains(t, string(warnings), "skipped Hermes state.db snapshot: /remote/state.db")
+}
+
+func writeSSHTestSQLiteDB(t *testing.T, path string) {
+	t.Helper()
+	database, err := sql.Open("sqlite3", path)
+	require.NoError(t, err)
+	_, err = database.Exec(`CREATE TABLE sessions (id TEXT PRIMARY KEY)`)
+	require.NoError(t, err)
+	require.NoError(t, database.Close())
 }
 
 func TestBuildTarCommandSkipsLineDelimitedUnsafePath(t *testing.T) {

--- a/internal/sync/hermes_archive_test.go
+++ b/internal/sync/hermes_archive_test.go
@@ -118,6 +118,34 @@ func TestHermesProviderFingerprintChangesWhenTranscriptRemoved(t *testing.T) {
 	assert.Equal(t, stateInfo.Size(), after.Size)
 }
 
+func TestHermesProfileCreatedAfterEngineInitializationIsDiscovered(t *testing.T) {
+	profilesRoot := filepath.Join(t.TempDir(), ".hermes", "profiles")
+	require.NoError(t, os.MkdirAll(profilesRoot, 0o755))
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentHermes: {profilesRoot},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+
+	before := engine.SyncAll(context.Background(), nil)
+	assert.Zero(t, before.Synced)
+
+	profileRoot := filepath.Join(profilesRoot, "research")
+	require.NoError(t, os.MkdirAll(profileRoot, 0o755))
+	writeHermesArchiveStateDB(t, profileRoot)
+
+	after := engine.SyncAll(context.Background(), nil)
+	assert.Equal(t, 1, after.Synced)
+	session, err := database.GetSession(context.Background(), "hermes:child")
+	require.NoError(t, err)
+	require.NotNil(t, session)
+	require.NotNil(t, session.FirstMessage)
+	assert.Equal(t, "state db message", *session.FirstMessage)
+}
+
 // TestProcessFileHermesArchiveSkipCacheUsesAggregateMtime confirms the
 // provider-authoritative processFile path keys the skip cache on the aggregate
 // archive mtime (state.db plus direct transcripts), so a cached entry stamped
@@ -246,6 +274,65 @@ func TestSyncPathsHermesArchiveTranscriptPersistsAggregateFingerprint(t *testing
 	require.True(t, found)
 	assert.Equal(t, wantSize, storedSize)
 	assert.Equal(t, wantMtime, storedMtime)
+}
+
+func TestSyncPathsHermesArchiveWALCommitRefreshesMetadata(t *testing.T) {
+	root := t.TempDir()
+	stateDB := writeHermesArchiveStateDB(t, root)
+	writer := openHermesArchiveWALWriter(t, stateDB)
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentHermes: {root},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+
+	initial := engine.SyncAll(context.Background(), nil)
+	require.Equal(t, 1, initial.Synced)
+	stateBefore, err := os.Stat(stateDB)
+	require.NoError(t, err)
+
+	_, err = writer.Exec(`UPDATE sessions SET title = 'WAL-only title' WHERE id = 'child'`)
+	require.NoError(t, err)
+	walPath := stateDB + "-wal"
+	walInfo, err := os.Stat(walPath)
+	require.NoError(t, err)
+	stateAfter, err := os.Stat(stateDB)
+	require.NoError(t, err)
+	assert.Equal(t, stateBefore.Size(), stateAfter.Size())
+	assert.Equal(t, stateBefore.ModTime(), stateAfter.ModTime(),
+		"the committed update must remain WAL-only for this regression")
+	walTime := stateAfter.ModTime().Add(2 * time.Second)
+	require.NoError(t, os.Chtimes(walPath, walTime, walTime))
+
+	engine.SyncPaths([]string{walPath})
+
+	session, err := database.GetSession(context.Background(), "hermes:child")
+	require.NoError(t, err)
+	require.NotNil(t, session)
+	require.NotNil(t, session.DisplayName)
+	assert.Equal(t, "WAL-only title", *session.DisplayName)
+	storedSize, storedMtime, found := database.GetFileInfoByPath(stateDB)
+	require.True(t, found)
+	assert.Equal(t, stateAfter.Size()+walInfo.Size(), storedSize)
+	assert.Equal(t, walTime.UnixNano(), storedMtime)
+}
+
+func openHermesArchiveWALWriter(t *testing.T, stateDB string) *sql.DB {
+	t.Helper()
+	writer, err := sql.Open("sqlite3", stateDB)
+	require.NoError(t, err)
+	writer.SetMaxOpenConns(1)
+	t.Cleanup(func() { require.NoError(t, writer.Close()) })
+
+	var journalMode string
+	require.NoError(t, writer.QueryRow(`PRAGMA journal_mode = WAL`).Scan(&journalMode))
+	assert.Equal(t, "wal", journalMode)
+	_, err = writer.Exec(`PRAGMA wal_autocheckpoint = 0`)
+	require.NoError(t, err)
+	return writer
 }
 
 func writeHermesArchiveStateDB(t *testing.T, root string) string {


### PR DESCRIPTION
AgentsView now treats Hermes named profiles as live archives rather than a startup-only list of transcript directories. Long-running servers discover profiles created after initialization and import sessions plus `state.db` metadata, including database-only sessions and WAL-only updates.

HTTP remote sync now publishes each Hermes `state.db` as a standalone SQLite online-backup snapshot whose manifest identity includes uncheckpointed changes. Full and delta transfers therefore cannot mix a main database with a different WAL generation, while target resolution remains confined to transcripts and database files instead of credential-bearing profile contents.

Hermes overrides retain replacement semantics, trailing-slash handling, profiles-container parity, and supported flat transcript roots across local and remote resolution.

SSH remote sync remains available for compatibility, but it is deprecated and receives only critical fixes. Remotes with Python 3 and SQLite backup support get the same coherent database snapshots; every database snapshot omitted because that support is unavailable or snapshotting fails emits a path-specific warning, while transcripts and unrelated agent data continue transferring. The CLI warns once per process, and the help and remote-sync documentation direct new configurations to HTTP.