### PR TITLE
fix(grok): ingest usage snapshots from updates.jsonl

### DIFF
--- a/internal/parser/grok.go
+++ b/internal/parser/grok.go
@@ -180,7 +180,11 @@ func ParseGrokSummary(
 	if err != nil {
 		return ParseResult{}, err
 	}
-	applyUsageEventTokenTotals(&result.Session, result.UsageEvents)
+	totalOutput, hasOutput, _, _ := UsageEventTokenAggregate(result.UsageEvents)
+	if hasOutput {
+		result.Session.TotalOutputTokens = totalOutput
+		result.Session.HasTotalOutputTokens = true
+	}
 	result.Session.aggregateTokenPresenceKnown =
 		result.Session.HasTotalOutputTokens ||
 			result.Session.HasPeakContextTokens
@@ -243,9 +247,19 @@ func grokUsageEvent(
 		OutputTokens:         int(usage.Get("outputTokens").Int()),
 		CacheReadInputTokens: cachedRead,
 		ReasoningTokens:      int(usage.Get("reasoningTokens").Int()),
+		CostUSD:              grokUsageCostUSD(usage),
 		OccurredAt:           occurredAt,
 		DedupKey:             "session:" + sessionID + ":" + model,
 	}
+}
+
+func grokUsageCostUSD(usage gjson.Result) *float64 {
+	ticks := usage.Get("costUsdTicks")
+	if !ticks.Exists() {
+		return nil
+	}
+	costUSD := float64(ticks.Int()) / 10_000_000_000
+	return &costUSD
 }
 
 func parseGrokChatHistory(path string) ([]ParsedMessage, int, error) {

--- a/internal/parser/grok.go
+++ b/internal/parser/grok.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -172,10 +173,79 @@ func ParseGrokSummary(
 		result.Session.PeakContextTokens = signals.PeakContextTokens
 		result.Session.HasPeakContextTokens = true
 	}
+	result.UsageEvents, err = parseGrokUsageEvents(
+		filepath.Join(sessionDir, "updates.jsonl"),
+		result.Session.ID, summary.ModelID, startedAt, endedAt,
+	)
+	if err != nil {
+		return ParseResult{}, err
+	}
+	applyUsageEventTokenTotals(&result.Session, result.UsageEvents)
 	result.Session.aggregateTokenPresenceKnown =
 		result.Session.HasTotalOutputTokens ||
 			result.Session.HasPeakContextTokens
 	return result, nil
+}
+
+func parseGrokUsageEvents(
+	path, sessionID, summaryModel string,
+	startedAt, endedAt time.Time,
+) ([]ParsedUsageEvent, error) {
+	var usage gjson.Result
+	_, err := readJSONLFrom(path, 0, func(line string) {
+		candidate := gjson.Get(line, "params.update.usage")
+		if candidate.Exists() && candidate.IsObject() {
+			usage = candidate
+		}
+	})
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	if !usage.Exists() {
+		return nil, nil
+	}
+
+	occurredAt := timeString(endedAt, startedAt)
+	modelUsage := usage.Get("modelUsage")
+	var events []ParsedUsageEvent
+	if modelUsage.IsObject() {
+		modelUsage.ForEach(func(model, modelData gjson.Result) bool {
+			events = append(events, grokUsageEvent(
+				sessionID, model.Str, modelData, occurredAt,
+			))
+			return true
+		})
+	}
+	if len(events) > 0 {
+		return events, nil
+	}
+	if summaryModel == "" {
+		summaryModel = "grok-summary"
+	}
+	return []ParsedUsageEvent{grokUsageEvent(
+		sessionID, summaryModel, usage, occurredAt,
+	)}, nil
+}
+
+func grokUsageEvent(
+	sessionID, model string, usage gjson.Result, occurredAt string,
+) ParsedUsageEvent {
+	input := int(usage.Get("inputTokens").Int())
+	cachedRead := int(usage.Get("cachedReadTokens").Int())
+	return ParsedUsageEvent{
+		SessionID:            sessionID,
+		Source:               "session",
+		Model:                model,
+		InputTokens:          max(input-cachedRead, 0),
+		OutputTokens:         int(usage.Get("outputTokens").Int()),
+		CacheReadInputTokens: cachedRead,
+		ReasoningTokens:      int(usage.Get("reasoningTokens").Int()),
+		OccurredAt:           occurredAt,
+		DedupKey:             "session:" + sessionID + ":" + model,
+	}
 }
 
 func parseGrokChatHistory(path string) ([]ParsedMessage, int, error) {

--- a/internal/parser/grok_provider.go
+++ b/internal/parser/grok_provider.go
@@ -65,7 +65,7 @@ func grokWatchRoots(roots []string) []WatchRoot {
 		out = append(out, WatchRoot{
 			Path:         root,
 			Recursive:    true,
-			IncludeGlobs: []string{"summary.json", "signals.json", "chat_history.jsonl"},
+			IncludeGlobs: []string{"summary.json", "signals.json", "chat_history.jsonl", "updates.jsonl"},
 			DebounceKey:  string(AgentGrok) + ":sessions:" + root,
 		})
 	}
@@ -140,7 +140,7 @@ func grokStrictMatch(root, path string) (singleFileMatch, bool) {
 
 func grokTrackedFileName(name string) bool {
 	switch name {
-	case "summary.json", "signals.json", "chat_history.jsonl":
+	case "summary.json", "signals.json", "chat_history.jsonl", "updates.jsonl":
 		return true
 	default:
 		return false
@@ -202,6 +202,7 @@ func grokCompanionFiles(summaryPath string) map[string]string {
 	return map[string]string{
 		"signals":      filepath.Join(dir, "signals.json"),
 		"chat_history": filepath.Join(dir, "chat_history.jsonl"),
+		"updates":      filepath.Join(dir, "updates.jsonl"),
 	}
 }
 
@@ -228,10 +229,11 @@ func grokProviderCapabilities() Capabilities {
 	return Capabilities{
 		Source: jsonlFileProviderSourceCapabilities(),
 		Content: ContentCapabilities{
-			FirstMessage:       CapabilitySupported,
-			SessionName:        CapabilitySupported,
-			TerminationStatus:  CapabilityNotApplicable,
-			MalformedLineCount: CapabilityNotApplicable,
+			FirstMessage:         CapabilitySupported,
+			SessionName:          CapabilitySupported,
+			TerminationStatus:    CapabilityNotApplicable,
+			MalformedLineCount:   CapabilityNotApplicable,
+			AggregateUsageEvents: CapabilitySupported,
 		},
 	}
 }

--- a/internal/parser/grok_test.go
+++ b/internal/parser/grok_test.go
@@ -355,6 +355,118 @@ func TestGrokProviderSummarySource(t *testing.T) {
 	assert.Equal(t, "Investigate the failing Grok session import", outcome.Results[0].Result.Messages[0].Content)
 }
 
+func parseGrokUsageFixture(t *testing.T, updates string) ParseResult {
+	t.Helper()
+	root := t.TempDir()
+	sessionDir := filepath.Join(root, "cwd-key", "sess-1")
+	writeGrokFixtureFile(t, filepath.Join(sessionDir, "summary.json"), `{
+		"summary":"Usage fixture",
+		"firstPrompt":"test usage",
+		"modelId":"grok-summary",
+		"createdAt":"2026-07-08T10:00:00Z",
+		"updatedAt":"2026-07-08T10:30:00Z"
+	}`)
+	writeGrokFixtureFile(t, filepath.Join(sessionDir, "updates.jsonl"), updates)
+	result, err := ParseGrokSummary(
+		filepath.Join(sessionDir, "summary.json"), "cwd-key", "local",
+	)
+	require.NoError(t, err)
+	return result
+}
+
+func parseGrokUsageFixtureWithSummary(
+	t *testing.T, summaryJSON, updates string,
+) ParseResult {
+	t.Helper()
+	root := t.TempDir()
+	sessionDir := filepath.Join(root, "cwd-key", "sess-1")
+	writeGrokFixtureFile(
+		t, filepath.Join(sessionDir, "summary.json"), summaryJSON,
+	)
+	writeGrokFixtureFile(t, filepath.Join(sessionDir, "updates.jsonl"), updates)
+	result, err := ParseGrokSummary(
+		filepath.Join(sessionDir, "summary.json"), "cwd-key", "local",
+	)
+	require.NoError(t, err)
+	return result
+}
+
+func TestGrokProviderLatestUsageSnapshot(t *testing.T) {
+	result := parseGrokUsageFixture(t, strings.Join([]string{
+		`{"params":{"update":{"usage":{"inputTokens":100,"outputTokens":20,"cachedReadTokens":10,"reasoningTokens":4}}}}`,
+		`{"params":{"update":{"usage":{"inputTokens":8,"outputTokens":3,"cachedReadTokens":13,"reasoningTokens":1}}}}`,
+		`not json`,
+	}, "\n"))
+
+	require.Len(t, result.UsageEvents, 1)
+	event := result.UsageEvents[0]
+	assert.Equal(t, 0, event.InputTokens)
+	assert.Equal(t, 13, event.CacheReadInputTokens)
+	assert.Equal(t, 3, event.OutputTokens)
+	assert.Equal(t, 1, event.ReasoningTokens)
+	assert.Equal(t, "grok-summary", event.Model)
+	assert.Equal(t, "session:grok:sess-1:grok-summary", event.DedupKey)
+}
+
+func TestGrokProviderUpdatesWithoutUsageEmitNoEvents(t *testing.T) {
+	result := parseGrokUsageFixture(t, strings.Join([]string{
+		`{"type":"unrelated"}`,
+		`not json`,
+	}, "\n"))
+
+	assert.Empty(t, result.UsageEvents)
+	assert.Equal(t, "Usage fixture", result.Session.SessionName)
+}
+
+func TestGrokProviderRetainsUsageAcrossUnrelatedJSON(t *testing.T) {
+	result := parseGrokUsageFixture(t, strings.Join([]string{
+		`{"params":{"update":{"usage":{"inputTokens":100,"outputTokens":20,"cachedReadTokens":10,"reasoningTokens":4}}}}`,
+		`{"type":"unrelated","payload":{"ok":true}}`,
+	}, "\n"))
+
+	require.Len(t, result.UsageEvents, 1)
+	event := result.UsageEvents[0]
+	assert.Equal(t, 90, event.InputTokens)
+	assert.Equal(t, 10, event.CacheReadInputTokens)
+	assert.Equal(t, 20, event.OutputTokens)
+	assert.Equal(t, 4, event.ReasoningTokens)
+	assert.Equal(t, "grok-summary", event.Model)
+}
+
+func TestGrokProviderUpdatesUsageByModel(t *testing.T) {
+	result := parseGrokUsageFixture(t, `{"params":{"update":{"usage":{"inputTokens":999,"outputTokens":999,"modelUsage":{"grok-a":{"inputTokens":10,"outputTokens":2},"grok-b":{"inputTokens":20,"outputTokens":3}}}}}}`)
+
+	require.Len(t, result.UsageEvents, 2)
+	models := map[string]ParsedUsageEvent{}
+	for _, event := range result.UsageEvents {
+		models[event.Model] = event
+	}
+	assert.Equal(t, 2, models["grok-a"].OutputTokens)
+	assert.Equal(t, 3, models["grok-b"].OutputTokens)
+	assert.NotContains(t, models, "grok-summary")
+}
+
+func TestGrokProviderUpdatesUsageTopLevelFallback(t *testing.T) {
+	result := parseGrokUsageFixture(t, `{"params":{"update":{"usage":{"inputTokens":12,"outputTokens":4,"modelUsage":{}}}}}`)
+
+	require.Len(t, result.UsageEvents, 1)
+	assert.Equal(t, "grok-summary", result.UsageEvents[0].Model)
+	assert.Equal(t, 12, result.UsageEvents[0].InputTokens)
+}
+
+func TestGrokProviderUpdatesUsageTopLevelFallbackWithoutSummaryModel(t *testing.T) {
+	result := parseGrokUsageFixtureWithSummary(t, `{
+		"summary":"Usage fixture",
+		"firstPrompt":"test usage",
+		"createdAt":"2026-07-08T10:00:00Z",
+		"updatedAt":"2026-07-08T10:30:00Z"
+	}`, `{"params":{"update":{"usage":{"inputTokens":12,"outputTokens":4,"modelUsage":{}}}}}`)
+
+	require.Len(t, result.UsageEvents, 1)
+	assert.Equal(t, "grok-summary", result.UsageEvents[0].Model)
+	assert.Equal(t, 12, result.UsageEvents[0].InputTokens)
+}
+
 func TestGrokProviderCurrentBuildSummarySchema(t *testing.T) {
 	root := t.TempDir()
 	cwdKey := "%2FUsers%2Fdev%2Frepos%2Fwp-devops"
@@ -668,7 +780,7 @@ func TestGrokProviderFingerprintTracksParsedFiles(t *testing.T) {
 	writeGrokFixtureFile(t, updates, "{\"delta\":1}\n")
 	afterUpdates, err := provider.Fingerprint(context.Background(), source)
 	require.NoError(t, err)
-	assert.Equal(t, afterChat.Hash, afterUpdates.Hash)
+	assert.NotEqual(t, afterChat.Hash, afterUpdates.Hash)
 
 	writeGrokFixtureFile(t, unrelated, "still ignored")
 	afterUnrelated, err := provider.Fingerprint(context.Background(), source)
@@ -695,7 +807,21 @@ func TestGrokProviderChangedPathTracksParsedFiles(t *testing.T) {
 		Path: filepath.Join(root, "cwd-key", "sess-1", "updates.jsonl"),
 	})
 	require.NoError(t, err)
-	assert.Empty(t, changed)
+	require.Len(t, changed, 1)
+	assert.Equal(t, filepath.Clean(summary), filepath.Clean(changed[0].FingerprintKey))
+}
+
+func TestGrokProviderWatchPlanIncludesUpdates(t *testing.T) {
+	root := t.TempDir()
+	provider := newGrokTestProvider(t, root)
+
+	plan, err := provider.WatchPlan(context.Background())
+	require.NoError(t, err)
+	require.Len(t, plan.Roots, 1)
+	assert.ElementsMatch(t,
+		[]string{"summary.json", "signals.json", "chat_history.jsonl", "updates.jsonl"},
+		plan.Roots[0].IncludeGlobs,
+	)
 }
 
 func TestGrokProviderArtifactBoundaries(t *testing.T) {
@@ -750,4 +876,6 @@ func TestGrokProviderRegistry(t *testing.T) {
 	mode, ok := ProviderMigrationModes()[AgentGrok]
 	require.True(t, ok)
 	assert.Equal(t, ProviderMigrationProviderAuthoritative, mode)
+	assert.Equal(t, CapabilitySupported,
+		factory.Capabilities().Content.AggregateUsageEvents)
 }

--- a/internal/parser/grok_test.go
+++ b/internal/parser/grok_test.go
@@ -355,6 +355,33 @@ func TestGrokProviderSummarySource(t *testing.T) {
 	assert.Equal(t, "Investigate the failing Grok session import", outcome.Results[0].Result.Messages[0].Content)
 }
 
+func TestGrokProviderPreservesSignalPeakOverCumulativeUsageInput(t *testing.T) {
+	root := t.TempDir()
+	sessionDir := filepath.Join(root, "cwd-key", "sess-1")
+	writeGrokFixtureFile(t, filepath.Join(sessionDir, "summary.json"), `{
+		"summary":"Usage fixture",
+		"firstPrompt":"test usage",
+		"modelId":"grok-summary",
+		"createdAt":"2026-07-08T10:00:00Z",
+		"updatedAt":"2026-07-08T10:30:00Z"
+	}`)
+	writeGrokFixtureFile(t, filepath.Join(sessionDir, "signals.json"), `{
+		"tokenUsage": {
+			"peakContextTokens": 4096
+		}
+	}`)
+	writeGrokFixtureFile(t, filepath.Join(sessionDir, "updates.jsonl"), `{"params":{"update":{"usage":{"inputTokens":8192,"outputTokens":7,"cachedReadTokens":96}}}}`)
+
+	result, err := ParseGrokSummary(
+		filepath.Join(sessionDir, "summary.json"), "cwd-key", "local",
+	)
+	require.NoError(t, err)
+	assert.True(t, result.Session.HasPeakContextTokens)
+	assert.Equal(t, 4096, result.Session.PeakContextTokens)
+	assert.True(t, result.Session.HasTotalOutputTokens)
+	assert.Equal(t, 7, result.Session.TotalOutputTokens)
+}
+
 func parseGrokUsageFixture(t *testing.T, updates string) ParseResult {
 	t.Helper()
 	root := t.TempDir()
@@ -434,7 +461,7 @@ func TestGrokProviderRetainsUsageAcrossUnrelatedJSON(t *testing.T) {
 }
 
 func TestGrokProviderUpdatesUsageByModel(t *testing.T) {
-	result := parseGrokUsageFixture(t, `{"params":{"update":{"usage":{"inputTokens":999,"outputTokens":999,"modelUsage":{"grok-a":{"inputTokens":10,"outputTokens":2},"grok-b":{"inputTokens":20,"outputTokens":3}}}}}}`)
+	result := parseGrokUsageFixture(t, `{"params":{"update":{"usage":{"inputTokens":999,"outputTokens":999,"costUsdTicks":9999999999,"modelUsage":{"grok-a":{"inputTokens":10,"outputTokens":2,"costUsdTicks":10000000000},"grok-b":{"inputTokens":20,"outputTokens":3,"costUsdTicks":2500000000}}}}}}`)
 
 	require.Len(t, result.UsageEvents, 2)
 	models := map[string]ParsedUsageEvent{}
@@ -443,15 +470,21 @@ func TestGrokProviderUpdatesUsageByModel(t *testing.T) {
 	}
 	assert.Equal(t, 2, models["grok-a"].OutputTokens)
 	assert.Equal(t, 3, models["grok-b"].OutputTokens)
+	require.NotNil(t, models["grok-a"].CostUSD)
+	require.NotNil(t, models["grok-b"].CostUSD)
+	assert.InDelta(t, 1.0, *models["grok-a"].CostUSD, 1e-12)
+	assert.InDelta(t, 0.25, *models["grok-b"].CostUSD, 1e-12)
 	assert.NotContains(t, models, "grok-summary")
 }
 
 func TestGrokProviderUpdatesUsageTopLevelFallback(t *testing.T) {
-	result := parseGrokUsageFixture(t, `{"params":{"update":{"usage":{"inputTokens":12,"outputTokens":4,"modelUsage":{}}}}}`)
+	result := parseGrokUsageFixture(t, `{"params":{"update":{"usage":{"inputTokens":12,"outputTokens":4,"costUsdTicks":424128000,"modelUsage":{}}}}}`)
 
 	require.Len(t, result.UsageEvents, 1)
 	assert.Equal(t, "grok-summary", result.UsageEvents[0].Model)
 	assert.Equal(t, 12, result.UsageEvents[0].InputTokens)
+	require.NotNil(t, result.UsageEvents[0].CostUSD)
+	assert.InDelta(t, 0.0424128, *result.UsageEvents[0].CostUSD, 1e-12)
 }
 
 func TestGrokProviderUpdatesUsageTopLevelFallbackWithoutSummaryModel(t *testing.T) {
@@ -465,6 +498,15 @@ func TestGrokProviderUpdatesUsageTopLevelFallbackWithoutSummaryModel(t *testing.
 	require.Len(t, result.UsageEvents, 1)
 	assert.Equal(t, "grok-summary", result.UsageEvents[0].Model)
 	assert.Equal(t, 12, result.UsageEvents[0].InputTokens)
+	assert.Nil(t, result.UsageEvents[0].CostUSD)
+}
+
+func TestGrokProviderUpdatesUsageReportedZeroCost(t *testing.T) {
+	result := parseGrokUsageFixture(t, `{"params":{"update":{"usage":{"inputTokens":12,"outputTokens":4,"costUsdTicks":0,"modelUsage":{}}}}}`)
+
+	require.Len(t, result.UsageEvents, 1)
+	require.NotNil(t, result.UsageEvents[0].CostUSD)
+	assert.Equal(t, 0.0, *result.UsageEvents[0].CostUSD)
 }
 
 func TestGrokProviderCurrentBuildSummarySchema(t *testing.T) {

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -315,6 +315,13 @@ func TestGrokSummaryCountsSurviveSync(t *testing.T) {
 		"worktreeLabel":"agentsview"
 	}`), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(
+		root, "cwd-key", "sess-1", "signals.json",
+	), []byte(`{
+		"tokenUsage": {
+			"peakContextTokens": 4096
+		}
+	}`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(
 		root, "cwd-key", "sess-1", "updates.jsonl",
 	), []byte(`{"params":{"update":{"usage":{"inputTokens":131966,"outputTokens":326,"totalTokens":132292,"cachedReadTokens":131456,"reasoningTokens":122,"modelCalls":1,"apiDurationMs":7493,"costUsdTicks":424128000,"modelUsage":{"grok-4.5-build":{"inputTokens":131966,"outputTokens":326,"totalTokens":132292,"cachedReadTokens":131456,"reasoningTokens":122,"modelCalls":1,"apiDurationMs":7493,"costUsdTicks":424128000}},"numTurns":1}}}}`+"\n"), 0o644))
 
@@ -334,6 +341,8 @@ func TestGrokSummaryCountsSurviveSync(t *testing.T) {
 	require.NotNil(t, sess)
 	assert.Equal(t, 6, sess.MessageCount)
 	assert.Equal(t, 1, sess.UserMessageCount)
+	assert.True(t, sess.HasPeakContextTokens)
+	assert.Equal(t, 4096, sess.PeakContextTokens)
 
 	promptSearch, err := database.Search(context.Background(), db.SearchFilter{
 		Query: "resume the build",
@@ -358,6 +367,7 @@ func TestGrokSummaryCountsSurviveSync(t *testing.T) {
 	assert.Equal(t, 510, daily.Totals.InputTokens)
 	assert.Equal(t, 131456, daily.Totals.CacheReadTokens)
 	assert.Equal(t, 326, daily.Totals.OutputTokens)
+	assert.InDelta(t, 0.0424128, daily.Totals.TotalCost, 1e-9)
 
 	usage, err := database.GetSessionUsage(
 		context.Background(), "grok:sess-1", true,
@@ -365,10 +375,14 @@ func TestGrokSummaryCountsSurviveSync(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, usage)
 	assert.Contains(t, usage.Models, "grok-4.5-build")
+	assert.True(t, usage.HasCost)
+	assert.InDelta(t, 0.0424128, usage.CostUSD, 1e-9)
 	require.Len(t, usage.Breakdown, 1)
 	assert.Equal(t, 510, usage.Breakdown[0].InputTokens)
 	assert.Equal(t, 131456, usage.Breakdown[0].CacheReadInputTokens)
 	assert.Equal(t, 326, usage.Breakdown[0].OutputTokens)
+	assert.True(t, usage.Breakdown[0].HasCost)
+	assert.InDelta(t, 0.0424128, usage.Breakdown[0].CostUSD, 1e-9)
 
 	events, err := database.GetUsageEvents(
 		context.Background(), "grok:sess-1",
@@ -376,6 +390,8 @@ func TestGrokSummaryCountsSurviveSync(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, events, 1)
 	assert.Equal(t, 122, events[0].ReasoningTokens)
+	require.NotNil(t, events[0].CostUSD)
+	assert.InDelta(t, 0.0424128, *events[0].CostUSD, 1e-9)
 
 	exported, err := database.ExportSessionSummaries(
 		context.Background(),

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -314,6 +314,9 @@ func TestGrokSummaryCountsSurviveSync(t *testing.T) {
 		"numMessages":6,
 		"worktreeLabel":"agentsview"
 	}`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(
+		root, "cwd-key", "sess-1", "updates.jsonl",
+	), []byte(`{"params":{"update":{"usage":{"inputTokens":131966,"outputTokens":326,"totalTokens":132292,"cachedReadTokens":131456,"reasoningTokens":122,"modelCalls":1,"apiDurationMs":7493,"costUsdTicks":424128000,"modelUsage":{"grok-4.5-build":{"inputTokens":131966,"outputTokens":326,"totalTokens":132292,"cachedReadTokens":131456,"reasoningTokens":122,"modelCalls":1,"apiDurationMs":7493,"costUsdTicks":424128000}},"numTurns":1}}}}`+"\n"), 0o644))
 
 	database := dbtest.OpenTestDB(t)
 	engine := sync.NewEngine(database, sync.EngineConfig{
@@ -347,6 +350,51 @@ func TestGrokSummaryCountsSurviveSync(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, nameSearch.Results, 1)
 	assert.Equal(t, "grok:sess-1", nameSearch.Results[0].SessionID)
+
+	daily, err := database.GetDailyUsage(context.Background(), db.UsageFilter{
+		From: "2026-07-08", To: "2026-07-08", Agent: "grok",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 510, daily.Totals.InputTokens)
+	assert.Equal(t, 131456, daily.Totals.CacheReadTokens)
+	assert.Equal(t, 326, daily.Totals.OutputTokens)
+
+	usage, err := database.GetSessionUsage(
+		context.Background(), "grok:sess-1", true,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+	assert.Contains(t, usage.Models, "grok-4.5-build")
+	require.Len(t, usage.Breakdown, 1)
+	assert.Equal(t, 510, usage.Breakdown[0].InputTokens)
+	assert.Equal(t, 131456, usage.Breakdown[0].CacheReadInputTokens)
+	assert.Equal(t, 326, usage.Breakdown[0].OutputTokens)
+
+	events, err := database.GetUsageEvents(
+		context.Background(), "grok:sess-1",
+	)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.Equal(t, 122, events[0].ReasoningTokens)
+
+	exported, err := database.ExportSessionSummaries(
+		context.Background(),
+		db.SessionExportOptions{
+			Filter: db.SessionFilter{Agent: "grok"},
+			Limit:  10,
+			Format: "json",
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, exported.Rows, 1)
+	require.NotNil(t, exported.Rows[0].ModelUsage)
+	assert.Equal(t, 122, exported.Rows[0].ModelUsage.ReasoningTokens)
+	require.Contains(t,
+		exported.Rows[0].ModelUsage.ByModel, "grok-4.5-build",
+	)
+	assert.Equal(t, 122,
+		exported.Rows[0].ModelUsage.ByModel["grok-4.5-build"].ReasoningTokens,
+	)
 }
 
 type openCodeFamilySQLiteCase struct {


### PR DESCRIPTION
Grok's provider reads session metadata, signals, and chat history while leaving the cumulative usage ledger in `updates.jsonl` outside freshness tracking and parsing, so daily and session usage remain empty.

This adds `updates.jsonl` to Grok companion freshness and converts the latest valid ledger snapshot into the existing usage-event model. Per-model rows remain the accounting authority when present, cache reads are separated from the producer's full input count, later smaller snapshots replace earlier values instead of being summed, and `signals.json` keeps ownership of peak-context reporting. Summary, signal, and transcript behavior stay unchanged when no usable snapshot exists; existing model pricing still applies when Grok does not report a cost.

The parser keeps the last valid `params.update.usage` object, emits one event per `modelUsage` entry or one summary-model event when the map is empty, maps each selected object's `costUsdTicks` onto `CostUSD`, and leaves `CostUSD` nil when the field is absent so catalog pricing remains the fallback. The sync integration now records input `510`, cache-read `131456`, output `326`, reasoning `122`, cost `0.0424128`, peak context `4096`, and model `grok-4.5-build` for the issue-shaped payload.

Watch-plan coverage pins `updates.jsonl` alongside the existing summary, signal, and transcript globs. Parser tests also cover a malformed trailing line retaining the latest snapshot and an updates file with no usable usage object producing no events.

Closes #1193
