### PR TITLE
fix(frontend): stop persisting rolling-derived session date bounds

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -317,7 +317,10 @@
   ): Record<string, string> | null {
     const dateParams = panelDateToSessionFilterParams(state);
     if (Object.keys(dateParams).length === 0) return null;
-    sessions.applyPanelDateFilters(dateParams, state.mode === "rolling");
+    sessions.applyPanelDateFilters(
+      dateParams,
+      state.mode === "rolling" ? state.windowDays ?? null : null,
+    );
     const params = { ...routeParams };
     for (const key of [
       "date",

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -311,6 +311,20 @@
     }
   }
 
+  // Session route params composed from filters must carry the rolling
+  // intent: a URL with concrete dates but no window_days re-enters
+  // initFromParams as an explicit fixed range, so the rolling
+  // persistence would be lost after one reload.
+  function sessionFilterRouteParams(): Record<string, string> {
+    const params = filtersToParams(sessions.filters);
+    if (sessions.dateFiltersWindowDays !== null) {
+      params[SESSION_ANALYTICS_WINDOW_PARAM] = String(
+        sessions.dateFiltersWindowDays,
+      );
+    }
+    return params;
+  }
+
   function applySessionDateState(
     state: PanelDateState,
     routeParams: Record<string, string>,
@@ -330,7 +344,7 @@
     ]) {
       delete params[key];
     }
