### PR TITLE
fix(parser): namespace Trae session identities

### DIFF
--- a/cmd/agentsview/archive_query_backend.go
+++ b/cmd/agentsview/archive_query_backend.go
@@ -243,9 +243,12 @@ func (b localArchiveQueryBackend) SessionUsage(
 	applyCustomPricing(b.database, b.cfg)
 	ensureUsagePricing(b.database, b.offline, b.cfg.CustomModelPricing)
 
-	resolvedID, known := resolveRawSessionID(
+	resolvedID, known, err := resolveRawSessionIDDetailed(
 		ctx, b.database, b.cfg.AgentDirs, sessionID,
 	)
+	if err != nil {
+		return nil, tokenUseExitErr, err
+	}
 
 	if known && !b.skipFreshData {
 		engine := sync.NewEngine(b.database, sync.EngineConfig{

--- a/cmd/agentsview/session_get.go
+++ b/cmd/agentsview/session_get.go
@@ -119,20 +119,25 @@ var traeSessionLookupNamespaces = []string{
 func resolveTraeRawSuffixAmbiguity(id string, matches []string) error {
 	workspaceID := string(parser.AgentTrae) + ":workspaceStorage:" + id
 	globalID := string(parser.AgentTrae) + ":globalStorage:" + id
-	hasWorkspace := false
-	hasGlobal := false
+	workspaceMatch := ""
+	globalMatch := ""
 	for _, match := range matches {
-		switch match {
+		_, stripped := parser.StripHostPrefix(match)
+		switch stripped {
 		case workspaceID:
-			hasWorkspace = true
+			if workspaceMatch == "" {
+				workspaceMatch = match
+			}
 		case globalID:
-			hasGlobal = true
+			if globalMatch == "" {
+				globalMatch = match
+			}
 		}
 	}
-	if hasWorkspace && hasGlobal {
+	if workspaceMatch != "" && globalMatch != "" {
 		return fmt.Errorf(
 			"session %s is ambiguous; use %s or %s",
-			id, workspaceID, globalID,
+			id, workspaceMatch, globalMatch,
 		)
 	}
 	return nil

--- a/cmd/agentsview/session_get.go
+++ b/cmd/agentsview/session_get.go
@@ -213,6 +213,9 @@ func resolveTraeNamespacedSessionID(
 	if match == "" {
 		matches, err := svc.FindSessionIDsByPartial(ctx, id, 64)
 		if err != nil {
+			if strings.Contains(err.Error(), "http: not found") {
+				return "", nil, false
+			}
 			return "", err, true
 		}
 		filtered := make([]string, 0, len(matches))

--- a/cmd/agentsview/session_get.go
+++ b/cmd/agentsview/session_get.go
@@ -64,6 +64,18 @@ func resolveServiceSessionID(
 	if detail != nil {
 		return id, nil
 	}
+	if hostPrefix, legacyRaw, ok := splitLegacyTraeSessionID(id); ok {
+		candidate, err, known := resolveTraeNamespacedSessionID(
+			ctx, svc, hostPrefix, legacyRaw,
+		)
+		if err != nil {
+			return "", err
+		}
+		if known {
+			return candidate, nil
+		}
+		return "", fmt.Errorf("session not found: %s", id)
+	}
 	// If the user already supplied a known agent-prefixed ID or
 	// a host-prefixed remote ID ("host~..."), don't second-guess
 	// them — the exact lookup is authoritative. Some raw IDs
@@ -73,7 +85,7 @@ func resolveServiceSessionID(
 	if isCanonicalServiceSessionID(id) {
 		return "", fmt.Errorf("session not found: %s", id)
 	}
-	traeCandidate, traeErr, traeKnown := resolveTraeBareSessionID(
+	traeCandidate, traeErr, traeKnown := resolveTraeNamespacedSessionID(
 		ctx, svc, id,
 	)
 	if traeErr != nil {
@@ -116,6 +128,24 @@ var traeSessionLookupNamespaces = []string{
 	"globalStorage",
 }
 
+func splitLegacyTraeSessionID(id string) (string, string, bool) {
+	host, stripped := parser.StripHostPrefix(id)
+	if !strings.HasPrefix(stripped, "trae:") ||
+		strings.HasPrefix(stripped, "trae:workspaceStorage:") ||
+		strings.HasPrefix(stripped, "trae:globalStorage:") {
+		return "", "", false
+	}
+	raw := strings.TrimPrefix(stripped, "trae:")
+	raw = strings.TrimPrefix(raw, "trae:")
+	if raw == "" {
+		return "", "", false
+	}
+	if host == "" {
+		return "", raw, true
+	}
+	return host + "~", raw, true
+}
+
 func resolveTraeRawSuffixAmbiguity(id string, matches []string) error {
 	workspaceID := string(parser.AgentTrae) + ":workspaceStorage:" + id
 	globalID := string(parser.AgentTrae) + ":globalStorage:" + id
@@ -143,17 +173,28 @@ func resolveTraeRawSuffixAmbiguity(id string, matches []string) error {
 	return nil
 }
 
-// resolveTraeBareSessionID restores bare-ID lookup for namespaced Trae
-// sessions when exactly one namespace matches, and rejects the ambiguous
-// dual-match case so callers do not silently pick a namespace.
-func resolveTraeBareSessionID(
+// resolveTraeNamespacedSessionID restores raw and legacy-canonical lookup for
+// namespaced Trae sessions when exactly one namespace matches, and rejects the
+// ambiguous dual-match case so callers do not silently pick a namespace.
+func resolveTraeNamespacedSessionID(
 	ctx context.Context,
 	svc service.SessionService,
-	id string,
+	args ...string,
 ) (string, error, bool) {
+	hostPrefix := ""
+	id := ""
+	switch len(args) {
+	case 1:
+		id = args[0]
+	case 2:
+		hostPrefix = args[0]
+		id = args[1]
+	default:
+		return "", fmt.Errorf("invalid trae session lookup"), true
+	}
 	var match string
 	for _, ns := range traeSessionLookupNamespaces {
-		candidate := string(parser.AgentTrae) + ":" + ns + ":" + id
+		candidate := hostPrefix + string(parser.AgentTrae) + ":" + ns + ":" + id
 		detail, err := svc.Get(ctx, candidate)
 		if err != nil {
 			return "", err, true
@@ -163,8 +204,8 @@ func resolveTraeBareSessionID(
 		}
 		if match != "" {
 			return "", fmt.Errorf(
-				"session %s is ambiguous; use trae:workspaceStorage:%s or trae:globalStorage:%s",
-				id, id, id,
+				"session %s is ambiguous; use %strae:workspaceStorage:%s or %strae:globalStorage:%s",
+				id, hostPrefix, id, hostPrefix, id,
 			), true
 		}
 		match = candidate

--- a/cmd/agentsview/session_get.go
+++ b/cmd/agentsview/session_get.go
@@ -73,6 +73,12 @@ func resolveServiceSessionID(
 	if isCanonicalServiceSessionID(id) {
 		return "", fmt.Errorf("session not found: %s", id)
 	}
+	traeCandidate, traeErr, traeKnown := resolveTraeBareSessionID(
+		ctx, svc, id,
+	)
+	if traeErr != nil {
+		return "", traeErr
+	}
 	for _, def := range parser.Registry {
 		if def.IDPrefix == "" {
 			continue
@@ -85,6 +91,9 @@ func resolveServiceSessionID(
 		if detail != nil {
 			return candidate, nil
 		}
+	}
+	if traeKnown {
+		return traeCandidate, nil
 	}
 	return "", fmt.Errorf("session not found: %s", id)
 }
@@ -100,6 +109,65 @@ func isCanonicalServiceSessionID(id string) bool {
 		}
 	}
 	return false
+}
+
+var traeSessionLookupNamespaces = []string{
+	"workspaceStorage",
+	"globalStorage",
+}
+
+func resolveTraeRawSuffixAmbiguity(id string, matches []string) error {
+	workspaceID := string(parser.AgentTrae) + ":workspaceStorage:" + id
+	globalID := string(parser.AgentTrae) + ":globalStorage:" + id
+	hasWorkspace := false
+	hasGlobal := false
+	for _, match := range matches {
+		switch match {
+		case workspaceID:
+			hasWorkspace = true
+		case globalID:
+			hasGlobal = true
+		}
+	}
+	if hasWorkspace && hasGlobal {
+		return fmt.Errorf(
+			"session %s is ambiguous; use %s or %s",
+			id, workspaceID, globalID,
+		)
+	}
+	return nil
+}
+
+// resolveTraeBareSessionID restores bare-ID lookup for namespaced Trae
+// sessions when exactly one namespace matches, and rejects the ambiguous
+// dual-match case so callers do not silently pick a namespace.
+func resolveTraeBareSessionID(
+	ctx context.Context,
+	svc service.SessionService,
+	id string,
+) (string, error, bool) {
+	var match string
+	for _, ns := range traeSessionLookupNamespaces {
+		candidate := string(parser.AgentTrae) + ":" + ns + ":" + id
+		detail, err := svc.Get(ctx, candidate)
+		if err != nil {
+			return "", err, true
+		}
+		if detail == nil {
+			continue
+		}
+		if match != "" {
+			return "", fmt.Errorf(
+				"session %s is ambiguous; use trae:workspaceStorage:%s or trae:globalStorage:%s",
+				id, id, id,
+			), true
+		}
+		match = candidate
+	}
+	if match == "" {
+		return "", nil, false
+	}
+	return match, nil, true
 }
 
 // lookupSessionWithPrefixes fetches a session detail, trying agent

--- a/cmd/agentsview/session_get.go
+++ b/cmd/agentsview/session_get.go
@@ -211,7 +211,29 @@ func resolveTraeNamespacedSessionID(
 		match = candidate
 	}
 	if match == "" {
-		return "", nil, false
+		matches, err := svc.FindSessionIDsByPartial(ctx, id, 64)
+		if err != nil {
+			return "", err, true
+		}
+		filtered := make([]string, 0, len(matches))
+		for _, candidate := range matches {
+			if hostPrefix != "" && !strings.HasPrefix(candidate, hostPrefix) {
+				continue
+			}
+			_, stripped := parser.StripHostPrefix(candidate)
+			switch stripped {
+			case string(parser.AgentTrae) + ":workspaceStorage:" + id,
+				string(parser.AgentTrae) + ":globalStorage:" + id:
+				filtered = append(filtered, candidate)
+			}
+		}
+		if len(filtered) == 0 {
+			return "", nil, false
+		}
+		if err := resolveTraeRawSuffixAmbiguity(id, filtered); err != nil {
+			return "", err, true
+		}
+		return filtered[0], nil, true
 	}
 	return match, nil, true
 }

--- a/cmd/agentsview/session_test.go
+++ b/cmd/agentsview/session_test.go
@@ -1677,11 +1677,11 @@ func TestSessionUsage_PGFlagRejectsAmbiguousTraeNamespaces(t *testing.T) {
 	rawID := "collision"
 	pgDB := dbtest.OpenTestDBAt(t, filepath.Join(dataDir, "pg.db"))
 	seedUsageSession(t, pgDB,
-		"trae:workspaceStorage:"+rawID,
+		"laptop~trae:workspaceStorage:"+rawID,
 		"pg-project", string(parser.AgentTrae), 84,
 	)
 	seedUsageSession(t, pgDB,
-		"trae:globalStorage:"+rawID,
+		"desktop~trae:globalStorage:"+rawID,
 		"pg-project", string(parser.AgentTrae), 84,
 	)
 	seedUsageSession(t, pgDB,
@@ -1698,8 +1698,8 @@ func TestSessionUsage_PGFlagRejectsAmbiguousTraeNamespaces(t *testing.T) {
 	assert.Nil(t, out)
 	assert.Equal(t, tokenUseExitErr, code)
 	assert.Contains(t, err.Error(), "ambiguous")
-	assert.Contains(t, err.Error(), "trae:workspaceStorage:"+rawID)
-	assert.Contains(t, err.Error(), "trae:globalStorage:"+rawID)
+	assert.Contains(t, err.Error(), "laptop~trae:workspaceStorage:"+rawID)
+	assert.Contains(t, err.Error(), "desktop~trae:globalStorage:"+rawID)
 }
 
 // TestSessionSync_UnknownID_ReportsNoFilePath verifies that the

--- a/cmd/agentsview/session_test.go
+++ b/cmd/agentsview/session_test.go
@@ -411,6 +411,21 @@ func TestSessionGetVariants(t *testing.T) {
 			project: "proj",
 			mut:     func(s *db.Session) { s.Agent = "amp" },
 		},
+		sessionSeed{
+			id:      "laptop~trae:workspaceStorage:remote-collision",
+			project: "proj",
+			mut:     func(s *db.Session) { s.Agent = string(parser.AgentTrae) },
+		},
+		sessionSeed{
+			id:      "desktop~trae:globalStorage:remote-collision",
+			project: "proj",
+			mut:     func(s *db.Session) { s.Agent = string(parser.AgentTrae) },
+		},
+		sessionSeed{
+			id:      "amp:remote-collision",
+			project: "proj",
+			mut:     func(s *db.Session) { s.Agent = "amp" },
+		},
 	)
 
 	t.Run("json format", func(t *testing.T) {
@@ -497,6 +512,17 @@ func TestSessionGetVariants(t *testing.T) {
 		assert.Contains(t, err.Error(), "ambiguous")
 		assert.Contains(t, err.Error(), "trae:workspaceStorage:collision")
 		assert.Contains(t, err.Error(), "trae:globalStorage:collision")
+	})
+
+	t.Run("bare trae id rejects ambiguous remote namespaces", func(t *testing.T) {
+		_, err := executeCommand(newRootCommand(),
+			"session", "get", "remote-collision", "--format", "json")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ambiguous")
+		assert.Contains(t, err.Error(),
+			"laptop~trae:workspaceStorage:remote-collision")
+		assert.Contains(t, err.Error(),
+			"desktop~trae:globalStorage:remote-collision")
 	})
 }
 

--- a/cmd/agentsview/session_test.go
+++ b/cmd/agentsview/session_test.go
@@ -391,6 +391,26 @@ func TestSessionGetVariants(t *testing.T) {
 			project: "proj",
 			mut:     func(s *db.Session) { s.Agent = "codex" },
 		},
+		sessionSeed{
+			id:      "trae:workspaceStorage:rewrite",
+			project: "proj",
+			mut:     func(s *db.Session) { s.Agent = string(parser.AgentTrae) },
+		},
+		sessionSeed{
+			id:      "trae:workspaceStorage:collision",
+			project: "proj",
+			mut:     func(s *db.Session) { s.Agent = string(parser.AgentTrae) },
+		},
+		sessionSeed{
+			id:      "trae:globalStorage:collision",
+			project: "proj",
+			mut:     func(s *db.Session) { s.Agent = string(parser.AgentTrae) },
+		},
+		sessionSeed{
+			id:      "amp:collision",
+			project: "proj",
+			mut:     func(s *db.Session) { s.Agent = "amp" },
+		},
 	)
 
 	t.Run("json format", func(t *testing.T) {
@@ -441,6 +461,24 @@ func TestSessionGetVariants(t *testing.T) {
 
 		got := decodeCLIJSON[map[string]any](t, out)
 		assert.Equal(t, "codex:"+bareID, got["id"])
+	})
+
+	t.Run("bare trae id finds single namespaced session", func(t *testing.T) {
+		out, err := executeCommand(newRootCommand(),
+			"session", "get", "rewrite", "--format", "json")
+		require.NoError(t, err)
+
+		got := decodeCLIJSON[map[string]any](t, out)
+		assert.Equal(t, "trae:workspaceStorage:rewrite", got["id"])
+	})
+
+	t.Run("bare trae id rejects ambiguous namespaces", func(t *testing.T) {
+		_, err := executeCommand(newRootCommand(),
+			"session", "get", "collision", "--format", "json")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ambiguous")
+		assert.Contains(t, err.Error(), "trae:workspaceStorage:collision")
+		assert.Contains(t, err.Error(), "trae:globalStorage:collision")
 	})
 }
 
@@ -1630,6 +1668,38 @@ func TestSessionUsage_PGFlagResolvesColonBearingRawSessionID(t *testing.T) {
 	assert.Equal(t, storedID, out.SessionID)
 	assert.Equal(t, "pg-project", out.Project)
 	assert.Equal(t, 84, out.TotalOutputTokens)
+}
+
+func TestSessionUsage_PGFlagRejectsAmbiguousTraeNamespaces(t *testing.T) {
+	dataDir := newAgentDataDir(t)
+	t.Setenv("AGENTSVIEW_PG_URL", "postgres://example.test/agentsview")
+
+	rawID := "collision"
+	pgDB := dbtest.OpenTestDBAt(t, filepath.Join(dataDir, "pg.db"))
+	seedUsageSession(t, pgDB,
+		"trae:workspaceStorage:"+rawID,
+		"pg-project", string(parser.AgentTrae), 84,
+	)
+	seedUsageSession(t, pgDB,
+		"trae:globalStorage:"+rawID,
+		"pg-project", string(parser.AgentTrae), 84,
+	)
+	seedUsageSession(t, pgDB,
+		"amp:"+rawID,
+		"pg-project", "amp", 84,
+	)
+
+	stubPGReadStore(t, pgDB)
+
+	cmd := sessionUsageCommand(t, "session", "usage", rawID, "--pg")
+
+	out, code, err := sessionUsageDataForCommand(cmd, rawID)
+	require.Error(t, err)
+	assert.Nil(t, out)
+	assert.Equal(t, tokenUseExitErr, code)
+	assert.Contains(t, err.Error(), "ambiguous")
+	assert.Contains(t, err.Error(), "trae:workspaceStorage:"+rawID)
+	assert.Contains(t, err.Error(), "trae:globalStorage:"+rawID)
 }
 
 // TestSessionSync_UnknownID_ReportsNoFilePath verifies that the

--- a/cmd/agentsview/session_test.go
+++ b/cmd/agentsview/session_test.go
@@ -472,9 +472,27 @@ func TestSessionGetVariants(t *testing.T) {
 		assert.Equal(t, "trae:workspaceStorage:rewrite", got["id"])
 	})
 
+	t.Run("legacy trae id resolves to namespaced session", func(t *testing.T) {
+		out, err := executeCommand(newRootCommand(),
+			"session", "get", "trae:rewrite", "--format", "json")
+		require.NoError(t, err)
+
+		got := decodeCLIJSON[map[string]any](t, out)
+		assert.Equal(t, "trae:workspaceStorage:rewrite", got["id"])
+	})
+
 	t.Run("bare trae id rejects ambiguous namespaces", func(t *testing.T) {
 		_, err := executeCommand(newRootCommand(),
 			"session", "get", "collision", "--format", "json")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ambiguous")
+		assert.Contains(t, err.Error(), "trae:workspaceStorage:collision")
+		assert.Contains(t, err.Error(), "trae:globalStorage:collision")
+	})
+
+	t.Run("legacy trae id rejects ambiguous namespaces", func(t *testing.T) {
+		_, err := executeCommand(newRootCommand(),
+			"session", "get", "trae:collision", "--format", "json")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "ambiguous")
 		assert.Contains(t, err.Error(), "trae:workspaceStorage:collision")

--- a/cmd/agentsview/session_usage.go
+++ b/cmd/agentsview/session_usage.go
@@ -254,6 +254,11 @@ func resolveStoreSessionID(
 			if matches[0] == sessionID {
 				return sessionID, nil
 			}
+			if err := resolveTraeRawSuffixAmbiguity(
+				sessionID, matches,
+			); err != nil {
+				return "", err
+			}
 			if len(matches) > 1 {
 				fmt.Fprintf(os.Stderr,
 					"warning: ambiguous session id %q matches "+

--- a/cmd/agentsview/token_use.go
+++ b/cmd/agentsview/token_use.go
@@ -100,6 +100,11 @@ func resolveRawSessionIDDetailed(
 		}
 		return matches[0], true, nil
 	}
+	if hostPrefix, legacyRaw, ok := splitLegacyTraeSessionID(input); ok {
+		return resolveLegacyTraeSessionIDDetailed(
+			ctx, database, agentDirs, input, hostPrefix, legacyRaw,
+		)
+	}
 
 	// Canonical disk probe: if the input starts with a known
 	// agent prefix, trust that interpretation first and strip
@@ -177,6 +182,58 @@ func resolveRawSessionIDDetailed(
 		return diskMatches[0], true, nil
 	}
 
+	return input, false, nil
+}
+
+func resolveLegacyTraeSessionIDDetailed(
+	ctx context.Context,
+	database *db.DB,
+	agentDirs map[parser.AgentType][]string,
+	input, hostPrefix, rawID string,
+) (resolved string, known bool, err error) {
+	var matches []string
+	for _, ns := range traeSessionLookupNamespaces {
+		candidate := hostPrefix + "trae:" + ns + ":" + rawID
+		sess, getErr := database.GetSession(ctx, candidate)
+		if getErr != nil {
+			return "", false, getErr
+		}
+		if sess != nil {
+			matches = append(matches, candidate)
+		}
+	}
+	if len(matches) > 1 {
+		return "", false, fmt.Errorf(
+			"session %s is ambiguous; use %s or %s",
+			rawID, matches[0], matches[1],
+		)
+	}
+	if len(matches) == 1 {
+		return matches[0], true, nil
+	}
+
+	traeDef, ok := parser.AgentByType(parser.AgentTrae)
+	if !ok {
+		return input, false, nil
+	}
+	for _, ns := range traeSessionLookupNamespaces {
+		qualifiedRawID := ns + ":" + rawID
+		for _, dir := range agentDirs[parser.AgentTrae] {
+			if findAgentSourceFile(traeDef, dir, qualifiedRawID) == "" {
+				continue
+			}
+			matches = append(matches, hostPrefix+"trae:"+qualifiedRawID)
+		}
+	}
+	if len(matches) > 1 {
+		return "", false, fmt.Errorf(
+			"session %s is ambiguous; use %s or %s",
+			rawID, matches[0], matches[1],
+		)
+	}
+	if len(matches) == 1 {
+		return matches[0], true, nil
+	}
 	return input, false, nil
 }
 

--- a/cmd/agentsview/token_use.go
+++ b/cmd/agentsview/token_use.go
@@ -21,7 +21,7 @@ const (
 	tokenUseExitErr           = 1
 	tokenUseExitNotFound      = 2
 	tokenUseExitNoTokenData   = 3
-	tokenUseResolveMatchLimit = 2
+	tokenUseResolveMatchLimit = 64
 )
 
 // resolveRawSessionID translates a user-supplied session ID into
@@ -58,8 +58,23 @@ func resolveRawSessionID(
 	agentDirs map[parser.AgentType][]string,
 	input string,
 ) (resolved string, known bool) {
+	resolved, known, _ = resolveRawSessionIDDetailed(
+		ctx, database, agentDirs, input,
+	)
+	return resolved, known
+}
+
+// resolveRawSessionIDDetailed mirrors resolveRawSessionID and also returns
+// a user-facing ambiguity error for raw IDs that collide across Trae's
+// workspaceStorage and globalStorage namespaces.
+func resolveRawSessionIDDetailed(
+	ctx context.Context,
+	database *db.DB,
+	agentDirs map[parser.AgentType][]string,
+	input string,
+) (resolved string, known bool, err error) {
 	if host, _ := parser.StripHostPrefix(input); host != "" {
-		return input, true
+		return input, true, nil
 	}
 
 	matches, err := database.FindSessionIDsByRawSuffix(
@@ -71,7 +86,10 @@ func resolveRawSessionID(
 	}
 	if len(matches) > 0 {
 		if matches[0] == input {
-			return input, true
+			return input, true, nil
+		}
+		if err := resolveTraeRawSuffixAmbiguity(input, matches); err != nil {
+			return "", false, err
 		}
 		if len(matches) > 1 {
 			fmt.Fprintf(os.Stderr,
@@ -80,7 +98,7 @@ func resolveRawSessionID(
 				input, matches[0],
 			)
 		}
-		return matches[0], true
+		return matches[0], true, nil
 	}
 
 	// Canonical disk probe: if the input starts with a known
@@ -98,7 +116,7 @@ func resolveRawSessionID(
 		bareID := strings.TrimPrefix(input, def.IDPrefix)
 		for _, dir := range agentDirs[def.Type] {
 			if findAgentSourceFile(def, dir, bareID) != "" {
-				return input, true
+				return input, true, nil
 			}
 		}
 	}
@@ -108,18 +126,65 @@ func resolveRawSessionID(
 	// the input via IsValidSessionID; agents that accept
 	// colon-bearing raw IDs (Kimi, OpenClaw, Kiro IDE) may
 	// match.
+	var diskMatches []string
+	seenDiskMatches := make(map[string]struct{})
 	for _, def := range parser.Registry {
 		if !agentHasDiskSourceLookup(def) {
 			continue
 		}
 		for _, dir := range agentDirs[def.Type] {
-			if findAgentSourceFile(def, dir, input) != "" {
-				return def.IDPrefix + input, true
+			if def.Type == parser.AgentTrae {
+				for _, namespace := range []string{
+					"workspaceStorage", "globalStorage",
+				} {
+					qualifiedRawID := namespace + ":" + input
+					sourcePath := findAgentSourceFile(def, dir, qualifiedRawID)
+					if sourcePath == "" {
+						continue
+					}
+					match := def.IDPrefix + qualifiedRawID
+					if _, ok := seenDiskMatches[match]; ok {
+						continue
+					}
+					seenDiskMatches[match] = struct{}{}
+					diskMatches = append(diskMatches, match)
+				}
+				continue
 			}
+			sourcePath := findAgentSourceFile(def, dir, input)
+			if sourcePath == "" {
+				continue
+			}
+			match := diskResolvedSessionID(def, sourcePath, input)
+			if _, ok := seenDiskMatches[match]; ok {
+				continue
+			}
+			seenDiskMatches[match] = struct{}{}
+			diskMatches = append(diskMatches, match)
 		}
 	}
+	if len(diskMatches) > 0 {
+		if err := resolveTraeRawSuffixAmbiguity(input, diskMatches); err != nil {
+			return "", false, err
+		}
+		if len(diskMatches) > 1 {
+			fmt.Fprintf(os.Stderr,
+				"warning: ambiguous session id %q matches "+
+					"multiple on-disk sessions, using first match (%s)\n",
+				input, diskMatches[0],
+			)
+		}
+		return diskMatches[0], true, nil
+	}
 
-	return input, false
+	return input, false, nil
+}
+
+func diskResolvedSessionID(
+	def parser.AgentDef, sourcePath, rawID string,
+) string {
+	_ = sourcePath
+	return def.IDPrefix + rawID
 }
 
 // agentHasDiskSourceLookup reports whether a session source can be located by

--- a/cmd/agentsview/token_use.go
+++ b/cmd/agentsview/token_use.go
@@ -73,6 +73,11 @@ func resolveRawSessionIDDetailed(
 	agentDirs map[parser.AgentType][]string,
 	input string,
 ) (resolved string, known bool, err error) {
+	if hostPrefix, legacyRaw, ok := splitLegacyTraeSessionID(input); ok {
+		return resolveLegacyTraeSessionIDDetailed(
+			ctx, database, agentDirs, input, hostPrefix, legacyRaw,
+		)
+	}
 	if host, _ := parser.StripHostPrefix(input); host != "" {
 		return input, true, nil
 	}
@@ -100,12 +105,6 @@ func resolveRawSessionIDDetailed(
 		}
 		return matches[0], true, nil
 	}
-	if hostPrefix, legacyRaw, ok := splitLegacyTraeSessionID(input); ok {
-		return resolveLegacyTraeSessionIDDetailed(
-			ctx, database, agentDirs, input, hostPrefix, legacyRaw,
-		)
-	}
-
 	// Canonical disk probe: if the input starts with a known
 	// agent prefix, trust that interpretation first and strip
 	// before resolving the source (which rejects IDs with

--- a/cmd/agentsview/token_use_test.go
+++ b/cmd/agentsview/token_use_test.go
@@ -239,6 +239,24 @@ func TestResolveSessionIDDetailed_LegacyTraeCanonicalRejectsNamespaceCollision(t
 	assert.Contains(t, err.Error(), "trae:globalStorage:"+raw)
 }
 
+func TestResolveSessionIDDetailed_HostPrefixedLegacyTraeCanonicalResolvesToQualifiedNamespace(t *testing.T) {
+	d := newTestDB(t)
+	ctx := context.Background()
+
+	raw := "remote-rewrite"
+	upsertSession(
+		t, d, "laptop~trae:workspaceStorage:"+raw,
+		string(parser.AgentTrae), "2026-04-17T10:00:00Z",
+	)
+
+	got, known, err := resolveRawSessionIDDetailed(
+		ctx, d, nil, "laptop~trae:"+raw,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "laptop~trae:workspaceStorage:"+raw, got)
+	assert.True(t, known)
+}
+
 func TestResolveSessionIDDetailed_TraeDiskLookupRejectsNamespaceCollision(t *testing.T) {
 	d := newTestDB(t)
 	ctx := context.Background()

--- a/cmd/agentsview/token_use_test.go
+++ b/cmd/agentsview/token_use_test.go
@@ -15,10 +15,29 @@ import (
 	"go.kenn.io/agentsview/internal/parser"
 )
 
+const traeTestStorageKey = "memento/icube-ai-agent-storage"
+
 // newTestDB opens a fresh SQLite DB for a single test.
 func newTestDB(t *testing.T) *db.DB {
 	t.Helper()
 	return dbtest.OpenTestDB(t)
+}
+
+func writeTraeTestDB(t *testing.T, path, sessionID string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	conn, err := sql.Open("sqlite3", path)
+	require.NoError(t, err)
+	defer conn.Close()
+	_, err = conn.Exec(`CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT)`)
+	require.NoError(t, err)
+	value := `{"list":[{"sessionId":"` + sessionID + `","createdAt":1715340600000,"messages":[{"role":"user","content":"hi"}]}]}`
+	_, err = conn.Exec(
+		`INSERT INTO ItemTable(key, value) VALUES (?, ?)`,
+		traeTestStorageKey,
+		value,
+	)
+	require.NoError(t, err)
 }
 
 // upsertSession inserts a session with minimal required fields.
@@ -106,6 +125,83 @@ func TestResolveSessionID_Ambiguous_MostRecentWins(t *testing.T) {
 	got, known := resolveRawSessionID(ctx, d, nil, bare)
 	assert.Equal(t, "amp:"+bare, got, "most recent should win")
 	assert.True(t, known)
+}
+
+func TestResolveSessionIDDetailed_TraeNamespaceCollisionErrors(t *testing.T) {
+	d := newTestDB(t)
+	ctx := context.Background()
+
+	raw := "collision"
+	upsertSession(t, d,
+		"amp:"+raw,
+		"amp",
+		"2026-04-18T10:00:00Z",
+	)
+	upsertSession(t, d,
+		"trae:workspaceStorage:"+raw,
+		string(parser.AgentTrae),
+		"2026-04-16T10:00:00Z",
+	)
+	upsertSession(t, d,
+		"trae:globalStorage:"+raw,
+		string(parser.AgentTrae),
+		"2026-04-17T10:00:00Z",
+	)
+
+	got, known, err := resolveRawSessionIDDetailed(ctx, d, nil, raw)
+	require.Error(t, err)
+	assert.Empty(t, got)
+	assert.False(t, known)
+	assert.Contains(t, err.Error(), "ambiguous")
+	assert.Contains(t, err.Error(), "trae:workspaceStorage:"+raw)
+	assert.Contains(t, err.Error(), "trae:globalStorage:"+raw)
+}
+
+func TestResolveSessionIDDetailed_TraeDiskLookupReturnsQualifiedNamespace(t *testing.T) {
+	d := newTestDB(t)
+	ctx := context.Background()
+
+	root := t.TempDir()
+	raw := "disk-session"
+	writeTraeTestDB(
+		t,
+		filepath.Join(root, "workspaceStorage", "hash", "state.vscdb"),
+		raw,
+	)
+
+	got, known, err := resolveRawSessionIDDetailed(ctx, d, map[parser.AgentType][]string{
+		parser.AgentTrae: {root},
+	}, raw)
+	require.NoError(t, err)
+	assert.Equal(t, "trae:workspaceStorage:"+raw, got)
+	assert.True(t, known)
+}
+
+func TestResolveSessionIDDetailed_TraeDiskLookupRejectsNamespaceCollision(t *testing.T) {
+	d := newTestDB(t)
+	ctx := context.Background()
+
+	root := t.TempDir()
+	raw := "disk-collision"
+	writeTraeTestDB(
+		t,
+		filepath.Join(root, "workspaceStorage", "hash", "state.vscdb"),
+		raw,
+	)
+	writeTraeTestDB(
+		t,
+		filepath.Join(root, "globalStorage", "state.vscdb"),
+		raw,
+	)
+
+	got, known, err := resolveRawSessionIDDetailed(ctx, d, map[parser.AgentType][]string{
+		parser.AgentTrae: {root},
+	}, raw)
+	require.Error(t, err)
+	assert.Empty(t, got)
+	assert.False(t, known)
+	assert.Contains(t, err.Error(), "trae:workspaceStorage:"+raw)
+	assert.Contains(t, err.Error(), "trae:globalStorage:"+raw)
 }
 
 func TestResolveSessionID_NotInDB_FoundOnDisk(t *testing.T) {

--- a/cmd/agentsview/token_use_test.go
+++ b/cmd/agentsview/token_use_test.go
@@ -201,6 +201,44 @@ func TestResolveSessionIDDetailed_TraeDiskLookupReturnsQualifiedNamespace(t *tes
 	assert.True(t, known)
 }
 
+func TestResolveSessionIDDetailed_LegacyTraeCanonicalResolvesToQualifiedNamespace(t *testing.T) {
+	d := newTestDB(t)
+	ctx := context.Background()
+
+	raw := "rewrite"
+	upsertSession(
+		t, d, "trae:workspaceStorage:"+raw,
+		string(parser.AgentTrae), "2026-04-17T10:00:00Z",
+	)
+
+	got, known, err := resolveRawSessionIDDetailed(ctx, d, nil, "trae:"+raw)
+	require.NoError(t, err)
+	assert.Equal(t, "trae:workspaceStorage:"+raw, got)
+	assert.True(t, known)
+}
+
+func TestResolveSessionIDDetailed_LegacyTraeCanonicalRejectsNamespaceCollision(t *testing.T) {
+	d := newTestDB(t)
+	ctx := context.Background()
+
+	raw := "collision"
+	upsertSession(
+		t, d, "trae:workspaceStorage:"+raw,
+		string(parser.AgentTrae), "2026-04-16T10:00:00Z",
+	)
+	upsertSession(
+		t, d, "trae:globalStorage:"+raw,
+		string(parser.AgentTrae), "2026-04-17T10:00:00Z",
+	)
+
+	got, known, err := resolveRawSessionIDDetailed(ctx, d, nil, "trae:"+raw)
+	require.Error(t, err)
+	assert.Empty(t, got)
+	assert.False(t, known)
+	assert.Contains(t, err.Error(), "trae:workspaceStorage:"+raw)
+	assert.Contains(t, err.Error(), "trae:globalStorage:"+raw)
+}
+
 func TestResolveSessionIDDetailed_TraeDiskLookupRejectsNamespaceCollision(t *testing.T) {
 	d := newTestDB(t)
 	ctx := context.Background()

--- a/cmd/agentsview/token_use_test.go
+++ b/cmd/agentsview/token_use_test.go
@@ -128,33 +128,57 @@ func TestResolveSessionID_Ambiguous_MostRecentWins(t *testing.T) {
 }
 
 func TestResolveSessionIDDetailed_TraeNamespaceCollisionErrors(t *testing.T) {
-	d := newTestDB(t)
-	ctx := context.Background()
+	cases := []struct {
+		name        string
+		workspaceID string
+		globalID    string
+	}{
+		{
+			name:        "local",
+			workspaceID: "trae:workspaceStorage:collision",
+			globalID:    "trae:globalStorage:collision",
+		},
+		{
+			name:        "host qualified",
+			workspaceID: "laptop~trae:workspaceStorage:collision",
+			globalID:    "desktop~trae:globalStorage:collision",
+		},
+		{
+			name:        "mixed host and local",
+			workspaceID: "trae:workspaceStorage:collision",
+			globalID:    "desktop~trae:globalStorage:collision",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := newTestDB(t)
+			ctx := context.Background()
+			raw := "collision"
+			upsertSession(t, d,
+				"amp:"+raw,
+				"amp",
+				"2026-04-18T10:00:00Z",
+			)
+			upsertSession(t, d,
+				tc.workspaceID,
+				string(parser.AgentTrae),
+				"2026-04-16T10:00:00Z",
+			)
+			upsertSession(t, d,
+				tc.globalID,
+				string(parser.AgentTrae),
+				"2026-04-17T10:00:00Z",
+			)
 
-	raw := "collision"
-	upsertSession(t, d,
-		"amp:"+raw,
-		"amp",
-		"2026-04-18T10:00:00Z",
-	)
-	upsertSession(t, d,
-		"trae:workspaceStorage:"+raw,
-		string(parser.AgentTrae),
-		"2026-04-16T10:00:00Z",
-	)
-	upsertSession(t, d,
-		"trae:globalStorage:"+raw,
-		string(parser.AgentTrae),
-		"2026-04-17T10:00:00Z",
-	)
-
-	got, known, err := resolveRawSessionIDDetailed(ctx, d, nil, raw)
-	require.Error(t, err)
-	assert.Empty(t, got)
-	assert.False(t, known)
-	assert.Contains(t, err.Error(), "ambiguous")
-	assert.Contains(t, err.Error(), "trae:workspaceStorage:"+raw)
-	assert.Contains(t, err.Error(), "trae:globalStorage:"+raw)
+			got, known, err := resolveRawSessionIDDetailed(ctx, d, nil, raw)
+			require.Error(t, err)
+			assert.Empty(t, got)
+			assert.False(t, known)
+			assert.Contains(t, err.Error(), "ambiguous")
+			assert.Contains(t, err.Error(), tc.workspaceID)
+			assert.Contains(t, err.Error(), tc.globalID)
+		})
+	}
 }
 
 func TestResolveSessionIDDetailed_TraeDiskLookupReturnsQualifiedNamespace(t *testing.T) {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -312,7 +312,7 @@ const projectIdentityRemoteScrubCompletedKey = "project_identity_remote_scrub_v1
 // for existing Hermes sessions so historical skill usage appears in analytics.)
 // (69: Trae namespace identities. Re-parsing rebuilds legacy trae:<raw> rows
 // into namespaced workspace/global identities and drops the superseded alias.)
-const dataVersion = 69
+const dataVersion = 70
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -310,7 +310,9 @@ const projectIdentityRemoteScrubCompletedKey = "project_identity_remote_scrub_v1
 // and relationship_type from agyReader.parentCascadeId in trajectory sidecars.)
 // (68: Hermes skill_view metadata. Re-parsing populates tool_calls.skill_name
 // for existing Hermes sessions so historical skill usage appears in analytics.)
-const dataVersion = 68
+// (69: Trae namespace identities. Re-parsing rebuilds legacy trae:<raw> rows
+// into namespaced workspace/global identities and drops the superseded alias.)
+const dataVersion = 69
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -931,7 +931,7 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 }
 
 func TestCurrentDataVersionTraeNamespaceMigration(t *testing.T) {
-	assert.Equal(t, 69, CurrentDataVersion(),
+	assert.Equal(t, 70, CurrentDataVersion(),
 		"Trae namespace identity migration requires a data version bump")
 }
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -930,9 +930,9 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 		"expected tool_result_events table after reopen")
 }
 
-func TestCurrentDataVersionHermesSkillName(t *testing.T) {
-	assert.Equal(t, 68, CurrentDataVersion(),
-		"Hermes skill-name parsing requires a data version bump")
+func TestCurrentDataVersionTraeNamespaceMigration(t *testing.T) {
+	assert.Equal(t, 69, CurrentDataVersion(),
+		"Trae namespace identity migration requires a data version bump")
 }
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {
 	d := testDB(t)

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -1237,9 +1237,12 @@ func replaceSessionMessagesTx(
 func bumpTranscriptRevisionTx(tx *sql.Tx, sessionID string) error {
 	result, err := tx.Exec(
 		`UPDATE sessions
-		 SET transcript_revision = CAST(
-			CAST(transcript_revision AS INTEGER) + 1 AS TEXT
-		 )
+		 SET transcript_revision = CASE
+			WHEN transcript_revision GLOB '[0-9]*'
+			 AND transcript_revision NOT GLOB '*[^0-9]*'
+			THEN CAST(CAST(transcript_revision AS INTEGER) + 1 AS TEXT)
+			ELSE transcript_revision
+		 END
 		 WHERE id = ?`,
 		sessionID,
 	)

--- a/internal/db/messages_test.go
+++ b/internal/db/messages_test.go
@@ -774,6 +774,34 @@ func TestInsertMessagesPreservesOpaqueTranscriptRevision(t *testing.T) {
 	assert.Equal(t, "workspace-rev", *session.TranscriptRevision)
 }
 
+func TestWriteSessionBatchPreservesExplicitTranscriptRevision(t *testing.T) {
+	t.Parallel()
+	d := testDB(t)
+	const sessionID = "batch-explicit-transcript-revision"
+	revision := "7"
+	_, err := d.WriteSessionBatch([]SessionBatchWrite{{
+		Session: Session{
+			ID:                 sessionID,
+			Project:            "proj",
+			Machine:            defaultMachine,
+			Agent:              defaultAgent,
+			MessageCount:       1,
+			UserMessageCount:   1,
+			TranscriptRevision: &revision,
+		},
+		Messages:        []Message{userMsg(sessionID, 0, "hello")},
+		DataVersion:     CurrentDataVersion(),
+		ReplaceMessages: true,
+	}})
+	require.NoError(t, err)
+
+	session, err := d.GetSession(context.Background(), sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, session)
+	require.NotNil(t, session.TranscriptRevision)
+	assert.Equal(t, "7", *session.TranscriptRevision)
+}
+
 // TestMessageReadsTolerateNullTimestamp pins NULL-timestamp robustness
 // across the three message read paths. timestamp is the only nullable
 // text column in the messages table; fresh inserts always bind a Go

--- a/internal/db/messages_test.go
+++ b/internal/db/messages_test.go
@@ -748,6 +748,32 @@ func TestReplacementAPIsOnlyBumpVisibleTranscriptChanges(t *testing.T) {
 	}
 }
 
+func TestInsertMessagesPreservesOpaqueTranscriptRevision(t *testing.T) {
+	t.Parallel()
+	d := testDB(t)
+	sessionID := "opaque-transcript-revision"
+	insertSession(t, d, sessionID, "proj")
+	_, err := d.getWriter().Exec(
+		`UPDATE sessions SET transcript_revision = 'workspace-rev' WHERE id = ?`,
+		sessionID,
+	)
+	require.NoError(t, err)
+
+	insertMessages(t, d, Message{
+		SessionID:     sessionID,
+		Ordinal:       0,
+		Role:          "user",
+		Content:       "hello",
+		ContentLength: len("hello"),
+	})
+
+	session, err := d.GetSession(context.Background(), sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, session)
+	require.NotNil(t, session.TranscriptRevision)
+	assert.Equal(t, "workspace-rev", *session.TranscriptRevision)
+}
+
 // TestMessageReadsTolerateNullTimestamp pins NULL-timestamp robustness
 // across the three message read paths. timestamp is the only nullable
 // text column in the messages table; fresh inserts always bind a Go

--- a/internal/db/orphaned.go
+++ b/internal/db/orphaned.go
@@ -533,127 +533,37 @@ func (d *DB) CopySessionMetadataFrom(
 	}
 
 	if oldDBHasTable(ctx, tx, "sessions") {
+		if err := rebuildLegacyTraeTargetMapTx(
+			ctx, tx, "old_db.sessions", "main.sessions",
+		); err != nil {
+			return err
+		}
 		if _, err := tx.ExecContext(ctx, `
-			WITH legacy AS (
-				SELECT
-					id AS legacy_id,
-					CASE
-						WHEN instr(id, '~') > 0 THEN substr(id, 1, instr(id, '~'))
-						ELSE ''
-					END AS host_prefix,
-					CASE
-						WHEN file_path LIKE '%workspaceStorage%' THEN 'workspaceStorage'
-						WHEN file_path LIKE '%globalStorage%' THEN 'globalStorage'
-						ELSE ''
-					END AS namespace,
-					CASE
-						WHEN source_session_id LIKE 'trae:%' THEN substr(source_session_id, 6)
-						ELSE source_session_id
-					END AS raw_id,
-					display_name,
-					deleted_at
-				FROM old_db.sessions
-				WHERE agent = 'trae'
-					AND (id LIKE 'trae:%' OR id LIKE '%~trae:%')
-					AND id NOT LIKE 'trae:workspaceStorage:%'
-					AND id NOT LIKE 'trae:globalStorage:%'
-					AND id NOT LIKE '%~trae:workspaceStorage:%'
-					AND id NOT LIKE '%~trae:globalStorage:%'
-			),
-			mapped AS (
-				SELECT
-					legacy_id,
-					host_prefix || 'trae:' || namespace || ':' || raw_id AS namespaced_id,
-					display_name,
-					deleted_at
-				FROM legacy
-				WHERE namespace <> '' AND raw_id <> ''
-			)
 			UPDATE main.sessions
 			SET display_name = CASE
-					WHEN main.sessions.display_name IS NULL THEN mapped.display_name
+					WHEN main.sessions.display_name IS NULL THEN legacy.display_name
 					ELSE main.sessions.display_name
 				END,
-				deleted_at = COALESCE(main.sessions.deleted_at, mapped.deleted_at)
-			FROM mapped
+				deleted_at = COALESCE(main.sessions.deleted_at, legacy.deleted_at)
+			FROM `+legacyTraeTargetMapTable+` mapped
+			JOIN old_db.sessions legacy
+				ON legacy.id = mapped.legacy_id
 			WHERE main.sessions.id = mapped.namespaced_id`); err != nil {
 			return fmt.Errorf("migrating legacy trae session metadata: %w", err)
 		}
 		if oldDBHasTable(ctx, tx, "starred_sessions") {
 			if _, err := tx.ExecContext(ctx, `
-			WITH legacy AS (
-				SELECT
-					id AS legacy_id,
-					CASE
-						WHEN instr(id, '~') > 0 THEN substr(id, 1, instr(id, '~'))
-						ELSE ''
-					END AS host_prefix,
-					CASE
-						WHEN file_path LIKE '%workspaceStorage%' THEN 'workspaceStorage'
-						WHEN file_path LIKE '%globalStorage%' THEN 'globalStorage'
-						ELSE ''
-					END AS namespace,
-					CASE
-						WHEN source_session_id LIKE 'trae:%' THEN substr(source_session_id, 6)
-						ELSE source_session_id
-					END AS raw_id
-				FROM old_db.sessions
-				WHERE agent = 'trae'
-					AND (id LIKE 'trae:%' OR id LIKE '%~trae:%')
-					AND id NOT LIKE 'trae:workspaceStorage:%'
-					AND id NOT LIKE 'trae:globalStorage:%'
-					AND id NOT LIKE '%~trae:workspaceStorage:%'
-					AND id NOT LIKE '%~trae:globalStorage:%'
-			),
-			mapped AS (
-				SELECT
-					legacy_id,
-					host_prefix || 'trae:' || namespace || ':' || raw_id AS namespaced_id
-				FROM legacy
-				WHERE namespace <> '' AND raw_id <> ''
-			)
 			INSERT OR IGNORE INTO main.starred_sessions
 				(session_id, created_at)
 			SELECT mapped.namespaced_id, ss.created_at
 			FROM old_db.starred_sessions ss
-			JOIN mapped ON mapped.legacy_id = ss.session_id
-			WHERE mapped.namespaced_id IN (SELECT id FROM main.sessions)`); err != nil {
+			JOIN `+legacyTraeTargetMapTable+` mapped
+				ON mapped.legacy_id = ss.session_id`); err != nil {
 				return fmt.Errorf("migrating legacy trae stars: %w", err)
 			}
 		}
 		if oldDBHasTable(ctx, tx, "pinned_messages") {
 			if _, err := tx.ExecContext(ctx, `
-			WITH legacy AS (
-				SELECT
-					id AS legacy_id,
-					CASE
-						WHEN instr(id, '~') > 0 THEN substr(id, 1, instr(id, '~'))
-						ELSE ''
-					END AS host_prefix,
-					CASE
-						WHEN file_path LIKE '%workspaceStorage%' THEN 'workspaceStorage'
-						WHEN file_path LIKE '%globalStorage%' THEN 'globalStorage'
-						ELSE ''
-					END AS namespace,
-					CASE
-						WHEN source_session_id LIKE 'trae:%' THEN substr(source_session_id, 6)
-						ELSE source_session_id
-					END AS raw_id
-				FROM old_db.sessions
-				WHERE agent = 'trae'
-					AND (id LIKE 'trae:%' OR id LIKE '%~trae:%')
-					AND id NOT LIKE 'trae:workspaceStorage:%'
-					AND id NOT LIKE 'trae:globalStorage:%'
-					AND id NOT LIKE '%~trae:workspaceStorage:%'
-					AND id NOT LIKE '%~trae:globalStorage:%'
-			),
-			mapped AS (
-				SELECT
-					legacy_id,
-					host_prefix || 'trae:' || namespace || ':' || raw_id AS namespaced_id
-				FROM legacy
-				WHERE namespace <> '' AND raw_id <> ''
-			)
 			INSERT OR IGNORE INTO main.pinned_messages
 				(session_id, message_id, ordinal, note, created_at)
 			SELECT
@@ -661,179 +571,59 @@ func (d *DB) CopySessionMetadataFrom(
 			FROM old_db.pinned_messages op
 			JOIN old_db.messages old_m
 				ON old_m.id = op.message_id
-			JOIN mapped
+			JOIN `+legacyTraeTargetMapTable+` mapped
 				ON mapped.legacy_id = op.session_id
 			JOIN main.messages new_m
 				ON new_m.session_id = mapped.namespaced_id
-				AND new_m.ordinal = old_m.ordinal
-			WHERE mapped.namespaced_id IN (SELECT id FROM main.sessions)`); err != nil {
+				AND new_m.ordinal = old_m.ordinal`); err != nil {
 				return fmt.Errorf("migrating legacy trae pins: %w", err)
 			}
 		}
 		if oldDBHasTable(ctx, tx, "recall_entries") {
 			if _, err := tx.ExecContext(ctx, `
-			WITH legacy AS (
-				SELECT
-					id AS legacy_id,
-					CASE
-						WHEN instr(id, '~') > 0 THEN substr(id, 1, instr(id, '~'))
-						ELSE ''
-					END AS host_prefix,
-					CASE
-						WHEN file_path LIKE '%workspaceStorage%' THEN 'workspaceStorage'
-						WHEN file_path LIKE '%globalStorage%' THEN 'globalStorage'
-						ELSE ''
-					END AS namespace,
-					CASE
-						WHEN source_session_id LIKE 'trae:%' THEN substr(source_session_id, 6)
-						ELSE source_session_id
-					END AS raw_id
-				FROM old_db.sessions
-				WHERE agent = 'trae'
-					AND (id LIKE 'trae:%' OR id LIKE '%~trae:%')
-					AND id NOT LIKE 'trae:workspaceStorage:%'
-					AND id NOT LIKE 'trae:globalStorage:%'
-					AND id NOT LIKE '%~trae:workspaceStorage:%'
-					AND id NOT LIKE '%~trae:globalStorage:%'
-			),
-			mapped AS (
-				SELECT
-					legacy_id,
-					host_prefix || 'trae:' || namespace || ':' || raw_id AS namespaced_id
-				FROM legacy
-				WHERE namespace <> '' AND raw_id <> ''
-			)
 			UPDATE main.recall_entries
 			SET source_session_id = (
 				SELECT mapped.namespaced_id
-				FROM mapped
+				FROM `+legacyTraeTargetMapTable+` mapped
 				WHERE mapped.legacy_id = main.recall_entries.source_session_id
 			)
-			WHERE source_session_id IN (SELECT legacy_id FROM mapped)`); err != nil {
+			WHERE source_session_id IN (
+				SELECT legacy_id FROM `+legacyTraeTargetMapTable+`
+			)`); err != nil {
 				return fmt.Errorf("migrating legacy trae recall entries: %w", err)
 			}
 			if _, err := tx.ExecContext(ctx, `
-			WITH legacy AS (
-				SELECT
-					id AS legacy_id,
-					CASE
-						WHEN instr(id, '~') > 0 THEN substr(id, 1, instr(id, '~'))
-						ELSE ''
-					END AS host_prefix,
-					CASE
-						WHEN file_path LIKE '%workspaceStorage%' THEN 'workspaceStorage'
-						WHEN file_path LIKE '%globalStorage%' THEN 'globalStorage'
-						ELSE ''
-					END AS namespace,
-					CASE
-						WHEN source_session_id LIKE 'trae:%' THEN substr(source_session_id, 6)
-						ELSE source_session_id
-					END AS raw_id
-				FROM old_db.sessions
-				WHERE agent = 'trae'
-					AND (id LIKE 'trae:%' OR id LIKE '%~trae:%')
-					AND id NOT LIKE 'trae:workspaceStorage:%'
-					AND id NOT LIKE 'trae:globalStorage:%'
-					AND id NOT LIKE '%~trae:workspaceStorage:%'
-					AND id NOT LIKE '%~trae:globalStorage:%'
-			),
-			mapped AS (
-				SELECT
-					legacy_id,
-					host_prefix || 'trae:' || namespace || ':' || raw_id AS namespaced_id
-				FROM legacy
-				WHERE namespace <> '' AND raw_id <> ''
-			)
 			UPDATE main.recall_evidence
 			SET session_id = (
 				SELECT mapped.namespaced_id
-				FROM mapped
+				FROM `+legacyTraeTargetMapTable+` mapped
 				WHERE mapped.legacy_id = main.recall_evidence.session_id
 			)
-			WHERE session_id IN (SELECT legacy_id FROM mapped)`); err != nil {
+			WHERE session_id IN (
+				SELECT legacy_id FROM `+legacyTraeTargetMapTable+`
+			)`); err != nil {
 				return fmt.Errorf("migrating legacy trae recall evidence: %w", err)
 			}
 		}
 		if oldDBHasTable(ctx, tx, "recall_extract_progress") {
 			if _, err := tx.ExecContext(ctx, `
-			WITH legacy AS (
-				SELECT
-					id AS legacy_id,
-					CASE
-						WHEN instr(id, '~') > 0 THEN substr(id, 1, instr(id, '~'))
-						ELSE ''
-					END AS host_prefix,
-					CASE
-						WHEN file_path LIKE '%workspaceStorage%' THEN 'workspaceStorage'
-						WHEN file_path LIKE '%globalStorage%' THEN 'globalStorage'
-						ELSE ''
-					END AS namespace,
-					CASE
-						WHEN source_session_id LIKE 'trae:%' THEN substr(source_session_id, 6)
-						ELSE source_session_id
-					END AS raw_id
-				FROM old_db.sessions
-				WHERE agent = 'trae'
-					AND (id LIKE 'trae:%' OR id LIKE '%~trae:%')
-					AND id NOT LIKE 'trae:workspaceStorage:%'
-					AND id NOT LIKE 'trae:globalStorage:%'
-					AND id NOT LIKE '%~trae:workspaceStorage:%'
-					AND id NOT LIKE '%~trae:globalStorage:%'
-			),
-			mapped AS (
-				SELECT
-					legacy_id,
-					host_prefix || 'trae:' || namespace || ':' || raw_id AS namespaced_id
-				FROM legacy
-				WHERE namespace <> '' AND raw_id <> ''
-			)
 			UPDATE main.recall_extract_progress
 			SET session_id = (
 				SELECT mapped.namespaced_id
-				FROM mapped
+				FROM `+legacyTraeTargetMapTable+` mapped
 				WHERE mapped.legacy_id = main.recall_extract_progress.session_id
 			)
-			WHERE session_id IN (SELECT legacy_id FROM mapped)`); err != nil {
+			WHERE session_id IN (
+				SELECT legacy_id FROM `+legacyTraeTargetMapTable+`
+			)`); err != nil {
 				return fmt.Errorf("migrating legacy trae recall extract progress: %w", err)
 			}
 		}
 		if _, err := tx.ExecContext(ctx, `
-			WITH legacy AS (
-				SELECT
-					id AS legacy_id,
-					CASE
-						WHEN instr(id, '~') > 0 THEN substr(id, 1, instr(id, '~'))
-						ELSE ''
-					END AS host_prefix,
-					CASE
-						WHEN file_path LIKE '%workspaceStorage%' THEN 'workspaceStorage'
-						WHEN file_path LIKE '%globalStorage%' THEN 'globalStorage'
-						ELSE ''
-					END AS namespace,
-					CASE
-						WHEN source_session_id LIKE 'trae:%' THEN substr(source_session_id, 6)
-						ELSE source_session_id
-					END AS raw_id
-				FROM old_db.sessions
-				WHERE agent = 'trae'
-					AND (id LIKE 'trae:%' OR id LIKE '%~trae:%')
-					AND id NOT LIKE 'trae:workspaceStorage:%'
-					AND id NOT LIKE 'trae:globalStorage:%'
-					AND id NOT LIKE '%~trae:workspaceStorage:%'
-					AND id NOT LIKE '%~trae:globalStorage:%'
-			),
-			mapped AS (
-				SELECT
-					legacy_id,
-					host_prefix || 'trae:' || namespace || ':' || raw_id AS namespaced_id
-				FROM legacy
-				WHERE namespace <> '' AND raw_id <> ''
-			)
 			DELETE FROM main.sessions
 			WHERE id IN (
 				SELECT legacy_id
-				FROM mapped
-				WHERE namespaced_id IN (SELECT id FROM main.sessions)
+				FROM `+legacyTraeTargetMapTable+`
 			)`); err != nil {
 			return fmt.Errorf("removing legacy trae session rows: %w", err)
 		}
@@ -1042,7 +832,7 @@ func copyLegacyTraeSessionProjectIdentitySnapshots(
 	ctx context.Context, tx *sql.Tx,
 ) error {
 	rows, err := tx.QueryContext(ctx, `
-		SELECT snap.session_id, old_s.file_path,
+		SELECT snap.session_id, old_s.file_path, old_s.source_session_id,
 			snap.project, snap.machine, snap.root_path, snap.git_remote,
 			snap.git_remote_name, snap.repository_path, snap.worktree_name,
 			snap.worktree_root_path, snap.worktree_relationship,
@@ -1067,6 +857,7 @@ func copyLegacyTraeSessionProjectIdentitySnapshots(
 		var (
 			oldID                string
 			filePath             sql.NullString
+			sourceSessionID      sql.NullString
 			project              string
 			machine              string
 			rootPath             string
@@ -1086,7 +877,7 @@ func copyLegacyTraeSessionProjectIdentitySnapshots(
 			key                  string
 		)
 		if err := rows.Scan(
-			&oldID, &filePath,
+			&oldID, &filePath, &sourceSessionID,
 			&project, &machine, &rootPath, &gitRemote,
 			&gitRemoteName, &repositoryPath, &worktreeName,
 			&worktreeRootPath, &worktreeRelationship,
@@ -1098,46 +889,30 @@ func copyLegacyTraeSessionProjectIdentitySnapshots(
 				"scanning legacy trae project identity snapshot: %w", err,
 			)
 		}
-		hostPrefix, strippedID := legacyTraeSessionPrefixAndStrippedID(oldID)
-		rawID := strings.TrimPrefix(strippedID, "trae:")
-		rawID = strings.TrimPrefix(rawID, "trae:")
-		if rawID == "" {
+		newID, err := resolveLegacyTraeNamespacedID(
+			oldID,
+			filePath.String,
+			sourceSessionID.String,
+			func(id string) (bool, error) {
+				var ok bool
+				if err := tx.QueryRowContext(ctx,
+					`SELECT EXISTS(SELECT 1 FROM main.sessions WHERE id = ?)`,
+					id,
+				).Scan(&ok); err != nil {
+					return false, err
+				}
+				return ok, nil
+			},
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"resolving legacy trae project identity snapshot %s: %w",
+				oldID, err,
+			)
+		}
+		if newID == "" {
 			continue
 		}
-		namespace := traeSessionNamespaceFromPath(filePath.String)
-		if namespace == "" {
-			workspaceID := hostPrefix + "trae:workspaceStorage:" + rawID
-			globalID := hostPrefix + "trae:globalStorage:" + rawID
-			var workspaceCount, globalCount int
-			if err := tx.QueryRowContext(ctx,
-				`SELECT COUNT(*) FROM main.sessions WHERE id = ?`,
-				workspaceID,
-			).Scan(&workspaceCount); err != nil {
-				return fmt.Errorf(
-					"checking migrated trae snapshot target %s: %w",
-					workspaceID, err,
-				)
-			}
-			if err := tx.QueryRowContext(ctx,
-				`SELECT COUNT(*) FROM main.sessions WHERE id = ?`,
-				globalID,
-			).Scan(&globalCount); err != nil {
-				return fmt.Errorf(
-					"checking migrated trae snapshot target %s: %w",
-					globalID, err,
-				)
-			}
-			switch {
-			case workspaceCount > 0 && globalCount == 0:
-				namespace = "workspaceStorage"
-			case globalCount > 0 && workspaceCount == 0:
-				namespace = "globalStorage"
-			}
-		}
-		if namespace == "" {
-			continue
-		}
-		newID := hostPrefix + "trae:" + namespace + ":" + rawID
 		if _, err := tx.ExecContext(ctx, `
 			INSERT INTO main.session_project_identity_snapshots (
 				session_id, project, machine, root_path, git_remote,

--- a/internal/db/orphaned.go
+++ b/internal/db/orphaned.go
@@ -981,6 +981,9 @@ func (d *DB) CopySessionMetadataFrom(
 					key = excluded.key`); err != nil {
 			return fmt.Errorf("copying session project identity snapshots: %w", err)
 		}
+		if err := copyLegacyTraeSessionProjectIdentitySnapshots(ctx, tx); err != nil {
+			return err
+		}
 	}
 
 	// Copy persistent worktree project mappings. Omit id so
@@ -1033,6 +1036,153 @@ func oldDBHasTable(
 		name,
 	).Scan(&n)
 	return err == nil && n == 1
+}
+
+func copyLegacyTraeSessionProjectIdentitySnapshots(
+	ctx context.Context, tx *sql.Tx,
+) error {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT snap.session_id, old_s.file_path,
+			snap.project, snap.machine, snap.root_path, snap.git_remote,
+			snap.git_remote_name, snap.repository_path, snap.worktree_name,
+			snap.worktree_root_path, snap.worktree_relationship,
+			snap.checkout_state, snap.git_branch, snap.remote_resolution,
+			snap.remote_candidate_count, snap.observed_at,
+			snap.normalized_remote, snap.key_source, snap.key
+		FROM old_db.session_project_identity_snapshots snap
+		JOIN old_db.sessions old_s
+			ON old_s.id = snap.session_id
+		WHERE old_s.agent = 'trae'
+		  AND snap.session_id LIKE '%trae:%'
+		  AND snap.session_id NOT LIKE '%trae:workspaceStorage:%'
+		  AND snap.session_id NOT LIKE '%trae:globalStorage:%'`)
+	if err != nil {
+		return fmt.Errorf(
+			"querying legacy trae project identity snapshots: %w", err,
+		)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			oldID                string
+			filePath             sql.NullString
+			project              string
+			machine              string
+			rootPath             string
+			gitRemote            string
+			gitRemoteName        string
+			repositoryPath       string
+			worktreeName         string
+			worktreeRootPath     string
+			worktreeRelationship string
+			checkoutState        string
+			gitBranch            string
+			remoteResolution     string
+			remoteCandidateCount int
+			observedAt           string
+			normalizedRemote     string
+			keySource            string
+			key                  string
+		)
+		if err := rows.Scan(
+			&oldID, &filePath,
+			&project, &machine, &rootPath, &gitRemote,
+			&gitRemoteName, &repositoryPath, &worktreeName,
+			&worktreeRootPath, &worktreeRelationship,
+			&checkoutState, &gitBranch, &remoteResolution,
+			&remoteCandidateCount, &observedAt,
+			&normalizedRemote, &keySource, &key,
+		); err != nil {
+			return fmt.Errorf(
+				"scanning legacy trae project identity snapshot: %w", err,
+			)
+		}
+		hostPrefix, strippedID := legacyTraeSessionPrefixAndStrippedID(oldID)
+		rawID := strings.TrimPrefix(strippedID, "trae:")
+		rawID = strings.TrimPrefix(rawID, "trae:")
+		if rawID == "" {
+			continue
+		}
+		namespace := traeSessionNamespaceFromPath(filePath.String)
+		if namespace == "" {
+			workspaceID := hostPrefix + "trae:workspaceStorage:" + rawID
+			globalID := hostPrefix + "trae:globalStorage:" + rawID
+			var workspaceCount, globalCount int
+			if err := tx.QueryRowContext(ctx,
+				`SELECT COUNT(*) FROM main.sessions WHERE id = ?`,
+				workspaceID,
+			).Scan(&workspaceCount); err != nil {
+				return fmt.Errorf(
+					"checking migrated trae snapshot target %s: %w",
+					workspaceID, err,
+				)
+			}
+			if err := tx.QueryRowContext(ctx,
+				`SELECT COUNT(*) FROM main.sessions WHERE id = ?`,
+				globalID,
+			).Scan(&globalCount); err != nil {
+				return fmt.Errorf(
+					"checking migrated trae snapshot target %s: %w",
+					globalID, err,
+				)
+			}
+			switch {
+			case workspaceCount > 0 && globalCount == 0:
+				namespace = "workspaceStorage"
+			case globalCount > 0 && workspaceCount == 0:
+				namespace = "globalStorage"
+			}
+		}
+		if namespace == "" {
+			continue
+		}
+		newID := hostPrefix + "trae:" + namespace + ":" + rawID
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO main.session_project_identity_snapshots (
+				session_id, project, machine, root_path, git_remote,
+				git_remote_name, repository_path, worktree_name,
+				worktree_root_path, worktree_relationship, checkout_state,
+				git_branch, remote_resolution, remote_candidate_count,
+				observed_at, normalized_remote, key_source, key
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT(session_id) DO UPDATE SET
+				project = excluded.project,
+				machine = excluded.machine,
+				root_path = excluded.root_path,
+				git_remote = excluded.git_remote,
+				git_remote_name = excluded.git_remote_name,
+				repository_path = excluded.repository_path,
+				worktree_name = excluded.worktree_name,
+				worktree_root_path = excluded.worktree_root_path,
+				worktree_relationship = excluded.worktree_relationship,
+				checkout_state = excluded.checkout_state,
+				git_branch = excluded.git_branch,
+				remote_resolution = excluded.remote_resolution,
+				remote_candidate_count = excluded.remote_candidate_count,
+				observed_at = excluded.observed_at,
+				normalized_remote = excluded.normalized_remote,
+				key_source = excluded.key_source,
+				key = excluded.key`,
+			newID, project, machine, rootPath, gitRemote,
+			gitRemoteName, repositoryPath, worktreeName,
+			worktreeRootPath, worktreeRelationship, checkoutState,
+			gitBranch, remoteResolution, remoteCandidateCount,
+			observedAt, normalizedRemote, keySource, key,
+		); err != nil {
+			return fmt.Errorf(
+				"copying legacy trae project identity snapshot %s: %w",
+				oldID, err,
+			)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf(
+			"iterating legacy trae project identity snapshots: %w",
+			err,
+		)
+	}
+	return nil
 }
 
 // orphanSessionCols returns the comma-separated column list for

--- a/internal/db/orphaned.go
+++ b/internal/db/orphaned.go
@@ -532,6 +532,270 @@ func (d *DB) CopySessionMetadataFrom(
 		}
 	}
 
+	if oldDBHasTable(ctx, tx, "sessions") {
+		if _, err := tx.ExecContext(ctx, `
+			WITH legacy AS (
+				SELECT
+					id AS legacy_id,
+					CASE
+						WHEN file_path LIKE '%workspaceStorage%' THEN 'workspaceStorage'
+						WHEN file_path LIKE '%globalStorage%' THEN 'globalStorage'
+						ELSE ''
+					END AS namespace,
+					CASE
+						WHEN source_session_id LIKE 'trae:%' THEN substr(source_session_id, 6)
+						ELSE source_session_id
+					END AS raw_id,
+					display_name,
+					deleted_at
+				FROM old_db.sessions
+				WHERE agent = 'trae'
+					AND id LIKE 'trae:%'
+					AND id NOT LIKE 'trae:workspaceStorage:%'
+					AND id NOT LIKE 'trae:globalStorage:%'
+			),
+			mapped AS (
+				SELECT
+					legacy_id,
+					'trae:' || namespace || ':' || raw_id AS namespaced_id,
+					display_name,
+					deleted_at
+				FROM legacy
+				WHERE namespace <> '' AND raw_id <> ''
+			)
+			UPDATE main.sessions
+			SET display_name = CASE
+					WHEN main.sessions.display_name IS NULL THEN mapped.display_name
+					ELSE main.sessions.display_name
+				END,
+				deleted_at = COALESCE(main.sessions.deleted_at, mapped.deleted_at)
+			FROM mapped
+			WHERE main.sessions.id = mapped.namespaced_id`); err != nil {
+			return fmt.Errorf("migrating legacy trae session metadata: %w", err)
+		}
+		if oldDBHasTable(ctx, tx, "starred_sessions") {
+			if _, err := tx.ExecContext(ctx, `
+			WITH legacy AS (
+				SELECT
+					id AS legacy_id,
+					CASE
+						WHEN file_path LIKE '%workspaceStorage%' THEN 'workspaceStorage'
+						WHEN file_path LIKE '%globalStorage%' THEN 'globalStorage'
+						ELSE ''
+					END AS namespace,
+					CASE
+						WHEN source_session_id LIKE 'trae:%' THEN substr(source_session_id, 6)
+						ELSE source_session_id
+					END AS raw_id
+				FROM old_db.sessions
+				WHERE agent = 'trae'
+					AND id LIKE 'trae:%'
+					AND id NOT LIKE 'trae:workspaceStorage:%'
+					AND id NOT LIKE 'trae:globalStorage:%'
+			),
+			mapped AS (
+				SELECT
+					legacy_id,
+					'trae:' || namespace || ':' || raw_id AS namespaced_id
+				FROM legacy
+				WHERE namespace <> '' AND raw_id <> ''
+			)
+			INSERT OR IGNORE INTO main.starred_sessions
+				(session_id, created_at)
+			SELECT mapped.namespaced_id, ss.created_at
+			FROM old_db.starred_sessions ss
+			JOIN mapped ON mapped.legacy_id = ss.session_id
+			WHERE mapped.namespaced_id IN (SELECT id FROM main.sessions)`); err != nil {
+				return fmt.Errorf("migrating legacy trae stars: %w", err)
+			}
+		}
+		if oldDBHasTable(ctx, tx, "pinned_messages") {
+			if _, err := tx.ExecContext(ctx, `
+			WITH legacy AS (
+				SELECT
+					id AS legacy_id,
+					CASE
+						WHEN file_path LIKE '%workspaceStorage%' THEN 'workspaceStorage'
+						WHEN file_path LIKE '%globalStorage%' THEN 'globalStorage'
+						ELSE ''
+					END AS namespace,
+					CASE
+						WHEN source_session_id LIKE 'trae:%' THEN substr(source_session_id, 6)
+						ELSE source_session_id
+					END AS raw_id
+				FROM old_db.sessions
+				WHERE agent = 'trae'
+					AND id LIKE 'trae:%'
+					AND id NOT LIKE 'trae:workspaceStorage:%'
+					AND id NOT LIKE 'trae:globalStorage:%'
+			),
+			mapped AS (
+				SELECT
+					legacy_id,
+					'trae:' || namespace || ':' || raw_id AS namespaced_id
+				FROM legacy
+				WHERE namespace <> '' AND raw_id <> ''
+			)
+			INSERT OR IGNORE INTO main.pinned_messages
+				(session_id, message_id, ordinal, note, created_at)
+			SELECT
+				mapped.namespaced_id, new_m.id, op.ordinal, op.note, op.created_at
+			FROM old_db.pinned_messages op
+			JOIN old_db.messages old_m
+				ON old_m.id = op.message_id
+			JOIN mapped
+				ON mapped.legacy_id = op.session_id
+			JOIN main.messages new_m
+				ON new_m.session_id = mapped.namespaced_id
+				AND new_m.ordinal = old_m.ordinal
+			WHERE mapped.namespaced_id IN (SELECT id FROM main.sessions)`); err != nil {
+				return fmt.Errorf("migrating legacy trae pins: %w", err)
+			}
+		}
+		if oldDBHasTable(ctx, tx, "recall_entries") {
+			if _, err := tx.ExecContext(ctx, `
+			WITH legacy AS (
+				SELECT
+					id AS legacy_id,
+					CASE
+						WHEN file_path LIKE '%workspaceStorage%' THEN 'workspaceStorage'
+						WHEN file_path LIKE '%globalStorage%' THEN 'globalStorage'
+						ELSE ''
+					END AS namespace,
+					CASE
+						WHEN source_session_id LIKE 'trae:%' THEN substr(source_session_id, 6)
+						ELSE source_session_id
+					END AS raw_id
+				FROM old_db.sessions
+				WHERE agent = 'trae'
+					AND id LIKE 'trae:%'
+					AND id NOT LIKE 'trae:workspaceStorage:%'
+					AND id NOT LIKE 'trae:globalStorage:%'
+			),
+			mapped AS (
+				SELECT
+					legacy_id,
+					'trae:' || namespace || ':' || raw_id AS namespaced_id
+				FROM legacy
+				WHERE namespace <> '' AND raw_id <> ''
+			)
+			UPDATE main.recall_entries
+			SET source_session_id = (
+				SELECT mapped.namespaced_id
+				FROM mapped
+				WHERE mapped.legacy_id = main.recall_entries.source_session_id
+			)
+			WHERE source_session_id IN (SELECT legacy_id FROM mapped)`); err != nil {
+				return fmt.Errorf("migrating legacy trae recall entries: %w", err)
+			}
+			if _, err := tx.ExecContext(ctx, `
+			WITH legacy AS (
+				SELECT
+					id AS legacy_id,
+					CASE
+						WHEN file_path LIKE '%workspaceStorage%' THEN 'workspaceStorage'
+						WHEN file_path LIKE '%globalStorage%' THEN 'globalStorage'
+						ELSE ''
+					END AS namespace,
+					CASE
+						WHEN source_session_id LIKE 'trae:%' THEN substr(source_session_id, 6)
+						ELSE source_session_id
+					END AS raw_id
+				FROM old_db.sessions
+				WHERE agent = 'trae'
+					AND id LIKE 'trae:%'
+					AND id NOT LIKE 'trae:workspaceStorage:%'
+					AND id NOT LIKE 'trae:globalStorage:%'
+			),
+			mapped AS (
+				SELECT
+					legacy_id,
+					'trae:' || namespace || ':' || raw_id AS namespaced_id
+				FROM legacy
+				WHERE namespace <> '' AND raw_id <> ''
+			)
+			UPDATE main.recall_evidence
+			SET session_id = (
+				SELECT mapped.namespaced_id
+				FROM mapped
+				WHERE mapped.legacy_id = main.recall_evidence.session_id
+			)
+			WHERE session_id IN (SELECT legacy_id FROM mapped)`); err != nil {
+				return fmt.Errorf("migrating legacy trae recall evidence: %w", err)
+			}
+		}
+		if oldDBHasTable(ctx, tx, "recall_extract_progress") {
+			if _, err := tx.ExecContext(ctx, `
+			WITH legacy AS (
+				SELECT
+					id AS legacy_id,
+					CASE
+						WHEN file_path LIKE '%workspaceStorage%' THEN 'workspaceStorage'
+						WHEN file_path LIKE '%globalStorage%' THEN 'globalStorage'
+						ELSE ''
+					END AS namespace,
+					CASE
+						WHEN source_session_id LIKE 'trae:%' THEN substr(source_session_id, 6)
+						ELSE source_session_id
+					END AS raw_id
+				FROM old_db.sessions
+				WHERE agent = 'trae'
+					AND id LIKE 'trae:%'
+					AND id NOT LIKE 'trae:workspaceStorage:%'
+					AND id NOT LIKE 'trae:globalStorage:%'
+			),
+			mapped AS (
+				SELECT
+					legacy_id,
+					'trae:' || namespace || ':' || raw_id AS namespaced_id
+				FROM legacy
+				WHERE namespace <> '' AND raw_id <> ''
+			)
+			UPDATE main.recall_extract_progress
+			SET session_id = (
+				SELECT mapped.namespaced_id
+				FROM mapped
+				WHERE mapped.legacy_id = main.recall_extract_progress.session_id
+			)
+			WHERE session_id IN (SELECT legacy_id FROM mapped)`); err != nil {
+				return fmt.Errorf("migrating legacy trae recall extract progress: %w", err)
+			}
+		}
+		if _, err := tx.ExecContext(ctx, `
+			WITH legacy AS (
+				SELECT
+					id AS legacy_id,
+					CASE
+						WHEN file_path LIKE '%workspaceStorage%' THEN 'workspaceStorage'
+						WHEN file_path LIKE '%globalStorage%' THEN 'globalStorage'
+						ELSE ''
+					END AS namespace,
+					CASE
+						WHEN source_session_id LIKE 'trae:%' THEN substr(source_session_id, 6)
+						ELSE source_session_id
+					END AS raw_id
+				FROM old_db.sessions
+				WHERE agent = 'trae'
+					AND id LIKE 'trae:%'
+					AND id NOT LIKE 'trae:workspaceStorage:%'
+					AND id NOT LIKE 'trae:globalStorage:%'
+			),
+			mapped AS (
+				SELECT
+					legacy_id,
+					'trae:' || namespace || ':' || raw_id AS namespaced_id
+				FROM legacy
+				WHERE namespace <> '' AND raw_id <> ''
+			)
+			DELETE FROM main.sessions
+			WHERE id IN (
+				SELECT legacy_id
+				FROM mapped
+				WHERE namespaced_id IN (SELECT id FROM main.sessions)
+			)`); err != nil {
+			return fmt.Errorf("removing legacy trae session rows: %w", err)
+		}
+	}
 	if oldDBHasTable(ctx, tx, "cursor_usage_events") {
 		if _, err := tx.ExecContext(ctx, `
 			DELETE FROM main.cursor_usage_events`); err != nil {

--- a/internal/db/orphaned.go
+++ b/internal/db/orphaned.go
@@ -538,6 +538,10 @@ func (d *DB) CopySessionMetadataFrom(
 				SELECT
 					id AS legacy_id,
 					CASE
+						WHEN instr(id, '~') > 0 THEN substr(id, 1, instr(id, '~'))
+						ELSE ''
+					END AS host_prefix,
+					CASE
 						WHEN file_path LIKE '%workspaceStorage%' THEN 'workspaceStorage'
 						WHEN file_path LIKE '%globalStorage%' THEN 'globalStorage'
 						ELSE ''
@@ -550,14 +554,16 @@ func (d *DB) CopySessionMetadataFrom(
 					deleted_at
 				FROM old_db.sessions
 				WHERE agent = 'trae'
-					AND id LIKE 'trae:%'
+					AND (id LIKE 'trae:%' OR id LIKE '%~trae:%')
 					AND id NOT LIKE 'trae:workspaceStorage:%'
 					AND id NOT LIKE 'trae:globalStorage:%'
+					AND id NOT LIKE '%~trae:workspaceStorage:%'
+					AND id NOT LIKE '%~trae:globalStorage:%'
 			),
 			mapped AS (
 				SELECT
 					legacy_id,
-					'trae:' || namespace || ':' || raw_id AS namespaced_id,
+					host_prefix || 'trae:' || namespace || ':' || raw_id AS namespaced_id,
 					display_name,
 					deleted_at
 				FROM legacy
@@ -579,6 +585,10 @@ func (d *DB) CopySessionMetadataFrom(
 				SELECT
 					id AS legacy_id,
 					CASE
+						WHEN instr(id, '~') > 0 THEN substr(id, 1, instr(id, '~'))
+						ELSE ''
+					END AS host_prefix,
+					CASE
 						WHEN file_path LIKE '%workspaceStorage%' THEN 'workspaceStorage'
 						WHEN file_path LIKE '%globalStorage%' THEN 'globalStorage'
 						ELSE ''
@@ -589,14 +599,16 @@ func (d *DB) CopySessionMetadataFrom(
 					END AS raw_id
 				FROM old_db.sessions
 				WHERE agent = 'trae'
-					AND id LIKE 'trae:%'
+					AND (id LIKE 'trae:%' OR id LIKE '%~trae:%')
 					AND id NOT LIKE 'trae:workspaceStorage:%'
 					AND id NOT LIKE 'trae:globalStorage:%'
+					AND id NOT LIKE '%~trae:workspaceStorage:%'
+					AND id NOT LIKE '%~trae:globalStorage:%'
 			),
 			mapped AS (
 				SELECT
 					legacy_id,
-					'trae:' || namespace || ':' || raw_id AS namespaced_id
+					host_prefix || 'trae:' || namespace || ':' || raw_id AS namespaced_id
 				FROM legacy
 				WHERE namespace <> '' AND raw_id <> ''
 			)
@@ -615,6 +627,10 @@ func (d *DB) CopySessionMetadataFrom(
 				SELECT
 					id AS legacy_id,
 					CASE
+						WHEN instr(id, '~') > 0 THEN substr(id, 1, instr(id, '~'))
+						ELSE ''
+					END AS host_prefix,
+					CASE
 						WHEN file_path LIKE '%workspaceStorage%' THEN 'workspaceStorage'
 						WHEN file_path LIKE '%globalStorage%' THEN 'globalStorage'
 						ELSE ''
@@ -625,14 +641,16 @@ func (d *DB) CopySessionMetadataFrom(
 					END AS raw_id
 				FROM old_db.sessions
 				WHERE agent = 'trae'
-					AND id LIKE 'trae:%'
+					AND (id LIKE 'trae:%' OR id LIKE '%~trae:%')
 					AND id NOT LIKE 'trae:workspaceStorage:%'
 					AND id NOT LIKE 'trae:globalStorage:%'
+					AND id NOT LIKE '%~trae:workspaceStorage:%'
+					AND id NOT LIKE '%~trae:globalStorage:%'
 			),
 			mapped AS (
 				SELECT
 					legacy_id,
-					'trae:' || namespace || ':' || raw_id AS namespaced_id
+					host_prefix || 'trae:' || namespace || ':' || raw_id AS namespaced_id
 				FROM legacy
 				WHERE namespace <> '' AND raw_id <> ''
 			)
@@ -658,6 +676,10 @@ func (d *DB) CopySessionMetadataFrom(
 				SELECT
 					id AS legacy_id,
 					CASE
+						WHEN instr(id, '~') > 0 THEN substr(id, 1, instr(id, '~'))
+						ELSE ''
+					END AS host_prefix,
+					CASE
 						WHEN file_path LIKE '%workspaceStorage%' THEN 'workspaceStorage'
 						WHEN file_path LIKE '%globalStorage%' THEN 'globalStorage'
 						ELSE ''
@@ -668,14 +690,16 @@ func (d *DB) CopySessionMetadataFrom(
 					END AS raw_id
 				FROM old_db.sessions
 				WHERE agent = 'trae'
-					AND id LIKE 'trae:%'
+					AND (id LIKE 'trae:%' OR id LIKE '%~trae:%')
 					AND id NOT LIKE 'trae:workspaceStorage:%'
 					AND id NOT LIKE 'trae:globalStorage:%'
+					AND id NOT LIKE '%~trae:workspaceStorage:%'
+					AND id NOT LIKE '%~trae:globalStorage:%'
 			),
 			mapped AS (
 				SELECT
 					legacy_id,
-					'trae:' || namespace || ':' || raw_id AS namespaced_id
+					host_prefix || 'trae:' || namespace || ':' || raw_id AS namespaced_id
 				FROM legacy
 				WHERE namespace <> '' AND raw_id <> ''
 			)
@@ -693,6 +717,10 @@ func (d *DB) CopySessionMetadataFrom(
 				SELECT
 					id AS legacy_id,
 					CASE
+						WHEN instr(id, '~') > 0 THEN substr(id, 1, instr(id, '~'))
+						ELSE ''
+					END AS host_prefix,
+					CASE
 						WHEN file_path LIKE '%workspaceStorage%' THEN 'workspaceStorage'
 						WHEN file_path LIKE '%globalStorage%' THEN 'globalStorage'
 						ELSE ''
@@ -703,14 +731,16 @@ func (d *DB) CopySessionMetadataFrom(
 					END AS raw_id
 				FROM old_db.sessions
 				WHERE agent = 'trae'
-					AND id LIKE 'trae:%'
+					AND (id LIKE 'trae:%' OR id LIKE '%~trae:%')
 					AND id NOT LIKE 'trae:workspaceStorage:%'
 					AND id NOT LIKE 'trae:globalStorage:%'
+					AND id NOT LIKE '%~trae:workspaceStorage:%'
+					AND id NOT LIKE '%~trae:globalStorage:%'
 			),
 			mapped AS (
 				SELECT
 					legacy_id,
-					'trae:' || namespace || ':' || raw_id AS namespaced_id
+					host_prefix || 'trae:' || namespace || ':' || raw_id AS namespaced_id
 				FROM legacy
 				WHERE namespace <> '' AND raw_id <> ''
 			)
@@ -730,6 +760,10 @@ func (d *DB) CopySessionMetadataFrom(
 				SELECT
 					id AS legacy_id,
 					CASE
+						WHEN instr(id, '~') > 0 THEN substr(id, 1, instr(id, '~'))
+						ELSE ''
+					END AS host_prefix,
+					CASE
 						WHEN file_path LIKE '%workspaceStorage%' THEN 'workspaceStorage'
 						WHEN file_path LIKE '%globalStorage%' THEN 'globalStorage'
 						ELSE ''
@@ -740,14 +774,16 @@ func (d *DB) CopySessionMetadataFrom(
 					END AS raw_id
 				FROM old_db.sessions
 				WHERE agent = 'trae'
-					AND id LIKE 'trae:%'
+					AND (id LIKE 'trae:%' OR id LIKE '%~trae:%')
 					AND id NOT LIKE 'trae:workspaceStorage:%'
 					AND id NOT LIKE 'trae:globalStorage:%'
+					AND id NOT LIKE '%~trae:workspaceStorage:%'
+					AND id NOT LIKE '%~trae:globalStorage:%'
 			),
 			mapped AS (
 				SELECT
 					legacy_id,
-					'trae:' || namespace || ':' || raw_id AS namespaced_id
+					host_prefix || 'trae:' || namespace || ':' || raw_id AS namespaced_id
 				FROM legacy
 				WHERE namespace <> '' AND raw_id <> ''
 			)
@@ -766,6 +802,10 @@ func (d *DB) CopySessionMetadataFrom(
 				SELECT
 					id AS legacy_id,
 					CASE
+						WHEN instr(id, '~') > 0 THEN substr(id, 1, instr(id, '~'))
+						ELSE ''
+					END AS host_prefix,
+					CASE
 						WHEN file_path LIKE '%workspaceStorage%' THEN 'workspaceStorage'
 						WHEN file_path LIKE '%globalStorage%' THEN 'globalStorage'
 						ELSE ''
@@ -776,14 +816,16 @@ func (d *DB) CopySessionMetadataFrom(
 					END AS raw_id
 				FROM old_db.sessions
 				WHERE agent = 'trae'
-					AND id LIKE 'trae:%'
+					AND (id LIKE 'trae:%' OR id LIKE '%~trae:%')
 					AND id NOT LIKE 'trae:workspaceStorage:%'
 					AND id NOT LIKE 'trae:globalStorage:%'
+					AND id NOT LIKE '%~trae:workspaceStorage:%'
+					AND id NOT LIKE '%~trae:globalStorage:%'
 			),
 			mapped AS (
 				SELECT
 					legacy_id,
-					'trae:' || namespace || ':' || raw_id AS namespaced_id
+					host_prefix || 'trae:' || namespace || ':' || raw_id AS namespaced_id
 				FROM legacy
 				WHERE namespace <> '' AND raw_id <> ''
 			)

--- a/internal/db/project_identity_backfill_test.go
+++ b/internal/db/project_identity_backfill_test.go
@@ -268,3 +268,73 @@ func TestProjectIdentityBackfillPersistsUnknownSnapshotForEmptyProject(
 	require.NoError(t, err)
 	assert.Equal(t, "completed", status.State)
 }
+
+func TestCopySessionMetadataMigratesLegacyTraeProjectIdentitySnapshot(
+	t *testing.T,
+) {
+	dir := t.TempDir()
+	ctx := context.Background()
+	sourcePath := filepath.Join(dir, "source.db")
+
+	source, err := Open(sourcePath)
+	require.NoError(t, err)
+	legacyPath := filepath.Join(
+		dir, "workspaceStorage", "legacy-trae", "transcript.jsonl",
+	)
+	require.NoError(t, source.UpsertSession(Session{
+		ID:               "trae:legacy-trae",
+		Project:          "app",
+		Machine:          "local",
+		Agent:            "trae",
+		SourceSessionID:  "legacy-trae",
+		FilePath:         &legacyPath,
+		MessageCount:     1,
+		UserMessageCount: 1,
+		CreatedAt:        "2026-07-21T00:00:00Z",
+	}))
+	require.NoError(t, source.UpsertProjectIdentityObservation(ctx,
+		export.ProjectIdentityObservation{
+			SessionID:     "trae:legacy-trae",
+			Project:       "app",
+			Machine:       "local",
+			RootPath:      "/historical/app",
+			GitRemote:     "https://github.com/example/app.git",
+			ObservedAt:    time.Date(2026, 7, 21, 0, 0, 0, 0, time.UTC),
+			GitBranch:     "feature/migrated",
+			CheckoutState: export.CheckoutBranch,
+		}))
+	require.NoError(t, source.Close())
+
+	destination := testDB(t)
+	require.NoError(t, destination.UpsertSession(Session{
+		ID:               "trae:workspaceStorage:legacy-trae",
+		Project:          "app",
+		Machine:          "local",
+		Agent:            "trae",
+		SourceSessionID:  "legacy-trae",
+		FilePath:         &legacyPath,
+		MessageCount:     1,
+		UserMessageCount: 1,
+		CreatedAt:        "2026-07-21T00:01:00Z",
+	}))
+
+	require.NoError(t, destination.CopySessionMetadataFrom(sourcePath))
+
+	snapshots, err := destination.listSessionProjectIdentitySnapshots(
+		ctx, []string{
+			"trae:legacy-trae",
+			"trae:workspaceStorage:legacy-trae",
+		},
+	)
+	require.NoError(t, err)
+	assert.NotContains(t, snapshots, "trae:legacy-trae")
+	require.Contains(t, snapshots, "trae:workspaceStorage:legacy-trae")
+	assert.Equal(t,
+		"/historical/app",
+		snapshots["trae:workspaceStorage:legacy-trae"].RootPath,
+	)
+	assert.Equal(t,
+		"feature/migrated",
+		snapshots["trae:workspaceStorage:legacy-trae"].GitBranch,
+	)
+}

--- a/internal/db/recall.go
+++ b/internal/db/recall.go
@@ -243,25 +243,32 @@ func (db *DB) CopyRecallEntriesFrom(sourcePath string) error {
 			SELECT
 				id AS legacy_id,
 				CASE
-					WHEN file_path LIKE '%workspaceStorage%' THEN
-						'trae:workspaceStorage:' ||
-						CASE
-							WHEN source_session_id LIKE 'trae:%' THEN substr(source_session_id, 6)
-							ELSE source_session_id
-						END
-					WHEN file_path LIKE '%globalStorage%' THEN
-						'trae:globalStorage:' ||
-						CASE
-							WHEN source_session_id LIKE 'trae:%' THEN substr(source_session_id, 6)
-							ELSE source_session_id
-						END
+					WHEN instr(id, '~') > 0 THEN substr(id, 1, instr(id, '~'))
 					ELSE ''
-				END AS namespaced_id
+				END AS host_prefix,
+				CASE
+					WHEN file_path LIKE '%workspaceStorage%' THEN 'workspaceStorage'
+					WHEN file_path LIKE '%globalStorage%' THEN 'globalStorage'
+					ELSE ''
+				END AS namespace,
+				CASE
+					WHEN source_session_id LIKE 'trae:%' THEN substr(source_session_id, 6)
+					ELSE source_session_id
+				END AS raw_id
 			FROM old_db.sessions
 			WHERE agent = 'trae'
-			  AND id LIKE 'trae:%'
+			  AND (id LIKE 'trae:%' OR id LIKE '%~trae:%')
 			  AND id NOT LIKE 'trae:workspaceStorage:%'
 			  AND id NOT LIKE 'trae:globalStorage:%'
+			  AND id NOT LIKE '%~trae:workspaceStorage:%'
+			  AND id NOT LIKE '%~trae:globalStorage:%'
+		),
+		mapped_legacy_trae AS (
+			SELECT
+				legacy_id,
+				host_prefix || 'trae:' || namespace || ':' || raw_id AS namespaced_id
+			FROM legacy_trae_map
+			WHERE namespace <> '' AND raw_id <> ''
 		)
 		INSERT OR IGNORE INTO recall_entries (
 			id, type, scope, status, review_state, title, body, trigger,
@@ -277,7 +284,7 @@ func (db *DB) CopyRecallEntriesFrom(sourcePath string) error {
 			COALESCE(
 				(
 					SELECT mapped.namespaced_id
-					FROM legacy_trae_map mapped
+					FROM mapped_legacy_trae mapped
 					WHERE mapped.legacy_id = old_db.recall_entries.source_session_id
 					  AND mapped.namespaced_id IN (SELECT id FROM main.sessions)
 				),
@@ -291,7 +298,7 @@ func (db *DB) CopyRecallEntriesFrom(sourcePath string) error {
 		WHERE COALESCE(
 			(
 				SELECT mapped.namespaced_id
-				FROM legacy_trae_map mapped
+				FROM mapped_legacy_trae mapped
 				WHERE mapped.legacy_id = old_db.recall_entries.source_session_id
 				  AND mapped.namespaced_id IN (SELECT id FROM main.sessions)
 			),
@@ -317,25 +324,32 @@ func (db *DB) CopyRecallEntriesFrom(sourcePath string) error {
 			SELECT
 				id AS legacy_id,
 				CASE
-					WHEN file_path LIKE '%workspaceStorage%' THEN
-						'trae:workspaceStorage:' ||
-						CASE
-							WHEN source_session_id LIKE 'trae:%' THEN substr(source_session_id, 6)
-							ELSE source_session_id
-						END
-					WHEN file_path LIKE '%globalStorage%' THEN
-						'trae:globalStorage:' ||
-						CASE
-							WHEN source_session_id LIKE 'trae:%' THEN substr(source_session_id, 6)
-							ELSE source_session_id
-						END
+					WHEN instr(id, '~') > 0 THEN substr(id, 1, instr(id, '~'))
 					ELSE ''
-				END AS namespaced_id
+				END AS host_prefix,
+				CASE
+					WHEN file_path LIKE '%workspaceStorage%' THEN 'workspaceStorage'
+					WHEN file_path LIKE '%globalStorage%' THEN 'globalStorage'
+					ELSE ''
+				END AS namespace,
+				CASE
+					WHEN source_session_id LIKE 'trae:%' THEN substr(source_session_id, 6)
+					ELSE source_session_id
+				END AS raw_id
 			FROM old_db.sessions
 			WHERE agent = 'trae'
-			  AND id LIKE 'trae:%'
+			  AND (id LIKE 'trae:%' OR id LIKE '%~trae:%')
 			  AND id NOT LIKE 'trae:workspaceStorage:%'
 			  AND id NOT LIKE 'trae:globalStorage:%'
+			  AND id NOT LIKE '%~trae:workspaceStorage:%'
+			  AND id NOT LIKE '%~trae:globalStorage:%'
+		),
+		mapped_legacy_trae AS (
+			SELECT
+				legacy_id,
+				host_prefix || 'trae:' || namespace || ':' || raw_id AS namespaced_id
+			FROM legacy_trae_map
+			WHERE namespace <> '' AND raw_id <> ''
 		)
 		INSERT INTO recall_evidence (
 			entry_id, session_id, message_start_ordinal,
@@ -347,7 +361,7 @@ func (db *DB) CopyRecallEntriesFrom(sourcePath string) error {
 			COALESCE(
 				(
 					SELECT mapped.namespaced_id
-					FROM legacy_trae_map mapped
+					FROM mapped_legacy_trae mapped
 					WHERE mapped.legacy_id = old_db.recall_evidence.session_id
 					  AND mapped.namespaced_id IN (SELECT id FROM main.sessions)
 				),
@@ -361,7 +375,7 @@ func (db *DB) CopyRecallEntriesFrom(sourcePath string) error {
 		  AND COALESCE(
 			(
 				SELECT mapped.namespaced_id
-				FROM legacy_trae_map mapped
+				FROM mapped_legacy_trae mapped
 				WHERE mapped.legacy_id = old_db.recall_evidence.session_id
 				  AND mapped.namespaced_id IN (SELECT id FROM main.sessions)
 			),

--- a/internal/db/recall.go
+++ b/internal/db/recall.go
@@ -231,6 +231,13 @@ func (db *DB) CopyRecallEntriesFrom(sourcePath string) error {
 	}
 	defer func() { _ = tx.Rollback() }()
 	var pendingRecallRevocations recallEvidenceRevocationEvents
+	if oldDBHasTable(ctx, tx, "sessions") {
+		if err := rebuildLegacyTraeTargetMapTx(
+			ctx, tx, "old_db.sessions", "main.sessions",
+		); err != nil {
+			return err
+		}
+	}
 	if err := copyRecallQueryEventsFromAttachedTx(ctx, tx); err != nil {
 		return err
 	}
@@ -239,37 +246,6 @@ func (db *DB) CopyRecallEntriesFrom(sourcePath string) error {
 	}
 
 	res, err := tx.ExecContext(ctx, `
-		WITH legacy_trae_map AS (
-			SELECT
-				id AS legacy_id,
-				CASE
-					WHEN instr(id, '~') > 0 THEN substr(id, 1, instr(id, '~'))
-					ELSE ''
-				END AS host_prefix,
-				CASE
-					WHEN file_path LIKE '%workspaceStorage%' THEN 'workspaceStorage'
-					WHEN file_path LIKE '%globalStorage%' THEN 'globalStorage'
-					ELSE ''
-				END AS namespace,
-				CASE
-					WHEN source_session_id LIKE 'trae:%' THEN substr(source_session_id, 6)
-					ELSE source_session_id
-				END AS raw_id
-			FROM old_db.sessions
-			WHERE agent = 'trae'
-			  AND (id LIKE 'trae:%' OR id LIKE '%~trae:%')
-			  AND id NOT LIKE 'trae:workspaceStorage:%'
-			  AND id NOT LIKE 'trae:globalStorage:%'
-			  AND id NOT LIKE '%~trae:workspaceStorage:%'
-			  AND id NOT LIKE '%~trae:globalStorage:%'
-		),
-		mapped_legacy_trae AS (
-			SELECT
-				legacy_id,
-				host_prefix || 'trae:' || namespace || ':' || raw_id AS namespaced_id
-			FROM legacy_trae_map
-			WHERE namespace <> '' AND raw_id <> ''
-		)
 		INSERT OR IGNORE INTO recall_entries (
 			id, type, scope, status, review_state, title, body, trigger,
 			confidence, uncertainty, project, cwd, git_branch, agent,
@@ -284,9 +260,8 @@ func (db *DB) CopyRecallEntriesFrom(sourcePath string) error {
 			COALESCE(
 				(
 					SELECT mapped.namespaced_id
-					FROM mapped_legacy_trae mapped
+					FROM `+legacyTraeTargetMapTable+` mapped
 					WHERE mapped.legacy_id = old_db.recall_entries.source_session_id
-					  AND mapped.namespaced_id IN (SELECT id FROM main.sessions)
 				),
 				source_session_id
 			),
@@ -298,9 +273,8 @@ func (db *DB) CopyRecallEntriesFrom(sourcePath string) error {
 		WHERE COALESCE(
 			(
 				SELECT mapped.namespaced_id
-				FROM mapped_legacy_trae mapped
+				FROM `+legacyTraeTargetMapTable+` mapped
 				WHERE mapped.legacy_id = old_db.recall_entries.source_session_id
-				  AND mapped.namespaced_id IN (SELECT id FROM main.sessions)
 			),
 			source_session_id
 		) IN (SELECT id FROM main.sessions)`)
@@ -320,37 +294,6 @@ func (db *DB) CopyRecallEntriesFrom(sourcePath string) error {
 	}
 
 	if _, err := tx.ExecContext(ctx, `
-		WITH legacy_trae_map AS (
-			SELECT
-				id AS legacy_id,
-				CASE
-					WHEN instr(id, '~') > 0 THEN substr(id, 1, instr(id, '~'))
-					ELSE ''
-				END AS host_prefix,
-				CASE
-					WHEN file_path LIKE '%workspaceStorage%' THEN 'workspaceStorage'
-					WHEN file_path LIKE '%globalStorage%' THEN 'globalStorage'
-					ELSE ''
-				END AS namespace,
-				CASE
-					WHEN source_session_id LIKE 'trae:%' THEN substr(source_session_id, 6)
-					ELSE source_session_id
-				END AS raw_id
-			FROM old_db.sessions
-			WHERE agent = 'trae'
-			  AND (id LIKE 'trae:%' OR id LIKE '%~trae:%')
-			  AND id NOT LIKE 'trae:workspaceStorage:%'
-			  AND id NOT LIKE 'trae:globalStorage:%'
-			  AND id NOT LIKE '%~trae:workspaceStorage:%'
-			  AND id NOT LIKE '%~trae:globalStorage:%'
-		),
-		mapped_legacy_trae AS (
-			SELECT
-				legacy_id,
-				host_prefix || 'trae:' || namespace || ':' || raw_id AS namespaced_id
-			FROM legacy_trae_map
-			WHERE namespace <> '' AND raw_id <> ''
-		)
 		INSERT INTO recall_evidence (
 			entry_id, session_id, message_start_ordinal,
 			message_end_ordinal, message_start_source_uuid,
@@ -361,9 +304,8 @@ func (db *DB) CopyRecallEntriesFrom(sourcePath string) error {
 			COALESCE(
 				(
 					SELECT mapped.namespaced_id
-					FROM mapped_legacy_trae mapped
+					FROM `+legacyTraeTargetMapTable+` mapped
 					WHERE mapped.legacy_id = old_db.recall_evidence.session_id
-					  AND mapped.namespaced_id IN (SELECT id FROM main.sessions)
 				),
 				session_id
 			),
@@ -375,9 +317,8 @@ func (db *DB) CopyRecallEntriesFrom(sourcePath string) error {
 		  AND COALESCE(
 			(
 				SELECT mapped.namespaced_id
-				FROM mapped_legacy_trae mapped
+				FROM `+legacyTraeTargetMapTable+` mapped
 				WHERE mapped.legacy_id = old_db.recall_evidence.session_id
-				  AND mapped.namespaced_id IN (SELECT id FROM main.sessions)
 			),
 			session_id
 		  ) IN (SELECT id FROM main.sessions)`); err != nil {

--- a/internal/db/recall.go
+++ b/internal/db/recall.go
@@ -239,6 +239,30 @@ func (db *DB) CopyRecallEntriesFrom(sourcePath string) error {
 	}
 
 	res, err := tx.ExecContext(ctx, `
+		WITH legacy_trae_map AS (
+			SELECT
+				id AS legacy_id,
+				CASE
+					WHEN file_path LIKE '%workspaceStorage%' THEN
+						'trae:workspaceStorage:' ||
+						CASE
+							WHEN source_session_id LIKE 'trae:%' THEN substr(source_session_id, 6)
+							ELSE source_session_id
+						END
+					WHEN file_path LIKE '%globalStorage%' THEN
+						'trae:globalStorage:' ||
+						CASE
+							WHEN source_session_id LIKE 'trae:%' THEN substr(source_session_id, 6)
+							ELSE source_session_id
+						END
+					ELSE ''
+				END AS namespaced_id
+			FROM old_db.sessions
+			WHERE agent = 'trae'
+			  AND id LIKE 'trae:%'
+			  AND id NOT LIKE 'trae:workspaceStorage:%'
+			  AND id NOT LIKE 'trae:globalStorage:%'
+		)
 		INSERT OR IGNORE INTO recall_entries (
 			id, type, scope, status, review_state, title, body, trigger,
 			confidence, uncertainty, project, cwd, git_branch, agent,
@@ -250,12 +274,29 @@ func (db *DB) CopyRecallEntriesFrom(sourcePath string) error {
 		SELECT
 			id, type, scope, status, review_state, title, body, trigger,
 			confidence, uncertainty, project, cwd, git_branch, agent,
-			source_session_id, source_episode_id, source_run_id,
+			COALESCE(
+				(
+					SELECT mapped.namespaced_id
+					FROM legacy_trae_map mapped
+					WHERE mapped.legacy_id = old_db.recall_entries.source_session_id
+					  AND mapped.namespaced_id IN (SELECT id FROM main.sessions)
+				),
+				source_session_id
+			),
+			source_episode_id, source_run_id,
 			extractor_method, model, transferable, provenance_ok,
 			supersedes_entry_id, superseded_by_entry_id,
 			created_at, updated_at
 		FROM old_db.recall_entries
-		WHERE source_session_id IN (SELECT id FROM main.sessions)`)
+		WHERE COALESCE(
+			(
+				SELECT mapped.namespaced_id
+				FROM legacy_trae_map mapped
+				WHERE mapped.legacy_id = old_db.recall_entries.source_session_id
+				  AND mapped.namespaced_id IN (SELECT id FROM main.sessions)
+			),
+			source_session_id
+		) IN (SELECT id FROM main.sessions)`)
 	if err != nil {
 		return fmt.Errorf("copying entries: %w", err)
 	}
@@ -272,18 +313,60 @@ func (db *DB) CopyRecallEntriesFrom(sourcePath string) error {
 	}
 
 	if _, err := tx.ExecContext(ctx, `
+		WITH legacy_trae_map AS (
+			SELECT
+				id AS legacy_id,
+				CASE
+					WHEN file_path LIKE '%workspaceStorage%' THEN
+						'trae:workspaceStorage:' ||
+						CASE
+							WHEN source_session_id LIKE 'trae:%' THEN substr(source_session_id, 6)
+							ELSE source_session_id
+						END
+					WHEN file_path LIKE '%globalStorage%' THEN
+						'trae:globalStorage:' ||
+						CASE
+							WHEN source_session_id LIKE 'trae:%' THEN substr(source_session_id, 6)
+							ELSE source_session_id
+						END
+					ELSE ''
+				END AS namespaced_id
+			FROM old_db.sessions
+			WHERE agent = 'trae'
+			  AND id LIKE 'trae:%'
+			  AND id NOT LIKE 'trae:workspaceStorage:%'
+			  AND id NOT LIKE 'trae:globalStorage:%'
+		)
 		INSERT INTO recall_evidence (
 			entry_id, session_id, message_start_ordinal,
 			message_end_ordinal, message_start_source_uuid,
 			message_end_source_uuid, content_digest, tool_use_id, snippet
 		)
 		SELECT
-			entry_id, session_id, message_start_ordinal,
+			entry_id,
+			COALESCE(
+				(
+					SELECT mapped.namespaced_id
+					FROM legacy_trae_map mapped
+					WHERE mapped.legacy_id = old_db.recall_evidence.session_id
+					  AND mapped.namespaced_id IN (SELECT id FROM main.sessions)
+				),
+				session_id
+			),
+			message_start_ordinal,
 			message_end_ordinal, message_start_source_uuid,
 			message_end_source_uuid, content_digest, tool_use_id, snippet
 		FROM old_db.recall_evidence
 		WHERE entry_id IN (SELECT id FROM main.recall_entries)
-		  AND session_id IN (SELECT id FROM main.sessions)`); err != nil {
+		  AND COALESCE(
+			(
+				SELECT mapped.namespaced_id
+				FROM legacy_trae_map mapped
+				WHERE mapped.legacy_id = old_db.recall_evidence.session_id
+				  AND mapped.namespaced_id IN (SELECT id FROM main.sessions)
+			),
+			session_id
+		  ) IN (SELECT id FROM main.sessions)`); err != nil {
 		return fmt.Errorf("copying recall evidence: %w", err)
 	}
 	if err := revokeRecallEntriesWithDroppedEvidenceTx(

--- a/internal/db/recall_extract.go
+++ b/internal/db/recall_extract.go
@@ -551,25 +551,32 @@ func copyRecallExtractStateFromAttachedTx(
 			SELECT
 				id AS legacy_id,
 				CASE
-					WHEN file_path LIKE '%workspaceStorage%' THEN
-						'trae:workspaceStorage:' ||
-						CASE
-							WHEN source_session_id LIKE 'trae:%' THEN substr(source_session_id, 6)
-							ELSE source_session_id
-						END
-					WHEN file_path LIKE '%globalStorage%' THEN
-						'trae:globalStorage:' ||
-						CASE
-							WHEN source_session_id LIKE 'trae:%' THEN substr(source_session_id, 6)
-							ELSE source_session_id
-						END
+					WHEN instr(id, '~') > 0 THEN substr(id, 1, instr(id, '~'))
 					ELSE ''
-				END AS namespaced_id
+				END AS host_prefix,
+				CASE
+					WHEN file_path LIKE '%workspaceStorage%' THEN 'workspaceStorage'
+					WHEN file_path LIKE '%globalStorage%' THEN 'globalStorage'
+					ELSE ''
+				END AS namespace,
+				CASE
+					WHEN source_session_id LIKE 'trae:%' THEN substr(source_session_id, 6)
+					ELSE source_session_id
+				END AS raw_id
 			FROM old_db.sessions
 			WHERE agent = 'trae'
-			  AND id LIKE 'trae:%'
+			  AND (id LIKE 'trae:%' OR id LIKE '%~trae:%')
 			  AND id NOT LIKE 'trae:workspaceStorage:%'
 			  AND id NOT LIKE 'trae:globalStorage:%'
+			  AND id NOT LIKE '%~trae:workspaceStorage:%'
+			  AND id NOT LIKE '%~trae:globalStorage:%'
+		),
+		mapped_legacy_trae AS (
+			SELECT
+				legacy_id,
+				host_prefix || 'trae:' || namespace || ':' || raw_id AS namespaced_id
+			FROM legacy_trae_map
+			WHERE namespace <> '' AND raw_id <> ''
 		)
 		INSERT OR IGNORE INTO recall_extract_progress (
 			session_id, generation_fingerprint, unit_cursor, units_total,
@@ -579,7 +586,7 @@ func copyRecallExtractStateFromAttachedTx(
 		       COALESCE(
 				(
 					SELECT mapped.namespaced_id
-					FROM legacy_trae_map mapped
+					FROM mapped_legacy_trae mapped
 					WHERE mapped.legacy_id = old_db.recall_extract_progress.session_id
 					  AND mapped.namespaced_id IN (SELECT id FROM main.sessions)
 				),
@@ -591,7 +598,7 @@ func copyRecallExtractStateFromAttachedTx(
 		WHERE COALESCE(
 			(
 				SELECT mapped.namespaced_id
-				FROM legacy_trae_map mapped
+				FROM mapped_legacy_trae mapped
 				WHERE mapped.legacy_id = old_db.recall_extract_progress.session_id
 				  AND mapped.namespaced_id IN (SELECT id FROM main.sessions)
 			),

--- a/internal/db/recall_extract.go
+++ b/internal/db/recall_extract.go
@@ -547,37 +547,6 @@ func copyRecallExtractStateFromAttachedTx(
 		return nil
 	}
 	if _, err := tx.ExecContext(ctx, `
-		WITH legacy_trae_map AS (
-			SELECT
-				id AS legacy_id,
-				CASE
-					WHEN instr(id, '~') > 0 THEN substr(id, 1, instr(id, '~'))
-					ELSE ''
-				END AS host_prefix,
-				CASE
-					WHEN file_path LIKE '%workspaceStorage%' THEN 'workspaceStorage'
-					WHEN file_path LIKE '%globalStorage%' THEN 'globalStorage'
-					ELSE ''
-				END AS namespace,
-				CASE
-					WHEN source_session_id LIKE 'trae:%' THEN substr(source_session_id, 6)
-					ELSE source_session_id
-				END AS raw_id
-			FROM old_db.sessions
-			WHERE agent = 'trae'
-			  AND (id LIKE 'trae:%' OR id LIKE '%~trae:%')
-			  AND id NOT LIKE 'trae:workspaceStorage:%'
-			  AND id NOT LIKE 'trae:globalStorage:%'
-			  AND id NOT LIKE '%~trae:workspaceStorage:%'
-			  AND id NOT LIKE '%~trae:globalStorage:%'
-		),
-		mapped_legacy_trae AS (
-			SELECT
-				legacy_id,
-				host_prefix || 'trae:' || namespace || ':' || raw_id AS namespaced_id
-			FROM legacy_trae_map
-			WHERE namespace <> '' AND raw_id <> ''
-		)
 		INSERT OR IGNORE INTO recall_extract_progress (
 			session_id, generation_fingerprint, unit_cursor, units_total,
 			state, content_digest, last_error, updated_at
@@ -586,9 +555,8 @@ func copyRecallExtractStateFromAttachedTx(
 		       COALESCE(
 				(
 					SELECT mapped.namespaced_id
-					FROM mapped_legacy_trae mapped
+					FROM `+legacyTraeTargetMapTable+` mapped
 					WHERE mapped.legacy_id = old_db.recall_extract_progress.session_id
-					  AND mapped.namespaced_id IN (SELECT id FROM main.sessions)
 				),
 				session_id
 		       ),
@@ -598,9 +566,8 @@ func copyRecallExtractStateFromAttachedTx(
 		WHERE COALESCE(
 			(
 				SELECT mapped.namespaced_id
-				FROM mapped_legacy_trae mapped
+				FROM `+legacyTraeTargetMapTable+` mapped
 				WHERE mapped.legacy_id = old_db.recall_extract_progress.session_id
-				  AND mapped.namespaced_id IN (SELECT id FROM main.sessions)
 			),
 			session_id
 		) IN (SELECT id FROM main.sessions)`); err != nil {

--- a/internal/db/recall_extract.go
+++ b/internal/db/recall_extract.go
@@ -547,14 +547,56 @@ func copyRecallExtractStateFromAttachedTx(
 		return nil
 	}
 	if _, err := tx.ExecContext(ctx, `
+		WITH legacy_trae_map AS (
+			SELECT
+				id AS legacy_id,
+				CASE
+					WHEN file_path LIKE '%workspaceStorage%' THEN
+						'trae:workspaceStorage:' ||
+						CASE
+							WHEN source_session_id LIKE 'trae:%' THEN substr(source_session_id, 6)
+							ELSE source_session_id
+						END
+					WHEN file_path LIKE '%globalStorage%' THEN
+						'trae:globalStorage:' ||
+						CASE
+							WHEN source_session_id LIKE 'trae:%' THEN substr(source_session_id, 6)
+							ELSE source_session_id
+						END
+					ELSE ''
+				END AS namespaced_id
+			FROM old_db.sessions
+			WHERE agent = 'trae'
+			  AND id LIKE 'trae:%'
+			  AND id NOT LIKE 'trae:workspaceStorage:%'
+			  AND id NOT LIKE 'trae:globalStorage:%'
+		)
 		INSERT OR IGNORE INTO recall_extract_progress (
 			session_id, generation_fingerprint, unit_cursor, units_total,
 			state, content_digest, last_error, updated_at
 		)
-		SELECT session_id, generation_fingerprint, unit_cursor, units_total,
+		SELECT
+		       COALESCE(
+				(
+					SELECT mapped.namespaced_id
+					FROM legacy_trae_map mapped
+					WHERE mapped.legacy_id = old_db.recall_extract_progress.session_id
+					  AND mapped.namespaced_id IN (SELECT id FROM main.sessions)
+				),
+				session_id
+		       ),
+		       generation_fingerprint, unit_cursor, units_total,
 		       state, content_digest, last_error, updated_at
 		FROM old_db.recall_extract_progress
-		WHERE session_id IN (SELECT id FROM main.sessions)`); err != nil {
+		WHERE COALESCE(
+			(
+				SELECT mapped.namespaced_id
+				FROM legacy_trae_map mapped
+				WHERE mapped.legacy_id = old_db.recall_extract_progress.session_id
+				  AND mapped.namespaced_id IN (SELECT id FROM main.sessions)
+			),
+			session_id
+		) IN (SELECT id FROM main.sessions)`); err != nil {
 		return fmt.Errorf("copying extract progress: %w", err)
 	}
 	return nil

--- a/internal/db/session_batch.go
+++ b/internal/db/session_batch.go
@@ -302,11 +302,11 @@ func writeOneSessionBatchTx(
 	if excluded == 1 {
 		return 0, ErrSessionExcluded
 	}
-	var deletedAt sql.NullString
+	var deletedAt, storedTranscriptRevision sql.NullString
 	err = tx.QueryRow(
-		"SELECT deleted_at FROM sessions WHERE id = ?",
+		"SELECT deleted_at, transcript_revision FROM sessions WHERE id = ?",
 		write.Session.ID,
-	).Scan(&deletedAt)
+	).Scan(&deletedAt, &storedTranscriptRevision)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return 0, fmt.Errorf(
 			"checking trash for %s: %w",
@@ -316,6 +316,12 @@ func writeOneSessionBatchTx(
 	sessionExists := err == nil
 	if deletedAt.Valid {
 		return 0, ErrSessionTrashed
+	}
+	hasExplicitTranscriptRevision := write.Session.TranscriptRevision != nil
+	if sessionExists && write.Session.TranscriptRevision == nil &&
+		storedTranscriptRevision.Valid {
+		revision := storedTranscriptRevision.String
+		write.Session.TranscriptRevision = &revision
 	}
 	replacementTranscriptChanged := false
 	if write.ReplaceMessages && sessionExists {
@@ -388,7 +394,7 @@ func writeOneSessionBatchTx(
 			return 0, err
 		}
 	}
-	if transcriptChanged {
+	if transcriptChanged && !hasExplicitTranscriptRevision {
 		if err := bumpTranscriptRevisionTx(tx, write.Session.ID); err != nil {
 			return 0, err
 		}

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -1271,12 +1271,17 @@ func (db *DB) DeleteParserExcludedSessions(ids []string) (int, error) {
 }
 
 func isLegacyTraeSessionID(id string) bool {
-	if idx := strings.Index(id, "~"); idx > 0 {
-		id = id[idx+1:]
-	}
+	_, id = legacyTraeSessionPrefixAndStrippedID(id)
 	return strings.HasPrefix(id, "trae:") &&
 		!strings.HasPrefix(id, "trae:workspaceStorage:") &&
 		!strings.HasPrefix(id, "trae:globalStorage:")
+}
+
+func legacyTraeSessionPrefixAndStrippedID(id string) (string, string) {
+	if idx := strings.Index(id, "~"); idx > 0 {
+		return id[:idx+1], id[idx+1:]
+	}
+	return "", id
 }
 
 func traeSessionNamespaceFromPath(path string) string {
@@ -1447,15 +1452,16 @@ func (db *DB) MigrateAllLegacyTraeSessions() error {
 		if err := rows.Scan(&id, &filePath); err != nil {
 			return fmt.Errorf("scanning legacy trae session: %w", err)
 		}
+		hostPrefix, strippedID := legacyTraeSessionPrefixAndStrippedID(id)
 		namespace := traeSessionNamespaceFromPath(filePath.String)
-		rawID := strings.TrimPrefix(id, "trae:")
+		rawID := strings.TrimPrefix(strippedID, "trae:")
 		rawID = strings.TrimPrefix(rawID, "trae:")
 		if rawID == "" {
 			continue
 		}
 		if namespace == "" {
-			workspaceID := "trae:workspaceStorage:" + rawID
-			globalID := "trae:globalStorage:" + rawID
+			workspaceID := hostPrefix + "trae:workspaceStorage:" + rawID
+			globalID := hostPrefix + "trae:globalStorage:" + rawID
 			var workspaceCount, globalCount int
 			_ = db.getReader().QueryRow(
 				"SELECT COUNT(*) FROM sessions WHERE id = ?",
@@ -1479,7 +1485,7 @@ func (db *DB) MigrateAllLegacyTraeSessions() error {
 		}
 		migrations = append(migrations, migration{
 			oldID:     id,
-			newID:     "trae:" + namespace + ":" + rawID,
+			newID:     hostPrefix + "trae:" + namespace + ":" + rawID,
 			namespace: namespace,
 		})
 	}

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -1419,6 +1419,9 @@ func (db *DB) MigrateLegacyTraeSessionState(
 	); err != nil {
 		return fmt.Errorf("applying legacy trae session state to %s: %w", newID, err)
 	}
+	if err := migrateSessionProjectIdentitySnapshotTx(tx, oldID, newID); err != nil {
+		return err
+	}
 	if err := restorePinsTx(tx, newID, pins); err != nil {
 		return fmt.Errorf("restoring migrated trae pins to %s: %w", newID, err)
 	}
@@ -1486,8 +1489,6 @@ func (db *DB) MigrateAllLegacyTraeSessions() error {
 				namespace = "workspaceStorage"
 			case globalCount > 0 && workspaceCount == 0:
 				namespace = "globalStorage"
-			case workspaceCount > 0:
-				namespace = "workspaceStorage"
 			}
 		}
 		if namespace == "" {
@@ -1515,6 +1516,52 @@ func (db *DB) MigrateAllLegacyTraeSessions() error {
 func nullStringValue(value sql.NullString) any {
 	if value.Valid {
 		return value.String
+	}
+	return nil
+}
+
+func migrateSessionProjectIdentitySnapshotTx(
+	tx *sql.Tx, oldID, newID string,
+) error {
+	if _, err := tx.Exec(
+		`INSERT INTO session_project_identity_snapshots (
+			session_id, project, machine, root_path, git_remote,
+			git_remote_name, repository_path, worktree_name,
+			worktree_root_path, worktree_relationship, checkout_state,
+			git_branch, remote_resolution, remote_candidate_count,
+			observed_at, normalized_remote, key_source, key
+		)
+		SELECT ?, project, machine, root_path, git_remote,
+			git_remote_name, repository_path, worktree_name,
+			worktree_root_path, worktree_relationship, checkout_state,
+			git_branch, remote_resolution, remote_candidate_count,
+			observed_at, normalized_remote, key_source, key
+		FROM session_project_identity_snapshots
+		WHERE session_id = ?
+		ON CONFLICT(session_id) DO UPDATE SET
+			project = excluded.project,
+			machine = excluded.machine,
+			root_path = excluded.root_path,
+			git_remote = excluded.git_remote,
+			git_remote_name = excluded.git_remote_name,
+			repository_path = excluded.repository_path,
+			worktree_name = excluded.worktree_name,
+			worktree_root_path = excluded.worktree_root_path,
+			worktree_relationship = excluded.worktree_relationship,
+			checkout_state = excluded.checkout_state,
+			git_branch = excluded.git_branch,
+			remote_resolution = excluded.remote_resolution,
+			remote_candidate_count = excluded.remote_candidate_count,
+			observed_at = excluded.observed_at,
+			normalized_remote = excluded.normalized_remote,
+			key_source = excluded.key_source,
+			key = excluded.key`,
+		newID, oldID,
+	); err != nil {
+		return fmt.Errorf(
+			"migrating legacy trae project identity snapshot %s: %w",
+			oldID, err,
+		)
 	}
 	return nil
 }

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -1243,6 +1243,9 @@ func (db *DB) DeleteParserExcludedSessions(ids []string) (int, error) {
 		if id == "" {
 			continue
 		}
+		if isLegacyTraeSessionID(id) {
+			continue
+		}
 		if err := deleteSessionMessagesTx(tx, id); err != nil {
 			return 0, fmt.Errorf(
 				"pre-deleting parser-excluded session %s messages: %w",
@@ -1265,6 +1268,239 @@ func (db *DB) DeleteParserExcludedSessions(ids []string) (int, error) {
 		return 0, fmt.Errorf("commit parser-excluded delete: %w", err)
 	}
 	return int(deleted), nil
+}
+
+func isLegacyTraeSessionID(id string) bool {
+	if idx := strings.Index(id, "~"); idx > 0 {
+		id = id[idx+1:]
+	}
+	return strings.HasPrefix(id, "trae:") &&
+		!strings.HasPrefix(id, "trae:workspaceStorage:") &&
+		!strings.HasPrefix(id, "trae:globalStorage:")
+}
+
+func traeSessionNamespaceFromPath(path string) string {
+	path = filepath.ToSlash(strings.TrimSpace(path))
+	switch {
+	case strings.Contains(path, "/workspaceStorage/"):
+		return "workspaceStorage"
+	case strings.Contains(path, "/globalStorage/"):
+		return "globalStorage"
+	default:
+		return ""
+	}
+}
+
+func (db *DB) ExcludeSessionID(id string) error {
+	if err := db.requireWritable(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(id) == "" {
+		return nil
+	}
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	_, err := db.getWriter().Exec(
+		"INSERT OR IGNORE INTO excluded_sessions (id) VALUES (?)",
+		id,
+	)
+	return err
+}
+
+func (db *DB) MigrateLegacyTraeSessionState(
+	oldID, newID, targetNamespace string,
+) error {
+	if err := db.requireWritable(); err != nil {
+		return err
+	}
+	if oldID == "" || newID == "" || oldID == newID || targetNamespace == "" {
+		return nil
+	}
+
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	tx, err := db.getWriter().Begin()
+	if err != nil {
+		return fmt.Errorf("beginning trae legacy migration: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var (
+		oldPath      sql.NullString
+		oldName      sql.NullString
+		oldDeletedAt sql.NullString
+	)
+	err = tx.QueryRow(
+		`SELECT file_path, display_name, deleted_at
+		   FROM sessions
+		  WHERE id = ?`,
+		oldID,
+	).Scan(&oldPath, &oldName, &oldDeletedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("loading legacy trae session %s: %w", oldID, err)
+	}
+	oldNamespace := traeSessionNamespaceFromPath(oldPath.String)
+	if oldNamespace != "" && oldNamespace != targetNamespace {
+		return nil
+	}
+
+	pins, err := savePinsTx(tx, oldID)
+	if err != nil {
+		return fmt.Errorf("saving legacy trae pins %s: %w", oldID, err)
+	}
+
+	if _, err := tx.Exec(
+		`INSERT OR IGNORE INTO starred_sessions (session_id, created_at)
+		 SELECT ?, created_at
+		   FROM starred_sessions
+		  WHERE session_id = ?`,
+		newID, oldID,
+	); err != nil {
+		return fmt.Errorf("migrating legacy trae stars %s: %w", oldID, err)
+	}
+	if _, err := tx.Exec(
+		`UPDATE recall_entries
+		    SET source_session_id = ?
+		  WHERE source_session_id = ?`,
+		newID, oldID,
+	); err != nil {
+		return fmt.Errorf("migrating legacy trae recall entries %s: %w", oldID, err)
+	}
+	if _, err := tx.Exec(
+		`UPDATE recall_evidence
+		    SET session_id = ?
+		  WHERE session_id = ?`,
+		newID, oldID,
+	); err != nil {
+		return fmt.Errorf("migrating legacy trae recall evidence %s: %w", oldID, err)
+	}
+	if _, err := tx.Exec(
+		`UPDATE recall_extract_progress
+		    SET session_id = ?
+		  WHERE session_id = ?`,
+		newID, oldID,
+	); err != nil {
+		return fmt.Errorf(
+			"migrating legacy trae recall extract progress %s: %w",
+			oldID, err,
+		)
+	}
+	if _, err := tx.Exec(
+		`UPDATE sessions
+		    SET display_name = CASE
+		    		WHEN display_name IS NULL THEN ?
+		    		ELSE display_name
+		    	END,
+		    	deleted_at = COALESCE(deleted_at, ?),
+		    	local_modified_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+		  WHERE id = ?`,
+		nullStringValue(oldName),
+		nullStringValue(oldDeletedAt),
+		newID,
+	); err != nil {
+		return fmt.Errorf("applying legacy trae session state to %s: %w", newID, err)
+	}
+	if err := restorePinsTx(tx, newID, pins); err != nil {
+		return fmt.Errorf("restoring migrated trae pins to %s: %w", newID, err)
+	}
+	if err := deleteSessionMessagesTx(tx, oldID); err != nil {
+		return fmt.Errorf("pre-deleting legacy trae session %s messages: %w", oldID, err)
+	}
+	if _, err := tx.Exec("DELETE FROM sessions WHERE id = ?", oldID); err != nil {
+		return fmt.Errorf("deleting legacy trae session %s: %w", oldID, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit trae legacy migration: %w", err)
+	}
+	return nil
+}
+
+func (db *DB) MigrateAllLegacyTraeSessions() error {
+	if err := db.requireWritable(); err != nil {
+		return err
+	}
+	rows, err := db.getReader().Query(`
+		SELECT id, file_path
+		  FROM sessions
+		 WHERE agent = 'trae'
+		   AND id LIKE 'trae:%'
+		   AND id NOT LIKE 'trae:workspaceStorage:%'
+		   AND id NOT LIKE 'trae:globalStorage:%'`)
+	if err != nil {
+		return fmt.Errorf("listing legacy trae sessions: %w", err)
+	}
+	defer rows.Close()
+
+	type migration struct {
+		oldID     string
+		newID     string
+		namespace string
+	}
+	var migrations []migration
+	for rows.Next() {
+		var id string
+		var filePath sql.NullString
+		if err := rows.Scan(&id, &filePath); err != nil {
+			return fmt.Errorf("scanning legacy trae session: %w", err)
+		}
+		namespace := traeSessionNamespaceFromPath(filePath.String)
+		rawID := strings.TrimPrefix(id, "trae:")
+		rawID = strings.TrimPrefix(rawID, "trae:")
+		if rawID == "" {
+			continue
+		}
+		if namespace == "" {
+			workspaceID := "trae:workspaceStorage:" + rawID
+			globalID := "trae:globalStorage:" + rawID
+			var workspaceCount, globalCount int
+			_ = db.getReader().QueryRow(
+				"SELECT COUNT(*) FROM sessions WHERE id = ?",
+				workspaceID,
+			).Scan(&workspaceCount)
+			_ = db.getReader().QueryRow(
+				"SELECT COUNT(*) FROM sessions WHERE id = ?",
+				globalID,
+			).Scan(&globalCount)
+			switch {
+			case workspaceCount > 0 && globalCount == 0:
+				namespace = "workspaceStorage"
+			case globalCount > 0 && workspaceCount == 0:
+				namespace = "globalStorage"
+			case workspaceCount > 0:
+				namespace = "workspaceStorage"
+			}
+		}
+		if namespace == "" {
+			continue
+		}
+		migrations = append(migrations, migration{
+			oldID:     id,
+			newID:     "trae:" + namespace + ":" + rawID,
+			namespace: namespace,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterating legacy trae sessions: %w", err)
+	}
+	for _, migration := range migrations {
+		if err := db.MigrateLegacyTraeSessionState(
+			migration.oldID, migration.newID, migration.namespace,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func nullStringValue(value sql.NullString) any {
+	if value.Valid {
+		return value.String
+	}
+	return nil
 }
 
 const insertSessionSQL = `

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -1656,13 +1656,14 @@ const insertSessionSQL = `
 			termination_status,
 			cwd, git_branch, source_session_id,
 			source_version, transcript_fidelity,
+			transcript_revision,
 			parser_malformed_lines,
 			is_truncated,
 			last_write_incremental,
 			file_path, file_size, file_mtime,
 			next_ordinal, last_entry_uuid,
 			file_inode, file_device, file_hash
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 
 // insertSessionIfAbsentSQL inserts a session only when its id does not already
 // exist, leaving an existing row untouched.
@@ -1697,6 +1698,7 @@ const upsertSessionSQL = insertSessionSQL + `
 			source_session_id = excluded.source_session_id,
 			source_version = excluded.source_version,
 			transcript_fidelity = excluded.transcript_fidelity,
+			transcript_revision = excluded.transcript_revision,
 			parser_malformed_lines = excluded.parser_malformed_lines,
 			is_truncated = excluded.is_truncated,
 			-- last_write_incremental is deliberately NOT touched on conflict.
@@ -1724,6 +1726,17 @@ func sessionIsAutomated(s Session) bool {
 			IsAutomatedSession(*s.FirstMessage))
 }
 
+func sessionTranscriptRevisionValue(value *string) string {
+	if value == nil {
+		return "0"
+	}
+	trimmed := strings.TrimSpace(*value)
+	if trimmed == "" {
+		return "0"
+	}
+	return trimmed
+}
+
 func upsertSessionArgs(s Session) []any {
 	return []any{
 		s.ID, s.Project, s.Machine, s.Agent, s.FirstMessage, s.SessionName,
@@ -1737,6 +1750,7 @@ func upsertSessionArgs(s Session) []any {
 		s.TerminationStatus,
 		s.Cwd, s.GitBranch, s.SourceSessionID,
 		s.SourceVersion, s.TranscriptFidelity,
+		sessionTranscriptRevisionValue(s.TranscriptRevision),
 		s.ParserMalformedLines,
 		s.IsTruncated,
 		// last_write_incremental is seeded false on fresh INSERT: a brand-new

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -1332,16 +1332,25 @@ func (db *DB) MigrateLegacyTraeSessionState(
 	defer func() { _ = tx.Rollback() }()
 
 	var (
-		oldPath      sql.NullString
-		oldName      sql.NullString
-		oldDeletedAt sql.NullString
+		oldPath               sql.NullString
+		oldName               sql.NullString
+		oldDeletedAt          sql.NullString
+		oldSourceSessionID    sql.NullString
+		oldTranscriptRevision sql.NullString
 	)
 	err = tx.QueryRow(
-		`SELECT file_path, display_name, deleted_at
+		`SELECT file_path, display_name, deleted_at,
+		        source_session_id, transcript_revision
 		   FROM sessions
 		  WHERE id = ?`,
 		oldID,
-	).Scan(&oldPath, &oldName, &oldDeletedAt)
+	).Scan(
+		&oldPath,
+		&oldName,
+		&oldDeletedAt,
+		&oldSourceSessionID,
+		&oldTranscriptRevision,
+	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil
 	}
@@ -1361,6 +1370,71 @@ func (db *DB) MigrateLegacyTraeSessionState(
 	}
 	if !targetExists {
 		return nil
+	}
+	if oldNamespace == "" {
+		workspaceID, globalID := legacyTraeSiblingSessionIDs(
+			oldID, oldSourceSessionID.String,
+		)
+		otherID := ""
+		switch targetNamespace {
+		case "workspaceStorage":
+			if workspaceID != newID {
+				return nil
+			}
+			otherID = globalID
+		case "globalStorage":
+			if globalID != newID {
+				return nil
+			}
+			otherID = workspaceID
+		default:
+			return nil
+		}
+		if otherID == "" {
+			return nil
+		}
+		var otherExists bool
+		if err := tx.QueryRow(
+			`SELECT EXISTS(SELECT 1 FROM sessions WHERE id = ?)`,
+			otherID,
+		).Scan(&otherExists); err != nil {
+			return fmt.Errorf(
+				"checking migrated trae sibling target %s: %w",
+				otherID, err,
+			)
+		}
+		if otherExists {
+			oldRevision := strings.TrimSpace(oldTranscriptRevision.String)
+			if oldRevision == "" {
+				return nil
+			}
+			var (
+				targetRevision sql.NullString
+				otherRevision  sql.NullString
+			)
+			if err := tx.QueryRow(
+				`SELECT transcript_revision FROM sessions WHERE id = ?`,
+				newID,
+			).Scan(&targetRevision); err != nil {
+				return fmt.Errorf(
+					"loading migrated trae target revision %s: %w",
+					newID, err,
+				)
+			}
+			if err := tx.QueryRow(
+				`SELECT transcript_revision FROM sessions WHERE id = ?`,
+				otherID,
+			).Scan(&otherRevision); err != nil {
+				return fmt.Errorf(
+					"loading migrated trae sibling revision %s: %w",
+					otherID, err,
+				)
+			}
+			if oldRevision != strings.TrimSpace(targetRevision.String) ||
+				oldRevision == strings.TrimSpace(otherRevision.String) {
+				return nil
+			}
+		}
 	}
 
 	pins, err := savePinsTx(tx, oldID)
@@ -1442,7 +1516,7 @@ func (db *DB) MigrateAllLegacyTraeSessions() error {
 		return err
 	}
 	rows, err := db.getReader().Query(`
-		SELECT id, file_path
+		SELECT id, file_path, source_session_id
 		  FROM sessions
 		 WHERE agent = 'trae'
 		   AND id LIKE 'trae:%'
@@ -1462,41 +1536,44 @@ func (db *DB) MigrateAllLegacyTraeSessions() error {
 	for rows.Next() {
 		var id string
 		var filePath sql.NullString
-		if err := rows.Scan(&id, &filePath); err != nil {
+		var sourceSessionID sql.NullString
+		if err := rows.Scan(&id, &filePath, &sourceSessionID); err != nil {
 			return fmt.Errorf("scanning legacy trae session: %w", err)
 		}
-		hostPrefix, strippedID := legacyTraeSessionPrefixAndStrippedID(id)
-		namespace := traeSessionNamespaceFromPath(filePath.String)
-		rawID := strings.TrimPrefix(strippedID, "trae:")
-		rawID = strings.TrimPrefix(rawID, "trae:")
-		if rawID == "" {
+		newID, err := resolveLegacyTraeNamespacedID(
+			id,
+			filePath.String,
+			sourceSessionID.String,
+			func(candidate string) (bool, error) {
+				var ok bool
+				if err := db.getReader().QueryRow(
+					`SELECT EXISTS(SELECT 1 FROM sessions WHERE id = ?)`,
+					candidate,
+				).Scan(&ok); err != nil {
+					return false, err
+				}
+				return ok, nil
+			},
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"resolving legacy trae session target %s: %w",
+				id, err,
+			)
+		}
+		if newID == "" {
 			continue
 		}
-		if namespace == "" {
-			workspaceID := hostPrefix + "trae:workspaceStorage:" + rawID
-			globalID := hostPrefix + "trae:globalStorage:" + rawID
-			var workspaceCount, globalCount int
-			_ = db.getReader().QueryRow(
-				"SELECT COUNT(*) FROM sessions WHERE id = ?",
-				workspaceID,
-			).Scan(&workspaceCount)
-			_ = db.getReader().QueryRow(
-				"SELECT COUNT(*) FROM sessions WHERE id = ?",
-				globalID,
-			).Scan(&globalCount)
-			switch {
-			case workspaceCount > 0 && globalCount == 0:
-				namespace = "workspaceStorage"
-			case globalCount > 0 && workspaceCount == 0:
-				namespace = "globalStorage"
-			}
-		}
-		if namespace == "" {
-			continue
+		namespace := ""
+		switch {
+		case strings.Contains(newID, "trae:workspaceStorage:"):
+			namespace = "workspaceStorage"
+		case strings.Contains(newID, "trae:globalStorage:"):
+			namespace = "globalStorage"
 		}
 		migrations = append(migrations, migration{
 			oldID:     id,
-			newID:     hostPrefix + "trae:" + namespace + ":" + rawID,
+			newID:     newID,
 			namespace: namespace,
 		})
 	}

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -1789,6 +1789,23 @@ func (db *DB) UpsertSession(s Session) error {
 	if trashed == 1 {
 		return ErrSessionTrashed
 	}
+	if s.TranscriptRevision == nil {
+		var storedTranscriptRevision sql.NullString
+		err := db.getWriter().QueryRow(
+			"SELECT transcript_revision FROM sessions WHERE id = ?",
+			s.ID,
+		).Scan(&storedTranscriptRevision)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf(
+				"loading transcript revision for %s: %w",
+				s.ID, err,
+			)
+		}
+		if err == nil && storedTranscriptRevision.Valid {
+			revision := storedTranscriptRevision.String
+			s.TranscriptRevision = &revision
+		}
+	}
 
 	// data_version is intentionally NOT advanced here. The
 	// caller must call SetSessionDataVersion only after the

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -1352,6 +1352,16 @@ func (db *DB) MigrateLegacyTraeSessionState(
 	if oldNamespace != "" && oldNamespace != targetNamespace {
 		return nil
 	}
+	var targetExists bool
+	if err := tx.QueryRow(
+		`SELECT EXISTS(SELECT 1 FROM sessions WHERE id = ?)`,
+		newID,
+	).Scan(&targetExists); err != nil {
+		return fmt.Errorf("checking migrated trae target %s: %w", newID, err)
+	}
+	if !targetExists {
+		return nil
+	}
 
 	pins, err := savePinsTx(tx, oldID)
 	if err != nil {

--- a/internal/db/sessions_test.go
+++ b/internal/db/sessions_test.go
@@ -330,6 +330,44 @@ func TestUpsertSessionPersistsTranscriptRevision(t *testing.T) {
 	assert.Equal(t, "9", *session.TranscriptRevision)
 }
 
+func TestUpsertSessionPreservesTranscriptRevisionWhenOmitted(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sessions.db")
+	d, err := openCopiedTestDB(path)
+	require.NoError(t, err, "openCopiedTestDB")
+	defer d.Close()
+
+	ctx := context.Background()
+	revision := "7"
+	require.NoError(t, d.UpsertSession(Session{
+		ID:                 "trae:workspaceStorage:preserve-revision",
+		Project:            "proj",
+		Machine:            "mac",
+		Agent:              "trae",
+		SourceSessionID:    "preserve-revision",
+		TranscriptRevision: &revision,
+		MessageCount:       1,
+		UserMessageCount:   1,
+		CreatedAt:          "2026-07-21T00:00:00Z",
+	}), "UpsertSession initial")
+
+	require.NoError(t, d.UpsertSession(Session{
+		ID:               "trae:workspaceStorage:preserve-revision",
+		Project:          "proj",
+		Machine:          "mac",
+		Agent:            "trae",
+		SourceSessionID:  "preserve-revision",
+		MessageCount:     1,
+		UserMessageCount: 1,
+		CreatedAt:        "2026-07-21T00:00:00Z",
+	}), "UpsertSession omitted revision")
+
+	session, err := d.GetSession(ctx, "trae:workspaceStorage:preserve-revision")
+	require.NoError(t, err, "GetSession preserved revision")
+	require.NotNil(t, session)
+	require.NotNil(t, session.TranscriptRevision)
+	assert.Equal(t, "7", *session.TranscriptRevision)
+}
+
 func TestMigrateLegacyTraeSessionStatePreservesLegacyWhenUnknownNamespaceStaysAmbiguous(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "sessions.db")
 	d, err := openCopiedTestDB(path)

--- a/internal/db/sessions_test.go
+++ b/internal/db/sessions_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/export"
 )
 
 func TestDeleteSession_LargeSessionFTSDelete(t *testing.T) {
@@ -86,6 +88,113 @@ func TestMigrateLegacyTraeSessionStatePreservesLegacyWhenTargetMissing(t *testin
 		oldID,
 	).Scan(&starCount), "count legacy stars")
 	assert.Equal(t, 1, starCount, "legacy star should remain attached")
+}
+
+func TestMigrateLegacyTraeSessionStateMovesProjectIdentitySnapshot(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sessions.db")
+	d, err := openCopiedTestDB(path)
+	require.NoError(t, err, "openCopiedTestDB")
+	defer d.Close()
+
+	ctx := context.Background()
+	const oldID = "trae:legacy-snapshot"
+	const newID = "trae:workspaceStorage:legacy-snapshot"
+	legacyPath := filepath.Join(
+		t.TempDir(), "workspaceStorage", "legacy-snapshot", "transcript.jsonl",
+	)
+	require.NoError(t, d.UpsertSession(Session{
+		ID:               oldID,
+		Project:          "proj",
+		Machine:          "mac",
+		Agent:            "trae",
+		SourceSessionID:  "legacy-snapshot",
+		MessageCount:     1,
+		UserMessageCount: 1,
+		CreatedAt:        "2026-07-21T00:00:00Z",
+		FilePath:         &legacyPath,
+	}), "UpsertSession legacy")
+	require.NoError(t, d.UpsertSession(Session{
+		ID:               newID,
+		Project:          "proj",
+		Machine:          "mac",
+		Agent:            "trae",
+		SourceSessionID:  "legacy-snapshot",
+		MessageCount:     1,
+		UserMessageCount: 1,
+		CreatedAt:        "2026-07-21T00:01:00Z",
+		FilePath:         &legacyPath,
+	}), "UpsertSession namespaced")
+	require.NoError(t, d.UpsertProjectIdentityObservation(ctx,
+		export.ProjectIdentityObservation{
+			SessionID:     oldID,
+			Project:       "proj",
+			Machine:       "mac",
+			RootPath:      "/repo/app",
+			GitRemote:     "https://github.com/example/app.git",
+			ObservedAt:    time.Date(2026, 7, 21, 0, 0, 0, 0, time.UTC),
+			GitBranch:     "feature/legacy",
+			CheckoutState: export.CheckoutBranch,
+		},
+	), "UpsertProjectIdentityObservation")
+
+	require.NoError(t, d.MigrateLegacyTraeSessionState(
+		oldID, newID, "workspaceStorage",
+	), "MigrateLegacyTraeSessionState")
+
+	snapshots, err := d.listSessionProjectIdentitySnapshots(
+		ctx, []string{oldID, newID},
+	)
+	require.NoError(t, err, "listSessionProjectIdentitySnapshots")
+	assert.NotContains(t, snapshots, oldID)
+	require.Contains(t, snapshots, newID)
+	assert.Equal(t, "/repo/app", snapshots[newID].RootPath)
+	assert.Equal(t, "feature/legacy", snapshots[newID].GitBranch)
+}
+
+func TestMigrateAllLegacyTraeSessionsPreservesAmbiguousNamespace(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sessions.db")
+	d, err := openCopiedTestDB(path)
+	require.NoError(t, err, "openCopiedTestDB")
+	defer d.Close()
+
+	ctx := context.Background()
+	const oldID = "trae:legacy-ambiguous"
+	require.NoError(t, d.UpsertSession(Session{
+		ID:               oldID,
+		Project:          "proj",
+		Machine:          "mac",
+		Agent:            "trae",
+		SourceSessionID:  "legacy-ambiguous",
+		MessageCount:     1,
+		UserMessageCount: 1,
+		CreatedAt:        "2026-07-21T00:00:00Z",
+	}), "UpsertSession legacy")
+	require.NoError(t, d.UpsertSession(Session{
+		ID:               "trae:workspaceStorage:legacy-ambiguous",
+		Project:          "proj",
+		Machine:          "mac",
+		Agent:            "trae",
+		SourceSessionID:  "legacy-ambiguous",
+		MessageCount:     1,
+		UserMessageCount: 1,
+		CreatedAt:        "2026-07-21T00:01:00Z",
+	}), "UpsertSession workspace")
+	require.NoError(t, d.UpsertSession(Session{
+		ID:               "trae:globalStorage:legacy-ambiguous",
+		Project:          "proj",
+		Machine:          "mac",
+		Agent:            "trae",
+		SourceSessionID:  "legacy-ambiguous",
+		MessageCount:     1,
+		UserMessageCount: 1,
+		CreatedAt:        "2026-07-21T00:02:00Z",
+	}), "UpsertSession global")
+
+	require.NoError(t, d.MigrateAllLegacyTraeSessions(), "MigrateAllLegacyTraeSessions")
+
+	legacy, err := d.GetSession(ctx, oldID)
+	require.NoError(t, err, "GetSession legacy")
+	require.NotNil(t, legacy, "ambiguous legacy state should be preserved")
 }
 
 func TestFindSessionIDsByPartial(t *testing.T) {

--- a/internal/db/sessions_test.go
+++ b/internal/db/sessions_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -36,6 +37,55 @@ func TestDeleteSession_LargeSessionFTSDelete(t *testing.T) {
 	require.NoError(t, err, "neighbor pins count")
 	assert.Equal(t, crossSessionNeighborCount, neighborPins,
 		"neighbor pins count")
+}
+
+func TestMigrateLegacyTraeSessionStatePreservesLegacyWhenTargetMissing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sessions.db")
+	d, err := openCopiedTestDB(path)
+	require.NoError(t, err, "openCopiedTestDB")
+	defer d.Close()
+
+	ctx := context.Background()
+	const oldID = "trae:legacy-missing-target"
+	const newID = "trae:workspaceStorage:legacy-missing-target"
+	require.NoError(t, d.UpsertSession(Session{
+		ID:               oldID,
+		Project:          "proj",
+		Machine:          "mac",
+		Agent:            "trae",
+		SourceSessionID:  "legacy-missing-target",
+		MessageCount:     1,
+		UserMessageCount: 1,
+		CreatedAt:        "2026-07-21T00:00:00Z",
+	}), "UpsertSession")
+	require.NoError(t, d.InsertMessages([]Message{{
+		SessionID:     oldID,
+		Ordinal:       0,
+		Role:          "user",
+		Content:       "hello",
+		ContentLength: 5,
+	}}), "InsertMessages")
+	starred, err := d.StarSession(oldID)
+	require.NoError(t, err, "StarSession")
+	require.True(t, starred, "legacy session should be starred")
+
+	require.NoError(t, d.MigrateLegacyTraeSessionState(
+		oldID, newID, "workspaceStorage",
+	), "MigrateLegacyTraeSessionState")
+
+	legacy, err := d.GetSession(ctx, oldID)
+	require.NoError(t, err, "GetSession legacy")
+	require.NotNil(t, legacy, "legacy session should remain when target is absent")
+	migrated, err := d.GetSession(ctx, newID)
+	require.NoError(t, err, "GetSession migrated")
+	assert.Nil(t, migrated, "missing target should not be synthesized")
+
+	var starCount int
+	require.NoError(t, d.getReader().QueryRow(
+		`SELECT COUNT(*) FROM starred_sessions WHERE session_id = ?`,
+		oldID,
+	).Scan(&starCount), "count legacy stars")
+	assert.Equal(t, 1, starCount, "legacy star should remain attached")
 }
 
 func TestFindSessionIDsByPartial(t *testing.T) {

--- a/internal/db/sessions_test.go
+++ b/internal/db/sessions_test.go
@@ -197,6 +197,183 @@ func TestMigrateAllLegacyTraeSessionsPreservesAmbiguousNamespace(t *testing.T) {
 	require.NotNil(t, legacy, "ambiguous legacy state should be preserved")
 }
 
+func TestMigrateLegacyTraeSessionStateUsesTranscriptRevisionForUnknownNamespace(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sessions.db")
+	d, err := openCopiedTestDB(path)
+	require.NoError(t, err, "openCopiedTestDB")
+	defer d.Close()
+
+	ctx := context.Background()
+	const oldID = "trae:legacy-collision"
+	const workspaceID = "trae:workspaceStorage:legacy-collision"
+	const globalID = "trae:globalStorage:legacy-collision"
+	workspaceRev := "workspace-rev"
+	globalRev := "global-rev"
+	unknownPath := filepath.Join(t.TempDir(), "storage", "state.vscdb", "rewrite")
+	require.NoError(t, d.UpsertSession(Session{
+		ID:                 oldID,
+		Project:            "proj",
+		Machine:            "mac",
+		Agent:              "trae",
+		SourceSessionID:    "legacy-collision",
+		TranscriptRevision: &workspaceRev,
+		MessageCount:       1,
+		UserMessageCount:   1,
+		CreatedAt:          "2026-07-21T00:00:00Z",
+		FilePath:           &unknownPath,
+	}), "UpsertSession legacy")
+	require.NoError(t, d.UpsertSession(Session{
+		ID:                 workspaceID,
+		Project:            "proj",
+		Machine:            "mac",
+		Agent:              "trae",
+		SourceSessionID:    "legacy-collision",
+		TranscriptRevision: &workspaceRev,
+		MessageCount:       1,
+		UserMessageCount:   1,
+		CreatedAt:          "2026-07-21T00:01:00Z",
+	}), "UpsertSession workspace")
+	require.NoError(t, d.UpsertSession(Session{
+		ID:                 globalID,
+		Project:            "proj",
+		Machine:            "mac",
+		Agent:              "trae",
+		SourceSessionID:    "legacy-collision",
+		TranscriptRevision: &globalRev,
+		MessageCount:       1,
+		UserMessageCount:   1,
+		CreatedAt:          "2026-07-21T00:02:00Z",
+	}), "UpsertSession global")
+	require.NoError(t, d.InsertMessages([]Message{{
+		SessionID:     oldID,
+		Ordinal:       0,
+		Role:          "user",
+		Content:       "hello",
+		ContentLength: 5,
+	}}), "InsertMessages")
+	_, err = d.getWriter().Exec(
+		`UPDATE sessions SET transcript_revision = ? WHERE id = ?`,
+		workspaceRev, oldID,
+	)
+	require.NoError(t, err, "set legacy transcript revision")
+	_, err = d.getWriter().Exec(
+		`UPDATE sessions SET transcript_revision = ? WHERE id = ?`,
+		workspaceRev, workspaceID,
+	)
+	require.NoError(t, err, "set workspace transcript revision")
+	_, err = d.getWriter().Exec(
+		`UPDATE sessions SET transcript_revision = ? WHERE id = ?`,
+		globalRev, globalID,
+	)
+	require.NoError(t, err, "set global transcript revision")
+	starred, err := d.StarSession(oldID)
+	require.NoError(t, err, "StarSession")
+	require.True(t, starred)
+
+	require.NoError(t, d.MigrateLegacyTraeSessionState(
+		oldID, workspaceID, "workspaceStorage",
+	), "MigrateLegacyTraeSessionState")
+
+	legacy, err := d.GetSession(ctx, oldID)
+	require.NoError(t, err, "GetSession legacy")
+	assert.Nil(t, legacy, "matched transcript revision should migrate legacy state")
+
+	var workspaceStars int
+	require.NoError(t, d.getReader().QueryRow(
+		`SELECT COUNT(*) FROM starred_sessions WHERE session_id = ?`,
+		workspaceID,
+	).Scan(&workspaceStars), "count workspace stars")
+	assert.Equal(t, 1, workspaceStars)
+}
+
+func TestMigrateLegacyTraeSessionStatePreservesLegacyWhenUnknownNamespaceStaysAmbiguous(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sessions.db")
+	d, err := openCopiedTestDB(path)
+	require.NoError(t, err, "openCopiedTestDB")
+	defer d.Close()
+
+	ctx := context.Background()
+	const oldID = "trae:legacy-collision-ambiguous"
+	const workspaceID = "trae:workspaceStorage:legacy-collision-ambiguous"
+	const globalID = "trae:globalStorage:legacy-collision-ambiguous"
+	sharedRev := "shared-rev"
+	unknownPath := filepath.Join(t.TempDir(), "storage", "state.vscdb", "rewrite")
+	require.NoError(t, d.UpsertSession(Session{
+		ID:                 oldID,
+		Project:            "proj",
+		Machine:            "mac",
+		Agent:              "trae",
+		SourceSessionID:    "legacy-collision-ambiguous",
+		TranscriptRevision: &sharedRev,
+		MessageCount:       1,
+		UserMessageCount:   1,
+		CreatedAt:          "2026-07-21T00:00:00Z",
+		FilePath:           &unknownPath,
+	}), "UpsertSession legacy")
+	require.NoError(t, d.UpsertSession(Session{
+		ID:                 workspaceID,
+		Project:            "proj",
+		Machine:            "mac",
+		Agent:              "trae",
+		SourceSessionID:    "legacy-collision-ambiguous",
+		TranscriptRevision: &sharedRev,
+		MessageCount:       1,
+		UserMessageCount:   1,
+		CreatedAt:          "2026-07-21T00:01:00Z",
+	}), "UpsertSession workspace")
+	require.NoError(t, d.UpsertSession(Session{
+		ID:                 globalID,
+		Project:            "proj",
+		Machine:            "mac",
+		Agent:              "trae",
+		SourceSessionID:    "legacy-collision-ambiguous",
+		TranscriptRevision: &sharedRev,
+		MessageCount:       1,
+		UserMessageCount:   1,
+		CreatedAt:          "2026-07-21T00:02:00Z",
+	}), "UpsertSession global")
+	require.NoError(t, d.InsertMessages([]Message{{
+		SessionID:     oldID,
+		Ordinal:       0,
+		Role:          "user",
+		Content:       "hello",
+		ContentLength: 5,
+	}}), "InsertMessages")
+	_, err = d.getWriter().Exec(
+		`UPDATE sessions SET transcript_revision = ? WHERE id = ?`,
+		sharedRev, oldID,
+	)
+	require.NoError(t, err, "set legacy transcript revision")
+	_, err = d.getWriter().Exec(
+		`UPDATE sessions SET transcript_revision = ? WHERE id = ?`,
+		sharedRev, workspaceID,
+	)
+	require.NoError(t, err, "set workspace transcript revision")
+	_, err = d.getWriter().Exec(
+		`UPDATE sessions SET transcript_revision = ? WHERE id = ?`,
+		sharedRev, globalID,
+	)
+	require.NoError(t, err, "set global transcript revision")
+	starred, err := d.StarSession(oldID)
+	require.NoError(t, err, "StarSession")
+	require.True(t, starred)
+
+	require.NoError(t, d.MigrateLegacyTraeSessionState(
+		oldID, workspaceID, "workspaceStorage",
+	), "MigrateLegacyTraeSessionState")
+
+	legacy, err := d.GetSession(ctx, oldID)
+	require.NoError(t, err, "GetSession legacy")
+	require.NotNil(t, legacy, "shared revisions should preserve legacy state")
+
+	var legacyStars int
+	require.NoError(t, d.getReader().QueryRow(
+		`SELECT COUNT(*) FROM starred_sessions WHERE session_id = ?`,
+		oldID,
+	).Scan(&legacyStars), "count legacy stars")
+	assert.Equal(t, 1, legacyStars)
+}
+
 func TestFindSessionIDsByPartial(t *testing.T) {
 	d := testDB(t)
 	insertSession(t, d, "abcdef-1111-2222", "proj")

--- a/internal/db/sessions_test.go
+++ b/internal/db/sessions_test.go
@@ -286,6 +286,50 @@ func TestMigrateLegacyTraeSessionStateUsesTranscriptRevisionForUnknownNamespace(
 	assert.Equal(t, 1, workspaceStars)
 }
 
+func TestUpsertSessionPersistsTranscriptRevision(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sessions.db")
+	d, err := openCopiedTestDB(path)
+	require.NoError(t, err, "openCopiedTestDB")
+	defer d.Close()
+
+	ctx := context.Background()
+	revision := "7"
+	require.NoError(t, d.UpsertSession(Session{
+		ID:                 "persist-transcript-revision",
+		Project:            "proj",
+		Machine:            "mac",
+		Agent:              "claude",
+		TranscriptRevision: &revision,
+		MessageCount:       1,
+		UserMessageCount:   1,
+		CreatedAt:          "2026-07-21T00:00:00Z",
+	}), "UpsertSession initial")
+
+	session, err := d.GetSession(ctx, "persist-transcript-revision")
+	require.NoError(t, err, "GetSession initial")
+	require.NotNil(t, session)
+	require.NotNil(t, session.TranscriptRevision)
+	assert.Equal(t, "7", *session.TranscriptRevision)
+
+	revision = "9"
+	require.NoError(t, d.UpsertSession(Session{
+		ID:                 "persist-transcript-revision",
+		Project:            "proj",
+		Machine:            "mac",
+		Agent:              "claude",
+		TranscriptRevision: &revision,
+		MessageCount:       1,
+		UserMessageCount:   1,
+		CreatedAt:          "2026-07-21T00:00:00Z",
+	}), "UpsertSession update")
+
+	session, err = d.GetSession(ctx, "persist-transcript-revision")
+	require.NoError(t, err, "GetSession update")
+	require.NotNil(t, session)
+	require.NotNil(t, session.TranscriptRevision)
+	assert.Equal(t, "9", *session.TranscriptRevision)
+}
+
 func TestMigrateLegacyTraeSessionStatePreservesLegacyWhenUnknownNamespaceStaysAmbiguous(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "sessions.db")
 	d, err := openCopiedTestDB(path)

--- a/internal/db/trae_legacy_migration.go
+++ b/internal/db/trae_legacy_migration.go
@@ -1,0 +1,173 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+const legacyTraeTargetMapTable = "temp._legacy_trae_target_map"
+
+func legacyTraeRawSessionID(oldID, sourceSessionID string) string {
+	rawID := strings.TrimSpace(sourceSessionID)
+	if rawID != "" {
+		rawID = strings.TrimPrefix(rawID, "trae:")
+		rawID = strings.TrimPrefix(rawID, "trae:")
+		if rawID != "" {
+			return rawID
+		}
+	}
+	_, strippedID := legacyTraeSessionPrefixAndStrippedID(oldID)
+	rawID = strings.TrimPrefix(strippedID, "trae:")
+	rawID = strings.TrimPrefix(rawID, "trae:")
+	return strings.TrimSpace(rawID)
+}
+
+func legacyTraeSiblingSessionIDs(
+	oldID, sourceSessionID string,
+) (workspaceID, globalID string) {
+	rawID := legacyTraeRawSessionID(oldID, sourceSessionID)
+	if rawID == "" {
+		return "", ""
+	}
+	hostPrefix, _ := legacyTraeSessionPrefixAndStrippedID(oldID)
+	return hostPrefix + "trae:workspaceStorage:" + rawID,
+		hostPrefix + "trae:globalStorage:" + rawID
+}
+
+func resolveLegacyTraeNamespacedID(
+	oldID, filePath, sourceSessionID string,
+	exists func(string) (bool, error),
+) (string, error) {
+	workspaceID, globalID := legacyTraeSiblingSessionIDs(oldID, sourceSessionID)
+	if workspaceID == "" || globalID == "" {
+		return "", nil
+	}
+
+	namespace := traeSessionNamespaceFromPath(filePath)
+	switch namespace {
+	case "workspaceStorage":
+		ok, err := exists(workspaceID)
+		if err != nil {
+			return "", err
+		}
+		if ok {
+			return workspaceID, nil
+		}
+		return "", nil
+	case "globalStorage":
+		ok, err := exists(globalID)
+		if err != nil {
+			return "", err
+		}
+		if ok {
+			return globalID, nil
+		}
+		return "", nil
+	}
+
+	workspaceExists, err := exists(workspaceID)
+	if err != nil {
+		return "", err
+	}
+	globalExists, err := exists(globalID)
+	if err != nil {
+		return "", err
+	}
+	switch {
+	case workspaceExists && !globalExists:
+		return workspaceID, nil
+	case globalExists && !workspaceExists:
+		return globalID, nil
+	default:
+		return "", nil
+	}
+}
+
+func rebuildLegacyTraeTargetMapTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	sourceSessionsTable, targetSessionsTable string,
+) error {
+	if _, err := tx.ExecContext(ctx,
+		`DROP TABLE IF EXISTS `+legacyTraeTargetMapTable,
+	); err != nil {
+		return fmt.Errorf("dropping legacy trae target map: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx,
+		`CREATE TEMP TABLE `+legacyTraeTargetMapTable+` (
+			legacy_id TEXT PRIMARY KEY,
+			namespaced_id TEXT NOT NULL
+		)`,
+	); err != nil {
+		return fmt.Errorf("creating legacy trae target map: %w", err)
+	}
+
+	rows, err := tx.QueryContext(ctx, fmt.Sprintf(`
+		SELECT id, file_path, source_session_id
+		FROM %s
+		WHERE agent = 'trae'
+		  AND (id LIKE 'trae:%%' OR id LIKE '%%~trae:%%')
+		  AND id NOT LIKE 'trae:workspaceStorage:%%'
+		  AND id NOT LIKE 'trae:globalStorage:%%'
+		  AND id NOT LIKE '%%~trae:workspaceStorage:%%'
+		  AND id NOT LIKE '%%~trae:globalStorage:%%'`,
+		sourceSessionsTable,
+	))
+	if err != nil {
+		return fmt.Errorf("querying legacy trae target map rows: %w", err)
+	}
+	defer rows.Close()
+
+	exists := func(id string) (bool, error) {
+		var ok bool
+		if err := tx.QueryRowContext(ctx,
+			fmt.Sprintf(
+				`SELECT EXISTS(SELECT 1 FROM %s WHERE id = ?)`,
+				targetSessionsTable,
+			),
+			id,
+		).Scan(&ok); err != nil {
+			return false, err
+		}
+		return ok, nil
+	}
+
+	for rows.Next() {
+		var (
+			oldID           string
+			filePath        sql.NullString
+			sourceSessionID sql.NullString
+		)
+		if err := rows.Scan(&oldID, &filePath, &sourceSessionID); err != nil {
+			return fmt.Errorf("scanning legacy trae target map row: %w", err)
+		}
+		namespacedID, err := resolveLegacyTraeNamespacedID(
+			oldID,
+			filePath.String,
+			sourceSessionID.String,
+			exists,
+		)
+		if err != nil {
+			return fmt.Errorf("resolving legacy trae target for %s: %w", oldID, err)
+		}
+		if namespacedID == "" {
+			continue
+		}
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO `+legacyTraeTargetMapTable+` (legacy_id, namespaced_id)
+			 VALUES (?, ?)`,
+			oldID, namespacedID,
+		); err != nil {
+			return fmt.Errorf(
+				"inserting legacy trae target map row %s -> %s: %w",
+				oldID, namespacedID, err,
+			)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterating legacy trae target map rows: %w", err)
+	}
+	return nil
+}

--- a/internal/db/trae_legacy_migration_test.go
+++ b/internal/db/trae_legacy_migration_test.go
@@ -1,0 +1,74 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveLegacyTraeNamespacedID(t *testing.T) {
+	tests := []struct {
+		name            string
+		oldID           string
+		filePath        string
+		sourceSessionID string
+		existing        map[string]bool
+		want            string
+	}{
+		{
+			name:            "path-derived workspace target must exist",
+			oldID:           "trae:rewrite",
+			filePath:        "/tmp/workspaceStorage/hash/state.vscdb#rewrite",
+			sourceSessionID: "rewrite",
+			existing:        map[string]bool{},
+			want:            "",
+		},
+		{
+			name:            "unknown path falls back to unique workspace target",
+			oldID:           "trae:rewrite",
+			filePath:        "/tmp/other/state.vscdb#rewrite",
+			sourceSessionID: "rewrite",
+			existing: map[string]bool{
+				"trae:workspaceStorage:rewrite": true,
+			},
+			want: "trae:workspaceStorage:rewrite",
+		},
+		{
+			name:            "unknown path preserves ambiguous legacy state",
+			oldID:           "trae:rewrite",
+			filePath:        "/tmp/other/state.vscdb#rewrite",
+			sourceSessionID: "rewrite",
+			existing: map[string]bool{
+				"trae:workspaceStorage:rewrite": true,
+				"trae:globalStorage:rewrite":    true,
+			},
+			want: "",
+		},
+		{
+			name:            "host-prefixed legacy id keeps host on unique fallback",
+			oldID:           "laptop~trae:rewrite",
+			filePath:        "/tmp/other/state.vscdb#rewrite",
+			sourceSessionID: "rewrite",
+			existing: map[string]bool{
+				"laptop~trae:globalStorage:rewrite": true,
+			},
+			want: "laptop~trae:globalStorage:rewrite",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveLegacyTraeNamespacedID(
+				tc.oldID,
+				tc.filePath,
+				tc.sourceSessionID,
+				func(id string) (bool, error) {
+					return tc.existing[id], nil
+				},
+			)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/internal/parser/trae_provider.go
+++ b/internal/parser/trae_provider.go
@@ -114,16 +114,31 @@ func traeMatch(dbPath, id string) multiSessionMatch {
 }
 
 func traeFindMember(root, rawID string) (multiSessionMatch, bool) {
+	namespace, lookupID := traeLookupNamespace(rawID)
 	for _, db := range traeDBs(root) {
+		if namespace != "" {
+			got, err := traeStorageNamespace(db.path)
+			if err != nil || got != namespace {
+				continue
+			}
+		}
 		snapshot, err := traeLoadSessionSnapshot(db.path)
 		if err != nil {
 			continue
 		}
-		if _, ok := snapshot.ids[rawID]; ok {
-			return traeMatch(db.path, rawID), true
+		if _, ok := snapshot.ids[lookupID]; ok {
+			return traeMatch(db.path, lookupID), true
 		}
 	}
 	return multiSessionMatch{}, false
+}
+
+func traeLookupNamespace(rawID string) (string, string) {
+	if namespace, id, ok := strings.Cut(rawID, ":"); ok &&
+		(namespace == "workspaceStorage" || namespace == "globalStorage") && id != "" {
+		return namespace, id
+	}
+	return "", rawID
 }
 
 func traeFingerprintSource(src multiSessionSource) (SourceFingerprint, error) {
@@ -213,17 +228,33 @@ func traeParseMember(
 }
 
 func traeParseRecord(src multiSessionSource, record traeSessionRecord, req ParseRequest) (*ParseResult, error) {
+	namespace, err := traeStorageNamespace(src.Container)
+	if err != nil {
+		return nil, err
+	}
 	sess, msgs := parseTraeSessionRecord(
 		record.Session,
 		req.Source.ProjectHint,
 		req.Machine,
 		traeVirtualPath(src.Container, record.SessionID),
+		namespace,
 	)
 	if sess == nil {
 		return nil, nil
 	}
 	sess.File.Hash = traeRecordHash(record.Hash, req.Source.ProjectHint)
 	return &ParseResult{Session: *sess, Messages: msgs}, nil
+}
+
+func traeStorageNamespace(container string) (string, error) {
+	container = filepath.Clean(container)
+	if filepath.Base(filepath.Dir(container)) == "globalStorage" {
+		return "globalStorage", nil
+	}
+	if filepath.Base(filepath.Dir(filepath.Dir(container))) == "workspaceStorage" {
+		return "workspaceStorage", nil
+	}
+	return "", fmt.Errorf("trae container %s has no supported storage namespace", container)
 }
 
 func traeMemberPresent(src multiSessionSource) bool {
@@ -495,7 +526,7 @@ func (t *traeTime) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func parseTraeSessionRecord(selected traeSession, project, machine, virtualPath string) (*ParsedSession, []ParsedMessage) {
+func parseTraeSessionRecord(selected traeSession, project, machine, virtualPath, namespace string) (*ParsedSession, []ParsedMessage) {
 	var messages []ParsedMessage
 	first := ""
 	started := selected.CreatedAt.Time
@@ -534,7 +565,8 @@ func parseTraeSessionRecord(selected traeSession, project, machine, virtualPath 
 	if ended.IsZero() {
 		ended = messages[len(messages)-1].Timestamp
 	}
-	sess := &ParsedSession{ID: "trae:" + strings.TrimPrefix(selected.SessionID, "trae:"), Project: project, Machine: machine, Agent: AgentTrae, SourceSessionID: selected.SessionID, FirstMessage: first, StartedAt: started, EndedAt: ended, MessageCount: len(messages), File: FileInfo{Path: virtualPath}}
+	rawSessionID := strings.TrimSpace(selected.SessionID)
+	sess := &ParsedSession{ID: "trae:" + namespace + ":" + strings.TrimPrefix(rawSessionID, "trae:"), Project: project, Machine: machine, Agent: AgentTrae, SourceSessionID: rawSessionID, FirstMessage: first, StartedAt: started, EndedAt: ended, MessageCount: len(messages), File: FileInfo{Path: virtualPath}}
 	if started.IsZero() {
 		sess.StartedAt = messages[0].Timestamp
 	}

--- a/internal/parser/trae_provider.go
+++ b/internal/parser/trae_provider.go
@@ -255,7 +255,8 @@ func traeParseRecord(src multiSessionSource, record traeSessionRecord, req Parse
 }
 
 func traeLegacySessionID(rawID string) string {
-	return string(AgentTrae) + ":" + strings.TrimSpace(rawID)
+	return string(AgentTrae) + ":" +
+		strings.TrimPrefix(strings.TrimSpace(rawID), "trae:")
 }
 
 func traeStorageNamespace(container string) (string, error) {

--- a/internal/parser/trae_provider.go
+++ b/internal/parser/trae_provider.go
@@ -176,12 +176,19 @@ func traeParseContainerOutcome(
 		}, nil
 	}
 	results := make([]ParseResultOutcome, 0, len(snapshot.records))
+	excluded := make([]string, 0, len(snapshot.records))
+	seenExcluded := make(map[string]struct{}, len(snapshot.records))
 	for _, record := range snapshot.records {
 		result, err := traeParseRecord(src, record, req)
 		if err != nil {
 			return ParseOutcome{}, err
 		}
 		if result != nil {
+			legacyID := traeLegacySessionID(record.SessionID)
+			if _, ok := seenExcluded[legacyID]; !ok {
+				seenExcluded[legacyID] = struct{}{}
+				excluded = append(excluded, legacyID)
+			}
 			results = append(results, ParseResultOutcome{
 				Result:      *result,
 				DataVersion: DataVersionCurrent,
@@ -196,9 +203,10 @@ func traeParseContainerOutcome(
 		}, nil
 	}
 	return ParseOutcome{
-		Results:           results,
-		ResultSetComplete: snapshot.complete,
-		ForceReplace:      true,
+		Results:            results,
+		ExcludedSessionIDs: excluded,
+		ResultSetComplete:  snapshot.complete,
+		ForceReplace:       true,
 	}, nil
 }
 
@@ -244,6 +252,10 @@ func traeParseRecord(src multiSessionSource, record traeSessionRecord, req Parse
 	}
 	sess.File.Hash = traeRecordHash(record.Hash, req.Source.ProjectHint)
 	return &ParseResult{Session: *sess, Messages: msgs}, nil
+}
+
+func traeLegacySessionID(rawID string) string {
+	return string(AgentTrae) + ":" + strings.TrimSpace(rawID)
 }
 
 func traeStorageNamespace(container string) (string, error) {

--- a/internal/parser/trae_provider_test.go
+++ b/internal/parser/trae_provider_test.go
@@ -153,6 +153,11 @@ func TestTraeWorkspaceGlobalCollisionIdentity(t *testing.T) {
 	assert.NotEqual(t, ids["workspaceStorage"], ids["globalStorage"])
 }
 
+func TestTraeLegacySessionIDNormalizesExistingPrefix(t *testing.T) {
+	assert.Equal(t, "trae:prefixed", traeLegacySessionID("trae:prefixed"))
+	assert.Equal(t, "trae:prefixed", traeLegacySessionID(" prefixed "))
+}
+
 func mustTraeStorageNamespace(t *testing.T, path string) string {
 	t.Helper()
 	namespace, err := traeStorageNamespace(path)

--- a/internal/parser/trae_provider_test.go
+++ b/internal/parser/trae_provider_test.go
@@ -86,7 +86,9 @@ func TestTraeWorkspaceGlobalDiscoveryAndParsing(t *testing.T) {
 	require.Len(t, sources, 2)
 
 	for _, source := range sources {
+		namespace := "globalStorage"
 		if strings.Contains(source.Key, "workspaceStorage") {
+			namespace = "workspaceStorage"
 			assert.Equal(t, "project", source.ProjectHint)
 		}
 		assert.NotContains(t, source.Key, "#session-1")
@@ -95,13 +97,65 @@ func TestTraeWorkspaceGlobalDiscoveryAndParsing(t *testing.T) {
 		require.Len(t, outcome.Results, 1)
 		result := outcome.Results[0].Result
 		assert.Equal(t, AgentTrae, result.Session.Agent)
-		assert.Equal(t, "trae:session-1", result.Session.ID)
+		assert.Equal(t, "trae:"+namespace+":session-1", result.Session.ID)
+		assert.Equal(t, "session-1", result.Session.SourceSessionID)
+		assert.Equal(t, traeVirtualPath(source.Key, "session-1"), result.Session.File.Path)
 		assert.Equal(t, []string{"first", "fallback"}, []string{result.Messages[0].Content, result.Messages[1].Content})
 		assert.Equal(t, "trae-model", result.Messages[1].Model)
 		assert.Empty(t, result.UsageEvents)
 		assert.False(t, result.Messages[1].HasOutputTokens)
 		assert.Equal(t, RelationshipType(""), result.Session.RelationshipType)
 	}
+}
+
+func TestTraeStorageNamespaceRequiresSupportedContainer(t *testing.T) {
+	assert.Equal(t, "workspaceStorage", mustTraeStorageNamespace(t, filepath.Join("root", "workspaceStorage", "hash", traeStateDBName)))
+	assert.Equal(t, "globalStorage", mustTraeStorageNamespace(t, filepath.Join("root", "globalStorage", traeStateDBName)))
+	_, err := traeStorageNamespace(filepath.Join("root", "other", traeStateDBName))
+	assert.Error(t, err)
+}
+
+func TestTraeWorkspaceGlobalCollisionIdentity(t *testing.T) {
+	root := t.TempDir()
+	workspaceDB := filepath.Join(root, "workspaceStorage", "hash", traeStateDBName)
+	globalDB := filepath.Join(root, "globalStorage", traeStateDBName)
+	collision := func(content string) string {
+		return traeStoreValue(t, []any{map[string]any{
+			"sessionId": "collision",
+			"createdAt": 1715340600000,
+			"messages":  []any{map[string]any{"role": "user", "content": content}},
+		}})
+	}
+	writeTraeDB(t, workspaceDB, collision("workspace"), "memento/unrelated-chat-storage")
+	writeTraeDB(t, globalDB, collision("global"), "memento/unrelated-chat-storage")
+
+	factory, ok := ProviderFactoryByType(AgentTrae)
+	require.True(t, ok)
+	sources, err := factory.NewProvider(ProviderConfig{Roots: []string{root}}).Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 2)
+	ids := map[string]string{}
+	for _, source := range sources {
+		outcome, err := factory.NewProvider(ProviderConfig{Roots: []string{root}}).Parse(context.Background(), ParseRequest{Source: source})
+		require.NoError(t, err)
+		require.Len(t, outcome.Results, 1)
+		result := outcome.Results[0].Result
+		namespace := "globalStorage"
+		if strings.Contains(source.Key, "workspaceStorage") {
+			namespace = "workspaceStorage"
+		}
+		ids[namespace] = result.Session.ID
+		assert.Equal(t, "trae:"+namespace+":collision", result.Session.ID)
+		assert.Equal(t, "collision", result.Session.SourceSessionID)
+	}
+	assert.NotEqual(t, ids["workspaceStorage"], ids["globalStorage"])
+}
+
+func mustTraeStorageNamespace(t *testing.T, path string) string {
+	t.Helper()
+	namespace, err := traeStorageNamespace(path)
+	require.NoError(t, err)
+	return namespace
 }
 
 func TestTraeWatchChangedPathAndVirtualLookup(t *testing.T) {
@@ -360,7 +414,7 @@ func TestTraeMalformedSessionEntryKeepsContainerIncomplete(t *testing.T) {
 	outcome, err := provider.Parse(context.Background(), ParseRequest{Source: sources[0]})
 	require.NoError(t, err)
 	require.Len(t, outcome.Results, 1)
-	assert.Equal(t, "trae:good", outcome.Results[0].Result.Session.ID)
+	assert.Equal(t, "trae:globalStorage:good", outcome.Results[0].Result.Session.ID)
 	assert.False(t, outcome.ResultSetComplete)
 
 	changed, err := provider.SourcesForChangedPath(context.Background(), ChangedPathRequest{
@@ -426,7 +480,7 @@ func TestTraeUnparseableSessionStatesKeepContainerIncomplete(t *testing.T) {
 			outcome, err := provider.Parse(context.Background(), ParseRequest{Source: sources[0]})
 			require.NoError(t, err)
 			require.Len(t, outcome.Results, 1)
-			assert.Equal(t, "trae:good", outcome.Results[0].Result.Session.ID)
+			assert.Equal(t, "trae:globalStorage:good", outcome.Results[0].Result.Session.ID)
 			assert.False(t, outcome.ResultSetComplete)
 
 			virtual := traeVirtualPath(path, tc.session["sessionId"].(string))

--- a/internal/parser/trae_provider_test.go
+++ b/internal/parser/trae_provider_test.go
@@ -98,6 +98,7 @@ func TestTraeWorkspaceGlobalDiscoveryAndParsing(t *testing.T) {
 		result := outcome.Results[0].Result
 		assert.Equal(t, AgentTrae, result.Session.Agent)
 		assert.Equal(t, "trae:"+namespace+":session-1", result.Session.ID)
+		assert.Equal(t, []string{"trae:session-1"}, outcome.ExcludedSessionIDs)
 		assert.Equal(t, "session-1", result.Session.SourceSessionID)
 		assert.Equal(t, traeVirtualPath(source.Key, "session-1"), result.Session.File.Path)
 		assert.Equal(t, []string{"first", "fallback"}, []string{result.Messages[0].Content, result.Messages[1].Content})
@@ -145,6 +146,7 @@ func TestTraeWorkspaceGlobalCollisionIdentity(t *testing.T) {
 			namespace = "workspaceStorage"
 		}
 		ids[namespace] = result.Session.ID
+		assert.Equal(t, []string{"trae:collision"}, outcome.ExcludedSessionIDs)
 		assert.Equal(t, "trae:"+namespace+":collision", result.Session.ID)
 		assert.Equal(t, "collision", result.Session.SourceSessionID)
 	}
@@ -414,6 +416,7 @@ func TestTraeMalformedSessionEntryKeepsContainerIncomplete(t *testing.T) {
 	outcome, err := provider.Parse(context.Background(), ParseRequest{Source: sources[0]})
 	require.NoError(t, err)
 	require.Len(t, outcome.Results, 1)
+	assert.Equal(t, []string{"trae:good"}, outcome.ExcludedSessionIDs)
 	assert.Equal(t, "trae:globalStorage:good", outcome.Results[0].Result.Session.ID)
 	assert.False(t, outcome.ResultSetComplete)
 
@@ -480,6 +483,7 @@ func TestTraeUnparseableSessionStatesKeepContainerIncomplete(t *testing.T) {
 			outcome, err := provider.Parse(context.Background(), ParseRequest{Source: sources[0]})
 			require.NoError(t, err)
 			require.Len(t, outcome.Results, 1)
+			assert.Equal(t, []string{"trae:good"}, outcome.ExcludedSessionIDs)
 			assert.Equal(t, "trae:globalStorage:good", outcome.Results[0].Result.Session.ID)
 			assert.False(t, outcome.ResultSetComplete)
 

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -1043,6 +1043,11 @@ func (s *Sync) pushBatchAttempt(
 	}
 
 	for _, sess := range batch {
+		if pgShouldSkipLegacyTraeBatchSession(
+			batchSessions, sess,
+		) {
+			continue
+		}
 		if err := s.pushSession(
 			ctx, tx, sess, markerID, legacyMarkerMachines,
 		); err != nil {
@@ -1820,6 +1825,39 @@ revisionCheckDone:
 		)
 	}
 	return nil
+}
+
+func pgShouldSkipLegacyTraeBatchSession(
+	batchSessions map[string]db.Session,
+	sess db.Session,
+) bool {
+	if sess.Agent != "trae" {
+		return false
+	}
+	if _, hasNamespace := pgTraeNamespacedSessionNamespace(sess.ID); hasNamespace {
+		return false
+	}
+	rawID := strings.TrimSpace(sess.SourceSessionID)
+	rawID = strings.TrimPrefix(rawID, "trae:")
+	rawID = strings.TrimPrefix(rawID, "trae:")
+	if rawID == "" {
+		rawID = strings.TrimPrefix(
+			strings.TrimPrefix(
+				strings.TrimPrefix(sess.ID, pgSessionIDPrefix(sess.ID)),
+				"trae:",
+			),
+			"trae:",
+		)
+	}
+	if rawID == "" {
+		return false
+	}
+	prefix := pgSessionIDPrefix(sess.ID)
+	workspaceID := prefix + "trae:workspaceStorage:" + rawID
+	globalID := prefix + "trae:globalStorage:" + rawID
+	_, hasWorkspace := batchSessions[workspaceID]
+	_, hasGlobal := batchSessions[globalID]
+	return hasWorkspace || hasGlobal
 }
 
 func pgPreferredTranscriptRevision(

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -1538,6 +1538,50 @@ func deletePGSessionIfExcluded(
 	return true, nil
 }
 
+func deletePGLegacyTraeSessionIfOwned(
+	ctx context.Context,
+	tx *sql.Tx,
+	sess db.Session,
+	markerID, pushedMachine string,
+	legacyMarkerMachines []string,
+) error {
+	legacyID := pgTraeLegacySessionID(sess)
+	if legacyID == "" {
+		return nil
+	}
+	if legacyMarkerMachines == nil {
+		legacyMarkerMachines = []string{}
+	}
+	legacyMarkerMachinesJSON, err := json.Marshal(legacyMarkerMachines)
+	if err != nil {
+		return fmt.Errorf("encoding legacy marker machines: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM sessions
+		 WHERE id = $1
+		   AND (
+		     (
+		       owner_marker = ''
+		       AND (
+		         machine = $2
+		         OR machine = 'local'
+		         OR machine = ''
+		         OR machine IN (
+		           SELECT jsonb_array_elements_text($3::jsonb)
+		         )
+		       )
+		     )
+		     OR owner_marker = $4
+		   )`,
+		legacyID, pushedMachine, string(legacyMarkerMachinesJSON), markerID,
+	); err != nil {
+		return fmt.Errorf(
+			"deleting owned legacy trae session %s: %w", legacyID, err,
+		)
+	}
+	return nil
+}
+
 // sessionPushFingerprint builds the change-detection fingerprint for a
 // session. pushedMachine is the value pushSession actually writes to PG
 // (pushedSessionMachine), not the raw sess.Machine: a "local"/empty sentinel
@@ -2028,6 +2072,11 @@ func (s *Sync) pushSession(
 		return errSessionExcluded
 	}
 	if err := replacePGSessionAliases(ctx, tx, sess); err != nil {
+		return err
+	}
+	if err := deletePGLegacyTraeSessionIfOwned(
+		ctx, tx, sess, markerID, pushedMachine, legacyMarkerMachines,
+	); err != nil {
 		return err
 	}
 	return nil

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -1583,9 +1583,15 @@ func deletePGLegacyTraeSessionIfOwned(
 				legacyID, err,
 			)
 		}
-		if legacyLocal != nil && legacyLocal.TranscriptRevision != nil {
-			legacyTranscriptRevision = legacyLocal.TranscriptRevision
-		}
+		legacyTranscriptRevision = pgPreferredTranscriptRevision(
+			sess.TranscriptRevision,
+			func() *string {
+				if legacyLocal == nil {
+					return nil
+				}
+				return legacyLocal.TranscriptRevision
+			}(),
+		)
 		if legacyLocal != nil && legacyLocal.FilePath != nil {
 			legacyNamespace := pgTraeSessionNamespaceFromPath(*legacyLocal.FilePath)
 			if legacyNamespace != "" {
@@ -1814,6 +1820,15 @@ revisionCheckDone:
 		)
 	}
 	return nil
+}
+
+func pgPreferredTranscriptRevision(
+	current, legacy *string,
+) *string {
+	if current != nil && *current != "" {
+		return current
+	}
+	return legacy
 }
 
 func pgResolveTraeSiblingSession(

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -1619,7 +1619,11 @@ func deletePGLegacyTraeSessionIfOwned(
 			}
 			if workspaceSibling != nil && globalSibling != nil {
 				if !pgTraeHasUniqueSiblingRevision(
-					currentNamespace, sess, *workspaceSibling, *globalSibling,
+					currentNamespace,
+					transcriptRevisionValue(legacyTranscriptRevision),
+					sess,
+					*workspaceSibling,
+					*globalSibling,
 				) {
 					return nil
 				}
@@ -1807,9 +1811,13 @@ revisionCheckDone:
 
 func pgTraeHasUniqueSiblingRevision(
 	currentNamespace string,
+	legacyRevision string,
 	current, workspaceSibling, globalSibling db.Session,
 ) bool {
 	currentRevision := transcriptRevisionValue(current.TranscriptRevision)
+	if currentRevision == "" || currentRevision != legacyRevision {
+		return false
+	}
 	switch currentNamespace {
 	case "workspaceStorage":
 		return currentRevision != transcriptRevisionValue(

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -1580,12 +1580,19 @@ func deletePGLegacyTraeSessionIfOwned(
 				legacyID, err,
 			)
 		}
+		if legacyLocal != nil && legacyLocal.TranscriptRevision != nil {
+			legacyTranscriptRevision = legacyLocal.TranscriptRevision
+		}
 		if legacyLocal != nil && legacyLocal.FilePath != nil {
 			legacyNamespace := pgTraeSessionNamespaceFromPath(*legacyLocal.FilePath)
-			if legacyNamespace != "" && legacyNamespace != currentNamespace {
-				return nil
+			if legacyNamespace != "" {
+				if legacyNamespace != currentNamespace {
+					return nil
+				}
+				goto revisionCheckDone
 			}
-		} else {
+		}
+		{
 			rawID := strings.TrimPrefix(
 				strings.TrimPrefix(
 					strings.TrimPrefix(sess.ID, pgSessionIDPrefix(sess.ID)),
@@ -1620,6 +1627,7 @@ func deletePGLegacyTraeSessionIfOwned(
 			}
 		}
 	}
+revisionCheckDone:
 	if legacyMarkerMachines == nil {
 		legacyMarkerMachines = []string{}
 	}

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -1561,6 +1561,23 @@ func deletePGLegacyTraeSessionIfOwned(
 	if legacyID == "" {
 		return nil
 	}
+	requireRevisionMatch := false
+	if stripped := strings.TrimPrefix(sess.ID, pgSessionIDPrefix(sess.ID)); strings.HasPrefix(stripped, "trae:workspaceStorage:") ||
+		strings.HasPrefix(stripped, "trae:globalStorage:") {
+		rawID := strings.TrimPrefix(stripped, "trae:workspaceStorage:")
+		rawID = strings.TrimPrefix(rawID, "trae:globalStorage:")
+		prefix := pgSessionIDPrefix(sess.ID)
+		var siblingCount int
+		if err := tx.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM sessions WHERE id = $1 OR id = $2`,
+			prefix+"trae:workspaceStorage:"+rawID,
+			prefix+"trae:globalStorage:"+rawID,
+		).Scan(&siblingCount); err != nil {
+			return fmt.Errorf("counting namespaced trae siblings for %s: %w", sess.ID, err)
+		}
+		requireRevisionMatch = siblingCount > 1
+	}
+	legacyTranscriptRevision := sess.TranscriptRevision
 	if legacyMarkerMachines == nil {
 		legacyMarkerMachines = []string{}
 	}
@@ -1589,8 +1606,14 @@ func deletePGLegacyTraeSessionIfOwned(
 				)
 				OR legacy_session.owner_marker = $4
 			)
+			AND (
+				NOT $6
+				OR COALESCE(legacy_session.transcript_revision, '') = $7
+			)
 		ON CONFLICT (session_id) DO NOTHING`,
-		legacyID, sess.ID, pushedMachine, markerID, string(legacyMarkerMachinesJSON),
+		legacyID, sess.ID, pushedMachine, markerID,
+		string(legacyMarkerMachinesJSON),
+		requireRevisionMatch, legacyTranscriptRevision,
 	); err != nil {
 		return fmt.Errorf("migrating legacy trae stars %s: %w", legacyID, err)
 	}
@@ -1631,9 +1654,13 @@ func deletePGLegacyTraeSessionIfOwned(
 								SELECT jsonb_array_elements_text($5::jsonb)
 							)
 						)
-					)
-					OR legacy_session.owner_marker = $4
 				)
+				OR legacy_session.owner_marker = $4
+			)
+			AND (
+				NOT $6
+				OR COALESCE(legacy_session.transcript_revision, '') = $7
+			)
 			ORDER BY p.id,
 				CASE WHEN m.ordinal = p.message_id THEN 0 ELSE 1 END,
 				m.ordinal
@@ -1649,7 +1676,9 @@ func deletePGLegacyTraeSessionIfOwned(
 			note = EXCLUDED.note,
 			ordinal = EXCLUDED.ordinal,
 			source_uuid = EXCLUDED.source_uuid`,
-		legacyID, sess.ID, pushedMachine, markerID, string(legacyMarkerMachinesJSON),
+		legacyID, sess.ID, pushedMachine, markerID,
+		string(legacyMarkerMachinesJSON),
+		requireRevisionMatch, legacyTranscriptRevision,
 	); err != nil {
 		return fmt.Errorf("migrating legacy trae pins %s: %w", legacyID, err)
 	}
@@ -1674,8 +1703,13 @@ func deletePGLegacyTraeSessionIfOwned(
 		       )
 		     )
 		     OR owner_marker = $4
+		   )
+		   AND (
+		     NOT $5
+		     OR COALESCE(transcript_revision, '') = $6
 		   )`,
 		legacyID, pushedMachine, string(legacyMarkerMachinesJSON), markerID,
+		requireRevisionMatch, legacyTranscriptRevision,
 	); err != nil {
 		return fmt.Errorf(
 			"deleting owned legacy trae session %s: %w", legacyID, err,

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -309,7 +309,7 @@ func (s *Sync) Push(
 	}
 
 	if err := purgePGExcludedPushSessions(
-		ctx, s.pg, sessionByID,
+		ctx, s.pg, s.local, sessionByID,
 	); err != nil {
 		return result, err
 	}
@@ -1462,12 +1462,15 @@ func pgExcludedSessionIDsQuery(ids []string) (string, []any) {
 }
 
 func purgePGExcludedPushSessions(
-	ctx context.Context, pg *sql.DB, sessionByID map[string]db.Session,
+	ctx context.Context, pg *sql.DB, local *db.DB, sessionByID map[string]db.Session,
 ) error {
 	tombstoneIDsBySession := make(map[string][]string, len(sessionByID))
 	candidateIDs := []string{}
 	for id, sess := range sessionByID {
-		tombstoneIDs := pgSessionTombstoneIDs(sess)
+		tombstoneIDs, err := pgSessionTombstoneIDs(ctx, local, sess)
+		if err != nil {
+			return err
+		}
 		tombstoneIDsBySession[id] = tombstoneIDs
 		candidateIDs = append(candidateIDs, tombstoneIDs...)
 	}
@@ -1532,9 +1535,12 @@ func deletePGExcludedSessionRows(
 }
 
 func deletePGSessionIfExcluded(
-	ctx context.Context, tx *sql.Tx, sess db.Session,
+	ctx context.Context, tx *sql.Tx, local *db.DB, sess db.Session,
 ) (bool, error) {
-	ids := pgSessionTombstoneIDs(sess)
+	ids, err := pgSessionTombstoneIDs(ctx, local, sess)
+	if err != nil {
+		return false, err
+	}
 	excluded, err := readPGExcludedSessionIDs(ctx, tx, ids)
 	if err != nil {
 		return false, err
@@ -1564,12 +1570,29 @@ func deletePGLegacyTraeSessionIfOwned(
 		return nil
 	}
 	requireRevisionMatch := false
-	if stripped := strings.TrimPrefix(sess.ID, pgSessionIDPrefix(sess.ID)); strings.HasPrefix(stripped, "trae:workspaceStorage:") ||
-		strings.HasPrefix(stripped, "trae:globalStorage:") {
-		rawID := strings.TrimPrefix(stripped, "trae:workspaceStorage:")
-		rawID = strings.TrimPrefix(rawID, "trae:globalStorage:")
-		prefix := pgSessionIDPrefix(sess.ID)
-		if local != nil {
+	currentNamespace, hasNamespace := pgTraeNamespacedSessionNamespace(sess.ID)
+	if hasNamespace && local != nil {
+		legacyLocal, err := local.GetSession(ctx, legacyID)
+		if err != nil {
+			return fmt.Errorf(
+				"loading legacy trae session %s: %w",
+				legacyID, err,
+			)
+		}
+		if legacyLocal != nil && legacyLocal.FilePath != nil {
+			legacyNamespace := pgTraeSessionNamespaceFromPath(*legacyLocal.FilePath)
+			if legacyNamespace != "" && legacyNamespace != currentNamespace {
+				return nil
+			}
+		} else {
+			rawID := strings.TrimPrefix(
+				strings.TrimPrefix(
+					strings.TrimPrefix(sess.ID, pgSessionIDPrefix(sess.ID)),
+					"trae:workspaceStorage:",
+				),
+				"trae:globalStorage:",
+			)
+			prefix := pgSessionIDPrefix(sess.ID)
 			workspaceSiblingID := prefix + "trae:workspaceStorage:" + rawID
 			globalSiblingID := prefix + "trae:globalStorage:" + rawID
 			workspaceSibling, err := local.GetSession(ctx, workspaceSiblingID)
@@ -1586,8 +1609,9 @@ func deletePGLegacyTraeSessionIfOwned(
 					globalSiblingID, err,
 				)
 			}
-			requireRevisionMatch =
-				workspaceSibling != nil && globalSibling != nil
+			if workspaceSibling != nil && globalSibling != nil {
+				return nil
+			}
 		}
 	}
 	legacyTranscriptRevision := sess.TranscriptRevision
@@ -1597,6 +1621,43 @@ func deletePGLegacyTraeSessionIfOwned(
 	legacyMarkerMachinesJSON, err := json.Marshal(legacyMarkerMachines)
 	if err != nil {
 		return fmt.Errorf("encoding legacy marker machines: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE sessions target
+		   SET display_name = legacy_session.display_name,
+		       source_display_name = legacy_session.source_display_name,
+		       deleted_at = legacy_session.deleted_at,
+		       source_deleted_at = legacy_session.source_deleted_at,
+		       updated_at = NOW()
+		  FROM sessions legacy_session
+		 WHERE legacy_session.id = $1
+		   AND target.id = $2
+		   AND (
+				(
+					legacy_session.owner_marker = ''
+					AND (
+						legacy_session.machine = $3
+						OR legacy_session.machine = 'local'
+						OR legacy_session.machine = ''
+						OR legacy_session.machine IN (
+							SELECT jsonb_array_elements_text($5::jsonb)
+						)
+					)
+				)
+				OR legacy_session.owner_marker = $4
+		   )
+		   AND (
+				NOT $6
+				OR COALESCE(legacy_session.transcript_revision, '') = $7
+		   )`,
+		legacyID, sess.ID, pushedMachine, markerID,
+		string(legacyMarkerMachinesJSON),
+		requireRevisionMatch, legacyTranscriptRevision,
+	); err != nil {
+		return fmt.Errorf(
+			"migrating legacy trae curation state %s: %w",
+			legacyID, err,
+		)
 	}
 	if _, err := tx.ExecContext(ctx, `
 		INSERT INTO starred_sessions (session_id, created_at)
@@ -2180,7 +2241,7 @@ func (s *Sync) pushSession(
 		return err
 	}
 	if rowsAffected, rowsErr := result.RowsAffected(); rowsErr == nil && rowsAffected == 0 {
-		excluded, excludedErr := deletePGSessionIfExcluded(ctx, tx, sess)
+		excluded, excludedErr := deletePGSessionIfExcluded(ctx, tx, s.local, sess)
 		if excludedErr != nil {
 			return excludedErr
 		}
@@ -2213,7 +2274,7 @@ func (s *Sync) pushSession(
 			return errSessionOwnershipConflict
 		}
 	}
-	excluded, excludedErr := deletePGSessionIfExcluded(ctx, tx, sess)
+	excluded, excludedErr := deletePGSessionIfExcluded(ctx, tx, s.local, sess)
 	if excludedErr != nil {
 		return excludedErr
 	}

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -1570,6 +1570,7 @@ func deletePGLegacyTraeSessionIfOwned(
 		return nil
 	}
 	requireRevisionMatch := false
+	legacyTranscriptRevision := sess.TranscriptRevision
 	currentNamespace, hasNamespace := pgTraeNamespacedSessionNamespace(sess.ID)
 	if hasNamespace && local != nil {
 		legacyLocal, err := local.GetSession(ctx, legacyID)
@@ -1610,11 +1611,15 @@ func deletePGLegacyTraeSessionIfOwned(
 				)
 			}
 			if workspaceSibling != nil && globalSibling != nil {
-				return nil
+				if !pgTraeHasUniqueSiblingRevision(
+					currentNamespace, sess, *workspaceSibling, *globalSibling,
+				) {
+					return nil
+				}
+				requireRevisionMatch = true
 			}
 		}
 	}
-	legacyTranscriptRevision := sess.TranscriptRevision
 	if legacyMarkerMachines == nil {
 		legacyMarkerMachines = []string{}
 	}
@@ -1790,6 +1795,25 @@ func deletePGLegacyTraeSessionIfOwned(
 		)
 	}
 	return nil
+}
+
+func pgTraeHasUniqueSiblingRevision(
+	currentNamespace string,
+	current, workspaceSibling, globalSibling db.Session,
+) bool {
+	currentRevision := transcriptRevisionValue(current.TranscriptRevision)
+	switch currentNamespace {
+	case "workspaceStorage":
+		return currentRevision != transcriptRevisionValue(
+			globalSibling.TranscriptRevision,
+		)
+	case "globalStorage":
+		return currentRevision != transcriptRevisionValue(
+			workspaceSibling.TranscriptRevision,
+		)
+	default:
+		return false
+	}
 }
 
 // sessionPushFingerprint builds the change-detection fingerprint for a

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -1106,7 +1106,8 @@ func (s *Sync) pushBatchAttempt(
 			}
 		}
 		if err := deletePGLegacyTraeSessionIfOwned(
-			ctx, tx, sess, markerID, pushedSessionMachine(sess, s.machine),
+			ctx, tx, s.local, sess, markerID,
+			pushedSessionMachine(sess, s.machine),
 			legacyMarkerMachines,
 		); err != nil {
 			log.Printf(
@@ -1553,6 +1554,7 @@ func deletePGSessionIfExcluded(
 func deletePGLegacyTraeSessionIfOwned(
 	ctx context.Context,
 	tx *sql.Tx,
+	local *db.DB,
 	sess db.Session,
 	markerID, pushedMachine string,
 	legacyMarkerMachines []string,
@@ -1567,15 +1569,26 @@ func deletePGLegacyTraeSessionIfOwned(
 		rawID := strings.TrimPrefix(stripped, "trae:workspaceStorage:")
 		rawID = strings.TrimPrefix(rawID, "trae:globalStorage:")
 		prefix := pgSessionIDPrefix(sess.ID)
-		var siblingCount int
-		if err := tx.QueryRowContext(ctx,
-			`SELECT COUNT(*) FROM sessions WHERE id = $1 OR id = $2`,
-			prefix+"trae:workspaceStorage:"+rawID,
-			prefix+"trae:globalStorage:"+rawID,
-		).Scan(&siblingCount); err != nil {
-			return fmt.Errorf("counting namespaced trae siblings for %s: %w", sess.ID, err)
+		if local != nil {
+			workspaceSiblingID := prefix + "trae:workspaceStorage:" + rawID
+			globalSiblingID := prefix + "trae:globalStorage:" + rawID
+			workspaceSibling, err := local.GetSession(ctx, workspaceSiblingID)
+			if err != nil {
+				return fmt.Errorf(
+					"loading namespaced trae sibling %s: %w",
+					workspaceSiblingID, err,
+				)
+			}
+			globalSibling, err := local.GetSession(ctx, globalSiblingID)
+			if err != nil {
+				return fmt.Errorf(
+					"loading namespaced trae sibling %s: %w",
+					globalSiblingID, err,
+				)
+			}
+			requireRevisionMatch =
+				workspaceSibling != nil && globalSibling != nil
 		}
-		requireRevisionMatch = siblingCount > 1
 	}
 	legacyTranscriptRevision := sess.TranscriptRevision
 	if legacyMarkerMachines == nil {

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -1659,10 +1659,14 @@ revisionCheckDone:
 	}
 	if _, err := tx.ExecContext(ctx, `
 		UPDATE sessions target
-		   SET display_name = legacy_session.display_name,
-		       source_display_name = legacy_session.source_display_name,
-		       deleted_at = legacy_session.deleted_at,
-		       source_deleted_at = legacy_session.source_deleted_at,
+		   SET display_name = COALESCE(
+					target.display_name,
+					legacy_session.display_name
+				),
+		       deleted_at = COALESCE(
+					target.deleted_at,
+					legacy_session.deleted_at
+				),
 		       updated_at = NOW()
 		  FROM sessions legacy_session
 		 WHERE legacy_session.id = $1
@@ -1780,11 +1784,7 @@ revisionCheckDone:
 		SELECT
 			$2, target_ordinal, target_ordinal, target_source_uuid, note, created_at
 		FROM matched
-		ON CONFLICT (session_id, message_id)
-		DO UPDATE SET
-			note = EXCLUDED.note,
-			ordinal = EXCLUDED.ordinal,
-			source_uuid = EXCLUDED.source_uuid`,
+		ON CONFLICT (session_id, message_id) DO NOTHING`,
 		legacyID, sess.ID, pushedMachine, markerID,
 		string(legacyMarkerMachinesJSON),
 		requireRevisionMatch, legacyTranscriptRevision,

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -1105,6 +1105,18 @@ func (s *Sync) pushBatchAttempt(
 				return batchResult{}, nil
 			}
 		}
+		if err := deletePGLegacyTraeSessionIfOwned(
+			ctx, tx, sess, markerID, pushedSessionMachine(sess, s.machine),
+			legacyMarkerMachines,
+		); err != nil {
+			log.Printf(
+				"pgsync: legacy trae migration %s: %v",
+				sess.ID, err,
+			)
+			_ = tx.Rollback()
+			*pushed = (*pushed)[:len(*pushed)-n]
+			return batchResult{}, nil
+		}
 
 		*pushed = append(*pushed, sess)
 		n++
@@ -1555,6 +1567,96 @@ func deletePGLegacyTraeSessionIfOwned(
 	legacyMarkerMachinesJSON, err := json.Marshal(legacyMarkerMachines)
 	if err != nil {
 		return fmt.Errorf("encoding legacy marker machines: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO starred_sessions (session_id, created_at)
+		SELECT $2, ss.created_at
+		FROM starred_sessions ss
+		JOIN sessions legacy_session
+			ON legacy_session.id = ss.session_id
+		WHERE ss.session_id = $1
+			AND (
+				(
+					legacy_session.owner_marker = ''
+					AND (
+						legacy_session.machine = $3
+						OR legacy_session.machine = 'local'
+						OR legacy_session.machine = ''
+						OR legacy_session.machine IN (
+							SELECT jsonb_array_elements_text($5::jsonb)
+						)
+					)
+				)
+				OR legacy_session.owner_marker = $4
+			)
+		ON CONFLICT (session_id) DO NOTHING`,
+		legacyID, sess.ID, pushedMachine, markerID, string(legacyMarkerMachinesJSON),
+	); err != nil {
+		return fmt.Errorf("migrating legacy trae stars %s: %w", legacyID, err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		WITH matched AS (
+			SELECT DISTINCT ON (p.id)
+				p.note,
+				p.created_at,
+				m.ordinal AS target_ordinal,
+				COALESCE(m.source_uuid, '') AS target_source_uuid
+			FROM pinned_messages p
+			JOIN sessions legacy_session
+				ON legacy_session.id = p.session_id
+			LEFT JOIN messages legacy_message
+				ON legacy_message.session_id = p.session_id
+				AND legacy_message.ordinal = p.message_id
+			JOIN messages m
+				ON m.session_id = $2
+				AND (
+					(
+						COALESCE(legacy_message.source_uuid, '') <> ''
+						AND m.source_uuid = legacy_message.source_uuid
+					)
+					OR (
+						COALESCE(legacy_message.source_uuid, '') = ''
+						AND m.ordinal = p.ordinal
+					)
+				)
+			WHERE p.session_id = $1
+				AND (
+					(
+						legacy_session.owner_marker = ''
+						AND (
+							legacy_session.machine = $3
+							OR legacy_session.machine = 'local'
+							OR legacy_session.machine = ''
+							OR legacy_session.machine IN (
+								SELECT jsonb_array_elements_text($5::jsonb)
+							)
+						)
+					)
+					OR legacy_session.owner_marker = $4
+				)
+			ORDER BY p.id,
+				CASE WHEN m.ordinal = p.message_id THEN 0 ELSE 1 END,
+				m.ordinal
+		)
+		INSERT INTO pinned_messages (
+			session_id, message_id, ordinal, source_uuid, note, created_at
+		)
+		SELECT
+			$2, target_ordinal, target_ordinal, target_source_uuid, note, created_at
+		FROM matched
+		ON CONFLICT (session_id, message_id)
+		DO UPDATE SET
+			note = EXCLUDED.note,
+			ordinal = EXCLUDED.ordinal,
+			source_uuid = EXCLUDED.source_uuid`,
+		legacyID, sess.ID, pushedMachine, markerID, string(legacyMarkerMachinesJSON),
+	); err != nil {
+		return fmt.Errorf("migrating legacy trae pins %s: %w", legacyID, err)
+	}
+	if err := reconcilePinnedMessages(ctx, tx, sess.ID); err != nil {
+		return fmt.Errorf(
+			"reconciling migrated legacy trae pins %s: %w", legacyID, err,
+		)
 	}
 	if _, err := tx.ExecContext(ctx,
 		`DELETE FROM sessions
@@ -2072,11 +2174,6 @@ func (s *Sync) pushSession(
 		return errSessionExcluded
 	}
 	if err := replacePGSessionAliases(ctx, tx, sess); err != nil {
-		return err
-	}
-	if err := deletePGLegacyTraeSessionIfOwned(
-		ctx, tx, sess, markerID, pushedMachine, legacyMarkerMachines,
-	); err != nil {
 		return err
 	}
 	return nil

--- a/internal/postgres/push.go
+++ b/internal/postgres/push.go
@@ -1023,8 +1023,10 @@ func (s *Sync) pushBatchAttempt(
 	msgs := 0
 	skippedConflicts := 0
 	sessionIDs := make([]string, 0, len(batch))
+	batchSessions := make(map[string]db.Session, len(batch))
 	for _, sess := range batch {
 		sessionIDs = append(sessionIDs, sess.ID)
+		batchSessions[sess.ID] = sess
 	}
 	comparisons := (*pushMessageComparison)(nil)
 	if preloadComparisons && len(sessionIDs) > 0 {
@@ -1106,7 +1108,7 @@ func (s *Sync) pushBatchAttempt(
 			}
 		}
 		if err := deletePGLegacyTraeSessionIfOwned(
-			ctx, tx, s.local, sess, markerID,
+			ctx, tx, s.local, batchSessions, sess, markerID,
 			pushedSessionMachine(sess, s.machine),
 			legacyMarkerMachines,
 		); err != nil {
@@ -1561,6 +1563,7 @@ func deletePGLegacyTraeSessionIfOwned(
 	ctx context.Context,
 	tx *sql.Tx,
 	local *db.DB,
+	batchSessions map[string]db.Session,
 	sess db.Session,
 	markerID, pushedMachine string,
 	legacyMarkerMachines []string,
@@ -1603,14 +1606,18 @@ func deletePGLegacyTraeSessionIfOwned(
 			prefix := pgSessionIDPrefix(sess.ID)
 			workspaceSiblingID := prefix + "trae:workspaceStorage:" + rawID
 			globalSiblingID := prefix + "trae:globalStorage:" + rawID
-			workspaceSibling, err := local.GetSession(ctx, workspaceSiblingID)
+			workspaceSibling, err := pgResolveTraeSiblingSession(
+				ctx, local, batchSessions, workspaceSiblingID,
+			)
 			if err != nil {
 				return fmt.Errorf(
 					"loading namespaced trae sibling %s: %w",
 					workspaceSiblingID, err,
 				)
 			}
-			globalSibling, err := local.GetSession(ctx, globalSiblingID)
+			globalSibling, err := pgResolveTraeSiblingSession(
+				ctx, local, batchSessions, globalSiblingID,
+			)
 			if err != nil {
 				return fmt.Errorf(
 					"loading namespaced trae sibling %s: %w",
@@ -1807,6 +1814,24 @@ revisionCheckDone:
 		)
 	}
 	return nil
+}
+
+func pgResolveTraeSiblingSession(
+	ctx context.Context,
+	local *db.DB,
+	batchSessions map[string]db.Session,
+	id string,
+) (*db.Session, error) {
+	if batchSessions != nil {
+		if sess, ok := batchSessions[id]; ok {
+			copy := sess
+			return &copy, nil
+		}
+	}
+	if local == nil {
+		return nil, nil
+	}
+	return local.GetSession(ctx, id)
 }
 
 func pgTraeHasUniqueSiblingRevision(

--- a/internal/postgres/push_pgtest_test.go
+++ b/internal/postgres/push_pgtest_test.go
@@ -404,7 +404,6 @@ func TestPushMessageContentHashRewriteRegression(t *testing.T) {
 		schema:     schema,
 		schemaDone: true,
 	}
-
 	const sessID = "content-hash-rewrite-001"
 	sess := db.Session{
 		ID:               sessID,
@@ -1035,6 +1034,7 @@ func TestPushPurgesOwnedLegacyTraeRowsDuringNamespaceMigration(t *testing.T) {
 		schema:     schema,
 		schemaDone: true,
 	}
+	store := &Store{pg: pg}
 
 	const legacyID = "trae:collision"
 	legacy := db.Session{
@@ -1058,10 +1058,12 @@ func TestPushPurgesOwnedLegacyTraeRowsDuringNamespaceMigration(t *testing.T) {
 
 	_, err = sync.Push(ctx, false, nil)
 	require.NoError(t, err, "initial Push")
-
-	deleted, err := localDB.DeleteParserExcludedSessions([]string{legacyID})
-	require.NoError(t, err, "DeleteParserExcludedSessions legacy")
-	assert.Equal(t, 1, deleted)
+	starred, err := store.StarSession(legacyID)
+	require.NoError(t, err, "StarSession legacy")
+	require.True(t, starred)
+	pinNote := "legacy pin"
+	_, err = store.PinMessage(legacyID, 0, &pinNote)
+	require.NoError(t, err, "PinMessage legacy")
 
 	const namespacedID = "trae:globalStorage:collision"
 	namespaced := legacy
@@ -1090,6 +1092,20 @@ func TestPushPurgesOwnedLegacyTraeRowsDuringNamespaceMigration(t *testing.T) {
 		namespacedID,
 	).Scan(&count), "count namespaced trae session")
 	assert.Equal(t, 1, count, "namespaced trae row should remain")
+
+	require.NoError(t, pg.QueryRow(
+		`SELECT COUNT(*) FROM starred_sessions WHERE session_id = $1`,
+		namespacedID,
+	).Scan(&count), "count migrated trae star")
+	assert.Equal(t, 1, count, "legacy trae star should move to namespaced row")
+
+	var gotNote sql.NullString
+	require.NoError(t, pg.QueryRow(
+		`SELECT note FROM pinned_messages WHERE session_id = $1`,
+		namespacedID,
+	).Scan(&gotNote), "read migrated trae pin")
+	require.True(t, gotNote.Valid)
+	assert.Equal(t, pinNote, gotNote.String)
 }
 
 func TestPushSessionSkipsPGExcludedSession(t *testing.T) {

--- a/internal/postgres/push_pgtest_test.go
+++ b/internal/postgres/push_pgtest_test.go
@@ -1064,6 +1064,16 @@ func TestPushPurgesOwnedLegacyTraeRowsDuringNamespaceMigration(t *testing.T) {
 	pinNote := "legacy pin"
 	_, err = store.PinMessage(legacyID, 0, &pinNote)
 	require.NoError(t, err, "PinMessage legacy")
+	_, err = pg.Exec(
+		`UPDATE sessions
+		 SET display_name = $2,
+		     source_display_name = NULL,
+		     deleted_at = NOW(),
+		     source_deleted_at = NULL
+		 WHERE id = $1`,
+		legacyID, "Legacy PG name",
+	)
+	require.NoError(t, err, "simulate legacy PG curation")
 
 	const namespacedID = "trae:globalStorage:collision"
 	namespaced := legacy
@@ -1106,6 +1116,21 @@ func TestPushPurgesOwnedLegacyTraeRowsDuringNamespaceMigration(t *testing.T) {
 	).Scan(&gotNote), "read migrated trae pin")
 	require.True(t, gotNote.Valid)
 	assert.Equal(t, pinNote, gotNote.String)
+
+	var gotDisplayName sql.NullString
+	var deletedAt sql.NullTime
+	var sourceDeletedAt sql.NullTime
+	require.NoError(t, pg.QueryRow(
+		`SELECT display_name, deleted_at, source_deleted_at
+		 FROM sessions WHERE id = $1`,
+		namespacedID,
+	).Scan(&gotDisplayName, &deletedAt, &sourceDeletedAt),
+		"read migrated trae curation")
+	require.True(t, gotDisplayName.Valid)
+	assert.Equal(t, "Legacy PG name", gotDisplayName.String)
+	assert.True(t, deletedAt.Valid, "legacy PG trash should survive migration")
+	assert.False(t, sourceDeletedAt.Valid,
+		"explicit legacy restore baseline must remain distinguishable")
 }
 
 func TestPushPurgesOwnedHostPrefixedLegacyTraeRowsDuringNamespaceMigration(t *testing.T) {
@@ -1344,6 +1369,80 @@ func TestPushSessionSkipsPGExcludedSession(t *testing.T) {
 		sessionID,
 	).Scan(&count), "count skipped session")
 	assert.Zero(t, count)
+}
+
+func TestPushSkipsNamespacedTraeSessionWhenLegacyTombstoneMatchesUniquely(
+	t *testing.T,
+) {
+	pgURL := testPGURL(t)
+
+	const schema = "agentsview_push_trae_legacy_excluded_test"
+	pg, err := Open(pgURL, schema, true)
+	require.NoError(t, err, "Open")
+	defer pg.Close()
+
+	ctx := context.Background()
+	_, err = pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
+
+	localDB, err := db.Open(filepath.Join(t.TempDir(), "local.db"))
+	require.NoError(t, err, "db.Open")
+	defer localDB.Close()
+
+	sync := &Sync{
+		pg:         pg,
+		local:      localDB,
+		machine:    "test-machine",
+		schema:     schema,
+		schemaDone: true,
+	}
+
+	sessionPath := filepath.Join(
+		t.TempDir(), "workspaceStorage", "legacy-excluded", "transcript.jsonl",
+	)
+	sess := db.Session{
+		ID:               "trae:workspaceStorage:legacy-excluded",
+		Project:          "test-proj",
+		Machine:          "test-machine",
+		Agent:            "trae",
+		SourceSessionID:  "legacy-excluded",
+		FilePath:         &sessionPath,
+		MessageCount:     1,
+		UserMessageCount: 1,
+		CreatedAt:        "2026-07-21T00:00:00Z",
+	}
+	require.NoError(t, localDB.UpsertSession(sess), "UpsertSession")
+	require.NoError(t, localDB.InsertMessages([]db.Message{{
+		SessionID:     sess.ID,
+		Ordinal:       0,
+		Role:          "user",
+		Content:       "hello",
+		ContentLength: len("hello"),
+	}}), "InsertMessages")
+
+	_, err = pg.Exec(
+		`INSERT INTO excluded_sessions (id) VALUES ($1)`,
+		"trae:legacy-excluded",
+	)
+	require.NoError(t, err, "insert legacy trae tombstone")
+
+	res, err := sync.Push(ctx, true, nil)
+	require.NoError(t, err, "Push with legacy tombstone")
+	assert.Zero(t, res.SessionsPushed)
+
+	var count int
+	require.NoError(t, pg.QueryRow(
+		`SELECT COUNT(*) FROM sessions WHERE id = $1`,
+		sess.ID,
+	).Scan(&count), "count skipped namespaced session")
+	assert.Zero(t, count)
+	require.NoError(t, pg.QueryRow(
+		`SELECT COUNT(*) FROM excluded_sessions
+		 WHERE id IN ($1, $2)`,
+		"trae:legacy-excluded", sess.ID,
+	).Scan(&count), "count propagated tombstones")
+	assert.Equal(t, 2, count, "legacy and namespaced tombstones should both remain")
 }
 
 func TestPushUpdatesSourceCurationFieldsWithoutPGOverride(t *testing.T) {

--- a/internal/postgres/push_pgtest_test.go
+++ b/internal/postgres/push_pgtest_test.go
@@ -1011,6 +1011,87 @@ func TestPushPurgesRowsForPGExcludedSessions(t *testing.T) {
 	assert.Zero(t, count, "excluded session row should be purged")
 }
 
+func TestPushPurgesOwnedLegacyTraeRowsDuringNamespaceMigration(t *testing.T) {
+	pgURL := testPGURL(t)
+
+	const schema = "agentsview_push_trae_legacy_purge_test"
+	pg, err := Open(pgURL, schema, true)
+	require.NoError(t, err, "Open")
+	defer pg.Close()
+
+	ctx := context.Background()
+	_, err = pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
+
+	localDB, err := db.Open(filepath.Join(t.TempDir(), "local.db"))
+	require.NoError(t, err, "db.Open")
+	defer localDB.Close()
+
+	sync := &Sync{
+		pg:         pg,
+		local:      localDB,
+		machine:    "test-machine",
+		schema:     schema,
+		schemaDone: true,
+	}
+
+	const legacyID = "trae:collision"
+	legacy := db.Session{
+		ID:               legacyID,
+		Project:          "test-proj",
+		Machine:          "test-machine",
+		Agent:            "trae",
+		SourceSessionID:  "collision",
+		MessageCount:     1,
+		UserMessageCount: 1,
+		CreatedAt:        "2026-01-01T00:00:00Z",
+	}
+	require.NoError(t, localDB.UpsertSession(legacy), "UpsertSession legacy")
+	require.NoError(t, localDB.InsertMessages([]db.Message{{
+		SessionID:     legacyID,
+		Ordinal:       0,
+		Role:          "user",
+		Content:       "legacy",
+		ContentLength: len("legacy"),
+	}}), "InsertMessages legacy")
+
+	_, err = sync.Push(ctx, false, nil)
+	require.NoError(t, err, "initial Push")
+
+	deleted, err := localDB.DeleteParserExcludedSessions([]string{legacyID})
+	require.NoError(t, err, "DeleteParserExcludedSessions legacy")
+	assert.Equal(t, 1, deleted)
+
+	const namespacedID = "trae:globalStorage:collision"
+	namespaced := legacy
+	namespaced.ID = namespacedID
+	require.NoError(t, localDB.UpsertSession(namespaced), "UpsertSession namespaced")
+	require.NoError(t, localDB.InsertMessages([]db.Message{{
+		SessionID:     namespacedID,
+		Ordinal:       0,
+		Role:          "user",
+		Content:       "namespaced",
+		ContentLength: len("namespaced"),
+	}}), "InsertMessages namespaced")
+
+	_, err = sync.Push(ctx, true, nil)
+	require.NoError(t, err, "full Push after namespace migration")
+
+	var count int
+	require.NoError(t, pg.QueryRow(
+		`SELECT COUNT(*) FROM sessions WHERE id = $1`,
+		legacyID,
+	).Scan(&count), "count legacy trae session")
+	assert.Zero(t, count, "legacy trae row should be purged")
+
+	require.NoError(t, pg.QueryRow(
+		`SELECT COUNT(*) FROM sessions WHERE id = $1`,
+		namespacedID,
+	).Scan(&count), "count namespaced trae session")
+	assert.Equal(t, 1, count, "namespaced trae row should remain")
+}
+
 func TestPushSessionSkipsPGExcludedSession(t *testing.T) {
 	pgURL := testPGURL(t)
 

--- a/internal/postgres/push_pgtest_test.go
+++ b/internal/postgres/push_pgtest_test.go
@@ -1108,6 +1108,190 @@ func TestPushPurgesOwnedLegacyTraeRowsDuringNamespaceMigration(t *testing.T) {
 	assert.Equal(t, pinNote, gotNote.String)
 }
 
+func TestPushPurgesOwnedHostPrefixedLegacyTraeRowsDuringNamespaceMigration(t *testing.T) {
+	pgURL := testPGURL(t)
+
+	const schema = "agentsview_push_trae_host_legacy_purge_test"
+	pg, err := Open(pgURL, schema, true)
+	require.NoError(t, err, "Open")
+	defer pg.Close()
+
+	ctx := context.Background()
+	_, err = pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
+
+	localDB, err := db.Open(filepath.Join(t.TempDir(), "local.db"))
+	require.NoError(t, err, "db.Open")
+	defer localDB.Close()
+
+	sync := &Sync{
+		pg:         pg,
+		local:      localDB,
+		machine:    "test-machine",
+		schema:     schema,
+		schemaDone: true,
+	}
+	store := &Store{pg: pg}
+	legacyRev := "legacy-rev"
+
+	const legacyID = "laptop~trae:collision"
+	legacy := db.Session{
+		ID:                 legacyID,
+		Project:            "test-proj",
+		Machine:            "test-machine",
+		Agent:              "trae",
+		SourceSessionID:    "collision",
+		TranscriptRevision: &legacyRev,
+		MessageCount:       1,
+		UserMessageCount:   1,
+		CreatedAt:          "2026-01-01T00:00:00Z",
+	}
+	require.NoError(t, localDB.UpsertSession(legacy), "UpsertSession legacy")
+	require.NoError(t, localDB.InsertMessages([]db.Message{{
+		SessionID:     legacyID,
+		Ordinal:       0,
+		Role:          "user",
+		Content:       "legacy",
+		ContentLength: len("legacy"),
+	}}), "InsertMessages legacy")
+
+	_, err = sync.Push(ctx, false, nil)
+	require.NoError(t, err, "initial Push")
+	starred, err := store.StarSession(legacyID)
+	require.NoError(t, err, "StarSession legacy")
+	require.True(t, starred)
+	pinNote := "legacy host pin"
+	_, err = store.PinMessage(legacyID, 0, &pinNote)
+	require.NoError(t, err, "PinMessage legacy")
+
+	const namespacedID = "laptop~trae:globalStorage:collision"
+	namespaced := legacy
+	namespaced.ID = namespacedID
+	namespaced.TranscriptRevision = &legacyRev
+	require.NoError(t, localDB.UpsertSession(namespaced), "UpsertSession namespaced")
+	require.NoError(t, localDB.InsertMessages([]db.Message{{
+		SessionID:     namespacedID,
+		Ordinal:       0,
+		Role:          "user",
+		Content:       "namespaced",
+		ContentLength: len("namespaced"),
+	}}), "InsertMessages namespaced")
+
+	_, err = sync.Push(ctx, true, nil)
+	require.NoError(t, err, "full Push after namespace migration")
+
+	var count int
+	require.NoError(t, pg.QueryRow(
+		`SELECT COUNT(*) FROM sessions WHERE id = $1`,
+		legacyID,
+	).Scan(&count), "count legacy trae session")
+	assert.Zero(t, count, "host-prefixed legacy trae row should be purged")
+
+	require.NoError(t, pg.QueryRow(
+		`SELECT COUNT(*) FROM starred_sessions WHERE session_id = $1`,
+		namespacedID,
+	).Scan(&count), "count migrated trae star")
+	assert.Equal(t, 1, count)
+}
+
+func TestPushMigratesLegacyTraeStateToMatchingNamespaceOnly(t *testing.T) {
+	pgURL := testPGURL(t)
+
+	const schema = "agentsview_push_trae_collision_guard_test"
+	pg, err := Open(pgURL, schema, true)
+	require.NoError(t, err, "Open")
+	defer pg.Close()
+
+	ctx := context.Background()
+	_, err = pg.Exec(`DROP SCHEMA IF EXISTS ` + schema + ` CASCADE`)
+	require.NoError(t, err, "drop schema")
+	require.NoError(t, EnsureSchema(ctx, pg, schema), "EnsureSchema")
+
+	localDB, err := db.Open(filepath.Join(t.TempDir(), "local.db"))
+	require.NoError(t, err, "db.Open")
+	defer localDB.Close()
+
+	sync := &Sync{
+		pg:         pg,
+		local:      localDB,
+		machine:    "test-machine",
+		schema:     schema,
+		schemaDone: true,
+	}
+	store := &Store{pg: pg}
+	workspaceRev := "workspace-rev"
+	globalRev := "global-rev"
+
+	const legacyID = "trae:collision"
+	legacy := db.Session{
+		ID:                 legacyID,
+		Project:            "test-proj",
+		Machine:            "test-machine",
+		Agent:              "trae",
+		SourceSessionID:    "collision",
+		TranscriptRevision: &workspaceRev,
+		MessageCount:       1,
+		UserMessageCount:   1,
+		CreatedAt:          "2026-01-01T00:00:00Z",
+	}
+	require.NoError(t, localDB.UpsertSession(legacy), "UpsertSession legacy")
+	require.NoError(t, localDB.InsertMessages([]db.Message{{
+		SessionID:     legacyID,
+		Ordinal:       0,
+		Role:          "user",
+		Content:       "workspace body",
+		ContentLength: len("workspace body"),
+	}}), "InsertMessages legacy")
+
+	_, err = sync.Push(ctx, false, nil)
+	require.NoError(t, err, "initial Push")
+	starred, err := store.StarSession(legacyID)
+	require.NoError(t, err, "StarSession legacy")
+	require.True(t, starred)
+	pinNote := "workspace pin"
+	_, err = store.PinMessage(legacyID, 0, &pinNote)
+	require.NoError(t, err, "PinMessage legacy")
+
+	workspace := legacy
+	workspace.ID = "trae:workspaceStorage:collision"
+	workspace.TranscriptRevision = &workspaceRev
+	global := legacy
+	global.ID = "trae:globalStorage:collision"
+	global.TranscriptRevision = &globalRev
+	require.NoError(t, localDB.UpsertSession(workspace), "UpsertSession workspace")
+	require.NoError(t, localDB.UpsertSession(global), "UpsertSession global")
+	require.NoError(t, localDB.InsertMessages([]db.Message{{
+		SessionID:     workspace.ID,
+		Ordinal:       0,
+		Role:          "user",
+		Content:       "workspace body",
+		ContentLength: len("workspace body"),
+	}, {
+		SessionID:     global.ID,
+		Ordinal:       0,
+		Role:          "user",
+		Content:       "global body",
+		ContentLength: len("global body"),
+	}}), "InsertMessages namespaced")
+
+	_, err = sync.Push(ctx, true, nil)
+	require.NoError(t, err, "full Push after split namespace migration")
+
+	var count int
+	require.NoError(t, pg.QueryRow(
+		`SELECT COUNT(*) FROM starred_sessions WHERE session_id = $1`,
+		global.ID,
+	).Scan(&count), "count migrated trae star on global")
+	assert.Zero(t, count, "global namespace must not steal legacy curation")
+
+	require.NoError(t, pg.QueryRow(
+		`SELECT COUNT(*) FROM starred_sessions WHERE session_id = $1`,
+		workspace.ID,
+	).Scan(&count), "count migrated trae star on workspace")
+	assert.Equal(t, 1, count, "matching namespace receives legacy curation")
+}
+
 func TestPushSessionSkipsPGExcludedSession(t *testing.T) {
 	pgURL := testPGURL(t)
 

--- a/internal/postgres/push_test.go
+++ b/internal/postgres/push_test.go
@@ -790,7 +790,7 @@ func TestPurgePGExcludedPushSessionsChecksDerivedAliases(t *testing.T) {
 	}
 
 	err := purgePGExcludedPushSessions(
-		context.Background(), pg, sessionByID,
+		context.Background(), pg, nil, sessionByID,
 	)
 
 	require.NoError(t, err, "purgePGExcludedPushSessions")

--- a/internal/postgres/push_test.go
+++ b/internal/postgres/push_test.go
@@ -282,6 +282,85 @@ func TestPGShouldSkipLegacyTraeBatchSession(t *testing.T) {
 	})
 }
 
+func TestDeletePGLegacyTraeSessionIfOwnedMigratesWorkspaceStar(t *testing.T) {
+	state := &legacyTraeMigrationProbeState{}
+	pg := newLegacyTraeMigrationProbeDB(t, state)
+	tx, err := pg.BeginTx(context.Background(), nil)
+	require.NoError(t, err, "BeginTx")
+	defer func() { _ = tx.Rollback() }()
+
+	path := filepath.Join(t.TempDir(), "sessions.db")
+	local, err := db.Open(path)
+	require.NoError(t, err, "db.Open")
+	defer local.Close()
+
+	legacyRevision := "workspace-rev"
+	globalRevision := "global-rev"
+	require.NoError(t, local.UpsertSession(db.Session{
+		ID:                 "trae:collision",
+		Project:            "proj",
+		Machine:            "mac",
+		Agent:              "trae",
+		SourceSessionID:    "collision",
+		TranscriptRevision: &legacyRevision,
+		MessageCount:       1,
+		UserMessageCount:   1,
+		CreatedAt:          "2026-07-21T00:00:00Z",
+	}), "UpsertSession legacy")
+	require.NoError(t, local.UpsertSession(db.Session{
+		ID:                 "trae:workspaceStorage:collision",
+		Project:            "proj",
+		Machine:            "mac",
+		Agent:              "trae",
+		SourceSessionID:    "collision",
+		TranscriptRevision: &legacyRevision,
+		MessageCount:       1,
+		UserMessageCount:   1,
+		CreatedAt:          "2026-07-21T00:01:00Z",
+	}), "UpsertSession workspace")
+	require.NoError(t, local.UpsertSession(db.Session{
+		ID:                 "trae:globalStorage:collision",
+		Project:            "proj",
+		Machine:            "mac",
+		Agent:              "trae",
+		SourceSessionID:    "collision",
+		TranscriptRevision: &globalRevision,
+		MessageCount:       1,
+		UserMessageCount:   1,
+		CreatedAt:          "2026-07-21T00:02:00Z",
+	}), "UpsertSession global")
+
+	err = deletePGLegacyTraeSessionIfOwned(
+		context.Background(),
+		tx,
+		local,
+		map[string]db.Session{
+			"trae:workspaceStorage:collision": {
+				ID:                 "trae:workspaceStorage:collision",
+				TranscriptRevision: &legacyRevision,
+			},
+			"trae:globalStorage:collision": {
+				ID:                 "trae:globalStorage:collision",
+				TranscriptRevision: &globalRevision,
+			},
+		},
+		db.Session{
+			ID:                 "trae:workspaceStorage:collision",
+			Agent:              "trae",
+			SourceSessionID:    "collision",
+			TranscriptRevision: &legacyRevision,
+		},
+		"marker",
+		"mac",
+		nil,
+	)
+
+	require.NoError(t, err, "deletePGLegacyTraeSessionIfOwned")
+	assert.Equal(t, 1, state.starInsertCalls)
+	assert.Equal(t, "trae:workspaceStorage:collision", state.lastTargetID)
+	assert.Equal(t, "workspace-rev", state.lastRevision)
+}
+
 type pushAliasRoutingDriver struct{}
 
 type pushAliasRoutingConn struct{}
@@ -294,7 +373,121 @@ type pushAliasRoutingRows struct {
 	next    int
 }
 
+type legacyTraeMigrationProbeDriver struct{}
+
+type legacyTraeMigrationProbeConn struct {
+	state *legacyTraeMigrationProbeState
+}
+
+type legacyTraeMigrationProbeTx struct{}
+
+type legacyTraeMigrationProbeState struct {
+	starInsertCalls int
+	lastTargetID    string
+	lastRevision    string
+}
+
 var pushAliasRoutingRegisterOnce sync.Once
+var legacyTraeMigrationProbeRegisterOnce sync.Once
+var legacyTraeMigrationProbeStatesMu sync.Mutex
+var legacyTraeMigrationProbeStates = map[string]*legacyTraeMigrationProbeState{}
+
+func newLegacyTraeMigrationProbeDB(
+	t *testing.T, state *legacyTraeMigrationProbeState,
+) *sql.DB {
+	t.Helper()
+	legacyTraeMigrationProbeRegisterOnce.Do(func() {
+		sql.Register(
+			"agentsview_legacy_trae_migration_probe",
+			legacyTraeMigrationProbeDriver{},
+		)
+	})
+	name := t.Name()
+	legacyTraeMigrationProbeStatesMu.Lock()
+	legacyTraeMigrationProbeStates[name] = state
+	legacyTraeMigrationProbeStatesMu.Unlock()
+	t.Cleanup(func() {
+		legacyTraeMigrationProbeStatesMu.Lock()
+		delete(legacyTraeMigrationProbeStates, name)
+		legacyTraeMigrationProbeStatesMu.Unlock()
+	})
+
+	pg, err := sql.Open("agentsview_legacy_trae_migration_probe", name)
+	require.NoError(t, err, "open legacy trae migration probe db")
+	t.Cleanup(func() { _ = pg.Close() })
+	return pg
+}
+
+func (legacyTraeMigrationProbeDriver) Open(name string) (driver.Conn, error) {
+	legacyTraeMigrationProbeStatesMu.Lock()
+	state := legacyTraeMigrationProbeStates[name]
+	legacyTraeMigrationProbeStatesMu.Unlock()
+	return &legacyTraeMigrationProbeConn{state: state}, nil
+}
+
+func (c *legacyTraeMigrationProbeConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("prepare not implemented")
+}
+
+func (c *legacyTraeMigrationProbeConn) Close() error { return nil }
+
+func (c *legacyTraeMigrationProbeConn) Begin() (driver.Tx, error) {
+	return c.BeginTx(context.Background(), driver.TxOptions{})
+}
+
+func (c *legacyTraeMigrationProbeConn) BeginTx(
+	context.Context, driver.TxOptions,
+) (driver.Tx, error) {
+	return legacyTraeMigrationProbeTx{}, nil
+}
+
+func (c *legacyTraeMigrationProbeConn) CheckNamedValue(
+	*driver.NamedValue,
+) error {
+	return nil
+}
+
+func (c *legacyTraeMigrationProbeConn) ExecContext(
+	_ context.Context, query string, args []driver.NamedValue,
+) (driver.Result, error) {
+	normalized := strings.ToLower(query)
+	switch {
+	case strings.Contains(normalized, "insert into starred_sessions"):
+		c.state.starInsertCalls++
+		if len(args) > 1 {
+			c.state.lastTargetID, _ = args[1].Value.(string)
+		}
+		if len(args) > 6 {
+			switch value := args[6].Value.(type) {
+			case string:
+				c.state.lastRevision = value
+			case *string:
+				if value != nil {
+					c.state.lastRevision = *value
+				}
+			}
+		}
+		return driver.RowsAffected(1), nil
+	case strings.Contains(normalized, "update sessions target"),
+		strings.Contains(normalized, "with matched as"),
+		strings.Contains(normalized, "delete from sessions"),
+		strings.Contains(normalized, "update pinned_messages p"),
+		strings.Contains(normalized, "delete from pinned_messages p"):
+		return driver.RowsAffected(1), nil
+	default:
+		return nil, errors.New("unexpected legacy trae migration probe exec")
+	}
+}
+
+func (c *legacyTraeMigrationProbeConn) QueryContext(
+	context.Context, string, []driver.NamedValue,
+) (driver.Rows, error) {
+	return nil, errors.New("query not implemented")
+}
+
+func (legacyTraeMigrationProbeTx) Commit() error { return nil }
+
+func (legacyTraeMigrationProbeTx) Rollback() error { return nil }
 
 func newPushAliasRoutingDB(t *testing.T) *sql.DB {
 	t.Helper()

--- a/internal/postgres/push_test.go
+++ b/internal/postgres/push_test.go
@@ -82,6 +82,63 @@ func (s *syncStateStoreStub) GetOrCreateSyncState(
 	return defaultValue, nil
 }
 
+func TestPGTraeHasUniqueSiblingRevision(t *testing.T) {
+	rev := func(value string) *string { return &value }
+
+	tests := []struct {
+		name             string
+		currentNamespace string
+		current          db.Session
+		workspaceSibling db.Session
+		globalSibling    db.Session
+		want             bool
+	}{
+		{
+			name:             "workspace revision differs from global",
+			currentNamespace: "workspaceStorage",
+			current:          db.Session{TranscriptRevision: rev("workspace-rev")},
+			workspaceSibling: db.Session{TranscriptRevision: rev("workspace-rev")},
+			globalSibling:    db.Session{TranscriptRevision: rev("global-rev")},
+			want:             true,
+		},
+		{
+			name:             "global revision differs from workspace",
+			currentNamespace: "globalStorage",
+			current:          db.Session{TranscriptRevision: rev("global-rev")},
+			workspaceSibling: db.Session{TranscriptRevision: rev("workspace-rev")},
+			globalSibling:    db.Session{TranscriptRevision: rev("global-rev")},
+			want:             true,
+		},
+		{
+			name:             "shared revision stays ambiguous",
+			currentNamespace: "workspaceStorage",
+			current:          db.Session{TranscriptRevision: rev("shared-rev")},
+			workspaceSibling: db.Session{TranscriptRevision: rev("shared-rev")},
+			globalSibling:    db.Session{TranscriptRevision: rev("shared-rev")},
+			want:             false,
+		},
+		{
+			name:             "missing workspace revision still counts as unique",
+			currentNamespace: "workspaceStorage",
+			current:          db.Session{},
+			workspaceSibling: db.Session{},
+			globalSibling:    db.Session{TranscriptRevision: rev("global-rev")},
+			want:             true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, pgTraeHasUniqueSiblingRevision(
+				tt.currentNamespace,
+				tt.current,
+				tt.workspaceSibling,
+				tt.globalSibling,
+			))
+		})
+	}
+}
+
 type pushAliasRoutingDriver struct{}
 
 type pushAliasRoutingConn struct{}

--- a/internal/postgres/push_test.go
+++ b/internal/postgres/push_test.go
@@ -87,6 +87,7 @@ func TestPGTraeHasUniqueSiblingRevision(t *testing.T) {
 
 	tests := []struct {
 		name             string
+		legacyRevision   string
 		currentNamespace string
 		current          db.Session
 		workspaceSibling db.Session
@@ -94,6 +95,7 @@ func TestPGTraeHasUniqueSiblingRevision(t *testing.T) {
 		want             bool
 	}{
 		{
+			legacyRevision:   "workspace-rev",
 			name:             "workspace revision differs from global",
 			currentNamespace: "workspaceStorage",
 			current:          db.Session{TranscriptRevision: rev("workspace-rev")},
@@ -102,14 +104,16 @@ func TestPGTraeHasUniqueSiblingRevision(t *testing.T) {
 			want:             true,
 		},
 		{
+			legacyRevision:   "workspace-rev",
 			name:             "global revision differs from workspace",
 			currentNamespace: "globalStorage",
 			current:          db.Session{TranscriptRevision: rev("global-rev")},
 			workspaceSibling: db.Session{TranscriptRevision: rev("workspace-rev")},
 			globalSibling:    db.Session{TranscriptRevision: rev("global-rev")},
-			want:             true,
+			want:             false,
 		},
 		{
+			legacyRevision:   "shared-rev",
 			name:             "shared revision stays ambiguous",
 			currentNamespace: "workspaceStorage",
 			current:          db.Session{TranscriptRevision: rev("shared-rev")},
@@ -118,12 +122,13 @@ func TestPGTraeHasUniqueSiblingRevision(t *testing.T) {
 			want:             false,
 		},
 		{
-			name:             "missing workspace revision still counts as unique",
+			legacyRevision:   "workspace-rev",
+			name:             "missing workspace revision cannot match legacy",
 			currentNamespace: "workspaceStorage",
 			current:          db.Session{},
 			workspaceSibling: db.Session{},
 			globalSibling:    db.Session{TranscriptRevision: rev("global-rev")},
-			want:             true,
+			want:             false,
 		},
 	}
 
@@ -131,6 +136,7 @@ func TestPGTraeHasUniqueSiblingRevision(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, pgTraeHasUniqueSiblingRevision(
 				tt.currentNamespace,
+				tt.legacyRevision,
 				tt.current,
 				tt.workspaceSibling,
 				tt.globalSibling,

--- a/internal/postgres/push_test.go
+++ b/internal/postgres/push_test.go
@@ -145,6 +145,74 @@ func TestPGTraeHasUniqueSiblingRevision(t *testing.T) {
 	}
 }
 
+func TestPGResolveTraeSiblingSessionPrefersBatch(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sessions.db")
+	local, err := db.Open(path)
+	require.NoError(t, err, "db.Open")
+	defer local.Close()
+
+	localRevision := "local-rev"
+	require.NoError(t, local.UpsertSession(db.Session{
+		ID:                 "trae:workspaceStorage:collision",
+		Project:            "proj",
+		Machine:            "mac",
+		Agent:              "trae",
+		TranscriptRevision: &localRevision,
+		MessageCount:       1,
+		UserMessageCount:   1,
+		CreatedAt:          "2026-07-21T00:00:00Z",
+	}), "UpsertSession local")
+
+	batchRevision := "batch-rev"
+	sess, err := pgResolveTraeSiblingSession(
+		context.Background(),
+		local,
+		map[string]db.Session{
+			"trae:workspaceStorage:collision": {
+				ID:                 "trae:workspaceStorage:collision",
+				TranscriptRevision: &batchRevision,
+			},
+		},
+		"trae:workspaceStorage:collision",
+	)
+
+	require.NoError(t, err, "pgResolveTraeSiblingSession")
+	require.NotNil(t, sess)
+	require.NotNil(t, sess.TranscriptRevision)
+	assert.Equal(t, "batch-rev", *sess.TranscriptRevision)
+}
+
+func TestPGResolveTraeSiblingSessionFallsBackToLocal(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "sessions.db")
+	local, err := db.Open(path)
+	require.NoError(t, err, "db.Open")
+	defer local.Close()
+
+	localRevision := "local-rev"
+	require.NoError(t, local.UpsertSession(db.Session{
+		ID:                 "trae:globalStorage:collision",
+		Project:            "proj",
+		Machine:            "mac",
+		Agent:              "trae",
+		TranscriptRevision: &localRevision,
+		MessageCount:       1,
+		UserMessageCount:   1,
+		CreatedAt:          "2026-07-21T00:00:00Z",
+	}), "UpsertSession local")
+
+	sess, err := pgResolveTraeSiblingSession(
+		context.Background(),
+		local,
+		nil,
+		"trae:globalStorage:collision",
+	)
+
+	require.NoError(t, err, "pgResolveTraeSiblingSession")
+	require.NotNil(t, sess)
+	require.NotNil(t, sess.TranscriptRevision)
+	assert.Equal(t, "local-rev", *sess.TranscriptRevision)
+}
+
 type pushAliasRoutingDriver struct{}
 
 type pushAliasRoutingConn struct{}

--- a/internal/postgres/push_test.go
+++ b/internal/postgres/push_test.go
@@ -361,6 +361,188 @@ func TestDeletePGLegacyTraeSessionIfOwnedMigratesWorkspaceStar(t *testing.T) {
 	assert.Equal(t, "workspace-rev", state.lastRevision)
 }
 
+func TestDeletePGLegacyTraeSessionIfOwnedPreservesCurrentMetadataOverrides(t *testing.T) {
+	state := &legacyTraeMigrationProbeState{}
+	pg := newLegacyTraeMigrationProbeDB(t, state)
+	tx, err := pg.BeginTx(context.Background(), nil)
+	require.NoError(t, err, "BeginTx")
+	defer func() { _ = tx.Rollback() }()
+
+	path := filepath.Join(t.TempDir(), "sessions.db")
+	local, err := db.Open(path)
+	require.NoError(t, err, "db.Open")
+	defer local.Close()
+
+	legacyRevision := "workspace-rev"
+	globalRevision := "global-rev"
+	require.NoError(t, local.UpsertSession(db.Session{
+		ID:                 "trae:collision",
+		Project:            "proj",
+		Machine:            "mac",
+		Agent:              "trae",
+		SourceSessionID:    "collision",
+		TranscriptRevision: &legacyRevision,
+		MessageCount:       1,
+		UserMessageCount:   1,
+		CreatedAt:          "2026-07-21T00:00:00Z",
+	}), "UpsertSession legacy")
+	require.NoError(t, local.UpsertSession(db.Session{
+		ID:                 "trae:workspaceStorage:collision",
+		Project:            "proj",
+		Machine:            "mac",
+		Agent:              "trae",
+		SourceSessionID:    "collision",
+		TranscriptRevision: &legacyRevision,
+		MessageCount:       1,
+		UserMessageCount:   1,
+		CreatedAt:          "2026-07-21T00:01:00Z",
+	}), "UpsertSession workspace")
+	require.NoError(t, local.UpsertSession(db.Session{
+		ID:                 "trae:globalStorage:collision",
+		Project:            "proj",
+		Machine:            "mac",
+		Agent:              "trae",
+		SourceSessionID:    "collision",
+		TranscriptRevision: &globalRevision,
+		MessageCount:       1,
+		UserMessageCount:   1,
+		CreatedAt:          "2026-07-21T00:02:00Z",
+	}), "UpsertSession global")
+
+	err = deletePGLegacyTraeSessionIfOwned(
+		context.Background(),
+		tx,
+		local,
+		map[string]db.Session{
+			"trae:workspaceStorage:collision": {
+				ID:                 "trae:workspaceStorage:collision",
+				TranscriptRevision: &legacyRevision,
+			},
+			"trae:globalStorage:collision": {
+				ID:                 "trae:globalStorage:collision",
+				TranscriptRevision: &globalRevision,
+			},
+		},
+		db.Session{
+			ID:                 "trae:workspaceStorage:collision",
+			Agent:              "trae",
+			SourceSessionID:    "collision",
+			TranscriptRevision: &legacyRevision,
+		},
+		"marker",
+		"mac",
+		nil,
+	)
+
+	require.NoError(t, err, "deletePGLegacyTraeSessionIfOwned")
+	assert.Contains(
+		t,
+		state.metadataUpdateQuery,
+		"display_name = coalesce( target.display_name, legacy_session.display_name )",
+	)
+	assert.Contains(
+		t,
+		state.metadataUpdateQuery,
+		"deleted_at = coalesce( target.deleted_at, legacy_session.deleted_at )",
+	)
+	assert.NotContains(
+		t,
+		state.metadataUpdateQuery,
+		"source_display_name = legacy_session.source_display_name",
+	)
+	assert.NotContains(
+		t,
+		state.metadataUpdateQuery,
+		"source_deleted_at = legacy_session.source_deleted_at",
+	)
+}
+
+func TestDeletePGLegacyTraeSessionIfOwnedIgnoresPinConflicts(t *testing.T) {
+	state := &legacyTraeMigrationProbeState{}
+	pg := newLegacyTraeMigrationProbeDB(t, state)
+	tx, err := pg.BeginTx(context.Background(), nil)
+	require.NoError(t, err, "BeginTx")
+	defer func() { _ = tx.Rollback() }()
+
+	path := filepath.Join(t.TempDir(), "sessions.db")
+	local, err := db.Open(path)
+	require.NoError(t, err, "db.Open")
+	defer local.Close()
+
+	legacyRevision := "workspace-rev"
+	globalRevision := "global-rev"
+	require.NoError(t, local.UpsertSession(db.Session{
+		ID:                 "trae:collision",
+		Project:            "proj",
+		Machine:            "mac",
+		Agent:              "trae",
+		SourceSessionID:    "collision",
+		TranscriptRevision: &legacyRevision,
+		MessageCount:       1,
+		UserMessageCount:   1,
+		CreatedAt:          "2026-07-21T00:00:00Z",
+	}), "UpsertSession legacy")
+	require.NoError(t, local.UpsertSession(db.Session{
+		ID:                 "trae:workspaceStorage:collision",
+		Project:            "proj",
+		Machine:            "mac",
+		Agent:              "trae",
+		SourceSessionID:    "collision",
+		TranscriptRevision: &legacyRevision,
+		MessageCount:       1,
+		UserMessageCount:   1,
+		CreatedAt:          "2026-07-21T00:01:00Z",
+	}), "UpsertSession workspace")
+	require.NoError(t, local.UpsertSession(db.Session{
+		ID:                 "trae:globalStorage:collision",
+		Project:            "proj",
+		Machine:            "mac",
+		Agent:              "trae",
+		SourceSessionID:    "collision",
+		TranscriptRevision: &globalRevision,
+		MessageCount:       1,
+		UserMessageCount:   1,
+		CreatedAt:          "2026-07-21T00:02:00Z",
+	}), "UpsertSession global")
+
+	err = deletePGLegacyTraeSessionIfOwned(
+		context.Background(),
+		tx,
+		local,
+		map[string]db.Session{
+			"trae:workspaceStorage:collision": {
+				ID:                 "trae:workspaceStorage:collision",
+				TranscriptRevision: &legacyRevision,
+			},
+			"trae:globalStorage:collision": {
+				ID:                 "trae:globalStorage:collision",
+				TranscriptRevision: &globalRevision,
+			},
+		},
+		db.Session{
+			ID:                 "trae:workspaceStorage:collision",
+			Agent:              "trae",
+			SourceSessionID:    "collision",
+			TranscriptRevision: &legacyRevision,
+		},
+		"marker",
+		"mac",
+		nil,
+	)
+
+	require.NoError(t, err, "deletePGLegacyTraeSessionIfOwned")
+	assert.Contains(
+		t,
+		state.pinInsertQuery,
+		"on conflict (session_id, message_id) do nothing",
+	)
+	assert.NotContains(
+		t,
+		state.pinInsertQuery,
+		"do update set",
+	)
+}
+
 type pushAliasRoutingDriver struct{}
 
 type pushAliasRoutingConn struct{}
@@ -382,9 +564,11 @@ type legacyTraeMigrationProbeConn struct {
 type legacyTraeMigrationProbeTx struct{}
 
 type legacyTraeMigrationProbeState struct {
-	starInsertCalls int
-	lastTargetID    string
-	lastRevision    string
+	starInsertCalls     int
+	lastTargetID        string
+	lastRevision        string
+	metadataUpdateQuery string
+	pinInsertQuery      string
 }
 
 var pushAliasRoutingRegisterOnce sync.Once
@@ -450,7 +634,7 @@ func (c *legacyTraeMigrationProbeConn) CheckNamedValue(
 func (c *legacyTraeMigrationProbeConn) ExecContext(
 	_ context.Context, query string, args []driver.NamedValue,
 ) (driver.Result, error) {
-	normalized := strings.ToLower(query)
+	normalized := strings.ToLower(strings.Join(strings.Fields(query), " "))
 	switch {
 	case strings.Contains(normalized, "insert into starred_sessions"):
 		c.state.starInsertCalls++
@@ -468,8 +652,13 @@ func (c *legacyTraeMigrationProbeConn) ExecContext(
 			}
 		}
 		return driver.RowsAffected(1), nil
-	case strings.Contains(normalized, "update sessions target"),
-		strings.Contains(normalized, "with matched as"),
+	case strings.Contains(normalized, "update sessions target"):
+		c.state.metadataUpdateQuery = normalized
+		return driver.RowsAffected(1), nil
+	case strings.Contains(normalized, "insert into pinned_messages"):
+		c.state.pinInsertQuery = normalized
+		return driver.RowsAffected(1), nil
+	case
 		strings.Contains(normalized, "delete from sessions"),
 		strings.Contains(normalized, "update pinned_messages p"),
 		strings.Contains(normalized, "delete from pinned_messages p"):

--- a/internal/postgres/push_test.go
+++ b/internal/postgres/push_test.go
@@ -231,6 +231,57 @@ func TestPGPreferredTranscriptRevision(t *testing.T) {
 	assert.Equal(t, "legacy-rev", *preferred)
 }
 
+func TestPGShouldSkipLegacyTraeBatchSession(t *testing.T) {
+	t.Run("legacy skipped when namespaced sibling is in batch", func(t *testing.T) {
+		legacy := db.Session{
+			ID:              "trae:collision",
+			Agent:           "trae",
+			SourceSessionID: "collision",
+		}
+		shouldSkip := pgShouldSkipLegacyTraeBatchSession(
+			map[string]db.Session{
+				"trae:workspaceStorage:collision": {
+					ID: "trae:workspaceStorage:collision",
+				},
+			},
+			legacy,
+		)
+		assert.True(t, shouldSkip)
+	})
+
+	t.Run("legacy kept when batch has no namespaced sibling", func(t *testing.T) {
+		shouldSkip := pgShouldSkipLegacyTraeBatchSession(
+			map[string]db.Session{
+				"trae:collision": {
+					ID: "trae:collision",
+				},
+			},
+			db.Session{
+				ID:              "trae:collision",
+				Agent:           "trae",
+				SourceSessionID: "collision",
+			},
+		)
+		assert.False(t, shouldSkip)
+	})
+
+	t.Run("namespaced session is never skipped by this gate", func(t *testing.T) {
+		shouldSkip := pgShouldSkipLegacyTraeBatchSession(
+			map[string]db.Session{
+				"trae:workspaceStorage:collision": {
+					ID: "trae:workspaceStorage:collision",
+				},
+			},
+			db.Session{
+				ID:              "trae:workspaceStorage:collision",
+				Agent:           "trae",
+				SourceSessionID: "collision",
+			},
+		)
+		assert.False(t, shouldSkip)
+	})
+}
+
 type pushAliasRoutingDriver struct{}
 
 type pushAliasRoutingConn struct{}

--- a/internal/postgres/push_test.go
+++ b/internal/postgres/push_test.go
@@ -213,6 +213,24 @@ func TestPGResolveTraeSiblingSessionFallsBackToLocal(t *testing.T) {
 	assert.Equal(t, "local-rev", *sess.TranscriptRevision)
 }
 
+func TestPGPreferredTranscriptRevision(t *testing.T) {
+	current := "current-rev"
+	legacy := "legacy-rev"
+
+	preferred := pgPreferredTranscriptRevision(&current, &legacy)
+	require.NotNil(t, preferred)
+	assert.Equal(t, "current-rev", *preferred)
+
+	preferred = pgPreferredTranscriptRevision(nil, &legacy)
+	require.NotNil(t, preferred)
+	assert.Equal(t, "legacy-rev", *preferred)
+
+	empty := ""
+	preferred = pgPreferredTranscriptRevision(&empty, &legacy)
+	require.NotNil(t, preferred)
+	assert.Equal(t, "legacy-rev", *preferred)
+}
+
 type pushAliasRoutingDriver struct{}
 
 type pushAliasRoutingConn struct{}

--- a/internal/postgres/session_aliases.go
+++ b/internal/postgres/session_aliases.go
@@ -51,6 +51,13 @@ func pgSessionTombstoneIDs(sess db.Session) []string {
 	return uniqueNonEmptyStrings(ids)
 }
 
+func pgSessionIDPrefix(id string) string {
+	if idx := strings.Index(id, "~"); idx > 0 {
+		return id[:idx+1]
+	}
+	return ""
+}
+
 func pgTraeLegacySessionID(sess db.Session) string {
 	if sess.Agent != "trae" {
 		return ""
@@ -59,7 +66,8 @@ func pgTraeLegacySessionID(sess db.Session) string {
 	if rawID == "" {
 		return ""
 	}
-	legacyID := "trae:" + strings.TrimPrefix(rawID, "trae:")
+	legacyID := pgSessionIDPrefix(sess.ID) + "trae:" +
+		strings.TrimPrefix(rawID, "trae:")
 	if legacyID == sess.ID {
 		return ""
 	}

--- a/internal/postgres/session_aliases.go
+++ b/internal/postgres/session_aliases.go
@@ -51,6 +51,21 @@ func pgSessionTombstoneIDs(sess db.Session) []string {
 	return uniqueNonEmptyStrings(ids)
 }
 
+func pgTraeLegacySessionID(sess db.Session) string {
+	if sess.Agent != "trae" {
+		return ""
+	}
+	rawID := strings.TrimSpace(sess.SourceSessionID)
+	if rawID == "" {
+		return ""
+	}
+	legacyID := "trae:" + strings.TrimPrefix(rawID, "trae:")
+	if legacyID == sess.ID {
+		return ""
+	}
+	return legacyID
+}
+
 func pgVibeFallbackAliasID(id, agent, filePath string) string {
 	if agent != "vibe" || filePath == "" {
 		return ""

--- a/internal/postgres/session_aliases.go
+++ b/internal/postgres/session_aliases.go
@@ -46,9 +46,18 @@ func pgSessionAliasIDs(sess db.Session) []string {
 	return []string{aliasID}
 }
 
-func pgSessionTombstoneIDs(sess db.Session) []string {
+func pgSessionTombstoneIDs(
+	ctx context.Context, local *db.DB, sess db.Session,
+) ([]string, error) {
 	ids := append([]string{sess.ID}, pgSessionAliasIDs(sess)...)
-	return uniqueNonEmptyStrings(ids)
+	legacyID, includeLegacy, err := pgTraeLegacyTombstoneID(ctx, local, sess)
+	if err != nil {
+		return nil, err
+	}
+	if includeLegacy {
+		ids = append(ids, legacyID)
+	}
+	return uniqueNonEmptyStrings(ids), nil
 }
 
 func pgSessionIDPrefix(id string) string {
@@ -72,6 +81,86 @@ func pgTraeLegacySessionID(sess db.Session) string {
 		return ""
 	}
 	return legacyID
+}
+
+func pgTraeLegacyTombstoneID(
+	ctx context.Context, local *db.DB, sess db.Session,
+) (string, bool, error) {
+	legacyID := pgTraeLegacySessionID(sess)
+	if legacyID == "" {
+		return "", false, nil
+	}
+	currentNamespace, hasNamespace := pgTraeNamespacedSessionNamespace(sess.ID)
+	if !hasNamespace {
+		return legacyID, true, nil
+	}
+	if local == nil {
+		return "", false, nil
+	}
+	legacyLocal, err := local.GetSession(ctx, legacyID)
+	if err != nil {
+		return "", false, fmt.Errorf(
+			"loading legacy trae tombstone source %s: %w",
+			legacyID, err,
+		)
+	}
+	if legacyLocal != nil && legacyLocal.FilePath != nil {
+		legacyNamespace := pgTraeSessionNamespaceFromPath(*legacyLocal.FilePath)
+		if legacyNamespace != "" {
+			return legacyID, legacyNamespace == currentNamespace, nil
+		}
+	}
+	rawID := strings.TrimPrefix(sess.ID, pgSessionIDPrefix(sess.ID))
+	rawID = strings.TrimPrefix(rawID, "trae:workspaceStorage:")
+	rawID = strings.TrimPrefix(rawID, "trae:globalStorage:")
+	workspaceID := pgSessionIDPrefix(sess.ID) + "trae:workspaceStorage:" + rawID
+	globalID := pgSessionIDPrefix(sess.ID) + "trae:globalStorage:" + rawID
+	workspaceSibling, err := local.GetSession(ctx, workspaceID)
+	if err != nil {
+		return "", false, fmt.Errorf(
+			"loading namespaced trae sibling %s: %w",
+			workspaceID, err,
+		)
+	}
+	globalSibling, err := local.GetSession(ctx, globalID)
+	if err != nil {
+		return "", false, fmt.Errorf(
+			"loading namespaced trae sibling %s: %w",
+			globalID, err,
+		)
+	}
+	switch {
+	case workspaceSibling != nil && globalSibling == nil:
+		return legacyID, currentNamespace == "workspaceStorage", nil
+	case globalSibling != nil && workspaceSibling == nil:
+		return legacyID, currentNamespace == "globalStorage", nil
+	default:
+		return "", false, nil
+	}
+}
+
+func pgTraeNamespacedSessionNamespace(id string) (string, bool) {
+	stripped := strings.TrimPrefix(id, pgSessionIDPrefix(id))
+	switch {
+	case strings.HasPrefix(stripped, "trae:workspaceStorage:"):
+		return "workspaceStorage", true
+	case strings.HasPrefix(stripped, "trae:globalStorage:"):
+		return "globalStorage", true
+	default:
+		return "", false
+	}
+}
+
+func pgTraeSessionNamespaceFromPath(path string) string {
+	path = filepath.ToSlash(strings.TrimSpace(path))
+	switch {
+	case strings.Contains(path, "/workspaceStorage/"):
+		return "workspaceStorage"
+	case strings.Contains(path, "/globalStorage/"):
+		return "globalStorage"
+	default:
+		return ""
+	}
 }
 
 func pgVibeFallbackAliasID(id, agent, filePath string) string {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1780,6 +1780,23 @@ func (e *Engine) resyncAllWithOptionsLocked(
 		return stats, err
 	}
 	stats.OrphanedCopied = orphaned
+	if err := newDB.MigrateAllLegacyTraeSessions(); err != nil {
+		log.Printf("resync: migrate legacy trae sessions: %v", err)
+		stats.Aborted = true
+		stats.Warnings = append(stats.Warnings,
+			"legacy trae migration failed, aborting swap: "+err.Error(),
+		)
+		newDB.Close()
+		removeTempDB(tempPath)
+		restoreSkipCache()
+		if rerr := origDB.Reopen(); rerr != nil {
+			log.Printf("resync: recovery reopen: %v", rerr)
+		}
+		e.mu.Lock()
+		e.lastSyncStats = stats
+		e.mu.Unlock()
+		return stats, err
+	}
 
 	// Re-link subagent sessions after orphan copy so copied
 	// tool_calls.subagent_session_id references are resolved.
@@ -1848,6 +1865,23 @@ func (e *Engine) resyncAllWithOptionsLocked(
 		context.Background(), e.machine,
 	); err != nil {
 		log.Printf("resync: apply worktree mappings: %v", err)
+	}
+	if err := newDB.MigrateAllLegacyTraeSessions(); err != nil {
+		log.Printf("resync: finalize legacy trae migration: %v", err)
+		stats.Aborted = true
+		stats.Warnings = append(stats.Warnings,
+			"legacy trae finalization failed, aborting swap: "+err.Error(),
+		)
+		newDB.Close()
+		removeTempDB(tempPath)
+		restoreSkipCache()
+		if rerr := origDB.Reopen(); rerr != nil {
+			log.Printf("resync: recovery reopen: %v", rerr)
+		}
+		e.mu.Lock()
+		e.lastSyncStats = stats
+		e.mu.Unlock()
+		return stats, err
 	}
 
 	// Reclassify is_automated across every row. Orphan-copied
@@ -1939,6 +1973,17 @@ func (e *Engine) resyncAllWithOptionsLocked(
 		return stats, err
 	} else {
 		origDB.MarkDataCurrent()
+		if err := origDB.MigrateAllLegacyTraeSessions(); err != nil {
+			log.Printf("resync: live legacy trae migration: %v", err)
+			stats.Aborted = true
+			stats.Warnings = append(stats.Warnings,
+				"resync completed but legacy trae migration failed: "+err.Error(),
+			)
+			e.mu.Lock()
+			e.lastSyncStats = stats
+			e.mu.Unlock()
+			return stats, err
+		}
 		if err := origDB.CheckpointWALTruncateWithRetry(ctx); err != nil {
 			if errors.Is(err, db.ErrWALCheckpointBusy) {
 				log.Printf("resync: wal checkpoint busy")
@@ -2312,6 +2357,16 @@ func (e *Engine) SyncAll(
 	}()
 	defer e.syncMu.Unlock()
 	defer e.clearCurrentProgress()
+	if e.db.NeedsResync() {
+		stats = e.resyncAllLocked(ctx, onProgress)
+		if stats.Aborted && ctx.Err() == nil {
+			stats = e.syncAllLocked(
+				ctx, onProgress, time.Time{}, nil,
+				syncWriteDefault, true, false,
+			)
+		}
+		return
+	}
 	stats = e.syncAllLocked(
 		ctx, onProgress, time.Time{}, nil, syncWriteDefault, true, false,
 	)
@@ -7855,6 +7910,12 @@ func (e *Engine) writeBatchBulk(
 	batch []pendingWrite, forceReplace bool,
 ) (writtenSessions, writtenMessages, failedSessions, cwdFiltered int) {
 	writes := make([]db.SessionBatchWrite, 0, len(batch))
+	type legacyTraeMigration struct {
+		oldID     string
+		newID     string
+		namespace string
+	}
+	migrations := make([]legacyTraeMigration, 0, len(batch))
 	sources := make(map[string]batchSourceFile, len(batch))
 	resolveWorktreeProject := e.loadWorktreeProjectResolver()
 
@@ -7867,6 +7928,14 @@ func (e *Engine) writeBatchBulk(
 		if verdict != sessionWriteOK {
 			if verdict == sessionWriteCwdFiltered {
 				cwdFiltered++
+			}
+			continue
+		}
+		legacyTraeID, legacyTraeNamespace := legacyTraeSessionMigrationTarget(s)
+		if legacyTraeID != "" && e.db.IsSessionExcluded(legacyTraeID) {
+			if err := e.db.ExcludeSessionID(s.ID); err != nil {
+				log.Printf("exclude migrated trae session %s: %v", s.ID, err)
+				failedSessions++
 			}
 			continue
 		}
@@ -7888,6 +7957,13 @@ func (e *Engine) writeBatchBulk(
 			DataVersion:     dataVersionForWrite(pw),
 			ReplaceMessages: replaceMessages,
 		})
+		if legacyTraeID != "" {
+			migrations = append(migrations, legacyTraeMigration{
+				oldID:     legacyTraeID,
+				newID:     s.ID,
+				namespace: legacyTraeNamespace,
+			})
+		}
 		if pw.sess.File.Path != "" {
 			sources[s.ID] = batchSourceFile{
 				path:        pw.sess.File.Path,
@@ -7919,6 +7995,17 @@ func (e *Engine) writeBatchBulk(
 	}
 	for _, err := range result.Errors {
 		log.Printf("write session batch: %v", err)
+	}
+	for _, migration := range migrations {
+		if err := e.db.MigrateLegacyTraeSessionState(
+			migration.oldID, migration.newID, migration.namespace,
+		); err != nil {
+			log.Printf(
+				"migrate legacy trae state %s -> %s: %v",
+				migration.oldID, migration.newID, err,
+			)
+			failedSessions++
+		}
 	}
 	return result.WrittenSessions,
 		result.WrittenMessages,
@@ -8514,6 +8601,13 @@ func (e *Engine) writeSessionFullWithResolver(
 	if verdict != sessionWriteOK {
 		return errSessionPreserved
 	}
+	legacyTraeID, legacyTraeNamespace := legacyTraeSessionMigrationTarget(s)
+	if legacyTraeID != "" && e.db.IsSessionExcluded(legacyTraeID) {
+		if err := e.db.ExcludeSessionID(s.ID); err != nil {
+			return err
+		}
+		return db.ErrSessionExcluded
+	}
 	if err := e.db.UpsertSession(s); err != nil {
 		if isIntentionalSessionSkip(err) {
 			if pw.sess.File.Path != "" {
@@ -8544,6 +8638,13 @@ func (e *Engine) writeSessionFullWithResolver(
 			s.ID, err,
 		)
 		return err
+	}
+	if legacyTraeID != "" {
+		if err := e.db.MigrateLegacyTraeSessionState(
+			legacyTraeID, s.ID, legacyTraeNamespace,
+		); err != nil {
+			return err
+		}
 	}
 
 	// See writeBatch for why data_version is bumped here
@@ -8844,6 +8945,36 @@ func countToolResultEvents(calls []db.ToolCall) int {
 
 func (e *Engine) applyIDPrefixToSessionIDs(ids []string) []string {
 	return applyIDPrefixToIDs(e.idPrefix, ids)
+}
+
+func legacyTraeSessionMigrationTarget(s db.Session) (string, string) {
+	if s.Agent != string(parser.AgentTrae) {
+		return "", ""
+	}
+	rawID := strings.TrimSpace(s.SourceSessionID)
+	rawID = strings.TrimPrefix(rawID, "trae:")
+	if rawID == "" {
+		return "", ""
+	}
+	id := "trae:" + rawID
+	namespace := ""
+	switch {
+	case strings.Contains(s.ID, "trae:workspaceStorage:"):
+		namespace = "workspaceStorage"
+	case strings.Contains(s.ID, "trae:globalStorage:"):
+		namespace = "globalStorage"
+	}
+	if namespace == "" || id == s.ID {
+		return "", ""
+	}
+	return applyIDPrefixToID(sessionIDPrefixForSession(s.ID), id), namespace
+}
+
+func sessionIDPrefixForSession(id string) string {
+	if idx := strings.Index(id, "~"); idx > 0 {
+		return id[:idx+1]
+	}
+	return ""
 }
 
 // applyRemoteRewrites prefixes session IDs and rewrites

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -7973,7 +7973,7 @@ func (e *Engine) writeBatchBulk(
 		}
 	}
 	if len(writes) == 0 {
-		return 0, 0, 0, cwdFiltered
+		return 0, 0, failedSessions, cwdFiltered
 	}
 
 	tWrite := time.Now()
@@ -7984,7 +7984,7 @@ func (e *Engine) writeBatchBulk(
 	e.phaseStats.BatchedWrites.Add(int64(result.WrittenSessions))
 	if err != nil {
 		log.Printf("write session batch: %v", err)
-		return 0, 0, len(writes), cwdFiltered
+		return 0, 0, len(writes) + failedSessions, cwdFiltered
 	}
 	for _, id := range result.ExcludedIDs {
 		if source, ok := sources[id]; ok && source.path != "" {
@@ -8009,7 +8009,7 @@ func (e *Engine) writeBatchBulk(
 	}
 	return result.WrittenSessions,
 		result.WrittenMessages,
-		result.FailedSessions,
+		result.FailedSessions + failedSessions,
 		cwdFiltered
 }
 

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -2359,12 +2359,6 @@ func (e *Engine) SyncAll(
 	defer e.clearCurrentProgress()
 	if e.db.NeedsResync() {
 		stats = e.resyncAllLocked(ctx, onProgress)
-		if stats.Aborted && ctx.Err() == nil {
-			stats = e.syncAllLocked(
-				ctx, onProgress, time.Time{}, nil,
-				syncWriteDefault, true, false,
-			)
-		}
 		return
 	}
 	stats = e.syncAllLocked(

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -6983,6 +6983,14 @@ func (e *Engine) writeBatch(
 			existing < db.CurrentDataVersion() {
 			stale = true
 		}
+		legacyTraeID, legacyTraeNamespace := legacyTraeSessionMigrationTarget(s)
+		if legacyTraeID != "" && e.db.IsSessionExcluded(legacyTraeID) {
+			if err := e.db.ExcludeSessionID(s.ID); err != nil {
+				log.Printf("exclude migrated trae session %s: %v", s.ID, err)
+				failedSessions++
+			}
+			continue
+		}
 
 		// UpsertSession first: the session row must exist
 		// before messages can be inserted (FK constraint).
@@ -7044,6 +7052,18 @@ func (e *Engine) writeBatch(
 			)
 			failedSessions++
 			continue
+		}
+		if legacyTraeID != "" {
+			if err := e.db.MigrateLegacyTraeSessionState(
+				legacyTraeID, s.ID, legacyTraeNamespace,
+			); err != nil {
+				log.Printf(
+					"migrate legacy trae state %s -> %s: %v",
+					legacyTraeID, s.ID, err,
+				)
+				failedSessions++
+				continue
+			}
 		}
 
 		// Advance data_version only after the message write

--- a/internal/sync/parsediff_dbbacked_test.go
+++ b/internal/sync/parsediff_dbbacked_test.go
@@ -437,7 +437,7 @@ func TestParseDiffTraePartialRemovalUsesContainerPresenceSweep(t *testing.T) {
 	assert.Equal(t, sync.ParseDiffTotals{
 		Examined: 2, Identical: 1, Changed: 1,
 	}, report.Totals)
-	sd := findSessionDiff(report, "trae:trae-b")
+	sd := findSessionDiff(report, "trae:globalStorage:trae-b")
 	require.NotNil(t, sd, "removed Trae sibling must be listed")
 	assert.Equal(t, sync.DiffChanged, sd.Class)
 	assert.ElementsMatch(t, []string{sync.FieldPresence},

--- a/internal/sync/trae_integration_test.go
+++ b/internal/sync/trae_integration_test.go
@@ -425,12 +425,53 @@ func TestResyncAllMigratesLegacyTraeNamespaceIDs(t *testing.T) {
 			ContentLength: len("legacy reply"),
 		},
 	)
+	legacyMsgs, err := archive.GetMessages(context.Background(), "trae:rewrite", 0, 10, true)
+	require.NoError(t, err)
+	require.Len(t, legacyMsgs, 2)
+	legacyName := "Legacy renamed session"
+	require.NoError(t, archive.RenameSession("trae:rewrite", &legacyName))
+	starred, err := archive.StarSession("trae:rewrite")
+	require.NoError(t, err)
+	require.True(t, starred)
+	pinNote := "legacy pin"
+	_, err = archive.PinMessage("trae:rewrite", legacyMsgs[1].ID, &pinNote)
+	require.NoError(t, err)
+	_, err = archive.InsertRecallEntry(db.RecallEntry{
+		ID:              "trae-legacy-recall",
+		Type:            "fact",
+		Scope:           "session",
+		Status:          "accepted",
+		ReviewState:     "human_reviewed",
+		Title:           "Legacy Trae recall",
+		Body:            "remember the migrated workspace session",
+		SourceSessionID: "trae:rewrite",
+		CreatedAt:       "2026-05-10T10:00:00Z",
+		UpdatedAt:       "2026-05-10T10:00:00Z",
+		Evidence: []db.RecallEvidence{{
+			SessionID:           "trae:rewrite",
+			MessageStartOrdinal: 1,
+			MessageEndOrdinal:   1,
+			Snippet:             "legacy reply",
+		}},
+	})
+	require.NoError(t, err)
 	require.NoError(t, archive.SetSessionDataVersion("trae:rewrite", 68))
 	require.NoError(t, archive.Close())
 
 	conn, err := sql.Open("sqlite3", archivePath)
 	require.NoError(t, err)
 	_, err = conn.Exec(`PRAGMA user_version = 68`)
+	require.NoError(t, err)
+	_, err = conn.Exec(`
+		INSERT INTO recall_extract_generations
+			(fingerprint, state, model, segmenter, params_json)
+		VALUES
+			('trae-gen', 'active', 'test-model', 'test-segmenter', '{}');
+		INSERT INTO recall_extract_progress
+			(session_id, generation_fingerprint, unit_cursor, units_total, state, content_digest, updated_at)
+		VALUES
+			('trae:rewrite', 'trae-gen', 2, 3, 'partial', 'legacy-digest', '2026-05-10T10:00:00Z');
+	`)
 	require.NoError(t, err)
 	require.NoError(t, conn.Close())
 
@@ -446,24 +487,94 @@ func TestResyncAllMigratesLegacyTraeNamespaceIDs(t *testing.T) {
 	stats := engine.SyncAll(context.Background(), nil)
 	require.False(t, stats.Aborted)
 	assert.Equal(t, 0, stats.OrphanedCopied)
+	verifyDB, err := sql.Open("sqlite3", archivePath)
+	require.NoError(t, err)
+	defer verifyDB.Close()
 
-	legacy, err := reopened.GetSessionFull(context.Background(), "trae:rewrite")
-	require.NoError(t, err)
-	assert.Nil(t, legacy)
+	var count int
+	require.NoError(t, verifyDB.QueryRow(
+		`SELECT COUNT(*) FROM sessions WHERE id = ?`,
+		"trae:rewrite",
+	).Scan(&count))
+	assert.Zero(t, count)
 
-	workspace, err := reopened.GetSessionFull(context.Background(), "trae:workspaceStorage:rewrite")
-	require.NoError(t, err)
-	require.NotNil(t, workspace)
-	global, err := reopened.GetSessionFull(context.Background(), "trae:globalStorage:rewrite")
-	require.NoError(t, err)
-	require.NotNil(t, global)
+	const workspaceID = "trae:workspaceStorage:rewrite"
+	const globalID = "trae:globalStorage:rewrite"
+	require.NoError(t, verifyDB.QueryRow(
+		`SELECT COUNT(*) FROM sessions WHERE id = ?`,
+		workspaceID,
+	).Scan(&count))
+	assert.Equal(t, 1, count)
+	require.NoError(t, verifyDB.QueryRow(
+		`SELECT COUNT(*) FROM sessions WHERE id = ?`,
+		globalID,
+	).Scan(&count))
+	assert.Equal(t, 1, count)
 
-	workspaceMessages, err := reopened.GetMessages(context.Background(), workspace.ID, 0, 10, true)
-	require.NoError(t, err)
-	globalMessages, err := reopened.GetMessages(context.Background(), global.ID, 0, 10, true)
-	require.NoError(t, err)
-	assert.Equal(t, "workspace reply", workspaceMessages[1].Content)
-	assert.Equal(t, "global reply", globalMessages[1].Content)
+	var gotDisplayName sql.NullString
+	require.NoError(t, verifyDB.QueryRow(
+		`SELECT display_name FROM sessions WHERE id = ?`,
+		workspaceID,
+	).Scan(&gotDisplayName))
+	require.True(t, gotDisplayName.Valid)
+	assert.Equal(t, legacyName, gotDisplayName.String)
+
+	var workspaceReply, globalReply string
+	require.NoError(t, verifyDB.QueryRow(
+		`SELECT content FROM messages
+		  WHERE session_id = ? AND ordinal = 1`,
+		workspaceID,
+	).Scan(&workspaceReply))
+	require.NoError(t, verifyDB.QueryRow(
+		`SELECT content FROM messages
+		  WHERE session_id = ? AND ordinal = 1`,
+		globalID,
+	).Scan(&globalReply))
+	assert.Equal(t, "workspace reply", workspaceReply)
+	assert.Equal(t, "global reply", globalReply)
+
+	require.NoError(t, verifyDB.QueryRow(
+		`SELECT COUNT(*) FROM starred_sessions WHERE session_id = ?`,
+		workspaceID,
+	).Scan(&count))
+	assert.Equal(t, 1, count)
+	require.NoError(t, verifyDB.QueryRow(
+		`SELECT COUNT(*) FROM starred_sessions WHERE session_id = ?`,
+		"trae:rewrite",
+	).Scan(&count))
+	assert.Zero(t, count)
+
+	var pinSessionID string
+	var pinOrdinal int
+	var gotPinNote sql.NullString
+	require.NoError(t, verifyDB.QueryRow(
+		`SELECT session_id, ordinal, note
+		   FROM pinned_messages
+		  WHERE session_id = ?`,
+		workspaceID,
+	).Scan(&pinSessionID, &pinOrdinal, &gotPinNote))
+	assert.Equal(t, workspaceID, pinSessionID)
+	assert.Equal(t, 1, pinOrdinal)
+	require.True(t, gotPinNote.Valid)
+	assert.Equal(t, pinNote, gotPinNote.String)
+
+	var recallSessionID, evidenceSessionID string
+	require.NoError(t, verifyDB.QueryRow(
+		`SELECT source_session_id FROM recall_entries WHERE id = ?`,
+		"trae-legacy-recall",
+	).Scan(&recallSessionID))
+	require.NoError(t, verifyDB.QueryRow(
+		`SELECT session_id FROM recall_evidence WHERE entry_id = ?`,
+		"trae-legacy-recall",
+	).Scan(&evidenceSessionID))
+	assert.Equal(t, workspaceID, recallSessionID)
+	assert.Equal(t, workspaceID, evidenceSessionID)
+
+	require.NoError(t, verifyDB.QueryRow(
+		`SELECT COUNT(*) FROM recall_extract_progress WHERE session_id = ?`,
+		workspaceID,
+	).Scan(&count))
+	assert.Equal(t, 1, count)
 }
 
 func TestFindSourceFileTraeRelocationUsesQualifiedRawID(t *testing.T) {

--- a/internal/sync/trae_integration_test.go
+++ b/internal/sync/trae_integration_test.go
@@ -203,7 +203,7 @@ func TestProcessFileProviderTraeChangedContainerDropsUnchangedSibling(t *testing
 	})
 	require.NoError(t, second.err)
 	require.Len(t, second.results, 1)
-	assert.Equal(t, "trae:rewrite", second.results[0].Session.ID)
+	assert.Equal(t, "trae:globalStorage:rewrite", second.results[0].Session.ID)
 	assert.Equal(t, "bravo reply", second.results[0].Messages[1].Content)
 }
 
@@ -255,7 +255,7 @@ func TestProcessFileProviderTraeWALWatcherEventDropsUnchangedSibling(t *testing.
 	second := engine.processFile(context.Background(), classified[0])
 	require.NoError(t, second.err)
 	require.Len(t, second.results, 1)
-	assert.Equal(t, "trae:rewrite", second.results[0].Session.ID)
+	assert.Equal(t, "trae:globalStorage:rewrite", second.results[0].Session.ID)
 	assert.Equal(t, "bravo reply", second.results[0].Messages[1].Content)
 }
 
@@ -293,4 +293,126 @@ func TestProcessFileProviderTraeRemovedWALSidecarDoesNotForceParse(t *testing.T)
 	stats := engine.LastSyncStats()
 	assert.Equal(t, 0, stats.Synced)
 	assert.Equal(t, 0, stats.Failed)
+}
+
+func TestProcessFileProviderTraeCrossNamespaceIDsSurviveUpsert(t *testing.T) {
+	root := t.TempDir()
+	workspacePath := filepath.Join(root, "workspaceStorage", "hash", "state.vscdb")
+	globalPath := filepath.Join(root, "globalStorage", "state.vscdb")
+	writeTraeSyncDB(t, workspacePath, "workspace reply")
+	writeTraeSyncDB(t, globalPath, "global reply")
+
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentTrae: {root}},
+		Machine:   "devbox",
+	})
+	for _, path := range []string{workspacePath, globalPath} {
+		processed := engine.processFile(context.Background(), parser.DiscoveredFile{Path: path, Agent: parser.AgentTrae})
+		require.NoError(t, processed.err)
+		require.Len(t, processed.results, 1)
+		written, _, failed, _ := engine.writeBatch([]pendingWrite{{
+			sess:         processed.results[0].Session,
+			msgs:         processed.results[0].Messages,
+			forceReplace: processed.forceReplace,
+		}}, syncWriteDefault, false)
+		require.Equal(t, 1, written)
+		require.Equal(t, 0, failed)
+	}
+
+	workspace, err := database.GetSessionFull(context.Background(), "trae:workspaceStorage:rewrite")
+	require.NoError(t, err)
+	global, err := database.GetSessionFull(context.Background(), "trae:globalStorage:rewrite")
+	require.NoError(t, err)
+	require.NotNil(t, workspace)
+	require.NotNil(t, global)
+	assert.Equal(t, "rewrite", workspace.SourceSessionID)
+	assert.Equal(t, "rewrite", global.SourceSessionID)
+	require.NotNil(t, workspace.FilePath)
+	require.NotNil(t, global.FilePath)
+	assert.Equal(t, workspacePath+"#rewrite", *workspace.FilePath)
+	assert.Equal(t, globalPath+"#rewrite", *global.FilePath)
+
+	workspaceMessages, err := database.GetMessages(context.Background(), workspace.ID, 0, 10, true)
+	require.NoError(t, err)
+	globalMessages, err := database.GetMessages(context.Background(), global.ID, 0, 10, true)
+	require.NoError(t, err)
+	assert.Equal(t, "workspace reply", workspaceMessages[1].Content)
+	assert.Equal(t, "global reply", globalMessages[1].Content)
+}
+
+func TestProcessFileProviderTraeNamespaceLifecycleIsolation(t *testing.T) {
+	root := t.TempDir()
+	workspacePath := filepath.Join(root, "workspaceStorage", "hash", "state.vscdb")
+	globalPath := filepath.Join(root, "globalStorage", "state.vscdb")
+	writeTraeSyncDB(t, workspacePath, "workspace reply")
+	writeTraeSyncDB(t, globalPath, "global reply")
+
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentTrae: {root}},
+		Machine:   "devbox",
+	})
+	for _, path := range []string{workspacePath, globalPath} {
+		processed := engine.processFile(context.Background(), parser.DiscoveredFile{Path: path, Agent: parser.AgentTrae})
+		require.NoError(t, processed.err)
+		require.Len(t, processed.results, 1)
+		written, _, failed, _ := engine.writeBatch([]pendingWrite{{
+			sess:         processed.results[0].Session,
+			msgs:         processed.results[0].Messages,
+			forceReplace: processed.forceReplace,
+		}}, syncWriteDefault, false)
+		require.Equal(t, 1, written)
+		require.Equal(t, 0, failed)
+	}
+
+	info, err := os.Stat(workspacePath)
+	require.NoError(t, err)
+	rewriteTraeSyncDB(t, workspacePath, "workspace rewritten", info.ModTime())
+	processed := engine.processFile(context.Background(), parser.DiscoveredFile{Path: workspacePath, Agent: parser.AgentTrae})
+	require.NoError(t, processed.err)
+	require.Len(t, processed.results, 1)
+	written, _, failed, _ := engine.writeBatch([]pendingWrite{{
+		sess:         processed.results[0].Session,
+		msgs:         processed.results[0].Messages,
+		forceReplace: processed.forceReplace,
+	}}, syncWriteDefault, false)
+	require.Equal(t, 1, written)
+	require.Equal(t, 0, failed)
+
+	workspaceMessages, err := database.GetMessages(context.Background(), "trae:workspaceStorage:rewrite", 0, 10, true)
+	require.NoError(t, err)
+	globalMessages, err := database.GetMessages(context.Background(), "trae:globalStorage:rewrite", 0, 10, true)
+	require.NoError(t, err)
+	assert.Equal(t, "workspace rewritten", workspaceMessages[1].Content)
+	assert.Equal(t, "global reply", globalMessages[1].Content)
+}
+
+func TestFindSourceFileTraeRelocationUsesQualifiedRawID(t *testing.T) {
+	root := t.TempDir()
+	oldDB := filepath.Join(root, "workspaceStorage", "old-hash", "state.vscdb")
+	newDB := filepath.Join(root, "workspaceStorage", "hash", "state.vscdb")
+	writeTraeSyncDB(t, oldDB, "old reply")
+	writeTraeSyncDB(t, newDB, "new reply")
+
+	database := dbtest.OpenTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentTrae: {root}},
+		Machine:   "devbox",
+	})
+	processed := engine.processFile(context.Background(), parser.DiscoveredFile{Path: oldDB, Agent: parser.AgentTrae})
+	require.NoError(t, processed.err)
+	require.Len(t, processed.results, 1)
+	written, _, failed, _ := engine.writeBatch([]pendingWrite{{
+		sess:         processed.results[0].Session,
+		msgs:         processed.results[0].Messages,
+		forceReplace: processed.forceReplace,
+	}}, syncWriteDefault, false)
+	require.Equal(t, 1, written)
+	require.Equal(t, 0, failed)
+
+	info, err := os.Stat(oldDB)
+	require.NoError(t, err)
+	setTraeSyncDBSessions(t, oldDB, []any{traeSyncSession("other", "old moved")}, info.ModTime())
+	assert.Equal(t, newDB+"#rewrite", engine.FindSourceFile("trae:workspaceStorage:rewrite"))
 }

--- a/internal/sync/trae_integration_test.go
+++ b/internal/sync/trae_integration_test.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/dbtest"
 	"go.kenn.io/agentsview/internal/parser"
 )
@@ -385,6 +386,83 @@ func TestProcessFileProviderTraeNamespaceLifecycleIsolation(t *testing.T) {
 	globalMessages, err := database.GetMessages(context.Background(), "trae:globalStorage:rewrite", 0, 10, true)
 	require.NoError(t, err)
 	assert.Equal(t, "workspace rewritten", workspaceMessages[1].Content)
+	assert.Equal(t, "global reply", globalMessages[1].Content)
+}
+
+func TestResyncAllMigratesLegacyTraeNamespaceIDs(t *testing.T) {
+	root := t.TempDir()
+	workspacePath := filepath.Join(root, "workspaceStorage", "hash", "state.vscdb")
+	globalPath := filepath.Join(root, "globalStorage", "state.vscdb")
+	writeTraeSyncDB(t, workspacePath, "workspace reply")
+	writeTraeSyncDB(t, globalPath, "global reply")
+
+	archivePath := filepath.Join(root, "agentsview.db")
+	dbtest.EnsureTestDBAt(t, archivePath)
+	archive, err := db.Open(archivePath)
+	require.NoError(t, err)
+
+	startedAt := "2026-05-10T10:00:00Z"
+	legacyPath := workspacePath + "#rewrite"
+	require.NoError(t, archive.UpsertSession(db.Session{
+		ID:               "trae:rewrite",
+		Project:          "agentsview",
+		Machine:          "devbox",
+		Agent:            string(parser.AgentTrae),
+		SourceSessionID:  "rewrite",
+		StartedAt:        &startedAt,
+		EndedAt:          &startedAt,
+		MessageCount:     2,
+		UserMessageCount: 1,
+		FilePath:         &legacyPath,
+	}))
+	dbtest.SeedMessages(t, archive,
+		dbtest.UserMsg("trae:rewrite", 0, "same prompt"),
+		db.Message{
+			SessionID:     "trae:rewrite",
+			Ordinal:       1,
+			Role:          "assistant",
+			Content:       "legacy reply",
+			ContentLength: len("legacy reply"),
+		},
+	)
+	require.NoError(t, archive.SetSessionDataVersion("trae:rewrite", 68))
+	require.NoError(t, archive.Close())
+
+	conn, err := sql.Open("sqlite3", archivePath)
+	require.NoError(t, err)
+	_, err = conn.Exec(`PRAGMA user_version = 68`)
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	reopened, err := db.Open(archivePath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, reopened.Close()) })
+	require.True(t, reopened.NeedsResync())
+
+	engine := NewEngine(reopened, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentTrae: {root}},
+		Machine:   "devbox",
+	})
+	stats := engine.SyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted)
+	assert.Equal(t, 0, stats.OrphanedCopied)
+
+	legacy, err := reopened.GetSessionFull(context.Background(), "trae:rewrite")
+	require.NoError(t, err)
+	assert.Nil(t, legacy)
+
+	workspace, err := reopened.GetSessionFull(context.Background(), "trae:workspaceStorage:rewrite")
+	require.NoError(t, err)
+	require.NotNil(t, workspace)
+	global, err := reopened.GetSessionFull(context.Background(), "trae:globalStorage:rewrite")
+	require.NoError(t, err)
+	require.NotNil(t, global)
+
+	workspaceMessages, err := reopened.GetMessages(context.Background(), workspace.ID, 0, 10, true)
+	require.NoError(t, err)
+	globalMessages, err := reopened.GetMessages(context.Background(), global.ID, 0, 10, true)
+	require.NoError(t, err)
+	assert.Equal(t, "workspace reply", workspaceMessages[1].Content)
 	assert.Equal(t, "global reply", globalMessages[1].Content)
 }
 

--- a/internal/sync/trae_integration_test.go
+++ b/internal/sync/trae_integration_test.go
@@ -605,3 +605,111 @@ func TestFindSourceFileTraeRelocationUsesQualifiedRawID(t *testing.T) {
 	setTraeSyncDBSessions(t, oldDB, []any{traeSyncSession("other", "old moved")}, info.ModTime())
 	assert.Equal(t, newDB+"#rewrite", engine.FindSourceFile("trae:workspaceStorage:rewrite"))
 }
+
+func TestProcessFileProviderTraeDefaultSyncMigratesLegacyState(t *testing.T) {
+	root := t.TempDir()
+	workspacePath := filepath.Join(root, "workspaceStorage", "hash", "state.vscdb")
+	writeTraeSyncDB(t, workspacePath, "workspace reply")
+
+	database := dbtest.OpenTestDB(t)
+	const legacyID = "trae:rewrite"
+	legacyPath := workspacePath + "#rewrite"
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID:               legacyID,
+		Project:          "agentsview",
+		Machine:          "devbox",
+		Agent:            string(parser.AgentTrae),
+		SourceSessionID:  "rewrite",
+		MessageCount:     2,
+		UserMessageCount: 1,
+		FilePath:         &legacyPath,
+	}))
+	dbtest.SeedMessages(t, database,
+		dbtest.UserMsg(legacyID, 0, "same prompt"),
+		db.Message{
+			SessionID:     legacyID,
+			Ordinal:       1,
+			Role:          "assistant",
+			Content:       "legacy reply",
+			ContentLength: len("legacy reply"),
+		},
+	)
+	legacyName := "Legacy renamed session"
+	require.NoError(t, database.RenameSession(legacyID, &legacyName))
+	starred, err := database.StarSession(legacyID)
+	require.NoError(t, err)
+	require.True(t, starred)
+
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentTrae: {root}},
+		Machine:   "devbox",
+	})
+	processed := engine.processFile(context.Background(), parser.DiscoveredFile{
+		Path:  workspacePath,
+		Agent: parser.AgentTrae,
+	})
+	require.NoError(t, processed.err)
+	require.Len(t, processed.results, 1)
+
+	written, _, failed, _ := engine.writeBatch([]pendingWrite{{
+		sess:         processed.results[0].Session,
+		msgs:         processed.results[0].Messages,
+		forceReplace: processed.forceReplace,
+	}}, syncWriteDefault, false)
+	require.Equal(t, 1, written)
+	require.Equal(t, 0, failed)
+
+	ctx := context.Background()
+	legacy, err := database.GetSession(ctx, legacyID)
+	require.NoError(t, err)
+	assert.Nil(t, legacy)
+
+	const namespacedID = "trae:workspaceStorage:rewrite"
+	namespaced, err := database.GetSession(ctx, namespacedID)
+	require.NoError(t, err)
+	require.NotNil(t, namespaced)
+	require.NotNil(t, namespaced.DisplayName)
+	assert.Equal(t, legacyName, *namespaced.DisplayName)
+
+	starredIDs, err := database.ListStarredSessionIDs(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, []string{namespacedID}, starredIDs)
+}
+
+func TestProcessFileProviderTraeDefaultSyncPropagatesLegacyExclusion(t *testing.T) {
+	root := t.TempDir()
+	workspacePath := filepath.Join(root, "workspaceStorage", "hash", "state.vscdb")
+	writeTraeSyncDB(t, workspacePath, "workspace reply")
+
+	database := dbtest.OpenTestDB(t)
+	require.NoError(t, database.ExcludeSessionID("trae:rewrite"))
+
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentTrae: {root}},
+		Machine:   "devbox",
+	})
+	processed := engine.processFile(context.Background(), parser.DiscoveredFile{
+		Path:  workspacePath,
+		Agent: parser.AgentTrae,
+	})
+	require.NoError(t, processed.err)
+	require.Len(t, processed.results, 1)
+
+	written, _, failed, _ := engine.writeBatch([]pendingWrite{{
+		sess:         processed.results[0].Session,
+		msgs:         processed.results[0].Messages,
+		forceReplace: processed.forceReplace,
+	}}, syncWriteDefault, false)
+	require.Zero(t, written)
+	require.Zero(t, failed)
+
+	ctx := context.Background()
+	namespaced, err := database.GetSession(
+		ctx, "trae:workspaceStorage:rewrite",
+	)
+	require.NoError(t, err)
+	assert.Nil(t, namespaced)
+	assert.True(t,
+		database.IsSessionExcluded("trae:workspaceStorage:rewrite"),
+	)
+}


### PR DESCRIPTION
Trae session discovery currently maps workspace and global records with the same raw session ID to one database key, so a later upsert silently replaces the earlier transcript.

This qualifies Trae's internal session IDs as `trae:workspaceStorage:<id>` or `trae:globalStorage:<id>` before they enter the shared sync and database path. Qualified recovery keys now resolve back to the matching storage namespace and bare producer ID, so relocated workspace containers remain findable through the engine fallback. Shared bare-ID consumers, `session get`, `session usage`, and the deprecated `token-use`, keep the old convenience path when exactly one Trae namespace matches and now fail explicitly when workspace and global candidates collide, including host-qualified stored IDs. Raw source session IDs, virtual source paths, transcript parsing, freshness, and tombstone behavior retain their existing semantics; both physical records remain addressable when their raw IDs match. Unsupported container provenance returns an error instead of creating an ambiguous identity.

Trae support landed in #1180 after v0.38.1, so this corrects the identity representation before its first release without changing the database schema. The parser data version now advances so existing archives rebuild legacy `trae:<raw>` rows into namespaced identities and avoid reviving the superseded alias during orphan preservation. PostgreSQL push now also deletes owned legacy `trae:<raw>` rows as their namespaced replacements land, so remote archives converge instead of keeping stale duplicates beside the qualified sessions. The collision case came from @mjacobs' review of the provider.

Closes #1191
