### PR TITLE
refactor(frontend): migrate cards and boolean controls to kit-ui

### DIFF
--- a/docs/superpowers/plans/2026-07-17-kit-ui-card-checkbox-migration.md
+++ b/docs/superpowers/plans/2026-07-17-kit-ui-card-checkbox-migration.md
@@ -1,0 +1,494 @@
+# Kit UI Card and Checkbox Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Pin the current kit-ui release and eliminate all 37 hand-rolled-card
+and four hand-rolled-checkbox findings without changing frontend behavior or
+layout.
+
+**Architecture:** Import kit-ui components directly at each affected Svelte call
+site. Real content surfaces move to `Card`; selection and on/off controls move
+to `Checkbox` or `Toggle`; compact controls accidentally matching the card
+recipe move to the existing semantically appropriate kit component instead of
+being wrapped in card markup. Feature classes retain only app-owned layout and
+state styling.
+
+**Tech Stack:** Svelte 5, TypeScript, Vitest, Playwright, Paraglide JS,
+`@kenn-io/kit-ui`, and `kit-ui-check`.
+
+## Global Constraints
+
+- Pin `@kenn-io/kit-ui` to commit `a362f4ecfbc6d4381225c771ec423df5b62a8d09`.
+- Preserve layout, interactions, accessibility labels, disabled states,
+  bindings, and event behavior.
+- Do not add user-facing copy or change locale catalogs.
+- Do not globally disable `hand-rolled-card` or `hand-rolled-checkbox`.
+- Do not add a `kit-ui-check-ignore` marker unless a concrete component gap is
+  found and documented beside the marker.
+- Avoid unrelated restyling and frontend refactoring.
+- Do not add tests that retest library behavior; protect app-owned state
+  transitions and rendered contracts.
+
+______________________________________________________________________
+
+### Task 1: Enable the New Kit UI Components and Conformance Rules
+
+**Files:**
+
+- Modify: `frontend/package.json:22`
+- Modify: `frontend/package-lock.json`
+
+**Interfaces:**
+
+- Consumes: the public git dependency at the exact commit above.
+
+- Produces: imports for `Card`, `Checkbox`, and `Toggle`, plus the full current
+  `kit-ui-check` rule set.
+
+- [ ] **Step 1: Update the dependency and lockfile**
+
+Run from `frontend/`:
+
+```bash
+npm install '@kenn-io/kit-ui@git+https://github.com/kenn-io/kit-ui.git#a362f4ecfbc6d4381225c771ec423df5b62a8d09'
+```
+
+Expected: `package.json` and `package-lock.json` resolve kit-ui at `a362f4e`.
+
+- [ ] **Step 2: Verify the red conformance state**
+
+Run:
+
+```bash
+npm run check:kit-ui
+```
+
+Expected: FAIL with exactly 41 findings: 37 `hand-rolled-card` and four
+`hand-rolled-checkbox` findings. A different inventory means the dependency or
+source tree changed and must be reconciled before migration.
+
+- [ ] **Step 3: Verify the dependency compiles before app migration**
+
+Run:
+
+```bash
+npm run check
+```
+
+Expected: PASS. The dependency bump alone must not break existing imports.
+
+- [ ] **Step 4: Commit the dependency bump**
+
+```bash
+git add frontend/package.json frontend/package-lock.json
+git commit -m "chore(frontend): update kit-ui card controls"
+```
+
+### Task 2: Migrate the Four Native Checkbox Controls
+
+**Files:**
+
+- Modify: `frontend/src/lib/components/settings/AppearanceSettings.svelte`
+- Modify: `frontend/src/lib/components/settings/DateRangeSettings.svelte`
+- Modify: `frontend/src/lib/components/settings/WorktreeMappingSettings.svelte`
+- Modify: `frontend/src/lib/components/trends/TrendsPage.svelte`
+- Test: `frontend/src/lib/components/settings/DateRangeSettings.test.ts`
+- Test: `frontend/src/lib/components/trends/TrendsPage.test.ts`
+
+**Interfaces:**
+
+- Consumes: `Checkbox.checked`, `Checkbox.onchange`, `Toggle.checked`, and
+  `Toggle.onchange(checked: boolean)`.
+
+- Produces: the same store mutations as the native controls, with `switch`
+  semantics for immediate settings and `checkbox` semantics for selections.
+
+- [ ] **Step 1: Add focused semantic assertions before changing markup**
+
+Extend the date-range and trends component tests with the app-owned switch
+semantics required for immediate on/off settings:
+
+```ts
+const linkedDates = getByRole("switch", {
+  name: "Link date ranges across pages",
+}) as HTMLInputElement;
+expect(linkedDates.checked).toBe(false);
+
+const normalize = document.querySelector<HTMLInputElement>(
+  'input[role="switch"][aria-label="Normalize by number of messages"]',
+);
+expect(normalize).not.toBeNull();
+```
+
+Both assertions are expected to fail against the current native checkbox markup
+because it has no `role="switch"`. Existing date-range persistence and worktree
+save assertions already protect the relevant callbacks; do not add duplicate
+tests for kit-ui's checkbox implementation.
+
+- [ ] **Step 2: Run the focused tests and confirm the expected red state**
+
+Run:
+
+```bash
+npm test -- src/lib/components/settings/DateRangeSettings.test.ts src/lib/components/trends/TrendsPage.test.ts
+```
+
+Expected: only the new switch-semantic assertions fail.
+
+- [ ] **Step 3: Replace the controls with kit components**
+
+Use these call-site contracts:
+
+```svelte
+<Checkbox
+  checked={ui.isBlockVisible(bt)}
+  onchange={() => ui.toggleBlock(bt)}
+  label={BLOCK_LABELS[bt]}
+/>
+
+<Toggle
+  checked={yokedDates.enabled}
+  onchange={(checked) => yokedDates.setEnabled(checked)}
+  label={m.settings_date_ranges_link()}
+/>
+
+<Checkbox bind:checked={enabled} label={m.worktree_enabled()} />
+
+<Toggle
+  checked={trends.normalized}
+  onchange={(checked) => {
+    trends.normalized = checked;
+    writeUrl();
+  }}
+  label={m.trends_normalize()}
+/>
+```
+
+Import `Checkbox` or `Toggle` from `@kenn-io/kit-ui` in each file. Remove the
+native `<label><input type="checkbox">` wrappers and delete only the obsolete
+checkbox label/input CSS. Keep surrounding flex/grid layout where it is still
+used by other content.
+
+- [ ] **Step 4: Verify the focused tests and conformance count**
+
+Run:
+
+```bash
+npm test -- src/lib/components/settings/AppearanceSettings.test.ts src/lib/components/settings/DateRangeSettings.test.ts src/lib/components/settings/WorktreeMappingSettings.test.ts src/lib/components/trends/TrendsPage.test.ts
+npm run check:kit-ui
+```
+
+Expected: focused tests PASS; conformance now reports 37 card findings and zero
+checkbox findings.
+
+- [ ] **Step 5: Commit the boolean-control migration**
+
+```bash
+git add frontend/src/lib/components/settings/AppearanceSettings.svelte frontend/src/lib/components/settings/DateRangeSettings.svelte frontend/src/lib/components/settings/DateRangeSettings.test.ts frontend/src/lib/components/settings/WorktreeMappingSettings.svelte frontend/src/lib/components/trends/TrendsPage.svelte frontend/src/lib/components/trends/TrendsPage.test.ts
+git commit -m "refactor(frontend): adopt kit boolean controls"
+```
+
+### Task 3: Migrate Content Surfaces to Card
+
+**Files:**
+
+- Modify: `frontend/src/lib/components/activity/ActivityPage.svelte`
+- Modify: `frontend/src/lib/components/activity/SummaryCards.svelte`
+- Modify: `frontend/src/lib/components/analytics/AnalyticsPage.svelte`
+- Modify: `frontend/src/lib/components/analytics/SessionHealthSection.svelte`
+- Modify: `frontend/src/lib/components/analytics/SummaryCards.svelte`
+- Modify: `frontend/src/lib/components/insights/InsightsPage.svelte`
+- Modify: `frontend/src/lib/components/settings/WorktreeMappingSettings.svelte`
+- Modify: `frontend/src/lib/components/usage/UsagePage.svelte`
+- Modify:
+  `frontend/src/lib/components/usage/UsagePairwiseComparisonPanel.svelte`
+- Modify: `frontend/src/lib/components/usage/UsageSummaryCards.svelte`
+
+**Interfaces:**
+
+- Consumes: `Card level="default" | "inset"`, `padding="none"`, `onclick`,
+  `selected`, and `class`.
+
+- Produces: unchanged feature DOM content inside kit-owned surface chrome.
+
+- [ ] **Step 1: Replace default-level surfaces**
+
+Import `Card` and change the root element for each listed selector to:
+
+```svelte
+<Card
+  level="default"
+  padding="none"
+  class={card.featured ? "card featured" : "card"}
+>
+  <span class="card-value">{card.value}</span>
+  <span class="card-label">{card.label}</span>
+  {#if card.sub}
+    <span class="card-sub">{card.sub}</span>
+  {/if}
+</Card>
+```
+
+The summary-card body above is the exact replacement in
+`activity/SummaryCards.svelte`. At every other listed call site, keep the file's
+current child block byte-for-byte and change only the opening and closing
+surface elements plus the imported component.
+
+Apply this to:
+
+- `ActivityPage.svelte`: `.chart-panel`.
+- `activity/SummaryCards.svelte`: `.card`.
+- `AnalyticsPage.svelte`: `.chart-panel`.
+- `SessionHealthSection.svelte`: `.card` and `.chart-panel`.
+- `analytics/SummaryCards.svelte`: `.card`.
+- `InsightsPage.svelte`: `.state-panel`, `.distribution-row`, `.evidence-panel`,
+  `.generated-controls`, `.inline-warning`, and `.skeleton-pattern`.
+- `UsagePage.svelte`: `.usage-note` and `.chart-panel`.
+- `UsagePairwiseComparisonPanel.svelte`: `.side` and `.error-bar`.
+- `UsageSummaryCards.svelte`: `.card`.
+
+For the selectable generated insight list, replace each button with:
+
+```svelte
+<Card
+  level="default"
+  padding="none"
+  class={task.status === "error" ? "error-task" : ""}
+  selected={insights.selectedTaskId === task.clientId}
+  onclick={() => selectGeneratedTask(task.clientId)}
+>
+  <span>{task.status === "error" ? m.insights_page_error() : m.insights_page_running()}</span>
+  <strong>{task.project || m.insights_page_global()}</strong>
+  <em>{task.kind ? cannedKindLabel(task.kind) : task.phase}</em>
+</Card>
+```
+
+Replace the saved-insight buttons with the same Card contract, using
+`selected={insights.selectedId === item.id}` and
+`onclick={() => selectGeneratedInsight(item.id)}` while retaining the current
+type, project, date-range, and created-time children.
+
+The `selected` prop replaces the old `active` class. Keep `error-task` as the
+explicit class string shown above.
+
+- [ ] **Step 2: Replace inset-level surfaces**
+
+Use the same pattern with `level="inset"` for:
+
+- `InsightsPage.svelte`: `.evidence-row`.
+
+- `WorktreeMappingSettings.svelte`: `.mapping-row`.
+
+- [ ] **Step 3: Remove only redundant card chrome**
+
+From each migrated selector remove declarations for the selected Card recipe:
+
+```css
+background: var(--bg-surface); /* or --bg-inset */
+border: 1px solid var(--border-muted);
+border-radius: var(--radius-md); /* or --radius-sm */
+box-shadow: var(--shadow-sm); /* only when the Card level owns it */
+```
+
+Retain padding, display, grid/flex, min/max sizing, overflow, border-left
+accents, selected/error border overrides, responsive rules, and typography.
+Update descendant selectors from element-dependent forms such as
+`.generated-list button strong` to class-based selectors that still match the
+Card-rendered markup.
+
+- [ ] **Step 4: Run affected component tests and conformance**
+
+Run:
+
+```bash
+npm test -- src/lib/components/activity/ActivityPage.test.ts src/lib/components/analytics/AnalyticsPage.test.ts src/lib/components/insights/InsightsPage.test.ts src/lib/components/settings/WorktreeMappingSettings.test.ts src/lib/components/usage/UsagePage.test.ts src/lib/components/usage/UsagePairwiseComparisonPanel.test.ts
+npm run check:kit-ui
+```
+
+Expected: tests PASS and only compact control findings remain.
+
+- [ ] **Step 5: Commit the content-surface migration**
+
+Stage only the files listed in this task and commit:
+
+```bash
+git commit -m "refactor(frontend): adopt kit card surfaces"
+```
+
+### Task 4: Replace Compact Control False Positives with Semantic Kit Components
+
+**Files:**
+
+- Modify: `frontend/src/lib/components/analytics/SkillTrend.svelte`
+- Modify: `frontend/src/lib/components/analytics/TopSkills.svelte`
+- Modify: `frontend/src/lib/components/settings/AppearanceSettings.svelte`
+- Modify: `frontend/src/lib/components/settings/EmbeddingsSettings.svelte`
+- Modify: `frontend/src/lib/components/settings/GithubSettings.svelte`
+- Modify: `frontend/src/lib/components/settings/RemoteSettings.svelte`
+- Modify: `frontend/src/lib/components/settings/SettingsPage.svelte`
+- Modify: `frontend/src/lib/components/settings/TerminalSettings.svelte`
+- Modify: `frontend/src/lib/components/settings/WorktreeMappingSettings.svelte`
+- Modify: `frontend/src/lib/components/insights/InsightsPage.svelte`
+
+**Interfaces:**
+
+- Consumes: existing kit `Button`, `Chip`, `IconButton`, `SegmentedControl`,
+  `TextInput`, and `Toggle` APIs.
+
+- Produces: zero card-rule matches without using Card for text fields, icon
+  buttons, badges, or segmented choices.
+
+- [ ] **Step 1: Migrate chips and badges**
+
+- `SkillTrend.svelte`: retain the native toggle button because kit-ui `Chip` and
+  `Button` do not expose `aria-pressed`. Add a same-line `kit-ui-check-ignore`
+  comment explaining that the legend is a pressed-state toggle and the current
+  kit controls cannot preserve that accessibility contract. Keep its existing
+  chrome and behavior unchanged.
+
+- `TopSkills.svelte`: use non-interactive `Chip size="xs" uppercase={false}` for
+  `.agent-chip`.
+
+- `EmbeddingsSettings.svelte`: use `Chip size="xs"` with success, warning,
+  danger, or muted tone based on generation state; preserve the displayed
+  status labels.
+
+Delete the obsolete inset-card background/border/radius declarations and keep
+only truncation, color-key, and layout rules that the feature still owns.
+
+- [ ] **Step 2: Migrate text fields**
+
+Replace the flagged native text inputs with `TextInput`, retaining ids,
+password/url/text types, placeholders, bindings, Enter-key handling, monospace
+classes, width, and disabled state:
+
+- `GithubSettings.svelte`: `.setting-input`.
+- `RemoteSettings.svelte`: both `.setting-input` fields.
+- `SettingsPage.svelte`: `.auth-input`.
+- `TerminalSettings.svelte`: both `.setting-input` fields.
+- `WorktreeMappingSettings.svelte`: `.field input` fields, using `block` and
+  preserving the derived disabled state.
+
+Use `size="md"` for 28-30px controls and retain a feature class only where the
+layout needs flex growth, block width, monospace font, or the 34px auth height.
+
+- [ ] **Step 3: Migrate buttons and option groups**
+
+- `AppearanceSettings.svelte`: use `Button size="sm"` for theme/high-contrast
+  actions and `SegmentedControl` for message layout and font scale.
+
+- `RemoteSettings.svelte`: use `Toggle` for require-auth and `Button size="sm"`
+  for the text-labeled token copy action, preserving loading/disabled and
+  copied-label behavior.
+
+- `SettingsPage.svelte`: use `Button` for resync.
+
+- `TerminalSettings.svelte`: use `SegmentedControl` for launch mode.
+
+- `WorktreeMappingSettings.svelte`: use `SegmentedControl` for layout.
+
+- `InsightsPage.svelte`: use `Button size="sm"` for `.header-action` and
+  `IconButton size="sm" tone="danger"` for `.icon-action`; retain localized
+  accessible labels for icon-only delete/dismiss actions.
+
+Do not rewrite other buttons in these files.
+
+- [ ] **Step 4: Run focused tests and the full conformance suite**
+
+Run:
+
+```bash
+npm test -- src/lib/components/analytics/SkillTrend.test.ts src/lib/components/analytics/TopSkills.test.ts src/lib/components/insights/InsightsPage.test.ts src/lib/components/settings/AppearanceSettings.test.ts src/lib/components/settings/EmbeddingsSettings.test.ts src/lib/components/settings/SettingsPage.test.ts src/lib/components/settings/WorktreeMappingSettings.test.ts
+npm run check:kit-ui
+```
+
+Expected: tests PASS and `kit-ui-check: 0 finding(s)` across the full rule set.
+
+- [ ] **Step 5: Commit the compact-control migration**
+
+Stage only this task's files and commit:
+
+```bash
+git commit -m "refactor(frontend): use semantic kit controls"
+```
+
+### Task 5: Full Verification and Visual QA
+
+**Files:**
+
+- Verify: all modified frontend files
+- Verify: `frontend/e2e/appearance-a11y.spec.ts`
+- Verify: `frontend/e2e/usage.spec.ts`
+- Verify: `frontend/e2e/insights-quality.spec.ts`
+
+**Interfaces:**
+
+- Consumes: the completed component migration.
+
+- Produces: fresh evidence for type safety, behavior, conformance, responsive
+  layout, and task closure.
+
+- [ ] **Step 1: Run complete frontend verification**
+
+Run from `frontend/`:
+
+```bash
+npm run check:kit-ui
+npm run check
+npm test
+```
+
+Expected: all three commands PASS with zero conformance findings.
+
+- [ ] **Step 2: Run relevant Playwright flows**
+
+Run:
+
+```bash
+npx playwright test e2e/appearance-a11y.spec.ts e2e/usage.spec.ts e2e/insights-quality.spec.ts
+```
+
+Expected: all selected workflows PASS. If the local E2E server prerequisites are
+unavailable, record the exact launch failure and run the repository's documented
+E2E setup rather than weakening assertions.
+
+- [ ] **Step 3: Perform desktop and narrow visual checks**
+
+Use the local app at a desktop viewport around 1440×900 and a narrow viewport
+around 390×844. Inspect settings, analytics/insights, trends, activity, and
+usage. Confirm card padding, grid wrapping, overflow, checked/disabled states,
+focus rings, labels, and selected generated-insight rows match the pre-migration
+layout.
+
+- [ ] **Step 4: Review the final diff and private-data scrub**
+
+Run from the repository root:
+
+```bash
+git status --short
+git diff --stat HEAD~4..HEAD
+git diff HEAD~4..HEAD
+```
+
+Expected: only task files changed; the scrub finds no private data in published
+content after manually reviewing the full diff. The design and plan documents
+must refer only to repository-relative paths.
+
+- [ ] **Step 5: Commit any verification-driven fixes**
+
+If verification required tracked-file changes, stage only those fixes and commit
+with a focused conventional message. If no files changed, do not create an empty
+commit.
+
+- [ ] **Step 6: Close kata task `pfvs` after verification**
+
+From the repository root, after the implementation commit SHA is known:
+
+```bash
+kata close pfvs --done --message "Migrated card surfaces and boolean controls to kit-ui components; frontend conformance, type checks, tests, and relevant UI flows pass." --commit "$(git rev-parse HEAD)"
+```
+
+Do not close the task if required verification is incomplete.

