### PR TITLE
feat(pricing): add OpenRouter as a second pricing source

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ agentsview usage statusline
 
 Features:
 
-- Automatic pricing via LiteLLM rates (with offline fallback)
+- Automatic pricing via LiteLLM and OpenRouter rates (with offline fallback)
 - Authoritative Copilot CLI billing totals when session logs provide them
 - Prompt-caching-aware cost calculation (cache creation / read tokens)
 - Per-model breakdown with `--breakdown`

--- a/cmd/agentsview/archive_query_backend.go
+++ b/cmd/agentsview/archive_query_backend.go
@@ -300,7 +300,7 @@ func (b localArchiveQueryBackend) SessionUsage(
 	}
 	if len(u.UnpricedModels) > 0 && !b.offline {
 		refreshed, refErr := pricingrefresh.RefreshIfStale(
-			b.database, pricing.FetchLiteLLMPricing,
+			b.database, pricing.FetchCatalog,
 			pricingrefresh.RefreshCooldown, time.Now(),
 		)
 		if refErr != nil {

--- a/cmd/agentsview/archive_query_backend.go
+++ b/cmd/agentsview/archive_query_backend.go
@@ -306,7 +306,10 @@ func (b localArchiveQueryBackend) SessionUsage(
 		if refErr != nil {
 			fmt.Fprintf(os.Stderr,
 				"warning: pricing refresh failed: %v\n", refErr)
-		} else if refreshed {
+		}
+		// A degraded refresh (see pricing.FetchCatalog) stores rows and
+		// reports an error at once, so re-read whenever rows changed.
+		if refreshed {
 			if u2, e := load(); e == nil && u2 != nil {
 				u = u2
 			}

--- a/cmd/agentsview/pricing_schedule_test.go
+++ b/cmd/agentsview/pricing_schedule_test.go
@@ -20,6 +20,8 @@ import (
 // swap, particularly on Windows where open handles prevent the rename.
 const pricingResyncTestTimeout = 10 * time.Second
 
+// pricingCatalogTransport answers the LiteLLM and OpenRouter catalog
+// requests a refresh makes and records their URLs.
 type pricingCatalogTransport struct {
 	requests chan *http.Request
 }
@@ -28,15 +30,19 @@ func (t pricingCatalogTransport) RoundTrip(
 	req *http.Request,
 ) (*http.Response, error) {
 	t.requests <- req
-	return &http.Response{
-		StatusCode: http.StatusOK,
-		Header:     make(http.Header),
-		Body: io.NopCloser(strings.NewReader(`{
+	body := `{"data": []}`
+	if req.URL.Host == "raw.githubusercontent.com" {
+		body = `{
 			"scheduled-model": {
 				"input_cost_per_token": 0.000002,
 				"litellm_provider": "test"
 			}
-		}`)),
+		}`
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
 	}, nil
 }
 
@@ -49,7 +55,7 @@ func TestRunPeriodicPricingRefreshFetchesAfterRecentAttempt(t *testing.T) {
 		"_litellm_last_attempt", previousAttempt,
 	))
 
-	requests := make(chan *http.Request, 1)
+	requests := make(chan *http.Request, 2)
 	originalTransport := http.DefaultTransport
 	http.DefaultTransport = pricingCatalogTransport{requests: requests}
 	t.Cleanup(func() {
@@ -81,11 +87,14 @@ func TestRunPeriodicPricingRefreshFetchesAfterRecentAttempt(t *testing.T) {
 		return err == nil && price != nil
 	}, time.Second, time.Millisecond)
 
-	request := <-requests
 	require.Equal(t,
 		"https://raw.githubusercontent.com/BerriAI/litellm/main/"+
 			"model_prices_and_context_window.json",
-		request.URL.String(),
+		(<-requests).URL.String(),
+	)
+	require.Equal(t,
+		"https://openrouter.ai/api/v1/models",
+		(<-requests).URL.String(),
 	)
 	currentAttempt, err := database.GetPricingMeta("_litellm_last_attempt")
 	require.NoError(t, err)
@@ -128,7 +137,7 @@ func TestStartPeriodicPricingRefreshWaitsForResyncSwap(t *testing.T) {
 		}
 	}, pricingResyncTestTimeout, time.Millisecond)
 
-	requests := make(chan *http.Request, 1)
+	requests := make(chan *http.Request, 2)
 	originalTransport := http.DefaultTransport
 	http.DefaultTransport = pricingCatalogTransport{requests: requests}
 	t.Cleanup(func() {

--- a/cmd/agentsview/usage.go
+++ b/cmd/agentsview/usage.go
@@ -438,7 +438,7 @@ func seedPricing(
 
 func ensurePricing(database *db.DB, offline bool) {
 	if _, err := pricingrefresh.Ensure(
-		database, offline, pricing.FetchLiteLLMPricing, time.Now(),
+		database, offline, pricing.FetchCatalog, time.Now(),
 	); err != nil {
 		fmt.Fprintf(os.Stderr,
 			"warning: pricing refresh failed: %v\n", err)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -397,7 +397,7 @@ agentsview usage daily [flags]
 | `--all`       | `false`       | Scan all history; overrides the default 30-day window                    |
 | `--agent`     |               | Filter by agent name                                                     |
 | `--breakdown` | `false`       | Show per-model rows and populate detailed JSON breakdown arrays          |
-| `--offline`   | `false`       | Skip the LiteLLM pricing fetch; use embedded fallback                    |
+| `--offline`   | `false`       | Skip the pricing catalog fetch; use embedded fallback                    |
 | `--no-sync`   | `false`       | Skip the on-demand sync pass before querying                             |
 | `--timezone`  | system        | IANA timezone name for date bucketing                                    |
 

--- a/docs/token-usage.md
+++ b/docs/token-usage.md
@@ -321,11 +321,16 @@ The default window is the last 30 days; pass `--all` to scan the full history.
 ### Pricing Source
 
 Model rates come from the
-[LiteLLM model pricing catalog](https://github.com/BerriAI/litellm), which is
-fetched on each `usage` invocation and upserted into the `model_pricing` table.
-If the fetch fails — no network, or LiteLLM is down — AgentsView falls back to
-an embedded copy of the catalog so offline use keeps working. Pass `--offline`
-to skip the fetch entirely and always use the embedded fallback.
+[LiteLLM model pricing catalog](https://github.com/BerriAI/litellm), with the
+[OpenRouter model catalog](https://openrouter.ai/docs/api/api-reference/models/get-models)
+layered underneath for models LiteLLM does not list. Both are fetched together
+(hourly at most on `usage` invocations, daily by the server) and merged into the
+`model_pricing` table; when both catalogs list a model, LiteLLM's rate wins, and
+an OpenRouter row is dropped once LiteLLM picks the model up. If either fetch
+fails, AgentsView keeps the last stored rates. Fresh databases are seeded from
+an embedded LiteLLM snapshot so offline use works before any refresh completes.
+Pass `--offline` to skip the fetch entirely and always use the embedded
+fallback.
 
 The embedded fallback is updated with AgentsView releases, so the numbers are as
 current as your installed version. For up-to-the-minute rates, leave `--offline`
@@ -388,13 +393,13 @@ output_microdollars_per_mtok = 800_000
 
 The table key is the model name as it appears in your session data (match the
 string the agent itself writes, dots and all — quote the key if it contains
-special characters). Custom rates take precedence over both the LiteLLM fetch
-and the embedded fallback, and apply to the Usage dashboard, the
-`agentsview usage` CLI, and `pg serve` alike. A custom entry replaces the full
-rate row for that model, so omitted fields are treated as zero rather than
-falling through to LiteLLM. A custom row is flat and suppresses any fetched
-request bands for that model. Models without a custom entry continue to resolve
-through LiteLLM as before.
+special characters). Custom rates take precedence over LiteLLM, OpenRouter, and
+the embedded fallback, and apply to the Usage dashboard, the `agentsview usage`
+CLI, and `pg serve` alike. A custom entry replaces the full rate row for that
+model, so omitted fields are treated as zero rather than falling through to
+another catalog. A custom row is flat and suppresses any fetched request bands
+for that model. Models without a custom entry continue to resolve through the
+stored catalog.
 
 ### Copilot CLI Token Metrics
 
@@ -1018,7 +1023,7 @@ Usage reports read from the same local SQLite database that powers the
 stored on each message row in the `messages` table; pricing is cached in a small
 `model_pricing` table that's refreshed on each `usage` invocation.
 
-No data leaves your machine. The only outbound request is the LiteLLM pricing
-fetch, which you can disable with `--offline`. See
+Session data stays on your machine. The only outbound requests are the LiteLLM
+and OpenRouter pricing fetches, which you can disable with `--offline`. See
 [Privacy and Telemetry](/configuration/#privacy-and-telemetry) for the full
 picture.

--- a/docs/token-usage.md
+++ b/docs/token-usage.md
@@ -326,8 +326,10 @@ Model rates come from the
 layered underneath for models LiteLLM does not list. Both are fetched together
 (hourly at most on `usage` invocations, daily by the server) and merged into the
 `model_pricing` table; when both catalogs list a model, LiteLLM's rate wins, and
-an OpenRouter row is dropped once LiteLLM picks the model up. If either fetch
-fails, AgentsView keeps the last stored rates. Fresh databases are seeded from
+an OpenRouter row is dropped once LiteLLM picks the model up. If the LiteLLM
+fetch fails, AgentsView keeps the last stored rates; if only the OpenRouter
+fetch fails, the fresh LiteLLM rates are still stored and the stored OpenRouter
+rates are kept. Fresh databases are seeded from
 an embedded LiteLLM snapshot so offline use works before any refresh completes.
 Pass `--offline` to skip the fetch entirely and always use the embedded
 fallback.

--- a/internal/db/pricing.go
+++ b/internal/db/pricing.go
@@ -45,7 +45,8 @@ const pricingWriteBatch = 100
 // FilterChangedModelPricing returns the subset of desired rows that
 // would actually insert or update pricing fields. UpdatedAt-only
 // differences are intentionally ignored to match the upsert WHERE
-// clause used by both SQLite and PostgreSQL.
+// clause used by both SQLite and PostgreSQL, except on sentinel
+// metadata rows, whose value lives in updated_at.
 func FilterChangedModelPricing(
 	existing, desired []ModelPricing,
 ) (PricingChangeSummary, []ModelPricing) {
@@ -74,6 +75,9 @@ func FilterChangedModelPricing(
 }
 
 func pricingFieldsEqual(a, b ModelPricing) bool {
+	if isPricingMetaPattern(a.ModelPattern) && a.UpdatedAt != b.UpdatedAt {
+		return false
+	}
 	return a.InputPerMTok == b.InputPerMTok &&
 		a.OutputPerMTok == b.OutputPerMTok &&
 		a.CacheCreationPerMTok == b.CacheCreationPerMTok &&
@@ -178,10 +182,28 @@ func sqlitePricingInsertMissingStatement(
 func (db *DB) UpsertModelPricing(
 	prices []ModelPricing,
 ) error {
+	return db.ReconcileModelPricing(prices, nil, PricingMeta{})
+}
+
+// PricingMeta is a sentinel metadata row (see SetPricingMeta) written
+// in the same transaction as a pricing reconciliation. A zero Key
+// writes nothing.
+type PricingMeta struct {
+	Key   string
+	Value string
+}
+
+// ReconcileModelPricing deletes removePatterns, upserts prices, and
+// writes meta in one transaction. A pattern that is both removed and
+// desired ends up upserted, so retiring one source's row never drops a
+// pattern another source still publishes.
+func (db *DB) ReconcileModelPricing(
+	prices []ModelPricing, removePatterns []string, meta PricingMeta,
+) error {
 	if err := db.requireWritable(); err != nil {
 		return err
 	}
-	if len(prices) == 0 {
+	if len(prices) == 0 && len(removePatterns) == 0 && meta.Key == "" {
 		return nil
 	}
 
@@ -194,8 +216,18 @@ func (db *DB) UpsertModelPricing(
 			"listing current pricing before upsert: %w", err,
 		)
 	}
-	_, prices = FilterChangedModelPricing(existing, prices)
-	if len(prices) == 0 {
+	removeSet := make(map[string]struct{}, len(removePatterns))
+	for _, pattern := range removePatterns {
+		removeSet[pattern] = struct{}{}
+	}
+	kept := make([]ModelPricing, 0, len(existing))
+	for _, price := range existing {
+		if _, removing := removeSet[price.ModelPattern]; !removing {
+			kept = append(kept, price)
+		}
+	}
+	_, prices = FilterChangedModelPricing(kept, prices)
+	if len(prices) == 0 && len(removePatterns) == 0 && meta.Key == "" {
 		return nil
 	}
 
@@ -205,6 +237,9 @@ func (db *DB) UpsertModelPricing(
 	}
 	defer func() { _ = tx.Rollback() }()
 
+	if err := deleteModelPricingTx(tx, removePatterns); err != nil {
+		return err
+	}
 	for i := 0; i < len(prices); i += pricingWriteBatch {
 		end := min(i+pricingWriteBatch, len(prices))
 		query, args := sqlitePricingUpsertStatement(prices[i:end])
@@ -235,7 +270,42 @@ func (db *DB) UpsertModelPricing(
 	if err := replaceModelPricingBands(tx, prices); err != nil {
 		return err
 	}
+	if meta.Key != "" {
+		if _, err := tx.Exec(
+			setPricingMetaSQL, meta.Key, meta.Value,
+		); err != nil {
+			return fmt.Errorf(
+				"setting pricing meta %q: %w", meta.Key, err,
+			)
+		}
+	}
 	return tx.Commit()
+}
+
+func deleteModelPricingTx(tx *sql.Tx, patterns []string) error {
+	for i := 0; i < len(patterns); i += pricingWriteBatch {
+		end := min(i+pricingWriteBatch, len(patterns))
+		placeholders := make([]string, end-i)
+		args := make([]any, end-i)
+		for j, pattern := range patterns[i:end] {
+			placeholders[j] = "?"
+			args[j] = pattern
+		}
+		in := strings.Join(placeholders, ", ")
+		for _, table := range []string{
+			"model_pricing_bands", "model_pricing",
+		} {
+			if _, err := tx.Exec(
+				`DELETE FROM `+table+` WHERE model_pattern IN (`+in+`)`,
+				args...,
+			); err != nil {
+				return fmt.Errorf(
+					"deleting %s rows starting at %d: %w", table, i, err,
+				)
+			}
+		}
+	}
+	return nil
 }
 
 func replaceModelPricingBands(tx *sql.Tx, prices []ModelPricing) error {
@@ -329,19 +399,24 @@ func (db *DB) GetPricingMeta(key string) (string, error) {
 	return val, nil
 }
 
+const setPricingMetaSQL = `INSERT INTO model_pricing
+		(model_pattern, input_microdollars_per_mtok, output_microdollars_per_mtok,
+		 cache_creation_microdollars_per_mtok, cache_read_microdollars_per_mtok,
+		 updated_at)
+	 VALUES (?, 0, 0, 0, 0, ?)
+	 ON CONFLICT(model_pattern) DO UPDATE SET
+		updated_at = excluded.updated_at`
+
+// isPricingMetaPattern reports whether a model_pricing pattern is a
+// sentinel metadata row rather than a model.
+func isPricingMetaPattern(pattern string) bool {
+	return strings.HasPrefix(pattern, "_")
+}
+
 // SetPricingMeta stores a metadata value as a sentinel row
 // in model_pricing with zero pricing fields.
 func (db *DB) SetPricingMeta(key, value string) error {
-	_, err := db.getWriter().Exec(
-		`INSERT INTO model_pricing
-			(model_pattern, input_microdollars_per_mtok, output_microdollars_per_mtok,
-			 cache_creation_microdollars_per_mtok, cache_read_microdollars_per_mtok,
-			 updated_at)
-		 VALUES (?, 0, 0, 0, 0, ?)
-		 ON CONFLICT(model_pattern) DO UPDATE SET
-			updated_at = excluded.updated_at`,
-		key, value,
-	)
+	_, err := db.getWriter().Exec(setPricingMetaSQL, key, value)
 	if err != nil {
 		return fmt.Errorf(
 			"setting pricing meta %q: %w", key, err,

--- a/internal/db/pricing_sync.go
+++ b/internal/db/pricing_sync.go
@@ -1,0 +1,99 @@
+package db
+
+import (
+	"fmt"
+	"slices"
+
+	"go.kenn.io/agentsview/internal/pricing"
+)
+
+// PlanModelPricingSync compares a push target's pricing rows with the
+// local rows and returns the rows to upsert and the patterns to delete.
+//
+// A shared target can hold rows other machines pushed, so the plan
+// applies the local refresh's rules in both directions, driven by the
+// OpenRouter sentinels rather than by set difference. A local OpenRouter
+// row is withheld when a target row from another source already covers
+// its model, and a target-owned row is removed only when the local
+// catalog covers its model under a different pattern, where keeping it
+// would tie with the replacement. Rows the local catalog lacks entirely,
+// such as a delisted model another machine still prices, are left alone.
+// The pushed sentinel merges target and local ownership, dropping only
+// patterns this push withholds or retires or that a local non-OpenRouter
+// row now supplies, so no machine strips ownership another machine
+// recorded.
+func PlanModelPricingSync(
+	existing, desired []ModelPricing,
+) (changed []ModelPricing, remove []string, err error) {
+	targetValue, targetOwned, err := openRouterModels(existing)
+	if err != nil {
+		return nil, nil, fmt.Errorf("target OpenRouter models: %w", err)
+	}
+	localValue, localOwned, err := openRouterModels(desired)
+	if err != nil {
+		return nil, nil, fmt.Errorf("local OpenRouter models: %w", err)
+	}
+	targetForeign := make([]string, 0, len(existing))
+	for _, row := range existing {
+		if !isPricingMetaPattern(row.ModelPattern) &&
+			!slices.Contains(targetOwned, row.ModelPattern) {
+			targetForeign = append(targetForeign, row.ModelPattern)
+		}
+	}
+	withheld := pricing.CoveredPatterns(targetForeign, localOwned)
+
+	local := make([]string, 0, len(desired))
+	models := make([]ModelPricing, 0, len(desired))
+	for _, row := range desired {
+		if isPricingMetaPattern(row.ModelPattern) ||
+			slices.Contains(withheld, row.ModelPattern) {
+			continue
+		}
+		local = append(local, row.ModelPattern)
+		models = append(models, row)
+	}
+	remove = pricing.ShadowedPatterns(local, targetOwned)
+
+	owned := make([]string, 0, len(localOwned)+len(targetOwned))
+	for _, pattern := range localOwned {
+		if !slices.Contains(withheld, pattern) {
+			owned = append(owned, pattern)
+		}
+	}
+	for _, pattern := range targetOwned {
+		if slices.Contains(remove, pattern) ||
+			(slices.Contains(local, pattern) &&
+				!slices.Contains(localOwned, pattern)) {
+			continue
+		}
+		owned = append(owned, pattern)
+	}
+	slices.Sort(owned)
+	owned = slices.Compact(owned)
+
+	_, changed = FilterChangedModelPricing(existing, models)
+	if targetValue == "" && localValue == "" {
+		return changed, remove, nil
+	}
+	if merged := pricing.EncodeOpenRouterModels(owned); merged != targetValue {
+		changed = append(changed, ModelPricing{
+			ModelPattern: pricing.OpenRouterModelsMetaKey,
+			UpdatedAt:    merged,
+		})
+	}
+	return changed, remove, nil
+}
+
+// openRouterModels finds the OpenRouter ownership sentinel in rows and
+// returns its raw value and decoded patterns; both are empty when rows
+// carry no sentinel.
+func openRouterModels(rows []ModelPricing) (string, []string, error) {
+	for _, row := range rows {
+		if row.ModelPattern != pricing.OpenRouterModelsMetaKey {
+			continue
+		}
+		patterns, err := pricing.DecodeOpenRouterModels(row.UpdatedAt)
+		return row.UpdatedAt, patterns, err
+	}
+	return "", nil, nil
+}

--- a/internal/db/pricing_test.go
+++ b/internal/db/pricing_test.go
@@ -189,6 +189,8 @@ func TestUpsertModelPricingOverwrites(t *testing.T) {
 	assert.Equal(t, money.MustParseDollars("1.00"), got.CacheReadPerMTok)
 }
 
+// Model rows compare by rate; sentinel metadata rows keep their value in
+// updated_at, so a new value is a change.
 func TestFilterChangedModelPricingIgnoresUpdatedAtOnlyDifferences(t *testing.T) {
 	existing := []ModelPricing{
 		{
@@ -256,12 +258,13 @@ func TestFilterChangedModelPricingIgnoresUpdatedAtOnlyDifferences(t *testing.T) 
 	assert.Equal(t, PricingChangeSummary{
 		Total:     4,
 		Missing:   1,
-		Changed:   1,
-		Unchanged: 2,
+		Changed:   2,
+		Unchanged: 1,
 	}, gotSummary)
-	require.Len(t, gotRows, 2)
-	assert.Equal(t, "changed-model", gotRows[0].ModelPattern)
-	assert.Equal(t, "missing-model", gotRows[1].ModelPattern)
+	require.Len(t, gotRows, 3)
+	assert.Equal(t, "_fallback_version", gotRows[0].ModelPattern)
+	assert.Equal(t, "changed-model", gotRows[1].ModelPattern)
+	assert.Equal(t, "missing-model", gotRows[2].ModelPattern)
 }
 
 func TestPricingMeta(t *testing.T) {
@@ -295,6 +298,166 @@ func TestPricingMeta(t *testing.T) {
 		assert.Zero(t, p.InputPerMTok,
 			"sentinel should have zero pricing, got %+v", p)
 	}
+}
+
+func TestReconcileModelPricing(t *testing.T) {
+	d := testDB(t)
+	require.NoError(t, d.UpsertModelPricing([]ModelPricing{
+		{
+			ModelPattern: "minimax/minimax-m3",
+			InputPerMTok: money.MustParseDollars("9"),
+			Bands: []PricingBand{{
+				AboveInputTokens: 1000,
+				InputPerMTok:     money.MustParseDollars("10"),
+			}},
+		},
+		{ModelPattern: "acme/keep", InputPerMTok: money.MustParseDollars("1")},
+	}))
+
+	require.NoError(t, d.ReconcileModelPricing(
+		[]ModelPricing{
+			{
+				ModelPattern: "minimax/MiniMax-M3",
+				InputPerMTok: money.MustParseDollars("2"),
+			},
+			// Removed and desired at once: the upsert wins.
+			{ModelPattern: "acme/keep", InputPerMTok: money.MustParseDollars("1")},
+		},
+		[]string{"minimax/minimax-m3", "acme/keep"},
+		PricingMeta{Key: "_openrouter_models", Value: `[]`},
+	))
+
+	removed, err := d.GetModelPricing("minimax/minimax-m3")
+	require.NoError(t, err)
+	assert.Nil(t, removed)
+	var bands int
+	require.NoError(t, d.getReader().QueryRow(
+		`SELECT COUNT(*) FROM model_pricing_bands WHERE model_pattern = ?`,
+		"minimax/minimax-m3",
+	).Scan(&bands))
+	assert.Zero(t, bands, "bands of a removed pattern are deleted")
+	kept, err := d.GetModelPricing("acme/keep")
+	require.NoError(t, err)
+	require.NotNil(t, kept)
+	assert.Equal(t, money.MustParseDollars("1"), kept.InputPerMTok)
+	added, err := d.GetModelPricing("minimax/MiniMax-M3")
+	require.NoError(t, err)
+	require.NotNil(t, added)
+	meta, err := d.GetPricingMeta("_openrouter_models")
+	require.NoError(t, err)
+	assert.Equal(t, `[]`, meta, "meta written with the rows")
+
+	require.NoError(t, d.ReconcileModelPricing(
+		nil, nil, PricingMeta{Key: "_openrouter_models", Value: `["x"]`},
+	))
+	meta, err = d.GetPricingMeta("_openrouter_models")
+	require.NoError(t, err)
+	assert.Equal(t, `["x"]`, meta, "meta-only reconcile still writes")
+}
+
+func TestPlanModelPricingSync(t *testing.T) {
+	model := func(pattern, dollars string) ModelPricing {
+		return ModelPricing{
+			ModelPattern: pattern,
+			InputPerMTok: money.MustParseDollars(dollars),
+		}
+	}
+	meta := func(value string) ModelPricing {
+		return ModelPricing{
+			ModelPattern: "_openrouter_models", UpdatedAt: value,
+		}
+	}
+	tests := []struct {
+		name       string
+		existing   []ModelPricing
+		desired    []ModelPricing
+		wantChange []ModelPricing
+		wantRemove []string
+	}{
+		{
+			name: "retired pattern removed and ownership dropped",
+			existing: []ModelPricing{
+				model("minimax/minimax-m3", "9"),
+				meta(`["minimax/minimax-m3"]`),
+			},
+			desired: []ModelPricing{
+				model("minimax/MiniMax-M3", "2"),
+				meta(`[]`),
+			},
+			wantChange: []ModelPricing{
+				model("minimax/MiniMax-M3", "2"), meta(`[]`),
+			},
+			wantRemove: []string{"minimax/minimax-m3"},
+		},
+		{
+			name: "pattern adopted by a local non-OpenRouter row loses ownership",
+			existing: []ModelPricing{
+				model("acme/model", "9"),
+				meta(`["acme/model"]`),
+			},
+			desired: []ModelPricing{
+				model("acme/model", "9"),
+				meta(`[]`),
+			},
+			wantChange: []ModelPricing{meta(`[]`)},
+		},
+		{
+			name: "delisted row another machine owns keeps its ownership",
+			existing: []ModelPricing{
+				model("acme/delisted", "9"),
+				meta(`["acme/delisted"]`),
+			},
+			desired: []ModelPricing{
+				model("acme/local", "1"),
+				meta(`["acme/local"]`),
+			},
+			wantChange: []ModelPricing{
+				model("acme/local", "1"),
+				meta(`["acme/delisted","acme/local"]`),
+			},
+		},
+		{
+			name: "local OpenRouter row covered by a target row is withheld",
+			existing: []ModelPricing{
+				model("acme/Stale-Model", "9"),
+				meta(`[]`),
+			},
+			desired: []ModelPricing{
+				model("acme/stale-model", "5"),
+				model("acme/fresh", "1"),
+				meta(`["acme/fresh","acme/stale-model"]`),
+			},
+			wantChange: []ModelPricing{
+				model("acme/fresh", "1"),
+				meta(`["acme/fresh"]`),
+			},
+		},
+		{
+			name:     "no sentinel anywhere pushes plain rows",
+			existing: []ModelPricing{model("acme/model", "9")},
+			desired:  []ModelPricing{model("other", "1")},
+			wantChange: []ModelPricing{
+				model("other", "1"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			changed, remove, err := PlanModelPricingSync(
+				tt.existing, tt.desired,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantChange, changed)
+			assert.Equal(t, tt.wantRemove, remove)
+		})
+	}
+}
+
+func TestPlanModelPricingSyncRejectsCorruptSentinel(t *testing.T) {
+	_, _, err := PlanModelPricingSync([]ModelPricing{{
+		ModelPattern: "_openrouter_models", UpdatedAt: "not json",
+	}}, nil)
+	require.Error(t, err)
 }
 
 func TestGetModelPricingNotFound(t *testing.T) {

--- a/internal/duckdb/push.go
+++ b/internal/duckdb/push.go
@@ -38,9 +38,15 @@ func (s *Sync) syncModelPricing(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	_, prices = db.FilterChangedModelPricing(existing, prices)
-	if len(prices) == 0 {
+	prices, removePatterns, err := db.PlanModelPricingSync(existing, prices)
+	if err != nil {
+		return fmt.Errorf("planning duckdb pricing sync: %w", err)
+	}
+	if len(prices) == 0 && len(removePatterns) == 0 {
 		return nil
+	}
+	if err := s.removeDuckModelPricing(ctx, removePatterns); err != nil {
+		return err
 	}
 
 	tx, err := s.duck.BeginTx(ctx, nil)
@@ -98,14 +104,58 @@ func (s *Sync) syncModelPricing(ctx context.Context) error {
 	return nil
 }
 
-func duckPricingBandDeleteStatement(prices []db.ModelPricing) (string, []any) {
-	placeholders := make([]string, len(prices))
-	args := make([]any, len(prices))
-	for i, price := range prices {
-		placeholders[i] = "?"
-		args[i] = price.ModelPattern
+// removeDuckModelPricing deletes retired pricing rows, committing the
+// band rows before the parent rows: DuckDB rejects deleting a parent row
+// in the same transaction that deleted its children. The mirror is
+// disposable, so a crash between the two leaves nothing worse than a
+// band-less row the next push deletes again.
+func (s *Sync) removeDuckModelPricing(
+	ctx context.Context, patterns []string,
+) error {
+	if len(patterns) == 0 {
+		return nil
 	}
-	return `DELETE FROM model_pricing_bands WHERE model_pattern IN (` +
+	for _, table := range []string{"model_pricing_bands", "model_pricing"} {
+		tx, err := s.duck.BeginTx(ctx, nil)
+		if err != nil {
+			return fmt.Errorf("beginning duckdb %s delete: %w", table, err)
+		}
+		for i := 0; i < len(patterns); i += duckPricingUpsertBatch {
+			end := min(i+duckPricingUpsertBatch, len(patterns))
+			query, args := duckPricingDeleteStatement(table, patterns[i:end])
+			if err := s.execMutation(ctx, tx, query, args...); err != nil {
+				_ = tx.Rollback()
+				return fmt.Errorf(
+					"deleting duckdb %s rows starting at %d: %w",
+					table, i, err,
+				)
+			}
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("committing duckdb %s delete: %w", table, err)
+		}
+	}
+	return nil
+}
+
+func duckPricingBandDeleteStatement(prices []db.ModelPricing) (string, []any) {
+	patterns := make([]string, len(prices))
+	for i, price := range prices {
+		patterns[i] = price.ModelPattern
+	}
+	return duckPricingDeleteStatement("model_pricing_bands", patterns)
+}
+
+func duckPricingDeleteStatement(
+	table string, patterns []string,
+) (string, []any) {
+	placeholders := make([]string, len(patterns))
+	args := make([]any, len(patterns))
+	for i, pattern := range patterns {
+		placeholders[i] = "?"
+		args[i] = pattern
+	}
+	return `DELETE FROM ` + table + ` WHERE model_pattern IN (` +
 		strings.Join(placeholders, ", ") + `)`, args
 }
 

--- a/internal/duckdb/sync_test.go
+++ b/internal/duckdb/sync_test.go
@@ -21,6 +21,7 @@ import (
 	"go.kenn.io/agentsview/internal/dbtest"
 	"go.kenn.io/agentsview/internal/export"
 	"go.kenn.io/agentsview/internal/money"
+	"go.kenn.io/agentsview/internal/pricing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1509,6 +1510,69 @@ func TestSyncModelPricingPreservesExistingMirrorRows(t *testing.T) {
 	).Scan(&input, &output))
 	assert.Equal(t, 1.0, input)
 	assert.Equal(t, 2.0, output)
+}
+
+func TestSyncModelPricingRetiresOpenRouterRows(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	require.NoError(t, local.ReconcileModelPricing(
+		[]db.ModelPricing{{
+			ModelPattern: "minimax/minimax-m3",
+			InputPerMTok: money.MustParseDollars("9"),
+			Bands: []db.PricingBand{{
+				AboveInputTokens: 1000,
+				InputPerMTok:     money.MustParseDollars("10"),
+			}},
+		}},
+		nil,
+		db.PricingMeta{
+			Key:   pricing.OpenRouterModelsMetaKey,
+			Value: `["minimax/minimax-m3"]`,
+		},
+	))
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+	require.NoError(t, createSchema(ctx, syncer.DB()))
+	require.NoError(t, syncer.syncModelPricing(ctx))
+
+	// LiteLLM now covers the model: the local refresh retires the
+	// OpenRouter row and rewrites the ownership sentinel.
+	require.NoError(t, local.ReconcileModelPricing(
+		[]db.ModelPricing{{
+			ModelPattern: "minimax/MiniMax-M3",
+			InputPerMTok: money.MustParseDollars("2"),
+		}},
+		[]string{"minimax/minimax-m3"},
+		db.PricingMeta{
+			Key: pricing.OpenRouterModelsMetaKey, Value: `[]`,
+		},
+	))
+	require.NoError(t, syncer.syncModelPricing(ctx))
+
+	var count int
+	require.NoError(t, syncer.DB().QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM model_pricing WHERE model_pattern = ?`,
+		"minimax/minimax-m3",
+	).Scan(&count))
+	assert.Zero(t, count, "retired row removed from the mirror")
+	require.NoError(t, syncer.DB().QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM model_pricing_bands WHERE model_pattern = ?`,
+		"minimax/minimax-m3",
+	).Scan(&count))
+	assert.Zero(t, count, "retired row's bands removed from the mirror")
+
+	var input int64
+	require.NoError(t, syncer.DB().QueryRowContext(ctx,
+		`SELECT input_microdollars_per_mtok FROM model_pricing
+		 WHERE model_pattern = ?`,
+		"minimax/MiniMax-M3",
+	).Scan(&input))
+	assert.Equal(t, int64(2_000_000), input, "replacement row mirrored")
+	var meta string
+	require.NoError(t, syncer.DB().QueryRowContext(ctx,
+		`SELECT updated_at FROM model_pricing WHERE model_pattern = ?`,
+		pricing.OpenRouterModelsMetaKey,
+	).Scan(&meta))
+	assert.Equal(t, `[]`, meta, "ownership sentinel mirrored by value")
 }
 
 func TestSyncModelPricingSkipsUnchangedMirrorRows(t *testing.T) {

--- a/internal/postgres/pricing.go
+++ b/internal/postgres/pricing.go
@@ -421,7 +421,7 @@ func pgPricingUpsertStatement(
 }
 
 func listPGModelPricing(
-	ctx context.Context, pg *sql.DB,
+	ctx context.Context, pg pgSessionQueryer,
 ) ([]db.ModelPricing, error) {
 	rows, err := pg.QueryContext(ctx,
 		pgModelPricingSelect,
@@ -586,20 +586,95 @@ func pgPricingBandInsertStatement(
 	return b.String(), args
 }
 
-func upsertModelPricing(
-	ctx context.Context, pg *sql.DB,
-	prices []db.ModelPricing,
+// pgPricingMetaUpsertStatement writes sentinel metadata rows, whose
+// updated_at holds an opaque value rather than a timestamp.
+func pgPricingMetaUpsertStatement(
+	metaRows []db.ModelPricing,
+) (string, []any) {
+	var b strings.Builder
+	b.WriteString(`INSERT INTO model_pricing
+		(model_pattern, input_microdollars_per_mtok, output_microdollars_per_mtok,
+		 cache_creation_microdollars_per_mtok, cache_read_microdollars_per_mtok,
+		 updated_at)
+	VALUES `)
+	args := make([]any, 0, len(metaRows)*2)
+	for i, row := range metaRows {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		fmt.Fprintf(&b, "($%d, 0, 0, 0, 0, $%d)", i*2+1, i*2+2)
+		args = append(args,
+			sanitizePG(row.ModelPattern), sanitizePG(row.UpdatedAt),
+		)
+	}
+	b.WriteString(`
+	ON CONFLICT (model_pattern) DO UPDATE SET
+		updated_at = EXCLUDED.updated_at`)
+	return b.String(), args
+}
+
+func pgPricingDeleteStatement(
+	table string, patterns []string,
+) (string, []any) {
+	placeholders := make([]string, len(patterns))
+	args := make([]any, len(patterns))
+	for i, pattern := range patterns {
+		placeholders[i] = fmt.Sprintf("$%d", i+1)
+		args[i] = sanitizePG(pattern)
+	}
+	return `DELETE FROM ` + table + ` WHERE model_pattern IN (` +
+		strings.Join(placeholders, ", ") + `)`, args
+}
+
+// reconcileModelPricing deletes removePatterns and upserts prices within
+// tx. Sentinel metadata rows are written by value; model rows go through
+// the change-detecting upsert and band replacement.
+func reconcileModelPricing(
+	ctx context.Context, tx *sql.Tx,
+	prices []db.ModelPricing, removePatterns []string,
 ) error {
-	if len(prices) == 0 {
-		return nil
+	if err := deletePGModelPricing(ctx, tx, removePatterns); err != nil {
+		return err
 	}
-
-	tx, err := pg.BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("beginning pg pricing upsert: %w", err)
+	metaRows := make([]db.ModelPricing, 0)
+	modelRows := make([]db.ModelPricing, 0, len(prices))
+	for _, price := range prices {
+		if strings.HasPrefix(price.ModelPattern, "_") {
+			metaRows = append(metaRows, price)
+		} else {
+			modelRows = append(modelRows, price)
+		}
 	}
-	defer func() { _ = tx.Rollback() }()
+	for i := 0; i < len(metaRows); i += pricingUpsertBatch {
+		end := min(i+pricingUpsertBatch, len(metaRows))
+		query, args := pgPricingMetaUpsertStatement(metaRows[i:end])
+		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+			return fmt.Errorf(
+				"upserting pg pricing meta at batch %d: %w", i, err)
+		}
+	}
+	return upsertPGModelPricing(ctx, tx, modelRows)
+}
 
+func deletePGModelPricing(
+	ctx context.Context, tx *sql.Tx, patterns []string,
+) error {
+	for i := 0; i < len(patterns); i += pricingUpsertBatch {
+		end := min(i+pricingUpsertBatch, len(patterns))
+		for _, table := range []string{"model_pricing_bands", "model_pricing"} {
+			query, args := pgPricingDeleteStatement(table, patterns[i:end])
+			if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+				return fmt.Errorf(
+					"deleting pg %s rows at batch %d: %w", table, i, err)
+			}
+		}
+	}
+	return nil
+}
+
+func upsertPGModelPricing(
+	ctx context.Context, tx *sql.Tx, prices []db.ModelPricing,
+) error {
 	defaultUpdatedAt := time.Now().UTC().Format(time.RFC3339Nano)
 	baseChanged := make(map[string]struct{}, len(prices))
 	for i := 0; i < len(prices); i += pricingUpsertBatch {
@@ -633,14 +708,10 @@ func upsertModelPricing(
 				"closing changed pg pricing at batch %d: %w", i, err)
 		}
 	}
-	modelPrices := make([]db.ModelPricing, 0, len(prices))
 	bandOnlyPrices := make([]db.ModelPricing, 0, len(prices))
 	for _, price := range prices {
-		if !strings.HasPrefix(price.ModelPattern, "_") {
-			modelPrices = append(modelPrices, price)
-			if _, changed := baseChanged[price.ModelPattern]; !changed {
-				bandOnlyPrices = append(bandOnlyPrices, price)
-			}
+		if _, changed := baseChanged[price.ModelPattern]; !changed {
+			bandOnlyPrices = append(bandOnlyPrices, price)
 		}
 	}
 	for i := 0; i < len(bandOnlyPrices); i += pricingUpsertBatch {
@@ -652,9 +723,9 @@ func upsertModelPricing(
 				"advancing pg pricing timestamps at batch %d: %w", i, err)
 		}
 	}
-	for i := 0; i < len(modelPrices); i += pricingUpsertBatch {
-		end := min(i+pricingUpsertBatch, len(modelPrices))
-		batch := modelPrices[i:end]
+	for i := 0; i < len(prices); i += pricingUpsertBatch {
+		end := min(i+pricingUpsertBatch, len(prices))
+		batch := prices[i:end]
 		query, args := pgPricingBandDeleteStatement(batch)
 		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
 			return fmt.Errorf(
@@ -662,7 +733,7 @@ func upsertModelPricing(
 		}
 	}
 	var bands []pgModelPricingBand
-	for _, price := range modelPrices {
+	for _, price := range prices {
 		for _, band := range price.Bands {
 			bands = append(bands, pgModelPricingBand{
 				model: price.ModelPattern,
@@ -679,10 +750,6 @@ func upsertModelPricing(
 				"inserting pg pricing bands at batch %d: %w", i, err)
 		}
 	}
-
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("committing pg pricing upsert: %w", err)
-	}
 	return nil
 }
 
@@ -694,18 +761,40 @@ func (s *Sync) syncModelPricing(ctx context.Context) error {
 	if len(prices) == 0 {
 		prices = fallbackPricingRows()
 	}
-	existing, err := listPGModelPricing(ctx, s.pg)
+	tx, err := s.pg.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("beginning pg pricing sync: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	// Pushes from several machines read the same ownership sentinel and
+	// each write a merged copy, so read, plan, and write are serialized
+	// under one lock; otherwise a slower push could overwrite ownership a
+	// faster one recorded and leave its rows untracked.
+	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock(
+		hashtext(current_schema()), hashtext('model_pricing')
+	)`); err != nil {
+		return fmt.Errorf("locking pg model pricing: %w", err)
+	}
+	existing, err := listPGModelPricing(ctx, tx)
 	if err != nil {
 		return fmt.Errorf("listing pg model pricing: %w", err)
 	}
-	_, changedPrices := db.FilterChangedModelPricing(
+	changedPrices, removePatterns, err := db.PlanModelPricingSync(
 		existing, prices,
 	)
-	if len(changedPrices) == 0 {
+	if err != nil {
+		return fmt.Errorf("planning model pricing sync: %w", err)
+	}
+	if len(changedPrices) == 0 && len(removePatterns) == 0 {
 		return nil
 	}
-	if err := upsertModelPricing(ctx, s.pg, changedPrices); err != nil {
+	if err := reconcileModelPricing(
+		ctx, tx, changedPrices, removePatterns,
+	); err != nil {
 		return fmt.Errorf("syncing model pricing to pg: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing pg pricing sync: %w", err)
 	}
 	return nil
 }

--- a/internal/postgres/pricing.go
+++ b/internal/postgres/pricing.go
@@ -753,6 +753,32 @@ func upsertPGModelPricing(
 	return nil
 }
 
+// pricingSyncLockKey names the sync_metadata row a pricing sync locks
+// for the life of its transaction.
+const pricingSyncLockKey = "model_pricing_sync_lock"
+
+// lockPGModelPricing serializes concurrent pricing syncs by locking a
+// dedicated sync_metadata row until tx ends. A row lock is used instead
+// of pg_advisory_xact_lock because supported CockroachDB versions do not
+// implement advisory locks, and sync_metadata lives in the target
+// schema, so the lock is schema-scoped on both engines.
+func lockPGModelPricing(ctx context.Context, tx *sql.Tx) error {
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO sync_metadata (key, value) VALUES ($1, '')
+		 ON CONFLICT (key) DO NOTHING`,
+		pricingSyncLockKey,
+	); err != nil {
+		return fmt.Errorf("creating pg model pricing lock row: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx,
+		`SELECT value FROM sync_metadata WHERE key = $1 FOR UPDATE`,
+		pricingSyncLockKey,
+	); err != nil {
+		return fmt.Errorf("locking pg model pricing: %w", err)
+	}
+	return nil
+}
+
 func (s *Sync) syncModelPricing(ctx context.Context) error {
 	prices, err := s.local.ListModelPricing(ctx)
 	if err != nil {
@@ -770,10 +796,8 @@ func (s *Sync) syncModelPricing(ctx context.Context) error {
 	// each write a merged copy, so read, plan, and write are serialized
 	// under one lock; otherwise a slower push could overwrite ownership a
 	// faster one recorded and leave its rows untracked.
-	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock(
-		hashtext(current_schema()), hashtext('model_pricing')
-	)`); err != nil {
-		return fmt.Errorf("locking pg model pricing: %w", err)
+	if err := lockPGModelPricing(ctx, tx); err != nil {
+		return err
 	}
 	existing, err := listPGModelPricing(ctx, tx)
 	if err != nil {

--- a/internal/postgres/pricing_unit_test.go
+++ b/internal/postgres/pricing_unit_test.go
@@ -756,6 +756,7 @@ func TestSyncModelPricingSkipsWriteWhenRemoteRowsUnchanged(t *testing.T) {
 	require.NoError(t, sync.syncModelPricing(ctx))
 	assert.Equal(t, 1, state.queryCount(), "pg pricing reads")
 	execs := state.execStatements()
-	require.Len(t, execs, 1, "only the serialization lock, no writes")
-	assert.Contains(t, execs[0], "pg_advisory_xact_lock")
+	require.Len(t, execs, 2, "only the serialization lock, no writes")
+	assert.Contains(t, execs[0], "ON CONFLICT (key) DO NOTHING")
+	assert.Contains(t, execs[1], "FOR UPDATE")
 }

--- a/internal/postgres/pricing_unit_test.go
+++ b/internal/postgres/pricing_unit_test.go
@@ -35,6 +35,7 @@ type pricingProbeState struct {
 	mu               sync.Mutex
 	doneOnce         sync.Once
 	queries          int
+	execs            []string
 	err              error
 	rows             [][]driver.Value
 	block            <-chan struct{}
@@ -85,7 +86,21 @@ func (c *pricingProbeConn) Prepare(string) (driver.Stmt, error) {
 func (c *pricingProbeConn) Close() error { return nil }
 
 func (c *pricingProbeConn) Begin() (driver.Tx, error) {
-	return nil, errors.New("begin not implemented")
+	return pricingProbeTx{}, nil
+}
+
+type pricingProbeTx struct{}
+
+func (pricingProbeTx) Commit() error   { return nil }
+func (pricingProbeTx) Rollback() error { return nil }
+
+func (c *pricingProbeConn) ExecContext(
+	_ context.Context, query string, _ []driver.NamedValue,
+) (driver.Result, error) {
+	c.state.mu.Lock()
+	defer c.state.mu.Unlock()
+	c.state.execs = append(c.state.execs, query)
+	return driver.RowsAffected(0), nil
 }
 
 func (c *pricingProbeConn) QueryContext(
@@ -148,6 +163,12 @@ func (s *pricingProbeState) queryCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.queries
+}
+
+func (s *pricingProbeState) execStatements() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.execs...)
 }
 
 func (s *pricingProbeState) setRows(rows [][]driver.Value) {
@@ -676,12 +697,39 @@ func TestPGPricingFilterMatchesUpsertSemantics(t *testing.T) {
 	assert.Equal(t, db.PricingChangeSummary{
 		Total:     4,
 		Missing:   1,
-		Changed:   1,
-		Unchanged: 2,
+		Changed:   2,
+		Unchanged: 1,
 	}, got)
-	require.Len(t, changedRows, 2)
-	assert.Equal(t, "changed-model", changedRows[0].ModelPattern)
-	assert.Equal(t, "missing-model", changedRows[1].ModelPattern)
+	require.Len(t, changedRows, 3)
+	assert.Equal(t, "_fallback_version", changedRows[0].ModelPattern,
+		"sentinel rows sync by value")
+	assert.Equal(t, "changed-model", changedRows[1].ModelPattern)
+	assert.Equal(t, "missing-model", changedRows[2].ModelPattern)
+}
+
+func TestPGPricingMetaUpsertStatement(t *testing.T) {
+	query, args := pgPricingMetaUpsertStatement([]db.ModelPricing{
+		{ModelPattern: "_openrouter_models", UpdatedAt: `["a"]`},
+		{ModelPattern: "_fallback_version", UpdatedAt: "v3"},
+	})
+
+	assert.Contains(t, query, "VALUES ($1, 0, 0, 0, 0, $2), ($3, 0, 0, 0, 0, $4)")
+	assert.Contains(t, query, "DO UPDATE SET\n\t\tupdated_at = EXCLUDED.updated_at")
+	assert.NotContains(t, query, "timestamptz",
+		"sentinel values are opaque and must not be cast")
+	assert.Equal(t, []any{
+		"_openrouter_models", `["a"]`, "_fallback_version", "v3",
+	}, args)
+}
+
+func TestPGPricingDeleteStatement(t *testing.T) {
+	query, args := pgPricingDeleteStatement(
+		"model_pricing", []string{"a", "b"},
+	)
+
+	assert.Equal(t,
+		"DELETE FROM model_pricing WHERE model_pattern IN ($1, $2)", query)
+	assert.Equal(t, []any{"a", "b"}, args)
 }
 
 func TestSyncModelPricingSkipsWriteWhenRemoteRowsUnchanged(t *testing.T) {
@@ -707,4 +755,7 @@ func TestSyncModelPricingSkipsWriteWhenRemoteRowsUnchanged(t *testing.T) {
 
 	require.NoError(t, sync.syncModelPricing(ctx))
 	assert.Equal(t, 1, state.queryCount(), "pg pricing reads")
+	execs := state.execStatements()
+	require.Len(t, execs, 1, "only the serialization lock, no writes")
+	assert.Contains(t, execs[0], "pg_advisory_xact_lock")
 }

--- a/internal/postgres/usage_pgtest_test.go
+++ b/internal/postgres/usage_pgtest_test.go
@@ -14,6 +14,7 @@ import (
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/export"
 	"go.kenn.io/agentsview/internal/money"
+	"go.kenn.io/agentsview/internal/pricing"
 	"go.kenn.io/agentsview/internal/service"
 )
 
@@ -1671,6 +1672,78 @@ func TestPushSyncsModelPricingToPostgres(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, secondRevision.After(firstRevision),
 		"band removal must advance the parent pricing revision")
+}
+
+func TestPushRetiresOpenRouterPricingRows(t *testing.T) {
+	pgURL := testPGURL(t)
+	cleanPGSchema(t, pgURL)
+	t.Cleanup(func() { cleanPGSchema(t, pgURL) })
+
+	local := testDB(t)
+	require.NoError(t, local.ReconcileModelPricing(
+		[]db.ModelPricing{{
+			ModelPattern: "minimax/minimax-m3",
+			InputPerMTok: money.MustParseDollars("9"),
+			Bands: []db.PricingBand{{
+				AboveInputTokens: 1000,
+				InputPerMTok:     money.MustParseDollars("10"),
+			}},
+		}},
+		nil,
+		db.PricingMeta{
+			Key:   pricing.OpenRouterModelsMetaKey,
+			Value: `["minimax/minimax-m3"]`,
+		},
+	))
+	ps, err := New(pgURL, "agentsview", local, "test-machine", true, SyncOptions{})
+	require.NoError(t, err, "New")
+	defer ps.Close()
+	_, err = ps.Push(context.Background(), false, nil)
+	require.NoError(t, err, "first push")
+
+	// LiteLLM now covers the model: the local refresh retires the
+	// OpenRouter row and rewrites the ownership sentinel.
+	require.NoError(t, local.ReconcileModelPricing(
+		[]db.ModelPricing{{
+			ModelPattern: "minimax/MiniMax-M3",
+			InputPerMTok: money.MustParseDollars("2"),
+		}},
+		[]string{"minimax/minimax-m3"},
+		db.PricingMeta{Key: pricing.OpenRouterModelsMetaKey, Value: `[]`},
+	))
+	_, err = ps.Push(context.Background(), false, nil)
+	require.NoError(t, err, "second push")
+
+	store, err := NewStore(pgURL, "agentsview", true)
+	require.NoError(t, err, "NewStore")
+	defer store.Close()
+	var patterns []string
+	rows, err := store.DB().QueryContext(context.Background(), `
+		SELECT model_pattern FROM model_pricing
+		WHERE model_pattern IN ('minimax/minimax-m3', 'minimax/MiniMax-M3')
+		ORDER BY model_pattern`)
+	require.NoError(t, err)
+	defer rows.Close()
+	for rows.Next() {
+		var pattern string
+		require.NoError(t, rows.Scan(&pattern))
+		patterns = append(patterns, pattern)
+	}
+	require.NoError(t, rows.Err())
+	assert.Equal(t, []string{"minimax/MiniMax-M3"}, patterns,
+		"retired row deleted, replacement pushed")
+
+	var bandCount int
+	require.NoError(t, store.DB().QueryRowContext(context.Background(), `
+		SELECT COUNT(*) FROM model_pricing_bands
+		WHERE model_pattern = 'minimax/minimax-m3'`).Scan(&bandCount))
+	assert.Zero(t, bandCount, "retired row's bands deleted")
+
+	var meta string
+	require.NoError(t, store.DB().QueryRowContext(context.Background(), `
+		SELECT updated_at FROM model_pricing WHERE model_pattern = $1`,
+		pricing.OpenRouterModelsMetaKey).Scan(&meta))
+	assert.Equal(t, `[]`, meta, "ownership sentinel mirrored by value")
 }
 
 func TestPushFallsBackToBuiltinPricingWhenLocalTableEmpty(t *testing.T) {

--- a/internal/pricing/catalog/litellm.go
+++ b/internal/pricing/catalog/litellm.go
@@ -44,12 +44,6 @@ var inputThresholdRatePattern = regexp.MustCompile(
 	`^input_cost_per_token_above_([0-9]+)(k?)_tokens$`,
 )
 
-// FetchLiteLLMPricing downloads the LiteLLM pricing JSON
-// and parses it into ModelPricing entries.
-func FetchLiteLLMPricing() ([]ModelPricing, error) {
-	return FetchLiteLLMPricingContext(context.Background())
-}
-
 // FetchLiteLLMPricingContext downloads the LiteLLM pricing JSON and binds the
 // request lifetime to ctx.
 func FetchLiteLLMPricingContext(

--- a/internal/pricing/catalog/openrouter.go
+++ b/internal/pricing/catalog/openrouter.go
@@ -1,0 +1,145 @@
+package catalog
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"go.kenn.io/agentsview/internal/money"
+)
+
+// openrouterURL is OpenRouter's public model list. It needs no auth and
+// returns every proxied model with its per-token prompt/completion price.
+const openrouterURL = "https://openrouter.ai/api/v1/models"
+
+// FetchOpenRouterPricingContext downloads the OpenRouter model catalog and
+// binds the request lifetime to ctx.
+func FetchOpenRouterPricingContext(
+	ctx context.Context,
+) ([]ModelPricing, error) {
+	client := &http.Client{Timeout: 30 * time.Second}
+	return fetchOpenRouterPricing(ctx, client, openrouterURL)
+}
+
+func fetchOpenRouterPricing(
+	ctx context.Context, client *http.Client, url string,
+) ([]ModelPricing, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating openrouter pricing request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching openrouter pricing: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf(
+			"fetching openrouter pricing: status %d", resp.StatusCode,
+		)
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading openrouter response: %w", err)
+	}
+	return ParseOpenRouterPricing(data)
+}
+
+type openrouterEntry struct {
+	ID           string `json:"id"`
+	Architecture struct {
+		Modality string `json:"modality"`
+	} `json:"architecture"`
+	Pricing struct {
+		Prompt          string `json:"prompt"`
+		Completion      string `json:"completion"`
+		InputCacheRead  string `json:"input_cache_read"`
+		InputCacheWrite string `json:"input_cache_write"`
+	} `json:"pricing"`
+}
+
+// ParseOpenRouterPricing parses the OpenRouter /models envelope
+// ({"data": [...]}) into ModelPricing entries keyed by the
+// provider-qualified OpenRouter id. Only models that produce text are
+// kept: agentsview prices token counters, so image, audio, and embedding
+// outputs are skipped. Prices are quoted in USD per token as decimal
+// strings and are converted to microdollars per million tokens. Entries
+// without a usable prompt or completion price are skipped rather than
+// failing the parse: OpenRouter marks dynamically priced routers with
+// "-1", and one odd entry must not take the whole catalog offline.
+func ParseOpenRouterPricing(data []byte) ([]ModelPricing, error) {
+	var envelope struct {
+		Data []openrouterEntry `json:"data"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return nil, fmt.Errorf("parsing openrouter JSON: %w", err)
+	}
+
+	var prices []ModelPricing
+	for _, e := range envelope.Data {
+		if !producesText(e.Architecture.Modality) {
+			continue
+		}
+		p, ok := openrouterModelPricing(e)
+		if ok {
+			prices = append(prices, p)
+		}
+	}
+	return prices, nil
+}
+
+func openrouterModelPricing(e openrouterEntry) (ModelPricing, bool) {
+	prompt, hasPrompt, err := parseOpenRouterRate(e.Pricing.Prompt)
+	if err != nil {
+		return ModelPricing{}, false
+	}
+	completion, hasCompletion, err := parseOpenRouterRate(e.Pricing.Completion)
+	if err != nil || (!hasPrompt && !hasCompletion) {
+		return ModelPricing{}, false
+	}
+	cacheRead, _, err := parseOpenRouterRate(e.Pricing.InputCacheRead)
+	if err != nil {
+		return ModelPricing{}, false
+	}
+	cacheWrite, _, err := parseOpenRouterRate(e.Pricing.InputCacheWrite)
+	if err != nil {
+		return ModelPricing{}, false
+	}
+	return ModelPricing{
+		ModelPattern:         e.ID,
+		InputPerMTok:         prompt,
+		OutputPerMTok:        completion,
+		CacheCreationPerMTok: cacheWrite,
+		CacheReadPerMTok:     cacheRead,
+	}, true
+}
+
+// producesText reports whether an OpenRouter modality ("text+image->text")
+// has text on the output side. An empty modality is treated as text: the
+// field is omitted for plain text models.
+func producesText(modality string) bool {
+	if modality == "" {
+		return true
+	}
+	_, output, ok := strings.Cut(modality, "->")
+	return ok && strings.Contains(output, "text")
+}
+
+// parseOpenRouterRate converts a per-token USD price to per-million-token
+// microdollars. An empty value means the field is absent; zero is a valid
+// price for free models; negative or malformed values are errors.
+func parseOpenRouterRate(value string) (money.Money, bool, error) {
+	if value == "" {
+		return money.Money{}, false, nil
+	}
+	rate, err := parsePerTokenRate(json.Number(value))
+	if err != nil {
+		return money.Money{}, false, err
+	}
+	return rate, true, nil
+}

--- a/internal/pricing/catalog/openrouter_test.go
+++ b/internal/pricing/catalog/openrouter_test.go
@@ -1,0 +1,117 @@
+package catalog
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/money"
+)
+
+func TestParseOpenRouterPricing(t *testing.T) {
+	data := []byte(`{
+		"data": [
+			{
+				"id": "minimax/minimax-m3",
+				"architecture": {"modality": "text+image->text"},
+				"pricing": {
+					"prompt": "0.000005",
+					"completion": "0.000025",
+					"input_cache_read": "0.0000005",
+					"input_cache_write": "0.00000625"
+				}
+			},
+			{
+				"id": "provider/plain",
+				"pricing": {"prompt": "0.000001", "completion": "0.000002"}
+			},
+			{
+				"id": "provider/free",
+				"architecture": {"modality": "text->text"},
+				"pricing": {"prompt": "0", "completion": "0"}
+			},
+			{
+				"id": "openai/image-model",
+				"architecture": {"modality": "text->image"},
+				"pricing": {"prompt": "0.01", "completion": "0.01"}
+			},
+			{
+				"id": "openrouter/auto",
+				"architecture": {"modality": "text->text"},
+				"pricing": {"prompt": "-1", "completion": "-1"}
+			},
+			{
+				"id": "provider/malformed",
+				"architecture": {"modality": "text->text"},
+				"pricing": {"prompt": "1 trailing", "completion": "NaN"}
+			},
+			{
+				"id": "provider/unpriced",
+				"architecture": {"modality": "text->text"},
+				"pricing": {"prompt": "", "completion": ""}
+			}
+		]
+	}`)
+
+	prices, err := ParseOpenRouterPricing(data)
+	require.NoError(t, err)
+
+	assert.Equal(t, []ModelPricing{
+		{
+			ModelPattern:         "minimax/minimax-m3",
+			InputPerMTok:         money.Money{Microdollars: 5_000_000},
+			OutputPerMTok:        money.Money{Microdollars: 25_000_000},
+			CacheCreationPerMTok: money.Money{Microdollars: 6_250_000},
+			CacheReadPerMTok:     money.Money{Microdollars: 500_000},
+		},
+		{
+			ModelPattern:  "provider/plain",
+			InputPerMTok:  money.Money{Microdollars: 1_000_000},
+			OutputPerMTok: money.Money{Microdollars: 2_000_000},
+		},
+		{ModelPattern: "provider/free"},
+	}, prices, "text-output models kept; non-text, negative, "+
+		"malformed, and unpriced entries skipped")
+}
+
+func TestParseOpenRouterPricingRejectsInvalidJSON(t *testing.T) {
+	_, err := ParseOpenRouterPricing([]byte(`<html>`))
+	require.Error(t, err)
+}
+
+func TestFetchOpenRouterPricing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(
+		w http.ResponseWriter, _ *http.Request,
+	) {
+		_, _ = w.Write([]byte(`{"data": [{
+			"id": "provider/model",
+			"pricing": {"prompt": "0.000001", "completion": "0.000002"}
+		}]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	prices, err := fetchOpenRouterPricing(
+		context.Background(), server.Client(), server.URL,
+	)
+	require.NoError(t, err)
+	require.Len(t, prices, 1)
+	assert.Equal(t, "provider/model", prices[0].ModelPattern)
+}
+
+func TestFetchOpenRouterPricingRejectsErrorStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(
+		w http.ResponseWriter, _ *http.Request,
+	) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := fetchOpenRouterPricing(
+		context.Background(), server.Client(), server.URL,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "status 503")
+}

--- a/internal/pricing/litellm.go
+++ b/internal/pricing/litellm.go
@@ -15,12 +15,6 @@ type ModelPricing = catalog.ModelPricing
 // threshold.
 type PricingBand = catalog.PricingBand
 
-// FetchLiteLLMPricing downloads the LiteLLM pricing JSON
-// and parses it into ModelPricing entries.
-func FetchLiteLLMPricing() ([]ModelPricing, error) {
-	return catalog.FetchLiteLLMPricing()
-}
-
 // FetchLiteLLMPricingContext downloads the LiteLLM pricing JSON and binds the
 // request lifetime to ctx.
 func FetchLiteLLMPricingContext(

--- a/internal/pricing/normalize_test.go
+++ b/internal/pricing/normalize_test.go
@@ -142,6 +142,32 @@ func TestResolveCanonicalDeterminism(t *testing.T) {
 		"duplicate unqualified canonical keys are ambiguous")
 }
 
+// TestResolveOverlappingQualifiedRows pins the resolver behavior that
+// MergeCatalog exists to protect: a bare session model name resolves
+// against a lone provider-qualified key, but two qualified spellings of
+// one model (LiteLLM's minimax/MiniMax-M3 against OpenRouter's
+// minimax/minimax-m3) tie and stay unresolved.
+func TestResolveOverlappingQualifiedRows(t *testing.T) {
+	single := map[string]int{"minimax/MiniMax-M3": 2}
+	got, ok := Resolve(single, "MiniMax-M3")
+	require.True(t, ok, "bare name resolves against a lone qualified key")
+	assert.Equal(t, 2, got)
+
+	colliding := map[string]int{
+		"minimax/MiniMax-M3": 2,
+		"minimax/minimax-m3": 9,
+	}
+	_, ok = Resolve(colliding, "MiniMax-M3")
+	assert.False(t, ok,
+		"same-provider spellings of one model tie and stay ambiguous")
+
+	// Each spelling still resolves when addressed exactly, so dropping
+	// the lower-priority row never orphans a real model id.
+	got, ok = Resolve(colliding, "minimax/minimax-m3")
+	require.True(t, ok, "exact key still resolves")
+	assert.Equal(t, 9, got)
+}
+
 func TestResolveRejectsArbitrarySubstrings(t *testing.T) {
 	rates := map[string]int{
 		"openai/gpt-5.5":   30,

--- a/internal/pricing/openrouter.go
+++ b/internal/pricing/openrouter.go
@@ -1,0 +1,177 @@
+package pricing
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+
+	"go.kenn.io/agentsview/internal/pricing/catalog"
+)
+
+// OpenRouterModelsMetaKey names the model_pricing sentinel row whose
+// updated_at holds the JSON list of patterns OpenRouter contributed to the
+// stored catalog. Refreshes use it to retire those rows once LiteLLM lists
+// the same model, and push targets use it to mirror that retirement.
+const OpenRouterModelsMetaKey = "_openrouter_models"
+
+// FetchOpenRouterPricingContext downloads the OpenRouter model catalog and
+// binds the request lifetime to ctx.
+func FetchOpenRouterPricingContext(
+	ctx context.Context,
+) ([]ModelPricing, error) {
+	return catalog.FetchOpenRouterPricingContext(ctx)
+}
+
+// ParseOpenRouterPricing parses the OpenRouter /models JSON into
+// ModelPricing entries. See catalog.ParseOpenRouterPricing.
+func ParseOpenRouterPricing(data []byte) ([]ModelPricing, error) {
+	return catalog.ParseOpenRouterPricing(data)
+}
+
+// Catalog is one upstream pricing snapshot: the LiteLLM and OpenRouter
+// rows as fetched. Reconcile merges them over a stored table.
+type Catalog struct {
+	LiteLLM    []ModelPricing
+	OpenRouter []ModelPricing
+}
+
+// FetchCatalog fetches LiteLLM and OpenRouter. Either fetch failing fails
+// the whole snapshot: a partial catalog could not tell which OpenRouter
+// rows LiteLLM shadows, so the caller keeps its last stored pricing.
+func FetchCatalog() (Catalog, error) {
+	return FetchCatalogContext(context.Background())
+}
+
+// FetchCatalogContext is FetchCatalog bound to ctx.
+func FetchCatalogContext(ctx context.Context) (Catalog, error) {
+	litellm, err := FetchLiteLLMPricingContext(ctx)
+	if err != nil {
+		return Catalog{}, err
+	}
+	openrouter, err := FetchOpenRouterPricingContext(ctx)
+	if err != nil {
+		return Catalog{}, err
+	}
+	return Catalog{LiteLLM: litellm, OpenRouter: openrouter}, nil
+}
+
+// Reconcile merges the catalog over a stored table and returns the rows to
+// store, the OpenRouter ownership list to record, and the stored patterns
+// to delete. stored lists every stored model pattern; previous lists the
+// patterns an earlier refresh took from OpenRouter.
+//
+// An OpenRouter row is dropped when the LiteLLM catalog or a stored row
+// from another source (LiteLLM, embedded, supplemental) already lists a
+// model with the same canonical name under any spelling or provider
+// prefix, so adding OpenRouter never changes a lookup that already
+// resolved: two provider-qualified spellings of one model (LiteLLM's
+// openrouter/openai/gpt-x against OpenRouter's openai/gpt-x) would
+// otherwise tie in the resolver and leave a bare session model name
+// unpriced. The cost is that a session naming the OpenRouter id exactly
+// stays unpriced in that case, as it did before. Rows are copied whole; a
+// zero rate is a valid price for free models, so fields are never
+// backfilled across sources.
+//
+// Of the previously stored OpenRouter rows, those the merged catalog or a
+// stored row from another source now covers under a different spelling
+// are retired (they would tie with the replacement), those the catalog
+// lists exactly follow the catalog's ownership, and rows OpenRouter merely
+// delisted stay stored and tracked so past sessions keep their price.
+func (c Catalog) Reconcile(
+	stored, previous []string,
+) (prices []ModelPricing, owned, retired []string) {
+	covering := make([]string, 0, len(c.LiteLLM)+len(stored))
+	for _, p := range c.LiteLLM {
+		covering = append(covering, p.ModelPattern)
+	}
+	for _, pattern := range stored {
+		if !slices.Contains(previous, pattern) {
+			covering = append(covering, pattern)
+		}
+	}
+	candidates := make([]string, len(c.OpenRouter))
+	for i, p := range c.OpenRouter {
+		candidates[i] = p.ModelPattern
+	}
+	dropped := CoveredPatterns(covering, candidates)
+	prices = c.LiteLLM
+	for _, p := range c.OpenRouter {
+		if slices.Contains(dropped, p.ModelPattern) {
+			continue
+		}
+		prices = append(prices, p)
+		owned = append(owned, p.ModelPattern)
+	}
+
+	listed := make([]string, 0, len(prices))
+	for _, p := range prices {
+		listed = append(listed, p.ModelPattern)
+	}
+	retired = ShadowedPatterns(append(listed, covering...), previous)
+	for _, pattern := range previous {
+		if !slices.Contains(listed, pattern) &&
+			!slices.Contains(retired, pattern) {
+			owned = append(owned, pattern)
+		}
+	}
+	slices.Sort(owned)
+	return prices, slices.Compact(owned), retired
+}
+
+// CoveredPatterns returns the candidates whose canonical model name some
+// pattern in covering shares, including exact listings. An OpenRouter row
+// covered by a higher-priority source must not be stored beside it.
+func CoveredPatterns(covering, candidates []string) []string {
+	covered := make(map[string]struct{}, len(covering))
+	for _, pattern := range covering {
+		covered[canonicalize(pattern)] = struct{}{}
+	}
+	var out []string
+	for _, pattern := range candidates {
+		if _, ok := covered[canonicalize(pattern)]; ok {
+			out = append(out, pattern)
+		}
+	}
+	slices.Sort(out)
+	return slices.Compact(out)
+}
+
+// ShadowedPatterns returns the candidates that catalog covers under a
+// different pattern with the same canonical name. Such a stored row would
+// tie with the catalog's row in the resolver, so it must be retired.
+// Candidates the catalog lists exactly or does not cover at all are not
+// returned; a delisted model that nothing replaces keeps its price.
+func ShadowedPatterns(catalog, candidates []string) []string {
+	var shadowed []string
+	for _, pattern := range CoveredPatterns(catalog, candidates) {
+		if !slices.Contains(catalog, pattern) {
+			shadowed = append(shadowed, pattern)
+		}
+	}
+	return shadowed
+}
+
+// EncodeOpenRouterModels renders an ownership list as the sentinel value.
+func EncodeOpenRouterModels(patterns []string) string {
+	if patterns == nil {
+		patterns = []string{}
+	}
+	encoded, _ := json.Marshal(patterns) // a []string always encodes
+	return string(encoded)
+}
+
+// DecodeOpenRouterModels parses a sentinel value written by
+// EncodeOpenRouterModels. An empty value decodes to no patterns.
+func DecodeOpenRouterModels(value string) ([]string, error) {
+	if value == "" {
+		return nil, nil
+	}
+	var patterns []string
+	if err := json.Unmarshal([]byte(value), &patterns); err != nil {
+		return nil, fmt.Errorf(
+			"decoding %s: %w", OpenRouterModelsMetaKey, err,
+		)
+	}
+	return patterns, nil
+}

--- a/internal/pricing/openrouter.go
+++ b/internal/pricing/openrouter.go
@@ -36,22 +36,38 @@ type Catalog struct {
 	OpenRouter []ModelPricing
 }
 
-// FetchCatalog fetches LiteLLM and OpenRouter. Either fetch failing fails
-// the whole snapshot: a partial catalog could not tell which OpenRouter
-// rows LiteLLM shadows, so the caller keeps its last stored pricing.
+// FetchCatalog fetches LiteLLM and OpenRouter. A LiteLLM failure fails
+// the whole snapshot and the caller keeps its last stored pricing. An
+// OpenRouter failure returns a LiteLLM-only snapshot alongside the
+// error: Reconcile treats the empty OpenRouter side as delisting
+// nothing, so previously stored OpenRouter rows stay priced and tracked
+// while the fresh LiteLLM rates are still stored, and the caller
+// surfaces the error as a warning.
 func FetchCatalog() (Catalog, error) {
 	return FetchCatalogContext(context.Background())
 }
 
 // FetchCatalogContext is FetchCatalog bound to ctx.
 func FetchCatalogContext(ctx context.Context) (Catalog, error) {
-	litellm, err := FetchLiteLLMPricingContext(ctx)
+	return fetchCatalog(
+		ctx, FetchLiteLLMPricingContext, FetchOpenRouterPricingContext,
+	)
+}
+
+func fetchCatalog(
+	ctx context.Context,
+	fetchLiteLLM, fetchOpenRouter func(context.Context) ([]ModelPricing, error),
+) (Catalog, error) {
+	litellm, err := fetchLiteLLM(ctx)
 	if err != nil {
 		return Catalog{}, err
 	}
-	openrouter, err := FetchOpenRouterPricingContext(ctx)
+	openrouter, err := fetchOpenRouter(ctx)
 	if err != nil {
-		return Catalog{}, err
+		return Catalog{LiteLLM: litellm}, fmt.Errorf(
+			"fetching openrouter catalog (storing litellm rates only): %w",
+			err,
+		)
 	}
 	return Catalog{LiteLLM: litellm, OpenRouter: openrouter}, nil
 }
@@ -170,7 +186,10 @@ func DecodeOpenRouterModels(value string) ([]string, error) {
 	var patterns []string
 	if err := json.Unmarshal([]byte(value), &patterns); err != nil {
 		return nil, fmt.Errorf(
-			"decoding %s: %w", OpenRouterModelsMetaKey, err,
+			"decoding %s (delete that model_pricing row on the "+
+				"affected database to reset OpenRouter ownership "+
+				"tracking): %w",
+			OpenRouterModelsMetaKey, err,
 		)
 	}
 	return patterns, nil

--- a/internal/pricing/openrouter_test.go
+++ b/internal/pricing/openrouter_test.go
@@ -1,6 +1,8 @@
 package pricing
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,6 +12,45 @@ import (
 
 func rate(dollars string) money.Money {
 	return money.MustParseDollars(dollars)
+}
+
+func TestFetchCatalogDegradesWhenOpenRouterFails(t *testing.T) {
+	litellm := []ModelPricing{
+		{ModelPattern: "acme/model", InputPerMTok: rate("1")},
+	}
+	fetchLiteLLM := func(context.Context) ([]ModelPricing, error) {
+		return litellm, nil
+	}
+	openrouterErr := errors.New("openrouter down")
+	fetchOpenRouter := func(context.Context) ([]ModelPricing, error) {
+		return nil, openrouterErr
+	}
+
+	catalog, err := fetchCatalog(
+		context.Background(), fetchLiteLLM, fetchOpenRouter,
+	)
+
+	assert.ErrorIs(t, err, openrouterErr)
+	assert.Equal(t, Catalog{LiteLLM: litellm}, catalog,
+		"LiteLLM rows survive an OpenRouter outage")
+}
+
+func TestFetchCatalogFailsWhenLiteLLMFails(t *testing.T) {
+	litellmErr := errors.New("litellm down")
+	fetchLiteLLM := func(context.Context) ([]ModelPricing, error) {
+		return nil, litellmErr
+	}
+	fetchOpenRouter := func(context.Context) ([]ModelPricing, error) {
+		t.Fatal("openrouter must not be fetched after a litellm failure")
+		return nil, nil
+	}
+
+	catalog, err := fetchCatalog(
+		context.Background(), fetchLiteLLM, fetchOpenRouter,
+	)
+
+	assert.ErrorIs(t, err, litellmErr)
+	assert.Equal(t, Catalog{}, catalog)
 }
 
 func TestCatalogReconcile(t *testing.T) {

--- a/internal/pricing/openrouter_test.go
+++ b/internal/pricing/openrouter_test.go
@@ -1,0 +1,120 @@
+package pricing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/money"
+)
+
+func rate(dollars string) money.Money {
+	return money.MustParseDollars(dollars)
+}
+
+func TestCatalogReconcile(t *testing.T) {
+	litellm := []ModelPricing{
+		{ModelPattern: "minimax/MiniMax-M3", InputPerMTok: rate("2")},
+		{ModelPattern: "openrouter/openai/gpt-x", InputPerMTok: rate("1")},
+		{ModelPattern: "free-model"},
+	}
+	openrouter := []ModelPricing{
+		// Same model, different spelling: LiteLLM's rate wins.
+		{ModelPattern: "minimax/minimax-m3", InputPerMTok: rate("9")},
+		// Same canonical name under another provider prefix.
+		{ModelPattern: "openai/gpt-x", InputPerMTok: rate("4")},
+		// Free in LiteLLM, paid in OpenRouter: no field backfill.
+		{ModelPattern: "free-model", InputPerMTok: rate("5")},
+		// A stale row from an earlier LiteLLM catalog still shadows.
+		{ModelPattern: "acme/stale", InputPerMTok: rate("6")},
+		{ModelPattern: "acme/only-openrouter", InputPerMTok: rate("7")},
+	}
+	stored := []string{
+		"minimax/MiniMax-M3", "acme/Stale", "acme/previous",
+		// A row from another source that shadows a delisted
+		// OpenRouter row stored under a different spelling.
+		"acme/Old-Spelling", "acme/old-spelling",
+	}
+
+	prices, owned, retired := Catalog{
+		LiteLLM: litellm, OpenRouter: openrouter,
+	}.Reconcile(stored, []string{"acme/previous", "acme/old-spelling"})
+
+	assert.Equal(t, append(litellm, openrouter[4]), prices)
+	assert.Equal(t, []string{"acme/only-openrouter", "acme/previous"}, owned,
+		"a delisted OpenRouter row stays tracked until something covers it")
+	assert.Equal(t, []string{"acme/old-spelling"}, retired)
+
+	byPattern := make(map[string]ModelPricing, len(prices))
+	for _, p := range prices {
+		byPattern[p.ModelPattern] = p
+	}
+	price, ok := Resolve(byPattern, "MiniMax-M3")
+	require.True(t, ok, "bare lookup resolves without a tie")
+	assert.Equal(t, rate("2"), price.InputPerMTok)
+	price, ok = Resolve(byPattern, "only-openrouter")
+	require.True(t, ok, "OpenRouter-only model resolves by bare name")
+	assert.Equal(t, rate("7"), price.InputPerMTok)
+}
+
+func TestCatalogReconcileRetiresShadowedPrevious(t *testing.T) {
+	c := Catalog{
+		LiteLLM: []ModelPricing{
+			{ModelPattern: "minimax/MiniMax-M3"},
+			{ModelPattern: "acme/now-in-litellm"},
+		},
+		OpenRouter: []ModelPricing{
+			{ModelPattern: "minimax/minimax-m3"},
+			{ModelPattern: "acme/still-listed"},
+		},
+	}
+	previous := []string{
+		"acme/still-listed",
+		// LiteLLM now spells this model differently: retire it.
+		"minimax/minimax-m3",
+		// LiteLLM adopted the exact spelling: LiteLLM owns it now.
+		"acme/now-in-litellm",
+		// OpenRouter dropped it and nothing replaces it: keep pricing.
+		"acme/delisted",
+	}
+
+	prices, owned, retired := c.Reconcile(
+		append([]string{"minimax/MiniMax-M3"}, previous...), previous,
+	)
+
+	assert.Equal(t, []ModelPricing{
+		{ModelPattern: "minimax/MiniMax-M3"},
+		{ModelPattern: "acme/now-in-litellm"},
+		{ModelPattern: "acme/still-listed"},
+	}, prices)
+	assert.Equal(t, []string{"acme/delisted", "acme/still-listed"}, owned)
+	assert.Equal(t, []string{"minimax/minimax-m3"}, retired)
+}
+
+func TestShadowedPatterns(t *testing.T) {
+	catalog := []string{"minimax/MiniMax-M3", "acme/listed", "Bare-Model"}
+
+	got := ShadowedPatterns(catalog, []string{
+		"minimax/minimax-m3", // spelled differently: shadowed
+		"acme/listed",        // listed exactly: not shadowed
+		"bare-model",         // bare spelling of a covered name: shadowed
+		"acme/delisted",      // nothing covers it: kept
+	})
+
+	assert.Equal(t, []string{"bare-model", "minimax/minimax-m3"}, got)
+	assert.Empty(t, ShadowedPatterns(nil, []string{"acme/model"}))
+}
+
+func TestOpenRouterModelsRoundTrip(t *testing.T) {
+	assert.Equal(t, "[]", EncodeOpenRouterModels(nil))
+	decoded, err := DecodeOpenRouterModels(EncodeOpenRouterModels(
+		[]string{"a", "b"},
+	))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "b"}, decoded)
+	decoded, err = DecodeOpenRouterModels("")
+	require.NoError(t, err)
+	assert.Nil(t, decoded)
+	_, err = DecodeOpenRouterModels("not json")
+	require.Error(t, err)
+}

--- a/internal/pricingrefresh/refresh.go
+++ b/internal/pricingrefresh/refresh.go
@@ -4,6 +4,8 @@ package pricingrefresh
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -75,7 +77,7 @@ func SeedFallback(database *db.DB) error {
 	if stored == pricing.SeedVersion && storageVersion == pricingStorageVersion {
 		return nil
 	}
-	if err := upsert(database, pricing.FallbackPricing()); err != nil {
+	if err := storeFallback(database); err != nil {
 		return err
 	}
 	// Only delete while reseeding (version mismatch). A later LiteLLM
@@ -97,7 +99,7 @@ func SeedFallback(database *db.DB) error {
 // RefreshIfStale refreshes when the last attempt is older than cooldown.
 func RefreshIfStale(
 	database *db.DB,
-	fetch func() ([]pricing.ModelPricing, error),
+	fetch func() (pricing.Catalog, error),
 	cooldown time.Duration,
 	now time.Time,
 ) (bool, error) {
@@ -116,7 +118,7 @@ func RefreshIfStale(
 
 func refreshAt(
 	database *db.DB,
-	fetch func() ([]pricing.ModelPricing, error),
+	fetch func() (pricing.Catalog, error),
 	now time.Time,
 ) (bool, error) {
 	if err := database.SetPricingMeta(
@@ -126,11 +128,11 @@ func refreshAt(
 			"recording pricing refresh attempt: %w", err,
 		)
 	}
-	prices, err := fetch()
+	catalog, err := fetch()
 	if err != nil {
 		return false, err
 	}
-	if err := upsert(database, prices); err != nil {
+	if err := storeCatalog(database, catalog); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -140,11 +142,11 @@ func refreshAt(
 func Ensure(
 	database *db.DB,
 	offline bool,
-	fetch func() ([]pricing.ModelPricing, error),
+	fetch func() (pricing.Catalog, error),
 	now time.Time,
 ) (bool, error) {
 	if offline {
-		return false, upsert(database, pricing.FallbackPricing())
+		return false, storeFallback(database)
 	}
 	if err := SeedFallback(database); err != nil {
 		return false, err
@@ -155,7 +157,7 @@ func Ensure(
 // EnsureCurrent applies the standard online pricing lifecycle.
 func EnsureCurrent(ctx context.Context, database *db.DB) error {
 	return ensureCurrent(
-		ctx, database, pricing.FetchLiteLLMPricingContext, time.Now(),
+		ctx, database, pricing.FetchCatalogContext, time.Now(),
 	)
 }
 
@@ -163,14 +165,14 @@ func EnsureCurrent(ctx context.Context, database *db.DB) error {
 // of the most recent refresh attempt.
 func RefreshCurrent(ctx context.Context, database *db.DB) error {
 	return refreshCurrent(
-		ctx, database, pricing.FetchLiteLLMPricingContext, time.Now(),
+		ctx, database, pricing.FetchCatalogContext, time.Now(),
 	)
 }
 
 func refreshCurrent(
 	ctx context.Context,
 	database *db.DB,
-	fetch func(context.Context) ([]pricing.ModelPricing, error),
+	fetch func(context.Context) (pricing.Catalog, error),
 	now time.Time,
 ) error {
 	return runCurrent(ctx, database, fetch, now, true)
@@ -179,7 +181,7 @@ func refreshCurrent(
 func ensureCurrent(
 	ctx context.Context,
 	database *db.DB,
-	fetch func(context.Context) ([]pricing.ModelPricing, error),
+	fetch func(context.Context) (pricing.Catalog, error),
 	now time.Time,
 ) error {
 	return runCurrent(ctx, database, fetch, now, false)
@@ -188,7 +190,7 @@ func ensureCurrent(
 func runCurrent(
 	ctx context.Context,
 	database *db.DB,
-	fetch func(context.Context) ([]pricing.ModelPricing, error),
+	fetch func(context.Context) (pricing.Catalog, error),
 	now time.Time,
 	force bool,
 ) error {
@@ -217,7 +219,7 @@ func runCurrent(
 	if err != nil {
 		return fmt.Errorf("reading pricing refresh meta: %w", err)
 	}
-	fetchCurrent := func() ([]pricing.ModelPricing, error) {
+	fetchCurrent := func() (pricing.Catalog, error) {
 		return fetch(ctx)
 	}
 	if force {
@@ -241,7 +243,81 @@ func runCurrent(
 	return err
 }
 
-func upsert(database *db.DB, prices []pricing.ModelPricing) error {
+// storeCatalog reconciles a fetched catalog with the stored table (see
+// pricing.Catalog.Reconcile) and writes rows, retirements, and the
+// OpenRouter ownership sentinel in one transaction, so a crash or a
+// concurrent push never sees rows without the metadata that retires them.
+func storeCatalog(database *db.DB, catalog pricing.Catalog) error {
+	value, err := database.GetPricingMeta(pricing.OpenRouterModelsMetaKey)
+	if err != nil {
+		return err
+	}
+	previous, err := pricing.DecodeOpenRouterModels(value)
+	if err != nil {
+		return err
+	}
+	existing, err := database.ListModelPricing(context.Background())
+	if err != nil {
+		return fmt.Errorf("listing stored pricing: %w", err)
+	}
+	stored := make([]string, 0, len(existing))
+	for _, row := range existing {
+		if !strings.HasPrefix(row.ModelPattern, "_") {
+			stored = append(stored, row.ModelPattern)
+		}
+	}
+	prices, owned, retired := catalog.Reconcile(stored, previous)
+	return database.ReconcileModelPricing(
+		dbModelPricing(prices), retired,
+		db.PricingMeta{
+			Key:   pricing.OpenRouterModelsMetaKey,
+			Value: pricing.EncodeOpenRouterModels(owned),
+		},
+	)
+}
+
+// storeFallback writes the embedded catalog over the stored table. Like
+// any non-OpenRouter source it outranks OpenRouter, so OpenRouter-owned
+// rows it covers under another spelling are retired and rows it lists
+// exactly pass to its ownership, in the same transaction, so a reseed
+// never leaves an OpenRouter row beside or under an embedded one while
+// the sentinel still claims it. Databases that never stored the sentinel
+// keep none.
+func storeFallback(database *db.DB) error {
+	value, err := database.GetPricingMeta(pricing.OpenRouterModelsMetaKey)
+	if err != nil {
+		return err
+	}
+	previous, err := pricing.DecodeOpenRouterModels(value)
+	if err != nil {
+		return err
+	}
+	fallback := pricing.FallbackPricing()
+	patterns := make([]string, len(fallback))
+	for i, p := range fallback {
+		patterns[i] = p.ModelPattern
+	}
+	retired := pricing.ShadowedPatterns(patterns, previous)
+	var owned []string
+	for _, pattern := range previous {
+		if !slices.Contains(patterns, pattern) &&
+			!slices.Contains(retired, pattern) {
+			owned = append(owned, pattern)
+		}
+	}
+	var meta db.PricingMeta
+	if value != "" {
+		meta = db.PricingMeta{
+			Key:   pricing.OpenRouterModelsMetaKey,
+			Value: pricing.EncodeOpenRouterModels(owned),
+		}
+	}
+	return database.ReconcileModelPricing(
+		dbModelPricing(fallback), retired, meta,
+	)
+}
+
+func dbModelPricing(prices []pricing.ModelPricing) []db.ModelPricing {
 	dbPrices := make([]db.ModelPricing, len(prices))
 	for i, price := range prices {
 		bands := make([]db.PricingBand, len(price.Bands))
@@ -263,5 +339,5 @@ func upsert(database *db.DB, prices []pricing.ModelPricing) error {
 			Bands:                bands,
 		}
 	}
-	return database.UpsertModelPricing(dbPrices)
+	return dbPrices
 }

--- a/internal/pricingrefresh/refresh.go
+++ b/internal/pricingrefresh/refresh.go
@@ -97,6 +97,9 @@ func SeedFallback(database *db.DB) error {
 }
 
 // RefreshIfStale refreshes when the last attempt is older than cooldown.
+// It can refresh and return an error at once: a fetch that degraded to a
+// LiteLLM-only snapshot (see pricing.FetchCatalog) still stores rows and
+// reports true, and the error describes the degradation.
 func RefreshIfStale(
 	database *db.DB,
 	fetch func() (pricing.Catalog, error),
@@ -128,14 +131,14 @@ func refreshAt(
 			"recording pricing refresh attempt: %w", err,
 		)
 	}
-	catalog, err := fetch()
-	if err != nil {
-		return false, err
+	catalog, fetchErr := fetch()
+	if fetchErr != nil && len(catalog.LiteLLM) == 0 {
+		return false, fetchErr
 	}
 	if err := storeCatalog(database, catalog); err != nil {
 		return false, err
 	}
-	return true, nil
+	return true, fetchErr
 }
 
 // Ensure seeds fallback pricing and refreshes online catalogs when due.
@@ -247,6 +250,14 @@ func runCurrent(
 // pricing.Catalog.Reconcile) and writes rows, retirements, and the
 // OpenRouter ownership sentinel in one transaction, so a crash or a
 // concurrent push never sees rows without the metadata that retires them.
+//
+// The sentinel and stored patterns are read before that transaction, and
+// the in-process refresh gate does not cover a second process on the
+// same archive (server loop beside a CLI refresh), so racing refreshes
+// can commit a plan built from a one-snapshot-stale read. The next
+// refresh recomputes ownership from the stored table and converges:
+// retiring an already-deleted row is a no-op and a re-listed pattern is
+// re-adopted.
 func storeCatalog(database *db.DB, catalog pricing.Catalog) error {
 	value, err := database.GetPricingMeta(pricing.OpenRouterModelsMetaKey)
 	if err != nil {

--- a/internal/pricingrefresh/refresh_test.go
+++ b/internal/pricingrefresh/refresh_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -24,9 +25,9 @@ type fetchRecorder struct {
 	err   error
 }
 
-func (f *fetchRecorder) fetch() ([]pricing.ModelPricing, error) {
+func (f *fetchRecorder) fetch() (pricing.Catalog, error) {
 	f.calls++
-	return f.rows, f.err
+	return pricing.Catalog{LiteLLM: f.rows}, f.err
 }
 
 func TestEnsureSeedsFallbackAndFetchedModel(t *testing.T) {
@@ -209,9 +210,9 @@ func TestEnsureSkipsFetchWithinCooldown(t *testing.T) {
 
 func TestEnsureOfflineSeedsFallbackWithoutFetch(t *testing.T) {
 	database := testDB(t)
-	fetch := func() ([]pricing.ModelPricing, error) {
+	fetch := func() (pricing.Catalog, error) {
 		t.Fatal("offline ensure must not fetch")
-		return nil, nil
+		return pricing.Catalog{}, nil
 	}
 
 	refreshed, err := Ensure(database, true, fetch, pricingTestNow())
@@ -223,6 +224,101 @@ func TestEnsureOfflineSeedsFallbackWithoutFetch(t *testing.T) {
 	require.NotNil(t, fallback)
 }
 
+func TestStoreCatalogRetiresShadowedOpenRouterRows(t *testing.T) {
+	database := testDB(t)
+	// A stale row from an earlier LiteLLM catalog that the live catalog
+	// no longer lists.
+	require.NoError(t, database.UpsertModelPricing([]db.ModelPricing{{
+		ModelPattern: "acme/Stale-Model",
+		InputPerMTok: money.MustParseDollars("1"),
+	}}))
+	openrouter := []pricing.ModelPricing{
+		{
+			ModelPattern: "minimax/minimax-m3",
+			InputPerMTok: money.MustParseDollars("9"),
+		},
+		{
+			ModelPattern: "acme/stale-model",
+			InputPerMTok: money.MustParseDollars("8"),
+		},
+	}
+	require.NoError(t, storeCatalog(database, pricing.Catalog{
+		OpenRouter: openrouter,
+	}))
+	meta, err := database.GetPricingMeta(pricing.OpenRouterModelsMetaKey)
+	require.NoError(t, err)
+	assert.Equal(t, `["minimax/minimax-m3"]`, meta,
+		"stored row from another source shadows OpenRouter's spelling")
+	shadowed, err := database.GetModelPricing("acme/stale-model")
+	require.NoError(t, err)
+	assert.Nil(t, shadowed)
+
+	// LiteLLM now lists the model under its own spelling.
+	require.NoError(t, storeCatalog(database, pricing.Catalog{
+		LiteLLM: []pricing.ModelPricing{{
+			ModelPattern: "minimax/MiniMax-M3",
+			InputPerMTok: money.MustParseDollars("2"),
+		}},
+		OpenRouter: openrouter,
+	}))
+
+	stale, err := database.GetModelPricing("minimax/minimax-m3")
+	require.NoError(t, err)
+	assert.Nil(t, stale, "shadowed OpenRouter row retired")
+	current, err := database.GetModelPricing("minimax/MiniMax-M3")
+	require.NoError(t, err)
+	require.NotNil(t, current)
+	assert.Equal(t, money.MustParseDollars("2"), current.InputPerMTok)
+	meta, err = database.GetPricingMeta(pricing.OpenRouterModelsMetaKey)
+	require.NoError(t, err)
+	assert.Equal(t, `[]`, meta)
+}
+
+func TestStoreFallbackReconcilesOpenRouterOwnership(t *testing.T) {
+	database := testDB(t)
+	fallback := pricing.FallbackPricing()
+	require.NotEmpty(t, fallback)
+	exact := fallback[0].ModelPattern
+	var spelled string
+	for _, p := range fallback {
+		if upper := strings.ToUpper(p.ModelPattern); upper != p.ModelPattern {
+			spelled = upper
+			break
+		}
+	}
+	require.NotEmpty(t, spelled, "need a fallback pattern with lowercase")
+	require.NoError(t, storeCatalog(database, pricing.Catalog{
+		OpenRouter: []pricing.ModelPricing{
+			{ModelPattern: exact, InputPerMTok: money.MustParseDollars("99")},
+			{ModelPattern: spelled, InputPerMTok: money.MustParseDollars("98")},
+			{ModelPattern: "acme/only-openrouter"},
+		},
+	}))
+
+	require.NoError(t, SeedFallback(database))
+
+	shadowed, err := database.GetModelPricing(spelled)
+	require.NoError(t, err)
+	assert.Nil(t, shadowed, "OpenRouter spelling of a seeded model retired")
+	seeded, err := database.GetModelPricing(exact)
+	require.NoError(t, err)
+	require.NotNil(t, seeded)
+	assert.Equal(t, fallback[0].InputPerMTok, seeded.InputPerMTok,
+		"embedded rate wins on the exact pattern")
+	meta, err := database.GetPricingMeta(pricing.OpenRouterModelsMetaKey)
+	require.NoError(t, err)
+	assert.Equal(t, `["acme/only-openrouter"]`, meta,
+		"ownership of seeded and retired patterns transferred")
+}
+
+func TestSeedFallbackWithoutSentinelWritesNone(t *testing.T) {
+	database := testDB(t)
+	require.NoError(t, SeedFallback(database))
+	meta, err := database.GetPricingMeta(pricing.OpenRouterModelsMetaKey)
+	require.NoError(t, err)
+	assert.Empty(t, meta)
+}
+
 func TestEnsureCurrentCancellationAllowsImmediateRetry(t *testing.T) {
 	database := testDB(t)
 	now := pricingTestNow()
@@ -231,9 +327,9 @@ func TestEnsureCurrentCancellationAllowsImmediateRetry(t *testing.T) {
 
 	err := ensureCurrent(ctx, database, func(
 		context.Context,
-	) ([]pricing.ModelPricing, error) {
+	) (pricing.Catalog, error) {
 		cancel()
-		return nil, ctx.Err()
+		return pricing.Catalog{}, ctx.Err()
 	}, now)
 
 	assert.ErrorIs(t, err, context.Canceled)
@@ -241,9 +337,9 @@ func TestEnsureCurrentCancellationAllowsImmediateRetry(t *testing.T) {
 	retryCalls := 0
 	err = ensureCurrent(context.Background(), database, func(
 		context.Context,
-	) ([]pricing.ModelPricing, error) {
+	) (pricing.Catalog, error) {
 		retryCalls++
-		return nil, nil
+		return pricing.Catalog{}, nil
 	}, now.Add(time.Minute))
 
 	require.NoError(t, err)
@@ -257,10 +353,10 @@ func TestRefreshCurrentFetchesDespiteRecentAttempt(t *testing.T) {
 
 	err := refreshCurrent(context.Background(), database, func(
 		context.Context,
-	) ([]pricing.ModelPricing, error) {
-		return []pricing.ModelPricing{{
+	) (pricing.Catalog, error) {
+		return pricing.Catalog{LiteLLM: []pricing.ModelPricing{{
 			ModelPattern: "scheduled-model",
-		}}, nil
+		}}}, nil
 	}, now)
 
 	require.NoError(t, err)
@@ -280,12 +376,12 @@ func TestRefreshCurrentSkipsWhileEnsureCurrentInFlight(t *testing.T) {
 	go func() {
 		ensureDone <- ensureCurrent(context.Background(), database, func(
 			context.Context,
-		) ([]pricing.ModelPricing, error) {
+		) (pricing.Catalog, error) {
 			close(ensureFetchStarted)
 			<-releaseEnsureFetch
-			return []pricing.ModelPricing{{
+			return pricing.Catalog{LiteLLM: []pricing.ModelPricing{{
 				ModelPattern: "ensure-model",
-			}}, nil
+			}}}, nil
 		}, now)
 	}()
 	defer func() {
@@ -307,11 +403,11 @@ func TestRefreshCurrentSkipsWhileEnsureCurrentInFlight(t *testing.T) {
 		refreshDone <- refreshCurrent(
 			context.Background(), database, func(
 				context.Context,
-			) ([]pricing.ModelPricing, error) {
+			) (pricing.Catalog, error) {
 				refreshFetchCalls.Add(1)
-				return []pricing.ModelPricing{{
+				return pricing.Catalog{LiteLLM: []pricing.ModelPricing{{
 					ModelPattern: "scheduled-model",
-				}}, nil
+				}}}, nil
 			}, now.Add(time.Minute),
 		)
 	}()

--- a/internal/pricingrefresh/refresh_test.go
+++ b/internal/pricingrefresh/refresh_test.go
@@ -169,6 +169,31 @@ func TestRefreshIfStaleFetchFailureRecordsAttempt(t *testing.T) {
 	assert.Zero(t, second.calls)
 }
 
+func TestRefreshIfStaleStoresDegradedCatalog(t *testing.T) {
+	database := testDB(t)
+	wantErr := errors.New("openrouter down")
+	fetcher := &fetchRecorder{
+		rows: []pricing.ModelPricing{{
+			ModelPattern:  "degraded-model",
+			InputPerMTok:  money.MustParseDollars("1"),
+			OutputPerMTok: money.MustParseDollars("2"),
+		}},
+		err: wantErr,
+	}
+
+	refreshed, err := RefreshIfStale(
+		database, fetcher.fetch, time.Hour, pricingTestNow(),
+	)
+
+	assert.ErrorIs(t, err, wantErr,
+		"the degradation is reported alongside the refresh")
+	assert.True(t, refreshed)
+	stored, priceErr := database.GetModelPricing("degraded-model")
+	require.NoError(t, priceErr)
+	require.NotNil(t, stored, "LiteLLM rows stored despite the error")
+	assert.Equal(t, money.MustParseDollars("1"), stored.InputPerMTok)
+}
+
 func TestEnsureFetchFailurePreservesFallback(t *testing.T) {
 	database := testDB(t)
 	wantErr := errors.New("network down")


### PR DESCRIPTION
Adds OpenRouter's public model catalog as a second pricing source under LiteLLM.

`pricing.FetchCatalog` fetches LiteLLM and OpenRouter together; if either fetch fails, the last stored catalog is kept. `pricingrefresh` drives every refresh through it, so the `usage` CLI, the statusline, and the server's existing daily refresh loop all pick up OpenRouter with no separate code path.

At store time, `Catalog.Reconcile` merges the snapshot over the stored table: an OpenRouter row is dropped when the LiteLLM catalog, or any stored row from another source (LiteLLM, embedded, supplemental), already lists the same canonical model name under any spelling or provider prefix. Adding OpenRouter therefore never changes a lookup that already resolved, and two spellings of one model never tie in the resolver. Rows are copied whole (a zero rate is a valid free-model price, so nothing is backfilled across sources), and no bare aliases are emitted because the resolver already matches a bare session name against a lone qualified key.

A single sentinel row, `_openrouter_models`, records which stored rows came from OpenRouter. A later refresh or fallback reseed retires a tracked row once another source covers its model under a different spelling, transfers ownership of exact patterns, and keeps rows OpenRouter merely delisted so old sessions stay priced. `db.ReconcileModelPricing` applies the deletes, upserts, and sentinel in one transaction.

`db.PlanModelPricingSync` gives the PostgreSQL and DuckDB pushes the same rules in both directions: a local OpenRouter row is withheld when a target row from another source already covers its model, a target-owned row is removed only when the local catalog covers its model under a different spelling, and target and local ownership are merged so no machine strips ownership another machine recorded on a shared target. PostgreSQL runs the read, plan, and write in one transaction under a schema-scoped advisory lock so concurrent pushes cannot overwrite each other's merged ownership. Sentinel rows compare by value in `FilterChangedModelPricing`; PostgreSQL writes them through a dedicated statement because their `updated_at` is not a timestamp, and DuckDB commits band deletes before parent deletes because it rejects both in one transaction.

The OpenRouter parser produces microdollar rates, keeps text-output models (including multimodal-input models), and skips negative or malformed entries per row so a single odd upstream entry cannot block the whole refresh.

Docs: pricing-source, `--offline`, and privacy sections describe the two catalogs and their precedence.

Reviewers: `internal/pricing/openrouter.go` (`Catalog.Reconcile`, `ShadowedPatterns`), `internal/pricingrefresh/refresh.go` (`storeCatalog`), `internal/db/pricing.go` and `pricing_sync.go`, and the push changes in `internal/postgres/pricing.go` and `internal/duckdb/push.go`.


