### PR TITLE
ci: cap Renovate TypeScript updates at 6.x

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -36,7 +36,7 @@
     {
       "matchManagers": ["npm"],
       "matchPackageNames": ["typescript"],
-      "allowedVersions": "!/^(7\\.0\\.)/"
+      "allowedVersions": "<7"
     }
   ]
 }


### PR DESCRIPTION
Renovate currently treats the frontend TypeScript pin as eligible for a 7.x major update, so closing the bot PR would only cause it to be recreated. TypeScript 7 is not yet an intended migration for agentsview.

This constrains Renovate TypeScript candidates to versions below 7. TypeScript remains exactly pinned in package.json, and Renovate can continue proposing 6.x maintenance releases without bundling a premature compiler major into the JavaScript dependency group.