### PR TITLE
fix(frontend): preserve project name when opening search sessions

### DIFF
--- a/frontend/e2e/navigation.spec.ts
+++ b/frontend/e2e/navigation.spec.ts
@@ -31,6 +31,43 @@ test.describe("Navigation", () => {
     await expect(sp.exportBtn).toContainText("Export CSV");
   });
 
+  test("search result for an unlisted session keeps the breadcrumb project (#1190)", async ({ page }) => {
+    // The target stays off the sidebar index page, as with a paginated
+    // or filtered index in production. Search still finds it; opening
+    // the result hydrates it by ID, and the index reload that entering
+    // the sessions route triggers must not drop the hydrated row after
+    // the detail fetch lands.
+    const sessionId = "test-session-duration-subagent-1";
+    await page.goto("/usage");
+    await page.route("**/api/v1/sessions/sidebar-index**", async (route) => {
+      const response = await route.fetch();
+      const body = await response.json();
+      body.sessions = body.sessions.filter(
+        (s: { id: string }) => s.id !== sessionId,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      await route.fulfill({ response, json: body });
+    });
+
+    await page.keyboard.press("ControlOrMeta+k");
+    const input = page.locator(".palette-input");
+    await expect(input).toBeVisible();
+    await input.fill("synchronous DB read");
+
+    const result = page.locator(".palette-item", {
+      hasText: "synchronous DB read",
+    }).first();
+    await expect(result).toBeVisible();
+    const indexReloaded = page.waitForResponse("**/api/v1/sessions/sidebar-index**");
+    await result.click();
+
+    await expect(page).toHaveURL(new RegExp(`/sessions/${sessionId}`));
+    await indexReloaded;
+    await expect(page.locator(".breadcrumb-current")).toHaveText(
+      /project-duration/,
+    );
+  });
+
   test("subagent cost rollup", async ({ page }, testInfo) => {
     await page.route("**/api/v1/sessions/*/usage**", async (route) => {
       const rollup = new URL(route.request().url()).searchParams.get("rollup");

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -451,13 +451,18 @@
   });
 
   // Deep-link: clear the selection when the URL drops its session.
-  // Tracks only the URL so local selection changes (which sync to
-  // the URL in a later effect) cannot trigger a spurious deselect.
+  // Tracks the route alongside the session id: entering bare /sessions
+  // from a non-session page leaves the id null both sides, so a
+  // session-id-only dependency would not rerun and a stale active
+  // session would keep showing instead of the list. Route is
+  // authoritative URL state that local selection does not mutate, so
+  // tracking it cannot trigger a spurious deselect.
   $effect(() => {
     const sid = router.sessionId;
+    const route = router.route;
     untrack(() => {
       if (
-        !sid && router.route === "sessions" &&
+        !sid && route === "sessions" &&
         sessions.activeSessionId !== null
       ) {
         sessions.deselectSession();

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -137,14 +137,17 @@
         return;
       }
       // Preserve selection when a pending scroll is queued
-      // for this specific session (e.g. search result
-      // navigation sets session + ordinal before this effect
-      // fires). Clear if the pending scroll targets a
-      // different session or there is no pending scroll.
+      // for this specific session. Route-first navigation
+      // (search results, insight evidence) queues ordinal +
+      // URL before the deep-link effect selects the target,
+      // so match the routed session as well as the active one.
+      // Clear if the pending scroll targets a different
+      // session or there is no pending scroll.
       const pendingMatchesSession =
         ui.pendingScrollOrdinal !== null &&
         (ui.pendingScrollSession === null ||
-          ui.pendingScrollSession === id);
+          ui.pendingScrollSession === id ||
+          ui.pendingScrollSession === router.sessionId);
       if (!pendingMatchesSession) {
         ui.clearSelection();
         ui.pendingScrollOrdinal = null;
@@ -410,32 +413,67 @@
     });
   });
 
-  // Deep-link: select session from URL and handle ?msg param.
+  // Deep-link: select and hydrate the routed session. Tracking
+  // activeSession (not just the URL) makes hydration self-healing:
+  // if a sidebar reload rebuilds the list mid-flight and the routed
+  // row is lost or reverts to index-only, this re-fires and
+  // re-hydrates. Refires caused by session-state changes (rather
+  // than a URL change) act only while the routed session is still
+  // the active one, so a newer local selection that has not synced
+  // to the URL yet is never snapped back. navigateToSession dedupes
+  // in-flight requests, and a failed fetch changes no tracked
+  // state, so this cannot loop.
+  let lastRoutedSessionId: string | null = null;
+  $effect(() => {
+    const sid = router.sessionId;
+    const hydrated = sessions.activeSession !== undefined;
+    untrack(() => {
+      if (!sid) {
+        lastRoutedSessionId = null;
+        return;
+      }
+      const sidChanged = sid !== lastRoutedSessionId;
+      lastRoutedSessionId = sid;
+      if (sidChanged) {
+        if (sid !== sessions.activeSessionId || !hydrated) {
+          void sessions.navigateToSession(sid);
+        }
+      } else if (sid === sessions.activeSessionId && !hydrated) {
+        void sessions.navigateToSession(sid);
+      }
+    });
+  });
+
+  // Deep-link: clear the selection when the URL drops its session.
+  // Tracks only the URL so local selection changes (which sync to
+  // the URL in a later effect) cannot trigger a spurious deselect.
+  $effect(() => {
+    const sid = router.sessionId;
+    untrack(() => {
+      if (
+        !sid && router.route === "sessions" &&
+        sessions.activeSessionId !== null
+      ) {
+        sessions.deselectSession();
+      }
+    });
+  });
+
+  // Deep-link: apply the ?msg param. Kept separate from the
+  // hydration effect above so scroll intent is not re-applied
+  // every time hydration state changes.
   $effect(() => {
     const sid = router.sessionId;
     const msgParam = router.params["msg"] ?? null;
     untrack(() => {
-      if (sid) {
-        if (
-          sid !== sessions.activeSessionId ||
-          sessions.activeSession === undefined
-        ) {
-          sessions.navigateToSession(sid);
-        }
-        if (msgParam) {
-          if (msgParam === "last") {
-            ui.pendingScrollOrdinal = -1;
-            ui.pendingScrollSession = sid;
-          } else {
-            const ordinal = parseInt(msgParam, 10);
-            if (Number.isFinite(ordinal)) {
-              ui.scrollToOrdinal(ordinal, sid);
-            }
-          }
-        }
-      } else if (router.route === "sessions") {
-        if (sessions.activeSessionId !== null) {
-          sessions.deselectSession();
+      if (!sid || !msgParam) return;
+      if (msgParam === "last") {
+        ui.pendingScrollOrdinal = -1;
+        ui.pendingScrollSession = sid;
+      } else {
+        const ordinal = parseInt(msgParam, 10);
+        if (Number.isFinite(ordinal)) {
+          ui.scrollToOrdinal(ordinal, sid);
         }
       }
     });

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -123,10 +123,13 @@
   // Load active session's messages when selection changes.
   // Only track activeSessionId — untrack the rest to prevent
   // reactive loops from messages.loading / messages.messages.
+  let lastMessageLoadSessionId: string | null = null;
   $effect(() => {
     const route = router.route;
     const id = sessions.activeSessionId;
     untrack(() => {
+      const idChanged = id !== lastMessageLoadSessionId;
+      lastMessageLoadSessionId = id;
       if (route !== "sessions") {
         sessions.cancelRouteReads();
         messages.cancelInFlight();
@@ -140,14 +143,17 @@
       // for this specific session. Route-first navigation
       // (search results, insight evidence) queues ordinal +
       // URL before the deep-link effect selects the target,
-      // so match the routed session as well as the active one.
+      // so also match the routed session — but only when this
+      // run wasn't triggered by a local selection change,
+      // otherwise a stale URL would preserve the previous
+      // navigation's intent across the user's new selection.
       // Clear if the pending scroll targets a different
       // session or there is no pending scroll.
       const pendingMatchesSession =
         ui.pendingScrollOrdinal !== null &&
         (ui.pendingScrollSession === null ||
           ui.pendingScrollSession === id ||
-          ui.pendingScrollSession === router.sessionId);
+          (!idChanged && ui.pendingScrollSession === router.sessionId));
       if (!pendingMatchesSession) {
         ui.clearSelection();
         ui.pendingScrollOrdinal = null;

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -185,6 +185,115 @@ describe("App session URL date state", () => {
     expect(navigateToSession).toHaveBeenCalledTimes(2);
   });
 
+  it("keeps route-first search scroll intent when entering the sessions route", async () => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    vi.spyOn(settings, "load").mockResolvedValue();
+    vi.spyOn(starred, "load").mockResolvedValue();
+    vi.spyOn(sync, "loadStatus").mockResolvedValue();
+    vi.spyOn(sync, "loadStats").mockResolvedValue();
+    vi.spyOn(sync, "loadVersion").mockResolvedValue();
+    vi.spyOn(sync, "checkForUpdate").mockResolvedValue();
+    vi.spyOn(sync, "startPolling").mockImplementation(() => {});
+    vi.spyOn(sync, "watchSession").mockImplementation(() => {});
+    vi.spyOn(sessions, "load").mockResolvedValue();
+    vi.spyOn(sessions, "loadProjects").mockResolvedValue();
+    vi.spyOn(sessions, "loadAgents").mockResolvedValue();
+    vi.spyOn(sessions, "attachSidebar").mockReturnValue(() => {});
+    vi.spyOn(sessions, "loadChildSessions").mockResolvedValue();
+    vi.spyOn(messages, "loadSession").mockResolvedValue();
+    vi.spyOn(sessionTiming, "load").mockResolvedValue();
+    vi.spyOn(pins, "loadForSession").mockResolvedValue();
+    vi.spyOn(usage, "fetchAll").mockResolvedValue();
+    const navigateToSession = vi
+      .spyOn(sessions, "navigateToSession")
+      .mockResolvedValue();
+
+    router.route = "usage";
+    component = mount(App, { target: document.body });
+    await flushEffects();
+
+    // Route-first search activation: URL and scroll intent are queued
+    // before the deep-link effect selects the target session.
+    router.navigateToSession("session-2");
+    ui.scrollToOrdinal(7, "session-2");
+    await flushEffects();
+
+    expect(navigateToSession).toHaveBeenCalledWith("session-2");
+    expect(ui.pendingScrollOrdinal).toBe(7);
+    expect(ui.pendingScrollSession).toBe("session-2");
+  });
+
+  it("rehydrates the routed session when a sidebar rebuild drops its row", async () => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    vi.spyOn(settings, "load").mockResolvedValue();
+    vi.spyOn(starred, "load").mockResolvedValue();
+    vi.spyOn(sync, "loadStatus").mockResolvedValue();
+    vi.spyOn(sync, "loadStats").mockResolvedValue();
+    vi.spyOn(sync, "loadVersion").mockResolvedValue();
+    vi.spyOn(sync, "checkForUpdate").mockResolvedValue();
+    vi.spyOn(sync, "startPolling").mockImplementation(() => {});
+    vi.spyOn(sync, "watchSession").mockImplementation(() => {});
+    vi.spyOn(sessions, "load").mockResolvedValue();
+    vi.spyOn(sessions, "loadProjects").mockResolvedValue();
+    vi.spyOn(sessions, "loadAgents").mockResolvedValue();
+    vi.spyOn(sessions, "attachSidebar").mockReturnValue(() => {});
+    vi.spyOn(sessions, "loadChildSessions").mockResolvedValue();
+    vi.spyOn(messages, "loadSession").mockResolvedValue();
+    vi.spyOn(sessionTiming, "load").mockResolvedValue();
+    vi.spyOn(pins, "loadForSession").mockResolvedValue();
+    vi.spyOn(usage, "fetchAll").mockResolvedValue();
+    const navigateToSession = vi
+      .spyOn(sessions, "navigateToSession")
+      .mockResolvedValue();
+
+    sessions.sessions = [
+      {
+        id: "session-1",
+        project: "proj-a",
+        machine: "local",
+        agent: "claude",
+        first_message: "hello",
+        started_at: "2026-02-20T12:30:00Z",
+        ended_at: "2026-02-20T12:31:00Z",
+        message_count: 2,
+        user_message_count: 1,
+        total_output_tokens: 0,
+        peak_context_tokens: 0,
+        has_total_output_tokens: false,
+        has_peak_context_tokens: false,
+        is_automated: false,
+        is_teammate: false,
+        is_index_only: false,
+        created_at: "2026-02-20T12:30:00Z",
+      } as unknown as (typeof sessions.sessions)[number],
+    ];
+    sessions.activeSessionId = "session-1";
+    router.route = "sessions";
+    router.sessionId = "session-1";
+    component = mount(App, { target: document.body });
+    await flushEffects();
+    expect(navigateToSession).not.toHaveBeenCalled();
+
+    sessions.sessions = [];
+    await flushEffects();
+
+    expect(navigateToSession).toHaveBeenCalledWith("session-1");
+  });
+
   it("treats rolling window and termination as sessions route params", () => {
     expect(SESSION_FILTER_KEYS.has("window_days")).toBe(true);
     expect(SESSION_FILTER_KEYS.has("termination")).toBe(true);

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -185,6 +185,55 @@ describe("App session URL date state", () => {
     expect(navigateToSession).toHaveBeenCalledTimes(2);
   });
 
+  it("clears a stale active session entering /sessions from a non-session page (#1190)", async () => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    vi.spyOn(settings, "load").mockResolvedValue();
+    vi.spyOn(starred, "load").mockResolvedValue();
+    vi.spyOn(sync, "loadStatus").mockResolvedValue();
+    vi.spyOn(sync, "loadStats").mockResolvedValue();
+    vi.spyOn(sync, "loadVersion").mockResolvedValue();
+    vi.spyOn(sync, "checkForUpdate").mockResolvedValue();
+    vi.spyOn(sync, "startPolling").mockImplementation(() => {});
+    vi.spyOn(sync, "watchSession").mockImplementation(() => {});
+    vi.spyOn(sessions, "load").mockResolvedValue();
+    vi.spyOn(sessions, "loadProjects").mockResolvedValue();
+    vi.spyOn(sessions, "loadAgents").mockResolvedValue();
+    vi.spyOn(sessions, "attachSidebar").mockReturnValue(() => {});
+    vi.spyOn(sessions, "loadChildSessions").mockResolvedValue();
+    vi.spyOn(messages, "loadSession").mockResolvedValue();
+    vi.spyOn(sessionTiming, "load").mockResolvedValue();
+    vi.spyOn(pins, "loadForSession").mockResolvedValue();
+    vi.spyOn(usage, "fetchAll").mockResolvedValue();
+    vi.spyOn(sessions, "navigateToSession").mockResolvedValue();
+
+    router.route = "sessions";
+    router.sessionId = "session-1";
+    sessions.activeSessionId = "session-1";
+    component = mount(App, { target: document.body });
+    await flushEffects();
+
+    // Leave for a non-session page: the URL drops the session id but the
+    // deselect guard only clears on the sessions route, so the active
+    // session is intentionally preserved here.
+    router.navigate("usage");
+    await flushEffects();
+    expect(sessions.activeSessionId).toBe("session-1");
+
+    // Enter the bare sessions list. The session id stays null across this
+    // transition, so a session-id-only dependency would not rerun; tracking
+    // the route makes the effect fire and clear the stale selection.
+    router.navigate("sessions");
+    await flushEffects();
+    expect(sessions.activeSessionId).toBeNull();
+  });
+
   it("keeps route-first search scroll intent when entering the sessions route", async () => {
     vi.stubGlobal(
       "ResizeObserver",

--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -230,6 +230,53 @@ describe("App session URL date state", () => {
     expect(ui.pendingScrollSession).toBe("session-2");
   });
 
+  it("clears stale route-first scroll intent when the user selects another session", async () => {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    vi.spyOn(settings, "load").mockResolvedValue();
+    vi.spyOn(starred, "load").mockResolvedValue();
+    vi.spyOn(sync, "loadStatus").mockResolvedValue();
+    vi.spyOn(sync, "loadStats").mockResolvedValue();
+    vi.spyOn(sync, "loadVersion").mockResolvedValue();
+    vi.spyOn(sync, "checkForUpdate").mockResolvedValue();
+    vi.spyOn(sync, "startPolling").mockImplementation(() => {});
+    vi.spyOn(sync, "watchSession").mockImplementation(() => {});
+    vi.spyOn(sessions, "load").mockResolvedValue();
+    vi.spyOn(sessions, "loadProjects").mockResolvedValue();
+    vi.spyOn(sessions, "loadAgents").mockResolvedValue();
+    vi.spyOn(sessions, "attachSidebar").mockReturnValue(() => {});
+    vi.spyOn(sessions, "loadChildSessions").mockResolvedValue();
+    vi.spyOn(messages, "loadSession").mockResolvedValue();
+    vi.spyOn(sessionTiming, "load").mockResolvedValue();
+    vi.spyOn(pins, "loadForSession").mockResolvedValue();
+    vi.spyOn(usage, "fetchAll").mockResolvedValue();
+    vi.spyOn(sessions, "navigateToSession").mockResolvedValue();
+
+    router.route = "sessions";
+    component = mount(App, { target: document.body });
+    await flushEffects();
+
+    // Route-first navigation to B queues its scroll intent; B's
+    // hydration never lands (mocked), so the URL still names B when
+    // the user selects C from the sidebar.
+    router.navigateToSession("session-b");
+    ui.scrollToOrdinal(7, "session-b");
+    await flushEffects();
+    expect(ui.pendingScrollOrdinal).toBe(7);
+
+    sessions.activeSessionId = "session-c";
+    await flushEffects();
+
+    expect(ui.pendingScrollOrdinal).toBeNull();
+    expect(ui.pendingScrollSession).toBeNull();
+  });
+
   it("rehydrates the routed session when a sidebar rebuild drops its row", async () => {
     vi.stubGlobal(
       "ResizeObserver",

--- a/frontend/src/lib/components/command-palette/CommandPalette.svelte
+++ b/frontend/src/lib/components/command-palette/CommandPalette.svelte
@@ -160,14 +160,18 @@
     }
   }
 
+  // Route-first: commit the URL and let App's deep-link effect own
+  // selection and hydration, exactly as a direct deep link does.
+  // Selecting through the sessions store before the route commits
+  // starts hydration under the old route, where it can be cancelled
+  // or lost (#1190).
   function selectSession(s: Session) {
-    sessions.selectSession(s.id);
     router.navigateToSession(s.id);
     close();
   }
 
   function selectSearchResult(r: PaletteSearchResult) {
-    void sessions.navigateToSession(r.session_id);
+    router.navigateToSession(r.session_id);
     if (r.ordinal !== -1) {
       ui.scrollToOrdinal(r.ordinal, r.session_id);
     } else {
@@ -175,7 +179,6 @@
       // previously highlighted ordinal is not left active.
       ui.clearScrollState();
     }
-    router.navigateToSession(r.session_id);
     close();
   }
 

--- a/frontend/src/lib/components/command-palette/CommandPalette.test.ts
+++ b/frontend/src/lib/components/command-palette/CommandPalette.test.ts
@@ -42,8 +42,6 @@ const {
         created_at: string;
       }>,
       filters: { project: "" },
-      selectSession: vi.fn(),
-      navigateToSession: vi.fn(),
       deselectSession: vi.fn(),
     },
     mockSearchStore: {
@@ -286,7 +284,7 @@ describe("CommandPalette", () => {
     unmount(component);
   });
 
-  it("name-only result (ordinal === -1) hydrates session and clears selection without scrolling", async () => {
+  it("name-only result (ordinal === -1) routes and clears selection without scrolling", async () => {
     mockSearchStore.results = [
       makeSearchResult({
         session_id: "claude:nameonly123",
@@ -307,8 +305,6 @@ describe("CommandPalette", () => {
     item.click();
     await tick();
 
-    expect(mockSessions.selectSession).not.toHaveBeenCalled();
-    expect(mockSessions.navigateToSession).toHaveBeenCalledWith("claude:nameonly123");
     expect(mockRouter.navigateToSession).toHaveBeenCalledWith("claude:nameonly123");
     expect(mockUi.scrollToOrdinal).not.toHaveBeenCalled();
     expect(mockUi.clearScrollState).toHaveBeenCalled();
@@ -364,10 +360,22 @@ describe("CommandPalette", () => {
     item.click();
     await tick();
 
-    expect(mockSessions.selectSession).not.toHaveBeenCalled();
-    expect(mockSessions.navigateToSession).toHaveBeenCalledWith("codex:search123");
-    expect(mockUi.scrollToOrdinal).toHaveBeenCalledWith(7, "codex:search123");
     expect(mockRouter.navigateToSession).toHaveBeenCalledWith("codex:search123");
+    expect(mockUi.scrollToOrdinal).toHaveBeenCalledWith(7, "codex:search123");
+
+    unmount(component);
+  });
+
+  it("recent result click routes to the session and closes the palette", async () => {
+    const component = mount(CommandPalette, { target: document.body });
+    await tick();
+
+    const item = await tickUntil(".palette-item");
+    item.click();
+    await tick();
+
+    expect(mockRouter.navigateToSession).toHaveBeenCalledWith("s1");
+    expect(mockUi.activeModal).toBeNull();
 
     unmount(component);
   });
@@ -425,7 +433,6 @@ describe("CommandPalette", () => {
     expect(mockSearchStore.setMode).toHaveBeenNthCalledWith(1, "semantic");
     expect(mockSearchStore.setMode).toHaveBeenNthCalledWith(2, "semantic");
     expect(mockSearchStore.retry).not.toHaveBeenCalled();
-    expect(mockSessions.navigateToSession).not.toHaveBeenCalled();
     expect(mockRouter.navigateToSession).not.toHaveBeenCalled();
 
     radios[0]?.dispatchEvent(
@@ -474,7 +481,6 @@ describe("CommandPalette", () => {
 
       expect(mockSearchStore.retry).toHaveBeenCalledOnce();
       expect(mockSearchStore.setMode).not.toHaveBeenCalled();
-      expect(mockSessions.navigateToSession).not.toHaveBeenCalled();
       expect(mockRouter.navigateToSession).not.toHaveBeenCalled();
 
       unmount(component);

--- a/frontend/src/lib/components/insights/InsightsPage.svelte
+++ b/frontend/src/lib/components/insights/InsightsPage.svelte
@@ -459,11 +459,12 @@
   ) {
     event.preventDefault();
     const params = evidenceSessionParams(example);
+    // Route-first: App's deep-link effect owns selection and
+    // hydration once the URL commits (#1190).
+    router.navigateToSession(example.session_id, params);
     if (example.message_ordinal != null) {
       ui.scrollToOrdinal(example.message_ordinal, example.session_id);
     }
-    sessions.navigateToSession(example.session_id);
-    router.navigateToSession(example.session_id, params);
   }
 
   function openEvidenceListSession(event: MouseEvent) {

--- a/frontend/src/lib/components/insights/InsightsPage.test.ts
+++ b/frontend/src/lib/components/insights/InsightsPage.test.ts
@@ -740,7 +740,6 @@ describe("InsightsPage evidence navigation", () => {
     await flushEffects();
 
     expect(scrollToOrdinal).toHaveBeenCalledWith(23, "second-session");
-    expect(mocks.navigateToSession).toHaveBeenCalledWith("second-session");
     expect(routeToSession).toHaveBeenCalledWith("second-session", {
       msg: "23",
     });

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -526,6 +526,17 @@ class SessionsStore {
       this.sessions = index.sessions.map((row) =>
         sidebarIndexRowToSession(row, existing.get(row.id))
       );
+      // Keep the active session's hydrated row when the new index
+      // page doesn't contain it: navigateToSession appends deep-linked,
+      // cross-page, and subagent targets, and dropping them here would
+      // revert activeSession to undefined mid-view.
+      const activeId = this.activeSessionId;
+      if (activeId && !this.sessions.some((s) => s.id === activeId)) {
+        const kept = existing.get(activeId);
+        if (kept && !kept.is_index_only) {
+          this.sessions = [...this.sessions, kept];
+        }
+      }
       this.nextCursor = index.next_cursor ?? null;
       this.total = index.total;
     } catch {
@@ -803,11 +814,20 @@ class SessionsStore {
     void this.hydrateSelectedIndexOnlySession(id);
   }
 
+  private navigateInFlight: { id: string; promise: Promise<void> } | null =
+    null;
+
   /**
    * Navigate to a session by ID, loading it into the sessions list if
    * not already present (e.g. subagent sessions filtered from groups).
+   * Re-invocations for the same still-active session join the in-flight
+   * fetch instead of restarting it, so reactive callers can re-request
+   * hydration without duplicating requests.
    */
   async navigateToSession(id: string) {
+    if (this.navigateInFlight?.id === id && this.activeSessionId === id) {
+      return this.navigateInFlight.promise;
+    }
     this.setActiveSession(id);
     const existing = this.sessions.find((s) => s.id === id);
     if (existing) {
@@ -815,25 +835,35 @@ class SessionsStore {
       return;
     }
     const signal = this.navigateRead.begin();
-    try {
-      configureGeneratedClient();
-      const session = await callGenerated(
-        () => SessionsService.getApiV1SessionsId({ id }),
-        signal,
-      ) as unknown as Session;
-      if (this.activeSessionId === id && this.navigateRead.isCurrent(signal)) {
-        const idx = this.sessions.findIndex((s) => s.id === id);
-        if (idx >= 0) {
-          this.mergeHydratedSession(session);
-        } else {
-          this.sessions = [...this.sessions, session];
+    const entry = { id, promise: Promise.resolve() };
+    entry.promise = (async () => {
+      try {
+        configureGeneratedClient();
+        const session = await callGenerated(
+          () => SessionsService.getApiV1SessionsId({ id }),
+          signal,
+        ) as unknown as Session;
+        if (
+          this.activeSessionId === id && this.navigateRead.isCurrent(signal)
+        ) {
+          const idx = this.sessions.findIndex((s) => s.id === id);
+          if (idx >= 0) {
+            this.mergeHydratedSession(session);
+          } else {
+            this.sessions = [...this.sessions, session];
+          }
+        }
+      } catch {
+        // Session not found — selection stands without metadata
+      } finally {
+        this.navigateRead.finish(signal);
+        if (this.navigateInFlight === entry) {
+          this.navigateInFlight = null;
         }
       }
-    } catch {
-      // Session not found — selection stands without metadata
-    } finally {
-      this.navigateRead.finish(signal);
-    }
+    })();
+    this.navigateInFlight = entry;
+    return entry.promise;
   }
 
   private async hydrateSelectedIndexOnlySession(id: string) {

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -526,10 +526,13 @@ class SessionsStore {
       this.sessions = index.sessions.map((row) =>
         sidebarIndexRowToSession(row, existing.get(row.id))
       );
+      this.sidebarIndexIds = new Set(index.sessions.map((row) => row.id));
       // Keep the active session's hydrated row when the new index
       // page doesn't contain it: navigateToSession appends deep-linked,
       // cross-page, and subagent targets, and dropping them here would
-      // revert activeSession to undefined mid-view.
+      // revert activeSession to undefined mid-view. It stays outside
+      // sidebarIndexIds, so later pages keep it at the tail until
+      // pagination reaches its real position.
       const activeId = this.activeSessionId;
       if (activeId && !this.sessions.some((s) => s.id === activeId)) {
         const kept = existing.get(activeId);
@@ -555,6 +558,10 @@ class SessionsStore {
   }
 
   sidebarIndexVersion: number = $state(0);
+  // Session ids supplied by the loaded sidebar index pages; rows in
+  // this.sessions outside this set were appended out of position
+  // (see loadSidebarPage / loadMore).
+  private sidebarIndexIds: Set<string> = new Set();
   hydratedSessionsByVersion: Map<number, Map<string, Session>> =
     $state(new Map());
 
@@ -680,21 +687,30 @@ class SessionsStore {
         signal,
       ) as unknown as SidebarSessionIndexResponse;
       if (this.loadVersion !== version) return;
-      // Drop rows the incoming page supersedes: the active session's
-      // hydrated row is re-appended out of position by loadSidebarPage
-      // when its index page isn't loaded yet, and must move to its
-      // real position (carrying its hydrated fields) when pagination
-      // reaches it, not duplicate.
-      const incoming = new Set(index.sessions.map((row) => row.id));
-      const kept = this.sessions.filter((s) => !incoming.has(s.id));
+      // Merge index-page order first, appended rows last. Rows outside
+      // sidebarIndexIds were appended out of position (the active
+      // session kept by loadSidebarPage, navigateToSession targets);
+      // they stay at the tail until pagination reaches their real
+      // position, then merge in place carrying their hydrated fields.
       const existingById = new Map(
         this.sessions.map((session) => [session.id, session]),
       );
+      for (const row of index.sessions) {
+        this.sidebarIndexIds.add(row.id);
+      }
+      const paged = this.sessions.filter(
+        (s) => this.sidebarIndexIds.has(s.id) &&
+          !index.sessions.some((row) => row.id === s.id),
+      );
+      const appended = this.sessions.filter(
+        (s) => !this.sidebarIndexIds.has(s.id),
+      );
       this.sessions = [
-        ...kept,
+        ...paged,
         ...index.sessions.map((row) =>
           sidebarIndexRowToSession(row, existingById.get(row.id))
         ),
+        ...appended,
       ];
       this.nextCursor = index.next_cursor ?? null;
       this.total = index.total;

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -680,13 +680,22 @@ class SessionsStore {
         signal,
       ) as unknown as SidebarSessionIndexResponse;
       if (this.loadVersion !== version) return;
-      this.sessions.push(
-        ...index.sessions.map((row) =>
-          sidebarIndexRowToSession(row, this.sessions.find(
-            (existing) => existing.id === row.id,
-          ))
-        ),
+      // Drop rows the incoming page supersedes: the active session's
+      // hydrated row is re-appended out of position by loadSidebarPage
+      // when its index page isn't loaded yet, and must move to its
+      // real position (carrying its hydrated fields) when pagination
+      // reaches it, not duplicate.
+      const incoming = new Set(index.sessions.map((row) => row.id));
+      const kept = this.sessions.filter((s) => !incoming.has(s.id));
+      const existingById = new Map(
+        this.sessions.map((session) => [session.id, session]),
       );
+      this.sessions = [
+        ...kept,
+        ...index.sessions.map((row) =>
+          sidebarIndexRowToSession(row, existingById.get(row.id))
+        ),
+      ];
       this.nextCursor = index.next_cursor ?? null;
       this.total = index.total;
     } catch (error) {

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -751,6 +751,32 @@ describe("SessionsStore", () => {
       );
     });
 
+    it("keeps the active appended row when the reloaded index omits it", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "listed" })]);
+      vi.mocked(api.getSession).mockResolvedValue(
+        makeSession({
+          id: "offpage",
+          first_message: "hydrated offpage detail",
+        }),
+      );
+
+      await sessions.load();
+      await sessions.navigateToSession("offpage");
+      expect(sessions.activeSession?.first_message).toBe(
+        "hydrated offpage detail",
+      );
+
+      await sessions.load();
+
+      expect(sessions.sessions.map((s) => s.id)).toEqual([
+        "listed",
+        "offpage",
+      ]);
+      expect(sessions.activeSession?.first_message).toBe(
+        "hydrated offpage detail",
+      );
+    });
+
     it("refreshes hydrated agent identity fields from the sidebar index", async () => {
       mockSidebarIndex([
         makeSkinnyRow({

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -797,12 +797,26 @@ describe("SessionsStore", () => {
         "offpage",
       ]);
 
+      // A page that doesn't contain the appended row keeps it at the
+      // tail, preserving index order for keyboard navigation.
+      vi.mocked(api.getSidebarSessionIndex).mockResolvedValueOnce({
+        sessions: [makeSkinnyRow({ id: "middle" })],
+        total: 4,
+        next_cursor: "page-3",
+      });
+      await sessions.loadMore();
+      expect(sessions.sessions.map((s) => s.id)).toEqual([
+        "listed",
+        "middle",
+        "offpage",
+      ]);
+
       vi.mocked(api.getSidebarSessionIndex).mockResolvedValueOnce({
         sessions: [
-          makeSkinnyRow({ id: "middle" }),
           makeSkinnyRow({ id: "offpage" }),
+          makeSkinnyRow({ id: "last" }),
         ],
-        total: 3,
+        total: 4,
         next_cursor: null,
       });
       await sessions.loadMore();
@@ -811,6 +825,7 @@ describe("SessionsStore", () => {
         "listed",
         "middle",
         "offpage",
+        "last",
       ]);
       expect(sessions.activeSession?.first_message).toBe(
         "hydrated offpage detail",

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -777,6 +777,46 @@ describe("SessionsStore", () => {
       );
     });
 
+    it("moves the appended active row into place when pagination reaches it", async () => {
+      vi.mocked(api.getSidebarSessionIndex).mockResolvedValueOnce({
+        sessions: [makeSkinnyRow({ id: "listed" })],
+        total: 2,
+        next_cursor: "page-2",
+      });
+      vi.mocked(api.getSession).mockResolvedValue(
+        makeSession({
+          id: "offpage",
+          first_message: "hydrated offpage detail",
+        }),
+      );
+
+      await sessions.load();
+      await sessions.navigateToSession("offpage");
+      expect(sessions.sessions.map((s) => s.id)).toEqual([
+        "listed",
+        "offpage",
+      ]);
+
+      vi.mocked(api.getSidebarSessionIndex).mockResolvedValueOnce({
+        sessions: [
+          makeSkinnyRow({ id: "middle" }),
+          makeSkinnyRow({ id: "offpage" }),
+        ],
+        total: 3,
+        next_cursor: null,
+      });
+      await sessions.loadMore();
+
+      expect(sessions.sessions.map((s) => s.id)).toEqual([
+        "listed",
+        "middle",
+        "offpage",
+      ]);
+      expect(sessions.activeSession?.first_message).toBe(
+        "hydrated offpage detail",
+      );
+    });
+
     it("refreshes hydrated agent identity fields from the sidebar index", async () => {
       mockSidebarIndex([
         makeSkinnyRow({


### PR DESCRIPTION
Opening a command-palette message-search result can leave the session breadcrumb without its project or display name. The palette selected the session through the sessions store before committing the route, and a target absent from the current sidebar index page loses its hydrated row when the index reload rebuilds the list, with nothing re-establishing it afterward.

This makes session opening route-first and hydration self-healing. The palette's search and recent results and the insights evidence links now commit the URL and let App's deep-link effect own selection and hydration, exactly as direct deep links do; that effect now tracks the routed session's hydration state, so a sidebar reload that drops or de-hydrates the routed row triggers a re-fetch. The sidebar rebuild keeps the active session's hydrated row when the incoming index page omits it, and pagination moves that row into its real position instead of duplicating it; `navigateToSession` joins an in-flight fetch for the same session instead of restarting it. Direct deep links, sidebar clicks, keyboard navigation, and `?msg` handling keep their current paths, and route exit still cancels all session-route reads unconditionally.

A Playwright regression drives the real palette flow against an index page that omits the target; it fails on the previous ordering with an empty breadcrumb and passes with this change. The interaction steps came from @tekumara's issue report.

![Hydrated search-result breadcrumb](https://raw.githubusercontent.com/rodboev/agentsview/screenshots/agentsview-1190-after.png)

Closes #1190
