### PR TITLE
fix(recall): chunk evidence hydration queries

### DIFF
--- a/internal/db/recall.go
+++ b/internal/db/recall.go
@@ -1428,30 +1428,36 @@ func (db *DB) listRecallEvidence(
 	if len(ids) == 0 {
 		return result, nil
 	}
-	args := make([]any, len(ids))
-	for i, id := range ids {
-		args[i] = id
-	}
-	rows, err := db.getReader().QueryContext(ctx, `
-		SELECT id, entry_id, session_id, message_start_ordinal,
-			message_end_ordinal, message_start_source_uuid,
-			message_end_source_uuid, content_digest, tool_use_id, snippet
-		FROM recall_evidence
-		WHERE entry_id IN (`+listPlaceholders(len(ids))+`)
-		ORDER BY entry_id ASC, id ASC`, args...)
-	if err != nil {
-		return nil, fmt.Errorf("querying recall evidence: %w", err)
-	}
-	defer rows.Close()
-
-	for rows.Next() {
-		e, err := scanRecallEvidenceRow(rows)
-		if err != nil {
-			return nil, fmt.Errorf("scanning recall evidence: %w", err)
+	err := queryChunked(ids, func(chunk []string) error {
+		args := make([]any, len(chunk))
+		for i, id := range chunk {
+			args[i] = id
 		}
-		result[e.EntryID] = append(result[e.EntryID], e)
+		rows, err := db.getReader().QueryContext(ctx, `
+			SELECT id, entry_id, session_id, message_start_ordinal,
+				message_end_ordinal, message_start_source_uuid,
+				message_end_source_uuid, content_digest, tool_use_id, snippet
+			FROM recall_evidence
+			WHERE entry_id IN (`+listPlaceholders(len(chunk))+`)
+			ORDER BY entry_id ASC, id ASC`, args...)
+		if err != nil {
+			return fmt.Errorf("querying recall evidence: %w", err)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			e, err := scanRecallEvidenceRow(rows)
+			if err != nil {
+				return fmt.Errorf("scanning recall evidence: %w", err)
+			}
+			result[e.EntryID] = append(result[e.EntryID], e)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
 	}
-	return result, rows.Err()
+	return result, nil
 }
 
 func toCoreRecallEntries(entries []RecallEntry) []corerecall.Entry {

--- a/internal/db/recall_test.go
+++ b/internal/db/recall_test.go
@@ -2359,6 +2359,43 @@ func TestQueryRecallEntriesHonorsStatusFilter(t *testing.T) {
 	assert.Equal(t, "arc", page.RecallEntries[0].ID)
 }
 
+func TestListRecallEvidenceHydratesMoreThanSQLiteBindLimit(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "s1", "agentsview")
+
+	const entryCount = 33_000
+	entryIDs := make([]string, entryCount)
+	for i := range entryIDs {
+		entryIDs[i] = fmt.Sprintf("entry-%05d", i)
+	}
+	for _, entryID := range []string{entryIDs[0], entryIDs[len(entryIDs)-1]} {
+		_, err := d.InsertRecallEntry(RecallEntry{
+			ID:              entryID,
+			Type:            "fact",
+			Scope:           "project",
+			Status:          "accepted",
+			Title:           "Large evidence hydration",
+			Body:            "Evidence remains available across large candidate sets.",
+			SourceSessionID: "s1",
+			Evidence: []RecallEvidence{{
+				SessionID:           "s1",
+				MessageStartOrdinal: 1,
+				MessageEndOrdinal:   2,
+				Snippet:             entryID,
+			}},
+		})
+		require.NoError(t, err)
+	}
+
+	evidence, err := d.listRecallEvidence(context.Background(), entryIDs)
+	require.NoError(t, err)
+	require.Len(t, evidence, 2)
+	for _, entryID := range []string{entryIDs[0], entryIDs[len(entryIDs)-1]} {
+		require.Len(t, evidence[entryID], 1)
+		assert.Equal(t, entryID, evidence[entryID][0].Snippet)
+	}
+}
+
 func TestVacuumPreservesRecallEntriesFTSSearchable(t *testing.T) {
 	d := testDB(t)
 	ctx := context.Background()


### PR DESCRIPTION
Large recall candidate sets could exceed SQLite’s bind-variable limit when evidence was hydrated in one query, causing otherwise valid recall queries to fail.

Evidence hydration now uses the existing bounded query helper and accumulates each chunk into the same result map. This preserves evidence ordering within each entry while bounding the number of variables in every query. The regression covers a candidate set above SQLite’s default bind limit with evidence at both ends.