### PR TITLE
trae: surface unsupported encrypted modern layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ thread JSON files.
 | VSCode Copilot        | `~/Library/Application Support/Code/User/` (macOS)                                                                                                                      |
 | Visual Studio Copilot | `%LOCALAPPDATA%\\Temp\\VSGitHubCopilotLogs\\traces\\` (Windows), `~/Library/Caches/VSGitHubCopilotLogs/traces/` (macOS), `~/.cache/VSGitHubCopilotLogs/traces/` (Linux) |
 | Windsurf              | `~/Library/Application Support/Windsurf/User/` (macOS), `~/.config/Windsurf/User/` (Linux), `%APPDATA%\\Windsurf\\User\\` (Windows)                                     |
+| Trae                  | `%APPDATA%\\Trae\\User\\` (Windows), `~/Library/Application Support/Trae/User/` (macOS), `~/.config/Trae/User/` (Linux)                                                                                             |
 | Warp                  | `~/.warp/` (platform-dependent)                                                                                                                                         |
 | WorkBuddy             | `~/.workbuddy/projects/`                                                                                                                                                |
 | ZCode                 | `~/.zcode/cli/db/`, `~/.zcode/cli/`                                                                                                                                     |

--- a/cmd/agentsview/doctor.go
+++ b/cmd/agentsview/doctor.go
@@ -52,6 +52,7 @@ type doctorSyncReport struct {
 	doctorDBInspection
 	TempFiles           []string
 	AgentRoots          []doctorAgentRoot
+	TraeEncryptedRoots  []string
 	DebugLines          []string
 	DebugLogErr         error
 	HasResyncFailureLog bool
@@ -100,6 +101,7 @@ func collectDoctorSyncReport(cfg config.Config) doctorSyncReport {
 	report.doctorDBInspection = inspectDoctorDB(cfg.DBPath)
 	report.TempFiles = listDoctorResyncTempFiles(cfg.DBPath)
 	report.AgentRoots = collectDoctorAgentRoots(cfg)
+	report.TraeEncryptedRoots = collectDoctorTraeEncryptedRoots(report.AgentRoots)
 	report.DebugLines, report.DebugLogErr = readDoctorDebugLines(
 		filepath.Join(cfg.DataDir, "debug.log"),
 	)
@@ -332,11 +334,29 @@ func writeDoctorSyncReport(w io.Writer, report doctorSyncReport) {
 	writeDoctorSummaryMode(w, report)
 	writeDoctorUnknownSchema(w, report)
 	writeDoctorMissingSecretScans(w, report)
+	writeDoctorTraeEncryptedLayouts(w, report)
 	writeDoctorTempFiles(w, report.TempFiles)
 	writeDoctorAgentRoots(w, report.AgentRoots)
 	writeDoctorDebugEvidence(w, report)
 	fmt.Fprintf(w, "Likely cause: %s\n",
 		doctorLikelyCause(report, currentVersion))
+}
+
+func writeDoctorTraeEncryptedLayouts(w io.Writer, report doctorSyncReport) {
+	for _, root := range report.TraeEncryptedRoots {
+		fmt.Fprintf(w, "Trae: unsupported encrypted transcript layout detected at %s\n", root)
+		fmt.Fprintln(w, "  -> legacy inline-message parsing is supported; modern encrypted transcripts are not readable")
+	}
+}
+
+func collectDoctorTraeEncryptedRoots(roots []doctorAgentRoot) []string {
+	var detected []string
+	for _, root := range roots {
+		if root.Agent == parser.AgentTrae && root.Exists && parser.TraeEncryptedLayoutDetected(root.Path) {
+			detected = append(detected, root.Path)
+		}
+	}
+	return detected
 }
 
 func doctorStartupDecision(

--- a/cmd/agentsview/doctor_test.go
+++ b/cmd/agentsview/doctor_test.go
@@ -9,12 +9,39 @@ import (
 	"path/filepath"
 	"testing"
 
+	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/parser"
 )
+
+func TestDoctorSyncTraeEncryptedLayout(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "Trae", "User")
+	state := filepath.Join(root, "globalStorage", "state.vscdb")
+	require.NoError(t, os.MkdirAll(filepath.Dir(state), 0o755))
+	conn, err := sql.Open("sqlite3", state)
+	require.NoError(t, err)
+	_, err = conn.Exec(`CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT)`)
+	require.NoError(t, err)
+	_, err = conn.Exec(`INSERT INTO ItemTable(key, value) VALUES (?, ?)`,
+		"memento/icube-ai-agent-storage",
+		`{"list":[{"sessionId":"stub","messages":[]}]}`)
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+	modular := filepath.Join(filepath.Dir(root), "ModularData", "ai-agent", "database.db")
+	require.NoError(t, os.MkdirAll(filepath.Dir(modular), 0o755))
+	require.NoError(t, os.WriteFile(modular, []byte("encrypted header"), 0o644))
+
+	var out bytes.Buffer
+	writeDoctorTraeEncryptedLayouts(&out, doctorSyncReport{
+		AgentRoots:         []doctorAgentRoot{{Agent: parser.AgentTrae, Path: root, Exists: true}},
+		TraeEncryptedRoots: collectDoctorTraeEncryptedRoots([]doctorAgentRoot{{Agent: parser.AgentTrae, Path: root, Exists: true}}),
+	})
+	assert.Contains(t, out.String(), "unsupported encrypted transcript layout")
+}
 
 func TestDoctorSyncCurrentDatabaseReportsNormalStartupSync(t *testing.T) {
 	dataDir := testDataDir(t)

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -976,6 +976,12 @@ func formatAnomalySummary(a sync.AnomalyStats) string {
 	}
 	var b strings.Builder
 	b.WriteString("Parser anomalies (this run):\n")
+	if a.UnsupportedSourceLayoutsTotal > 0 {
+		fmt.Fprintf(&b, "  unsupported source layouts: %d total\n", a.UnsupportedSourceLayoutsTotal)
+		for _, agent := range slices.Sorted(maps.Keys(a.UnsupportedSourceLayoutsByAgent)) {
+			fmt.Fprintf(&b, "    %s: %d\n", agent, a.UnsupportedSourceLayoutsByAgent[agent])
+		}
+	}
 	if a.MalformedLinesTotal > 0 {
 		fmt.Fprintf(&b,
 			"  malformed lines: %d total\n", a.MalformedLinesTotal,

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -1418,6 +1418,19 @@ func TestFormatAnomalySummary(t *testing.T) {
 				"timestamps blanked: 1",
 			},
 		},
+		{
+			name: "unsupported Trae layout only",
+			anomalies: agentsync.AnomalyStats{
+				UnsupportedSourceLayoutsByAgent: map[string]int{"trae": 2},
+				UnsupportedSourceLayoutsTotal:   2,
+			},
+			wantContain: []string{
+				"Parser anomalies (this run):",
+				"unsupported source layouts: 2 total",
+				"trae: 2",
+			},
+			wantOmit: []string{"malformed lines", "sanitized fields"},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -276,7 +276,7 @@ can still be parsed.
 | Visual Studio Copilot | (platform-specific, see below)                                                   | Trace JSONL files                                                                                                               |
 | VS Code Copilot       | (platform-specific, see below)                                                   | JSON / JSONL per session                                                                                                        |
 | Windsurf              | (platform-specific, see below)                                                   | SQLite `workspaceStorage/<hash>/state.vscdb` workspace chat data                                                                |
-| Trae                  | (platform-specific, see below)                                                   | SQLite `workspaceStorage/<hash>/state.vscdb` and `globalStorage/state.vscdb` chat data                                        |
+| Trae                  | (platform-specific, see below)                                                   | Legacy inline chat data in SQLite `workspaceStorage/<hash>/state.vscdb` and `globalStorage/state.vscdb`; modern encrypted layouts are detected as unsupported |
 | Warp                  | (platform-specific, see below)                                                   | SQLite database                                                                                                                 |
 | WorkBuddy             | `~/.workbuddy/projects/`                                                         | JSONL per session                                                                                                               |
 | ZCode                 | `~/.zcode/cli/db/` or `~/.zcode/cli/`                                            | SQLite database (`db.sqlite`) with usage rows                                                                                   |
@@ -329,8 +329,9 @@ Trae stores chats in `workspaceStorage/<hash>/state.vscdb` and
 AgentsView watches `workspaceStorage` and `globalStorage`, then reads chat
 records from those SQLite stores.
 
-Trae local parsing is supported, but remote HTTP and SSH target resolution is
-still disabled. A Trae root is a full user profile, and AgentsView does not
+Trae legacy inline-message parsing is supported. Modern encrypted transcript
+layouts are detected and reported as unsupported. Remote HTTP and SSH target
+resolution is still disabled. A Trae root is a full user profile, and AgentsView does not
 archive or ship that profile wholesale. The follow-up path is Windsurf-style
 curated file targets only: `state.vscdb`, `state.vscdb-wal`, and
 `workspace.json` for each supported workspace store.

--- a/internal/parser/trae_layout.go
+++ b/internal/parser/trae_layout.go
@@ -1,0 +1,79 @@
+package parser
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type traeLayoutState uint8
+
+const (
+	traeLayoutSupported traeLayoutState = iota
+	traeLayoutValidEmpty
+	traeLayoutIncomplete
+	traeLayoutUnsupported
+)
+
+func classifyTraeLayout(root string, snapshot traeSessionSnapshot) traeLayoutState {
+	if len(snapshot.records) > 0 {
+		return traeLayoutSupported
+	}
+	if snapshot.malformed {
+		return traeLayoutIncomplete
+	}
+	if snapshot.authoritative && snapshot.complete {
+		return traeLayoutValidEmpty
+	}
+	if traeEncryptedModularData(root) {
+		return traeLayoutUnsupported
+	}
+	return traeLayoutIncomplete
+}
+
+// TraeEncryptedLayoutDetected reports the measured modern Trae layout for a
+// configured User root. Files outside the expected profile shape stay quiet.
+func TraeEncryptedLayoutDetected(root string) bool {
+	dbs := traeDBs(root)
+	if len(dbs) == 0 {
+		return false
+	}
+	foundUnsupported := false
+	for _, db := range dbs {
+		snapshot, err := traeLoadSessionSnapshot(db.path)
+		if err != nil {
+			continue
+		}
+		switch classifyTraeLayout(root, snapshot) {
+		case traeLayoutSupported:
+			return false
+		case traeLayoutUnsupported:
+			foundUnsupported = true
+		}
+	}
+	return foundUnsupported
+}
+
+func traeEncryptedModularData(root string) bool {
+	profile := filepath.Clean(root)
+	if filepath.Base(profile) != "User" {
+		return false
+	}
+	product := strings.ToLower(filepath.Base(filepath.Dir(profile)))
+	if product != "trae" && product != "trae cn" && product != "trae solo cn" {
+		return false
+	}
+	path := filepath.Join(filepath.Dir(profile), "ModularData", "ai-agent", "database.db")
+	file, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer file.Close()
+	header := make([]byte, len(sqliteHeaderMagic))
+	if _, err := io.ReadFull(file, header); err != nil {
+		return false
+	}
+	return !bytes.Equal(header, sqliteHeaderMagic)
+}

--- a/internal/parser/trae_layout_test.go
+++ b/internal/parser/trae_layout_test.go
@@ -1,0 +1,185 @@
+package parser
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func traeProfileRoot(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "Trae", "User")
+}
+
+func writeTraeModularData(t *testing.T, root string, header string) {
+	t.Helper()
+	path := filepath.Join(filepath.Dir(root), "ModularData", "ai-agent", "database.db")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(header), 0o644))
+}
+
+func TestClassifyTraeLayout(t *testing.T) {
+	root := traeProfileRoot(t)
+	writeTraeModularData(t, root, "encrypted header")
+	tests := []struct {
+		name     string
+		root     string
+		snapshot traeSessionSnapshot
+		want     traeLayoutState
+	}{
+		{name: "supported", root: root, snapshot: traeSessionSnapshot{records: []traeSessionRecord{{SessionID: "one"}}}, want: traeLayoutSupported},
+		{name: "valid empty", root: root, snapshot: traeSessionSnapshot{authoritative: true, complete: true}, want: traeLayoutValidEmpty},
+		{name: "unsupported", root: root, snapshot: traeSessionSnapshot{complete: false}, want: traeLayoutUnsupported},
+		{name: "malformed", root: root, snapshot: traeSessionSnapshot{complete: false, malformed: true}, want: traeLayoutIncomplete},
+		{name: "incomplete without evidence", root: filepath.Join(t.TempDir(), "custom", "User"), snapshot: traeSessionSnapshot{complete: false}, want: traeLayoutIncomplete},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, classifyTraeLayout(test.root, test.snapshot))
+		})
+	}
+}
+
+func TestTraeLayoutStateMatrix(t *testing.T) {
+	tests := []struct {
+		name  string
+		root  func(t *testing.T) string
+		setup func(t *testing.T, root string)
+		check func(t *testing.T, outcome ParseOutcome)
+	}{
+		{
+			name: "supported",
+			root: traeProfileRoot,
+			setup: func(t *testing.T, root string) {
+				writeTraeModularData(t, root, "encrypted header")
+				writeTraeDB(t, filepath.Join(root, "globalStorage", traeStateDBName), traeStoreValue(t, []any{
+					map[string]any{
+						"sessionId": "real",
+						"messages":  []any{map[string]any{"role": "user", "content": "legacy"}},
+					},
+				}), "memento/unrelated-chat-storage")
+			},
+			check: func(t *testing.T, outcome ParseOutcome) {
+				require.Len(t, outcome.Results, 1)
+				assert.Equal(t, SkipNone, outcome.SkipReason)
+			},
+		},
+		{
+			name: "valid empty",
+			root: traeProfileRoot,
+			setup: func(t *testing.T, root string) {
+				writeTraeModularData(t, root, "encrypted header")
+				writeTraeDB(t, filepath.Join(root, "globalStorage", traeStateDBName), traeStoreValue(t, []any{}), "memento/unrelated-chat-storage")
+			},
+			check: func(t *testing.T, outcome ParseOutcome) {
+				assert.Equal(t, SkipNoSession, outcome.SkipReason)
+				assert.True(t, outcome.ResultSetComplete)
+				assert.True(t, outcome.ForceReplace)
+			},
+		},
+		{
+			name: "unsupported",
+			root: traeProfileRoot,
+			setup: func(t *testing.T, root string) {
+				writeTraeModularData(t, root, "encrypted header")
+				writeTraeDBWithoutStorageKey(t, filepath.Join(root, "globalStorage", traeStateDBName), "memento/unrelated-chat-storage")
+			},
+			check: func(t *testing.T, outcome ParseOutcome) {
+				assert.Equal(t, SkipUnsupportedSource, outcome.SkipReason)
+				assert.False(t, outcome.ResultSetComplete)
+				assert.False(t, outcome.ForceReplace)
+			},
+		},
+		{
+			name: "malformed",
+			root: traeProfileRoot,
+			setup: func(t *testing.T, root string) {
+				writeTraeModularData(t, root, "encrypted header")
+				writeTraeDB(t, filepath.Join(root, "globalStorage", traeStateDBName), traeStoreValue(t, []any{
+					map[string]any{
+						"sessionId": "unknown-role",
+						"messages":  []any{map[string]any{"role": "system", "content": "ignored"}},
+					},
+				}), "memento/unrelated-chat-storage")
+			},
+			check: func(t *testing.T, outcome ParseOutcome) {
+				assert.Equal(t, SkipNoSession, outcome.SkipReason)
+				assert.False(t, outcome.ResultSetComplete)
+				assert.False(t, outcome.ForceReplace)
+			},
+		},
+		{
+			name: "incomplete without evidence",
+			root: func(t *testing.T) string { return filepath.Join(t.TempDir(), "custom", "User") },
+			setup: func(t *testing.T, root string) {
+				writeTraeDBWithoutStorageKey(t, filepath.Join(root, "globalStorage", traeStateDBName), "memento/unrelated-chat-storage")
+			},
+			check: func(t *testing.T, outcome ParseOutcome) {
+				assert.Equal(t, SkipNoSession, outcome.SkipReason)
+				assert.False(t, outcome.ResultSetComplete)
+				assert.False(t, outcome.ForceReplace)
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := test.root(t)
+			test.setup(t, root)
+			factory, ok := ProviderFactoryByType(AgentTrae)
+			require.True(t, ok)
+			provider := factory.NewProvider(ProviderConfig{Roots: []string{root}})
+			sources, err := provider.Discover(context.Background())
+			require.NoError(t, err)
+			require.Len(t, sources, 1)
+			outcome, err := provider.Parse(context.Background(), ParseRequest{Source: sources[0]})
+			require.NoError(t, err)
+			test.check(t, outcome)
+		})
+	}
+}
+
+func TestTraeLayoutNegativeSpace(t *testing.T) {
+	root := traeProfileRoot(t)
+	writeTraeModularData(t, root, string(sqliteHeaderMagic))
+	assert.False(t, traeEncryptedModularData(root))
+	assert.False(t, traeEncryptedModularData(filepath.Join(t.TempDir(), "custom", "User")))
+
+	root = filepath.Join(t.TempDir(), "Trae", "User")
+	writeTraeModularData(t, root, "encrypted header")
+	assert.Equal(t, traeLayoutValidEmpty, classifyTraeLayout(root, traeSessionSnapshot{authoritative: true, complete: true}))
+	assert.Equal(t, traeLayoutSupported, classifyTraeLayout(root, traeSessionSnapshot{records: []traeSessionRecord{{SessionID: "real"}}}))
+
+	unsupportedRoot := traeProfileRoot(t)
+	writeTraeModularData(t, unsupportedRoot, "encrypted header")
+	unsupportedPath := filepath.Join(unsupportedRoot, "globalStorage", traeStateDBName)
+	writeTraeDBWithoutStorageKey(t, unsupportedPath, "memento/unrelated-chat-storage")
+	assert.True(t, TraeEncryptedLayoutDetected(unsupportedRoot))
+
+	validEmptyRoot := traeProfileRoot(t)
+	writeTraeModularData(t, validEmptyRoot, "encrypted header")
+	workspacePath := filepath.Join(validEmptyRoot, "workspaceStorage", "one", traeStateDBName)
+	writeTraeDBWithoutStorageKey(t, workspacePath, "memento/unrelated-chat-storage")
+	globalPath := filepath.Join(validEmptyRoot, "globalStorage", traeStateDBName)
+	writeTraeDB(t, globalPath, traeStoreValue(t, []any{}), "memento/unrelated-chat-storage")
+	assert.True(t, TraeEncryptedLayoutDetected(validEmptyRoot))
+
+	errorRoot := traeProfileRoot(t)
+	writeTraeModularData(t, errorRoot, "encrypted header")
+	errorGlobal := filepath.Join(errorRoot, "globalStorage", traeStateDBName)
+	writeTraeDBWithoutStorageKey(t, errorGlobal, "memento/unrelated-chat-storage")
+	errorWorkspace := filepath.Join(errorRoot, "workspaceStorage", "one", traeStateDBName)
+	writeTraeDBWithoutStorageKey(t, errorWorkspace, "memento/unrelated-chat-storage")
+	orig := traeLoadSessionSnapshot
+	defer func() { traeLoadSessionSnapshot = orig }()
+	traeLoadSessionSnapshot = func(path string) (traeSessionSnapshot, error) {
+		if path == errorWorkspace {
+			return traeSessionSnapshot{}, os.ErrPermission
+		}
+		return orig(path)
+	}
+	assert.True(t, TraeEncryptedLayoutDetected(errorRoot))
+}

