### PR TITLE
fix(frontend): back the open session with a detail cache instead of a row injected into the filtered sidebar

### DIFF
--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -551,18 +551,7 @@ class SessionsStore {
       );
       this.nextCursor = index.next_cursor ?? null;
       this.total = index.total;
-      // An included active row may have absorbed index refreshes (renames,
-      // counts) that the detail cache never saw; resync it so a later reload
-      // that excludes the row doesn't revert the breadcrumb to stale fields.
-      // Skip when a navigation/refresh/rename committed for the now-active
-      // session while this index was in flight — the cache is then fresher
-      // than the merged row.
-      if (
-        this.activeSessionId !== null &&
-        this.detailGenerationUnchanged(detailGenerations, this.activeSessionId)
-      ) {
-        this.cacheActiveSessionDetailFromList(this.activeSessionId);
-      }
+      this.syncActiveSessionAfterIndexCommit(detailGenerations);
     } catch {
       // Restore previous state so a transient failure
       // doesn't wipe the visible session list.
@@ -750,14 +739,7 @@ class SessionsStore {
       ];
       this.nextCursor = index.next_cursor ?? null;
       this.total = index.total;
-      // A re-listed active row can carry index refreshes the detail cache
-      // never saw; resync it (same reasoning as loadSidebarPage).
-      if (
-        this.activeSessionId !== null &&
-        this.detailGenerationUnchanged(detailGenerations, this.activeSessionId)
-      ) {
-        this.cacheActiveSessionDetailFromList(this.activeSessionId);
-      }
+      this.syncActiveSessionAfterIndexCommit(detailGenerations);
     } catch (error) {
       if (signal.aborted || isAbortError(error)) return;
       throw error;
@@ -934,6 +916,42 @@ class SessionsStore {
     if (cached?.id === id) {
       this.activeSessionDetail = mergeIndexFieldsIntoDetail(row, cached);
     }
+  }
+
+  // After an index commit, reconcile the active session's sidebar row and
+  // detail cache in whichever direction is fresher. When no active-detail
+  // read/rename committed for the now-active session while the index was in
+  // flight, the merged row may have absorbed index refreshes (renames,
+  // counts) the cache never saw — resync the cache from it so a later reload
+  // that excludes the row doesn't revert the breadcrumb to stale fields.
+  // When one did commit, the cache is fresher than the merged row: push it
+  // back into the row so the sidebar and the breadcrumb display the
+  // committed state instead of the older index snapshot.
+  private syncActiveSessionAfterIndexCommit(
+    snapshot: ReadonlyMap<string, number>,
+  ) {
+    const id = this.activeSessionId;
+    if (id === null) return;
+    if (this.detailGenerationUnchanged(snapshot, id)) {
+      this.cacheActiveSessionDetailFromList(id);
+    } else {
+      this.restoreActiveRowFromDetailCache(id);
+    }
+  }
+
+  // Inverse of cacheActiveSessionDetailFromList: the cached detail is a full
+  // post-commit snapshot (it is never index-only), so replace the re-listed
+  // row wholesale rather than merging the stale index's fields over it. If
+  // the cache is empty (e.g. a navigation is still in flight), leave the row
+  // alone — the pending read commits through mergeHydratedSession when it
+  // resolves.
+  private restoreActiveRowFromDetailCache(id: string) {
+    if (id !== this.activeSessionId) return;
+    const cached = this.activeSessionDetail;
+    if (cached?.id !== id) return;
+    const idx = this.sessions.findIndex((s) => s.id === id);
+    if (idx < 0) return;
+    this.sessions[idx] = { ...cached };
   }
 
   private navigateInFlight: { id: string; promise: Promise<void> } | null =

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -393,6 +393,12 @@ class SessionsStore {
       // stale page (see loadSidebarPage).
       removedRow: boolean;
       removedRootAtDeletion: boolean;
+      // Provenance of the removed row: the query signature it was loaded
+      // under (off-page total subtraction applies only within the same
+      // query) and its parent link (clearSubtreeTombstones needs it for
+      // rows whose snapshots are gone).
+      removedUnderSignature?: string;
+      parentSessionId?: string;
     }
   >();
   // Generations are globally unique (not per-id counters) so pruning an
@@ -439,7 +445,7 @@ class SessionsStore {
   // makes request-issue order the single freshness rule in both directions.
   private indexCommitByRow = new Map<
     string,
-    { ordinal: number; row: Session }
+    { ordinal: number; row: Session; querySignature: string }
   >();
   // True while activeSessionDetail is a fabricated rename snapshot (the
   // rename endpoint returns the DB-session shape without detail-only
@@ -601,6 +607,7 @@ class SessionsStore {
     const version = ++this.loadVersion;
     const indexVersion = this.sidebarIndexVersion + 1;
     const requestOrdinal = ++this.requestClock;
+    const querySignature = JSON.stringify(params);
     this.inFlightRequestTicks.add(requestOrdinal);
     const detailCommits = this.snapshotDetailCommits();
     // Keep the existing list visible during reloads, but mark
@@ -666,6 +673,7 @@ class SessionsStore {
           if (
             commit.deleted &&
             commit.removedRootAtDeletion &&
+            commit.removedUnderSignature === querySignature &&
             commit.generation !== (detailCommits.get(cid) ?? 0) &&
             commit.issuedAtIndexOrdinal >= requestOrdinal &&
             !incomingIds.has(cid)
@@ -684,6 +692,7 @@ class SessionsStore {
         this.indexCommitByRow.set(session.id, {
           ordinal: requestOrdinal,
           row: session,
+          querySignature,
         });
       }
       // A COMPLETE publish (no further pages) that excludes the id is
@@ -827,10 +836,19 @@ class SessionsStore {
           // when a reload has excluded the row this is the only update the
           // off-list session will get (the version check below discards the
           // row merge, and no hydration retries an absent row).
+          // An epoch invalidation (messages event) marks this response
+          // stale in place: it must not seed the cache either. The check
+          // only means something while this hydration's version is still
+          // current — after a version change the old epoch entry is pruned
+          // and the reload's own freshness machinery governs instead.
+          const epochValid =
+            version !== this.sidebarIndexVersion ||
+            epoch === (this.sidebarHydrationEpochByVersion.get(version) ?? 0);
           if (
             hydrated.id === this.activeSessionId &&
             !hydrated.is_index_only &&
-            detailFresh
+            detailFresh &&
+            epochValid
           ) {
             this.activeSessionDetail = hydrated;
             this.bumpDetailCommit(id, false, issuedAtIndexOrdinal, hydrated);
@@ -930,6 +948,10 @@ class SessionsStore {
     if (!this.nextCursor || this.loading) return;
     const version = ++this.loadVersion;
     const requestOrdinal = ++this.requestClock;
+    const querySignature = JSON.stringify({
+      ...this.apiParams,
+      limit: SESSION_PAGE_SIZE,
+    });
     this.inFlightRequestTicks.add(requestOrdinal);
     const detailCommits = this.snapshotDetailCommits();
     // Rows already loaded when this request began had any mid-flight
@@ -1001,6 +1023,7 @@ class SessionsStore {
         this.indexCommitByRow.set(session.id, {
           ordinal: requestOrdinal,
           row: session,
+          querySignature,
         });
       }
       this.syncActiveSessionAfterIndexCommit(detailCommits, requestOrdinal);
@@ -1140,6 +1163,12 @@ class SessionsStore {
       removedRootAtDeletion: deleted && previous?.deleted === true
         ? previous.removedRootAtDeletion
         : false,
+      removedUnderSignature: deleted && previous?.deleted === true
+        ? previous.removedUnderSignature
+        : undefined,
+      parentSessionId: deleted && previous?.deleted === true
+        ? previous.parentSessionId
+        : undefined,
     });
     if (deleted) {
       this.committedDetailByRow.delete(id);
@@ -1334,6 +1363,15 @@ class SessionsStore {
         commit.removedRow = true;
         commit.removedRootAtDeletion =
           !row.parent_session_id || !presentIds.has(row.parent_session_id);
+        commit.removedUnderSignature =
+          this.indexCommitByRow.get(row.id)?.querySignature;
+      }
+    }
+    for (const known of knownRows) {
+      if (!subtree.has(known.id)) continue;
+      const commit = this.activeDetailCommitBySession.get(known.id);
+      if (commit?.deleted && known.parent_session_id) {
+        commit.parentSessionId = known.parent_session_id;
       }
     }
     return subtree;
@@ -1377,6 +1415,7 @@ class SessionsStore {
       for (const [cid, commit] of this.activeDetailCommitBySession) {
         if (!commit.deleted || cleared.has(cid)) continue;
         const parent =
+          commit.parentSessionId ??
           this.indexCommitByRow.get(cid)?.row.parent_session_id ??
           this.committedDetailByRow.get(cid)?.parent_session_id;
         if (parent && cleared.has(parent)) {
@@ -2098,6 +2137,15 @@ class SessionsStore {
         commit.removedRow = true;
         commit.removedRootAtDeletion =
           !row.parent_session_id || !presentIds.has(row.parent_session_id);
+        commit.removedUnderSignature =
+          this.indexCommitByRow.get(row.id)?.querySignature;
+      }
+    }
+    for (const known of knownRows) {
+      if (!subtree.has(known.id)) continue;
+      const commit = this.activeDetailCommitBySession.get(known.id);
+      if (commit?.deleted && known.parent_session_id) {
+        commit.parentSessionId = known.parent_session_id;
       }
     }
     if (this.activeSessionId && subtree.has(this.activeSessionId)) {

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -1500,13 +1500,18 @@ class SessionsStore {
     // the name with a pre-rename snapshot. Cancel and advance the generation
     // even when the detail cache is empty (index-only row with hydration in
     // flight) — the cache-population paths all check the generation.
+    // The rename response is itself a full post-rename snapshot (the endpoint
+    // reads the session back), so commit it as the active detail: an
+    // index-only or out-of-list active session whose pending read was just
+    // cancelled has nothing else to back the breadcrumb until the next
+    // watcher refresh.
     if (this.activeSessionId === id) {
       this.cancelActiveDetailRead();
-    }
-    // The active session may be backed only by the detail cache (absent from
-    // the sidebar list); keep its name in sync so the breadcrumb updates too.
-    if (this.activeSessionDetail?.id === id) {
-      this.activeSessionDetail = applyRename(this.activeSessionDetail);
+      const base =
+        this.activeSessionDetail?.id === id
+          ? this.activeSessionDetail
+          : { ...updated, is_index_only: false };
+      this.activeSessionDetail = applyRename(base);
     }
   }
 

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -363,10 +363,12 @@ class SessionsStore {
   // rename or hydration committing its snapshot, a 404 committing a
   // deletion. A read that merely BEGAN proves nothing — it may fail, and if
   // it commits it commits later and wins — so it never invalidates anything.
-  // Generations are per session id (activity on one session says nothing
-  // about another's in-flight hydration, which a later selection may join),
-  // monotonic, and never removed: resetting one could make a stale capture
-  // compare equal again.
+  // Generations are drawn from one global counter (see
+  // detailCommitGenerationCounter) so entries pruned by
+  // pruneReconciliationState can never be recreated with a generation an
+  // in-flight snapshot already captured; per-session maps keep activity on
+  // one session from invalidating another's in-flight hydration, which a
+  // later selection may join.
   private activeDetailRead = new LatestRead();
   // Each commit records the sidebar index-request ordinal current when its
   // underlying request was issued (Infinity for write-derived rename/404
@@ -624,7 +626,7 @@ class SessionsStore {
       // descendants, whose groups the backend removes with them — instead
       // of reinserting them.
       const tombstoned = this.expandTombstoned(index.sessions, (rid) =>
-        this.deletedSinceSnapshot(rid, detailCommits)
+        this.deletedSinceSnapshot(rid, detailCommits, requestOrdinal)
       );
       const dropped = index.sessions.filter((row) => tombstoned.has(row.id));
       const rows = index.sessions.filter((row) => !tombstoned.has(row.id));
@@ -664,7 +666,7 @@ class SessionsStore {
       if (this.loadVersion === version) {
         const restoredTombstones = this.expandTombstoned(
           prev.sessions,
-          (rid) => this.deletedSinceSnapshot(rid, detailCommits),
+          (rid) => this.deletedSinceSnapshot(rid, detailCommits, requestOrdinal),
         );
         const droppedRows = prev.sessions.filter((s) =>
           restoredTombstones.has(s.id)
@@ -886,7 +888,7 @@ class SessionsStore {
       // Same deletion-tombstone guard as loadSidebarPage for appended
       // pages, including descendants of tombstoned rows.
       const tombstoned = this.expandTombstoned(index.sessions, (rid) =>
-        this.deletedSinceSnapshot(rid, detailCommits)
+        this.deletedSinceSnapshot(rid, detailCommits, requestOrdinal)
       );
       const dropped = index.sessions.filter((row) => tombstoned.has(row.id));
       const rows = index.sessions.filter((row) => !tombstoned.has(row.id));
@@ -1109,12 +1111,17 @@ class SessionsStore {
   private deletedSinceSnapshot(
     id: string,
     snapshot: ReadonlyMap<string, number>,
+    requestOrdinal: number,
   ): boolean {
     const commit = this.activeDetailCommitBySession.get(id);
     return (
       commit !== undefined &&
       commit.deleted &&
-      commit.generation !== (snapshot.get(id) ?? 0)
+      commit.generation !== (snapshot.get(id) ?? 0) &&
+      // A read-derived tombstone (finite tick) only outranks requests
+      // issued before it; a response from a later-issued request reflects
+      // newer server state and supersedes the transient 404.
+      commit.issuedAtIndexOrdinal >= requestOrdinal
     );
   }
 
@@ -1186,7 +1193,10 @@ class SessionsStore {
   // each so stale responses cannot reinsert them, and decrement the root
   // total once per removed group. The caller records the ancestor's own
   // deletion commit.
-  private removeSessionSubtree(id: string): ReadonlySet<string> {
+  private removeSessionSubtree(
+    id: string,
+    tombstoneTick: number = Number.POSITIVE_INFINITY,
+  ): ReadonlySet<string> {
     // A cache-only active session (deep link, search) has no sidebar row
     // but may descend from the deleted ancestor; include it so callers
     // clear the selection instead of leaving a ghost.
@@ -1203,7 +1213,7 @@ class SessionsStore {
     subtree.add(id);
     for (const rid of subtree) {
       if (rid !== id) {
-        this.bumpDetailCommit(rid, true, Number.POSITIVE_INFINITY);
+        this.bumpDetailCommit(rid, true, tombstoneTick);
       }
     }
     const droppedRows = this.sessions.filter((s) => subtree.has(s.id));
@@ -1303,7 +1313,7 @@ class SessionsStore {
     if (
       commit === undefined ||
       commit.generation === (snapshot.get(id) ?? 0) ||
-      (!commit.deleted && commit.issuedAtIndexOrdinal < requestOrdinal)
+      commit.issuedAtIndexOrdinal < requestOrdinal
     ) {
       // Nothing committed mid-flight, or the commit's request predates this
       // index request — the index's server snapshot is at least as fresh, so
@@ -1507,12 +1517,16 @@ class SessionsStore {
         this.activeSessionId === id &&
         this.activeDetailRead.isCurrent(signal)
       ) {
-        this.bumpDetailCommit(id, true, Number.POSITIVE_INFINITY);
+        // Read-derived tombstone: recorded at this refresh's own issue
+        // tick so later-issued successful responses can supersede it.
+        // Infinity is reserved for confirmed mutations (explicit deletes,
+        // renames).
+        this.bumpDetailCommit(id, true, issuedAtIndexOrdinal);
         this.activeSessionDetail = null;
         // A hydrated matching row would keep backing activeSession as a
         // ghost of the deleted session; drop it and keep the pagination
         // total consistent, mirroring deleteSession.
-        this.removeSessionSubtree(id);
+        this.removeSessionSubtree(id, issuedAtIndexOrdinal);
       }
     } finally {
       this.inFlightRequestTicks.delete(issuedAtIndexOrdinal);

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -1401,9 +1401,8 @@ class SessionsStore {
       id,
       requestBody: { display_name: displayName },
     }) as unknown as Session;
-    const idx = this.sessions.findIndex((s) => s.id === id);
-    if (idx !== -1) {
-      const merged = { ...this.sessions[idx]!, ...updated };
+    const applyRename = (target: Session): Session => {
+      const merged = { ...target, ...updated };
       // When the caller cleared the rename and the backend found no agent name
       // to restore, display_name is absent from the response (omitempty on nil).
       // Explicitly null it out so the store reflects the cleared state rather
@@ -1411,7 +1410,16 @@ class SessionsStore {
       if (displayName === null && updated.display_name === undefined) {
         merged.display_name = null;
       }
-      this.sessions[idx] = merged;
+      return merged;
+    };
+    const idx = this.sessions.findIndex((s) => s.id === id);
+    if (idx !== -1) {
+      this.sessions[idx] = applyRename(this.sessions[idx]!);
+    }
+    // The active session may be backed only by the detail cache (absent from
+    // the sidebar list); keep its name in sync so the breadcrumb updates too.
+    if (this.activeSessionDetail?.id === id) {
+      this.activeSessionDetail = applyRename(this.activeSessionDetail);
     }
   }
 

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -377,8 +377,24 @@ class SessionsStore {
   // server snapshot.
   private activeDetailCommitBySession = new Map<
     string,
-    { generation: number; deleted: boolean; issuedAtIndexOrdinal: number }
+    {
+      generation: number;
+      deleted: boolean;
+      issuedAtIndexOrdinal: number;
+      committedAtTick: number;
+    }
   >();
+  // Generations are globally unique (not per-id counters) so pruning an
+  // entry and later recreating it can never produce a generation equal to
+  // one an in-flight request captured in its snapshot.
+  private detailCommitGenerationCounter = 0;
+  // Issue ticks of every in-flight request (index loads and detail reads).
+  // Reconciliation entries committed before the oldest in-flight request's
+  // issue can no longer influence any comparison — in-flight snapshots saw
+  // them as unchanged, and future requests get larger ticks — so publish
+  // prunes them, keeping these maps bounded by live rows plus in-flight
+  // work instead of every session ever seen.
+  private inFlightRequestTicks = new Set<number>();
   // Last committed session snapshot per id, kept so an index publish can
   // honor a superseding commit even when no prior sidebar row exists (a
   // cache-only session renamed and then deselected). Written by non-deletion
@@ -574,6 +590,7 @@ class SessionsStore {
     const version = ++this.loadVersion;
     const indexVersion = this.sidebarIndexVersion + 1;
     const requestOrdinal = ++this.requestClock;
+    this.inFlightRequestTicks.add(requestOrdinal);
     const detailCommits = this.snapshotDetailCommits();
     // Keep the existing list visible during reloads, but mark
     // loading=true so large filter expansions expose that more
@@ -637,6 +654,7 @@ class SessionsStore {
         });
       }
       this.syncActiveSessionAfterIndexCommit(detailCommits, requestOrdinal);
+      this.pruneReconciliationState();
     } catch {
       // Restore previous state so a transient failure
       // doesn't wipe the visible session list — but reapply deletion
@@ -662,6 +680,7 @@ class SessionsStore {
         );
       }
     } finally {
+      this.inFlightRequestTicks.delete(requestOrdinal);
       if (this.loadVersion === version) {
         this.loading = false;
       }
@@ -713,6 +732,7 @@ class SessionsStore {
         if (signal.aborted) return;
         const detailCommitGeneration = this.detailCommitGeneration(id);
         const issuedAtIndexOrdinal = ++this.requestClock;
+        this.inFlightRequestTicks.add(issuedAtIndexOrdinal);
         try {
           configureGeneratedClient();
           const raw = await callGenerated(
@@ -779,6 +799,7 @@ class SessionsStore {
         } catch {
           // Visible hydration is best-effort; the skinny row remains usable.
         } finally {
+          this.inFlightRequestTicks.delete(issuedAtIndexOrdinal);
           inflight.delete(id);
         }
       });
@@ -837,6 +858,7 @@ class SessionsStore {
     if (!this.nextCursor || this.loading) return;
     const version = ++this.loadVersion;
     const requestOrdinal = ++this.requestClock;
+    this.inFlightRequestTicks.add(requestOrdinal);
     const detailCommits = this.snapshotDetailCommits();
     // Rows already loaded when this request began had any mid-flight
     // deletion applied to the total by the delete path itself; a stale page
@@ -910,10 +932,12 @@ class SessionsStore {
         });
       }
       this.syncActiveSessionAfterIndexCommit(detailCommits, requestOrdinal);
+      this.pruneReconciliationState();
     } catch (error) {
       if (signal.aborted || isAbortError(error)) return;
       throw error;
     } finally {
+      this.inFlightRequestTicks.delete(requestOrdinal);
       if (this.loadVersion === version) {
         this.loading = false;
       }
@@ -1029,11 +1053,11 @@ class SessionsStore {
     issuedAtIndexOrdinal: number,
     snapshot?: Session,
   ): void {
-    const current = this.activeDetailCommitBySession.get(id);
     this.activeDetailCommitBySession.set(id, {
-      generation: (current?.generation ?? 0) + 1,
+      generation: ++this.detailCommitGenerationCounter,
       deleted,
       issuedAtIndexOrdinal,
+      committedAtTick: this.requestClock,
     });
     if (deleted) {
       this.committedDetailByRow.delete(id);
@@ -1163,8 +1187,17 @@ class SessionsStore {
   // total once per removed group. The caller records the ancestor's own
   // deletion commit.
   private removeSessionSubtree(id: string): ReadonlySet<string> {
+    // A cache-only active session (deep link, search) has no sidebar row
+    // but may descend from the deleted ancestor; include it so callers
+    // clear the selection instead of leaving a ghost.
+    const cachedActive = this.activeSessionDetail;
+    const knownRows =
+      cachedActive !== null &&
+        !this.sessions.some((row) => row.id === cachedActive.id)
+        ? [...this.sessions, cachedActive]
+        : this.sessions;
     const subtree = this.expandTombstoned(
-      this.sessions,
+      knownRows,
       (rid) => rid === id,
     );
     subtree.add(id);
@@ -1181,6 +1214,24 @@ class SessionsStore {
       this.total - this.countDroppedRoots(droppedRows, presentIds),
     );
     return subtree;
+  }
+
+  private pruneReconciliationState(): void {
+    let horizon = Infinity;
+    for (const tick of this.inFlightRequestTicks) {
+      if (tick < horizon) horizon = tick;
+    }
+    for (const [id, commit] of this.activeDetailCommitBySession) {
+      if (commit.committedAtTick < horizon) {
+        this.activeDetailCommitBySession.delete(id);
+        this.committedDetailByRow.delete(id);
+      }
+    }
+    for (const [id, stamp] of this.indexCommitByRow) {
+      if (stamp.ordinal < horizon) {
+        this.indexCommitByRow.delete(id);
+      }
+    }
   }
 
   private snapshotDetailCommits(): ReadonlyMap<string, number> {
@@ -1312,6 +1363,7 @@ class SessionsStore {
     }
     const signal = this.activeDetailRead.begin();
     const issuedAtIndexOrdinal = ++this.requestClock;
+    this.inFlightRequestTicks.add(issuedAtIndexOrdinal);
     const entry = { id, promise: Promise.resolve() };
     entry.promise = (async () => {
       try {
@@ -1348,6 +1400,7 @@ class SessionsStore {
       } catch {
         // Session not found — selection stands without metadata
       } finally {
+        this.inFlightRequestTicks.delete(issuedAtIndexOrdinal);
         this.activeDetailRead.finish(signal);
         if (this.navigateInFlight === entry) {
           this.navigateInFlight = null;
@@ -1388,6 +1441,7 @@ class SessionsStore {
     }
     const signal = this.activeDetailRead.begin();
     const issuedAtIndexOrdinal = ++this.requestClock;
+    this.inFlightRequestTicks.add(issuedAtIndexOrdinal);
     try {
       configureGeneratedClient();
       const raw = await callGenerated(
@@ -1461,6 +1515,7 @@ class SessionsStore {
         this.removeSessionSubtree(id);
       }
     } finally {
+      this.inFlightRequestTicks.delete(issuedAtIndexOrdinal);
       this.activeDetailRead.finish(signal);
     }
   }
@@ -1855,7 +1910,13 @@ class SessionsStore {
     // snapshot was taken after these tombstones and would otherwise keep
     // the deleted rows visible. Known local descendants are tombstoned with
     // their roots, mirroring the backend's subtree removal.
-    const subtree = this.expandTombstoned(this.sessions, (rid) =>
+    const cachedActive = this.activeSessionDetail;
+    const knownRows =
+      cachedActive !== null &&
+        !this.sessions.some((row) => row.id === cachedActive.id)
+        ? [...this.sessions, cachedActive]
+        : this.sessions;
+    const subtree = this.expandTombstoned(knownRows, (rid) =>
       idSet.has(rid)
     );
     for (const id of ids) subtree.add(id);

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -627,7 +627,7 @@ class SessionsStore {
 
       const promise = this.runSidebarHydration(async () => {
         if (signal.aborted) return;
-        const detailGeneration = this.detailGeneration(id);
+        const detailCommitGeneration = this.detailCommitGeneration(id);
         try {
           configureGeneratedClient();
           const hydrated = await callGenerated(
@@ -637,14 +637,17 @@ class SessionsStore {
           // A superseded hydration still carries valid detail for the active
           // session, so let it back the breadcrumb when the new index excludes
           // the row — but only fill an empty cache, and only when no newer
-          // navigation/refresh/rename touched THIS session's active-detail
-          // state while this response was in flight (another session's read
-          // says nothing about this one). A stale response must never
-          // overwrite detail already resolved for this session by a newer
-          // request; the fresh path below (mergeHydratedSession) owns updates
-          // once the version check passes.
+          // detail COMMITTED for THIS session while this response was in
+          // flight (another session's activity says nothing about this one,
+          // and a read that merely began — possibly failing — proves nothing
+          // either; if it does commit, it commits later and wins). A stale
+          // response must never overwrite detail already committed for this
+          // session by a newer request; the fresh path below
+          // (mergeHydratedSession) owns updates once the version check
+          // passes. Successful active-detail writes count as commits so a
+          // staler index response cannot overwrite them.
           const detailFresh =
-            detailGeneration === this.detailGeneration(id);
+            detailCommitGeneration === this.detailCommitGeneration(id);
           if (
             hydrated.id === this.activeSessionId &&
             !hydrated.is_index_only &&
@@ -652,6 +655,7 @@ class SessionsStore {
             detailFresh
           ) {
             this.activeSessionDetail = hydrated;
+            this.bumpDetailCommit(id, false);
           }
           if (
             version !== this.sidebarIndexVersion ||
@@ -660,13 +664,16 @@ class SessionsStore {
             return;
           }
           // Same-version guard for the active row: a hydration issued before
-          // a newer refresh resolved must not clobber the row or the cache
+          // a newer commit resolved must not clobber the row or the cache
           // with its older snapshot.
           if (hydrated.id === this.activeSessionId && !detailFresh) {
             return;
           }
           cache.set(id, hydrated);
           this.mergeHydratedSession(hydrated);
+          if (hydrated.id === this.activeSessionId) {
+            this.bumpDetailCommit(id, false);
+          }
         } catch {
           // Visible hydration is best-effort; the skinny row remains usable.
         } finally {
@@ -874,6 +881,10 @@ class SessionsStore {
     this.activeDetailGenerationBySession.set(id, this.detailGeneration(id) + 1);
   }
 
+  private detailCommitGeneration(id: string): number {
+    return this.activeDetailCommitBySession.get(id)?.generation ?? 0;
+  }
+
   private bumpDetailCommit(id: string, deleted: boolean): void {
     const current = this.activeDetailCommitBySession.get(id);
     this.activeDetailCommitBySession.set(id, {
@@ -944,29 +955,31 @@ class SessionsStore {
   }
 
   // After an index commit, reconcile the active session's sidebar row and
-  // detail cache in whichever direction is fresher. When no active-detail
-  // read began and no rename/deletion committed for the now-active session
-  // while the index was in flight, the merged row may have absorbed index
-  // refreshes (renames, counts) the cache never saw — resync the cache from
-  // it so a later reload that excludes the row doesn't revert the breadcrumb
-  // to stale fields. When something newer actually COMMITTED mid-flight, the
-  // committed state wins over the older index snapshot: a deletion removes
-  // the re-listed row (the index predates the 404), and committed detail
-  // replaces it. A read that merely began — it may still be in flight or
-  // have failed — proves nothing about the cache's freshness: leave the row
-  // and the cache alone, and let the read commit through
-  // mergeHydratedSession if and when it resolves.
+  // detail cache in whichever direction is fresher. When something newer
+  // actually COMMITTED mid-flight (navigation/refresh/rename/hydration, or
+  // a 404 deletion), the committed state wins over the older index
+  // snapshot: a deletion removes the re-listed row (the index predates the
+  // 404) and committed detail replaces it. When nothing committed but a
+  // read merely began — it may still be in flight or have failed, proving
+  // nothing about the cache's freshness — leave the row and the cache
+  // alone, and let the read commit through mergeHydratedSession if and when
+  // it resolves. Otherwise the merged row may have absorbed index refreshes
+  // (renames, counts) the cache never saw — resync the cache from it so a
+  // later reload that excludes the row doesn't revert the breadcrumb to
+  // stale fields.
   private syncActiveSessionAfterIndexCommit(
     snapshot: DetailFreshnessSnapshot,
   ) {
     const id = this.activeSessionId;
     if (id === null) return;
-    if (this.detailGeneration(id) === (snapshot.reads.get(id) ?? 0)) {
-      this.cacheActiveSessionDetailFromList(id);
-      return;
-    }
     const commit = this.activeDetailCommitBySession.get(id);
     if (!commit || commit.generation === (snapshot.commits.get(id) ?? 0)) {
+      // Nothing committed mid-flight. If a read began without committing
+      // (still in flight, or it failed), leave both sides alone; otherwise
+      // absorb the index's refreshes into the cache.
+      if (this.detailGeneration(id) === (snapshot.reads.get(id) ?? 0)) {
+        this.cacheActiveSessionDetailFromList(id);
+      }
       return;
     }
     if (commit.deleted) {

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -387,7 +387,14 @@ class SessionsStore {
   // fields. Rename and 404 commits are write-derived and always win;
   // navigation/refresh commits stay unconditional because the coordinator
   // already serializes them against each other.
-  private indexRequestOrdinal = 0;
+  //
+  // requestClock is one monotonic issue-order clock shared by sidebar index
+  // loads AND detail reads (navigation/refresh/hydration): every request
+  // takes a tick when its fetch begins, commits and row stamps record their
+  // request's tick, and freshness is strict tick comparison. A shared clock
+  // makes ties impossible, so two detail reads issued within the same index
+  // generation are still totally ordered.
+  private requestClock = 0;
   // Per-row stamp of the index REQUEST ordinal whose commit last
   // re-published each row. A detail response (navigation/refresh/hydration)
   // defers its index-owned fields (display_name, counts, timestamps) to the
@@ -557,7 +564,7 @@ class SessionsStore {
   ) {
     const version = ++this.loadVersion;
     const indexVersion = this.sidebarIndexVersion + 1;
-    const requestOrdinal = ++this.indexRequestOrdinal;
+    const requestOrdinal = ++this.requestClock;
     const detailCommits = this.snapshotDetailCommits();
     // Keep the existing list visible during reloads, but mark
     // loading=true so large filter expansions expose that more
@@ -669,7 +676,7 @@ class SessionsStore {
       const promise = this.runSidebarHydration(async () => {
         if (signal.aborted) return;
         const detailCommitGeneration = this.detailCommitGeneration(id);
-        const issuedAtIndexOrdinal = this.indexRequestOrdinal;
+        const issuedAtIndexOrdinal = ++this.requestClock;
         try {
           configureGeneratedClient();
           const raw = await callGenerated(
@@ -791,7 +798,7 @@ class SessionsStore {
   async loadMore() {
     if (!this.nextCursor || this.loading) return;
     const version = ++this.loadVersion;
-    const requestOrdinal = ++this.indexRequestOrdinal;
+    const requestOrdinal = ++this.requestClock;
     const detailCommits = this.snapshotDetailCommits();
     const signal = this.routeSignal();
     this.loading = true;
@@ -1116,7 +1123,7 @@ class SessionsStore {
       return;
     }
     const signal = this.activeDetailRead.begin();
-    const issuedAtIndexOrdinal = this.indexRequestOrdinal;
+    const issuedAtIndexOrdinal = ++this.requestClock;
     const entry = { id, promise: Promise.resolve() };
     entry.promise = (async () => {
       try {
@@ -1184,7 +1191,7 @@ class SessionsStore {
       return this.refreshActiveSession();
     }
     const signal = this.activeDetailRead.begin();
-    const issuedAtIndexOrdinal = this.indexRequestOrdinal;
+    const issuedAtIndexOrdinal = ++this.requestClock;
     try {
       configureGeneratedClient();
       const raw = await callGenerated(
@@ -1607,6 +1614,9 @@ class SessionsStore {
   async deleteSession(id: string) {
     configureGeneratedClient();
     await SessionsService.deleteApiV1SessionsId({ id });
+    // Tombstone the explicit delete so an index load that was in flight
+    // (and its failure-restore path) cannot resurrect the row.
+    this.bumpDetailCommit(id, true, Number.POSITIVE_INFINITY);
     const before = this.sessions.length;
     this.sessions = this.sessions.filter((s) => s.id !== id);
     const removed = before - this.sessions.length;
@@ -1626,6 +1636,9 @@ class SessionsStore {
     await SessionsService.postApiV1SessionsBatchDelete({
       requestBody: { session_ids: ids },
     });
+    for (const id of ids) {
+      this.bumpDetailCommit(id, true, Number.POSITIVE_INFINITY);
+    }
     const idSet = new Set(ids);
     if (this.activeSessionId && idSet.has(this.activeSessionId)) {
       this.setActiveSession(null);
@@ -1640,6 +1653,8 @@ class SessionsStore {
   async restoreSession(id: string) {
     configureGeneratedClient();
     await SessionsService.postApiV1SessionsIdRestore({ id });
+    // Clear the deletion tombstone: the session exists again.
+    this.bumpDetailCommit(id, false, Number.POSITIVE_INFINITY);
     this.clearRecentlyDeleted(id);
     this.invalidateFilterCaches();
     await this.load();
@@ -1654,6 +1669,7 @@ class SessionsStore {
     for (const id of ids) {
       try {
         await SessionsService.postApiV1SessionsIdRestore({ id });
+        this.bumpDetailCommit(id, false, Number.POSITIVE_INFINITY);
       } catch {
         failed.push(id);
       }

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -368,9 +368,16 @@ class SessionsStore {
   // monotonic, and never removed: resetting one could make a stale capture
   // compare equal again.
   private activeDetailRead = new LatestRead();
+  // Each commit records the sidebar index-request ordinal current when its
+  // underlying request was issued (Infinity for write-derived rename/404
+  // commits, which reflect a server mutation and always win). The post-index
+  // reconciliation restores committed detail over the index only when the
+  // commit's request is at least as new as the index request — a detail read
+  // issued before the index was requested cannot outrank the index's later
+  // server snapshot.
   private activeDetailCommitBySession = new Map<
     string,
-    { generation: number; deleted: boolean }
+    { generation: number; deleted: boolean; issuedAtIndexOrdinal: number }
   >();
   // Issue-order counter for sidebar index requests. Read-derived hydration
   // commits only count as commits when no newer index request was issued
@@ -546,7 +553,7 @@ class SessionsStore {
   ) {
     const version = ++this.loadVersion;
     const indexVersion = this.sidebarIndexVersion + 1;
-    this.indexRequestOrdinal++;
+    const requestOrdinal = ++this.indexRequestOrdinal;
     const detailCommits = this.snapshotDetailCommits();
     // Keep the existing list visible during reloads, but mark
     // loading=true so large filter expansions expose that more
@@ -584,7 +591,7 @@ class SessionsStore {
       for (const row of index.sessions) {
         this.indexCommitByRow.set(row.id, commitOrdinal);
       }
-      this.syncActiveSessionAfterIndexCommit(detailCommits);
+      this.syncActiveSessionAfterIndexCommit(detailCommits, requestOrdinal);
     } catch {
       // Restore previous state so a transient failure
       // doesn't wipe the visible session list.
@@ -681,11 +688,7 @@ class SessionsStore {
             detailFresh
           ) {
             this.activeSessionDetail = hydrated;
-            // Count as a commit only when no newer index request was issued
-            // since this fetch began — see indexRequestOrdinal.
-            if (issuedAtIndexOrdinal === this.indexRequestOrdinal) {
-              this.bumpDetailCommit(id, false);
-            }
+            this.bumpDetailCommit(id, false, issuedAtIndexOrdinal);
           }
           if (
             version !== this.sidebarIndexVersion ||
@@ -701,11 +704,8 @@ class SessionsStore {
           }
           cache.set(id, hydrated);
           this.mergeHydratedSession(hydrated);
-          if (
-            hydrated.id === this.activeSessionId &&
-            issuedAtIndexOrdinal === this.indexRequestOrdinal
-          ) {
-            this.bumpDetailCommit(id, false);
+          if (hydrated.id === this.activeSessionId) {
+            this.bumpDetailCommit(id, false, issuedAtIndexOrdinal);
           }
         } catch {
           // Visible hydration is best-effort; the skinny row remains usable.
@@ -767,7 +767,7 @@ class SessionsStore {
   async loadMore() {
     if (!this.nextCursor || this.loading) return;
     const version = ++this.loadVersion;
-    this.indexRequestOrdinal++;
+    const requestOrdinal = ++this.indexRequestOrdinal;
     const detailCommits = this.snapshotDetailCommits();
     const signal = this.routeSignal();
     this.loading = true;
@@ -801,7 +801,7 @@ class SessionsStore {
       for (const row of index.sessions) {
         this.indexCommitByRow.set(row.id, commitOrdinal);
       }
-      this.syncActiveSessionAfterIndexCommit(detailCommits);
+      this.syncActiveSessionAfterIndexCommit(detailCommits, requestOrdinal);
     } catch (error) {
       if (signal.aborted || isAbortError(error)) return;
       throw error;
@@ -915,11 +915,16 @@ class SessionsStore {
     return this.activeDetailCommitBySession.get(id)?.generation ?? 0;
   }
 
-  private bumpDetailCommit(id: string, deleted: boolean): void {
+  private bumpDetailCommit(
+    id: string,
+    deleted: boolean,
+    issuedAtIndexOrdinal: number,
+  ): void {
     const current = this.activeDetailCommitBySession.get(id);
     this.activeDetailCommitBySession.set(id, {
       generation: (current?.generation ?? 0) + 1,
       deleted,
+      issuedAtIndexOrdinal,
     });
   }
 
@@ -1001,11 +1006,20 @@ class SessionsStore {
   // strictly fresher detail on top.
   private syncActiveSessionAfterIndexCommit(
     snapshot: ReadonlyMap<string, number>,
+    requestOrdinal: number,
   ) {
     const id = this.activeSessionId;
     if (id === null) return;
     const commit = this.activeDetailCommitBySession.get(id);
-    if (!commit || commit.generation === (snapshot.get(id) ?? 0)) {
+    if (
+      commit === undefined ||
+      commit.generation === (snapshot.get(id) ?? 0) ||
+      (!commit.deleted && commit.issuedAtIndexOrdinal < requestOrdinal)
+    ) {
+      // Nothing committed mid-flight, or the commit's request predates this
+      // index request — the index's server snapshot is at least as fresh, so
+      // absorb its refreshes into the cache (the commit's detail-owned
+      // fields survive through the row's existing-field carry-over).
       this.cacheActiveSessionDetailFromList(id);
       return;
     }
@@ -1064,6 +1078,7 @@ class SessionsStore {
       return;
     }
     const signal = this.activeDetailRead.begin();
+    const issuedAtIndexOrdinal = this.indexRequestOrdinal;
     const indexCommitsAtStart = this.indexCommitOrdinal;
     const entry = { id, promise: Promise.resolve() };
     entry.promise = (async () => {
@@ -1088,7 +1103,7 @@ class SessionsStore {
           } else {
             this.activeSessionDetail = session;
           }
-          this.bumpDetailCommit(id, false);
+          this.bumpDetailCommit(id, false, issuedAtIndexOrdinal);
         }
       } catch {
         // Session not found — selection stands without metadata
@@ -1132,6 +1147,7 @@ class SessionsStore {
       return this.refreshActiveSession();
     }
     const signal = this.activeDetailRead.begin();
+    const issuedAtIndexOrdinal = this.indexRequestOrdinal;
     const indexCommitsAtStart = this.indexCommitOrdinal;
     try {
       configureGeneratedClient();
@@ -1161,7 +1177,7 @@ class SessionsStore {
         // breadcrumb.
         this.activeSessionDetail = session;
       }
-      this.bumpDetailCommit(id, false);
+      this.bumpDetailCommit(id, false, issuedAtIndexOrdinal);
     } catch (e) {
       // The session may have been deleted, locally or on another machine. On
       // a definitive not-found drop the cached detail so the breadcrumb
@@ -1174,7 +1190,7 @@ class SessionsStore {
         this.activeSessionId === id &&
         this.activeDetailRead.isCurrent(signal)
       ) {
-        this.bumpDetailCommit(id, true);
+        this.bumpDetailCommit(id, true, Number.POSITIVE_INFINITY);
         this.activeSessionDetail = null;
         // A hydrated matching row would keep backing activeSession as a
         // ghost of the deleted session; drop it and keep the pagination
@@ -1709,12 +1725,20 @@ class SessionsStore {
     // watcher refresh.
     if (this.activeSessionId === id) {
       this.activeDetailRead.cancel();
-      this.bumpDetailCommit(id, false);
-      const base =
-        this.activeSessionDetail?.id === id
-          ? this.activeSessionDetail
-          : { ...updated, is_index_only: false };
-      this.activeSessionDetail = applyRename(base);
+      this.bumpDetailCommit(id, false, Number.POSITIVE_INFINITY);
+      const cached =
+        this.activeSessionDetail?.id === id ? this.activeSessionDetail : null;
+      this.activeSessionDetail = applyRename(
+        cached ?? { ...updated, is_index_only: false },
+      );
+      // The rename endpoint returns the plain DB-session shape, without the
+      // derived detail-only fields (decode confidence, health explanations).
+      // Merging onto a populated cache preserves those, but a fabricated
+      // base is only an interim snapshot: chase with a fresh detail read so
+      // the enriched shape arrives instead of masquerading as hydrated.
+      if (cached === null) {
+        void this.refreshActiveSession();
+      }
     }
   }
 

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -388,18 +388,22 @@ class SessionsStore {
   // navigation/refresh commits stay unconditional because the coordinator
   // already serializes them against each other.
   private indexRequestOrdinal = 0;
-  // Commit-order counter for sidebar index requests, bumped when a loader
-  // publishes its rows, plus a per-row stamp of the commit that last
+  // Per-row stamp of the index REQUEST ordinal whose commit last
   // re-published each row. A detail response (navigation/refresh/hydration)
-  // resolving after an index commit that re-listed ITS row may predate that
-  // index's server snapshot: its detail-owned fields still apply, but
-  // index-owned fields (display_name, counts, timestamps) must not revert
-  // the committed row — reconcileDetailResponse keeps the row's index
-  // fields in that case. A commit that did not re-list the row (an
-  // unrelated loadMore page) says nothing about it, so the response still
-  // applies wholesale.
-  private indexCommitOrdinal = 0;
+  // defers its index-owned fields (display_name, counts, timestamps) to the
+  // row only when the stamping index request was issued AFTER the detail
+  // request began — then the index's server snapshot is the newer one. An
+  // index issued before the detail request, or a commit that never re-listed
+  // the row (an unrelated loadMore page), says nothing newer, so the
+  // response applies wholesale. Together with the commit records above this
+  // makes request-issue order the single freshness rule in both directions.
   private indexCommitByRow = new Map<string, number>();
+  // True while activeSessionDetail is a fabricated rename snapshot (the
+  // rename endpoint returns the DB-session shape without detail-only
+  // fields). Cleared by any read-derived commit for the active session;
+  // a rename seeing it still set re-issues the enrichment fetch, so rapid
+  // renames cannot cancel the only fetch and strand the interim shape.
+  private interimActiveDetail = false;
   private childSessionsRead = new LatestRead();
 
   private liveRefreshStarted = false;
@@ -587,9 +591,8 @@ class SessionsStore {
       );
       this.nextCursor = index.next_cursor ?? null;
       this.total = index.total;
-      const commitOrdinal = ++this.indexCommitOrdinal;
       for (const row of index.sessions) {
-        this.indexCommitByRow.set(row.id, commitOrdinal);
+        this.indexCommitByRow.set(row.id, requestOrdinal);
       }
       this.syncActiveSessionAfterIndexCommit(detailCommits, requestOrdinal);
     } catch {
@@ -652,7 +655,6 @@ class SessionsStore {
         if (signal.aborted) return;
         const detailCommitGeneration = this.detailCommitGeneration(id);
         const issuedAtIndexOrdinal = this.indexRequestOrdinal;
-        const indexCommitsAtStart = this.indexCommitOrdinal;
         try {
           configureGeneratedClient();
           const raw = await callGenerated(
@@ -665,7 +667,7 @@ class SessionsStore {
           const hydrated = this.reconcileDetailResponse(
             id,
             raw,
-            indexCommitsAtStart,
+            issuedAtIndexOrdinal,
           );
           // A superseded hydration still carries valid detail for the active
           // session, so let it back the breadcrumb when the new index excludes
@@ -797,9 +799,8 @@ class SessionsStore {
       ];
       this.nextCursor = index.next_cursor ?? null;
       this.total = index.total;
-      const commitOrdinal = ++this.indexCommitOrdinal;
       for (const row of index.sessions) {
-        this.indexCommitByRow.set(row.id, commitOrdinal);
+        this.indexCommitByRow.set(row.id, requestOrdinal);
       }
       this.syncActiveSessionAfterIndexCommit(detailCommits, requestOrdinal);
     } catch (error) {
@@ -926,19 +927,28 @@ class SessionsStore {
       deleted,
       issuedAtIndexOrdinal,
     });
+    // A read-derived commit (finite ordinal) carries the full detail shape;
+    // it supersedes any interim rename snapshot backing the active session.
+    if (
+      !deleted &&
+      Number.isFinite(issuedAtIndexOrdinal) &&
+      id === this.activeSessionId
+    ) {
+      this.interimActiveDetail = false;
+    }
   }
 
-  // See indexCommitOrdinal: when an index committed while a detail read was
-  // in flight, take only detail-owned fields from the response and keep the
-  // row's committed index-owned fields. When none did, the response is the
-  // freshest source for every field (e.g. a refresh propagating a remote
-  // rename) and is returned untouched.
+  // See indexCommitByRow: when an index request issued after this detail
+  // read began has committed the row, take only detail-owned fields from
+  // the response and keep the row's committed index-owned fields. Otherwise
+  // the response is the freshest source for every field (e.g. a refresh
+  // propagating a remote rename) and is returned untouched.
   private reconcileDetailResponse(
     id: string,
     session: Session,
-    indexCommitsAtStart: number,
+    issuedAtIndexOrdinal: number,
   ): Session {
-    if ((this.indexCommitByRow.get(id) ?? 0) <= indexCommitsAtStart) {
+    if ((this.indexCommitByRow.get(id) ?? 0) <= issuedAtIndexOrdinal) {
       return session;
     }
     const row = this.sessions.find((s) => s.id === id);
@@ -965,6 +975,7 @@ class SessionsStore {
     this.childSessionsRead.cancel();
     this.activeSessionId = id;
     this.activeSessionDetail = null;
+    this.interimActiveDetail = false;
     this.activeSessionUsageVersion = 0;
     this.childSessionsVersion++;
   }
@@ -1084,7 +1095,6 @@ class SessionsStore {
     }
     const signal = this.activeDetailRead.begin();
     const issuedAtIndexOrdinal = this.indexRequestOrdinal;
-    const indexCommitsAtStart = this.indexCommitOrdinal;
     const entry = { id, promise: Promise.resolve() };
     entry.promise = (async () => {
       try {
@@ -1100,7 +1110,7 @@ class SessionsStore {
           const session = this.reconcileDetailResponse(
             id,
             raw,
-            indexCommitsAtStart,
+            issuedAtIndexOrdinal,
           );
           const idx = this.sessions.findIndex((s) => s.id === id);
           if (idx >= 0) {
@@ -1153,7 +1163,6 @@ class SessionsStore {
     }
     const signal = this.activeDetailRead.begin();
     const issuedAtIndexOrdinal = this.indexRequestOrdinal;
-    const indexCommitsAtStart = this.indexCommitOrdinal;
     try {
       configureGeneratedClient();
       const raw = await callGenerated(
@@ -1169,7 +1178,7 @@ class SessionsStore {
       const session = this.reconcileDetailResponse(
         id,
         raw,
-        indexCommitsAtStart,
+        issuedAtIndexOrdinal,
       );
       const idx = this.sessions.findIndex((s) => s.id === id);
       if (idx >= 0) {
@@ -1740,8 +1749,11 @@ class SessionsStore {
       // derived detail-only fields (decode confidence, health explanations).
       // Merging onto a populated cache preserves those, but a fabricated
       // base is only an interim snapshot: chase with a fresh detail read so
-      // the enriched shape arrives instead of masquerading as hydrated.
-      if (cached === null) {
+      // the enriched shape arrives instead of masquerading as hydrated. A
+      // still-interim cache re-chases — this rename just cancelled the
+      // previous enrichment fetch.
+      if (cached === null || this.interimActiveDetail) {
+        this.interimActiveDetail = true;
         void this.refreshActiveSession();
       }
     }

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -646,13 +646,17 @@ class SessionsStore {
     const idx = this.sessions.findIndex((s) => s.id === hydrated.id);
     if (idx < 0) return;
     const current = this.sessions[idx]!;
-    this.sessions[idx] = {
+    const merged = {
       ...current,
       ...hydrated,
       display_name: hydrated.display_name ?? current.display_name,
       is_teammate: hydrated.is_teammate ?? current.is_teammate,
       is_index_only: false,
     };
+    this.sessions[idx] = merged;
+    // Keep the active-session cache in sync so the breadcrumb survives a later
+    // reload that drops this row from the filtered/first page.
+    if (merged.id === this.activeSessionId) this.activeSessionDetail = merged;
   }
 
   private invalidateHydratedSessionDetails() {
@@ -834,11 +838,18 @@ class SessionsStore {
 
   selectSession(id: string) {
     this.setActiveSession(id);
+    this.cacheActiveSessionDetailFromList(id);
     void this.hydrateSelectedIndexOnlySession(id);
   }
 
-  private navigateInFlight: { id: string; promise: Promise<void> } | null =
-    null;
+  // Seed activeSessionDetail from a hydrated sidebar row so the open session
+  // survives a later reload that drops it from the filtered/first page. Skips
+  // index-only stubs; hydration then seeds the cache via mergeHydratedSession.
+  private cacheActiveSessionDetailFromList(id: string) {
+    if (id !== this.activeSessionId) return;
+    const row = this.sessions.find((s) => s.id === id);
+    if (row && !row.is_index_only) this.activeSessionDetail = row;
+  }
 
   /**
    * Navigate to a session by ID. If it isn't in the current sidebar list
@@ -854,6 +865,7 @@ class SessionsStore {
     this.setActiveSession(id);
     const existing = this.sessions.find((s) => s.id === id);
     if (existing) {
+      this.cacheActiveSessionDetailFromList(id);
       await this.hydrateSelectedIndexOnlySession(id);
       return;
     }

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -666,7 +666,10 @@ class SessionsStore {
       if (this.loadVersion === version) {
         const restoredTombstones = this.expandTombstoned(
           prev.sessions,
-          (rid) => this.deletedSinceSnapshot(rid, detailCommits, requestOrdinal),
+          // A failed load carries no newer server state, so unlike a
+          // successful publish it cannot supersede a read-derived
+          // tombstone: honor anything committed after the snapshot.
+          (rid) => this.deletedSinceSnapshot(rid, detailCommits, 0),
         );
         const droppedRows = prev.sessions.filter((s) =>
           restoredTombstones.has(s.id)
@@ -1348,7 +1351,7 @@ class SessionsStore {
     if (commit.deleted) {
       // Honor the deletion tombstone instead of letting the stale index
       // resurrect the row (mirrors refreshActiveSession's 404 removal).
-      this.removeSessionSubtree(id);
+      this.removeSessionSubtree(id, commit.issuedAtIndexOrdinal);
       return;
     }
     this.restoreActiveRowFromDetailCache(id);

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -335,7 +335,6 @@ class SessionsStore {
   private agentsLoaded: boolean = false;
   private agentsPromise: Promise<void> | null = null;
   private agentsVersion: number = 0;
-  private refreshVersion: number = 0;
   private childSessionsVersion: number = 0;
   private machinesLoaded: boolean = false;
   private machinesPromise: Promise<void> | null = null;
@@ -352,8 +351,11 @@ class SessionsStore {
   private sidebarLoadSignature: string | null = null;
   private sidebarAbort: AbortController | null = null;
   private routeAbort: AbortController | null = null;
-  private navigateRead = new LatestRead();
-  private refreshRead = new LatestRead();
+  // Single coordinator for every read that commits to activeSessionDetail
+  // (navigation and watcher refresh): the newest read cancels older in-flight
+  // ones, so a stale response resolving late can never overwrite fresher
+  // cached detail.
+  private activeDetailRead = new LatestRead();
   private childSessionsRead = new LatestRead();
 
   private liveRefreshStarted = false;
@@ -839,13 +841,11 @@ class SessionsStore {
 
   private setActiveSession(id: string | null) {
     if (id === this.activeSessionId) return;
-    this.navigateRead.cancel();
-    this.refreshRead.cancel();
+    this.activeDetailRead.cancel();
     this.childSessionsRead.cancel();
     this.activeSessionId = id;
     this.activeSessionDetail = null;
     this.activeSessionUsageVersion = 0;
-    this.refreshVersion++;
     this.childSessionsVersion++;
   }
 
@@ -882,14 +882,17 @@ class SessionsStore {
       await this.hydrateSelectedIndexOnlySession(id);
       return;
     }
-    const signal = this.navigateRead.begin();
+    const signal = this.activeDetailRead.begin();
     try {
       configureGeneratedClient();
       const session = await callGenerated(
         () => SessionsService.getApiV1SessionsId({ id }),
         signal,
       ) as unknown as Session;
-      if (this.activeSessionId === id && this.navigateRead.isCurrent(signal)) {
+      if (
+        this.activeSessionId === id &&
+        this.activeDetailRead.isCurrent(signal)
+      ) {
         const idx = this.sessions.findIndex((s) => s.id === id);
         if (idx >= 0) {
           this.mergeHydratedSession(session);
@@ -897,9 +900,11 @@ class SessionsStore {
           this.activeSessionDetail = session;
         }
       }
-    })();
-    this.navigateInFlight = entry;
-    return entry.promise;
+    } catch {
+      // Session not found — selection stands without metadata
+    } finally {
+      this.activeDetailRead.finish(signal);
+    }
   }
 
   private async hydrateSelectedIndexOnlySession(id: string) {
@@ -916,8 +921,7 @@ class SessionsStore {
   async refreshActiveSession() {
     const id = this.activeSessionId;
     if (!id) return;
-    const version = ++this.refreshVersion;
-    const signal = this.refreshRead.begin();
+    const signal = this.activeDetailRead.begin();
     try {
       configureGeneratedClient();
       const session = await callGenerated(
@@ -925,9 +929,8 @@ class SessionsStore {
         signal,
       ) as unknown as Session;
       if (
-        this.refreshVersion !== version ||
         this.activeSessionId !== id ||
-        !this.refreshRead.isCurrent(signal)
+        !this.activeDetailRead.isCurrent(signal)
       ) {
         return;
       }
@@ -945,7 +948,7 @@ class SessionsStore {
     } catch {
       // Session may have been deleted
     } finally {
-      this.refreshRead.finish(signal);
+      this.activeDetailRead.finish(signal);
     }
   }
 
@@ -1442,7 +1445,10 @@ class SessionsStore {
     }
     // The active session may be backed only by the detail cache (absent from
     // the sidebar list); keep its name in sync so the breadcrumb updates too.
+    // Drop any in-flight active-detail read first: it was issued before the
+    // rename and would revert the name with a pre-rename snapshot.
     if (this.activeSessionDetail?.id === id) {
+      this.activeDetailRead.cancel();
       this.activeSessionDetail = applyRename(this.activeSessionDetail);
     }
   }
@@ -1513,11 +1519,9 @@ class SessionsStore {
     this.sidebarLoadSignature = null;
     this.routeAbort?.abort();
     this.routeAbort = null;
-    this.navigateRead.cancel();
-    this.refreshRead.cancel();
+    this.activeDetailRead.cancel();
     this.childSessionsRead.cancel();
     this.loadVersion++;
-    this.refreshVersion++;
     this.childSessionsVersion++;
     this.loading = false;
     this.signalDetailInflight.clear();

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -593,12 +593,21 @@ class SessionsStore {
         session.id,
         session,
       ]));
-      this.sessions = index.sessions.map((row) =>
+      // A deletion that committed while this index was in flight supersedes
+      // the index's older server snapshot: drop tombstoned rows instead of
+      // reinserting them.
+      const rows = index.sessions.filter(
+        (row) => !this.deletedSinceSnapshot(row.id, detailCommits),
+      );
+      this.sessions = rows.map((row) =>
         sidebarIndexRowToSession(row, existing.get(row.id))
       );
       this.nextCursor = index.next_cursor ?? null;
-      this.total = index.total;
-      for (const row of index.sessions) {
+      this.total = Math.max(
+        0,
+        index.total - (index.sessions.length - rows.length),
+      );
+      for (const row of rows) {
         this.indexCommitByRow.set(row.id, requestOrdinal);
       }
       this.syncActiveSessionAfterIndexCommit(detailCommits, requestOrdinal);
@@ -609,15 +618,9 @@ class SessionsStore {
       // removed its row from the live list, and the pre-load snapshot still
       // contains it.
       if (this.loadVersion === version) {
-        const deletedMidFlight = (id: string) => {
-          const commit = this.activeDetailCommitBySession.get(id);
-          return (
-            commit !== undefined &&
-            commit.deleted &&
-            commit.generation !== (detailCommits.get(id) ?? 0)
-          );
-        };
-        const restored = prev.sessions.filter((s) => !deletedMidFlight(s.id));
+        const restored = prev.sessions.filter(
+          (s) => !this.deletedSinceSnapshot(s.id, detailCommits),
+        );
         this.sessions = restored;
         this.nextCursor = prev.nextCursor;
         this.total = Math.max(
@@ -819,16 +822,23 @@ class SessionsStore {
       const existingById = new Map(
         this.sessions.map((session) => [session.id, session]),
       );
-      const pageIds = new Set(index.sessions.map((row) => row.id));
+      // Same deletion-tombstone guard as loadSidebarPage for appended pages.
+      const rows = index.sessions.filter(
+        (row) => !this.deletedSinceSnapshot(row.id, detailCommits),
+      );
+      const pageIds = new Set(rows.map((row) => row.id));
       this.sessions = [
         ...this.sessions.filter((s) => !pageIds.has(s.id)),
-        ...index.sessions.map((row) =>
+        ...rows.map((row) =>
           sidebarIndexRowToSession(row, existingById.get(row.id))
         ),
       ];
       this.nextCursor = index.next_cursor ?? null;
-      this.total = index.total;
-      for (const row of index.sessions) {
+      this.total = Math.max(
+        0,
+        index.total - (index.sessions.length - rows.length),
+      );
+      for (const row of rows) {
         this.indexCommitByRow.set(row.id, requestOrdinal);
       }
       this.syncActiveSessionAfterIndexCommit(detailCommits, requestOrdinal);
@@ -988,6 +998,23 @@ class SessionsStore {
     const cached = this.activeSessionDetail;
     if (cached?.id === id) return mergeIndexFieldsIntoDetail(cached, session);
     return session;
+  }
+
+  // True when a deletion committed for id after the given commit snapshot
+  // was taken — i.e. mid-flight relative to whichever request captured it.
+  // Index publishing, the reload failure-restore, and reconciliation all
+  // honor these tombstones so a response whose server snapshot predates the
+  // deletion cannot resurrect the row.
+  private deletedSinceSnapshot(
+    id: string,
+    snapshot: ReadonlyMap<string, number>,
+  ): boolean {
+    const commit = this.activeDetailCommitBySession.get(id);
+    return (
+      commit !== undefined &&
+      commit.deleted &&
+      commit.generation !== (snapshot.get(id) ?? 0)
+    );
   }
 
   private snapshotDetailCommits(): ReadonlyMap<string, number> {

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -1102,17 +1102,16 @@ class SessionsStore {
       snapshot !== undefined &&
       !this.sessions.some((row) => row.id === id)
     ) {
-      const presentIds = new Set(this.sessions.map((row) => row.id));
+      // Adjust the total by the change in locally represented root groups:
+      // a revived orphan child counts as a promoted root, and a parent
+      // reviving later demotes it again, so the group is counted exactly
+      // once regardless of revival order.
+      const rootGroupsBefore = this.countRootGroups(this.sessions);
       this.sessions = [...this.sessions, { ...snapshot }];
-      // Root status is judged against the CURRENT rows: a revived
-      // descendant whose parent is still absent is a promoted orphan root
-      // now, whatever it was at deletion time.
-      if (
-        !snapshot.parent_session_id ||
-        !presentIds.has(snapshot.parent_session_id)
-      ) {
-        this.total += 1;
-      }
+      this.total = Math.max(
+        0,
+        this.total + this.countRootGroups(this.sessions) - rootGroupsBefore,
+      );
       this.scheduleIndexRefresh();
     }
   }
@@ -1288,6 +1287,15 @@ class SessionsStore {
         this.indexCommitByRow.delete(id);
       }
     }
+  }
+
+  // Count locally represented root groups: rows that are parentless or
+  // whose parent is absent from the set (promoted orphans).
+  private countRootGroups(rows: ReadonlyArray<Session>): number {
+    const ids = new Set(rows.map((row) => row.id));
+    return rows.filter(
+      (row) => !row.parent_session_id || !ids.has(row.parent_session_id),
+    ).length;
   }
 
   private snapshotDetailCommits(): ReadonlyMap<string, number> {

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -1055,6 +1055,7 @@ class SessionsStore {
     issuedAtIndexOrdinal: number,
     snapshot?: Session,
   ): void {
+    const previous = this.activeDetailCommitBySession.get(id);
     this.activeDetailCommitBySession.set(id, {
       generation: ++this.detailCommitGenerationCounter,
       deleted,
@@ -1074,6 +1075,28 @@ class SessionsStore {
       id === this.activeSessionId
     ) {
       this.interimActiveDetail = false;
+    }
+    // A live commit superseding a read-derived tombstone proves the session
+    // exists: restore the sidebar row and root total the transient 404
+    // removed. The appended position is approximate; the scheduled
+    // authoritative reload corrects ordering.
+    if (
+      !deleted &&
+      previous !== undefined &&
+      previous.deleted &&
+      Number.isFinite(previous.issuedAtIndexOrdinal) &&
+      snapshot !== undefined &&
+      !this.sessions.some((row) => row.id === id)
+    ) {
+      const presentIds = new Set(this.sessions.map((row) => row.id));
+      this.sessions = [...this.sessions, { ...snapshot }];
+      if (
+        !snapshot.parent_session_id ||
+        !presentIds.has(snapshot.parent_session_id)
+      ) {
+        this.total += 1;
+      }
+      this.scheduleIndexRefresh();
     }
   }
 

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -381,6 +381,13 @@ class SessionsStore {
   // navigation/refresh commits stay unconditional because the coordinator
   // already serializes them against each other.
   private indexRequestOrdinal = 0;
+  // Commit-order counter for sidebar index requests, bumped when a loader
+  // publishes its rows. A detail response (navigation/refresh/hydration)
+  // resolving after an index committed mid-flight may predate that index's
+  // server snapshot: its detail-owned fields still apply, but index-owned
+  // fields (display_name, counts, timestamps) must not revert the committed
+  // row — reconcileDetailResponse keeps the row's index fields in that case.
+  private indexCommitOrdinal = 0;
   private childSessionsRead = new LatestRead();
 
   private liveRefreshStarted = false;
@@ -568,6 +575,7 @@ class SessionsStore {
       );
       this.nextCursor = index.next_cursor ?? null;
       this.total = index.total;
+      this.indexCommitOrdinal++;
       this.syncActiveSessionAfterIndexCommit(detailCommits);
     } catch {
       // Restore previous state so a transient failure
@@ -629,12 +637,21 @@ class SessionsStore {
         if (signal.aborted) return;
         const detailCommitGeneration = this.detailCommitGeneration(id);
         const issuedAtIndexOrdinal = this.indexRequestOrdinal;
+        const indexCommitsAtStart = this.indexCommitOrdinal;
         try {
           configureGeneratedClient();
-          const hydrated = await callGenerated(
+          const raw = await callGenerated(
             () => SessionsService.getApiV1SessionsId({ id }),
             signal,
           ) as unknown as Session;
+          // The version/epoch checks below catch full reloads, but a
+          // loadMore page committing mid-flight re-lists rows without
+          // changing the index version; reconcile against that too.
+          const hydrated = this.reconcileDetailResponse(
+            id,
+            raw,
+            indexCommitsAtStart,
+          );
           // A superseded hydration still carries valid detail for the active
           // session, so let it back the breadcrumb when the new index excludes
           // the row — but only fill an empty cache, and only when no newer
@@ -772,6 +789,7 @@ class SessionsStore {
       ];
       this.nextCursor = index.next_cursor ?? null;
       this.total = index.total;
+      this.indexCommitOrdinal++;
       this.syncActiveSessionAfterIndexCommit(detailCommits);
     } catch (error) {
       if (signal.aborted || isAbortError(error)) return;
@@ -892,6 +910,22 @@ class SessionsStore {
       generation: (current?.generation ?? 0) + 1,
       deleted,
     });
+  }
+
+  // See indexCommitOrdinal: when an index committed while a detail read was
+  // in flight, take only detail-owned fields from the response and keep the
+  // row's committed index-owned fields. When none did, the response is the
+  // freshest source for every field (e.g. a refresh propagating a remote
+  // rename) and is returned untouched.
+  private reconcileDetailResponse(
+    id: string,
+    session: Session,
+    indexCommitsAtStart: number,
+  ): Session {
+    if (indexCommitsAtStart === this.indexCommitOrdinal) return session;
+    const row = this.sessions.find((s) => s.id === id);
+    if (!row) return session;
+    return mergeIndexFieldsIntoDetail(row, session);
   }
 
   private snapshotDetailCommits(): ReadonlyMap<string, number> {
@@ -1017,11 +1051,12 @@ class SessionsStore {
       return;
     }
     const signal = this.activeDetailRead.begin();
+    const indexCommitsAtStart = this.indexCommitOrdinal;
     const entry = { id, promise: Promise.resolve() };
     entry.promise = (async () => {
       try {
         configureGeneratedClient();
-        const session = await callGenerated(
+        const raw = await callGenerated(
           () => SessionsService.getApiV1SessionsId({ id }),
           signal,
         ) as unknown as Session;
@@ -1029,6 +1064,11 @@ class SessionsStore {
           this.activeSessionId === id &&
           this.activeDetailRead.isCurrent(signal)
         ) {
+          const session = this.reconcileDetailResponse(
+            id,
+            raw,
+            indexCommitsAtStart,
+          );
           const idx = this.sessions.findIndex((s) => s.id === id);
           if (idx >= 0) {
             this.mergeHydratedSession(session);
@@ -1073,9 +1113,10 @@ class SessionsStore {
       return this.navigateInFlight.promise;
     }
     const signal = this.activeDetailRead.begin();
+    const indexCommitsAtStart = this.indexCommitOrdinal;
     try {
       configureGeneratedClient();
-      const session = await callGenerated(
+      const raw = await callGenerated(
         () => SessionsService.getApiV1SessionsId({ id }),
         signal,
       ) as unknown as Session;
@@ -1085,6 +1126,11 @@ class SessionsStore {
       ) {
         return;
       }
+      const session = this.reconcileDetailResponse(
+        id,
+        raw,
+        indexCommitsAtStart,
+      );
       const idx = this.sessions.findIndex((s) => s.id === id);
       if (idx >= 0) {
         this.mergeHydratedSession(session);

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -596,6 +596,9 @@ class SessionsStore {
       // A deletion that committed while this index was in flight supersedes
       // the index's older server snapshot: drop tombstoned rows instead of
       // reinserting them.
+      const dropped = index.sessions.filter((row) =>
+        this.deletedSinceSnapshot(row.id, detailCommits)
+      );
       const rows = index.sessions.filter(
         (row) => !this.deletedSinceSnapshot(row.id, detailCommits),
       );
@@ -603,10 +606,7 @@ class SessionsStore {
         sidebarIndexRowToSession(row, existing.get(row.id))
       );
       this.nextCursor = index.next_cursor ?? null;
-      this.total = Math.max(
-        0,
-        index.total - (index.sessions.length - rows.length),
-      );
+      this.total = Math.max(0, index.total - this.countDroppedRoots(dropped));
       for (const row of rows) {
         this.indexCommitByRow.set(row.id, requestOrdinal);
       }
@@ -618,14 +618,16 @@ class SessionsStore {
       // removed its row from the live list, and the pre-load snapshot still
       // contains it.
       if (this.loadVersion === version) {
-        const restored = prev.sessions.filter(
+        const droppedRows = prev.sessions.filter((s) =>
+          this.deletedSinceSnapshot(s.id, detailCommits)
+        );
+        this.sessions = prev.sessions.filter(
           (s) => !this.deletedSinceSnapshot(s.id, detailCommits),
         );
-        this.sessions = restored;
         this.nextCursor = prev.nextCursor;
         this.total = Math.max(
           0,
-          prev.total - (prev.sessions.length - restored.length),
+          prev.total - this.countDroppedRoots(droppedRows),
         );
       }
     } finally {
@@ -823,6 +825,9 @@ class SessionsStore {
         this.sessions.map((session) => [session.id, session]),
       );
       // Same deletion-tombstone guard as loadSidebarPage for appended pages.
+      const dropped = index.sessions.filter((row) =>
+        this.deletedSinceSnapshot(row.id, detailCommits)
+      );
       const rows = index.sessions.filter(
         (row) => !this.deletedSinceSnapshot(row.id, detailCommits),
       );
@@ -834,10 +839,7 @@ class SessionsStore {
         ),
       ];
       this.nextCursor = index.next_cursor ?? null;
-      this.total = Math.max(
-        0,
-        index.total - (index.sessions.length - rows.length),
-      );
+      this.total = Math.max(0, index.total - this.countDroppedRoots(dropped));
       for (const row of rows) {
         this.indexCommitByRow.set(row.id, requestOrdinal);
       }
@@ -1017,6 +1019,17 @@ class SessionsStore {
     );
   }
 
+  // The paginated sidebar total counts root groups, while rows include
+  // roots and their descendants: only removing a parentless row can shrink
+  // the root count — a descendant's removal leaves its group in place.
+  // Orphan promotion after a root deletion is settled by the next
+  // authoritative index response.
+  private countDroppedRoots(
+    rows: ReadonlyArray<{ parent_session_id?: string | null }>,
+  ): number {
+    return rows.filter((row) => !row.parent_session_id).length;
+  }
+
   private snapshotDetailCommits(): ReadonlyMap<string, number> {
     return new Map(
       [...this.activeDetailCommitBySession].map(
@@ -1098,12 +1111,12 @@ class SessionsStore {
     if (commit.deleted) {
       // Honor the deletion tombstone instead of letting the stale index
       // resurrect the row (mirrors refreshActiveSession's 404 removal).
-      const before = this.sessions.length;
+      const droppedRows = this.sessions.filter((s) => s.id === id);
       this.sessions = this.sessions.filter((s) => s.id !== id);
-      const removed = before - this.sessions.length;
-      if (removed > 0) {
-        this.total = Math.max(0, this.total - removed);
-      }
+      this.total = Math.max(
+        0,
+        this.total - this.countDroppedRoots(droppedRows),
+      );
       return;
     }
     this.restoreActiveRowFromDetailCache(id);
@@ -1163,18 +1176,26 @@ class SessionsStore {
           this.activeSessionId === id &&
           this.activeDetailRead.isCurrent(signal)
         ) {
-          const session = this.reconcileDetailResponse(
-            id,
-            raw,
-            issuedAtIndexOrdinal,
-          );
-          const idx = this.sessions.findIndex((s) => s.id === id);
-          if (idx >= 0) {
-            this.mergeHydratedSession(session);
-          } else {
-            this.activeSessionDetail = session;
+          // Same later-issued-read guard as refreshActiveSession.
+          const latestTick =
+            this.activeDetailCommitBySession.get(id)?.issuedAtIndexOrdinal ??
+              0;
+          if (
+            !Number.isFinite(latestTick) || latestTick <= issuedAtIndexOrdinal
+          ) {
+            const session = this.reconcileDetailResponse(
+              id,
+              raw,
+              issuedAtIndexOrdinal,
+            );
+            const idx = this.sessions.findIndex((s) => s.id === id);
+            if (idx >= 0) {
+              this.mergeHydratedSession(session);
+            } else {
+              this.activeSessionDetail = session;
+            }
+            this.bumpDetailCommit(id, false, issuedAtIndexOrdinal);
           }
-          this.bumpDetailCommit(id, false, issuedAtIndexOrdinal);
         }
       } catch {
         // Session not found — selection stands without metadata
@@ -1231,6 +1252,16 @@ class SessionsStore {
       ) {
         return;
       }
+      // A commit from a later-issued READ (e.g. a hydration issued after
+      // this request began) already holds fresher detail than this
+      // response; leave it in place. Write-derived commits (Infinity) are
+      // excluded: they invalidate stale reads through the coordinator, and
+      // a read issued after them observes post-write state and must commit.
+      const latestTick =
+        this.activeDetailCommitBySession.get(id)?.issuedAtIndexOrdinal ?? 0;
+      if (Number.isFinite(latestTick) && latestTick > issuedAtIndexOrdinal) {
+        return;
+      }
       const session = this.reconcileDetailResponse(
         id,
         raw,
@@ -1265,12 +1296,12 @@ class SessionsStore {
         // A hydrated matching row would keep backing activeSession as a
         // ghost of the deleted session; drop it and keep the pagination
         // total consistent, mirroring deleteSession.
-        const before = this.sessions.length;
+        const droppedRows = this.sessions.filter((s) => s.id === id);
         this.sessions = this.sessions.filter((s) => s.id !== id);
-        const removed = before - this.sessions.length;
-        if (removed > 0) {
-          this.total = Math.max(0, this.total - removed);
-        }
+        this.total = Math.max(
+          0,
+          this.total - this.countDroppedRoots(droppedRows),
+        );
       }
     } finally {
       this.activeDetailRead.finish(signal);
@@ -1644,12 +1675,12 @@ class SessionsStore {
     // Tombstone the explicit delete so an index load that was in flight
     // (and its failure-restore path) cannot resurrect the row.
     this.bumpDetailCommit(id, true, Number.POSITIVE_INFINITY);
-    const before = this.sessions.length;
+    const droppedRows = this.sessions.filter((s) => s.id === id);
     this.sessions = this.sessions.filter((s) => s.id !== id);
-    const removed = before - this.sessions.length;
-    if (removed > 0) {
-      this.total = Math.max(0, this.total - removed);
-    }
+    this.total = Math.max(
+      0,
+      this.total - this.countDroppedRoots(droppedRows),
+    );
     if (this.activeSessionId === id) {
       this.setActiveSession(null);
     }

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -355,8 +355,12 @@ class SessionsStore {
   // Single coordinator for every read that commits to activeSessionDetail
   // (navigation and watcher refresh): the newest read cancels older in-flight
   // ones, so a stale response resolving late can never overwrite fresher
-  // cached detail.
+  // cached detail. The generation counter extends that freshness to sidebar
+  // hydration, which shares its fetches with non-active rows and so cannot
+  // claim the coordinator itself: a hydration only touches active-session
+  // state when no read began and no rename committed since it was issued.
   private activeDetailRead = new LatestRead();
+  private activeDetailGeneration = 0;
   private childSessionsRead = new LatestRead();
 
   private liveRefreshStarted = false;
@@ -604,6 +608,7 @@ class SessionsStore {
 
       const promise = this.runSidebarHydration(async () => {
         if (signal.aborted) return;
+        const detailGeneration = this.activeDetailGeneration;
         try {
           configureGeneratedClient();
           const hydrated = await callGenerated(
@@ -612,14 +617,19 @@ class SessionsStore {
           ) as unknown as Session;
           // A superseded hydration still carries valid detail for the active
           // session, so let it back the breadcrumb when the new index excludes
-          // the row — but only fill an empty cache. A stale-version response
-          // must never overwrite detail already resolved for this session by a
-          // newer request; the fresh path below (mergeHydratedSession) owns
-          // updates once the version check passes.
+          // the row — but only fill an empty cache, and only when no newer
+          // navigation/refresh/rename touched active-detail state while this
+          // response was in flight. A stale response must never overwrite
+          // detail already resolved for this session by a newer request; the
+          // fresh path below (mergeHydratedSession) owns updates once the
+          // version check passes.
+          const detailFresh =
+            detailGeneration === this.activeDetailGeneration;
           if (
             hydrated.id === this.activeSessionId &&
             !hydrated.is_index_only &&
-            this.activeSessionDetail?.id !== this.activeSessionId
+            this.activeSessionDetail?.id !== this.activeSessionId &&
+            detailFresh
           ) {
             this.activeSessionDetail = hydrated;
           }
@@ -627,6 +637,12 @@ class SessionsStore {
             version !== this.sidebarIndexVersion ||
             epoch !== (this.sidebarHydrationEpochByVersion.get(version) ?? 0)
           ) {
+            return;
+          }
+          // Same-version guard for the active row: a hydration issued before
+          // a newer refresh resolved must not clobber the row or the cache
+          // with its older snapshot.
+          if (hydrated.id === this.activeSessionId && !detailFresh) {
             return;
           }
           cache.set(id, hydrated);
@@ -840,6 +856,19 @@ class SessionsStore {
     return this.machinesPromise;
   }
 
+  // The generation advances only when something newer commits to (or starts
+  // a read for) active-detail state — never on plain cancellation, so a
+  // hydration joined at selection time can still seed an empty cache.
+  private beginActiveDetailRead(): AbortSignal {
+    this.activeDetailGeneration++;
+    return this.activeDetailRead.begin();
+  }
+
+  private cancelActiveDetailRead(): void {
+    this.activeDetailGeneration++;
+    this.activeDetailRead.cancel();
+  }
+
   private setActiveSession(id: string | null) {
     if (id === this.activeSessionId) return;
     this.activeDetailRead.cancel();
@@ -883,7 +912,7 @@ class SessionsStore {
       await this.hydrateSelectedIndexOnlySession(id);
       return;
     }
-    const signal = this.activeDetailRead.begin();
+    const signal = this.beginActiveDetailRead();
     try {
       configureGeneratedClient();
       const session = await callGenerated(
@@ -922,7 +951,7 @@ class SessionsStore {
   async refreshActiveSession() {
     const id = this.activeSessionId;
     if (!id) return;
-    const signal = this.activeDetailRead.begin();
+    const signal = this.beginActiveDetailRead();
     try {
       configureGeneratedClient();
       const session = await callGenerated(
@@ -958,6 +987,7 @@ class SessionsStore {
         this.activeSessionId === id &&
         this.activeDetailRead.isCurrent(signal)
       ) {
+        this.activeDetailGeneration++;
         this.activeSessionDetail = null;
       }
     } finally {
@@ -1461,7 +1491,7 @@ class SessionsStore {
     // Drop any in-flight active-detail read first: it was issued before the
     // rename and would revert the name with a pre-rename snapshot.
     if (this.activeSessionDetail?.id === id) {
-      this.activeDetailRead.cancel();
+      this.cancelActiveDetailRead();
       this.activeSessionDetail = applyRename(this.activeSessionDetail);
     }
   }

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -1486,12 +1486,17 @@ class SessionsStore {
     if (idx !== -1) {
       this.sessions[idx] = applyRename(this.sessions[idx]!);
     }
+    // Renaming the active session invalidates any in-flight active-detail
+    // read or hydration: both were issued before the rename and would revert
+    // the name with a pre-rename snapshot. Cancel and advance the generation
+    // even when the detail cache is empty (index-only row with hydration in
+    // flight) — the cache-population paths all check the generation.
+    if (this.activeSessionId === id) {
+      this.cancelActiveDetailRead();
+    }
     // The active session may be backed only by the detail cache (absent from
     // the sidebar list); keep its name in sync so the breadcrumb updates too.
-    // Drop any in-flight active-detail read first: it was issued before the
-    // rename and would revert the name with a pre-rename snapshot.
     if (this.activeSessionDetail?.id === id) {
-      this.cancelActiveDetailRead();
       this.activeSessionDetail = applyRename(this.activeSessionDetail);
     }
   }

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -772,9 +772,10 @@ class SessionsStore {
           }
           cache.set(id, hydrated);
           this.mergeHydratedSession(hydrated);
-          if (hydrated.id === this.activeSessionId) {
-            this.bumpDetailCommit(id, false, issuedAtIndexOrdinal, hydrated);
-          }
+          // Record the commit for every merged row, active or not: the
+          // session may be selected before an older index request resolves,
+          // and the publish-side supersedes check needs the ordinal.
+          this.bumpDetailCommit(id, false, issuedAtIndexOrdinal, hydrated);
         } catch {
           // Visible hydration is best-effort; the skinny row remains usable.
         } finally {
@@ -1157,6 +1158,31 @@ class SessionsStore {
     return removed;
   }
 
+  // Remove a deleted session and its known local descendants, tombstoning
+  // each so stale responses cannot reinsert them, and decrement the root
+  // total once per removed group. The caller records the ancestor's own
+  // deletion commit.
+  private removeSessionSubtree(id: string): ReadonlySet<string> {
+    const subtree = this.expandTombstoned(
+      this.sessions,
+      (rid) => rid === id,
+    );
+    subtree.add(id);
+    for (const rid of subtree) {
+      if (rid !== id) {
+        this.bumpDetailCommit(rid, true, Number.POSITIVE_INFINITY);
+      }
+    }
+    const droppedRows = this.sessions.filter((s) => subtree.has(s.id));
+    const presentIds = new Set(this.sessions.map((s) => s.id));
+    this.sessions = this.sessions.filter((s) => !subtree.has(s.id));
+    this.total = Math.max(
+      0,
+      this.total - this.countDroppedRoots(droppedRows, presentIds),
+    );
+    return subtree;
+  }
+
   private snapshotDetailCommits(): ReadonlyMap<string, number> {
     return new Map(
       [...this.activeDetailCommitBySession].map(
@@ -1238,13 +1264,7 @@ class SessionsStore {
     if (commit.deleted) {
       // Honor the deletion tombstone instead of letting the stale index
       // resurrect the row (mirrors refreshActiveSession's 404 removal).
-      const droppedRows = this.sessions.filter((s) => s.id === id);
-      const presentIds = new Set(this.sessions.map((s) => s.id));
-      this.sessions = this.sessions.filter((s) => s.id !== id);
-      this.total = Math.max(
-        0,
-        this.total - this.countDroppedRoots(droppedRows, presentIds),
-      );
+      this.removeSessionSubtree(id);
       return;
     }
     this.restoreActiveRowFromDetailCache(id);
@@ -1438,13 +1458,7 @@ class SessionsStore {
         // A hydrated matching row would keep backing activeSession as a
         // ghost of the deleted session; drop it and keep the pagination
         // total consistent, mirroring deleteSession.
-        const droppedRows = this.sessions.filter((s) => s.id === id);
-        const presentIds = new Set(this.sessions.map((s) => s.id));
-        this.sessions = this.sessions.filter((s) => s.id !== id);
-        this.total = Math.max(
-          0,
-          this.total - this.countDroppedRoots(droppedRows, presentIds),
-        );
+        this.removeSessionSubtree(id);
       }
     } finally {
       this.activeDetailRead.finish(signal);
@@ -1819,26 +1833,10 @@ class SessionsStore {
     // (and its failure-restore path) cannot resurrect the row.
     this.bumpDetailCommit(id, true, Number.POSITIVE_INFINITY);
     // The backend removes the whole subtree from sidebar queries; mirror it
-    // locally, tombstoning known descendants so stale responses cannot
-    // reinsert them either.
-    const subtree = this.expandTombstoned(
-      this.sessions,
-      (rid) => rid === id,
-    );
-    subtree.add(id);
-    for (const rid of subtree) {
-      if (rid !== id) {
-        this.bumpDetailCommit(rid, true, Number.POSITIVE_INFINITY);
-      }
-    }
-    const droppedRows = this.sessions.filter((s) => subtree.has(s.id));
-    const presentIds = new Set(this.sessions.map((s) => s.id));
-    this.sessions = this.sessions.filter((s) => !subtree.has(s.id));
-    this.total = Math.max(
-      0,
-      this.total - this.countDroppedRoots(droppedRows, presentIds),
-    );
-    if (this.activeSessionId === id) {
+    // locally so stale responses cannot reinsert descendants either.
+    const removed = this.removeSessionSubtree(id);
+    // The active session may be a descendant removed with its ancestor.
+    if (this.activeSessionId !== null && removed.has(this.activeSessionId)) {
       this.setActiveSession(null);
     }
     this.addRecentlyDeleted([id]);
@@ -1871,7 +1869,7 @@ class SessionsStore {
       0,
       this.total - this.countDroppedRoots(droppedRows, presentIds),
     );
-    if (this.activeSessionId && idSet.has(this.activeSessionId)) {
+    if (this.activeSessionId && subtree.has(this.activeSessionId)) {
       this.setActiveSession(null);
     }
     this.addRecentlyDeleted(ids);

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -385,11 +385,10 @@ class SessionsStore {
       issuedAtIndexOrdinal: number;
       committedAtTick: number;
       // For deleted commits: whether the tombstone actually removed a
-      // sidebar row, and whether that row counted as a root group. Revival
-      // restores only what was removed — a cache-only session excluded by
-      // the filter must not be injected into the list.
+      // sidebar row. Revival restores a row only if one was removed — a
+      // cache-only session excluded by the filter must not be injected
+      // into the list. Root status is recomputed at append time.
       removedRow: boolean;
-      removedRoot: boolean;
     }
   >();
   // Generations are globally unique (not per-id counters) so pruning an
@@ -779,10 +778,14 @@ class SessionsStore {
           const detailFresh =
             detailCommitGeneration === this.detailCommitGeneration(id) ||
             (latestCommit?.issuedAtIndexOrdinal ?? 0) < issuedAtIndexOrdinal;
+          // Commit for the active session even over a populated cache: the
+          // reconciled response carries any newer index-owned fields, and
+          // when a reload has excluded the row this is the only update the
+          // off-list session will get (the version check below discards the
+          // row merge, and no hydration retries an absent row).
           if (
             hydrated.id === this.activeSessionId &&
             !hydrated.is_index_only &&
-            this.activeSessionDetail?.id !== this.activeSessionId &&
             detailFresh
           ) {
             this.activeSessionDetail = hydrated;
@@ -1071,7 +1074,6 @@ class SessionsStore {
       issuedAtIndexOrdinal,
       committedAtTick: this.requestClock,
       removedRow: false,
-      removedRoot: false,
     });
     if (deleted) {
       this.committedDetailByRow.delete(id);
@@ -1100,8 +1102,15 @@ class SessionsStore {
       snapshot !== undefined &&
       !this.sessions.some((row) => row.id === id)
     ) {
+      const presentIds = new Set(this.sessions.map((row) => row.id));
       this.sessions = [...this.sessions, { ...snapshot }];
-      if (previous.removedRoot) {
+      // Root status is judged against the CURRENT rows: a revived
+      // descendant whose parent is still absent is a promoted orphan root
+      // now, whatever it was at deletion time.
+      if (
+        !snapshot.parent_session_id ||
+        !presentIds.has(snapshot.parent_session_id)
+      ) {
         this.total += 1;
       }
       this.scheduleIndexRefresh();
@@ -1258,8 +1267,6 @@ class SessionsStore {
       const commit = this.activeDetailCommitBySession.get(row.id);
       if (commit?.deleted) {
         commit.removedRow = true;
-        commit.removedRoot =
-          !row.parent_session_id || !presentIds.has(row.parent_session_id);
       }
     }
     return subtree;

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -660,6 +660,20 @@ class SessionsStore {
           row: session,
         });
       }
+      // A full publish issued after a read-derived tombstone that excludes
+      // the id is authoritative for the current filters: revival must not
+      // append the row back into a list that no longer contains it.
+      for (const [cid, commit] of this.activeDetailCommitBySession) {
+        if (
+          commit.deleted &&
+          commit.removedRow &&
+          Number.isFinite(commit.issuedAtIndexOrdinal) &&
+          commit.issuedAtIndexOrdinal < requestOrdinal &&
+          !incomingIds.has(cid)
+        ) {
+          commit.removedRow = false;
+        }
+      }
       this.syncActiveSessionAfterIndexCommit(detailCommits, requestOrdinal);
       this.pruneReconciliationState();
     } catch {
@@ -795,6 +809,14 @@ class SessionsStore {
             version !== this.sidebarIndexVersion ||
             epoch !== (this.sidebarHydrationEpochByVersion.get(version) ?? 0)
           ) {
+            // The row set moved on, but a fresh response for the ACTIVE
+            // session still outranks whatever the re-listed row carries;
+            // merge it, or the getter (which prefers a hydrated row over
+            // the cache) shows the older data and nothing re-hydrates a
+            // non-index-only row.
+            if (hydrated.id === this.activeSessionId && detailFresh) {
+              this.mergeHydratedSession(hydrated);
+            }
             return;
           }
           // A hydration issued before a newer commit resolved must not

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -355,12 +355,16 @@ class SessionsStore {
   // Single coordinator for every read that commits to activeSessionDetail
   // (navigation and watcher refresh): the newest read cancels older in-flight
   // ones, so a stale response resolving late can never overwrite fresher
-  // cached detail. The generation counter extends that freshness to sidebar
+  // cached detail. The generation counters extend that freshness to sidebar
   // hydration, which shares its fetches with non-active rows and so cannot
   // claim the coordinator itself: a hydration only touches active-session
-  // state when no read began and no rename committed since it was issued.
+  // state when no read began and no rename committed for that same session
+  // since it was issued. Freshness is tracked per session id — a read for
+  // one session must not stale an in-flight hydration of another session
+  // that a later selection may join. Entries are monotonic and never
+  // removed: resetting one could make a stale capture compare equal again.
   private activeDetailRead = new LatestRead();
-  private activeDetailGeneration = 0;
+  private activeDetailGenerationBySession = new Map<string, number>();
   private childSessionsRead = new LatestRead();
 
   private liveRefreshStarted = false;
@@ -514,7 +518,7 @@ class SessionsStore {
   ) {
     const version = ++this.loadVersion;
     const indexVersion = this.sidebarIndexVersion + 1;
-    const detailGeneration = this.activeDetailGeneration;
+    const detailGenerations = this.snapshotDetailGenerations();
     // Keep the existing list visible during reloads, but mark
     // loading=true so large filter expansions expose that more
     // pages are still being fetched after page 1 is published.
@@ -550,11 +554,12 @@ class SessionsStore {
       // An included active row may have absorbed index refreshes (renames,
       // counts) that the detail cache never saw; resync it so a later reload
       // that excludes the row doesn't revert the breadcrumb to stale fields.
-      // Skip when a navigation/refresh/rename committed while this index was
-      // in flight — the cache is then fresher than the merged row.
+      // Skip when a navigation/refresh/rename committed for the now-active
+      // session while this index was in flight — the cache is then fresher
+      // than the merged row.
       if (
         this.activeSessionId !== null &&
-        detailGeneration === this.activeDetailGeneration
+        this.detailGenerationUnchanged(detailGenerations, this.activeSessionId)
       ) {
         this.cacheActiveSessionDetailFromList(this.activeSessionId);
       }
@@ -616,7 +621,7 @@ class SessionsStore {
 
       const promise = this.runSidebarHydration(async () => {
         if (signal.aborted) return;
-        const detailGeneration = this.activeDetailGeneration;
+        const detailGeneration = this.detailGeneration(id);
         try {
           configureGeneratedClient();
           const hydrated = await callGenerated(
@@ -626,13 +631,14 @@ class SessionsStore {
           // A superseded hydration still carries valid detail for the active
           // session, so let it back the breadcrumb when the new index excludes
           // the row — but only fill an empty cache, and only when no newer
-          // navigation/refresh/rename touched active-detail state while this
-          // response was in flight. A stale response must never overwrite
-          // detail already resolved for this session by a newer request; the
-          // fresh path below (mergeHydratedSession) owns updates once the
-          // version check passes.
+          // navigation/refresh/rename touched THIS session's active-detail
+          // state while this response was in flight (another session's read
+          // says nothing about this one). A stale response must never
+          // overwrite detail already resolved for this session by a newer
+          // request; the fresh path below (mergeHydratedSession) owns updates
+          // once the version check passes.
           const detailFresh =
-            detailGeneration === this.activeDetailGeneration;
+            detailGeneration === this.detailGeneration(id);
           if (
             hydrated.id === this.activeSessionId &&
             !hydrated.is_index_only &&
@@ -715,7 +721,7 @@ class SessionsStore {
   async loadMore() {
     if (!this.nextCursor || this.loading) return;
     const version = ++this.loadVersion;
-    const detailGeneration = this.activeDetailGeneration;
+    const detailGenerations = this.snapshotDetailGenerations();
     const signal = this.routeSignal();
     this.loading = true;
     try {
@@ -748,7 +754,7 @@ class SessionsStore {
       // never saw; resync it (same reasoning as loadSidebarPage).
       if (
         this.activeSessionId !== null &&
-        detailGeneration === this.activeDetailGeneration
+        this.detailGenerationUnchanged(detailGenerations, this.activeSessionId)
       ) {
         this.cacheActiveSessionDetailFromList(this.activeSessionId);
       }
@@ -861,16 +867,36 @@ class SessionsStore {
     return this.machinesPromise;
   }
 
-  // The generation advances only when something newer commits to (or starts
-  // a read for) active-detail state — never on plain cancellation, so a
-  // hydration joined at selection time can still seed an empty cache.
-  private beginActiveDetailRead(): AbortSignal {
-    this.activeDetailGeneration++;
+  private detailGeneration(id: string): number {
+    return this.activeDetailGenerationBySession.get(id) ?? 0;
+  }
+
+  private bumpDetailGeneration(id: string): void {
+    this.activeDetailGenerationBySession.set(id, this.detailGeneration(id) + 1);
+  }
+
+  private snapshotDetailGenerations(): ReadonlyMap<string, number> {
+    return new Map(this.activeDetailGenerationBySession);
+  }
+
+  private detailGenerationUnchanged(
+    snapshot: ReadonlyMap<string, number>,
+    id: string,
+  ): boolean {
+    return this.detailGeneration(id) === (snapshot.get(id) ?? 0);
+  }
+
+  // A session's generation advances only when something newer commits to (or
+  // starts a read for) that session's active-detail state — never on plain
+  // cancellation, so a hydration joined at selection time can still seed an
+  // empty cache.
+  private beginActiveDetailRead(id: string): AbortSignal {
+    this.bumpDetailGeneration(id);
     return this.activeDetailRead.begin();
   }
 
-  private cancelActiveDetailRead(): void {
-    this.activeDetailGeneration++;
+  private cancelActiveDetailRead(id: string): void {
+    this.bumpDetailGeneration(id);
     this.activeDetailRead.cancel();
   }
 
@@ -935,7 +961,7 @@ class SessionsStore {
       await this.hydrateSelectedIndexOnlySession(id);
       return;
     }
-    const signal = this.beginActiveDetailRead();
+    const signal = this.beginActiveDetailRead(id);
     const entry = { id, promise: Promise.resolve() };
     entry.promise = (async () => {
       try {
@@ -982,7 +1008,7 @@ class SessionsStore {
   async refreshActiveSession() {
     const id = this.activeSessionId;
     if (!id) return;
-    const signal = this.beginActiveDetailRead();
+    const signal = this.beginActiveDetailRead(id);
     try {
       configureGeneratedClient();
       const session = await callGenerated(
@@ -1018,7 +1044,7 @@ class SessionsStore {
         this.activeSessionId === id &&
         this.activeDetailRead.isCurrent(signal)
       ) {
-        this.activeDetailGeneration++;
+        this.bumpDetailGeneration(id);
         this.activeSessionDetail = null;
         // A hydrated matching row would keep backing activeSession as a
         // ghost of the deleted session; drop it and keep the pagination
@@ -1543,16 +1569,16 @@ class SessionsStore {
     }
     // Renaming the active session invalidates any in-flight active-detail
     // read or hydration: both were issued before the rename and would revert
-    // the name with a pre-rename snapshot. Cancel and advance the generation
-    // even when the detail cache is empty (index-only row with hydration in
-    // flight) — the cache-population paths all check the generation.
+    // the name with a pre-rename snapshot. Cancel and advance the session's
+    // generation even when the detail cache is empty (index-only row with
+    // hydration in flight) — the cache-population paths all check it.
     // The rename response is itself a full post-rename snapshot (the endpoint
     // reads the session back), so commit it as the active detail: an
     // index-only or out-of-list active session whose pending read was just
     // cancelled has nothing else to back the breadcrumb until the next
     // watcher refresh.
     if (this.activeSessionId === id) {
-      this.cancelActiveDetailRead();
+      this.cancelActiveDetailRead(id);
       const base =
         this.activeSessionDetail?.id === id
           ? this.activeSessionDetail

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -526,18 +526,19 @@ class SessionsStore {
       this.sessions = index.sessions.map((row) =>
         sidebarIndexRowToSession(row, existing.get(row.id))
       );
-      this.sidebarIndexIds = new Set(index.sessions.map((row) => row.id));
-      // Keep the active session's hydrated row when the new index
-      // page doesn't contain it: navigateToSession appends deep-linked,
-      // cross-page, and subagent targets, and dropping them here would
-      // revert activeSession to undefined mid-view. It stays outside
-      // sidebarIndexIds, so later pages keep it at the tail until
-      // pagination reaches its real position.
+      // Preserve the open session when the (filtered) index omits it, e.g. one
+      // opened from search that falls outside the current sidebar filters.
+      // navigateToSession appended it to the list; dropping it on reload leaves
+      // activeSession undefined and strips the breadcrumb's project, name, and
+      // badges. Keep the previously resolved row so the detail view stays intact.
       const activeId = this.activeSessionId;
-      if (activeId && !this.sessions.some((s) => s.id === activeId)) {
-        const kept = existing.get(activeId);
-        if (kept && !kept.is_index_only) {
-          this.sessions = [...this.sessions, kept];
+      if (
+        activeId !== null &&
+        !index.sessions.some((row) => row.id === activeId)
+      ) {
+        const preserved = existing.get(activeId);
+        if (preserved && !preserved.is_index_only) {
+          this.sessions = [...this.sessions, preserved];
         }
       }
       this.nextCursor = index.next_cursor ?? null;

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -42,6 +42,11 @@ type LoadOptions = {
 
 const SESSION_PAGE_SIZE = 500;
 const SIDEBAR_HYDRATION_CONCURRENCY = 6;
+
+type DetailFreshnessSnapshot = {
+  reads: ReadonlyMap<string, number>;
+  commits: ReadonlyMap<string, number>;
+};
 const LIVE_REFRESH_DEBOUNCE_MS = 300;
 const SAFETY_NET_REFRESH_MS = 5 * 60 * 1000;
 const RECENTLY_DELETED_TTL_MS = 10_000;
@@ -363,8 +368,20 @@ class SessionsStore {
   // one session must not stale an in-flight hydration of another session
   // that a later selection may join. Entries are monotonic and never
   // removed: resetting one could make a stale capture compare equal again.
+  //
+  // Two tiers per session: the read generation advances when a read merely
+  // BEGINS (or a rename/404 invalidates in-flight reads) and guards against
+  // stale writes into the cache; the commit generation advances only when
+  // fresher state actually COMMITS (navigation/refresh resolves, a rename
+  // commits, a 404 commits a deletion). Only a commit proves the cache — or
+  // a deletion — is fresher than a concurrently loaded index; a read that
+  // began and failed proves nothing.
   private activeDetailRead = new LatestRead();
   private activeDetailGenerationBySession = new Map<string, number>();
+  private activeDetailCommitBySession = new Map<
+    string,
+    { generation: number; deleted: boolean }
+  >();
   private childSessionsRead = new LatestRead();
 
   private liveRefreshStarted = false;
@@ -518,7 +535,7 @@ class SessionsStore {
   ) {
     const version = ++this.loadVersion;
     const indexVersion = this.sidebarIndexVersion + 1;
-    const detailGenerations = this.snapshotDetailGenerations();
+    const detailFreshness = this.snapshotDetailFreshness();
     // Keep the existing list visible during reloads, but mark
     // loading=true so large filter expansions expose that more
     // pages are still being fetched after page 1 is published.
@@ -551,7 +568,7 @@ class SessionsStore {
       );
       this.nextCursor = index.next_cursor ?? null;
       this.total = index.total;
-      this.syncActiveSessionAfterIndexCommit(detailGenerations);
+      this.syncActiveSessionAfterIndexCommit(detailFreshness);
     } catch {
       // Restore previous state so a transient failure
       // doesn't wipe the visible session list.
@@ -710,7 +727,7 @@ class SessionsStore {
   async loadMore() {
     if (!this.nextCursor || this.loading) return;
     const version = ++this.loadVersion;
-    const detailGenerations = this.snapshotDetailGenerations();
+    const detailFreshness = this.snapshotDetailFreshness();
     const signal = this.routeSignal();
     this.loading = true;
     try {
@@ -739,7 +756,7 @@ class SessionsStore {
       ];
       this.nextCursor = index.next_cursor ?? null;
       this.total = index.total;
-      this.syncActiveSessionAfterIndexCommit(detailGenerations);
+      this.syncActiveSessionAfterIndexCommit(detailFreshness);
     } catch (error) {
       if (signal.aborted || isAbortError(error)) return;
       throw error;
@@ -857,21 +874,29 @@ class SessionsStore {
     this.activeDetailGenerationBySession.set(id, this.detailGeneration(id) + 1);
   }
 
-  private snapshotDetailGenerations(): ReadonlyMap<string, number> {
-    return new Map(this.activeDetailGenerationBySession);
+  private bumpDetailCommit(id: string, deleted: boolean): void {
+    const current = this.activeDetailCommitBySession.get(id);
+    this.activeDetailCommitBySession.set(id, {
+      generation: (current?.generation ?? 0) + 1,
+      deleted,
+    });
   }
 
-  private detailGenerationUnchanged(
-    snapshot: ReadonlyMap<string, number>,
-    id: string,
-  ): boolean {
-    return this.detailGeneration(id) === (snapshot.get(id) ?? 0);
+  private snapshotDetailFreshness(): DetailFreshnessSnapshot {
+    return {
+      reads: new Map(this.activeDetailGenerationBySession),
+      commits: new Map(
+        [...this.activeDetailCommitBySession].map(
+          ([id, commit]) => [id, commit.generation],
+        ),
+      ),
+    };
   }
 
-  // A session's generation advances only when something newer commits to (or
-  // starts a read for) that session's active-detail state — never on plain
-  // cancellation, so a hydration joined at selection time can still seed an
-  // empty cache.
+  // A session's read generation advances only when something newer starts a
+  // read for (or commits to) that session's active-detail state — never on
+  // plain cancellation, so a hydration joined at selection time can still
+  // seed an empty cache.
   private beginActiveDetailRead(id: string): AbortSignal {
     this.bumpDetailGeneration(id);
     return this.activeDetailRead.begin();
@@ -920,23 +945,42 @@ class SessionsStore {
 
   // After an index commit, reconcile the active session's sidebar row and
   // detail cache in whichever direction is fresher. When no active-detail
-  // read/rename committed for the now-active session while the index was in
-  // flight, the merged row may have absorbed index refreshes (renames,
-  // counts) the cache never saw — resync the cache from it so a later reload
-  // that excludes the row doesn't revert the breadcrumb to stale fields.
-  // When one did commit, the cache is fresher than the merged row: push it
-  // back into the row so the sidebar and the breadcrumb display the
-  // committed state instead of the older index snapshot.
+  // read began and no rename/deletion committed for the now-active session
+  // while the index was in flight, the merged row may have absorbed index
+  // refreshes (renames, counts) the cache never saw — resync the cache from
+  // it so a later reload that excludes the row doesn't revert the breadcrumb
+  // to stale fields. When something newer actually COMMITTED mid-flight, the
+  // committed state wins over the older index snapshot: a deletion removes
+  // the re-listed row (the index predates the 404), and committed detail
+  // replaces it. A read that merely began — it may still be in flight or
+  // have failed — proves nothing about the cache's freshness: leave the row
+  // and the cache alone, and let the read commit through
+  // mergeHydratedSession if and when it resolves.
   private syncActiveSessionAfterIndexCommit(
-    snapshot: ReadonlyMap<string, number>,
+    snapshot: DetailFreshnessSnapshot,
   ) {
     const id = this.activeSessionId;
     if (id === null) return;
-    if (this.detailGenerationUnchanged(snapshot, id)) {
+    if (this.detailGeneration(id) === (snapshot.reads.get(id) ?? 0)) {
       this.cacheActiveSessionDetailFromList(id);
-    } else {
-      this.restoreActiveRowFromDetailCache(id);
+      return;
     }
+    const commit = this.activeDetailCommitBySession.get(id);
+    if (!commit || commit.generation === (snapshot.commits.get(id) ?? 0)) {
+      return;
+    }
+    if (commit.deleted) {
+      // Honor the deletion tombstone instead of letting the stale index
+      // resurrect the row (mirrors refreshActiveSession's 404 removal).
+      const before = this.sessions.length;
+      this.sessions = this.sessions.filter((s) => s.id !== id);
+      const removed = before - this.sessions.length;
+      if (removed > 0) {
+        this.total = Math.max(0, this.total - removed);
+      }
+      return;
+    }
+    this.restoreActiveRowFromDetailCache(id);
   }
 
   // Inverse of cacheActiveSessionDetailFromList: the cached detail is a full
@@ -998,6 +1042,7 @@ class SessionsStore {
           } else {
             this.activeSessionDetail = session;
           }
+          this.bumpDetailCommit(id, false);
         }
       } catch {
         // Session not found — selection stands without metadata
@@ -1050,6 +1095,7 @@ class SessionsStore {
         // breadcrumb.
         this.activeSessionDetail = session;
       }
+      this.bumpDetailCommit(id, false);
     } catch (e) {
       // The session may have been deleted, locally or on another machine. On
       // a definitive not-found drop the cached detail so the breadcrumb
@@ -1063,6 +1109,7 @@ class SessionsStore {
         this.activeDetailRead.isCurrent(signal)
       ) {
         this.bumpDetailGeneration(id);
+        this.bumpDetailCommit(id, true);
         this.activeSessionDetail = null;
         // A hydrated matching row would keep backing activeSession as a
         // ghost of the deleted session; drop it and keep the pagination
@@ -1597,6 +1644,7 @@ class SessionsStore {
     // watcher refresh.
     if (this.activeSessionId === id) {
       this.cancelActiveDetailRead(id);
+      this.bumpDetailCommit(id, false);
       const base =
         this.activeSessionDetail?.id === id
           ? this.activeSessionDetail

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -514,6 +514,7 @@ class SessionsStore {
   ) {
     const version = ++this.loadVersion;
     const indexVersion = this.sidebarIndexVersion + 1;
+    const detailGeneration = this.activeDetailGeneration;
     // Keep the existing list visible during reloads, but mark
     // loading=true so large filter expansions expose that more
     // pages are still being fetched after page 1 is published.
@@ -546,6 +547,17 @@ class SessionsStore {
       );
       this.nextCursor = index.next_cursor ?? null;
       this.total = index.total;
+      // An included active row may have absorbed index refreshes (renames,
+      // counts) that the detail cache never saw; resync it so a later reload
+      // that excludes the row doesn't revert the breadcrumb to stale fields.
+      // Skip when a navigation/refresh/rename committed while this index was
+      // in flight — the cache is then fresher than the merged row.
+      if (
+        this.activeSessionId !== null &&
+        detailGeneration === this.activeDetailGeneration
+      ) {
+        this.cacheActiveSessionDetailFromList(this.activeSessionId);
+      }
     } catch {
       // Restore previous state so a transient failure
       // doesn't wipe the visible session list.
@@ -703,6 +715,7 @@ class SessionsStore {
   async loadMore() {
     if (!this.nextCursor || this.loading) return;
     const version = ++this.loadVersion;
+    const detailGeneration = this.activeDetailGeneration;
     const signal = this.routeSignal();
     this.loading = true;
     try {
@@ -731,6 +744,14 @@ class SessionsStore {
       ];
       this.nextCursor = index.next_cursor ?? null;
       this.total = index.total;
+      // A re-listed active row can carry index refreshes the detail cache
+      // never saw; resync it (same reasoning as loadSidebarPage).
+      if (
+        this.activeSessionId !== null &&
+        detailGeneration === this.activeDetailGeneration
+      ) {
+        this.cacheActiveSessionDetailFromList(this.activeSessionId);
+      }
     } catch (error) {
       if (signal.aborted || isAbortError(error)) return;
       throw error;

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -607,10 +607,17 @@ class SessionsStore {
             () => SessionsService.getApiV1SessionsId({ id }),
             signal,
           ) as unknown as Session;
-          // The active session's detail stays valid even if a concurrent
-          // reload superseded this hydration version: seed the cache first so
-          // the breadcrumb survives when the new index excludes the row.
-          if (hydrated.id === this.activeSessionId && !hydrated.is_index_only) {
+          // A superseded hydration still carries valid detail for the active
+          // session, so let it back the breadcrumb when the new index excludes
+          // the row — but only fill an empty cache. A stale-version response
+          // must never overwrite detail already resolved for this session by a
+          // newer request; the fresh path below (mergeHydratedSession) owns
+          // updates once the version check passes.
+          if (
+            hydrated.id === this.activeSessionId &&
+            !hydrated.is_index_only &&
+            this.activeSessionDetail?.id !== this.activeSessionId
+          ) {
             this.activeSessionDetail = hydrated;
           }
           if (
@@ -927,9 +934,12 @@ class SessionsStore {
       const idx = this.sessions.findIndex((s) => s.id === id);
       if (idx >= 0) {
         this.mergeHydratedSession(session);
-      } else if (this.activeSessionDetail?.id === id) {
-        // Active session is backed by the detail cache (not in the sidebar
-        // list); refresh the cache so metadata stays current.
+      } else {
+        // Active session is not in the sidebar list, so back it with the detail
+        // cache. Assign unconditionally (id is validated above): this both
+        // refreshes an existing cache and restores one left empty by a failed
+        // initial navigation or hydration, so watcher refreshes can recover the
+        // breadcrumb.
         this.activeSessionDetail = session;
       }
     } catch {

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -3,6 +3,9 @@ import {
   MetadataService,
   SessionsService,
 } from "../api/generated/index";
+// Imported from core rather than the index barrel so instanceof keeps the
+// real class identity in tests that mock "../api/generated/index".
+import { ApiError as GeneratedApiError } from "../api/generated/core/ApiError";
 import {
   callGenerated,
   configureGeneratedClient,
@@ -945,8 +948,19 @@ class SessionsStore {
         // breadcrumb.
         this.activeSessionDetail = session;
       }
-    } catch {
-      // Session may have been deleted
+    } catch (e) {
+      // The session may have been deleted, locally or on another machine. On
+      // a definitive not-found drop the cached detail so the breadcrumb
+      // empties instead of showing a ghost session; transient failures keep
+      // the cache and the next watcher refresh retries.
+      if (
+        e instanceof GeneratedApiError &&
+        e.status === 404 &&
+        this.activeSessionId === id &&
+        this.activeDetailRead.isCurrent(signal)
+      ) {
+        this.activeSessionDetail = null;
+      }
     } finally {
       this.activeDetailRead.finish(signal);
     }

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -1073,7 +1073,12 @@ class SessionsStore {
       deleted,
       issuedAtIndexOrdinal,
       committedAtTick: this.requestClock,
-      removedRow: false,
+      // A repeat 404 finds the row already gone: carry the removal record
+      // across consecutive deletion commits so revival still knows a row
+      // was removed. A live commit resets it.
+      removedRow: deleted && previous?.deleted === true
+        ? previous.removedRow
+        : false,
     });
     if (deleted) {
       this.committedDetailByRow.delete(id);

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -382,12 +382,17 @@ class SessionsStore {
   // already serializes them against each other.
   private indexRequestOrdinal = 0;
   // Commit-order counter for sidebar index requests, bumped when a loader
-  // publishes its rows. A detail response (navigation/refresh/hydration)
-  // resolving after an index committed mid-flight may predate that index's
-  // server snapshot: its detail-owned fields still apply, but index-owned
-  // fields (display_name, counts, timestamps) must not revert the committed
-  // row — reconcileDetailResponse keeps the row's index fields in that case.
+  // publishes its rows, plus a per-row stamp of the commit that last
+  // re-published each row. A detail response (navigation/refresh/hydration)
+  // resolving after an index commit that re-listed ITS row may predate that
+  // index's server snapshot: its detail-owned fields still apply, but
+  // index-owned fields (display_name, counts, timestamps) must not revert
+  // the committed row — reconcileDetailResponse keeps the row's index
+  // fields in that case. A commit that did not re-list the row (an
+  // unrelated loadMore page) says nothing about it, so the response still
+  // applies wholesale.
   private indexCommitOrdinal = 0;
+  private indexCommitByRow = new Map<string, number>();
   private childSessionsRead = new LatestRead();
 
   private liveRefreshStarted = false;
@@ -575,7 +580,10 @@ class SessionsStore {
       );
       this.nextCursor = index.next_cursor ?? null;
       this.total = index.total;
-      this.indexCommitOrdinal++;
+      const commitOrdinal = ++this.indexCommitOrdinal;
+      for (const row of index.sessions) {
+        this.indexCommitByRow.set(row.id, commitOrdinal);
+      }
       this.syncActiveSessionAfterIndexCommit(detailCommits);
     } catch {
       // Restore previous state so a transient failure
@@ -789,7 +797,10 @@ class SessionsStore {
       ];
       this.nextCursor = index.next_cursor ?? null;
       this.total = index.total;
-      this.indexCommitOrdinal++;
+      const commitOrdinal = ++this.indexCommitOrdinal;
+      for (const row of index.sessions) {
+        this.indexCommitByRow.set(row.id, commitOrdinal);
+      }
       this.syncActiveSessionAfterIndexCommit(detailCommits);
     } catch (error) {
       if (signal.aborted || isAbortError(error)) return;
@@ -922,7 +933,9 @@ class SessionsStore {
     session: Session,
     indexCommitsAtStart: number,
   ): Session {
-    if (indexCommitsAtStart === this.indexCommitOrdinal) return session;
+    if ((this.indexCommitByRow.get(id) ?? 0) <= indexCommitsAtStart) {
+      return session;
+    }
     const row = this.sessions.find((s) => s.id === id);
     if (!row) return session;
     return mergeIndexFieldsIntoDetail(row, session);
@@ -1101,16 +1114,22 @@ class SessionsStore {
     this.childSessions = new Map();
   }
 
-  async refreshActiveSession() {
+  async refreshActiveSession(): Promise<void> {
     const id = this.activeSessionId;
     if (!id) return;
     // Navigation and refresh issue the identical detail GET. Join a pending
     // same-session navigation instead of cancelling it to reissue the same
     // request: if this refresh then failed transiently, the cancelled
     // navigation could no longer fill the empty cache and nothing would
-    // retry until the next watcher event.
+    // retry until the next watcher event. The event that triggered this
+    // refresh may postdate the navigation's request, though, so chase with
+    // a fresh read once the navigation settles — it observes the post-event
+    // state (including a deletion), while a transient chase failure still
+    // leaves the navigation's committed result in place.
     if (this.navigateInFlight?.id === id) {
-      return this.navigateInFlight.promise;
+      await this.navigateInFlight.promise;
+      if (this.activeSessionId !== id) return;
+      return this.refreshActiveSession();
     }
     const signal = this.activeDetailRead.begin();
     const indexCommitsAtStart = this.indexCommitOrdinal;

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -410,7 +410,10 @@ class SessionsStore {
   // the row (an unrelated loadMore page), says nothing newer, so the
   // response applies wholesale. Together with the commit records above this
   // makes request-issue order the single freshness rule in both directions.
-  private indexCommitByRow = new Map<string, number>();
+  private indexCommitByRow = new Map<
+    string,
+    { ordinal: number; row: Session }
+  >();
   // True while activeSessionDetail is a fabricated rename snapshot (the
   // rename endpoint returns the DB-session shape without detail-only
   // fields). Cleared by any read-derived commit for the active session;
@@ -600,16 +603,16 @@ class SessionsStore {
         session,
       ]));
       // A deletion that committed while this index was in flight supersedes
-      // the index's older server snapshot: drop tombstoned rows instead of
-      // reinserting them.
-      const dropped = index.sessions.filter((row) =>
-        this.deletedSinceSnapshot(row.id, detailCommits)
+      // the index's older server snapshot: drop tombstoned rows — and their
+      // descendants, whose groups the backend removes with them — instead
+      // of reinserting them.
+      const tombstoned = this.expandTombstoned(index.sessions, (rid) =>
+        this.deletedSinceSnapshot(rid, detailCommits)
       );
-      const rows = index.sessions.filter(
-        (row) => !this.deletedSinceSnapshot(row.id, detailCommits),
-      );
+      const dropped = index.sessions.filter((row) => tombstoned.has(row.id));
+      const rows = index.sessions.filter((row) => !tombstoned.has(row.id));
       const incomingIds = new Set(index.sessions.map((row) => row.id));
-      this.sessions = rows.map((row) => {
+      const published = rows.map((row) => {
         const prior = existing.get(row.id);
         // A rename/read that committed for this row after this index was
         // requested outranks the index's snapshot — keep the prior row, or
@@ -621,13 +624,17 @@ class SessionsStore {
         }
         return sidebarIndexRowToSession(row, prior);
       });
+      this.sessions = published;
       this.nextCursor = index.next_cursor ?? null;
       this.total = Math.max(
         0,
         index.total - this.countDroppedRoots(dropped, incomingIds),
       );
-      for (const row of rows) {
-        this.indexCommitByRow.set(row.id, requestOrdinal);
+      for (const session of published) {
+        this.indexCommitByRow.set(session.id, {
+          ordinal: requestOrdinal,
+          row: session,
+        });
       }
       this.syncActiveSessionAfterIndexCommit(detailCommits, requestOrdinal);
     } catch {
@@ -637,12 +644,16 @@ class SessionsStore {
       // removed its row from the live list, and the pre-load snapshot still
       // contains it.
       if (this.loadVersion === version) {
+        const restoredTombstones = this.expandTombstoned(
+          prev.sessions,
+          (rid) => this.deletedSinceSnapshot(rid, detailCommits),
+        );
         const droppedRows = prev.sessions.filter((s) =>
-          this.deletedSinceSnapshot(s.id, detailCommits)
+          restoredTombstones.has(s.id)
         );
         const prevIds = new Set(prev.sessions.map((s) => s.id));
         this.sessions = prev.sessions.filter(
-          (s) => !this.deletedSinceSnapshot(s.id, detailCommits),
+          (s) => !restoredTombstones.has(s.id),
         );
         this.nextCursor = prev.nextCursor;
         this.total = Math.max(
@@ -849,28 +860,29 @@ class SessionsStore {
       const existingById = new Map(
         this.sessions.map((session) => [session.id, session]),
       );
-      // Same deletion-tombstone guard as loadSidebarPage for appended pages.
-      const dropped = index.sessions.filter((row) =>
-        this.deletedSinceSnapshot(row.id, detailCommits)
+      // Same deletion-tombstone guard as loadSidebarPage for appended
+      // pages, including descendants of tombstoned rows.
+      const tombstoned = this.expandTombstoned(index.sessions, (rid) =>
+        this.deletedSinceSnapshot(rid, detailCommits)
       );
-      const rows = index.sessions.filter(
-        (row) => !this.deletedSinceSnapshot(row.id, detailCommits),
-      );
+      const dropped = index.sessions.filter((row) => tombstoned.has(row.id));
+      const rows = index.sessions.filter((row) => !tombstoned.has(row.id));
       const incomingIds = new Set(index.sessions.map((row) => row.id));
       const pageIds = new Set(rows.map((row) => row.id));
+      const appended = rows.map((row) => {
+        const prior = existingById.get(row.id);
+        if (
+          this.commitSupersedesIndex(row.id, detailCommits, requestOrdinal)
+        ) {
+          if (prior) return prior;
+          const committed = this.committedDetailByRow.get(row.id);
+          if (committed) return { ...committed };
+        }
+        return sidebarIndexRowToSession(row, prior);
+      });
       this.sessions = [
         ...this.sessions.filter((s) => !pageIds.has(s.id)),
-        ...rows.map((row) => {
-          const prior = existingById.get(row.id);
-          if (
-            this.commitSupersedesIndex(row.id, detailCommits, requestOrdinal)
-          ) {
-            if (prior) return prior;
-            const committed = this.committedDetailByRow.get(row.id);
-            if (committed) return { ...committed };
-          }
-          return sidebarIndexRowToSession(row, prior);
-        }),
+        ...appended,
       ];
       this.nextCursor = index.next_cursor ?? null;
       // Cursor responses carry the total from the first page's snapshot,
@@ -890,8 +902,11 @@ class SessionsStore {
         0,
         this.total - this.countDroppedRoots(newlyDropped, paginationContext),
       );
-      for (const row of rows) {
-        this.indexCommitByRow.set(row.id, requestOrdinal);
+      for (const session of appended) {
+        this.indexCommitByRow.set(session.id, {
+          ordinal: requestOrdinal,
+          row: session,
+        });
       }
       this.syncActiveSessionAfterIndexCommit(detailCommits, requestOrdinal);
     } catch (error) {
@@ -1045,17 +1060,20 @@ class SessionsStore {
     session: Session,
     issuedAtIndexOrdinal: number,
   ): Session {
-    if ((this.indexCommitByRow.get(id) ?? 0) <= issuedAtIndexOrdinal) {
+    const stamped = this.indexCommitByRow.get(id);
+    if (stamped === undefined || stamped.ordinal <= issuedAtIndexOrdinal) {
       return session;
     }
     const row = this.sessions.find((s) => s.id === id);
     if (row) return mergeIndexFieldsIntoDetail(row, session);
     // The re-published row was since excluded by a later reload; the
-    // absorbed index fields survive only in the active cache, so reconcile
-    // against that instead of letting the stale response apply wholesale.
+    // absorbed index fields survive in the active cache, or failing that in
+    // the stamped publish snapshot (an index-only row never fills the
+    // cache), so reconcile against those instead of letting the stale
+    // response apply wholesale.
     const cached = this.activeSessionDetail;
     if (cached?.id === id) return mergeIndexFieldsIntoDetail(cached, session);
-    return session;
+    return mergeIndexFieldsIntoDetail(stamped.row, session);
   }
 
   // True when a deletion committed for id after the given commit snapshot
@@ -1108,6 +1126,35 @@ class SessionsStore {
       commit.generation !== (snapshot.get(id) ?? 0) &&
       commit.issuedAtIndexOrdinal >= requestOrdinal
     );
+  }
+
+  // Deleting a session removes its whole subtree from the backend's
+  // sidebar queries; extend a tombstone predicate across parent chains so
+  // publication, restoration, and local removal treat the group
+  // consistently. Runs to a fixpoint over the given rows; ancestors need
+  // not be present in the row set (the predicate is consulted for parent
+  // ids directly).
+  private expandTombstoned(
+    rows: ReadonlyArray<{ id: string; parent_session_id?: string | null }>,
+    isTombstoned: (id: string) => boolean,
+  ): Set<string> {
+    const removed = new Set<string>();
+    let grew = true;
+    while (grew) {
+      grew = false;
+      for (const row of rows) {
+        if (removed.has(row.id)) continue;
+        const parent = row.parent_session_id;
+        if (
+          isTombstoned(row.id) ||
+          (parent && (removed.has(parent) || isTombstoned(parent)))
+        ) {
+          removed.add(row.id);
+          grew = true;
+        }
+      }
+    }
+    return removed;
   }
 
   private snapshotDetailCommits(): ReadonlyMap<string, number> {
@@ -1378,7 +1425,7 @@ class SessionsStore {
           !latestCommit.deleted &&
           Number.isFinite(latestCommit.issuedAtIndexOrdinal) &&
           latestCommit.issuedAtIndexOrdinal > issuedAtIndexOrdinal) ||
-        (this.indexCommitByRow.get(id) ?? 0) > issuedAtIndexOrdinal;
+        (this.indexCommitByRow.get(id)?.ordinal ?? 0) > issuedAtIndexOrdinal;
       if (
         e instanceof ApiError &&
         e.status === 404 &&
@@ -1771,9 +1818,22 @@ class SessionsStore {
     // Tombstone the explicit delete so an index load that was in flight
     // (and its failure-restore path) cannot resurrect the row.
     this.bumpDetailCommit(id, true, Number.POSITIVE_INFINITY);
-    const droppedRows = this.sessions.filter((s) => s.id === id);
+    // The backend removes the whole subtree from sidebar queries; mirror it
+    // locally, tombstoning known descendants so stale responses cannot
+    // reinsert them either.
+    const subtree = this.expandTombstoned(
+      this.sessions,
+      (rid) => rid === id,
+    );
+    subtree.add(id);
+    for (const rid of subtree) {
+      if (rid !== id) {
+        this.bumpDetailCommit(rid, true, Number.POSITIVE_INFINITY);
+      }
+    }
+    const droppedRows = this.sessions.filter((s) => subtree.has(s.id));
     const presentIds = new Set(this.sessions.map((s) => s.id));
-    this.sessions = this.sessions.filter((s) => s.id !== id);
+    this.sessions = this.sessions.filter((s) => !subtree.has(s.id));
     this.total = Math.max(
       0,
       this.total - this.countDroppedRoots(droppedRows, presentIds),
@@ -1791,17 +1851,22 @@ class SessionsStore {
     await SessionsService.postApiV1SessionsBatchDelete({
       requestBody: { session_ids: ids },
     });
-    for (const id of ids) {
-      this.bumpDetailCommit(id, true, Number.POSITIVE_INFINITY);
-    }
     const idSet = new Set(ids);
     // Remove rows and adjust the root total immediately: the forced reload
     // below is authoritative when it succeeds, but if it fails its restore
     // snapshot was taken after these tombstones and would otherwise keep
-    // the deleted rows visible.
+    // the deleted rows visible. Known local descendants are tombstoned with
+    // their roots, mirroring the backend's subtree removal.
+    const subtree = this.expandTombstoned(this.sessions, (rid) =>
+      idSet.has(rid)
+    );
+    for (const id of ids) subtree.add(id);
+    for (const rid of subtree) {
+      this.bumpDetailCommit(rid, true, Number.POSITIVE_INFINITY);
+    }
     const presentIds = new Set(this.sessions.map((s) => s.id));
-    const droppedRows = this.sessions.filter((s) => idSet.has(s.id));
-    this.sessions = this.sessions.filter((s) => !idSet.has(s.id));
+    const droppedRows = this.sessions.filter((s) => subtree.has(s.id));
+    this.sessions = this.sessions.filter((s) => !subtree.has(s.id));
     this.total = Math.max(
       0,
       this.total - this.countDroppedRoots(droppedRows, presentIds),

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -602,11 +602,24 @@ class SessionsStore {
       const rows = index.sessions.filter(
         (row) => !this.deletedSinceSnapshot(row.id, detailCommits),
       );
-      this.sessions = rows.map((row) =>
-        sidebarIndexRowToSession(row, existing.get(row.id))
-      );
+      const incomingIds = new Set(index.sessions.map((row) => row.id));
+      this.sessions = rows.map((row) => {
+        const prior = existing.get(row.id);
+        // A rename/read that committed for this row after this index was
+        // requested outranks the index's snapshot — keep the prior row.
+        if (
+          prior &&
+          this.commitSupersedesIndex(row.id, detailCommits, requestOrdinal)
+        ) {
+          return prior;
+        }
+        return sidebarIndexRowToSession(row, prior);
+      });
       this.nextCursor = index.next_cursor ?? null;
-      this.total = Math.max(0, index.total - this.countDroppedRoots(dropped));
+      this.total = Math.max(
+        0,
+        index.total - this.countDroppedRoots(dropped, incomingIds),
+      );
       for (const row of rows) {
         this.indexCommitByRow.set(row.id, requestOrdinal);
       }
@@ -621,13 +634,14 @@ class SessionsStore {
         const droppedRows = prev.sessions.filter((s) =>
           this.deletedSinceSnapshot(s.id, detailCommits)
         );
+        const prevIds = new Set(prev.sessions.map((s) => s.id));
         this.sessions = prev.sessions.filter(
           (s) => !this.deletedSinceSnapshot(s.id, detailCommits),
         );
         this.nextCursor = prev.nextCursor;
         this.total = Math.max(
           0,
-          prev.total - this.countDroppedRoots(droppedRows),
+          prev.total - this.countDroppedRoots(droppedRows, prevIds),
         );
       }
     } finally {
@@ -732,10 +746,11 @@ class SessionsStore {
           ) {
             return;
           }
-          // Same-version guard for the active row: a hydration issued before
-          // a newer commit resolved must not clobber the row or the cache
-          // with its older snapshot.
-          if (hydrated.id === this.activeSessionId && !detailFresh) {
+          // A hydration issued before a newer commit resolved must not
+          // clobber the row or the cache with its older snapshot. This
+          // holds for every row: a rename commits for its session id even
+          // if the user has since selected another session.
+          if (!detailFresh) {
             return;
           }
           cache.set(id, hydrated);
@@ -831,15 +846,29 @@ class SessionsStore {
       const rows = index.sessions.filter(
         (row) => !this.deletedSinceSnapshot(row.id, detailCommits),
       );
+      const incomingIds = new Set(index.sessions.map((row) => row.id));
       const pageIds = new Set(rows.map((row) => row.id));
       this.sessions = [
         ...this.sessions.filter((s) => !pageIds.has(s.id)),
-        ...rows.map((row) =>
-          sidebarIndexRowToSession(row, existingById.get(row.id))
-        ),
+        ...rows.map((row) => {
+          const prior = existingById.get(row.id);
+          if (
+            prior &&
+            this.commitSupersedesIndex(row.id, detailCommits, requestOrdinal)
+          ) {
+            return prior;
+          }
+          return sidebarIndexRowToSession(row, prior);
+        }),
       ];
       this.nextCursor = index.next_cursor ?? null;
-      this.total = Math.max(0, index.total - this.countDroppedRoots(dropped));
+      // Cursor responses carry the total from the first page's snapshot,
+      // which predates any local deletions since then: keep the locally
+      // maintained total and subtract only this page's tombstoned roots.
+      this.total = Math.max(
+        0,
+        this.total - this.countDroppedRoots(dropped, incomingIds),
+      );
       for (const row of rows) {
         this.indexCommitByRow.set(row.id, requestOrdinal);
       }
@@ -1020,14 +1049,38 @@ class SessionsStore {
   }
 
   // The paginated sidebar total counts root groups, while rows include
-  // roots and their descendants: only removing a parentless row can shrink
-  // the root count — a descendant's removal leaves its group in place.
-  // Orphan promotion after a root deletion is settled by the next
+  // roots and their descendants: only removing a row that anchors its own
+  // group can shrink the root count — a descendant's removal leaves its
+  // group in place. A row anchors a group when it has no parent OR its
+  // parent is absent from the surrounding set (the sidebar promotes such
+  // orphans to root groups). Deeper orphan chains are settled by the next
   // authoritative index response.
   private countDroppedRoots(
-    rows: ReadonlyArray<{ parent_session_id?: string | null }>,
+    rows: ReadonlyArray<{ id: string; parent_session_id?: string | null }>,
+    presentIds: ReadonlySet<string>,
   ): number {
-    return rows.filter((row) => !row.parent_session_id).length;
+    return rows.filter(
+      (row) =>
+        !row.parent_session_id || !presentIds.has(row.parent_session_id),
+    ).length;
+  }
+
+  // A non-deletion commit that landed while an index request was in flight
+  // and whose own request is at least as new as the index's supersedes the
+  // index's older snapshot for that row (see syncActiveSessionAfterIndexCommit
+  // for the active-session cache side of the same rule).
+  private commitSupersedesIndex(
+    id: string,
+    snapshot: ReadonlyMap<string, number>,
+    requestOrdinal: number,
+  ): boolean {
+    const commit = this.activeDetailCommitBySession.get(id);
+    return (
+      commit !== undefined &&
+      !commit.deleted &&
+      commit.generation !== (snapshot.get(id) ?? 0) &&
+      commit.issuedAtIndexOrdinal >= requestOrdinal
+    );
   }
 
   private snapshotDetailCommits(): ReadonlyMap<string, number> {
@@ -1112,10 +1165,11 @@ class SessionsStore {
       // Honor the deletion tombstone instead of letting the stale index
       // resurrect the row (mirrors refreshActiveSession's 404 removal).
       const droppedRows = this.sessions.filter((s) => s.id === id);
+      const presentIds = new Set(this.sessions.map((s) => s.id));
       this.sessions = this.sessions.filter((s) => s.id !== id);
       this.total = Math.max(
         0,
-        this.total - this.countDroppedRoots(droppedRows),
+        this.total - this.countDroppedRoots(droppedRows, presentIds),
       );
       return;
     }
@@ -1297,10 +1351,11 @@ class SessionsStore {
         // ghost of the deleted session; drop it and keep the pagination
         // total consistent, mirroring deleteSession.
         const droppedRows = this.sessions.filter((s) => s.id === id);
+        const presentIds = new Set(this.sessions.map((s) => s.id));
         this.sessions = this.sessions.filter((s) => s.id !== id);
         this.total = Math.max(
           0,
-          this.total - this.countDroppedRoots(droppedRows),
+          this.total - this.countDroppedRoots(droppedRows, presentIds),
         );
       }
     } finally {
@@ -1676,10 +1731,11 @@ class SessionsStore {
     // (and its failure-restore path) cannot resurrect the row.
     this.bumpDetailCommit(id, true, Number.POSITIVE_INFINITY);
     const droppedRows = this.sessions.filter((s) => s.id === id);
+    const presentIds = new Set(this.sessions.map((s) => s.id));
     this.sessions = this.sessions.filter((s) => s.id !== id);
     this.total = Math.max(
       0,
-      this.total - this.countDroppedRoots(droppedRows),
+      this.total - this.countDroppedRoots(droppedRows, presentIds),
     );
     if (this.activeSessionId === id) {
       this.setActiveSession(null);
@@ -1698,6 +1754,17 @@ class SessionsStore {
       this.bumpDetailCommit(id, true, Number.POSITIVE_INFINITY);
     }
     const idSet = new Set(ids);
+    // Remove rows and adjust the root total immediately: the forced reload
+    // below is authoritative when it succeeds, but if it fails its restore
+    // snapshot was taken after these tombstones and would otherwise keep
+    // the deleted rows visible.
+    const presentIds = new Set(this.sessions.map((s) => s.id));
+    const droppedRows = this.sessions.filter((s) => idSet.has(s.id));
+    this.sessions = this.sessions.filter((s) => !idSet.has(s.id));
+    this.total = Math.max(
+      0,
+      this.total - this.countDroppedRoots(droppedRows, presentIds),
+    );
     if (this.activeSessionId && idSet.has(this.activeSessionId)) {
       this.setActiveSession(null);
     }
@@ -1833,9 +1900,12 @@ class SessionsStore {
     // index-only or out-of-list active session whose pending read was just
     // cancelled has nothing else to back the breadcrumb until the next
     // watcher refresh.
+    // Record the write commit for ANY renamed session: hydrations and
+    // index publishes consult it per id, so a stale response cannot revert
+    // the rename even after the user selects another session.
+    this.bumpDetailCommit(id, false, Number.POSITIVE_INFINITY);
     if (this.activeSessionId === id) {
       this.activeDetailRead.cancel();
-      this.bumpDetailCommit(id, false, Number.POSITIVE_INFINITY);
       const cached =
         this.activeSessionDetail?.id === id ? this.activeSessionDetail : null;
       this.activeSessionDetail = applyRename(

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -597,11 +597,26 @@ class SessionsStore {
       this.syncActiveSessionAfterIndexCommit(detailCommits, requestOrdinal);
     } catch {
       // Restore previous state so a transient failure
-      // doesn't wipe the visible session list.
+      // doesn't wipe the visible session list — but reapply deletion
+      // tombstones committed while this load was in flight: a refresh 404
+      // removed its row from the live list, and the pre-load snapshot still
+      // contains it.
       if (this.loadVersion === version) {
-        this.sessions = prev.sessions;
+        const deletedMidFlight = (id: string) => {
+          const commit = this.activeDetailCommitBySession.get(id);
+          return (
+            commit !== undefined &&
+            commit.deleted &&
+            commit.generation !== (detailCommits.get(id) ?? 0)
+          );
+        };
+        const restored = prev.sessions.filter((s) => !deletedMidFlight(s.id));
+        this.sessions = restored;
         this.nextCursor = prev.nextCursor;
-        this.total = prev.total;
+        this.total = Math.max(
+          0,
+          prev.total - (prev.sessions.length - restored.length),
+        );
       }
     } finally {
       if (this.loadVersion === version) {
@@ -681,8 +696,15 @@ class SessionsStore {
           // (mergeHydratedSession) owns updates once the version check
           // passes. Successful active-detail writes count as commits so a
           // staler index response cannot overwrite them.
+          // A commit invalidates this hydration only when its underlying
+          // request was issued no earlier than this one's: a superseded
+          // hydration from an older index version seeding the cache must
+          // not discard this later-issued response, while a rename/404
+          // (Infinity) or a read issued at or after this one still does.
+          const latestCommit = this.activeDetailCommitBySession.get(id);
           const detailFresh =
-            detailCommitGeneration === this.detailCommitGeneration(id);
+            detailCommitGeneration === this.detailCommitGeneration(id) ||
+            (latestCommit?.issuedAtIndexOrdinal ?? 0) < issuedAtIndexOrdinal;
           if (
             hydrated.id === this.activeSessionId &&
             !hydrated.is_index_only &&

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -379,6 +379,12 @@ class SessionsStore {
     string,
     { generation: number; deleted: boolean; issuedAtIndexOrdinal: number }
   >();
+  // Last committed session snapshot per id, kept so an index publish can
+  // honor a superseding commit even when no prior sidebar row exists (a
+  // cache-only session renamed and then deselected). Written by non-deletion
+  // commits, dropped by deletion commits; overwritten in place, so it stays
+  // bounded by the sessions that ever committed detail.
+  private committedDetailByRow = new Map<string, Session>();
   // Issue-order counter for sidebar index requests. Read-derived hydration
   // commits only count as commits when no newer index request was issued
   // after the hydration's fetch began: a hydration that predates the index
@@ -606,12 +612,12 @@ class SessionsStore {
       this.sessions = rows.map((row) => {
         const prior = existing.get(row.id);
         // A rename/read that committed for this row after this index was
-        // requested outranks the index's snapshot — keep the prior row.
-        if (
-          prior &&
-          this.commitSupersedesIndex(row.id, detailCommits, requestOrdinal)
-        ) {
-          return prior;
+        // requested outranks the index's snapshot — keep the prior row, or
+        // the retained committed snapshot when the session had no row yet.
+        if (this.commitSupersedesIndex(row.id, detailCommits, requestOrdinal)) {
+          if (prior) return prior;
+          const committed = this.committedDetailByRow.get(row.id);
+          if (committed) return { ...committed };
         }
         return sidebarIndexRowToSession(row, prior);
       });
@@ -738,7 +744,7 @@ class SessionsStore {
             detailFresh
           ) {
             this.activeSessionDetail = hydrated;
-            this.bumpDetailCommit(id, false, issuedAtIndexOrdinal);
+            this.bumpDetailCommit(id, false, issuedAtIndexOrdinal, hydrated);
           }
           if (
             version !== this.sidebarIndexVersion ||
@@ -756,7 +762,7 @@ class SessionsStore {
           cache.set(id, hydrated);
           this.mergeHydratedSession(hydrated);
           if (hydrated.id === this.activeSessionId) {
-            this.bumpDetailCommit(id, false, issuedAtIndexOrdinal);
+            this.bumpDetailCommit(id, false, issuedAtIndexOrdinal, hydrated);
           }
         } catch {
           // Visible hydration is best-effort; the skinny row remains usable.
@@ -820,6 +826,10 @@ class SessionsStore {
     const version = ++this.loadVersion;
     const requestOrdinal = ++this.requestClock;
     const detailCommits = this.snapshotDetailCommits();
+    // Rows already loaded when this request began had any mid-flight
+    // deletion applied to the total by the delete path itself; a stale page
+    // re-listing one must not subtract it again.
+    const loadedIdsAtStart = new Set(this.sessions.map((s) => s.id));
     const signal = this.routeSignal();
     this.loading = true;
     try {
@@ -853,10 +863,11 @@ class SessionsStore {
         ...rows.map((row) => {
           const prior = existingById.get(row.id);
           if (
-            prior &&
             this.commitSupersedesIndex(row.id, detailCommits, requestOrdinal)
           ) {
-            return prior;
+            if (prior) return prior;
+            const committed = this.committedDetailByRow.get(row.id);
+            if (committed) return { ...committed };
           }
           return sidebarIndexRowToSession(row, prior);
         }),
@@ -864,10 +875,14 @@ class SessionsStore {
       this.nextCursor = index.next_cursor ?? null;
       // Cursor responses carry the total from the first page's snapshot,
       // which predates any local deletions since then: keep the locally
-      // maintained total and subtract only this page's tombstoned roots.
+      // maintained total and subtract only tombstoned roots this page would
+      // have introduced (see loadedIdsAtStart).
+      const newlyDropped = dropped.filter(
+        (row) => !loadedIdsAtStart.has(row.id),
+      );
       this.total = Math.max(
         0,
-        this.total - this.countDroppedRoots(dropped, incomingIds),
+        this.total - this.countDroppedRoots(newlyDropped, incomingIds),
       );
       for (const row of rows) {
         this.indexCommitByRow.set(row.id, requestOrdinal);
@@ -990,6 +1005,7 @@ class SessionsStore {
     id: string,
     deleted: boolean,
     issuedAtIndexOrdinal: number,
+    snapshot?: Session,
   ): void {
     const current = this.activeDetailCommitBySession.get(id);
     this.activeDetailCommitBySession.set(id, {
@@ -997,6 +1013,11 @@ class SessionsStore {
       deleted,
       issuedAtIndexOrdinal,
     });
+    if (deleted) {
+      this.committedDetailByRow.delete(id);
+    } else if (snapshot) {
+      this.committedDetailByRow.set(id, snapshot);
+    }
     // A read-derived commit (finite ordinal) carries the full detail shape;
     // it supersedes any interim rename snapshot backing the active session.
     if (
@@ -1248,7 +1269,7 @@ class SessionsStore {
             } else {
               this.activeSessionDetail = session;
             }
-            this.bumpDetailCommit(id, false, issuedAtIndexOrdinal);
+            this.bumpDetailCommit(id, false, issuedAtIndexOrdinal, session);
           }
         }
       } catch {
@@ -1332,7 +1353,7 @@ class SessionsStore {
         // breadcrumb.
         this.activeSessionDetail = session;
       }
-      this.bumpDetailCommit(id, false, issuedAtIndexOrdinal);
+      this.bumpDetailCommit(id, false, issuedAtIndexOrdinal, session);
     } catch (e) {
       // The session may have been deleted, locally or on another machine. On
       // a definitive not-found drop the cached detail so the breadcrumb
@@ -1902,8 +1923,22 @@ class SessionsStore {
     // watcher refresh.
     // Record the write commit for ANY renamed session: hydrations and
     // index publishes consult it per id, so a stale response cannot revert
-    // the rename even after the user selects another session.
-    this.bumpDetailCommit(id, false, Number.POSITIVE_INFINITY);
+    // the rename even after the user selects another session. The snapshot
+    // prefers full detail (cache, then row); a fabricated fallback stays
+    // index-only so a row published from it still hydrates later.
+    const renamedRow = this.sessions.find((s) => s.id === id);
+    const renamedSnapshot =
+      this.activeSessionId === id && this.activeSessionDetail?.id === id
+        ? applyRename(this.activeSessionDetail)
+        : renamedRow !== undefined
+          ? applyRename(renamedRow)
+          : applyRename({ ...updated, is_index_only: true });
+    this.bumpDetailCommit(
+      id,
+      false,
+      Number.POSITIVE_INFINITY,
+      renamedSnapshot,
+    );
     if (this.activeSessionId === id) {
       this.activeDetailRead.cancel();
       const cached =

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -942,8 +942,13 @@ class SessionsStore {
       return session;
     }
     const row = this.sessions.find((s) => s.id === id);
-    if (!row) return session;
-    return mergeIndexFieldsIntoDetail(row, session);
+    if (row) return mergeIndexFieldsIntoDetail(row, session);
+    // The re-published row was since excluded by a later reload; the
+    // absorbed index fields survive only in the active cache, so reconcile
+    // against that instead of letting the stale response apply wholesale.
+    const cached = this.activeSessionDetail;
+    if (cached?.id === id) return mergeIndexFieldsIntoDetail(cached, session);
+    return session;
   }
 
   private snapshotDetailCommits(): ReadonlyMap<string, number> {

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -42,11 +42,6 @@ type LoadOptions = {
 
 const SESSION_PAGE_SIZE = 500;
 const SIDEBAR_HYDRATION_CONCURRENCY = 6;
-
-type DetailFreshnessSnapshot = {
-  reads: ReadonlyMap<string, number>;
-  commits: ReadonlyMap<string, number>;
-};
 const LIVE_REFRESH_DEBOUNCE_MS = 300;
 const SAFETY_NET_REFRESH_MS = 5 * 60 * 1000;
 const RECENTLY_DELETED_TTL_MS = 10_000;
@@ -360,24 +355,19 @@ class SessionsStore {
   // Single coordinator for every read that commits to activeSessionDetail
   // (navigation and watcher refresh): the newest read cancels older in-flight
   // ones, so a stale response resolving late can never overwrite fresher
-  // cached detail. The generation counters extend that freshness to sidebar
-  // hydration, which shares its fetches with non-active rows and so cannot
-  // claim the coordinator itself: a hydration only touches active-session
-  // state when no read began and no rename committed for that same session
-  // since it was issued. Freshness is tracked per session id — a read for
-  // one session must not stale an in-flight hydration of another session
-  // that a later selection may join. Entries are monotonic and never
-  // removed: resetting one could make a stale capture compare equal again.
-  //
-  // Two tiers per session: the read generation advances when a read merely
-  // BEGINS (or a rename/404 invalidates in-flight reads) and guards against
-  // stale writes into the cache; the commit generation advances only when
-  // fresher state actually COMMITS (navigation/refresh resolves, a rename
-  // commits, a 404 commits a deletion). Only a commit proves the cache — or
-  // a deletion — is fresher than a concurrently loaded index; a read that
-  // began and failed proves nothing.
+  // cached detail. The commit generations extend that freshness to sidebar
+  // hydration and index reconciliation, which cannot claim the coordinator
+  // themselves (hydration shares its fetches with non-active rows). A
+  // session's commit generation advances only when fresher state actually
+  // COMMITS to its active-detail state: a navigation or refresh resolving, a
+  // rename or hydration committing its snapshot, a 404 committing a
+  // deletion. A read that merely BEGAN proves nothing — it may fail, and if
+  // it commits it commits later and wins — so it never invalidates anything.
+  // Generations are per session id (activity on one session says nothing
+  // about another's in-flight hydration, which a later selection may join),
+  // monotonic, and never removed: resetting one could make a stale capture
+  // compare equal again.
   private activeDetailRead = new LatestRead();
-  private activeDetailGenerationBySession = new Map<string, number>();
   private activeDetailCommitBySession = new Map<
     string,
     { generation: number; deleted: boolean }
@@ -535,7 +525,7 @@ class SessionsStore {
   ) {
     const version = ++this.loadVersion;
     const indexVersion = this.sidebarIndexVersion + 1;
-    const detailFreshness = this.snapshotDetailFreshness();
+    const detailCommits = this.snapshotDetailCommits();
     // Keep the existing list visible during reloads, but mark
     // loading=true so large filter expansions expose that more
     // pages are still being fetched after page 1 is published.
@@ -568,7 +558,7 @@ class SessionsStore {
       );
       this.nextCursor = index.next_cursor ?? null;
       this.total = index.total;
-      this.syncActiveSessionAfterIndexCommit(detailFreshness);
+      this.syncActiveSessionAfterIndexCommit(detailCommits);
     } catch {
       // Restore previous state so a transient failure
       // doesn't wipe the visible session list.
@@ -734,7 +724,7 @@ class SessionsStore {
   async loadMore() {
     if (!this.nextCursor || this.loading) return;
     const version = ++this.loadVersion;
-    const detailFreshness = this.snapshotDetailFreshness();
+    const detailCommits = this.snapshotDetailCommits();
     const signal = this.routeSignal();
     this.loading = true;
     try {
@@ -763,7 +753,7 @@ class SessionsStore {
       ];
       this.nextCursor = index.next_cursor ?? null;
       this.total = index.total;
-      this.syncActiveSessionAfterIndexCommit(detailFreshness);
+      this.syncActiveSessionAfterIndexCommit(detailCommits);
     } catch (error) {
       if (signal.aborted || isAbortError(error)) return;
       throw error;
@@ -873,14 +863,6 @@ class SessionsStore {
     return this.machinesPromise;
   }
 
-  private detailGeneration(id: string): number {
-    return this.activeDetailGenerationBySession.get(id) ?? 0;
-  }
-
-  private bumpDetailGeneration(id: string): void {
-    this.activeDetailGenerationBySession.set(id, this.detailGeneration(id) + 1);
-  }
-
   private detailCommitGeneration(id: string): number {
     return this.activeDetailCommitBySession.get(id)?.generation ?? 0;
   }
@@ -893,29 +875,12 @@ class SessionsStore {
     });
   }
 
-  private snapshotDetailFreshness(): DetailFreshnessSnapshot {
-    return {
-      reads: new Map(this.activeDetailGenerationBySession),
-      commits: new Map(
-        [...this.activeDetailCommitBySession].map(
-          ([id, commit]) => [id, commit.generation],
-        ),
+  private snapshotDetailCommits(): ReadonlyMap<string, number> {
+    return new Map(
+      [...this.activeDetailCommitBySession].map(
+        ([id, commit]) => [id, commit.generation],
       ),
-    };
-  }
-
-  // A session's read generation advances only when something newer starts a
-  // read for (or commits to) that session's active-detail state — never on
-  // plain cancellation, so a hydration joined at selection time can still
-  // seed an empty cache.
-  private beginActiveDetailRead(id: string): AbortSignal {
-    this.bumpDetailGeneration(id);
-    return this.activeDetailRead.begin();
-  }
-
-  private cancelActiveDetailRead(id: string): void {
-    this.bumpDetailGeneration(id);
-    this.activeDetailRead.cancel();
+    );
   }
 
   private setActiveSession(id: string | null) {
@@ -956,30 +921,26 @@ class SessionsStore {
 
   // After an index commit, reconcile the active session's sidebar row and
   // detail cache in whichever direction is fresher. When something newer
-  // actually COMMITTED mid-flight (navigation/refresh/rename/hydration, or
-  // a 404 deletion), the committed state wins over the older index
-  // snapshot: a deletion removes the re-listed row (the index predates the
-  // 404) and committed detail replaces it. When nothing committed but a
-  // read merely began — it may still be in flight or have failed, proving
-  // nothing about the cache's freshness — leave the row and the cache
-  // alone, and let the read commit through mergeHydratedSession if and when
-  // it resolves. Otherwise the merged row may have absorbed index refreshes
-  // (renames, counts) the cache never saw — resync the cache from it so a
-  // later reload that excludes the row doesn't revert the breadcrumb to
-  // stale fields.
+  // COMMITTED mid-flight (navigation/refresh/rename/hydration, or a 404
+  // deletion), the committed state wins over the older index snapshot: a
+  // deletion removes the re-listed row (the index predates the 404) and
+  // committed detail replaces it. When nothing committed mid-flight, the
+  // committed index is at least as fresh as the cache — any commit the
+  // cache holds resolved before this index request was even issued, so the
+  // server produced the index rows afterwards — and the merged row may
+  // carry index refreshes (renames, counts) the cache never saw: absorb
+  // them into the cache so a later reload that excludes the row doesn't
+  // revert the breadcrumb to stale fields. A read that merely began and
+  // hasn't committed changes nothing here; if it resolves, it commits
+  // strictly fresher detail on top.
   private syncActiveSessionAfterIndexCommit(
-    snapshot: DetailFreshnessSnapshot,
+    snapshot: ReadonlyMap<string, number>,
   ) {
     const id = this.activeSessionId;
     if (id === null) return;
     const commit = this.activeDetailCommitBySession.get(id);
-    if (!commit || commit.generation === (snapshot.commits.get(id) ?? 0)) {
-      // Nothing committed mid-flight. If a read began without committing
-      // (still in flight, or it failed), leave both sides alone; otherwise
-      // absorb the index's refreshes into the cache.
-      if (this.detailGeneration(id) === (snapshot.reads.get(id) ?? 0)) {
-        this.cacheActiveSessionDetailFromList(id);
-      }
+    if (!commit || commit.generation === (snapshot.get(id) ?? 0)) {
+      this.cacheActiveSessionDetailFromList(id);
       return;
     }
     if (commit.deleted) {
@@ -1036,7 +997,7 @@ class SessionsStore {
       await this.hydrateSelectedIndexOnlySession(id);
       return;
     }
-    const signal = this.beginActiveDetailRead(id);
+    const signal = this.activeDetailRead.begin();
     const entry = { id, promise: Promise.resolve() };
     entry.promise = (async () => {
       try {
@@ -1084,7 +1045,15 @@ class SessionsStore {
   async refreshActiveSession() {
     const id = this.activeSessionId;
     if (!id) return;
-    const signal = this.beginActiveDetailRead(id);
+    // Navigation and refresh issue the identical detail GET. Join a pending
+    // same-session navigation instead of cancelling it to reissue the same
+    // request: if this refresh then failed transiently, the cancelled
+    // navigation could no longer fill the empty cache and nothing would
+    // retry until the next watcher event.
+    if (this.navigateInFlight?.id === id) {
+      return this.navigateInFlight.promise;
+    }
+    const signal = this.activeDetailRead.begin();
     try {
       configureGeneratedClient();
       const session = await callGenerated(
@@ -1121,7 +1090,6 @@ class SessionsStore {
         this.activeSessionId === id &&
         this.activeDetailRead.isCurrent(signal)
       ) {
-        this.bumpDetailGeneration(id);
         this.bumpDetailCommit(id, true);
         this.activeSessionDetail = null;
         // A hydrated matching row would keep backing activeSession as a
@@ -1656,7 +1624,7 @@ class SessionsStore {
     // cancelled has nothing else to back the breadcrumb until the next
     // watcher refresh.
     if (this.activeSessionId === id) {
-      this.cancelActiveDetailRead(id);
+      this.activeDetailRead.cancel();
       this.bumpDetailCommit(id, false);
       const base =
         this.activeSessionDetail?.id === id

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -989,6 +989,15 @@ class SessionsStore {
       ) {
         this.activeDetailGeneration++;
         this.activeSessionDetail = null;
+        // A hydrated matching row would keep backing activeSession as a
+        // ghost of the deleted session; drop it and keep the pagination
+        // total consistent, mirroring deleteSession.
+        const before = this.sessions.length;
+        this.sessions = this.sessions.filter((s) => s.id !== id);
+        const removed = before - this.sessions.length;
+        if (removed > 0) {
+          this.total = Math.max(0, this.total - removed);
+        }
       }
     } finally {
       this.activeDetailRead.finish(signal);

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -372,6 +372,15 @@ class SessionsStore {
     string,
     { generation: number; deleted: boolean }
   >();
+  // Issue-order counter for sidebar index requests. Read-derived hydration
+  // commits only count as commits when no newer index request was issued
+  // after the hydration's fetch began: a hydration that predates the index
+  // request cannot carry fresher server state than the index's snapshot, so
+  // letting it win the post-index reconciliation would revert newer index
+  // fields. Rename and 404 commits are write-derived and always win;
+  // navigation/refresh commits stay unconditional because the coordinator
+  // already serializes them against each other.
+  private indexRequestOrdinal = 0;
   private childSessionsRead = new LatestRead();
 
   private liveRefreshStarted = false;
@@ -525,6 +534,7 @@ class SessionsStore {
   ) {
     const version = ++this.loadVersion;
     const indexVersion = this.sidebarIndexVersion + 1;
+    this.indexRequestOrdinal++;
     const detailCommits = this.snapshotDetailCommits();
     // Keep the existing list visible during reloads, but mark
     // loading=true so large filter expansions expose that more
@@ -618,6 +628,7 @@ class SessionsStore {
       const promise = this.runSidebarHydration(async () => {
         if (signal.aborted) return;
         const detailCommitGeneration = this.detailCommitGeneration(id);
+        const issuedAtIndexOrdinal = this.indexRequestOrdinal;
         try {
           configureGeneratedClient();
           const hydrated = await callGenerated(
@@ -645,7 +656,11 @@ class SessionsStore {
             detailFresh
           ) {
             this.activeSessionDetail = hydrated;
-            this.bumpDetailCommit(id, false);
+            // Count as a commit only when no newer index request was issued
+            // since this fetch began — see indexRequestOrdinal.
+            if (issuedAtIndexOrdinal === this.indexRequestOrdinal) {
+              this.bumpDetailCommit(id, false);
+            }
           }
           if (
             version !== this.sidebarIndexVersion ||
@@ -661,7 +676,10 @@ class SessionsStore {
           }
           cache.set(id, hydrated);
           this.mergeHydratedSession(hydrated);
-          if (hydrated.id === this.activeSessionId) {
+          if (
+            hydrated.id === this.activeSessionId &&
+            issuedAtIndexOrdinal === this.indexRequestOrdinal
+          ) {
             this.bumpDetailCommit(id, false);
           }
         } catch {
@@ -724,6 +742,7 @@ class SessionsStore {
   async loadMore() {
     if (!this.nextCursor || this.loading) return;
     const version = ++this.loadVersion;
+    this.indexRequestOrdinal++;
     const detailCommits = this.snapshotDetailCommits();
     const signal = this.routeSignal();
     this.loading = true;

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -607,6 +607,12 @@ class SessionsStore {
             () => SessionsService.getApiV1SessionsId({ id }),
             signal,
           ) as unknown as Session;
+          // The active session's detail stays valid even if a concurrent
+          // reload superseded this hydration version: seed the cache first so
+          // the breadcrumb survives when the new index excludes the row.
+          if (hydrated.id === this.activeSessionId && !hydrated.is_index_only) {
+            this.activeSessionDetail = hydrated;
+          }
           if (
             version !== this.sidebarIndexVersion ||
             epoch !== (this.sidebarHydrationEpochByVersion.get(version) ?? 0)
@@ -1045,16 +1051,12 @@ class SessionsStore {
       // an unstarred session while starred-only filter is on) — jump to
       // an edge so the keyboard shortcut doesn't silently fail.
       const edge = delta > 0 ? 0 : list.length - 1;
-      const id = list[edge]!.id;
-      this.setActiveSession(id);
-      void this.hydrateSelectedIndexOnlySession(id);
+      this.selectSession(list[edge]!.id);
       return;
     }
     const next = idx + delta;
     if (next >= 0 && next < list.length) {
-      const id = list[next]!.id;
-      this.setActiveSession(id);
-      void this.hydrateSelectedIndexOnlySession(id);
+      this.selectSession(list[next]!.id);
     }
   }
 

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -3,10 +3,8 @@ import {
   MetadataService,
   SessionsService,
 } from "../api/generated/index";
-// Imported from core rather than the index barrel so instanceof keeps the
-// real class identity in tests that mock "../api/generated/index".
-import { ApiError as GeneratedApiError } from "../api/generated/core/ApiError";
 import {
+  ApiError,
   callGenerated,
   configureGeneratedClient,
   isAbortError,
@@ -952,9 +950,10 @@ class SessionsStore {
       // The session may have been deleted, locally or on another machine. On
       // a definitive not-found drop the cached detail so the breadcrumb
       // empties instead of showing a ghost session; transient failures keep
-      // the cache and the next watcher refresh retries.
+      // the cache and the next watcher refresh retries. callGenerated rethrows
+      // generated errors as the runtime ApiError, so match that class.
       if (
-        e instanceof GeneratedApiError &&
+        e instanceof ApiError &&
         e.status === 404 &&
         this.activeSessionId === id &&
         this.activeDetailRead.isCurrent(signal)

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -387,8 +387,12 @@ class SessionsStore {
       // For deleted commits: whether the tombstone actually removed a
       // sidebar row. Revival restores a row only if one was removed — a
       // cache-only session excluded by the filter must not be injected
-      // into the list. Root status is recomputed at append time.
+      // into the list. Root status for REVIVAL is recomputed at append
+      // time; removedRootAtDeletion records the removal-time status for a
+      // different consumer — total accounting of deletions absent from a
+      // stale page (see loadSidebarPage).
       removedRow: boolean;
+      removedRootAtDeletion: boolean;
     }
   >();
   // Generations are globally unique (not per-id counters) so pruning an
@@ -650,9 +654,31 @@ class SessionsStore {
       });
       this.sessions = published;
       this.nextCursor = index.next_cursor ?? null;
+      // Root deletions committed after this request's snapshot that are
+      // absent from the returned page (a later-page root deleted
+      // mid-flight) must still come off the stale total. Only paginated
+      // responses qualify: a COMPLETE publish's total already reflects
+      // full membership, so an id absent from it was not counted at all
+      // (e.g. excluded by changed filters).
+      let offPageDeletedRoots = 0;
+      if ((index.next_cursor ?? null) !== null) {
+        for (const [cid, commit] of this.activeDetailCommitBySession) {
+          if (
+            commit.deleted &&
+            commit.removedRootAtDeletion &&
+            commit.generation !== (detailCommits.get(cid) ?? 0) &&
+            commit.issuedAtIndexOrdinal >= requestOrdinal &&
+            !incomingIds.has(cid)
+          ) {
+            offPageDeletedRoots++;
+          }
+        }
+      }
       this.total = Math.max(
         0,
-        index.total - this.countDroppedRoots(dropped, incomingIds),
+        index.total -
+          this.countDroppedRoots(dropped, incomingIds) -
+          offPageDeletedRoots,
       );
       for (const session of published) {
         this.indexCommitByRow.set(session.id, {
@@ -660,18 +686,22 @@ class SessionsStore {
           row: session,
         });
       }
-      // A full publish issued after a read-derived tombstone that excludes
-      // the id is authoritative for the current filters: revival must not
-      // append the row back into a list that no longer contains it.
-      for (const [cid, commit] of this.activeDetailCommitBySession) {
-        if (
-          commit.deleted &&
-          commit.removedRow &&
-          Number.isFinite(commit.issuedAtIndexOrdinal) &&
-          commit.issuedAtIndexOrdinal < requestOrdinal &&
-          !incomingIds.has(cid)
-        ) {
-          commit.removedRow = false;
+      // A COMPLETE publish (no further pages) that excludes the id is
+      // authoritative for sidebar membership under the current filters,
+      // regardless of request issue order — filters do not depend on the
+      // 404's timing. Revival must not append the row back into a list
+      // that no longer contains it. A paginated first page proves nothing:
+      // the session may live on a later page.
+      if ((index.next_cursor ?? null) === null) {
+        for (const [cid, commit] of this.activeDetailCommitBySession) {
+          if (
+            commit.deleted &&
+            commit.removedRow &&
+            Number.isFinite(commit.issuedAtIndexOrdinal) &&
+            !incomingIds.has(cid)
+          ) {
+            commit.removedRow = false;
+          }
         }
       }
       this.syncActiveSessionAfterIndexCommit(detailCommits, requestOrdinal);
@@ -813,8 +843,14 @@ class SessionsStore {
             // session still outranks whatever the re-listed row carries;
             // merge it, or the getter (which prefers a hydrated row over
             // the cache) shows the older data and nothing re-hydrates a
-            // non-index-only row.
-            if (hydrated.id === this.activeSessionId && detailFresh) {
+            // non-index-only row. Epoch-only invalidation is different: a
+            // messages event marked this response stale in place, so it
+            // must not merge back.
+            if (
+              version !== this.sidebarIndexVersion &&
+              hydrated.id === this.activeSessionId &&
+              detailFresh
+            ) {
               this.mergeHydratedSession(hydrated);
             }
             return;
@@ -1101,6 +1137,9 @@ class SessionsStore {
       removedRow: deleted && previous?.deleted === true
         ? previous.removedRow
         : false,
+      removedRootAtDeletion: deleted && previous?.deleted === true
+        ? previous.removedRootAtDeletion
+        : false,
     });
     if (deleted) {
       this.committedDetailByRow.delete(id);
@@ -1293,6 +1332,8 @@ class SessionsStore {
       const commit = this.activeDetailCommitBySession.get(row.id);
       if (commit?.deleted) {
         commit.removedRow = true;
+        commit.removedRootAtDeletion =
+          !row.parent_session_id || !presentIds.has(row.parent_session_id);
       }
     }
     return subtree;
@@ -1323,6 +1364,32 @@ class SessionsStore {
     return rows.filter(
       (row) => !row.parent_session_id || !ids.has(row.parent_session_id),
     ).length;
+  }
+
+  // Restoring a session also restores its subtree server-side; clear any
+  // descendant tombstones so stale filters cannot keep suppressing them.
+  // Parent links come from the retained publish/commit snapshots.
+  private clearSubtreeTombstones(id: string): void {
+    const cleared = new Set([id]);
+    let grew = true;
+    while (grew) {
+      grew = false;
+      for (const [cid, commit] of this.activeDetailCommitBySession) {
+        if (!commit.deleted || cleared.has(cid)) continue;
+        const parent =
+          this.indexCommitByRow.get(cid)?.row.parent_session_id ??
+          this.committedDetailByRow.get(cid)?.parent_session_id;
+        if (parent && cleared.has(parent)) {
+          cleared.add(cid);
+          grew = true;
+        }
+      }
+    }
+    for (const cid of cleared) {
+      if (cid !== id) {
+        this.bumpDetailCommit(cid, false, Number.POSITIVE_INFINITY);
+      }
+    }
   }
 
   private snapshotDetailCommits(): ReadonlyMap<string, number> {
@@ -2025,6 +2092,14 @@ class SessionsStore {
       0,
       this.total - this.countDroppedRoots(droppedRows, presentIds),
     );
+    for (const row of droppedRows) {
+      const commit = this.activeDetailCommitBySession.get(row.id);
+      if (commit?.deleted) {
+        commit.removedRow = true;
+        commit.removedRootAtDeletion =
+          !row.parent_session_id || !presentIds.has(row.parent_session_id);
+      }
+    }
     if (this.activeSessionId && subtree.has(this.activeSessionId)) {
       this.setActiveSession(null);
     }
@@ -2038,11 +2113,14 @@ class SessionsStore {
   async restoreSession(id: string) {
     configureGeneratedClient();
     await SessionsService.postApiV1SessionsIdRestore({ id });
-    // Clear the deletion tombstone: the session exists again.
+    // Clear the deletion tombstones — the session and its subtree exist
+    // again — and force a fresh load: a joined pre-restore reload would
+    // publish a list without the restored root.
     this.bumpDetailCommit(id, false, Number.POSITIVE_INFINITY);
+    this.clearSubtreeTombstones(id);
     this.clearRecentlyDeleted(id);
     this.invalidateFilterCaches();
-    await this.load();
+    await this.load({ force: true });
   }
 
   async restoreRecentlyDeleted(deleted: RecentlyDeletedSessions) {
@@ -2055,6 +2133,7 @@ class SessionsStore {
       try {
         await SessionsService.postApiV1SessionsIdRestore({ id });
         this.bumpDetailCommit(id, false, Number.POSITIVE_INFINITY);
+        this.clearSubtreeTombstones(id);
       } catch {
         failed.push(id);
       }

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -880,9 +880,15 @@ class SessionsStore {
       const newlyDropped = dropped.filter(
         (row) => !loadedIdsAtStart.has(row.id),
       );
+      // Classify against everything loaded plus this page: a dropped child
+      // whose parent lives on an earlier page is not a promoted root.
+      const paginationContext = new Set([
+        ...loadedIdsAtStart,
+        ...incomingIds,
+      ]);
       this.total = Math.max(
         0,
-        this.total - this.countDroppedRoots(newlyDropped, incomingIds),
+        this.total - this.countDroppedRoots(newlyDropped, paginationContext),
       );
       for (const row of rows) {
         this.indexCommitByRow.set(row.id, requestOrdinal);
@@ -1360,9 +1366,23 @@ class SessionsStore {
       // empties instead of showing a ghost session; transient failures keep
       // the cache and the next watcher refresh retries. callGenerated rethrows
       // generated errors as the runtime ApiError, so match that class.
+      // A 404 from a request issued before newer successful evidence — a
+      // later-issued read commit or an index that re-listed the row — is a
+      // stale response, not proof of deletion; keep the session and let the
+      // next refresh decide. Write commits (Infinity) are excluded as
+      // evidence: they persist indefinitely and would immunize ever-renamed
+      // sessions against genuine deletions.
+      const latestCommit = this.activeDetailCommitBySession.get(id);
+      const newerEvidence =
+        (latestCommit !== undefined &&
+          !latestCommit.deleted &&
+          Number.isFinite(latestCommit.issuedAtIndexOrdinal) &&
+          latestCommit.issuedAtIndexOrdinal > issuedAtIndexOrdinal) ||
+        (this.indexCommitByRow.get(id) ?? 0) > issuedAtIndexOrdinal;
       if (
         e instanceof ApiError &&
         e.status === 404 &&
+        !newerEvidence &&
         this.activeSessionId === id &&
         this.activeDetailRead.isCurrent(signal)
       ) {

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -296,6 +296,11 @@ class SessionsStore {
   agents: AgentInfo[] = $state([]);
   machines: string[] = $state([]);
   activeSessionId: string | null = $state(null);
+  // Resolved detail for the open session, held outside the sidebar list so a
+  // session that falls outside the current filters or page (e.g. opened from
+  // search) can back activeSession without polluting groupedSessions or being
+  // double-counted when loadMore appends a later page. Cleared on navigation.
+  activeSessionDetail: Session | null = $state(null);
   activeSessionUsageVersion: number = $state(0);
   childSessions: Map<string, Session> = $state(new Map());
   nextCursor: string | null = $state(null);
@@ -358,7 +363,13 @@ class SessionsStore {
 
   get activeSession(): Session | undefined {
     const session = this.sessions.find((s) => s.id === this.activeSessionId);
-    return session?.is_index_only ? undefined : session;
+    if (session && !session.is_index_only) return session;
+    // The open session may be absent from the filtered/paginated sidebar list
+    // (opened from search, filtered out, or on an unloaded page), or present
+    // only as an index-only stub. Fall back to the separately resolved detail.
+    const cached = this.activeSessionDetail;
+    if (cached && cached.id === this.activeSessionId) return cached;
+    return undefined;
   }
 
   get groupedSessions(): SessionGroup[] {
@@ -526,21 +537,6 @@ class SessionsStore {
       this.sessions = index.sessions.map((row) =>
         sidebarIndexRowToSession(row, existing.get(row.id))
       );
-      // Preserve the open session when the (filtered) index omits it, e.g. one
-      // opened from search that falls outside the current sidebar filters.
-      // navigateToSession appended it to the list; dropping it on reload leaves
-      // activeSession undefined and strips the breadcrumb's project, name, and
-      // badges. Keep the previously resolved row so the detail view stays intact.
-      const activeId = this.activeSessionId;
-      if (
-        activeId !== null &&
-        !index.sessions.some((row) => row.id === activeId)
-      ) {
-        const preserved = existing.get(activeId);
-        if (preserved && !preserved.is_index_only) {
-          this.sessions = [...this.sessions, preserved];
-        }
-      }
       this.nextCursor = index.next_cursor ?? null;
       this.total = index.total;
     } catch {
@@ -830,6 +826,7 @@ class SessionsStore {
     this.refreshRead.cancel();
     this.childSessionsRead.cancel();
     this.activeSessionId = id;
+    this.activeSessionDetail = null;
     this.activeSessionUsageVersion = 0;
     this.refreshVersion++;
     this.childSessionsVersion++;
@@ -844,11 +841,11 @@ class SessionsStore {
     null;
 
   /**
-   * Navigate to a session by ID, loading it into the sessions list if
-   * not already present (e.g. subagent sessions filtered from groups).
-   * Re-invocations for the same still-active session join the in-flight
-   * fetch instead of restarting it, so reactive callers can re-request
-   * hydration without duplicating requests.
+   * Navigate to a session by ID. If it isn't in the current sidebar list
+   * (e.g. opened from search, filtered out, or on an unloaded page), its
+   * detail is fetched into activeSessionDetail rather than injected into the
+   * sidebar collection, so it can back activeSession without appearing in the
+   * filtered list or being double-counted when loadMore appends later pages.
    */
   async navigateToSession(id: string) {
     if (this.navigateInFlight?.id === id && this.activeSessionId === id) {
@@ -861,30 +858,18 @@ class SessionsStore {
       return;
     }
     const signal = this.navigateRead.begin();
-    const entry = { id, promise: Promise.resolve() };
-    entry.promise = (async () => {
-      try {
-        configureGeneratedClient();
-        const session = await callGenerated(
-          () => SessionsService.getApiV1SessionsId({ id }),
-          signal,
-        ) as unknown as Session;
-        if (
-          this.activeSessionId === id && this.navigateRead.isCurrent(signal)
-        ) {
-          const idx = this.sessions.findIndex((s) => s.id === id);
-          if (idx >= 0) {
-            this.mergeHydratedSession(session);
-          } else {
-            this.sessions = [...this.sessions, session];
-          }
-        }
-      } catch {
-        // Session not found — selection stands without metadata
-      } finally {
-        this.navigateRead.finish(signal);
-        if (this.navigateInFlight === entry) {
-          this.navigateInFlight = null;
+    try {
+      configureGeneratedClient();
+      const session = await callGenerated(
+        () => SessionsService.getApiV1SessionsId({ id }),
+        signal,
+      ) as unknown as Session;
+      if (this.activeSessionId === id && this.navigateRead.isCurrent(signal)) {
+        const idx = this.sessions.findIndex((s) => s.id === id);
+        if (idx >= 0) {
+          this.mergeHydratedSession(session);
+        } else {
+          this.activeSessionDetail = session;
         }
       }
     })();
@@ -924,6 +909,10 @@ class SessionsStore {
       const idx = this.sessions.findIndex((s) => s.id === id);
       if (idx >= 0) {
         this.mergeHydratedSession(session);
+      } else if (this.activeSessionDetail?.id === id) {
+        // Active session is backed by the detail cache (not in the sidebar
+        // list); refresh the cache so metadata stays current.
+        this.activeSessionDetail = session;
       }
     } catch {
       // Session may have been deleted

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -1121,6 +1121,21 @@ class SessionsStore {
         };
       }
     }
+    // A cache-only session (opened from search, off the loaded pages) has no
+    // list row to carry the signal detail; fill the cache the same way.
+    const cached = this.activeSessionDetail;
+    if (
+      cached &&
+      cached.id === id &&
+      cached.health_score_basis === undefined &&
+      detail.basis != null
+    ) {
+      this.activeSessionDetail = {
+        ...cached,
+        health_score_basis: detail.basis,
+        health_penalties: detail.penalties,
+      };
+    }
   }
 
   navigateSession(delta: number, filter?: (s: Session) => boolean) {

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -562,10 +562,6 @@ class SessionsStore {
   }
 
   sidebarIndexVersion: number = $state(0);
-  // Session ids supplied by the loaded sidebar index pages; rows in
-  // this.sessions outside this set were appended out of position
-  // (see loadSidebarPage / loadMore).
-  private sidebarIndexIds: Set<string> = new Set();
   hydratedSessionsByVersion: Map<number, Map<string, Session>> =
     $state(new Map());
 
@@ -720,30 +716,18 @@ class SessionsStore {
         signal,
       ) as unknown as SidebarSessionIndexResponse;
       if (this.loadVersion !== version) return;
-      // Merge index-page order first, appended rows last. Rows outside
-      // sidebarIndexIds were appended out of position (the active
-      // session kept by loadSidebarPage, navigateToSession targets);
-      // they stay at the tail until pagination reaches their real
-      // position, then merge in place carrying their hydrated fields.
+      // A later page can re-list a row already present (the index shifts
+      // while paginating); merge it into its new position, carrying the
+      // hydrated fields, instead of duplicating it.
       const existingById = new Map(
         this.sessions.map((session) => [session.id, session]),
       );
-      for (const row of index.sessions) {
-        this.sidebarIndexIds.add(row.id);
-      }
-      const paged = this.sessions.filter(
-        (s) => this.sidebarIndexIds.has(s.id) &&
-          !index.sessions.some((row) => row.id === s.id),
-      );
-      const appended = this.sessions.filter(
-        (s) => !this.sidebarIndexIds.has(s.id),
-      );
+      const pageIds = new Set(index.sessions.map((row) => row.id));
       this.sessions = [
-        ...paged,
+        ...this.sessions.filter((s) => !pageIds.has(s.id)),
         ...index.sessions.map((row) =>
           sidebarIndexRowToSession(row, existingById.get(row.id))
         ),
-        ...appended,
       ];
       this.nextCursor = index.next_cursor ?? null;
       this.total = index.total;
@@ -894,12 +878,19 @@ class SessionsStore {
     if (row && !row.is_index_only) this.activeSessionDetail = row;
   }
 
+  private navigateInFlight: { id: string; promise: Promise<void> } | null =
+    null;
+
   /**
    * Navigate to a session by ID. If it isn't in the current sidebar list
    * (e.g. opened from search, filtered out, or on an unloaded page), its
    * detail is fetched into activeSessionDetail rather than injected into the
    * sidebar collection, so it can back activeSession without appearing in the
    * filtered list or being double-counted when loadMore appends later pages.
+   * Re-invocations for the same still-active session join the in-flight
+   * fetch instead of cancelling and restarting it, so reactive callers
+   * (App's deep-link effect) can re-request hydration without churning the
+   * read coordinator.
    */
   async navigateToSession(id: string) {
     if (this.navigateInFlight?.id === id && this.activeSessionId === id) {
@@ -913,28 +904,36 @@ class SessionsStore {
       return;
     }
     const signal = this.beginActiveDetailRead();
-    try {
-      configureGeneratedClient();
-      const session = await callGenerated(
-        () => SessionsService.getApiV1SessionsId({ id }),
-        signal,
-      ) as unknown as Session;
-      if (
-        this.activeSessionId === id &&
-        this.activeDetailRead.isCurrent(signal)
-      ) {
-        const idx = this.sessions.findIndex((s) => s.id === id);
-        if (idx >= 0) {
-          this.mergeHydratedSession(session);
-        } else {
-          this.activeSessionDetail = session;
+    const entry = { id, promise: Promise.resolve() };
+    entry.promise = (async () => {
+      try {
+        configureGeneratedClient();
+        const session = await callGenerated(
+          () => SessionsService.getApiV1SessionsId({ id }),
+          signal,
+        ) as unknown as Session;
+        if (
+          this.activeSessionId === id &&
+          this.activeDetailRead.isCurrent(signal)
+        ) {
+          const idx = this.sessions.findIndex((s) => s.id === id);
+          if (idx >= 0) {
+            this.mergeHydratedSession(session);
+          } else {
+            this.activeSessionDetail = session;
+          }
+        }
+      } catch {
+        // Session not found — selection stands without metadata
+      } finally {
+        this.activeDetailRead.finish(signal);
+        if (this.navigateInFlight === entry) {
+          this.navigateInFlight = null;
         }
       }
-    } catch {
-      // Session not found — selection stands without metadata
-    } finally {
-      this.activeDetailRead.finish(signal);
-    }
+    })();
+    this.navigateInFlight = entry;
+    return entry.promise;
   }
 
   private async hydrateSelectedIndexOnlySession(id: string) {

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -384,6 +384,12 @@ class SessionsStore {
       deleted: boolean;
       issuedAtIndexOrdinal: number;
       committedAtTick: number;
+      // For deleted commits: whether the tombstone actually removed a
+      // sidebar row, and whether that row counted as a root group. Revival
+      // restores only what was removed — a cache-only session excluded by
+      // the filter must not be injected into the list.
+      removedRow: boolean;
+      removedRoot: boolean;
     }
   >();
   // Generations are globally unique (not per-id counters) so pruning an
@@ -1064,6 +1070,8 @@ class SessionsStore {
       deleted,
       issuedAtIndexOrdinal,
       committedAtTick: this.requestClock,
+      removedRow: false,
+      removedRoot: false,
     });
     if (deleted) {
       this.committedDetailByRow.delete(id);
@@ -1087,16 +1095,13 @@ class SessionsStore {
       !deleted &&
       previous !== undefined &&
       previous.deleted &&
+      previous.removedRow &&
       Number.isFinite(previous.issuedAtIndexOrdinal) &&
       snapshot !== undefined &&
       !this.sessions.some((row) => row.id === id)
     ) {
-      const presentIds = new Set(this.sessions.map((row) => row.id));
       this.sessions = [...this.sessions, { ...snapshot }];
-      if (
-        !snapshot.parent_session_id ||
-        !presentIds.has(snapshot.parent_session_id)
-      ) {
+      if (previous.removedRoot) {
         this.total += 1;
       }
       this.scheduleIndexRefresh();
@@ -1249,6 +1254,14 @@ class SessionsStore {
       0,
       this.total - this.countDroppedRoots(droppedRows, presentIds),
     );
+    for (const row of droppedRows) {
+      const commit = this.activeDetailCommitBySession.get(row.id);
+      if (commit?.deleted) {
+        commit.removedRow = true;
+        commit.removedRoot =
+          !row.parent_session_id || !presentIds.has(row.parent_session_id);
+      }
+    }
     return subtree;
   }
 

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -891,12 +891,23 @@ class SessionsStore {
   }
 
   // Seed activeSessionDetail from a hydrated sidebar row so the open session
-  // survives a later reload that drops it from the filtered/first page. Skips
-  // index-only stubs; hydration then seeds the cache via mergeHydratedSession.
+  // survives a later reload that drops it from the filtered/first page. An
+  // index-only stub cannot seed an empty cache (hydration does that via
+  // mergeHydratedSession), but its index fields still refresh an existing
+  // cached detail: a cache-only session whose row re-enters the index must
+  // absorb renames and count changes the index carries.
   private cacheActiveSessionDetailFromList(id: string) {
     if (id !== this.activeSessionId) return;
     const row = this.sessions.find((s) => s.id === id);
-    if (row && !row.is_index_only) this.activeSessionDetail = row;
+    if (!row) return;
+    if (!row.is_index_only) {
+      this.activeSessionDetail = row;
+      return;
+    }
+    const cached = this.activeSessionDetail;
+    if (cached?.id === id) {
+      this.activeSessionDetail = mergeIndexFieldsIntoDetail(row, cached);
+    }
   }
 
   private navigateInFlight: { id: string; promise: Promise<void> } | null =
@@ -1685,6 +1696,15 @@ function sidebarIndexRowToSession(
     created_at: row.created_at,
   };
   if (!existing || existing.is_index_only) return skinny;
+  return mergeIndexFieldsIntoDetail(skinny, existing);
+}
+
+// Overlay the index-owned fields of a skinny row onto previously hydrated
+// detail, keeping the detail-only fields (first_message, tokens, health).
+function mergeIndexFieldsIntoDetail(
+  skinny: Session,
+  existing: Session,
+): Session {
   return {
     ...skinny,
     ...existing,

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -4276,6 +4276,114 @@ describe("SessionsStore", () => {
       expect(sessions.total).toBe(1);
     });
 
+    it("keeps a rename on a row after the user selects another session", async () => {
+      mockSidebarIndex([
+        makeSkinnyRow({ id: "a", project: "proj-a", display_name: "old" }),
+        makeSkinnyRow({ id: "b", project: "proj-a" }),
+      ]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "a", project: "proj-a", display_name: "old" }),
+      );
+      await sessions.hydrateVisibleSessions(["a"]);
+      sessions.selectSession("a");
+
+      // A re-hydration of A is in flight when A is renamed and the user
+      // then selects B...
+      (sessions as any).invalidateHydratedSessionDetails();
+      let resolveHydration!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveHydration = r;
+        }),
+      );
+      const hydration = sessions.hydrateVisibleSessions(["a"]);
+      await Promise.resolve();
+      vi.mocked(api.renameSession).mockResolvedValueOnce(
+        makeSession({ id: "a", display_name: "renamed" }),
+      );
+      await sessions.renameSession("a", "renamed");
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "b", project: "proj-a", first_message: "b-detail" }),
+      );
+      sessions.selectSession("b");
+
+      // ...and A's stale pre-rename response resolves. A is no longer the
+      // active session, but its committed rename must still win.
+      resolveHydration(
+        makeSession({ id: "a", project: "proj-a", display_name: "old" }),
+      );
+      await hydration;
+
+      expect(
+        sessions.sessions.find((s) => s.id === "a")?.display_name,
+      ).toBe("renamed");
+    });
+
+    it("removes batch-deleted rows even when the forced reload fails", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "gone", project: "proj-a" })]);
+      await sessions.load();
+      expect(sessions.total).toBe(1);
+
+      vi.mocked(api.batchDeleteSessions).mockResolvedValueOnce({});
+      vi.mocked(api.getSidebarSessionIndex).mockRejectedValueOnce(
+        new Error("network"),
+      );
+      await sessions.batchDeleteSessions(["gone"]);
+
+      expect(sessions.sessions.some((s) => s.id === "gone")).toBe(false);
+      expect(sessions.total).toBe(0);
+    });
+
+    it("keeps local root deletions when a later page's stale total arrives", async () => {
+      vi.mocked(api.getSidebarSessionIndex).mockResolvedValueOnce({
+        sessions: [makeSkinnyRow({ id: "root1", project: "proj-a" })],
+        total: 2,
+        next_cursor: "page-2",
+      });
+      await sessions.load();
+      expect(sessions.total).toBe(2);
+
+      // A root loaded on page 1 is deleted...
+      vi.mocked(api.deleteSession).mockResolvedValueOnce({});
+      await sessions.deleteSession("root1");
+      expect(sessions.total).toBe(1);
+
+      // ...then page 2 resolves carrying the cursor's page-1-era total.
+      // The stale snapshot total must not undo the local deletion.
+      vi.mocked(api.getSidebarSessionIndex).mockResolvedValueOnce({
+        sessions: [makeSkinnyRow({ id: "root2", project: "proj-a" })],
+        total: 2,
+        next_cursor: null,
+      });
+      await sessions.loadMore();
+
+      expect(sessions.total).toBe(1);
+    });
+
+    it("counts a promoted orphan row as a root when it is deleted", async () => {
+      vi.mocked(api.getSidebarSessionIndex).mockResolvedValue({
+        sessions: [
+          makeSkinnyRow({
+            id: "orphan",
+            project: "proj-a",
+            parent_session_id: "missing-root",
+          }),
+        ],
+        total: 1,
+        next_cursor: null,
+      });
+      await sessions.load();
+      expect(sessions.total).toBe(1);
+
+      // The orphan's parent is not in the list, so the sidebar promotes it
+      // to its own root group; deleting it must decrement the root total.
+      vi.mocked(api.deleteSession).mockResolvedValueOnce({});
+      await sessions.deleteSession("orphan");
+
+      expect(sessions.total).toBe(0);
+    });
+
     it("ignores a stale hydration resolving after a newer refresh", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -14,12 +14,14 @@ import {
   splitExcludeProjectParam,
 } from "./sessions.svelte.js";
 import { SessionsService } from "../api/generated/index";
-import { ApiError } from "../api/generated/core/ApiError";
 import { starred } from "./starred.svelte.js";
 import { yokedDates } from "./yokedDates.svelte.js";
 import type { Filters } from "./sessions.svelte.js";
 import type { Session } from "../api/types.js";
-import { callGenerated } from "../api/runtime.js";
+import {
+  ApiError as RuntimeApiError,
+  callGenerated,
+} from "../api/runtime.js";
 import { rollingRange } from "../utils/dates.js";
 
 const api = vi.hoisted(() => ({
@@ -62,14 +64,18 @@ vi.mock("../api/client.js", () => ({
   watchEvents: api.watchEvents,
 }));
 
-vi.mock("../api/runtime.js", () => ({
-  configureGeneratedClient: vi.fn(),
-  callGenerated: vi.fn((request: () => Promise<unknown>) => request()),
-  isAbortError: vi.fn(
-    (error: unknown) =>
-      error instanceof DOMException && error.name === "AbortError",
-  ),
-}));
+vi.mock("../api/runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../api/runtime.js")>();
+  return {
+    ...actual,
+    configureGeneratedClient: vi.fn(),
+    callGenerated: vi.fn((request: () => Promise<unknown>) => request()),
+    isAbortError: vi.fn(
+      (error: unknown) =>
+        error instanceof DOMException && error.name === "AbortError",
+    ),
+  };
+});
 
 vi.mock("../api/generated/index", () => ({
   SessionsService: {
@@ -106,13 +112,11 @@ function mockSidebarPage(
   });
 }
 
-function makeNotFoundError(id: string): ApiError {
-  const url = `/api/v1/sessions/${id}`;
-  return new ApiError(
-    { method: "GET", url },
-    { url, ok: false, status: 404, statusText: "Not Found", body: null },
-    "Not Found",
-  );
+// Store code never sees the generated ApiError class: production callGenerated
+// converts it to the runtime ApiError before rethrowing. Reject fixtures with
+// the runtime class to model that boundary faithfully.
+function makeNotFoundError(id: string): RuntimeApiError {
+  return new RuntimeApiError(404, `session ${id} not found`);
 }
 
 function rejectGeneratedRequestOnAbort(

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -2915,6 +2915,70 @@ describe("SessionsStore", () => {
       expect(sessions.activeSession?.display_name).toBe("renamed");
     });
 
+    it("seeds the cache from a hydration already in flight at selection", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
+      await sessions.load();
+
+      // Viewport hydration of the row is already in flight when the user
+      // selects it; selection joins that request rather than issuing a new
+      // one, so its response must still hydrate the row and seed the cache.
+      let resolveHydration!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveHydration = r;
+        }),
+      );
+      const hydration = sessions.hydrateVisibleSessions(["sel"]);
+      await Promise.resolve();
+      sessions.selectSession("sel");
+
+      resolveHydration(
+        makeSession({ id: "sel", project: "proj-a", first_message: "detail" }),
+      );
+      await hydration;
+
+      expect(api.getSession).toHaveBeenCalledTimes(1);
+      expect(sessions.activeSession?.first_message).toBe("detail");
+
+      // The seeded cache must survive a reload that drops the row.
+      mockSidebarIndex([makeSkinnyRow({ id: "other", project: "proj-b" })]);
+      await sessions.load();
+      expect(sessions.activeSession?.first_message).toBe("detail");
+    });
+
+    it("ignores a stale hydration resolving after a newer refresh", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
+      await sessions.load();
+
+      // Hydration of the visible row stays in flight...
+      let resolveHydration!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveHydration = r;
+        }),
+      );
+      const hydration = sessions.hydrateVisibleSessions(["sel"]);
+      await Promise.resolve();
+
+      // ...the user selects that row, and a watcher-driven refresh resolves
+      // first with a fresher snapshot for both the row and the cache.
+      sessions.selectSession("sel");
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", project: "proj-a", first_message: "NEWER" }),
+      );
+      await sessions.refreshActiveSession();
+      expect(sessions.activeSession?.first_message).toBe("NEWER");
+
+      // The older hydration passes the sidebar version/epoch checks (no
+      // reload happened) but must not clobber the newer active detail.
+      resolveHydration(
+        makeSession({ id: "sel", project: "proj-a", first_message: "STALE" }),
+      );
+      await hydration;
+
+      expect(sessions.activeSession?.first_message).toBe("NEWER");
+    });
+
     it("clears the cached detail when the active session was deleted", async () => {
       mockSidebarIndex([]);
       await sessions.load();
@@ -2928,6 +2992,35 @@ describe("SessionsStore", () => {
       // breadcrumb must empty rather than keep showing the ghost session.
       vi.mocked(api.getSession).mockRejectedValueOnce(makeNotFoundError("gone"));
       await sessions.refreshActiveSession();
+
+      expect(sessions.activeSession).toBeUndefined();
+    });
+
+    it("does not let an in-flight hydration resurrect a deleted session", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "gone", project: "proj-a" })]);
+      await sessions.load();
+
+      let resolveHydration!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveHydration = r;
+        }),
+      );
+      const hydration = sessions.hydrateVisibleSessions(["gone"]);
+      await Promise.resolve();
+      sessions.selectSession("gone");
+
+      // The session is deleted elsewhere; a refresh 404s and clears the
+      // cache while the hydration response is still in flight.
+      vi.mocked(api.getSession).mockRejectedValueOnce(makeNotFoundError("gone"));
+      await sessions.refreshActiveSession();
+      expect(sessions.activeSession).toBeUndefined();
+
+      // The pre-deletion hydration snapshot must not refill the cache.
+      resolveHydration(
+        makeSession({ id: "gone", project: "proj-a", first_message: "ghost" }),
+      );
+      await hydration;
 
       expect(sessions.activeSession).toBeUndefined();
     });

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -3254,6 +3254,88 @@ describe("SessionsStore", () => {
       ).toBe("renamed");
     });
 
+    it("keeps newer index fields when a failed refresh preceded the commit", async () => {
+      mockSidebarIndex([
+        makeSkinnyRow({ id: "sel", project: "proj-a", display_name: "old" }),
+      ]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", project: "proj-a", display_name: "old" }),
+      );
+      await sessions.hydrateVisibleSessions(["sel"]);
+      sessions.selectSession("sel");
+
+      // An index reload is in flight, carrying a newer rename from another
+      // machine...
+      let resolveIndex!: (v: unknown) => void;
+      vi.mocked(api.getSidebarSessionIndex).mockReturnValueOnce(
+        new Promise((r) => {
+          resolveIndex = r;
+        }),
+      );
+      const reload = sessions.load({ force: true });
+
+      // ...when a watcher refresh starts and fails transiently. The read
+      // began but committed nothing, so the cache holds no fresher state
+      // than the index — restoring it would revert the newer rename.
+      vi.mocked(api.getSession).mockRejectedValueOnce(new Error("network"));
+      await sessions.refreshActiveSession();
+
+      resolveIndex({
+        sessions: [
+          makeSkinnyRow({
+            id: "sel",
+            project: "proj-a",
+            display_name: "server-renamed",
+          }),
+        ],
+        total: 1,
+      });
+      await reload;
+
+      expect(
+        sessions.sessions.find((s) => s.id === "sel")?.display_name,
+      ).toBe("server-renamed");
+      expect(sessions.activeSession?.display_name).toBe("server-renamed");
+    });
+
+    it("does not let a stale index resurrect a 404-deleted active row", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "gone", project: "proj-a" })]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "gone", project: "proj-a", first_message: "detail" }),
+      );
+      await sessions.hydrateVisibleSessions(["gone"]);
+      sessions.selectSession("gone");
+
+      // An index reload whose server snapshot predates the deletion is in
+      // flight when a refresh 404s and removes the row...
+      let resolveIndex!: (v: unknown) => void;
+      vi.mocked(api.getSidebarSessionIndex).mockReturnValueOnce(
+        new Promise((r) => {
+          resolveIndex = r;
+        }),
+      );
+      const reload = sessions.load({ force: true });
+
+      vi.mocked(api.getSession).mockRejectedValueOnce(makeNotFoundError("gone"));
+      await sessions.refreshActiveSession();
+      expect(sessions.activeSession).toBeUndefined();
+      expect(sessions.sessions.some((s) => s.id === "gone")).toBe(false);
+
+      // ...the stale index still lists the session; committing it must honor
+      // the deletion instead of resurrecting the row.
+      resolveIndex({
+        sessions: [makeSkinnyRow({ id: "gone", project: "proj-a" })],
+        total: 1,
+      });
+      await reload;
+
+      expect(sessions.sessions.some((s) => s.id === "gone")).toBe(false);
+      expect(sessions.activeSession).toBeUndefined();
+      expect(sessions.total).toBe(0);
+    });
+
     it("ignores a stale hydration resolving after a newer refresh", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -2915,6 +2915,44 @@ describe("SessionsStore", () => {
       expect(sessions.activeSession?.display_name).toBe("renamed");
     });
 
+    it("does not let an in-flight hydration revert a rename of an index-only row", async () => {
+      mockSidebarIndex([
+        makeSkinnyRow({ id: "sel", project: "proj-a", display_name: "stale" }),
+      ]);
+      await sessions.load();
+
+      // Hydration of the index-only row stays in flight while the user
+      // selects it (selection joins the request) and renames it. The detail
+      // cache is still empty at rename time, so the rename must advance the
+      // freshness generation without relying on a populated cache.
+      let resolveHydration!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveHydration = r;
+        }),
+      );
+      const hydration = sessions.hydrateVisibleSessions(["sel"]);
+      await Promise.resolve();
+      sessions.selectSession("sel");
+
+      vi.mocked(api.renameSession).mockResolvedValue(
+        makeSession({ id: "sel", display_name: "renamed" }),
+      );
+      await sessions.renameSession("sel", "renamed");
+      expect(sessions.sessions[0]?.display_name).toBe("renamed");
+
+      // The pre-rename hydration snapshot must not overwrite the row or seed
+      // the breadcrumb cache with the old name.
+      resolveHydration(
+        makeSession({ id: "sel", project: "proj-a", display_name: "stale" }),
+      );
+      await hydration;
+
+      expect(sessions.sessions[0]?.display_name).toBe("renamed");
+      expect(sessions.activeSession?.display_name).not.toBe("stale");
+      expect(sessions.activeSessionDetail?.display_name).not.toBe("stale");
+    });
+
     it("seeds the cache from a hydration already in flight at selection", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -3505,6 +3505,62 @@ describe("SessionsStore", () => {
       expect(sessions.activeSession?.display_name).toBe("server-renamed");
     });
 
+    it("keeps mid-flight index commits' fields over an older refresh response", async () => {
+      mockSidebarIndex([
+        makeSkinnyRow({ id: "sel", project: "proj-a", display_name: "old" }),
+      ]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({
+          id: "sel",
+          project: "proj-a",
+          display_name: "old",
+          first_message: "detail-1",
+        }),
+      );
+      await sessions.hydrateVisibleSessions(["sel"]);
+      sessions.selectSession("sel");
+
+      // A watcher refresh is in flight...
+      let resolveRefresh!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveRefresh = r;
+        }),
+      );
+      const refresh = sessions.refreshActiveSession();
+      await Promise.resolve();
+
+      // ...when an index reload commits a newer remote rename.
+      mockSidebarIndex([
+        makeSkinnyRow({
+          id: "sel",
+          project: "proj-a",
+          display_name: "server-renamed",
+        }),
+      ]);
+      await sessions.load({ force: true });
+      expect(sessions.activeSession?.display_name).toBe("server-renamed");
+
+      // The refresh response predates that commit. Its detail-owned fields
+      // still apply, but the committed index's fields must not be reverted.
+      resolveRefresh(
+        makeSession({
+          id: "sel",
+          project: "proj-a",
+          display_name: "old",
+          first_message: "detail-2",
+        }),
+      );
+      await refresh;
+
+      expect(sessions.activeSession?.display_name).toBe("server-renamed");
+      expect(sessions.activeSession?.first_message).toBe("detail-2");
+      const row = sessions.sessions.find((s) => s.id === "sel");
+      expect(row?.display_name).toBe("server-renamed");
+      expect(row?.first_message).toBe("detail-2");
+    });
+
     it("ignores a stale hydration resolving after a newer refresh", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -14,6 +14,7 @@ import {
   splitExcludeProjectParam,
 } from "./sessions.svelte.js";
 import { SessionsService } from "../api/generated/index";
+import { ApiError } from "../api/generated/core/ApiError";
 import { starred } from "./starred.svelte.js";
 import { yokedDates } from "./yokedDates.svelte.js";
 import type { Filters } from "./sessions.svelte.js";
@@ -103,6 +104,15 @@ function mockSidebarPage(
     total: 0,
     ...overrides,
   });
+}
+
+function makeNotFoundError(id: string): ApiError {
+  const url = `/api/v1/sessions/${id}`;
+  return new ApiError(
+    { method: "GET", url },
+    { url, ok: false, status: 404, statusText: "Not Found", body: null },
+    "Not Found",
+  );
 }
 
 function rejectGeneratedRequestOnAbort(
@@ -2901,6 +2911,38 @@ describe("SessionsStore", () => {
       expect(sessions.activeSession?.display_name).toBe("renamed");
     });
 
+    it("clears the cached detail when the active session was deleted", async () => {
+      mockSidebarIndex([]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "gone", project: "proj-b", first_message: "detail" }),
+      );
+      await sessions.navigateToSession("gone");
+      expect(sessions.activeSession?.id).toBe("gone");
+
+      // The session is deleted elsewhere; a watcher-driven refresh 404s. The
+      // breadcrumb must empty rather than keep showing the ghost session.
+      vi.mocked(api.getSession).mockRejectedValueOnce(makeNotFoundError("gone"));
+      await sessions.refreshActiveSession();
+
+      expect(sessions.activeSession).toBeUndefined();
+    });
+
+    it("keeps the cached detail when a refresh fails transiently", async () => {
+      mockSidebarIndex([]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "flaky", project: "proj-b", first_message: "detail" }),
+      );
+      await sessions.navigateToSession("flaky");
+
+      // A non-404 failure (server restart, network) must not blank the
+      // breadcrumb; only a definitive not-found may clear the cache.
+      vi.mocked(api.getSession).mockRejectedValueOnce(new Error("network down"));
+      await sessions.refreshActiveSession();
+
+      expect(sessions.activeSession?.first_message).toBe("detail");
+    });
   });
 
   describe("route cancellation", () => {

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -4123,6 +4123,40 @@ describe("SessionsStore", () => {
       expect(sessions.total).toBe(0);
     });
 
+    it("does not reinsert a deleted row from a stale successful reload", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "gone", project: "proj-a" })]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "gone", project: "proj-a", first_message: "detail" }),
+      );
+      await sessions.hydrateVisibleSessions(["gone"]);
+
+      // A reload whose server snapshot predates the deletion is in flight
+      // when the user deletes the (non-active) row...
+      let resolveIndex!: (v: unknown) => void;
+      vi.mocked(api.getSidebarSessionIndex).mockReturnValueOnce(
+        new Promise((r) => {
+          resolveIndex = r;
+        }),
+      );
+      const reload = sessions.load({ force: true });
+      vi.mocked(api.deleteSession).mockResolvedValueOnce({});
+      await sessions.deleteSession("gone");
+      expect(sessions.sessions.some((s) => s.id === "gone")).toBe(false);
+
+      // ...and the reload then resolves successfully, still listing the row.
+      // Publishing must honor the deletion tombstone for every row, not just
+      // the active session's.
+      resolveIndex({
+        sessions: [makeSkinnyRow({ id: "gone", project: "proj-a" })],
+        total: 1,
+      });
+      await reload;
+
+      expect(sessions.sessions.some((s) => s.id === "gone")).toBe(false);
+      expect(sessions.total).toBe(0);
+    });
+
     it("ignores a stale hydration resolving after a newer refresh", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -5130,6 +5130,36 @@ describe("SessionsStore", () => {
       expect(sessions.total).toBe(1);
     });
 
+    it("revives the row after consecutive 404s for the same session", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", project: "proj-a", first_message: "A" }),
+      );
+      await sessions.hydrateVisibleSessions(["sel"]);
+      sessions.selectSession("sel");
+
+      // Two consecutive transient 404s: the first removes the row, the
+      // second finds it already gone. The record of the removal must
+      // survive both.
+      vi.mocked(api.getSession).mockRejectedValueOnce(makeNotFoundError("sel"));
+      await sessions.refreshActiveSession();
+      vi.mocked(api.getSession).mockRejectedValueOnce(makeNotFoundError("sel"));
+      await sessions.refreshActiveSession();
+      expect(sessions.sessions.length).toBe(0);
+
+      // A later successful refresh revives the session: the sidebar row and
+      // total must come back, not just the detail cache.
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", project: "proj-a", first_message: "B" }),
+      );
+      await sessions.refreshActiveSession();
+
+      expect(sessions.activeSession?.first_message).toBe("B");
+      expect(sessions.sessions.some((s) => s.id === "sel")).toBe(true);
+      expect(sessions.total).toBe(1);
+    });
+
     it("ignores a stale hydration resolving after a newer refresh", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -5240,6 +5240,196 @@ describe("SessionsStore", () => {
       expect(sessions.total).toBe(1);
     });
 
+    it("subtracts a later-page root deleted during a stale reload", async () => {
+      vi.mocked(api.getSidebarSessionIndex).mockResolvedValueOnce({
+        sessions: [makeSkinnyRow({ id: "rootA", project: "proj-a" })],
+        total: 2,
+        next_cursor: "page-2",
+      });
+      await sessions.load();
+      vi.mocked(api.getSidebarSessionIndex).mockResolvedValueOnce({
+        sessions: [makeSkinnyRow({ id: "rootB", project: "proj-a" })],
+        total: 2,
+        next_cursor: null,
+      });
+      await sessions.loadMore();
+      expect(sessions.total).toBe(2);
+
+      // A reload is in flight when the later-page root is deleted. The
+      // stale first page neither lists rootB nor knows it is gone, but its
+      // committed total must still reflect the deletion.
+      let resolveIndex!: (v: unknown) => void;
+      vi.mocked(api.getSidebarSessionIndex).mockReturnValueOnce(
+        new Promise((r) => {
+          resolveIndex = r;
+        }),
+      );
+      const reload = sessions.load({ force: true });
+      vi.mocked(api.deleteSession).mockResolvedValueOnce({});
+      await sessions.deleteSession("rootB");
+      expect(sessions.total).toBe(1);
+
+      resolveIndex({
+        sessions: [makeSkinnyRow({ id: "rootA", project: "proj-a" })],
+        total: 2,
+        next_cursor: "page-2",
+      });
+      await reload;
+
+      expect(sessions.total).toBe(1);
+    });
+
+    it("forces a fresh reload after restoring a deleted session", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "rootP", project: "proj-a" })]);
+      await sessions.load();
+      vi.mocked(api.deleteSession).mockResolvedValueOnce({});
+      await sessions.deleteSession("rootP");
+      expect(sessions.total).toBe(0);
+
+      // A watcher-driven reload with a pre-restore snapshot is in flight
+      // when the user restores the session. Joining it would publish a list
+      // without the restored root; the restore must force a fresh load.
+      let resolveStale!: (v: unknown) => void;
+      vi.mocked(api.getSidebarSessionIndex).mockReturnValueOnce(
+        new Promise((r) => {
+          resolveStale = r;
+        }),
+      );
+      void sessions.load();
+      await Promise.resolve();
+      vi.mocked(api.restoreSession).mockResolvedValueOnce({});
+      vi.mocked(api.getSidebarSessionIndex).mockResolvedValueOnce({
+        sessions: [makeSkinnyRow({ id: "rootP", project: "proj-a" })],
+        total: 1,
+        next_cursor: null,
+      });
+      const restore = sessions.restoreSession("rootP");
+      resolveStale({ sessions: [], total: 0, next_cursor: null });
+      await restore;
+
+      expect(sessions.sessions.some((s) => s.id === "rootP")).toBe(true);
+      expect(sessions.total).toBe(1);
+    });
+
+    it("treats any complete publish excluding the id as membership truth", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", project: "proj-a", first_message: "A" }),
+      );
+      await sessions.hydrateVisibleSessions(["sel"]);
+      sessions.selectSession("sel");
+
+      // A filter reload excluding the session is issued BEFORE the 404...
+      let resolveIndex!: (v: unknown) => void;
+      vi.mocked(api.getSidebarSessionIndex).mockReturnValueOnce(
+        new Promise((r) => {
+          resolveIndex = r;
+        }),
+      );
+      const reload = sessions.load({ force: true });
+      vi.mocked(api.getSession).mockRejectedValueOnce(makeNotFoundError("sel"));
+      await sessions.refreshActiveSession();
+
+      // ...and commits after it, excluding the session by filters.
+      resolveIndex({
+        sessions: [makeSkinnyRow({ id: "other", project: "proj-b" })],
+        total: 1,
+        next_cursor: null,
+      });
+      await reload;
+
+      // Revival must respect that complete publish's membership regardless
+      // of which request was issued first.
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", project: "proj-a", first_message: "B" }),
+      );
+      await sessions.refreshActiveSession();
+
+      expect(sessions.activeSession?.first_message).toBe("B");
+      expect(sessions.sessions.some((s) => s.id === "sel")).toBe(false);
+      expect(sessions.total).toBe(1);
+    });
+
+    it("keeps newer index fields when merging a version-superseded hydration", async () => {
+      mockSidebarIndex([
+        makeSkinnyRow({ id: "sel", project: "proj-a", message_count: 5 }),
+      ]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({
+          id: "sel",
+          project: "proj-a",
+          message_count: 5,
+          first_message: "v1",
+        }),
+      );
+      await sessions.hydrateVisibleSessions(["sel"]);
+      sessions.selectSession("sel");
+
+      (sessions as any).invalidateHydratedSessionDetails();
+      let resolveHydration!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveHydration = r;
+        }),
+      );
+      const hydration = sessions.hydrateVisibleSessions(["sel"]);
+      await Promise.resolve();
+
+      // The reload re-lists the row with newer index-owned fields.
+      mockSidebarIndex([
+        makeSkinnyRow({ id: "sel", project: "proj-a", message_count: 42 }),
+      ]);
+      await sessions.load({ force: true });
+
+      // The version-superseded hydration still merges its detail fields,
+      // but must not roll back the reloaded row's newer index-owned ones.
+      resolveHydration(
+        makeSession({
+          id: "sel",
+          project: "proj-a",
+          message_count: 5,
+          first_message: "v2",
+        }),
+      );
+      await hydration;
+
+      const row = sessions.sessions.find((s) => s.id === "sel");
+      expect(row?.first_message).toBe("v2");
+      expect(row?.message_count).toBe(42);
+    });
+
+    it("does not merge a hydration superseded by an epoch invalidation", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", project: "proj-a", first_message: "fresh" }),
+      );
+      await sessions.hydrateVisibleSessions(["sel"]);
+      sessions.selectSession("sel");
+
+      // A hydration is in flight when a messages event invalidates the
+      // hydration caches (same index version, bumped epoch). Its response
+      // predates the messages change and must not merge back.
+      (sessions as any).invalidateHydratedSessionDetails();
+      let resolveStale!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveStale = r;
+        }),
+      );
+      const stale = sessions.hydrateVisibleSessions(["sel"]);
+      await Promise.resolve();
+      (sessions as any).invalidateHydratedSessionDetails();
+      resolveStale(
+        makeSession({ id: "sel", project: "proj-a", first_message: "older" }),
+      );
+      await stale;
+
+      expect(sessions.activeSession?.first_message).toBe("fresh");
+    });
+
     it("ignores a stale hydration resolving after a newer refresh", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -2743,6 +2743,60 @@ describe("SessionsStore", () => {
       expect(sessions.activeSessionId).toBe("sel");
       expect(sessions.activeSession?.project).toBe("proj-a");
     });
+
+    it("keeps a keyboard-navigated session across an excluding reload", async () => {
+      mockSidebarIndex([
+        makeSkinnyRow({ id: "a", project: "proj-a" }),
+        makeSkinnyRow({ id: "b", project: "proj-a" }),
+      ]);
+      vi.mocked(api.getSession).mockImplementation((id: string) =>
+        Promise.resolve(
+          makeSession({ id, project: "proj-a", first_message: `${id}-detail` }),
+        ),
+      );
+      await sessions.load();
+      sessions.selectSession("a");
+      await vi.waitFor(() => expect(sessions.activeSession?.id).toBe("a"));
+
+      // Keyboard next moves to "b" via navigateSession, not selectSession.
+      sessions.navigateSession(1);
+      await vi.waitFor(() => expect(sessions.activeSession?.id).toBe("b"));
+
+      // A reload excludes the keyboard-navigated session.
+      mockSidebarIndex([makeSkinnyRow({ id: "c", project: "proj-b" })]);
+      await sessions.load();
+
+      expect(sessions.activeSessionId).toBe("b");
+      expect(sessions.activeSession?.id).toBe("b");
+    });
+
+    it("caches an index-only selection even when a reload supersedes hydration", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
+      await sessions.load();
+
+      // Hydration request stays in flight until after the reload below.
+      let resolveGet!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValue(
+        new Promise<Session>((r) => {
+          resolveGet = r;
+        }),
+      );
+      sessions.selectSession("sel");
+      await Promise.resolve();
+
+      // A reload bumps the sidebar index version and drops "sel".
+      mockSidebarIndex([makeSkinnyRow({ id: "other", project: "proj-b" })]);
+      await sessions.load();
+
+      // The superseded hydration resolves; its version is stale for the list
+      // but the active-session cache must still capture it.
+      resolveGet(makeSession({ id: "sel", project: "proj-a", first_message: "detail" }));
+      await vi.waitFor(() => {
+        expect(sessions.activeSession?.project).toBe("proj-a");
+      });
+
+      expect(sessions.activeSessionId).toBe("sel");
+    });
   });
 
   describe("route cancellation", () => {

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -3176,6 +3176,44 @@ describe("SessionsStore", () => {
       expect(sessions.activeSession?.first_message).toBe("detail");
     });
 
+    it("keeps a joined hydration fresh across another session's detail read", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
+      await sessions.load();
+
+      // Viewport hydration of the row is in flight...
+      let resolveHydration!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveHydration = r;
+        }),
+      );
+      const hydration = sessions.hydrateVisibleSessions(["sel"]);
+      await Promise.resolve();
+
+      // ...while a navigation resolves detail for a DIFFERENT session.
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "other", project: "proj-b" }),
+      );
+      await sessions.navigateToSession("other");
+      expect(sessions.activeSession?.id).toBe("other");
+
+      // The user then selects the still-hydrating row; selection joins the
+      // in-flight request. The other session's read must not mark this
+      // session's hydration stale — no newer read for THIS session exists,
+      // so the joined response still owns the row and the detail cache.
+      sessions.selectSession("sel");
+      resolveHydration(
+        makeSession({ id: "sel", project: "proj-a", first_message: "detail" }),
+      );
+      await hydration;
+
+      expect(api.getSession).toHaveBeenCalledTimes(2);
+      expect(sessions.activeSession?.first_message).toBe("detail");
+      expect(
+        sessions.sessions.find((s) => s.id === "sel")?.is_index_only,
+      ).toBe(false);
+    });
+
     it("ignores a stale hydration resolving after a newer refresh", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -765,6 +765,67 @@ describe("SessionsStore", () => {
       );
     });
 
+    it("keeps refreshed active-row fields when a later reload excludes the row", async () => {
+      mockSidebarIndex([
+        makeSkinnyRow({ id: "active", display_name: "old-name" }),
+      ]);
+      vi.mocked(api.getSession).mockResolvedValue(
+        makeSession({ id: "active", first_message: "hydrated detail" }),
+      );
+
+      await sessions.load();
+      sessions.selectSession("active");
+      await vi.waitFor(() => {
+        expect(sessions.activeSession?.first_message).toBe("hydrated detail");
+      });
+
+      // An index refresh renames the still-included active row...
+      mockSidebarIndex([
+        makeSkinnyRow({ id: "active", display_name: "new-name" }),
+      ]);
+      await sessions.load();
+
+      // ...and a later reload excludes it: the breadcrumb must keep the
+      // refreshed fields, not revert to the pre-refresh cached snapshot.
+      mockSidebarIndex([]);
+      await sessions.load();
+
+      expect(sessions.activeSession?.first_message).toBe("hydrated detail");
+      expect(sessions.activeSession?.display_name).toBe("new-name");
+    });
+
+    it("keeps active-row fields refreshed by a later page through an excluding reload", async () => {
+      vi.mocked(api.getSidebarSessionIndex).mockResolvedValueOnce({
+        sessions: [makeSkinnyRow({ id: "active", display_name: "old-name" })],
+        total: 2,
+        next_cursor: "page-2",
+      });
+      vi.mocked(api.getSession).mockResolvedValue(
+        makeSession({ id: "active", first_message: "hydrated detail" }),
+      );
+
+      await sessions.load();
+      sessions.selectSession("active");
+      await vi.waitFor(() => {
+        expect(sessions.activeSession?.first_message).toBe("hydrated detail");
+      });
+
+      // The index shifted while paginating: page 2 re-lists the active row
+      // with a refreshed name.
+      vi.mocked(api.getSidebarSessionIndex).mockResolvedValueOnce({
+        sessions: [makeSkinnyRow({ id: "active", display_name: "new-name" })],
+        total: 2,
+        next_cursor: null,
+      });
+      await sessions.loadMore();
+
+      mockSidebarIndex([]);
+      await sessions.load();
+
+      expect(sessions.activeSession?.first_message).toBe("hydrated detail");
+      expect(sessions.activeSession?.display_name).toBe("new-name");
+    });
+
     it("keeps the open off-page session when the reloaded index omits it", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "listed" })]);
       vi.mocked(api.getSession).mockResolvedValue(
@@ -3199,6 +3260,7 @@ describe("SessionsStore", () => {
 
       expect(sessions.activeSession?.first_message).toBe("detail");
     });
+
   });
 
   describe("route cancellation", () => {

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -3063,6 +3063,28 @@ describe("SessionsStore", () => {
       expect(sessions.activeSession).toBeUndefined();
     });
 
+    it("drops a hydrated sidebar row when a refresh 404s for the active session", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "gone", project: "proj-a" })]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "gone", project: "proj-a", first_message: "detail" }),
+      );
+      await sessions.hydrateVisibleSessions(["gone"]);
+      sessions.selectSession("gone");
+      expect(sessions.activeSession?.first_message).toBe("detail");
+      expect(sessions.total).toBe(1);
+
+      // The session is deleted elsewhere; a refresh 404s. Clearing only the
+      // detail cache is not enough — the hydrated sidebar row would keep
+      // backing activeSession as a ghost of the deleted session.
+      vi.mocked(api.getSession).mockRejectedValueOnce(makeNotFoundError("gone"));
+      await sessions.refreshActiveSession();
+
+      expect(sessions.activeSession).toBeUndefined();
+      expect(sessions.sessions.some((s) => s.id === "gone")).toBe(false);
+      expect(sessions.total).toBe(0);
+    });
+
     it("keeps the cached detail when a refresh fails transiently", async () => {
       mockSidebarIndex([]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -4048,6 +4048,81 @@ describe("SessionsStore", () => {
       expect(sessions.total).toBe(0);
     });
 
+    it("orders same-generation detail reads by issue, not resolution", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", project: "proj-a", first_message: "A" }),
+      );
+      await sessions.hydrateVisibleSessions(["sel"]);
+      sessions.selectSession("sel");
+
+      // A refresh is issued first and stays in flight...
+      let resolveRefresh!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveRefresh = r;
+        }),
+      );
+      const refresh = sessions.refreshActiveSession();
+      await Promise.resolve();
+
+      // ...then a messages event invalidates hydration caches and a NEW
+      // hydration is issued for the same row, in the same index generation.
+      (sessions as any).invalidateHydratedSessionDetails();
+      let resolveHydration!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveHydration = r;
+        }),
+      );
+      const hydration = sessions.hydrateVisibleSessions(["sel"]);
+      await Promise.resolve();
+
+      // The earlier-issued refresh resolves first with older data. Its
+      // commit must not invalidate the later-issued hydration, whose
+      // response is the newer one.
+      resolveRefresh(
+        makeSession({ id: "sel", project: "proj-a", first_message: "R-stale" }),
+      );
+      await refresh;
+      resolveHydration(
+        makeSession({ id: "sel", project: "proj-a", first_message: "H-newer" }),
+      );
+      await hydration;
+
+      expect(sessions.activeSession?.first_message).toBe("H-newer");
+    });
+
+    it("does not resurrect an explicitly deleted row when a reload fails", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "gone", project: "proj-a" })]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "gone", project: "proj-a", first_message: "detail" }),
+      );
+      await sessions.hydrateVisibleSessions(["gone"]);
+
+      // A reload is in flight when the user explicitly deletes the row...
+      let rejectIndex!: (e: unknown) => void;
+      vi.mocked(api.getSidebarSessionIndex).mockReturnValueOnce(
+        new Promise((_r, rej) => {
+          rejectIndex = rej;
+        }),
+      );
+      const reload = sessions.load({ force: true });
+      vi.mocked(api.deleteSession).mockResolvedValueOnce({});
+      await sessions.deleteSession("gone");
+      expect(sessions.sessions.some((s) => s.id === "gone")).toBe(false);
+
+      // ...and the reload then fails. The restored pre-reload snapshot must
+      // not bring the deleted row back as a sidebar ghost.
+      rejectIndex(new Error("network"));
+      await reload;
+
+      expect(sessions.sessions.some((s) => s.id === "gone")).toBe(false);
+      expect(sessions.total).toBe(0);
+    });
+
     it("ignores a stale hydration resolving after a newer refresh", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -3969,6 +3969,85 @@ describe("SessionsStore", () => {
       expect(sessions.activeSession?.first_message).toBe("enriched-detail");
     });
 
+    it("does not let a superseded hydration invalidate a newer one", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
+      await sessions.load();
+
+      // Hydration H1 is in flight under the old index version...
+      let resolveH1!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveH1 = r;
+        }),
+      );
+      const h1 = sessions.hydrateVisibleSessions(["sel"]);
+      await Promise.resolve();
+      sessions.selectSession("sel");
+
+      // ...a reload commits a new index version, and hydration H2 starts
+      // under it.
+      mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
+      await sessions.load({ force: true });
+      let resolveH2!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveH2 = r;
+        }),
+      );
+      const h2 = sessions.hydrateVisibleSessions(["sel"]);
+      await Promise.resolve();
+
+      // H1 resolves first and seeds the empty cache (its commit is
+      // older-issued). That commit must not invalidate the later-issued H2,
+      // whose response is the newer one.
+      resolveH1(
+        makeSession({ id: "sel", project: "proj-a", first_message: "H1" }),
+      );
+      await h1;
+      resolveH2(
+        makeSession({ id: "sel", project: "proj-a", first_message: "H2-newer" }),
+      );
+      await h2;
+
+      expect(sessions.activeSession?.first_message).toBe("H2-newer");
+      expect(
+        sessions.sessions.find((s) => s.id === "sel")?.is_index_only,
+      ).toBe(false);
+    });
+
+    it("does not resurrect a 404-deleted row when a reload fails", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "gone", project: "proj-a" })]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "gone", project: "proj-a", first_message: "detail" }),
+      );
+      await sessions.hydrateVisibleSessions(["gone"]);
+      sessions.selectSession("gone");
+      expect(sessions.activeSession?.id).toBe("gone");
+
+      // A reload is in flight when a refresh 404s and removes the row...
+      let rejectIndex!: (e: unknown) => void;
+      vi.mocked(api.getSidebarSessionIndex).mockReturnValueOnce(
+        new Promise((_r, rej) => {
+          rejectIndex = rej;
+        }),
+      );
+      const reload = sessions.load({ force: true });
+      vi.mocked(api.getSession).mockRejectedValueOnce(makeNotFoundError("gone"));
+      await sessions.refreshActiveSession();
+      expect(sessions.activeSession).toBeUndefined();
+      expect(sessions.sessions.some((s) => s.id === "gone")).toBe(false);
+
+      // ...and the reload then fails. Restoring the pre-reload list must
+      // reapply the deletion instead of resurrecting the hydrated ghost row.
+      rejectIndex(new Error("network"));
+      await reload;
+
+      expect(sessions.sessions.some((s) => s.id === "gone")).toBe(false);
+      expect(sessions.activeSession).toBeUndefined();
+      expect(sessions.total).toBe(0);
+    });
+
     it("ignores a stale hydration resolving after a newer refresh", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -4546,6 +4546,105 @@ describe("SessionsStore", () => {
       expect(sessions.total).toBe(2);
     });
 
+    it("reconciles a stale response from the stamped row after exclusion", async () => {
+      mockSidebarIndex([
+        makeSkinnyRow({ id: "sel", project: "proj-a", display_name: "old" }),
+      ]);
+      await sessions.load();
+
+      // Selection hydration of the index-only row is pinned in flight...
+      let resolveHydration!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveHydration = r;
+        }),
+      );
+      sessions.selectSession("sel");
+      await Promise.resolve();
+
+      // ...a reload publishes a newer remote rename onto the still
+      // index-only row (the empty cache cannot absorb it), then a second
+      // reload excludes the row entirely.
+      mockSidebarIndex([
+        makeSkinnyRow({
+          id: "sel",
+          project: "proj-a",
+          display_name: "server-renamed",
+        }),
+      ]);
+      await sessions.load({ force: true });
+      mockSidebarIndex([makeSkinnyRow({ id: "other", project: "proj-b" })]);
+      await sessions.load({ force: true });
+
+      // The stale pre-rename response resolves with row and cache both
+      // absent: the newer index fields survive only in the stamped publish
+      // snapshot, which must win the reconciliation.
+      resolveHydration(
+        makeSession({
+          id: "sel",
+          project: "proj-a",
+          display_name: "old",
+          first_message: "detail",
+        }),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(sessions.activeSession?.display_name).toBe("server-renamed");
+      expect(sessions.activeSession?.first_message).toBe("detail");
+    });
+
+    it("removes local descendants when their root is deleted", async () => {
+      vi.mocked(api.getSidebarSessionIndex).mockResolvedValue({
+        sessions: [
+          makeSkinnyRow({ id: "root1", project: "proj-a" }),
+          makeSkinnyRow({
+            id: "child1",
+            project: "proj-a",
+            parent_session_id: "root1",
+          }),
+        ],
+        total: 1,
+        next_cursor: null,
+      });
+      await sessions.load();
+      expect(sessions.total).toBe(1);
+
+      // A stale reload is in flight when the root is deleted. The backend
+      // removes the whole subtree from sidebar queries; local state must
+      // match: the descendant goes with its root, counted once.
+      let resolveIndex!: (v: unknown) => void;
+      vi.mocked(api.getSidebarSessionIndex).mockReturnValueOnce(
+        new Promise((r) => {
+          resolveIndex = r;
+        }),
+      );
+      const reload = sessions.load({ force: true });
+      vi.mocked(api.deleteSession).mockResolvedValueOnce({});
+      await sessions.deleteSession("root1");
+
+      expect(sessions.sessions.some((s) => s.id === "child1")).toBe(false);
+      expect(sessions.total).toBe(0);
+
+      // The stale reload still lists the subtree; publishing must drop the
+      // descendant along with its tombstoned root.
+      resolveIndex({
+        sessions: [
+          makeSkinnyRow({ id: "root1", project: "proj-a" }),
+          makeSkinnyRow({
+            id: "child1",
+            project: "proj-a",
+            parent_session_id: "root1",
+          }),
+        ],
+        total: 1,
+      });
+      await reload;
+
+      expect(sessions.sessions.length).toBe(0);
+      expect(sessions.total).toBe(0);
+    });
+
     it("ignores a stale hydration resolving after a newer refresh", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -5160,6 +5160,86 @@ describe("SessionsStore", () => {
       expect(sessions.total).toBe(1);
     });
 
+    it("merges a fresh version-superseded hydration into the active row", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", project: "proj-a", first_message: "v1" }),
+      );
+      await sessions.hydrateVisibleSessions(["sel"]);
+      sessions.selectSession("sel");
+
+      // A fresh hydration is in flight under the old index version...
+      (sessions as any).invalidateHydratedSessionDetails();
+      let resolveHydration!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveHydration = r;
+        }),
+      );
+      const hydration = sessions.hydrateVisibleSessions(["sel"]);
+      await Promise.resolve();
+
+      // ...when a reload commits a new version that re-lists the row,
+      // carrying its older hydrated fields.
+      mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
+      await sessions.load({ force: true });
+
+      // The hydration resolves with newer detail. The version check bars
+      // the normal merge path, but the active row would otherwise keep
+      // showing the older data forever — the getter prefers a hydrated row
+      // over the cache, and a hydrated row is never re-hydrated.
+      resolveHydration(
+        makeSession({ id: "sel", project: "proj-a", first_message: "v2" }),
+      );
+      await hydration;
+
+      expect(sessions.activeSession?.first_message).toBe("v2");
+      expect(
+        sessions.sessions.find((s) => s.id === "sel")?.first_message,
+      ).toBe("v2");
+    });
+
+    it("does not revive a row a newer publish established as excluded", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", project: "proj-a", first_message: "A" }),
+      );
+      await sessions.hydrateVisibleSessions(["sel"]);
+      sessions.selectSession("sel");
+
+      // An unrelated hydration stays in flight, holding the prune horizon
+      // below the tombstone so the GC cannot collect it mid-test.
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>(() => {}),
+      );
+      const held = sessions.hydrateVisibleSessions(["held"]);
+      await Promise.resolve();
+      void held;
+
+      // A transient 404 removes the row...
+      vi.mocked(api.getSession).mockRejectedValueOnce(makeNotFoundError("sel"));
+      await sessions.refreshActiveSession();
+
+      // ...then a full reload (filters changed) publishes a list that
+      // excludes the session entirely.
+      mockSidebarIndex([makeSkinnyRow({ id: "other", project: "proj-b" })]);
+      await sessions.load({ force: true });
+      expect(sessions.total).toBe(1);
+
+      // A successful refresh revives the session. The current list
+      // authoritatively excludes it: only the detail cache may recover.
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", project: "proj-a", first_message: "B" }),
+      );
+      await sessions.refreshActiveSession();
+
+      expect(sessions.activeSession?.first_message).toBe("B");
+      expect(sessions.sessions.some((s) => s.id === "sel")).toBe(false);
+      expect(sessions.total).toBe(1);
+    });
+
     it("ignores a stale hydration resolving after a newer refresh", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -3866,6 +3866,109 @@ describe("SessionsStore", () => {
       expect(sessions.activeSession?.first_message).toBe("detail-2");
     });
 
+    it("lets a detail read issued after an index request keep its fields", async () => {
+      mockSidebarIndex([
+        makeSkinnyRow({ id: "sel", project: "proj-a", display_name: "old" }),
+      ]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", project: "proj-a", display_name: "old" }),
+      );
+      await sessions.hydrateVisibleSessions(["sel"]);
+      sessions.selectSession("sel");
+
+      // An index reload is issued first...
+      let resolveIndex!: (v: unknown) => void;
+      vi.mocked(api.getSidebarSessionIndex).mockReturnValueOnce(
+        new Promise((r) => {
+          resolveIndex = r;
+        }),
+      );
+      const reload = sessions.load({ force: true });
+
+      // ...then a refresh is issued, observing a rename the reload's older
+      // server snapshot cannot contain. The reload commits first.
+      let resolveRefresh!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveRefresh = r;
+        }),
+      );
+      const refresh = sessions.refreshActiveSession();
+      await Promise.resolve();
+      resolveIndex({
+        sessions: [
+          makeSkinnyRow({ id: "sel", project: "proj-a", display_name: "old" }),
+        ],
+        total: 1,
+      });
+      await reload;
+
+      // The index committed after the refresh began, but its request was
+      // issued before the refresh's — its snapshot is older, so the
+      // later-issued refresh response must apply wholesale.
+      resolveRefresh(
+        makeSession({
+          id: "sel",
+          project: "proj-a",
+          display_name: "fresh-rename",
+          first_message: "detail-2",
+        }),
+      );
+      await refresh;
+
+      expect(sessions.activeSession?.display_name).toBe("fresh-rename");
+      expect(
+        sessions.sessions.find((s) => s.id === "sel")?.display_name,
+      ).toBe("fresh-rename");
+    });
+
+    it("chases again when a second rename cancels the enrichment fetch", async () => {
+      mockSidebarIndex([]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockRejectedValueOnce(new Error("network"));
+      await sessions.navigateToSession("sel");
+
+      // First rename on the empty cache commits an interim snapshot and
+      // starts an enrichment fetch, which stays in flight...
+      vi.mocked(api.renameSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", display_name: "one" }),
+      );
+      let resolveChase!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveChase = r;
+        }),
+      );
+      await sessions.renameSession("sel", "one");
+
+      // ...when a second rename cancels it. The cache is still only the
+      // interim rename shape, so a fresh enrichment fetch must be issued —
+      // otherwise the detail-only fields never arrive.
+      vi.mocked(api.renameSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", display_name: "two" }),
+      );
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({
+          id: "sel",
+          project: "proj-b",
+          display_name: "two",
+          first_message: "enriched-detail",
+        }),
+      );
+      await sessions.renameSession("sel", "two");
+      await new Promise((r) => setTimeout(r, 0));
+
+      // The cancelled first chase resolving late must stay discarded.
+      resolveChase(
+        makeSession({ id: "sel", display_name: "one", first_message: "stale" }),
+      );
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(sessions.activeSession?.display_name).toBe("two");
+      expect(sessions.activeSession?.first_message).toBe("enriched-detail");
+    });
+
     it("ignores a stale hydration resolving after a newer refresh", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -2339,6 +2339,41 @@ describe("SessionsStore", () => {
 
       expect(sessions.sessions[0]!.display_name).toBe("agent-name");
     });
+
+    it("renames an active session backed only by the detail cache", async () => {
+      // Open a session that is absent from the (empty) sidebar list, so it is
+      // held solely in activeSessionDetail.
+      mockSidebarIndex([]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValue(
+        makeSession({ id: "cached", display_name: null, project: "proj-b" }),
+      );
+      await sessions.navigateToSession("cached");
+      expect(sessions.sessions.some((s) => s.id === "cached")).toBe(false);
+
+      vi.mocked(api.renameSession).mockResolvedValue(
+        makeSession({ id: "cached", display_name: "renamed-in-breadcrumb" }),
+      );
+      await sessions.renameSession("cached", "renamed-in-breadcrumb");
+
+      expect(sessions.activeSession?.display_name).toBe("renamed-in-breadcrumb");
+    });
+
+    it("clears a cache-backed active session name when the response omits it", async () => {
+      mockSidebarIndex([]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValue(
+        makeSession({ id: "cached", display_name: "custom-name" }),
+      );
+      await sessions.navigateToSession("cached");
+      expect(sessions.activeSession?.display_name).toBe("custom-name");
+
+      // Backend clears the name and omits display_name (omitempty on nil).
+      vi.mocked(api.renameSession).mockResolvedValue(makeSession({ id: "cached" }));
+      await sessions.renameSession("cached", null);
+
+      expect(sessions.activeSession?.display_name).toBeNull();
+    });
   });
 
   describe("loadProjects dedup", () => {

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -2984,37 +2984,6 @@ describe("SessionsStore", () => {
       expect(sessions.activeSession?.first_message).toBe("restored");
     });
 
-    it("ignores a stale navigation response resolving after a newer refresh", async () => {
-      mockSidebarIndex([]);
-      await sessions.load();
-
-      // Navigation fetch for an out-of-list session stays in flight...
-      let resolveNavigate!: (s: Session) => void;
-      vi.mocked(api.getSession).mockReturnValueOnce(
-        new Promise<Session>((r) => {
-          resolveNavigate = r;
-        }),
-      );
-      const nav = sessions.navigateToSession("sel");
-      await Promise.resolve();
-
-      // ...while a watcher-driven refresh for the same session resolves
-      // first with a fresher snapshot.
-      vi.mocked(api.getSession).mockResolvedValueOnce(
-        makeSession({ id: "sel", project: "proj-a", first_message: "NEWER" }),
-      );
-      await sessions.refreshActiveSession();
-      expect(sessions.activeSession?.first_message).toBe("NEWER");
-
-      // The older navigation response must not clobber the newer detail.
-      resolveNavigate(
-        makeSession({ id: "sel", project: "proj-a", first_message: "OLDER" }),
-      );
-      await nav;
-
-      expect(sessions.activeSession?.first_message).toBe("NEWER");
-    });
-
     it("does not let a pre-rename refresh response revert a rename", async () => {
       mockSidebarIndex([]);
       await sessions.load();
@@ -3408,6 +3377,80 @@ describe("SessionsStore", () => {
       expect(
         sessions.sessions.find((s) => s.id === "sel")?.display_name,
       ).toBe("renamed");
+    });
+
+    it("resyncs the cache from a newer index despite an uncommitted read", async () => {
+      mockSidebarIndex([
+        makeSkinnyRow({ id: "sel", project: "proj-a", display_name: "old" }),
+      ]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", project: "proj-a", display_name: "old" }),
+      );
+      await sessions.hydrateVisibleSessions(["sel"]);
+      sessions.selectSession("sel");
+
+      // An index reload carrying a newer remote rename is in flight when a
+      // watcher refresh starts and fails without committing anything...
+      let resolveIndex!: (v: unknown) => void;
+      vi.mocked(api.getSidebarSessionIndex).mockReturnValueOnce(
+        new Promise((r) => {
+          resolveIndex = r;
+        }),
+      );
+      const reload = sessions.load({ force: true });
+      vi.mocked(api.getSession).mockRejectedValueOnce(new Error("network"));
+      await sessions.refreshActiveSession();
+
+      resolveIndex({
+        sessions: [
+          makeSkinnyRow({
+            id: "sel",
+            project: "proj-a",
+            display_name: "server-renamed",
+          }),
+        ],
+        total: 1,
+      });
+      await reload;
+
+      // The committed index is at least as fresh as any pre-flight commit,
+      // so the cache must absorb it even though a read began mid-flight —
+      // otherwise a later reload that excludes the row falls back to the
+      // stale cached name.
+      mockSidebarIndex([makeSkinnyRow({ id: "other", project: "proj-b" })]);
+      await sessions.load();
+      expect(sessions.activeSession?.display_name).toBe("server-renamed");
+    });
+
+    it("lets a refresh join an in-flight navigation for the same session", async () => {
+      mockSidebarIndex([]);
+      await sessions.load();
+
+      // Deep-link navigation to an off-list session is in flight...
+      let resolveNavigate!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveNavigate = r;
+        }),
+      );
+      const nav = sessions.navigateToSession("deep");
+      await Promise.resolve();
+
+      // ...when a watcher refresh fires for the same session. Both issue the
+      // identical detail GET: the refresh must join the pending navigation
+      // rather than cancel it and reissue — a cancelled navigation plus a
+      // transiently failing refresh would leave the cache empty with nothing
+      // to retry. No further response is queued: a second fetch would fail.
+      const refresh = sessions.refreshActiveSession();
+
+      resolveNavigate(
+        makeSession({ id: "deep", project: "proj-b", first_message: "detail" }),
+      );
+      await Promise.all([nav, refresh]);
+
+      expect(api.getSession).toHaveBeenCalledTimes(1);
+      expect(sessions.activeSession?.first_message).toBe("detail");
     });
 
     it("ignores a stale hydration resolving after a newer refresh", async () => {

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -3453,6 +3453,58 @@ describe("SessionsStore", () => {
       expect(sessions.activeSession?.first_message).toBe("detail");
     });
 
+    it("does not count a pre-reload hydration as fresher than the reload", async () => {
+      mockSidebarIndex([
+        makeSkinnyRow({ id: "sel", project: "proj-a", display_name: "old" }),
+      ]);
+      await sessions.load();
+
+      // Hydration of the selected row is issued BEFORE the index reload...
+      let resolveHydration!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveHydration = r;
+        }),
+      );
+      const hydration = sessions.hydrateVisibleSessions(["sel"]);
+      await Promise.resolve();
+      sessions.selectSession("sel");
+
+      // ...then a reload starts whose server snapshot carries a newer remote
+      // rename, and the older hydration resolves while it is in flight.
+      let resolveIndex!: (v: unknown) => void;
+      vi.mocked(api.getSidebarSessionIndex).mockReturnValueOnce(
+        new Promise((r) => {
+          resolveIndex = r;
+        }),
+      );
+      const reload = sessions.load({ force: true });
+      resolveHydration(
+        makeSession({ id: "sel", project: "proj-a", display_name: "old" }),
+      );
+      await hydration;
+
+      // The hydration request predates the reload, so its snapshot cannot
+      // outrank the reload's: the newer index fields must win in the row and
+      // be absorbed into the cache, not be replaced by the older hydration.
+      resolveIndex({
+        sessions: [
+          makeSkinnyRow({
+            id: "sel",
+            project: "proj-a",
+            display_name: "server-renamed",
+          }),
+        ],
+        total: 1,
+      });
+      await reload;
+
+      expect(
+        sessions.sessions.find((s) => s.id === "sel")?.display_name,
+      ).toBe("server-renamed");
+      expect(sessions.activeSession?.display_name).toBe("server-renamed");
+    });
+
     it("ignores a stale hydration resolving after a newer refresh", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -3721,6 +3721,99 @@ describe("SessionsStore", () => {
       expect(sessions.activeSession?.first_message).toBe("detail");
     });
 
+    it("prefers a later-issued index over a detail commit issued earlier", async () => {
+      mockSidebarIndex([
+        makeSkinnyRow({ id: "sel", project: "proj-a", display_name: "old" }),
+      ]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", project: "proj-a", display_name: "old" }),
+      );
+      await sessions.hydrateVisibleSessions(["sel"]);
+      sessions.selectSession("sel");
+
+      // A refresh is issued first...
+      let resolveRefresh!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveRefresh = r;
+        }),
+      );
+      const refresh = sessions.refreshActiveSession();
+      await Promise.resolve();
+
+      // ...then a reload is issued, whose server snapshot carries a newer
+      // remote rename. The refresh commits while the reload is pending.
+      let resolveIndex!: (v: unknown) => void;
+      vi.mocked(api.getSidebarSessionIndex).mockReturnValueOnce(
+        new Promise((r) => {
+          resolveIndex = r;
+        }),
+      );
+      const reload = sessions.load({ force: true });
+      resolveRefresh(
+        makeSession({
+          id: "sel",
+          project: "proj-a",
+          display_name: "old",
+          first_message: "detail-2",
+        }),
+      );
+      await refresh;
+
+      // The refresh's request predates the reload's, so its commit must not
+      // outrank the later-issued index snapshot: the newer rename wins and
+      // the refresh contributes its detail-owned fields through the row.
+      resolveIndex({
+        sessions: [
+          makeSkinnyRow({
+            id: "sel",
+            project: "proj-a",
+            display_name: "server-renamed",
+          }),
+        ],
+        total: 1,
+      });
+      await reload;
+
+      expect(sessions.activeSession?.display_name).toBe("server-renamed");
+      expect(sessions.activeSession?.first_message).toBe("detail-2");
+      const row = sessions.sessions.find((s) => s.id === "sel");
+      expect(row?.display_name).toBe("server-renamed");
+    });
+
+    it("refetches enriched detail after renaming an unhydrated session", async () => {
+      mockSidebarIndex([]);
+      await sessions.load();
+
+      // Deep-link navigation failed transiently: the session is active with
+      // an empty detail cache.
+      vi.mocked(api.getSession).mockRejectedValueOnce(new Error("network"));
+      await sessions.navigateToSession("sel");
+
+      // The rename endpoint returns a plain DB-session shape without the
+      // derived detail-only fields, so committing it can only be an interim
+      // snapshot: a fresh detail GET must follow to fetch the enriched
+      // shape the detail UI needs.
+      vi.mocked(api.renameSession).mockResolvedValue(
+        makeSession({ id: "sel", display_name: "renamed" }),
+      );
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({
+          id: "sel",
+          project: "proj-b",
+          display_name: "renamed",
+          first_message: "enriched-detail",
+        }),
+      );
+      await sessions.renameSession("sel", "renamed");
+      expect(sessions.activeSession?.display_name).toBe("renamed");
+
+      await new Promise((r) => setTimeout(r, 0));
+      expect(sessions.activeSession?.first_message).toBe("enriched-detail");
+      expect(sessions.activeSession?.display_name).toBe("renamed");
+    });
+
     it("ignores a stale hydration resolving after a newer refresh", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -5077,6 +5077,59 @@ describe("SessionsStore", () => {
       expect(sessions.activeSession?.first_message).toBe("v2");
     });
 
+    it("counts a revived subtree once when the child revives first", async () => {
+      vi.mocked(api.getSidebarSessionIndex).mockResolvedValue({
+        sessions: [
+          makeSkinnyRow({ id: "root1", project: "proj-a" }),
+          makeSkinnyRow({
+            id: "child1",
+            project: "proj-a",
+            parent_session_id: "root1",
+          }),
+        ],
+        total: 1,
+        next_cursor: null,
+      });
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "root1", project: "proj-a", first_message: "d" }),
+      );
+      sessions.selectSession("root1");
+      await sessions.hydrateVisibleSessions(["root1"]);
+
+      // The root transiently 404s, removing the subtree.
+      vi.mocked(api.getSession).mockRejectedValueOnce(
+        makeNotFoundError("root1"),
+      );
+      await sessions.refreshActiveSession();
+      expect(sessions.sessions.length).toBe(0);
+      expect(sessions.total).toBe(0);
+
+      // The child revives first (as a promoted orphan root, +1)...
+      (sessions as any).invalidateHydratedSessionDetails();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({
+          id: "child1",
+          project: "proj-a",
+          parent_session_id: "root1",
+          first_message: "c",
+        }),
+      );
+      await sessions.hydrateVisibleSessions(["child1"]);
+      expect(sessions.total).toBe(1);
+
+      // ...then the root revives, demoting the child back to nested. The
+      // group must be counted once, not twice.
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "root1", project: "proj-a", first_message: "d2" }),
+      );
+      await sessions.refreshActiveSession();
+
+      expect(sessions.sessions.some((s) => s.id === "root1")).toBe(true);
+      expect(sessions.sessions.some((s) => s.id === "child1")).toBe(true);
+      expect(sessions.total).toBe(1);
+    });
+
     it("ignores a stale hydration resolving after a newer refresh", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -2556,8 +2556,10 @@ describe("SessionsStore", () => {
       resolveGet(makeSession({ id: "new-id" }));
       await promise;
 
-      expect(sessions.sessions).toHaveLength(1);
-      expect(sessions.sessions[0]!.id).toBe("new-id");
+      // The out-of-list session backs activeSession via the detail cache
+      // without being injected into the (filtered) sidebar collection.
+      expect(sessions.sessions).toHaveLength(0);
+      expect(sessions.activeSession?.id).toBe("new-id");
     });
 
     it("skips fetch for already-loaded session", async () => {
@@ -2629,8 +2631,9 @@ describe("SessionsStore", () => {
 
     it("keeps a search-navigated out-of-index session across a sidebar reload", async () => {
       // Sidebar is filtered so the searched session never appears in the
-      // index. Opening it from search fetches and appends it; a later index
-      // reload (route/filter re-evaluation) must not drop the open session.
+      // index. Opening it from search backs activeSession via the detail
+      // cache; a later index reload (route/filter re-evaluation) must not drop
+      // the open session, and the session must not leak into the sidebar list.
       mockSidebarIndex([makeSkinnyRow({ id: "in-index", project: "proj-a" })]);
       await sessions.load();
 
@@ -2643,6 +2646,7 @@ describe("SessionsStore", () => {
       );
       await sessions.navigateToSession("searched");
       expect(sessions.activeSession?.project).toBe("proj-b");
+      expect(sessions.sessions.some((s) => s.id === "searched")).toBe(false);
 
       // The filtered index still excludes the searched session.
       mockSidebarIndex([makeSkinnyRow({ id: "in-index", project: "proj-a" })]);
@@ -2650,6 +2654,38 @@ describe("SessionsStore", () => {
 
       expect(sessions.activeSessionId).toBe("searched");
       expect(sessions.activeSession?.project).toBe("proj-b");
+      // Not conflated with the filtered sidebar collection.
+      expect(sessions.sessions.map((s) => s.id)).toEqual(["in-index"]);
+    });
+
+    it("does not duplicate an active session that appears on a later page", async () => {
+      // Page 1 of the filtered index omits the active session; it lives on a
+      // later page reachable through loadMore. Backing it via the detail cache
+      // (not the sidebar list) means the later page appends it exactly once.
+      vi.mocked(api.getSidebarSessionIndex)
+        .mockResolvedValueOnce({
+          sessions: [makeSkinnyRow({ id: "page1" })],
+          total: 2,
+          next_cursor: "cursor-2",
+        })
+        .mockResolvedValueOnce({
+          sessions: [makeSkinnyRow({ id: "later", project: "proj-b" })],
+          total: 2,
+          next_cursor: null,
+        });
+      await sessions.load();
+
+      vi.mocked(api.getSession).mockResolvedValue(
+        makeSession({ id: "later", project: "proj-b", first_message: "from search" }),
+      );
+      await sessions.navigateToSession("later");
+      expect(sessions.activeSession?.id).toBe("later");
+      expect(sessions.sessions.some((s) => s.id === "later")).toBe(false);
+
+      await sessions.loadMore();
+
+      expect(sessions.sessions.filter((s) => s.id === "later")).toHaveLength(1);
+      expect(sessions.activeSession?.id).toBe("later");
     });
   });
 

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -2995,6 +2995,32 @@ describe("SessionsStore", () => {
       expect(sessions.activeSession?.display_name).toBe("renamed");
     });
 
+    it("joins an in-flight navigation for the same active session", async () => {
+      mockSidebarIndex([]);
+      await sessions.load();
+
+      let resolveNavigate!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveNavigate = r;
+        }),
+      );
+      const first = sessions.navigateToSession("sel");
+      await Promise.resolve();
+
+      // A reactive caller (App's deep-link effect) re-requests hydration
+      // while the fetch is pending; it must join the in-flight read rather
+      // than cancel and restart it.
+      const second = sessions.navigateToSession("sel");
+      resolveNavigate(
+        makeSession({ id: "sel", first_message: "detail" }),
+      );
+      await Promise.all([first, second]);
+
+      expect(api.getSession).toHaveBeenCalledTimes(1);
+      expect(sessions.activeSession?.first_message).toBe("detail");
+    });
+
     it("commits the rename response when it lands during the navigation fetch", async () => {
       mockSidebarIndex([]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -4466,6 +4466,86 @@ describe("SessionsStore", () => {
       expect(sessions.total).toBe(1);
     });
 
+    it("ignores a stale 404 after a later read confirmed the session", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", project: "proj-a", first_message: "A" }),
+      );
+      await sessions.hydrateVisibleSessions(["sel"]);
+      sessions.selectSession("sel");
+
+      // A refresh is in flight...
+      let rejectRefresh!: (e: unknown) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((_r, rej) => {
+          rejectRefresh = rej;
+        }),
+      );
+      const refresh = sessions.refreshActiveSession();
+      await Promise.resolve();
+
+      // ...while a later-issued hydration confirms the session exists.
+      (sessions as any).invalidateHydratedSessionDetails();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", project: "proj-a", first_message: "H" }),
+      );
+      await sessions.hydrateVisibleSessions(["sel"]);
+      expect(sessions.activeSession?.first_message).toBe("H");
+
+      // The earlier refresh then 404s. Newer evidence outranks the stale
+      // response: the session must not be tombstoned.
+      rejectRefresh(makeNotFoundError("sel"));
+      await refresh;
+
+      expect(sessions.activeSession?.first_message).toBe("H");
+      expect(sessions.sessions.some((s) => s.id === "sel")).toBe(true);
+      expect(sessions.total).toBe(1);
+    });
+
+    it("classifies dropped page rows against all loaded rows", async () => {
+      vi.mocked(api.getSidebarSessionIndex).mockResolvedValueOnce({
+        sessions: [makeSkinnyRow({ id: "root1", project: "proj-a" })],
+        total: 2,
+        next_cursor: "page-2",
+      });
+      await sessions.load();
+
+      // A never-loaded child of an already-loaded root is deleted while
+      // page 2 is in flight...
+      let resolvePage!: (v: unknown) => void;
+      vi.mocked(api.getSidebarSessionIndex).mockReturnValueOnce(
+        new Promise((r) => {
+          resolvePage = r;
+        }),
+      );
+      const more = sessions.loadMore();
+      vi.mocked(api.deleteSession).mockResolvedValueOnce({});
+      await sessions.deleteSession("child1");
+      expect(sessions.total).toBe(2);
+
+      // ...and the stale page re-lists it alongside another root. The child
+      // belongs to root1's group (loaded on page 1): dropping it must not
+      // count as a dropped root group.
+      resolvePage({
+        sessions: [
+          makeSkinnyRow({
+            id: "child1",
+            project: "proj-a",
+            parent_session_id: "root1",
+          }),
+          makeSkinnyRow({ id: "root2", project: "proj-a" }),
+        ],
+        total: 2,
+        next_cursor: null,
+      });
+      await more;
+
+      expect(sessions.sessions.some((s) => s.id === "child1")).toBe(false);
+      expect(sessions.sessions.some((s) => s.id === "root2")).toBe(true);
+      expect(sessions.total).toBe(2);
+    });
+
     it("ignores a stale hydration resolving after a newer refresh", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -4807,6 +4807,50 @@ describe("SessionsStore", () => {
       expect(sessions.activeSessionId).toBeNull();
     });
 
+    it("lets a later-issued hydration supersede a transient refresh 404", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", project: "proj-a", first_message: "A" }),
+      );
+      await sessions.hydrateVisibleSessions(["sel"]);
+      sessions.selectSession("sel");
+
+      // A refresh is in flight...
+      let rejectRefresh!: (e: unknown) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((_r, rej) => {
+          rejectRefresh = rej;
+        }),
+      );
+      const refresh = sessions.refreshActiveSession();
+      await Promise.resolve();
+
+      // ...then a later-issued hydration starts, and the refresh 404s
+      // first (a transient server-side gap, e.g. mid-resync).
+      (sessions as any).invalidateHydratedSessionDetails();
+      let resolveHydration!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveHydration = r;
+        }),
+      );
+      const hydration = sessions.hydrateVisibleSessions(["sel"]);
+      await Promise.resolve();
+      rejectRefresh(makeNotFoundError("sel"));
+      await refresh;
+
+      // The hydration was issued after the 404's request: its successful
+      // response is newer evidence and must supersede the read-derived
+      // tombstone instead of being discarded.
+      resolveHydration(
+        makeSession({ id: "sel", project: "proj-a", first_message: "H" }),
+      );
+      await hydration;
+
+      expect(sessions.activeSession?.first_message).toBe("H");
+    });
+
     it("ignores a stale hydration resolving after a newer refresh", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -4896,6 +4896,108 @@ describe("SessionsStore", () => {
       expect(sessions.total).toBe(1);
     });
 
+    it("honors a 404 tombstone when a later-issued reload fails", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "gone", project: "proj-a" })]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "gone", project: "proj-a", first_message: "d" }),
+      );
+      await sessions.hydrateVisibleSessions(["gone"]);
+      sessions.selectSession("gone");
+
+      // A refresh is issued, then a reload; the refresh 404s while the
+      // reload is in flight, and the reload then fails. A failed load
+      // carries no newer server state, so its restore must still honor the
+      // tombstone even though the load was issued after the 404's request.
+      let rejectRefresh!: (e: unknown) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((_r, rej) => {
+          rejectRefresh = rej;
+        }),
+      );
+      const refresh = sessions.refreshActiveSession();
+      await Promise.resolve();
+      let rejectIndex!: (e: unknown) => void;
+      vi.mocked(api.getSidebarSessionIndex).mockReturnValueOnce(
+        new Promise((_r, rej) => {
+          rejectIndex = rej;
+        }),
+      );
+      const reload = sessions.load({ force: true });
+      rejectRefresh(makeNotFoundError("gone"));
+      await refresh;
+      expect(sessions.sessions.some((s) => s.id === "gone")).toBe(false);
+
+      rejectIndex(new Error("network"));
+      await reload;
+
+      expect(sessions.sessions.some((s) => s.id === "gone")).toBe(false);
+      expect(sessions.total).toBe(0);
+    });
+
+    it("keeps descendants revivable after their root's transient 404", async () => {
+      vi.mocked(api.getSidebarSessionIndex).mockResolvedValue({
+        sessions: [
+          makeSkinnyRow({ id: "root1", project: "proj-a" }),
+          makeSkinnyRow({
+            id: "child1",
+            project: "proj-a",
+            parent_session_id: "root1",
+          }),
+        ],
+        total: 1,
+        next_cursor: null,
+      });
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "root1", project: "proj-a", first_message: "d" }),
+      );
+      sessions.selectSession("root1");
+      await sessions.hydrateVisibleSessions(["root1"]);
+
+      // A refresh is issued, then a reload whose server snapshot lists the
+      // subtree; the refresh 404s transiently while the reload is in
+      // flight.
+      let rejectRefresh!: (e: unknown) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((_r, rej) => {
+          rejectRefresh = rej;
+        }),
+      );
+      const refresh = sessions.refreshActiveSession();
+      await Promise.resolve();
+      let resolveIndex!: (v: unknown) => void;
+      vi.mocked(api.getSidebarSessionIndex).mockReturnValueOnce(
+        new Promise((r) => {
+          resolveIndex = r;
+        }),
+      );
+      const reload = sessions.load({ force: true });
+      rejectRefresh(makeNotFoundError("root1"));
+      await refresh;
+      expect(sessions.sessions.length).toBe(0);
+
+      // The later-issued reload confirms the subtree exists. Both the root
+      // AND its descendant must supersede the read-derived tombstones —
+      // descendants inherit the ancestor's finite tick, not Infinity.
+      resolveIndex({
+        sessions: [
+          makeSkinnyRow({ id: "root1", project: "proj-a" }),
+          makeSkinnyRow({
+            id: "child1",
+            project: "proj-a",
+            parent_session_id: "root1",
+          }),
+        ],
+        total: 1,
+      });
+      await reload;
+
+      expect(sessions.sessions.some((s) => s.id === "root1")).toBe(true);
+      expect(sessions.sessions.some((s) => s.id === "child1")).toBe(true);
+      expect(sessions.total).toBe(1);
+    });
+
     it("ignores a stale hydration resolving after a newer refresh", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -4384,6 +4384,88 @@ describe("SessionsStore", () => {
       expect(sessions.total).toBe(0);
     });
 
+    it("publishes a committed rename for a row with no prior sidebar row", async () => {
+      mockSidebarIndex([]);
+      await sessions.load();
+
+      // A cache-only session (opened from search, off the filtered list) is
+      // active...
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "a", project: "proj-a", display_name: "old" }),
+      );
+      await sessions.navigateToSession("a");
+
+      // ...an index reload is issued, then the session is renamed and the
+      // user navigates to another session, discarding the cache.
+      let resolveIndex!: (v: unknown) => void;
+      vi.mocked(api.getSidebarSessionIndex).mockReturnValueOnce(
+        new Promise((r) => {
+          resolveIndex = r;
+        }),
+      );
+      const reload = sessions.load({ force: true });
+      vi.mocked(api.renameSession).mockResolvedValueOnce(
+        makeSession({ id: "a", display_name: "renamed" }),
+      );
+      await sessions.renameSession("a", "renamed");
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "b", project: "proj-b", first_message: "b-detail" }),
+      );
+      await sessions.navigateToSession("b");
+
+      // The pre-rename index resolves, listing the renamed session for the
+      // first time. There is no prior sidebar row to preserve — the
+      // committed rename snapshot must still outrank the stale index name.
+      resolveIndex({
+        sessions: [
+          makeSkinnyRow({ id: "a", project: "proj-a", display_name: "old" }),
+        ],
+        total: 1,
+      });
+      await reload;
+
+      expect(
+        sessions.sessions.find((s) => s.id === "a")?.display_name,
+      ).toBe("renamed");
+    });
+
+    it("does not double-subtract a deleted root re-listed by a stale page", async () => {
+      vi.mocked(api.getSidebarSessionIndex).mockResolvedValueOnce({
+        sessions: [makeSkinnyRow({ id: "root1", project: "proj-a" })],
+        total: 2,
+        next_cursor: "page-2",
+      });
+      await sessions.load();
+
+      // Page 2 is in flight when an already-loaded root is deleted; the
+      // delete path decrements the total once.
+      let resolvePage!: (v: unknown) => void;
+      vi.mocked(api.getSidebarSessionIndex).mockReturnValueOnce(
+        new Promise((r) => {
+          resolvePage = r;
+        }),
+      );
+      const more = sessions.loadMore();
+      vi.mocked(api.deleteSession).mockResolvedValueOnce({});
+      await sessions.deleteSession("root1");
+      expect(sessions.total).toBe(1);
+
+      // The stale page re-lists the deleted root alongside a new one.
+      // Dropping the tombstoned duplicate must not decrement again.
+      resolvePage({
+        sessions: [
+          makeSkinnyRow({ id: "root1", project: "proj-a" }),
+          makeSkinnyRow({ id: "root2", project: "proj-a" }),
+        ],
+        total: 2,
+        next_cursor: null,
+      });
+      await more;
+
+      expect(sessions.sessions.some((s) => s.id === "root1")).toBe(false);
+      expect(sessions.total).toBe(1);
+    });
+
     it("ignores a stale hydration resolving after a newer refresh", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -3678,6 +3678,49 @@ describe("SessionsStore", () => {
       expect(row?.first_message).toBe("detail-2");
     });
 
+    it("seeds a post-reload cache with the reload's index fields", async () => {
+      mockSidebarIndex([
+        makeSkinnyRow({ id: "sel", project: "proj-a", display_name: "old" }),
+      ]);
+      await sessions.load();
+
+      // Hydration of the selected row is in flight when a full reload
+      // commits a newer remote rename, re-listing the row as index-only...
+      let resolveHydration!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveHydration = r;
+        }),
+      );
+      const hydration = sessions.hydrateVisibleSessions(["sel"]);
+      await Promise.resolve();
+      sessions.selectSession("sel");
+      mockSidebarIndex([
+        makeSkinnyRow({
+          id: "sel",
+          project: "proj-a",
+          display_name: "server-renamed",
+        }),
+      ]);
+      await sessions.load({ force: true });
+
+      // ...and the superseded hydration then resolves. It may still seed the
+      // empty cache (the breadcrumb needs detail), but with the committed
+      // row's newer index-owned fields, not its own pre-reload snapshot.
+      resolveHydration(
+        makeSession({
+          id: "sel",
+          project: "proj-a",
+          display_name: "old",
+          first_message: "detail",
+        }),
+      );
+      await hydration;
+
+      expect(sessions.activeSession?.display_name).toBe("server-renamed");
+      expect(sessions.activeSession?.first_message).toBe("detail");
+    });
+
     it("ignores a stale hydration resolving after a newer refresh", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -3437,11 +3437,13 @@ describe("SessionsStore", () => {
       const nav = sessions.navigateToSession("deep");
       await Promise.resolve();
 
-      // ...when a watcher refresh fires for the same session. Both issue the
-      // identical detail GET: the refresh must join the pending navigation
-      // rather than cancel it and reissue — a cancelled navigation plus a
-      // transiently failing refresh would leave the cache empty with nothing
-      // to retry. No further response is queued: a second fetch would fail.
+      // ...when a watcher refresh fires for the same session. The refresh
+      // must not cancel the pending navigation (a cancelled navigation plus
+      // a transiently failing refresh would leave the cache empty with
+      // nothing to retry): it joins the navigation, then chases with a
+      // fresh read. Here the chase fails transiently — the navigation's
+      // committed result must survive.
+      vi.mocked(api.getSession).mockRejectedValueOnce(new Error("network"));
       const refresh = sessions.refreshActiveSession();
 
       resolveNavigate(
@@ -3449,8 +3451,123 @@ describe("SessionsStore", () => {
       );
       await Promise.all([nav, refresh]);
 
-      expect(api.getSession).toHaveBeenCalledTimes(1);
+      expect(api.getSession).toHaveBeenCalledTimes(2);
       expect(sessions.activeSession?.first_message).toBe("detail");
+    });
+
+    it("chases a joined navigation with a fresh read for the newer event", async () => {
+      mockSidebarIndex([]);
+      await sessions.load();
+
+      // Deep-link navigation is in flight with a pre-event snapshot...
+      let resolveNavigate!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveNavigate = r;
+        }),
+      );
+      const nav = sessions.navigateToSession("deep");
+      await Promise.resolve();
+
+      // ...when an event-driven refresh fires because the session just
+      // changed. Joining alone would commit the pre-event snapshot with no
+      // guaranteed later refresh; after the navigation settles, the refresh
+      // must issue a fresh read that observes the post-event state.
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({
+          id: "deep",
+          project: "proj-b",
+          display_name: "post-event",
+        }),
+      );
+      const refresh = sessions.refreshActiveSession();
+      resolveNavigate(
+        makeSession({
+          id: "deep",
+          project: "proj-b",
+          display_name: "pre-event",
+        }),
+      );
+      await Promise.all([nav, refresh]);
+
+      expect(api.getSession).toHaveBeenCalledTimes(2);
+      expect(sessions.activeSession?.display_name).toBe("post-event");
+    });
+
+    it("clears a deleted session after a refresh joined its navigation", async () => {
+      mockSidebarIndex([]);
+      await sessions.load();
+
+      let resolveNavigate!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveNavigate = r;
+        }),
+      );
+      const nav = sessions.navigateToSession("gone");
+      await Promise.resolve();
+
+      // The session is deleted server-side; the deletion event triggers a
+      // refresh while the pre-delete navigation is still in flight. The
+      // chase read 404s — the navigation's ghost snapshot must not stand.
+      vi.mocked(api.getSession).mockRejectedValueOnce(makeNotFoundError("gone"));
+      const refresh = sessions.refreshActiveSession();
+      resolveNavigate(
+        makeSession({ id: "gone", project: "proj-b", first_message: "ghost" }),
+      );
+      await Promise.all([nav, refresh]);
+
+      expect(sessions.activeSession).toBeUndefined();
+    });
+
+    it("does not reconcile against an index commit that skipped the row", async () => {
+      vi.mocked(api.getSidebarSessionIndex).mockResolvedValueOnce({
+        sessions: [
+          makeSkinnyRow({ id: "sel", project: "proj-a", display_name: "old" }),
+        ],
+        total: 2,
+        next_cursor: "page-2",
+      });
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", project: "proj-a", display_name: "old" }),
+      );
+      await sessions.hydrateVisibleSessions(["sel"]);
+      sessions.selectSession("sel");
+
+      // A refresh carrying a genuinely newer rename is in flight...
+      let resolveRefresh!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveRefresh = r;
+        }),
+      );
+      const refresh = sessions.refreshActiveSession();
+      await Promise.resolve();
+
+      // ...when an unrelated loadMore page commits WITHOUT re-listing the
+      // active row. That commit says nothing about this row's index fields,
+      // so the response must still apply wholesale.
+      vi.mocked(api.getSidebarSessionIndex).mockResolvedValueOnce({
+        sessions: [makeSkinnyRow({ id: "other", project: "proj-a" })],
+        total: 2,
+        next_cursor: null,
+      });
+      await sessions.loadMore();
+
+      resolveRefresh(
+        makeSession({
+          id: "sel",
+          project: "proj-a",
+          display_name: "fresh-title",
+        }),
+      );
+      await refresh;
+
+      expect(sessions.activeSession?.display_name).toBe("fresh-title");
+      expect(
+        sessions.sessions.find((s) => s.id === "sel")?.display_name,
+      ).toBe("fresh-title");
     });
 
     it("does not count a pre-reload hydration as fresher than the reload", async () => {

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -2626,6 +2626,31 @@ describe("SessionsStore", () => {
         "fetched during navigation",
       );
     });
+
+    it("keeps a search-navigated out-of-index session across a sidebar reload", async () => {
+      // Sidebar is filtered so the searched session never appears in the
+      // index. Opening it from search fetches and appends it; a later index
+      // reload (route/filter re-evaluation) must not drop the open session.
+      mockSidebarIndex([makeSkinnyRow({ id: "in-index", project: "proj-a" })]);
+      await sessions.load();
+
+      vi.mocked(api.getSession).mockResolvedValue(
+        makeSession({
+          id: "searched",
+          project: "proj-b",
+          first_message: "opened from search",
+        }),
+      );
+      await sessions.navigateToSession("searched");
+      expect(sessions.activeSession?.project).toBe("proj-b");
+
+      // The filtered index still excludes the searched session.
+      mockSidebarIndex([makeSkinnyRow({ id: "in-index", project: "proj-a" })]);
+      await sessions.load();
+
+      expect(sessions.activeSessionId).toBe("searched");
+      expect(sessions.activeSession?.project).toBe("proj-b");
+    });
   });
 
   describe("route cancellation", () => {

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -3814,6 +3814,58 @@ describe("SessionsStore", () => {
       expect(sessions.activeSession?.display_name).toBe("renamed");
     });
 
+    it("reconciles against the cache when the re-published row was dropped", async () => {
+      mockSidebarIndex([
+        makeSkinnyRow({ id: "sel", project: "proj-a", display_name: "old" }),
+      ]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", project: "proj-a", display_name: "old" }),
+      );
+      await sessions.hydrateVisibleSessions(["sel"]);
+      sessions.selectSession("sel");
+
+      // A refresh is in flight...
+      let resolveRefresh!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveRefresh = r;
+        }),
+      );
+      const refresh = sessions.refreshActiveSession();
+      await Promise.resolve();
+
+      // ...while one reload re-publishes the row with a newer rename (the
+      // cache absorbs it), and a second reload then excludes the row.
+      mockSidebarIndex([
+        makeSkinnyRow({
+          id: "sel",
+          project: "proj-a",
+          display_name: "server-renamed",
+        }),
+      ]);
+      await sessions.load({ force: true });
+      mockSidebarIndex([makeSkinnyRow({ id: "other", project: "proj-b" })]);
+      await sessions.load({ force: true });
+      expect(sessions.activeSession?.display_name).toBe("server-renamed");
+
+      // The stale refresh response resolves with the row now absent: the
+      // absorbed index fields live only in the cache, and the response must
+      // reconcile against them rather than applying wholesale.
+      resolveRefresh(
+        makeSession({
+          id: "sel",
+          project: "proj-a",
+          display_name: "old",
+          first_message: "detail-2",
+        }),
+      );
+      await refresh;
+
+      expect(sessions.activeSession?.display_name).toBe("server-renamed");
+      expect(sessions.activeSession?.first_message).toBe("detail-2");
+    });
+
     it("ignores a stale hydration resolving after a newer refresh", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -3261,6 +3261,32 @@ describe("SessionsStore", () => {
       expect(sessions.activeSession?.first_message).toBe("detail");
     });
 
+    it("fills the cached detail with fetched signal detail for an off-list session", async () => {
+      mockSidebarIndex([]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "offlist", first_message: "detail" }),
+      );
+      await sessions.navigateToSession("offlist");
+      expect(sessions.activeSession?.health_score_basis).toBeUndefined();
+
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({
+          id: "offlist",
+          first_message: "detail",
+          health_score_basis: ["clean_termination"],
+          health_penalties: { tool_failures: 5 },
+        }),
+      );
+      await sessions.fetchSignalDetail("offlist");
+
+      expect(sessions.activeSession?.health_score_basis).toEqual([
+        "clean_termination",
+      ]);
+      expect(sessions.activeSession?.health_penalties).toEqual({
+        tool_failures: 5,
+      });
+    });
   });
 
   describe("route cancellation", () => {

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -826,6 +826,38 @@ describe("SessionsStore", () => {
       expect(sessions.activeSession?.display_name).toBe("new-name");
     });
 
+    it("folds index refreshes of a cache-only session's returning row into the cache", async () => {
+      mockSidebarIndex([]);
+      vi.mocked(api.getSession).mockResolvedValue(
+        makeSession({
+          id: "offpage",
+          display_name: "old-name",
+          first_message: "hydrated offpage detail",
+        }),
+      );
+
+      await sessions.load();
+      await sessions.navigateToSession("offpage");
+      expect(sessions.activeSession?.display_name).toBe("old-name");
+
+      // The open cache-only session's row enters the index (filter change,
+      // index shift) carrying a refreshed name, as an index-only stub...
+      mockSidebarIndex([
+        makeSkinnyRow({ id: "offpage", display_name: "new-name" }),
+      ]);
+      await sessions.load();
+
+      // ...and a later reload excludes it again: the breadcrumb must keep
+      // the refreshed index fields on top of the cached hydrated detail.
+      mockSidebarIndex([]);
+      await sessions.load();
+
+      expect(sessions.activeSession?.first_message).toBe(
+        "hydrated offpage detail",
+      );
+      expect(sessions.activeSession?.display_name).toBe("new-name");
+    });
+
     it("keeps the open off-page session when the reloaded index omits it", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "listed" })]);
       vi.mocked(api.getSession).mockResolvedValue(

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -4645,6 +4645,121 @@ describe("SessionsStore", () => {
       expect(sessions.total).toBe(0);
     });
 
+    it("protects a non-active hydration from an older index request", async () => {
+      mockSidebarIndex([
+        makeSkinnyRow({ id: "a", project: "proj-a", display_name: "old" }),
+        makeSkinnyRow({ id: "b", project: "proj-a" }),
+      ]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "b", project: "proj-a", first_message: "b-detail" }),
+      );
+      sessions.selectSession("b");
+      await Promise.resolve();
+
+      // An index reload is issued...
+      let resolveIndex!: (v: unknown) => void;
+      vi.mocked(api.getSidebarSessionIndex).mockReturnValueOnce(
+        new Promise((r) => {
+          resolveIndex = r;
+        }),
+      );
+      const reload = sessions.load({ force: true });
+
+      // ...then the NON-active row hydrates with a newer remote rename and
+      // the user selects it.
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({
+          id: "a",
+          project: "proj-a",
+          display_name: "hydra-renamed",
+        }),
+      );
+      await sessions.hydrateVisibleSessions(["a"]);
+      sessions.selectSession("a");
+      expect(sessions.activeSession?.display_name).toBe("hydra-renamed");
+
+      // The older index resolves with the pre-rename name. The hydration
+      // was issued after this index request, so its fields must win even
+      // though the row was not active when it committed.
+      resolveIndex({
+        sessions: [
+          makeSkinnyRow({ id: "a", project: "proj-a", display_name: "old" }),
+          makeSkinnyRow({ id: "b", project: "proj-a" }),
+        ],
+        total: 2,
+      });
+      await reload;
+
+      expect(sessions.activeSession?.display_name).toBe("hydra-renamed");
+      expect(
+        sessions.sessions.find((s) => s.id === "a")?.display_name,
+      ).toBe("hydra-renamed");
+    });
+
+    it("removes known descendants when a refresh 404s for their root", async () => {
+      vi.mocked(api.getSidebarSessionIndex).mockResolvedValue({
+        sessions: [
+          makeSkinnyRow({ id: "root1", project: "proj-a" }),
+          makeSkinnyRow({
+            id: "child1",
+            project: "proj-a",
+            parent_session_id: "root1",
+          }),
+        ],
+        total: 1,
+        next_cursor: null,
+      });
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "root1", project: "proj-a", first_message: "d" }),
+      );
+      sessions.selectSession("root1");
+      await Promise.resolve();
+
+      // The root is deleted elsewhere; a refresh 404s. The backend hides
+      // the whole subtree, so the loaded descendant must go with its root.
+      vi.mocked(api.getSession).mockRejectedValueOnce(
+        makeNotFoundError("root1"),
+      );
+      await sessions.refreshActiveSession();
+
+      expect(sessions.activeSession).toBeUndefined();
+      expect(sessions.sessions.length).toBe(0);
+      expect(sessions.total).toBe(0);
+    });
+
+    it("clears an active descendant when its ancestor is deleted", async () => {
+      vi.mocked(api.getSidebarSessionIndex).mockResolvedValue({
+        sessions: [
+          makeSkinnyRow({ id: "root1", project: "proj-a" }),
+          makeSkinnyRow({
+            id: "child1",
+            project: "proj-a",
+            parent_session_id: "root1",
+          }),
+        ],
+        total: 1,
+        next_cursor: null,
+      });
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "child1", project: "proj-a", first_message: "c" }),
+      );
+      sessions.selectSession("child1");
+      await sessions.hydrateVisibleSessions(["child1"]);
+      expect(sessions.activeSession?.id).toBe("child1");
+
+      // Deleting the parent removes the whole subtree; the active child is
+      // part of it, so the selection must clear rather than leaving the
+      // cached detail backing a ghost active session.
+      vi.mocked(api.deleteSession).mockResolvedValueOnce({});
+      await sessions.deleteSession("root1");
+
+      expect(sessions.activeSession).toBeUndefined();
+      expect(sessions.activeSessionId).toBeNull();
+    });
+
     it("ignores a stale hydration resolving after a newer refresh", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -5430,6 +5430,80 @@ describe("SessionsStore", () => {
       expect(sessions.activeSession?.first_message).toBe("fresh");
     });
 
+    it("does not seed the cache from an epoch-invalidated hydration", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
+      await sessions.load();
+
+      // Selection hydration is in flight when a messages event invalidates
+      // the hydration caches (same index version, bumped epoch).
+      let resolveHydration!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveHydration = r;
+        }),
+      );
+      sessions.selectSession("sel");
+      await Promise.resolve();
+      (sessions as any).invalidateHydratedSessionDetails();
+
+      // The invalidated response resolves; its content predates the
+      // messages change, so it must not seed the active-session cache.
+      resolveHydration(
+        makeSession({
+          id: "sel",
+          project: "proj-a",
+          first_message: "stale-detail",
+        }),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // A reload excludes the row: with no valid cache, the breadcrumb
+      // empties instead of surfacing the invalidated snapshot.
+      mockSidebarIndex([makeSkinnyRow({ id: "other", project: "proj-b" })]);
+      await sessions.load({ force: true });
+
+      expect(sessions.activeSession).toBeUndefined();
+    });
+
+    it("scopes off-page deletion accounting to the same query", async () => {
+      vi.mocked(api.getSidebarSessionIndex).mockResolvedValueOnce({
+        sessions: [makeSkinnyRow({ id: "rootA", project: "proj-a" })],
+        total: 2,
+        next_cursor: "page-2",
+      });
+      await sessions.load();
+      vi.mocked(api.getSidebarSessionIndex).mockResolvedValueOnce({
+        sessions: [makeSkinnyRow({ id: "rootB", project: "proj-a" })],
+        total: 2,
+        next_cursor: null,
+      });
+      await sessions.loadMore();
+
+      // Filters change and a paginated reload for the NEW query is in
+      // flight when a root loaded under the OLD query is deleted. The old
+      // row was never part of the new query's total.
+      sessions.filters.project = "proj-x";
+      let resolveIndex!: (v: unknown) => void;
+      vi.mocked(api.getSidebarSessionIndex).mockReturnValueOnce(
+        new Promise((r) => {
+          resolveIndex = r;
+        }),
+      );
+      const reload = sessions.load();
+      vi.mocked(api.deleteSession).mockResolvedValueOnce({});
+      await sessions.deleteSession("rootB");
+
+      resolveIndex({
+        sessions: [makeSkinnyRow({ id: "rootX", project: "proj-x" })],
+        total: 5,
+        next_cursor: "page-2",
+      });
+      await reload;
+
+      expect(sessions.total).toBe(5);
+    });
+
     it("ignores a stale hydration resolving after a newer refresh", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -2797,6 +2797,45 @@ describe("SessionsStore", () => {
 
       expect(sessions.activeSessionId).toBe("sel");
     });
+
+    it("does not let a superseded hydration overwrite fresher active detail", async () => {
+      // Active session backed by fresh cache via a navigation fetch.
+      mockSidebarIndex([]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", project: "proj-a", first_message: "FRESH" }),
+      );
+      await sessions.navigateToSession("sel");
+      expect(sessions.activeSession?.first_message).toBe("FRESH");
+
+      // A superseded (older-version) hydration resolves for the same id; its
+      // version check fails, so it must not replace the newer cached detail.
+      const staleVersion = (sessions as any).sidebarIndexVersion - 1;
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", project: "proj-a", first_message: "STALE" }),
+      );
+      await (sessions as any).hydrateVisibleSessions(["sel"], staleVersion);
+
+      expect(sessions.activeSession?.first_message).toBe("FRESH");
+    });
+
+    it("restores an empty out-of-list active cache on refresh", async () => {
+      // Initial navigation fetch fails, leaving activeSession undefined.
+      mockSidebarIndex([]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockRejectedValueOnce(new Error("fetch failed"));
+      await sessions.navigateToSession("gone");
+      expect(sessions.activeSessionId).toBe("gone");
+      expect(sessions.activeSession).toBeUndefined();
+
+      // A watcher-driven refresh succeeds and must populate the empty cache.
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "gone", project: "proj-b", first_message: "restored" }),
+      );
+      await sessions.refreshActiveSession();
+
+      expect(sessions.activeSession?.first_message).toBe("restored");
+    });
   });
 
   describe("route cancellation", () => {

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -4157,6 +4157,125 @@ describe("SessionsStore", () => {
       expect(sessions.total).toBe(0);
     });
 
+    it("does not let an older refresh overwrite a later hydration commit", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", project: "proj-a", first_message: "A" }),
+      );
+      await sessions.hydrateVisibleSessions(["sel"]);
+      sessions.selectSession("sel");
+
+      // A refresh is issued and stays in flight...
+      let resolveRefresh!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveRefresh = r;
+        }),
+      );
+      const refresh = sessions.refreshActiveSession();
+      await Promise.resolve();
+
+      // ...then a messages event invalidates hydration caches and a
+      // later-issued hydration resolves and commits newer detail first.
+      (sessions as any).invalidateHydratedSessionDetails();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", project: "proj-a", first_message: "H-newer" }),
+      );
+      await sessions.hydrateVisibleSessions(["sel"]);
+      expect(sessions.activeSession?.first_message).toBe("H-newer");
+
+      // The earlier-issued refresh resolving late must not overwrite the
+      // later-issued hydration's commit with its older snapshot.
+      resolveRefresh(
+        makeSession({ id: "sel", project: "proj-a", first_message: "R-stale" }),
+      );
+      await refresh;
+
+      expect(sessions.activeSession?.first_message).toBe("H-newer");
+    });
+
+    it("does not decrement the root total when a child row is removed", async () => {
+      vi.mocked(api.getSidebarSessionIndex).mockResolvedValue({
+        sessions: [
+          makeSkinnyRow({ id: "root1", project: "proj-a" }),
+          makeSkinnyRow({
+            id: "c1",
+            project: "proj-a",
+            parent_session_id: "root1",
+          }),
+        ],
+        total: 1,
+        next_cursor: null,
+      });
+      await sessions.load();
+      expect(sessions.total).toBe(1);
+
+      // A reload whose snapshot predates the deletion is in flight when the
+      // child is explicitly deleted; the paginated total counts root groups,
+      // so neither the delete nor the tombstoned publish may decrement it.
+      let resolveIndex!: (v: unknown) => void;
+      vi.mocked(api.getSidebarSessionIndex).mockReturnValueOnce(
+        new Promise((r) => {
+          resolveIndex = r;
+        }),
+      );
+      const reload = sessions.load({ force: true });
+      vi.mocked(api.deleteSession).mockResolvedValueOnce({});
+      await sessions.deleteSession("c1");
+      expect(sessions.total).toBe(1);
+
+      resolveIndex({
+        sessions: [
+          makeSkinnyRow({ id: "root1", project: "proj-a" }),
+          makeSkinnyRow({
+            id: "c1",
+            project: "proj-a",
+            parent_session_id: "root1",
+          }),
+        ],
+        total: 1,
+      });
+      await reload;
+
+      expect(sessions.sessions.some((s) => s.id === "c1")).toBe(false);
+      expect(sessions.total).toBe(1);
+    });
+
+    it("does not append a deleted row from a stale loadMore page", async () => {
+      vi.mocked(api.getSidebarSessionIndex).mockResolvedValueOnce({
+        sessions: [makeSkinnyRow({ id: "keep", project: "proj-a" })],
+        total: 2,
+        next_cursor: "page-2",
+      });
+      await sessions.load();
+
+      // Page 2 is in flight when the not-yet-loaded session it carries is
+      // explicitly deleted...
+      let resolvePage!: (v: unknown) => void;
+      vi.mocked(api.getSidebarSessionIndex).mockReturnValueOnce(
+        new Promise((r) => {
+          resolvePage = r;
+        }),
+      );
+      const more = sessions.loadMore();
+      vi.mocked(api.deleteSession).mockResolvedValueOnce({});
+      await sessions.deleteSession("gone");
+
+      // ...and the stale page then resolves still listing it. The appended
+      // page must honor the tombstone and adjust the root total.
+      resolvePage({
+        sessions: [makeSkinnyRow({ id: "gone", project: "proj-a" })],
+        total: 2,
+        next_cursor: null,
+      });
+      await more;
+
+      expect(sessions.sessions.some((s) => s.id === "gone")).toBe(false);
+      expect(sessions.sessions.some((s) => s.id === "keep")).toBe(true);
+      expect(sessions.total).toBe(1);
+    });
+
     it("ignores a stale hydration resolving after a newer refresh", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -2722,6 +2722,27 @@ describe("SessionsStore", () => {
       expect(sessions.sessions.filter((s) => s.id === "later")).toHaveLength(1);
       expect(sessions.activeSession?.id).toBe("later");
     });
+
+    it("keeps a sidebar-selected session across a reload that filters it out", async () => {
+      // Select a hydrated sidebar row, then reload with a filtered index that
+      // no longer includes it. The breadcrumb must not go blank.
+      mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
+      vi.mocked(api.getSession).mockResolvedValue(
+        makeSession({ id: "sel", project: "proj-a", first_message: "detail" }),
+      );
+      await sessions.load();
+      await sessions.hydrateVisibleSessions(["sel"]);
+      expect(sessions.sessions[0]!.is_index_only).toBe(false);
+
+      sessions.selectSession("sel");
+      expect(sessions.activeSession?.id).toBe("sel");
+
+      mockSidebarIndex([makeSkinnyRow({ id: "other", project: "proj-b" })]);
+      await sessions.load();
+
+      expect(sessions.activeSessionId).toBe("sel");
+      expect(sessions.activeSession?.project).toBe("proj-a");
+    });
   });
 
   describe("route cancellation", () => {

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -2940,17 +2940,50 @@ describe("SessionsStore", () => {
       );
       await sessions.renameSession("sel", "renamed");
       expect(sessions.sessions[0]?.display_name).toBe("renamed");
+      // The rename response backs the breadcrumb: the row is still index-only
+      // and its in-flight hydration was invalidated by the rename.
+      expect(sessions.activeSession?.display_name).toBe("renamed");
 
-      // The pre-rename hydration snapshot must not overwrite the row or seed
-      // the breadcrumb cache with the old name.
+      // The pre-rename hydration snapshot must not overwrite the row or the
+      // breadcrumb cache with the old name.
       resolveHydration(
         makeSession({ id: "sel", project: "proj-a", display_name: "stale" }),
       );
       await hydration;
 
       expect(sessions.sessions[0]?.display_name).toBe("renamed");
-      expect(sessions.activeSession?.display_name).not.toBe("stale");
-      expect(sessions.activeSessionDetail?.display_name).not.toBe("stale");
+      expect(sessions.activeSession?.display_name).toBe("renamed");
+    });
+
+    it("commits the rename response when it lands during the navigation fetch", async () => {
+      mockSidebarIndex([]);
+      await sessions.load();
+
+      // Navigation fetch for an out-of-list session stays in flight, so the
+      // detail cache is still empty when the rename resolves.
+      let resolveNavigate!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveNavigate = r;
+        }),
+      );
+      const nav = sessions.navigateToSession("sel");
+      await Promise.resolve();
+
+      vi.mocked(api.renameSession).mockResolvedValue(
+        makeSession({ id: "sel", display_name: "renamed" }),
+      );
+      await sessions.renameSession("sel", "renamed");
+      expect(sessions.activeSession?.display_name).toBe("renamed");
+
+      // The cancelled pre-rename navigation response must not replace the
+      // committed rename snapshot.
+      resolveNavigate(
+        makeSession({ id: "sel", display_name: "stale" }),
+      );
+      await nav;
+
+      expect(sessions.activeSession?.display_name).toBe("renamed");
     });
 
     it("seeds the cache from a hydration already in flight at selection", async () => {

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -3336,6 +3336,80 @@ describe("SessionsStore", () => {
       expect(sessions.total).toBe(0);
     });
 
+    it("commits a hydration that resolves after a failed refresh", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
+      await sessions.load();
+
+      // Hydration of the selected index-only row is in flight...
+      let resolveHydration!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveHydration = r;
+        }),
+      );
+      const hydration = sessions.hydrateVisibleSessions(["sel"]);
+      await Promise.resolve();
+      sessions.selectSession("sel");
+
+      // ...when a watcher refresh starts and fails transiently. The read
+      // began but committed nothing newer, so the hydration's successful
+      // response is still the freshest detail there is — discarding it
+      // would leave the row index-only and the breadcrumb blank.
+      vi.mocked(api.getSession).mockRejectedValueOnce(new Error("network"));
+      await sessions.refreshActiveSession();
+
+      resolveHydration(
+        makeSession({ id: "sel", project: "proj-a", first_message: "detail" }),
+      );
+      await hydration;
+
+      expect(sessions.activeSession?.first_message).toBe("detail");
+      expect(
+        sessions.sessions.find((s) => s.id === "sel")?.is_index_only,
+      ).toBe(false);
+    });
+
+    it("keeps hydration-committed detail over a staler index response", async () => {
+      mockSidebarIndex([
+        makeSkinnyRow({ id: "sel", project: "proj-a", display_name: "old" }),
+      ]);
+      await sessions.load();
+
+      // An index reload whose server snapshot predates a remote rename is in
+      // flight...
+      let resolveIndex!: (v: unknown) => void;
+      vi.mocked(api.getSidebarSessionIndex).mockReturnValueOnce(
+        new Promise((r) => {
+          resolveIndex = r;
+        }),
+      );
+      const reload = sessions.load({ force: true });
+
+      // ...while selection hydrates the index-only row, resolving with the
+      // renamed session and committing it as the active detail.
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", project: "proj-a", display_name: "renamed" }),
+      );
+      sessions.selectSession("sel");
+      await sessions.hydrateVisibleSessions(["sel"]);
+      expect(sessions.activeSession?.display_name).toBe("renamed");
+
+      // The staler index must not overwrite the committed hydration in the
+      // row or drag the cache back through the row resync.
+      resolveIndex({
+        sessions: [
+          makeSkinnyRow({ id: "sel", project: "proj-a", display_name: "old" }),
+        ],
+        total: 1,
+      });
+      await reload;
+
+      expect(sessions.activeSession?.display_name).toBe("renamed");
+      expect(
+        sessions.sessions.find((s) => s.id === "sel")?.display_name,
+      ).toBe("renamed");
+    });
+
     it("ignores a stale hydration resolving after a newer refresh", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -4760,6 +4760,53 @@ describe("SessionsStore", () => {
       expect(sessions.activeSessionId).toBeNull();
     });
 
+    it("prunes reconciliation state once no in-flight request needs it", async () => {
+      const makePage = (prefix: string) =>
+        Array.from({ length: 40 }, (_v, i) =>
+          makeSkinnyRow({ id: `${prefix}-${i}`, project: "proj-a" }));
+
+      // Three successive filter-change reloads publish disjoint row sets,
+      // with no requests left in flight between them.
+      for (const prefix of ["one", "two", "three"]) {
+        mockSidebarIndex(makePage(prefix));
+        await sessions.load({ force: true });
+      }
+
+      // Reconciliation bookkeeping must stay bounded by live rows plus
+      // in-flight work, not accumulate every row ever published.
+      const stamps = (sessions as any).indexCommitByRow as Map<
+        string,
+        unknown
+      >;
+      expect(stamps.size).toBeLessThanOrEqual(40 + 1);
+    });
+
+    it("clears a cache-only active descendant when its ancestor is deleted", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "root1", project: "proj-a" })]);
+      await sessions.load();
+
+      // A child session opened from a deep link exists only in the detail
+      // cache; its parent is the listed root.
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({
+          id: "child1",
+          project: "proj-a",
+          parent_session_id: "root1",
+          first_message: "c",
+        }),
+      );
+      await sessions.navigateToSession("child1");
+      expect(sessions.activeSession?.id).toBe("child1");
+
+      // Deleting the root removes the subtree backend-side; the cache-only
+      // active child belongs to it and must be cleared, not left as a ghost.
+      vi.mocked(api.deleteSession).mockResolvedValueOnce({});
+      await sessions.deleteSession("root1");
+
+      expect(sessions.activeSession).toBeUndefined();
+      expect(sessions.activeSessionId).toBeNull();
+    });
+
     it("ignores a stale hydration resolving after a newer refresh", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -2946,22 +2946,36 @@ describe("SessionsStore", () => {
     });
 
     it("does not let a superseded hydration overwrite fresher active detail", async () => {
-      // Active session backed by fresh cache via a navigation fetch.
       mockSidebarIndex([]);
       await sessions.load();
+
+      // A hydration is issued first and stays in flight...
+      const staleVersion = (sessions as any).sidebarIndexVersion - 1;
+      let resolveHydration!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveHydration = r;
+        }),
+      );
+      const hydration = (sessions as any).hydrateVisibleSessions(
+        ["sel"],
+        staleVersion,
+      );
+      await Promise.resolve();
+
+      // ...then a navigation commits fresher detail for the same session.
       vi.mocked(api.getSession).mockResolvedValueOnce(
         makeSession({ id: "sel", project: "proj-a", first_message: "FRESH" }),
       );
       await sessions.navigateToSession("sel");
       expect(sessions.activeSession?.first_message).toBe("FRESH");
 
