### PR TITLE
fix(parser): bound Gemini reconciliation work

### DIFF
--- a/internal/parser/gemini_copilot_provider_test.go
+++ b/internal/parser/gemini_copilot_provider_test.go
@@ -87,6 +87,55 @@ func TestGeminiProviderSourceMethods(t *testing.T) {
 	require.Empty(t, fingerprint)
 }
 
+func TestGeminiProviderReconciliationProjectMapWorkIsArchiveBounded(t *testing.T) {
+	var projectMapBuilds int
+	orig := buildGeminiProjectMap
+	buildGeminiProjectMap = func(string) map[string]string {
+		projectMapBuilds++
+		return map[string]string{}
+	}
+	t.Cleanup(func() { buildGeminiProjectMap = orig })
+
+	for _, sourceCount := range []int{1, 64} {
+		t.Run(fmt.Sprintf("sources_%d", sourceCount), func(t *testing.T) {
+			root := t.TempDir()
+			sourcePaths := make([]string, sourceCount)
+			for i := range sourcePaths {
+				sourcePaths[i] = filepath.Join(
+					root,
+					"tmp",
+					fmt.Sprintf("project-hash-%03d", i),
+					geminiChatsDir,
+					fmt.Sprintf("session-2026-06-19T12-%02d-source.json", i),
+				)
+				writeSourceFile(t, sourcePaths[i], "{}")
+			}
+
+			provider, ok := NewProvider(AgentGemini, ProviderConfig{
+				Roots: []string{root},
+			})
+			require.True(t, ok)
+			resolver, ok := provider.(ReconciliationSourceResolver)
+			require.True(t, ok)
+
+			projectMapBuilds = 0
+			for i, path := range sourcePaths {
+				project := fmt.Sprintf("spooled_project_%d", i)
+				source, found, err := resolver.SourceForReconciliation(
+					t.Context(), path, project,
+				)
+				require.NoError(t, err)
+				require.True(t, found)
+				assert.Equal(t, path, source.DisplayPath)
+				assert.Equal(t, path, source.FingerprintKey)
+				assert.Equal(t, project, source.ProjectHint)
+			}
+			assert.Zero(t, projectMapBuilds,
+				"exact reconciliation must not rebuild root-wide metadata per source")
+		})
+	}
+}
+
 func TestGeminiProviderProjectMetadataChangesClassifyAndFingerprint(t *testing.T) {
 	root := t.TempDir()
 	sessionID := "gemini-project-metadata"

--- a/internal/parser/gemini_provider.go
+++ b/internal/parser/gemini_provider.go
@@ -66,6 +66,13 @@ func (p *geminiProvider) SourcesForChangedPath(
 	return p.sources.SourcesForChangedPath(ctx, req)
 }
 
+func (p *geminiProvider) SourceForReconciliation(
+	ctx context.Context,
+	path, project string,
+) (SourceRef, bool, error) {
+	return p.sources.SourceForReconciliation(ctx, path, project)
+}
+
 func (p *geminiProvider) FindSource(
 	ctx context.Context,
 	req FindSourceRequest,
@@ -496,6 +503,30 @@ func (s geminiSourceSet) rootPathFromSource(source SourceRef) (string, string, b
 
 func (s geminiSourceSet) sourceRef(root, path string) (SourceRef, bool) {
 	return s.sourceRefForPath(root, path, true)
+}
+
+// SourceForReconciliation rebuilds an exact source already admitted by
+// streaming discovery. The discovered project hint is authoritative here, so
+// rehydration must not rebuild root-wide Gemini project metadata per source.
+func (s geminiSourceSet) SourceForReconciliation(
+	ctx context.Context, path, project string,
+) (SourceRef, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return SourceRef{}, false, err
+	}
+	for _, root := range s.roots {
+		source, ok := s.sourceRefForPathWithProjectMap(
+			root, path, true, map[string]string{},
+		)
+		if !ok {
+			continue
+		}
+		if project != "" {
+			source.ProjectHint = project
+		}
+		return source, true, nil
+	}
+	return SourceRef{}, false, nil
 }
 
 func (s geminiSourceSet) sourceRefForPath(


### PR DESCRIPTION
Lost-event recovery rehydrates discovered Gemini sources in bounded pages. Gemini previously routed every candidate back through changed-path classification, rebuilding root-wide project metadata and repeating filesystem and Git resolution once per session. Large recoveries could therefore keep an otherwise idle daemon CPU-bound long after discovery completed.

Teach the Gemini provider to reconstruct the exact discovered source from its spooled path and project hint. This preserves the project selected by authoritative discovery while keeping reconciliation work proportional to the candidate batch. A scaling regression covers both small and larger archives.