--- a/internal/parser/trae_provider.go
+++ b/internal/parser/trae_provider.go
@@ -154,10 +154,16 @@ func traeParseContainerOutcome(
 	if err != nil {
 		return ParseOutcome{}, err
 	}
+	state := classifyTraeLayout(src.Root, snapshot)
 	if !snapshot.authoritative {
 		return ParseOutcome{
 			ResultSetComplete: false,
-			SkipReason:        SkipNoSession,
+			SkipReason: func() SkipReason {
+				if state == traeLayoutUnsupported {
+					return SkipUnsupportedSource
+				}
+				return SkipNoSession
+			}(),
 		}, nil
 	}
 	results := make([]ParseResultOutcome, 0, len(snapshot.records))
@@ -175,9 +181,14 @@ func traeParseContainerOutcome(
 	}
 	if len(results) == 0 {
 		return ParseOutcome{
-			ResultSetComplete: snapshot.complete,
-			ForceReplace:      snapshot.complete,
-			SkipReason:        SkipNoSession,
+			ResultSetComplete: state != traeLayoutUnsupported && snapshot.complete,
+			ForceReplace:      state != traeLayoutUnsupported && snapshot.complete,
+			SkipReason: func() SkipReason {
+				if state == traeLayoutUnsupported {
+					return SkipUnsupportedSource
+				}
+				return SkipNoSession
+			}(),
 		}, nil
 	}
 	return ParseOutcome{
@@ -307,6 +318,7 @@ type traeSessionSnapshot struct {
 	ids           map[string]struct{}
 	authoritative bool
 	complete      bool
+	malformed     bool
 }
 
 func (s traeSessionSnapshot) record(id string) (traeSessionRecord, bool) {
@@ -357,19 +369,27 @@ func decodeTraeSessionSnapshot(value string) (traeSessionSnapshot, error) {
 		var session traeSession
 		if err := json.Unmarshal(raw, &session); err != nil {
 			snapshot.complete = false
+			snapshot.malformed = true
 			continue
 		}
 		id := strings.TrimSpace(session.SessionID)
-		if id == "" || len(session.Messages) == 0 {
+		if id == "" {
+			snapshot.complete = false
+			snapshot.malformed = true
+			continue
+		}
+		if len(session.Messages) == 0 {
 			snapshot.complete = false
 			continue
 		}
 		if !traeSessionProducesMessages(session) {
 			snapshot.complete = false
+			snapshot.malformed = true
 			continue
 		}
 		if _, ok := seen[id]; ok {
 			snapshot.complete = false
+			snapshot.malformed = true
 			continue
 		}
 		seen[id] = struct{}{}

--- a/internal/parser/trae_provider_test.go
+++ b/internal/parser/trae_provider_test.go
@@ -28,6 +28,18 @@ func writeTraeDB(t *testing.T, path, value string, extraKey string) {
 	require.NoError(t, err)
 }
 
+func writeTraeDBWithoutStorageKey(t *testing.T, path string, extraKey string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	db, err := sql.Open("sqlite3", path)
+	require.NoError(t, err)
+	defer db.Close()
+	_, err = db.Exec(`CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT)`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO ItemTable(key, value) VALUES (?, ?)`, extraKey, `{"list":[{"sessionId":"ignored","messages":[{"role":"user","content":"wrong"}]}]}`)
+	require.NoError(t, err)
+}
+
 func setTraeDBValue(t *testing.T, path, value string) {
 	t.Helper()
 	db, err := sql.Open("sqlite3", path)
@@ -373,6 +385,80 @@ func TestTraeMalformedSessionEntryKeepsContainerIncomplete(t *testing.T) {
 	assert.Equal(t, path, changed[0].Key)
 }
 
+func TestTraeEncryptedLayoutOutcomeUnsupported(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, path string)
+	}{
+		{
+			name: "empty stub",
+			setup: func(t *testing.T, path string) {
+				writeTraeDB(t, path, traeStoreValue(t, []any{
+					map[string]any{
+						"sessionId": "stub",
+						"messages":  []any{},
+					},
+				}), "memento/unrelated-chat-storage")
+			},
+		},
+		{
+			name: "missing storage key",
+			setup: func(t *testing.T, path string) {
+				writeTraeDBWithoutStorageKey(t, path, "memento/unrelated-chat-storage")
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := traeProfileRoot(t)
+			path := filepath.Join(root, "globalStorage", traeStateDBName)
+			test.setup(t, path)
+			writeTraeModularData(t, root, "encrypted header")
+
+			factory, ok := ProviderFactoryByType(AgentTrae)
+			require.True(t, ok)
+			provider := factory.NewProvider(ProviderConfig{Roots: []string{root}})
+			sources, err := provider.Discover(context.Background())
+			require.NoError(t, err)
+			require.Len(t, sources, 1)
+
+			outcome, err := provider.Parse(context.Background(), ParseRequest{Source: sources[0]})
+			require.NoError(t, err)
+			assert.Equal(t, SkipUnsupportedSource, outcome.SkipReason)
+			assert.False(t, outcome.ResultSetComplete)
+			assert.False(t, outcome.ForceReplace)
+		})
+	}
+}
+
+func TestTraeMixedLegacyAndEmptyStubPreservesInlineSession(t *testing.T) {
+	root := traeProfileRoot(t)
+	path := filepath.Join(root, "globalStorage", traeStateDBName)
+	writeTraeDB(t, path, traeStoreValue(t, []any{
+		map[string]any{
+			"sessionId": "real",
+			"messages":  []any{map[string]any{"role": "user", "content": "legacy"}},
+		},
+		map[string]any{
+			"sessionId": "stub",
+			"messages":  []any{map[string]any{"role": "assistant", "content": ""}},
+		},
+	}), "memento/unrelated-chat-storage")
+	writeTraeModularData(t, root, "encrypted header")
+
+	factory, ok := ProviderFactoryByType(AgentTrae)
+	require.True(t, ok)
+	provider := factory.NewProvider(ProviderConfig{Roots: []string{root}})
+	sources, err := provider.Discover(context.Background())
+	require.NoError(t, err)
+	require.Len(t, sources, 1)
+	outcome, err := provider.Parse(context.Background(), ParseRequest{Source: sources[0]})
+	require.NoError(t, err)
+	require.Len(t, outcome.Results, 1)
+	assert.Equal(t, "trae:real", outcome.Results[0].Result.Session.ID)
+	assert.Equal(t, SkipNone, outcome.SkipReason)
+}
+
 func TestTraeUnparseableSessionStatesKeepContainerIncomplete(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -448,6 +534,59 @@ func TestTraeUnparseableSessionStatesKeepContainerIncomplete(t *testing.T) {
 			assert.True(t, ok)
 			_, err = provider.Parse(context.Background(), ParseRequest{Source: found})
 			require.Error(t, err)
+		})
+	}
+}
+
+func TestTraeUnparseableEncryptedSessionsStayIncomplete(t *testing.T) {
+	cases := []struct {
+		name    string
+		session map[string]any
+	}{
+		{
+			name: "empty content",
+			session: map[string]any{
+				"sessionId": "empty-content",
+				"createdAt": 1715340600000,
+				"messages":  []any{map[string]any{"role": "user", "content": "   "}},
+			},
+		},
+		{
+			name: "unknown role",
+			session: map[string]any{
+				"sessionId": "unknown-role",
+				"createdAt": 1715340600000,
+				"messages":  []any{map[string]any{"role": "system", "content": "ignored"}},
+			},
+		},
+		{
+			name: "partial init",
+			session: map[string]any{
+				"sessionId": "partial-init",
+				"createdAt": 1715340600000,
+				"messages":  []any{map[string]any{"role": "assistant", "content": "", "agentTaskContent": map[string]any{}}},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := traeProfileRoot(t)
+			path := filepath.Join(root, "globalStorage", traeStateDBName)
+			writeTraeDB(t, path, traeStoreValue(t, []any{tc.session}), "memento/unrelated-chat-storage")
+			writeTraeModularData(t, root, "encrypted header")
+
+			factory, ok := ProviderFactoryByType(AgentTrae)
+			require.True(t, ok)
+			provider := factory.NewProvider(ProviderConfig{Roots: []string{root}})
+			sources, err := provider.Discover(context.Background())
+			require.NoError(t, err)
+			require.Len(t, sources, 1)
+
+			outcome, err := provider.Parse(context.Background(), ParseRequest{Source: sources[0]})
+			require.NoError(t, err)
+			assert.Equal(t, SkipNoSession, outcome.SkipReason)
+			assert.False(t, outcome.ResultSetComplete)
+			assert.False(t, outcome.ForceReplace)
 		})
 	}
 }

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -4683,6 +4683,9 @@ func (e *Engine) processProviderFile(
 	applyProviderFingerprintFileInfo(file.Agent, fingerprint, outcome.Results)
 	cleanCache := providerOutcomeAllowsCleanSkipCache(outcome)
 	if outcome.SkipReason != parser.SkipNone {
+		if outcome.SkipReason == parser.SkipUnsupportedSource {
+			e.anomalies.recordUnsupportedSourceLayout(string(file.Agent), file.Path)
+		}
 		excludedSessionIDs := append([]string(nil), outcome.ExcludedSessionIDs...)
 		if outcome.ForceReplace && outcome.ResultSetComplete {
 			excludedSessionIDs = append(

--- a/internal/sync/progress.go
+++ b/internal/sync/progress.go
@@ -96,6 +96,8 @@ type SyncStats struct {
 // the central validateAndSanitize pass. It is a per-run summary only; no
 // new persisted columns back it.
 type AnomalyStats struct {
+	UnsupportedSourceLayoutsByAgent map[string]int `json:"unsupported_source_layouts_by_agent,omitempty"`
+	UnsupportedSourceLayoutsTotal   int            `json:"unsupported_source_layouts_total,omitempty"`
 	// MalformedLinesByAgent maps an agent type to the total number of
 	// parser malformed lines reported by sessions of that agent in this
 	// run. Only non-zero agents are present.
@@ -154,10 +156,22 @@ func (s SanitizeStats) IsZero() bool {
 // IsZero reports whether the run observed no anomalies at all, so the CLI
 // summary can omit the anomaly section entirely on clean runs.
 func (a AnomalyStats) IsZero() bool {
-	return a.MalformedLinesTotal == 0 &&
+	return a.UnsupportedSourceLayoutsTotal == 0 &&
+		a.MalformedLinesTotal == 0 &&
 		a.UnknownSchemaSessionsTotal == 0 &&
 		a.GenMetadataWithoutUsageTotal == 0 &&
 		a.Sanitize.IsZero()
+}
+
+func (a *AnomalyStats) RecordUnsupportedSourceLayouts(agent string, n int) {
+	if n <= 0 {
+		return
+	}
+	if a.UnsupportedSourceLayoutsByAgent == nil {
+		a.UnsupportedSourceLayoutsByAgent = make(map[string]int)
+	}
+	a.UnsupportedSourceLayoutsByAgent[agent] += n
+	a.UnsupportedSourceLayoutsTotal += n
 }
 
 // RecordMalformedLines attributes n parser malformed lines to the given
@@ -214,6 +228,9 @@ func (a *AnomalyStats) addSanitize(v validationStats) {
 
 // merge folds another AnomalyStats into the receiver.
 func (a *AnomalyStats) merge(o AnomalyStats) {
+	for agent, n := range o.UnsupportedSourceLayoutsByAgent {
+		a.RecordUnsupportedSourceLayouts(agent, n)
+	}
 	for agent, n := range o.MalformedLinesByAgent {
 		a.RecordMalformedLines(agent, n)
 	}
@@ -243,7 +260,8 @@ type anomalyAccumulator struct {
 	// malformedFiles tracks source paths whose malformed-line count has
 	// already been recorded this run, so a file that forks into several
 	// sessions counts its malformed lines once. Reset each run.
-	malformedFiles map[string]bool
+	malformedFiles     map[string]bool
+	unsupportedSources map[string]bool
 }
 
 // reset clears the accumulator at the start of a sync run.
@@ -251,7 +269,21 @@ func (a *anomalyAccumulator) reset() {
 	a.mu.Lock()
 	a.stats = AnomalyStats{}
 	a.malformedFiles = nil
+	a.unsupportedSources = nil
 	a.mu.Unlock()
+}
+
+func (a *anomalyAccumulator) recordUnsupportedSourceLayout(agent, source string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.unsupportedSources == nil {
+		a.unsupportedSources = make(map[string]bool)
+	}
+	if a.unsupportedSources[source] {
+		return
+	}
+	a.unsupportedSources[source] = true
+	a.stats.RecordUnsupportedSourceLayouts(agent, 1)
 }
 
 // recordMalformedLines accumulates an agent's parser malformed-line count for

--- a/internal/sync/progress_test.go
+++ b/internal/sync/progress_test.go
@@ -359,12 +359,37 @@ func TestAnomalyStats_IsZero(t *testing.T) {
 			a:    AnomalyStats{Sanitize: SanitizeStats{ModelClamped: 1}},
 			want: false,
 		},
+		{
+			name: "unsupported source layout only",
+			a:    AnomalyStats{UnsupportedSourceLayoutsTotal: 1},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, tt.a.IsZero())
 		})
 	}
+}
+
+func TestAnomalyStats_RecordUnsupportedSourceLayouts(t *testing.T) {
+	var a AnomalyStats
+	a.RecordUnsupportedSourceLayouts("trae", 2)
+	a.RecordUnsupportedSourceLayouts("trae", 1)
+	a.RecordUnsupportedSourceLayouts("trae", 0)
+	assert.Equal(t, 3, a.UnsupportedSourceLayoutsTotal)
+	assert.Equal(t, 3, a.UnsupportedSourceLayoutsByAgent["trae"])
+}
+
+func TestAnomalyAccumulator_DedupesUnsupportedSource(t *testing.T) {
+	var acc anomalyAccumulator
+	acc.recordUnsupportedSourceLayout("trae", "state.vscdb")
+	acc.recordUnsupportedSourceLayout("trae", "state.vscdb")
+
+	var stats SyncStats
+	acc.applyTo(&stats)
+	assert.Equal(t, 1, stats.Anomalies.UnsupportedSourceLayoutsTotal)
+	assert.Equal(t, 1, stats.Anomalies.UnsupportedSourceLayoutsByAgent["trae"])
 }
 
 func TestProgress_Percent(t *testing.T) {

--- a/internal/sync/trae_integration_test.go
+++ b/internal/sync/trae_integration_test.go
@@ -31,6 +31,26 @@ func writeTraeSyncDB(t *testing.T, path, reply string) {
 	require.NoError(t, err)
 }
 
+func writeTraeSyncDBWithoutStorageKey(t *testing.T, path string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	db, err := sql.Open("sqlite3", path)
+	require.NoError(t, err)
+	defer db.Close()
+	require.NoError(t, db.Ping())
+	_, err = db.Exec(`CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT)`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO ItemTable(key, value) VALUES (?, ?)`, "memento/unrelated-chat-storage", `{"list":[{"sessionId":"ignored","messages":[{"role":"user","content":"wrong"}]}]}`)
+	require.NoError(t, err)
+}
+
+func writeTraeSyncModularData(t *testing.T, root string) {
+	t.Helper()
+	path := filepath.Join(filepath.Dir(root), "ModularData", "ai-agent", "database.db")
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte("encrypted header"), 0o644))
+}
+
 func rewriteTraeSyncDB(t *testing.T, path, reply string, mtime time.Time) {
 	t.Helper()
 	db, err := sql.Open("sqlite3", path)
@@ -85,6 +105,65 @@ func traeSyncSession(id, reply string) map[string]any {
 			map[string]any{"role": "user", "content": "same prompt"},
 			map[string]any{"role": "assistant", "content": reply},
 		},
+	}
+}
+
+func TestTraeEncryptedLayoutReportsUnsupportedSource(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, path string)
+	}{
+		{
+			name: "empty stub",
+			setup: func(t *testing.T, path string) {
+				require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+				db, err := sql.Open("sqlite3", path)
+				require.NoError(t, err)
+				defer db.Close()
+				_, err = db.Exec(`CREATE TABLE ItemTable (key TEXT PRIMARY KEY, value TEXT)`)
+				require.NoError(t, err)
+				value, err := json.Marshal(map[string]any{"list": []any{map[string]any{
+					"sessionId": "stub",
+					"messages":  []any{},
+				}}})
+				require.NoError(t, err)
+				_, err = db.Exec(`INSERT INTO ItemTable(key, value) VALUES (?, ?)`, "memento/icube-ai-agent-storage", value)
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "missing storage key",
+			setup: func(t *testing.T, path string) {
+				writeTraeSyncDBWithoutStorageKey(t, path)
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root := filepath.Join(t.TempDir(), "Trae", "User")
+			path := filepath.Join(root, "globalStorage", "state.vscdb")
+			test.setup(t, path)
+			writeTraeSyncModularData(t, root)
+
+			database := dbtest.OpenTestDB(t)
+			engine := NewEngine(database, EngineConfig{
+				AgentDirs: map[parser.AgentType][]string{parser.AgentTrae: {root}},
+				Machine:   "devbox",
+			})
+			res := engine.processFile(context.Background(), parser.DiscoveredFile{
+				Path:  path,
+				Agent: parser.AgentTrae,
+			})
+			require.NoError(t, res.err)
+			assert.True(t, res.skip)
+			assert.False(t, res.forceReplace)
+			assert.Empty(t, res.results)
+
+			var stats SyncStats
+			engine.anomalies.applyTo(&stats)
+			assert.Equal(t, 1, stats.Anomalies.UnsupportedSourceLayoutsTotal)
+			assert.Equal(t, 1, stats.Anomalies.UnsupportedSourceLayoutsByAgent[string(parser.AgentTrae)])
+		})
 	}
 }
 


