### PR TITLE
Fix browser-timezone session date filters

### DIFF
--- a/frontend/src/lib/api/generated/services/SearchService.ts
+++ b/frontend/src/lib/api/generated/services/SearchService.ts
@@ -87,6 +87,7 @@ export class SearchService {
     date,
     dateFrom,
     dateTo,
+    timezone,
     activeSince,
     includeChildren,
     includeAutomated,
@@ -156,6 +157,10 @@ export class SearchService {
      */
     dateTo?: string,
     /**
+     * IANA timezone for calendar-date filters; defaults to UTC
+     */
+    timezone?: string,
+    /**
      * Filter sessions active since this RFC3339 timestamp
      */
     activeSince?: string,
@@ -205,6 +210,7 @@ export class SearchService {
         'date': date,
         'date_from': dateFrom,
         'date_to': dateTo,
+        'timezone': timezone,
         'active_since': activeSince,
         'include_children': includeChildren,
         'include_automated': includeAutomated,

--- a/frontend/src/lib/api/generated/services/SessionsService.ts
+++ b/frontend/src/lib/api/generated/services/SessionsService.ts
@@ -105,6 +105,7 @@ export class SessionsService {
     date,
     dateFrom,
     dateTo,
+    timezone,
     activeSince,
     minMessages,
     maxMessages,
@@ -155,6 +156,10 @@ export class SessionsService {
      * Filter sessions active on or before this date
      */
     dateTo?: string,
+    /**
+     * IANA timezone for calendar-date filters; defaults to UTC
+     */
+    timezone?: string,
     /**
      * Filter sessions active since this RFC3339 timestamp
      */
@@ -236,6 +241,7 @@ export class SessionsService {
         'date': date,
         'date_from': dateFrom,
         'date_to': dateTo,
+        'timezone': timezone,
         'active_since': activeSince,
         'min_messages': minMessages,
         'max_messages': maxMessages,
@@ -313,6 +319,7 @@ export class SessionsService {
     date,
     dateFrom,
     dateTo,
+    timezone,
     activeSince,
     minMessages,
     maxMessages,
@@ -363,6 +370,10 @@ export class SessionsService {
      * Filter sessions active on or before this date
      */
     dateTo?: string,
+    /**
+     * IANA timezone for calendar-date filters; defaults to UTC
+     */
+    timezone?: string,
     /**
      * Filter sessions active since this RFC3339 timestamp
      */
@@ -444,6 +455,7 @@ export class SessionsService {
         'date': date,
         'date_from': dateFrom,
         'date_to': dateTo,
+        'timezone': timezone,
         'active_since': activeSince,
         'min_messages': minMessages,
         'max_messages': maxMessages,

--- a/frontend/src/lib/stores/sessions.svelte.ts
+++ b/frontend/src/lib/stores/sessions.svelte.ts
@@ -381,6 +381,7 @@ class SessionsStore {
       date: f.date || undefined,
       dateFrom: f.dateFrom || undefined,
       dateTo: f.dateTo || undefined,
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
       activeSince: f.recentlyActive
         ? new Date(
             Date.now() - 24 * 60 * 60 * 1000,

--- a/frontend/src/lib/stores/sessions.test.ts
+++ b/frontend/src/lib/stores/sessions.test.ts
@@ -222,7 +222,13 @@ describe("SessionsStore", () => {
   let sessions: ReturnType<typeof createSessionsStore>;
 
   beforeEach(() => {
+    vi.restoreAllMocks();
     vi.clearAllMocks();
+    const resolvedOptions = Intl.DateTimeFormat().resolvedOptions();
+    vi.spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions").mockReturnValue({
+      ...resolvedOptions,
+      timeZone: "America/New_York",
+    });
     vi.mocked(callGenerated).mockImplementation(
       (request: () => Promise<unknown>) => request(),
     );
@@ -1559,6 +1565,14 @@ describe("SessionsStore", () => {
   });
 
   describe("load serialization", () => {
+    it("should pass the browser timezone", async () => {
+      await sessions.load();
+
+      expectSidebarIndexCalledWith({
+        timezone: "America/New_York",
+      });
+    });
+
     it("should omit min/max_messages when 0", async () => {
       sessions.filters.minMessages = 0;
       sessions.filters.maxMessages = 0;
@@ -1668,6 +1682,17 @@ describe("SessionsStore", () => {
   });
 
   describe("loadMore serialization", () => {
+    it("should pass the browser timezone in loadMore", async () => {
+      sessions.nextCursor = "cur-timezone";
+
+      mockSidebarPage();
+      await sessions.loadMore();
+
+      expectPaginatedSidebarIndexCalledWith({
+        timezone: "America/New_York",
+      });
+    });
+
     it("should load the sidebar index once with consistent filters", async () => {
       mockSidebarIndex([
         makeSkinnyRow({ id: "s1" }),

--- a/internal/db/filter_test.go
+++ b/internal/db/filter_test.go
@@ -870,23 +870,23 @@ func TestSessionDateFilterIncludesOverlappingSessions(t *testing.T) {
 	d := testDB(t)
 
 	insertSession(t, d, "before", "proj", func(s *Session) {
-		s.StartedAt = new("2024-06-15T08:00:00Z")
-		s.EndedAt = new("2024-06-15T09:00:00Z")
+		s.StartedAt = new("2024-06-16T02:00:00Z")
+		s.EndedAt = new("2024-06-16T03:59:59Z")
 		s.MessageCount = 2
 	})
 	insertSession(t, d, "spanning", "proj", func(s *Session) {
-		s.StartedAt = new("2024-06-15T23:00:00Z")
+		s.StartedAt = new("2024-06-16T03:00:00Z")
 		s.EndedAt = new("2024-06-16T10:00:00Z")
 		s.MessageCount = 2
 	})
 	insertSession(t, d, "open", "proj", func(s *Session) {
-		s.StartedAt = new("2024-06-15T22:00:00Z")
+		s.StartedAt = new("2024-06-16T02:00:00Z")
 		s.MessageCount = 2
 	})
-	seedMessage(t, d, "open", 1, "user", "2024-06-16T11:00:00Z", "")
+	seedMessage(t, d, "open", 1, "user", "2024-06-17T03:59:59Z", "")
 	insertSession(t, d, "after", "proj", func(s *Session) {
-		s.StartedAt = new("2024-06-17T08:00:00Z")
-		s.EndedAt = new("2024-06-17T09:00:00Z")
+		s.StartedAt = new("2024-06-17T04:00:00Z")
+		s.EndedAt = new("2024-06-17T05:00:00Z")
 		s.MessageCount = 2
 	})
 	insertSession(t, d, "child", "proj", func(s *Session) {
@@ -903,24 +903,33 @@ func TestSessionDateFilterIncludesOverlappingSessions(t *testing.T) {
 		want   []string
 	}{
 		{
-			name:   "ExactDate",
-			filter: SessionFilter{Date: "2024-06-16"},
-			want:   []string{"spanning", "open"},
+			name: "ExactDate",
+			filter: SessionFilter{
+				Date: "2024-06-16", Timezone: "America/New_York",
+			},
+			want: []string{"spanning", "open"},
 		},
 		{
-			name:   "DateRange",
-			filter: SessionFilter{DateFrom: "2024-06-16", DateTo: "2024-06-16"},
-			want:   []string{"spanning", "open"},
+			name: "DateRange",
+			filter: SessionFilter{
+				DateFrom: "2024-06-16", DateTo: "2024-06-16",
+				Timezone: "America/New_York",
+			},
+			want: []string{"spanning", "open"},
 		},
 		{
-			name:   "DateFrom",
-			filter: SessionFilter{DateFrom: "2024-06-16"},
-			want:   []string{"spanning", "open", "after"},
+			name: "DateFrom",
+			filter: SessionFilter{
+				DateFrom: "2024-06-16", Timezone: "America/New_York",
+			},
+			want: []string{"spanning", "open", "after"},
 		},
 		{
-			name:   "DateTo",
-			filter: SessionFilter{DateTo: "2024-06-15"},
-			want:   []string{"before", "spanning", "open"},
+			name: "DateTo",
+			filter: SessionFilter{
+				DateTo: "2024-06-15", Timezone: "America/New_York",
+			},
+			want: []string{"before", "spanning", "open"},
 		},
 	}
 
@@ -931,7 +940,7 @@ func TestSessionDateFilterIncludesOverlappingSessions(t *testing.T) {
 	}
 
 	index, err := d.GetSidebarSessionIndex(context.Background(), SessionFilter{
-		Date: "2024-06-16",
+		Date: "2024-06-16", Timezone: "America/New_York",
 	})
 	require.NoError(t, err, "GetSidebarSessionIndex")
 	requireSidebarIndexIDs(t, index.Sessions, []string{

--- a/internal/db/query_dialect.go
+++ b/internal/db/query_dialect.go
@@ -35,7 +35,6 @@ type QueryDialect struct {
 	dateStartExpr      func(func(string) string) string
 	dateEndExpr        func(func(string) string) string
 	dateParam          func(string) string
-	activityExpr       string
 	activityParam      func(string) string
 	cursorActivityExpr string
 	cursorParam        func(string) string
@@ -71,18 +70,18 @@ func SQLiteQueryDialect() QueryDialect {
 		trueLiteral:      "1",
 		falseLiteral:     "0",
 		dateStartExpr: func(q func(string) string) string {
-			return "date(COALESCE(NULLIF(" + q("started_at") +
+			return "julianday(COALESCE(NULLIF(" + q("started_at") +
 				", ''), " + q("created_at") + "))"
 		},
 		dateEndExpr: func(q func(string) string) string {
-			return "date(COALESCE(NULLIF(" + q("ended_at") +
-				", ''), (SELECT MAX(m.timestamp) FROM messages m" +
+			return "julianday(COALESCE(NULLIF(" + q("ended_at") +
+				", ''), (SELECT m.timestamp FROM messages m" +
 				" WHERE m.session_id = " + outerSessionID(q) +
-				" AND m.timestamp != ''), NULLIF(" + q("started_at") +
+				" AND m.timestamp != '' ORDER BY julianday(m.timestamp)" +
+				" DESC, m.timestamp DESC LIMIT 1), NULLIF(" + q("started_at") +
 				", ''), " + q("created_at") + "))"
 		},
-		dateParam:              func(ph string) string { return ph },
-		activityExpr:           "COALESCE(NULLIF(ended_at, ''), NULLIF(started_at, ''), created_at)",
+		dateParam:              func(ph string) string { return "julianday(" + ph + ")" },
 		activityParam:          func(ph string) string { return ph },
 		cursorActivityExpr:     "COALESCE(NULLIF(ended_at, ''), NULLIF(started_at, ''), created_at)",
 		cursorParam:            func(ph string) string { return ph },
@@ -109,18 +108,17 @@ func PostgresQueryDialect() QueryDialect {
 		trueLiteral:      "TRUE",
 		falseLiteral:     "FALSE",
 		dateStartExpr: func(q func(string) string) string {
-			return "DATE(COALESCE(" + q("started_at") + ", " +
-				q("created_at") + ") AT TIME ZONE 'UTC')"
+			return "COALESCE(" + q("started_at") + ", " +
+				q("created_at") + ")"
 		},
 		dateEndExpr: func(q func(string) string) string {
-			return "DATE(COALESCE(" + q("ended_at") +
+			return "COALESCE(" + q("ended_at") +
 				", (SELECT MAX(m.timestamp) FROM messages m" +
 				" WHERE m.session_id = " + outerSessionID(q) +
 				" AND m.timestamp IS NOT NULL), " + q("started_at") +
-				", " + q("created_at") + ") AT TIME ZONE 'UTC')"
+				", " + q("created_at") + ")"
 		},
-		dateParam:    func(ph string) string { return ph + "::date" },
-		activityExpr: "COALESCE(ended_at, started_at, created_at)",
+		dateParam: func(ph string) string { return ph + "::timestamptz" },
 		activityParam: func(ph string) string {
 			return ph + "::timestamptz"
 		},
@@ -152,19 +150,18 @@ func DuckDBQueryDialect() QueryDialect {
 		falseLiteral:     "FALSE",
 		dateStartExpr: func(q func(string) string) string {
 			return "CAST(COALESCE(" + q("started_at") + ", " +
-				q("created_at") + ") AS DATE)"
+				q("created_at") + ") AS TIMESTAMP)"
 		},
 		dateEndExpr: func(q func(string) string) string {
 			return "CAST(COALESCE(" + q("ended_at") +
 				", (SELECT MAX(m.timestamp) FROM messages m" +
 				" WHERE m.session_id = " + outerSessionID(q) +
 				" AND m.timestamp IS NOT NULL), " + q("started_at") +
-				", " + q("created_at") + ") AS DATE)"
+				", " + q("created_at") + ") AS TIMESTAMP)"
 		},
 		dateParam: func(ph string) string {
-			return "CAST(" + ph + " AS DATE)"
+			return "CAST(" + ph + " AS TIMESTAMP)"
 		},
-		activityExpr:       "COALESCE(ended_at, started_at, created_at)",
 		activityParam:      func(ph string) string { return "CAST(" + ph + " AS TIMESTAMP)" },
 		cursorActivityExpr: "COALESCE(ended_at, started_at, created_at)",
 		cursorParam: func(ph string) string {
@@ -209,6 +206,50 @@ func (d QueryDialect) Qualify(parts ...string) string {
 }
 
 var safeIdentifierRE = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// NormalizeSessionTimezone validates an IANA timezone name and returns the
+// canonical UTC default used when callers omit it. "Local" is intentionally
+// rejected because it depends on the server environment rather than naming a
+// browser-selected zone.
+func NormalizeSessionTimezone(name string) (string, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "UTC", nil
+	}
+	if name == "Local" {
+		return "", fmt.Errorf("invalid timezone: %s", name)
+	}
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		return "", fmt.Errorf("invalid timezone: %s", name)
+	}
+	return loc.String(), nil
+}
+
+func sessionDateBoundary(date, timezone string, nextDay bool) string {
+	name, err := NormalizeSessionTimezone(timezone)
+	if err != nil {
+		// Public HTTP and service inputs validate before reaching the store.
+		// Keep internal store callers deterministic if they violate that
+		// contract rather than making SQL construction panic.
+		name = "UTC"
+	}
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		loc = time.UTC
+	}
+	boundary, err := time.ParseInLocation(time.DateOnly, date, loc)
+	if err != nil {
+		// Dates are likewise validated at public boundaries. Returning the
+		// original value preserves the historical behavior for invalid
+		// internal filters.
+		return date
+	}
+	if nextDay {
+		boundary = boundary.AddDate(0, 0, 1)
+	}
+	return boundary.UTC().Format(time.RFC3339)
+}
 
 // QueryBuilder allocates dialect placeholders and collects bind parameters.
 type QueryBuilder struct {
@@ -554,21 +595,29 @@ func sessionFilterPredicates(
 	}
 	if f.Date != "" {
 		preds = append(preds, "("+b.dialect.dateEndExpr(q)+" >= "+
-			b.dialect.dateParam(b.Add(f.Date))+" AND "+
-			b.dialect.dateStartExpr(q)+" <= "+
-			b.dialect.dateParam(b.Add(f.Date))+")")
+			b.dialect.dateParam(b.Add(sessionDateBoundary(
+				f.Date, f.Timezone, false,
+			)))+" AND "+
+			b.dialect.dateStartExpr(q)+" < "+
+			b.dialect.dateParam(b.Add(sessionDateBoundary(
+				f.Date, f.Timezone, true,
+			)))+")")
 	}
 	if f.DateFrom != "" {
 		preds = append(preds, b.dialect.dateEndExpr(q)+" >= "+
-			b.dialect.dateParam(b.Add(f.DateFrom)))
+			b.dialect.dateParam(b.Add(sessionDateBoundary(
+				f.DateFrom, f.Timezone, false,
+			))))
 	}
 	if f.DateTo != "" {
-		preds = append(preds, b.dialect.dateStartExpr(q)+" <= "+
-			b.dialect.dateParam(b.Add(f.DateTo)))
+		preds = append(preds, b.dialect.dateStartExpr(q)+" < "+
+			b.dialect.dateParam(b.Add(sessionDateBoundary(
+				f.DateTo, f.Timezone, true,
+			))))
 	}
 	if f.ActiveSince != "" {
-		preds = append(preds, b.dialect.activityExpr+" >= "+
-			b.dialect.activityParam(b.Add(f.ActiveSince)))
+		preds = append(preds, b.dialect.dateEndExpr(q)+" >= "+
+			b.dialect.dateParam(b.Add(f.ActiveSince)))
 	}
 	if f.MinMessages > 0 {
 		preds = append(preds,

--- a/internal/db/query_dialect_test.go
+++ b/internal/db/query_dialect_test.go
@@ -28,6 +28,7 @@ func TestBuildSessionFilterSQLRendersEquivalentDialectFilters(t *testing.T) {
 		Date:                 "2026-06-08",
 		DateFrom:             "2026-06-01",
 		DateTo:               "2026-06-30",
+		Timezone:             "America/New_York",
 		ActiveSince:          "2026-06-08T12:00:00Z",
 		MinMessages:          3,
 		MaxMessages:          100,
@@ -59,11 +60,11 @@ func TestBuildSessionFilterSQLRendersEquivalentDialectFilters(t *testing.T) {
 				"project != ?",
 				"machine IN (?,?)",
 				"agent IN (?,?)",
-				"date(COALESCE(NULLIF(ended_at, ''), (SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = sessions.id AND m.timestamp != ''), NULLIF(started_at, ''), created_at)) >= ?",
-				"date(COALESCE(NULLIF(started_at, ''), created_at)) <= ?",
-				"date(COALESCE(NULLIF(ended_at, ''), (SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = sessions.id AND m.timestamp != ''), NULLIF(started_at, ''), created_at)) >= ?",
-				"date(COALESCE(NULLIF(started_at, ''), created_at)) <= ?",
-				"COALESCE(NULLIF(ended_at, ''), NULLIF(started_at, ''), created_at) >= ?",
+				"julianday(COALESCE(NULLIF(ended_at, ''), (SELECT m.timestamp FROM messages m WHERE m.session_id = sessions.id AND m.timestamp != '' ORDER BY julianday(m.timestamp) DESC, m.timestamp DESC LIMIT 1), NULLIF(started_at, ''), created_at)) >= julianday(?)",
+				"julianday(COALESCE(NULLIF(started_at, ''), created_at)) < julianday(?)",
+				"julianday(COALESCE(NULLIF(ended_at, ''), (SELECT m.timestamp FROM messages m WHERE m.session_id = sessions.id AND m.timestamp != '' ORDER BY julianday(m.timestamp) DESC, m.timestamp DESC LIMIT 1), NULLIF(started_at, ''), created_at)) >= julianday(?)",
+				"julianday(COALESCE(NULLIF(started_at, ''), created_at)) < julianday(?)",
+				"julianday(COALESCE(NULLIF(ended_at, ''), (SELECT m.timestamp FROM messages m WHERE m.session_id = sessions.id AND m.timestamp != '' ORDER BY julianday(m.timestamp) DESC, m.timestamp DESC LIMIT 1), NULLIF(started_at, ''), created_at)) >= julianday(?)",
 				"message_count >= ?",
 				"message_count <= ?",
 				"user_message_count >= ?",
@@ -86,11 +87,11 @@ func TestBuildSessionFilterSQLRendersEquivalentDialectFilters(t *testing.T) {
 				"project != $2",
 				"machine IN ($3,$4)",
 				"agent IN ($5,$6)",
-				"DATE(COALESCE(ended_at, (SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = sessions.id AND m.timestamp IS NOT NULL), started_at, created_at) AT TIME ZONE 'UTC') >= $7::date",
-				"DATE(COALESCE(started_at, created_at) AT TIME ZONE 'UTC') <= $8::date",
-				"DATE(COALESCE(ended_at, (SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = sessions.id AND m.timestamp IS NOT NULL), started_at, created_at) AT TIME ZONE 'UTC') >= $9::date",
-				"DATE(COALESCE(started_at, created_at) AT TIME ZONE 'UTC') <= $10::date",
-				"COALESCE(ended_at, started_at, created_at) >= $11::timestamptz",
+				"COALESCE(ended_at, (SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = sessions.id AND m.timestamp IS NOT NULL), started_at, created_at) >= $7::timestamptz",
+				"COALESCE(started_at, created_at) < $8::timestamptz",
+				"COALESCE(ended_at, (SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = sessions.id AND m.timestamp IS NOT NULL), started_at, created_at) >= $9::timestamptz",
+				"COALESCE(started_at, created_at) < $10::timestamptz",
+				"COALESCE(ended_at, (SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = sessions.id AND m.timestamp IS NOT NULL), started_at, created_at) >= $11::timestamptz",
 				"message_count >= $12",
 				"message_count <= $13",
 				"user_message_count >= $14",
@@ -113,11 +114,11 @@ func TestBuildSessionFilterSQLRendersEquivalentDialectFilters(t *testing.T) {
 				"project != ?",
 				"machine IN (?,?)",
 				"agent IN (?,?)",
-				"CAST(COALESCE(ended_at, (SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = sessions.id AND m.timestamp IS NOT NULL), started_at, created_at) AS DATE) >= CAST(? AS DATE)",
-				"CAST(COALESCE(started_at, created_at) AS DATE) <= CAST(? AS DATE)",
-				"CAST(COALESCE(ended_at, (SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = sessions.id AND m.timestamp IS NOT NULL), started_at, created_at) AS DATE) >= CAST(? AS DATE)",
-				"CAST(COALESCE(started_at, created_at) AS DATE) <= CAST(? AS DATE)",
-				"COALESCE(ended_at, started_at, created_at) >= CAST(? AS TIMESTAMP)",
+				"CAST(COALESCE(ended_at, (SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = sessions.id AND m.timestamp IS NOT NULL), started_at, created_at) AS TIMESTAMP) >= CAST(? AS TIMESTAMP)",
+				"CAST(COALESCE(started_at, created_at) AS TIMESTAMP) < CAST(? AS TIMESTAMP)",
+				"CAST(COALESCE(ended_at, (SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = sessions.id AND m.timestamp IS NOT NULL), started_at, created_at) AS TIMESTAMP) >= CAST(? AS TIMESTAMP)",
+				"CAST(COALESCE(started_at, created_at) AS TIMESTAMP) < CAST(? AS TIMESTAMP)",
+				"CAST(COALESCE(ended_at, (SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = sessions.id AND m.timestamp IS NOT NULL), started_at, created_at) AS TIMESTAMP) >= CAST(? AS TIMESTAMP)",
 				"message_count >= ?",
 				"message_count <= ?",
 				"user_message_count >= ?",
@@ -132,7 +133,8 @@ func TestBuildSessionFilterSQLRendersEquivalentDialectFilters(t *testing.T) {
 	}
 	wantArgs := []any{
 		"proj-a", "unknown", "laptop", "server", "claude", "codex",
-		"2026-06-08", "2026-06-08", "2026-06-01", "2026-06-30",
+		"2026-06-08T04:00:00Z", "2026-06-09T04:00:00Z",
+		"2026-06-01T04:00:00Z", "2026-07-01T04:00:00Z",
 		"2026-06-08T12:00:00Z", 3, 100, 2,
 		"success", "failed", "A", "C", 2, "v1", "v2",
 	}
@@ -152,6 +154,32 @@ func TestBuildSessionFilterSQLRendersEquivalentDialectFilters(t *testing.T) {
 			} {
 				assert.NotContains(t, normalized, "'"+value+"'")
 			}
+		})
+	}
+}
+
+func TestBuildSessionFilterSQLResolvesDSTDateBounds(t *testing.T) {
+	filter := SessionFilter{
+		DateFrom: "2024-03-10",
+		DateTo:   "2024-03-10",
+		Timezone: "America/New_York",
+	}
+
+	tests := []struct {
+		name    string
+		dialect QueryDialect
+	}{
+		{name: "sqlite", dialect: SQLiteQueryDialect()},
+		{name: "postgres", dialect: PostgresQueryDialect()},
+		{name: "duckdb", dialect: DuckDBQueryDialect()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, args := BuildSessionFilterSQL(filter, tt.dialect)
+			assert.Equal(t, []any{
+				"2024-03-10T05:00:00Z",
+				"2024-03-11T04:00:00Z",
+			}, args)
 		})
 	}
 }

--- a/internal/db/search_content.go
+++ b/internal/db/search_content.go
@@ -33,7 +33,7 @@ type ContentSearchFilter struct {
 	ExcludeSystem bool
 
 	Project, ExcludeProject, Machine, Agent           string
-	Date, DateFrom, DateTo, ActiveSince               string
+	Date, DateFrom, DateTo, Timezone, ActiveSince     string
 	IncludeChildren, IncludeAutomated, IncludeOneShot bool
 	// GitBranch is a branchListSep-joined list of opaque (project, branch) tokens (EncodeBranchFilterToken).
 	GitBranch string
@@ -125,6 +125,7 @@ func contentSessionFilter(f ContentSearchFilter) SessionFilter {
 		Project: f.Project, ExcludeProject: f.ExcludeProject,
 		Machine: f.Machine, GitBranch: f.GitBranch, Agent: f.Agent,
 		Date: f.Date, DateFrom: f.DateFrom, DateTo: f.DateTo,
+		Timezone:         f.Timezone,
 		ActiveSince:      f.ActiveSince,
 		ExcludeOneShot:   !f.IncludeOneShot,
 		ExcludeAutomated: !f.IncludeAutomated,

--- a/internal/db/search_content_test.go
+++ b/internal/db/search_content_test.go
@@ -549,6 +549,36 @@ func TestSearchContentMultiSourceWithProjectFilter(t *testing.T) {
 	}
 }
 
+func TestSearchContentDateFilterUsesRequestedTimezone(t *testing.T) {
+	d := testDB(t)
+	for _, row := range []struct {
+		id, started, ended string
+	}{
+		{"new-york-previous-day", "2024-06-16T01:00:00Z", "2024-06-16T02:00:00Z"},
+		{"new-york-requested-day", "2024-06-16T05:00:00Z", "2024-06-16T06:00:00Z"},
+	} {
+		insertSession(t, d, row.id, "proj", func(s *Session) {
+			s.Agent = "claude"
+			s.StartedAt = new(row.started)
+			s.EndedAt = new(row.ended)
+			s.UserMessageCount = 2
+		})
+		insertMessages(t, d, Message{
+			SessionID: row.id, Ordinal: 0, Role: "user",
+			Content: "TIMEZONE_NEEDLE", Timestamp: row.started,
+		})
+	}
+
+	got, err := d.SearchContent(context.Background(), ContentSearchFilter{
+		Pattern: "TIMEZONE_NEEDLE", Mode: "substring",
+		Sources: []string{"messages"}, Date: "2024-06-16",
+		Timezone: "America/New_York", Limit: 50,
+	})
+	require.NoError(t, err, "SearchContent")
+	require.Len(t, got.Matches, 1)
+	assert.Equal(t, "new-york-requested-day", got.Matches[0].SessionID)
+}
+
 func TestSnippetWindowRuneBoundaries(t *testing.T) {
 	// "é" and "ü" are two bytes each, so a byte-radius that lands inside them
 	// would slice mid-rune. The match itself is ASCII; only the padding edges

--- a/internal/db/session_export.go
+++ b/internal/db/session_export.go
@@ -1058,7 +1058,17 @@ func canonicalSessionExportFilter(f SessionFilter) SessionFilter {
 	f.Date = strings.TrimSpace(f.Date)
 	f.DateFrom = strings.TrimSpace(f.DateFrom)
 	f.DateTo = strings.TrimSpace(f.DateTo)
-	f.Timezone = strings.TrimSpace(f.Timezone)
+	if timezone, err := NormalizeSessionTimezone(f.Timezone); err == nil {
+		if timezone == "UTC" {
+			// Preserve the existing cursor wire form while treating an
+			// explicit UTC filter as equivalent to the omitted UTC default.
+			f.Timezone = ""
+		} else {
+			f.Timezone = timezone
+		}
+	} else {
+		f.Timezone = strings.TrimSpace(f.Timezone)
+	}
 	f.ActiveSince = strings.TrimSpace(f.ActiveSince)
 	f.AutomatedScope = normalizeAutomatedScope(f.AutomatedScope, f.ExcludeAutomated)
 	f.ExcludeAutomated = false

--- a/internal/db/session_export.go
+++ b/internal/db/session_export.go
@@ -1108,12 +1108,6 @@ func sessionExportFiltersEqual(
 
 func buildSessionExportFilter(f SessionFilter) (string, []any) {
 	dialect := SQLiteQueryDialect()
-	if f.IncludeChildren {
-		dialect.activityExpr = sessionExportLastActivitySortExprFor("root_session")
-	} else {
-		dialect.activityExpr = sessionExportLastActivitySortExpr()
-	}
-	dialect.activityParam = func(ph string) string { return "julianday(" + ph + ")" }
 	return BuildSessionFilterSQL(f, dialect)
 }
 

--- a/internal/db/session_export.go
+++ b/internal/db/session_export.go
@@ -131,6 +131,7 @@ type sessionExportCursorFilters struct {
 	Date                 string   `json:"date,omitempty"`
 	DateFrom             string   `json:"date_from,omitempty"`
 	DateTo               string   `json:"date_to,omitempty"`
+	Timezone             string   `json:"timezone,omitempty"`
 	ActiveSince          string   `json:"active_since,omitempty"`
 	MinMessages          int      `json:"min_messages,omitempty"`
 	MaxMessages          int      `json:"max_messages,omitempty"`
@@ -999,6 +1000,7 @@ func sessionExportFilters(f SessionFilter) sessionExportCursorFilters {
 		Date:                 f.Date,
 		DateFrom:             f.DateFrom,
 		DateTo:               f.DateTo,
+		Timezone:             f.Timezone,
 		ActiveSince:          f.ActiveSince,
 		MinMessages:          f.MinMessages,
 		MaxMessages:          f.MaxMessages,
@@ -1028,6 +1030,7 @@ func sessionExportFilterFromCursor(f sessionExportCursorFilters) SessionFilter {
 		Date:                 f.Date,
 		DateFrom:             f.DateFrom,
 		DateTo:               f.DateTo,
+		Timezone:             f.Timezone,
 		ActiveSince:          f.ActiveSince,
 		MinMessages:          f.MinMessages,
 		MaxMessages:          f.MaxMessages,
@@ -1055,6 +1058,7 @@ func canonicalSessionExportFilter(f SessionFilter) SessionFilter {
 	f.Date = strings.TrimSpace(f.Date)
 	f.DateFrom = strings.TrimSpace(f.DateFrom)
 	f.DateTo = strings.TrimSpace(f.DateTo)
+	f.Timezone = strings.TrimSpace(f.Timezone)
 	f.ActiveSince = strings.TrimSpace(f.ActiveSince)
 	f.AutomatedScope = normalizeAutomatedScope(f.AutomatedScope, f.ExcludeAutomated)
 	f.ExcludeAutomated = false

--- a/internal/db/session_export_test.go
+++ b/internal/db/session_export_test.go
@@ -1485,6 +1485,41 @@ func TestSessionExportCursorPreservesTimezoneFilter(t *testing.T) {
 	})
 }
 
+func TestSessionExportCursorTreatsDefaultAndExplicitUTCAsEquivalent(t *testing.T) {
+	d := testSessionExportDB(t)
+	ctx := context.Background()
+	for _, row := range []struct {
+		id, started, ended string
+	}{
+		{"utc-later", "2024-06-16T03:00:00Z", "2024-06-16T04:00:00Z"},
+		{"utc-earlier", "2024-06-16T01:00:00Z", "2024-06-16T02:00:00Z"},
+	} {
+		insertExportSession(t, d, Session{
+			ID: row.id, Project: "utc-cursor", Machine: "local", Agent: "claude",
+			StartedAt: new(row.started), EndedAt: new(row.ended),
+			MessageCount: 1, UserMessageCount: 1,
+		})
+	}
+
+	first, err := d.ExportSessionSummaries(ctx, SessionExportOptions{
+		Filter: SessionFilter{Project: "utc-cursor", Date: "2024-06-16"},
+		Limit:  1,
+	})
+	require.NoError(t, err, "first page")
+	require.Equal(t, []string{"utc-later"}, sessionExportRowIDs(first.Rows))
+	require.NotEmpty(t, first.NextCursor)
+
+	second, err := d.ExportSessionSummaries(ctx, SessionExportOptions{
+		Filter: SessionFilter{
+			Project: "utc-cursor", Date: "2024-06-16", Timezone: "UTC",
+		},
+		Cursor: first.NextCursor,
+		Limit:  1,
+	})
+	require.NoError(t, err, "explicit UTC should match the default timezone")
+	assert.Equal(t, []string{"utc-earlier"}, sessionExportRowIDs(second.Rows))
+}
+
 func TestSessionExportCursorTamperingReturnsInvalidCursor(t *testing.T) {
 	ctx := context.Background()
 	d := testSessionExportDB(t)

--- a/internal/db/session_export_test.go
+++ b/internal/db/session_export_test.go
@@ -1409,6 +1409,82 @@ func TestSessionExportCursorAllowsEquivalentFilters(t *testing.T) {
 	assert.Equal(t, []string{"filter-b"}, sessionExportRowIDs(second.Rows))
 }
 
+func TestSessionExportCursorPreservesTimezoneFilter(t *testing.T) {
+	d := testSessionExportDB(t)
+	ctx := context.Background()
+	for _, row := range []struct {
+		id, started, ended string
+	}{
+		{"new-york-late", "2024-06-17T02:30:00Z", "2024-06-17T03:00:00Z"},
+		{"new-york-earlier", "2024-06-17T01:30:00Z", "2024-06-17T02:00:00Z"},
+		{"utc-only", "2024-06-16T01:30:00Z", "2024-06-16T02:00:00Z"},
+	} {
+		insertExportSession(t, d, Session{
+			ID:               row.id,
+			Project:          "timezone-cursor",
+			Machine:          "local",
+			Agent:            "claude",
+			StartedAt:        Ptr(row.started),
+			EndedAt:          Ptr(row.ended),
+			MessageCount:     1,
+			UserMessageCount: 1,
+		})
+	}
+
+	first, err := d.ExportSessionSummaries(ctx, SessionExportOptions{
+		Filter: SessionFilter{
+			Project:  "timezone-cursor",
+			Date:     "2024-06-16",
+			Timezone: " America/New_York ",
+		},
+		Limit: 1,
+	})
+	require.NoError(t, err, "first page")
+	require.Equal(t, []string{"new-york-late"}, sessionExportRowIDs(first.Rows))
+	require.NotEmpty(t, first.NextCursor)
+
+	t.Run("cursor owned filter", func(t *testing.T) {
+		second, err := d.ExportSessionSummaries(ctx, SessionExportOptions{
+			Cursor:          first.NextCursor,
+			UseCursorFilter: true,
+			Limit:           1,
+		})
+		require.NoError(t, err, "resume with embedded filter")
+		assert.Equal(t,
+			[]string{"new-york-earlier"}, sessionExportRowIDs(second.Rows))
+		assert.Empty(t, second.NextCursor)
+	})
+
+	t.Run("equivalent timezone", func(t *testing.T) {
+		second, err := d.ExportSessionSummaries(ctx, SessionExportOptions{
+			Filter: SessionFilter{
+				Project:  "timezone-cursor",
+				Date:     "2024-06-16",
+				Timezone: "America/New_York",
+			},
+			Cursor: first.NextCursor,
+			Limit:  1,
+		})
+		require.NoError(t, err, "resume with equivalent timezone")
+		assert.Equal(t,
+			[]string{"new-york-earlier"}, sessionExportRowIDs(second.Rows))
+	})
+
+	t.Run("changed timezone", func(t *testing.T) {
+		_, err := d.ExportSessionSummaries(ctx, SessionExportOptions{
+			Filter: SessionFilter{
+				Project:  "timezone-cursor",
+				Date:     "2024-06-16",
+				Timezone: "UTC",
+			},
+			Cursor: first.NextCursor,
+			Limit:  1,
+		})
+		require.Error(t, err, "changed timezone")
+		assert.ErrorIs(t, err, ErrSessionExportCursorConflict)
+	})
+}
+
 func TestSessionExportCursorTamperingReturnsInvalidCursor(t *testing.T) {
 	ctx := context.Background()
 	d := testSessionExportDB(t)

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -487,6 +487,7 @@ type SessionFilter struct {
 	Date            string // date overlapped by session activity, YYYY-MM-DD
 	DateFrom        string // activity range start (inclusive)
 	DateTo          string // activity range end (inclusive)
+	Timezone        string // IANA timezone for date filters; empty means UTC
 	ActiveSince     string // ISO-8601 timestamp; filters on most recent activity
 	MinMessages     int    // message_count >= N (0 = no filter)
 	MaxMessages     int    // message_count <= N (0 = no filter)

--- a/internal/duckdb/store.go
+++ b/internal/duckdb/store.go
@@ -1371,6 +1371,7 @@ func contentSessionFilter(f db.ContentSearchFilter) db.SessionFilter {
 		Project: f.Project, ExcludeProject: f.ExcludeProject,
 		Machine: f.Machine, GitBranch: f.GitBranch, Agent: f.Agent,
 		Date: f.Date, DateFrom: f.DateFrom, DateTo: f.DateTo,
+		Timezone:         f.Timezone,
 		ActiveSince:      f.ActiveSince,
 		ExcludeOneShot:   !f.IncludeOneShot,
 		ExcludeAutomated: !f.IncludeAutomated,

--- a/internal/duckdb/store_test.go
+++ b/internal/duckdb/store_test.go
@@ -1741,6 +1741,44 @@ func TestSearchContentGitBranchFilter(t *testing.T) {
 	assert.Equal(t, alphaMain.ID, got.Matches[0].SessionID)
 }
 
+func TestSearchContentDateFilterUsesRequestedTimezone(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	previousDay := syncSession(
+		"duck-new-york-previous-day", "alpha", "previous", "2024-06-16T01:00:00Z", 1)
+	requestedDay := syncSession(
+		"duck-new-york-requested-day", "alpha", "requested", "2024-06-16T05:00:00Z", 1)
+	_, err := local.WriteSessionBatchAtomic([]db.SessionBatchWrite{
+		{
+			Session: previousDay,
+			Messages: []db.Message{syncMessage(
+				previousDay.ID, 0, "user", "TIMEZONE_NEEDLE", *previousDay.StartedAt)},
+			DataVersion: 1, ReplaceMessages: true,
+		},
+		{
+			Session: requestedDay,
+			Messages: []db.Message{syncMessage(
+				requestedDay.ID, 0, "user", "TIMEZONE_NEEDLE", *requestedDay.StartedAt)},
+			DataVersion: 1, ReplaceMessages: true,
+		},
+	})
+	require.NoError(t, err)
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+	require.NoError(t, createSchema(ctx, syncer.DB()))
+	_, err = syncer.pushEverything(ctx, nil)
+	require.NoError(t, err)
+	store := NewStoreFromDB(syncer.DB())
+
+	got, err := store.SearchContent(ctx, db.ContentSearchFilter{
+		Pattern: "TIMEZONE_NEEDLE", Mode: "substring",
+		Sources: []string{"messages"}, Date: "2024-06-16",
+		Timezone: "America/New_York", IncludeOneShot: true, Limit: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, got.Matches, 1)
+	assert.Equal(t, requestedDay.ID, got.Matches[0].SessionID)
+}
+
 func TestSearchContentSubstringPaginatesAfterGlobalOrdering(t *testing.T) {
 	ctx := context.Background()
 	store, _ := newSyncedStore(t)

--- a/internal/postgres/search_content.go
+++ b/internal/postgres/search_content.go
@@ -88,6 +88,7 @@ func pgSessionFilter(f db.ContentSearchFilter) db.SessionFilter {
 		Project: f.Project, ExcludeProject: f.ExcludeProject,
 		Machine: f.Machine, GitBranch: f.GitBranch, Agent: f.Agent,
 		Date: f.Date, DateFrom: f.DateFrom, DateTo: f.DateTo,
+		Timezone:         f.Timezone,
 		ActiveSince:      f.ActiveSince,
 		ExcludeOneShot:   !f.IncludeOneShot,
 		ExcludeAutomated: !f.IncludeAutomated,

--- a/internal/postgres/search_content_pgtest_test.go
+++ b/internal/postgres/search_content_pgtest_test.go
@@ -157,6 +157,29 @@ func TestPGSearchContentSubstringMessages(t *testing.T) {
 		"match timestamp must equal the inserted instant, want %v got %v", want, parsed)
 }
 
+func TestPGSearchContentDateFilterUsesRequestedTimezone(t *testing.T) {
+	store := setupContentSearch(t)
+	for _, row := range []struct {
+		id, started, ended string
+	}{
+		{"cs-new-york-previous-day", "2024-06-16T01:00:00Z", "2024-06-16T02:00:00Z"},
+		{"cs-new-york-requested-day", "2024-06-16T05:00:00Z", "2024-06-16T06:00:00Z"},
+	} {
+		insertCSSession(t, store, row.id, "proj", "claude", row.started, row.ended)
+		insertCSMessage(t, store, row.id, 0, "user",
+			"TIMEZONE_NEEDLE", row.started, false)
+	}
+
+	got, err := store.SearchContent(context.Background(), db.ContentSearchFilter{
+		Pattern: "TIMEZONE_NEEDLE", Mode: "substring",
+		Sources: []string{"messages"}, Date: "2024-06-16",
+		Timezone: "America/New_York", Limit: 50,
+	})
+	require.NoError(t, err, "SearchContent")
+	require.Len(t, got.Matches, 1)
+	assert.Equal(t, "cs-new-york-requested-day", got.Matches[0].SessionID)
+}
+
 // TestPGSearchContentRedactsStraddlingSecret pins the PG default (non-reveal)
 // guarantee: a secret adjacent to the match that extends past the snippet
 // window must not leak; reveal opts out and shows raw bytes.

--- a/internal/postgres/sessions_pgtest_test.go
+++ b/internal/postgres/sessions_pgtest_test.go
@@ -55,17 +55,17 @@ func TestListSessionsDateFilterIncludesOverlappingSessions(t *testing.T) {
 			 message_count, user_message_count)
 		VALUES
 			('date-overlap-before', 'm', 'date-overlap', 'claude',
-			 '2024-06-15T08:00:00Z'::timestamptz,
-			 '2024-06-15T09:00:00Z'::timestamptz, 2, 1),
+			 '2024-06-16T02:00:00Z'::timestamptz,
+			 '2024-06-16T03:59:59Z'::timestamptz, 2, 1),
 			('date-overlap-spanning', 'm', 'date-overlap', 'claude',
-			 '2024-06-15T23:00:00Z'::timestamptz,
+			 '2024-06-16T03:00:00Z'::timestamptz,
 			 '2024-06-16T10:00:00Z'::timestamptz, 2, 1),
 			('date-overlap-open', 'm', 'date-overlap', 'claude',
-			 '2024-06-15T22:00:00Z'::timestamptz,
+			 '2024-06-16T02:00:00Z'::timestamptz,
 			 NULL, 2, 1),
 			('date-overlap-after', 'm', 'date-overlap', 'claude',
-			 '2024-06-17T08:00:00Z'::timestamptz,
-			 '2024-06-17T09:00:00Z'::timestamptz, 2, 1),
+			 '2024-06-17T04:00:00Z'::timestamptz,
+			 '2024-06-17T05:00:00Z'::timestamptz, 2, 1),
 			('date-overlap-child', 'm', 'date-overlap', 'claude',
 			 '2024-06-17T08:00:00Z'::timestamptz,
 			 '2024-06-17T09:00:00Z'::timestamptz, 1, 1);
@@ -77,14 +77,15 @@ func TestListSessionsDateFilterIncludesOverlappingSessions(t *testing.T) {
 			(session_id, ordinal, role, content, timestamp, content_length)
 		VALUES
 			('date-overlap-open', 1, 'user', 'x',
-			 '2024-06-16T11:00:00Z'::timestamptz, 1)
+			 '2024-06-17T03:59:59Z'::timestamptz, 1)
 	`)
 	require.NoError(t, err, "seeding date-overlap sessions")
 
 	page, err := store.ListSessions(context.Background(), db.SessionFilter{
-		Project: "date-overlap",
-		Date:    "2024-06-16",
-		Limit:   50,
+		Project:  "date-overlap",
+		Date:     "2024-06-16",
+		Timezone: "America/New_York",
+		Limit:    50,
 	})
 	require.NoError(t, err, "ListSessions")
 	ids := make([]string, len(page.Sessions))
@@ -98,8 +99,9 @@ func TestListSessionsDateFilterIncludesOverlappingSessions(t *testing.T) {
 	}, ids)
 
 	index, err := store.GetSidebarSessionIndex(context.Background(), db.SessionFilter{
-		Project: "date-overlap",
-		Date:    "2024-06-16",
+		Project:  "date-overlap",
+		Date:     "2024-06-16",
+		Timezone: "America/New_York",
 	})
 	require.NoError(t, err, "GetSidebarSessionIndex")
 	ids = ids[:0]

--- a/internal/server/huma_routes_search.go
+++ b/internal/server/huma_routes_search.go
@@ -47,6 +47,7 @@ type contentSearchInput struct {
 	Date             string             `query:"date" format:"date" doc:"Filter sessions active on this YYYY-MM-DD date"`
 	DateFrom         string             `query:"date_from" format:"date" doc:"Filter sessions active on or after this date"`
 	DateTo           string             `query:"date_to" format:"date" doc:"Filter sessions active on or before this date"`
+	Timezone         string             `query:"timezone" doc:"IANA timezone for calendar-date filters; defaults to UTC"`
 	ActiveSince      string             `query:"active_since" format:"date-time" doc:"Filter sessions active since this RFC3339 timestamp"`
 	IncludeChildren  bool               `query:"include_children" doc:"Include child sessions"`
 	IncludeAutomated bool               `query:"include_automated" doc:"Include automated sessions"`
@@ -114,6 +115,10 @@ func (s *Server) humaSearchContent(
 	if err := validateDateFilterValues(in.Date, in.DateFrom, in.DateTo, in.ActiveSince); err != nil {
 		return nil, err
 	}
+	timezone, err := db.NormalizeSessionTimezone(in.Timezone)
+	if err != nil {
+		return nil, apiError(http.StatusBadRequest, err.Error())
+	}
 	res, err := s.sessions.SearchContent(ctx, service.ContentSearchRequest{
 		Pattern:          in.Pattern,
 		Mode:             string(in.Mode),
@@ -128,6 +133,7 @@ func (s *Server) humaSearchContent(
 		Date:             in.Date,
 		DateFrom:         in.DateFrom,
 		DateTo:           in.DateTo,
+		Timezone:         timezone,
 		ActiveSince:      in.ActiveSince,
 		IncludeChildren:  in.IncludeChildren,
 		IncludeAutomated: in.IncludeAutomated,

--- a/internal/server/huma_routes_sessions.go
+++ b/internal/server/huma_routes_sessions.go
@@ -67,6 +67,7 @@ type sessionFilterInput struct {
 	Date             string            `query:"date" format:"date" doc:"Filter sessions active on this YYYY-MM-DD date"`
 	DateFrom         string            `query:"date_from" format:"date" doc:"Filter sessions active on or after this date"`
 	DateTo           string            `query:"date_to" format:"date" doc:"Filter sessions active on or before this date"`
+	Timezone         string            `query:"timezone" doc:"IANA timezone for calendar-date filters; defaults to UTC"`
 	ActiveSince      string            `query:"active_since" format:"date-time" doc:"Filter sessions active since this RFC3339 timestamp"`
 	MinMessages      int               `query:"min_messages" minimum:"0" doc:"Minimum total message count"`
 	MaxMessages      int               `query:"max_messages" minimum:"0" doc:"Maximum total message count"`
@@ -115,6 +116,10 @@ func (in *sessionFilterInput) listFilter() (service.ListFilter, error) {
 	if err := validateDateFilterValues(in.Date, in.DateFrom, in.DateTo, in.ActiveSince); err != nil {
 		return service.ListFilter{}, err
 	}
+	timezone, err := db.NormalizeSessionTimezone(in.Timezone)
+	if err != nil {
+		return service.ListFilter{}, apiError(http.StatusBadRequest, err.Error())
+	}
 	if _, err := db.ParseSortSpec(in.OrderBy); err != nil {
 		return service.ListFilter{}, apiError(http.StatusBadRequest, "invalid order_by: "+err.Error())
 	}
@@ -128,6 +133,7 @@ func (in *sessionFilterInput) listFilter() (service.ListFilter, error) {
 		Date:             in.Date,
 		DateFrom:         in.DateFrom,
 		DateTo:           in.DateTo,
+		Timezone:         timezone,
 		ActiveSince:      in.ActiveSince,
 		MinMessages:      in.MinMessages,
 		MaxMessages:      in.MaxMessages,
@@ -155,6 +161,10 @@ func (in *sessionFilterInput) dbFilter(includeChildren bool) (db.SessionFilter, 
 	if err := validateDateFilterValues(in.Date, in.DateFrom, in.DateTo, in.ActiveSince); err != nil {
 		return db.SessionFilter{}, err
 	}
+	timezone, err := db.NormalizeSessionTimezone(in.Timezone)
+	if err != nil {
+		return db.SessionFilter{}, apiError(http.StatusBadRequest, err.Error())
+	}
 	// The order_by param is shared with the list route via this struct; reject
 	// malformed specs here too (the dropped enum used to guard every route),
 	// even though the sidebar index applies its own ordering and ignores it.
@@ -174,6 +184,7 @@ func (in *sessionFilterInput) dbFilter(includeChildren bool) (db.SessionFilter, 
 		Date:             in.Date,
 		DateFrom:         in.DateFrom,
 		DateTo:           in.DateTo,
+		Timezone:         timezone,
 		ActiveSince:      in.ActiveSince,
 		MinMessages:      in.MinMessages,
 		MaxMessages:      in.MaxMessages,

--- a/internal/server/search_content_test.go
+++ b/internal/server/search_content_test.go
@@ -26,6 +26,7 @@ func TestHandleSearchContentInvalidParams(t *testing.T) {
 		{"invalid mode", "pattern=x&mode=bad", "127.0.0.1:1234", "", http.StatusBadRequest},
 		{"invalid limit", "pattern=x&limit=abc", "127.0.0.1:1234", "", http.StatusBadRequest},
 		{"invalid cursor", "pattern=x&cursor=abc", "127.0.0.1:1234", "", http.StatusBadRequest},
+		{"invalid timezone", "pattern=x&timezone=Fake%2FZone", "127.0.0.1:1234", "", http.StatusBadRequest},
 		{"reveal from remote", "pattern=x&reveal=true", "203.0.113.5:1234", "", http.StatusForbidden},
 		// A reverse proxy reaches the loopback backend, so RemoteAddr is
 		// loopback; the forwarding header marks it as proxied, so reveal

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1795,6 +1795,31 @@ func TestSessionDateFilterUsesRequestedTimezoneAndDefaultsToUTC(t *testing.T) {
 	assertBodyContains(t, w, "invalid timezone: Fake/Zone")
 }
 
+func TestContentSearchDateFilterUsesRequestedTimezone(t *testing.T) {
+	te := setup(t)
+	te.seedSession(t, "search-new-york-previous-day", "my-app", 2, func(s *db.Session) {
+		s.StartedAt = new("2024-06-16T01:00:00Z")
+		s.EndedAt = new("2024-06-16T02:00:00Z")
+	})
+	te.seedMessages(t, "search-new-york-previous-day", 1, func(_ int, m *db.Message) {
+		m.Content = "TIMEZONE_NEEDLE"
+	})
+	te.seedSession(t, "search-new-york-requested-day", "my-app", 2, func(s *db.Session) {
+		s.StartedAt = new("2024-06-16T05:00:00Z")
+		s.EndedAt = new("2024-06-16T06:00:00Z")
+	})
+	te.seedMessages(t, "search-new-york-requested-day", 1, func(_ int, m *db.Message) {
+		m.Content = "TIMEZONE_NEEDLE"
+	})
+
+	w := te.get(t, "/api/v1/search/content?pattern=TIMEZONE_NEEDLE"+
+		"&date=2024-06-16&timezone=America%2FNew_York")
+	assertStatus(t, w, http.StatusOK)
+	result := decode[service.ContentSearchResult](t, w)
+	require.Len(t, result.Matches, 1)
+	assert.Equal(t, "search-new-york-requested-day", result.Matches[0].SessionID)
+}
+
 func TestGetSession_Found(t *testing.T) {
 	te := setup(t)
 	te.seedSession(t, "s1", "my-app", 5)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1741,6 +1741,7 @@ func TestSidebarIndexValidatesParams(t *testing.T) {
 		"/api/v1/sessions/sidebar-index?min_user_messages=bad",
 		"/api/v1/sessions/sidebar-index?date=2024-99-99",
 		"/api/v1/sessions/sidebar-index?date_from=2024-06-02&date_to=2024-06-01",
+		"/api/v1/sessions/sidebar-index?timezone=Fake%2FZone",
 		"/api/v1/sessions/sidebar-index?active_since=not-a-timestamp",
 	}
 
@@ -1750,6 +1751,48 @@ func TestSidebarIndexValidatesParams(t *testing.T) {
 			assertStatus(t, w, http.StatusBadRequest)
 		})
 	}
+}
+
+func TestSessionDateFilterUsesRequestedTimezoneAndDefaultsToUTC(t *testing.T) {
+	te := setup(t)
+	te.seedSession(t, "utc-only", "my-app", 2, func(s *db.Session) {
+		s.UserMessageCount = 2
+		s.StartedAt = new("2024-06-16T01:00:00Z")
+		s.EndedAt = new("2024-06-16T02:00:00Z")
+	})
+	te.seedSession(t, "new-york-day", "my-app", 2, func(s *db.Session) {
+		s.UserMessageCount = 2
+		s.StartedAt = new("2024-06-16T05:00:00Z")
+		s.EndedAt = new("2024-06-16T06:00:00Z")
+	})
+
+	w := te.get(t, "/api/v1/sessions?date=2024-06-16")
+	assertStatus(t, w, http.StatusOK)
+	list := decode[sessionListResponse](t, w)
+	listIDs := make([]string, len(list.Sessions))
+	for i, session := range list.Sessions {
+		listIDs[i] = session.ID
+	}
+	assert.ElementsMatch(t, []string{"utc-only", "new-york-day"},
+		listIDs)
+
+	w = te.get(t,
+		"/api/v1/sessions?date=2024-06-16&timezone=America%2FNew_York")
+	assertStatus(t, w, http.StatusOK)
+	list = decode[sessionListResponse](t, w)
+	require.Len(t, list.Sessions, 1)
+	assert.Equal(t, "new-york-day", list.Sessions[0].ID)
+
+	w = te.get(t,
+		"/api/v1/sessions/sidebar-index?date=2024-06-16&timezone=America%2FNew_York")
+	assertStatus(t, w, http.StatusOK)
+	index := decode[db.SidebarSessionIndex](t, w)
+	assert.Equal(t, []string{"new-york-day"},
+		sidebarIndexRowIDs(index.Sessions))
+
+	w = te.get(t, "/api/v1/sessions?timezone=Fake%2FZone")
+	assertStatus(t, w, http.StatusBadRequest)
+	assertBodyContains(t, w, "invalid timezone: Fake/Zone")
 }
 
 func TestGetSession_Found(t *testing.T) {

--- a/internal/service/direct.go
+++ b/internal/service/direct.go
@@ -139,6 +139,11 @@ func (b *directBackend) List(
 			"list: invalid active_since %q: use RFC3339", f.ActiveSince,
 		)
 	}
+	timezone, err := db.NormalizeSessionTimezone(f.Timezone)
+	if err != nil {
+		return nil, fmt.Errorf("list: %w", err)
+	}
+	f.Timezone = timezone
 	if _, err := db.ParseSortSpec(f.OrderBy); err != nil {
 		return nil, fmt.Errorf(
 			"list: invalid sort %q: %v (valid keys: %s)",
@@ -180,6 +185,7 @@ func listFilterToDB(f ListFilter) db.SessionFilter {
 		Date:                 f.Date,
 		DateFrom:             f.DateFrom,
 		DateTo:               f.DateTo,
+		Timezone:             f.Timezone,
 		ActiveSince:          f.ActiveSince,
 		MinMessages:          f.MinMessages,
 		MaxMessages:          f.MaxMessages,

--- a/internal/service/direct.go
+++ b/internal/service/direct.go
@@ -782,6 +782,11 @@ func (b *directBackend) SearchContent(
 	if req.Context > maxContentSearchContext {
 		return nil, &db.SearchInputError{Msg: "context: maximum is 10"}
 	}
+	timezone, err := db.NormalizeSessionTimezone(req.Timezone)
+	if err != nil {
+		return nil, &db.SearchInputError{Msg: "search: " + err.Error()}
+	}
+	req.Timezone = timezone
 	page, err := b.db.SearchContent(ctx, db.ContentSearchFilter{
 		Pattern:          req.Pattern,
 		Mode:             req.Mode,
@@ -795,6 +800,7 @@ func (b *directBackend) SearchContent(
 		Date:             req.Date,
 		DateFrom:         req.DateFrom,
 		DateTo:           req.DateTo,
+		Timezone:         req.Timezone,
 		ActiveSince:      req.ActiveSince,
 		IncludeChildren:  req.IncludeChildren,
 		IncludeAutomated: req.IncludeAutomated,

--- a/internal/service/direct_test.go
+++ b/internal/service/direct_test.go
@@ -643,6 +643,17 @@ func TestDirectBackend_List_TimezoneValidationAndUTCDefault(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid timezone: Fake/Zone")
 }
 
+func TestDirectSearchContentRejectsInvalidTimezone(t *testing.T) {
+	t.Parallel()
+	svc, _ := newDirectTestSvc(t)
+
+	_, err := svc.SearchContent(context.Background(), service.ContentSearchRequest{
+		Pattern: "test", Timezone: "Fake/Zone",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid timezone: Fake/Zone")
+}
+
 // TestDirectBackend_List_ClampsOverMaxLimit verifies that a caller
 // passing a Limit larger than db.MaxSessionLimit is clamped to
 // MaxSessionLimit rather than being reset to DefaultSessionLimit

--- a/internal/service/direct_test.go
+++ b/internal/service/direct_test.go
@@ -600,6 +600,49 @@ func TestDirectBackend_List_ValidDatesAccepted(t *testing.T) {
 	require.NotNil(t, list)
 }
 
+func TestDirectBackend_List_TimezoneValidationAndUTCDefault(t *testing.T) {
+	t.Parallel()
+	svc, env := newDirectTestSvc(t)
+	dbtest.SeedSession(t, env.db, "utc-only", "p1", func(s *db.Session) {
+		s.MessageCount = 2
+		s.UserMessageCount = 2
+		s.StartedAt = dbtest.Ptr("2024-06-16T01:00:00Z")
+		s.EndedAt = dbtest.Ptr("2024-06-16T02:00:00Z")
+	})
+	dbtest.SeedSession(t, env.db, "new-york-day", "p1", func(s *db.Session) {
+		s.MessageCount = 2
+		s.UserMessageCount = 2
+		s.StartedAt = dbtest.Ptr("2024-06-16T05:00:00Z")
+		s.EndedAt = dbtest.Ptr("2024-06-16T06:00:00Z")
+	})
+
+	list, err := svc.List(context.Background(), service.ListFilter{
+		Date: "2024-06-16", Limit: 10,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, list)
+	ids := make([]string, len(list.Sessions))
+	for i, session := range list.Sessions {
+		ids[i] = session.ID
+	}
+	assert.ElementsMatch(t, []string{"utc-only", "new-york-day"}, ids)
+
+	list, err = svc.List(context.Background(), service.ListFilter{
+		Date: "2024-06-16", Timezone: "America/New_York", Limit: 10,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, list)
+	require.Len(t, list.Sessions, 1)
+	assert.Equal(t, "new-york-day", list.Sessions[0].ID)
+
+	list, err = svc.List(context.Background(), service.ListFilter{
+		Timezone: "Fake/Zone",
+	})
+	require.Error(t, err)
+	assert.Nil(t, list)
+	assert.Contains(t, err.Error(), "invalid timezone: Fake/Zone")
+}
+
 // TestDirectBackend_List_ClampsOverMaxLimit verifies that a caller
 // passing a Limit larger than db.MaxSessionLimit is clamped to
 // MaxSessionLimit rather than being reset to DefaultSessionLimit

--- a/internal/service/http.go
+++ b/internal/service/http.go
@@ -506,6 +506,7 @@ func (b *httpBackend) SearchContent(
 		"date":            req.Date,
 		"date_from":       req.DateFrom,
 		"date_to":         req.DateTo,
+		"timezone":        req.Timezone,
 		"active_since":    req.ActiveSince,
 		"scope":           req.Scope,
 	} {

--- a/internal/service/http.go
+++ b/internal/service/http.go
@@ -209,6 +209,7 @@ func filterToQuery(f ListFilter) url.Values {
 	setIfNotEmpty("date", f.Date)
 	setIfNotEmpty("date_from", f.DateFrom)
 	setIfNotEmpty("date_to", f.DateTo)
+	setIfNotEmpty("timezone", f.Timezone)
 	setIfNotEmpty("active_since", f.ActiveSince)
 	if f.MinMessages > 0 {
 		q.Set("min_messages", strconv.Itoa(f.MinMessages))

--- a/internal/service/http_internal_test.go
+++ b/internal/service/http_internal_test.go
@@ -41,6 +41,17 @@ func TestHTTPBackendRecallCapabilityRespectsReadOnlyMode(t *testing.T) {
 	}
 }
 
+func TestFilterToQueryKeepsTimezoneWithCursor(t *testing.T) {
+	t.Parallel()
+	query := filterToQuery(ListFilter{
+		Timezone: "America/New_York",
+		Cursor:   "next-page",
+	})
+
+	assert.Equal(t, "America/New_York", query.Get("timezone"))
+	assert.Equal(t, "next-page", query.Get("cursor"))
+}
+
 func TestSearchContentUsesLongRunningClient(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/http_test.go
+++ b/internal/service/http_test.go
@@ -951,13 +951,16 @@ func TestHTTPSearchContent(t *testing.T) {
 			if r.URL.Query().Get("pattern") != "needle" {
 				t.Errorf("pattern = %s", r.URL.Query().Get("pattern"))
 			}
+			if r.URL.Query().Get("timezone") != "America/New_York" {
+				t.Errorf("timezone = %s", r.URL.Query().Get("timezone"))
+			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"matches":[{"session_id":"s1","location":"message"}],"next_cursor":0}`))
 		}))
 	defer srv.Close()
 	be := service.NewHTTPBackend(srv.URL, "", true)
 	res, err := be.SearchContent(context.Background(), service.ContentSearchRequest{
-		Pattern: "needle", Limit: 50,
+		Pattern: "needle", Timezone: "America/New_York", Limit: 50,
 	})
 	require.NoError(t, err)
 	require.Len(t, res.Matches, 1)

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -166,7 +166,7 @@ type ContentSearchRequest struct {
 	Context int `json:"context,omitempty"`
 
 	Project, ExcludeProject, Machine, Agent           string
-	Date, DateFrom, DateTo, ActiveSince               string
+	Date, DateFrom, DateTo, Timezone, ActiveSince     string
 	IncludeChildren, IncludeAutomated, IncludeOneShot bool
 	// GitBranch is a branchListSep-joined list of opaque (project, branch) tokens (EncodeBranchFilterToken).
 	GitBranch string

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -379,6 +379,7 @@ type ListFilter struct {
 	Date             string `json:"date,omitempty"`
 	DateFrom         string `json:"date_from,omitempty"`
 	DateTo           string `json:"date_to,omitempty"`
+	Timezone         string `json:"timezone,omitempty"`
 	ActiveSince      string `json:"active_since,omitempty"`
 	MinMessages      int    `json:"min_messages,omitempty"`
 	MaxMessages      int    `json:"max_messages,omitempty"`


### PR DESCRIPTION
Session list and sidebar calendar-date filters now accept the browser IANA timezone, default omitted values to UTC, and reject invalid zones.

Local calendar dates are translated into DST-aware UTC boundaries while preserving latest-message activity fallback and equivalent SQLite, PostgreSQL, and DuckDB query behavior. The sidebar sends the browser timezone on initial and paginated requests, and the generated API client reflects the new parameter.

Fixes #1232.