### PR TITLE
fix(parser): detect opencode invalid tool calls as failures

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -228,6 +228,13 @@ Grok section and remove the explicit registry exception in the coverage test.
   prefers a concrete `session.directory` over `project.worktree` when resolving
   cwd/project (verified against live `opencode.db` rows under `project_id=global`
   on 2026-07-23; see #1236).
+- **Invalid tool calls:** Model calls to unknown or malformed tools are
+  recorded as a synthetic `invalid` tool part whose `execute` succeeds
+  (`packages/opencode/src/tool/invalid.ts`, registered in
+  `packages/opencode/src/tool/registry.ts` at the pinned commit), so
+  `state.status` is `completed` with the error text in the output. Agentsview
+  attaches an errored result event to `tool:"invalid"` parts so tool health
+  counts them as failures (verified 2026-07-24; see #1254).
 - **Agentsview:** `internal/parser/opencode.go`,
   `internal/parser/opencode_provider.go`, and
   `internal/parser/opencode_storage_state.go`; legacy and database layouts are

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -321,7 +321,11 @@ const projectIdentityRemoteScrubCompletedKey = "project_identity_remote_scrub_v1
 // (71: OpenCode SQLite cwd/project derivation now prefers a concrete
 // session.directory over the synthetic global project worktree "/". Existing
 // OpenCode rows need re-parsing so unchanged sessions refresh cwd and project.)
-const dataVersion = 71
+// (72: OpenCode invalid tool calls emit an errored result event. OpenCode
+// records unknown-tool calls as a synthetic "invalid" tool that completes
+// successfully, so existing rows carry no failure signal. Re-parsing attaches
+// the errored event so tool-health failure counts cover historical sessions.)
+const dataVersion = 72
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1007,9 +1007,9 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 		"expected tool_result_events table after reopen")
 }
 
