### PR TITLE
feat(recall): add session evidence panel

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1148,6 +1148,7 @@
   "session_recall_error": "Could not load distilled recall.",
   "session_recall_generation": "Generation",
   "session_recall_review_state": "Review state",
+  "session_recall_provenance_revoked": "Provenance revoked",
   "session_recall_evidence_range": "Messages {start}–{end}",
   "session_recall_jump_evidence": "Jump to transcript messages {start}–{end}",
   "session_vitals_title": "Analysis",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1142,6 +1142,14 @@
       }
     }
   ],
+  "session_recall_title": "Recall",
+  "session_recall_loading": "Loading distilled recall…",
+  "session_recall_empty": "No distilled recall for this session.",
+  "session_recall_error": "Could not load distilled recall.",
+  "session_recall_generation": "Generation",
+  "session_recall_review_state": "Review state",
+  "session_recall_evidence_range": "Messages {start}–{end}",
+  "session_recall_jump_evidence": "Jump to transcript messages {start}–{end}",
   "session_vitals_title": "Analysis",
   "session_vitals_subtitle": "Session vital signs",
   "session_vitals_close": "Close session analysis",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1142,6 +1142,14 @@
       }
     }
   ],
+  "session_recall_title": "Mémoire",
+  "session_recall_loading": "Chargement des mémoires distillées…",
+  "session_recall_empty": "Aucune mémoire distillée pour cette session.",
+  "session_recall_error": "Impossible de charger les mémoires distillées.",
+  "session_recall_generation": "Génération",
+  "session_recall_review_state": "État de révision",
+  "session_recall_evidence_range": "Messages {start}–{end}",
+  "session_recall_jump_evidence": "Aller aux messages {start}–{end} de la transcription",
   "session_vitals_title": "Analyse",
   "session_vitals_subtitle": "Signes vitaux de la session",
   "session_vitals_close": "Fermer l'analyse de la session",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1148,6 +1148,7 @@
   "session_recall_error": "Impossible de charger les mémoires distillées.",
   "session_recall_generation": "Génération",
   "session_recall_review_state": "État de révision",
+  "session_recall_provenance_revoked": "Provenance révoquée",
   "session_recall_evidence_range": "Messages {start}–{end}",
   "session_recall_jump_evidence": "Aller aux messages {start}–{end} de la transcription",
   "session_vitals_title": "Analyse",

--- a/frontend/messages/ko.json
+++ b/frontend/messages/ko.json
@@ -1112,6 +1112,14 @@
       }
     }
   ],
+  "session_recall_title": "리콜",
+  "session_recall_loading": "추출된 리콜을 불러오는 중…",
+  "session_recall_empty": "이 세션에 추출된 리콜이 없습니다.",
+  "session_recall_error": "추출된 리콜을 불러올 수 없습니다.",
+  "session_recall_generation": "세대",
+  "session_recall_review_state": "검토 상태",
+  "session_recall_evidence_range": "메시지 {start}–{end}",
+  "session_recall_jump_evidence": "대화 기록 메시지 {start}–{end}(으)로 이동",
   "session_vitals_title": "분석",
   "session_vitals_subtitle": "세션 바이탈 사인",
   "session_vitals_close": "세션 분석 닫기",

--- a/frontend/messages/ko.json
+++ b/frontend/messages/ko.json
@@ -1118,6 +1118,7 @@
   "session_recall_error": "추출된 리콜을 불러올 수 없습니다.",
   "session_recall_generation": "세대",
   "session_recall_review_state": "검토 상태",
+  "session_recall_provenance_revoked": "출처가 취소됨",
   "session_recall_evidence_range": "메시지 {start}–{end}",
   "session_recall_jump_evidence": "대화 기록 메시지 {start}–{end}(으)로 이동",
   "session_vitals_title": "분석",

--- a/frontend/messages/zh-CN.json
+++ b/frontend/messages/zh-CN.json
@@ -1110,6 +1110,14 @@
       }
     }
   ],
