### PR TITLE
fix(ssh): deduplicate resolved Poolside targets

### DIFF
--- a/internal/ssh/resolve.go
+++ b/internal/ssh/resolve.go
@@ -372,9 +372,9 @@ func resolveAgentHasOnDiskSource(def parser.AgentDef) bool {
 	}
 }
 
-// parseResolvedTargets parses script output into agent root paths,
-// agent-scoped files, and a deduplicated list of extra files (records
-// tagged with resolveFilePrefix). Generated resolver output is
+// parseResolvedTargets parses script output into deduplicated agent root paths,
+// agent-scoped files, and extra files (records tagged with resolveFilePrefix).
+// Generated resolver output is
 // NUL-delimited so remote paths containing newlines cannot inject extra
 // records; newline-delimited input is accepted only for older tests and
 // defensive compatibility. Most agent targets are directories; Aider
@@ -386,6 +386,7 @@ func parseResolvedTargets(
 	dirs := make(map[parser.AgentType][]string)
 	files := make(map[parser.AgentType][]string)
 	var extraFiles []string
+	seenDir := make(map[parser.AgentType]map[string]struct{})
 	seenFile := make(map[string]struct{})
 	seenAgentFile := make(map[parser.AgentType]map[string]struct{})
 	for _, record := range resolveOutputRecords(output) {
@@ -431,6 +432,15 @@ func parseResolvedTargets(
 			path.Base(value) != parser.AiderHistoryFileName() {
 			continue
 		}
+		seen, ok := seenDir[at]
+		if !ok {
+			seen = make(map[string]struct{})
+			seenDir[at] = seen
+		}
+		if _, dup := seen[value]; dup {
+			continue
+		}
+		seen[value] = struct{}{}
 		dirs[at] = append(dirs[at], value)
 	}
 	return dirs, files, extraFiles

--- a/internal/ssh/resolve_test.go
+++ b/internal/ssh/resolve_test.go
@@ -774,6 +774,10 @@ func TestResolveScriptPoolsideTrajectoriesRoot(t *testing.T) {
 
 	out := runResolveScriptForTest(t, "HOME="+home, "POOLSIDE_DIR="+trajectoriesDir)
 
+	dirs, _ := parseResolvedDirs(string(out))
+	assert.Equal(t, []string{trajectoriesDir}, dirs[parser.AgentPoolside],
+		"the environment override must produce one transfer target")
+
 	records := resolveOutputRecords(string(out))
 	agentSuffix := filepath.ToSlash(filepath.Join("poolside", "trajectories"))
 	assert.True(t, hasRecordWithPathSuffix(records,


### PR DESCRIPTION
Poolside support in #1241 registered three platform-specific default directories behind the single `POOLSIDE_DIR` override. The SSH resolver evaluates that override while iterating each default, so a non-empty override emits the same `trajectories` target three times. The Linux fallback correction in #1258 changed one default path but did not cause or resolve this duplication.

Deduplicate resolved directory targets per agent before archive construction, preserving first-seen order and allowing different agents to share a path independently. Strengthen the Poolside override regression to require one parsed transfer target. This addresses the post-merge roborev finding on #1241.