### PR TITLE
docs: inventory provider session format provenance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,12 @@ Instructions for autonomous coding agents working in this repository.
 - Never overwrite an existing file that is not positively identified as an
   agentsview DuckDB mirror; unrecognized destinations fail closed.
 
+## Provider Format Provenance
+
+When adding a provider or changing a provider's on-disk format or usage/cost
+accounting, consult `docs/internal/session-format-sources.md` and update its
+evidence entry in the same change.
+
 ## Localization
 
 - Keep frontend message catalogs synchronized. When adding, removing, or

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,9 +114,11 @@ Instructions for autonomous coding agents working in this repository.
 
 ## Provider Format Provenance
 
-When adding a provider or changing a provider's on-disk format or usage/cost
-accounting, consult `docs/internal/session-format-sources.md` and update its
-evidence entry in the same change.
+When adding a provider, changing its format or usage/cost accounting, or
+investigating a provider release, new artifact generation, parser bug, or usage
+discrepancy, consult `docs/internal/session-format-sources.md` and reverify or
+update its evidence entry in the same change. Grok remains temporarily excluded
+only until its separately owned format-alignment work lands.
 
 ## Localization
 

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -1,0 +1,822 @@
+# Session Format Source Inventory
+
+This inventory records the best reproducible evidence currently available for
+the session formats consumed by Agentsview. It is a maintainer research aid, not
+a compatibility guarantee. Source links are pinned; documentation links are
+moving first-party pages and include the date checked.
+
+Evidence classes:
+
+- `source`: public producer, persistence, schema, or migration source.
+- `documentation`: first-party format documentation without suitable public
+  producer source.
+- `no-public-source`: no usable public source or authoritative format
+  documentation was found after the searches recorded in the entry.
+
+Usage notes distinguish values persisted by the provider from costs Agentsview
+computes later with its pricing catalog. A compatible upstream implementation is
+useful evidence for a shared format family, but is called out when it is not the
+product's own producer source.
+
+## Claude Code (`claude`)
+
+- **Format:** Project-scoped JSONL transcripts, including subagent JSONL, with
+  `user`, `assistant`, `system`, and progress records.
+- **Evidence:** `no-public-source`.
+- **Upstream:** The public
+  [Claude Code repository](https://github.com/anthropics/claude-code) at
+  `015170d3fd84fb57ef4685a64b673fadd0690dc1` and the
+  [Claude Code documentation](https://docs.anthropic.com/en/docs/claude-code)
+  were checked 2026-07-19. The repository does not publish the CLI persistence
+  implementation or an authoritative transcript schema.
+- **Usage and cost:** Assistant messages persist input, output, cache-creation,
+  and cache-read tokens. Model IDs are present. No authoritative persisted USD
+  cost field is consumed; Agentsview prices the tokens from its catalog.
+- **Agentsview:** `internal/parser/claude.go` and
+  `internal/parser/claude_provider.go`; local observations and fixtures are
+  the implementation evidence for fields not documented upstream.
+
+## OpenClaude (`openclaude`)
+
+- **Format:** OpenClaude JSONL with Claude-compatible message content and usage
+  objects.
+- **Evidence:** `no-public-source`.
+- **Upstream:** Product pages, first-party documentation, and public GitHub
+  repositories discoverable for OpenClaude were searched 2026-07-19; no
+  authoritative persistence source or format documentation was found.
+- **Usage and cost:** Claude-style input, output, cache-creation, and cache-read
+  tokens are persisted. Agentsview derives money from its pricing catalog; no
+  provider-reported cost is consumed.
+- **Agentsview:** `internal/parser/openclaude.go` plus the shared Claude parsing
+  code in `internal/parser/claude.go`; compatibility with Claude fields is an
+  observed format relationship, not an upstream guarantee.
+
+## Cowork (`cowork`)
+
+- **Format:** A workspace metadata JSON file plus nested Claude-compatible
+  project and subagent JSONL transcripts.
+- **Evidence:** `no-public-source`.
+- **Upstream:** Anthropic's moving
+  [Cowork documentation](https://support.anthropic.com/en/collections/14464166-cowork)
+  and the public Claude Code repository were checked 2026-07-19. They
+  explain the product but do not publish a Cowork disk schema, so the local
+  layout and transcript fields remain implementation evidence.
+- **Usage and cost:** Nested assistant records carry Claude-style input, output,
+  cache-creation, and cache-read tokens with model IDs. Agentsview
+  catalog-prices them; no persisted USD total is consumed.
+- **Agentsview:** `internal/parser/cowork.go`,
+  `internal/parser/cowork_paths.go`, and `internal/parser/cowork_provider.go`.
+
+## Codex (`codex`)
+
+- **Format:** Rollout JSONL files, with a separate JSONL session index used for
+  discovery and metadata.
+- **Evidence:** `source`.
+- **Upstream:** Clone `https://github.com/openai/codex.git` at
+  `3e2f79727a4e8ddfc8e3acb838d496b121094b9e`; see the pinned
+  [rollout recorder](https://github.com/openai/codex/blob/3e2f79727a4e8ddfc8e3acb838d496b121094b9e/codex-rs/rollout/src/recorder.rs)
+  and
+  [protocol types](https://github.com/openai/codex/blob/3e2f79727a4e8ddfc8e3acb838d496b121094b9e/codex-rs/protocol/src/protocol.rs).
+- **Usage and cost:** `token_count` records include total and last usage with
+  input, cached input, cache-write input, output, reasoning output, and total
+  tokens. Input includes cached input upstream, so Agentsview subtracts the
+  cached portion before recording uncached input. Cost is catalog-derived.
+- **Agentsview:** `internal/parser/codex.go` and
+  `internal/parser/codex_provider.go`; usage is taken from the last-turn
+  counters rather than repeatedly counting cumulative totals.
+
+## GitHub Copilot CLI (`copilot`)
+
+- **Format:** Flat session JSONL or a session directory containing
+  `events.jsonl`.
+- **Evidence:** `no-public-source`.
+- **Upstream:** The public
+  [Copilot CLI repository](https://github.com/github/copilot-cli) at
+  `fd24cea5cb11da4e630485ff2d9269318b8c2a4e` and
+  [Copilot CLI documentation](https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli)
+  were checked 2026-07-19. No producer-side session serializer or public
+  disk schema was present.
+- **Usage and cost:** Shutdown metrics can persist input, output, cache-read,
+  cache-write, and reasoning tokens. Copilot accounting is credit-oriented;
+  Agentsview does not treat credits as USD and does not infer a monetary cost.
+- **Agentsview:** `internal/parser/copilot.go` and
+  `internal/parser/copilot_provider.go`.
+
+## Gemini CLI (`gemini`)
+
+- **Format:** Project chat recordings written as JSONL, with older JSON
+  recordings also accepted.
+- **Evidence:** `source`.
+- **Upstream:** Clone `https://github.com/google-gemini/gemini-cli.git` at
+  `acae7124bdd849e554eaa5e090199a0cf08cd782`; see
+  [chatRecordingService.ts](https://github.com/google-gemini/gemini-cli/blob/acae7124bdd849e554eaa5e090199a0cf08cd782/packages/core/src/services/chatRecordingService.ts)
+  and
+  [session management](https://github.com/google-gemini/gemini-cli/blob/acae7124bdd849e554eaa5e090199a0cf08cd782/docs/cli/session-management.md).
+- **Usage and cost:** Message usage stores input, output, cached, thoughts,
+  tool, and total tokens derived from Gemini API usage metadata. Some records
+  are cumulative or streamed, so Agentsview normalizes deltas. Model IDs are
+  available; monetary cost is catalog-derived.
+- **Agentsview:** `internal/parser/gemini.go` and
+  `internal/parser/gemini_provider.go`; both JSON and JSONL generations remain
+  supported.
+
+## MiMo Code (`mimocode`)
+
+- **Format:** OpenCode-compatible SQLite or legacy `storage/session`,
+  `storage/message`, and `storage/part` JSON stores.
+- **Evidence:** `no-public-source`.
+- **Upstream:** MiMo Code's first-party product pages, documentation, and public
+  GitHub organization surfaces were searched 2026-07-19 without locating its
+  persistence implementation. The compatible OpenCode source is documented in
+  the `opencode` entry but is not MiMo Code producer evidence.
+- **Usage and cost:** The compatible message parts can contain input, output,
+  cache-read, and cache-write tokens with a model. No provider-reported USD
+  field is consumed; Agentsview uses catalog pricing.
+- **Agentsview:** `internal/parser/mimocode.go` delegates to
+  `internal/parser/opencode.go`; product-specific divergence is therefore a
+  known risk.
+
+## OpenCode (`opencode`)
+
+- **Format:** Current SQLite-backed session/message/part records and the legacy
+  JSON storage tree.
+- **Evidence:** `source`.
+- **Upstream:** Clone `https://github.com/anomalyco/opencode.git` at
+  `67caf894e0843ee370e72839e8265e483233479b`; see
+  [message-v2.ts](https://github.com/anomalyco/opencode/blob/67caf894e0843ee370e72839e8265e483233479b/packages/opencode/src/session/message-v2.ts)
+  and
+  [session.ts](https://github.com/anomalyco/opencode/blob/67caf894e0843ee370e72839e8265e483233479b/packages/opencode/src/session/session.ts).
+- **Usage and cost:** Assistant messages persist input, output, cache-read, and
+  cache-write tokens, plus model/provider identity. Agentsview computes price
+  from those tokens rather than consuming a persisted USD total.
+- **Agentsview:** `internal/parser/opencode.go`,
+  `internal/parser/opencode_provider.go`, and
+  `internal/parser/opencode_storage_state.go`; legacy and database layouts are
+  both intentional compatibility targets.
+
+## Kilo Code (`kilo`)
+
+- **Format:** Kilo's current session store and OpenCode-compatible legacy
+  session/message/part data.
+- **Evidence:** `source`.
+- **Upstream:** Clone `https://github.com/Kilo-Org/kilocode.git` at
+  `938919ab72e3977d1512e0363417270e3337c7b1`; see
+  [session.ts](https://github.com/Kilo-Org/kilocode/blob/938919ab72e3977d1512e0363417270e3337c7b1/packages/core/src/session.ts)
+  and
+  [message.ts](https://github.com/Kilo-Org/kilocode/blob/938919ab72e3977d1512e0363417270e3337c7b1/packages/core/src/session/message.ts).
+- **Usage and cost:** Compatible message data includes input, output,
+  cache-read, and cache-write tokens with model identity. The parser does not
+  consume a Kilo-reported currency total; Agentsview catalog-prices tokens.
+- **Agentsview:** `internal/parser/kilo.go` uses the OpenCode family parser.
+  Kilo migrations mean the pinned current source must be compared with legacy
+  fixtures when changing compatibility.
+
+## OpenHands (`openhands`)
+
+- **Format:** A CLI conversation directory containing `base_state.json`,
+  `TASKS.json`, and one JSON file per event under `events/`.
+- **Evidence:** `source`.
+- **Upstream:** Clone `https://github.com/OpenHands/OpenHands.git` at
+  `93c0871951f9247cc87a63940972ae7e25d46b6f`; current storage infrastructure
+  is represented by
+  [event_store.py](https://github.com/OpenHands/OpenHands/blob/93c0871951f9247cc87a63940972ae7e25d46b6f/openhands/app_server/event/event_store.py)
+  and the
+  [local file store](https://github.com/OpenHands/OpenHands/blob/93c0871951f9247cc87a63940972ae7e25d46b6f/openhands/app_server/file_store/local.py).
+  The exact legacy CLI directory is no longer specified by one current
+  schema, so repository history remains relevant.
+- **Usage and cost:** The consumed event format is used for transcript content;
+  Agentsview currently exposes no token, cache, reasoning, or cost events for
+  OpenHands.
+- **Agentsview:** `internal/parser/openhands.go` and
+  `internal/parser/openhands_provider.go`; the legacy layout limitation is
+  explicit.
+
+## Cursor (`cursor`)
+
+- **Format:** Markdown session transcripts under Cursor project directories.
+- **Evidence:** `no-public-source`.
+- **Upstream:** The first-party [Cursor documentation](https://docs.cursor.com/)
+  and Cursor's public GitHub organization repositories were searched
+  2026-07-19; no authoritative local transcript schema or producer source was
+  found.
+- **Usage and cost:** The consumed Markdown has no reliable per-message token,
+  cache, reasoning, credit, or monetary-cost fields.
+- **Agentsview:** `internal/parser/cursor.go`,
+  `internal/parser/cursor_paths.go`, and `internal/parser/cursor_provider.go`;
+  role and attribution boundaries are reconstructed from Markdown.
+
+## Amp (`amp`)
+
+- **Format:** One JSON thread document per session.
+- **Evidence:** `no-public-source`.
+- **Upstream:** The first-party [Amp manual](https://ampcode.com/manual) and
+  public Sourcegraph/Amp repositories were searched 2026-07-19; no
+  session-file producer or authoritative disk schema was found.
+- **Usage and cost:** The consumed thread documents do not expose token, cache,
+  reasoning, credit, or USD fields to Agentsview.
+- **Agentsview:** `internal/parser/amp.go` and
+  `internal/parser/amp_provider.go`.
+
+## VS Code Copilot (`vscode-copilot`)
+
+- **Format:** VS Code `chatSessions/<uuid>.json` snapshots and JSONL operation
+  logs containing serialized chat requests and responses.
+- **Evidence:** `source`.
+- **Upstream:** Clone `https://github.com/microsoft/vscode.git` at
+  `693614c9f239b49f6d13d55da7f1a851d5b82c36`; see
+  [chatModel.ts](https://github.com/microsoft/vscode/blob/693614c9f239b49f6d13d55da7f1a851d5b82c36/src/vs/workbench/contrib/chat/common/model/chatModel.ts)
+  and
+  [chatSessionStore.ts](https://github.com/microsoft/vscode/blob/693614c9f239b49f6d13d55da7f1a851d5b82c36/src/vs/workbench/contrib/chat/common/model/chatSessionStore.ts).
+- **Usage and cost:** Request metadata can persist prompt and output tokens plus
+  the resolved model, but has no cache split or provider-reported USD cost in
+  the consumed shape. Copilot credits are not treated as currency.
+- **Agentsview:** `internal/parser/vscode_copilot.go` and
+  `internal/parser/vscode_copilot_provider.go`; both compact snapshots and
+  operation logs are supported.
+
+## Windsurf (`windsurf`)
+
+- **Format:** VS Code-compatible workspace `state.vscdb` rows whose keys and
+  values encode Windsurf tabs and conversation bubbles.
+- **Evidence:** `no-public-source`.
+- **Upstream:** The first-party
+  [Windsurf documentation](https://docs.windsurf.com/) and public Codeium
+  repositories were searched 2026-07-19; no producer source or authoritative
+  workspace-state schema was found.
+- **Usage and cost:** The consumed state exposes no reliable token, cache,
+  reasoning, or USD fields. Windsurf credit accounting is not converted to
+  monetary cost.
+- **Agentsview:** `internal/parser/windsurf_provider.go` and the shared VS
+  Code-state helpers; database keys are reverse-engineered implementation
+  evidence.
+
+## Visual Studio Copilot (`visualstudio-copilot`)
+
+- **Format:** OpenTelemetry JSONL spans exported by Visual Studio's GitHub
+  Copilot integration.
+- **Evidence:** `documentation`.
+- **Upstream:** GitHub's
+  [Copilot usage metrics documentation](https://docs.github.com/en/copilot/reference/copilot-usage-metrics)
+  and the OpenTelemetry
+  [generative-AI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/)
+  were checked 2026-07-19. Visual Studio's emitting implementation and its
+  on-disk exporter configuration are not public.
+- **Usage and cost:** Spans persist `gen_ai.usage.input_tokens` and
+  `gen_ai.usage.output_tokens`, with model attributes when emitted. Cache and
+  reasoning splits are absent in the consumed data. Copilot credits are not
+  USD; Agentsview does not synthesize a currency value from them.
+- **Agentsview:** `internal/parser/visualstudio_copilot.go`,
+  `internal/parser/visualstudio_copilot_provider.go`, and
+  `docs/internal/visual-studio-copilot-traces.md`.
+
+## Pi (`pi`)
+
+- **Format:** A tree-structured JSONL log with a session header and entries
+  connected by `id` and `parentId`.
+- **Evidence:** `source`.
+- **Upstream:** Clone `https://github.com/earendil-works/pi.git` at
+  `f1c587dde39025c75d7397bc14532d8fa5c001d9`; see the pinned
+  [session format](https://github.com/earendil-works/pi/blob/f1c587dde39025c75d7397bc14532d8fa5c001d9/packages/coding-agent/docs/session-format.md)
+  and
+  [session manager](https://github.com/earendil-works/pi/blob/f1c587dde39025c75d7397bc14532d8fa5c001d9/packages/coding-agent/src/core/session-manager.ts).
+- **Usage and cost:** Assistant messages persist input and output tokens plus
+  cache-read and cache-write/creation values in nested or historical flat
+  shapes. Model IDs are present. Agentsview catalog-prices the tokens.
+- **Agentsview:** `internal/parser/pi.go` and `internal/parser/pi_provider.go`;
+  alternate branches remain in the file but only the active ancestry is a
+  conversation.
+
+## Oh My Pi (`omp`)
+
+- **Format:** Pi-family JSONL with Oh My Pi session entry and persistence
+  extensions.
+
+- **Evidence:** `source`.
+
+- **Upstream:** Clone `https://github.com/can1357/oh-my-pi.git` at
+  `39c95e5e29b1c8b082059f57421ce445c3dffdd4`; see
+  [session-entries.ts](https://github.com/can1357/oh-my-pi/blob/39c95e5e29b1c8b082059f57421ce445c3dffdd4/packages/coding-agent/src/session/session-entries.ts),
+
+    [session-persistence.ts](https://github.com/can1357/oh-my-pi/blob/39c95e5e29b1c8b082059f57421ce445c3dffdd4/packages/coding-agent/src/session/session-persistence.ts),
+    and
+    [usage.ts](https://github.com/can1357/oh-my-pi/blob/39c95e5e29b1c8b082059f57421ce445c3dffdd4/packages/ai/src/usage.ts).
+
+- **Usage and cost:** Pi-family usage persists input, output, cache-read, and
+  cache-write tokens with a model. Agentsview derives monetary cost from the
+  catalog; provider reporting notes are not treated as exact persisted USD.
+
+- **Agentsview:** Oh My Pi is registered through the Pi-family provider in
+  `internal/parser/pi.go` and `internal/parser/pi_provider.go`.
+
+## Qwen Code (`qwen`)
+
+- **Format:** Gemini-derived project chat-record JSONL.
+- **Evidence:** `source`.
+- **Upstream:** Clone `https://github.com/QwenLM/qwen-code.git` at
+  `076427650d363ce9e9a0962f389361b474c170dc`; see
+  [chatRecordingService.ts](https://github.com/QwenLM/qwen-code/blob/076427650d363ce9e9a0962f389361b474c170dc/packages/core/src/services/chatRecordingService.ts)
+  and
+  [tokenUsageService.ts](https://github.com/QwenLM/qwen-code/blob/076427650d363ce9e9a0962f389361b474c170dc/packages/core/src/services/tokenUsageService.ts).
+- **Usage and cost:** `usageMetadata` supplies prompt, candidate/output,
+  cached-content, thoughts, and total tokens. Streaming records may repeat
+  cumulative values, so Agentsview aggregates carefully. Price is
+  catalog-derived.
+- **Agentsview:** `internal/parser/qwen.go` and
+  `internal/parser/qwen_provider.go`.
+
+## Command Code (`commandcode`)
+
+- **Format:** Session JSONL accompanied by a `.meta.json` sidecar.
+- **Evidence:** `no-public-source`.
+- **Upstream:** Command Code's first-party product site, documentation surfaces,
+  and public GitHub repository search were checked 2026-07-19. Only
+  third-party provider bridges were located; no authoritative CLI persistence
+  source or disk schema was public.
+- **Usage and cost:** The consumed records provide transcript and metadata but
+  no token, cache, reasoning, credit, or USD accounting to Agentsview.
+- **Agentsview:** `internal/parser/commandcode.go` and
+  `internal/parser/commandcode_provider.go`.
+
+## DeepSeek TUI (`deepseek-tui`)
+
+- **Format:** Per-session JSON documents, excluding transient latest-session and
+  offline-queue artifacts.
+- **Evidence:** `no-public-source`.
+- **Upstream:** DeepSeek's first-party GitHub organization and documentation,
+  plus searches for the named TUI product, were checked 2026-07-19. No
+  first-party repository or authoritative persisted-session schema was found.
+- **Usage and cost:** The consumed JSON does not expose token, cache, reasoning,
+  credit, or monetary-cost fields to Agentsview.
+- **Agentsview:** `internal/parser/deepseek_tui.go` and
+  `internal/parser/deepseek_tui_provider.go`.
+
+## OpenClaw (`openclaw`)
+
+- **Format:** Per-agent session JSONL managed by the OpenClaw session store.
+- **Evidence:** `source`.
+- **Upstream:** Clone `https://github.com/openclaw/openclaw.git` at
+  `40d31f34813c2a01284b097c0d0d785fbb173400`; see
+  [session-store.ts](https://github.com/openclaw/openclaw/blob/40d31f34813c2a01284b097c0d0d785fbb173400/src/agents/command/session-store.ts)
+  and
+  [usage-accumulator.ts](https://github.com/openclaw/openclaw/blob/40d31f34813c2a01284b097c0d0d785fbb173400/src/agents/embedded-agent-runner/usage-accumulator.ts).
+- **Usage and cost:** Messages persist input, output, cache-read, cache-write,
+  model identity, and sometimes `usage.cost.total`. Agentsview intentionally
+  ignores the reported cost and catalog-prices normalized token fields to keep
+  pricing attribution consistent.
+- **Agentsview:** `internal/parser/openclaw.go`.
+
+## QClaw (`qclaw`)
+
+- **Format:** OpenClaw-compatible agent session JSONL with QClaw-specific root
+  discovery.
+- **Evidence:** `no-public-source`.
+- **Upstream:** QClaw's product pages and public repository search were checked
+  2026-07-19. No verified first-party persistence source was found. The public
+  OpenClaw producer source pinned in the `openclaw` entry describes the
+  compatible format family, not QClaw itself.
+- **Usage and cost:** Compatible records can contain input, output, cache-read,
+  cache-write, model, and reported total cost. As for OpenClaw, Agentsview
+  ignores the reported monetary field and catalog-prices tokens.
+- **Agentsview:** `internal/parser/qclaw.go` delegates message decoding to
+  `internal/parser/openclaw.go`.
+
+## Kimi CLI (`kimi`)
+
+- **Format:** Session directories containing `wire.jsonl`, with both current and
+  legacy wire layouts.
+
+- **Evidence:** `source`.
+
+- **Upstream:** Clone `https://github.com/MoonshotAI/kimi-cli.git` at
+  `4a550effdfcb29a25a5d325bf935296cc50cd417`; see
+  [session.py](https://github.com/MoonshotAI/kimi-cli/blob/4a550effdfcb29a25a5d325bf935296cc50cd417/src/kimi_cli/session.py),
+
+    [wire-mode.md](https://github.com/MoonshotAI/kimi-cli/blob/4a550effdfcb29a25a5d325bf935296cc50cd417/docs/en/customization/wire-mode.md),
+    and the
+    [Kimi provider usage mapping](https://github.com/MoonshotAI/kimi-cli/blob/4a550effdfcb29a25a5d325bf935296cc50cd417/packages/kosong/src/kosong/chat_provider/kimi.py).
+
+- **Usage and cost:** Native usage distinguishes uncached/other input, output,
+  cache read, and cache creation. The aggregate fallback exposes only output
+  and is therefore a lower bound. Agentsview catalog-prices usage with a
+  model.
+
+- **Agentsview:** `internal/parser/kimi.go` and
+  `internal/parser/kimi_provider.go`.
+
+## Claude.ai Export (`claude-ai`)
+
+- **Format:** The `conversations.json` artifact from a Claude.ai data export.
+- **Evidence:** `documentation`.
+- **Upstream:** Anthropic's first-party
+  [data export instructions](https://support.anthropic.com/en/articles/9450526-how-can-i-export-my-claude-ai-data)
+  were checked 2026-07-19. They establish the export artifact but do not
+  publish its complete JSON schema.
+- **Usage and cost:** The export contains conversation content and timestamps,
+  not authoritative token, cache, reasoning, credit, or USD accounting.
+- **Agentsview:** `internal/parser/claude_ai.go`; this is an import format, not
+  a live application session store.
+
+## ChatGPT Export (`chatgpt`)
+
+- **Format:** `conversations.json` and numbered `conversations-*.json` export
+  artifacts containing a conversation DAG and message mapping.
+- **Evidence:** `documentation`.
+- **Upstream:** OpenAI's first-party
+  [ChatGPT data export instructions](https://help.openai.com/en/articles/7260999-how-do-i-export-my-chatgpt-history-and-data)
+  were checked 2026-07-19. The help page does not publish a versioned JSON
+  schema.
+- **Usage and cost:** Export messages may include `model_slug`, but the artifact
+  does not provide authoritative token, cache, reasoning, credit, or cost
+  data.
+- **Agentsview:** `internal/parser/chatgpt.go`; graph ancestry is flattened for
+  display and the importer does not claim billing completeness.
+
+## Kiro CLI (`kiro`)
+
+- **Format:** Legacy JSONL plus companion metadata JSON, and newer SQLite
+  session databases.
+- **Evidence:** `no-public-source`.
+- **Upstream:** The first-party [Kiro documentation](https://kiro.dev/docs/) and
+  public AWS/Kiro GitHub repositories were searched 2026-07-19. No producer
+  source or authoritative schema for either local generation was found.
+- **Usage and cost:** The consumed stores currently provide transcript and model
+  context but no token, cache, reasoning, credit, or USD events to Agentsview.
+- **Agentsview:** `internal/parser/kiro.go`, `internal/parser/kiro_sqlite.go`,
+  and `internal/parser/kiro_provider.go`; both generations must remain
+  discoverable.
+
+## Kiro IDE (`kiro-ide`)
+
+- **Format:** Historical `.chat` files and newer workspace-session JSON data.
+- **Evidence:** `no-public-source`.
+- **Upstream:** The first-party [Kiro documentation](https://kiro.dev/docs/) and
+  public AWS/Kiro repositories were searched 2026-07-19; no IDE persistence
+  serializer or versioned disk schema was public.
+- **Usage and cost:** Model metadata may be present, but the consumed format
+  exposes no authoritative token, cache, reasoning, credit, or monetary cost.
+- **Agentsview:** `internal/parser/kiro_ide.go` and
+  `internal/parser/kiro_ide_provider.go`.
+
+## Cortex (`cortex`)
+
+- **Format:** A session JSON document with an optional `.history.jsonl`
+  companion.
+- **Evidence:** `no-public-source`.
+- **Upstream:** Cortex's first-party product documentation and public
+  organization repositories were searched 2026-07-19; no unambiguous producer
+  repository or authoritative local-session schema was located.
+- **Usage and cost:** The consumed files expose transcript content but no token,
+  cache, reasoning, credit, or USD accounting.
+- **Agentsview:** `internal/parser/cortex.go` and
+  `internal/parser/cortex_provider.go`.
+
+## Hermes Agent (`hermes`)
+
+- **Format:** `state.db` for indexed state and usage, with JSONL/JSON session
+  transcripts retained for compatibility.
+- **Evidence:** `source`.
+- **Upstream:** Clone `https://github.com/NousResearch/hermes-agent.git` at
+  `299e409f15aa5615a8a64be488580be92cda351e`; see
+  [hermes_state.py](https://github.com/NousResearch/hermes-agent/blob/299e409f15aa5615a8a64be488580be92cda351e/hermes_state.py)
+  and
+  [usage_pricing.py](https://github.com/NousResearch/hermes-agent/blob/299e409f15aa5615a8a64be488580be92cda351e/agent/usage_pricing.py).
+- **Usage and cost:** State records distinguish input, output, cache-read,
+  cache-write, and reasoning tokens and can retain estimated or actual cost
+  with status/source metadata. Agentsview uses provider-reported cost when it
+  is meaningfully identified; otherwise it falls back to catalog pricing.
+- **Agentsview:** `internal/parser/hermes.go` and
+  `internal/parser/hermes_provider.go`; database and file generations are both
+  recognized.
+
+## Forge (`forge`)
+
+- **Format:** A `.forge.db` SQLite database containing conversations, context
+  messages, and usage records.
+- **Evidence:** `source`.
+- **Upstream:** Clone `https://github.com/tailcallhq/forgecode.git` at
+  `c5698103bce973d1c569ae905bca6f34ba85c1d0`; see
+  [conversation_record.rs](https://github.com/tailcallhq/forgecode/blob/c5698103bce973d1c569ae905bca6f34ba85c1d0/crates/forge_repo/src/conversation/conversation_record.rs)
+  and the pinned
+  [conversation migration](https://github.com/tailcallhq/forgecode/blob/c5698103bce973d1c569ae905bca6f34ba85c1d0/crates/forge_repo/src/database/migrations/2025-09-12-065405_create_conversations_table/up.sql).
+- **Usage and cost:** Usage records distinguish actual prompt, completion, and
+  cached tokens. Although Forge domain data can discuss cost, Agentsview does
+  not consume a direct persisted currency total from this store and instead
+  catalog-prices normalized tokens.
+- **Agentsview:** `internal/parser/forge.go`.
+
+## Devin CLI (`devin`)
+
+- **Format:** `cli/sessions.db` for session metadata plus transcript JSON
+  artifacts.
+- **Evidence:** `no-public-source`.
+- **Upstream:** Cognition's first-party
+  [Devin documentation](https://docs.devin.ai/) and public repositories were
+  searched 2026-07-19; no CLI database schema or transcript serializer was
+  published.
+- **Usage and cost:** Message or aggregate metrics can persist prompt,
+  completion, and cached tokens. The parser handles multiple observed field
+  names; no authoritative provider-reported USD value is consumed, so pricing
+  is catalog-derived when model attribution is possible.
+- **Agentsview:** `internal/parser/devin.go` and
+  `internal/parser/devin_provider.go`; metric aliases are implementation
+  evidence because the upstream schema is unavailable.
+
+## Piebald (`piebald`)
+
+- **Format:** An `app.db` SQLite database containing sessions and messages.
+- **Evidence:** `no-public-source`.
+- **Upstream:** Piebald's first-party website and the
+  [Piebald-AI GitHub organization](https://github.com/Piebald-AI) were
+  searched 2026-07-19. Related utilities are public, but the application
+  persistence schema and serializer were not located.
+- **Usage and cost:** Messages can persist input, output, reasoning, cache-read,
+  and cache-write tokens. Agentsview folds reasoning into output where
+  required by the observed counters and catalog-prices the result; no provider
+  USD total is consumed.
+- **Agentsview:** `internal/parser/piebald.go`.
+
+## Warp (`warp`)
+
+- **Format:** A `warp.sqlite` database whose conversation records include
+  transcript metadata and aggregate usage counters.
+- **Evidence:** `no-public-source`.
+- **Upstream:** The first-party [Warp documentation](https://docs.warp.dev/) and
+  public Warp repositories were searched 2026-07-19; no authoritative local
+  database schema for AI conversations was found.
+- **Usage and cost:** The consumed metadata has aggregate `warp_tokens` and
+  `byok_tokens`, not attributable per-request billing tokens, cache splits, or
+  reasoning. Agentsview reports the aggregates as session metrics and does not
+  derive USD from them.
+- **Agentsview:** `internal/parser/warp.go` and `internal/parser/warp_paths.go`.
+
+## Positron (`positron`)
+
+- **Format:** VS Code-derived `chatSessions` JSON snapshots or JSONL operation
+  logs in Positron workspace storage.
+- **Evidence:** `source`.
+- **Upstream:** Clone `https://github.com/posit-dev/positron.git` at
+  `61345078cc1833b740fda2b1fe1aabc8472d2249`; see
+  [chatModel.ts](https://github.com/posit-dev/positron/blob/61345078cc1833b740fda2b1fe1aabc8472d2249/src/vs/workbench/contrib/chat/common/model/chatModel.ts)
+  and
+  [chatSessionStore.ts](https://github.com/posit-dev/positron/blob/61345078cc1833b740fda2b1fe1aabc8472d2249/src/vs/workbench/contrib/chat/common/model/chatSessionStore.ts).
+- **Usage and cost:** The underlying VS Code shape can carry prompt/output
+  metadata and model identity, but the Positron provider currently exposes no
+  usage events. Cache, reasoning, and monetary cost are therefore absent from
+  Agentsview analytics for this provider.
+- **Agentsview:** `internal/parser/positron_provider.go` and the shared decoding
+  in `internal/parser/vscode_copilot.go`; the lack of usage export is a parser
+  limitation, not proof that upstream never records metadata.
+
+## Posit Assistant (`posit-assistant`)
+
+- **Format:** Workspace conversation directories containing `conversation.json`,
+  `lm-messages.jsonl`, and `ui-messages.jsonl`.
+- **Evidence:** `no-public-source`.
+- **Upstream:** Posit's product documentation and the
+  [posit-dev GitHub organization](https://github.com/posit-dev) were searched
+  2026-07-19. Demo and feedback repositories were public, but no producer
+  source or authoritative persisted-session schema was found.
+- **Usage and cost:** Language-model messages can persist input, output,
+  cache-read, and cache-write tokens with model identity. Agentsview
+  catalog-prices these values; no provider-reported USD total is consumed.
+- **Agentsview:** `internal/parser/posit_assistant_provider.go`; current schema
+  details are based on observed files and fixtures.
+
+## Z Code (`zcode`)
+
+- **Format:** A `db.sqlite` database, including a `model_usage` table.
+- **Evidence:** `no-public-source`.
+- **Upstream:** Z Code's first-party product pages, documentation, and public
+  GitHub organization surfaces were searched 2026-07-19; no database migration
+  or producer source was found.
+- **Usage and cost:** `model_usage` rows persist input, output, reasoning,
+  cache-creation, cache-read, computed total, and model data. Agentsview emits
+  usage events and derives monetary price from its catalog rather than a
+  provider-reported USD value.
+- **Agentsview:** `internal/parser/zcode.go`; table and column semantics remain
+  reverse-engineered implementation evidence.
+
+## Zed (`zed`)
+
+- **Format:** `threads/threads.db`, whose thread payload is JSON or zstd-
+  compressed JSON depending on generation.
+- **Evidence:** `source`.
+- **Upstream:** Clone `https://github.com/zed-industries/zed.git` at
+  `f14fea9bf3c93797d5161f7440ed418655bc6c57`; see
+  [thread_store.rs](https://github.com/zed-industries/zed/blob/f14fea9bf3c93797d5161f7440ed418655bc6c57/crates/agent/src/thread_store.rs)
+  and
+  [thread.rs](https://github.com/zed-industries/zed/blob/f14fea9bf3c93797d5161f7440ed418655bc6c57/crates/agent/src/thread.rs).
+- **Usage and cost:** Thread metadata can persist aggregate input and output
+  token usage with model identity. It does not provide per-message cache or
+  reasoning splits in the consumed shape. Agentsview emits one aggregate usage
+  event and catalog-prices it.
+- **Agentsview:** `internal/parser/zed.go`, `internal/parser/zed_helpers.go`,
+  and `internal/parser/zed_provider.go`.
+
+## Antigravity IDE (`antigravity`)
+
+- **Format:** Per-session SQLite databases, optionally supplemented by
+  trajectory JSON sidecars.
+- **Evidence:** `no-public-source`.
+- **Upstream:** Google's first-party Antigravity product and documentation
+  surfaces and public repositories were searched 2026-07-19; no application
+  database schema or protobuf definition for `gen_metadata` was published.
+- **Usage and cost:** Heuristically decoded generation metadata or sidecars
+  provide uncached input, output (including thinking), cache-read, and model
+  data. There is no separate reliable reasoning counter or reported USD cost;
+  Agentsview catalog-prices tokens. Decode failures are surfaced explicitly.
+- **Agentsview:** `internal/parser/antigravity.go`,
+  `internal/parser/antigravity_proto.go`, and
+  `internal/parser/antigravity_provider.go`; field decoding is deliberately
+  marked as reverse engineering.
+
+## Antigravity CLI (`antigravity-cli`)
+
+- **Format:** Newer per-session SQLite databases or older encrypted protobuf
+  files, with trajectory/history/brain sidecars when present.
+- **Evidence:** `no-public-source`.
+- **Upstream:** Google's Antigravity product documentation and public
+  repositories were searched 2026-07-19; no CLI persistence source, encryption
+  specification, or authoritative protobuf schema was found.
+- **Usage and cost:** Sidecar generator metadata can carry input, output,
+  thinking-output, cache-read, and model fields; output already includes
+  thinking. Agentsview avoids double counting and catalog-prices usage. No
+  provider USD cost is consumed.
+- **Agentsview:** `internal/parser/antigravity_cli.go`,
+  `internal/parser/antigravity_crypto.go`, and
+  `internal/parser/antigravity_cli_provider.go`.
+
+## iFlow CLI (`iflow`)
+
+- **Format:** Claude-like JSONL with UUID/parent UUID links and streaming
+  message records.
+- **Evidence:** `no-public-source`.
+- **Upstream:** The public
+  [iFlow CLI repository](https://github.com/iflow-ai/iflow-cli) at
+  `4642808afbc6580ac117d930f6c64ac0d84955c7` and its first-party documentation
+  were checked 2026-07-19. The repository publishes documentation and release
+  material but no usable session persistence implementation or schema.
+- **Usage and cost:** Although records may resemble Claude streaming events,
+  Agentsview does not expose token, cache, reasoning, credit, or USD
+  accounting for iFlow.
+- **Agentsview:** `internal/parser/iflow.go` and
+  `internal/parser/iflow_provider.go`; field interpretation is based on
+  observed files rather than upstream authority.
+
+## ICodeMate (`icodemate`)
+
+- **Format:** OpenCode-compatible SQLite or legacy session/message/part storage.
+- **Evidence:** `no-public-source`.
+- **Upstream:** ICodeMate's first-party product pages, documentation, and public
+  GitHub repository search were checked 2026-07-19 without finding producer
+  source or an authoritative disk schema. The OpenCode source pinned in the
+  `opencode` entry is compatible-family evidence only.
+- **Usage and cost:** Compatible messages can persist input, output, cache-read,
+  cache-write, and model identity. Agentsview catalog-prices these values and
+  consumes no product-reported USD total.
+- **Agentsview:** `internal/parser/icodemate.go` delegates to
+  `internal/parser/opencode.go`; product-specific divergence is a known
+  limitation.
+
+## WorkBuddy (`workbuddy`)
+
+- **Format:** Session JSONL with provider-specific raw usage embedded under
+  message provider data.
+- **Evidence:** `no-public-source`.
+- **Upstream:** WorkBuddy's first-party product site, documentation, and public
+  repositories were searched 2026-07-19; no authoritative persistence producer
+  or versioned schema was found.
+- **Usage and cost:** Usage may contain input, output, cache, and reasoning
+  counters. Upstream prompt totals include cache, so Agentsview subtracts
+  cache to obtain uncached input and keeps reasoning separate. Monetary cost
+  is catalog-derived.
+- **Agentsview:** `internal/parser/workbuddy.go` and
+  `internal/parser/workbuddy_provider.go`; counter semantics are
+  implementation evidence.
+
+## Zencoder (`zencoder`)
+
+- **Format:** Per-session JSONL transcripts.
+- **Evidence:** `no-public-source`.
+- **Upstream:** The first-party
+  [Zencoder documentation](https://docs.zencoder.ai/) and public repositories
+  were searched 2026-07-19; no local transcript serializer or authoritative
+  schema was found.
+- **Usage and cost:** The consumed JSONL exposes no reliable token, cache,
+  reasoning, credit, or monetary-cost fields to Agentsview.
+- **Agentsview:** `internal/parser/zencoder.go` and
+  `internal/parser/zencoder_provider.go`.
+
+## gptme (`gptme`)
+
+- **Format:** Conversation `conversation.jsonl` files containing typed message
+  records and metadata.
+- **Evidence:** `source`.
+- **Upstream:** Clone `https://github.com/gptme/gptme.git` at
+  `a1d8ca21dd662e04970ff36c8c3e9b342f989605`; see
+  [conversations.py](https://github.com/gptme/gptme/blob/a1d8ca21dd662e04970ff36c8c3e9b342f989605/gptme/logmanager/conversations.py)
+  and
+  [message.py](https://github.com/gptme/gptme/blob/a1d8ca21dd662e04970ff36c8c3e9b342f989605/gptme/message.py).
+- **Usage and cost:** Assistant metadata can persist input, output, cache-read,
+  and cache-creation tokens with model data. Agentsview catalog-prices the
+  normalized usage and consumes no authoritative persisted USD total.
+- **Agentsview:** `internal/parser/gptme.go` and
+  `internal/parser/gptme_provider.go`.
+
+## Qoder (`qoder`)
+
+- **Format:** Project JSONL transcripts, `-session.json` metadata, and related
+  subagent artifacts.
+- **Evidence:** `no-public-source`.
+- **Upstream:** The first-party [Qoder documentation](https://docs.qoder.com/)
+  and public repositories were searched 2026-07-19; no producer-side session
+  serializer or authoritative local schema was found.
+- **Usage and cost:** The consumed files provide transcript and model/session
+  metadata but no authoritative token, cache, reasoning, credit, or USD events
+  to Agentsview.
+- **Agentsview:** `internal/parser/qoder.go` and
+  `internal/parser/qoder_provider.go`.
+
+## QwenPaw (`qwenpaw`)
+
+- **Format:** Workspace `sessions/<name>.json` documents whose
+  `agent.memory.content` holds message/content-block pairs.
+- **Evidence:** `source`.
+- **Upstream:** Clone `https://github.com/agentscope-ai/QwenPaw.git` at
+  `a15a69fca73e67c17dc47326e933eaa259fa0d8d`; see the context
+  [serializer](https://github.com/agentscope-ai/QwenPaw/blob/a15a69fca73e67c17dc47326e933eaa259fa0d8d/src/qwenpaw/agents/context/scroll/serialize.py)
+  and
+  [history implementation](https://github.com/agentscope-ai/QwenPaw/blob/a15a69fca73e67c17dc47326e933eaa259fa0d8d/src/qwenpaw/agents/context/scroll/history.py).
+- **Usage and cost:** The consumed session memory contains messages and content
+  blocks but no per-message billing usage. QwenPaw has separate token-usage
+  services, but Agentsview does not join that accounting store to session
+  files; cache, reasoning totals, and USD cost are therefore absent.
+- **Agentsview:** `internal/parser/qwenpaw.go` and
+  `internal/parser/qwenpaw_provider.go`.
+
+## Shelley (`shelley`)
+
+- **Format:** A `shelley.db` SQLite database containing conversations, messages,
+  and JSON usage data.
+- **Evidence:** `no-public-source`.
+- **Upstream:** Shelley's first-party product pages, documentation, and public
+  GitHub repository search were checked 2026-07-19; no persistence migration
+  or producer source was found.
+- **Usage and cost:** `usage_data` can persist input, cache-creation,
+  cache-read, output, model, and exact `cost_usd`. Agentsview intentionally
+  ignores `cost_usd` while emitting token usage, avoiding mixed/double cost
+  attribution and using catalog pricing instead.
+- **Agentsview:** `internal/parser/shelley.go` and
+  `internal/parser/shelley_provider.go`; schema and cost-field behavior are
+  observed implementation evidence.
+
+## Mistral Vibe (`vibe`)
+
+- **Format:** A session directory containing `messages.jsonl` and `meta.json`.
+- **Evidence:** `source`.
+- **Upstream:** Clone `https://github.com/mistralai/mistral-vibe.git` at
+  `0685654a40a4035966891289065379a751a7e617`; see
+  [session_logger.py](https://github.com/mistralai/mistral-vibe/blob/0685654a40a4035966891289065379a751a7e617/vibe/core/session/session_logger.py)
+  and
+  [history_manager.py](https://github.com/mistralai/mistral-vibe/blob/0685654a40a4035966891289065379a751a7e617/vibe/cli/history_manager.py).
+- **Usage and cost:** Metadata stores aggregate session prompt/completion and
+  context/last-turn/total statistics, without per-message cache or cost data.
+  Agentsview emits one aggregate usage event and catalog-prices it when model
+  identity is available.
+- **Agentsview:** `internal/parser/vibe.go` and
+  `internal/parser/vibe_provider.go`.
+
+## Aider (`aider`)
+
+- **Format:** Repository-local `.aider.chat.history.md`; multiple runs can be
+  reconstructed from one Markdown history.
+- **Evidence:** `source`.
+- **Upstream:** Clone `https://github.com/Aider-AI/aider.git` at
+  `5dc9490bb35f9729ef2c95d00a19ccd30c26339c`; see
+  [history.py](https://github.com/Aider-AI/aider/blob/5dc9490bb35f9729ef2c95d00a19ccd30c26339c/aider/history.py)
+  and the first-party
+  [usage documentation](https://github.com/Aider-AI/aider/blob/5dc9490bb35f9729ef2c95d00a19ccd30c26339c/aider/website/docs/usage.md).
+- **Usage and cost:** The Markdown transcript does not persist authoritative
+  per-message tokens, cache, reasoning, credits, or USD cost. Aider may
+  display runtime cost elsewhere, but Agentsview does not infer it from this
+  history.
+- **Agentsview:** `internal/parser/aider.go` and
+  `internal/parser/aider_provider.go`; roles and run boundaries are
+  reconstructed from Markdown.
+
+## Reasonix (`reasonix`)
+
+- **Format:** Session JSONL plus `.jsonl.meta` sidecars across live, archive,
+  project, and subagent roots.
+- **Evidence:** `source`.
+- **Upstream:** Clone `https://github.com/esengine/DeepSeek-Reasonix.git` at
+  `2301e24827bf62c7584f34c4f541c432dd4f6e0b`; see
+  [session.go](https://github.com/esengine/DeepSeek-Reasonix/blob/2301e24827bf62c7584f34c4f541c432dd4f6e0b/internal/agent/session.go)
+  and
+  [session content](https://github.com/esengine/DeepSeek-Reasonix/blob/2301e24827bf62c7584f34c4f541c432dd4f6e0b/internal/agent/session_content.go).
+- **Usage and cost:** The consumed session records do not currently yield
+  authoritative per-message token, cache, reasoning, credit, or monetary-cost
+  events to Agentsview.
+- **Agentsview:** `internal/parser/reasonix.go` and
+  `internal/parser/reasonix_provider.go`; discovery spans multiple roots and
+  uses metadata sidecars for identity.

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -14,9 +14,9 @@ Evidence classes:
   documentation was found after the searches recorded in the entry.
 
 Usage notes distinguish values persisted by the provider from costs Agentsview
-computes later with its pricing catalog. A compatible upstream implementation is
-useful evidence for a shared format family, but is called out when it is not the
-product's own producer source.
+computes later with its pricing catalog. A compatible upstream implementation,
+independent parser, or recorded fixture is useful evidence for a format, but is
+called out when it is not the product's own producer source.
 
 All entries were last verified on 2026-07-19. A pinned revision is a
 reproducible research snapshot, not a claim that it produced every historical
@@ -69,16 +69,25 @@ Grok section and remove the explicit registry exception in the coverage test.
 
 - **Format:** OpenClaude JSONL with Claude-compatible message content and usage
   objects.
-- **Evidence:** `no-public-source`.
-- **Upstream:** Product pages, first-party documentation, and public GitHub
-  repositories discoverable for OpenClaude were searched 2026-07-19; no
-  authoritative persistence source or format documentation was found.
+
+- **Evidence:** `source`.
+
+- **Upstream:** Clone `https://github.com/Gitlawb/openclaude.git` at
+  `1ddb7d68399a2cd5028d4c5f487676f941879eae`; see the pinned
+  [session JSONL writer](https://github.com/Gitlawb/openclaude/blob/1ddb7d68399a2cd5028d4c5f487676f941879eae/src/utils/sessionStorage.ts),
+
+    [project-directory resolver](https://github.com/Gitlawb/openclaude/blob/1ddb7d68399a2cd5028d4c5f487676f941879eae/src/utils/envUtils.ts),
+    and
+    [assistant message type](https://github.com/Gitlawb/openclaude/blob/1ddb7d68399a2cd5028d4c5f487676f941879eae/src/types/message.ts).
+
 - **Usage and cost:** Claude-style input, output, cache-creation, and cache-read
-  tokens are persisted. Agentsview derives money from its pricing catalog; no
-  provider-reported cost is consumed.
+  tokens are persisted in each assistant message's API usage object.
+  Agentsview derives money from its pricing catalog; no provider-reported cost
+  is consumed.
+
 - **Agentsview:** `internal/parser/openclaude.go` plus the shared Claude parsing
-  code in `internal/parser/claude.go`; compatibility with Claude fields is an
-  observed format relationship, not an upstream guarantee.
+  code in `internal/parser/claude.go`; the producer writes the same
+  project-scoped JSONL family that the parser consumes.
 
 ## Cowork (`cowork`)
 
@@ -469,12 +478,33 @@ Grok section and remove the explicit registry exception in the coverage test.
 
 - **Format:** Legacy JSONL plus companion metadata JSON, and newer SQLite
   session databases.
+
 - **Evidence:** `no-public-source`.
-- **Upstream:** The first-party [Kiro documentation](https://kiro.dev/docs/) and
-  public AWS/Kiro GitHub repositories were searched 2026-07-19. No producer
-  source or authoritative schema for either local generation was found.
-- **Usage and cost:** The consumed stores currently provide transcript and model
-  context but no token, cache, reasoning, credit, or USD events to Agentsview.
+
+- **Upstream:** Kiro's first-party [license page](https://kiro.dev/license/) and
+  [CLI page](https://kiro.dev/cli/) were checked 2026-07-19: current Kiro CLI
+  is proprietary. The open-source predecessor can be cloned from
+  `https://github.com/aws/amazon-q-developer-cli.git` at
+  `15cc8f3cd18c4272925ce1c7053268eedff1ea0a`, but its pinned
+  [conversation migration](https://github.com/aws/amazon-q-developer-cli/blob/15cc8f3cd18c4272925ce1c7053268eedff1ea0a/crates/chat-cli/src/database/sqlite_migrations/007_conversations_table.sql)
+  does not establish either Kiro generation. Useful independent format
+  evidence can be cloned from `https://github.com/ingo-eichhorst/Irrlicht.git`
+  at `12375a273a289c131a45b4fd3eb1ad6483b4e9d4`; see its pinned
+  [Kiro JSONL parser](https://github.com/ingo-eichhorst/Irrlicht/blob/12375a273a289c131a45b4fd3eb1ad6483b4e9d4/core/adapters/inbound/agents/kirocli/parser.go),
+
+    [sidecar metrics reader](https://github.com/ingo-eichhorst/Irrlicht/blob/12375a273a289c131a45b4fd3eb1ad6483b4e9d4/core/adapters/inbound/agents/kirocli/sidecar_metrics.go),
+    and recorded
+    [token-accounting assessment](https://github.com/ingo-eichhorst/Irrlicht/blob/12375a273a289c131a45b4fd3eb1ad6483b4e9d4/replaydata/agents/kiro-cli/scenarios/5-1_token-accounting/metadata.json).
+    These are consumer observations, not Kiro producer authority, and they do
+    not cover the newer `conversations_v2` writer.
+
+- **Usage and cost:** JSONL events contain no model, token, cache, credit, or
+  USD fields. The companion state can contain model/window metadata, context
+  percentage, and per-turn credit metering; the recorded Kiro 2.5.1 evidence
+  found input/output counters present but zero and no cache split. Agentsview
+  currently consumes none of those sidecar usage fields, so it emits no Kiro
+  usage or cost metrics.
+
 - **Agentsview:** `internal/parser/kiro.go`, `internal/parser/kiro_sqlite.go`,
   and `internal/parser/kiro_provider.go`; both generations must remain
   discoverable.
@@ -483,9 +513,12 @@ Grok section and remove the explicit registry exception in the coverage test.
 
 - **Format:** Historical `.chat` files and newer workspace-session JSON data.
 - **Evidence:** `no-public-source`.
-- **Upstream:** The first-party [Kiro documentation](https://kiro.dev/docs/) and
-  public AWS/Kiro repositories were searched 2026-07-19; no IDE persistence
-  serializer or versioned disk schema was public.
+- **Upstream:** Kiro's first-party [license page](https://kiro.dev/license/),
+  [documentation](https://kiro.dev/docs/), and the public
+  [kirodotdev/Kiro repository](https://github.com/kirodotdev/Kiro/tree/e8daa058590dd58efb14f6d41ddb3ba1a26cfba3)
+  were checked 2026-07-19. The IDE is proprietary, and the public repository
+  contains community and issue infrastructure rather than the IDE persistence
+  serializer or a versioned disk schema.
 - **Usage and cost:** Model metadata may be present, but the consumed format
   exposes no authoritative token, cache, reasoning, credit, or monetary cost.
 - **Agentsview:** `internal/parser/kiro_ide.go` and
@@ -573,14 +606,23 @@ Grok section and remove the explicit registry exception in the coverage test.
 
 - **Format:** A `warp.sqlite` database whose conversation records include
   transcript metadata and aggregate usage counters.
-- **Evidence:** `no-public-source`.
-- **Upstream:** The first-party [Warp documentation](https://docs.warp.dev/) and
-  public Warp repositories were searched 2026-07-19; no authoritative local
-  database schema for AI conversations was found.
+
+- **Evidence:** `source`.
+
+- **Upstream:** Clone `https://github.com/warpdotdev/warp.git` at
+  `69ce3728acae0b01c2f457b65a90c144664686aa`; see the pinned
+  [agent conversation migration](https://github.com/warpdotdev/warp/blob/69ce3728acae0b01c2f457b65a90c144664686aa/crates/persistence/migrations/2025-06-09-013710_create_agent_conversations_table/up.sql),
+
+    [persistence writer](https://github.com/warpdotdev/warp/blob/69ce3728acae0b01c2f457b65a90c144664686aa/app/src/persistence/agent.rs),
+    and
+    [conversation usage types](https://github.com/warpdotdev/warp/blob/69ce3728acae0b01c2f457b65a90c144664686aa/crates/persistence/src/model.rs).
+
 - **Usage and cost:** The consumed metadata has aggregate `warp_tokens` and
-  `byok_tokens`, not attributable per-request billing tokens, cache splits, or
-  reasoning. Agentsview reports the aggregates as session metrics and does not
-  derive USD from them.
+  `byok_tokens` by model and category, plus custom-endpoint tokens and credit
+  fields upstream. Agentsview consumes only the Warp/BYOK aggregates; they are
+  not attributable per-request billing tokens, cache splits, or reasoning, so
+  it reports them as session metrics and does not derive USD from them.
+
 - **Agentsview:** `internal/parser/warp.go` and `internal/parser/warp_paths.go`.
 
 ## Positron (`positron`)

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -18,13 +18,14 @@ computes later with its pricing catalog. A compatible upstream implementation,
 independent parser, or recorded fixture is useful evidence for a format, but is
 called out when it is not the product's own producer source.
 
-All entries were last verified on 2026-07-19. A pinned revision is a
-reproducible research snapshot, not a claim that it produced every historical
-artifact that Agentsview accepts. Where an entry covers several generations, its
-**Format** and **Agentsview** fields identify that boundary; the parser, its
-colocated tests, and `internal/parser/testdata` remain the implementation
-evidence for observed legacy or closed-source artifacts. Add a producer release
-or format-version range when one can be tied confidently to an artifact.
+Unless an entry states otherwise, entries were last verified on 2026-07-19. A
+pinned revision is a reproducible research snapshot, not a claim that it
+produced every historical artifact that Agentsview accepts. Where an entry
+covers several generations, its **Format** and **Agentsview** fields identify
+that boundary; the parser, its colocated tests, and `internal/parser/testdata`
+remain the implementation evidence for observed legacy or closed-source
+artifacts. Add a producer release or format-version range when one can be tied
+confidently to an artifact.
 
 An evidence class names the strongest public authority in an entry, not every
 claim in that section. Source links may prove a current producer or migration
@@ -232,6 +233,27 @@ Grok section and remove the explicit registry exception in the coverage test.
   Kilo migrations mean the pinned current source must be compared with legacy
   fixtures when changing compatibility.
 
+## Roo Code (`roocode`)
+
+- **Format:** One task directory per session with `history_item.json` metadata
+  and a `ui_messages.json` array of UI transcript records.
+- **Evidence:** `source`.
+- **Upstream:** Clone `https://github.com/RooCodeInc/Roo-Code.git` at
+  `b867ec9145750d0ae1ff7f02d35406e9bf2a0b16`. The pinned
+  [per-task history store](https://github.com/RooCodeInc/Roo-Code/blob/b867ec9145750d0ae1ff7f02d35406e9bf2a0b16/src/core/task-persistence/TaskHistoryStore.ts)
+  persists `history_item.json`, while the
+  [UI message reader and writer](https://github.com/RooCodeInc/Roo-Code/blob/b867ec9145750d0ae1ff7f02d35406e9bf2a0b16/src/core/task-persistence/taskMessages.ts)
+  owns `ui_messages.json`. The
+  [history-item construction](https://github.com/RooCodeInc/Roo-Code/blob/b867ec9145750d0ae1ff7f02d35406e9bf2a0b16/src/core/task-persistence/taskMetadata.ts)
+  derives the persisted usage totals.
+- **Usage and cost:** `history_item.json` persists cumulative input, output,
+  cache-write, and cache-read tokens plus `totalCost` and optional API profile
+  identity. Agentsview consumes the reported cost, including explicit zero,
+  instead of replacing it with catalog pricing.
+- **Agentsview:** `internal/parser/roocode.go` and
+  `internal/parser/roocode_provider.go`; observed older Roo/Cline message
+  variants remain covered by the parser's colocated fixtures.
+
 ## OpenHands (`openhands`)
 
 - **Format:** A CLI conversation directory containing `base_state.json` and one
@@ -328,6 +350,24 @@ Grok section and remove the explicit registry exception in the coverage test.
 - **Agentsview:** `internal/parser/windsurf_provider.go` and the shared VS
   Code-state helpers; database keys are reverse-engineered implementation
   evidence.
+
+## Trae (`trae`)
+
+- **Format:** VS Code-compatible workspace and global `state.vscdb` files with a
+  JSON session list stored under the `memento/icube-ai-agent-storage`
+  `ItemTable` key.
+- **Evidence:** `no-public-source`.
+- **Upstream:** Trae's first-party [product site](https://www.trae.ai/) and the
+  official `https://github.com/Trae-AI/Trae.git` repository at
+  `d9386061fd45805f00fd74e09f35566deb4d5a79` were searched 2026-07-21. The
+  repository contains product notices rather than the desktop producer, and
+  neither source publishes the `state.vscdb` key or an authoritative session
+  schema.
+- **Usage and cost:** The consumed session list provides optional model identity
+  but no token, cache, reasoning, credit, or USD fields. Agentsview leaves
+  usage and cost unavailable rather than estimating them.
+- **Agentsview:** `internal/parser/trae_provider.go`; the storage key and JSON
+  shape are based on observed local databases and controlled fixtures.
 
 ## Visual Studio Copilot (`visualstudio-copilot`)
 

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -18,6 +18,35 @@ computes later with its pricing catalog. A compatible upstream implementation is
 useful evidence for a shared format family, but is called out when it is not the
 product's own producer source.
 
+All entries were last verified on 2026-07-19. A pinned revision is a
+reproducible research snapshot, not a claim that it produced every historical
+artifact that Agentsview accepts. Where an entry covers several generations, its
+**Format** and **Agentsview** fields identify that boundary; the parser, its
+colocated tests, and `internal/parser/testdata` remain the implementation
+evidence for observed legacy or closed-source artifacts. Add a producer release
+or format-version range when one can be tied confidently to an artifact.
+
+An evidence class names the strongest public authority in an entry, not every
+claim in that section. Source links may prove a current producer or migration
+while an explicitly labeled limitation remains based on observed files. Generic
+standards or documentation that only proves an export exists do not establish
+the complete persisted schema.
+
+For `no-public-source` entries, the repeatable search used the first-party
+pages, organizations, or pinned public repositories named in the entry, plus
+repository and code searches for `<display name> session format`,
+`<display name> persistence`, and `<display name> token usage cost`, including
+likely JSONL and SQLite names. Reverify an entry during provider-release
+investigations, when a new artifact generation appears, for parser or
+usage-accounting bug reports, and during periodic inventory review. Record newly
+discovered exact URLs, releases, and queries in the provider entry. If a
+repository or document disappears, retain its original URL and commit hash and
+add an archived or maintained mirror without replacing the original identity.
+
+Grok is temporarily excluded at the user's request because a separate
+format-alignment change owns that provider. Once that alignment lands, add a
+Grok section and remove the explicit registry exception in the coverage test.
+
 ## Claude Code (`claude`)
 
 - **Format:** Project-scoped JSONL transcripts, including subagent JSONL, with
@@ -79,8 +108,11 @@ product's own producer source.
   [protocol types](https://github.com/openai/codex/blob/3e2f79727a4e8ddfc8e3acb838d496b121094b9e/codex-rs/protocol/src/protocol.rs).
 - **Usage and cost:** `token_count` records include total and last usage with
   input, cached input, cache-write input, output, reasoning output, and total
-  tokens. Input includes cached input upstream, so Agentsview subtracts the
-  cached portion before recording uncached input. Cost is catalog-derived.
+  tokens. Agentsview currently consumes input, cached input, and output only:
+  it subtracts cached input from upstream's inclusive input total, maps cached
+  input to cache-read, and ignores cache-write and reasoning-output fields.
+  Catalog pricing therefore covers only the normalized fields the parser
+  emits.
 - **Agentsview:** `internal/parser/codex.go` and
   `internal/parser/codex_provider.go`; usage is taken from the last-turn
   counters rather than repeatedly counting cumulative totals.
@@ -175,15 +207,16 @@ product's own producer source.
 
 - **Format:** A CLI conversation directory containing `base_state.json`,
   `TASKS.json`, and one JSON file per event under `events/`.
-- **Evidence:** `source`.
+- **Evidence:** `no-public-source`.
 - **Upstream:** Clone `https://github.com/OpenHands/OpenHands.git` at
-  `93c0871951f9247cc87a63940972ae7e25d46b6f`; current storage infrastructure
-  is represented by
+  `93c0871951f9247cc87a63940972ae7e25d46b6f` was checked 2026-07-19. Current
+  storage infrastructure is represented by
   [event_store.py](https://github.com/OpenHands/OpenHands/blob/93c0871951f9247cc87a63940972ae7e25d46b6f/openhands/app_server/event/event_store.py)
   and the
   [local file store](https://github.com/OpenHands/OpenHands/blob/93c0871951f9247cc87a63940972ae7e25d46b6f/openhands/app_server/file_store/local.py).
-  The exact legacy CLI directory is no longer specified by one current
-  schema, so repository history remains relevant.
+  These are supplemental current source: the exact legacy CLI directory
+  consumed by Agentsview is no longer specified by a public producer or
+  schema.
 - **Usage and cost:** The consumed event format is used for transcript content;
   Agentsview currently exposes no token, cache, reasoning, or cost events for
   OpenHands.
@@ -254,13 +287,14 @@ product's own producer source.
 
 - **Format:** OpenTelemetry JSONL spans exported by Visual Studio's GitHub
   Copilot integration.
-- **Evidence:** `documentation`.
+- **Evidence:** `no-public-source`.
 - **Upstream:** GitHub's
   [Copilot usage metrics documentation](https://docs.github.com/en/copilot/reference/copilot-usage-metrics)
   and the OpenTelemetry
   [generative-AI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/)
-  were checked 2026-07-19. Visual Studio's emitting implementation and its
-  on-disk exporter configuration are not public.
+  were checked 2026-07-19. They are supplemental usage-semantics references;
+  Visual Studio's emitting implementation, persisted exporter format, and
+  on-disk configuration are not public.
 - **Usage and cost:** Spans persist `gen_ai.usage.input_tokens` and
   `gen_ai.usage.output_tokens`, with model attributes when emitted. Cache and
   reasoning splits are absent in the consumed data. Copilot credits are not

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -57,7 +57,13 @@ Grok section and remove the explicit registry exception in the coverage test.
   `015170d3fd84fb57ef4685a64b673fadd0690dc1` and the
   [Claude Code documentation](https://docs.anthropic.com/en/docs/claude-code)
   were checked 2026-07-19. The repository does not publish the CLI persistence
-  implementation or an authoritative transcript schema.
+  implementation or an authoritative transcript schema. As independent
+  corroboration, clone `https://github.com/getagentseal/codeburn.git` at
+  `3472885629c41725b40c19c0780ecce148b067bf` and inspect its
+  [Claude format notes](https://github.com/getagentseal/codeburn/blob/3472885629c41725b40c19c0780ecce148b067bf/docs/providers/claude.md)
+  and
+  [parser](https://github.com/getagentseal/codeburn/blob/3472885629c41725b40c19c0780ecce148b067bf/src/providers/claude.ts);
+  these are consumer observations, not Anthropic authority.
 - **Usage and cost:** Assistant messages persist input, output, cache-creation,
   and cache-read tokens. Model IDs are present. No authoritative persisted USD
   cost field is consumed; Agentsview prices the tokens from its catalog.
@@ -130,13 +136,23 @@ Grok section and remove the explicit registry exception in the coverage test.
 
 - **Format:** Flat session JSONL or a session directory containing
   `events.jsonl`.
-- **Evidence:** `no-public-source`.
+- **Evidence:** `documentation`.
 - **Upstream:** The public
   [Copilot CLI repository](https://github.com/github/copilot-cli) at
   `fd24cea5cb11da4e630485ff2d9269318b8c2a4e` and
-  [Copilot CLI documentation](https://docs.github.com/en/copilot/concepts/agents/about-copilot-cli)
-  were checked 2026-07-19. No producer-side session serializer or public
-  disk schema was present.
+  [Copilot CLI session-data documentation](https://docs.github.com/en/copilot/concepts/agents/copilot-cli/chronicle)
+  were checked 2026-07-19. GitHub documents complete per-session files under
+  `~/.copilot/session-state/` and the derived `~/.copilot/session-store.db`,
+  including reindex behavior, but not the event or database schema. The
+  [configuration-directory reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-config-dir-reference)
+  further identifies `events.jsonl` and workspace artifacts. No
+  producer-side serializer is public. For independent legacy CLI and sibling
+  Copilot-store observations, clone
+  `https://github.com/getagentseal/codeburn.git` at
+  `3472885629c41725b40c19c0780ecce148b067bf` and inspect its
+  [Copilot format notes](https://github.com/getagentseal/codeburn/blob/3472885629c41725b40c19c0780ecce148b067bf/docs/providers/copilot.md)
+  and
+  [parser](https://github.com/getagentseal/codeburn/blob/3472885629c41725b40c19c0780ecce148b067bf/src/providers/copilot.ts).
 - **Usage and cost:** Shutdown metrics can persist input, output, cache-read,
   cache-write, and reasoning tokens. Copilot accounting is credit-oriented;
   Agentsview does not treat credits as USD and does not infer a monetary cost.
@@ -165,17 +181,21 @@ Grok section and remove the explicit registry exception in the coverage test.
 
 - **Format:** OpenCode-compatible SQLite or legacy `storage/session`,
   `storage/message`, and `storage/part` JSON stores.
-- **Evidence:** `no-public-source`.
-- **Upstream:** MiMo Code's first-party product pages, documentation, and public
-  GitHub organization surfaces were searched 2026-07-19 without locating its
-  persistence implementation. The compatible OpenCode source is documented in
-  the `opencode` entry but is not MiMo Code producer evidence.
-- **Usage and cost:** The compatible message parts can contain input, output,
-  cache-read, and cache-write tokens with a model. No provider-reported USD
-  field is consumed; Agentsview uses catalog pricing.
+- **Evidence:** `source`.
+- **Upstream:** Clone `https://github.com/XiaomiMiMo/MiMo-Code.git` at
+  `f24ce4eb7341bfba6bb608436c1d27a843508adf`; see the SQLite
+  [session/message/part tables](https://github.com/XiaomiMiMo/MiMo-Code/blob/f24ce4eb7341bfba6bb608436c1d27a843508adf/packages/opencode/src/session/session.sql.ts),
+  persisted
+  [message usage shape](https://github.com/XiaomiMiMo/MiMo-Code/blob/f24ce4eb7341bfba6bb608436c1d27a843508adf/packages/opencode/src/session/message.ts),
+  and
+  [usage normalization and cost calculation](https://github.com/XiaomiMiMo/MiMo-Code/blob/f24ce4eb7341bfba6bb608436c1d27a843508adf/packages/opencode/src/session/session.ts).
+- **Usage and cost:** Assistant message data persists input, output, reasoning,
+  cache-read, cache-write, model, and a calculated currency cost. Agentsview
+  reads the token/model fields but deliberately ignores the stored cost and
+  catalog-prices the normalized usage.
 - **Agentsview:** `internal/parser/mimocode.go` delegates to
-  `internal/parser/opencode.go`; product-specific divergence is therefore a
-  known risk.
+  `internal/parser/opencode.go`; compare MiMo's pinned schema with OpenCode
+  whenever their shared parser changes.
 
 ## OpenCode (`opencode`)
 
@@ -214,35 +234,45 @@ Grok section and remove the explicit registry exception in the coverage test.
 
 ## OpenHands (`openhands`)
 
-- **Format:** A CLI conversation directory containing `base_state.json`,
-  `TASKS.json`, and one JSON file per event under `events/`.
-- **Evidence:** `no-public-source`.
-- **Upstream:** Clone `https://github.com/OpenHands/OpenHands.git` at
-  `93c0871951f9247cc87a63940972ae7e25d46b6f` was checked 2026-07-19. Current
-  storage infrastructure is represented by
-  [event_store.py](https://github.com/OpenHands/OpenHands/blob/93c0871951f9247cc87a63940972ae7e25d46b6f/openhands/app_server/event/event_store.py)
-  and the
-  [local file store](https://github.com/OpenHands/OpenHands/blob/93c0871951f9247cc87a63940972ae7e25d46b6f/openhands/app_server/file_store/local.py).
-  These are supplemental current source: the exact legacy CLI directory
-  consumed by Agentsview is no longer specified by a public producer or
-  schema.
-- **Usage and cost:** The consumed event format is used for transcript content;
-  Agentsview currently exposes no token, cache, reasoning, or cost events for
-  OpenHands.
+- **Format:** A CLI conversation directory containing `base_state.json` and one
+  JSON file per event under `events/`; Agentsview also fingerprints optional
+  legacy `TASKS.json` files.
+- **Evidence:** `source`.
+- **Upstream:** Clone `https://github.com/OpenHands/software-agent-sdk.git` at
+  `4fe565663af2b4f1130a6e0dac7566b002bfe9b4`. Inspect the
+  [persistence constants](https://github.com/OpenHands/software-agent-sdk/blob/4fe565663af2b4f1130a6e0dac7566b002bfe9b4/openhands-sdk/openhands/sdk/conversation/persistence_const.py)
+  for filenames, the
+  [base-state writer](https://github.com/OpenHands/software-agent-sdk/blob/4fe565663af2b4f1130a6e0dac7566b002bfe9b4/openhands-sdk/openhands/sdk/conversation/state.py)
+  for event-log attachment, and the
+  [metrics model](https://github.com/OpenHands/software-agent-sdk/blob/4fe565663af2b4f1130a6e0dac7566b002bfe9b4/openhands-sdk/openhands/sdk/llm/utils/metrics.py)
+  for persisted usage and cost fields. The public CLI clone
+  `https://github.com/OpenHands/OpenHands-CLI.git` at
+  `2df8a2835d3f1bd2f2eadf5a7a2e1ad0dfb0d271` supplies the matching
+  [conversation store](https://github.com/OpenHands/OpenHands-CLI/blob/2df8a2835d3f1bd2f2eadf5a7a2e1ad0dfb0d271/openhands_cli/conversations/store/local.py).
+- **Usage and cost:** `base_state.json` persists per-model prompt, completion,
+  cache-read, cache-write, reasoning, context-window, per-call and accumulated
+  token data, plus per-call and accumulated cost. Agentsview currently reads
+  transcript events only and exposes none of those persisted metrics; that is
+  a parser limitation.
 - **Agentsview:** `internal/parser/openhands.go` and
-  `internal/parser/openhands_provider.go`; the legacy layout limitation is
-  explicit.
+  `internal/parser/openhands_provider.go`; `TASKS.json` is legacy supplemental
+  state rather than a requirement of the pinned current producer.
 
 ## Cursor (`cursor`)
 
-- **Format:** Markdown session transcripts under Cursor project directories.
-- **Evidence:** `no-public-source`.
-- **Upstream:** The first-party [Cursor documentation](https://docs.cursor.com/)
-  and Cursor's public GitHub organization repositories were searched
-  2026-07-19; no authoritative local transcript schema or producer source was
-  found.
-- **Usage and cost:** The consumed Markdown has no reliable per-message token,
-  cache, reasoning, credit, or monetary-cost fields.
+- **Format:** Legacy text and newer JSONL transcripts under per-project
+  `agent-transcripts` directories.
+- **Evidence:** `documentation`.
+- **Upstream:** Cursor's first-party
+  [history documentation](https://docs.cursor.com/en/agent/chat/history)
+  confirms local chat persistence and the separate SQLite history index.
+  Cursor support on the official forum documents the
+  [`~/.cursor/projects/<project>/agent-transcripts` layout](https://forum.cursor.com/t/chat-history-gone-after-pc-restart-agent-transcripts-files-emptied-how-to-recover/158251/5)
+  and identifies `state.vscdb` as metadata. Cursor's public GitHub
+  organization was also searched 2026-07-19; no transcript schema or producer
+  source was found.
+- **Usage and cost:** The consumed text/JSONL transcripts have no reliable
+  per-message token, cache, reasoning, credit, or monetary-cost fields.
 - **Agentsview:** `internal/parser/cursor.go`,
   `internal/parser/cursor_paths.go`, and `internal/parser/cursor_provider.go`;
   role and attribution boundaries are reconstructed from Markdown.
@@ -284,7 +314,14 @@ Grok section and remove the explicit registry exception in the coverage test.
 - **Upstream:** The first-party
   [Windsurf documentation](https://docs.windsurf.com/) and public Codeium
   repositories were searched 2026-07-19; no producer source or authoritative
-  workspace-state schema was found.
+  workspace-state schema was found. For a reproducible independent reader,
+  clone `https://github.com/veverke/chatwizard.git` at
+  `d5d4eebb610da04cdd656be83016973281d82eff`; its pinned
+  [workspace discovery](https://github.com/veverke/chatwizard/blob/d5d4eebb610da04cdd656be83016973281d82eff/src/readers/windsurfWorkspace.ts)
+  and
+  [`cascade.sessionData` parser](https://github.com/veverke/chatwizard/blob/d5d4eebb610da04cdd656be83016973281d82eff/src/parsers/windsurf.ts)
+  document the cross-platform `state.vscdb` locations and a directly
+  observed key/value shape. This is consumer evidence, not Windsurf authority.
 - **Usage and cost:** The consumed state exposes no reliable token, cache,
   reasoning, or USD fields. Windsurf credit accounting is not converted to
   monetary cost.
@@ -372,8 +409,10 @@ Grok section and remove the explicit registry exception in the coverage test.
 - **Format:** Session JSONL accompanied by a `.meta.json` sidecar.
 - **Evidence:** `no-public-source`.
 - **Upstream:** Command Code's first-party product site, documentation surfaces,
-  and public GitHub repository search were checked 2026-07-19. Only
-  third-party provider bridges were located; no authoritative CLI persistence
+  and public GitHub repositories were checked 2026-07-19. Clone the official
+  `https://github.com/CommandCodeAI/command-code.git` repository at
+  `a774fe8cbe71697d115d4660de299c9c1b286cea`; it contains product and issue
+  material only, not the CLI implementation. No authoritative persistence
   source or disk schema was public.
 - **Usage and cost:** The consumed records provide transcript and metadata but
   no token, cache, reasoning, credit, or USD accounting to Agentsview.
@@ -384,14 +423,21 @@ Grok section and remove the explicit registry exception in the coverage test.
 
 - **Format:** Per-session JSON documents, excluding transient latest-session and
   offline-queue artifacts.
-- **Evidence:** `no-public-source`.
-- **Upstream:** DeepSeek's first-party GitHub organization and documentation,
-  plus searches for the named TUI product, were checked 2026-07-19. No
-  first-party repository or authoritative persisted-session schema was found.
-- **Usage and cost:** The consumed JSON does not expose token, cache, reasoning,
-  credit, or monetary-cost fields to Agentsview.
+- **Evidence:** `source`.
+- **Upstream:** Clone `https://github.com/Hmbown/DeepSeek-TUI.git` at
+  `7e845f3bf409d2eb06a2f4764c0b332b4190b0c3`; the project is now branded
+  CodeWhale. See the
+  [saved-session schema and atomic writer](https://github.com/Hmbown/DeepSeek-TUI/blob/7e845f3bf409d2eb06a2f4764c0b332b4190b0c3/crates/tui/src/session_manager.rs)
+  and
+  [message/content-block schema](https://github.com/Hmbown/DeepSeek-TUI/blob/7e845f3bf409d2eb06a2f4764c0b332b4190b0c3/crates/tui/src/models.rs).
+- **Usage and cost:** Session metadata persists aggregate `total_tokens`, model
+  and provider identity, plus separate parent-session and subagent USD/CNY
+  cost snapshots and displayed high-water marks. It does not persist a
+  dependable input/output/cache/reasoning token split. Agentsview currently
+  emits no usage event from this metadata; that is a parser limitation.
 - **Agentsview:** `internal/parser/deepseek_tui.go` and
-  `internal/parser/deepseek_tui_provider.go`.
+  `internal/parser/deepseek_tui_provider.go`; both `.codewhale` and legacy
+  `.deepseek` roots are intentional.
 
 ## OpenClaw (`openclaw`)
 
@@ -414,9 +460,12 @@ Grok section and remove the explicit registry exception in the coverage test.
   discovery.
 - **Evidence:** `no-public-source`.
 - **Upstream:** QClaw's product pages and public repository search were checked
-  2026-07-19. No verified first-party persistence source was found. The public
-  OpenClaw producer source pinned in the `openclaw` entry describes the
-  compatible format family, not QClaw itself.
+  2026-07-19. Tencent's first-party
+  [launch description](https://www.tencent.com/tencent-launches-qclaw-globally-lowering-barriers-to-ai-agent-deployment/)
+  confirms that QClaw is built on OpenClaw, but publishes neither the exact
+  embedded OpenClaw revision nor its wrapper's persistence changes. The public
+  OpenClaw producer source pinned in the `openclaw` entry therefore describes
+  the compatible format family, not the exact QClaw build.
 - **Usage and cost:** Compatible records can contain input, output, cache-read,
   cache-write, model, and reported total cost. As for OpenClaw, Agentsview
   ignores the reported monetary field and catalog-prices tokens.
@@ -479,11 +528,14 @@ Grok section and remove the explicit registry exception in the coverage test.
 - **Format:** Legacy JSONL plus companion metadata JSON, and newer SQLite
   session databases.
 
-- **Evidence:** `no-public-source`.
+- **Evidence:** `documentation`.
 
 - **Upstream:** Kiro's first-party [license page](https://kiro.dev/license/) and
-  [CLI page](https://kiro.dev/cli/) were checked 2026-07-19: current Kiro CLI
-  is proprietary. The open-source predecessor can be cloned from
+  [conversation-persistence documentation](https://kiro.dev/docs/cli/chat/#conversation-persistence)
+  were checked 2026-07-19: current Kiro CLI is proprietary. The
+  documentation confirms automatic per-directory database persistence,
+  resume-by-ID, and manual JSON save/load, but does not publish either
+  database generation's schema. The open-source predecessor can be cloned from
   `https://github.com/aws/amazon-q-developer-cli.git` at
   `15cc8f3cd18c4272925ce1c7053268eedff1ea0a`, but its pinned
   [conversation migration](https://github.com/aws/amazon-q-developer-cli/blob/15cc8f3cd18c4272925ce1c7053268eedff1ea0a/crates/chat-cli/src/database/sqlite_migrations/007_conversations_table.sql)
@@ -528,10 +580,17 @@ Grok section and remove the explicit registry exception in the coverage test.
 
 - **Format:** A session JSON document with an optional `.history.jsonl`
   companion.
-- **Evidence:** `no-public-source`.
-- **Upstream:** Cortex's first-party product documentation and public
-  organization repositories were searched 2026-07-19; no unambiguous producer
-  repository or authoritative local-session schema was located.
+- **Evidence:** `documentation`.
+- **Upstream:** Snowflake's first-party
+  [CoCo session-replay guide](https://www.snowflake.com/en/developers/guides/create-shareable-coco-session-replays-with-cortex-replay/)
+  was checked 2026-07-19 and documents automatic JSON transcript storage at
+  `~/.snowflake/cortex/conversations/<session-id>.json`. It links an
+  independent open-source reader: clone
+  `https://github.com/dataprofessor/cortex-replay.git` at
+  `d61d46a7acbe55b3367f695a04e56eca24871320` and inspect the pinned
+  [session parser](https://github.com/dataprofessor/cortex-replay/blob/d61d46a7acbe55b3367f695a04e56eca24871320/src/parser.mjs).
+  Snowflake does not publish the producer or a versioned schema, and the
+  independent reader does not cover the newer split-history generation.
 - **Usage and cost:** The consumed files expose transcript content but no token,
   cache, reasoning, credit, or USD accounting.
 - **Agentsview:** `internal/parser/cortex.go` and
@@ -579,7 +638,18 @@ Grok section and remove the explicit registry exception in the coverage test.
 - **Upstream:** Cognition's first-party
   [Devin documentation](https://docs.devin.ai/) and public repositories were
   searched 2026-07-19; no CLI database schema or transcript serializer was
-  published.
+  published. The transcript generation follows the public Agent Trajectory
+  Interchange Format: clone `https://github.com/harbor-framework/harbor.git`
+  at `071281b3d931aafd6a5375fa7d5933e23054d784` and see the pinned
+  [ATIF specification](https://github.com/harbor-framework/harbor/blob/071281b3d931aafd6a5375fa7d5933e23054d784/rfcs/0001-trajectory-format.md).
+  Devin-specific field aliases and the SQLite enrichment store are
+  independently documented by `https://github.com/getagentseal/codeburn.git`
+  at `3472885629c41725b40c19c0780ecce148b067bf` in its
+  [Devin format notes](https://github.com/getagentseal/codeburn/blob/3472885629c41725b40c19c0780ecce148b067bf/docs/providers/devin.md).
+  The pinned
+  [Devin parser](https://github.com/getagentseal/codeburn/blob/3472885629c41725b40c19c0780ecce148b067bf/src/providers/devin.ts)
+  makes the observed aliases reproducible. Neither project is Cognition's
+  producer source.
 - **Usage and cost:** Message or aggregate metrics can persist prompt,
   completion, and cached tokens. The parser handles multiple observed field
   names; no authoritative provider-reported USD value is consumed, so pricing
@@ -590,16 +660,20 @@ Grok section and remove the explicit registry exception in the coverage test.
 
 ## Piebald (`piebald`)
 
-- **Format:** An `app.db` SQLite database containing sessions and messages.
-- **Evidence:** `no-public-source`.
-- **Upstream:** Piebald's first-party website and the
-  [Piebald-AI GitHub organization](https://github.com/Piebald-AI) were
-  searched 2026-07-19. Related utilities are public, but the application
-  persistence schema and serializer were not located.
+- **Format:** An `app.db` SQLite database containing chats, projects, and
+  messages.
+- **Evidence:** `source`.
+- **Upstream:** Clone `https://github.com/Piebald-AI/splitrail.git` at
+  `e2f195906dc7bf80d0faf16281cf9544e6413d01`; its first-party
+  [Piebald analyzer](https://github.com/Piebald-AI/splitrail/blob/e2f195906dc7bf80d0faf16281cf9544e6413d01/src/analyzers/piebald.rs)
+  defines the database location, `chats`/`projects`/`messages` joins, token
+  columns, service-tier joins, and normalization. This is a read-only
+  first-party schema consumer rather than the application serializer, but it
+  is maintained by the product company and directly targets the current store.
 - **Usage and cost:** Messages can persist input, output, reasoning, cache-read,
-  and cache-write tokens. Agentsview folds reasoning into output where
-  required by the observed counters and catalog-prices the result; no provider
-  USD total is consumed.
+  cache-write, model, and service-tier data. The official analyzer derives
+  price from those fields; it does not read a persisted provider USD total.
+  Agentsview likewise normalizes the counters and catalog-prices the result.
 - **Agentsview:** `internal/parser/piebald.go`.
 
 ## Warp (`warp`)
@@ -650,8 +724,15 @@ Grok section and remove the explicit registry exception in the coverage test.
 - **Evidence:** `no-public-source`.
 - **Upstream:** Posit's product documentation and the
   [posit-dev GitHub organization](https://github.com/posit-dev) were searched
-  2026-07-19. Demo and feedback repositories were public, but no producer
-  source or authoritative persisted-session schema was found.
+  2026-07-19. Clone the public Positron repository
+  `https://github.com/posit-dev/positron.git` at
+  `61345078cc1833b740fda2b1fe1aabc8472d2249`; its current tree includes an
+  older
+  [Copilot conversation store](https://github.com/posit-dev/positron/blob/61345078cc1833b740fda2b1fe1aabc8472d2249/extensions/copilot/src/extension/conversationStore/node/conversationStore.ts),
+  but contains no producer for `.posit/assistant/workspaces`,
+  `conversation.json`, or `lm-messages.jsonl`. Demo and feedback repositories
+  were also public, but no matching producer or authoritative
+  persisted-session schema was found.
 - **Usage and cost:** Language-model messages can persist input, output,
   cache-read, and cache-write tokens with model identity. Agentsview
   catalog-prices these values; no provider-reported USD total is consumed.
@@ -663,8 +744,17 @@ Grok section and remove the explicit registry exception in the coverage test.
 - **Format:** A `db.sqlite` database, including a `model_usage` table.
 - **Evidence:** `no-public-source`.
 - **Upstream:** Z Code's first-party product pages, documentation, and public
-  GitHub organization surfaces were searched 2026-07-19; no database migration
-  or producer source was found.
+  GitHub organization surfaces were searched 2026-07-19. Its
+  [usage documentation](https://zcode.z.ai/en/docs/usage-stats) confirms that
+  the application reads local ZCode session records and presents token,
+  session, message, and model totals, but does not publish the database
+  schema. For a reproducible independent schema observation, clone
+  `https://github.com/getagentseal/codeburn.git` at
+  `3472885629c41725b40c19c0780ecce148b067bf` and inspect the pinned
+  [ZCode format notes](https://github.com/getagentseal/codeburn/blob/3472885629c41725b40c19c0780ecce148b067bf/docs/providers/zcode.md)
+  and
+  [parser](https://github.com/getagentseal/codeburn/blob/3472885629c41725b40c19c0780ecce148b067bf/src/providers/zcode.ts).
+  No producer migration or source was found.
 - **Usage and cost:** `model_usage` rows persist input, output, reasoning,
   cache-creation, cache-read, computed total, and model data. Agentsview emits
   usage events and derives monetary price from its catalog rather than a
@@ -696,7 +786,14 @@ Grok section and remove the explicit registry exception in the coverage test.
 - **Evidence:** `no-public-source`.
 - **Upstream:** Google's first-party Antigravity product and documentation
   surfaces and public repositories were searched 2026-07-19; no application
-  database schema or protobuf definition for `gen_metadata` was published.
+  database schema or protobuf definition for `gen_metadata` was published. For
+  an independent implementation that queries Antigravity's local
+  language-server RPC and documents the protobuf-derived token fields, clone
+  `https://github.com/getagentseal/codeburn.git` at
+  `3472885629c41725b40c19c0780ecce148b067bf` and inspect its
+  [Antigravity format notes](https://github.com/getagentseal/codeburn/blob/3472885629c41725b40c19c0780ecce148b067bf/docs/providers/antigravity.md)
+  and
+  [parser](https://github.com/getagentseal/codeburn/blob/3472885629c41725b40c19c0780ecce148b067bf/src/providers/antigravity.ts).
 - **Usage and cost:** Heuristically decoded generation metadata or sidecars
   provide uncached input, output (including thinking), cache-read, and model
   data. There is no separate reliable reasoning counter or reported USD cost;
@@ -713,7 +810,10 @@ Grok section and remove the explicit registry exception in the coverage test.
 - **Evidence:** `no-public-source`.
 - **Upstream:** Google's Antigravity product documentation and public
   repositories were searched 2026-07-19; no CLI persistence source, encryption
-  specification, or authoritative protobuf schema was found.
+  specification, or authoritative protobuf schema was found. The independent
+  CodeBurn evidence pinned in the `antigravity` entry also covers CLI
+  discovery, live RPC metadata, and the shorter capture window, but not the
+  encrypted producer format.
 - **Usage and cost:** Sidecar generator metadata can carry input, output,
   thinking-output, cache-read, and model fields; output already includes
   thinking. Agentsview avoids double counting and catalog-prices usage. No
@@ -731,7 +831,13 @@ Grok section and remove the explicit registry exception in the coverage test.
   [iFlow CLI repository](https://github.com/iflow-ai/iflow-cli) at
   `4642808afbc6580ac117d930f6c64ac0d84955c7` and its first-party documentation
   were checked 2026-07-19. The repository publishes documentation and release
-  material but no usable session persistence implementation or schema.
+  material but no usable session persistence implementation or schema. As
+  independent compatible-format evidence, clone
+  `https://github.com/chenhg5/tape.git` at
+  `c40d46d16a32295da63221629293a000b0675df2` and inspect its pinned
+  [iFlow source adapter](https://github.com/chenhg5/tape/blob/c40d46d16a32295da63221629293a000b0675df2/internal/source/iflow/iflow.go),
+  which records discovery paths and delegates the observed wire shape to its
+  Gemini-family parser.
 - **Usage and cost:** Although records may resemble Claude streaming events,
   Agentsview does not expose token, cache, reasoning, credit, or USD
   accounting for iFlow.
@@ -761,7 +867,13 @@ Grok section and remove the explicit registry exception in the coverage test.
 - **Evidence:** `no-public-source`.
 - **Upstream:** WorkBuddy's first-party product site, documentation, and public
   repositories were searched 2026-07-19; no authoritative persistence producer
-  or versioned schema was found.
+  or versioned schema was found. For reproducible independent format and
+  accounting evidence, clone `https://github.com/mm7894215/TokenTracker.git`
+  at `eaf6048b07729f3ae1224def6011ea22f80cd035` and inspect its pinned
+  [WorkBuddy reader](https://github.com/mm7894215/TokenTracker/blob/eaf6048b07729f3ae1224def6011ea22f80cd035/src/lib/rollout.js),
+  which documents the recursive JSONL layout, raw usage variants, cache and
+  reasoning normalization, model fallback, and newer `workbuddy.db` aggregate
+  fallback. These are consumer observations, not Tencent authority.
 - **Usage and cost:** Usage may contain input, output, cache, and reasoning
   counters. Upstream prompt totals include cache, so Agentsview subtracts
   cache to obtain uncached input and keeps reasoning separate. Monetary cost
@@ -776,8 +888,10 @@ Grok section and remove the explicit registry exception in the coverage test.
 - **Evidence:** `no-public-source`.
 - **Upstream:** The first-party
   [Zencoder documentation](https://docs.zencoder.ai/) and public repositories
-  were searched 2026-07-19; no local transcript serializer or authoritative
-  schema was found.
+  were searched 2026-07-19. Zencoder publishes an organization-level
+  [Analytics API](https://docs.zencoder.ai/features/analytics-api), but it
+  does not document the local JSONL transcript or its fields. No local
+  transcript serializer or authoritative schema was found.
 - **Usage and cost:** The consumed JSONL exposes no reliable token, cache,
   reasoning, credit, or monetary-cost fields to Agentsview.
 - **Agentsview:** `internal/parser/zencoder.go` and
@@ -806,7 +920,14 @@ Grok section and remove the explicit registry exception in the coverage test.
 - **Evidence:** `no-public-source`.
 - **Upstream:** The first-party [Qoder documentation](https://docs.qoder.com/)
   and public repositories were searched 2026-07-19; no producer-side session
-  serializer or authoritative local schema was found.
+  serializer or authoritative local schema was found. The official scoped npm
+  package currently names a GitHub repository that is not publicly clonable.
+  For independent reproducible evidence, clone
+  `https://github.com/chenhg5/tape.git` at
+  `c40d46d16a32295da63221629293a000b0675df2` and inspect its pinned
+  [Qoder source adapter](https://github.com/chenhg5/tape/blob/c40d46d16a32295da63221629293a000b0675df2/internal/source/qoder/qoder.go),
+  which documents the transcript/metadata pair and shared Qwen `ChatRecord`
+  shape.
 - **Usage and cost:** The consumed files provide transcript and model/session
   metadata but no authoritative token, cache, reasoning, credit, or USD events
   to Agentsview.
@@ -834,10 +955,12 @@ Grok section and remove the explicit registry exception in the coverage test.
 
 - **Format:** A `shelley.db` SQLite database containing conversations, messages,
   and JSON usage data.
-- **Evidence:** `no-public-source`.
-- **Upstream:** Shelley's first-party product pages, documentation, and public
-  GitHub repository search were checked 2026-07-19; no persistence migration
-  or producer source was found.
+- **Evidence:** `documentation`.
+- **Upstream:** The first-party
+  [Shelley launch and storage documentation](https://blog.exe.dev/shelley) was
+  checked 2026-07-19 and identifies the SQLite store at
+  `~/.config/shelley/shelley.db`. No public migration, table schema, or
+  producer source was found, so column-level details remain observed evidence.
 - **Usage and cost:** `usage_data` can persist input, cache-creation,
   cache-read, output, model, and exact `cost_usd`. Agentsview intentionally
   ignores `cost_usd` while emitting token usage, avoiding mixed/double cost

--- a/docs/superpowers/plans/2026-07-19-session-format-provenance.md
+++ b/docs/superpowers/plans/2026-07-19-session-format-provenance.md
@@ -26,8 +26,14 @@ repositories, and first-party vendor documentation.
 - Classify evidence as `source`, `documentation`, or `no-public-source`.
 - Source-backed entries use an HTTPS clone URL, a full 40-character commit hash,
   and permanent file links verified at that revision.
+- Treat a pinned revision as a reproducible research snapshot, not proof that it
+  produced every historical artifact. Record producer or format-version ranges
+  when they can be tied confidently to observed files.
 - Documentation-backed entries use first-party URLs and record the check date as
   `2026-07-19`.
+- Give every evidence class a last-verified date and reverify during provider
+  release investigations, new artifact generations, parser or accounting bug
+  reports, and periodic inventory review.
 - Distinguish persisted token/cost data from Agentsview-computed pricing.
 - State explicitly when token usage, cost, cache, reasoning, aggregate, or
   credit data is absent or ambiguous.
@@ -204,7 +210,7 @@ Use this exact field order in every provider section:
 
 - [ ] **Step 2: Add all canonical provider headings before research**
 
-Add one section, in registry order, for each of these exact IDs:
+Add one section, in this canonical reading order, for each of these exact IDs:
 
 ```text
 claude
@@ -261,6 +267,10 @@ reasonix
 
 Do not add a `grok` heading.
 
+Research and review the entries in provider-family batches. After each batch,
+check format-generation boundaries, evidence authority, and usage/cost mappings
+before proceeding; the complete registry-coverage test remains the final gate.
+
 - [ ] **Step 3: Build an implementation-derived format map**
 
 For each heading, inspect its parser and provider source with:
@@ -295,7 +305,9 @@ entry unchanged. At minimum, compare these known families:
 For every provider with a plausible public producer repository:
 
 1. Prefer the first-party repository over forks or reverse-engineering tools.
-1. Resolve a full revision with `git ls-remote <https-clone-url> HEAD`.
+1. Prefer a release-tag commit tied to an observed artifact. When only current
+   `HEAD` is usable, resolve it with `git ls-remote <https-clone-url> HEAD`
+   and record that applicability limitation.
 1. Inspect the repository tree or a filtered clone for persistence/schema files.
 1. Verify each cited path with `git cat-file -e <revision>:<path>`.
 1. Cite a permanent `blob/<full-revision>/<path>` link.
@@ -329,6 +341,12 @@ documentation sites, or product pages checked, then describe current parser
 behavior as Agentsview implementation evidence. Do not elevate fixtures,
 third-party blog posts, or inferred field names to upstream authority.
 
+Record a repeatable search log: exact first-party URLs or organizations, pinned
+public repository revisions when available, the search terms used for session
+format/persistence and token/cost fields, and the verification date. Retain an
+original URL and commit hash if evidence disappears, adding an archive or mirror
+without replacing the original identity.
+
 - [ ] **Step 7: Audit token and cost semantics provider by provider**
 
 For every section, answer all applicable questions explicitly:
@@ -349,7 +367,15 @@ rg -n 'TokenUsage|UsageEvents|InputTokens|OutputTokens|ContextTokens|CostUSD|cos
   internal/parser --glob '*.go' --glob '!**/*_test.go'
 ```
 
-- [ ] **Step 8: Run the focused coverage test to reach green**
+- [ ] **Step 8: Enforce section structure and run the focused test to reach
+  green**
+
+Extend the inventory test with malformed literal sections proving that it
+rejects missing, duplicate, or misordered required fields; invalid evidence
+classes; source entries without an HTTPS clone URL, full revision, or pinned
+file link; and documentation or negative-source entries without a check date.
+This validates the maintained contract without attempting to freeze prose
+conclusions.
 
 Run:
 
@@ -467,8 +493,9 @@ git diff -- AGENTS.md docs/internal/session-format-sources.md \
   internal/parser/format_sources_test.go
 ```
 
-Expected: no whitespace errors, only the three intended implementation files, no
-private data, no absolute local paths, and no Grok section.
+Expected: no whitespace errors, only implementation-owned changes beyond any
+pre-existing user changes recorded at the start, no private data, no absolute
+local paths, and no Grok section.
 
 - [ ] **Step 5: Stage only implementation files**
 
@@ -508,4 +535,5 @@ push or open a pull request unless the user explicitly requests those actions.
   inventory.
 - [ ] Go formatting, Go vet, focused tests, Markdown checks, and practical
   broader tests have recorded results.
-- [ ] The worktree is clean after the implementation commit.
+- [ ] No implementation-owned changes remain uncommitted; unrelated changes
+  present at the start are preserved and reported.

--- a/docs/superpowers/plans/2026-07-19-session-format-provenance.md
+++ b/docs/superpowers/plans/2026-07-19-session-format-provenance.md
@@ -1,0 +1,511 @@
+# Session Format Provenance Inventory Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a reproducible source inventory for every registered session
+provider except Grok, with special attention to token-usage and cost fields.
+
+**Architecture:** A human-readable internal Markdown document is the source of
+truth. A focused Go test extracts provider IDs from its headings and enforces
+exact two-way coverage against `parser.Registry`, while a root `AGENTS.md` rule
+keeps the inventory in the provider-development workflow.
+
+**Tech Stack:** Markdown, Go 1.26.3, `testify`, Git, first-party source
+repositories, and first-party vendor documentation.
+
+## Global Constraints
+
+- Exclude `AgentGrok`; its format alignment belongs to a separate pull request.
+- Include all other entries in `internal/parser.Registry`, including import-only
+  Claude.ai and ChatGPT formats.
+- Give each provider its own `` ## Display Name (`provider-id`) `` heading even
+  when formats are shared.
+- Classify evidence as `source`, `documentation`, or `no-public-source`.
+- Source-backed entries use an HTTPS clone URL, a full 40-character commit hash,
+  and permanent file links verified at that revision.
+- Documentation-backed entries use first-party URLs and record the check date as
+  `2026-07-19`.
+- Distinguish persisted token/cost data from Agentsview-computed pricing.
+- State explicitly when token usage, cost, cache, reasoning, aggregate, or
+  credit data is absent or ambiguous.
+- Do not change parser behavior, pricing behavior, or provider registration.
+- Do not include private project names, hostnames, personal identities,
+  infrastructure details, or absolute local paths in committed content.
+- Do not push, pull, rebase, amend, or open a pull request without a separate
+  explicit request.
+
+______________________________________________________________________
+
+## File Map
+
+- Create `docs/internal/session-format-sources.md`: research inventory and sole
+  human-maintained source of provider format provenance.
+- Create `internal/parser/format_sources_test.go`: exact registry-minus-Grok
+  coverage enforcement for inventory headings.
+- Modify `AGENTS.md`: durable instruction to consult and update the inventory
+  during provider work.
+
+### Task 1: Add the registry coverage contract
+
+**Files:**
+
+- Create: `internal/parser/format_sources_test.go`
+- Read: `internal/parser/types.go`
+- Read: `internal/parser/types_test.go`
+
+**Interfaces:**
+
+- Consumes: `parser.Registry`, `parser.AgentGrok`, and second-level inventory
+  headings shaped as `` ## Display Name (`provider-id`) ``.
+
+- Produces: `TestSessionFormatSourcesCoverRegistry`, which fails for a missing,
+  unknown, or duplicate provider ID.
+
+- [ ] **Step 1: Write the failing coverage test**
+
+Create `internal/parser/format_sources_test.go` with:
+
+```go
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var formatSourceHeadingRE = regexp.MustCompile(
+	"(?m)^## [^\\n]+ \\(`([a-z0-9-]+)`\\)$",
+)
+
+func TestSessionFormatSourcesCoverRegistry(t *testing.T) {
+	_, testFile, _, ok := runtime.Caller(0)
+	require.True(t, ok, "resolve format inventory test path")
+
+	inventoryPath := filepath.Join(
+		filepath.Dir(testFile), "..", "..", "docs", "internal",
+		"session-format-sources.md",
+	)
+	raw, err := os.ReadFile(inventoryPath)
+	require.NoError(t, err)
+
+	documented := make(map[AgentType]bool)
+	for _, match := range formatSourceHeadingRE.FindAllSubmatch(raw, -1) {
+		agent := AgentType(match[1])
+		assert.Falsef(t, documented[agent],
+			"provider %q documented more than once", agent)
+		documented[agent] = true
+	}
+
+	expected := make(map[AgentType]bool, len(Registry)-1)
+	for _, def := range Registry {
+		if def.Type == AgentGrok {
+			continue
+		}
+		expected[def.Type] = true
+	}
+
+	for agent := range documented {
+		assert.Truef(t, expected[agent],
+			"inventory documents unknown or excluded provider %q", agent)
+	}
+	for agent := range expected {
+		assert.Truef(t, documented[agent],
+			"provider %q missing from format inventory", agent)
+	}
+}
+```
+
+- [ ] **Step 2: Format the test**
+
+Run:
+
+```bash
+gofmt -w internal/parser/format_sources_test.go
+```
+
+Expected: the file is formatted with no output.
+
+- [ ] **Step 3: Run the test to establish the red state**
+
+Run:
+
+```bash
+CGO_ENABLED=1 go test -tags fts5 ./internal/parser \
+  -run '^TestSessionFormatSourcesCoverRegistry$' -count=1
+```
+
+Expected: FAIL because `docs/internal/session-format-sources.md` does not exist.
+
+### Task 2: Research and author the complete inventory
+
+**Files:**
+
+- Create: `docs/internal/session-format-sources.md`
+- Read: `internal/parser/*.go`
+- Read: `internal/parser/testdata/**`
+- Read: `docs/internal/visual-studio-copilot-traces.md`
+
+**Interfaces:**
+
+- Consumes: the evidence policy in
+  `docs/superpowers/specs/2026-07-19-session-format-provenance-design.md` and
+  the heading parser from Task 1.
+
+- Produces: 50 independently useful provider sections whose heading IDs exactly
+  match the registry minus `grok`.
+
+- [ ] **Step 1: Create the inventory preamble and evidence template**
+
+Start `docs/internal/session-format-sources.md` with this contract:
+
+```markdown
+# Session Format Source Inventory
+
+This inventory records the best reproducible evidence currently available for
+the session formats consumed by Agentsview. It is a maintainer research aid, not
+a compatibility guarantee. Source links are pinned; documentation links are
+moving first-party pages and include the date checked.
+
+Evidence classes:
+
+- `source`: public producer, persistence, schema, or migration source.
+- `documentation`: first-party format documentation without suitable public
+  producer source.
+- `no-public-source`: no usable public source or authoritative format
+  documentation was found after the searches recorded in the entry.
+
+Usage notes distinguish values persisted by the provider from costs Agentsview
+computes later with its pricing catalog.
+```
+
+Use this exact field order in every provider section:
+
+```markdown
+## Display Name (`provider-id`)
+
+- **Format:** Files, database tables, or import artifact consumed by Agentsview.
+- **Evidence:** `source`, `documentation`, or `no-public-source`.
+- **Upstream:** HTTPS clone URL plus full revision and pinned file links; or
+  first-party documentation plus `checked 2026-07-19`; or the public surfaces
+  searched without success.
+- **Usage and cost:** Persisted token, cache, reasoning, aggregate, credit, and
+  reported-cost fields, including what is absent and what Agentsview derives.
+- **Agentsview:** Relative parser source paths and any format limitations.
+```
+
+- [ ] **Step 2: Add all canonical provider headings before research**
+
+Add one section, in registry order, for each of these exact IDs:
+
+```text
+claude
+openclaude
+cowork
+codex
+copilot
+gemini
+mimocode
+opencode
+kilo
+openhands
+cursor
+amp
+vscode-copilot
+windsurf
+visualstudio-copilot
+pi
+omp
+qwen
+commandcode
+deepseek-tui
+openclaw
+qclaw
+kimi
+claude-ai
+chatgpt
+kiro
+kiro-ide
+cortex
+hermes
+forge
+devin
+piebald
+warp
+positron
+posit-assistant
+zcode
+zed
+antigravity
+antigravity-cli
+iflow
+icodemate
+workbuddy
+zencoder
+gptme
+qoder
+qwenpaw
+shelley
+vibe
+aider
+reasonix
+```
+
+Do not add a `grok` heading.
+
+- [ ] **Step 3: Build an implementation-derived format map**
+
+For each heading, inspect its parser and provider source with:
+
+```bash
+rg -n 'json|jsonl|sqlite|\.db|history|session|message|usage|token|cache|cost|credit|reasoning' \
+  internal/parser --glob '*.go' --glob '!**/*_test.go'
+```
+
+Record the concrete source layout and Agentsview parser paths first. For format
+families, inspect all provider-specific differences rather than copying one
+entry unchanged. At minimum, compare these known families:
+
+- Claude Code, OpenClaude, and Cowork;
+
+- OpenCode, MiMoCode, Kilo, and IcodeMate;
+
+- Copilot CLI, VS Code Copilot, and Visual Studio Copilot;
+
+- Pi, OhMyPi, and Reasonix;
+
+- OpenClaw, QClaw, and QwenPaw;
+
+- Kiro CLI and Kiro IDE;
+
+- Antigravity IDE and Antigravity CLI; and
+
+- VS Code-derived stores used by Windsurf and Positron.
+
+- [ ] **Step 4: Verify public-source evidence at immutable revisions**
+
+For every provider with a plausible public producer repository:
+
+1. Prefer the first-party repository over forks or reverse-engineering tools.
+1. Resolve a full revision with `git ls-remote <https-clone-url> HEAD`.
+1. Inspect the repository tree or a filtered clone for persistence/schema files.
+1. Verify each cited path with `git cat-file -e <revision>:<path>`.
+1. Cite a permanent `blob/<full-revision>/<path>` link.
+1. Cite separate files when session shape and usage accounting are defined in
+   different locations.
+
+Start with the known first-party projects represented by Codex, Gemini CLI,
+OpenCode, OpenHands, Pi, Qwen Code, Hermes Agent, Zed, Positron, Posit
+Assistant, gptme, Mistral Vibe, and Aider, then follow first-party package or
+repository links found in the remaining provider metadata and documentation.
+Treat this list as a search starting point, not evidence by itself.
+
+- [ ] **Step 5: Verify documentation evidence for closed-source formats**
+
+Search first-party vendor documentation and public organization repositories for
+every entry without suitable producer source. Prefer export-format, telemetry,
+storage, schema, or session-history pages over general product docs. Record
+`checked 2026-07-19` beside each moving documentation URL.
+
+For Claude.ai and ChatGPT, document the exported archive consumed by the import
+parser rather than a local application store. For OpenTelemetry-derived Visual
+Studio Copilot data, cite the vendor evidence for emitted attributes and the
+applicable semantic conventions, while retaining the existing local trace note
+as implementation detail.
+
+- [ ] **Step 6: Record exhausted searches honestly**
+
+When neither producer source nor authoritative format documentation is public,
+use `no-public-source`. Name the first-party organization repositories,
+documentation sites, or product pages checked, then describe current parser
+behavior as Agentsview implementation evidence. Do not elevate fixtures,
+third-party blog posts, or inferred field names to upstream authority.
+
+- [ ] **Step 7: Audit token and cost semantics provider by provider**
+
+For every section, answer all applicable questions explicitly:
+
+- Are input and output tokens persisted per message, per request, or only as an
+  aggregate?
+- Are cache creation/read, reasoning, or context token fields persisted?
+- Is monetary cost persisted by the provider, are AI credits persisted, or does
+  Agentsview compute price later?
+- Does the parser intentionally expose no per-message token data?
+- Are usage fields cumulative counters requiring deltas or independent events?
+- Are model IDs present where pricing needs them?
+
+Cross-check the resulting statements against the parser's actual field reads:
+
+```bash
+rg -n 'TokenUsage|UsageEvents|InputTokens|OutputTokens|ContextTokens|CostUSD|cost|credits|cached|reasoning' \
+  internal/parser --glob '*.go' --glob '!**/*_test.go'
+```
+
+- [ ] **Step 8: Run the focused coverage test to reach green**
+
+Run:
+
+```bash
+CGO_ENABLED=1 go test -tags fts5 ./internal/parser \
+  -run '^TestSessionFormatSourcesCoverRegistry$' -count=1
+```
+
+Expected: PASS with all 50 in-scope providers documented exactly once.
+
+### Task 3: Add the durable provider-maintenance rule
+
+**Files:**
+
+- Modify: `AGENTS.md`, after the `## Backend Parity` section
+- Read: `frontend/AGENTS.md` only to confirm it remains untouched
+
+**Interfaces:**
+
+- Consumes: `docs/internal/session-format-sources.md` from Task 2.
+
+- Produces: a standing repository instruction that keeps format provenance
+  synchronized with provider implementation changes.
+
+- [ ] **Step 1: Add the root instruction**
+
+Add this one-line paragraph to the root `AGENTS.md` under a new
+`## Provider Format Provenance` heading:
+
+```markdown
+## Provider Format Provenance
+
+When adding a provider or changing a provider's on-disk format or usage/cost
+accounting, consult `docs/internal/session-format-sources.md` and update its
+evidence entry in the same change.
+```
+
+- [ ] **Step 2: Confirm the frontend instruction file is unchanged**
+
+Run:
+
+```bash
+git diff -- frontend/AGENTS.md
+```
+
+Expected: no output.
+
+### Task 4: Format, validate, review, and commit the implementation
+
+**Files:**
+
+- Modify: formatting only in the three implementation files from Tasks 1-3
+- Validate: `docs/internal/session-format-sources.md`
+- Validate: `internal/parser/format_sources_test.go`
+- Validate: `AGENTS.md`
+
+**Interfaces:**
+
+- Consumes: the completed inventory, coverage test, and maintenance rule.
+
+- Produces: one focused implementation commit ready for review.
+
+- [ ] **Step 1: Format Go and Markdown**
+
+Run:
+
+```bash
+gofmt -w internal/parser/format_sources_test.go
+cd docs && uv run --frozen mdformat --wrap 80 \
+  internal/session-format-sources.md ../AGENTS.md
+```
+
+Expected: formatting succeeds and changes only the intended files.
+
+- [ ] **Step 2: Run required Go verification**
+
+Run:
+
+```bash
+go fmt ./...
+CGO_ENABLED=1 go test -tags fts5 ./internal/parser \
+  -run '^TestSessionFormatSourcesCoverRegistry$' -count=1
+go vet ./...
+```
+
+Expected: all commands pass.
+
+- [ ] **Step 3: Run broader practical checks**
+
+Run:
+
+```bash
+python3 docs/scripts/check_markdown_sources.py
+make test-short
+```
+
+Expected: the Markdown source check and short test suite pass. If the broader
+suite fails for an unrelated environment issue, preserve the exact output and
+report it rather than weakening the check.
+
+- [ ] **Step 4: Check evidence mechanics and content hygiene**
+
+Confirm every `source` entry has a clone URL, full 40-character revision, and at
+least one pinned file link. Re-run `git cat-file -e` for every cited path in the
+corresponding temporary clone. Confirm every `documentation` entry includes
+`checked 2026-07-19`, every `no-public-source` entry names the searches made,
+and all 50 sections discuss usage/cost availability.
+
+Run:
+
+```bash
+git diff --check
+git diff --stat
+git diff -- AGENTS.md docs/internal/session-format-sources.md \
+  internal/parser/format_sources_test.go
+```
+
+Expected: no whitespace errors, only the three intended implementation files, no
+private data, no absolute local paths, and no Grok section.
+
+- [ ] **Step 5: Stage only implementation files**
+
+Run:
+
+```bash
+git add AGENTS.md docs/internal/session-format-sources.md \
+  internal/parser/format_sources_test.go
+git diff --cached --check
+git diff --cached --stat
+```
+
+Expected: exactly the inventory, coverage test, and root maintenance rule are
+staged.
+
+- [ ] **Step 6: Commit through the mandatory commit workflow**
+
+After invoking the mandatory commit skill, create a conventional commit without
+generated attribution lines, as required by the repository instructions:
+
+```bash
+git commit -m "docs: inventory provider session format sources" \
+  -m "Provider parsing and usage accounting need reproducible upstream evidence so format changes can be audited without rediscovering source schemas and closed-source limitations. The inventory pins public source, records authoritative documentation or exhausted searches, and enforces registry coverage while leaving prose conclusions reviewable."
+```
+
+Expected: hooks pass and one non-empty implementation commit is created. Do not
+push or open a pull request unless the user explicitly requests those actions.
+
+## Final Verification Checklist
+
+- [ ] The design commit remains separate from the implementation commit.
+- [ ] The inventory has exactly 50 provider headings and excludes `grok`.
+- [ ] Every public-source citation resolves at its full pinned revision.
+- [ ] Every provider section explains token and cost availability or absence.
+- [ ] `TestSessionFormatSourcesCoverRegistry` passes.
+- [ ] `AGENTS.md` requires future provider implementers to maintain the
+  inventory.
+- [ ] Go formatting, Go vet, focused tests, Markdown checks, and practical
+  broader tests have recorded results.
+- [ ] The worktree is clean after the implementation commit.

--- a/docs/superpowers/specs/2026-07-19-session-format-provenance-design.md
+++ b/docs/superpowers/specs/2026-07-19-session-format-provenance-design.md
@@ -1,0 +1,118 @@
+# Session Format Provenance Inventory Design
+
+## Context
+
+Agentsview supports a large and growing set of session providers, but the
+evidence used to understand their on-disk or import formats is spread across
+parser implementations, fixtures, upstream repositories, vendor documentation,
+and reverse-engineering notes. That makes it difficult to audit parsing choices,
+especially token-usage and cost attribution, or to refresh a parser when an
+upstream format changes.
+
+Create one internal inventory that gives maintainers a reproducible starting
+point for every registered provider. The inventory is research documentation,
+not a public compatibility promise or a replacement for parser tests.
+
+The `grok` provider is excluded because its format alignment is being handled in
+a separate pull request. Every other entry in `internal/parser.Registry` is in
+scope, including import-only providers such as Claude.ai and ChatGPT.
+
+## Inventory Location and Structure
+
+Add `docs/internal/session-format-sources.md` as the source of truth. Give every
+in-scope provider its own second-level heading containing the registry ID in
+backticks. Providers that share an upstream format family still receive distinct
+sections so coverage and provider-specific differences remain explicit.
+
+Each provider section records:
+
+- display name and registry ID;
+- the on-disk or import layout that Agentsview consumes;
+- evidence classification;
+- a cloneable upstream repository URL when public source exists;
+- a full pinned commit hash and permanent links to relevant files at that
+  commit;
+- the upstream fields and semantics relevant to input, output, cache, reasoning,
+  aggregate, credit, or reported-cost accounting;
+- the Agentsview parser files that consume the format; and
+- limitations, ambiguity, or absence of usage data.
+
+The inventory may link to the existing Visual Studio Copilot trace note for
+additional local detail, but it remains responsible for that provider's upstream
+provenance and token-field summary.
+
+## Evidence Policy
+
+Classify every entry as one of:
+
+- `source`: public producer or schema source exists;
+- `documentation`: no suitable public producer source was found, but
+  authoritative vendor documentation describes the persisted or exported
+  format; or
+- `no-public-source`: public source and authoritative format documentation were
+  exhausted without finding usable evidence.
+
+For `source` entries, prefer producer-side serialization, persistence, schema,
+or migration code over examples and downstream consumers. Use the repository's
+HTTPS clone URL, a full 40-character commit hash, and file links pinned to that
+hash. Verify that every cited path exists at the pinned revision. When one file
+defines the session shape and another defines usage accounting, cite both.
+
+For `documentation` entries, prefer first-party vendor documentation and record
+the URL plus the date it was checked. Do not imply that a moving documentation
+page is pinned. Public standards may supplement vendor evidence when the vendor
+explicitly uses them, but a general standard alone does not prove a provider's
+persisted format.
+
+For `no-public-source` entries, state that no usable public format source was
+found and summarize the first-party repositories or documentation surfaces that
+were checked. Sanitized local observations and the Agentsview parser may explain
+current behavior, but must be labeled as implementation evidence rather than
+upstream authority.
+
+Token and cost notes must distinguish fields directly persisted by the provider
+from values Agentsview derives later using its pricing catalog. Explicitly state
+when a format exposes no token usage, reports only aggregate usage, uses AI
+credits instead of currency, or stores a provider-reported monetary cost.
+
+## Coverage Enforcement
+
+Add a focused Go test in `internal/parser` that reads provider IDs from the
+inventory's second-level headings and compares them with
+`internal/parser.Registry` in both directions after excluding `AgentGrok`. The
+test fails for missing entries, unknown entries, and duplicate provider IDs.
+
+The test enforces inventory membership only. It does not parse or freeze prose,
+URLs, repository paths, or evidence conclusions. Research quality remains a
+review concern, while the automated check prevents new providers from silently
+bypassing the inventory.
+
+## Maintainer Rule
+
+Add a one-line rule to the root `AGENTS.md` requiring implementers who add or
+change a provider to consult `docs/internal/session-format-sources.md` and
+update its evidence entry in the same change. The wording must cover new
+providers and format or usage-accounting changes to existing providers.
+
+Do not modify the frontend-specific `AGENTS.md`; the rule concerns parser and
+provider maintenance across the repository.
+
+## Validation
+
+- Format the new Markdown with `mdformat --wrap 80` when the configured Markdown
+  tooling is available.
+- Run the focused inventory-coverage test with the repository's required Go
+  build settings.
+- Run the existing Markdown source check and any broader parser tests practical
+  for the documentation and test changes.
+- Review the final diff for private project names, hostnames, personal identity,
+  infrastructure details, and absolute local paths.
+- Do not change parser behavior, pricing behavior, provider registration, or the
+  Grok inventory in this work.
+
+## Deliverable
+
+Commit the design separately, then implement the inventory, coverage test, and
+root maintenance rule as focused follow-up work on the approved feature branch.
+Push and pull-request creation remain separate actions requiring the user's
+request under the repository Git rules.

--- a/docs/superpowers/specs/2026-07-19-session-format-provenance-design.md
+++ b/docs/superpowers/specs/2026-07-19-session-format-provenance-design.md
@@ -32,6 +32,9 @@ Each provider section records:
 - a cloneable upstream repository URL when public source exists;
 - a full pinned commit hash and permanent links to relevant files at that
   commit;
+- the producer release or format-version range tied to the consumed artifact
+  when that relationship can be established, otherwise an explicit statement
+  that the revision is only a research snapshot;
 - the upstream fields and semantics relevant to input, output, cache, reasoning,
   aggregate, credit, or reported-cost accounting;
 - the Agentsview parser files that consume the format; and
@@ -57,6 +60,9 @@ or migration code over examples and downstream consumers. Use the repository's
 HTTPS clone URL, a full 40-character commit hash, and file links pinned to that
 hash. Verify that every cited path exists at the pinned revision. When one file
 defines the session shape and another defines usage accounting, cite both.
+Prefer a release-tag commit that can be tied to an observed artifact. A current
+`HEAD` revision is acceptable only when its snapshot-only applicability and any
+known legacy-generation boundary are stated.
 
 For `documentation` entries, prefer first-party vendor documentation and record
 the URL plus the date it was checked. Do not imply that a moving documentation
@@ -68,7 +74,18 @@ For `no-public-source` entries, state that no usable public format source was
 found and summarize the first-party repositories or documentation surfaces that
 were checked. Sanitized local observations and the Agentsview parser may explain
 current behavior, but must be labeled as implementation evidence rather than
-upstream authority.
+upstream authority. Record exact URLs or organizations, useful pinned revisions,
+the repeated format/persistence and token/cost search terms, and the check date
+so the negative conclusion can be reproduced.
+
+Treat the evidence class as the strongest public authority present, not blanket
+support for every claim in a section. Generic standards and documentation that
+only establishes an export artifact are supplemental rather than proof of a
+complete persisted schema. Give every entry a last-verified date and reverify it
+during provider-release investigations, new artifact generations, parser or
+usage-accounting bug reports, and periodic inventory review. If evidence
+disappears, retain its original URL and commit identity while adding an archive
+or maintained mirror.
 
 Token and cost notes must distinguish fields directly persisted by the provider
 from values Agentsview derives later using its pricing catalog. Explicitly state
@@ -82,17 +99,23 @@ inventory's second-level headings and compares them with
 `internal/parser.Registry` in both directions after excluding `AgentGrok`. The
 test fails for missing entries, unknown entries, and duplicate provider IDs.
 
-The test enforces inventory membership only. It does not parse or freeze prose,
-URLs, repository paths, or evidence conclusions. Research quality remains a
-review concern, while the automated check prevents new providers from silently
-bypassing the inventory.
+The test also enforces exactly one of each required field in the prescribed
+order, the evidence-class vocabulary, full source revisions and pinned links,
+and check dates for documentation or negative-source entries. It does not parse
+or freeze prose conclusions. Research quality remains a review concern, while
+the automated contract prevents structurally incomplete entries from appearing
+covered.
 
 ## Maintainer Rule
 
-Add a one-line rule to the root `AGENTS.md` requiring implementers who add or
-change a provider to consult `docs/internal/session-format-sources.md` and
-update its evidence entry in the same change. The wording must cover new
-providers and format or usage-accounting changes to existing providers.
+Add a rule to the root `AGENTS.md` requiring implementers who add or change a
+provider, or investigate a provider release, new artifact generation, parser
+bug, or usage discrepancy, to consult `docs/internal/session-format-sources.md`
+and reverify or update its evidence entry in the same change.
+
+Grok remains temporarily excluded because its separately owned format-alignment
+work is in progress. The exit criterion is that work landing: then add Grok to
+the inventory and remove the explicit registry exception.
 
 Do not modify the frontend-specific `AGENTS.md`; the rule concerns parser and
 provider maintenance across the repository.

--- a/internal/parser/format_sources_test.go
+++ b/internal/parser/format_sources_test.go
@@ -1,0 +1,53 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var formatSourceHeadingRE = regexp.MustCompile(
+	"(?m)^## [^\\n]+ \\(`([a-z0-9-]+)`\\)$",
+)
+
+func TestSessionFormatSourcesCoverRegistry(t *testing.T) {
+	_, testFile, _, ok := runtime.Caller(0)
+	require.True(t, ok, "resolve format inventory test path")
+
+	inventoryPath := filepath.Join(
+		filepath.Dir(testFile), "..", "..", "docs", "internal",
+		"session-format-sources.md",
+	)
+	raw, err := os.ReadFile(inventoryPath)
+	require.NoError(t, err)
+
+	documented := make(map[AgentType]bool)
+	for _, match := range formatSourceHeadingRE.FindAllSubmatch(raw, -1) {
+		agent := AgentType(match[1])
+		assert.Falsef(t, documented[agent],
+			"provider %q documented more than once", agent)
+		documented[agent] = true
+	}
+
+	expected := make(map[AgentType]bool, len(Registry)-1)
+	for _, def := range Registry {
+		if def.Type == AgentGrok {
+			continue
+		}
+		expected[def.Type] = true
+	}
+
+	for agent := range documented {
+		assert.Truef(t, expected[agent],
+			"inventory documents unknown or excluded provider %q", agent)
+	}
+	for agent := range expected {
+		assert.Truef(t, documented[agent],
+			"provider %q missing from format inventory", agent)
+	}
+}

--- a/internal/parser/format_sources_test.go
+++ b/internal/parser/format_sources_test.go
@@ -1,10 +1,12 @@
 package parser
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,6 +15,18 @@ import (
 
 var formatSourceHeadingRE = regexp.MustCompile(
 	"(?m)^## [^\\n]+ \\(`([a-z0-9-]+)`\\)$",
+)
+
+var formatSourceEvidenceRE = regexp.MustCompile(
+	"(?m)^- \\*\\*Evidence:\\*\\* `([^`]+)`\\.$",
+)
+
+var (
+	formatSourceCloneRE     = regexp.MustCompile("Clone `https://[^`]+\\.git`")
+	formatSourceRevisionRE  = regexp.MustCompile("`([0-9a-f]{40})`")
+	formatSourceCheckDateRE = regexp.MustCompile(
+		`\b(?:checked|searched)\s+20\d{2}-\d{2}-\d{2}\b`,
+	)
 )
 
 func TestSessionFormatSourcesCoverRegistry(t *testing.T) {
@@ -25,6 +39,7 @@ func TestSessionFormatSourcesCoverRegistry(t *testing.T) {
 	)
 	raw, err := os.ReadFile(inventoryPath)
 	require.NoError(t, err)
+	assert.Empty(t, validateFormatSourceInventory(raw))
 
 	documented := make(map[AgentType]bool)
 	for _, match := range formatSourceHeadingRE.FindAllSubmatch(raw, -1) {
@@ -50,4 +65,226 @@ func TestSessionFormatSourcesCoverRegistry(t *testing.T) {
 		assert.Truef(t, documented[agent],
 			"provider %q missing from format inventory", agent)
 	}
+}
+
+func TestSessionFormatSourcesRejectIncompleteSection(t *testing.T) {
+	raw := []byte(`## Example (` + "`example`" + `)
+
+- **Format:** JSONL.
+- **Evidence:** ` + "`documentation`" + `.
+- **Upstream:** Vendor docs were checked 2026-07-19.
+- **Agentsview:** internal/parser/example.go.
+`)
+
+	errs := validateFormatSourceInventory(raw)
+	assert.Contains(t, errs, `provider "example" missing "Usage and cost" field`)
+}
+
+func TestSessionFormatSourcesRejectInvalidEvidenceClass(t *testing.T) {
+	raw := []byte(`## Example (` + "`example`" + `)
+
+- **Format:** JSONL.
+- **Evidence:** ` + "`inferred`" + `.
+- **Upstream:** Vendor material was checked 2026-07-19.
+- **Usage and cost:** No usage is persisted.
+- **Agentsview:** internal/parser/example.go.
+`)
+
+	errs := validateFormatSourceInventory(raw)
+	assert.Contains(t, errs, `provider "example" has invalid evidence class "inferred"`)
+}
+
+func TestSessionFormatSourcesRejectMalformedEvidenceDeclaration(t *testing.T) {
+	raw := []byte(`## Example (` + "`example`" + `)
+
+- **Format:** JSONL.
+- **Evidence:** documentation.
+- **Upstream:** Vendor material was checked 2026-07-19.
+- **Usage and cost:** No usage is persisted.
+- **Agentsview:** internal/parser/example.go.
+`)
+
+	errs := validateFormatSourceInventory(raw)
+	assert.Contains(t, errs, `provider "example" has malformed evidence declaration`)
+}
+
+func TestSessionFormatSourcesRequireEvidenceMetadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		evidence string
+		upstream string
+		want     string
+	}{
+		{
+			name:     "source revision",
+			evidence: "source",
+			upstream: "Clone `https://github.com/example/tool.git`.",
+			want:     `provider "example" source evidence lacks a full revision`,
+		},
+		{
+			name:     "source clone URL",
+			evidence: "source",
+			upstream: "Revision `0123456789abcdef0123456789abcdef01234567`; " +
+				"see https://github.com/example/tool/blob/" +
+				"0123456789abcdef0123456789abcdef01234567/session.go.",
+			want: `provider "example" source evidence lacks an HTTPS clone URL`,
+		},
+		{
+			name:     "source pinned file link",
+			evidence: "source",
+			upstream: "Clone `https://github.com/example/tool.git` at " +
+				"`0123456789abcdef0123456789abcdef01234567`.",
+			want: `provider "example" source evidence lacks a pinned file link`,
+		},
+		{
+			name:     "documentation check date",
+			evidence: "documentation",
+			upstream: "Vendor documentation was checked recently.",
+			want:     `provider "example" documentation evidence lacks a check date`,
+		},
+		{
+			name:     "negative search date",
+			evidence: "no-public-source",
+			upstream: "Vendor documentation and repositories were searched.",
+			want:     `provider "example" no-public-source evidence lacks a check date`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := []byte("## Example (`example`)\n\n" +
+				"- **Format:** JSONL.\n" +
+				"- **Evidence:** `" + tt.evidence + "`.\n" +
+				"- **Upstream:** " + tt.upstream + "\n" +
+				"- **Usage and cost:** No usage is persisted.\n" +
+				"- **Agentsview:** internal/parser/example.go.\n")
+
+			errs := validateFormatSourceInventory(raw)
+			assert.Contains(t, errs, tt.want)
+		})
+	}
+}
+
+func TestSessionFormatSourcesRequireFieldsOnceInOrder(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "duplicate field",
+			raw: "- **Format:** JSONL.\n" +
+				"- **Format:** SQLite.\n" +
+				"- **Evidence:** `documentation`.\n" +
+				"- **Upstream:** Vendor docs were checked 2026-07-19.\n" +
+				"- **Usage and cost:** No usage is persisted.\n" +
+				"- **Agentsview:** internal/parser/example.go.\n",
+			want: `provider "example" has 2 "Format" fields`,
+		},
+		{
+			name: "misordered field",
+			raw: "- **Format:** JSONL.\n" +
+				"- **Evidence:** `documentation`.\n" +
+				"- **Upstream:** Vendor docs were checked 2026-07-19.\n" +
+				"- **Agentsview:** internal/parser/example.go.\n" +
+				"- **Usage and cost:** No usage is persisted.\n",
+			want: `provider "example" fields are not in required order`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := validateFormatSourceInventory([]byte(
+				"## Example (`example`)\n\n" + tt.raw,
+			))
+			assert.Contains(t, errs, tt.want)
+		})
+	}
+}
+
+func validateFormatSourceInventory(raw []byte) []string {
+	matches := formatSourceHeadingRE.FindAllSubmatchIndex(raw, -1)
+	var errs []string
+	for i, match := range matches {
+		sectionEnd := len(raw)
+		if i+1 < len(matches) {
+			sectionEnd = matches[i+1][0]
+		}
+		agent := string(raw[match[2]:match[3]])
+		section := string(raw[match[1]:sectionEnd])
+		fields := []string{
+			"Format", "Evidence", "Upstream", "Usage and cost", "Agentsview",
+		}
+		lastFieldIndex := -1
+		fieldsInOrder := true
+		for _, field := range fields {
+			marker := "- **" + field + ":**"
+			fieldCount := strings.Count(section, marker)
+			if fieldCount == 0 {
+				errs = append(errs, fmt.Sprintf(
+					"provider %q missing %q field", agent, field,
+				))
+				continue
+			}
+			if fieldCount > 1 {
+				errs = append(errs, fmt.Sprintf(
+					"provider %q has %d %q fields", agent, fieldCount, field,
+				))
+			}
+			fieldIndex := strings.Index(section, marker)
+			if fieldIndex <= lastFieldIndex {
+				fieldsInOrder = false
+			}
+			lastFieldIndex = fieldIndex
+		}
+		if !fieldsInOrder {
+			errs = append(errs, fmt.Sprintf(
+				"provider %q fields are not in required order", agent,
+			))
+		}
+
+		evidenceMatch := formatSourceEvidenceRE.FindStringSubmatch(section)
+		if evidenceMatch == nil {
+			errs = append(errs, fmt.Sprintf(
+				"provider %q has malformed evidence declaration", agent,
+			))
+			continue
+		}
+		evidence := evidenceMatch[1]
+		if evidence != "source" && evidence != "documentation" &&
+			evidence != "no-public-source" {
+			errs = append(errs, fmt.Sprintf(
+				"provider %q has invalid evidence class %q", agent, evidence,
+			))
+			continue
+		}
+
+		switch evidence {
+		case "source":
+			revisionMatch := formatSourceRevisionRE.FindStringSubmatch(section)
+			if revisionMatch == nil {
+				errs = append(errs, fmt.Sprintf(
+					"provider %q source evidence lacks a full revision", agent,
+				))
+				continue
+			}
+			if !formatSourceCloneRE.MatchString(section) {
+				errs = append(errs, fmt.Sprintf(
+					"provider %q source evidence lacks an HTTPS clone URL", agent,
+				))
+			}
+			if !strings.Contains(section, "/blob/"+revisionMatch[1]+"/") {
+				errs = append(errs, fmt.Sprintf(
+					"provider %q source evidence lacks a pinned file link", agent,
+				))
+			}
+		case "documentation", "no-public-source":
+			if !formatSourceCheckDateRE.MatchString(section) {
+				errs = append(errs, fmt.Sprintf(
+					"provider %q %s evidence lacks a check date", agent, evidence,
+				))
+			}
+		}
+	}
+	return errs
 }


### PR DESCRIPTION
Provider parsers rely on upstream on-disk formats whose token, cache, reasoning, and monetary-cost fields can change independently of Agentsview. Those assumptions were previously scattered across implementation details and fixtures, making format investigations repetitive and leaving authority boundaries unclear for closed-source products.

This adds a maintained provider-by-provider provenance inventory with immutable source revisions where available, first-party documentation where source is closed, and explicit exhausted-search results otherwise. It also records known accounting limitations, enforces registry coverage and evidence shape, and directs future provider implementers to reverify the inventory when formats or usage behavior change. Grok remains temporarily excluded while its separately owned format-alignment work lands.

<sup>generated by a clanker</sup>