+  "session_recall_title": "记忆",
+  "session_recall_loading": "正在加载提炼记忆…",
+  "session_recall_empty": "此会话没有提炼记忆。",
+  "session_recall_error": "无法加载提炼记忆。",
+  "session_recall_generation": "代次",
+  "session_recall_review_state": "审核状态",
+  "session_recall_evidence_range": "消息 {start}–{end}",
+  "session_recall_jump_evidence": "跳转到转录消息 {start}–{end}",
   "session_vitals_title": "分析",
   "session_vitals_subtitle": "会话指标",
   "session_vitals_close": "关闭会话分析",

--- a/frontend/messages/zh-CN.json
+++ b/frontend/messages/zh-CN.json
@@ -1116,6 +1116,7 @@
   "session_recall_error": "无法加载提炼记忆。",
   "session_recall_generation": "代次",
   "session_recall_review_state": "审核状态",
+  "session_recall_provenance_revoked": "来源已撤销",
   "session_recall_evidence_range": "消息 {start}–{end}",
   "session_recall_jump_evidence": "跳转到转录消息 {start}–{end}",
   "session_vitals_title": "分析",

--- a/frontend/messages/zh-TW.json
+++ b/frontend/messages/zh-TW.json
@@ -1110,6 +1110,14 @@
       }
     }
   ],
+  "session_recall_title": "記憶",
+  "session_recall_loading": "正在載入提煉記憶…",
+  "session_recall_empty": "此工作階段沒有提煉記憶。",
+  "session_recall_error": "無法載入提煉記憶。",
+  "session_recall_generation": "代次",
+  "session_recall_review_state": "審核狀態",
+  "session_recall_evidence_range": "訊息 {start}–{end}",
+  "session_recall_jump_evidence": "跳至逐字稿訊息 {start}–{end}",
   "session_vitals_title": "分析",
   "session_vitals_subtitle": "會話指標",
   "session_vitals_close": "關閉會話分析",

--- a/frontend/messages/zh-TW.json
+++ b/frontend/messages/zh-TW.json
@@ -1116,6 +1116,7 @@
   "session_recall_error": "無法載入提煉記憶。",
   "session_recall_generation": "代次",
   "session_recall_review_state": "審核狀態",
+  "session_recall_provenance_revoked": "來源已撤銷",
   "session_recall_evidence_range": "訊息 {start}–{end}",
   "session_recall_jump_evidence": "跳至逐字稿訊息 {start}–{end}",
   "session_vitals_title": "分析",

--- a/frontend/src/lib/api/recall.ts
+++ b/frontend/src/lib/api/recall.ts
@@ -1,0 +1,34 @@
+import type {
+  RecallEntriesResponse,
+  RecallEntry,
+} from "./types/recall.js";
+import {
+  ApiError,
+  authHeaders,
+  getBase,
+  responseErrorMessage,
+} from "./runtime.js";
+
+const SESSION_RECALL_LIMIT = 500;
+
+export async function fetchSessionRecall(
+  sessionId: string,
+  signal?: AbortSignal,
+): Promise<RecallEntry[]> {
+  const query = new URLSearchParams({
+    source_session_id: sessionId,
+    limit: String(SESSION_RECALL_LIMIT),
+  });
+  const response = await fetch(
+    `${getBase()}/recall/entries?${query.toString()}`,
+    authHeaders({ signal }),
+  );
+  if (!response.ok) {
+    throw new ApiError(
+      response.status,
+      await responseErrorMessage(response),
+    );
+  }
+  const data = (await response.json()) as RecallEntriesResponse;
+  return data.entries ?? [];
+}

--- a/frontend/src/lib/api/types/index.ts
+++ b/frontend/src/lib/api/types/index.ts
@@ -7,3 +7,4 @@ export type * from "./insights.js";
 export type * from "./session-activity.js";
 export type * from "./timing.js";
 export type * from "./usage.js";
+export type * from "./recall.js";

