### PR TITLE
feat(parser): detect opencode bash tool failures from metadata.exit

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -244,8 +244,8 @@ Grok section and remove the explicit registry exception in the coverage test.
   failure signal. The tool's own output text carries no `exit status N`
   marker, and the shell is `COMSPEC`/`cmd.exe` on Windows, so text-pattern
   matching alone misses these failures on every platform. Agentsview treats a
-  non-zero `state.metadata.exit` on any tool part as a failure and attaches an
-  errored result event. Only `bash` parts record `exit`; other tools omit the
+  non-zero `state.metadata.exit` on a `bash` tool part as a failure and attaches
+  an errored result event. Only `bash` parts record `exit`; other tools omit the
   key. Verified 2026-07-24 against a live `opencode.db` where all 24 bash
   parts with `exit` in `{1, 127, 128}` had output text without an
   `exit status` marker, and the 81 successful parts recorded `exit=0`. Known

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -235,6 +235,24 @@ Grok section and remove the explicit registry exception in the coverage test.
   `state.status` is `completed` with the error text in the output. Agentsview
   attaches an errored result event to `tool:"invalid"` parts so tool health
   counts them as failures (verified 2026-07-24; see #1254).
+- **Bash exit codes:** The `bash` tool declares a structured output of
+  `{exit, truncated, timeout}` and returns the child process exit code as
+  `exit`
+  ([bash.ts](https://github.com/anomalyco/opencode/blob/67caf894e0843ee370e72839e8265e483233479b/packages/core/src/tool/bash.ts)
+  at the pinned commit). That structured output is persisted as the tool
+  part's `state.metadata`, so `state.metadata.exit` is the authoritative
+  failure signal. The tool's own output text carries no `exit status N`
+  marker, and the shell is `COMSPEC`/`cmd.exe` on Windows, so text-pattern
+  matching alone misses these failures on every platform. Agentsview treats a
+  non-zero `state.metadata.exit` on any tool part as a failure and attaches an
+  errored result event. Only `bash` parts record `exit`; other tools omit the
+  key. Verified 2026-07-24 against a live `opencode.db` where all 24 bash
+  parts with `exit` in `{1, 127, 128}` had output text without an
+  `exit status` marker, and the 81 successful parts recorded `exit=0`. Known
+  gaps: a command that legitimately exits non-zero (`grep` with no match)
+  counts as a failure, matching the existing `exit status N` heuristic, and a
+  timed-out command records `timeout: true` with no `exit` key, so it is not
+  detected here. See #1256.
 - **Agentsview:** `internal/parser/opencode.go`,
   `internal/parser/opencode_provider.go`, and
   `internal/parser/opencode_storage_state.go`; legacy and database layouts are

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -325,7 +325,12 @@ const projectIdentityRemoteScrubCompletedKey = "project_identity_remote_scrub_v1
 // records unknown-tool calls as a synthetic "invalid" tool that completes
 // successfully, so existing rows carry no failure signal. Re-parsing attaches
 // the errored event so tool-health failure counts cover historical sessions.)
-const dataVersion = 72
+// (73: OpenCode bash tool calls emit an errored result event when the tool
+// state records a non-zero metadata.exit. Windows shells produce no "exit
+// status N" output text, so existing rows carry no failure signal. Re-parsing
+// attaches the errored event so tool-health failure counts cover historical
+// OpenCode sessions on every platform.)
+const dataVersion = 73
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1007,9 +1007,9 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 		"expected tool_result_events table after reopen")
 }
 
