### PR TITLE
fix(parser): prefer OpenCode session.directory over project worktree

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -223,6 +223,11 @@ Grok section and remove the explicit registry exception in the coverage test.
 - **Usage and cost:** Assistant messages persist input, output, cache-read, and
   cache-write tokens, plus model/provider identity. Agentsview computes price
   from those tokens rather than consuming a persisted USD total.
+- **Working directory:** SQLite sessions store a per-session `directory` and a
+  `project_id`. The synthetic `global` project uses `worktree=/`. Agentsview
+  prefers a concrete `session.directory` over `project.worktree` when resolving
+  cwd/project (verified against live `opencode.db` rows under `project_id=global`
+  on 2026-07-23; see #1236).
 - **Agentsview:** `internal/parser/opencode.go`,
   `internal/parser/opencode_provider.go`, and
   `internal/parser/opencode_storage_state.go`; legacy and database layouts are

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -318,7 +318,10 @@ const projectIdentityRemoteScrubCompletedKey = "project_identity_remote_scrub_v1
 // and model replaces the single last-payload event per session, with
 // occurred_at from each turn's timestamp. Existing Grok rows undercount
 // multi-turn sessions and need re-parsing.)
-const dataVersion = 70
+// (71: OpenCode SQLite cwd/project derivation now prefers a concrete
+// session.directory over the synthetic global project worktree "/". Existing
+// OpenCode rows need re-parsing so unchanged sessions refresh cwd and project.)
+const dataVersion = 71
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1007,9 +1007,9 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 		"expected tool_result_events table after reopen")
 }
 
-func TestCurrentDataVersionGrokPerTurnUsage(t *testing.T) {
-	assert.Equal(t, 70, CurrentDataVersion(),
-		"Grok per-turn usage parsing requires a data version bump")
+func TestCurrentDataVersionOpenCodeSessionDirectory(t *testing.T) {
+	assert.Equal(t, 71, CurrentDataVersion(),
+		"OpenCode cwd/project derivation requires a data version bump")
 }
 
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {

--- a/internal/parser/opencode.go
+++ b/internal/parser/opencode.go
@@ -156,10 +156,33 @@ func parseOpenCodeDBSession(
 		)
 	}
 
-	worktree := projects[s.projectID]
+	worktree := resolveOpenCodeWorktree(
+		s.directory, projects[s.projectID],
+	)
 	return buildOpenCodeSession(
 		db, s, worktree, dbPath, machine,
 	)
+}
+
+// resolveOpenCodeWorktree picks the session working directory used for
+// cwd/project. OpenCode's synthetic "global" project stores worktree="/",
+// while session.directory still holds the real path the session ran in.
+// Prefer a concrete session directory; fall back to the project worktree.
+func resolveOpenCodeWorktree(
+	sessionDirectory, projectWorktree string,
+) string {
+	if dir := strings.TrimSpace(sessionDirectory); openCodeUsableWorktree(dir) {
+		return dir
+	}
+	return strings.TrimSpace(projectWorktree)
+}
+
+func openCodeUsableWorktree(path string) bool {
+	if path == "" {
+		return false
+	}
+	// Root is OpenCode's global-project placeholder, not a real project cwd.
+	return path != string(filepath.Separator) && path != "/"
 }
 
 // parseOpenCodeStorageFile parses a file-backed OpenCode storage
@@ -339,6 +362,7 @@ type openCodeSessionRow struct {
 	projectID   string
 	parentID    string
 	title       string
+	directory   string
 	timeCreated int64
 	timeUpdated int64
 }
@@ -350,6 +374,7 @@ func loadOneOpenCodeSession(
 		SELECT s.id, s.project_id,
 		       COALESCE(s.parent_id, ''),
 		       COALESCE(s.title, ''),
+		       COALESCE(s.directory, ''),
 		       s.time_created, s.time_updated
 		FROM session s
 		WHERE s.id = ?
@@ -358,7 +383,8 @@ func loadOneOpenCodeSession(
 	var s openCodeSessionRow
 	err := row.Scan(
 		&s.id, &s.projectID, &s.parentID,
-		&s.title, &s.timeCreated, &s.timeUpdated,
+		&s.title, &s.directory,
+		&s.timeCreated, &s.timeUpdated,
 	)
 	return s, err
 }

--- a/internal/parser/opencode.go
+++ b/internal/parser/opencode.go
@@ -148,7 +148,14 @@ func parseOpenCodeDBSession(
 		)
 	}
 