--- a/docs/superpowers/plans/2026-07-17-kit-ui-card-checkbox-migration.md
+++ b/docs/superpowers/plans/2026-07-17-kit-ui-card-checkbox-migration.md
@@ -118,9 +118,12 @@ const linkedDates = getByRole("switch", {
 expect(linkedDates.checked).toBe(false);
 
 const normalize = document.querySelector<HTMLInputElement>(
-  'input[role="switch"][aria-label="Normalize by number of messages"]',
+  'input[role="switch"]',
 );
 expect(normalize).not.toBeNull();
+expect(normalize?.closest("label")?.textContent).toContain(
+  "Normalize by number of messages",
+);
 ```
 
 Both assertions are expected to fail against the current native checkbox markup

--- a/docs/superpowers/specs/2026-07-17-kit-ui-card-checkbox-migration-design.md
+++ b/docs/superpowers/specs/2026-07-17-kit-ui-card-checkbox-migration-design.md
@@ -1,0 +1,91 @@
+# Kit UI Card and Checkbox Migration Design
+
+## Context
+
+The current frontend pins `@kenn-io/kit-ui` before its `Card`, `Checkbox`, and
+`Toggle` components and the associated conformance rules. Running the current
+kit-ui checker against the frontend reports 41 findings: 37 matching card
+surfaces and four native checkbox controls.
+
+The migration must adopt the shared components without restyling the affected
+screens or changing their interactions. Existing feature-specific layout and
+state styling remains app-owned; shared surface and boolean-control chrome moves
+to kit-ui.
+
+## Dependency
+
+Update the kit-ui pin and lockfile to commit `a362f4e`, the current main commit
+when the task was claimed. This includes the component introduction and the
+subsequent accessibility contract fixes available at task time.
+
+## Card Migration
+
+Replace each conformance-matched surface with `Card` imported directly from
+`@kenn-io/kit-ui`.
+
+- Use `level="default"` for the existing `bg-surface`, `border-muted`, and
+  `radius-md` recipe.
+- Use `level="inset"` for the existing `bg-inset`, `border-muted`, and
+  `radius-sm` recipe.
+- Use `padding="none"` when the existing component owns bespoke padding,
+  grid/flex layout, overflow, or responsive spacing. Use kit padding only when
+  it exactly matches the current token-based spacing.
+- Pass the existing feature class to `Card` so sizing, layout, responsive
+  behavior, and feature-specific states remain unchanged.
+- Remove only the local background, border, radius, and redundant shadow
+  declarations now provided by the selected `Card` level. Retain layout,
+  typography, dimensions, colors, overflow, and state selectors that remain
+  feature-specific.
+- Do not use structured `Card` header or footer props unless the existing markup
+  already matches those regions without changing DOM order or layout.
+
+No local wrapper component is introduced. The app does not add behavior to these
+surfaces, so a wrapper would duplicate kit-ui's abstraction and make the
+component source less obvious.
+
+## Checkbox and Toggle Migration
+
+Replace the four native checkbox controls according to their user-facing
+semantics:
+
+- Appearance block visibility uses `Checkbox`: each control selects whether a
+  transcript block category is included.
+- Worktree mapping enabled uses `Checkbox`: the value is part of editable form
+  state saved with the mapping.
+- Linked date ranges uses `Toggle`: the setting takes effect immediately as an
+  on/off preference.
+- Trend normalization uses `Toggle`: the setting immediately changes the
+  displayed/query state.
+
+Keep localized labels at the call sites. Preserve `bind:checked` or controlled
+`checked`/`onchange` behavior as appropriate, along with existing disabled and
+accessible-label contracts. Remove local label/input styles that duplicate the
+kit controls, retaining only surrounding layout rules that are still needed.
+
+## Testing and Verification
+
+The dependency bump enables the new conformance rules and establishes the TDD
+red state: `npm run check:kit-ui` must report the known 41 findings before the
+migration. After implementation it must report zero findings across the full
+rule set, including zero `hand-rolled-card` and zero `hand-rolled-checkbox`
+findings.
+
+Run `npm run check` and `npm test` from `frontend/`. Run focused existing tests
+and relevant Playwright flows for any touched workflow with applicable coverage.
+Do not add tests that merely retest kit-ui component behavior. Add a focused app
+test only if the migration changes an app-owned interaction seam that existing
+tests do not protect.
+
+Visually inspect affected representative screens at desktop and narrow viewport
+widths. Cover at least settings, analytics/insights, trends, and usage/activity
+surfaces, checking spacing, overflow, control labels, checked states, and
+disabled behavior.
+
+## Scope Boundaries
+
+- Do not redesign card hierarchy or restyle affected screens.
+- Do not refactor unrelated frontend code.
+- Do not globally disable either conformance rule.
+- Add a `kit-ui-check-ignore` marker only if implementation uncovers a genuine
+  component gap, and document the specific missing capability beside it.
+- Do not change user-facing copy or locale catalogs as part of this migration.

--- a/frontend/e2e/appearance-a11y.spec.ts
+++ b/frontend/e2e/appearance-a11y.spec.ts
@@ -57,6 +57,126 @@ function expectReadableContrast(colors: {
 }
 
 test.describe("Appearance accessibility", () => {
+  test("keeps Insights semantic wrappers as rendered layout boxes", async ({
+    page,
+  }) => {
+    let failSignals = false;
+    await page.route("**/api/v1/analytics/signals*", (route) => {
+      if (failSignals) {
+        return route.fulfill({ status: 500, body: "request failed" });
+      }
+      return route.fulfill({
+        json: {
+          scored_sessions: 2,
+          unscored_sessions: 0,
+          grade_distribution: { A: 1, B: 1 },
+          avg_health_score: 85,
+          outcome_distribution: { completed: 2 },
+          outcome_confidence_distribution: { high: 2 },
+          tool_health: {
+            total_failure_signals: 1,
+            total_retries: 0,
+            total_edit_churn: 0,
+            sessions_with_failures: 1,
+            failure_rate: 50,
+          },
+          context_health: {
+            avg_compaction_count: 0,
+            sessions_with_compaction: 0,
+            mid_task_compaction_count: 0,
+            sessions_with_mid_task_compaction: 0,
+            sessions_with_context_data: 2,
+            avg_context_pressure: 0.2,
+            high_pressure_sessions: 0,
+          },
+          quality_health: {
+            computed_sessions: 2,
+            totals: {
+              short_prompt_count: 2,
+              unstructured_start: 1,
+              missing_success_criteria_count: 0,
+              missing_verification_count: 0,
+              duplicate_prompt_count: 0,
+              no_code_context_count: 0,
+              runaway_tool_loop_count: 0,
+              frustration_marker_count: 0,
+            },
+            sessions_with_signal: {
+              short_prompt_count: 2,
+              unstructured_start: 1,
+              missing_success_criteria_count: 0,
+              missing_verification_count: 0,
+              duplicate_prompt_count: 0,
+              no_code_context_count: 0,
+              runaway_tool_loop_count: 0,
+              frustration_marker_count: 0,
+            },
+          },
+          trend: [],
+          by_agent: [],
+          by_project: [],
+          calibration: {},
+        },
+      });
+    });
+    await page.route("**/api/v1/analytics/signal-sessions*", (route) =>
+      route.fulfill({
+        json: {
+          signal: "short_prompt_count",
+          sessions: [
+            {
+              session_id: "example-session",
+              project: "agentsview",
+              agent: "codex",
+              date: "2026-07-10",
+              is_automated: false,
+              outcome: "completed",
+              health_score: 90,
+              health_grade: "A",
+              signal_total: 1,
+              reason_code: "short_prompt",
+              excerpt: "Example evidence",
+              message_ordinal: 7,
+              failure_signals: 0,
+              retries: 0,
+              edit_churn: 0,
+            },
+          ],
+        },
+      }),
+    );
+
+    await page.goto("/insights");
+    await expect(
+      page.getByRole("heading", { name: "Quality Patterns" }),
+    ).toBeVisible();
+    await page.locator(".driver-row").first().click();
+    await expect(page.locator(".evidence-panel-live")).toBeVisible();
+
+    const contentDisplays = await page.evaluate(() => {
+      const display = (selector: string) =>
+        getComputedStyle(document.querySelector(selector)!).display;
+      return {
+        recommendation: display(".recommendation-content"),
+        summary: display(".summary-card-content"),
+        pattern: display(".pattern-card-content"),
+        evidence: display(".evidence-panel-live"),
+      };
+    });
+    expect(contentDisplays).toEqual({
+      recommendation: "grid",
+      summary: "flex",
+      pattern: "flex",
+      evidence: "grid",
+    });
+
+    failSignals = true;
+    await page.reload();
+    const alert = page.getByRole("alert");
+    await expect(alert).toBeVisible();
+    await expect(alert).toHaveCSS("display", "grid");
+  });
+
   test("text size scales the UI on web without horizontal overflow", async ({
     page,
   }) => {

--- a/frontend/e2e/session-list.spec.ts
+++ b/frontend/e2e/session-list.spec.ts
@@ -124,7 +124,7 @@ test.describe("Session list", () => {
 
     await page.getByRole("button", { name: "Settings" }).click();
     await page
-      .getByRole("checkbox", { name: "Link date ranges across pages" })
+      .getByRole("switch", { name: "Link date ranges across pages" })
       .check();
 
     const requestPromise = page.waitForRequest((request) =>
@@ -179,7 +179,7 @@ test.describe("Session list", () => {
     await page.getByRole("button", { name: "90d", exact: true }).click();
     await page.getByRole("button", { name: "Settings" }).click();
     await page
-      .getByRole("checkbox", { name: "Link date ranges across pages" })
+      .getByRole("switch", { name: "Link date ranges across pages" })
       .check();
 
     await page.goto(

--- a/frontend/e2e/usage.spec.ts
+++ b/frontend/e2e/usage.spec.ts
@@ -214,7 +214,7 @@ test.describe("Usage page", () => {
 
     await page.getByRole("button", { name: "Settings" }).click();
     await page
-      .getByRole("checkbox", { name: "Link date ranges across pages" })
+      .getByRole("switch", { name: "Link date ranges across pages" })
       .check();
 
     await clickNavTab(page, "Usage");

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "agentsview-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@kenn-io/kit-ui": "git+https://github.com/kenn-io/kit-ui.git#7b6118630e617599836871e0b4c0c05343f3dce4",
+        "@kenn-io/kit-ui": "git+https://github.com/kenn-io/kit-ui.git#a362f4ecfbc6d4381225c771ec423df5b62a8d09",
         "@lucide/svelte": "1.24.0",
         "@tanstack/virtual-core": "3.17.3",
         "dompurify": "3.4.11",
@@ -491,8 +491,8 @@
     },
     "node_modules/@kenn-io/kit-ui": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/kenn-io/kit-ui.git#7b6118630e617599836871e0b4c0c05343f3dce4",
-      "integrity": "sha512-TucvwCPB8DAPm60XnnV2UeACcf0fg4Cg9BCE1nNTvL7Bm95x7SweG0JTvxsguNAKOqVu767Tw55HM44DoPc4+A==",
+      "resolved": "git+ssh://git@github.com/kenn-io/kit-ui.git#a362f4ecfbc6d4381225c771ec423df5b62a8d09",
+      "integrity": "sha512-lOUuJgv1AQ3LBPbEWVv8Fkhsu6dM8K2nxAU41OaUQ6ycUUn59mYyyE5gJR4rgy2xL/qDLKqiMqBG6SkFI5KrwA==",
       "license": "Apache-2.0",
       "bin": {
         "kit-ui-check": "bin/kit-ui-check.mjs"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
     "e2e": "playwright test"
   },
   "dependencies": {
-    "@kenn-io/kit-ui": "git+https://github.com/kenn-io/kit-ui.git#7b6118630e617599836871e0b4c0c05343f3dce4",
+    "@kenn-io/kit-ui": "git+https://github.com/kenn-io/kit-ui.git#a362f4ecfbc6d4381225c771ec423df5b62a8d09",
     "@lucide/svelte": "1.24.0",
     "@tanstack/virtual-core": "3.17.3",
     "dompurify": "3.4.11",

--- a/frontend/src/lib/components/activity/ActivityPage.svelte
+++ b/frontend/src/lib/components/activity/ActivityPage.svelte
@@ -16,7 +16,7 @@
     type PanelDateState,
   } from "../../stores/yokedDates.svelte.js";
   import ProjectTypeahead from "../layout/ProjectTypeahead.svelte";
-  import { Typeahead, type TypeaheadOption } from "@kenn-io/kit-ui";
+  import { Card, Typeahead, type TypeaheadOption } from "@kenn-io/kit-ui";
   import RefreshControl from "../shared/RefreshControl.svelte";
   import {
     addDays,
@@ -384,24 +384,24 @@
          error states only show before the first report exists. -->
     {#if activity.report}
       <SummaryCards report={activity.report} />
-      <div class="chart-panel">
+      <Card level="default" padding="none" class="chart-panel">
         <ConcurrencyTimeline
           report={activity.report}
           selectedBucket={slotFilter?.idx ?? null}
           onSelectBucket={(sel) => (slotFilter = sel)}
         />
-      </div>
-      <div class="chart-panel">
+      </Card>
+      <Card level="default" padding="none" class="chart-panel">
         <SessionsTable
           report={activity.report}
           filterIds={slotFilter?.sessionIds ?? null}
           filterLabel={slotFilter?.label ?? ""}
           onClearFilter={() => (slotFilter = null)}
         />
-      </div>
-      <div class="chart-panel">
+      </Card>
+      <Card level="default" padding="none" class="chart-panel">
         <Breakdowns report={activity.report} />
-      </div>
+      </Card>
     {:else if activity.loading}
       <div class="status">{m.activity_loading_report()}</div>
     {:else if activity.error}
@@ -422,13 +422,13 @@
          single-day fallback (a deep link to a week/month/custom range would
          otherwise fetch an insight for the wrong span while the report loads). -->
     {#if activity.report}
-      <div class="chart-panel">
+      <Card level="default" padding="none" class="chart-panel">
         <ActivityInsight
           dateFrom={insightFrom}
           dateTo={insightTo}
           timezone={activity.timezone}
         />
-      </div>
+      </Card>
     {/if}
   </div>
 </div>
@@ -471,10 +471,7 @@
     gap: 16px;
   }
 
-  .chart-panel {
-    background: var(--bg-surface);
-    border: 1px solid var(--border-muted);
-    border-radius: var(--radius-md);
+  .activity-content :global(.chart-panel) {
     padding: 12px;
     min-width: 0;
   }

--- a/frontend/src/lib/components/activity/SummaryCards.svelte
+++ b/frontend/src/lib/components/activity/SummaryCards.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { Card } from "@kenn-io/kit-ui";
   import { formatDateTime, m } from "../../i18n/index.js";
   import type { Report } from "../../api/types.js";
 
@@ -55,14 +56,14 @@
   const peakAt = $derived(fmtClock(report.peak.at));
   const asOf = $derived(fmtClock(report.as_of));
 
-  interface Card {
+  interface SummaryCard {
     label: string;
     value: string;
     sub?: string;
     featured?: boolean;
   }
 
-  const cards = $derived.by((): Card[] => {
+  const cards = $derived.by((): SummaryCard[] => {
     const t = report.totals;
     return [
       {
@@ -105,13 +106,17 @@
 
 <div class="summary-cards">
   {#each cards as card}
-    <div class="card" class:featured={card.featured}>
+    <Card
+      level="default"
+      padding="none"
+      class={card.featured ? "card featured" : "card"}
+    >
       <span class="card-value">{card.value}</span>
       <span class="card-label">{card.label}</span>
       {#if card.sub}
         <span class="card-sub">{card.sub}</span>
       {/if}
-    </div>
+    </Card>
   {/each}
 </div>
 
@@ -126,19 +131,20 @@
     flex-wrap: wrap;
   }
 
-  .card {
+  .summary-cards :global(.card) {
     flex: 1;
     min-width: 110px;
     padding: 12px;
-    background: var(--bg-surface);
-    border: 1px solid var(--border-muted);
-    border-radius: var(--radius-md);
     display: flex;
     flex-direction: column;
     gap: 2px;
   }
 
-  .card.featured {
+  .summary-cards :global(.card > .kit-card__body) {
+    display: contents;
+  }
+
+  .summary-cards :global(.card.featured) {
     border-width: 2px;
     border-color: var(--accent-blue);
   }

--- a/frontend/src/lib/components/analytics/AnalyticsPage.svelte
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { Card } from "@kenn-io/kit-ui";
   import { onMount, onDestroy, untrack } from "svelte";
   import RangePicker from "../shared/RangePicker.svelte";
   import {
@@ -562,11 +563,11 @@
     <SummaryCards />
 
     <div class="chart-grid">
-      <div class="chart-panel wide">
+      <Card level="default" padding="none" class="chart-panel wide">
         <Heatmap />
-      </div>
+      </Card>
 
-      <div class="chart-panel">
+      <Card level="default" padding="none" class="chart-panel">
         <div class="chart-header">
           <h3 class="chart-title">
             {m.analytics_activity_by_day_hour()}
@@ -578,39 +579,39 @@
         <ActivityTimeline onDateRangeChange={handleDateRangeChange} />
         <div class="chart-divider"></div>
         <HourOfWeekHeatmap />
-      </div>
+      </Card>
 
-      <div class="chart-panel">
+      <Card level="default" padding="none" class="chart-panel">
         <TopSessions />
-      </div>
+      </Card>
 
-      <div class="chart-panel wide">
+      <Card level="default" padding="none" class="chart-panel wide">
         <ProjectBreakdown />
-      </div>
+      </Card>
 
-      <div class="chart-panel">
+      <Card level="default" padding="none" class="chart-panel">
         <SessionShape />
-      </div>
+      </Card>
 
-      <div class="chart-panel">
+      <Card level="default" padding="none" class="chart-panel">
         <ToolUsage />
-      </div>
+      </Card>
 
-      <div class="chart-panel wide">
+      <Card level="default" padding="none" class="chart-panel wide">
         <TopSkills />
-      </div>
+      </Card>
 
-      <div class="chart-panel wide">
+      <Card level="default" padding="none" class="chart-panel wide">
         <SkillTrend />
-      </div>
+      </Card>
 
-      <div class="chart-panel wide">
+      <Card level="default" padding="none" class="chart-panel wide">
         <VelocityMetrics />
-      </div>
+      </Card>
 
-      <div class="chart-panel wide">
+      <Card level="default" padding="none" class="chart-panel wide">
         <AgentComparison />
-      </div>
+      </Card>
     </div>
 
     <SessionHealthSection />
@@ -704,19 +705,21 @@
     gap: 12px;
   }
 
-  .chart-panel {
-    background: var(--bg-surface);
-    border: 1px solid var(--border-muted);
-    border-radius: var(--radius-md);
+  .chart-grid :global(.chart-panel) {
     padding: 12px;
     min-height: 200px;
     min-width: 0;
     overflow-x: hidden;
     display: flex;
     flex-direction: column;
+    gap: 0;
   }
 
-  .chart-panel.wide {
+  .chart-grid :global(.chart-panel > .kit-card__body) {
+    display: contents;
+  }
+
+  .chart-grid :global(.chart-panel.wide) {
     grid-column: 1 / -1;
   }
 

--- a/frontend/src/lib/components/analytics/SessionHealthSection.svelte
+++ b/frontend/src/lib/components/analytics/SessionHealthSection.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { Card } from "@kenn-io/kit-ui";
   import { analytics } from "../../stores/analytics.svelte.js";
   import { scoreToGrade } from "../../utils/grade.js";
   import GradeDistribution
@@ -39,7 +40,7 @@
     </div>
 
     <div class="health-summary-cards">
-      <div class="card">
+      <Card level="default" padding="none" class="card">
         <span class="card-label">{m.analytics_session_health_avg_score()}</span>
         <span class="card-value">
           {signals.avg_health_score != null
@@ -51,8 +52,8 @@
             {m.analytics_session_health_grade({ grade: scoreToGrade(signals.avg_health_score) })}
           </span>
         {/if}
-      </div>
-      <div class="card">
+      </Card>
+      <Card level="default" padding="none" class="card">
         <span class="card-label">{m.analytics_session_health_completed()}</span>
         <span class="card-value" style:color="var(--accent-green)">
           {#if signals.scored_sessions > 0}
@@ -69,8 +70,8 @@
         <span class="card-sub">
           {formatSessionCount(signals.outcome_distribution?.completed ?? 0)}
         </span>
-      </div>
-      <div class="card">
+      </Card>
+      <Card level="default" padding="none" class="card">
         <span class="card-label">{m.analytics_session_health_errored()}</span>
         <span class="card-value" style:color="var(--accent-red)">
           {#if signals.scored_sessions > 0}
@@ -87,8 +88,8 @@
         <span class="card-sub">
           {formatSessionCount(signals.outcome_distribution?.errored ?? 0)}
         </span>
-      </div>
-      <div class="card">
+      </Card>
+      <Card level="default" padding="none" class="card">
         <span class="card-label">{m.analytics_session_health_tool_failures()}</span>
         <span class="card-value" style:color="var(--accent-amber)">
           {#if signals.scored_sessions > 0}
@@ -100,8 +101,8 @@
         <span class="card-sub">
           {formatSessionCount(signals.tool_health.sessions_with_failures)}
         </span>
-      </div>
-      <div class="card">
+      </Card>
+      <Card level="default" padding="none" class="card">
         <span class="card-label">{m.analytics_session_health_compactions()}</span>
         <span
           class="card-value"
@@ -121,24 +122,24 @@
             value: signals.context_health.avg_compaction_count.toFixed(1),
           })}
         </span>
-      </div>
+      </Card>
     </div>
 
     <div class="chart-grid">
-      <div class="chart-panel">
+      <Card level="default" padding="none" class="chart-panel">
         <GradeDistribution
           distribution={signals.grade_distribution}
         />
-      </div>
-      <div class="chart-panel">
+      </Card>
+      <Card level="default" padding="none" class="chart-panel">
         <OutcomeDistribution
           distribution={signals.outcome_distribution}
         />
-      </div>
-      <div class="chart-panel wide">
+      </Card>
+      <Card level="default" padding="none" class="chart-panel wide">
         <HealthTrend trend={signals.trend} />
-      </div>
-      <div class="chart-panel">
+      </Card>
+      <Card level="default" padding="none" class="chart-panel">
         <div class="mini-table">
           <div class="table-title">{m.analytics_by_agent()}</div>
           <table>
@@ -170,8 +171,8 @@
             </tbody>
           </table>
         </div>
-      </div>
-      <div class="chart-panel">
+      </Card>
+      <Card level="default" padding="none" class="chart-panel">
         <div class="mini-table">
           <div class="table-title">{m.analytics_by_project()}</div>
           <table>
@@ -203,7 +204,7 @@
             </tbody>
           </table>
         </div>
-      </div>
+      </Card>
     </div>
   </div>
 {/if}
@@ -231,10 +232,7 @@
     gap: 12px;
     margin-bottom: 12px;
   }
-  .card {
-    background: var(--bg-surface);
-    border: 1px solid var(--border-muted);
-    border-radius: var(--radius-md);
+  .health-summary-cards :global(.card) {
     padding: 12px;
   }
   .card-label {
@@ -261,13 +259,10 @@
     grid-template-columns: 1fr 1fr;
     gap: 12px;
   }
-  .chart-panel {
-    background: var(--bg-surface);
-    border: 1px solid var(--border-muted);
-    border-radius: var(--radius-md);
+  .chart-grid :global(.chart-panel) {
     padding: 12px;
   }
-  .chart-panel.wide {
+  .chart-grid :global(.chart-panel.wide) {
     grid-column: 1 / -1;
   }
   .mini-table {
@@ -304,7 +299,7 @@
     .chart-grid {
       grid-template-columns: 1fr;
     }
-    .chart-panel.wide {
+    .chart-grid :global(.chart-panel.wide) {
       grid-column: 1;
     }
   }

--- a/frontend/src/lib/components/analytics/SkillTrend.svelte
+++ b/frontend/src/lib/components/analytics/SkillTrend.svelte
@@ -461,7 +461,7 @@
     margin-bottom: 10px;
   }
 
-  .legend-chip {
+  .legend-chip { /* kit-ui-check-ignore: the legend is a pressed-state toggle, and the current kit Chip and Button controls cannot preserve aria-pressed. */
     display: inline-flex;
     align-items: center;
     gap: var(--space-2);

--- a/frontend/src/lib/components/analytics/SummaryCards.svelte
+++ b/frontend/src/lib/components/analytics/SummaryCards.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { Card } from "@kenn-io/kit-ui";
   import { analytics } from "../../stores/analytics.svelte.js";
   import { m } from "../../i18n/index.js";
 
@@ -10,13 +11,13 @@
     return `${(n * 100).toFixed(1)}%`;
   }
 
-  interface Card {
+  interface SummaryCard {
     label: () => string;
     value: () => string;
     sub?: () => string;
   }
 
-  const cards: Card[] = [
+  const cards: SummaryCard[] = [
     {
       label: () => m.analytics_summary_sessions(),
       value: () =>
@@ -63,7 +64,7 @@
 
 <div class="summary-cards">
   {#each cards as card}
-    <div class="card">
+    <Card level="default" padding="none" class="card">
       {#if analytics.errors.summary}
         <span class="card-value error">--</span>
         <span class="card-label">{card.label()}</span>
@@ -79,7 +80,7 @@
           {/if}
         {/if}
       {/if}
-    </div>
+    </Card>
   {/each}
 </div>
 
@@ -102,16 +103,17 @@
     flex-wrap: wrap;
   }
 
-  .card {
+  .summary-cards :global(.card) {
     flex: 1;
     min-width: 120px;
     padding: 12px;
-    background: var(--bg-surface);
-    border: 1px solid var(--border-muted);
-    border-radius: var(--radius-md);
     display: flex;
     flex-direction: column;
     gap: 2px;
+  }
+
+  .summary-cards :global(.card > .kit-card__body) {
+    display: contents;
   }
 
   .card-value {

--- a/frontend/src/lib/components/analytics/TopSkills.svelte
+++ b/frontend/src/lib/components/analytics/TopSkills.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { Chip } from "@kenn-io/kit-ui";
   import { analytics } from "../../stores/analytics.svelte.js";
   import type {
     SkillAgentBreakdown,
@@ -140,13 +141,13 @@
             <span class="breakdown-label">{m.analytics_top_skills_agents()}</span>
             {#if skill.agent_breakdown?.length}
               {#each skill.agent_breakdown as agent}
-                <span class="agent-chip">
+                <Chip size="xs" uppercase={false} class="agent-chip">
                   <span class="agent-name">{agent.agent}</span>
                   <span class="agent-count">{agent.count.toLocaleString()}</span>
                   <span class="agent-pct">
                     {agentPct(agent, skill.call_count)}
                   </span>
-                </span>
+                </Chip>
               {/each}
             {:else}
               <span class="muted">{m.shared_none()}</span>
@@ -285,15 +286,8 @@
     color: var(--text-secondary);
   }
 
-  .agent-chip {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
+  :global(.agent-chip.kit-chip) {
     max-width: 160px;
-    padding: 2px 5px;
-    border: 1px solid var(--border-muted);
-    border-radius: var(--radius-sm);
-    background: var(--bg-inset);
     color: var(--text-secondary);
   }
 

--- a/frontend/src/lib/components/insights/InsightsPage.svelte
+++ b/frontend/src/lib/components/insights/InsightsPage.svelte
@@ -2377,6 +2377,16 @@
 
   .content :global(.inline-warning) {
     padding: 9px 10px;
+    background: color-mix(
+      in srgb,
+      var(--accent-amber) 10%,
+      var(--bg-surface)
+    );
+    border-color: color-mix(
+      in srgb,
+      var(--accent-amber) 24%,
+      var(--border-muted)
+    );
     color: var(--text-secondary);
     font-size: 12px;
   }

--- a/frontend/src/lib/components/insights/InsightsPage.svelte
+++ b/frontend/src/lib/components/insights/InsightsPage.svelte
@@ -35,7 +35,7 @@
     SignalCalibration,
     SignalSessionExample,
   } from "../../api/types.js";
-  import { Card, CopyButton, IconButton, Typeahead } from "@kenn-io/kit-ui";
+  import { Button, Card, CopyButton, IconButton, Typeahead } from "@kenn-io/kit-ui";
   import ProjectTypeahead from "../layout/ProjectTypeahead.svelte";
   import RangePicker from "../shared/RangePicker.svelte";
   import {
@@ -1287,21 +1287,22 @@
                     >
                       {m.insights_page_retry()}
                     </button>
-                    <button
-                      class="icon-action danger"
-                      type="button"
+                    <IconButton
+                      class="icon-action"
+                      size="sm"
+                      tone="danger"
                       onclick={() =>
                         insights.dismissTask(
                           insights.selectedTask!.clientId,
                         )}
                       title={m.insights_page_dismiss_failed()}
-                      aria-label={m.insights_page_dismiss_failed()}
+                      ariaLabel={m.insights_page_dismiss_failed()}
                     >
                       <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
                         <path d="M5.5 5.5A.5.5 0 016 6v6a.5.5 0 01-1 0V6a.5.5 0 01.5-.5zm2.5 0a.5.5 0 01.5.5v6a.5.5 0 01-1 0V6a.5.5 0 01.5-.5zm3 .5a.5.5 0 00-1 0v6a.5.5 0 001 0V6z"/>
                         <path fill-rule="evenodd" d="M14.5 3a1 1 0 01-1 1H13v9a2 2 0 01-2 2H5a2 2 0 01-2-2V4h-.5a1 1 0 01-1-1V2a1 1 0 011-1H5.5l1-1h3l1 1h2.5a1 1 0 011 1v1zM4.118 4L4 4.059V13a1 1 0 001 1h6a1 1 0 001-1V4.059L11.882 4H4.118zM2.5 3V2h11v1h-11z"/>
                       </svg>
-                    </button>
+                    </IconButton>
                   </div>
                 {/if}
               </div>
@@ -1338,27 +1339,27 @@
                   {/if}
                 </div>
                 <div class="generated-actions">
-                  <button
+                  <Button
                     class="header-action"
-                    type="button"
+                    size="sm"
                     onclick={handleInsightExport}
                   >
                     Export
-                  </button>
-                  <button
+                  </Button>
+                  <Button
                     class="header-action"
-                    type="button"
+                    size="sm"
                     onclick={() => openInsightPublish(false)}
                   >
                     Publish
-                  </button>
-                  <button
+                  </Button>
+                  <Button
                     class="header-action subtle"
-                    type="button"
+                    size="sm"
                     onclick={() => openInsightPublish(true)}
                   >
                     Secret
-                  </button>
+                  </Button>
                   <CopyButton
                     class="insight-link-copy"
                     copied={copiedInsightLinkId === insights.selectedItem.id}
@@ -1369,9 +1370,10 @@
                     onclick={() =>
                       handleCopyInsightLink(insights.selectedItem!.id)}
                   />
-                  <button
-                    class="icon-action danger"
-                    type="button"
+                  <IconButton
+                    class="icon-action"
+                    size="sm"
+                    tone="danger"
                     onclick={() => {
                       if (insights.selectedItem) {
                         insights.deleteItem(insights.selectedItem.id);
@@ -1381,13 +1383,13 @@
                       }
                     }}
                     title={m.insights_page_delete_insight()}
-                    aria-label={m.insights_page_delete_insight()}
+                    ariaLabel={m.insights_page_delete_insight()}
                   >
                     <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
                       <path d="M5.5 5.5A.5.5 0 016 6v6a.5.5 0 01-1 0V6a.5.5 0 01.5-.5zm2.5 0a.5.5 0 01.5.5v6a.5.5 0 01-1 0V6a.5.5 0 01.5-.5zm3 .5a.5.5 0 00-1 0v6a.5.5 0 001 0V6z"/>
                       <path fill-rule="evenodd" d="M14.5 3a1 1 0 01-1 1H13v9a2 2 0 01-2 2H5a2 2 0 01-2-2V4h-.5a1 1 0 01-1-1V2a1 1 0 011-1H5.5l1-1h3l1 1h2.5a1 1 0 011 1v1zM4.118 4L4 4.059V13a1 1 0 001 1h6a1 1 0 001-1V4.059L11.882 4H4.118zM2.5 3V2h11v1h-11z"/>
                     </svg>
-                  </button>
+                  </IconButton>
                 </div>
               </div>
               <div class="markdown-body">
@@ -2177,26 +2179,11 @@
     gap: 8px;
   }
 
-  .header-action {
-    height: 28px;
-    padding: 0 10px;
-    border-radius: var(--radius-sm);
-    font-size: 11px;
+  :global(.header-action.kit-button) {
     font-weight: 600;
-    color: var(--text-secondary);
-    background: var(--bg-inset);
-    border: 1px solid var(--border-muted);
-    transition: background 0.12s, color 0.12s,
-      border-color 0.12s;
   }
 
-  .header-action:hover {
-    background: var(--bg-surface-hover);
-    color: var(--text-primary);
-    border-color: var(--border-default);
-  }
-
-  .header-action.subtle {
+  :global(.header-action.subtle.kit-button) {
     color: var(--text-muted);
   }
 
@@ -2244,39 +2231,6 @@
 
   .generated-actions :global(.insight-link-copy.kit-copy-btn:hover) {
     border-color: var(--border-default);
-  }
-
-  .icon-action {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 26px;
-    height: 26px;
-    border: 1px solid var(--border-muted);
-    border-radius: var(--radius-sm);
-    background: var(--bg-inset);
-    color: var(--text-muted);
-    cursor: pointer;
-    flex-shrink: 0;
-    transition:
-      background 0.15s,
-      border-color 0.15s,
-      color 0.15s,
-      transform 0.08s;
-  }
-
-  .icon-action:hover {
-    background: var(--bg-surface-hover);
-    border-color: var(--border-default);
-    color: var(--text-primary);
-  }
-
-  .icon-action.danger:hover {
-    color: var(--accent-red);
-  }
-
-  .icon-action:active {
-    transform: scale(0.94);
   }
 
   .detail-chip {

--- a/frontend/src/lib/components/insights/InsightsPage.svelte
+++ b/frontend/src/lib/components/insights/InsightsPage.svelte
@@ -1612,9 +1612,17 @@
     justify-content: space-between;
   }
 
-  .summary-grid :global(.summary-card > .kit-card__body),
-  .summary-card-content {
+  .summary-grid :global(.summary-card > .kit-card__body) {
     display: contents;
+  }
+
+  .summary-card-content {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    gap: 0;
+    justify-content: space-between;
+    min-width: 0;
   }
 
   .summary-grid :global(.summary-card .label) {
@@ -1690,9 +1698,16 @@
     gap: 12px;
   }
 
-  .pattern-grid :global(.pattern-card > .kit-card__body),
-  .pattern-card-content {
+  .pattern-grid :global(.pattern-card > .kit-card__body) {
     display: contents;
+  }
+
+  .pattern-card-content {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    gap: 12px;
+    min-width: 0;
   }
 
   .pattern-head {
@@ -1912,9 +1927,14 @@
     padding: 12px;
   }
 
-  .content :global(.evidence-panel > .kit-card__body),
-  .evidence-panel-live {
+  .content :global(.evidence-panel > .kit-card__body) {
     display: contents;
+  }
+
+  .evidence-panel-live {
+    display: grid;
+    gap: var(--space-5);
+    min-width: 0;
   }
 
   .evidence-head {
@@ -2004,9 +2024,14 @@
     gap: var(--space-3);
   }
 
-  .recommendation-list :global(.recommendation > .kit-card__body),
-  .recommendation-content {
+  .recommendation-list :global(.recommendation > .kit-card__body) {
     display: contents;
+  }
+
+  .recommendation-content {
+    display: grid;
+    gap: var(--space-3);
+    min-width: 0;
   }
 
   .recommendation-list :global(.recommendation strong) {
@@ -2296,9 +2321,14 @@
     color: var(--text-secondary);
   }
 
-  .content :global(.state-panel > .kit-card__body),
-  .state-panel-alert {
+  .content :global(.state-panel > .kit-card__body) {
     display: contents;
+  }
+
+  .state-panel-alert {
+    display: grid;
+    gap: 6px;
+    min-width: 0;
   }
 
   .content :global(.state-panel strong) {

--- a/frontend/src/lib/components/insights/InsightsPage.svelte
+++ b/frontend/src/lib/components/insights/InsightsPage.svelte
@@ -35,7 +35,7 @@
     SignalCalibration,
     SignalSessionExample,
   } from "../../api/types.js";
-  import { CopyButton, IconButton, Typeahead } from "@kenn-io/kit-ui";
+  import { Card, CopyButton, IconButton, Typeahead } from "@kenn-io/kit-ui";
   import ProjectTypeahead from "../layout/ProjectTypeahead.svelte";
   import RangePicker from "../shared/RangePicker.svelte";
   import {
@@ -466,6 +466,35 @@
     router.navigateToSession(example.session_id, params);
   }
 
+  function openEvidenceListSession(event: MouseEvent) {
+    if (
+      !(event.target instanceof Element) ||
+      !(event.currentTarget instanceof HTMLElement)
+    ) return;
+    const link = event.target.closest<HTMLAnchorElement>("a.evidence-row");
+    if (!link) return;
+    const links = Array.from(
+      event.currentTarget.querySelectorAll<HTMLAnchorElement>(
+        "a.evidence-row",
+      ),
+    );
+    const example = signalExamples[links.indexOf(link)];
+    if (!example) return;
+    openEvidenceSession(example, event);
+  }
+
+  function delegateEvidenceClicks(node: HTMLElement) {
+    const handleClick = (event: MouseEvent) => {
+      openEvidenceListSession(event);
+    };
+    node.addEventListener("click", handleClick);
+    return {
+      destroy() {
+        node.removeEventListener("click", handleClick);
+      },
+    };
+  }
+
   function evidenceSessionParams(
     example: SignalSessionExample,
   ): Record<string, string> {
@@ -848,20 +877,22 @@
       </div>
 
       {#if recommendations.length === 0}
-        <div class="state-panel compact-state">
+        <Card level="default" padding="none" class="state-panel compact-state">
           <strong>{m.insights_page_no_rule_actions()}</strong>
           <span>
             {m.insights_page_patterns_clear()}
           </span>
-        </div>
+        </Card>
       {:else}
         <div class="recommendation-list">
           {#each recommendations as rec}
-            <article class="recommendation">
-              <span class="badge rule">{m.insights_page_rule_based()}</span>
-              <strong>{rec.label}</strong>
-              <p>{rec.rationale}</p>
-            </article>
+            <Card level="default" padding="none" class="recommendation">
+              <article class="recommendation-content">
+                <span class="badge rule">{m.insights_page_rule_based()}</span>
+                <strong>{rec.label}</strong>
+                <p>{rec.rationale}</p>
+              </article>
+            </Card>
           {/each}
         </div>
       {/if}
@@ -889,63 +920,80 @@
         </div>
         <div class="pattern-grid">
           {#each Array(4) as _}
-            <div class="skeleton-pattern"></div>
+            <Card level="default" padding="none" class="skeleton-pattern"></Card>
           {/each}
         </div>
       {:else if error && !signals}
-        <div class="state-panel error" role="alert">
-          <strong>{m.insights_page_could_not_load()}</strong>
-          <span>{error}</span>
-          <button onclick={fetchInsightSignals}>
-            {m.insights_page_retry()}
-          </button>
-        </div>
+        <Card level="default" padding="none" class="state-panel error">
+          <div class="state-panel-alert" role="alert">
+            <strong>{m.insights_page_could_not_load()}</strong>
+            <span>{error}</span>
+            <button onclick={fetchInsightSignals}>
+              {m.insights_page_retry()}
+            </button>
+          </div>
+        </Card>
       {:else if !hasData}
-        <div class="state-panel">
+        <Card level="default" padding="none" class="state-panel">
           <strong>{m.insights_page_no_scored_data()}</strong>
           <span>
             {m.insights_page_no_scored_data_hint()}
           </span>
-        </div>
+        </Card>
       {:else}
         {#if error}
-          <div class="inline-warning" role="status">
-            {m.insights_page_cached_warning({ error })}
-          </div>
+          <Card level="default" padding="none" class="inline-warning">
+            <div role="status">
+              {m.insights_page_cached_warning({ error })}
+            </div>
+          </Card>
         {/if}
 
         <div class="summary-grid">
-          <article class="summary-card">
-            <span class="label">{m.insights_page_average_score()}</span>
-            <strong>
-              {summary.avgHealthScore == null
-                ? "--"
-                : Math.round(summary.avgHealthScore)}
-            </strong>
-            <span>
-              {summary.avgHealthScore == null
-                ? m.insights_page_no_scored_sessions()
-                : m.insights_page_grade_badge({ grade: scoreToGrade(summary.avgHealthScore) })}
-            </span>
-          </article>
-          <article class="summary-card">
-            <span class="label">{m.insights_page_scored_sessions()}</span>
-            <strong>{summary.scoredSessions}</strong>
-            <span>{m.insights_page_unscored_count({ count: summary.unscoredSessions })}</span>
-          </article>
-          <article class="summary-card">
-            <span class="label">{m.insights_page_low_quality()}</span>
-            <strong>{summary.lowQualitySessions}</strong>
-            <span>{m.insights_page_df_graded()}</span>
-          </article>
-          <article class="summary-card">
-            <span class="label">{m.insights_page_prompt_signals()}</span>
-            <strong>{summary.computedQualitySessions}</strong>
-            <span>{m.insights_page_sessions_computed()}</span>
-          </article>
+          <Card level="default" padding="none" class="summary-card">
+            <article class="summary-card-content">
+              <span class="label">{m.insights_page_average_score()}</span>
+              <strong>
+                {summary.avgHealthScore == null
+                  ? "--"
+                  : Math.round(summary.avgHealthScore)}
+              </strong>
+              <span>
+                {summary.avgHealthScore == null
+                  ? m.insights_page_no_scored_sessions()
+                  : m.insights_page_grade_badge({ grade: scoreToGrade(summary.avgHealthScore) })}
+              </span>
+            </article>
+          </Card>
+          <Card level="default" padding="none" class="summary-card">
+            <article class="summary-card-content">
+              <span class="label">{m.insights_page_scored_sessions()}</span>
+              <strong>{summary.scoredSessions}</strong>
+              <span>{m.insights_page_unscored_count({ count: summary.unscoredSessions })}</span>
+            </article>
+          </Card>
+          <Card level="default" padding="none" class="summary-card">
+            <article class="summary-card-content">
+              <span class="label">{m.insights_page_low_quality()}</span>
+              <strong>{summary.lowQualitySessions}</strong>
+              <span>{m.insights_page_df_graded()}</span>
+            </article>
+          </Card>
+          <Card level="default" padding="none" class="summary-card">
+            <article class="summary-card-content">
+              <span class="label">{m.insights_page_prompt_signals()}</span>
+              <strong>{summary.computedQualitySessions}</strong>
+              <span>{m.insights_page_sessions_computed()}</span>
+            </article>
+          </Card>
         </div>
 
-        <div class="distribution-row" aria-label={m.insights_page_score_distribution()}>
+        <Card
+          level="default"
+          padding="none"
+          class="distribution-row"
+          ariaLabel={m.insights_page_score_distribution()}
+        >
           {#each summary.scoreDistribution as bucket}
             <div class="grade-bar">
               <span>{bucket.grade}</span>
@@ -958,14 +1006,19 @@
               <strong>{bucket.count}</strong>
             </div>
           {/each}
-        </div>
+        </Card>
 
         <div class="pattern-grid">
           {#each patterns as pattern}
-            <article
+            <Card
+              level="default"
+              padding="none"
               class={`pattern-card severity-${pattern.severity}`}
-              aria-labelledby={`${pattern.id}-title`}
             >
+              <article
+                class="pattern-card-content"
+                aria-labelledby={`${pattern.id}-title`}
+              >
               <div class="pattern-head">
                 <div>
                   <h3 id={`${pattern.id}-title`}>
@@ -1031,13 +1084,15 @@
                   {/each}
                 </div>
               {/if}
-            </article>
+              </article>
+            </Card>
           {/each}
         </div>
 
         {#if selectedSignalId}
-          <section class="evidence-panel" aria-live="polite">
-            <div class="evidence-head">
+          <Card level="default" padding="none" class="evidence-panel">
+            <section class="evidence-panel-live" aria-live="polite">
+              <div class="evidence-head">
               <div>
                 <span class="examples-label">{m.insights_page_session_evidence()}</span>
                 <h3>{selectedSignalLabel()}</h3>
@@ -1056,42 +1111,43 @@
               >
                 {m.insights_page_close()}
               </button>
-            </div>
-            {#if signalExamplesLoading}
-              <p class="evidence-state">{m.insights_page_loading_examples()}</p>
-            {:else if signalExamplesError}
-              <p class="evidence-state error">{signalExamplesError}</p>
-            {:else if signalExamples.length === 0}
-              <p class="evidence-state">
-                {m.insights_page_no_triggering_sessions()}
-              </p>
-            {:else}
-              <div class="evidence-list">
-                {#each signalExamples as example}
-                  <a
-                    class="evidence-row"
-                    href={router.buildSessionHref(
+              </div>
+              {#if signalExamplesLoading}
+                <p class="evidence-state">{m.insights_page_loading_examples()}</p>
+              {:else if signalExamplesError}
+                <p class="evidence-state error">{signalExamplesError}</p>
+              {:else if signalExamples.length === 0}
+                <p class="evidence-state">
+                  {m.insights_page_no_triggering_sessions()}
+                </p>
+              {:else}
+                <div class="evidence-list" use:delegateEvidenceClicks>
+                  {#each signalExamples as example}
+                    <Card
+                      level="inset"
+                      padding="none"
+                      class="evidence-row"
+                      href={router.buildSessionHref(
                       example.session_id,
                       evidenceSessionParams(example),
                     )}
-                    onclick={(event) =>
-                      openEvidenceSession(example, event)}
-                  >
-                    <span class="evidence-main">
-                      <strong>{example.project || m.insights_page_unassigned_project()}</strong>
-                      <em>{example.excerpt || m.insights_page_no_excerpt()}</em>
-                    </span>
-                    <span class="evidence-meta">
-                      <span>{agentLabel(example.agent)}</span>
-                      <span>{example.outcome || m.insights_page_unknown()}</span>
-                      <span>{qualityBadge(example)}</span>
-                      <span>{m.insights_page_failures({ count: example.failure_signals })}</span>
-                    </span>
-                  </a>
-                {/each}
-              </div>
-            {/if}
-          </section>
+                    >
+                      <span class="evidence-main">
+                        <strong>{example.project || m.insights_page_unassigned_project()}</strong>
+                        <em>{example.excerpt || m.insights_page_no_excerpt()}</em>
+                      </span>
+                      <span class="evidence-meta">
+                        <span>{agentLabel(example.agent)}</span>
+                        <span>{example.outcome || m.insights_page_unknown()}</span>
+                        <span>{qualityBadge(example)}</span>
+                        <span>{m.insights_page_failures({ count: example.failure_signals })}</span>
+                      </span>
+                    </Card>
+                  {/each}
+                </div>
+              {/if}
+            </section>
+          </Card>
         {/if}
       {/if}
     </section>
@@ -1113,7 +1169,7 @@
         </p>
       </div>
 
-      <div class="generated-controls">
+      <Card level="default" padding="none" class="generated-controls">
         <label class="generated-control">
           <span>{m.insights_page_template_label()}</span>
           <Typeahead
@@ -1162,24 +1218,26 @@
         >
           {m.insights_page_generate()}
         </button>
-      </div>
+      </Card>
 
       {#if insights.loading}
-        <div class="state-panel compact-state">{m.insights_page_loading_archive()}</div>
+        <Card level="default" padding="none" class="state-panel compact-state">{m.insights_page_loading_archive()}</Card>
       {:else if insights.items.length === 0 && insights.tasks.length === 0}
-        <div class="state-panel compact-state">
+        <Card level="default" padding="none" class="state-panel compact-state">
           <strong>{m.insights_page_no_generated_saved()}</strong>
           <span>
             {m.insights_page_no_generated_hint()}
           </span>
-        </div>
+        </Card>
       {:else}
         <div class="generated-layout">
           <div class="generated-list">
             {#each insights.tasks as task (task.clientId)}
-              <button
-                class:active={insights.selectedTaskId === task.clientId}
-                class:error-task={task.status === "error"}
+              <Card
+                level="default"
+                padding="none"
+                class={task.status === "error" ? "error-task" : ""}
+                selected={insights.selectedTaskId === task.clientId}
                 onclick={() => selectGeneratedTask(task.clientId)}
               >
                 <span>{task.status === "error" ? m.insights_page_error() : m.insights_page_running()}</span>
@@ -1187,11 +1245,13 @@
                 <em>
                   {task.kind ? cannedKindLabel(task.kind) : task.phase}
                 </em>
-              </button>
+              </Card>
             {/each}
             {#each insights.items as item (item.id)}
-              <button
-                class:active={insights.selectedId === item.id}
+              <Card
+                level="default"
+                padding="none"
+                selected={insights.selectedId === item.id}
                 onclick={() => selectGeneratedInsight(item.id)}
               >
                 <span>
@@ -1202,11 +1262,12 @@
                   {formatDateRange(item.date_from, item.date_to)}
                   · {formatTime(item.created_at)}
                 </em>
-              </button>
+              </Card>
             {/each}
           </div>
 
-          <article class="generated-detail">
+          <Card level="default" padding="none" class="generated-detail">
+            <article>
             {#if insights.selectedTask}
               <div class="generated-detail-head">
                 <span class="badge generated">
@@ -1335,7 +1396,8 @@
             {:else}
               <p>{m.insights_page_select_to_read()}</p>
             {/if}
-          </article>
+            </article>
+          </Card>
         </div>
       {/if}
     </section>
@@ -1539,25 +1601,21 @@
     gap: var(--space-5);
   }
 
-  .summary-card,
-  .pattern-card,
-  .recommendation,
-  .generated-detail,
-  .state-panel {
-    background: var(--bg-surface);
-    border: 1px solid var(--border-muted);
-    border-radius: var(--radius-md);
-  }
-
-  .summary-card {
+  .summary-grid :global(.summary-card) {
     min-height: 92px;
     padding: 12px;
     display: flex;
     flex-direction: column;
+    gap: 0;
     justify-content: space-between;
   }
 
-  .summary-card .label {
+  .summary-grid :global(.summary-card > .kit-card__body),
+  .summary-card-content {
+    display: contents;
+  }
+
+  .summary-grid :global(.summary-card .label) {
     color: var(--text-muted);
     font-size: 11px;
     font-weight: 600;
@@ -1565,26 +1623,27 @@
     letter-spacing: 0.04em;
   }
 
-  .summary-card strong {
+  .summary-grid :global(.summary-card strong) {
     font-size: 28px;
     line-height: 1;
     color: var(--text-primary);
     font-variant-numeric: tabular-nums;
   }
 
-  .summary-card span:last-child {
+  .summary-grid :global(.summary-card span:last-child) {
     color: var(--text-secondary);
     font-size: 12px;
   }
 
-  .distribution-row {
+  .content :global(.distribution-row) {
     display: grid;
     grid-template-columns: repeat(5, minmax(0, 1fr));
     gap: 8px;
     padding: 10px;
-    background: var(--bg-surface);
-    border: 1px solid var(--border-muted);
-    border-radius: var(--radius-md);
+  }
+
+  .content :global(.distribution-row > .kit-card__body) {
+    display: contents;
   }
 
   .grade-bar {
@@ -1621,12 +1680,17 @@
     gap: 12px;
   }
 
-  .pattern-card {
+  .pattern-grid :global(.pattern-card) {
     min-height: 310px;
     padding: 14px;
     display: flex;
     flex-direction: column;
     gap: 12px;
+  }
+
+  .pattern-grid :global(.pattern-card > .kit-card__body),
+  .pattern-card-content {
+    display: contents;
   }
 
   .pattern-head {
@@ -1656,7 +1720,7 @@
     border: 1px solid var(--border-muted);
   }
 
-  .severity-critical .severity {
+  .pattern-grid :global(.severity-critical .severity) {
     color: var(--accent-red);
     background: color-mix(
       in srgb,
@@ -1665,8 +1729,8 @@
     );
   }
 
-  .severity-warning .severity,
-  .severity-watch .severity {
+  .pattern-grid :global(.severity-warning .severity),
+  .pattern-grid :global(.severity-watch .severity) {
     color: var(--accent-amber);
     background: color-mix(
       in srgb,
@@ -1675,7 +1739,7 @@
     );
   }
 
-  .severity-clear .severity {
+  .pattern-grid :global(.severity-clear .severity) {
     color: var(--accent-green);
     background: color-mix(
       in srgb,
@@ -1684,7 +1748,7 @@
     );
   }
 
-  .severity-unavailable .severity {
+  .pattern-grid :global(.severity-unavailable .severity) {
     color: var(--text-muted);
     background: var(--bg-inset);
   }
@@ -1840,13 +1904,15 @@
     white-space: nowrap;
   }
 
-  .evidence-panel {
+  .content :global(.evidence-panel) {
     display: grid;
     gap: var(--space-5);
     padding: 12px;
-    background: var(--bg-surface);
-    border: 1px solid var(--border-muted);
-    border-radius: var(--radius-md);
+  }
+
+  .content :global(.evidence-panel > .kit-card__body),
+  .evidence-panel-live {
+    display: contents;
   }
 
   .evidence-head {
@@ -1876,19 +1942,20 @@
     gap: 6px;
   }
 
-  .evidence-row {
+  .evidence-list :global(.evidence-row) {
     display: grid;
     grid-template-columns: minmax(0, 1fr) auto;
     gap: 12px;
     align-items: center;
     padding: 9px 10px;
-    border: 1px solid var(--border-muted);
-    border-radius: var(--radius-sm);
-    background: var(--bg-inset);
     text-decoration: none;
   }
 
-  .evidence-row:hover {
+  .evidence-list :global(.evidence-row > .kit-card__body) {
+    display: contents;
+  }
+
+  .evidence-list :global(.evidence-row:hover) {
     border-color: var(--border-default);
     background: var(--bg-surface-hover);
   }
@@ -1929,18 +1996,23 @@
     gap: var(--space-5);
   }
 
-  .recommendation {
+  .recommendation-list :global(.recommendation) {
     padding: 12px;
     display: grid;
     gap: var(--space-3);
   }
 
-  .recommendation strong {
+  .recommendation-list :global(.recommendation > .kit-card__body),
+  .recommendation-content {
+    display: contents;
+  }
+
+  .recommendation-list :global(.recommendation strong) {
     color: var(--text-primary);
     font-size: 13px;
   }
 
-  .recommendation p {
+  .recommendation-list :global(.recommendation p) {
     color: var(--text-secondary);
     font-size: 12px;
     line-height: 1.45;
@@ -1961,7 +2033,7 @@
     container-type: inline-size;
   }
 
-  .generated-controls {
+  .generated-block :global(.generated-controls) {
     display: grid;
     grid-template-columns:
       minmax(180px, 220px) minmax(130px, 160px)
@@ -1969,9 +2041,10 @@
     gap: var(--space-5);
     align-items: end;
     padding: 12px;
-    background: var(--bg-surface);
-    border: 1px solid var(--border-muted);
-    border-radius: var(--radius-md);
+  }
+
+  .generated-block :global(.generated-controls > .kit-card__body) {
+    display: contents;
   }
 
   .generated-control {
@@ -2052,7 +2125,7 @@
   }
 
   @container (max-width: 760px) {
-    .generated-controls,
+    .generated-block :global(.generated-controls),
     .generated-layout {
       grid-template-columns: 1fr;
     }
@@ -2064,42 +2137,37 @@
     gap: 6px;
   }
 
-  .generated-list button {
+  .generated-list :global(.kit-card) {
     min-height: 54px;
     padding: 9px 10px;
     display: grid;
     gap: 2px;
     text-align: left;
-    background: var(--bg-surface);
-    border: 1px solid var(--border-muted);
-    border-radius: var(--radius-md);
   }
 
-  .generated-list button:hover,
-  .generated-list button.active {
-    background: var(--bg-surface-hover);
-    border-color: var(--border-default);
+  .generated-list :global(.kit-card > .kit-card__body) {
+    display: contents;
   }
 
-  .generated-list button span {
+  .generated-list :global(.kit-card span) {
     color: var(--accent-purple);
     font-size: 10px;
     font-weight: 700;
     text-transform: uppercase;
   }
 
-  .generated-list button strong {
+  .generated-list :global(.kit-card strong) {
     color: var(--text-primary);
     font-size: 12px;
   }
 
-  .generated-list button em {
+  .generated-list :global(.kit-card em) {
     color: var(--text-muted);
     font-size: 11px;
     font-style: normal;
   }
 
-  .generated-list button.error-task span {
+  .generated-list :global(.kit-card.error-task span) {
     color: var(--accent-red);
   }
 
@@ -2141,7 +2209,7 @@
     color: var(--accent-red);
   }
 
-  .generated-detail {
+  .generated-layout :global(.generated-detail) {
     min-height: 220px;
     padding: 14px;
   }
@@ -2267,18 +2335,23 @@
     padding-left: 18px;
   }
 
-  .state-panel {
+  .content :global(.state-panel) {
     padding: 18px;
     display: grid;
     gap: 6px;
     color: var(--text-secondary);
   }
 
-  .state-panel strong {
+  .content :global(.state-panel > .kit-card__body),
+  .state-panel-alert {
+    display: contents;
+  }
+
+  .content :global(.state-panel strong) {
     color: var(--text-primary);
   }
 
-  .state-panel button {
+  .content :global(.state-panel button) {
     justify-self: start;
     margin-top: 6px;
     height: 26px;
@@ -2290,7 +2363,7 @@
     font-weight: 700;
   }
 
-  .state-panel.error {
+  .content :global(.state-panel.error) {
     border-color: color-mix(
       in srgb,
       var(--accent-red) 35%,
@@ -2298,30 +2371,18 @@
     );
   }
 
-  .compact-state {
+  .content :global(.compact-state) {
     padding: 14px;
   }
 
-  .inline-warning {
+  .content :global(.inline-warning) {
     padding: 9px 10px;
-    background: color-mix(
-      in srgb,
-      var(--accent-amber) 10%,
-      var(--bg-surface)
-    );
-    border: 1px solid color-mix(
-      in srgb,
-      var(--accent-amber) 24%,
-      var(--border-muted)
-    );
-    border-radius: var(--radius-md);
     color: var(--text-secondary);
     font-size: 12px;
   }
 
   .skeleton-card,
-  .skeleton-pattern {
-    border-radius: var(--radius-md);
+  .pattern-grid :global(.skeleton-pattern) {
     background: linear-gradient(
       90deg,
       var(--bg-surface) 0%,
@@ -2330,14 +2391,15 @@
     );
     background-size: 200% 100%;
     animation: shimmer 1.4s ease-in-out infinite;
-    border: 1px solid var(--border-muted);
   }
 
   .skeleton-card {
+    border-radius: var(--radius-md);
+    border: 1px solid var(--border-muted);
     height: 92px;
   }
 
-  .skeleton-pattern {
+  .pattern-grid :global(.skeleton-pattern) {
     height: 310px;
   }
 
@@ -2382,12 +2444,12 @@
       grid-template-columns: 1fr;
     }
 
-    .distribution-row {
+    .content :global(.distribution-row) {
       grid-template-columns: 1fr;
     }
 
     .driver-row,
-    .evidence-row {
+    .evidence-list :global(.evidence-row) {
       grid-template-columns: 1fr;
     }
 

--- a/frontend/src/lib/components/insights/InsightsPage.test.ts
+++ b/frontend/src/lib/components/insights/InsightsPage.test.ts
@@ -17,6 +17,7 @@ import {
   AnalyticsService,
   CancelablePromise,
 } from "../../api/generated/index.js";
+import type { SignalsAnalyticsResponse } from "../../api/types.js";
 // @ts-ignore
 import InsightsPage from "./InsightsPage.svelte";
 import source from "./InsightsPage.svelte?raw";
@@ -106,6 +107,7 @@ const mocks = vi.hoisted(() => ({
   loadAgents: vi.fn(),
   loadInsights: vi.fn(),
   loadProjects: vi.fn(),
+  navigateToSession: vi.fn(),
   watchEvents: vi.fn(() => ({ close() {} })),
 }));
 
@@ -195,6 +197,7 @@ vi.mock("../../stores/sessions.svelte.js", () => ({
     projects: [],
     loadAgents: mocks.loadAgents,
     loadProjects: mocks.loadProjects,
+    navigateToSession: mocks.navigateToSession,
   },
 }));
 
@@ -280,6 +283,58 @@ async function selectCustomRange(fromLabel: string, toLabel: string) {
   to!.click();
   await flushEffects();
 }
+
+const signalsFixture: SignalsAnalyticsResponse = {
+  scored_sessions: 2,
+  unscored_sessions: 0,
+  grade_distribution: { A: 1, B: 1 },
+  avg_health_score: 85,
+  outcome_distribution: { completed: 2 },
+  outcome_confidence_distribution: { high: 2 },
+  tool_health: {
+    total_failure_signals: 1,
+    total_retries: 0,
+    total_edit_churn: 0,
+    sessions_with_failures: 1,
+    failure_rate: 50,
+  },
+  context_health: {
+    avg_compaction_count: 0,
+    sessions_with_compaction: 0,
+    mid_task_compaction_count: 0,
+    sessions_with_mid_task_compaction: 0,
+    sessions_with_context_data: 2,
+    avg_context_pressure: 0.2,
+    high_pressure_sessions: 0,
+  },
+  quality_health: {
+    computed_sessions: 2,
+    totals: {
+      short_prompt_count: 2,
+      unstructured_start: 0,
+      missing_success_criteria_count: 0,
+      missing_verification_count: 0,
+      duplicate_prompt_count: 0,
+      no_code_context_count: 0,
+      runaway_tool_loop_count: 0,
+      frustration_marker_count: 0,
+    },
+    sessions_with_signal: {
+      short_prompt_count: 2,
+      unstructured_start: 0,
+      missing_success_criteria_count: 0,
+      missing_verification_count: 0,
+      duplicate_prompt_count: 0,
+      no_code_context_count: 0,
+      runaway_tool_loop_count: 0,
+      frustration_marker_count: 0,
+    },
+  },
+  trend: [],
+  by_agent: [],
+  by_project: [],
+  calibration: {},
+};
 
 describe("InsightsPage date yoke integration", () => {
   let component: ReturnType<typeof mount> | undefined;
@@ -591,6 +646,103 @@ describe("InsightsPage date yoke integration", () => {
       isPinned: true,
       from: "2026-06-01",
       to: "2026-06-07",
+    });
+  });
+});
+
+describe("InsightsPage evidence navigation", () => {
+  let component: ReturnType<typeof mount> | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.history.replaceState(null, "", "/insights");
+    router.route = "insights";
+    router.params = {};
+    analytics.signals = signalsFixture;
+    analytics.loading.signals = false;
+    analytics.errors.signals = null;
+    vi.spyOn(analytics, "fetchSignalsForInsights").mockResolvedValue();
+  });
+
+  afterEach(() => {
+    if (component) {
+      unmount(component);
+      component = undefined;
+    }
+    vi.restoreAllMocks();
+    document.body.innerHTML = "";
+    analytics.signals = null;
+    analytics.loading.signals = false;
+    analytics.errors.signals = null;
+    window.history.replaceState(null, "", "/");
+    router.route = "sessions";
+    router.params = {};
+  });
+
+  it("navigates with the clicked example's session and message ordinal", async () => {
+    vi.spyOn(
+      AnalyticsService,
+      "getApiV1AnalyticsSignalSessions",
+    ).mockResolvedValue({
+      signal: "short_prompt_count",
+      sessions: [
+        {
+          session_id: "first-session",
+          project: "alpha",
+          agent: "codex",
+          date: "2026-07-10",
+          is_automated: false,
+          outcome: "completed",
+          health_score: 90,
+          health_grade: "A",
+          signal_total: 1,
+          reason_code: "short_prompt",
+          excerpt: "First example",
+          message_ordinal: 7,
+          failure_signals: 0,
+          retries: 0,
+          edit_churn: 0,
+        },
+        {
+          session_id: "second-session",
+          project: "beta",
+          agent: "claude",
+          date: "2026-07-09",
+          is_automated: false,
+          outcome: "errored",
+          health_score: 55,
+          health_grade: "D",
+          signal_total: 2,
+          reason_code: "short_prompt",
+          excerpt: "Second example",
+          message_ordinal: 23,
+          failure_signals: 2,
+          retries: 1,
+          edit_churn: 1,
+        },
+      ],
+    });
+    const scrollToOrdinal = vi.spyOn(ui, "scrollToOrdinal");
+    const routeToSession = vi
+      .spyOn(router, "navigateToSession")
+      .mockImplementation(() => {});
+
+    component = mount(InsightsPage, { target: document.body });
+    await flushEffects();
+    document.querySelector<HTMLButtonElement>(".driver-row")!.click();
+    await flushEffects();
+
+    const evidenceLinks = document.querySelectorAll<HTMLAnchorElement>(
+      "a.evidence-row",
+    );
+    expect(evidenceLinks).toHaveLength(2);
+    evidenceLinks[1]!.click();
+    await flushEffects();
+
+    expect(scrollToOrdinal).toHaveBeenCalledWith(23, "second-session");
+    expect(mocks.navigateToSession).toHaveBeenCalledWith("second-session");
+    expect(routeToSession).toHaveBeenCalledWith("second-session", {
+      msg: "23",
     });
   });
 });

--- a/frontend/src/lib/components/settings/AppearanceSettings.svelte
+++ b/frontend/src/lib/components/settings/AppearanceSettings.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Checkbox } from "@kenn-io/kit-ui";
+  import { Button, Checkbox, SegmentedControl } from "@kenn-io/kit-ui";
   import { m } from "../../i18n/index.js";
   import SettingsSection from "./SettingsSection.svelte";
   import {
@@ -24,6 +24,13 @@
     tool: m.header_transcript_blocks_tool(),
     code: m.header_transcript_blocks_code(),
   });
+
+  const FONT_SCALE_OPTIONS = $derived(
+    FONT_SCALE_STEPS.map((step) => ({
+      value: String(step),
+      label: `${step}%`,
+    })),
+  );
 </script>
 
 <SettingsSection
@@ -32,46 +39,36 @@
 >
   <div class="setting-row">
     <span class="setting-label">{m.appearance_theme()}</span>
-    <button class="setting-toggle" onclick={() => ui.toggleTheme()}>
+    <Button size="sm" onclick={() => ui.toggleTheme()}>
       {ui.theme === "light" ? m.appearance_light() : m.appearance_dark()}
-    </button>
+    </Button>
   </div>
 
   <div class="setting-row">
     <span class="setting-label">{m.appearance_high_contrast()}</span>
-    <button class="setting-toggle" onclick={() => ui.toggleHighContrast()}>
+    <Button size="sm" onclick={() => ui.toggleHighContrast()}>
       {ui.highContrast ? m.appearance_on() : m.appearance_off()}
-    </button>
+    </Button>
   </div>
 
   <div class="setting-row">
     <span class="setting-label">{m.appearance_message_layout()}</span>
-    <div class="setting-options">
-      {#each LAYOUT_OPTIONS as opt}
-        <button
-          class="option-btn"
-          class:active={ui.messageLayout === opt.value}
-          onclick={() => ui.setLayout(opt.value)}
-        >
-          {opt.label}
-        </button>
-      {/each}
-    </div>
+    <SegmentedControl
+      options={LAYOUT_OPTIONS}
+      value={ui.messageLayout}
+      ariaLabel={m.appearance_message_layout()}
+      onchange={(value) => ui.setLayout(value as MessageLayout)}
+    />
   </div>
 
   <div class="setting-row">
     <span class="setting-label">{m.appearance_text_size()}</span>
-    <div class="setting-options">
-      {#each FONT_SCALE_STEPS as step}
-        <button
-          class="option-btn"
-          class:active={ui.fontScale === step}
-          onclick={() => ui.setFontScale(step)}
-        >
-          {step}%
-        </button>
-      {/each}
-    </div>
+    <SegmentedControl
+      options={FONT_SCALE_OPTIONS}
+      value={String(ui.fontScale)}
+      ariaLabel={m.appearance_text_size()}
+      onchange={(value) => ui.setFontScale(Number(value))}
+    />
   </div>
 
   <div class="setting-row column">
@@ -106,52 +103,6 @@
     font-weight: 500;
     color: var(--text-secondary);
     white-space: nowrap;
-  }
-
-  .setting-toggle {
-    height: 26px;
-    padding: 0 12px;
-    border-radius: var(--radius-sm);
-    font-size: 11px;
-    font-weight: 500;
-    color: var(--text-secondary);
-    background: var(--bg-inset);
-    border: 1px solid var(--border-muted);
-    cursor: pointer;
-    transition: background 0.12s;
-  }
-
-  .setting-toggle:hover {
-    background: var(--bg-surface-hover);
-  }
-
-  .setting-options {
-    display: flex;
-    gap: 4px;
-  }
-
-  .option-btn {
-    height: 26px;
-    padding: 0 10px;
-    border-radius: var(--radius-sm);
-    font-size: 11px;
-    font-weight: 500;
-    color: var(--text-muted);
-    background: var(--bg-inset);
-    border: 1px solid var(--border-muted);
-    cursor: pointer;
-    transition: all 0.12s;
-  }
-
-  .option-btn:hover {
-    color: var(--text-secondary);
-    background: var(--bg-surface-hover);
-  }
-
-  .option-btn.active {
-    color: var(--accent-blue);
-    background: color-mix(in srgb, var(--accent-blue) 10%, transparent);
-    border-color: var(--accent-blue);
   }
 
   .block-toggles {

--- a/frontend/src/lib/components/settings/AppearanceSettings.svelte
+++ b/frontend/src/lib/components/settings/AppearanceSettings.svelte
@@ -51,7 +51,7 @@
     </Button>
   </div>
 
-  <div class="setting-row">
+  <div class="setting-row option-row">
     <span class="setting-label">{m.appearance_message_layout()}</span>
     <SegmentedControl
       options={LAYOUT_OPTIONS}
@@ -61,7 +61,7 @@
     />
   </div>
 
-  <div class="setting-row">
+  <div class="setting-row option-row">
     <span class="setting-label">{m.appearance_text_size()}</span>
     <SegmentedControl
       options={FONT_SCALE_OPTIONS}
@@ -109,5 +109,26 @@
     display: flex;
     flex-wrap: wrap;
     gap: 8px;
+  }
+
+  @media (max-width: 640px) {
+    .setting-row.option-row {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .option-row .setting-label {
+      align-self: flex-start;
+    }
+
+    .option-row :global(.kit-segmented) {
+      width: 100%;
+    }
+
+    .option-row :global(.kit-segmented__btn) {
+      flex: 1;
+      min-width: 0;
+      padding-inline: 6px;
+    }
   }
 </style>

--- a/frontend/src/lib/components/settings/AppearanceSettings.svelte
+++ b/frontend/src/lib/components/settings/AppearanceSettings.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { Checkbox } from "@kenn-io/kit-ui";
   import { m } from "../../i18n/index.js";
   import SettingsSection from "./SettingsSection.svelte";
   import {
@@ -77,14 +78,11 @@
     <span class="setting-label">{m.appearance_block_visibility()}</span>
     <div class="block-toggles">
       {#each ALL_BLOCK_TYPES as bt}
-        <label class="block-toggle">
-          <input
-            type="checkbox"
-            checked={ui.isBlockVisible(bt)}
-            onchange={() => ui.toggleBlock(bt)}
-          />
-          <span>{BLOCK_LABELS[bt]}</span>
-        </label>
+        <Checkbox
+          checked={ui.isBlockVisible(bt)}
+          onchange={() => ui.toggleBlock(bt)}
+          label={BLOCK_LABELS[bt]}
+        />
       {/each}
     </div>
   </div>
@@ -160,18 +158,5 @@
     display: flex;
     flex-wrap: wrap;
     gap: 8px;
-  }
-
-  .block-toggle {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    font-size: 12px;
-    color: var(--text-secondary);
-    cursor: pointer;
-  }
-
-  .block-toggle input {
-    accent-color: var(--accent-blue);
   }
 </style>

--- a/frontend/src/lib/components/settings/AppearanceSettings.test.ts
+++ b/frontend/src/lib/components/settings/AppearanceSettings.test.ts
@@ -15,16 +15,16 @@ describe("AppearanceSettings", () => {
     ui.setFontScale(110);
     const { getByRole } = render(AppearanceSettings);
     for (const pct of [90, 100, 110, 120, 130]) {
-      expect(getByRole("button", { name: `${pct}%` })).toBeTruthy();
+      expect(getByRole("radio", { name: `${pct}%` })).toBeTruthy();
     }
     expect(
-      getByRole("button", { name: "110%" }).classList.contains("active"),
-    ).toBe(true);
+      getByRole("radio", { name: "110%" }).getAttribute("aria-checked"),
+    ).toBe("true");
   });
 
   it("changes the font scale when an option is clicked", async () => {
     const { getByRole } = render(AppearanceSettings);
-    await fireEvent.click(getByRole("button", { name: "120%" }));
+    await fireEvent.click(getByRole("radio", { name: "120%" }));
     expect(ui.fontScale).toBe(120);
   });
 

--- a/frontend/src/lib/components/settings/DateRangeSettings.svelte
+++ b/frontend/src/lib/components/settings/DateRangeSettings.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { Toggle } from "@kenn-io/kit-ui";
   import { m } from "../../i18n/index.js";
   import { yokedDates } from "../../stores/yokedDates.svelte.js";
   import SettingsSection from "./SettingsSection.svelte";
@@ -8,28 +9,9 @@
   title={m.settings_date_ranges_title()}
   description={m.settings_date_ranges_description()}
 >
-  <label class="date-range-toggle">
-    <input
-      type="checkbox"
-      checked={yokedDates.enabled}
-      onchange={(event) =>
-        yokedDates.setEnabled(event.currentTarget.checked)}
-    />
-    <span>{m.settings_date_ranges_link()}</span>
-  </label>
+  <Toggle
+    checked={yokedDates.enabled}
+    onchange={(checked) => yokedDates.setEnabled(checked)}
+    label={m.settings_date_ranges_link()}
+  />
 </SettingsSection>
-
-<style>
-  .date-range-toggle {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    color: var(--text-secondary);
-    font-size: 12px;
-    cursor: pointer;
-  }
-
-  .date-range-toggle input {
-    accent-color: var(--accent-blue);
-  }
-</style>

--- a/frontend/src/lib/components/settings/DateRangeSettings.test.ts
+++ b/frontend/src/lib/components/settings/DateRangeSettings.test.ts
@@ -23,14 +23,14 @@ afterEach(() => {
 
 describe("DateRangeSettings", () => {
   it("enables date linking and persists the browser preference", async () => {
-    const { getByLabelText } = render(DateRangeSettings);
-    const checkbox = getByLabelText(
-      "Link date ranges across pages",
-    ) as HTMLInputElement;
+    const { getByRole } = render(DateRangeSettings);
+    const linkedDates = getByRole("switch", {
+      name: "Link date ranges across pages",
+    }) as HTMLInputElement;
 
-    expect(checkbox.checked).toBe(false);
+    expect(linkedDates.checked).toBe(false);
 
-    await fireEvent.click(checkbox);
+    await fireEvent.click(linkedDates);
 
     expect(yokedDates.enabled).toBe(true);
     expect(JSON.parse(localStorage.getItem(YOKED_DATES_STORAGE_KEY)!)).toEqual({

--- a/frontend/src/lib/components/settings/EmbeddingsSettings.svelte
+++ b/frontend/src/lib/components/settings/EmbeddingsSettings.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { Chip, type ChipTone } from "@kenn-io/kit-ui";
   import { onMount } from "svelte";
   import { getLocale, m } from "../../i18n/index.js";
   import SettingsSection from "./SettingsSection.svelte";
@@ -194,6 +195,13 @@
     if (state === "retired") return m.settings_embeddings_state_retired();
     return state;
   }
+
+  function stateTone(state: string): ChipTone {
+    if (state === "active") return "success";
+    if (state === "building") return "warning";
+    if (state === "failed") return "danger";
+    return "muted";
+  }
 </script>
 
 <SettingsSection
@@ -220,11 +228,11 @@
       <span class="row-label">{m.settings_embeddings_status_label()}</span>
       <span class="row-value">
         {#if running}
-          <span class="state-badge building">{phaseLabel()}</span>
+          <Chip size="xs" tone="warning">{phaseLabel()}</Chip>
         {:else if status.last_error}
-          <span class="state-badge failed"
-            >{m.settings_embeddings_last_build_failed()}</span
-          >
+          <Chip size="xs" tone="danger">
+            {m.settings_embeddings_last_build_failed()}
+          </Chip>
         {:else}
           {m.settings_embeddings_status_idle()}
         {/if}
@@ -327,7 +335,9 @@
         <ul class="generation-list">
           {#each generations as gen (gen.id)}
             <li class="generation-row">
-              <span class="state-badge {gen.state}">{stateLabel(gen.state)}</span>
+              <Chip size="xs" tone={stateTone(gen.state)}>
+                {stateLabel(gen.state)}
+              </Chip>
               <span class="gen-model mono">{gen.model} · {numberFormat.format(gen.dimension)}d</span>
               <span class="gen-coverage">
                 {m.settings_embeddings_coverage({
@@ -450,33 +460,6 @@
     align-items: center;
     gap: var(--space-4);
     font-size: 12px;
-  }
-
-  .state-badge {
-    font-size: 10px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    padding: 1px 6px;
-    border-radius: var(--radius-sm);
-    background: var(--bg-inset);
-    color: var(--text-muted);
-    border: 1px solid var(--border-muted);
-  }
-
-  .state-badge.active {
-    color: var(--accent-green, #22c55e);
-    border-color: var(--accent-green, #22c55e);
-  }
-
-  .state-badge.building {
-    color: var(--accent-amber, #f59e0b);
-    border-color: var(--accent-amber, #f59e0b);
-  }
-
-  .state-badge.failed {
-    color: var(--accent-red, #ef4444);
-    border-color: var(--accent-red, #ef4444);
   }
 
   .gen-model {

--- a/frontend/src/lib/components/settings/GithubSettings.svelte
+++ b/frontend/src/lib/components/settings/GithubSettings.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { TextInput } from "@kenn-io/kit-ui";
   import { m } from "../../i18n/index.js";
   import SettingsSection from "./SettingsSection.svelte";
   import { settings } from "../../stores/settings.svelte.js";
@@ -43,8 +44,9 @@
   </div>
 
   <div class="token-row">
-    <input
+    <TextInput
       class="setting-input"
+      size="md"
       type="password"
       placeholder="ghp_..."
       bind:value={tokenInput}
@@ -93,22 +95,9 @@
     gap: 8px;
   }
 
-  .setting-input {
+  :global(.setting-input.kit-text-input) {
     flex: 1;
-    height: 30px;
-    padding: 0 10px;
-    border-radius: var(--radius-sm);
-    font-size: 12px;
     font-family: var(--font-mono, monospace);
-    color: var(--text-primary);
-    background: var(--bg-inset);
-    border: 1px solid var(--border-muted);
-    transition: border-color 0.15s;
-  }
-
-  .setting-input:focus {
-    outline: none;
-    border-color: var(--accent-blue);
   }
 
   .save-btn {

--- a/frontend/src/lib/components/settings/RemoteSettings.svelte
+++ b/frontend/src/lib/components/settings/RemoteSettings.svelte
@@ -21,10 +21,15 @@
   let saving: boolean = $state(false);
   let saveMsg: string | null = $state(null);
   let remoteToggling: boolean = $state(false);
+  let pendingRequireAuth: boolean = $state(settings.requireAuth);
 
   let isRemote: boolean = $derived(isRemoteConnection());
   let copied: boolean = $state(false);
   const versionRead = new LatestRead();
+
+  $effect(() => {
+    if (!remoteToggling) pendingRequireAuth = settings.requireAuth;
+  });
 
   async function handleTestConnection() {
     if (!serverUrl.trim()) return;
@@ -79,11 +84,13 @@
     setTimeout(() => window.location.reload(), 500);
   }
 
-  async function handleToggleRemote() {
+  async function handleToggleRemote(requireAuth: boolean) {
+    pendingRequireAuth = requireAuth;
     remoteToggling = true;
     try {
-      await settings.save({ require_auth: !settings.requireAuth });
+      await settings.save({ require_auth: requireAuth });
     } finally {
+      pendingRequireAuth = settings.requireAuth;
       remoteToggling = false;
     }
   }
@@ -107,12 +114,12 @@
       <div class="toggle-row">
         <span class="toggle-label">{m.settings_remote_require_auth()}</span>
         <Toggle
-          checked={settings.requireAuth}
+          checked={pendingRequireAuth}
           disabled={remoteToggling}
           ariaLabel={m.settings_remote_require_auth()}
           onchange={handleToggleRemote}
         >
-          {settings.requireAuth ? m.settings_remote_enabled() : m.settings_remote_disabled()}
+          {pendingRequireAuth ? m.settings_remote_enabled() : m.settings_remote_disabled()}
         </Toggle>
       </div>
 

--- a/frontend/src/lib/components/settings/RemoteSettings.svelte
+++ b/frontend/src/lib/components/settings/RemoteSettings.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { Button, TextInput, Toggle } from "@kenn-io/kit-ui";
   import { onDestroy } from "svelte";
   import { m } from "../../i18n/index.js";
   import SettingsSection from "./SettingsSection.svelte";
@@ -105,14 +106,14 @@
     <div class="subsection">
       <div class="toggle-row">
         <span class="toggle-label">{m.settings_remote_require_auth()}</span>
-        <button
-          class="toggle-btn"
-          class:active={settings.requireAuth}
+        <Toggle
+          checked={settings.requireAuth}
           disabled={remoteToggling}
-          onclick={handleToggleRemote}
+          ariaLabel={m.settings_remote_require_auth()}
+          onchange={handleToggleRemote}
         >
           {settings.requireAuth ? m.settings_remote_enabled() : m.settings_remote_disabled()}
-        </button>
+        </Toggle>
       </div>
 
       <p class="restart-note">
@@ -128,9 +129,9 @@
           <span class="field-label">{m.settings_remote_auth_token()}</span>
           <div class="token-row">
             <code class="token-value">{settings.authToken}</code>
-            <button class="copy-btn" onclick={handleCopyToken}>
+            <Button size="sm" onclick={handleCopyToken}>
               {copied ? m.settings_remote_copied() : m.settings_remote_copy()}
-            </button>
+            </Button>
           </div>
         </div>
 
@@ -168,9 +169,11 @@
     {:else}
       <div class="field">
         <label class="field-label" for="remote-url">{m.settings_remote_server_url()}</label>
-        <input
+        <TextInput
           id="remote-url"
           class="setting-input"
+          size="md"
+          block
           type="url"
           placeholder="http://192.168.1.100:8080"
           bind:value={serverUrl}
@@ -179,9 +182,11 @@
 
       <div class="field">
         <label class="field-label" for="remote-token">{m.settings_remote_auth_token()}</label>
-        <input
+        <TextInput
           id="remote-token"
           class="setting-input"
+          size="md"
+          block
           type="password"
           placeholder={m.settings_remote_paste_token_from_server()}
           bind:value={tokenInput}
@@ -248,32 +253,6 @@
     color: var(--text-primary);
   }
 
-  .toggle-btn {
-    height: 26px;
-    padding: 0 12px;
-    border-radius: var(--radius-sm);
-    font-size: 11px;
-    font-weight: 500;
-    border: 1px solid var(--border-muted);
-    cursor: pointer;
-    background: var(--bg-inset);
-    color: var(--text-secondary);
-    transition:
-      background 0.12s,
-      color 0.12s;
-  }
-
-  .toggle-btn.active {
-    background: var(--accent-green, #22c55e);
-    color: var(--accent-green-foreground);
-    border-color: transparent;
-  }
-
-  .toggle-btn:disabled {
-    opacity: 0.6;
-    cursor: default;
-  }
-
   .token-display,
   .server-info,
   .connected-info {
@@ -308,24 +287,6 @@
     min-width: 0;
   }
 
-  .copy-btn {
-    height: 24px;
-    padding: 0 10px;
-    border-radius: var(--radius-sm);
-    font-size: 11px;
-    font-weight: 500;
-    color: var(--text-secondary);
-    background: var(--bg-inset);
-    border: 1px solid var(--border-muted);
-    cursor: pointer;
-    white-space: nowrap;
-    transition: opacity 0.12s;
-  }
-
-  .copy-btn:hover {
-    opacity: 0.8;
-  }
-
   .info-value {
     font-size: 12px;
     font-family: var(--font-mono, monospace);
@@ -338,21 +299,8 @@
     gap: 4px;
   }
 
-  .setting-input {
-    height: 30px;
-    padding: 0 10px;
-    border-radius: var(--radius-sm);
-    font-size: 12px;
+  :global(.setting-input.kit-text-input) {
     font-family: var(--font-mono, monospace);
-    color: var(--text-primary);
-    background: var(--bg-inset);
-    border: 1px solid var(--border-muted);
-    transition: border-color 0.15s;
-  }
-
-  .setting-input:focus {
-    outline: none;
-    border-color: var(--accent-blue);
   }
 
   .actions {

--- a/frontend/src/lib/components/settings/RemoteSettings.test.ts
+++ b/frontend/src/lib/components/settings/RemoteSettings.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import {
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+} from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { tick } from "svelte";
+
+import { initI18n } from "../../i18n/index.js";
+import { settings } from "../../stores/settings.svelte.js";
+import RemoteSettings from "./RemoteSettings.svelte";
+
+beforeEach(() => {
+  localStorage.clear();
+  initI18n();
+  settings.requireAuth = false;
+  settings.authToken = "";
+  settings.host = "127.0.0.1";
+  settings.port = 8080;
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  localStorage.clear();
+  settings.requireAuth = false;
+  settings.authToken = "";
+});
+
+describe("RemoteSettings", () => {
+  it("shows the requested authentication state while saving", async () => {
+    let releaseSave!: () => void;
+    const saveSpy = vi.spyOn(settings, "save").mockImplementation(
+      async (patch) => {
+        expect(patch).toEqual({ require_auth: true });
+        await new Promise<void>((resolve) => {
+          releaseSave = resolve;
+        });
+        settings.requireAuth = true;
+      },
+    );
+    const { getByRole } = render(RemoteSettings);
+    const requireAuth = getByRole("switch", {
+      name: "Require auth token",
+    }) as HTMLInputElement;
+
+    await fireEvent.click(requireAuth);
+    await tick();
+
+    try {
+      expect(saveSpy).toHaveBeenCalledOnce();
+      expect(requireAuth.checked).toBe(true);
+      expect(requireAuth.disabled).toBe(true);
+      expect(requireAuth.closest("label")?.textContent).toContain("Enabled");
+    } finally {
+      releaseSave();
+      await saveSpy.mock.results[0]!.value;
+      await tick();
+    }
+  });
+
+  it("rolls back when saving leaves authentication unchanged", async () => {
+    const saveSpy = vi.spyOn(settings, "save").mockImplementation(
+      async (patch) => {
+        expect(patch).toEqual({ require_auth: true });
+      },
+    );
+    const { getByRole } = render(RemoteSettings);
+    const requireAuth = getByRole("switch", {
+      name: "Require auth token",
+    }) as HTMLInputElement;
+
+    await fireEvent.click(requireAuth);
+    await waitFor(() => expect(requireAuth.disabled).toBe(false));
+
+    expect(saveSpy).toHaveBeenCalledOnce();
+    expect(settings.requireAuth).toBe(false);
+    expect(requireAuth.checked).toBe(false);
+    expect(requireAuth.closest("label")?.textContent).toContain("Disabled");
+  });
+});

--- a/frontend/src/lib/components/settings/SettingsPage.svelte
+++ b/frontend/src/lib/components/settings/SettingsPage.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { Button, TextInput } from "@kenn-io/kit-ui";
   import { onMount } from "svelte";
   import { settings } from "../../stores/settings.svelte.js";
   import { sync } from "../../stores/sync.svelte.js";
@@ -44,8 +45,9 @@
         {m.app_auth_description()}
       </p>
       <div class="auth-field">
-        <input
+        <TextInput
           class="auth-input"
+          size="md"
           type="password"
           placeholder={m.app_auth_placeholder()}
           bind:value={authTokenInput}
@@ -100,8 +102,7 @@
       <RemoteSettings />
 
       <div class="settings-actions">
-        <button
-          class="resync-btn"
+        <Button
           onclick={() => {
             if (!sync.readOnly) ui.activeModal = "resync";
           }}
@@ -111,7 +112,7 @@
             : m.resync_title()}
         >
           {m.resync_title()}
-        </button>
+        </Button>
         <span class="settings-actions-hint">
           {sync.readOnly
             ? m.settings_resync_unavailable_hint()
@@ -174,29 +175,6 @@
     border-top: 1px solid var(--border-muted);
   }
 
-  .resync-btn {
-    height: 30px;
-    padding: 0 14px;
-    border-radius: var(--radius-sm);
-    font-size: 12px;
-    font-weight: 500;
-    color: var(--text-primary);
-    background: var(--bg-inset);
-    border: 1px solid var(--border-muted);
-    cursor: pointer;
-    white-space: nowrap;
-    transition: opacity 0.12s;
-  }
-
-  .resync-btn:hover:not(:disabled) {
-    opacity: 0.8;
-  }
-
-  .resync-btn:disabled {
-    opacity: 0.55;
-    cursor: default;
-  }
-
   .settings-actions-hint {
     font-size: 11px;
     color: var(--text-muted);
@@ -231,21 +209,10 @@
     margin: 0 auto;
   }
 
-  .auth-input {
+  :global(.auth-input.kit-text-input) {
     flex: 1;
     height: 34px;
-    padding: 0 12px;
-    border-radius: var(--radius-sm);
-    font-size: 13px;
     font-family: var(--font-mono, monospace);
-    color: var(--text-primary);
-    background: var(--bg-inset);
-    border: 1px solid var(--border-muted);
-  }
-
-  .auth-input:focus {
-    outline: none;
-    border-color: var(--accent-blue);
   }
 
   .auth-btn {

--- a/frontend/src/lib/components/settings/TerminalSettings.svelte
+++ b/frontend/src/lib/components/settings/TerminalSettings.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { SegmentedControl, TextInput } from "@kenn-io/kit-ui";
   import { m } from "../../i18n/index.js";
   import SettingsSection from "./SettingsSection.svelte";
   import { settings } from "../../stores/settings.svelte.js";
@@ -12,7 +13,7 @@
     { value: "auto", label: m.settings_terminal_mode_auto() },
     { value: "custom", label: m.settings_terminal_mode_custom() },
     { value: "clipboard", label: m.settings_terminal_mode_clipboard() },
-  ] as const);
+  ]);
 
   let localMode: string = $state(settings.terminal.mode || "auto");
   let localBin: string = $state(settings.terminal.custom_bin ?? "");
@@ -50,25 +51,22 @@
 >
   <div class="setting-row">
     <span class="setting-label">{m.settings_terminal_launch_mode()}</span>
-    <div class="setting-options">
-      {#each MODES as opt}
-        <button
-          class="option-btn"
-          class:active={localMode === opt.value}
-          onclick={() => (localMode = opt.value)}
-        >
-          {opt.label}
-        </button>
-      {/each}
-    </div>
+    <SegmentedControl
+      options={MODES}
+      value={localMode}
+      ariaLabel={m.settings_terminal_launch_mode()}
+      onchange={(value) => (localMode = value)}
+    />
   </div>
 
   {#if localMode === "custom"}
     <div class="setting-row column">
       <label class="setting-label" for="terminal-bin">{m.settings_terminal_terminal_binary()}</label>
-      <input
+      <TextInput
         id="terminal-bin"
         class="setting-input"
+        size="md"
+        block
         type="text"
         placeholder="/usr/bin/kitty"
         bind:value={localBin}
@@ -79,9 +77,11 @@
       <label class="setting-label" for="terminal-args">
         {m.settings_terminal_arguments()} <span class="hint">{m.settings_terminal_args_hint()}</span>
       </label>
-      <input
+      <TextInput
         id="terminal-args"
         class="setting-input"
+        size="md"
+        block
         type="text"
         placeholder="-- bash -c {"{cmd}"}"
         bind:value={localArgs}
@@ -127,51 +127,8 @@
     color: var(--text-muted);
   }
 
-  .setting-options {
-    display: flex;
-    gap: 4px;
-  }
-
-  .option-btn {
-    height: 26px;
-    padding: 0 10px;
-    border-radius: var(--radius-sm);
-    font-size: 11px;
-    font-weight: 500;
-    color: var(--text-muted);
-    background: var(--bg-inset);
-    border: 1px solid var(--border-muted);
-    cursor: pointer;
-    transition: all 0.12s;
-  }
-
-  .option-btn:hover {
-    color: var(--text-secondary);
-    background: var(--bg-surface-hover);
-  }
-
-  .option-btn.active {
-    color: var(--accent-blue);
-    background: color-mix(in srgb, var(--accent-blue) 10%, transparent);
-    border-color: var(--accent-blue);
-  }
-
-  .setting-input {
-    width: 100%;
-    height: 30px;
-    padding: 0 10px;
-    border-radius: var(--radius-sm);
-    font-size: 12px;
+  :global(.setting-input.kit-text-input) {
     font-family: var(--font-mono, monospace);
-    color: var(--text-primary);
-    background: var(--bg-inset);
-    border: 1px solid var(--border-muted);
-    transition: border-color 0.15s;
-  }
-
-  .setting-input:focus {
-    outline: none;
-    border-color: var(--accent-blue);
   }
 
   .save-row {

--- a/frontend/src/lib/components/settings/WorktreeMappingSettings.svelte
+++ b/frontend/src/lib/components/settings/WorktreeMappingSettings.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Checkbox } from "@kenn-io/kit-ui";
+  import { Card, Checkbox } from "@kenn-io/kit-ui";
   import { m } from "../../i18n/index.js";
   import SettingsSection from "./SettingsSection.svelte";
   import {
@@ -196,7 +196,11 @@
           <div class="empty">{m.worktree_no_mappings()}</div>
         {:else}
           {#each mappings as mapping (mapping.id)}
-            <div class="mapping-row" class:disabled={!mapping.enabled}>
+            <Card
+              level="inset"
+              padding="none"
+              class={!mapping.enabled ? "mapping-row disabled" : "mapping-row"}
+            >
               <div class="mapping-main">
                 <div class="mapping-project">
                   {mapping.project || (mapping.layout === repoDotWorktreesLayout ? m.worktree_layout_repo_dot_worktrees({ repo: "repo", branch: "branch" }) : m.worktree_layout_explicit({}))}
@@ -212,7 +216,7 @@
                 {m.worktree_delete()}
               </button>
             </div>
-          </div>
+          </Card>
         {/each}
       {/if}
     </div>
@@ -328,19 +332,20 @@
     gap: 6px;
   }
 
-  .mapping-row {
+  .mapping-list :global(.mapping-row) {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 12px;
     min-height: 48px;
     padding: 8px 10px;
-    border: 1px solid var(--border-muted);
-    border-radius: var(--radius-sm);
-    background: var(--bg-inset);
   }
 
-  .mapping-row.disabled {
+  .mapping-list :global(.mapping-row > .kit-card__body) {
+    display: contents;
+  }
+
+  .mapping-list :global(.mapping-row.disabled) {
     opacity: 0.65;
   }
 
@@ -480,7 +485,7 @@
   }
 
   @media (max-width: 640px) {
-    .mapping-row,
+    .mapping-list :global(.mapping-row),
     .button-row {
       align-items: stretch;
       flex-direction: column;

--- a/frontend/src/lib/components/settings/WorktreeMappingSettings.svelte
+++ b/frontend/src/lib/components/settings/WorktreeMappingSettings.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { Checkbox } from "@kenn-io/kit-ui";
   import { m } from "../../i18n/index.js";
   import SettingsSection from "./SettingsSection.svelte";
   import {
@@ -262,10 +263,7 @@
           {isRepoDotWorktrees ? m.worktree_project_derived() : m.worktree_project_required()}
         </div>
       </label>
-      <label class="enabled-toggle">
-        <input type="checkbox" bind:checked={enabled} />
-        {m.worktree_enabled()}
-      </label>
+      <Checkbox bind:checked={enabled} label={m.worktree_enabled()} />
     </div>
 
     {#if error}
@@ -425,14 +423,6 @@
     color: var(--text-muted);
     font-size: 11px;
     line-height: 1.3;
-  }
-
-  .enabled-toggle {
-    display: flex;
-    align-items: center;
-    gap: var(--space-4);
-    color: var(--text-secondary);
-    font-size: 12px;
   }
 
   .small-btn,

--- a/frontend/src/lib/components/settings/WorktreeMappingSettings.svelte
+++ b/frontend/src/lib/components/settings/WorktreeMappingSettings.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Card, Checkbox } from "@kenn-io/kit-ui";
+  import { Card, Checkbox, SegmentedControl, TextInput } from "@kenn-io/kit-ui";
   import { m } from "../../i18n/index.js";
   import SettingsSection from "./SettingsSection.svelte";
   import {
@@ -23,6 +23,17 @@
 
   const explicitLayout = "explicit";
   const repoDotWorktreesLayout = "repo_dot_worktrees";
+
+  const layoutOptions = $derived([
+    { value: explicitLayout, label: m.worktree_layout_explicit({}) },
+    {
+      value: repoDotWorktreesLayout,
+      label: m.worktree_layout_repo_dot_worktrees({
+        repo: "repo",
+        branch: "branch",
+      }),
+    },
+  ]);
 
   let { readOnly = false }: Props = $props();
 
@@ -222,32 +233,22 @@
     </div>
 
     <div class="form-grid">
-      <label class="field">
+      <div class="field">
         <span>{m.worktree_layout()}</span>
-        <div class="layout-options" role="group" aria-label={m.worktree_layout()}>
-          <button
-            type="button"
-            class:active={layout === explicitLayout}
-            onclick={() => (layout = explicitLayout)}
-          >
-            {m.worktree_layout_explicit({})}
-          </button>
-          <button
-            type="button"
-            class:active={layout === repoDotWorktreesLayout}
-            onclick={() => (layout = repoDotWorktreesLayout)}
-          >
-            {m.worktree_layout_repo_dot_worktrees({
-              repo: "repo",
-              branch: "branch",
-            })}
-          </button>
-        </div>
-      </label>
+        <SegmentedControl
+          options={layoutOptions}
+          value={layout}
+          block
+          ariaLabel={m.worktree_layout()}
+          onchange={(value) => (layout = value)}
+        />
+      </div>
       <label class="field">
         <span>{isRepoDotWorktrees ? m.worktree_parent_directory() : m.worktree_path_prefix()}</span>
-        <input
+        <TextInput
           type="text"
+          size="md"
+          block
           bind:value={pathPrefix}
           placeholder={isRepoDotWorktrees ? "/Users/me" : "/Users/me/project.worktrees"}
         />
@@ -257,8 +258,10 @@
       </label>
       <label class="field">
         <span>{m.worktree_project()}</span>
-        <input
+        <TextInput
           type="text"
+          size="md"
+          block
           bind:value={project}
           placeholder="project-name"
           disabled={isRepoDotWorktrees}
@@ -386,42 +389,8 @@
     min-width: 0;
   }
 
-  .field input {
-    height: 30px;
+  .field :global(.kit-text-input) {
     min-width: 0;
-    padding: 0 10px;
-    border: 1px solid var(--border-muted);
-    border-radius: var(--radius-sm);
-    background: var(--bg-inset);
-    color: var(--text-primary);
-    font-size: 12px;
-  }
-
-  .layout-options {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 4px;
-  }
-
-  .layout-options button {
-    min-height: 30px;
-    padding: 4px 8px;
-    border: 1px solid var(--border-muted);
-    border-radius: var(--radius-sm);
-    background: var(--bg-inset);
-    color: var(--text-secondary);
-    font-size: 12px;
-    cursor: pointer;
-  }
-
-  .layout-options button.active {
-    border-color: var(--accent-blue);
-    color: var(--text-primary);
-  }
-
-  .field input:focus {
-    outline: none;
-    border-color: var(--accent-blue);
   }
 
   .hint {

--- a/frontend/src/lib/components/trends/TrendsPage.svelte
+++ b/frontend/src/lib/components/trends/TrendsPage.svelte
@@ -13,7 +13,7 @@
   import { rollingRange } from "../../utils/dates.js";
   import type { TrendsGranularity } from "../../api/types.js";
   import { ChartColumnIcon, ChevronDownIcon } from "../../icons.js";
-  import { Spinner } from "@kenn-io/kit-ui";
+  import { Spinner, Toggle } from "@kenn-io/kit-ui";
   import RangePicker from "../shared/RangePicker.svelte";
   import {
     resolveRange,
@@ -189,11 +189,6 @@
     return panelDateState(range.from, range.to, { mode: "fixed" });
   }
 
-  function setNormalized(event: Event) {
-    trends.normalized = (event.currentTarget as HTMLInputElement).checked;
-    writeUrl();
-  }
-
   async function resetTerms() {
     materializeRollingWindow();
     writeUrl();
@@ -329,14 +324,14 @@
             </div>
           {/if}
         </div>
-        <label class="normalize-toggle">
-          <input
-            type="checkbox"
-            bind:checked={trends.normalized}
-            onchange={setNormalized}
-          />
-          <span>{m.trends_normalize()}</span>
-        </label>
+        <Toggle
+          checked={trends.normalized}
+          onchange={(checked) => {
+            trends.normalized = checked;
+            writeUrl();
+          }}
+          label={m.trends_normalize()}
+        />
       </div>
       <TrendsLineChart
         buckets={trends.response?.buckets ?? []}
@@ -423,7 +418,6 @@
   }
 
   button,
-  input,
   textarea {
     font: inherit;
   }
@@ -478,18 +472,11 @@
     font-weight: 600;
   }
 
-  input,
   textarea {
     border: 1px solid var(--border-default);
     border-radius: 6px;
     background: var(--bg-surface);
     color: var(--text-primary);
-  }
-
-  input {
-    height: 32px;
-    padding: 0 8px;
-    font-size: 12px;
   }
 
   .chart-options {
@@ -572,22 +559,6 @@
   .group-item.active {
     color: var(--accent-blue);
     font-weight: 500;
-  }
-
-  .normalize-toggle {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    color: var(--text-muted);
-    font-size: 12px;
-    font-weight: 500;
-    cursor: pointer;
-  }
-
-  .normalize-toggle input {
-    width: 14px;
-    height: 14px;
-    padding: 0;
   }
 
   .content-grid {

--- a/frontend/src/lib/components/trends/TrendsPage.test.ts
+++ b/frontend/src/lib/components/trends/TrendsPage.test.ts
@@ -448,6 +448,13 @@ describe("TrendsPage", () => {
     expect(document.body.textContent).toContain(
       "Normalize by number of messages",
     );
+    const normalize = document.querySelector<HTMLInputElement>(
+      'input[role="switch"]',
+    );
+    expect(normalize).not.toBeNull();
+    expect(normalize?.closest("label")?.textContent).toContain(
+      "Normalize by number of messages",
+    );
   });
 
   it("shows a y-axis metric label", async () => {

--- a/frontend/src/lib/components/usage/UsagePage.svelte
+++ b/frontend/src/lib/components/usage/UsagePage.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { Card } from "@kenn-io/kit-ui";
   import { onDestroy, onMount, tick, untrack } from "svelte";
   import {
     usage,
@@ -467,33 +468,35 @@
     {/if}
 
     {#if unsupportedUsageMessage}
-      <div class="usage-note" role="status">
-        {unsupportedUsageMessage}
-      </div>
+      <Card level="default" padding="none" class="usage-note">
+        <div role="status">
+          {unsupportedUsageMessage}
+        </div>
+      </Card>
     {/if}
 
     <UsageSummaryCards />
 
-    <div class="chart-panel wide">
+    <Card level="default" padding="none" class="chart-panel wide">
       <CostTimeSeriesChart />
-    </div>
+    </Card>
 
-    <div class="chart-panel wide">
+    <Card level="default" padding="none" class="chart-panel wide">
       <AttributionPanel />
-    </div>
+    </Card>
 
     <div class="bottom-grid">
-      <div class="chart-panel bounded">
+      <Card level="default" padding="none" class="chart-panel bounded">
         <TopSessionsTable />
-      </div>
-      <div class="chart-panel bounded">
+      </Card>
+      <Card level="default" padding="none" class="chart-panel bounded">
         <CacheEfficiencyPanel />
-      </div>
+      </Card>
     </div>
 
-    <div class="chart-panel wide">
+    <Card level="default" padding="none" class="chart-panel wide">
       <UsagePairwiseComparisonPanel />
-    </div>
+    </Card>
   </div>
 </div>
 
@@ -540,12 +543,9 @@
     transition: opacity 0.12s;
   }
 
-  .usage-note {
+  .usage-content :global(.usage-note) {
     padding: 12px 14px;
-    background: var(--bg-surface);
-    border: 1px solid var(--border-muted);
     border-left: 4px solid var(--accent-blue);
-    border-radius: var(--radius-md);
     color: var(--text-secondary);
   }
 
@@ -578,15 +578,12 @@
     animation: query-progress 1s ease-in-out infinite;
   }
 
-  .chart-panel {
-    background: var(--bg-surface);
-    border: 1px solid var(--border-muted);
-    border-radius: var(--radius-md);
+  .usage-content :global(.chart-panel) {
     padding: 12px;
     min-width: 0;
   }
 
-  .chart-panel.wide {
+  .usage-content :global(.chart-panel.wide) {
     width: 100%;
   }
 
@@ -597,7 +594,7 @@
     align-items: start;
   }
 
-  .chart-panel.bounded {
+  .usage-content :global(.chart-panel.bounded) {
     max-height: min(420px, 48vh);
     overflow: auto;
   }

--- a/frontend/src/lib/components/usage/UsagePairwiseComparisonPanel.svelte
+++ b/frontend/src/lib/components/usage/UsagePairwiseComparisonPanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Typeahead, type TypeaheadOption } from "@kenn-io/kit-ui";
+  import { Card, Typeahead, type TypeaheadOption } from "@kenn-io/kit-ui";
   import { usage } from "../../stores/usage.svelte.js";
   import { m } from "../../i18n/index.js";
   import type { UsagePairwiseDimension } from "../../api/types/usage.js";
@@ -177,7 +177,7 @@
   </div>
 
   <div class="selectors">
-    <div class="side">
+    <Card level="default" padding="none" class="side">
       <span class="side-label">{m.usage_pairwise_left()}</span>
       <div class="side-controls">
         <label>
@@ -217,9 +217,9 @@
           </div>
         </label>
       </div>
-    </div>
+    </Card>
 
-    <div class="side">
+    <Card level="default" padding="none" class="side">
       <span class="side-label">{m.usage_pairwise_right()}</span>
       <div class="side-controls">
         <label>
@@ -259,22 +259,22 @@
           </div>
         </label>
       </div>
-    </div>
+    </Card>
   </div>
 
   {#if usage.errors.pairwise}
-    <div class="error-bar">
+    <Card level="default" padding="none" class="error-bar">
       <span>{usage.errors.pairwise}</span>
       <button class="retry-btn" onclick={() => usage.fetchAll()}>
         {m.shared_retry()}
       </button>
-    </div>
+    </Card>
   {:else if !hasSelection}
-    <div class="pairwise-note">
+    <Card level="default" padding="none" class="pairwise-note">
       {m.usage_pairwise_not_enough_data()}
-    </div>
+    </Card>
   {:else if usage.loading.pairwise && rows.length === 0}
-    <div class="pairwise-note">{m.shared_refresh()}</div>
+    <Card level="default" padding="none" class="pairwise-note">{m.shared_refresh()}</Card>
   {:else if rows.length > 0}
     <div class="table-wrap">
       <table>
@@ -341,11 +341,8 @@
     gap: 12px;
   }
 
-  .side {
+  .selectors :global(.side) {
     padding: 12px;
-    border: 1px solid var(--border-muted);
-    border-radius: var(--radius-md);
-    background: color-mix(in srgb, var(--bg-surface) 92%, transparent);
   }
 
   .side-label {
@@ -422,22 +419,24 @@
     font-size: 11px;
   }
 
-  .pairwise-note,
-  .error-bar {
+  .pairwise-panel :global(.pairwise-note) {
     padding: 12px;
-    border: 1px solid var(--border-muted);
-    border-radius: var(--radius-md);
-    background: var(--bg-surface);
     color: var(--text-muted);
     font-size: 12px;
   }
 
-  .error-bar {
+  .pairwise-panel :global(.error-bar) {
     display: flex;
     align-items: center;
     gap: 8px;
+    padding: 12px;
     border-color: var(--accent-red);
     color: var(--accent-red);
+    font-size: 12px;
+  }
+
+  .pairwise-panel :global(.error-bar > .kit-card__body) {
+    display: contents;
   }
 
   .retry-btn {

--- a/frontend/src/lib/components/usage/UsageSummaryCards.svelte
+++ b/frontend/src/lib/components/usage/UsageSummaryCards.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { Card } from "@kenn-io/kit-ui";
   import { usage } from "../../stores/usage.svelte.js";
   import { m } from "../../i18n/index.js";
 
@@ -81,7 +82,7 @@
     return String(v.toFixed(0));
   }
 
-  interface Card {
+  interface SummaryCard {
     label: () => string;
     value: () => string;
     sub?: () => string;
@@ -89,7 +90,7 @@
   }
 
   const cards = $derived.by(() => {
-    const baseCards: Card[] = [
+    const baseCards: SummaryCard[] = [
       {
         label: () => m.usage_summary_total_cost(),
         value: () => fmtCost(usage.summary?.totals.totalCost ?? 0),
@@ -158,9 +159,10 @@
 
 <div class="summary-cards">
   {#each cards as card}
-    <div
-      class="card"
-      class:featured={card.featured}
+    <Card
+      level="default"
+      padding="none"
+      class={card.featured ? "card featured" : "card"}
     >
       {#if usage.errors.summary}
         <span class="card-value error">--</span>
@@ -175,7 +177,7 @@
           {/if}
         {/if}
       {/if}
-    </div>
+    </Card>
   {/each}
 </div>
 
@@ -198,19 +200,20 @@
     flex-wrap: wrap;
   }
 
-  .card {
+  .summary-cards :global(.card) {
     flex: 1;
     min-width: 120px;
     padding: 12px;
-    background: var(--bg-surface);
-    border: 1px solid var(--border-muted);
-    border-radius: var(--radius-md);
     display: flex;
     flex-direction: column;
     gap: 2px;
   }
 
-  .card.featured {
+  .summary-cards :global(.card > .kit-card__body) {
+    display: contents;
+  }
+
+  .summary-cards :global(.card.featured) {
     border-width: 2px;
     border-color: var(--accent-blue);
   }


### PR DESCRIPTION
The kit-ui conformance update made the existing hand-rolled card and checkbox chrome a maintenance and accessibility liability. This migration moves those surfaces and boolean settings onto shared Card, Checkbox, Toggle, Button, and Select primitives so hierarchy, focus and disabled states, and interaction semantics are owned consistently across the frontend.

Feature-specific layout and state styling remain local. Narrow display adapters are limited to non-semantic Card body wrappers, while alert, live-region, and article elements remain real layout boxes. Remote authentication owns pending and rollback state so optimistic toggle feedback cannot drift from persisted settings.

Reviewers should focus on the Insights card wrapper semantics, remote-auth toggle synchronization, and responsive settings controls. One documented conformance exception remains in SkillTrend because the current kit primitives cannot preserve its aria-pressed toggle semantics.

<sup>generated by a clanker</sup>