### PR TITLE
feat(frontend): collapse Calls detail in analysis

### DIFF
--- a/docs/superpowers/plans/2026-07-22-collapsible-calls-detail.md
+++ b/docs/superpowers/plans/2026-07-22-collapsible-calls-detail.md
@@ -343,7 +343,7 @@ Calls becomes a button.
 ```ts
 const headers = page
   .locator(".v-section .v-h")
-  .filter({ hasText: /^(Session|Time spent|Timeline|Calls)/ });
+  .filter({ hasText: /(Session|Time spent|Timeline|Calls)/ });
 await expect(headers).toHaveCount(4);
 ```
 

--- a/docs/superpowers/plans/2026-07-22-collapsible-calls-detail.md
+++ b/docs/superpowers/plans/2026-07-22-collapsible-calls-detail.md
@@ -1,0 +1,394 @@
+# Collapsible Calls Detail Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an accessible disclosure control to the session analysis Calls
+section and persist its expanded state across sessions and reloads.
+
+**Architecture:** Extend the existing global `UIStore` with one boolean
+preference, initialized and persisted through the store's guarded LocalStorage
+pattern. Bind the Calls header in `SessionVitals.svelte` to that preference and
+conditionally render only the detail body, leaving the localized section label
+and summary visible in both states.
+
+**Tech Stack:** Svelte 5 runes, TypeScript, Vitest/Vite+, Testing Library,
+Paraglide messages, Lucide Svelte icons.
+
+## Global Constraints
+
+- The disclosure defaults to expanded when no valid preference exists.
+- The preference is global to the analysis sidebar, not scoped to a session.
+- The collapsed header retains the existing localized Calls summary.
+- No new user-facing copy or locale message keys are introduced.
+- The control is keyboard reachable, exposes `aria-expanded`, and has a visible
+  focus state.
+- Tests assert rendered behavior and the owned LocalStorage boundary.
+
+______________________________________________________________________
+
+### Task 1: Persisted Calls Disclosure
+
+**Files:**
+
+- Modify: `frontend/src/lib/stores/ui.svelte.ts`
+- Modify: `frontend/src/lib/stores/ui.test.ts`
+- Modify: `frontend/src/lib/components/content/SessionVitals.svelte`
+- Modify: `frontend/src/lib/components/content/SessionVitals.test.ts`
+- Modify: `frontend/e2e/session-timing.spec.ts`
+
+**Interfaces:**
+
+- Consumes: existing `readStoredBool(key, fallback)`, `UIStore` persistence
+  effects, `m.session_vitals_calls()`, and
+  `m.session_vitals_calls_summary(...)`.
+
+- Produces: `ui.vitalsCallsExpanded: boolean` and
+  `ui.toggleVitalsCalls(): void`, consumed by `SessionVitals.svelte`.
+
+- [ ] **Step 1: Add failing store tests for restoration and persistence**
+
+Add a `describe("Calls detail preference", ...)` block to
+`frontend/src/lib/stores/ui.test.ts`. The restoration test imports a fresh store
+module with `agentsview-session-vitals-calls-expanded` seeded to `"false"` and
+expects `vitalsCallsExpanded` to be false. The persistence test toggles a fresh
+store instance and expects the key to be written as `"false"`.
+
+```ts
+describe("Calls detail preference", () => {
+  it("restores a collapsed Calls detail preference", async () => {
+    const original = globalThis.localStorage;
+    const setItem = vi.fn();
+    Object.defineProperty(globalThis, "localStorage", {
+      value: {
+        getItem: vi.fn((key: string) =>
+          key === "agentsview-session-vitals-calls-expanded" ? "false" : null,
+        ),
+        setItem,
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    try {
+      // @ts-expect-error -- query string busts module cache
+      const mod = await import("./ui.svelte.js?vitalsCallsCollapsed");
+      expect(mod.ui.vitalsCallsExpanded).toBe(false);
+    } finally {
+      Object.defineProperty(globalThis, "localStorage", {
+        value: original,
+        writable: true,
+        configurable: true,
+      });
+    }
+  });
+
+  it("persists Calls detail changes", async () => {
+    const original = globalThis.localStorage;
+    const setItem = vi.fn();
+    Object.defineProperty(globalThis, "localStorage", {
+      value: { getItem: vi.fn(() => null), setItem },
+      writable: true,
+      configurable: true,
+    });
+
+    try {
+      // @ts-expect-error -- query string busts module cache
+      const mod = await import("./ui.svelte.js?vitalsCallsPersist");
+      setItem.mockClear();
+      mod.ui.toggleVitalsCalls();
+      await tick();
+      expect(mod.ui.vitalsCallsExpanded).toBe(false);
+      expect(setItem).toHaveBeenCalledWith(
+        "agentsview-session-vitals-calls-expanded",
+        "false",
+      );
+    } finally {
+      Object.defineProperty(globalThis, "localStorage", {
+        value: original,
+        writable: true,
+        configurable: true,
+      });
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run the store tests and verify the expected failure**
+
+Run:
+
+```bash
+cd frontend
+npm test -- src/lib/stores/ui.test.ts
+```
+
+Expected: FAIL because `vitalsCallsExpanded` and `toggleVitalsCalls` do not yet
+exist.
+
+- [ ] **Step 3: Add the failing component disclosure test**
+
+In `frontend/src/lib/components/content/SessionVitals.test.ts`, reset
+`ui.vitalsCallsExpanded = true` in `beforeEach`. Add a concrete timing fixture
+with one Bash call, render the component, and assert the disclosure's observable
+behavior.
+
+```ts
+it("collapses and restores the Calls detail while keeping its summary", async () => {
+  mocks.fetchSessionTiming.mockResolvedValue(timingWithCall());
+  component = mount(SessionVitals, {
+    target: document.body,
+    props: { sessionId: "sess-1" },
+  });
+  await tick();
+  await tick();
+
+  const disclosure = document.querySelector<HTMLButtonElement>(
+    `button[aria-expanded="true"]`,
+  );
+  expect(disclosure).not.toBeNull();
+  expect(disclosure?.textContent).toContain(m.session_vitals_calls());
+  expect(document.querySelector(".scale-axis")).not.toBeNull();
+  expect(document.querySelector(".calls")).not.toBeNull();
+
+  disclosure!.click();
+  await tick();
+
+  expect(disclosure?.getAttribute("aria-expanded")).toBe("false");
+  expect(disclosure?.textContent).toContain(
+    m.session_vitals_calls_summary({
+      count: 1,
+      countLabel: "1",
+      runningCount: 0,
+    }),
+  );
+  expect(document.querySelector(".scale-axis")).toBeNull();
+  expect(document.querySelector(".calls")).toBeNull();
+
+  disclosure!.click();
+  await tick();
+
+  expect(disclosure?.getAttribute("aria-expanded")).toBe("true");
+  expect(document.querySelector(".scale-axis")).not.toBeNull();
+  expect(document.querySelector(".calls")).not.toBeNull();
+});
+
+function timingWithCall(): SessionTiming {
+  return {
+    ...mocks.timing,
+    tool_duration_ms: 400,
+    tool_call_count: 1,
+    turns: [
+      {
+        message_id: 1,
+        ordinal: 1,
+        started_at: "2026-07-14T12:00:00Z",
+        duration_ms: 400,
+        primary_category: "Bash",
+        calls: [
+          {
+            tool_use_id: "call-1",
+            tool_name: "Bash",
+            category: "Bash",
+            duration_ms: 400,
+            is_parallel: false,
+            input_preview: "go test ./...",
+          },
+        ],
+      },
+    ],
+  };
+}
+```
+
+- [ ] **Step 4: Run the component test and verify the expected failure**
+
+Run:
+
+```bash
+cd frontend
+npm test -- src/lib/components/content/SessionVitals.test.ts
+```
+
+Expected: FAIL because the Calls header is not a disclosure button and the
+detail remains rendered after activation.
+
+- [ ] **Step 5: Implement the persisted UI-store preference**
+
+In `frontend/src/lib/stores/ui.svelte.ts`, add the storage key beside the other
+analysis-panel keys, initialize the state with an expanded fallback, persist it
+in the constructor, and expose the toggle.
+
+```ts
+const VITALS_CALLS_EXPANDED_KEY =
+  "agentsview-session-vitals-calls-expanded";
+
+vitalsCallsExpanded: boolean = $state(
+  readStoredBool(VITALS_CALLS_EXPANDED_KEY, true),
+);
+
+$effect(() => {
+  try {
+    localStorage?.setItem(
+      VITALS_CALLS_EXPANDED_KEY,
+      String(this.vitalsCallsExpanded),
+    );
+  } catch {
+    // ignore
+  }
+});
+
+toggleVitalsCalls() {
+  this.vitalsCallsExpanded = !this.vitalsCallsExpanded;
+}
+```
+
+- [ ] **Step 6: Implement the Calls disclosure UI**
+
+Import `ChevronRightIcon` in `SessionVitals.svelte`. Replace the Calls header
+contents with a full-width button bound to the global preference, and render the
+axis and rows only while expanded.
+
+```svelte
+<header class="v-h calls-header" class:expanded={ui.vitalsCallsExpanded}>
+  <button
+    type="button"
+    class="calls-disclosure"
+    aria-expanded={ui.vitalsCallsExpanded}
+    onclick={() => ui.toggleVitalsCalls()}
+  >
+    <span class="calls-heading">
+      <span class="calls-chevron" class:open={ui.vitalsCallsExpanded}>
+        <ChevronRightIcon size="10" strokeWidth="2.4" aria-hidden="true" />
+      </span>
+      <span>{m.session_vitals_calls()}</span>
+    </span>
+    <span class="v-meta">
+      {m.session_vitals_calls_summary({
+        count: timing.tool_call_count,
+        countLabel: formatNumber(timing.tool_call_count),
+        runningCount: timing.running ? 1 : 0,
+      })}
+    </span>
+  </button>
+</header>
+{#if ui.vitalsCallsExpanded}
+  <!-- existing scale axis and calls list -->
+{/if}
+```
+
+Add scoped styles that preserve the existing header layout while making the full
+row interactive.
+
+```css
+.calls-header {
+  margin-bottom: 0;
+}
+
+.calls-disclosure {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: calc(100% + 8px);
+  padding: 2px 4px;
+  margin: -2px -4px;
+  border-radius: var(--radius-sm);
+  color: inherit;
+  text-align: left;
+  transition: background 0.12s;
+}
+
+.calls-header.expanded {
+  margin-bottom: 9px;
+}
+
+.calls-disclosure:hover {
+  background: var(--bg-surface-hover);
+}
+
+.calls-disclosure:focus-visible {
+  outline: 2px solid var(--accent-blue);
+  outline-offset: 2px;
+}
+
+.calls-heading,
+.calls-chevron {
+  display: inline-flex;
+  align-items: center;
+}
+
+.calls-heading {
+  gap: 4px;
+}
+
+.calls-chevron {
+  transition: transform 0.15s ease-out;
+}
+
+.calls-chevron.open {
+  transform: rotate(90deg);
+}
+```
+
+- [ ] **Step 7: Keep the existing section-count E2E assertion semantic**
+
+Update `frontend/e2e/session-timing.spec.ts` so the section-header assertion
+selects the four `.v-h` elements instead of assuming every header's first child
+is a text-only span. This preserves the existing user-visible assertion after
+Calls becomes a button.
+
+```ts
+const headers = page
+  .locator(".v-section .v-h")
+  .filter({ hasText: /^(Session|Time spent|Timeline|Calls)/ });
+await expect(headers).toHaveCount(4);
+```
+
+- [ ] **Step 8: Run the focused tests and verify they pass**
+
+Run:
+
+```bash
+cd frontend
+npm test -- src/lib/stores/ui.test.ts src/lib/components/content/SessionVitals.test.ts
+```
+
+Expected: 2 test files pass with no failures.
+
+- [ ] **Step 9: Run frontend validation**
+
+Run:
+
+```bash
+cd frontend
+npm run check
+npm run check:kit-ui
+npm test
+```
+
+Expected: Svelte/TypeScript and kit-ui checks pass and all frontend tests pass.
+
+- [ ] **Step 10: Run the focused Playwright spec when the local E2E harness is
+  available**
+
+Run:
+
+```bash
+cd frontend
+npm run e2e -- session-timing.spec.ts
+```
+
+Expected: the Session Vital Signs spec passes. If the local E2E harness cannot
+start, report the exact blocker instead of weakening or skipping assertions.
+
+- [ ] **Step 11: Review and commit the implementation**
+
+Review `git diff --check`, `git status --short`, `git diff --stat`, and
+`git diff HEAD`. Stage only the five implementation/test files and commit with:
+
+```bash
+git commit -m "feat(frontend): collapse Calls detail in analysis"
+```

--- a/docs/superpowers/specs/2026-07-21-collapsible-calls-detail-design.md
+++ b/docs/superpowers/specs/2026-07-21-collapsible-calls-detail-design.md
@@ -1,0 +1,66 @@
+# Collapsible Calls Detail Design
+
+## Goal
+
+Let users reclaim vertical space in the session analysis sidebar by collapsing
+the detailed Calls visualization, while keeping the section summary visible and
+remembering the preference across sessions and reloads.
+
+## Interaction
+
+The existing Calls section header becomes a full-width disclosure button. A
+small right-pointing chevron appears before the Calls label and rotates downward
+when expanded. The call-count summary remains aligned at the opposite edge in
+both states.
+
+Activating the header toggles the detail body, which contains the time axis and
+the call rows. The section itself remains visible when collapsed, so users can
+still see the total call count and restore the detail without searching for a
+separate control.
+
+The disclosure defaults to expanded when no preference has been stored. The
+choice is global to the analysis sidebar rather than session-specific: moving
+between sessions and reloading the app preserves the most recent state.
+
+## Visual Treatment
+
+The control reuses the sidebar's existing compact section typography, spacing,
+colors, and Lucide chevron vocabulary. Hover and keyboard-focus states cover the
+full header target. The implementation does not add a card, extra text action,
+or decorative animation. The only motion is the short chevron rotation that
+communicates disclosure state.
+
+## Accessibility
+
+The header is a semantic button with `aria-expanded` reflecting whether the
+detail body is visible. Its accessible name comes from the localized Calls label
+and existing localized summary. The chevron is decorative and hidden from
+assistive technology. The control remains keyboard reachable and has a visible
+focus indicator.
+
+## Persistence
+
+The global UI store owns a boolean Calls-expanded preference and persists it to
+LocalStorage using an `agentsview-` namespaced key. Stored `"true"` and
+`"false"` values are accepted; missing, invalid, or unavailable storage falls
+back to expanded. Storage failures do not prevent the disclosure from working
+for the current page lifetime.
+
+## Testing
+
+Component coverage will verify the user-visible contract: Calls details render
+by default, activating the disclosure hides the axis and rows while retaining
+the summary, `aria-expanded` changes with the state, and activating it again
+restores the detail.
+
+Store coverage will verify that a persisted collapsed value is restored and that
+toggling the preference writes the corresponding boolean string. Tests will
+assert rendered behavior and the owned persistence boundary, not Svelte or
+LocalStorage implementation mechanics.
+
+## Alternatives Considered
+
+An icon-only button would be visually lighter but would provide a smaller and
+less obvious target. A separate Show/Hide text action would be explicit but add
+noise to an already dense header. Making the full header interactive provides
+the clearest affordance and largest target without increasing visual density.

--- a/frontend/e2e/session-timing.spec.ts
+++ b/frontend/e2e/session-timing.spec.ts
@@ -40,12 +40,12 @@ test.describe("Session Vital Signs", () => {
   test("renders all four sections", async ({ page }) => {
     await gotoShowcase(page);
 
-    // Section headers live inside `.v-h > span` (text-only spans),
-    // not semantic <h*> headings, so we match by text on .v-h
-    // instead of the plan-sketch's `getByRole("heading")`.
+    // Section labels are not semantic headings, so match the compact
+    // section-header rows. Calls uses a disclosure button while the other
+    // sections keep text-only labels.
     const headers = page
-      .locator(".v-section .v-h > span:first-child")
-      .filter({ hasText: /^(Session|Time spent|Timeline|Calls)$/ });
+      .locator(".v-section .v-h")
+      .filter({ hasText: /(Session|Time spent|Timeline|Calls)/ });
     await expect(headers).toHaveCount(4);
 
     await expect(

--- a/frontend/src/lib/components/content/SessionVitals.svelte
+++ b/frontend/src/lib/components/content/SessionVitals.svelte
@@ -22,7 +22,7 @@
   import CallRow from "./CallRow.svelte";
   import CallGroup from "./CallGroup.svelte";
   import SubagentCalls from "./SubagentCalls.svelte";
-  import { XIcon } from "../../icons.js";
+  import { ChevronRightIcon, XIcon } from "../../icons.js";
   import { LatestRead } from "../../utils/latest-read.js";
   import type { Session } from "../../api/types/core.js";
 
@@ -526,99 +526,123 @@
 
     {#if timing.turns.length > 0}
       <section class="v-section">
-        <header class="v-h">
-          <span>{m.session_vitals_calls()}</span>
-          <span class="v-meta">
-            {m.session_vitals_calls_summary({
-              count: timing.tool_call_count,
-              countLabel: formatNumber(timing.tool_call_count),
-              runningCount: timing.running ? 1 : 0,
-            })}
-          </span>
+        <header
+          class="v-h calls-header"
+          class:expanded={ui.vitalsCallsExpanded}
+        >
+          <button
+            type="button"
+            class="calls-disclosure"
+            aria-expanded={ui.vitalsCallsExpanded}
+            onclick={() => ui.toggleVitalsCalls()}
+          >
+            <span class="calls-heading">
+              <span
+                class="calls-chevron"
+                class:open={ui.vitalsCallsExpanded}
+              >
+                <ChevronRightIcon
+                  size="10"
+                  strokeWidth="2.4"
+                  aria-hidden="true"
+                />
+              </span>
+              <span>{m.session_vitals_calls()}</span>
+            </span>
+            <span class="v-meta">
+              {m.session_vitals_calls_summary({
+                count: timing.tool_call_count,
+                countLabel: formatNumber(timing.tool_call_count),
+                runningCount: timing.running ? 1 : 0,
+              })}
+            </span>
+          </button>
         </header>
-        <div class="scale-axis">
-          <span>0</span>
-          <span>{formatDuration(timing.total_duration_ms / 4)}</span>
-          <span>{formatDuration(timing.total_duration_ms / 2)}</span>
-          <span
-            >{formatDuration(
-              (3 * timing.total_duration_ms) / 4,
-            )}</span
-          >
-          <span class:now={timing.running}
-            >{timing.running
-              ? m.session_vitals_now()
-              : formatDuration(timing.total_duration_ms)}</span
-          >
-        </div>
-        <div class="calls">
-          {#each timing.turns as turn (turn.message_id)}
-            {@const isLive =
-              turn.duration_ms == null &&
-              isLastTurn(turn) &&
-              !!timing.running}
-            {@const liveElapsed = isLive ? liveElapsedFor(turn) : undefined}
-            {#if turn.calls.length === 1}
-              {@const call = turn.calls[0]!}
-              <CallRow
-                {call}
-                barWidthPct={callBarPct(call, timing)}
-                isSlow={isSlowCall(call)}
-                {isLive}
-                liveDurationMs={liveElapsed}
-                dimmed={categoryFilter !== null &&
-                  call.category !== categoryFilter}
-                isSubagentExpanded={!!call.subagent_session_id &&
-                  expandedSubagentIds.has(call.subagent_session_id)}
-                onClick={() => ui.scrollToOrdinal(turn.ordinal)}
-                onChevronClick={() => {
-                  void toggleSubagent(call);
-                }}
-              />
-              {#if call.subagent_session_id && expandedSubagentIds.has(call.subagent_session_id)}
-                {@const subT = subagentTimings.get(
-                  call.subagent_session_id,
-                )}
-                {#if subT}
-                  <SubagentCalls
-                    timing={subT}
-                    barScalePct={(c) => callBarPct(c, subT)}
-                    {categoryFilter}
-                  />
+        {#if ui.vitalsCallsExpanded}
+          <div class="scale-axis">
+            <span>0</span>
+            <span>{formatDuration(timing.total_duration_ms / 4)}</span>
+            <span>{formatDuration(timing.total_duration_ms / 2)}</span>
+            <span
+              >{formatDuration(
+                (3 * timing.total_duration_ms) / 4,
+              )}</span
+            >
+            <span class:now={timing.running}
+              >{timing.running
+                ? m.session_vitals_now()
+                : formatDuration(timing.total_duration_ms)}</span
+            >
+          </div>
+          <div class="calls">
+            {#each timing.turns as turn (turn.message_id)}
+              {@const isLive =
+                turn.duration_ms == null &&
+                isLastTurn(turn) &&
+                !!timing.running}
+              {@const liveElapsed = isLive ? liveElapsedFor(turn) : undefined}
+              {#if turn.calls.length === 1}
+                {@const call = turn.calls[0]!}
+                <CallRow
+                  {call}
+                  barWidthPct={callBarPct(call, timing)}
+                  isSlow={isSlowCall(call)}
+                  {isLive}
+                  liveDurationMs={liveElapsed}
+                  dimmed={categoryFilter !== null &&
+                    call.category !== categoryFilter}
+                  isSubagentExpanded={!!call.subagent_session_id &&
+                    expandedSubagentIds.has(call.subagent_session_id)}
+                  onClick={() => ui.scrollToOrdinal(turn.ordinal)}
+                  onChevronClick={() => {
+                    void toggleSubagent(call);
+                  }}
+                />
+                {#if call.subagent_session_id && expandedSubagentIds.has(call.subagent_session_id)}
+                  {@const subT = subagentTimings.get(
+                    call.subagent_session_id,
+                  )}
+                  {#if subT}
+                    <SubagentCalls
+                      timing={subT}
+                      barScalePct={(c) => callBarPct(c, subT)}
+                      {categoryFilter}
+                    />
+                  {/if}
                 {/if}
+              {:else}
+                <CallGroup
+                  calls={turn.calls}
+                  groupDurationMs={turn.duration_ms}
+                  barScalePct={(c) => callBarPct(c, timing)}
+                  headerBarPct={turnHeaderBarPct(turn, timing)}
+                  {isLive}
+                  liveDurationMs={liveElapsed}
+                  isSlow={isSlowCall}
+                  dimmed={categoryFilter !== null &&
+                    turn.primary_category !== categoryFilter}
+                  onCallClick={() => ui.scrollToOrdinal(turn.ordinal)}
+                  onSubagentExpand={(c) => {
+                    void toggleSubagent(c);
+                  }}
+                  {expandedSubagentIds}
+                />
+                {#each turn.calls.filter((c) => !!c.subagent_session_id && expandedSubagentIds.has(c.subagent_session_id)) as expandedCall (expandedCall.tool_use_id)}
+                  {@const subT = subagentTimings.get(
+                    expandedCall.subagent_session_id!,
+                  )}
+                  {#if subT}
+                    <SubagentCalls
+                      timing={subT}
+                      barScalePct={(c) => callBarPct(c, subT)}
+                      {categoryFilter}
+                    />
+                  {/if}
+                {/each}
               {/if}
-            {:else}
-              <CallGroup
-                calls={turn.calls}
-                groupDurationMs={turn.duration_ms}
-                barScalePct={(c) => callBarPct(c, timing)}
-                headerBarPct={turnHeaderBarPct(turn, timing)}
-                {isLive}
-                liveDurationMs={liveElapsed}
-                isSlow={isSlowCall}
-                dimmed={categoryFilter !== null &&
-                  turn.primary_category !== categoryFilter}
-                onCallClick={() => ui.scrollToOrdinal(turn.ordinal)}
-                onSubagentExpand={(c) => {
-                  void toggleSubagent(c);
-                }}
-                {expandedSubagentIds}
-              />
-              {#each turn.calls.filter((c) => !!c.subagent_session_id && expandedSubagentIds.has(c.subagent_session_id)) as expandedCall (expandedCall.tool_use_id)}
-                {@const subT = subagentTimings.get(
-                  expandedCall.subagent_session_id!,
-                )}
-                {#if subT}
-                  <SubagentCalls
-                    timing={subT}
-                    barScalePct={(c) => callBarPct(c, subT)}
-                    {categoryFilter}
-                  />
-                {/if}
-              {/each}
-            {/if}
-          {/each}
-        </div>
+            {/each}
+          </div>
+        {/if}
       </section>
     {/if}
   {:else if sessionTiming.error}
@@ -952,6 +976,52 @@
   /* Calls section --------------------------------------------------- */
   /* Adapted from the session-duration UX mockup, with the raw colors mapped to
      theme tokens. */
+  .calls-header {
+    margin-bottom: 0;
+  }
+  .calls-header.expanded {
+    margin-bottom: 9px;
+  }
+  .calls-disclosure {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    width: calc(100% + 8px);
+    padding: 2px 4px;
+    margin: -2px -4px;
+    border: 0;
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    text-align: left;
+    text-transform: inherit;
+    letter-spacing: inherit;
+    cursor: pointer;
+    transition: background 0.12s;
+  }
+  .calls-disclosure:hover {
+    background: var(--bg-surface-hover);
+  }
+  .calls-disclosure:focus-visible {
+    outline: 2px solid var(--accent-blue);
+    outline-offset: 2px;
+  }
+  .calls-heading,
+  .calls-chevron {
+    display: inline-flex;
+    align-items: center;
+  }
+  .calls-heading {
+    gap: 4px;
+  }
+  .calls-chevron {
+    transition: transform 0.15s ease-out;
+  }
+  .calls-chevron.open {
+    transform: rotate(90deg);
+  }
   .scale-axis {
     display: flex;
     justify-content: space-between;

--- a/frontend/src/lib/components/content/SessionVitals.test.ts
+++ b/frontend/src/lib/components/content/SessionVitals.test.ts
@@ -328,7 +328,7 @@ describe("SessionVitals", () => {
     mocks.fetchSessionTiming.mockResolvedValue(timingWithCall());
     component = mount(SessionVitals, {
       target: document.body,
-      props: { sessionId: "sess-1" },
+      props: { sessionId: "sess-1", session: undefined },
     });
     await tick();
     await tick();

--- a/frontend/src/lib/components/content/SessionVitals.test.ts
+++ b/frontend/src/lib/components/content/SessionVitals.test.ts
@@ -79,6 +79,7 @@ describe("SessionVitals", () => {
     }));
     sessionTiming.reset();
     ui.vitalsOpen = true;
+    ui.vitalsCallsExpanded = true;
   });
 
   afterEach(() => {
@@ -323,6 +324,47 @@ describe("SessionVitals", () => {
     });
   });
 
+  it("collapses and restores the Calls detail while keeping its summary", async () => {
+    mocks.fetchSessionTiming.mockResolvedValue(timingWithCall());
+    component = mount(SessionVitals, {
+      target: document.body,
+      props: { sessionId: "sess-1" },
+    });
+    await tick();
+    await tick();
+
+    const disclosure = document.querySelector<HTMLButtonElement>(
+      'button[aria-expanded="true"]',
+    );
+    expect(disclosure).not.toBeNull();
+    expect(disclosure?.textContent).toContain(
+      m.session_vitals_calls(),
+    );
+    expect(document.querySelector(".scale-axis")).not.toBeNull();
+    expect(document.querySelector(".calls")).not.toBeNull();
+
+    disclosure!.click();
+    await tick();
+
+    expect(disclosure?.getAttribute("aria-expanded")).toBe("false");
+    expect(disclosure?.textContent).toContain(
+      m.session_vitals_calls_summary({
+        count: 1,
+        countLabel: "1",
+        runningCount: 0,
+      }),
+    );
+    expect(document.querySelector(".scale-axis")).toBeNull();
+    expect(document.querySelector(".calls")).toBeNull();
+
+    disclosure!.click();
+    await tick();
+
+    expect(disclosure?.getAttribute("aria-expanded")).toBe("true");
+    expect(document.querySelector(".scale-axis")).not.toBeNull();
+    expect(document.querySelector(".calls")).not.toBeNull();
+  });
+
   it("aborts a pending sub-agent timing read when collapsed", async () => {
     const signals: AbortSignal[] = [];
     mocks.fetchSessionTiming.mockImplementation(
@@ -424,6 +466,33 @@ describe("SessionVitals", () => {
     expect(signals[0]?.aborted).toBe(true);
   });
 });
+
+function timingWithCall(): SessionTiming {
+  return {
+    ...mocks.timing,
+    tool_duration_ms: 400,
+    tool_call_count: 1,
+    turns: [
+      {
+        message_id: 1,
+        ordinal: 1,
+        started_at: "2026-07-14T12:00:00Z",
+        duration_ms: 400,
+        primary_category: "Bash",
+        calls: [
+          {
+            tool_use_id: "call-1",
+            tool_name: "Bash",
+            category: "Bash",
+            duration_ms: 400,
+            is_parallel: false,
+            input_preview: "go test ./...",
+          },
+        ],
+      },
+    ],
+  };
+}
 
 function parentTimingWithSubagent(): SessionTiming {
   return {

--- a/frontend/src/lib/stores/ui.svelte.ts
+++ b/frontend/src/lib/stores/ui.svelte.ts
@@ -48,6 +48,8 @@ export const ALL_BLOCK_TYPES: BlockType[] = [
 const BLOCK_FILTER_KEY = "agentsview-block-filters";
 const TRANSCRIPT_MODE_KEY = "agentsview-transcript-mode";
 const VITALS_KEY = "agentsview-session-vitals";
+const VITALS_CALLS_EXPANDED_KEY =
+  "agentsview-session-vitals-calls-expanded";
 const SIGNAL_PANEL_KEY = "agentsview-signal-panel";
 const FOLLOW_LATEST_KEY = "agentsview-follow-latest";
 
@@ -281,6 +283,9 @@ class UIStore {
   vitalsOpen: boolean = $state(
     readStoredBool(VITALS_KEY, false),
   );
+  vitalsCallsExpanded: boolean = $state(
+    readStoredBool(VITALS_CALLS_EXPANDED_KEY, true),
+  );
   signalPanelOpen: boolean = $state(
     readStoredBool(SIGNAL_PANEL_KEY, false),
   );
@@ -373,6 +378,17 @@ class UIStore {
           localStorage?.setItem(
             VITALS_KEY,
             String(this.vitalsOpen),
+          );
+        } catch {
+          // ignore
+        }
+      });
+
+      $effect(() => {
+        try {
+          localStorage?.setItem(
+            VITALS_CALLS_EXPANDED_KEY,
+            String(this.vitalsCallsExpanded),
           );
         } catch {
           // ignore
@@ -601,6 +617,10 @@ class UIStore {
 
   closeVitals() {
     this.vitalsOpen = false;
+  }
+
+  toggleVitalsCalls() {
+    this.vitalsCallsExpanded = !this.vitalsCallsExpanded;
   }
 
   toggleSignalPanel() {

--- a/frontend/src/lib/stores/ui.test.ts
+++ b/frontend/src/lib/stores/ui.test.ts
@@ -629,6 +629,92 @@ describe("UIStore", () => {
     });
   });
 
+  describe("Calls detail preference", () => {
+    it("defaults the Calls detail to expanded", async () => {
+      const original = globalThis.localStorage;
+      Object.defineProperty(globalThis, "localStorage", {
+        value: {
+          getItem: vi.fn(() => null),
+          setItem: vi.fn(),
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      try {
+        // @ts-expect-error -- query string busts module cache
+        const mod = await import("./ui.svelte.js?vitalsCallsDefault");
+        expect(mod.ui.vitalsCallsExpanded).toBe(true);
+      } finally {
+        Object.defineProperty(globalThis, "localStorage", {
+          value: original,
+          writable: true,
+          configurable: true,
+        });
+      }
+    });
+
+    it("restores a collapsed Calls detail preference", async () => {
+      const original = globalThis.localStorage;
+      const setItem = vi.fn();
+      Object.defineProperty(globalThis, "localStorage", {
+        value: {
+          getItem: vi.fn((key: string) =>
+            key === "agentsview-session-vitals-calls-expanded"
+              ? "false"
+              : null,
+          ),
+          setItem,
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      try {
+        // @ts-expect-error -- query string busts module cache
+        const mod = await import("./ui.svelte.js?vitalsCallsCollapsed");
+        expect(mod.ui.vitalsCallsExpanded).toBe(false);
+      } finally {
+        Object.defineProperty(globalThis, "localStorage", {
+          value: original,
+          writable: true,
+          configurable: true,
+        });
+      }
+    });
+
+    it("persists Calls detail changes", async () => {
+      const original = globalThis.localStorage;
+      const setItem = vi.fn();
+      Object.defineProperty(globalThis, "localStorage", {
+        value: { getItem: vi.fn(() => null), setItem },
+        writable: true,
+        configurable: true,
+      });
+
+      try {
+        // @ts-expect-error -- query string busts module cache
+        const mod = await import("./ui.svelte.js?vitalsCallsPersist");
+        setItem.mockClear();
+
+        mod.ui.toggleVitalsCalls();
+        await tick();
+
+        expect(mod.ui.vitalsCallsExpanded).toBe(false);
+        expect(setItem).toHaveBeenCalledWith(
+          "agentsview-session-vitals-calls-expanded",
+          "false",
+        );
+      } finally {
+        Object.defineProperty(globalThis, "localStorage", {
+          value: original,
+          writable: true,
+          configurable: true,
+        });
+      }
+    });
+  });
+
   describe("postMessage theme control", () => {
     it("should change theme on valid theme:set message", () => {
       ui.theme = "light";


### PR DESCRIPTION
Long session call timelines can consume most of the analysis sidebar even when the aggregate count is all the user needs. The Calls header is now a keyboard-accessible disclosure that keeps the localized summary visible while hiding the time axis and individual rows.

The expanded choice is stored globally in LocalStorage, so switching sessions or reloading preserves the user’s preferred density. Existing users retain the current expanded behavior until they collapse it, and the other analysis sections remain unchanged.

<sup>generated by a clanker</sup>