### PR TITLE
Add artifact publication ledger and export pipeline

### DIFF
--- a/cmd/agentsview/artifact_machine_test.go
+++ b/cmd/agentsview/artifact_machine_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
+)
+
+func TestOpenDBConfiguresArtifactLocalMachineOwnership(t *testing.T) {
+	cfg := config.Config{
+		DBPath:           filepath.Join(t.TempDir(), "sessions.db"),
+		LocalMachineName: "workstation.example",
+	}
+	database, err := openDB(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "hostname-local", Project: "project",
+		Machine: cfg.LocalMachineName, Agent: "claude",
+	}))
+	_, err = database.EnsureArtifactOrigin("desktop-a1b2c3")
+	require.NoError(t, err)
+
+	pending, err := database.PendingArtifactExports(t.Context(), 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	assert.Equal(t, "hostname-local", pending[0].SessionID)
+}

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -1235,6 +1235,14 @@ func openDB(cfg config.Config) (*db.DB, error) {
 	if err != nil {
 		return nil, err
 	}
+	localMachine := cfg.LocalMachineName
+	if strings.TrimSpace(localMachine) == "" {
+		localMachine = "local"
+	}
+	if err := database.ConfigureArtifactLocalMachine(localMachine); err != nil {
+		database.Close()
+		return nil, fmt.Errorf("configuring artifact local machine: %w", err)
+	}
 	applyCustomPricing(database, cfg)
 	return database, nil
 }

--- a/docs/superpowers/plans/2026-07-27-artifact-export-reliability.md
+++ b/docs/superpowers/plans/2026-07-27-artifact-export-reliability.md
@@ -1,0 +1,1403 @@
+# Artifact Export Reliability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make artifact publication origin-safe, memory-bounded before complete
+session materialization, and able to durably reject one deterministic failure
+without starving later queue claims.
+
+**Architecture:** Keep the existing publication ledger and immutable artifact
+formats. Add a database-owned bounded snapshot loader, validate origin inside
+the locked publication transaction, and finalize success/rejection outcomes
+atomically with checkpoint authority. Deterministic validation failures delete
+stale publication authority and become durable generation-scoped diagnostics;
+transient failures remain fail-fast.
+
+**Tech Stack:** Go, `database/sql`, SQLite/FTS5, `testify`, the existing
+filesystem-backed artifact store, and Go's `errors.Is` typed-error contract.
+
+## Global Constraints
+
+- Follow
+  `docs/superpowers/specs/2026-07-27-artifact-export-reliability-design.md`.
+- Preserve the SQLite archive through non-destructive column migrations; never
+  drop, truncate, or recreate it.
+- Keep preflight limits equal to existing artifact policy: 32,768 messages,
+  32,768 usage events, 256 tool calls per message, 65,536 tool calls per
+  session, 1,024 result events per call, 262,144 result events per session,
+  256 MiB raw message/nested bytes, and 16 MiB raw usage bytes.
+- `rejected_generation` is diagnostic only. Correctness always compares the
+  claim against the queue row's current `generation`.
+- A deterministic rejection removes prior publication authority; it never
+  retains a stale manifest as current.
+- Store, context, SQLite, origin-mismatch, and stale-claim failures remain
+  transient/fatal and must not consume claims.
+- Every new test uses real SQLite state or the real artifact boundary, uses
+  `testify`, and must be observed failing before production code is added.
+- After Go changes run `go fmt ./...` and `go vet ./...` before committing.
+- If a future change tightens an export limit, that change must include a
+  migration that requeues existing publications.
+
+______________________________________________________________________
+
+## File Map
+
+- `internal/db/artifact_publication.go`: origin validation, claim outcomes,
+  rejection diagnostics, and atomic finalization.
+- `internal/db/artifact_export_load.go`: bounded snapshot loader and typed
+  preflight limit errors.
+- `internal/db/artifact_export_load_test.go`: cardinality, byte, snapshot, and
+  scaling regressions for the loader.
+- `internal/db/schema.sql`: rejection columns for newly created archives.
+- `internal/db/db.go`: non-destructive rejection-column migrations plus queue
+  trigger/requeue clearing.
+- `internal/db/orphaned.go`: resync copy/requeue behavior for rejection state.
+- `internal/db/artifact_publication_test.go`: origin, outcome, migration,
+  mutation-retry, adoption, and stale-generation tests.
+- `internal/artifact/export.go`: bounded loader use, typed deterministic
+  classification, per-claim isolation, and rejected-result count.
+- `internal/artifact/limits.go`: deterministic export-rejection sentinel and
+  mapping from artifact policy to database load limits.
+- `internal/artifact/export_limits_test.go`: limit classification and bounded
+  loader integration.
+- `internal/artifact/export_test.go`: mixed success/rejection checkpoint flow
+  and transient-failure behavior.
+- `internal/artifact/origin_test.go`: end-to-end rejection removal, mutation
+  retry, and origin-adoption behavior.
+
+______________________________________________________________________
+
+### Task 1: Lock Publication Authority to the Persisted Origin
+
+**Files:**
+
+- Modify: `internal/db/artifact_publication.go:13-25,157-180`
+- Test: `internal/db/artifact_publication_test.go`
+
+**Interfaces:**
+
+- Consumes: `lockArtifactPublicationTx(context.Context, *sql.Tx) error` and the
+  `pg_sync_state` key `artifact_origin_id`.
+
+- Produces: `db.ErrArtifactOriginMismatch`, returned by
+  `ApplyArtifactPublicationChanges` before claim validation or mutation.
+
+- [ ] **Step 1: Write the failing transaction-boundary test**
+
+Add a test that seeds origin A, creates and claims one local session, then calls
+`ApplyArtifactPublicationChanges` with origin B:
+
+```go
+func TestArtifactPublicationChangesRejectMismatchedPersistedOrigin(t *testing.T) {
+	database := testDB(t)
+	ctx := t.Context()
+	require.NoError(t, database.AdoptArtifactOrigin("origin-a1b2c3"))
+	require.NoError(t, database.UpsertSession(Session{
+		ID: "session", Project: "project", Machine: "local", Agent: "claude",
+	}))
+	claims, err := database.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, claims, 1)
+
+	revision, changed, err := database.ApplyArtifactPublicationChanges(
+		ctx, "origin-d4e5f6", []ArtifactPublicationChange{{
+			SessionID: "session", Generation: claims[0].Generation,
+			ManifestHash: "manifest", SourceFingerprint: "fingerprint",
+		}},
+	)
+	require.ErrorIs(t, err, ErrArtifactOriginMismatch)
+	assert.Zero(t, revision)
+	assert.False(t, changed)
+
+	var publications []ArtifactPublication
+	_, streamErr := database.StreamArtifactPublications(
+		ctx, "origin-d4e5f6", func(row ArtifactPublication) error {
+			publications = append(publications, row)
+			return nil
+		},
+	)
+	require.NoError(t, streamErr)
+	assert.Empty(t, publications)
+	pending, pendingErr := database.PendingArtifactExports(ctx, 10)
+	require.NoError(t, pendingErr)
+	require.Equal(t, claims, pending)
+}
+```
+
+Add a missing-origin subtest by deleting the state key after the claim and
+asserting the same typed error and unchanged claim.
+
+- [ ] **Step 2: Run the test and observe the wrong-origin mutation**
+
+Run:
+
+```bash
+CGO_ENABLED=1 go test -tags fts5 ./internal/db \
+  -run '^TestArtifactPublicationChangesRejectMismatchedPersistedOrigin$' \
+  -count=1 -v
+```
+
+Expected: FAIL because the wrong-origin publication is inserted and no
+`ErrArtifactOriginMismatch` exists.
+
+- [ ] **Step 3: Add the typed error and locked validation**
+
+Add near `ErrArtifactExportClaimStale`:
+
+```go
+var ErrArtifactOriginMismatch = errors.New("artifact origin does not match persisted origin")
+```
+
+Add:
+
+```go
+func validateArtifactOriginTx(
+	ctx context.Context, tx *sql.Tx, origin string,
+) error {
+	var persisted string
+	err := tx.QueryRowContext(ctx, `
+		SELECT value FROM pg_sync_state WHERE key = 'artifact_origin_id'`,
+	).Scan(&persisted)
+	if errors.Is(err, sql.ErrNoRows) || err == nil && persisted == "" {
+		return fmt.Errorf("%w: no persisted artifact origin", ErrArtifactOriginMismatch)
+	}
+	if err != nil {
+		return fmt.Errorf("reading persisted artifact origin: %w", err)
+	}
+	if persisted != origin {
+		return fmt.Errorf(
+			"%w: requested %s, persisted %s",
+			ErrArtifactOriginMismatch, origin, persisted,
+		)
+	}
+	return nil
+}
+```
+
+Immediately after `lockArtifactPublicationTx` in
+`ApplyArtifactPublicationChanges`, call:
+
+```go
+if err := validateArtifactOriginTx(ctx, tx, origin); err != nil {
+	return 0, false, err
+}
+```
+
+Do not rely on an unlocked preflight read for correctness.
+
+- [ ] **Step 4: Verify matching and mismatching origins**
+
+Run:
+
+```bash
+CGO_ENABLED=1 go test -tags fts5 ./internal/db \
+  -run 'TestArtifactPublicationChangesRejectMismatchedPersistedOrigin|TestArtifactPublicationAtomicLifecycle' \
+  -count=1 -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 1**
+
+```bash
+git add internal/db/artifact_publication.go internal/db/artifact_publication_test.go
+git commit -m "fix(artifact): bind publication claims to active origin" \
+  -m "The queue is global, so publication authority must verify the configured namespace under the same writer reservation as claim validation. Reject stale exporters before they can advance a dead origin."
+```
+
+______________________________________________________________________
+
+### Task 2: Persist and Atomically Finalize Rejected Generations
+
+**Files:**
+
+- Modify: `internal/db/schema.sql:126-139`
+- Modify: `internal/db/db.go:artifactSessionQueueTriggerCreatesSQL`
+- Modify: `internal/db/db.go:schemaColumnMigrations`
+- Modify: `internal/db/db.go:bootstrapArtifactExportQueueSQL`
+- Modify: `internal/db/db.go:requeueArtifactExportsSQL`
+- Modify: `internal/db/db.go:requeueArtifactOriginExportsSQL`
+- Modify: `internal/db/artifact_publication.go:263-439,607-632`
+- Modify: `internal/db/orphaned.go:380-445`
+- Test: `internal/db/artifact_publication_test.go`
+
+**Interfaces:**
+
+- Produces:
+
+```go
+type ArtifactExportOutcome struct {
+	Item      ArtifactExportQueueItem
+	Rejection string
+}
+
+type ArtifactExportRejection struct {
+	SessionID  string
+	Generation int64
+	Error      string
+	RejectedAt string
+}
+
+func (db *DB) FinalizeArtifactExports(
+	context.Context, []ArtifactExportOutcome,
+) error
+
+func (db *DB) RecordArtifactCheckpointHeadOutcomes(
+	context.Context, ArtifactCheckpointHead, []ArtifactExportOutcome,
+) error
+
+func (db *DB) GetArtifactExportRejection(
+	context.Context, string,
+) (ArtifactExportRejection, bool, error)
+```
+
+- Preserves: `AcknowledgeArtifactExports` and `RecordArtifactCheckpointHead` as
+  successful-outcome wrappers for existing callers.
+
+- [ ] **Step 1: Add failing outcome lifecycle tests**
+
+Add tests using a real database:
+
+```go
+func TestArtifactExportRejectionFinalizesExactGeneration(t *testing.T) {
+	database := testDB(t)
+	ctx := t.Context()
+	require.NoError(t, database.AdoptArtifactOrigin("origin-a1b2c3"))
+	require.NoError(t, database.UpsertSession(Session{
+		ID: "rejected", Project: "project", Machine: "local", Agent: "claude",
+	}))
+	claims, err := database.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, claims, 1)
+
+	require.NoError(t, database.FinalizeArtifactExports(ctx, []ArtifactExportOutcome{{
+		Item: claims[0], Rejection: "session message limit exceeded",
+	}}))
+	pending, err := database.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	assert.Empty(t, pending)
+	rejection, ok, err := database.GetArtifactExportRejection(ctx, "rejected")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, claims[0].Generation, rejection.Generation)
+	assert.Equal(t, "session message limit exceeded", rejection.Error)
+	assert.NotEmpty(t, rejection.RejectedAt)
+
+	require.NoError(t, database.ReplaceSessionMessages("rejected", []Message{{
+		SessionID: "rejected", Ordinal: 0, Role: "user", Content: "changed",
+	}}))
+	pending, err = database.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	assert.Greater(t, pending[0].Generation, claims[0].Generation)
+	_, ok, err = database.GetArtifactExportRejection(ctx, "rejected")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+```
+
+Add:
+
+- `TestArtifactExportRejectionCannotConsumeNewerGeneration`: mutate after taking
+  a claim, then assert `ErrArtifactExportClaimStale` and that the new
+  generation remains pending.
+
+- `TestArtifactCheckpointHeadAndRejectionsCommitAtomically`: record a head with
+  one successful and one rejected outcome and assert head, clean rows, and
+  diagnostics; inject a stale generation and assert none of them change.
+
+- `TestArtifactRequeueLifecycleClearsRejection`: cover divergent origin adoption
+  and resync, asserting new generations are pending and rejection fields are
+  empty.
+
+- Migration coverage opening a database whose queue lacks the three new columns,
+  then asserting all columns exist without losing the queue row.
+
+- [ ] **Step 2: Run the lifecycle tests and observe missing schema/API
+  failures**
+
+Run:
+
+```bash
+CGO_ENABLED=1 go test -tags fts5 ./internal/db \
+  -run 'TestArtifactExportRejection|TestArtifactCheckpointHeadAndRejections|TestArtifactRequeueLifecycle' \
+  -count=1 -v
+```
+
+Expected: build or test FAIL because rejection columns and outcome APIs do not
+exist.
+
+- [ ] **Step 3: Add queue columns and non-destructive migrations**
+
+Change the queue schema to:
+
+```sql
+CREATE TABLE IF NOT EXISTS artifact_export_queue (
+    session_id  TEXT PRIMARY KEY,
+    enqueued_at TEXT NOT NULL
+        DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    generation INTEGER NOT NULL DEFAULT 1,
+    pending INTEGER NOT NULL DEFAULT 1 CHECK (pending IN (0, 1)),
+    rejected_generation INTEGER,
+    last_error TEXT NOT NULL DEFAULT '',
+    rejected_at TEXT
+);
+```
+
+Append these entries to `schemaColumnMigrations()`:
+
+```go
+{
+	"artifact_export_queue", "rejected_generation",
+	"ALTER TABLE artifact_export_queue ADD COLUMN rejected_generation INTEGER",
+},
+{
+	"artifact_export_queue", "last_error",
+	"ALTER TABLE artifact_export_queue ADD COLUMN last_error TEXT NOT NULL DEFAULT ''",
+},
+{
+	"artifact_export_queue", "rejected_at",
+	"ALTER TABLE artifact_export_queue ADD COLUMN rejected_at TEXT",
+},
+```
+
+Every queue conflict that creates a new generation must add:
+
+```sql
+rejected_generation = NULL,
+last_error = '',
+rejected_at = NULL
+```
+
+Apply that reset to all three session triggers, `enqueueArtifactExportTx`,
+`requeueArtifactExportsSQL`, and `requeueArtifactOriginExportsSQL`.
+`bootstrapArtifactExportQueueSQL` remains `INSERT OR IGNORE`: it does not
+advance an existing generation.
+
+Update the resync queue copy to insert the new columns but deliberately clear
+them because it advances every copied generation:
+
+```sql
+INSERT INTO main.artifact_export_queue(
+    session_id, enqueued_at, generation, pending,
+    rejected_generation, last_error, rejected_at
+)
+SELECT session_id, enqueued_at, generation + 1, 1, NULL, '', NULL
+FROM old_db.artifact_export_queue WHERE true
+ON CONFLICT(session_id) DO UPDATE SET
+    enqueued_at = CASE
+        WHEN artifact_export_queue.pending = 1 AND excluded.pending = 1
+            THEN min(artifact_export_queue.enqueued_at, excluded.enqueued_at)
+        WHEN artifact_export_queue.pending = 1
+            THEN artifact_export_queue.enqueued_at
+        ELSE excluded.enqueued_at
+    END,
+    generation = max(artifact_export_queue.generation, excluded.generation) + 1,
+    pending = 1,
+    rejected_generation = NULL,
+    last_error = '',
+    rejected_at = NULL
+```
+
+- [ ] **Step 4: Implement per-claim finalization**
+
+Add the outcome and rejection structs exactly as declared in **Interfaces**.
+Convert old item slices with:
+
+```go
+func successfulArtifactExportOutcomes(
+	items []ArtifactExportQueueItem,
+) []ArtifactExportOutcome {
+	outcomes := make([]ArtifactExportOutcome, len(items))
+	for i, item := range items {
+		outcomes[i] = ArtifactExportOutcome{Item: item}
+	}
+	return outcomes
+}
+```
+
+Replace the clean-row helper with outcome finalization:
+
+```go
+func finalizeArtifactExportOutcomesTx(
+	ctx context.Context, tx *sql.Tx, outcomes []ArtifactExportOutcome,
+) error {
+	items := make([]ArtifactExportQueueItem, len(outcomes))
+	for i, outcome := range outcomes {
+		items[i] = outcome.Item
+	}
+	unique, err := validateArtifactExportClaimsTx(ctx, tx, items)
+	if err != nil {
+		return err
+	}
+	bySession := make(map[string]string, len(outcomes))
+	for _, outcome := range outcomes {
+		if previous, ok := bySession[outcome.Item.SessionID]; ok &&
+			previous != outcome.Rejection {
+			return fmt.Errorf(
+				"conflicting artifact export outcomes for session %s",
+				outcome.Item.SessionID,
+			)
+		}
+		bySession[outcome.Item.SessionID] = outcome.Rejection
+	}
+	for _, item := range unique {
+		rejection := bySession[item.SessionID]
+		var rejectedGeneration any
+		var rejectedAt any
+		if rejection != "" {
+			rejectedGeneration = item.Generation
+			rejectedAt = time.Now().UTC().Format(time.RFC3339Nano)
+		}
+		result, err := tx.ExecContext(ctx, `
+			UPDATE artifact_export_queue SET
+				pending = 0,
+				rejected_generation = ?,
+				last_error = ?,
+				rejected_at = ?
+			WHERE session_id = ? AND generation = ? AND pending = 1`,
+			rejectedGeneration, rejection, rejectedAt,
+			item.SessionID, item.Generation,
+		)
+		if err != nil {
+			return fmt.Errorf("finalizing artifact export %s: %w", item.SessionID, err)
+		}
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("reading artifact export finalization %s: %w", item.SessionID, err)
+		}
+		if rows != 1 {
+			return fmt.Errorf(
+				"%w: session %s generation %d",
+				ErrArtifactExportClaimStale, item.SessionID, item.Generation,
+			)
+		}
+	}
+	return nil
+}
+```
+
+`rejected_generation` is written from the validated claim only and is never used
+to decide staleness.
+
+Implement `FinalizeArtifactExports` with the same lock/transaction structure as
+`AcknowledgeArtifactExports`. Make `AcknowledgeArtifactExports` call it with
+successful outcomes.
+
+Move the current checkpoint body into `RecordArtifactCheckpointHeadOutcomes`,
+call `finalizeArtifactExportOutcomesTx` after the head insert, and retain
+`RecordArtifactCheckpointHead` as a successful-outcome wrapper.
+
+Implement diagnostic lookup:
+
+```go
+func (db *DB) GetArtifactExportRejection(
+	ctx context.Context, sessionID string,
+) (ArtifactExportRejection, bool, error) {
+	var rejection ArtifactExportRejection
+	err := db.getReader().QueryRowContext(ctx, `
+		SELECT session_id, rejected_generation, last_error, rejected_at
+		FROM artifact_export_queue
+		WHERE session_id = ?
+		  AND rejected_generation IS NOT NULL
+		  AND last_error <> ''
+		  AND rejected_at IS NOT NULL`, sessionID,
+	).Scan(
+		&rejection.SessionID, &rejection.Generation,
+		&rejection.Error, &rejection.RejectedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ArtifactExportRejection{}, false, nil
+	}
+	if err != nil {
+		return ArtifactExportRejection{}, false,
+			fmt.Errorf("reading artifact export rejection: %w", err)
+	}
+	return rejection, true, nil
+}
+```
+
+- [ ] **Step 5: Verify schema, lifecycle, and existing acknowledgement
+  behavior**
+
+Run:
+
+```bash
+CGO_ENABLED=1 go test -tags fts5 ./internal/db \
+  -run 'ArtifactExport|ArtifactPublication|ArtifactCheckpoint|ArtifactOrigin' \
+  -count=1 -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 2**
+
+```bash
+git add internal/db/schema.sql internal/db/db.go \
+  internal/db/orphaned.go internal/db/artifact_publication.go \
+  internal/db/artifact_publication_test.go
+git commit -m "feat(artifact): persist rejected export generations" \
+  -m "Deterministic failures need a durable terminal outcome that remains generation-guarded and checkpoint-atomic. Record diagnostics on clean queue rows while making every later enqueue a fresh retry."
+```
+
+______________________________________________________________________
+
+### Task 3: Add a Transactional Bounded Export Loader
+
+**Files:**
+
+- Create: `internal/db/artifact_export_load.go`
+- Create: `internal/db/artifact_export_load_test.go`
+- Modify: `internal/db/usage_events.go:285-335`
+
+**Interfaces:**
+
+- Produces:
+
+```go
+var ErrArtifactExportLimit = errors.New("artifact export load limit exceeded")
+
+type ArtifactExportLoadLimits struct {
+	Messages            int
+	UsageEvents         int
+	MessageToolCalls    int
+	ToolResultEvents    int
+	SessionToolCalls    int
+	SessionResultEvents int
+	MessageBytes        int64
+	UsageBytes          int64
+}
+
+type ArtifactExportData struct {
+	Messages    []Message
+	UsageEvents []UsageEvent
+}
+
+func (db *DB) LoadArtifactExportData(
+	context.Context, string, ArtifactExportLoadLimits,
+) (ArtifactExportData, error)
+```
+
+- Consumes: `selectMessageCols`, `scanMessages`, `attachToolCallsWithQuerier`,
+  and a factored `scanUsageEvents`.
+
+- [ ] **Step 1: Write table-driven failing boundary tests**
+
+Create `internal/db/artifact_export_load_test.go` with:
+
+```go
+func smallArtifactExportLoadLimits() ArtifactExportLoadLimits {
+	return ArtifactExportLoadLimits{
+		Messages: 2, UsageEvents: 2,
+		MessageToolCalls: 2, ToolResultEvents: 2,
+		SessionToolCalls: 3, SessionResultEvents: 3,
+		MessageBytes: 1 << 20, UsageBytes: 1 << 20,
+	}
+}
+```
+
+Add exact-boundary and `limit + 1` subtests for:
+
+- three messages with `Messages: 2`;
+- three usage events with `UsageEvents: 2`;
+- three calls on one message with `MessageToolCalls: 2`;
+- four calls across messages with `SessionToolCalls: 3`;
+- three result events on one call with `ToolResultEvents: 2`;
+- four result events across calls with `SessionResultEvents: 3`.
+
+Every failure must use:
+
+```go
+_, err := database.LoadArtifactExportData(ctx, "session", limits)
+require.ErrorIs(t, err, ErrArtifactExportLimit)
+```
+
+For every collection, remove the last row and assert the exact boundary loads
+successfully with literal expected lengths.
+
+Add raw-byte tests with one message whose only non-empty exported strings are
+role `"user"` and content `"abcd"`:
+
+```go
+limits := smallArtifactExportLoadLimits()
+limits.MessageBytes = 8
+data, err := database.LoadArtifactExportData(ctx, "session", limits)
+require.NoError(t, err)
+require.Len(t, data.Messages, 1)
+
+limits.MessageBytes = 7
+_, err = database.LoadArtifactExportData(ctx, "session", limits)
+require.ErrorIs(t, err, ErrArtifactExportLimit)
+```
+
+Add an analogous usage event with source `"src"` and model `"model"`:
+`UsageBytes: 8` succeeds and `UsageBytes: 7` fails.
+
+- [ ] **Step 2: Add the cardinality-scaling regression**
+
+Use two separate databases containing 3 and 10,000 messages for the claimed
+session, with `Messages: 2`. Measure allocations around only
+`LoadArtifactExportData` after setup:
+
+```go
+smallAllocs := testing.AllocsPerRun(5, func() {
+	_, err := small.LoadArtifactExportData(ctx, "session", limits)
+	require.ErrorIs(t, err, ErrArtifactExportLimit)
+})
+largeAllocs := testing.AllocsPerRun(5, func() {
+	_, err := large.LoadArtifactExportData(ctx, "session", limits)
+	require.ErrorIs(t, err, ErrArtifactExportLimit)
+})
+assert.LessOrEqual(t, largeAllocs, smallAllocs+50,
+	"preflight allocation must remain bounded by limit, not session cardinality")
+```
+
+This catches removal of the SQL `LIMIT limits.Messages + 1` guard without
+inspecting source text.
+
+- [ ] **Step 3: Run tests and observe the missing bounded-loader API**
+
+Run:
+
+```bash
+CGO_ENABLED=1 go test -tags fts5 ./internal/db \
+  -run '^TestLoadArtifactExportData' -count=1 -v
+```
+
+Expected: build FAIL because the API does not exist.
+
+- [ ] **Step 4: Add the limits, data type, and validation**
+
+Create `internal/db/artifact_export_load.go` with the declarations from
+**Interfaces** and:
+
+```go
+func validateArtifactExportLoadLimits(limits ArtifactExportLoadLimits) error {
+	if limits.Messages < 1 || limits.UsageEvents < 1 ||
+		limits.MessageToolCalls < 1 || limits.ToolResultEvents < 1 ||
+		limits.SessionToolCalls < 1 || limits.SessionResultEvents < 1 ||
+		limits.MessageBytes < 1 || limits.UsageBytes < 1 {
+		return errors.New("artifact export load limits must all be positive")
+	}
+	if limits.Messages == math.MaxInt || limits.UsageEvents == math.MaxInt ||
+		limits.SessionToolCalls == math.MaxInt ||
+		limits.SessionResultEvents == math.MaxInt {
+		return errors.New("artifact export load limits must permit a limit-plus-one probe")
+	}
+	return nil
+}
+
+func artifactExportLimitf(format string, args ...any) error {
+	return fmt.Errorf("%w: %s", ErrArtifactExportLimit, fmt.Sprintf(format, args...))
+}
+```
+
+- [ ] **Step 5: Implement bounded preflight queries**
+
+Define exact raw-byte expressions:
+
+```go
+const artifactMessageRawBytesSQL = `
+	length(CAST(role AS BLOB)) +
+	length(CAST(content AS BLOB)) +
+	length(CAST(thinking_text AS BLOB)) +
+	length(CAST(COALESCE(timestamp, '') AS BLOB)) +
+	length(CAST(model AS BLOB)) +
+	length(CAST(token_usage AS BLOB)) +
+	length(CAST(claude_message_id AS BLOB)) +
+	length(CAST(claude_request_id AS BLOB)) +
+	length(CAST(source_type AS BLOB)) +
+	length(CAST(source_subtype AS BLOB)) +
+	length(CAST(source_uuid AS BLOB)) +
+	length(CAST(source_parent_uuid AS BLOB))`
+
+const artifactToolCallRawBytesSQL = `
+	length(CAST(tool_name AS BLOB)) +
+	length(CAST(category AS BLOB)) +
+	length(CAST(COALESCE(tool_use_id, '') AS BLOB)) +
+	length(CAST(COALESCE(input_json, '') AS BLOB)) +
+	length(CAST(COALESCE(skill_name, '') AS BLOB)) +
+	length(CAST(COALESCE(result_content, '') AS BLOB)) +
+	length(CAST(COALESCE(subagent_session_id, '') AS BLOB)) +
+	length(CAST(COALESCE(file_path, '') AS BLOB))`
+
+const artifactResultEventRawBytesSQL = `
+	length(CAST(COALESCE(tool_use_id, '') AS BLOB)) +
+	length(CAST(COALESCE(agent_id, '') AS BLOB)) +
+	length(CAST(COALESCE(subagent_session_id, '') AS BLOB)) +
+	length(CAST(source AS BLOB)) +
+	length(CAST(status AS BLOB)) +
+	length(CAST(content AS BLOB)) +
+	length(CAST(COALESCE(timestamp, '') AS BLOB))`
+
+const artifactUsageRawBytesSQL = `
+	length(CAST(source AS BLOB)) +
+	length(CAST(model AS BLOB)) +
+	length(CAST(cost_status AS BLOB)) +
+	length(CAST(cost_source AS BLOB)) +
+	length(CAST(COALESCE(occurred_at, '') AS BLOB)) +
+	length(CAST(dedup_key AS BLOB))`
+```
+
+Implement `preflightArtifactExportTx` as four streaming queries, each with
+`LIMIT cap + 1` and no `ORDER BY`, so SQLite can stop from the session index
+without sorting an oversized session:
+
+```go
+func preflightArtifactExportTx(
+	ctx context.Context, tx *sql.Tx, sessionID string, limits ArtifactExportLoadLimits,
+) error {
+	messageBytes, err := preflightArtifactMessagesTx(ctx, tx, sessionID, limits)
+	if err != nil {
+		return err
+	}
+	nestedBytes, err := preflightArtifactToolCallsTx(ctx, tx, sessionID, limits)
+	if err != nil {
+		return err
+	}
+	resultBytes, err := preflightArtifactResultEventsTx(ctx, tx, sessionID, limits)
+	if err != nil {
+		return err
+	}
+	if messageBytes+nestedBytes+resultBytes > limits.MessageBytes {
+		return artifactExportLimitf(
+			"session %s raw message bytes exceed %d", sessionID, limits.MessageBytes,
+		)
+	}
+	return preflightArtifactUsageTx(ctx, tx, sessionID, limits)
+}
+```
+
+The four helpers must use these query shapes:
+
+```sql
+SELECT id, ordinal, <artifactMessageRawBytesSQL>
+FROM messages WHERE session_id = ? LIMIT ?
+```
+
+```sql
+SELECT message_id, <artifactToolCallRawBytesSQL>
+FROM tool_calls WHERE session_id = ? LIMIT ?
+```
+
+```sql
+SELECT tool_call_message_ordinal, call_index,
+       <artifactResultEventRawBytesSQL>
+FROM tool_result_events WHERE session_id = ? LIMIT ?
+```
+
+```sql
+SELECT <artifactUsageRawBytesSQL>
+FROM usage_events WHERE session_id = ? LIMIT ?
+```
+
+For each helper:
+
+- iterate rows without appending objects;
+
+- reject when the row count reaches the applicable global `limit + 1`;
+
+- maintain bounded `map[int64]int` or `map[[2]int]int` parent counts for the
+  per-message/per-call limits;
+
+- add raw bytes using overflow-safe comparison
+  `current > limit || additional > limit-current`;
+
+- return errors wrapping `ErrArtifactExportLimit`;
+
+- propagate query, scan, close, and context errors without wrapping the limit
+  sentinel.
+
+- [ ] **Step 6: Materialize from the same read snapshot**
+
+Factor the body of `GetUsageEvents` into:
+
+```go
+func usageEventsWithQuerier(
+	ctx context.Context, q messageRowsQuerier, sessionID string, limit int,
+) ([]UsageEvent, error)
+```
+
+When `limit > 0`, append `LIMIT ?` to the existing stable-order query and bind
+that value. When `limit == 0`, run the current query without a limit.
+`GetUsageEvents` passes `0`, preserving its public behavior, while the artifact
+loader passes `limits.UsageEvents + 1`. The helper only scans; the caller that
+requested a cap compares the returned length with its policy limit.
+
+Implement the loader:
+
+```go
+func (db *DB) LoadArtifactExportData(
+	ctx context.Context, sessionID string, limits ArtifactExportLoadLimits,
+) (_ ArtifactExportData, retErr error) {
+	if sessionID == "" {
+		return ArtifactExportData{}, errors.New("artifact export session id is required")
+	}
+	if err := validateArtifactExportLoadLimits(limits); err != nil {
+		return ArtifactExportData{}, err
+	}
+	db.connMu.RLock()
+	reader := db.reader.Load()
+	if reader == nil {
+		db.connMu.RUnlock()
+		return ArtifactExportData{}, errors.New("database is closed")
+	}
+	tx, err := reader.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	db.connMu.RUnlock()
+	if err != nil {
+		return ArtifactExportData{}, fmt.Errorf("beginning artifact export snapshot: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			retErr = errors.Join(retErr, tx.Rollback())
+		}
+	}()
+
+	if err := preflightArtifactExportTx(ctx, tx, sessionID, limits); err != nil {
+		return ArtifactExportData{}, err
+	}
+	rows, err := tx.QueryContext(ctx, fmt.Sprintf(`
+		SELECT %s FROM messages
+		WHERE session_id = ?
+		ORDER BY ordinal ASC
+		LIMIT ?`, selectMessageCols), sessionID, limits.Messages+1)
+	if err != nil {
+		return ArtifactExportData{}, fmt.Errorf("loading artifact export messages: %w", err)
+	}
+	messages, scanErr := scanMessages(rows)
+	closeErr := rows.Close()
+	if scanErr != nil || closeErr != nil {
+		return ArtifactExportData{}, errors.Join(scanErr, closeErr)
+	}
+	if len(messages) > limits.Messages {
+		return ArtifactExportData{}, artifactExportLimitf(
+			"session %s message count exceeds %d", sessionID, limits.Messages,
+		)
+	}
+	if err := attachToolCallsWithQuerier(ctx, tx, messages); err != nil {
+		return ArtifactExportData{}, err
+	}
+	usage, err := usageEventsWithQuerier(
+		ctx, tx, sessionID, limits.UsageEvents+1,
+	)
+	if err != nil {
+		return ArtifactExportData{}, err
+	}
+	if len(usage) > limits.UsageEvents {
+		return ArtifactExportData{}, artifactExportLimitf(
+			"session %s usage count exceeds %d", sessionID, limits.UsageEvents,
+		)
+	}
+	if err := tx.Commit(); err != nil {
+		return ArtifactExportData{}, fmt.Errorf("committing artifact export snapshot: %w", err)
+	}
+	committed = true
+	return ArtifactExportData{Messages: messages, UsageEvents: usage}, nil
+}
+```
+
+- [ ] **Step 7: Verify boundaries and existing readers**
+
+Run:
+
+```bash
+CGO_ENABLED=1 go test -tags fts5 ./internal/db \
+  -run 'TestLoadArtifactExportData|TestGetUsageEvents|TestGetAllMessages' \
+  -count=1 -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit Task 3**
+
+```bash
+git add internal/db/artifact_export_load.go \
+  internal/db/artifact_export_load_test.go internal/db/usage_events.go
+git commit -m "feat(artifact): bound export snapshot loading" \
+  -m "Wire limits must also cap construction memory. Preflight each claimed session through bounded SQLite queries and only materialize data proven to fit within the existing artifact policy."
+```
+
+______________________________________________________________________
+
+### Task 4: Route Export Through the Bounded Loader and Type Deterministic Limits
+
+**Files:**
+
+- Modify: `internal/artifact/limits.go`
+- Modify: `internal/artifact/export.go:14-32,104-148,333-370,458-635`
+- Modify: `internal/artifact/export_limits_test.go`
+
+**Interfaces:**
+
+- Consumes: `db.LoadArtifactExportData` and `db.ErrArtifactExportLimit`.
+- Produces:
+
+```go
+var ErrArtifactExportRejected = errors.New("artifact export rejected")
+
+func artifactExportLoadLimits(artifactLimits) db.ArtifactExportLoadLimits
+
+func isDeterministicArtifactExportError(error) bool
+
+func exportToStoreWithLimits(
+	context.Context, artifactExportStore, ArtifactStore, ExportOptions,
+	artifactLimits,
+) (ExportResult, error)
+
+func exportClaimedSessionToStore(
+	context.Context, artifactExportStore, ArtifactStore, string, *db.Session,
+	artifactLimits,
+) (string, bool, error)
+```
+
+- [ ] **Step 1: Write failing bounded-loader integration tests**
+
+Add a wrapper that counts legacy reads while embedding the real DB:
+
+```go
+type boundedLoadExportStore struct {
+	*db.DB
+	allMessageLoads int
+	usageLoads      int
+}
+
+func (s *boundedLoadExportStore) GetAllMessages(
+	ctx context.Context, sessionID string,
+) ([]db.Message, error) {
+	s.allMessageLoads++
+	return s.DB.GetAllMessages(ctx, sessionID)
+}
+
+func (s *boundedLoadExportStore) GetUsageEvents(
+	ctx context.Context, sessionID string,
+) ([]db.UsageEvent, error) {
+	s.usageLoads++
+	return s.DB.GetUsageEvents(ctx, sessionID)
+}
+```
+
+Export a normal session and assert:
+
+```go
+assert.Zero(t, wrapped.allMessageLoads)
+assert.Zero(t, wrapped.usageLoads)
+```
+
+Add a small-limit direct test through `exportClaimedSessionToStore` using the
+signature in **Interfaces**. Seed `limits.sessionMessages + 1` messages and
+assert the error satisfies both `ErrArtifactExportRejected` and
+`db.ErrArtifactExportLimit`, with no manifest or segment created.
+
+- [ ] **Step 2: Run tests and observe legacy loading and untyped errors**
+
+Run:
+
+```bash
+CGO_ENABLED=1 go test -tags fts5 ./internal/artifact \
+  -run 'TestExportUsesBoundedSnapshotLoader|TestExportClassifiesBoundedLoadLimit' \
+  -count=1 -v
+```
+
+Expected: FAIL because `ExportToStore` calls `GetAllMessages` and
+`GetUsageEvents`, and limit errors are not typed as deterministic rejection.
+
+- [ ] **Step 3: Map artifact policy to database limits**
+
+Add:
+
+```go
+var ErrArtifactExportRejected = errors.New("artifact export rejected")
+
+func artifactExportLoadLimits(limits artifactLimits) db.ArtifactExportLoadLimits {
+	return db.ArtifactExportLoadLimits{
+		Messages: limits.sessionMessages,
+		UsageEvents: limits.manifestUsageEvents,
+		MessageToolCalls: limits.messageToolCalls,
+		ToolResultEvents: limits.toolResultEvents,
+		SessionToolCalls: limits.sessionToolCalls,
+		SessionResultEvents: limits.sessionResultEvents,
+		MessageBytes: limits.sessionDecodedBytes,
+		UsageBytes: manifestDecodedLimit,
+	}
+}
+
+func rejectArtifactExportf(format string, args ...any) error {
+	return fmt.Errorf(
+		"%w: %s", ErrArtifactExportRejected, fmt.Sprintf(format, args...),
+	)
+}
+
+func classifyArtifactExportLoadError(err error) error {
+	if errors.Is(err, db.ErrArtifactExportLimit) {
+		return fmt.Errorf("%w: %w", ErrArtifactExportRejected, err)
+	}
+	return err
+}
+
+func isDeterministicArtifactExportError(err error) bool {
+	return errors.Is(err, ErrArtifactExportRejected) ||
+		errors.Is(err, db.ErrArtifactExportLimit)
+}
+```
+
+Wrap existing deterministic validation failures in `exportLoadedSessionToStore`,
+`validateExportNestedCollections`, `exportMessageSegmentsToStore`, and generated
+manifest/session/segment size checks with `ErrArtifactExportRejected`. Do not
+wrap `store.Create`, spool I/O, context, database, or corruption errors.
+
+- [ ] **Step 4: Replace unbounded reads in claimed and full-recovery paths**
+
+Change `artifactExportStore` to consume:
+
+```go
+LoadArtifactExportData(
+	context.Context, string, db.ArtifactExportLoadLimits,
+) (db.ArtifactExportData, error)
+```
+
+Remove `GetAllMessages` and `GetUsageEvents` from the interface after all call
+sites switch.
+
+For a live local session:
+
+```go
+data, err := database.LoadArtifactExportData(
+	ctx, sessionID, artifactExportLoadLimits(limits),
+)
+if err != nil {
+	return "", false, fmt.Errorf(
+		"loading bounded artifact export data %s: %w",
+		sessionID, classifyArtifactExportLoadError(err),
+	)
+}
+return exportLoadedSessionToStore(
+	ctx, store, origin, sess, data.Messages, data.UsageEvents, limits,
+)
+```
+
+Make `ExportToStore` a production-policy wrapper:
+
+```go
+return exportToStoreWithLimits(
+	ctx, database, store, opts, productionArtifactLimits(),
+)
+```
+
+Move its current body to `exportToStoreWithLimits`. Add
+`exportFullToStoreWithDrainRoundsAndLimits(ctx, database, store, origin, drainRounds, limits)`
+and have both existing full-export wrappers pass production limits. Every
+recursive queue page inside full export must call `exportToStoreWithLimits` with
+the same `limits`, so small-limit tests exercise the complete path.
+
+Use `exportClaimedSessionToStore` in the normal claimed loop and in full
+dependency recovery. Keep full recovery fail-fast because it has no claim to
+finalize.
+
+- [ ] **Step 5: Verify bounded loading and deterministic classification**
+
+Run:
+
+```bash
+CGO_ENABLED=1 go test -tags fts5 ./internal/artifact ./internal/db \
+  -run 'ArtifactExport|ExportRejects|ExportUsesBounded|LoadArtifactExport' \
+  -count=1 -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 4**
+
+```bash
+git add internal/artifact/limits.go internal/artifact/export.go \
+  internal/artifact/export_limits_test.go
+git commit -m "fix(artifact): enforce limits before export materialization" \
+  -m "Artifact wire guards were too late to protect construction memory. Route every session export through the bounded SQLite snapshot and classify only deterministic policy failures as rejectable."
+```
+
+______________________________________________________________________
+
+### Task 5: Isolate Deterministic Failures Within a Publication Batch
+
+**Files:**
+
+- Modify: `internal/artifact/export.go:33-44,95-280,405-425`
+- Modify: `internal/artifact/export_test.go`
+- Modify: `internal/artifact/export_limits_test.go`
+- Modify: test wrappers overriding `AcknowledgeArtifactExports` or
+  `RecordArtifactCheckpointHead`
+
+**Interfaces:**
+
+- Extends:
+
+```go
+type ExportResult struct {
+	ExportedSessions   int
+	RejectedSessions   int
+	CheckpointCreated  bool
+	CheckpointSequence int
+}
+```
+
+- `artifactExportStore` consumes:
+
+```go
+FinalizeArtifactExports(context.Context, []db.ArtifactExportOutcome) error
+RecordArtifactCheckpointHeadOutcomes(
+	context.Context, db.ArtifactCheckpointHead, []db.ArtifactExportOutcome,
+) error
+```
+
+- [ ] **Step 1: Write the mixed FIFO regression**
+
+Seed an already-published session `rejected` and a later valid session `valid`.
+Mutate `rejected` to exceed a small test limit, ensure its `enqueued_at` sorts
+first, then export both through `exportToStoreWithLimits`.
+
+Assert observable authority:
+
+```go
+require.NoError(t, err)
+assert.Equal(t, 1, result.ExportedSessions)
+assert.Equal(t, 1, result.RejectedSessions)
+checkpoint := latestStoreCheckpointForTest(t, store, origin)
+assert.NotContains(t, checkpoint.Sessions, origin+"~rejected")
+assert.Contains(t, checkpoint.Sessions, origin+"~valid")
+pending, err := database.PendingArtifactExports(t.Context(), 10)
+require.NoError(t, err)
+assert.Empty(t, pending)
+rejection, ok, err := database.GetArtifactExportRejection(
+	t.Context(), "rejected",
+)
+require.NoError(t, err)
+require.True(t, ok)
+assert.Contains(t, rejection.Error, "message limit")
+```
+
+This test must fail against the current early-return loop with the valid session
+absent and both claims pending.
+
+- [ ] **Step 2: Add transient and crash-boundary regressions**
+
+Add separate tests:
+
+- a store that fails `Create` for `rejected` returns the injected error, records
+  no rejection, and leaves both claims pending;
+- a store that fails checkpoint creation after one deterministic rejection
+  leaves both claims pending and retains prior checkpoint authority;
+- a mutation between collection and checkpoint finalization returns
+  `db.ErrArtifactExportClaimStale`, leaves the newer generation pending, and
+  records no stale rejection.
+
+Use different store doubles for each branch and assert exact call arguments and
+counts.
+
+- [ ] **Step 3: Run the new tests and observe FIFO starvation**
+
+Run:
+
+```bash
+CGO_ENABLED=1 go test -tags fts5 ./internal/artifact \
+  -run 'TestExportContinuesPastDeterministicRejection|TestExportTransientFailureDoesNotReject|TestExportRejectionWaitsForCheckpoint|TestExportStaleRejectionCannotConsumeMutation' \
+  -count=1 -v
+```
+
+Expected: FAIL because the first deterministic error aborts the batch.
+
+- [ ] **Step 4: Collect per-claim outcomes**
+
+Refactor the session loop to use:
+
+```go
+changes := make([]db.ArtifactPublicationChange, 0, len(claims))
+outcomes := make([]db.ArtifactExportOutcome, 0, len(claims))
+```
+
+For missing/deleted/foreign claimed sessions, append a delete change and a
+successful outcome.
+
+For live sessions:
+
+```go
+manifestHash, created, err := exportClaimedSessionToStore(
+	ctx, database, store, opts.Origin, sess, limits,
+)
+if err != nil {
+	if !claimed || !isDeterministicArtifactExportError(err) {
+		return result, err
+	}
+	changes = append(changes, db.ArtifactPublicationChange{
+		SessionID: sessionID, Generation: claim.Generation, Delete: true,
+	})
+	outcomes = append(outcomes, db.ArtifactExportOutcome{
+		Item: claim, Rejection: err.Error(),
+	})
+	result.RejectedSessions++
+	continue
+}
+if created && claimed {
+	result.ExportedSessions++
+}
+if claimed {
+	changes = append(changes, db.ArtifactPublicationChange{
+		SessionID: sessionID, Generation: claim.Generation,
+		ManifestHash: manifestHash, SourceFingerprint: manifestHash,
+	})
+	outcomes = append(outcomes, db.ArtifactExportOutcome{Item: claim})
+}
+```
+
+Do not classify a deterministic failure from the unclaimed full-recovery pass as
+a rejection.
+
+- [ ] **Step 5: Finalize outcomes only behind checkpoint authority**
+
+In the verified-unchanged-head fast path, replace acknowledgement with:
+
+```go
+if err := database.FinalizeArtifactExports(ctx, outcomes); err != nil {
+	return result, err
+}
+```
+
+In both checkpoint record paths, call:
+
+```go
+database.RecordArtifactCheckpointHeadOutcomes(ctx, head, outcomes)
+```
+
+Update every test wrapper that requeues after finalization to override the new
+methods and delegate to the embedded `*db.DB`, preserving the existing
+concurrent-write tests.
+
+Update `mergeArtifactExportResult`:
+
+```go
+total.ExportedSessions += page.ExportedSessions
+total.RejectedSessions += page.RejectedSessions
+```
+
+- [ ] **Step 6: Verify mixed success, transient failure, and full drains**
+
+Run:
+
+```bash
+CGO_ENABLED=1 go test -tags fts5 ./internal/artifact \
+  -run 'ExportContinuesPast|ExportTransient|ExportRejection|ExportStale|ExportFullDrain' \
+  -count=1 -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 5**
+
+```bash
+git add internal/artifact/export.go internal/artifact/export_test.go \
+  internal/artifact/export_limits_test.go
+git commit -m "fix(artifact): isolate deterministic claim failures" \
+  -m "One permanently invalid FIFO entry must not block unrelated publication work. Delete stale authority, checkpoint successful claims, and finalize generation-scoped rejection diagnostics together."
+```
+
+______________________________________________________________________
+
+### Task 6: Complete Lifecycle Coverage and Repository Verification
+
+**Files:**
+
+- Modify: `internal/db/artifact_publication_test.go`
+- Modify: `internal/artifact/origin_test.go`
+
+**Interfaces:**
+
+- Consumes all interfaces from Tasks 1–5.
+
+- Produces no new production API.
+
+- [ ] **Step 1: Add the end-to-end lifecycle regression**
+
+Add one real-store test in `internal/artifact/origin_test.go` that covers:
+
+1. publish a session under origin A;
+1. force a deterministic rejection and verify the next A checkpoint removes it;
+1. mutate the session and verify rejection state clears and a later A checkpoint
+   republishes it;
+1. adopt origin B and verify all requeued rows have no stale rejection fields.
+
+Expected checkpoint maps must use literal session GIDs and explicit
+`Contains`/`NotContains` assertions.
+
+- [ ] **Step 2: Run the lifecycle regression**
+
+Run:
+
+```bash
+CGO_ENABLED=1 go test -tags fts5 ./internal/artifact ./internal/db \
+  -run 'Artifact.*Rejection|Origin.*Rejection|LoadArtifactExport|ExportContinuesPast' \
+  -count=1 -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Format and run complete affected-package tests**
+
+```bash
+go fmt ./...
+git diff --check
+CGO_ENABLED=1 go test -tags fts5 ./internal/db ./internal/artifact -count=1
+```
+
+Expected: PASS with no formatting errors.
+
+- [ ] **Step 4: Run repository verification**
+
+Run:
+
+```bash
+make test-short
+go vet ./...
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 5: Inspect the final diff and private-data hygiene**
+
+```bash
+git status --short
+git diff --stat
+git diff HEAD
+git diff --check
+git log --format='%s%n%b%n---' -10
+```
+
+Confirm the diff contains no private hostnames, identities, absolute paths,
+credentials, generated attribution blocks, or unrelated changes.
+
+- [ ] **Step 6: Commit lifecycle tests**
+
+```bash
+git add internal/db/artifact_publication_test.go \
+  internal/artifact/origin_test.go
+git commit -m "test(artifact): cover rejected claim lifecycle" \
+  -m "Rejection correctness spans checkpoint removal, generation-driven retry, resync, and origin adoption. Protect the complete lifecycle with real database and artifact-store authority checks."
+```
+
+- [ ] **Step 7: Request focused code review**
+
+Dispatch a read-only reviewer against the implementation range. Require review
+of origin locking, snapshot lifetime, bounded query shapes, error
+classification, checkpoint ordering, resync migration, and tests. Resolve every
+Critical or Important issue before publishing.
+
+- [ ] **Step 8: Push the completed branch**
+
+After confirming a clean working tree and matching local tests:
+
+```bash
+git push origin artifact/2-export-ledger
+```
+
+Do not poll CI unless explicitly requested.

--- a/docs/superpowers/specs/2026-07-27-artifact-export-reliability-design.md
+++ b/docs/superpowers/specs/2026-07-27-artifact-export-reliability-design.md
@@ -1,0 +1,292 @@
+# Artifact Export Reliability Design
+
+## Status
+
+Approved design for follow-up reliability work on the artifact publication
+ledger.
+
+## Problem
+
+Artifact export currently has three related consistency gaps:
+
+1. Publication changes accept any syntactically valid origin. A stale exporter
+   can consume the global queue under a namespace that no longer matches the
+   database's persisted `artifact_origin_id`.
+1. Export reads all messages, tool calls, result events, and usage events before
+   enforcing cardinality and decoded-size limits. The limits protect the wire
+   format but do not bound memory used while constructing the source object
+   graph.
+1. One deterministically unexportable FIFO claim aborts its whole batch. The
+   claim remains oldest and is retried forever, so unrelated later claims do
+   not make progress.
+
+These are one design problem: a claimed generation needs a bounded read,
+origin-consistent publication decision, and a durable terminal outcome.
+
+## Goals
+
+- Prevent a claim from changing publication authority under any origin other
+  than the database's persisted artifact origin.
+- Bound export-side object construction before loading a complete session.
+- Let successful claims publish even when another claim in the same batch is
+  deterministically unexportable.
+- Remove a rejected session's stale publication from the next checkpoint.
+- Record the rejected generation and reason durably.
+- Retry a rejected session automatically when a later session mutation advances
+  its queue generation.
+- Preserve generation guards across origin adoption, resync, concurrent writes,
+  checkpoint creation, and acknowledgement.
+
+## Non-goals
+
+- Retrying transient database, context, or artifact-store failures within one
+  export call.
+- Adding an operator-facing rejection UI or CLI command in this change.
+- Replacing the current immutable segment and manifest formats.
+- Rewriting the exporter as a fully streaming wire encoder.
+
+## Chosen Approach
+
+Use a transactional bounded loader followed by capped materialization, and add
+durable rejection state to the existing export queue.
+
+This is deliberately smaller than a fully streaming exporter. The database first
+examines a session through bounded pages inside one read snapshot, stopping as
+soon as a cardinality or raw-byte budget is exceeded. Only a session proven to
+fit those budgets is materialized through the existing message and usage models.
+Existing canonical wire-size checks remain the final, exact format guard.
+
+Deterministic failures become per-claim rejected outcomes. Other claims in the
+same bounded batch continue. Successful and rejected publication changes are
+checkpointed together, after which their exact generations are finalized
+atomically.
+
+## Consistency Invariants
+
+1. A publication mutation is valid only when its origin equals the non-empty
+   persisted `artifact_origin_id`.
+1. Origin validation, claim-generation validation, and publication mutation
+   occur under the same SQLite writer reservation.
+1. No claim becomes clean until its resulting publication map has a durable
+   checkpoint, or an unchanged recorded checkpoint has been verified.
+1. A deterministic rejection deletes any publication for that session under the
+   active origin.
+1. Rejection state belongs to one queue generation. A later generation is new
+   work and must be eligible for export.
+1. Transient failures do not acknowledge, reject, or otherwise consume claims.
+1. A stale claim cannot finalize either success or rejection after a concurrent
+   mutation or origin adoption advances its generation.
+
+## Origin Validation
+
+`ApplyArtifactPublicationChanges` will read `artifact_origin_id` after acquiring
+the existing artifact-publication writer reservation and before validating or
+mutating claims.
+
+- Missing or empty persisted origin: return an origin-mismatch error.
+- Persisted origin differs from the requested origin: return an origin-mismatch
+  error.
+- Matching origin: continue with claim validation and publication changes.
+
+The check remains inside the same transaction as the authoritative mutation. An
+optional earlier read may avoid creating immutable dependencies for an obviously
+stale exporter, but it is only an optimization; the locked check is the
+correctness boundary. Immutable objects created before a failed locked check are
+harmless unreferenced content and never become checkpoint authority.
+
+## Bounded Session Loading
+
+### API boundary
+
+The database will expose an artifact-specific snapshot loader accepting a
+database-owned limits struct. Keeping the struct in `internal/db` avoids an
+import cycle while making every bound explicit:
+
+- 32,768 messages per session;
+- 32,768 usage events per manifest;
+- 256 tool calls per message and 65,536 per session;
+- 1,024 result events per tool call and 262,144 per session;
+- 256 MiB of raw export-visible message and nested-collection bytes before
+  materialization;
+- 16 MiB of raw export-visible usage-event bytes before materialization.
+
+These values match the existing artifact cardinality, session decoded-size, and
+manifest decoded-size limits. The artifact package maps them to the
+database-owned structure rather than defining a second policy. Test-only small
+limits exercise every boundary.
+
+### Read algorithm
+
+The loader owns one read-only SQLite transaction so preflight and
+materialization observe the same snapshot.
+
+1. Read messages in bounded ordinal pages. Count rows and the byte lengths of
+   export-visible scalar and JSON columns without retaining complete message
+   objects.
+1. Read tool calls and result events in bounded pages, enforcing per-parent and
+   per-session cardinality while accumulating export-visible raw bytes.
+1. Read usage events in bounded pages, enforcing count and raw-byte budgets.
+1. Stop immediately when any count or byte budget is exceeded and return a typed
+   deterministic limit error.
+1. If preflight succeeds, materialize messages with nested collections and usage
+   events from the same snapshot. Every materializing query retains a
+   `limit + 1` defense so an implementation regression cannot silently bypass
+   preflight.
+1. Commit or roll back the read transaction before artifact-store I/O.
+
+Paging keeps preflight memory bounded by a small page, not by session size. The
+raw-byte budgets bound the object graph that may be materialized. Existing
+canonical segment, session decoded-byte, manifest decoded-byte, and nested
+collection checks remain authoritative for exact wire encoding, including JSON
+escaping overhead.
+
+The loader scans only rows belonging to the claimed session and stops at the
+first exceeded limit. Work therefore scales with the configured cap, not with
+the total archive or an arbitrarily oversized session.
+
+## Failure Classification
+
+Only failures that are deterministic for the claimed generation are rejectable:
+
+- bounded-loader cardinality or raw-byte limit violations;
+- existing artifact nested-collection limits;
+- exact generated session, segment-reference, or manifest decoded-size limits;
+- other explicitly typed validation failures that cannot succeed without a
+  session mutation or a future format-limit change.
+
+Context cancellation, SQLite errors, stale claims, origin mismatch, temporary
+filesystem failures, and artifact-store errors remain fatal for the export call.
+They leave every unfinalized claim pending.
+
+Deterministic errors use a typed sentinel so the batch loop never classifies an
+error by matching text.
+
+## Durable Rejection State
+
+Add non-destructive columns to `artifact_export_queue`:
+
+- `rejected_generation INTEGER`;
+- `last_error TEXT NOT NULL DEFAULT ''`;
+- `rejected_at TEXT`.
+
+Schema initialization and column migrations add the fields without rebuilding or
+deleting the persistent archive. Resync preserves the columns as part of the
+ledger schema, but clears their values when it advances copied generations for
+mandatory re-export.
+
+Every enqueue path advances `generation`, sets `pending = 1`, and clears stale
+rejection fields. Thus a content mutation automatically retries a previously
+rejected session. Existing FIFO timestamp behavior remains unchanged.
+
+Checkpoint finalization accepts per-claim outcomes rather than only a list of
+successful acknowledgements:
+
+- success: mark the exact generation clean and clear rejection fields;
+- rejection: mark the exact generation clean and store its generation, stable
+  error text, and timestamp.
+
+Finalization validates every generation before updating any row. Recording a new
+checkpoint head and finalizing all outcomes remain one transaction. The
+verified-unchanged-head path uses the same outcome finalizer without rewriting
+the head.
+
+## Batch Export Flow
+
+For each selected claim:
+
+1. Load the session metadata.
+1. Treat missing, deleted, or foreign sessions as publication deletions.
+1. Bounded-load export data for a live local session.
+1. On success, create immutable dependencies and collect an upsert change.
+1. On a deterministic failure, collect a deletion change and rejected outcome,
+   then continue to the next claim.
+1. On a transient failure, abort and leave all unfinalized claims pending.
+
+After the loop, apply all successful upserts and deletion changes together.
+Build the checkpoint from the resulting publication ledger, then finalize
+successful, deleted, and rejected outcomes atomically with the checkpoint head.
+
+`ExportResult` gains a rejected-session count. Rejections are not returned as a
+fatal error because that would stop full-export pagination after a batch that
+was durably handled. Durable queue state retains the detailed reasons.
+
+If a rejected session had a prior publication, its deletion advances the
+publication revision and the new checkpoint omits it. If it had no publication,
+the verified-unchanged-head path can finalize the rejection without creating a
+redundant checkpoint.
+
+The full-export dependency-recovery pass remains fail-fast for sessions that
+have no claim because it cannot safely consume unclaimed authority. Dirty
+claimed sessions, including deterministic rejections, are handled by the bounded
+queue-drain phases before and after recovery.
+
+## Resync and Origin Adoption
+
+Resync copies queue generation authority with the rest of the artifact ledger,
+then advances every copied generation and forces it pending as it does today.
+That new generation clears the prior rejection state. Rebuilt-only sessions are
+still enqueued after origin restore; their fresh generation likewise has no
+rejection state.
+
+Origin adoption continues to requeue live sessions and target-origin publication
+IDs. Requeueing clears rejection state because every adopted claim must be
+evaluated under the newly active namespace.
+
+## Testing
+
+Tests use real SQLite databases and artifact stores where observable behavior
+matters.
+
+### Origin tests
+
+- Applying changes under an origin different from persisted `artifact_origin_id`
+  returns the typed mismatch error.
+- No publication, revision, queue acknowledgement, or checkpoint-head state
+  changes.
+- Matching-origin behavior remains unchanged.
+
+### Bounded loading tests
+
+- Message, usage-event, tool-call, result-event, and raw-byte limits fail at
+  `limit + 1`.
+- Exact boundaries succeed.
+- A large fixture proves preflight stops after bounded rows rather than loading
+  the entire session graph.
+- Existing segment and manifest exact-size tests remain green.
+
+### Rejection and progress tests
+
+- An oversized oldest claim is removed from publication authority, recorded as
+  rejected, and marked clean only after checkpoint finalization.
+- A valid later claim in the same batch publishes and is acknowledged.
+- A transient store failure does not reject or acknowledge either claim.
+- Mutating a rejected session advances its generation, clears stale rejection
+  state, and makes it pending again.
+- A stale rejection outcome cannot consume a newer generation.
+- A crash/error before checkpoint finalization leaves the rejected claim
+  pending.
+
+### Lifecycle tests
+
+- Resync advances copied and rebuilt generations, clears prior rejection state,
+  and leaves every affected row pending.
+- Divergent origin adoption clears rejection state and requeues the relevant
+  claims.
+
+## Trade-offs
+
+- Preflight adds a second read pass for sessions that fit. Both passes are
+  bounded by the same per-session caps, and avoiding unbounded allocation is
+  worth the extra local SQLite work.
+- Raw-byte preflight is a memory-safety bound, not a replacement for canonical
+  encoded-size validation. Exact wire checks remain after materialization.
+- Rejected sessions disappear from checkpoint authority until their content
+  changes and exports successfully. This is preferable to serving stale data
+  as if it represented the current archive.
+- Rejection diagnostics are durable but intentionally have no UI in this change.
+  A later status surface can read the recorded queue fields without a schema
+  redesign.
+- A future release that tightens export limits must include a migration that
+  requeues existing publications. Otherwise the unclaimed full-export
+  dependency-recovery pass remains intentionally fail-fast and cannot convert
+  an old clean publication into a rejected claim.

--- a/internal/artifact/export.go
+++ b/internal/artifact/export.go
@@ -29,6 +29,7 @@ type artifactExportStore interface {
 	ApplyArtifactPublicationChanges(context.Context, string, []db.ArtifactPublicationChange) (int64, bool, error)
 	FinalizeArtifactExports(context.Context, []db.ArtifactExportOutcome) error
 	GetArtifactCheckpointHead(context.Context, string) (db.ArtifactCheckpointHead, bool, error)
+	ArtifactLocalMachineName(context.Context) (string, error)
 	StreamArtifactPublications(context.Context, string, func(db.ArtifactPublication) error) (int64, error)
 	RecordArtifactCheckpointHeadOutcomes(
 		context.Context, db.ArtifactCheckpointHead, []db.ArtifactExportOutcome,
@@ -100,8 +101,12 @@ func exportToStoreWithLimits(
 		)
 	}
 
+	localMachine, err := database.ArtifactLocalMachineName(ctx)
+	if err != nil {
+		return ExportResult{}, fmt.Errorf("reading artifact local machine: %w", err)
+	}
+
 	var claims []db.ArtifactExportQueueItem
-	var err error
 	if len(opts.SessionIDs) > 0 {
 		claims, err = database.ArtifactExportClaims(ctx, opts.SessionIDs)
 	} else {
@@ -135,7 +140,7 @@ func exportToStoreWithLimits(
 		if err != nil {
 			return result, fmt.Errorf("loading artifact export session %s: %w", sessionID, err)
 		}
-		if sess == nil || sess.Machine != "local" || sess.DeletedAt != nil {
+		if sess == nil || !artifactMachineIsOwned(sess.Machine, localMachine) || sess.DeletedAt != nil {
 			if claimed {
 				changes = append(changes, db.ArtifactPublicationChange{
 					SessionID: sessionID, Generation: claim.Generation, Delete: true,
@@ -335,6 +340,11 @@ func exportFullToStoreWithDrainRoundsAndLimits(
 	drainRounds int,
 	limits artifactLimits,
 ) (ExportResult, error) {
+	localMachine, err := database.ArtifactLocalMachineName(ctx)
+	if err != nil {
+		return ExportResult{}, fmt.Errorf("reading artifact local machine: %w", err)
+	}
+
 	result := ExportResult{}
 	processed := make(map[string]struct{})
 	drainSnapshot := func() error {
@@ -391,7 +401,7 @@ func exportFullToStoreWithDrainRoundsAndLimits(
 		if err != nil {
 			return result, fmt.Errorf("loading full artifact export session %s: %w", sessionID, err)
 		}
-		if sess == nil || sess.Machine != "local" || sess.DeletedAt != nil {
+		if sess == nil || !artifactMachineIsOwned(sess.Machine, localMachine) || sess.DeletedAt != nil {
 			continue
 		}
 		if _, _, err := exportClaimedSessionToStore(
@@ -425,6 +435,10 @@ func exportFullToStoreWithDrainRoundsAndLimits(
 	return result, fmt.Errorf(
 		"artifact export queue did not settle after %d drain rounds", drainRounds,
 	)
+}
+
+func artifactMachineIsOwned(machine, localMachine string) bool {
+	return machine == "local" || machine == localMachine
 }
 
 const maxArtifactExportBatchSize = 1024

--- a/internal/artifact/export.go
+++ b/internal/artifact/export.go
@@ -22,7 +22,7 @@ type artifactExportStore interface {
 	CountPendingArtifactExports(context.Context) (int, error)
 	PendingArtifactExports(context.Context, int) ([]db.ArtifactExportQueueItem, error)
 	ArtifactExportClaims(context.Context, []string) ([]db.ArtifactExportQueueItem, error)
-	GetSessionFull(context.Context, string) (*db.Session, error)
+	GetArtifactExportSession(context.Context, string) (*db.Session, error)
 	LoadArtifactExportData(
 		context.Context, string, db.ArtifactExportLoadLimits,
 	) (db.ArtifactExportData, error)
@@ -131,7 +131,7 @@ func exportToStoreWithLimits(
 			return result, err
 		}
 		claim, claimed := claimByID[sessionID]
-		sess, err := database.GetSessionFull(ctx, sessionID)
+		sess, err := database.GetArtifactExportSession(ctx, sessionID)
 		if err != nil {
 			return result, fmt.Errorf("loading artifact export session %s: %w", sessionID, err)
 		}
@@ -382,7 +382,7 @@ func exportFullToStoreWithDrainRoundsAndLimits(
 		if _, ok := processed[sessionID]; ok {
 			continue
 		}
-		sess, err := database.GetSessionFull(ctx, sessionID)
+		sess, err := database.GetArtifactExportSession(ctx, sessionID)
 		if err != nil {
 			return result, fmt.Errorf("loading full artifact export session %s: %w", sessionID, err)
 		}

--- a/internal/artifact/export.go
+++ b/internal/artifact/export.go
@@ -520,7 +520,10 @@ func exportLoadedSessionToStore(
 	}
 	data, err := canonicalJSON(m)
 	if err != nil {
-		return "", false, err
+		return "", false, fmt.Errorf(
+			"%w: encoding manifest for %s: %w",
+			ErrArtifactExportRejected, sess.ID, err,
+		)
 	}
 	if int64(len(data)) > manifestDecodedLimit {
 		return "", false, rejectArtifactExportf(

--- a/internal/artifact/export.go
+++ b/internal/artifact/export.go
@@ -1,0 +1,949 @@
+package artifact
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+	"io/fs"
+	"os"
+	"sort"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+type artifactExportStore interface {
+	ListOwnedSessionIDsForExport(context.Context) ([]string, error)
+	CountPendingArtifactExports(context.Context) (int, error)
+	PendingArtifactExports(context.Context, int) ([]db.ArtifactExportQueueItem, error)
+	ArtifactExportClaims(context.Context, []string) ([]db.ArtifactExportQueueItem, error)
+	GetSessionFull(context.Context, string) (*db.Session, error)
+	LoadArtifactExportData(
+		context.Context, string, db.ArtifactExportLoadLimits,
+	) (db.ArtifactExportData, error)
+	ApplyArtifactPublicationChanges(context.Context, string, []db.ArtifactPublicationChange) (int64, bool, error)
+	FinalizeArtifactExports(context.Context, []db.ArtifactExportOutcome) error
+	GetArtifactCheckpointHead(context.Context, string) (db.ArtifactCheckpointHead, bool, error)
+	StreamArtifactPublications(context.Context, string, func(db.ArtifactPublication) error) (int64, error)
+	RecordArtifactCheckpointHeadOutcomes(
+		context.Context, db.ArtifactCheckpointHead, []db.ArtifactExportOutcome,
+	) error
+	GetArtifactCheckpointFloor(context.Context, string) (int, bool, error)
+	ReserveArtifactCheckpointSequence(context.Context, string, int) (int, error)
+}
+
+const artifactExportBatchSize = 128
+
+// ExportOptions selects artifact publication work. The default and explicit-ID
+// modes process one bounded batch. Full drains bounded claim pages before
+// recreating every currently-owned session's immutable dependencies one body
+// at a time; publication authority still changes only through guarded claims.
+type ExportOptions struct {
+	Origin     string
+	SessionIDs []string
+	Full       bool
+}
+
+// ExportResult summarizes one canonical store export.
+type ExportResult struct {
+	ExportedSessions   int
+	RejectedSessions   int
+	CheckpointCreated  bool
+	CheckpointSequence int
+}
+
+// ExportToStore publishes generation-guarded work into the canonical artifact
+// store. Immutable dependencies are created before their manifest, and each
+// bounded page's checkpoint is created last. Full mode may publish several
+// bounded pages before its dependency-recovery pass completes.
+func ExportToStore(
+	ctx context.Context,
+	database artifactExportStore,
+	store ArtifactStore,
+	opts ExportOptions,
+) (ExportResult, error) {
+	return exportToStoreWithLimits(
+		ctx, database, store, opts, productionArtifactLimits(),
+	)
+}
+
+func exportToStoreWithLimits(
+	ctx context.Context,
+	database artifactExportStore,
+	store ArtifactStore,
+	opts ExportOptions,
+	limits artifactLimits,
+) (_ ExportResult, retErr error) {
+	if database == nil {
+		return ExportResult{}, errors.New("artifact export database is required")
+	}
+	if store == nil {
+		return ExportResult{}, errors.New("artifact export store is required")
+	}
+	if err := validateOriginID(opts.Origin); err != nil {
+		return ExportResult{}, err
+	}
+	if len(opts.SessionIDs) > 1024 {
+		return ExportResult{}, errors.New("artifact export session batch exceeds 1024 rows")
+	}
+	if opts.Full && len(opts.SessionIDs) > 0 {
+		return ExportResult{}, errors.New("full artifact export cannot select session IDs")
+	}
+	if opts.Full {
+		return exportFullToStoreWithDrainRoundsAndLimits(
+			ctx, database, store, opts.Origin, maxExportDrainRounds, limits,
+		)
+	}
+
+	var claims []db.ArtifactExportQueueItem
+	var err error
+	if len(opts.SessionIDs) > 0 {
+		claims, err = database.ArtifactExportClaims(ctx, opts.SessionIDs)
+	} else {
+		queueLimit := artifactExportBatchSize
+		if opts.Full {
+			queueLimit = 1024
+		}
+		claims, err = database.PendingArtifactExports(ctx, queueLimit)
+	}
+	if err != nil {
+		return ExportResult{}, fmt.Errorf("reading artifact export queue: %w", err)
+	}
+	claimByID := make(map[string]db.ArtifactExportQueueItem, len(claims))
+	for _, claim := range claims {
+		claimByID[claim.SessionID] = claim
+	}
+
+	selected, err := selectArtifactExportSessionIDs(ctx, database, opts, claims, claimByID)
+	if err != nil {
+		return ExportResult{}, err
+	}
+	changes := make([]db.ArtifactPublicationChange, 0, len(claims))
+	outcomes := make([]db.ArtifactExportOutcome, 0, len(claims))
+	result := ExportResult{}
+	for _, sessionID := range selected {
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+		claim, claimed := claimByID[sessionID]
+		sess, err := database.GetSessionFull(ctx, sessionID)
+		if err != nil {
+			return result, fmt.Errorf("loading artifact export session %s: %w", sessionID, err)
+		}
+		if sess == nil || sess.Machine != "local" || sess.DeletedAt != nil {
+			if claimed {
+				changes = append(changes, db.ArtifactPublicationChange{
+					SessionID: sessionID, Generation: claim.Generation, Delete: true,
+				})
+				outcomes = append(outcomes, db.ArtifactExportOutcome{Item: claim})
+			}
+			continue
+		}
+		manifestHash, created, err := exportClaimedSessionToStore(
+			ctx, database, store, opts.Origin, sess, limits,
+		)
+		if err != nil {
+			if !claimed || !isDeterministicArtifactExportError(err) {
+				return result, err
+			}
+			changes = append(changes, db.ArtifactPublicationChange{
+				SessionID: sessionID, Generation: claim.Generation, Delete: true,
+			})
+			outcomes = append(outcomes, db.ArtifactExportOutcome{
+				Item: claim, Rejection: err.Error(),
+			})
+			result.RejectedSessions++
+			continue
+		}
+		if created && claimed {
+			result.ExportedSessions++
+		}
+		if claimed {
+			changes = append(changes, db.ArtifactPublicationChange{
+				SessionID: sessionID, Generation: claim.Generation,
+				ManifestHash: manifestHash, SourceFingerprint: manifestHash,
+			})
+			outcomes = append(outcomes, db.ArtifactExportOutcome{Item: claim})
+		}
+	}
+
+	head, hadHead, err := database.GetArtifactCheckpointHead(ctx, opts.Origin)
+	if err != nil {
+		return result, fmt.Errorf("reading artifact checkpoint head: %w", err)
+	}
+	publicationRevision, changed, err := database.ApplyArtifactPublicationChanges(
+		ctx, opts.Origin, changes,
+	)
+	if err != nil {
+		return result, err
+	}
+	if !changed && hadHead && head.PublicationRevision == publicationRevision {
+		verified, err := statRecordedCheckpoint(ctx, store, head)
+		if err != nil {
+			return result, err
+		}
+		if verified {
+			if err := database.FinalizeArtifactExports(ctx, outcomes); err != nil {
+				return result, err
+			}
+			return result, nil
+		}
+	}
+
+	comparableHead := !changed && hadHead
+	if !hadHead {
+		head, comparableHead, err = latestValidCheckpointHead(ctx, store, opts.Origin)
+		if err != nil {
+			return result, err
+		}
+	}
+	mapSpool, mapDigest, mapRevision, err := spoolArtifactPublicationMap(ctx, database, opts.Origin)
+	if err != nil {
+		return result, err
+	}
+	defer func() {
+		if mapSpool != nil {
+			retErr = errors.Join(retErr, closeAndRemoveExportSpool(mapSpool))
+		}
+	}()
+	if comparableHead && head.SessionMapSHA256 == mapDigest {
+		checkpointSpool, checkpointIdentity, err := spoolArtifactCheckpoint(
+			ctx, mapSpool, opts.Origin, head.Sequence,
+		)
+		if err != nil {
+			return result, err
+		}
+		defer func() {
+			if checkpointSpool != nil {
+				retErr = errors.Join(retErr, closeAndRemoveExportSpool(checkpointSpool))
+			}
+		}()
+		if checkpointIdentity.SHA256 != head.CheckpointSHA256 {
+			return result, fmt.Errorf(
+				"%w: recorded checkpoint %d hash differs from canonical publications",
+				ErrArtifactCorrupt, head.Sequence,
+			)
+		}
+		head.PublicationRevision = mapRevision
+		head.CheckpointSize = checkpointIdentity.Size
+		checkpointRef, err := NewRef(opts.Origin, KindCheckpoints,
+			fmt.Sprintf("cp-%010d.json", head.Sequence))
+		if err != nil {
+			return result, err
+		}
+		if err := closeAndRemoveExportSpool(mapSpool); err != nil {
+			return result, fmt.Errorf("cleaning artifact session map spool: %w", err)
+		}
+		mapSpool = nil
+		create, err := store.Create(ctx, checkpointRef, checkpointIdentity,
+			canonicalArtifactMediaType(KindCheckpoints), checkpointSpool)
+		if err != nil {
+			return result, fmt.Errorf("recreating artifact checkpoint: %w", err)
+		}
+		if err := closeAndRemoveExportSpool(checkpointSpool); err != nil {
+			return result, fmt.Errorf("cleaning artifact checkpoint spool: %w", err)
+		}
+		checkpointSpool = nil
+		if err := database.RecordArtifactCheckpointHeadOutcomes(
+			ctx, head, outcomes,
+		); err != nil {
+			return result, err
+		}
+		result.CheckpointCreated = create.Created
+		result.CheckpointSequence = head.Sequence
+		return result, nil
+	}
+
+	sequence, err := reserveCheckpointSequenceFromStore(ctx, database, store, opts.Origin)
+	if err != nil {
+		return result, err
+	}
+	checkpointSpool, checkpointIdentity, err := spoolArtifactCheckpoint(
+		ctx, mapSpool, opts.Origin, sequence,
+	)
+	if err != nil {
+		return result, err
+	}
+	defer func() {
+		if checkpointSpool != nil {
+			retErr = errors.Join(retErr, closeAndRemoveExportSpool(checkpointSpool))
+		}
+	}()
+	checkpointRef, err := NewRef(opts.Origin, KindCheckpoints,
+		fmt.Sprintf("cp-%010d.json", sequence))
+	if err != nil {
+		return result, err
+	}
+	if err := closeAndRemoveExportSpool(mapSpool); err != nil {
+		return result, fmt.Errorf("cleaning artifact session map spool: %w", err)
+	}
+	mapSpool = nil
+	if _, err := store.Create(ctx, checkpointRef, checkpointIdentity,
+		canonicalArtifactMediaType(KindCheckpoints), checkpointSpool,
+	); err != nil {
+		return result, fmt.Errorf("creating artifact checkpoint: %w", err)
+	}
+	if err := closeAndRemoveExportSpool(checkpointSpool); err != nil {
+		return result, fmt.Errorf("cleaning artifact checkpoint spool: %w", err)
+	}
+	checkpointSpool = nil
+	if err := database.RecordArtifactCheckpointHeadOutcomes(ctx, db.ArtifactCheckpointHead{
+		Origin: opts.Origin, Sequence: sequence, PublicationRevision: mapRevision,
+		SessionMapSHA256: mapDigest, CheckpointSHA256: checkpointIdentity.SHA256,
+		CheckpointSize: checkpointIdentity.Size,
+	}, outcomes); err != nil {
+		return result, err
+	}
+	result.CheckpointCreated = true
+	result.CheckpointSequence = sequence
+	return result, nil
+}
+
+// maxExportDrainRounds bounds the terminal drain loop below. Full export must
+// terminate even when the queue is kept perpetually non-empty by concurrent
+// writers; after the cap is reached the accumulated result is still returned,
+// paired with an error describing the unsettled queue.
+const maxExportDrainRounds = 32
+
+func exportFullToStoreWithDrainRounds(
+	ctx context.Context,
+	database artifactExportStore,
+	store ArtifactStore,
+	origin string,
+	drainRounds int,
+) (ExportResult, error) {
+	return exportFullToStoreWithDrainRoundsAndLimits(
+		ctx, database, store, origin, drainRounds, productionArtifactLimits(),
+	)
+}
+
+func exportFullToStoreWithDrainRoundsAndLimits(
+	ctx context.Context,
+	database artifactExportStore,
+	store ArtifactStore,
+	origin string,
+	drainRounds int,
+	limits artifactLimits,
+) (ExportResult, error) {
+	result := ExportResult{}
+	processed := make(map[string]struct{})
+	drainSnapshot := func() error {
+		remaining, err := database.CountPendingArtifactExports(ctx)
+		if err != nil {
+			return fmt.Errorf("counting full artifact export queue: %w", err)
+		}
+		for remaining > 0 {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			claims, err := database.PendingArtifactExports(
+				ctx, min(remaining, maxArtifactExportBatchSize),
+			)
+			if err != nil {
+				return fmt.Errorf("reading full artifact export queue: %w", err)
+			}
+			if len(claims) == 0 {
+				return nil
+			}
+			remaining -= len(claims)
+			ids := make([]string, len(claims))
+			for i, claim := range claims {
+				ids[i] = claim.SessionID
+				processed[claim.SessionID] = struct{}{}
+			}
+			page, err := exportToStoreWithLimits(
+				ctx, database, store,
+				ExportOptions{Origin: origin, SessionIDs: ids},
+				limits,
+			)
+			if err != nil {
+				return err
+			}
+			mergeArtifactExportResult(&result, page)
+		}
+		return nil
+	}
+	if err := drainSnapshot(); err != nil {
+		return result, err
+	}
+	ids, err := database.ListOwnedSessionIDsForExport(ctx)
+	if err != nil {
+		return result, fmt.Errorf("listing sessions for full artifact export: %w", err)
+	}
+	for _, sessionID := range ids {
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+		if _, ok := processed[sessionID]; ok {
+			continue
+		}
+		sess, err := database.GetSessionFull(ctx, sessionID)
+		if err != nil {
+			return result, fmt.Errorf("loading full artifact export session %s: %w", sessionID, err)
+		}
+		if sess == nil || sess.Machine != "local" || sess.DeletedAt != nil {
+			continue
+		}
+		if _, _, err := exportClaimedSessionToStore(
+			ctx, database, store, origin, sess, limits,
+		); err != nil {
+			return result, err
+		}
+	}
+	if err := drainSnapshot(); err != nil {
+		return result, err
+	}
+	for range drainRounds {
+		final, err := exportToStoreWithLimits(
+			ctx, database, store, ExportOptions{Origin: origin}, limits,
+		)
+		if err != nil {
+			return result, err
+		}
+		mergeArtifactExportResult(&result, final)
+		pending, err := database.PendingArtifactExports(ctx, 1)
+		if err != nil {
+			return result, fmt.Errorf("checking concurrent full artifact work: %w", err)
+		}
+		if len(pending) == 0 {
+			return result, nil
+		}
+		if err := drainSnapshot(); err != nil {
+			return result, err
+		}
+	}
+	return result, fmt.Errorf(
+		"artifact export queue did not settle after %d drain rounds", drainRounds,
+	)
+}
+
+const maxArtifactExportBatchSize = 1024
+
+func mergeArtifactExportResult(total *ExportResult, page ExportResult) {
+	total.ExportedSessions += page.ExportedSessions
+	total.RejectedSessions += page.RejectedSessions
+	if page.CheckpointCreated {
+		total.CheckpointCreated = true
+	}
+	if page.CheckpointSequence > total.CheckpointSequence {
+		total.CheckpointSequence = page.CheckpointSequence
+	}
+}
+
+func selectArtifactExportSessionIDs(
+	ctx context.Context,
+	database artifactExportStore,
+	opts ExportOptions,
+	claims []db.ArtifactExportQueueItem,
+	claimByID map[string]db.ArtifactExportQueueItem,
+) ([]string, error) {
+	selected := make(map[string]struct{})
+	switch {
+	case opts.Full:
+		ids, err := database.ListOwnedSessionIDsForExport(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("listing sessions for full artifact export: %w", err)
+		}
+		for _, id := range ids {
+			selected[id] = struct{}{}
+		}
+		for _, claim := range claims {
+			selected[claim.SessionID] = struct{}{}
+		}
+	case len(opts.SessionIDs) > 0:
+		for _, id := range opts.SessionIDs {
+			if _, ok := claimByID[id]; ok {
+				selected[id] = struct{}{}
+			}
+		}
+	default:
+		for _, claim := range claims {
+			selected[claim.SessionID] = struct{}{}
+		}
+	}
+	ids := make([]string, 0, len(selected))
+	for id := range selected {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids, nil
+}
+
+func exportLoadedSessionToStore(
+	ctx context.Context,
+	store ArtifactStore,
+	origin string,
+	sess *db.Session,
+	messages []db.Message,
+	usageEvents []db.UsageEvent,
+	limits artifactLimits,
+) (string, bool, error) {
+	if len(messages) > limits.sessionMessages {
+		return "", false, rejectArtifactExportf(
+			"session message limit exceeded for %s: got %d, limit %d",
+			sess.ID, len(messages), limits.sessionMessages,
+		)
+	}
+	if len(usageEvents) > limits.manifestUsageEvents {
+		return "", false, rejectArtifactExportf(
+			"manifest usage event limit exceeded for %s: got %d, limit %d",
+			sess.ID, len(usageEvents), limits.manifestUsageEvents,
+		)
+	}
+	if err := validateExportNestedCollections(messages, limits); err != nil {
+		return "", false, fmt.Errorf("validating nested collections for %s: %w", sess.ID, err)
+	}
+
+	segmentHashes, err := exportMessageSegmentsToStore(
+		ctx, store, origin, sess.ID, messages, limits,
+	)
+	if err != nil {
+		return "", false, err
+	}
+
+	wireSession := manifestSessionFromDB(*sess)
+	wireSession.Machine = origin
+	normalizeManifestSessionLocalState(&wireSession)
+	m := manifest{
+		Version: manifestFormatVersion, Origin: origin, NativeSessionID: sess.ID,
+		Session: wireSession, SessionName: sess.SessionName,
+		Segments: segmentHashes, UsageEvents: canonicalUsageEvents(usageEvents),
+		DataVersion: sess.DataVersion, Generation: 1,
+		SessionHasToolCalls:   sess.HasToolCalls,
+		SessionHasContextData: sess.HasContextData,
+		SessionQualitySignals: manifestQualitySignalsFromDB(sess.StoredQualitySignals()),
+	}
+	data, err := canonicalJSON(m)
+	if err != nil {
+		return "", false, err
+	}
+	if int64(len(data)) > manifestDecodedLimit {
+		return "", false, rejectArtifactExportf(
+			"generated manifest exceeds %d-byte readable limit: got %d bytes",
+			manifestDecodedLimit, len(data),
+		)
+	}
+	hash := hashHex(data)
+	identity, err := NewIdentity(hash, int64(len(data)))
+	if err != nil {
+		return "", false, err
+	}
+	ref, err := NewRef(origin, KindManifests, hash+".json")
+	if err != nil {
+		return "", false, err
+	}
+	created, err := store.Create(ctx, ref, identity,
+		canonicalArtifactMediaType(KindManifests), bytes.NewReader(data))
+	if err != nil {
+		return "", false, fmt.Errorf("creating manifest for %s: %w", sess.ID, err)
+	}
+	return hash, created.Created, nil
+}
+
+func exportClaimedSessionToStore(
+	ctx context.Context,
+	database artifactExportStore,
+	store ArtifactStore,
+	origin string,
+	sess *db.Session,
+	limits artifactLimits,
+) (string, bool, error) {
+	data, err := database.LoadArtifactExportData(
+		ctx, sess.ID, artifactExportLoadLimits(limits),
+	)
+	if err != nil {
+		return "", false, fmt.Errorf(
+			"loading bounded artifact export data %s: %w",
+			sess.ID, classifyArtifactExportLoadError(err),
+		)
+	}
+	return exportLoadedSessionToStore(
+		ctx, store, origin, sess, data.Messages, data.UsageEvents, limits,
+	)
+}
+
+func exportMessageSegmentsToStore(
+	ctx context.Context,
+	store ArtifactStore,
+	origin string,
+	sessionID string,
+	messages []db.Message,
+	limits artifactLimits,
+) (_ []string, retErr error) {
+	segmentHashes := make([]string, 0, 1)
+	seen := make(map[string]struct{})
+	var decodedBytes int64
+	var spool *os.File
+	var hasher hash.Hash
+	var segmentBytes int64
+	segmentMessages := 0
+	segmentNested := nestedCollectionCounts{}
+	defer func() {
+		if spool != nil {
+			retErr = errors.Join(retErr, closeAndRemoveExportSpool(spool))
+		}
+	}()
+
+	start := func() error {
+		var err error
+		spool, err = os.CreateTemp("", "agentsview-artifact-segment-*")
+		if err != nil {
+			return fmt.Errorf("creating artifact segment spool: %w", err)
+		}
+		if err := spool.Chmod(0o600); err != nil {
+			return fmt.Errorf("securing artifact segment spool: %w", err)
+		}
+		hasher = sha256.New()
+		segmentBytes = 0
+		segmentMessages = 0
+		segmentNested = nestedCollectionCounts{}
+		return nil
+	}
+	flush := func() error {
+		if len(segmentHashes) >= limits.manifestSegments {
+			return rejectArtifactExportf(
+				"manifest segment reference limit exceeded for %s: limit %d",
+				sessionID, limits.manifestSegments)
+		}
+		digest := hex.EncodeToString(hasher.Sum(nil))
+		if _, duplicate := seen[digest]; duplicate {
+			return rejectArtifactExportf("generated duplicate segment reference %s", digest)
+		}
+		identity, err := NewIdentity(digest, segmentBytes)
+		if err != nil {
+			return err
+		}
+		ref, err := NewRef(origin, KindSegments, digest+".ndjson")
+		if err != nil {
+			return err
+		}
+		if _, err := spool.Seek(0, io.SeekStart); err != nil {
+			return fmt.Errorf("rewinding artifact segment spool: %w", err)
+		}
+		if _, err := store.Create(ctx, ref, identity,
+			canonicalArtifactMediaType(KindSegments), spool); err != nil {
+			return fmt.Errorf("creating segment for %s: %w", sessionID, err)
+		}
+		cleanupErr := closeAndRemoveExportSpool(spool)
+		spool = nil
+		if cleanupErr != nil {
+			return fmt.Errorf("cleaning artifact segment spool: %w", cleanupErr)
+		}
+		seen[digest] = struct{}{}
+		segmentHashes = append(segmentHashes, digest)
+		return nil
+	}
+
+	if err := start(); err != nil {
+		return nil, err
+	}
+	for _, message := range messages {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		messageNested, err := dbMessageNestedCounts(message, limits)
+		if err != nil {
+			return nil, err
+		}
+		if err := validateMessageFitsSegment(message.Ordinal, messageNested, limits); err != nil {
+			return nil, err
+		}
+		data, err := canonicalJSON(segmentMessageFromDB(message))
+		if err != nil {
+			return nil, fmt.Errorf(
+				"%w: encoding message segment at ordinal %d: %w",
+				ErrArtifactExportRejected, message.Ordinal, err,
+			)
+		}
+		if int64(len(data)) > segmentDecodedLimit {
+			return nil, rejectArtifactExportf(
+				"encoded message record at ordinal %d exceeds %d-byte readable limit",
+				message.Ordinal, segmentDecodedLimit,
+			)
+		}
+		if segmentBytes > 0 && (segmentBytes+int64(len(data)) > segmentTargetSize ||
+			segmentMessages >= limits.segmentMessages ||
+			exceedsCollectionLimit(segmentNested.toolCalls,
+				messageNested.toolCalls, limits.segmentToolCalls) ||
+			exceedsCollectionLimit(segmentNested.resultEvents,
+				messageNested.resultEvents, limits.segmentResultEvents)) {
+			if err := flush(); err != nil {
+				return nil, err
+			}
+			if err := start(); err != nil {
+				return nil, err
+			}
+		}
+		if int64(len(data)) > limits.sessionDecodedBytes-decodedBytes {
+			return nil, rejectArtifactExportf(
+				"session decoded byte limit exceeded for %s: limit %d",
+				sessionID, limits.sessionDecodedBytes)
+		}
+		if _, err := io.MultiWriter(spool, hasher).Write(data); err != nil {
+			return nil, fmt.Errorf("writing artifact segment spool: %w", err)
+		}
+		segmentBytes += int64(len(data))
+		decodedBytes += int64(len(data))
+		segmentMessages++
+		segmentNested.toolCalls += messageNested.toolCalls
+		segmentNested.resultEvents += messageNested.resultEvents
+	}
+	if err := flush(); err != nil {
+		return nil, err
+	}
+	return segmentHashes, nil
+}
+
+func spoolArtifactPublicationMap(
+	ctx context.Context,
+	database artifactExportStore,
+	origin string,
+) (_ *os.File, _ string, _ int64, retErr error) {
+	spool, err := os.CreateTemp("", "agentsview-artifact-map-*")
+	if err != nil {
+		return nil, "", 0, fmt.Errorf("creating artifact session map spool: %w", err)
+	}
+	failed := true
+	defer func() {
+		if failed {
+			retErr = errors.Join(retErr, exportSpoolCleanup(spool))
+		}
+	}()
+	if err := exportSpoolChmod(spool); err != nil {
+		return nil, "", 0, fmt.Errorf("securing artifact session map spool: %w", err)
+	}
+	hasher := sha256.New()
+	writer := io.MultiWriter(spool, hasher)
+	if _, err := io.WriteString(writer, "{"); err != nil {
+		return nil, "", 0, err
+	}
+	first := true
+	revision, err := database.StreamArtifactPublications(ctx, origin, func(publication db.ArtifactPublication) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if publication.Origin != origin {
+			return fmt.Errorf("artifact publication origin mismatch: got %q", publication.Origin)
+		}
+		gid, err := json.Marshal(origin + "~" + publication.SessionID)
+		if err != nil {
+			return err
+		}
+		hash, err := json.Marshal(publication.ManifestHash)
+		if err != nil {
+			return err
+		}
+		if !first {
+			if _, err := io.WriteString(writer, ","); err != nil {
+				return err
+			}
+		}
+		first = false
+		_, err = writer.Write(append(append(gid, ':'), hash...))
+		return err
+	})
+	if err != nil {
+		return nil, "", 0, fmt.Errorf("streaming artifact session map: %w", err)
+	}
+	if _, err := io.WriteString(writer, "}"); err != nil {
+		return nil, "", 0, err
+	}
+	if _, err := hasher.Write([]byte{'\n'}); err != nil {
+		return nil, "", 0, err
+	}
+	if _, err := spool.Seek(0, io.SeekStart); err != nil {
+		return nil, "", 0, fmt.Errorf("rewinding artifact session map spool: %w", err)
+	}
+	failed = false
+	return spool, hex.EncodeToString(hasher.Sum(nil)), revision, nil
+}
+
+func spoolArtifactCheckpoint(
+	ctx context.Context,
+	mapSpool *os.File,
+	origin string,
+	sequence int,
+) (*os.File, Identity, error) {
+	return spoolArtifactCheckpointWithLimit(
+		ctx, mapSpool, origin, sequence, checkpointDecodedLimit,
+	)
+}
+
+func spoolArtifactCheckpointWithLimit(
+	ctx context.Context,
+	mapSpool *os.File,
+	origin string,
+	sequence int,
+	decodedLimit int64,
+) (_ *os.File, _ Identity, retErr error) {
+	if _, err := mapSpool.Seek(0, io.SeekStart); err != nil {
+		return nil, Identity{}, fmt.Errorf("rewinding artifact session map: %w", err)
+	}
+	spool, err := os.CreateTemp("", "agentsview-artifact-checkpoint-*")
+	if err != nil {
+		return nil, Identity{}, fmt.Errorf("creating artifact checkpoint spool: %w", err)
+	}
+	failed := true
+	defer func() {
+		if failed {
+			retErr = errors.Join(retErr, exportSpoolCleanup(spool))
+		}
+	}()
+	if err := exportSpoolChmod(spool); err != nil {
+		return nil, Identity{}, fmt.Errorf("securing artifact checkpoint spool: %w", err)
+	}
+	hasher := sha256.New()
+	writer := io.MultiWriter(spool, hasher)
+	originJSON, err := json.Marshal(origin)
+	if err != nil {
+		return nil, Identity{}, err
+	}
+	if _, err := fmt.Fprintf(writer, `{"origin":%s,"seq":%d,"sessions":`, originJSON, sequence); err != nil {
+		return nil, Identity{}, err
+	}
+	if _, err := io.Copy(writer, &contextArtifactReader{ctx: ctx, reader: mapSpool}); err != nil {
+		return nil, Identity{}, fmt.Errorf("copying artifact session map: %w", err)
+	}
+	if _, err := io.WriteString(writer, `,"v":1}`+"\n"); err != nil {
+		return nil, Identity{}, err
+	}
+	info, err := spool.Stat()
+	if err != nil {
+		return nil, Identity{}, fmt.Errorf("stating artifact checkpoint spool: %w", err)
+	}
+	if info.Size() > decodedLimit {
+		return nil, Identity{}, fmt.Errorf(
+			"artifact checkpoint exceeds decoded size limit: %d bytes > %d",
+			info.Size(), decodedLimit,
+		)
+	}
+	identity, err := NewIdentity(hex.EncodeToString(hasher.Sum(nil)), info.Size())
+	if err != nil {
+		return nil, Identity{}, err
+	}
+	if _, err := spool.Seek(0, io.SeekStart); err != nil {
+		return nil, Identity{}, fmt.Errorf("rewinding artifact checkpoint spool: %w", err)
+	}
+	failed = false
+	return spool, identity, nil
+}
+
+func closeAndRemoveExportSpool(file *os.File) error {
+	if file == nil {
+		return nil
+	}
+	name := file.Name()
+	closeErr := file.Close()
+	removeErr := os.Remove(name)
+	if errors.Is(removeErr, fs.ErrNotExist) {
+		removeErr = nil
+	}
+	return errors.Join(closeErr, removeErr)
+}
+
+var (
+	exportSpoolChmod   = func(file *os.File) error { return file.Chmod(0o600) }
+	exportSpoolCleanup = closeAndRemoveExportSpool
+)
+
+func canonicalUsageEvents(events []db.UsageEvent) []artifactUsageEvent {
+	out := make([]artifactUsageEvent, len(events))
+	for i, ev := range events {
+		out[i] = artifactUsageEvent{
+			MessageOrdinal:           ev.MessageOrdinal,
+			Source:                   ev.Source,
+			Model:                    ev.Model,
+			InputTokens:              ev.InputTokens,
+			OutputTokens:             ev.OutputTokens,
+			CacheCreationInputTokens: ev.CacheCreationInputTokens,
+			CacheReadInputTokens:     ev.CacheReadInputTokens,
+			ReasoningTokens:          ev.ReasoningTokens,
+			Cost:                     ev.Cost,
+			CostStatus:               ev.CostStatus,
+			CostSource:               ev.CostSource,
+			OccurredAt:               ev.OccurredAt,
+			DedupKey:                 ev.DedupKey,
+		}
+	}
+	return out
+}
+
+func validateExportNestedCollections(msgs []db.Message, limits artifactLimits) error {
+	total := nestedCollectionCounts{}
+	for _, msg := range msgs {
+		messageNested, err := dbMessageNestedCounts(msg, limits)
+		if err != nil {
+			return err
+		}
+		if err := validateMessageFitsSegment(msg.Ordinal, messageNested, limits); err != nil {
+			return err
+		}
+		if exceedsCollectionLimit(
+			total.toolCalls, messageNested.toolCalls, limits.sessionToolCalls,
+		) {
+			return rejectArtifactExportf(
+				"session tool call limit exceeded at message ordinal %d: limit %d",
+				msg.Ordinal, limits.sessionToolCalls,
+			)
+		}
+		if exceedsCollectionLimit(
+			total.resultEvents, messageNested.resultEvents, limits.sessionResultEvents,
+		) {
+			return rejectArtifactExportf(
+				"session result event limit exceeded at message ordinal %d: limit %d",
+				msg.Ordinal, limits.sessionResultEvents,
+			)
+		}
+		total.toolCalls += messageNested.toolCalls
+		total.resultEvents += messageNested.resultEvents
+	}
+	return nil
+}
+
+func dbMessageNestedCounts(
+	msg db.Message,
+	limits artifactLimits,
+) (nestedCollectionCounts, error) {
+	if len(msg.ToolCalls) > limits.messageToolCalls {
+		return nestedCollectionCounts{}, rejectArtifactExportf(
+			"tool call limit exceeded for message ordinal %d: got %d, limit %d",
+			msg.Ordinal, len(msg.ToolCalls), limits.messageToolCalls,
+		)
+	}
+	counts := nestedCollectionCounts{toolCalls: len(msg.ToolCalls)}
+	for toolIndex, call := range msg.ToolCalls {
+		if len(call.ResultEvents) > limits.toolResultEvents {
+			return nestedCollectionCounts{}, rejectArtifactExportf(
+				"result event limit exceeded for tool call %d in message ordinal %d: got %d, limit %d",
+				toolIndex, msg.Ordinal, len(call.ResultEvents), limits.toolResultEvents,
+			)
+		}
+		counts.resultEvents += len(call.ResultEvents)
+	}
+	return counts, nil
+}
+
+func validateMessageFitsSegment(
+	ordinal int,
+	counts nestedCollectionCounts,
+	limits artifactLimits,
+) error {
+	if counts.toolCalls > limits.segmentToolCalls {
+		return rejectArtifactExportf(
+			"message ordinal %d cannot fit in one segment: got %d tool calls, segment limit %d",
+			ordinal, counts.toolCalls, limits.segmentToolCalls,
+		)
+	}
+	if counts.resultEvents > limits.segmentResultEvents {
+		return rejectArtifactExportf(
+			"message ordinal %d cannot fit in one segment: got %d result events, segment limit %d",
+			ordinal, counts.resultEvents, limits.segmentResultEvents,
+		)
+	}
+	return nil
+}

--- a/internal/artifact/export.go
+++ b/internal/artifact/export.go
@@ -194,6 +194,11 @@ func exportToStoreWithLimits(
 			return result, nil
 		}
 	}
+	if hadHead {
+		if err := validateRecordedCheckpointFormat(ctx, store, head); err != nil {
+			return result, err
+		}
+	}
 
 	comparableHead := !changed && hadHead
 	if !hadHead {

--- a/internal/artifact/export_checkpoint.go
+++ b/internal/artifact/export_checkpoint.go
@@ -98,48 +98,91 @@ func latestValidCheckpointHead(
 			if err != nil || sequence <= head.Sequence {
 				continue
 			}
-			if entry.Identity.Size > checkpointDecodedLimit {
-				continue
-			}
-			_, reader, err := store.Open(ctx, entry.Ref)
-			if errors.Is(err, ErrArtifactNotFound) || errors.Is(err, ErrArtifactCorrupt) {
-				continue
-			}
-			if err != nil {
-				return db.ArtifactCheckpointHead{}, false,
-					fmt.Errorf("opening artifact checkpoint: %w", err)
-			}
-			candidate, decodeErr := decodeCanonicalCheckpointHead(
-				reader, origin, entry.Ref.Name, entry.Identity,
+			candidate, valid, err := decodeCheckpointCandidate(
+				ctx, store, origin, entry,
 			)
-			// Verify drains any bytes left unread after an early semantic
-			// decode failure before authenticating the complete stream.
-			verifyErr := reader.Verify()
-			closeErr := reader.Close()
-			if closeErr != nil && !errors.Is(closeErr, ErrArtifactCorrupt) {
-				return db.ArtifactCheckpointHead{}, false,
-					fmt.Errorf("closing artifact checkpoint: %w", closeErr)
+			if err != nil {
+				return db.ArtifactCheckpointHead{}, false, err
 			}
-			if verifyErr != nil && !errors.Is(verifyErr, ErrArtifactCorrupt) {
-				return db.ArtifactCheckpointHead{}, false,
-					fmt.Errorf("verifying artifact checkpoint: %w", verifyErr)
+			if valid {
+				head = candidate
 			}
-			if verifyErr != nil || closeErr != nil {
-				continue
-			}
-			if errors.Is(decodeErr, errFutureArtifactVersion) {
-				return db.ArtifactCheckpointHead{}, false, decodeErr
-			}
-			if decodeErr != nil {
-				continue
-			}
-			head = candidate
 		}
 		if errors.Is(nextErr, io.EOF) {
 			break
 		}
 	}
 	return head, head.Sequence > 0, nil
+}
+
+func decodeCheckpointCandidate(
+	ctx context.Context,
+	store ArtifactStore,
+	origin string,
+	entry Entry,
+) (db.ArtifactCheckpointHead, bool, error) {
+	if entry.Identity.Size > checkpointDecodedLimit {
+		return db.ArtifactCheckpointHead{}, false, nil
+	}
+	_, reader, err := store.Open(ctx, entry.Ref)
+	if errors.Is(err, ErrArtifactNotFound) || errors.Is(err, ErrArtifactCorrupt) {
+		return db.ArtifactCheckpointHead{}, false, nil
+	}
+	if err != nil {
+		return db.ArtifactCheckpointHead{}, false,
+			fmt.Errorf("opening artifact checkpoint: %w", err)
+	}
+	candidate, decodeErr := decodeCanonicalCheckpointHead(
+		reader, origin, entry.Ref.Name, entry.Identity,
+	)
+	// Verify drains any bytes left unread after an early semantic decode
+	// failure before authenticating the complete stream.
+	verifyErr := reader.Verify()
+	closeErr := reader.Close()
+	if closeErr != nil && !errors.Is(closeErr, ErrArtifactCorrupt) {
+		return db.ArtifactCheckpointHead{}, false,
+			fmt.Errorf("closing artifact checkpoint: %w", closeErr)
+	}
+	if verifyErr != nil && !errors.Is(verifyErr, ErrArtifactCorrupt) {
+		return db.ArtifactCheckpointHead{}, false,
+			fmt.Errorf("verifying artifact checkpoint: %w", verifyErr)
+	}
+	if verifyErr != nil || closeErr != nil {
+		return db.ArtifactCheckpointHead{}, false, nil
+	}
+	if errors.Is(decodeErr, errFutureArtifactVersion) {
+		return db.ArtifactCheckpointHead{}, false, decodeErr
+	}
+	if decodeErr != nil {
+		return db.ArtifactCheckpointHead{}, false, nil
+	}
+	return candidate, true, nil
+}
+
+func validateRecordedCheckpointFormat(
+	ctx context.Context,
+	store ArtifactStore,
+	head db.ArtifactCheckpointHead,
+) error {
+	if head.CheckpointSize > checkpointDecodedLimit {
+		return fmt.Errorf(
+			"%w: recorded checkpoint %d exceeds the decode limit",
+			ErrArtifactUnsupported, head.Sequence,
+		)
+	}
+	ref, err := NewRef(head.Origin, KindCheckpoints,
+		fmt.Sprintf("cp-%010d.json", head.Sequence))
+	if err != nil {
+		return err
+	}
+	_, _, err = decodeCheckpointCandidate(ctx, store, head.Origin, Entry{
+		Ref: ref,
+		Identity: Identity{
+			SHA256: head.CheckpointSHA256,
+			Size:   head.CheckpointSize,
+		},
+	})
+	return err
 }
 
 func decodeCanonicalCheckpointHead(

--- a/internal/artifact/export_checkpoint.go
+++ b/internal/artifact/export_checkpoint.go
@@ -124,10 +124,13 @@ func latestValidCheckpointHead(
 				return db.ArtifactCheckpointHead{}, false,
 					fmt.Errorf("verifying artifact checkpoint: %w", verifyErr)
 			}
+			if verifyErr != nil || closeErr != nil {
+				continue
+			}
 			if errors.Is(decodeErr, errFutureArtifactVersion) {
 				return db.ArtifactCheckpointHead{}, false, decodeErr
 			}
-			if decodeErr != nil || verifyErr != nil || closeErr != nil {
+			if decodeErr != nil {
 				continue
 			}
 			head = candidate
@@ -156,6 +159,7 @@ func decodeCanonicalCheckpointHead(
 	expectedFields := []string{"origin", "seq", "sessions", "v"}
 	var sequence int
 	var mapDigest string
+	var futureVersion int
 	for index, expected := range expectedFields {
 		token, err := decoder.Token()
 		if err != nil {
@@ -214,11 +218,9 @@ func decodeCanonicalCheckpointHead(
 				return db.ArtifactCheckpointHead{}, errors.New("checkpoint version is unsupported")
 			}
 			if version > checkpointFormatVersion {
-				return db.ArtifactCheckpointHead{}, fmt.Errorf(
-					"%w: checkpoint version %d", errFutureArtifactVersion, version,
-				)
+				futureVersion = version
 			}
-			if version != checkpointFormatVersion {
+			if version < checkpointFormatVersion {
 				return db.ArtifactCheckpointHead{}, errors.New("checkpoint version is unsupported")
 			}
 			_, _ = io.WriteString(canonical, strconv.Itoa(version))
@@ -244,6 +246,11 @@ func decodeCanonicalCheckpointHead(
 	if canonical.sha256() != identity.SHA256 || canonical.size != identity.Size {
 		return db.ArtifactCheckpointHead{}, errors.New(
 			"checkpoint stored identity differs from canonical encoding",
+		)
+	}
+	if futureVersion > 0 {
+		return db.ArtifactCheckpointHead{}, fmt.Errorf(
+			"%w: checkpoint version %d", errFutureArtifactVersion, futureVersion,
 		)
 	}
 	return db.ArtifactCheckpointHead{

--- a/internal/artifact/export_checkpoint.go
+++ b/internal/artifact/export_checkpoint.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash"
 	"io"
 	"strconv"
 	"strings"
@@ -21,6 +22,25 @@ type artifactCheckpointSequenceDB interface {
 
 type checkpointFloorStore interface {
 	checkpointFloor(context.Context, string) (int, error)
+}
+
+type checkpointCanonicalIdentityWriter struct {
+	hasher hash.Hash
+	size   int64
+}
+
+func newCheckpointCanonicalIdentityWriter() *checkpointCanonicalIdentityWriter {
+	return &checkpointCanonicalIdentityWriter{hasher: sha256.New()}
+}
+
+func (w *checkpointCanonicalIdentityWriter) Write(data []byte) (int, error) {
+	n, err := w.hasher.Write(data)
+	w.size += int64(n)
+	return n, err
+}
+
+func (w *checkpointCanonicalIdentityWriter) sha256() string {
+	return hex.EncodeToString(w.hasher.Sum(nil))
 }
 
 func openStoreEntryIterator(
@@ -129,10 +149,12 @@ func decodeCanonicalCheckpointHead(
 	if err != nil || token != json.Delim('{') {
 		return db.ArtifactCheckpointHead{}, errors.New("checkpoint is not a JSON object")
 	}
+	canonical := newCheckpointCanonicalIdentityWriter()
+	_, _ = io.WriteString(canonical, "{")
 	expectedFields := []string{"origin", "seq", "sessions", "v"}
 	var sequence int
 	var mapDigest string
-	for _, expected := range expectedFields {
+	for index, expected := range expectedFields {
 		token, err := decoder.Token()
 		if err != nil {
 			return db.ArtifactCheckpointHead{}, err
@@ -143,6 +165,12 @@ func decodeCanonicalCheckpointHead(
 				"checkpoint is not canonical: expected field %q", expected,
 			)
 		}
+		if index > 0 {
+			_, _ = io.WriteString(canonical, ",")
+		}
+		fieldJSON, _ := json.Marshal(expected)
+		_, _ = canonical.Write(fieldJSON)
+		_, _ = io.WriteString(canonical, ":")
 		switch field {
 		case "origin":
 			var got string
@@ -154,6 +182,8 @@ func decodeCanonicalCheckpointHead(
 					"checkpoint origin mismatch for %s: got %q", origin, got,
 				)
 			}
+			valueJSON, _ := json.Marshal(got)
+			_, _ = canonical.Write(valueJSON)
 		case "seq":
 			var number json.Number
 			if err := decoder.Decode(&number); err != nil {
@@ -164,8 +194,11 @@ func decodeCanonicalCheckpointHead(
 				return db.ArtifactCheckpointHead{}, errors.New("checkpoint sequence is invalid")
 			}
 			sequence = int(value)
+			_, _ = io.WriteString(canonical, strconv.Itoa(sequence))
 		case "sessions":
-			mapDigest, err = decodeCanonicalCheckpointSessionMap(decoder, origin)
+			mapDigest, err = decodeCanonicalCheckpointSessionMap(
+				decoder, origin, canonical,
+			)
 			if err != nil {
 				return db.ArtifactCheckpointHead{}, err
 			}
@@ -186,6 +219,7 @@ func decodeCanonicalCheckpointHead(
 			if version != checkpointFormatVersion {
 				return db.ArtifactCheckpointHead{}, errors.New("checkpoint version is unsupported")
 			}
+			_, _ = io.WriteString(canonical, strconv.Itoa(version))
 		}
 	}
 	token, err = decoder.Token()
@@ -199,9 +233,15 @@ func decodeCanonicalCheckpointHead(
 		}
 		return db.ArtifactCheckpointHead{}, err
 	}
+	_, _ = io.WriteString(canonical, "}\n")
 	if fmt.Sprintf("cp-%010d.json", sequence) != name {
 		return db.ArtifactCheckpointHead{}, fmt.Errorf(
 			"checkpoint sequence identity mismatch: got %s", name,
+		)
+	}
+	if canonical.sha256() != identity.SHA256 || canonical.size != identity.Size {
+		return db.ArtifactCheckpointHead{}, errors.New(
+			"checkpoint stored identity differs from canonical encoding",
 		)
 	}
 	return db.ArtifactCheckpointHead{
@@ -214,13 +254,15 @@ func decodeCanonicalCheckpointHead(
 func decodeCanonicalCheckpointSessionMap(
 	decoder *json.Decoder,
 	origin string,
+	checkpointWriter io.Writer,
 ) (string, error) {
 	token, err := decoder.Token()
 	if err != nil || token != json.Delim('{') {
 		return "", errors.New("checkpoint sessions is not an object")
 	}
 	hasher := sha256.New()
-	_, _ = io.WriteString(hasher, "{")
+	writer := io.MultiWriter(hasher, checkpointWriter)
+	_, _ = io.WriteString(writer, "{")
 	first := true
 	previous := ""
 	for decoder.More() {
@@ -243,13 +285,13 @@ func decodeCanonicalCheckpointSessionMap(
 			return "", fmt.Errorf("checkpoint manifest hash is invalid: %w", err)
 		}
 		if !first {
-			_, _ = io.WriteString(hasher, ",")
+			_, _ = io.WriteString(writer, ",")
 		}
 		gidJSON, _ := json.Marshal(gid)
 		hashJSON, _ := json.Marshal(manifestHash)
-		_, _ = hasher.Write(gidJSON)
-		_, _ = io.WriteString(hasher, ":")
-		_, _ = hasher.Write(hashJSON)
+		_, _ = writer.Write(gidJSON)
+		_, _ = io.WriteString(writer, ":")
+		_, _ = writer.Write(hashJSON)
 		first = false
 		previous = gid
 	}
@@ -257,7 +299,8 @@ func decodeCanonicalCheckpointSessionMap(
 	if err != nil || token != json.Delim('}') {
 		return "", errors.New("checkpoint sessions object is incomplete")
 	}
-	_, _ = io.WriteString(hasher, "}\n")
+	_, _ = io.WriteString(writer, "}")
+	_, _ = io.WriteString(hasher, "\n")
 	return hex.EncodeToString(hasher.Sum(nil)), nil
 }
 

--- a/internal/artifact/export_checkpoint.go
+++ b/internal/artifact/export_checkpoint.go
@@ -157,24 +157,35 @@ func decodeCanonicalCheckpointHead(
 	canonical := newCheckpointCanonicalIdentityWriter()
 	_, _ = io.WriteString(canonical, "{")
 	expectedFields := []string{"origin", "seq", "sessions", "v"}
+	fields := make([]string, 0, len(expectedFields))
 	var sequence int
+	var version int
 	var mapDigest string
-	var futureVersion int
-	for index, expected := range expectedFields {
+	var originSeen bool
+	var sequenceSeen bool
+	var versionSeen bool
+	for decoder.More() {
 		token, err := decoder.Token()
 		if err != nil {
 			return db.ArtifactCheckpointHead{}, err
 		}
 		field, ok := token.(string)
-		if !ok || field != expected {
-			return db.ArtifactCheckpointHead{}, fmt.Errorf(
-				"checkpoint is not canonical: expected field %q", expected,
+		if !ok {
+			return db.ArtifactCheckpointHead{}, errors.New(
+				"checkpoint field name is invalid",
 			)
 		}
-		if index > 0 {
+		if len(fields) > 0 && field <= fields[len(fields)-1] {
+			return db.ArtifactCheckpointHead{}, fmt.Errorf(
+				"checkpoint fields are not canonical: %q follows %q",
+				field, fields[len(fields)-1],
+			)
+		}
+		if len(fields) > 0 {
 			_, _ = io.WriteString(canonical, ",")
 		}
-		fieldJSON, _ := json.Marshal(expected)
+		fields = append(fields, field)
+		fieldJSON, _ := json.Marshal(field)
 		_, _ = canonical.Write(fieldJSON)
 		_, _ = io.WriteString(canonical, ":")
 		switch field {
@@ -188,6 +199,7 @@ func decodeCanonicalCheckpointHead(
 					"checkpoint origin mismatch for %s: got %q", origin, got,
 				)
 			}
+			originSeen = true
 			valueJSON, _ := json.Marshal(got)
 			_, _ = canonical.Write(valueJSON)
 		case "seq":
@@ -200,6 +212,7 @@ func decodeCanonicalCheckpointHead(
 				return db.ArtifactCheckpointHead{}, errors.New("checkpoint sequence is invalid")
 			}
 			sequence = int(value)
+			sequenceSeen = true
 			_, _ = io.WriteString(canonical, strconv.Itoa(sequence))
 		case "sessions":
 			mapDigest, err = decodeCanonicalCheckpointSessionMap(
@@ -213,17 +226,17 @@ func decodeCanonicalCheckpointHead(
 			if err := decoder.Decode(&number); err != nil {
 				return db.ArtifactCheckpointHead{}, err
 			}
-			version, err := strconv.Atoi(number.String())
-			if err != nil || version < 1 {
+			parsedVersion, err := strconv.Atoi(number.String())
+			if err != nil || parsedVersion < 1 {
 				return db.ArtifactCheckpointHead{}, errors.New("checkpoint version is unsupported")
 			}
-			if version > checkpointFormatVersion {
-				futureVersion = version
-			}
-			if version < checkpointFormatVersion {
-				return db.ArtifactCheckpointHead{}, errors.New("checkpoint version is unsupported")
-			}
+			version = parsedVersion
+			versionSeen = true
 			_, _ = io.WriteString(canonical, strconv.Itoa(version))
+		default:
+			if err := writeCanonicalCheckpointValue(decoder, canonical, 0); err != nil {
+				return db.ArtifactCheckpointHead{}, err
+			}
 		}
 	}
 	token, err = decoder.Token()
@@ -238,6 +251,15 @@ func decodeCanonicalCheckpointHead(
 		return db.ArtifactCheckpointHead{}, err
 	}
 	_, _ = io.WriteString(canonical, "}\n")
+	if !originSeen {
+		return db.ArtifactCheckpointHead{}, errors.New("checkpoint origin is missing")
+	}
+	if !sequenceSeen {
+		return db.ArtifactCheckpointHead{}, errors.New("checkpoint sequence is missing")
+	}
+	if !versionSeen {
+		return db.ArtifactCheckpointHead{}, errors.New("checkpoint version is missing")
+	}
 	if fmt.Sprintf("cp-%010d.json", sequence) != name {
 		return db.ArtifactCheckpointHead{}, fmt.Errorf(
 			"checkpoint sequence identity mismatch: got %s", name,
@@ -248,9 +270,17 @@ func decodeCanonicalCheckpointHead(
 			"checkpoint stored identity differs from canonical encoding",
 		)
 	}
-	if futureVersion > 0 {
+	if version > checkpointFormatVersion {
 		return db.ArtifactCheckpointHead{}, fmt.Errorf(
-			"%w: checkpoint version %d", errFutureArtifactVersion, futureVersion,
+			"%w: checkpoint version %d", errFutureArtifactVersion, version,
+		)
+	}
+	if version < checkpointFormatVersion {
+		return db.ArtifactCheckpointHead{}, errors.New("checkpoint version is unsupported")
+	}
+	if !checkpointFieldsEqual(fields, expectedFields) {
+		return db.ArtifactCheckpointHead{}, errors.New(
+			"checkpoint current-version fields are not canonical",
 		)
 	}
 	return db.ArtifactCheckpointHead{
@@ -258,6 +288,106 @@ func decodeCanonicalCheckpointHead(
 		SessionMapSHA256: mapDigest, CheckpointSHA256: identity.SHA256,
 		CheckpointSize: identity.Size,
 	}, nil
+}
+
+func checkpointFieldsEqual(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for index := range want {
+		if got[index] != want[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func writeCanonicalCheckpointValue(
+	decoder *json.Decoder,
+	writer io.Writer,
+	depth int,
+) error {
+	const maxCheckpointJSONDepth = 1_000
+	if depth > maxCheckpointJSONDepth {
+		return errors.New("checkpoint JSON nesting is too deep")
+	}
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	switch value := token.(type) {
+	case nil:
+		_, _ = io.WriteString(writer, "null")
+	case bool:
+		_, _ = io.WriteString(writer, strconv.FormatBool(value))
+	case string:
+		encoded, _ := json.Marshal(value)
+		_, _ = writer.Write(encoded)
+	case json.Number:
+		_, _ = io.WriteString(writer, value.String())
+	case json.Delim:
+		switch value {
+		case '{':
+			_, _ = io.WriteString(writer, "{")
+			first := true
+			previous := ""
+			for decoder.More() {
+				keyToken, err := decoder.Token()
+				if err != nil {
+					return err
+				}
+				key, ok := keyToken.(string)
+				if !ok {
+					return errors.New("checkpoint object key is invalid")
+				}
+				if !first && key <= previous {
+					return errors.New("checkpoint object keys are not canonical")
+				}
+				if !first {
+					_, _ = io.WriteString(writer, ",")
+				}
+				encoded, _ := json.Marshal(key)
+				_, _ = writer.Write(encoded)
+				_, _ = io.WriteString(writer, ":")
+				if err := writeCanonicalCheckpointValue(
+					decoder, writer, depth+1,
+				); err != nil {
+					return err
+				}
+				first = false
+				previous = key
+			}
+			end, err := decoder.Token()
+			if err != nil || end != json.Delim('}') {
+				return errors.New("checkpoint object value is incomplete")
+			}
+			_, _ = io.WriteString(writer, "}")
+		case '[':
+			_, _ = io.WriteString(writer, "[")
+			first := true
+			for decoder.More() {
+				if !first {
+					_, _ = io.WriteString(writer, ",")
+				}
+				if err := writeCanonicalCheckpointValue(
+					decoder, writer, depth+1,
+				); err != nil {
+					return err
+				}
+				first = false
+			}
+			end, err := decoder.Token()
+			if err != nil || end != json.Delim(']') {
+				return errors.New("checkpoint array value is incomplete")
+			}
+			_, _ = io.WriteString(writer, "]")
+		default:
+			return errors.New("checkpoint JSON value is invalid")
+		}
+	default:
+		return errors.New("checkpoint JSON value is invalid")
+	}
+	return nil
 }
 
 func decodeCanonicalCheckpointSessionMap(

--- a/internal/artifact/export_checkpoint.go
+++ b/internal/artifact/export_checkpoint.go
@@ -112,6 +112,8 @@ func latestValidCheckpointHead(
 			candidate, decodeErr := decodeCanonicalCheckpointHead(
 				reader, origin, entry.Ref.Name, entry.Identity,
 			)
+			// Verify drains any bytes left unread after an early semantic
+			// decode failure before authenticating the complete stream.
 			verifyErr := reader.Verify()
 			closeErr := reader.Close()
 			if closeErr != nil && !errors.Is(closeErr, ErrArtifactCorrupt) {

--- a/internal/artifact/export_checkpoint.go
+++ b/internal/artifact/export_checkpoint.go
@@ -1,0 +1,340 @@
+package artifact
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+type artifactCheckpointSequenceDB interface {
+	GetArtifactCheckpointFloor(context.Context, string) (int, bool, error)
+	ReserveArtifactCheckpointSequence(context.Context, string, int) (int, error)
+}
+
+type checkpointFloorStore interface {
+	checkpointFloor(context.Context, string) (int, error)
+}
+
+func openStoreEntryIterator(
+	ctx context.Context, store ArtifactStore, origin string, kind Kind,
+) (EntryIterator, error) {
+	return store.Entries(ctx, origin, kind)
+}
+
+// statRecordedCheckpoint trusts the store's catalog identity, which is
+// established by verified immutable creation and checked again on normal
+// reads. Periodic unchanged export must remain constant work; full physical
+// verification belongs bootstrap and maintenance.
+func statRecordedCheckpoint(
+	ctx context.Context,
+	store ArtifactStore,
+	head db.ArtifactCheckpointHead,
+) (bool, error) {
+	ref, err := NewRef(head.Origin, KindCheckpoints,
+		fmt.Sprintf("cp-%010d.json", head.Sequence))
+	if err != nil {
+		return false, err
+	}
+	entry, err := store.Stat(ctx, ref)
+	if errors.Is(err, ErrArtifactNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("stating recorded artifact checkpoint: %w", err)
+	}
+	if entry.Identity.SHA256 != head.CheckpointSHA256 || entry.Identity.Size != head.CheckpointSize {
+		quarantineErr := store.Quarantine(ctx, ref, "recorded checkpoint identity mismatch")
+		return false, quarantineErr
+	}
+	return true, nil
+}
+
+func latestValidCheckpointHead(
+	ctx context.Context,
+	store ArtifactStore,
+	origin string,
+) (_ db.ArtifactCheckpointHead, _ bool, retErr error) {
+	var head db.ArtifactCheckpointHead
+	iterator, err := openStoreEntryIterator(ctx, store, origin, KindCheckpoints)
+	if err != nil {
+		return db.ArtifactCheckpointHead{}, false, fmt.Errorf("listing artifact checkpoints: %w", err)
+	}
+	defer func() { retErr = errors.Join(retErr, iterator.Close()) }()
+	for {
+		entries, nextErr := iterator.Next(ctx, checkpointFloorPageSize)
+		if nextErr != nil && !errors.Is(nextErr, io.EOF) {
+			return db.ArtifactCheckpointHead{}, false, fmt.Errorf("listing artifact checkpoints: %w", nextErr)
+		}
+		for _, entry := range entries {
+			sequence, err := checkpointSequence(entry.Ref.Name)
+			if err != nil || sequence <= head.Sequence {
+				continue
+			}
+			if entry.Identity.Size > checkpointDecodedLimit {
+				continue
+			}
+			_, reader, err := store.Open(ctx, entry.Ref)
+			if errors.Is(err, ErrArtifactNotFound) || errors.Is(err, ErrArtifactCorrupt) {
+				continue
+			}
+			if err != nil {
+				return db.ArtifactCheckpointHead{}, false,
+					fmt.Errorf("opening artifact checkpoint: %w", err)
+			}
+			candidate, decodeErr := decodeCanonicalCheckpointHead(
+				reader, origin, entry.Ref.Name, entry.Identity,
+			)
+			verifyErr := reader.Verify()
+			closeErr := reader.Close()
+			if closeErr != nil && !errors.Is(closeErr, ErrArtifactCorrupt) {
+				return db.ArtifactCheckpointHead{}, false,
+					fmt.Errorf("closing artifact checkpoint: %w", closeErr)
+			}
+			if verifyErr != nil && !errors.Is(verifyErr, ErrArtifactCorrupt) {
+				return db.ArtifactCheckpointHead{}, false,
+					fmt.Errorf("verifying artifact checkpoint: %w", verifyErr)
+			}
+			if errors.Is(decodeErr, errFutureArtifactVersion) {
+				return db.ArtifactCheckpointHead{}, false, decodeErr
+			}
+			if decodeErr != nil || verifyErr != nil || closeErr != nil {
+				continue
+			}
+			head = candidate
+		}
+		if errors.Is(nextErr, io.EOF) {
+			break
+		}
+	}
+	return head, head.Sequence > 0, nil
+}
+
+func decodeCanonicalCheckpointHead(
+	reader io.Reader,
+	origin string,
+	name string,
+	identity Identity,
+) (db.ArtifactCheckpointHead, error) {
+	decoder := json.NewDecoder(reader)
+	decoder.UseNumber()
+	token, err := decoder.Token()
+	if err != nil || token != json.Delim('{') {
+		return db.ArtifactCheckpointHead{}, errors.New("checkpoint is not a JSON object")
+	}
+	expectedFields := []string{"origin", "seq", "sessions", "v"}
+	var sequence int
+	var mapDigest string
+	for _, expected := range expectedFields {
+		token, err := decoder.Token()
+		if err != nil {
+			return db.ArtifactCheckpointHead{}, err
+		}
+		field, ok := token.(string)
+		if !ok || field != expected {
+			return db.ArtifactCheckpointHead{}, fmt.Errorf(
+				"checkpoint is not canonical: expected field %q", expected,
+			)
+		}
+		switch field {
+		case "origin":
+			var got string
+			if err := decoder.Decode(&got); err != nil {
+				return db.ArtifactCheckpointHead{}, err
+			}
+			if got != origin {
+				return db.ArtifactCheckpointHead{}, fmt.Errorf(
+					"checkpoint origin mismatch for %s: got %q", origin, got,
+				)
+			}
+		case "seq":
+			var number json.Number
+			if err := decoder.Decode(&number); err != nil {
+				return db.ArtifactCheckpointHead{}, err
+			}
+			value, err := strconv.ParseInt(number.String(), 10, 32)
+			if err != nil || value < 1 {
+				return db.ArtifactCheckpointHead{}, errors.New("checkpoint sequence is invalid")
+			}
+			sequence = int(value)
+		case "sessions":
+			mapDigest, err = decodeCanonicalCheckpointSessionMap(decoder, origin)
+			if err != nil {
+				return db.ArtifactCheckpointHead{}, err
+			}
+		case "v":
+			var number json.Number
+			if err := decoder.Decode(&number); err != nil {
+				return db.ArtifactCheckpointHead{}, err
+			}
+			version, err := strconv.Atoi(number.String())
+			if err != nil || version < 1 {
+				return db.ArtifactCheckpointHead{}, errors.New("checkpoint version is unsupported")
+			}
+			if version > checkpointFormatVersion {
+				return db.ArtifactCheckpointHead{}, fmt.Errorf(
+					"%w: checkpoint version %d", errFutureArtifactVersion, version,
+				)
+			}
+			if version != checkpointFormatVersion {
+				return db.ArtifactCheckpointHead{}, errors.New("checkpoint version is unsupported")
+			}
+		}
+	}
+	token, err = decoder.Token()
+	if err != nil || token != json.Delim('}') {
+		return db.ArtifactCheckpointHead{}, errors.New("checkpoint object is incomplete")
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return db.ArtifactCheckpointHead{}, errors.New("checkpoint has trailing JSON")
+		}
+		return db.ArtifactCheckpointHead{}, err
+	}
+	if fmt.Sprintf("cp-%010d.json", sequence) != name {
+		return db.ArtifactCheckpointHead{}, fmt.Errorf(
+			"checkpoint sequence identity mismatch: got %s", name,
+		)
+	}
+	return db.ArtifactCheckpointHead{
+		Origin: origin, Sequence: sequence,
+		SessionMapSHA256: mapDigest, CheckpointSHA256: identity.SHA256,
+		CheckpointSize: identity.Size,
+	}, nil
+}
+
+func decodeCanonicalCheckpointSessionMap(
+	decoder *json.Decoder,
+	origin string,
+) (string, error) {
+	token, err := decoder.Token()
+	if err != nil || token != json.Delim('{') {
+		return "", errors.New("checkpoint sessions is not an object")
+	}
+	hasher := sha256.New()
+	_, _ = io.WriteString(hasher, "{")
+	first := true
+	previous := ""
+	for decoder.More() {
+		token, err := decoder.Token()
+		if err != nil {
+			return "", err
+		}
+		gid, ok := token.(string)
+		if !ok || gid == "" || !strings.HasPrefix(gid, origin+"~") {
+			return "", errors.New("checkpoint session identity is invalid")
+		}
+		if !first && gid <= previous {
+			return "", errors.New("checkpoint sessions are not in canonical order")
+		}
+		var manifestHash string
+		if err := decoder.Decode(&manifestHash); err != nil {
+			return "", err
+		}
+		if err := validateHashHex(manifestHash); err != nil {
+			return "", fmt.Errorf("checkpoint manifest hash is invalid: %w", err)
+		}
+		if !first {
+			_, _ = io.WriteString(hasher, ",")
+		}
+		gidJSON, _ := json.Marshal(gid)
+		hashJSON, _ := json.Marshal(manifestHash)
+		_, _ = hasher.Write(gidJSON)
+		_, _ = io.WriteString(hasher, ":")
+		_, _ = hasher.Write(hashJSON)
+		first = false
+		previous = gid
+	}
+	token, err = decoder.Token()
+	if err != nil || token != json.Delim('}') {
+		return "", errors.New("checkpoint sessions object is incomplete")
+	}
+	_, _ = io.WriteString(hasher, "}\n")
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+// Export temporarily preserves the root-based API while canonical publication
+// migrates to ArtifactStore. The reference filesystem store is isolated from
+// the legacy wire tree, then encoded into that tree for existing transports.
+func reserveCheckpointSequenceFromStore(
+	ctx context.Context,
+	database artifactCheckpointSequenceDB,
+	store ArtifactStore,
+	origin string,
+) (_ int, retErr error) {
+	_, bootstrapped, err := database.GetArtifactCheckpointFloor(ctx, origin)
+	if err != nil {
+		return 0, fmt.Errorf("reading checkpoint floor for %s: %w", origin, err)
+	}
+	if bootstrapped {
+		sequence, err := database.ReserveArtifactCheckpointSequence(ctx, origin, 0)
+		if err != nil {
+			return 0, fmt.Errorf("reserving checkpoint sequence for %s: %w", origin, err)
+		}
+		return sequence, nil
+	}
+	observedFloor := 0
+	if observer, ok := store.(checkpointFloorStore); ok {
+		floor, err := observer.checkpointFloor(ctx, origin)
+		if err != nil {
+			return 0, fmt.Errorf("listing checkpoint floor for %s: %w", origin, err)
+		}
+		observedFloor = floor
+	} else {
+		iterator, err := openStoreEntryIterator(ctx, store, origin, KindCheckpoints)
+		if err != nil {
+			return 0, fmt.Errorf("listing checkpoint floor for %s: %w", origin, err)
+		}
+		defer func() { retErr = errors.Join(retErr, iterator.Close()) }()
+		for {
+			entries, nextErr := iterator.Next(ctx, checkpointFloorPageSize)
+			if nextErr != nil && !errors.Is(nextErr, io.EOF) {
+				return 0, fmt.Errorf("listing checkpoint floor for %s: %w", origin, nextErr)
+			}
+			for _, entry := range entries {
+				sequence, err := checkpointSequence(entry.Ref.Name)
+				if err != nil {
+					continue
+				}
+				observedFloor = max(observedFloor, sequence)
+			}
+			if errors.Is(nextErr, io.EOF) {
+				break
+			}
+		}
+	}
+	sequence, err := database.ReserveArtifactCheckpointSequence(ctx, origin, observedFloor)
+	if err != nil {
+		return 0, fmt.Errorf("reserving checkpoint sequence for %s: %w", origin, err)
+	}
+	return sequence, nil
+}
+
+func normalizeManifestSessionLocalState(sess *manifestSession) {
+	// Keep non-content, machine-local state out of the canonical manifest so a
+	// source-only change to it does not alter the content hash and trigger a
+	// re-import that clears the importer's local findings. secret_leak_count is
+	// import-discarded secret state (see rewriteForImport); local_modified_at is
+	// the local sync watermark, which import ignores (the importer stamps its
+	// own) -- and a secret rescan bumps both even when no exported message
+	// content changed. The file_* fields are source-file bookkeeping that
+	// import clears (see clearImportedSessionSourceState); a touch, move, or
+	// re-download of the source file changes them without changing any
+	// exported content.
+	sess.SecretLeakCount = 0
+	sess.LocalModifiedAt = nil
+	sess.FilePath = nil
+	sess.FileSize = nil
+	sess.FileMtime = nil
+	sess.FileInode = nil
+	sess.FileDevice = nil
+	sess.FileHash = nil
+}

--- a/internal/artifact/export_checkpoint.go
+++ b/internal/artifact/export_checkpoint.go
@@ -161,6 +161,7 @@ func decodeCanonicalCheckpointHead(
 	var sequence int
 	var version int
 	var mapDigest string
+	var sessionSchemaErr error
 	var originSeen bool
 	var sequenceSeen bool
 	var versionSeen bool
@@ -215,7 +216,7 @@ func decodeCanonicalCheckpointHead(
 			sequenceSeen = true
 			_, _ = io.WriteString(canonical, strconv.Itoa(sequence))
 		case "sessions":
-			mapDigest, err = decodeCanonicalCheckpointSessionMap(
+			mapDigest, sessionSchemaErr, err = decodeCanonicalCheckpointSessions(
 				decoder, origin, canonical,
 			)
 			if err != nil {
@@ -283,6 +284,9 @@ func decodeCanonicalCheckpointHead(
 			"checkpoint current-version fields are not canonical",
 		)
 	}
+	if sessionSchemaErr != nil {
+		return db.ArtifactCheckpointHead{}, sessionSchemaErr
+	}
 	return db.ArtifactCheckpointHead{
 		Origin: origin, Sequence: sequence,
 		SessionMapSHA256: mapDigest, CheckpointSHA256: identity.SHA256,
@@ -307,13 +311,22 @@ func writeCanonicalCheckpointValue(
 	writer io.Writer,
 	depth int,
 ) error {
-	const maxCheckpointJSONDepth = 1_000
-	if depth > maxCheckpointJSONDepth {
-		return errors.New("checkpoint JSON nesting is too deep")
-	}
 	token, err := decoder.Token()
 	if err != nil {
 		return err
+	}
+	return writeCanonicalCheckpointToken(decoder, writer, token, depth)
+}
+
+func writeCanonicalCheckpointToken(
+	decoder *json.Decoder,
+	writer io.Writer,
+	token json.Token,
+	depth int,
+) error {
+	const maxCheckpointJSONDepth = 1_000
+	if depth > maxCheckpointJSONDepth {
+		return errors.New("checkpoint JSON nesting is too deep")
 	}
 	switch value := token.(type) {
 	case nil:
@@ -390,14 +403,22 @@ func writeCanonicalCheckpointValue(
 	return nil
 }
 
-func decodeCanonicalCheckpointSessionMap(
+func decodeCanonicalCheckpointSessions(
 	decoder *json.Decoder,
 	origin string,
 	checkpointWriter io.Writer,
-) (string, error) {
+) (mapDigest string, schemaErr error, err error) {
 	token, err := decoder.Token()
-	if err != nil || token != json.Delim('{') {
-		return "", errors.New("checkpoint sessions is not an object")
+	if err != nil {
+		return "", nil, err
+	}
+	if token != json.Delim('{') {
+		if err := writeCanonicalCheckpointToken(
+			decoder, checkpointWriter, token, 0,
+		); err != nil {
+			return "", nil, err
+		}
+		return "", errors.New("checkpoint sessions is not an object"), nil
 	}
 	hasher := sha256.New()
 	writer := io.MultiWriter(hasher, checkpointWriter)
@@ -407,40 +428,54 @@ func decodeCanonicalCheckpointSessionMap(
 	for decoder.More() {
 		token, err := decoder.Token()
 		if err != nil {
-			return "", err
+			return "", nil, err
 		}
 		gid, ok := token.(string)
-		if !ok || gid == "" || !strings.HasPrefix(gid, origin+"~") {
-			return "", errors.New("checkpoint session identity is invalid")
+		if !ok {
+			return "", nil, errors.New("checkpoint object key is invalid")
 		}
 		if !first && gid <= previous {
-			return "", errors.New("checkpoint sessions are not in canonical order")
+			return "", nil, errors.New("checkpoint sessions are not in canonical order")
 		}
-		var manifestHash string
-		if err := decoder.Decode(&manifestHash); err != nil {
-			return "", err
+		if schemaErr == nil &&
+			(gid == "" || !strings.HasPrefix(gid, origin+"~")) {
+			schemaErr = errors.New("checkpoint session identity is invalid")
 		}
-		if err := validateHashHex(manifestHash); err != nil {
-			return "", fmt.Errorf("checkpoint manifest hash is invalid: %w", err)
+		valueToken, err := decoder.Token()
+		if err != nil {
+			return "", nil, err
+		}
+		if schemaErr == nil {
+			manifestHash, ok := valueToken.(string)
+			if !ok {
+				schemaErr = errors.New("checkpoint manifest hash is invalid")
+			} else if err := validateHashHex(manifestHash); err != nil {
+				schemaErr = fmt.Errorf(
+					"checkpoint manifest hash is invalid: %w", err,
+				)
+			}
 		}
 		if !first {
 			_, _ = io.WriteString(writer, ",")
 		}
 		gidJSON, _ := json.Marshal(gid)
-		hashJSON, _ := json.Marshal(manifestHash)
 		_, _ = writer.Write(gidJSON)
 		_, _ = io.WriteString(writer, ":")
-		_, _ = writer.Write(hashJSON)
+		if err := writeCanonicalCheckpointToken(
+			decoder, writer, valueToken, 1,
+		); err != nil {
+			return "", nil, err
+		}
 		first = false
 		previous = gid
 	}
 	token, err = decoder.Token()
 	if err != nil || token != json.Delim('}') {
-		return "", errors.New("checkpoint sessions object is incomplete")
+		return "", nil, errors.New("checkpoint sessions object is incomplete")
 	}
 	_, _ = io.WriteString(writer, "}")
 	_, _ = io.WriteString(hasher, "\n")
-	return hex.EncodeToString(hasher.Sum(nil)), nil
+	return hex.EncodeToString(hasher.Sum(nil)), schemaErr, nil
 }
 
 // Export temporarily preserves the root-based API while canonical publication

--- a/internal/artifact/export_checkpoint_test.go
+++ b/internal/artifact/export_checkpoint_test.go
@@ -1,0 +1,188 @@
+package artifact
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/docbank"
+)
+
+func TestCheckpointFloorBootstrapsFromLiveAndQuarantinedNodes(t *testing.T) {
+	_, store := newTestDocbankStore(t, docbank.Config{})
+	database := testDB(t)
+	origin := contractOrigin
+	for sequence := 1; sequence <= checkpointFloorPageSize+2; sequence++ {
+		body := fmt.Appendf(nil, `{"v":1,"origin":%q,"sequence":%d,"sessions":{}}`, origin, sequence)
+		createCheckpointBody(t, store, sequence, body)
+	}
+	quarantinedName := fmt.Sprintf("cp-%010d.json", checkpointFloorPageSize+2)
+	require.NoError(t, store.Quarantine(t.Context(),
+		requireContractRef(t, origin, KindCheckpoints, quarantinedName),
+		"test quarantine"))
+
+	sequence, err := reserveCheckpointSequenceFromStore(
+		t.Context(), database, store, origin,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 131, sequence)
+
+	// A fresh vault may report no sequence after reset or quarantine expiry, but
+	// the SQLite floor remains authoritative and may never be lowered.
+	_, emptyStore := newTestDocbankStore(t, docbank.Config{})
+	sequence, err = reserveCheckpointSequenceFromStore(
+		t.Context(), database, emptyStore, origin,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 132, sequence)
+
+	// If both SQLite and the vault are lost simultaneously, local prevention is
+	// impossible; peer common-checkpoint conflict handling is the final backstop.
+}
+
+func TestCheckpointFloorTraversesStoreOnlyBeforeBootstrap(t *testing.T) {
+	database := testDB(t)
+	store := &countingCheckpointFloorStore{floor: 40}
+
+	sequence, err := reserveCheckpointSequenceFromStore(
+		t.Context(), database, store, contractOrigin,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 41, sequence)
+	sequence, err = reserveCheckpointSequenceFromStore(
+		t.Context(), database, store, contractOrigin,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 42, sequence)
+	assert.Equal(t, 1, store.calls, "durable floor avoids repeated vault traversal")
+}
+
+type countingCheckpointFloorStore struct {
+	ArtifactStore
+	floor int
+	calls int
+}
+
+func (s *countingCheckpointFloorStore) checkpointFloor(context.Context, string) (int, error) {
+	s.calls++
+	return s.floor, nil
+}
+
+func TestExportCheckpointBootstrapStreamsLargeSessionMap(t *testing.T) {
+	sessions := make(map[string]string, 2000)
+	for i := range 2000 {
+		sessions[fmt.Sprintf("%s~session-%04d", contractOrigin, i)] = strings64("a")
+	}
+	body, err := canonicalJSON(checkpoint{
+		Version: checkpointFormatVersion, Origin: contractOrigin, Sequence: 42, Sessions: sessions,
+	})
+	require.NoError(t, err)
+	reader := &maxReadReader{reader: strings.NewReader(string(body))}
+	head, err := decodeCanonicalCheckpointHead(reader, contractOrigin,
+		"cp-0000000042.json", identityForBytes(t, body))
+	require.NoError(t, err)
+	mapBytes, err := canonicalJSON(sessions)
+	require.NoError(t, err)
+	assert.Equal(t, hashHex(mapBytes), head.SessionMapSHA256)
+	assert.Less(t, reader.max, len(body)/4,
+		"bootstrap must tokenize the checkpoint instead of reading its full body")
+}
+
+type maxReadReader struct {
+	reader io.Reader
+	max    int
+}
+
+func (r *maxReadReader) Read(p []byte) (int, error) {
+	if len(p) > r.max {
+		r.max = len(p)
+	}
+	return r.reader.Read(p)
+}
+
+// strings64 builds a 64-character stand-in for a sha256 hex digest.
+func strings64(ch string) string {
+	return strings.Repeat(ch, 64)
+}
+
+func TestDecodeSegmentRejectsAggregateNestedLimitsWithSmallLimits(t *testing.T) {
+	tests := []struct {
+		name      string
+		records   []segmentMessage
+		configure func(*artifactLimits)
+		wantError string
+	}{
+		{
+			name: "tool calls per segment",
+			records: []segmentMessage{
+				{ToolCalls: []segmentToolCall{{}}},
+				{ToolCalls: []segmentToolCall{{}}},
+			},
+			configure: func(limits *artifactLimits) {
+				limits.segmentToolCalls = 1
+			},
+			wantError: "segment tool call limit",
+		},
+		{
+			name: "result events per segment",
+			records: []segmentMessage{
+				{ToolCalls: []segmentToolCall{{ResultEvents: []segmentResultEvent{{}}}}},
+				{ToolCalls: []segmentToolCall{{ResultEvents: []segmentResultEvent{{}}}}},
+			},
+			configure: func(limits *artifactLimits) {
+				limits.segmentResultEvents = 1
+			},
+			wantError: "segment result event limit",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			limits := productionArtifactLimits()
+			tt.configure(&limits)
+			data := nestedSegmentData(t, tt.records...)
+
+			_, err := decodeSegmentWithLimits(data, limits)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantError)
+		})
+	}
+}
+
+func TestDecodeSegmentAcceptsCanonicalTrailingNewlineAndEmptySession(t *testing.T) {
+	record := nestedSegmentData(t, segmentMessage{})
+	tests := []struct {
+		name string
+		data []byte
+		want int
+	}{
+		{name: "canonical trailing newline", data: record, want: 1},
+		{name: "zero byte empty segment", data: nil, want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msgs, err := decodeSegment(tt.data)
+			require.NoError(t, err)
+			assert.Len(t, msgs, tt.want)
+		})
+	}
+}
+
+func nestedSegmentData(t *testing.T, records ...segmentMessage) []byte {
+	t.Helper()
+	var data bytes.Buffer
+	for ordinal := range records {
+		records[ordinal].Version = messageSegmentFormatVersion
+		records[ordinal].Ordinal = ordinal
+		records[ordinal].Role = "assistant"
+		encoded, err := canonicalJSON(records[ordinal])
+		require.NoError(t, err)
+		_, err = data.Write(encoded)
+		require.NoError(t, err)
+	}
+	return data.Bytes()
+}

--- a/internal/artifact/export_checkpoint_test.go
+++ b/internal/artifact/export_checkpoint_test.go
@@ -3,6 +3,7 @@ package artifact
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -149,6 +150,105 @@ func TestExportCheckpointBootstrapSkipsMalformedCheckpointBeforeEOF(t *testing.T
 	require.NoError(t, err)
 	require.True(t, ok)
 	assert.Equal(t, 2, head.Sequence)
+}
+
+func TestExportCheckpointBootstrapDefersOnlyValidFutureCheckpoint(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		corrupt    bool
+		wantFuture bool
+	}{
+		{
+			name:       "valid future checkpoint",
+			body:       `{"origin":"contract-a1b2c3","seq":1,"sessions":{},"v":2}` + "\n",
+			wantFuture: true,
+		},
+		{
+			name: "incomplete future checkpoint",
+			body: `{"origin":"contract-a1b2c3","seq":1,"sessions":{},"v":2`,
+		},
+		{
+			name: "future checkpoint with trailing JSON",
+			body: `{"origin":"contract-a1b2c3","seq":1,"sessions":{},"v":2}` + "\n{}",
+		},
+		{
+			name: "future checkpoint with mismatched filename sequence",
+			body: `{"origin":"contract-a1b2c3","seq":9,"sessions":{},"v":2}` + "\n",
+		},
+		{
+			name: "noncanonical future checkpoint",
+			body: `{"origin":"contract-a1b2c3","seq":1,"sessions":{},"v":2}`,
+		},
+		{
+			name:    "corrupt future checkpoint",
+			body:    `{"origin":"contract-a1b2c3","seq":1,"sessions":{},"v":2}` + "\n",
+			corrupt: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			database := testExportDB(t)
+			baseStore := newTestArtifactStore(t)
+			createCheckpointBody(t, baseStore, 1, []byte(tt.body))
+			var store ArtifactStore = baseStore
+			if tt.corrupt {
+				store = &checkpointVerifyErrorStore{
+					ArtifactStore: baseStore,
+					err:           ErrArtifactCorrupt,
+				}
+			}
+
+			result, err := ExportToStore(
+				t.Context(), database, store,
+				ExportOptions{Origin: contractOrigin},
+			)
+			if tt.wantFuture {
+				require.ErrorIs(t, err, errFutureArtifactVersion)
+				assert.False(t, result.CheckpointCreated)
+				page, listErr := firstStoreEntryPage(
+					t.Context(), baseStore, contractOrigin, KindCheckpoints, 10,
+				)
+				require.NoError(t, listErr)
+				assert.Len(t, page.Items, 1)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.True(t, result.CheckpointCreated)
+			assert.Equal(t, 2, result.CheckpointSequence)
+			head, ok, headErr := database.GetArtifactCheckpointHead(
+				t.Context(), contractOrigin,
+			)
+			require.NoError(t, headErr)
+			require.True(t, ok)
+			assert.Equal(t, 2, head.Sequence)
+		})
+	}
+}
+
+type verifyErrorReader struct {
+	VerifiedReader
+	err error
+}
+
+func (r *verifyErrorReader) Verify() error {
+	return errors.Join(r.VerifiedReader.Verify(), r.err)
+}
+
+type checkpointVerifyErrorStore struct {
+	ArtifactStore
+	err error
+}
+
+func (s *checkpointVerifyErrorStore) Open(
+	ctx context.Context, ref Ref,
+) (Entry, VerifiedReader, error) {
+	entry, reader, err := s.ArtifactStore.Open(ctx, ref)
+	if err != nil || ref.Kind != KindCheckpoints {
+		return entry, reader, err
+	}
+	return entry, &verifyErrorReader{VerifiedReader: reader, err: s.err}, nil
 }
 
 type maxReadReader struct {

--- a/internal/artifact/export_checkpoint_test.go
+++ b/internal/artifact/export_checkpoint_test.go
@@ -93,6 +93,43 @@ func TestExportCheckpointBootstrapStreamsLargeSessionMap(t *testing.T) {
 		"bootstrap must tokenize the checkpoint instead of reading its full body")
 }
 
+func TestExportCheckpointBootstrapSkipsNoncanonicalJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "whitespace",
+			body: `{ "origin":"contract-a1b2c3","seq":1,"sessions":{},"v":1}` + "\n",
+		},
+		{
+			name: "escaped field name",
+			body: `{"orig\u0069n":"contract-a1b2c3","seq":1,"sessions":{},"v":1}` + "\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			database := testExportDB(t)
+			store := newTestArtifactStore(t)
+			createCheckpointBody(t, store, 1, []byte(tt.body))
+
+			result, err := ExportToStore(
+				t.Context(), database, store,
+				ExportOptions{Origin: contractOrigin},
+			)
+			require.NoError(t, err)
+			assert.True(t, result.CheckpointCreated)
+			assert.Equal(t, 2, result.CheckpointSequence)
+			head, ok, err := database.GetArtifactCheckpointHead(
+				t.Context(), contractOrigin,
+			)
+			require.NoError(t, err)
+			require.True(t, ok)
+			assert.Equal(t, 2, head.Sequence)
+		})
+	}
+}
+
 type maxReadReader struct {
 	reader io.Reader
 	max    int

--- a/internal/artifact/export_checkpoint_test.go
+++ b/internal/artifact/export_checkpoint_test.go
@@ -171,9 +171,20 @@ func TestExportCheckpointBootstrapDefersOnlyValidFutureCheckpoint(t *testing.T) 
 			wantFuture: true,
 		},
 		{
+			name: "valid future checkpoint with changed sessions representation",
+			body: `{"origin":"contract-a1b2c3","seq":1,"sessions":[` +
+				`{"gid":"contract-a1b2c3~session","hash":"sha512:future"}],"v":2}` + "\n",
+			wantFuture: true,
+		},
+		{
 			name: "current checkpoint with added canonical field",
 			body: `{"metadata":{"codec":"v1"},"origin":"contract-a1b2c3",` +
 				`"seq":1,"sessions":{},"v":1}` + "\n",
+		},
+		{
+			name: "current checkpoint with changed sessions representation",
+			body: `{"origin":"contract-a1b2c3","seq":1,"sessions":[` +
+				`{"gid":"contract-a1b2c3~session","hash":"sha512:future"}],"v":1}` + "\n",
 		},
 		{
 			name: "incomplete future checkpoint",

--- a/internal/artifact/export_checkpoint_test.go
+++ b/internal/artifact/export_checkpoint_test.go
@@ -165,6 +165,17 @@ func TestExportCheckpointBootstrapDefersOnlyValidFutureCheckpoint(t *testing.T) 
 			wantFuture: true,
 		},
 		{
+			name: "valid future checkpoint with added canonical field",
+			body: `{"metadata":{"codec":"v2"},"origin":"contract-a1b2c3",` +
+				`"seq":1,"sessions":{},"v":2}` + "\n",
+			wantFuture: true,
+		},
+		{
+			name: "current checkpoint with added canonical field",
+			body: `{"metadata":{"codec":"v1"},"origin":"contract-a1b2c3",` +
+				`"seq":1,"sessions":{},"v":1}` + "\n",
+		},
+		{
 			name: "incomplete future checkpoint",
 			body: `{"origin":"contract-a1b2c3","seq":1,"sessions":{},"v":2`,
 		},

--- a/internal/artifact/export_checkpoint_test.go
+++ b/internal/artifact/export_checkpoint_test.go
@@ -130,6 +130,27 @@ func TestExportCheckpointBootstrapSkipsNoncanonicalJSON(t *testing.T) {
 	}
 }
 
+func TestExportCheckpointBootstrapSkipsMalformedCheckpointBeforeEOF(t *testing.T) {
+	database := testExportDB(t)
+	store := newTestArtifactStore(t)
+	body := append([]byte(`{"unexpected":`), deterministicDocbankBytes(1<<20)...)
+	createCheckpointBody(t, store, 1, body)
+
+	result, err := ExportToStore(
+		t.Context(), database, store,
+		ExportOptions{Origin: contractOrigin},
+	)
+	require.NoError(t, err)
+	assert.True(t, result.CheckpointCreated)
+	assert.Equal(t, 2, result.CheckpointSequence)
+	head, ok, err := database.GetArtifactCheckpointHead(
+		t.Context(), contractOrigin,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, 2, head.Sequence)
+}
+
 type maxReadReader struct {
 	reader io.Reader
 	max    int

--- a/internal/artifact/export_helpers_test.go
+++ b/internal/artifact/export_helpers_test.go
@@ -1,0 +1,69 @@
+package artifact
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+type queuedArtifactExportStore interface {
+	PendingArtifactExports(context.Context, int) ([]db.ArtifactExportQueueItem, error)
+	GetSessionFull(context.Context, string) (*db.Session, error)
+	GetAllMessages(context.Context, string) ([]db.Message, error)
+	GetUsageEvents(context.Context, string) ([]db.UsageEvent, error)
+}
+
+type queuedArtifactExport struct {
+	Item        db.ArtifactExportQueueItem
+	Session     *db.Session
+	Messages    []db.Message
+	UsageEvents []db.UsageEvent
+}
+
+// forEachQueuedArtifactExport loads only the bounded dirty batch and at most
+// one complete session body at a time. A missing session represents a pending
+// publication deletion and deliberately performs no message or usage reads.
+func forEachQueuedArtifactExport(
+	ctx context.Context,
+	store queuedArtifactExportStore,
+	limit int,
+	visit func(queuedArtifactExport) error,
+) error {
+	if visit == nil {
+		return errors.New("queued artifact export visitor is required")
+	}
+	items, err := store.PendingArtifactExports(ctx, limit)
+	if err != nil {
+		return fmt.Errorf("reading queued artifact exports: %w", err)
+	}
+	for _, item := range items {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		work := queuedArtifactExport{Item: item}
+		work.Session, err = store.GetSessionFull(ctx, item.SessionID)
+		if err != nil {
+			return fmt.Errorf("loading queued artifact session %s: %w", item.SessionID, err)
+		}
+		if work.Session != nil &&
+			(work.Session.Machine != "local" || work.Session.DeletedAt != nil) {
+			work.Session = nil
+		}
+		if work.Session != nil {
+			work.Messages, err = store.GetAllMessages(ctx, item.SessionID)
+			if err != nil {
+				return fmt.Errorf("loading queued artifact messages %s: %w", item.SessionID, err)
+			}
+			work.UsageEvents, err = store.GetUsageEvents(ctx, item.SessionID)
+			if err != nil {
+				return fmt.Errorf("loading queued artifact usage %s: %w", item.SessionID, err)
+			}
+		}
+		if err := visit(work); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/artifact/export_limits_test.go
+++ b/internal/artifact/export_limits_test.go
@@ -1,0 +1,545 @@
+package artifact
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/db"
+)
+
+func exportSessionToTestStoreWithLimits(
+	t *testing.T,
+	ctx context.Context,
+	database *db.DB,
+	store ArtifactStore,
+	origin string,
+	limits artifactLimits,
+) (string, bool, error) {
+	t.Helper()
+	sess, err := database.GetSessionFull(ctx, "sess-1")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	return exportClaimedSessionToStore(
+		ctx, database, store, origin, sess, limits,
+	)
+}
+
+// latestTestStoreManifest is a test-only stand-in for the reference's
+// latestTestStoreManifest, rewritten to use latestStoreCheckpointForTest
+// (export_test.go) instead of peer.go's latestStoreCheckpointSummary (out of
+// PR2 scope; see plan hazard 6).
+func latestTestStoreManifest(t *testing.T, store ArtifactStore, origin string) manifest {
+	t.Helper()
+	cp := latestStoreCheckpointForTest(t, store, origin)
+	hash := cp.Sessions[origin+"~sess-1"]
+	require.NotEmpty(t, hash)
+	ref, err := NewRef(origin, KindManifests, hash+".json")
+	require.NoError(t, err)
+	m, err := decodeManifestWithLimits(readContractArtifact(t, store, ref), productionArtifactLimits())
+	require.NoError(t, err)
+	return m
+}
+
+func testStoreManifestMessages(t *testing.T, store ArtifactStore, origin string, m manifest) []db.Message {
+	t.Helper()
+	var messages []db.Message
+	for _, hash := range m.Segments {
+		ref, err := NewRef(origin, KindSegments, hash+".ndjson")
+		require.NoError(t, err)
+		segment, err := decodeSegment(readContractArtifact(t, store, ref))
+		require.NoError(t, err)
+		messages = append(messages, segment...)
+	}
+	return messages
+}
+
+func assertNoPublishedAuthority(t *testing.T, store ArtifactStore, origin string) {
+	t.Helper()
+	for _, kind := range []Kind{KindManifests, KindCheckpoints} {
+		page, err := firstStoreEntryPage(t.Context(), store, origin, kind, maxArtifactListPageSize)
+		require.NoError(t, err)
+		assert.Empty(t, page.Items, "unexpected published %s artifact", kind)
+		require.Empty(t, page.Next)
+	}
+}
+
+func assertFinalizedExportRejection(
+	t *testing.T,
+	database *db.DB,
+	store ArtifactStore,
+	origin string,
+	result ExportResult,
+	wantError string,
+) {
+	t.Helper()
+	assert.Zero(t, result.ExportedSessions)
+	assert.Equal(t, 1, result.RejectedSessions)
+	checkpoint := latestStoreCheckpointForTest(t, store, origin)
+	assert.NotContains(t, checkpoint.Sessions, origin+"~sess-1")
+	rejection, ok, err := database.GetArtifactExportRejection(
+		t.Context(), "sess-1",
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Contains(t, rejection.Error, wantError)
+	pending, err := database.PendingArtifactExports(t.Context(), 10)
+	require.NoError(t, err)
+	assert.Empty(t, pending)
+}
+
+func TestExportClassifiesBoundedLoadLimit(t *testing.T) {
+	ctx := t.Context()
+	database := testExportDB(t)
+	store := newTestArtifactStore(t)
+	seedSession(t, database, "sess-1", "alpha")
+	require.NoError(t, database.ReplaceSessionMessages("sess-1", []db.Message{
+		{SessionID: "sess-1", Ordinal: 0, Role: "user", Content: "one"},
+		{SessionID: "sess-1", Ordinal: 1, Role: "assistant", Content: "two"},
+		{SessionID: "sess-1", Ordinal: 2, Role: "user", Content: "three"},
+	}))
+	limits := productionArtifactLimits()
+	limits.sessionMessages = 2
+
+	_, _, err := exportSessionToTestStoreWithLimits(
+		t, ctx, database, store, contractOrigin, limits,
+	)
+	require.ErrorIs(t, err, ErrArtifactExportRejected)
+	require.ErrorIs(t, err, db.ErrArtifactExportLimit)
+	assertNoPublishedArtifacts(t, store, contractOrigin)
+}
+
+func TestExportRejectsNestedAmplificationBeforePublication(t *testing.T) {
+	tests := []struct {
+		name      string
+		message   db.Message
+		wantError string
+	}{
+		{
+			name: "too many tool calls in one message",
+			message: db.Message{
+				ToolCalls: make([]db.ToolCall, 257),
+			},
+			wantError: "message tool call count exceeds 256",
+		},
+		{
+			name: "too many result events in one tool call",
+			message: db.Message{
+				ToolCalls: []db.ToolCall{{
+					ResultEvents: make([]db.ToolResultEvent, 1_025),
+				}},
+			},
+			wantError: "tool result event count exceeds 1024",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			database := testExportDB(t)
+			store := newTestArtifactStore(t)
+			origin := contractOrigin
+			seedSession(t, database, "sess-1", "alpha")
+			message := tt.message
+			message.SessionID = "sess-1"
+			message.Ordinal = 0
+			message.Role = "assistant"
+			require.NoError(t, database.ReplaceSessionMessages("sess-1", []db.Message{message}))
+
+			result, err := ExportToStore(
+				ctx, database, store, ExportOptions{Origin: origin, Full: true},
+			)
+			require.NoError(t, err)
+			assertFinalizedExportRejection(
+				t, database, store, origin, result, tt.wantError,
+			)
+		})
+	}
+}
+
+func TestExportChunksOnAggregateNestedLimitsWithSmallLimits(t *testing.T) {
+	tests := []struct {
+		name         string
+		resultEvents []db.ToolResultEvent
+		configure    func(*artifactLimits)
+	}{
+		{
+			name: "tool calls per segment",
+			configure: func(limits *artifactLimits) {
+				limits.segmentToolCalls = 2
+			},
+		},
+		{
+			name:         "result events per segment",
+			resultEvents: []db.ToolResultEvent{{EventIndex: 0}},
+			configure: func(limits *artifactLimits) {
+				limits.segmentResultEvents = 2
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			database := testExportDB(t)
+			store := newTestArtifactStore(t)
+			origin := contractOrigin
+			seedSession(t, database, "sess-1", "alpha")
+			msgs := make([]db.Message, 3)
+			for ordinal := range msgs {
+				msgs[ordinal] = db.Message{
+					SessionID: "sess-1",
+					Ordinal:   ordinal,
+					Role:      "assistant",
+					ToolCalls: []db.ToolCall{{
+						ResultEvents: tt.resultEvents,
+					}},
+				}
+			}
+			require.NoError(t, database.ReplaceSessionMessages("sess-1", msgs))
+			limits := productionArtifactLimits()
+			tt.configure(&limits)
+
+			manifestHash, changed, err := exportSessionToTestStoreWithLimits(
+				t, ctx, database, store, origin, limits,
+			)
+			require.NoError(t, err)
+			assert.True(t, changed)
+			manifestRef, err := NewRef(origin, KindManifests, manifestHash+".json")
+			require.NoError(t, err)
+			m, err := decodeManifestWithLimits(
+				readContractArtifact(t, store, manifestRef), productionArtifactLimits(),
+			)
+			require.NoError(t, err)
+			require.Len(t, m.Segments, 2)
+			got := testStoreManifestMessages(t, store, origin, m)
+			require.Len(t, got, 3)
+			for ordinal := range got {
+				assert.Equal(t, ordinal, got[ordinal].Ordinal)
+				require.Len(t, got[ordinal].ToolCalls, 1)
+				assert.Len(t, got[ordinal].ToolCalls[0].ResultEvents, len(tt.resultEvents))
+			}
+		})
+	}
+}
+
+func TestExportRejectsMessageThatCannotFitNestedSegmentLimits(t *testing.T) {
+	tests := []struct {
+		name      string
+		message   db.Message
+		configure func(*artifactLimits)
+		wantError string
+	}{
+		{
+			name: "tool calls cannot split across segments",
+			message: db.Message{
+				ToolCalls: []db.ToolCall{{}, {}},
+			},
+			configure: func(limits *artifactLimits) {
+				limits.segmentToolCalls = 1
+			},
+			wantError: "2 tool calls",
+		},
+		{
+			name: "one tool result history cannot split across segments",
+			message: db.Message{
+				ToolCalls: []db.ToolCall{{
+					ResultEvents: []db.ToolResultEvent{{EventIndex: 0}, {EventIndex: 1}},
+				}},
+			},
+			configure: func(limits *artifactLimits) {
+				limits.segmentResultEvents = 1
+			},
+			wantError: "2 result events",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			database := testExportDB(t)
+			store := newTestArtifactStore(t)
+			origin := contractOrigin
+			seedSession(t, database, "sess-1", "alpha")
+			message := tt.message
+			message.SessionID = "sess-1"
+			message.Ordinal = 0
+			message.Role = "assistant"
+			require.NoError(t, database.ReplaceSessionMessages("sess-1", []db.Message{message}))
+			limits := productionArtifactLimits()
+			tt.configure(&limits)
+
+			_, _, err := exportSessionToTestStoreWithLimits(
+				t, ctx, database, store, origin, limits,
+			)
+			require.Error(t, err)
+			require.ErrorIs(t, err, ErrArtifactExportRejected)
+			assert.Contains(t, err.Error(), "cannot fit in one segment")
+			assert.Contains(t, err.Error(), tt.wantError)
+			assertNoPublishedArtifacts(t, store, origin)
+		})
+	}
+}
+
+func TestExportRejectsSessionNestedLimitsBeforeWritingWithSmallLimits(t *testing.T) {
+	tests := []struct {
+		name      string
+		configure func(*artifactLimits)
+		wantError string
+	}{
+		{
+			name: "tool calls per session",
+			configure: func(limits *artifactLimits) {
+				limits.sessionToolCalls = 1
+			},
+			wantError: "tool call count exceeds 1",
+		},
+		{
+			name: "result events per session",
+			configure: func(limits *artifactLimits) {
+				limits.sessionResultEvents = 1
+			},
+			wantError: "result event count exceeds 1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			database := testExportDB(t)
+			store := newTestArtifactStore(t)
+			origin := contractOrigin
+			seedSession(t, database, "sess-1", "alpha")
+			msgs := make([]db.Message, 2)
+			for ordinal := range msgs {
+				msgs[ordinal] = db.Message{
+					SessionID: "sess-1",
+					Ordinal:   ordinal,
+					Role:      "assistant",
+					ToolCalls: []db.ToolCall{{
+						ResultEvents: []db.ToolResultEvent{{EventIndex: 0}},
+					}},
+				}
+			}
+			require.NoError(t, database.ReplaceSessionMessages("sess-1", msgs))
+			limits := productionArtifactLimits()
+			tt.configure(&limits)
+
+			_, _, err := exportSessionToTestStoreWithLimits(
+				t, ctx, database, store, origin, limits,
+			)
+			require.Error(t, err)
+			require.ErrorIs(t, err, ErrArtifactExportRejected)
+			assert.Contains(t, err.Error(), tt.wantError)
+			assertNoPublishedArtifacts(t, store, origin)
+		})
+	}
+}
+
+func TestExportChunksOnMessageRecordLimit(t *testing.T) {
+	ctx := context.Background()
+	database := testExportDB(t)
+	store := newTestArtifactStore(t)
+	origin := contractOrigin
+	seedSession(t, database, "sess-1", "alpha")
+	msgs := make([]db.Message, 4_097)
+	for i := range msgs {
+		msgs[i] = db.Message{SessionID: "sess-1", Ordinal: i, Role: "user"}
+	}
+	require.NoError(t, database.ReplaceSessionMessages("sess-1", msgs))
+
+	_, err := ExportToStore(ctx, database, store, ExportOptions{Origin: origin, Full: true})
+	require.NoError(t, err)
+	m := latestTestStoreManifest(t, store, origin)
+	require.Len(t, m.Segments, 2)
+	got := testStoreManifestMessages(t, store, origin, m)
+	assert.Len(t, got, 4_097)
+}
+
+func TestExportRejectsOversizedGeneratedManifestBeforePublication(t *testing.T) {
+	ctx := context.Background()
+	database := testExportDB(t)
+	store := newTestArtifactStore(t)
+	origin := contractOrigin
+	seedSession(t, database, "sess-1", "alpha", func(sess *db.Session) {
+		first := strings.Repeat("x", int(manifestDecodedLimit))
+		sess.FirstMessage = &first
+	})
+
+	result, err := ExportToStore(
+		ctx, database, store, ExportOptions{Origin: origin, Full: true},
+	)
+	require.NoError(t, err)
+	assertFinalizedExportRejection(
+		t, database, store, origin, result, "generated manifest exceeds",
+	)
+}
+
+func TestExportRejectsSessionMessageAmplificationBeforePublication(t *testing.T) {
+	ctx := context.Background()
+	database := testExportDB(t)
+	store := newTestArtifactStore(t)
+	origin := contractOrigin
+	seedSession(t, database, "sess-1", "alpha")
+	msgs := make([]db.Message, 32_769)
+	for i := range msgs {
+		msgs[i] = db.Message{SessionID: "sess-1", Ordinal: i, Role: "user"}
+	}
+	require.NoError(t, database.ReplaceSessionMessages("sess-1", msgs))
+
+	result, err := ExportToStore(
+		ctx, database, store, ExportOptions{Origin: origin, Full: true},
+	)
+	require.NoError(t, err)
+	assertFinalizedExportRejection(
+		t, database, store, origin, result, "message count exceeds 32768",
+	)
+}
+
+func TestExportRejectsUsageEventAmplificationBeforePublication(t *testing.T) {
+	ctx := context.Background()
+	database := testExportDB(t)
+	store := newTestArtifactStore(t)
+	origin := contractOrigin
+	seedSession(t, database, "sess-1", "alpha")
+	events := make([]db.UsageEvent, 32_769)
+	for i := range events {
+		events[i] = db.UsageEvent{
+			SessionID: "sess-1",
+			Source:    "fixture",
+			DedupKey:  fmt.Sprintf("usage-%d", i),
+		}
+	}
+	require.NoError(t, database.ReplaceSessionUsageEvents("sess-1", events))
+
+	result, err := ExportToStore(
+		ctx, database, store, ExportOptions{Origin: origin, Full: true},
+	)
+	require.NoError(t, err)
+	assertFinalizedExportRejection(
+		t, database, store, origin, result, "usage event count exceeds 32768",
+	)
+}
+
+func TestExportSessionRejectsAggregateLimitsBeforeWritingWithSmallLimits(t *testing.T) {
+	tests := []struct {
+		name      string
+		configure func(*artifactLimits)
+		wantError string
+	}{
+		{
+			name: "decoded bytes",
+			configure: func(limits *artifactLimits) {
+				limits.sessionDecodedBytes = 1
+			},
+			wantError: "session decoded byte limit",
+		},
+		{
+			name: "segment references",
+			configure: func(limits *artifactLimits) {
+				limits.segmentMessages = 1
+				limits.manifestSegments = 1
+			},
+			wantError: "segment reference limit",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			database := testExportDB(t)
+			store := newTestArtifactStore(t)
+			origin := contractOrigin
+			seedSession(t, database, "sess-1", "alpha")
+			limits := productionArtifactLimits()
+			tt.configure(&limits)
+
+			sess, err := database.GetSessionFull(ctx, "sess-1")
+			require.NoError(t, err)
+			require.NotNil(t, sess)
+			messages, err := database.GetAllMessages(ctx, "sess-1")
+			require.NoError(t, err)
+			_, _, err = exportLoadedSessionToStore(
+				ctx, store, origin, sess, messages, nil, limits,
+			)
+			require.Error(t, err)
+			require.ErrorIs(t, err, ErrArtifactExportRejected)
+			assert.Contains(t, err.Error(), tt.wantError)
+			assertNoPublishedAuthority(t, store, origin)
+		})
+	}
+}
+
+func TestExportChunksLargeMultiMessageSessionInOrder(t *testing.T) {
+	ctx := context.Background()
+	database := testExportDB(t)
+	store := newTestArtifactStore(t)
+	origin := contractOrigin
+	seedSession(t, database, "sess-1", "alpha")
+	content := strings.Repeat("x", 9<<20)
+	msgs := make([]db.Message, 4)
+	for i := range msgs {
+		msgs[i] = db.Message{
+			SessionID:     "sess-1",
+			Ordinal:       i,
+			Role:          "user",
+			Content:       content,
+			ContentLength: len(content),
+		}
+	}
+	require.NoError(t, database.ReplaceSessionMessages("sess-1", msgs))
+
+	exportResult, err := ExportToStore(ctx, database, store, ExportOptions{Origin: origin, Full: true})
+	require.NoError(t, err)
+	assert.Equal(t, 1, exportResult.ExportedSessions)
+	m := latestTestStoreManifest(t, store, origin)
+	require.Len(t, m.Segments, 2)
+
+	got := testStoreManifestMessages(t, store, origin, m)
+	require.Len(t, got, 4)
+	for i := range got {
+		assert.Equal(t, i, got[i].Ordinal)
+		assert.Equal(t, content, got[i].Content)
+	}
+}
+
+func TestExportRejectsSingleEncodedRecordAboveReadableLimit(t *testing.T) {
+	ctx := context.Background()
+	database := testExportDB(t)
+	store := newTestArtifactStore(t)
+	origin := contractOrigin
+	seedSession(t, database, "sess-1", "alpha")
+	content := strings.Repeat("x", 64<<20)
+	require.NoError(t, database.ReplaceSessionMessages("sess-1", []db.Message{{
+		SessionID:     "sess-1",
+		Ordinal:       0,
+		Role:          "user",
+		Content:       content,
+		ContentLength: len(content),
+	}}))
+
+	result, err := ExportToStore(
+		ctx, database, store, ExportOptions{Origin: origin, Full: true},
+	)
+	require.NoError(t, err)
+	assertFinalizedExportRejection(
+		t, database, store, origin, result,
+		"encoded message record at ordinal 0 exceeds 67108864-byte readable limit",
+	)
+}
+
+func TestExportPreservesSmallSingleSegmentHash(t *testing.T) {
+	ctx := context.Background()
+	database := testExportDB(t)
+	store := newTestArtifactStore(t)
+	origin := contractOrigin
+	seedSession(t, database, "sess-1", "alpha")
+	msgs, err := database.GetAllMessages(ctx, "sess-1")
+	require.NoError(t, err)
+	segmentData, err := encodeSegment(canonicalMessages(msgs))
+	require.NoError(t, err)
+	wantHash := hashHex(segmentData)
+
+	_, err = ExportToStore(ctx, database, store, ExportOptions{Origin: origin, Full: true})
+	require.NoError(t, err)
+	m := latestTestStoreManifest(t, store, origin)
+	assert.Equal(t, []string{wantHash}, m.Segments)
+}

--- a/internal/artifact/export_test.go
+++ b/internal/artifact/export_test.go
@@ -620,6 +620,26 @@ func TestExportKeepsAgentSessionNameSeparateFromUserDisplayName(t *testing.T) {
 	assert.Equal(t, agentName, *published.SessionName)
 }
 
+func TestExportToStorePublishesConfiguredHostnameSession(t *testing.T) {
+	database := testExportDB(t)
+	require.NoError(t, database.SetSyncState(
+		"artifact_local_machine_name", "workstation.example",
+	))
+	seedSession(t, database, "sess-hostname", "alpha", func(sess *db.Session) {
+		sess.Machine = "workstation.example"
+	})
+	store := newTestArtifactStore(t)
+
+	result, err := ExportToStore(
+		t.Context(), database, store,
+		ExportOptions{Origin: contractOrigin, Full: true},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.ExportedSessions)
+	checkpoint := latestStoreCheckpointForTest(t, store, contractOrigin)
+	assert.Contains(t, checkpoint.Sessions, contractOrigin+"~sess-hostname")
+}
+
 func TestExportToStoreFullRepairsMissingDependencyWithoutNewCheckpoint(t *testing.T) {
 	database := testExportDB(t)
 	seedSession(t, database, "sess-1", "alpha")

--- a/internal/artifact/export_test.go
+++ b/internal/artifact/export_test.go
@@ -711,8 +711,69 @@ func TestExportToStoreChangedBatchDoesNotScanCheckpointHistory(t *testing.T) {
 	assert.Equal(t, 2, result.CheckpointSequence)
 	assert.Zero(t, store.lists,
 		"a recorded pre-apply head avoids checkpoint-history traversal")
-	assert.Zero(t, store.opens,
-		"normal changed export does not read an old checkpoint body")
+	assert.Equal(t, 1, store.opens,
+		"normal changed export validates only the recorded checkpoint body")
+}
+
+func TestExportToStoreDirtyBatchDefersRecordedFutureCheckpoint(t *testing.T) {
+	database := testExportDB(t)
+	seedSession(t, database, "sess-1", "alpha")
+	filesystem, err := newProtocolTestStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, filesystem.Close()) })
+	_, err = ExportToStore(t.Context(), database, filesystem, ExportOptions{
+		Origin: contractOrigin,
+	})
+	require.NoError(t, err)
+	currentHead, ok, err := database.GetArtifactCheckpointHead(
+		t.Context(), contractOrigin,
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	futureSequence, err := database.ReserveArtifactCheckpointSequence(
+		t.Context(), contractOrigin, currentHead.Sequence,
+	)
+	require.NoError(t, err)
+	require.Equal(t, 2, futureSequence)
+	futureBody := []byte(
+		`{"origin":"contract-a1b2c3","seq":2,"sessions":[` +
+			`{"gid":"contract-a1b2c3~session","hash":"sha512:future"}],"v":2}` + "\n",
+	)
+	futureIdentity := identityForBytes(t, futureBody)
+	createCheckpointBody(t, filesystem, futureSequence, futureBody)
+	require.NoError(t, database.RecordArtifactCheckpointHead(
+		t.Context(), db.ArtifactCheckpointHead{
+			Origin: contractOrigin, Sequence: futureSequence,
+			PublicationRevision: currentHead.PublicationRevision,
+			SessionMapSHA256:    strings64("b"),
+			CheckpointSHA256:    futureIdentity.SHA256,
+			CheckpointSize:      futureIdentity.Size,
+		}, nil,
+	))
+	require.NoError(t, database.ReplaceSessionMessages("sess-1", []db.Message{{
+		SessionID: "sess-1", Ordinal: 0, Role: "user", Content: "changed",
+	}}))
+
+	result, err := ExportToStore(t.Context(), database, filesystem, ExportOptions{
+		Origin: contractOrigin,
+	})
+	require.ErrorIs(t, err, errFutureArtifactVersion)
+	assert.False(t, result.CheckpointCreated)
+	result, err = ExportToStore(t.Context(), database, filesystem, ExportOptions{
+		Origin: contractOrigin,
+	})
+	require.ErrorIs(t, err, errFutureArtifactVersion)
+	assert.False(t, result.CheckpointCreated)
+	head, ok, headErr := database.GetArtifactCheckpointHead(t.Context(), contractOrigin)
+	require.NoError(t, headErr)
+	require.True(t, ok)
+	assert.Equal(t, futureSequence, head.Sequence)
+	page, listErr := firstStoreEntryPage(
+		t.Context(), filesystem, contractOrigin, KindCheckpoints, 10,
+	)
+	require.NoError(t, listErr)
+	assert.Len(t, page.Items, 2)
 }
 
 func TestExportToStoreUnchangedCheckpointUsesCatalogIdentityOnly(t *testing.T) {

--- a/internal/artifact/export_test.go
+++ b/internal/artifact/export_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -431,6 +432,40 @@ func TestExportContinuesPastInvalidTokenUsage(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok)
 	assert.Contains(t, rejection.Error, "encoding message segment at ordinal 0")
+}
+
+func TestExportContinuesPastInvalidManifestValue(t *testing.T) {
+	database := testExportDB(t)
+	store := newTestArtifactStore(t)
+	seedSession(t, database, "invalid", "alpha")
+	require.NoError(t, database.UpdateSessionSignals(
+		"invalid", db.SessionSignalUpdate{
+			ContextPressureMax: new(math.Inf(1)),
+		},
+	))
+	stored, err := database.GetSessionFull(t.Context(), "invalid")
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	require.NotNil(t, stored.ContextPressureMax)
+	require.True(t, math.IsInf(*stored.ContextPressureMax, 1))
+	seedSession(t, database, "valid", "alpha")
+
+	result, err := ExportToStore(
+		t.Context(), database, store, ExportOptions{Origin: contractOrigin},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.ExportedSessions)
+	assert.Equal(t, 1, result.RejectedSessions)
+	checkpoint := latestStoreCheckpointForTest(t, store, contractOrigin)
+	assert.NotContains(t, checkpoint.Sessions, contractOrigin+"~invalid")
+	assert.Contains(t, checkpoint.Sessions, contractOrigin+"~valid")
+	pending, err := database.PendingArtifactExports(t.Context(), 10)
+	require.NoError(t, err)
+	assert.Empty(t, pending)
+	rejection, ok, err := database.GetArtifactExportRejection(t.Context(), "invalid")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Contains(t, rejection.Error, "encoding manifest for invalid")
 }
 
 func TestExportTransientFailureDoesNotReject(t *testing.T) {

--- a/internal/artifact/export_test.go
+++ b/internal/artifact/export_test.go
@@ -1,0 +1,1669 @@
+package artifact
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/db"
+)
+
+// exportOnlyKinds mirrors transport.go's package-wide transportKinds (out of
+// PR2 scope) restricted to the kinds ExportToStore can create, so tests can
+// assert nothing was published without pulling in transport.go.
+var exportOnlyKinds = []Kind{KindSegments, KindManifests, KindCheckpoints}
+
+func assertNoPublishedArtifacts(t *testing.T, store ArtifactStore, origin string) {
+	t.Helper()
+	for _, kind := range exportOnlyKinds {
+		page, err := firstStoreEntryPage(t.Context(), store, origin, kind, maxArtifactListPageSize)
+		require.NoError(t, err)
+		assert.Empty(t, page.Items, "unexpected published %s artifact", kind)
+		require.Empty(t, page.Next)
+	}
+}
+
+// testExportDB returns a database with an artifact origin already
+// established (plan deviation 1: the queue triggers and enqueue hooks only
+// fire once an origin row exists) so sessions seeded afterward populate the
+// export queue as export tests expect. Origin-gating itself is exercised
+// directly by origin_test.go's own tests against a bare testDB.
+func testExportDB(t *testing.T) *db.DB {
+	t.Helper()
+	database := testDB(t)
+	require.NoError(t, database.SetSyncState(originStateKey, contractOrigin))
+	return database
+}
+
+// latestStoreCheckpointForTest locates the highest-sequence checkpoint for
+// origin and decodes its full session map. It stands in for peer.go's
+// latestStoreCheckpointSummary (out of PR2 scope; see plan hazard 6) so
+// export tests can assert on published manifest hashes without pulling in
+// peer.go.
+func latestStoreCheckpointForTest(t *testing.T, store ArtifactStore, origin string) *checkpoint {
+	t.Helper()
+	ctx := t.Context()
+	page, err := firstStoreEntryPage(ctx, store, origin, KindCheckpoints, maxArtifactListPageSize)
+	require.NoError(t, err)
+	require.NotEmpty(t, page.Items, "no checkpoints published for %s", origin)
+
+	var winner Ref
+	winnerSeq := 0
+	for _, entry := range page.Items {
+		_, reader, err := store.Open(ctx, entry.Ref)
+		require.NoError(t, err)
+		head, decodeErr := decodeCanonicalCheckpointHead(reader, origin, entry.Ref.Name, entry.Identity)
+		require.NoError(t, reader.Verify())
+		require.NoError(t, reader.Close())
+		require.NoError(t, decodeErr)
+		if head.Sequence > winnerSeq {
+			winnerSeq = head.Sequence
+			winner = entry.Ref
+		}
+	}
+	require.Positive(t, winnerSeq)
+
+	var cp checkpoint
+	require.NoError(t, json.Unmarshal(readContractArtifact(t, store, winner), &cp))
+	return &cp
+}
+
+type countingQueuedExportStore struct {
+	database     *db.DB
+	queueQueries int
+	sessionLoads int
+	messageLoads int
+	usageLoads   int
+}
+
+func (s *countingQueuedExportStore) PendingArtifactExports(
+	ctx context.Context, limit int,
+) ([]db.ArtifactExportQueueItem, error) {
+	s.queueQueries++
+	return s.database.PendingArtifactExports(ctx, limit)
+}
+
+func (s *countingQueuedExportStore) GetSessionFull(
+	ctx context.Context, id string,
+) (*db.Session, error) {
+	s.sessionLoads++
+	return s.database.GetSessionFull(ctx, id)
+}
+
+func (s *countingQueuedExportStore) GetAllMessages(
+	ctx context.Context, id string,
+) ([]db.Message, error) {
+	s.messageLoads++
+	return s.database.GetAllMessages(ctx, id)
+}
+
+func (s *countingQueuedExportStore) GetUsageEvents(
+	ctx context.Context, id string,
+) ([]db.UsageEvent, error) {
+	s.usageLoads++
+	return s.database.GetUsageEvents(ctx, id)
+}
+
+type countingCanonicalExportDB struct {
+	*db.DB
+	sessionLoads int
+	boundedLoads int
+	messageLoads int
+	usageLoads   int
+}
+
+func (s *countingCanonicalExportDB) GetSessionFull(
+	ctx context.Context, id string,
+) (*db.Session, error) {
+	s.sessionLoads++
+	return s.DB.GetSessionFull(ctx, id)
+}
+
+func (s *countingCanonicalExportDB) LoadArtifactExportData(
+	ctx context.Context, id string, limits db.ArtifactExportLoadLimits,
+) (db.ArtifactExportData, error) {
+	s.boundedLoads++
+	return s.DB.LoadArtifactExportData(ctx, id, limits)
+}
+
+func (s *countingCanonicalExportDB) GetAllMessages(
+	ctx context.Context, id string,
+) ([]db.Message, error) {
+	s.messageLoads++
+	return s.DB.GetAllMessages(ctx, id)
+}
+
+func (s *countingCanonicalExportDB) GetUsageEvents(
+	ctx context.Context, id string,
+) ([]db.UsageEvent, error) {
+	s.usageLoads++
+	return s.DB.GetUsageEvents(ctx, id)
+}
+
+type recordedArtifactCreate struct {
+	Ref      Ref
+	Identity Identity
+	Created  bool
+}
+
+type recordingArtifactStore struct {
+	ArtifactStore
+	creates []recordedArtifactCreate
+}
+
+func (s *recordingArtifactStore) Create(
+	ctx context.Context,
+	ref Ref,
+	identity Identity,
+	mediaType string,
+	body io.Reader,
+) (CreateResult, error) {
+	result, err := s.ArtifactStore.Create(ctx, ref, identity, mediaType, body)
+	if err == nil {
+		s.creates = append(s.creates, recordedArtifactCreate{
+			Ref: ref, Identity: identity, Created: result.Created,
+		})
+	}
+	return result, err
+}
+
+type checkpointReadCountingStore struct {
+	ArtifactStore
+	lists int
+	opens int
+}
+
+func (s *checkpointReadCountingStore) Entries(
+	ctx context.Context, origin string, kind Kind,
+) (EntryIterator, error) {
+	if kind == Kind(KindCheckpoints) {
+		s.lists++
+	}
+	return s.ArtifactStore.Entries(ctx, origin, kind)
+}
+
+func (s *checkpointReadCountingStore) Open(
+	ctx context.Context, ref Ref,
+) (Entry, VerifiedReader, error) {
+	if ref.Kind == Kind(KindCheckpoints) {
+		s.opens++
+	}
+	return s.ArtifactStore.Open(ctx, ref)
+}
+
+type catalogCheckpointStore struct {
+	ArtifactStore
+	entry     Entry
+	statCalls int
+	openCalls int
+}
+
+func (s *catalogCheckpointStore) Stat(context.Context, Ref) (Entry, error) {
+	s.statCalls++
+	return s.entry, nil
+}
+
+func (s *catalogCheckpointStore) Open(
+	context.Context, Ref,
+) (Entry, VerifiedReader, error) {
+	s.openCalls++
+	return Entry{}, nil, errors.New("checkpoint body must not be opened")
+}
+
+type checkpointStatOverrideStore struct {
+	ArtifactStore
+	identity *Identity
+	err      error
+}
+
+func (s *checkpointStatOverrideStore) Stat(ctx context.Context, ref Ref) (Entry, error) {
+	if ref.Kind == Kind(KindCheckpoints) {
+		if s.err != nil {
+			return Entry{}, s.err
+		}
+		if s.identity != nil {
+			return Entry{Ref: ref, Identity: *s.identity}, nil
+		}
+	}
+	return s.ArtifactStore.Stat(ctx, ref)
+}
+
+type hiddenCheckpointHeadDB struct {
+	*db.DB
+}
+
+func (s *hiddenCheckpointHeadDB) GetArtifactCheckpointHead(
+	context.Context, string,
+) (db.ArtifactCheckpointHead, bool, error) {
+	return db.ArtifactCheckpointHead{}, false, nil
+}
+
+type closeErrorVerifiedReader struct {
+	VerifiedReader
+	err error
+}
+
+func (r *closeErrorVerifiedReader) Close() error {
+	return errors.Join(r.VerifiedReader.Close(), r.err)
+}
+
+type checkpointCloseErrorStore struct {
+	ArtifactStore
+	err error
+}
+
+func (s *checkpointCloseErrorStore) Open(
+	ctx context.Context, ref Ref,
+) (Entry, VerifiedReader, error) {
+	entry, reader, err := s.ArtifactStore.Open(ctx, ref)
+	if err != nil || ref.Kind != Kind(KindCheckpoints) {
+		return entry, reader, err
+	}
+	return entry, &closeErrorVerifiedReader{VerifiedReader: reader, err: s.err}, nil
+}
+
+type checkpointOpenFailureStore struct {
+	ArtifactStore
+	err error
+}
+
+func (s *checkpointOpenFailureStore) Open(
+	ctx context.Context, ref Ref,
+) (Entry, VerifiedReader, error) {
+	if ref.Kind == Kind(KindCheckpoints) {
+		return Entry{}, nil, s.err
+	}
+	return s.ArtifactStore.Open(ctx, ref)
+}
+
+type failingArtifactStore struct {
+	ArtifactStore
+	failKind Kind
+	failErr  error
+	failed   bool
+	calls    []Kind
+}
+
+func (s *failingArtifactStore) Create(
+	ctx context.Context,
+	ref Ref,
+	identity Identity,
+	mediaType string,
+	body io.Reader,
+) (CreateResult, error) {
+	s.calls = append(s.calls, ref.Kind)
+	if !s.failed && ref.Kind == s.failKind {
+		s.failed = true
+		return CreateResult{}, s.failErr
+	}
+	return s.ArtifactStore.Create(ctx, ref, identity, mediaType, body)
+}
+
+type staleClaimExportDB struct {
+	*db.DB
+	once sync.Once
+}
+
+func (s *staleClaimExportDB) ApplyArtifactPublicationChanges(
+	ctx context.Context,
+	origin string,
+	changes []db.ArtifactPublicationChange,
+) (int64, bool, error) {
+	s.once.Do(func() {
+		_ = s.ReplaceSessionMessages("sess-1", []db.Message{{
+			SessionID: "sess-1", Ordinal: 0, Role: "user", Content: "newer",
+		}})
+	})
+	return s.DB.ApplyArtifactPublicationChanges(ctx, origin, changes)
+}
+
+type mutateAfterCheckpointStore struct {
+	ArtifactStore
+	database *db.DB
+	session  string
+	once     sync.Once
+}
+
+func (s *mutateAfterCheckpointStore) Create(
+	ctx context.Context,
+	ref Ref,
+	identity Identity,
+	mediaType string,
+	body io.Reader,
+) (CreateResult, error) {
+	result, err := s.ArtifactStore.Create(ctx, ref, identity, mediaType, body)
+	if err == nil && ref.Kind == Kind(KindCheckpoints) {
+		s.once.Do(func() {
+			sessionID := s.session
+			if sessionID == "" {
+				sessionID = "sess-1"
+			}
+			_ = s.database.ReplaceSessionMessages(sessionID, []db.Message{{
+				SessionID: sessionID, Ordinal: 0, Role: "user", Content: "newest",
+			}})
+		})
+	}
+	return result, err
+}
+
+func deterministicRejectionBatch(
+	t *testing.T,
+) (*db.DB, ArtifactStore, artifactLimits) {
+	t.Helper()
+	database := testExportDB(t)
+	filesystem, err := newProtocolTestStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, filesystem.Close()) })
+
+	seedSession(t, database, "rejected", "alpha")
+	_, err = ExportToStore(t.Context(), database, filesystem, ExportOptions{
+		Origin: contractOrigin, SessionIDs: []string{"rejected"},
+	})
+	require.NoError(t, err)
+	require.NoError(t, database.ReplaceSessionMessages("rejected", []db.Message{
+		{SessionID: "rejected", Ordinal: 0, Role: "user", Content: "one"},
+		{SessionID: "rejected", Ordinal: 1, Role: "assistant", Content: "two"},
+		{SessionID: "rejected", Ordinal: 2, Role: "user", Content: "three"},
+	}))
+	seedSession(t, database, "valid", "alpha")
+	limits := productionArtifactLimits()
+	limits.sessionMessages = 2
+	return database, filesystem, limits
+}
+
+func TestExportContinuesPastDeterministicRejection(t *testing.T) {
+	database, store, limits := deterministicRejectionBatch(t)
+
+	result, err := exportToStoreWithLimits(
+		t.Context(), database, store,
+		ExportOptions{Origin: contractOrigin}, limits,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.ExportedSessions)
+	assert.Equal(t, 1, result.RejectedSessions)
+	checkpoint := latestStoreCheckpointForTest(t, store, contractOrigin)
+	assert.NotContains(t, checkpoint.Sessions, contractOrigin+"~rejected")
+	assert.Contains(t, checkpoint.Sessions, contractOrigin+"~valid")
+	pending, err := database.PendingArtifactExports(t.Context(), 10)
+	require.NoError(t, err)
+	assert.Empty(t, pending)
+	rejection, ok, err := database.GetArtifactExportRejection(
+		t.Context(), "rejected",
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Contains(t, rejection.Error, "message count exceeds 2")
+}
+
+func TestExportContinuesPastInvalidTokenUsage(t *testing.T) {
+	database := testExportDB(t)
+	store := newTestArtifactStore(t)
+	seedSession(t, database, "invalid", "alpha")
+	require.NoError(t, database.ReplaceSessionMessages("invalid", []db.Message{{
+		SessionID: "invalid", Ordinal: 0, Role: "assistant",
+		Content: "bad usage", TokenUsage: json.RawMessage(`{"input_tokens":`),
+	}}))
+	seedSession(t, database, "valid", "alpha")
+
+	result, err := ExportToStore(
+		t.Context(), database, store, ExportOptions{Origin: contractOrigin},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.ExportedSessions)
+	assert.Equal(t, 1, result.RejectedSessions)
+	checkpoint := latestStoreCheckpointForTest(t, store, contractOrigin)
+	assert.NotContains(t, checkpoint.Sessions, contractOrigin+"~invalid")
+	assert.Contains(t, checkpoint.Sessions, contractOrigin+"~valid")
+	pending, err := database.PendingArtifactExports(t.Context(), 10)
+	require.NoError(t, err)
+	assert.Empty(t, pending)
+	rejection, ok, err := database.GetArtifactExportRejection(t.Context(), "invalid")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Contains(t, rejection.Error, "encoding message segment at ordinal 0")
+}
+
+func TestExportTransientFailureDoesNotReject(t *testing.T) {
+	database := testExportDB(t)
+	seedSession(t, database, "rejected", "alpha")
+	seedSession(t, database, "valid", "alpha")
+	filesystem, err := newProtocolTestStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, filesystem.Close()) })
+	failure := errors.New("injected transient store failure")
+	store := &failingArtifactStore{
+		ArtifactStore: filesystem, failKind: Kind(KindSegments), failErr: failure,
+	}
+
+	_, err = ExportToStore(t.Context(), database, store, ExportOptions{
+		Origin: contractOrigin,
+	})
+	require.ErrorIs(t, err, failure)
+	for _, sessionID := range []string{"rejected", "valid"} {
+		_, ok, rejectionErr := database.GetArtifactExportRejection(
+			t.Context(), sessionID,
+		)
+		require.NoError(t, rejectionErr)
+		assert.False(t, ok)
+	}
+	pending, err := database.PendingArtifactExports(t.Context(), 10)
+	require.NoError(t, err)
+	assert.Len(t, pending, 2)
+}
+
+func TestExportRejectionWaitsForCheckpoint(t *testing.T) {
+	database, filesystem, limits := deterministicRejectionBatch(t)
+	failure := errors.New("injected checkpoint failure")
+	store := &failingArtifactStore{
+		ArtifactStore: filesystem, failKind: Kind(KindCheckpoints), failErr: failure,
+	}
+
+	_, err := exportToStoreWithLimits(
+		t.Context(), database, store,
+		ExportOptions{Origin: contractOrigin}, limits,
+	)
+	require.ErrorIs(t, err, failure)
+	checkpoint := latestStoreCheckpointForTest(t, filesystem, contractOrigin)
+	assert.Contains(t, checkpoint.Sessions, contractOrigin+"~rejected")
+	assert.NotContains(t, checkpoint.Sessions, contractOrigin+"~valid")
+	_, ok, err := database.GetArtifactExportRejection(t.Context(), "rejected")
+	require.NoError(t, err)
+	assert.False(t, ok)
+	pending, err := database.PendingArtifactExports(t.Context(), 10)
+	require.NoError(t, err)
+	assert.Len(t, pending, 2)
+}
+
+func TestExportStaleRejectionCannotConsumeMutation(t *testing.T) {
+	database, filesystem, limits := deterministicRejectionBatch(t)
+	store := &mutateAfterCheckpointStore{
+		ArtifactStore: filesystem, database: database, session: "rejected",
+	}
+
+	_, err := exportToStoreWithLimits(
+		t.Context(), database, store,
+		ExportOptions{Origin: contractOrigin}, limits,
+	)
+	require.ErrorIs(t, err, db.ErrArtifactExportClaimStale)
+	_, ok, err := database.GetArtifactExportRejection(t.Context(), "rejected")
+	require.NoError(t, err)
+	assert.False(t, ok)
+	pending, err := database.PendingArtifactExports(t.Context(), 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 2)
+	assert.Equal(t, "rejected", pending[0].SessionID)
+	assert.Greater(t, pending[0].Generation, int64(2))
+}
+
+func TestExportToStorePublishesDependenciesBeforeCheckpointAndSkipsUnchanged(t *testing.T) {
+	database := testExportDB(t)
+	seedSession(t, database, "sess-1", "alpha")
+	filesystem, err := newProtocolTestStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, filesystem.Close()) })
+	store := &recordingArtifactStore{ArtifactStore: filesystem}
+
+	result, err := ExportToStore(t.Context(), database, store, ExportOptions{
+		Origin: contractOrigin,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.ExportedSessions)
+	assert.True(t, result.CheckpointCreated)
+	require.Len(t, store.creates, 3)
+	assert.Equal(t, Kind(KindSegments), store.creates[0].Ref.Kind)
+	assert.Equal(t, Kind(KindManifests), store.creates[1].Ref.Kind)
+	assert.Equal(t, Kind(KindCheckpoints), store.creates[2].Ref.Kind)
+	assert.True(t, store.creates[0].Created)
+	assert.True(t, store.creates[1].Created)
+	assert.True(t, store.creates[2].Created)
+	checkpointBytes := readContractArtifact(t, store, store.creates[2].Ref)
+	var published checkpoint
+	require.NoError(t, json.Unmarshal(checkpointBytes, &published))
+	canonicalCheckpoint, err := canonicalJSON(published)
+	require.NoError(t, err)
+	assert.Equal(t, canonicalCheckpoint, checkpointBytes,
+		"streaming checkpoint encoding must remain byte-compatible")
+
+	store.creates = nil
+	result, err = ExportToStore(t.Context(), database, store, ExportOptions{
+		Origin: contractOrigin,
+		Full:   true,
+	})
+	require.NoError(t, err)
+	assert.Zero(t, result.ExportedSessions)
+	assert.False(t, result.CheckpointCreated)
+	require.Len(t, store.creates, 2,
+		"full export verifies immutable dependencies without minting a version")
+	assert.Equal(t, Kind(KindSegments), store.creates[0].Ref.Kind)
+	assert.Equal(t, Kind(KindManifests), store.creates[1].Ref.Kind)
+	assert.False(t, store.creates[0].Created)
+	assert.False(t, store.creates[1].Created)
+}
+
+func TestExportToStoreFullRepairsMissingDependencyWithoutNewCheckpoint(t *testing.T) {
+	database := testExportDB(t)
+	seedSession(t, database, "sess-1", "alpha")
+	filesystem, err := newProtocolTestStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, filesystem.Close()) })
+	first, err := ExportToStore(t.Context(), database, filesystem, ExportOptions{
+		Origin: contractOrigin,
+	})
+	require.NoError(t, err)
+	require.True(t, first.CheckpointCreated)
+	segments, err := firstStoreEntryPage(t.Context(), filesystem, contractOrigin, KindSegments, 10)
+	require.NoError(t, err)
+	require.Len(t, segments.Items, 1)
+	require.NoError(t, filesystem.Trash(t.Context(), segments.Items[0].Ref))
+	_, err = filesystem.Stat(t.Context(), segments.Items[0].Ref)
+	require.ErrorIs(t, err, ErrArtifactNotFound)
+	headBefore, ok, err := database.GetArtifactCheckpointHead(t.Context(), contractOrigin)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	result, err := ExportToStore(t.Context(), database, filesystem, ExportOptions{
+		Origin: contractOrigin, Full: true,
+	})
+	require.NoError(t, err)
+	assert.False(t, result.CheckpointCreated)
+	_, err = filesystem.Stat(t.Context(), segments.Items[0].Ref)
+	require.NoError(t, err, "full export recreates a missing dependency even when its manifest survives")
+	headAfter, ok, err := database.GetArtifactCheckpointHead(t.Context(), contractOrigin)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, headBefore, headAfter)
+}
+
+func TestExportToStoreRecreatesMissingRecordedCheckpointAfterVaultReset(t *testing.T) {
+	database := testExportDB(t)
+	seedSession(t, database, "sess-1", "alpha")
+	first, err := newProtocolTestStore(t.TempDir())
+	require.NoError(t, err)
+	_, err = ExportToStore(t.Context(), database, first, ExportOptions{
+		Origin: contractOrigin,
+	})
+	require.NoError(t, err)
+	require.NoError(t, first.Close())
+
+	replacement, err := newProtocolTestStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, replacement.Close()) })
+	result, err := ExportToStore(t.Context(), database, replacement, ExportOptions{
+		Origin: contractOrigin,
+		Full:   true,
+	})
+	require.NoError(t, err)
+	assert.True(t, result.CheckpointCreated)
+	assert.Equal(t, 1, result.CheckpointSequence,
+		"vault reset recreates the recorded immutable checkpoint without consuming a new sequence")
+	checkpointRef := requireContractRef(t, contractOrigin, KindCheckpoints,
+		"cp-0000000001.json")
+	checkpointBytes := readContractArtifact(t, replacement, checkpointRef)
+	var published checkpoint
+	require.NoError(t, json.Unmarshal(checkpointBytes, &published))
+	assert.Equal(t, map[string]string{
+		contractOrigin + "~sess-1": published.Sessions[contractOrigin+"~sess-1"],
+	}, published.Sessions)
+}
+
+func TestExportToStoreChangedBatchDoesNotScanCheckpointHistory(t *testing.T) {
+	database := testExportDB(t)
+	seedSession(t, database, "sess-1", "alpha")
+	filesystem, err := newProtocolTestStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, filesystem.Close()) })
+	store := &checkpointReadCountingStore{ArtifactStore: filesystem}
+	_, err = ExportToStore(t.Context(), database, store, ExportOptions{
+		Origin: contractOrigin,
+	})
+	require.NoError(t, err)
+	store.lists = 0
+	store.opens = 0
+	require.NoError(t, database.ReplaceSessionMessages("sess-1", []db.Message{{
+		SessionID: "sess-1", Ordinal: 0, Role: "user", Content: "changed",
+	}}))
+
+	result, err := ExportToStore(t.Context(), database, store, ExportOptions{
+		Origin: contractOrigin,
+	})
+	require.NoError(t, err)
+	assert.True(t, result.CheckpointCreated)
+	assert.Equal(t, 2, result.CheckpointSequence)
+	assert.Zero(t, store.lists,
+		"a recorded pre-apply head avoids checkpoint-history traversal")
+	assert.Zero(t, store.opens,
+		"normal changed export does not read an old checkpoint body")
+}
+
+func TestExportToStoreUnchangedCheckpointUsesCatalogIdentityOnly(t *testing.T) {
+	for _, size := range []int64{128, 64 << 20} {
+		t.Run(fmt.Sprintf("size-%d", size), func(t *testing.T) {
+			database := testExportDB(t)
+			ref := requireContractRef(t, contractOrigin, KindCheckpoints, "cp-0000000001.json")
+			identity := Identity{SHA256: strings64("a"), Size: size}
+			require.NoError(t, database.RecordArtifactCheckpointHead(t.Context(), db.ArtifactCheckpointHead{
+				Origin: contractOrigin, Sequence: 1,
+				SessionMapSHA256: strings64("b"), CheckpointSHA256: identity.SHA256,
+				CheckpointSize: identity.Size,
+			}, nil))
+			store := &catalogCheckpointStore{entry: Entry{Ref: ref, Identity: identity}}
+
+			result, err := ExportToStore(t.Context(), database, store, ExportOptions{
+				Origin: contractOrigin,
+			})
+			require.NoError(t, err)
+			assert.False(t, result.CheckpointCreated)
+			assert.Equal(t, 1, store.statCalls)
+			assert.Zero(t, store.openCalls,
+				"unchanged periodic export cannot drain the checkpoint body")
+		})
+	}
+}
+
+func TestExportToStoreRecordedCheckpointStatRecovery(t *testing.T) {
+	database := testExportDB(t)
+	seedSession(t, database, "sess-1", "alpha")
+	filesystem, err := newProtocolTestStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, filesystem.Close()) })
+	_, err = ExportToStore(t.Context(), database, filesystem, ExportOptions{
+		Origin: contractOrigin,
+	})
+	require.NoError(t, err)
+
+	operationalFailure := errors.New("injected checkpoint stat failure")
+	_, err = ExportToStore(t.Context(), database, &checkpointStatOverrideStore{
+		ArtifactStore: filesystem, err: operationalFailure,
+	}, ExportOptions{Origin: contractOrigin})
+	require.ErrorIs(t, err, operationalFailure)
+
+	mismatch := Identity{SHA256: strings64("c"), Size: 1}
+	result, err := ExportToStore(t.Context(), database, &checkpointStatOverrideStore{
+		ArtifactStore: filesystem, identity: &mismatch,
+	}, ExportOptions{Origin: contractOrigin})
+	require.NoError(t, err)
+	assert.True(t, result.CheckpointCreated)
+	assert.Equal(t, 1, result.CheckpointSequence,
+		"catalog identity mismatch quarantines and reconstructs the recorded checkpoint")
+}
+
+func TestExportToStoreBootstrapsMissingDatabaseHeadFromLatestCheckpoint(t *testing.T) {
+	database := testExportDB(t)
+	seedSession(t, database, "sess-1", "alpha")
+	filesystem, err := newProtocolTestStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, filesystem.Close()) })
+	_, err = ExportToStore(t.Context(), database, filesystem, ExportOptions{
+		Origin: contractOrigin,
+	})
+	require.NoError(t, err)
+	store := &checkpointReadCountingStore{ArtifactStore: filesystem}
+
+	result, err := ExportToStore(t.Context(), &hiddenCheckpointHeadDB{DB: database},
+		store, ExportOptions{Origin: contractOrigin})
+	require.NoError(t, err)
+	assert.False(t, result.CheckpointCreated)
+	assert.Equal(t, 1, result.CheckpointSequence)
+	assert.Positive(t, store.lists)
+	assert.Equal(t, 1, store.opens)
+	page, err := firstStoreEntryPage(t.Context(), filesystem, contractOrigin, KindCheckpoints, 10)
+	require.NoError(t, err)
+	assert.Len(t, page.Items, 1)
+}
+
+func TestExportCheckpointBootstrapPropagatesOperationalOpenErrors(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		err  error
+	}{
+		{name: "canceled", err: context.Canceled},
+		{name: "unavailable", err: errors.New("checkpoint store unavailable")},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			database := testExportDB(t)
+			seedSession(t, database, "sess-1", "alpha")
+			filesystem, err := newProtocolTestStore(t.TempDir())
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, filesystem.Close()) })
+			_, err = ExportToStore(t.Context(), database, filesystem, ExportOptions{
+				Origin: contractOrigin,
+			})
+			require.NoError(t, err)
+
+			_, err = ExportToStore(t.Context(), &hiddenCheckpointHeadDB{DB: database},
+				&checkpointOpenFailureStore{ArtifactStore: filesystem, err: test.err},
+				ExportOptions{Origin: contractOrigin})
+			require.ErrorIs(t, err, test.err)
+		})
+	}
+}
+
+func TestLatestValidCheckpointFallsBackPastSemanticCandidateAndDefersFuture(t *testing.T) {
+	filesystem, err := newProtocolTestStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, filesystem.Close()) })
+	for _, candidate := range []struct {
+		name string
+		body string
+	}{
+		{name: "cp-0000000001.json", body: `{"origin":"contract-a1b2c3","seq":1,"sessions":{},"v":1}` + "\n"},
+		{name: "cp-0000000002.json", body: `{"origin":"contract-a1b2c3","seq":99,"sessions":{},"v":1}` + "\n"},
+	} {
+		body := []byte(candidate.body)
+		ref := requireContractRef(t, contractOrigin, KindCheckpoints, candidate.name)
+		_, err := filesystem.Create(t.Context(), ref, identityForBytes(t, body),
+			canonicalArtifactMediaType(KindCheckpoints), strings.NewReader(candidate.body))
+		require.NoError(t, err)
+	}
+
+	head, ok, err := latestValidCheckpointHead(t.Context(), filesystem, contractOrigin)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, 1, head.Sequence)
+
+	future := []byte(`{"origin":"contract-a1b2c3","seq":3,"sessions":{},"v":2}` + "\n")
+	ref := requireContractRef(t, contractOrigin, KindCheckpoints, "cp-0000000003.json")
+	_, err = filesystem.Create(t.Context(), ref, identityForBytes(t, future),
+		canonicalArtifactMediaType(KindCheckpoints), strings.NewReader(string(future)))
+	require.NoError(t, err)
+	_, _, err = latestValidCheckpointHead(t.Context(), filesystem, contractOrigin)
+	require.ErrorIs(t, err, errFutureArtifactVersion)
+}
+
+func TestExportSpoolConstructionJoinsCleanupFailures(t *testing.T) {
+	chmodFailure := errors.New("injected spool setup failure")
+	cleanupFailure := errors.New("injected spool cleanup failure")
+	previousChmod := exportSpoolChmod
+	previousCleanup := exportSpoolCleanup
+	t.Cleanup(func() {
+		exportSpoolChmod = previousChmod
+		exportSpoolCleanup = previousCleanup
+	})
+	exportSpoolChmod = func(*os.File) error { return chmodFailure }
+	exportSpoolCleanup = func(file *os.File) error {
+		return errors.Join(closeAndRemoveExportSpool(file), cleanupFailure)
+	}
+
+	_, _, _, err := spoolArtifactPublicationMap(
+		t.Context(), testExportDB(t), contractOrigin,
+	)
+	require.ErrorIs(t, err, chmodFailure)
+	require.ErrorIs(t, err, cleanupFailure)
+
+	mapSpool, err := os.CreateTemp("", "agentsview-artifact-test-map-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = closeAndRemoveExportSpool(mapSpool) })
+	_, err = io.WriteString(mapSpool, "{}\n")
+	require.NoError(t, err)
+	_, _, err = spoolArtifactCheckpoint(t.Context(), mapSpool, contractOrigin, 1)
+	require.ErrorIs(t, err, chmodFailure)
+	require.ErrorIs(t, err, cleanupFailure)
+}
+
+func TestSpoolArtifactCheckpointEnforcesDecodedSizeBoundary(t *testing.T) {
+	mapSpool, err := os.CreateTemp("", "agentsview-artifact-test-map-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = closeAndRemoveExportSpool(mapSpool) })
+	_, err = io.WriteString(mapSpool, "{}\n")
+	require.NoError(t, err)
+
+	baseline, identity, err := spoolArtifactCheckpointWithLimit(
+		t.Context(), mapSpool, contractOrigin, 1, checkpointDecodedLimit,
+	)
+	require.NoError(t, err)
+	require.NoError(t, closeAndRemoveExportSpool(baseline))
+
+	atLimit, atLimitIdentity, err := spoolArtifactCheckpointWithLimit(
+		t.Context(), mapSpool, contractOrigin, 1, identity.Size,
+	)
+	require.NoError(t, err)
+	require.Equal(t, identity, atLimitIdentity)
+	require.NoError(t, closeAndRemoveExportSpool(atLimit))
+
+	checkpoint, _, err := spoolArtifactCheckpointWithLimit(
+		t.Context(), mapSpool, contractOrigin, 1, identity.Size-1,
+	)
+	require.Error(t, err)
+	assert.Nil(t, checkpoint)
+	assert.Contains(t, err.Error(), "checkpoint exceeds decoded size limit")
+}
+
+func TestExportToStorePropagatesCheckpointCloseErrorWithoutAcknowledging(t *testing.T) {
+	database := testExportDB(t)
+	seedSession(t, database, "sess-1", "alpha")
+	filesystem, err := newProtocolTestStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, filesystem.Close()) })
+	_, err = ExportToStore(t.Context(), database, filesystem, ExportOptions{
+		Origin: contractOrigin,
+	})
+	require.NoError(t, err)
+	require.NoError(t, database.ReplaceSessionMessages("sess-1", []db.Message{{
+		SessionID: "sess-1", Ordinal: 0, Role: "user", Content: "changed",
+	}}))
+	closeFailure := errors.New("injected checkpoint close failure")
+
+	_, err = ExportToStore(t.Context(), &hiddenCheckpointHeadDB{DB: database}, &checkpointCloseErrorStore{
+		ArtifactStore: filesystem, err: closeFailure,
+	}, ExportOptions{Origin: contractOrigin})
+	require.ErrorIs(t, err, closeFailure)
+	pending, err := database.PendingArtifactExports(t.Context(), 10)
+	require.NoError(t, err)
+	assert.Len(t, pending, 1)
+}
+
+func TestExportToStoreCancellationLeavesQueuePending(t *testing.T) {
+	database := testExportDB(t)
+	seedSession(t, database, "sess-1", "alpha")
+	filesystem, err := newProtocolTestStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, filesystem.Close()) })
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err = ExportToStore(ctx, database, filesystem, ExportOptions{
+		Origin: contractOrigin,
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	pending, err := database.PendingArtifactExports(t.Context(), 10)
+	require.NoError(t, err)
+	assert.Len(t, pending, 1)
+}
+
+func TestExportToStoreFailureKeepsClaimAndCheckpointLast(t *testing.T) {
+	failure := errors.New("injected artifact create failure")
+	tests := []struct {
+		name         string
+		failKind     Kind
+		wantCalls    []Kind
+		wantRetrySeq int
+	}{
+		{name: "dependency", failKind: Kind(KindSegments),
+			wantCalls: []Kind{Kind(KindSegments)}, wantRetrySeq: 1},
+		{name: "manifest", failKind: Kind(KindManifests),
+			wantCalls: []Kind{Kind(KindSegments), Kind(KindManifests)}, wantRetrySeq: 1},
+		{name: "checkpoint", failKind: Kind(KindCheckpoints),
+			wantCalls: []Kind{Kind(KindSegments), Kind(KindManifests), Kind(KindCheckpoints)}, wantRetrySeq: 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			database := testExportDB(t)
+			seedSession(t, database, "sess-1", "alpha")
+			filesystem, err := newProtocolTestStore(t.TempDir())
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, filesystem.Close()) })
+			store := &failingArtifactStore{
+				ArtifactStore: filesystem, failKind: tt.failKind, failErr: failure,
+			}
+
+			_, err = ExportToStore(t.Context(), database, store, ExportOptions{
+				Origin: contractOrigin,
+			})
+			require.ErrorIs(t, err, failure)
+			assert.Equal(t, tt.wantCalls, store.calls)
+			pending, err := database.PendingArtifactExports(t.Context(), 10)
+			require.NoError(t, err)
+			require.Len(t, pending, 1, "failed export must retain its exact claim")
+			page, err := firstStoreEntryPage(t.Context(), store, contractOrigin, KindCheckpoints, 10)
+			require.NoError(t, err)
+			assert.Empty(t, page.Items, "checkpoint cannot precede a failed dependency")
+
+			store.calls = nil
+			result, err := ExportToStore(t.Context(), database, store, ExportOptions{
+				Origin: contractOrigin,
+			})
+			require.NoError(t, err)
+			assert.True(t, result.CheckpointCreated)
+			assert.Equal(t, tt.wantRetrySeq, result.CheckpointSequence)
+			pending, err = database.PendingArtifactExports(t.Context(), 10)
+			require.NoError(t, err)
+			assert.Empty(t, pending)
+		})
+	}
+}
+
+func TestExportToStoreStaleGenerationDoesNotPublishOrAcknowledge(t *testing.T) {
+	database := testExportDB(t)
+	seedSession(t, database, "sess-1", "alpha")
+	stale := &staleClaimExportDB{DB: database}
+	filesystem, err := newProtocolTestStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, filesystem.Close()) })
+
+	_, err = ExportToStore(t.Context(), stale, filesystem, ExportOptions{
+		Origin: contractOrigin,
+	})
+	require.ErrorIs(t, err, db.ErrArtifactExportClaimStale)
+	_, ok, err := database.GetArtifactCheckpointHead(t.Context(), contractOrigin)
+	require.NoError(t, err)
+	assert.False(t, ok)
+	pending, err := database.PendingArtifactExports(t.Context(), 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	assert.Greater(t, pending[0].Generation, int64(1))
+	page, err := firstStoreEntryPage(t.Context(), filesystem, contractOrigin, KindCheckpoints, 10)
+	require.NoError(t, err)
+	assert.Empty(t, page.Items)
+}
+
+func TestExportToStoreStaleGenerationAfterCheckpointDoesNotAdvanceHead(t *testing.T) {
+	database := testExportDB(t)
+	seedSession(t, database, "sess-1", "alpha")
+	filesystem, err := newProtocolTestStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, filesystem.Close()) })
+	store := &mutateAfterCheckpointStore{ArtifactStore: filesystem, database: database}
+
+	_, err = ExportToStore(t.Context(), database, store, ExportOptions{
+		Origin: contractOrigin,
+	})
+	require.ErrorIs(t, err, db.ErrArtifactExportClaimStale)
+	_, ok, err := database.GetArtifactCheckpointHead(t.Context(), contractOrigin)
+	require.NoError(t, err)
+	assert.False(t, ok)
+	pending, err := database.PendingArtifactExports(t.Context(), 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	firstPage, err := firstStoreEntryPage(t.Context(), filesystem, contractOrigin, KindCheckpoints, 10)
+	require.NoError(t, err)
+	require.Len(t, firstPage.Items, 1,
+		"the immutable stale checkpoint is harmless while no head references it")
+
+	result, err := ExportToStore(t.Context(), database, store, ExportOptions{
+		Origin: contractOrigin,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.CheckpointSequence)
+	head, ok, err := database.GetArtifactCheckpointHead(t.Context(), contractOrigin)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, 2, head.Sequence)
+	pending, err = database.PendingArtifactExports(t.Context(), 10)
+	require.NoError(t, err)
+	assert.Empty(t, pending)
+}
+
+func TestExportToStorePublicationRevisionRejectsPhysicallyCreatedStaleCheckpoint(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "archive.db")
+	first, err := db.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, first.Close()) })
+	require.NoError(t, first.SetSyncState(originStateKey, contractOrigin))
+	second, err := db.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, second.Close()) })
+	filesystem, err := newProtocolTestStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, filesystem.Close()) })
+	ctx := t.Context()
+	seedSession(t, first, "session-a", "project")
+	claimA, err := first.ArtifactExportClaims(ctx, []string{"session-a"})
+	require.NoError(t, err)
+	require.Len(t, claimA, 1)
+	sessionA, err := first.GetSessionFull(ctx, "session-a")
+	require.NoError(t, err)
+	messagesA, err := first.GetAllMessages(ctx, "session-a")
+	require.NoError(t, err)
+	usageA, err := first.GetUsageEvents(ctx, "session-a")
+	require.NoError(t, err)
+	manifestA, _, err := exportLoadedSessionToStore(
+		ctx, filesystem, contractOrigin, sessionA, messagesA, usageA, productionArtifactLimits(),
+	)
+	require.NoError(t, err)
+	revisionA, changed, err := first.ApplyArtifactPublicationChanges(ctx, contractOrigin,
+		[]db.ArtifactPublicationChange{{
+			SessionID: "session-a", Generation: claimA[0].Generation,
+			ManifestHash: manifestA, SourceFingerprint: manifestA,
+		}})
+	require.NoError(t, err)
+	require.True(t, changed)
+	mapA, digestA, snapshotA, err := spoolArtifactPublicationMap(ctx, first, contractOrigin)
+	require.NoError(t, err)
+	require.Equal(t, revisionA, snapshotA)
+	t.Cleanup(func() { _ = closeAndRemoveExportSpool(mapA) })
+
+	seedSession(t, second, "session-b", "project")
+	claimB, err := second.ArtifactExportClaims(ctx, []string{"session-b"})
+	require.NoError(t, err)
+	require.Len(t, claimB, 1)
+	sessionB, err := second.GetSessionFull(ctx, "session-b")
+	require.NoError(t, err)
+	messagesB, err := second.GetAllMessages(ctx, "session-b")
+	require.NoError(t, err)
+	usageB, err := second.GetUsageEvents(ctx, "session-b")
+	require.NoError(t, err)
+	manifestB, _, err := exportLoadedSessionToStore(
+		ctx, filesystem, contractOrigin, sessionB, messagesB, usageB, productionArtifactLimits(),
+	)
+	require.NoError(t, err)
+	revisionB, changed, err := second.ApplyArtifactPublicationChanges(ctx, contractOrigin,
+		[]db.ArtifactPublicationChange{{
+			SessionID: "session-b", Generation: claimB[0].Generation,
+			ManifestHash: manifestB, SourceFingerprint: manifestB,
+		}})
+	require.NoError(t, err)
+	require.True(t, changed)
+	mapB, digestB, snapshotB, err := spoolArtifactPublicationMap(ctx, second, contractOrigin)
+	require.NoError(t, err)
+	require.Equal(t, revisionB, snapshotB)
+	sequenceB, err := reserveCheckpointSequenceFromStore(ctx, second, filesystem, contractOrigin)
+	require.NoError(t, err)
+	checkpointB, identityB, err := spoolArtifactCheckpoint(ctx, mapB, contractOrigin, sequenceB)
+	require.NoError(t, err)
+	refB := requireContractRef(t, contractOrigin, KindCheckpoints,
+		fmt.Sprintf("cp-%010d.json", sequenceB))
+	_, err = filesystem.Create(ctx, refB, identityB,
+		canonicalArtifactMediaType(KindCheckpoints), checkpointB)
+	require.NoError(t, err)
+	require.NoError(t, closeAndRemoveExportSpool(mapB))
+	require.NoError(t, closeAndRemoveExportSpool(checkpointB))
+	require.NoError(t, second.RecordArtifactCheckpointHead(ctx, db.ArtifactCheckpointHead{
+		Origin: contractOrigin, Sequence: sequenceB, PublicationRevision: snapshotB,
+		SessionMapSHA256: digestB, CheckpointSHA256: identityB.SHA256,
+		CheckpointSize: identityB.Size,
+	}, claimB))
+
+	sequenceA, err := reserveCheckpointSequenceFromStore(ctx, first, filesystem, contractOrigin)
+	require.NoError(t, err)
+	require.Greater(t, sequenceA, sequenceB)
+	checkpointA, identityA, err := spoolArtifactCheckpoint(ctx, mapA, contractOrigin, sequenceA)
+	require.NoError(t, err)
+	refA := requireContractRef(t, contractOrigin, KindCheckpoints,
+		fmt.Sprintf("cp-%010d.json", sequenceA))
+	_, err = filesystem.Create(ctx, refA, identityA,
+		canonicalArtifactMediaType(KindCheckpoints), checkpointA)
+	require.NoError(t, err)
+	require.NoError(t, closeAndRemoveExportSpool(checkpointA))
+	err = first.RecordArtifactCheckpointHead(ctx, db.ArtifactCheckpointHead{
+		Origin: contractOrigin, Sequence: sequenceA, PublicationRevision: snapshotA,
+		SessionMapSHA256: digestA, CheckpointSHA256: identityA.SHA256,
+		CheckpointSize: identityA.Size,
+	}, claimA)
+	require.ErrorIs(t, err, db.ErrArtifactExportClaimStale)
+	_, err = filesystem.Stat(ctx, refA)
+	require.NoError(t, err, "the stale immutable checkpoint may exist without becoming authoritative")
+	head, ok, err := first.GetArtifactCheckpointHead(ctx, contractOrigin)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, sequenceB, head.Sequence)
+	pending, err := first.ArtifactExportClaims(ctx, []string{"session-a"})
+	require.NoError(t, err)
+	require.Equal(t, claimA, pending)
+
+	result, err := ExportToStore(ctx, first, filesystem, ExportOptions{Origin: contractOrigin})
+	require.NoError(t, err)
+	assert.False(t, result.CheckpointCreated)
+	pending, err = first.ArtifactExportClaims(ctx, []string{"session-a"})
+	require.NoError(t, err)
+	assert.Empty(t, pending)
+}
+
+func TestArtifactExportCardinalityLoadsOnlyDirtyBatch(t *testing.T) {
+	for _, archiveSize := range []int{20, 2000} {
+		t.Run(fmt.Sprintf("archive-%d", archiveSize), func(t *testing.T) {
+			database := testExportDB(t)
+			for i := range archiveSize {
+				require.NoError(t, database.UpsertSession(db.Session{
+					ID: fmt.Sprintf("peer-%04d", i), Project: "project",
+					Machine: "peer-a1b2c3", Agent: "claude",
+				}))
+			}
+			require.NoError(t, database.UpsertSession(db.Session{
+				ID: "dirty", Project: "project", Machine: "local", Agent: "claude",
+			}))
+			require.NoError(t, database.ReplaceSessionMessages("dirty", []db.Message{{
+				SessionID: "dirty", Ordinal: 0, Role: "user", Content: "changed",
+			}}))
+			require.NoError(t, database.ReplaceSessionUsageEvents("dirty", []db.UsageEvent{{
+				SessionID: "dirty", Source: "event", Model: "model", DedupKey: "one",
+			}}))
+
+			store := &countingQueuedExportStore{database: database}
+			visited := 0
+			err := forEachQueuedArtifactExport(t.Context(), store, 1, func(work queuedArtifactExport) error {
+				visited++
+				assert.Equal(t, "dirty", work.Item.SessionID)
+				require.NotNil(t, work.Session)
+				assert.Len(t, work.Messages, 1)
+				assert.Len(t, work.UsageEvents, 1)
+				return nil
+			})
+			require.NoError(t, err)
+			assert.Equal(t, 1, visited)
+			assert.Equal(t, 1, store.queueQueries)
+			assert.Equal(t, 1, store.sessionLoads)
+			assert.Equal(t, 1, store.messageLoads)
+			assert.Equal(t, 1, store.usageLoads)
+		})
+	}
+}
+
+func TestExportToStoreCardinalityIgnoresUnrelatedArchiveBodies(t *testing.T) {
+	for _, archiveSize := range []int{20, 2000} {
+		t.Run(fmt.Sprintf("archive-%d", archiveSize), func(t *testing.T) {
+			database := testExportDB(t)
+			for i := range archiveSize {
+				require.NoError(t, database.UpsertSession(db.Session{
+					ID: fmt.Sprintf("peer-%04d", i), Project: "project",
+					Machine: "peer-a1b2c3", Agent: "claude",
+				}))
+			}
+			seedSession(t, database, "dirty", "project")
+			counted := &countingCanonicalExportDB{DB: database}
+			filesystem, err := newProtocolTestStore(t.TempDir())
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, filesystem.Close()) })
+
+			result, err := ExportToStore(t.Context(), counted, filesystem, ExportOptions{
+				Origin: contractOrigin,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, 1, result.ExportedSessions)
+			assert.Equal(t, 1, counted.sessionLoads)
+			assert.Equal(t, 1, counted.boundedLoads)
+			assert.Zero(t, counted.messageLoads)
+			assert.Zero(t, counted.usageLoads)
+		})
+	}
+}
+
+func TestExportToStoreIncrementalBatchIsBoundedAndFullStreamsAllBodies(t *testing.T) {
+	database := testExportDB(t)
+	const total = artifactExportBatchSize + 5
+	for i := range total {
+		seedSession(t, database, fmt.Sprintf("session-%03d", i), "project")
+	}
+	filesystem, err := newProtocolTestStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, filesystem.Close()) })
+
+	result, err := ExportToStore(t.Context(), database, filesystem, ExportOptions{
+		Origin: contractOrigin,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, artifactExportBatchSize, result.ExportedSessions)
+	pending, err := database.PendingArtifactExports(t.Context(), 1024)
+	require.NoError(t, err)
+	assert.Len(t, pending, 5)
+	firstBytes := readContractArtifact(t, filesystem,
+		requireContractRef(t, contractOrigin, KindCheckpoints, "cp-0000000001.json"))
+	var first checkpoint
+	require.NoError(t, json.Unmarshal(firstBytes, &first))
+	assert.Len(t, first.Sessions, artifactExportBatchSize)
+
+	result, err = ExportToStore(t.Context(), database, filesystem, ExportOptions{
+		Origin: contractOrigin,
+		Full:   true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 5, result.ExportedSessions,
+		"full pass idempotently recreates clean dependencies and creates only missing manifests")
+	pending, err = database.PendingArtifactExports(t.Context(), 1024)
+	require.NoError(t, err)
+	assert.Empty(t, pending)
+	secondBytes := readContractArtifact(t, filesystem,
+		requireContractRef(t, contractOrigin, KindCheckpoints, "cp-0000000002.json"))
+	var second checkpoint
+	require.NoError(t, json.Unmarshal(secondBytes, &second))
+	assert.Len(t, second.Sessions, total)
+}
+
+func TestExportToStoreFullDrainsMoreThanOneClaimPage(t *testing.T) {
+	database := testExportDB(t)
+	const total = 1025
+	for i := range total {
+		require.NoError(t, database.UpsertSession(db.Session{
+			ID: fmt.Sprintf("session-%04d", i), Project: "project",
+			Machine: "local", Agent: "claude", CreatedAt: "2026-06-14T01:02:03Z",
+		}))
+	}
+	counted := &countingCanonicalExportDB{DB: database}
+	filesystem, err := newProtocolTestStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, filesystem.Close()) })
+
+	result, err := ExportToStore(t.Context(), counted, filesystem, ExportOptions{
+		Origin: contractOrigin, Full: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, total, result.ExportedSessions)
+	assert.Equal(t, total, counted.sessionLoads,
+		"full export loads each body once instead of reloading the archive per page")
+	assert.Equal(t, total, counted.boundedLoads)
+	assert.Zero(t, counted.messageLoads)
+	assert.Zero(t, counted.usageLoads)
+	pending, err := database.PendingArtifactExports(t.Context(), 1024)
+	require.NoError(t, err)
+	assert.Empty(t, pending)
+	head, ok, err := database.GetArtifactCheckpointHead(t.Context(), contractOrigin)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, 2, head.Sequence)
+	body := readContractArtifact(t, filesystem, requireContractRef(
+		t, contractOrigin, KindCheckpoints, "cp-0000000002.json",
+	))
+	var published checkpoint
+	require.NoError(t, json.Unmarshal(body, &published))
+	assert.Len(t, published.Sessions, total)
+}
+
+func TestExportToStoreExplicitSessionIDsClaimBeyondOldestQueuePage(t *testing.T) {
+	database := testExportDB(t)
+	const total = 1025
+	for i := range total {
+		require.NoError(t, database.UpsertSession(db.Session{
+			ID: fmt.Sprintf("session-%04d", i), Project: "project",
+			Machine: "local", Agent: "claude",
+		}))
+	}
+	filesystem, err := newProtocolTestStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, filesystem.Close()) })
+
+	result, err := ExportToStore(t.Context(), database, filesystem, ExportOptions{
+		Origin: contractOrigin, SessionIDs: []string{"session-1024"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.ExportedSessions)
+	pending, err := database.PendingArtifactExports(t.Context(), 1024)
+	require.NoError(t, err)
+	assert.Len(t, pending, 1024)
+	body := readContractArtifact(t, filesystem,
+		requireContractRef(t, contractOrigin, KindCheckpoints, "cp-0000000001.json"))
+	var published checkpoint
+	require.NoError(t, json.Unmarshal(body, &published))
+	assert.Equal(t, map[string]string{
+		contractOrigin + "~session-1024": published.Sessions[contractOrigin+"~session-1024"],
+	}, published.Sessions)
+}
+
+func TestExportToStorePublishesEmptyAndDeletionSets(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		database := testExportDB(t)
+		filesystem, err := newProtocolTestStore(t.TempDir())
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, filesystem.Close()) })
+
+		result, err := ExportToStore(t.Context(), database, filesystem, ExportOptions{
+			Origin: contractOrigin, Full: true,
+		})
+		require.NoError(t, err)
+		assert.True(t, result.CheckpointCreated)
+		body := readContractArtifact(t, filesystem,
+			requireContractRef(t, contractOrigin, KindCheckpoints, "cp-0000000001.json"))
+		assert.Equal(t,
+			`{"origin":"contract-a1b2c3","seq":1,"sessions":{},"v":1}`+"\n",
+			string(body))
+	})
+
+	t.Run("deletion", func(t *testing.T) {
+		database := testExportDB(t)
+		seedSession(t, database, "sess-1", "project")
+		filesystem, err := newProtocolTestStore(t.TempDir())
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, filesystem.Close()) })
+		_, err = ExportToStore(t.Context(), database, filesystem, ExportOptions{
+			Origin: contractOrigin,
+		})
+		require.NoError(t, err)
+		require.NoError(t, database.SoftDeleteSession("sess-1"))
+
+		result, err := ExportToStore(t.Context(), database, filesystem, ExportOptions{
+			Origin: contractOrigin,
+		})
+		require.NoError(t, err)
+		assert.True(t, result.CheckpointCreated)
+		body := readContractArtifact(t, filesystem,
+			requireContractRef(t, contractOrigin, KindCheckpoints, "cp-0000000002.json"))
+		assert.Contains(t, string(body), `"sessions":{}`)
+	})
+}
+
+func TestQueuedArtifactExportTreatsOwnershipLossAsDeletion(t *testing.T) {
+	database := testExportDB(t)
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "moved", Project: "project", Machine: "local", Agent: "claude",
+	}))
+	require.NoError(t, database.ReplaceSessionMessages("moved", []db.Message{{
+		SessionID: "moved", Ordinal: 0, Role: "user", Content: "local content",
+	}}))
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID: "moved", Project: "project", Machine: "peer-a1b2c3", Agent: "claude",
+	}))
+
+	store := &countingQueuedExportStore{database: database}
+	visited := 0
+	err := forEachQueuedArtifactExport(t.Context(), store, 1, func(work queuedArtifactExport) error {
+		visited++
+		assert.Nil(t, work.Session)
+		assert.Empty(t, work.Messages)
+		assert.Empty(t, work.UsageEvents)
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, visited)
+	assert.Equal(t, 1, store.sessionLoads)
+	assert.Zero(t, store.messageLoads)
+	assert.Zero(t, store.usageLoads)
+}
+
+func TestExportEmitsNewManifestAfterDataVersionChange(t *testing.T) {
+	ctx := context.Background()
+	database := testExportDB(t)
+	store := newTestArtifactStore(t)
+	origin := contractOrigin
+	seedSession(t, database, "sess-1", "alpha")
+
+	result, err := ExportToStore(ctx, database, store, ExportOptions{Origin: origin, Full: true})
+	require.NoError(t, err)
+	require.Equal(t, 1, result.ExportedSessions)
+	cp := latestStoreCheckpointForTest(t, store, origin)
+	firstHash := cp.Sessions[origin+"~sess-1"]
+	require.NotEmpty(t, firstHash)
+
+	require.NoError(t, database.SetSessionDataVersion("sess-1", 42))
+	result, err = ExportToStore(ctx, database, store, ExportOptions{Origin: origin, Full: true})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.ExportedSessions)
+	cp = latestStoreCheckpointForTest(t, store, origin)
+	nextHash := cp.Sessions[origin+"~sess-1"]
+	require.NotEmpty(t, nextHash)
+	assert.NotEqual(t, firstHash, nextHash)
+
+	ref, err := NewRef(origin, KindManifests, nextHash+".json")
+	require.NoError(t, err)
+	m, err := decodeManifestWithLimits(readContractArtifact(t, store, ref), productionArtifactLimits())
+	require.NoError(t, err)
+	assert.Equal(t, 42, m.DataVersion)
+}
+
+func TestExportIncludesLocalOwnedSessionClasses(t *testing.T) {
+	ctx := context.Background()
+	database := testExportDB(t)
+	store := newTestArtifactStore(t)
+	origin := contractOrigin
+	seedSession(t, database, "file-sess", "alpha")
+	seedSession(t, database, "claude-ai-sess", "bravo", func(s *db.Session) {
+		s.Agent = "claude-ai"
+	})
+	seedSession(t, database, "upload-sess", "charlie", func(s *db.Session) {
+		s.Agent = "upload"
+	})
+	seedSession(t, database, "orphan-sess", "delta", func(s *db.Session) {
+		s.SourceSessionID = "missing-source"
+	})
+
+	result, err := ExportToStore(ctx, database, store, ExportOptions{Origin: origin, Full: true})
+	require.NoError(t, err)
+	assert.Equal(t, 4, result.ExportedSessions)
+
+	cp := latestStoreCheckpointForTest(t, store, origin)
+	assert.Contains(t, cp.Sessions, origin+"~file-sess")
+	assert.Contains(t, cp.Sessions, origin+"~claude-ai-sess")
+	assert.Contains(t, cp.Sessions, origin+"~upload-sess")
+	assert.Contains(t, cp.Sessions, origin+"~orphan-sess")
+}
+
+func TestExportScrubsUnstableArtifactIDs(t *testing.T) {
+	ctx := context.Background()
+	database := testExportDB(t)
+	store := newTestArtifactStore(t)
+	origin := contractOrigin
+	seedSession(t, database, "sess-1", "alpha")
+	require.NoError(t, database.ReplaceSessionUsageEvents("sess-1", []db.UsageEvent{
+		{
+			SessionID:   "sess-1",
+			Source:      "fixture",
+			Model:       "claude-test",
+			InputTokens: 1,
+			OccurredAt:  "2026-06-14T01:02:04Z",
+			DedupKey:    "usage-1",
+		},
+	}))
+
+	_, err := ExportToStore(ctx, database, store, ExportOptions{Origin: origin, Full: true})
+	require.NoError(t, err)
+	cp := latestStoreCheckpointForTest(t, store, origin)
+	manifestHash := cp.Sessions[origin+"~sess-1"]
+	require.NotEmpty(t, manifestHash)
+
+	ref, err := NewRef(origin, KindManifests, manifestHash+".json")
+	require.NoError(t, err)
+	m, err := decodeManifestWithLimits(readContractArtifact(t, store, ref), productionArtifactLimits())
+	require.NoError(t, err)
+	require.Len(t, m.UsageEvents, 1)
+	manifestData, err := canonicalJSON(m)
+	require.NoError(t, err)
+	assert.NotContains(t, string(manifestData), `"ID"`)
+	assert.NotContains(t, string(manifestData), `"SessionID"`)
+
+	msgs := testStoreManifestMessages(t, store, origin, m)
+	require.Len(t, msgs, 2)
+	for _, msg := range msgs {
+		assert.Zero(t, msg.ID)
+		assert.Empty(t, msg.SessionID)
+	}
+}
+
+func TestExportRejectsInvalidOriginBeforeCreatingPaths(t *testing.T) {
+	ctx := context.Background()
+	database := testExportDB(t)
+	store := newTestArtifactStore(t)
+	seedSession(t, database, "sess-1", "alpha")
+
+	result, err := ExportToStore(ctx, database, store, ExportOptions{Origin: "../outside", Full: true})
+	require.Error(t, err)
+	assert.Zero(t, result.ExportedSessions)
+	assert.Contains(t, err.Error(), "invalid artifact origin")
+	assertNoPublishedArtifacts(t, store, "outside-a1b2c3")
+}
+
+func TestExportSkipsDeletedAndForeignSessions(t *testing.T) {
+	ctx := context.Background()
+	store := newTestArtifactStore(t)
+	origin := contractOrigin
+	database := testExportDB(t)
+
+	seedSession(t, database, "owned", "alpha")
+	// A soft-deleted owned session and a foreign-owned session are both excluded.
+	seedSession(t, database, "trashed", "alpha")
+	require.NoError(t, database.SoftDeleteSession("trashed"))
+	require.NoError(t, database.UpsertSession(db.Session{
+		ID:        "foreign",
+		Project:   "alpha",
+		Machine:   "desktop-d4e5f6",
+		Agent:     "claude",
+		CreatedAt: "2026-06-14T01:02:03Z",
+	}))
+
+	_, err := ExportToStore(ctx, database, store, ExportOptions{Origin: origin, Full: true})
+	require.NoError(t, err)
+
+	cp := latestStoreCheckpointForTest(t, store, origin)
+	assert.Contains(t, cp.Sessions, origin+"~owned")
+	assert.NotContains(t, cp.Sessions, origin+"~trashed")
+	assert.NotContains(t, cp.Sessions, origin+"~foreign")
+}
+
+// reEnqueueOnBoundaryStore re-enqueues its one session only at the outer
+// round-boundary check exportFullToStore makes with limit 1
+// (database.PendingArtifactExports(ctx, 1) just after each round's
+// ExportToStore call), never on an ordinary acknowledgement. Deviation 5
+// requires this ordering: a fake that re-enqueues on every acknowledgement
+// keeps drain()'s own unbounded internal loop non-empty forever and the test
+// hangs instead of exercising the outer cap.
+type reEnqueueOnBoundaryStore struct {
+	*db.DB
+	round int
+}
+
+func (s *reEnqueueOnBoundaryStore) PendingArtifactExports(
+	ctx context.Context, limit int,
+) ([]db.ArtifactExportQueueItem, error) {
+	if limit == 1 {
+		s.round++
+		if err := s.ReplaceSessionMessages("sess-1", []db.Message{{
+			SessionID: "sess-1", Ordinal: 0, Role: "user",
+			Content: fmt.Sprintf("round %d", s.round),
+		}}); err != nil {
+			return nil, err
+		}
+	}
+	return s.DB.PendingArtifactExports(ctx, limit)
+}
+
+// TestExportFullDrainCapReturnsAccumulatedResultAfterUnsettledQueue covers
+// plan deviation 5: exportFullToStore's terminal drain must not spin forever
+// when a concurrent writer keeps the queue perpetually non-empty. It must
+// give up after maxExportDrainRounds and still return whatever it exported.
+func TestExportFullDrainCapReturnsAccumulatedResultAfterUnsettledQueue(t *testing.T) {
+	const drainRounds = 3
+	database := testExportDB(t)
+	seedSession(t, database, "sess-1", "alpha")
+	filesystem, err := newProtocolTestStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, filesystem.Close()) })
+	store := &reEnqueueOnBoundaryStore{DB: database}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	result, err := exportFullToStoreWithDrainRounds(
+		ctx, store, filesystem, contractOrigin, drainRounds,
+	)
+	require.EqualError(t, err, "artifact export queue did not settle after 3 drain rounds")
+	assert.Positive(t, result.ExportedSessions,
+		"the accumulated result must still be returned alongside the drain-cap error")
+}
+
+type reEnqueueAfterAcknowledgeStore struct {
+	*db.DB
+	requeues int
+}
+
+func (s *reEnqueueAfterAcknowledgeStore) FinalizeArtifactExports(
+	ctx context.Context, outcomes []db.ArtifactExportOutcome,
+) error {
+	if err := s.DB.FinalizeArtifactExports(ctx, outcomes); err != nil {
+		return err
+	}
+	return s.requeue(outcomes)
+}
+
+func (s *reEnqueueAfterAcknowledgeStore) RecordArtifactCheckpointHeadOutcomes(
+	ctx context.Context,
+	head db.ArtifactCheckpointHead,
+	outcomes []db.ArtifactExportOutcome,
+) error {
+	if err := s.DB.RecordArtifactCheckpointHeadOutcomes(ctx, head, outcomes); err != nil {
+		return err
+	}
+	return s.requeue(outcomes)
+}
+
+func (s *reEnqueueAfterAcknowledgeStore) requeue(
+	outcomes []db.ArtifactExportOutcome,
+) error {
+	if len(outcomes) == 0 {
+		return nil
+	}
+	s.requeues++
+	return s.ReplaceSessionMessages("sess-1", []db.Message{{
+		SessionID: "sess-1", Ordinal: 0, Role: "user",
+		Content: fmt.Sprintf("concurrent write %d", s.requeues),
+	}})
+}
+
+func TestExportFullDrainCapAppliesToWritesArrivingDuringDrain(t *testing.T) {
+	const drainRounds = 3
+	database := testExportDB(t)
+	seedSession(t, database, "sess-1", "alpha")
+	filesystem, err := newProtocolTestStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, filesystem.Close()) })
+	concurrent := &reEnqueueAfterAcknowledgeStore{DB: database}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+
+	result, err := exportFullToStoreWithDrainRounds(
+		ctx, concurrent, filesystem, contractOrigin, drainRounds,
+	)
+	require.EqualError(t, err, "artifact export queue did not settle after 3 drain rounds")
+	assert.Positive(t, result.ExportedSessions)
+	assert.GreaterOrEqual(t, concurrent.requeues, drainRounds)
+}
+
+// TestExportRoundTripsSessionQualitySignals pins the PR1 invariant that the
+// manifest-level session_quality_signals field is the sole canonical carrier
+// for a session's quality signals (manifest_session.go): the inner session
+// DTO must never gain a quality-signals field of its own, and every seeded
+// signal value -- not just non-nil presence -- must survive the encode then
+// decode round trip.
+func TestExportRoundTripsSessionQualitySignals(t *testing.T) {
+	ctx := context.Background()
+	database := testExportDB(t)
+	store := newTestArtifactStore(t)
+	origin := contractOrigin
+	seedSession(t, database, "sess-1", "alpha")
+
+	want := db.QualitySignals{
+		Version:                     2,
+		ShortPromptCount:            3,
+		UnstructuredStart:           true,
+		MissingSuccessCriteriaCount: 4,
+		MissingVerificationCount:    5,
+		DuplicatePromptCount:        6,
+		NoCodeContextCount:          7,
+		RunawayToolLoopCount:        8,
+	}
+	require.NoError(t, database.UpdateSessionSignals("sess-1", db.SessionSignalUpdate{
+		QualitySignals: want,
+	}))
+	seeded, err := database.GetSessionFull(ctx, "sess-1")
+	require.NoError(t, err)
+	require.NotNil(t, seeded)
+	require.Equal(t, &want, seeded.StoredQualitySignals(),
+		"UpdateSessionSignals must persist through the scalar columns export reads")
+
+	result, err := ExportToStore(ctx, database, store, ExportOptions{Origin: origin, Full: true})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.ExportedSessions)
+
+	cp := latestStoreCheckpointForTest(t, store, origin)
+	manifestHash := cp.Sessions[origin+"~sess-1"]
+	require.NotEmpty(t, manifestHash)
+	ref, err := NewRef(origin, KindManifests, manifestHash+".json")
+	require.NoError(t, err)
+	m, err := decodeManifestWithLimits(readContractArtifact(t, store, ref), productionArtifactLimits())
+	require.NoError(t, err)
+
+	require.NotNil(t, m.SessionQualitySignals)
+	assert.Equal(t, &manifestQualitySignals{
+		Version:                     want.Version,
+		ShortPromptCount:            want.ShortPromptCount,
+		UnstructuredStart:           want.UnstructuredStart,
+		MissingSuccessCriteriaCount: want.MissingSuccessCriteriaCount,
+		MissingVerificationCount:    want.MissingVerificationCount,
+		DuplicatePromptCount:        want.DuplicatePromptCount,
+		NoCodeContextCount:          want.NoCodeContextCount,
+		RunawayToolLoopCount:        want.RunawayToolLoopCount,
+	}, m.SessionQualitySignals, "the manifest-level field must round-trip every seeded value")
+
+	sessionData, err := json.Marshal(m.Session)
+	require.NoError(t, err)
+	assert.NotContains(t, string(sessionData), "short_prompt_count",
+		"the inner session DTO must carry no quality-signals content of its own")
+	assert.NotContains(t, string(sessionData), `"quality_signals"`,
+		"the inner session DTO must carry no quality-signals content of its own")
+}

--- a/internal/artifact/export_test.go
+++ b/internal/artifact/export_test.go
@@ -123,11 +123,11 @@ type countingCanonicalExportDB struct {
 	usageLoads   int
 }
 
-func (s *countingCanonicalExportDB) GetSessionFull(
+func (s *countingCanonicalExportDB) GetArtifactExportSession(
 	ctx context.Context, id string,
 ) (*db.Session, error) {
 	s.sessionLoads++
-	return s.DB.GetSessionFull(ctx, id)
+	return s.DB.GetArtifactExportSession(ctx, id)
 }
 
 func (s *countingCanonicalExportDB) LoadArtifactExportData(
@@ -583,6 +583,41 @@ func TestExportToStorePublishesDependenciesBeforeCheckpointAndSkipsUnchanged(t *
 	assert.Equal(t, Kind(KindManifests), store.creates[1].Ref.Kind)
 	assert.False(t, store.creates[0].Created)
 	assert.False(t, store.creates[1].Created)
+}
+
+func TestExportKeepsAgentSessionNameSeparateFromUserDisplayName(t *testing.T) {
+	database := testExportDB(t)
+	store := newTestArtifactStore(t)
+	agentName := "Agent-provided title"
+	seedSession(t, database, "sess-1", "alpha", func(sess *db.Session) {
+		sess.SessionName = &agentName
+	})
+	var storedDisplayName, storedSessionName *string
+	require.NoError(t, database.Reader().QueryRow(
+		`SELECT display_name, session_name FROM sessions WHERE id = ?`, "sess-1",
+	).Scan(&storedDisplayName, &storedSessionName))
+	assert.Nil(t, storedDisplayName)
+	require.NotNil(t, storedSessionName)
+	assert.Equal(t, agentName, *storedSessionName)
+
+	result, err := ExportToStore(
+		t.Context(), database, store, ExportOptions{Origin: contractOrigin},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.ExportedSessions)
+
+	checkpoint := latestStoreCheckpointForTest(t, store, contractOrigin)
+	manifestHash := checkpoint.Sessions[contractOrigin+"~sess-1"]
+	require.NotEmpty(t, manifestHash)
+	ref, err := NewRef(contractOrigin, KindManifests, manifestHash+".json")
+	require.NoError(t, err)
+	published, err := decodeManifestWithLimits(
+		readContractArtifact(t, store, ref), productionArtifactLimits(),
+	)
+	require.NoError(t, err)
+	assert.Nil(t, published.Session.DisplayName)
+	require.NotNil(t, published.SessionName)
+	assert.Equal(t, agentName, *published.SessionName)
 }
 
 func TestExportToStoreFullRepairsMissingDependencyWithoutNewCheckpoint(t *testing.T) {
@@ -1045,7 +1080,7 @@ func TestExportToStorePublicationRevisionRejectsPhysicallyCreatedStaleCheckpoint
 	claimA, err := first.ArtifactExportClaims(ctx, []string{"session-a"})
 	require.NoError(t, err)
 	require.Len(t, claimA, 1)
-	sessionA, err := first.GetSessionFull(ctx, "session-a")
+	sessionA, err := first.GetArtifactExportSession(ctx, "session-a")
 	require.NoError(t, err)
 	messagesA, err := first.GetAllMessages(ctx, "session-a")
 	require.NoError(t, err)
@@ -1071,7 +1106,7 @@ func TestExportToStorePublicationRevisionRejectsPhysicallyCreatedStaleCheckpoint
 	claimB, err := second.ArtifactExportClaims(ctx, []string{"session-b"})
 	require.NoError(t, err)
 	require.Len(t, claimB, 1)
-	sessionB, err := second.GetSessionFull(ctx, "session-b")
+	sessionB, err := second.GetArtifactExportSession(ctx, "session-b")
 	require.NoError(t, err)
 	messagesB, err := second.GetAllMessages(ctx, "session-b")
 	require.NoError(t, err)

--- a/internal/artifact/format_test.go
+++ b/internal/artifact/format_test.go
@@ -103,6 +103,25 @@ func TestCanonicalManifestGolden(t *testing.T) {
 	assert.Equal(t, "d84a3987c40f800f23ea943ebd50c0910c64444e6ff4b64b6f8a68782f7a32d6", hashHex(data))
 }
 
+func TestDecodeManifestRejectsUnsupportedOlderVersion(t *testing.T) {
+	data := []byte(`{
+		"v": 1,
+		"origin": "laptop-a1b2c3",
+		"native_session_id": "sess-1",
+		"segments": [],
+		"usage_events": [{
+			"source": "fixture",
+			"model": "claude-test",
+			"cost_usd": 0.03125
+		}]
+	}`)
+
+	decoded, err := decodeManifestWithLimits(data, productionArtifactLimits())
+	require.Error(t, err)
+	assert.Empty(t, decoded)
+	assert.Contains(t, err.Error(), "manifest has unsupported artifact version 1")
+}
+
 func TestCanonicalMessageSegmentGolden(t *testing.T) {
 	msgs := []db.Message{
 		{

--- a/internal/artifact/limits.go
+++ b/internal/artifact/limits.go
@@ -1,0 +1,126 @@
+package artifact
+
+import (
+	"errors"
+	"fmt"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+// ErrArtifactExportRejected identifies a deterministic session-shape failure
+// that can be finalized without retrying the same generation forever.
+var ErrArtifactExportRejected = errors.New("artifact export rejected")
+
+const (
+	originStateKey    = "artifact_origin_id"
+	segmentTargetSize = int64(32 << 20)
+
+	// Cardinality caps complement the byte caps: 4,096 records keeps one
+	// segment's decoded object graph bounded, while 32,768 records and 256 MiB
+	// leave ample room for unusually long sessions without letting many valid
+	// chunks amplify during aggregation. Sixteen references accommodate uneven
+	// 32 MiB chunks; the aggregate byte cap remains the final session bound.
+	maxManifestSegments    = 16
+	maxManifestUsageEvents = 32_768
+	maxSegmentMessages     = 4_096
+	maxSessionMessages     = 32_768
+	maxSessionDecodedBytes = int64(256 << 20)
+
+	// Nested collections need independent caps because compact empty objects can
+	// amplify far beyond the decoded byte budget when unmarshaled. A message may
+	// still describe unusually wide tool fan-out, and one tool may retain a long
+	// result history. Segment totals keep one decoded chunk modest; session totals
+	// allow eight full nested-budget segments, matching the message-count ratio.
+	maxMessageToolCalls    = 256
+	maxToolResultEvents    = 1_024
+	maxSegmentToolCalls    = 8_192
+	maxSegmentResultEvents = 32_768
+	maxSessionToolCalls    = 65_536
+	maxSessionResultEvents = 262_144
+)
+
+const (
+	checkpointFloorPageSize = 128
+	checkpointDecodedLimit  = int64(64 << 20)
+)
+
+// artifactLimits bounds decoded collection cardinality in addition to raw
+// bytes. The production values are intentionally generous for real sessions
+// while preventing small JSON records from amplifying into unbounded Go
+// object graphs.
+type artifactLimits struct {
+	manifestSegments    int
+	manifestUsageEvents int
+	segmentMessages     int
+	sessionMessages     int
+	sessionDecodedBytes int64
+	messageToolCalls    int
+	toolResultEvents    int
+	segmentToolCalls    int
+	segmentResultEvents int
+	sessionToolCalls    int
+	sessionResultEvents int
+}
+
+func productionArtifactLimits() artifactLimits {
+	return artifactLimits{
+		manifestSegments:    maxManifestSegments,
+		manifestUsageEvents: maxManifestUsageEvents,
+		segmentMessages:     maxSegmentMessages,
+		sessionMessages:     maxSessionMessages,
+		sessionDecodedBytes: maxSessionDecodedBytes,
+		messageToolCalls:    maxMessageToolCalls,
+		toolResultEvents:    maxToolResultEvents,
+		segmentToolCalls:    maxSegmentToolCalls,
+		segmentResultEvents: maxSegmentResultEvents,
+		sessionToolCalls:    maxSessionToolCalls,
+		sessionResultEvents: maxSessionResultEvents,
+	}
+}
+
+func artifactExportLoadLimits(limits artifactLimits) db.ArtifactExportLoadLimits {
+	return db.ArtifactExportLoadLimits{
+		Messages:            limits.sessionMessages,
+		UsageEvents:         limits.manifestUsageEvents,
+		MessageToolCalls:    limits.messageToolCalls,
+		ToolResultEvents:    limits.toolResultEvents,
+		SessionToolCalls:    limits.sessionToolCalls,
+		SessionResultEvents: limits.sessionResultEvents,
+		MessageBytes:        limits.sessionDecodedBytes,
+		UsageBytes:          manifestDecodedLimit,
+	}
+}
+
+func rejectArtifactExportf(format string, args ...any) error {
+	return fmt.Errorf(
+		"%w: %s", ErrArtifactExportRejected, fmt.Sprintf(format, args...),
+	)
+}
+
+func classifyArtifactExportLoadError(err error) error {
+	if errors.Is(err, db.ErrArtifactExportLimit) {
+		return fmt.Errorf("%w: %w", ErrArtifactExportRejected, err)
+	}
+	return err
+}
+
+func isDeterministicArtifactExportError(err error) bool {
+	return errors.Is(err, ErrArtifactExportRejected) ||
+		errors.Is(err, db.ErrArtifactExportLimit)
+}
+
+type nestedCollectionCounts struct {
+	toolCalls    int
+	resultEvents int
+}
+
+type segmentPreflight struct {
+	records [][]byte
+	nested  nestedCollectionCounts
+}
+
+func exceedsCollectionLimit(current, additional, limit int) bool {
+	return current > limit || additional > limit-current
+}
+
+var errFutureArtifactVersion = errors.New("future artifact version")

--- a/internal/artifact/origin.go
+++ b/internal/artifact/origin.go
@@ -45,9 +45,6 @@ func AdoptOrigin(database *db.DB, origin string) error {
 	if err := validateOriginID(origin); err != nil {
 		return fmt.Errorf("adopting artifact origin: %w", err)
 	}
-	if _, err := StoredOrigin(database); err != nil {
-		return err
-	}
 	if err := database.AdoptArtifactOrigin(origin); err != nil {
 		return fmt.Errorf("adopting artifact origin: %w", err)
 	}

--- a/internal/artifact/origin.go
+++ b/internal/artifact/origin.go
@@ -1,0 +1,105 @@
+package artifact
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strings"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+// EnsureOrigin returns the persisted origin ID, creating one when absent.
+func EnsureOrigin(database *db.DB) (string, error) {
+	origin, err := StoredOrigin(database)
+	if err != nil {
+		return "", err
+	}
+	if origin != "" {
+		return origin, nil
+	}
+	origin, err = newOriginID()
+	if err != nil {
+		return "", err
+	}
+	if err := validateOriginID(origin); err != nil {
+		return "", fmt.Errorf("generated artifact origin: %w", err)
+	}
+	origin, err = database.EnsureArtifactOrigin(origin)
+	if err != nil {
+		return "", fmt.Errorf("initializing artifact origin: %w", err)
+	}
+	if err := validateOriginID(origin); err != nil {
+		return "", fmt.Errorf("stored artifact origin: %w", err)
+	}
+	return origin, nil
+}
+
+// AdoptOrigin persists origin as this machine's artifact origin in the database
+// sync state so DB-derived lookups (EnsureOrigin and its callers) agree with the
+// authoritative config origin. It validates the input and is idempotent: it only
+// writes when the stored value differs. The config origin always wins, so a
+// previously stored value is overwritten to converge on a single origin.
+func AdoptOrigin(database *db.DB, origin string) error {
+	if err := validateOriginID(origin); err != nil {
+		return fmt.Errorf("adopting artifact origin: %w", err)
+	}
+	if _, err := StoredOrigin(database); err != nil {
+		return err
+	}
+	if err := database.AdoptArtifactOrigin(origin); err != nil {
+		return fmt.Errorf("adopting artifact origin: %w", err)
+	}
+	return nil
+}
+
+// StoredOrigin returns the persisted origin ID without creating one.
+func StoredOrigin(database *db.DB) (string, error) {
+	origin, err := database.GetSyncState(originStateKey)
+	if err != nil {
+		return "", fmt.Errorf("reading artifact origin: %w", err)
+	}
+	if origin != "" {
+		if err := validateOriginID(origin); err != nil {
+			return "", fmt.Errorf("stored artifact origin: %w", err)
+		}
+		return origin, nil
+	}
+	return "", nil
+}
+
+func newOriginID() (string, error) {
+	host, err := os.Hostname()
+	if err != nil || strings.TrimSpace(host) == "" {
+		host = "machine"
+	}
+	host = sanitizeOriginPart(host)
+	if host == "" || host == "local" {
+		host = "machine"
+	}
+	var suffix [3]byte
+	if _, err := rand.Read(suffix[:]); err != nil {
+		return "", fmt.Errorf("generating artifact origin suffix: %w", err)
+	}
+	return fmt.Sprintf("%s-%s", host, hex.EncodeToString(suffix[:])), nil
+}
+
+func sanitizeOriginPart(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	var b strings.Builder
+	lastDash := false
+	for _, r := range s {
+		ok := r >= 'a' && r <= 'z' || r >= '0' && r <= '9'
+		if ok {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}

--- a/internal/artifact/origin_test.go
+++ b/internal/artifact/origin_test.go
@@ -1,0 +1,306 @@
+package artifact
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/db"
+)
+
+func TestEnsureOriginPersists(t *testing.T) {
+	database := testDB(t)
+
+	first, err := EnsureOrigin(database)
+	require.NoError(t, err)
+	require.NotEmpty(t, first)
+	require.NotEqual(t, "local", first)
+
+	second, err := EnsureOrigin(database)
+	require.NoError(t, err)
+	assert.Equal(t, first, second)
+}
+
+func TestAdoptOriginPersistsConfigOrigin(t *testing.T) {
+	database := testDB(t)
+
+	require.NoError(t, AdoptOrigin(database, "desk-a1b2c3"))
+
+	stored, err := StoredOrigin(database)
+	require.NoError(t, err)
+	assert.Equal(t, "desk-a1b2c3", stored)
+
+	// EnsureOrigin and its callers now agree with the adopted origin instead
+	// of generating a divergent DB-only value.
+	ensured, err := EnsureOrigin(database)
+	require.NoError(t, err)
+	assert.Equal(t, "desk-a1b2c3", ensured)
+}
+
+func TestAdoptOriginIsIdempotent(t *testing.T) {
+	database := testDB(t)
+
+	require.NoError(t, AdoptOrigin(database, "desk-a1b2c3"))
+	require.NoError(t, AdoptOrigin(database, "desk-a1b2c3"))
+
+	stored, err := StoredOrigin(database)
+	require.NoError(t, err)
+	assert.Equal(t, "desk-a1b2c3", stored)
+}
+
+func TestAdoptOriginOverwritesDivergentDBOrigin(t *testing.T) {
+	database := testDB(t)
+
+	// Simulate the pre-fix state: the recorder generated a DB-only origin
+	// before the authoritative config origin existed.
+	stale, err := EnsureOrigin(database)
+	require.NoError(t, err)
+	require.NotEqual(t, "desk-a1b2c3", stale)
+
+	require.NoError(t, AdoptOrigin(database, "desk-a1b2c3"))
+
+	stored, err := StoredOrigin(database)
+	require.NoError(t, err)
+	assert.Equal(t, "desk-a1b2c3", stored)
+}
+
+func TestAdoptOriginRejectsInvalidOrigin(t *testing.T) {
+	database := testDB(t)
+
+	err := AdoptOrigin(database, "../outside")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "adopting artifact origin")
+
+	stored, err := StoredOrigin(database)
+	require.NoError(t, err)
+	assert.Empty(t, stored)
+}
+
+func TestEnsureOriginRejectsInvalidPersistedOrigin(t *testing.T) {
+	database := testDB(t)
+	require.NoError(t, database.SetSyncState(originStateKey, "../outside"))
+
+	origin, err := EnsureOrigin(database)
+	require.Error(t, err)
+	assert.Empty(t, origin)
+	assert.Contains(t, err.Error(), "stored artifact origin")
+	assert.Contains(t, err.Error(), "invalid artifact origin")
+}
+
+// TestEnsureOriginBootstrapsPreExistingLocalSessions verifies the deviation-2
+// ordering: sessions written before an artifact origin exists are invisible
+// to the origin-gated queue triggers and enqueue hooks, so EnsureOrigin must
+// bootstrap the queue immediately after it persists the origin key.
+func TestEnsureOriginBootstrapsPreExistingLocalSessions(t *testing.T) {
+	database := testDB(t)
+	seedSession(t, database, "sess-1", "alpha")
+	seedSession(t, database, "sess-2", "alpha")
+
+	pending, err := database.PendingArtifactExports(t.Context(), 10)
+	require.NoError(t, err)
+	require.Empty(t, pending, "no origin yet: queue triggers stay gated")
+
+	origin, err := EnsureOrigin(database)
+	require.NoError(t, err)
+	require.NotEmpty(t, origin)
+
+	pending, err = database.PendingArtifactExports(t.Context(), 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 2)
+	assert.ElementsMatch(t, []string{"sess-1", "sess-2"}, []string{
+		pending[0].SessionID, pending[1].SessionID,
+	})
+}
+
+// TestAdoptOriginRequeuesAllExportsOnDivergentAdoption covers the divergent
+// adoption path: when a new origin replaces an established one whose sessions
+// are already acknowledged, INSERT OR IGNORE bootstrap would leave the ledger
+// empty, so every owned session must be force-requeued with a bumped
+// generation.
+func TestAdoptOriginRequeuesAllExportsOnDivergentAdoption(t *testing.T) {
+	database := testDB(t)
+	require.NoError(t, AdoptOrigin(database, "origin-a1b2c3"))
+	seedSession(t, database, "sess-1", "alpha")
+	seedSession(t, database, "sess-2", "alpha")
+
+	ctx := t.Context()
+	pending, err := database.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 2)
+	genBefore := map[string]int64{}
+	for _, item := range pending {
+		genBefore[item.SessionID] = item.Generation
+	}
+
+	// Simulate the prior origin having fully published every session.
+	require.NoError(t, database.AcknowledgeArtifactExports(ctx, pending))
+	drained, err := database.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	require.Empty(t, drained)
+
+	require.NoError(t, AdoptOrigin(database, "origin-d4e5f6"))
+	pending, err = database.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 2, "divergent adoption re-verifies every owned session")
+	assert.ElementsMatch(t, []string{"sess-1", "sess-2"}, []string{
+		pending[0].SessionID, pending[1].SessionID,
+	})
+	for _, item := range pending {
+		assert.Greater(t, item.Generation, genBefore[item.SessionID],
+			"divergent adoption must bump the generation of every requeued session")
+	}
+}
+
+func TestAdoptOriginRemovesPublicationsThatBecameDeletedWhileOriginWasInactive(t *testing.T) {
+	database := testDB(t)
+	store, err := newProtocolTestStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	const (
+		originA = "origin-a1b2c3"
+		originB = "origin-d4e5f6"
+	)
+	require.NoError(t, AdoptOrigin(database, originA))
+	seedSession(t, database, "sess-1", "alpha")
+	_, err = ExportToStore(t.Context(), database, store, ExportOptions{Origin: originA})
+	require.NoError(t, err)
+	require.Contains(t, latestStoreCheckpointForTest(t, store, originA).Sessions,
+		originA+"~sess-1")
+
+	require.NoError(t, AdoptOrigin(database, originB))
+	require.NoError(t, database.SoftDeleteSession("sess-1"))
+	_, err = ExportToStore(t.Context(), database, store, ExportOptions{Origin: originB})
+	require.NoError(t, err)
+	pending, err := database.PendingArtifactExports(t.Context(), 10)
+	require.NoError(t, err)
+	require.Empty(t, pending)
+
+	require.NoError(t, AdoptOrigin(database, originA))
+	_, err = ExportToStore(t.Context(), database, store, ExportOptions{Origin: originA})
+	require.NoError(t, err)
+	assert.NotContains(t, latestStoreCheckpointForTest(t, store, originA).Sessions,
+		originA+"~sess-1")
+}
+
+func TestOriginRejectionLifecycleRemovesRetriesAndRequeues(t *testing.T) {
+	database := testDB(t)
+	store, err := newProtocolTestStore(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	const (
+		originA    = "origin-a1b2c3"
+		originB    = "origin-d4e5f6"
+		sessionID  = "sess-1"
+		sessionGID = originA + "~" + sessionID
+	)
+	require.NoError(t, AdoptOrigin(database, originA))
+	seedSession(t, database, sessionID, "alpha")
+	_, err = ExportToStore(t.Context(), database, store, ExportOptions{
+		Origin: originA,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, latestStoreCheckpointForTest(t, store, originA).Sessions,
+		sessionGID)
+
+	require.NoError(t, database.ReplaceSessionMessages(sessionID, []db.Message{
+		{SessionID: sessionID, Ordinal: 0, Role: "user", Content: "one"},
+		{SessionID: sessionID, Ordinal: 1, Role: "assistant", Content: "two"},
+		{SessionID: sessionID, Ordinal: 2, Role: "user", Content: "three"},
+	}))
+	limits := productionArtifactLimits()
+	limits.sessionMessages = 2
+	result, err := exportToStoreWithLimits(
+		t.Context(), database, store, ExportOptions{Origin: originA}, limits,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.RejectedSessions)
+	assert.NotContains(t, latestStoreCheckpointForTest(t, store, originA).Sessions,
+		sessionGID)
+	rejection, ok, err := database.GetArtifactExportRejection(t.Context(), sessionID)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Contains(t, rejection.Error, "message count exceeds 2")
+
+	require.NoError(t, database.ReplaceSessionMessages(sessionID, []db.Message{
+		{SessionID: sessionID, Ordinal: 0, Role: "user", Content: "fixed"},
+	}))
+	_, ok, err = database.GetArtifactExportRejection(t.Context(), sessionID)
+	require.NoError(t, err)
+	assert.False(t, ok, "a new generation clears the prior rejection")
+	result, err = exportToStoreWithLimits(
+		t.Context(), database, store, ExportOptions{Origin: originA}, limits,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.ExportedSessions)
+	assert.Contains(t, latestStoreCheckpointForTest(t, store, originA).Sessions,
+		sessionGID)
+
+	require.NoError(t, AdoptOrigin(database, originB))
+	pending, err := database.PendingArtifactExports(t.Context(), 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	assert.Equal(t, sessionID, pending[0].SessionID)
+	for _, item := range pending {
+		_, rejected, rejectionErr := database.GetArtifactExportRejection(
+			t.Context(), item.SessionID,
+		)
+		require.NoError(t, rejectionErr)
+		assert.False(t, rejected,
+			"origin adoption must not carry stale rejection diagnostics")
+	}
+}
+
+// TestAdoptOriginBootstrapsPreExistingLocalSessions mirrors the EnsureOrigin
+// case for the AdoptOrigin path (used when a config-declared origin is
+// applied to a database that predates it).
+func TestAdoptOriginBootstrapsPreExistingLocalSessions(t *testing.T) {
+	database := testDB(t)
+	seedSession(t, database, "sess-1", "alpha")
+
+	pending, err := database.PendingArtifactExports(t.Context(), 10)
+	require.NoError(t, err)
+	require.Empty(t, pending, "no origin yet: queue triggers stay gated")
+
+	require.NoError(t, AdoptOrigin(database, "desk-a1b2c3"))
+
+	pending, err = database.PendingArtifactExports(t.Context(), 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	assert.Equal(t, "sess-1", pending[0].SessionID)
+}
+
+func testDB(t *testing.T) *db.DB {
+	t.Helper()
+	database, err := db.Open(filepath.Join(t.TempDir(), "test.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { database.Close() })
+	return database
+}
+
+func seedSession(t *testing.T, database *db.DB, id, project string, opts ...func(*db.Session)) {
+	t.Helper()
+	sess := db.Session{
+		ID:               id,
+		Project:          project,
+		Machine:          "local",
+		Agent:            "claude",
+		MessageCount:     2,
+		UserMessageCount: 1,
+		FirstMessage:     new("hello"),
+		StartedAt:        new("2026-06-14T01:02:03Z"),
+		EndedAt:          new("2026-06-14T01:03:03Z"),
+		SessionName:      new("Test Session"),
+		CreatedAt:        "2026-06-14T01:02:03Z",
+	}
+	for _, opt := range opts {
+		opt(&sess)
+	}
+	require.NoError(t, database.UpsertSession(sess))
+	require.NoError(t, database.ReplaceSessionMessages(id, []db.Message{
+		{SessionID: id, Ordinal: 0, Role: "user", Content: "hello", ContentLength: 5},
+		{SessionID: id, Ordinal: 1, Role: "assistant", Content: "world", ContentLength: 5},
+	}))
+}

--- a/internal/artifact/origin_test.go
+++ b/internal/artifact/origin_test.go
@@ -65,6 +65,17 @@ func TestAdoptOriginOverwritesDivergentDBOrigin(t *testing.T) {
 	assert.Equal(t, "desk-a1b2c3", stored)
 }
 
+func TestAdoptOriginRepairsInvalidPersistedOrigin(t *testing.T) {
+	database := testDB(t)
+	require.NoError(t, database.SetSyncState(originStateKey, "../outside"))
+
+	require.NoError(t, AdoptOrigin(database, "desk-a1b2c3"))
+
+	stored, err := StoredOrigin(database)
+	require.NoError(t, err)
+	assert.Equal(t, "desk-a1b2c3", stored)
+}
+
 func TestAdoptOriginRejectsInvalidOrigin(t *testing.T) {
 	database := testDB(t)
 

--- a/internal/artifact/store.go
+++ b/internal/artifact/store.go
@@ -92,6 +92,18 @@ func canonicalArtifactMediaType(kind Kind) string {
 	}
 }
 
+type contextArtifactReader struct {
+	ctx    context.Context
+	reader io.Reader
+}
+
+func (r *contextArtifactReader) Read(p []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return r.reader.Read(p)
+}
+
 func artifactStoreError(op string, ref Ref, err error) error {
 	return &ArtifactOpError{Op: op, Ref: ref, Err: err}
 }

--- a/internal/artifact/store_docbank.go
+++ b/internal/artifact/store_docbank.go
@@ -399,6 +399,95 @@ func (s *docbankStore) Close() error {
 	return s.vault.Close()
 }
 
+// checkpointFloor traverses both Docbank namespaces through stable walkers,
+// page-by-page, without materializing either checkpoint collection.
+func (s *docbankStore) checkpointFloor(
+	ctx context.Context, origin string,
+) (int, error) {
+	liveCollection := docbankLiveRoot + "/" + origin + "/" + string(KindCheckpoints)
+	live, err := s.walkCheckpointFloor(ctx, liveCollection, false)
+	if err != nil {
+		return 0, err
+	}
+	quarantineCollection := docbankQuarantineRoot + "/" + origin + "/" + string(KindCheckpoints)
+	quarantined, err := s.walkCheckpointFloor(ctx, quarantineCollection, true)
+	if err != nil {
+		return 0, err
+	}
+	return max(live, quarantined), nil
+}
+
+func (s *docbankStore) walkCheckpointFloor(
+	ctx context.Context, collection string, quarantined bool,
+) (_ int, retErr error) {
+	return walkCheckpointFloor(ctx, collection, quarantined, func(
+		ctx context.Context,
+	) (docbankWalker, error) {
+		return s.vault.Walk(ctx, collection, docbank.WalkOptions{
+			PageSize: checkpointFloorPageSize,
+		})
+	})
+}
+
+func walkCheckpointFloor(
+	ctx context.Context,
+	collection string,
+	quarantined bool,
+	open func(context.Context) (docbankWalker, error),
+) (_ int, retErr error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	walker, err := open(ctx)
+	if errors.Is(err, docbank.ErrNotFound) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, mapDocbankError(err)
+	}
+	defer func() { retErr = errors.Join(retErr, walker.Close()) }()
+	prefix := collection + "/"
+	floor := 0
+	for {
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
+		page, nextErr := walker.Next(ctx)
+		if err := ctx.Err(); err != nil {
+			return 0, err
+		}
+		if errors.Is(nextErr, io.EOF) {
+			return floor, nil
+		}
+		if nextErr != nil {
+			return 0, mapDocbankError(nextErr)
+		}
+		for _, item := range page {
+			if item.Node.BlobHash == "" {
+				continue
+			}
+			name := strings.TrimPrefix(item.Path, prefix)
+			if name == item.Path || strings.Contains(name, "/") {
+				continue
+			}
+			if quarantined {
+				if len(name) <= 33 || name[32] != '-' {
+					continue
+				}
+				quarantineID, err := hex.DecodeString(name[:32])
+				if err != nil || len(quarantineID) != 16 {
+					continue
+				}
+				name = name[33:]
+			}
+			sequence, err := checkpointSequence(name)
+			if err == nil {
+				floor = max(floor, sequence)
+			}
+		}
+	}
+}
+
 type docbankWalker interface {
 	Next(context.Context) ([]docbank.WalkEntry, error)
 	Close() error

--- a/internal/artifact/store_docbank_test.go
+++ b/internal/artifact/store_docbank_test.go
@@ -234,6 +234,23 @@ func newTestDocbankStore(t *testing.T, config docbank.Config) (*docbank.Vault, *
 	return vault, store
 }
 
+func newTestArtifactStore(t *testing.T) *docbankStore {
+	t.Helper()
+	_, store := newTestDocbankStore(t, docbank.Config{})
+	return store
+}
+
+// newProtocolTestStore opens a real isolated Docbank store at root without
+// registering test cleanup. Callers use it for explicit close/reopen protocol
+// and transport scenarios.
+func newProtocolTestStore(root string) (*docbankStore, error) {
+	vault, err := docbank.New(context.Background(), docbank.Config{Root: root})
+	if err != nil {
+		return nil, err
+	}
+	return newDocbankContent(vault), nil
+}
+
 func walkDocbankTestEntries(
 	t *testing.T, vault *docbank.Vault, root string,
 ) []docbank.WalkEntry {

--- a/internal/artifact/store_iterator_test.go
+++ b/internal/artifact/store_iterator_test.go
@@ -1,0 +1,22 @@
+package artifact
+
+import (
+	"context"
+	"errors"
+	"io"
+)
+
+func firstStoreEntryPage(
+	ctx context.Context, store ArtifactStore, origin string, kind Kind, limit int,
+) (_ Page, retErr error) {
+	iterator, err := store.Entries(ctx, origin, kind)
+	if err != nil {
+		return Page{}, err
+	}
+	defer func() { retErr = errors.Join(retErr, iterator.Close()) }()
+	items, err := iterator.Next(ctx, limit)
+	if errors.Is(err, io.EOF) {
+		err = nil
+	}
+	return Page{Items: items}, err
+}

--- a/internal/artifact/wire_codec.go
+++ b/internal/artifact/wire_codec.go
@@ -15,6 +15,9 @@ const (
 	manifestExtension = ".json.zst"
 	segmentExtension  = ".ndjson.zst"
 
+	manifestDecodedLimit = int64(16 << 20)
+	segmentDecodedLimit  = int64(64 << 20)
+
 	// zstd.NewWriter documents an 8 MiB maximum default window. Pinning that
 	// size keeps existing package-written artifacts readable without accepting
 	// attacker-selected large decoder windows.

--- a/internal/artifact/wire_decode.go
+++ b/internal/artifact/wire_decode.go
@@ -1,0 +1,381 @@
+package artifact
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"go.kenn.io/agentsview/internal/db"
+)
+
+func decodeManifestWithLimits(data []byte, limits artifactLimits) (manifest, error) {
+	var envelope struct {
+		Version     int             `json:"v"`
+		Origin      string          `json:"origin"`
+		Segments    json.RawMessage `json:"segments"`
+		UsageEvents json.RawMessage `json:"usage_events"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return manifest{}, err
+	}
+	// Future manifests are retained for forward compatibility. Reading only
+	// their scalar header avoids allocating collections whose schema this
+	// version does not understand.
+	if envelope.Version > manifestFormatVersion {
+		return manifest{Version: envelope.Version, Origin: envelope.Origin}, nil
+	}
+	if envelope.Version != manifestFormatVersion {
+		return manifest{}, fmt.Errorf(
+			"manifest has unsupported artifact version %d", envelope.Version,
+		)
+	}
+	if err := preflightManifestCollections(
+		envelope.Segments, envelope.UsageEvents, limits,
+	); err != nil {
+		return manifest{}, err
+	}
+	var m manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return manifest{}, err
+	}
+	return m, nil
+}
+
+func preflightManifestCollections(
+	segments, usageEvents json.RawMessage,
+	limits artifactLimits,
+) error {
+	if err := preflightSegmentReferences(segments, limits.manifestSegments); err != nil {
+		return err
+	}
+	return preflightJSONArrayCount(
+		usageEvents, "manifest usage event", limits.manifestUsageEvents,
+	)
+}
+
+func preflightSegmentReferences(data json.RawMessage, limit int) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil
+	}
+	dec := json.NewDecoder(bytes.NewReader(trimmed))
+	token, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	if token != json.Delim('[') {
+		return errors.New("manifest segments must be an array")
+	}
+	seen := make(map[string]struct{}, min(limit, 16))
+	count := 0
+	for dec.More() {
+		if count >= limit {
+			return fmt.Errorf("manifest segment reference limit exceeded: limit %d", limit)
+		}
+		var hash string
+		if err := dec.Decode(&hash); err != nil {
+			return fmt.Errorf("decoding manifest segment reference: %w", err)
+		}
+		if _, ok := seen[hash]; ok {
+			return fmt.Errorf("manifest has duplicate segment reference %s", hash)
+		}
+		seen[hash] = struct{}{}
+		count++
+	}
+	_, err = dec.Token()
+	return err
+}
+
+func preflightJSONArrayCount(data json.RawMessage, name string, limit int) error {
+	_, err := countJSONArrayElements(data, name, limit)
+	return err
+}
+
+func countJSONArrayElements(
+	data json.RawMessage,
+	name string,
+	limit int,
+) (int, error) {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return 0, nil
+	}
+	dec := json.NewDecoder(bytes.NewReader(trimmed))
+	token, err := dec.Token()
+	if err != nil {
+		return 0, err
+	}
+	if token != json.Delim('[') {
+		return 0, fmt.Errorf("%ss must be an array", name)
+	}
+	count := 0
+	for dec.More() {
+		if count >= limit {
+			return 0, fmt.Errorf("%s limit exceeded: limit %d", name, limit)
+		}
+		var value json.RawMessage
+		if err := dec.Decode(&value); err != nil {
+			return 0, fmt.Errorf("decoding %s: %w", name, err)
+		}
+		count++
+	}
+	if _, err := dec.Token(); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+func canonicalMessages(msgs []db.Message) []db.Message {
+	out := make([]db.Message, len(msgs))
+	for i, msg := range msgs {
+		msg.ID = 0
+		msg.SessionID = ""
+		if len(msg.ToolCalls) > 0 {
+			calls := make([]db.ToolCall, len(msg.ToolCalls))
+			copy(calls, msg.ToolCalls)
+			for j := range calls {
+				calls[j].MessageID = 0
+				calls[j].SessionID = ""
+			}
+			msg.ToolCalls = calls
+		}
+		out[i] = msg
+	}
+	return out
+}
+
+func decodeSegment(data []byte) ([]db.Message, error) {
+	return decodeSegmentWithLimits(data, productionArtifactLimits())
+}
+
+func decodeSegmentWithLimits(data []byte, limits artifactLimits) ([]db.Message, error) {
+	preflight, err := preflightSegmentData(data, limits)
+	if err != nil {
+		return nil, err
+	}
+	return decodePreflightedSegment(preflight)
+}
+
+func decodePreflightedSegment(preflight segmentPreflight) ([]db.Message, error) {
+	msgs := make([]db.Message, 0, len(preflight.records))
+	for _, line := range preflight.records {
+		var record segmentMessage
+		if err := json.Unmarshal(line, &record); err != nil {
+			return nil, fmt.Errorf("decoding message segment: %w", err)
+		}
+		msgs = append(msgs, record.dbMessage())
+	}
+	return msgs, nil
+}
+
+func segmentRecords(data []byte, limit int) ([][]byte, error) {
+	capacity := min(max(limit, 0), 64)
+	records := make([][]byte, 0, capacity)
+	remaining := data
+	lineNumber := 0
+	for len(remaining) > 0 {
+		lineNumber++
+		newline := bytes.IndexByte(remaining, '\n')
+		line := remaining
+		if newline >= 0 {
+			line = remaining[:newline]
+			remaining = remaining[newline+1:]
+		} else {
+			remaining = nil
+		}
+		if len(records) >= limit {
+			return nil, fmt.Errorf(
+				"message record limit exceeded: limit %d per segment", limit,
+			)
+		}
+		if len(bytes.TrimSpace(line)) == 0 {
+			return nil, fmt.Errorf("blank message record at line %d", lineNumber)
+		}
+		records = append(records, line)
+	}
+	return records, nil
+}
+
+func preflightSegmentData(data []byte, limits artifactLimits) (segmentPreflight, error) {
+	records, err := segmentRecords(data, limits.segmentMessages)
+	if err != nil {
+		return segmentPreflight{}, err
+	}
+	preflight := segmentPreflight{records: records}
+	for _, line := range records {
+		var header struct {
+			Version int `json:"v"`
+		}
+		if err := json.Unmarshal(line, &header); err != nil {
+			return segmentPreflight{}, fmt.Errorf("decoding message segment header: %w", err)
+		}
+		if header.Version > messageSegmentFormatVersion {
+			return segmentPreflight{}, fmt.Errorf(
+				"%w: message segment has artifact version %d",
+				errFutureArtifactVersion, header.Version,
+			)
+		}
+		if header.Version != messageSegmentFormatVersion {
+			return segmentPreflight{}, fmt.Errorf(
+				"message segment has unsupported artifact version %d",
+				header.Version,
+			)
+		}
+		messageNested, err := preflightMessageNestedCollections(line, limits)
+		if err != nil {
+			return segmentPreflight{}, err
+		}
+		if exceedsCollectionLimit(
+			preflight.nested.toolCalls,
+			messageNested.toolCalls,
+			limits.segmentToolCalls,
+		) {
+			return segmentPreflight{}, fmt.Errorf(
+				"segment tool call limit exceeded: limit %d", limits.segmentToolCalls,
+			)
+		}
+		if exceedsCollectionLimit(
+			preflight.nested.resultEvents,
+			messageNested.resultEvents,
+			limits.segmentResultEvents,
+		) {
+			return segmentPreflight{}, fmt.Errorf(
+				"segment result event limit exceeded: limit %d",
+				limits.segmentResultEvents,
+			)
+		}
+		preflight.nested.toolCalls += messageNested.toolCalls
+		preflight.nested.resultEvents += messageNested.resultEvents
+	}
+	return preflight, nil
+}
+
+func preflightMessageNestedCollections(
+	line []byte,
+	limits artifactLimits,
+) (nestedCollectionCounts, error) {
+	var envelope struct {
+		Ordinal   int             `json:"ordinal"`
+		ToolCalls json.RawMessage `json:"tool_calls"`
+	}
+	if err := json.Unmarshal(line, &envelope); err != nil {
+		return nestedCollectionCounts{}, fmt.Errorf(
+			"decoding message segment collections: %w", err,
+		)
+	}
+	return preflightToolCallCollections(envelope.ToolCalls, envelope.Ordinal, limits)
+}
+
+func preflightToolCallCollections(
+	data json.RawMessage,
+	ordinal int,
+	limits artifactLimits,
+) (nestedCollectionCounts, error) {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nestedCollectionCounts{}, nil
+	}
+	dec := json.NewDecoder(bytes.NewReader(trimmed))
+	token, err := dec.Token()
+	if err != nil {
+		return nestedCollectionCounts{}, err
+	}
+	if token != json.Delim('[') {
+		return nestedCollectionCounts{}, errors.New("message tool_calls must be an array")
+	}
+	counts := nestedCollectionCounts{}
+	for dec.More() {
+		if counts.toolCalls >= limits.messageToolCalls {
+			return nestedCollectionCounts{}, fmt.Errorf(
+				"tool call limit exceeded for message ordinal %d: limit %d per message",
+				ordinal, limits.messageToolCalls,
+			)
+		}
+		var toolEnvelope struct {
+			ResultEvents json.RawMessage `json:"result_events"`
+		}
+		if err := dec.Decode(&toolEnvelope); err != nil {
+			return nestedCollectionCounts{}, fmt.Errorf(
+				"decoding tool call %d in message ordinal %d: %w",
+				counts.toolCalls, ordinal, err,
+			)
+		}
+		resultEvents, err := countJSONArrayElements(
+			toolEnvelope.ResultEvents, "result event", limits.toolResultEvents,
+		)
+		if err != nil {
+			return nestedCollectionCounts{}, fmt.Errorf(
+				"preflighting tool call %d in message ordinal %d: %w",
+				counts.toolCalls, ordinal, err,
+			)
+		}
+		counts.toolCalls++
+		counts.resultEvents += resultEvents
+	}
+	if _, err := dec.Token(); err != nil {
+		return nestedCollectionCounts{}, err
+	}
+	return counts, nil
+}
+
+func (m segmentMessage) dbMessage() db.Message {
+	msg := db.Message{
+		Ordinal:           m.Ordinal,
+		Role:              m.Role,
+		Content:           m.Content,
+		ThinkingText:      m.ThinkingText,
+		Timestamp:         m.Timestamp,
+		HasThinking:       m.HasThinking,
+		HasToolUse:        m.HasToolUse,
+		ContentLength:     m.ContentLength,
+		Model:             m.Model,
+		TokenUsage:        m.TokenUsage,
+		ContextTokens:     m.ContextTokens,
+		OutputTokens:      m.OutputTokens,
+		HasContextTokens:  m.HasContextTokens,
+		HasOutputTokens:   m.HasOutputTokens,
+		ClaudeMessageID:   m.ClaudeMessageID,
+		ClaudeRequestID:   m.ClaudeRequestID,
+		IsSystem:          m.IsSystem,
+		SourceType:        m.SourceType,
+		SourceSubtype:     m.SourceSubtype,
+		SourceUUID:        m.SourceUUID,
+		SourceParentUUID:  m.SourceParentUUID,
+		IsSidechain:       m.IsSidechain,
+		IsCompactBoundary: m.IsCompactBoundary,
+	}
+	if len(m.ToolCalls) > 0 {
+		msg.ToolCalls = make([]db.ToolCall, len(m.ToolCalls))
+		for i, call := range m.ToolCalls {
+			msg.ToolCalls[i] = db.ToolCall{
+				ToolName:            call.ToolName,
+				Category:            call.Category,
+				ToolUseID:           call.ToolUseID,
+				InputJSON:           call.InputJSON,
+				FilePath:            call.FilePath,
+				SkillName:           call.SkillName,
+				ResultContentLength: call.ResultContentLength,
+				ResultContent:       call.ResultContent,
+				SubagentSessionID:   call.SubagentSessionID,
+			}
+			if len(call.ResultEvents) > 0 {
+				msg.ToolCalls[i].ResultEvents = make([]db.ToolResultEvent, len(call.ResultEvents))
+				for j, ev := range call.ResultEvents {
+					msg.ToolCalls[i].ResultEvents[j] = db.ToolResultEvent{
+						ToolUseID:         ev.ToolUseID,
+						AgentID:           ev.AgentID,
+						SubagentSessionID: ev.SubagentSessionID,
+						Source:            ev.Source,
+						Status:            ev.Status,
+						Content:           ev.Content,
+						ContentLength:     ev.ContentLength,
+						Timestamp:         ev.Timestamp,
+						EventIndex:        ev.EventIndex,
+					}
+				}
+			}
+		}
+	}
+	return msg
+}

--- a/internal/db/artifact_export_load.go
+++ b/internal/db/artifact_export_load.go
@@ -1,0 +1,616 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+)
+
+// ErrArtifactExportLimit identifies a deterministic session-shape violation
+// encountered before the complete export object graph is materialized.
+var ErrArtifactExportLimit = errors.New("artifact export load limit exceeded")
+
+// ArtifactExportLoadLimits bounds the source rows and raw string bytes that
+// may be materialized for one artifact export.
+type ArtifactExportLoadLimits struct {
+	Messages            int
+	UsageEvents         int
+	MessageToolCalls    int
+	ToolResultEvents    int
+	SessionToolCalls    int
+	SessionResultEvents int
+	MessageBytes        int64
+	UsageBytes          int64
+}
+
+// ArtifactExportData is one session's export-visible transcript and usage data
+// loaded from a single SQLite read snapshot.
+type ArtifactExportData struct {
+	Messages    []Message
+	UsageEvents []UsageEvent
+}
+
+const artifactMessageRawBytesSQL = `
+	length(CAST(role AS BLOB)) +
+	length(CAST(content AS BLOB)) +
+	length(CAST(thinking_text AS BLOB)) +
+	length(CAST(COALESCE(timestamp, '') AS BLOB)) +
+	length(CAST(model AS BLOB)) +
+	length(CAST(token_usage AS BLOB)) +
+	length(CAST(claude_message_id AS BLOB)) +
+	length(CAST(claude_request_id AS BLOB)) +
+	length(CAST(source_type AS BLOB)) +
+	length(CAST(source_subtype AS BLOB)) +
+	length(CAST(source_uuid AS BLOB)) +
+	length(CAST(source_parent_uuid AS BLOB))`
+
+const artifactToolCallRawBytesSQL = `
+	length(CAST(tool_name AS BLOB)) +
+	length(CAST(category AS BLOB)) +
+	length(CAST(COALESCE(tool_use_id, '') AS BLOB)) +
+	length(CAST(COALESCE(input_json, '') AS BLOB)) +
+	length(CAST(COALESCE(skill_name, '') AS BLOB)) +
+	length(CAST(COALESCE(result_content, '') AS BLOB)) +
+	length(CAST(COALESCE(subagent_session_id, '') AS BLOB)) +
+	length(CAST(COALESCE(file_path, '') AS BLOB))`
+
+const artifactResultEventRawBytesSQL = `
+	length(CAST(COALESCE(tool_use_id, '') AS BLOB)) +
+	length(CAST(COALESCE(agent_id, '') AS BLOB)) +
+	length(CAST(COALESCE(subagent_session_id, '') AS BLOB)) +
+	length(CAST(source AS BLOB)) +
+	length(CAST(status AS BLOB)) +
+	length(CAST(content AS BLOB)) +
+	length(CAST(COALESCE(timestamp, '') AS BLOB))`
+
+const artifactUsageRawBytesSQL = `
+	length(CAST(source AS BLOB)) +
+	length(CAST(model AS BLOB)) +
+	length(CAST(cost_status AS BLOB)) +
+	length(CAST(cost_source AS BLOB)) +
+	length(CAST(COALESCE(occurred_at, '') AS BLOB)) +
+	length(CAST(dedup_key AS BLOB))`
+
+// LoadArtifactExportData preflights and materializes one session from the same
+// read transaction so concurrent writes cannot invalidate the bounds.
+func (db *DB) LoadArtifactExportData(
+	ctx context.Context, sessionID string, limits ArtifactExportLoadLimits,
+) (_ ArtifactExportData, retErr error) {
+	if sessionID == "" {
+		return ArtifactExportData{}, errors.New("artifact export session id is required")
+	}
+	if err := validateArtifactExportLoadLimits(limits); err != nil {
+		return ArtifactExportData{}, err
+	}
+	db.connMu.RLock()
+	reader := db.reader.Load()
+	if reader == nil {
+		db.connMu.RUnlock()
+		return ArtifactExportData{}, errors.New("database is closed")
+	}
+	tx, err := reader.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	db.connMu.RUnlock()
+	if err != nil {
+		return ArtifactExportData{}, fmt.Errorf("beginning artifact export snapshot: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			retErr = errors.Join(retErr, tx.Rollback())
+		}
+	}()
+
+	if err := preflightArtifactExportTx(ctx, tx, sessionID, limits); err != nil {
+		return ArtifactExportData{}, err
+	}
+	rows, err := tx.QueryContext(ctx, fmt.Sprintf(`
+		SELECT %s FROM messages
+		WHERE session_id = ?
+		ORDER BY ordinal ASC
+		LIMIT ?`, selectMessageCols), sessionID, limits.Messages+1)
+	if err != nil {
+		return ArtifactExportData{}, fmt.Errorf("loading artifact export messages: %w", err)
+	}
+	messages, scanErr := scanMessages(rows)
+	closeErr := rows.Close()
+	if scanErr != nil || closeErr != nil {
+		return ArtifactExportData{}, errors.Join(scanErr, closeErr)
+	}
+	if len(messages) > limits.Messages {
+		return ArtifactExportData{}, artifactExportLimitf(
+			"session %s message count exceeds %d", sessionID, limits.Messages,
+		)
+	}
+	if err := attachArtifactNestedCollectionsTx(
+		ctx, tx, sessionID, messages, limits,
+	); err != nil {
+		return ArtifactExportData{}, err
+	}
+	usage, err := usageEventsWithQuerier(
+		ctx, tx, sessionID, limits.UsageEvents+1,
+	)
+	if err != nil {
+		return ArtifactExportData{}, err
+	}
+	if len(usage) > limits.UsageEvents {
+		return ArtifactExportData{}, artifactExportLimitf(
+			"session %s usage count exceeds %d", sessionID, limits.UsageEvents,
+		)
+	}
+	if err := tx.Commit(); err != nil {
+		return ArtifactExportData{}, fmt.Errorf("committing artifact export snapshot: %w", err)
+	}
+	committed = true
+	return ArtifactExportData{Messages: messages, UsageEvents: usage}, nil
+}
+
+func attachArtifactNestedCollectionsTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	sessionID string,
+	messages []Message,
+	limits ArtifactExportLoadLimits,
+) error {
+	if len(messages) == 0 {
+		return nil
+	}
+	messageByID := make(map[int64]int, len(messages))
+	messageByOrdinal := make(map[int]int, len(messages))
+	for i, message := range messages {
+		messageByID[message.ID] = i
+		messageByOrdinal[message.Ordinal] = i
+	}
+
+	type toolCallRow struct {
+		rowID int64
+		call  ToolCall
+	}
+	rows, err := tx.QueryContext(ctx, `
+		SELECT id, message_id, session_id, tool_name, category,
+			tool_use_id, input_json, skill_name,
+			result_content_length, result_content, subagent_session_id,
+			file_path, call_index
+		FROM tool_calls
+		WHERE session_id = ?
+		LIMIT ?`, sessionID, limits.SessionToolCalls+1)
+	if err != nil {
+		return fmt.Errorf("loading bounded artifact tool calls: %w", err)
+	}
+	toolCalls := make([]toolCallRow, 0)
+	for rows.Next() {
+		var row toolCallRow
+		var toolUseID, inputJSON, skillName sql.NullString
+		var subagentSessionID, resultContent sql.NullString
+		var filePath sql.NullString
+		var resultLen sql.NullInt64
+		var callIndex sql.NullInt64
+		if err := rows.Scan(
+			&row.rowID, &row.call.MessageID, &row.call.SessionID,
+			&row.call.ToolName, &row.call.Category,
+			&toolUseID, &inputJSON, &skillName,
+			&resultLen, &resultContent, &subagentSessionID,
+			&filePath, &callIndex,
+		); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scanning bounded artifact tool call: %w", err)
+		}
+		if toolUseID.Valid {
+			row.call.ToolUseID = toolUseID.String
+		}
+		if inputJSON.Valid {
+			row.call.InputJSON = inputJSON.String
+		}
+		if skillName.Valid {
+			row.call.SkillName = skillName.String
+		}
+		if resultLen.Valid {
+			row.call.ResultContentLength = int(resultLen.Int64)
+		}
+		if resultContent.Valid {
+			row.call.ResultContent = resultContent.String
+		}
+		if subagentSessionID.Valid {
+			row.call.SubagentSessionID = subagentSessionID.String
+		}
+		if filePath.Valid {
+			row.call.FilePath = filePath.String
+		}
+		if callIndex.Valid {
+			row.call.CallIndex = int(callIndex.Int64)
+		}
+		toolCalls = append(toolCalls, row)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("iterating bounded artifact tool calls: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("closing bounded artifact tool calls: %w", err)
+	}
+	if len(toolCalls) > limits.SessionToolCalls {
+		return artifactExportLimitf(
+			"session %s tool call count exceeds %d",
+			sessionID, limits.SessionToolCalls,
+		)
+	}
+	sort.Slice(toolCalls, func(i, j int) bool {
+		if toolCalls[i].call.MessageID != toolCalls[j].call.MessageID {
+			return toolCalls[i].call.MessageID < toolCalls[j].call.MessageID
+		}
+		if toolCalls[i].call.CallIndex != toolCalls[j].call.CallIndex {
+			return toolCalls[i].call.CallIndex < toolCalls[j].call.CallIndex
+		}
+		return toolCalls[i].rowID < toolCalls[j].rowID
+	})
+	for _, row := range toolCalls {
+		if messageIndex, ok := messageByID[row.call.MessageID]; ok {
+			messages[messageIndex].ToolCalls = append(
+				messages[messageIndex].ToolCalls, row.call,
+			)
+		}
+	}
+
+	type resultEventRow struct {
+		rowID          int64
+		messageOrdinal int
+		callIndex      int
+		event          ToolResultEvent
+	}
+	rows, err = tx.QueryContext(ctx, `
+		SELECT id, tool_call_message_ordinal, call_index,
+			tool_use_id, agent_id, subagent_session_id,
+			source, status, content, content_length,
+			timestamp, event_index
+		FROM tool_result_events
+		WHERE session_id = ?
+		LIMIT ?`, sessionID, limits.SessionResultEvents+1)
+	if err != nil {
+		return fmt.Errorf("loading bounded artifact result events: %w", err)
+	}
+	resultEvents := make([]resultEventRow, 0)
+	for rows.Next() {
+		var row resultEventRow
+		var toolUseID, agentID, subagentSessionID, timestamp sql.NullString
+		if err := rows.Scan(
+			&row.rowID, &row.messageOrdinal, &row.callIndex,
+			&toolUseID, &agentID, &subagentSessionID,
+			&row.event.Source, &row.event.Status, &row.event.Content,
+			&row.event.ContentLength, &timestamp, &row.event.EventIndex,
+		); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scanning bounded artifact result event: %w", err)
+		}
+		if toolUseID.Valid {
+			row.event.ToolUseID = toolUseID.String
+		}
+		if agentID.Valid {
+			row.event.AgentID = agentID.String
+		}
+		if subagentSessionID.Valid {
+			row.event.SubagentSessionID = subagentSessionID.String
+		}
+		if timestamp.Valid {
+			row.event.Timestamp = timestamp.String
+		}
+		resultEvents = append(resultEvents, row)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("iterating bounded artifact result events: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("closing bounded artifact result events: %w", err)
+	}
+	if len(resultEvents) > limits.SessionResultEvents {
+		return artifactExportLimitf(
+			"session %s result event count exceeds %d",
+			sessionID, limits.SessionResultEvents,
+		)
+	}
+	sort.Slice(resultEvents, func(i, j int) bool {
+		if resultEvents[i].messageOrdinal != resultEvents[j].messageOrdinal {
+			return resultEvents[i].messageOrdinal < resultEvents[j].messageOrdinal
+		}
+		if resultEvents[i].callIndex != resultEvents[j].callIndex {
+			return resultEvents[i].callIndex < resultEvents[j].callIndex
+		}
+		if resultEvents[i].event.EventIndex != resultEvents[j].event.EventIndex {
+			return resultEvents[i].event.EventIndex < resultEvents[j].event.EventIndex
+		}
+		return resultEvents[i].rowID < resultEvents[j].rowID
+	})
+	for _, row := range resultEvents {
+		messageIndex, ok := messageByOrdinal[row.messageOrdinal]
+		if !ok || row.callIndex < 0 ||
+			row.callIndex >= len(messages[messageIndex].ToolCalls) {
+			continue
+		}
+		messages[messageIndex].ToolCalls[row.callIndex].ResultEvents = append(
+			messages[messageIndex].ToolCalls[row.callIndex].ResultEvents,
+			row.event,
+		)
+	}
+	return nil
+}
+
+func validateArtifactExportLoadLimits(limits ArtifactExportLoadLimits) error {
+	if limits.Messages < 1 || limits.UsageEvents < 1 ||
+		limits.MessageToolCalls < 1 || limits.ToolResultEvents < 1 ||
+		limits.SessionToolCalls < 1 || limits.SessionResultEvents < 1 ||
+		limits.MessageBytes < 1 || limits.UsageBytes < 1 {
+		return errors.New("artifact export load limits must all be positive")
+	}
+	if limits.Messages == math.MaxInt || limits.UsageEvents == math.MaxInt ||
+		limits.SessionToolCalls == math.MaxInt ||
+		limits.SessionResultEvents == math.MaxInt {
+		return errors.New("artifact export load limits must permit a limit-plus-one probe")
+	}
+	return nil
+}
+
+func preflightArtifactExportTx(
+	ctx context.Context, tx *sql.Tx, sessionID string, limits ArtifactExportLoadLimits,
+) error {
+	messageBytes, err := preflightArtifactMessagesTx(ctx, tx, sessionID, limits)
+	if err != nil {
+		return err
+	}
+	nestedBytes, err := preflightArtifactToolCallsTx(ctx, tx, sessionID, limits)
+	if err != nil {
+		return err
+	}
+	resultBytes, err := preflightArtifactResultEventsTx(ctx, tx, sessionID, limits)
+	if err != nil {
+		return err
+	}
+	totalBytes, exceeded := addArtifactExportBytes(0, messageBytes, limits.MessageBytes)
+	if !exceeded {
+		totalBytes, exceeded = addArtifactExportBytes(
+			totalBytes, nestedBytes, limits.MessageBytes,
+		)
+	}
+	if !exceeded {
+		_, exceeded = addArtifactExportBytes(
+			totalBytes, resultBytes, limits.MessageBytes,
+		)
+	}
+	if exceeded {
+		return artifactExportLimitf(
+			"session %s raw message bytes exceed %d", sessionID, limits.MessageBytes,
+		)
+	}
+	return preflightArtifactUsageTx(ctx, tx, sessionID, limits)
+}
+
+func preflightArtifactMessagesTx(
+	ctx context.Context, tx *sql.Tx, sessionID string, limits ArtifactExportLoadLimits,
+) (int64, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT id, ordinal, `+artifactMessageRawBytesSQL+`
+		FROM messages WHERE session_id = ? LIMIT ?`,
+		sessionID, limits.Messages+1,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("preflighting artifact messages: %w", err)
+	}
+	var count int
+	var totalBytes int64
+	for rows.Next() {
+		var id int64
+		var ordinal int
+		var rawBytes int64
+		if err := rows.Scan(&id, &ordinal, &rawBytes); err != nil {
+			_ = rows.Close()
+			return 0, fmt.Errorf("scanning artifact message preflight: %w", err)
+		}
+		count++
+		if count > limits.Messages {
+			return 0, closeArtifactPreflightAtLimit(rows, artifactExportLimitf(
+				"session %s message count exceeds %d", sessionID, limits.Messages,
+			))
+		}
+		var exceeded bool
+		totalBytes, exceeded = addArtifactExportBytes(
+			totalBytes, rawBytes, limits.MessageBytes,
+		)
+		if exceeded {
+			return 0, closeArtifactPreflightAtLimit(rows, artifactExportLimitf(
+				"session %s raw message bytes exceed %d",
+				sessionID, limits.MessageBytes,
+			))
+		}
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return 0, fmt.Errorf("iterating artifact message preflight: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return 0, fmt.Errorf("closing artifact message preflight: %w", err)
+	}
+	return totalBytes, nil
+}
+
+func preflightArtifactToolCallsTx(
+	ctx context.Context, tx *sql.Tx, sessionID string, limits ArtifactExportLoadLimits,
+) (int64, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT message_id, `+artifactToolCallRawBytesSQL+`
+		FROM tool_calls WHERE session_id = ? LIMIT ?`,
+		sessionID, limits.SessionToolCalls+1,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("preflighting artifact tool calls: %w", err)
+	}
+	perMessage := make(map[int64]int)
+	var count int
+	var totalBytes int64
+	for rows.Next() {
+		var messageID int64
+		var rawBytes int64
+		if err := rows.Scan(&messageID, &rawBytes); err != nil {
+			_ = rows.Close()
+			return 0, fmt.Errorf("scanning artifact tool call preflight: %w", err)
+		}
+		count++
+		perMessage[messageID]++
+		if count > limits.SessionToolCalls {
+			return 0, closeArtifactPreflightAtLimit(rows, artifactExportLimitf(
+				"session %s tool call count exceeds %d",
+				sessionID, limits.SessionToolCalls,
+			))
+		}
+		if perMessage[messageID] > limits.MessageToolCalls {
+			return 0, closeArtifactPreflightAtLimit(rows, artifactExportLimitf(
+				"session %s message tool call count exceeds %d",
+				sessionID, limits.MessageToolCalls,
+			))
+		}
+		var exceeded bool
+		totalBytes, exceeded = addArtifactExportBytes(
+			totalBytes, rawBytes, limits.MessageBytes,
+		)
+		if exceeded {
+			return 0, closeArtifactPreflightAtLimit(rows, artifactExportLimitf(
+				"session %s raw message bytes exceed %d",
+				sessionID, limits.MessageBytes,
+			))
+		}
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return 0, fmt.Errorf("iterating artifact tool call preflight: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return 0, fmt.Errorf("closing artifact tool call preflight: %w", err)
+	}
+	return totalBytes, nil
+}
+
+func preflightArtifactResultEventsTx(
+	ctx context.Context, tx *sql.Tx, sessionID string, limits ArtifactExportLoadLimits,
+) (int64, error) {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT tool_call_message_ordinal, call_index,
+		       `+artifactResultEventRawBytesSQL+`
+		FROM tool_result_events WHERE session_id = ? LIMIT ?`,
+		sessionID, limits.SessionResultEvents+1,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("preflighting artifact result events: %w", err)
+	}
+	type callKey struct {
+		messageOrdinal int
+		callIndex      int
+	}
+	perCall := make(map[callKey]int)
+	var count int
+	var totalBytes int64
+	for rows.Next() {
+		var key callKey
+		var rawBytes int64
+		if err := rows.Scan(&key.messageOrdinal, &key.callIndex, &rawBytes); err != nil {
+			_ = rows.Close()
+			return 0, fmt.Errorf("scanning artifact result event preflight: %w", err)
+		}
+		count++
+		perCall[key]++
+		if count > limits.SessionResultEvents {
+			return 0, closeArtifactPreflightAtLimit(rows, artifactExportLimitf(
+				"session %s result event count exceeds %d",
+				sessionID, limits.SessionResultEvents,
+			))
+		}
+		if perCall[key] > limits.ToolResultEvents {
+			return 0, closeArtifactPreflightAtLimit(rows, artifactExportLimitf(
+				"session %s tool result event count exceeds %d",
+				sessionID, limits.ToolResultEvents,
+			))
+		}
+		var exceeded bool
+		totalBytes, exceeded = addArtifactExportBytes(
+			totalBytes, rawBytes, limits.MessageBytes,
+		)
+		if exceeded {
+			return 0, closeArtifactPreflightAtLimit(rows, artifactExportLimitf(
+				"session %s raw message bytes exceed %d",
+				sessionID, limits.MessageBytes,
+			))
+		}
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return 0, fmt.Errorf("iterating artifact result event preflight: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return 0, fmt.Errorf("closing artifact result event preflight: %w", err)
+	}
+	return totalBytes, nil
+}
+
+func preflightArtifactUsageTx(
+	ctx context.Context, tx *sql.Tx, sessionID string, limits ArtifactExportLoadLimits,
+) error {
+	rows, err := tx.QueryContext(ctx, `
+		SELECT `+artifactUsageRawBytesSQL+`
+		FROM usage_events WHERE session_id = ? LIMIT ?`,
+		sessionID, limits.UsageEvents+1,
+	)
+	if err != nil {
+		return fmt.Errorf("preflighting artifact usage events: %w", err)
+	}
+	var count int
+	var totalBytes int64
+	for rows.Next() {
+		var rawBytes int64
+		if err := rows.Scan(&rawBytes); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scanning artifact usage preflight: %w", err)
+		}
+		count++
+		if count > limits.UsageEvents {
+			return closeArtifactPreflightAtLimit(rows, artifactExportLimitf(
+				"session %s usage event count exceeds %d",
+				sessionID, limits.UsageEvents,
+			))
+		}
+		var exceeded bool
+		totalBytes, exceeded = addArtifactExportBytes(
+			totalBytes, rawBytes, limits.UsageBytes,
+		)
+		if exceeded {
+			return closeArtifactPreflightAtLimit(rows, artifactExportLimitf(
+				"session %s raw usage bytes exceed %d",
+				sessionID, limits.UsageBytes,
+			))
+		}
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("iterating artifact usage preflight: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("closing artifact usage preflight: %w", err)
+	}
+	return nil
+}
+
+func closeArtifactPreflightAtLimit(rows *sql.Rows, limitErr error) error {
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("closing artifact preflight at limit: %w", err)
+	}
+	return limitErr
+}
+
+func addArtifactExportBytes(current, additional, limit int64) (int64, bool) {
+	if current > limit || additional < 0 || additional > limit-current {
+		return current, true
+	}
+	return current + additional, false
+}
+
+func artifactExportLimitf(format string, args ...any) error {
+	return fmt.Errorf("%w: %s", ErrArtifactExportLimit, fmt.Sprintf(format, args...))
+}

--- a/internal/db/artifact_export_load_test.go
+++ b/internal/db/artifact_export_load_test.go
@@ -1,0 +1,401 @@
+package db
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func smallArtifactExportLoadLimits() ArtifactExportLoadLimits {
+	return ArtifactExportLoadLimits{
+		Messages: 2, UsageEvents: 2,
+		MessageToolCalls: 2, ToolResultEvents: 2,
+		SessionToolCalls: 3, SessionResultEvents: 3,
+		MessageBytes: 1 << 20, UsageBytes: 1 << 20,
+	}
+}
+
+func TestLoadArtifactExportDataCardinalityBoundaries(t *testing.T) {
+	t.Run("messages", func(t *testing.T) {
+		database := artifactExportLoadTestDB(t)
+		require.NoError(t, database.ReplaceSessionMessages("session", []Message{
+			artifactExportLoadMessage(0),
+			artifactExportLoadMessage(1),
+		}))
+		data, err := database.LoadArtifactExportData(
+			t.Context(), "session", smallArtifactExportLoadLimits(),
+		)
+		require.NoError(t, err)
+		assert.Len(t, data.Messages, 2)
+
+		require.NoError(t, database.ReplaceSessionMessages("session", []Message{
+			artifactExportLoadMessage(0),
+			artifactExportLoadMessage(1),
+			artifactExportLoadMessage(2),
+		}))
+		_, err = database.LoadArtifactExportData(
+			t.Context(), "session", smallArtifactExportLoadLimits(),
+		)
+		require.ErrorIs(t, err, ErrArtifactExportLimit)
+	})
+
+	t.Run("usage events", func(t *testing.T) {
+		database := artifactExportLoadTestDB(t)
+		require.NoError(t, database.ReplaceSessionUsageEvents("session", []UsageEvent{
+			artifactExportLoadUsageEvent(0),
+			artifactExportLoadUsageEvent(1),
+		}))
+		data, err := database.LoadArtifactExportData(
+			t.Context(), "session", smallArtifactExportLoadLimits(),
+		)
+		require.NoError(t, err)
+		assert.Len(t, data.UsageEvents, 2)
+
+		require.NoError(t, database.ReplaceSessionUsageEvents("session", []UsageEvent{
+			artifactExportLoadUsageEvent(0),
+			artifactExportLoadUsageEvent(1),
+			artifactExportLoadUsageEvent(2),
+		}))
+		_, err = database.LoadArtifactExportData(
+			t.Context(), "session", smallArtifactExportLoadLimits(),
+		)
+		require.ErrorIs(t, err, ErrArtifactExportLimit)
+	})
+
+	t.Run("tool calls per message", func(t *testing.T) {
+		database := artifactExportLoadTestDB(t)
+		require.NoError(t, database.ReplaceSessionMessages("session", []Message{{
+			SessionID: "session", Ordinal: 0, Role: "assistant", Content: "calls",
+			ToolCalls: []ToolCall{
+				artifactExportLoadToolCall(0),
+				artifactExportLoadToolCall(1),
+			},
+		}}))
+		data, err := database.LoadArtifactExportData(
+			t.Context(), "session", smallArtifactExportLoadLimits(),
+		)
+		require.NoError(t, err)
+		require.Len(t, data.Messages, 1)
+		assert.Len(t, data.Messages[0].ToolCalls, 2)
+
+		require.NoError(t, database.ReplaceSessionMessages("session", []Message{{
+			SessionID: "session", Ordinal: 0, Role: "assistant", Content: "calls",
+			ToolCalls: []ToolCall{
+				artifactExportLoadToolCall(0),
+				artifactExportLoadToolCall(1),
+				artifactExportLoadToolCall(2),
+			},
+		}}))
+		_, err = database.LoadArtifactExportData(
+			t.Context(), "session", smallArtifactExportLoadLimits(),
+		)
+		require.ErrorIs(t, err, ErrArtifactExportLimit)
+	})
+
+	t.Run("tool calls per session", func(t *testing.T) {
+		database := artifactExportLoadTestDB(t)
+		require.NoError(t, database.ReplaceSessionMessages("session", []Message{
+			{
+				SessionID: "session", Ordinal: 0, Role: "assistant", Content: "first",
+				ToolCalls: []ToolCall{
+					artifactExportLoadToolCall(0),
+					artifactExportLoadToolCall(1),
+				},
+			},
+			{
+				SessionID: "session", Ordinal: 1, Role: "assistant", Content: "second",
+				ToolCalls: []ToolCall{artifactExportLoadToolCall(0)},
+			},
+		}))
+		data, err := database.LoadArtifactExportData(
+			t.Context(), "session", smallArtifactExportLoadLimits(),
+		)
+		require.NoError(t, err)
+		require.Len(t, data.Messages, 2)
+		assert.Len(t, data.Messages[0].ToolCalls, 2)
+		assert.Len(t, data.Messages[1].ToolCalls, 1)
+
+		require.NoError(t, database.ReplaceSessionMessages("session", []Message{
+			{
+				SessionID: "session", Ordinal: 0, Role: "assistant", Content: "first",
+				ToolCalls: []ToolCall{
+					artifactExportLoadToolCall(0),
+					artifactExportLoadToolCall(1),
+				},
+			},
+			{
+				SessionID: "session", Ordinal: 1, Role: "assistant", Content: "second",
+				ToolCalls: []ToolCall{
+					artifactExportLoadToolCall(0),
+					artifactExportLoadToolCall(1),
+				},
+			},
+		}))
+		_, err = database.LoadArtifactExportData(
+			t.Context(), "session", smallArtifactExportLoadLimits(),
+		)
+		require.ErrorIs(t, err, ErrArtifactExportLimit)
+	})
+
+	t.Run("result events per call", func(t *testing.T) {
+		database := artifactExportLoadTestDB(t)
+		call := artifactExportLoadToolCall(0)
+		call.ResultEvents = []ToolResultEvent{
+			artifactExportLoadResultEvent(0),
+			artifactExportLoadResultEvent(1),
+		}
+		require.NoError(t, database.ReplaceSessionMessages("session", []Message{{
+			SessionID: "session", Ordinal: 0, Role: "assistant", Content: "results",
+			ToolCalls: []ToolCall{call},
+		}}))
+		data, err := database.LoadArtifactExportData(
+			t.Context(), "session", smallArtifactExportLoadLimits(),
+		)
+		require.NoError(t, err)
+		require.Len(t, data.Messages, 1)
+		require.Len(t, data.Messages[0].ToolCalls, 1)
+		assert.Len(t, data.Messages[0].ToolCalls[0].ResultEvents, 2)
+
+		call.ResultEvents = append(
+			call.ResultEvents, artifactExportLoadResultEvent(2),
+		)
+		require.NoError(t, database.ReplaceSessionMessages("session", []Message{{
+			SessionID: "session", Ordinal: 0, Role: "assistant", Content: "results",
+			ToolCalls: []ToolCall{call},
+		}}))
+		_, err = database.LoadArtifactExportData(
+			t.Context(), "session", smallArtifactExportLoadLimits(),
+		)
+		require.ErrorIs(t, err, ErrArtifactExportLimit)
+	})
+
+	t.Run("result events per session", func(t *testing.T) {
+		database := artifactExportLoadTestDB(t)
+		first := artifactExportLoadToolCall(0)
+		first.ResultEvents = []ToolResultEvent{
+			artifactExportLoadResultEvent(0),
+			artifactExportLoadResultEvent(1),
+		}
+		second := artifactExportLoadToolCall(1)
+		second.ResultEvents = []ToolResultEvent{artifactExportLoadResultEvent(0)}
+		require.NoError(t, database.ReplaceSessionMessages("session", []Message{{
+			SessionID: "session", Ordinal: 0, Role: "assistant", Content: "results",
+			ToolCalls: []ToolCall{first, second},
+		}}))
+		data, err := database.LoadArtifactExportData(
+			t.Context(), "session", smallArtifactExportLoadLimits(),
+		)
+		require.NoError(t, err)
+		require.Len(t, data.Messages, 1)
+		require.Len(t, data.Messages[0].ToolCalls, 2)
+		assert.Len(t, data.Messages[0].ToolCalls[0].ResultEvents, 2)
+		assert.Len(t, data.Messages[0].ToolCalls[1].ResultEvents, 1)
+
+		second.ResultEvents = append(
+			second.ResultEvents, artifactExportLoadResultEvent(1),
+		)
+		require.NoError(t, database.ReplaceSessionMessages("session", []Message{{
+			SessionID: "session", Ordinal: 0, Role: "assistant", Content: "results",
+			ToolCalls: []ToolCall{first, second},
+		}}))
+		_, err = database.LoadArtifactExportData(
+			t.Context(), "session", smallArtifactExportLoadLimits(),
+		)
+		require.ErrorIs(t, err, ErrArtifactExportLimit)
+	})
+}
+
+func TestLoadArtifactExportDataRawByteBoundaries(t *testing.T) {
+	t.Run("message data", func(t *testing.T) {
+		database := artifactExportLoadTestDB(t)
+		require.NoError(t, database.ReplaceSessionMessages("session", []Message{{
+			SessionID: "session", Ordinal: 0, Role: "user", Content: "abcd",
+		}}))
+		limits := smallArtifactExportLoadLimits()
+		limits.MessageBytes = 8
+		data, err := database.LoadArtifactExportData(t.Context(), "session", limits)
+		require.NoError(t, err)
+		assert.Len(t, data.Messages, 1)
+
+		limits.MessageBytes = 7
+		_, err = database.LoadArtifactExportData(t.Context(), "session", limits)
+		require.ErrorIs(t, err, ErrArtifactExportLimit)
+	})
+
+	t.Run("usage data", func(t *testing.T) {
+		database := artifactExportLoadTestDB(t)
+		require.NoError(t, database.ReplaceSessionUsageEvents("session", []UsageEvent{{
+			SessionID: "session", Source: "src", Model: "model",
+		}}))
+		limits := smallArtifactExportLoadLimits()
+		limits.UsageBytes = 8
+		data, err := database.LoadArtifactExportData(t.Context(), "session", limits)
+		require.NoError(t, err)
+		assert.Len(t, data.UsageEvents, 1)
+
+		limits.UsageBytes = 7
+		_, err = database.LoadArtifactExportData(t.Context(), "session", limits)
+		require.ErrorIs(t, err, ErrArtifactExportLimit)
+	})
+
+	t.Run("tool call data", func(t *testing.T) {
+		database := artifactExportLoadTestDB(t)
+		require.NoError(t, database.ReplaceSessionMessages("session", []Message{{
+			SessionID: "session", Ordinal: 0,
+			ToolCalls: []ToolCall{{
+				ToolName: "Read", Category: "file", InputJSON: "abcd",
+			}},
+		}}))
+		limits := smallArtifactExportLoadLimits()
+		limits.MessageBytes = 12
+		data, err := database.LoadArtifactExportData(t.Context(), "session", limits)
+		require.NoError(t, err)
+		require.Len(t, data.Messages, 1)
+		assert.Len(t, data.Messages[0].ToolCalls, 1)
+
+		limits.MessageBytes = 11
+		_, err = database.LoadArtifactExportData(t.Context(), "session", limits)
+		require.ErrorIs(t, err, ErrArtifactExportLimit)
+	})
+
+	t.Run("result event data", func(t *testing.T) {
+		database := artifactExportLoadTestDB(t)
+		require.NoError(t, database.ReplaceSessionMessages("session", []Message{{
+			SessionID: "session", Ordinal: 0,
+			ToolCalls: []ToolCall{{
+				ResultEvents: []ToolResultEvent{{
+					Source: "src", Status: "ok", Content: "abc",
+				}},
+			}},
+		}}))
+		limits := smallArtifactExportLoadLimits()
+		limits.MessageBytes = 8
+		data, err := database.LoadArtifactExportData(t.Context(), "session", limits)
+		require.NoError(t, err)
+		require.Len(t, data.Messages, 1)
+		require.Len(t, data.Messages[0].ToolCalls, 1)
+		assert.Len(t, data.Messages[0].ToolCalls[0].ResultEvents, 1)
+
+		limits.MessageBytes = 7
+		_, err = database.LoadArtifactExportData(t.Context(), "session", limits)
+		require.ErrorIs(t, err, ErrArtifactExportLimit)
+	})
+
+	t.Run("message and nested aggregate", func(t *testing.T) {
+		database := artifactExportLoadTestDB(t)
+		require.NoError(t, database.ReplaceSessionMessages("session", []Message{{
+			SessionID: "session", Ordinal: 0, Role: "user", Content: "a",
+			ToolCalls: []ToolCall{{
+				ToolName: "Read", Category: "file",
+				ResultEvents: []ToolResultEvent{{
+					Source: "src", Status: "ok", Content: "zz",
+				}},
+			}},
+		}}))
+		limits := smallArtifactExportLoadLimits()
+		limits.MessageBytes = 20
+		data, err := database.LoadArtifactExportData(t.Context(), "session", limits)
+		require.NoError(t, err)
+		require.Len(t, data.Messages, 1)
+		require.Len(t, data.Messages[0].ToolCalls, 1)
+		assert.Len(t, data.Messages[0].ToolCalls[0].ResultEvents, 1)
+
+		limits.MessageBytes = 19
+		_, err = database.LoadArtifactExportData(t.Context(), "session", limits)
+		require.ErrorIs(t, err, ErrArtifactExportLimit)
+	})
+}
+
+func TestLoadArtifactExportDataDoesNotHydrateMismatchedNestedRows(t *testing.T) {
+	database := artifactExportLoadTestDB(t)
+	require.NoError(t, database.UpsertSession(Session{
+		ID: "foreign", Project: "project", Machine: "local", Agent: "claude",
+	}))
+	require.NoError(t, database.ReplaceSessionMessages("session", []Message{{
+		SessionID: "session", Ordinal: 0, Role: "user", Content: "message",
+	}}))
+	message, err := database.GetMessageByOrdinal("session", 0)
+	require.NoError(t, err)
+	require.NotNil(t, message)
+	_, err = database.getWriter().Exec(`
+		INSERT INTO tool_calls(
+			message_id, session_id, tool_name, category, input_json, call_index
+		) VALUES (?, 'foreign', 'Read', 'file', ?, 0)`,
+		message.ID, strings.Repeat("x", 2<<20),
+	)
+	require.NoError(t, err)
+
+	data, err := database.LoadArtifactExportData(
+		t.Context(), "session", smallArtifactExportLoadLimits(),
+	)
+	require.NoError(t, err)
+	require.Len(t, data.Messages, 1)
+	assert.Empty(t, data.Messages[0].ToolCalls,
+		"nested rows from a different stored session must not bypass preflight")
+}
+
+func TestLoadArtifactExportDataAllocationIsBoundedByLimit(t *testing.T) {
+	limits := smallArtifactExportLoadLimits()
+	makeDatabase := func(t *testing.T, count int) *DB {
+		t.Helper()
+		database := artifactExportLoadTestDB(t)
+		messages := make([]Message, count)
+		for i := range messages {
+			messages[i] = artifactExportLoadMessage(i)
+		}
+		require.NoError(t, database.ReplaceSessionMessages("session", messages))
+		return database
+	}
+	small := makeDatabase(t, 3)
+	large := makeDatabase(t, 10_000)
+
+	smallAllocs := testing.AllocsPerRun(5, func() {
+		_, err := small.LoadArtifactExportData(t.Context(), "session", limits)
+		require.ErrorIs(t, err, ErrArtifactExportLimit)
+	})
+	largeAllocs := testing.AllocsPerRun(5, func() {
+		_, err := large.LoadArtifactExportData(t.Context(), "session", limits)
+		require.ErrorIs(t, err, ErrArtifactExportLimit)
+	})
+	assert.LessOrEqual(t, largeAllocs, smallAllocs+50,
+		"preflight allocation must remain bounded by limit, not session cardinality")
+}
+
+func artifactExportLoadTestDB(t *testing.T) *DB {
+	t.Helper()
+	database := testDB(t)
+	require.NoError(t, database.UpsertSession(Session{
+		ID: "session", Project: "project", Machine: "local", Agent: "claude",
+	}))
+	return database
+}
+
+func artifactExportLoadMessage(ordinal int) Message {
+	return Message{
+		SessionID: "session", Ordinal: ordinal, Role: "user", Content: "message",
+	}
+}
+
+func artifactExportLoadUsageEvent(index int) UsageEvent {
+	return UsageEvent{
+		SessionID: "session", Source: "source", Model: "model",
+		DedupKey: "event-" + strconv.Itoa(index),
+	}
+}
+
+func artifactExportLoadToolCall(index int) ToolCall {
+	return ToolCall{
+		SessionID: "session", ToolName: "Read", Category: "file",
+		ToolUseID: "call-" + strconv.Itoa(index), CallIndex: index,
+	}
+}
+
+func artifactExportLoadResultEvent(index int) ToolResultEvent {
+	return ToolResultEvent{
+		Source: "tool", Status: "completed", Content: "result",
+		EventIndex: index,
+	}
+}

--- a/internal/db/artifact_publication.go
+++ b/internal/db/artifact_publication.go
@@ -1,0 +1,785 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const maxArtifactQueuePageSize = 1024
+
+// ErrArtifactExportClaimStale tells callers to discard computed export
+// output and retry from a fresh queue claim.
+var ErrArtifactExportClaimStale = errors.New("artifact export claim is stale")
+
+// ErrArtifactOriginMismatch tells callers that the exporter is not operating
+// under the database's currently configured artifact namespace.
+var ErrArtifactOriginMismatch = errors.New("artifact origin does not match persisted origin")
+
+// beforeApplyArtifactPublicationLock is a test synchronization seam for
+// exercising origin adoption races at the writer-reservation boundary.
+var beforeApplyArtifactPublicationLock = func() {}
+
+// ArtifactExportQueueItem identifies one locally-owned session whose artifact
+// publication may no longer match the archive.
+type ArtifactExportQueueItem struct {
+	SessionID  string
+	EnqueuedAt string
+	Generation int64
+}
+
+// ArtifactExportOutcome is the terminal result for one exact queue claim.
+// An empty Rejection marks successful work clean; a non-empty Rejection records
+// a deterministic failure for diagnostics.
+type ArtifactExportOutcome struct {
+	Item      ArtifactExportQueueItem
+	Rejection string
+}
+
+// ArtifactExportRejection describes the most recent deterministically rejected
+// generation for one session.
+type ArtifactExportRejection struct {
+	SessionID  string
+	Generation int64
+	Error      string
+	RejectedAt string
+}
+
+// ArtifactPublication is the last manifest selected for one locally-owned
+// session. Rows are the authority used to stream a full checkpoint map.
+type ArtifactPublication struct {
+	Origin            string
+	SessionID         string
+	ManifestHash      string
+	SourceFingerprint string
+}
+
+// ArtifactPublicationChange changes or removes one publication row. Delete is
+// used when a queued session is no longer locally owned or no longer exists.
+type ArtifactPublicationChange struct {
+	SessionID         string
+	Generation        int64
+	ManifestHash      string
+	SourceFingerprint string
+	Delete            bool
+}
+
+// ArtifactCheckpointHead records the last successfully created checkpoint,
+// the exact publication revision it represents, and its catalog identity.
+type ArtifactCheckpointHead struct {
+	Origin              string
+	Sequence            int
+	PublicationRevision int64
+	SessionMapSHA256    string
+	CheckpointSHA256    string
+	CheckpointSize      int64
+}
+
+// CountPendingArtifactExports snapshots the current dirty queue cardinality.
+// Full exports use the count as a finite drain boundary so work arriving after
+// the snapshot is left for a later convergence round.
+func (db *DB) CountPendingArtifactExports(ctx context.Context) (int, error) {
+	var count int
+	if err := db.getReader().QueryRowContext(ctx, `
+		SELECT count(*) FROM artifact_export_queue
+		WHERE pending = 1`).Scan(&count); err != nil {
+		return 0, fmt.Errorf("counting artifact export queue: %w", err)
+	}
+	return count, nil
+}
+
+// PendingArtifactExports returns the oldest bounded page of dirty local
+// sessions. Reading work never acknowledges it.
+func (db *DB) PendingArtifactExports(
+	ctx context.Context, limit int,
+) ([]ArtifactExportQueueItem, error) {
+	if err := validateArtifactQueueLimit(limit); err != nil {
+		return nil, err
+	}
+	rows, err := db.getReader().QueryContext(ctx, `
+		SELECT session_id, enqueued_at, generation
+		FROM artifact_export_queue
+		WHERE pending = 1
+		ORDER BY enqueued_at, session_id
+		LIMIT ?`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("reading artifact export queue: %w", err)
+	}
+	defer rows.Close()
+	items := make([]ArtifactExportQueueItem, 0, min(limit, 64))
+	for rows.Next() {
+		var item ArtifactExportQueueItem
+		if err := rows.Scan(&item.SessionID, &item.EnqueuedAt, &item.Generation); err != nil {
+			return nil, fmt.Errorf("scanning artifact export queue: %w", err)
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating artifact export queue: %w", err)
+	}
+	return items, nil
+}
+
+// ArtifactExportClaims returns pending generation claims for the exact bounded
+// session set requested by a watcher batch. Missing or already-clean IDs are
+// omitted; mutation APIs revalidate every returned generation under a writer
+// reservation before changing publication authority.
+func (db *DB) ArtifactExportClaims(
+	ctx context.Context, sessionIDs []string,
+) ([]ArtifactExportQueueItem, error) {
+	if len(sessionIDs) == 0 {
+		return []ArtifactExportQueueItem{}, nil
+	}
+	if len(sessionIDs) > maxArtifactQueuePageSize {
+		return nil, fmt.Errorf("artifact export claim batch exceeds %d rows", maxArtifactQueuePageSize)
+	}
+	unique := make([]string, 0, len(sessionIDs))
+	seen := make(map[string]struct{}, len(sessionIDs))
+	for _, id := range sessionIDs {
+		if id == "" {
+			return nil, errors.New("artifact export claim session id is required")
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		unique = append(unique, id)
+	}
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(unique)), ",")
+	args := make([]any, len(unique))
+	for i, id := range unique {
+		args[i] = id
+	}
+	rows, err := db.getReader().QueryContext(ctx, `
+		SELECT session_id, enqueued_at, generation
+		FROM artifact_export_queue
+		WHERE pending = 1 AND session_id IN (`+placeholders+`)
+		ORDER BY session_id`, args...)
+	if err != nil {
+		return nil, fmt.Errorf("reading exact artifact export claims: %w", err)
+	}
+	defer rows.Close()
+	items := make([]ArtifactExportQueueItem, 0, len(unique))
+	for rows.Next() {
+		var item ArtifactExportQueueItem
+		if err := rows.Scan(&item.SessionID, &item.EnqueuedAt, &item.Generation); err != nil {
+			return nil, fmt.Errorf("scanning exact artifact export claim: %w", err)
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating exact artifact export claims: %w", err)
+	}
+	return items, nil
+}
+
+// ApplyArtifactPublicationChanges atomically applies a bounded export batch and
+// returns the resulting per-origin publication revision. The revision advances
+// only when a publication row changes. Queue rows remain pending until the
+// resulting checkpoint has been created.
+func (db *DB) ApplyArtifactPublicationChanges(
+	ctx context.Context, origin string, changes []ArtifactPublicationChange,
+) (int64, bool, error) {
+	if origin == "" {
+		return 0, false, errors.New("artifact publication origin is required")
+	}
+	if len(changes) > maxArtifactQueuePageSize {
+		return 0, false, fmt.Errorf(
+			"artifact publication batch exceeds %d rows", maxArtifactQueuePageSize,
+		)
+	}
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	tx, err := db.getWriter().BeginTx(ctx, nil)
+	if err != nil {
+		return 0, false, fmt.Errorf("beginning artifact publication changes: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	beforeApplyArtifactPublicationLock()
+	if err := lockArtifactPublicationTx(ctx, tx); err != nil {
+		return 0, false, err
+	}
+	if err := validateArtifactOriginTx(ctx, tx, origin); err != nil {
+		return 0, false, err
+	}
+	claims := make([]ArtifactExportQueueItem, 0, len(changes))
+	for _, change := range changes {
+		claims = append(claims, ArtifactExportQueueItem{
+			SessionID: change.SessionID, Generation: change.Generation,
+		})
+	}
+	if _, err := validateArtifactExportClaimsTx(ctx, tx, claims); err != nil {
+		return 0, false, err
+	}
+	changed := false
+	for _, change := range changes {
+		if change.SessionID == "" {
+			return 0, false, errors.New("artifact publication session id is required")
+		}
+		var result sql.Result
+		if change.Delete {
+			result, err = tx.ExecContext(ctx, `
+				DELETE FROM artifact_publications
+				WHERE origin = ? AND session_id = ?`, origin, change.SessionID)
+		} else {
+			if change.ManifestHash == "" || change.SourceFingerprint == "" {
+				return 0, false, fmt.Errorf(
+					"artifact publication %s requires manifest hash and source fingerprint",
+					change.SessionID,
+				)
+			}
+			result, err = tx.ExecContext(ctx, `
+				INSERT INTO artifact_publications (
+					origin, session_id, manifest_hash, source_fingerprint
+				) VALUES (?, ?, ?, ?)
+				ON CONFLICT(origin, session_id) DO UPDATE SET
+					manifest_hash = excluded.manifest_hash,
+					source_fingerprint = excluded.source_fingerprint
+				WHERE artifact_publications.manifest_hash <> excluded.manifest_hash
+				   OR artifact_publications.source_fingerprint <> excluded.source_fingerprint`,
+				origin, change.SessionID, change.ManifestHash, change.SourceFingerprint)
+		}
+		if err != nil {
+			return 0, false, fmt.Errorf("applying artifact publication %s: %w", change.SessionID, err)
+		}
+		if result == nil {
+			return 0, false, fmt.Errorf("applying artifact publication %s returned no result", change.SessionID)
+		}
+		rows, rowsErr := result.RowsAffected()
+		if rowsErr != nil {
+			return 0, false, fmt.Errorf("reading artifact publication result %s: %w", change.SessionID, rowsErr)
+		}
+		changed = changed || rows > 0
+	}
+	revision, err := artifactPublicationRevisionTx(ctx, tx, origin, changed)
+	if err != nil {
+		return 0, false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, false, fmt.Errorf("committing artifact publication changes: %w", err)
+	}
+	return revision, changed, nil
+}
+
+func validateArtifactOriginTx(
+	ctx context.Context, tx *sql.Tx, origin string,
+) error {
+	var persisted string
+	err := tx.QueryRowContext(ctx, `
+		SELECT value FROM pg_sync_state WHERE key = 'artifact_origin_id'`,
+	).Scan(&persisted)
+	if errors.Is(err, sql.ErrNoRows) || (err == nil && persisted == "") {
+		return fmt.Errorf("%w: no persisted artifact origin", ErrArtifactOriginMismatch)
+	}
+	if err != nil {
+		return fmt.Errorf("reading persisted artifact origin: %w", err)
+	}
+	if persisted != origin {
+		return fmt.Errorf(
+			"%w: requested %s, persisted %s",
+			ErrArtifactOriginMismatch, origin, persisted,
+		)
+	}
+	return nil
+}
+
+func artifactPublicationRevisionTx(
+	ctx context.Context, tx *sql.Tx, origin string, increment bool,
+) (int64, error) {
+	var revision int64
+	if increment {
+		err := tx.QueryRowContext(ctx, `
+			INSERT INTO artifact_publication_revisions(origin, revision) VALUES (?, 1)
+			ON CONFLICT(origin) DO UPDATE SET revision = revision + 1
+			RETURNING revision`, origin).Scan(&revision)
+		if err != nil {
+			return 0, fmt.Errorf("advancing artifact publication revision: %w", err)
+		}
+		return revision, nil
+	}
+	err := tx.QueryRowContext(ctx, `
+		SELECT revision FROM artifact_publication_revisions WHERE origin = ?`, origin,
+	).Scan(&revision)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("reading artifact publication revision: %w", err)
+	}
+	return revision, nil
+}
+
+// AcknowledgeArtifactExports marks successfully processed work clean while
+// retaining its generation authority when no checkpoint-head update is needed.
+func (db *DB) AcknowledgeArtifactExports(
+	ctx context.Context, items []ArtifactExportQueueItem,
+) error {
+	return db.FinalizeArtifactExports(ctx, successfulArtifactExportOutcomes(items))
+}
+
+// FinalizeArtifactExports records terminal outcomes while retaining generation
+// authority when no checkpoint-head update is needed.
+func (db *DB) FinalizeArtifactExports(
+	ctx context.Context, outcomes []ArtifactExportOutcome,
+) error {
+	if len(outcomes) > maxArtifactQueuePageSize {
+		return fmt.Errorf("artifact export finalization exceeds %d rows", maxArtifactQueuePageSize)
+	}
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	tx, err := db.getWriter().BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("beginning artifact export finalization: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := lockArtifactPublicationTx(ctx, tx); err != nil {
+		return err
+	}
+	if err := finalizeArtifactExportOutcomesTx(ctx, tx, outcomes); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing artifact export finalization: %w", err)
+	}
+	return nil
+}
+
+// RecordArtifactCheckpointHead atomically records a successfully created head
+// and acknowledges exactly the queue rows represented by that export batch.
+func (db *DB) RecordArtifactCheckpointHead(
+	ctx context.Context, head ArtifactCheckpointHead, acknowledgedItems []ArtifactExportQueueItem,
+) error {
+	return db.RecordArtifactCheckpointHeadOutcomes(
+		ctx, head, successfulArtifactExportOutcomes(acknowledgedItems),
+	)
+}
+
+// RecordArtifactCheckpointHeadOutcomes atomically records a successfully
+// created head and finalizes exactly the queue claims represented by the
+// export batch.
+func (db *DB) RecordArtifactCheckpointHeadOutcomes(
+	ctx context.Context, head ArtifactCheckpointHead, outcomes []ArtifactExportOutcome,
+) error {
+	if head.Origin == "" || head.Sequence < 1 || head.PublicationRevision < 0 ||
+		head.SessionMapSHA256 == "" || head.CheckpointSHA256 == "" || head.CheckpointSize < 0 {
+		return errors.New("complete artifact checkpoint head is required")
+	}
+	if len(outcomes) > maxArtifactQueuePageSize {
+		return fmt.Errorf("artifact checkpoint finalization exceeds %d rows", maxArtifactQueuePageSize)
+	}
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	tx, err := db.getWriter().BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("beginning artifact checkpoint head: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := lockArtifactPublicationTx(ctx, tx); err != nil {
+		return err
+	}
+	currentRevision, err := artifactPublicationRevisionTx(ctx, tx, head.Origin, false)
+	if err != nil {
+		return err
+	}
+	if currentRevision != head.PublicationRevision {
+		return fmt.Errorf("%w: artifact publication revision %d is now %d",
+			ErrArtifactExportClaimStale, head.PublicationRevision, currentRevision)
+	}
+	result, err := tx.ExecContext(ctx, `
+		INSERT INTO artifact_checkpoint_heads (
+			origin, sequence, publication_revision, session_map_sha256,
+			checkpoint_sha256, checkpoint_size
+		) VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(origin) DO UPDATE SET
+			sequence = excluded.sequence,
+			publication_revision = excluded.publication_revision,
+			session_map_sha256 = excluded.session_map_sha256,
+			checkpoint_sha256 = excluded.checkpoint_sha256,
+			checkpoint_size = excluded.checkpoint_size
+		WHERE excluded.sequence > artifact_checkpoint_heads.sequence
+		   OR (
+			excluded.sequence = artifact_checkpoint_heads.sequence
+			AND excluded.session_map_sha256 = artifact_checkpoint_heads.session_map_sha256
+			AND excluded.checkpoint_sha256 = artifact_checkpoint_heads.checkpoint_sha256
+			AND excluded.checkpoint_size = artifact_checkpoint_heads.checkpoint_size
+		   )`,
+		head.Origin, head.Sequence, head.PublicationRevision, head.SessionMapSHA256,
+		head.CheckpointSHA256, head.CheckpointSize,
+	)
+	if err != nil {
+		return fmt.Errorf("recording artifact checkpoint head: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("reading artifact checkpoint head result: %w", err)
+	}
+	if rows != 1 {
+		return fmt.Errorf(
+			"artifact checkpoint head %s sequence %d conflicts with a newer or different head",
+			head.Origin, head.Sequence,
+		)
+	}
+	if err := finalizeArtifactExportOutcomesTx(ctx, tx, outcomes); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing artifact checkpoint head: %w", err)
+	}
+	return nil
+}
+
+func successfulArtifactExportOutcomes(
+	items []ArtifactExportQueueItem,
+) []ArtifactExportOutcome {
+	outcomes := make([]ArtifactExportOutcome, len(items))
+	for i, item := range items {
+		outcomes[i] = ArtifactExportOutcome{Item: item}
+	}
+	return outcomes
+}
+
+func validateArtifactExportClaimsTx(
+	ctx context.Context, tx *sql.Tx, items []ArtifactExportQueueItem,
+) ([]ArtifactExportQueueItem, error) {
+	unique := make([]ArtifactExportQueueItem, 0, len(items))
+	seen := make(map[string]int64, len(items))
+	for _, item := range items {
+		if item.SessionID == "" || item.Generation < 1 {
+			return nil, errors.New("complete artifact export acknowledgement item is required")
+		}
+		if generation, ok := seen[item.SessionID]; ok {
+			if generation != item.Generation {
+				return nil, fmt.Errorf("%w: conflicting generations for session %s",
+					ErrArtifactExportClaimStale, item.SessionID)
+			}
+			continue
+		}
+		seen[item.SessionID] = item.Generation
+		unique = append(unique, item)
+	}
+	for _, item := range unique {
+		var generation int64
+		var pending bool
+		err := tx.QueryRowContext(ctx, `
+			SELECT generation, pending FROM artifact_export_queue WHERE session_id = ?`,
+			item.SessionID,
+		).Scan(&generation, &pending)
+		if errors.Is(err, sql.ErrNoRows) || err == nil && (!pending || generation != item.Generation) {
+			return nil, fmt.Errorf("%w: session %s generation %d",
+				ErrArtifactExportClaimStale, item.SessionID, item.Generation)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("validating artifact export claim %s: %w", item.SessionID, err)
+		}
+	}
+	return unique, nil
+}
+
+func finalizeArtifactExportOutcomesTx(
+	ctx context.Context, tx *sql.Tx, outcomes []ArtifactExportOutcome,
+) error {
+	items := make([]ArtifactExportQueueItem, len(outcomes))
+	for i, outcome := range outcomes {
+		items[i] = outcome.Item
+	}
+	unique, err := validateArtifactExportClaimsTx(ctx, tx, items)
+	if err != nil {
+		return err
+	}
+	bySession := make(map[string]string, len(outcomes))
+	for _, outcome := range outcomes {
+		if previous, ok := bySession[outcome.Item.SessionID]; ok &&
+			previous != outcome.Rejection {
+			return fmt.Errorf(
+				"conflicting artifact export outcomes for session %s",
+				outcome.Item.SessionID,
+			)
+		}
+		bySession[outcome.Item.SessionID] = outcome.Rejection
+	}
+	for _, item := range unique {
+		rejection := bySession[item.SessionID]
+		var rejectedGeneration any
+		var rejectedAt any
+		if rejection != "" {
+			rejectedGeneration = item.Generation
+			rejectedAt = time.Now().UTC().Format(time.RFC3339Nano)
+		}
+		result, err := tx.ExecContext(ctx, `
+			UPDATE artifact_export_queue SET
+				pending = 0,
+				rejected_generation = ?,
+				last_error = ?,
+				rejected_at = ?
+			WHERE session_id = ? AND generation = ? AND pending = 1`,
+			rejectedGeneration, rejection, rejectedAt,
+			item.SessionID, item.Generation,
+		)
+		if err != nil {
+			return fmt.Errorf("finalizing artifact export %s: %w", item.SessionID, err)
+		}
+		rows, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("reading artifact export finalization %s: %w", item.SessionID, err)
+		}
+		if rows != 1 {
+			return fmt.Errorf("%w: session %s generation %d",
+				ErrArtifactExportClaimStale, item.SessionID, item.Generation)
+		}
+	}
+	return nil
+}
+
+// GetArtifactExportRejection returns the deterministic rejection diagnostics
+// for a session's current clean generation, if present.
+func (db *DB) GetArtifactExportRejection(
+	ctx context.Context, sessionID string,
+) (ArtifactExportRejection, bool, error) {
+	var rejection ArtifactExportRejection
+	err := db.getReader().QueryRowContext(ctx, `
+		SELECT session_id, rejected_generation, last_error, rejected_at
+		FROM artifact_export_queue
+		WHERE session_id = ?
+		  AND rejected_generation IS NOT NULL
+		  AND last_error <> ''
+		  AND rejected_at IS NOT NULL`, sessionID,
+	).Scan(
+		&rejection.SessionID, &rejection.Generation,
+		&rejection.Error, &rejection.RejectedAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ArtifactExportRejection{}, false, nil
+	}
+	if err != nil {
+		return ArtifactExportRejection{}, false,
+			fmt.Errorf("reading artifact export rejection: %w", err)
+	}
+	return rejection, true, nil
+}
+
+// lockArtifactPublicationTx obtains SQLite's writer reservation before claim
+// validation, closing the check-to-mutate race with other database handles.
+func lockArtifactPublicationTx(ctx context.Context, tx *sql.Tx) error {
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE artifact_export_queue SET generation = generation WHERE 0`); err != nil {
+		return fmt.Errorf("locking artifact publication transaction: %w", err)
+	}
+	return nil
+}
+
+// GetArtifactCheckpointHead returns the current recorded head for origin.
+func (db *DB) GetArtifactCheckpointHead(
+	ctx context.Context, origin string,
+) (ArtifactCheckpointHead, bool, error) {
+	var head ArtifactCheckpointHead
+	err := db.getReader().QueryRowContext(ctx, `
+		SELECT origin, sequence, publication_revision, session_map_sha256,
+		       checkpoint_sha256, checkpoint_size
+		FROM artifact_checkpoint_heads WHERE origin = ?`, origin).Scan(
+		&head.Origin, &head.Sequence, &head.PublicationRevision,
+		&head.SessionMapSHA256, &head.CheckpointSHA256, &head.CheckpointSize,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ArtifactCheckpointHead{}, false, nil
+	}
+	if err != nil {
+		return ArtifactCheckpointHead{}, false, fmt.Errorf("reading artifact checkpoint head: %w", err)
+	}
+	return head, true, nil
+}
+
+// StreamArtifactPublications visits publication rows in canonical session-id
+// order without materializing the full checkpoint map. The returned revision
+// and every visited row come from the same SQLite read snapshot.
+func (db *DB) StreamArtifactPublications(
+	ctx context.Context, origin string, visit func(ArtifactPublication) error,
+) (int64, error) {
+	if visit == nil {
+		return 0, errors.New("artifact publication visitor is required")
+	}
+	db.connMu.RLock()
+	reader := db.reader.Load()
+	if reader == nil {
+		db.connMu.RUnlock()
+		return 0, errors.New("database is closed")
+	}
+	tx, err := reader.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	db.connMu.RUnlock()
+	if err != nil {
+		return 0, fmt.Errorf("beginning artifact publication snapshot: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	revision, err := artifactPublicationRevisionTx(ctx, tx, origin, false)
+	if err != nil {
+		return 0, err
+	}
+	rows, err := tx.QueryContext(ctx, `
+		SELECT origin, session_id, manifest_hash, source_fingerprint
+		FROM artifact_publications
+		WHERE origin = ?
+		ORDER BY session_id`, origin)
+	if err != nil {
+		return 0, fmt.Errorf("streaming artifact publications: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var publication ArtifactPublication
+		if err := rows.Scan(
+			&publication.Origin, &publication.SessionID,
+			&publication.ManifestHash, &publication.SourceFingerprint,
+		); err != nil {
+			return 0, fmt.Errorf("scanning artifact publication: %w", err)
+		}
+		if err := visit(publication); err != nil {
+			return 0, err
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("iterating artifact publications: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return 0, fmt.Errorf("closing artifact publications: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("committing artifact publication snapshot: %w", err)
+	}
+	return revision, nil
+}
+
+// ReserveArtifactCheckpointSequence commits the next sequence in an immediate
+// transaction before returning. observedFloor is a stable vault traversal's
+// maximum sequence and can only raise, never lower, the retained authority.
+func (db *DB) ReserveArtifactCheckpointSequence(
+	ctx context.Context, origin string, observedFloor int,
+) (_ int, retErr error) {
+	if origin == "" {
+		return 0, errors.New("artifact checkpoint origin is required")
+	}
+	if observedFloor < 0 {
+		return 0, errors.New("artifact checkpoint observed floor must not be negative")
+	}
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	conn, err := db.getWriter().Conn(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("acquiring artifact checkpoint connection: %w", err)
+	}
+	defer conn.Close()
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		return 0, fmt.Errorf("beginning artifact checkpoint reservation: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, rollbackErr := conn.ExecContext(context.WithoutCancel(ctx), "ROLLBACK")
+			retErr = errors.Join(retErr, rollbackErr)
+		}
+	}()
+	var sequence int
+	err = conn.QueryRowContext(ctx, `
+		INSERT INTO artifact_checkpoint_floors(origin, sequence)
+		VALUES (?, ? + 1)
+		ON CONFLICT(origin) DO UPDATE SET
+			sequence = max(artifact_checkpoint_floors.sequence, ?)+1
+		RETURNING sequence`, origin, observedFloor, observedFloor).Scan(&sequence)
+	if err != nil {
+		return 0, fmt.Errorf("reserving artifact checkpoint sequence: %w", err)
+	}
+	if _, err := conn.ExecContext(context.WithoutCancel(ctx), "COMMIT"); err != nil {
+		return 0, fmt.Errorf("committing artifact checkpoint reservation: %w", err)
+	}
+	committed = true
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	return sequence, nil
+}
+
+// GetArtifactCheckpointFloor reports the durable sequence authority, if this
+// origin has already been bootstrapped.
+func (db *DB) GetArtifactCheckpointFloor(
+	ctx context.Context, origin string,
+) (int, bool, error) {
+	if origin == "" {
+		return 0, false, errors.New("artifact checkpoint origin is required")
+	}
+	var sequence int
+	err := db.getReader().QueryRowContext(ctx, `
+		SELECT sequence FROM artifact_checkpoint_floors WHERE origin = ?`, origin,
+	).Scan(&sequence)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, fmt.Errorf("reading artifact checkpoint floor: %w", err)
+	}
+	return sequence, true, nil
+}
+
+func validateArtifactQueueLimit(limit int) error {
+	if limit < 1 || limit > maxArtifactQueuePageSize {
+		return fmt.Errorf("artifact queue limit must be between 1 and %d", maxArtifactQueuePageSize)
+	}
+	return nil
+}
+
+// enqueueArtifactExportTx advances one locally-owned session exactly once for
+// a production transaction whose child-row mutation does not also change an
+// export-relevant sessions column. The write is gated on the presence of an
+// artifact origin (pg_sync_state key artifact_origin_id) so that archives
+// which have never created or adopted an artifact origin never populate the
+// export queue.
+func enqueueArtifactExportTx(tx *sql.Tx, sessionID string) error {
+	_, err := tx.Exec(`
+		INSERT INTO artifact_export_queue(session_id)
+		SELECT id FROM sessions WHERE id = ? AND machine = 'local'
+			AND EXISTS (SELECT 1 FROM pg_sync_state
+				WHERE key = 'artifact_origin_id')
+		ON CONFLICT(session_id) DO UPDATE SET
+			enqueued_at = CASE WHEN pending = 0
+				THEN strftime('%Y-%m-%dT%H:%M:%fZ','now') ELSE enqueued_at END,
+			generation = generation + 1,
+			pending = 1,
+			rejected_generation = NULL,
+			last_error = '',
+			rejected_at = NULL`, sessionID)
+	if err != nil {
+		return fmt.Errorf("enqueueing artifact export for %s: %w", sessionID, err)
+	}
+	return nil
+}
+
+func artifactExportGenerationTx(
+	tx *sql.Tx, sessionID string,
+) (int64, bool, error) {
+	var generation int64
+	err := tx.QueryRow(`
+		SELECT generation FROM artifact_export_queue WHERE session_id = ?`, sessionID,
+	).Scan(&generation)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, fmt.Errorf("reading artifact export generation for %s: %w", sessionID, err)
+	}
+	return generation, true, nil
+}
+
+func enqueueArtifactExportIfGenerationUnchangedTx(
+	tx *sql.Tx,
+	sessionID string,
+	generationBefore int64,
+	existedBefore bool,
+) error {
+	generationAfter, existsAfter, err := artifactExportGenerationTx(tx, sessionID)
+	if err != nil {
+		return err
+	}
+	if existedBefore == existsAfter && generationBefore == generationAfter {
+		return enqueueArtifactExportTx(tx, sessionID)
+	}
+	return nil
+}

--- a/internal/db/artifact_publication.go
+++ b/internal/db/artifact_publication.go
@@ -422,6 +422,15 @@ func (db *DB) RecordArtifactCheckpointHeadOutcomes(
 			head.Origin, head.Sequence,
 		)
 	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO artifact_checkpoint_floors(origin, sequence)
+		VALUES (?, ?)
+		ON CONFLICT(origin) DO UPDATE SET
+			sequence = max(artifact_checkpoint_floors.sequence, excluded.sequence)`,
+		head.Origin, head.Sequence,
+	); err != nil {
+		return fmt.Errorf("advancing artifact checkpoint floor from head: %w", err)
+	}
 	if err := finalizeArtifactExportOutcomesTx(ctx, tx, outcomes); err != nil {
 		return err
 	}

--- a/internal/db/artifact_publication.go
+++ b/internal/db/artifact_publication.go
@@ -11,6 +11,8 @@ import (
 
 const maxArtifactQueuePageSize = 1024
 
+const artifactLocalMachineStateKey = "artifact_local_machine_name"
+
 // ErrArtifactExportClaimStale tells callers to discard computed export
 // output and retry from a fresh queue claim.
 var ErrArtifactExportClaimStale = errors.New("artifact export claim is stale")
@@ -744,7 +746,12 @@ func validateArtifactQueueLimit(limit int) error {
 func enqueueArtifactExportTx(tx *sql.Tx, sessionID string) error {
 	_, err := tx.Exec(`
 		INSERT INTO artifact_export_queue(session_id)
-		SELECT id FROM sessions WHERE id = ? AND machine = 'local'
+		SELECT id FROM sessions WHERE id = ? AND (
+			machine = 'local' OR machine = (
+				SELECT value FROM pg_sync_state
+				WHERE key = 'artifact_local_machine_name'
+			)
+		)
 			AND EXISTS (SELECT 1 FROM pg_sync_state
 				WHERE key = 'artifact_origin_id')
 		ON CONFLICT(session_id) DO UPDATE SET
@@ -759,6 +766,74 @@ func enqueueArtifactExportTx(tx *sql.Tx, sessionID string) error {
 		return fmt.Errorf("enqueueing artifact export for %s: %w", sessionID, err)
 	}
 	return nil
+}
+
+// ArtifactLocalMachineName returns the configured machine identity used to
+// distinguish locally ingested sessions from imported peer sessions. "local"
+// remains the fallback for archives created before the identity was persisted.
+func (db *DB) ArtifactLocalMachineName(ctx context.Context) (string, error) {
+	var machine string
+	err := db.getReader().QueryRowContext(ctx, `
+		SELECT value FROM pg_sync_state WHERE key = ?`,
+		artifactLocalMachineStateKey,
+	).Scan(&machine)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "local", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("reading artifact local machine name: %w", err)
+	}
+	if strings.TrimSpace(machine) == "" {
+		return "local", nil
+	}
+	return machine, nil
+}
+
+// ConfigureArtifactLocalMachine atomically persists the runtime local-machine
+// identity and re-dirties active-origin publications when that identity
+// changes. This publishes newly owned sessions and removes publications that
+// belonged to the previous machine identity.
+func (db *DB) ConfigureArtifactLocalMachine(machine string) error {
+	if strings.TrimSpace(machine) == "" {
+		return errors.New("artifact local machine name is required")
+	}
+	return db.Update(func(tx *sql.Tx) error {
+		if err := lockArtifactPublicationTx(context.Background(), tx); err != nil {
+			return err
+		}
+		var existing string
+		err := tx.QueryRow(`
+			SELECT value FROM pg_sync_state WHERE key = ?`,
+			artifactLocalMachineStateKey,
+		).Scan(&existing)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("reading artifact local machine name: %w", err)
+		}
+		if err == nil && existing == machine {
+			return nil
+		}
+		if _, err := tx.Exec(`
+			INSERT INTO pg_sync_state(key, value) VALUES (?, ?)
+			ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+			artifactLocalMachineStateKey, machine,
+		); err != nil {
+			return fmt.Errorf("persisting artifact local machine name: %w", err)
+		}
+		var origin string
+		err = tx.QueryRow(`
+			SELECT value FROM pg_sync_state WHERE key = 'artifact_origin_id'`,
+		).Scan(&origin)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("reading artifact origin: %w", err)
+		}
+		if origin == "" {
+			return nil
+		}
+		return populateArtifactOriginQueueTx(tx, origin, true)
+	})
 }
 
 func artifactExportGenerationTx(

--- a/internal/db/artifact_publication_test.go
+++ b/internal/db/artifact_publication_test.go
@@ -614,6 +614,77 @@ func TestBootstrapArtifactExportQueueEnqueuesExistingLocalSessions(t *testing.T)
 	assert.Equal(t, firstEnqueuedAt, pendingAgain[0].EnqueuedAt)
 }
 
+func TestArtifactPublicationOwnsConfiguredHostnameSessions(t *testing.T) {
+	database := testDB(t)
+	require.NoError(t, database.SetSyncState(
+		"artifact_local_machine_name", "workstation.example",
+	))
+	seedArtifactOrigin(t, database)
+	require.NoError(t, database.UpsertSession(Session{
+		ID: "hostname-local", Project: "project",
+		Machine: "workstation.example", Agent: "claude",
+	}))
+	require.NoError(t, database.UpsertSession(Session{
+		ID: "foreign", Project: "project",
+		Machine: "peer.example", Agent: "claude",
+	}))
+
+	pending, err := database.PendingArtifactExports(t.Context(), 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	assert.Equal(t, "hostname-local", pending[0].SessionID)
+	owned, err := database.ListOwnedSessionIDsForExport(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"hostname-local"}, owned)
+
+	clearArtifactExportQueue(t, database)
+	require.NoError(t, database.ReplaceSessionUsageEvents(
+		"hostname-local", []UsageEvent{{
+			SessionID: "hostname-local", Source: "event",
+			Model: "model", DedupKey: "hostname",
+		}},
+	))
+	assert.Equal(t, []string{"hostname-local"}, artifactExportQueueIDs(t, database),
+		"child-row fallback uses the configured local machine")
+}
+
+func TestBootstrapArtifactExportQueueOwnsConfiguredHostname(t *testing.T) {
+	database := testDB(t)
+	require.NoError(t, database.SetSyncState(
+		"artifact_local_machine_name", "workstation.example",
+	))
+	require.NoError(t, database.UpsertSession(Session{
+		ID: "existing-hostname", Project: "project",
+		Machine: "workstation.example", Agent: "claude",
+	}))
+
+	require.NoError(t, database.BootstrapArtifactExportQueue())
+	pending, err := database.PendingArtifactExports(t.Context(), 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	assert.Equal(t, "existing-hostname", pending[0].SessionID)
+}
+
+func TestConfigureArtifactLocalMachineRequeuesExistingHostnameSession(t *testing.T) {
+	database := testDB(t)
+	require.NoError(t, database.UpsertSession(Session{
+		ID: "existing-hostname", Project: "project",
+		Machine: "workstation.example", Agent: "claude",
+	}))
+	seedArtifactOrigin(t, database)
+	assert.Empty(t, artifactExportQueueIDs(t, database))
+
+	require.NoError(t, database.ConfigureArtifactLocalMachine("workstation.example"))
+
+	machine, err := database.ArtifactLocalMachineName(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "workstation.example", machine)
+	pending, err := database.PendingArtifactExports(t.Context(), 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	assert.Equal(t, "existing-hostname", pending[0].SessionID)
+}
+
 func TestEnsureArtifactOriginPublishesOriginWithBootstrapQueue(t *testing.T) {
 	database := testDB(t)
 	require.NoError(t, database.UpsertSession(Session{

--- a/internal/db/artifact_publication_test.go
+++ b/internal/db/artifact_publication_test.go
@@ -1213,6 +1213,63 @@ func TestArtifactCheckpointFloorReservationIsConcurrentAndNeverLowers(t *testing
 	assert.Equal(t, 11+reservations, next)
 }
 
+func TestArtifactCheckpointHeadAdvancesSequenceFloor(t *testing.T) {
+	database := testDB(t)
+	ctx := t.Context()
+	require.NoError(t, database.RecordArtifactCheckpointHead(
+		ctx, ArtifactCheckpointHead{
+			Origin: "desktop-a1b2c3", Sequence: 7,
+			SessionMapSHA256: "map", CheckpointSHA256: "checkpoint",
+		}, nil,
+	))
+
+	floor, ok, err := database.GetArtifactCheckpointFloor(
+		ctx, "desktop-a1b2c3",
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, 7, floor)
+	next, err := database.ReserveArtifactCheckpointSequence(
+		ctx, "desktop-a1b2c3", 0,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 8, next)
+}
+
+func TestOpenBackfillsCheckpointFloorFromLegacyHeadWhenStoreIsEmpty(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy-head.db")
+	database, err := Open(path)
+	require.NoError(t, err)
+	require.NoError(t, database.RecordArtifactCheckpointHead(
+		t.Context(), ArtifactCheckpointHead{
+			Origin: "desktop-a1b2c3", Sequence: 7,
+			SessionMapSHA256: "map", CheckpointSHA256: "checkpoint",
+		}, nil,
+	))
+	_, err = database.getWriter().Exec(`
+		DELETE FROM artifact_checkpoint_floors
+		WHERE origin = 'desktop-a1b2c3'`)
+	require.NoError(t, err)
+	require.NoError(t, database.Close())
+
+	reopened, err := Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, reopened.Close()) })
+	floor, ok, err := reopened.GetArtifactCheckpointFloor(
+		t.Context(), "desktop-a1b2c3",
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, 7, floor)
+	// observedFloor=0 models recovery against an empty or reset artifact
+	// store: the migrated database head remains the sequence authority.
+	next, err := reopened.ReserveArtifactCheckpointSequence(
+		t.Context(), "desktop-a1b2c3", 0,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 8, next)
+}
+
 func TestArtifactPublicationStateSurvivesFullResyncCopy(t *testing.T) {
 	dir := t.TempDir()
 	sourcePath := filepath.Join(dir, "source.db")
@@ -1487,6 +1544,17 @@ func TestArtifactPublicationStateCopyAcceptsPreRevisionCheckpointHead(t *testing
 	assert.Equal(t, 4, head.Sequence)
 	assert.Zero(t, head.PublicationRevision)
 	assert.Zero(t, head.CheckpointSize)
+	floor, ok, err := target.GetArtifactCheckpointFloor(
+		t.Context(), "desktop-a1b2c3",
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, 4, floor)
+	next, err := target.ReserveArtifactCheckpointSequence(
+		t.Context(), "desktop-a1b2c3", 0,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 5, next)
 }
 
 func TestArtifactPublicationExportCardinalityIsQueueBounded(t *testing.T) {

--- a/internal/db/artifact_publication_test.go
+++ b/internal/db/artifact_publication_test.go
@@ -659,6 +659,91 @@ func TestEnsureArtifactOriginPublishesOriginWithBootstrapQueue(t *testing.T) {
 	assert.Equal(t, "session-a", pending[0].SessionID)
 }
 
+func TestEnsureArtifactOriginRequeuesExistingLedgerWhenOriginStateIsEmpty(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		clearOrigin func(*testing.T, *DB)
+	}{
+		{
+			name: "missing row",
+			clearOrigin: func(t *testing.T, database *DB) {
+				t.Helper()
+				require.NoError(t, database.Update(func(tx *sql.Tx) error {
+					_, err := tx.Exec(
+						`DELETE FROM pg_sync_state WHERE key = 'artifact_origin_id'`,
+					)
+					return err
+				}))
+			},
+		},
+		{
+			name: "empty value",
+			clearOrigin: func(t *testing.T, database *DB) {
+				t.Helper()
+				require.NoError(t, database.SetSyncState("artifact_origin_id", ""))
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			database := testDB(t)
+			ctx := t.Context()
+			for _, session := range []Session{
+				{ID: "accepted", Project: "project", Machine: "local", Agent: "claude"},
+				{ID: "rejected", Project: "project", Machine: "local", Agent: "claude"},
+				{ID: "foreign", Project: "project", Machine: "peer-a1b2c3", Agent: "claude"},
+				{ID: "deleted", Project: "project", Machine: "local", Agent: "claude"},
+			} {
+				require.NoError(t, database.UpsertSession(session))
+			}
+			require.NoError(t, database.SoftDeleteSession("deleted"))
+			require.NoError(t, database.AdoptArtifactOrigin("origin-a1b2c3"))
+
+			claims, err := database.PendingArtifactExports(ctx, 10)
+			require.NoError(t, err)
+			require.Len(t, claims, 2)
+			claimByID := map[string]ArtifactExportQueueItem{
+				claims[0].SessionID: claims[0],
+				claims[1].SessionID: claims[1],
+			}
+			require.NoError(t, database.FinalizeArtifactExports(
+				ctx, []ArtifactExportOutcome{
+					{Item: claimByID["accepted"]},
+					{Item: claimByID["rejected"], Rejection: "message limit exceeded"},
+				},
+			))
+			drained, err := database.PendingArtifactExports(ctx, 10)
+			require.NoError(t, err)
+			require.Empty(t, drained)
+			_, rejected, err := database.GetArtifactExportRejection(ctx, "rejected")
+			require.NoError(t, err)
+			require.True(t, rejected)
+
+			tt.clearOrigin(t, database)
+			origin, err := database.EnsureArtifactOrigin("origin-d4e5f6")
+			require.NoError(t, err)
+			assert.Equal(t, "origin-d4e5f6", origin)
+
+			pending, err := database.PendingArtifactExports(ctx, 10)
+			require.NoError(t, err)
+			require.Len(t, pending, 2)
+			assert.ElementsMatch(t, []string{"accepted", "rejected"}, []string{
+				pending[0].SessionID, pending[1].SessionID,
+			})
+			for _, item := range pending {
+				assert.Greater(t, item.Generation, claimByID[item.SessionID].Generation)
+			}
+			_, rejected, err = database.GetArtifactExportRejection(ctx, "rejected")
+			require.NoError(t, err)
+			assert.False(t, rejected)
+			excluded, err := database.ArtifactExportClaims(
+				ctx, []string{"foreign", "deleted"},
+			)
+			require.NoError(t, err)
+			assert.Empty(t, excluded)
+		})
+	}
+}
+
 func TestArtifactOriginTransactionRollsBackQueuePopulationFailure(t *testing.T) {
 	database := testDB(t)
 	require.NoError(t, database.AdoptArtifactOrigin("before-a1b2c3"))

--- a/internal/db/artifact_publication_test.go
+++ b/internal/db/artifact_publication_test.go
@@ -1,0 +1,1837 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedArtifactOrigin marks database as owning an artifact origin. The
+// session triggers and enqueueArtifactExportTx that populate
+// artifact_export_queue are gated on this pg_sync_state row (see
+// artifactSessionQueueTriggerCreatesSQL and enqueueArtifactExportTx); tests
+// that exercise queue/trigger behavior must call this before any session
+// mutation they expect to enqueue.
+func seedArtifactOrigin(t *testing.T, database *DB) {
+	t.Helper()
+	require.NoError(t, database.SetSyncState("artifact_origin_id", "desktop-a1b2c3"))
+}
+
+func TestArtifactPublicationChangesRejectMismatchedPersistedOrigin(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		removeOrigin  bool
+		requestOrigin string
+	}{
+		{
+			name:          "different origin",
+			requestOrigin: "origin-d4e5f6",
+		},
+		{
+			name:          "missing origin",
+			removeOrigin:  true,
+			requestOrigin: "origin-a1b2c3",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			database := testDB(t)
+			ctx := t.Context()
+			require.NoError(t, database.AdoptArtifactOrigin("origin-a1b2c3"))
+			require.NoError(t, database.UpsertSession(Session{
+				ID: "session", Project: "project", Machine: "local", Agent: "claude",
+			}))
+			claims, err := database.PendingArtifactExports(ctx, 10)
+			require.NoError(t, err)
+			require.Len(t, claims, 1)
+			if tc.removeOrigin {
+				require.NoError(t, database.Update(func(tx *sql.Tx) error {
+					_, err := tx.Exec(
+						`DELETE FROM pg_sync_state WHERE key = 'artifact_origin_id'`,
+					)
+					return err
+				}))
+			}
+
+			revision, changed, err := database.ApplyArtifactPublicationChanges(
+				ctx, tc.requestOrigin, []ArtifactPublicationChange{{
+					SessionID: "session", Generation: claims[0].Generation,
+					ManifestHash: "manifest", SourceFingerprint: "fingerprint",
+				}},
+			)
+			require.ErrorIs(t, err, ErrArtifactOriginMismatch)
+			assert.Zero(t, revision)
+			assert.False(t, changed)
+
+			var publications []ArtifactPublication
+			_, streamErr := database.StreamArtifactPublications(
+				ctx, tc.requestOrigin, func(row ArtifactPublication) error {
+					publications = append(publications, row)
+					return nil
+				},
+			)
+			require.NoError(t, streamErr)
+			assert.Empty(t, publications)
+			pending, pendingErr := database.PendingArtifactExports(ctx, 10)
+			require.NoError(t, pendingErr)
+			require.Equal(t, claims, pending)
+		})
+	}
+}
+
+func TestArtifactPublicationOriginValidationFollowsWriterReservation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "archive.db")
+	exporter, err := Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, exporter.Close()) })
+	adopter, err := Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, adopter.Close()) })
+	require.NoError(t, exporter.AdoptArtifactOrigin("origin-a1b2c3"))
+	require.NoError(t, exporter.UpsertSession(Session{
+		ID: "session", Project: "project", Machine: "local", Agent: "claude",
+	}))
+	claims, err := exporter.PendingArtifactExports(t.Context(), 10)
+	require.NoError(t, err)
+	require.Len(t, claims, 1)
+
+	originalPopulate := populateArtifactOriginQueueTx
+	adoptionStarted := make(chan struct{})
+	releaseAdoption := make(chan struct{})
+	populateArtifactOriginQueueTx = func(tx *sql.Tx, origin string, requeue bool) error {
+		close(adoptionStarted)
+		<-releaseAdoption
+		return originalPopulate(tx, origin, requeue)
+	}
+	originalBeforeLock := beforeApplyArtifactPublicationLock
+	applyAtLock := make(chan struct{})
+	releaseApply := make(chan struct{})
+	beforeApplyArtifactPublicationLock = func() {
+		close(applyAtLock)
+		<-releaseApply
+	}
+	t.Cleanup(func() {
+		populateArtifactOriginQueueTx = originalPopulate
+		beforeApplyArtifactPublicationLock = originalBeforeLock
+	})
+
+	adoptDone := make(chan error, 1)
+	go func() {
+		adoptDone <- adopter.AdoptArtifactOrigin("origin-d4e5f6")
+	}()
+	<-adoptionStarted
+
+	type applyResult struct {
+		revision int64
+		changed  bool
+		err      error
+	}
+	applyDone := make(chan applyResult, 1)
+	go func() {
+		revision, changed, err := exporter.ApplyArtifactPublicationChanges(
+			t.Context(), "origin-a1b2c3", []ArtifactPublicationChange{{
+				SessionID: "session", Generation: claims[0].Generation,
+				ManifestHash: "manifest", SourceFingerprint: "fingerprint",
+			}},
+		)
+		applyDone <- applyResult{revision: revision, changed: changed, err: err}
+	}()
+	<-applyAtLock
+	close(releaseAdoption)
+	require.NoError(t, <-adoptDone)
+	close(releaseApply)
+
+	result := <-applyDone
+	require.ErrorIs(t, result.err, ErrArtifactOriginMismatch)
+	assert.Zero(t, result.revision)
+	assert.False(t, result.changed)
+	revision, err := exporter.StreamArtifactPublications(
+		t.Context(), "origin-a1b2c3", func(ArtifactPublication) error {
+			return errors.New("stale origin must not gain publication authority")
+		},
+	)
+	require.NoError(t, err)
+	assert.Zero(t, revision)
+	pending, err := exporter.PendingArtifactExports(t.Context(), 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	assert.Greater(t, pending[0].Generation, claims[0].Generation,
+		"the only queue change comes from the committed origin adoption")
+}
+
+func TestArtifactExportRejectionFinalizesExactGeneration(t *testing.T) {
+	database := testDB(t)
+	ctx := t.Context()
+	require.NoError(t, database.AdoptArtifactOrigin("origin-a1b2c3"))
+	require.NoError(t, database.UpsertSession(Session{
+		ID: "rejected", Project: "project", Machine: "local", Agent: "claude",
+	}))
+	claims, err := database.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, claims, 1)
+
+	require.NoError(t, database.FinalizeArtifactExports(ctx, []ArtifactExportOutcome{{
+		Item: claims[0], Rejection: "session message limit exceeded",
+	}}))
+	pending, err := database.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	assert.Empty(t, pending)
+	rejection, ok, err := database.GetArtifactExportRejection(ctx, "rejected")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, claims[0].Generation, rejection.Generation)
+	assert.Equal(t, "session message limit exceeded", rejection.Error)
+	assert.NotEmpty(t, rejection.RejectedAt)
+
+	require.NoError(t, database.ReplaceSessionMessages("rejected", []Message{{
+		SessionID: "rejected", Ordinal: 0, Role: "user", Content: "changed",
+	}}))
+	pending, err = database.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	assert.Greater(t, pending[0].Generation, claims[0].Generation)
+	_, ok, err = database.GetArtifactExportRejection(ctx, "rejected")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestArtifactExportRejectionCannotConsumeNewerGeneration(t *testing.T) {
+	database := testDB(t)
+	ctx := t.Context()
+	require.NoError(t, database.AdoptArtifactOrigin("origin-a1b2c3"))
+	require.NoError(t, database.UpsertSession(Session{
+		ID: "rejected", Project: "project", Machine: "local", Agent: "claude",
+	}))
+	claims, err := database.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, claims, 1)
+	require.NoError(t, database.UpsertSession(Session{
+		ID: "rejected", Project: "changed", Machine: "local", Agent: "claude",
+	}))
+
+	err = database.FinalizeArtifactExports(ctx, []ArtifactExportOutcome{{
+		Item: claims[0], Rejection: "stale rejection",
+	}})
+	require.ErrorIs(t, err, ErrArtifactExportClaimStale)
+	pending, err := database.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	assert.Greater(t, pending[0].Generation, claims[0].Generation)
+	_, ok, err := database.GetArtifactExportRejection(ctx, "rejected")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestArtifactCheckpointHeadAndRejectionsCommitAtomically(t *testing.T) {
+	database := testDB(t)
+	ctx := t.Context()
+	require.NoError(t, database.AdoptArtifactOrigin("origin-a1b2c3"))
+	for _, id := range []string{"accepted", "rejected"} {
+		require.NoError(t, database.UpsertSession(Session{
+			ID: id, Project: "project", Machine: "local", Agent: "claude",
+		}))
+	}
+	claims, err := database.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, claims, 2)
+	claimByID := map[string]ArtifactExportQueueItem{
+		claims[0].SessionID: claims[0],
+		claims[1].SessionID: claims[1],
+	}
+	head := ArtifactCheckpointHead{
+		Origin: "origin-a1b2c3", Sequence: 1, PublicationRevision: 0,
+		SessionMapSHA256: "map-one", CheckpointSHA256: "checkpoint-one",
+		CheckpointSize: 17,
+	}
+	require.NoError(t, database.RecordArtifactCheckpointHeadOutcomes(
+		ctx, head, []ArtifactExportOutcome{
+			{Item: claimByID["accepted"]},
+			{Item: claimByID["rejected"], Rejection: "message limit exceeded"},
+		},
+	))
+
+	gotHead, ok, err := database.GetArtifactCheckpointHead(ctx, head.Origin)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, head, gotHead)
+	pending, err := database.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	assert.Empty(t, pending)
+	rejection, ok, err := database.GetArtifactExportRejection(ctx, "rejected")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, claimByID["rejected"].Generation, rejection.Generation)
+
+	for _, id := range []string{"accepted", "rejected"} {
+		require.NoError(t, database.UpsertSession(Session{
+			ID: id, Project: "retry", Machine: "local", Agent: "claude",
+		}))
+	}
+	retryClaims, err := database.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, retryClaims, 2)
+	retryByID := map[string]ArtifactExportQueueItem{
+		retryClaims[0].SessionID: retryClaims[0],
+		retryClaims[1].SessionID: retryClaims[1],
+	}
+	require.NoError(t, database.UpsertSession(Session{
+		ID: "rejected", Project: "newer", Machine: "local", Agent: "claude",
+	}))
+
+	err = database.RecordArtifactCheckpointHeadOutcomes(
+		ctx, ArtifactCheckpointHead{
+			Origin: "origin-a1b2c3", Sequence: 2, PublicationRevision: 0,
+			SessionMapSHA256: "map-two", CheckpointSHA256: "checkpoint-two",
+			CheckpointSize: 23,
+		}, []ArtifactExportOutcome{
+			{Item: retryByID["accepted"]},
+			{Item: retryByID["rejected"], Rejection: "stale rejection"},
+		},
+	)
+	require.ErrorIs(t, err, ErrArtifactExportClaimStale)
+	gotHead, ok, err = database.GetArtifactCheckpointHead(ctx, head.Origin)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, head, gotHead)
+	pending, err = database.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 2)
+	pendingByID := map[string]ArtifactExportQueueItem{
+		pending[0].SessionID: pending[0],
+		pending[1].SessionID: pending[1],
+	}
+	assert.Equal(t, retryByID["accepted"].Generation, pendingByID["accepted"].Generation)
+	assert.Greater(t, pendingByID["rejected"].Generation, retryByID["rejected"].Generation)
+	_, ok, err = database.GetArtifactExportRejection(ctx, "rejected")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestArtifactRequeueLifecycleClearsRejection(t *testing.T) {
+	t.Run("origin adoption", func(t *testing.T) {
+		database := testDB(t)
+		ctx := t.Context()
+		require.NoError(t, database.AdoptArtifactOrigin("origin-a1b2c3"))
+		require.NoError(t, database.UpsertSession(Session{
+			ID: "session", Project: "project", Machine: "local", Agent: "claude",
+		}))
+		claims, err := database.PendingArtifactExports(ctx, 10)
+		require.NoError(t, err)
+		require.Len(t, claims, 1)
+		require.NoError(t, database.FinalizeArtifactExports(ctx, []ArtifactExportOutcome{{
+			Item: claims[0], Rejection: "message limit exceeded",
+		}}))
+
+		require.NoError(t, database.AdoptArtifactOrigin("origin-d4e5f6"))
+		pending, err := database.PendingArtifactExports(ctx, 10)
+		require.NoError(t, err)
+		require.Len(t, pending, 1)
+		assert.Greater(t, pending[0].Generation, claims[0].Generation)
+		_, ok, err := database.GetArtifactExportRejection(ctx, "session")
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("resync", func(t *testing.T) {
+		dir := t.TempDir()
+		sourcePath := filepath.Join(dir, "source.db")
+		source, err := Open(sourcePath)
+		require.NoError(t, err)
+		require.NoError(t, source.AdoptArtifactOrigin("origin-a1b2c3"))
+		require.NoError(t, source.UpsertSession(Session{
+			ID: "session", Project: "project", Machine: "local", Agent: "claude",
+		}))
+		claims, err := source.PendingArtifactExports(t.Context(), 10)
+		require.NoError(t, err)
+		require.Len(t, claims, 1)
+		require.NoError(t, source.FinalizeArtifactExports(
+			t.Context(), []ArtifactExportOutcome{{
+				Item: claims[0], Rejection: "message limit exceeded",
+			}},
+		))
+		require.NoError(t, source.Close())
+
+		target, err := Open(filepath.Join(dir, "target.db"))
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, target.Close()) })
+		require.NoError(t, target.CopySyncStateFrom(sourcePath))
+		pending, err := target.PendingArtifactExports(t.Context(), 10)
+		require.NoError(t, err)
+		require.Len(t, pending, 1)
+		assert.Greater(t, pending[0].Generation, claims[0].Generation)
+		_, ok, err := target.GetArtifactExportRejection(t.Context(), "session")
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+}
+
+func TestArtifactExportQueueRejectionColumnMigration(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy-artifact-queue.db")
+	database, err := Open(path)
+	require.NoError(t, err)
+	require.NoError(t, database.AdoptArtifactOrigin("origin-a1b2c3"))
+	require.NoError(t, database.UpsertSession(Session{
+		ID: "preserved", Project: "project", Machine: "local", Agent: "claude",
+	}))
+	claims, err := database.PendingArtifactExports(t.Context(), 10)
+	require.NoError(t, err)
+	require.Len(t, claims, 1)
+	require.NoError(t, database.Close())
+
+	conn, err := sql.Open("sqlite3", makeDSN(path, false))
+	require.NoError(t, err)
+	_, err = conn.Exec(artifactSessionQueueTriggerDropsSQL)
+	require.NoError(t, err)
+	for _, column := range []string{"rejected_generation", "last_error", "rejected_at"} {
+		_, err = conn.Exec(`ALTER TABLE artifact_export_queue DROP COLUMN ` + column)
+		require.NoError(t, err)
+	}
+	require.NoError(t, conn.Close())
+
+	migrated, err := Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, migrated.Close()) })
+	rows, err := migrated.getReader().Query(
+		`SELECT name FROM pragma_table_info('artifact_export_queue')
+		 WHERE name IN ('rejected_generation', 'last_error', 'rejected_at')
+		 ORDER BY name`,
+	)
+	require.NoError(t, err)
+	defer rows.Close()
+	var columns []string
+	for rows.Next() {
+		var column string
+		require.NoError(t, rows.Scan(&column))
+		columns = append(columns, column)
+	}
+	require.NoError(t, rows.Err())
+	assert.Equal(t, []string{"last_error", "rejected_at", "rejected_generation"}, columns)
+	pending, err := migrated.PendingArtifactExports(t.Context(), 10)
+	require.NoError(t, err)
+	require.Equal(t, claims, pending)
+}
+
+func TestArtifactPublicationAtomicLifecycle(t *testing.T) {
+	database := testDB(t)
+	ctx := t.Context()
+	seedArtifactOrigin(t, database)
+	require.NoError(t, database.UpsertSession(Session{
+		ID: "session-a", Project: "project", Machine: "local", Agent: "claude",
+	}))
+
+	pending, err := database.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	require.Equal(t, []ArtifactExportQueueItem{{
+		SessionID: "session-a", EnqueuedAt: pending[0].EnqueuedAt,
+		Generation: pending[0].Generation,
+	}}, pending)
+
+	// Merely reading work models a failed export: nothing is acknowledged until
+	// a checkpoint is durably created and its head is recorded.
+	pendingAgain, err := database.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	require.Equal(t, pending, pendingAgain)
+
+	revision, changed, err := database.ApplyArtifactPublicationChanges(ctx, "desktop-a1b2c3", []ArtifactPublicationChange{{
+		SessionID: "session-a", Generation: pending[0].Generation,
+		ManifestHash: "manifest-a", SourceFingerprint: "source-a",
+	}})
+	require.NoError(t, err)
+	assert.True(t, changed)
+	assert.Equal(t, int64(1), revision)
+
+	revision, changed, err = database.ApplyArtifactPublicationChanges(ctx, "desktop-a1b2c3", []ArtifactPublicationChange{{
+		SessionID: "session-a", Generation: pending[0].Generation,
+		ManifestHash: "manifest-a", SourceFingerprint: "source-a",
+	}})
+	require.NoError(t, err)
+	assert.False(t, changed, "identical publication state must not force a checkpoint")
+
+	head := ArtifactCheckpointHead{
+		Origin: "desktop-a1b2c3", Sequence: 7, PublicationRevision: revision,
+		SessionMapSHA256: "map-hash", CheckpointSHA256: "checkpoint-hash",
+	}
+	require.NoError(t, database.RecordArtifactCheckpointHead(ctx, head, pending))
+	gotHead, ok, err := database.GetArtifactCheckpointHead(ctx, "desktop-a1b2c3")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, head, gotHead)
+	pending, err = database.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	assert.Empty(t, pending)
+
+	require.NoError(t, database.UpsertSession(Session{
+		ID: "session-a", Project: "project-2", Machine: "local", Agent: "claude",
+	}))
+	pending, err = database.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	_, changed, err = database.ApplyArtifactPublicationChanges(ctx, "desktop-a1b2c3", []ArtifactPublicationChange{{
+		SessionID: "session-a", Generation: pending[0].Generation, Delete: true,
+	}})
+	require.NoError(t, err)
+	assert.True(t, changed)
+	staleHead, ok, err := database.GetArtifactCheckpointHead(ctx, "desktop-a1b2c3")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, revision, staleHead.PublicationRevision,
+		"the retained head revision identifies it as stale")
+	pending, err = database.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	require.NoError(t, database.AcknowledgeArtifactExports(ctx, pending))
+	var publications []ArtifactPublication
+	_, err = database.StreamArtifactPublications(ctx, "desktop-a1b2c3", func(row ArtifactPublication) error {
+		publications = append(publications, row)
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Empty(t, publications)
+}
+
+func TestArtifactCheckpointHeadRejectsStalePublicationRevision(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "archive.db")
+	first, err := Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, first.Close()) })
+	second, err := Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, second.Close()) })
+	seedArtifactOrigin(t, first)
+
+	ctx := t.Context()
+	require.NoError(t, first.UpsertSession(Session{
+		ID: "session-a", Project: "project", Machine: "local", Agent: "claude",
+	}))
+	claimA, err := first.ArtifactExportClaims(ctx, []string{"session-a"})
+	require.NoError(t, err)
+	require.Len(t, claimA, 1)
+	revisionA, changed, err := first.ApplyArtifactPublicationChanges(
+		ctx, "desktop-a1b2c3", []ArtifactPublicationChange{{
+			SessionID: "session-a", Generation: claimA[0].Generation,
+			ManifestHash: "manifest-a", SourceFingerprint: "source-a",
+		}},
+	)
+	require.NoError(t, err)
+	require.True(t, changed)
+	streamedRevisionA, err := first.StreamArtifactPublications(
+		ctx, "desktop-a1b2c3", func(ArtifactPublication) error { return nil },
+	)
+	require.NoError(t, err)
+	require.Equal(t, revisionA, streamedRevisionA)
+
+	require.NoError(t, second.UpsertSession(Session{
+		ID: "session-b", Project: "project", Machine: "local", Agent: "claude",
+	}))
+	claimB, err := second.ArtifactExportClaims(ctx, []string{"session-b"})
+	require.NoError(t, err)
+	require.Len(t, claimB, 1)
+	revisionB, changed, err := second.ApplyArtifactPublicationChanges(
+		ctx, "desktop-a1b2c3", []ArtifactPublicationChange{{
+			SessionID: "session-b", Generation: claimB[0].Generation,
+			ManifestHash: "manifest-b", SourceFingerprint: "source-b",
+		}},
+	)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Greater(t, revisionB, revisionA)
+	streamedRevisionB, err := second.StreamArtifactPublications(
+		ctx, "desktop-a1b2c3", func(ArtifactPublication) error { return nil },
+	)
+	require.NoError(t, err)
+	require.Equal(t, revisionB, streamedRevisionB)
+	require.NoError(t, second.RecordArtifactCheckpointHead(ctx, ArtifactCheckpointHead{
+		Origin: "desktop-a1b2c3", Sequence: 1, PublicationRevision: revisionB,
+		SessionMapSHA256: "map-b", CheckpointSHA256: "checkpoint-b", CheckpointSize: 12,
+	}, claimB))
+
+	err = first.RecordArtifactCheckpointHead(ctx, ArtifactCheckpointHead{
+		Origin: "desktop-a1b2c3", Sequence: 2, PublicationRevision: streamedRevisionA,
+		SessionMapSHA256: "map-a", CheckpointSHA256: "checkpoint-a", CheckpointSize: 12,
+	}, claimA)
+	require.ErrorIs(t, err, ErrArtifactExportClaimStale)
+	head, ok, err := first.GetArtifactCheckpointHead(ctx, "desktop-a1b2c3")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, 1, head.Sequence)
+	require.Equal(t, revisionB, head.PublicationRevision)
+	pending, err := first.ArtifactExportClaims(ctx, []string{"session-a"})
+	require.NoError(t, err)
+	require.Equal(t, claimA, pending, "stale recording cannot consume pending work")
+
+	retryRevision, changed, err := first.ApplyArtifactPublicationChanges(
+		ctx, "desktop-a1b2c3", []ArtifactPublicationChange{{
+			SessionID: "session-a", Generation: claimA[0].Generation,
+			ManifestHash: "manifest-a", SourceFingerprint: "source-a",
+		}},
+	)
+	require.NoError(t, err)
+	require.False(t, changed)
+	require.Equal(t, revisionB, retryRevision)
+	require.NoError(t, first.RecordArtifactCheckpointHead(ctx, ArtifactCheckpointHead{
+		Origin: "desktop-a1b2c3", Sequence: 3, PublicationRevision: retryRevision,
+		SessionMapSHA256: "map-b", CheckpointSHA256: "checkpoint-c", CheckpointSize: 12,
+	}, claimA))
+}
+
+func TestBootstrapArtifactExportQueueEnqueuesExistingLocalSessions(t *testing.T) {
+	database := testDB(t)
+	require.NoError(t, database.UpsertSession(Session{
+		ID: "existing-local", Project: "project", Machine: "local", Agent: "claude",
+	}))
+	require.NoError(t, database.UpsertSession(Session{
+		ID: "existing-peer", Project: "project", Machine: "peer-a1b2c3", Agent: "claude",
+	}))
+	require.NoError(t, database.UpsertSession(Session{
+		ID: "existing-trash", Project: "project", Machine: "local", Agent: "claude",
+	}))
+	require.NoError(t, database.SoftDeleteSession("existing-trash"))
+
+	require.NoError(t, database.BootstrapArtifactExportQueue())
+	pending, err := database.PendingArtifactExports(t.Context(), 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	assert.Equal(t, "existing-local", pending[0].SessionID,
+		"only the live locally-owned session is bootstrapped")
+	assert.Equal(t, int64(1), pending[0].Generation)
+	firstEnqueuedAt := pending[0].EnqueuedAt
+
+	require.NoError(t, database.BootstrapArtifactExportQueue())
+	pendingAgain, err := database.PendingArtifactExports(t.Context(), 10)
+	require.NoError(t, err)
+	require.Len(t, pendingAgain, 1, "repeated bootstrap must not duplicate queue rows")
+	assert.Equal(t, "existing-local", pendingAgain[0].SessionID)
+	assert.Equal(t, int64(1), pendingAgain[0].Generation,
+		"INSERT OR IGNORE leaves the existing generation untouched")
+	assert.Equal(t, firstEnqueuedAt, pendingAgain[0].EnqueuedAt)
+}
+
+func TestEnsureArtifactOriginPublishesOriginWithBootstrapQueue(t *testing.T) {
+	database := testDB(t)
+	require.NoError(t, database.UpsertSession(Session{
+		ID: "session-a", Project: "project", Machine: "local", Agent: "claude",
+	}))
+
+	originalPopulate := populateArtifactOriginQueueTx
+	started := make(chan struct{})
+	release := make(chan struct{})
+	populateArtifactOriginQueueTx = func(tx *sql.Tx, origin string, requeue bool) error {
+		close(started)
+		<-release
+		return originalPopulate(tx, origin, requeue)
+	}
+	t.Cleanup(func() { populateArtifactOriginQueueTx = originalPopulate })
+
+	type ensureResult struct {
+		origin string
+		err    error
+	}
+	done := make(chan ensureResult, 1)
+	go func() {
+		origin, err := database.EnsureArtifactOrigin("desk-a1b2c3")
+		done <- ensureResult{origin: origin, err: err}
+	}()
+
+	<-started
+	visible, err := database.GetSyncState("artifact_origin_id")
+	require.NoError(t, err)
+	assert.Empty(t, visible,
+		"the origin must remain invisible until queue population commits")
+	close(release)
+
+	result := <-done
+	require.NoError(t, result.err)
+	assert.Equal(t, "desk-a1b2c3", result.origin)
+	stored, err := database.GetSyncState("artifact_origin_id")
+	require.NoError(t, err)
+	assert.Equal(t, "desk-a1b2c3", stored)
+	pending, err := database.PendingArtifactExports(t.Context(), 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	assert.Equal(t, "session-a", pending[0].SessionID)
+}
+
+func TestArtifactOriginTransactionRollsBackQueuePopulationFailure(t *testing.T) {
+	database := testDB(t)
+	require.NoError(t, database.AdoptArtifactOrigin("before-a1b2c3"))
+	require.NoError(t, database.UpsertSession(Session{
+		ID: "session-a", Project: "project", Machine: "local", Agent: "claude",
+	}))
+	pending, err := database.PendingArtifactExports(t.Context(), 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	require.NoError(t, database.AcknowledgeArtifactExports(t.Context(), pending))
+
+	injected := errors.New("queue population failed")
+	originalPopulate := populateArtifactOriginQueueTx
+	populateArtifactOriginQueueTx = func(*sql.Tx, string, bool) error { return injected }
+	t.Cleanup(func() { populateArtifactOriginQueueTx = originalPopulate })
+
+	err = database.AdoptArtifactOrigin("after-d4e5f6")
+	require.ErrorIs(t, err, injected)
+	stored, err := database.GetSyncState("artifact_origin_id")
+	require.NoError(t, err)
+	assert.Equal(t, "before-a1b2c3", stored)
+	after, err := database.PendingArtifactExports(t.Context(), 10)
+	require.NoError(t, err)
+	assert.Empty(t, after,
+		"failed adoption must leave the previous origin's clean queue unchanged")
+}
+
+func TestEnsureArtifactOriginRollsBackQueuePopulationFailure(t *testing.T) {
+	database := testDB(t)
+	require.NoError(t, database.UpsertSession(Session{
+		ID: "session-a", Project: "project", Machine: "local", Agent: "claude",
+	}))
+
+	injected := errors.New("queue population failed")
+	originalPopulate := populateArtifactOriginQueueTx
+	populateArtifactOriginQueueTx = func(*sql.Tx, string, bool) error { return injected }
+	t.Cleanup(func() { populateArtifactOriginQueueTx = originalPopulate })
+
+	origin, err := database.EnsureArtifactOrigin("desk-a1b2c3")
+	require.ErrorIs(t, err, injected)
+	assert.Empty(t, origin)
+	stored, err := database.GetSyncState("artifact_origin_id")
+	require.NoError(t, err)
+	assert.Empty(t, stored)
+	pending, err := database.PendingArtifactExports(t.Context(), 10)
+	require.NoError(t, err)
+	assert.Empty(t, pending,
+		"failed initialization must leave the export gate and queue unchanged")
+}
+
+func TestEnsureArtifactOriginSerializesAcrossDatabaseHandles(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "shared.db")
+	const handleCount = 8
+	handles := make([]*DB, handleCount)
+	for i := range handles {
+		database, err := Open(path)
+		require.NoError(t, err)
+		handles[i] = database
+	}
+	t.Cleanup(func() {
+		for _, database := range handles {
+			require.NoError(t, database.Close())
+		}
+	})
+
+	start := make(chan struct{})
+	type result struct {
+		origin string
+		err    error
+	}
+	results := make(chan result, handleCount)
+	var ready sync.WaitGroup
+	ready.Add(handleCount)
+	for i, database := range handles {
+		go func() {
+			ready.Done()
+			<-start
+			origin, err := database.EnsureArtifactOrigin(
+				fmt.Sprintf("desk-%d-a1b2c3", i),
+			)
+			results <- result{origin: origin, err: err}
+		}()
+	}
+	ready.Wait()
+	close(start)
+
+	var winner string
+	for range handleCount {
+		got := <-results
+		require.NoError(t, got.err)
+		require.NotEmpty(t, got.origin)
+		if winner == "" {
+			winner = got.origin
+		}
+		assert.Equal(t, winner, got.origin)
+	}
+	stored, err := handles[0].GetSyncState("artifact_origin_id")
+	require.NoError(t, err)
+	assert.Equal(t, winner, stored)
+}
+
+func TestArtifactExportClaimsSelectsExactPendingSessionSet(t *testing.T) {
+	database := testDB(t)
+	seedArtifactOrigin(t, database)
+	for _, id := range []string{"alpha", "bravo", "charlie"} {
+		require.NoError(t, database.UpsertSession(Session{
+			ID: id, Project: "project", Machine: "local", Agent: "claude",
+		}))
+	}
+
+	claims, err := database.ArtifactExportClaims(t.Context(),
+		[]string{"charlie", "missing", "alpha", "charlie"})
+	require.NoError(t, err)
+	require.Len(t, claims, 2)
+	assert.Equal(t, "alpha", claims[0].SessionID)
+	assert.Equal(t, "charlie", claims[1].SessionID)
+	assert.Positive(t, claims[0].Generation)
+	assert.Positive(t, claims[1].Generation)
+}
+
+func TestArtifactPublicationStaleClaimRollsBackEntireBatch(t *testing.T) {
+	database := testDB(t)
+	ctx := t.Context()
+	seedArtifactOrigin(t, database)
+	for _, id := range []string{"alpha", "bravo"} {
+		require.NoError(t, database.UpsertSession(Session{
+			ID: id, Project: "project", Machine: "local", Agent: "claude",
+		}))
+	}
+	claimed, err := database.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, claimed, 2)
+
+	_, err = database.getWriter().Exec(
+		`UPDATE sessions SET display_name = 'newer' WHERE id = 'bravo'`,
+	)
+	require.NoError(t, err)
+	_, _, err = database.ApplyArtifactPublicationChanges(ctx, "desktop-a1b2c3", []ArtifactPublicationChange{
+		{SessionID: "alpha", Generation: claimed[0].Generation, ManifestHash: "alpha", SourceFingerprint: "alpha"},
+		{SessionID: "bravo", Generation: claimed[1].Generation, ManifestHash: "bravo", SourceFingerprint: "bravo"},
+	})
+	require.ErrorIs(t, err, ErrArtifactExportClaimStale)
+
+	var publications []ArtifactPublication
+	_, err = database.StreamArtifactPublications(ctx, "desktop-a1b2c3", func(row ArtifactPublication) error {
+		publications = append(publications, row)
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Empty(t, publications, "a stale claim must not partially mutate publication state")
+
+	fresh, err := database.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, fresh, 2)
+	_, _, err = database.ApplyArtifactPublicationChanges(ctx, "desktop-a1b2c3", []ArtifactPublicationChange{
+		{SessionID: fresh[0].SessionID, Generation: fresh[0].Generation, ManifestHash: "fresh-0", SourceFingerprint: "fresh-0"},
+		{SessionID: fresh[1].SessionID, Generation: fresh[1].Generation, ManifestHash: "fresh-1", SourceFingerprint: "fresh-1"},
+	})
+	require.NoError(t, err)
+	publications = nil
+	_, err = database.StreamArtifactPublications(ctx, "desktop-a1b2c3", func(row ArtifactPublication) error {
+		publications = append(publications, row)
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Len(t, publications, 2, "fresh claims remain applicable after a stale retry")
+}
+
+func TestArtifactCheckpointHeadStaleClaimRollsBackHead(t *testing.T) {
+	database := testDB(t)
+	ctx := t.Context()
+	seedArtifactOrigin(t, database)
+	require.NoError(t, database.UpsertSession(Session{
+		ID: "racing", Project: "project", Machine: "local", Agent: "claude",
+	}))
+	claimed, err := database.PendingArtifactExports(ctx, 1)
+	require.NoError(t, err)
+	require.Len(t, claimed, 1)
+	_, err = database.getWriter().Exec(
+		`UPDATE sessions SET display_name = 'newer' WHERE id = 'racing'`,
+	)
+	require.NoError(t, err)
+
+	err = database.RecordArtifactCheckpointHead(ctx, ArtifactCheckpointHead{
+		Origin: "desktop-a1b2c3", Sequence: 1,
+		SessionMapSHA256: "map-1", CheckpointSHA256: "checkpoint-1",
+	}, claimed)
+	require.ErrorIs(t, err, ErrArtifactExportClaimStale)
+	_, ok, err := database.GetArtifactCheckpointHead(ctx, "desktop-a1b2c3")
+	require.NoError(t, err)
+	assert.False(t, ok, "stale acknowledgement must roll back the checkpoint head")
+	pending, err := database.PendingArtifactExports(ctx, 1)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	assert.Greater(t, pending[0].Generation, claimed[0].Generation)
+}
+
+func TestArtifactPublicationRowsStreamInCanonicalOrder(t *testing.T) {
+	database := testDB(t)
+	ctx := t.Context()
+	seedArtifactOrigin(t, database)
+	for _, id := range []string{"zulu", "alpha"} {
+		require.NoError(t, database.UpsertSession(Session{
+			ID: id, Project: "project", Machine: "local", Agent: "claude",
+		}))
+	}
+	claimed, err := database.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	claimGeneration := map[string]int64{}
+	for _, item := range claimed {
+		claimGeneration[item.SessionID] = item.Generation
+	}
+	_, changed, err := database.ApplyArtifactPublicationChanges(ctx, "desktop-a1b2c3", []ArtifactPublicationChange{
+		{SessionID: "zulu", Generation: claimGeneration["zulu"], ManifestHash: "hash-z", SourceFingerprint: "source-z"},
+		{SessionID: "alpha", Generation: claimGeneration["alpha"], ManifestHash: "hash-a", SourceFingerprint: "source-a"},
+	})
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	var got []string
+	_, err = database.StreamArtifactPublications(ctx, "desktop-a1b2c3", func(row ArtifactPublication) error {
+		got = append(got, row.SessionID+"="+row.ManifestHash)
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"alpha=hash-a", "zulu=hash-z"}, got)
+}
+
+func TestArtifactCheckpointHeadRejectsRegressionWithoutAcknowledgingWork(t *testing.T) {
+	database := testDB(t)
+	ctx := t.Context()
+	seedArtifactOrigin(t, database)
+	require.NoError(t, database.RecordArtifactCheckpointHead(ctx, ArtifactCheckpointHead{
+		Origin: "desktop-a1b2c3", Sequence: 7,
+		SessionMapSHA256: "map-7", CheckpointSHA256: "checkpoint-7",
+	}, nil))
+	require.NoError(t, database.UpsertSession(Session{
+		ID: "still-pending", Project: "project", Machine: "local", Agent: "claude",
+	}))
+
+	pendingBefore, err := database.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	err = database.RecordArtifactCheckpointHead(ctx, ArtifactCheckpointHead{
+		Origin: "desktop-a1b2c3", Sequence: 6,
+		SessionMapSHA256: "map-6", CheckpointSHA256: "checkpoint-6",
+	}, pendingBefore)
+	require.Error(t, err)
+
+	pending, err := database.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	assert.Equal(t, "still-pending", pending[0].SessionID)
+	head, ok, err := database.GetArtifactCheckpointHead(ctx, "desktop-a1b2c3")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, 7, head.Sequence)
+}
+
+func TestArtifactPublicationAcknowledgementCannotConsumeNewerMutation(t *testing.T) {
+	database := testDB(t)
+	ctx := t.Context()
+	seedArtifactOrigin(t, database)
+	require.NoError(t, database.UpsertSession(Session{
+		ID: "racing", Project: "project", Machine: "local", Agent: "claude",
+	}))
+	claimed, err := database.PendingArtifactExports(ctx, 1)
+	require.NoError(t, err)
+	require.Len(t, claimed, 1)
+
+	// Both writes can share the same SQLite millisecond. Generation, not wall
+	// time, is the compare-and-ack token.
+	_, err = database.getWriter().Exec(
+		`UPDATE sessions SET display_name = 'newer' WHERE id = 'racing'`,
+	)
+	require.NoError(t, err)
+	newer, err := database.PendingArtifactExports(ctx, 1)
+	require.NoError(t, err)
+	require.Len(t, newer, 1)
+	assert.Equal(t, claimed[0].EnqueuedAt, newer[0].EnqueuedAt)
+	assert.Greater(t, newer[0].Generation, claimed[0].Generation)
+
+	err = database.RecordArtifactCheckpointHead(ctx, ArtifactCheckpointHead{
+		Origin: "desktop-a1b2c3", Sequence: 1,
+		SessionMapSHA256: "map-1", CheckpointSHA256: "checkpoint-1",
+	}, claimed)
+	require.ErrorIs(t, err, ErrArtifactExportClaimStale)
+	pending, err := database.PendingArtifactExports(ctx, 1)
+	require.NoError(t, err)
+	require.Equal(t, newer, pending, "stale acknowledgment must leave newer work pending")
+}
+
+func TestArtifactPublicationQueueGenerationSurvivesAcknowledgementABA(t *testing.T) {
+	database := testDB(t)
+	ctx := t.Context()
+	seedArtifactOrigin(t, database)
+	require.NoError(t, database.UpsertSession(Session{
+		ID: "aba", Project: "project", Machine: "local", Agent: "claude",
+	}))
+	oldClaim, err := database.PendingArtifactExports(ctx, 1)
+	require.NoError(t, err)
+	require.Len(t, oldClaim, 1)
+	_, _, err = database.ApplyArtifactPublicationChanges(ctx, "desktop-a1b2c3", []ArtifactPublicationChange{{
+		SessionID: "aba", Generation: oldClaim[0].Generation,
+		ManifestHash: "old-manifest", SourceFingerprint: "old-source",
+	}})
+	require.NoError(t, err)
+	require.NoError(t, database.AcknowledgeArtifactExports(ctx, oldClaim))
+	pending, err := database.PendingArtifactExports(ctx, 1)
+	require.NoError(t, err)
+	assert.Empty(t, pending)
+
+	_, err = database.getWriter().Exec(
+		`UPDATE sessions SET display_name = 'new mutation' WHERE id = 'aba'`,
+	)
+	require.NoError(t, err)
+	newClaim, err := database.PendingArtifactExports(ctx, 1)
+	require.NoError(t, err)
+	require.Len(t, newClaim, 1)
+	_, err = database.getWriter().Exec(
+		`UPDATE artifact_export_queue SET enqueued_at = ? WHERE session_id = 'aba'`,
+		oldClaim[0].EnqueuedAt,
+	)
+	require.NoError(t, err)
+	newClaim, err = database.PendingArtifactExports(ctx, 1)
+	require.NoError(t, err)
+	require.Len(t, newClaim, 1)
+	assert.Equal(t, oldClaim[0].EnqueuedAt, newClaim[0].EnqueuedAt,
+		"the ABA guard cannot depend on timestamp precision")
+	assert.Greater(t, newClaim[0].Generation, oldClaim[0].Generation)
+
+	revision, _, err := database.ApplyArtifactPublicationChanges(ctx, "desktop-a1b2c3", []ArtifactPublicationChange{{
+		SessionID: "aba", Generation: newClaim[0].Generation,
+		ManifestHash: "new-manifest", SourceFingerprint: "new-source",
+	}})
+	require.NoError(t, err)
+	require.NoError(t, database.RecordArtifactCheckpointHead(ctx, ArtifactCheckpointHead{
+		Origin: "desktop-a1b2c3", Sequence: 1, PublicationRevision: revision,
+		SessionMapSHA256: "map-1", CheckpointSHA256: "checkpoint-1",
+	}, nil))
+
+	_, _, err = database.ApplyArtifactPublicationChanges(ctx, "desktop-a1b2c3", []ArtifactPublicationChange{{
+		SessionID: "aba", Generation: oldClaim[0].Generation,
+		ManifestHash: "stale-manifest", SourceFingerprint: "stale-source",
+	}})
+	require.ErrorIs(t, err, ErrArtifactExportClaimStale)
+	err = database.RecordArtifactCheckpointHead(ctx, ArtifactCheckpointHead{
+		Origin: "desktop-a1b2c3", Sequence: 2,
+		SessionMapSHA256: "stale-map", CheckpointSHA256: "stale-checkpoint",
+	}, oldClaim)
+	require.ErrorIs(t, err, ErrArtifactExportClaimStale)
+	require.ErrorIs(t, database.AcknowledgeArtifactExports(ctx, oldClaim), ErrArtifactExportClaimStale)
+
+	var publications []ArtifactPublication
+	_, err = database.StreamArtifactPublications(ctx, "desktop-a1b2c3", func(row ArtifactPublication) error {
+		publications = append(publications, row)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Len(t, publications, 1)
+	assert.Equal(t, "new-manifest", publications[0].ManifestHash)
+	head, ok, err := database.GetArtifactCheckpointHead(ctx, "desktop-a1b2c3")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, 1, head.Sequence)
+	pending, err = database.PendingArtifactExports(ctx, 1)
+	require.NoError(t, err)
+	assert.Equal(t, newClaim, pending)
+}
+
+func TestArtifactPublicationUsageOnlyAtomicBatchEnqueuesExactlyOnce(t *testing.T) {
+	for _, machine := range []string{"local", "peer-a1b2c3"} {
+		t.Run(machine, func(t *testing.T) {
+			database := testDB(t)
+			seedArtifactOrigin(t, database)
+			session := Session{
+				ID: "usage-batch", Project: "project", Machine: machine, Agent: "claude",
+			}
+			require.NoError(t, database.UpsertSession(session))
+			if machine == "local" {
+				claim, err := database.PendingArtifactExports(t.Context(), 1)
+				require.NoError(t, err)
+				require.NoError(t, database.AcknowledgeArtifactExports(t.Context(), claim))
+			}
+			stored, err := database.GetSessionFull(t.Context(), session.ID)
+			require.NoError(t, err)
+			require.NotNil(t, stored)
+
+			_, err = database.WriteSessionBatchAtomic([]SessionBatchWrite{{
+				Session: *stored,
+				UsageEvents: []UsageEvent{{
+					SessionID: session.ID, Source: "event", Model: "model",
+					InputTokens: 10, OutputTokens: 2, DedupKey: "changed",
+				}},
+				ReplaceMessages: false,
+			}})
+			require.NoError(t, err)
+			pending, err := database.PendingArtifactExports(t.Context(), 10)
+			require.NoError(t, err)
+			if machine != "local" {
+				assert.Empty(t, pending)
+				return
+			}
+			require.Len(t, pending, 1)
+			assert.Equal(t, int64(2), pending[0].Generation,
+				"usage-only batch advances the clean authority exactly once")
+		})
+	}
+}
+
+func TestArtifactClaimErrorsRemainDiscoverableWhenWrapped(t *testing.T) {
+	assert.True(t, errors.Is(fmt.Errorf("retry: %w", ErrArtifactExportClaimStale), ErrArtifactExportClaimStale))
+}
+
+func TestArtifactCheckpointFloorReservationIsConcurrentAndNeverLowers(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "floor.db")
+	first, err := Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, first.Close()) })
+	second, err := Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, second.Close()) })
+
+	const reservations = 24
+	sequences := make(chan int, reservations)
+	errs := make(chan error, reservations)
+	var wg sync.WaitGroup
+	for i := range reservations {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			database := first
+			if i%2 == 1 {
+				database = second
+			}
+			sequence, reserveErr := database.ReserveArtifactCheckpointSequence(
+				context.Background(), "desktop-a1b2c3", 10,
+			)
+			if reserveErr != nil {
+				errs <- reserveErr
+				return
+			}
+			sequences <- sequence
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for reserveErr := range errs {
+		require.NoError(t, reserveErr)
+	}
+	close(sequences)
+	var got []int
+	for sequence := range sequences {
+		got = append(got, sequence)
+	}
+	sort.Ints(got)
+	want := make([]int, reservations)
+	for i := range want {
+		want[i] = 11 + i
+	}
+	assert.Equal(t, want, got)
+
+	// Simulate a crash after the committed floor reservation but before the
+	// checkpoint node is created, followed by a vault reset reporting no live
+	// sequence. The durable floor consumes the missing sequence permanently.
+	next, err := first.ReserveArtifactCheckpointSequence(t.Context(), "desktop-a1b2c3", 0)
+	require.NoError(t, err)
+	assert.Equal(t, 11+reservations, next)
+}
+
+func TestArtifactPublicationStateSurvivesFullResyncCopy(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	source, err := Open(sourcePath)
+	require.NoError(t, err)
+	seedArtifactOrigin(t, source)
+
+	ctx := t.Context()
+	require.NoError(t, source.UpsertSession(Session{
+		ID: "queued", Project: "project", Machine: "local", Agent: "claude",
+	}))
+	require.NoError(t, source.UpsertSession(Session{
+		ID: "published", Project: "project", Machine: "local", Agent: "claude",
+	}))
+	claims, err := source.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	var publishedClaim ArtifactExportQueueItem
+	for _, claim := range claims {
+		if claim.SessionID == "published" {
+			publishedClaim = claim
+		}
+	}
+	require.NotZero(t, publishedClaim.Generation)
+	revision, _, err := source.ApplyArtifactPublicationChanges(ctx, "desktop-a1b2c3", []ArtifactPublicationChange{{
+		SessionID: "published", Generation: publishedClaim.Generation,
+		ManifestHash: "manifest", SourceFingerprint: "source",
+	}})
+	require.NoError(t, err)
+	require.NoError(t, source.AcknowledgeArtifactExports(ctx, []ArtifactExportQueueItem{publishedClaim}))
+	require.NoError(t, source.RecordArtifactCheckpointHead(ctx, ArtifactCheckpointHead{
+		Origin: "desktop-a1b2c3", Sequence: 4, PublicationRevision: revision,
+		SessionMapSHA256: "map", CheckpointSHA256: "checkpoint",
+	}, nil))
+	sequence, err := source.ReserveArtifactCheckpointSequence(ctx, "desktop-a1b2c3", 8)
+	require.NoError(t, err)
+	require.Equal(t, 9, sequence)
+	require.NoError(t, source.Close())
+
+	target, err := Open(filepath.Join(dir, "target.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, target.Close()) })
+	require.NoError(t, target.CopySyncStateFrom(sourcePath))
+
+	// A resync re-verifies every copied session, so the acknowledged
+	// "published" row is re-dirtied alongside the still-pending "queued" row.
+	pending, err := target.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 2)
+	assert.ElementsMatch(t, []string{"queued", "published"}, []string{
+		pending[0].SessionID, pending[1].SessionID,
+	})
+	var publications []ArtifactPublication
+	streamedRevision, err := target.StreamArtifactPublications(ctx, "desktop-a1b2c3", func(row ArtifactPublication) error {
+		publications = append(publications, row)
+		return nil
+	})
+	require.NoError(t, err)
+	assert.Equal(t, revision, streamedRevision)
+	require.Len(t, publications, 1)
+	assert.Equal(t, "published", publications[0].SessionID)
+	head, ok, err := target.GetArtifactCheckpointHead(ctx, "desktop-a1b2c3")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, 4, head.Sequence)
+	next, err := target.ReserveArtifactCheckpointSequence(ctx, "desktop-a1b2c3", 0)
+	require.NoError(t, err)
+	assert.Equal(t, 10, next)
+
+	// Clean authority rows survive the swap and copied generations are advanced,
+	// so an in-flight claim against the source database cannot become valid in
+	// the replacement archive after the same session is dirtied again.
+	require.NoError(t, target.UpsertSession(Session{
+		ID: "published", Project: "project", Machine: "local", Agent: "claude",
+	}))
+	pending, err = target.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	var republished ArtifactExportQueueItem
+	for _, item := range pending {
+		if item.SessionID == "published" {
+			republished = item
+		}
+	}
+	require.Greater(t, republished.Generation, publishedClaim.Generation)
+	_, _, err = target.ApplyArtifactPublicationChanges(ctx, "desktop-a1b2c3", []ArtifactPublicationChange{{
+		SessionID: "published", Generation: publishedClaim.Generation,
+		ManifestHash: "stale", SourceFingerprint: "stale",
+	}})
+	require.ErrorIs(t, err, ErrArtifactExportClaimStale)
+}
+
+// TestCopySyncStateForcesPendingOnFreshCopiedQueueRows models the shipped
+// resync flow: the old DB holds acknowledged (pending=0) queue rows, the fresh
+// DB has no origin key so the triggers stay gated and the queue is empty, and
+// CopySyncStateFrom must re-dirty every copied row so the exporter re-verifies
+// the rebuilt archive. Covers the fresh-insert branch of the queue copy.
+func TestCopySyncStateForcesPendingOnFreshCopiedQueueRows(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	source, err := Open(sourcePath)
+	require.NoError(t, err)
+	seedArtifactOrigin(t, source)
+	ctx := t.Context()
+
+	for _, id := range []string{"sess-1", "sess-2"} {
+		require.NoError(t, source.UpsertSession(Session{
+			ID: id, Project: "project", Machine: "local", Agent: "claude",
+		}))
+	}
+	claims, err := source.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, claims, 2)
+	require.NoError(t, source.AcknowledgeArtifactExports(ctx, claims))
+	drained, err := source.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	require.Empty(t, drained, "old queue rows are acknowledged before the resync")
+	oldGen := map[string]int64{}
+	for _, claim := range claims {
+		oldGen[claim.SessionID] = claim.Generation
+	}
+	require.NoError(t, source.Close())
+
+	target, err := Open(filepath.Join(dir, "target.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, target.Close()) })
+	for _, id := range []string{"sess-1", "sess-2"} {
+		require.NoError(t, target.UpsertSession(Session{
+			ID: id, Project: "project", Machine: "local", Agent: "claude",
+		}))
+	}
+	emptyBefore, err := target.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	require.Empty(t, emptyBefore, "no origin key: queue triggers stay gated during resync")
+
+	require.NoError(t, target.CopySyncStateFrom(sourcePath))
+
+	pending, err := target.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 2, "a resync must re-verify every copied session")
+	assert.ElementsMatch(t, []string{"sess-1", "sess-2"}, []string{
+		pending[0].SessionID, pending[1].SessionID,
+	})
+	for _, item := range pending {
+		assert.Greater(t, item.Generation, oldGen[item.SessionID],
+			"copied generation must advance and never regress")
+	}
+}
+
+func TestCopySyncStateQueuesSessionsDiscoveredDuringRebuild(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	source, err := Open(sourcePath)
+	require.NoError(t, err)
+	seedArtifactOrigin(t, source)
+	ctx := t.Context()
+
+	require.NoError(t, source.UpsertSession(Session{
+		ID: "existing", Project: "project", Machine: "local", Agent: "claude",
+	}))
+	sourceClaims, err := source.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, sourceClaims, 1)
+	require.NoError(t, source.AcknowledgeArtifactExports(ctx, sourceClaims))
+	require.NoError(t, source.Close())
+
+	target, err := Open(filepath.Join(dir, "target.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, target.Close()) })
+	for _, id := range []string{"existing", "discovered-during-rebuild"} {
+		require.NoError(t, target.UpsertSession(Session{
+			ID: id, Project: "project", Machine: "local", Agent: "claude",
+		}))
+	}
+	before, err := target.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	require.Empty(t, before, "the rebuild has no origin until sync state is restored")
+
+	require.NoError(t, target.CopySyncStateFrom(sourcePath))
+
+	pending, err := target.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 2)
+	generations := make(map[string]int64, len(pending))
+	for _, item := range pending {
+		generations[item.SessionID] = item.Generation
+	}
+	assert.Equal(t, sourceClaims[0].Generation+1, generations["existing"],
+		"queue completion must preserve the copied ledger generation")
+	assert.Equal(t, int64(1), generations["discovered-during-rebuild"],
+		"a rebuilt-only session must receive a fresh queue row")
+}
+
+// TestCopySyncStateMergesQueueRowsAsPending exercises the ON CONFLICT merge
+// branch of the queue copy (previously untested). The fresh DB already has the
+// origin key and a trigger-created row that has itself been acknowledged, and
+// the old DB carries an acknowledged row for the same session at a different
+// generation. After the copy the row is pending again and its generation is the
+// advanced maximum of both sources.
+func TestCopySyncStateMergesQueueRowsAsPending(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.db")
+	source, err := Open(sourcePath)
+	require.NoError(t, err)
+	seedArtifactOrigin(t, source)
+	ctx := t.Context()
+
+	require.NoError(t, source.UpsertSession(Session{
+		ID: "overlap", Project: "project", Machine: "local", Agent: "claude",
+	}))
+	for i := range 3 {
+		_, err = source.getWriter().Exec(
+			`UPDATE sessions SET display_name = ? WHERE id = 'overlap'`, "v"+strconv.Itoa(i))
+		require.NoError(t, err)
+	}
+	oldClaims, err := source.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, oldClaims, 1)
+	oldGen := oldClaims[0].Generation
+	require.Greater(t, oldGen, int64(1))
+	require.NoError(t, source.AcknowledgeArtifactExports(ctx, oldClaims))
+	require.NoError(t, source.Close())
+
+	target, err := Open(filepath.Join(dir, "target.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, target.Close()) })
+	seedArtifactOrigin(t, target)
+	require.NoError(t, target.UpsertSession(Session{
+		ID: "overlap", Project: "project", Machine: "local", Agent: "claude",
+	}))
+	newClaims, err := target.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, newClaims, 1)
+	newGen := newClaims[0].Generation
+	require.NoError(t, target.AcknowledgeArtifactExports(ctx, newClaims))
+	acked, err := target.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	require.Empty(t, acked, "both queue rows are acknowledged before the merge")
+
+	require.NoError(t, target.CopySyncStateFrom(sourcePath))
+
+	pending, err := target.PendingArtifactExports(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 1, "the merged row is re-dirtied by the resync")
+	assert.Equal(t, "overlap", pending[0].SessionID)
+	expected := max(oldGen+1, newGen) + 1
+	assert.Equal(t, expected, pending[0].Generation,
+		"merged generation is the advanced maximum of both sources")
+}
+
+func TestArtifactPublicationStateCopyAcceptsPreRevisionCheckpointHead(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "legacy.db")
+	legacy, err := sql.Open("sqlite3", sourcePath)
+	require.NoError(t, err)
+	_, err = legacy.Exec(`
+		CREATE TABLE artifact_checkpoint_heads (
+			origin TEXT PRIMARY KEY,
+			sequence INTEGER NOT NULL,
+			session_map_sha256 TEXT NOT NULL,
+			checkpoint_sha256 TEXT NOT NULL
+		);
+		INSERT INTO artifact_checkpoint_heads VALUES (
+			'desktop-a1b2c3', 4, 'map', 'checkpoint'
+		);`)
+	require.NoError(t, err)
+	require.NoError(t, legacy.Close())
+
+	target := testDB(t)
+	require.NoError(t, target.CopySyncStateFrom(sourcePath))
+	head, ok, err := target.GetArtifactCheckpointHead(t.Context(), "desktop-a1b2c3")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, 4, head.Sequence)
+	assert.Zero(t, head.PublicationRevision)
+	assert.Zero(t, head.CheckpointSize)
+}
+
+func TestArtifactPublicationExportCardinalityIsQueueBounded(t *testing.T) {
+	for _, unrelated := range []int{20, 2000} {
+		t.Run(strconv.Itoa(unrelated), func(t *testing.T) {
+			database := testDB(t)
+			seedArtifactOrigin(t, database)
+			for i := range unrelated {
+				_, err := database.getWriter().Exec(
+					`INSERT INTO sessions (id, project, machine, agent)
+					 VALUES (?, 'project', 'peer-a1b2c3', 'claude')`,
+					"peer-"+strconv.Itoa(i),
+				)
+				require.NoError(t, err)
+			}
+			require.NoError(t, database.UpsertSession(Session{
+				ID: "dirty", Project: "project", Machine: "local", Agent: "claude",
+			}))
+			pending, err := database.PendingArtifactExports(t.Context(), 1)
+			require.NoError(t, err)
+			require.Len(t, pending, 1)
+			assert.Equal(t, "dirty", pending[0].SessionID)
+		})
+	}
+}
+
+func TestArtifactPublicationQueueTracksOnlyLocallyOwnedContent(t *testing.T) {
+	database := testDB(t)
+	seedArtifactOrigin(t, database)
+
+	require.NoError(t, database.UpsertSession(Session{
+		ID: "local-session", Project: "project", Machine: "local", Agent: "claude",
+	}))
+	require.Equal(t, []string{"local-session"}, artifactExportQueueIDs(t, database))
+	clearArtifactExportQueue(t, database)
+
+	require.NoError(t, database.UpsertSession(Session{
+		ID: "peer-session", Project: "project", Machine: "peer-a1b2c3", Agent: "claude",
+	}))
+	assert.Empty(t, artifactExportQueueIDs(t, database), "foreign inserts stay out of the local publication queue")
+
+	_, err := database.getWriter().Exec(
+		`UPDATE sessions SET display_name = 'renamed' WHERE id = 'local-session'`,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []string{"local-session"}, artifactExportQueueIDs(t, database))
+	clearArtifactExportQueue(t, database)
+
+	_, err = database.getWriter().Exec(
+		`UPDATE sessions SET machine = 'peer-a1b2c3' WHERE id = 'local-session'`,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []string{"local-session"}, artifactExportQueueIDs(t, database),
+		"local-to-foreign transition must publish removal")
+	clearArtifactExportQueue(t, database)
+
+	_, err = database.getWriter().Exec(
+		`UPDATE sessions SET machine = 'local' WHERE id = 'peer-session'`,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []string{"peer-session"}, artifactExportQueueIDs(t, database),
+		"foreign-to-local transition must publish content")
+	clearArtifactExportQueue(t, database)
+
+	_, err = database.getWriter().Exec(
+		`UPDATE sessions SET display_name = 'peer rename' WHERE id = 'local-session'`,
+	)
+	require.NoError(t, err)
+	assert.Empty(t, artifactExportQueueIDs(t, database), "unchanged foreign updates stay out of the queue")
+}
+
+func TestArtifactPublicationQueueKeepsFirstDirtyTimeForFIFO(t *testing.T) {
+	database := testDB(t)
+	seedArtifactOrigin(t, database)
+	require.NoError(t, database.UpsertSession(Session{
+		ID: "dirty", Project: "project", Machine: "local", Agent: "claude",
+	}))
+	const firstDirty = "2026-01-02T03:04:05.000Z"
+	_, err := database.getWriter().Exec(
+		`UPDATE artifact_export_queue SET enqueued_at = ? WHERE session_id = 'dirty'`,
+		firstDirty,
+	)
+	require.NoError(t, err)
+
+	_, err = database.getWriter().Exec(
+		`UPDATE sessions SET display_name = 'changed again' WHERE id = 'dirty'`,
+	)
+	require.NoError(t, err)
+	pending, err := database.PendingArtifactExports(t.Context(), 1)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	assert.Equal(t, firstDirty, pending[0].EnqueuedAt,
+		"repeated changes retain FIFO position until acknowledgement")
+	assert.Greater(t, pending[0].Generation, int64(1),
+		"repeated changes advance the compare-and-ack generation")
+}
+
+func TestArtifactPublicationQueueRefreshesDirtyTimeOnlyAfterAcknowledgement(t *testing.T) {
+	database := testDB(t)
+	seedArtifactOrigin(t, database)
+	require.NoError(t, database.UpsertSession(Session{
+		ID: "dirty", Project: "project", Machine: "local", Agent: "claude",
+	}))
+	const oldDirty = "2020-01-02T03:04:05.000Z"
+	_, err := database.getWriter().Exec(
+		`UPDATE artifact_export_queue SET enqueued_at = ? WHERE session_id = 'dirty'`,
+		oldDirty,
+	)
+	require.NoError(t, err)
+	claim, err := database.PendingArtifactExports(t.Context(), 1)
+	require.NoError(t, err)
+	require.NoError(t, database.AcknowledgeArtifactExports(t.Context(), claim))
+
+	_, err = database.getWriter().Exec(
+		`UPDATE sessions SET display_name = 'first clean mutation' WHERE id = 'dirty'`,
+	)
+	require.NoError(t, err)
+	pending, err := database.PendingArtifactExports(t.Context(), 1)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	assert.NotEqual(t, oldDirty, pending[0].EnqueuedAt,
+		"clean-to-pending transition receives a fresh FIFO position")
+	firstDirty := pending[0].EnqueuedAt
+
+	_, err = database.getWriter().Exec(
+		`UPDATE sessions SET display_name = 'second pending mutation' WHERE id = 'dirty'`,
+	)
+	require.NoError(t, err)
+	pending, err = database.PendingArtifactExports(t.Context(), 1)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	assert.Equal(t, firstDirty, pending[0].EnqueuedAt,
+		"repeated pending writes retain their FIFO position")
+}
+
+func TestArtifactPublicationQueueTracksMessagesUsageAndCascadeDeletion(t *testing.T) {
+	database := testDB(t)
+	seedArtifactOrigin(t, database)
+	for _, session := range []Session{
+		{ID: "local-session", Project: "project", Machine: "local", Agent: "claude"},
+		{ID: "peer-session", Project: "project", Machine: "peer-a1b2c3", Agent: "claude"},
+	} {
+		require.NoError(t, database.UpsertSession(session))
+	}
+	clearArtifactExportQueue(t, database)
+
+	require.NoError(t, database.InsertMessages([]Message{
+		{SessionID: "local-session", Ordinal: 0, Role: "user", Content: "local"},
+		{SessionID: "peer-session", Ordinal: 0, Role: "user", Content: "peer"},
+	}))
+	require.Equal(t, []string{"local-session"}, artifactExportQueueIDs(t, database))
+	pending, err := database.PendingArtifactExports(t.Context(), 1)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	assert.Equal(t, int64(2), pending[0].Generation,
+		"InsertMessages enqueues once for the owning session")
+	clearArtifactExportQueue(t, database)
+
+	require.NoError(t, database.ReplaceSessionUsageEvents("local-session", []UsageEvent{{
+		SessionID: "local-session", Source: "event", Model: "model", DedupKey: "local",
+	}}))
+	require.NoError(t, database.ReplaceSessionUsageEvents("peer-session", []UsageEvent{{
+		SessionID: "peer-session", Source: "event", Model: "model", DedupKey: "peer",
+	}}))
+	require.Equal(t, []string{"local-session"}, artifactExportQueueIDs(t, database))
+	pending, err = database.PendingArtifactExports(t.Context(), 1)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	assert.Equal(t, int64(3), pending[0].Generation,
+		"usage replacement enqueues once independently of event rows")
+	clearArtifactExportQueue(t, database)
+
+	_, err = database.getWriter().Exec(`DELETE FROM sessions WHERE id = 'local-session'`)
+	require.NoError(t, err)
+	require.Equal(t, []string{"local-session"}, artifactExportQueueIDs(t, database),
+		"the owner signal must survive child-row cascade ordering")
+}
+
+func TestArtifactPublicationQueueMessageReplacementIsBatchBounded(t *testing.T) {
+	for _, count := range []int{2, 2000} {
+		t.Run(strconv.Itoa(count), func(t *testing.T) {
+			database := testDB(t)
+			seedArtifactOrigin(t, database)
+			require.NoError(t, database.UpsertSession(Session{
+				ID: "session", Project: "project", Machine: "local", Agent: "claude",
+			}))
+			clearArtifactExportQueue(t, database)
+			messages := make([]Message, count)
+			for i := range messages {
+				messages[i] = Message{
+					SessionID: "session", Ordinal: i, Role: "user",
+					Content: "message " + strconv.Itoa(i),
+				}
+			}
+			require.NoError(t, database.ReplaceSessionMessages("session", messages))
+			pending, err := database.PendingArtifactExports(t.Context(), 1)
+			require.NoError(t, err)
+			require.Len(t, pending, 1)
+			assert.Equal(t, int64(2), pending[0].Generation,
+				"one transaction advances the queue independently of message count")
+		})
+	}
+}
+
+func TestArtifactPublicationQueueTracksMetadataOnlyStandaloneReplacements(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		replace func(*DB, string, []Message) error
+	}{
+		{
+			name: "messages",
+			replace: func(database *DB, sessionID string, messages []Message) error {
+				return database.ReplaceSessionMessages(sessionID, messages)
+			},
+		},
+		{
+			name: "content",
+			replace: func(database *DB, sessionID string, messages []Message) error {
+				return database.ReplaceSessionContent(
+					sessionID, messages, SessionSignalUpdate{}, nil,
+				)
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			database := testDB(t)
+			seedArtifactOrigin(t, database)
+			require.NoError(t, database.UpsertSession(Session{
+				ID: "session", Project: "project", Machine: "local", Agent: "claude",
+			}))
+			original := Message{
+				SessionID: "session", Ordinal: 0, Role: "assistant",
+				Content: "unchanged", ContentLength: len("unchanged"),
+			}
+			require.NoError(t, test.replace(database, "session", []Message{original}))
+			clearArtifactExportQueue(t, database)
+
+			var generationBefore int64
+			require.NoError(t, database.getReader().QueryRow(`
+				SELECT generation FROM artifact_export_queue WHERE session_id = 'session'`,
+			).Scan(&generationBefore))
+
+			metadataOnly := original
+			metadataOnly.ContentLength = 999
+			metadataOnly.TokenUsage = []byte(`{"input_tokens":17}`)
+			metadataOnly.ClaudeRequestID = "request-2"
+			metadataOnly.SourceUUID = "source-2"
+			require.NoError(t, test.replace(database, "session", []Message{metadataOnly}))
+
+			pending, err := database.PendingArtifactExports(t.Context(), 10)
+			require.NoError(t, err)
+			require.Len(t, pending, 1)
+			assert.Equal(t, "session", pending[0].SessionID)
+			assert.Equal(t, generationBefore+1, pending[0].Generation)
+			stored, err := database.GetAllMessages(t.Context(), "session")
+			require.NoError(t, err)
+			require.Len(t, stored, 1)
+			assert.Equal(t, metadataOnly.TokenUsage, stored[0].TokenUsage)
+			assert.Equal(t, metadataOnly.ClaudeRequestID, stored[0].ClaudeRequestID)
+			assert.Equal(t, metadataOnly.SourceUUID, stored[0].SourceUUID)
+		})
+	}
+}
+
+func TestArtifactPublicationQueueIgnoresSessionBookkeepingUpdates(t *testing.T) {
+	database := testDB(t)
+	seedArtifactOrigin(t, database)
+	require.NoError(t, database.UpsertSession(Session{
+		ID: "session", Project: "project", Machine: "local", Agent: "claude",
+	}))
+	clearArtifactExportQueue(t, database)
+	_, err := database.getWriter().Exec(`
+		UPDATE sessions SET
+			file_path = '/tmp/local', file_size = 42, file_mtime = 43,
+			next_ordinal = 9, last_entry_uuid = 'uuid', file_inode = 44,
+			file_device = 45, file_hash = 'hash', local_modified_at = 'now',
+			last_write_incremental = 1, secrets_rules_version = 'rules',
+			secret_leak_count = 2, sync_marker = 'marker'
+		WHERE id = 'session'`)
+	require.NoError(t, err)
+	assert.Empty(t, artifactExportQueueIDs(t, database))
+}
+
+// TestArtifactExportQueueStaysEmptyWithoutOrigin covers the deviation-1
+// origin gate: an archive that has never created or adopted an artifact
+// origin must never populate artifact_export_queue, regardless of how many
+// locally-owned sessions are inserted, updated, or deleted.
+func TestArtifactExportQueueStaysEmptyWithoutOrigin(t *testing.T) {
+	database := testDB(t)
+	require.NoError(t, database.UpsertSession(Session{
+		ID: "no-origin", Project: "project", Machine: "local", Agent: "claude",
+	}))
+	assertArtifactExportQueueEmpty(t, database, "insert")
+
+	_, err := database.getWriter().Exec(
+		`UPDATE sessions SET display_name = 'changed' WHERE id = 'no-origin'`,
+	)
+	require.NoError(t, err)
+	assertArtifactExportQueueEmpty(t, database, "update")
+
+	_, err = database.getWriter().Exec(`DELETE FROM sessions WHERE id = 'no-origin'`)
+	require.NoError(t, err)
+	assertArtifactExportQueueEmpty(t, database, "delete")
+}
+
+// TestArtifactExportQueueHooksRespectOriginGate covers the session_batch.go
+// and usage_events.go enqueue hooks (artifactExportGenerationTx /
+// enqueueArtifactExportTx), as distinct from the sessions-table triggers
+// covered by TestArtifactExportQueueStaysEmptyWithoutOrigin: a batch write
+// must not populate the queue before an artifact origin exists, and the
+// identical write must enqueue once an origin is seeded.
+func TestArtifactExportQueueHooksRespectOriginGate(t *testing.T) {
+	database := testDB(t)
+	write := SessionBatchWrite{
+		Session: Session{
+			ID: "gated-session", Project: "project", Machine: "local", Agent: "claude",
+		},
+		Messages: []Message{
+			{SessionID: "gated-session", Ordinal: 0, Role: "user", Content: "hi"},
+		},
+	}
+	result, err := database.WriteSessionBatch([]SessionBatchWrite{write})
+	require.NoError(t, err)
+	require.Equal(t, 1, result.WrittenSessions)
+	assert.Empty(t, artifactExportQueueIDs(t, database),
+		"a batch write must not populate the export queue before an artifact origin exists")
+
+	seedArtifactOrigin(t, database)
+	write.Session.ID = "gated-session-2"
+	write.Messages[0].SessionID = "gated-session-2"
+	result, err = database.WriteSessionBatch([]SessionBatchWrite{write})
+	require.NoError(t, err)
+	require.Equal(t, 1, result.WrittenSessions)
+	assert.Equal(t, []string{"gated-session-2"}, artifactExportQueueIDs(t, database),
+		"after an artifact origin exists, the identical batch write enqueues the session")
+}
+
+// TestReplaceSessionUsageEventsEnqueuesArtifactExport covers the standalone
+// ReplaceSessionUsageEvents path (usage_events.go, enqueueArtifact=true),
+// as distinct from the batch path (WriteSessionBatch passes false and relies
+// on its own end-of-batch generation check; see
+// TestArtifactPublicationUsageOnlyAtomicBatchEnqueuesExactlyOnce).
+func TestReplaceSessionUsageEventsEnqueuesArtifactExport(t *testing.T) {
+	database := testDB(t)
+	seedArtifactOrigin(t, database)
+	require.NoError(t, database.UpsertSession(Session{
+		ID: "usage-standalone", Project: "project", Machine: "local", Agent: "claude",
+	}))
+	clearArtifactExportQueue(t, database)
+
+	require.NoError(t, database.ReplaceSessionUsageEvents("usage-standalone", []UsageEvent{{
+		SessionID: "usage-standalone", Source: "event", Model: "model", DedupKey: "standalone",
+	}}))
+	pending, err := database.PendingArtifactExports(t.Context(), 1)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	assert.Equal(t, "usage-standalone", pending[0].SessionID)
+	assert.Equal(t, int64(2), pending[0].Generation,
+		"standalone ReplaceSessionUsageEvents enqueues directly")
+}
+
+// TestArtifactSessionTriggersSurviveLegacySchemaMigration is the deviation-3
+// regression test: the sessions triggers must be installed after
+// applySchemaColumnMigrations runs, not at schema-init time, or the update
+// trigger's change-detection list fires "no such column" against an archive
+// created before those columns existed.
+func TestArtifactSessionTriggersSurviveLegacySchemaMigration(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy-artifact.db")
+	conn, err := sql.Open("sqlite3", makeDSN(path, false))
+	require.NoError(t, err)
+	conn.SetMaxOpenConns(1)
+	_, err = conn.Exec(preParentLegacySchema)
+	require.NoError(t, err)
+	_, err = conn.Exec(legacyArchiveRows)
+	require.NoError(t, err)
+	_, err = conn.Exec(fmt.Sprintf("PRAGMA user_version = %d", dataVersion))
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+
+	database, err := Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, database.Close()) })
+	assert.True(t, database.NeedsResync())
+	seedArtifactOrigin(t, database)
+
+	require.NoError(t, database.UpsertSession(Session{
+		ID: "legacy-fresh", Project: "project", Machine: "local", Agent: "claude",
+	}))
+	assert.Contains(t, artifactExportQueueIDs(t, database), "legacy-fresh",
+		"insert trigger must fire cleanly on the migrated schema")
+
+	_, err = database.getWriter().Exec(
+		`UPDATE sessions SET display_name = 'renamed' WHERE id = 'legacy-session'`,
+	)
+	require.NoError(t, err,
+		"update trigger must not fail with 'no such column' on a column added by migration")
+	assert.Contains(t, artifactExportQueueIDs(t, database), "legacy-session",
+		"update trigger must enqueue the migrated legacy session")
+}
+
+func assertArtifactExportQueueEmpty(t *testing.T, database *DB, op string) {
+	t.Helper()
+	var count int
+	require.NoError(t, database.getReader().QueryRow(
+		`SELECT count(*) FROM artifact_export_queue`,
+	).Scan(&count))
+	assert.Zero(t, count,
+		"session %s without an artifact origin must not populate the export queue", op)
+}
+
+func artifactExportQueueIDs(t *testing.T, database *DB) []string {
+	t.Helper()
+	rows, err := database.getReader().Query(
+		`SELECT session_id FROM artifact_export_queue
+		 WHERE pending = 1 ORDER BY session_id`,
+	)
+	require.NoError(t, err)
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		require.NoError(t, rows.Scan(&id))
+		ids = append(ids, id)
+	}
+	require.NoError(t, rows.Err())
+	return ids
+}
+
+func clearArtifactExportQueue(t *testing.T, database *DB) {
+	t.Helper()
+	_, err := database.getWriter().Exec(`UPDATE artifact_export_queue SET pending = 0`)
+	require.NoError(t, err)
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -2179,7 +2179,12 @@ DROP TRIGGER IF EXISTS artifact_sessions_delete_queue;
 
 const artifactSessionQueueTriggerCreatesSQL = `
 CREATE TRIGGER IF NOT EXISTS artifact_sessions_insert_queue
-AFTER INSERT ON sessions WHEN NEW.machine = 'local' AND EXISTS (
+AFTER INSERT ON sessions WHEN (
+    NEW.machine = 'local' OR EXISTS (
+        SELECT 1 FROM pg_sync_state
+        WHERE key = 'artifact_local_machine_name' AND value = NEW.machine
+    )
+) AND EXISTS (
     SELECT 1 FROM pg_sync_state WHERE key = 'artifact_origin_id'
 ) BEGIN
     INSERT INTO artifact_export_queue(session_id) VALUES (NEW.id)
@@ -2195,7 +2200,13 @@ END;
 
 CREATE TRIGGER IF NOT EXISTS artifact_sessions_update_queue
 AFTER UPDATE ON sessions
-WHEN (OLD.machine = 'local' OR NEW.machine = 'local') AND EXISTS (
+WHEN (
+    OLD.machine = 'local' OR NEW.machine = 'local' OR EXISTS (
+        SELECT 1 FROM pg_sync_state
+        WHERE key = 'artifact_local_machine_name'
+          AND (value = OLD.machine OR value = NEW.machine)
+    )
+) AND EXISTS (
     SELECT 1 FROM pg_sync_state WHERE key = 'artifact_origin_id'
 ) AND (
     OLD.project IS NOT NEW.project OR
@@ -2266,7 +2277,12 @@ WHEN (OLD.machine = 'local' OR NEW.machine = 'local') AND EXISTS (
 END;
 
 CREATE TRIGGER IF NOT EXISTS artifact_sessions_delete_queue
-BEFORE DELETE ON sessions WHEN OLD.machine = 'local' AND EXISTS (
+BEFORE DELETE ON sessions WHEN (
+    OLD.machine = 'local' OR EXISTS (
+        SELECT 1 FROM pg_sync_state
+        WHERE key = 'artifact_local_machine_name' AND value = OLD.machine
+    )
+) AND EXISTS (
     SELECT 1 FROM pg_sync_state WHERE key = 'artifact_origin_id'
 ) BEGIN
     INSERT INTO artifact_export_queue(session_id) VALUES (OLD.id)
@@ -2482,11 +2498,21 @@ const (
 	bootstrapArtifactExportQueueSQL = `
 		INSERT OR IGNORE INTO artifact_export_queue(session_id)
 		SELECT id FROM sessions
-		WHERE machine = 'local' AND deleted_at IS NULL`
+		WHERE (
+			machine = 'local' OR machine = (
+				SELECT value FROM pg_sync_state
+				WHERE key = 'artifact_local_machine_name'
+			)
+		) AND deleted_at IS NULL`
 	requeueArtifactExportsSQL = `
 		INSERT INTO artifact_export_queue(session_id)
 		SELECT id FROM sessions
-		WHERE machine = 'local' AND deleted_at IS NULL
+		WHERE (
+			machine = 'local' OR machine = (
+				SELECT value FROM pg_sync_state
+				WHERE key = 'artifact_local_machine_name'
+			)
+		) AND deleted_at IS NULL
 		ON CONFLICT(session_id) DO UPDATE SET
 			enqueued_at = CASE WHEN pending = 0
 				THEN strftime('%Y-%m-%dT%H:%M:%fZ','now') ELSE enqueued_at END,
@@ -2498,7 +2524,12 @@ const (
 	requeueArtifactOriginExportsSQL = `
 		INSERT INTO artifact_export_queue(session_id)
 		SELECT id FROM sessions
-		WHERE machine = 'local' AND deleted_at IS NULL
+		WHERE (
+			machine = 'local' OR machine = (
+				SELECT value FROM pg_sync_state
+				WHERE key = 'artifact_local_machine_name'
+			)
+		) AND deleted_at IS NULL
 		UNION
 		SELECT session_id FROM artifact_publications
 		WHERE origin = ?

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1368,6 +1368,11 @@ var readOnlyRequiredTables = []string{
 	"recall_query_exposures",
 	"recall_extract_generations",
 	"recall_extract_progress",
+	"artifact_export_queue",
+	"artifact_publications",
+	"artifact_publication_revisions",
+	"artifact_checkpoint_heads",
+	"artifact_checkpoint_floors",
 }
 
 var (
@@ -1657,6 +1662,18 @@ func legacySchemaColumnMigrations() []schemaColumnMigration {
 
 func schemaColumnMigrations() []schemaColumnMigration {
 	return []schemaColumnMigration{
+		{
+			"artifact_export_queue", "rejected_generation",
+			"ALTER TABLE artifact_export_queue ADD COLUMN rejected_generation INTEGER",
+		},
+		{
+			"artifact_export_queue", "last_error",
+			"ALTER TABLE artifact_export_queue ADD COLUMN last_error TEXT NOT NULL DEFAULT ''",
+		},
+		{
+			"artifact_export_queue", "rejected_at",
+			"ALTER TABLE artifact_export_queue ADD COLUMN rejected_at TEXT",
+		},
 		{
 			"sessions", "display_name",
 			"ALTER TABLE sessions ADD COLUMN display_name TEXT",
@@ -2135,6 +2152,135 @@ func repairLegacySchemaBeforeInit(w *writerHandle) error {
 	return nil
 }
 
+// artifactSessionQueueTriggerDropsSQL and artifactSessionQueueTriggerCreatesSQL
+// together keep the three sessions-table triggers that populate
+// artifact_export_queue upgradable across releases. They are applied here
+// rather than in schema.sql because the CREATE bodies reference columns added
+// by applySchemaColumnMigrations; running them at schema-init time would fire
+// "no such column" errors against a legacy archive before those columns
+// exist.
+//
+// The drops run BEFORE applySchemaColumnMigrations and the creates run AFTER:
+// a trigger left over from a previous release must not still be attached to
+// the sessions table while column migrations run, because a future
+// migration that rebuilds the table (rather than a plain ALTER TABLE ADD
+// COLUMN) would fail against a trigger body referencing columns mid-rebuild.
+// Splitting the DDL this way keeps the table trigger-free for the duration
+// of the migration step regardless of what a later migration needs to do.
+//
+// Every trigger additionally gates on the presence of an artifact origin
+// (pg_sync_state key artifact_origin_id) so that archives which have never
+// created or adopted an artifact origin never populate the export queue.
+const artifactSessionQueueTriggerDropsSQL = `
+DROP TRIGGER IF EXISTS artifact_sessions_insert_queue;
+DROP TRIGGER IF EXISTS artifact_sessions_update_queue;
+DROP TRIGGER IF EXISTS artifact_sessions_delete_queue;
+`
+
+const artifactSessionQueueTriggerCreatesSQL = `
+CREATE TRIGGER IF NOT EXISTS artifact_sessions_insert_queue
+AFTER INSERT ON sessions WHEN NEW.machine = 'local' AND EXISTS (
+    SELECT 1 FROM pg_sync_state WHERE key = 'artifact_origin_id'
+) BEGIN
+    INSERT INTO artifact_export_queue(session_id) VALUES (NEW.id)
+    ON CONFLICT(session_id) DO UPDATE SET
+        enqueued_at = CASE WHEN pending = 0
+            THEN strftime('%Y-%m-%dT%H:%M:%fZ','now') ELSE enqueued_at END,
+        generation = generation + 1,
+        pending = 1,
+        rejected_generation = NULL,
+        last_error = '',
+        rejected_at = NULL;
+END;
+
+CREATE TRIGGER IF NOT EXISTS artifact_sessions_update_queue
+AFTER UPDATE ON sessions
+WHEN (OLD.machine = 'local' OR NEW.machine = 'local') AND EXISTS (
+    SELECT 1 FROM pg_sync_state WHERE key = 'artifact_origin_id'
+) AND (
+    OLD.project IS NOT NEW.project OR
+    OLD.machine IS NOT NEW.machine OR
+    OLD.agent IS NOT NEW.agent OR
+    OLD.agent_label IS NOT NEW.agent_label OR
+    OLD.entrypoint IS NOT NEW.entrypoint OR
+    OLD.first_message IS NOT NEW.first_message OR
+    OLD.display_name IS NOT NEW.display_name OR
+    OLD.session_name IS NOT NEW.session_name OR
+    OLD.started_at IS NOT NEW.started_at OR
+    OLD.ended_at IS NOT NEW.ended_at OR
+    OLD.message_count IS NOT NEW.message_count OR
+    OLD.user_message_count IS NOT NEW.user_message_count OR
+    OLD.transcript_revision IS NOT NEW.transcript_revision OR
+    OLD.parent_session_id IS NOT NEW.parent_session_id OR
+    OLD.relationship_type IS NOT NEW.relationship_type OR
+    OLD.total_output_tokens IS NOT NEW.total_output_tokens OR
+    OLD.peak_context_tokens IS NOT NEW.peak_context_tokens OR
+    OLD.has_total_output_tokens IS NOT NEW.has_total_output_tokens OR
+    OLD.has_peak_context_tokens IS NOT NEW.has_peak_context_tokens OR
+    OLD.is_automated IS NOT NEW.is_automated OR
+    OLD.tool_failure_signal_count IS NOT NEW.tool_failure_signal_count OR
+    OLD.tool_retry_count IS NOT NEW.tool_retry_count OR
+    OLD.edit_churn_count IS NOT NEW.edit_churn_count OR
+    OLD.consecutive_failure_max IS NOT NEW.consecutive_failure_max OR
+    OLD.outcome IS NOT NEW.outcome OR
+    OLD.outcome_confidence IS NOT NEW.outcome_confidence OR
+    OLD.ended_with_role IS NOT NEW.ended_with_role OR
+    OLD.final_failure_streak IS NOT NEW.final_failure_streak OR
+    OLD.signals_pending_since IS NOT NEW.signals_pending_since OR
+    OLD.compaction_count IS NOT NEW.compaction_count OR
+    OLD.mid_task_compaction_count IS NOT NEW.mid_task_compaction_count OR
+    OLD.context_pressure_max IS NOT NEW.context_pressure_max OR
+    OLD.health_score IS NOT NEW.health_score OR
+    OLD.health_grade IS NOT NEW.health_grade OR
+    OLD.has_tool_calls IS NOT NEW.has_tool_calls OR
+    OLD.has_context_data IS NOT NEW.has_context_data OR
+    OLD.quality_signal_version IS NOT NEW.quality_signal_version OR
+    OLD.short_prompt_count IS NOT NEW.short_prompt_count OR
+    OLD.unstructured_start IS NOT NEW.unstructured_start OR
+    OLD.missing_success_criteria_count IS NOT NEW.missing_success_criteria_count OR
+    OLD.missing_verification_count IS NOT NEW.missing_verification_count OR
+    OLD.duplicate_prompt_count IS NOT NEW.duplicate_prompt_count OR
+    OLD.no_code_context_count IS NOT NEW.no_code_context_count OR
+    OLD.runaway_tool_loop_count IS NOT NEW.runaway_tool_loop_count OR
+    OLD.data_version IS NOT NEW.data_version OR
+    OLD.cwd IS NOT NEW.cwd OR
+    OLD.git_branch IS NOT NEW.git_branch OR
+    OLD.source_session_id IS NOT NEW.source_session_id OR
+    OLD.source_version IS NOT NEW.source_version OR
+    OLD.transcript_fidelity IS NOT NEW.transcript_fidelity OR
+    OLD.parser_malformed_lines IS NOT NEW.parser_malformed_lines OR
+    OLD.is_truncated IS NOT NEW.is_truncated OR
+    OLD.deleted_at IS NOT NEW.deleted_at OR
+    OLD.created_at IS NOT NEW.created_at OR
+    OLD.termination_status IS NOT NEW.termination_status
+) BEGIN
+    INSERT INTO artifact_export_queue(session_id) VALUES (NEW.id)
+    ON CONFLICT(session_id) DO UPDATE SET
+        enqueued_at = CASE WHEN pending = 0
+            THEN strftime('%Y-%m-%dT%H:%M:%fZ','now') ELSE enqueued_at END,
+        generation = generation + 1,
+        pending = 1,
+        rejected_generation = NULL,
+        last_error = '',
+        rejected_at = NULL;
+END;
+
+CREATE TRIGGER IF NOT EXISTS artifact_sessions_delete_queue
+BEFORE DELETE ON sessions WHEN OLD.machine = 'local' AND EXISTS (
+    SELECT 1 FROM pg_sync_state WHERE key = 'artifact_origin_id'
+) BEGIN
+    INSERT INTO artifact_export_queue(session_id) VALUES (OLD.id)
+    ON CONFLICT(session_id) DO UPDATE SET
+        enqueued_at = CASE WHEN pending = 0
+            THEN strftime('%Y-%m-%dT%H:%M:%fZ','now') ELSE enqueued_at END,
+        generation = generation + 1,
+        pending = 1,
+        rejected_generation = NULL,
+        last_error = '',
+        rejected_at = NULL;
+END;
+`
+
 // migrateColumns adds columns introduced by this branch to databases created
 // by older releases, then runs the data repairs required by a normal writable
 // startup. Schema-only callers use applySchemaColumnMigrations directly.
@@ -2145,8 +2291,14 @@ func (db *DB) migrateColumns() error {
 	if err := migrateMoneyColumnsLocked(w); err != nil {
 		return err
 	}
+	if _, err := w.Exec(artifactSessionQueueTriggerDropsSQL); err != nil {
+		return fmt.Errorf("dropping artifact session queue triggers: %w", err)
+	}
 	if err := applySchemaColumnMigrations(w.QueryRow, w.Exec); err != nil {
 		return err
+	}
+	if _, err := w.Exec(artifactSessionQueueTriggerCreatesSQL); err != nil {
+		return fmt.Errorf("installing artifact session queue triggers: %w", err)
 	}
 	if err := installSyncMarkerSchemaLocked(w); err != nil {
 		return err
@@ -2322,6 +2474,141 @@ func (db *DB) migrateColumns() error {
 	}
 	if err := db.markTokenCoverageRepairDoneLocked(w); err != nil {
 		return err
+	}
+	return nil
+}
+
+const (
+	bootstrapArtifactExportQueueSQL = `
+		INSERT OR IGNORE INTO artifact_export_queue(session_id)
+		SELECT id FROM sessions
+		WHERE machine = 'local' AND deleted_at IS NULL`
+	requeueArtifactExportsSQL = `
+		INSERT INTO artifact_export_queue(session_id)
+		SELECT id FROM sessions
+		WHERE machine = 'local' AND deleted_at IS NULL
+		ON CONFLICT(session_id) DO UPDATE SET
+			enqueued_at = CASE WHEN pending = 0
+				THEN strftime('%Y-%m-%dT%H:%M:%fZ','now') ELSE enqueued_at END,
+			generation = generation + 1,
+			pending = 1,
+			rejected_generation = NULL,
+			last_error = '',
+			rejected_at = NULL`
+	requeueArtifactOriginExportsSQL = `
+		INSERT INTO artifact_export_queue(session_id)
+		SELECT id FROM sessions
+		WHERE machine = 'local' AND deleted_at IS NULL
+		UNION
+		SELECT session_id FROM artifact_publications
+		WHERE origin = ?
+		ON CONFLICT(session_id) DO UPDATE SET
+			enqueued_at = CASE WHEN pending = 0
+				THEN strftime('%Y-%m-%dT%H:%M:%fZ','now') ELSE enqueued_at END,
+			generation = generation + 1,
+			pending = 1,
+			rejected_generation = NULL,
+			last_error = '',
+			rejected_at = NULL`
+)
+
+var populateArtifactOriginQueueTx = func(tx *sql.Tx, origin string, requeue bool) error {
+	statement := bootstrapArtifactExportQueueSQL
+	action := "bootstrapping"
+	args := []any(nil)
+	if requeue {
+		statement = requeueArtifactOriginExportsSQL
+		action = "requeueing"
+		args = append(args, origin)
+	}
+	if _, err := tx.Exec(statement, args...); err != nil {
+		return fmt.Errorf("%s artifact export queue: %w", action, err)
+	}
+	return nil
+}
+
+// EnsureArtifactOrigin atomically persists candidate when no origin exists and
+// bootstraps every pre-existing local session into the export queue. A
+// concurrent initializer's committed origin wins and is returned unchanged.
+func (db *DB) EnsureArtifactOrigin(candidate string) (string, error) {
+	return db.setArtifactOrigin(candidate, false)
+}
+
+// AdoptArtifactOrigin atomically persists an authoritative configured origin
+// and populates its export queue. Replacing an established origin re-dirties
+// every live local session so clean rows from the previous origin are
+// published again.
+func (db *DB) AdoptArtifactOrigin(origin string) error {
+	_, err := db.setArtifactOrigin(origin, true)
+	return err
+}
+
+func (db *DB) setArtifactOrigin(origin string, adopt bool) (string, error) {
+	resolved := origin
+	err := db.Update(func(tx *sql.Tx) error {
+		if err := lockArtifactPublicationTx(context.Background(), tx); err != nil {
+			return err
+		}
+		var existing string
+		err := tx.QueryRow(
+			`SELECT value FROM pg_sync_state WHERE key = 'artifact_origin_id'`,
+		).Scan(&existing)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("reading artifact origin: %w", err)
+		}
+		if err == nil && existing != "" {
+			if !adopt || existing == origin {
+				resolved = existing
+				return nil
+			}
+		}
+		if _, err := tx.Exec(
+			`INSERT INTO pg_sync_state (key, value)
+			 VALUES ('artifact_origin_id', ?)
+			 ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+			origin,
+		); err != nil {
+			return fmt.Errorf("persisting artifact origin: %w", err)
+		}
+		if err := populateArtifactOriginQueueTx(tx, origin, existing != ""); err != nil {
+			return err
+		}
+		resolved = origin
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return resolved, nil
+}
+
+// BootstrapArtifactExportQueue enqueues every live locally-owned session
+// once. Called by maintenance and tests that already own origin lifecycle;
+// normal origin initialization uses EnsureArtifactOrigin so the origin and
+// queue commit atomically.
+func (db *DB) BootstrapArtifactExportQueue() error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	_, err := db.getWriter().Exec(bootstrapArtifactExportQueueSQL)
+	if err != nil {
+		return fmt.Errorf("bootstrapping artifact export queue: %w", err)
+	}
+	return nil
+}
+
+// RequeueAllArtifactExports forces every live locally-owned session pending
+// with a bumped generation. Called when a divergent artifact origin is
+// adopted: BootstrapArtifactExportQueue is INSERT OR IGNORE, so a session
+// already acknowledged (pending=0) under the previous origin would be skipped
+// and never re-verified under the new origin. This re-dirties the ledger so
+// the new origin publishes every owned session. The ON CONFLICT clause matches
+// the session queue triggers' generation semantics.
+func (db *DB) RequeueAllArtifactExports() error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	_, err := db.getWriter().Exec(requeueArtifactExportsSQL)
+	if err != nil {
+		return fmt.Errorf("requeueing artifact export queue: %w", err)
 	}
 	return nil
 }
@@ -2878,6 +3165,7 @@ func (db *DB) backfillMessageTokenCoverageLocked(
 	}
 	defer stmt.Close()
 
+	sessions := make(map[string]struct{})
 	for _, candidate := range candidates {
 		if _, err := stmt.Exec(
 			candidate.hasContext, candidate.hasOutput, candidate.id,
@@ -2886,6 +3174,12 @@ func (db *DB) backfillMessageTokenCoverageLocked(
 				"updating message token backfill %d: %w",
 				candidate.id, err,
 			)
+		}
+		sessions[candidate.sessionID] = struct{}{}
+	}
+	for sessionID := range sessions {
+		if err := enqueueArtifactExportTx(tx, sessionID); err != nil {
+			return 0, err
 		}
 	}
 	if err := tx.Commit(); err != nil {
@@ -2901,7 +3195,7 @@ func (db *DB) messageTokenCoverageBackfillCandidatesLocked(
 	w *writerHandle,
 ) ([]messageTokenCoverageBackfillCandidate, error) {
 	rows, err := w.Query(
-		`SELECT id, token_usage, context_tokens, output_tokens,
+		`SELECT id, session_id, token_usage, context_tokens, output_tokens,
 			has_context_tokens, has_output_tokens
 		 FROM messages
 		 WHERE (has_context_tokens = 0 OR has_output_tokens = 0)
@@ -2919,11 +3213,12 @@ func (db *DB) messageTokenCoverageBackfillCandidatesLocked(
 	var candidates []messageTokenCoverageBackfillCandidate
 	for rows.Next() {
 		var id int64
+		var sessionID string
 		var tokenUsage string
 		var contextTokens, outputTokens int
 		var hasContextTokens, hasOutputTokens bool
 		if err := rows.Scan(
-			&id, &tokenUsage, &contextTokens,
+			&id, &sessionID, &tokenUsage, &contextTokens,
 			&outputTokens, &hasContextTokens,
 			&hasOutputTokens,
 		); err != nil {
@@ -2941,6 +3236,7 @@ func (db *DB) messageTokenCoverageBackfillCandidatesLocked(
 		}
 		candidates = append(candidates, messageTokenCoverageBackfillCandidate{
 			id:         id,
+			sessionID:  sessionID,
 			hasContext: hasContext,
 			hasOutput:  hasOutput,
 		})
@@ -2953,6 +3249,7 @@ func (db *DB) messageTokenCoverageBackfillCandidatesLocked(
 
 type messageTokenCoverageBackfillCandidate struct {
 	id         int64
+	sessionID  string
 	hasContext bool
 	hasOutput  bool
 }
@@ -4013,6 +4310,16 @@ func (db *DB) DeleteSyncStateByPrefix(prefix string) error {
 	_, err := db.getWriter().Exec(
 		"DELETE FROM pg_sync_state WHERE key LIKE ? ESCAPE '\\'",
 		escaped+"%",
+	)
+	return err
+}
+
+// DeleteSyncState removes the pg_sync_state row for exactly key, if present.
+func (db *DB) DeleteSyncState(key string) error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	_, err := db.getWriter().Exec(
+		"DELETE FROM pg_sync_state WHERE key = ?", key,
 	)
 	return err
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -2570,7 +2570,7 @@ func (db *DB) setArtifactOrigin(origin string, adopt bool) (string, error) {
 		); err != nil {
 			return fmt.Errorf("persisting artifact origin: %w", err)
 		}
-		if err := populateArtifactOriginQueueTx(tx, origin, existing != ""); err != nil {
+		if err := populateArtifactOriginQueueTx(tx, origin, true); err != nil {
 			return err
 		}
 		resolved = origin

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -5561,10 +5561,15 @@ func TestCopySyncStateFrom_OnlyCopiesDurablePGKeys(t *testing.T) {
 	srcDB := testDBAtPath(t, srcPath, "src")
 	require.NoError(t, srcDB.SetSyncState("pg_push_marker_id", "marker-123"),
 		"seed source marker")
+	require.NoError(t, srcDB.SetSyncState("artifact_origin_id", "laptop-a1b2c3"),
+		"seed source artifact origin")
 	require.NoError(t, srcDB.SetSyncState("last_sync_started_at", "old-start"),
 		"seed source started")
 	require.NoError(t, srcDB.SetSyncState("last_sync_finished_at", "old-finish"),
 		"seed source finished")
+	require.NoError(t, srcDB.UpsertSession(Session{
+		ID: "queued-session", Project: "p", Machine: "local", Agent: "claude",
+	}), "seed source queued session")
 	require.NoError(t, srcDB.Close(), "Close src")
 
 	dstPath := filepath.Join(dir, "dst.db")
@@ -5581,6 +5586,14 @@ func TestCopySyncStateFrom_OnlyCopiesDurablePGKeys(t *testing.T) {
 	gotMarker, err := dstDB.GetSyncState("pg_push_marker_id")
 	require.NoError(t, err, "GetSyncState pg_push_marker_id")
 	assert.Equal(t, "marker-123", gotMarker)
+
+	gotOrigin, err := dstDB.GetSyncState("artifact_origin_id")
+	require.NoError(t, err, "GetSyncState artifact_origin_id")
+	assert.Equal(t, "laptop-a1b2c3", gotOrigin,
+		"artifact_% sync-state keys must survive the copy")
+
+	assert.Contains(t, artifactExportQueueIDs(t, dstDB), "queued-session",
+		"artifact export queue rows must survive the copy")
 
 	gotStarted, err := dstDB.GetSyncState("last_sync_started_at")
 	require.NoError(t, err, "GetSyncState last_sync_started_at")
@@ -7377,10 +7390,13 @@ func TestMigration_TerminationStatusColumn(t *testing.T) {
 	requireNoError(t, err, "raw open")
 
 	// SQLite supports DROP COLUMN as of 3.35; the in-tree driver is
-	// recent enough. Drop the index first since SQLite blocks
-	// dropping a column referenced by an index.
+	// recent enough. Drop the index and the trigger that references the
+	// column first since SQLite blocks dropping a column referenced by an
+	// index or a trigger.
 	_, err = conn.Exec(`DROP INDEX IF EXISTS idx_sessions_termination_status`)
 	requireNoError(t, err, "drop termination_status index")
+	_, err = conn.Exec(`DROP TRIGGER IF EXISTS artifact_sessions_update_queue`)
+	requireNoError(t, err, "drop artifact_sessions_update_queue trigger")
 	_, err = conn.Exec(`ALTER TABLE sessions DROP COLUMN termination_status`)
 	requireNoError(t, err, "drop termination_status column")
 

--- a/internal/db/messages.go
+++ b/internal/db/messages.go
@@ -1157,6 +1157,12 @@ func (db *DB) ReplaceSessionMessages(
 		return fmt.Errorf("beginning tx: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
+	queueGenerationBefore, queueExistedBefore, err := artifactExportGenerationTx(
+		tx, sessionID,
+	)
+	if err != nil {
+		return err
+	}
 	var pendingRecallRevocations recallEvidenceRevocationEvents
 
 	if useDiff {
@@ -1194,6 +1200,11 @@ func (db *DB) ReplaceSessionMessages(
 		return err
 	}
 	if err := invalidateSessionSignalsTx(tx, sessionID); err != nil {
+		return err
+	}
+	if err := enqueueArtifactExportIfGenerationUnchangedTx(
+		tx, sessionID, queueGenerationBefore, queueExistedBefore,
+	); err != nil {
 		return err
 	}
 	if err := tx.Commit(); err != nil {
@@ -1364,6 +1375,12 @@ func (db *DB) ReplaceSessionContent(
 		return fmt.Errorf("beginning tx: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
+	queueGenerationBefore, queueExistedBefore, err := artifactExportGenerationTx(
+		tx, sessionID,
+	)
+	if err != nil {
+		return err
+	}
 	var pendingRecallRevocations recallEvidenceRevocationEvents
 
 	if useDiff {
@@ -1401,6 +1418,11 @@ func (db *DB) ReplaceSessionContent(
 	// the count cannot diverge from the findings it summarizes.
 	if err := replaceSecretFindingsTx(tx, sessionID, findings,
 		signals.SecretLeakCount, signals.SecretsRulesVersion); err != nil {
+		return err
+	}
+	if err := enqueueArtifactExportIfGenerationUnchangedTx(
+		tx, sessionID, queueGenerationBefore, queueExistedBefore,
+	); err != nil {
 		return err
 	}
 	if err := tx.Commit(); err != nil {

--- a/internal/db/orphaned.go
+++ b/internal/db/orphaned.go
@@ -444,6 +444,16 @@ func (d *DB) CopySyncStateFrom(sourcePath string) error {
 		}
 	}
 	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO main.artifact_checkpoint_floors(origin, sequence)
+		SELECT origin, sequence FROM main.artifact_checkpoint_heads WHERE true
+		ON CONFLICT(origin) DO UPDATE SET
+			sequence = max(
+				artifact_checkpoint_floors.sequence,
+				excluded.sequence
+			)`); err != nil {
+		return fmt.Errorf("advancing copied artifact checkpoint floors: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
 		INSERT OR IGNORE INTO main.artifact_export_queue(session_id)
 		SELECT id FROM main.sessions
 		WHERE machine = 'local'

--- a/internal/db/orphaned.go
+++ b/internal/db/orphaned.go
@@ -323,9 +323,12 @@ func (d *DB) CopyTrashedDataFrom(sourcePath string) (int, error) {
 	return count, nil
 }
 
-// CopySyncStateFrom copies pg_sync_state rows from the source database into the
-// current database. ResyncAll uses this to preserve durable local sync metadata
-// such as the PG push owner marker across the temp-DB swap.
+// CopySyncStateFrom copies durable synchronization authority from the source
+// database into the current database. Alongside selected pg_sync_state rows it
+// preserves artifact publication work, publications, checkpoint heads, and
+// floors across the temp-database resync swap. Transient bookkeeping such as
+// last_sync_* timestamps is deliberately left behind so the rebuilt DB reports
+// its own sync times.
 func (d *DB) CopySyncStateFrom(sourcePath string) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -346,24 +349,113 @@ func (d *DB) CopySyncStateFrom(sourcePath string) error {
 		_, _ = execWithoutCancel(ctx, conn, "DETACH DATABASE old_db")
 	}()
 
-	// Older databases may have no pg_sync_state table.
-	var tableExists int
-	err = conn.QueryRowContext(
-		ctx, "SELECT 1 FROM old_db.sqlite_master WHERE type='table' AND name='pg_sync_state'",
-	).Scan(&tableExists)
+	tx, err := conn.BeginTx(ctx, nil)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil
+		return fmt.Errorf("beginning sync state copy: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if oldDBHasTable(ctx, tx, "pg_sync_state") {
+		if _, err := tx.ExecContext(ctx, `
+			INSERT OR REPLACE INTO main.pg_sync_state (key, value)
+			SELECT key, value FROM old_db.pg_sync_state
+			WHERE key = 'pg_push_marker_id'
+			   OR key LIKE 'artifact\_%' ESCAPE '\'`); err != nil {
+			return fmt.Errorf("copying sync state: %w", err)
 		}
-		return fmt.Errorf("probing pg_sync_state table: %w", err)
 	}
 
-	_, err = conn.ExecContext(ctx, `
-		INSERT OR REPLACE INTO main.pg_sync_state (key, value)
-		SELECT key, value FROM old_db.pg_sync_state
-		WHERE key = 'pg_push_marker_id'`)
-	if err != nil {
-		return fmt.Errorf("copying sync state: %w", err)
+	headRevisionExpr := "0"
+	if oldDBHasColumn(ctx, tx, "artifact_checkpoint_heads", "publication_revision") {
+		headRevisionExpr = "publication_revision"
+	}
+	headSizeExpr := "0"
+	if oldDBHasColumn(ctx, tx, "artifact_checkpoint_heads", "checkpoint_size") {
+		headSizeExpr = "checkpoint_size"
+	}
+	artifactCopies := []struct {
+		table string
+		sql   string
+	}{
+		{
+			// A resync rebuilds the archive, so every copied session must be
+			// re-verified by the exporter: copied rows are forced pending=1 on
+			// both the fresh-insert and merge branches. Unchanged content is
+			// cheap to skip because artifacts are content-addressed. Generation
+			// still advances and never regresses so a stale source claim cannot
+			// become valid in the rebuilt archive.
+			"artifact_export_queue",
+			`INSERT INTO main.artifact_export_queue(
+				session_id, enqueued_at, generation, pending,
+				rejected_generation, last_error, rejected_at)
+			 SELECT session_id, enqueued_at, generation + 1, 1, NULL, '', NULL
+			 FROM old_db.artifact_export_queue WHERE true
+			 ON CONFLICT(session_id) DO UPDATE SET
+				enqueued_at = CASE
+					WHEN artifact_export_queue.pending = 1 AND excluded.pending = 1
+						THEN min(artifact_export_queue.enqueued_at, excluded.enqueued_at)
+					WHEN artifact_export_queue.pending = 1
+						THEN artifact_export_queue.enqueued_at
+					ELSE excluded.enqueued_at
+				END,
+				generation = max(artifact_export_queue.generation, excluded.generation) + 1,
+				pending = 1,
+				rejected_generation = NULL,
+				last_error = '',
+				rejected_at = NULL`,
+		},
+		{
+			"artifact_publications",
+			`INSERT OR REPLACE INTO main.artifact_publications(
+				origin, session_id, manifest_hash, source_fingerprint)
+			 SELECT origin, session_id, manifest_hash, source_fingerprint
+			 FROM old_db.artifact_publications`,
+		},
+		{
+			"artifact_publication_revisions",
+			`INSERT INTO main.artifact_publication_revisions(origin, revision)
+			 SELECT origin, revision FROM old_db.artifact_publication_revisions WHERE true
+			 ON CONFLICT(origin) DO UPDATE SET
+				revision = max(artifact_publication_revisions.revision, excluded.revision)`,
+		},
+		{
+			"artifact_checkpoint_heads",
+			`INSERT OR REPLACE INTO main.artifact_checkpoint_heads(
+				origin, sequence, publication_revision, session_map_sha256,
+				checkpoint_sha256, checkpoint_size)
+			 SELECT origin, sequence, ` + headRevisionExpr + `, session_map_sha256,
+				checkpoint_sha256, ` + headSizeExpr + `
+			 FROM old_db.artifact_checkpoint_heads`,
+		},
+		{
+			"artifact_checkpoint_floors",
+			`INSERT INTO main.artifact_checkpoint_floors(origin, sequence)
+			 SELECT origin, sequence FROM old_db.artifact_checkpoint_floors WHERE true
+			 ON CONFLICT(origin) DO UPDATE SET
+				sequence = max(artifact_checkpoint_floors.sequence, excluded.sequence)`,
+		},
+	}
+	for _, copy := range artifactCopies {
+		if !oldDBHasTable(ctx, tx, copy.table) {
+			continue
+		}
+		if _, err := tx.ExecContext(ctx, copy.sql); err != nil {
+			return fmt.Errorf("copying %s: %w", copy.table, err)
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT OR IGNORE INTO main.artifact_export_queue(session_id)
+		SELECT id FROM main.sessions
+		WHERE machine = 'local'
+		  AND deleted_at IS NULL
+		  AND EXISTS (
+			SELECT 1 FROM main.pg_sync_state
+			WHERE key = 'artifact_origin_id'
+		  )`); err != nil {
+		return fmt.Errorf("queueing rebuilt sessions for artifact export: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing sync state copy: %w", err)
 	}
 	return nil
 }

--- a/internal/db/orphaned.go
+++ b/internal/db/orphaned.go
@@ -456,7 +456,12 @@ func (d *DB) CopySyncStateFrom(sourcePath string) error {
 	if _, err := tx.ExecContext(ctx, `
 		INSERT OR IGNORE INTO main.artifact_export_queue(session_id)
 		SELECT id FROM main.sessions
-		WHERE machine = 'local'
+		WHERE (
+			machine = 'local' OR machine = (
+				SELECT value FROM main.pg_sync_state
+				WHERE key = 'artifact_local_machine_name'
+			)
+		  )
 		  AND deleted_at IS NULL
 		  AND EXISTS (
 			SELECT 1 FROM main.pg_sync_state

--- a/internal/db/read_only_test.go
+++ b/internal/db/read_only_test.go
@@ -269,8 +269,15 @@ func TestOpenReadOnlyWriteMethodsReturnErrReadOnly(t *testing.T) {
 
 func TestOpenReadOnlyRejectsMissingMigratedColumn(t *testing.T) {
 	path := createClosedTestDB(t, tempDBPath(t, "sessions.db"), nil)
-	execRawSQLite(t, path, "ALTER TABLE sessions DROP COLUMN display_name")
-	requireOpenReadOnlyFails(t, path, "schema missing sessions.display_name")
+	// deletion_cause has no index and is deliberately excluded from the
+	// artifact_sessions_update_queue trigger's change-detection list (it is
+	// sync bookkeeping, not export-relevant), so SQLite's trigger/index-aware
+	// column-drop guard does not block removing it here. A column that the
+	// trigger references (e.g. display_name) or that is indexed (e.g.
+	// local_modified_at) cannot be dropped with DROP COLUMN while that
+	// trigger or index exists.
+	execRawSQLite(t, path, "ALTER TABLE sessions DROP COLUMN deletion_cause")
+	requireOpenReadOnlyFails(t, path, "schema missing sessions.deletion_cause")
 }
 
 func TestReadOnlySchemaCompatibilityRejectsMissingReadColumn(t *testing.T) {

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -118,6 +118,55 @@ CREATE TABLE IF NOT EXISTS messages (
     UNIQUE(session_id, ordinal)
 );
 
+-- Durable, bounded artifact publication state. The export queue intentionally
+-- has no foreign key: a deleted locally-owned session remains pending until a
+-- checkpoint publishes its removal. Acknowledged rows remain as generation
+-- authority, so this table is bounded by historical archive session IDs rather
+-- than only the currently dirty set.
+CREATE TABLE IF NOT EXISTS artifact_export_queue (
+    session_id  TEXT PRIMARY KEY,
+    enqueued_at TEXT NOT NULL
+        DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    -- Compare-and-ack token. Repeated writes retain their FIFO timestamp but
+    -- advance generation, including multiple writes in one SQLite millisecond.
+    generation INTEGER NOT NULL DEFAULT 1,
+    -- Acknowledgement clears pending but retains the row as durable generation
+    -- authority, preventing an old claim from becoming valid after requeue.
+    pending INTEGER NOT NULL DEFAULT 1 CHECK (pending IN (0, 1)),
+    rejected_generation INTEGER,
+    last_error TEXT NOT NULL DEFAULT '',
+    rejected_at TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_artifact_export_queue_pending
+    ON artifact_export_queue(pending, enqueued_at, session_id);
+
+CREATE TABLE IF NOT EXISTS artifact_publications (
+    origin             TEXT NOT NULL,
+    session_id         TEXT NOT NULL,
+    manifest_hash      TEXT NOT NULL,
+    source_fingerprint TEXT NOT NULL,
+    PRIMARY KEY(origin, session_id)
+);
+
+CREATE TABLE IF NOT EXISTS artifact_publication_revisions (
+    origin   TEXT PRIMARY KEY,
+    revision INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS artifact_checkpoint_heads (
+    origin             TEXT PRIMARY KEY,
+    sequence           INTEGER NOT NULL,
+    publication_revision INTEGER NOT NULL,
+    session_map_sha256 TEXT NOT NULL,
+    checkpoint_sha256  TEXT NOT NULL,
+    checkpoint_size    INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS artifact_checkpoint_floors (
+    origin   TEXT PRIMARY KEY,
+    sequence INTEGER NOT NULL
+);
+
 -- Stats table maintained by triggers
 CREATE TABLE IF NOT EXISTS stats (
     key   TEXT PRIMARY KEY,

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -167,6 +167,11 @@ CREATE TABLE IF NOT EXISTS artifact_checkpoint_floors (
     sequence INTEGER NOT NULL
 );
 
+INSERT INTO artifact_checkpoint_floors(origin, sequence)
+SELECT origin, sequence FROM artifact_checkpoint_heads WHERE true
+ON CONFLICT(origin) DO UPDATE SET
+    sequence = max(artifact_checkpoint_floors.sequence, excluded.sequence);
+
 -- Stats table maintained by triggers
 CREATE TABLE IF NOT EXISTS stats (
     key   TEXT PRIMARY KEY,

--- a/internal/db/session_batch.go
+++ b/internal/db/session_batch.go
@@ -325,6 +325,12 @@ func writeOneSessionBatchTx(
 	}
 	replaceMessages := write.ReplaceMessages ||
 		(deletionCause.Valid && deletionCause.String == deletionCauseSourceMissing)
+	queueGenerationBefore, queueExistedBefore, err := artifactExportGenerationTx(
+		tx, write.Session.ID,
+	)
+	if err != nil {
+		return 0, err
+	}
 	replacementTranscriptChanged := false
 	if replaceMessages && sessionExists {
 		stored, err := sessionMessagesTx(
@@ -355,7 +361,7 @@ func writeOneSessionBatchTx(
 		}
 	}
 	if err := replaceSessionUsageEventsTx(
-		tx, write.Session.ID, write.UsageEvents,
+		tx, write.Session.ID, write.UsageEvents, false,
 	); err != nil {
 		return 0, err
 	}
@@ -449,6 +455,11 @@ func writeOneSessionBatchTx(
 	}
 	if err := replaceSecretFindingsTx(tx, write.Session.ID, write.Findings,
 		write.Signals.SecretLeakCount, write.Signals.SecretsRulesVersion); err != nil {
+		return 0, err
+	}
+	if err := enqueueArtifactExportIfGenerationUnchangedTx(
+		tx, write.Session.ID, queueGenerationBefore, queueExistedBefore,
+	); err != nil {
 		return 0, err
 	}
 

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -2870,7 +2870,12 @@ func sqliteLikeEscape(value string) string {
 func (db *DB) ListOwnedSessionIDsForExport(ctx context.Context) ([]string, error) {
 	rows, err := db.getReader().QueryContext(ctx,
 		`SELECT id FROM sessions
-		 WHERE machine = 'local' AND deleted_at IS NULL
+		 WHERE (
+			machine = 'local' OR machine = (
+				SELECT value FROM pg_sync_state
+				WHERE key = 'artifact_local_machine_name'
+			)
+		 ) AND deleted_at IS NULL
 		 ORDER BY id`,
 	)
 	if err != nil {

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -2845,6 +2845,35 @@ func sqliteLikeEscape(value string) string {
 	return value
 }
 
+// ListOwnedSessionIDsForExport returns the IDs of locally-owned, non-deleted
+// sessions for artifact export, ordered by id. Unlike ListSessions it does not
+// apply the sidebar visibility filter (message_count > 0), so zero-message
+// usage-only sessions are still published.
+func (db *DB) ListOwnedSessionIDsForExport(ctx context.Context) ([]string, error) {
+	rows, err := db.getReader().QueryContext(ctx,
+		`SELECT id FROM sessions
+		 WHERE machine = 'local' AND deleted_at IS NULL
+		 ORDER BY id`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("listing sessions for artifact export: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scanning export session ID: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating export session IDs: %w", err)
+	}
+	return ids, nil
+}
+
 // GetDataVersionByPath returns the minimum data_version for non-source-missing
 // sessions matching a file_path. Returns 0 when no eligible session exists.
 func (db *DB) GetDataVersionByPath(path string) int {

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -1084,6 +1084,32 @@ func (db *DB) GetSession(
 func (db *DB) GetSessionFull(
 	ctx context.Context, id string,
 ) (*Session, error) {
+	s, err := db.getSessionFullUncoalesced(ctx, id)
+	if err != nil || s == nil {
+		return s, err
+	}
+	// Expose the visible name (user rename, else agent session name)
+	// like the PG and DuckDB GetSessionFull and the sqlite base reads.
+	// The coalesce happens post-scan because sessionFullCols is shared
+	// with ListSessionsModifiedBetween, whose push consumers must see
+	// display_name and session_name unmerged.
+	if s.DisplayName == nil {
+		s.DisplayName = s.SessionName
+	}
+	return s, nil
+}
+
+// GetArtifactExportSession returns raw user- and agent-owned session names so
+// canonical manifests do not publish session_name as a user display_name.
+func (db *DB) GetArtifactExportSession(
+	ctx context.Context, id string,
+) (*Session, error) {
+	return db.getSessionFullUncoalesced(ctx, id)
+}
+
+func (db *DB) getSessionFullUncoalesced(
+	ctx context.Context, id string,
+) (*Session, error) {
 	row := db.getReader().QueryRowContext(
 		ctx,
 		"SELECT "+sessionFullCols+" FROM sessions WHERE id = ?",
@@ -1133,14 +1159,6 @@ func (db *DB) GetSessionFull(
 	}
 	if err != nil {
 		return nil, fmt.Errorf("getting session full %s: %w", id, err)
-	}
-	// Expose the visible name (user rename, else agent session name)
-	// like the PG and DuckDB GetSessionFull and the sqlite base reads.
-	// The coalesce happens post-scan because sessionFullCols is shared
-	// with ListSessionsModifiedBetween, whose push consumers must see
-	// display_name and session_name unmerged.
-	if s.DisplayName == nil {
-		s.DisplayName = s.SessionName
 	}
 	return &s, nil
 }

--- a/internal/db/usage_events.go
+++ b/internal/db/usage_events.go
@@ -76,7 +76,7 @@ func (db *DB) ReplaceSessionUsageEvents(
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	if err := replaceSessionUsageEventsTx(tx, sessionID, events); err != nil {
+	if err := replaceSessionUsageEventsTx(tx, sessionID, events, true); err != nil {
 		return err
 	}
 
@@ -84,7 +84,7 @@ func (db *DB) ReplaceSessionUsageEvents(
 }
 
 func replaceSessionUsageEventsTx(
-	tx *sql.Tx, sessionID string, events []UsageEvent,
+	tx *sql.Tx, sessionID string, events []UsageEvent, enqueueArtifact bool,
 ) error {
 	if _, err := tx.Exec(
 		`DELETE FROM usage_events WHERE session_id = ?`,
@@ -148,6 +148,11 @@ func replaceSessionUsageEventsTx(
 			"bumping local_modified_at for %s after usage replace: %w",
 			sessionID, err,
 		)
+	}
+	if enqueueArtifact {
+		if err := enqueueArtifactExportTx(tx, sessionID); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -280,7 +285,13 @@ func (db *DB) UsageEventFingerprint(sessionID string) (string, error) {
 func (db *DB) GetUsageEvents(
 	ctx context.Context, sessionID string,
 ) ([]UsageEvent, error) {
-	rows, err := db.getReader().QueryContext(ctx, `
+	return usageEventsWithQuerier(ctx, db.getReader(), sessionID, 0)
+}
+
+func usageEventsWithQuerier(
+	ctx context.Context, q messageRowsQuerier, sessionID string, limit int,
+) ([]UsageEvent, error) {
+	query := `
 		SELECT id, session_id, message_ordinal, source, model,
 			input_tokens, output_tokens,
 			cache_creation_input_tokens, cache_read_input_tokens,
@@ -288,9 +299,13 @@ func (db *DB) GetUsageEvents(
 			occurred_at, dedup_key
 		FROM usage_events
 		WHERE session_id = ?
-		ORDER BY COALESCE(occurred_at, ''), id`,
-		sessionID,
-	)
+		ORDER BY COALESCE(occurred_at, ''), id`
+	args := []any{sessionID}
+	if limit > 0 {
+		query += ` LIMIT ?`
+		args = append(args, limit)
+	}
+	rows, err := q.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("querying usage events: %w", err)
 	}


### PR DESCRIPTION
Second PR in the artifact-sync split (follows #1242, which froze the wire format and added the docbank-backed store). Extracted from the closed #1239 branch with review fixes applied during extraction.

## What this adds

- **SQLite publication ledger** (`internal/db`): `artifact_export_queue`, `artifact_publications`, `artifact_publication_revisions`, `artifact_checkpoint_heads`/`_floors`, plus session triggers that enqueue owned-session changes. Triggers are origin-gated — they fire only once an artifact origin exists in `pg_sync_state` — so archives that never opt in carry no queue writes. Trigger DDL lives in Go and is installed after column migrations (drops run before), so no trigger references session columns while migrations run.
- **Go enqueue hooks** for child-only mutations that don't touch trigger-covered session columns: batch message writes (queue generation sampled around the batch, enqueues exactly once when the triggers didn't fire), standalone usage-event replacement, and token-coverage backfill. Queue bootstrap is an explicit call at origin creation, not a migrate-time backfill.
- **Origin lifecycle** (`internal/artifact`): `EnsureOrigin`/`AdoptOrigin`/`StoredOrigin`. Creating or adopting an origin bootstraps the export queue; a failed bootstrap rolls the origin back (deleting the key when there was none before, since the gates test key existence) so a retry re-runs population. Adopting over a different established origin force-requeues every owned session with a generation bump, because prior acknowledgements belong to the old origin.
- **Checkpointed export pipeline** (`internal/artifact`): claims pending queue rows, publishes content-addressed session manifests and segments into the store, records publication revisions, and advances per-origin checkpoint heads with monotone sequence reservation. Stale claims (a writer advanced the generation mid-export) roll back atomically. Incremental export is bounded by the dirty batch; an unchanged archive costs a catalog identity check only. Full export streams all bodies, then re-checks the queue up to 32 settle rounds — hitting the bound returns the accumulated result with an error meaning "made progress, run again."
- **Resync carriage**: `CopySyncStateFrom` carries queue, publication, revision, and checkpoint state across a full resync and re-dirties every copied queue row — the origin gate keeps triggers silent in the rebuild's temp DB, and a parser bump changes manifest hashes anyway, so the exporter must re-verify each session (unchanged content is cheap to skip, being content-addressed).

## Scope and limitations

- Export-side only. Nothing wires the pipeline to the daemon or CLI yet; that lands with folder transport and import in a later PR. There is no import/read path here.
- The ledger is local SQLite state. PostgreSQL push and shared query shapes are untouched.
- The wire format is unchanged: no golden churn, format stays frozen at v1.

## Where to look

- `internal/db/artifact_publication.go` — queue and ledger SQL, origin-gated enqueue
- `internal/db/db.go` — trigger DDL split around column migrations, bootstrap/requeue
- `internal/artifact/export.go` — publish → manifest → checkpoint ordering and claim lifecycle
- `internal/artifact/origin.go` — origin lifecycle and rollback semantics
- `internal/db/orphaned.go` — resync carriage and the pending-flag decision