### PR TITLE
fix(sync): bound OpenCode watcher updates

### DIFF
--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -341,6 +341,11 @@ func runServe(cfg config.Config, opts serveOptions) {
 			},
 		)
 		defer stopWatcher()
+		// Establish the live engine's disposable journal watermark after
+		// collection begins and before startup reconciliation. An in-process
+		// full sync may replace it; worker-backed startup needs it so the first
+		// queued settlement is not consumed as a lazy baseline.
+		engine.InitializeOpenCodeWatchBaseline(ctx)
 		onStartupReconciled = newStartupReconciliationHandler(
 			ctx,
 			database.CheckpointWALTruncateWithRetry,

--- a/internal/parser/opencode.go
+++ b/internal/parser/opencode.go
@@ -27,6 +27,203 @@ type OpenCodeSessionMeta struct {
 	FileMtime   int64
 }
 
+// OpenCodeJournalEvent is the session-level interpretation of one recognized
+// OpenCode event row. Settlement is false for streaming updates that should be
+// coalesced until a turn boundary arrives.
+type OpenCodeJournalEvent struct {
+	SessionID  string
+	Settlement bool
+}
+
+// OpenCodeJournalBatch is a bounded, transactionally consistent event range.
+// Supported is false when the source does not expose the verified OpenCode
+// journal schema. Safe is false when targeted classification cannot be proven.
+type OpenCodeJournalBatch struct {
+	HighRowID int64
+	Events    []OpenCodeJournalEvent
+	Supported bool
+	Safe      bool
+	Overflow  bool
+}
+
+// OpenCodeJournalHighWater reads the current journal rowid without enumerating
+// sessions. The journal is an optimization; callers treat unsupported schemas
+// and read failures as reasons to wait for authoritative full sync.
+func OpenCodeJournalHighWater(
+	ctx context.Context, dbPath string,
+) (int64, bool, error) {
+	db, err := openOpenCodeDBContext(dbPath)
+	if err != nil {
+		return 0, false, err
+	}
+	defer db.Close()
+	supported, err := openCodeEventJournalSupported(ctx, db)
+	if err != nil || !supported {
+		return 0, supported, err
+	}
+	var high int64
+	if err := db.QueryRowContext(ctx,
+		"SELECT COALESCE(MAX(rowid), 0) FROM event",
+	).Scan(&high); err != nil {
+		return 0, true, fmt.Errorf("reading opencode journal high-water mark: %w", preferContextError(ctx, err))
+	}
+	return high, true, nil
+}
+
+// ReadOpenCodeJournal reads at most limit rows plus one overflow sentinel from
+// (afterRowID, currentHighRowID] in one read transaction.
+func ReadOpenCodeJournal(
+	ctx context.Context, dbPath string, afterRowID int64, limit int,
+) (OpenCodeJournalBatch, error) {
+	if err := ctx.Err(); err != nil {
+		return OpenCodeJournalBatch{}, err
+	}
+	if limit <= 0 {
+		return OpenCodeJournalBatch{}, fmt.Errorf("opencode journal limit must be positive")
+	}
+	db, err := openOpenCodeDBContext(dbPath)
+	if err != nil {
+		return OpenCodeJournalBatch{}, err
+	}
+	defer db.Close()
+	supported, err := openCodeEventJournalSupported(ctx, db)
+	if err != nil || !supported {
+		return OpenCodeJournalBatch{Supported: supported}, err
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return OpenCodeJournalBatch{}, fmt.Errorf("starting opencode journal read: %w", preferContextError(ctx, err))
+	}
+	defer func() { _ = tx.Rollback() }()
+	batch := OpenCodeJournalBatch{Supported: true, Safe: true}
+	if err := tx.QueryRowContext(ctx,
+		"SELECT COALESCE(MAX(rowid), 0) FROM event",
+	).Scan(&batch.HighRowID); err != nil {
+		return OpenCodeJournalBatch{}, fmt.Errorf("reading opencode journal high-water mark: %w", preferContextError(ctx, err))
+	}
+	if batch.HighRowID < afterRowID {
+		batch.Safe = false
+		return batch, nil
+	}
+	rows, err := tx.QueryContext(ctx, `
+		SELECT aggregate_id, type, data
+		FROM event
+		WHERE rowid > ? AND rowid <= ?
+		ORDER BY rowid
+		LIMIT ?
+	`, afterRowID, batch.HighRowID, limit+1)
+	if err != nil {
+		return OpenCodeJournalBatch{}, fmt.Errorf("listing opencode journal events: %w", preferContextError(ctx, err))
+	}
+	defer rows.Close()
+	rowsRead := 0
+	for rows.Next() {
+		if err := ctx.Err(); err != nil {
+			return OpenCodeJournalBatch{}, err
+		}
+		if rowsRead == limit {
+			batch.Overflow = true
+			batch.Safe = false
+			break
+		}
+		rowsRead++
+		var aggregateID, eventType, data string
+		if err := rows.Scan(&aggregateID, &eventType, &data); err != nil {
+			return OpenCodeJournalBatch{}, fmt.Errorf("scanning opencode journal event: %w", err)
+		}
+		event, ok := interpretOpenCodeJournalEvent(aggregateID, eventType, data)
+		if !ok {
+			batch.Safe = false
+			continue
+		}
+		batch.Events = append(batch.Events, event)
+	}
+	if err := rows.Err(); err != nil {
+		return OpenCodeJournalBatch{}, fmt.Errorf("listing opencode journal events: %w", preferContextError(ctx, err))
+	}
+	if err := tx.Commit(); err != nil {
+		return OpenCodeJournalBatch{}, fmt.Errorf("finishing opencode journal read: %w", preferContextError(ctx, err))
+	}
+	return batch, nil
+}
+
+func interpretOpenCodeJournalEvent(
+	aggregateID, eventType, data string,
+) (OpenCodeJournalEvent, bool) {
+	if !strings.HasPrefix(aggregateID, "ses_") || aggregateID == "ses_" || !json.Valid([]byte(data)) {
+		return OpenCodeJournalEvent{}, false
+	}
+	event := OpenCodeJournalEvent{SessionID: aggregateID}
+	switch {
+	case strings.HasPrefix(eventType, "session."):
+		event.Settlement = true
+	case eventType == "message.updated.1":
+		role := gjson.Get(data, "info.role").String()
+		completed := gjson.Get(data, "info.time.completed").Exists()
+		failed := gjson.Get(data, "info.error").Exists()
+		if role != "user" && role != "assistant" && role != "" {
+			return OpenCodeJournalEvent{}, false
+		}
+		event.Settlement = role == "user" || completed || failed
+	case eventType == "message.removed.1",
+		eventType == "message.part.updated.1",
+		eventType == "message.part.removed.1":
+		// Intermediate transcript mutation; wait for a settlement event.
+	default:
+		return OpenCodeJournalEvent{}, false
+	}
+	return event, true
+}
+
+// ListOpenCodeSessionMetaByID loads only selected session rows. Missing rows
+// are omitted so watcher-time source deletion never becomes archive deletion.
+func ListOpenCodeSessionMetaByID(
+	ctx context.Context, dbPath string, sessionIDs []string,
+) ([]OpenCodeSessionMeta, error) {
+	if len(sessionIDs) == 0 {
+		return nil, nil
+	}
+	db, err := openOpenCodeDBContext(dbPath)
+	if err != nil {
+		return nil, err
+	}
+	defer db.Close()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("starting opencode metadata read: %w", preferContextError(ctx, err))
+	}
+	defer func() { _ = tx.Rollback() }()
+	stmt, err := tx.PrepareContext(ctx,
+		"SELECT time_updated FROM session WHERE id = ?",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("preparing opencode metadata read: %w", preferContextError(ctx, err))
+	}
+	defer stmt.Close()
+	metas := make([]OpenCodeSessionMeta, 0, len(sessionIDs))
+	for _, id := range sessionIDs {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		var updated int64
+		err := stmt.QueryRowContext(ctx, id).Scan(&updated)
+		if err == sql.ErrNoRows {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("reading opencode session metadata: %w", preferContextError(ctx, err))
+		}
+		metas = append(metas, OpenCodeSessionMeta{
+			SessionID: id, VirtualPath: dbPath + "#" + id,
+			FileMtime: updated * 1_000_000,
+		})
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("finishing opencode metadata read: %w", preferContextError(ctx, err))
+	}
+	return metas, nil
+}
+
 // OpenCodeSQLiteSessionExists reports whether a session row with
 // the given ID is present in the OpenCode SQLite database at
 // dbPath. Returns false when the file is missing, the schema is
@@ -245,8 +442,17 @@ func parseOpenCodeStorageFile(
 }
 
 func openOpenCodeDB(dbPath string) (*sql.DB, error) {
+	return openOpenCodeDBWithBusyTimeout(dbPath, 3000)
+}
+
+func openOpenCodeDBContext(dbPath string) (*sql.DB, error) {
+	// go-sqlite3 does not interrupt its native busy handler through Context.
+	return openOpenCodeDBWithBusyTimeout(dbPath, 100)
+}
+
+func openOpenCodeDBWithBusyTimeout(dbPath string, timeoutMS int) (*sql.DB, error) {
 	dsn := "file:" + sqliteURIPath(dbPath) +
-		"?mode=ro&_busy_timeout=3000"
+		fmt.Sprintf("?mode=ro&_busy_timeout=%d", timeoutMS)
 	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -254,6 +460,30 @@ func openOpenCodeDB(dbPath string) (*sql.DB, error) {
 		)
 	}
 	return db, nil
+}
+
+func preferContextError(ctx context.Context, err error) error {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
+	return err
+}
+
+func openCodeEventJournalSupported(ctx context.Context, db *sql.DB) (bool, error) {
+	var tables, eventColumns, sequenceColumns int
+	err := db.QueryRowContext(ctx, `
+		SELECT
+			(SELECT COUNT(*) FROM sqlite_schema
+			 WHERE type = 'table' AND name IN ('event', 'event_sequence')),
+			(SELECT COUNT(*) FROM pragma_table_info('event')
+			 WHERE name IN ('id', 'aggregate_id', 'seq', 'type', 'data')),
+			(SELECT COUNT(*) FROM pragma_table_info('event_sequence')
+			 WHERE name IN ('aggregate_id', 'seq'))
+	`).Scan(&tables, &eventColumns, &sequenceColumns)
+	if err != nil {
+		return false, preferContextError(ctx, err)
+	}
+	return tables == 2 && eventColumns == 5 && sequenceColumns == 2, nil
 }
 
 // openCodeProject is a row from the opencode project table.