-      // A superseded (older-version) hydration resolves for the same id; its
-      // version check fails, so it must not replace the newer cached detail.
-      const staleVersion = (sessions as any).sidebarIndexVersion - 1;
-      vi.mocked(api.getSession).mockResolvedValueOnce(
+      // The earlier-issued hydration resolves late; its response predates
+      // the navigation's commit and must not replace the newer detail.
+      resolveHydration(
         makeSession({ id: "sel", project: "proj-a", first_message: "STALE" }),
       );
-      await (sessions as any).hydrateVisibleSessions(["sel"], staleVersion);
+      await hydration;
 
       expect(sessions.activeSession?.first_message).toBe("FRESH");
     });
@@ -5024,6 +5038,43 @@ describe("SessionsStore", () => {
       expect(sessions.activeSession?.first_message).toBe("again");
       expect(sessions.sessions.length).toBe(0);
       expect(sessions.total).toBe(0);
+    });
+
+    it("updates a populated cache from a hydration after an excluding reload", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", project: "proj-a", first_message: "v1" }),
+      );
+      await sessions.hydrateVisibleSessions(["sel"]);
+      sessions.selectSession("sel");
+      expect(sessions.activeSession?.first_message).toBe("v1");
+
+      // A messages event invalidates hydration caches and a fresh hydration
+      // is issued...
+      (sessions as any).invalidateHydratedSessionDetails();
+      let resolveHydration!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveHydration = r;
+        }),
+      );
+      const hydration = sessions.hydrateVisibleSessions(["sel"]);
+      await Promise.resolve();
+
+      // ...then a reload excludes the active row from the sidebar.
+      mockSidebarIndex([makeSkinnyRow({ id: "other", project: "proj-b" })]);
+      await sessions.load({ force: true });
+
+      // The hydration resolves with newer detail. The populated (older)
+      // cache is now the only thing backing the off-list session, and no
+      // retry will come — the fresh response must replace it.
+      resolveHydration(
+        makeSession({ id: "sel", project: "proj-a", first_message: "v2" }),
+      );
+      await hydration;
+
+      expect(sessions.activeSession?.first_message).toBe("v2");
     });
 
     it("ignores a stale hydration resolving after a newer refresh", async () => {

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -4998,6 +4998,34 @@ describe("SessionsStore", () => {
       expect(sessions.total).toBe(1);
     });
 
+    it("does not inject a cache-only session into the sidebar on revival", async () => {
+      mockSidebarIndex([]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "c", project: "proj-b", first_message: "detail" }),
+      );
+      await sessions.navigateToSession("c");
+      expect(sessions.sessions.length).toBe(0);
+
+      // The cache-only session (excluded by the current filter) transiently
+      // 404s...
+      vi.mocked(api.getSession).mockRejectedValueOnce(makeNotFoundError("c"));
+      await sessions.refreshActiveSession();
+      expect(sessions.activeSession).toBeUndefined();
+
+      // ...and a later refresh confirms it exists. The detail cache must
+      // recover, but the tombstone never removed a sidebar row: nothing may
+      // be appended to the filtered list and the root total must not grow.
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "c", project: "proj-b", first_message: "again" }),
+      );
+      await sessions.refreshActiveSession();
+
+      expect(sessions.activeSession?.first_message).toBe("again");
+      expect(sessions.sessions.length).toBe(0);
+      expect(sessions.total).toBe(0);
+    });
+
     it("ignores a stale hydration resolving after a newer refresh", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -765,7 +765,7 @@ describe("SessionsStore", () => {
       );
     });
 
