### PR TITLE
test(frontend): make StatusBar sync-label test locale-independent

### DIFF
--- a/frontend/src/lib/components/layout/StatusBar.test.ts
+++ b/frontend/src/lib/components/layout/StatusBar.test.ts
@@ -11,6 +11,7 @@ import { mount, tick, unmount } from "svelte";
 // @ts-ignore
 import StatusBar from "./StatusBar.svelte";
 import { sync } from "../../stores/sync.svelte.js";
+import { formatTimestamp } from "../../utils/format.js";
 
 describe("StatusBar", () => {
   beforeEach(() => {
@@ -50,15 +51,10 @@ describe("StatusBar", () => {
     const syncLabel = document.querySelector(
       ".kit-status-bar__section--right span[title]",
     );
-    const expectedTitle = new Date(sync.lastSync!).toLocaleString(
-      undefined,
-      {
-        month: "short",
-        day: "numeric",
-        hour: "2-digit",
-        minute: "2-digit",
-      },
-    );
+    // Compute the expected title through the same i18n path the component
+    // uses. toLocaleString(undefined, ...) resolves to the OS locale, which
+    // diverges from the Paraglide app locale on non-English systems (#1195).
+    const expectedTitle = formatTimestamp(sync.lastSync!);
 
     expect(document.body.textContent).toContain(
       "synced just now",


### PR DESCRIPTION
Fixes #1195.

The StatusBar sync-label test computed its expected title with `toLocaleString(undefined, ...)`, which resolves to the OS locale, while the component formats the title through the i18n `formatDateTime` using the Paraglide app locale (`en` in the test environment). The two sources only agree on English-locale systems, so the full suite failed on any non-English machine (observed on Korean-locale Windows; reproduced on current `main`).

The expected value is now computed through the same `formatTimestamp` path the component uses, which keeps the assertion focused on the wiring contract and makes it independent of the host locale. The formatting behavior itself is already covered by the i18n unit tests, including the locale-selection cases in `i18n.test.ts`.

This was the only `toLocaleString`-based expectation in the test suite.