-func TestCurrentDataVersionOpenCodeInvalidToolFailure(t *testing.T) {
-	assert.Equal(t, 72, CurrentDataVersion(),
-		"OpenCode invalid-tool failure detection requires a data version bump")
+func TestCurrentDataVersionOpenCodeBashExitFailure(t *testing.T) {
+	assert.Equal(t, 73, CurrentDataVersion(),
+		"OpenCode bash metadata.exit failure detection requires a data version bump")
 }
 
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {

--- a/internal/parser/opencode.go
+++ b/internal/parser/opencode.go
@@ -984,7 +984,13 @@ type openCodeToolData struct {
 
 // openCodeToolState holds the nested state of a tool call.
 type openCodeToolState struct {
-	Input json.RawMessage `json:"input"`
+	Input    json.RawMessage `json:"input"`
+	Metadata json.RawMessage `json:"metadata"`
+}
+
+// openCodeToolMetadata holds the optional metadata from a tool state.
+type openCodeToolMetadata struct {
+	Exit int `json:"exit"`
 }
 
 func extractOpenCodeToolCall(data, cwd string) ParsedToolCall {
@@ -993,12 +999,25 @@ func extractOpenCodeToolCall(data, cwd string) ParsedToolCall {
 		return ParsedToolCall{}
 	}
 
-	var inputJSON string
+	var (
+		inputJSON string
+		isFailure bool
+	)
 	if len(d.State) > 0 {
 		var state openCodeToolState
 		if err := json.Unmarshal(d.State, &state); err == nil {
 			if len(state.Input) > 0 {
 				inputJSON = string(state.Input)
+			}
+			// OpenCode records the shell exit code in the tool
+			// state metadata. On Windows the output text carries
+			// no "exit status N" marker, so metadata.exit is the
+			// only reliable failure signal.
+			if len(state.Metadata) > 0 {
+				var m openCodeToolMetadata
+				if err := json.Unmarshal(state.Metadata, &m); err == nil && m.Exit > 0 {
+					isFailure = true
+				}
 			}
 		}
 	}
@@ -1027,6 +1046,10 @@ func extractOpenCodeToolCall(data, cwd string) ParsedToolCall {
 	// is "completed" and carries no error signal. Attach an errored
 	// result event so tool health counts these as failures.
 	if d.ToolName == "invalid" {
+		isFailure = true
+	}
+
+	if isFailure {
 		tc.ResultEvents = append(tc.ResultEvents, ParsedToolResultEvent{
 			ToolUseID: d.CallID,
 			Status:    "errored",

--- a/internal/parser/opencode.go
+++ b/internal/parser/opencode.go
@@ -1013,7 +1013,7 @@ func extractOpenCodeToolCall(data, cwd string) ParsedToolCall {
 			// state metadata. On Windows the output text carries
 			// no "exit status N" marker, so metadata.exit is the
 			// only reliable failure signal.
-			if len(state.Metadata) > 0 {
+			if d.ToolName == "bash" && len(state.Metadata) > 0 {
 				var m openCodeToolMetadata
 				if err := json.Unmarshal(state.Metadata, &m); err == nil && m.Exit > 0 {
 					isFailure = true

--- a/internal/parser/opencode_test.go
+++ b/internal/parser/opencode_test.go
@@ -929,6 +929,37 @@ func TestParseOpenCodeDB_InvalidToolCall(t *testing.T) {
 	assertEq(t, "ResultEvents[0].Status", ast.ToolCalls[0].ResultEvents[0].Status, "errored")
 }
 
+// TestParseOpenCodeDB_BashExitFailure verifies that a bash tool
+// with metadata.exit > 0 sets ResultEvents[0].Status="errored"
+// even when output lacks "exit status N" text.
+func TestParseOpenCodeDB_BashExitFailure(t *testing.T) {
+	dbPath, seeder, db := newTestDB(t)
+	defer db.Close()
+
+	seeder.AddProject("prj_1", "/tmp/proj")
+	seeder.AddSession("ses_bexit", "prj_1", "", "", 1700000000000, 1700000030000)
+
+	seeder.AddMessage("msg_u", "ses_bexit", 1700000000000, 1700000000000, `{"role":"user"}`)
+	seeder.AddPart("prt_u", "msg_u", "ses_bexit", 1700000000000, 1700000000000, `{"type":"text","text":"build"}`)
+
+	seeder.AddMessage("msg_a", "ses_bexit", 1700000010000, 1700000010000, `{"role":"assistant"}`)
+	// bash tool with metadata.exit=1 but no "exit status" in output
+	seeder.AddPart("prt_t", "msg_a", "ses_bexit", 1700000010000, 1700000010000,
+		`{"type":"tool","tool":"bash","callID":"call_exit","state":{"input":{"command":"build"},"output":"error: command failed","metadata":{"exit":1}}}`)
+
+	sessions, err := parseOpenCodeAll(dbPath, "m")
+	require.NoError(t, err, "ParseOpenCodeDB")
+	require.Len(t, sessions, 1, "sessions len")
+
+	msgs := sessions[0].Messages
+	require.Len(t, msgs, 2, "messages len")
+
+	ast := msgs[1]
+	require.Len(t, ast.ToolCalls, 1, "tool calls len")
+	require.Len(t, ast.ToolCalls[0].ResultEvents, 1, "result events len")
+	assertEq(t, "ResultEvents[0].Status", ast.ToolCalls[0].ResultEvents[0].Status, "errored")
+}
+
 // TestParseOpenCodeDB_SkillNameFromReadTool verifies that a
 // "read" tool part whose input points at a real on-disk SKILL.md
 // infers the skill name from the file's frontmatter, matching the

--- a/internal/parser/opencode_test.go
+++ b/internal/parser/opencode_test.go
@@ -929,35 +929,75 @@ func TestParseOpenCodeDB_InvalidToolCall(t *testing.T) {
 	assertEq(t, "ResultEvents[0].Status", ast.ToolCalls[0].ResultEvents[0].Status, "errored")
 }
 
-// TestParseOpenCodeDB_BashExitFailure verifies that a bash tool
-// with metadata.exit > 0 sets ResultEvents[0].Status="errored"
-// even when output lacks "exit status N" text.
+// TestParseOpenCodeDB_BashExitFailure verifies that a bash tool whose
+// state metadata records a non-zero exit is reported as a failure even
+// when the output text lacks an "exit status N" marker, and that a
+// successful or exit-less part stays clean.
 func TestParseOpenCodeDB_BashExitFailure(t *testing.T) {
-	dbPath, seeder, db := newTestDB(t)
-	defer db.Close()
+	tests := []struct {
+		name        string
+		state       string
+		wantErrored bool
+	}{
+		{
+			name:        "non-zero exit without exit-status text",
+			state:       `{"input":{"command":"build"},"output":"error: command failed","metadata":{"exit":1}}`,
+			wantErrored: true,
+		},
+		{
+			name:        "non-zero exit with empty output",
+			state:       `{"input":{"command":"build"},"output":"","metadata":{"exit":127}}`,
+			wantErrored: true,
+		},
+		{
+			name:        "zero exit is not a failure",
+			state:       `{"input":{"command":"build"},"output":"ok","metadata":{"exit":0}}`,
+			wantErrored: false,
+		},
+		{
+			name:        "metadata without an exit key is not a failure",
+			state:       `{"input":{"command":"build"},"output":"ok","metadata":{"truncated":false}}`,
+			wantErrored: false,
+		},
+		{
+			name:        "no metadata is not a failure",
+			state:       `{"input":{"command":"build"},"output":"ok"}`,
+			wantErrored: false,
+		},
+	}
 
-	seeder.AddProject("prj_1", "/tmp/proj")
-	seeder.AddSession("ses_bexit", "prj_1", "", "", 1700000000000, 1700000030000)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dbPath, seeder, db := newTestDB(t)
+			defer db.Close()
 
-	seeder.AddMessage("msg_u", "ses_bexit", 1700000000000, 1700000000000, `{"role":"user"}`)
-	seeder.AddPart("prt_u", "msg_u", "ses_bexit", 1700000000000, 1700000000000, `{"type":"text","text":"build"}`)
+			seeder.AddProject("prj_1", "/tmp/proj")
+			seeder.AddSession("ses_bexit", "prj_1", "", "", 1700000000000, 1700000030000)
 
-	seeder.AddMessage("msg_a", "ses_bexit", 1700000010000, 1700000010000, `{"role":"assistant"}`)
-	// bash tool with metadata.exit=1 but no "exit status" in output
-	seeder.AddPart("prt_t", "msg_a", "ses_bexit", 1700000010000, 1700000010000,
-		`{"type":"tool","tool":"bash","callID":"call_exit","state":{"input":{"command":"build"},"output":"error: command failed","metadata":{"exit":1}}}`)
+			seeder.AddMessage("msg_u", "ses_bexit", 1700000000000, 1700000000000, `{"role":"user"}`)
+			seeder.AddPart("prt_u", "msg_u", "ses_bexit", 1700000000000, 1700000000000, `{"type":"text","text":"build"}`)
 
-	sessions, err := parseOpenCodeAll(dbPath, "m")
-	require.NoError(t, err, "ParseOpenCodeDB")
-	require.Len(t, sessions, 1, "sessions len")
+			seeder.AddMessage("msg_a", "ses_bexit", 1700000010000, 1700000010000, `{"role":"assistant"}`)
+			seeder.AddPart("prt_t", "msg_a", "ses_bexit", 1700000010000, 1700000010000,
+				`{"type":"tool","tool":"bash","callID":"call_exit","state":`+tt.state+`}`)
 
-	msgs := sessions[0].Messages
-	require.Len(t, msgs, 2, "messages len")
+			sessions, err := parseOpenCodeAll(dbPath, "m")
+			require.NoError(t, err, "ParseOpenCodeDB")
+			require.Len(t, sessions, 1, "sessions len")
 
-	ast := msgs[1]
-	require.Len(t, ast.ToolCalls, 1, "tool calls len")
-	require.Len(t, ast.ToolCalls[0].ResultEvents, 1, "result events len")
-	assertEq(t, "ResultEvents[0].Status", ast.ToolCalls[0].ResultEvents[0].Status, "errored")
+			msgs := sessions[0].Messages
+			require.Len(t, msgs, 2, "messages len")
+
+			ast := msgs[1]
+			require.Len(t, ast.ToolCalls, 1, "tool calls len")
+			if !tt.wantErrored {
+				assert.Empty(t, ast.ToolCalls[0].ResultEvents, "result events")
+				return
+			}
+			require.Len(t, ast.ToolCalls[0].ResultEvents, 1, "result events len")
+			assertEq(t, "ResultEvents[0].Status", ast.ToolCalls[0].ResultEvents[0].Status, "errored")
+		})
+	}
 }
 
 // TestParseOpenCodeDB_SkillNameFromReadTool verifies that a

--- a/internal/parser/opencode_test.go
+++ b/internal/parser/opencode_test.go
@@ -936,32 +936,44 @@ func TestParseOpenCodeDB_InvalidToolCall(t *testing.T) {
 func TestParseOpenCodeDB_BashExitFailure(t *testing.T) {
 	tests := []struct {
 		name        string
+		tool        string
 		state       string
 		wantErrored bool
 	}{
 		{
 			name:        "non-zero exit without exit-status text",
+			tool:        "bash",
 			state:       `{"input":{"command":"build"},"output":"error: command failed","metadata":{"exit":1}}`,
 			wantErrored: true,
 		},
 		{
 			name:        "non-zero exit with empty output",
+			tool:        "bash",
 			state:       `{"input":{"command":"build"},"output":"","metadata":{"exit":127}}`,
 			wantErrored: true,
 		},
 		{
 			name:        "zero exit is not a failure",
+			tool:        "bash",
 			state:       `{"input":{"command":"build"},"output":"ok","metadata":{"exit":0}}`,
 			wantErrored: false,
 		},
 		{
 			name:        "metadata without an exit key is not a failure",
+			tool:        "bash",
 			state:       `{"input":{"command":"build"},"output":"ok","metadata":{"truncated":false}}`,
 			wantErrored: false,
 		},
 		{
 			name:        "no metadata is not a failure",
+			tool:        "bash",
 			state:       `{"input":{"command":"build"},"output":"ok"}`,
+			wantErrored: false,
+		},
+		{
+			name:        "non-bash metadata exit is not a failure",
+			tool:        "mcp_lookup",
+			state:       `{"input":{"query":"exit routes"},"output":"route 1","metadata":{"exit":1}}`,
 			wantErrored: false,
 		},
 	}
@@ -979,7 +991,7 @@ func TestParseOpenCodeDB_BashExitFailure(t *testing.T) {
 
 			seeder.AddMessage("msg_a", "ses_bexit", 1700000010000, 1700000010000, `{"role":"assistant"}`)
 			seeder.AddPart("prt_t", "msg_a", "ses_bexit", 1700000010000, 1700000010000,
-				`{"type":"tool","tool":"bash","callID":"call_exit","state":`+tt.state+`}`)
+				`{"type":"tool","tool":"`+tt.tool+`","callID":"call_exit","state":`+tt.state+`}`)
 
 			sessions, err := parseOpenCodeAll(dbPath, "m")
 			require.NoError(t, err, "ParseOpenCodeDB")


### PR DESCRIPTION
## Problem

OpenCode bash tool failures leave `metadata.exit > 0` in the tool state but the output text does NOT contain the `exit status N` pattern that AgentsView's `isBashFailure()` checks. This is not Windows-specific: on a Linux `opencode.db`, all 24 bash parts with a non-zero exit (1, 127, 128) had output text with no `exit status` marker, while all 81 successful parts recorded `exit=0`. Example outputs from real sessions:

- `'choco' is not recognized as an internal or external command` - exit=1, no "exit status" text
- (empty output) - exit=1, no text at all
- `rsync error: some files could not be transferred` - exit=1

The exit code is reliably recorded in `metadata.exit` by the agent, but the parser never reads it.

## Impact

On a Windows machine with 273 opencode sessions, 1233 bash tool failures are missed because they lack the `exit status` output pattern. Only 51 are currently detected (via the `tool:"invalid"` fix). The remaining ~1200 are invisible to signals, insights, and health scoring.

## Fix

In `extractOpenCodeToolCall()`, after parsing the tool state, check `metadata.exit`:

```go
if len(state.Metadata) > 0 {
    var m struct { Exit int `json:"exit"` }
    if err := json.Unmarshal(state.Metadata, &m); err == nil && m.Exit > 0 {
        isFailure = true
    }
}
```

This is opt-in per agent - only opencode records metadata.exit. Other agents are unaffected.

`dataVersion` moves to 73 so existing opencode rows are re-parsed and historical sessions backfill the failure events, and the format evidence is recorded in `docs/internal/session-format-sources.md`.

## Branch

https://github.com/ajinkyajacob/agentsview/tree/feat/opencode-metadata-exit-failure-detection

## Risk

- Non-zero exit doesn't always mean failure (e.g., `grep` returns 1 for no match). However, AgentsView's existing `exitStatusRe` already makes the same assumption via output text. This just adds parity for the metadata path.
- Only applies when `metadata` key exists in the tool state (opencode format), so other agents are isolated.