-    it("keeps the active appended row when the reloaded index omits it", async () => {
+    it("keeps the open off-page session when the reloaded index omits it", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "listed" })]);
       vi.mocked(api.getSession).mockResolvedValue(
         makeSession({
@@ -782,16 +782,16 @@ describe("SessionsStore", () => {
 
       await sessions.load();
 
-      expect(sessions.sessions.map((s) => s.id)).toEqual([
-        "listed",
-        "offpage",
-      ]);
+      // The open session is backed by the detail cache, not injected into
+      // the filtered sidebar collection, so the reload neither drops the
+      // breadcrumb nor grows the list.
+      expect(sessions.sessions.map((s) => s.id)).toEqual(["listed"]);
       expect(sessions.activeSession?.first_message).toBe(
         "hydrated offpage detail",
       );
     });
 
-    it("moves the appended active row into place when pagination reaches it", async () => {
+    it("keeps the open session through pagination reaching its real row", async () => {
       vi.mocked(api.getSidebarSessionIndex).mockResolvedValueOnce({
         sessions: [makeSkinnyRow({ id: "listed" })],
         total: 2,
@@ -806,13 +806,10 @@ describe("SessionsStore", () => {
 
       await sessions.load();
       await sessions.navigateToSession("offpage");
-      expect(sessions.sessions.map((s) => s.id)).toEqual([
-        "listed",
-        "offpage",
-      ]);
+      // The off-page target backs activeSession from the detail cache
+      // without being injected into the sidebar collection.
+      expect(sessions.sessions.map((s) => s.id)).toEqual(["listed"]);
 
-      // A page that doesn't contain the appended row keeps it at the
-      // tail, preserving index order for keyboard navigation.
       vi.mocked(api.getSidebarSessionIndex).mockResolvedValueOnce({
         sessions: [makeSkinnyRow({ id: "middle" })],
         total: 4,
@@ -822,9 +819,14 @@ describe("SessionsStore", () => {
       expect(sessions.sessions.map((s) => s.id)).toEqual([
         "listed",
         "middle",
-        "offpage",
       ]);
+      expect(sessions.activeSession?.first_message).toBe(
+        "hydrated offpage detail",
+      );
 
+      // Pagination reaches the open session's real row: it appears in its
+      // index position exactly once, and the breadcrumb keeps the cached
+      // detail while the row arrives as an index-only stub.
       vi.mocked(api.getSidebarSessionIndex).mockResolvedValueOnce({
         sessions: [
           makeSkinnyRow({ id: "offpage" }),
@@ -844,6 +846,44 @@ describe("SessionsStore", () => {
       expect(sessions.activeSession?.first_message).toBe(
         "hydrated offpage detail",
       );
+    });
+
+    it("merges a re-listed row in place when a later page repeats it", async () => {
+      vi.mocked(api.getSidebarSessionIndex).mockResolvedValueOnce({
+        sessions: [
+          makeSkinnyRow({ id: "first" }),
+          makeSkinnyRow({ id: "shifted" }),
+        ],
+        total: 3,
+        next_cursor: "page-2",
+      });
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValue(
+        makeSession({ id: "shifted", first_message: "hydrated shifted" }),
+      );
+      await sessions.hydrateVisibleSessions(["shifted"]);
+
+      // The index shifted while paginating and page 2 re-lists a row from
+      // page 1: it must move to its new position once, not duplicate, and
+      // carry its hydrated fields.
+      vi.mocked(api.getSidebarSessionIndex).mockResolvedValueOnce({
+        sessions: [
+          makeSkinnyRow({ id: "shifted" }),
+          makeSkinnyRow({ id: "last" }),
+        ],
+        total: 3,
+        next_cursor: null,
+      });
+      await sessions.loadMore();
+
+      expect(sessions.sessions.map((s) => s.id)).toEqual([
+        "first",
+        "shifted",
+        "last",
+      ]);
+      expect(
+        sessions.sessions.find((s) => s.id === "shifted")?.first_message,
+      ).toBe("hydrated shifted");
     });
 
     it("refreshes hydrated agent identity fields from the sidebar index", async () => {

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -4851,6 +4851,51 @@ describe("SessionsStore", () => {
       expect(sessions.activeSession?.first_message).toBe("H");
     });
 
+    it("restores the sidebar row when a hydration revives a 404d session", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", project: "proj-a", first_message: "A" }),
+      );
+      await sessions.hydrateVisibleSessions(["sel"]);
+      sessions.selectSession("sel");
+
+      let rejectRefresh!: (e: unknown) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((_r, rej) => {
+          rejectRefresh = rej;
+        }),
+      );
+      const refresh = sessions.refreshActiveSession();
+      await Promise.resolve();
+
+      (sessions as any).invalidateHydratedSessionDetails();
+      let resolveHydration!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveHydration = r;
+        }),
+      );
+      const hydration = sessions.hydrateVisibleSessions(["sel"]);
+      await Promise.resolve();
+      rejectRefresh(makeNotFoundError("sel"));
+      await refresh;
+      expect(sessions.sessions.some((s) => s.id === "sel")).toBe(false);
+      expect(sessions.total).toBe(0);
+
+      // The superseding hydration proves the session exists: besides
+      // recovering the breadcrumb, the sidebar row and root total the
+      // transient 404 removed must come back.
+      resolveHydration(
+        makeSession({ id: "sel", project: "proj-a", first_message: "H" }),
+      );
+      await hydration;
+
+      expect(sessions.activeSession?.first_message).toBe("H");
+      expect(sessions.sessions.some((s) => s.id === "sel")).toBe(true);
+      expect(sessions.total).toBe(1);
+    });
+
     it("ignores a stale hydration resolving after a newer refresh", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -3214,6 +3214,46 @@ describe("SessionsStore", () => {
       ).toBe(false);
     });
 
+    it("restores the active row when a stale index resolves after a rename", async () => {
+      mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", project: "proj-a", first_message: "detail" }),
+      );
+      await sessions.hydrateVisibleSessions(["sel"]);
+      sessions.selectSession("sel");
+
+      // An index reload is in flight when the user renames the session...
+      let resolveIndex!: (v: unknown) => void;
+      vi.mocked(api.getSidebarSessionIndex).mockReturnValueOnce(
+        new Promise((r) => {
+          resolveIndex = r;
+        }),
+      );
+      const reload = sessions.load({ force: true });
+
+      vi.mocked(api.renameSession).mockResolvedValue(
+        makeSession({ id: "sel", display_name: "renamed" }),
+      );
+      await sessions.renameSession("sel", "renamed");
+      expect(sessions.activeSession?.display_name).toBe("renamed");
+
+      // ...and resolves afterward with a pre-rename snapshot of the row.
+      // The committed rename must keep backing both the sidebar row and the
+      // breadcrumb, not survive only inside the detail cache while the
+      // stale row is what gets displayed.
+      resolveIndex({
+        sessions: [makeSkinnyRow({ id: "sel", project: "proj-a" })],
+        total: 1,
+      });
+      await reload;
+
+      expect(sessions.activeSession?.display_name).toBe("renamed");
+      expect(
+        sessions.sessions.find((s) => s.id === "sel")?.display_name,
+      ).toBe("renamed");
+    });
+
     it("ignores a stale hydration resolving after a newer refresh", async () => {
       mockSidebarIndex([makeSkinnyRow({ id: "sel", project: "proj-a" })]);
       await sessions.load();

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -2836,6 +2836,71 @@ describe("SessionsStore", () => {
 
       expect(sessions.activeSession?.first_message).toBe("restored");
     });
+
+    it("ignores a stale navigation response resolving after a newer refresh", async () => {
+      mockSidebarIndex([]);
+      await sessions.load();
+
+      // Navigation fetch for an out-of-list session stays in flight...
+      let resolveNavigate!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveNavigate = r;
+        }),
+      );
+      const nav = sessions.navigateToSession("sel");
+      await Promise.resolve();
+
+      // ...while a watcher-driven refresh for the same session resolves
+      // first with a fresher snapshot.
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", project: "proj-a", first_message: "NEWER" }),
+      );
+      await sessions.refreshActiveSession();
+      expect(sessions.activeSession?.first_message).toBe("NEWER");
+
+      // The older navigation response must not clobber the newer detail.
+      resolveNavigate(
+        makeSession({ id: "sel", project: "proj-a", first_message: "OLDER" }),
+      );
+      await nav;
+
+      expect(sessions.activeSession?.first_message).toBe("NEWER");
+    });
+
+    it("does not let a pre-rename refresh response revert a rename", async () => {
+      mockSidebarIndex([]);
+      await sessions.load();
+      vi.mocked(api.getSession).mockResolvedValueOnce(
+        makeSession({ id: "sel", display_name: null, first_message: "detail" }),
+      );
+      await sessions.navigateToSession("sel");
+
+      // Refresh fetch carrying a pre-rename snapshot stays in flight...
+      let resolveRefresh!: (s: Session) => void;
+      vi.mocked(api.getSession).mockReturnValueOnce(
+        new Promise<Session>((r) => {
+          resolveRefresh = r;
+        }),
+      );
+      const refresh = sessions.refreshActiveSession();
+      await Promise.resolve();
+
+      // ...while a rename completes and updates the cached detail.
+      vi.mocked(api.renameSession).mockResolvedValue(
+        makeSession({ id: "sel", display_name: "renamed" }),
+      );
+      await sessions.renameSession("sel", "renamed");
+      expect(sessions.activeSession?.display_name).toBe("renamed");
+
+      resolveRefresh(
+        makeSession({ id: "sel", display_name: null, first_message: "detail" }),
+      );
+      await refresh;
+
+      expect(sessions.activeSession?.display_name).toBe("renamed");
+    });
+
   });
 
   describe("route cancellation", () => {


### PR DESCRIPTION
Supersedes #1201's store internals and replaces the approach #1204 introduced for #1190, while keeping #1204's route-first opening flow.

## Why

#1204 fixed the lost-breadcrumb bug (#1190) by injecting and keeping the open session's row inside the filtered sidebar collection. That leaks the open session into `groupedSessions`: a session excluded by the active filters (opened from search, or fallen off the loaded pages) visibly appears in the sidebar and shifts group membership and pagination accounting. This PR instead backs the open session with a separate `activeSessionDetail` cache in the sessions store: `activeSession` falls back to the cache when the session's row is absent or index-only, and the sidebar collection stays exactly what the filters say it is.

## What it does now

- Keeps #1204's route-first opening flow, deep-link self-healing, and loadMore dedupe; the same-session navigate join is ported onto the shared active-detail read coordinator.
- Coordinates every read that commits to active-detail state (navigation, watcher refresh, rename, sidebar hydration, signal detail) through a latest-read coordinator plus per-session commit generations: a session's generation advances only when fresher state actually commits (navigation/refresh resolved, a rename or hydration committed its snapshot, a 404 committed a deletion), so a read that merely began — and may fail — never invalidates anything, and interleaved responses cannot overwrite fresher detail with a stale snapshot. Generations are per session id, so activity on one session never invalidates an in-flight hydration of another — a selection may join that hydration and depend on its result. A watcher refresh likewise joins a pending same-session navigation (both issue the identical detail GET) instead of cancelling it, so a transiently failing refresh can never strand a deep link with an empty cache.
- Enforces the invariant that every update a sidebar row receives, the cache receives: hydration merges, renames, delete/404 removals, index commits in `loadSidebarPage`/`loadMore`, an index-only stub of a cache-only session re-entering the index, and signal-detail merges all sync the cache.
- After every index commit the active session's row and cache reconcile in whichever direction is fresher, gated on committed state: the merged row resyncs the cache when nothing newer committed mid-flight (a just-committed index is at least as fresh as any commit that resolved before the index request was issued); a rename, detail refresh, or hydration that committed while the index was in flight replaces the re-listed row; and a 404 deletion that committed mid-flight removes the re-listed row (tombstone). The same ordering applies in the other direction: a navigation/refresh/hydration response that resolves after an index commit re-published its row contributes only detail-owned fields, keeping the committed index's fields (display_name, counts) instead of reverting them (falling back to the cache when a later reload dropped the row). Ordering is by request issue: every commit records the index-request ordinal its underlying request began at (renames and 404s are write-derived and always win), and committed detail outranks an index commit only when its request is at least as new as the index's. A rename that lands on an empty cache also chases with a fresh detail read, since the rename endpoint's response lacks the derived detail-only fields.
- A definitive 404 for the active session drops both the cached detail and the sidebar row, so a session deleted on another machine empties the breadcrumb instead of lingering as a ghost.

## Tradeoffs and limitations

- Freshness generations are scoped to active-detail reads, which only exist for the open session: a rename of a session that is not open can still be transiently reverted in the sidebar by an index response already in flight, until the next refresh corrects it.
- A remote-delete 404 leaves `activeSessionId` set (only the detail and row are dropped) so the selection can recover if the session reappears; local delete still clears the selection. The asymmetry is deliberate.

## Where to look

Nearly all changes are in `frontend/src/lib/stores/sessions.svelte.ts` and its colocated test file; `frontend/src/lib/utils/latest-read.ts` holds the read coordinator.

## Credit

The detail-cache design and its original regression suite are @bangddong's work from #1201 (the first six commits here are theirs); this PR carries that design forward, rebased onto current main and reconciled with #1204's flow, with additional race hardening on top.





