### PR TITLE
fix(claude): keep ide context out of session titles

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -75,7 +75,10 @@ Grok section and remove the explicit registry exception in the coverage test.
   `attachment.type=queued_command` are written mid-stream, in file order
   between consecutive `assistant` records that share one `message.id`, so a
   queued command can fall inside a streaming run that straddles an incremental
-  sync boundary.
+  sync boundary. Reverified 2026-07-23 against the transcript shape reported in
+  [#1238](https://github.com/kenn-io/agentsview/issues/1238): Claude Code for
+  VS Code writes standalone `user` records wrapped in `ide_opened_file` or
+  `ide_selection` tags for editor context rather than operator prompts.
 
 ## OpenClaude (`openclaude`)
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -330,7 +330,10 @@ const projectIdentityRemoteScrubCompletedKey = "project_identity_remote_scrub_v1
 // status N" output text, so existing rows carry no failure signal. Re-parsing
 // attaches the errored event so tool-health failure counts cover historical
 // OpenCode sessions on every platform.)
-const dataVersion = 73
+// (74: Claude Code IDE context reparse. Standalone ide_opened_file and
+// ide_selection wrappers are promoted to system metadata so existing
+// VS Code sessions no longer use them as titles or user turns.)
+const dataVersion = 74
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1007,9 +1007,9 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 		"expected tool_result_events table after reopen")
 }
 
