### PR TITLE
fix(grok): emit one usage event per turn instead of last-snapshot-per-session

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -313,7 +313,12 @@ const projectIdentityRemoteScrubCompletedKey = "project_identity_remote_scrub_v1
 // (69: Copilot shutdown events persist the authoritative AI-credit total as
 // reported cost. Re-parsing populates cost_usd and cost_source on existing
 // Copilot rows from session.shutdown totalNanoAiu values.)
-const dataVersion = 69
+// (70: Grok per-turn usage reparse. turn_completed usage payloads are
+// per-turn measurements, not cumulative snapshots — one event per turn
+// and model replaces the single last-payload event per session, with
+// occurred_at from each turn's timestamp. Existing Grok rows undercount
+// multi-turn sessions and need re-parsing.)
+const dataVersion = 70
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -930,9 +930,9 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 		"expected tool_result_events table after reopen")
 }
 
-func TestCurrentDataVersionCopilotReportedCost(t *testing.T) {
-	assert.Equal(t, 69, CurrentDataVersion(),
-		"Copilot reported-cost parsing requires a data version bump")
+func TestCurrentDataVersionGrokPerTurnUsage(t *testing.T) {
+	assert.Equal(t, 70, CurrentDataVersion(),
+		"Grok per-turn usage parsing requires a data version bump")
 }
 
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -324,6 +324,50 @@ func TestUsageEventsReplaceAndList(t *testing.T) {
 	require.Len(t, got, 0, "usage events after clear =")
 }
 
+func TestUsageEventsReplaceRejectsDuplicateDedupKeysAndRollsBack(t *testing.T) {
+	// A parser emitting two events with the same dedup key (e.g. Grok
+	// retry/replay lines sharing a prompt_id, before the parser-side
+	// last-wins dedupe) violates idx_usage_events_dedup and must fail
+	// the whole replace, leaving the prior events untouched. Parsers
+	// therefore dedupe in memory before handing events to the DB.
+	d := testDB(t)
+	ctx := context.Background()
+
+	insertSession(t, d, "grok:dup", "proj", func(s *Session) {
+		s.Agent = "grok"
+	})
+
+	prior := []UsageEvent{{
+		SessionID:   "grok:dup",
+		Source:      "session",
+		Model:       "grok-4.5",
+		InputTokens: 1,
+		DedupKey:    "session:grok:dup:p-1:grok-4.5",
+	}}
+	require.NoError(t, d.ReplaceSessionUsageEvents("grok:dup", prior))
+
+	dup := []UsageEvent{{
+		SessionID:   "grok:dup",
+		Source:      "session",
+		Model:       "grok-4.5",
+		InputTokens: 2,
+		DedupKey:    "session:grok:dup:p-2:grok-4.5",
+	}, {
+		SessionID:   "grok:dup",
+		Source:      "session",
+		Model:       "grok-4.5",
+		InputTokens: 3,
+		DedupKey:    "session:grok:dup:p-2:grok-4.5",
+	}}
+	err := d.ReplaceSessionUsageEvents("grok:dup", dup)
+	require.Error(t, err, "duplicate dedup keys must violate idx_usage_events_dedup")
+
+	got, err := d.GetUsageEvents(ctx, "grok:dup")
+	require.NoError(t, err, "GetUsageEvents after failed replace")
+	require.Len(t, got, 1, "failed replace must roll back to the prior events")
+	assert.Equal(t, 1, got[0].InputTokens, "prior event must survive the rollback")
+}
+
 func TestGetDailyUsageWithData(t *testing.T) {
 	d := testDB(t)
 	ctx := context.Background()

--- a/internal/parser/grok.go
+++ b/internal/parser/grok.go
@@ -191,15 +191,57 @@ func ParseGrokSummary(
 	return result, nil
 }
 
+// Grok Build writes one usage payload per completed turn, and those
+// payloads are per-turn measurements — not cumulative session snapshots
+// (cachedReadTokens is non-monotonic across a session's turns, and
+// modelCalls resets each turn). Emit one event per turn and model so
+// session totals and daily bucketing sum correctly; keeping only the
+// final payload undercounts multi-turn sessions by orders of magnitude
+// and attributes everything to the session's end date (#1227).
 func parseGrokUsageEvents(
 	path, sessionID, summaryModel string,
 	startedAt, endedAt time.Time,
 ) ([]ParsedUsageEvent, error) {
-	var usage gjson.Result
+	sessionFallback := timeString(endedAt, startedAt)
+	var events []ParsedUsageEvent
+	turn := 0
 	_, err := readJSONLFrom(path, 0, func(line string) {
-		candidate := gjson.Get(line, "params.update.usage")
-		if candidate.Exists() && candidate.IsObject() {
-			usage = candidate
+		usage := gjson.Get(line, "params.update.usage")
+		if !usage.Exists() || !usage.IsObject() {
+			return
+		}
+		turn++
+		// prompt_id is unique per turn and stable across re-parses; the
+		// ordinal fallback covers payloads that predate prompt_id.
+		turnKey := gjson.Get(line, "params.update.prompt_id").String()
+		if turnKey == "" {
+			turnKey = fmt.Sprintf("turn-%d", turn)
+		}
+		occurredAt := timeString(
+			hermesUnixTime(gjson.Get(line, "timestamp").Float()), time.Time{},
+		)
+		if occurredAt == "" {
+			occurredAt = sessionFallback
+		}
+		modelUsage := usage.Get("modelUsage")
+		emitted := false
+		if modelUsage.IsObject() {
+			modelUsage.ForEach(func(model, modelData gjson.Result) bool {
+				events = append(events, grokUsageEvent(
+					sessionID, model.Str, turnKey, modelData, occurredAt,
+				))
+				emitted = true
+				return true
+			})
+		}
+		if !emitted {
+			model := summaryModel
+			if model == "" {
+				model = "grok-summary"
+			}
+			events = append(events, grokUsageEvent(
+				sessionID, model, turnKey, usage, occurredAt,
+			))
 		}
 	})
 	if errors.Is(err, os.ErrNotExist) {
@@ -208,34 +250,11 @@ func parseGrokUsageEvents(
 	if err != nil {
 		return nil, err
 	}
-	if !usage.Exists() {
-		return nil, nil
-	}
-
-	occurredAt := timeString(endedAt, startedAt)
-	modelUsage := usage.Get("modelUsage")
-	var events []ParsedUsageEvent
-	if modelUsage.IsObject() {
-		modelUsage.ForEach(func(model, modelData gjson.Result) bool {
-			events = append(events, grokUsageEvent(
-				sessionID, model.Str, modelData, occurredAt,
-			))
-			return true
-		})
-	}
-	if len(events) > 0 {
-		return events, nil
-	}
-	if summaryModel == "" {
-		summaryModel = "grok-summary"
-	}
-	return []ParsedUsageEvent{grokUsageEvent(
-		sessionID, summaryModel, usage, occurredAt,
-	)}, nil
+	return events, nil
 }
 
 func grokUsageEvent(
-	sessionID, model string, usage gjson.Result, occurredAt string,
+	sessionID, model, turnKey string, usage gjson.Result, occurredAt string,
 ) ParsedUsageEvent {
 	input := int(usage.Get("inputTokens").Int())
 	cachedRead := int(usage.Get("cachedReadTokens").Int())
@@ -249,7 +268,7 @@ func grokUsageEvent(
 		ReasoningTokens:      int(usage.Get("reasoningTokens").Int()),
 		CostUSD:              grokUsageCostUSD(usage),
 		OccurredAt:           occurredAt,
-		DedupKey:             "session:" + sessionID + ":" + model,
+		DedupKey:             "session:" + sessionID + ":" + turnKey + ":" + model,
 	}
 }
 

--- a/internal/parser/grok.go
+++ b/internal/parser/grok.go
@@ -204,6 +204,19 @@ func parseGrokUsageEvents(
 ) ([]ParsedUsageEvent, error) {
 	sessionFallback := timeString(endedAt, startedAt)
 	var events []ParsedUsageEvent
+	// Last-wins in-memory dedupe: a re-emitted payload for the same turn
+	// and model (retry/replay lines share a prompt_id) is a rewrite of
+	// that turn, and duplicate DedupKeys would violate the DB's unique
+	// (session_id, source, dedup_key) index and roll back the replace.
+	eventIndex := map[string]int{}
+	emit := func(ev ParsedUsageEvent) {
+		if i, ok := eventIndex[ev.DedupKey]; ok {
+			events[i] = ev
+			return
+		}
+		eventIndex[ev.DedupKey] = len(events)
+		events = append(events, ev)
+	}
 	turn := 0
 	_, err := readJSONLFrom(path, 0, func(line string) {
 		usage := gjson.Get(line, "params.update.usage")
@@ -227,7 +240,7 @@ func parseGrokUsageEvents(
 		emitted := false
 		if modelUsage.IsObject() {
 			modelUsage.ForEach(func(model, modelData gjson.Result) bool {
-				events = append(events, grokUsageEvent(
+				emit(grokUsageEvent(
 					sessionID, model.Str, turnKey, modelData, occurredAt,
 				))
 				emitted = true
@@ -239,7 +252,7 @@ func parseGrokUsageEvents(
 			if model == "" {
 				model = "grok-summary"
 			}
-			events = append(events, grokUsageEvent(
+			emit(grokUsageEvent(
 				sessionID, model, turnKey, usage, occurredAt,
 			))
 		}

--- a/internal/parser/grok_test.go
+++ b/internal/parser/grok_test.go
@@ -462,6 +462,25 @@ func TestGrokProviderPerTurnUsageDedupsByPromptID(t *testing.T) {
 	}, keys)
 }
 
+func TestGrokProviderPerTurnUsageLastWinsOnDuplicatePromptID(t *testing.T) {
+	// Retry/replay lines re-emit a turn's payload under the same
+	// prompt_id. They must collapse to a single event (the DB enforces a
+	// unique (session_id, source, dedup_key) index — a duplicate would
+	// roll back the whole usage replace), keeping the last payload.
+	result := parseGrokUsageFixture(t, strings.Join([]string{
+		`{"timestamp":1784575476,"params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"p-aaa","usage":{"modelUsage":{"grok-4.5":{"inputTokens":1100,"outputTokens":10,"cachedReadTokens":1000}}}}}}`,
+		`{"timestamp":1784575480,"params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"p-aaa","usage":{"modelUsage":{"grok-4.5":{"inputTokens":1200,"outputTokens":15,"cachedReadTokens":1000}}}}}}`,
+	}, "\n"))
+
+	require.Len(t, result.UsageEvents, 1)
+	event := result.UsageEvents[0]
+	assert.Equal(t, "session:grok:sess-1:p-aaa:grok-4.5", event.DedupKey)
+	assert.Equal(t, 200, event.InputTokens)
+	assert.Equal(t, 15, event.OutputTokens)
+	assert.Equal(t, "2026-07-20T19:24:40Z", event.OccurredAt)
+	assert.Equal(t, 15, result.Session.TotalOutputTokens)
+}
+
 func TestGrokProviderPerTurnUsageDatesByTurnTimestamp(t *testing.T) {
 	// A session spanning several days must bucket each turn's usage on
 	// the day the turn happened, not the session's end date.

--- a/internal/parser/grok_test.go
+++ b/internal/parser/grok_test.go
@@ -418,21 +418,64 @@ func parseGrokUsageFixtureWithSummary(
 	return result
 }
 
-func TestGrokProviderLatestUsageSnapshot(t *testing.T) {
+func TestGrokProviderPerTurnUsageEvents(t *testing.T) {
+	// Usage payloads are per-turn measurements, not cumulative snapshots:
+	// every turn must produce its own event, and cachedReadTokens moving
+	// down between turns (10 -> 13 with a lower input) must be preserved
+	// as-is rather than treated as a snapshot to overwrite.
 	result := parseGrokUsageFixture(t, strings.Join([]string{
 		`{"params":{"update":{"usage":{"inputTokens":100,"outputTokens":20,"cachedReadTokens":10,"reasoningTokens":4}}}}`,
 		`{"params":{"update":{"usage":{"inputTokens":8,"outputTokens":3,"cachedReadTokens":13,"reasoningTokens":1}}}}`,
 		`not json`,
 	}, "\n"))
 
-	require.Len(t, result.UsageEvents, 1)
-	event := result.UsageEvents[0]
-	assert.Equal(t, 0, event.InputTokens)
-	assert.Equal(t, 13, event.CacheReadInputTokens)
-	assert.Equal(t, 3, event.OutputTokens)
-	assert.Equal(t, 1, event.ReasoningTokens)
-	assert.Equal(t, "grok-summary", event.Model)
-	assert.Equal(t, "session:grok:sess-1:grok-summary", event.DedupKey)
+	require.Len(t, result.UsageEvents, 2)
+	first, second := result.UsageEvents[0], result.UsageEvents[1]
+	assert.Equal(t, 90, first.InputTokens)
+	assert.Equal(t, 10, first.CacheReadInputTokens)
+	assert.Equal(t, 20, first.OutputTokens)
+	assert.Equal(t, 4, first.ReasoningTokens)
+	assert.Equal(t, "session:grok:sess-1:turn-1:grok-summary", first.DedupKey)
+	assert.Equal(t, 0, second.InputTokens)
+	assert.Equal(t, 13, second.CacheReadInputTokens)
+	assert.Equal(t, 3, second.OutputTokens)
+	assert.Equal(t, 1, second.ReasoningTokens)
+	assert.Equal(t, "session:grok:sess-1:turn-2:grok-summary", second.DedupKey)
+	assert.Equal(t, 23, result.Session.TotalOutputTokens)
+}
+
+func TestGrokProviderPerTurnUsageDedupsByPromptID(t *testing.T) {
+	result := parseGrokUsageFixture(t, strings.Join([]string{
+		`{"timestamp":1784575476,"params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"p-aaa","usage":{"modelUsage":{"grok-4.5":{"inputTokens":1100,"outputTokens":10,"cachedReadTokens":1000}}}}}}`,
+		`{"timestamp":1784575500,"params":{"update":{"sessionUpdate":"turn_completed","prompt_id":"p-bbb","usage":{"modelUsage":{"grok-4.5":{"inputTokens":200,"outputTokens":20,"cachedReadTokens":128},"grok-4.5-build":{"inputTokens":50,"outputTokens":5,"cachedReadTokens":0}}}}}}`,
+	}, "\n"))
+
+	require.Len(t, result.UsageEvents, 3)
+	keys := make([]string, 0, len(result.UsageEvents))
+	for _, event := range result.UsageEvents {
+		keys = append(keys, event.DedupKey)
+	}
+	assert.ElementsMatch(t, []string{
+		"session:grok:sess-1:p-aaa:grok-4.5",
+		"session:grok:sess-1:p-bbb:grok-4.5",
+		"session:grok:sess-1:p-bbb:grok-4.5-build",
+	}, keys)
+}
+
+func TestGrokProviderPerTurnUsageDatesByTurnTimestamp(t *testing.T) {
+	// A session spanning several days must bucket each turn's usage on
+	// the day the turn happened, not the session's end date.
+	result := parseGrokUsageFixture(t, strings.Join([]string{
+		`{"timestamp":1779735600,"params":{"update":{"usage":{"inputTokens":10,"outputTokens":1}}}}`,
+		`{"timestamp":1779822000,"params":{"update":{"usage":{"inputTokens":20,"outputTokens":2}}}}`,
+		`{"params":{"update":{"usage":{"inputTokens":30,"outputTokens":3}}}}`,
+	}, "\n"))
+
+	require.Len(t, result.UsageEvents, 3)
+	assert.Equal(t, "2026-05-25T19:00:00Z", result.UsageEvents[0].OccurredAt)
+	assert.Equal(t, "2026-05-26T19:00:00Z", result.UsageEvents[1].OccurredAt)
+	// No per-turn timestamp: falls back to the session window (updatedAt).
+	assert.Equal(t, "2026-07-08T10:30:00Z", result.UsageEvents[2].OccurredAt)
 }
 
 func TestGrokProviderUpdatesWithoutUsageEmitNoEvents(t *testing.T) {


### PR DESCRIPTION
Fixes #1227.

## Problem

`parseGrokUsageEvents` treats `params.update.usage` payloads in `updates.jsonl` as cumulative session snapshots and keeps only the last one per session. Grok Build's `turn_completed` usage is actually **per-turn** (`cachedReadTokens` is non-monotonic across a session's turns; `modelCalls` resets each turn), so multi-turn sessions are undercounted by orders of magnitude and all usage lands on the session's end date. Full evidence incl. an exact-token reproduction of the undercount is in #1227.

## Change

- Emit one usage event per usage payload and model (from `usage.modelUsage`, with the existing top-level fallback), instead of one per session.
- Dedup key gains a turn component: `session:<sessionID>:<prompt_id>:<model>` — `prompt_id` is unique per turn and stable across re-parses (verified collision-free on a 2,976-turn archive); a `turn-<n>` ordinal covers payloads without `prompt_id`.
- `OccurredAt` comes from each payload's own top-level `timestamp` (unix seconds), falling back to the session window when absent — a days-long session now buckets each turn on the day it happened.
- The existing `max(input − cachedRead, 0)` netting and `costUsdTicks` handling are unchanged.
- `dataVersion` 69 → 70 (same convention as 51, the Gemini cumulative-to-delta reparse) so existing Grok rows are re-parsed on upgrade.

## Before / after on a real archive

44 sessions / 2,976 `turn_completed` payloads, `usage daily --agent grok` totals:

| metric | before (main `75b9e8b`) | after | ground truth (independent re-parse of raw files) |
|---|---|---|---|
| input (net) | 662,978 | 19,023,100 | 19,023,100 |
| output | 53,230 | 2,674,197 | 2,674,197 |
| cachedRead | 12,658,048 | 2,591,768,960 | 2,591,768,960 |
| days present | 6 | 8 | 8 |

The heaviest day of the archive (929M tokens) was previously missing entirely from the daily output (its sessions ended on other dates); it now reports correctly.

## Testing

- `go test -short ./internal/...` passes; `gofmt`/`go vet` clean.
- Reworked `TestGrokProviderLatestUsageSnapshot` → `TestGrokProviderPerTurnUsageEvents` (two payloads → two events, non-monotonic cache preserved, session total output = sum).
- New: `TestGrokProviderPerTurnUsageDedupsByPromptID` (multi-model turn, prompt_id-keyed dedup) and `TestGrokProviderPerTurnUsageDatesByTurnTimestamp` (multi-day session buckets per turn; timestamp-less payload falls back to the session window).