### PR TITLE
Fix nested subagent hierarchy: re-parent depth≥2 subagents to their spawner

### DIFF
--- a/internal/db/link_subagent_nested_test.go
+++ b/internal/db/link_subagent_nested_test.go
@@ -1,0 +1,97 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLinkSubagentSessionsReParentsNestedGrandchild reproduces the
+// nested-subagent bug: when a subagent spawns its own subagent (depth >= 2),
+// the grandchild is parsed with a path-derived parent pointing at the MAIN
+// session (all subagents live in the same flat <main>/subagents/ dir) and is
+// tagged relationship_type='subagent'. LinkSubagentSessions must re-point it
+// to the intermediate subagent that actually spawned it, using the
+// authoritative tool_calls edge.
+//
+// Tree under test:  main -> orchestrator -> grandchild
+func TestLinkSubagentSessionsReParentsNestedGrandchild(t *testing.T) {
+	d := testDB(t)
+
+	mainID := "main"
+	orchestratorID := "orchestrator"
+	grandchildID := "grandchild"
+
+	// Main session (root).
+	insertSession(t, d, mainID, "p", func(s *Session) {
+		s.MessageCount = 1
+	})
+
+	// Orchestrator: a depth-1 subagent. Path derivation put its parent at
+	// the main session (correct here) and tagged it 'subagent'.
+	insertSession(t, d, orchestratorID, "p", func(s *Session) {
+		s.MessageCount = 1
+		parent := mainID
+		s.ParentSessionID = &parent
+		s.RelationshipType = "subagent"
+	})
+
+	// Grandchild: a depth-2 subagent. Path derivation ALSO put its parent at
+	// the main session (WRONG — it should be the orchestrator) and tagged it
+	// 'subagent'. This is the buggy stored state we expect linking to fix.
+	insertSession(t, d, grandchildID, "p", func(s *Session) {
+		s.MessageCount = 1
+		wrongParent := mainID
+		s.ParentSessionID = &wrongParent
+		s.RelationshipType = "subagent"
+	})
+
+	// The authoritative spawn edges, exactly as the parser records them in
+	// tool_calls from toolUseResult.agentId:
+	//   main         --Task--> orchestrator
+	//   orchestrator --Task--> grandchild
+	insertMessages(t,
+		d,
+		Message{
+			SessionID: mainID, Ordinal: 0, Role: "assistant",
+			Content: "spawn orchestrator", HasToolUse: true,
+			ToolCalls: []ToolCall{{
+				ToolName: "Agent", Category: "Task",
+				SubagentSessionID: orchestratorID,
+			}},
+		},
+		Message{
+			SessionID: orchestratorID, Ordinal: 0, Role: "assistant",
+			Content: "spawn grandchild", HasToolUse: true,
+			ToolCalls: []ToolCall{{
+				ToolName: "Agent", Category: "Task",
+				SubagentSessionID: grandchildID,
+			}},
+		},
+	)
+
+	require.NoError(t, d.LinkSubagentSessions(), "LinkSubagentSessions")
+
+	// Orchestrator stays under main.
+	orch, err := d.GetSession(context.Background(), orchestratorID)
+	requireNoError(t, err, "GetSession orchestrator")
+	if assert.NotNil(t, orch.ParentSessionID, "orchestrator parent") {
+		assert.Equal(t, mainID, *orch.ParentSessionID,
+			"orchestrator.parent_session_id")
+	}
+
+	// Grandchild must be re-parented to the orchestrator, NOT the main
+	// session. This is the assertion that fails on the current
+	// `WHERE relationship_type != 'subagent'` guard.
+	gc, err := d.GetSession(context.Background(), grandchildID)
+	requireNoError(t, err, "GetSession grandchild")
+	assert.Equal(t, "subagent", gc.RelationshipType,
+		"grandchild relationship_type")
+	if assert.NotNil(t, gc.ParentSessionID, "grandchild parent") {
+		assert.Equal(t, orchestratorID, *gc.ParentSessionID,
+			"grandchild.parent_session_id must be the orchestrator, "+
+				"not the flat main session")
+	}
+}

--- a/internal/db/link_subagent_nested_test.go
+++ b/internal/db/link_subagent_nested_test.go
@@ -95,3 +95,50 @@ func TestLinkSubagentSessionsReParentsNestedGrandchild(t *testing.T) {
 				"not the flat main session")
 	}
 }
+
+// TestLinkSubagentSessionsUpgradesTypeWhenParentAlreadyMatches guards the
+// regression flagged in review: LinkSubagentSessions sets BOTH parent_session_id
+// and relationship_type='subagent'. A session can already carry the correct
+// (authoritative) parent while still being misclassified as continuation / fork
+// / empty. The type upgrade must run even when the parent does not change, or
+// the session is grouped wrong.
+func TestLinkSubagentSessionsUpgradesTypeWhenParentAlreadyMatches(t *testing.T) {
+	d := testDB(t)
+
+	// Parent session with a tool call referencing the child.
+	insertSession(t, d, "parent", "p", func(s *Session) {
+		s.MessageCount = 1
+	})
+
+	// Child ALREADY has the correct parent (== the tool-call spawner) but is
+	// misclassified as a continuation (e.g. a header parentId that coincides
+	// with the spawner). parent_session_id won't change; relationship_type
+	// must still be upgraded to 'subagent'.
+	insertSession(t, d, "child", "p", func(s *Session) {
+		s.MessageCount = 1
+		parent := "parent"
+		s.ParentSessionID = &parent
+		s.RelationshipType = "continuation"
+	})
+
+	insertMessages(t, d, Message{
+		SessionID: "parent", Ordinal: 0, Role: "assistant",
+		Content: "spawn child", HasToolUse: true,
+		ToolCalls: []ToolCall{{
+			ToolName: "Agent", Category: "Task",
+			SubagentSessionID: "child",
+		}},
+	})
+
+	require.NoError(t, d.LinkSubagentSessions(), "LinkSubagentSessions")
+
+	child, err := d.GetSession(context.Background(), "child")
+	requireNoError(t, err, "GetSession child")
+	assert.Equal(t, "subagent", child.RelationshipType,
+		"relationship_type must upgrade to 'subagent' even when the parent "+
+			"already matches the tool-call spawner")
+	if assert.NotNil(t, child.ParentSessionID, "child parent") {
+		assert.Equal(t, "parent", *child.ParentSessionID,
+			"child.parent_session_id")
+	}
+}

--- a/internal/db/link_subagent_nested_test.go
+++ b/internal/db/link_subagent_nested_test.go
@@ -182,3 +182,60 @@ func TestLinkSubagentSessionsLinksNullParentSubagent(t *testing.T) {
 			"orphan.parent_session_id")
 	}
 }
+
+// TestLinkSubagentSessionsPreservesParentOnConflictingEdges guards against
+// arbitrary re-parenting when a child is referenced by spawn edges from more
+// than one distinct session (reachable via copied/forked history). The parent
+// must be resolved only from an unambiguous edge; with conflicting edges the
+// current parent is preserved rather than picked arbitrarily by a bare LIMIT 1.
+func TestLinkSubagentSessionsPreservesParentOnConflictingEdges(t *testing.T) {
+	d := testDB(t)
+
+	insertSession(t, d, "p1", "p", func(s *Session) {
+		s.MessageCount = 1
+	})
+	insertSession(t, d, "p2", "p", func(s *Session) {
+		s.MessageCount = 1
+	})
+	// "kid" is already a correctly parented subagent under p2.
+	insertSession(t, d, "kid", "p", func(s *Session) {
+		s.MessageCount = 1
+		parent := "p2"
+		s.ParentSessionID = &parent
+		s.RelationshipType = "subagent"
+	})
+
+	// Two DISTINCT sessions both carry a spawn edge to "kid". p1's edge is
+	// inserted first (lower rowid), so a bare `LIMIT 1` would pick p1 and
+	// wrongly re-parent kid away from its current p2. The unambiguous-edge
+	// resolution must instead preserve p2.
+	insertMessages(t, d,
+		Message{
+			SessionID: "p1", Ordinal: 0, Role: "assistant",
+			Content: "spawn kid (copy A)", HasToolUse: true,
+			ToolCalls: []ToolCall{{
+				ToolName: "Agent", Category: "Task",
+				SubagentSessionID: "kid",
+			}},
+		},
+		Message{
+			SessionID: "p2", Ordinal: 0, Role: "assistant",
+			Content: "spawn kid (copy B)", HasToolUse: true,
+			ToolCalls: []ToolCall{{
+				ToolName: "Agent", Category: "Task",
+				SubagentSessionID: "kid",
+			}},
+		},
+	)
+
+	require.NoError(t, d.LinkSubagentSessions(), "LinkSubagentSessions")
+
+	kid, err := d.GetSession(context.Background(), "kid")
+	requireNoError(t, err, "GetSession kid")
+	assert.Equal(t, "subagent", kid.RelationshipType, "kid relationship_type")
+	if assert.NotNil(t, kid.ParentSessionID, "kid parent") {
+		assert.Equal(t, "p2", *kid.ParentSessionID,
+			"conflicting edges must preserve the current parent, "+
+				"not pick one arbitrarily")
+	}
+}

--- a/internal/db/link_subagent_nested_test.go
+++ b/internal/db/link_subagent_nested_test.go
@@ -142,3 +142,43 @@ func TestLinkSubagentSessionsUpgradesTypeWhenParentAlreadyMatches(t *testing.T) 
 			"child.parent_session_id")
 	}
 }
+
+// TestLinkSubagentSessionsLinksNullParentSubagent guards the null-safe `IS NOT`
+// predicate. A session already tagged 'subagent' but with a NULL parent (and a
+// tool_calls spawn edge) must be linked to its spawner. Replacing `IS NOT` with
+// `!=` would leave the parent NULL (`NULL != 'x'` is NULL, not true), so this
+// test fails under that mutation.
+func TestLinkSubagentSessionsLinksNullParentSubagent(t *testing.T) {
+	d := testDB(t)
+
+	insertSession(t, d, "spawner", "p", func(s *Session) {
+		s.MessageCount = 1
+	})
+
+	// Already tagged 'subagent' (so the type branch is false) but its parent
+	// was never set. Only the null-safe parent branch can link it.
+	insertSession(t, d, "orphan", "p", func(s *Session) {
+		s.MessageCount = 1
+		s.RelationshipType = "subagent"
+		// ParentSessionID left nil -> NULL in the DB.
+	})
+
+	insertMessages(t, d, Message{
+		SessionID: "spawner", Ordinal: 0, Role: "assistant",
+		Content: "spawn orphan", HasToolUse: true,
+		ToolCalls: []ToolCall{{
+			ToolName: "Agent", Category: "Task",
+			SubagentSessionID: "orphan",
+		}},
+	})
+
+	require.NoError(t, d.LinkSubagentSessions(), "LinkSubagentSessions")
+
+	orphan, err := d.GetSession(context.Background(), "orphan")
+	requireNoError(t, err, "GetSession orphan")
+	if assert.NotNil(t, orphan.ParentSessionID,
+		"NULL-parent subagent must be linked to its spawner (null-safe IS NOT)") {
+		assert.Equal(t, "spawner", *orphan.ParentSessionID,
+			"orphan.parent_session_id")
+	}
+}

