### PR TITLE
fix(frontend): keep the open session across a filtered sidebar reload

### DIFF
--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -296,6 +296,11 @@ class SessionsStore {
   agents: AgentInfo[] = $state([]);
   machines: string[] = $state([]);
   activeSessionId: string | null = $state(null);
+  // Resolved detail for the open session, held outside the sidebar list so a
+  // session that falls outside the current filters or page (e.g. opened from
+  // search) can back activeSession without polluting groupedSessions or being
+  // double-counted when loadMore appends a later page. Cleared on navigation.
+  activeSessionDetail: Session | null = $state(null);
   activeSessionUsageVersion: number = $state(0);
   childSessions: Map<string, Session> = $state(new Map());
   nextCursor: string | null = $state(null);
@@ -358,7 +363,13 @@ class SessionsStore {
 
   get activeSession(): Session | undefined {
     const session = this.sessions.find((s) => s.id === this.activeSessionId);
-    return session?.is_index_only ? undefined : session;
+    if (session && !session.is_index_only) return session;
+    // The open session may be absent from the filtered/paginated sidebar list
+    // (opened from search, filtered out, or on an unloaded page), or present
+    // only as an index-only stub. Fall back to the separately resolved detail.
+    const cached = this.activeSessionDetail;
+    if (cached && cached.id === this.activeSessionId) return cached;
+    return undefined;
   }
 
   get groupedSessions(): SessionGroup[] {
@@ -526,21 +537,6 @@ class SessionsStore {
       this.sessions = index.sessions.map((row) =>
         sidebarIndexRowToSession(row, existing.get(row.id))
       );
-      // Preserve the open session when the (filtered) index omits it, e.g. one
-      // opened from search that falls outside the current sidebar filters.
-      // navigateToSession appended it to the list; dropping it on reload leaves
-      // activeSession undefined and strips the breadcrumb's project, name, and
-      // badges. Keep the previously resolved row so the detail view stays intact.
-      const activeId = this.activeSessionId;
-      if (
-        activeId !== null &&
-        !index.sessions.some((row) => row.id === activeId)
-      ) {
-        const preserved = existing.get(activeId);
-        if (preserved && !preserved.is_index_only) {
-          this.sessions = [...this.sessions, preserved];
-        }
-      }
       this.nextCursor = index.next_cursor ?? null;
       this.total = index.total;
     } catch {
@@ -808,6 +804,7 @@ class SessionsStore {
     this.refreshRead.cancel();
     this.childSessionsRead.cancel();
     this.activeSessionId = id;
+    this.activeSessionDetail = null;
     this.activeSessionUsageVersion = 0;
     this.refreshVersion++;
     this.childSessionsVersion++;
@@ -819,8 +816,11 @@ class SessionsStore {
   }
 
   /**
-   * Navigate to a session by ID, loading it into the sessions list if
-   * not already present (e.g. subagent sessions filtered from groups).
+   * Navigate to a session by ID. If it isn't in the current sidebar list
+   * (e.g. opened from search, filtered out, or on an unloaded page), its
+   * detail is fetched into activeSessionDetail rather than injected into the
+   * sidebar collection, so it can back activeSession without appearing in the
+   * filtered list or being double-counted when loadMore appends later pages.
    */
   async navigateToSession(id: string) {
     this.setActiveSession(id);
@@ -841,7 +841,7 @@ class SessionsStore {
         if (idx >= 0) {
           this.mergeHydratedSession(session);
         } else {
-          this.sessions = [...this.sessions, session];
+          this.activeSessionDetail = session;
         }
       }
     } catch {
@@ -883,6 +883,10 @@ class SessionsStore {
       const idx = this.sessions.findIndex((s) => s.id === id);
       if (idx >= 0) {
         this.mergeHydratedSession(session);
+      } else if (this.activeSessionDetail?.id === id) {
+        // Active session is backed by the detail cache (not in the sidebar
+        // list); refresh the cache so metadata stays current.
+        this.activeSessionDetail = session;
       }
     } catch {
       // Session may have been deleted

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -642,13 +642,17 @@ class SessionsStore {
     const idx = this.sessions.findIndex((s) => s.id === hydrated.id);
     if (idx < 0) return;
     const current = this.sessions[idx]!;
-    this.sessions[idx] = {
+    const merged = {
       ...current,
       ...hydrated,
       display_name: hydrated.display_name ?? current.display_name,
       is_teammate: hydrated.is_teammate ?? current.is_teammate,
       is_index_only: false,
     };
+    this.sessions[idx] = merged;
+    // Keep the active-session cache in sync so the breadcrumb survives a later
+    // reload that drops this row from the filtered/first page.
+    if (merged.id === this.activeSessionId) this.activeSessionDetail = merged;
   }
 
   private invalidateHydratedSessionDetails() {
@@ -812,7 +816,17 @@ class SessionsStore {
 
   selectSession(id: string) {
     this.setActiveSession(id);
+    this.cacheActiveSessionDetailFromList(id);
     void this.hydrateSelectedIndexOnlySession(id);
+  }
+
+  // Seed activeSessionDetail from a hydrated sidebar row so the open session
+  // survives a later reload that drops it from the filtered/first page. Skips
+  // index-only stubs; hydration then seeds the cache via mergeHydratedSession.
+  private cacheActiveSessionDetailFromList(id: string) {
+    if (id !== this.activeSessionId) return;
+    const row = this.sessions.find((s) => s.id === id);
+    if (row && !row.is_index_only) this.activeSessionDetail = row;
   }
 
   /**
@@ -826,6 +840,7 @@ class SessionsStore {
     this.setActiveSession(id);
     const existing = this.sessions.find((s) => s.id === id);
     if (existing) {
+      this.cacheActiveSessionDetailFromList(id);
       await this.hydrateSelectedIndexOnlySession(id);
       return;
     }

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -964,6 +964,15 @@ class SessionsStore {
       ) {
         this.activeDetailGeneration++;
         this.activeSessionDetail = null;
+        // A hydrated matching row would keep backing activeSession as a
+        // ghost of the deleted session; drop it and keep the pagination
+        // total consistent, mirroring deleteSession.
+        const before = this.sessions.length;
+        this.sessions = this.sessions.filter((s) => s.id !== id);
+        const removed = before - this.sessions.length;
+        if (removed > 0) {
+          this.total = Math.max(0, this.total - removed);
+        }
       }
     } finally {
       this.activeDetailRead.finish(signal);

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -526,6 +526,21 @@ class SessionsStore {
       this.sessions = index.sessions.map((row) =>
         sidebarIndexRowToSession(row, existing.get(row.id))
       );
+      // Preserve the open session when the (filtered) index omits it, e.g. one
+      // opened from search that falls outside the current sidebar filters.
+      // navigateToSession appended it to the list; dropping it on reload leaves
+      // activeSession undefined and strips the breadcrumb's project, name, and
+      // badges. Keep the previously resolved row so the detail view stays intact.
+      const activeId = this.activeSessionId;
+      if (
+        activeId !== null &&
+        !index.sessions.some((row) => row.id === activeId)
+      ) {
+        const preserved = existing.get(activeId);
+        if (preserved && !preserved.is_index_only) {
+          this.sessions = [...this.sessions, preserved];
+        }
+      }
       this.nextCursor = index.next_cursor ?? null;
       this.total = index.total;
     } catch {

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -1375,9 +1375,8 @@ class SessionsStore {
       id,
       requestBody: { display_name: displayName },
     }) as unknown as Session;
-    const idx = this.sessions.findIndex((s) => s.id === id);
-    if (idx !== -1) {
-      const merged = { ...this.sessions[idx]!, ...updated };
+    const applyRename = (target: Session): Session => {
+      const merged = { ...target, ...updated };
       // When the caller cleared the rename and the backend found no agent name
       // to restore, display_name is absent from the response (omitempty on nil).
       // Explicitly null it out so the store reflects the cleared state rather
@@ -1385,7 +1384,16 @@ class SessionsStore {
       if (displayName === null && updated.display_name === undefined) {
         merged.display_name = null;
       }
-      this.sessions[idx] = merged;
+      return merged;
+    };
+    const idx = this.sessions.findIndex((s) => s.id === id);
+    if (idx !== -1) {
+      this.sessions[idx] = applyRename(this.sessions[idx]!);
+    }
+    // The active session may be backed only by the detail cache (absent from
+    // the sidebar list); keep its name in sync so the breadcrumb updates too.
+    if (this.activeSessionDetail?.id === id) {
+      this.activeSessionDetail = applyRename(this.activeSessionDetail);
     }
   }
 

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -603,6 +603,12 @@ class SessionsStore {
             () => SessionsService.getApiV1SessionsId({ id }),
             signal,
           ) as unknown as Session;
+          // The active session's detail stays valid even if a concurrent
+          // reload superseded this hydration version: seed the cache first so
+          // the breadcrumb survives when the new index excludes the row.
+          if (hydrated.id === this.activeSessionId && !hydrated.is_index_only) {
+            this.activeSessionDetail = hydrated;
+          }
           if (
             version !== this.sidebarIndexVersion ||
             epoch !== (this.sidebarHydrationEpochByVersion.get(version) ?? 0)
@@ -1022,16 +1028,12 @@ class SessionsStore {
       // an unstarred session while starred-only filter is on) — jump to
       // an edge so the keyboard shortcut doesn't silently fail.
       const edge = delta > 0 ? 0 : list.length - 1;
-      const id = list[edge]!.id;
-      this.setActiveSession(id);
-      void this.hydrateSelectedIndexOnlySession(id);
+      this.selectSession(list[edge]!.id);
       return;
     }
     const next = idx + delta;
     if (next >= 0 && next < list.length) {
-      const id = list[next]!.id;
-      this.setActiveSession(id);
-      void this.hydrateSelectedIndexOnlySession(id);
+      this.selectSession(list[next]!.id);
     }
   }
 

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -355,8 +355,12 @@ class SessionsStore {
   // Single coordinator for every read that commits to activeSessionDetail
   // (navigation and watcher refresh): the newest read cancels older in-flight
   // ones, so a stale response resolving late can never overwrite fresher
-  // cached detail.
+  // cached detail. The generation counter extends that freshness to sidebar
+  // hydration, which shares its fetches with non-active rows and so cannot
+  // claim the coordinator itself: a hydration only touches active-session
+  // state when no read began and no rename committed since it was issued.
   private activeDetailRead = new LatestRead();
+  private activeDetailGeneration = 0;
   private childSessionsRead = new LatestRead();
 
   private liveRefreshStarted = false;
@@ -600,6 +604,7 @@ class SessionsStore {
 
       const promise = this.runSidebarHydration(async () => {
         if (signal.aborted) return;
+        const detailGeneration = this.activeDetailGeneration;
         try {
           configureGeneratedClient();
           const hydrated = await callGenerated(
@@ -608,14 +613,19 @@ class SessionsStore {
           ) as unknown as Session;
           // A superseded hydration still carries valid detail for the active
           // session, so let it back the breadcrumb when the new index excludes
-          // the row — but only fill an empty cache. A stale-version response
-          // must never overwrite detail already resolved for this session by a
-          // newer request; the fresh path below (mergeHydratedSession) owns
-          // updates once the version check passes.
+          // the row — but only fill an empty cache, and only when no newer
+          // navigation/refresh/rename touched active-detail state while this
+          // response was in flight. A stale response must never overwrite
+          // detail already resolved for this session by a newer request; the
+          // fresh path below (mergeHydratedSession) owns updates once the
+          // version check passes.
+          const detailFresh =
+            detailGeneration === this.activeDetailGeneration;
           if (
             hydrated.id === this.activeSessionId &&
             !hydrated.is_index_only &&
-            this.activeSessionDetail?.id !== this.activeSessionId
+            this.activeSessionDetail?.id !== this.activeSessionId &&
+            detailFresh
           ) {
             this.activeSessionDetail = hydrated;
           }
@@ -623,6 +633,12 @@ class SessionsStore {
             version !== this.sidebarIndexVersion ||
             epoch !== (this.sidebarHydrationEpochByVersion.get(version) ?? 0)
           ) {
+            return;
+          }
+          // Same-version guard for the active row: a hydration issued before
+          // a newer refresh resolved must not clobber the row or the cache
+          // with its older snapshot.
+          if (hydrated.id === this.activeSessionId && !detailFresh) {
             return;
           }
           cache.set(id, hydrated);
@@ -818,6 +834,19 @@ class SessionsStore {
     return this.machinesPromise;
   }
 
+  // The generation advances only when something newer commits to (or starts
+  // a read for) active-detail state — never on plain cancellation, so a
+  // hydration joined at selection time can still seed an empty cache.
+  private beginActiveDetailRead(): AbortSignal {
+    this.activeDetailGeneration++;
+    return this.activeDetailRead.begin();
+  }
+
+  private cancelActiveDetailRead(): void {
+    this.activeDetailGeneration++;
+    this.activeDetailRead.cancel();
+  }
+
   private setActiveSession(id: string | null) {
     if (id === this.activeSessionId) return;
     this.activeDetailRead.cancel();
@@ -858,7 +887,7 @@ class SessionsStore {
       await this.hydrateSelectedIndexOnlySession(id);
       return;
     }
-    const signal = this.activeDetailRead.begin();
+    const signal = this.beginActiveDetailRead();
     try {
       configureGeneratedClient();
       const session = await callGenerated(
@@ -897,7 +926,7 @@ class SessionsStore {
   async refreshActiveSession() {
     const id = this.activeSessionId;
     if (!id) return;
-    const signal = this.activeDetailRead.begin();
+    const signal = this.beginActiveDetailRead();
     try {
       configureGeneratedClient();
       const session = await callGenerated(
@@ -933,6 +962,7 @@ class SessionsStore {
         this.activeSessionId === id &&
         this.activeDetailRead.isCurrent(signal)
       ) {
+        this.activeDetailGeneration++;
         this.activeSessionDetail = null;
       }
     } finally {
@@ -1436,7 +1466,7 @@ class SessionsStore {
     // Drop any in-flight active-detail read first: it was issued before the
     // rename and would revert the name with a pre-rename snapshot.
     if (this.activeSessionDetail?.id === id) {
-      this.activeDetailRead.cancel();
+      this.cancelActiveDetailRead();
       this.activeSessionDetail = applyRename(this.activeSessionDetail);
     }
   }

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -603,10 +603,17 @@ class SessionsStore {
             () => SessionsService.getApiV1SessionsId({ id }),
             signal,
           ) as unknown as Session;
-          // The active session's detail stays valid even if a concurrent
-          // reload superseded this hydration version: seed the cache first so
-          // the breadcrumb survives when the new index excludes the row.
-          if (hydrated.id === this.activeSessionId && !hydrated.is_index_only) {
+          // A superseded hydration still carries valid detail for the active
+          // session, so let it back the breadcrumb when the new index excludes
+          // the row — but only fill an empty cache. A stale-version response
+          // must never overwrite detail already resolved for this session by a
+          // newer request; the fresh path below (mergeHydratedSession) owns
+          // updates once the version check passes.
+          if (
+            hydrated.id === this.activeSessionId &&
+            !hydrated.is_index_only &&
+            this.activeSessionDetail?.id !== this.activeSessionId
+          ) {
             this.activeSessionDetail = hydrated;
           }
           if (
@@ -904,9 +911,12 @@ class SessionsStore {
       const idx = this.sessions.findIndex((s) => s.id === id);
       if (idx >= 0) {
         this.mergeHydratedSession(session);
-      } else if (this.activeSessionDetail?.id === id) {
-        // Active session is backed by the detail cache (not in the sidebar
-        // list); refresh the cache so metadata stays current.
+      } else {
+        // Active session is not in the sidebar list, so back it with the detail
+        // cache. Assign unconditionally (id is validated above): this both
+        // refreshes an existing cache and restores one left empty by a failed
+        // initial navigation or hydration, so watcher refreshes can recover the
+        // breadcrumb.
         this.activeSessionDetail = session;
       }
     } catch {

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -1461,12 +1461,17 @@ class SessionsStore {
     if (idx !== -1) {
       this.sessions[idx] = applyRename(this.sessions[idx]!);
     }
+    // Renaming the active session invalidates any in-flight active-detail
+    // read or hydration: both were issued before the rename and would revert
+    // the name with a pre-rename snapshot. Cancel and advance the generation
+    // even when the detail cache is empty (index-only row with hydration in
+    // flight) — the cache-population paths all check the generation.
+    if (this.activeSessionId === id) {
+      this.cancelActiveDetailRead();
+    }
     // The active session may be backed only by the detail cache (absent from
     // the sidebar list); keep its name in sync so the breadcrumb updates too.
-    // Drop any in-flight active-detail read first: it was issued before the
-    // rename and would revert the name with a pre-rename snapshot.
     if (this.activeSessionDetail?.id === id) {
-      this.cancelActiveDetailRead();
       this.activeSessionDetail = applyRename(this.activeSessionDetail);
     }
   }

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -3,10 +3,8 @@ import {
   MetadataService,
   SessionsService,
 } from "../api/generated/index";
-// Imported from core rather than the index barrel so instanceof keeps the
-// real class identity in tests that mock "../api/generated/index".
-import { ApiError as GeneratedApiError } from "../api/generated/core/ApiError";
 import {
+  ApiError,
   callGenerated,
   configureGeneratedClient,
   isAbortError,
@@ -927,9 +925,10 @@ class SessionsStore {
       // The session may have been deleted, locally or on another machine. On
       // a definitive not-found drop the cached detail so the breadcrumb
       // empties instead of showing a ghost session; transient failures keep
-      // the cache and the next watcher refresh retries.
+      // the cache and the next watcher refresh retries. callGenerated rethrows
+      // generated errors as the runtime ApiError, so match that class.
       if (
-        e instanceof GeneratedApiError &&
+        e instanceof ApiError &&
         e.status === 404 &&
         this.activeSessionId === id &&
         this.activeDetailRead.isCurrent(signal)

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -1475,13 +1475,18 @@ class SessionsStore {
     // the name with a pre-rename snapshot. Cancel and advance the generation
     // even when the detail cache is empty (index-only row with hydration in
     // flight) — the cache-population paths all check the generation.
+    // The rename response is itself a full post-rename snapshot (the endpoint
+    // reads the session back), so commit it as the active detail: an
+    // index-only or out-of-list active session whose pending read was just
+    // cancelled has nothing else to back the breadcrumb until the next
+    // watcher refresh.
     if (this.activeSessionId === id) {
       this.cancelActiveDetailRead();
-    }
-    // The active session may be backed only by the detail cache (absent from
-    // the sidebar list); keep its name in sync so the breadcrumb updates too.
-    if (this.activeSessionDetail?.id === id) {
-      this.activeSessionDetail = applyRename(this.activeSessionDetail);
+      const base =
+        this.activeSessionDetail?.id === id
+          ? this.activeSessionDetail
+          : { ...updated, is_index_only: false };
+      this.activeSessionDetail = applyRename(base);
     }
   }
 

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -335,7 +335,6 @@ class SessionsStore {
   private agentsLoaded: boolean = false;
   private agentsPromise: Promise<void> | null = null;
   private agentsVersion: number = 0;
-  private refreshVersion: number = 0;
   private childSessionsVersion: number = 0;
   private machinesLoaded: boolean = false;
   private machinesPromise: Promise<void> | null = null;
@@ -352,8 +351,11 @@ class SessionsStore {
   private sidebarLoadSignature: string | null = null;
   private sidebarAbort: AbortController | null = null;
   private routeAbort: AbortController | null = null;
-  private navigateRead = new LatestRead();
-  private refreshRead = new LatestRead();
+  // Single coordinator for every read that commits to activeSessionDetail
+  // (navigation and watcher refresh): the newest read cancels older in-flight
+  // ones, so a stale response resolving late can never overwrite fresher
+  // cached detail.
+  private activeDetailRead = new LatestRead();
   private childSessionsRead = new LatestRead();
 
   private liveRefreshStarted = false;
@@ -817,13 +819,11 @@ class SessionsStore {
 
   private setActiveSession(id: string | null) {
     if (id === this.activeSessionId) return;
-    this.navigateRead.cancel();
-    this.refreshRead.cancel();
+    this.activeDetailRead.cancel();
     this.childSessionsRead.cancel();
     this.activeSessionId = id;
     this.activeSessionDetail = null;
     this.activeSessionUsageVersion = 0;
-    this.refreshVersion++;
     this.childSessionsVersion++;
   }
 
@@ -857,14 +857,17 @@ class SessionsStore {
       await this.hydrateSelectedIndexOnlySession(id);
       return;
     }
-    const signal = this.navigateRead.begin();
+    const signal = this.activeDetailRead.begin();
     try {
       configureGeneratedClient();
       const session = await callGenerated(
         () => SessionsService.getApiV1SessionsId({ id }),
         signal,
       ) as unknown as Session;
-      if (this.activeSessionId === id && this.navigateRead.isCurrent(signal)) {
+      if (
+        this.activeSessionId === id &&
+        this.activeDetailRead.isCurrent(signal)
+      ) {
         const idx = this.sessions.findIndex((s) => s.id === id);
         if (idx >= 0) {
           this.mergeHydratedSession(session);
@@ -875,7 +878,7 @@ class SessionsStore {
     } catch {
       // Session not found — selection stands without metadata
     } finally {
-      this.navigateRead.finish(signal);
+      this.activeDetailRead.finish(signal);
     }
   }
 
@@ -893,8 +896,7 @@ class SessionsStore {
   async refreshActiveSession() {
     const id = this.activeSessionId;
     if (!id) return;
-    const version = ++this.refreshVersion;
-    const signal = this.refreshRead.begin();
+    const signal = this.activeDetailRead.begin();
     try {
       configureGeneratedClient();
       const session = await callGenerated(
@@ -902,9 +904,8 @@ class SessionsStore {
         signal,
       ) as unknown as Session;
       if (
-        this.refreshVersion !== version ||
         this.activeSessionId !== id ||
-        !this.refreshRead.isCurrent(signal)
+        !this.activeDetailRead.isCurrent(signal)
       ) {
         return;
       }
@@ -922,7 +923,7 @@ class SessionsStore {
     } catch {
       // Session may have been deleted
     } finally {
-      this.refreshRead.finish(signal);
+      this.activeDetailRead.finish(signal);
     }
   }
 
@@ -1419,7 +1420,10 @@ class SessionsStore {
     }
     // The active session may be backed only by the detail cache (absent from
     // the sidebar list); keep its name in sync so the breadcrumb updates too.
+    // Drop any in-flight active-detail read first: it was issued before the
+    // rename and would revert the name with a pre-rename snapshot.
     if (this.activeSessionDetail?.id === id) {
+      this.activeDetailRead.cancel();
       this.activeSessionDetail = applyRename(this.activeSessionDetail);
     }
   }
@@ -1490,11 +1494,9 @@ class SessionsStore {
     this.sidebarLoadSignature = null;
     this.routeAbort?.abort();
     this.routeAbort = null;
-    this.navigateRead.cancel();
-    this.refreshRead.cancel();
+    this.activeDetailRead.cancel();
     this.childSessionsRead.cancel();
     this.loadVersion++;
-    this.refreshVersion++;
     this.childSessionsVersion++;
     this.loading = false;
     this.signalDetailInflight.clear();

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -3,6 +3,9 @@ import {
   MetadataService,
   SessionsService,
 } from "../api/generated/index";
+// Imported from core rather than the index barrel so instanceof keeps the
+// real class identity in tests that mock "../api/generated/index".
+import { ApiError as GeneratedApiError } from "../api/generated/core/ApiError";
 import {
   callGenerated,
   configureGeneratedClient,
@@ -920,8 +923,19 @@ class SessionsStore {
         // breadcrumb.
         this.activeSessionDetail = session;
       }
-    } catch {
-      // Session may have been deleted
+    } catch (e) {
+      // The session may have been deleted, locally or on another machine. On
+      // a definitive not-found drop the cached detail so the breadcrumb
+      // empties instead of showing a ghost session; transient failures keep
+      // the cache and the next watcher refresh retries.
+      if (
+        e instanceof GeneratedApiError &&
+        e.status === 404 &&
+        this.activeSessionId === id &&
+        this.activeDetailRead.isCurrent(signal)
+      ) {
+        this.activeSessionDetail = null;
+      }
     } finally {
       this.activeDetailRead.finish(signal);
     }

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -2859,17 +2859,50 @@ describe("SessionsStore", () => {
       );
       await sessions.renameSession("sel", "renamed");
       expect(sessions.sessions[0]?.display_name).toBe("renamed");
+      // The rename response backs the breadcrumb: the row is still index-only
+      // and its in-flight hydration was invalidated by the rename.
+      expect(sessions.activeSession?.display_name).toBe("renamed");
 
-      // The pre-rename hydration snapshot must not overwrite the row or seed
-      // the breadcrumb cache with the old name.
+      // The pre-rename hydration snapshot must not overwrite the row or the
+      // breadcrumb cache with the old name.
       resolveHydration(
         makeSession({ id: "sel", project: "proj-a", display_name: "stale" }),
       );
       await hydration;
 
       expect(sessions.sessions[0]?.display_name).toBe("renamed");
-      expect(sessions.activeSession?.display_name).not.toBe("stale");
-      expect(sessions.activeSessionDetail?.display_name).not.toBe("stale");
+      expect(sessions.activeSession?.display_name).toBe("renamed");
+    });
+
+    it("commits the rename response when it lands during the navigation fetch", async () => {
+      mockSidebarIndex([]);
+      await sessions.load();
+
+      // Navigation fetch for an out-of-list session stays in flight, so the
+      // detail cache is still empty when the rename resolves.
+      let resolveNavigate!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveNavigate = r;
+        }),
+      );
+      const nav = sessions.navigateToSession("sel");
+      await Promise.resolve();
+
+      vi.mocked(api.renameSession).mockResolvedValue(
+        makeSession({ id: "sel", display_name: "renamed" }),
+      );
+      await sessions.renameSession("sel", "renamed");
+      expect(sessions.activeSession?.display_name).toBe("renamed");
+
+      // The cancelled pre-rename navigation response must not replace the
+      // committed rename snapshot.
+      resolveNavigate(
+        makeSession({ id: "sel", display_name: "stale" }),
+      );
+      await nav;
+
+      expect(sessions.activeSession?.display_name).toBe("renamed");
     });
 
     it("seeds the cache from a hydration already in flight at selection", async () => {

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -14,12 +14,14 @@ import {
   splitExcludeProjectParam,
 } from "./sessions.svelte.js";
 import { SessionsService } from "../api/generated/index";
-import { ApiError } from "../api/generated/core/ApiError";
 import { starred } from "./starred.svelte.js";
 import { yokedDates } from "./yokedDates.svelte.js";
 import type { Filters } from "./sessions.svelte.js";
 import type { Session } from "../api/types.js";
-import { callGenerated } from "../api/runtime.js";
+import {
+  ApiError as RuntimeApiError,
+  callGenerated,
+} from "../api/runtime.js";
 import { rollingRange } from "../utils/dates.js";
 
 const api = vi.hoisted(() => ({
@@ -62,14 +64,18 @@ vi.mock("../api/client.js", () => ({
   watchEvents: api.watchEvents,
 }));
 
-vi.mock("../api/runtime.js", () => ({
-  configureGeneratedClient: vi.fn(),
-  callGenerated: vi.fn((request: () => Promise<unknown>) => request()),
-  isAbortError: vi.fn(
-    (error: unknown) =>
-      error instanceof DOMException && error.name === "AbortError",
-  ),
-}));
+vi.mock("../api/runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../api/runtime.js")>();
+  return {
+    ...actual,
+    configureGeneratedClient: vi.fn(),
+    callGenerated: vi.fn((request: () => Promise<unknown>) => request()),
+    isAbortError: vi.fn(
+      (error: unknown) =>
+        error instanceof DOMException && error.name === "AbortError",
+    ),
+  };
+});
 
 vi.mock("../api/generated/index", () => ({
   SessionsService: {
@@ -106,13 +112,11 @@ function mockSidebarPage(
   });
 }
 
-function makeNotFoundError(id: string): ApiError {
-  const url = `/api/v1/sessions/${id}`;
-  return new ApiError(
-    { method: "GET", url },
-    { url, ok: false, status: 404, statusText: "Not Found", body: null },
-    "Not Found",
-  );
+// Store code never sees the generated ApiError class: production callGenerated
+// converts it to the runtime ApiError before rethrowing. Reject fixtures with
+// the runtime class to model that boundary faithfully.
+function makeNotFoundError(id: string): RuntimeApiError {
+  return new RuntimeApiError(404, `session ${id} not found`);
 }
 
 function rejectGeneratedRequestOnAbort(

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -2258,6 +2258,41 @@ describe("SessionsStore", () => {
 
       expect(sessions.sessions[0]!.display_name).toBe("agent-name");
     });
+
+    it("renames an active session backed only by the detail cache", async () => {
+      // Open a session that is absent from the (empty) sidebar list, so it is
+      // held solely in activeSessionDetail.
+      mockSidebarIndex([]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValue(
+        makeSession({ id: "cached", display_name: null, project: "proj-b" }),
+      );
+      await sessions.navigateToSession("cached");
+      expect(sessions.sessions.some((s) => s.id === "cached")).toBe(false);
+
+      vi.mocked(api.renameSession).mockResolvedValue(
+        makeSession({ id: "cached", display_name: "renamed-in-breadcrumb" }),
+      );
+      await sessions.renameSession("cached", "renamed-in-breadcrumb");
+
+      expect(sessions.activeSession?.display_name).toBe("renamed-in-breadcrumb");
+    });
+
+    it("clears a cache-backed active session name when the response omits it", async () => {
+      mockSidebarIndex([]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValue(
+        makeSession({ id: "cached", display_name: "custom-name" }),
+      );
+      await sessions.navigateToSession("cached");
+      expect(sessions.activeSession?.display_name).toBe("custom-name");
+
+      // Backend clears the name and omits display_name (omitempty on nil).
+      vi.mocked(api.renameSession).mockResolvedValue(makeSession({ id: "cached" }));
+      await sessions.renameSession("cached", null);
+
+      expect(sessions.activeSession?.display_name).toBeNull();
+    });
   });
 
   describe("loadProjects dedup", () => {

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -2834,6 +2834,44 @@ describe("SessionsStore", () => {
       expect(sessions.activeSession?.display_name).toBe("renamed");
     });
 
+    it("does not let an in-flight hydration revert a rename of an index-only row", async () => {
+      mockSidebarIndex([
+        makeSkinnyRow({ id: "sel", project: "proj-a", display_name: "stale" }),
+      ]);
+      await sessions.load();
+
+      // Hydration of the index-only row stays in flight while the user
+      // selects it (selection joins the request) and renames it. The detail
+      // cache is still empty at rename time, so the rename must advance the
+      // freshness generation without relying on a populated cache.
+      let resolveHydration!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveHydration = r;
+        }),
+      );
+      const hydration = sessions.hydrateVisibleSessions(["sel"]);
+      await Promise.resolve();
+      sessions.selectSession("sel");
+
+      vi.mocked(api.renameSession).mockResolvedValue(
+        makeSession({ id: "sel", display_name: "renamed" }),
+      );
+      await sessions.renameSession("sel", "renamed");
+      expect(sessions.sessions[0]?.display_name).toBe("renamed");
+
+      // The pre-rename hydration snapshot must not overwrite the row or seed
+      // the breadcrumb cache with the old name.
+      resolveHydration(
+        makeSession({ id: "sel", project: "proj-a", display_name: "stale" }),
+      );
+      await hydration;
+
+      expect(sessions.sessions[0]?.display_name).toBe("renamed");
+      expect(sessions.activeSession?.display_name).not.toBe("stale");
+      expect(sessions.activeSessionDetail?.display_name).not.toBe("stale");
+    });
+
     it("seeds the cache from a hydration already in flight at selection", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -2982,6 +2982,28 @@ describe("SessionsStore", () => {
       expect(sessions.activeSession).toBeUndefined();
     });
 
+    it("drops a hydrated sidebar row when a refresh 404s for the active session", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "gone", project: "proj-a" })]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "gone", project: "proj-a", first_message: "detail" }),
+      );
+      await sessions.hydrateVisibleSessions(["gone"]);
+      sessions.selectSession("gone");
+      expect(sessions.activeSession?.first_message).toBe("detail");
+      expect(sessions.total).toBe(1);
+
+      // The session is deleted elsewhere; a refresh 404s. Clearing only the
+      // detail cache is not enough — the hydrated sidebar row would keep
+      // backing activeSession as a ghost of the deleted session.
+      vi.mocked(api.getSession).mockRejectedValueOnce(makeNotFoundError("gone"));
+      await sessions.refreshActiveSession();
+
+      expect(sessions.activeSession).toBeUndefined();
+      expect(sessions.sessions.some((s) => s.id === "gone")).toBe(false);
+      expect(sessions.total).toBe(0);
+    });
+
     it("keeps the cached detail when a refresh fails transiently", async () => {
       mockSidebarIndex([]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -2475,8 +2475,10 @@ describe("SessionsStore", () => {
       resolveGet(makeSession({ id: "new-id" }));
       await promise;
 
-      expect(sessions.sessions).toHaveLength(1);
-      expect(sessions.sessions[0]!.id).toBe("new-id");
+      // The out-of-list session backs activeSession via the detail cache
+      // without being injected into the (filtered) sidebar collection.
+      expect(sessions.sessions).toHaveLength(0);
+      expect(sessions.activeSession?.id).toBe("new-id");
     });
 
     it("skips fetch for already-loaded session", async () => {
@@ -2548,8 +2550,9 @@ describe("SessionsStore", () => {
 
     it("keeps a search-navigated out-of-index session across a sidebar reload", async () => {
       // Sidebar is filtered so the searched session never appears in the
-      // index. Opening it from search fetches and appends it; a later index
-      // reload (route/filter re-evaluation) must not drop the open session.
+      // index. Opening it from search backs activeSession via the detail
+      // cache; a later index reload (route/filter re-evaluation) must not drop
+      // the open session, and the session must not leak into the sidebar list.
       mockSidebarIndex([makeSkinnyRow({ id: "in-index", project: "proj-a" })]);
       await sessions.load();
 
@@ -2562,6 +2565,7 @@ describe("SessionsStore", () => {
       );
       await sessions.navigateToSession("searched");
       expect(sessions.activeSession?.project).toBe("proj-b");
+      expect(sessions.sessions.some((s) => s.id === "searched")).toBe(false);
 
       // The filtered index still excludes the searched session.
       mockSidebarIndex([makeSkinnyRow({ id: "in-index", project: "proj-a" })]);
@@ -2569,6 +2573,38 @@ describe("SessionsStore", () => {
 
       expect(sessions.activeSessionId).toBe("searched");
       expect(sessions.activeSession?.project).toBe("proj-b");
+      // Not conflated with the filtered sidebar collection.
+      expect(sessions.sessions.map((s) => s.id)).toEqual(["in-index"]);
+    });
+
+    it("does not duplicate an active session that appears on a later page", async () => {
+      // Page 1 of the filtered index omits the active session; it lives on a
+      // later page reachable through loadMore. Backing it via the detail cache
+      // (not the sidebar list) means the later page appends it exactly once.
+      vi.mocked(api.getSidebarSessionIndex)
+        .mockResolvedValueOnce({
+          sessions: [makeSkinnyRow({ id: "page1" })],
+          total: 2,
+          next_cursor: "cursor-2",
+        })
+        .mockResolvedValueOnce({
+          sessions: [makeSkinnyRow({ id: "later", project: "proj-b" })],
+          total: 2,
+          next_cursor: null,
+        });
+      await sessions.load();
+
+      vi.mocked(api.getSession).mockResolvedValue(
+        makeSession({ id: "later", project: "proj-b", first_message: "from search" }),
+      );
+      await sessions.navigateToSession("later");
+      expect(sessions.activeSession?.id).toBe("later");
+      expect(sessions.sessions.some((s) => s.id === "later")).toBe(false);
+
+      await sessions.loadMore();
+
+      expect(sessions.sessions.filter((s) => s.id === "later")).toHaveLength(1);
+      expect(sessions.activeSession?.id).toBe("later");
     });
   });
 

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -2662,6 +2662,60 @@ describe("SessionsStore", () => {
       expect(sessions.activeSessionId).toBe("sel");
       expect(sessions.activeSession?.project).toBe("proj-a");
     });
+
+    it("keeps a keyboard-navigated session across an excluding reload", async () => {
+      mockSidebarIndex([
+        makeSkinnyRow({ id: "a", project: "proj-a" }),
+        makeSkinnyRow({ id: "b", project: "proj-a" }),
+      ]);
+      vi.mocked(api.getSession).mockImplementation((id: string) =>
+        Promise.resolve(
+          makeSession({ id, project: "proj-a", first_message: `${id}-detail` }),
+        ),
+      );
+      await sessions.load();
+      sessions.selectSession("a");
+      await vi.waitFor(() => expect(sessions.activeSession?.id).toBe("a"));
+
+      // Keyboard next moves to "b" via navigateSession, not selectSession.
+      sessions.navigateSession(1);
+      await vi.waitFor(() => expect(sessions.activeSession?.id).toBe("b"));
+
+      // A reload excludes the keyboard-navigated session.
+      mockSidebarIndex([makeSkinnyRow({ id: "c", project: "proj-b" })]);
+      await sessions.load();
+
+      expect(sessions.activeSessionId).toBe("b");
+      expect(sessions.activeSession?.id).toBe("b");
+    });
+
+    it("caches an index-only selection even when a reload supersedes hydration", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
+      await sessions.load();
+
+      // Hydration request stays in flight until after the reload below.
+      let resolveGet!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValue(
+        new Promise<Session>((r) => {
+          resolveGet = r;
+        }),
+      );
+      sessions.selectSession("sel");
+      await Promise.resolve();
+
+      // A reload bumps the sidebar index version and drops "sel".
+      mockSidebarIndex([makeSkinnyRow({ id: "other", project: "proj-b" })]);
+      await sessions.load();
+
+      // The superseded hydration resolves; its version is stale for the list
+      // but the active-session cache must still capture it.
+      resolveGet(makeSession({ id: "sel", project: "proj-a", first_message: "detail" }));
+      await vi.waitFor(() => {
+        expect(sessions.activeSession?.project).toBe("proj-a");
+      });
+
+      expect(sessions.activeSessionId).toBe("sel");
+    });
   });
 
   describe("route cancellation", () => {

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -2716,6 +2716,45 @@ describe("SessionsStore", () => {
 
       expect(sessions.activeSessionId).toBe("sel");
     });
+
+    it("does not let a superseded hydration overwrite fresher active detail", async () => {
+      // Active session backed by fresh cache via a navigation fetch.
+      mockSidebarIndex([]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", project: "proj-a", first_message: "FRESH" }),
+      );
+      await sessions.navigateToSession("sel");
+      expect(sessions.activeSession?.first_message).toBe("FRESH");
+
+      // A superseded (older-version) hydration resolves for the same id; its
+      // version check fails, so it must not replace the newer cached detail.
+      const staleVersion = (sessions as any).sidebarIndexVersion - 1;
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", project: "proj-a", first_message: "STALE" }),
+      );
+      await (sessions as any).hydrateVisibleSessions(["sel"], staleVersion);
+
+      expect(sessions.activeSession?.first_message).toBe("FRESH");
+    });
+
+    it("restores an empty out-of-list active cache on refresh", async () => {
+      // Initial navigation fetch fails, leaving activeSession undefined.
+      mockSidebarIndex([]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockRejectedValueOnce(new Error("fetch failed"));
+      await sessions.navigateToSession("gone");
+      expect(sessions.activeSessionId).toBe("gone");
+      expect(sessions.activeSession).toBeUndefined();
+
+      // A watcher-driven refresh succeeds and must populate the empty cache.
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "gone", project: "proj-b", first_message: "restored" }),
+      );
+      await sessions.refreshActiveSession();
+
+      expect(sessions.activeSession?.first_message).toBe("restored");
+    });
   });
 
   describe("route cancellation", () => {

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -2755,6 +2755,71 @@ describe("SessionsStore", () => {
 
       expect(sessions.activeSession?.first_message).toBe("restored");
     });
+
+    it("ignores a stale navigation response resolving after a newer refresh", async () => {
+      mockSidebarIndex([]);
+      await sessions.load();
+
+      // Navigation fetch for an out-of-list session stays in flight...
+      let resolveNavigate!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveNavigate = r;
+        }),
+      );
+      const nav = sessions.navigateToSession("sel");
+      await Promise.resolve();
+
+      // ...while a watcher-driven refresh for the same session resolves
+      // first with a fresher snapshot.
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", project: "proj-a", first_message: "NEWER" }),
+      );
+      await sessions.refreshActiveSession();
+      expect(sessions.activeSession?.first_message).toBe("NEWER");
+
+      // The older navigation response must not clobber the newer detail.
+      resolveNavigate(
+        makeSession({ id: "sel", project: "proj-a", first_message: "OLDER" }),
+      );
+      await nav;
+
+      expect(sessions.activeSession?.first_message).toBe("NEWER");
+    });
+
+    it("does not let a pre-rename refresh response revert a rename", async () => {
+      mockSidebarIndex([]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", display_name: null, first_message: "detail" }),
+      );
+      await sessions.navigateToSession("sel");
+
+      // Refresh fetch carrying a pre-rename snapshot stays in flight...
+      let resolveRefresh!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveRefresh = r;
+        }),
+      );
+      const refresh = sessions.refreshActiveSession();
+      await Promise.resolve();
+
+      // ...while a rename completes and updates the cached detail.
+      vi.mocked(api.renameSession).mockResolvedValue(
+        makeSession({ id: "sel", display_name: "renamed" }),
+      );
+      await sessions.renameSession("sel", "renamed");
+      expect(sessions.activeSession?.display_name).toBe("renamed");
+
+      resolveRefresh(
+        makeSession({ id: "sel", display_name: null, first_message: "detail" }),
+      );
+      await refresh;
+
+      expect(sessions.activeSession?.display_name).toBe("renamed");
+    });
+
   });
 
   describe("route cancellation", () => {

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -14,6 +14,7 @@ import {
   splitExcludeProjectParam,
 } from "./sessions.svelte.js";
 import { SessionsService } from "../api/generated/index";
+import { ApiError } from "../api/generated/core/ApiError";
 import { starred } from "./starred.svelte.js";
 import { yokedDates } from "./yokedDates.svelte.js";
 import type { Filters } from "./sessions.svelte.js";
@@ -103,6 +104,15 @@ function mockSidebarPage(
     total: 0,
     ...overrides,
   });
+}
+
+function makeNotFoundError(id: string): ApiError {
+  const url = `/api/v1/sessions/${id}`;
+  return new ApiError(
+    { method: "GET", url },
+    { url, ok: false, status: 404, statusText: "Not Found", body: null },
+    "Not Found",
+  );
 }
 
 function rejectGeneratedRequestOnAbort(
@@ -2820,6 +2830,38 @@ describe("SessionsStore", () => {
       expect(sessions.activeSession?.display_name).toBe("renamed");
     });
 
+    it("clears the cached detail when the active session was deleted", async () => {
+      mockSidebarIndex([]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "gone", project: "proj-b", first_message: "detail" }),
+      );
+      await sessions.navigateToSession("gone");
+      expect(sessions.activeSession?.id).toBe("gone");
+
+      // The session is deleted elsewhere; a watcher-driven refresh 404s. The
+      // breadcrumb must empty rather than keep showing the ghost session.
+      vi.mocked(api.getSession).mockRejectedValueOnce(makeNotFoundError("gone"));
+      await sessions.refreshActiveSession();
+
+      expect(sessions.activeSession).toBeUndefined();
+    });
+
+    it("keeps the cached detail when a refresh fails transiently", async () => {
+      mockSidebarIndex([]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "flaky", project: "proj-b", first_message: "detail" }),
+      );
+      await sessions.navigateToSession("flaky");
+
+      // A non-404 failure (server restart, network) must not blank the
+      // breadcrumb; only a definitive not-found may clear the cache.
+      vi.mocked(api.getSession).mockRejectedValueOnce(new Error("network down"));
+      await sessions.refreshActiveSession();
+
+      expect(sessions.activeSession?.first_message).toBe("detail");
+    });
   });
 
   describe("route cancellation", () => {

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -2834,6 +2834,70 @@ describe("SessionsStore", () => {
       expect(sessions.activeSession?.display_name).toBe("renamed");
     });
 
+    it("seeds the cache from a hydration already in flight at selection", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
+      await sessions.load();
+
+      // Viewport hydration of the row is already in flight when the user
+      // selects it; selection joins that request rather than issuing a new
+      // one, so its response must still hydrate the row and seed the cache.
+      let resolveHydration!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveHydration = r;
+        }),
+      );
+      const hydration = sessions.hydrateVisibleSessions(["sel"]);
+      await Promise.resolve();
+      sessions.selectSession("sel");
+
+      resolveHydration(
+        makeSession({ id: "sel", project: "proj-a", first_message: "detail" }),
+      );
+      await hydration;
+
+      expect(api.getSession).toHaveBeenCalledTimes(1);
+      expect(sessions.activeSession?.first_message).toBe("detail");
+
+      // The seeded cache must survive a reload that drops the row.
+      mockSidebarIndex([makeSkinnyRow({ id: "other", project: "proj-b" })]);
+      await sessions.load();
+      expect(sessions.activeSession?.first_message).toBe("detail");
+    });
+
+    it("ignores a stale hydration resolving after a newer refresh", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
+      await sessions.load();
+
+      // Hydration of the visible row stays in flight...
+      let resolveHydration!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveHydration = r;
+        }),
+      );
+      const hydration = sessions.hydrateVisibleSessions(["sel"]);
+      await Promise.resolve();
+
+      // ...the user selects that row, and a watcher-driven refresh resolves
+      // first with a fresher snapshot for both the row and the cache.
+      sessions.selectSession("sel");
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", project: "proj-a", first_message: "NEWER" }),
+      );
+      await sessions.refreshActiveSession();
+      expect(sessions.activeSession?.first_message).toBe("NEWER");
+
+      // The older hydration passes the sidebar version/epoch checks (no
+      // reload happened) but must not clobber the newer active detail.
+      resolveHydration(
+        makeSession({ id: "sel", project: "proj-a", first_message: "STALE" }),
+      );
+      await hydration;
+
+      expect(sessions.activeSession?.first_message).toBe("NEWER");
+    });
+
     it("clears the cached detail when the active session was deleted", async () => {
       mockSidebarIndex([]);
       await sessions.load();
@@ -2847,6 +2911,35 @@ describe("SessionsStore", () => {
       // breadcrumb must empty rather than keep showing the ghost session.
       vi.mocked(api.getSession).mockRejectedValueOnce(makeNotFoundError("gone"));
       await sessions.refreshActiveSession();
+
+      expect(sessions.activeSession).toBeUndefined();
+    });
+
+    it("does not let an in-flight hydration resurrect a deleted session", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "gone", project: "proj-a" })]);
+      await sessions.load();
+
+      let resolveHydration!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveHydration = r;
+        }),
+      );
+      const hydration = sessions.hydrateVisibleSessions(["gone"]);
+      await Promise.resolve();
+      sessions.selectSession("gone");
+
+      // The session is deleted elsewhere; a refresh 404s and clears the
+      // cache while the hydration response is still in flight.
+      vi.mocked(api.getSession).mockRejectedValueOnce(makeNotFoundError("gone"));
+      await sessions.refreshActiveSession();
+      expect(sessions.activeSession).toBeUndefined();
+
+      // The pre-deletion hydration snapshot must not refill the cache.
+      resolveHydration(
+        makeSession({ id: "gone", project: "proj-a", first_message: "ghost" }),
+      );
+      await hydration;
 
       expect(sessions.activeSession).toBeUndefined();
     });

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -2545,6 +2545,31 @@ describe("SessionsStore", () => {
         "fetched during navigation",
       );
     });
+
+    it("keeps a search-navigated out-of-index session across a sidebar reload", async () => {
+      // Sidebar is filtered so the searched session never appears in the
+      // index. Opening it from search fetches and appends it; a later index
+      // reload (route/filter re-evaluation) must not drop the open session.
+      mockSidebarIndex([makeSkinnyRow({ id: "in-index", project: "proj-a" })]);
+      await sessions.load();
+
+      vi.mocked(api.getSession).mockResolvedValue(
+        makeSession({
+          id: "searched",
+          project: "proj-b",
+          first_message: "opened from search",
+        }),
+      );
+      await sessions.navigateToSession("searched");
+      expect(sessions.activeSession?.project).toBe("proj-b");
+
+      // The filtered index still excludes the searched session.
+      mockSidebarIndex([makeSkinnyRow({ id: "in-index", project: "proj-a" })]);
+      await sessions.load();
+
+      expect(sessions.activeSessionId).toBe("searched");
+      expect(sessions.activeSession?.project).toBe("proj-b");
+    });
   });
 
   describe("route cancellation", () => {

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -2641,6 +2641,27 @@ describe("SessionsStore", () => {
       expect(sessions.sessions.filter((s) => s.id === "later")).toHaveLength(1);
       expect(sessions.activeSession?.id).toBe("later");
     });
+
+    it("keeps a sidebar-selected session across a reload that filters it out", async () => {
+      // Select a hydrated sidebar row, then reload with a filtered index that
+      // no longer includes it. The breadcrumb must not go blank.
+      mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
+      vi.mocked(api.getSession).mockResolvedValue(
+        makeSession({ id: "sel", project: "proj-a", first_message: "detail" }),
+      );
+      await sessions.load();
+      await sessions.hydrateVisibleSessions(["sel"]);
+      expect(sessions.sessions[0]!.is_index_only).toBe(false);
+
+      sessions.selectSession("sel");
+      expect(sessions.activeSession?.id).toBe("sel");
+
+      mockSidebarIndex([makeSkinnyRow({ id: "other", project: "proj-b" })]);
+      await sessions.load();
+
+      expect(sessions.activeSessionId).toBe("sel");
+      expect(sessions.activeSession?.project).toBe("proj-a");
+    });
   });
 
   describe("route cancellation", () => {


### PR DESCRIPTION
Fixes #1190.

Opening a session from search (`navigateToSession`) appends it to the sidebar list even when it falls outside the active sidebar filters — search ignores those filters. The subsequent index reload (`load()`, triggered by route/filter re-evaluation) rebuilt `this.sessions` from the filtered index alone, so the out-of-filter session was dropped. `activeSession` then resolved to `undefined` and the `SessionBreadcrumb` lost its project name, session name, and badges, which is what the reporter saw when opening a search result rather than a recent session.

`load()` now preserves the previously resolved active-session row when the new index omits it, mirroring the append behavior `navigateToSession` already relies on for out-of-index sessions. The row is only re-added when it was a fully hydrated session (not an index-only stub) and is not already present in the new index, so filtered sidebar contents and ordering are otherwise unchanged.

Reviewers: the change is confined to `load()` in `frontend/src/lib/stores/sessions.svelte.ts`; the getter it feeds is `activeSession`, and the affected consumer is `SessionBreadcrumb.svelte` via `App.svelte`.