-func TestCurrentDataVersionOpenCodeBashExitFailure(t *testing.T) {
-	assert.Equal(t, 73, CurrentDataVersion(),
-		"OpenCode bash metadata.exit failure detection requires a data version bump")
+func TestCurrentDataVersionClaudeIDEContext(t *testing.T) {
+	assert.Equal(t, 74, CurrentDataVersion(),
+		"Claude IDE context parsing requires a data version bump")
 }
 
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -2431,7 +2431,7 @@ func isCommandEnvelope(content string) bool {
 	return strings.TrimSpace(stripped) == ""
 }
 
-// isSkippablePreviewCommand returns true when content is a Claude
+// IsSkippablePreviewCommand returns true when content is a Claude
 // Code slash command (e.g. /login, /plan, /roborev-fix). Detection
 // is generic: the trimmed content must start with "/" followed by one
 // or more letters, digits, hyphens, or underscores, then either end
@@ -2439,7 +2439,7 @@ func isCommandEnvelope(content string) bool {
 // because command envelopes normalise to names like /skill-name.
 // File-path references like "/usr/local/bin gives an error" are not
 // skipped because the embedded "/" terminates the match.
-func isSkippablePreviewCommand(content string) bool {
+func IsSkippablePreviewCommand(content string) bool {
 	trimmed := strings.TrimSpace(content)
 	if !strings.HasPrefix(trimmed, "/") {
 		return false
@@ -2481,7 +2481,7 @@ func firstMessageAndUserCount(
 		}
 		userCount++
 		if firstMsg == "" &&
-			!isSkippablePreviewCommand(m.Content) {
+			!IsSkippablePreviewCommand(m.Content) {
 			firstMsg = truncate(
 				strings.ReplaceAll(m.Content, "\n", " "), 300,
 			)

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -1169,9 +1169,8 @@ func parseLinear(
 	endedAt = laterTime(globalEnd, endedAt)
 	annotateSubagentSessions(messages, subagentMap)
 
-	// Promoted system messages (continuation/resume/interrupted/
-	// task_notification/stop_hook) carry Role=user so role-keyed
-	// analytics ignore them, but they are not real user turns;
+	// Promoted system messages carry Role=user so role-keyed analytics
+	// ignore them, but they are not real user turns;
 	// firstMessageAndUserCount skips them when computing
 	// user_message_count / first_message. It also skips leading
 	// /clear and /effort command envelopes so the sidebar shows
@@ -1982,11 +1981,10 @@ func pathWithinDir(path, dir string) bool {
 		rel != ".."
 }
 
-// countUserTurns counts all user entries reachable from a
-// starting index by traversing the entire subtree. Earlier
-// versions followed only the first child at each node, which
-// undercounted in sessions with many nested forks and caused
-// the fork heuristic to discard the main conversation branch.
+// countUserTurns counts real user entries reachable from a starting index
+// by traversing the entire subtree. System-injected user records must not
+// influence branch selection because they are promoted to system metadata
+// when messages are extracted.
 func countUserTurns(
 	entries []dagEntry,
 	children map[string][]int,
@@ -1997,12 +1995,23 @@ func countUserTurns(
 	for len(stack) > 0 {
 		current := stack[len(stack)-1]
 		stack = stack[:len(stack)-1]
-		if entries[current].entryType == "user" {
+		if isCountedClaudeUserTurn(entries[current]) {
 			count++
 		}
 		stack = append(stack, children[entries[current].uuid]...)
 	}
 	return count
+}
+
+func isCountedClaudeUserTurn(entry dagEntry) bool {
+	if entry.entryType != "user" ||
+		gjson.Get(entry.line, "isMeta").Bool() ||
+		gjson.Get(entry.line, "isCompactSummary").Bool() {
+		return false
+	}
+	content := gjson.Get(entry.line, "message.content")
+	text, _, _, _, _, _ := ExtractTextContent(content)
+	return classifyClaudeSystemMessage(text) == ""
 }
 
 // extractMessages converts dagEntries into ParsedMessages, applying
@@ -2565,8 +2574,26 @@ func classifyClaudeSystemMessage(content string) string {
 			return ""
 		}
 		return "system_reminder"
+	case isStandaloneClaudeTaggedMessage(trimmed, "ide_opened_file"):
+		return "ide_opened_file"
+	case isStandaloneClaudeTaggedMessage(trimmed, "ide_selection"):
+		return "ide_selection"
 	}
 	return ""
+}
+
+func isStandaloneClaudeTaggedMessage(content, tag string) bool {
+	trimmed := strings.TrimSpace(content)
+	openTag := "<" + tag + ">"
+	closeTag := "</" + tag + ">"
+	if !strings.HasPrefix(trimmed, openTag) ||
+		!strings.HasSuffix(trimmed, closeTag) {
+		return false
+	}
+
+	afterOpen := trimmed[len(openTag):]
+	return strings.Index(afterOpen, closeTag) ==
+		len(afterOpen)-len(closeTag)
 }
 
 func stripLeadingClaudeSystemReminderContent(content string) string {

--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -2011,7 +2011,11 @@ func isCountedClaudeUserTurn(entry dagEntry) bool {
 	}
 	content := gjson.Get(entry.line, "message.content")
 	text, _, _, _, _, _ := ExtractTextContent(content)
-	return classifyClaudeSystemMessage(text) == ""
+	text, skip := preprocessClaudeUserText(text)
+	if skip || strings.TrimSpace(text) == "" {
+		return false
+	}
+	return !isClaudeSystemMessage(text)
 }
 
 // extractMessages converts dagEntries into ParsedMessages, applying

--- a/internal/parser/claude_parser_test.go
+++ b/internal/parser/claude_parser_test.go
@@ -285,20 +285,29 @@ func TestParseClaudeSession_SkippedMessages(t *testing.T) {
 			// Non-caveat local-command is pure noise and stays skipped.
 			testjsonl.ClaudeUserJSON("<local-command-result>ok</local-command-result>", "2024-01-01T00:00:05Z"),
 			testjsonl.ClaudeUserJSON("Stop hook feedback: rejected", "2024-01-01T00:00:06Z"),
-			testjsonl.ClaudeUserJSON("real user message", "2024-01-01T00:00:07Z"),
+			testjsonl.ClaudeUserJSON(
+				"<ide_opened_file>The user opened /workspace/app/README.md.</ide_opened_file>",
+				"2024-01-01T00:00:07Z",
+			),
+			testjsonl.ClaudeUserJSON(
+				"<ide_selection>The user selected package main.</ide_selection>",
+				"2024-01-01T00:00:08Z",
+			),
+			testjsonl.ClaudeUserJSON("real user message", "2024-01-01T00:00:09Z"),
 		)
 		sess, msgs := runClaudeParserTest(t, "test.jsonl", content)
-		// 5 promoted system + 1 real user; <local-command-result>
+		// 7 promoted system + 1 real user; <local-command-result>
 		// is still skipped.
-		assert.Equal(t, 6, sess.MessageCount)
+		assert.Equal(t, 8, sess.MessageCount)
 		assert.Equal(t, 1, sess.UserMessageCount)
 		assert.Equal(t, "real user message", sess.FirstMessage)
 
 		wantSubtypes := []string{
 			"continuation", "interrupted", "resume",
 			"task_notification", "stop_hook",
+			"ide_opened_file", "ide_selection",
 		}
-		require.Len(t, msgs, 6)
+		require.Len(t, msgs, 8)
 		for i, want := range wantSubtypes {
 			assert.True(t, msgs[i].IsSystem,
 				"msgs[%d] should be system", i)
@@ -310,9 +319,9 @@ func TestParseClaudeSession_SkippedMessages(t *testing.T) {
 			assert.Equal(t, want, msgs[i].SourceSubtype)
 		}
 		// Final message is the real user message.
-		assert.False(t, msgs[5].IsSystem)
-		assert.Equal(t, RoleUser, msgs[5].Role)
-		assert.Equal(t, "real user message", msgs[5].Content)
+		assert.False(t, msgs[7].IsSystem)
+		assert.Equal(t, RoleUser, msgs[7].Role)
+		assert.Equal(t, "real user message", msgs[7].Content)
 	})
 
 	t.Run("skill invocation shown as user message", func(t *testing.T) {
@@ -819,6 +828,45 @@ func TestParseClaudeSessionFrom_QueuedSystemMessage(t *testing.T) {
 	assert.True(t, newMsgs[0].IsSystem)
 	assert.Equal(t, "system", newMsgs[0].SourceType)
 	assert.Equal(t, "system_reminder", newMsgs[0].SourceSubtype)
+}
+
+func TestParseClaudeSessionFrom_IDEContext(t *testing.T) {
+	t.Parallel()
+
+	initial := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON("hello", tsEarly),
+		testjsonl.ClaudeAssistantJSON("hi", tsEarlyS1),
+	)
+	path := createTestFile(t, "inc-ide-context.jsonl", initial)
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+
+	appended := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON(
+			"<ide_opened_file>The user opened /workspace/app/README.md.</ide_opened_file>",
+			tsEarlyS5,
+		),
+		testjsonl.ClaudeUserJSON(
+			"<ide_selection>The user selected package main.</ide_selection>",
+			tsLate,
+		),
+	)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.WriteString(appended)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	newMsgs, _, _, err := callParseClaudeSessionFrom(path, info.Size(), 2, "")
+	require.NoError(t, err)
+	require.Len(t, newMsgs, 2)
+	for i, subtype := range []string{"ide_opened_file", "ide_selection"} {
+		assert.Equal(t, RoleUser, newMsgs[i].Role)
+		assert.True(t, newMsgs[i].IsSystem)
+		assert.Equal(t, "system", newMsgs[i].SourceType)
+		assert.Equal(t, subtype, newMsgs[i].SourceSubtype)
+		assert.Equal(t, i+2, newMsgs[i].Ordinal)
+	}
 }
 
 func TestParseClaudeSessionFrom_ReminderPrefixedCommand(t *testing.T) {
@@ -2578,6 +2626,10 @@ func TestClassifyClaudeSystemMessage(t *testing.T) {
 		{"system_reminder", "<system-reminder>remember this</system-reminder>", "system_reminder"},
 		{"system_reminder plus prompt", "<system-reminder>remember this</system-reminder>\n\nreal prompt", ""},
 		{"malformed system_reminder", "<system-reminder>literal tag at the start", ""},
+		{"opened file", "\uFEFF  <ide_opened_file>The user opened README.md.</ide_opened_file>\n", "ide_opened_file"},
+		{"selection", "<ide_selection>The user selected package main.</ide_selection>", "ide_selection"},
+		{"selection plus prompt", "<ide_selection>package main</ide_selection>\n\nexplain this", ""},
+		{"malformed opened file", "<ide_opened_file>The user opened README.md.", ""},
 		{"task-notification-status", "<task-notification-status>ready", ""},
 		{"bom prefix", "\uFEFF  This session is being continued", "continuation"},
 		{"non-caveat local-command", "<local-command-stdout>foo</local-command-stdout>", ""},

--- a/internal/parser/claude_parser_test.go
+++ b/internal/parser/claude_parser_test.go
@@ -2723,7 +2723,7 @@ func TestIsSkippablePreviewCommand(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := isSkippablePreviewCommand(tc.content)
+			got := IsSkippablePreviewCommand(tc.content)
 			assert.Equal(t, tc.want, got,
 				"content=%q", tc.content)
 		})

--- a/internal/parser/fork_test.go
+++ b/internal/parser/fork_test.go
@@ -117,28 +117,31 @@ func TestForkDetection_SmallGapRetry(t *testing.T) {
 	assertMessage(t, results[0].Messages[3], RoleAssistant, "retry answer")
 }
 
-func TestForkDetection_IDEContextDoesNotPromoteObsoleteBranch(t *testing.T) {
+func TestForkDetection_ReminderPrefixedIDEContextDoesNotPromoteObsoleteBranch(
+	t *testing.T,
+) {
+	const reminder = "<system-reminder>context</system-reminder>\n"
 	content := testjsonl.NewSessionBuilder().
 		AddClaudeUserWithUUID("2024-01-01T10:00:00Z", "start", "a", "").
 		AddClaudeAssistantWithUUID("2024-01-01T10:00:01Z", "ok", "b", "a").
 		AddClaudeUserWithUUID(
 			"2024-01-01T10:00:02Z",
-			"<ide_opened_file>one</ide_opened_file>",
+			reminder+"<ide_opened_file>one</ide_opened_file>",
 			"c", "b",
 		).
 		AddClaudeUserWithUUID(
 			"2024-01-01T10:00:03Z",
-			"<ide_selection>two</ide_selection>",
+			reminder+"<ide_selection>two</ide_selection>",
 			"d", "c",
 		).
 		AddClaudeUserWithUUID(
 			"2024-01-01T10:00:04Z",
-			"<ide_opened_file>three</ide_opened_file>",
+			reminder+"<ide_opened_file>three</ide_opened_file>",
 			"e", "d",
 		).
 		AddClaudeUserWithUUID(
 			"2024-01-01T10:00:05Z",
-			"<ide_selection>four</ide_selection>",
+			reminder+"<ide_selection>four</ide_selection>",
 			"f", "e",
 		).
 		AddClaudeUserWithUUID(

--- a/internal/parser/fork_test.go
+++ b/internal/parser/fork_test.go
@@ -117,6 +117,44 @@ func TestForkDetection_SmallGapRetry(t *testing.T) {
 	assertMessage(t, results[0].Messages[3], RoleAssistant, "retry answer")
 }
 
+func TestForkDetection_IDEContextDoesNotPromoteObsoleteBranch(t *testing.T) {
+	content := testjsonl.NewSessionBuilder().
+		AddClaudeUserWithUUID("2024-01-01T10:00:00Z", "start", "a", "").
+		AddClaudeAssistantWithUUID("2024-01-01T10:00:01Z", "ok", "b", "a").
+		AddClaudeUserWithUUID(
+			"2024-01-01T10:00:02Z",
+			"<ide_opened_file>one</ide_opened_file>",
+			"c", "b",
+		).
+		AddClaudeUserWithUUID(
+			"2024-01-01T10:00:03Z",
+			"<ide_selection>two</ide_selection>",
+			"d", "c",
+		).
+		AddClaudeUserWithUUID(
+			"2024-01-01T10:00:04Z",
+			"<ide_opened_file>three</ide_opened_file>",
+			"e", "d",
+		).
+		AddClaudeUserWithUUID(
+			"2024-01-01T10:00:05Z",
+			"<ide_selection>four</ide_selection>",
+			"f", "e",
+		).
+		AddClaudeUserWithUUID(
+			"2024-01-01T10:01:00Z", "real retry", "z", "b",
+		).
+		AddClaudeAssistantWithUUID(
+			"2024-01-01T10:01:01Z", "retry answer", "zz", "z",
+		).
+		String()
+
+	results := parseTestContent(t, "ide-context-fork.jsonl", content, 1)
+	require.Len(t, results[0].Messages, 4)
+	assert.Equal(t, "real retry", results[0].Messages[2].Content)
+	assert.Equal(t, "retry answer", results[0].Messages[3].Content)
+}
+
 func TestForkDetection_NoUUIDs(t *testing.T) {
 	// Entries without uuid fields — should work as before, 1 result.
 	content := testjsonl.NewSessionBuilder().

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -8507,21 +8507,6 @@ func (e *Engine) tryIncrementalJSONL(
 		return processResult{}, false
 	}
 
-	// Claude-only: if the stored preview is empty, the parser has
-	// not seen a real user prompt yet (e.g. a session that opens
-	// with IDE context, /clear, or /effort). Fall back to a full
-	// parse so any real user message appended this sync becomes
-	// first_message.
-	//
-	// Other agents can legitimately have UserMsgCount > 0 with
-	// an empty first_message — for example Codex inserts orphan
-	// subagent notifications as Role=user messages that bypass
-	// firstMessage — so this fall-through is gated on Claude.
-	if agent == parser.AgentClaude &&
-		inc.FirstMessage == "" {
-		return processResult{}, false
-	}
-
 	currentSize := info.Size()
 
 	// A prior sync that stored no message rows has no safe append
@@ -8706,6 +8691,31 @@ func (e *Engine) tryIncrementalJSONL(
 				return processResult{forceReplace: true}, false
 			}
 		}
+	}
+
+	// Claude-only: an empty stored preview means no real user prompt
+	// has been parsed yet (a session that starts with injected IDE
+	// context, a continuation record, /clear, or /effort). When this
+	// chunk carries the first real prompt, fall back to a full parse
+	// so first_message is re-derived from the whole file. Chunks
+	// without one — streamed assistant work after an auto-compact
+	// continuation, or more injected IDE context — stay incremental
+	// so per-event work is bounded by the appended bytes rather than
+	// the transcript size.
+	//
+	// Other agents can legitimately have an empty first_message
+	// alongside real user rows — for example Codex inserts orphan
+	// subagent notifications as Role=user messages that bypass
+	// firstMessage — so this fall-through is gated on Claude.
+	if agent == parser.AgentClaude && inc.FirstMessage == "" &&
+		chunkHasRealUserPrompt(newMsgs) {
+		log.Printf(
+			"incremental %s %s: first real user prompt after "+
+				"empty preview, full parse",
+			agent, file.Path,
+		)
+		lease.Release()
+		return processResult{}, false
 	}
 
 	newUserCount := countUserMsgs(newMsgs)
@@ -11695,6 +11705,25 @@ func postFilterCounts(msgs []db.Message) (total, user int) {
 		}
 	}
 	return len(msgs), user
+}
+
+// chunkHasRealUserPrompt reports whether msgs contains a message the
+// Claude parser would use as first_message (mirroring the firstMsg
+// rule in firstMessageAndUserCount): role user, not system-injected,
+// non-empty content, and not a bare slash command. Promoted system
+// records (IDE context, continuation, stop-hook), tool-result-only
+// rows, and preview-skipped commands like /clear do not qualify —
+// a full parse triggered by those would leave first_message empty
+// and the next append would full-parse again.
+func chunkHasRealUserPrompt(msgs []parser.ParsedMessage) bool {
+	for _, m := range msgs {
+		if m.Role == parser.RoleUser && !m.IsSystem &&
+			m.Content != "" &&
+			!parser.IsSkippablePreviewCommand(m.Content) {
+			return true
+		}
+	}
+	return false
 }
 
 // countUserMsgs counts user messages in parsed messages.

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -8507,18 +8507,18 @@ func (e *Engine) tryIncrementalJSONL(
 		return processResult{}, false
 	}
 
-	// Claude-only: if the stored preview is empty despite the
-	// session already having user turns, the parser skipped
-	// every user message so far (e.g. a session that opens with
-	// /clear or /effort). Fall back to a full parse so any real
-	// user message appended this sync becomes first_message.
+	// Claude-only: if the stored preview is empty, the parser has
+	// not seen a real user prompt yet (e.g. a session that opens
+	// with IDE context, /clear, or /effort). Fall back to a full
+	// parse so any real user message appended this sync becomes
+	// first_message.
 	//
 	// Other agents can legitimately have UserMsgCount > 0 with
 	// an empty first_message — for example Codex inserts orphan
 	// subagent notifications as Role=user messages that bypass
 	// firstMessage — so this fall-through is gated on Claude.
 	if agent == parser.AgentClaude &&
-		inc.FirstMessage == "" && inc.UserMsgCount > 0 {
+		inc.FirstMessage == "" {
 		return processResult{}, false
 	}
 

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -13598,6 +13598,154 @@ func TestIncrementalSync_ClaudeIDEContextOnlyRepairedOnAppend(t *testing.T) {
 		updated.UserMessageCount)
 }
 
+// A Claude session can hold an empty preview for a long time — after
+// an auto-compact the new file starts with a promoted continuation
+// record and can stream assistant work for hours before the next real
+// prompt. Appends without a real prompt must stay on the incremental
+// path so per-event work is bounded by the appended bytes, not the
+// transcript size. The already-consumed prefix is overwritten with
+// garbage after the first sync as a tripwire: the incremental path
+// never re-reads it, while a fall-through to a full parse would parse
+// the garbage, drop the stored continuation row, and change the
+// session counts.
+func TestIncrementalSync_ClaudeEmptyPreviewAppendStaysIncremental(t *testing.T) {
+	env := setupTestEnv(t)
+
+	initial := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON(
+			"This session is being continued from a previous "+
+				"conversation that ran out of context.",
+			tsZero,
+		),
+	)
+	path := env.writeClaudeSession(
+		t, "proj", "continuation-only.jsonl", initial,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+
+	full, err := env.db.GetSessionFull(
+		context.Background(), "continuation-only",
+	)
+	require.NoError(t, err, "GetSessionFull after initial sync")
+	require.Equal(t, 1, full.MessageCount,
+		"initial MessageCount = %d, want 1", full.MessageCount)
+	require.Zero(t, full.UserMessageCount,
+		"initial UserMessageCount = %d, want 0", full.UserMessageCount)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err, "stat before corrupting prefix")
+	garbage := strings.Repeat("x", int(info.Size())-1) + "\n"
+	f, err := os.OpenFile(path, os.O_WRONLY, 0o644)
+	require.NoError(t, err, "open for prefix rewrite")
+	_, err = f.WriteAt([]byte(garbage), 0)
+	require.NoError(t, err, "rewrite consumed prefix")
+	require.NoError(t, f.Close(), "close after prefix rewrite")
+
+	// None of these qualify as a first real prompt: injected IDE
+	// context is promoted to a system row, /clear is a
+	// preview-skipped command that cannot become first_message,
+	// and assistant output is not a user turn.
+	appended := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON(
+			"<ide_opened_file>The user opened /workspace/app/README.md.</ide_opened_file>",
+			tsZeroS1,
+		),
+		testjsonl.ClaudeUserJSON(
+			"<command-name>/clear</command-name>",
+			"2024-01-01T00:00:02Z",
+		),
+		testjsonl.ClaudeAssistantJSON("still working", tsZeroS5),
+	)
+	f, err = os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err, "open for append")
+	_, err = f.WriteString(appended)
+	require.NoError(t, err, "append")
+	require.NoError(t, f.Close(), "close after append")
+
+	env.engine.SyncPaths([]string{path})
+
+	updated, err := env.db.GetSessionFull(
+		context.Background(), "continuation-only",
+	)
+	require.NoError(t, err, "GetSessionFull after append")
+	assert.Equal(t, 4, updated.MessageCount,
+		"MessageCount after append = %d, want 4 (a full parse "+
+			"would have re-read the corrupted prefix)",
+		updated.MessageCount)
+	assert.Equal(t, 1, updated.UserMessageCount,
+		"UserMessageCount after append = %d, want 1 (the /clear "+
+			"turn only)",
+		updated.UserMessageCount)
+	if updated.FirstMessage != nil {
+		assert.Equal(t, "", *updated.FirstMessage,
+			"FirstMessage after append = %q, want empty",
+			*updated.FirstMessage)
+	}
+}
+
+// The empty-preview repair must still fire when the first real prompt
+// arrives only after earlier promptless appends were consumed
+// incrementally.
+func TestIncrementalSync_ClaudeEmptyPreviewRepairedOnLaterPrompt(t *testing.T) {
+	env := setupTestEnv(t)
+
+	initial := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON(
+			"This session is being continued from a previous "+
+				"conversation that ran out of context.",
+			tsZero,
+		),
+	)
+	path := env.writeClaudeSession(
+		t, "proj", "continuation-late-prompt.jsonl", initial,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+
+	appendLine := func(line string) {
+		f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+		require.NoError(t, err, "open for append")
+		_, err = f.WriteString(line + "\n")
+		require.NoError(t, err, "append")
+		require.NoError(t, f.Close(), "close after append")
+	}
+
+	appendLine(testjsonl.ClaudeUserJSON(
+		"<ide_selection>The user selected package main.</ide_selection>",
+		tsZeroS1,
+	))
+	env.engine.SyncPaths([]string{path})
+
+	mid, err := env.db.GetSessionFull(
+		context.Background(), "continuation-late-prompt",
+	)
+	require.NoError(t, err, "GetSessionFull after IDE append")
+	require.Equal(t, 2, mid.MessageCount,
+		"MessageCount after IDE append = %d, want 2", mid.MessageCount)
+	require.Zero(t, mid.UserMessageCount,
+		"UserMessageCount after IDE append = %d, want 0",
+		mid.UserMessageCount)
+
+	appendLine(testjsonl.ClaudeUserJSON("Explain this code", tsZeroS5))
+	env.engine.SyncPaths([]string{path})
+
+	updated, err := env.db.GetSessionFull(
+		context.Background(), "continuation-late-prompt",
+	)
+	require.NoError(t, err, "GetSessionFull after prompt append")
+	require.NotNil(t, updated.FirstMessage,
+		"FirstMessage after prompt append = nil, want %q",
+		"Explain this code")
+	assert.Equal(t, "Explain this code", *updated.FirstMessage,
+		"FirstMessage after prompt append = %q, want %q",
+		*updated.FirstMessage, "Explain this code")
+	assert.Equal(t, 1, updated.UserMessageCount,
+		"UserMessageCount after prompt append = %d, want 1",
+		updated.UserMessageCount)
+	assert.Equal(t, 3, updated.MessageCount,
+		"MessageCount after prompt append = %d, want 3",
+		updated.MessageCount)
+}
+
 // TestIncrementalSync_CodexReemittedPromptDedupedOnAppend covers
 // the case where Codex re-emits the initial prompt verbatim on a
 // continued turn. The duplicate is appended after the first sync,

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -13542,6 +13542,62 @@ func TestIncrementalSync_ClaudeClearOnlyRepairedOnAppend(t *testing.T) {
 	assert.Equal(t, 2, updated.UserMessageCount, "UserMessageCount after append = %d, want 2", updated.UserMessageCount)
 }
 
+func TestIncrementalSync_ClaudeIDEContextOnlyRepairedOnAppend(t *testing.T) {
+	env := setupTestEnv(t)
+
+	// Initial sync: Claude has only emitted injected IDE context,
+	// so there is no real user prompt to use as the title.
+	initial := testjsonl.JoinJSONL(
+		testjsonl.ClaudeUserJSON(
+			"<ide_opened_file>The user opened /workspace/app/README.md.</ide_opened_file>",
+			tsZero,
+		),
+	)
+	path := env.writeClaudeSession(
+		t, "proj", "ide-context-only.jsonl", initial,
+	)
+	env.engine.SyncAll(context.Background(), nil)
+
+	full, err := env.db.GetSessionFull(
+		context.Background(), "ide-context-only",
+	)
+	require.NoError(t, err, "GetSessionFull after initial sync")
+	if full.FirstMessage != nil {
+		require.Equal(t, "", *full.FirstMessage,
+			"initial FirstMessage = %q, want empty", *full.FirstMessage)
+	}
+	require.Zero(t, full.UserMessageCount,
+		"initial UserMessageCount = %d, want 0", full.UserMessageCount)
+
+	// Appending the first real prompt must force a full parse so
+	// first_message is derived instead of remaining permanently empty.
+	appended := testjsonl.ClaudeUserJSON(
+		"Explain this code", tsZeroS1,
+	) + "\n"
+	f, err := os.OpenFile(
+		path, os.O_APPEND|os.O_WRONLY, 0o644,
+	)
+	require.NoError(t, err, "open for append")
+	_, err = f.WriteString(appended)
+	require.NoError(t, err, "append")
+	require.NoError(t, f.Close(), "close")
+
+	env.engine.SyncPaths([]string{path})
+
+	updated, err := env.db.GetSessionFull(
+		context.Background(), "ide-context-only",
+	)
+	require.NoError(t, err, "GetSessionFull after append")
+	require.NotNil(t, updated.FirstMessage,
+		"FirstMessage after append = nil, want %q", "Explain this code")
+	assert.Equal(t, "Explain this code", *updated.FirstMessage,
+		"FirstMessage after append = %q, want %q",
+		*updated.FirstMessage, "Explain this code")
+	assert.Equal(t, 1, updated.UserMessageCount,
+		"UserMessageCount after append = %d, want 1",
+		updated.UserMessageCount)
+}
+
 // TestIncrementalSync_CodexReemittedPromptDedupedOnAppend covers
 // the case where Codex re-emits the initial prompt verbatim on a
 // continued turn. The duplicate is appended after the first sync,

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -13603,11 +13603,7 @@ func TestIncrementalSync_ClaudeIDEContextOnlyRepairedOnAppend(t *testing.T) {
 // record and can stream assistant work for hours before the next real
 // prompt. Appends without a real prompt must stay on the incremental
 // path so per-event work is bounded by the appended bytes, not the
-// transcript size. The already-consumed prefix is overwritten with
-// garbage after the first sync as a tripwire: the incremental path
-// never re-reads it, while a fall-through to a full parse would parse
-// the garbage, drop the stored continuation row, and change the
-// session counts.
+// transcript size.
 func TestIncrementalSync_ClaudeEmptyPreviewAppendStaysIncremental(t *testing.T) {
 	env := setupTestEnv(t)
 
@@ -13632,15 +13628,6 @@ func TestIncrementalSync_ClaudeEmptyPreviewAppendStaysIncremental(t *testing.T) 
 	require.Zero(t, full.UserMessageCount,
 		"initial UserMessageCount = %d, want 0", full.UserMessageCount)
 
-	info, err := os.Stat(path)
-	require.NoError(t, err, "stat before corrupting prefix")
-	garbage := strings.Repeat("x", int(info.Size())-1) + "\n"
-	f, err := os.OpenFile(path, os.O_WRONLY, 0o644)
-	require.NoError(t, err, "open for prefix rewrite")
-	_, err = f.WriteAt([]byte(garbage), 0)
-	require.NoError(t, err, "rewrite consumed prefix")
-	require.NoError(t, f.Close(), "close after prefix rewrite")
-
 	// None of these qualify as a first real prompt: injected IDE
 	// context is promoted to a system row, /clear is a
 	// preview-skipped command that cannot become first_message,
@@ -13656,7 +13643,7 @@ func TestIncrementalSync_ClaudeEmptyPreviewAppendStaysIncremental(t *testing.T) 
 		),
 		testjsonl.ClaudeAssistantJSON("still working", tsZeroS5),
 	)
-	f, err = os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
 	require.NoError(t, err, "open for append")
 	_, err = f.WriteString(appended)
 	require.NoError(t, err, "append")
@@ -13668,14 +13655,12 @@ func TestIncrementalSync_ClaudeEmptyPreviewAppendStaysIncremental(t *testing.T) 
 		context.Background(), "continuation-only",
 	)
 	require.NoError(t, err, "GetSessionFull after append")
+	assert.True(t, updated.LastWriteIncremental,
+		"promptless append should use the incremental write path")
 	assert.Equal(t, 4, updated.MessageCount,
-		"MessageCount after append = %d, want 4 (a full parse "+
-			"would have re-read the corrupted prefix)",
-		updated.MessageCount)
+		"MessageCount after append = %d, want 4", updated.MessageCount)
 	assert.Equal(t, 1, updated.UserMessageCount,
-		"UserMessageCount after append = %d, want 1 (the /clear "+
-			"turn only)",
-		updated.UserMessageCount)
+		"UserMessageCount after append = %d, want 1", updated.UserMessageCount)
 	if updated.FirstMessage != nil {
 		assert.Equal(t, "", *updated.FirstMessage,
 			"FirstMessage after append = %q, want empty",


### PR DESCRIPTION
the claude code vscode extension writes file-open and selection hints as standalone user-role xml envelopes. agentsview currently treats them as operator prompts, so they can become sidebar titles, count as user turns, and render raw markup.

complete standalone `ide_opened_file` and `ide_selection` envelopes now promote to hidden system metadata with distinct subtypes. the match is intentionally strict, so malformed wrappers and messages with real prompt text remain ordinary user content.

dag fork selection applies the same user-text preprocessing before counting turns, so reminder-prefixed ide context cannot promote an obsolete branch. incremental sync keeps promptless ide and continuation appends bounded to the new bytes, falling back to a full parse only when the first title-eligible prompt arrives.

the source data version advances to 74 because main now uses 73 for opencode bash exit-failure detection. existing sqlite archives are reparsed on upgrade, and duckdb mirrors rebuild on their next push through the independent source data-version gate; the mirror schema is unchanged.

closes #1238