--- a/internal/db/link_subagent_nested_test.go
+++ b/internal/db/link_subagent_nested_test.go
@@ -183,49 +183,179 @@ func TestLinkSubagentSessionsLinksNullParentSubagent(t *testing.T) {
 	}
 }
 
-// TestLinkSubagentSessionsPreservesParentOnConflictingEdges guards against
-// arbitrary re-parenting when a child is referenced by spawn edges from more
-// than one distinct session (reachable via copied/forked history). The parent
-// must be resolved only from an unambiguous edge; with conflicting edges the
-// current parent is preserved rather than picked arbitrarily by a bare LIMIT 1.
-func TestLinkSubagentSessionsPreservesParentOnConflictingEdges(t *testing.T) {
+// spawnEdgeTo builds the assistant message whose tool call records
+// `from` spawning `child` — the authoritative edge LinkSubagentSessions
+// resolves against.
+func spawnEdgeTo(from, child, note string) Message {
+	return Message{
+		SessionID: from, Ordinal: 0, Role: "assistant",
+		Content: note, HasToolUse: true,
+		ToolCalls: []ToolCall{{
+			ToolName: "Agent", Category: "Task",
+			SubagentSessionID: child,
+		}},
+	}
+}
+
+// parentOfSession returns the stored parent of id, failing the test when it
+// is unset.
+func parentOfSession(t *testing.T, d *DB, id string) string {
+	t.Helper()
+	s, err := d.GetSession(context.Background(), id)
+	requireNoError(t, err, "GetSession "+id)
+	require.NotNil(t, s.ParentSessionID, "%s parent must be set", id)
+	return *s.ParentSessionID
+}
+
+// TestLinkSubagentSessionsConvergesAcrossIngestionOrder covers the
+// ingestion-order case raised in review. Conflicting spawn edges (reachable
+// through copied or forked history) can arrive in any order, and either one
+// may be the ONLY stored edge when a sync runs — so a link made from that
+// partial view is provisional. Resolution must therefore be a pure function
+// of the stored edges and never of the order they were written, so the
+// provisional link self-corrects on the next sync instead of being locked in.
+//
+// A fork derives from its source and so always starts after it: the
+// earliest-started spawner is the real one, which makes the resolution
+// deterministic in both ingestion orders below.
+func TestLinkSubagentSessionsConvergesAcrossIngestionOrder(t *testing.T) {
+	const (
+		realSpawner = "real-spawner"
+		copySpawner = "copied-spawner"
+		child       = "kid"
+	)
+
+	// setup builds two spawners plus a child already correctly parented
+	// under the real (earliest-started) one.
+	setup := func(t *testing.T) *DB {
+		t.Helper()
+		d := testDB(t)
+		insertSession(t, d, realSpawner, "p", func(s *Session) {
+			s.MessageCount = 1
+			s.StartedAt = Ptr("2026-01-01T00:00:00.000Z")
+		})
+		// The copy derives from the real session, so it starts later.
+		insertSession(t, d, copySpawner, "p", func(s *Session) {
+			s.MessageCount = 1
+			s.StartedAt = Ptr("2026-06-01T00:00:00.000Z")
+		})
+		insertSession(t, d, child, "p", func(s *Session) {
+			s.MessageCount = 1
+			s.ParentSessionID = Ptr(realSpawner)
+			s.RelationshipType = "subagent"
+		})
+		return d
+	}
+
+	t.Run("copied edge ingested first", func(t *testing.T) {
+		d := setup(t)
+
+		// The copied edge is briefly the only stored edge: this link runs
+		// with no record of the real spawn yet, so whatever it writes is
+		// provisional.
+		insertMessages(t, d, spawnEdgeTo(copySpawner, child, "copied spawn"))
+		require.NoError(t, d.LinkSubagentSessions(), "link (copied edge only)")
+
+		// The real edge lands on a later sync.
+		insertMessages(t, d, spawnEdgeTo(realSpawner, child, "real spawn"))
+		require.NoError(t, d.LinkSubagentSessions(), "link (both edges)")
+
+		assert.Equal(t, realSpawner, parentOfSession(t, d, child),
+			"child must converge to the earliest-started (real) spawner "+
+				"even though the copied edge was linked first")
+
+		// ...and stay there: linking is idempotent, not oscillating.
+		require.NoError(t, d.LinkSubagentSessions(), "relink")
+		assert.Equal(t, realSpawner, parentOfSession(t, d, child),
+			"child must remain under the real spawner on later syncs")
+	})
+
+	t.Run("real edge ingested first", func(t *testing.T) {
+		d := setup(t)
+
+		insertMessages(t, d, spawnEdgeTo(realSpawner, child, "real spawn"))
+		require.NoError(t, d.LinkSubagentSessions(), "link (real edge only)")
+		assert.Equal(t, realSpawner, parentOfSession(t, d, child),
+			"real spawner must be linked")
+
+		// A later-arriving copied edge must not steal the child.
+		insertMessages(t, d, spawnEdgeTo(copySpawner, child, "copied spawn"))
+		require.NoError(t, d.LinkSubagentSessions(), "link (both edges)")
+
+		assert.Equal(t, realSpawner, parentOfSession(t, d, child),
+			"a later-arriving copied edge must not re-parent the child")
+	})
+}
+
+// TestLinkSubagentSessionsPrefersSpawnerWithKnownStartTime guards the
+// null-handling in the ordering. started_at is nullable TEXT (and the empty
+// string is treated as unset elsewhere in this package), and a plain ORDER BY
+// started_at sorts NULL FIRST in SQLite — which would hand the child to the
+// spawner whose start time is unknown. Sessions with a usable started_at must
+// win instead.
+func TestLinkSubagentSessionsPrefersSpawnerWithKnownStartTime(t *testing.T) {
 	d := testDB(t)
 
-	insertSession(t, d, "p1", "p", func(s *Session) {
+	// No usable start time: NULL and '' respectively.
+	insertSession(t, d, "unknown-null", "p", func(s *Session) {
 		s.MessageCount = 1
 	})
-	insertSession(t, d, "p2", "p", func(s *Session) {
+	insertSession(t, d, "unknown-empty", "p", func(s *Session) {
 		s.MessageCount = 1
+		s.StartedAt = Ptr("")
 	})
-	// "kid" is already a correctly parented subagent under p2.
+	insertSession(t, d, "known", "p", func(s *Session) {
+		s.MessageCount = 1
+		s.StartedAt = Ptr("2026-03-01T00:00:00.000Z")
+	})
 	insertSession(t, d, "kid", "p", func(s *Session) {
 		s.MessageCount = 1
-		parent := "p2"
-		s.ParentSessionID = &parent
 		s.RelationshipType = "subagent"
 	})
 
-	// Two DISTINCT sessions both carry a spawn edge to "kid". p1's edge is
-	// inserted first (lower rowid), so a bare `LIMIT 1` would pick p1 and
-	// wrongly re-parent kid away from its current p2. The unambiguous-edge
-	// resolution must instead preserve p2.
+	// The unknown-start edges are written first, so neither rowid order nor
+	// NULL-first ordering may decide the winner.
 	insertMessages(t, d,
-		Message{
-			SessionID: "p1", Ordinal: 0, Role: "assistant",
-			Content: "spawn kid (copy A)", HasToolUse: true,
-			ToolCalls: []ToolCall{{
-				ToolName: "Agent", Category: "Task",
-				SubagentSessionID: "kid",
-			}},
-		},
-		Message{
-			SessionID: "p2", Ordinal: 0, Role: "assistant",
-			Content: "spawn kid (copy B)", HasToolUse: true,
-			ToolCalls: []ToolCall{{
-				ToolName: "Agent", Category: "Task",
-				SubagentSessionID: "kid",
-			}},
-		},
+		spawnEdgeTo("unknown-null", "kid", "spawn (null start)"),
+		spawnEdgeTo("unknown-empty", "kid", "spawn (empty start)"),
+		spawnEdgeTo("known", "kid", "spawn (known start)"),
+	)
+
+	require.NoError(t, d.LinkSubagentSessions(), "LinkSubagentSessions")
+
+	assert.Equal(t, "known", parentOfSession(t, d, "kid"),
+		"a spawner with a usable started_at must outrank one whose start "+
+			"time is NULL or empty")
+}
+
+// TestLinkSubagentSessionsResolvesConflictingEdgesDeterministically covers the
+// remaining tie: when no candidate has a usable started_at the timestamp
+// cannot decide, so resolution falls back to the session id. Without that
+// tiebreak a bare LIMIT 1 would return whichever edge SQLite happened to visit
+// first, making the parent depend on insertion order.
+func TestLinkSubagentSessionsResolvesConflictingEdgesDeterministically(
+	t *testing.T,
+) {
+	d := testDB(t)
+
+	insertSession(t, d, "p2", "p", func(s *Session) {
+		s.MessageCount = 1
+	})
+	insertSession(t, d, "p1", "p", func(s *Session) {
+		s.MessageCount = 1
+	})
+	// "kid" currently sits under p2.
+	insertSession(t, d, "kid", "p", func(s *Session) {
+		s.MessageCount = 1
+		s.ParentSessionID = Ptr("p2")
+		s.RelationshipType = "subagent"
+	})
+
+	// p2's edge is written first (lower rowid); the id tiebreak must still
+	// select p1 rather than following insertion order.
+	insertMessages(t, d,
+		spawnEdgeTo("p2", "kid", "spawn kid (copy B)"),
+		spawnEdgeTo("p1", "kid", "spawn kid (copy A)"),
 	)
 
 	require.NoError(t, d.LinkSubagentSessions(), "LinkSubagentSessions")
@@ -233,9 +363,7 @@ func TestLinkSubagentSessionsPreservesParentOnConflictingEdges(t *testing.T) {
 	kid, err := d.GetSession(context.Background(), "kid")
 	requireNoError(t, err, "GetSession kid")
 	assert.Equal(t, "subagent", kid.RelationshipType, "kid relationship_type")
-	if assert.NotNil(t, kid.ParentSessionID, "kid parent") {
-		assert.Equal(t, "p2", *kid.ParentSessionID,
-			"conflicting edges must preserve the current parent, "+
-				"not pick one arbitrarily")
-	}
+	assert.Equal(t, "p1", parentOfSession(t, d, "kid"),
+		"ties must break on session id so the parent does not depend on "+
+			"which edge was inserted first")
 }

--- a/internal/db/link_subagent_nested_test.go
+++ b/internal/db/link_subagent_nested_test.go
@@ -566,6 +566,28 @@ func TestLinkSubagentSessionsForSessionsChunksLargeBatches(t *testing.T) {
 		"an id beyond the first chunk must still drive linking")
 }
 
+// TestSubagentChildSessionIDs covers the pre-write capture helper: it must
+// return the distinct children the given sessions' spawn edges reference,
+// ignore sessions with no edges, and treat an empty input as a no-op.
+func TestSubagentChildSessionIDs(t *testing.T) {
+	d := testDB(t)
+	for _, id := range []string{"s1", "s2", "quiet"} {
+		insertSession(t, d, id, "p", func(s *Session) { s.MessageCount = 1 })
+	}
+	insertMessages(t, d,
+		spawnEdgeTo("s1", "kid-a", "spawn a"),
+		spawnEdgeTo("s2", "kid-b", "spawn b"),
+	)
+
+	children, err := d.SubagentChildSessionIDs([]string{"s1", "s2", "quiet"})
+	require.NoError(t, err, "SubagentChildSessionIDs")
+	assert.ElementsMatch(t, []string{"kid-a", "kid-b"}, children)
+
+	none, err := d.SubagentChildSessionIDs(nil)
+	require.NoError(t, err, "empty input")
+	assert.Empty(t, none)
+}
+
 // TestLinkSubagentSessionsForSessionsPlanIsBatchBounded pins the cost shape
 // of the scoped statement, mirroring TestLinkSubagentSessionsPlanScalesWith-
 // SpawnEdges: the watcher calls this once per changed file, so neither

--- a/internal/db/link_subagent_nested_test.go
+++ b/internal/db/link_subagent_nested_test.go
@@ -426,10 +426,200 @@ func TestLinkSubagentSessionsPlanScalesWithSpawnEdges(t *testing.T) {
 	}
 }
 
+// TestLinkSubagentSessionsForSessionsScopesToBatch pins the scoped variant's
+// contract: only children reachable from the given batch — via a batch
+// member's spawn edges (spawner side) or as a batch member that is itself a
+// child (child side) — are re-resolved. A mislinked child outside the batch
+// must be left alone; that skip is what bounds a single-session watcher sync
+// by the changed batch instead of the archive.
+func TestLinkSubagentSessionsForSessionsScopesToBatch(t *testing.T) {
+	setup := func(t *testing.T) *DB {
+		t.Helper()
+		d := testDB(t)
+		for _, pair := range [][2]string{
+			{"spawner-a", "child-a"},
+			{"spawner-b", "child-b"},
+		} {
+			spawner, child := pair[0], pair[1]
+			insertSession(t, d, spawner, "p", func(s *Session) {
+				s.MessageCount = 1
+			})
+			// Both children carry the buggy path-derived state: wrong
+			// parent, already tagged 'subagent'.
+			insertSession(t, d, child, "p", func(s *Session) {
+				s.MessageCount = 1
+				s.ParentSessionID = Ptr("wrong-parent")
+				s.RelationshipType = "subagent"
+			})
+			insertMessages(t, d, spawnEdgeTo(spawner, child, "spawn "+child))
+		}
+		return d
+	}
+
+	t.Run("spawner in batch links its child", func(t *testing.T) {
+		d := setup(t)
+		require.NoError(t,
+			d.LinkSubagentSessionsForSessions([]string{"spawner-a"}))
+
+		assert.Equal(t, "spawner-a", parentOfSession(t, d, "child-a"),
+			"child of a batch spawner must be re-linked")
+		assert.Equal(t, "wrong-parent", parentOfSession(t, d, "child-b"),
+			"a mislinked child outside the batch must not be touched")
+	})
+
+	t.Run("child in batch links itself", func(t *testing.T) {
+		d := setup(t)
+		require.NoError(t,
+			d.LinkSubagentSessionsForSessions([]string{"child-b"}))
+
+		assert.Equal(t, "spawner-b", parentOfSession(t, d, "child-b"),
+			"a batch member that is itself a child must be re-linked")
+		assert.Equal(t, "wrong-parent", parentOfSession(t, d, "child-a"),
+			"a mislinked child outside the batch must not be touched")
+	})
+
+	t.Run("empty batch is a no-op", func(t *testing.T) {
+		d := setup(t)
+		require.NoError(t, d.LinkSubagentSessionsForSessions(nil))
+		assert.Equal(t, "wrong-parent", parentOfSession(t, d, "child-a"))
+		assert.Equal(t, "wrong-parent", parentOfSession(t, d, "child-b"))
+	})
+}
+
+// TestLinkSubagentSessionsForSessionsConvergesAcrossIngestionOrder replays
+// the ingestion-order sequence of TestLinkSubagentSessionsConvergesAcross-
+// IngestionOrder through the scoped variant, batching exactly the session a
+// single-file watcher sync would have written each time. A conflicting edge
+// always arrives through its spawner's transcript, so the spawner is in that
+// sync's batch and the child it claims is re-resolved — scoping must not
+// reintroduce the provisional-parent lock-in the earliest-started rule fixed.
+func TestLinkSubagentSessionsForSessionsConvergesAcrossIngestionOrder(
+	t *testing.T,
+) {
+	const (
+		realSpawner = "real-spawner"
+		copySpawner = "copied-spawner"
+		child       = "kid"
+	)
+
+	d := testDB(t)
+	insertSession(t, d, realSpawner, "p", func(s *Session) {
+		s.MessageCount = 1
+		s.StartedAt = Ptr("2026-01-01T00:00:00.000Z")
+	})
+	insertSession(t, d, copySpawner, "p", func(s *Session) {
+		s.MessageCount = 1
+		s.StartedAt = Ptr("2026-06-01T00:00:00.000Z")
+	})
+	insertSession(t, d, child, "p", func(s *Session) {
+		s.MessageCount = 1
+		s.RelationshipType = "subagent"
+	})
+
+	// The copied spawner's transcript syncs first: its edge is the only one
+	// stored, so the link it writes is provisional.
+	insertMessages(t, d, spawnEdgeTo(copySpawner, child, "copied spawn"))
+	require.NoError(t,
+		d.LinkSubagentSessionsForSessions([]string{copySpawner}),
+		"link (copied edge only)")
+	assert.Equal(t, copySpawner, parentOfSession(t, d, child),
+		"the only stored edge wins provisionally")
+
+	// The real spawner's transcript syncs later. Only the real spawner is
+	// in this batch, but its edge claims the child, so the child must be
+	// re-resolved against BOTH edges and converge to the earliest-started
+	// (real) spawner.
+	insertMessages(t, d, spawnEdgeTo(realSpawner, child, "real spawn"))
+	require.NoError(t,
+		d.LinkSubagentSessionsForSessions([]string{realSpawner}),
+		"link (both edges)")
+	assert.Equal(t, realSpawner, parentOfSession(t, d, child),
+		"a scoped link must still converge to the real spawner once its "+
+			"edge lands")
+}
+
+// TestLinkSubagentSessionsForSessionsChunksLargeBatches drives a batch past
+// the per-statement chunk size (each id binds twice, so chunks are halved) to
+// prove linking still reaches ids beyond the first chunk.
+func TestLinkSubagentSessionsForSessionsChunksLargeBatches(t *testing.T) {
+	d := testDB(t)
+	insertSession(t, d, "spawner", "p", func(s *Session) {
+		s.MessageCount = 1
+	})
+	insertSession(t, d, "kid", "p", func(s *Session) {
+		s.MessageCount = 1
+		s.ParentSessionID = Ptr("wrong-parent")
+		s.RelationshipType = "subagent"
+	})
+	insertMessages(t, d, spawnEdgeTo("spawner", "kid", "spawn"))
+
+	// Front-load enough filler ids that the real spawner lands in a later
+	// chunk.
+	ids := make([]string, 0, maxSQLVars+1)
+	for i := range maxSQLVars {
+		ids = append(ids, "no-such-session-"+strconv.Itoa(i))
+	}
+	ids = append(ids, "spawner")
+
+	require.NoError(t, d.LinkSubagentSessionsForSessions(ids))
+	assert.Equal(t, "spawner", parentOfSession(t, d, "kid"),
+		"an id beyond the first chunk must still drive linking")
+}
+
+// TestLinkSubagentSessionsForSessionsPlanIsBatchBounded pins the cost shape
+// of the scoped statement, mirroring TestLinkSubagentSessionsPlanScalesWith-
+// SpawnEdges: the watcher calls this once per changed file, so neither
+// sessions nor tool_calls may be scanned — both UNION branches have to seek
+// their index and the archive's size must never enter the plan.
+func TestLinkSubagentSessionsForSessionsPlanIsBatchBounded(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		sessions int
+	}{
+		{name: "small archive", sessions: 4},
+		{name: "large archive", sessions: 500},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := testDB(t)
+			for i := range tc.sessions {
+				insertSession(t, d, "bulk-"+strconv.Itoa(i), "p",
+					func(s *Session) { s.MessageCount = 1 })
+			}
+			insertSession(t, d, "spawner", "p", func(s *Session) {
+				s.MessageCount = 1
+			})
+			insertSession(t, d, "kid", "p", func(s *Session) {
+				s.MessageCount = 1
+				s.RelationshipType = "subagent"
+			})
+			insertMessages(t, d, spawnEdgeTo("spawner", "kid", "spawn"))
+			require.NoError(t,
+				d.LinkSubagentSessionsForSessions([]string{"spawner"}))
+
+			plan := queryPlanOf(
+				t, d, linkSubagentSessionsForSessionsQuery("(?)"),
+				"spawner", "spawner",
+			)
+
+			assert.NotContains(t, plan, "SCAN s",
+				"scoped linking must not scan sessions\n"+plan)
+			assert.NotContains(t, plan, "SCAN tc",
+				"scoped linking must not scan tool_calls: per-event cost "+
+					"has to track the batch, not the archive's edges\n"+plan)
+			assert.Contains(t, plan, "idx_tool_calls_session",
+				"the spawner-side branch must seek the session_id index\n"+
+					plan)
+			assert.Contains(t, plan, "idx_tool_calls_subagent",
+				"the child-side branch must seek the subagent partial "+
+					"index\n"+plan)
+		})
+	}
+}
+
 // queryPlanOf returns the EXPLAIN QUERY PLAN detail lines for sql.
-func queryPlanOf(t *testing.T, d *DB, sql string) string {
+func queryPlanOf(t *testing.T, d *DB, sql string, args ...any) string {
 	t.Helper()
-	rows, err := d.getReader().Query("EXPLAIN QUERY PLAN " + sql)
+	rows, err := d.getReader().Query("EXPLAIN QUERY PLAN "+sql, args...)
 	requireNoError(t, err, "EXPLAIN QUERY PLAN")
 	defer rows.Close()
 

--- a/internal/db/link_subagent_nested_test.go
+++ b/internal/db/link_subagent_nested_test.go
@@ -2,10 +2,15 @@ package db
 
 import (
 	"context"
+	"strconv"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/timeutil"
 )
 
 // TestLinkSubagentSessionsReParentsNestedGrandchild reproduces the
@@ -366,4 +371,122 @@ func TestLinkSubagentSessionsResolvesConflictingEdgesDeterministically(
 	assert.Equal(t, "p1", parentOfSession(t, d, "kid"),
 		"ties must break on session id so the parent does not depend on "+
 			"which edge was inserted first")
+}
+
+// TestLinkSubagentSessionsPlanScalesWithSpawnEdges pins the cost shape of the
+// linking statement. Every sync calls LinkSubagentSessions, and it must stay
+// cheap on a large archive in which nothing changed, so the row set has to be
+// driven from the spawn edges (the idx_tool_calls_subagent partial index)
+// rather than from a scan of sessions.
+//
+// The invariant is asserted on the query plan rather than on a wall-clock
+// comparison between a small and a large archive, because the plan is what
+// actually decides the scaling and it is deterministic in CI (see
+// TestListActiveSessionSourceOwnershipScopesUsesBoundedSeeks for the same
+// approach). The regression this guards is silent: swapping the IN back to
+// the equivalent-reading EXISTS(...) keeps every behavioural test green while
+// re-introducing a full sessions scan on every sync.
+//
+// Both archive sizes are exercised so the assertion cannot pass merely
+// because the planner had no statistics to work with.
+func TestLinkSubagentSessionsPlanScalesWithSpawnEdges(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		sessions int
+	}{
+		{name: "small archive", sessions: 4},
+		{name: "large archive", sessions: 500},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := testDB(t)
+			for i := range tc.sessions {
+				insertSession(t, d, "bulk-"+strconv.Itoa(i), "p",
+					func(s *Session) { s.MessageCount = 1 })
+			}
+			// Exactly one spawn edge, regardless of archive size.
+			insertSession(t, d, "spawner", "p", func(s *Session) {
+				s.MessageCount = 1
+				s.StartedAt = Ptr("2026-01-01T00:00:00.000Z")
+			})
+			insertSession(t, d, "kid", "p", func(s *Session) {
+				s.MessageCount = 1
+				s.RelationshipType = "subagent"
+			})
+			insertMessages(t, d, spawnEdgeTo("spawner", "kid", "spawn"))
+			require.NoError(t, d.LinkSubagentSessions(), "LinkSubagentSessions")
+
+			plan := queryPlanOf(t, d, linkSubagentSessionsQuery)
+
+			assert.NotContains(t, plan, "SCAN s",
+				"linking must not scan sessions: its cost has to track the "+
+					"number of spawn edges, not the size of the archive\n"+plan)
+			assert.Contains(t, plan, "idx_tool_calls_subagent",
+				"linking must be driven from the spawn-edge partial index\n"+plan)
+		})
+	}
+}
+
+// queryPlanOf returns the EXPLAIN QUERY PLAN detail lines for sql.
+func queryPlanOf(t *testing.T, d *DB, sql string) string {
+	t.Helper()
+	rows, err := d.getReader().Query("EXPLAIN QUERY PLAN " + sql)
+	requireNoError(t, err, "EXPLAIN QUERY PLAN")
+	defer rows.Close()
+
+	var details []string
+	for rows.Next() {
+		var id, parent, notused int
+		var detail string
+		require.NoError(t, rows.Scan(&id, &parent, &notused, &detail))
+		details = append(details, detail)
+	}
+	require.NoError(t, rows.Err())
+	return strings.Join(details, "\n")
+}
+
+// TestLinkSubagentSessionsOrdersStartTimesChronologically covers the
+// timestamp-ordering case raised in review. started_at is TEXT written by
+// timeutil.Format (time.RFC3339Nano), which strips trailing zeros from the
+// fractional second, so production values are NOT fixed width: a whole-second
+// start is stored '...T00:00:00Z' and a later one '...T00:00:00.1Z'. Because
+// '.' sorts before 'Z', raw lexical order puts the LATER timestamp FIRST —
+// which would resolve the child to the copy. The ordering must normalize
+// started_at so it compares chronologically.
+func TestLinkSubagentSessionsOrdersStartTimesChronologically(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	realStart := timeutil.Format(base)
+	copyStart := timeutil.Format(base.Add(100 * time.Millisecond))
+
+	// Pin the production shapes this test exists for: the real spawner starts
+	// 100ms EARLIER, yet its stored string sorts LATER lexically.
+	require.Equal(t, "2026-01-01T00:00:00Z", realStart, "whole-second form")
+	require.Equal(t, "2026-01-01T00:00:00.1Z", copyStart, "fractional form")
+	require.Less(t, copyStart, realStart,
+		"guard: raw lexical order must be inverted here, otherwise this test "+
+			"would pass even without normalizing started_at")
+
+	d := testDB(t)
+	insertSession(t, d, "real-spawner", "p", func(s *Session) {
+		s.MessageCount = 1
+		s.StartedAt = Ptr(realStart)
+	})
+	insertSession(t, d, "copied-spawner", "p", func(s *Session) {
+		s.MessageCount = 1
+		s.StartedAt = Ptr(copyStart)
+	})
+	insertSession(t, d, "kid", "p", func(s *Session) {
+		s.MessageCount = 1
+		s.RelationshipType = "subagent"
+	})
+
+	insertMessages(t, d,
+		spawnEdgeTo("copied-spawner", "kid", "copied spawn"),
+		spawnEdgeTo("real-spawner", "kid", "real spawn"),
+	)
+
+	require.NoError(t, d.LinkSubagentSessions(), "LinkSubagentSessions")
+
+	assert.Equal(t, "real-spawner", parentOfSession(t, d, "kid"),
+		"the chronologically earliest spawner must win; ordering the raw "+
+			"RFC3339Nano strings would pick the later copied spawner")
 }

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -1570,10 +1570,24 @@ func (db *DB) LinkSubagentSessions() error {
 		),
 		relationship_type = 'subagent',
 		local_modified_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