-    Object.assign(params, filtersToParams(sessions.filters));
+    Object.assign(params, sessionFilterRouteParams());
     if (
       state.mode === "rolling" &&
       state.windowDays
@@ -445,7 +459,7 @@
   $effect(() => {
     const activeId = sessions.activeSessionId;
     const currentUrlSessionId = router.sessionId;
-    const filterParams = filtersToParams(sessions.filters);
+    const filterParams = sessionFilterRouteParams();
     const filterParamsSignature = JSON.stringify(filterParams);
     untrack(() => {
       if (router.route !== "sessions") {
@@ -504,7 +518,7 @@
   $effect(() => {
     const route = router.route;
     const newParams = sessionRouteParamsForFilters(
-      filtersToParams(sessions.filters),
+      sessionFilterRouteParams(),
       router.params,
     );
     untrack(() => {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -317,9 +317,7 @@
   ): Record<string, string> | null {
     const dateParams = panelDateToSessionFilterParams(state);
     if (Object.keys(dateParams).length === 0) return null;
-    sessions.filters.date = dateParams["date"] ?? "";
-    sessions.filters.dateFrom = dateParams["date_from"] ?? "";
-    sessions.filters.dateTo = dateParams["date_to"] ?? "";
+    sessions.applyPanelDateFilters(dateParams, state.mode === "rolling");
     const params = { ...routeParams };
     for (const key of [
       "date",

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -13,6 +13,7 @@ import { insights } from "./lib/stores/insights.svelte.js";
 import { messages } from "./lib/stores/messages.svelte.js";
 import { pins } from "./lib/stores/pins.svelte.js";
 import { router } from "./lib/stores/router.svelte.js";
+import { rollingRange } from "./lib/utils/dates.js";
 import { sessionTiming } from "./lib/stores/sessionTiming.svelte.js";
 import { sessions } from "./lib/stores/sessions.svelte.js";
 import { settings } from "./lib/stores/settings.svelte.js";
@@ -189,6 +190,28 @@ describe("App session URL date state", () => {
     expect(SESSION_FILTER_KEYS.has("termination")).toBe(true);
   });
 
+  it("carries rolling intent into the sessions URL write-back", async () => {
+    component = mount(App, { target: document.body });
+    await tick();
+    // Simulates a rolling window restored from localStorage (or applied
+    // from a panel): the URL write-back must include window_days, or the
+    // next route initialization re-reads the concrete dates as an
+    // explicit fixed range and the rolling intent is lost after one
+    // reload.
+    sessions.applyPanelDateFilters(
+      { date_from: "2026-03-10", date_to: "2026-04-08" },
+      30,
+    );
+    await tick();
+    await tick();
+    expect(router.params["window_days"]).toBe("30");
+    // The route round-trip rematerializes the window against the current
+    // date — the intent surviving is the contract, not the exact bounds.
+    const range = rollingRange(30);
+    expect(router.params["date_from"]).toBe(range.from);
+    expect(router.params["date_to"]).toBe(range.to);
+  });
+
   it("preserves rolling window dates when writing sessions URLs", () => {
     expect(source).toContain("sessionRouteParamsForFilters(");
     expect(source).toContain("router.navigateFromSession(nextParams)");
@@ -254,7 +277,9 @@ describe("App session URL date state", () => {
     expect(source).toContain(
       "let lastDetailFilterParamsSignature: string | null = $state(null);",
     );
-    expect(syncUrlBlock).toContain("const filterParams = filtersToParams(");
+    expect(syncUrlBlock).toContain(
+      "const filterParams = sessionFilterRouteParams();",
+    );
     expect(syncUrlBlock).toContain(
       "lastDetailFilterParamsSignature !== null &&",
     );
@@ -706,6 +731,10 @@ describe("App analytics date navigation", () => {
     sessions.filters.date = "";
     sessions.filters.dateFrom = "";
     sessions.filters.dateTo = "";
+    // Clearing dates now also means clearing the rolling intent — the
+    // store-level clear paths (clearSessionFilters, setProjectFilter) do
+    // both, and the URL write-back re-adds window_days otherwise.
+    sessions.dateFiltersWindowDays = null;
     router.params = {};
     await flushEffects();
 

--- a/frontend/src/lib/components/analytics/AnalyticsPage.svelte
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.svelte
@@ -171,9 +171,7 @@
     const before = JSON.stringify(filtersToParams(sessions.filters));
     clearSessionDateFilters();
     const params = panelDateToSessionFilterParams(state);
-    sessions.filters.date = params["date"] ?? "";
-    sessions.filters.dateFrom = params["date_from"] ?? "";
-    sessions.filters.dateTo = params["date_to"] ?? "";
+    sessions.applyPanelDateFilters(params, state.mode === "rolling");
     const after = JSON.stringify(filtersToParams(sessions.filters));
     return before !== after;
   }

--- a/frontend/src/lib/components/analytics/AnalyticsPage.svelte
+++ b/frontend/src/lib/components/analytics/AnalyticsPage.svelte
@@ -142,12 +142,6 @@
     return JSON.stringify({ mode: "none" });
   }
 
-  function clearSessionDateFilters(): void {
-    sessions.filters.date = "";
-    sessions.filters.dateFrom = "";
-    sessions.filters.dateTo = "";
-  }
-
   function sessionDateFiltersAreClear(): boolean {
     return !sessions.filters.date &&
       !sessions.filters.dateFrom &&
@@ -169,9 +163,11 @@
     state: PanelDateState,
   ): boolean {
     const before = JSON.stringify(filtersToParams(sessions.filters));
-    clearSessionDateFilters();
     const params = panelDateToSessionFilterParams(state);
-    sessions.applyPanelDateFilters(params, state.mode === "rolling");
+    sessions.applyPanelDateFilters(
+      params,
+      state.mode === "rolling" ? state.windowDays ?? null : null,
+    );
     const after = JSON.stringify(filtersToParams(sessions.filters));
     return before !== after;
   }

--- a/frontend/src/lib/stores/sessionRouteParams.ts
+++ b/frontend/src/lib/stores/sessionRouteParams.ts
@@ -53,10 +53,18 @@ export function sessionDateIntentCleared(
     !hasSessionDateIntent(nextParams);
 }
 
-function isValidWindowDaysParam(raw: string | undefined): raw is string {
-  if (!raw) return false;
+/** Parses a window_days param; null unless a canonical positive integer. */
+export function parseWindowDaysParam(
+  raw: string | undefined,
+): number | null {
+  if (!raw) return null;
   const n = Number.parseInt(raw, 10);
-  return Number.isInteger(n) && n > 0 && String(n) === raw;
+  if (!Number.isInteger(n) || n <= 0 || String(n) !== raw) return null;
+  return n;
+}
+
+function isValidWindowDaysParam(raw: string | undefined): raw is string {
+  return parseWindowDaysParam(raw) !== null;
 }
 
 function fixedSessionDateParamsEqual(

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -19,7 +19,11 @@ import { sync } from "./sync.svelte.js";
 import { events } from "./events.svelte.js";
 import { starred } from "./starred.svelte.js";
 import { yokedDates } from "./yokedDates.svelte.js";
-import { SESSION_ANALYTICS_WINDOW_PARAM } from "./sessionRouteParams.js";
+import {
+  SESSION_ANALYTICS_WINDOW_PARAM,
+  parseWindowDaysParam,
+} from "./sessionRouteParams.js";
+import { rollingRange } from "../utils/dates.js";
 import { LatestRead } from "../utils/latest-read.js";
 
 type SidebarIndexParams = Parameters<
@@ -121,19 +125,32 @@ function defaultFilters(): Filters {
 }
 
 const SESSION_FILTERS_KEY = "session-filters";
-// v2 marks entries whose date bounds carry provenance: rolling-derived
-// bounds are never persisted (see saveFilters). Unversioned entries predate
-// that guarantee and may hold rolling bounds saved as if explicit (#1086).
+// v2 marks entries whose date bounds carry provenance: rolling bounds are
+// persisted as intent (`windowDays`) and rematerialized on load, never as
+// pinned dates. Unversioned entries predate that guarantee and may hold
+// rolling bounds saved as if explicit (#1086).
 const SESSION_FILTERS_VERSION = 2;
 
-function loadSavedFilters(): Filters {
+interface SavedFilters {
+  filters: Filters;
+  windowDays: number | null;
+}
+
+function validWindowDays(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+function loadSavedFilters(): SavedFilters {
   try {
     const raw = localStorage.getItem(SESSION_FILTERS_KEY);
     if (raw) {
-      const { version, ...saved } = JSON.parse(raw) as Partial<Filters> & {
-        version?: unknown;
-      };
+      const { version, windowDays, ...saved } = JSON.parse(
+        raw,
+      ) as Partial<Filters> & { version?: unknown; windowDays?: unknown };
       const filters = { ...defaultFilters(), ...saved };
+      // Deliberately `!==`, not `<`: an entry written by a newer (or older)
+      // format is not trusted either way — dropping date bounds is the
+      // fail-safe direction in both.
       if (version !== SESSION_FILTERS_VERSION) {
         // Legacy bounds have unknown provenance. Dropping them once is the
         // safe direction: an intentional range is re-picked in one click,
@@ -142,23 +159,34 @@ function loadSavedFilters(): Filters {
         filters.dateFrom = "";
         filters.dateTo = "";
         saveFilters(filters);
+        return { filters, windowDays: null };
       }
-      return filters;
+      if (validWindowDays(windowDays)) {
+        // Rolling intent survives restarts; its bounds are recomputed
+        // against the current date so the window keeps rolling forward.
+        const range = rollingRange(windowDays);
+        filters.date = "";
+        filters.dateFrom = range.from;
+        filters.dateTo = range.to;
+        return { filters, windowDays };
+      }
+      return { filters, windowDays: null };
     }
   } catch {
     // Corrupted localStorage — fall back to defaults.
   }
-  return defaultFilters();
+  return { filters: defaultFilters(), windowDays: null };
 }
 
-function saveFilters(f: Filters, omitDates = false): void {
-  // Date bounds materialized from a rolling window must not be persisted:
-  // restoring them verbatim on the next launch pins the window to the day
-  // it was saved, silently hiding newer sessions (#1086). Only explicitly
-  // chosen fixed ranges survive a restart.
-  const toSave = omitDates
-    ? { ...f, date: "", dateFrom: "", dateTo: "" }
-    : f;
+function saveFilters(f: Filters, windowDays: number | null = null): void {
+  // Rolling bounds are persisted as intent (windowDays) and rematerialized
+  // on load; the materialized dates themselves are session-scoped. Storing
+  // them verbatim would pin the window to the day it was saved, silently
+  // hiding newer sessions (#1086).
+  const toSave =
+    windowDays !== null
+      ? { ...f, date: "", dateFrom: "", dateTo: "", windowDays }
+      : f;
   try {
     localStorage.setItem(
       SESSION_FILTERS_KEY,
@@ -273,11 +301,14 @@ class SessionsStore {
   nextCursor: string | null = $state(null);
   total: number = $state(0);
   loading: boolean = $state(false);
-  filters: Filters = $state(loadSavedFilters());
-  /** True when the current date bounds were materialized from a rolling
-   *  window rather than chosen explicitly; such bounds are session-scoped
-   *  and excluded from persistence (#1086). */
-  dateFiltersDerived = false;
+  #savedFilters = loadSavedFilters();
+  filters: Filters = $state(this.#savedFilters.filters);
+  /** Rolling window (in days) behind the current date bounds, or null when
+   *  the bounds were chosen explicitly. Persisted as intent and
+   *  rematerialized on load so the window keeps rolling forward (#1086). */
+  dateFiltersWindowDays: number | null = $state(
+    this.#savedFilters.windowDays,
+  );
 
   private signalDetailCache = new Map<
     string,
@@ -387,20 +418,21 @@ class SessionsStore {
     };
   }
 
-  /** Set date filters materialized from a panel date state. `derived` marks
-   *  bounds that came from a rolling window and must not be persisted. */
+  /** Set date filters materialized from a panel date state. `windowDays`
+   *  carries the rolling intent behind the bounds (null for explicitly
+   *  chosen fixed ranges). */
   applyPanelDateFilters(
     dateParams: Record<string, string>,
-    derived: boolean,
+    windowDays: number | null,
   ): void {
     this.filters.date = dateParams["date"] ?? "";
     this.filters.dateFrom = dateParams["date_from"] ?? "";
     this.filters.dateTo = dateParams["date_to"] ?? "";
-    this.dateFiltersDerived = derived;
+    this.dateFiltersWindowDays = windowDays;
     // Persist immediately: a provenance flip with identical bounds does
     // not register as a filter change, so callers that diff serialized
     // filters may never trigger a load() and its save.
-    saveFilters(this.filters, derived);
+    saveFilters(this.filters, windowDays);
   }
 
   initFromParams(params: Record<string, string>) {
@@ -408,8 +440,9 @@ class SessionsStore {
     const prevAutomated = this.filters.includeAutomated;
     const next = parseFiltersFromParams(params);
     this.filters = next;
-    this.dateFiltersDerived =
-      params[SESSION_ANALYTICS_WINDOW_PARAM] !== undefined;
+    this.dateFiltersWindowDays = parseWindowDaysParam(
+      params[SESSION_ANALYTICS_WINDOW_PARAM],
+    );
     if (prevOneShot !== next.includeOneShot ||
         prevAutomated !== next.includeAutomated) {
       this.invalidateFilterCaches();
@@ -418,7 +451,7 @@ class SessionsStore {
   }
 
   async load(options: LoadOptions = {}) {
-    saveFilters(this.filters, this.dateFiltersDerived);
+    saveFilters(this.filters, this.dateFiltersWindowDays);
 
     const params = {
       ...this.apiParams,
@@ -971,7 +1004,7 @@ class SessionsStore {
   setProjectFilter(project: string) {
     const prev = this.filters;
     this.filters = { ...defaultFilters(), project, agent: prev.agent };
-    this.dateFiltersDerived = false;
+    this.dateFiltersWindowDays = null;
     this.setActiveSession(null);
     if (prev.includeOneShot !== this.filters.includeOneShot ||
         prev.includeAutomated !== this.filters.includeAutomated) {
@@ -1134,7 +1167,7 @@ class SessionsStore {
       yokedDates.clear();
     }
     this.filters = { ...defaultFilters(), project };
-    this.dateFiltersDerived = false;
+    this.dateFiltersWindowDays = null;
     this.setActiveSession(null);
     if (wasOneShot !== this.filters.includeOneShot || wasAutomated) {
       this.invalidateFilterCaches();

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -948,6 +948,7 @@ class SessionsStore {
   setProjectFilter(project: string) {
     const prev = this.filters;
     this.filters = { ...defaultFilters(), project, agent: prev.agent };
+    this.dateFiltersDerived = false;
     this.setActiveSession(null);
     if (prev.includeOneShot !== this.filters.includeOneShot ||
         prev.includeAutomated !== this.filters.includeAutomated) {
@@ -1110,6 +1111,7 @@ class SessionsStore {
       yokedDates.clear();
     }
     this.filters = { ...defaultFilters(), project };
+    this.dateFiltersDerived = false;
     this.setActiveSession(null);
     if (wasOneShot !== this.filters.includeOneShot || wasAutomated) {
       this.invalidateFilterCaches();

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -378,6 +378,10 @@ class SessionsStore {
     this.filters.dateFrom = dateParams["date_from"] ?? "";
     this.filters.dateTo = dateParams["date_to"] ?? "";
     this.dateFiltersDerived = derived;
+    // Persist immediately: a provenance flip with identical bounds does
+    // not register as a filter change, so callers that diff serialized
+    // filters may never trigger a load() and its save.
+    saveFilters(this.filters, derived);
   }
 
   initFromParams(params: Record<string, string>) {

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -19,6 +19,7 @@ import { sync } from "./sync.svelte.js";
 import { events } from "./events.svelte.js";
 import { starred } from "./starred.svelte.js";
 import { yokedDates } from "./yokedDates.svelte.js";
+import { SESSION_ANALYTICS_WINDOW_PARAM } from "./sessionRouteParams.js";
 import { LatestRead } from "../utils/latest-read.js";
 
 type SidebarIndexParams = Parameters<
@@ -134,9 +135,16 @@ function loadSavedFilters(): Filters {
   return defaultFilters();
 }
 
-function saveFilters(f: Filters): void {
+function saveFilters(f: Filters, omitDates = false): void {
+  // Date bounds materialized from a rolling window must not be persisted:
+  // restoring them verbatim on the next launch pins the window to the day
+  // it was saved, silently hiding newer sessions (#1086). Only explicitly
+  // chosen fixed ranges survive a restart.
+  const toSave = omitDates
+    ? { ...f, date: "", dateFrom: "", dateTo: "" }
+    : f;
   try {
-    localStorage.setItem(SESSION_FILTERS_KEY, JSON.stringify(f));
+    localStorage.setItem(SESSION_FILTERS_KEY, JSON.stringify(toSave));
   } catch {
     // localStorage full or unavailable — silently skip.
   }
@@ -247,6 +255,10 @@ class SessionsStore {
   total: number = $state(0);
   loading: boolean = $state(false);
   filters: Filters = $state(loadSavedFilters());
+  /** True when the current date bounds were materialized from a rolling
+   *  window rather than chosen explicitly; such bounds are session-scoped
+   *  and excluded from persistence (#1086). */
+  dateFiltersDerived = false;
 
   private signalDetailCache = new Map<
     string,
@@ -356,11 +368,25 @@ class SessionsStore {
     };
   }
 
+  /** Set date filters materialized from a panel date state. `derived` marks
+   *  bounds that came from a rolling window and must not be persisted. */
+  applyPanelDateFilters(
+    dateParams: Record<string, string>,
+    derived: boolean,
+  ): void {
+    this.filters.date = dateParams["date"] ?? "";
+    this.filters.dateFrom = dateParams["date_from"] ?? "";
+    this.filters.dateTo = dateParams["date_to"] ?? "";
+    this.dateFiltersDerived = derived;
+  }
+
   initFromParams(params: Record<string, string>) {
     const prevOneShot = this.filters.includeOneShot;
     const prevAutomated = this.filters.includeAutomated;
     const next = parseFiltersFromParams(params);
     this.filters = next;
+    this.dateFiltersDerived =
+      params[SESSION_ANALYTICS_WINDOW_PARAM] !== undefined;
     if (prevOneShot !== next.includeOneShot ||
         prevAutomated !== next.includeAutomated) {
       this.invalidateFilterCaches();
@@ -369,7 +395,7 @@ class SessionsStore {
   }
 
   async load(options: LoadOptions = {}) {
-    saveFilters(this.filters);
+    saveFilters(this.filters, this.dateFiltersDerived);
 
     const params = {
       ...this.apiParams,

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -121,13 +121,29 @@ function defaultFilters(): Filters {
 }
 
 const SESSION_FILTERS_KEY = "session-filters";
+// v2 marks entries whose date bounds carry provenance: rolling-derived
+// bounds are never persisted (see saveFilters). Unversioned entries predate
+// that guarantee and may hold rolling bounds saved as if explicit (#1086).
+const SESSION_FILTERS_VERSION = 2;
 
 function loadSavedFilters(): Filters {
   try {
     const raw = localStorage.getItem(SESSION_FILTERS_KEY);
     if (raw) {
-      const saved = JSON.parse(raw) as Partial<Filters>;
-      return { ...defaultFilters(), ...saved };
+      const { version, ...saved } = JSON.parse(raw) as Partial<Filters> & {
+        version?: unknown;
+      };
+      const filters = { ...defaultFilters(), ...saved };
+      if (version !== SESSION_FILTERS_VERSION) {
+        // Legacy bounds have unknown provenance. Dropping them once is the
+        // safe direction: an intentional range is re-picked in one click,
+        // while a poisoned one keeps silently hiding new sessions.
+        filters.date = "";
+        filters.dateFrom = "";
+        filters.dateTo = "";
+        saveFilters(filters);
+      }
+      return filters;
     }
   } catch {
     // Corrupted localStorage — fall back to defaults.
@@ -144,7 +160,10 @@ function saveFilters(f: Filters, omitDates = false): void {
     ? { ...f, date: "", dateFrom: "", dateTo: "" }
     : f;
   try {
-    localStorage.setItem(SESSION_FILTERS_KEY, JSON.stringify(toSave));
+    localStorage.setItem(
+      SESSION_FILTERS_KEY,
+      JSON.stringify({ ...toSave, version: SESSION_FILTERS_VERSION }),
+    );
   } catch {
     // localStorage full or unavailable — silently skip.
   }

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -364,6 +364,41 @@ describe("SessionsStore", () => {
       expect(sessions.filters.dateFrom).toBe("2025-07-07");
     });
 
+    it("resumes persisting when a derived range is replaced by an explicit one", async () => {
+      sessions.applyPanelDateFilters(
+        { date_from: "2025-07-07", date_to: "2026-07-06" },
+        true,
+      );
+      await sessions.load();
+      sessions.applyPanelDateFilters(
+        { date_from: "2026-01-01", date_to: "2026-01-31" },
+        false,
+      );
+      await sessions.load();
+
+      const saved = JSON.parse(
+        localStorage.getItem("session-filters") ?? "{}",
+      );
+      expect(saved.dateFrom).toBe("2026-01-01");
+      expect(saved.dateTo).toBe("2026-01-31");
+    });
+
+    it("clears the derived flag on wholesale filter resets", async () => {
+      sessions.applyPanelDateFilters(
+        { date_from: "2025-07-07", date_to: "2026-07-06" },
+        true,
+      );
+      sessions.clearSessionFilters();
+      expect(sessions.dateFiltersDerived).toBe(false);
+
+      sessions.applyPanelDateFilters(
+        { date_from: "2025-07-07", date_to: "2026-07-06" },
+        true,
+      );
+      sessions.setProjectFilter("myproj");
+      expect(sessions.dateFiltersDerived).toBe(false);
+    });
+
     it("persists deep-linked explicit date bounds", async () => {
       sessions.initFromParams({
         date_from: "2026-01-01",

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -313,6 +313,70 @@ describe("SessionsStore", () => {
       expect(store.filters.project).toBe("");
       expect(store.filters.includeOneShot).toBe(true);
     });
+
+    it("does not persist rolling-derived date bounds", async () => {
+      sessions.filters.project = "myproj";
+      sessions.applyPanelDateFilters(
+        { date_from: "2025-07-07", date_to: "2026-07-06" },
+        true,
+      );
+      await sessions.load();
+
+      const saved = JSON.parse(
+        localStorage.getItem("session-filters") ?? "{}",
+      );
+      expect(saved.dateFrom).toBe("");
+      expect(saved.dateTo).toBe("");
+      expect(saved.date).toBe("");
+      expect(saved.project).toBe("myproj");
+      // The current tab still queries with the materialized bounds.
+      expect(sessions.filters.dateFrom).toBe("2025-07-07");
+      expect(sessions.filters.dateTo).toBe("2026-07-06");
+    });
+
+    it("persists explicitly chosen fixed date bounds", async () => {
+      sessions.applyPanelDateFilters(
+        { date_from: "2026-01-01", date_to: "2026-01-31" },
+        false,
+      );
+      await sessions.load();
+
+      const saved = JSON.parse(
+        localStorage.getItem("session-filters") ?? "{}",
+      );
+      expect(saved.dateFrom).toBe("2026-01-01");
+      expect(saved.dateTo).toBe("2026-01-31");
+    });
+
+    it("treats deep-linked window_days date bounds as derived", async () => {
+      sessions.initFromParams({
+        window_days: "365",
+        date_from: "2025-07-07",
+        date_to: "2026-07-06",
+      });
+      await sessions.load();
+
+      const saved = JSON.parse(
+        localStorage.getItem("session-filters") ?? "{}",
+      );
+      expect(saved.dateFrom).toBe("");
+      expect(saved.dateTo).toBe("");
+      expect(sessions.filters.dateFrom).toBe("2025-07-07");
+    });
+
+    it("persists deep-linked explicit date bounds", async () => {
+      sessions.initFromParams({
+        date_from: "2026-01-01",
+        date_to: "2026-01-31",
+      });
+      await sessions.load();
+
+      const saved = JSON.parse(
+        localStorage.getItem("session-filters") ?? "{}",
+      );
+      expect(saved.dateFrom).toBe("2026-01-01");
+      expect(saved.dateTo).toBe("2026-01-31");
+    });
   });
 
   describe("sidebar loading", () => {

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -383,6 +383,27 @@ describe("SessionsStore", () => {
       expect(saved.dateTo).toBe("2026-01-31");
     });
 
+    it("persists a provenance flip even when the bounds are identical", async () => {
+      // Fixed range persisted, then a rolling preset materializes to the
+      // exact same bounds. Callers that diff serialized filters see no
+      // change and skip load(), so the store must persist on apply.
+      sessions.applyPanelDateFilters(
+        { date_from: "2025-07-07", date_to: "2026-07-06" },
+        false,
+      );
+      await sessions.load();
+      sessions.applyPanelDateFilters(
+        { date_from: "2025-07-07", date_to: "2026-07-06" },
+        true,
+      );
+
+      const saved = JSON.parse(
+        localStorage.getItem("session-filters") ?? "{}",
+      );
+      expect(saved.dateFrom).toBe("");
+      expect(saved.dateTo).toBe("");
+    });
+
     it("clears the derived flag on wholesale filter resets", async () => {
       sessions.applyPanelDateFilters(
         { date_from: "2025-07-07", date_to: "2026-07-06" },

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -314,6 +314,54 @@ describe("SessionsStore", () => {
       expect(store.filters.includeOneShot).toBe(true);
     });
 
+    it("clears date bounds from legacy unversioned entries", () => {
+      // Entries written before provenance tracking may hold rolling bounds
+      // persisted as if explicit; only their date fields are dropped.
+      localStorage.setItem(
+        "session-filters",
+        JSON.stringify({
+          project: "saved-proj",
+          dateFrom: "2025-07-07",
+          dateTo: "2026-07-06",
+          date: "2025-07-07",
+        }),
+      );
+      const store = createSessionsStore();
+      expect(store.filters.project).toBe("saved-proj");
+      expect(store.filters.dateFrom).toBe("");
+      expect(store.filters.dateTo).toBe("");
+      expect(store.filters.date).toBe("");
+      // Migration is written back so it runs only once.
+      const saved = JSON.parse(
+        localStorage.getItem("session-filters") ?? "{}",
+      );
+      expect(saved.version).toBe(2);
+      expect(saved.dateFrom).toBe("");
+    });
+
+    it("keeps date bounds from versioned entries", () => {
+      localStorage.setItem(
+        "session-filters",
+        JSON.stringify({
+          version: 2,
+          dateFrom: "2026-01-01",
+          dateTo: "2026-01-31",
+        }),
+      );
+      const store = createSessionsStore();
+      expect(store.filters.dateFrom).toBe("2026-01-01");
+      expect(store.filters.dateTo).toBe("2026-01-31");
+    });
+
+    it("stamps the storage version when persisting", async () => {
+      sessions.filters.project = "myproj";
+      await sessions.load();
+      const saved = JSON.parse(
+        localStorage.getItem("session-filters") ?? "{}",
+      );
+      expect(saved.version).toBe(2);
+    });
+
     it("does not persist rolling-derived date bounds", async () => {
       sessions.filters.project = "myproj";
       sessions.applyPanelDateFilters(

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -19,6 +19,7 @@ import { yokedDates } from "./yokedDates.svelte.js";
 import type { Filters } from "./sessions.svelte.js";
 import type { Session } from "../api/types.js";
 import { callGenerated } from "../api/runtime.js";
+import { rollingRange } from "../utils/dates.js";
 
 const api = vi.hoisted(() => ({
   listSessions: vi.fn(),
@@ -362,11 +363,11 @@ describe("SessionsStore", () => {
       expect(saved.version).toBe(2);
     });
 
-    it("does not persist rolling-derived date bounds", async () => {
+    it("persists rolling bounds as windowDays intent, not dates", async () => {
       sessions.filters.project = "myproj";
       sessions.applyPanelDateFilters(
         { date_from: "2025-07-07", date_to: "2026-07-06" },
-        true,
+        365,
       );
       await sessions.load();
 
@@ -376,16 +377,40 @@ describe("SessionsStore", () => {
       expect(saved.dateFrom).toBe("");
       expect(saved.dateTo).toBe("");
       expect(saved.date).toBe("");
+      expect(saved.windowDays).toBe(365);
       expect(saved.project).toBe("myproj");
       // The current tab still queries with the materialized bounds.
       expect(sessions.filters.dateFrom).toBe("2025-07-07");
       expect(sessions.filters.dateTo).toBe("2026-07-06");
     });
 
+    it("rematerializes a persisted rolling window on load", () => {
+      localStorage.setItem(
+        "session-filters",
+        JSON.stringify({ version: 2, project: "p", windowDays: 30 }),
+      );
+      const store = createSessionsStore();
+      const range = rollingRange(30);
+      expect(store.filters.dateFrom).toBe(range.from);
+      expect(store.filters.dateTo).toBe(range.to);
+      expect(store.dateFiltersWindowDays).toBe(30);
+      expect(store.filters.project).toBe("p");
+    });
+
+    it("ignores an invalid persisted windowDays", () => {
+      localStorage.setItem(
+        "session-filters",
+        JSON.stringify({ version: 2, windowDays: -5 }),
+      );
+      const store = createSessionsStore();
+      expect(store.filters.dateFrom).toBe("");
+      expect(store.dateFiltersWindowDays).toBe(null);
+    });
+
     it("persists explicitly chosen fixed date bounds", async () => {
       sessions.applyPanelDateFilters(
         { date_from: "2026-01-01", date_to: "2026-01-31" },
-        false,
+        null,
       );
       await sessions.load();
 
@@ -394,9 +419,10 @@ describe("SessionsStore", () => {
       );
       expect(saved.dateFrom).toBe("2026-01-01");
       expect(saved.dateTo).toBe("2026-01-31");
+      expect(saved.windowDays).toBeUndefined();
     });
 
-    it("treats deep-linked window_days date bounds as derived", async () => {
+    it("treats deep-linked window_days date bounds as rolling intent", async () => {
       sessions.initFromParams({
         window_days: "365",
         date_from: "2025-07-07",
@@ -409,18 +435,34 @@ describe("SessionsStore", () => {
       );
       expect(saved.dateFrom).toBe("");
       expect(saved.dateTo).toBe("");
+      expect(saved.windowDays).toBe(365);
       expect(sessions.filters.dateFrom).toBe("2025-07-07");
     });
 
-    it("resumes persisting when a derived range is replaced by an explicit one", async () => {
+    it("treats an invalid deep-linked window_days as explicit bounds", async () => {
+      sessions.initFromParams({
+        window_days: "abc",
+        date_from: "2026-01-01",
+        date_to: "2026-01-31",
+      });
+      expect(sessions.dateFiltersWindowDays).toBe(null);
+      await sessions.load();
+
+      const saved = JSON.parse(
+        localStorage.getItem("session-filters") ?? "{}",
+      );
+      expect(saved.dateFrom).toBe("2026-01-01");
+    });
+
+    it("resumes persisting dates when a rolling range is replaced by an explicit one", async () => {
       sessions.applyPanelDateFilters(
         { date_from: "2025-07-07", date_to: "2026-07-06" },
-        true,
+        365,
       );
       await sessions.load();
       sessions.applyPanelDateFilters(
         { date_from: "2026-01-01", date_to: "2026-01-31" },
-        false,
+        null,
       );
       await sessions.load();
 
@@ -429,6 +471,7 @@ describe("SessionsStore", () => {
       );
       expect(saved.dateFrom).toBe("2026-01-01");
       expect(saved.dateTo).toBe("2026-01-31");
+      expect(saved.windowDays).toBeUndefined();
     });
 
     it("persists a provenance flip even when the bounds are identical", async () => {
@@ -437,12 +480,12 @@ describe("SessionsStore", () => {
       // change and skip load(), so the store must persist on apply.
       sessions.applyPanelDateFilters(
         { date_from: "2025-07-07", date_to: "2026-07-06" },
-        false,
+        null,
       );
       await sessions.load();
       sessions.applyPanelDateFilters(
         { date_from: "2025-07-07", date_to: "2026-07-06" },
-        true,
+        365,
       );
 
       const saved = JSON.parse(
@@ -450,22 +493,23 @@ describe("SessionsStore", () => {
       );
       expect(saved.dateFrom).toBe("");
       expect(saved.dateTo).toBe("");
+      expect(saved.windowDays).toBe(365);
     });
 
-    it("clears the derived flag on wholesale filter resets", async () => {
+    it("clears the rolling intent on wholesale filter resets", async () => {
       sessions.applyPanelDateFilters(
         { date_from: "2025-07-07", date_to: "2026-07-06" },
-        true,
+        365,
       );
       sessions.clearSessionFilters();
-      expect(sessions.dateFiltersDerived).toBe(false);
+      expect(sessions.dateFiltersWindowDays).toBe(null);
 
       sessions.applyPanelDateFilters(
         { date_from: "2025-07-07", date_to: "2026-07-06" },
-        true,
+        365,
       );
       sessions.setProjectFilter("myproj");
-      expect(sessions.dateFiltersDerived).toBe(false);
+      expect(sessions.dateFiltersWindowDays).toBe(null);
     });
 
     it("persists deep-linked explicit date bounds", async () => {


### PR DESCRIPTION
Fixes #1086.

Date bounds materialized from a rolling window (`window_days`) were saved into the `session-filters` localStorage entry and restored verbatim on the next launch. Once yoked dates could no longer overwrite them — e.g. after the v1 storage migration disabled them — the range stayed pinned to the day it was saved and newer sessions silently disappeared from the sidebar and analytics.

The sessions store now tracks the provenance of its date bounds as `dateFiltersWindowDays`: bounds applied from a rolling panel state (`App.svelte`, `AnalyticsPage.svelte`) or a `window_days` deep link (`initFromParams`, validated with the route layer's shared `parseWindowDaysParam`) carry their rolling intent, while explicitly chosen fixed ranges carry `null`. Persistence stores the intent rather than the materialized dates: the saved entry keeps `windowDays` and blank bounds, and `loadSavedFilters` rematerializes the bounds against the current date, so a rolling filter survives restarts and keeps rolling forward instead of pinning or vanishing. `applyPanelDateFilters` persists immediately, so a provenance flip between fixed and rolling with identical materialized bounds — which does not register as a filter change and may never trigger a `load()` — still updates the saved entry. Wholesale filter resets clear the intent, and the store is now the sole writer of session date bounds (`clearSessionDateFilters` removed as dead code).

Already-poisoned installs are also repaired: saved entries are stamped with a storage version, and unversioned (pre-provenance) entries have their date bounds dropped once on load and are rewritten in the new format, mirroring the yoked-dates v1 migration. The check is deliberately `!==` rather than `<` so a downgraded newer format is also not trusted; dropping bounds is the fail-safe direction in both. Other persisted filter fields are preserved.

Reviewers should look at `saveFilters`/`loadSavedFilters`/`applyPanelDateFilters` in `sessions.svelte.ts` and the two call sites. Known cosmetic note: a persisted one-day rolling window rematerializes as `date_from`/`date_to` rather than the single `date` param; both filter identically.