-	s, err := loadOneOpenCodeSession(db, sessionID)
+	hasDirectory, err := openCodeSessionHasDirectoryCached(db, dbPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf(
+			"probing opencode session schema: %w", err,
+		)
+	}
+
+	s, err := loadOneOpenCodeSession(db, sessionID, hasDirectory)
 	if err != nil {
 		return nil, nil, fmt.Errorf(
 			"loading opencode session %s: %w",
@@ -367,24 +374,120 @@ type openCodeSessionRow struct {
 	timeUpdated int64
 }
 
+type openCodeSessionSchemaCacheEntry struct {
+	state        SQLiteContainerState
+	hasDirectory bool
+}
+
+// openCodeSessionSchemaCache memoizes whether session.directory exists for
+// each shared OpenCode SQLite path. Legacy OpenCode-family DBs (older
+// OpenCode, Kilo, MiMoCode, ICodeMate) omit the column; probing once per
+// container state avoids a PRAGMA on every session parse.
+var (
+	openCodeSessionSchemaCacheMu sync.Mutex
+	openCodeSessionSchemaCache   = map[string]openCodeSessionSchemaCacheEntry{}
+)
+
+func openCodeSessionHasDirectoryCached(
+	db *sql.DB, dbPath string,
+) (bool, error) {
+	state, ok := StatSQLiteContainerState(dbPath)
+	if !ok {
+		return openCodeSessionTableHasDirectory(db)
+	}
+	openCodeSessionSchemaCacheMu.Lock()
+	entry, hit := openCodeSessionSchemaCache[dbPath]
+	openCodeSessionSchemaCacheMu.Unlock()
+	if hit && entry.state == state {
+		return entry.hasDirectory, nil
+	}
+	hasDirectory, err := openCodeSessionTableHasDirectory(db)
+	if err != nil {
+		return false, err
+	}
+	openCodeSessionSchemaCacheMu.Lock()
+	openCodeSessionSchemaCache[dbPath] = openCodeSessionSchemaCacheEntry{
+		state:        state,
+		hasDirectory: hasDirectory,
+	}
+	openCodeSessionSchemaCacheMu.Unlock()
+	return hasDirectory, nil
+}
+
+func openCodeSessionTableHasDirectory(db *sql.DB) (bool, error) {
+	rows, err := db.Query(`PRAGMA table_info(session)`)
+	if err != nil {
+		return false, fmt.Errorf(
+			"listing opencode session table info: %w", err,
+		)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			cid        int
+			name       string
+			typeName   string
+			notNull    int
+			defaultV   sql.NullString
+			primaryKey int
+		)
+		if err := rows.Scan(
+			&cid, &name, &typeName, &notNull, &defaultV, &primaryKey,
+		); err != nil {
+			return false, fmt.Errorf(
+				"scanning opencode session table info: %w", err,
+			)
+		}
+		if strings.EqualFold(name, "directory") {
+			return true, nil
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return false, err
+	}
+	return false, nil
+}
+
 func loadOneOpenCodeSession(
-	db *sql.DB, sessionID string,
+	db *sql.DB, sessionID string, hasDirectory bool,
 ) (openCodeSessionRow, error) {
-	row := db.QueryRow(`
+	var (
+		row *sql.Row
+		s   openCodeSessionRow
+		err error
+	)
+	if hasDirectory {
+		row = db.QueryRow(`
+			SELECT s.id, s.project_id,
+			       COALESCE(s.parent_id, ''),
+			       COALESCE(s.title, ''),
+			       COALESCE(s.directory, ''),
+			       s.time_created, s.time_updated
+			FROM session s
+			WHERE s.id = ?
+		`, sessionID)
+		err = row.Scan(
+			&s.id, &s.projectID, &s.parentID,
+			&s.title, &s.directory,
+			&s.timeCreated, &s.timeUpdated,
+		)
+		return s, err
+	}
+
+	// Legacy OpenCode-family schemas omit session.directory; cwd falls
+	// back to project.worktree via resolveOpenCodeWorktree.
+	row = db.QueryRow(`
 		SELECT s.id, s.project_id,
 		       COALESCE(s.parent_id, ''),
 		       COALESCE(s.title, ''),
-		       COALESCE(s.directory, ''),
 		       s.time_created, s.time_updated
 		FROM session s
 		WHERE s.id = ?
 	`, sessionID)
-
-	var s openCodeSessionRow
-	err := row.Scan(
+	err = row.Scan(
 		&s.id, &s.projectID, &s.parentID,
-		&s.title, &s.directory,
-		&s.timeCreated, &s.timeUpdated,
+		&s.title, &s.timeCreated, &s.timeUpdated,
 	)
 	return s, err
 }

--- a/internal/parser/opencode.go
+++ b/internal/parser/opencode.go
@@ -163,11 +163,13 @@ func parseOpenCodeDBSession(
 		)
 	}
 
-	worktree := resolveOpenCodeWorktree(
-		s.directory, projects[s.projectID],
-	)
+	projectWorktree := strings.TrimSpace(projects[s.projectID])
+	cwd := resolveOpenCodeWorktree(s.directory, projectWorktree)
+	if !openCodeUsableWorktree(projectWorktree) {
+		projectWorktree = cwd
+	}
 	return buildOpenCodeSession(
-		db, s, worktree, dbPath, machine,
+		db, s, cwd, projectWorktree, dbPath, machine,
 	)
 }
 
@@ -250,6 +252,7 @@ func parseOpenCodeStorageFile(
 			timeUpdated: sf.Time.Updated,
 		},
 		sf.Directory,
+		sf.Directory,
 		sessionPath,
 		fileMtime,
 		machine,
@@ -267,6 +270,7 @@ func parseOpenCodeStorageFile(
 			timeCreated: sf.Time.Created,
 			timeUpdated: sf.Time.Updated,
 		},
+		sf.Directory,
 		sf.Directory,
 		msgs,
 		parts,
@@ -535,6 +539,7 @@ type openCodeStorageFingerprintSession struct {
 	ProjectID   string `json:"project_id,omitempty"`
 	ParentID    string `json:"parent_id,omitempty"`
 	Title       string `json:"title,omitempty"`
+	Directory   string `json:"directory,omitempty"`
 	Worktree    string `json:"worktree,omitempty"`
 	TimeCreated int64  `json:"time_created,omitempty"`
 	TimeUpdated int64  `json:"time_updated,omitempty"`
@@ -615,7 +620,7 @@ func loadOpenCodeParts(
 func buildOpenCodeSession(
 	db *sql.DB,
 	s openCodeSessionRow,
-	worktree, dbPath, machine string,
+	cwd, projectWorktree, dbPath, machine string,
 ) (*ParsedSession, []ParsedMessage, error) {
 	msgs, err := loadOpenCodeMessages(db, s.id)
 	if err != nil {
@@ -633,7 +638,8 @@ func buildOpenCodeSession(
 
 	sess, parsed, err := buildOpenCodeParsedSession(
 		s,
-		worktree,
+		cwd,
+		projectWorktree,
 		dbPath+"#"+s.id,
 		s.timeUpdated*1_000_000,
 		machine,
@@ -644,14 +650,14 @@ func buildOpenCodeSession(
 		return sess, parsed, err
 	}
 	sess.File.Hash = buildOpenCodeSessionFingerprint(
-		s, worktree, msgs, parts,
+		s, cwd, projectWorktree, msgs, parts,
 	)
 	return sess, parsed, nil
 }
 
 func buildOpenCodeParsedSession(
 	s openCodeSessionRow,
-	worktree, filePath string,
+	cwd, projectWorktree, filePath string,
 	fileMtime int64,
 	machine string,
 	msgs []openCodeMessageRow,
@@ -695,7 +701,7 @@ func buildOpenCodeParsedSession(
 		})
 
 		pm := buildOpenCodeMessage(
-			ordinal, role, m.timeCreated, msgParts, worktree,
+			ordinal, role, m.timeCreated, msgParts, cwd,
 		)
 		applyOpenCodeTokenUsage(&pm, md, m.data, msgParts)
 		if strings.TrimSpace(pm.Content) == "" &&
@@ -718,7 +724,7 @@ func buildOpenCodeParsedSession(
 		return nil, nil, nil
 	}
 
-	project := ExtractProjectFromCwd(worktree)
+	project := ExtractProjectFromCwd(projectWorktree)
 	if project == "" {
 		project = "unknown"
 	}
@@ -743,7 +749,7 @@ func buildOpenCodeParsedSession(
 		Project:          project,
 		Machine:          machine,
 		Agent:            AgentOpenCode,
-		Cwd:              worktree,
+		Cwd:              cwd,
 		ParentSessionID:  parentID,
 		FirstMessage:     firstMsg,
 		StartedAt:        startedAt,
@@ -1279,7 +1285,7 @@ func buildOpenCodeStorageFingerprint(
 
 func buildOpenCodeSessionFingerprint(
 	s openCodeSessionRow,
-	worktree string,
+	directory, worktree string,
 	msgs []openCodeMessageRow,
 	parts map[string][]openCodePartRow,
 ) string {
@@ -1289,6 +1295,7 @@ func buildOpenCodeSessionFingerprint(
 			ProjectID:   s.projectID,
 			ParentID:    s.parentID,
 			Title:       s.title,
+			Directory:   directory,
 			Worktree:    worktree,
 			TimeCreated: s.timeCreated,
 			TimeUpdated: s.timeUpdated,

--- a/internal/parser/opencode_test.go
+++ b/internal/parser/opencode_test.go
@@ -96,7 +96,24 @@ func (s *OpenCodeSeeder) AddProject(id, worktree string) {
 
 func (s *OpenCodeSeeder) AddSession(id, projectID, parentID, title string, timeCreated, timeUpdated int64) {
 	s.t.Helper()
-	s.AddSessionDirectory(id, projectID, parentID, title, "", timeCreated, timeUpdated)
+
+	var pID, tStr any
+	if parentID != "" {
+		pID = parentID
+	}
+	if title != "" {
+		tStr = title
+	}
+
+	// Omit directory so the same helper works on legacy schemas that
+	// lack the column; modern fixtures default directory to ''.
+	_, err := s.db.Exec(
+		`INSERT INTO session
+			(id, project_id, parent_id, title, time_created, time_updated)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		id, projectID, pID, tStr, timeCreated, timeUpdated,
+	)
+	require.NoError(s.t, err, "add session")
 }
 
 func (s *OpenCodeSeeder) AddSessionDirectory(
@@ -120,7 +137,7 @@ func (s *OpenCodeSeeder) AddSessionDirectory(
 		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
 		id, projectID, pID, tStr, directory, timeCreated, timeUpdated,
 	)
-	require.NoError(s.t, err, "add session")
+	require.NoError(s.t, err, "add session with directory")
 }
 
 func (s *OpenCodeSeeder) AddMessage(id, sessionID string, timeCreated, timeUpdated int64, data string) {
@@ -1126,6 +1143,103 @@ func TestParseOpenCodeDB_EmptySessionDirectoryUsesProjectWorktree(t *testing.T) 
 	s := sessions[0].Session
 	assert.Equal(t, "/home/user/code/myapp", s.Cwd)
 	assert.Equal(t, "myapp", s.Project)
+}
+
+// openCodeSchemaLegacy omits session.directory, matching older OpenCode-family
+// SQLite layouts still used by Kilo/MiMoCode/ICodeMate archives.
+const openCodeSchemaLegacy = `
+CREATE TABLE project (
+	id TEXT PRIMARY KEY,
+	worktree TEXT NOT NULL,
+	time_created INTEGER NOT NULL DEFAULT 0,
+	time_updated INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE session (
+	id TEXT PRIMARY KEY,
+	project_id TEXT NOT NULL,
+	parent_id TEXT,
+	title TEXT,
+	time_created INTEGER NOT NULL,
+	time_updated INTEGER NOT NULL,
+	FOREIGN KEY (project_id) REFERENCES project(id)
+);
+
+CREATE TABLE message (
+	id TEXT PRIMARY KEY,
+	session_id TEXT NOT NULL,
+	time_created INTEGER NOT NULL,
+	time_updated INTEGER NOT NULL,
+	data TEXT NOT NULL,
+	FOREIGN KEY (session_id) REFERENCES session(id)
+);
+
+CREATE TABLE part (
+	id TEXT PRIMARY KEY,
+	message_id TEXT NOT NULL,
+	session_id TEXT NOT NULL,
+	time_created INTEGER NOT NULL,
+	time_updated INTEGER NOT NULL,
+	data TEXT NOT NULL,
+	FOREIGN KEY (message_id) REFERENCES message(id)
+);
+`
+
+func newLegacyOpenCodeTestDB(t *testing.T) (string, *OpenCodeSeeder, *sql.DB) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "opencode-legacy.db")
+	db, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err, "open legacy test db")
+	_, err = db.Exec(openCodeSchemaLegacy)
+	require.NoError(t, err, "create legacy schema")
+	return dbPath, &OpenCodeSeeder{db: db, t: t}, db
+}
+
+func TestParseOpenCodeDB_LegacySchemaWithoutDirectoryUsesProjectWorktree(t *testing.T) {
+	dbPath, seeder, db := newLegacyOpenCodeTestDB(t)
+	defer db.Close()
+
+	seeder.AddProject("prj_legacy", "/home/user/code/legacy-app")
+	// AddSession inserts without directory; legacy schema has no such column.
+	seeder.AddSession(
+		"ses_legacy", "prj_legacy", "", "Legacy Session",
+		1700000000000, 1700000010000,
+	)
+	seeder.AddMessage("msg_1", "ses_legacy", 1700000000000, 1700000000000, `{"role":"user"}`)
+	seeder.AddPart(
+		"prt_1", "msg_1", "ses_legacy",
+		1700000000000, 1700000000000,
+		`{"type":"text","text":"hello from legacy schema"}`,
+	)
+
+	// Confirm the column is actually absent so the test would fail closed
+	// if the modern SELECT path were used.
+	hasDir, err := openCodeSessionTableHasDirectory(db)
+	require.NoError(t, err)
+	require.False(t, hasDir, "legacy fixture must omit session.directory")
+
+	sessions, err := parseOpenCodeAll(dbPath, "testmachine")
+	require.NoError(t, err, "ParseOpenCodeDB on legacy schema")
+	require.Len(t, sessions, 1)
+
+	s := sessions[0].Session
+	assert.Equal(t, "/home/user/code/legacy-app", s.Cwd)
+	assert.Equal(t, "legacy_app", s.Project)
+}
+
+func TestParseOpenCodeDB_ModernSchemaDirectoryColumnDetected(t *testing.T) {
+	dbPath, seeder, db := newTestDB(t)
+	defer db.Close()
+	seedStandardSession(t, seeder)
+
+	hasDir, err := openCodeSessionHasDirectoryCached(db, dbPath)
+	require.NoError(t, err)
+	assert.True(t, hasDir, "modern fixture must include session.directory")
+
+	sessions, err := parseOpenCodeAll(dbPath, "testmachine")
+	require.NoError(t, err)
+	require.Len(t, sessions, 1)
+	assert.Equal(t, "/home/user/code/myapp", sessions[0].Session.Cwd)
 }
 
 func TestParseOpenCodeSession_SingleSession(t *testing.T) {

--- a/internal/parser/opencode_test.go
+++ b/internal/parser/opencode_test.go
@@ -52,6 +52,7 @@ CREATE TABLE session (
 	project_id TEXT NOT NULL,
 	parent_id TEXT,
 	title TEXT,
+	directory TEXT NOT NULL DEFAULT '',
 	time_created INTEGER NOT NULL,
 	time_updated INTEGER NOT NULL,
 	FOREIGN KEY (project_id) REFERENCES project(id)
@@ -95,6 +96,14 @@ func (s *OpenCodeSeeder) AddProject(id, worktree string) {
 
 func (s *OpenCodeSeeder) AddSession(id, projectID, parentID, title string, timeCreated, timeUpdated int64) {
 	s.t.Helper()
+	s.AddSessionDirectory(id, projectID, parentID, title, "", timeCreated, timeUpdated)
+}
+
+func (s *OpenCodeSeeder) AddSessionDirectory(
+	id, projectID, parentID, title, directory string,
+	timeCreated, timeUpdated int64,
+) {
+	s.t.Helper()
 
 	var pID, tStr any
 	if parentID != "" {
@@ -104,8 +113,13 @@ func (s *OpenCodeSeeder) AddSession(id, projectID, parentID, title string, timeC
 		tStr = title
 	}
 
-	_, err := s.db.Exec(`INSERT INTO session (id, project_id, parent_id, title, time_created, time_updated) VALUES (?, ?, ?, ?, ?, ?)`,
-		id, projectID, pID, tStr, timeCreated, timeUpdated)
+	_, err := s.db.Exec(
+		`INSERT INTO session
+			(id, project_id, parent_id, title, directory,
+			 time_created, time_updated)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		id, projectID, pID, tStr, directory, timeCreated, timeUpdated,
+	)
 	require.NoError(s.t, err, "add session")
 }
 
@@ -1010,6 +1024,108 @@ func TestParseOpenCodeDB_ProjectFromWorktree(t *testing.T) {
 	assertEq(t, "sessions len", len(sessions), 1)
 
 	assertEq(t, "Project", sessions[0].Session.Project, "my_project")
+}
+
+func TestResolveOpenCodeWorktree(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		session string
+		project string
+		want    string
+	}{
+		{
+			name:    "prefers concrete session directory over global project",
+			session: "/home/user/code/myapp",
+			project: "/",
+			want:    "/home/user/code/myapp",
+		},
+		{
+			name:    "falls back when session directory empty",
+			session: "",
+			project: "/home/user/code/myapp",
+			want:    "/home/user/code/myapp",
+		},
+		{
+			name:    "falls back when session directory is root",
+			session: "/",
+			project: "/home/user/code/myapp",
+			want:    "/home/user/code/myapp",
+		},
+		{
+			name:    "trims session directory whitespace",
+			session: "  /home/user/code/myapp  ",
+			project: "/",
+			want:    "/home/user/code/myapp",
+		},
+		{
+			name:    "keeps project root when session unusable",
+			session: "/",
+			project: "/",
+			want:    "/",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := resolveOpenCodeWorktree(tt.session, tt.project)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseOpenCodeDB_PrefersSessionDirectoryOverGlobalProject(t *testing.T) {
+	dbPath, seeder, db := newTestDB(t)
+	defer db.Close()
+
+	// OpenCode's synthetic global project uses worktree="/".
+	seeder.AddProject("global", "/")
+	seeder.AddSessionDirectory(
+		"ses_global", "global", "", "Global Session",
+		"/home/user/code/lonely-app",
+		1700000000000, 1700000010000,
+	)
+	seeder.AddMessage("msg_1", "ses_global", 1700000000000, 1700000000000, `{"role":"user"}`)
+	seeder.AddPart(
+		"prt_1", "msg_1", "ses_global",
+		1700000000000, 1700000000000,
+		`{"type":"text","text":"hello from global project"}`,
+	)
+
+	sessions, err := parseOpenCodeAll(dbPath, "testmachine")
+	require.NoError(t, err, "ParseOpenCodeDB")
+	require.Len(t, sessions, 1)
+
+	s := sessions[0].Session
+	assert.Equal(t, "/home/user/code/lonely-app", s.Cwd)
+	assert.Equal(t, "lonely_app", s.Project)
+	assert.NotEqual(t, "unknown", s.Project)
+}
+
+func TestParseOpenCodeDB_EmptySessionDirectoryUsesProjectWorktree(t *testing.T) {
+	dbPath, seeder, db := newTestDB(t)
+	defer db.Close()
+
+	seeder.AddProject("prj_1", "/home/user/code/myapp")
+	seeder.AddSessionDirectory(
+		"ses_empty_dir", "prj_1", "", "No Directory",
+		"",
+		1700000000000, 1700000010000,
+	)
+	seeder.AddMessage("msg_1", "ses_empty_dir", 1700000000000, 1700000000000, `{"role":"user"}`)
+	seeder.AddPart(
+		"prt_1", "msg_1", "ses_empty_dir",
+		1700000000000, 1700000000000,
+		`{"type":"text","text":"hello"}`,
+	)
+
+	sessions, err := parseOpenCodeAll(dbPath, "testmachine")
+	require.NoError(t, err, "ParseOpenCodeDB")
+	require.Len(t, sessions, 1)
+
+	s := sessions[0].Session
+	assert.Equal(t, "/home/user/code/myapp", s.Cwd)
+	assert.Equal(t, "myapp", s.Project)
 }
 
 func TestParseOpenCodeSession_SingleSession(t *testing.T) {

--- a/internal/parser/opencode_test.go
+++ b/internal/parser/opencode_test.go
@@ -940,13 +940,16 @@ func TestParseOpenCodeDB_SkillNameFromReadToolRelativePath(t *testing.T) {
 	// Frontmatter name intentionally differs from the folder name
 	// ("renamed") to prove we read frontmatter, not the directory.
 	path := writeTestSkill(t, "renamed", "actual-skill")
-	worktree := filepath.Dir(filepath.Dir(filepath.Dir(path)))
+	directory := filepath.Dir(filepath.Dir(filepath.Dir(path)))
 
 	dbPath, seeder, db := newTestDB(t)
 	defer db.Close()
 
-	seeder.AddProject("prj_1", worktree)
-	seeder.AddSession("ses_rel", "prj_1", "", "", 1700000000000, 1700000030000)
+	seeder.AddProject("prj_1", filepath.Join(t.TempDir(), "project-root"))
+	seeder.AddSessionDirectory(
+		"ses_rel", "prj_1", "", "", directory,
+		1700000000000, 1700000030000,
+	)
 
 	seeder.AddMessage("msg_u", "ses_rel", 1700000000000, 1700000000000, `{"role":"user"}`)
 	seeder.AddPart("prt_u", "msg_u", "ses_rel", 1700000000000, 1700000000000, `{"type":"text","text":"read the skill"}`)
@@ -1117,6 +1120,39 @@ func TestParseOpenCodeDB_PrefersSessionDirectoryOverGlobalProject(t *testing.T) 
 	assert.Equal(t, "/home/user/code/lonely-app", s.Cwd)
 	assert.Equal(t, "lonely_app", s.Project)
 	assert.NotEqual(t, "unknown", s.Project)
+}
+
+func TestParseOpenCodeDB_ProjectFromUnavailableProjectWorktree(t *testing.T) {
+	dbPath, seeder, db := newTestDB(t)
+	defer db.Close()
+
+	worktree := filepath.Join(t.TempDir(), "unavailable-repo")
+	directory := filepath.Join(worktree, "subdir")
+	_, err := os.Stat(worktree)
+	require.Error(t, err)
+	require.True(t, os.IsNotExist(err), "project checkout must be unavailable")
+
+	seeder.AddProject("prj_unavailable", worktree)
+	seeder.AddSessionDirectory(
+		"ses_subdir", "prj_unavailable", "", "Unavailable Checkout",
+		directory, 1700000000000, 1700000010000,
+	)
+	seeder.AddMessage(
+		"msg_1", "ses_subdir", 1700000000000, 1700000000000,
+		`{"role":"user"}`,
+	)
+	seeder.AddPart(
+		"prt_1", "msg_1", "ses_subdir",
+		1700000000000, 1700000000000,
+		`{"type":"text","text":"hello"}`,
+	)
+
+	sessions, err := parseOpenCodeAll(dbPath, "testmachine")
+	require.NoError(t, err)
+	require.Len(t, sessions, 1)
+
+	assert.Equal(t, directory, sessions[0].Session.Cwd)
+	assert.Equal(t, "unavailable_repo", sessions[0].Session.Project)
 }
 
 func TestParseOpenCodeDB_EmptySessionDirectoryUsesProjectWorktree(t *testing.T) {

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -6061,6 +6061,55 @@ func TestSyncEngineOpenCodeBulkSync(t *testing.T) {
 	)
 }
 
+func TestSyncEngineOpenCodeDataVersionRefreshesUnchangedCwdProject(
+	t *testing.T,
+) {
+	env := setupSingleAgentTestEnv(t, parser.AgentOpenCode)
+	oc := createOpenCodeDB(t, env.opencodeDir)
+	oc.mustExec(t, "add session directory column",
+		`ALTER TABLE session
+		 ADD COLUMN directory TEXT NOT NULL DEFAULT ''`,
+	)
+	oc.addProject(t, "global", "/")
+
+	const sessionID = "oc-global-session"
+	oc.mustExec(t, "insert session directory",
+		`INSERT INTO session
+			(id, project_id, directory, time_created, time_updated)
+		 VALUES (?, ?, ?, ?, ?)`,
+		sessionID, "global", "/home/user/code/lonely-app",
+		int64(1704067200000), int64(1704067205000),
+	)
+	oc.addMessage(t, "msg-u1", sessionID, "user", 1704067200000)
+	oc.addTextPart(
+		t, "part-u1", sessionID, "msg-u1", "hello", 1704067200000,
+	)
+
+	stats := env.engine.SyncAll(context.Background(), nil)
+	require.Equal(t, 1, stats.Synced)
+
+	agentviewID := "opencode:" + sessionID
+	stored := openCodeStoredSession(t, env.db, agentviewID)
+	stored.Cwd = "/"
+	stored.Project = "unknown"
+	require.NoError(t, env.db.UpsertSession(*stored))
+	require.NoError(t, env.db.SetSessionDataVersion(agentviewID, 70))
+
+	sourceState, ok := parser.StatSQLiteContainerState(oc.path)
+	require.True(t, ok)
+	stats = env.engine.SyncAll(context.Background(), nil)
+	require.Equal(t, 1, stats.Synced)
+	afterState, ok := parser.StatSQLiteContainerState(oc.path)
+	require.True(t, ok)
+	assert.Equal(t, sourceState, afterState, "source database must remain unchanged")
+
+	assertSessionState(t, env.db, agentviewID, func(sess *db.Session) {
+		assert.Equal(t, "/home/user/code/lonely-app", sess.Cwd)
+		assert.Equal(t, "lonely_app", sess.Project)
+		assert.Equal(t, db.CurrentDataVersion(), sess.DataVersion)
+	})
+}
+
 func TestSyncEngineOpenCodeReviewWithGeneratedTitleIsAutomated(
 	t *testing.T,
 ) {


### PR DESCRIPTION
## Why

OpenCode sessions under the synthetic `global` project were imported with `cwd=/` and project `unknown`, even when `session.directory` held a real working directory. That left recent OpenCode work ungrouped and blocked worktree mappings (see #1236).

## What Changed

- Load `session.directory` from the OpenCode SQLite session row.
- Resolve cwd with `resolveOpenCodeWorktree`: prefer a concrete session directory over `project.worktree`, treating `/` as unusable.
- Derive project from the resolved cwd as before.
- Document the global-project directory behavior in `docs/internal/session-format-sources.md`.
- Cover the resolver and global-project parse path with unit tests.

Closes #1236