-		WHERE relationship_type != 'subagent'
-		AND EXISTS (
+		-- The tool_calls edge (from toolUseResult.agentId) is the record of
+		-- the actual spawn, so it is authoritative over the path-derived
+		-- parent set at parse time. Nested subagents (depth >= 2) all live in
+		-- the same flat <main>/subagents/ dir, so path derivation pins them to
+		-- the main session AND tags them 'subagent'; the previous
+		-- relationship_type != subagent guard then skipped them, leaving
+		-- the hierarchy flat. Re-point whenever the authoritative parent
+		-- differs (IS NOT = null-safe), which also covers the old
+		-- continuation -> subagent upgrade.
+		WHERE EXISTS (
 			SELECT 1 FROM tool_calls tc
 			WHERE tc.subagent_session_id = sessions.id
+		)
+		AND parent_session_id IS NOT (
+			SELECT tc.session_id
+			FROM tool_calls tc
+			WHERE tc.subagent_session_id = sessions.id
+			LIMIT 1
 		)`)
 	if err != nil {
 		return fmt.Errorf("linking subagent sessions: %w", err)

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -1566,37 +1566,49 @@ func (db *DB) LinkSubagentSessions() error {
 	// same pattern).
 	_, err := db.getWriter().Exec(`
 		UPDATE sessions
-		SET parent_session_id = (
-			SELECT tc.session_id
-			FROM tool_calls tc
-			WHERE tc.subagent_session_id = sessions.id
-			LIMIT 1
+		SET parent_session_id = COALESCE(
+			(
+				SELECT tc.session_id
+				FROM tool_calls tc
+				WHERE tc.subagent_session_id = sessions.id
+				GROUP BY tc.subagent_session_id
+				HAVING COUNT(DISTINCT tc.session_id) = 1
+			),
+			parent_session_id
 		),
 		relationship_type = 'subagent',
 		local_modified_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
-		-- The tool_calls edge (from toolUseResult.agentId) is the record of
-		-- the actual spawn, so it is authoritative over the path-derived
-		-- parent set at parse time. Nested subagents (depth >= 2) all live in
-		-- the same flat <main>/subagents/ dir, so path derivation pins them to
-		-- the main session AND tags them 'subagent'; the previous
-		-- relationship_type != subagent guard then skipped them, leaving
-		-- the hierarchy flat. Update the row when EITHER it is not yet tagged
-		-- 'subagent' (upgrades a continuation/fork/empty classification even
-		-- when its parent already matches the spawner) OR the authoritative
-		-- parent differs (the nested depth>=2 re-parent). Null-safe IS NOT.
-		-- Already-correct subagents match neither branch and are left as-is to
-		-- avoid needless local_modified_at churn.
+		-- The tool_calls edge (from toolUseResult.agentId) records the actual
+		-- spawn, authoritative over the path-derived parent set at parse time.
+		-- Nested subagents (depth >= 2) live flat in <main>/subagents/, so path
+		-- derivation pins them to the main session AND tags them 'subagent';
+		-- the old relationship_type != 'subagent' guard skipped them, leaving
+		-- the hierarchy flat.
+		--
+		-- Resolve the parent only from an UNAMBIGUOUS edge: the grouped
+		-- subquery yields a spawner only when exactly one distinct session
+		-- spawned this child (HAVING COUNT(DISTINCT tc.session_id) = 1). With
+		-- conflicting edges from copied/forked history it yields NULL and
+		-- COALESCE keeps the current parent, so a correctly parented subagent
+		-- is never re-parented arbitrarily. Update when EITHER the row is not
+		-- yet 'subagent' (upgrade continuation/fork/empty; parent preserved if
+		-- ambiguous) OR the unambiguous parent differs (null-safe IS NOT).
+		-- Already-correct subagents match neither branch (no churn).
 		WHERE EXISTS (
 			SELECT 1 FROM tool_calls tc
 			WHERE tc.subagent_session_id = sessions.id
 		)
 		AND (
 			relationship_type != 'subagent'
-			OR parent_session_id IS NOT (
-				SELECT tc.session_id
-				FROM tool_calls tc
-				WHERE tc.subagent_session_id = sessions.id
-				LIMIT 1
+			OR parent_session_id IS NOT COALESCE(
+				(
+					SELECT tc.session_id
+					FROM tool_calls tc
+					WHERE tc.subagent_session_id = sessions.id
+					GROUP BY tc.subagent_session_id
+					HAVING COUNT(DISTINCT tc.session_id) = 1
+				),
+				parent_session_id
 			)
 		)`)
 	if err != nil {

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -1576,18 +1576,24 @@ func (db *DB) LinkSubagentSessions() error {
 		-- the same flat <main>/subagents/ dir, so path derivation pins them to
 		-- the main session AND tags them 'subagent'; the previous
 		-- relationship_type != subagent guard then skipped them, leaving
-		-- the hierarchy flat. Re-point whenever the authoritative parent
-		-- differs (IS NOT = null-safe), which also covers the old
-		-- continuation -> subagent upgrade.
+		-- the hierarchy flat. Update the row when EITHER it is not yet tagged
+		-- 'subagent' (upgrades a continuation/fork/empty classification even
+		-- when its parent already matches the spawner) OR the authoritative
+		-- parent differs (the nested depth>=2 re-parent). Null-safe IS NOT.
+		-- Already-correct subagents match neither branch and are left as-is to
+		-- avoid needless local_modified_at churn.
 		WHERE EXISTS (
 			SELECT 1 FROM tool_calls tc
 			WHERE tc.subagent_session_id = sessions.id
 		)
-		AND parent_session_id IS NOT (
-			SELECT tc.session_id
-			FROM tool_calls tc
-			WHERE tc.subagent_session_id = sessions.id
-			LIMIT 1
+		AND (
+			relationship_type != 'subagent'
+			OR parent_session_id IS NOT (
+				SELECT tc.session_id
+				FROM tool_calls tc
+				WHERE tc.subagent_session_id = sessions.id
+				LIMIT 1
+			)
 		)`)
 	if err != nil {
 		return fmt.Errorf("linking subagent sessions: %w", err)

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -1544,11 +1544,15 @@ func (db *DB) GetChildSessions(
 }
 
 // LinkSubagentSessions sets parent_session_id and
-// relationship_type on sessions that are referenced by
-// tool_calls.subagent_session_id. Updates sessions that either
-// have no parent yet or have a non-subagent relationship (e.g.
-// a Zencoder session classified as "continuation" from header
-// parentId that is actually a spawned subagent).
+// relationship_type on sessions referenced by
+// tool_calls.subagent_session_id (the authoritative spawn edge).
+// A session is updated when it is not yet tagged 'subagent' (e.g.
+// a Zencoder session classified as "continuation" from a header
+// parentId that is actually a spawned subagent) OR when its stored
+// parent disagrees with the spawn edge. The latter re-parents
+// nested subagents (depth >= 2), which the parser pins to the main
+// session because Claude Code stores every subagent flat under
+// <main>/subagents/. Already-correct subagents are left untouched.
 func (db *DB) LinkSubagentSessions() error {
 	db.mu.Lock()
 	defer db.mu.Unlock()

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -1543,6 +1543,43 @@ func (db *DB) GetChildSessions(
 	return scanSessionRows(rows)
 }
 
+// subagentSpawnerExpr resolves the parent of the session aliased `s`
+// from the authoritative tool_calls spawn edges (recorded by the parser
+// from toolUseResult.agentId).
+//
+// A child is normally referenced by exactly one edge, but copied or
+// forked history can leave several sessions claiming the same child.
+// Resolution must then be a pure function of the stored edges and never
+// of the order they arrived, because any single sync may observe only a
+// subset of them: a link written from a partial view has to self-correct
+// once the rest land, rather than being locked in.
+//
+// A fork derives from the session it was forked from, so it always
+// starts later. Ordering candidates by start time therefore resolves to
+// the original spawner from any subset, and converges on the next sync.
+// The remaining keys keep that total order well defined:
+//   - started_at is nullable TEXT (the empty string is likewise treated
+//     as unset in this package), and SQLite sorts NULL first, so an
+//     unknown start time would otherwise outrank every real one — the
+//     leading IS NULL key pushes those candidates last instead.
+//   - the session id breaks ties, so a child whose candidates all lack a
+//     start time still resolves the same way on every sync instead of
+//     following whichever edge SQLite visited first.
+//
+// The LEFT JOIN keeps an edge whose spawner has no sessions row as a
+// last-resort candidate (it sorts with the unknown start times) rather
+// than discarding it.
+const subagentSpawnerExpr = `
+		SELECT tc.session_id
+		FROM tool_calls tc
+		LEFT JOIN sessions ps ON ps.id = tc.session_id
+		WHERE tc.subagent_session_id = s.id
+		ORDER BY
+			(NULLIF(ps.started_at, '') IS NULL),
+			NULLIF(ps.started_at, ''),
+			tc.session_id
+		LIMIT 1`
+
 // LinkSubagentSessions sets parent_session_id and
 // relationship_type on sessions referenced by
 // tool_calls.subagent_session_id (the authoritative spawn edge).
@@ -1553,6 +1590,9 @@ func (db *DB) GetChildSessions(
 // nested subagents (depth >= 2), which the parser pins to the main
 // session because Claude Code stores every subagent flat under
 // <main>/subagents/. Already-correct subagents are left untouched.
+//
+// See subagentSpawnerExpr for how a child claimed by more than one
+// spawner is resolved.
 func (db *DB) LinkSubagentSessions() error {
 	db.mu.Lock()
 	defer db.mu.Unlock()
@@ -1565,16 +1605,8 @@ func (db *DB) LinkSubagentSessions() error {
 	// (see updateSessionSignalsTx and ReplaceSessionUsageEvents for the
 	// same pattern).
 	_, err := db.getWriter().Exec(`
-		UPDATE sessions
-		SET parent_session_id = COALESCE(
-			(
-				SELECT tc.session_id
-				FROM tool_calls tc
-				WHERE tc.subagent_session_id = sessions.id
-				GROUP BY tc.subagent_session_id
-				HAVING COUNT(DISTINCT tc.session_id) = 1
-			),
-			parent_session_id
+		UPDATE sessions AS s
+		SET parent_session_id = (` + subagentSpawnerExpr + `
 		),
 		relationship_type = 'subagent',
 		local_modified_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
@@ -1585,30 +1617,19 @@ func (db *DB) LinkSubagentSessions() error {
 		-- the old relationship_type != 'subagent' guard skipped them, leaving
 		-- the hierarchy flat.
 		--
-		-- Resolve the parent only from an UNAMBIGUOUS edge: the grouped
-		-- subquery yields a spawner only when exactly one distinct session
-		-- spawned this child (HAVING COUNT(DISTINCT tc.session_id) = 1). With
-		-- conflicting edges from copied/forked history it yields NULL and
-		-- COALESCE keeps the current parent, so a correctly parented subagent
-		-- is never re-parented arbitrarily. Update when EITHER the row is not
-		-- yet 'subagent' (upgrade continuation/fork/empty; parent preserved if
-		-- ambiguous) OR the unambiguous parent differs (null-safe IS NOT).
-		-- Already-correct subagents match neither branch (no churn).
+		-- Update when EITHER the row is not yet 'subagent' (upgrade
+		-- continuation/fork/empty) OR the resolved spawner differs from the
+		-- stored parent (null-safe IS NOT, so a subagent with a NULL parent is
+		-- still linked). Because the resolved spawner depends only on the
+		-- stored edges, a row already pointing at it matches neither branch:
+		-- linking stays a no-op and does not churn local_modified_at.
 		WHERE EXISTS (
 			SELECT 1 FROM tool_calls tc
-			WHERE tc.subagent_session_id = sessions.id
+			WHERE tc.subagent_session_id = s.id
 		)
 		AND (
 			relationship_type != 'subagent'
-			OR parent_session_id IS NOT COALESCE(
-				(
-					SELECT tc.session_id
-					FROM tool_calls tc
-					WHERE tc.subagent_session_id = sessions.id
-					GROUP BY tc.subagent_session_id
-					HAVING COUNT(DISTINCT tc.session_id) = 1
-				),
-				parent_session_id
+			OR parent_session_id IS NOT (` + subagentSpawnerExpr + `
 			)
 		)`)
 	if err != nil {

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -1579,6 +1579,14 @@ func (db *DB) GetChildSessions(
 //     usable start time still resolves the same way on every sync
 //     instead of following whichever edge SQLite visited first.
 //
+// Ranking unknown start times last is a deliberate trade-off: a real
+// spawner with no usable started_at loses to a copied spawner that has
+// one. The only signal that could protect it — the child's currently
+// stored parent — depends on what earlier syncs wrote, which is the
+// ingestion-order dependence this resolution exists to remove. If the
+// spawner's start time later becomes known, its row update re-enters
+// linking and the child self-corrects.
+//
 // The LEFT JOIN keeps an edge whose spawner has no sessions row as a
 // last-resort candidate (it sorts with the unknown start times) rather
 // than discarding it.

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -1650,7 +1650,9 @@ const linkSubagentSessionsQuery = `
 // spawner is resolved, and linkSubagentSessionsQuery for why the
 // statement is driven from the spawn-edge index: every sync calls this,
 // so its cost has to track the number of spawn edges rather than the
-// size of the archive.
+// size of the archive. Per-event paths (single-session watcher syncs)
+// use LinkSubagentSessionsForSessions instead, which further bounds the
+// pass to the changed batch.
 func (db *DB) LinkSubagentSessions() error {
 	db.mu.Lock()
 	defer db.mu.Unlock()
@@ -1667,6 +1669,78 @@ func (db *DB) LinkSubagentSessions() error {
 		return fmt.Errorf("linking subagent sessions: %w", err)
 	}
 	return nil
+}
+
+// linkSubagentSessionsForSessionsQuery is linkSubagentSessionsQuery
+// restricted to the children a batch of changed sessions can affect. ph is
+// an inPlaceholders list bound twice: once per branch of the UNION.
+//
+// A changed session can alter linking in exactly two ways, one per branch:
+//   - tc.session_id IN ph: the session's transcript carries spawn edges, so
+//     every child it claims is re-resolved (idx_tool_calls_session seek).
+//     A conflicting edge always arrives through its spawner's transcript,
+//     so this branch is what lets a provisional link self-correct — the
+//     spawner whose edge just landed is in the batch by definition.
+//   - tc.subagent_session_id IN ph: the session is itself a child whose row
+//     was rewritten (e.g. re-parsed with a path-derived parent), so its own
+//     link is re-resolved (idx_tool_calls_subagent seek).
+//
+// Sessions outside both branches have unchanged edges, and resolution is a
+// pure function of the stored edges (see subagentSpawnerExpr), so their
+// links cannot have changed — skipping them is what keeps a single-session
+// watcher sync bounded by the batch instead of the archive.
+func linkSubagentSessionsForSessionsQuery(ph string) string {
+	return `
+	UPDATE sessions AS s
+	SET parent_session_id = (` + subagentSpawnerExpr + `
+	),
+	relationship_type = 'subagent',
+	local_modified_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+	WHERE s.id IN (
+		SELECT tc.subagent_session_id FROM tool_calls tc
+		WHERE tc.session_id IN ` + ph + `
+		AND tc.subagent_session_id IS NOT NULL
+		UNION
+		SELECT tc.subagent_session_id FROM tool_calls tc
+		WHERE tc.subagent_session_id IN ` + ph + `
+	)
+	AND (
+		relationship_type != 'subagent'
+		OR parent_session_id IS NOT (` + subagentSpawnerExpr + `
+		)
+	)`
+}
+
+// LinkSubagentSessionsForSessions is LinkSubagentSessions scoped to the
+// sessions written by one sync batch: only children reachable from a batch
+// member's spawn edges (or batch members that are themselves children) are
+// re-resolved. Per-event paths — the session watcher re-syncs a single file
+// on every change — must use this form so their linking cost tracks the
+// changed batch; bulk paths (full sync, reconciliation, resync) keep the
+// global LinkSubagentSessions pass they already coalesce to.
+func (db *DB) LinkSubagentSessionsForSessions(ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	// Each id binds twice (once per UNION branch), so halve the chunk to
+	// stay within SQLite's bind-variable limit.
+	return queryChunkedSize(ids, maxSQLVars/2, func(chunk []string) error {
+		ph, args := inPlaceholders(chunk)
+		allArgs := append(args, args...)
+		_, err := db.getWriter().Exec(
+			linkSubagentSessionsForSessionsQuery(ph), allArgs...,
+		)
+		if err != nil {
+			return fmt.Errorf(
+				"linking subagent sessions for %d changed sessions: %w",
+				len(chunk), err,
+			)
+		}
+		return nil
+	})
 }
 
 // GetSessionFileInfo returns file_size and file_mtime for a session. Used for

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -1751,6 +1751,47 @@ func (db *DB) LinkSubagentSessionsForSessions(ids []string) error {
 	})
 }
 
+// SubagentChildSessionIDs returns the distinct children the given sessions'
+// spawn edges currently reference (tool_calls.subagent_session_id). Sync
+// captures this BEFORE a full rewrite or parser-exclusion delete: those
+// writes cascade tool_calls away, and LinkSubagentSessionsForSessions
+// discovers children only through post-write edges, so a child whose edge is
+// about to disappear must be carried into the scoped batch explicitly to be
+// re-resolved against its remaining spawners.
+func (db *DB) SubagentChildSessionIDs(ids []string) ([]string, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	var children []string
+	err := queryChunked(ids, func(chunk []string) error {
+		ph, args := inPlaceholders(chunk)
+		rows, err := db.getReader().Query(`
+			SELECT DISTINCT tc.subagent_session_id
+			FROM tool_calls tc
+			WHERE tc.session_id IN `+ph+`
+			AND tc.subagent_session_id IS NOT NULL`, args...)
+		if err != nil {
+			return fmt.Errorf(
+				"listing subagent children of %d sessions: %w",
+				len(chunk), err,
+			)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var child string
+			if err := rows.Scan(&child); err != nil {
+				return fmt.Errorf("scanning subagent child: %w", err)
+			}
+			children = append(children, child)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return children, nil
+}
+
 // GetSessionFileInfo returns file_size and file_mtime for a session. Used for
 // fast skip checks during sync. Recoverable source-missing tombstones are
 // excluded so an identical source restoration cannot be mistaken for fresh.

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -1557,14 +1557,27 @@ func (db *DB) GetChildSessions(
 // A fork derives from the session it was forked from, so it always
 // starts later. Ordering candidates by start time therefore resolves to
 // the original spawner from any subset, and converges on the next sync.
+//
+// started_at has to be NORMALIZED before it is ordered, not compared
+// raw. It is TEXT written by timeutil.Format, i.e. time.RFC3339Nano,
+// which STRIPS trailing zeros from the fractional second: a whole-second
+// start is stored '...T00:00:00Z' while a later one is stored
+// '...T00:00:00.1Z', and '.' (0x2E) sorts before 'Z' (0x5A). Raw lexical
+// order is therefore not chronological in exactly the case that matters
+// here — it ranks a whole-second spawner behind every fractional one and
+// would hand the child to a copy. strftime re-renders each value as
+// fixed-width '...T00:00:00.000Z', for which lexical order IS
+// chronological (to the millisecond; anything closer than that falls
+// through to the id key below).
+//
 // The remaining keys keep that total order well defined:
-//   - started_at is nullable TEXT (the empty string is likewise treated
-//     as unset in this package), and SQLite sorts NULL first, so an
-//     unknown start time would otherwise outrank every real one — the
-//     leading IS NULL key pushes those candidates last instead.
+//   - strftime yields NULL for a started_at that is unset, empty or
+//     malformed, and SQLite sorts NULL first, so an unknown start time
+//     would otherwise outrank every real one — the leading IS NULL key
+//     pushes those candidates last instead.
 //   - the session id breaks ties, so a child whose candidates all lack a
-//     start time still resolves the same way on every sync instead of
-//     following whichever edge SQLite visited first.
+//     usable start time still resolves the same way on every sync
+//     instead of following whichever edge SQLite visited first.
 //
 // The LEFT JOIN keeps an edge whose spawner has no sessions row as a
 // last-resort candidate (it sorts with the unknown start times) rather
@@ -1575,10 +1588,52 @@ const subagentSpawnerExpr = `
 		LEFT JOIN sessions ps ON ps.id = tc.session_id
 		WHERE tc.subagent_session_id = s.id
 		ORDER BY
-			(NULLIF(ps.started_at, '') IS NULL),
-			NULLIF(ps.started_at, ''),
+			(strftime('%Y-%m-%dT%H:%M:%fZ', ps.started_at) IS NULL),
+			strftime('%Y-%m-%dT%H:%M:%fZ', ps.started_at),
 			tc.session_id
 		LIMIT 1`
+
+// linkSubagentSessionsQuery re-points every session that carries a spawn edge
+// at the spawner subagentSpawnerExpr resolves for it.
+//
+// The statement is driven from the edges rather than from sessions: `s.id IN
+// (SELECT tc.subagent_session_id ...)` lets SQLite seek the partial index
+// idx_tool_calls_subagent and then look each child up by primary key, so a
+// sync's linking cost scales with the number of spawn edges instead of with
+// the size of the archive. The equivalent EXISTS(...) form reads the same but
+// plans as a full scan of sessions with a correlated probe per row, which is
+// what makes linking on a large archive expensive even when nothing changed.
+// The IS NOT NULL filter keeps the candidate list free of NULLs, so the IN
+// comparison cannot go three-valued (the partial index carries exactly those
+// rows, so the filter is free).
+const linkSubagentSessionsQuery = `
+	UPDATE sessions AS s
+	SET parent_session_id = (` + subagentSpawnerExpr + `
+	),
+	relationship_type = 'subagent',
+	local_modified_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+	-- The tool_calls edge (from toolUseResult.agentId) records the actual
+	-- spawn, authoritative over the path-derived parent set at parse time.
+	-- Nested subagents (depth >= 2) live flat in <main>/subagents/, so path
+	-- derivation pins them to the main session AND tags them 'subagent';
+	-- the old relationship_type != 'subagent' guard skipped them, leaving
+	-- the hierarchy flat.
+	--
+	-- Update when EITHER the row is not yet 'subagent' (upgrade
+	-- continuation/fork/empty) OR the resolved spawner differs from the
+	-- stored parent (null-safe IS NOT, so a subagent with a NULL parent is
+	-- still linked). Because the resolved spawner depends only on the
+	-- stored edges, a row already pointing at it matches neither branch:
+	-- linking stays a no-op and does not churn local_modified_at.
+	WHERE s.id IN (
+		SELECT tc.subagent_session_id FROM tool_calls tc
+		WHERE tc.subagent_session_id IS NOT NULL
+	)
+	AND (
+		relationship_type != 'subagent'
+		OR parent_session_id IS NOT (` + subagentSpawnerExpr + `
+		)
+	)`
 
 // LinkSubagentSessions sets parent_session_id and
 // relationship_type on sessions referenced by
@@ -1592,7 +1647,10 @@ const subagentSpawnerExpr = `
 // <main>/subagents/. Already-correct subagents are left untouched.
 //
 // See subagentSpawnerExpr for how a child claimed by more than one
-// spawner is resolved.
+// spawner is resolved, and linkSubagentSessionsQuery for why the
+// statement is driven from the spawn-edge index: every sync calls this,
+// so its cost has to track the number of spawn edges rather than the
+// size of the archive.
 func (db *DB) LinkSubagentSessions() error {
 	db.mu.Lock()
 	defer db.mu.Unlock()
@@ -1604,34 +1662,7 @@ func (db *DB) LinkSubagentSessions() error {
 	// session after a mirror's cutoff would otherwise never re-push it
 	// (see updateSessionSignalsTx and ReplaceSessionUsageEvents for the
 	// same pattern).
-	_, err := db.getWriter().Exec(`
-		UPDATE sessions AS s
-		SET parent_session_id = (` + subagentSpawnerExpr + `
-		),
-		relationship_type = 'subagent',
-		local_modified_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
-		-- The tool_calls edge (from toolUseResult.agentId) records the actual
-		-- spawn, authoritative over the path-derived parent set at parse time.
-		-- Nested subagents (depth >= 2) live flat in <main>/subagents/, so path
-		-- derivation pins them to the main session AND tags them 'subagent';
-		-- the old relationship_type != 'subagent' guard skipped them, leaving
-		-- the hierarchy flat.
-		--
-		-- Update when EITHER the row is not yet 'subagent' (upgrade
-		-- continuation/fork/empty) OR the resolved spawner differs from the
-		-- stored parent (null-safe IS NOT, so a subagent with a NULL parent is
-		-- still linked). Because the resolved spawner depends only on the
-		-- stored edges, a row already pointing at it matches neither branch:
-		-- linking stays a no-op and does not churn local_modified_at.
-		WHERE EXISTS (
-			SELECT 1 FROM tool_calls tc
-			WHERE tc.subagent_session_id = s.id
-		)
-		AND (
-			relationship_type != 'subagent'
-			OR parent_session_id IS NOT (` + subagentSpawnerExpr + `
-			)
-		)`)
+	_, err := db.getWriter().Exec(linkSubagentSessionsQuery)
 	if err != nil {
 		return fmt.Errorf("linking subagent sessions: %w", err)
 	}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -12467,6 +12467,7 @@ func (e *Engine) SyncSingleSessionContext(
 		return nil
 	}
 
+	writtenIDs := make([]string, 0, len(res.results))
 	for _, pr := range res.results {
 		if err := e.writeSessionFull(
 			pendingWrite{
@@ -12484,12 +12485,18 @@ func (e *Engine) SyncSingleSessionContext(
 		} else if errors.Is(err, errSessionPreserved) {
 			preserved = true
 		}
+		writtenIDs = append(writtenIDs, pr.Session.ID)
 	}
 
-	// Link subagent child sessions to their parents.
-	// Required for Zencoder sessions that reference subagent
-	// session IDs in tool_calls.subagent_session_id.
-	if err := e.db.LinkSubagentSessions(); err != nil {
+	// Link subagent child sessions to their parents (required for agents
+	// that reference subagent session IDs in
+	// tool_calls.subagent_session_id, e.g. Zencoder). Scoped to the
+	// sessions this sync wrote: the session watcher re-syncs a single file
+	// on every change, so a global pass here would make per-event work
+	// scale with the archive's spawn edges instead of the changed batch.
+	if err := e.db.LinkSubagentSessionsForSessions(
+		e.applyIDPrefixToSessionIDs(writtenIDs),
+	); err != nil {
 		log.Printf("link subagent sessions: %v", err)
 	}
 

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -12416,6 +12416,28 @@ func (e *Engine) SyncSingleSessionContext(
 		e.clearSkip(res.skipCacheKey(path))
 	}
 
+	// Capture the children this batch's PRE-write spawn edges reference.
+	// The parser-exclusion delete below and the full message replacement
+	// in the write loop both cascade tool_calls away, and the scoped
+	// linker discovers children only through post-write edges — so a
+	// child whose edge is about to be removed must be carried into the
+	// linking batch explicitly, or it could never re-resolve to a
+	// remaining spawner until the next bulk sync.
+	excluded := e.applyIDPrefixToSessionIDs(res.excludedSessionIDs)
+	resultIDs := make([]string, 0, len(res.results))
+	for _, pr := range res.results {
+		resultIDs = append(resultIDs, pr.Session.ID)
+	}
+	resultIDs = e.applyIDPrefixToSessionIDs(resultIDs)
+	priorChildren, childErr := e.db.SubagentChildSessionIDs(
+		append(append([]string{}, excluded...), resultIDs...),
+	)
+	if childErr != nil {
+		// Degrade to batch-only linking; the next bulk sync's global
+		// pass repairs anything a removed edge left behind.
+		log.Printf("list pre-write subagent children: %v", childErr)
+	}
+
 	// Delete parser-excluded sessions before writing the parsed
 	// results, mirroring collectAndBatch. Vibe promotes a session
 	// from its directory-name fallback ID to the canonical
@@ -12424,9 +12446,7 @@ func (e *Engine) SyncSingleSessionContext(
 	// the DB and double-count messages and usage. Like
 	// collectAndBatch, exclusions from a source with no session
 	// inside the cwd allow-list are frozen so archived rows survive.
-	if excluded := e.applyIDPrefixToSessionIDs(
-		res.excludedSessionIDs,
-	); len(excluded) > 0 && e.sourceAllowsParserExclusions(res) {
+	if len(excluded) > 0 && e.sourceAllowsParserExclusions(res) {
 		if _, err := e.db.DeleteParserExcludedSessions(
 			excluded,
 		); err != nil {
@@ -12460,14 +12480,29 @@ func (e *Engine) SyncSingleSessionContext(
 		if err := e.writeIncremental(res.incremental); err != nil {
 			return err
 		}
+		// An append can introduce a spawn edge (a Task tool_use whose
+		// subagent mapping lands in the same append stays on the
+		// incremental path), so its child must be linked now rather
+		// than waiting for the next bulk sync's global pass.
+		if err := e.db.LinkSubagentSessionsForSessions(append(
+			priorChildren, res.incremental.sessionID,
+		)); err != nil {
+			log.Printf("link subagent sessions: %v", err)
+		}
 		return nil
 	}
 
 	if len(res.results) == 0 {
+		// No writes, but the exclusion delete above may still have
+		// removed spawn edges; re-resolve their former children.
+		if err := e.db.LinkSubagentSessionsForSessions(
+			priorChildren,
+		); err != nil {
+			log.Printf("link subagent sessions: %v", err)
+		}
 		return nil
 	}
 
-	writtenIDs := make([]string, 0, len(res.results))
 	for _, pr := range res.results {
 		if err := e.writeSessionFull(
 			pendingWrite{
@@ -12485,17 +12520,17 @@ func (e *Engine) SyncSingleSessionContext(
 		} else if errors.Is(err, errSessionPreserved) {
 			preserved = true
 		}
-		writtenIDs = append(writtenIDs, pr.Session.ID)
 	}
 
 	// Link subagent child sessions to their parents (required for agents
 	// that reference subagent session IDs in
 	// tool_calls.subagent_session_id, e.g. Zencoder). Scoped to the
-	// sessions this sync wrote: the session watcher re-syncs a single file
-	// on every change, so a global pass here would make per-event work
-	// scale with the archive's spawn edges instead of the changed batch.
+	// sessions this sync wrote plus the children their pre-write edges
+	// referenced: the session watcher re-syncs a single file on every
+	// change, so a global pass here would make per-event work scale with
+	// the archive's spawn edges instead of the changed batch.
 	if err := e.db.LinkSubagentSessionsForSessions(
-		e.applyIDPrefixToSessionIDs(writtenIDs),
+		append(priorChildren, resultIDs...),
 	); err != nil {
 		log.Printf("link subagent sessions: %v", err)
 	}

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -13562,3 +13562,170 @@ func testStringPtrValue(v *string) string {
 	}
 	return *v
 }
+
+// parentSessionIDOf returns the stored parent_session_id of id, failing the
+// test when the session is missing or its parent is unset.
+func parentSessionIDOf(t *testing.T, env *testEnv, id string) string {
+	t.Helper()
+	sess, err := env.db.GetSession(context.Background(), id)
+	require.NoError(t, err, "GetSession %s", id)
+	require.NotNil(t, sess, "session %s must exist", id)
+	require.NotNil(t, sess.ParentSessionID, "%s parent must be set", id)
+	return *sess.ParentSessionID
+}
+
+// TestSyncSingleSessionIncrementalAppendLinksSpawnedChild covers the
+// incremental branch of SyncSingleSessionContext: an append that introduces
+// a Task tool_use together with its subagent mapping stays on the
+// incremental path, and the spawn edge it stores must re-link the child in
+// the same sync rather than leaving the hierarchy stale until the next bulk
+// pass. The scenario is the depth-2 tree the linking fix exists for: the
+// orchestrator (itself a subagent, path-derived parent = main) spawns the
+// grandchild, whose path-derived parent also points at main.
+func TestSyncSingleSessionIncrementalAppendLinksSpawnedChild(t *testing.T) {
+	env := setupTestEnv(t)
+
+	env.writeClaudeSession(
+		t, "proj-inc-link", "main-inc-link.jsonl", testjsonl.JoinJSONL(
+			`{"type":"user","timestamp":"2024-01-01T09:00:00Z","uuid":"m1","message":{"content":"root"},"cwd":"/tmp","sessionId":"main-inc-link"}`,
+		),
+	)
+	orchPath := env.writeSession(
+		t, env.claudeDir,
+		filepath.Join(
+			"proj-inc-link", "main-inc-link", "subagents",
+			"agent-orch.jsonl",
+		),
+		testjsonl.JoinJSONL(
+			`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"o1","message":{"content":"orchestrate"},"cwd":"/tmp","sessionId":"main-inc-link"}`,
+		),
+	)
+	env.writeSession(
+		t, env.claudeDir,
+		filepath.Join(
+			"proj-inc-link", "main-inc-link", "subagents",
+			"agent-kid.jsonl",
+		),
+		testjsonl.JoinJSONL(
+			`{"type":"user","timestamp":"2024-01-01T10:30:00Z","uuid":"k1","message":{"content":"grandchild work"},"cwd":"/tmp","sessionId":"main-inc-link"}`,
+		),
+	)
+
+	env.engine.SyncAll(context.Background(), nil)
+
+	// Path derivation pins every flat subagent to the main session.
+	require.Equal(t, "main-inc-link",
+		parentSessionIDOf(t, env, "agent-kid"),
+		"before the append the grandchild sits under main")
+
+	// The stored orchestrator row id proves the append stayed on the
+	// incremental path: a full replacement would delete and reinsert it.
+	var orchMsgID int64
+	require.NoError(t, env.db.Reader().QueryRow(`
+		SELECT id FROM messages
+		WHERE session_id = ? AND ordinal = 0`,
+		"agent-orch",
+	).Scan(&orchMsgID), "query orchestrator message id before append")
+
+	// One append introduces the Task tool_use AND its subagent mapping,
+	// so the incremental parser can link without a full parse.
+	appended := testjsonl.JoinJSONL(
+		`{"type":"assistant","timestamp":"2024-01-01T10:31:00Z","uuid":"o2","parentUuid":"o1","message":{"id":"msg_orch","content":[{"type":"tool_use","id":"toolu_inc","name":"Agent","input":{"description":"d","subagent_type":"Explore","prompt":"p"}}],"usage":{"input_tokens":1,"output_tokens":1},"stop_reason":"tool_use"}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:32:00Z","uuid":"o3","parentUuid":"o2","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_inc","content":"done"}]},"toolUseResult":{"status":"completed","agentId":"kid"}}`,
+	) + "\n"
+	f, err := os.OpenFile(orchPath, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err, "open orchestrator transcript for append")
+	_, writeErr := f.WriteString(appended)
+	f.Close()
+	require.NoError(t, writeErr, "append spawn edge")
+
+	require.NoError(t, env.engine.SyncSingleSession("agent-orch"),
+		"SyncSingleSession orchestrator")
+
+	var gotMsgID int64
+	require.NoError(t, env.db.Reader().QueryRow(`
+		SELECT id FROM messages
+		WHERE session_id = ? AND ordinal = 0`,
+		"agent-orch",
+	).Scan(&gotMsgID), "query orchestrator message id after append")
+	require.Equal(t, orchMsgID, gotMsgID,
+		"the append must stay on the incremental path for this test to "+
+			"pin the incremental branch (a full replace reinserts rows)")
+
+	assert.Equal(t, "agent-orch", parentSessionIDOf(t, env, "agent-kid"),
+		"an incrementally appended spawn edge must re-link the child in "+
+			"the same single-session sync")
+}
+
+// TestSyncSingleSessionRewriteRemovingEdgeRelinksFormerChild covers the
+// pre-write child capture in SyncSingleSessionContext: a full rewrite that
+// REMOVES a spawn edge cascades the tool_calls row away, so the scoped
+// linker can no longer discover the former child through post-write edges.
+// The child must still be re-resolved — here to the remaining spawner —
+// in the same sync instead of keeping the deleted edge's stale parent.
+func TestSyncSingleSessionRewriteRemovingEdgeRelinksFormerChild(t *testing.T) {
+	env := setupTestEnv(t)
+
+	env.writeClaudeSession(
+		t, "proj-edge-rm", "main-edge-rm.jsonl", testjsonl.JoinJSONL(
+			`{"type":"user","timestamp":"2024-01-01T09:00:00Z","uuid":"m1","message":{"content":"root"},"cwd":"/tmp","sessionId":"main-edge-rm"}`,
+		),
+	)
+	// Both orchestrators claim the grandchild; orcha starts earlier, so
+	// the chronological resolution links the child under orcha.
+	orchaInitial := testjsonl.JoinJSONL(
+		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"a1","message":{"content":"orchestrate a"},"cwd":"/tmp","sessionId":"main-edge-rm"}`,
+		`{"type":"assistant","timestamp":"2024-01-01T10:01:00Z","uuid":"a2","parentUuid":"a1","message":{"id":"msg_a","content":[{"type":"tool_use","id":"toolu_a","name":"Agent","input":{"description":"d","subagent_type":"Explore","prompt":"p"}}],"usage":{"input_tokens":1,"output_tokens":1},"stop_reason":"tool_use"}}`,
+		`{"type":"user","timestamp":"2024-01-01T10:02:00Z","uuid":"a3","parentUuid":"a2","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_a","content":"done"}]},"toolUseResult":{"status":"completed","agentId":"kid"}}`,
+	)
+	orchaPath := env.writeSession(
+		t, env.claudeDir,
+		filepath.Join(
+			"proj-edge-rm", "main-edge-rm", "subagents",
+			"agent-orcha.jsonl",
+		),
+		orchaInitial,
+	)
+	env.writeSession(
+		t, env.claudeDir,
+		filepath.Join(
+			"proj-edge-rm", "main-edge-rm", "subagents",
+			"agent-orchb.jsonl",
+		),
+		testjsonl.JoinJSONL(
+			`{"type":"user","timestamp":"2024-01-01T11:00:00Z","uuid":"b1","message":{"content":"orchestrate b"},"cwd":"/tmp","sessionId":"main-edge-rm"}`,
+			`{"type":"assistant","timestamp":"2024-01-01T11:01:00Z","uuid":"b2","parentUuid":"b1","message":{"id":"msg_b","content":[{"type":"tool_use","id":"toolu_b","name":"Agent","input":{"description":"d","subagent_type":"Explore","prompt":"p"}}],"usage":{"input_tokens":1,"output_tokens":1},"stop_reason":"tool_use"}}`,
+			`{"type":"user","timestamp":"2024-01-01T11:02:00Z","uuid":"b3","parentUuid":"b2","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_b","content":"done"}]},"toolUseResult":{"status":"completed","agentId":"kid"}}`,
+		),
+	)
+	env.writeSession(
+		t, env.claudeDir,
+		filepath.Join(
+			"proj-edge-rm", "main-edge-rm", "subagents",
+			"agent-kid.jsonl",
+		),
+		testjsonl.JoinJSONL(
+			`{"type":"user","timestamp":"2024-01-01T11:30:00Z","uuid":"k1","message":{"content":"grandchild work"},"cwd":"/tmp","sessionId":"main-edge-rm"}`,
+		),
+	)
+
+	env.engine.SyncAll(context.Background(), nil)
+
+	require.Equal(t, "agent-orcha",
+		parentSessionIDOf(t, env, "agent-kid"),
+		"the earliest-started spawner wins while both edges exist")
+
+	// Rewrite orcha WITHOUT its spawn edge (same first message, so its
+	// start time is unchanged; the shrunk file forces a full replace,
+	// which cascades the toolu_a edge away).
+	require.NoError(t, os.WriteFile(orchaPath, []byte(testjsonl.JoinJSONL(
+		`{"type":"user","timestamp":"2024-01-01T10:00:00Z","uuid":"a1","message":{"content":"orchestrate a"},"cwd":"/tmp","sessionId":"main-edge-rm"}`,
+	)+"\n"), 0o644), "rewrite orcha without the spawn edge")
+
+	require.NoError(t, env.engine.SyncSingleSession("agent-orcha"),
+		"SyncSingleSession rewritten orchestrator")
+
+	assert.Equal(t, "agent-orchb", parentSessionIDOf(t, env, "agent-kid"),
+		"removing orcha's edge must re-resolve its former child to the "+
+			"remaining spawner in the same sync, not leave the stale parent")
+}


### PR DESCRIPTION
Fixes #1246.

## Problem

Nested Claude Code subagents (`main -> orchestrator -> grandchild`, spawnDepth >= 2) all
live in the same flat `<main-session>/subagents/` directory, so path derivation assigns
`parent_session_id = main session` at every depth and tags each row
`relationship_type = 'subagent'`. `LinkSubagentSessions()` — which corrects the parent
from the authoritative `tool_calls.subagent_session_id` spawn edge — skipped those rows
because of its `WHERE relationship_type != 'subagent'` guard. The hierarchy stayed flat
past depth 1: `GET /sessions/{orchestrator}/children` was empty and per-session usage
rollups attributed the whole subtree to the main session.

## Change

All in `internal/db/sessions.go`, plus one call-site change in `internal/sync/engine.go`:

- **Re-parent from the spawn edge.** The linking predicate now updates a session when it
  is not yet tagged `subagent` (the pre-existing upgrade path) or when its stored parent
  differs from the spawn edge (null-safe `IS NOT`). The tool-call edge records the actual
  spawn, so it is authoritative over the path heuristic.
- **Deterministic conflict resolution** (`subagentSpawnerExpr`). Copied or forked history
  can leave several sessions claiming the same child. Resolution is a pure function of
  the stored edges — never of ingestion order — so a link written from a partial view
  self-corrects on a later sync: candidates are ordered by start time (a fork derives
  from its source, so it starts later), with `started_at` normalized via `strftime`
  because raw RFC3339Nano strings do not sort chronologically when fractional seconds
  are stripped. Unknown or malformed start times rank last, and the session id breaks
  remaining ties.
- **Cost bounded by edges, not archive.** The global statement is driven from the
  `idx_tool_calls_subagent` partial index (`s.id IN (SELECT tc.subagent_session_id ...)`)
  instead of a full `sessions` scan, so bulk-sync linking cost tracks the number of spawn
  edges rather than archive size.
- **Watcher syncs bounded by the batch.** `SyncSingleSessionContext` — called by the
  session watcher on every file change — now uses `LinkSubagentSessionsForSessions`,
  which restricts the pass to children reachable from the sessions that sync wrote
  (spawner-side and child-side branches, both index seeks). Bulk paths (full sync,
  reconciliation, resync) keep their coalesced global pass. Query-plan tests pin both
  cost shapes at two archive sizes.
- **All single-session branches link.** The incremental append path (which can
  introduce a spawn edge when the Task tool_use and its subagent mapping land in the
  same append) links scoped to the appended session, and children referenced by a
  batch's pre-write edges are captured (`SubagentChildSessionIDs`) before rewrites or
  parser-exclusion deletes cascade those edges away, so a former child still
  re-resolves to its remaining spawner in the same sync.

## Tradeoffs and limitations

- When conflicting edges exist and the real spawner has no usable `started_at`, a dated
  copy wins; protecting it would require reading the child's stored parent, which
  reintroduces ingestion-order dependence. The link self-corrects once the spawner's
  start time becomes known. Documented in `subagentSpawnerExpr`.
- Fork/copy provenance policy (self-edge guards, deeper lineage tracking) is scoped to
  #1250.
- No frontend change: transcript drill-down already follows `tool_calls` at any depth;
  this fix makes `/children` and usage rollups correct.

Reviewers should start at `subagentSpawnerExpr` and the two linking statements in
`internal/db/sessions.go`, then the `SyncSingleSessionContext` call site.

---

Disclosure: investigated and written with Claude Code (AI).
