### PR TITLE
fix(recall): keep large body bound out of request grammar

### DIFF
--- a/docs/internal/recall-extraction.md
+++ b/docs/internal/recall-extraction.md
@@ -351,10 +351,12 @@ The daemon scheduler mirrors the embedding scheduler's shape:
 Concurrency is one pass at a time, one session at a time, one unit per model
 call. Each response is bounded locally as well as by the transport size cap: the
 client refuses responses exceeding fixed limits on entries per call and on
-title, body, and entity lengths, and the requested JSON schema declares the same
-bounds (`maxItems`/`maxLength`), so a compliant constrained-decoding server
-never produces a refused response while a non-compliant one cannot balloon the
-archive or hold its write lock through oversized inserts.
+title, body, and entity lengths. The requested JSON schema declares the entry,
+title, entity-count, and entity-length bounds. The 5000-character body bound is
+enforced client-side only because expanding that large `maxLength` makes some
+JSON-schema grammar compilers reject the request before inference. A
+non-compliant endpoint still cannot balloon the archive or hold its write lock
+through oversized inserts.
 
 ## Activation
 

--- a/docs/internal/recall-extraction.md
+++ b/docs/internal/recall-extraction.md
@@ -356,7 +356,9 @@ title, entity-count, and entity-length bounds. The 5000-character body bound is
 enforced client-side only because expanding that large `maxLength` makes some
 JSON-schema grammar compilers reject the request before inference. A
 non-compliant endpoint still cannot balloon the archive or hold its write lock
-through oversized inserts.
+through oversized inserts. An oversized body fails only its source session
+behind the normal backoff; it is not an endpoint-scoped schema violation that
+aborts the remaining pass.
 
 ## Activation
 

--- a/docs/internal/recall-extraction.md
+++ b/docs/internal/recall-extraction.md
@@ -356,9 +356,10 @@ title, entity-count, and entity-length bounds. The 5000-character body bound is
 enforced client-side only because expanding that large `maxLength` makes some
 JSON-schema grammar compilers reject the request before inference. A
 non-compliant endpoint still cannot balloon the archive or hold its write lock
-through oversized inserts. An oversized body fails only its source session
-behind the normal backoff; it is not an endpoint-scoped schema violation that
-aborts the remaining pass.
+through oversized inserts. A successful response that exceeds the transport cap
+or the client-only body bound fails only its source session behind the normal
+backoff; it is not an endpoint-scoped schema violation that aborts the remaining
+pass.
 
 ## Activation
 

--- a/internal/recall/extract/client.go
+++ b/internal/recall/extract/client.go
@@ -149,16 +149,18 @@ const maxRetryDelay = 30 * time.Second
 // v2: minLength constraints on entry title and body.
 // v3: truncation always splits; the entry-capped compact retry is gone.
 // v4: maxItems/maxLength bounds on entries, fields, and entities.
-const extractionProtocolVersion = 4
+// v5: body maxLength is enforced client-side only for grammar compatibility.
+const extractionProtocolVersion = 5
 
 // Local resource bounds on a single distill response. The transport cap
 // only bounds bytes; within it a compromised or misconfigured endpoint
 // could return tens of thousands of entries or multi-megabyte fields, and
 // accepting them would balloon the archive (and its FTS index) and hold
-// the write lock through the inserts. entrySchema declares the same limits
-// (maxItems/maxLength), so a compliant constrained-decoding server never
-// produces a response the client refuses. Lengths count Unicode code
-// points to match JSON Schema maxLength semantics.
+// the write lock through the inserts. entrySchema declares every limit except
+// the body maxLength: some JSON-schema grammar compilers expand a 5000-character
+// string bound into a grammar too large to parse. The transport and client-side
+// checks still bound bodies safely. Lengths count Unicode code points to match
+// JSON Schema maxLength semantics where the schema carries the constraint.
 const (
 	maxResponseEntries = 100
 	maxEntryTitleChars = 500
@@ -209,7 +211,6 @@ var entrySchema = map[string]any{
 					},
 					"body": map[string]any{
 						"type": "string", "minLength": 1,
-						"maxLength": maxEntryBodyChars,
 					},
 					"entities": map[string]any{
 						"type":     "array",

--- a/internal/recall/extract/client.go
+++ b/internal/recall/extract/client.go
@@ -170,11 +170,12 @@ const extractionProtocolVersion = 5
 // checks still bound bodies safely. Lengths count Unicode code points to match
 // JSON Schema maxLength semantics where the schema carries the constraint.
 const (
-	maxResponseEntries = 100
-	maxEntryTitleChars = 500
-	maxEntryBodyChars  = 5000
-	maxEntryEntities   = 50
-	maxEntityChars     = 200
+	maxResponseBodyBytes = 16 << 20
+	maxResponseEntries   = 100
+	maxEntryTitleChars   = 500
+	maxEntryBodyChars    = 5000
+	maxEntryEntities     = 50
+	maxEntityChars       = 200
 )
 
 // Entry is one distilled memory entry as the model produces it.
@@ -452,7 +453,9 @@ func (c *Client) distill(
 			c.transportErrorDetail(cause))}
 	}
 	defer func() { _ = response.Body.Close() }()