### PR DESCRIPTION
Current international Trae builds can still expose the `Trae/User` state stores that AgentsView already discovers, while moving the actual transcript rows into `ModularData/ai-agent/database.db`, an encrypted non-SQLite store. The visible `state.vscdb` files now carry empty session stubs or no session key, so the provider decodes zero usable inline sessions and silently returns a no-session skip. That makes a modern encrypted Trae install indistinguishable from an empty or broken one.

This change follows the Antigravity direction and surfaces the unsupported state instead of trying to read data AgentsView cannot read. A Trae-specific layout owner in `internal/parser` classifies the measured store shape, the provider maps that state to the existing `SkipUnsupportedSource` reason, sync records it in the existing per-run parser anomaly summary, and `agentsview doctor sync` reports the affected Trae roots directly from disk. The encrypted database stays untouched.

Legacy behavior stays intact. Inline-message Trae stores still parse exactly as before, valid explicit empty stores stay quiet, incomplete or malformed stores stay on the current preservation path, the existing Trae discovery roots remain unchanged, and the HTTP and SSH exclusions added with Trae support remain unchanged. The new signal only fires when the discovery-visible Trae store yields no usable inline sessions and the sibling `ModularData/ai-agent/database.db` matches the measured unsupported encrypted layout.

Closes #1210