-func TestCurrentDataVersionOpenCodeSessionDirectory(t *testing.T) {
-	assert.Equal(t, 71, CurrentDataVersion(),
-		"OpenCode cwd/project derivation requires a data version bump")
+func TestCurrentDataVersionOpenCodeInvalidToolFailure(t *testing.T) {
+	assert.Equal(t, 72, CurrentDataVersion(),
+		"OpenCode invalid-tool failure detection requires a data version bump")
 }
 
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {

--- a/internal/parser/opencode.go
+++ b/internal/parser/opencode.go
@@ -993,7 +993,10 @@ func extractOpenCodeToolCall(data, cwd string) ParsedToolCall {
 		return ParsedToolCall{}
 	}
 
-	var inputJSON string
+	var (
+		inputJSON  string
+		isFailure  bool
+	)
 	if len(d.State) > 0 {
 		var state openCodeToolState
 		if err := json.Unmarshal(d.State, &state); err == nil {
@@ -1001,6 +1004,10 @@ func extractOpenCodeToolCall(data, cwd string) ParsedToolCall {
 				inputJSON = string(state.Input)
 			}
 		}
+	}
+
+	if d.ToolName == "invalid" {
+		isFailure = true
 	}
 
 	var skillName string
@@ -1014,13 +1021,22 @@ func extractOpenCodeToolCall(data, cwd string) ParsedToolCall {
 		skillName = inferOpenCodeSkillName(d.ToolName, inputJSON, cwd)
 	}
 
-	return ParsedToolCall{
+	tc := ParsedToolCall{
 		ToolUseID: d.CallID,
 		ToolName:  d.ToolName,
 		Category:  NormalizeToolCategory(d.ToolName),
 		InputJSON: inputJSON,
 		SkillName: skillName,
 	}
+
+	if isFailure {
+		tc.ResultEvents = append(tc.ResultEvents, ParsedToolResultEvent{
+			ToolUseID: d.CallID,
+			Status:    "errored",
+		})
+	}
+
+	return tc
 }
 
 func inferOpenCodeSkillName(toolName, inputJSON, cwd string) string {

--- a/internal/parser/opencode.go
+++ b/internal/parser/opencode.go
@@ -993,10 +993,7 @@ func extractOpenCodeToolCall(data, cwd string) ParsedToolCall {
 		return ParsedToolCall{}
 	}
 
-	var (
-		inputJSON  string
-		isFailure  bool
-	)
+	var inputJSON string
 	if len(d.State) > 0 {
 		var state openCodeToolState
 		if err := json.Unmarshal(d.State, &state); err == nil {
@@ -1004,10 +1001,6 @@ func extractOpenCodeToolCall(data, cwd string) ParsedToolCall {
 				inputJSON = string(state.Input)
 			}
 		}
-	}
-
-	if d.ToolName == "invalid" {
-		isFailure = true
 	}
 
 	var skillName string
@@ -1029,7 +1022,11 @@ func extractOpenCodeToolCall(data, cwd string) ParsedToolCall {
 		SkillName: skillName,
 	}
 
-	if isFailure {
+	// OpenCode records model calls to unknown or malformed tools as a
+	// synthetic "invalid" tool whose execute succeeds, so state.status
+	// is "completed" and carries no error signal. Attach an errored
+	// result event so tool health counts these as failures.
+	if d.ToolName == "invalid" {
 		tc.ResultEvents = append(tc.ResultEvents, ParsedToolResultEvent{
 			ToolUseID: d.CallID,
 			Status:    "errored",

--- a/internal/parser/opencode_test.go
+++ b/internal/parser/opencode_test.go
@@ -899,6 +899,36 @@ func TestParseOpenCodeDB_SkillTool(t *testing.T) {
 	assertEq(t, "SkillName", ast.ToolCalls[0].SkillName, "doc-writer")
 }
 
+// TestParseOpenCodeDB_InvalidToolCall verifies that an invalid
+// tool call (tool:"invalid") populates ResultEvents with
+// Status:"errored" so the signal engine detects it as a failure.
+func TestParseOpenCodeDB_InvalidToolCall(t *testing.T) {
+	dbPath, seeder, db := newTestDB(t)
+	defer db.Close()
+
+	seeder.AddProject("prj_1", "/tmp/proj")
+	seeder.AddSession("ses_inv", "prj_1", "", "", 1700000000000, 1700000030000)
+
+	seeder.AddMessage("msg_u", "ses_inv", 1700000000000, 1700000000000, `{"role":"user"}`)
+	seeder.AddPart("prt_u", "msg_u", "ses_inv", 1700000000000, 1700000000000, `{"type":"text","text":"do something"}`)
+
+	seeder.AddMessage("msg_a", "ses_inv", 1700000010000, 1700000010000, `{"role":"assistant"}`)
+	seeder.AddPart("prt_t", "msg_a", "ses_inv", 1700000010000, 1700000010000,
+		`{"type":"tool","tool":"invalid","callID":"call_inv","state":{"input":{"tool":"nonexistent_tool","error":"Model tried to call unavailable tool 'nonexistent_tool'"}}}`)
+
+	sessions, err := parseOpenCodeAll(dbPath, "m")
+	require.NoError(t, err, "ParseOpenCodeDB")
+	require.Len(t, sessions, 1, "sessions len")
+
+	msgs := sessions[0].Messages
+	require.Len(t, msgs, 2, "messages len")
+
+	ast := msgs[1]
+	require.Len(t, ast.ToolCalls, 1, "tool calls len")
+	require.Len(t, ast.ToolCalls[0].ResultEvents, 1, "result events len")
+	assertEq(t, "ResultEvents[0].Status", ast.ToolCalls[0].ResultEvents[0].Status, "errored")
+}
+
 // TestParseOpenCodeDB_SkillNameFromReadTool verifies that a
 // "read" tool part whose input points at a real on-disk SKILL.md
 // infers the skill name from the file's frontmatter, matching the


### PR DESCRIPTION
Fixes #1254

## Problem

Opencode stores failed tool calls with `tool: "invalid"` and `state.status: "completed"` — the parser never emitted a `ResultEvent`, so `ComputeToolHealth` had no error signal to detect. All opencode sessions showed `tool_failure_signal_count: 0` despite confirmed invalid tool calls.

## Fix

In `extractOpenCodeToolCall()`, when `d.ToolName == "invalid"`, attach a `ResultEvent{Status: "errored"}` so the signal pipeline (`extractToolCallRows` → `signals.IsFailure` → `ComputeToolHealth`) counts it as a failure.

## Test

Added `TestParseOpenCodeDB_InvalidToolCall` that seeds a session with an invalid tool part and asserts `ResultEvents[0].Status == "errored"`.

All existing opencode tests continue to pass.