-	raw, err := io.ReadAll(io.LimitReader(response.Body, 16<<20))
+	raw, err := io.ReadAll(io.LimitReader(
+		response.Body, int64(maxResponseBodyBytes)+1,
+	))
 	if err != nil {
 		// Read errors quote raw wire bytes — a malformed chunked trailer
 		// line is echoed verbatim — so the detail follows the same policy
@@ -461,6 +464,14 @@ func (c *Client) distill(
 			err: fmt.Errorf("reading distill response: %s",
 				c.transportErrorDetail(err)),
 		}
+	}
+	responseTooLarge := len(raw) > maxResponseBodyBytes
+	if responseTooLarge {
+		// Non-success responses are classified by their status below; their
+		// diagnostic excerpt never needs the sentinel byte. A successful
+		// response is checked before JSON decoding so truncation cannot
+		// masquerade as a transient parse failure.
+		raw = raw[:maxResponseBodyBytes]
 	}
 	if response.StatusCode == http.StatusBadRequest {
 		detail := c.responseDetail(raw)
@@ -511,6 +522,12 @@ func (c *Client) distill(
 				response.StatusCode, c.responseDetail(raw),
 			),
 		}
+	}
+	if responseTooLarge {
+		return nil, Usage{}, fmt.Errorf(
+			"%w: response body exceeds the %d-byte transport cap",
+			errClientOnlyResponseLimit, maxResponseBodyBytes,
+		)
 	}
 
 	var parsed struct {

--- a/internal/recall/extract/client.go
+++ b/internal/recall/extract/client.go
@@ -61,6 +61,14 @@ var errProtocolViolation = errors.New(
 	"distill response violates the extraction protocol",
 )
 
+// errClientOnlyResponseLimit marks a resource bound enforced only after the
+// response arrives. Unlike a schema violation, it indicts one model output,
+// not the endpoint: the manager fails that session behind its backoff and
+// continues through the remaining candidates.
+var errClientOnlyResponseLimit = errors.New(
+	"distill response exceeds a client-only resource limit",
+)
+
 // requestStatusError carries the HTTP status of a permanent server
 // rejection so callers can tell endpoint-scoped failures from
 // input-specific ones.
@@ -559,6 +567,9 @@ func (c *Client) distill(
 	}
 	entries, err := parseEntries(choice.Message.Content)
 	if err != nil {
+		if errors.Is(err, errClientOnlyResponseLimit) {
+			return nil, parsed.Usage, err
+		}
 		// The server was asked for constrained decoding, so a violation
 		// means it did not enforce the schema; at temperature zero that is
 		// deterministic and not worth retrying.
@@ -775,7 +786,8 @@ func parseEntries(content string) ([]Entry, error) {
 		}
 		if n := utf8.RuneCountInString(entry.Body); n > maxEntryBodyChars {
 			return nil, fmt.Errorf(
-				"entry %d: body is %d characters, limit %d",
+				"%w: entry %d body is %d characters, limit %d",
+				errClientOnlyResponseLimit,
 				i, n, maxEntryBodyChars,
 			)
 		}

--- a/internal/recall/extract/client_test.go
+++ b/internal/recall/extract/client_test.go
@@ -13,6 +13,9 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type scriptedResponse struct {
@@ -1209,37 +1212,50 @@ func TestClientRejectsOversizedContent(t *testing.T) {
 	}
 }
 
-// TestEntrySchemaMirrorsResponseLimits pins that the limits enforced locally
-// are also requested from the server: a compliant constrained-decoding
-// endpoint then never produces a response the client refuses.
-func TestEntrySchemaMirrorsResponseLimits(t *testing.T) {
-	entriesSchema, ok := entrySchema["properties"].(map[string]any)["entries"].(map[string]any)
-	if !ok {
-		t.Fatal("entry schema has no entries property")
-	}
-	if got := entriesSchema["maxItems"]; got != maxResponseEntries {
-		t.Fatalf("entries maxItems = %v, want %d", got, maxResponseEntries)
-	}
-	fields, ok := entriesSchema["items"].(map[string]any)["properties"].(map[string]any)
-	if !ok {
-		t.Fatal("entry schema has no item properties")
-	}
-	if got := fields["title"].(map[string]any)["maxLength"]; got != maxEntryTitleChars {
-		t.Fatalf("title maxLength = %v, want %d", got, maxEntryTitleChars)
-	}
-	if got := fields["body"].(map[string]any)["maxLength"]; got != maxEntryBodyChars {
-		t.Fatalf("body maxLength = %v, want %d", got, maxEntryBodyChars)
-	}
+// TestClientRequestSchemaKeepsLargeBodyLimitLocal pins the server boundary:
+// large maxLength values make some JSON-schema-to-grammar implementations
+// reject the entire request, while the client still rejects oversized bodies
+// in TestClientRejectsOversizedContent.
+func TestClientRequestSchemaKeepsLargeBodyLimitLocal(t *testing.T) {
+	var requests []map[string]any
+	server := newScriptedServer(t, []scriptedResponse{
+		{finishReason: "stop", content: entriesJSON(t, "one")},
+	}, &requests)
+	defer server.Close()
+
+	_, _, err := testClient(server.URL).DistillWithRecovery(
+		context.Background(), "p", "text", 3,
+	)
+	require.NoError(t, err)
+	require.Len(t, requests, 1)
+
+	responseFormat, ok := requests[0]["response_format"].(map[string]any)
+	require.True(t, ok, "request has no response_format object")
+	jsonSchema, ok := responseFormat["json_schema"].(map[string]any)
+	require.True(t, ok, "response_format has no json_schema object")
+	schema, ok := jsonSchema["schema"].(map[string]any)
+	require.True(t, ok, "json_schema has no schema object")
+	properties, ok := schema["properties"].(map[string]any)
+	require.True(t, ok, "entry schema has no properties object")
+	entriesSchema, ok := properties["entries"].(map[string]any)
+	require.True(t, ok, "entry schema has no entries property")
+	assert.Equal(t, float64(maxResponseEntries), entriesSchema["maxItems"])
+	items, ok := entriesSchema["items"].(map[string]any)
+	require.True(t, ok, "entries schema has no items object")
+	fields, ok := items["properties"].(map[string]any)
+	require.True(t, ok, "entry schema has no item properties")
+	title, ok := fields["title"].(map[string]any)
+	require.True(t, ok, "entry schema has no title property")
+	assert.Equal(t, float64(maxEntryTitleChars), title["maxLength"])
+	body, ok := fields["body"].(map[string]any)
+	require.True(t, ok, "entry schema has no body property")
+	assert.NotContains(t, body, "maxLength")
 	entities, ok := fields["entities"].(map[string]any)
-	if !ok {
-		t.Fatal("entry schema has no entities property")
-	}
-	if got := entities["maxItems"]; got != maxEntryEntities {
-		t.Fatalf("entities maxItems = %v, want %d", got, maxEntryEntities)
-	}
-	if got := entities["items"].(map[string]any)["maxLength"]; got != maxEntityChars {
-		t.Fatalf("entity maxLength = %v, want %d", got, maxEntityChars)
-	}
+	require.True(t, ok, "entry schema has no entities property")
+	assert.Equal(t, float64(maxEntryEntities), entities["maxItems"])
+	entityItems, ok := entities["items"].(map[string]any)
+	require.True(t, ok, "entities schema has no items object")
+	assert.Equal(t, float64(maxEntityChars), entityItems["maxLength"])
 }
 
 func TestSplitFloorChars(t *testing.T) {

--- a/internal/recall/extract/client_test.go
+++ b/internal/recall/extract/client_test.go
@@ -1212,6 +1212,27 @@ func TestClientRejectsOversizedContent(t *testing.T) {
 	}
 }
 
+// TestClientClassifiesTransportOverflowWithoutRetry pins the HTTP boundary:
+// reading exactly at the cap cannot reveal whether the body was truncated.
+// The extra sentinel byte must turn an oversized 200 into a client-only limit
+// error instead of a transient JSON parse failure and retry ladder.
+func TestClientClassifiesTransportOverflowWithoutRetry(t *testing.T) {
+	var requests []map[string]any
+	server := newScriptedServer(t, []scriptedResponse{{
+		finishReason: "stop",
+		content:      strings.Repeat("x", maxResponseBodyBytes+1),
+	}}, &requests)
+	defer server.Close()
+
+	_, _, err := testClient(server.URL).DistillWithRecovery(
+		context.Background(), "p", "text", 3,
+	)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errClientOnlyResponseLimit)
+	assert.False(t, endpointScopedRejection(err))
+	assert.Len(t, requests, 1, "a deterministic overflow must not retry")
+}
+
 // TestClientRequestSchemaKeepsLargeBodyLimitLocal pins the server boundary:
 // large maxLength values make some JSON-schema-to-grammar implementations
 // reject the entire request, while the client still rejects oversized bodies

--- a/internal/recall/extract/manager_test.go
+++ b/internal/recall/extract/manager_test.go
@@ -2219,50 +2219,71 @@ func TestManagerAbortsPassOnSchemaViolation(t *testing.T) {
 	}
 }
 
-// TestManagerContinuesAfterClientOnlyBodyLimit pins that a response exceeding
-// a bound omitted from the request schema poisons only that session. Treating
-// it as a schema violation would abort before the later candidate is visited.
-func TestManagerContinuesAfterClientOnlyBodyLimit(t *testing.T) {
-	d := newTestArchive(t)
-	ctx := context.Background()
-	oversized := `{"entries":[{"type":"fact","title":"too long",` +
-		`"body":"` + strings.Repeat("x", maxEntryBodyChars+1) +
-		`","entities":[]}]}`
-	server, log := modelServer(t, func(text string, _ int) (int, string) {
-		if strings.Contains(text, "oversize") {
-			return http.StatusOK, completionBody(t, oversized)
-		}
-		return http.StatusOK, completionBody(t, entriesJSON(t, "later"))
-	})
-	seedSession(t, d, "sess-a", turnMessages("oversize this", "done"), nil)
-	seedSession(t, d, "sess-b", turnMessages("ship it", "shipped"), nil)
-	m := newManager(t, d, server.URL, nil)
+// TestManagerContinuesAfterClientOnlyResponseLimit pins that a response
+// exceeding the transport cap or a bound omitted from the request schema
+// poisons only that session. Treating either as a transport or schema failure
+// would abort before the later candidate is visited.
+func TestManagerContinuesAfterClientOnlyResponseLimit(t *testing.T) {
+	cases := map[string]struct {
+		oversized string
+		wantError string
+	}{
+		"entry body": {
+			oversized: `{"entries":[{"type":"fact","title":"too long",` +
+				`"body":"` + strings.Repeat("x", maxEntryBodyChars+1) +
+				`","entities":[]}]}`,
+			wantError: "body is 5001 characters",
+		},
+		"transport body": {
+			oversized: strings.Repeat("x", maxResponseBodyBytes+1),
+			wantError: "response body exceeds the 16777216-byte transport cap",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			d := newTestArchive(t)
+			ctx := context.Background()
+			server, log := modelServer(t, func(text string, _ int) (int, string) {
+				if strings.Contains(text, "oversize") {
+					return http.StatusOK, completionBody(t, tc.oversized)
+				}
+				return http.StatusOK, completionBody(t, entriesJSON(t, "later"))
+			})
+			seedSession(t, d, "sess-a", turnMessages("oversize this", "done"), nil)
+			seedSession(t, d, "sess-b", turnMessages("ship it", "shipped"), nil)
+			m := newManager(t, d, server.URL, nil)
 
-	result, err := m.RunPass(ctx, PassOptions{})
-	require.NoError(t, err)
-	assert.Equal(t, 1, result.Sessions)
-	assert.Equal(t, 1, result.Failed)
-	assert.Equal(t, 2, result.Units)
-	assert.Equal(t, 2, result.Entries)
-	assert.Equal(t, 3, log.count(),
-		"one rejected call must not prevent both units of the later session")
+			result, err := m.RunPass(ctx, PassOptions{})
+			require.NoError(t, err)
+			assert.Equal(t, 1, result.Sessions)
+			assert.Equal(t, 1, result.Failed)
+			assert.Equal(t, 2, result.Units)
+			assert.Equal(t, 2, result.Entries)
+			assert.Equal(t, 3, log.count(),
+				"one rejected call must not prevent both units of the later session")
 
-	failed, found, err := d.ExtractProgress(ctx, "sess-a", m.Fingerprint())
-	require.NoError(t, err)
-	require.True(t, found)
-	assert.Equal(t, db.ExtractProgressFailed, failed.State)
-	assert.Contains(t, failed.LastError, "body is 5001 characters")
+			failed, found, err := d.ExtractProgress(
+				ctx, "sess-a", m.Fingerprint(),
+			)
+			require.NoError(t, err)
+			require.True(t, found)
+			assert.Equal(t, db.ExtractProgressFailed, failed.State)
+			assert.Contains(t, failed.LastError, tc.wantError)
 
-	done, found, err := d.ExtractProgress(ctx, "sess-b", m.Fingerprint())
-	require.NoError(t, err)
-	require.True(t, found)
-	assert.Equal(t, db.ExtractProgressDone, done.State)
-	entry, err := d.GetRecallEntry(
-		ctx, EntryID(m.Fingerprint(), "sess-b", 0, 0),
-	)
-	require.NoError(t, err)
-	require.NotNil(t, entry)
-	assert.Equal(t, "later", entry.Title)
+			done, found, err := d.ExtractProgress(
+				ctx, "sess-b", m.Fingerprint(),
+			)
+			require.NoError(t, err)
+			require.True(t, found)
+			assert.Equal(t, db.ExtractProgressDone, done.State)
+			entry, err := d.GetRecallEntry(
+				ctx, EntryID(m.Fingerprint(), "sess-b", 0, 0),
+			)
+			require.NoError(t, err)
+			require.NotNil(t, entry)
+			assert.Equal(t, "later", entry.Title)
+		})
+	}
 }
 
 // TestBoundedLastErrorCapsStoredText pins the persistence-side bound on

--- a/internal/recall/extract/manager_test.go
+++ b/internal/recall/extract/manager_test.go
@@ -2219,6 +2219,52 @@ func TestManagerAbortsPassOnSchemaViolation(t *testing.T) {
 	}
 }
 