--- a/frontend/src/lib/api/types/recall.ts
+++ b/frontend/src/lib/api/types/recall.ts
@@ -1,0 +1,32 @@
+export interface RecallEvidence {
+  id: number;
+  entry_id: string;
+  session_id: string;
+  message_start_ordinal: number;
+  message_end_ordinal: number;
+  snippet?: string;
+}
+
+export interface RecallEntry {
+  id: string;
+  type: string;
+  scope: string;
+  status: string;
+  review_state: string;
+  title: string;
+  body: string;
+  source_session_id: string;
+  source_run_id?: string;
+  extractor_method?: string;
+  model?: string;
+  transferable: boolean;
+  provenance_ok: boolean;
+  created_at: string;
+  updated_at: string;
+  evidence?: RecallEvidence[];
+}
+
+export interface RecallEntriesResponse {
+  entries: RecallEntry[];
+  trusted_only: boolean;
+}

--- a/frontend/src/lib/components/content/RecallPanel.svelte
+++ b/frontend/src/lib/components/content/RecallPanel.svelte
@@ -78,6 +78,11 @@
         <Card level="inset" padding="none" class="recall-entry">
           <div class="recall-entry-head">
             <span class="recall-type">{entry.type}</span>
+            {#if !entry.provenance_ok}
+              <span class="recall-provenance-revoked">
+                {m.session_recall_provenance_revoked()}
+              </span>
+            {/if}
           </div>
           <h3>{entry.title}</h3>
           <p class="recall-body">{entry.body}</p>
@@ -96,18 +101,24 @@
           {#if entry.evidence?.length}
             <div class="recall-evidence">
               {#each entry.evidence as evidence (evidence.id)}
-                <Button
-                  class="recall-evidence-button"
-                  size="sm"
-                  tone="neutral"
-                  surface="outline"
-                  label={evidenceLabel(evidence)}
-                  title={m.session_recall_jump_evidence({
-                    start: evidence.message_start_ordinal,
-                    end: evidence.message_end_ordinal,
-                  })}
-                  onclick={() => jumpToEvidence(evidence)}
-                />
+                {#if entry.provenance_ok}
+                  <Button
+                    class="recall-evidence-button"
+                    size="sm"
+                    tone="neutral"
+                    surface="outline"
+                    label={evidenceLabel(evidence)}
+                    title={m.session_recall_jump_evidence({
+                      start: evidence.message_start_ordinal,
+                      end: evidence.message_end_ordinal,
+                    })}
+                    onclick={() => jumpToEvidence(evidence)}
+                  />
+                {:else}
+                  <span class="recall-evidence-revoked">
+                    {evidenceLabel(evidence)}
+                  </span>
+                {/if}
               {/each}
             </div>
           {/if}
@@ -177,6 +188,10 @@
     text-transform: uppercase;
   }
 
+  .recall-provenance-revoked {
+    color: var(--slow-fg);
+  }
+
   h3 {
     margin: 0;
     color: var(--text-primary);
@@ -230,6 +245,12 @@
   }
 
   :global(.recall-evidence-button) {
+    font-family: var(--font-mono);
+    font-size: 9px;
+  }
+
+  .recall-evidence-revoked {
+    color: var(--text-muted);
     font-family: var(--font-mono);
     font-size: 9px;
   }

--- a/frontend/src/lib/components/content/RecallPanel.svelte
+++ b/frontend/src/lib/components/content/RecallPanel.svelte
@@ -1,0 +1,236 @@
+<script lang="ts">
+  import { Button, Card } from "@kenn-io/kit-ui";
+  import { fetchSessionRecall } from "../../api/recall.js";
+  import type {
+    RecallEntry,
+    RecallEvidence,
+  } from "../../api/types/recall.js";
+  import { isAbortError } from "../../api/runtime.js";
+  import { m } from "../../i18n/index.js";
+  import { ui } from "../../stores/ui.svelte.js";
+  import { LatestRead } from "../../utils/latest-read.js";
+
+  interface Props {
+    sessionId: string;
+  }
+
+  let { sessionId }: Props = $props();
+  let entries = $state<RecallEntry[]>([]);
+  let loading = $state(true);
+  let failed = $state(false);
+  const read = new LatestRead();
+
+  async function load(id: string) {
+    const signal = read.begin();
+    loading = true;
+    failed = false;
+    try {
+      const next = await fetchSessionRecall(id, signal);
+      if (!read.isCurrent(signal)) return;
+      entries = next;
+    } catch (error) {
+      if (isAbortError(error) || !read.isCurrent(signal)) return;
+      entries = [];
+      failed = true;
+    } finally {
+      if (read.finish(signal)) loading = false;
+    }
+  }
+
+  function evidenceLabel(evidence: RecallEvidence): string {
+    return m.session_recall_evidence_range({
+      start: evidence.message_start_ordinal,
+      end: evidence.message_end_ordinal,
+    });
+  }
+
+  function jumpToEvidence(evidence: RecallEvidence) {
+    ui.scrollToOrdinal(
+      evidence.message_start_ordinal,
+      evidence.session_id || sessionId,
+    );
+  }
+
+  $effect(() => {
+    const id = sessionId;
+    void load(id);
+    return () => read.cancel();
+  });
+</script>
+
+<section class="recall-panel" aria-labelledby="session-recall-title">
+  <header class="recall-header">
+    <span id="session-recall-title">{m.session_recall_title()}</span>
+    {#if !loading && !failed}
+      <span class="recall-count">{entries.length}</span>
+    {/if}
+  </header>
+
+  {#if loading}
+    <p class="recall-state">{m.session_recall_loading()}</p>
+  {:else if failed}
+    <p class="recall-state recall-error">{m.session_recall_error()}</p>
+  {:else if entries.length === 0}
+    <p class="recall-state">{m.session_recall_empty()}</p>
+  {:else}
+    <div class="recall-list">
+      {#each entries as entry (entry.id)}
+        <Card level="inset" padding="none" class="recall-entry">
+          <div class="recall-entry-head">
+            <span class="recall-type">{entry.type}</span>
+          </div>
+          <h3>{entry.title}</h3>
+          <p class="recall-body">{entry.body}</p>
+          <dl class="recall-meta">
+            <div>
+              <dt>{m.session_recall_generation()}</dt>
+              <dd title={entry.source_run_id || undefined}>
+                {entry.source_run_id || "—"}
+              </dd>
+            </div>
+            <div>
+              <dt>{m.session_recall_review_state()}</dt>
+              <dd>{entry.review_state}</dd>
+            </div>
+          </dl>
+          {#if entry.evidence?.length}
+            <div class="recall-evidence">
+              {#each entry.evidence as evidence (evidence.id)}
+                <Button
+                  class="recall-evidence-button"
+                  size="sm"
+                  tone="neutral"
+                  surface="outline"
+                  label={evidenceLabel(evidence)}
+                  title={m.session_recall_jump_evidence({
+                    start: evidence.message_start_ordinal,
+                    end: evidence.message_end_ordinal,
+                  })}
+                  onclick={() => jumpToEvidence(evidence)}
+                />
+              {/each}
+            </div>
+          {/if}
+        </Card>
+      {/each}
+    </div>
+  {/if}
+</section>
+
+<style>
+  .recall-panel {
+    padding: 12px 14px 14px;
+    border-bottom: 1px solid var(--border-muted);
+  }
+
+  .recall-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 9px;
+    color: var(--text-muted);
+    font-size: 9px;
+    font-weight: 500;
+    letter-spacing: 0.6px;
+    text-transform: uppercase;
+  }
+
+  .recall-count {
+    font-family: var(--font-mono);
+    letter-spacing: 0;
+  }
+
+  .recall-state {
+    margin: 0;
+    color: var(--text-muted);
+    font-size: 10px;
+    line-height: 1.45;
+  }
+
+  .recall-error {
+    color: var(--slow-fg);
+  }
+
+  .recall-list {
+    display: grid;
+    gap: var(--space-5);
+  }
+
+  :global(.recall-entry) {
+    min-width: 0;
+    padding: var(--space-4);
+  }
+
+  .recall-entry-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    margin-bottom: 6px;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-size: 9px;
+  }
+
+  .recall-type {
+    color: var(--accent-blue);
+    text-transform: uppercase;
+  }
+
+  h3 {
+    margin: 0;
+    color: var(--text-primary);
+    font-size: 11px;
+    font-weight: 600;
+    line-height: 1.35;
+  }
+
+  .recall-body {
+    margin: 5px 0 0;
+    color: var(--text-secondary);
+    font-size: 10px;
+    line-height: 1.45;
+    overflow-wrap: anywhere;
+  }
+
+  .recall-meta {
+    display: grid;
+    gap: var(--space-2);
+    margin: 8px 0 0;
+    padding-top: 7px;
+    border-top: 1px solid var(--border-muted);
+    font-family: var(--font-mono);
+    font-size: 9px;
+  }
+
+  .recall-meta > div {
+    display: grid;
+    grid-template-columns: 68px minmax(0, 1fr);
+    gap: 6px;
+  }
+
+  dt {
+    color: var(--text-muted);
+  }
+
+  dd {
+    min-width: 0;
+    margin: 0;
+    overflow: hidden;
+    color: var(--text-primary);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .recall-evidence {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    margin-top: 8px;
+  }
+
+  :global(.recall-evidence-button) {
+    font-family: var(--font-mono);
+    font-size: 9px;
+  }
+</style>

--- a/frontend/src/lib/components/content/SessionVitals.svelte
+++ b/frontend/src/lib/components/content/SessionVitals.svelte
@@ -18,6 +18,7 @@
     TurnTiming,
   } from "../../api/types/timing.js";
   import ActivityLane from "./ActivityLane.svelte";
+  import RecallPanel from "./RecallPanel.svelte";
   import CallRow from "./CallRow.svelte";
   import CallGroup from "./CallGroup.svelte";
   import SubagentCalls from "./SubagentCalls.svelte";
@@ -397,6 +398,8 @@
       {/if}
     </section>
   {/if}
+
+  <RecallPanel {sessionId} />
 
   {#if timing}
     {#if timing.by_category.length > 0}

--- a/frontend/src/lib/components/content/SessionVitals.test.ts
+++ b/frontend/src/lib/components/content/SessionVitals.test.ts
@@ -64,6 +64,19 @@ describe("SessionVitals", () => {
 
   beforeEach(() => {
     mocks.fetchSessionTiming.mockReset().mockResolvedValue(mocks.timing);
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/v1/recall/entries?")) {
+        return new Response(
+          JSON.stringify({ entries: [], trusted_only: false }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response(
+        JSON.stringify({ error: "not mocked" }),
+        { status: 500, headers: { "Content-Type": "application/json" } },
+      );
+    }));
     sessionTiming.reset();
     ui.vitalsOpen = true;
   });
@@ -179,6 +192,87 @@ describe("SessionVitals", () => {
     worktreeCopy!.click();
     await Promise.resolve();
     expect(writeText).toHaveBeenNthCalledWith(2, traceSession.cwd);
+  });
+
+  it("shows distilled recall and jumps to its transcript evidence", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(
+      JSON.stringify({
+        entries: [{
+          id: "recall-1",
+          type: "fact",
+          scope: "project",
+          status: "accepted",
+          review_state: "unreviewed_auto",
+          title: "Retry bounded background work",
+          body: "Background retries stop after one delayed attempt.",
+          source_session_id: "sess-1",
+          source_run_id: "generation-2026-07-23",
+          extractor_method: "turns-v1",
+          transferable: false,
+          provenance_ok: true,
+          created_at: "2026-07-23T10:00:00Z",
+          updated_at: "2026-07-23T10:00:00Z",
+          evidence: [{
+            id: 1,
+            entry_id: "recall-1",
+            session_id: "sess-1",
+            message_start_ordinal: 12,
+            message_end_ordinal: 14,
+            snippet: "Bound the retry lifecycle.",
+          }],
+        }],
+        trusted_only: false,
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    ));
+    vi.stubGlobal("fetch", fetchMock);
+    const scroll = vi.spyOn(ui, "scrollToOrdinal");
+    component = mount(SessionVitals, {
+      target: document.body,
+      props: { sessionId: "sess-1", session: traceSession },
+    });
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "/api/v1/recall/entries?source_session_id=sess-1",
+        ),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+    await vi.waitFor(() => {
+      expect(document.body.textContent).toContain(
+        "Retry bounded background work",
+      );
+    });
+    expect(document.body.textContent).toContain(
+      "Background retries stop after one delayed attempt.",
+    );
+    expect(document.body.textContent).toContain("fact");
+    expect(document.body.textContent).toContain("unreviewed_auto");
+    expect(document.body.textContent).toContain("generation-2026-07-23");
+
+    const evidenceButton = Array.from(
+      document.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((button) => button.textContent?.includes("12–14"));
+    expect(evidenceButton).toBeDefined();
+    evidenceButton!.click();
+
+    expect(scroll).toHaveBeenCalledWith(12, "sess-1");
+    scroll.mockRestore();
+  });
+
+  it("shows an empty Recall state for a session without distilled entries", async () => {
+    component = mount(SessionVitals, {
+      target: document.body,
+      props: { sessionId: "sess-1", session: traceSession },
+    });
+
+    await vi.waitFor(() => {
+      expect(document.body.textContent).toContain(
+        m.session_recall_empty(),
+      );
+    });
   });
 
   it("aborts a pending sub-agent timing read when collapsed", async () => {

--- a/frontend/src/lib/components/content/SessionVitals.test.ts
+++ b/frontend/src/lib/components/content/SessionVitals.test.ts
@@ -262,6 +262,54 @@ describe("SessionVitals", () => {
     scroll.mockRestore();
   });
 
+  it("labels revoked recall provenance and does not link its evidence", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(
+      JSON.stringify({
+        entries: [{
+          id: "recall-revoked",
+          type: "fact",
+          scope: "project",
+          status: "accepted",
+          review_state: "unreviewed_auto",
+          title: "Outdated transcript claim",
+          body: "This entry no longer has valid source provenance.",
+          source_session_id: "sess-1",
+          source_run_id: "generation-revoked",
+          extractor_method: "turns-v1",
+          transferable: false,
+          provenance_ok: false,
+          created_at: "2026-07-23T10:00:00Z",
+          updated_at: "2026-07-23T10:00:00Z",
+          evidence: [{
+            id: 2,
+            entry_id: "recall-revoked",
+            session_id: "sess-1",
+            message_start_ordinal: 21,
+            message_end_ordinal: 23,
+            snippet: "This source range was revoked.",
+          }],
+        }],
+        trusted_only: false,
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    ));
+    vi.stubGlobal("fetch", fetchMock);
+    component = mount(SessionVitals, {
+      target: document.body,
+      props: { sessionId: "sess-1", session: traceSession },
+    });
+
+    await vi.waitFor(() => {
+      expect(document.body.textContent).toContain("Outdated transcript claim");
+    });
+    expect(document.body.textContent).toContain("Provenance revoked");
+    expect(document.body.textContent).toContain("Messages 21–23");
+    const evidenceButton = Array.from(
+      document.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((button) => button.textContent?.includes("21–23"));
+    expect(evidenceButton).toBeUndefined();
+  });
+
   it("shows an empty Recall state for a session without distilled entries", async () => {
     component = mount(SessionVitals, {
       target: document.body,


### PR DESCRIPTION
Adds a read-only Recall panel to the session analysis view. It lists accepted distilled entries with their type, title, body, extraction generation, and review state.

Valid evidence ranges use the existing transcript navigation path, so reviewers can jump directly from an entry to its source messages. Entries with revoked provenance remain visible for diagnosis but are explicitly labeled and their stale evidence ranges are non-interactive. Session-scoped loading is abort-safe, bounded to 500 entries, and localized across the supported catalogs.