### PR TITLE
feat(recall): add hybrid vector retrieval

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -344,6 +344,9 @@ GitHub Actions service container in `.github/workflows/ci.yml`.
 
 ## Pull Requests
 
+- Do not poll or watch GitHub Actions checks unless the developer explicitly
+  requests it.
+- Do not use `gh api` to watch CI jobs unless the user explicitly requests it.
 - PR descriptions should be summaries only, with no test plans or checklists. Do
   not add a "Tests", "Testing", "Verification", or "Test plan" section. CI
   runs the tests, so the description must not restate the suite, list test

--- a/cmd/agentsview/embed_scheduler.go
+++ b/cmd/agentsview/embed_scheduler.go
@@ -213,7 +213,10 @@ func (s *embedScheduler) Run(ctx context.Context) {
 						pendingRelease()
 						pendingRelease = nil
 					}
-					pendingBackstop = false
+					// A failed full reconciliation remains owed. Stop automatic
+					// retries and release the lease, but let the next fresh
+					// notification carry Backstop: true instead of deferring the
+					// full pass until the next periodic tick.
 					buildErrorRetries = 0
 					continue
 				}
@@ -395,7 +398,7 @@ func (a recallSearcherAdapter) SearchRecall(
 		ctx, identity.generationFingerprint, identity.revision,
 	)
 	if err != nil {
-		return nil, false, translateSearchError(err)
+		return nil, false, translateRecallSearchError(err)
 	}
 	if stale {
 		return nil, false, fmt.Errorf(
@@ -405,13 +408,13 @@ func (a recallSearcherAdapter) SearchRecall(
 	}
 	hits, exhausted, err := a.ix.SearchPage(ctx, a.enc, query, limit)
 	if err != nil {
-		return nil, false, translateSearchError(err)
+		return nil, false, translateRecallSearchError(err)
 	}
 	stale, err = a.ix.StaleActive(
 		ctx, identity.generationFingerprint, identity.revision,
 	)
 	if err != nil {
-		return nil, false, translateSearchError(err)
+		return nil, false, translateRecallSearchError(err)
 	}
 	if stale {
 		return nil, false, fmt.Errorf(
@@ -532,6 +535,29 @@ func translateSearchError(err error) error {
 		return fmt.Errorf("%w: %w", db.ErrSemanticTransient, queryEncErr.Err)
 	default:
 		return err
+	}
+}
+
+// translateRecallSearchError preserves the shared semantic error taxonomy but
+// replaces message-store build guidance with Recall's explicit store selector.
+func translateRecallSearchError(err error) error {
+	var buildingErr *vector.BuildingError
+	switch {
+	case errors.As(err, &buildingErr):
+		return db.NewSemanticUnavailableError(fmt.Sprintf(
+			"recall index is building: %d%% complete", buildingErr.Percent,
+		))
+	case errors.Is(err, vector.ErrMirrorVersionMismatch):
+		return db.NewSemanticUnavailableError(fmt.Sprintf(
+			"%v; rebuild the recall index with 'agentsview embeddings build --store recall'",
+			err,
+		))
+	case errors.Is(err, vector.ErrNoActiveGeneration):
+		return db.NewSemanticUnavailableError(
+			"recall index has not been built; run 'agentsview embeddings build --store recall'",
+		)
+	default:
+		return translateSearchError(err)
 	}
 }
 

--- a/cmd/agentsview/embed_scheduler.go
+++ b/cmd/agentsview/embed_scheduler.go
@@ -238,8 +238,18 @@ func (s *embedScheduler) Run(ctx context.Context) {
 			pendingBackstop = false
 			buildErrorRetries = 0
 		case <-backstopC:
-			// A periodic reconciliation is a new work item with its own
-			// bounded error retry.
+			if buildErrorRetries > 0 {
+				// A failed work item already owns the retained lease and
+				// retry timer. Fold the periodic reconciliation into it
+				// without restarting its bounded retry; otherwise a backstop
+				// interval shorter than debounce can postpone exhaustion
+				// forever. Healthy pending work may still be satisfied by a
+				// backstop before its ordinary debounce expires.
+				pendingBackstop = true
+				continue
+			}
+			// With no error retry pending, a periodic reconciliation gets a
+			// fresh attempt and bounded retry lifecycle.
 			buildErrorRetries = 0
 			release, ok := s.idle.BeginWork()
 			if !ok {

--- a/cmd/agentsview/embed_scheduler.go
+++ b/cmd/agentsview/embed_scheduler.go
@@ -63,6 +63,12 @@ func acquireVectorsWriteLockWithRetry(
 // waits, after the last sync-completion signal, before running a build.
 const embedDebounceInterval = 30 * time.Second
 
+// embedBuildErrorRetryLimit bounds retries for one scheduled work item. A
+// fresh notification, backstop tick, or daemon restart gets a fresh attempt;
+// repeated errors release the idle lease so a permanent provider or
+// configuration failure cannot keep a detached daemon alive indefinitely.
+const embedBuildErrorRetryLimit = 1
+
 // embedManager is the subset of *vector.Manager the scheduler needs,
 // letting tests substitute a fake that records TryBuild calls instead of
 // driving a real build.
@@ -79,13 +85,16 @@ type embedScheduler struct {
 	mgr      embedManager
 	debounce time.Duration
 	backstop time.Duration
+	// idle keeps queued debounce work and active builds alive in detached
+	// daemon mode. Nil is a no-op tracker for foreground mode.
+	idle *server.IdleTracker
 	// includeAutomated is the configured [vector].include_automated scope,
 	// carried into every scheduler-driven BuildRequest so scheduled builds
 	// stay config-authoritative rather than drifting from a CLI-only
 	// override (see EmbeddingsBuildOptions.IncludeAutomatedSet).
 	includeAutomated bool
 
-	dirty chan struct{}
+	dirty chan func()
 	stop  chan struct{}
 	done  chan struct{}
 }
@@ -94,13 +103,17 @@ type embedScheduler struct {
 // periodic backstop ticker entirely, leaving only the after-sync debounce
 // path. includeAutomated is the configured [vector].include_automated scope
 // applied to every build this scheduler triggers.
-func newEmbedScheduler(mgr embedManager, debounce, backstop time.Duration, includeAutomated bool) *embedScheduler {
+func newEmbedScheduler(
+	mgr embedManager, debounce, backstop time.Duration, includeAutomated bool,
+	idle *server.IdleTracker,
+) *embedScheduler {
 	return &embedScheduler{
 		mgr:              mgr,
 		debounce:         debounce,
 		backstop:         backstop,
+		idle:             idle,
 		includeAutomated: includeAutomated,
-		dirty:            make(chan struct{}, 1),
+		dirty:            make(chan func(), 1),
 		stop:             make(chan struct{}),
 		done:             make(chan struct{}),
 	}
@@ -108,11 +121,17 @@ func newEmbedScheduler(mgr embedManager, debounce, backstop time.Duration, inclu
 
 // Notify signals that new data may need embedding. It never blocks: dirty
 // has capacity 1, so a burst of calls while Run is busy (or not yet
-// started) coalesces into a single pending signal.
+// started) coalesces into a single pending signal. The queued signal carries
+// an idle work lease so a startup build cannot be reaped during its debounce.
 func (s *embedScheduler) Notify() {
+	release, ok := s.idle.BeginWork()
+	if !ok {
+		return
+	}
 	select {
-	case s.dirty <- struct{}{}:
+	case s.dirty <- release:
 	default:
+		release()
 	}
 }
 
@@ -141,14 +160,27 @@ func (s *embedScheduler) Run(ctx context.Context) {
 		backstopC = ticker.C
 	}
 
-	// pendingBackstop remembers a backstop tick that collided with a build
-	// already running elsewhere (a long manual `embeddings build`, or the
-	// HTTP API) and so was dropped: without it, that reconciliation pass
-	// would be silently deferred until the next backstop tick (24h by
-	// default) instead of running as soon as any build slot frees up. It
-	// is read and written only from this single goroutine, so it needs no
-	// synchronization of its own.
+	// pendingBackstop remembers a backstop tick that collided with another
+	// build or failed transiently. Without it, that reconciliation pass would
+	// be silently deferred until the next backstop tick (24h by default)
+	// instead of retrying on the debounce interval. It is read and written only
+	// from this single goroutine, so it needs no synchronization of its own.
 	var pendingBackstop bool
+	var pendingRelease func()
+	var buildErrorRetries int
+	defer func() {
+		if pendingRelease != nil {
+			pendingRelease()
+		}
+		for {
+			select {
+			case release := <-s.dirty:
+				release()
+			default:
+				return
+			}
+		}
+	}()
 
 	for {
 		select {
@@ -156,41 +188,90 @@ func (s *embedScheduler) Run(ctx context.Context) {
 			return
 		case <-s.stop:
 			return
-		case <-s.dirty:
+		case release := <-s.dirty:
+			// A new mutation is a new work item, even if an earlier attempt is
+			// still waiting to retry.
+			buildErrorRetries = 0
+			if pendingRelease == nil {
+				pendingRelease = release
+			} else {
+				// One pending lease already spans the debounce. The new
+				// lease closed the handoff gap while Notify queued this
+				// signal, but retaining both would over-count the same
+				// coalesced work.
+				release()
+			}
 			resetTimer(debounceTimer, s.debounce)
 		case <-debounceTimer.C:
 			req := vector.BuildRequest{Backstop: pendingBackstop, IncludeAutomated: s.includeAutomated}
 			started, err := s.mgr.TryBuild(ctx, req)
 			if err != nil {
 				log.Printf("embed scheduler: build failed: %v", err)
-			}
-			if !started {
-				// A build was already running elsewhere; re-arm rather
-				// than drop the pass entirely. pendingBackstop, if set,
-				// stays set so the retry still carries it.
+				if buildErrorRetries >= embedBuildErrorRetryLimit {
+					log.Printf("embed scheduler: retry limit reached; deferring until new work")
+					if pendingRelease != nil {
+						pendingRelease()
+						pendingRelease = nil
+					}
+					pendingBackstop = false
+					buildErrorRetries = 0
+					continue
+				}
+				buildErrorRetries++
 				resetTimer(debounceTimer, s.debounce)
 				continue
 			}
-			// Only clear a carried backstop once the build both started and
-			// succeeded: a started-but-failed build (started=true, err!=nil)
-			// never actually ran the full reconciliation it carried, so
-			// clearing pendingBackstop here would silently defer that
-			// reconciliation to the next backstop tick (24h by default)
-			// instead of retrying on the very next debounced build.
-			if err == nil {
-				pendingBackstop = false
+			if !started {
+				// A collision leaves the scheduled work pending. Keep its
+				// idle lease and retry without requiring another external
+				// notification.
+				resetTimer(debounceTimer, s.debounce)
+				continue
 			}
+			if pendingRelease != nil {
+				pendingRelease()
+				pendingRelease = nil
+			}
+			pendingBackstop = false
+			buildErrorRetries = 0
 		case <-backstopC:
+			// A periodic reconciliation is a new work item with its own
+			// bounded error retry.
+			buildErrorRetries = 0
+			release, ok := s.idle.BeginWork()
+			if !ok {
+				continue
+			}
 			started, err := s.mgr.TryBuild(ctx,
 				vector.BuildRequest{Backstop: true, IncludeAutomated: s.includeAutomated})
 			if err != nil {
 				log.Printf("embed scheduler: backstop build failed: %v", err)
+				buildErrorRetries++
 			}
-			// Same started-but-failed rule as the debounced path above:
-			// a build that started but errored never completed its
-			// reconciliation, so the pass must still be retried rather
-			// than deferred to the next backstop tick.
-			pendingBackstop = !started || err != nil
+			if !started || err != nil {
+				pendingBackstop = true
+				if pendingRelease == nil {
+					// Retain the backstop's work lease across the retry
+					// interval so a detached daemon cannot idle out.
+					pendingRelease = release
+				} else {
+					release()
+				}
+				resetTimer(debounceTimer, s.debounce)
+				continue
+			}
+
+			release()
+			pendingBackstop = false
+			if pendingRelease != nil {
+				// This successful full reconciliation also satisfies work
+				// that was already pending before the backstop began. A
+				// Notify queued during the build carries its own lease and
+				// will re-arm the timer when the loop receives it.
+				pendingRelease()
+				pendingRelease = nil
+				stopTimer(debounceTimer)
+			}
 		}
 	}
 }
@@ -224,6 +305,38 @@ type teeEmitter struct {
 	runAfterSync bool
 }
 
+// notifyTeeEmitter fans a successful sync event out to another bounded
+// background consumer after preserving the primary emitter's delivery.
+type notifyTeeEmitter struct {
+	primary sync.Emitter
+	notify  func()
+}
+
+func (t notifyTeeEmitter) Emit(scope string) {
+	t.primary.Emit(scope)
+	t.notify()
+}
+
+// wrapEmbeddingSyncEmitter connects successful sync and resync events to both
+// embedding stores. Recall refreshes cannot depend on extraction being enabled:
+// a resync can journal removed Recall entries while copying the durable corpus.
+func wrapEmbeddingSyncEmitter(
+	primary sync.Emitter, serving vectorServing, runAfterSync bool,
+) sync.Emitter {
+	if serving.Scheduler != nil {
+		primary = teeEmitter{
+			primary: primary, scheduler: serving.Scheduler,
+			runAfterSync: runAfterSync,
+		}
+	}
+	if serving.RecallMutationNotify != nil {
+		primary = notifyTeeEmitter{
+			primary: primary, notify: serving.RecallMutationNotify,
+		}
+	}
+	return primary
+}
+
 func (t teeEmitter) Emit(scope string) {
 	t.primary.Emit(scope)
 	if t.runAfterSync {
@@ -240,6 +353,89 @@ type searcherAdapter struct {
 	fingerprint string
 }
 
+type recallSearcherAdapter struct {
+	ix       *vector.Index
+	enc      kitvec.EncodeFunc
+	database *db.DB
+	cfg      config.Config
+}
+
+type recallSearchCorpusIdentity struct {
+	generationFingerprint string
+	revision              string
+}
+
+func (a recallSearcherAdapter) corpusIdentity(
+	ctx context.Context,
+) (recallSearchCorpusIdentity, error) {
+	extractionFingerprint, err := recallCorpusFingerprint(ctx, a.database)
+	if err != nil {
+		return recallSearchCorpusIdentity{}, err
+	}
+	revision, err := a.database.RecallCorpusRevision(ctx)
+	if err != nil {
+		return recallSearchCorpusIdentity{}, err
+	}
+	return recallSearchCorpusIdentity{
+		generationFingerprint: recallVectorGeneration(
+			a.cfg.Vector.Embeddings, extractionFingerprint,
+		).Fingerprint(),
+		revision: revision,
+	}, nil
+}
+
+func (a recallSearcherAdapter) SearchRecall(
+	ctx context.Context, query string, limit int,
+) ([]db.RecallVectorHit, bool, error) {
+	identity, err := a.corpusIdentity(ctx)
+	if err != nil {
+		return nil, false, fmt.Errorf("%w: %v", db.ErrSemanticUnavailable, err)
+	}
+	stale, err := a.ix.StaleActive(
+		ctx, identity.generationFingerprint, identity.revision,
+	)
+	if err != nil {
+		return nil, false, translateSearchError(err)
+	}
+	if stale {
+		return nil, false, fmt.Errorf(
+			"%w: recall index is stale: run 'agentsview embeddings build --store recall'",
+			db.ErrSemanticUnavailable,
+		)
+	}
+	hits, exhausted, err := a.ix.SearchPage(ctx, a.enc, query, limit)
+	if err != nil {
+		return nil, false, translateSearchError(err)
+	}
+	stale, err = a.ix.StaleActive(
+		ctx, identity.generationFingerprint, identity.revision,
+	)
+	if err != nil {
+		return nil, false, translateSearchError(err)
+	}
+	if stale {
+		return nil, false, fmt.Errorf(
+			"%w: recall index changed during search; retry the query",
+			db.ErrSemanticUnavailable,
+		)
+	}
+	currentIdentity, err := a.corpusIdentity(ctx)
+	if err != nil {
+		return nil, false, fmt.Errorf("%w: %v", db.ErrSemanticUnavailable, err)
+	}
+	if currentIdentity != identity {
+		return nil, false, fmt.Errorf(
+			"%w: recall corpus changed during search; retry after the recall index refreshes",
+			db.ErrSemanticUnavailable,
+		)
+	}
+	out := make([]db.RecallVectorHit, len(hits))
+	for i, hit := range hits {
+		out[i] = db.RecallVectorHit{EntryID: hit.SessionID, Score: hit.Score}
+	}
+	return out, exhausted, nil
+}
+
 // newSearcherAdapter builds a searcherAdapter for gen's configured
 // embedding identity.
 func newSearcherAdapter(ix *vector.Index, enc kitvec.EncodeFunc, gen kitvec.Generation) searcherAdapter {
@@ -253,7 +449,7 @@ func newSearcherAdapter(ix *vector.Index, enc kitvec.EncodeFunc, gen kitvec.Gene
 func (a searcherAdapter) SemanticSearch(
 	ctx context.Context, query string, limit int,
 ) ([]db.VectorHit, error) {
-	stale, err := a.ix.StaleActive(ctx, a.fingerprint)
+	stale, err := a.ix.StaleActive(ctx, a.fingerprint, "")
 	if err != nil {
 		// StaleActive shares Search's error taxonomy (notably
 		// vector.ErrMirrorVersionMismatch from a version-mismatched
@@ -343,9 +539,11 @@ func translateSearchError(err error) error {
 // into the daemon. All fields are zero when [vector] is disabled, so
 // callers can treat it uniformly without a separate enabled check.
 type vectorServing struct {
-	ServerOpts []server.Option
-	Scheduler  *embedScheduler
-	Close      func() error
+	ServerOpts           []server.Option
+	Scheduler            *embedScheduler
+	RecallScheduler      *embedScheduler
+	RecallMutationNotify func()
+	Close                func() error
 }
 
 // setupVectorServing acquires vectors.write.lock, opens vectors.db
@@ -364,6 +562,7 @@ type vectorServing struct {
 // a warning — rather than blocking or failing daemon startup.
 func setupVectorServing(
 	ctx context.Context, cfg config.Config, database *db.DB,
+	idle *server.IdleTracker,
 ) (vectorServing, error) {
 	if !cfg.Vector.Enabled {
 		return vectorServing{}, nil
@@ -392,16 +591,28 @@ func setupVectorServing(
 		}}, nil
 	}
 
-	ix, err := vector.Open(
-		ctx, cfg.Vector.ResolvedDBPath(cfg.DataDir), false, cfg.Vector.Embeddings.MaxInputChars,
+	path := cfg.Vector.ResolvedDBPath(cfg.DataDir)
+	ix, err := vector.OpenSpec(
+		ctx, path, vector.MessageIndexSpec(), false,
+		cfg.Vector.Embeddings.MaxInputChars,
 	)
 	if err != nil {
 		_ = lock.Close()
 		return vectorServing{}, fmt.Errorf("opening vectors.db: %w", err)
 	}
+	recallIX, err := vector.OpenSpec(
+		ctx, path, vector.RecallIndexSpec(), false,
+		cfg.Vector.Embeddings.MaxInputChars,
+	)
+	if err != nil {
+		ix.Close()
+		_ = lock.Close()
+		return vectorServing{}, fmt.Errorf("opening recall vectors: %w", err)
+	}
 
 	encoders, err := vectorDocumentEncoderSet(cfg.Vector.Embeddings)
 	if err != nil {
+		recallIX.Close()
 		ix.Close()
 		_ = lock.Close()
 		return vectorServing{}, err
@@ -410,6 +621,7 @@ func setupVectorServing(
 	// pick any named entry via BuildRequest.Using.
 	queryEnc, err := newVectorQueryEncoder(cfg.Vector.Embeddings, "")
 	if err != nil {
+		recallIX.Close()
 		ix.Close()
 		_ = lock.Close()
 		return vectorServing{}, err
@@ -417,6 +629,7 @@ func setupVectorServing(
 
 	backstop, err := time.ParseDuration(cfg.Vector.Embed.BackstopInterval)
 	if err != nil {
+		recallIX.Close()
 		ix.Close()
 		_ = lock.Close()
 		return vectorServing{}, fmt.Errorf(
@@ -426,24 +639,67 @@ func setupVectorServing(
 
 	gen := vectorGeneration(cfg.Vector.Embeddings)
 	mgr := vector.NewManager(ix, database, encoders, gen)
+	recallMgr := embeddingManager(
+		recallIX, database, encoders, cfg, vector.RecallIndexSpec().Name,
+	)
 	database.SetVectorSearcher(newSearcherAdapter(ix, queryEnc, gen))
-	scheduler := newEmbedScheduler(mgr, embedDebounceInterval, backstop, cfg.Vector.IncludeAutomated)
+	database.SetRecallVectorSearcher(recallSearcherAdapter{
+		ix: recallIX, enc: queryEnc, database: database, cfg: cfg,
+	})
+	scheduler := newEmbedScheduler(
+		mgr, embedDebounceInterval, backstop, cfg.Vector.IncludeAutomated, idle,
+	)
+	recallScheduler := newEmbedScheduler(
+		recallMgr, embedDebounceInterval, recallBackstop(cfg, backstop), false, idle,
+	)
+	serverOpts := []server.Option{
+		server.WithEmbeddingsManager(mgr),
+		server.WithEmbeddingsStoreManager(
+			vector.RecallIndexSpec().Name, recallMgr,
+		),
+		server.WithEmbeddingsIncludeAutomatedDefault(cfg.Vector.IncludeAutomated),
+	}
+	var recallMutationNotify func()
+	if cfg.Vector.Embed.Recall {
+		// An import or extraction mutation can happen while the daemon is down,
+		// after its last notification was consumed, or before vectors.db exists.
+		// Queue one ordinary incremental build before Run starts; the buffered
+		// signal stays bounded and coalesces with any startup mutation burst.
+		recallScheduler.Notify()
+		recallMutationNotify = recallScheduler.Notify
+		serverOpts = append(serverOpts,
+			server.WithRecallCorpusMutationNotifier(recallMutationNotify),
+			server.WithSessionMutationNotifier(recallMutationNotify),
+		)
+	}
 
 	return vectorServing{
-		ServerOpts: []server.Option{
-			server.WithEmbeddingsManager(mgr),
-			server.WithEmbeddingsIncludeAutomatedDefault(cfg.Vector.IncludeAutomated),
-		},
-		Scheduler: scheduler,
+		ServerOpts:           serverOpts,
+		Scheduler:            scheduler,
+		RecallScheduler:      recallScheduler,
+		RecallMutationNotify: recallMutationNotify,
 		Close: func() error {
+			mgr.Wait()
+			recallMgr.Wait()
 			ixErr := ix.Close()
+			recallErr := recallIX.Close()
 			lockErr := lock.Close()
 			if ixErr != nil {
 				return ixErr
 			}
+			if recallErr != nil {
+				return recallErr
+			}
 			return lockErr
 		},
 	}, nil
+}
+
+func recallBackstop(cfg config.Config, configured time.Duration) time.Duration {
+	if !cfg.Vector.Embed.Recall {
+		return -1
+	}
+	return configured
 }
 
 // installDirectVectorSearcher wires a read-only vectors.db into d's
@@ -481,24 +737,54 @@ func installDirectVectorSearcher(cfg config.Config, d *db.DB) func() error {
 		return nil
 	}
 
-	ix, err := vector.Open(context.Background(), path, true, cfg.Vector.Embeddings.MaxInputChars)
-	if err != nil {
+	ix, messageErr := vector.OpenSpec(
+		context.Background(), path, vector.MessageIndexSpec(), true,
+		cfg.Vector.Embeddings.MaxInputChars,
+	)
+	recallIX, recallErr := vector.OpenSpec(
+		context.Background(), path, vector.RecallIndexSpec(), true,
+		cfg.Vector.Embeddings.MaxInputChars,
+	)
+	if messageErr != nil && recallErr != nil {
 		log.Printf(
-			"warning: opening vectors.db for semantic search: %v; "+
-				"continuing without semantic search", err,
+			"warning: opening vectors.db for semantic search: messages: %v; recall: %v; "+
+				"continuing without semantic search", messageErr, recallErr,
 		)
 		return nil
 	}
 	// Query encoding uses the default server.
 	enc, err := newVectorQueryEncoder(cfg.Vector.Embeddings, "")
 	if err != nil {
-		ix.Close()
+		if ix != nil {
+			ix.Close()
+		}
+		if recallIX != nil {
+			recallIX.Close()
+		}
 		log.Printf(
 			"warning: building embeddings encoder for semantic search: %v; "+
 				"continuing without semantic search", err,
 		)
 		return nil
 	}
-	d.SetVectorSearcher(newSearcherAdapter(ix, enc, vectorGeneration(cfg.Vector.Embeddings)))
-	return ix.Close
+	if ix != nil {
+		d.SetVectorSearcher(newSearcherAdapter(ix, enc, vectorGeneration(cfg.Vector.Embeddings)))
+	}
+	if recallIX != nil {
+		d.SetRecallVectorSearcher(recallSearcherAdapter{
+			ix: recallIX, enc: enc, database: d, cfg: cfg,
+		})
+	}
+	return func() error {
+		var closeErr error
+		if ix != nil {
+			closeErr = ix.Close()
+		}
+		if recallIX != nil {
+			if err := recallIX.Close(); closeErr == nil {
+				closeErr = err
+			}
+		}
+		return closeErr
+	}
 }

--- a/cmd/agentsview/embed_scheduler.go
+++ b/cmd/agentsview/embed_scheduler.go
@@ -363,80 +363,84 @@ type recallSearcherAdapter struct {
 	cfg      config.Config
 }
 
-type recallSearchCorpusIdentity struct {
-	generationFingerprint string
-	revision              string
-}
-
 func (a recallSearcherAdapter) corpusIdentity(
 	ctx context.Context,
-) (recallSearchCorpusIdentity, error) {
+) (db.RecallVectorSnapshot, error) {
 	extractionFingerprint, err := recallCorpusFingerprint(ctx, a.database)
 	if err != nil {
-		return recallSearchCorpusIdentity{}, err
+		return db.RecallVectorSnapshot{}, err
 	}
 	revision, err := a.database.RecallCorpusRevision(ctx)
 	if err != nil {
-		return recallSearchCorpusIdentity{}, err
+		return db.RecallVectorSnapshot{}, err
 	}
-	return recallSearchCorpusIdentity{
-		generationFingerprint: recallVectorGeneration(
+	return db.RecallVectorSnapshot{
+		GenerationFingerprint: recallVectorGeneration(
 			a.cfg.Vector.Embeddings, extractionFingerprint,
 		).Fingerprint(),
-		revision: revision,
+		CorpusRevision: revision,
 	}, nil
 }
 
 func (a recallSearcherAdapter) SearchRecall(
 	ctx context.Context, query string, limit int,
-) ([]db.RecallVectorHit, bool, error) {
+) ([]db.RecallVectorHit, bool, db.RecallVectorSnapshot, error) {
 	identity, err := a.corpusIdentity(ctx)
 	if err != nil {
-		return nil, false, fmt.Errorf("%w: %v", db.ErrSemanticUnavailable, err)
+		return nil, false, db.RecallVectorSnapshot{}, fmt.Errorf("%w: %v", db.ErrSemanticUnavailable, err)
 	}
 	stale, err := a.ix.StaleActive(
-		ctx, identity.generationFingerprint, identity.revision,
+		ctx, identity.GenerationFingerprint, identity.CorpusRevision,
 	)
 	if err != nil {
-		return nil, false, translateRecallSearchError(err)
+		return nil, false, db.RecallVectorSnapshot{}, translateRecallSearchError(err)
 	}
 	if stale {
-		return nil, false, fmt.Errorf(
+		return nil, false, db.RecallVectorSnapshot{}, fmt.Errorf(
 			"%w: recall index is stale: run 'agentsview embeddings build --store recall'",
 			db.ErrSemanticUnavailable,
 		)
 	}
 	hits, exhausted, err := a.ix.SearchPage(ctx, a.enc, query, limit)
 	if err != nil {
-		return nil, false, translateRecallSearchError(err)
+		return nil, false, db.RecallVectorSnapshot{}, translateRecallSearchError(err)
 	}
-	stale, err = a.ix.StaleActive(
-		ctx, identity.generationFingerprint, identity.revision,
+	if err := a.ValidateRecallSnapshot(ctx, identity); err != nil {
+		return nil, false, db.RecallVectorSnapshot{}, err
+	}
+	out := make([]db.RecallVectorHit, len(hits))
+	for i, hit := range hits {
+		out[i] = db.RecallVectorHit{EntryID: hit.SessionID, Score: hit.Score}
+	}
+	return out, exhausted, identity, nil
+}
+
+func (a recallSearcherAdapter) ValidateRecallSnapshot(
+	ctx context.Context, identity db.RecallVectorSnapshot,
+) error {
+	stale, err := a.ix.StaleActive(
+		ctx, identity.GenerationFingerprint, identity.CorpusRevision,
 	)
 	if err != nil {
-		return nil, false, translateRecallSearchError(err)
+		return translateRecallSearchError(err)
 	}
 	if stale {
-		return nil, false, fmt.Errorf(
+		return fmt.Errorf(
 			"%w: recall index changed during search; retry the query",
 			db.ErrSemanticUnavailable,
 		)
 	}
 	currentIdentity, err := a.corpusIdentity(ctx)
 	if err != nil {
-		return nil, false, fmt.Errorf("%w: %v", db.ErrSemanticUnavailable, err)
+		return fmt.Errorf("%w: %v", db.ErrSemanticUnavailable, err)
 	}
 	if currentIdentity != identity {
-		return nil, false, fmt.Errorf(
+		return fmt.Errorf(
 			"%w: recall corpus changed during search; retry after the recall index refreshes",
 			db.ErrSemanticUnavailable,
 		)
 	}
-	out := make([]db.RecallVectorHit, len(hits))
-	for i, hit := range hits {
-		out[i] = db.RecallVectorHit{EntryID: hit.SessionID, Score: hit.Score}
-	}
-	return out, exhausted, nil
+	return nil
 }
 
 // newSearcherAdapter builds a searcherAdapter for gen's configured

--- a/cmd/agentsview/embed_scheduler_test.go
+++ b/cmd/agentsview/embed_scheduler_test.go
@@ -421,6 +421,34 @@ func TestEmbedSchedulerRepeatedBackstopFailuresReleaseIdleLease(
 		fake.callsSnapshot(), "one backstop tick should get one bounded retry")
 }
 
+func TestEmbedSchedulerExhaustedBackstopCarriesIntoNextNotification(
+	t *testing.T,
+) {
+	buildErr := errors.New("embedding request rejected")
+	fake := &fakeEmbedManager{results: []fakeTryBuildResult{
+		{started: true, err: buildErr},
+		{started: true, err: buildErr},
+		{started: true},
+	}}
+	s := newEmbedScheduler(
+		fake, 20*time.Millisecond, 200*time.Millisecond, false, nil,
+	)
+	go s.Run(t.Context())
+	defer s.Stop()
+
+	waitForSchedulerCondition(t, func() bool { return fake.callCount() >= 2 },
+		"expected the failed backstop and its bounded retry")
+	s.Notify()
+	waitForSchedulerConditionWithin(t, 100*time.Millisecond,
+		func() bool { return fake.callCount() >= 3 },
+		"a new notification should recover the deferred reconciliation")
+
+	assert.Equal(t, []vector.BuildRequest{
+		{Backstop: true}, {Backstop: true}, {Backstop: true},
+	}, fake.callsSnapshot(),
+		"retry exhaustion must preserve full-reconciliation intent")
+}
+
 // TestEmbedSchedulerDroppedBackstopRetriesOnNextDebouncedBuild is the fix-4
 // regression test: a backstop tick that collides with a build already
 // running elsewhere must not be silently dropped for a full backstop
@@ -715,6 +743,42 @@ func TestTranslateSearchErrorMapsVectorErrorsToSemanticUnavailable(t *testing.T)
 		assert.Contains(t, got.Error(), "embeddings build",
 			"the rebuild remediation must survive translation")
 	})
+}
+
+func TestTranslateRecallSearchErrorUsesRecallRemediation(t *testing.T) {
+	t.Run("mirror version mismatch", func(t *testing.T) {
+		err := translateRecallSearchError(vector.ErrMirrorVersionMismatch)
+
+		assert.ErrorIs(t, err, db.ErrSemanticUnavailable)
+		assert.Contains(t, err.Error(), "embeddings build --store recall")
+	})
+	t.Run("building", func(t *testing.T) {
+		err := translateRecallSearchError(&vector.BuildingError{Percent: 37})
+
+		assert.ErrorIs(t, err, db.ErrSemanticUnavailable)
+		assert.Contains(t, err.Error(), "recall index is building: 37% complete")
+		assert.NotContains(t, err.Error(), "agentsview embeddings build",
+			"an in-progress Recall build should not recommend another store build")
+	})
+}
+
+func TestRecallSearcherNoActiveGenerationNamesRecallBuild(t *testing.T) {
+	dataDir := t.TempDir()
+	database := dbtest.OpenTestDBAt(t, filepath.Join(dataDir, "sessions.db"))
+	cfg := vectorTestConfig(dataDir)
+	ix, err := vector.OpenSpec(
+		t.Context(), cfg.Vector.ResolvedDBPath(dataDir),
+		vector.RecallIndexSpec(), false, cfg.Vector.Embeddings.MaxInputChars,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, ix.Close()) })
+	searcher := recallSearcherAdapter{ix: ix, database: database, cfg: cfg}
+
+	_, _, err = searcher.SearchRecall(t.Context(), "database pool", 5)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, db.ErrSemanticUnavailable)
+	assert.Contains(t, err.Error(), "embeddings build --store recall")
 }
 
 // TestSearcherAdapterVersionMismatchedIndexReturnsSemanticUnavailable is the

--- a/cmd/agentsview/embed_scheduler_test.go
+++ b/cmd/agentsview/embed_scheduler_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -12,6 +13,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -40,6 +42,25 @@ type fakeEmbedManager struct {
 type fakeTryBuildResult struct {
 	started bool
 	err     error
+}
+
+type blockingEmbedManager struct {
+	started     chan struct{}
+	startedOnce sync.Once
+	release     chan struct{}
+	releasedFn  sync.Once
+}
+
+func (b *blockingEmbedManager) TryBuild(
+	_ context.Context, _ vector.BuildRequest,
+) (bool, error) {
+	b.startedOnce.Do(func() { close(b.started) })
+	<-b.release
+	return true, nil
+}
+
+func (b *blockingEmbedManager) releaseOnce() {
+	b.releasedFn.Do(func() { close(b.release) })
 }
 
 func (f *fakeEmbedManager) TryBuild(
@@ -77,7 +98,14 @@ func (f *fakeEmbedManager) callsSnapshot() []vector.BuildRequest {
 // under load or slow the suite down needlessly.
 func waitForSchedulerCondition(t *testing.T, cond func() bool, msg string) {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
+	waitForSchedulerConditionWithin(t, 2*time.Second, cond, msg)
+}
+
+func waitForSchedulerConditionWithin(
+	t *testing.T, timeout time.Duration, cond func() bool, msg string,
+) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		if cond() {
 			return
@@ -89,7 +117,7 @@ func waitForSchedulerCondition(t *testing.T, cond func() bool, msg string) {
 
 func TestEmbedSchedulerBurstOfNotifyProducesExactlyOneBuild(t *testing.T) {
 	fake := &fakeEmbedManager{}
-	s := newEmbedScheduler(fake, 20*time.Millisecond, 0, false)
+	s := newEmbedScheduler(fake, 20*time.Millisecond, 0, false, nil)
 
 	// Queue the whole burst before Run starts so the test exercises the
 	// scheduler's documented pre-reader coalescing without racing the debounce
@@ -118,7 +146,7 @@ func TestEmbedSchedulerBurstOfNotifyProducesExactlyOneBuild(t *testing.T) {
 // than silently reverting to includeAutomated=false.
 func TestEmbedSchedulerIncludeAutomatedThreadsIntoBuildRequests(t *testing.T) {
 	fake := &fakeEmbedManager{}
-	s := newEmbedScheduler(fake, 5*time.Millisecond, 20*time.Millisecond, true)
+	s := newEmbedScheduler(fake, 5*time.Millisecond, 20*time.Millisecond, true, nil)
 
 	ctx := t.Context()
 	go s.Run(ctx)
@@ -144,7 +172,7 @@ func TestEmbedSchedulerNotifyDuringRunningBuildRearmsForFollowUpPass(t *testing.
 			{started: true, err: nil},  // the follow-up pass actually runs
 		},
 	}
-	s := newEmbedScheduler(fake, 15*time.Millisecond, 0, false)
+	s := newEmbedScheduler(fake, 15*time.Millisecond, 0, false, nil)
 
 	ctx := t.Context()
 	go s.Run(ctx)
@@ -163,7 +191,7 @@ func TestEmbedSchedulerNotifyDuringRunningBuildRearmsForFollowUpPass(t *testing.
 func TestEmbedSchedulerBackstopTickIssuesBackstopBuild(t *testing.T) {
 	fake := &fakeEmbedManager{}
 	// A very long debounce so only the backstop ticker can fire a build.
-	s := newEmbedScheduler(fake, time.Hour, 20*time.Millisecond, false)
+	s := newEmbedScheduler(fake, time.Hour, 20*time.Millisecond, false, nil)
 
 	ctx := t.Context()
 	go s.Run(ctx)
@@ -174,6 +202,223 @@ func TestEmbedSchedulerBackstopTickIssuesBackstopBuild(t *testing.T) {
 	calls := fake.callsSnapshot()
 	require.NotEmpty(t, calls)
 	assert.True(t, calls[0].Backstop, "backstop tick must set BuildRequest.Backstop")
+}
+
+func TestEmbedSchedulerPendingDebounceHoldsIdleWorkLease(t *testing.T) {
+	fake := &fakeEmbedManager{}
+	idled := make(chan struct{})
+	ctx, cancel := context.WithCancel(t.Context())
+	tracker := server.NewIdleTracker(20*time.Millisecond, func() {
+		close(idled)
+		cancel()
+	})
+	s := newEmbedScheduler(fake, 100*time.Millisecond, 0, false, tracker)
+
+	// setupVectorServing queues Recall startup work before either goroutine
+	// starts, so exercise that ordering explicitly.
+	s.Notify()
+	go tracker.Run(ctx)
+	go s.Run(ctx)
+	defer s.Stop()
+
+	waitForSchedulerCondition(t, func() bool { return fake.callCount() >= 1 },
+		"pending startup work did not survive an idle timeout shorter than its debounce")
+	select {
+	case <-idled:
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "daemon never idled after the pending build completed")
+	}
+}
+
+func TestEmbedSchedulerBuildsHoldIdleWorkLease(t *testing.T) {
+	tests := []struct {
+		name     string
+		debounce time.Duration
+		backstop time.Duration
+		notify   bool
+	}{
+		{name: "debounced", debounce: 5 * time.Millisecond, notify: true},
+		{name: "backstop", debounce: time.Hour, backstop: 5 * time.Millisecond},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mgr := &blockingEmbedManager{
+				started: make(chan struct{}),
+				release: make(chan struct{}),
+			}
+			idled := make(chan struct{})
+			tracker := server.NewIdleTracker(50*time.Millisecond, func() { close(idled) })
+			s := newEmbedScheduler(
+				mgr, tt.debounce, tt.backstop, false, tracker,
+			)
+			ctx := t.Context()
+			go tracker.Run(ctx)
+			go s.Run(ctx)
+			defer s.Stop()
+			defer mgr.releaseOnce()
+
+			if tt.notify {
+				s.Notify()
+			}
+			<-mgr.started
+			select {
+			case <-idled:
+				require.Fail(t, "daemon idled while an embedding build was in flight")
+			case <-time.After(200 * time.Millisecond):
+			}
+			mgr.releaseOnce()
+			select {
+			case <-idled:
+			case <-time.After(2 * time.Second):
+				require.Fail(t, "daemon never idled after the embedding build completed")
+			}
+		})
+	}
+}
+
+func TestEmbedSchedulerFailedDebouncedBuildRetriesWithoutNotification(
+	t *testing.T,
+) {
+	fake := &fakeEmbedManager{results: []fakeTryBuildResult{
+		{started: true, err: errors.New("embedding endpoint unavailable")},
+		{started: true},
+	}}
+	idled := make(chan struct{})
+	ctx, cancel := context.WithCancel(t.Context())
+	tracker := server.NewIdleTracker(20*time.Millisecond, func() {
+		close(idled)
+		cancel()
+	})
+	s := newEmbedScheduler(fake, 50*time.Millisecond, 0, false, tracker)
+	s.Notify()
+	go tracker.Run(ctx)
+	go s.Run(ctx)
+	defer s.Stop()
+
+	waitForSchedulerCondition(t, func() bool { return fake.callCount() >= 2 },
+		"a failed debounced build must retry without another notification")
+	select {
+	case <-idled:
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "daemon never idled after the retry succeeded")
+	}
+	assert.Equal(t, []vector.BuildRequest{{}, {}}, fake.callsSnapshot())
+}
+
+func TestEmbedSchedulerRepeatedDebouncedFailuresReleaseIdleLease(
+	t *testing.T,
+) {
+	buildErr := errors.New("embedding request rejected")
+	fake := &fakeEmbedManager{results: []fakeTryBuildResult{
+		{started: true, err: buildErr},
+		{started: true, err: buildErr},
+	}}
+	idled := make(chan struct{})
+	ctx, cancel := context.WithCancel(t.Context())
+	tracker := server.NewIdleTracker(15*time.Millisecond, func() {
+		close(idled)
+		cancel()
+	})
+	s := newEmbedScheduler(fake, 20*time.Millisecond, 0, false, tracker)
+	s.Notify()
+	go tracker.Run(ctx)
+	go s.Run(ctx)
+	defer s.Stop()
+
+	select {
+	case <-idled:
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "repeated build failures kept the daemon alive indefinitely")
+	}
+	assert.Equal(t, []vector.BuildRequest{{}, {}}, fake.callsSnapshot(),
+		"one notification should get one bounded retry")
+}
+
+func TestEmbedSchedulerPendingBackstopRetriesBeforeNextTick(
+	t *testing.T,
+) {
+	tests := []struct {
+		name   string
+		result fakeTryBuildResult
+	}{
+		{
+			name: "failed build",
+			result: fakeTryBuildResult{
+				started: true, err: errors.New("embedding endpoint unavailable"),
+			},
+		},
+		{name: "colliding build", result: fakeTryBuildResult{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &fakeEmbedManager{results: []fakeTryBuildResult{
+				tt.result,
+				{started: true},
+			}}
+			idled := make(chan struct{})
+			ctx, cancel := context.WithCancel(t.Context())
+			tracker := server.NewIdleTracker(450*time.Millisecond, func() {
+				close(idled)
+				cancel()
+			})
+			s := newEmbedScheduler(
+				fake, 200*time.Millisecond, 300*time.Millisecond, false, tracker,
+			)
+			go tracker.Run(ctx)
+			go s.Run(ctx)
+			defer s.Stop()
+
+			waitForSchedulerCondition(t, func() bool { return fake.callCount() >= 1 },
+				"expected the initial backstop attempt")
+			waitForSchedulerConditionWithin(t, 250*time.Millisecond,
+				func() bool { return fake.callCount() >= 2 },
+				"a pending backstop must retry before the next backstop tick")
+			select {
+			case <-idled:
+			case <-time.After(2 * time.Second):
+				require.Fail(t, "daemon never idled after the backstop retry succeeded")
+			}
+			calls := fake.callsSnapshot()
+			require.Len(t, calls, 2)
+			assert.True(t, calls[0].Backstop)
+			assert.True(t, calls[1].Backstop)
+		})
+	}
+}
+
+func TestEmbedSchedulerRepeatedBackstopFailuresReleaseIdleLease(
+	t *testing.T,
+) {
+	buildErr := errors.New("embedding request rejected")
+	fake := &fakeEmbedManager{results: []fakeTryBuildResult{
+		{started: true, err: buildErr},
+		{started: true, err: buildErr},
+	}}
+	idled := make(chan struct{})
+	ctx, cancel := context.WithCancel(t.Context())
+	tracker := server.NewIdleTracker(30*time.Millisecond, func() {
+		close(idled)
+		cancel()
+	})
+	s := newEmbedScheduler(
+		fake, 20*time.Millisecond, 200*time.Millisecond, false, tracker,
+	)
+	go s.Run(ctx)
+	defer s.Stop()
+
+	waitForSchedulerCondition(t, func() bool { return fake.callCount() >= 2 },
+		"expected the failed backstop and its bounded retry")
+	// Start idle observation only after the backstop has acquired its lease;
+	// otherwise a detached daemon with no startup work could reap before the
+	// first deliberately delayed test tick.
+	go tracker.Run(ctx)
+	select {
+	case <-idled:
+	case <-time.After(150 * time.Millisecond):
+		require.Fail(t, "repeated backstop failures retained the idle lease")
+	}
+	assert.Equal(t, []vector.BuildRequest{{Backstop: true}, {Backstop: true}},
+		fake.callsSnapshot(), "one backstop tick should get one bounded retry")
 }
 
 // TestEmbedSchedulerDroppedBackstopRetriesOnNextDebouncedBuild is the fix-4
@@ -191,7 +436,7 @@ func TestEmbedSchedulerDroppedBackstopRetriesOnNextDebouncedBuild(t *testing.T) 
 	// A long backstop interval relative to the debounce interval and the
 	// test's own buffers keeps a second, unrelated backstop tick from
 	// firing mid-test and making the call count non-deterministic.
-	s := newEmbedScheduler(fake, 10*time.Millisecond, 500*time.Millisecond, false)
+	s := newEmbedScheduler(fake, 10*time.Millisecond, 500*time.Millisecond, false, nil)
 
 	ctx := t.Context()
 	go s.Run(ctx)
@@ -240,7 +485,7 @@ func TestEmbedSchedulerBackstopTickStartedButFailedKeepsPendingBackstop(t *testi
 			{started: true, err: nil},      // the following debounced build recovers it
 		},
 	}
-	s := newEmbedScheduler(fake, 10*time.Millisecond, 500*time.Millisecond, false)
+	s := newEmbedScheduler(fake, 10*time.Millisecond, 500*time.Millisecond, false, nil)
 
 	ctx := t.Context()
 	go s.Run(ctx)
@@ -288,7 +533,7 @@ func TestEmbedSchedulerDebouncedBuildStartedButFailedKeepsPendingBackstop(t *tes
 			{started: true, err: nil},      // a further debounced build finally succeeds
 		},
 	}
-	s := newEmbedScheduler(fake, 10*time.Millisecond, 500*time.Millisecond, false)
+	s := newEmbedScheduler(fake, 10*time.Millisecond, 500*time.Millisecond, false, nil)
 
 	ctx := t.Context()
 	go s.Run(ctx)
@@ -316,7 +561,7 @@ func TestEmbedSchedulerDebouncedBuildStartedButFailedKeepsPendingBackstop(t *tes
 
 func TestEmbedSchedulerStopTerminatesRun(t *testing.T) {
 	fake := &fakeEmbedManager{}
-	s := newEmbedScheduler(fake, time.Hour, 0, false)
+	s := newEmbedScheduler(fake, time.Hour, 0, false, nil)
 
 	go s.Run(context.Background())
 
@@ -337,7 +582,7 @@ func TestEmbedSchedulerStopTerminatesRun(t *testing.T) {
 
 func TestEmbedSchedulerNotifyNeverBlocksWithoutAReader(t *testing.T) {
 	fake := &fakeEmbedManager{}
-	s := newEmbedScheduler(fake, time.Hour, 0, false)
+	s := newEmbedScheduler(fake, time.Hour, 0, false, nil)
 
 	done := make(chan struct{})
 	go func() {
@@ -376,7 +621,7 @@ func (e *recordingEmitter) count() int {
 func TestTeeEmitterAlwaysCallsPrimaryAndGatesSchedulerOnRunAfterSync(t *testing.T) {
 	primary := &recordingEmitter{}
 	fake := &fakeEmbedManager{}
-	s := newEmbedScheduler(fake, 10*time.Millisecond, 0, false)
+	s := newEmbedScheduler(fake, 10*time.Millisecond, 0, false, nil)
 	ctx := t.Context()
 	go s.Run(ctx)
 	defer s.Stop()
@@ -406,7 +651,7 @@ func TestTeeEmitterAlwaysCallsPrimaryAndGatesSchedulerOnRunAfterSync(t *testing.
 func TestRunRemoteHostSyncLoop_EmitsThroughTeeNotifiesScheduler(t *testing.T) {
 	primary := &recordingEmitter{}
 	fake := &fakeEmbedManager{}
-	s := newEmbedScheduler(fake, 5*time.Millisecond, 0, false)
+	s := newEmbedScheduler(fake, 5*time.Millisecond, 0, false, nil)
 	schedCtx := t.Context()
 	go s.Run(schedCtx)
 	defer s.Stop()
@@ -539,6 +784,7 @@ func vectorTestConfig(dataDir string) config.Config {
 			},
 			Embed: config.VectorEmbedConfig{
 				BackstopInterval: "24h",
+				Recall:           true,
 			},
 		},
 	}
@@ -582,9 +828,10 @@ func TestServeConstructionRegistersEmbeddingsRoutesWhenVectorEnabled(t *testing.
 	ln, port := listenLoopback(t)
 	cfg := vectorTestConfig(dataDir)
 	cfg.Host, cfg.Port = "127.0.0.1", port
-	vs, err := setupVectorServing(context.Background(), cfg, database)
+	vs, err := setupVectorServing(context.Background(), cfg, database, nil)
 	require.NoError(t, err)
 	require.NotNil(t, vs.Scheduler)
+	require.NotNil(t, vs.RecallScheduler)
 	require.NotNil(t, vs.Close)
 	defer func() { require.NoError(t, vs.Close()) }()
 
@@ -596,6 +843,485 @@ func TestServeConstructionRegistersEmbeddingsRoutesWhenVectorEnabled(t *testing.
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "application/json", mediaType(t, resp.Header.Get("Content-Type")))
+}
+
+func TestRecallSchedulerBackstopRemovesArchivedEntryVectors(t *testing.T) {
+	dataDir := t.TempDir()
+	database := dbtest.OpenTestDBAt(t, filepath.Join(dataDir, "sessions.db"))
+	dbtest.SeedSession(t, database, "s1", "agentsview")
+	require.NoError(t, database.Update(func(tx *sql.Tx) error {
+		_, err := tx.Exec(`
+			INSERT INTO recall_extract_generations
+				(fingerprint, state, model, segmenter, params_json)
+			VALUES ('extract-active', 'active', 'extract-model', 'turns-v1', '{}')`)
+		return err
+	}))
+	_, err := database.InsertRecallEntry(db.RecallEntry{
+		ID: "recall-entry", Type: "fact", Scope: "project", Status: "accepted",
+		Title: "Database pool", Body: "Reuse idle connections.",
+		SourceSessionID: "s1", SourceRunID: "extract-active",
+	})
+	require.NoError(t, err)
+
+	stub := newEmbeddingsStubServer(t, 3)
+	t.Cleanup(stub.Close)
+	cfg := vectorTestConfig(dataDir)
+	embeddingsServer := cfg.Vector.Embeddings.Servers["local"]
+	embeddingsServer.Endpoint = stub.URL + "/v1"
+	cfg.Vector.Embeddings.Servers["local"] = embeddingsServer
+	cfg.Vector.Embed.BackstopInterval = "20ms"
+
+	vs, err := setupVectorServing(t.Context(), cfg, database, nil)
+	require.NoError(t, err)
+	require.NotNil(t, vs.RecallScheduler)
+	require.NotNil(t, vs.Close)
+	go vs.RecallScheduler.Run(t.Context())
+	t.Cleanup(func() {
+		vs.RecallScheduler.Stop()
+		require.NoError(t, vs.Close())
+	})
+
+	embeddedCount := func() int64 {
+		generations, err := directListGenerations(
+			t.Context(), cfg, vector.RecallIndexSpec(),
+		)
+		if err != nil || len(generations) == 0 {
+			return -1
+		}
+		return generations[0].Embedded
+	}
+	waitForSchedulerCondition(t, func() bool { return embeddedCount() == 1 },
+		"recall backstop never embedded the accepted entry")
+
+	require.NoError(t, database.Update(func(tx *sql.Tx) error {
+		_, err := tx.Exec(
+			"UPDATE recall_entries SET status = 'archived' WHERE id = 'recall-entry'",
+		)
+		return err
+	}))
+	waitForSchedulerCondition(t, func() bool { return embeddedCount() == 0 },
+		"recall backstop did not remove the archived entry vector")
+}
+
+func TestRecallSchedulerSyncRemovesDeletedEntryWithoutExtraction(t *testing.T) {
+	dataDir := t.TempDir()
+	database := dbtest.OpenTestDBAt(t, filepath.Join(dataDir, "sessions.db"))
+	dbtest.SeedSession(t, database, "s1", "agentsview")
+	_, err := database.InsertRecallEntry(db.RecallEntry{
+		ID: "recall-entry", Type: "fact", Scope: "project", Status: "accepted",
+		Title: "Database pool", Body: "Reuse idle connections.",
+		SourceSessionID: "s1", ExtractorMethod: "import-v1",
+	})
+	require.NoError(t, err)
+
+	stub := newEmbeddingsStubServer(t, 3)
+	t.Cleanup(stub.Close)
+	cfg := vectorTestConfig(dataDir)
+	cfg.Vector.Embed.BackstopInterval = "0s"
+	embeddingsServer := cfg.Vector.Embeddings.Servers["local"]
+	embeddingsServer.Endpoint = stub.URL + "/v1"
+	cfg.Vector.Embeddings.Servers["local"] = embeddingsServer
+
+	vs, err := setupVectorServing(t.Context(), cfg, database, nil)
+	require.NoError(t, err)
+	require.NotNil(t, vs.RecallScheduler)
+	require.NotNil(t, vs.Close)
+	vs.RecallScheduler.debounce = 10 * time.Millisecond
+	go vs.RecallScheduler.Run(t.Context())
+	t.Cleanup(func() {
+		vs.RecallScheduler.Stop()
+		require.NoError(t, vs.Close())
+	})
+
+	embeddedCount := func() int64 {
+		generations, listErr := directListGenerations(
+			t.Context(), cfg, vector.RecallIndexSpec(),
+		)
+		if listErr != nil || len(generations) == 0 {
+			return -1
+		}
+		return generations[0].Embedded
+	}
+	waitForSchedulerCondition(t, func() bool { return embeddedCount() == 1 },
+		"startup reconciliation did not embed the accepted entry")
+
+	require.NoError(t, database.Update(func(tx *sql.Tx) error {
+		_, deleteErr := tx.Exec("DELETE FROM recall_entries WHERE id = 'recall-entry'")
+		return deleteErr
+	}))
+	emitter := wrapEmbeddingSyncEmitter(
+		&recordingEmitter{}, vs, cfg.Vector.Embed.RunAfterSyncEnabled(),
+	)
+	emitter.Emit("sync")
+
+	waitForSchedulerCondition(t, func() bool { return embeddedCount() == 0 },
+		"successful sync did not remove the deleted Recall vector")
+}
+
+func TestRecallSchedulerSessionDeletionRemovesImportedEntryWithoutExtraction(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		path       string
+		wantStatus int
+	}{
+		{name: "permanent delete", path: "/api/v1/sessions/s1/permanent", wantStatus: http.StatusNoContent},
+		{name: "empty trash", path: "/api/v1/trash", wantStatus: http.StatusOK},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dataDir := t.TempDir()
+			database := dbtest.OpenTestDBAt(t, filepath.Join(dataDir, "sessions.db"))
+			dbtest.SeedSession(t, database, "s1", "agentsview")
+			_, err := database.InsertRecallEntry(db.RecallEntry{
+				ID: "imported-entry", Type: "fact", Scope: "project", Status: "accepted",
+				Title: "Imported policy", Body: "Remove this with its source session.",
+				SourceSessionID: "s1", ExtractorMethod: "import-v1",
+			})
+			require.NoError(t, err)
+			require.NoError(t, database.SoftDeleteSession("s1"))
+
+			stub := newEmbeddingsStubServer(t, 3)
+			t.Cleanup(stub.Close)
+			ln, port := listenLoopback(t)
+			cfg := vectorTestConfig(dataDir)
+			cfg.Host, cfg.Port = "127.0.0.1", port
+			cfg.Vector.Embed.BackstopInterval = "0s"
+			embeddingsServer := cfg.Vector.Embeddings.Servers["local"]
+			embeddingsServer.Endpoint = stub.URL + "/v1"
+			cfg.Vector.Embeddings.Servers["local"] = embeddingsServer
+
+			vs, err := setupVectorServing(t.Context(), cfg, database, nil)
+			require.NoError(t, err)
+			require.NotNil(t, vs.RecallScheduler)
+			require.NotNil(t, vs.Close)
+			vs.RecallScheduler.debounce = 10 * time.Millisecond
+			go vs.RecallScheduler.Run(t.Context())
+			t.Cleanup(func() {
+				vs.RecallScheduler.Stop()
+				require.NoError(t, vs.Close())
+			})
+
+			embeddedCount := func() int64 {
+				generations, listErr := directListGenerations(
+					t.Context(), cfg, vector.RecallIndexSpec(),
+				)
+				if listErr != nil || len(generations) == 0 {
+					return -1
+				}
+				return generations[0].Embedded
+			}
+			waitForSchedulerCondition(t, func() bool { return embeddedCount() == 1 },
+				"startup reconciliation did not embed the imported entry")
+
+			srv := server.New(cfg, database, nil, vs.ServerOpts...)
+			ts := startTestServer(t, ln, srv.Handler())
+			req, err := http.NewRequestWithContext(
+				t.Context(), http.MethodDelete, ts.URL+tc.path, nil,
+			)
+			require.NoError(t, err)
+			req.Header.Set("Origin", ts.URL)
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			assert.Equal(t, tc.wantStatus, resp.StatusCode)
+
+			waitForSchedulerCondition(t, func() bool { return embeddedCount() == 0 },
+				"session deletion did not remove the imported Recall vector")
+		})
+	}
+}
+
+func TestRecallSchedulerStartupBuildsOfflineImportedCorpus(t *testing.T) {
+	dataDir := t.TempDir()
+	database := dbtest.OpenTestDBAt(t, filepath.Join(dataDir, "sessions.db"))
+	dbtest.SeedSession(t, database, "s1", "agentsview")
+	_, err := database.InsertRecallEntry(db.RecallEntry{
+		ID: "offline-import", Type: "fact", Scope: "project", Status: "accepted",
+		Title: "Offline policy", Body: "Refresh this entry after daemon restart.",
+		SourceSessionID: "s1", ExtractorMethod: "import-v1",
+	})
+	require.NoError(t, err)
+
+	stub := newEmbeddingsStubServer(t, 3)
+	t.Cleanup(stub.Close)
+	cfg := vectorTestConfig(dataDir)
+	embeddingsServer := cfg.Vector.Embeddings.Servers["local"]
+	embeddingsServer.Endpoint = stub.URL + "/v1"
+	cfg.Vector.Embeddings.Servers["local"] = embeddingsServer
+
+	vs, err := setupVectorServing(t.Context(), cfg, database, nil)
+	require.NoError(t, err)
+	require.NotNil(t, vs.RecallScheduler)
+	require.NotNil(t, vs.Close)
+	vs.RecallScheduler.debounce = 10 * time.Millisecond
+	go vs.RecallScheduler.Run(t.Context())
+	t.Cleanup(func() {
+		vs.RecallScheduler.Stop()
+		require.NoError(t, vs.Close())
+	})
+
+	waitForSchedulerCondition(t, func() bool {
+		generations, err := directListGenerations(
+			t.Context(), cfg, vector.RecallIndexSpec(),
+		)
+		return err == nil && len(generations) == 1 && generations[0].Embedded == 1
+	}, "daemon startup did not reconcile an offline imported recall entry")
+}
+
+func TestRecallSchedulerStartupDoesNotDependOnRunAfterSync(t *testing.T) {
+	dataDir := t.TempDir()
+	database := dbtest.OpenTestDBAt(t, filepath.Join(dataDir, "sessions.db"))
+	dbtest.SeedSession(t, database, "s1", "agentsview")
+	_, err := database.InsertRecallEntry(db.RecallEntry{
+		ID: "offline-import", Type: "fact", Scope: "project", Status: "accepted",
+		Title: "Offline policy", Body: "Refresh Recall independently of session sync.",
+		SourceSessionID: "s1", ExtractorMethod: "import-v1",
+	})
+	require.NoError(t, err)
+
+	stub := newEmbeddingsStubServer(t, 3)
+	t.Cleanup(stub.Close)
+	cfg := vectorTestConfig(dataDir)
+	disabled := false
+	cfg.Vector.Embed.RunAfterSync = &disabled
+	embeddingsServer := cfg.Vector.Embeddings.Servers["local"]
+	embeddingsServer.Endpoint = stub.URL + "/v1"
+	cfg.Vector.Embeddings.Servers["local"] = embeddingsServer
+
+	vs, err := setupVectorServing(t.Context(), cfg, database, nil)
+	require.NoError(t, err)
+	require.NotNil(t, vs.RecallScheduler)
+	require.NotNil(t, vs.RecallMutationNotify,
+		"non-sync Recall mutations must still schedule a refresh")
+	require.NotNil(t, vs.Close)
+	vs.RecallScheduler.debounce = 10 * time.Millisecond
+	go vs.RecallScheduler.Run(t.Context())
+	t.Cleanup(func() {
+		vs.RecallScheduler.Stop()
+		require.NoError(t, vs.Close())
+	})
+
+	waitForSchedulerCondition(t, func() bool {
+		generations, listErr := directListGenerations(
+			t.Context(), cfg, vector.RecallIndexSpec(),
+		)
+		return listErr == nil && len(generations) == 1 && generations[0].Embedded == 1
+	}, "Recall startup reconciliation must not depend on run_after_sync")
+
+	_, err = database.InsertRecallEntry(db.RecallEntry{
+		ID: "runtime-import", Type: "fact", Scope: "project", Status: "accepted",
+		Title: "Runtime policy", Body: "Refresh this non-sync mutation too.",
+		SourceSessionID: "s1", ExtractorMethod: "import-v1",
+	})
+	require.NoError(t, err)
+	vs.RecallMutationNotify()
+	waitForSchedulerCondition(t, func() bool {
+		generations, listErr := directListGenerations(
+			t.Context(), cfg, vector.RecallIndexSpec(),
+		)
+		return listErr == nil && len(generations) == 1 && generations[0].Embedded == 2
+	}, "a non-sync Recall mutation must refresh when run_after_sync is disabled")
+}
+
+func TestRecallSearchRejectsCorpusMutationUntilRefresh(t *testing.T) {
+	dataDir := t.TempDir()
+	database := dbtest.OpenTestDBAt(t, filepath.Join(dataDir, "sessions.db"))
+	dbtest.SeedSession(t, database, "s1", "agentsview")
+	_, err := database.InsertRecallEntry(db.RecallEntry{
+		ID: "entry-1", Type: "fact", Scope: "project", Status: "accepted",
+		Title: "Database pool", Body: "Reuse idle connections.",
+		SourceSessionID: "s1", ExtractorMethod: "import-v1",
+	})
+	require.NoError(t, err)
+
+	stub := newEmbeddingsStubServer(t, 3)
+	t.Cleanup(stub.Close)
+	cfg := vectorTestConfig(dataDir)
+	embeddingsServer := cfg.Vector.Embeddings.Servers["local"]
+	embeddingsServer.Endpoint = stub.URL + "/v1"
+	cfg.Vector.Embeddings.Servers["local"] = embeddingsServer
+
+	ix, err := vector.OpenSpec(
+		t.Context(), cfg.Vector.ResolvedDBPath(dataDir),
+		vector.RecallIndexSpec(), false, cfg.Vector.Embeddings.MaxInputChars,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, ix.Close()) })
+	encoders, err := vectorDocumentEncoderSet(cfg.Vector.Embeddings)
+	require.NoError(t, err)
+	mgr := embeddingManager(ix, database, encoders, cfg, vector.RecallIndexSpec().Name)
+	started, err := mgr.TryBuild(t.Context(), vector.BuildRequest{})
+	require.NoError(t, err)
+	require.True(t, started)
+
+	queryEncoder, err := newVectorQueryEncoder(cfg.Vector.Embeddings, "")
+	require.NoError(t, err)
+	searcher := recallSearcherAdapter{
+		ix: ix, enc: queryEncoder, database: database, cfg: cfg,
+	}
+	_, _, err = searcher.SearchRecall(t.Context(), "connection reuse", 5)
+	require.NoError(t, err)
+
+	searcher.enc = func(
+		ctx context.Context, texts []string,
+	) ([][]float32, error) {
+		if updateErr := database.Update(func(tx *sql.Tx) error {
+			_, execErr := tx.Exec(`
+				UPDATE recall_entries
+				SET title = 'Connection policy',
+					updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+				WHERE id = 'entry-1'`)
+			return execErr
+		}); updateErr != nil {
+			return nil, updateErr
+		}
+		return queryEncoder(ctx, texts)
+	}
+	_, _, err = searcher.SearchRecall(t.Context(), "connection reuse", 5)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, db.ErrSemanticUnavailable)
+	assert.Contains(t, err.Error(), "changed during search")
+
+	searcher.enc = queryEncoder
+
+	_, _, err = searcher.SearchRecall(t.Context(), "connection reuse", 5)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, db.ErrSemanticUnavailable)
+	assert.Contains(t, err.Error(), "embeddings build --store recall")
+
+	started, err = mgr.TryBuild(t.Context(), vector.BuildRequest{})
+	require.NoError(t, err)
+	require.True(t, started)
+	_, _, err = searcher.SearchRecall(t.Context(), "connection reuse", 5)
+	require.NoError(t, err)
+}
+
+func TestRecallSchedulerRequiresExplicitOptInForAutomaticBuilds(t *testing.T) {
+	dataDir := t.TempDir()
+	database := dbtest.OpenTestDBAt(t, filepath.Join(dataDir, "sessions.db"))
+	dbtest.SeedSession(t, database, "s1", "agentsview")
+	_, err := database.InsertRecallEntry(db.RecallEntry{
+		ID: "offline-import", Type: "fact", Scope: "project", Status: "accepted",
+		Title: "Offline policy", Body: "Do not send this entry automatically.",
+		SourceSessionID: "s1", ExtractorMethod: "import-v1",
+	})
+	require.NoError(t, err)
+
+	stub := newEmbeddingsStubServer(t, 3)
+	t.Cleanup(stub.Close)
+	ln, port := listenLoopback(t)
+	cfg := vectorTestConfig(dataDir)
+	cfg.Host, cfg.Port = "127.0.0.1", port
+	cfg.Vector.Embed.Recall = false
+	cfg.Vector.Embed.BackstopInterval = "20ms"
+	embeddingsServer := cfg.Vector.Embeddings.Servers["local"]
+	embeddingsServer.Endpoint = stub.URL + "/v1"
+	cfg.Vector.Embeddings.Servers["local"] = embeddingsServer
+
+	vs, err := setupVectorServing(t.Context(), cfg, database, nil)
+	require.NoError(t, err)
+	require.NotNil(t, vs.RecallScheduler)
+	require.NotNil(t, vs.Close)
+	vs.RecallScheduler.debounce = 10 * time.Millisecond
+	go vs.RecallScheduler.Run(t.Context())
+	t.Cleanup(func() {
+		vs.RecallScheduler.Stop()
+		require.NoError(t, vs.Close())
+	})
+
+	assert.Never(t, func() bool {
+		generations, listErr := directListGenerations(
+			t.Context(), cfg, vector.RecallIndexSpec(),
+		)
+		return listErr != nil || len(generations) != 0
+	}, 100*time.Millisecond, 5*time.Millisecond,
+		"Recall content must not be embedded automatically without explicit opt-in")
+
+	srv := server.New(cfg, database, nil, vs.ServerOpts...)
+	ts := startTestServer(t, ln, srv.Handler())
+	input := strings.NewReader(`
+{"candidate_id":"second-import","type":"fact","scope":"repository","title":"Import policy","body":"Keep imports manual too.","project":"agentsview","agent":"codex","session_id":"import-session","label":"correct","transferable":true,"provenance_ok":true,"evidence":{"ordinal_start":0,"ordinal_end":0}}
+`)
+	req, err := http.NewRequestWithContext(
+		t.Context(), http.MethodPost,
+		ts.URL+"/api/v1/recall/import?allow_placeholder_sessions=true", input,
+	)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", ts.URL)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	var imported db.RecallImportResult
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&imported))
+	assert.Equal(t, 1, imported.Imported)
+
+	assert.Never(t, func() bool {
+		generations, listErr := directListGenerations(
+			t.Context(), cfg, vector.RecallIndexSpec(),
+		)
+		return listErr != nil || len(generations) != 0
+	}, 100*time.Millisecond, 5*time.Millisecond,
+		"manual-only configuration must not build Recall embeddings after an import")
+}
+
+func TestRecallImportSchedulesEmbeddingRefresh(t *testing.T) {
+	dataDir := t.TempDir()
+	database := dbtest.OpenTestDBAt(t, filepath.Join(dataDir, "sessions.db"))
+	require.NoError(t, database.Update(func(tx *sql.Tx) error {
+		_, err := tx.Exec(`
+			INSERT INTO recall_extract_generations
+				(fingerprint, state, model, segmenter, params_json)
+			VALUES ('extract-active', 'active', 'extract-model', 'turns-v1', '{}')`)
+		return err
+	}))
+
+	stub := newEmbeddingsStubServer(t, 3)
+	t.Cleanup(stub.Close)
+	ln, port := listenLoopback(t)
+	cfg := vectorTestConfig(dataDir)
+	cfg.Host, cfg.Port = "127.0.0.1", port
+	embeddingsServer := cfg.Vector.Embeddings.Servers["local"]
+	embeddingsServer.Endpoint = stub.URL + "/v1"
+	cfg.Vector.Embeddings.Servers["local"] = embeddingsServer
+
+	vs, err := setupVectorServing(t.Context(), cfg, database, nil)
+	require.NoError(t, err)
+	require.NotNil(t, vs.RecallScheduler)
+	require.NotNil(t, vs.Close)
+	vs.RecallScheduler.debounce = 10 * time.Millisecond
+	go vs.RecallScheduler.Run(t.Context())
+	t.Cleanup(func() {
+		vs.RecallScheduler.Stop()
+		require.NoError(t, vs.Close())
+	})
+
+	srv := server.New(cfg, database, nil, vs.ServerOpts...)
+	ts := startTestServer(t, ln, srv.Handler())
+	input := strings.NewReader(`
+{"candidate_id":"imported-entry","type":"fact","scope":"repository","title":"Database pool","body":"Reuse idle connections.","project":"agentsview","agent":"codex","session_id":"import-session","label":"correct","transferable":true,"provenance_ok":true,"evidence":{"ordinal_start":0,"ordinal_end":0}}
+`)
+	req, err := http.NewRequestWithContext(
+		t.Context(), http.MethodPost,
+		ts.URL+"/api/v1/recall/import?allow_placeholder_sessions=true", input,
+	)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", ts.URL)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	var imported db.RecallImportResult
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&imported))
+	assert.Equal(t, 1, imported.Imported)
+
+	waitForSchedulerCondition(t, func() bool {
+		generations, err := directListGenerations(
+			t.Context(), cfg, vector.RecallIndexSpec(),
+		)
+		return err == nil && len(generations) == 1 && generations[0].Embedded == 1
+	}, "a corpus-changing import did not schedule recall embedding")
 }
 
 // TestEmbeddingsDaemonClientBuildSucceedsThroughRealMiddleware drives a POST
@@ -613,7 +1339,7 @@ func TestEmbeddingsDaemonClientBuildSucceedsThroughRealMiddleware(t *testing.T) 
 	ln, port := listenLoopback(t)
 	cfg := vectorTestConfig(dataDir)
 	cfg.Host, cfg.Port = "127.0.0.1", port
-	vs, err := setupVectorServing(context.Background(), cfg, database)
+	vs, err := setupVectorServing(context.Background(), cfg, database, nil)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, vs.Close()) }()
 
@@ -624,6 +1350,86 @@ func TestEmbeddingsDaemonClientBuildSucceedsThroughRealMiddleware(t *testing.T) 
 	err = client.startBuild(context.Background(), vector.BuildRequest{})
 	require.NoError(t, err,
 		"a POST build must succeed once the client sets Origin to satisfy the CSRF guard")
+}
+
+func TestVectorServingCloseWaitsForAPIStartedRecallBuild(t *testing.T) {
+	dataDir := t.TempDir()
+	database := dbtest.OpenTestDBAt(t, filepath.Join(dataDir, "sessions.db"))
+	dbtest.SeedSession(t, database, "s1", "agentsview")
+	_, err := database.InsertRecallEntry(db.RecallEntry{
+		ID: "manual-entry", Type: "fact", Scope: "project", Status: "accepted",
+		Title: "Manual build", Body: "Keep the index open.", SourceSessionID: "s1",
+	})
+	require.NoError(t, err)
+
+	encodeStarted := make(chan struct{})
+	encodeRelease := make(chan struct{})
+	var startedOnce sync.Once
+	var releaseOnce sync.Once
+	releaseEncode := func() { releaseOnce.Do(func() { close(encodeRelease) }) }
+	defer releaseEncode()
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Input []string `json:"input"`
+		}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		startedOnce.Do(func() { close(encodeStarted) })
+		<-encodeRelease
+		data := make([]map[string]any, len(req.Input))
+		for i := range req.Input {
+			data[i] = map[string]any{
+				"index": i, "embedding": []float32{1, 0, 0},
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"data": data}))
+	}))
+	t.Cleanup(stub.Close)
+
+	ln, port := listenLoopback(t)
+	cfg := vectorTestConfig(dataDir)
+	cfg.Host, cfg.Port = "127.0.0.1", port
+	cfg.Vector.Embed.Recall = false
+	embeddingsServer := cfg.Vector.Embeddings.Servers["local"]
+	embeddingsServer.Endpoint = stub.URL + "/v1"
+	cfg.Vector.Embeddings.Servers["local"] = embeddingsServer
+	vs, err := setupVectorServing(t.Context(), cfg, database, nil)
+	require.NoError(t, err)
+	var closeOnce sync.Once
+	var vectorCloseErr error
+	closeVectorServing := func() error {
+		closeOnce.Do(func() { vectorCloseErr = vs.Close() })
+		return vectorCloseErr
+	}
+	t.Cleanup(func() { require.NoError(t, closeVectorServing()) })
+
+	srv := server.New(cfg, database, nil, vs.ServerOpts...)
+	ts := startTestServer(t, ln, srv.Handler())
+	client := embeddingsDaemonClient{baseURL: ts.URL}
+	require.NoError(t, client.startBuild(t.Context(), vector.BuildRequest{
+		Store: vector.RecallIndexSpec().Name,
+	}))
+	select {
+	case <-encodeStarted:
+	case <-time.After(time.Second):
+		require.Fail(t, "manual Recall build never reached the encoder")
+	}
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- closeVectorServing() }()
+	select {
+	case closeErr := <-closeDone:
+		require.NoError(t, closeErr)
+		require.Fail(t, "vector serving closed while the API build was active")
+	case <-time.After(100 * time.Millisecond):
+	}
+	releaseEncode()
+	select {
+	case closeErr := <-closeDone:
+		require.NoError(t, closeErr)
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "vector serving did not close after the API build completed")
+	}
 }
 
 // TestSetupVectorServingDisablesWhenWriteLockHeld asserts a held
@@ -650,7 +1456,7 @@ func TestSetupVectorServingDisablesWhenWriteLockHeld(t *testing.T) {
 
 	logBuf := captureLogOutput(t)
 
-	vs, err := setupVectorServing(context.Background(), cfg, database)
+	vs, err := setupVectorServing(context.Background(), cfg, database, nil)
 	require.NoError(t, err, "a held lock must degrade, not fail, daemon startup")
 	assert.Nil(t, vs.Scheduler)
 	assert.Nil(t, vs.Close)
@@ -674,7 +1480,7 @@ func TestSetupVectorServingAcquiresAndReleasesWriteLock(t *testing.T) {
 	database := dbtest.OpenTestDBAt(t, filepath.Join(dataDir, "sessions.db"))
 	cfg := vectorTestConfig(dataDir)
 
-	vs, err := setupVectorServing(context.Background(), cfg, database)
+	vs, err := setupVectorServing(context.Background(), cfg, database, nil)
 	require.NoError(t, err)
 	require.NotNil(t, vs.Close)
 
@@ -698,7 +1504,7 @@ func TestServeConstructionKeepsEmbeddingsRoutesUnavailableWhenVectorDisabled(t *
 	ln, port := listenLoopback(t)
 	cfg := config.Config{DataDir: dataDir, DBPath: filepath.Join(dataDir, "sessions.db"),
 		Host: "127.0.0.1", Port: port}
-	vs, err := setupVectorServing(context.Background(), cfg, database)
+	vs, err := setupVectorServing(context.Background(), cfg, database, nil)
 	require.NoError(t, err)
 	assert.Nil(t, vs.Scheduler)
 	assert.Nil(t, vs.Close)

--- a/cmd/agentsview/embed_scheduler_test.go
+++ b/cmd/agentsview/embed_scheduler_test.go
@@ -774,7 +774,7 @@ func TestRecallSearcherNoActiveGenerationNamesRecallBuild(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, ix.Close()) })
 	searcher := recallSearcherAdapter{ix: ix, database: database, cfg: cfg}
 
-	_, _, err = searcher.SearchRecall(t.Context(), "database pool", 5)
+	_, _, _, err = searcher.SearchRecall(t.Context(), "database pool", 5)
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, db.ErrSemanticUnavailable)
@@ -1222,7 +1222,7 @@ func TestRecallSearchRejectsCorpusMutationUntilRefresh(t *testing.T) {
 	searcher := recallSearcherAdapter{
 		ix: ix, enc: queryEncoder, database: database, cfg: cfg,
 	}
-	_, _, err = searcher.SearchRecall(t.Context(), "connection reuse", 5)
+	_, _, _, err = searcher.SearchRecall(t.Context(), "connection reuse", 5)
 	require.NoError(t, err)
 
 	searcher.enc = func(
@@ -1240,14 +1240,14 @@ func TestRecallSearchRejectsCorpusMutationUntilRefresh(t *testing.T) {
 		}
 		return queryEncoder(ctx, texts)
 	}
-	_, _, err = searcher.SearchRecall(t.Context(), "connection reuse", 5)
+	_, _, _, err = searcher.SearchRecall(t.Context(), "connection reuse", 5)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, db.ErrSemanticUnavailable)
 	assert.Contains(t, err.Error(), "changed during search")
 
 	searcher.enc = queryEncoder
 
-	_, _, err = searcher.SearchRecall(t.Context(), "connection reuse", 5)
+	_, _, _, err = searcher.SearchRecall(t.Context(), "connection reuse", 5)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, db.ErrSemanticUnavailable)
 	assert.Contains(t, err.Error(), "embeddings build --store recall")
@@ -1255,7 +1255,7 @@ func TestRecallSearchRejectsCorpusMutationUntilRefresh(t *testing.T) {
 	started, err = mgr.TryBuild(t.Context(), vector.BuildRequest{})
 	require.NoError(t, err)
 	require.True(t, started)
-	_, _, err = searcher.SearchRecall(t.Context(), "connection reuse", 5)
+	_, _, _, err = searcher.SearchRecall(t.Context(), "connection reuse", 5)
 	require.NoError(t, err)
 }
 

--- a/cmd/agentsview/embed_scheduler_test.go
+++ b/cmd/agentsview/embed_scheduler_test.go
@@ -421,6 +421,37 @@ func TestEmbedSchedulerRepeatedBackstopFailuresReleaseIdleLease(
 		fake.callsSnapshot(), "one backstop tick should get one bounded retry")
 }
 
+func TestEmbedSchedulerBackstopTicksDoNotRestartPendingRetry(t *testing.T) {
+	buildErr := errors.New("embedding request rejected")
+	fake := &fakeEmbedManager{results: []fakeTryBuildResult{
+		{started: true, err: buildErr},
+	}}
+	idled := make(chan struct{})
+	ctx, cancel := context.WithCancel(t.Context())
+	tracker := server.NewIdleTracker(5*time.Millisecond, func() {
+		close(idled)
+		cancel()
+	})
+	s := newEmbedScheduler(
+		fake, 70*time.Millisecond, 20*time.Millisecond, false, tracker,
+	)
+	go s.Run(ctx)
+	defer s.Stop()
+
+	waitForSchedulerCondition(t, func() bool { return fake.callCount() >= 1 },
+		"expected the initial backstop attempt")
+	go tracker.Run(ctx)
+	select {
+	case <-idled:
+	case <-time.After(500 * time.Millisecond):
+		require.Fail(t,
+			"frequent backstop ticks restarted the retry lifecycle and retained the idle lease")
+	}
+	assert.Equal(t, []vector.BuildRequest{
+		{Backstop: true}, {Backstop: true},
+	}, fake.callsSnapshot(), "one backstop work item should get one bounded retry")
+}
+
 func TestEmbedSchedulerExhaustedBackstopCarriesIntoNextNotification(
 	t *testing.T,
 ) {

--- a/cmd/agentsview/embeddings.go
+++ b/cmd/agentsview/embeddings.go
@@ -11,7 +11,7 @@ import (
 	"io"
 	"maps"
 	"net/http"
-	"os"
+	"net/url"
 	"slices"
 	"strconv"
 	"strings"
@@ -70,6 +70,7 @@ func newEmbeddingsCommand() *cobra.Command {
 
 // EmbeddingsBuildOptions holds the parsed `embeddings build` flags.
 type EmbeddingsBuildOptions struct {
+	Store         string
 	FullRebuild   bool
 	Backstop      bool
 	RepairInvalid bool
@@ -120,6 +121,8 @@ func newEmbeddingsBuildCommand() *cobra.Command {
 			"scheduled builds: mixing this flag with a different config "+
 			"default flips the index's scope on every other build, forcing "+
 			"a full mirror reconciliation each time.")
+	cmd.Flags().StringVar(&opts.Store, "store", "",
+		"Embedding store to build (default: messages)")
 	cmd.MarkFlagsMutuallyExclusive("full-rebuild", "repair-invalid")
 	cmd.MarkFlagsMutuallyExclusive("backstop", "repair-invalid")
 	return cmd
@@ -197,10 +200,11 @@ func newEmbeddingsRetireCommand() *cobra.Command {
 // vectorStoreSpec resolves an `--store` name against the registered
 // embedding stores. There is one registry entry per store; a PR adding a
 // new store registers its spec here and extends the daemon embeddings API
-// (which currently serves only the message store) alongside it.
+// alongside it.
 func vectorStoreSpec(name string) (vector.IndexSpec, error) {
 	specs := map[string]vector.IndexSpec{
 		vector.MessageIndexSpec().Name: vector.MessageIndexSpec(),
+		vector.RecallIndexSpec().Name:  vector.RecallIndexSpec(),
 	}
 	if name == "" {
 		name = vector.MessageIndexSpec().Name
@@ -274,6 +278,15 @@ func vectorGeneration(c config.VectorEmbeddingsConfig) kitvec.Generation {
 		Dimensions: c.Dimension,
 		Params:     params,
 	}
+}
+
+func recallVectorGeneration(
+	c config.VectorEmbeddingsConfig, extractionFingerprint string,
+) kitvec.Generation {
+	gen := vectorGeneration(c)
+	gen.Params["doc_unit_scheme"] = "recall_entry_v2"
+	gen.Params[vector.CorpusFingerprintParam] = extractionFingerprint
+	return gen
 }
 
 // newVectorEncoder builds the OpenAI-compatible embeddings encoder for one
@@ -358,14 +371,21 @@ func runEmbeddingsBuild(
 	if err := requireVectorEnabled(cfg); err != nil {
 		return err
 	}
+	spec, err := vectorStoreSpec(opts.Store)
+	if err != nil {
+		return err
+	}
 
 	includeAutomated := cfg.Vector.IncludeAutomated
 	if opts.IncludeAutomatedSet {
 		includeAutomated = opts.IncludeAutomated
 	}
+	includeAutomated = spec.NormalizeIncludeAutomated(includeAutomated)
 
 	if opts.FullRebuild && !opts.Yes {
-		proceed, err := confirmFullRebuild(ctx, in, out, cfg, includeAutomated)
+		proceed, err := confirmFullRebuild(
+			ctx, in, out, cfg, includeAutomated, spec.Name,
+		)
 		if err != nil {
 			return err
 		}
@@ -382,6 +402,7 @@ func runEmbeddingsBuild(
 	}
 
 	req := vector.BuildRequest{
+		Store:            strings.TrimSpace(opts.Store),
 		FullRebuild:      opts.FullRebuild,
 		Backstop:         opts.Backstop,
 		RepairInvalid:    opts.RepairInvalid,
@@ -399,9 +420,10 @@ func runEmbeddingsBuild(
 // documents (user messages and assistant runs) in the archive under
 // includeAutomated's scope — the exact set a full rebuild re-embeds.
 func confirmFullRebuild(
-	ctx context.Context, in io.Reader, out io.Writer, cfg config.Config, includeAutomated bool,
+	ctx context.Context, in io.Reader, out io.Writer, cfg config.Config,
+	includeAutomated bool, store string,
 ) (bool, error) {
-	n, err := countEmbeddableUnits(ctx, cfg, includeAutomated)
+	n, err := countEmbeddingStoreUnits(ctx, cfg, includeAutomated, store)
 	if err != nil {
 		return false, fmt.Errorf("counting documents: %w", err)
 	}
@@ -409,18 +431,21 @@ func confirmFullRebuild(
 	return confirm(in, out, msg), nil
 }
 
-// countEmbeddableUnits opens the archive database read-only and counts
-// every unit document eligible for embedding under includeAutomated's
-// scope, for the full-rebuild confirmation prompt.
-func countEmbeddableUnits(ctx context.Context, cfg config.Config, includeAutomated bool) (int, error) {
+func countEmbeddingStoreUnits(
+	ctx context.Context, cfg config.Config, includeAutomated bool, store string,
+) (int, error) {
 	archiveDB, err := openReadOnlyDB(cfg)
 	if err != nil {
 		return 0, err
 	}
 	defer archiveDB.Close()
 
+	source, _, _, err := embeddingBuildTarget(ctx, archiveDB, cfg, store)
+	if err != nil {
+		return 0, err
+	}
 	var n int
-	if _, err := archiveDB.ScanEmbeddableUnits(
+	if _, err := source.ScanEmbeddableUnits(
 		ctx, "", includeAutomated, func(db.EmbeddableUnit) error {
 			n++
 			return nil
@@ -449,8 +474,13 @@ func runEmbeddingsBuildDirect(
 	}
 	defer archiveDB.Close()
 
-	ix, err := vector.Open(
-		ctx, cfg.Vector.ResolvedDBPath(cfg.DataDir), false, cfg.Vector.Embeddings.MaxInputChars,
+	spec, err := vectorStoreSpec(req.Store)
+	if err != nil {
+		return err
+	}
+	ix, err := vector.OpenSpec(
+		ctx, cfg.Vector.ResolvedDBPath(cfg.DataDir), spec, false,
+		cfg.Vector.Embeddings.MaxInputChars,
 	)
 	if err != nil {
 		return fmt.Errorf("opening vectors.db: %w", err)
@@ -462,8 +492,78 @@ func runEmbeddingsBuildDirect(
 		return err
 	}
 
-	m := vector.NewManager(ix, archiveDB, encoders, vectorGeneration(cfg.Vector.Embeddings))
+	m := embeddingManager(ix, archiveDB, encoders, cfg, spec.Name)
 	return runDirectBuild(ctx, out, m, req)
+}
+
+type recallEmbeddingSource struct {
+	db *db.DB
+}
+
+func (s recallEmbeddingSource) ScanEmbeddableUnits(
+	ctx context.Context, since string, _ bool,
+	fn func(db.EmbeddableUnit) error,
+) (string, error) {
+	return s.db.ScanRecallEmbeddingUnits(
+		ctx, since, fn,
+	)
+}
+
+const importedOnlyRecallCorpusFingerprint = "no-active-extraction-v1"
+
+func recallCorpusFingerprint(ctx context.Context, database *db.DB) (string, error) {
+	generations, err := database.ExtractGenerations(ctx)
+	if err != nil {
+		return "", err
+	}
+	for _, generation := range generations {
+		if generation.State == db.ExtractGenerationActive {
+			return generation.Fingerprint, nil
+		}
+	}
+	return importedOnlyRecallCorpusFingerprint, nil
+}
+
+func embeddingBuildTarget(
+	ctx context.Context, database *db.DB, cfg config.Config, store string,
+) (vector.UnitSource, kitvec.Generation, string, error) {
+	if store != vector.RecallIndexSpec().Name {
+		return database, vectorGeneration(cfg.Vector.Embeddings), "", nil
+	}
+	fingerprint, err := recallCorpusFingerprint(ctx, database)
+	if err != nil {
+		return nil, kitvec.Generation{}, "", err
+	}
+	revision, err := database.RecallCorpusRevision(ctx)
+	if err != nil {
+		return nil, kitvec.Generation{}, "", err
+	}
+	return recallEmbeddingSource{db: database},
+		recallVectorGeneration(cfg.Vector.Embeddings, fingerprint), revision, nil
+}
+
+func embeddingManager(
+	ix *vector.Index, database *db.DB, encoders vector.EncoderSet,
+	cfg config.Config, store string,
+) *vector.Manager {
+	if store != vector.RecallIndexSpec().Name {
+		return vector.NewManager(
+			ix, database, encoders, vectorGeneration(cfg.Vector.Embeddings),
+		)
+	}
+	return vector.NewResolvingManager(
+		ix,
+		encoders,
+		recallVectorGeneration(cfg.Vector.Embeddings, ""),
+		func(ctx context.Context) (vector.BuildTarget, error) {
+			source, generation, revision, err := embeddingBuildTarget(
+				ctx, database, cfg, store,
+			)
+			return vector.BuildTarget{
+				Source: source, Generation: generation, CorpusRevision: revision,
+			}, err
+		},
+	)
 }
 
 // runDirectBuild runs m.TryBuild synchronously on a background goroutine
@@ -516,6 +616,7 @@ func runEmbeddingsBuildDaemon(
 	if err != nil {
 		return err
 	}
+	client.store = daemonEmbeddingStore(req.Store)
 	return buildViaDaemon(ctx, out, client, req)
 }
 
@@ -642,7 +743,7 @@ func printBuildSummary(w io.Writer, result vector.BuildResult) {
 // renders it as a table or JSON. Generation IDs are only unique within a
 // store, so every entry is stamped with the resolved store's name before
 // display, including entries fetched from the daemon (which does not send
-// one, since it currently only serves the message store).
+// one because the selected store is already explicit in the request).
 func runEmbeddingsList(ctx context.Context, out io.Writer, jsonOutput bool, store string) error {
 	cfg, err := config.LoadMinimal()
 	if err != nil {
@@ -662,6 +763,7 @@ func runEmbeddingsList(ctx context.Context, out io.Writer, jsonOutput bool, stor
 		if err != nil {
 			return err
 		}
+		client.store = daemonEmbeddingStore(spec.Name)
 		gens, err = client.generations(ctx)
 		if err != nil {
 			return err
@@ -695,11 +797,12 @@ func directListGenerations(
 	ctx context.Context, cfg config.Config, spec vector.IndexSpec,
 ) ([]vector.GenerationInfo, error) {
 	path := cfg.Vector.ResolvedDBPath(cfg.DataDir)
-	if _, err := os.Stat(path); err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
+	exists, err := vector.StoreExists(ctx, path, spec)
+	if err != nil {
 		return nil, err
+	}
+	if !exists {
+		return nil, nil
 	}
 	ix, err := vector.OpenSpec(ctx, path, spec, true, cfg.Vector.Embeddings.MaxInputChars)
 	if err != nil {
@@ -733,9 +836,7 @@ func truncateFingerprint(fp string) string {
 // `retire <id>`: it loads config, gates on [vector] enabled, resolves the
 // requested store, and dispatches the requested action to the daemon or
 // directly. A 409/refusal error's message is returned verbatim (no extra
-// wrapping) so it displays exactly as the manager phrased it. The daemon
-// only serves the message store, so the daemon path needs no request
-// change beyond resolving (and thereby validating) the --store name.
+// wrapping) so it displays exactly as the manager phrased it.
 func runEmbeddingsGenerationAction(
 	ctx context.Context, out io.Writer, id int64, force, retire bool, store string,
 ) error {
@@ -756,6 +857,7 @@ func runEmbeddingsGenerationAction(
 		if err != nil {
 			return err
 		}
+		client.store = daemonEmbeddingStore(spec.Name)
 		if retire {
 			err = client.retire(ctx, id, force)
 		} else {
@@ -825,6 +927,7 @@ func resolveEmbeddingsDaemonClient(cfg config.Config) (embeddingsDaemonClient, e
 type embeddingsDaemonClient struct {
 	baseURL string
 	token   string
+	store   string
 }
 
 // daemonAPIError carries an embeddings API error response's HTTP status
@@ -844,6 +947,7 @@ func (e *daemonAPIError) Error() string { return e.message }
 // explicit `--include-automated=false` override when the daemon's config
 // says true.
 type daemonBuildRequest struct {
+	Store            string `json:"store,omitempty"`
 	FullRebuild      bool   `json:"full_rebuild,omitempty"`
 	Backstop         bool   `json:"backstop,omitempty"`
 	RepairInvalid    bool   `json:"repair_invalid,omitempty"`
@@ -853,6 +957,7 @@ type daemonBuildRequest struct {
 
 func (c embeddingsDaemonClient) startBuild(ctx context.Context, req vector.BuildRequest) error {
 	wire := daemonBuildRequest{
+		Store:            req.Store,
 		FullRebuild:      req.FullRebuild,
 		Backstop:         req.Backstop,
 		RepairInvalid:    req.RepairInvalid,
@@ -864,7 +969,7 @@ func (c embeddingsDaemonClient) startBuild(ctx context.Context, req vector.Build
 
 func (c embeddingsDaemonClient) status(ctx context.Context) (vector.BuildStatus, error) {
 	var st vector.BuildStatus
-	err := c.do(ctx, http.MethodGet, "/api/v1/embeddings/status", nil, &st)
+	err := c.do(ctx, http.MethodGet, c.storePath("/api/v1/embeddings/status"), nil, &st)
 	return st, err
 }
 
@@ -872,18 +977,32 @@ func (c embeddingsDaemonClient) generations(ctx context.Context) ([]vector.Gener
 	var body struct {
 		Generations []vector.GenerationInfo `json:"generations"`
 	}
-	err := c.do(ctx, http.MethodGet, "/api/v1/embeddings/generations", nil, &body)
+	err := c.do(ctx, http.MethodGet, c.storePath("/api/v1/embeddings/generations"), nil, &body)
 	return body.Generations, err
 }
 
 func (c embeddingsDaemonClient) activate(ctx context.Context, id int64, force bool) error {
 	path := fmt.Sprintf("/api/v1/embeddings/generations/%d/activate", id)
-	return c.do(ctx, http.MethodPost, path, map[string]bool{"force": force}, nil)
+	return c.do(ctx, http.MethodPost, c.storePath(path), map[string]bool{"force": force}, nil)
 }
 
 func (c embeddingsDaemonClient) retire(ctx context.Context, id int64, force bool) error {
 	path := fmt.Sprintf("/api/v1/embeddings/generations/%d/retire", id)
-	return c.do(ctx, http.MethodPost, path, map[string]bool{"force": force}, nil)
+	return c.do(ctx, http.MethodPost, c.storePath(path), map[string]bool{"force": force}, nil)
+}
+
+func daemonEmbeddingStore(name string) string {
+	if name == vector.MessageIndexSpec().Name {
+		return ""
+	}
+	return name
+}
+
+func (c embeddingsDaemonClient) storePath(path string) string {
+	if c.store == "" {
+		return path
+	}
+	return path + "?store=" + url.QueryEscape(c.store)
 }
 
 // do performs one HTTP call against the daemon's embeddings API,

--- a/cmd/agentsview/embeddings_test.go
+++ b/cmd/agentsview/embeddings_test.go
@@ -194,6 +194,27 @@ func TestVectorGenerationParams(t *testing.T) {
 		"enabling request_dimensions cuts a new generation")
 }
 
+func TestRecallVectorGenerationExtendsExtractionFingerprint(t *testing.T) {
+	cfg := config.VectorEmbeddingsConfig{
+		Model: "embed-model", Dimension: 3, MaxInputChars: 4000,
+	}
+
+	oldGeneration := recallVectorGeneration(cfg, "extract-old")
+	newGeneration := recallVectorGeneration(cfg, "extract-new")
+
+	assert.Equal(t, "extract-old",
+		oldGeneration.Params[vector.CorpusFingerprintParam])
+	assert.Equal(t, "recall_entry_v2", oldGeneration.Params["doc_unit_scheme"])
+	assert.NotEqual(t, oldGeneration.Fingerprint(), newGeneration.Fingerprint())
+}
+
+func TestVectorStoreSpecIncludesRecall(t *testing.T) {
+	spec, err := vectorStoreSpec("recall")
+
+	require.NoError(t, err)
+	assert.Equal(t, vector.RecallIndexSpec(), spec)
+}
+
 // TestEmbeddingsDisabledReturnsError asserts every subcommand refuses with
 // the exact "vector search is not enabled" message when [vector] is off
 // (the default), before attempting any daemon detection or I/O.
@@ -353,6 +374,33 @@ func TestEmbeddingsListEmptyIndexReturnsNoRows(t *testing.T) {
 	require.Len(t, lines, 1, "expected only the header line, got: %q", out.String())
 }
 
+func TestDirectListGenerationsReturnsEmptyForUnbuiltSelectedStore(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		built vector.IndexSpec
+		list  vector.IndexSpec
+	}{
+		{name: "message only", built: vector.MessageIndexSpec(), list: vector.RecallIndexSpec()},
+		{name: "recall only", built: vector.RecallIndexSpec(), list: vector.MessageIndexSpec()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dataDir := t.TempDir()
+			cfg := vectorTestConfig(dataDir)
+			ix, err := vector.OpenSpec(
+				t.Context(), cfg.Vector.ResolvedDBPath(dataDir), tc.built,
+				false, cfg.Vector.Embeddings.MaxInputChars,
+			)
+			require.NoError(t, err)
+			require.NoError(t, ix.Close())
+
+			generations, err := directListGenerations(t.Context(), cfg, tc.list)
+
+			require.NoError(t, err)
+			assert.Empty(t, generations)
+		})
+	}
+}
+
 // TestEmbeddingsBuildDirectEndToEnd seeds a temp archive with one user
 // message and a two-message assistant run (two embeddable units), points
 // [vector.embeddings] at an httptest OpenAI-compatible stub, and asserts the
@@ -373,6 +421,49 @@ func TestEmbeddingsBuildDirectEndToEnd(t *testing.T) {
 
 	assert.Contains(t, out.String(), "Embedded 2 documents (2 chunks), skipped 0, stale 0")
 	assert.Contains(t, out.String(), "Generation activated.")
+}
+
+func TestImportedOnlyRecallEmbeddingsBuildAndVectorQueryEndToEnd(t *testing.T) {
+	dataDir := testDataDir(t)
+	stub := newEmbeddingsStubServer(t, 3)
+	defer stub.Close()
+	writeEmbeddingsTestConfig(t, dataDir, stub.URL+"/v1")
+
+	archivePath := filepath.Join(dataDir, "sessions.db")
+	database, err := db.Open(archivePath)
+	require.NoError(t, err)
+	dbtest.SeedSession(t, database, "s1", "agentsview")
+	_, err = database.InsertRecallEntry(db.RecallEntry{
+		ID: "recall-entry", Type: "fact", Scope: "project", Status: "accepted",
+		Title: "Database pool", Body: "Reuse idle connections.",
+		Project: "agentsview", SourceSessionID: "s1",
+		SourceRunID: "import-run", ExtractorMethod: "import-v1",
+	})
+	require.NoError(t, err)
+	require.NoError(t, database.Close())
+
+	cmd := newEmbeddingsBuildCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--store", "recall"})
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, out.String(), "Embedded 1 documents (1 chunks)")
+
+	database, err = db.Open(archivePath)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	cfg, err := config.LoadMinimal()
+	require.NoError(t, err)
+	closeVector := installDirectVectorSearcher(cfg, database)
+	require.NotNil(t, closeVector)
+	t.Cleanup(func() { require.NoError(t, closeVector()) })
+
+	page, err := database.QueryRecallEntries(context.Background(), db.RecallQuery{
+		Text: "connection reuse", Mode: db.RecallQueryModeVector, Limit: 5,
+	})
+	require.NoError(t, err)
+	require.Len(t, page.RecallEntries, 1)
+	assert.Equal(t, "recall-entry", page.RecallEntries[0].ID)
 }
 
 // TestRoleAwarePrefixesReachBuildAndSearch exercises the user-visible role
@@ -905,6 +996,36 @@ func TestEmbeddingsBuildIncludeAutomatedFlagThreadsToDaemonRequest(t *testing.T)
 	require.NoError(t, cmd.Execute())
 
 	assert.True(t, gotIncludeAutomated.Load(), "--include-automated must pass through to the daemon")
+}
+
+func TestRecallEmbeddingsBuildNormalizesIncludeAutomatedForDaemon(t *testing.T) {
+	dataDir := testDataDir(t)
+	writeEmbeddingsTestConfig(t, dataDir, "http://127.0.0.1:1")
+
+	var gotIncludeAutomated atomic.Bool
+	startEmbeddingsTestDaemon(t, dataDir, map[string]http.HandlerFunc{
+		"POST /api/v1/embeddings/build": func(w http.ResponseWriter, r *http.Request) {
+			var req vector.BuildRequest
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+			gotIncludeAutomated.Store(req.IncludeAutomated)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(map[string]bool{"started": true})
+		},
+		"GET /api/v1/embeddings/status": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(vector.BuildStatus{Running: false})
+		},
+	})
+
+	cmd := newEmbeddingsBuildCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{"--store", "recall", "--include-automated"})
+	require.NoError(t, cmd.Execute())
+
+	assert.False(t, gotIncludeAutomated.Load(),
+		"Recall has no automated-session scope and must normalize it")
 }
 
 // TestEmbeddingsBuildDaemonRequestDefaultsToConfigScope asserts that without

--- a/cmd/agentsview/extract_scheduler.go
+++ b/cmd/agentsview/extract_scheduler.go
@@ -38,6 +38,11 @@ type extractScheduler struct {
 	// lease so a detached daemon cannot idle out — cancelling the shared
 	// context — under a long model-backed pass. Nil in foreground mode.
 	idle *server.IdleTracker
+	// onPassFinished is called after every pass that started, even when it
+	// returns an error. Extraction commits per session, so a later failure can
+	// still leave downstream recall embeddings stale. Dropped passes do not
+	// call it because they cannot have changed the corpus.
+	onPassFinished func()
 
 	dirty chan struct{}
 	stop  chan struct{}
@@ -216,6 +221,9 @@ func (s *extractScheduler) tryPassWithLease(
 	}
 	defer release()
 	started, _, err = s.mgr.TryPass(ctx, opts)
+	if started && s.onPassFinished != nil {
+		s.onPassFinished()
+	}
 	return started, true, err
 }
 

--- a/cmd/agentsview/extract_scheduler_test.go
+++ b/cmd/agentsview/extract_scheduler_test.go
@@ -25,6 +25,7 @@ type fakePassManager struct {
 
 type fakeTryPassResult struct {
 	started bool
+	result  extract.PassResult
 	err     error
 }
 
@@ -37,11 +38,11 @@ func (f *fakePassManager) TryPass(
 	idx := len(f.calls) - 1
 	if idx < len(f.results) {
 		r := f.results[idx]
-		return r.started, extract.PassResult{}, r.err
+		return r.started, r.result, r.err
 	}
 	if len(f.results) > 0 {
 		r := f.results[len(f.results)-1]
-		return r.started, extract.PassResult{}, r.err
+		return r.started, r.result, r.err
 	}
 	return true, extract.PassResult{}, nil
 }
@@ -82,6 +83,40 @@ func TestExtractSchedulerBurstOfNotifyProducesExactlyOnePass(t *testing.T) {
 	calls = mgr.callsSnapshot()
 	assert.False(t, calls[1].Full,
 		"event-driven passes after the startup pass are incremental")
+}
+
+func TestExtractSchedulerNotifiesDownstreamAfterEveryStartedPass(t *testing.T) {
+	mgr := &fakePassManager{results: []fakeTryPassResult{
+		{started: false},
+		{
+			started: true,
+			result:  extract.PassResult{Sessions: 1, Entries: 2},
+			err:     errors.New("later extraction failed"),
+		},
+		{started: true},
+	}}
+	s := newExtractScheduler(mgr, time.Hour, 0, 0, nil)
+	var notified int
+	s.onPassFinished = func() { notified++ }
+
+	started, ok, err := s.tryPassWithLease(t.Context(), extract.PassOptions{})
+	assert.False(t, started)
+	assert.True(t, ok)
+	require.NoError(t, err)
+	assert.Zero(t, notified)
+
+	started, ok, err = s.tryPassWithLease(t.Context(), extract.PassOptions{})
+	assert.True(t, started)
+	assert.True(t, ok)
+	require.EqualError(t, err, "later extraction failed")
+	assert.Equal(t, 1, notified,
+		"partial commits must refresh downstream indexes despite a later error")
+
+	started, ok, err = s.tryPassWithLease(t.Context(), extract.PassOptions{})
+	assert.True(t, started)
+	assert.True(t, ok)
+	require.NoError(t, err)
+	assert.Equal(t, 2, notified)
 }
 
 func TestExtractSchedulerBackstopTickRunsFullPass(t *testing.T) {

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -258,7 +258,7 @@ func runServe(cfg config.Config, opts serveOptions) {
 
 	broadcaster := server.NewBroadcaster(cfg.EventsCoalesceInterval)
 
-	vectorServe, err := setupVectorServing(ctx, cfg, database)
+	vectorServe, err := setupVectorServing(ctx, cfg, database, idleTracker)
 	if err != nil {
 		fatal("setting up vector index: %v", err)
 	}
@@ -270,20 +270,18 @@ func runServe(cfg config.Config, opts serveOptions) {
 		}()
 	}
 
-	var emitter sync.Emitter = broadcaster
-	if vectorServe.Scheduler != nil {
-		emitter = teeEmitter{
-			primary:      broadcaster,
-			scheduler:    vectorServe.Scheduler,
-			runAfterSync: cfg.Vector.Embed.RunAfterSyncEnabled(),
-		}
-	}
+	emitter := wrapEmbeddingSyncEmitter(
+		broadcaster, vectorServe, cfg.Vector.Embed.RunAfterSyncEnabled(),
+	)
 
 	extractSched, err := setupRecallExtraction(cfg, database, idleTracker)
 	if err != nil {
 		fatal("setting up recall extraction: %v", err)
 	}
 	if extractSched != nil {
+		if vectorServe.RecallMutationNotify != nil {
+			extractSched.onPassFinished = vectorServe.RecallMutationNotify
+		}
 		emitter = extractTeeEmitter{primary: emitter, scheduler: extractSched}
 	}
 
@@ -566,6 +564,10 @@ func runServe(cfg config.Config, opts serveOptions) {
 		// unwind order runs Stop (which waits for any in-flight
 		// TryBuild to return) before vectors.db is closed.
 		defer vectorServe.Scheduler.Stop()
+	}
+	if vectorServe.RecallScheduler != nil {
+		go vectorServe.RecallScheduler.Run(ctx)
+		defer vectorServe.RecallScheduler.Stop()
 	}
 
 	if extractSched != nil {
@@ -1080,6 +1082,7 @@ func runWorkerResyncBuild(
 		// fallback from launching another archive-scale pass. The emit and
 		// startup callback fire after the lock below.
 		doneStats = statsFromWorkerResult(result)
+		doneStats.ArchiveRebuilt = true
 		engine.RecordStartupReconciledExclusive(doneStats, nil)
 		return nil
 	})

--- a/cmd/agentsview/mcp.go
+++ b/cmd/agentsview/mcp.go
@@ -34,7 +34,7 @@ func newMCPCommand() *cobra.Command {
 StreamableHTTP, exposing read-only tools for searching and reading
 recorded agent sessions: search_sessions, list_sessions,
 get_session_overview, get_messages, search_content, and
-get_usage_summary.
+get_usage_summary, plus query_recall for distilled session knowledge.
 
 The server reads through the daemon path. By default each tool call talks to
 the local agentsview daemon, starting it when needed so a long-lived MCP server
@@ -150,7 +150,13 @@ func resolveMCPService(
 		if err != nil {
 			return nil, nil, err
 		}
-		return service.NewHTTPBackend(remote, token, false),
+		capabilities, err := service.ProbeHTTPServerCapabilities(
+			cmd.Context(), remote, token,
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		return service.NewHTTPBackendForServer(remote, token, capabilities),
 			func() {}, nil
 	}
 	cfg, err := config.LoadPFlags(cmd.Flags())
@@ -174,6 +180,14 @@ type mcpDaemonService struct {
 
 func newMCPDaemonService(cfg config.Config) service.SessionService {
 	return &mcpDaemonService{cfg: cfg}
+}
+
+func (s *mcpDaemonService) SupportsRecallQueries() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	runtime := FindDaemonRuntime(s.cfg.DataDir, s.cfg.AuthToken)
+	return runtime == nil || !runtime.ReadOnly
 }
 
 func (s *mcpDaemonService) daemonService(

--- a/cmd/agentsview/mcp_test.go
+++ b/cmd/agentsview/mcp_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -147,6 +148,59 @@ func TestResolveMCPServicePGFlagUsesPGReadStore(t *testing.T) {
 	assert.Equal(t, "custom_schema", stub.PG.Schema)
 }
 
+func TestResolveMCPServiceExplicitServerUsesReportedCapabilities(
+	t *testing.T,
+) {
+	tokenFile := filepath.Join(t.TempDir(), "token")
+	require.NoError(t, os.WriteFile(tokenFile, []byte("probe-token\n"), 0o600))
+
+	tests := []struct {
+		name                 string
+		readOnly             bool
+		apiVersion           int
+		wantRecallCapability bool
+	}{
+		{
+			name: "writable API v4 server", apiVersion: 4,
+			wantRecallCapability: true,
+		},
+		{name: "writable API v3 server", apiVersion: 3},
+		{name: "read-only API v4 server", readOnly: true, apiVersion: 4},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var probeCount int
+			srv := httptest.NewServer(http.HandlerFunc(func(
+				w http.ResponseWriter, r *http.Request,
+			) {
+				probeCount++
+				assert.Equal(t, "/api/v1/version", r.URL.Path)
+				assert.Equal(t, "Bearer probe-token", r.Header.Get("Authorization"))
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"read_only":   tt.readOnly,
+					"api_version": tt.apiVersion,
+				})
+			}))
+			t.Cleanup(srv.Close)
+
+			cmd := newMCPCommand()
+			cmd.SetContext(context.Background())
+			require.NoError(t, cmd.ParseFlags([]string{
+				"--server", srv.URL,
+				"--server-token-file", tokenFile,
+			}))
+
+			svc, cleanup, err := resolveMCPService(cmd)
+			require.NoError(t, err)
+			t.Cleanup(cleanup)
+
+			assert.Equal(t, tt.wantRecallCapability,
+				service.SupportsRecallQueries(svc))
+			assert.Equal(t, 1, probeCount)
+		})
+	}
+}
+
 func TestMCPDaemonServiceStartsDaemonForEachOperation(t *testing.T) {
 	dataDir := t.TempDir()
 	cfg := config.Config{
@@ -180,6 +234,26 @@ func TestMCPDaemonServiceStartsDaemonForEachOperation(t *testing.T) {
 	}
 	assert.Equal(t, 2, starts)
 	assert.NoFileExists(t, cfg.DBPath)
+}
+
+func TestMCPDaemonServiceRecallCapabilityFollowsResolvedRuntime(t *testing.T) {
+	tests := []struct {
+		name     string
+		readOnly bool
+		want     bool
+	}{
+		{name: "writable daemon", want: true},
+		{name: "read-only daemon", readOnly: true, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dataDir := runtimeTestDir(t)
+			writeLiveRuntime(t, dataDir, tt.readOnly)
+			svc := newMCPDaemonService(config.Config{DataDir: dataDir})
+
+			assert.Equal(t, tt.want, service.SupportsRecallQueries(svc))
+		})
+	}
 }
 
 func TestMCPDaemonService_UsagePairwiseComparisonForwardsToDaemon(t *testing.T) {

--- a/cmd/agentsview/recall.go
+++ b/cmd/agentsview/recall.go
@@ -1231,6 +1231,12 @@ func currentGitRoot() (string, error) {
 
 func addRecallQueryFlags(cmd *cobra.Command, req *service.RecallQuery) {
 	flags := cmd.Flags()
+	flags.StringVar(
+		&req.Mode,
+		"mode",
+		db.RecallQueryModeLexical,
+		"Retrieval mode: lexical, vector, or hybrid",
+	)
 	flags.StringVar(&req.Project, "project", "", "Filter by project")
 	flags.StringVar(&req.CWD, "cwd", "", "Filter by cwd")
 	flags.StringVar(&req.GitBranch, "git-branch", "", "Filter by git branch")

--- a/cmd/agentsview/recall_test.go
+++ b/cmd/agentsview/recall_test.go
@@ -232,6 +232,7 @@ func TestRecallQueryUsesExplicitServerURL(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		require.NoError(t, json.NewEncoder(w).Encode(service.RecallQueryResult{
 			QueryID: "remote-query-id",
+			Mode:    db.RecallQueryModeHybrid,
 			RecallEntries: []db.RecallResult{{
 				RecallEntry: db.RecallEntry{
 					ID:              "m-remote",
@@ -251,11 +252,13 @@ func TestRecallQueryUsesExplicitServerURL(t *testing.T) {
 	out, err := executeCommand(newRootCommand(),
 		"recall", "--server", srv.URL,
 		"query", "remote daemon recall",
+		"--mode", "hybrid",
 		"--format", "json")
 
 	require.NoError(t, err)
 	assert.Equal(t, "/api/v1/recall/query", gotPath)
 	assert.Equal(t, "remote daemon recall", gotReq.Query)
+	assert.Equal(t, db.RecallQueryModeHybrid, gotReq.Mode)
 	assert.Equal(t, "query", gotReq.Surface)
 	assert.NoFileExists(t, filepath.Join(dataDir, "sessions.db"))
 	var got service.RecallQueryResult

--- a/docs/semantic-search.md
+++ b/docs/semantic-search.md
@@ -51,6 +51,7 @@ max_retries = 3                   # attempts on 429/5xx/network errors; 4xx fail
 
 [vector.embed]
 run_after_sync = true             # daemon embeds deltas after each sync, debounced ~30s (default true)
+recall = false                    # default; set true to permit automatic Recall embedding
 backstop_interval = "24h"         # periodic full reconciliation scan; negative disables (default "24h")
 ```
 
@@ -58,6 +59,18 @@ backstop_interval = "24h"         # periodic full reconciliation scan; negative 
 entry with an `endpoint` are required once `enabled = true`; `agentsview` fails
 fast with an actionable message if any is missing or a duration field doesn't
 parse. Restart the daemon (or run a CLI command) after editing the file.
+
+Automatic Recall embedding has a separate, default-off consent gate. Setting
+`[vector.embed] recall = true` permits daemon startup, corpus mutations, and
+periodic backstops to send accepted Recall entry titles, bodies, and triggers
+to the configured embeddings endpoint. `run_after_sync` controls only session
+archive sync notifications; it does not suppress Recall startup or Recall
+corpus-mutation refreshes after that consent is enabled. A manual
+`agentsview embeddings build --store recall` remains available without this
+setting because invoking that command is an explicit one-time request.
+Recall vector and hybrid queries also fail closed as unavailable whenever the
+served Recall corpus is newer than the last completed build; lexical queries
+remain available while an automatic or manual refresh catches up.
 
 ### Named embeddings servers
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -274,6 +274,9 @@ type VectorEmbedConfig struct {
 	// RunAfterSync enables debounced embedding of sync deltas.
 	// Defaults to true when unset; read it via RunAfterSyncEnabled.
 	RunAfterSync *bool `toml:"run_after_sync" json:"run_after_sync,omitempty"`
+	// Recall explicitly permits automatic Recall embedding. It defaults to
+	// false because Recall entries may contain distilled private content.
+	Recall bool `toml:"recall" json:"recall"`
 	// BackstopInterval is a parseable duration string for a periodic
 	// full rescan. Default "24h"; a negative duration disables it.
 	BackstopInterval string `toml:"backstop_interval" json:"backstop_interval"`
@@ -1187,6 +1190,9 @@ func (c *Config) applyConfigTOML(data string) error {
 	}
 	if file.Vector.Embed.RunAfterSync != nil {
 		c.Vector.Embed.RunAfterSync = file.Vector.Embed.RunAfterSync
+	}
+	if meta.IsDefined("vector", "embed", "recall") {
+		c.Vector.Embed.Recall = file.Vector.Embed.Recall
 	}
 	if file.Vector.Embed.BackstopInterval != "" {
 		c.Vector.Embed.BackstopInterval = file.Vector.Embed.BackstopInterval

--- a/internal/config/config_vector_test.go
+++ b/internal/config/config_vector_test.go
@@ -237,6 +237,8 @@ func TestVectorConfigDefaults(t *testing.T) {
 	assert.Empty(t, cfg.Vector.Embeddings.Servers)
 	assert.True(t, cfg.Vector.Embed.RunAfterSyncEnabled(),
 		"run_after_sync defaults to true when unset")
+	assert.False(t, cfg.Vector.Embed.Recall,
+		"automatic Recall embedding requires explicit opt-in")
 
 	disabled := false
 	cfg.Vector.Embed.RunAfterSync = &disabled
@@ -396,6 +398,23 @@ func TestVectorConfigTOMLLoad(t *testing.T) {
 			},
 		})
 		assert.True(t, cfg.Vector.IncludeAutomated)
+	})
+
+	t.Run("automatic Recall embedding opt-in is loaded", func(t *testing.T) {
+		cfg := loadMinimalWithConfig(t, map[string]any{
+			"vector": map[string]any{
+				"enabled": true,
+				"embeddings": map[string]any{
+					"model":     "nomic-embed-text",
+					"dimension": 768,
+					"servers":   minimalServers(),
+				},
+				"embed": map[string]any{
+					"recall": true,
+				},
+			},
+		})
+		assert.True(t, cfg.Vector.Embed.Recall)
 	})
 
 	t.Run("enabled without servers fails to load", func(t *testing.T) {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -534,6 +534,7 @@ type DB struct {
 
 	vectorMu       sync.RWMutex
 	vectorSearcher VectorSearcher
+	recallSearcher RecallVectorSearcher
 }
 
 // Reader exposes guarded read-only query operations. It intentionally does

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -408,8 +408,12 @@ type EmbeddableUnit struct {
 	Ordinal     int    // first member's ordinal (ordinal_start)
 	OrdinalEnd  int    // last member's ordinal (== Ordinal for user docs)
 	Subordinate bool
-	Content     string       // members joined with "\n\n"
-	Offsets     []UnitOffset // one per member; nil for user docs
+	// Deleted marks a stable document identity that left its source corpus.
+	// Incremental mirror refreshes remove its row and vectors instead of
+	// embedding Content. Message scans never emit tombstones; recall scans do.
+	Deleted bool
+	Content string       // members joined with "\n\n"
+	Offsets []UnitOffset // one per member; nil for user docs
 }
 
 // UnitOffset locates one member message inside a run's joined content.

--- a/internal/db/recall.go
+++ b/internal/db/recall.go
@@ -1164,7 +1164,9 @@ func (db *DB) queryRecallEntriesVector(
 ) (RecallPage, error) {
 	searcher := db.getRecallVectorSearcher()
 	if searcher == nil {
-		return RecallPage{}, ErrSemanticUnavailable
+		return RecallPage{}, NewSemanticUnavailableError(
+			"recall index is not available; run 'agentsview embeddings build --store recall'",
+		)
 	}
 	limit := recallLimit(q.Limit)
 	k := max(recallLimit(q.Limit)*4, SemanticOverfetchMin)

--- a/internal/db/recall.go
+++ b/internal/db/recall.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"slices"
 	"sort"
 	"strings"
 
@@ -18,6 +19,9 @@ const (
 	MaxRecallSearchTerms             = corerecall.MaxScoringQueryTerms
 	recallFTS4PreselectLimit         = 50000
 	recallEvidenceFTS4PreselectLimit = 50000
+	RecallQueryModeLexical           = "lexical"
+	RecallQueryModeVector            = "vector"
+	RecallQueryModeHybrid            = "hybrid"
 )
 
 type RecallEntry struct {
@@ -82,6 +86,7 @@ type RecallEvidence struct {
 
 type RecallQuery struct {
 	Text                string
+	Mode                string
 	Project             string
 	CWD                 string
 	GitBranch           string
@@ -237,6 +242,15 @@ func (db *DB) CopyRecallEntriesFrom(sourcePath string) error {
 	if err := copyRecallExtractStateFromAttachedTx(ctx, tx); err != nil {
 		return err
 	}
+	if err := copyRecallCorpusRevisionFromAttachedTx(ctx, tx); err != nil {
+		return err
+	}
+	if err := copyRecallEmbeddingChangesFromAttachedTx(ctx, tx); err != nil {
+		return err
+	}
+	if err := copyRecallEmbeddingDeletionsFromAttachedTx(ctx, tx); err != nil {
+		return err
+	}
 
 	res, err := tx.ExecContext(ctx, `
 		INSERT OR IGNORE INTO recall_entries (
@@ -312,6 +326,93 @@ func (db *DB) CopyRecallEntriesFrom(sourcePath string) error {
 				"source session not preserved)",
 			copied, total, total-copied,
 		)
+	}
+	return nil
+}
+
+func copyRecallCorpusRevisionFromAttachedTx(
+	ctx context.Context, tx *sql.Tx,
+) error {
+	if !oldDBHasTable(ctx, tx, "recall_corpus_state") {
+		return nil
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE main.recall_corpus_state
+		SET revision = MAX(revision, COALESCE((
+			SELECT revision
+			FROM old_db.recall_corpus_state
+			WHERE singleton = 1
+		), revision))
+		WHERE singleton = 1`); err != nil {
+		return fmt.Errorf("copying recall corpus revision: %w", err)
+	}
+	return nil
+}
+
+func copyRecallEmbeddingChangesFromAttachedTx(
+	ctx context.Context, tx *sql.Tx,
+) error {
+	if !oldDBHasTable(ctx, tx, "recall_embedding_changes") {
+		return nil
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO main.recall_embedding_changes (entry_id, revision)
+		SELECT entry_id, revision
+		FROM old_db.recall_embedding_changes
+		WHERE true
+		ON CONFLICT(entry_id) DO UPDATE SET
+			revision = MAX(recall_embedding_changes.revision, excluded.revision)`); err != nil {
+		return fmt.Errorf("copying recall embedding changes: %w", err)
+	}
+	return nil
+}
+
+func copyRecallEmbeddingDeletionsFromAttachedTx(
+	ctx context.Context, tx *sql.Tx,
+) error {
+	if oldDBHasTable(ctx, tx, "recall_embedding_deletions") {
+		if _, err := tx.ExecContext(ctx, `
+			INSERT INTO main.recall_embedding_deletions (entry_id, deleted_at)
+			SELECT entry_id, deleted_at
+			FROM old_db.recall_embedding_deletions
+			WHERE true
+			ON CONFLICT(entry_id) DO UPDATE SET
+				deleted_at = excluded.deleted_at`); err != nil {
+			return fmt.Errorf("copying recall embedding deletions: %w", err)
+		}
+	}
+	// A full resync deliberately omits entries whose source session was not
+	// preserved. vectors.db survives that archive swap, so publish those
+	// identities as fresh tombstones for its next incremental refresh.
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO main.recall_embedding_deletions (entry_id, deleted_at)
+		SELECT id, strftime('%Y-%m-%dT%H:%M:%fZ','now')
+		FROM old_db.recall_entries
+		WHERE source_session_id NOT IN (SELECT id FROM main.sessions)
+		ON CONFLICT(entry_id) DO UPDATE SET
+			deleted_at = excluded.deleted_at`); err != nil {
+		return fmt.Errorf("journaling recall entries skipped during resync: %w", err)
+	}
+	var hasDeletions bool
+	if err := tx.QueryRowContext(ctx, `
+		SELECT EXISTS (SELECT 1 FROM main.recall_embedding_deletions)
+	`).Scan(&hasDeletions); err != nil {
+		return fmt.Errorf("checking copied recall embedding deletions: %w", err)
+	}
+	if hasDeletions {
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE main.recall_corpus_state
+			SET revision = revision + 1
+			WHERE singleton = 1;
+			INSERT INTO main.recall_embedding_changes (entry_id, revision)
+			SELECT deletion.entry_id, state.revision
+			FROM main.recall_embedding_deletions deletion
+			CROSS JOIN main.recall_corpus_state state
+			WHERE state.singleton = 1
+			ON CONFLICT(entry_id) DO UPDATE SET revision = excluded.revision;
+		`); err != nil {
+			return fmt.Errorf("sequencing copied recall embedding deletions: %w", err)
+		}
 	}
 	return nil
 }
@@ -981,6 +1082,19 @@ func (db *DB) QueryRecallEntries(
 		return RecallPage{}, err
 	}
 	q = NormalizeRecallQuery(q)
+	switch q.Mode {
+	case RecallQueryModeVector:
+		return db.queryRecallEntriesVector(ctx, q)
+	case RecallQueryModeHybrid:
+		return db.queryRecallEntriesHybrid(ctx, q)
+	default:
+		return db.queryRecallEntriesLexical(ctx, q)
+	}
+}
+
+func (db *DB) queryRecallEntriesLexical(
+	ctx context.Context, q RecallQuery,
+) (RecallPage, error) {
 	if strings.TrimSpace(q.Text) == "" {
 		entries, err := db.ListRecallEntries(ctx, q)
 		if err != nil {
@@ -1045,10 +1159,187 @@ func (db *DB) QueryRecallEntries(
 	return page, nil
 }
 
+func (db *DB) queryRecallEntriesVector(
+	ctx context.Context, q RecallQuery,
+) (RecallPage, error) {
+	searcher := db.getRecallVectorSearcher()
+	if searcher == nil {
+		return RecallPage{}, ErrSemanticUnavailable
+	}
+	limit := recallLimit(q.Limit)
+	k := max(recallLimit(q.Limit)*4, SemanticOverfetchMin)
+	for {
+		hits, exhausted, err := searcher.SearchRecall(ctx, q.Text, k)
+		if err != nil {
+			return RecallPage{}, err
+		}
+		page, err := db.recallPageFromVectorHits(ctx, q, hits, limit)
+		if err != nil {
+			return RecallPage{}, err
+		}
+		if len(page.RecallEntries) >= limit || exhausted {
+			return page, nil
+		}
+		next := k * 2
+		if next <= k {
+			return page, nil
+		}
+		k = next
+	}
+}
+
+func (db *DB) recallPageFromVectorHits(
+	ctx context.Context, q RecallQuery, hits []RecallVectorHit, limit int,
+) (RecallPage, error) {
+	if len(hits) == 0 {
+		return RecallPage{RecallEntries: []RecallResult{}}, nil
+	}
+	ids := make([]string, 0, len(hits))
+	seen := make(map[string]struct{}, len(hits))
+	for _, hit := range hits {
+		if hit.EntryID == "" {
+			continue
+		}
+		if _, ok := seen[hit.EntryID]; ok {
+			continue
+		}
+		seen[hit.EntryID] = struct{}{}
+		ids = append(ids, hit.EntryID)
+	}
+	entries, err := db.listRecallEntriesByIDs(ctx, q, ids)
+	if err != nil {
+		return RecallPage{}, err
+	}
+	byID := make(map[string]RecallEntry, len(entries))
+	for _, entry := range entries {
+		byID[entry.ID] = entry
+	}
+	page := RecallPage{RecallEntries: make([]RecallResult, 0, min(limit, len(entries)))}
+	seen = make(map[string]struct{}, len(entries))
+	for _, hit := range hits {
+		entry, ok := byID[hit.EntryID]
+		if !ok {
+			continue
+		}
+		if _, ok := seen[hit.EntryID]; ok {
+			continue
+		}
+		seen[hit.EntryID] = struct{}{}
+		page.RecallEntries = append(page.RecallEntries, RecallResult{
+			RecallEntry: entry,
+			Score:       float64(hit.Score),
+			MatchReasons: []string{
+				"semantic",
+			},
+		})
+		if len(page.RecallEntries) == limit {
+			break
+		}
+	}
+	return page, nil
+}
+
+func (db *DB) queryRecallEntriesHybrid(
+	ctx context.Context, q RecallQuery,
+) (RecallPage, error) {
+	limit := recallLimit(q.Limit)
+	candidateQuery := q
+	candidateQuery.Mode = RecallQueryModeLexical
+	candidateQuery.Limit = MaxRecallEntryLimit
+	lexical, err := db.queryRecallEntriesLexical(ctx, candidateQuery)
+	if err != nil {
+		return RecallPage{}, err
+	}
+	candidateQuery.Mode = RecallQueryModeVector
+	vector, err := db.queryRecallEntriesVector(ctx, candidateQuery)
+	if err != nil {
+		return RecallPage{}, err
+	}
+	legs := [][]RankedUnit{
+		recallResultRankedUnits(lexical.RecallEntries),
+		recallResultRankedUnits(vector.RecallEntries),
+	}
+	merged := RRFMerge(legs, limit)
+	byID := make(map[string]RecallResult,
+		len(lexical.RecallEntries)+len(vector.RecallEntries))
+	for _, result := range lexical.RecallEntries {
+		byID[result.ID] = result
+	}
+	for _, result := range vector.RecallEntries {
+		if existing, ok := byID[result.ID]; ok {
+			if !slices.Contains(existing.MatchReasons, "semantic") {
+				existing.MatchReasons = append(existing.MatchReasons, "semantic")
+			}
+			byID[result.ID] = existing
+			continue
+		}
+		byID[result.ID] = result
+	}
+	page := RecallPage{RecallEntries: make([]RecallResult, 0, len(merged))}
+	for _, fused := range merged {
+		result := byID[fused.Unit.Key]
+		result.Score = fused.Score
+		page.RecallEntries = append(page.RecallEntries, result)
+	}
+	return page, nil
+}
+
+func recallResultRankedUnits(results []RecallResult) []RankedUnit {
+	ranked := make([]RankedUnit, 0, len(results))
+	for _, result := range results {
+		ranked = append(ranked, RankedUnit{Key: result.ID})
+	}
+	return ranked
+}
+
+func (db *DB) listRecallEntriesByIDs(
+	ctx context.Context, q RecallQuery, ids []string,
+) ([]RecallEntry, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	var entries []RecallEntry
+	err := queryChunked(ids, func(chunk []string) error {
+		where, filterArgs := buildRecallEntryWhere(q, false)
+		placeholders, idArgs := inPlaceholders(chunk)
+		args := append(idArgs, filterArgs...)
+		rows, err := db.getReader().QueryContext(ctx,
+			"SELECT "+recallBaseCols+" FROM recall_entries WHERE id IN "+
+				placeholders+" AND "+where,
+			args...,
+		)
+		if err != nil {
+			return fmt.Errorf("querying recall vector candidates: %w", err)
+		}
+		defer rows.Close()
+		chunkEntries, err := scanRecallEntryRows(rows)
+		if err != nil {
+			return err
+		}
+		entries = append(entries, chunkEntries...)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	evidence, err := db.listRecallEvidence(ctx, recallIDs(entries))
+	if err != nil {
+		return nil, err
+	}
+	for i := range entries {
+		entries[i].Evidence = evidence[entries[i].ID]
+	}
+	return entries, nil
+}
+
 // NormalizeRecallQuery trims whitespace from a query's exact-match filters so
 // padded values match consistently. It is exported so the Postgres store can
 // apply the same normalization as the SQLite store.
 func NormalizeRecallQuery(q RecallQuery) RecallQuery {
+	q.Mode = strings.ToLower(strings.TrimSpace(q.Mode))
+	if q.Mode == "" {
+		q.Mode = RecallQueryModeLexical
+	}
 	q.Project = strings.TrimSpace(q.Project)
 	q.CWD = strings.TrimSpace(q.CWD)
 	q.GitBranch = strings.TrimSpace(q.GitBranch)
@@ -1070,6 +1361,21 @@ func NormalizeRecallQuery(q RecallQuery) RecallQuery {
 // for another explicit status is therefore a caller error, not an empty page.
 func ValidateRecallQuery(q RecallQuery) error {
 	q = NormalizeRecallQuery(q)
+	switch q.Mode {
+	case RecallQueryModeLexical, RecallQueryModeVector, RecallQueryModeHybrid:
+	default:
+		return fmt.Errorf(
+			"%w: recall query mode must be lexical, vector, or hybrid",
+			ErrInvalidRecallQuery,
+		)
+	}
+	if q.Mode != RecallQueryModeLexical && q.Status != "" &&
+		q.Status != corerecall.StatusAccepted {
+		return fmt.Errorf(
+			"%w: vector and hybrid recall queries only support accepted status",
+			ErrInvalidRecallQuery,
+		)
+	}
 	if q.TrustedOnly && q.Status != "" && q.Status != corerecall.StatusAccepted {
 		return fmt.Errorf(
 			"%w: trusted_only requires status %q",

--- a/internal/db/recall.go
+++ b/internal/db/recall.go
@@ -1171,12 +1171,15 @@ func (db *DB) queryRecallEntriesVector(
 	limit := recallLimit(q.Limit)
 	k := max(recallLimit(q.Limit)*4, SemanticOverfetchMin)
 	for {
-		hits, exhausted, err := searcher.SearchRecall(ctx, q.Text, k)
+		hits, exhausted, snapshot, err := searcher.SearchRecall(ctx, q.Text, k)
 		if err != nil {
 			return RecallPage{}, err
 		}
 		page, err := db.recallPageFromVectorHits(ctx, q, hits, limit)
 		if err != nil {
+			return RecallPage{}, err
+		}
+		if err := searcher.ValidateRecallSnapshot(ctx, snapshot); err != nil {
 			return RecallPage{}, err
 		}
 		if len(page.RecallEntries) >= limit || exhausted {

--- a/internal/db/recall_query_events.go
+++ b/internal/db/recall_query_events.go
@@ -11,6 +11,8 @@ import (
 
 const (
 	RecallLexicalScorePolicyVersion = corerecall.LexicalScorePolicyVersion
+	RecallVectorScorePolicyVersion  = "recall-vector-cosine-v1"
+	RecallHybridScorePolicyVersion  = "recall-hybrid-rrf-v1"
 	RecallQuerySurfaceQuery         = "query"
 	RecallQuerySurfaceBrief         = "brief"
 	RecallQuerySurfaceCalibration   = "calibration"

--- a/internal/db/recall_test.go
+++ b/internal/db/recall_test.go
@@ -16,9 +16,11 @@ import (
 )
 
 type fakeRecallVectorSearcher struct {
-	hits  []RecallVectorHit
-	query string
-	limit int
+	hits     []RecallVectorHit
+	query    string
+	limit    int
+	onSearch func()
+	database *DB
 }
 
 type boundedRecallVectorSearcher struct {
@@ -28,18 +30,51 @@ type boundedRecallVectorSearcher struct {
 
 func (f *boundedRecallVectorSearcher) SearchRecall(
 	_ context.Context, _ string, limit int,
-) ([]RecallVectorHit, bool, error) {
+) ([]RecallVectorHit, bool, RecallVectorSnapshot, error) {
 	f.limits = append(f.limits, limit)
 	return append([]RecallVectorHit(nil), f.hits[:min(limit, len(f.hits))]...),
-		len(f.hits) <= limit, nil
+		len(f.hits) <= limit, RecallVectorSnapshot{}, nil
+}
+
+func (f *boundedRecallVectorSearcher) ValidateRecallSnapshot(
+	context.Context, RecallVectorSnapshot,
+) error {
+	return nil
 }
 
 func (f *fakeRecallVectorSearcher) SearchRecall(
-	_ context.Context, query string, limit int,
-) ([]RecallVectorHit, bool, error) {
+	ctx context.Context, query string, limit int,
+) ([]RecallVectorHit, bool, RecallVectorSnapshot, error) {
 	f.query = query
 	f.limit = limit
-	return append([]RecallVectorHit(nil), f.hits...), true, nil
+	var snapshot RecallVectorSnapshot
+	if f.database != nil {
+		revision, err := f.database.RecallCorpusRevision(ctx)
+		if err != nil {
+			return nil, false, RecallVectorSnapshot{}, err
+		}
+		snapshot.CorpusRevision = revision
+	}
+	if f.onSearch != nil {
+		f.onSearch()
+	}
+	return append([]RecallVectorHit(nil), f.hits...), true, snapshot, nil
+}
+
+func (f *fakeRecallVectorSearcher) ValidateRecallSnapshot(
+	ctx context.Context, snapshot RecallVectorSnapshot,
+) error {
+	if f.database == nil {
+		return nil
+	}
+	revision, err := f.database.RecallCorpusRevision(ctx)
+	if err != nil {
+		return err
+	}
+	if revision != snapshot.CorpusRevision {
+		return NewSemanticUnavailableError("recall corpus changed during search")
+	}
+	return nil
 }
 
 func TestRecallEntriesSchemaIndexesSourceEpisode(t *testing.T) {
@@ -1773,6 +1808,34 @@ func TestQueryRecallEntriesVectorUsesSemanticRankingAndFilters(t *testing.T) {
 	assert.Equal(t, "semantic", page.RecallEntries[0].ID)
 	assert.InDelta(t, 0.75, page.RecallEntries[0].Score, 0.0001)
 	assert.Equal(t, []string{"semantic"}, page.RecallEntries[0].MatchReasons)
+}
+
+func TestQueryRecallEntriesVectorRejectsCorpusMutationAfterSearch(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	insertSession(t, d, "s1", "agentsview")
+	_, err := d.InsertRecallEntry(RecallEntry{
+		ID: "semantic", Type: "fact", Scope: "project", Status: "accepted",
+		Title: "Connection reuse", Body: "Keep idle resources available.",
+		SourceSessionID: "s1",
+	})
+	require.NoError(t, err)
+	d.SetRecallVectorSearcher(&fakeRecallVectorSearcher{
+		hits:     []RecallVectorHit{{EntryID: "semantic", Score: 0.75}},
+		database: d,
+		onSearch: func() {
+			_, updateErr := d.getWriter().ExecContext(ctx,
+				"UPDATE recall_entries SET title = 'Edited after vector search' WHERE id = 'semantic'",
+			)
+			require.NoError(t, updateErr)
+		},
+	})
+
+	_, err = d.QueryRecallEntries(ctx, RecallQuery{
+		Text: "database pool", Mode: RecallQueryModeVector, Limit: 5,
+	})
+
+	assert.ErrorIs(t, err, ErrSemanticUnavailable)
 }
 
 func TestQueryRecallEntriesVectorExpandsPastFilteredCandidates(t *testing.T) {

--- a/internal/db/recall_test.go
+++ b/internal/db/recall_test.go
@@ -15,6 +15,33 @@ import (
 	corerecall "go.kenn.io/agentsview/internal/recall"
 )
 
+type fakeRecallVectorSearcher struct {
+	hits  []RecallVectorHit
+	query string
+	limit int
+}
+
+type boundedRecallVectorSearcher struct {
+	hits   []RecallVectorHit
+	limits []int
+}
+
+func (f *boundedRecallVectorSearcher) SearchRecall(
+	_ context.Context, _ string, limit int,
+) ([]RecallVectorHit, bool, error) {
+	f.limits = append(f.limits, limit)
+	return append([]RecallVectorHit(nil), f.hits[:min(limit, len(f.hits))]...),
+		len(f.hits) <= limit, nil
+}
+
+func (f *fakeRecallVectorSearcher) SearchRecall(
+	_ context.Context, query string, limit int,
+) ([]RecallVectorHit, bool, error) {
+	f.query = query
+	f.limit = limit
+	return append([]RecallVectorHit(nil), f.hits...), true, nil
+}
+
 func TestRecallEntriesSchemaIndexesSourceEpisode(t *testing.T) {
 	d := testDB(t)
 
@@ -1709,6 +1736,164 @@ func TestQueryRecallEntriesFindsEvidenceMatchBeyondRecentEvidenceCandidateCap(
 	assert.Equal(t, 3, page.RecallEntries[0].ScoreBreakdown.EvidenceKeywordOverlap)
 }
 
+func TestQueryRecallEntriesVectorUsesSemanticRankingAndFilters(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	insertSession(t, d, "s1", "agentsview")
+	for _, entry := range []RecallEntry{
+		{
+			ID: "semantic", Type: "fact", Scope: "project", Status: "accepted",
+			Title: "Connection reuse", Body: "Keep idle resources available.",
+			Project: "agentsview", SourceSessionID: "s1",
+		},
+		{
+			ID: "other-project", Type: "fact", Scope: "project", Status: "accepted",
+			Title: "Database pool", Body: "An unrelated project entry.",
+			Project: "other", SourceSessionID: "s1",
+		},
+	} {
+		_, err := d.InsertRecallEntry(entry)
+		require.NoError(t, err)
+	}
+	searcher := &fakeRecallVectorSearcher{hits: []RecallVectorHit{
+		{EntryID: "other-project", Score: 0.99},
+		{EntryID: "semantic", Score: 0.75},
+	}}
+	d.SetRecallVectorSearcher(searcher)
+
+	page, err := d.QueryRecallEntries(ctx, RecallQuery{
+		Text: "database pool", Mode: RecallQueryModeVector,
+		Project: "agentsview", Limit: 5,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "database pool", searcher.query)
+	assert.GreaterOrEqual(t, searcher.limit, 5)
+	require.Len(t, page.RecallEntries, 1)
+	assert.Equal(t, "semantic", page.RecallEntries[0].ID)
+	assert.InDelta(t, 0.75, page.RecallEntries[0].Score, 0.0001)
+	assert.Equal(t, []string{"semantic"}, page.RecallEntries[0].MatchReasons)
+}
+
+func TestQueryRecallEntriesVectorExpandsPastFilteredCandidates(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	insertSession(t, d, "s1", "agentsview")
+	hits := make([]RecallVectorHit, 0, SemanticOverfetchMin+1)
+	for i := range SemanticOverfetchMin {
+		id := fmt.Sprintf("excluded-%03d", i)
+		_, err := d.InsertRecallEntry(RecallEntry{
+			ID: id, Type: "fact", Scope: "project", Status: "accepted",
+			Title: "Other project", Body: "Higher semantic score.",
+			Project: "other", SourceSessionID: "s1",
+		})
+		require.NoError(t, err)
+		hits = append(hits, RecallVectorHit{EntryID: id, Score: float32(1 - float64(i)/1000)})
+	}
+	_, err := d.InsertRecallEntry(RecallEntry{
+		ID: "matching-project", Type: "fact", Scope: "project", Status: "accepted",
+		Title: "Matching project", Body: "Lower-ranked but eligible.",
+		Project: "agentsview", SourceSessionID: "s1",
+	})
+	require.NoError(t, err)
+	hits = append(hits, RecallVectorHit{EntryID: "matching-project", Score: 0.5})
+	searcher := &boundedRecallVectorSearcher{hits: hits}
+	d.SetRecallVectorSearcher(searcher)
+
+	page, err := d.QueryRecallEntries(ctx, RecallQuery{
+		Text: "semantic policy", Mode: RecallQueryModeVector,
+		Project: "agentsview", Limit: 1,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, page.RecallEntries, 1)
+	assert.Equal(t, "matching-project", page.RecallEntries[0].ID)
+	assert.Equal(t, []int{SemanticOverfetchMin, SemanticOverfetchMin * 2}, searcher.limits)
+}
+
+func TestQueryRecallEntriesHybridUsesReciprocalRankFusion(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+	insertSession(t, d, "s1", "agentsview")
+	for _, entry := range []RecallEntry{
+		{
+			ID: "both", Type: "fact", Scope: "project", Status: "accepted",
+			Title: "Database pool", Body: "Reuse idle connections.",
+			SourceSessionID: "s1",
+		},
+		{
+			ID: "lexical-only", Type: "fact", Scope: "project", Status: "accepted",
+			Title: "Database pool", Body: "Size the pool carefully.",
+			SourceSessionID: "s1",
+		},
+		{
+			ID: "vector-only", Type: "fact", Scope: "project", Status: "accepted",
+			Title: "Resource reuse", Body: "Keep spare connections available.",
+			SourceSessionID: "s1",
+		},
+	} {
+		_, err := d.InsertRecallEntry(entry)
+		require.NoError(t, err)
+	}
+	d.SetRecallVectorSearcher(&fakeRecallVectorSearcher{hits: []RecallVectorHit{
+		{EntryID: "both", Score: 0.8},
+		{EntryID: "vector-only", Score: 0.7},
+	}})
+
+	page, err := d.QueryRecallEntries(ctx, RecallQuery{
+		Text: "database pool", Mode: RecallQueryModeHybrid, Limit: 3,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, page.RecallEntries, 3)
+	assert.Equal(t, "both", page.RecallEntries[0].ID)
+	assert.ElementsMatch(t,
+		[]string{"both", "lexical-only", "vector-only"},
+		[]string{
+			page.RecallEntries[0].ID,
+			page.RecallEntries[1].ID,
+			page.RecallEntries[2].ID,
+		},
+	)
+	assert.Contains(t, page.RecallEntries[0].MatchReasons, "semantic")
+	assert.Greater(t, page.RecallEntries[0].Score, page.RecallEntries[1].Score)
+}
+
+func TestQueryRecallEntriesVectorRequiresSemanticIndex(t *testing.T) {
+	d := testDB(t)
+
+	_, err := d.QueryRecallEntries(context.Background(), RecallQuery{
+		Text: "database pool", Mode: RecallQueryModeVector,
+	})
+
+	assert.ErrorIs(t, err, ErrSemanticUnavailable)
+}
+
+func TestValidateRecallQueryRejectsUnknownMode(t *testing.T) {
+	err := ValidateRecallQuery(RecallQuery{Text: "database", Mode: "fuzzy"})
+
+	require.ErrorIs(t, err, ErrInvalidRecallQuery)
+	assert.Contains(t, err.Error(), "recall query mode")
+}
+
+func TestValidateRecallQueryRejectsNonServedStatusForSemanticModes(t *testing.T) {
+	for _, mode := range []string{RecallQueryModeVector, RecallQueryModeHybrid} {
+		t.Run(mode, func(t *testing.T) {
+			err := ValidateRecallQuery(RecallQuery{
+				Text: "database", Mode: mode, Status: corerecall.StatusArchived,
+			})
+
+			require.ErrorIs(t, err, ErrInvalidRecallQuery)
+			assert.Contains(t, err.Error(), "accepted status")
+		})
+	}
+
+	require.NoError(t, ValidateRecallQuery(RecallQuery{
+		Text: "database", Mode: RecallQueryModeLexical,
+		Status: corerecall.StatusArchived,
+	}))
+}
+
 func TestQueryRecallEntriesDiversifiesSourceEpisodesBeforeRepeatingChunks(t *testing.T) {
 	d := testDB(t)
 	ctx := context.Background()
@@ -2085,6 +2270,14 @@ func TestCopyRecallEntriesFrom(t *testing.T) {
 		Project: "agentsview", Agent: "codex", SourceSessionID: "s2",
 	})
 	require.NoError(t, err, "insert m2")
+	_, err = srcDB.InsertRecallEntry(RecallEntry{
+		ID: "m3", Type: "fact", Scope: "project", Status: "accepted",
+		Title: "retracted", Body: "removed before the resync",
+		Project: "agentsview", Agent: "codex", SourceSessionID: "s1",
+	})
+	require.NoError(t, err, "insert m3")
+	_, err = srcDB.getWriter().Exec("DELETE FROM recall_entries WHERE id = 'm3'")
+	require.NoError(t, err, "delete m3")
 
 	// Pin known timestamps to verify they survive the copy.
 	_, err = srcDB.getWriter().Exec(
@@ -2092,6 +2285,8 @@ func TestCopyRecallEntriesFrom(t *testing.T) {
 		"2024-01-02T03:04:05.678Z", "2024-02-03T04:05:06.789Z",
 	)
 	require.NoError(t, err, "stamp m1")
+	sourceRevision, err := srcDB.RecallCorpusRevision(context.Background())
+	require.NoError(t, err)
 	srcDB.Close()
 
 	// Destination DB has only s1 (s2 was not preserved by the resync).
@@ -2106,6 +2301,14 @@ func TestCopyRecallEntriesFrom(t *testing.T) {
 	require.NoError(t, dstDB.CopyRecallEntriesFrom(srcPath), "CopyRecallEntriesFrom")
 
 	ctx := context.Background()
+	destinationRevision, err := dstDB.RecallCorpusRevision(ctx)
+	require.NoError(t, err)
+	sourceRevisionNumber, ok := parseRecallCorpusRevision(sourceRevision)
+	require.True(t, ok)
+	destinationRevisionNumber, ok := parseRecallCorpusRevision(destinationRevision)
+	require.True(t, ok)
+	assert.Greater(t, destinationRevisionNumber, sourceRevisionNumber,
+		"an archive swap must advance the monotonic Recall revision")
 
 	// m1 copied with evidence and original timestamps preserved.
 	m1, err := dstDB.GetRecallEntry(ctx, "m1")
@@ -2120,6 +2323,25 @@ func TestCopyRecallEntriesFrom(t *testing.T) {
 	m2, err := dstDB.GetRecallEntry(ctx, "m2")
 	require.NoError(t, err, "get m2")
 	assert.Nil(t, m2, "m2 skipped: source session not preserved")
+	var embeddingChanges []EmbeddableUnit
+	_, err = dstDB.ScanRecallEmbeddingUnits(
+		ctx, "2000-01-01T00:00:00Z",
+		func(unit EmbeddableUnit) error {
+			embeddingChanges = append(embeddingChanges, unit)
+			return nil
+		},
+	)
+	require.NoError(t, err, "scan copied embedding changes")
+	require.Len(t, embeddingChanges, 3)
+	changesByID := make(map[string]EmbeddableUnit, len(embeddingChanges))
+	for _, unit := range embeddingChanges {
+		changesByID[unit.SessionID] = unit
+	}
+	assert.True(t, changesByID["m2"].Deleted,
+		"an entry skipped during resync must remove its persistent mirror row")
+	assert.True(t, changesByID["m3"].Deleted,
+		"a pre-resync hard deletion must survive the archive swap")
+	assert.False(t, changesByID["m1"].Deleted)
 
 	// Copied recall is searchable via FTS in the destination.
 	cands, err := dstDB.ListRecallEntryTextCandidates(
@@ -2128,6 +2350,55 @@ func TestCopyRecallEntriesFrom(t *testing.T) {
 	require.NoError(t, err, "search copied recall")
 	require.Len(t, cands, 1, "fts finds copied recall")
 	assert.Equal(t, "m1", cands[0].ID)
+}
+
+func TestCopyRecallEntriesFromPreservesPendingArchivedEmbeddingChange(
+	t *testing.T,
+) {
+	dir := t.TempDir()
+	ctx := context.Background()
+	srcPath := filepath.Join(dir, "old.db")
+	srcDB, err := Open(srcPath)
+	require.NoError(t, err)
+	insertSession(t, srcDB, "s1", "agentsview")
+	_, err = srcDB.InsertRecallEntry(RecallEntry{
+		ID: "archived-after-build", Type: "fact", Scope: "project",
+		Status: "accepted", Title: "Served entry", Body: "Indexed content",
+		SourceSessionID: "s1",
+	})
+	require.NoError(t, err)
+
+	vectorWatermark, err := srcDB.ScanRecallEmbeddingUnits(
+		ctx, "", func(EmbeddableUnit) error { return nil },
+	)
+	require.NoError(t, err)
+	_, err = srcDB.getWriter().Exec(`
+		UPDATE recall_entries SET status = 'archived'
+		WHERE id = 'archived-after-build'`)
+	require.NoError(t, err)
+	require.NoError(t, srcDB.Close())
+
+	dstDB, err := Open(filepath.Join(dir, "new.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dstDB.Close() })
+	insertSession(t, dstDB, "s1", "agentsview")
+	require.NoError(t, dstDB.CopyRecallEntriesFrom(srcPath))
+
+	var changes []EmbeddableUnit
+	nextWatermark, err := dstDB.ScanRecallEmbeddingUnits(
+		ctx, vectorWatermark,
+		func(unit EmbeddableUnit) error {
+			changes = append(changes, unit)
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, changes, 1)
+	assert.Equal(t, "archived-after-build", changes[0].SessionID)
+	assert.True(t, changes[0].Deleted,
+		"the first post-resync incremental build must remove the archived vector")
+	assert.NotEqual(t, vectorWatermark, nextWatermark)
 }
 
 func TestCopyRecallEntriesFromReconcilesShiftedEvidence(t *testing.T) {

--- a/internal/db/recall_test.go
+++ b/internal/db/recall_test.go
@@ -1867,6 +1867,7 @@ func TestQueryRecallEntriesVectorRequiresSemanticIndex(t *testing.T) {
 	})
 
 	assert.ErrorIs(t, err, ErrSemanticUnavailable)
+	assert.Contains(t, err.Error(), "embeddings build --store recall")
 }
 
 func TestValidateRecallQueryRejectsUnknownMode(t *testing.T) {

--- a/internal/db/recall_vector.go
+++ b/internal/db/recall_vector.go
@@ -1,0 +1,354 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	recallEmbeddingWatermarkStatus = "__watermark__"
+	recallCorpusRevisionPrefix     = "counter-v1:"
+)
+
+// RecallCorpusRevision returns a stable source revision for freshness checks.
+// Current archives maintain a monotonic counter through recall_entries
+// triggers. Read-only archives created before that schema addition fall back
+// to their indexed timestamp watermarks so explicit builds remain usable.
+func (db *DB) RecallCorpusRevision(ctx context.Context) (string, error) {
+	hasState, err := db.recallTableExists(ctx, "recall_corpus_state")
+	if err != nil {
+		return "", err
+	}
+	if hasState {
+		var revision int64
+		if err := db.getReader().QueryRowContext(ctx, `
+			SELECT revision FROM recall_corpus_state WHERE singleton = 1
+		`).Scan(&revision); err != nil {
+			return "", fmt.Errorf("reading recall corpus revision: %w", err)
+		}
+		return recallCorpusRevisionPrefix + strconv.FormatInt(revision, 10), nil
+	}
+
+	var maxUpdated string
+	if err := db.getReader().QueryRowContext(ctx, `
+		SELECT COALESCE((
+			SELECT updated_at
+			FROM recall_entries INDEXED BY idx_recall_entries_updated
+			ORDER BY updated_at DESC, id ASC
+			LIMIT 1
+		), '')
+	`).Scan(&maxUpdated); err != nil {
+		return "", fmt.Errorf("reading legacy recall corpus revision: %w", err)
+	}
+	hasDeletions, err := db.recallTableExists(ctx, "recall_embedding_deletions")
+	if err != nil {
+		return "", err
+	}
+	if hasDeletions {
+		var maxDeleted string
+		if err := db.getReader().QueryRowContext(ctx, `
+			SELECT COALESCE((
+				SELECT deleted_at
+				FROM recall_embedding_deletions
+					INDEXED BY idx_recall_embedding_deletions_updated
+				ORDER BY deleted_at DESC, entry_id ASC
+				LIMIT 1
+			), '')
+		`).Scan(&maxDeleted); err != nil {
+			return "", fmt.Errorf("reading legacy recall deletion revision: %w", err)
+		}
+		if endedAfter(maxDeleted, maxUpdated) {
+			maxUpdated = maxDeleted
+		}
+	}
+	return "watermark-v1:" + maxUpdated, nil
+}
+
+func (db *DB) recallTableExists(ctx context.Context, name string) (bool, error) {
+	var exists bool
+	if err := db.getReader().QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?
+		)`, name).Scan(&exists); err != nil {
+		return false, fmt.Errorf("checking recall table %s: %w", name, err)
+	}
+	return exists, nil
+}
+
+// ScanRecallEmbeddingUnits streams the complete served accepted-entry corpus
+// as one embedding document per entry. SessionID and SourceUUID both carry the
+// entry ID so the generic vector mirror can retain its stable document identity
+// and return the entry ID from semantic hits.
+func (db *DB) ScanRecallEmbeddingUnits(
+	ctx context.Context,
+	since string,
+	fn func(EmbeddableUnit) error,
+) (maxUpdated string, err error) {
+	hasChanges, err := db.recallTableExists(ctx, "recall_embedding_changes")
+	if err != nil {
+		return "", err
+	}
+	if hasChanges {
+		if since == "" {
+			return db.scanRecallEmbeddingRevision(ctx, 0, true, fn)
+		}
+		if revision, ok := parseRecallCorpusRevision(since); ok {
+			return db.scanRecallEmbeddingRevision(ctx, revision, false, fn)
+		}
+		// A vectors.db created before revision watermarks may still carry an
+		// RFC3339 cursor. Reconcile every surviving identity once, including
+		// tombstones, then advance it into the monotonic revision domain.
+		return db.scanRecallEmbeddingCompatibility(ctx, fn)
+	}
+	if strings.HasPrefix(since, recallCorpusRevisionPrefix) {
+		// Transitional read-only archives can have the corpus counter from an
+		// earlier binary but not the compact change table. A complete delta is
+		// the only safe way to avoid blessing skipped backdated mutations.
+		return db.scanRecallEmbeddingCompatibility(ctx, fn)
+	}
+
+	includeDeletions, err := db.recallTableExists(ctx, "recall_embedding_deletions")
+	if err != nil {
+		return "", err
+	}
+	query, args := recallEmbeddingScanSQL(since, includeDeletions)
+
+	rows, err := db.getReader().QueryContext(ctx, query, args...)
+	if err != nil {
+		return "", fmt.Errorf("scanning recall embedding units: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id, title, body, trigger, status, updatedAt string
+		if err := rows.Scan(
+			&id, &title, &body, &trigger, &status, &updatedAt,
+		); err != nil {
+			return "", fmt.Errorf("scanning recall embedding unit: %w", err)
+		}
+		if endedAfter(updatedAt, maxUpdated) {
+			maxUpdated = updatedAt
+		}
+		if status == recallEmbeddingWatermarkStatus {
+			continue
+		}
+		content := title + "\n\n" + body
+		if trigger != "" {
+			content += "\n\n" + trigger
+		}
+		if err := fn(EmbeddableUnit{
+			SessionID:  id,
+			Kind:       "user",
+			SourceUUID: id,
+			Deleted:    status != "accepted",
+			Content:    content,
+		}); err != nil {
+			return "", err
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return "", fmt.Errorf("iterating recall embedding units: %w", err)
+	}
+	return maxUpdated, nil
+}
+
+func parseRecallCorpusRevision(value string) (int64, bool) {
+	if !strings.HasPrefix(value, recallCorpusRevisionPrefix) {
+		return 0, false
+	}
+	revision, err := strconv.ParseInt(
+		strings.TrimPrefix(value, recallCorpusRevisionPrefix), 10, 64,
+	)
+	return revision, err == nil && revision >= 0
+}
+
+func (db *DB) scanRecallEmbeddingRevision(
+	ctx context.Context, since int64, full bool,
+	fn func(EmbeddableUnit) error,
+) (string, error) {
+	query, args := recallEmbeddingRevisionScanSQL(since, full)
+	rows, err := db.getReader().QueryContext(ctx, query, args...)
+	if err != nil {
+		return "", fmt.Errorf("scanning recall embedding revisions: %w", err)
+	}
+	defer rows.Close()
+	var maxRevision int64
+	for rows.Next() {
+		var id, title, body, trigger, status string
+		var revision int64
+		if err := rows.Scan(
+			&id, &title, &body, &trigger, &status, &revision,
+		); err != nil {
+			return "", fmt.Errorf("scanning recall embedding revision: %w", err)
+		}
+		if revision > maxRevision {
+			maxRevision = revision
+		}
+		if status == recallEmbeddingWatermarkStatus {
+			continue
+		}
+		if err := emitRecallEmbeddingUnit(fn, id, title, body, trigger, status); err != nil {
+			return "", err
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return "", fmt.Errorf("iterating recall embedding revisions: %w", err)
+	}
+	return recallCorpusRevisionPrefix + strconv.FormatInt(maxRevision, 10), nil
+}
+
+func recallEmbeddingRevisionScanSQL(since int64, full bool) (string, []any) {
+	if full {
+		return `
+			WITH current_revision AS (
+				SELECT revision FROM recall_corpus_state WHERE singleton = 1
+			)
+			SELECT id, title, body, trigger, status, revision
+			FROM recall_entries CROSS JOIN current_revision
+			WHERE status = 'accepted'
+			UNION ALL
+			SELECT '', '', '', '', '` + recallEmbeddingWatermarkStatus + `', revision
+			FROM current_revision
+			ORDER BY id ASC`, nil
+	}
+	return `
+		WITH current_revision AS (
+			SELECT revision FROM recall_corpus_state WHERE singleton = 1
+		), changed AS (
+			SELECT changes.entry_id, changes.revision
+			FROM recall_embedding_changes changes CROSS JOIN current_revision
+			WHERE changes.revision > ?
+			  AND changes.revision <= current_revision.revision
+		)
+		SELECT changed.entry_id,
+			COALESCE(entry.title, ''), COALESCE(entry.body, ''),
+			COALESCE(entry.trigger, ''), COALESCE(entry.status, 'deleted'),
+			changed.revision
+		FROM changed
+		LEFT JOIN recall_entries entry ON entry.id = changed.entry_id
+		UNION ALL
+		SELECT '', '', '', '', '` + recallEmbeddingWatermarkStatus + `', revision
+		FROM current_revision
+		ORDER BY revision ASC, entry_id ASC`, []any{since}
+}
+
+func (db *DB) scanRecallEmbeddingCompatibility(
+	ctx context.Context, fn func(EmbeddableUnit) error,
+) (string, error) {
+	hasState, err := db.recallTableExists(ctx, "recall_corpus_state")
+	if err != nil {
+		return "", err
+	}
+	if !hasState {
+		return "", fmt.Errorf("recall corpus revision state is unavailable")
+	}
+	hasDeletions, err := db.recallTableExists(ctx, "recall_embedding_deletions")
+	if err != nil {
+		return "", err
+	}
+	query := `
+		WITH current_revision AS (
+			SELECT revision FROM recall_corpus_state WHERE singleton = 1
+		)
+		SELECT id, title, body, trigger, status, revision
+		FROM recall_entries CROSS JOIN current_revision`
+	if hasDeletions {
+		query += `
+		UNION ALL
+		SELECT entry_id, '', '', '', 'deleted', revision
+		FROM recall_embedding_deletions CROSS JOIN current_revision`
+	}
+	query += `
+		UNION ALL
+		SELECT '', '', '', '', '` + recallEmbeddingWatermarkStatus + `', revision
+		FROM current_revision
+		ORDER BY id ASC`
+	rows, err := db.getReader().QueryContext(ctx, query)
+	if err != nil {
+		return "", fmt.Errorf("scanning recall embedding compatibility delta: %w", err)
+	}
+	defer rows.Close()
+	var revision int64
+	for rows.Next() {
+		var id, title, body, trigger, status string
+		if err := rows.Scan(&id, &title, &body, &trigger, &status, &revision); err != nil {
+			return "", fmt.Errorf("scanning recall embedding compatibility row: %w", err)
+		}
+		if status == recallEmbeddingWatermarkStatus {
+			continue
+		}
+		if err := emitRecallEmbeddingUnit(fn, id, title, body, trigger, status); err != nil {
+			return "", err
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return "", fmt.Errorf("iterating recall embedding compatibility delta: %w", err)
+	}
+	return recallCorpusRevisionPrefix + strconv.FormatInt(revision, 10), nil
+}
+
+func emitRecallEmbeddingUnit(
+	fn func(EmbeddableUnit) error,
+	id, title, body, trigger, status string,
+) error {
+	content := title + "\n\n" + body
+	if trigger != "" {
+		content += "\n\n" + trigger
+	}
+	return fn(EmbeddableUnit{
+		SessionID:  id,
+		Kind:       "user",
+		SourceUUID: id,
+		Deleted:    status != "accepted",
+		Content:    content,
+	})
+}
+
+func recallEmbeddingScanSQL(since string, includeDeletions bool) (string, []any) {
+	query := `
+		SELECT id, title, body, trigger, status, updated_at
+		FROM recall_entries`
+	var args []any
+	if since != "" {
+		query += " INDEXED BY idx_recall_entries_updated WHERE updated_at >= ?"
+		args = append(args, since)
+		if includeDeletions {
+			query += `
+			UNION ALL
+			SELECT entry_id, '', '', '', 'deleted', deleted_at
+			FROM recall_embedding_deletions
+				INDEXED BY idx_recall_embedding_deletions_updated
+			WHERE deleted_at >= ?`
+			args = append(args, since)
+		}
+		return `SELECT id, title, body, trigger, status, updated_at FROM (` + query +
+			") ORDER BY updated_at DESC, id ASC", args
+	} else {
+		watermarkSQL := `COALESCE((
+			SELECT updated_at
+			FROM recall_entries INDEXED BY idx_recall_entries_updated
+			ORDER BY updated_at DESC, id ASC
+			LIMIT 1
+		), '')`
+		if includeDeletions {
+			watermarkSQL = `MAX(` + watermarkSQL + `,
+				COALESCE((
+					SELECT deleted_at
+					FROM recall_embedding_deletions
+						INDEXED BY idx_recall_embedding_deletions_updated
+					ORDER BY deleted_at DESC, entry_id ASC
+					LIMIT 1
+				), '')
+			)`
+		}
+		return `
+			SELECT id, title, body, trigger, status, updated_at
+			FROM recall_entries
+			WHERE status = 'accepted'
+			UNION ALL
+			SELECT '', '', '', '', '` + recallEmbeddingWatermarkStatus + `',
+				` + watermarkSQL + `
+			ORDER BY id ASC`, nil
+	}
+}

--- a/internal/db/recall_vector_test.go
+++ b/internal/db/recall_vector_test.go
@@ -1,0 +1,472 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScanRecallEmbeddingUnitsIncludesCompleteServedCorpus(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "s1", "agentsview")
+	for _, entry := range []RecallEntry{
+		{
+			ID: "active-entry", Type: "fact", Scope: "project", Status: "accepted",
+			Title: "Database pool", Body: "Reuse idle connections.",
+			Trigger:         "connection storm",
+			SourceSessionID: "s1", SourceRunID: "extract-fp-active",
+		},
+		{
+			ID: "other-generation", Type: "fact", Scope: "project", Status: "accepted",
+			Title: "Old pool", Body: "This belongs to an older corpus.",
+			SourceSessionID: "s1", SourceRunID: "extract-fp-old",
+		},
+		{
+			ID: "human-import", Type: "fact", Scope: "global", Status: "accepted",
+			ReviewState: "human_reviewed",
+			Title:       "Imported policy", Body: "This entry has no extraction run.",
+			SourceSessionID: "s1",
+		},
+		{
+			ID: "archived-entry", Type: "fact", Scope: "project", Status: "archived",
+			Title: "Archived pool", Body: "This is no longer served.",
+			SourceSessionID: "s1", SourceRunID: "extract-fp-active",
+		},
+	} {
+		_, err := d.InsertRecallEntry(entry)
+		require.NoError(t, err)
+	}
+
+	var units []EmbeddableUnit
+	watermark, err := d.ScanRecallEmbeddingUnits(
+		context.Background(), "",
+		func(unit EmbeddableUnit) error {
+			units = append(units, unit)
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, units, 3)
+	assert.Equal(t,
+		[]string{"active-entry", "human-import", "other-generation"},
+		[]string{units[0].SessionID, units[1].SessionID, units[2].SessionID},
+	)
+	assert.Equal(t, "active-entry", units[0].SourceUUID)
+	assert.Equal(t, "user", units[0].Kind)
+	assert.Equal(t,
+		"Database pool\n\nReuse idle connections.\n\nconnection storm",
+		units[0].Content)
+	assert.NotEmpty(t, watermark)
+}
+
+func TestScanRecallEmbeddingUnitsFullSupportsArchiveWithoutDeletionJournal(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "s1", "agentsview")
+	_, err := d.InsertRecallEntry(RecallEntry{
+		ID: "legacy-entry", Type: "fact", Scope: "project", Status: "accepted",
+		Title: "Legacy archive", Body: "Still available.", SourceSessionID: "s1",
+	})
+	require.NoError(t, err)
+	require.NoError(t, d.Update(func(tx *sql.Tx) error {
+		for _, trigger := range []string{
+			"trg_recall_embedding_deletion",
+			"trg_recall_embedding_reinsert",
+			"trg_recall_corpus_insert",
+			"trg_recall_corpus_update",
+			"trg_recall_corpus_delete",
+		} {
+			if _, err := tx.Exec("DROP TRIGGER " + trigger); err != nil {
+				return err
+			}
+		}
+		_, err := tx.Exec("DROP TABLE recall_embedding_deletions")
+		if err != nil {
+			return err
+		}
+		if _, err = tx.Exec("DROP TABLE recall_embedding_changes"); err != nil {
+			return err
+		}
+		_, err = tx.Exec("DROP TABLE recall_corpus_state")
+		return err
+	}))
+
+	var ids []string
+	watermark, err := d.ScanRecallEmbeddingUnits(
+		context.Background(), "",
+		func(unit EmbeddableUnit) error {
+			ids = append(ids, unit.SessionID)
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"legacy-entry"}, ids)
+	assert.NotEmpty(t, watermark)
+	revision, err := d.RecallCorpusRevision(context.Background())
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(revision, "watermark-v1:"))
+}
+
+func TestRecallCorpusRevisionTracksServedEntryMutations(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "s1", "agentsview")
+
+	revision, err := d.RecallCorpusRevision(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "counter-v1:0", revision)
+
+	_, err = d.InsertRecallEntry(RecallEntry{
+		ID: "entry-1", Type: "fact", Scope: "project", Status: "accepted",
+		Title: "Initial", Body: "Body", SourceSessionID: "s1",
+	})
+	require.NoError(t, err)
+	revision, err = d.RecallCorpusRevision(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "counter-v1:1", revision)
+
+	_, err = d.getWriter().Exec(`
+		UPDATE recall_entries SET updated_at = '2026-01-01T00:00:00Z'
+		WHERE id = 'entry-1'`)
+	require.NoError(t, err)
+	revision, err = d.RecallCorpusRevision(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "counter-v1:1", revision,
+		"non-embedded metadata does not require a vector refresh")
+
+	_, err = d.getWriter().Exec(`
+		UPDATE recall_entries SET title = 'Edited' WHERE id = 'entry-1'`)
+	require.NoError(t, err)
+	revision, err = d.RecallCorpusRevision(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "counter-v1:2", revision)
+
+	_, err = d.getWriter().Exec("DELETE FROM recall_entries WHERE id = 'entry-1'")
+	require.NoError(t, err)
+	revision, err = d.RecallCorpusRevision(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "counter-v1:3", revision)
+}
+
+func TestRecallCorpusRevisionIgnoresUnservedEntryMutations(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "s1", "agentsview")
+
+	_, err := d.InsertRecallEntry(RecallEntry{
+		ID: "staging-entry", Type: "fact", Scope: "project", Status: "archived",
+		Title: "Draft", Body: "Not served", SourceSessionID: "s1",
+	})
+	require.NoError(t, err)
+	_, err = d.getWriter().Exec(`
+		UPDATE recall_entries SET title = 'Edited draft' WHERE id = 'staging-entry'`)
+	require.NoError(t, err)
+	_, err = d.getWriter().Exec(`DELETE FROM recall_entries WHERE id = 'staging-entry'`)
+	require.NoError(t, err)
+
+	revision, err := d.RecallCorpusRevision(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "counter-v1:0", revision,
+		"archived staging changes do not alter the served embedding corpus")
+}
+
+func TestRecallCorpusRevisionTracksServedStatusBoundary(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "s1", "agentsview")
+	_, err := d.InsertRecallEntry(RecallEntry{
+		ID: "promoted-entry", Type: "fact", Scope: "project", Status: "archived",
+		Title: "Draft", Body: "Promote later", SourceSessionID: "s1",
+	})
+	require.NoError(t, err)
+
+	_, err = d.getWriter().Exec(`
+		UPDATE recall_entries SET status = 'accepted' WHERE id = 'promoted-entry'`)
+	require.NoError(t, err)
+	revision, err := d.RecallCorpusRevision(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "counter-v1:1", revision)
+
+	_, err = d.getWriter().Exec(`
+		UPDATE recall_entries SET status = 'archived' WHERE id = 'promoted-entry'`)
+	require.NoError(t, err)
+	revision, err = d.RecallCorpusRevision(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "counter-v1:2", revision)
+
+	_, err = d.getWriter().Exec(`DELETE FROM recall_entries WHERE id = 'promoted-entry'`)
+	require.NoError(t, err)
+	revision, err = d.RecallCorpusRevision(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "counter-v1:2", revision,
+		"deleting an already-unserved entry does not advance the corpus")
+}
+
+func TestScanRecallEmbeddingUnitsFindsBackdatedMutationByRevision(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "s1", "agentsview")
+	_, err := d.InsertRecallEntry(RecallEntry{
+		ID: "backdated", Type: "fact", Scope: "project", Status: "accepted",
+		Title: "Initial", Body: "Body", SourceSessionID: "s1",
+	})
+	require.NoError(t, err)
+
+	watermark, err := d.ScanRecallEmbeddingUnits(
+		context.Background(), "", func(EmbeddableUnit) error { return nil },
+	)
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(watermark, "counter-v1:"))
+
+	_, err = d.getWriter().Exec(`
+		UPDATE recall_entries
+		SET title = 'Backdated edit', updated_at = '2000-01-01T00:00:00Z'
+		WHERE id = 'backdated'`)
+	require.NoError(t, err)
+
+	var units []EmbeddableUnit
+	next, err := d.ScanRecallEmbeddingUnits(
+		context.Background(), watermark,
+		func(unit EmbeddableUnit) error {
+			units = append(units, unit)
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, units, 1)
+	assert.Equal(t, "backdated", units[0].SessionID)
+	assert.Contains(t, units[0].Content, "Backdated edit")
+	assert.NotEqual(t, watermark, next)
+}
+
+func TestRecallEmbeddingIncrementalPlanStaysBoundedAcrossCorpusSizes(t *testing.T) {
+	var plans []string
+	for _, size := range []int{10, 5000} {
+		t.Run(fmt.Sprintf("entries_%d", size), func(t *testing.T) {
+			d := testDB(t)
+			insertSession(t, d, "s1", "agentsview")
+			tx, err := d.getWriter().Begin()
+			require.NoError(t, err)
+			stmt, err := tx.Prepare(`
+				INSERT INTO recall_entries
+					(id, type, scope, status, title, body, source_session_id, updated_at)
+				VALUES (?, 'fact', 'project', 'accepted', 'title', 'body', 's1', ?)`)
+			require.NoError(t, err)
+			for i := range size {
+				updatedAt := "2026-01-01T00:00:00.000Z"
+				if i == size-1 {
+					updatedAt = "2026-03-01T00:00:00.000Z"
+				}
+				_, err = stmt.Exec(fmt.Sprintf("entry-%05d", i), updatedAt)
+				require.NoError(t, err)
+			}
+			require.NoError(t, stmt.Close())
+			require.NoError(t, tx.Commit())
+			_, err = d.getWriter().Exec("ANALYZE recall_embedding_changes")
+			require.NoError(t, err)
+
+			query, args := recallEmbeddingRevisionScanSQL(int64(size-1), false)
+			rows, err := d.getReader().Query("EXPLAIN QUERY PLAN "+query, args...)
+			require.NoError(t, err)
+			var plan strings.Builder
+			for rows.Next() {
+				var id, parent, notUsed int
+				var detail string
+				require.NoError(t, rows.Scan(&id, &parent, &notUsed, &detail))
+				plan.WriteString(detail)
+			}
+			require.NoError(t, rows.Err())
+			require.NoError(t, rows.Close())
+			assert.Contains(t, plan.String(), "idx_recall_embedding_changes_revision")
+			assert.Contains(t, plan.String(), "revision>?")
+			plans = append(plans, plan.String())
+		})
+	}
+	require.Len(t, plans, 2)
+	assert.Equal(t, plans[0], plans[1],
+		"incremental query shape must not degrade as old corpus cardinality grows")
+}
+
+func TestScanRecallEmbeddingUnitsHonorsUpdatedWatermark(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "s1", "agentsview")
+	for _, id := range []string{"older", "newer"} {
+		_, err := d.InsertRecallEntry(RecallEntry{
+			ID: id, Type: "fact", Scope: "project", Status: "accepted",
+			Title: id, Body: "body", SourceSessionID: "s1",
+			SourceRunID: "extract-fp",
+		})
+		require.NoError(t, err)
+	}
+	watermark, err := d.ScanRecallEmbeddingUnits(
+		context.Background(), "", func(EmbeddableUnit) error { return nil },
+	)
+	require.NoError(t, err)
+	_, err = d.getWriter().Exec(`
+		UPDATE recall_entries
+		SET title = 'changed', updated_at = '2000-01-01T00:00:00Z'
+		WHERE id = 'newer'`)
+	require.NoError(t, err)
+
+	var ids []string
+	next, err := d.ScanRecallEmbeddingUnits(
+		context.Background(), watermark,
+		func(unit EmbeddableUnit) error {
+			ids = append(ids, unit.SessionID)
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"newer"}, ids)
+	assert.NotEqual(t, watermark, next)
+}
+
+func TestScanRecallEmbeddingUnitsFullWatermarkSkipsOlderChangesIncrementally(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "s1", "agentsview")
+	for _, entry := range []RecallEntry{
+		{
+			ID: "accepted-old", Type: "fact", Scope: "project", Status: "accepted",
+			Title: "Served entry", Body: "Still available.", SourceSessionID: "s1",
+		},
+		{
+			ID: "archived-newer", Type: "fact", Scope: "project", Status: "archived",
+			Title: "Archived entry", Body: "No longer available.", SourceSessionID: "s1",
+		},
+		{
+			ID: "deleted-newest", Type: "fact", Scope: "project", Status: "accepted",
+			Title: "Deleted entry", Body: "Removed permanently.", SourceSessionID: "s1",
+		},
+	} {
+		_, err := d.InsertRecallEntry(entry)
+		require.NoError(t, err)
+	}
+	_, err := d.getWriter().Exec(`
+		UPDATE recall_entries SET updated_at = CASE id
+			WHEN 'accepted-old' THEN '2026-01-01T00:00:00.000Z'
+			WHEN 'archived-newer' THEN '2026-02-01T00:00:00.000Z'
+			WHEN 'deleted-newest' THEN '2026-03-01T00:00:00.000Z'
+		END`)
+	require.NoError(t, err)
+	_, err = d.getWriter().Exec("DELETE FROM recall_entries WHERE id = 'deleted-newest'")
+	require.NoError(t, err)
+	_, err = d.getWriter().Exec(`
+		UPDATE recall_embedding_deletions
+		SET deleted_at = '2026-03-01T00:00:00.000Z'
+		WHERE entry_id = 'deleted-newest'`)
+	require.NoError(t, err)
+
+	var fullIDs []string
+	watermark, err := d.ScanRecallEmbeddingUnits(
+		context.Background(), "",
+		func(unit EmbeddableUnit) error {
+			fullIDs = append(fullIDs, unit.SessionID)
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"accepted-old"}, fullIDs)
+	assert.True(t, strings.HasPrefix(watermark, recallCorpusRevisionPrefix))
+
+	var incrementalIDs []string
+	_, err = d.ScanRecallEmbeddingUnits(
+		context.Background(), watermark,
+		func(unit EmbeddableUnit) error {
+			incrementalIDs = append(incrementalIDs, unit.SessionID)
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, incrementalIDs,
+		"the full-scan watermark must not replay older archived changes")
+}
+
+func TestScanRecallEmbeddingUnitsEmitsChangedArchivedEntryAsTombstone(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "s1", "agentsview")
+	_, err := d.InsertRecallEntry(RecallEntry{
+		ID: "archived", Type: "fact", Scope: "project", Status: "accepted",
+		Title: "Old entry", Body: "Initially served.", SourceSessionID: "s1",
+	})
+	require.NoError(t, err)
+	watermark, err := d.ScanRecallEmbeddingUnits(
+		context.Background(), "", func(EmbeddableUnit) error { return nil },
+	)
+	require.NoError(t, err)
+	_, err = d.getWriter().Exec(`
+		UPDATE recall_entries
+		SET status = 'archived', updated_at = '2000-01-01T00:00:00.000Z'
+		WHERE id = 'archived'`)
+	require.NoError(t, err)
+
+	var units []EmbeddableUnit
+	next, err := d.ScanRecallEmbeddingUnits(
+		context.Background(), watermark,
+		func(unit EmbeddableUnit) error {
+			units = append(units, unit)
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, units, 1)
+	assert.Equal(t, "archived", units[0].SessionID)
+	assert.True(t, units[0].Deleted)
+	assert.NotEqual(t, watermark, next)
+}
+
+func TestScanRecallEmbeddingUnitsTracksDeleteAndReinsert(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "s1", "agentsview")
+	_, err := d.InsertRecallEntry(RecallEntry{
+		ID: "retracted", Type: "fact", Scope: "project", Status: "accepted",
+		Title: "Private entry", Body: "Must leave semantic search.",
+		SourceSessionID: "s1",
+	})
+	require.NoError(t, err)
+	watermark, err := d.ScanRecallEmbeddingUnits(
+		context.Background(), "", func(EmbeddableUnit) error { return nil },
+	)
+	require.NoError(t, err)
+	_, err = d.getWriter().Exec(
+		"DELETE FROM recall_entries WHERE id = 'retracted'")
+	require.NoError(t, err)
+
+	var units []EmbeddableUnit
+	watermark, err = d.ScanRecallEmbeddingUnits(
+		context.Background(), watermark,
+		func(unit EmbeddableUnit) error {
+			units = append(units, unit)
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, units, 1)
+	assert.Equal(t, "retracted", units[0].SessionID)
+	assert.True(t, units[0].Deleted)
+
+	_, err = d.InsertRecallEntry(RecallEntry{
+		ID: "retracted", Type: "fact", Scope: "project", Status: "accepted",
+		Title: "Restored entry", Body: "This identity serves again.",
+		SourceSessionID: "s1",
+	})
+	require.NoError(t, err)
+	units = nil
+	_, err = d.ScanRecallEmbeddingUnits(
+		context.Background(), watermark,
+		func(unit EmbeddableUnit) error {
+			units = append(units, unit)
+			return nil
+		},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, units, 1)
+	assert.Equal(t, "Restored entry\n\nThis identity serves again.", units[0].Content)
+	assert.False(t, units[0].Deleted)
+}

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -377,6 +377,97 @@ CREATE INDEX IF NOT EXISTS idx_recall_entries_updated
 CREATE INDEX IF NOT EXISTS idx_recall_entries_supersession
     ON recall_entries(supersedes_entry_id, superseded_by_entry_id);
 
+-- Monotonic source revision for Recall vector freshness. Unlike timestamps,
+-- this cannot collide when several corpus mutations happen in one clock tick.
+CREATE TABLE IF NOT EXISTS recall_corpus_state (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    revision  INTEGER NOT NULL DEFAULT 0
+);
+INSERT OR IGNORE INTO recall_corpus_state (singleton, revision) VALUES (1, 0);
+
+-- Compact per-entry mutation sequence for bounded Recall vector refreshes.
+-- One row per identity is enough: an incremental reader needs only the latest
+-- state after its completed corpus revision, not every intermediate edit.
+CREATE TABLE IF NOT EXISTS recall_embedding_changes (
+    entry_id TEXT PRIMARY KEY,
+    revision INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_recall_embedding_changes_revision
+    ON recall_embedding_changes(revision, entry_id);
+INSERT OR IGNORE INTO recall_embedding_changes (entry_id, revision)
+SELECT recall_entries.id, recall_corpus_state.revision
+FROM recall_entries CROSS JOIN recall_corpus_state
+WHERE recall_corpus_state.singleton = 1;
+
+DROP TRIGGER IF EXISTS trg_recall_corpus_insert;
+CREATE TRIGGER IF NOT EXISTS trg_recall_corpus_insert
+AFTER INSERT ON recall_entries
+WHEN NEW.status = 'accepted'
+BEGIN
+    UPDATE recall_corpus_state SET revision = revision + 1 WHERE singleton = 1;
+    INSERT INTO recall_embedding_changes (entry_id, revision)
+    SELECT NEW.id, revision FROM recall_corpus_state WHERE singleton = 1
+    ON CONFLICT(entry_id) DO UPDATE SET revision = excluded.revision;
+END;
+
+DROP TRIGGER IF EXISTS trg_recall_corpus_update;
+CREATE TRIGGER IF NOT EXISTS trg_recall_corpus_update
+AFTER UPDATE ON recall_entries
+WHEN (OLD.status = 'accepted') <> (NEW.status = 'accepted')
+  OR (NEW.status = 'accepted' AND (
+      OLD.title IS NOT NEW.title
+      OR OLD.body IS NOT NEW.body
+      OR OLD.trigger IS NOT NEW.trigger
+  ))
+BEGIN
+    UPDATE recall_corpus_state SET revision = revision + 1 WHERE singleton = 1;
+    INSERT INTO recall_embedding_changes (entry_id, revision)
+    SELECT NEW.id, revision FROM recall_corpus_state WHERE singleton = 1
+    ON CONFLICT(entry_id) DO UPDATE SET revision = excluded.revision;
+END;
+
+DROP TRIGGER IF EXISTS trg_recall_corpus_delete;
+CREATE TRIGGER IF NOT EXISTS trg_recall_corpus_delete
+AFTER DELETE ON recall_entries
+WHEN OLD.status = 'accepted'
+BEGIN
+    UPDATE recall_corpus_state SET revision = revision + 1 WHERE singleton = 1;
+    INSERT INTO recall_embedding_changes (entry_id, revision)
+    SELECT OLD.id, revision FROM recall_corpus_state WHERE singleton = 1
+    ON CONFLICT(entry_id) DO UPDATE SET revision = excluded.revision;
+END;
+
+-- Recall-entry deletion journal: preserves the identity of hard-deleted
+-- entries long enough for an incremental vector refresh to remove their
+-- disposable mirror documents without scanning the complete served corpus.
+CREATE TABLE IF NOT EXISTS recall_embedding_deletions (
+    entry_id   TEXT PRIMARY KEY,
+    deleted_at TEXT NOT NULL
+        DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_recall_embedding_deletions_updated
+    ON recall_embedding_deletions(deleted_at DESC, entry_id);
+
+DROP TRIGGER IF EXISTS trg_recall_embedding_deletion;
+CREATE TRIGGER IF NOT EXISTS trg_recall_embedding_deletion
+AFTER DELETE ON recall_entries
+BEGIN
+    INSERT INTO recall_embedding_deletions (entry_id, deleted_at)
+    VALUES (OLD.id, strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+    ON CONFLICT(entry_id) DO UPDATE SET deleted_at = excluded.deleted_at;
+END;
+
+DROP TRIGGER IF EXISTS trg_recall_embedding_reinsert;
+CREATE TRIGGER IF NOT EXISTS trg_recall_embedding_reinsert
+AFTER INSERT ON recall_entries
+WHEN EXISTS (
+    SELECT 1 FROM recall_embedding_deletions WHERE entry_id = NEW.id
+)
+BEGIN
+    DELETE FROM recall_embedding_deletions WHERE entry_id = NEW.id;
+END;
+
 CREATE TABLE IF NOT EXISTS recall_evidence (
     id                    INTEGER PRIMARY KEY,
     entry_id             TEXT NOT NULL

--- a/internal/db/vector.go
+++ b/internal/db/vector.go
@@ -97,12 +97,34 @@ type VectorSearcher interface {
 	ResolveMessageUnits(ctx context.Context, refs []MessageRef) ([]UnitRef, error)
 }
 
+// RecallVectorHit is one semantic recall-entry match, ranked best first.
+type RecallVectorHit struct {
+	EntryID string
+	Score   float32
+}
+
+// RecallVectorSearcher is the seam through which recall querying reaches the
+// recall-entry embedding index without introducing an internal/db ->
+// internal/vector import cycle.
+type RecallVectorSearcher interface {
+	SearchRecall(
+		ctx context.Context, query string, limit int,
+	) (hits []RecallVectorHit, exhausted bool, err error)
+}
+
 // SetVectorSearcher wires (or, with nil, clears) the semantic search
 // backend. Safe to call concurrently with SearchContent/HasSemantic.
 func (db *DB) SetVectorSearcher(v VectorSearcher) {
 	db.vectorMu.Lock()
 	defer db.vectorMu.Unlock()
 	db.vectorSearcher = v
+}
+
+// SetRecallVectorSearcher wires (or clears with nil) semantic recall search.
+func (db *DB) SetRecallVectorSearcher(v RecallVectorSearcher) {
+	db.vectorMu.Lock()
+	defer db.vectorMu.Unlock()
+	db.recallSearcher = v
 }
 
 // HasSemantic reports whether a VectorSearcher has been wired in.
@@ -115,4 +137,10 @@ func (db *DB) getVectorSearcher() VectorSearcher {
 	db.vectorMu.RLock()
 	defer db.vectorMu.RUnlock()
 	return db.vectorSearcher
+}
+
+func (db *DB) getRecallVectorSearcher() RecallVectorSearcher {
+	db.vectorMu.RLock()
+	defer db.vectorMu.RUnlock()
+	return db.recallSearcher
 }

--- a/internal/db/vector.go
+++ b/internal/db/vector.go
@@ -103,13 +103,21 @@ type RecallVectorHit struct {
 	Score   float32
 }
 
+// RecallVectorSnapshot identifies the embedding generation and served Recall
+// corpus revision used to rank a set of vector hits.
+type RecallVectorSnapshot struct {
+	GenerationFingerprint string
+	CorpusRevision        string
+}
+
 // RecallVectorSearcher is the seam through which recall querying reaches the
 // recall-entry embedding index without introducing an internal/db ->
 // internal/vector import cycle.
 type RecallVectorSearcher interface {
 	SearchRecall(
 		ctx context.Context, query string, limit int,
-	) (hits []RecallVectorHit, exhausted bool, err error)
+	) (hits []RecallVectorHit, exhausted bool, snapshot RecallVectorSnapshot, err error)
+	ValidateRecallSnapshot(ctx context.Context, snapshot RecallVectorSnapshot) error
 }
 
 // SetVectorSearcher wires (or, with nil, clears) the semantic search

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,5 +1,5 @@
 // ABOUTME: Builds and serves the agentsview MCP server (stdio or
-// ABOUTME: StreamableHTTP) over the six read-only retrieval tools.
+// ABOUTME: StreamableHTTP) over the supported read-only retrieval tools.
 package mcp
 
 import (
@@ -22,6 +22,7 @@ import (
 // to it in tests.
 const (
 	ToolSearchSessions     = "search_sessions"
+	ToolQueryRecall        = "query_recall"
 	ToolListSessions       = "list_sessions"
 	ToolGetSessionOverview = "get_session_overview"
 	ToolGetMessages        = "get_messages"
@@ -44,8 +45,8 @@ type ServeOptions struct {
 	Token string
 }
 
-// newServer builds an MCP server with all six read-only tools
-// registered. Shared by the stdio and StreamableHTTP transports.
+// newServer builds an MCP server with the tools supported by its backing
+// service. Shared by the stdio and StreamableHTTP transports.
 func newServer(opts ServeOptions) *mcp.Server {
 	version := opts.Version
 	if version == "" {
@@ -71,6 +72,17 @@ func newServer(opts ServeOptions) *mcp.Server {
 			"unless include_active is set.",
 		Annotations: readOnly,
 	}, t.searchSessions)
+
+	if service.SupportsRecallQueries(opts.Service) {
+		mcp.AddTool(s, &mcp.Tool{
+			Name: ToolQueryRecall,
+			Description: "Search distilled knowledge extracted from prior sessions. " +
+				"Use lexical mode for exact terms, vector mode for semantic similarity, " +
+				"or hybrid mode to fuse both rankings. Returns recall entries with their " +
+				"source-session evidence and retrieval scores.",
+			Annotations: readOnly,
+		}, t.queryRecall)
+	}
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name: ToolListSessions,

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -41,7 +41,7 @@ func callParams(name string, args map[string]any) *mcp.CallToolParams {
 	return &mcp.CallToolParams{Name: name, Arguments: args}
 }
 
-func TestNewServer_RegistersSixReadOnlyTools(t *testing.T) {
+func TestNewServer_RegistersSevenReadOnlyTools(t *testing.T) {
 	d := dbtest.OpenTestDB(t)
 	srv := newServer(ServeOptions{
 		Service: service.NewDirectBackend(d, nil),
@@ -52,11 +52,29 @@ func TestNewServer_RegistersSixReadOnlyTools(t *testing.T) {
 	st, ct := newInMemoryPair(t, srv)
 	tools, err := ct.ListTools(context.Background(), nil)
 	require.NoError(t, err)
-	require.Len(t, tools.Tools, 6)
+	require.Len(t, tools.Tools, 7)
 	for _, tl := range tools.Tools {
 		require.NotNil(t, tl.Annotations, "tool %s missing annotations", tl.Name)
 		require.True(t, tl.Annotations.ReadOnlyHint,
 			"tool %s should be annotated read-only", tl.Name)
+	}
+	require.NoError(t, ct.Close())
+	require.NoError(t, st.Wait())
+}
+
+func TestNewServer_OmitsRecallToolForUnsupportedBackend(t *testing.T) {
+	d := dbtest.OpenTestDB(t)
+	srv := newServer(ServeOptions{
+		Service: service.NewReadOnlyBackend(d),
+		Now:     func() time.Time { return fixedNow },
+	})
+
+	st, ct := newInMemoryPair(t, srv)
+	tools, err := ct.ListTools(context.Background(), nil)
+	require.NoError(t, err)
+	require.Len(t, tools.Tools, 6)
+	for _, tool := range tools.Tools {
+		assert.NotEqual(t, ToolQueryRecall, tool.Name)
 	}
 	require.NoError(t, ct.Close())
 	require.NoError(t, st.Wait())

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -154,6 +154,49 @@ func (t *toolset) searchSessions(
 	return nil, out, nil
 }
 
+// --- query_recall ---
+
+type queryRecallIn struct {
+	Query           string `json:"query" jsonschema:"Natural-language query over distilled recall entries."`
+	Mode            string `json:"mode,omitempty" jsonschema:"Retrieval mode: lexical (default), vector, or hybrid."`
+	Project         string `json:"project,omitempty" jsonschema:"Filter by project name."`
+	CWD             string `json:"cwd,omitempty" jsonschema:"Filter by working directory."`
+	GitBranch       string `json:"git_branch,omitempty" jsonschema:"Filter by git branch."`
+	Agent           string `json:"agent,omitempty" jsonschema:"Filter by agent."`
+	Type            string `json:"type,omitempty" jsonschema:"Filter by recall entry type."`
+	Scope           string `json:"scope,omitempty" jsonschema:"Filter by recall scope."`
+	ExtractorMethod string `json:"extractor_method,omitempty" jsonschema:"Filter by extractor method."`
+	TrustedOnly     bool   `json:"trusted_only,omitempty" jsonschema:"Return only human-reviewed, transferable entries with verified provenance."`
+	Limit           int    `json:"limit,omitempty" jsonschema:"Max results, default 10, max 30."`
+}
+
+type queryRecallOut struct {
+	Mode        string            `json:"mode"`
+	QueryID     string            `json:"query_id,omitempty"`
+	Entries     []db.RecallResult `json:"entries"`
+	TrustedOnly bool              `json:"trusted_only"`
+}
+
+func (t *toolset) queryRecall(
+	ctx context.Context, _ *mcp.CallToolRequest, in queryRecallIn,
+) (*mcp.CallToolResult, queryRecallOut, error) {
+	result, err := t.svc.QueryRecallEntries(ctx, service.RecallQuery{
+		Query: in.Query, Mode: in.Mode,
+		Project: in.Project, CWD: in.CWD, GitBranch: in.GitBranch,
+		Agent: in.Agent, Type: in.Type, Scope: in.Scope,
+		ExtractorMethod: in.ExtractorMethod, TrustedOnly: in.TrustedOnly,
+		Limit:         clampLimit(in.Limit, defaultSearchLimit, maxSearchLimit),
+		SkipRecording: true,
+	})
+	if err != nil {
+		return nil, queryRecallOut{}, err
+	}
+	return nil, queryRecallOut{
+		Mode: result.Mode, QueryID: result.QueryID,
+		Entries: result.RecallEntries, TrustedOnly: result.TrustedOnly,
+	}, nil
+}
+
 // --- list_sessions ---
 
 type listSessionsIn struct {

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -25,8 +25,14 @@ type fakeMCPRecallVectorSearcher struct {
 
 func (f *fakeMCPRecallVectorSearcher) SearchRecall(
 	context.Context, string, int,
-) ([]db.RecallVectorHit, bool, error) {
-	return append([]db.RecallVectorHit(nil), f.hits...), true, nil
+) ([]db.RecallVectorHit, bool, db.RecallVectorSnapshot, error) {
+	return append([]db.RecallVectorHit(nil), f.hits...), true, db.RecallVectorSnapshot{}, nil
+}
+
+func (f *fakeMCPRecallVectorSearcher) ValidateRecallSnapshot(
+	context.Context, db.RecallVectorSnapshot,
+) error {
+	return nil
 }
 
 func newTestToolset(t *testing.T) (*toolset, *db.DB) {

--- a/internal/mcp/tools_test.go
+++ b/internal/mcp/tools_test.go
@@ -19,6 +19,16 @@ import (
 // self-reference exclusion window is reproducible.
 var fixedNow = time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
 
+type fakeMCPRecallVectorSearcher struct {
+	hits []db.RecallVectorHit
+}
+
+func (f *fakeMCPRecallVectorSearcher) SearchRecall(
+	context.Context, string, int,
+) ([]db.RecallVectorHit, bool, error) {
+	return append([]db.RecallVectorHit(nil), f.hits...), true, nil
+}
+
 func newTestToolset(t *testing.T) (*toolset, *db.DB) {
 	t.Helper()
 	d := dbtest.OpenTestDB(t)
@@ -141,6 +151,36 @@ func TestListSessions_ReturnsRows(t *testing.T) {
 	require.Len(t, out.Sessions, 1)
 	assert.Equal(t, "a-1", out.Sessions[0].SessionID)
 	assert.Equal(t, "proj-a", out.Sessions[0].Project)
+}
+
+func TestQueryRecall_ThreadsVectorModeAndReturnsDistilledEntries(t *testing.T) {
+	ts, d := newTestToolset(t)
+	dbtest.SeedSession(t, d, "s1", "agentsview")
+	_, err := d.InsertRecallEntry(db.RecallEntry{
+		ID: "semantic-entry", Type: "fact", Scope: "project", Status: "accepted",
+		Title: "Connection reuse", Body: "Keep idle resources available.",
+		Project: "agentsview", SourceSessionID: "s1",
+	})
+	require.NoError(t, err)
+	d.SetRecallVectorSearcher(&fakeMCPRecallVectorSearcher{hits: []db.RecallVectorHit{{
+		EntryID: "semantic-entry", Score: 0.75,
+	}}})
+
+	_, out, err := ts.queryRecall(
+		context.Background(), nil,
+		queryRecallIn{
+			Query: "database pool", Mode: db.RecallQueryModeVector,
+			Project: "agentsview", Limit: 5,
+		},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, db.RecallQueryModeVector, out.Mode)
+	assert.Empty(t, out.QueryID,
+		"a read-only MCP query must not append recall measurement rows")
+	require.Len(t, out.Entries, 1)
+	assert.Equal(t, "semantic-entry", out.Entries[0].ID)
+	assert.Equal(t, []string{"semantic"}, out.Entries[0].MatchReasons)
 }
 
 func TestGetSessionOverview_ChronologicalTail(t *testing.T) {
@@ -903,7 +943,7 @@ func TestServer_EndToEnd(t *testing.T) {
 		names = append(names, tl.Name)
 	}
 	assert.ElementsMatch(t, []string{
-		ToolSearchSessions, ToolListSessions, ToolGetSessionOverview,
+		ToolSearchSessions, ToolQueryRecall, ToolListSessions, ToolGetSessionOverview,
 		ToolGetMessages, ToolSearchContent, ToolGetUsageSummary,
 	}, names)
 

--- a/internal/server/huma_routes_embeddings.go
+++ b/internal/server/huma_routes_embeddings.go
@@ -15,6 +15,7 @@ import (
 // (Task 16), not part of the HTTP surface.
 type EmbeddingsManager interface {
 	StartBuild(req vector.BuildRequest) error
+	Wait()
 	Status() vector.BuildStatus
 	Generations(ctx context.Context) ([]vector.GenerationInfo, error)
 	Activate(ctx context.Context, id int64, force bool) error
@@ -27,6 +28,16 @@ type EmbeddingsManager interface {
 // API surface; handlers return 501 until vector serving is configured.
 func WithEmbeddingsManager(m EmbeddingsManager) Option {
 	return func(s *Server) { s.embeddingsManager = m }
+}
+
+// WithEmbeddingsStoreManager registers a non-default embedding store manager.
+func WithEmbeddingsStoreManager(name string, m EmbeddingsManager) Option {
+	return func(s *Server) {
+		if s.embeddingsStores == nil {
+			s.embeddingsStores = make(map[string]EmbeddingsManager)
+		}
+		s.embeddingsStores[name] = m
+	}
 }
 
 // WithEmbeddingsUnavailableReason records why the embeddings routes are
@@ -75,6 +86,7 @@ func (s *Server) registerEmbeddingsRoutes() {
 // scheduler and CLI builds resolve it; an explicit value overrides the
 // config for this build only.
 type embeddingsBuildRequest struct {
+	Store            string `json:"store,omitempty"`
 	FullRebuild      bool   `json:"full_rebuild,omitempty"`
 	Backstop         bool   `json:"backstop,omitempty"`
 	RepairInvalid    bool   `json:"repair_invalid,omitempty"`
@@ -99,25 +111,43 @@ type embeddingsGenerationsResponse struct {
 	Generations []vector.GenerationInfo `json:"generations"`
 }
 
+type embeddingsStoreInput struct {
+	Store string `query:"store"`
+}
+
 type embeddingsGenerationActionRequest struct {
 	Force bool `json:"force,omitempty"`
 }
 
 type embeddingsGenerationActionInput struct {
-	ID   int64 `path:"id" required:"true" doc:"Generation ordinal ID"`
-	Body embeddingsGenerationActionRequest
+	ID    int64  `path:"id" required:"true" doc:"Generation ordinal ID"`
+	Store string `query:"store"`
+	Body  embeddingsGenerationActionRequest
+}
+
+func (s *Server) embeddingsManagerFor(store string) EmbeddingsManager {
+	if store == "" || store == vector.MessageIndexSpec().Name {
+		return s.embeddingsManager
+	}
+	return s.embeddingsStores[store]
 }
 
 func (s *Server) humaEmbeddingsBuild(
 	_ context.Context, in *embeddingsBuildInput,
 ) (*embeddingsBuildOutput, error) {
-	if s.embeddingsManager == nil {
+	manager := s.embeddingsManagerFor(in.Body.Store)
+	if manager == nil {
 		return nil, s.embeddingsUnavailableError()
 	}
 	includeAutomated := s.embeddingsIncludeAutomatedDefault
 	if in.Body.IncludeAutomated != nil {
 		includeAutomated = *in.Body.IncludeAutomated
 	}
+	spec := vector.MessageIndexSpec()
+	if in.Body.Store == vector.RecallIndexSpec().Name {
+		spec = vector.RecallIndexSpec()
+	}
+	includeAutomated = spec.NormalizeIncludeAutomated(includeAutomated)
 	req := vector.BuildRequest{
 		FullRebuild:      in.Body.FullRebuild,
 		Backstop:         in.Body.Backstop,
@@ -125,7 +155,12 @@ func (s *Server) humaEmbeddingsBuild(
 		IncludeAutomated: includeAutomated,
 		Using:            in.Body.Using,
 	}
-	if err := s.embeddingsManager.StartBuild(req); err != nil {
+	release, ok := s.idle.BeginWork()
+	if !ok {
+		return nil, apiError(http.StatusServiceUnavailable, "server is shutting down")
+	}
+	if err := manager.StartBuild(req); err != nil {
+		release()
 		if errors.Is(err, vector.ErrBuildRunning) {
 			return nil, apiError(http.StatusConflict, err.Error())
 		}
@@ -135,6 +170,10 @@ func (s *Server) humaEmbeddingsBuild(
 		}
 		return nil, internalError("start embeddings build", err)
 	}
+	go func() {
+		manager.Wait()
+		release()
+	}()
 	return &embeddingsBuildOutput{
 		Status: http.StatusAccepted,
 		Body:   embeddingsBuildResponse{Started: true},
@@ -142,21 +181,23 @@ func (s *Server) humaEmbeddingsBuild(
 }
 
 func (s *Server) humaEmbeddingsStatus(
-	_ context.Context, _ *emptyInput,
+	_ context.Context, in *embeddingsStoreInput,
 ) (*jsonOutput[vector.BuildStatus], error) {
-	if s.embeddingsManager == nil {
+	manager := s.embeddingsManagerFor(in.Store)
+	if manager == nil {
 		return nil, s.embeddingsUnavailableError()
 	}
-	return &jsonOutput[vector.BuildStatus]{Body: s.embeddingsManager.Status()}, nil
+	return &jsonOutput[vector.BuildStatus]{Body: manager.Status()}, nil
 }
 
 func (s *Server) humaEmbeddingsGenerations(
-	ctx context.Context, _ *emptyInput,
+	ctx context.Context, in *embeddingsStoreInput,
 ) (*jsonOutput[embeddingsGenerationsResponse], error) {
-	if s.embeddingsManager == nil {
+	manager := s.embeddingsManagerFor(in.Store)
+	if manager == nil {
 		return nil, s.embeddingsUnavailableError()
 	}
-	gens, err := s.embeddingsManager.Generations(ctx)
+	gens, err := manager.Generations(ctx)
 	if err != nil {
 		return nil, internalError("list embedding generations", err)
 	}
@@ -171,10 +212,11 @@ func (s *Server) humaEmbeddingsGenerations(
 func (s *Server) humaEmbeddingsActivate(
 	ctx context.Context, in *embeddingsGenerationActionInput,
 ) (*noContentOutput, error) {
-	if s.embeddingsManager == nil {
+	manager := s.embeddingsManagerFor(in.Store)
+	if manager == nil {
 		return nil, s.embeddingsUnavailableError()
 	}
-	if err := s.embeddingsManager.Activate(ctx, in.ID, in.Body.Force); err != nil {
+	if err := manager.Activate(ctx, in.ID, in.Body.Force); err != nil {
 		return nil, embeddingsActionError(err)
 	}
 	return &noContentOutput{Status: http.StatusNoContent}, nil
@@ -183,10 +225,11 @@ func (s *Server) humaEmbeddingsActivate(
 func (s *Server) humaEmbeddingsRetire(
 	ctx context.Context, in *embeddingsGenerationActionInput,
 ) (*noContentOutput, error) {
-	if s.embeddingsManager == nil {
+	manager := s.embeddingsManagerFor(in.Store)
+	if manager == nil {
 		return nil, s.embeddingsUnavailableError()
 	}
-	if err := s.embeddingsManager.Retire(ctx, in.ID, in.Body.Force); err != nil {
+	if err := manager.Retire(ctx, in.ID, in.Body.Force); err != nil {
 		return nil, embeddingsActionError(err)
 	}
 	return &noContentOutput{Status: http.StatusNoContent}, nil

--- a/internal/server/huma_routes_embeddings_test.go
+++ b/internal/server/huma_routes_embeddings_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -45,6 +46,8 @@ type fakeEmbeddingsManager struct {
 
 	retireErr   error
 	retireCalls []activateCall
+
+	waitForBuild <-chan struct{}
 }
 
 func (f *fakeEmbeddingsManager) StartBuild(req vector.BuildRequest) error {
@@ -78,6 +81,12 @@ func (f *fakeEmbeddingsManager) Retire(_ context.Context, id int64, force bool) 
 	defer f.mu.Unlock()
 	f.retireCalls = append(f.retireCalls, activateCall{id: id, force: force})
 	return f.retireErr
+}
+
+func (f *fakeEmbeddingsManager) Wait() {
+	if f.waitForBuild != nil {
+		<-f.waitForBuild
+	}
 }
 
 // newEmbeddingsTestServer builds a full Server (via testServer, so the SPA
@@ -158,6 +167,64 @@ func TestEmbeddingsBuildReturnsAcceptedAndStartsBuild(t *testing.T) {
 	require.Len(t, fake.startBuildCalls, 1)
 	assert.True(t, fake.startBuildCalls[0].FullRebuild)
 	assert.False(t, fake.startBuildCalls[0].RepairInvalid)
+}
+
+func TestEmbeddingsBuildHoldsIdleLeaseUntilManagerCompletes(t *testing.T) {
+	buildDone := make(chan struct{})
+	var completeOnce sync.Once
+	complete := func() { completeOnce.Do(func() { close(buildDone) }) }
+	defer complete()
+	fake := &fakeEmbeddingsManager{waitForBuild: buildDone}
+	idled := make(chan struct{}, 1)
+	tracker := NewIdleTracker(20*time.Millisecond, func() { idled <- struct{}{} })
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	s := testServer(t, 0, WithEmbeddingsManager(fake), WithIdleTracker(tracker))
+	tracker.Touch()
+	go tracker.Run(ctx)
+
+	w := serveJSON(t, s.mux, http.MethodPost, "/api/v1/embeddings/build",
+		vector.BuildRequest{})
+	assertRecorderStatus(t, w, http.StatusAccepted)
+
+	select {
+	case <-idled:
+		require.Fail(t, "daemon idled while an API-started embedding build was active")
+	case <-time.After(100 * time.Millisecond):
+	}
+	complete()
+	select {
+	case <-idled:
+	case <-time.After(time.Second):
+		require.Fail(t, "daemon did not idle after the API-started build completed")
+	}
+}
+
+func TestEmbeddingsRoutesSelectRecallStoreManager(t *testing.T) {
+	messages := &fakeEmbeddingsManager{status: vector.BuildStatus{Done: 1}}
+	recall := &fakeEmbeddingsManager{status: vector.BuildStatus{Done: 2}}
+	s := testServer(t, 0,
+		WithEmbeddingsManager(messages),
+		WithEmbeddingsStoreManager(vector.RecallIndexSpec().Name, recall),
+	)
+
+	w := serveJSON(t, s.mux, http.MethodPost, "/api/v1/embeddings/build",
+		map[string]any{
+			"store": "recall", "full_rebuild": true,
+			"include_automated": true,
+		})
+	assertRecorderStatus(t, w, http.StatusAccepted)
+	assert.Empty(t, messages.startBuildCalls)
+	require.Len(t, recall.startBuildCalls, 1)
+	assert.True(t, recall.startBuildCalls[0].FullRebuild)
+	assert.False(t, recall.startBuildCalls[0].IncludeAutomated,
+		"Recall has no automated-session scope and must normalize it")
+
+	statusResponse := serveGet(t, s, "/api/v1/embeddings/status?store=recall")
+	assertRecorderStatus(t, statusResponse, http.StatusOK)
+	var status vector.BuildStatus
+	require.NoError(t, json.Unmarshal(statusResponse.Body.Bytes(), &status))
+	assert.Equal(t, int64(2), status.Done)
 }
 
 // TestEmbeddingsBuildIncludeAutomatedDefaulting pins the tri-state contract:

--- a/internal/server/recall.go
+++ b/internal/server/recall.go
@@ -159,6 +159,14 @@ func (s *Server) handleQueryRecallEntries(
 		if handleReadOnly(w, err) {
 			return
 		}
+		if errors.Is(err, db.ErrSemanticTransient) {
+			writeError(w, http.StatusServiceUnavailable, err.Error())
+			return
+		}
+		if errors.Is(err, db.ErrSemanticUnavailable) {
+			writeError(w, http.StatusNotImplemented, err.Error())
+			return
+		}
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
@@ -201,6 +209,9 @@ func (s *Server) handleImportRecallEntries(
 			AllowProductionImport:   allowProductionImport,
 		},
 	)
+	if result.Imported > 0 && s.recallCorpusMutationNotify != nil {
+		s.recallCorpusMutationNotify()
+	}
 	if err != nil {
 		if handleContextError(w, err) {
 			return

--- a/internal/server/recall_eval_ingest.go
+++ b/internal/server/recall_eval_ingest.go
@@ -117,6 +117,9 @@ func (s *Server) handleIngestEvalTrajectory(
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	if result.EntriesIndexed > 0 && s.recallCorpusMutationNotify != nil {
+		s.recallCorpusMutationNotify()
+	}
 	writeJSON(w, http.StatusOK, result)
 }
 

--- a/internal/server/recall_eval_ingest_test.go
+++ b/internal/server/recall_eval_ingest_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,6 +16,7 @@ import (
 
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/server"
 )
 
 // evalQueryResponse mirrors the fields of the (unexported) recall query
@@ -90,6 +92,37 @@ func TestIngestEvalTrajectoryIdempotent(t *testing.T) {
 	w2 := te.post(t, "/api/v1/recall/eval/trajectories", body)
 	assertStatus(t, w2, http.StatusOK)
 	assert.Equal(t, 0, decode[db.EvalTrajectoryIngestResult](t, w2).EntriesIndexed)
+}
+
+func TestIngestEvalTrajectoryNotifiesOnlyWhenAcceptedCorpusChanges(t *testing.T) {
+	var notifications atomic.Int32
+	te := setupWithServerOpts(t, []server.Option{
+		server.WithRecallCorpusMutationNotifier(func() {
+			notifications.Add(1)
+		}),
+	})
+	body := `
+{"run_id":"run-notify","trajectory_id":"traj-notify","extractor_method":"eval-harness-raw-trajectory","source_version":"test-harness-v1","trajectory":{"text":"schedule semantic refresh"}}
+`
+
+	w := te.post(t, "/api/v1/recall/eval/trajectories", body)
+	assertStatus(t, w, http.StatusOK)
+	assert.Equal(t, 1, decode[db.EvalTrajectoryIngestResult](t, w).EntriesIndexed)
+	assert.Equal(t, int32(1), notifications.Load())
+
+	w = te.post(t, "/api/v1/recall/eval/trajectories", body)
+	assertStatus(t, w, http.StatusOK)
+	assert.Equal(t, 0, decode[db.EvalTrajectoryIngestResult](t, w).EntriesIndexed)
+	assert.Equal(t, int32(1), notifications.Load(),
+		"idempotent ingestion must not schedule an unchanged corpus")
+
+	w = te.post(t, "/api/v1/recall/eval/trajectories", `
+{"run_id":"run-empty","trajectory_id":"traj-empty","extractor_method":"eval-harness-raw-trajectory","source_version":"test-harness-v1","trajectory":{"n":1}}
+`)
+	assertStatus(t, w, http.StatusOK)
+	assert.Equal(t, 0, decode[db.EvalTrajectoryIngestResult](t, w).EntriesIndexed)
+	assert.Equal(t, int32(1), notifications.Load(),
+		"zero-entry ingestion must not schedule an unchanged corpus")
 }
 
 func TestIngestEvalTrajectoryVersionsExposeQueryableCorpusID(t *testing.T) {

--- a/internal/server/recall_test.go
+++ b/internal/server/recall_test.go
@@ -3,11 +3,13 @@ package server_test
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -51,6 +53,42 @@ func (s *readOnlyRecallQueryStore) QueryRecallEntries(
 }
 
 func (*readOnlyRecallQueryStore) ReadOnly() bool { return true }
+
+type recallErrorSearcher struct{ err error }
+
+func (s recallErrorSearcher) SearchRecall(
+	context.Context, string, int,
+) ([]db.RecallVectorHit, bool, error) {
+	return nil, false, s.err
+}
+
+func TestQueryRecallMapsSemanticAvailabilityErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		searcher   db.RecallVectorSearcher
+		wantStatus int
+	}{
+		{name: "unavailable", wantStatus: http.StatusNotImplemented},
+		{
+			name: "transient",
+			searcher: recallErrorSearcher{err: fmt.Errorf(
+				"%w: encoder offline", db.ErrSemanticTransient,
+			)},
+			wantStatus: http.StatusServiceUnavailable,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			te := setup(t)
+			te.db.SetRecallVectorSearcher(tt.searcher)
+			w := te.post(t, "/api/v1/recall/query", `{
+				"query":"semantic query",
+				"mode":"vector"
+			}`)
+			assertStatus(t, w, tt.wantStatus)
+		})
+	}
+}
 
 func TestListRecallEntriesFiltersByProject(t *testing.T) {
 	te := setup(t)
@@ -702,6 +740,44 @@ func TestImportRecallEntriesJSONL(t *testing.T) {
 	assertStatus(t, w, http.StatusOK)
 	recall := decode[db.RecallEntry](t, w)
 	assert.Equal(t, "Check cwd before file reads", recall.Title)
+}
+
+func TestImportRecallEntriesNotifiesOnlyWhenAcceptedCorpusChanges(t *testing.T) {
+	var notifications atomic.Int32
+	te := setupWithServerOpts(t, []server.Option{
+		server.WithRecallCorpusMutationNotifier(func() {
+			notifications.Add(1)
+		}),
+	})
+	seedRecallEntrySession(t, te)
+	seedRecallImportEvidence(t, te)
+	input := `
+{"candidate_id":"m-notify","type":"debugging_method","scope":"repository","title":"Check cwd before file reads","body":"Verify cwd before retrying failed reads.","project":"agentsview","agent":"codex","session_id":"recall-session","label":"correct","transferable":true,"provenance_ok":true,"evidence":{"ordinal_start":3,"ordinal_end":7,"tool_use_ids":["toolu_1"]}}
+`
+
+	w := te.post(t, "/api/v1/recall/import", input)
+	assertStatus(t, w, http.StatusOK)
+	assert.Equal(t, int32(1), notifications.Load())
+
+	w = te.post(t, "/api/v1/recall/import", input)
+	assertStatus(t, w, http.StatusOK)
+	assert.Equal(t, int32(1), notifications.Load(),
+		"a duplicate-only import must not schedule an unchanged corpus")
+
+	w = te.post(t, "/api/v1/recall/import?dry_run=true", strings.ReplaceAll(
+		input, "m-notify", "m-dry-run",
+	))
+	assertStatus(t, w, http.StatusOK)
+	assert.Equal(t, int32(1), notifications.Load(),
+		"a dry run must not schedule embedding work")
+
+	partial := strings.ReplaceAll(input, "m-notify", "m-partial") + "\n{"
+	w = te.post(t, "/api/v1/recall/import", partial)
+	assertStatus(t, w, http.StatusBadRequest)
+	assert.Equal(t, int32(2), notifications.Load(),
+		"entries committed before a later parse error must schedule embedding")
+	w = te.get(t, "/api/v1/recall/entries/m-partial")
+	assertStatus(t, w, http.StatusOK)
 }
 
 func TestImportRecallEntriesRefusesDefaultDataDirWithoutOverride(t *testing.T) {

--- a/internal/server/recall_test.go
+++ b/internal/server/recall_test.go
@@ -58,8 +58,14 @@ type recallErrorSearcher struct{ err error }
 
 func (s recallErrorSearcher) SearchRecall(
 	context.Context, string, int,
-) ([]db.RecallVectorHit, bool, error) {
-	return nil, false, s.err
+) ([]db.RecallVectorHit, bool, db.RecallVectorSnapshot, error) {
+	return nil, false, db.RecallVectorSnapshot{}, s.err
+}
+
+func (s recallErrorSearcher) ValidateRecallSnapshot(
+	context.Context, db.RecallVectorSnapshot,
+) error {
+	return s.err
 }
 
 func TestQueryRecallMapsSemanticAvailabilityErrors(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -45,7 +45,7 @@ type VersionInfo struct {
 // APIVersion is shared by HTTP version reporting and local daemon discovery.
 // Bump it when a client-visible contract cannot be decoded safely by an older
 // CLI or daemon.
-const APIVersion = 3
+const APIVersion = 4
 
 const daemonService = "agentsview"
 
@@ -107,6 +107,9 @@ type Server struct {
 	// activity would otherwise surface. Called synchronously; it must not
 	// block.
 	sessionMutationNotify func()
+	// recallCorpusMutationNotify, when set, is called after an import adds or
+	// supersedes accepted recall entries so semantic mirrors can refresh.
+	recallCorpusMutationNotify func()
 
 	// pprofEnabled registers net/http/pprof handlers under
 	// /debug/pprof/ so a running daemon can be profiled. Off by
@@ -117,6 +120,7 @@ type Server struct {
 	// build lifecycle routes. Nil (the default) leaves those routes
 	// unregistered, e.g. when semantic search is not configured.
 	embeddingsManager EmbeddingsManager
+	embeddingsStores  map[string]EmbeddingsManager
 
 	// embeddingsUnavailableReason, when non-empty, replaces the generic
 	// "embeddings manager not available" 501 message on the embeddings
@@ -321,11 +325,32 @@ func WithIdleTracker(t *IdleTracker) Option {
 }
 
 // WithSessionMutationNotifier registers fn to run after a route changes a
-// session's lifecycle (trash, restore, permanent delete). fn is called
-// synchronously on the request path and must not block; a non-blocking
-// scheduler signal is the intended shape.
+// session's lifecycle (trash, restore, permanent delete). Multiple options
+// fan out in registration order so independent lifecycle consumers do not
+// suppress one another. Each fn is called synchronously on the request path
+// and must not block; a non-blocking scheduler signal is the intended shape.
 func WithSessionMutationNotifier(fn func()) Option {
-	return func(s *Server) { s.sessionMutationNotify = fn }
+	return func(s *Server) {
+		if fn == nil {
+			return
+		}
+		previous := s.sessionMutationNotify
+		if previous == nil {
+			s.sessionMutationNotify = fn
+			return
+		}
+		s.sessionMutationNotify = func() {
+			previous()
+			fn()
+		}
+	}
+}
+
+// WithRecallCorpusMutationNotifier registers fn to run after a successful
+// import changes the accepted recall corpus. fn must not block; a scheduler's
+// coalescing Notify method is the intended shape.
+func WithRecallCorpusMutationNotifier(fn func()) Option {
+	return func(s *Server) { s.recallCorpusMutationNotify = fn }
 }
 
 // WithPprof enables the net/http/pprof handlers under

--- a/internal/server/session_mutation_notify_internal_test.go
+++ b/internal/server/session_mutation_notify_internal_test.go
@@ -12,6 +12,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"go.kenn.io/agentsview/internal/config"
@@ -100,6 +101,30 @@ func TestSessionMutationRoutesNotify(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
 	require.Equal(t, int32(7), notified.Load(),
 		"a completed daemon scan must notify")
+}
+
+func TestSessionMutationRoutesFanOutToAllNotifiers(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+	database := dbtest.OpenTestDBAt(t, dbPath)
+	var extractionNotified, recallNotified atomic.Int32
+	s := New(config.Config{
+		Host: "127.0.0.1", Port: 0, DataDir: dir, DBPath: dbPath,
+	}, database, nil,
+		WithSessionMutationNotifier(func() { extractionNotified.Add(1) }),
+		WithSessionMutationNotifier(func() { recallNotified.Add(1) }),
+	)
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "sess-1", Project: "proj", Machine: "local", Agent: "claude",
+	}))
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/sessions/sess-1", nil)
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNoContent, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, int32(1), extractionNotified.Load())
+	assert.Equal(t, int32(1), recallNotified.Load())
 }
 
 // cancelOnProgressWriter cancels the request context as soon as the

--- a/internal/service/direct.go
+++ b/internal/service/direct.go
@@ -53,6 +53,8 @@ func NewReadOnlyBackend(d db.Store) SessionService {
 	return &directBackend{db: d}
 }
 
+func (b *directBackend) SupportsRecallQueries() bool { return b.local != nil }
+
 func (b *directBackend) Get(
 	ctx context.Context, id string,
 ) (*SessionDetail, error) {

--- a/internal/service/http.go
+++ b/internal/service/http.go
@@ -45,6 +45,23 @@ type errNotImplementedBody struct {
 func (e *errNotImplementedBody) Error() string { return errHTTPNotImplemented.Error() }
 func (e *errNotImplementedBody) Unwrap() error { return errHTTPNotImplemented }
 
+type httpStatusError struct {
+	method     string
+	path       string
+	statusCode int
+	body       []byte
+}
+
+func (e *httpStatusError) Error() string {
+	return fmt.Sprintf(
+		"%s %s: HTTP %d: %s", e.method, e.path, e.statusCode, e.body,
+	)
+}
+
+func (e *httpStatusError) message() string {
+	return notImplementedMessage(e.body)
+}
+
 // notImplementedMessage extracts the {"error": "..."} message huma's error
 // responses carry, falling back to the raw (trimmed) body when it isn't in
 // that shape.
@@ -557,6 +574,17 @@ func wrapSemanticUnavailable(message string) error {
 	return db.NewSemanticUnavailableError(message)
 }
 
+func wrapSemanticTransient(message string) error {
+	sentinel := db.ErrSemanticTransient.Error()
+	if message == "" || message == sentinel {
+		return db.ErrSemanticTransient
+	}
+	if cause, ok := strings.CutPrefix(message, sentinel); ok {
+		return fmt.Errorf("%w%s", db.ErrSemanticTransient, cause)
+	}
+	return fmt.Errorf("%w: %s", db.ErrSemanticTransient, message)
+}
+
 func (b *httpBackend) UsageSummary(
 	ctx context.Context, req UsageRequest,
 ) (*UsageSummaryResult, error) {
@@ -760,6 +788,13 @@ func (b *httpBackend) QueryRecallEntries(
 			return nil, fmt.Errorf(
 				"recall query: daemon at %s: %w", b.baseURL, db.ErrReadOnly,
 			)
+		}
+		var statusErr *httpStatusError
+		if (mode == db.RecallQueryModeVector ||
+			mode == db.RecallQueryModeHybrid) &&
+			errors.As(err, &statusErr) &&
+			statusErr.statusCode == http.StatusServiceUnavailable {
+			return nil, wrapSemanticTransient(statusErr.message())
 		}
 		return nil, err
 	}
@@ -1064,9 +1099,10 @@ func (b *httpBackend) getJSONWithClient(
 	}
 	if resp.StatusCode != http.StatusOK {
 		msg, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf(
-			"GET %s: HTTP %d: %s", path, resp.StatusCode, msg,
-		)
+		return &httpStatusError{
+			method: http.MethodGet, path: path,
+			statusCode: resp.StatusCode, body: msg,
+		}
 	}
 	return json.NewDecoder(resp.Body).Decode(out)
 }
@@ -1113,9 +1149,10 @@ func (b *httpBackend) postJSONWithClient(
 	}
 	if resp.StatusCode != http.StatusOK {
 		msg, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf(
-			"POST %s: HTTP %d: %s", path, resp.StatusCode, msg,
-		)
+		return &httpStatusError{
+			method: http.MethodPost, path: path,
+			statusCode: resp.StatusCode, body: msg,
+		}
 	}
 	return json.NewDecoder(resp.Body).Decode(out)
 }

--- a/internal/service/http.go
+++ b/internal/service/http.go
@@ -63,7 +63,17 @@ type httpBackend struct {
 	client            *http.Client
 	longRunningClient *http.Client
 	readOnly          bool
+	recallQueries     bool
 	token             string
+}
+
+const recallNonRecordingAPIVersion = 4
+
+// HTTPServerCapabilities is the subset of version metadata needed to expose
+// client features safely for an explicitly selected daemon.
+type HTTPServerCapabilities struct {
+	ReadOnly   bool `json:"read_only"`
+	APIVersion int  `json:"api_version"`
 }
 
 // NewHTTPBackend constructs a SessionService that proxies to a
@@ -73,14 +83,51 @@ type httpBackend struct {
 // on every request so the backend works against daemons running
 // with require_auth=true.
 func NewHTTPBackend(baseURL, token string, readOnly bool) SessionService {
+	return newHTTPBackend(baseURL, token, readOnly, !readOnly)
+}
+
+// NewHTTPBackendForServer constructs a backend whose advertised capabilities
+// are limited by metadata probed from an explicitly selected daemon.
+func NewHTTPBackendForServer(
+	baseURL, token string, capabilities HTTPServerCapabilities,
+) SessionService {
+	return newHTTPBackend(
+		baseURL,
+		token,
+		capabilities.ReadOnly,
+		!capabilities.ReadOnly &&
+			capabilities.APIVersion >= recallNonRecordingAPIVersion,
+	)
+}
+
+func newHTTPBackend(
+	baseURL, token string, readOnly, recallQueries bool,
+) *httpBackend {
 	return &httpBackend{
 		baseURL:           strings.TrimSuffix(baseURL, "/"),
 		client:            &http.Client{Timeout: 30 * time.Second},
 		longRunningClient: &http.Client{Timeout: 0},
 		readOnly:          readOnly,
+		recallQueries:     recallQueries,
 		token:             token,
 	}
 }
+
+// ProbeHTTPServerCapabilities reads the metadata needed to expose tools safely
+// for an explicit daemon URL. Such callers do not have a local runtime record.
+func ProbeHTTPServerCapabilities(
+	ctx context.Context, baseURL, token string,
+) (HTTPServerCapabilities, error) {
+	b := newHTTPBackend(baseURL, token, false, false)
+	var capabilities HTTPServerCapabilities
+	if err := b.getJSON(ctx, "/api/v1/version", &capabilities); err != nil {
+		return HTTPServerCapabilities{},
+			fmt.Errorf("probing server capabilities: %w", err)
+	}
+	return capabilities, nil
+}
+
+func (b *httpBackend) SupportsRecallQueries() bool { return b.recallQueries }
 
 func (b *httpBackend) Get(
 	ctx context.Context, id string,
@@ -695,9 +742,21 @@ func (b *httpBackend) QueryRecallEntries(
 	if req.StrictRecording {
 		return nil, fmt.Errorf("strict recall recording requires a direct backend")
 	}
+	mode := db.NormalizeRecallQuery(db.RecallQuery{Mode: req.Mode}).Mode
+	post := b.postJSON
+	if mode == db.RecallQueryModeVector || mode == db.RecallQueryModeHybrid {
+		post = b.postJSONLong
+	}
 	var out RecallQueryResult
-	if err := b.postJSON(ctx, "/api/v1/recall/query", req, &out); err != nil {
+	if err := post(ctx, "/api/v1/recall/query", req, &out); err != nil {
 		if errors.Is(err, errHTTPNotImplemented) {
+			var notImpl *errNotImplementedBody
+			if (mode == db.RecallQueryModeVector ||
+				mode == db.RecallQueryModeHybrid) &&
+				errors.As(err, &notImpl) &&
+				notImpl.message != "not available in remote mode" {
+				return nil, wrapSemanticUnavailable(notImpl.message)
+			}
 			return nil, fmt.Errorf(
 				"recall query: daemon at %s: %w", b.baseURL, db.ErrReadOnly,
 			)
@@ -707,6 +766,15 @@ func (b *httpBackend) QueryRecallEntries(
 	if out.RecallEntries == nil {
 		out.RecallEntries = []db.RecallResult{}
 	}
+	requestedMode := mode
+	returnedMode := db.NormalizeRecallQuery(db.RecallQuery{Mode: out.Mode}).Mode
+	if returnedMode != requestedMode {
+		return nil, fmt.Errorf(
+			"recall query: requested recall mode %s but daemon returned %s",
+			requestedMode, returnedMode,
+		)
+	}
+	out.Mode = returnedMode
 	if req.TrustedOnly {
 		out.TrustedOnly = true
 	}
@@ -1006,6 +1074,18 @@ func (b *httpBackend) getJSONWithClient(
 func (b *httpBackend) postJSON(
 	ctx context.Context, path string, in any, out any,
 ) error {
+	return b.postJSONWithClient(ctx, b.client, path, in, out)
+}
+
+func (b *httpBackend) postJSONLong(
+	ctx context.Context, path string, in any, out any,
+) error {
+	return b.postJSONWithClient(ctx, b.longRunningClient, path, in, out)
+}
+
+func (b *httpBackend) postJSONWithClient(
+	ctx context.Context, client *http.Client, path string, in any, out any,
+) error {
 	body, err := json.Marshal(in)
 	if err != nil {
 		return err
@@ -1019,7 +1099,7 @@ func (b *httpBackend) postJSON(
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Origin", b.baseURL)
 	b.addAuth(req)
-	resp, err := b.client.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return err
 	}

--- a/internal/service/http_internal_test.go
+++ b/internal/service/http_internal_test.go
@@ -23,6 +23,24 @@ func TestNewHTTPBackendUsesLongRunningClient(t *testing.T) {
 	assert.Zero(t, backend.longRunningClient.Timeout)
 }
 
+func TestHTTPBackendRecallCapabilityRespectsReadOnlyMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		readOnly bool
+		want     bool
+	}{
+		{name: "writable daemon", want: true},
+		{name: "read-only daemon", readOnly: true, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			svc := NewHTTPBackend("http://example.test", "", tt.readOnly)
+			assert.Equal(t, tt.want, SupportsRecallQueries(svc))
+		})
+	}
+}
+
 func TestSearchContentUsesLongRunningClient(t *testing.T) {
 	t.Parallel()
 
@@ -44,4 +62,38 @@ func TestSearchContentUsesLongRunningClient(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Empty(t, result.Matches)
+}
+
+func TestQueryRecallSemanticModesUseLongRunningClient(t *testing.T) {
+	tests := []struct {
+		name      string
+		inputMode string
+		wantMode  string
+	}{
+		{name: "vector", inputMode: " VECTOR ", wantMode: "vector"},
+		{name: "hybrid", inputMode: "Hybrid", wantMode: "hybrid"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				time.Sleep(50 * time.Millisecond)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"mode":"` + tt.wantMode + `","recall_entries":[]}`))
+			}))
+			t.Cleanup(srv.Close)
+
+			svc := NewHTTPBackend(srv.URL, "", false)
+			backend, ok := svc.(*httpBackend)
+			require.True(t, ok)
+			backend.client.Timeout = 10 * time.Millisecond
+
+			result, err := svc.QueryRecallEntries(context.Background(), RecallQuery{
+				Query: "connection storm", Mode: tt.inputMode,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantMode, result.Mode)
+			assert.Empty(t, result.RecallEntries)
+		})
+	}
 }

--- a/internal/service/http_test.go
+++ b/internal/service/http_test.go
@@ -378,6 +378,28 @@ func TestHTTPBackend_QueryRecallEntriesIncludesSourceEpisodeID(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestHTTPBackend_QueryRecallEntriesTransportsSkipRecording(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var got service.RecallQuery
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
+		assert.True(t, got.SkipRecording)
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(service.RecallQueryResult{
+			Mode: db.RecallQueryModeLexical, RecallEntries: []db.RecallResult{},
+		}))
+	}))
+	t.Cleanup(srv.Close)
+
+	svc := service.NewHTTPBackend(srv.URL, "", false)
+	result, err := svc.QueryRecallEntries(context.Background(), service.RecallQuery{
+		Query: "read only recall", SkipRecording: true,
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, result.QueryID)
+}
+
 func TestHTTPBackend_QueryRecallEntriesRejectsNegativeContextMaxBytesLocally(t *testing.T) {
 	t.Parallel()
 	var calls int
@@ -796,6 +818,49 @@ func TestHTTPBackend_RecallReads_RemoteReadOnly(t *testing.T) {
 			assert.Contains(t, err.Error(), env.BaseURL)
 		})
 	}
+}
+
+func TestHTTPBackend_QueryRecallVector501PreservesSemanticCause(t *testing.T) {
+	t.Parallel()
+	body := service.ErrSemanticUnavailable.Error() + ": recall index is stale"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotImplemented)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]string{
+			"error": body,
+		}))
+	}))
+	t.Cleanup(srv.Close)
+
+	be := service.NewHTTPBackend(srv.URL, "", false)
+	_, err := be.QueryRecallEntries(context.Background(), service.RecallQuery{
+		Query: "retry policy",
+		Mode:  "VECTOR",
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, service.ErrSemanticUnavailable)
+	assert.Equal(t, body, err.Error())
+}
+
+func TestHTTPBackend_QueryRecallRejectsResponseModeMismatch(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(service.RecallQueryResult{
+			Mode:          db.RecallQueryModeLexical,
+			RecallEntries: []db.RecallResult{},
+		}))
+	}))
+	t.Cleanup(srv.Close)
+
+	be := service.NewHTTPBackend(srv.URL, "", false)
+	_, err := be.QueryRecallEntries(context.Background(), service.RecallQuery{
+		Query: "retry policy", Mode: db.RecallQueryModeHybrid,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requested recall mode hybrid")
+	assert.Contains(t, err.Error(), "returned lexical")
 }
 
 func TestHTTPBackend_Watch_ReceivesSessionUpdated(t *testing.T) {

--- a/internal/service/http_test.go
+++ b/internal/service/http_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -112,6 +113,18 @@ func (readOnlyHTTPStore) ReadOnly() bool { return true }
 
 type recallUnavailableHTTPStore struct {
 	readOnlyHTTPStore
+}
+
+type recallTransientHTTPStore struct {
+	*db.DB
+}
+
+func (recallTransientHTTPStore) QueryRecallEntries(
+	context.Context, db.RecallQuery,
+) (db.RecallPage, error) {
+	return db.RecallPage{}, fmt.Errorf(
+		"%w: embedding endpoint unavailable", db.ErrSemanticTransient,
+	)
 }
 
 func (recallUnavailableHTTPStore) GetRecallEntry(
@@ -840,6 +853,21 @@ func TestHTTPBackend_QueryRecallVector501PreservesSemanticCause(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, service.ErrSemanticUnavailable)
 	assert.Equal(t, body, err.Error())
+}
+
+func TestHTTPBackend_QueryRecallVector503PreservesTransientCause(t *testing.T) {
+	env := newHTTPBackendEnv(t, withHTTPStore(func(d *db.DB) db.Store {
+		return recallTransientHTTPStore{DB: d}
+	}))
+
+	_, err := env.Backend("", false).QueryRecallEntries(
+		context.Background(),
+		service.RecallQuery{Query: "retry policy", Mode: db.RecallQueryModeVector},
+	)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, db.ErrSemanticTransient)
+	assert.Contains(t, err.Error(), "embedding endpoint unavailable")
 }
 
 func TestHTTPBackend_QueryRecallRejectsResponseModeMismatch(t *testing.T) {

--- a/internal/service/recall.go
+++ b/internal/service/recall.go
@@ -55,6 +55,7 @@ func QueryRecallStore(
 	}
 	query := db.RecallQuery{
 		Text:                req.Query,
+		Mode:                req.Mode,
 		Project:             req.Project,
 		CWD:                 req.CWD,
 		GitBranch:           req.GitBranch,
@@ -82,6 +83,7 @@ func QueryRecallStore(
 		page.RecallEntries = []db.RecallResult{}
 	}
 	resp := &RecallQueryResult{
+		Mode:          db.NormalizeRecallQuery(query).Mode,
 		RecallEntries: page.RecallEntries,
 		TrustedOnly:   req.TrustedOnly,
 		Summary:       BuildRecallQuerySummary(page.RecallEntries),
@@ -107,15 +109,18 @@ func QueryRecallStore(
 			resp.MissReason = RecallMissReasonContextEmpty
 		}
 	}
-	if err := recordRecallQueryOutcome(
-		ctx, store, req, surface, resp,
-	); err != nil {
-		return nil, err
+	if !req.SkipRecording {
+		if err := recordRecallQueryOutcome(
+			ctx, store, req, surface, resp,
+		); err != nil {
+			return nil, err
+		}
 	}
 	return resp, nil
 }
 
 type recallQueryEventFilters struct {
+	Mode                string `json:"mode"`
 	Project             string `json:"project"`
 	CWD                 string `json:"cwd"`
 	GitBranch           string `json:"git_branch"`
@@ -150,6 +155,7 @@ func recordRecallQueryOutcome(
 		return nil
 	}
 	filtersJSON, err := json.Marshal(recallQueryEventFilters{
+		Mode:                resp.Mode,
 		Project:             req.Project,
 		CWD:                 req.CWD,
 		GitBranch:           req.GitBranch,
@@ -195,7 +201,7 @@ func recordRecallQueryOutcome(
 		Surface:            surface,
 		FiltersJSON:        string(filtersJSON),
 		TrustedOnly:        req.TrustedOnly,
-		ScorePolicyVersion: db.RecallLexicalScorePolicyVersion,
+		ScorePolicyVersion: recallScorePolicyVersion(resp.Mode),
 		ResultCount:        len(resp.RecallEntries),
 		PackedCount:        len(packedIDs),
 		TopScore:           topScore,
@@ -211,6 +217,17 @@ func recordRecallQueryOutcome(
 	}
 	resp.QueryID = queryID
 	return nil
+}
+
+func recallScorePolicyVersion(mode string) string {
+	switch mode {
+	case db.RecallQueryModeVector:
+		return db.RecallVectorScorePolicyVersion
+	case db.RecallQueryModeHybrid:
+		return db.RecallHybridScorePolicyVersion
+	default:
+		return db.RecallLexicalScorePolicyVersion
+	}
 }
 
 func NormalizeRecallContextMaxBytes(maxBytes int) (int, error) {

--- a/internal/service/recall_test.go
+++ b/internal/service/recall_test.go
@@ -241,7 +241,7 @@ func TestDirectBackend_RecallRecordsEveryRankAndPackedFlag(t *testing.T) {
 	assert.Equal(t, 1, event.PackedCount)
 	assert.Equal(t, db.RecallLexicalScorePolicyVersion, event.ScorePolicyVersion)
 	assert.Equal(t,
-		`{"project":"agentsview","cwd":"","git_branch":"","agent":"codex","type":"","scope":"","status":"","extractor_method":"","source_session_id":"","source_episode_id":"","source_run_id":"","supersedes_entry_id":"","superseded_by_entry_id":"","limit":2,"include_context":true,"context_max_bytes":340}`,
+		`{"mode":"lexical","project":"agentsview","cwd":"","git_branch":"","agent":"codex","type":"","scope":"","status":"","extractor_method":"","source_session_id":"","source_episode_id":"","source_run_id":"","supersedes_entry_id":"","superseded_by_entry_id":"","limit":2,"include_context":true,"context_max_bytes":340}`,
 		event.FiltersJSON,
 	)
 	require.Len(t, event.Exposures, 2)

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -18,6 +18,19 @@ import (
 // regardless of transport (the REST handler maps it back to HTTP 501).
 var ErrSearchUnavailable = errors.New("search not available")
 
+// RecallQueryCapability is implemented by services whose backing store can
+// query Recall entries. Callers should treat services without this capability
+// as unsupported so retrieval surfaces are not advertised optimistically.
+type RecallQueryCapability interface {
+	SupportsRecallQueries() bool
+}
+
+// SupportsRecallQueries reports whether svc can query Recall entries.
+func SupportsRecallQueries(svc SessionService) bool {
+	capability, ok := svc.(RecallQueryCapability)
+	return ok && capability.SupportsRecallQueries()
+}
+
 // ErrAroundMutuallyExclusive is returned by Messages when Around is combined
 // with From or a non-default Direction: the two retrieval modes (symmetric
 // window vs. linear pagination) cannot both be requested. The HTTP handler
@@ -202,6 +215,7 @@ type RecallList struct {
 // RecallQuery mirrors POST /api/v1/recall/query.
 type RecallQuery struct {
 	Query               string `json:"query"`
+	Mode                string `json:"mode,omitempty"`
 	Surface             string `json:"surface,omitempty"`
 	Project             string `json:"project,omitempty"`
 	CWD                 string `json:"cwd,omitempty"`
@@ -220,6 +234,9 @@ type RecallQuery struct {
 	Limit               int    `json:"limit,omitempty"`
 	IncludeContext      bool   `json:"include_context,omitempty"`
 	ContextMaxBytes     int    `json:"context_max_bytes,omitempty"`
+	// SkipRecording keeps retrieval read-only by omitting the query event and
+	// exposure snapshot. MCP sets it because query_recall is declared read-only.
+	SkipRecording bool `json:"skip_recording,omitempty"`
 	// StrictRecording is reserved for local calibration workflows. It is not
 	// transported over JSON; ordinary query paths keep measurement best-effort.
 	StrictRecording bool `json:"-"`
@@ -227,6 +244,7 @@ type RecallQuery struct {
 
 // RecallQueryResult mirrors POST /api/v1/recall/query response.
 type RecallQueryResult struct {
+	Mode           string              `json:"mode"`
 	QueryID        string              `json:"query_id"`
 	MissReason     string              `json:"miss_reason"`
 	RecallEntries  []db.RecallResult   `json:"entries"`

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1553,7 +1553,7 @@ func (e *Engine) ResyncAll(
 	defer e.notifyStartupReconciled()
 	// Defers LIFO: Unlock runs before emit.
 	defer func() {
-		if stats.Synced > 0 {
+		if stats.shouldEmitSync() {
 			e.emit("sync")
 		}
 	}()
@@ -1599,7 +1599,7 @@ func (e *Engine) resyncAllWithOptionsAndOperations(
 	e.syncMu.Lock()
 	defer e.notifyStartupReconciled()
 	defer func() {
-		if stats.Synced > 0 && !stats.Aborted {
+		if stats.shouldEmitSync() {
 			e.emit("sync")
 		}
 	}()
@@ -2405,6 +2405,7 @@ func (e *Engine) swapResyncDatabaseLocked(
 			log.Printf("resync: wal checkpoint: %v", err)
 		}
 	}
+	stats.ArchiveRebuilt = true
 	return true, nil
 }
 
@@ -2609,7 +2610,7 @@ func (e *Engine) SyncThenRun(
 	defer e.notifyStartupReconciled()
 	// Defers run LIFO: Unlock runs before emit.
 	defer func() {
-		if stats.Synced > 0 {
+		if stats.shouldEmitSync() {
 			e.emit("sync")
 		}
 	}()
@@ -2695,7 +2696,7 @@ func (e *Engine) SyncThenRunWithRebuild(
 	e.syncMu.Lock()
 	defer e.notifyStartupReconciled()
 	defer func() {
-		if stats.Synced > 0 && !stats.Aborted {
+		if stats.shouldEmitSync() {
 			e.emit("sync")
 		}
 	}()
@@ -2858,7 +2859,7 @@ func (e *Engine) RecordStartupReconciledExclusive(stats SyncStats, err error) {
 // could let an Emitter widen the critical section or deadlock by re-entering
 // sync code, so this must be called after RunExclusive returns.
 func (e *Engine) FinishStartupReconciled(stats SyncStats) {
-	if stats.Synced > 0 {
+	if stats.shouldEmitSync() {
 		e.emit("sync")
 	}
 	e.notifyStartupReconciled()
@@ -2917,7 +2918,7 @@ func (e *Engine) RunStartupSyncFallback(
 	defer e.notifyStartupReconciled()
 	// Defers run LIFO: Unlock runs before emit.
 	defer func() {
-		if stats.Synced > 0 {
+		if stats.shouldEmitSync() {
 			e.emit("sync")
 		}
 	}()

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -7050,6 +7050,79 @@ func TestEngine_SyncAllDoesNotEmitOnEmptyRun(t *testing.T) {
 	assert.Empty(t, em.got(), "expected no emissions")
 }
 
+func TestEngine_ZeroSyncedSuccessfulResyncEmits(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(*testing.T, *Engine) (SyncStats, error)
+	}{
+		{
+			name: "direct resync",
+			run: func(_ *testing.T, engine *Engine) (SyncStats, error) {
+				return engine.ResyncAll(context.Background(), nil), nil
+			},
+		},
+		{
+			name: "direct resync with options",
+			run: func(_ *testing.T, engine *Engine) (SyncStats, error) {
+				return engine.ResyncAllWithOptions(
+					context.Background(), nil, RebuildOptions{},
+				)
+			},
+		},
+		{
+			name: "coordinated full sync",
+			run: func(t *testing.T, engine *Engine) (SyncStats, error) {
+				return engine.SyncThenRun(
+					context.Background(), true, nil,
+					func(forceFull bool) error {
+						assert.True(t, forceFull)
+						return nil
+					},
+				)
+			},
+		},
+		{
+			name: "coordinated full rebuild",
+			run: func(t *testing.T, engine *Engine) (SyncStats, error) {
+				return engine.SyncThenRunWithRebuild(
+					context.Background(), true, nil,
+					func() (RebuildOptions, RebuildCleanup, error) {
+						return RebuildOptions{}, nil, nil
+					},
+					func(forceFull, rebuilt bool) error {
+						assert.True(t, forceFull)
+						assert.True(t, rebuilt)
+						return nil
+					},
+				)
+			},
+		},
+		{
+			name: "worker completion tail",
+			run: func(_ *testing.T, engine *Engine) (SyncStats, error) {
+				stats := SyncStats{ArchiveRebuilt: true}
+				engine.FinishStartupReconciled(stats)
+				return stats, nil
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fx := newEngineFixture(t)
+			em := &fakeEmitter{}
+			fx.engineWithEmitter(em)
+
+			stats, err := tt.run(t, fx.engine)
+
+			require.NoError(t, err)
+			require.False(t, stats.Aborted)
+			assert.Zero(t, stats.Synced)
+			assert.Equal(t, []string{"sync"}, em.got(),
+				"a completed database swap must publish corpus changes")
+		})
+	}
+}
+
 func TestEngine_SyncPathsEmitsWhenSessionsChange(t *testing.T) {
 	fx := newEngineFixture(t)
 	em := &fakeEmitter{}

--- a/internal/sync/progress.go
+++ b/internal/sync/progress.go
@@ -83,6 +83,12 @@ type SyncStats struct {
 	parserExcludedFiles    int // file-level intentional parser exclusions
 	parserExcludedIDs      []string
 	providerFailures       int // authoritative discoveries that did not complete
+	// ArchiveRebuilt records a completed full-resync database swap. A rebuild
+	// can preserve/copy durable corpus rows while syncing zero session files,
+	// so downstream refresh consumers cannot infer it from Synced. It is not
+	// serialized in sync API responses; parent-side worker coordination sets it
+	// only after the replacement archive has been installed successfully.
+	ArchiveRebuilt bool `json:"-"`
 	// cwdFilteredSessions counts sessions vetoed by the
 	// sync_include_cwd_prefixes allow-list. The resync abort guard uses
 	// it so a run where every discovered session is filtered reads as
@@ -93,6 +99,10 @@ type SyncStats struct {
 	// must account for all of filesOK before the resync abort guard
 	// treats a zero-write run as intentional.
 	cwdFilteredFiles int
+}
+
+func (s SyncStats) shouldEmitSync() bool {
+	return !s.Aborted && (s.Synced > 0 || s.ArchiveRebuilt)
 }
 
 // AnomalyStats aggregates parser-output anomaly signals observed during a

--- a/internal/vector/build.go
+++ b/internal/vector/build.go
@@ -22,6 +22,15 @@ var progressInterval = 2 * time.Second
 
 const repairStatusCountTimeout = 2 * time.Second
 
+// CorpusFingerprintParam names the generation parameter whose value identifies
+// the source corpus, independently of the embedding model. A change forces a
+// full mirror reconciliation before the new vector generation is filled.
+const CorpusFingerprintParam = "corpus_fingerprint"
+
+const corpusFingerprintMetaKey = "corpus_fingerprint"
+
+const completedCorpusRevisionMetaKey = "completed_corpus_revision:"
+
 // BuildOptions configures one Build pass.
 type BuildOptions struct {
 	// FullRebuild forces every document to be re-embedded under the target
@@ -48,6 +57,10 @@ type BuildOptions struct {
 	// Concurrency is the number of documents encoded in parallel (config
 	// concurrency). Values <= 0 encode sequentially.
 	Concurrency int
+	// CorpusRevision identifies the source state captured when this build
+	// target was resolved. A successful ordinary build persists it only after
+	// refresh and fill complete, allowing searches to reject newer source data.
+	CorpusRevision string
 	// Progress, if non-nil, is called at most ~every 2s with incremental
 	// embedding progress, plus once more after the run completes.
 	Progress func(BuildProgress)
@@ -119,7 +132,22 @@ func (ix *Index) Build(
 	// then setIncludeAutomatedScope below stamps the key so every later
 	// build compares against a real stored scope again.
 	scopeChanged := !hasScope || storedScope != o.IncludeAutomated
-	full := o.FullRebuild || o.Backstop || firstEver || scopeChanged
+	corpusFingerprint := gen.Params[CorpusFingerprintParam]
+	storedCorpusFingerprint, hasCorpusFingerprint, err := ix.metaGet(
+		ctx, corpusFingerprintMetaKey,
+	)
+	if err != nil {
+		return BuildResult{}, fmt.Errorf("reading corpus fingerprint: %w", err)
+	}
+	corpusChanged := corpusFingerprint != "" &&
+		(!hasCorpusFingerprint || storedCorpusFingerprint != corpusFingerprint)
+	full := o.FullRebuild || o.Backstop || firstEver || scopeChanged || corpusChanged
+	fp := gen.Fingerprint()
+	if full {
+		if err := ix.clearCompletedCorpusRevision(ctx, fp); err != nil {
+			return BuildResult{}, err
+		}
+	}
 	// Report the scanning phase before the mirror refresh: on a large archive
 	// the refresh (and the pending count below) can run for a while with no
 	// chunk totals yet, and without a phase report a progress consumer can
@@ -134,8 +162,12 @@ func (ix *Index) Build(
 	if err := ix.setIncludeAutomatedScope(ctx, o.IncludeAutomated); err != nil {
 		return BuildResult{}, err
 	}
+	if corpusFingerprint != "" {
+		if err := ix.metaSet(ctx, corpusFingerprintMetaKey, corpusFingerprint); err != nil {
+			return BuildResult{}, fmt.Errorf("storing corpus fingerprint: %w", err)
+		}
+	}
 
-	fp := gen.Fingerprint()
 	target, wasBuilding, err := ix.resolveBuildTarget(ctx, gen, fp, o.FullRebuild)
 	if err != nil {
 		return BuildResult{}, err
@@ -170,6 +202,13 @@ func (ix *Index) Build(
 		return result, err
 	}
 	result.Activated = activated
+	if o.CorpusRevision != "" {
+		if err := ix.metaSet(
+			ctx, completedCorpusRevisionMetaKey+target, o.CorpusRevision,
+		); err != nil {
+			return result, fmt.Errorf("storing completed corpus revision: %w", err)
+		}
+	}
 	return result, nil
 }
 
@@ -336,7 +375,7 @@ func (ix *Index) resolveBuildTarget(
 
 	if hasActive && active == fp {
 		if fullRebuild {
-			if err := ix.resetGeneration(ctx, fp); err != nil {
+			if err := ix.resetGenerationForFullRebuild(ctx, fp); err != nil {
 				return "", false, err
 			}
 		}
@@ -366,11 +405,33 @@ func (ix *Index) resolveBuildTarget(
 		return "", false, err
 	}
 	if fullRebuild && existed {
-		if err := ix.resetGeneration(ctx, target); err != nil {
+		if err := ix.resetGenerationForFullRebuild(ctx, target); err != nil {
 			return "", false, err
 		}
 	}
 	return target, true, nil
+}
+
+// resetGenerationForFullRebuild invalidates the generation's completed corpus
+// revision before removing its vectors and stamps. Clearing first keeps
+// StaleActive fail-closed if either the reset or the subsequent fill fails.
+// Build writes the completed revision again only after fill and activation
+// succeed.
+func (ix *Index) resetGenerationForFullRebuild(ctx context.Context, fp string) error {
+	if err := ix.clearCompletedCorpusRevision(ctx, fp); err != nil {
+		return err
+	}
+	return ix.resetGeneration(ctx, fp)
+}
+
+func (ix *Index) clearCompletedCorpusRevision(ctx context.Context, fp string) error {
+	if _, err := ix.db.ExecContext(ctx,
+		`DELETE FROM `+ix.spec.MetaTable+` WHERE key = ?`,
+		completedCorpusRevisionMetaKey+fp,
+	); err != nil {
+		return fmt.Errorf("clearing completed corpus revision: %w", err)
+	}
+	return nil
 }
 
 // retireAbandonedBuildingGenerations transitions every generation still in

--- a/internal/vector/build_test.go
+++ b/internal/vector/build_test.go
@@ -2,8 +2,10 @@ package vector
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -12,6 +14,8 @@ import (
 	"github.com/stretchr/testify/require"
 	kitvec "go.kenn.io/kit/vector"
 	"go.kenn.io/kit/vector/sqlitevec"
+
+	"go.kenn.io/agentsview/internal/db"
 )
 
 // fakeBuildEncoder returns a deterministic 3-dimensional encoder that never
@@ -46,6 +50,21 @@ func fakeGeneration(model string) kitvec.Generation {
 	return kitvec.Generation{Model: model, Dimensions: 3}
 }
 
+type failingRefreshSource struct {
+	unit db.EmbeddableUnit
+	err  error
+}
+
+func (s failingRefreshSource) ScanEmbeddableUnits(
+	_ context.Context, _ string, _ bool,
+	fn func(db.EmbeddableUnit) error,
+) (string, error) {
+	if err := fn(s.unit); err != nil {
+		return "", err
+	}
+	return "", s.err
+}
+
 func TestBuildFirstBuildEmbedsAllAndActivates(t *testing.T) {
 	ix := openTestIndex(t)
 	ctx := context.Background()
@@ -77,6 +96,154 @@ func TestBuildSecondBuildNoChangesFillsZero(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, result.Fill.Documents)
 	assert.False(t, result.Activated, "already active, no re-activation")
+}
+
+func TestBuildFailureDoesNotAdvanceCompletedCorpusRevision(t *testing.T) {
+	ix := openTestIndex(t)
+	ctx := context.Background()
+	gen := fakeGeneration("fake-model")
+	src := twoDocSource()
+
+	_, err := ix.Build(ctx, src, fakeBuildEncoder(), gen,
+		BuildOptions{CorpusRevision: "revision-1"})
+	require.NoError(t, err)
+
+	src.rows[0].unit.Content = "changed"
+	src.rows[0].endedAt = "2024-02-01T00:00:00Z"
+	failingEncoder := func(context.Context, []string) ([][]float32, error) {
+		return nil, errors.New("endpoint unavailable")
+	}
+	_, err = ix.Build(ctx, src, failingEncoder, gen,
+		BuildOptions{CorpusRevision: "revision-2"})
+	require.Error(t, err)
+
+	stale, err := ix.StaleActive(ctx, gen.Fingerprint(), "revision-2")
+	require.NoError(t, err)
+	assert.True(t, stale, "a failed fill must not mark the new corpus revision complete")
+}
+
+func TestFailedFullRebuildClearsCompletedCorpusRevision(t *testing.T) {
+	ix := openTestIndex(t)
+	ctx := context.Background()
+	gen := fakeGeneration("fake-model")
+	src := twoDocSource()
+
+	_, err := ix.Build(ctx, src, fakeBuildEncoder(), gen,
+		BuildOptions{CorpusRevision: "revision-1"})
+	require.NoError(t, err)
+
+	failingEncoder := func(context.Context, []string) ([][]float32, error) {
+		return nil, errors.New("endpoint unavailable")
+	}
+	_, err = ix.Build(ctx, src, failingEncoder, gen, BuildOptions{
+		FullRebuild:    true,
+		CorpusRevision: "revision-1",
+	})
+	require.Error(t, err)
+
+	stale, err := ix.StaleActive(ctx, gen.Fingerprint(), "revision-1")
+	require.NoError(t, err)
+	assert.True(t, stale,
+		"a failed full rebuild must not leave the reset generation marked complete")
+
+	_, err = ix.Build(ctx, src, fakeBuildEncoder(), gen, BuildOptions{
+		FullRebuild:    true,
+		CorpusRevision: "revision-1",
+	})
+	require.NoError(t, err)
+	stale, err = ix.StaleActive(ctx, gen.Fingerprint(), "revision-1")
+	require.NoError(t, err)
+	assert.False(t, stale, "a successful full rebuild restores the completed revision")
+}
+
+func TestFailedFullRefreshClearsCompletedCorpusRevision(t *testing.T) {
+	ix := openTestIndex(t)
+	ctx := context.Background()
+	gen := fakeGeneration("fake-model")
+
+	_, err := ix.Build(ctx, twoDocSource(), fakeBuildEncoder(), gen,
+		BuildOptions{CorpusRevision: "revision-1"})
+	require.NoError(t, err)
+
+	_, err = ix.Build(ctx, failingRefreshSource{
+		unit: userDoc("s1", "u1", 0, "partially refreshed"),
+		err:  errors.New("source scan failed"),
+	}, fakeBuildEncoder(), gen, BuildOptions{
+		Backstop:       true,
+		CorpusRevision: "revision-1",
+	})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "source scan failed")
+
+	row, ok := readMirrorRow(t, ix, DocKey("user", "s1", "u1", 0, 1))
+	require.True(t, ok)
+	assert.Equal(t, "partially refreshed", row.content,
+		"the refresh must mutate the mirror before failing")
+	stale, err := ix.StaleActive(ctx, gen.Fingerprint(), "revision-1")
+	require.NoError(t, err)
+	assert.True(t, stale,
+		"a failed full refresh must not leave the partially changed mirror marked complete")
+
+	_, err = ix.Build(ctx, twoDocSource(), fakeBuildEncoder(), gen, BuildOptions{
+		Backstop:       true,
+		CorpusRevision: "revision-1",
+	})
+	require.NoError(t, err)
+	stale, err = ix.StaleActive(ctx, gen.Fingerprint(), "revision-1")
+	require.NoError(t, err)
+	assert.False(t, stale,
+		"a successful full refresh and fill restore the completed revision")
+}
+
+func TestBuildCorpusFingerprintChangeForcesFullReconciliation(t *testing.T) {
+	ctx := context.Background()
+	ix, err := OpenSpec(
+		ctx,
+		filepath.Join(t.TempDir(), "vectors.db"),
+		RecallIndexSpec(),
+		false,
+		4000,
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, ix.Close()) })
+
+	oldSource := &fakeUnitSource{rows: []fakeUnit{{
+		unit:    userDoc("old-entry", "old-entry", 0, "old content"),
+		endedAt: "2026-02-01T00:00:00Z",
+	}}}
+	oldGeneration := kitvec.Generation{
+		Model: "fake-model", Dimensions: 3,
+		Params: map[string]string{CorpusFingerprintParam: "extract-old"},
+	}
+	_, err = ix.Build(ctx, oldSource, fakeBuildEncoder(), oldGeneration, BuildOptions{})
+	require.NoError(t, err)
+
+	newSource := &fakeUnitSource{rows: []fakeUnit{{
+		unit:    userDoc("new-entry", "new-entry", 0, "new content"),
+		endedAt: "2026-01-01T00:00:00Z",
+	}}}
+	newGeneration := kitvec.Generation{
+		Model: "fake-model", Dimensions: 3,
+		Params: map[string]string{CorpusFingerprintParam: "extract-new"},
+	}
+	result, err := ix.Build(
+		ctx, newSource, fakeBuildEncoder(), newGeneration, BuildOptions{},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Refresh.Upserted)
+	assert.Equal(t, 1, result.Refresh.Deleted)
+	rows, err := ix.db.Query(`SELECT doc_key FROM vector_recall_entries ORDER BY doc_key`)
+	require.NoError(t, err)
+	defer rows.Close()
+	var keys []string
+	for rows.Next() {
+		var key string
+		require.NoError(t, rows.Scan(&key))
+		keys = append(keys, key)
+	}
+	require.NoError(t, rows.Err())
+	assert.Equal(t, []string{"u:new-entry:new-entry"}, keys)
 }
 
 func TestBuildContentChangeReembedsExactlyOne(t *testing.T) {

--- a/internal/vector/index.go
+++ b/internal/vector/index.go
@@ -46,6 +46,26 @@ CREATE TABLE IF NOT EXISTS vector_meta (
 );
 `
 
+const recallMirrorDDL = `
+CREATE TABLE IF NOT EXISTS vector_recall_entries (
+    doc_key      TEXT PRIMARY KEY,
+    session_id   TEXT NOT NULL,
+    source_uuid  TEXT NOT NULL DEFAULT '',
+    ordinal      INTEGER NOT NULL,
+    ordinal_end  INTEGER NOT NULL,
+    subordinate  INTEGER NOT NULL DEFAULT 0,
+    offsets      TEXT NOT NULL DEFAULT '[]',
+    content      TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    embed_gen    TEXT
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_vector_recall_entries_identity
+    ON vector_recall_entries(session_id, ordinal);
+CREATE TABLE IF NOT EXISTS vector_recall_meta (
+    key TEXT PRIMARY KEY, value TEXT NOT NULL
+);
+`
+
 // mirrorSchemaVersionKey is the metadata-table key holding a spec's
 // MirrorSchemaVersion.
 const mirrorSchemaVersionKey = "mirror_schema_version"
@@ -61,6 +81,10 @@ const mirrorSchemaVersionKey = "mirror_schema_version"
 type IndexSpec struct {
 	// Name identifies the store for CLI selection and display ("messages").
 	Name string
+	// SupportsAutomatedScope reports whether IncludeAutomated changes this
+	// store's source corpus. It defaults to false so new stores cannot inherit
+	// message-specific scope behavior accidentally.
+	SupportsAutomatedScope bool
 	// DocsTable is the store's mirror documents table.
 	DocsTable string
 	// MetaTable is the store's own key/value metadata table (schema
@@ -77,6 +101,13 @@ type IndexSpec struct {
 	// MirrorSchemaVersion versions the mirror's DDL shape and its
 	// document-identity scheme; see prepareMirrorSchema.
 	MirrorSchemaVersion string
+}
+
+// NormalizeIncludeAutomated applies the store's scope capability to a build
+// request. Stores whose sources are not session-filtered always use false so
+// alternating build entry points cannot churn their stored scope metadata.
+func (s IndexSpec) NormalizeIncludeAutomated(value bool) bool {
+	return s.SupportsAutomatedScope && value
 }
 
 func (s IndexSpec) schema() sqlitevec.Schema {
@@ -105,12 +136,27 @@ func (s IndexSpec) repairQueueTable() string { return s.VectorsPrefix + "_repair
 // messages) with no DDL change.
 func MessageIndexSpec() IndexSpec {
 	return IndexSpec{
-		Name:                "messages",
-		DocsTable:           "vector_messages",
-		MetaTable:           "vector_meta",
-		VectorsPrefix:       "message_vectors",
-		MirrorDDL:           messageMirrorDDL,
-		MirrorSchemaVersion: "3",
+		Name:                   "messages",
+		SupportsAutomatedScope: true,
+		DocsTable:              "vector_messages",
+		MetaTable:              "vector_meta",
+		VectorsPrefix:          "message_vectors",
+		MirrorDDL:              messageMirrorDDL,
+		MirrorSchemaVersion:    "3",
+	}
+}
+
+// RecallIndexSpec is the distilled recall-entry embedding store. It shares
+// vectors.db with the message store but owns disjoint mirror, metadata, and
+// kit-managed vector tables.
+func RecallIndexSpec() IndexSpec {
+	return IndexSpec{
+		Name:                "recall",
+		DocsTable:           "vector_recall_entries",
+		MetaTable:           "vector_recall_meta",
+		VectorsPrefix:       "recall_vectors",
+		MirrorDDL:           recallMirrorDDL,
+		MirrorSchemaVersion: "1",
 	}
 }
 
@@ -169,6 +215,40 @@ func ChunkOverlap(maxInputChars int) int {
 // Open opens the message-store index; see OpenSpec.
 func Open(ctx context.Context, path string, readOnly bool, maxInputChars int) (*Index, error) {
 	return OpenSpec(ctx, path, MessageIndexSpec(), readOnly, maxInputChars)
+}
+
+// StoreExists reports whether vectors.db contains any tables owned by spec.
+// It probes sqlite_master without constructing sqlitevec's store, because
+// sqlitevec initializes missing bookkeeping tables and cannot do that through
+// a read-only connection. A partially present store counts as existing so its
+// normal open path can surface corruption or schema-version errors.
+func StoreExists(
+	ctx context.Context, path string, spec IndexSpec,
+) (bool, error) {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	database, err := sql.Open(vectorDriverName, vectorDSN(path, true))
+	if err != nil {
+		return false, fmt.Errorf("opening vectors.db store probe: %w", err)
+	}
+	defer database.Close()
+	var exists bool
+	err = database.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM sqlite_master
+			WHERE type = 'table'
+			  AND (name IN (?, ?) OR substr(name, 1, ?) = ?)
+		)`, spec.DocsTable, spec.MetaTable,
+		len(spec.VectorsPrefix), spec.VectorsPrefix,
+	).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("probing vectors.db store %s: %w", spec.Name, err)
+	}
+	return exists, nil
 }
 
 // OpenSpec opens (creating when rw) vectors.db and the kit sqlitevec store

--- a/internal/vector/index_test.go
+++ b/internal/vector/index_test.go
@@ -505,7 +505,7 @@ func TestMirrorSchemaVersionV2StampReadOnlyReturnsSentinel(t *testing.T) {
 	_, err = ro.Search(ctx, fakeSearchEncoder(), "alpha", 10)
 	assert.ErrorIs(t, err, ErrMirrorVersionMismatch)
 
-	_, err = ro.StaleActive(ctx, "any-fingerprint")
+	_, err = ro.StaleActive(ctx, "any-fingerprint", "")
 	assert.ErrorIs(t, err, ErrMirrorVersionMismatch,
 		"StaleActive must apply the same version gate Search does")
 }

--- a/internal/vector/manager.go
+++ b/internal/vector/manager.go
@@ -77,10 +77,10 @@ func validateBuildRequest(req BuildRequest) error {
 // their check-then-act refusal invariants (Missing coverage, the
 // active-generation check) hold under concurrent calls.
 type Manager struct {
-	ix       *Index
-	src      UnitSource
-	encoders EncoderSet
-	gen      kitvec.Generation
+	ix            *Index
+	encoders      EncoderSet
+	gen           kitvec.Generation
+	resolveTarget func(context.Context) (BuildTarget, error)
 
 	// opMu serializes lifecycle operations: build starts (begin) and the
 	// whole of Activate/Retire. It is never held across a running build —
@@ -90,10 +90,11 @@ type Manager struct {
 
 	// mu guards running and status; held only for short field updates so
 	// Status() stays responsive during a build.
-	mu      sync.Mutex
-	running bool
-	status  BuildStatus
-	eta     buildETAEstimator
+	mu        sync.Mutex
+	running   bool
+	buildDone chan struct{}
+	status    BuildStatus
+	eta       buildETAEstimator
 
 	// now stamps BuildStatus.StartedAt when a build begins; a test hook
 	// defaulting to time.Now.
@@ -103,8 +104,11 @@ type Manager struct {
 // BuildRequest is the caller-controlled subset of BuildOptions the manager
 // exposes; encode settings and Progress are the manager's own concerns.
 type BuildRequest struct {
-	FullRebuild bool `json:"full_rebuild,omitempty"`
-	Backstop    bool `json:"backstop,omitempty"`
+	// Store selects one embedding store at transport/command boundaries. A
+	// Manager already represents one store and therefore ignores this field.
+	Store       string `json:"store,omitempty"`
+	FullRebuild bool   `json:"full_rebuild,omitempty"`
+	Backstop    bool   `json:"backstop,omitempty"`
 	// RepairInvalid scans only the selected target generation and queues
 	// documents containing unusable stored vectors for regeneration.
 	RepairInvalid bool `json:"repair_invalid,omitempty"`
@@ -176,6 +180,15 @@ type EncoderSet struct {
 	ByName  map[string]ManagedEncoder
 }
 
+// BuildTarget is the source corpus and vector-generation identity for one
+// build pass. Resolving it per pass lets a long-lived manager follow a source
+// corpus whose own active generation can change at runtime.
+type BuildTarget struct {
+	Source         UnitSource
+	Generation     kitvec.Generation
+	CorpusRevision string
+}
+
 // NewManager creates a Manager that builds gen's embedding space over ix,
 // scanning src and encoding with one of encoders' entries per build (the
 // default, or BuildRequest.Using). Each encoder is wrapped so a panic
@@ -184,12 +197,32 @@ type EncoderSet struct {
 func NewManager(
 	ix *Index, src UnitSource, encoders EncoderSet, gen kitvec.Generation,
 ) *Manager {
+	return NewResolvingManager(
+		ix, encoders, gen,
+		func(context.Context) (BuildTarget, error) {
+			return BuildTarget{Source: src, Generation: gen}, nil
+		},
+	)
+}
+
+// NewResolvingManager creates a manager that resolves its source and
+// generation at the start of every build. displayGen supplies the stable model
+// and dimension shown by Status before or between builds.
+func NewResolvingManager(
+	ix *Index,
+	encoders EncoderSet,
+	displayGen kitvec.Generation,
+	resolveTarget func(context.Context) (BuildTarget, error),
+) *Manager {
 	wrapped := EncoderSet{Default: encoders.Default, ByName: make(map[string]ManagedEncoder, len(encoders.ByName))}
 	for name, me := range encoders.ByName {
 		me.Encode = recoveringEncoder(me.Encode)
 		wrapped.ByName[name] = me
 	}
-	return &Manager{ix: ix, src: src, encoders: wrapped, gen: gen, now: time.Now}
+	return &Manager{
+		ix: ix, encoders: wrapped, gen: displayGen,
+		resolveTarget: resolveTarget, now: time.Now,
+	}
 }
 
 // resolveEncoder picks the encoder a build request encodes with: the named
@@ -280,6 +313,21 @@ func (m *Manager) Status() BuildStatus {
 	return status
 }
 
+// Wait blocks until no embedding build is running. It covers both asynchronous
+// StartBuild calls and synchronous TryBuild calls, allowing owners to keep
+// indexes open through detached API work during shutdown.
+func (m *Manager) Wait() {
+	for {
+		m.mu.Lock()
+		done := m.buildDone
+		m.mu.Unlock()
+		if done == nil {
+			return
+		}
+		<-done
+	}
+}
+
 // Generations delegates to the underlying Index, listing every generation
 // with its coverage of the current mirror.
 func (m *Manager) Generations(ctx context.Context) ([]GenerationInfo, error) {
@@ -345,6 +393,7 @@ func (m *Manager) begin() error {
 		return ErrBuildRunning
 	}
 	m.running = true
+	m.buildDone = make(chan struct{})
 	m.status.Running = true
 	m.status.BuildID++
 	m.status.StartedAt = m.now().UTC().Format(time.RFC3339)
@@ -370,13 +419,21 @@ func (m *Manager) runBuild(
 			err = fmt.Errorf("build panicked: %v", r)
 		}
 	}()
-	return m.ix.Build(ctx, m.src, me.Encode, m.gen, BuildOptions{
+	target, err := m.resolveTarget(ctx)
+	if err != nil {
+		return BuildResult{}, err
+	}
+	if target.Source == nil {
+		return BuildResult{}, errors.New("embedding build target has no unit source")
+	}
+	return m.ix.Build(ctx, target.Source, me.Encode, target.Generation, BuildOptions{
 		FullRebuild:      req.FullRebuild,
 		Backstop:         req.Backstop,
 		RepairInvalid:    req.RepairInvalid,
 		IncludeAutomated: req.IncludeAutomated,
 		BatchSize:        me.Settings.BatchSize,
 		Concurrency:      me.Settings.Concurrency,
+		CorpusRevision:   target.CorpusRevision,
 		Progress:         m.reportProgress,
 	})
 }
@@ -403,6 +460,10 @@ func (m *Manager) finish(result BuildResult, err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.running = false
+	if m.buildDone != nil {
+		close(m.buildDone)
+		m.buildDone = nil
+	}
 	m.status.Running = false
 	m.clearETA()
 	r := result

--- a/internal/vector/manager_test.go
+++ b/internal/vector/manager_test.go
@@ -103,6 +103,36 @@ func TestManagerBuildUsingSelectsNamedEncoder(t *testing.T) {
 	assert.Positive(t, localCalls.Load(), "a build without Using must encode on the default server")
 }
 
+func TestManagerResolvesBuildTargetForEveryPass(t *testing.T) {
+	ix := openTestIndex(t)
+	oldGeneration := kitvec.Generation{
+		Model: "fake-model", Dimensions: 3,
+		Params: map[string]string{CorpusFingerprintParam: "extract-old"},
+	}
+	newGeneration := kitvec.Generation{
+		Model: "fake-model", Dimensions: 3,
+		Params: map[string]string{CorpusFingerprintParam: "extract-new"},
+	}
+	target := BuildTarget{Source: twoDocSource(), Generation: oldGeneration}
+	m := NewResolvingManager(
+		ix,
+		soloEncoders(fakeBuildEncoder()),
+		oldGeneration,
+		func(context.Context) (BuildTarget, error) { return target, nil },
+	)
+
+	started, err := m.TryBuild(context.Background(), BuildRequest{})
+	require.NoError(t, err)
+	require.True(t, started)
+	assert.Equal(t, oldGeneration.Fingerprint(), m.Status().LastResult.Fingerprint)
+
+	target = BuildTarget{Source: twoDocSource(), Generation: newGeneration}
+	started, err = m.TryBuild(context.Background(), BuildRequest{})
+	require.NoError(t, err)
+	require.True(t, started)
+	assert.Equal(t, newGeneration.Fingerprint(), m.Status().LastResult.Fingerprint)
+}
+
 func TestManagerBuildUnknownUsingFailsBeforeStarting(t *testing.T) {
 	ix := openTestIndex(t)
 	src := twoDocSource()
@@ -171,6 +201,34 @@ func TestManagerStartBuildSetsRunningAndConcurrentStartReturnsErrBuildRunning(t 
 	close(release)
 	waitFor(t, func() bool { return !m.Status().Running }, "build never finished")
 	assert.Empty(t, m.Status().LastError)
+}
+
+func TestManagerWaitBlocksUntilAsyncBuildCompletes(t *testing.T) {
+	ix := openTestIndex(t)
+	release := make(chan struct{})
+	m := NewManager(
+		ix, twoDocSource(), soloEncoders(blockingEncoder(release)),
+		fakeGeneration("fake-model"),
+	)
+	require.NoError(t, m.StartBuild(BuildRequest{}))
+	waitFor(t, func() bool { return m.Status().Running }, "build never reported running")
+
+	waited := make(chan struct{})
+	go func() {
+		m.Wait()
+		close(waited)
+	}()
+	select {
+	case <-waited:
+		require.Fail(t, "Wait returned while the asynchronous build was active")
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(release)
+	select {
+	case <-waited:
+	case <-time.After(time.Second):
+		require.Fail(t, "Wait did not return after the asynchronous build completed")
+	}
 }
 
 func TestManagerTryBuildReturnsFalseWhileRunning(t *testing.T) {

--- a/internal/vector/mirror.go
+++ b/internal/vector/mirror.go
@@ -13,9 +13,9 @@ import (
 	"go.kenn.io/agentsview/internal/db"
 )
 
-// refreshWatermarkKey is the metadata-table key holding the RFC3339
-// ended_at high-water mark of the most recent Refresh scan, used to
-// restrict the next incremental (full=false) scan to newer sessions.
+// refreshWatermarkKey is the metadata-table key holding the source-defined
+// high-water mark of the most recent Refresh scan. Session sources use an
+// RFC3339 ended_at value; Recall uses a monotonic corpus revision.
 const refreshWatermarkKey = "refresh_watermark"
 
 // scopeIncludeAutomatedKey is the metadata-table key holding the
@@ -158,7 +158,9 @@ func contentHash(content string) string {
 // slot it no longer occupies is deleted via store.DeleteVectors only if it
 // was not reinserted elsewhere in the same scan, so a row that merely
 // shifted (or was displaced in a shift cascade) keeps its embeddings. The
-// watermark is advanced to the scan's max ended_at afterwards.
+// Incremental sources may also emit tombstones, which delete matching mirror
+// rows and vectors immediately. The watermark advances to the opaque value
+// returned by the source after a successful scan.
 func (ix *Index) Refresh(
 	ctx context.Context, src UnitSource, full, includeAutomated bool,
 ) (RefreshStats, error) {
@@ -183,7 +185,7 @@ func (ix *Index) Refresh(
 	if err != nil {
 		return RefreshStats{}, err
 	}
-	maxEnded, err := src.ScanEmbeddableUnits(ctx, since, includeAutomated, func(u db.EmbeddableUnit) error {
+	nextWatermark, err := src.ScanEmbeddableUnits(ctx, since, includeAutomated, func(u db.EmbeddableUnit) error {
 		occurrence := 1
 		if u.SourceUUID != "" {
 			occKey := u.SessionID + "\x00" + u.SourceUUID
@@ -191,6 +193,16 @@ func (ix *Index) Refresh(
 			occurrence = occurrences[occKey]
 		}
 		key := DocKey(u.Kind, u.SessionID, u.SourceUUID, u.Ordinal, occurrence)
+		if u.Deleted {
+			deleted, err := ix.deleteMirrorDocument(ctx, key)
+			if err != nil {
+				return fmt.Errorf("deleting tombstoned mirror row %s: %w", key, err)
+			}
+			if deleted {
+				stats.Deleted++
+			}
+			return nil
+		}
 		unchanged, evictedKeys, err := ix.upsertMirrorRow(ctx, key, u, &sentinel)
 		if err != nil {
 			return fmt.Errorf("upserting mirror row %s: %w", key, err)
@@ -234,13 +246,33 @@ func (ix *Index) Refresh(
 		stats.Deleted += deleted
 	}
 
-	if maxEnded != "" {
-		if err := ix.setRefreshWatermark(ctx, maxEnded); err != nil {
+	if nextWatermark != "" {
+		if err := ix.setRefreshWatermark(ctx, nextWatermark); err != nil {
 			return RefreshStats{}, err
 		}
 	}
 
 	return stats, nil
+}
+
+func (ix *Index) deleteMirrorDocument(ctx context.Context, key string) (bool, error) {
+	if err := ix.store.DeleteVectors(ctx, key); err != nil {
+		return false, fmt.Errorf("deleting vectors for %s: %w", key, err)
+	}
+	if err := ix.deleteRepairTargets(ctx, key); err != nil {
+		return false, err
+	}
+	result, err := ix.db.ExecContext(ctx,
+		`DELETE FROM `+ix.spec.DocsTable+` WHERE doc_key = ?`, key,
+	)
+	if err != nil {
+		return false, fmt.Errorf("deleting mirror row %s: %w", key, err)
+	}
+	deleted, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("counting deleted mirror row %s: %w", key, err)
+	}
+	return deleted > 0, nil
 }
 
 // upsertMirrorRow evicts any row occupying the same (session_id, ordinal)

--- a/internal/vector/mirror_test.go
+++ b/internal/vector/mirror_test.go
@@ -659,6 +659,31 @@ func TestRefreshIncrementalUsesWatermark(t *testing.T) {
 	assert.True(t, ok)
 }
 
+func TestRefreshIncrementalTombstoneDeletesOnlyChangedDocument(t *testing.T) {
+	ix := openTestIndex(t)
+	ctx := context.Background()
+	src := &fakeUnitSource{rows: []fakeUnit{
+		{unit: userDoc("entry-1", "entry-1", 0, "first"), endedAt: "2026-01-01T00:00:00Z"},
+		{unit: userDoc("entry-2", "entry-2", 0, "second"), endedAt: "2026-01-01T00:00:00Z"},
+	}}
+	_, err := ix.Build(ctx, src, fakeBuildEncoder(), fakeGeneration("model"), BuildOptions{})
+	require.NoError(t, err)
+
+	src.rows = []fakeUnit{{
+		unit: db.EmbeddableUnit{
+			SessionID: "entry-1", SourceUUID: "entry-1", Kind: "user", Deleted: true,
+		},
+		endedAt: "2026-02-01T00:00:00Z",
+	}}
+	result, err := ix.Build(
+		ctx, src, fakeBuildEncoder(), fakeGeneration("model"), BuildOptions{},
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Refresh.Deleted)
+	assert.Equal(t, []string{"u:entry-2:entry-2"}, mirrorDocKeys(t, ix))
+}
+
 // TestRefreshDuplicateSourceUUIDGetsStableOccurrenceKeys asserts that two
 // units in one session sharing a non-empty source_uuid (permitted by the
 // messages schema) collapse into two distinct mirror rows rather than one,

--- a/internal/vector/search.go
+++ b/internal/vector/search.go
@@ -91,34 +91,48 @@ func (e *QueryEncodeError) Unwrap() error { return e.Err }
 func (ix *Index) Search(
 	ctx context.Context, enc kitvec.EncodeFunc, query string, limit int,
 ) ([]Hit, error) {
+	hits, _, err := ix.SearchPage(ctx, enc, query, limit)
+	return hits, err
+}
+
+// SearchPage returns semantic hits and whether the vector store exhausted the
+// active generation before reaching limit. Callers that progressively expand
+// selective searches need the pre-rollup exhaustion signal: several chunk
+// hits can collapse into one document, so len(hits) alone cannot prove that
+// no lower-ranked documents remain.
+func (ix *Index) SearchPage(
+	ctx context.Context, enc kitvec.EncodeFunc, query string, limit int,
+) ([]Hit, bool, error) {
 	if ix.versionMismatch {
-		return nil, ErrMirrorVersionMismatch
+		return nil, false, ErrMirrorVersionMismatch
 	}
 
 	active, hasActive, err := ix.ActiveFingerprint(ctx)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	if !hasActive {
-		return nil, ix.noActiveGenerationError(ctx)
+		return nil, false, ix.noActiveGenerationError(ctx)
 	}
 
 	vectors, err := kitvec.EncodeBatched(ctx, enc,
 		[]kitvec.Chunk{{Index: 0, Text: query}}, kitvec.BatchOptions{})
 	if err != nil {
-		return nil, &QueryEncodeError{Err: err}
+		return nil, false, &QueryEncodeError{Err: err}
 	}
 
 	hits, err := ix.store.QueryGeneration(ctx, active, vectors[0], limit)
 	if err != nil {
-		return nil, fmt.Errorf("search: %w", err)
+		return nil, false, fmt.Errorf("search: %w", err)
 	}
+	exhausted := len(hits) < limit
 	hits = kitvec.RollupByDocument(hits)
 	if len(hits) > limit {
 		hits = hits[:limit]
 	}
 
-	return ix.hydrateHits(ctx, hits)
+	hydrated, err := ix.hydrateHits(ctx, hits)
+	return hydrated, exhausted, err
 }
 
 // noActiveGenerationError distinguishes an empty index (ErrNoActiveGeneration)
@@ -454,10 +468,10 @@ SELECT doc_key, ordinal, ordinal_end, subordinate
 }
 
 // StaleActive reports whether the active generation's fingerprint differs
-// from want (the fingerprint of the current config) — the "index stale"
-// signal surfaced by the db layer. It returns false when there is no active
-// generation at all: Search already distinguishes that case with
-// ErrNoActiveGeneration / BuildingError.
+// from want or the last successfully completed corpus revision differs from
+// wantRevision. It returns false when there is no active generation at all:
+// Search already distinguishes that case with ErrNoActiveGeneration /
+// BuildingError. An expected revision with no completed stamp is stale.
 //
 // Like Search, StaleActive fails closed with ErrMirrorVersionMismatch —
 // before touching any table — when ix was opened read-only against a
@@ -465,7 +479,9 @@ SELECT doc_key, ordinal, ordinal_end, subordinate
 // staleness before searching, so without this gate a version-mismatched
 // index would surface a raw SQL error (or a wrong staleness verdict) here
 // and the sentinel in Search would never be reached.
-func (ix *Index) StaleActive(ctx context.Context, want string) (bool, error) {
+func (ix *Index) StaleActive(
+	ctx context.Context, want, wantRevision string,
+) (bool, error) {
 	if ix.versionMismatch {
 		return false, ErrMirrorVersionMismatch
 	}
@@ -476,5 +492,15 @@ func (ix *Index) StaleActive(ctx context.Context, want string) (bool, error) {
 	if !hasActive {
 		return false, nil
 	}
-	return active != want, nil
+	if active != want {
+		return true, nil
+	}
+	if wantRevision == "" {
+		return false, nil
+	}
+	completed, ok, err := ix.metaGet(ctx, completedCorpusRevisionMetaKey+active)
+	if err != nil {
+		return false, fmt.Errorf("reading completed corpus revision: %w", err)
+	}
+	return !ok || completed != wantRevision, nil
 }

--- a/internal/vector/search_test.go
+++ b/internal/vector/search_test.go
@@ -93,6 +93,34 @@ func TestSearchLimitCapsResults(t *testing.T) {
 	assert.Len(t, hits, 1)
 }
 
+func TestSearchPageExhaustionUsesChunkCandidatesBeforeDocumentRollup(t *testing.T) {
+	ix := openTestIndex(t)
+	ix.split = kitvec.SplitOptions{MaxRunes: 10, Overlap: 0}
+	ctx := context.Background()
+	src := &fakeUnitSource{rows: []fakeUnit{{
+		unit: userDoc(
+			"s1", "u1", 0,
+			"alpha alpha alpha alpha alpha alpha alpha alpha",
+		),
+		endedAt: "2024-01-01T00:00:00Z",
+	}}}
+	gen := fakeGeneration("fake-model")
+
+	_, err := ix.Build(ctx, src, fakeSearchEncoder(), gen, BuildOptions{})
+	require.NoError(t, err)
+
+	hits, exhausted, err := ix.SearchPage(ctx, fakeSearchEncoder(), "alpha", 2)
+	require.NoError(t, err)
+	require.Len(t, hits, 1,
+		"two chunk candidates from one document must roll up to one hit")
+	assert.False(t, exhausted,
+		"a short rolled-up page does not prove the vector candidates were exhausted")
+
+	_, exhausted, err = ix.SearchPage(ctx, fakeSearchEncoder(), "alpha", 100)
+	require.NoError(t, err)
+	assert.True(t, exhausted)
+}
+
 func TestSearchNoGenerationsReturnsErrNoActiveGeneration(t *testing.T) {
 	ix := openTestIndex(t)
 	ctx := context.Background()
@@ -159,20 +187,40 @@ func TestStaleActiveTrueWhenFingerprintsDiffer(t *testing.T) {
 	_, err := ix.Build(ctx, src, fakeSearchEncoder(), gen, BuildOptions{})
 	require.NoError(t, err)
 
-	stale, err := ix.StaleActive(ctx, "some-other-fingerprint")
+	stale, err := ix.StaleActive(ctx, "some-other-fingerprint", "")
 	require.NoError(t, err)
 	assert.True(t, stale)
 
-	stale, err = ix.StaleActive(ctx, gen.Fingerprint())
+	stale, err = ix.StaleActive(ctx, gen.Fingerprint(), "")
 	require.NoError(t, err)
 	assert.False(t, stale, "matching fingerprint is not stale")
+}
+
+func TestStaleActiveRejectsNewerCorpusRevision(t *testing.T) {
+	ix := openTestIndex(t)
+	ctx := context.Background()
+	gen := fakeGeneration("fake-model")
+
+	_, err := ix.Build(
+		ctx, threeDocSearchSource(), fakeSearchEncoder(), gen,
+		BuildOptions{CorpusRevision: "revision-1"},
+	)
+	require.NoError(t, err)
+
+	stale, err := ix.StaleActive(ctx, gen.Fingerprint(), "revision-1")
+	require.NoError(t, err)
+	assert.False(t, stale)
+
+	stale, err = ix.StaleActive(ctx, gen.Fingerprint(), "revision-2")
+	require.NoError(t, err)
+	assert.True(t, stale)
 }
 
 func TestStaleActiveFalseWhenNoActiveGeneration(t *testing.T) {
 	ix := openTestIndex(t)
 	ctx := context.Background()
 
-	stale, err := ix.StaleActive(ctx, "anything")
+	stale, err := ix.StaleActive(ctx, "anything", "")
 	require.NoError(t, err)
 	assert.False(t, stale, "no active generation means nothing to compare")
 }


### PR DESCRIPTION
Recall retrieval is currently lexical-only, which misses useful entries when query wording differs from distilled memory. This PR adds a dedicated Recall vector corpus and exposes `lexical`, `vector`, and RRF-fused `hybrid` query modes through the CLI, HTTP API, and supported MCP backends. Lexical remains the default.

- Indexes the complete served accepted-entry corpus, including imports and entries from older extraction generations. Embeddings cover title, body, and trigger text.
- Tracks corpus revisions, per-entry changes, tombstones, and completed build revisions so semantic search fails closed when vectors are stale. The corpus and generation snapshot is revalidated after archive hydration, and selective filters progressively expand vector candidates instead of truncating eligible results.
- Requires explicit `[vector.embed] recall = true` consent for automatic Recall embedding. Startup, import, extraction, eval ingestion, session mutations, and completed full-resync swaps coalesce refresh work. Provider errors get one delayed retry before the idle lease is released, and periodic ticks do not restart an active retry lifecycle; owed full reconciliations carry into the next notification.
- Advances the daemon retrieval contract to API v4, rejects silent mode downgrades, preserves retryable semantic errors across HTTP, exposes MCP Recall only when the backend supports writable non-recording queries, and gives unavailable Recall searches the effective `embeddings build --store recall` remediation.
- Updates repository agent guidance to prohibit unsolicited GitHub Actions polling and `gh api` job watching.