### PR TITLE
fix(daemon): preserve full resync progress detail

### DIFF
--- a/cmd/agentsview/startup_state.go
+++ b/cmd/agentsview/startup_state.go
@@ -92,6 +92,9 @@ func (w *startupStateWriter) SetPhase(phase string) {
 	}
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	if phase == w.state.Phase {
+		return
+	}
 	w.state.Phase = phase
 	w.state.Detail = ""
 	w.write()
@@ -112,7 +115,11 @@ func (w *startupStateWriter) SetDetail(detail string) {
 	if detail == "" || detail == w.state.Detail {
 		return
 	}
-	if w.now().Sub(w.lastWrite) < startupDetailThrottle {
+	// Publish the first detail for a new phase immediately. This costs at most
+	// one extra write per phase and prevents the phase write itself from hiding
+	// the only useful description of a long-running step. Once detail exists,
+	// keep throttling high-frequency counter updates as before.
+	if w.state.Detail != "" && w.now().Sub(w.lastWrite) < startupDetailThrottle {
 		return
 	}
 	w.state.Detail = detail

--- a/cmd/agentsview/startup_state_test.go
+++ b/cmd/agentsview/startup_state_test.go
@@ -42,17 +42,17 @@ func TestStartupStateDetailThrottle(t *testing.T) {
 	w := newStartupStateWriter(dir, now)
 	w.SetPhase("full resync")
 
-	// Within the throttle window: not persisted.
+	// The first detail for a phase is immediately useful and persists even
+	// though the phase snapshot was just written.
 	w.SetDetail("1/100 sessions")
 	st := readStartupState(dir)
 	require.NotNil(t, st)
-	assert.Empty(t, st.Detail, "detail must not persist inside the throttle window")
+	assert.Equal(t, "1/100 sessions", st.Detail)
 
-	// The same stable detail must persist once the window passes
-	// (regression: a throttled detail was stored in memory and then
-	// deduplicated against itself forever).
-	step(startupDetailThrottle)
-	w.SetDetail("1/100 sessions")
+	// Repeating a phase must not clear its detail or bypass the throttle for a
+	// counter-only update.
+	w.SetPhase("full resync")
+	w.SetDetail("2/100 sessions")
 	st = readStartupState(dir)
 	require.NotNil(t, st)
 	assert.Equal(t, "1/100 sessions", st.Detail)

--- a/cmd/agentsview/startup_worker_test.go
+++ b/cmd/agentsview/startup_worker_test.go
@@ -153,6 +153,54 @@ func TestStartupWorkerFailureFallsBackInProcess(t *testing.T) {
 	}
 }
 
+func TestStartupWorkerPublishesEnrichedResyncProgress(t *testing.T) {
+	cfg := config.Config{DataDir: t.TempDir()}
+	now, step := fakeClock(time.Date(2026, 7, 22, 22, 0, 0, 0, time.UTC))
+	progress := newStartupStateWriter(cfg.DataDir, now)
+	progress.SetPhase("initial sync")
+
+	restore := stubLaunchSyncWorker(t, func(
+		_ context.Context, _ config.Config, mode string, onLine func(workerLine),
+	) (workerResult, error) {
+		assert.Equal(t, "startup", mode)
+		onLine(workerLine{Progress: &syncpkg.Progress{
+			Phase:  syncpkg.PhasePreparingResync,
+			Detail: "Preparing full resync",
+			Resync: true,
+		}})
+		state := readStartupState(cfg.DataDir)
+		require.NotNil(t, state)
+		assert.Equal(t, "full resync", state.Phase)
+		assert.Equal(t, "Preparing full resync", state.Detail)
+
+		step(startupDetailThrottle)
+		onLine(workerLine{Progress: &syncpkg.Progress{
+			Phase:           syncpkg.PhaseSyncing,
+			Detail:          "Syncing sessions into rebuilt database",
+			Resync:          true,
+			SessionsDone:    25,
+			SessionsTotal:   100,
+			MessagesIndexed: 800,
+		}})
+		state = readStartupState(cfg.DataDir)
+		require.NotNil(t, state)
+		assert.Equal(t, "full resync", state.Phase)
+		assert.Equal(t,
+			"Syncing sessions into rebuilt database: 25/100 sessions (25%) · 800 messages",
+			state.Detail,
+		)
+
+		stats := syncpkg.SyncStats{}
+		return workerResult{
+			Status: "ok", DiscoveryComplete: true, Stats: &stats,
+		}, nil
+	})
+	defer restore()
+
+	_, err := runStartupSyncViaWorker(t.Context(), cfg, progress)
+	require.NoError(t, err)
+}
+
 // TestStartupWorkerOutcomeDiscriminatesSpawnFromRanFailed pins the Finding 1
 // contract: a spawn failure asks the caller to fall back in process, while a
 // worker that ran and reported failure is carried forward as an aborted result


### PR DESCRIPTION
Long full resyncs launched by `daemon start` or `daemon restart` were reported as repeated bare elapsed heartbeats because duplicate phase updates erased the worker detail before it was persisted. That made a healthy multi-minute rebuild indistinguishable from a stalled one.

Startup progress now treats repeated phase notifications as idempotent and publishes the first detail for a new phase immediately. Attached lifecycle commands retain the current rebuild step and session/message counters while subsequent updates remain bounded by the existing throttle.