--- a/internal/parser/opencode_provider.go
+++ b/internal/parser/opencode_provider.go
@@ -14,6 +14,14 @@ import (
 
 var _ Provider = (*openCodeFormatProvider)(nil)
 
+// OpenCodeTargetedSourceProvider constructs virtual sources for a bounded set
+// of journal-selected OpenCode session IDs without scanning storage or SQLite.
+type OpenCodeTargetedSourceProvider interface {
+	OpenCodeSourcesForSessionIDs(
+		context.Context, string, []string,
+	) ([]SourceRef, error)
+}
+
 // A SQLite WAL begins with a 32-byte header. Bytes beyond the header are
 // transaction frames, so a larger WAL can contain source changes worth
 // syncing. Read-only SQLite connections may create an empty WAL and its SHM
@@ -102,6 +110,34 @@ func (p *openCodeFormatProvider) SourceForReconciliation(
 	ctx context.Context, path, project string,
 ) (SourceRef, bool, error) {
 	return p.sources.SourceForReconciliation(ctx, path, project)
+}
+
+func (p *openCodeFormatProvider) OpenCodeSourcesForSessionIDs(
+	ctx context.Context, dbPath string, sessionIDs []string,
+) ([]SourceRef, error) {
+	if p.Def.Type != AgentOpenCode {
+		return nil, nil
+	}
+	for _, root := range p.sources.roots {
+		if filepath.Clean(filepath.Join(root, p.sources.spec.dbName)) != filepath.Clean(dbPath) {
+			continue
+		}
+		metas, err := ListOpenCodeSessionMetaByID(ctx, dbPath, sessionIDs)
+		if err != nil {
+			return nil, err
+		}
+		sources := make([]SourceRef, 0, len(metas))
+		for _, meta := range metas {
+			source, ok := p.sources.sqliteSourceRefFromMeta(root, meta)
+			if !ok {
+				continue
+			}
+			source.ContentChanged = true
+			sources = append(sources, source)
+		}
+		return sources, nil
+	}
+	return nil, nil
 }
 
 func (p *openCodeFormatProvider) FindSource(
@@ -877,6 +913,11 @@ func (s openCodeFormatSourceSet) sourcesForChangedPathInRoot(
 	if isSQLiteChange {
 		dbPath := filepath.Join(root, s.spec.dbName)
 		if !IsRegularFile(dbPath) {
+			return nil, true, nil
+		}
+		// OpenCode database events are classified by the engine-owned bounded
+		// journal fast path. Never fall back to enumerating the container here.
+		if s.spec.agent == AgentOpenCode {
 			return nil, true, nil
 		}
 		storageIDs := map[string]struct{}{}

--- a/internal/parser/opencode_provider_test.go
+++ b/internal/parser/opencode_provider_test.go
@@ -527,7 +527,17 @@ func TestOpenCodeProviderSQLiteSourceMethods(t *testing.T) {
 		ChangedPathRequest{Path: dbPath, EventKind: "write", WatchRoot: root},
 	)
 	require.NoError(t, err)
-	requireSourcePathsMatch(t, changed, fixture.AllVirtualPaths)
+	assert.Empty(t, changed, "OpenCode DB events must not enumerate the container")
+
+	targeted, ok := provider.(OpenCodeTargetedSourceProvider)
+	require.True(t, ok)
+	changed, err = targeted.OpenCodeSourcesForSessionIDs(
+		context.Background(), dbPath, []string{fixture.TargetSessionID},
+	)
+	require.NoError(t, err)
+	require.Len(t, changed, 1)
+	assert.Equal(t, virtualPath, changed[0].DisplayPath)
+	assert.True(t, changed[0].ContentChanged)
 
 	changed, err = provider.SourcesForChangedPath(
 		context.Background(),
@@ -671,6 +681,12 @@ func TestOpenCodeProviderReadsLiveSQLiteWAL(t *testing.T) {
 			EventKind: "write",
 			WatchRoot: filepath.Dir(dbPath),
 		},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, changed)
+	targeted := provider.(OpenCodeTargetedSourceProvider)
+	changed, err = targeted.OpenCodeSourcesForSessionIDs(
+		context.Background(), dbPath, []string{"ses_abc"},
 	)
 	require.NoError(t, err)
 	require.Len(t, changed, 1)

--- a/internal/parser/opencode_test.go
+++ b/internal/parser/opencode_test.go
@@ -213,7 +213,7 @@ func TestListOpenCodeSessionMetaByIDIsTargeted(t *testing.T) {
 	dbPath, seeder, writer := newTestDB(t)
 	defer writer.Close()
 	seeder.AddProject("prj", "/tmp/project")
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		seeder.AddSession(fmt.Sprintf("ses_%03d", i), "prj", "", "", 1, int64(i+1))
 	}
 
@@ -241,7 +241,7 @@ func TestOpenCodeJournalWorkIsArchiveCardinalityIndependent(t *testing.T) {
 				VALUES (?, 'prj', 1, 2)
 			`)
 			require.NoError(t, err)
-			for i := 0; i < archiveSize; i++ {
+			for i := range archiveSize {
 				_, err = stmt.Exec(fmt.Sprintf("ses_%05d", i))
 				require.NoError(t, err)
 			}

--- a/internal/parser/opencode_test.go
+++ b/internal/parser/opencode_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -75,6 +76,22 @@ CREATE TABLE part (
 	data TEXT NOT NULL,
 	FOREIGN KEY (message_id) REFERENCES message(id)
 );
+
+CREATE TABLE event_sequence (
+	aggregate_id TEXT PRIMARY KEY,
+	seq INTEGER NOT NULL
+);
+
+CREATE TABLE event (
+	id TEXT PRIMARY KEY,
+	aggregate_id TEXT NOT NULL,
+	seq INTEGER NOT NULL,
+	type TEXT NOT NULL,
+	data TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX event_aggregate_seq_idx
+	ON event (aggregate_id, seq);
 `
 
 func assertEq[T comparable](t *testing.T, name string, got, want T) {
@@ -121,6 +138,131 @@ func (s *OpenCodeSeeder) AddPart(id, messageID, sessionID string, timeCreated, t
 	_, err := s.db.Exec(`INSERT INTO part (id, message_id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?, ?)`,
 		id, messageID, sessionID, timeCreated, timeUpdated, data)
 	require.NoError(s.t, err, "add part")
+}
+
+func (s *OpenCodeSeeder) AddEvent(
+	id, sessionID, eventType, data string, seq int,
+) {
+	s.t.Helper()
+	_, err := s.db.Exec(`
+		INSERT INTO event_sequence (aggregate_id, seq) VALUES (?, ?)
+		ON CONFLICT (aggregate_id) DO UPDATE SET seq = excluded.seq;
+		INSERT INTO event (id, aggregate_id, seq, type, data)
+		VALUES (?, ?, ?, ?, ?)
+	`, sessionID, seq, id, sessionID, seq, eventType, data)
+	require.NoError(s.t, err, "add event")
+}
+
+func TestReadOpenCodeJournalBoundedSettlement(t *testing.T) {
+	dbPath, seeder, writer := newTestDB(t)
+	defer writer.Close()
+	seeder.AddEvent("evt_1", "ses_stream", "message.part.updated.1", `{"time":1}`, 1)
+	seeder.AddEvent("evt_2", "ses_stream", "message.updated.1", `{"info":{"role":"assistant","time":{"completed":2}}}`, 2)
+	seeder.AddEvent("evt_3", "ses_other", "session.updated.1", `{"time":3}`, 1)
+
+	batch, err := ReadOpenCodeJournal(context.Background(), dbPath, 0, 2)
+	require.NoError(t, err)
+	assert.True(t, batch.Supported)
+	assert.False(t, batch.Safe)
+	assert.True(t, batch.Overflow)
+	assert.Equal(t, int64(3), batch.HighRowID)
+	require.Len(t, batch.Events, 2)
+	assert.False(t, batch.Events[0].Settlement)
+	assert.True(t, batch.Events[1].Settlement)
+
+	batch, err = ReadOpenCodeJournal(context.Background(), dbPath, 0, 3)
+	require.NoError(t, err)
+	assert.True(t, batch.Safe)
+	assert.False(t, batch.Overflow)
+	assert.Equal(t, []OpenCodeJournalEvent{
+		{SessionID: "ses_stream", Settlement: false},
+		{SessionID: "ses_stream", Settlement: true},
+		{SessionID: "ses_other", Settlement: true},
+	}, batch.Events)
+}
+
+func TestReadOpenCodeJournalRejectsUnrecognizedRows(t *testing.T) {
+	dbPath, seeder, writer := newTestDB(t)
+	defer writer.Close()
+	seeder.AddEvent("evt_1", "global", "project.updated.1", `{"time":1}`, 1)
+
+	batch, err := ReadOpenCodeJournal(context.Background(), dbPath, 0, 10)
+	require.NoError(t, err)
+	assert.True(t, batch.Supported)
+	assert.False(t, batch.Safe)
+	assert.Empty(t, batch.Events)
+}
+
+func TestOpenCodeJournalRejectsIncompatibleSchema(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "opencode.db")
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	defer db.Close()
+	_, err = db.Exec(`
+		CREATE TABLE event (id TEXT PRIMARY KEY, payload TEXT);
+		CREATE TABLE event_sequence (aggregate_id TEXT PRIMARY KEY, seq INTEGER);
+	`)
+	require.NoError(t, err)
+
+	_, supported, err := OpenCodeJournalHighWater(context.Background(), dbPath)
+	require.NoError(t, err)
+	assert.False(t, supported)
+}
+
+func TestListOpenCodeSessionMetaByIDIsTargeted(t *testing.T) {
+	dbPath, seeder, writer := newTestDB(t)
+	defer writer.Close()
+	seeder.AddProject("prj", "/tmp/project")
+	for i := 0; i < 100; i++ {
+		seeder.AddSession(fmt.Sprintf("ses_%03d", i), "prj", "", "", 1, int64(i+1))
+	}
+
+	metas, err := ListOpenCodeSessionMetaByID(
+		context.Background(), dbPath, []string{"ses_042", "ses_missing"},
+	)
+	require.NoError(t, err)
+	require.Len(t, metas, 1)
+	assert.Equal(t, "ses_042", metas[0].SessionID)
+	assert.Equal(t, dbPath+"#ses_042", metas[0].VirtualPath)
+	assert.Equal(t, int64(43_000_000), metas[0].FileMtime)
+}
+
+func TestOpenCodeJournalWorkIsArchiveCardinalityIndependent(t *testing.T) {
+	for _, archiveSize := range []int{10, 5000} {
+		t.Run(fmt.Sprintf("sessions-%d", archiveSize), func(t *testing.T) {
+			dbPath, seeder, writer := newTestDB(t)
+			defer writer.Close()
+			seeder.AddProject("prj", "/tmp/project")
+			tx, err := writer.Begin()
+			require.NoError(t, err)
+			stmt, err := tx.Prepare(`
+				INSERT INTO session
+					(id, project_id, time_created, time_updated)
+				VALUES (?, 'prj', 1, 2)
+			`)
+			require.NoError(t, err)
+			for i := 0; i < archiveSize; i++ {
+				_, err = stmt.Exec(fmt.Sprintf("ses_%05d", i))
+				require.NoError(t, err)
+			}
+			require.NoError(t, stmt.Close())
+			require.NoError(t, tx.Commit())
+			seeder.AddEvent(
+				"evt_target", "ses_00000", "session.updated.1", `{"time":1}`, 1,
+			)
+
+			batch, err := ReadOpenCodeJournal(context.Background(), dbPath, 0, 10)
+			require.NoError(t, err)
+			require.True(t, batch.Safe)
+			require.Len(t, batch.Events, 1)
+			metas, err := ListOpenCodeSessionMetaByID(
+				context.Background(), dbPath, []string{batch.Events[0].SessionID},
+			)
+			require.NoError(t, err)
+			require.Len(t, metas, 1)
+			assert.Equal(t, "ses_00000", metas[0].SessionID)
+		})
+	}
 }
 
 func newTestDB(t *testing.T) (string, *OpenCodeSeeder, *sql.DB) {

--- a/internal/parser/provider.go
+++ b/internal/parser/provider.go
@@ -260,6 +260,11 @@ type SourceRef struct {
 	ReconciliationIdentity string
 	// ProjectHint is advisory metadata for UI grouping and may be empty.
 	ProjectHint string
+	// ContentChanged means a bounded source-side journal positively selected
+	// this source even though its coarse size or mtime may be unchanged. The
+	// engine bypasses pre-parse freshness gates but still applies the parsed
+	// content fingerprint before writing.
+	ContentChanged bool
 	// DiscoveryMTimeNS is an optional per-source modification time in Unix
 	// nanoseconds captured at discovery. Providers whose sources are virtual --
 	// a shared store fanned out to one source per session, where DisplayPath is

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -3129,6 +3129,30 @@ func (e *Engine) reconcileWatchRootsStreamed(
 	if force {
 		e.clearWatcherOverflowCaches()
 	}
+	scope := newRootSyncScope(roots)
+	if full {
+		scope = nil
+	} else if scope != nil {
+		scope.agent = agent
+	}
+	var (
+		openCodeBaseline   map[string]openCodeWatchState
+		openCodeBaselineOK bool
+	)
+	if force {
+		// Capture before authoritative discovery. Installing this pre-pass
+		// watermark after success leaves events committed during reconciliation
+		// visible to the next watcher batch.
+		openCodeBaseline, openCodeBaselineOK =
+			e.captureOpenCodeWatchBaselineForScope(ctx, scope)
+		defer func() {
+			if retErr == nil && ctx.Err() == nil && !stats.Aborted &&
+				stats.Failed == 0 && stats.providerFailures == 0 &&
+				openCodeBaselineOK {
+				e.mergeOpenCodeWatchBaseline(openCodeBaseline)
+			}
+		}()
+	}
 	e.phaseStats.Reset()
 	e.anomalies.reset()
 	defer func() { e.anomalies.applyTo(&stats) }()
@@ -3167,12 +3191,6 @@ func (e *Engine) reconcileWatchRootsStreamed(
 		}
 	}()
 
-	scope := newRootSyncScope(roots)
-	if full {
-		scope = nil
-	} else if scope != nil {
-		scope.agent = agent
-	}
 	preContainerStates := e.captureSQLiteContainerStates(nil)
 	providers, completedScopes, failedRoots, failures, discoveryErr, err := e.streamReconciliationCandidates(
 		ctx, scope, spool,

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -280,20 +280,16 @@ type Engine struct {
 	// idPrefix and pathRewriter support remote sync:
 	// prefix all session IDs to avoid collisions, rewrite
 	// temp paths to "host:/remote/path" form.
-	ephemeral              bool
-	idPrefix               string
-	pathRewriter           func(string) string
-	emitter                Emitter
-	providerFactories      map[parser.AgentType]parser.ProviderFactory
-	providerMigrationModes map[parser.AgentType]parser.ProviderMigrationMode
-	providerWatchRootsMu   gosync.Mutex
-	providerWatchRoots     map[parser.AgentType][]parser.WatchRoot
-	openCodeWatchMu        gosync.Mutex
-	openCodeWatch          map[string]openCodeWatchState
-	// stagedOpenCodeWatch holds a pre-discovery journal baseline captured during
-	// resyncBuildLocked. It is installed only after a successful swap so a
-	// discarded rebuild cannot advance the watcher watermark.
-	stagedOpenCodeWatch     map[string]openCodeWatchState
+	ephemeral               bool
+	idPrefix                string
+	pathRewriter            func(string) string
+	emitter                 Emitter
+	providerFactories       map[parser.AgentType]parser.ProviderFactory
+	providerMigrationModes  map[parser.AgentType]parser.ProviderMigrationMode
+	providerWatchRootsMu    gosync.Mutex
+	providerWatchRoots      map[parser.AgentType][]parser.WatchRoot
+	openCodeWatchMu         gosync.Mutex
+	openCodeWatch           map[string]openCodeWatchState
 	projectIdentityMu       gosync.Mutex
 	projectIdentityCache    map[string]projectIdentityCacheEntry
 	projectIdentityWritten  map[string]struct{}
@@ -1721,7 +1717,6 @@ func (e *Engine) resyncAllWithOptionsLocked(
 
 	stats, err := e.resyncBuildLocked(ctx, onProgress, opts, ops)
 	if err != nil || stats.Aborted {
-		e.stagedOpenCodeWatch = nil
 		return stats, err
 	}
 	swapStageReached = true
@@ -1737,7 +1732,6 @@ func (e *Engine) resyncAllWithOptionsLocked(
 			e.skipCache = preBuildSkipCache
 			e.skipHashKeys = preBuildSkipHashKeys
 			e.skipMu.Unlock()
-			e.stagedOpenCodeWatch = nil
 		}
 		e.setLastSyncStats(stats)
 		return stats, swapErr
@@ -1759,9 +1753,6 @@ func (e *Engine) resyncBuildLocked(
 	ctx context.Context, onProgress ProgressFunc, opts RebuildOptions,
 	ops rebuildOperations,
 ) (stats SyncStats, retErr error) {
-	// A prior successful build that never swapped must not install after a
-	// later discarded rebuild.
-	e.stagedOpenCodeWatch = nil
 	reportResyncProgress := func(p Progress) {
 		p.Resync = true
 		if p.Phase == PhaseSyncing && p.Detail == "" {
@@ -1969,10 +1960,8 @@ func (e *Engine) resyncBuildLocked(
 		"Discovering sessions",
 		"",
 	)
-	var stagedOpenCodeWatch map[string]openCodeWatchState
-	stats = e.syncAllLockedStagingOpenCodeWatch(
+	stats = e.syncAllLocked(
 		ctx, reportResyncProgress, time.Time{}, nil, syncWriteBulk, true, false,
-		&stagedOpenCodeWatch,
 	)
 	e.db = origDB // restore immediately
 	e.archiveStore = nil
@@ -2341,9 +2330,6 @@ func (e *Engine) resyncBuildLocked(
 		e.mu.Unlock()
 		return stats, err
 	}
-	// Stage only after the replacement is fully built and closed. ResetCachesAfterSwap
-	// installs it once the live archive has been swapped successfully.
-	e.stagedOpenCodeWatch = stagedOpenCodeWatch
 	return stats, nil
 }
 
@@ -2483,18 +2469,12 @@ func (e *Engine) SwapResyncDatabase(tempPath string) error {
 // storage sessions, and verified sources, then reloads the skip cache from the
 // swapped archive so the engine carries warm skip state. skipFingerprints is
 // reset to empty, matching engine construction (fingerprints are recomputed on
-// the next sync, never persisted). When a resync build staged an OpenCode
-// journal baseline, it is installed here so a discarded rebuild cannot advance
-// the watcher watermark. The caller invokes it immediately after a successful
-// SwapResyncDatabase.
+// the next sync, never persisted). The caller invokes it immediately after a
+// successful SwapResyncDatabase.
 func (e *Engine) ResetCachesAfterSwap() error {
 	e.clearTrustedSQLiteContainers()
 	e.clearTrustedOpenCodeStorageSessions()
 	e.clearVerifiedSources()
-	if e.stagedOpenCodeWatch != nil {
-		e.installOpenCodeWatchBaseline(e.stagedOpenCodeWatch)
-		e.stagedOpenCodeWatch = nil
-	}
 	return e.ReloadSkipCache()
 }
 
@@ -4476,18 +4456,6 @@ func (e *Engine) syncAllLocked(
 	scope *rootSyncScope, writeMode syncWriteMode, recordSyncState bool,
 	forceDiscoveredFiles bool,
 ) (stats SyncStats) {
-	return e.syncAllLockedStagingOpenCodeWatch(
-		ctx, onProgress, since, scope, writeMode, recordSyncState,
-		forceDiscoveredFiles, nil,
-	)
-}
-
-func (e *Engine) syncAllLockedStagingOpenCodeWatch(
-	ctx context.Context, onProgress ProgressFunc, since time.Time,
-	scope *rootSyncScope, writeMode syncWriteMode, recordSyncState bool,
-	forceDiscoveredFiles bool,
-	stagedOpenCodeWatch *map[string]openCodeWatchState,
-) (stats SyncStats) {
 	if ctx.Err() != nil {
 		return SyncStats{Aborted: true}
 	}
@@ -4526,7 +4494,7 @@ func (e *Engine) syncAllLockedStagingOpenCodeWatch(
 		openCodeBaseline   map[string]openCodeWatchState
 		openCodeBaselineOK bool
 	)
-	if scope == nil && since.IsZero() {
+	if scope == nil && since.IsZero() && e.archiveStore == nil {
 		// Capture before discovery so events committed while the pass is
 		// parsing remain after the installed watermark for watcher processing.
 		openCodeBaseline, openCodeBaselineOK =
@@ -4785,11 +4753,7 @@ func (e *Engine) syncAllLockedStagingOpenCodeWatch(
 		e.recordSyncFinished()
 	}
 	if openCodeBaselineOK && providerFailures == 0 && stats.Failed == 0 {
-		if stagedOpenCodeWatch != nil {
-			*stagedOpenCodeWatch = openCodeBaseline
-		} else {
-			e.installOpenCodeWatchBaseline(openCodeBaseline)
-		}
+		e.installOpenCodeWatchBaseline(openCodeBaseline)
 	}
 	// Emission happens in SyncAll / SyncAllSince after syncMu is
 	// released; syncAllLocked runs under the caller's lock.

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -920,9 +920,6 @@ func (e *Engine) classifyPaths(
 	files := make([]parser.DiscoveredFile, 0, len(paths))
 	var classificationErr error
 	for _, p := range paths {
-		if ctx.Err() != nil {
-			break
-		}
 		// Codex resolved-index events map to potentially several session
 		// sources and must classify even when the event path was deleted, so
 		// they are handled by classifyCodexIndexPath. All other changed paths,
@@ -992,9 +989,6 @@ func (e *Engine) classifyProviderChangedPath(
 	})
 
 	for _, agentType := range agents {
-		if ctx.Err() != nil {
-			return files, classificationErr
-		}
 		mode := e.providerMigrationModes[agentType]
 		switch mode {
 		case parser.ProviderMigrationProviderAuthoritative:
@@ -1050,9 +1044,6 @@ func (e *Engine) classifyProviderChangedPath(
 			continue
 		}
 		for _, watchRoot := range watchRoots {
-			if ctx.Err() != nil {
-				return files, classificationErr
-			}
 			request := parser.ChangedPathRequest{
 				Path:      path,
 				EventKind: eventKind,

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -280,20 +280,20 @@ type Engine struct {
 	// idPrefix and pathRewriter support remote sync:
 	// prefix all session IDs to avoid collisions, rewrite
 	// temp paths to "host:/remote/path" form.
-	ephemeral               bool
-	idPrefix                string
-	pathRewriter            func(string) string
-	emitter                 Emitter
-	providerFactories       map[parser.AgentType]parser.ProviderFactory
-	providerMigrationModes  map[parser.AgentType]parser.ProviderMigrationMode
-	providerWatchRootsMu    gosync.Mutex
-	providerWatchRoots      map[parser.AgentType][]parser.WatchRoot
-	openCodeWatchMu         gosync.Mutex
-	openCodeWatch           map[string]openCodeWatchState
+	ephemeral              bool
+	idPrefix               string
+	pathRewriter           func(string) string
+	emitter                Emitter
+	providerFactories      map[parser.AgentType]parser.ProviderFactory
+	providerMigrationModes map[parser.AgentType]parser.ProviderMigrationMode
+	providerWatchRootsMu   gosync.Mutex
+	providerWatchRoots     map[parser.AgentType][]parser.WatchRoot
+	openCodeWatchMu        gosync.Mutex
+	openCodeWatch          map[string]openCodeWatchState
 	// stagedOpenCodeWatch holds a pre-discovery journal baseline captured during
 	// resyncBuildLocked. It is installed only after a successful swap so a
 	// discarded rebuild cannot advance the watcher watermark.
-	stagedOpenCodeWatch map[string]openCodeWatchState
+	stagedOpenCodeWatch     map[string]openCodeWatchState
 	projectIdentityMu       gosync.Mutex
 	projectIdentityCache    map[string]projectIdentityCacheEntry
 	projectIdentityWritten  map[string]struct{}
@@ -993,7 +993,7 @@ func (e *Engine) classifyProviderChangedPath(
 
 	for _, agentType := range agents {
 		if ctx.Err() != nil {
-			return files
+			return files, classificationErr
 		}
 		mode := e.providerMigrationModes[agentType]
 		switch mode {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -288,6 +288,8 @@ type Engine struct {
 	providerMigrationModes  map[parser.AgentType]parser.ProviderMigrationMode
 	providerWatchRootsMu    gosync.Mutex
 	providerWatchRoots      map[parser.AgentType][]parser.WatchRoot
+	openCodeWatchMu         gosync.Mutex
+	openCodeWatch           map[string]openCodeWatchState
 	projectIdentityMu       gosync.Mutex
 	projectIdentityCache    map[string]projectIdentityCacheEntry
 	projectIdentityWritten  map[string]struct{}
@@ -499,6 +501,7 @@ func NewEngine(
 		providerFactories:       providerFactoryMap(providerFactories),
 		providerMigrationModes:  providerModes,
 		providerWatchRoots:      make(map[parser.AgentType][]parser.WatchRoot),
+		openCodeWatch:           make(map[string]openCodeWatchState),
 		projectIdentityCache:    make(map[string]projectIdentityCacheEntry),
 		projectIdentityWritten:  make(map[string]struct{}),
 		startupMaintenanceReady: make(chan struct{}),
@@ -913,6 +916,9 @@ func (e *Engine) classifyPaths(
 	files := make([]parser.DiscoveredFile, 0, len(paths))
 	var classificationErr error
 	for _, p := range paths {
+		if ctx.Err() != nil {
+			break
+		}
 		// Codex resolved-index events map to potentially several session
 		// sources and must classify even when the event path was deleted, so
 		// they are handled by classifyCodexIndexPath. All other changed paths,
@@ -955,6 +961,11 @@ func mergeChangedPathDiscoveredFile(
 	}
 	if current.ProviderSource == nil && next.ProviderSource != nil {
 		current.ProviderSource = next.ProviderSource
+	} else if current.ProviderSource != nil && next.ProviderSource != nil &&
+		next.ProviderSource.ContentChanged && !current.ProviderSource.ContentChanged {
+		merged := *current.ProviderSource
+		merged.ContentChanged = true
+		current.ProviderSource = &merged
 	}
 	return current
 }
@@ -977,6 +988,9 @@ func (e *Engine) classifyProviderChangedPath(
 	})
 
 	for _, agentType := range agents {
+		if ctx.Err() != nil {
+			return files
+		}
 		mode := e.providerMigrationModes[agentType]
 		switch mode {
 		case parser.ProviderMigrationProviderAuthoritative:
@@ -1032,6 +1046,9 @@ func (e *Engine) classifyProviderChangedPath(
 			continue
 		}
 		for _, watchRoot := range watchRoots {
+			if ctx.Err() != nil {
+				return files, classificationErr
+			}
 			request := parser.ChangedPathRequest{
 				Path:      path,
 				EventKind: eventKind,
@@ -1060,11 +1077,21 @@ func (e *Engine) classifyProviderChangedPath(
 					}
 				}
 			}
-			sources, err := provider.SourcesForChangedPath(
-				ctx,
-				request,
+			var (
+				sources []parser.SourceRef
+				srcErr  error
+				handled bool
 			)
-			if err != nil {
+			if agentType == parser.AgentOpenCode {
+				sources, handled = e.classifyOpenCodeJournalPath(
+					ctx, path, watchRoot, provider,
+				)
+			}
+			if !handled {
+				sources, srcErr = provider.SourcesForChangedPath(ctx, request)
+			}
+			if srcErr != nil {
+				err = srcErr
 				if !errors.Is(err, parser.ErrUnsupportedProviderFeature) {
 					classificationErr = errors.Join(
 						classificationErr,
@@ -4724,6 +4751,9 @@ func (e *Engine) syncAllLocked(
 	if recordSyncState && stats.providerFailures == 0 {
 		e.recordSyncFinished()
 	}
+	if scope == nil && since.IsZero() && providerFailures == 0 && stats.Failed == 0 {
+		e.rebaselineOpenCodeWatch(ctx)
+	}
 	// Emission happens in SyncAll / SyncAllSince after syncMu is
 	// released; syncAllLocked runs under the caller's lock.
 	return stats
@@ -6783,6 +6813,7 @@ func (e *Engine) processProviderFile(
 	ctx context.Context,
 	file parser.DiscoveredFile,
 ) (processResult, bool) {
+	contentChanged := file.ProviderSource != nil && file.ProviderSource.ContentChanged
 	mode := e.providerMigrationModes[file.Agent]
 	usesProvider := processFileUsesProvider(file.Agent)
 	if mode != parser.ProviderMigrationProviderAuthoritative && !usesProvider {
@@ -6802,7 +6833,7 @@ func (e *Engine) processProviderFile(
 	// provably has not changed since the last fully verified pass, none
 	// of its sessions can have changed, so skip before paying for the
 	// per-session fingerprint (a DB open per source) and parse.
-	if e.sqliteContainerSourceFresh(file) {
+	if !contentChanged && e.sqliteContainerSourceFresh(file) {
 		return processResult{skip: true}, true
 	}
 
@@ -6866,7 +6897,7 @@ func (e *Engine) processProviderFile(
 
 	verifiedCapture, verifiedMtime, verifiedFresh, verifiedStateOK :=
 		e.verifiedProviderSourceState(provider, source, file)
-	if verifiedStateOK && verifiedFresh {
+	if !contentChanged && verifiedStateOK && verifiedFresh {
 		if e.verifiedProviderSourceFreshInDB(
 			source, verifiedCapture.signature.size, verifiedMtime,
 		) {
@@ -6887,7 +6918,7 @@ func (e *Engine) processProviderFile(
 	sourceForceReplace := false
 	if mtime, fresh, forceReplace, contentVerified := e.providerSingleSessionFresh(
 		ctx, provider, source, file,
-	); fresh {
+	); fresh && !contentChanged {
 		if !verifiedStateOK || contentVerified {
 			if verifiedStateOK {
 				e.promoteVerifiedSource(verifiedCapture)
@@ -6904,7 +6935,7 @@ func (e *Engine) processProviderFile(
 	} else if forceReplace {
 		sourceForceReplace = true
 	}
-	if freshMtime, fresh := e.providerSourceFreshBeforeFingerprint(source, file); fresh {
+	if freshMtime, fresh := e.providerSourceFreshBeforeFingerprint(source, file); fresh && !contentChanged {
 		return processResult{
 			skip:  true,
 			mtime: freshMtime,
@@ -6928,7 +6959,7 @@ func (e *Engine) processProviderFile(
 	}
 	cacheKey := providerProcessCacheKey(file, source, fingerprint)
 	cacheSkip := e.shouldCacheSkip(file)
-	if cacheSkip && !e.forceParse && !file.ForceParse {
+	if cacheSkip && !contentChanged && !e.forceParse && !file.ForceParse {
 		e.skipMu.RLock()
 		cachedMtime, cached := e.skipCache[cacheKey]
 		e.skipMu.RUnlock()
@@ -6962,7 +6993,7 @@ func (e *Engine) processProviderFile(
 			}
 		}
 	}
-	if cacheSkip && e.shouldSkipProviderSource(file, source, fingerprint) {
+	if cacheSkip && !contentChanged && e.shouldSkipProviderSource(file, source, fingerprint) {
 		return processResult{
 			skip:      true,
 			mtime:     fingerprint.MTimeNS,
@@ -6994,7 +7025,7 @@ func (e *Engine) processProviderFile(
 	// engine). For Codex this also folds in the session_index.jsonl sidecar:
 	// a shared index mtime bump that did not change this session's title must
 	// not trigger a reparse.
-	if !incForceReplace && !e.forceParse && !file.ForceParse &&
+	if !contentChanged && !incForceReplace && !e.forceParse && !file.ForceParse &&
 		e.shouldSkipProviderSourceByDB(file, fingerprint) {
 		if verifiedStateOK {
 			e.promoteVerifiedSource(verifiedCapture)
@@ -7018,7 +7049,7 @@ func (e *Engine) processProviderFile(
 	// a provider whose fingerprint mtime differs from the stored value simply
 	// reparses, matching the prior behavior. Claude and Cowork have their own
 	// earlier freshness checks; this is the generic fallback for the rest.
-	if !incForceReplace && !e.forceParse && !file.ForceParse &&
+	if !contentChanged && !incForceReplace && !e.forceParse && !file.ForceParse &&
 		e.providerSourceUnchangedInDB(source, fingerprint) {
 		return processResult{
 			skip:      true,

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -290,6 +290,10 @@ type Engine struct {
 	providerWatchRoots      map[parser.AgentType][]parser.WatchRoot
 	openCodeWatchMu         gosync.Mutex
 	openCodeWatch           map[string]openCodeWatchState
+	// stagedOpenCodeWatch holds a pre-discovery journal baseline captured during
+	// resyncBuildLocked. It is installed only after a successful swap so a
+	// discarded rebuild cannot advance the watcher watermark.
+	stagedOpenCodeWatch map[string]openCodeWatchState
 	projectIdentityMu       gosync.Mutex
 	projectIdentityCache    map[string]projectIdentityCacheEntry
 	projectIdentityWritten  map[string]struct{}
@@ -1726,6 +1730,7 @@ func (e *Engine) resyncAllWithOptionsLocked(
 
 	stats, err := e.resyncBuildLocked(ctx, onProgress, opts, ops)
 	if err != nil || stats.Aborted {
+		e.stagedOpenCodeWatch = nil
 		return stats, err
 	}
 	swapStageReached = true
@@ -1741,6 +1746,7 @@ func (e *Engine) resyncAllWithOptionsLocked(
 			e.skipCache = preBuildSkipCache
 			e.skipHashKeys = preBuildSkipHashKeys
 			e.skipMu.Unlock()
+			e.stagedOpenCodeWatch = nil
 		}
 		e.setLastSyncStats(stats)
 		return stats, swapErr
@@ -1762,6 +1768,9 @@ func (e *Engine) resyncBuildLocked(
 	ctx context.Context, onProgress ProgressFunc, opts RebuildOptions,
 	ops rebuildOperations,
 ) (stats SyncStats, retErr error) {
+	// A prior successful build that never swapped must not install after a
+	// later discarded rebuild.
+	e.stagedOpenCodeWatch = nil
 	reportResyncProgress := func(p Progress) {
 		p.Resync = true
 		if p.Phase == PhaseSyncing && p.Detail == "" {
@@ -1969,8 +1978,10 @@ func (e *Engine) resyncBuildLocked(
 		"Discovering sessions",
 		"",
 	)
-	stats = e.syncAllLocked(
+	var stagedOpenCodeWatch map[string]openCodeWatchState
+	stats = e.syncAllLockedStagingOpenCodeWatch(
 		ctx, reportResyncProgress, time.Time{}, nil, syncWriteBulk, true, false,
+		&stagedOpenCodeWatch,
 	)
 	e.db = origDB // restore immediately
 	e.archiveStore = nil
@@ -2339,6 +2350,9 @@ func (e *Engine) resyncBuildLocked(
 		e.mu.Unlock()
 		return stats, err
 	}
+	// Stage only after the replacement is fully built and closed. ResetCachesAfterSwap
+	// installs it once the live archive has been swapped successfully.
+	e.stagedOpenCodeWatch = stagedOpenCodeWatch
 	return stats, nil
 }
 
@@ -2478,12 +2492,18 @@ func (e *Engine) SwapResyncDatabase(tempPath string) error {
 // storage sessions, and verified sources, then reloads the skip cache from the
 // swapped archive so the engine carries warm skip state. skipFingerprints is
 // reset to empty, matching engine construction (fingerprints are recomputed on
-// the next sync, never persisted). The caller invokes it immediately after a
-// successful SwapResyncDatabase.
+// the next sync, never persisted). When a resync build staged an OpenCode
+// journal baseline, it is installed here so a discarded rebuild cannot advance
+// the watcher watermark. The caller invokes it immediately after a successful
+// SwapResyncDatabase.
 func (e *Engine) ResetCachesAfterSwap() error {
 	e.clearTrustedSQLiteContainers()
 	e.clearTrustedOpenCodeStorageSessions()
 	e.clearVerifiedSources()
+	if e.stagedOpenCodeWatch != nil {
+		e.installOpenCodeWatchBaseline(e.stagedOpenCodeWatch)
+		e.stagedOpenCodeWatch = nil
+	}
 	return e.ReloadSkipCache()
 }
 
@@ -4465,6 +4485,18 @@ func (e *Engine) syncAllLocked(
 	scope *rootSyncScope, writeMode syncWriteMode, recordSyncState bool,
 	forceDiscoveredFiles bool,
 ) (stats SyncStats) {
+	return e.syncAllLockedStagingOpenCodeWatch(
+		ctx, onProgress, since, scope, writeMode, recordSyncState,
+		forceDiscoveredFiles, nil,
+	)
+}
+
+func (e *Engine) syncAllLockedStagingOpenCodeWatch(
+	ctx context.Context, onProgress ProgressFunc, since time.Time,
+	scope *rootSyncScope, writeMode syncWriteMode, recordSyncState bool,
+	forceDiscoveredFiles bool,
+	stagedOpenCodeWatch *map[string]openCodeWatchState,
+) (stats SyncStats) {
 	if ctx.Err() != nil {
 		return SyncStats{Aborted: true}
 	}
@@ -4499,6 +4531,16 @@ func (e *Engine) syncAllLocked(
 		Phase:  PhaseDiscovering,
 		Detail: "Discovering sessions",
 	})
+	var (
+		openCodeBaseline   map[string]openCodeWatchState
+		openCodeBaselineOK bool
+	)
+	if scope == nil && since.IsZero() {
+		// Capture before discovery so events committed while the pass is
+		// parsing remain after the installed watermark for watcher processing.
+		openCodeBaseline, openCodeBaselineOK =
+			e.captureOpenCodeWatchBaseline(ctx)
+	}
 
 	// Container states must be captured BEFORE discovery lists any session
 	// rows, so a promoted state can never be newer than the discovered
@@ -4751,8 +4793,12 @@ func (e *Engine) syncAllLocked(
 	if recordSyncState && stats.providerFailures == 0 {
 		e.recordSyncFinished()
 	}
-	if scope == nil && since.IsZero() && providerFailures == 0 && stats.Failed == 0 {
-		e.rebaselineOpenCodeWatch(ctx)
+	if openCodeBaselineOK && providerFailures == 0 && stats.Failed == 0 {
+		if stagedOpenCodeWatch != nil {
+			*stagedOpenCodeWatch = openCodeBaseline
+		} else {
+			e.installOpenCodeWatchBaseline(openCodeBaseline)
+		}
 	}
 	// Emission happens in SyncAll / SyncAllSince after syncMu is
 	// released; syncAllLocked runs under the caller's lock.

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -779,6 +779,44 @@ func TestSyncEngineOpenCodeJournalDefersStreamingUntilSettlement(
 	assert.Equal(t, *after.LocalModifiedAt, *unchanged.LocalModifiedAt)
 }
 
+func TestSyncEngineOpenCodeEventCommittedDuringFullSyncRemainsWatchable(
+	t *testing.T,
+) {
+	env := setupSingleAgentTestEnv(t, parser.AgentOpenCode)
+	oc := createOpenCodeDB(t, env.opencodeDir)
+	oc.addProject(t, "proj", "/home/user/code/opencode-app")
+	seedOpenCodeSQLiteTextSession(
+		t, oc, "proj", "ses_during_sync",
+		1779012000000, 1779012030000,
+		"original prompt", "original answer",
+	)
+
+	mutated := false
+	stats := env.engine.SyncAll(context.Background(), func(progress sync.Progress) {
+		if mutated || progress.Phase != sync.PhaseDone {
+			return
+		}
+		mutated = true
+		oc.replaceTextContent(
+			t, "ses_during_sync", "late prompt", "late answer",
+			1779012000000,
+		)
+		oc.addEvent(
+			t, "evt_late", "ses_during_sync", "session.updated.1",
+			`{"time":1}`, 1,
+		)
+	})
+	require.False(t, stats.Aborted)
+	require.True(t, mutated)
+	sessionID := "opencode:ses_during_sync"
+	assertMessageContent(
+		t, env.db, sessionID, "original prompt", "original answer",
+	)
+
+	env.engine.SyncPaths([]string{oc.path})
+	assertMessageContent(t, env.db, sessionID, "late prompt", "late answer")
+}
+
 // TestSyncEngineOpenCodeSQLiteUntouchedContainerSkipsReparse pins the
 // container-level freshness gate: when the shared opencode.db file is
 // completely untouched since the last verified sync, its sessions must be

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -722,6 +722,63 @@ func TestSyncEngineOpenCodeSQLiteSameMtimeContentChangeUsesFingerprint(
 		"successful rewrite must bump local_modified_at for push windows")
 }
 
+func TestSyncEngineOpenCodeJournalDefersStreamingUntilSettlement(
+	t *testing.T,
+) {
+	env := setupSingleAgentTestEnv(t, parser.AgentOpenCode)
+	oc := createOpenCodeDB(t, env.opencodeDir)
+	oc.addProject(t, "proj", "/home/user/code/opencode-app")
+	seedOpenCodeSQLiteTextSession(
+		t, oc, "proj", "ses_stream",
+		1779012000000, 1779012030000,
+		"original prompt", "original answer",
+	)
+
+	stats := env.engine.SyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted)
+	require.Equal(t, 1, stats.Synced)
+	sessionID := "opencode:ses_stream"
+	before := openCodeStoredSession(t, env.db, sessionID)
+	require.NotNil(t, before.LocalModifiedAt)
+
+	oc.replaceTextContent(
+		t, "ses_stream", "streamed prompt", "streamed answer",
+		1779012000000,
+	)
+	oc.addEvent(
+		t, "evt_001", "ses_stream", "message.part.updated.1",
+		`{"time":1}`, 1,
+	)
+	env.engine.SyncPaths([]string{oc.path})
+	assertMessageContent(
+		t, env.db, sessionID, "original prompt", "original answer",
+	)
+
+	oc.addEvent(
+		t, "evt_002", "ses_stream", "message.updated.1",
+		`{"info":{"role":"assistant","time":{"completed":2}}}`, 2,
+	)
+	time.Sleep(20 * time.Millisecond)
+	env.engine.SyncPaths([]string{oc.path})
+	assertMessageContent(
+		t, env.db, sessionID, "streamed prompt", "streamed answer",
+	)
+	after := openCodeStoredSession(t, env.db, sessionID)
+	require.NotNil(t, after.LocalModifiedAt)
+	assert.Greater(t, *after.LocalModifiedAt, *before.LocalModifiedAt)
+
+	// A settlement can select a source whose normalized content is unchanged;
+	// the post-parse fingerprint gate must still prevent an archive rewrite.
+	oc.addEvent(
+		t, "evt_003", "ses_stream", "session.updated.1", `{"time":3}`, 3,
+	)
+	time.Sleep(20 * time.Millisecond)
+	env.engine.SyncPaths([]string{oc.path})
+	unchanged := openCodeStoredSession(t, env.db, sessionID)
+	require.NotNil(t, unchanged.LocalModifiedAt)
+	assert.Equal(t, *after.LocalModifiedAt, *unchanged.LocalModifiedAt)
+}
+
 // TestSyncEngineOpenCodeSQLiteUntouchedContainerSkipsReparse pins the
 // container-level freshness gate: when the shared opencode.db file is
 // completely untouched since the last verified sync, its sessions must be
@@ -6313,27 +6370,27 @@ func TestOpenCodeSQLiteRootSyncPathsAndStaleReparse(t *testing.T) {
 		return assistantMessageID
 	}
 
-	syncPathsID := "oc-sqlite-sync-paths"
+	syncPathsID := "ses_sqlite_sync_paths"
 	seedTextSession(
 		syncPathsID,
 		"original sqlite question", "original sqlite answer", 0,
 	)
-	staleVersionID := "oc-sqlite-stale-version"
+	staleVersionID := "ses_sqlite_stale_version"
 	staleAssistantMessageID := seedTextSession(
 		staleVersionID,
 		"stale version question", "stale version answer", 10,
 	)
-	sourceMtimeID := "oc-source-sqlite"
+	sourceMtimeID := "ses_source_sqlite"
 	seedTextSession(
 		sourceMtimeID,
 		"source mtime question", "source mtime answer", 20,
 	)
-	goodSessionID := "oc-sqlite-watch-good"
+	goodSessionID := "ses_sqlite_watch_good"
 	seedTextSession(
 		goodSessionID,
 		"good original question", "good original answer", 30,
 	)
-	badSessionID := "oc-sqlite-watch-bad"
+	badSessionID := "ses_sqlite_watch_bad"
 	seedTextSession(
 		badSessionID,
 		"bad original question", "", 40,
@@ -6360,6 +6417,9 @@ func TestOpenCodeSQLiteRootSyncPathsAndStaleReparse(t *testing.T) {
 		timeCreated,
 	)
 	oc.updateSessionTime(t, syncPathsID, timeUpdated+1000)
+	oc.addEvent(
+		t, "evt-sync-paths", syncPathsID, "session.updated.1", `{"time":1}`, 1,
+	)
 
 	env.engine.SyncPaths([]string{oc.path})
 
@@ -6397,6 +6457,12 @@ func TestOpenCodeSQLiteRootSyncPathsAndStaleReparse(t *testing.T) {
 		t, "corrupt bad session message time",
 		"UPDATE message SET time_created = ? WHERE id = ?",
 		"broken-time", badSessionID+"-msg-u1",
+	)
+	oc.addEvent(
+		t, "evt-good", goodSessionID, "session.updated.1", `{"time":2}`, 1,
+	)
+	oc.addEvent(
+		t, "evt-bad", badSessionID, "session.updated.1", `{"time":2}`, 1,
 	)
 
 	env.engine.SyncPaths([]string{oc.path})
@@ -6484,7 +6550,7 @@ func TestSyncPathsOpenCodeSQLiteDBEventIgnoresStaleSkipCache(
 	oc := createOpenCodeDB(t, env.opencodeDir)
 	oc.addProject(t, "proj-1", "/home/user/code/myapp")
 
-	sessionID := "oc-sqlite-sync-paths-skip-cache"
+	sessionID := "ses_sqlite_sync_paths_skip_cache"
 	timeCreated := int64(1704067200000)
 	timeUpdated := int64(1704067205000)
 
@@ -6527,6 +6593,9 @@ func TestSyncPathsOpenCodeSQLiteDBEventIgnoresStaleSkipCache(
 		timeCreated,
 	)
 	oc.updateSessionTime(t, sessionID, timeUpdated+1000)
+	oc.addEvent(
+		t, "evt-skip-cache", sessionID, "session.updated.1", `{"time":1}`, 1,
+	)
 	require.NoError(t, os.Chtimes(oc.path, cachedMtime, cachedMtime), "restore db mtime")
 
 	env.engine.SyncPaths([]string{oc.path})
@@ -6829,7 +6898,7 @@ func TestOpenCodeHybridRootSyncsSQLiteSessions(t *testing.T) {
 		"storage reply", 1704067201000,
 	)
 
-	const duplicateID = "oc-hybrid-dup"
+	const duplicateID = "ses_hybrid_dup"
 	storage.addSession(
 		t, "global", duplicateID,
 		"/home/user/code/storage-app", "Hybrid Dup",
@@ -6847,7 +6916,7 @@ func TestOpenCodeHybridRootSyncsSQLiteSessions(t *testing.T) {
 	sqlite := createOpenCodeDB(t, env.opencodeDir)
 	sqlite.addProject(t, "proj-1", "/home/user/code/sqlite-app")
 	sqlite.addProject(t, "proj-2", "/home/user/code/storage-app")
-	sessionID := "oc-hybrid-sqlite"
+	sessionID := "ses_hybrid_sqlite"
 	timeCreated := int64(1704067200000)
 	timeUpdated := int64(1704067205000)
 	sqlite.addSession(
@@ -6926,6 +6995,9 @@ func TestOpenCodeHybridRootSyncsSQLiteSessions(t *testing.T) {
 		timeCreated,
 	)
 	sqlite.updateSessionTime(t, sessionID, timeUpdated+1000)
+	sqlite.addEvent(
+		t, "evt-hybrid-sqlite", sessionID, "session.updated.1", `{"time":1}`, 1,
+	)
 	env.engine.SyncPaths([]string{sqlite.path})
 	assertMessageContent(
 		t, env.db, "opencode:"+sessionID,
@@ -6954,10 +7026,36 @@ func TestOpenCodeHybridRootSyncsSQLiteSessions(t *testing.T) {
 		timeCreated,
 	)
 	sqlite.updateSessionTime(t, duplicateID, duplicateUpdated+1000)
+	sqlite.addEvent(
+		t, "evt-hybrid-duplicate", duplicateID, "session.updated.1", `{"time":1}`, 1,
+	)
 	env.engine.SyncPaths([]string{sqlite.path})
 	assertMessageContent(
 		t, env.db, "opencode:"+duplicateID,
 		"canonical storage reply",
+	)
+
+	const newSessionID = "ses_hybrid_new"
+	sqlite.addSession(t, newSessionID, "proj-1", timeCreated, timeUpdated)
+	sqlite.addMessage(t, "new-msg-u1", newSessionID, "user", timeCreated)
+	sqlite.addTextPart(
+		t, "new-part-u1", newSessionID, "new-msg-u1",
+		"new hybrid question", timeCreated,
+	)
+	sqlite.addEvent(
+		t, "evt-hybrid-new", newSessionID, "session.created.1", `{"time":1}`, 1,
+	)
+	env.engine.SyncPaths([]string{sqlite.path})
+	newSession, err := env.db.GetSession(
+		context.Background(), "opencode:"+newSessionID,
+	)
+	require.NoError(t, err)
+	assert.Nil(t, newSession, "unknown hybrid sessions wait for full discovery")
+
+	stats := env.engine.SyncAll(context.Background(), nil)
+	require.False(t, stats.Aborted)
+	assertMessageContent(
+		t, env.db, "opencode:"+newSessionID, "new hybrid question",
 	)
 }
 

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -779,6 +779,56 @@ func TestSyncEngineOpenCodeJournalDefersStreamingUntilSettlement(
 	assert.Equal(t, *after.LocalModifiedAt, *unchanged.LocalModifiedAt)
 }
 
+func TestSyncEngineOpenCodeJournalOverflowDefersRepairToFullSync(
+	t *testing.T,
+) {
+	env := setupSingleAgentTestEnv(t, parser.AgentOpenCode)
+	oc := createOpenCodeDB(t, env.opencodeDir)
+	oc.addProject(t, "proj", "/home/user/code/opencode-app")
+	seedOpenCodeSQLiteTextSession(
+		t, oc, "proj", "ses_overflow_repair",
+		1779012000000, 1779012030000,
+		"original prompt", "original answer",
+	)
+
+	stats := env.engine.SyncAll(t.Context(), nil)
+	require.False(t, stats.Aborted)
+	require.Equal(t, 1, stats.Synced)
+	oc.replaceTextContent(
+		t, "ses_overflow_repair", "repaired prompt", "repaired answer",
+		1779012000000,
+	)
+	// The watcher reads at most 256 journal rows; the settlement is the
+	// overflow sentinel and must be deferred rather than parsed immediately.
+	for seq := 1; seq <= 256; seq++ {
+		oc.addEvent(
+			t, fmt.Sprintf("evt_overflow_%03d", seq),
+			"ses_overflow_repair", "message.part.updated.1",
+			`{"time":1}`, seq,
+		)
+	}
+	oc.addEvent(
+		t, "evt_overflow_settlement", "ses_overflow_repair",
+		"message.updated.1",
+		`{"info":{"role":"assistant","time":{"completed":2}}}`,
+		257,
+	)
+
+	require.NoError(t, env.engine.SyncPathsContext(t.Context(), []string{oc.path}))
+	assertMessageContent(
+		t, env.db, "opencode:ses_overflow_repair",
+		"original prompt", "original answer",
+	)
+
+	stats = env.engine.SyncAll(t.Context(), nil)
+	require.False(t, stats.Aborted)
+	assert.Equal(t, 1, stats.Synced)
+	assertMessageContent(
+		t, env.db, "opencode:ses_overflow_repair",
+		"repaired prompt", "repaired answer",
+	)
+}
+
 func TestSyncEngineOpenCodeEventCommittedDuringFullSyncRemainsWatchable(
 	t *testing.T,
 ) {

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -817,6 +817,47 @@ func TestSyncEngineOpenCodeEventCommittedDuringFullSyncRemainsWatchable(
 	assertMessageContent(t, env.db, sessionID, "late prompt", "late answer")
 }
 
+func TestSyncEngineOpenCodeLiveEngineProcessesFirstPostStartupSettlement(
+	t *testing.T,
+) {
+	env := setupSingleAgentTestEnv(t, parser.AgentOpenCode)
+	oc := createOpenCodeDB(t, env.opencodeDir)
+	oc.addProject(t, "proj", "/home/user/code/opencode-app")
+	seedOpenCodeSQLiteTextSession(
+		t, oc, "proj", "ses_startup",
+		1779012000000, 1779012030000,
+		"original prompt", "original answer",
+	)
+
+	stats := env.engine.SyncAll(t.Context(), nil)
+	require.False(t, stats.Aborted)
+	parent := sync.NewEngine(env.db, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentOpenCode: {env.opencodeDir},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(parent.Close)
+	parent.InitializeOpenCodeWatchBaseline(t.Context())
+	require.NoError(t, parent.ReconcileWatchRoots(
+		t.Context(), []string{env.opencodeDir}, false,
+	))
+
+	oc.replaceTextContent(
+		t, "ses_startup", "first live prompt", "first live answer",
+		1779012000000,
+	)
+	oc.addEvent(
+		t, "evt_first_live", "ses_startup", "session.updated.1",
+		`{"time":1}`, 1,
+	)
+	parent.SyncPaths([]string{oc.path})
+	assertMessageContent(
+		t, env.db, "opencode:ses_startup",
+		"first live prompt", "first live answer",
+	)
+}
+
 // TestSyncEngineOpenCodeSQLiteUntouchedContainerSkipsReparse pins the
 // container-level freshness gate: when the shared opencode.db file is
 // completely untouched since the last verified sync, its sessions must be

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -7368,12 +7368,12 @@ func TestOpenCodeWatchCoalescesIntermediateEvents(t *testing.T) {
 		AgentDirs: map[parser.AgentType][]string{parser.AgentOpenCode: {root}},
 	})
 
-	assert.Empty(t, engine.classifyPaths([]string{dbPath}))
+	assert.Empty(t, requireClassifyPaths(t, engine, []string{dbPath}))
 	addOpenCodeSQLiteTestEvent(
 		t, dbPath, "evt_002", "ses_stream", "message.part.updated.1",
 		`{"time":2}`, 2,
 	)
-	assert.Empty(t, engine.classifyPaths([]string{dbPath}))
+	assert.Empty(t, requireClassifyPaths(t, engine, []string{dbPath}))
 
 	engine.openCodeWatchMu.Lock()
 	_, pending := engine.openCodeWatch[dbPath].pending["ses_stream"]
@@ -7384,7 +7384,7 @@ func TestOpenCodeWatchCoalescesIntermediateEvents(t *testing.T) {
 		t, dbPath, "evt_003", "ses_stream", "message.updated.1",
 		`{"info":{"role":"assistant","time":{"completed":3}}}`, 3,
 	)
-	files := engine.classifyPaths([]string{dbPath})
+	files := requireClassifyPaths(t, engine, []string{dbPath})
 	require.Len(t, files, 1)
 	assert.Equal(t, parser.OpenCodeSQLiteVirtualPath(dbPath, "ses_stream"), files[0].Path)
 }
@@ -7397,14 +7397,14 @@ func TestOpenCodeWatchJournalOverflowStaysBounded(t *testing.T) {
 	engine := NewEngine(database, EngineConfig{
 		AgentDirs: map[parser.AgentType][]string{parser.AgentOpenCode: {root}},
 	})
-	assert.Empty(t, engine.classifyPaths([]string{dbPath}))
+	assert.Empty(t, requireClassifyPaths(t, engine, []string{dbPath}))
 	for seq := 2; seq <= openCodeJournalBatchLimit+2; seq++ {
 		addOpenCodeSQLiteTestEvent(
 			t, dbPath, fmt.Sprintf("evt_%03d", seq), "ses_overflow",
 			"message.part.updated.1", `{"time":2}`, seq,
 		)
 	}
-	assert.Empty(t, engine.classifyPaths([]string{dbPath}))
+	assert.Empty(t, requireClassifyPaths(t, engine, []string{dbPath}))
 	engine.openCodeWatchMu.Lock()
 	state := engine.openCodeWatch[dbPath]
 	engine.openCodeWatchMu.Unlock()
@@ -7420,7 +7420,7 @@ func TestOpenCodeWatchPendingOverflowClearsState(t *testing.T) {
 	engine := NewEngine(database, EngineConfig{
 		AgentDirs: map[parser.AgentType][]string{parser.AgentOpenCode: {root}},
 	})
-	assert.Empty(t, engine.classifyPaths([]string{dbPath}))
+	assert.Empty(t, requireClassifyPaths(t, engine, []string{dbPath}))
 	for i := 0; i <= openCodePendingLimit; i++ {
 		addOpenCodeSQLiteTestEvent(
 			t, dbPath, fmt.Sprintf("evt-pending-%03d", i),
@@ -7428,7 +7428,7 @@ func TestOpenCodeWatchPendingOverflowClearsState(t *testing.T) {
 			`{"time":2}`, 1,
 		)
 	}
-	assert.Empty(t, engine.classifyPaths([]string{dbPath}))
+	assert.Empty(t, requireClassifyPaths(t, engine, []string{dbPath}))
 	engine.openCodeWatchMu.Lock()
 	state := engine.openCodeWatch[dbPath]
 	engine.openCodeWatchMu.Unlock()

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -7465,6 +7465,76 @@ func TestOpenCodeWatchPendingOverflowClearsState(t *testing.T) {
 	assert.Empty(t, state.pending)
 }
 
+func TestOpenCodeWatchLostEventReconciliationRebasesBeforeDiscovery(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "opencode.db")
+	seedOpenCodeSQLiteWALSession(t, dbPath, "ses_lost_events")
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentOpenCode: {root}},
+		Machine:   "local",
+	})
+	t.Cleanup(engine.Close)
+
+	stats := engine.SyncAll(t.Context(), nil)
+	require.Equal(t, 1, stats.Synced)
+	updatePart := func(content string) {
+		writer, err := sql.Open("sqlite3", dbPath)
+		require.NoError(t, err)
+		_, err = writer.Exec(
+			`UPDATE part SET data = ? WHERE id = 'part_1'`,
+			`{"type":"text","text":"`+content+`"}`,
+		)
+		require.NoError(t, err)
+		require.NoError(t, writer.Close())
+	}
+	updatePart("reconciled")
+	for seq := 2; seq <= openCodeJournalBatchLimit+1; seq++ {
+		addOpenCodeSQLiteTestEvent(
+			t, dbPath, fmt.Sprintf("evt_backlog_%03d", seq),
+			"ses_lost_events", "message.part.updated.1", `{"time":2}`, seq,
+		)
+	}
+
+	mutatedDuringReconciliation := false
+	engine.writeBatchOverride = func(
+		pending []pendingWrite, mode syncWriteMode, forceReplace bool,
+	) (int, int, int, int) {
+		outcome := engine.writeBatchWithOutcome(pending, mode, forceReplace)
+		if !mutatedDuringReconciliation {
+			mutatedDuringReconciliation = true
+			updatePart("during reconciliation")
+			addOpenCodeSQLiteTestEvent(
+				t, dbPath, "evt_during_reconciliation", "ses_lost_events",
+				"message.updated.1",
+				`{"info":{"role":"assistant","time":{"completed":3}}}`,
+				openCodeJournalBatchLimit+2,
+			)
+		}
+		return outcome.writtenSessions, outcome.writtenMessages,
+			outcome.failedSessions, outcome.cwdFiltered
+	}
+	require.NoError(t, engine.ReconcileWatchRootsAfterLostEvents(
+		t.Context(), []string{root}, false,
+	))
+	engine.writeBatchOverride = nil
+	require.True(t, mutatedDuringReconciliation)
+	messages, err := database.GetMessages(
+		t.Context(), "opencode:ses_lost_events", 0, 10, true,
+	)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Equal(t, "reconciled", messages[0].Content)
+
+	require.NoError(t, engine.SyncPathsContext(t.Context(), []string{dbPath}))
+	messages, err = database.GetMessages(
+		t.Context(), "opencode:ses_lost_events", 0, 10, true,
+	)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Equal(t, "during reconciliation", messages[0].Content)
+}
+
 func TestEngine_ClassifyPathsOpenCodeRemovedMessageFile(
 	t *testing.T,
 ) {

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -7389,6 +7389,36 @@ func TestOpenCodeWatchCoalescesIntermediateEvents(t *testing.T) {
 	assert.Equal(t, parser.OpenCodeSQLiteVirtualPath(dbPath, "ses_stream"), files[0].Path)
 }
 
+func TestOpenCodeWatchLaterIntermediateEventClearsReadiness(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "opencode.db")
+	seedOpenCodeSQLiteWALSession(t, dbPath, "ses_stream")
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentOpenCode: {root}},
+	})
+	engine.InitializeOpenCodeWatchBaseline(t.Context())
+
+	addOpenCodeSQLiteTestEvent(
+		t, dbPath, "evt_002", "ses_stream", "message.updated.1",
+		`{"info":{"role":"assistant","time":{"completed":2}}}`, 2,
+	)
+	addOpenCodeSQLiteTestEvent(
+		t, dbPath, "evt_003", "ses_stream", "message.part.updated.1",
+		`{"time":3}`, 3,
+	)
+	assert.Empty(t, requireClassifyPaths(t, engine, []string{dbPath}),
+		"a newer streaming event must supersede readiness from an earlier settlement")
+
+	addOpenCodeSQLiteTestEvent(
+		t, dbPath, "evt_004", "ses_stream", "message.updated.1",
+		`{"info":{"role":"assistant","time":{"completed":4}}}`, 4,
+	)
+	files := requireClassifyPaths(t, engine, []string{dbPath})
+	require.Len(t, files, 1)
+	assert.Equal(t, parser.OpenCodeSQLiteVirtualPath(dbPath, "ses_stream"), files[0].Path)
+}
+
 func TestOpenCodeWatchJournalOverflowStaysBounded(t *testing.T) {
 	database := openTestDB(t)
 	root := t.TempDir()
@@ -7433,58 +7463,6 @@ func TestOpenCodeWatchPendingOverflowClearsState(t *testing.T) {
 	state := engine.openCodeWatch[dbPath]
 	engine.openCodeWatchMu.Unlock()
 	assert.Empty(t, state.pending)
-}
-
-func TestOpenCodeWatchDiscardedResyncDoesNotAdvanceBaseline(t *testing.T) {
-	database := openTestDB(t)
-	root := t.TempDir()
-	dbPath := filepath.Join(root, "opencode.db")
-	seedOpenCodeSQLiteWALSession(t, dbPath, "ses_resync")
-	engine := NewEngine(database, EngineConfig{
-		AgentDirs: map[parser.AgentType][]string{parser.AgentOpenCode: {root}},
-		Machine:   "local",
-	})
-	t.Cleanup(engine.Close)
-
-	stats := engine.SyncAll(context.Background(), nil)
-	require.Zero(t, stats.Failed)
-	writer, err := sql.Open("sqlite3", dbPath)
-	require.NoError(t, err)
-	_, err = writer.Exec(`
-		UPDATE part SET data = '{"type":"text","text":"after failed resync"}'
-		WHERE id = 'part_1'
-	`)
-	require.NoError(t, err)
-	require.NoError(t, writer.Close())
-	addOpenCodeSQLiteTestEvent(
-		t, dbPath, "evt_002", "ses_resync", "session.updated.1",
-		`{"time":2}`, 2,
-	)
-
-	sentinel := errors.New("fts baseline sentinel")
-	engine.syncMu.Lock()
-	stats, err = engine.resyncAllWithOptionsLocked(
-		context.Background(), nil, RebuildOptions{}, rebuildOperations{
-			rebuildFTS: func(*db.DB) error { return sentinel },
-		},
-	)
-	engine.syncMu.Unlock()
-	require.ErrorIs(t, err, sentinel)
-	require.True(t, stats.Aborted)
-	messages, err := database.GetMessages(
-		context.Background(), "opencode:ses_resync", 0, 10, true,
-	)
-	require.NoError(t, err)
-	require.Len(t, messages, 1)
-	assert.Equal(t, "hello", messages[0].Content)
-
-	engine.SyncPaths([]string{dbPath})
-	messages, err = database.GetMessages(
-		context.Background(), "opencode:ses_resync", 0, 10, true,
-	)
-	require.NoError(t, err)
-	require.Len(t, messages, 1)
-	assert.Equal(t, "after failed resync", messages[0].Content)
 }
 
 func TestEngine_ClassifyPathsOpenCodeRemovedMessageFile(

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -50,6 +50,17 @@ func requireClassifyProviderChangedPath(
 	return files
 }
 
+func TestMergeChangedPathDiscoveredFilePreservesContentChange(t *testing.T) {
+	current := parser.SourceRef{Key: "session"}
+	next := parser.SourceRef{Key: "session", ContentChanged: true}
+	merged := mergeChangedPathDiscoveredFile(
+		parser.DiscoveredFile{ProviderSource: &current},
+		parser.DiscoveredFile{ProviderSource: &next},
+	)
+	require.NotNil(t, merged.ProviderSource)
+	assert.True(t, merged.ProviderSource.ContentChanged)
+}
+
 func TestClaudeIDFreshnessRejectsSourceMissingTombstone(t *testing.T) {
 	database := openTestDB(t)
 	root := t.TempDir()
@@ -7239,6 +7250,13 @@ func TestEngine_ClassifyPathsOpenCodeSQLiteWALFile(
 	require.NoError(t, err, "Stat(%q)", walPath)
 	require.Greater(t, walInfo.Size(), int64(32), "WAL must contain transaction frames")
 
+	// The first event establishes a disposable baseline and intentionally does
+	// not enumerate the existing container.
+	assert.Empty(t, requireClassifyPaths(t, engine, []string{walPath}))
+	addOpenCodeSQLiteTestEvent(
+		t, dbPath, "evt_002", "ses_wal", "message.updated.1",
+		`{"info":{"role":"user"}}`, 2,
+	)
 	files := requireClassifyPaths(t, engine, []string{walPath})
 	require.Len(t, files, 1)
 	assert.Equal(t,
@@ -7246,6 +7264,8 @@ func TestEngine_ClassifyPathsOpenCodeSQLiteWALFile(
 		files[0].Path,
 	)
 	assert.Equal(t, parser.AgentOpenCode, files[0].Agent)
+	require.NotNil(t, files[0].ProviderSource)
+	assert.True(t, files[0].ProviderSource.ContentChanged)
 }
 
 // seedOpenCodeSQLiteWALSession creates a minimal OpenCode-shaped SQLite
@@ -7280,6 +7300,19 @@ func seedOpenCodeSQLiteWALSession(t *testing.T, dbPath, sessionID string) {
 			data TEXT NOT NULL,
 			time_created INTEGER NOT NULL
 		);
+		CREATE TABLE event_sequence (
+			aggregate_id TEXT PRIMARY KEY,
+			seq INTEGER NOT NULL
+		);
+		CREATE TABLE event (
+			id TEXT PRIMARY KEY,
+			aggregate_id TEXT NOT NULL,
+			seq INTEGER NOT NULL,
+			type TEXT NOT NULL,
+			data TEXT NOT NULL
+		);
+		CREATE UNIQUE INDEX event_aggregate_seq_idx
+			ON event (aggregate_id, seq);
 	`)
 	require.NoError(t, err, "create opencode schema")
 	var journalMode string
@@ -7297,6 +7330,109 @@ func seedOpenCodeSQLiteWALSession(t *testing.T, dbPath, sessionID string) {
 		sessionID,
 	)
 	require.NoError(t, err, "insert session")
+	_, err = d.Exec(`
+		INSERT INTO message (id, session_id, data, time_created)
+		VALUES ('msg_1', ?, '{"role":"user"}', 1);
+		INSERT INTO part (id, session_id, message_id, data, time_created)
+		VALUES ('part_1', ?, 'msg_1', '{"type":"text","text":"hello"}', 1);
+		INSERT INTO event_sequence (aggregate_id, seq) VALUES (?, 1);
+		INSERT INTO event (id, aggregate_id, seq, type, data)
+		VALUES ('evt_001', ?, 1, 'session.created.1', '{"time":1}');
+	`, sessionID, sessionID, sessionID, sessionID)
+	require.NoError(t, err, "insert transcript and baseline event")
+}
+
+func addOpenCodeSQLiteTestEvent(
+	t *testing.T,
+	dbPath, eventID, sessionID, eventType, data string,
+	seq int,
+) {
+	t.Helper()
+	d, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	defer d.Close()
+	_, err = d.Exec(`
+		INSERT INTO event (id, aggregate_id, seq, type, data)
+		VALUES (?, ?, ?, ?, ?);
+		UPDATE event_sequence SET seq = ? WHERE aggregate_id = ?;
+	`, eventID, sessionID, seq, eventType, data, seq, sessionID)
+	require.NoError(t, err)
+}
+
+func TestOpenCodeWatchCoalescesIntermediateEvents(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "opencode.db")
+	seedOpenCodeSQLiteWALSession(t, dbPath, "ses_stream")
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentOpenCode: {root}},
+	})
+
+	assert.Empty(t, engine.classifyPaths([]string{dbPath}))
+	addOpenCodeSQLiteTestEvent(
+		t, dbPath, "evt_002", "ses_stream", "message.part.updated.1",
+		`{"time":2}`, 2,
+	)
+	assert.Empty(t, engine.classifyPaths([]string{dbPath}))
+
+	engine.openCodeWatchMu.Lock()
+	_, pending := engine.openCodeWatch[dbPath].pending["ses_stream"]
+	engine.openCodeWatchMu.Unlock()
+	assert.True(t, pending)
+
+	addOpenCodeSQLiteTestEvent(
+		t, dbPath, "evt_003", "ses_stream", "message.updated.1",
+		`{"info":{"role":"assistant","time":{"completed":3}}}`, 3,
+	)
+	files := engine.classifyPaths([]string{dbPath})
+	require.Len(t, files, 1)
+	assert.Equal(t, parser.OpenCodeSQLiteVirtualPath(dbPath, "ses_stream"), files[0].Path)
+}
+
+func TestOpenCodeWatchJournalOverflowStaysBounded(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "opencode.db")
+	seedOpenCodeSQLiteWALSession(t, dbPath, "ses_overflow")
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentOpenCode: {root}},
+	})
+	assert.Empty(t, engine.classifyPaths([]string{dbPath}))
+	for seq := 2; seq <= openCodeJournalBatchLimit+2; seq++ {
+		addOpenCodeSQLiteTestEvent(
+			t, dbPath, fmt.Sprintf("evt_%03d", seq), "ses_overflow",
+			"message.part.updated.1", `{"time":2}`, seq,
+		)
+	}
+	assert.Empty(t, engine.classifyPaths([]string{dbPath}))
+	engine.openCodeWatchMu.Lock()
+	state := engine.openCodeWatch[dbPath]
+	engine.openCodeWatchMu.Unlock()
+	assert.Empty(t, state.pending)
+	assert.Equal(t, int64(openCodeJournalBatchLimit+2), state.rowID)
+}
+
+func TestOpenCodeWatchPendingOverflowClearsState(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "opencode.db")
+	seedOpenCodeSQLiteWALSession(t, dbPath, "ses_initial")
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentOpenCode: {root}},
+	})
+	assert.Empty(t, engine.classifyPaths([]string{dbPath}))
+	for i := 0; i <= openCodePendingLimit; i++ {
+		addOpenCodeSQLiteTestEvent(
+			t, dbPath, fmt.Sprintf("evt-pending-%03d", i),
+			fmt.Sprintf("ses_pending_%03d", i), "message.part.updated.1",
+			`{"time":2}`, 1,
+		)
+	}
+	assert.Empty(t, engine.classifyPaths([]string{dbPath}))
+	engine.openCodeWatchMu.Lock()
+	state := engine.openCodeWatch[dbPath]
+	engine.openCodeWatchMu.Unlock()
+	assert.Empty(t, state.pending)
 }
 
 func TestEngine_ClassifyPathsOpenCodeRemovedMessageFile(

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -7435,6 +7435,58 @@ func TestOpenCodeWatchPendingOverflowClearsState(t *testing.T) {
 	assert.Empty(t, state.pending)
 }
 
+func TestOpenCodeWatchDiscardedResyncDoesNotAdvanceBaseline(t *testing.T) {
+	database := openTestDB(t)
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "opencode.db")
+	seedOpenCodeSQLiteWALSession(t, dbPath, "ses_resync")
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{parser.AgentOpenCode: {root}},
+		Machine:   "local",
+	})
+	t.Cleanup(engine.Close)
+
+	stats := engine.SyncAll(context.Background(), nil)
+	require.Zero(t, stats.Failed)
+	writer, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err)
+	_, err = writer.Exec(`
+		UPDATE part SET data = '{"type":"text","text":"after failed resync"}'
+		WHERE id = 'part_1'
+	`)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	addOpenCodeSQLiteTestEvent(
+		t, dbPath, "evt_002", "ses_resync", "session.updated.1",
+		`{"time":2}`, 2,
+	)
+
+	sentinel := errors.New("fts baseline sentinel")
+	engine.syncMu.Lock()
+	stats, err = engine.resyncAllWithOptionsLocked(
+		context.Background(), nil, RebuildOptions{}, rebuildOperations{
+			rebuildFTS: func(*db.DB) error { return sentinel },
+		},
+	)
+	engine.syncMu.Unlock()
+	require.ErrorIs(t, err, sentinel)
+	require.True(t, stats.Aborted)
+	messages, err := database.GetMessages(
+		context.Background(), "opencode:ses_resync", 0, 10, true,
+	)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Equal(t, "hello", messages[0].Content)
+
+	engine.SyncPaths([]string{dbPath})
+	messages, err = database.GetMessages(
+		context.Background(), "opencode:ses_resync", 0, 10, true,
+	)
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Equal(t, "after failed resync", messages[0].Content)
+}
+
 func TestEngine_ClassifyPathsOpenCodeRemovedMessageFile(
 	t *testing.T,
 ) {

--- a/internal/sync/opencode_watch.go
+++ b/internal/sync/opencode_watch.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"context"
 	"log"
+	"maps"
 	"os"
 	"path/filepath"
 	"sort"
@@ -161,8 +162,6 @@ func (e *Engine) rebaselineOpenCodeWatch(ctx context.Context) {
 	for dbPath := range e.openCodeWatch {
 		delete(e.openCodeWatch, dbPath)
 	}
-	for dbPath, state := range baselines {
-		e.openCodeWatch[dbPath] = state
-	}
+	maps.Copy(e.openCodeWatch, baselines)
 	e.openCodeWatchMu.Unlock()
 }

--- a/internal/sync/opencode_watch.go
+++ b/internal/sync/opencode_watch.go
@@ -83,6 +83,11 @@ func (e *Engine) classifyOpenCodeJournalPath(
 	}
 	state.rowID = batch.HighRowID
 	if !batch.Safe || batch.Overflow {
+		// Advancing past the range is deliberate. Retaining it would reread the
+		// same capped page on every later watcher event, while paging, retrying,
+		// or starting scoped reconciliation would recreate the cursor/retry
+		// subsystem rejected by #1208. Startup and the daily authoritative full
+		// sync repair sessions deferred by this bounded best-effort path.
 		state.pending = make(map[string]struct{})
 		e.openCodeWatch[dbPath] = state
 		e.openCodeWatchMu.Unlock()

--- a/internal/sync/opencode_watch.go
+++ b/internal/sync/opencode_watch.go
@@ -1,0 +1,168 @@
+package sync
+
+import (
+	"context"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+const (
+	openCodeJournalBatchLimit = 256
+	openCodePendingLimit      = 128
+)
+
+// openCodeWatchState is disposable watcher optimization state. Startup and
+// periodic full sync remain authoritative; this state never acknowledges
+// durable correctness and intentionally owns no retry timer.
+type openCodeWatchState struct {
+	rowID   int64
+	pending map[string]struct{}
+}
+
+func (e *Engine) classifyOpenCodeJournalPath(
+	ctx context.Context,
+	path, watchRoot string,
+	provider parser.Provider,
+) ([]parser.SourceRef, bool) {
+	root := filepath.Clean(watchRoot)
+	dbPath := filepath.Join(root, "opencode.db")
+	cleanPath := filepath.Clean(path)
+	if cleanPath != dbPath && cleanPath != dbPath+"-wal" {
+		return nil, false
+	}
+	if cleanPath == dbPath+"-wal" {
+		info, err := os.Stat(cleanPath)
+		if os.IsNotExist(err) || (err == nil && (info == nil || !info.Mode().IsRegular() || info.Size() <= 32)) {
+			return nil, true
+		}
+	}
+	if info, err := os.Stat(dbPath); err != nil || info == nil || !info.Mode().IsRegular() {
+		return nil, true
+	}
+	targeted, ok := provider.(parser.OpenCodeTargetedSourceProvider)
+	if !ok {
+		return nil, true
+	}
+
+	e.openCodeWatchMu.Lock()
+	state, initialized := e.openCodeWatch[dbPath]
+	if !initialized {
+		high, supported, err := parser.OpenCodeJournalHighWater(ctx, dbPath)
+		if err == nil && supported {
+			e.openCodeWatch[dbPath] = openCodeWatchState{
+				rowID: high, pending: make(map[string]struct{}),
+			}
+		}
+		e.openCodeWatchMu.Unlock()
+		if err != nil && ctx.Err() == nil {
+			log.Printf("opencode watcher baseline: %v", err)
+		}
+		return nil, true
+	}
+	batch, err := parser.ReadOpenCodeJournal(
+		ctx, dbPath, state.rowID, openCodeJournalBatchLimit,
+	)
+	if err != nil {
+		// A later event establishes a fresh baseline instead of retrying.
+		delete(e.openCodeWatch, dbPath)
+		e.openCodeWatchMu.Unlock()
+		if ctx.Err() == nil {
+			log.Printf("opencode watcher journal: %v", err)
+		}
+		return nil, true
+	}
+	if !batch.Supported {
+		delete(e.openCodeWatch, dbPath)
+		e.openCodeWatchMu.Unlock()
+		return nil, true
+	}
+	state.rowID = batch.HighRowID
+	if !batch.Safe || batch.Overflow {
+		state.pending = make(map[string]struct{})
+		e.openCodeWatch[dbPath] = state
+		e.openCodeWatchMu.Unlock()
+		return nil, true
+	}
+	ready := make(map[string]struct{})
+	for _, event := range batch.Events {
+		if event.Settlement {
+			ready[event.SessionID] = struct{}{}
+			delete(state.pending, event.SessionID)
+			continue
+		}
+		state.pending[event.SessionID] = struct{}{}
+		if len(state.pending) > openCodePendingLimit {
+			state.pending = make(map[string]struct{})
+			e.openCodeWatch[dbPath] = state
+			e.openCodeWatchMu.Unlock()
+			return nil, true
+		}
+	}
+	e.openCodeWatch[dbPath] = state
+	e.openCodeWatchMu.Unlock()
+	if len(ready) == 0 {
+		return nil, true
+	}
+
+	ids := make([]string, 0, len(ready))
+	for id := range ready {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	if parser.ResolveOpenCodeSource(root).Mode == parser.OpenCodeSourceStorage {
+		filtered := ids[:0]
+		for _, id := range ids {
+			virtualPath := parser.OpenCodeSQLiteVirtualPath(dbPath, id)
+			storedPath := e.db.GetSessionFilePath("opencode:" + id)
+			if storedPath == virtualPath {
+				filtered = append(filtered, id)
+			}
+			// A storage-backed canonical source is ignored. A new hybrid
+			// session is deferred until full discovery proves its canonical source.
+		}
+		ids = filtered
+	}
+	if len(ids) == 0 {
+		return nil, true
+	}
+	sources, err := targeted.OpenCodeSourcesForSessionIDs(ctx, dbPath, ids)
+	if err != nil {
+		if ctx.Err() == nil {
+			log.Printf("opencode watcher metadata: %v", err)
+		}
+		return nil, true
+	}
+	return sources, true
+}
+
+func (e *Engine) rebaselineOpenCodeWatch(ctx context.Context) {
+	baselines := make(map[string]openCodeWatchState)
+	for _, root := range e.agentDirs[parser.AgentOpenCode] {
+		if err := ctx.Err(); err != nil {
+			return
+		}
+		dbPath := parser.ResolveOpenCodeSource(filepath.Clean(root)).DBPath
+		if dbPath == "" {
+			continue
+		}
+		high, supported, err := parser.OpenCodeJournalHighWater(ctx, dbPath)
+		if err != nil || !supported {
+			continue
+		}
+		baselines[dbPath] = openCodeWatchState{
+			rowID: high, pending: make(map[string]struct{}),
+		}
+	}
+	e.openCodeWatchMu.Lock()
+	for dbPath := range e.openCodeWatch {
+		delete(e.openCodeWatch, dbPath)
+	}
+	for dbPath, state := range baselines {
+		e.openCodeWatch[dbPath] = state
+	}
+	e.openCodeWatchMu.Unlock()
+}

--- a/internal/sync/opencode_watch.go
+++ b/internal/sync/opencode_watch.go
@@ -95,6 +95,7 @@ func (e *Engine) classifyOpenCodeJournalPath(
 			delete(state.pending, event.SessionID)
 			continue
 		}
+		delete(ready, event.SessionID)
 		state.pending[event.SessionID] = struct{}{}
 		if len(state.pending) > openCodePendingLimit {
 			state.pending = make(map[string]struct{})
@@ -140,6 +141,17 @@ func (e *Engine) classifyOpenCodeJournalPath(
 	return sources, true
 }
 
+// InitializeOpenCodeWatchBaseline establishes the live engine's disposable
+// journal watermark before an authoritative startup reconciliation. Watcher
+// collection must already be active so events committed after this capture are
+// queued for dispatch.
+func (e *Engine) InitializeOpenCodeWatchBaseline(ctx context.Context) {
+	baselines, ok := e.captureOpenCodeWatchBaseline(ctx)
+	if ok {
+		e.installOpenCodeWatchBaseline(baselines)
+	}
+}
+
 func (e *Engine) captureOpenCodeWatchBaseline(
 	ctx context.Context,
 ) (map[string]openCodeWatchState, bool) {
@@ -151,6 +163,16 @@ func (e *Engine) captureOpenCodeWatchBaseline(
 		dbPath := parser.ResolveOpenCodeSource(filepath.Clean(root)).DBPath
 		if dbPath == "" {
 			continue
+		}
+		info, err := os.Stat(dbPath)
+		if os.IsNotExist(err) || (err == nil && (info == nil || !info.Mode().IsRegular())) {
+			continue
+		}
+		if err != nil {
+			if ctx.Err() == nil {
+				log.Printf("opencode watcher baseline stat: %v", err)
+			}
+			return nil, false
 		}
 		high, supported, err := parser.OpenCodeJournalHighWater(ctx, dbPath)
 		if err != nil {

--- a/internal/sync/opencode_watch.go
+++ b/internal/sync/opencode_watch.go
@@ -140,24 +140,38 @@ func (e *Engine) classifyOpenCodeJournalPath(
 	return sources, true
 }
 
-func (e *Engine) rebaselineOpenCodeWatch(ctx context.Context) {
+func (e *Engine) captureOpenCodeWatchBaseline(
+	ctx context.Context,
+) (map[string]openCodeWatchState, bool) {
 	baselines := make(map[string]openCodeWatchState)
 	for _, root := range e.agentDirs[parser.AgentOpenCode] {
 		if err := ctx.Err(); err != nil {
-			return
+			return nil, false
 		}
 		dbPath := parser.ResolveOpenCodeSource(filepath.Clean(root)).DBPath
 		if dbPath == "" {
 			continue
 		}
 		high, supported, err := parser.OpenCodeJournalHighWater(ctx, dbPath)
-		if err != nil || !supported {
+		if err != nil {
+			if ctx.Err() == nil {
+				log.Printf("opencode watcher full-sync baseline: %v", err)
+			}
+			return nil, false
+		}
+		if !supported {
 			continue
 		}
 		baselines[dbPath] = openCodeWatchState{
 			rowID: high, pending: make(map[string]struct{}),
 		}
 	}
+	return baselines, true
+}
+
+func (e *Engine) installOpenCodeWatchBaseline(
+	baselines map[string]openCodeWatchState,
+) {
 	e.openCodeWatchMu.Lock()
 	for dbPath := range e.openCodeWatch {
 		delete(e.openCodeWatch, dbPath)

--- a/internal/sync/opencode_watch.go
+++ b/internal/sync/opencode_watch.go
@@ -160,10 +160,22 @@ func (e *Engine) InitializeOpenCodeWatchBaseline(ctx context.Context) {
 func (e *Engine) captureOpenCodeWatchBaseline(
 	ctx context.Context,
 ) (map[string]openCodeWatchState, bool) {
+	return e.captureOpenCodeWatchBaselineForScope(ctx, nil)
+}
+
+func (e *Engine) captureOpenCodeWatchBaselineForScope(
+	ctx context.Context, scope *rootSyncScope,
+) (map[string]openCodeWatchState, bool) {
 	baselines := make(map[string]openCodeWatchState)
+	if !scope.matchesAgent(parser.AgentOpenCode) {
+		return baselines, true
+	}
 	for _, root := range e.agentDirs[parser.AgentOpenCode] {
 		if err := ctx.Err(); err != nil {
 			return nil, false
+		}
+		if !scope.includes(root) {
+			continue
 		}
 		dbPath := parser.ResolveOpenCodeSource(filepath.Clean(root)).DBPath
 		if dbPath == "" {
@@ -203,6 +215,14 @@ func (e *Engine) installOpenCodeWatchBaseline(
 	for dbPath := range e.openCodeWatch {
 		delete(e.openCodeWatch, dbPath)
 	}
+	maps.Copy(e.openCodeWatch, baselines)
+	e.openCodeWatchMu.Unlock()
+}
+
+func (e *Engine) mergeOpenCodeWatchBaseline(
+	baselines map[string]openCodeWatchState,
+) {
+	e.openCodeWatchMu.Lock()
 	maps.Copy(e.openCodeWatch, baselines)
 	e.openCodeWatchMu.Unlock()
 }

--- a/internal/sync/test_helpers_test.go
+++ b/internal/sync/test_helpers_test.go
@@ -228,6 +228,19 @@ const openCodeLikeSchema = `
 		data TEXT NOT NULL,
 		time_created INTEGER NOT NULL
 	);
+	CREATE TABLE event_sequence (
+		aggregate_id TEXT PRIMARY KEY,
+		seq INTEGER NOT NULL
+	);
+	CREATE TABLE event (
+		id TEXT PRIMARY KEY,
+		aggregate_id TEXT NOT NULL,
+		seq INTEGER NOT NULL,
+		type TEXT NOT NULL,
+		data TEXT NOT NULL
+	);
+	CREATE UNIQUE INDEX event_aggregate_seq_idx
+		ON event (aggregate_id, seq);
 `
 
 const kiroSQLiteSchema = `
@@ -487,6 +500,18 @@ func (oc *openCodeTestDB) updateMessageData(
 		"UPDATE message SET data = ? WHERE id = ?",
 		string(raw), id,
 	)
+}
+
+func (oc *openCodeTestDB) addEvent(
+	t *testing.T, id, sessionID, eventType, data string, seq int,
+) {
+	t.Helper()
+	oc.mustExec(t, "insert event", `
+		INSERT INTO event_sequence (aggregate_id, seq) VALUES (?, ?)
+		ON CONFLICT (aggregate_id) DO UPDATE SET seq = excluded.seq;
+		INSERT INTO event (id, aggregate_id, seq, type, data)
+		VALUES (?, ?, ?, ?, ?)
+	`, sessionID, seq, id, sessionID, seq, eventType, data)
 }
 
 func (oc *openCodeTestDB) addTextPart(


### PR DESCRIPTION
**Problem**

During active OpenCode use, agentsview repeatedly consumed roughly 244% to 937% CPU. Profiling showed 89.5% of CPU time under OpenCode SQLite parsing: each write to `opencode.db` or its WAL was expanded to every virtual session, while streamed part updates repeatedly reparsed the active session's full transcript. Watcher work therefore scaled with archive size and transcript history instead of the changed batch.

**Fix**

OpenCode watcher events now use a capped journal range read and targeted metadata lookup. Intermediate message and part events are held in a bounded, process-local pending set; user messages, completed or failed assistant messages, and session events settle the session and trigger one targeted parse. Journal-selected sources bypass coarse freshness checks while retaining post-parse content fingerprint filtering and hybrid storage shadowing.

This deliberately replaces #1189's durable cursor acknowledgement, quiet-period scheduler, and retry subsystem. Live watcher sync is a bounded best-effort optimization with no persisted state or timers; startup and periodic full sync remain the authoritative repair path for overflow, incompatible schemas, transient failures, and deferred hybrid sessions.

Closes #1208.