+// TestManagerContinuesAfterClientOnlyBodyLimit pins that a response exceeding
+// a bound omitted from the request schema poisons only that session. Treating
+// it as a schema violation would abort before the later candidate is visited.
+func TestManagerContinuesAfterClientOnlyBodyLimit(t *testing.T) {
+	d := newTestArchive(t)
+	ctx := context.Background()
+	oversized := `{"entries":[{"type":"fact","title":"too long",` +
+		`"body":"` + strings.Repeat("x", maxEntryBodyChars+1) +
+		`","entities":[]}]}`
+	server, log := modelServer(t, func(text string, _ int) (int, string) {
+		if strings.Contains(text, "oversize") {
+			return http.StatusOK, completionBody(t, oversized)
+		}
+		return http.StatusOK, completionBody(t, entriesJSON(t, "later"))
+	})
+	seedSession(t, d, "sess-a", turnMessages("oversize this", "done"), nil)
+	seedSession(t, d, "sess-b", turnMessages("ship it", "shipped"), nil)
+	m := newManager(t, d, server.URL, nil)
+
+	result, err := m.RunPass(ctx, PassOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Sessions)
+	assert.Equal(t, 1, result.Failed)
+	assert.Equal(t, 2, result.Units)
+	assert.Equal(t, 2, result.Entries)
+	assert.Equal(t, 3, log.count(),
+		"one rejected call must not prevent both units of the later session")
+
+	failed, found, err := d.ExtractProgress(ctx, "sess-a", m.Fingerprint())
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, db.ExtractProgressFailed, failed.State)
+	assert.Contains(t, failed.LastError, "body is 5001 characters")
+
+	done, found, err := d.ExtractProgress(ctx, "sess-b", m.Fingerprint())
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, db.ExtractProgressDone, done.State)
+	entry, err := d.GetRecallEntry(
+		ctx, EntryID(m.Fingerprint(), "sess-b", 0, 0),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, entry)
+	assert.Equal(t, "later", entry.Title)
+}
+
 // TestBoundedLastErrorCapsStoredText pins the persistence-side bound on
 // externally derived error text: whatever the client lets through, a
 // failure row must not store megabytes per session.


### PR DESCRIPTION
Some OpenAI-compatible constrained-decoding servers expand JSON Schema string-length bounds into grammar productions. The recall body limit of 5,000 characters can make that generated grammar too large for the server to parse, causing every extraction request to fail before inference even though the endpoint supports `json_schema`.

Keep the 5,000-character body limit in AgentsView's existing client-side response validation, while omitting only that large bound from the model-facing schema. Entry counts, title lengths, entity counts, and entity lengths remain constrained in both places, and the transport cap plus local validation still prevent oversized responses from reaching the archive. The response reader consumes one sentinel byte beyond that cap so oversized successful output is identified explicitly instead of becoming a transient truncated-JSON failure.

Because these limits are client-only, an oversized generated body or successful transport response fails its source session behind the normal backoff while the pass continues through later candidates. Actual violations of constraints still present in the request schema remain endpoint-scoped and abort the pass.

The extraction protocol version advances so output produced under the compatible request contract receives a new generation fingerprint instead of mixing with an older corpus.