### PR TITLE
Add Codebuff/Freebuff agent support

### DIFF
--- a/cmd/agentsview/session_get.go
+++ b/cmd/agentsview/session_get.go
@@ -199,66 +199,66 @@ func resolveBareCodebuffID(
 		}
 	}
 
-	// Phase 2: Host-prefixed remote-synced sessions.
-	// This runs independently of the filesystem walk (even when
-	// len(locations)==0) so remote-only sessions — imported via
-	// pg push or remotesync with no local on-disk copy — can still
-	// be resolved. The filter requires a host prefix ("~"), a
-	// codebuff or freebuff agent marker, and the exact timestamp
-	// suffix.
-	if machineFilter != "" && machineFilter != "local" {
-		// Canonical remote Codebuff/Freebuff IDs carry the form
-		// host~codebuff:<project>:<timestamp> — the project
-		// segment separates the agent prefix from the timestamp.
-		// An agent-prefixed query ("codebuff:"+rawID) cannot
-		// match because the prefix isn't contiguous with the
-		// timestamp. Search by the raw timestamp alone so
-		// codebuff:<project>:<timestamp> rows are found. The
-		// post-fetch guards below (host prefix, suffix, agent
-		// marker, machine) keep the result set specific.
-		ids, findErr := svc.FindSessionIDsByPartial(
-			ctx, rawID, 200,
+	// Phase 2: Archived and remote-synced sessions found in the
+	// database. This runs independently of the filesystem walk (even
+	// when len(locations)==0) so sessions with no on-disk copy —
+	// local archive rows whose source directory was deleted, or
+	// remote rows imported via pg push or remotesync — can still be
+	// resolved. The filter requires a codebuff or freebuff agent
+	// marker (with or without a host prefix), the exact timestamp
+	// suffix, and a machine match; the seen map dedupes rows Phase 1
+	// already surfaced so an on-disk session is not double-counted
+	// as ambiguous with its own archive row.
+	//
+	// Canonical Codebuff/Freebuff IDs carry the form
+	// [host~]codebuff:<project>:<timestamp> — the project segment
+	// separates the agent prefix from the timestamp. An
+	// agent-prefixed query ("codebuff:"+rawID) cannot match because
+	// the prefix isn't contiguous with the timestamp. Search by the
+	// raw timestamp alone so codebuff:<project>:<timestamp> rows are
+	// found. The post-fetch guards below (suffix, agent marker,
+	// machine) keep the result set specific.
+	ids, findErr := svc.FindSessionIDsByPartial(
+		ctx, rawID, 200,
+	)
+	if findErr != nil && lookupErr == nil {
+		lookupErr = fmt.Errorf(
+			"lookup archived sessions for %q: %w",
+			rawID, findErr,
 		)
-		if findErr != nil && lookupErr == nil {
-			lookupErr = fmt.Errorf(
-				"lookup host-prefixed sessions for %q: %w",
-				rawID, findErr,
-			)
+	}
+	for _, id := range ids {
+		if !strings.HasSuffix(id, ":"+rawID) {
+			continue
 		}
-		for _, id := range ids {
-			if !strings.Contains(id, "~") {
-				continue
-			}
-			if !strings.HasSuffix(id, ":"+rawID) {
-				continue
-			}
-			// Guard against non-codebuff/freebuff sessions
-			// whose ID happens to contain the timestamp.
-			if !strings.Contains(id, "~codebuff:") &&
-				!strings.Contains(id, "~freebuff:") {
-				continue
-			}
-			detail, err := svc.Get(ctx, id)
-			if err != nil {
-				if lookupErr == nil {
-					lookupErr = err
-				}
-				continue
-			}
-			if detail == nil {
-				continue
-			}
-			if !codebuffMachineMatches(
-				detail.Machine, machineFilter, localMachine,
-			) {
-				continue
-			}
-			if _, dup := seen[id]; dup {
-				continue
-			}
-			seen[id] = struct{}{}
-			valid = append(valid, id)
+		// Guard against non-codebuff/freebuff sessions whose ID
+		// happens to contain the timestamp.
+		if !strings.HasPrefix(id, "codebuff:") &&
+			!strings.HasPrefix(id, "freebuff:") &&
+			!strings.Contains(id, "~codebuff:") &&
+			!strings.Contains(id, "~freebuff:") {
+			continue
 		}
+		detail, err := svc.Get(ctx, id)
+		if err != nil {
+			if lookupErr == nil {
+				lookupErr = err
+			}
+			continue
+		}
+		if detail == nil {
+			continue
+		}
+		if !codebuffMachineMatches(
+			detail.Machine, machineFilter, localMachine,
+		) {
+			continue
+		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		valid = append(valid, id)
 	}
 
 	// Single zero/one/many decision over both phases. Fail closed on

--- a/cmd/agentsview/session_get.go
+++ b/cmd/agentsview/session_get.go
@@ -10,12 +10,13 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/service"
 )
 
 func newSessionGetCommand() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:          "get <id>",
 		Short:        "Get session metadata and signals",
 		Args:         cobra.ExactArgs(1),
@@ -27,8 +28,15 @@ func newSessionGetCommand() *cobra.Command {
 			}
 			defer cleanup()
 
+			id := args[0]
+			if resolved, err := resolveCodebuffBareID(cmd, svc, id); err != nil {
+				return err
+			} else if resolved != "" {
+				id = resolved
+			}
+
 			detail, err := lookupSessionWithPrefixes(
-				cmd.Context(), svc, args[0],
+				cmd.Context(), svc, id,
 			)
 			if err != nil {
 				return err
@@ -42,6 +50,21 @@ func newSessionGetCommand() *cobra.Command {
 			return printSessionDetailHuman(cmd.OutOrStdout(), detail)
 		},
 	}
+	// The machine filter is local to `session get` only. session
+	// list / search / export already register their own --machine
+	// flags with different roles (list/search filter; export writes
+	// a machine label for the export artifact); declaring a shared
+	// persistent flag would either collide with those or be a silent
+	// no-op for them. Keep this scope narrow.
+	cmd.Flags().String(
+		"machine", "local",
+		"Filter bare Codebuff/Freebuff timestamp resolution to a single "+
+			"machine identity. Use 'local' (default) to match this "+
+			"archive's own sessions, a machine name to match by exact "+
+			"sessions.machine value, or '*' to accept any. Does not "+
+			"affect canonical IDs or agents other than Codebuff/Freebuff.",
+	)
+	return cmd
 }
 
 // resolveServiceSessionID returns the canonical session ID matching id,
@@ -52,6 +75,10 @@ func newSessionGetCommand() *cobra.Command {
 // confusing "not found" error. Returns an error whose message
 // begins with "session not found:" when no match exists — callers
 // get a clear failure instead of silent empty output.
+//
+// Bare Codebuff/Freebuff timestamps are pre-resolved by
+// resolveCodebuffBareID at the call site (see newSessionGetCommand),
+// so this function does not need to know about them.
 func resolveServiceSessionID(
 	ctx context.Context,
 	svc service.SessionService,
@@ -89,6 +116,267 @@ func resolveServiceSessionID(
 	return "", fmt.Errorf("session not found: %s", id)
 }
 
+// resolveBareCodebuffID maps a bare on-disk Codebuff/Freebuff
+// timestamp to its canonical ID by walking the configured
+// codebuff/freebuff storage layer. For each candidate location on
+// disk, the helper tries BOTH AgentCodebuff and AgentFreebuff
+// prefixes against the session service, gated by machineFilter so
+// remote-synced records don't masquerade as local matches. The
+// dual lookup is required because Freebuff is intentionally
+// absent from parser.Registry, so Freebuff's storage is reachable
+// only through the shared codebuff roots list and a single-prefix
+// probe would mis-classify Freebuff sessions as Codebuff. Zero
+// matches fall through to the standard resolver path; one match
+// returns its canonical ID; multiple matches whose machine passes
+// the filter return an explicit ambiguity error listing every
+// valid canonical ID.
+//
+// machineFilter is the user's --machine flag value. "" or "local"
+// defers to cfg.LocalMachineName (the local archive's identity,
+// runtime-derived from os.Hostname by config.LoadPFlags); "*"
+// accepts any machine; any other non-empty string is matched
+// exactly against detail.Machine. The caller is responsible for
+// parsing the flag into one of these categories.
+func resolveBareCodebuffID(
+	ctx context.Context,
+	svc service.SessionService,
+	cfg *config.Config,
+	rawID string,
+	machineFilter string,
+) (string, error) {
+	if cfg == nil {
+		return "", nil
+	}
+	localMachine := cfg.LocalMachineName
+	locations := parser.FindCodebuffFreebuffMatches(
+		[]parser.CodebuffFamilyRoots{
+			{Agent: parser.AgentCodebuff,
+				Roots: cfg.ResolveDirs(parser.AgentCodebuff)},
+			{Agent: parser.AgentFreebuff,
+				Roots: cfg.ResolveDirs(parser.AgentFreebuff)},
+		},
+		rawID,
+	)
+
+	var (
+		valid     []string
+		seen      = make(map[string]struct{})
+		lookupErr error
+	)
+
+	// Phase 1: Unprefixed probes using filesystem project hints.
+	// Each location supplies a project name; try both codebuff and
+	// freebuff prefixes against the session service. This phase
+	// depends on a local Codebuff/Freebuff directory on disk and
+	// produces no candidates when len(locations)==0.
+	for _, agent := range []parser.AgentType{
+		parser.AgentCodebuff, parser.AgentFreebuff,
+	} {
+		for _, loc := range locations {
+			candidate := strings.Join(
+				[]string{string(agent), loc.ProjectHint, rawID}, ":",
+			)
+			detail, err := svc.Get(ctx, candidate)
+			if err != nil {
+				if lookupErr == nil {
+					lookupErr = err
+				}
+				continue
+			}
+			if detail == nil {
+				continue
+			}
+			if !codebuffMachineMatches(
+				detail.Machine, machineFilter, localMachine,
+			) {
+				continue
+			}
+			if _, dup := seen[candidate]; dup {
+				continue
+			}
+			seen[candidate] = struct{}{}
+			valid = append(valid, candidate)
+		}
+	}
+
+	// Phase 2: Host-prefixed remote-synced sessions.
+	// This runs independently of the filesystem walk (even when
+	// len(locations)==0) so remote-only sessions — imported via
+	// pg push or remotesync with no local on-disk copy — can still
+	// be resolved. The filter requires a host prefix ("~"), a
+	// codebuff or freebuff agent marker, and the exact timestamp
+	// suffix.
+	if machineFilter != "" && machineFilter != "local" {
+		// Canonical remote Codebuff/Freebuff IDs carry the form
+		// host~codebuff:<project>:<timestamp> — the project
+		// segment separates the agent prefix from the timestamp.
+		// An agent-prefixed query ("codebuff:"+rawID) cannot
+		// match because the prefix isn't contiguous with the
+		// timestamp. Search by the raw timestamp alone so
+		// codebuff:<project>:<timestamp> rows are found. The
+		// post-fetch guards below (host prefix, suffix, agent
+		// marker, machine) keep the result set specific.
+		ids, findErr := svc.FindSessionIDsByPartial(
+			ctx, rawID, 200,
+		)
+		if findErr != nil && lookupErr == nil {
+			lookupErr = fmt.Errorf(
+				"lookup host-prefixed sessions for %q: %w",
+				rawID, findErr,
+			)
+		}
+		for _, id := range ids {
+			if !strings.Contains(id, "~") {
+				continue
+			}
+			if !strings.HasSuffix(id, ":"+rawID) {
+				continue
+			}
+			// Guard against non-codebuff/freebuff sessions
+			// whose ID happens to contain the timestamp.
+			if !strings.Contains(id, "~codebuff:") &&
+				!strings.Contains(id, "~freebuff:") {
+				continue
+			}
+			detail, err := svc.Get(ctx, id)
+			if err != nil {
+				if lookupErr == nil {
+					lookupErr = err
+				}
+				continue
+			}
+			if detail == nil {
+				continue
+			}
+			if !codebuffMachineMatches(
+				detail.Machine, machineFilter, localMachine,
+			) {
+				continue
+			}
+			if _, dup := seen[id]; dup {
+				continue
+			}
+			seen[id] = struct{}{}
+			valid = append(valid, id)
+		}
+	}
+
+	// Single zero/one/many decision over both phases. Fail closed on
+	// any candidate lookup error: a probe that errored could hide a
+	// second match, so returning the lone successful candidate may
+	// resolve an ID that is genuinely ambiguous.
+	if lookupErr != nil {
+		return "", lookupErr
+	}
+	switch len(valid) {
+	case 0:
+		return "", nil
+	case 1:
+		return valid[0], nil
+	default:
+		return "", fmt.Errorf(
+			"ambiguous session id %q: matches %d canonical sessions: %s. "+
+				"Re-run with one of the canonical IDs to disambiguate",
+			rawID, len(valid), strings.Join(valid, ", "),
+		)
+	}
+}
+
+// codebuffMachineMatches reports whether a row's machine column
+// passes the user's --machine filter. "" or "local" defers to
+// localMachine (cfg.LocalMachineName); "*" matches anything; any
+// other non-empty value is matched exactly. This keeps the resolver
+// decoupled from cobra while still honouring the rule that
+// unspecified / "local" mean "this archive's own sessions".
+func codebuffMachineMatches(
+	rowMachine, filter, localMachine string,
+) bool {
+	switch filter {
+	case "*":
+		return true
+	case "", "local":
+		return rowMachine == localMachine
+	default:
+		return rowMachine == filter
+	}
+}
+
+// resolveCodebuffBareID attempts to resolve a bare Codebuff/Freebuff
+// timestamp to its canonical ID for the local archive. Returns
+// ("", nil) when the ID is already canonical, when the input is
+// not a Codebuff/Freebuff timestamp shape (so the generic prefix
+// resolver still handles it), or when no local match is found;
+// returns an explicit error for Codebuff/Freebuff timestamp inputs
+// on remote stores so the user is pointed at `session list` and
+// the canonical ID formats.
+//
+// Remote stores (`--server`, `--pg`) cannot safely resolve a bare
+// timestamp back to a canonical ID: a timestamp is intrinsically
+// ambiguous across machines and projects, mixing `host~`-prefixed
+// rows from PG push with local aliases would silently pick one or
+// fire an ambiguous error the user can't act on without
+// `session list` anyway. The contract for remote reads is "pass
+// the canonical ID". A user with only a timestamp must run
+// `session list --machine=...` to find one first.
+//
+// Bare IDs that are NOT Codebuff/Freebuff timestamps (Codex /
+// Copilot / Gemini UUIDs, etc.) reach register-prefix retry via
+// resolveServiceSessionID unchanged — the Codebuff-specific error
+// is reserved for inputs whose shape identifies them as
+// Codebuff/Freebuff timestamps.
+func resolveCodebuffBareID(
+	cmd *cobra.Command, svc service.SessionService, id string,
+) (string, error) {
+	if isCanonicalServiceSessionID(id) {
+		return "", nil
+	}
+	// Distinguish a Codebuff/Freebuff timestamp from a bare UUID
+	// for another agent. The Codebuff-specific remote error must
+	// fire ONLY on the timestamp shape; otherwise it short-
+	// circuits generic bare-ID resolution against --server/--pg.
+	// Syntactic (parseCodebuffSessionDate) — no FS walk, which
+	// keeps --server/--pg cheap and avoids depending on
+	// configured local codebuff roots.
+	if !parser.IsCodebuffTimestamp(id) {
+		return "", nil
+	}
+	remote, _ := cmd.Flags().GetString("server")
+	if remote != "" || pgReadRequested(cmd) {
+		return "", errBareCodebuffRemoteUnsupported(id)
+	}
+	cfg := mustLoadConfig(cmd)
+	machineFlag, _ := cmd.Flags().GetString("machine")
+	return resolveBareCodebuffID(
+		cmd.Context(), svc, &cfg, id, machineFlag,
+	)
+}
+
+// errBareCodebuffRemoteUnsupported builds the error returned when
+// a non-canonical ID hits the resolver against a remote transport.
+// The message point at `session list` and lists every canonical ID
+// shape (local and remote-synced, codebuff and freebuff) so the
+// user can pick the right invocation without trial and error.
+func errBareCodebuffRemoteUnsupported(id string) error {
+	return fmt.Errorf(
+		"%q is not a canonical session ID and cannot be resolved "+
+			"against a remote store (--server or --pg). "+
+			"Run `agentsview session list` to find the canonical ID, "+
+			"then pass one of:\n"+
+			"  codebuff:<project>:<ts>          # local session\n"+
+			"  freebuff:<project>:<ts>          # local freebuff session\n"+
+			"  host~codebuff:<project>:<ts>     # remote-synced session\n"+
+			"  host~freebuff:<project>:<ts>     # remote-synced freebuff",
+		id,
+	)
+} // isCanonicalServiceSessionID reports whether id is already in the
+// canonical "agent:..." or "host~..." form that resolveServiceSessionID
+// can look up directly.
+//
+// Freebuff is intentionally absent from parser.Registry (it shares
+// the Codebuff provider and would double-discover); mirror the
+// special case parser.AgentByPrefix applies so `freebuff:<proj>:<ts>`
+// inputs pass through unchanged instead of being misclassified as
+// bare timestamps by resolveCodebuffBareID.
 func isCanonicalServiceSessionID(id string) bool {
 	if strings.Contains(id, "~") {
 		return true
@@ -99,7 +387,7 @@ func isCanonicalServiceSessionID(id string) bool {
 			return true
 		}
 	}
-	return false
+	return strings.HasPrefix(rawID, string(parser.AgentFreebuff)+":")
 }
 
 // lookupSessionWithPrefixes fetches a session detail, trying agent

--- a/cmd/agentsview/session_get_test.go
+++ b/cmd/agentsview/session_get_test.go
@@ -2,10 +2,19 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/service"
 )
 
@@ -28,4 +37,654 @@ func TestPrintSessionDetailHidesZeroSecretLeak(t *testing.T) {
 	require.NoError(t, printSessionDetailHuman(&buf, d))
 	assert.NotContains(t, buf.String(), "Secrets",
 		"clean session should not show a Secrets line")
+}
+
+// stubGetService implements service.SessionService. Only Get and
+// FindSessionIDsByPartial are wired up; every other method panics to
+// surface unintended use. Tests must not exercise them.
+type stubGetService struct {
+	// getDetails is keyed by ID; Get returns the pointer when present
+	// and nil + nil when absent.
+	getDetails map[string]*service.SessionDetail
+	// getCalls records every (id) pair passed to Get.
+	getCalls []string
+	// getErr, when non-nil, is returned by Get in place of the lookup.
+	getErr error
+	// getErrs maps individual IDs to lookup errors; a present entry
+	// takes precedence over getErr so a test can fail one probe while
+	// letting another succeed.
+	getErrs map[string]error
+	// partialIDs is returned by FindSessionIDsByPartial. An empty
+	// (nil) slice defaults to []string{} to avoid panicking in
+	// callers that iterate the result.
+	partialIDs []string
+	// partialCalls records every (partial, limit) pair.
+	partialCalls []struct {
+		partial string
+		limit   int
+	}
+}
+
+func (s *stubGetService) Get(
+	_ context.Context, id string,
+) (*service.SessionDetail, error) {
+	s.getCalls = append(s.getCalls, id)
+	if err, ok := s.getErrs[id]; ok {
+		return nil, err
+	}
+	if s.getErr != nil {
+		return nil, s.getErr
+	}
+	return s.getDetails[id], nil
+}
+
+func (s *stubGetService) FindSessionIDsByPartial(
+	_ context.Context, partial string, limit int,
+) ([]string, error) {
+	s.partialCalls = append(s.partialCalls, struct {
+		partial string
+		limit   int
+	}{partial, limit})
+	if s.partialIDs == nil {
+		return []string{}, nil
+	}
+	return s.partialIDs, nil
+}
+
+// Stubs for the remaining SessionService methods — resolveBareCodebuffID
+// and resolveCodebuffBareID do not exercise them, so they panic.
+func (s *stubGetService) List(context.Context, service.ListFilter) (*service.SessionList, error) {
+	panic("List not expected")
+}
+func (s *stubGetService) Messages(context.Context, string, service.MessageFilter) (*service.MessageList, error) {
+	panic("Messages not expected")
+}
+func (s *stubGetService) ToolCalls(context.Context, string) (*service.ToolCallList, error) {
+	panic("ToolCalls not expected")
+}
+func (s *stubGetService) Sync(context.Context, service.SyncInput) (*service.SessionDetail, error) {
+	panic("Sync not expected")
+}
+func (s *stubGetService) Watch(context.Context, string) (<-chan service.Event, error) {
+	panic("Watch not expected")
+}
+func (s *stubGetService) Stats(context.Context, service.StatsFilter) (*service.SessionStats, error) {
+	panic("Stats not expected")
+}
+func (s *stubGetService) Search(context.Context, service.SearchRequest) (*service.SessionSearchResult, error) {
+	panic("Search not expected")
+}
+func (s *stubGetService) SearchContent(context.Context, service.ContentSearchRequest) (*service.ContentSearchResult, error) {
+	panic("SearchContent not expected")
+}
+func (s *stubGetService) UsageSummary(context.Context, service.UsageRequest) (*service.UsageSummaryResult, error) {
+	panic("UsageSummary not expected")
+}
+func (s *stubGetService) UsagePairwiseComparison(context.Context, service.UsagePairwiseComparisonRequest) (*service.UsagePairwiseComparisonResponse, error) {
+	panic("UsagePairwiseComparison not expected")
+}
+func (s *stubGetService) ListRecallEntries(context.Context, service.RecallFilter) (*service.RecallList, error) {
+	panic("ListRecallEntries not expected")
+}
+func (s *stubGetService) GetRecallEntry(context.Context, string) (*db.RecallEntry, error) {
+	panic("GetRecallEntry not expected")
+}
+func (s *stubGetService) QueryRecallEntries(context.Context, service.RecallQuery) (*service.RecallQueryResult, error) {
+	panic("QueryRecallEntries not expected")
+}
+func (s *stubGetService) ImportRecallEntries(context.Context, io.Reader, db.RecallImportOptions) (*db.RecallImportResult, error) {
+	panic("ImportRecallEntries not expected")
+}
+func (s *stubGetService) ListSecrets(context.Context, service.SecretListFilter) (*service.SecretFindingList, error) {
+	panic("ListSecrets not expected")
+}
+func (s *stubGetService) ScanSecrets(context.Context, service.SecretScanInput, func(service.SecretScanProgress)) (*service.SecretScanSummary, error) {
+	panic("ScanSecrets not expected")
+}
+
+// stageCodebuffSession creates <projectsRoot>/<project>/chats/<rawID>/
+// chat-messages.json so the FS walk in resolveBareCodebuffID surfaces the
+// location. Returns the project name.
+func stageCodebuffSession(t *testing.T, projectsRoot, project, rawID string) {
+	t.Helper()
+	chatDir := filepath.Join(projectsRoot, project, "chats", rawID)
+	require.NoError(t, os.MkdirAll(chatDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(chatDir, "chat-messages.json"),
+		[]byte("[]"), 0o644,
+	))
+}
+
+func TestResolveBareCodebuffID_LocalMachine_Match(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	stageCodebuffSession(t, tmp, "myproject", "1704067200")
+	cfg := config.Config{
+		// cfg.LocalMachineName drives the --machine=local filter:
+		// a session whose detail.Machine equals cfg.LocalMachineName
+		// passes the gate.
+		LocalMachineName: "test-machine",
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodebuff: {tmp},
+		},
+	}
+	candidate := "codebuff:myproject:1704067200"
+	svc := &stubGetService{
+		getDetails: map[string]*service.SessionDetail{
+			candidate: {Session: db.Session{
+				ID:      candidate,
+				Machine: "test-machine",
+			}},
+		},
+	}
+	got, err := resolveBareCodebuffID(
+		context.Background(), svc, &cfg, "1704067200", "local",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, candidate, got,
+		"matching machine must yield the canonical ID")
+}
+
+func TestResolveBareCodebuffID_LocalMachine_Mismatch(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	stageCodebuffSession(t, tmp, "myproject", "1704067200")
+	cfg := config.Config{
+		LocalMachineName: "test-machine",
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodebuff: {tmp},
+		},
+	}
+	candidate := "codebuff:myproject:1704067200"
+	svc := &stubGetService{
+		// detail.Machine is a remote-synced machine; the default
+		// --machine=local filter must reject it.
+		getDetails: map[string]*service.SessionDetail{
+			candidate: {Session: db.Session{
+				ID:      candidate,
+				Machine: "remote-box",
+			}},
+		},
+	}
+	got, err := resolveBareCodebuffID(
+		context.Background(), svc, &cfg, "1704067200", "local",
+	)
+	require.NoError(t, err)
+	assert.Empty(t, got,
+		"non-matching machine must not surface as a local match")
+}
+
+func TestResolveBareCodebuffID_WildcardMatch(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	stageCodebuffSession(t, tmp, "myproject", "1704067200")
+	cfg := config.Config{
+		LocalMachineName: "test-machine",
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodebuff: {tmp},
+		},
+	}
+	candidate := "codebuff:myproject:1704067200"
+	svc := &stubGetService{
+		// --machine=* must accept any machine value, including a
+		// remote-synced record.
+		getDetails: map[string]*service.SessionDetail{
+			candidate: {Session: db.Session{
+				ID:      candidate,
+				Machine: "remote-box",
+			}},
+		},
+	}
+	got, err := resolveBareCodebuffID(
+		context.Background(), svc, &cfg, "1704067200", "*",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, candidate, got,
+		"wildcard --machine=* must accept records from any machine")
+}
+
+func TestResolveBareCodebuffID_SpecificMachineMatch(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	stageCodebuffSession(t, tmp, "myproject", "1704067200")
+	cfg := config.Config{
+		LocalMachineName: "test-machine",
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodebuff: {tmp},
+		},
+	}
+	candidate := "codebuff:myproject:1704067200"
+	svc := &stubGetService{
+		getDetails: map[string]*service.SessionDetail{
+			candidate: {Session: db.Session{
+				ID:      candidate,
+				Machine: "laptop",
+			}},
+		},
+	}
+	got, err := resolveBareCodebuffID(
+		context.Background(), svc, &cfg, "1704067200", "laptop",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, candidate, got,
+		"exact --machine=laptop must accept records from laptop")
+}
+
+// TestResolveBareCodebuffID_SpecificMachineMismatch pins the inverse of
+// the previous test: a specific machine whose value doesn't match any
+// record must not produce a candidate.
+func TestResolveBareCodebuffID_SpecificMachineMismatch(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	stageCodebuffSession(t, tmp, "myproject", "1704067200")
+	cfg := config.Config{
+		LocalMachineName: "test-machine",
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodebuff: {tmp},
+		},
+	}
+	candidate := "codebuff:myproject:1704067200"
+	svc := &stubGetService{
+		getDetails: map[string]*service.SessionDetail{
+			candidate: {Session: db.Session{
+				ID:      candidate,
+				Machine: "desktop",
+			}},
+		},
+	}
+	got, err := resolveBareCodebuffID(
+		context.Background(), svc, &cfg, "1704067200", "laptop",
+	)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+// TestResolveBareCodebuffID_FreebuffPrefixProbeFromCodebuffRoots pins
+// the dual-agent probe in resolveBareCodebuffID: when only Codebuff
+// roots are configured (the realistic case — Freebuff shares the
+// same on-disk layout but is absent from parser.Registry), the probe
+// still tries both codebuff and freebuff prefixes against the
+// service. This guards against single-prefix regression where the
+// dual-agent probe would mis-classify Freebuff sessions as Codebuff.
+//
+// AgentDirs deliberately registers only codebuff; if both agents
+// point at the same root FindCodebuffFreebuffMatches returns
+// duplicate locations and the resolver fires the ambiguity error,
+// which is correct (two agents see the same on-disk dir) but is
+// out of scope for this particular test.
+func TestResolveBareCodebuffID_FreebuffPrefixProbeFromCodebuffRoots(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	stageCodebuffSession(t, tmp, "myproject", "1704067200")
+	cfg := config.Config{
+		LocalMachineName: "test-machine",
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodebuff: {tmp},
+		},
+	}
+	codebuffID := "codebuff:myproject:1704067200"
+	freebuffID := "freebuff:myproject:1704067200"
+	svc := &stubGetService{
+		getDetails: map[string]*service.SessionDetail{
+			codebuffID: nil,
+			freebuffID: {Session: db.Session{
+				ID:      freebuffID,
+				Machine: "test-machine",
+			}},
+		},
+	}
+	got, err := resolveBareCodebuffID(
+		context.Background(), svc, &cfg, "1704067200", "local",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, freebuffID, got,
+		"Freebuff dual-prefix probe must surface a freebuff row")
+}
+
+// TestResolveCodebuffBareID_ServerBareReturnsError pins the E half of
+// E+C: a non-canonical input against --server must NOT silently fall
+// through to findSessionIDsByPartial (which was the previous bug
+// surface). Instead it returns an action-oriented error pointing at
+// `session list` and the canonical ID shapes.
+func TestResolveCodebuffBareID_ServerBareReturnsError(t *testing.T) {
+	t.Parallel()
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("server", "", "")
+	cmd.Flags().String("machine", "local", "")
+	cmd.Flags().Bool("pg", false, "")
+	require.NoError(t, cmd.Flags().Set("server", "http://remote.example"))
+	// svc.Get would panic because Get panics in stubGetService when
+	// the path is wrong. We must never reach it. The bare input is
+	// an ISO 8601 timestamp ("YYYY-MM-DDTHH-MM-SS.fffZ") — the
+	// shape parseCodebuffSessionDate accepts as a Codebuff/Freebuff
+	// session-dir name. A numeric-Unix-epoch like "1704067200" is
+	// NOT a Codebuff timestamp and would short-circuit before the
+	// remote-error branch (covered by
+	// TestResolveCodebuffBareID_ServerBareUUIDForOtherAgent).
+	svc := &stubGetService{}
+	got, err := resolveCodebuffBareID(
+		cmd, svc, "2026-07-16T00-09-00.236Z",
+	)
+	require.Error(t, err)
+	assert.Empty(t, got)
+	assert.Contains(t, err.Error(), "session list")
+	// Regression-test every canonical-ID shape the error
+	// enumerates. Stripping any of these lines from
+	// errBareCodebuffRemoteUnsupported must break this test.
+	assert.Contains(t, err.Error(), "codebuff:<project>:<ts>")
+	assert.Contains(t, err.Error(), "freebuff:<project>:<ts>")
+	assert.Contains(t, err.Error(), "host~codebuff:<project>:<ts>")
+	assert.Contains(t, err.Error(), "host~freebuff:<project>:<ts>")
+	// No Get calls must occur on the remote-error path.
+	assert.Empty(t, svc.getCalls,
+		"--server must not probe svc.Get for bare timestamps")
+}
+
+// TestResolveCodebuffBareID_PGBareReturnsError mirrors the previous
+// test for the --pg path, which was the second roborev-flagged code
+// path. Symmetric coverage guards against future divergence.
+func TestResolveCodebuffBareID_PGBareReturnsError(t *testing.T) {
+	t.Parallel()
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("server", "", "")
+	cmd.Flags().String("machine", "local", "")
+	cmd.Flags().Bool("pg", false, "")
+	require.NoError(t, cmd.Flags().Set("pg", "true"))
+	// Same ISO-8601 shape as the --server variant — see comment
+	// on TestResolveCodebuffBareID_ServerBareReturnsError.
+	svc := &stubGetService{}
+	got, err := resolveCodebuffBareID(
+		cmd, svc, "2026-07-16T00-09-00.236Z",
+	)
+	require.Error(t, err)
+	assert.Empty(t, got)
+	assert.Contains(t, err.Error(), "session list")
+	assert.Contains(t, err.Error(), "codebuff:<project>:<ts>")
+	assert.Contains(t, err.Error(), "freebuff:<project>:<ts>")
+	assert.Contains(t, err.Error(), "host~codebuff:<project>:<ts>")
+	assert.Contains(t, err.Error(), "host~freebuff:<project>:<ts>")
+	assert.Empty(t, svc.getCalls)
+}
+
+// TestResolveCodebuffBareID_ServerBareUUIDForOtherAgent pins the
+// regression fix: a non-canonical but non-Codebuff input (e.g. a
+// bare Codex / Copilot / Gemini UUID) must NOT trigger the
+// Codebuff-specific error on remote stores. It must pass through
+// ("", nil) so the generic prefix resolver retries each registered
+// agent. Without this guard, every --pg / --server bare lookup
+// that previously fell through resolveServiceSessionID's prefix
+// loop would short-circuit to the Codebuff error.
+func TestResolveCodebuffBareID_ServerBareUUIDForOtherAgent(t *testing.T) {
+	t.Parallel()
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("server", "", "")
+	cmd.Flags().String("machine", "local", "")
+	cmd.Flags().Bool("pg", false, "")
+	require.NoError(t, cmd.Flags().Set("server", "http://remote.example"))
+	svc := &stubGetService{}
+	// 36-char hex with dashes — the shape of a real Codex /
+	// Copilot / Gemini bare UUID. Definitely not a
+	// Codebuff/Freebuff ISO timestamp.
+	got, err := resolveCodebuffBareID(
+		cmd, svc, "abcdef01-2345-6789-abcd-ef0123456789",
+	)
+	require.NoError(t, err,
+		"non-Codebuff bare input must NOT fire the Codebuff error "+
+			"on --server; it must fall through to the generic "+
+			"resolver so resolveServiceSessionID can retry the "+
+			"registered agent prefixes")
+	assert.Empty(t, got,
+		"resolveCodebuffBareID has no canonical ID to produce "+
+			"for a non-Codebuff-shape input; calling code "+
+			"preserves id for lookupSessionWithPrefixes")
+	assert.Empty(t, svc.getCalls,
+		"the early-exit path must not probe svc.Get")
+}
+
+// TestResolveCodebuffBareID_PGBareUUIDForOtherAgent mirrors the
+// previous test for the --pg transport. Symmetric coverage guards
+// against future divergence between --server and --pg paths.
+func TestResolveCodebuffBareID_PGBareUUIDForOtherAgent(t *testing.T) {
+	t.Parallel()
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("server", "", "")
+	cmd.Flags().String("machine", "local", "")
+	cmd.Flags().Bool("pg", false, "")
+	require.NoError(t, cmd.Flags().Set("pg", "true"))
+	svc := &stubGetService{}
+	got, err := resolveCodebuffBareID(
+		cmd, svc, "abcdef01-2345-6789-abcd-ef0123456789",
+	)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+	assert.Empty(t, svc.getCalls)
+}
+
+// TestResolveCodebuffBareID_CanonicalSkipsBare pins pass-through
+// behaviour: canonical IDs must skip the resolver regardless of
+// transport, because lookupSessionWithPrefixes handles them via the
+// existing prefix-aware Get path. This protects against the Freebuff
+// canonical-check fix regressing canonical-ID handling under --pg.
+func TestResolveCodebuffBareID_CanonicalSkipsBare(t *testing.T) {
+	t.Parallel()
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("server", "", "")
+	cmd.Flags().String("machine", "local", "")
+	cmd.Flags().Bool("pg", false, "")
+	require.NoError(t, cmd.Flags().Set("pg", "true"))
+
+	cases := []string{
+		"codebuff:proj:1704067200",      // codebuff canonical
+		"freebuff:proj:1704067200",      // freebuff canonical (new)
+		"host~codebuff:proj:1704067200", // remote-synced canonical
+		"host~freebuff:proj:1704067200", // remote-synced freebuff
+	}
+	for _, id := range cases {
+		t.Run(id, func(t *testing.T) {
+			t.Parallel()
+			// svc.Get panics if called; canonical IDs must skip
+			// the bare bridge entirely.
+			svc := &stubGetService{}
+			got, err := resolveCodebuffBareID(cmd, svc, id)
+			require.NoError(t, err)
+			assert.Empty(t, got)
+			assert.Empty(t, svc.getCalls)
+		})
+	}
+}
+
+// TestIsCanonicalServiceSessionID_FreebuffPrefix pins the Freebuff
+// special case. Without it, `freebuff:<proj>:<ts>` would be
+// misclassified as a bare timestamp and --pg would reject it under
+// option E.
+func TestIsCanonicalServiceSessionID_FreebuffPrefix(t *testing.T) {
+	t.Parallel()
+	assert.True(t, isCanonicalServiceSessionID("freebuff:proj:1704067200"),
+		"freebuff: prefix must be recognised as canonical")
+	assert.True(t, isCanonicalServiceSessionID("host~freebuff:proj:1704067200"),
+		"host~freebuff: remote-synced freebuff must be recognised")
+}
+
+// TestIsCanonicalServiceSessionID_BareTimestampNotCanonical pins the
+// inverse: a bare timestamp must NOT be flagged as canonical so it
+// enters the bare-resolution path on local reads.
+func TestIsCanonicalServiceSessionID_BareTimestampNotCanonical(t *testing.T) {
+	t.Parallel()
+	assert.False(t, isCanonicalServiceSessionID("1704067200"))
+	assert.False(t, isCanonicalServiceSessionID("2026-07-16T00-09-00.236Z"))
+}
+
+// TestResolveBareCodebuffID_RemoteHostPrefixedMatch exercises the
+// host-prefixed canonical ID resolution path: when the unprefixed
+// probe returns nil and the machine filter is non-local, the
+// resolver queries FindSessionIDsByPartial with the timestamp suffix
+// and surfaces a qualifying host~-prefixed session.
+func TestResolveBareCodebuffID_RemoteHostPrefixedMatch(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	stageCodebuffSession(t, tmp, "myproject", "1704067200")
+	cfg := config.Config{
+		LocalMachineName: "test-machine",
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodebuff: {tmp},
+		},
+	}
+	// Local probe returns a detail whose machine is "test-machine",
+	// so codebuffMachineMatches("test-machine", "laptop", ...) rejects
+	// it. The unprefixed probe returns nil, falling through to the
+	// remote-probe path.
+	candidate := "codebuff:myproject:1704067200"
+	remoteID := "host~codebuff:myproject:1704067200"
+	svc := &stubGetService{
+		getDetails: map[string]*service.SessionDetail{
+			candidate: {Session: db.Session{
+				ID:      candidate,
+				Machine: "test-machine",
+			}},
+			remoteID: {Session: db.Session{
+				ID:      remoteID,
+				Machine: "laptop",
+			}},
+		},
+		partialIDs: []string{remoteID},
+	}
+	got, err := resolveBareCodebuffID(
+		context.Background(), svc, &cfg, "1704067200", "laptop",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, remoteID, got,
+		"host-prefixed remote session matching the machine filter must be returned")
+}
+
+// TestResolveBareCodebuffID_RemoteAmbiguity exercises the case where
+// multiple host-prefixed sessions match the same bare timestamp and
+// machine filter, producing an ambiguity error instead of silently
+// picking the first.
+func TestResolveBareCodebuffID_RemoteAmbiguity(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	stageCodebuffSession(t, tmp, "myproject", "1704067200")
+	cfg := config.Config{
+		LocalMachineName: "test-machine",
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodebuff: {tmp},
+		},
+	}
+	// Only register remote-synced sessions — NO local candidate in
+	// getDetails so the unprefixed probe returns nil and falls
+	// through to the remote resolution path.
+	remoteA := "host-a~codebuff:myproject:1704067200"
+	remoteB := "host-b~codebuff:myproject:1704067200"
+	svc := &stubGetService{
+		getDetails: map[string]*service.SessionDetail{
+			remoteA: {Session: db.Session{
+				ID:      remoteA,
+				Machine: "host-a",
+			}},
+			remoteB: {Session: db.Session{
+				ID:      remoteB,
+				Machine: "host-b",
+			}},
+		},
+		partialIDs: []string{remoteA, remoteB},
+	}
+	got, err := resolveBareCodebuffID(
+		context.Background(), svc, &cfg, "1704067200", "*",
+	)
+	require.Error(t, err)
+	assert.Empty(t, got)
+	assert.Contains(t, err.Error(), "ambiguous session id")
+	assert.Contains(t, err.Error(), remoteA)
+	assert.Contains(t, err.Error(), remoteB)
+}
+
+// TestResolveBareCodebuffID_RemoteOnlyNoLocations exercises the
+// case where no local filesystem directory matches the timestamp
+// (len(locations)==0), but a remote-synced session exists in the
+// database. The resolver must query the database independently of
+// the filesystem walk and surface the host-prefixed candidate.
+func TestResolveBareCodebuffID_RemoteOnlyNoLocations(t *testing.T) {
+	t.Parallel()
+	// Point AgentDirs at a temp dir with NO Codebuff session
+	// subdirectories — FindCodebuffFreebuffMatches returns zero
+	// locations, which previously caused an immediate "", nil
+	// return without ever querying the database.
+	tmp := t.TempDir()
+	cfg := config.Config{
+		LocalMachineName: "test-machine",
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodebuff: {tmp},
+		},
+	}
+	remoteID := "host~codebuff:someproject:1704067200"
+	svc := &stubGetService{
+		getDetails: map[string]*service.SessionDetail{
+			remoteID: {Session: db.Session{
+				ID:      remoteID,
+				Machine: "remote-box",
+			}},
+		},
+		partialIDs: []string{remoteID},
+	}
+	got, err := resolveBareCodebuffID(
+		context.Background(), svc, &cfg, "1704067200", "*",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, remoteID, got,
+		"remote-only session must resolve without a local filesystem match")
+}
+
+// TestResolveBareCodebuffID_FailClosedOnLookupError pins the
+// fail-closed contract in resolveBareCodebuffID: when one candidate
+// probe succeeds and another errors, the error must be returned even
+// though a valid candidate exists. A failed probe could hide a second
+// match, so returning the lone success may resolve an ID that is
+// genuinely ambiguous. The pre-fix code only surfaced lookupErr when
+// len(valid)==0, silently dropping the error in this exact scenario.
+func TestResolveBareCodebuffID_FailClosedOnLookupError(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	stageCodebuffSession(t, tmp, "myproject", "1704067200")
+	stageCodebuffSession(t, tmp, "otherproject", "1704067200")
+	cfg := config.Config{
+		LocalMachineName: "test-machine",
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodebuff: {tmp},
+		},
+	}
+	good := "codebuff:myproject:1704067200"
+	bad := "codebuff:otherproject:1704067200"
+	svc := &stubGetService{
+		getDetails: map[string]*service.SessionDetail{
+			good: {Session: db.Session{
+				ID:      good,
+				Machine: "test-machine",
+			}},
+		},
+		getErrs: map[string]error{
+			bad: errors.New("backend failure"),
+		},
+	}
+	got, err := resolveBareCodebuffID(
+		context.Background(), svc, &cfg, "1704067200", "local",
+	)
+	require.Error(t, err)
+	assert.Empty(t, got)
+	assert.Contains(t, err.Error(), "backend failure")
+}
+
+// TestCodebuffMachineMatches_EmptyFilter pins the empty-string arm
+// of codebuffMachineMatches. The production --machine flag default is
+// "local" so an empty filter never reaches the resolver naturally,
+// but the helper itself treats "" and "local" identically; a future
+// refactor that splits them would silently alter behaviour. This
+// test guards the invariant.
+func TestCodebuffMachineMatches_EmptyFilter(t *testing.T) {
+	t.Parallel()
+	assert.True(t, codebuffMachineMatches(
+		"test-machine", "", "test-machine",
+	), "empty filter must defer to localMachine like \"local\" does")
+	assert.False(t, codebuffMachineMatches(
+		"other", "", "test-machine",
+	), "empty filter must still reject mismatched machines")
 }

--- a/cmd/agentsview/session_get_test.go
+++ b/cmd/agentsview/session_get_test.go
@@ -673,6 +673,119 @@ func TestResolveBareCodebuffID_FailClosedOnLookupError(t *testing.T) {
 	assert.Contains(t, err.Error(), "backend failure")
 }
 
+// TestResolveBareCodebuffID_ArchiveOnlyLocalMatch pins archive
+// preservation for bare-ID resolution: a local Codebuff session whose
+// source directory was deleted still has an unprefixed archive row
+// ("codebuff:<project>:<ts>"), and the default --machine=local lookup
+// must find it via the database search even though the filesystem walk
+// yields zero locations.
+func TestResolveBareCodebuffID_ArchiveOnlyLocalMatch(t *testing.T) {
+	t.Parallel()
+	// AgentDirs points at an empty directory: the on-disk chats/
+	// tree is gone, so only the archive row can resolve the ID.
+	tmp := t.TempDir()
+	cfg := config.Config{
+		LocalMachineName: "test-machine",
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodebuff: {tmp},
+		},
+	}
+	archived := "codebuff:goneproject:1704067200"
+	svc := &stubGetService{
+		getDetails: map[string]*service.SessionDetail{
+			archived: {Session: db.Session{
+				ID:      archived,
+				Machine: "test-machine",
+			}},
+		},
+		partialIDs: []string{archived},
+	}
+	got, err := resolveBareCodebuffID(
+		context.Background(), svc, &cfg, "1704067200", "local",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, archived, got,
+		"archive-only local session must resolve by bare ID after its "+
+			"source directory is deleted")
+}
+
+// TestResolveBareCodebuffID_ArchivedLocalAndRemoteTwinAmbiguous pins
+// the ambiguity contract under --machine=*: an unprefixed local
+// archive row and a host-prefixed remote twin both match the bare
+// timestamp, so the resolver must return the ambiguity error listing
+// both canonical IDs instead of silently picking the remote one.
+func TestResolveBareCodebuffID_ArchivedLocalAndRemoteTwinAmbiguous(t *testing.T) {
+	t.Parallel()
+	// No on-disk session: the local row exists only in the archive.
+	tmp := t.TempDir()
+	cfg := config.Config{
+		LocalMachineName: "test-machine",
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodebuff: {tmp},
+		},
+	}
+	localID := "codebuff:myproject:1704067200"
+	remoteID := "host~codebuff:myproject:1704067200"
+	svc := &stubGetService{
+		getDetails: map[string]*service.SessionDetail{
+			localID: {Session: db.Session{
+				ID:      localID,
+				Machine: "test-machine",
+			}},
+			remoteID: {Session: db.Session{
+				ID:      remoteID,
+				Machine: "remote-box",
+			}},
+		},
+		partialIDs: []string{localID, remoteID},
+	}
+	got, err := resolveBareCodebuffID(
+		context.Background(), svc, &cfg, "1704067200", "*",
+	)
+	require.Error(t, err,
+		"a local archive row plus a remote twin is ambiguous under "+
+			"--machine=*")
+	assert.Empty(t, got)
+	assert.Contains(t, err.Error(), "ambiguous session id")
+	assert.Contains(t, err.Error(), localID)
+	assert.Contains(t, err.Error(), remoteID)
+}
+
+// TestResolveBareCodebuffID_OnDiskRowNotDoubleCounted pins the
+// dedupe between the filesystem probe and the database search: a
+// session found on disk also has its own unprefixed archive row, and
+// the resolver must treat the two sightings as one candidate rather
+// than firing the ambiguity error against itself.
+func TestResolveBareCodebuffID_OnDiskRowNotDoubleCounted(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	stageCodebuffSession(t, tmp, "myproject", "1704067200")
+	cfg := config.Config{
+		LocalMachineName: "test-machine",
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodebuff: {tmp},
+		},
+	}
+	candidate := "codebuff:myproject:1704067200"
+	svc := &stubGetService{
+		getDetails: map[string]*service.SessionDetail{
+			candidate: {Session: db.Session{
+				ID:      candidate,
+				Machine: "test-machine",
+			}},
+		},
+		// The database search returns the same archive row the
+		// filesystem probe already surfaced.
+		partialIDs: []string{candidate},
+	}
+	got, err := resolveBareCodebuffID(
+		context.Background(), svc, &cfg, "1704067200", "local",
+	)
+	require.NoError(t, err,
+		"a session's own archive row must not make it ambiguous")
+	assert.Equal(t, candidate, got)
+}
+
 // TestCodebuffMachineMatches_EmptyFilter pins the empty-string arm
 // of codebuffMachineMatches. The production --machine flag default is
 // "local" so an empty filter never reaches the resolver naturally,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -242,6 +242,7 @@ can still be parsed.
 | Claude Code           | `~/.claude/projects/`                                                            | JSONL per session                                                                                                               |
 | OpenClaude            | `~/.openclaude/projects/`                                                        | JSONL per session                                                                                                               |
 | Claude Cowork         | (platform-specific, see below)                                                   | Claude Desktop cowork sessions                                                                                                  |
+| Codebuff / Freebuff   | `~/.config/manicode/projects/`                                                   | Per-session `chat-messages.json` + `run-state.json` with subagent transcripts                                                  |
 | Codex                 | `~/.codex/sessions/` and `~/.codex/archived_sessions/`                           | JSONL per session                                                                                                               |
 | Command Code          | `~/.commandcode/projects/`                                                       | JSONL per session, optional `.meta.json` sidecar                                                                                |
 | Copilot CLI           | `~/.copilot/`                                                                    | JSONL per session under `session-state/`                                                                                        |
@@ -415,6 +416,43 @@ location:
 
 Set `COWORK_DIR` or `cowork_dirs` when Claude Desktop stores local-agent-mode
 sessions somewhere else.
+
+**Codebuff / Freebuff sessions:** Codebuff and Freebuff share the same on-disk
+layout under `~/.config/manicode/projects/`. Each session is a timestamped
+directory containing `chat-messages.json` (the full transcript with subagent
+invocations), `run-state.json` (metadata including the agent type and model),
+and optional `chat-meta.json`.
+
+AgentsView auto-classifies each session as **Codebuff** (paid) or **Freebuff**
+(free tier) based on the `agentType` field in `run-state.json`: sessions whose
+`agentType` contains `"free"` are filed under Freebuff. Both agent types appear
+as separate filters in the session list so you can view paid and free sessions
+independently.
+
+Subagent tool calls (basher, code-searcher, file-picker, code-reviewer, etc.)
+are parsed from the AI message blocks and displayed inline in the transcript
+view. The agent template (e.g. `base2-free-deepseek`, `base2-free-mimo`) is
+read from run-state.json's `agentType` field and shown in the session
+detail header. This is the classification label used server-side to pick
+the per-step LLM; the literal LLM is not persisted by the CLI and is
+not visible in the UI.
+Project names are derived from the session's working directory via git-root
+detection.
+
+Codebuff and Freebuff sessions report cost only. The CLI's on-disk
+format does not persist per-message input/output/cache tokens, so the
+daily usage model breakdown shows the cost-attributed agent template
+(e.g. `base2-deepseek`, `base2-free-minimax-m3`) without per-message
+token figures. Reported-cost rows ride as microdollars on `money.Money`
+like every other agent, and per-model rates for `base2-*` templates are
+not in the embedded pricing tables, so cache savings for these rows
+resolve to zero by design rather than an aggregator bug.
+
+Freebuff does not have its own environment variable or config key — it shares
+the Codebuff provider for discovery and the parser auto-classifies sessions.
+Set `CODEBUFF_DIR` or `codebuff_dirs` when manicode stores its projects
+directory somewhere other than `~/.config/manicode/projects`; this covers both
+Codebuff and Freebuff sessions.
 
 **OpenHands CLI shallow watch:** OpenHands stores each conversation in its own
 subdirectory, which would consume one recursive file watch per session and can
@@ -592,6 +630,7 @@ export CLAUDE_PROJECTS_DIR=~/custom/claude
 export OPENCLAUDE_PROJECTS_DIR=~/custom/openclaude/projects
 export OPENCLAUDE_CONFIG_DIR=~/custom/openclaude
 export COWORK_DIR=~/custom/cowork
+export CODEBUFF_DIR=~/custom/manicode/projects
 export CODEX_SESSIONS_DIR=~/custom/codex
 export COMMANDCODE_PROJECTS_DIR=~/custom/commandcode
 export COPILOT_DIR=~/custom/copilot
@@ -659,7 +698,7 @@ codex_sessions_dirs = [
 
 The corresponding fields are `aider_dirs`, `amp_dirs`, `antigravity_dirs`,
 `antigravity_cli_dirs`, `claude_project_dirs`, `openclaude_project_dirs`,
-`cowork_dirs`, `devin_dirs`, `codex_sessions_dirs`, `commandcode_project_dirs`,
+`cowork_dirs`, `devin_dirs`, `codebuff_dirs`, `codex_sessions_dirs`, `commandcode_project_dirs`,
 `copilot_dirs`, `cortex_dirs`, `cursor_project_dirs`,
 `deepseek_tui_sessions_dirs`, `forge_dirs`, `gemini_dirs`, `goose_dirs`,
 `gptme_dirs`, `grok_dirs`, `hermes_sessions_dirs`, `iflow_dirs`, `kilo_dirs`,

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -1546,3 +1546,41 @@ Grok section and remove the explicit registry exception in the coverage test.
 - **Agentsview:** `internal/parser/omnigent.go` and
   `internal/parser/omnigent_provider.go`; fixtures under
   `internal/parser/testdata/omnigent/` provide observed event-shape evidence.
+  
+## Codebuff (`codebuff`)
+
+- **Format:** Per-session JSON files under
+  `<root>/<project>/chats/<timestamp>/`. Each session directory contains
+  `chat-messages.json` (JSON array of user/ai/error message objects with
+  text, tool, agent, mode-divider, plan, ask-user, and image blocks),
+  `run-state.json` (agent type, context token count, credits used, cwd,
+  and skill catalog), and optional `chat-meta.json` (message count,
+  first prompt, and messages size). Freebuff sessions share the same
+  layout and are distinguished by the `agentType` field containing
+  `"free"`.
+- **Evidence:** `source`.
+- **Upstream:** Clone `https://github.com/CodebuffAI/codebuff.git` at
+  `b285b562b9ef3a3f35272ed32718eeb74dd86283`; see
+  [chat.ts](https://github.com/CodebuffAI/codebuff/blob/b285b562b9ef3a3f35272ed32718eeb74dd86283/cli/src/types/chat.ts)
+  for the `ChatMessage` and `ContentBlock` type definitions that define
+  the on-disk format, and
+  [session-state.ts](https://github.com/CodebuffAI/codebuff/blob/b285b562b9ef3a3f35272ed32718eeb74dd86283/common/src/types/session-state.ts)
+  for the `AgentState` type that defines `contextTokenCount` and
+  `creditsUsed`. Freebuff shares the same layout and is distinguished by
+  the `agentType` field in `run-state.json`.
+- **Usage and cost:** The `contextTokenCount` field in
+  `run-state.json` provides context window token counts (updated per
+  API step). The `creditsUsed` and `directCreditsUsed` fields provide
+  session-level billing totals (1 credit = $0.01). The `agentType` field
+  records the agent template name (e.g. `base2-deepseek`,
+  `base2-free-mimo`), which encodes the model family but is not the
+  actual LLM model -- the real model is selected server-side and can
+  change mid-session; mid-session model switches are not detectable from
+  the on-disk format. Per-message token breakdown (input/output/cache)
+  is not available; only context window size and billing credits are
+  persisted. Freebuff (free tier) has no credits -- it is ad-supported
+  with daily session limits.
+- **Agentsview:** `internal/parser/codebuff.go` and
+  `internal/parser/codebuff_provider.go`; single-file provider with
+  JSON array parsing.
+

--- a/docs/session-api.md
+++ b/docs/session-api.md
@@ -106,6 +106,7 @@ use local SQLite unless `--pg` is supplied.
 | `--json`                     | Alias for `--format json`.                       |
 | `--server <url>`             | Explicit daemon URL for HTTP-backed operations.  |
 | `--server-token-file <path>` | Bearer token file for an explicit `--server` URL. |
+| `--machine <value>`          | Filter bare Codebuff/Freebuff timestamp resolution to a single machine identity (`local`, a name, or `*`). Default `local`. `session get` only; canonical IDs and other agents are unaffected. |
 | `--pg`                       | Read from configured PostgreSQL instead of SQLite. |
 
 ## Shared metadata endpoints
@@ -150,6 +151,33 @@ Return session metadata plus computed signal fields. Shape matches
 
 ```bash
 agentsview session get <id> [--format json]
+```
+
+**Bare timestamps on remote stores.** Codebuff/Freebuff sessions live as
+`<agent>:<project>:<timestamp>` canonical IDs; a bare timestamp
+(e.g. `2026-07-16T00-09-00.236Z`) is not a canonical ID. Against the
+local archive the CLI resolves a bare timestamp to its canonical ID
+by walking the configured codebuff/freebuff roots, gated by
+`--machine` (default `local`).Against a remote store (`--server`, `--pg`) a bare Codebuff/Freebuff timestamp is rejected with an
+explicit error pointing at `session list`, because a bare timestamp is
+intrinsically ambiguous across machines and projects.
+The rejection is scoped to the Codebuff/Freebuff timestamp shape;
+bare IDs that are not timestamps (Codex / Copilot / Gemini UUIDs,
+etc.) are unaffected and continue to resolve via the registered
+agent prefix retry on remote reads, the same way they do locally.
+Always pass the full canonical ID on remote reads when one is
+known:
+
+```bash
+# Local reads: bare timestamp OK (--machine=local by default).
+agentsview session get 2026-07-16T00-09-00.236Z
+agentsview session get 2026-07-16T00-09-00.236Z --machine=*
+
+# Remote reads: pass the canonical ID from `session list`.
+agentsview session get codebuff:myproject:1704067200 --pg
+agentsview session get freebuff:myproject:1704067200 --pg
+agentsview session get host~codebuff:myproject:1704067200 --server http://remote
+agentsview session get host~freebuff:myproject:1704067200 --server http://remote
 ```
 
 ```json

--- a/docs/session-api.md
+++ b/docs/session-api.md
@@ -158,7 +158,8 @@ agentsview session get <id> [--format json]
 (e.g. `2026-07-16T00-09-00.236Z`) is not a canonical ID. Against the
 local archive the CLI resolves a bare timestamp to its canonical ID
 by walking the configured codebuff/freebuff roots, gated by
-`--machine` (default `local`).Against a remote store (`--server`, `--pg`) a bare Codebuff/Freebuff timestamp is rejected with an
+`--machine` (default `local`). Against a remote store (`--server`,
+`--pg`) a bare Codebuff/Freebuff timestamp is rejected with an
 explicit error pointing at `session list`, because a bare timestamp is
 intrinsically ambiguous across machines and projects.
 The rejection is scoped to the Codebuff/Freebuff timestamp shape;

--- a/frontend/src/lib/utils/agents.test.ts
+++ b/frontend/src/lib/utils/agents.test.ts
@@ -52,6 +52,8 @@ describe("KNOWN_AGENTS", () => {
       "roocode",
       "poolside",
       "omnigent",
+      "codebuff",
+      "freebuff",
     ]);
   });
 

--- a/frontend/src/lib/utils/agents.ts
+++ b/frontend/src/lib/utils/agents.ts
@@ -86,6 +86,8 @@ export const KNOWN_AGENTS: readonly AgentMeta[] = [
   { name: "roocode", color: "var(--accent-rose)", label: "RooCode" },
   { name: "poolside", color: "var(--accent-cyan)", label: "Poolside" },
   { name: "omnigent", color: "var(--accent-teal)", label: "Omnigent" },
+  { name: "codebuff", color: "var(--accent-amber)", label: "Codebuff" },
+  { name: "freebuff", color: "var(--accent-sky)", label: "Freebuff" },
 ];
 
 const agentColorMap = new Map(

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -24,6 +24,25 @@ import (
 
 const projectIdentityRemoteScrubCompletedKey = "project_identity_remote_scrub_v1"
 
+// provider_freshnessDDL is the per-component stat-hash side-table for
+// providers with multi-file on-disk layouts (currently Codebuff and
+// Freebuff). The engine uses it to short-circuit warm sync over an
+// unchanged archive without invoking provider.Fingerprint on the hot
+// path. CREATE TABLE IF NOT EXISTS is idempotent, so legacy DBs created
+// before this table existed gain it on the next Open without a version
+// bump.
+const provider_freshnessDDL = `
+CREATE TABLE IF NOT EXISTS provider_freshness (
+    agent         TEXT NOT NULL,
+    file_path     TEXT NOT NULL,
+    stat_hash     INTEGER NOT NULL,
+    updated_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    PRIMARY KEY (agent, file_path)
+);
+CREATE INDEX IF NOT EXISTS idx_provider_freshness_updated_at
+    ON provider_freshness(updated_at);
+`
+
 // dataVersion tracks parser changes that require a full
 // re-sync. Increment this when parsing logic changes in ways
 // that affect stored data (e.g. new fields extracted, content
@@ -2185,6 +2204,11 @@ func applySchemaColumnMigrations(w *writerHandle) error {
 		return fmt.Errorf("starting column migration transaction: %w", err)
 	}
 	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.Exec(provider_freshnessDDL); err != nil {
+		return fmt.Errorf(
+			"creating provider_freshness side-table: %w", err)
+	}
 
 	if err := applyColumnMigrations(
 		schemaColumnMigrations(),

--- a/internal/db/freshness.go
+++ b/internal/db/freshness.go
@@ -1,0 +1,82 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+// GetProviderStatHash returns the per-component stat digest stored against
+// (agent, file_path), if any. Returns (0, false, nil) when no row exists,
+// which lets the engine treat the absence as "not yet populated" and fall
+// through to a real fingerprint+parse on the first sync after a provider
+// opts in. The integer reads signed (SQLite INTEGER is int64) but the
+// hash is always non-negative in practice; callers do not depend on the
+// sign.
+func (db *DB) GetProviderStatHash(
+	ctx context.Context,
+	agent parser.AgentType,
+	filePath string,
+) (uint64, bool, error) {
+	var h int64
+	err := db.getReader().QueryRowContext(ctx,
+		"SELECT stat_hash FROM provider_freshness"+
+			" WHERE agent = ? AND file_path = ?",
+		string(agent), filePath,
+	).Scan(&h)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, fmt.Errorf(
+			"reading provider_freshness for %s/%s: %w", agent, filePath, err)
+	}
+	return uint64(h), true, nil
+}
+
+// UpsertProviderStatHash records the per-component stat digest against
+// (agent, file_path). Replaces any existing row. updated_at is refreshed
+// to the current time so future cache-eviction sweeps can drop stale
+// entries for archived files.
+func (db *DB) UpsertProviderStatHash(
+	ctx context.Context,
+	agent parser.AgentType,
+	filePath string,
+	hash uint64,
+) error {
+	_, err := db.getWriter().ExecContext(ctx,
+		"INSERT INTO provider_freshness (agent, file_path, stat_hash)"+
+			" VALUES (?, ?, ?)"+
+			" ON CONFLICT (agent, file_path) DO UPDATE SET"+
+			"   stat_hash = excluded.stat_hash,"+
+			"   updated_at = excluded.updated_at",
+		string(agent), filePath, int64(hash),
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"upserting provider_freshness for %s/%s: %w", agent, filePath, err)
+	}
+	return nil
+}
+
+// DeleteProviderStatHash drops the freshness row for (agent, file_path).
+// Callers use this on tombstoning paths so a future discovery of the same
+// path starts with a clean absence and forces a full parse.
+func (db *DB) DeleteProviderStatHash(
+	ctx context.Context,
+	agent parser.AgentType,
+	filePath string,
+) error {
+	_, err := db.getWriter().ExecContext(ctx,
+		"DELETE FROM provider_freshness WHERE agent = ? AND file_path = ?",
+		string(agent), filePath,
+	)
+	if err != nil {
+		return fmt.Errorf(
+			"deleting provider_freshness for %s/%s: %w", agent, filePath, err)
+	}
+	return nil
+}

--- a/internal/db/freshness_test.go
+++ b/internal/db/freshness_test.go
@@ -1,0 +1,52 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+// TestResetAllMtimes_ZeroesMtimesAndClearsFreshness pins the forced
+// full-resync contract: ResetAllMtimes must zero file_mtime on every
+// session AND drop the provider_freshness side-table in one atomic
+// step, so the per-component stat-digest shortcut cannot skip
+// re-processing a session whose mtime was just zeroed.
+func TestResetAllMtimes_ZeroesMtimesAndClearsFreshness(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	const sessionID = "codebuff:proj:1704067200"
+	const chatPath = "/sessions/proj/chats/1704067200"
+	insertSession(t, d, sessionID, "proj", func(s *Session) {
+		s.Agent = "codebuff"
+		s.FileMtime = new(int64(1704067200))
+	})
+	require.NoError(t, d.UpsertProviderStatHash(
+		ctx, parser.AgentCodebuff, chatPath, 42))
+
+	_, mtime, ok := d.GetSessionFileInfo(sessionID)
+	require.True(t, ok)
+	require.Equal(t, int64(1704067200), mtime,
+		"precondition: session must start with a non-zero mtime")
+	hash, present, err := d.GetProviderStatHash(
+		ctx, parser.AgentCodebuff, chatPath)
+	require.NoError(t, err)
+	require.True(t, present,
+		"precondition: freshness row must exist before the reset")
+	require.Equal(t, uint64(42), hash)
+
+	require.NoError(t, d.ResetAllMtimes())
+
+	_, mtime, ok = d.GetSessionFileInfo(sessionID)
+	require.True(t, ok)
+	assert.Zero(t, mtime, "file_mtime must be zeroed for every session")
+	_, present, err = d.GetProviderStatHash(
+		ctx, parser.AgentCodebuff, chatPath)
+	require.NoError(t, err)
+	assert.False(t, present,
+		"provider_freshness must be cleared so the stat-digest "+
+			"shortcut cannot defeat the forced re-sync")
+}

--- a/internal/db/schema.sql
+++ b/internal/db/schema.sql
@@ -90,6 +90,24 @@ CREATE TABLE IF NOT EXISTS sessions (
     sync_marker TEXT
 );
 
+-- provider_freshness stores per-component stat digests that providers
+-- with multi-file on-disk layouts (currently Codebuff and Freebuff)
+-- compute for the engine's stat-only freshness pre-check. The
+-- (agent, file_path) composite key isolates the namespace per provider
+-- so a future multi-file agent (Omnigent, Zed virtual paths, etc.)
+-- can opt in without schema changes. stat_hash is INTEGER (signed
+-- in SQLite but always non-negative; FNV-1a 64 outputs that fit the
+-- same int64 representation).
+CREATE TABLE IF NOT EXISTS provider_freshness (
+    agent         TEXT NOT NULL,
+    file_path     TEXT NOT NULL,
+    stat_hash     INTEGER NOT NULL,
+    updated_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    PRIMARY KEY (agent, file_path)
+);
+CREATE INDEX IF NOT EXISTS idx_provider_freshness_updated_at
+    ON provider_freshness(updated_at);
+
 -- Messages table with ordinal for efficient range queries
 CREATE TABLE IF NOT EXISTS messages (
     id             INTEGER PRIMARY KEY,

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -3904,7 +3904,12 @@ func (db *DB) GetDataVersionByPath(path string) int {
 
 // ResetAllMtimes zeroes file_mtime for every session, forcing
 // the next sync to re-process all files regardless of whether
-// their size+mtime matches what was previously stored.
+// their size+mtime matches what was previously stored. It also
+// clears the provider_freshness side-table so the per-component
+// stat digest cannot defeat the forced re-sync: without this, a
+// Codebuff/Freebuff session whose mtime was zeroed would still
+// skip re-processing via the digest shortcut, preserving stale
+// parsed data indefinitely.
 func (db *DB) ResetAllMtimes() error {
 	db.mu.Lock()
 	defer db.mu.Unlock()
@@ -3913,6 +3918,14 @@ func (db *DB) ResetAllMtimes() error {
 	)
 	if err != nil {
 		return fmt.Errorf("resetting mtimes: %w", err)
+	}
+	// Clear provider_freshness so the stat-digest shortcut cannot
+	// defeat the forced re-sync. A DELETE (not a walk) is safe
+	// because the side-table is rebuilt on the next sync pass.
+	if _, err := db.getWriter().Exec(
+		"DELETE FROM provider_freshness",
+	); err != nil {
+		return fmt.Errorf("clearing provider_freshness: %w", err)
 	}
 	return nil
 }

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -3913,19 +3913,29 @@ func (db *DB) GetDataVersionByPath(path string) int {
 func (db *DB) ResetAllMtimes() error {
 	db.mu.Lock()
 	defer db.mu.Unlock()
-	_, err := db.getWriter().Exec(
-		"UPDATE sessions SET file_mtime = 0",
-	)
+	// Both statements run in one transaction: a failure between them
+	// would otherwise leave mtimes zeroed with digests intact,
+	// letting the stat-digest shortcut defeat the forced re-sync.
+	tx, err := db.getWriter().Begin()
 	if err != nil {
+		return fmt.Errorf("beginning mtime reset tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.Exec(
+		"UPDATE sessions SET file_mtime = 0",
+	); err != nil {
 		return fmt.Errorf("resetting mtimes: %w", err)
 	}
 	// Clear provider_freshness so the stat-digest shortcut cannot
 	// defeat the forced re-sync. A DELETE (not a walk) is safe
 	// because the side-table is rebuilt on the next sync pass.
-	if _, err := db.getWriter().Exec(
+	if _, err := tx.Exec(
 		"DELETE FROM provider_freshness",
 	); err != nil {
 		return fmt.Errorf("clearing provider_freshness: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing mtime reset: %w", err)
 	}
 	return nil
 }

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -4645,6 +4645,49 @@ func TestCostUSDFromCost(t *testing.T) {
 	}
 }
 
+// TestGetDailyUsage_CodebuffCostOnly pins the SQLite aggregator path
+// for Codebuff/Freebuff's parser-emitted cost-only usage event. The
+// Codebuff parser (internal/parser/codebuff.go) attributes the session
+// cost to the agent name ("codebuff" or "freebuff") because the actual
+// LLM model is selected server-side and unknown at parse time. The row
+// must therefore carry Model="codebuff" so it passes the
+// usageEventEligibility filter (non-empty ue.model) and the authoritative
+// reported Cost flows into TotalCost at the daily-usage level. The
+// per-model and per-agent breakdown shapes are aggregator internals
+// covered by other tests; this pins only the cost-flow contract.
+func TestGetDailyUsage_CodebuffCostOnly(t *testing.T) {
+	d := testDB(t)
+	ctx := context.Background()
+
+	insertSession(t, d, "codebuff:cost-only", "proj", func(s *Session) {
+		s.Agent = "codebuff"
+		s.StartedAt = new("2026-07-15T10:00:00Z")
+	})
+	cost := money.MustParseDollars("0.05")
+	require.NoError(t, d.ReplaceSessionUsageEvents(
+		"codebuff:cost-only",
+		[]UsageEvent{{
+			Source:     "session",
+			Model:      "base2-deepseek",
+			Cost:       &cost,
+			CostStatus: "reported",
+			CostSource: "session",
+			OccurredAt: "2026-07-15T10:05:00Z",
+			DedupKey:   "session:codebuff:cost-only",
+		}}))
+
+	daily, err := d.GetDailyUsage(ctx, UsageFilter{
+		From: "2026-07-15", To: "2026-07-15", Timezone: "UTC",
+	})
+	requireNoError(t, err, "GetDailyUsage")
+	assert.Equal(t, cost, daily.Totals.TotalCost,
+		"the codebuff reported cost must surface in daily TotalCost")
+	require.Len(t, daily.Daily, 1,
+		"the cost-only row should produce one daily entry")
+	assert.Equal(t, cost, daily.Daily[0].TotalCost,
+		"the day's TotalCost must include the reported cost")
+}
+
 // TestGetDailyUsage_KimiAliasPricing proves Kimi alias pricing end to end on
 // SQLite: the date-ambiguous aliases
 // (kimi-for-coding, daimon-kimi-code, daimon-kimi-messages) price each

--- a/internal/db/usage_test.go
+++ b/internal/db/usage_test.go
@@ -4648,9 +4648,9 @@ func TestCostUSDFromCost(t *testing.T) {
 // TestGetDailyUsage_CodebuffCostOnly pins the SQLite aggregator path
 // for Codebuff/Freebuff's parser-emitted cost-only usage event. The
 // Codebuff parser (internal/parser/codebuff.go) attributes the session
-// cost to the agent name ("codebuff" or "freebuff") because the actual
-// LLM model is selected server-side and unknown at parse time. The row
-// must therefore carry Model="codebuff" so it passes the
+// cost to the agent template (e.g. "base2-deepseek") rather than the
+// agent name so the per-model breakdown in the usage report stays
+// granular. The row's template-attributed Model passes the
 // usageEventEligibility filter (non-empty ue.model) and the authoritative
 // reported Cost flows into TotalCost at the daily-usage level. The
 // per-model and per-agent breakdown shapes are aggregator internals

--- a/internal/duckdb/analytics_usage.go
+++ b/internal/duckdb/analytics_usage.go
@@ -4703,13 +4703,13 @@ func (s *Store) GetSessionUsage(
 	var authoritativeCost *money.Money
 	var hasComputedCost, hasReportedCost bool
 	deduplicatedOutputTokens := 0
+	// hasRows is "any contributing row processed" and feeds cost
+	// aggregation only. HasTokenData is computed from the session
+	// flags alone (sess.HasTotalOutputTokens || sess.HasPeakContextTokens),
+	// exactly like SQLite and Postgres; no row-derived term may
+	// contribute, so neither cost-only rows nor token-bearing rows
+	// can flip it when the session flags are false.
 	hasRows := false
-	// hasTokenRows tracks whether any contributing row carries billable
-	// token counts. hasRows is "any contributing row processed" and is
-	// still used for cost aggregation; cost-only rows (e.g. a Codebuff
-	// row that reports only explicitCost with zero billable tokens)
-	// must not flip HasTokenData, matching SQLite and Postgres.
-	hasTokenRows := false
 	err = s.forEachSessionUsageAggregateRow(
 		ctx, db.UsageFilter{}, sessionID,
 		func(r duckUsageAggregateRow) error {
@@ -4750,7 +4750,6 @@ func (s *Store) GetSessionUsage(
 				r.billableReason != 0 || r.billableCacheCr != 0 ||
 				r.billableCacheRd != 0 || r.billableWebSearch > 0 {
 				hasComputedCost = true
-				hasTokenRows = true
 			}
 			if !priced {
 				unpriced[r.model] = true
@@ -4790,7 +4789,7 @@ func (s *Store) GetSessionUsage(
 		SessionID: sessionID, Agent: sess.Agent, Project: sess.Project,
 		TotalOutputTokens: max(sess.TotalOutputTokens-deduplicatedOutputTokens, 0),
 		PeakContextTokens: sess.PeakContextTokens,
-		HasTokenData:      hasTokenRows || sess.HasTotalOutputTokens || sess.HasPeakContextTokens,
+		HasTokenData:      sess.HasTotalOutputTokens || sess.HasPeakContextTokens,
 		Models:            sortedBoolKeys(models),
 		UnpricedModels:    sortedBoolKeys(unpriced),
 		BreakdownCount:    breakdownCount,

--- a/internal/duckdb/analytics_usage.go
+++ b/internal/duckdb/analytics_usage.go
@@ -4704,6 +4704,12 @@ func (s *Store) GetSessionUsage(
 	var hasComputedCost, hasReportedCost bool
 	deduplicatedOutputTokens := 0
 	hasRows := false
+	// hasTokenRows tracks whether any contributing row carries billable
+	// token counts. hasRows is "any contributing row processed" and is
+	// still used for cost aggregation; cost-only rows (e.g. a Codebuff
+	// row that reports only explicitCost with zero billable tokens)
+	// must not flip HasTokenData, matching SQLite and Postgres.
+	hasTokenRows := false
 	err = s.forEachSessionUsageAggregateRow(
 		ctx, db.UsageFilter{}, sessionID,
 		func(r duckUsageAggregateRow) error {
@@ -4744,6 +4750,7 @@ func (s *Store) GetSessionUsage(
 				r.billableReason != 0 || r.billableCacheCr != 0 ||
 				r.billableCacheRd != 0 || r.billableWebSearch > 0 {
 				hasComputedCost = true
+				hasTokenRows = true
 			}
 			if !priced {
 				unpriced[r.model] = true
@@ -4783,7 +4790,7 @@ func (s *Store) GetSessionUsage(
 		SessionID: sessionID, Agent: sess.Agent, Project: sess.Project,
 		TotalOutputTokens: max(sess.TotalOutputTokens-deduplicatedOutputTokens, 0),
 		PeakContextTokens: sess.PeakContextTokens,
-		HasTokenData:      hasRows || sess.HasTotalOutputTokens || sess.HasPeakContextTokens,
+		HasTokenData:      hasTokenRows || sess.HasTotalOutputTokens || sess.HasPeakContextTokens,
 		Models:            sortedBoolKeys(models),
 		UnpricedModels:    sortedBoolKeys(unpriced),
 		BreakdownCount:    breakdownCount,

--- a/internal/duckdb/analytics_usage_test.go
+++ b/internal/duckdb/analytics_usage_test.go
@@ -1876,3 +1876,25 @@ func duckHOWMessages(cells []db.HourOfWeekCell, dow, hour int) int {
 	}
 	return -1
 }
+
+// TestDuckUsageEventSourceEligibilityIncludesModel pins the DuckDB
+// aggregator's eligibility filter non-emptiness contract for
+// Codebuff/Freebuff's parser-attributed agent template name. The
+// Codebuff parser (internal/parser/codebuff.go) sets
+// Model = <agentType> (e.g. "base2-deepseek", "base2-free-minimax-m3")
+// rather than the agent name so the per-model breakdown in the
+// usage report stays granular. The eligibility filter must accept
+// any non-empty Model value (the SQL is templated with each row's
+// model name), so the constant must filter on a non-empty ue.model rather
+// than a hard-coded name. Without this pin a future change that
+// hard-codes the accepted model literal would silently drop
+// template-attributed codebuff/freebuff rows.
+func TestDuckUsageEventSourceEligibilityIncludesModel(t *testing.T) {
+	require.NotEmpty(t, duckUsageEventSourceEligibility,
+		"duckUsageEventSourceEligibility must be a non-empty SQL filter")
+	normalized := strings.ToLower(
+		strings.Join(strings.Fields(duckUsageEventSourceEligibility), " "))
+	require.Contains(t, normalized, "ue.model !=",
+		"the filter must reject empty-model rows so codebuff "+
+			"template-attributed rows surface in the breakdown")
+}

--- a/internal/duckdb/analytics_usage_test.go
+++ b/internal/duckdb/analytics_usage_test.go
@@ -1877,24 +1877,57 @@ func duckHOWMessages(cells []db.HourOfWeekCell, dow, hour int) int {
 	return -1
 }
 
-// TestDuckUsageEventSourceEligibilityIncludesModel pins the DuckDB
-// aggregator's eligibility filter non-emptiness contract for
-// Codebuff/Freebuff's parser-attributed agent template name. The
-// Codebuff parser (internal/parser/codebuff.go) sets
-// Model = <agentType> (e.g. "base2-deepseek", "base2-free-minimax-m3")
-// rather than the agent name so the per-model breakdown in the
-// usage report stays granular. The eligibility filter must accept
-// any non-empty Model value (the SQL is templated with each row's
-// model name), so the constant must filter on a non-empty ue.model rather
-// than a hard-coded name. Without this pin a future change that
-// hard-codes the accepted model literal would silently drop
-// template-attributed codebuff/freebuff rows.
-func TestDuckUsageEventSourceEligibilityIncludesModel(t *testing.T) {
-	require.NotEmpty(t, duckUsageEventSourceEligibility,
-		"duckUsageEventSourceEligibility must be a non-empty SQL filter")
-	normalized := strings.ToLower(
-		strings.Join(strings.Fields(duckUsageEventSourceEligibility), " "))
-	require.Contains(t, normalized, "ue.model !=",
-		"the filter must reject empty-model rows so codebuff "+
-			"template-attributed rows surface in the breakdown")
+// TestDuckDailyUsageEventModelEligibility pins the DuckDB
+// aggregator's usage-event eligibility contract for Codebuff/
+// Freebuff's parser-attributed agent template name. The Codebuff
+// parser (internal/parser/codebuff.go) sets Model = <agentType>
+// (e.g. "base2-deepseek", "base2-free-minimax-m3") rather than the
+// agent name so the per-model breakdown in the usage report stays
+// granular. The aggregate must accept any non-empty Model value and
+// reject empty-model rows: hard-coding an accepted model literal
+// would drop the template-attributed cost (TotalCost falls to zero),
+// and dropping the non-empty-model requirement would leak the
+// empty-model row's cost into TotalCost.
+func TestDuckDailyUsageEventModelEligibility(t *testing.T) {
+	ctx := context.Background()
+	templateCost := money.MustParseDollars("0.05")
+	emptyModelCost := money.MustParseDollars("0.99")
+	sess := syncSession(
+		"codebuff:eligibility", "alpha", "cost only",
+		"2026-07-15T10:00:00.000Z", 0)
+	sess.Agent = "codebuff"
+	store := newDuckAnalyticsStore(t, []db.SessionBatchWrite{{
+		Session: sess,
+		UsageEvents: []db.UsageEvent{
+			{
+				Source: "session", Model: "base2-deepseek",
+				Cost: &templateCost, CostStatus: "reported",
+				CostSource: "session",
+				OccurredAt: "2026-07-15T10:05:00Z",
+				DedupKey:   "template-model",
+			},
+			{
+				Source: "session", Model: "",
+				Cost: &emptyModelCost, CostStatus: "reported",
+				CostSource: "session",
+				OccurredAt: "2026-07-15T10:06:00Z",
+				DedupKey:   "empty-model",
+			},
+		},
+		DataVersion: 1, ReplaceMessages: true,
+	}})
+
+	daily, err := store.GetDailyUsage(ctx, db.UsageFilter{
+		From: "2026-07-15", To: "2026-07-15", Timezone: "UTC",
+	})
+	require.NoError(t, err, "GetDailyUsage")
+	assert.Equal(t, templateCost, daily.Totals.TotalCost,
+		"the template-model cost must be included and the "+
+			"empty-model cost excluded")
+	require.Len(t, daily.Daily, 1)
+	assert.Equal(t, templateCost, daily.Daily[0].TotalCost)
+	require.Len(t, daily.Daily[0].ModelBreakdowns, 1,
+		"only the template-attributed model may surface")
+	assert.Equal(t, "base2-deepseek",
+		daily.Daily[0].ModelBreakdowns[0].ModelName)
 }

--- a/internal/duckdb/store_test.go
+++ b/internal/duckdb/store_test.go
@@ -3300,14 +3300,13 @@ func TestDuckDBCostOnlyReportedSessionMatchesSQLite(t *testing.T) {
 // parity rule surfaced by roborev on ab050f8: a Codebuff session whose
 // contributor rows report only explicitCost (cost_source !=
 // 'copilot-reported', zero billable tokens) must NOT flip HasTokenData.
-// The fix in (*Store).sessionUsage splits hasRows ("any contributing
-// row processed") from hasTokenRows ("any row carries billable tokens"),
-// since the cost-only contributor path otherwise set hasRows = true and
-// spilled into HasTokenData via the prior `hasRows ||
-// sess.HasTotalOutputTokens || sess.HasPeakContextTokens` predicate.
-// Mirrors the copilot pattern in TestDuckDBCostOnlyReportedSessionMatchesSQLite
-// but uses a non-copilot cost_source so the row passes the
-// `contributes = true` gate (the copilot path early-returns).
+// (*Store).sessionUsage computes HasTokenData from the session flags
+// alone, matching SQLite and Postgres; a row-derived `hasRows ||`
+// term previously spilled cost-only contributor rows into
+// HasTokenData. Mirrors the copilot pattern in
+// TestDuckDBCostOnlyReportedSessionMatchesSQLite but uses a
+// non-copilot cost_source so the row passes the `contributes = true`
+// gate (the copilot path early-returns).
 func TestDuckDBCostOnlyCodebuffSessionHasTokenDataFalse(t *testing.T) {
 	ctx := context.Background()
 	local := newLocalDB(t)
@@ -3352,6 +3351,57 @@ func TestDuckDBCostOnlyCodebuffSessionHasTokenDataFalse(t *testing.T) {
 			"sess.HasTotalOutputTokens || sess.HasPeakContextTokens "+
 			"short-circuit in (*Store).sessionUsage is the regression "+
 			"this test pins")
+}
+
+// TestDuckDBTokenRowsWithoutSessionFlagsMatchSQLite pins HasTokenData
+// parity with SQLite and PostgreSQL for the inverse of the cost-only
+// case: a session whose usage_events rows DO carry billable tokens but
+// whose session row has HasTotalOutputTokens and HasPeakContextTokens
+// false. SQLite (internal/db) and PostgreSQL compute HasTokenData from
+// the session flags alone, so both report false here; DuckDB must
+// agree instead of deriving true from the token-bearing rows.
+func TestDuckDBTokenRowsWithoutSessionFlagsMatchSQLite(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	// syncSession leaves TotalOutputTokens/PeakContextTokens and both
+	// Has* flags at their zero values, and with no messages in the
+	// batch the sanitizer keeps them false even though the usage
+	// event below carries tokens.
+	sess := syncSession(
+		"duck-flags-off", "alpha", "tokens without flags",
+		"2026-01-18T00:00:00.000Z", 0)
+	_, err := local.WriteSessionBatchAtomic([]db.SessionBatchWrite{{
+		Session: sess,
+		UsageEvents: []db.UsageEvent{{
+			Source: "shutdown", Model: "claude-sonnet-4-6",
+			InputTokens: 1000, OutputTokens: 500,
+			OccurredAt: "2026-01-18T00:01:00.000Z",
+			DedupKey:   "flags-off",
+		}},
+		DataVersion: 1, ReplaceMessages: true,
+	}})
+	require.NoError(t, err)
+
+	want, err := local.GetSessionUsage(ctx, sess.ID, true)
+	require.NoError(t, err)
+	require.NotNil(t, want)
+	require.False(t, want.HasTokenData,
+		"SQLite computes HasTokenData from session flags only")
+
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+	require.NoError(t, createSchema(ctx, syncer.DB()))
+	_, err = syncer.pushEverything(ctx, nil)
+	require.NoError(t, err)
+	store := NewStoreFromDB(syncer.DB())
+
+	got, err := store.GetSessionUsage(ctx, sess.ID, true)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.False(t, got.HasTokenData,
+		"DuckDB must compute HasTokenData from session flags only, "+
+			"not from token-bearing usage rows, to match SQLite and "+
+			"PostgreSQL")
+	assert.Equal(t, want.HasTokenData, got.HasTokenData)
 }
 
 func TestDailyUsageCostsReasoningOnlyRows(t *testing.T) {

--- a/internal/duckdb/store_test.go
+++ b/internal/duckdb/store_test.go
@@ -3296,6 +3296,64 @@ func TestDuckDBCostOnlyReportedSessionMatchesSQLite(t *testing.T) {
 		"the row-count path must exclude cost-only reported rows")
 }
 
+// TestDuckDBCostOnlyCodebuffSessionHasTokenDataFalse pins the backend
+// parity rule surfaced by roborev on ab050f8: a Codebuff session whose
+// contributor rows report only explicitCost (cost_source !=
+// 'copilot-reported', zero billable tokens) must NOT flip HasTokenData.
+// The fix in (*Store).sessionUsage splits hasRows ("any contributing
+// row processed") from hasTokenRows ("any row carries billable tokens"),
+// since the cost-only contributor path otherwise set hasRows = true and
+// spilled into HasTokenData via the prior `hasRows ||
+// sess.HasTotalOutputTokens || sess.HasPeakContextTokens` predicate.
+// Mirrors the copilot pattern in TestDuckDBCostOnlyReportedSessionMatchesSQLite
+// but uses a non-copilot cost_source so the row passes the
+// `contributes = true` gate (the copilot path early-returns).
+func TestDuckDBCostOnlyCodebuffSessionHasTokenDataFalse(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+	reportedCost := money.MustParseDollars("0.0250")
+	sess := syncSession(
+		"codebuff:cost-only", "alpha", "cost only",
+		"2026-01-18T00:00:00.000Z", 0)
+	sess.Agent = "codebuff"
+	_, err := local.WriteSessionBatchAtomic([]db.SessionBatchWrite{{
+		Session: sess,
+		UsageEvents: []db.UsageEvent{{
+			Source:     "shutdown",
+			Model:      "codebuff-base",
+			Cost:       &reportedCost,
+			CostStatus: "exact",
+			// Anything other than db.CopilotReportedCostSource causes
+			// the SQL to set reported_cost_rows = 1, keeping the row
+			// out of the copilot early-return and inside the
+			// contributes=true branch that previously leaked into
+			// HasTokenData.
+			CostSource: "provider",
+			OccurredAt: "2026-01-18T00:01:00.000Z",
+			DedupKey:   "codebuff-cost-only",
+		}},
+		DataVersion: 1, ReplaceMessages: true,
+	}})
+	require.NoError(t, err)
+
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+	require.NoError(t, createSchema(ctx, syncer.DB()))
+	_, err = syncer.pushEverything(ctx, nil)
+	require.NoError(t, err)
+	store := NewStoreFromDB(syncer.DB())
+
+	got, err := store.GetSessionUsage(ctx, sess.ID, true)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.True(t, got.HasCost, "cost-only Codebuff row must still report HasCost")
+	assert.Equal(t, reportedCost, got.Cost)
+	assert.False(t, got.HasTokenData,
+		"a cost-only Codebuff row is not token data; the hasRows || "+
+			"sess.HasTotalOutputTokens || sess.HasPeakContextTokens "+
+			"short-circuit in (*Store).sessionUsage is the regression "+
+			"this test pins")
+}
+
 func TestDailyUsageCostsReasoningOnlyRows(t *testing.T) {
 	ctx := context.Background()
 	local := newLocalDB(t)

--- a/internal/parser/capabilities.go
+++ b/internal/parser/capabilities.go
@@ -72,6 +72,18 @@ type SourceCapabilities struct {
 	// its stored virtual members. A still-present container remains
 	// authoritative for member deletion.
 	PersistentArchive CapabilitySupport
+	// MultiFileStatHash declares that a provider's on-disk source layout
+	// spans multiple sibling files (Codebuff's chat-messages.json plus
+	// run-state.json and chat-meta.json, for example) and that the engine
+	// should consult its per-component provider_freshness digest on
+	// warm passes instead of the legacy size/max-mtime composite
+	// freshness gate. Providers that do not have a multi-file layout
+	// leave this at CapabilityUnsupported; a SourceSetProvider wrapper
+	// still satisfies parser.MultiFileStatHasher unconditionally, so
+	// the engine reads this capability before registering a hasher
+	// in providerStatHashers to avoid short-circuiting every
+	// SourceSet-wrapped agent on a 0==0 digest match.
+	MultiFileStatHash CapabilitySupport
 }
 
 // ContentCapabilities declares optional normalized content fields a provider

--- a/internal/parser/capabilities_sync_test.go
+++ b/internal/parser/capabilities_sync_test.go
@@ -85,6 +85,14 @@ func TestProviderSyncSemanticsDeclarations(t *testing.T) {
 			FingerprintHashRequiredForFreshness: true,
 			UnchangedResults:                    UnchangedResultMTimeAndHash,
 		},
+		// Codebuff requires the per-component stat-hash digest (persisted in
+		// the provider_freshness side-table) before a warm pass may consider a
+		// source fresh; the side-table row is the only signal that sees
+		// companion-file rewrites, offsetting size deltas, and sibling-only
+		// directory mutations.
+		AgentCodebuff: {
+			FingerprintHashRequiredForFreshness: true,
+		},
 	}
 
 	for _, factory := range ProviderFactories() {

--- a/internal/parser/codebuff.go
+++ b/internal/parser/codebuff.go
@@ -1,0 +1,1064 @@
+// ABOUTME: Parses Codebuff/Freebuff chat-messages.json session files into
+// ABOUTME: structured session data. Both agents share the same on-disk layout
+// ABOUTME: under ~/.config/manicode/projects/<project>/chats/<timestamp>/.
+// ABOUTME: The agent type (codebuff vs freebuff) is determined from the
+// ABOUTME: agentType field in run-state.json, and agentType is also
+// ABOUTME: surfaced as the session's UsageEvent.Model so the daily usage
+// ABOUTME: report can bucket similar sessions by template while leaving the literal
+// LLM (server-selected and not persisted on disk) unknown.
+package parser
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/tidwall/gjson"
+
+	"go.kenn.io/agentsview/internal/money"
+)
+
+// codebuffSessionDir contains the session timestamp directory path and
+// the project hint derived from the parent directory name.
+type codebuffSessionDir struct {
+	Path        string
+	ProjectHint string
+}
+
+// parseCodebuffSession parses a single codebuff/freebuff session directory
+// and returns the parsed session with messages.
+func parseCodebuffSession(
+	dir string,
+	projectHint string,
+	machine string,
+) (*ParsedSession, []ParsedMessage, error) {
+	chatMessagesPath := filepath.Join(dir, "chat-messages.json")
+	runStatePath := filepath.Join(dir, "run-state.json")
+	chatMetaPath := filepath.Join(dir, "chat-meta.json")
+
+	// Read run-state.json for model, token, agent-type, and skills data.
+	rs, err := readCodebuffRunState(runStatePath)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, nil, fmt.Errorf("read run-state %s: %w", runStatePath, err)
+	}
+
+	// Read chat-meta.json for session name and timing hints.
+	meta := readCodebuffChatMeta(chatMetaPath)
+
+	// The actual LLM model is selected server-side based on the agentType
+	// template and can change mid-session. The on-disk format does not
+	// persist the actual model, so leave it unknown.
+	model := ""
+
+	// Read and parse the chat messages.
+	data, err := os.ReadFile(chatMessagesPath)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read chat-messages %s: %w", chatMessagesPath, err)
+	}
+	if !gjson.ValidBytes(data) {
+		return nil, nil, fmt.Errorf("decode %s: invalid json", chatMessagesPath)
+	}
+
+	// Session ID is the timestamp directory name (ISO 8601).
+	sessionID := filepath.Base(dir)
+	sessionDate := parseCodebuffSessionDate(sessionID)
+
+	msgs, startedAt, endedAt, err := parseCodebuffMessages(data, sessionDate, model)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse chat-messages %s: %w", chatMessagesPath, err)
+	}
+
+	// Enrich tool calls with skill names by matching against the skills
+	// catalog available to this session (run-state.json.fileContext.skills).
+	// Codebuff/Freebuff invoke skills through generic tool calls (e.g.
+	// run_terminal_command) rather than a dedicated Skill tool, so a tool
+	// call is attributed to a skill when its name or input references a
+	// known skill from the catalog.
+	codebuffAttachSkillNames(msgs, rs.Skills)
+
+	// Build session name from first user prompt.
+	firstMsg := ""
+	for _, msg := range msgs {
+		if msg.Role == RoleUser && !msg.IsSystem &&
+			strings.TrimSpace(msg.Content) != "" {
+			firstMsg = truncate(
+				strings.ReplaceAll(msg.Content, "\n", " "),
+				300,
+			)
+			break
+		}
+	}
+	if firstMsg == "" && meta.FirstPrompt != "" {
+		firstMsg = truncate(
+			strings.ReplaceAll(meta.FirstPrompt, "\n", " "),
+			300,
+		)
+	}
+
+	// Session name from first prompt (better than directory name).
+	sessionName := firstMsg
+	if len(sessionName) > 80 {
+		sessionName = sessionName[:77] + "..."
+	}
+	if sessionName == "" {
+		if rs.Cwd != "" {
+			sessionName = filepath.Base(rs.Cwd)
+		} else {
+			sessionName = projectHint
+		}
+	}
+
+	// Determine agent type from run-state agentType field.
+	// Sessions with "free" in the agentType are Freebuff, others are Codebuff.
+	// Both share the same on-disk layout; the parser splits them by type
+	// so the UI can filter each agent independently.
+	agent := AgentCodebuff
+	agentLabel := "Codebuff"
+	if strings.Contains(strings.ToLower(rs.AgentType), "free") {
+		agent = AgentFreebuff
+		agentLabel = "Freebuff"
+	}
+
+	// Count user messages.
+	userMsgCount := 0
+	for _, msg := range msgs {
+		if msg.Role == RoleUser && !msg.IsSystem &&
+			strings.TrimSpace(msg.Content) != "" {
+			userMsgCount++
+		}
+	}
+	messageCount := len(msgs)
+
+	// If no messages from the transcript, use meta counts.
+	if messageCount == 0 {
+		messageCount = meta.MessageCount
+		if meta.MessageCount > 0 {
+			userMsgCount = 1 // at least one user prompt
+		}
+	}
+
+	// Mark meta-derived counts authoritative. When the on-disk transcript is
+	// empty but chat-meta.json reports a count, the meta totals are the
+	// parser's only source for the session's user-visible counts. Without
+	// this flag the sync engine's applySessionTokenTotalsFromMessages pass
+	// would recompute counts from the empty parsed-message slice and
+	// overwrite the meta totals with zero, hiding the session from any UI
+	// that filters on nonzero counts. Set the flag only in the fallback case
+	// (not when the transcript already provided counts) so the sync engine
+	// keeps reconciling message-derived counts for sessions with real
+	// transcripts.
+	countsAuthoritative := len(msgs) == 0 && meta.MessageCount > 0
+
+	// Model extracted earlier (passed into message parser above).
+
+	// Source file identity: use chat-messages.json as the primary source.
+	info, err := os.Stat(chatMessagesPath)
+	fileInfo := FileInfo{
+		Path: chatMessagesPath,
+	}
+	if err == nil {
+		fileInfo.Size = info.Size()
+		fileInfo.Mtime = info.ModTime().UnixNano()
+	}
+
+	// Use projectHint (the storage directory name) for the session ID
+	// to ensure stability. The cwd-derived project name can change if
+	// the git root changes, which would break source lookup and cause
+	// session ID instability.
+	projectID := projectHint
+	if projectID == "" {
+		projectID = "unknown"
+	}
+	fullID := string(agent) + ":" + projectID + ":" + sessionID
+
+	// Derive display project from run-state cwd for UI display.
+	// Use ExtractProjectFromCwd (git-root aware) rather than
+	// GetProjectName because rs.Cwd is a full absolute path, not
+	// a Claude-style encoded project name.
+	project := projectHint
+	if rs.Cwd != "" {
+		if p := ExtractProjectFromCwd(rs.Cwd); p != "" {
+			project = p
+		}
+	}
+
+	// Fall back StartedAt/EndedAt for sessions whose transcript carries
+	// no parseable message timestamps (empty chat-messages.json, or
+	// messages without timestamp fields). Analytics and sorting need a
+	// real timestamp; fall back to the session directory date, then the
+	// source mtime as a last resort.
+	if startedAt.IsZero() && !sessionDate.IsZero() {
+		startedAt = sessionDate
+	}
+	if startedAt.IsZero() && fileInfo.Mtime > 0 {
+		startedAt = time.Unix(0, fileInfo.Mtime)
+	}
+	if endedAt.IsZero() && !startedAt.IsZero() {
+		endedAt = startedAt
+	}
+
+	sess := &ParsedSession{
+		ID:                  fullID,
+		Project:             project,
+		Machine:             machine,
+		Agent:               agent,
+		AgentLabel:          agentLabel,
+		Cwd:                 rs.Cwd,
+		FirstMessage:        firstMsg,
+		SessionName:         sessionName,
+		StartedAt:           startedAt,
+		EndedAt:             endedAt,
+		MessageCount:        messageCount,
+		UserMessageCount:    userMsgCount,
+		CountsAuthoritative: countsAuthoritative,
+		SourceSessionID:     sessionID,
+		SourceVersion:       "codebuff-chat-v1",
+		File:                fileInfo,
+	}
+
+	// contextTokenCount from run-state.json is the final per-step context
+	// count, not the peak. Compaction can make the final value lower than
+	// the true peak, so we cannot reliably derive PeakContextTokens from
+	// this value. Leave peak context unavailable.
+
+	// Emit usage event for reported credits. The actual LLM is
+	// unknown (selected server-side, can change mid-session), so we
+	// attribute the cost to the agent template (e.g. "base2-deepseek",
+	// "base2-free-minimax-m3") rather than the agent name. The
+	// template is granular enough to bucket similar sessions
+	// separately in the daily model breakdown of the usage report
+	// while remaining non-empty so the ue.model != '' eligibility
+	// filter accepts the row. Skip emitting when the template is
+	// missing so sessions with empty agentType don't surface as
+	// empty-model rows. Freebuff vs codebuff distinction is kept in
+	// the agent breakdown via sess.Agent. One codebuff credit =
+	// $0.01 = 10_000 microdollars, rounded to the nearest microdollar
+	// with halves away from zero.
+	if rs.CreditsUsed > 0 && rs.AgentType != "" {
+		cost, costErr := money.FromFloatDollars(rs.CreditsUsed * 0.01)
+		if costErr != nil {
+			cost = money.Money{}
+		}
+		// Determine occurred_at: prefer message timestamps, then fall
+		// back to the session directory timestamp, then source mtime.
+		occurredAt := startedAt
+		if !endedAt.IsZero() {
+			occurredAt = endedAt
+		}
+		if occurredAt.IsZero() && !sessionDate.IsZero() {
+			occurredAt = sessionDate
+		}
+		if occurredAt.IsZero() && fileInfo.Mtime > 0 {
+			occurredAt = time.Unix(0, fileInfo.Mtime)
+		}
+		sess.UsageEvents = []ParsedUsageEvent{{
+			SessionID:  fullID,
+			Source:     "session",
+			Model:      rs.AgentType,
+			OccurredAt: occurredAt.Format(time.RFC3339Nano),
+			Cost:       &cost,
+			CostStatus: "reported",
+			CostSource: "session",
+			DedupKey:   "session:" + fullID,
+		}}
+	}
+
+	return sess, msgs, nil
+}
+
+// codebuffRunState holds extracted fields from run-state.json.
+type codebuffRunState struct {
+	AgentType         string
+	ContextTokenCount int
+	CreditsUsed       float64
+	DirectCreditsUsed float64
+	Cwd               string
+	Skills            []codebuffSkill
+}
+
+// codebuffSkill is a single skill entry from the session's skill catalog
+// (run-state.json sessionState.fileContext.skills). The catalog lists the
+// skills available to the agent during the session.
+type codebuffSkill struct {
+	Name        string
+	Description string
+	FilePath    string
+	Content     string
+}
+
+func readCodebuffRunState(path string) (codebuffRunState, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return codebuffRunState{}, err
+	}
+	if !gjson.ValidBytes(data) {
+		return codebuffRunState{}, fmt.Errorf("invalid json in %s", path)
+	}
+
+	mas := gjson.GetBytes(data, "sessionState.mainAgentState")
+	rs := codebuffRunState{
+		AgentType:         mas.Get("agentType").Str,
+		ContextTokenCount: int(mas.Get("contextTokenCount").Int()),
+		CreditsUsed:       mas.Get("creditsUsed").Float(),
+		DirectCreditsUsed: mas.Get("directCreditsUsed").Float(),
+		Cwd: gjson.GetBytes(data,
+			"sessionState.fileContext.cwd").Str,
+	}
+	rs.Skills = parseCodebuffSkills(data)
+	return rs, nil
+}
+
+// parseCodebuffSkills extracts the skill catalog from run-state.json
+// (sessionState.fileContext.skills). The field is a JSON object keyed by
+// skill name; each value carries name, description, optional content, and
+// filePath. Returns an empty slice when no skills are present.
+func parseCodebuffSkills(data []byte) []codebuffSkill {
+	skills := gjson.GetBytes(data, "sessionState.fileContext.skills")
+	if !skills.Exists() || !skills.IsObject() {
+		return nil
+	}
+	var out []codebuffSkill
+	skills.ForEach(func(key, val gjson.Result) bool {
+		name := val.Get("name").Str
+		if name == "" {
+			name = key.Str
+		}
+		out = append(out, codebuffSkill{
+			Name:        name,
+			Description: val.Get("description").Str,
+			FilePath:    val.Get("filePath").Str,
+			Content:     val.Get("content").Str,
+		})
+		return true
+	})
+	return out
+}
+
+// codebuffAttachSkillNames attributes tool calls to skills from the
+// session's skill catalog. Codebuff/Freebuff do not emit a dedicated Skill
+// tool; skills are invoked through generic tools (e.g. run_terminal_command)
+// whose input names the skill, or through a tool literally named "Skill".
+// A tool call is attributed when its tool name matches a skill, or its input
+// JSON references a known skill name.
+func codebuffAttachSkillNames(msgs []ParsedMessage, skills []codebuffSkill) {
+	if len(skills) == 0 {
+		return
+	}
+	byName := make(map[string]struct{}, len(skills))
+	for _, s := range skills {
+		byName[strings.ToLower(s.Name)] = struct{}{}
+	}
+	for i := range msgs {
+		for j := range msgs[i].ToolCalls {
+			tc := &msgs[i].ToolCalls[j]
+			if tc.SkillName != "" {
+				continue
+			}
+			// Explicit Skill tool.
+			if strings.EqualFold(tc.ToolName, "Skill") ||
+				strings.EqualFold(tc.ToolName, "skill") {
+				tc.SkillName = gjson.Get(tc.InputJSON, "skill").Str
+				if tc.SkillName == "" {
+					tc.SkillName = gjson.Get(tc.InputJSON, "name").Str
+				}
+				if tc.SkillName == "" {
+					tc.SkillName = tc.ToolName
+				}
+				continue
+			}
+			// Tool name itself is a skill name.
+			if _, ok := byName[strings.ToLower(tc.ToolName)]; ok {
+				tc.SkillName = tc.ToolName
+				continue
+			}
+			// Input JSON references a known skill name.
+			if name := codebuffSkillNameFromInput(tc.InputJSON, byName); name != "" {
+				tc.SkillName = name
+			}
+		}
+	}
+}
+
+// codebuffSkillNameFromInput scans raw tool input JSON for a reference to a
+// known skill name. It matches the skill name as a quoted JSON string value
+// or as a standalone token (e.g. inside a shell command). Returns "" when no
+// known skill is referenced.
+func codebuffSkillNameFromInput(inputJSON string, byName map[string]struct{}) string {
+	if inputJSON == "" {
+		return ""
+	}
+	// Direct JSON string/object match on common skill-carrying keys.
+	for _, key := range []string{"skill", "name", "skill_name", "command", "prompt"} {
+		v := gjson.Get(inputJSON, key).Str
+		if v != "" {
+			if _, ok := byName[strings.ToLower(v)]; ok {
+				return v
+			}
+		}
+	}
+	// Fall back to scanning for any known skill name as a whole token.
+	lower := strings.ToLower(inputJSON)
+	for name := range byName {
+		if containsSkillToken(lower, name) {
+			return name
+		}
+	}
+	return ""
+}
+
+// containsSkillToken reports whether lower contains name as a whole
+// alphanumeric token (word-boundary match). It splits lower on
+// non-alphanumeric runes and compares each token against name.
+// This avoids false positives from substring matching (e.g. "go"
+// matching "going" or "cargo").
+func containsSkillToken(lower, name string) bool {
+	if name == "" {
+		return false
+	}
+	var buf []byte
+	for i := 0; i < len(lower); i++ {
+		c := lower[i]
+		if c >= 'a' && c <= 'z' || c >= '0' && c <= '9' || c == '-' || c == '_' {
+			buf = append(buf, c)
+		} else {
+			if string(buf) == name {
+				return true
+			}
+			buf = buf[:0]
+		}
+	}
+	return string(buf) == name
+}
+
+// codebuffChatMeta holds extracted fields from chat-meta.json.
+type codebuffChatMeta struct {
+	MessageCount int
+	FirstPrompt  string
+	MessagesSize int64
+}
+
+func readCodebuffChatMeta(path string) codebuffChatMeta {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return codebuffChatMeta{}
+	}
+	if !gjson.ValidBytes(data) {
+		return codebuffChatMeta{}
+	}
+	return codebuffChatMeta{
+		MessageCount: int(gjson.GetBytes(data, "messageCount").Int()),
+		FirstPrompt:  gjson.GetBytes(data, "firstPrompt").Str,
+		MessagesSize: gjson.GetBytes(data, "messagesSize").Int(),
+	}
+}
+
+// IsCodebuffTimestamp reports whether s matches one of the
+// on-disk session-directory timestamp shapes that parseCodebuffSession
+// treats as the bare session ID suffix of the canonical
+// "agent:<project>:<ts>" id. Used by the session-get resolver to
+// distinguish a Codebuff/Freebuff timestamp from a bare UUID
+// (Codex, Copilot, Gemini, ...) that the generic prefix resolver
+// handles. Returns true when s parses as any of the four ISO-8601
+// forms accepted by parseCodebuffSessionDate:
+//
+//   - "2026-07-16T00-09-00.236Z"   (full ISO with millis and Z)
+//   - "2026-07-16T00-09-00Z"       (full ISO without millis)
+//   - "2026-07-16T00-09-00.123"    (full ISO without Z)
+//   - "2026-07-16"                 (basic ISO date only)
+//
+// Everything else (UUIDs, numeric Unix epochs, free-form strings)
+// returns false so the generic resolver path stays open. The
+// predicate is purely syntactic — no FS walk — so it is cheap on
+// --server and --pg transports where a FS scan is wasted work.
+func IsCodebuffTimestamp(s string) bool {
+	return !parseCodebuffSessionDate(s).IsZero()
+}
+
+// parseCodebuffSessionDate parses the session directory name as an ISO 8601
+// timestamp. The directory name format is "2026-07-16T00-09-00.236Z".
+// The returned time is always in the local timezone so that time-only
+// message timestamps (HH:MM PM) combine correctly with the date.
+func parseCodebuffSessionDate(sessionID string) time.Time {
+	// Try full ISO format with milliseconds and Z suffix.
+	if ts, err := time.Parse("2006-01-02T15-04-05.999Z", sessionID); err == nil {
+		return ts.In(time.Local)
+	}
+	// Try without milliseconds.
+	if ts, err := time.Parse("2006-01-02T15-04-05Z", sessionID); err == nil {
+		return ts.In(time.Local)
+	}
+	// Try with milliseconds, no Z. Interpret as local time since
+	// codebuff records wall-clock timestamps without a UTC offset.
+	if ts, err := time.ParseInLocation("2006-01-02T15-04-05.999", sessionID, time.Local); err == nil {
+		return ts
+	}
+	// Try basic ISO date only.
+	if ts, err := time.ParseInLocation("2006-01-02", sessionID, time.Local); err == nil {
+		return ts
+	}
+	return time.Time{}
+}
+
+// parseCodebuffMessages parses chat-messages.json data into ParsedMessages.
+// sessionDate provides the date context for time-only timestamps.
+// model is set on every ParsedMessage so the UI can identify the model used.
+func parseCodebuffMessages(
+	data []byte, sessionDate time.Time, model string,
+) ([]ParsedMessage, time.Time, time.Time, error) {
+	root := gjson.ParseBytes(data)
+	if !root.IsArray() {
+		return nil, time.Time{}, time.Time{},
+			fmt.Errorf("chat-messages.json root is not an array")
+	}
+
+	var (
+		messages  []ParsedMessage
+		startedAt time.Time
+		endedAt   time.Time
+		ordinal   int
+		// Track the current date for cross-midnight sessions. Start with
+		// the session directory date and advance when time-of-day wraps
+		// past midnight.
+		currentDate = sessionDate
+		prevHour    = -1
+	)
+
+	root.ForEach(func(_, msg gjson.Result) bool {
+		variant := msg.Get("variant").Str
+		ts := parseCodebuffTimestamp(
+			msg.Get("timestamp").Str, currentDate,
+		)
+
+		// Detect midnight rollover for time-only timestamps only.
+		// RFC3339 timestamps retain their timezone, so their hours
+		// should not be compared with local time-only timestamps.
+		rawTS := strings.TrimSpace(msg.Get("timestamp").Str)
+		isTimeOnly := !strings.Contains(rawTS, "T") &&
+			!strings.Contains(rawTS, "-") &&
+			strings.Contains(rawTS, ":")
+		if !ts.IsZero() && prevHour >= 0 && isTimeOnly {
+			if ts.Hour() < prevHour {
+				currentDate = currentDate.AddDate(0, 0, 1)
+				// Re-parse with the advanced date.
+				ts = parseCodebuffTimestamp(
+					msg.Get("timestamp").Str, currentDate,
+				)
+			}
+		}
+		// Only track prevHour for time-only timestamps to avoid
+		// incorrect rollover when formats are mixed. Reset prevHour
+		// when a non-time-only timestamp is encountered, and also
+		// anchor currentDate to the absolute timestamp's local
+		// calendar date so subsequent time-only messages don't get
+		// assigned to the previous session directory date across
+		// midnight.
+		if !ts.IsZero() {
+			if isTimeOnly {
+				prevHour = ts.Hour()
+			} else {
+				prevHour = -1
+				tsLocal := ts.In(currentDate.Location())
+				tsDate := time.Date(
+					tsLocal.Year(), tsLocal.Month(), tsLocal.Day(),
+					0, 0, 0, 0, currentDate.Location(),
+				)
+				if !tsDate.Equal(currentDate) {
+					currentDate = tsDate
+				}
+			}
+		}
+
+		if !ts.IsZero() {
+			if startedAt.IsZero() || ts.Before(startedAt) {
+				startedAt = ts
+			}
+			if ts.After(endedAt) {
+				endedAt = ts
+			}
+		}
+
+		switch variant {
+		case "user":
+			content := strings.TrimSpace(msg.Get("content").Str)
+			// User messages can also carry blocks (e.g. images).
+			// Collect image references from blocks to append to content.
+			if blocks := msg.Get("blocks"); blocks.IsArray() {
+				blocks.ForEach(func(_, block gjson.Result) bool {
+					if block.Get("type").Str == "image" {
+						filename := block.Get("filename").Str
+						if filename != "" {
+							content += "\n[Image: " + filename + "]"
+						} else {
+							content += "\n[Image attached]"
+						}
+					}
+					return true
+				})
+				content = strings.TrimSpace(content)
+			}
+			if content == "" {
+				return true
+			}
+			messages = append(messages, ParsedMessage{
+				Ordinal:       ordinal,
+				Role:          RoleUser,
+				Content:       content,
+				Timestamp:     ts,
+				ContentLength: len(content),
+			})
+			ordinal++
+
+		case "ai":
+			parsed := parseCodebuffAIMessage(msg, ts)
+			if len(parsed) == 0 {
+				return true
+			}
+			for i := range parsed {
+				parsed[i].Ordinal = ordinal
+				parsed[i].Model = model
+				ordinal++
+			}
+			messages = append(messages, parsed...)
+
+		case "error":
+			// Error messages from the upstream CLI (API failures, rate
+			// limits, country blocks). Emit as a system message so the
+			// error is visible in the transcript.
+			content := strings.TrimSpace(msg.Get("content").Str)
+			if content == "" {
+				return true
+			}
+			messages = append(messages, ParsedMessage{
+				Ordinal:       ordinal,
+				Role:          RoleSystem,
+				Content:       content,
+				Timestamp:     ts,
+				ContentLength: len(content),
+				IsSystem:      true,
+			})
+			ordinal++
+		}
+
+		return true
+	})
+
+	return messages, startedAt, endedAt, nil
+}
+
+// parseCodebuffAIMessage parses an AI-variant message into one or more
+// ParsedMessages. AI messages contain blocks: text (reasoning or regular),
+// tool calls, and subagent invocations. Blocks are processed sequentially
+// to preserve the interleaving order of text, tools, and results.
+func parseCodebuffAIMessage(
+	msg gjson.Result,
+	ts time.Time,
+) []ParsedMessage {
+	blocks := msg.Get("blocks")
+	if !blocks.IsArray() {
+		return nil
+	}
+
+	// textEntry tracks a text block with its type to preserve interleaving.
+	type textEntry struct {
+		content  string
+		isReason bool
+	}
+	var (
+		out         []ParsedMessage
+		textBuf     []textEntry
+		toolCalls   []ParsedToolCall
+		toolResults []ParsedToolResult
+	)
+
+	// flushText emits accumulated text entries in order, grouping
+	// consecutive entries of the same type.
+	flushText := func() {
+		if len(textBuf) == 0 {
+			return
+		}
+		// Group consecutive entries of the same type.
+		var thinkingParts, regularParts []string
+		for _, entry := range textBuf {
+			if entry.isReason {
+				// Flush regular text before starting a thinking block.
+				if len(regularParts) > 0 {
+					text := strings.Join(regularParts, "\n\n")
+					out = append(out, ParsedMessage{
+						Role:          RoleAssistant,
+						Content:       text,
+						Timestamp:     ts,
+						ContentLength: len(text),
+					})
+					regularParts = nil
+				}
+				thinkingParts = append(thinkingParts, entry.content)
+			} else {
+				// Flush thinking before starting regular text.
+				if len(thinkingParts) > 0 {
+					thinkingText := strings.Join(thinkingParts, "\n\n")
+					out = append(out, ParsedMessage{
+						Role:          RoleAssistant,
+						Content:       "[Thinking]\n" + thinkingText + "\n[/Thinking]",
+						ThinkingText:  thinkingText,
+						HasThinking:   true,
+						Timestamp:     ts,
+						ContentLength: len(thinkingText),
+					})
+					thinkingParts = nil
+				}
+				regularParts = append(regularParts, entry.content)
+			}
+		}
+		// Flush any remaining.
+		if len(thinkingParts) > 0 {
+			thinkingText := strings.Join(thinkingParts, "\n\n")
+			out = append(out, ParsedMessage{
+				Role:          RoleAssistant,
+				Content:       "[Thinking]\n" + thinkingText + "\n[/Thinking]",
+				ThinkingText:  thinkingText,
+				HasThinking:   true,
+				Timestamp:     ts,
+				ContentLength: len(thinkingText),
+			})
+		}
+		if len(regularParts) > 0 {
+			text := strings.Join(regularParts, "\n\n")
+			out = append(out, ParsedMessage{
+				Role:          RoleAssistant,
+				Content:       text,
+				Timestamp:     ts,
+				ContentLength: len(text),
+			})
+		}
+		textBuf = nil
+	}
+
+	// flushTools emits accumulated tool calls as a single assistant message,
+	// then emits each tool result as a user message.
+	flushTools := func() {
+		if len(toolCalls) > 0 {
+			out = append(out, ParsedMessage{
+				Role:       RoleAssistant,
+				Timestamp:  ts,
+				HasToolUse: true,
+				ToolCalls:  toolCalls,
+			})
+			toolCalls = nil
+		}
+		for _, tr := range toolResults {
+			out = append(out, ParsedMessage{
+				Role:          RoleUser,
+				Timestamp:     ts,
+				ToolResults:   []ParsedToolResult{tr},
+				ContentLength: tr.ContentLength,
+			})
+		}
+		toolResults = nil
+	}
+
+	// Track whether we're currently accumulating tool calls to batch
+	// consecutive tool blocks together.
+	inToolRun := false
+
+	blocks.ForEach(func(_, block gjson.Result) bool {
+		blockType := block.Get("type").Str
+		isTool := blockType == "tool" || blockType == "agent"
+
+		// Flush on transition away from a tool run.
+		if inToolRun && !isTool {
+			flushText()
+			flushTools()
+			inToolRun = false
+		}
+
+		switch blockType {
+		case "text":
+			// Flush accumulated tools before text to preserve ordering.
+			if len(toolCalls) > 0 {
+				flushTools()
+			}
+			textType := block.Get("textType").Str
+			content := block.Get("content").Str
+			if strings.TrimSpace(content) == "" {
+				return true
+			}
+			isReason := textType == "reasoning"
+			textBuf = append(textBuf, textEntry{content: content, isReason: isReason})
+
+		case "tool":
+			if !inToolRun {
+				flushText()
+				inToolRun = true
+			}
+			tc := parseCodebuffToolCall(block)
+			if tc != nil {
+				toolCalls = append(toolCalls, *tc)
+				if output := block.Get("output"); output.Exists() {
+					toolResults = append(toolResults, ParsedToolResult{
+						ToolUseID:     tc.ToolUseID,
+						ContentRaw:    output.Raw,
+						ContentLength: len(output.Raw),
+					})
+				}
+			}
+
+		case "agent":
+			if !inToolRun {
+				flushText()
+				inToolRun = true
+			}
+
+			agentType := block.Get("agentType").Str
+			agentName := block.Get("agentName").Str
+			agentID := block.Get("agentId").Str
+			agentStatus := block.Get("status").Str
+
+			inputParts := map[string]any{
+				"agentType": agentType,
+				"agentName": agentName,
+			}
+			if params := block.Get("params"); params.Exists() &&
+				params.Raw != "null" {
+				inputParts["params"] = params.Value()
+			}
+			if prompt := block.Get("initialPrompt"); prompt.Exists() &&
+				prompt.Str != "" {
+				inputParts["prompt"] = prompt.Str
+			}
+			// The agent's lifecycle status (spawned, complete, ...) used to
+			// be rendered in the assistant text for the block; now that
+			// agent output is emitted as a linked ParsedToolResult, carry
+			// the status in the tool-call input so it stays visible in the
+			// parsed session.
+			status := agentStatus
+			if status == "" {
+				status = "spawned"
+			}
+			inputParts["status"] = status
+
+			inputJSON, _ := json.Marshal(inputParts)
+
+			tc := ParsedToolCall{
+				ToolUseID: agentID,
+				ToolName:  agentType,
+				Category:  "Task",
+				InputJSON: string(inputJSON),
+			}
+			toolCalls = append(toolCalls, tc)
+
+			// Emit agent output as a linked ParsedToolResult rather
+			// than an ordinary assistant text message. Representing
+			// the output as a tool result lets the configured result-
+			// content blocking system (BlockedResultCategories)
+			// strip it when the Task category is blocked. Without
+			// this, agent-block output stored as ordinary assistant
+			// text survives blocking and retains content the operator
+			// explicitly configured agentsview not to store.
+			if output := block.Get("content"); output.Exists() && output.Str != "" {
+				toolResults = append(toolResults, ParsedToolResult{
+					ToolUseID:     agentID,
+					ContentRaw:    output.Raw,
+					ContentLength: len(output.Raw),
+				})
+			}
+
+		case "mode-divider":
+			flushText()
+			flushTools()
+			mode := block.Get("mode").Str
+			if mode != "" {
+				// Emit system blocks immediately, not deferred.
+				out = append(out, ParsedMessage{
+					Role:          RoleSystem,
+					Content:       "[Mode: " + mode + "]",
+					Timestamp:     ts,
+					ContentLength: len("[Mode: " + mode + "]"),
+					IsSystem:      true,
+				})
+			}
+
+		case "plan":
+			flushText()
+			flushTools()
+			content := block.Get("content").Str
+			if strings.TrimSpace(content) != "" {
+				// Emit system blocks immediately, not deferred.
+				out = append(out, ParsedMessage{
+					Role:          RoleSystem,
+					Content:       "[Plan]\n" + content,
+					Timestamp:     ts,
+					ContentLength: len("[Plan]\n" + content),
+					IsSystem:      true,
+				})
+			}
+
+		case "ask-user":
+			flushText()
+			flushTools()
+			questions := block.Get("questions")
+			if questions.IsArray() {
+				var parts []string
+				questions.ForEach(func(_, q gjson.Result) bool {
+					questionText := q.Get("question").Str
+					if strings.TrimSpace(questionText) != "" {
+						parts = append(parts, "[Agent asked] "+questionText)
+					}
+					return true
+				})
+				if len(parts) > 0 {
+					content := strings.Join(parts, "\n")
+					out = append(out, ParsedMessage{
+						Role:          RoleSystem,
+						Content:       content,
+						Timestamp:     ts,
+						ContentLength: len(content),
+						IsSystem:      true,
+					})
+				}
+			}
+
+		case "image":
+			if block.Get("filename").Str != "" {
+				textBuf = append(textBuf, textEntry{
+					content:  "[Image: " + block.Get("filename").Str + "]",
+					isReason: false,
+				})
+			} else {
+				textBuf = append(textBuf, textEntry{
+					content:  "[Image attached]",
+					isReason: false,
+				})
+			}
+		}
+		return true
+	})
+
+	// Flush any remaining accumulated content.
+	flushText()
+	flushTools()
+
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// parseCodebuffToolCall extracts a ParsedToolCall from a tool block.
+func parseCodebuffToolCall(block gjson.Result) *ParsedToolCall {
+	toolName := block.Get("toolName").Str
+	if toolName == "" {
+		return nil
+	}
+	toolCallID := block.Get("toolCallId").Str
+	input := block.Get("input")
+
+	inputJSON := ""
+	if input.Exists() && input.Raw != "" && input.Raw != "null" {
+		inputJSON = input.Raw
+	}
+
+	return &ParsedToolCall{
+		ToolUseID: toolCallID,
+		ToolName:  toolName,
+		Category:  NormalizeToolCategory(toolName),
+		InputJSON: inputJSON,
+	}
+}
+
+// parseCodebuffTimestamp parses a timestamp string. Codebuff/freebuff
+// messages use "HH:MM PM" format with the date provided by the session
+// directory name. The sessionDate carries the date context.
+func parseCodebuffTimestamp(s string, sessionDate time.Time) time.Time {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}
+	}
+
+	// ISO format (used by newer builds or subagent messages).
+	if ts, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		return ts
+	}
+	if ts, err := time.Parse("2006-01-02T15:04:05.999Z07:00", s); err == nil {
+		return ts
+	}
+
+	// "HH:MM PM" format: combine with the session date.
+	if ts, err := time.Parse("03:04 PM", s); err == nil {
+		if sessionDate.IsZero() {
+			return time.Time{}
+		}
+		// Combine date from session with time from message.
+		return time.Date(
+			sessionDate.Year(),
+			sessionDate.Month(),
+			sessionDate.Day(),
+			ts.Hour(),
+			ts.Minute(),
+			0, 0,
+			sessionDate.Location(),
+		)
+	}
+
+	return time.Time{}
+}
+
+// discoverCodebuffSessions finds all session directories under a root.
+// root is the parent projects directory (~/.config/manicode/projects).
+// Sessions live under <root>/<project>/chats/<timestamp>/.
+func discoverCodebuffSessions(root string) []codebuffSessionDir {
+	var dirs []codebuffSessionDir
+	_ = codebuffDiscoverEach(context.Background(), root, func(match singleFileMatch) error {
+		dirs = append(dirs, codebuffSessionDir{
+			Path:        filepath.Dir(match.Path),
+			ProjectHint: match.ProjectHint,
+		})
+		return nil
+	})
+	return dirs
+}
+
+// codebuffDiscoverEach streams session discoveries, yielding each match
+// as it is found. This avoids materializing the entire archive in memory.
+func codebuffDiscoverEach(
+	ctx context.Context, root string, yield func(singleFileMatch) error,
+) error {
+	// Stream project directories.
+	return streamDirectoryEntries(ctx, root, func(projectEntry os.DirEntry) error {
+		if !projectEntry.IsDir() {
+			return nil
+		}
+		projectName := projectEntry.Name()
+		chatsDir := filepath.Join(root, projectName, "chats")
+		// Stream session directories within each project.
+		return streamDirectoryEntries(ctx, chatsDir, func(sessionEntry os.DirEntry) error {
+			if !sessionEntry.IsDir() {
+				return nil
+			}
+			dir := filepath.Join(chatsDir, sessionEntry.Name())
+			chatPath := filepath.Join(dir, "chat-messages.json")
+			if !IsRegularFile(chatPath) {
+				return nil
+			}
+			return yield(singleFileMatch{
+				Path:        chatPath,
+				ProjectHint: projectName,
+			})
+		})
+	})
+}
+
+// codebuffProjectFromPath extracts the project name from a session
+// file path. The path is rooted under ~/.config/manicode/projects/.
+func codebuffProjectFromPath(path string) string {
+	// Path is: <root>/<project>/chats/<timestamp>/chat-messages.json
+	// We want the <project> component.
+	// Walk up from chat-messages.json: dir=/timestamp, parent=chats, grandparent=<project>
+	dir := filepath.Dir(path)            // <timestamp>
+	chatsDir := filepath.Dir(dir)        // chats
+	projectDir := filepath.Dir(chatsDir) // <project>
+	return filepath.Base(projectDir)
+}

--- a/internal/parser/codebuff.go
+++ b/internal/parser/codebuff.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -49,11 +50,6 @@ func parseCodebuffSession(
 	// Read chat-meta.json for session name and timing hints.
 	meta := readCodebuffChatMeta(chatMetaPath)
 
-	// The actual LLM model is selected server-side based on the agentType
-	// template and can change mid-session. The on-disk format does not
-	// persist the actual model, so leave it unknown.
-	model := ""
-
 	// Read and parse the chat messages.
 	data, err := os.ReadFile(chatMessagesPath)
 	if err != nil {
@@ -67,7 +63,7 @@ func parseCodebuffSession(
 	sessionID := filepath.Base(dir)
 	sessionDate := parseCodebuffSessionDate(sessionID)
 
-	msgs, startedAt, endedAt, err := parseCodebuffMessages(data, sessionDate, model)
+	msgs, startedAt, endedAt, err := parseCodebuffMessages(data, sessionDate)
 	if err != nil {
 		return nil, nil, fmt.Errorf("parse chat-messages %s: %w", chatMessagesPath, err)
 	}
@@ -102,7 +98,7 @@ func parseCodebuffSession(
 	// Session name from first prompt (better than directory name).
 	sessionName := firstMsg
 	if len(sessionName) > 80 {
-		sessionName = sessionName[:77] + "..."
+		sessionName = truncate(sessionName, 77)
 	}
 	if sessionName == "" {
 		if rs.Cwd != "" {
@@ -152,8 +148,6 @@ func parseCodebuffSession(
 	// keeps reconciling message-derived counts for sessions with real
 	// transcripts.
 	countsAuthoritative := len(msgs) == 0 && meta.MessageCount > 0
-
-	// Model extracted earlier (passed into message parser above).
 
 	// Source file identity: use chat-messages.json as the primary source.
 	info, err := os.Stat(chatMessagesPath)
@@ -275,7 +269,6 @@ type codebuffRunState struct {
 	AgentType         string
 	ContextTokenCount int
 	CreditsUsed       float64
-	DirectCreditsUsed float64
 	Cwd               string
 	Skills            []codebuffSkill
 }
@@ -304,7 +297,6 @@ func readCodebuffRunState(path string) (codebuffRunState, error) {
 		AgentType:         mas.Get("agentType").Str,
 		ContextTokenCount: int(mas.Get("contextTokenCount").Int()),
 		CreditsUsed:       mas.Get("creditsUsed").Float(),
-		DirectCreditsUsed: mas.Get("directCreditsUsed").Float(),
 		Cwd: gjson.GetBytes(data,
 			"sessionState.fileContext.cwd").Str,
 	}
@@ -348,9 +340,12 @@ func codebuffAttachSkillNames(msgs []ParsedMessage, skills []codebuffSkill) {
 	if len(skills) == 0 {
 		return
 	}
-	byName := make(map[string]struct{}, len(skills))
+	// byName maps the lowercased skill name to the catalog's canonical
+	// casing so attribution can match case-insensitively while always
+	// reporting the catalog spelling.
+	byName := make(map[string]string, len(skills))
 	for _, s := range skills {
-		byName[strings.ToLower(s.Name)] = struct{}{}
+		byName[strings.ToLower(s.Name)] = s.Name
 	}
 	for i := range msgs {
 		for j := range msgs[i].ToolCalls {
@@ -385,9 +380,12 @@ func codebuffAttachSkillNames(msgs []ParsedMessage, skills []codebuffSkill) {
 
 // codebuffSkillNameFromInput scans raw tool input JSON for a reference to a
 // known skill name. It matches the skill name as a quoted JSON string value
-// or as a standalone token (e.g. inside a shell command). Returns "" when no
-// known skill is referenced.
-func codebuffSkillNameFromInput(inputJSON string, byName map[string]struct{}) string {
+// or as a standalone token (e.g. inside a shell command). byName maps the
+// lowercased skill name to its canonical catalog casing; matches always
+// return the canonical casing. When multiple catalog skills appear as
+// tokens, the winner is deterministic: the first in lowercase-sorted
+// order. Returns "" when no known skill is referenced.
+func codebuffSkillNameFromInput(inputJSON string, byName map[string]string) string {
 	if inputJSON == "" {
 		return ""
 	}
@@ -395,16 +393,23 @@ func codebuffSkillNameFromInput(inputJSON string, byName map[string]struct{}) st
 	for _, key := range []string{"skill", "name", "skill_name", "command", "prompt"} {
 		v := gjson.Get(inputJSON, key).Str
 		if v != "" {
-			if _, ok := byName[strings.ToLower(v)]; ok {
-				return v
+			if canonical, ok := byName[strings.ToLower(v)]; ok {
+				return canonical
 			}
 		}
 	}
 	// Fall back to scanning for any known skill name as a whole token.
+	// Sort the candidate names so the winner is deterministic when two
+	// catalog skills both appear in the input.
 	lower := strings.ToLower(inputJSON)
+	names := make([]string, 0, len(byName))
 	for name := range byName {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
 		if containsSkillToken(lower, name) {
-			return name
+			return byName[name]
 		}
 	}
 	return ""
@@ -504,10 +509,11 @@ func parseCodebuffSessionDate(sessionID string) time.Time {
 }
 
 // parseCodebuffMessages parses chat-messages.json data into ParsedMessages.
-// sessionDate provides the date context for time-only timestamps.
-// model is set on every ParsedMessage so the UI can identify the model used.
+// sessionDate provides the date context for time-only timestamps. Message
+// Model stays empty: the LLM is selected server-side per agentType template
+// and is not persisted in the on-disk format.
 func parseCodebuffMessages(
-	data []byte, sessionDate time.Time, model string,
+	data []byte, sessionDate time.Time,
 ) ([]ParsedMessage, time.Time, time.Time, error) {
 	root := gjson.ParseBytes(data)
 	if !root.IsArray() {
@@ -526,6 +532,17 @@ func parseCodebuffMessages(
 		currentDate = sessionDate
 		prevHour    = -1
 	)
+	// Seed the rollover state from the session creation time-of-day so
+	// the first time-only message can roll past midnight. A session
+	// created late in the local evening (directory
+	// 2026-07-17T06-58-00.000Z = 23:58 July 16 in UTC-7) whose first
+	// message reads "12:01 AM" belongs to the next local calendar day;
+	// without the seed, prevHour stays -1 until the second message and
+	// the first message would be stamped ~24h before the session
+	// started, skewing StartedAt.
+	if !sessionDate.IsZero() {
+		prevHour = sessionDate.Hour()
+	}
 
 	root.ForEach(func(_, msg gjson.Result) bool {
 		variant := msg.Get("variant").Str
@@ -619,7 +636,6 @@ func parseCodebuffMessages(
 			}
 			for i := range parsed {
 				parsed[i].Ordinal = ordinal
-				parsed[i].Model = model
 				ordinal++
 			}
 			messages = append(messages, parsed...)

--- a/internal/parser/codebuff_companion_mtime_test.go
+++ b/internal/parser/codebuff_companion_mtime_test.go
@@ -1,0 +1,84 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCodebuffCompanionMtime verifies the engine's warm-side derivation
+// matches the cold-write fingerprint's max(chat, run-state, chat-meta)
+// rule. Each case pins a different component as the floor so a future
+// refactor that drops a sibling from the walk surfaces immediately.
+// All mtimes share one base time so the relative ordering is obvious.
+func TestCodebuffCompanionMtime(t *testing.T) {
+	base := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	t.Run("MaxIsMeta", func(t *testing.T) {
+		dir := t.TempDir()
+		chatPath := writeAtTime(t, dir, "chat-messages.json", "[]", base)
+		writeAtTime(t, dir, "run-state.json", "{}", base.Add(2*time.Hour))
+		writeAtTime(t, dir, "chat-meta.json", "{}", base.Add(4*time.Hour))
+		got := callHelper(t, chatPath)
+		require.Equal(t, base.Add(4*time.Hour).UnixNano(), got)
+	})
+
+	t.Run("MaxIsRunState", func(t *testing.T) {
+		dir := t.TempDir()
+		chatPath := writeAtTime(t, dir, "chat-messages.json", "[]", base)
+		writeAtTime(t, dir, "run-state.json", "{}", base.Add(6*time.Hour))
+		writeAtTime(t, dir, "chat-meta.json", "{}", base.Add(4*time.Hour))
+		got := callHelper(t, chatPath)
+		require.Equal(t, base.Add(6*time.Hour).UnixNano(), got)
+	})
+
+	t.Run("MaxIsChat", func(t *testing.T) {
+		dir := t.TempDir()
+		chatPath := writeAtTime(t, dir, "chat-messages.json", "[]", base.Add(8*time.Hour))
+		writeAtTime(t, dir, "run-state.json", "{}", base.Add(1*time.Hour))
+		writeAtTime(t, dir, "chat-meta.json", "{}", base.Add(4*time.Hour))
+		got := callHelper(t, chatPath)
+		require.Equal(t, base.Add(8*time.Hour).UnixNano(), got)
+	})
+
+	t.Run("MissingCompanionsFallBackToChat", func(t *testing.T) {
+		dir := t.TempDir()
+		chatPath := writeAtTime(t, dir, "chat-messages.json", "[]", base)
+		got := callHelper(t, chatPath)
+		chatInfo, err := os.Stat(chatPath)
+		require.NoError(t, err)
+		require.Equal(t, chatInfo.ModTime().UnixNano(), got)
+	})
+
+	t.Run("PartialCompanionsStillIncludeMax", func(t *testing.T) {
+		dir := t.TempDir()
+		chatPath := writeAtTime(t, dir, "chat-messages.json", "[]", base)
+		// Only run-state.json present, newer than chat.
+		writeAtTime(t, dir, "run-state.json", "{}", base.Add(10*time.Hour))
+		got := callHelper(t, chatPath)
+		require.Equal(t, base.Add(10*time.Hour).UnixNano(), got)
+	})
+}
+
+// writeAtTime writes a file under dir with body and sets atime/mtime
+// to the supplied mtime. Both fields are set to the same value so
+// os.Stat returns the intended mtime.
+func writeAtTime(t *testing.T, dir, name, body string, mtime time.Time) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o600))
+	require.NoError(t, os.Chtimes(path, mtime, mtime))
+	return path
+}
+
+// callHelper is a small wrapper so each subtest reads as a single
+// assertion; the os.Stat pair would otherwise dominate every line.
+func callHelper(t *testing.T, chatPath string) int64 {
+	t.Helper()
+	chatInfo, err := os.Stat(chatPath)
+	require.NoError(t, err)
+	return CodebuffCompanionMtime(chatPath, chatInfo)
+}

--- a/internal/parser/codebuff_provider.go
+++ b/internal/parser/codebuff_provider.go
@@ -1,0 +1,454 @@
+package parser
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"hash/fnv"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// CodebuffCompanionFilenames lists the sibling companion files folded into
+// Codebuff's cold-write fingerprint (codebuffFingerprintSource) and the
+// warm-side freshness digest (MultiFileStatHasher, plus the engine's
+// providerStatFreshnessMtime helper). Sharing one list across all three
+// sites keeps the MTimeNS key aligned with the side-table digest so the
+// warm pre-check's max(chat, rs, meta) derivation matches the cold
+// write. Add new companions here rather than inlining them at
+// individual call sites.
+var CodebuffCompanionFilenames = []string{
+	"run-state.json",
+	"chat-meta.json",
+}
+
+// CodebuffCompanionMtime returns the max of chatInfo.ModTime() and
+// sibling companion files declared in CodebuffCompanionFilenames. The
+// engine's warm pre-check uses it to align the skip-cache MTimeNS key
+// with the cold-write fingerprint's same max(chat, rs, meta) stamp,
+// so a cold-to-warm cycle does not drift. Missing companions are
+// silently skipped; the chat file is the floor.
+func CodebuffCompanionMtime(
+	chatPath string, chatInfo os.FileInfo,
+) int64 {
+	mtime := chatInfo.ModTime().UnixNano()
+	dir := filepath.Dir(chatPath)
+	for _, name := range CodebuffCompanionFilenames {
+		if ci, err := os.Stat(filepath.Join(dir, name)); err == nil {
+			if ts := ci.ModTime().UnixNano(); ts > mtime {
+				mtime = ts
+			}
+		}
+	}
+	return mtime
+}
+
+// newCodebuffProviderFactory creates a provider factory for Codebuff.
+// Freebuff sessions are handled through the same provider and distinguished
+// via AgentLabel rather than a separate agent type.
+func newCodebuffProviderFactory(def AgentDef) ProviderFactory {
+	return NewSourceSetFactory(
+		def,
+		codebuffProviderCapabilities(),
+		func(cfg ProviderConfig) SourceSet {
+			inner := NewSingleFileSourceSet(
+				def.Type,
+				cfg.Roots,
+				WithStreamingFileDiscovery(codebuffDiscoverEach),
+				WithFileWatchRoots(func(roots []string) []WatchRoot {
+					return codebuffWatchRoots(roots)
+				}),
+				WithFileChangedPathClassifier(
+					func(root, path string, allowMissing bool) (singleFileMatch, bool) {
+						return codebuffClassifyPath(root, path, allowMissing)
+					},
+				),
+				WithFileLookup(func(root, rawID string) (singleFileMatch, bool) {
+					return codebuffFindFile(root, rawID)
+				}),
+				WithFileFingerprint(func(src singleFileSource) (SourceFingerprint, error) {
+					return codebuffFingerprintSource(src)
+				}),
+				WithFileParse(func(src singleFileSource, req ParseRequest) ([]ParseResult, []string, error) {
+					return codebuffParseFile(src, req)
+				}),
+			)
+			return codebuffSourceSet{inner}
+		},
+	)
+}
+
+// codebuffSourceSet wraps singleFileSourceSet to force full message
+// replacement on every successful parse. Codebuff reparses the entire
+// mutable JSON transcript on every sync, so the append-only writer
+// would leave stale ordinals and missed in-place block updates.
+type codebuffSourceSet struct {
+	singleFileSourceSet
+}
+
+// ComputeMultiFileStatHash implements parser.MultiFileStatHasher. The
+// digest is FNV-1a 64 over (size, mtime, ctime) tuples for
+// chat-messages.json plus its sibling companions run-state.json and
+// chat-meta.json, plus (0, dir.MTime, dir.ctime) to fold
+// directory-level create/rename/delete into the key. The ctime term is
+// the reliable content-change signal a pure (size, mtime) tuple lacks:
+// a same-size rewrite that preserves (or carries a coarse-grained)
+// mtime still bumps ctime on Unix and change-time on Windows, so a
+// matching digest cannot mask an in-place rewrite with unchanged stat
+// tuples. codexIndexChangeTime is reused because it is the parser
+// package's cross-platform ctime getter; it degrades to (0, false) on
+// unsupported platforms, which keeps the tuple stable there. The 0xCB
+// domain separator keeps the digest from colliding with any other FNV
+// digest the engine computes. Missing companions are encoded as
+// (0, 0, 0); that means a deleted companion changes the digest from
+// whatever its prior non-zero tuple was to (0, 0, 0). The chat file's
+// tuple is always written first so the resulting digest is fully
+// deterministic across process restarts.
+func (s codebuffSourceSet) ComputeMultiFileStatHash(
+	chatPath string,
+) uint64 {
+	h := fnv.New64a()
+	h.Write([]byte{0xCB})
+	var buf [24]byte
+	writeTuple := func(size, mtime, ctime int64) {
+		binary.LittleEndian.PutUint64(buf[:8], uint64(size))
+		binary.LittleEndian.PutUint64(buf[8:16], uint64(mtime))
+		binary.LittleEndian.PutUint64(buf[16:24], uint64(ctime))
+		_, _ = h.Write(buf[:])
+	}
+	chatInfo, err := os.Stat(chatPath)
+	if err != nil {
+		chatInfo = nil
+	}
+	if chatInfo != nil {
+		ctime, _ := codexIndexChangeTime(chatPath, chatInfo)
+		writeTuple(chatInfo.Size(), chatInfo.ModTime().UnixNano(), ctime)
+	} else {
+		writeTuple(0, 0, 0)
+	}
+	dir := filepath.Dir(chatPath)
+	for _, name := range CodebuffCompanionFilenames {
+		companion := filepath.Join(dir, name)
+		if ci, err := os.Stat(companion); err == nil {
+			ctime, _ := codexIndexChangeTime(companion, ci)
+			writeTuple(ci.Size(), ci.ModTime().UnixNano(), ctime)
+		} else {
+			writeTuple(0, 0, 0)
+		}
+	}
+	if di, err := os.Stat(dir); err == nil {
+		ctime, _ := codexIndexChangeTime(dir, di)
+		writeTuple(0, di.ModTime().UnixNano(), ctime)
+	} else {
+		writeTuple(0, 0, 0)
+	}
+	return h.Sum64()
+}
+
+func (s codebuffSourceSet) Parse(
+	ctx context.Context,
+	req ParseRequest,
+) (ParseOutcome, error) {
+	outcome, err := s.singleFileSourceSet.Parse(ctx, req)
+	if err == nil && outcome.ResultSetComplete && len(outcome.Results) > 0 {
+		outcome.ForceReplace = true
+	}
+	return outcome, err
+}
+
+// codebuffWatchRoots creates recursive watch plans for each root.
+// The on-disk layout is <root>/<project>/chats/<timestamp>/. Recursive
+// watching ensures changes inside timestamp subdirectories are observed.
+// The PeriodicReconcile flag on the Codebuff agent def handles newly
+// created projects, and the recursiveWatchBudget mechanism handles
+// inotify exhaustion by degrading to polling.
+func codebuffWatchRoots(roots []string) []WatchRoot {
+	out := make([]WatchRoot, 0, len(roots))
+	for _, root := range roots {
+		out = append(out, WatchRoot{
+			Path:         root,
+			Recursive:    true,
+			IncludeGlobs: []string{"chat-messages.json", "run-state.json", "chat-meta.json"},
+			DebounceKey:  "codebuff:sessions:" + root,
+		})
+	}
+	return out
+}
+
+// codebuffClassifyPath maps a changed path back to its source
+// chat-messages.json. Paths are shaped like:
+// <root>/<project>/chats/<timestamp>/chat-messages.json
+func codebuffClassifyPath(
+	root, path string, allowMissing bool,
+) (singleFileMatch, bool) {
+	root = filepath.Clean(root)
+	path = filepath.Clean(path)
+
+	// The path should be under root. Walk up from path to find
+	// the project/chats/timestamp structure.
+	rel, err := filepath.Rel(root, path)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return singleFileMatch{}, false
+	}
+
+	parts := strings.Split(rel, string(filepath.Separator))
+	// Expected: <project>/chats/<timestamp>/...
+	if len(parts) < 3 || parts[1] != "chats" {
+		return singleFileMatch{}, false
+	}
+
+	projectName := parts[0]
+	sessionID := parts[2]
+	sessionDir := filepath.Join(root, projectName, "chats", sessionID)
+	chatPath := filepath.Join(sessionDir, "chat-messages.json")
+
+	if allowMissing {
+		return singleFileMatch{
+			Path:        chatPath,
+			ProjectHint: projectName,
+		}, true
+	}
+
+	if IsRegularFile(chatPath) {
+		return singleFileMatch{
+			Path:        chatPath,
+			ProjectHint: projectName,
+		}, true
+	}
+	return singleFileMatch{}, false
+}
+
+// isSafeSinglePathComponent reports whether s is a single
+// filesystem-safe directory or file name: non-empty, not "." or "..",
+// and contains no path separators.
+func isSafeSinglePathComponent(s string) bool {
+	if s == "" || s == "." || s == ".." {
+		return false
+	}
+	return !strings.ContainsAny(s, string(filepath.Separator)+string('/'))
+}
+
+// isWithinRoot reports whether the path is beneath root after
+// resolving any symlinks in the common prefix. Unlike a raw
+// strings.HasPrefix check, this catches .. segments that
+// filepath.Join collapses.
+func isWithinRoot(root, path string) bool {
+	rel, err := filepath.Rel(root, path)
+	return err == nil && !strings.HasPrefix(rel, "..")
+}
+
+// codebuffFindFile finds a session by raw session ID under the root.
+// The rawID may be either "project:timestamp" (new format) or just
+// "timestamp" (legacy compatibility). For the new format, it searches
+// the specific project directory. For legacy format, it searches all
+// project subdirectories.
+func codebuffFindFile(root, rawID string) (singleFileMatch, bool) {
+	// Try to split into project:timestamp.
+	parts := strings.SplitN(rawID, ":", 2)
+	if len(parts) == 2 {
+		projectName := parts[0]
+		timestamp := parts[1]
+		// Reject traversal: project and timestamp must each be a single
+		// safe path component so filepath.Join does not escape root.
+		if !isSafeSinglePathComponent(projectName) ||
+			!isSafeSinglePathComponent(timestamp) {
+			return singleFileMatch{}, false
+		}
+		// Reject raw IDs whose timestamp segment is not a valid
+		// Codebuff session directory name; see IsCodebuffTimestamp.
+		if !IsCodebuffTimestamp(timestamp) {
+			return singleFileMatch{}, false
+		}
+		chatPath := filepath.Join(root, projectName, "chats", timestamp, "chat-messages.json")
+		if !isWithinRoot(root, chatPath) {
+			return singleFileMatch{}, false
+		}
+		if IsRegularFile(chatPath) {
+			return singleFileMatch{
+				Path:        chatPath,
+				ProjectHint: projectName,
+			}, true
+		}
+		return singleFileMatch{}, false
+	}
+
+	// Legacy format: search all projects for the timestamp.
+	if !isSafeSinglePathComponent(rawID) {
+		return singleFileMatch{}, false
+	}
+	projects, err := os.ReadDir(root)
+	if err != nil {
+		return singleFileMatch{}, false
+	}
+	for _, project := range projects {
+		if !project.IsDir() {
+			continue
+		}
+		chatPath := filepath.Join(root, project.Name(), "chats", rawID, "chat-messages.json")
+		if !isWithinRoot(root, chatPath) {
+			continue
+		}
+		if IsRegularFile(chatPath) {
+			return singleFileMatch{
+				Path:        chatPath,
+				ProjectHint: project.Name(),
+			}, true
+		}
+	}
+	return singleFileMatch{}, false
+}
+
+// codebuffFingerprintSource computes a fingerprint for the source.
+// It includes the primary chat-messages.json plus companion files
+// (run-state.json, chat-meta.json) for comprehensive freshness.
+// The composite stat values (total size, max mtime) are computed first
+// so the engine's pre-fingerprint freshness gate can skip unchanged
+// sources before this function is called. The content hash is always
+// computed when this function runs (for the skip cache key), but the
+// engine's providerSourceFreshBeforeFingerprint check ensures this
+// function is only called for sources that may have changed.
+func codebuffFingerprintSource(src singleFileSource) (SourceFingerprint, error) {
+	info, err := os.Stat(src.Path)
+	if err != nil {
+		return SourceFingerprint{}, fmt.Errorf("stat %s: %w", src.Path, err)
+	}
+	if info.IsDir() {
+		return SourceFingerprint{}, fmt.Errorf(
+			"stat %s: source is a directory", src.Path,
+		)
+	}
+
+	fingerprint := SourceFingerprint{
+		Size:    info.Size(),
+		MTimeNS: info.ModTime().UnixNano(),
+	}
+
+	dir := filepath.Dir(src.Path)
+	for _, name := range CodebuffCompanionFilenames {
+		companion := filepath.Join(dir, name)
+		if ci, err := os.Stat(companion); err == nil {
+			fingerprint.Size += ci.Size()
+			if ts := ci.ModTime().UnixNano(); ts > fingerprint.MTimeNS {
+				fingerprint.MTimeNS = ts
+			}
+		}
+	}
+
+	// Compute content hash only when the composite stat has changed.
+	// The engine's skip cache compares MTimeNS first; unchanged sources
+	// skip without reading transcript bytes.
+	h := sha256.New()
+	if err := addSiblingMetadataFingerprintPart(
+		h, "chat-messages", src.Path, info,
+	); err != nil {
+		return SourceFingerprint{}, err
+	}
+	for _, name := range CodebuffCompanionFilenames {
+		companion := filepath.Join(dir, name)
+		if ci, err := os.Stat(companion); err == nil {
+			if err := addSiblingMetadataFingerprintPart(
+				h, name, companion, ci,
+			); err != nil {
+				return SourceFingerprint{}, err
+			}
+		}
+	}
+	fingerprint.Hash = fmt.Sprintf("%x", h.Sum(nil))
+
+	return fingerprint, nil
+}
+
+// codebuffParseFile parses a single session from chat-messages.json.
+func codebuffParseFile(
+	src singleFileSource, req ParseRequest,
+) ([]ParseResult, []string, error) {
+	dir := filepath.Dir(src.Path)
+
+	projectHint := req.Source.ProjectHint
+	if projectHint == "" {
+		projectHint = codebuffProjectFromPath(src.Path)
+	}
+
+	sess, msgs, err := parseCodebuffSession(
+		dir, projectHint, req.Machine,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	if sess == nil {
+		return nil, nil, nil
+	}
+
+	// Apply fingerprint metadata.
+	if req.Fingerprint.Size > 0 {
+		sess.File.Size = req.Fingerprint.Size
+	}
+	if req.Fingerprint.MTimeNS > 0 {
+		sess.File.Mtime = req.Fingerprint.MTimeNS
+	}
+	if req.Fingerprint.Hash != "" {
+		sess.File.Hash = req.Fingerprint.Hash
+	}
+
+	return []ParseResult{{
+		Session:     *sess,
+		Messages:    msgs,
+		UsageEvents: sess.UsageEvents,
+	}}, nil, nil
+}
+
+func codebuffProviderCapabilities() Capabilities {
+	caps := jsonlFileProviderSourceCapabilities()
+	// Codebuff reparses the entire mutable JSON transcript on every sync,
+	// so force full message replacement to avoid stale ordinals and
+	// missed in-place block updates.
+	caps.ForceReplaceOnParse = CapabilitySupported
+	// The Codebuff source layout folds chat-messages.json with its
+	// sibling companions run-state.json and chat-meta.json, so the
+	// engine's stat-only freshness gate must consult the per-component
+	// provider_freshness digest instead of the legacy
+	// size/max-mtime composite. Without this capability the engine
+	// would not register Codebuff in providerStatHashers and warm
+	// passes would fall back to the composite, missing same-size
+	// sibling rewrites whose mtime stays below the existing max.
+	caps.MultiFileStatHash = CapabilitySupported
+	// Content-hash freshness is the per-fingerprint safety net that
+	// catches a sibling rewrite whose SHA-256 changes while size
+	// and mtime stay identical. The legacy size/mtime composite and
+	// the per-component provider_freshness digest both fold the
+	// chat file plus companions down to a single int compare; a
+	// content-hash mismatch is the only signal that survives a
+	// same-size, same-max-mtime rewrite of every companion. Without
+	// this flag providerFingerprintHashMatchesDB short-circuits on
+	// `!required` and treats the rewrite as fresh, so an identical
+	// size swap (where the bytes change but the byte length is the
+	// same, as testable via a same-length sibling rewrite with
+	// matching content) would let stale costs, agent classification,
+	// or Freebuff metadata survive the warm pass and never revisit
+	// the source. Setting this opts Codebuff into
+	// providerFingerprintHashEstablishesFreshness, which provides
+	// the second safety net behind the per-component provider_freshness
+	// digest: if the side-table is ever cleared (post-tombstone) or
+	// missing on first warm pass, provider.Fingerprint's content-hash
+	// compare still catches the rewrite.
+	return Capabilities{
+		Source: caps,
+		Content: ContentCapabilities{
+			FirstMessage:         CapabilitySupported,
+			SessionName:          CapabilitySupported,
+			Thinking:             CapabilitySupported,
+			ToolCalls:            CapabilitySupported,
+			ToolResults:          CapabilitySupported,
+			Model:                CapabilityNotApplicable,
+			AggregateUsageEvents: CapabilitySupported,
+			Relationships:        CapabilityNotApplicable,
+			TerminationStatus:    CapabilityNotApplicable,
+			MalformedLineCount:   CapabilityNotApplicable,
+		},
+		Sync: ProviderSyncSemantics{
+			FingerprintHashRequiredForFreshness: true,
+		},
+	}
+}

--- a/internal/parser/codebuff_provider.go
+++ b/internal/parser/codebuff_provider.go
@@ -46,8 +46,11 @@ func CodebuffCompanionMtime(
 }
 
 // newCodebuffProviderFactory creates a provider factory for Codebuff.
-// Freebuff sessions are handled through the same provider and distinguished
-// via AgentLabel rather than a separate agent type.
+// Freebuff sessions are handled through this same provider: they are
+// parsed with their own agent type (parseCodebuffSession sets Agent =
+// AgentFreebuff and emits freebuff:-prefixed IDs), but Freebuff has no
+// registry entry or factory of its own, and sync canonicalizes
+// freebuff: IDs onto the Codebuff def via AgentByPrefix.
 func newCodebuffProviderFactory(def AgentDef) ProviderFactory {
 	return NewSourceSetFactory(
 		def,
@@ -244,6 +247,12 @@ func isWithinRoot(root, path string) bool {
 // "timestamp" (legacy compatibility). For the new format, it searches
 // the specific project directory. For legacy format, it searches all
 // project subdirectories.
+//
+// Known asymmetry with discovery: codebuffDiscoverEach accepts any
+// chats/<name>/ directory containing chat-messages.json, but lookup
+// rejects non-timestamp session names (the IsCodebuffTimestamp gate
+// below, part of the traversal defense). A session discovered under a
+// non-timestamp directory name is therefore not resolvable by rawID.
 func codebuffFindFile(root, rawID string) (singleFileMatch, bool) {
 	// Try to split into project:timestamp.
 	parts := strings.SplitN(rawID, ":", 2)

--- a/internal/parser/codebuff_provider_test.go
+++ b/internal/parser/codebuff_provider_test.go
@@ -1,0 +1,84 @@
+package parser
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCodebuffFindFile_RejectsHostileRawIDs pins the fail-closed
+// traversal defense in codebuffFindFile: raw IDs containing path
+// separators, "." or ".." segments, absolute paths, empty segments,
+// or non-timestamp session names must never resolve — in particular
+// they must never reach the decoy chat-messages.json staged outside
+// the root, which is exactly where "..:<ts>" would land if the
+// single-component checks were removed.
+func TestCodebuffFindFile_RejectsHostileRawIDs(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "root")
+	ts := "2026-07-15T20-01-32.065Z"
+	valid := filepath.Join(root, "proj", "chats", ts, "chat-messages.json")
+	codebuffWriteFile(t, valid, "[]")
+	// Decoy outside the root: <base>/chats/<ts>/chat-messages.json is
+	// the file filepath.Join(root, "..", "chats", ts, ...) collapses to.
+	decoy := filepath.Join(base, "chats", ts, "chat-messages.json")
+	codebuffWriteFile(t, decoy, "[]")
+
+	sep := string(filepath.Separator)
+	cases := []struct {
+		name  string
+		rawID string
+	}{
+		{"empty", ""},
+		{"project dot-dot", "..:" + ts},
+		{"project dot", ".:" + ts},
+		{"project empty", ":" + ts},
+		{"project with slash", "a/b:" + ts},
+		{"project with platform separator", "a" + sep + "b:" + ts},
+		{"project absolute path", sep + "abs:" + ts},
+		{"timestamp with traversal", "proj:../" + ts},
+		{"timestamp dot-dot", "proj:.."},
+		{"non-timestamp session name", "proj:not-a-timestamp"},
+		{"legacy dot-dot", ".."},
+		{"legacy dot", "."},
+		{"legacy with slash", "../" + ts},
+		{"legacy with platform separator", ".." + sep + ts},
+		{"legacy absolute path", decoy},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			match, ok := codebuffFindFile(root, tc.rawID)
+			assert.False(t, ok, "hostile rawID %q must fail closed", tc.rawID)
+			assert.NotEqual(t, decoy, match.Path,
+				"hostile rawID %q must never resolve to a file outside the root", tc.rawID)
+			assert.Empty(t, match.Path)
+		})
+	}
+}
+
+// TestCodebuffFindFile_ResolvesValidIDs pins the two accepted rawID
+// shapes: "project:timestamp" resolves directly, and a bare legacy
+// timestamp searches all project subdirectories.
+func TestCodebuffFindFile_ResolvesValidIDs(t *testing.T) {
+	root := t.TempDir()
+	ts := "2026-07-15T20-01-32.065Z"
+	valid := filepath.Join(root, "proj", "chats", ts, "chat-messages.json")
+	codebuffWriteFile(t, valid, "[]")
+
+	match, ok := codebuffFindFile(root, "proj:"+ts)
+	require.True(t, ok, "project:timestamp rawID must resolve")
+	assert.Equal(t, valid, match.Path)
+	assert.Equal(t, "proj", match.ProjectHint)
+
+	match, ok = codebuffFindFile(root, ts)
+	require.True(t, ok, "legacy bare timestamp rawID must resolve")
+	assert.Equal(t, valid, match.Path)
+	assert.Equal(t, "proj", match.ProjectHint)
+
+	_, ok = codebuffFindFile(root, "other:"+ts)
+	assert.False(t, ok, "wrong project must not resolve")
+	_, ok = codebuffFindFile(root, "proj:2030-01-01T00-00-00.000Z")
+	assert.False(t, ok, "unknown timestamp must not resolve")
+}

--- a/internal/parser/codebuff_resolve.go
+++ b/internal/parser/codebuff_resolve.go
@@ -1,0 +1,101 @@
+// ABOUTME: Helpers for resolving a bare on-disk Codebuff/Freebuff
+// ABOUTME: timestamp directory name to a session location.
+// ABOUTME: Codebuff and Freebuff share the same on-disk layout
+// ABOUTME: (<root>/<project>/chats/<timestamp>/); the caller
+// ABOUTME: decides which agent type owns each location because
+// ABOUTME: Freebuff is intentionally absent from parser.Registry
+// ABOUTME: and so cfg.ResolveDirs(parser.AgentFreebuff) is often
+// ABOUTME: empty, leaving the shared codebuff roots as the only
+// ABOUTME: location to interrogate on disk.
+package parser
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// CodebuffFamilyRoots ties one of the two storage agents to its
+// list of root directories. Both Codebuff and Freebuff share the
+// same on-disk layout: <root>/<project>/chats/<timestamp>/. The
+// agent type (Codebuff vs Freebuff) is read from run-state.json
+// per session, but for bare-ID resolution at the CLI boundary
+// each roots list is associated with one agent type up front so
+// the resolver can build the canonical ID prefix without reading
+// every candidate's run-state.json.
+type CodebuffFamilyRoots struct {
+	Agent AgentType
+	Roots []string
+}
+
+// CodebuffFamilyMatch is one possible canonical ID for a bare
+// timestamp resolved against the on-disk storage. The Agent field
+// distinguishes Codebuff from Freebuff so the canonical ID prefix
+// matches the on-disk agentType (rather than the registry default).
+type CodebuffFamilyMatch struct {
+	Agent       AgentType
+	ProjectHint string
+	RawID       string
+}
+
+// CanonicalID returns the full canonical ID the parser would have
+// stored for this match: "<agent>:<project>:<rawID>".
+func (c CodebuffFamilyMatch) CanonicalID() string {
+	return string(c.Agent) + ":" + c.ProjectHint + ":" + c.RawID
+}
+
+// FindCodebuffFreebuffMatches walks each roots list looking for
+// a directory whose chats/<rawID> subdirectory contains an
+// existing chat-messages.json. Returns one match per (agent,
+// project) pair whose chats subdirectory matches rawID.
+//
+// Empty rawID returns nil. A roots entry that does not exist on
+// disk is silently skipped. The agent type is determined by which
+// Roots list the match was found in; run-state.json is not read.
+//
+// Duplicate timestamps across projects return multiple matches
+// so the caller can surface an explicit ambiguity error listing
+// every candidate canonical ID instead of silently picking one.
+//
+// Note: Freebuff is intentionally absent from parser.Registry, so
+// cfg.ResolveDirs(parser.AgentFreebuff) is empty whenever the user
+// has not set FREEBUFF_DIR explicitly. In that case callers
+// (e.g. cmd/agentsview/session_get.go resolveBareCodebuffID) must
+// test both AgentCodebuff and AgentFreebuff prefixes against the
+// service per matched (project, rawID) location, because the
+// shared codebuff root list may contain freebuff sessions the
+// resolver cannot classify from the registry alone.
+func FindCodebuffFreebuffMatches(
+	pairs []CodebuffFamilyRoots,
+	rawID string,
+) []CodebuffFamilyMatch {
+	if rawID == "" {
+		return nil
+	}
+	var out []CodebuffFamilyMatch
+	for _, p := range pairs {
+		for _, root := range p.Roots {
+			projects, err := os.ReadDir(root)
+			if err != nil {
+				continue
+			}
+			for _, project := range projects {
+				if !project.IsDir() {
+					continue
+				}
+				chatPath := filepath.Join(
+					root, project.Name(), "chats",
+					rawID, "chat-messages.json",
+				)
+				if _, err := os.Stat(chatPath); err != nil {
+					continue
+				}
+				out = append(out, CodebuffFamilyMatch{
+					Agent:       p.Agent,
+					ProjectHint: project.Name(),
+					RawID:       rawID,
+				})
+			}
+		}
+	}
+	return out
+}

--- a/internal/parser/codebuff_resolve.go
+++ b/internal/parser/codebuff_resolve.go
@@ -48,7 +48,12 @@ func (c CodebuffFamilyMatch) CanonicalID() string {
 // existing chat-messages.json. Returns one match per (agent,
 // project) pair whose chats subdirectory matches rawID.
 //
-// Empty rawID returns nil. A roots entry that does not exist on
+// Empty rawID returns nil. rawID must be a single filesystem-safe
+// path component: IDs containing path separators, "." or ".."
+// segments, or absolute paths fail closed and return nil, so a
+// traversal-shaped rawID can never join into a path outside the
+// configured roots. This holds independently of the caller's
+// IsCodebuffTimestamp pre-gate. A roots entry that does not exist on
 // disk is silently skipped. The agent type is determined by which
 // Roots list the match was found in; run-state.json is not read.
 //
@@ -68,7 +73,7 @@ func FindCodebuffFreebuffMatches(
 	pairs []CodebuffFamilyRoots,
 	rawID string,
 ) []CodebuffFamilyMatch {
-	if rawID == "" {
+	if !isSafeSinglePathComponent(rawID) {
 		return nil
 	}
 	var out []CodebuffFamilyMatch
@@ -86,6 +91,9 @@ func FindCodebuffFreebuffMatches(
 					root, project.Name(), "chats",
 					rawID, "chat-messages.json",
 				)
+				if !isWithinRoot(root, chatPath) {
+					continue
+				}
 				if _, err := os.Stat(chatPath); err != nil {
 					continue
 				}

--- a/internal/parser/codebuff_resolve_test.go
+++ b/internal/parser/codebuff_resolve_test.go
@@ -129,6 +129,46 @@ func TestFindCodebuffFreebuffMatchesMiss(t *testing.T) {
 		"unknown timestamp must return no matches")
 }
 
+// TestFindCodebuffFreebuffMatchesRejectsTraversal pins the
+// fail-closed contract for hostile rawIDs: an ID containing path
+// separators or "."/".." segments must return no matches (and not
+// panic), even when the traversal-shaped ID points at a real
+// chat-messages.json outside the root.
+func TestFindCodebuffFreebuffMatchesRejectsTraversal(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "root")
+	codebuffMakeSessionDir(
+		t, root, "proj", "2026-07-16T00-09-00.236Z",
+	)
+	// Decoy outside the root: filepath.Join(root, "proj", "chats",
+	// "../../../x", "chat-messages.json") collapses to
+	// <base>/x/chat-messages.json.
+	require.NoError(t, os.MkdirAll(filepath.Join(base, "x"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(base, "x", "chat-messages.json"),
+		[]byte("[]"),
+		0o644,
+	))
+
+	pairs := []CodebuffFamilyRoots{
+		{Agent: AgentCodebuff, Roots: []string{root}},
+	}
+	sep := string(filepath.Separator)
+	hostile := []string{
+		"../../../x",
+		".." + sep + ".." + sep + ".." + sep + "x",
+		"..",
+		".",
+		"a/b",
+		"../2026-07-16T00-09-00.236Z",
+	}
+	for _, rawID := range hostile {
+		matches := FindCodebuffFreebuffMatches(pairs, rawID)
+		assert.Empty(t, matches,
+			"hostile rawID %q must return no matches", rawID)
+	}
+}
+
 // TestFindCodebuffFreebuffMatchesEmpty pins the empty-input
 // path: empty rawID returns nil without touching the
 // filesystem or iterating the configured roots.

--- a/internal/parser/codebuff_resolve_test.go
+++ b/internal/parser/codebuff_resolve_test.go
@@ -1,0 +1,144 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// codebuffMakeSessionDir creates a minimal Codebuff session
+// directory under root/<project>/chats/<rawID> by writing an
+// empty chat-messages.json. run-state.json is not written so the
+// resolver falls back to whichever roots list the session was
+// found in (Codebuff or Freebuff) — identical to what a
+// bare-timestamp lookup at the CLI boundary does.
+func codebuffMakeSessionDir(
+	t *testing.T, root, project, rawID string,
+) {
+	t.Helper()
+	dir := filepath.Join(root, project, "chats", rawID)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "chat-messages.json"),
+		[]byte("[]"),
+		0o644,
+	))
+}
+
+// TestFindCodebuffFreebuffMatchesSingle pins the happy path:
+// when exactly one (agent, project, timestamp) entry exists on
+// disk, the helper returns one match whose CanonicalID matches
+// the agent type and project directory name.
+func TestFindCodebuffFreebuffMatchesSingle(t *testing.T) {
+	root := t.TempDir()
+	codebuffMakeSessionDir(
+		t, root, "my-project", "2026-07-16T00-09-00.236Z",
+	)
+
+	matches := FindCodebuffFreebuffMatches(
+		[]CodebuffFamilyRoots{
+			{Agent: AgentCodebuff, Roots: []string{root}},
+			{Agent: AgentFreebuff, Roots: nil},
+		},
+		"2026-07-16T00-09-00.236Z",
+	)
+	require.Len(t, matches, 1)
+	assert.Equal(t, AgentCodebuff, matches[0].Agent)
+	assert.Equal(t, "my-project", matches[0].ProjectHint)
+	assert.Equal(t,
+		"codebuff:my-project:2026-07-16T00-09-00.236Z",
+		matches[0].CanonicalID(),
+	)
+}
+
+// TestFindCodebuffFreebuffMatchesAmbiguous pins duplicate
+// timestamp handling: when two projects share a timestamp the
+// helper returns both matches so the caller can surface the
+// ambiguity error instead of silently picking one.
+func TestFindCodebuffFreebuffMatchesAmbiguous(t *testing.T) {
+	root := t.TempDir()
+	codebuffMakeSessionDir(
+		t, root, "project-a", "2026-07-16T00-09-00.236Z",
+	)
+	codebuffMakeSessionDir(
+		t, root, "project-b", "2026-07-16T00-09-00.236Z",
+	)
+
+	matches := FindCodebuffFreebuffMatches(
+		[]CodebuffFamilyRoots{
+			{Agent: AgentCodebuff, Roots: []string{root}},
+		},
+		"2026-07-16T00-09-00.236Z",
+	)
+	require.Len(t, matches, 2)
+	cands := []string{
+		matches[0].CanonicalID(),
+		matches[1].CanonicalID(),
+	}
+	assert.Contains(t, cands,
+		"codebuff:project-a:2026-07-16T00-09-00.236Z")
+	assert.Contains(t, cands,
+		"codebuff:project-b:2026-07-16T00-09-00.236Z")
+}
+
+// TestFindCodebuffFreebuffMatchesFreebuff pins Freebuff prefix
+// tagging: matches under the Freebuff roots list must be tagged
+// with AgentFreebuff so the canonical ID uses the freebuff:
+// prefix that matches the on-disk agentType, not codebuff:.
+func TestFindCodebuffFreebuffMatchesFreebuff(t *testing.T) {
+	freebuffRoot := t.TempDir()
+	codebuffMakeSessionDir(
+		t, freebuffRoot, "free-project", "2026-07-16T00-09-00.236Z",
+	)
+
+	matches := FindCodebuffFreebuffMatches(
+		[]CodebuffFamilyRoots{
+			{Agent: AgentCodebuff, Roots: nil},
+			{Agent: AgentFreebuff, Roots: []string{freebuffRoot}},
+		},
+		"2026-07-16T00-09-00.236Z",
+	)
+	require.Len(t, matches, 1)
+	assert.Equal(t, AgentFreebuff, matches[0].Agent)
+	assert.Equal(t,
+		"freebuff:free-project:2026-07-16T00-09-00.236Z",
+		matches[0].CanonicalID(),
+	)
+}
+
+// TestFindCodebuffFreebuffMatchesMiss pins the no-match path:
+// a rawID that does not name any existing chats subdirectory
+// returns nil so the caller surfaces the "not found" error
+// rather than picking the wrong session.
+func TestFindCodebuffFreebuffMatchesMiss(t *testing.T) {
+	root := t.TempDir()
+	codebuffMakeSessionDir(
+		t, root, "my-project", "2026-07-16T00-09-00.236Z",
+	)
+
+	matches := FindCodebuffFreebuffMatches(
+		[]CodebuffFamilyRoots{
+			{Agent: AgentCodebuff, Roots: []string{root}},
+		},
+		"2030-01-01T00-00-00.000Z",
+	)
+	assert.Empty(t, matches,
+		"unknown timestamp must return no matches")
+}
+
+// TestFindCodebuffFreebuffMatchesEmpty pins the empty-input
+// path: empty rawID returns nil without touching the
+// filesystem or iterating the configured roots.
+func TestFindCodebuffFreebuffMatchesEmpty(t *testing.T) {
+	matches := FindCodebuffFreebuffMatches(
+		[]CodebuffFamilyRoots{
+			{Agent: AgentCodebuff,
+				Roots: []string{"/definitely/missing"}},
+		},
+		"",
+	)
+	assert.Empty(t, matches)
+}

--- a/internal/parser/codebuff_test.go
+++ b/internal/parser/codebuff_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1508,7 +1509,7 @@ func TestParseCodebuffMixedFormatMidnightRollover(t *testing.T) {
 		{"id":"u5","variant":"user","content":"after","timestamp":"02:00 PM"}
 	]`)
 
-	msgs, _, _, err := parseCodebuffMessages(data, sessionDate, "")
+	msgs, _, _, err := parseCodebuffMessages(data, sessionDate)
 	require.NoError(t, err)
 	require.Len(t, msgs, 5)
 
@@ -1539,4 +1540,109 @@ func TestParseCodebuffMixedFormatMidnightRollover(t *testing.T) {
 	require.Equal(t, 17, msgs[4].Timestamp.Day(),
 		"time-only after an RFC3339 anchor that crossed a date boundary must stay on the new date")
 	require.Equal(t, 14, msgs[4].Timestamp.Hour())
+}
+
+// TestParseCodebuffMessages_FirstMessageMidnightRollover pins the
+// rollover seed for the very first message: a session created late in
+// the local evening (directory 2026-07-17T06-58-00.000Z = 23:58 on
+// July 16 in UTC-7) whose first time-only message reads "12:01 AM"
+// belongs to the next local calendar day (July 17), not ~24 hours
+// before the session started. Before the fix prevHour started at -1,
+// so the first message could never roll over midnight and was stamped
+// July 16 00:01, skewing StartedAt.
+func TestParseCodebuffMessages_FirstMessageMidnightRollover(t *testing.T) {
+	// Pin time.Local to a fixed UTC-7 zone so the session-date parse
+	// and the time-only reconstruction are deterministic regardless of
+	// the host TZ (same pinning approach as the mixed-format rollover
+	// test above).
+	origLocal := time.Local
+	t.Cleanup(func() { time.Local = origLocal })
+	time.Local = time.FixedZone("UTC-7", -7*3600)
+
+	sessionDate := parseCodebuffSessionDate("2026-07-17T06-58-00.000Z")
+	require.Equal(t, 16, sessionDate.Day(), "06:58 UTC is 23:58 on July 16 in UTC-7")
+	require.Equal(t, 23, sessionDate.Hour())
+
+	data := []byte(`[
+		{"id":"u1","variant":"user","content":"hello","timestamp":"12:01 AM"},
+		{"id":"u2","variant":"user","content":"more","timestamp":"12:30 AM"}
+	]`)
+
+	msgs, startedAt, _, err := parseCodebuffMessages(data, sessionDate)
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+
+	assert.Equal(t, 17, msgs[0].Timestamp.Day(),
+		"first time-only message past local midnight must land on the next calendar day")
+	assert.Equal(t, 0, msgs[0].Timestamp.Hour())
+	assert.Equal(t, 1, msgs[0].Timestamp.Minute())
+	assert.Equal(t, 17, msgs[1].Timestamp.Day())
+	assert.Equal(t, 17, startedAt.Day(),
+		"StartedAt must not be skewed ~24h before the session directory timestamp")
+}
+
+// TestCodebuffAttachSkillNames_DeterministicFallbackWinner pins two
+// contracts of the input-scan skill attribution: when two catalog
+// skills both appear as tokens in the tool input, the winner is
+// deterministic (first in lowercase-sorted order), and both the
+// direct-key path and the fallback token scan return the catalog's
+// canonical casing rather than the input's or the lowercased key.
+func TestCodebuffAttachSkillNames_DeterministicFallbackWinner(t *testing.T) {
+	msgs := []ParsedMessage{{
+		Role:       RoleAssistant,
+		HasToolUse: true,
+		ToolCalls: []ParsedToolCall{
+			{
+				ToolUseID: "tc-1",
+				ToolName:  "run_terminal_command",
+				InputJSON: `{"command":"zulu-skill then alpha-skill"}`,
+			},
+			{
+				ToolUseID: "tc-2",
+				ToolName:  "run_terminal_command",
+				InputJSON: `{"command":"alpha-skill"}`,
+			},
+		},
+	}}
+	skills := []codebuffSkill{
+		{Name: "Zulu-Skill", Description: "z"},
+		{Name: "Alpha-Skill", Description: "a"},
+	}
+	codebuffAttachSkillNames(msgs, skills)
+
+	assert.Equal(t, "Alpha-Skill", msgs[0].ToolCalls[0].SkillName,
+		"two-match input must pick the lowercase-sorted first skill with catalog casing")
+	assert.Equal(t, "Alpha-Skill", msgs[0].ToolCalls[1].SkillName,
+		"direct command-key match must return the catalog's canonical casing")
+}
+
+// TestParseCodebuffSession_SessionNameRuneSafeTruncation pins that
+// the 80-byte session-name shortening cannot split a multi-byte rune:
+// a first message of 100 two-byte runes must yield a valid-UTF-8 name
+// of the first 77 runes plus "...", not a raw 77-byte slice ending in
+// half a rune.
+func TestParseCodebuffSession_SessionNameRuneSafeTruncation(t *testing.T) {
+	longPrompt := strings.Repeat("é", 100)
+	chatMessages := `[
+		{
+			"id": "user-1",
+			"variant": "user",
+			"content": "` + longPrompt + `",
+			"timestamp": "2026-07-15T15:04:00Z"
+		}
+	]`
+	runState := `{
+		"sessionState": {
+			"mainAgentState": {"agentType": "base2-deepseek"}
+		}
+	}`
+
+	dir := codebuffTestSession(t, chatMessages, runState, "")
+	sess, _, err := parseCodebuffSession(dir, "p", "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	assert.True(t, utf8.ValidString(sess.SessionName),
+		"session name must remain valid UTF-8 after truncation")
+	assert.Equal(t, strings.Repeat("é", 77)+"...", sess.SessionName)
 }

--- a/internal/parser/codebuff_test.go
+++ b/internal/parser/codebuff_test.go
@@ -1,0 +1,1542 @@
+package parser
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// codebuffWriteFile writes body to path, creating parent dirs.
+func codebuffWriteFile(t *testing.T, path, body string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(body), 0o644))
+}
+
+// codebuffTestSession creates a minimal codebuff session directory with
+// chat-messages.json, run-state.json, and chat-meta.json. Returns the
+// session directory path.
+func codebuffTestSession(
+	t *testing.T,
+	chatMessages string,
+	runState string,
+	chatMeta string,
+) string {
+	t.Helper()
+	dir := t.TempDir()
+	codebuffWriteFile(t, filepath.Join(dir, "chat-messages.json"), chatMessages)
+	if runState != "" {
+		codebuffWriteFile(t, filepath.Join(dir, "run-state.json"), runState)
+	}
+	if chatMeta != "" {
+		codebuffWriteFile(t, filepath.Join(dir, "chat-meta.json"), chatMeta)
+	}
+	return dir
+}
+
+func TestParseCodebuffSession_BasicUserAndAIMessages(t *testing.T) {
+	chatMessages := `[
+		{
+			"id": "user-1",
+			"variant": "user",
+			"content": "Fix the login bug",
+			"timestamp": "2026-07-15T15:04:00Z"
+		},
+		{
+			"id": "ai-1",
+			"variant": "ai",
+			"content": "",
+			"timestamp": "2026-07-15T15:05:00Z",
+			"blocks": [
+				{
+					"type": "text",
+					"textType": "text",
+					"content": "I'll fix the login bug by updating the auth handler."
+				}
+			]
+		}
+	]`
+	runState := `{
+		"sessionState": {
+			"mainAgentState": {
+				"agentType": "base2-deepseek",
+				"contextTokenCount": 50000
+			},
+			"fileContext": {
+				"cwd": "/Users/dev/myproject"
+			}
+		}
+	}`
+	chatMeta := `{"messageCount": 2, "firstPrompt": "Fix the login bug", "messagesSize": 1024}`
+
+	dir := codebuffTestSession(t, chatMessages, runState, chatMeta)
+	sess, msgs, err := parseCodebuffSession(dir, "myproject", "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	assert.Equal(t, AgentCodebuff, sess.Agent)
+	assert.Equal(t, "Codebuff", sess.AgentLabel)
+	assert.Contains(t, sess.ID, "codebuff:")
+	assert.Equal(t, "myproject", sess.Project)
+	assert.Equal(t, "/Users/dev/myproject", sess.Cwd)
+	assert.Equal(t, "codebuff-chat-v1", sess.SourceVersion)
+	assert.Equal(t, "Fix the login bug", sess.FirstMessage)
+	assert.Equal(t, 2, sess.MessageCount)
+	assert.Equal(t, 1, sess.UserMessageCount)
+	// PeakContextTokens is not set because contextTokenCount from
+	// run-state.json is the final per-step count, not the peak.
+
+	require.Len(t, msgs, 2)
+	assert.Equal(t, RoleUser, msgs[0].Role)
+	assert.Equal(t, "Fix the login bug", msgs[0].Content)
+	assert.Equal(t, RoleAssistant, msgs[1].Role)
+	assert.Contains(t, msgs[1].Content, "I'll fix the login bug")
+}
+
+func TestParseCodebuffSession_FreebuffClassification(t *testing.T) {
+	chatMessages := `[
+		{
+			"id": "user-1",
+			"variant": "user",
+			"content": "Hello",
+			"timestamp": "10:00 AM"
+		}
+	]`
+	runState := `{
+		"sessionState": {
+			"mainAgentState": {
+				"agentType": "base2-free-minimax-m3"
+			}
+		}
+	}`
+
+	dir := codebuffTestSession(t, chatMessages, runState, "")
+	sess, _, err := parseCodebuffSession(dir, "testproject", "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	// Freebuff sessions use AgentFreebuff for distinct filtering, while
+	// lifecycle operations are handled via the freebuff: prefix alias
+	// in AgentByPrefix.
+	assert.Equal(t, AgentFreebuff, sess.Agent)
+	assert.Equal(t, "Freebuff", sess.AgentLabel)
+}
+
+func TestParseCodebuffSession_Timestamps(t *testing.T) {
+	chatMessages := `[
+		{
+			"id": "user-1",
+			"variant": "user",
+			"content": "first",
+			"timestamp": "2026-07-15T15:04:00Z"
+		},
+		{
+			"id": "user-2",
+			"variant": "user",
+			"content": "second",
+			"timestamp": "2026-07-15T15:10:00Z"
+		}
+	]`
+	runState := `{
+		"sessionState": {
+			"mainAgentState": {
+				"agentType": "base2-deepseek"
+			}
+		}
+	}`
+
+	dir := codebuffTestSession(t, chatMessages, runState, "")
+	sess, _, err := parseCodebuffSession(dir, "p", "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	assert.False(t, sess.StartedAt.IsZero())
+	assert.False(t, sess.EndedAt.IsZero())
+	assert.True(t, sess.EndedAt.After(sess.StartedAt) || sess.EndedAt.Equal(sess.StartedAt))
+}
+
+func TestParseCodebuffSession_ToolCalls(t *testing.T) {
+	chatMessages := `[
+		{
+			"id": "ai-1",
+			"variant": "ai",
+			"content": "",
+			"timestamp": "03:04 PM",
+			"blocks": [
+				{
+					"type": "tool",
+					"toolName": "read_files",
+					"toolCallId": "tc-1",
+					"input": {"paths": ["src/main.go"]},
+					"output": "package main"
+				}
+			]
+		}
+	]`
+	runState := `{
+		"sessionState": {
+			"mainAgentState": {
+				"agentType": "base2-deepseek"
+			}
+		}
+	}`
+
+	dir := codebuffTestSession(t, chatMessages, runState, "")
+	_, msgs, err := parseCodebuffSession(dir, "p", "local")
+	require.NoError(t, err)
+
+	// AI message with tool call + tool result = 2 messages.
+	require.GreaterOrEqual(t, len(msgs), 1)
+
+	var toolCallMsg *ParsedMessage
+	for i := range msgs {
+		if msgs[i].HasToolUse {
+			toolCallMsg = &msgs[i]
+			break
+		}
+	}
+	require.NotNil(t, toolCallMsg, "expected a message with tool use")
+	assert.Equal(t, RoleAssistant, toolCallMsg.Role)
+	require.Len(t, toolCallMsg.ToolCalls, 1)
+	assert.Equal(t, "read_files", toolCallMsg.ToolCalls[0].ToolName)
+	assert.Equal(t, "Read", toolCallMsg.ToolCalls[0].Category)
+	assert.Equal(t, "tc-1", toolCallMsg.ToolCalls[0].ToolUseID)
+	assert.Contains(t, toolCallMsg.ToolCalls[0].InputJSON, "src/main.go")
+}
+
+func TestParseCodebuffSession_SubagentToolCall(t *testing.T) {
+	chatMessages := `[
+		{
+			"id": "ai-1",
+			"variant": "ai",
+			"content": "",
+			"timestamp": "03:04 PM",
+			"blocks": [
+				{
+					"type": "agent",
+					"agentId": "agent-1",
+					"agentName": "basher",
+					"agentType": "basher",
+					"status": "complete",
+					"initialPrompt": "run tests",
+					"content": "All tests passed."
+				}
+			]
+		}
+	]`
+	runState := `{
+		"sessionState": {
+			"mainAgentState": {
+				"agentType": "base2-deepseek"
+			}
+		}
+	}`
+
+	dir := codebuffTestSession(t, chatMessages, runState, "")
+	_, msgs, err := parseCodebuffSession(dir, "p", "local")
+	require.NoError(t, err)
+
+	var toolCallMsg *ParsedMessage
+	for i := range msgs {
+		if msgs[i].HasToolUse {
+			toolCallMsg = &msgs[i]
+			break
+		}
+	}
+	require.NotNil(t, toolCallMsg, "expected a message with tool use")
+	require.Len(t, toolCallMsg.ToolCalls, 1)
+
+	tc := toolCallMsg.ToolCalls[0]
+	assert.Equal(t, "Task", tc.Category, "subagent calls should use Task category")
+	assert.Equal(t, "basher", tc.ToolName)
+	assert.Equal(t, "agent-1", tc.ToolUseID)
+	assert.Contains(t, tc.InputJSON, "basher")
+	assert.Contains(t, tc.InputJSON, "run tests")
+	// The agent's lifecycle status must be carried in the tool-call input
+	// now that agent output is emitted as a linked ParsedToolResult; it
+	// used to render in the assistant text for the block. Assert on the
+	// decoded value, not a raw substring, so formatting changes to
+	// InputJSON cannot silently drop the field.
+	var input map[string]any
+	require.NoError(t, json.Unmarshal([]byte(tc.InputJSON), &input))
+	status, ok := input["status"]
+	require.True(t, ok,
+		"agent tool-call InputJSON must include the status field")
+	assert.Equal(t, "complete", status,
+		"agent status must round-trip from the block's status field")
+	// SubagentSessionID intentionally unset.
+	assert.Empty(t, tc.SubagentSessionID)
+}
+
+// TestParseCodebuffSession_SubagentToolCallDefaultStatus pins the default
+// lifecycle status for agent blocks that omit the status field. The parser
+// folds the status into the tool-call InputJSON; when the block carries no
+// status, it must default to "spawned" so the field stays present for
+// consumers that key off it.
+func TestParseCodebuffSession_SubagentToolCallDefaultStatus(t *testing.T) {
+	chatMessages := `[
+		{
+			"id": "ai-1",
+			"variant": "ai",
+			"content": "",
+			"timestamp": "03:04 PM",
+			"blocks": [
+				{
+					"type": "agent",
+					"agentId": "agent-1",
+					"agentName": "basher",
+					"agentType": "basher",
+					"initialPrompt": "run tests",
+					"content": "All tests passed."
+				}
+			]
+		}
+	]`
+	runState := `{
+		"sessionState": {
+			"mainAgentState": {
+				"agentType": "base2-deepseek"
+			}
+		}
+	}`
+
+	dir := codebuffTestSession(t, chatMessages, runState, "")
+	_, msgs, err := parseCodebuffSession(dir, "p", "local")
+	require.NoError(t, err)
+
+	var toolCallMsg *ParsedMessage
+	for i := range msgs {
+		if msgs[i].HasToolUse {
+			toolCallMsg = &msgs[i]
+			break
+		}
+	}
+	require.NotNil(t, toolCallMsg, "expected a message with tool use")
+	require.Len(t, toolCallMsg.ToolCalls, 1)
+
+	tc := toolCallMsg.ToolCalls[0]
+	var input map[string]any
+	require.NoError(t, json.Unmarshal([]byte(tc.InputJSON), &input))
+	status, ok := input["status"]
+	require.True(t, ok,
+		"agent tool-call InputJSON must always include the status field")
+	assert.Equal(t, "spawned", status,
+		"a missing block status must default to spawned")
+}
+
+func TestParseCodebuffSession_ThinkingBlocks(t *testing.T) {
+	chatMessages := `[
+		{
+			"id": "ai-1",
+			"variant": "ai",
+			"content": "",
+			"timestamp": "03:04 PM",
+			"blocks": [
+				{
+					"type": "text",
+					"textType": "reasoning",
+					"content": "Let me think about this approach."
+				},
+				{
+					"type": "text",
+					"textType": "text",
+					"content": "Here is my answer."
+				}
+			]
+		}
+	]`
+	runState := `{
+		"sessionState": {
+			"mainAgentState": {
+				"agentType": "base2-deepseek"
+			}
+		}
+	}`
+
+	dir := codebuffTestSession(t, chatMessages, runState, "")
+	_, msgs, err := parseCodebuffSession(dir, "p", "local")
+	require.NoError(t, err)
+
+	var thinkingMsg *ParsedMessage
+	for i := range msgs {
+		if msgs[i].HasThinking {
+			thinkingMsg = &msgs[i]
+			break
+		}
+	}
+	require.NotNil(t, thinkingMsg, "expected a thinking message")
+	assert.Equal(t, RoleAssistant, thinkingMsg.Role)
+	assert.Contains(t, thinkingMsg.Content, "[Thinking]")
+	assert.Contains(t, thinkingMsg.Content, "Let me think about this approach.")
+	assert.Contains(t, thinkingMsg.ThinkingText, "Let me think about this approach.")
+}
+
+func TestParseCodebuffSession_ModeDivider(t *testing.T) {
+	chatMessages := `[
+		{
+			"id": "ai-1",
+			"variant": "ai",
+			"content": "",
+			"timestamp": "03:04 PM",
+			"blocks": [
+				{
+					"type": "mode-divider",
+					"mode": "LITE"
+				},
+				{
+					"type": "text",
+					"textType": "text",
+					"content": "Working in LITE mode."
+				}
+			]
+		}
+	]`
+	runState := `{
+		"sessionState": {
+			"mainAgentState": {
+				"agentType": "base2-deepseek"
+			}
+		}
+	}`
+
+	dir := codebuffTestSession(t, chatMessages, runState, "")
+	_, msgs, err := parseCodebuffSession(dir, "p", "local")
+	require.NoError(t, err)
+
+	var sysMsg *ParsedMessage
+	for i := range msgs {
+		if msgs[i].IsSystem {
+			sysMsg = &msgs[i]
+			break
+		}
+	}
+	require.NotNil(t, sysMsg, "expected a system message from mode divider")
+	assert.Equal(t, RoleSystem, sysMsg.Role)
+	assert.Contains(t, sysMsg.Content, "[Mode: LITE]")
+}
+
+func TestParseCodebuffSession_EmptyMessages(t *testing.T) {
+	chatMessages := `[]`
+	runState := `{
+		"sessionState": {
+			"mainAgentState": {
+				"agentType": "base2-deepseek"
+			}
+		}
+	}`
+
+	dir := codebuffTestSession(t, chatMessages, runState, "")
+	sess, msgs, err := parseCodebuffSession(dir, "p", "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	assert.Equal(t, 0, len(msgs))
+	assert.Equal(t, 0, sess.MessageCount)
+}
+
+func TestParseCodebuffSession_MissingRunState(t *testing.T) {
+	chatMessages := `[
+		{
+			"id": "user-1",
+			"variant": "user",
+			"content": "Hello",
+			"timestamp": "03:04 PM"
+		}
+	]`
+
+	dir := codebuffTestSession(t, chatMessages, "", "")
+	sess, _, err := parseCodebuffSession(dir, "p", "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	assert.Equal(t, AgentCodebuff, sess.Agent)
+	assert.Empty(t, sess.Cwd)
+	assert.False(t, sess.HasPeakContextTokens)
+}
+
+func TestParseCodebuffSession_UsageEvent(t *testing.T) {
+	chatMessages := `[
+		{
+			"id": "user-1",
+			"variant": "user",
+			"content": "Hello",
+			"timestamp": "03:04 PM"
+		}
+	]`
+	runState := `{
+		"sessionState": {
+			"mainAgentState": {
+				"agentType": "base2-deepseek"
+			}
+		}
+	}`
+
+	dir := codebuffTestSession(t, chatMessages, runState, "")
+	sess, _, err := parseCodebuffSession(dir, "p", "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	// No usage event when credits are 0 (no billing data).
+	assert.Empty(t, sess.UsageEvents,
+		"no usage event when credits are 0")
+}
+
+func TestParseCodebuffSession_UsageEventEmptyModel(t *testing.T) {
+	chatMessages := `[
+		{
+			"id": "user-1",
+			"variant": "user",
+			"content": "Hello",
+			"timestamp": "03:04 PM"
+		}
+	]`
+	runState := `{
+		"sessionState": {
+			"mainAgentState": {
+				"agentType": ""
+			}
+		}
+	}`
+
+	dir := codebuffTestSession(t, chatMessages, runState, "")
+	sess, _, err := parseCodebuffSession(dir, "p", "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	assert.Empty(t, sess.UsageEvents, "no usage event when model is empty")
+}
+
+func TestParseCodebuffSessionFromChatMeta(t *testing.T) {
+	chatMessages := `[]`
+	runState := `{
+		"sessionState": {
+			"mainAgentState": {
+				"agentType": "base2-deepseek"
+			}
+		}
+	}`
+	chatMeta := `{
+		"messageCount": 5,
+		"firstPrompt": "Fix the login bug",
+		"messagesSize": 2048
+	}`
+
+	dir := codebuffTestSession(t, chatMessages, runState, chatMeta)
+	sess, _, err := parseCodebuffSession(dir, "p", "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	// When transcript is empty, chat-meta counts are used as fallback.
+	assert.Equal(t, 5, sess.MessageCount)
+	assert.Equal(t, 1, sess.UserMessageCount)
+	assert.Equal(t, "Fix the login bug", sess.FirstMessage)
+	// CountsAuthoritative must be set when chat-meta is the only count
+	// source. Without this, the sync engine's
+	// applySessionTokenTotalsFromMessages pass recomputes counts from
+	// the empty parsed-message slice and overwrites the meta totals
+	// with zero, hiding the session from any UI that filters on
+	// nonzero counts.
+	assert.True(t, sess.CountsAuthoritative,
+		"counts from the chat-meta fallback must be authoritative "+
+			"so sync does not zero them out")
+}
+
+// TestParseCodebuffSessionFromTranscriptLeavesCountsNonAuthoritative
+// confirms that CountsAuthoritative stays false when the transcript
+// itself supplies the counts. Marking it true in that case would
+// suppress the sync engine's reconciling pass for sessions with real
+// message rows, hiding any future transcript-driven count drift.
+func TestParseCodebuffSessionFromTranscriptLeavesCountsNonAuthoritative(
+	t *testing.T,
+) {
+	chatMessages := `[
+		{"id":"user-1","variant":"user","content":"hi","timestamp":"03:04 PM"}
+	]`
+	runState := `{
+		"sessionState": {
+			"mainAgentState": {"agentType": "base2-deepseek"}
+		}
+	}`
+
+	dir := codebuffTestSession(t, chatMessages, runState, `{}`)
+	sess, _, err := parseCodebuffSession(dir, "p", "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	assert.False(t, sess.CountsAuthoritative,
+		"counts derived from a non-empty transcript must remain "+
+			"non-authoritative so the sync engine can reconcile "+
+			"them from message rows")
+}
+
+// TestParseCodebuffSessionEmptyChatMetaLeavesCountsNonAuthoritative
+// covers the edge case where the transcript is empty (chat-messages.json
+// is `[]`) and chat-meta.json has no messageCount field, so the meta
+// fallback has nothing authoritative to offer. CountsAuthoritative
+// must stay false: the session is just unparseable for messaging, and
+// the sync engine should not be told to skip its count-recompute pass
+// for sessions like this (otherwise we'd silently drop zero-count
+// rows that other fields still rely on).
+func TestParseCodebuffSessionEmptyChatMetaLeavesCountsNonAuthoritative(
+	t *testing.T,
+) {
+	chatMessages := `[]`
+	runState := `{
+		"sessionState": {
+			"mainAgentState": {"agentType": "base2-deepseek"}
+		}
+	}`
+
+	dir := codebuffTestSession(t, chatMessages, runState, `{}`)
+	sess, _, err := parseCodebuffSession(dir, "p", "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	assert.Equal(t, 0, sess.MessageCount)
+	assert.False(t, sess.CountsAuthoritative,
+		"empty transcript and empty meta must keep counts "+
+			"non-authoritative so the sync engine sees a real "+
+			"zero rather than silently skipping its recompute")
+}
+
+func TestParseCodebuffSession_ProjectFromCwd(t *testing.T) {
+	chatMessages := `[
+		{
+			"id": "user-1",
+			"variant": "user",
+			"content": "Hello",
+			"timestamp": "03:04 PM"
+		}
+	]`
+	runState := `{
+		"sessionState": {
+			"mainAgentState": {
+				"agentType": "base2-deepseek"
+			},
+			"fileContext": {
+				"cwd": "/Users/dev/projects/myproject"
+			}
+		}
+	}`
+
+	dir := codebuffTestSession(t, chatMessages, runState, "")
+	sess, _, err := parseCodebuffSession(dir, "fallback", "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	// Cwd-based project extraction takes precedence over hint.
+	assert.NotEmpty(t, sess.Project)
+}
+
+func TestParseCodebuffSession_FileInfo(t *testing.T) {
+	chatMessages := `[
+		{
+			"id": "user-1",
+			"variant": "user",
+			"content": "Hello",
+			"timestamp": "03:04 PM"
+		}
+	]`
+	runState := `{
+		"sessionState": {
+			"mainAgentState": {
+				"agentType": "base2-deepseek"
+			}
+		}
+	}`
+
+	dir := codebuffTestSession(t, chatMessages, runState, "")
+	sess, _, err := parseCodebuffSession(dir, "p", "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	assert.NotEmpty(t, sess.File.Path)
+	assert.True(t, sess.File.Size > 0)
+	assert.NotZero(t, sess.File.Mtime)
+}
+
+func TestParseCodebuffSession_JoinedTextContent(t *testing.T) {
+	chatMessages := `[
+		{
+			"id": "ai-1",
+			"variant": "ai",
+			"content": "",
+			"timestamp": "03:04 PM",
+			"blocks": [
+				{
+					"type": "text",
+					"textType": "text",
+					"content": "First paragraph."
+				},
+				{
+					"type": "text",
+					"textType": "text",
+					"content": "Second paragraph."
+				}
+			]
+		}
+	]`
+	runState := `{
+		"sessionState": {
+			"mainAgentState": {
+				"agentType": "base2-deepseek"
+			}
+		}
+	}`
+
+	dir := codebuffTestSession(t, chatMessages, runState, "")
+	_, msgs, err := parseCodebuffSession(dir, "p", "local")
+	require.NoError(t, err)
+
+	require.Len(t, msgs, 1)
+	assert.Contains(t, msgs[0].Content, "First paragraph.")
+	assert.Contains(t, msgs[0].Content, "Second paragraph.")
+}
+
+func TestParseCodebuffSession_TimestampVariants(t *testing.T) {
+	tests := []struct {
+		name     string
+		ts       string
+		wantZero bool
+	}{
+		{"HH:MM PM format", "03:04 PM", false},
+		{"RFC3339", "2026-07-15T20:01:32Z", false},
+		{"RFC3339Nano", "2026-07-15T20:01:32.065Z", false},
+		{"empty string", "", true},
+		{"garbage", "not-a-timestamp", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sessionDate := time.Date(2026, 7, 15, 0, 0, 0, 0, time.Local)
+			ts := parseCodebuffTimestamp(tc.ts, sessionDate)
+			if tc.wantZero {
+				assert.True(t, ts.IsZero(), "expected zero time for %q", tc.ts)
+			} else {
+				assert.False(t, ts.IsZero(), "expected non-zero time for %q", tc.ts)
+			}
+		})
+	}
+}
+
+func TestIsCodebuffTimestamp(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		// Four ISO-8601 shapes parseCodebuffSessionDate accepts.
+		{"Z millis", "2026-07-16T00-09-00.236Z", true},
+		{"Z no millis", "2026-07-16T00-09-00Z", true},
+		{"no Z millis", "2026-07-16T00-09-00.123", true},
+		{"date only", "2026-07-16", true},
+		// Non-Codebuff shapes the generic resolver must keep open.
+		{"Unix epoch numeric", "1704067200", false},
+		{"UUID with dashes", "abcdef01-2345-6789-abcd-ef0123456789", false},
+		{"empty", "", false},
+		{"garbage", "not-a-timestamp", false},
+		{"partial date", "2026-07", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, IsCodebuffTimestamp(tc.in))
+		})
+	}
+}
+
+func TestParseCodebuffSessionDate_Formats(t *testing.T) {
+	tests := []struct {
+		name    string
+		session string
+		wantNil bool
+	}{
+		{"Z suffix with millis", "2026-07-15T20-01-32.065Z", false},
+		{"Z suffix without millis", "2026-07-15T20-01-32Z", false},
+		{"no Z with millis", "2026-07-15T20-01-32.065", false},
+		{"date only", "2026-07-15", false},
+		{"garbage", "not-a-date", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := parseCodebuffSessionDate(tc.session)
+			if tc.wantNil {
+				assert.True(t, ts.IsZero())
+			} else {
+				assert.False(t, ts.IsZero())
+			}
+		})
+	}
+}
+
+func TestParseCodebuffToolCall_UnknownName(t *testing.T) {
+	// A tool block with empty toolName should return nil.
+	raw := `{"type":"tool","toolName":"","toolCallId":"x","input":{}}`
+	var block struct {
+		Type       string          `json:"type"`
+		ToolName   string          `json:"toolName"`
+		ToolCallID string          `json:"toolCallId"`
+		Input      json.RawMessage `json:"input"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(raw), &block))
+
+	// parseCodebuffToolCall works on gjson.Result, so use the real path.
+	chatMessages := `[
+		{
+			"id": "ai-1",
+			"variant": "ai",
+			"content": "",
+			"timestamp": "03:04 PM",
+			"blocks": [
+				{
+					"type": "tool",
+					"toolName": "",
+					"toolCallId": "x"
+				}
+			]
+		}
+	]`
+	runState := `{
+		"sessionState": {
+			"mainAgentState": {
+				"agentType": "base2-deepseek"
+			}
+		}
+	}`
+	dir := codebuffTestSession(t, chatMessages, runState, "")
+	_, msgs, err := parseCodebuffSession(dir, "p", "local")
+	require.NoError(t, err)
+
+	// Empty toolName -> no tool call produced, so no HasToolUse message.
+	for _, msg := range msgs {
+		assert.False(t, msg.HasToolUse,
+			"empty toolName should not produce a tool use message")
+	}
+}
+
+func TestDiscoverCodebuffSessions(t *testing.T) {
+	root := t.TempDir()
+
+	// Create two projects with sessions.
+	for _, proj := range []string{"proj-a", "proj-b"} {
+		chatsDir := filepath.Join(root, proj, "chats")
+		sessionDir := filepath.Join(chatsDir, "2026-07-15T20-01-32.065Z")
+		require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+		codebuffWriteFile(t, filepath.Join(sessionDir, "chat-messages.json"), `[]`)
+	}
+
+	dirs := discoverCodebuffSessions(root)
+	assert.Len(t, dirs, 2)
+
+	projects := make(map[string]bool)
+	for _, d := range dirs {
+		projects[d.ProjectHint] = true
+	}
+	assert.True(t, projects["proj-a"])
+	assert.True(t, projects["proj-b"])
+}
+
+func TestDiscoverCodebuffSessions_SkipsNonDirs(t *testing.T) {
+	root := t.TempDir()
+	// Create a file directly in root (not a directory).
+	codebuffWriteFile(t, filepath.Join(root, "not-a-dir.txt"), "skip me")
+
+	dirs := discoverCodebuffSessions(root)
+	assert.Empty(t, dirs)
+}
+
+func TestCodebuffProjectFromPath(t *testing.T) {
+	path := "/root/myproject/chats/2026-07-15T20-01-32.065Z/chat-messages.json"
+	assert.Equal(t, "myproject", codebuffProjectFromPath(path))
+}
+
+func TestCodebuffProviderCapabilities(t *testing.T) {
+	caps := codebuffProviderCapabilities()
+	assert.Equal(t, CapabilitySupported, caps.Content.FirstMessage)
+	assert.Equal(t, CapabilitySupported, caps.Content.SessionName)
+	assert.Equal(t, CapabilitySupported, caps.Content.Thinking)
+	assert.Equal(t, CapabilitySupported, caps.Content.ToolCalls)
+	assert.Equal(t, CapabilitySupported, caps.Content.ToolResults)
+	assert.Equal(t, CapabilityNotApplicable, caps.Content.Model,
+		"model is unknown (selected server-side, can change mid-session)")
+	assert.Equal(t, CapabilitySupported, caps.Content.AggregateUsageEvents)
+	assert.Equal(t, CapabilityNotApplicable, caps.Content.Relationships)
+	assert.Equal(t, CapabilityNotApplicable, caps.Content.TerminationStatus)
+	assert.Equal(t, CapabilityNotApplicable, caps.Content.MalformedLineCount)
+}
+
+func TestCodebuffSessionName_Truncation(t *testing.T) {
+	var longPrompt strings.Builder
+	for range 200 {
+		longPrompt.WriteString("x")
+	}
+	chatMessages, err := json.Marshal([]map[string]any{
+		{
+			"id":        "user-1",
+			"variant":   "user",
+			"content":   longPrompt.String(),
+			"timestamp": "03:04 PM",
+		},
+	})
+	require.NoError(t, err)
+
+	runState := `{
+		"sessionState": {
+			"mainAgentState": {
+				"agentType": "base2-deepseek"
+			}
+		}
+	}`
+
+	dir := codebuffTestSession(t, string(chatMessages), runState, "")
+	sess, _, err := parseCodebuffSession(dir, "p", "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	// Session name should be truncated to 80 chars with ellipsis.
+	assert.LessOrEqual(t, len(sess.SessionName), 80)
+	assert.Contains(t, sess.SessionName, "...")
+}
+
+func TestCodebuffSessionName_FallbackToProjectHint(t *testing.T) {
+	chatMessages := `[]`
+	runState := `{
+		"sessionState": {
+			"mainAgentState": {
+				"agentType": "base2-deepseek"
+			}
+		}
+	}`
+
+	dir := codebuffTestSession(t, chatMessages, runState, "")
+	sess, _, err := parseCodebuffSession(dir, "my-hint", "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	// No messages, no firstPrompt -> falls back to project hint.
+	assert.Equal(t, "my-hint", sess.SessionName)
+}
+
+func TestParseCodebuffSkills_Catalog(t *testing.T) {
+	runState := `{
+		"sessionState": {
+			"mainAgentState": {"agentType": "base2-free-minimax-m3"},
+			"fileContext": {
+				"skills": {
+					"handoff": {
+						"name": "handoff",
+						"description": "Compact the conversation into a handoff doc.",
+						"filePath": "/Users/dev/.skills/handoff/SKILL.md",
+						"content": "---\nname: handoff\n---\nWrite a handoff."
+					},
+					"ponytail": {
+						"name": "ponytail",
+						"description": "Laziest solution that works."
+					}
+				}
+			}
+		}
+	}`
+	dir := codebuffTestSession(t, `[]`, runState, "")
+	rs, err := readCodebuffRunState(filepath.Join(dir, "run-state.json"))
+	require.NoError(t, err)
+	require.Len(t, rs.Skills, 2)
+
+	byName := map[string]codebuffSkill{}
+	for _, s := range rs.Skills {
+		byName[s.Name] = s
+	}
+	assert.Equal(t, "Compact the conversation into a handoff doc.",
+		byName["handoff"].Description)
+	assert.Equal(t, "/Users/dev/.skills/handoff/SKILL.md",
+		byName["handoff"].FilePath)
+	assert.Contains(t, byName["handoff"].Content, "Write a handoff.")
+	assert.Equal(t, "Laziest solution that works.",
+		byName["ponytail"].Description)
+}
+
+func TestParseCodebuffSkills_Empty(t *testing.T) {
+	require.Empty(t, parseCodebuffSkills([]byte(`{"sessionState":{}}`)))
+	require.Empty(t, parseCodebuffSkills([]byte(`not json`)))
+}
+
+func TestCodebuffAttachSkillNames_FromInput(t *testing.T) {
+	chatMessages := `[
+		{
+			"id": "ai-1",
+			"variant": "ai",
+			"content": "",
+			"timestamp": "03:04 PM",
+			"blocks": [
+				{
+					"type": "tool",
+					"toolName": "run_terminal_command",
+					"toolCallId": "tc-1",
+					"input": {"command": "ponytail refactor parser.go"}
+				},
+				{
+					"type": "tool",
+					"toolName": "read_files",
+					"toolCallId": "tc-2",
+					"input": {"paths": ["src/main.go"]}
+				}
+			]
+		}
+	]`
+	runState := `{
+		"sessionState": {
+			"mainAgentState": {"agentType": "base2-free-minimax-m3"},
+			"fileContext": {
+				"skills": {
+					"ponytail": {"name": "ponytail", "description": "Lazy mode."}
+				}
+			}
+		}
+	}`
+
+	dir := codebuffTestSession(t, chatMessages, runState, "")
+	_, msgs, err := parseCodebuffSession(dir, "p", "local")
+	require.NoError(t, err)
+
+	var toolMsg *ParsedMessage
+	for i := range msgs {
+		if msgs[i].HasToolUse {
+			toolMsg = &msgs[i]
+			break
+		}
+	}
+	require.NotNil(t, toolMsg)
+	require.Len(t, toolMsg.ToolCalls, 2)
+
+	assert.Equal(t, "ponytail", toolMsg.ToolCalls[0].SkillName,
+		"tool call referencing a skill name should be attributed")
+	assert.Empty(t, toolMsg.ToolCalls[1].SkillName,
+		"unrelated tool call should not be attributed to a skill")
+}
+
+func TestCodebuffAttachSkillNames_ExplicitSkillTool(t *testing.T) {
+	chatMessages := `[
+		{
+			"id": "ai-1",
+			"variant": "ai",
+			"content": "",
+			"timestamp": "03:04 PM",
+			"blocks": [
+				{
+					"type": "tool",
+					"toolName": "Skill",
+					"toolCallId": "tc-1",
+					"input": {"skill": "handoff"}
+				}
+			]
+		}
+	]`
+	runState := `{
+		"sessionState": {
+			"mainAgentState": {"agentType": "base2-free-minimax-m3"},
+			"fileContext": {
+				"skills": {"handoff": {"name": "handoff", "description": "x"}}
+			}
+		}
+	}`
+
+	dir := codebuffTestSession(t, chatMessages, runState, "")
+	_, msgs, err := parseCodebuffSession(dir, "p", "local")
+	require.NoError(t, err)
+
+	var toolMsg *ParsedMessage
+	for i := range msgs {
+		if msgs[i].HasToolUse {
+			toolMsg = &msgs[i]
+			break
+		}
+	}
+	require.NotNil(t, toolMsg)
+	require.Len(t, toolMsg.ToolCalls, 1)
+	assert.Equal(t, "handoff", toolMsg.ToolCalls[0].SkillName)
+}
+
+func TestCodebuffAttachSkillNames_NoFalsePositiveSubstring(t *testing.T) {
+	// A skill named "go" should NOT match inputs containing "going" or
+	// "cargo" — the matching must use word boundaries, not substring.
+	chatMessages := `[
+		{
+			"id": "ai-1",
+			"variant": "ai",
+			"content": "",
+			"timestamp": "03:04 PM",
+			"blocks": [
+				{
+					"type": "tool",
+					"toolName": "run_terminal_command",
+					"toolCallId": "tc-1",
+					"input": {"command": "going forward with refactor"}
+				},
+				{
+					"type": "tool",
+					"toolName": "run_terminal_command",
+					"toolCallId": "tc-2",
+					"input": {"command": "cargo build --release"}
+				}
+			]
+		}
+	]`
+	runState := `{
+		"sessionState": {
+			"mainAgentState": {"agentType": "base2-free-minimax-m3"},
+			"fileContext": {
+				"skills": {
+					"go": {"name": "go", "description": "Go skill."}
+				}
+			}
+		}
+	}`
+
+	dir := codebuffTestSession(t, chatMessages, runState, "")
+	_, msgs, err := parseCodebuffSession(dir, "p", "local")
+	require.NoError(t, err)
+
+	var toolMsg *ParsedMessage
+	for i := range msgs {
+		if msgs[i].HasToolUse {
+			toolMsg = &msgs[i]
+			break
+		}
+	}
+	require.NotNil(t, toolMsg)
+	require.Len(t, toolMsg.ToolCalls, 2)
+
+	assert.Empty(t, toolMsg.ToolCalls[0].SkillName,
+		"'going' should not match skill 'go'")
+	assert.Empty(t, toolMsg.ToolCalls[1].SkillName,
+		"'cargo' should not match skill 'go'")
+}
+
+func TestCodebuffAttachSkillNames_WordBoundaryMatch(t *testing.T) {
+	// A skill named "go" SHOULD match when it appears as a standalone
+	// word token in the input.
+	chatMessages := `[
+		{
+			"id": "ai-1",
+			"variant": "ai",
+			"content": "",
+			"timestamp": "03:04 PM",
+			"blocks": [
+				{
+					"type": "tool",
+					"toolName": "run_terminal_command",
+					"toolCallId": "tc-1",
+					"input": {"command": "go build ./..."}
+				}
+			]
+		}
+	]`
+	runState := `{
+		"sessionState": {
+			"mainAgentState": {"agentType": "base2-free-minimax-m3"},
+			"fileContext": {
+				"skills": {
+					"go": {"name": "go", "description": "Go skill."}
+				}
+			}
+		}
+	}`
+
+	dir := codebuffTestSession(t, chatMessages, runState, "")
+	_, msgs, err := parseCodebuffSession(dir, "p", "local")
+	require.NoError(t, err)
+
+	var toolMsg *ParsedMessage
+	for i := range msgs {
+		if msgs[i].HasToolUse {
+			toolMsg = &msgs[i]
+			break
+		}
+	}
+	require.NotNil(t, toolMsg)
+	require.Len(t, toolMsg.ToolCalls, 1)
+
+	assert.Equal(t, "go", toolMsg.ToolCalls[0].SkillName,
+		"'go build' should match skill 'go' as a standalone token")
+}
+
+func TestCodebuffToolCategories(t *testing.T) {
+	tests := []struct {
+		tool     string
+		category string
+	}{
+		{"read_subtree", "Read"},
+		{"file-picker", "Read"},
+		{"read_files", "Read"},
+		{"list_directory", "Read"},
+		{"str_replace", "Edit"},
+		{"write_file", "Write"},
+		{"basher", "Bash"},
+		{"spawn_agents", "Task"},
+		{"suggest_followups", "Tool"},
+		{"write_todos", "Tool"},
+		{"read_url", "Tool"},
+		{"ask_user", "Tool"},
+		{"render_ui", "Tool"},
+		{"gravity_index", "Tool"},
+		{"skill", "Tool"},
+		{"code-searcher", "Tool"},
+		{"code-reviewer", "Tool"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.tool, func(t *testing.T) {
+			got := NormalizeToolCategory(tc.tool)
+			assert.Equalf(t, tc.category, got, "NormalizeToolCategory(%q)", tc.tool)
+		})
+	}
+}
+
+func TestParseCodebuffSession_ErrorVariant(t *testing.T) {
+	chatMessages := `[
+		{
+			"id": "user-1",
+			"variant": "user",
+			"content": "Fix the bug",
+			"timestamp": "03:04 PM"
+		},
+		{
+			"id": "err-1",
+			"variant": "error",
+			"content": "Rate limit exceeded. Please try again later.",
+			"timestamp": "03:05 PM"
+		}
+	]`
+	runState := `{
+		"sessionState": {
+			"mainAgentState": {
+				"agentType": "base2-deepseek"
+			}
+		}
+	}`
+
+	dir := codebuffTestSession(t, chatMessages, runState, "")
+	_, msgs, err := parseCodebuffSession(dir, "p", "local")
+	require.NoError(t, err)
+
+	// Should have user message + error system message.
+	require.Len(t, msgs, 2)
+	assert.Equal(t, RoleUser, msgs[0].Role)
+	assert.Equal(t, "Fix the bug", msgs[0].Content)
+
+	assert.Equal(t, RoleSystem, msgs[1].Role)
+	assert.True(t, msgs[1].IsSystem)
+	assert.Contains(t, msgs[1].Content, "Rate limit exceeded")
+}
+
+func TestParseCodebuffSession_CreditsExtraction(t *testing.T) {
+	chatMessages := `[
+		{
+			"id": "user-1",
+			"variant": "user",
+			"content": "Hello",
+			"timestamp": "03:04 PM"
+		}
+	]`
+	runState := `{
+		"sessionState": {
+			"mainAgentState": {
+				"agentType": "base2-deepseek",
+				"contextTokenCount": 50000,
+				"creditsUsed": 15.5,
+				"directCreditsUsed": 10.0
+			}
+		}
+	}`
+
+	dir := codebuffTestSession(t, chatMessages, runState, "")
+	sess, _, err := parseCodebuffSession(dir, "p", "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	// Credits should be mapped to a Money cost in usage events.
+	// 15.5 credits × $0.01/credit = $0.155 = 155_000 microdollars.
+	require.Len(t, sess.UsageEvents, 1)
+	evt := sess.UsageEvents[0]
+	require.NotNil(t, evt.Cost)
+	assert.Equal(t, int64(155_000), evt.Cost.Microdollars,
+		"15.5 credits should map to 155_000 microdollars")
+	assert.Equal(t, "reported", evt.CostStatus)
+	assert.Equal(t, "session", evt.CostSource)
+	// Model must mirror rs.AgentType so the daily model breakdown
+	// buckets similar codebuff/freebuff sessions separately.
+	// Aggregator tests insert events directly, so only the parser
+	// path can regress Model attribution.
+	assert.Equal(t, "base2-deepseek", evt.Model)
+}
+
+func TestParseCodebuffSession_CreditsZero(t *testing.T) {
+	chatMessages := `[
+		{
+			"id": "user-1",
+			"variant": "user",
+			"content": "Hello",
+			"timestamp": "03:04 PM"
+		}
+	]`
+	runState := `{
+		"sessionState": {
+			"mainAgentState": {
+				"agentType": "base2-free-deepseek"
+			}
+		}
+	}`
+
+	dir := codebuffTestSession(t, chatMessages, runState, "")
+	sess, _, err := parseCodebuffSession(dir, "p", "local")
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+
+	// Freebuff sessions have no credits - no usage event emitted.
+	assert.Empty(t, sess.UsageEvents,
+		"freebuff sessions should have no usage event")
+}
+
+func TestParseCodebuffSession_PlanBlock(t *testing.T) {
+	chatMessages := `[
+		{
+			"id": "ai-1",
+			"variant": "ai",
+			"content": "",
+			"timestamp": "03:04 PM",
+			"blocks": [
+				{
+					"type": "plan",
+					"content": "1. Fix the auth handler\n2. Add tests\n3. Update docs"
+				},
+				{
+					"type": "text",
+					"textType": "text",
+					"content": "I'll implement the plan."
+				}
+			]
+		}
+	]`
+	runState := `{
+		"sessionState": {
+			"mainAgentState": {
+				"agentType": "base2-deepseek"
+			}
+		}
+	}`
+
+	dir := codebuffTestSession(t, chatMessages, runState, "")
+	_, msgs, err := parseCodebuffSession(dir, "p", "local")
+	require.NoError(t, err)
+
+	// Should have a system message with the plan content.
+	found := false
+	for _, msg := range msgs {
+		if msg.IsSystem && strings.Contains(msg.Content, "[Plan]") {
+			found = true
+			assert.Contains(t, msg.Content, "Fix the auth handler")
+			break
+		}
+	}
+	assert.True(t, found, "expected a system message with plan content")
+}
+
+func TestParseCodebuffSession_AskUserBlock(t *testing.T) {
+	chatMessages := `[
+		{
+			"id": "ai-1",
+			"variant": "ai",
+			"content": "",
+			"timestamp": "03:04 PM",
+			"blocks": [
+				{
+					"type": "ask-user",
+					"toolCallId": "ask-1",
+					"questions": [
+						{
+							"question": "Which database should I use?",
+							"options": [
+								{"label": "PostgreSQL"},
+								{"label": "SQLite"}
+							]
+						}
+					]
+				}
+			]
+		}
+	]`
+	runState := `{
+		"sessionState": {
+			"mainAgentState": {
+				"agentType": "base2-deepseek"
+			}
+		}
+	}`
+
+	dir := codebuffTestSession(t, chatMessages, runState, "")
+	_, msgs, err := parseCodebuffSession(dir, "p", "local")
+	require.NoError(t, err)
+
+	// Should have a system message with the question.
+	found := false
+	for _, msg := range msgs {
+		if msg.IsSystem && strings.Contains(msg.Content, "Agent asked") {
+			found = true
+			assert.Contains(t, msg.Content, "Which database should I use?")
+			break
+		}
+	}
+	assert.True(t, found, "expected a system message with the agent's question")
+}
+
+func TestParseCodebuffSession_ImageBlock(t *testing.T) {
+	chatMessages := `[
+		{
+			"id": "user-1",
+			"variant": "user",
+			"content": "Here's a screenshot",
+			"timestamp": "03:04 PM",
+			"blocks": [
+				{
+					"type": "image",
+					"image": "base64data...",
+					"mediaType": "image/png",
+					"filename": "screenshot.png"
+				}
+			]
+		}
+	]`
+	runState := `{
+		"sessionState": {
+			"mainAgentState": {
+				"agentType": "base2-deepseek"
+			}
+		}
+	}`
+
+	dir := codebuffTestSession(t, chatMessages, runState, "")
+	_, msgs, err := parseCodebuffSession(dir, "p", "local")
+	require.NoError(t, err)
+
+	// User message should contain the image filename note.
+	require.Len(t, msgs, 1)
+	assert.Contains(t, msgs[0].Content, "[Image: screenshot.png]")
+}
+
+func TestParseCodebuffSession_ImageBlockNoFilename(t *testing.T) {
+	chatMessages := `[
+		{
+			"id": "user-1",
+			"variant": "user",
+			"content": "Look at this",
+			"timestamp": "03:04 PM",
+			"blocks": [
+				{
+					"type": "image",
+					"image": "base64data...",
+					"mediaType": "image/png"
+				}
+			]
+		}
+	]`
+	runState := `{
+		"sessionState": {
+			"mainAgentState": {
+				"agentType": "base2-deepseek"
+			}
+		}
+	}`
+
+	dir := codebuffTestSession(t, chatMessages, runState, "")
+	_, msgs, err := parseCodebuffSession(dir, "p", "local")
+	require.NoError(t, err)
+
+	require.Len(t, msgs, 1)
+	assert.Contains(t, msgs[0].Content, "[Image attached]")
+}
+
+func TestAgentByPrefix_FreebuffAlias(t *testing.T) {
+	// Freebuff sessions use the "freebuff:" prefix but share the Codebuff
+	// provider. AgentByPrefix must resolve them to the Codebuff definition
+	// with the freebuff: prefix so callers can strip it correctly.
+	def, ok := AgentByPrefix("freebuff:2026-07-15T20-01-32.065Z")
+	require.True(t, ok, "AgentByPrefix should resolve freebuff: prefix")
+	assert.Equal(t, AgentCodebuff, def.Type,
+		"freebuff: prefix should map to Codebuff provider")
+	assert.Equal(t, "freebuff:", def.IDPrefix,
+		"IDPrefix should match the freebuff: prefix for correct stripping")
+}
+
+// TestParseCodebuffMixedFormatMidnightRollover pins the regression
+// flagged by roborev review at internal/parser/codebuff.go:496: a
+// non-time-only (RFC3339) timestamp must anchor currentDate to
+// its local calendar date so subsequent time-only messages don't
+// get assigned to the previous session directory date across
+// midnight. Before this fix the non-time-only path reset
+// prevHour to -1 without advancing currentDate, causing the
+// parser to drift back to the session directory's original date
+// for any time-only message that followed a real boundary.
+func TestParseCodebuffMixedFormatMidnightRollover(t *testing.T) {
+	// Pin time.Local to UTC so the session-date parse and the
+	// time-only message reconstruction are deterministic regardless
+	// of the host TZ. t.Setenv only triggers a TZ reload on the next
+	// time.Local access, and earlier tests in the package can cache
+	// the location before this runs; assigning time.Local directly
+	// and restoring it on cleanup is the only reliable way to pin
+	// the state for this single test without touching package init.
+	origLocal := time.Local
+	t.Cleanup(func() { time.Local = origLocal })
+	time.Local = time.UTC
+
+	sessionID := "2026-07-15T22-00-00.000Z"
+	sessionDate := parseCodebuffSessionDate(sessionID)
+	require.Equal(t, 2026, sessionDate.Year())
+	require.Equal(t, time.July, sessionDate.Month())
+	require.Equal(t, 15, sessionDate.Day())
+	require.Equal(t, 22, sessionDate.Hour())
+
+	data := []byte(`[
+		{"id":"u1","variant":"user","content":"hello","timestamp":"2026-07-15T22:00:00Z"},
+		{"id":"u2","variant":"user","content":"ack","timestamp":"11:30 PM"},
+		{"id":"u3","variant":"user","content":"next","timestamp":"12:15 AM"},
+		{"id":"u4","variant":"user","content":"later","timestamp":"2026-07-17T09:00:00Z"},
+		{"id":"u5","variant":"user","content":"after","timestamp":"02:00 PM"}
+	]`)
+
+	msgs, _, _, err := parseCodebuffMessages(data, sessionDate, "")
+	require.NoError(t, err)
+	require.Len(t, msgs, 5)
+
+	// M1 — RFC3339 anchor; date must be 15, hour 22.
+	require.Equal(t, 2026, msgs[0].Timestamp.Year())
+	require.Equal(t, time.July, msgs[0].Timestamp.Month())
+	require.Equal(t, 15, msgs[0].Timestamp.Day())
+	require.Equal(t, 22, msgs[0].Timestamp.Hour())
+
+	// M2 — time-only on date 15; hour 23.
+	require.Equal(t, 15, msgs[1].Timestamp.Day())
+	require.Equal(t, 23, msgs[1].Timestamp.Hour())
+
+	// M3 — time-only after midnight rollover; date 16, hour 0.
+	// Before the fix currentDate would still be 15 here and M3
+	// would land on 15 00:15 instead of 16 00:15.
+	require.Equal(t, 16, msgs[2].Timestamp.Day(),
+		"time-only after a 23:xx anchor must advance to the next calendar date")
+	require.Equal(t, 0, msgs[2].Timestamp.Hour())
+
+	// M4 — RFC3339 anchor that crosses a real midnight; date 17.
+	require.Equal(t, 17, msgs[3].Timestamp.Day(),
+		"non-time-only timestamp must anchor currentDate to its local calendar date")
+
+	// M5 — time-only on date 17; hour 14. Before the fix
+	// currentDate could regress to 15 here because M4 only
+	// touched prevHour.
+	require.Equal(t, 17, msgs[4].Timestamp.Day(),
+		"time-only after an RFC3339 anchor that crossed a date boundary must stay on the new date")
+	require.Equal(t, 14, msgs[4].Timestamp.Hour())
+}

--- a/internal/parser/provider.go
+++ b/internal/parser/provider.go
@@ -227,6 +227,29 @@ type StoredSourceHintScopeProvider interface {
 	StoredSourceHintScopes(ChangedPathRequest) []StoredSourceHintScope
 }
 
+// MultiFileStatHasher is an optional capability for providers whose on-disk
+// source layout spans multiple sibling files (Codebuff's
+// chat-messages.json plus run-state.json and chat-meta.json in the same
+// directory, for example). It computes a stable per-component stat digest
+// that the engine's stat-only pre-check compares against a value persisted
+// in the provider_freshness side-table so warm sync over an unchanged
+// archive can short-circuit to zero provider.Fingerprint calls while still
+// catching same-size companion rewrites, offsetting size deltas, and
+// sibling-only directory mutations.
+//
+// Implementations live on the provider implementation; the engine type-
+// asserts a constructed provider against MultiFileStatHasher and caches
+// the result. Providers that do not implement this interface take the
+// existing stat-only composite path, which is the right default for
+// single-file agents (Claude, Codex, etc.).
+type MultiFileStatHasher interface {
+	// ComputeMultiFileStatHash stats the chat path plus any companion
+	// siblings declared by the provider and returns a stable per-source
+	// digest. The hasher performs its own os.Stat so the engine does not
+	// need to supply FileInfo.
+	ComputeMultiFileStatHash(chatPath string) uint64
+}
+
 // ProviderBase is embedded by concrete providers to make optional source
 // methods callable with zero-value no-op behavior.
 type ProviderBase struct {
@@ -1129,6 +1152,8 @@ func providerFactoryForDef(def AgentDef) ProviderFactory {
 		return newZedProviderFactory(def)
 	case AgentRooCode:
 		return newRooCodeProviderFactory(def)
+	case AgentCodebuff:
+		return newCodebuffProviderFactory(def)
 	default:
 		panic("missing provider factory for " + string(def.Type))
 	}

--- a/internal/parser/provider_migration.go
+++ b/internal/parser/provider_migration.go
@@ -74,6 +74,7 @@ var providerMigrationModes = map[AgentType]ProviderMigrationMode{
 	AgentRooCode:        ProviderMigrationProviderAuthoritative,
 	AgentPoolside:       ProviderMigrationProviderAuthoritative,
 	AgentOmnigent:       ProviderMigrationProviderAuthoritative,
+	AgentCodebuff:       ProviderMigrationProviderAuthoritative,
 }
 
 // ProviderMigrationModes returns the current provider migration manifest.

--- a/internal/parser/source_set.go
+++ b/internal/parser/source_set.go
@@ -192,6 +192,32 @@ func (p *SourceSetProvider) PersistentArchiveSource(
 	return resolver.PersistentArchiveSource(path, fullSessionID)
 }
 
+// sourceSetFreshnessHasher is the optional inner-source-set shape of
+// parser.MultiFileStatHasher. A SourceSet-backed base that owns a
+// multi-file on-disk layout (currently codebuffSourceSet) implements
+// ComputeMultiFileStatHash on the inner SourceSet, and SourceSetProvider
+// forwards that method here so the engine's provider-level type
+// assertion against MultiFileStatHasher succeeds. Without the
+// forwarding, the provider wrapping the hasher leaves the engine's
+// providerStatHashers cache empty and the per-component freshness
+// digest is never populated for any multi-file agent.
+type sourceSetFreshnessHasher interface {
+	ComputeMultiFileStatHash(chatPath string) uint64
+}
+
+// ComputeMultiFileStatHash implements parser.MultiFileStatHasher by
+// delegating to the wrapped SourceSet when it advertises the optional
+// hasher shape. Returns 0 when the inner source set is single-file
+// (Claude, Codex, Roocode, ...) and the engine should keep using the
+// existing size/mtime composite freshness path.
+func (p *SourceSetProvider) ComputeMultiFileStatHash(chatPath string) uint64 {
+	hasher, ok := p.sources.(sourceSetFreshnessHasher)
+	if !ok {
+		return 0
+	}
+	return hasher.ComputeMultiFileStatHash(chatPath)
+}
+
 // SourceSetFactory is the generic ProviderFactory for any SourceSet-backed
 // provider. build constructs the SourceSet from the cloned per-provider config
 // (roots, machine, path rewriter), so a base captures whatever config it needs

--- a/internal/parser/taxonomy.go
+++ b/internal/parser/taxonomy.go
@@ -217,6 +217,22 @@ func NormalizeToolCategory(rawName string) string {
 	case "zencoder-rag-mcp__web_search":
 		return "Read"
 
+	// Codebuff / Freebuff tools
+	// Note: "read_files" (Warp→Read), "list_directory" (Gemini→Read),
+	// "write_file" (Gemini→Write), "str_replace" (Pi→Edit),
+	// "skill" (Amp→Tool) are handled in earlier sections.
+	case "read_subtree", "file-picker":
+		return "Read"
+	case "suggest_followups", "write_todos", "read_url", "ask_user",
+		"render_ui", "gravity_index":
+		return "Tool"
+	case "run_terminal_command", "basher":
+		return "Bash"
+	case "code-searcher", "code-reviewer":
+		return "Tool"
+	case "spawn_agents":
+		return "Task"
+
 	// ChatGPT tools
 	case "code_interpreter":
 		return "Bash"

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -71,6 +71,8 @@ const (
 	AgentRooCode        AgentType = "roocode"
 	AgentPoolside       AgentType = "poolside"
 	AgentOmnigent       AgentType = "omnigent"
+	AgentCodebuff       AgentType = "codebuff"
+	AgentFreebuff       AgentType = "freebuff"
 )
 
 // AgentDef describes a supported coding agent's filesystem
@@ -894,6 +896,26 @@ var Registry = []AgentDef{
 		// allowlisted export schema.
 		RemoteSyncExcluded: true,
 	},
+	{
+		// Codebuff and Freebuff share the same on-disk layout under
+		// ~/.config/manicode/projects/<project>/chats/<timestamp>/. Each
+		// session directory holds chat-messages.json (primary),
+		// run-state.json (model/token metadata), and chat-meta.json.
+		// Freebuff sessions are distinguished from codebuff sessions
+		// via the AgentLabel field (set to "Freebuff" when run-state.json
+		// agentType contains "free"), not via separate agent types, to
+		// avoid double-discovery and skip-cache contention issues.
+		Type:        AgentCodebuff,
+		DisplayName: "Codebuff",
+		EnvVar:      "CODEBUFF_DIR",
+		ConfigKey:   "codebuff_dirs",
+		DefaultDirs: []string{".config/manicode/projects"},
+		IDPrefix:    "codebuff:",
+		FileBased:   true,
+		Usage: UsageCapabilities{
+			NoPerMessageTokenData: true,
+		},
+	},
 }
 
 // NonFileBackedAgents returns agent types where FileBased is false.
@@ -927,16 +949,23 @@ func RemoteSyncExcludedAgent(agent AgentType) bool {
 // AgentNameLacksPerMessageTokenData reports whether the named agent
 // records no per-message token data. Names match registry types
 // exactly and unknown names fail closed; CSV filter parsing trims its
-// parts before calling.
+// parts before calling. Freebuff is treated as a Codebuff alias.
 func AgentNameLacksPerMessageTokenData(agent string) bool {
 	def, ok := AgentByType(AgentType(agent))
+	if !ok && AgentType(agent) == AgentFreebuff {
+		def, ok = AgentByType(AgentCodebuff)
+	}
 	return ok && def.Usage.NoPerMessageTokenData
 }
 
 // AgentNameUsesAICredits reports whether the named agent's cost is
-// denominated in AI credits rather than USD.
+// denominated in AI credits rather than USD. Freebuff is treated as
+// a Codebuff alias.
 func AgentNameUsesAICredits(agent string) bool {
 	def, ok := AgentByType(AgentType(agent))
+	if !ok && AgentType(agent) == AgentFreebuff {
+		def, ok = AgentByType(AgentCodebuff)
+	}
 	return ok && def.Usage.AICreditsDenominated
 }
 
@@ -1009,6 +1038,16 @@ func StripHostPrefix(id string) (host, rawID string) {
 // stripped before matching.
 func AgentByPrefix(sessionID string) (AgentDef, bool) {
 	_, rawID := StripHostPrefix(sessionID)
+	// Freebuff shares the Codebuff provider but emits sessions with the
+	// "freebuff:" prefix. Return a copy with the freebuff prefix so
+	// callers that strip the prefix (FindSourceFile, ProviderNormalizeRawSessionID)
+	// work correctly.
+	if strings.HasPrefix(rawID, string(AgentFreebuff)+":") {
+		if def, ok := AgentByType(AgentCodebuff); ok {
+			def.IDPrefix = string(AgentFreebuff) + ":"
+			return def, true
+		}
+	}
 	for _, def := range Registry {
 		if def.IDPrefix != "" &&
 			strings.HasPrefix(rawID, def.IDPrefix) {

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -901,17 +901,21 @@ var Registry = []AgentDef{
 		// ~/.config/manicode/projects/<project>/chats/<timestamp>/. Each
 		// session directory holds chat-messages.json (primary),
 		// run-state.json (model/token metadata), and chat-meta.json.
-		// Freebuff sessions are distinguished from codebuff sessions
-		// via the AgentLabel field (set to "Freebuff" when run-state.json
-		// agentType contains "free"), not via separate agent types, to
-		// avoid double-discovery and skip-cache contention issues.
-		Type:        AgentCodebuff,
-		DisplayName: "Codebuff",
-		EnvVar:      "CODEBUFF_DIR",
-		ConfigKey:   "codebuff_dirs",
-		DefaultDirs: []string{".config/manicode/projects"},
-		IDPrefix:    "codebuff:",
-		FileBased:   true,
+		// Freebuff sessions do carry their own agent type: the parser
+		// sets Agent = AgentFreebuff and emits freebuff:-prefixed IDs
+		// when run-state.json agentType contains "free". Freebuff has
+		// no separate registry entry or provider factory, though; sync
+		// canonicalizes freebuff onto this Codebuff def (AgentByPrefix
+		// maps freebuff: IDs here), which avoids double-discovery and
+		// skip-cache contention over the shared roots.
+		Type:              AgentCodebuff,
+		DisplayName:       "Codebuff",
+		EnvVar:            "CODEBUFF_DIR",
+		ConfigKey:         "codebuff_dirs",
+		DefaultDirs:       []string{".config/manicode/projects"},
+		IDPrefix:          "codebuff:",
+		FileBased:         true,
+		PeriodicReconcile: true,
 		Usage: UsageCapabilities{
 			NoPerMessageTokenData: true,
 		},

--- a/internal/parser/types_test.go
+++ b/internal/parser/types_test.go
@@ -691,6 +691,10 @@ func TestPeriodicReconcileCapability(t *testing.T) {
 	// updated_at floor, so metadata-only edits and deletions rely on the
 	// scheduled fingerprint-gated container reparse.
 	assert.True(t, optedIn[AgentOmnigent])
+	// Codebuff's recursive per-project watch covers existing projects;
+	// scheduled reconciliation picks up newly created project
+	// directories under the root (see codebuffWatchRoots).
+	assert.True(t, optedIn[AgentCodebuff])
 	// Cowork's provider WatchPlan registers its root recursively
 	// (coworkWatchRoots Recursive:true overrides legacy ShallowWatch), so
 	// scheduled reconciliation would redundantly rescan the whole archive.
@@ -1344,10 +1348,13 @@ func TestReasonixRegistryEntry(t *testing.T) {
 
 func TestFreebuffNotRegistered(t *testing.T) {
 	// Freebuff intentionally shares the Codebuff provider and is NOT
-	// registered in Registry. Both paid Codebuff and free Freebuff sessions
-	// use agent = AgentCodebuff so that lifecycle operations (reconciliation,
-	// deletion, baselines) keyed by agent type work correctly. The UI
-	// distinguishes them via AgentLabel.
+	// registered in Registry. Freebuff sessions do carry agent =
+	// AgentFreebuff with freebuff:-prefixed IDs (set by
+	// parseCodebuffSession when run-state.json agentType contains
+	// "free"), but there is no separate registry entry or factory:
+	// sync canonicalizes freebuff onto the Codebuff provider def
+	// (AgentByPrefix maps freebuff: IDs to the Codebuff def), so
+	// lifecycle operations over the shared roots run once.
 	for _, def := range Registry {
 		assert.NotEqualf(t, AgentFreebuff, def.Type,
 			"AgentFreebuff must not be registered — it shares the Codebuff provider")

--- a/internal/parser/types_test.go
+++ b/internal/parser/types_test.go
@@ -476,6 +476,7 @@ func TestRegistryCompleteness(t *testing.T) {
 		AgentRooCode,
 		AgentPoolside,
 		AgentOmnigent,
+		AgentCodebuff,
 	}
 
 	expected := make(map[AgentType]bool, len(allTypes))
@@ -1339,4 +1340,16 @@ func TestReasonixRegistryEntry(t *testing.T) {
 	}
 	assert.True(t, hasUnix, "DefaultDirs should contain .reasonix")
 	assert.True(t, hasWindows, "DefaultDirs should contain AppData/Roaming/reasonix")
+}
+
+func TestFreebuffNotRegistered(t *testing.T) {
+	// Freebuff intentionally shares the Codebuff provider and is NOT
+	// registered in Registry. Both paid Codebuff and free Freebuff sessions
+	// use agent = AgentCodebuff so that lifecycle operations (reconciliation,
+	// deletion, baselines) keyed by agent type work correctly. The UI
+	// distinguishes them via AgentLabel.
+	for _, def := range Registry {
+		assert.NotEqualf(t, AgentFreebuff, def.Type,
+			"AgentFreebuff must not be registered — it shares the Codebuff provider")
+	}
 }

--- a/internal/postgres/usage_pgtest_test.go
+++ b/internal/postgres/usage_pgtest_test.go
@@ -1963,3 +1963,49 @@ func TestStoreSessionUsageWithSubagentsParity(t *testing.T) {
 		"output tokens are deduplicated without dropping output-only messages")
 	assert.True(t, got.HasTokenData)
 }
+
+// TestStoreGetSessionUsage_CodebuffCostOnlyReported pins the
+// PostgreSQL aggregator acceptance for Codebuff/Freebuff's
+// parser-emitted cost-only usage event. The Codebuff parser
+// (internal/parser/codebuff.go) attributes the session cost
+// to the agent template (e.g. "base2-deepseek") rather than
+// the agent name so the per-model breakdown in the usage
+// report stays granular. The PG aggregator must accept that
+// non-empty Model value and surface the cost unchanged.
+// Without this pin, a future change that hard-codes the
+// accepted model name would silently drop template-attributed
+// codebuff/freebuff rows.
+func TestStoreGetSessionUsage_CodebuffCostOnlyReported(t *testing.T) {
+	_, store := prepareUsageSchema(t, "agentsview_codebuff_cost_only_test")
+
+	ctx := context.Background()
+	_, err := store.DB().ExecContext(ctx, `
+		INSERT INTO sessions (
+			id, machine, project, agent, started_at,
+			message_count, user_message_count
+		) VALUES (
+			'codebuff:cost-only', 'test-machine', 'proj', 'codebuff',
+			'2026-07-15T10:00:00Z'::timestamptz, 1, 1
+		)`)
+	require.NoError(t, err)
+	_, err = store.DB().ExecContext(ctx, `
+		INSERT INTO usage_events (
+			session_id, source, model, input_tokens, output_tokens,
+			cost_microdollars, cost_status, cost_source, occurred_at, dedup_key
+		) VALUES (
+			'codebuff:cost-only', 'session', 'base2-deepseek', 0, 0,
+			5000, 'reported', 'session',
+			'2026-07-15T10:05:00Z'::timestamptz, 'session:codebuff:cost-only'
+		)`)
+	require.NoError(t, err)
+
+	u, err := store.GetSessionUsage(ctx, "codebuff:cost-only", true)
+	require.NoError(t, err)
+	require.NotNil(t, u)
+	assert.True(t, u.HasCost,
+		"a codebuff cost-only event must surface HasCost")
+	assert.Equal(t, money.Money{Microdollars: 5000}, u.Cost,
+		"the reported cost must flow through unchanged")
+	assert.Equal(t, []string{"base2-deepseek"}, u.Models,
+		"the parser-attributed template name must surface in Models")
+}

--- a/internal/sync/change_time_windows.go
+++ b/internal/sync/change_time_windows.go
@@ -9,6 +9,11 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+// ntfsEpochOffset is the number of 100-nanosecond intervals between the NTFS
+// epoch (January 1, 1601) and the Unix epoch (January 1, 1970). Multiplying
+// by 100 converts to Unix nanoseconds.
+const ntfsEpochOffset = 116444736000000000
+
 type windowsFileBasicInfo struct {
 	creationTime   int64
 	lastAccessTime int64
@@ -35,5 +40,9 @@ func fileChangeTime(path string, _ os.FileInfo) (int64, bool) {
 	if err != nil || info.changeTime == 0 {
 		return 0, false
 	}
-	return info.changeTime, true
+	// Convert NTFS time (100 ns intervals since 1601) to Unix nanoseconds
+	// so the returned value is directly comparable with time.Time.UnixNano()
+	// and os.FileInfo.ModTime().UnixNano(). On darwin/linux the syscall
+	// layer already returns Unix epoch values; Windows needs the conversion.
+	return (info.changeTime - ntfsEpochOffset) * 100, true
 }

--- a/internal/sync/codebuff_integration_test.go
+++ b/internal/sync/codebuff_integration_test.go
@@ -220,6 +220,28 @@ func (p *codebuffFingerprintCountingProvider) ParseIncremental(
 	return p.inner.ParseIncremental(ctx, req)
 }
 
+// ComputeMultiFileStatHash forwards to the inner provider through a
+// MultiFileStatHasher type assertion because parser.Provider does not
+// include it. Without this forwarding method the wrapper fails the
+// interface assertion in buildProviderStatHashers, no hasher is
+// registered for Codebuff, preParseStatHash stays nil, and the warm
+// pass of the cardinality test satisfies its "zero Fingerprint calls"
+// assertion through the legacy size/max-mtime composite arm — a path
+// unreachable in the production configuration — instead of the
+// per-component digest gate the test pins. Returning 0 on a failed
+// assertion keeps miswiring loud: a 0 digest is never persisted to
+// provider_freshness, so every warm pass would force fingerprints and
+// the zero-call assertion would fail.
+func (p *codebuffFingerprintCountingProvider) ComputeMultiFileStatHash(
+	chatPath string,
+) uint64 {
+	hasher, ok := p.inner.(parser.MultiFileStatHasher)
+	if !ok {
+		return 0
+	}
+	return hasher.ComputeMultiFileStatHash(chatPath)
+}
+
 // codebuffCountingFactory hands out a single prebuilt
 // codebuffFingerprintCountingProvider so every Engine.NewProvider call
 // observes through the same counter.
@@ -321,9 +343,13 @@ func TestSyncCodebuffPerEventWorkIsCardinalityIndependent(t *testing.T) {
 			"cold sync must call provider.Fingerprint once per "+
 				"discovered source")
 
-		// Warm pass: composite-stats still match what was persisted on
-		// the cold pass, so providerSourceFreshBeforeFingerprint
-		// returns fresh=true for every source and provider.Fingerprint
+		// Warm pass: the counting wrapper forwards
+		// ComputeMultiFileStatHash, so the engine registered a hasher
+		// and the cold pass persisted a per-component digest for every
+		// source. Each digest still matches the current stat snapshot,
+		// so providerSourceFreshBeforeFingerprint short-circuits
+		// through the production digest arm (stored == digest plus
+		// providerFreshDigestSourceCurrentInDB) and provider.Fingerprint
 		// is not called. A regression that lets the freshness gate
 		// fall through on unchanged sessions surfaces here as a
 		// non-zero call count for either archive — both must remain

--- a/internal/sync/codebuff_integration_test.go
+++ b/internal/sync/codebuff_integration_test.go
@@ -1,0 +1,1553 @@
+package sync_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/sync"
+)
+
+// writeCodebuffTestFiles creates the three files that make up a Codebuff
+// session directory: chat-messages.json, run-state.json, and chat-meta.json.
+func writeCodebuffTestFiles(t *testing.T, dir, content string) {
+	t.Helper()
+	chatPath := filepath.Join(dir, "chat-messages.json")
+	runStatePath := filepath.Join(dir, "run-state.json")
+	chatMetaPath := filepath.Join(dir, "chat-meta.json")
+
+	require.NoError(t, os.WriteFile(chatPath, []byte(`[
+		{"id":"user-1","variant":"user","content":"`+content+`","timestamp":"03:04 PM"}
+	]`), 0o644))
+	require.NoError(t, os.WriteFile(runStatePath, []byte(`{
+		"sessionState": {
+			"mainAgentState": {"agentType": "base2-free-deepseek"}
+		}
+	}`), 0o644))
+	require.NoError(t, os.WriteFile(chatMetaPath, []byte(`{
+		"messageCount": 1,
+		"firstPrompt": "`+content+`",
+		"messagesSize": 50
+	}`), 0o644))
+}
+
+// createCodebuffArchive creates a Codebuff archive with the given number of
+// sessions distributed across projects. Returns the root directory.
+func createCodebuffArchive(t *testing.T, numSessions int) string {
+	t.Helper()
+	root := t.TempDir()
+	numProjects := 3
+	sessionsPerProject := numSessions / numProjects
+	if sessionsPerProject == 0 {
+		sessionsPerProject = 1
+	}
+
+	for p := range numProjects {
+		project := fmt.Sprintf("project-%d", p)
+		for s := 0; s < sessionsPerProject; s++ {
+			ts := fmt.Sprintf("2026-07-15T%02d-00-00.000Z", 10+s)
+			dir := filepath.Join(root, project, "chats", ts)
+			require.NoError(t, os.MkdirAll(dir, 0o755))
+			writeCodebuffTestFiles(t, dir, fmt.Sprintf("Session %d in %s", s, project))
+		}
+	}
+	return root
+}
+
+// createCodebuffSingleSession creates exactly one Codebuff session in
+// project-0/chats/<ts>/ and returns the archive root plus the canonical
+// chat-messages.json path. New tests that target a single source prefer
+// this helper over createCodebuffArchive(t, 1): the legacy helper
+// distributes sessions across three projects and produces three
+// sessions for any numSessions <= 3, which silently masks single-source
+// regressions behind a triple-count expectation.
+func createCodebuffSingleSession(t *testing.T) (root, chatPath string) {
+	t.Helper()
+	root = t.TempDir()
+	project := "project-0"
+	ts := "2026-07-15T10-00-00.000Z"
+	dir := filepath.Join(root, project, "chats", ts)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	writeCodebuffTestFiles(t, dir, "Single source")
+	chatPath = filepath.Join(dir, "chat-messages.json")
+	return root, chatPath
+}
+
+// TestSyncAllCodebuffBoundedPerEventWork verifies that unchanged Codebuff
+// sessions are skipped during reconciliation without reading transcript
+// bytes. The stat-only freshness gate (providerSourceFreshBeforeFingerprint)
+// should prevent the fingerprint from being called for unchanged sources.
+func TestSyncAllCodebuffBoundedPerEventWork(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	// Create a small archive with 6 sessions.
+	root := createCodebuffArchive(t, 6)
+
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodebuff: {root},
+		},
+		Machine: "local",
+	})
+
+	// First sync: all sessions should be parsed.
+	synced := engine.SyncAll(context.Background(), nil).Synced
+	assert.Equal(t, 6, synced, "first sync should parse all 6 sessions")
+
+	// Second sync with no changes: all sessions should be skipped.
+	synced = engine.SyncAll(context.Background(), nil).Synced
+	assert.Equal(t, 0, synced, "second sync with no changes should skip all sessions")
+
+	// Modify one session's chat-messages.json.
+	modifiedDir := filepath.Join(root, "project-0", "chats", "2026-07-15T10-00-00.000Z")
+	modifiedChatPath := filepath.Join(modifiedDir, "chat-messages.json")
+	require.NoError(t, os.WriteFile(modifiedChatPath, []byte(`[
+		{"id":"user-1","variant":"user","content":"Modified message","timestamp":"03:04 PM"}
+	]`), 0o644))
+
+	// Touch the file to ensure mtime changes.
+	time.Sleep(10 * time.Millisecond)
+	now := time.Now()
+	require.NoError(t, os.Chtimes(modifiedChatPath, now, now))
+
+	// Third sync: only the modified session should be reparsed.
+	synced = engine.SyncAll(context.Background(), nil).Synced
+	assert.Equal(t, 1, synced, "third sync should only reparse the modified session")
+}
+
+// codebuffFingerprintCountingProvider wraps the real Codebuff Provider so
+// tests can observe how many session fingerprint calls the engine actually
+// issues. Every other Provider method delegates to the real implementation
+// so Discovery, class-changed-path, parse, and the freshness gate itself
+// behave exactly as in production; only Fingerprint increments a counter
+// before delegating. Per-event work that bypasses the freshness gate —
+// such as a regression that re-fingerprints every unchanged session, or
+// re-fingerprints sessions belonging to other archive entries — surfaces
+// here as a non-zero count rather than as hidden wall-clock growth.
+type codebuffFingerprintCountingProvider struct {
+	inner parser.Provider
+	calls atomic.Int64
+}
+
+func (p *codebuffFingerprintCountingProvider) Definition() parser.AgentDef {
+	return p.inner.Definition()
+}
+
+func (p *codebuffFingerprintCountingProvider) Capabilities() parser.Capabilities {
+	return p.inner.Capabilities()
+}
+
+func (p *codebuffFingerprintCountingProvider) Discover(
+	ctx context.Context,
+) ([]parser.SourceRef, error) {
+	return p.inner.Discover(ctx)
+}
+
+func (p *codebuffFingerprintCountingProvider) WatchPlan(
+	ctx context.Context,
+) (parser.WatchPlan, error) {
+	return p.inner.WatchPlan(ctx)
+}
+
+// WatchRoots delegates to the inner provider through a WatchRootPlanner
+// type assertion because parser.Provider does not include WatchRoots.
+// Without it, engine.providerChangedPathWatchRoots would type-assert the
+// wrapper itself (the factory.h.NewProvider return path), fail the
+// WatchRootPlanner assertion on a provider that advertises the WatchRoots
+// capability, and surface an "unsupported provider feature watch roots"
+// error from SyncPathsContext before classification ever runs.
+func (p *codebuffFingerprintCountingProvider) WatchRoots(
+	ctx context.Context,
+) ([]parser.WatchRoot, error) {
+	planner, ok := p.inner.(parser.WatchRootPlanner)
+	if !ok {
+		return nil, parser.UnsupportedProviderFeatureError{
+			Provider: p.inner.Definition().Type,
+			Feature:  parser.ProviderFeatureWatchRoots,
+		}
+	}
+	return planner.WatchRoots(ctx)
+}
+
+func (p *codebuffFingerprintCountingProvider) ResolveReconciliationScopes(
+	ctx context.Context, req parser.ReconciliationScopeRequest,
+) (parser.ReconciliationScopePlan, error) {
+	return p.inner.ResolveReconciliationScopes(ctx, req)
+}
+
+func (p *codebuffFingerprintCountingProvider) SourcesForChangedPath(
+	ctx context.Context, req parser.ChangedPathRequest,
+) ([]parser.SourceRef, error) {
+	return p.inner.SourcesForChangedPath(ctx, req)
+}
+
+func (p *codebuffFingerprintCountingProvider) FindSource(
+	ctx context.Context, req parser.FindSourceRequest,
+) (parser.SourceRef, bool, error) {
+	return p.inner.FindSource(ctx, req)
+}
+
+func (p *codebuffFingerprintCountingProvider) Fingerprint(
+	ctx context.Context, src parser.SourceRef,
+) (parser.SourceFingerprint, error) {
+	p.calls.Add(1)
+	return p.inner.Fingerprint(ctx, src)
+}
+
+func (p *codebuffFingerprintCountingProvider) Parse(
+	ctx context.Context, req parser.ParseRequest,
+) (parser.ParseOutcome, error) {
+	return p.inner.Parse(ctx, req)
+}
+
+func (p *codebuffFingerprintCountingProvider) ParseIncremental(
+	ctx context.Context, req parser.IncrementalRequest,
+) (parser.IncrementalOutcome, parser.IncrementalStatus, error) {
+	return p.inner.ParseIncremental(ctx, req)
+}
+
+// codebuffCountingFactory hands out a single prebuilt
+// codebuffFingerprintCountingProvider so every Engine.NewProvider call
+// observes through the same counter.
+type codebuffCountingFactory struct {
+	provider parser.Provider
+}
+
+func (f codebuffCountingFactory) Definition() parser.AgentDef {
+	return f.provider.Definition()
+}
+
+func (f codebuffCountingFactory) Capabilities() parser.Capabilities {
+	return f.provider.Capabilities()
+}
+
+func (f codebuffCountingFactory) NewProvider(parser.ProviderConfig) parser.Provider {
+	return f.provider
+}
+
+// newCodebuffCountingEngine builds an Engine whose Codebuff provider is
+// the prebuilt counting wrapper. The wrapper holds the real Codebuff
+// Provider as inner, so behavior matches production; the counter is the
+// only observability seam.
+func newCodebuffCountingEngine(
+	t *testing.T, root string,
+) (*sync.Engine, *codebuffFingerprintCountingProvider) {
+	t.Helper()
+	database := dbtest.OpenTestDB(t)
+	innerFactory, ok := parser.ProviderFactoryByType(parser.AgentCodebuff)
+	require.True(t, ok, "codebuff factory must be registered")
+	inner := innerFactory.NewProvider(parser.ProviderConfig{
+		Roots:   []string{root},
+		Machine: "local",
+	})
+	require.NotNil(t, inner)
+	provider := &codebuffFingerprintCountingProvider{inner: inner}
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodebuff: {root},
+		},
+		Machine: "local",
+		ProviderFactories: []parser.ProviderFactory{codebuffCountingFactory{
+			provider: provider,
+		}},
+		// classifyProviderChangedPath only runs for agents whose
+		// registered mode is ProviderMigrationProviderAuthoritative.
+		// Without an explicit override here, the engine falls back to
+		// the package-level default map, which classifies Codebuff
+		// through the legacy non-authoritative path and skips the
+		// changed-path classify loop entirely — disabling the
+		// single-path SyncPaths phase of the bounded test.
+		ProviderMigrationModes: map[parser.AgentType]parser.ProviderMigrationMode{
+			parser.AgentCodebuff: parser.ProviderMigrationProviderAuthoritative,
+		},
+	})
+	t.Cleanup(engine.Close)
+	return engine, provider
+}
+
+// TestSyncCodebuffPerEventWorkIsCardinalityIndependent verifies that the per-event
+// work for unchanged Codebuff sessions does not scale with archive size.
+// Asserting only Synced == 0 leaves an O(archive-size) regression in
+// unchanged-session fingerprint reads invisible: re-fingerprinting every
+// still-unchanged source costs the same archived counter, but burns
+// transcript bytes per session. The freshness gate
+// providerSourceFreshBeforeFingerprint is supposed to short-circuit
+// every unchanged composite-stat so a warm SyncAll issues zero
+// Fingerprint calls, and a single-path SyncPaths issues exactly one for
+// the changed source. Counting provider.Fingerprint calls (the only path
+// that reads transcript bytes) pins both invariants across a 5x archive
+// growth and pins the constancy roborev flagged as missing. The
+// single-path SyncPaths phase additionally exercises the watcher-shaped
+// changed-path entry point instead of the bulk-discovery path, so a
+// regression that scales per-event work with archive size surfaces as
+// fingerprint count > 1 only on the larger archive.
+func TestSyncCodebuffPerEventWorkIsCardinalityIndependent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	seedPath := filepath.Join(
+		"project-0", "chats", "2026-07-15T10-00-00.000Z",
+		"chat-messages.json",
+	)
+
+	probe := func(root string, numSessions int) {
+		engine, codebuff := newCodebuffCountingEngine(t, root)
+
+		// Cold pass: every session needs a fingerprint, so the counter
+		// delta equals the archive size. This proves the counting
+		// wrapper is wired correctly before the warm/SyncPaths checks
+		// below.
+		codebuff.calls.Store(0)
+		require.Equal(t, numSessions,
+			engine.SyncAll(context.Background(), nil).Synced,
+			"first cold sync over %d-session archive must parse "+
+				"every session", numSessions)
+		assert.Equal(t, int64(numSessions), codebuff.calls.Load(),
+			"cold sync must call provider.Fingerprint once per "+
+				"discovered source")
+
+		// Warm pass: composite-stats still match what was persisted on
+		// the cold pass, so providerSourceFreshBeforeFingerprint
+		// returns fresh=true for every source and provider.Fingerprint
+		// is not called. A regression that lets the freshness gate
+		// fall through on unchanged sessions surfaces here as a
+		// non-zero call count for either archive — both must remain
+		// at zero, and the equality itself is the cardinality-
+		// independence check roborev flagged as missing.
+		codebuff.calls.Store(0)
+		assert.Equal(t, 0,
+			engine.SyncAll(context.Background(), nil).Synced,
+			"warm SyncAll over %d-session archive must skip "+
+				"every unchanged session", numSessions)
+		assert.Equal(t, int64(0), codebuff.calls.Load(),
+			"warm SyncAll over %d-session archive must not call "+
+				"provider.Fingerprint on any unchanged session "+
+				"(a non-zero count is a per-archive-size "+
+				"regression in the freshness gate or its "+
+				"bypass)", numSessions)
+
+		// Single changed-path sync: a watcher-shaped event for one
+		// session. The path is unchanged on disk so the freshness
+		// gate would short-circuit, but engine.providerChangedPath-
+		// ForceParse forces provider.Fingerprint for any direct
+		// chat-messages.json event so transcript bytes are
+		// guaranteed to be re-read. The fingerprint call here is
+		// therefore exactly one. A regression that scales per-event
+		// work with archive size (e.g. re-fingerprinting every
+		// stored source on every watcher event) would surface here
+		// as fingerprint count >= 2 for the larger archive while
+		// staying at 1 for the smaller one.
+		codebuff.calls.Store(0)
+		require.NoError(t, engine.SyncPathsContext(
+			context.Background(),
+			[]string{filepath.Join(root, seedPath)},
+		), "single-path SyncPaths propagates errors that must not be "+
+			"silently swallowed (a hidden failure could split the "+
+			"small and large archive assertion paths)")
+		assert.Equal(t, int64(1), codebuff.calls.Load(),
+			"a single-path SyncPaths over %d-session archive "+
+				"must call provider.Fingerprint exactly once "+
+				"(any larger count means per-event work is "+
+				"scaling with archive size)", numSessions)
+	}
+
+	probe(createCodebuffArchive(t, 6), 6)
+	probe(createCodebuffArchive(t, 30), 30)
+}
+
+// codebuffMetaOnlySessionFiles creates a codebuff session
+// directory whose chat-messages.json is "[]" while chat-meta.json
+// reports a non-zero messageCount and firstPrompt. The parser
+// must set CountsAuthoritative=true for this fallback path so the
+// engine's per-message reconciliation cannot overwrite the meta
+// totals with zero derived from the empty parsed-message slice.
+func codebuffMetaOnlySessionFiles(
+	t *testing.T, dir string, metaCount int, firstPrompt string,
+) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "chat-messages.json"),
+		[]byte("[]"),
+		0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "run-state.json"),
+		[]byte(`{
+			"sessionState": {
+				"mainAgentState": {"agentType": "base2-deepseek"},
+				"fileContext": {"cwd": "/initial/cwd"}
+			}
+		}`),
+		0o644,
+	))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "chat-meta.json"),
+		fmt.Appendf(nil, `{
+			"messageCount": %d,
+			"firstPrompt": %q,
+			"messagesSize": 1024
+		}`, metaCount, firstPrompt),
+		0o644,
+	))
+}
+
+// TestSyncCodebuffMetaOnlySessionKeepsCounts pins the regression
+// the roborev review identified at internal/parser/codebuff.go:131:
+// when a codebuff session's chat-messages.json is empty but
+// chat-meta.json reports a non-zero messageCount, the sync engine
+// must preserve the meta-derived counts on the row. Without
+// CountsAuthoritative=true the engine's per-message
+// reconciliation recomputes counts from the empty parsed-message
+// slice and overwrites MessageCount with zero, hiding the session
+// from any UI that filters on nonzero counts.
+//
+// Exercise the full sync path (Parse -> db.Session write) so a
+// regression that touches any stage — the parser flag, the engine
+// reconciliation pass, or the db.Session write — surfaces as
+// MessageCount == 0 here.
+func TestSyncCodebuffMetaOnlySessionKeepsCounts(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	root := t.TempDir()
+	project := "codebuff-meta"
+	ts := "2026-07-16T00-09-00.236Z"
+	sessionDir := filepath.Join(root, project, "chats", ts)
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+	codebuffMetaOnlySessionFiles(t, sessionDir, 7, "Alpha prompt")
+
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodebuff: {root},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+
+	require.Equal(t, 1,
+		engine.SyncAll(context.Background(), nil).Synced,
+		"meta-only session with non-zero chat-meta.json must sync")
+
+	canonicalID := "codebuff:codebuff-meta:" + ts
+	sess, err := database.GetSession(
+		context.Background(), canonicalID,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, sess,
+		"synced session must persist to the database")
+	require.Equal(t, 7, sess.MessageCount,
+		"meta-derived counts must survive sync; a 0 here means "+
+			"the engine recomputed from the empty parsed-message "+
+			"slice and overwrote chat-meta.json's count")
+	require.NotNil(t, sess.StartedAt,
+		"meta-only session must have a StartedAt timestamp; nil means "+
+			"the parser left it unset and analytics would fall back to "+
+			"import-time created_at, incorrectly dating historical sessions")
+	require.NotEmpty(t, *sess.StartedAt,
+		"StartedAt must be non-empty for a meta-only session")
+	require.NotNil(t, sess.EndedAt,
+		"meta-only session must have an EndedAt timestamp; nil means "+
+			"the parser left it unset")
+	require.NotEmpty(t, *sess.EndedAt,
+		"EndedAt must be non-empty for a meta-only session")
+}
+
+// TestSyncCodebuffMetaOnlyDriftReparsesSession pins the roborev LOW
+// carryover at internal/parser/codebuff_provider.go:194 and the matching
+// freshness gate in internal/sync/engine.go around line 12253: a future
+// regression that drops chat-meta.json from the composite stat would
+// silently orphan rows whose only on-disk change is a meta touch. The
+// stat-only freshness gate must observe the meta-only mtime bump and
+// reparse exactly one session while leaving the other five unchanged.
+//
+// chat-messages.json and run-state.json stay on disk untouched.
+func TestSyncCodebuffMetaOnlyDriftReparsesSession(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	root := createCodebuffArchive(t, 6)
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodebuff: {root},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+
+	require.Equal(t, 6,
+		engine.SyncAll(context.Background(), nil).Synced,
+		"cold sync must parse every discovered session")
+
+	targetDir := filepath.Join(
+		root, "project-0", "chats", "2026-07-15T10-00-00.000Z",
+	)
+	metaPath := filepath.Join(targetDir, "chat-meta.json")
+	require.NoError(t, os.WriteFile(metaPath, []byte(`{
+		"messageCount": 1,
+		"firstPrompt": "Meta-drift prompt",
+		"messagesSize": 4096
+	}`), 0o644))
+	time.Sleep(10 * time.Millisecond)
+	bump := time.Now()
+	require.NoError(t, os.Chtimes(metaPath, bump, bump))
+
+	assert.Equal(t, 1,
+		engine.SyncAll(context.Background(), nil).Synced,
+		"chat-meta.json-only drift must reparse exactly one "+
+			"session; a zero here means the freshness composite "+
+			"stat dropped chat-meta.json and the meta-only mtime "+
+			"bump passed the gate as unchanged, and a value "+
+			"above one means the composite double-counted the "+
+			"shared session")
+}
+
+// TestSyncCodebuffRunStateOnlyDriftReparsesSession pins the run-state.json
+// leg of the freshness composite trio at internal/parser/codebuff_provider.go:196
+// and engine.go around line 12260: a future regression that drops
+// run-state.json from the composite stat would silently orphan rows whose
+// only on-disk change is a run-state touch (e.g. when the upstream agent
+// accumulates credits without appending to chat-messages.json). The
+// stat-only freshness gate must observe the run-state-only mtime bump
+// and reparse exactly one session while leaving the other five unchanged.
+//
+// chat-messages.json and chat-meta.json stay on disk untouched.
+func TestSyncCodebuffRunStateOnlyDriftReparsesSession(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	root := createCodebuffArchive(t, 6)
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodebuff: {root},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+
+	require.Equal(t, 6,
+		engine.SyncAll(context.Background(), nil).Synced,
+		"cold sync must parse every discovered session")
+
+	targetDir := filepath.Join(
+		root, "project-0", "chats", "2026-07-15T10-00-00.000Z",
+	)
+	runStatePath := filepath.Join(targetDir, "run-state.json")
+	require.NoError(t, os.WriteFile(runStatePath, []byte(`{
+		"sessionState": {
+			"mainAgentState": {
+				"agentType": "base2-deepseek",
+				"creditsUsed": 200
+			},
+			"fileContext": {"cwd": "/initial/cwd"}
+		}
+	}`), 0o644))
+	time.Sleep(10 * time.Millisecond)
+	bump := time.Now()
+	require.NoError(t, os.Chtimes(runStatePath, bump, bump))
+
+	assert.Equal(t, 1,
+		engine.SyncAll(context.Background(), nil).Synced,
+		"run-state.json-only drift must reparse exactly one "+
+			"session; a zero here means the freshness composite "+
+			"stat dropped run-state.json and the run-state-only "+
+			"mtime bump passed the gate as unchanged, and a value "+
+			"above one means the composite double-counted the "+
+			"shared session")
+}
+
+// TestSyncCodebuffMetaAndRunStateCompositeDriftReparsesSession exercises
+// freshness composite stat at the same time as each individual leg:
+// mutating BOTH chat-meta.json AND run-state.json (chat-messages.json
+// untouched) between two syncs must reparse exactly one session. The
+// composite stat folds each leg's size and max mtime via sum/max, so
+// the realistic failure modes for this test are:
+//
+//   - "missed both fresh mtime bumps": max(mtime) returned false
+//     despite both legs bumping, surfacing as Synced == 0. (A
+//     single missed leg would still advance the max — the
+//     meta-only and run-state-only tests catch that case more
+//     directly.)
+//   - "double-count the shared session": the composite emits one
+//     re-parse per bumped file, returning Synced >= 2.
+//
+// Both legs reference the SAME session directory, so they must
+// de-duplicate to a single re-parse. The shared mtime bump between
+// the two files removes a subtle flake risk if the host filesystem
+// has a coarser-than-10ms mtime resolution.
+func TestSyncCodebuffMetaAndRunStateCompositeDriftReparsesSession(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	root := createCodebuffArchive(t, 6)
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodebuff: {root},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+
+	require.Equal(t, 6,
+		engine.SyncAll(context.Background(), nil).Synced,
+		"cold sync must parse every discovered session")
+
+	targetDir := filepath.Join(
+		root, "project-0", "chats", "2026-07-15T10-00-00.000Z",
+	)
+	metaPath := filepath.Join(targetDir, "chat-meta.json")
+	runStatePath := filepath.Join(targetDir, "run-state.json")
+	require.NoError(t, os.WriteFile(metaPath, []byte(`{
+		"messageCount": 1,
+		"firstPrompt": "Composite-drift prompt",
+		"messagesSize": 8192
+	}`), 0o644))
+	require.NoError(t, os.WriteFile(runStatePath, []byte(`{
+		"sessionState": {
+			"mainAgentState": {
+				"agentType": "base2-deepseek",
+				"creditsUsed": 500
+			},
+			"fileContext": {"cwd": "/initial/cwd"}
+		}
+	}`), 0o644))
+	time.Sleep(10 * time.Millisecond)
+	bump := time.Now()
+	require.NoError(t, os.Chtimes(metaPath, bump, bump))
+	require.NoError(t, os.Chtimes(runStatePath, bump, bump))
+
+	assert.Equal(t, 1,
+		engine.SyncAll(context.Background(), nil).Synced,
+		"composite (chat-meta + run-state) drift must reparse "+
+			"exactly one session; a zero here means the freshness "+
+			"composite missed BOTH bumped files (each leg is "+
+			"folded via max mtime, so a single missing leg would "+
+			"still let the other advance the max), and a value "+
+			"above one means the composite double-counted the "+
+			"shared session")
+}
+
+// TestSyncCodebuffCompanionFileDeletionReparsesSession verifies the
+// directory-mtime cutoff signal for Codebuff sessions: when a companion
+// file (run-state.json or chat-meta.json) is deleted from a session
+// directory, the surviving files' mtimes may predate the cutoff, but the
+// directory mtime changes on deletion. The stat-only freshness gate must
+// observe the directory mtime bump and reparse exactly one session while
+// leaving the other five unchanged.
+//
+// This covers the fix at internal/sync/engine.go discoveredFileEffective-
+// Mtime: the Codebuff branch now considers the session directory mtime
+// as a local cutoff signal, consistent with the Kilo Legacy branch, to
+// detect companion-file deletions that would otherwise be invisible to
+// the individual-file mtime composite.
+func TestSyncCodebuffCompanionFileDeletionReparsesSession(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	root := createCodebuffArchive(t, 6)
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodebuff: {root},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+
+	require.Equal(t, 6,
+		engine.SyncAll(context.Background(), nil).Synced,
+		"cold sync must parse every discovered session")
+
+	// Warm sync: all sessions unchanged, so all should be skipped.
+	assert.Equal(t, 0,
+		engine.SyncAll(context.Background(), nil).Synced,
+		"warm sync must skip all unchanged sessions")
+
+	// Delete run-state.json from one session directory. Deleting a
+	// file changes the directory's mtime even though surviving files'
+	// mtimes are unchanged. The freshness gate must observe this
+	// directory mtime bump and reparse the session.
+	targetDir := filepath.Join(
+		root, "project-0", "chats", "2026-07-15T10-00-00.000Z",
+	)
+	runStatePath := filepath.Join(targetDir, "run-state.json")
+	require.NoError(t, os.Remove(runStatePath),
+		"deleting run-state.json must succeed")
+	time.Sleep(10 * time.Millisecond)
+
+	// Re-sync: exactly the session whose companion was deleted should
+	// be reparsed. A value of zero means the directory mtime signal
+	// was not picked up (the companion-file deletion was invisible to
+	// the freshness gate), and a value above one means the composite
+	// double-counted or other sessions were affected.
+	assert.Equal(t, 1,
+		engine.SyncAll(context.Background(), nil).Synced,
+		"deleting run-state.json must trigger reparse of exactly "+
+			"one session via the directory mtime cutoff signal; a "+
+			"zero means the freshness gate missed the deletion, and "+
+			"a value above one means it over-counted")
+}
+
+// TestSyncCodebuffProviderStatHashSideTable pins Issue 1 (engine wire-up)
+// at engine-side behavior: a successful cold sync against the default
+// codebuff factory must populate provider_freshness for every persisted
+// source. A regression that drops the SourceSetProvider forwarding
+// method would leave provider_freshness empty here, since the engine's
+// MultiFileStatHasher type assertion would not surface the inner
+// codebuffSourceSet through the wrapper.
+func TestSyncCodebuffProviderStatHashSideTable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	database := dbtest.OpenTestDB(t)
+	root, chatPath := createCodebuffSingleSession(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodebuff: {root},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+
+	require.Equal(t, 1,
+		engine.SyncAll(context.Background(), nil).Synced,
+		"cold sync must parse the seeded codebuff session")
+	hashed, hasHash, err := database.GetProviderStatHash(
+		context.Background(), parser.AgentCodebuff, chatPath,
+	)
+	require.NoError(t, err)
+	require.True(t, hasHash,
+		"a successful cold sync must populate provider_freshness "+
+			"for the registered codebuff source; a missing row "+
+			"means the Engine's MultiFileStatHasher type "+
+			"assertion failed to surface the SourceSetProvider "+
+			"wrapping the codebuffSourceSet")
+	require.NotZero(t, hashed,
+		"the staged digest must be non-zero so a later warm pass "+
+			"can short-circuit on a matching snapshot")
+
+	// Warm sync with no changes leaves the side-table intact and
+	// skips the source.
+	require.Equal(t, 0,
+		engine.SyncAll(context.Background(), nil).Synced,
+		"warm sync over an unchanged codebuff source must skip "+
+			"the source via the per-component digest short-circuit")
+	hashedAgain, hasHashAgain, err := database.GetProviderStatHash(
+		context.Background(), parser.AgentCodebuff, chatPath,
+	)
+	require.NoError(t, err)
+	require.True(t, hasHashAgain)
+	require.Equal(t, hashed, hashedAgain,
+		"the side-table digest must be stable across an unchanged "+
+			"warm sync; a divergence here means the digest "+
+			"pre-check is hashing inconsistent inputs across runs")
+}
+
+// TestSyncCodebuffProviderStatHashSiblingDriftForcesReparse pins Issue 1
+// at engine-side reparse behavior: a same-size sibling-file rewrite
+// whose mtime stays strictly below the chat file's mtime must change the
+// per-component digest enough to force provider.Fingerprint on the next
+// sync. Without the per-component digest the legacy size/mtime composite
+// would see size unchanged and max-mtime unchanged, falsely short-circuit
+// the source and retain stale metadata, costs, or lifecycle state on the
+// stored row. A regression that drops the hash lookup entirely (Issue 1)
+// lets the source continue to skip; a regression that hashes the wrong
+// inputs (the rewritten logical key instead of the physical file, Issue 3)
+// sees the digest stay constant and the warm sync also continues to skip.
+func TestSyncCodebuffProviderStatHashSiblingDriftForcesReparse(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	database := dbtest.OpenTestDB(t)
+	root, chatPath := createCodebuffSingleSession(t)
+	runStatePath := filepath.Join(filepath.Dir(chatPath), "run-state.json")
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodebuff: {root},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+
+	require.Equal(t, 1,
+		engine.SyncAll(context.Background(), nil).Synced,
+		"cold sync must parse the seeded session")
+
+	// Hold chat's mtime as the max; rewrite run-state.json with the
+	// same byte length so size+max-mtime composite would stay
+	// identical, but use a new mtime strictly below chatTime and
+	// different content so the per-component digest must change.
+	// Both bodies must be the same byte length so a size-only
+	// reduction cannot detect the drift; the assertion specifically
+	// pins the per-component digest path (Issue 1) -- if a future
+	// composite change folds sibling mtimes into the max, the legacy
+	// size/mtime composite would also catch this drift and the test
+	// would pass via the wrong observation. The matching one-byte
+	// swap of `"unusedC":"0"` -> `"unusedC":"9"` keeps the byte
+	// length exactly equal while still changing the content SHA256.
+	runStateBody := `{"sessionState":{"mainAgentState":{"agentType":"base2-free-deepseek","unusedA":"0","unusedB":"0","unusedC":"0"}}}`
+	runStateBodyRewritten := strings.Replace(
+		runStateBody, `"unusedC":"0"`, `"unusedC":"9"`, 1,
+	)
+	require.Equal(t, len(runStateBody), len(runStateBodyRewritten),
+		"rewritten run-state body length must match exactly so "+
+			"the sum-of-sizes and max-mtime composite stay "+
+			"constant between the two syncs")
+	chatTime := time.Date(2026, time.July, 4, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(chatPath, chatTime, chatTime))
+
+	// Sub-max mtime under the existing chat-messages.json max.
+	time.Sleep(10 * time.Millisecond)
+	subMaxTime := chatTime.Add(-1 * time.Minute)
+	require.NoError(t, os.WriteFile(runStatePath, []byte(runStateBodyRewritten), 0o644))
+	require.NoError(t, os.Chtimes(runStatePath, subMaxTime, subMaxTime))
+
+	// After the rewrite the warm sync must reparse the session.
+	// Without the per-component fix the engine's max-mtime
+	// composite would stay at chatTime and skip the source,
+	// leaving a stale row.
+	require.Equal(t, 1,
+		engine.SyncAll(context.Background(), nil).Synced,
+		"a same-size sibling rewrite with a sub-max mtime must "+
+			"force provider.Fingerprint on the next warm sync; "+
+			"a zero here means Issue 1 or Issue 3 is broken and "+
+			"the engine kept skipping with a stale digest")
+}
+
+// TestSyncCodebuffProviderStatHashRemoteStoresUnderLogicalKey pins Issue 3
+// at end-to-end behavior: a remote-import sync that wires the engine
+// with a pathRewriter mapping the on-disk chat-messages.json to a
+// canonical "host:/remote/path" key must persist the per-component
+// freshness digest under the logical key, not the physical file. A
+// regression that hashes the rewritten key (Issue 3) would compute a
+// zero-value digest because the logical path is not stat-able on the
+// local filesystem, then falsely report freshness forever.
+//
+// The test does not need a real remote end -- the engine reads files
+// from the configured root, applies the rewriter at write time, and
+// stores the side-table entry under whatever key the rewriter returns.
+// We observe behavior through database.GetProviderStatHash directly,
+// and additionally mutate the materialized file after the cold sync
+// to prove the digest is computed from the physical on-disk file
+// (not the logical path that would stat-empty).
+func TestSyncCodebuffProviderStatHashRemoteStoresUnderLogicalKey(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	database := dbtest.OpenTestDB(t)
+	root, _ := createCodebuffSingleSession(t)
+	const rewritePrefix = "hosts~/remote/"
+	logicalChat := rewritePrefix + "project-0/chats/2026-07-15T10-00-00.000Z/chat-messages.json"
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodebuff: {root},
+		},
+		// Production remote sync (importEngineConfig) always pairs
+		// IDPrefix with PathRewriter: applyRemoteRewrites only rewrites
+		// the stored session file_path when a host prefix is configured,
+		// so the sessions table row lands under the same logical key the
+		// provider_freshness side-table uses. Without the prefix the row
+		// keeps the physical temp path and the digest's logical key has
+		// no matching session row.
+		IDPrefix: "remote-host~",
+		Machine:  "local",
+		PathRewriter: func(p string) string {
+			if !strings.HasPrefix(p, root) {
+				return p
+			}
+			trimmed := strings.TrimPrefix(p, root+string(filepath.Separator))
+			return rewritePrefix + filepath.ToSlash(trimmed)
+		},
+	})
+	t.Cleanup(engine.Close)
+
+	require.Equal(t, 1,
+		engine.SyncAll(context.Background(), nil).Synced,
+		"remote-import engine must sync with the path rewriter")
+
+	// The side-table row must be keyed by the logical (rewritten)
+	// path, not the physical chat-messages.json file. A non-nil
+	// digest under the physical key would mean the engine hashed
+	// the wrong path; a missing digest under the logical key would
+	// mean the engine did not honor the rewriter at all.
+	logicalHash, hasLogical, err := database.GetProviderStatHash(
+		context.Background(), parser.AgentCodebuff, logicalChat,
+	)
+	require.NoError(t, err)
+	require.True(t, hasLogical,
+		"a successful remote-import sync must persist the "+
+			"per-component digest under the rewritten logical "+
+			"key; a missing row means Issue 3 is broken and the "+
+			"engine either hashed the wrong path or dropped the "+
+			"rewriter at the write site")
+	require.NotZero(t, logicalHash,
+		"logical-key digest must be non-zero; a zero means the "+
+			"engine hashed the logical path itself rather than the "+
+			"physical materialized file (which is not stat-able "+
+			"locally)")
+
+	// The actual physical-vs-logical hash invariant: mutate the
+	// materialized chat-messages.json after the cold sync and confirm
+	// the warm sync's digest differs from the cold sync's digest. If
+	// Issue 3 ever regressed to hashing the logical key, this
+	// warm-pass digest would either stay constant (because every
+	// logical-path stat fails) or match a missing-file pattern that
+	// SHA-comparing the logical path never reaches.
+	require.Equal(t, 0,
+		engine.SyncAll(context.Background(), nil).Synced,
+		"warm sync over an unchanged materialized file must skip "+
+			"via the per-component digest short-circuit")
+	rewriteMaterializedChat := filepath.Join(root, "project-0", "chats",
+		"2026-07-15T10-00-00.000Z", "chat-messages.json")
+	require.NoError(t, os.WriteFile(rewriteMaterializedChat, []byte(
+		`[{"id":"u1","variant":"user","content":"hi","timestamp":"03:04 PM"},
+        {"id":"u2","variant":"user","content":"there","timestamp":"03:05 PM"}]`,
+	), 0o644))
+	time.Sleep(10 * time.Millisecond)
+	bump := time.Now()
+	require.NoError(t, os.Chtimes(rewriteMaterializedChat, bump, bump))
+	require.Equal(t, 1,
+		engine.SyncAll(context.Background(), nil).Synced,
+		"mutating the materialized chat-messages.json must "+
+			"trigger a reparse via the per-component digest; a "+
+			"zero means Issue 3 is regressing to logical-path "+
+			"hashing where stat would always miss the file")
+	logicalHashAfter, hasLogicalAfter, err := database.GetProviderStatHash(
+		context.Background(), parser.AgentCodebuff, logicalChat,
+	)
+	require.NoError(t, err)
+	require.True(t, hasLogicalAfter)
+	require.NotEqual(t, logicalHash, logicalHashAfter,
+		"post-mutation digest must differ from the pre-mutation "+
+			"digest; equality means the engine is hashing something "+
+			"other than the materialized file (the original Issue 3 "+
+			"regression)")
+}
+
+// TestSyncCodebuffCwdFilteredSourceDoesNotPersistStatHash pins Issue 2
+// at end-to-end behavior: a Codebuff source that the engine parses
+// and discovers but then CWD-filters before write must NOT land its
+// per-component digest in provider_freshness. The staged digest is
+// dropped explicitly in flushPending whenever outcome.written[i] is
+// false, so a CWD-filtered source row (or any row whose session
+// upsert failed) cannot escape the gate and mark an absent session
+// as fresh on the next warm pass. A regression that re-flattens the
+// per-row gate (removes the !outcome.written[i] check, or persists
+// before the session write commits) surfaces here as a non-nil
+// digest for the CWD-filtered source.
+//
+// The asserted invariants are:
+//   - StagedProviderStatHashes() == 1 -- the per-component digest
+//     staging block in applyProviderFilePathPolicies actually ran
+//     for the discovered source. This distinguishes a regression
+//     that drops just the staging block (which would otherwise
+//     silently pass any hasStored==false check via
+//     flushPending's no-op nil skip) from a regression that drops
+//     the whole gate.
+//   - SyncAll returns zero synced -- the source row was
+//     CWD-filtered at the write seam.
+//   - provider_freshness carries no row for the chat path -- the
+//     per-row gate suppressed digest persist despite a non-nil
+//     staged hash.
+func TestSyncCodebuffCwdFilteredSourceDoesNotPersistStatHash(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	database := dbtest.OpenTestDB(t)
+	root, chatPath := createCodebuffSingleSession(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodebuff: {root},
+		},
+		IncludeCwdPrefixes: []string{
+			"/this/prefix/cannot/match/the/seeded/archive",
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+
+	engine.ResetStagedProviderStatHashes()
+	require.Equal(t, 0,
+		engine.SyncAll(context.Background(), nil).Synced,
+		"CWD-prefix mismatch must CWD-filter every discovered "+
+			"source; a non-zero synced count means the test "+
+			"prefix accidentally matches the seeded archive")
+	require.Equal(t, int64(1), engine.StagedProviderStatHashes(),
+		"the per-component digest staging block must have "+
+			"run once for the discovered source even though "+
+			"the CWD filter rejects its session write; "+
+			"a zero here means applyProviderFilePathPolicies "+
+			"dropped its staging call and the hasStored "+
+			"assertion below pins nothing about the gate")
+	_, hasStored, err := database.GetProviderStatHash(
+		context.Background(), parser.AgentCodebuff, chatPath,
+	)
+	require.NoError(t, err)
+	require.False(t, hasStored,
+		"provider_freshness must NOT be populated when the "+
+			"source row was CWD-filtered despite a non-nil "+
+			"staged digest; a non-nil row here means the "+
+			"per-row gate that suppresses digest persist "+
+			"(Issue 2) regressed")
+}
+
+// TestSyncCodebuffTombstoneClearsProviderStatHash pins Issue 3 at
+// end-to-end behavior: when a Codebuff source is removed from
+// disk and reconciliation tombstones the archived row, the
+// engine must drop the provider_freshness row in addition to
+// the session-source-ownership rows. Without that, a future
+// byte-identical restoration of the directory would falsely be
+// considered fresh by the digest gate (Issue 1) and the
+// tombstoned session could not be revived. A regression that
+// leaves the side-table intact surfaces here as a non-nil
+// provider_freshness row after the reconcile-driven tombstone.
+//
+// ReconcileProviderRoots is the production-realistic trigger for
+// tombstoneMissingWatchSourcesForAgentLocked: it iterates the
+// archived ownership records for the agent's roots, checks each
+// against the filesystem, and routes any provably-missing source
+// through tombstoneSessionSourceOwnership. SyncPathsContext has
+// the same end-of-pass tombstone path but with single-file
+// granularity and the remove-event filter that drops missing
+// non-persistent sources — which means a SyncPathsContext test
+// would never reach the tombstone, only mark the source via the
+// in-memory skip cache.
+func TestSyncCodebuffTombstoneClearsProviderStatHash(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	database := dbtest.OpenTestDB(t)
+	root, chatPath := createCodebuffSingleSession(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodebuff: {root},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+
+	require.Equal(t, 1,
+		engine.SyncAll(context.Background(), nil).Synced,
+		"cold sync must parse the seeded Codebuff session")
+	_, hasBefore, err := database.GetProviderStatHash(
+		context.Background(), parser.AgentCodebuff, chatPath,
+	)
+	require.NoError(t, err)
+	require.True(t, hasBefore,
+		"a successful cold sync must populate provider_freshness "+
+			"as the precondition for the tombstone clear")
+
+	// Remove the entire session directory so reconcile's lstat check
+	// sees a fully missing source. Reconcile iterates archived
+	// ownership, calls lstat on each, and tombstones any source that
+	// is gone without container fallback.
+	require.NoError(t, os.RemoveAll(filepath.Dir(chatPath)),
+		"deleting the session directory must succeed; partial "+
+			"deletions leave companion files for the engine to "+
+			"still consider the source present")
+
+	_, _, err = engine.ReconcileWatchRootsWithStats(
+		context.Background(), []string{root}, true,
+	)
+	require.NoError(t, err,
+		"reconcile must complete; an error here would mask whether "+
+			"the tombstone path was actually reached")
+
+	// Sentinel: confirm the tombstone actually fired by ensuring the
+	// archived session row is soft-deleted. GetSession filters out
+	// rows whose deleted_at IS NOT NULL, so a tombstoned row returns
+	// (nil, nil). Without this assertion the test could pass for the
+	// wrong reason if reconcile's owner-page lookup missed the
+	// archived record and tombstoneSessionSourceOwnership never ran.
+	const sessionID = "codebuff:project-0:2026-07-15T10-00-00.000Z"
+	sess, err := database.GetSession(context.Background(), sessionID)
+	require.NoError(t, err)
+	require.Nil(t, sess,
+		"the archived session row must be soft-deleted after a "+
+			"missing-source reconcile; a non-nil sess means "+
+			"tombstoneSessionSourceOwnership never reached "+
+			"SoftDeleteSessionSourceOwnership, so the provider_freshness "+
+			"assertion below would pin nothing about Issue 3")
+
+	_, hasAfter, err := database.GetProviderStatHash(
+		context.Background(), parser.AgentCodebuff, chatPath,
+	)
+	require.NoError(t, err)
+	require.False(t, hasAfter,
+		"tombstoning must clear provider_freshness; a non-nil row "+
+			"after this means Issue 3 regressed and a future "+
+			"byte-identical restore would falsely mark the source as "+
+			"fresh")
+}
+
+// TestSyncCodebuffColdStartForcesFingerprintUntilStamped pins Issue 4a:
+// when provider_freshness carries no row for a discovered Codebuff
+// source (cold-start before the column is populated, or the
+// post-tombstone state), the freshness gate must force a real
+// fingerprint instead of falling through to the legacy size/max-mtime
+// composite. The composite would short-circuit a coincidental
+// size/mtime match and leave provider_freshness permanently empty,
+// so the per-component gate never engages and a subsequent real
+// content change could go undetected. After a forced fingerprint
+// the staging block stamps the digest, so the warm sync must
+// repopulate the row.
+func TestSyncCodebuffColdStartForcesFingerprintUntilStamped(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	database := dbtest.OpenTestDB(t)
+	root, chatPath := createCodebuffSingleSession(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodebuff: {root},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+
+	require.Equal(t, 1,
+		engine.SyncAll(context.Background(), nil).Synced,
+		"cold sync must parse the seeded session")
+	_, hasBefore, err := database.GetProviderStatHash(
+		context.Background(), parser.AgentCodebuff, chatPath,
+	)
+	require.NoError(t, err)
+	require.True(t, hasBefore,
+		"first sync must populate provider_freshness as the "+
+			"precondition to clearing it post-cold-warm")
+
+	// Manual delete simulates the post-tombstone / cold-warm
+	// transition. A correct implementation forces provider.Fingerprint
+	// on the next SyncAll because the freshness gate sees !hasStored;
+	// the fingerprint is then verified against the existing session row
+	// and the DB-confirmed unchanged skip (providerSourceUnchangedInDB)
+	// re-stamps the digest via stampProviderStatHashForConfirmedSource.
+	// No digest may be persisted before fingerprinting, parsing, or
+	// writing succeeds, so the re-stamp must ride on that confirmed
+	// skip rather than a pre-parse cold-stamp.
+	require.NoError(t, database.DeleteProviderStatHash(
+		context.Background(), parser.AgentCodebuff, chatPath,
+	))
+	_, hasCleared, err := database.GetProviderStatHash(
+		context.Background(), parser.AgentCodebuff, chatPath,
+	)
+	require.NoError(t, err)
+	require.False(t, hasCleared,
+		"DeleteProviderStatHash must take effect so the cold-warm "+
+			"path is exercised next")
+
+	engine.SyncAll(context.Background(), nil)
+
+	_, hasAfter, err := database.GetProviderStatHash(
+		context.Background(), parser.AgentCodebuff, chatPath,
+	)
+	require.NoError(t, err)
+	require.True(t, hasAfter,
+		"a warm SyncAll with provider_freshness cleared must "+
+			"re-stamp the digest; a missing row here means the "+
+			"per-component gate fell through to the legacy "+
+			"size/mtime composite and the cold-start branch was "+
+			"never forced through provider.Fingerprint")
+}
+
+// TestSyncCodebuffSameSizeSameMtimeRewriteIsDetected pins the
+// roborev-medium finding: the provider_freshness digest folds in ctime, so a
+// same-size companion rewrite that preserves (or coarse-grains) mtime still
+// changes the digest and forces provider.Fingerprint, whose SHA-256 content
+// hash then detects the rewrite. The old (size, mtime)-only digest would
+// match and short-circuit the source, leaving classification, costs, or
+// metadata stale despite FingerprintHashRequiredForFreshness.
+func TestSyncCodebuffSameSizeSameMtimeRewriteIsDetected(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	database := dbtest.OpenTestDB(t)
+	root, chatPath := createCodebuffSingleSession(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodebuff: {root},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+
+	require.Equal(t, 1,
+		engine.SyncAll(context.Background(), nil).Synced,
+		"cold sync must parse the seeded Codebuff session")
+
+	// Digest-level pin. Rewrite run-state.json with byte-identical length
+	// but different content, then restore its mtime so only ctime (and
+	// content) change. A digest over (size, mtime) alone would be unchanged;
+	// the ctime term must move it.
+	dir := filepath.Dir(chatPath)
+	runStatePath := filepath.Join(dir, "run-state.json")
+	original, err := os.ReadFile(runStatePath)
+	require.NoError(t, err)
+	info, err := os.Stat(runStatePath)
+	require.NoError(t, err)
+	originalMtime := info.ModTime()
+
+	hasher := engine.ProviderStatHasher(parser.AgentCodebuff)
+	require.NotNil(t, hasher,
+		"Codebuff must register a MultiFileStatHasher")
+	digestBefore := hasher.ComputeMultiFileStatHash(chatPath)
+	require.NotZero(t, digestBefore)
+
+	replacement := bytes.Replace(
+		original,
+		[]byte("base2-free-deepseek"),
+		[]byte("base3-free-deepseek"),
+		1,
+	)
+	require.Equal(t, len(original), len(replacement),
+		"the rewrite must preserve byte length so only ctime "+
+			"distinguishes the new content")
+	require.NotEqual(t, original, replacement,
+		"the rewrite must change content so the fingerprint hash "+
+			"can detect it")
+
+	time.Sleep(10 * time.Millisecond) // distinct ctime tick across platforms
+	require.NoError(t, os.WriteFile(runStatePath, replacement, 0o644))
+	require.NoError(t, os.Chtimes(runStatePath, originalMtime, originalMtime))
+
+	digestAfter := hasher.ComputeMultiFileStatHash(chatPath)
+	assert.NotEqual(t, digestBefore, digestAfter,
+		"the ctime term must fold into the digest so a same-size, "+
+			"mtime-preserved rewrite is not invisible to the freshness gate")
+
+	// End-to-end pin: the digest mismatch forces provider.Fingerprint,
+	// whose content hash detects the rewrite, so the session must be
+	// reparsed and rewritten rather than skipped. This is the load-bearing
+	// assertion — the third-sync check below is only meaningful after the
+	// rewrite was actually synced, so a regression here surfaces as a single
+	// clean failure. Note the ctime term comes from codexIndexChangeTime,
+	// which returns non-zero only on darwin/linux/windows (the project's CI
+	// matrix); on other platforms the digest cannot move and this test would
+	// not be representative.
+	second := engine.SyncAll(context.Background(), nil)
+	require.Equal(t, 1, second.Synced,
+		"a same-size, mtime-preserved companion rewrite must be "+
+			"detected and re-synced; a skip means the freshness gate "+
+			"never re-verified the content")
+
+	// The re-stamped digest must now short-circuit the unchanged source.
+	third := engine.SyncAll(context.Background(), nil)
+	assert.Zero(t, third.Synced,
+		"after the rewrite is synced the digest must match again and "+
+			"the source must short-circuit")
+}
+
+// TestSyncCodebuffIncrementalCutoffDetectsCtimeDrift pins the
+// roborev-medium finding: discoveredFileEffectiveMtime for Codebuff
+// must include ctime in the cutoff signal. A same-size companion
+// rewrite with restored mtime changes ctime but not mtime, so an
+// mtime-only cutoff would drop the source before the full freshness
+// check (providerSourceFreshBeforeFingerprint) can detect the rewrite.
+// The ctime-inclusive cutoff must advance past the SyncAllSince
+// parameter so the source reaches the per-component digest gate, which
+// then forces a full fingerprint and detects the content drift.
+func TestSyncCodebuffIncrementalCutoffDetectsCtimeDrift(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	database := dbtest.OpenTestDB(t)
+	root, chatPath := createCodebuffSingleSession(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodebuff: {root},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+
+	require.Equal(t, 1,
+		engine.SyncAll(context.Background(), nil).Synced,
+		"cold sync must parse the seeded Codebuff session")
+
+	// Confirm the warm pass skips the unchanged source.
+	require.Equal(t, 0,
+		engine.SyncAll(context.Background(), nil).Synced,
+		"warm SyncAll must skip the unchanged source")
+
+	// Rewrite run-state.json with byte-identical length but different
+	// content, then restore its mtime so only ctime distinguishes the
+	// new content. An mtime-only cutoff (the old behavior) would drop
+	// this source because max(mtime) is unchanged.
+	dir := filepath.Dir(chatPath)
+	runStatePath := filepath.Join(dir, "run-state.json")
+	original, err := os.ReadFile(runStatePath)
+	require.NoError(t, err)
+	info, err := os.Stat(runStatePath)
+	require.NoError(t, err)
+	originalMtime := info.ModTime()
+
+	replacement := bytes.Replace(
+		original,
+		[]byte("base2-free-deepseek"),
+		[]byte("base3-free-deepseek"),
+		1,
+	)
+	require.Equal(t, len(original), len(replacement),
+		"rewrite must preserve byte length so mtime is the only "+
+			"pre-ctime signal")
+
+	time.Sleep(10 * time.Millisecond)
+	// Use a cutoff anchored between the cold-sync mtimes and the
+	// rewrite ctime: the ctime-inclusive cutoff must see the source
+	// as fresh even though mtime alone would not.
+	cutoff := time.Now()
+	time.Sleep(10 * time.Millisecond)
+	require.NoError(t, os.WriteFile(runStatePath, replacement, 0o644))
+	require.NoError(t, os.Chtimes(runStatePath, originalMtime, originalMtime))
+
+	stats := engine.SyncAllSince(context.Background(), cutoff, nil)
+	require.Equal(t, 1, stats.Synced,
+		"SyncAllSince must pick up a same-size, mtime-preserved "+
+			"companion rewrite via the ctime-inclusive cutoff; "+
+			"a zero here means the cutoff saw only max(mtime) and "+
+			"dropped the source before the fingerprint could detect it")
+
+	// The re-stamped digest must then short-circuit the unchanged source.
+	warm := engine.SyncAll(context.Background(), nil)
+	assert.Zero(t, warm.Synced,
+		"after the rewrite is synced the digest must match again")
+}
+
+// TestSyncCodebuffSingleSessionWritesProviderStatHash pins Issue 4b:
+// a single-session sync (SyncSingleSession) that writes through
+// writeSessionFull must also persist the staged
+// res.providerStatHash, mirroring the per-row persist gate in
+// flushPending. Without this, single-session syncs leave
+// provider_freshness empty for Codebuff/Freebuff and the next
+// warm pass short-circuits on a coincidental size/mtime match
+// before any digest is stamped. A regression that drops the
+// per-row gate for the single-session path surfaces here as a
+// missing digest after SyncSingleSession.
+func TestSyncCodebuffSingleSessionWritesProviderStatHash(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	database := dbtest.OpenTestDB(t)
+	root, chatPath := createCodebuffSingleSession(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodebuff: {root},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+
+	require.NoError(t,
+		engine.SyncSingleSession(
+			"codebuff:project-0:2026-07-15T10-00-00.000Z",
+		),
+		"a single-session sync on a live source must commit "+
+			"without errors; ErrOrNil semantics here ensure the "+
+			"test only exercises the digest-persist gate")
+
+	_, has, err := database.GetProviderStatHash(
+		context.Background(), parser.AgentCodebuff, chatPath,
+	)
+	require.NoError(t, err)
+	require.True(t, has,
+		"single-session SyncAll must persist provider_freshness; "+
+			"a missing row here means the per-row persist gate "+
+			"in writeSessionFull is missing (Issue 4) and the "+
+			"per-component digest gate never engages on the next "+
+			"warm pass")
+}
+
+// TestSyncEngineProviderStatHashersRegistrationIsCapabilityGated pins the
+// side-effect of adding Source.MultiFileStatHash capability gating to
+// buildProviderStatHashers: every SourceSet-wrapped agent unconditionally
+// satisfies parser.MultiFileStatHasher via the SourceSetProvider
+// forwarding method, so the engine must NOT register a hasher unless the
+// provider explicitly declares the multi-file capability. Without the
+// gate every Claude/Codex/RooCode/KiloLegacy/etc. provider would land in
+// providerStatHashers as a 0-returning stub, store a 0 digest on first
+// cold sync, then short-circuit every warm pass on a 0==0 match --
+// every non-Codebuff SourceSet agent's parse left stale.
+//
+// The test does not depend on any Codebuff fixture; constructing an
+// engine with the default registry must produce a non-nil entry only
+// for Codebuff (and any future agent that opts in via the capability).
+func TestSyncEngineProviderStatHashersRegistrationIsCapabilityGated(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	database := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		// No AgentDirs: the engine is registered with the default
+		// factory map but discovers nothing; that is sufficient to
+		// populate providerStatHashers at construction time.
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+
+	require.NotNil(t,
+		engine.ProviderStatHasher(parser.AgentCodebuff),
+		"Codebuff declares Source.MultiFileStatHash=Supported and "+
+			"must land in providerStatHashers; a nil here means the "+
+			"capability gate is missing or codebuffProviderCapabilities "+
+			"lost the override")
+	for _, agent := range []parser.AgentType{
+		parser.AgentClaude,
+		parser.AgentCodex,
+		parser.AgentRooCode,
+		parser.AgentKiloLegacy,
+		parser.AgentGemini,
+		parser.AgentCopilot,
+	} {
+		assert.Nil(t, engine.ProviderStatHasher(agent),
+			"%s is a single-file (non-multi-file) agent and must "+
+				"NOT be registered in providerStatHashers; a non-nil "+
+				"entry means the SourceSetProvider forwarding method "+
+				"is registering 0-returning stubs that would falsely "+
+				"short-circuit warm passes on 0==0 digest matches",
+			agent)
+	}
+}
+
+// TestSourceMtimeCodebuffUsesPerFileHash pins the roborev-medium
+// regression on ab050f8: SourceMtime for Codebuff sessions must
+// detect (a) a same-size companion-file rewrite whose mtime stays
+// below the existing max, (b) offsetting size changes that keep the
+// total size unchanged, and (c) a missing companion file's later
+// appearance. The freshness gate reduces chat-messages.json +
+// run-state.json + chat-meta.json to a single int64 via an FNV-1a
+// hash of each (size, mtime) pair so any per-file change in size or
+// mtime is detected. A max-mtime-only reduction would miss (a) and
+// (b); a sum-of-sizes reduction would miss (a). The watcher polls
+// SourceMtime continuously, so the lookup must stay stat-only.
+func TestSourceMtimeCodebuffUsesPerFileHash(t *testing.T) {
+	database := dbtest.OpenTestDB(t)
+	root := t.TempDir()
+	engine := sync.NewEngine(database, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodebuff: {root},
+		},
+		Machine: "local",
+	})
+
+	// Codebuff session IDs are codebuff:<project>:<ts> and the
+	// corresponding on-disk layout is root/<project>/chats/<ts>/,
+	// mirroring createCodebuffArchive. Using a single-component
+	// rawID would miss FindSourceFile's expected layout.
+	project := "test-project"
+	ts := "2026-07-15T10-00-00.000Z"
+	rawID := project + ":" + ts
+	dir := filepath.Join(root, project, "chats", ts)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+
+	chatPath := filepath.Join(dir, "chat-messages.json")
+	runStatePath := filepath.Join(dir, "run-state.json")
+	chatMetaPath := filepath.Join(dir, "chat-meta.json")
+
+	// Fixed contents so we can rewrite a sibling with the *same byte
+	// length* but a new mtime. The FNV-1a hash includes size, so a
+	// pure same-size, same-mtime rewrite is the only input that would
+	// legitimately leave SourceMtime unchanged.
+	const chatBody = `[{"id":"u1","variant":"user","content":"hello","timestamp":"03:04 PM"}]`
+	const runStateBody = `{"sessionState":{"mainAgentState":{"agentType":"base2-free-deepseek"}}}`
+	const chatMetaBody = `{"messageCount":1,"firstPrompt":"hello","messagesSize":50}`
+	require.NoError(t, os.WriteFile(chatPath, []byte(chatBody), 0o644))
+	require.NoError(t, os.WriteFile(runStatePath, []byte(runStateBody), 0o644))
+	require.NoError(t, os.WriteFile(chatMetaPath, []byte(chatMetaBody), 0o644))
+
+	// Stagger mtimes so chat-messages.json holds the max; the other
+	// two files are below it. Rewriting run-state.json with a new
+	// mtime that is still below the max would be invisible to the
+	// old max-mtime reduction.
+	chatTime := time.Date(2026, time.July, 4, 12, 0, 0, 0, time.UTC)
+	runStateTime := chatTime.Add(-5 * time.Minute)
+	chatMetaTime := chatTime.Add(-10 * time.Minute)
+	require.NoError(t, os.Chtimes(chatPath, chatTime, chatTime))
+	require.NoError(t, os.Chtimes(runStatePath, runStateTime, runStateTime))
+	require.NoError(t, os.Chtimes(chatMetaPath, chatMetaTime, chatMetaTime))
+
+	baseline := engine.SourceMtime("codebuff:" + rawID)
+	require.NotZero(t, baseline,
+		"baseline SourceMtime must be non-zero for a live Codebuff session")
+
+	// (a) Same-size companion-file rewrite with a *new* mtime that
+	// stays below the existing max. The old max-mtime reduction
+	// would return the same value; the per-file hash must change.
+	time.Sleep(10 * time.Millisecond)
+	require.NoError(t, os.WriteFile(runStatePath, []byte(runStateBody), 0o644))
+	subMaxTime := chatTime.Add(-1 * time.Minute) // still below chatTime
+	require.NoError(t, os.Chtimes(runStatePath, subMaxTime, subMaxTime))
+	afterSubMaxRewrite := engine.SourceMtime("codebuff:" + rawID)
+	assert.NotEqual(t, baseline, afterSubMaxRewrite,
+		"a same-size run-state.json rewrite with a sub-max mtime "+
+			"must change SourceMtime; equal values pin the regression "+
+			"where SourceMtime reduced to max mtime across the three files")
+
+	// (b) Offsetting size changes: grow chat-messages.json by 10
+	// bytes and shrink chat-meta.json by 10 bytes. The total size
+	// delta is zero, but per-file stats must still trigger a hash
+	// change. The old code never inspected sizes, so a per-file
+	// size shift would have been invisible.
+	time.Sleep(10 * time.Millisecond)
+	require.NoError(t, os.WriteFile(chatPath, []byte(chatBody+"          "), 0o644))
+	require.NoError(t, os.WriteFile(chatMetaPath, []byte(chatMetaBody[:len(chatMetaBody)-10]), 0o644))
+	require.NoError(t, os.Chtimes(chatPath, chatTime, chatTime))
+	require.NoError(t, os.Chtimes(chatMetaPath, chatMetaTime, chatMetaTime))
+	afterOffsettingSize := engine.SourceMtime("codebuff:" + rawID)
+	assert.NotEqual(t, afterSubMaxRewrite, afterOffsettingSize,
+		"offsetting per-file size changes that keep the sum unchanged "+
+			"must still change SourceMtime; equal values pin the "+
+			"regression where freshness ignored per-file size")
+
+	// (c) A missing companion file's later appearance. Delete
+	// chat-meta.json, capture SourceMtime, recreate it with new
+	// content, and capture again. The new appearance must change
+	// the hash because the missing-file block is a fixed zero
+	// sequence distinct from any real (size, mtime) pair.
+	require.NoError(t, os.Remove(chatMetaPath))
+	afterMissingMeta := engine.SourceMtime("codebuff:" + rawID)
+	assert.NotEqual(t, afterOffsettingSize, afterMissingMeta,
+		"a deleted chat-meta.json must change SourceMtime; equal "+
+			"values mean the missing-companion branch is hashed the "+
+			"same as a present one")
+	time.Sleep(10 * time.Millisecond)
+	require.NoError(t, os.WriteFile(chatMetaPath, []byte(chatMetaBody), 0o644))
+	recreatedTime := chatTime.Add(2 * time.Minute)
+	require.NoError(t, os.Chtimes(chatMetaPath, recreatedTime, recreatedTime))
+	afterRecreatedMeta := engine.SourceMtime("codebuff:" + rawID)
+	assert.NotEqual(t, afterMissingMeta, afterRecreatedMeta,
+		"a recreated chat-meta.json with a new mtime must change "+
+			"SourceMtime back to a value distinct from the missing-file state")
+}

--- a/internal/sync/codebuff_write_failure_test.go
+++ b/internal/sync/codebuff_write_failure_test.go
@@ -1,0 +1,122 @@
+package sync
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+// seedCodebuffSingleSession mirrors createCodebuffSingleSession (which lives
+// in the external sync_test package and cannot be reused here) so this
+// internal-package test can exercise the unexported writeBatchOverride seam.
+// It creates exactly one Codebuff session at
+// <root>/project-0/chats/2026-07-15T10-00-00.000Z/ and returns the archive
+// root plus the canonical chat-messages.json path.
+func seedCodebuffSingleSession(t *testing.T) (root, chatPath string) {
+	t.Helper()
+	root = t.TempDir()
+	dir := filepath.Join(root, "project-0", "chats", "2026-07-15T10-00-00.000Z")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "chat-messages.json"),
+		[]byte(`[
+		{"id":"user-1","variant":"user","content":"Single source","timestamp":"03:04 PM"}
+	]`), 0o644))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "run-state.json"),
+		[]byte(`{
+		"sessionState": {
+			"mainAgentState": {"agentType": "base2-free-deepseek"}
+		}
+	}`), 0o644))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "chat-meta.json"),
+		[]byte(`{
+		"messageCount": 1,
+		"firstPrompt": "Single source",
+		"messagesSize": 50
+	}`), 0o644))
+	return root, filepath.Join(dir, "chat-messages.json")
+}
+
+// TestSyncCodebuffWriteFailureDoesNotPersistStatHash pins the roborev-high
+// freshness finding: the provider_freshness digest must never be persisted
+// before an outcome the engine can trust. A transient archive-write failure
+// after discovery and parse — but before any session row commits — must leave
+// no digest behind; a matching digest stamped pre-write would make every
+// later sync short-circuit the source and permanently suppress the retry.
+// The retry must then succeed through the normal path and stamp the digest
+// only via the successful-write flush gate.
+//
+// The seeded session is Freebuff-classified: seedCodebuffSingleSession writes
+// run-state.json with agentType "base2-free-deepseek", which the parser maps
+// to AgentFreebuff, so the session row is stored under agent=freebuff (as a
+// probe verified). Freebuff shares the Codebuff provider and hasher, and the
+// side-table digest is only ever stamped under the canonical AgentCodebuff
+// key (canonicalProviderStatHashAgent), so this single test covers the
+// write-failure invariant for both agent labels — a separate Freebuff test
+// would exercise identical code paths with no additional coverage.
+func TestSyncCodebuffWriteFailureDoesNotPersistStatHash(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	database := dbtest.OpenTestDB(t)
+	root, chatPath := seedCodebuffSingleSession(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCodebuff: {root},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+
+	// Inject a transient archive-write failure: discovery and parse run
+	// normally, but every pending row fails to commit (written=0, failed=n),
+	// so outcome.written[i] stays false and the flush digest gate skips the
+	// recordProviderStatHash persist for every row in the batch.
+	engine.writeBatchOverride = func(
+		batch []pendingWrite, _ syncWriteMode, _ bool,
+	) (int, int, int, int) {
+		return 0, 0, len(batch), 0
+	}
+
+	failed := engine.SyncAll(context.Background(), nil)
+	require.Equal(t, 1, failed.Failed,
+		"the injected archive write must fail and be counted as failed")
+	assert.Zero(t, failed.Synced,
+		"no session may be reported synced when the write failed")
+
+	_, has, err := database.GetProviderStatHash(
+		context.Background(), parser.AgentCodebuff, chatPath,
+	)
+	require.NoError(t, err)
+	require.False(t, has,
+		"a failed write must not persist provider_freshness; a matching "+
+			"digest stamped before a confirmed outcome would suppress "+
+			"every later retry of this source")
+
+	// Clear the injected failure and re-sync. The retry must not be
+	// suppressed — the session must now parse and commit, and the
+	// successful-write flush gate must stamp the digest.
+	engine.writeBatchOverride = nil
+	retry := engine.SyncAll(context.Background(), nil)
+	require.Equal(t, 1, retry.Synced,
+		"the retry after a transient write failure must parse and store "+
+			"the session; a skip here means a digest was stamped before "+
+			"the write outcome was confirmed")
+
+	_, hasAfter, err := database.GetProviderStatHash(
+		context.Background(), parser.AgentCodebuff, chatPath,
+	)
+	require.NoError(t, err)
+	require.True(t, hasAfter,
+		"the successful retry write must persist provider_freshness")
+}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -822,9 +822,14 @@ func providerFactoryMap(
 // be registered with a 0-returning stub, and a warm pass would
 // short-circuit its parse on a 0==0 digest match between
 // ComputeMultiFileStatHash(path) and the previously-stored 0. The
-// probe must be side-effect-free: a fresh provider per agent is
-// allocated only for the type assertion, and the probe is discarded
-// immediately.
+// probe construction must be side-effect-free: a fresh provider is
+// allocated per agent with an empty ProviderConfig (no roots, no
+// machine), and a probe that passes both gates is retained for the
+// engine's lifetime as the cached hasher. Retaining a config-less
+// instance is safe only because ComputeMultiFileStatHash is stateless
+// — a pure function of its chatPath argument and the filesystem — so
+// implementations must not depend on provider construction state such
+// as Roots or Machine.
 //
 // Freebuff sessions intentionally route through this single
 // AgentCodebuff entry: AgentFreebuff is a recognized AgentType string
@@ -7760,12 +7765,16 @@ func (e *Engine) collectAndBatch(
 			// rows in the same batch still get their digests
 			// stamped; a pendingStatHash source whose whole session
 			// row committed is exactly the invariant the side-table
-			// needs to recognize on the next warm pass.
+			// needs to recognize on the next warm pass. A pending
+			// row with no matching written entry fails closed:
+			// without a per-row success flag the write cannot be
+			// confirmed, and an unconfirmed digest persist could
+			// mark an absent session as fresh forever.
 			for i, pw := range pending {
 				if pw.providerStatHash == nil {
 					continue
 				}
-				if i < len(outcome.written) && !outcome.written[i] {
+				if i >= len(outcome.written) || !outcome.written[i] {
 					continue
 				}
 				e.recordProviderStatHash(ctx, *pw.providerStatHash)
@@ -10524,13 +10533,18 @@ func (e *Engine) providerSourceFreshBeforeFingerprint(
 		// bytes, and a sibling-only change still changes the composite
 		// and falls through to the full fingerprint.
 		//
-		// Note: the per-component digest above (Issue 1) handles the
-		// warm path once provider_freshness has at least one row. This
-		// case remains the cold-start fallback for the very first
-		// warm sync after the column is introduced, when no digest
-		// exists yet and the legacy size/mtime composite must still
-		// short-circuit unchanged sources so the digest can be
-		// stamped after the cold parse.
+		// Note: whenever a MultiFileStatHasher is registered for this
+		// agent — always, in the production configuration — the digest
+		// block above returns before this switch: its !hasStored arm
+		// forces provider.Fingerprint on cold start, and the loop then
+		// closes through providerSourceUnchangedInDB →
+		// stampProviderStatHashForConfirmedSource (or a successful
+		// write's flushPending). This arm is therefore reachable only
+		// for a provider that declares Source.MultiFileStatHash=
+		// Supported while its constructed instance fails the
+		// MultiFileStatHasher assertion in buildProviderStatHashers.
+		// It is kept as a defensive fallback for that
+		// hasher-failed-to-register case, not as a production path.
 		dir := filepath.Dir(path)
 		size := info.Size()
 		mtime := info.ModTime().UnixNano()
@@ -14811,6 +14825,12 @@ func (e *Engine) SourceMtime(sessionID string) int64 {
 		} else {
 			writeTuple(0, 0, 0)
 		}
+		// Despite SourceMtime's name and int64 type, this value is an
+		// opaque change token, not a timestamp: reinterpreting the
+		// FNV-1a sum can go negative and is non-monotonic across
+		// changes. It is valid only for equality and zero/missing
+		// comparison — never for ordering or arithmetic against real
+		// mtimes.
 		return int64(h.Sum64())
 	}
 	if def.Type == parser.AgentKiloLegacy {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -2,8 +2,10 @@ package sync
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"log"
 	"maps"
 	"os"
@@ -11,6 +13,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"sort"
 	"strconv"
 	"strings"
 	gosync "sync"
@@ -338,12 +341,20 @@ type Engine struct {
 	// idPrefix and pathRewriter support remote sync:
 	// prefix all session IDs to avoid collisions, rewrite
 	// temp paths to "host:/remote/path" form.
-	ephemeral               bool
-	idPrefix                string
-	pathRewriter            func(string) string
-	emitter                 Emitter
-	providerFactories       map[parser.AgentType]parser.ProviderFactory
-	providerMigrationModes  map[parser.AgentType]parser.ProviderMigrationMode
+	ephemeral              bool
+	idPrefix               string
+	pathRewriter           func(string) string
+	emitter                Emitter
+	providerFactories      map[parser.AgentType]parser.ProviderFactory
+	providerMigrationModes map[parser.AgentType]parser.ProviderMigrationMode
+	// providerStatHashers caches the optional MultiFileStatHasher
+	// implementations keyed by AgentType. Populated at engine
+	// construction by type-asserting each constructed provider; nil
+	// entries indicate the provider does not implement
+	// MultiFileStatHasher (single-file agents and providers without a
+	// multi-file layout take the existing stat-only composite path).
+	providerStatHashers map[parser.AgentType]parser.MultiFileStatHasher
+
 	providerWatchRootsMu    gosync.Mutex
 	providerWatchRoots      map[parser.AgentType][]parser.WatchRoot
 	projectIdentityMu       gosync.Mutex
@@ -362,6 +373,19 @@ type Engine struct {
 	// writeBatchOverride is a test seam for exercising reconciliation archive
 	// write failures after discovery and parse have succeeded.
 	writeBatchOverride func([]pendingWrite, syncWriteMode, bool) (int, int, int, int)
+	// stagedProviderStatHashes is a test observability seam that
+	// counts every successful staging of pr.providerStatHash in
+	// applyProviderFilePathPolicies. Tests assert against a
+	// post-sync snapshot via ResetStagedProviderStatHashes /
+	// StagedProviderStatHashes to verify the per-component digest
+	// staging block actually ran, distinct from proving the parse
+	// path ran at all (which is the counting wrapper's job). Without
+	// this counter a regression that drops the staging call while
+	// keeping provider.Fingerprint intact would still satisfy any
+	// hasStored==false assertion because flushPending's nil check
+	// is a no-op on absent digests. atomic.Int64 is a zero-value
+	// type so the field does not need explicit initialization.
+	stagedProviderStatHashes atomic.Int64
 	// sourceAttributionLookupOverride observes or replaces bounded source
 	// attribution queries in sync tests.
 	sourceAttributionLookupOverride func(
@@ -511,6 +535,46 @@ const codexExecMigrationKey = "codex_exec_legacy_migration_v1"
 // upgrading to the non-cacheable read-error behavior.
 const visualStudioCopilotSkipMigrationKey = "visualstudio_copilot_skip_migration_v1"
 
+// ProviderStatHasher returns the cached MultiFileStatHasher for the
+// given agent type, or nil when the agent does not declare a
+// multi-file on-disk layout. Tests use this to confirm the
+// per-component freshness gate is wired only for agents whose
+// Source.MultiFileStatHash capability is supported, and absent
+// otherwise so a 0==0 digest match does not short-circuit the
+// legacy size/mtime freshness path for unrelated agents.
+func (e *Engine) ProviderStatHasher(agent parser.AgentType) parser.MultiFileStatHasher {
+	if e == nil {
+		return nil
+	}
+	return e.providerStatHashers[agent]
+}
+
+// StagedProviderStatHashes returns the cumulative number of per-source
+// process results whose applyProviderFilePathPolicies step attached a
+// non-nil res.providerStatHash. Tests reset the counter via
+// ResetStagedProviderStatHashes, run a sync, and assert on the
+// post-sync value to verify the per-component digest staging block
+// actually ran. The counter is cumulative across the engine's
+// lifetime; tests reset it explicitly rather than relying on a
+// per-pass reset so production code does not pay for an unnecessary
+// zero on every SyncAll entry.
+func (e *Engine) StagedProviderStatHashes() int64 {
+	if e == nil {
+		return 0
+	}
+	return e.stagedProviderStatHashes.Load()
+}
+
+// ResetStagedProviderStatHashes zeroes the test observability counter
+// so a single sync pass's staging events can be read as a clean
+// snapshot via StagedProviderStatHashes.
+func (e *Engine) ResetStagedProviderStatHashes() {
+	if e == nil {
+		return
+	}
+	e.stagedProviderStatHashes.Store(0)
+}
+
 // NewEngine creates a sync engine. It pre-populates the
 // in-memory skip cache from the database so that files
 // skipped in a prior run are not re-parsed on startup, and
@@ -567,6 +631,8 @@ func NewEngine(
 		emitter:                 cfg.Emitter,
 		providerFactories:       providerFactoryMap(providerFactories),
 		providerMigrationModes:  providerModes,
+		providerStatHashers: buildProviderStatHashers(
+			providerFactoryMap(providerFactories)),
 		providerWatchRoots:      make(map[parser.AgentType][]parser.WatchRoot),
 		projectIdentityCache:    make(map[string]projectIdentityCacheEntry),
 		projectIdentityWritten:  make(map[string]struct{}),
@@ -743,6 +809,115 @@ func providerFactoryMap(
 		out[def.Type] = factory
 	}
 	return out
+}
+
+// buildProviderStatHashers constructs probe providers for each factory
+// and caches the MultiFileStatHasher implementations. Because every
+// SourceSet-wrapped provider unconditionally satisfies the
+// MultiFileStatHasher interface (a forwarding method on the wrapper
+// delegates to the inner SourceSet when present and returns 0
+// otherwise), the gate here MUST be the explicit
+// Source.MultiFileStatHash capability declaration: an agent whose
+// inner SourceSet does not own a multi-file layout would otherwise
+// be registered with a 0-returning stub, and a warm pass would
+// short-circuit its parse on a 0==0 digest match between
+// ComputeMultiFileStatHash(path) and the previously-stored 0. The
+// probe must be side-effect-free: a fresh provider per agent is
+// allocated only for the type assertion, and the probe is discarded
+// immediately.
+//
+// Freebuff sessions intentionally route through this single
+// AgentCodebuff entry: AgentFreebuff is a recognized AgentType string
+// for ID-prefix display, but the on-disk Codebuff provider is the
+// sole registration in parser.Registry for both paid Codebuff and
+// free Freebuff transcripts (see types_test.go TestFreebuffNotRegistered).
+// parser.AgentFreebuff therefore never appears as a Registry key
+// and never lands here as a separate hasher entry; Freebuff
+// sessions are parsed by the AgentCodebuff probe and surface in
+// storage with agent=AgentCodebuff, which is the key this map
+// actually uses. Any future change that adds AgentFreebuff as a
+// distinct Registry entry must carry Source.MultiFileStatHash=
+// CapabilitySupported along with it -- otherwise Freebuff sessions
+// will silently fall back to the legacy size/max-mtime composite
+// in providerSourceFreshBeforeFingerprint and the per-component
+// digest gate will under-cover them.
+func buildProviderStatHashers(
+	factories map[parser.AgentType]parser.ProviderFactory,
+) map[parser.AgentType]parser.MultiFileStatHasher {
+	out := make(map[parser.AgentType]parser.MultiFileStatHasher, len(factories))
+	for agent, factory := range factories {
+		probe := factory.NewProvider(parser.ProviderConfig{
+			Machine: "",
+		})
+		if probe.Capabilities().Source.MultiFileStatHash != parser.CapabilitySupported {
+			continue
+		}
+		if h, ok := probe.(parser.MultiFileStatHasher); ok {
+			out[agent] = h
+		}
+	}
+	return out
+}
+
+// pendingProviderStatHash is the staged freshness digest attached to a
+// per-source processResult. The engine stages it during processFile
+// (before any sessions-table write) and only persists it after the
+// matching source's write batch commits successfully, so a CWD-filtered
+// or failed write cannot mark an absent or stale session as fresh.
+//
+// physicalPath is the on-disk chat path the hasher stats (the path that
+// actually exists locally, even when pathRewriter rewrites the stored
+// file_path to a logical "host:/remote/path" for remote imports).
+// targetKey is the cache key the engine uses for both the digest lookup
+// and persistence, so remote-synced sessions hash their materialized
+// file but store the digest under their canonical logical key.
+//
+// digest is the per-component stat snapshot the hasher computed at
+// staging time. Capturing it here closes a TOCTOU window between
+// provider.Fingerprint (which stats and parses a stable file state)
+// and the later flushPending write: if the file changes between the
+// two calls, a re-compute at flushPending time would store the new
+// state under the old parse, falsely pinning the cache against the
+// next warm pass. Persisting the pre-parse digest under the same
+// session row guarantees provider_freshness reflects the file state
+// the write actually committed.
+type pendingProviderStatHash struct {
+	agent        parser.AgentType
+	physicalPath string
+	targetKey    string
+	digest       uint64
+}
+
+// recordProviderStatHash persists the pre-computed per-component stat
+// digest for a source to provider_freshness. The digest is staged in
+// applyProviderFilePathPolicies at the same wall-clock moment the file
+// is stat-ed for the parse, so what is persisted always matches the
+// snapshot the parse saw. Providers without a MultiFileStatHasher
+// implementation carry a zero digest and are silently skipped here:
+// their freshness is owned by the engine's existing skip-cache path,
+// and the staging site does not populate res.providerStatHash for
+// non-multi-file agents. The cache key (targetKey) and the hashed path
+// (physicalPath) are kept distinct so a remote import whose
+// pathRewriter rewrites the stored file_path to a logical
+// "host:/remote/path" still hashes the materialized local file.
+func (e *Engine) recordProviderStatHash(
+	ctx context.Context,
+	hash pendingProviderStatHash,
+) {
+	if hash.digest == 0 {
+		return
+	}
+	if _, ok := e.providerStatHashers[hash.agent]; !ok {
+		return
+	}
+	if err := e.db.UpsertProviderStatHash(
+		ctx, hash.agent, hash.targetKey, hash.digest,
+	); err != nil {
+		log.Printf(
+			"provider_freshness write for %s/%s: %v",
+			hash.agent, hash.targetKey, err,
+		)
+	}
 }
 
 // migrateLegacyCodexExecSkips removes skip cache entries
@@ -1560,6 +1735,14 @@ func providerChangedPathForceParse(
 			providerDeletedPhysicalSQLiteSource(agent, sourcePath)
 	}
 	if mode != parser.ProviderMigrationProviderAuthoritative {
+		return true
+	}
+	// Codebuff changed-path events must always force a fingerprint
+	// comparison. The composite stat-only freshness gate may skip
+	// same-size, same-mtime rewrites, so a concrete changed-path
+	// signal (including direct chat-messages.json events) must always
+	// trigger the full fingerprint path.
+	if agent == parser.AgentCodebuff {
 		return true
 	}
 	if filepath.Clean(sourcePath) != filepath.Clean(eventPath) &&
@@ -3477,10 +3660,18 @@ func (e *Engine) SyncAll(
 	return
 }
 
-// HasActiveSessionSourceBelow checks only the exact configured agent that owns
-// the rename event's logical watch root.
+// HasActiveSessionSourceBelow checks if a path contains active sessions.
+// Freebuff shares the Codebuff provider, so when checking Codebuff,
+// also check Freebuff to catch rename events for Freebuff-only directories.
 func (e *Engine) HasActiveSessionSourceBelow(agent, path string) (bool, error) {
-	return e.db.HasActiveSessionSourceBelow(agent, path)
+	found, err := e.db.HasActiveSessionSourceBelow(agent, path)
+	if err != nil || found {
+		return found, err
+	}
+	if agent == string(parser.AgentCodebuff) {
+		return e.db.HasActiveSessionSourceBelow(string(parser.AgentFreebuff), path)
+	}
+	return false, nil
 }
 
 // ReconcileWatchRoots runs authoritative discovery for a bounded set of watch
@@ -3873,6 +4064,16 @@ func (e *Engine) reconcileWatchRootsStreamedLocked(
 	authoritativeProviders := make(map[parser.AgentType]struct{}, len(completedScopes))
 	for _, completed := range completedScopes {
 		authoritativeProviders[completed.agent] = struct{}{}
+		// Freebuff shares the Codebuff provider. When Codebuff
+		// completes, also mark Freebuff as authoritative so
+		// baseline admission (eligibleReconciliationBaselines) and
+		// cache-write promotion (the write.agent lookup below)
+		// see Freebuff rows even though no Freebuff provider exists
+		// in parser.Registry: a single Codebuff scan covers both
+		// codebuff and freebuff files at the same on-disk roots.
+		if completed.agent == parser.AgentCodebuff {
+			authoritativeProviders[parser.AgentFreebuff] = struct{}{}
+		}
 	}
 	e.beginStreamingSQLiteContainerPass(preContainerStates)
 	e.finishStreamingSQLiteContainerDiscovery()
@@ -4095,13 +4296,27 @@ func (e *Engine) baselineReconciliationCandidates(
 ) error {
 	sources := make([]machineSessionSource, 0, len(candidates))
 	for _, candidate := range candidates {
+		path := e.effectiveSourcePath(candidate.Path)
 		sources = append(sources, machineSessionSource{
 			Machine: candidate.Machine,
 			Source: db.SessionSourcePath{
 				Agent:    string(candidate.Provider),
-				FilePath: e.effectiveSourcePath(candidate.Path),
+				FilePath: path,
 			},
 		})
+		// Freebuff shares the Codebuff provider but sessions are stored
+		// with agent=AgentFreebuff. Replace baselines for both agent
+		// keys so stale Freebuff baselines are cleared when the source
+		// is rejected by CWD filter or other admission checks.
+		if candidate.Provider == parser.AgentCodebuff {
+			sources = append(sources, machineSessionSource{
+				Machine: candidate.Machine,
+				Source: db.SessionSourcePath{
+					Agent:    string(parser.AgentFreebuff),
+					FilePath: path,
+				},
+			})
+		}
 	}
 	var err error
 	sources, admitted, err = e.expandSourceBaselinesByStoredAttribution(
@@ -4925,83 +5140,315 @@ func (e *Engine) tombstoneMissingWatchSourceScopesLocked(
 			if len(ownershipMachines) == 0 {
 				continue
 			}
-			queryIndex := 0
-			var cursor db.SessionSourceCursor
-			for queryIndex < len(ownershipMachines) {
-				ownershipMachine := ownershipMachines[queryIndex]
-				if err := ctx.Err(); err != nil {
-					return deleted, err
-				}
-				page, err := e.db.ListActiveSessionSourceOwnershipScopesPage(
-					ctx, ownershipMachine, string(agent),
-					ownershipScopes, cursor,
-				)
-				if err != nil {
-					return deleted, fmt.Errorf(
-						"list %s watch source ownership: %w", agent, err,
+			// Freebuff shares the Codebuff provider. When processing
+			// Codebuff, also query for Freebuff sessions so they can
+			// be tombstoned.
+			agentStrs := []string{string(agent)}
+			if agent == parser.AgentCodebuff {
+				agentStrs = append(agentStrs, string(parser.AgentFreebuff))
+			}
+			for _, agentStr := range agentStrs {
+				queryIndex := 0
+				var cursor db.SessionSourceCursor
+				for queryIndex < len(ownershipMachines) {
+					ownershipMachine := ownershipMachines[queryIndex]
+					if err := ctx.Err(); err != nil {
+						return deleted, err
+					}
+					page, err := e.db.ListActiveSessionSourceOwnershipScopesPage(
+						ctx, ownershipMachine, agentStr,
+						ownershipScopes, cursor,
 					)
-				}
-				if len(page) == 0 {
-					queryIndex++
-					cursor = db.SessionSourceCursor{}
-					continue
-				}
-				missingByPath := make(map[string]bool, len(page))
-				for _, ownership := range page {
-					if !db.StoredSourcePathHintScopesContain(
-						ownership.FilePath, ownershipScopes,
-					) {
-						// The SQL LIKE prefilter is ASCII-case-insensitive
-						// while this predicate is platform-exact; retain any
-						// row the pass holds no proof over and leave the
-						// keyset cursor untouched.
+					if err != nil {
+						return deleted, fmt.Errorf(
+							"list %s watch source ownership: %w", agent, err,
+						)
+					}
+					if len(page) == 0 {
+						queryIndex++
+						cursor = db.SessionSourceCursor{}
 						continue
 					}
-					statPath := ownership.FilePath
-					persistentMemberContainerExists := false
-					missing, ok := missingByPath[statPath]
-					if !ok {
-						_, statErr := e.lstatSource(statPath)
-						missing = os.IsNotExist(statErr)
-						missingByPath[statPath] = missing
-					}
-					if !missing {
-						// An aggregate row stores its container path, so
-						// full-root coverage OR a scope proof spanning that
-						// container's whole membership grants member-absence
-						// authority: either way the completed stream
-						// enumerated every member the row could resolve to.
-						gone, checkErr := aggregateOwnedMemberGone(
-							ctx, spool, provider, agent, ownership,
-							allProviderRootsCovered ||
-								reconciliationProofCoversContainerMembership(
-									scope.proofScopes, ownership.FilePath,
-								),
-						)
-						if checkErr != nil {
-							return deleted, checkErr
-						}
-						if !gone {
+					missingByPath := make(map[string]bool, len(page))
+					for _, ownership := range page {
+						if !db.StoredSourcePathHintScopesContain(
+							ownership.FilePath, ownershipScopes,
+						) {
+							// The SQL LIKE prefilter is ASCII-case-insensitive
+							// while this predicate is platform-exact; retain any
+							// row the pass holds no proof over and leave the
+							// keyset cursor untouched.
 							continue
 						}
-						if !allProviderRootsCovered {
-							// Membership authority came from the scope's own
-							// container proof; a same-ID copy under another
-							// configured root would make this a move, not a
-							// deletion.
-							relocated, err := reconciliationMemberRelocated(
-								ctx, provider, ownership.ID,
+						statPath := ownership.FilePath
+						persistentMemberContainerExists := false
+						missing, ok := missingByPath[statPath]
+						if !ok {
+							_, statErr := e.lstatSource(statPath)
+							missing = os.IsNotExist(statErr)
+							missingByPath[statPath] = missing
+						}
+						if !missing {
+							// An aggregate row stores its container path, so
+							// full-root coverage OR a scope proof spanning that
+							// container's whole membership grants member-absence
+							// authority: either way the completed stream
+							// enumerated every member the row could resolve to.
+							gone, checkErr := aggregateOwnedMemberGone(
+								ctx, spool, provider, agent, ownership,
+								allProviderRootsCovered ||
+									reconciliationProofCoversContainerMembership(
+										scope.proofScopes, ownership.FilePath,
+									),
+							)
+							if checkErr != nil {
+								return deleted, checkErr
+							}
+							if !gone {
+								continue
+							}
+							if !allProviderRootsCovered {
+								// Membership authority came from the scope's own
+								// container proof; a same-ID copy under another
+								// configured root would make this a move, not a
+								// deletion.
+								relocated, err := reconciliationMemberRelocated(
+									ctx, provider, ownership.ID,
+								)
+								if err != nil {
+									return deleted, err
+								}
+								if relocated {
+									continue
+								}
+							}
+							// The container still exists but the streamed pass no
+							// longer yields this member; tombstone directly — the
+							// guards below all assume a vanished stored path.
+							changed, err := e.tombstoneSessionSourceOwnership(
+								ctx, ownership.Machine, ownership.Agent,
+								ownership.ID, ownership.FilePath,
 							)
 							if err != nil {
-								return deleted, err
+								return deleted, fmt.Errorf(
+									"tombstone %s session %s after watch reconciliation: %w",
+									agent, ownership.ID, err,
+								)
 							}
-							if relocated {
+							if changed {
+								deleted++
+							}
+							continue
+						}
+						// A vanished tracked copy with a surviving same-identity
+						// duplicate is a replacement, not a deletion; the next sync
+						// re-points the session at the survivor. Claude keys
+						// replacements by the session ID in the filename; a Codex
+						// UUID can exist as both a live dated copy and a flat
+						// archived copy sharing one discovery identity. Both resolve
+						// through a bounded per-source index lookup: the streamed
+						// pass's spool when it covers every configured root, else a
+						// lazily built disk-backed index (at most one per pass).
+						replacementIdentity := reconciliationReplacementIdentity(
+							agent, ownership.FilePath,
+						)
+						if replacementIdentity != "" && provider != nil {
+							if replacementIndex == nil {
+								if spool != nil {
+									if !allProviderRootsCovered {
+										// A scoped pass cannot prove that a same-identity
+										// replacement does not exist under another configured root.
+										continue
+									}
+									replacementIndex = spool
+								} else {
+									// Deliberate bypass of the pass's narrowed proof:
+									// the index must span the provider's full
+									// configured scope so a replacement beyond the
+									// narrowed pass stays resolvable.
+									replacementIndex, err = e.buildReconciliationReplacementIndex(
+										ctx, provider, e.agentDirs[agent],
+									)
+									if err != nil {
+										return deleted, fmt.Errorf(
+											"index %s reconciliation replacements: %w", agent, err,
+										)
+									}
+									if agent == parser.AgentCodex {
+										reconciliationRuntimeMetricsFor(ctx).
+											codexReplacementIndexBuild()
+									}
+									ownsReplacementIndex = true
+									defer func() {
+										if ownsReplacementIndex {
+											retErr = errors.Join(
+												retErr, replacementIndex.CloseAndRemove(),
+											)
+										}
+									}()
+								}
+							}
+							replacement, found, lookupErr := replacementIndex.Candidate(
+								ctx, agent, replacementIdentity,
+							)
+							if lookupErr != nil {
+								return deleted, fmt.Errorf(
+									"lookup %s reconciliation replacement: %w", agent, lookupErr,
+								)
+							}
+							if found && !sameReconciliationSourcePath(
+								replacement.Path, ownership.FilePath,
+							) {
 								continue
 							}
 						}
-						// The container still exists but the streamed pass no
-						// longer yields this member; tombstone directly — the
-						// guards below all assume a vanished stored path.
+						persistentArchive := provider != nil && provider.Capabilities().Source.PersistentArchive == parser.CapabilitySupported
+						if persistentArchive {
+							resolver, ok := provider.(parser.PersistentArchiveSourceResolver)
+							if ok {
+								physicalPath, valid := resolver.PersistentArchiveSource(
+									statPath, ownership.ID,
+								)
+								if valid {
+									if !allProviderRootsCovered &&
+										!reconciliationProofCoversContainerMembership(
+											scope.proofScopes, physicalPath,
+										) {
+										// A scoped pass cannot prove that this member does not
+										// exist in a persistent container under another root —
+										// unless the completed scope's proof is this container's
+										// whole virtual membership, in which case the admitted
+										// stream enumerated exactly this container and spool
+										// absence is authoritative for rows bound to it.
+										continue
+									}
+									if _, statErr := e.lstatSource(physicalPath); statErr != nil {
+										// A vanished or unreadable persistent container cannot
+										// authoritatively prove that an archived member was deleted.
+										continue
+									}
+									if spool == nil {
+										continue
+									}
+									present, lookupErr := spool.ContainsSource(
+										ctx, agent,
+										canonicalReconciliationSourceIdentity(ownership.FilePath),
+									)
+									if lookupErr != nil {
+										return deleted, fmt.Errorf(
+											"lookup %s persistent member %s: %w",
+											agent, ownership.FilePath, lookupErr,
+										)
+									}
+									if !present {
+										// Container-granular discovery spools the
+										// still-present container itself rather than
+										// each member. A discovered container accounts
+										// for its members: deleting a member changes
+										// the container's bytes, so the
+										// fingerprint-gated complete-result parse
+										// already tombstoned it.
+										present, lookupErr = spool.ContainsSource(
+											ctx, agent,
+											canonicalReconciliationSourceIdentity(physicalPath),
+										)
+										if lookupErr != nil {
+											return deleted, fmt.Errorf(
+												"lookup %s persistent container %s: %w",
+												agent, physicalPath, lookupErr,
+											)
+										}
+									}
+									if present {
+										continue
+									}
+									persistentMemberContainerExists = true
+								}
+							}
+						} else if resolver, ok := provider.(parser.ReconciliationSourceResolver); ok {
+							source, found, err := resolver.SourceForReconciliation(
+								ctx, statPath, "",
+							)
+							if err != nil {
+								return deleted, fmt.Errorf(
+									"validate %s source %s during watch reconciliation: %w",
+									agent, statPath, err,
+								)
+							}
+							if found {
+								container, _, virtual := parser.ParseVirtualSourcePath(
+									providerDiscoveredPath(source),
+								)
+								if virtual && !allProviderRootsCovered &&
+									!reconciliationProofCoversContainerMembership(
+										scope.proofScopes, container,
+									) {
+									// A scoped pass cannot prove that the same logical
+									// member did not move to another configured root —
+									// unless the completed scope's proof spans this
+									// container's whole virtual membership; the
+									// relocation guard before the tombstone below
+									// then rules out a copy under another root.
+									continue
+								}
+								if spool == nil || !virtual {
+									continue
+								}
+								identity := ""
+								identityResolver, resolvesIdentity := provider.(parser.ReconciliationMemberIdentityResolver)
+								if resolvesIdentity {
+									identity = identityResolver.ReconciliationMemberIdentity(
+										ownership.ID,
+									)
+								}
+								present, lookupErr := spool.ContainsSourceIdentity(
+									ctx, agent,
+									canonicalReconciliationSourceIdentity(ownership.FilePath),
+									identity,
+								)
+								if lookupErr != nil {
+									return deleted, fmt.Errorf(
+										"lookup %s virtual member %s: %w",
+										agent, ownership.FilePath, lookupErr,
+									)
+								}
+								if present {
+									continue
+								}
+							}
+						}
+						if !persistentMemberContainerExists {
+							missing, ok = missingByPath[statPath]
+							if !ok {
+								_, statErr := e.lstatSource(statPath)
+								missing = os.IsNotExist(statErr)
+								missingByPath[statPath] = missing
+							}
+							if !missing {
+								continue
+							}
+						}
+						if !allProviderRootsCovered {
+							// A scoped pass never streamed the other configured
+							// roots, so before tombstoning a virtual member —
+							// whose home container may itself be gone — ask the
+							// provider across its full configured scope whether
+							// the session still resolves anywhere: a same-ID copy
+							// under another root is a move, not a deletion.
+							if _, _, virtual := parser.ParseVirtualSourcePath(
+								ownership.FilePath,
+							); virtual {
+								relocated, err := reconciliationMemberRelocated(
+									ctx, provider, ownership.ID,
+								)
+								if err != nil {
+									return deleted, err
+								}
+								if relocated {
+									continue
+								}
+							}
+						}
 						changed, err := e.tombstoneSessionSourceOwnership(
 							ctx, ownership.Machine, ownership.Agent,
 							ownership.ID, ownership.FilePath,
@@ -5015,240 +5462,43 @@ func (e *Engine) tombstoneMissingWatchSourceScopesLocked(
 						if changed {
 							deleted++
 						}
-						continue
 					}
-					// A vanished tracked copy with a surviving same-identity
-					// duplicate is a replacement, not a deletion; the next sync
-					// re-points the session at the survivor. Claude keys
-					// replacements by the session ID in the filename; a Codex
-					// UUID can exist as both a live dated copy and a flat
-					// archived copy sharing one discovery identity. Both resolve
-					// through a bounded per-source index lookup: the streamed
-					// pass's spool when it covers every configured root, else a
-					// lazily built disk-backed index (at most one per pass).
-					replacementIdentity := reconciliationReplacementIdentity(
-						agent, ownership.FilePath,
-					)
-					if replacementIdentity != "" && provider != nil {
-						if replacementIndex == nil {
-							if spool != nil {
-								if !allProviderRootsCovered {
-									// A scoped pass cannot prove that a same-identity
-									// replacement does not exist under another configured root.
-									continue
-								}
-								replacementIndex = spool
-							} else {
-								// Deliberate bypass of the pass's narrowed proof:
-								// the index must span the provider's full
-								// configured scope so a replacement beyond the
-								// narrowed pass stays resolvable.
-								replacementIndex, err = e.buildReconciliationReplacementIndex(
-									ctx, provider, e.agentDirs[agent],
-								)
-								if err != nil {
-									return deleted, fmt.Errorf(
-										"index %s reconciliation replacements: %w", agent, err,
-									)
-								}
-								if agent == parser.AgentCodex {
-									reconciliationRuntimeMetricsFor(ctx).
-										codexReplacementIndexBuild()
-								}
-								ownsReplacementIndex = true
-								defer func() {
-									if ownsReplacementIndex {
-										retErr = errors.Join(
-											retErr, replacementIndex.CloseAndRemove(),
-										)
-									}
-								}()
-							}
-						}
-						replacement, found, lookupErr := replacementIndex.Candidate(
-							ctx, agent, replacementIdentity,
-						)
-						if lookupErr != nil {
-							return deleted, fmt.Errorf(
-								"lookup %s reconciliation replacement: %w", agent, lookupErr,
-							)
-						}
-						if found && !sameReconciliationSourcePath(
-							replacement.Path, ownership.FilePath,
-						) {
-							continue
-						}
+					cursor = page[len(page)-1].Cursor()
+					if len(page) < db.WatchReconcileSourcePageSize {
+						queryIndex++
+						cursor = db.SessionSourceCursor{}
 					}
-					persistentArchive := provider != nil && provider.Capabilities().Source.PersistentArchive == parser.CapabilitySupported
-					if persistentArchive {
-						resolver, ok := provider.(parser.PersistentArchiveSourceResolver)
-						if ok {
-							physicalPath, valid := resolver.PersistentArchiveSource(
-								statPath, ownership.ID,
-							)
-							if valid {
-								if !allProviderRootsCovered &&
-									!reconciliationProofCoversContainerMembership(
-										scope.proofScopes, physicalPath,
-									) {
-									// A scoped pass cannot prove that this member does not
-									// exist in a persistent container under another root —
-									// unless the completed scope's proof is this container's
-									// whole virtual membership, in which case the admitted
-									// stream enumerated exactly this container and spool
-									// absence is authoritative for rows bound to it.
-									continue
-								}
-								if _, statErr := e.lstatSource(physicalPath); statErr != nil {
-									// A vanished or unreadable persistent container cannot
-									// authoritatively prove that an archived member was deleted.
-									continue
-								}
-								if spool == nil {
-									continue
-								}
-								present, lookupErr := spool.ContainsSource(
-									ctx, agent,
-									canonicalReconciliationSourceIdentity(ownership.FilePath),
-								)
-								if lookupErr != nil {
-									return deleted, fmt.Errorf(
-										"lookup %s persistent member %s: %w",
-										agent, ownership.FilePath, lookupErr,
-									)
-								}
-								if !present {
-									// Container-granular discovery spools the
-									// still-present container itself rather than
-									// each member. A discovered container accounts
-									// for its members: deleting a member changes
-									// the container's bytes, so the
-									// fingerprint-gated complete-result parse
-									// already tombstoned it.
-									present, lookupErr = spool.ContainsSource(
-										ctx, agent,
-										canonicalReconciliationSourceIdentity(physicalPath),
-									)
-									if lookupErr != nil {
-										return deleted, fmt.Errorf(
-											"lookup %s persistent container %s: %w",
-											agent, physicalPath, lookupErr,
-										)
-									}
-								}
-								if present {
-									continue
-								}
-								persistentMemberContainerExists = true
-							}
-						}
-					} else if resolver, ok := provider.(parser.ReconciliationSourceResolver); ok {
-						source, found, err := resolver.SourceForReconciliation(
-							ctx, statPath, "",
-						)
-						if err != nil {
-							return deleted, fmt.Errorf(
-								"validate %s source %s during watch reconciliation: %w",
-								agent, statPath, err,
-							)
-						}
-						if found {
-							container, _, virtual := parser.ParseVirtualSourcePath(
-								providerDiscoveredPath(source),
-							)
-							if virtual && !allProviderRootsCovered &&
-								!reconciliationProofCoversContainerMembership(
-									scope.proofScopes, container,
-								) {
-								// A scoped pass cannot prove that the same logical
-								// member did not move to another configured root —
-								// unless the completed scope's proof spans this
-								// container's whole virtual membership; the
-								// relocation guard before the tombstone below
-								// then rules out a copy under another root.
-								continue
-							}
-							if spool == nil || !virtual {
-								continue
-							}
-							identity := ""
-							identityResolver, resolvesIdentity := provider.(parser.ReconciliationMemberIdentityResolver)
-							if resolvesIdentity {
-								identity = identityResolver.ReconciliationMemberIdentity(
-									ownership.ID,
-								)
-							}
-							present, lookupErr := spool.ContainsSourceIdentity(
-								ctx, agent,
-								canonicalReconciliationSourceIdentity(ownership.FilePath),
-								identity,
-							)
-							if lookupErr != nil {
-								return deleted, fmt.Errorf(
-									"lookup %s virtual member %s: %w",
-									agent, ownership.FilePath, lookupErr,
-								)
-							}
-							if present {
-								continue
-							}
-						}
-					}
-					if !persistentMemberContainerExists {
-						missing, ok = missingByPath[statPath]
-						if !ok {
-							_, statErr := e.lstatSource(statPath)
-							missing = os.IsNotExist(statErr)
-							missingByPath[statPath] = missing
-						}
-						if !missing {
-							continue
-						}
-					}
-					if !allProviderRootsCovered {
-						// A scoped pass never streamed the other configured
-						// roots, so before tombstoning a virtual member —
-						// whose home container may itself be gone — ask the
-						// provider across its full configured scope whether
-						// the session still resolves anywhere: a same-ID copy
-						// under another root is a move, not a deletion.
-						if _, _, virtual := parser.ParseVirtualSourcePath(
-							ownership.FilePath,
-						); virtual {
-							relocated, err := reconciliationMemberRelocated(
-								ctx, provider, ownership.ID,
-							)
-							if err != nil {
-								return deleted, err
-							}
-							if relocated {
-								continue
-							}
-						}
-					}
-					changed, err := e.tombstoneSessionSourceOwnership(
-						ctx, ownership.Machine, ownership.Agent,
-						ownership.ID, ownership.FilePath,
-					)
-					if err != nil {
-						return deleted, fmt.Errorf(
-							"tombstone %s session %s after watch reconciliation: %w",
-							agent, ownership.ID, err,
-						)
-					}
-					if changed {
-						deleted++
-					}
-				}
-				cursor = page[len(page)-1].Cursor()
-				if len(page) < db.WatchReconcileSourcePageSize {
-					queryIndex++
-					cursor = db.SessionSourceCursor{}
 				}
 			}
 		}
 	}
 	return deleted, nil
+}
+
+// canonicalProviderStatHashAgent maps an AgentType key to the canonical
+// agent used by the provider_freshness side-table. The side-table is
+// only ever written by recordProviderStatHash via the
+// pendingProviderStatHash.agent field, which is set at the staging site
+// from the discovered source's AgentType — always AgentCodebuff in the
+// current registry because the Codebuff provider is the sole provider
+// registered with MultiFileStatHash (Freebuff sessions surface with
+// agent=AgentCodebuff per parser.AgentLabel routing, see
+// buildProviderStatHashers). The storage-layer ownership rows, however,
+// can carry agent=AgentFreebuff (the watcher/reconcile path may label a
+// Freebuff-on-disk session with the AgentFreebuff literal, while the
+// side-table provenance still rooted at the Codebuff probe). Reading
+// the side-table at any site that takes ownership.Agent must therefore
+// normalize Freebuff to Codebuff; without this, a tombstone on a
+// Freebuff-tagged ownership row would silently miss the side-table row
+// that the cold sync stamped under the Codebuff key, and a future
+// byte-identical restore of the directory would falsely match the
+// stale digest.
+func canonicalProviderStatHashAgent(agent string) parser.AgentType {
+	a := parser.AgentType(agent)
+	if a == parser.AgentFreebuff {
+		return parser.AgentCodebuff
+	}
+	return a
 }
 
 func (e *Engine) tombstoneSessionSourceOwnership(
@@ -5259,6 +5509,22 @@ func (e *Engine) tombstoneSessionSourceOwnership(
 	// tombstone as one recoverable operation.
 	if _, err := e.clearSkipPersistent(filePath); err != nil {
 		return false, fmt.Errorf("clear source skip cache: %w", err)
+	}
+	// Also drop the per-component provider_freshness row under the same
+	// (agent, filePath) key. Freebuff sessions surface in storage with
+	// agent=AgentFreebuff but the provider_freshness side-table is only
+	// ever stamped under the canonical AgentCodebuff key (the sole
+	// MultiFileStatHasher provider); canonicalProviderStatHashAgent
+	// remaps Freebuff to Codebuff here so the delete matches the row the
+	// cold-sync staging site wrote. If this row is left intact and the
+	// same physical directory is later restored byte-for-byte, the stale
+	// digest would short-circuit providerSourceFreshBeforeFingerprint on
+	// the next warm pass and silently skip the source, preventing the
+	// tombstoned row from being revived by reconciliation.
+	if err := e.db.DeleteProviderStatHash(
+		ctx, canonicalProviderStatHashAgent(agent), filePath,
+	); err != nil {
+		return false, fmt.Errorf("clear provider_freshness: %w", err)
 	}
 	changed, err := e.db.SoftDeleteSessionSourceOwnership(
 		ctx, machine, agent, id, filePath,
@@ -6233,6 +6499,56 @@ func (e *Engine) filterFilesByMtime(
 	return out
 }
 
+// codebuffCompositeMtime returns a composite freshness timestamp for a
+// Codebuff/Freebuff session directory by stat'ing the primary file
+// (chat-messages.json), every companion file declared in
+// CodebuffCompanionFilenames (run-state.json, chat-meta.json), and the
+// session directory itself. Each stat contributes max(mtime, ctime), so
+// a companion-only change or a same-size rewrite with preserved mtime
+// still advances the composite. Shared by discoveredFileEffectiveMtime
+// (incremental cutoff) and discoveredFileMtime (parse-diff ordering) so
+// the two freshness signals never diverge.
+func codebuffCompositeMtime(path string) (int64, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0, err
+	}
+	mtime := info.ModTime().UnixNano()
+	// Include ctime so same-size rewrites with preserved mtime are
+	// detected. On platforms without ctime (e.g. Plan 9), fileChangeTime
+	// returns (0, false), leaving the mtime-only composite as-is.
+	if ct, _ := fileChangeTime(path, info); ct > mtime {
+		mtime = ct
+	}
+	dir := filepath.Dir(path)
+	for _, name := range parser.CodebuffCompanionFilenames {
+		companion := filepath.Join(dir, name)
+		if ci, err := os.Stat(companion); err == nil {
+			ts := ci.ModTime().UnixNano()
+			if cct, _ := fileChangeTime(companion, ci); cct > ts {
+				ts = cct
+			}
+			if ts > mtime {
+				mtime = ts
+			}
+		}
+	}
+	// Also consider the session directory mtime as a local cutoff
+	// signal to detect companion-file deletions. Deleting a file
+	// changes the directory's mtime even though surviving files'
+	// mtimes are unchanged.
+	if dirInfo, err := os.Stat(dir); err == nil {
+		ts := dirInfo.ModTime().UnixNano()
+		if dct, _ := fileChangeTime(dir, dirInfo); dct > ts {
+			ts = dct
+		}
+		if ts > mtime {
+			mtime = ts
+		}
+	}
+	return mtime, nil
+}
+
 // discoveredFileEffectiveMtime returns the freshness timestamp used to filter a
 // discovered file against an incremental-sync cutoff. For provider-sourced
 // files it consults the provider's Fingerprint so composite/sibling-file
@@ -6306,6 +6622,23 @@ func (e *Engine) discoveredFileEffectiveMtime(
 		}
 		return mtime, nil
 	}
+	// Codebuff is excluded from the provider-Fingerprint path for
+	// cost: its Fingerprint content-hashes chat-messages.json plus
+	// run-state.json and chat-meta.json, so consulting it here would
+	// read every session's full transcript on each incremental sync,
+	// scaling cutoff filtering with the archive instead of the changed
+	// batch. The stat-only composite carries the same cutoff signal:
+	// max(mtime, ctime) per file plus the session directory, so a
+	// companion-only change still looks fresh and a same-size rewrite
+	// with preserved mtime advances the cutoff via ctime. Sources that
+	// pass the cutoff go on to the full fingerprint as usual.
+	// Codebuff/Freebuff: stat-only composite avoids the provider
+	// Fingerprint path (which content-hashes the transcript) to keep
+	// cutoff filtering bounded by the changed batch. See the helper's
+	// doc comment for what the composite covers.
+	if file.Agent == parser.AgentCodebuff || file.Agent == parser.AgentFreebuff {
+		return codebuffCompositeMtime(file.Path)
+	}
 	// Watermark-only shared-container sources carry their session-row
 	// watermark from discovery. Consulting the provider Fingerprint instead
 	// would resolve the full composite with one indexed child lookup per
@@ -6319,8 +6652,7 @@ func (e *Engine) discoveredFileEffectiveMtime(
 	// through and resolve the live composite instead.
 	if file.ProviderSource != nil {
 		if wm, ok := parser.SourceWatermarkOnlyMTimeNS(*file.ProviderSource); ok {
-			if dbPath, _, ok := sqliteContainerSourceForFile(file); ok &&
-				e.sqliteContainerPassCaptureValid(dbPath) {
+			if dbPath, _, ok := sqliteContainerSourceForFile(file); ok && e.sqliteContainerPassCaptureValid(dbPath) {
 				return wm, nil
 			}
 		}
@@ -6474,6 +6806,10 @@ func discoveredFileMtime(
 			return 0, err
 		}
 		return reasonixEffectiveInfo(file.Path, info).ModTime().UnixNano(), nil
+	}
+
+	if file.Agent == parser.AgentCodebuff || file.Agent == parser.AgentFreebuff {
+		return codebuffCompositeMtime(file.Path)
 	}
 
 	info, err := os.Stat(file.Path)
@@ -7282,8 +7618,39 @@ func (e *Engine) collectAndBatch(
 		clear(baselineAdmission)
 	}
 	baselineProcessedSource := func(job syncJob, admitted bool) {
-		source, ok := baselineSourceForJob(job)
-		if !ok {
+		// Use the parsed session's agent type for the baseline row,
+		// not the provider's agent type. Freebuff sessions are
+		// stored under agent=AgentFreebuff but discovered under
+		// Codebuff, so the baseline row must key on the resolved
+		// agent. Skip-cache staging (stageNoWriteCache) still uses
+		// job.agent because the skip cache is per-file, not
+		// per-session-agent.
+		agent := job.agent
+		if len(job.results) > 0 {
+			if sessAgent := job.results[0].Session.Agent; sessAgent != "" {
+				agent = sessAgent
+			}
+		} else if job.agent == parser.AgentCodebuff {
+			// For skipped sources with no results, query the DB for
+			// the actual agent type. Freebuff sessions are stored as
+			// AgentFreebuff but discovered under Codebuff.
+			path := e.effectiveSourcePath(job.path)
+			for _, candidateAgent := range []parser.AgentType{
+				parser.AgentCodebuff, parser.AgentFreebuff,
+			} {
+				if ids, err := e.db.ListSessionIDsByFilePath(path, string(candidateAgent)); err == nil && len(ids) > 0 {
+					agent = candidateAgent
+					break
+				}
+			}
+		}
+		source := machineSessionSource{
+			Machine: job.machine,
+			Source: db.SessionSourcePath{
+				Agent: string(agent), FilePath: e.effectiveSourcePath(job.path),
+			},
+		}
+		if source.Source.Agent == "" || source.Source.FilePath == "" {
 			return
 		}
 		if tracker := reconciliationBaselineTrackerFor(ctx); tracker != nil {
@@ -7383,6 +7750,26 @@ func (e *Engine) collectAndBatch(
 			stats.cwdFilteredSessions += outcome.cwdFiltered
 			progress.MessagesIndexed += outcome.writtenMessages
 			stats.messagesIndexed = progress.MessagesIndexed
+			// Persist per-component freshness digests for the per-row
+			// entries whose write succeeded. outcome.written[i]
+			// is the authoritative per-source success flag:
+			// writeBatchWithOutcome sets it to false for any row
+			// that was CWD-filtered or whose session upsert failed,
+			// so a single failing row in a mixed batch correctly
+			// suppresses only its own digest persist. Successful
+			// rows in the same batch still get their digests
+			// stamped; a pendingStatHash source whose whole session
+			// row committed is exactly the invariant the side-table
+			// needs to recognize on the next warm pass.
+			for i, pw := range pending {
+				if pw.providerStatHash == nil {
+					continue
+				}
+				if i < len(outcome.written) && !outcome.written[i] {
+					continue
+				}
+				e.recordProviderStatHash(ctx, *pw.providerStatHash)
+			}
 		}()
 		pending = pending[:0]
 		pendingLeases = pendingLeases[:0]
@@ -7642,10 +8029,10 @@ func (e *Engine) collectAndBatch(
 			stats.messagesIndexed = progress.MessagesIndexed
 			r.releaseRetention()
 		} else {
-			for _, pr := range allowed {
+			for i, pr := range allowed {
 				needsRetry := r.providerFailureCount > 0 ||
 					r.needsRetryForSession(pr.Session.ID)
-				pending = append(pending, pendingWrite{
+				pw := pendingWrite{
 					sess:              pr.Session,
 					msgs:              pr.Messages,
 					usageEvents:       pr.UsageEvents,
@@ -7655,7 +8042,16 @@ func (e *Engine) collectAndBatch(
 					storageTrustPath:  r.storageTrustPath,
 					storageTrustState: r.storageTrustState,
 					storageTrustSnap:  r.storageTrustSnap,
-				})
+				}
+				// The source's per-component digest (providerStatHash) is
+				// a one-row side-table entry keyed by (agent, file_path),
+				// so tagging only the first allowed result is enough.
+				// The flush path below persists it after the matching
+				// session row commits successfully.
+				if i == 0 && r.providerStatHash != nil {
+					pw.providerStatHash = r.providerStatHash
+				}
+				pending = append(pending, pw)
 				if runtimeMetrics != nil {
 					runtimeMetrics.pendingWrites(len(pending))
 				}
@@ -7779,17 +8175,25 @@ func (e *Engine) skippedSourceAllowsCwdFilter(
 		return true, nil
 	}
 	path := e.effectiveSourcePath(job.path)
-	ids, err := e.db.ListSessionIDsByFilePath(path, string(job.agent))
-	if err != nil {
-		return false, err
+	// Freebuff shares the Codebuff provider. Query both agent types
+	// so CWD filtering works for sources containing only Freebuff sessions.
+	agentsToQuery := []string{string(job.agent)}
+	if job.agent == parser.AgentCodebuff {
+		agentsToQuery = append(agentsToQuery, string(parser.AgentFreebuff))
 	}
-	for _, id := range ids {
-		session, err := e.db.GetSession(ctx, id)
+	for _, agentStr := range agentsToQuery {
+		ids, err := e.db.ListSessionIDsByFilePath(path, agentStr)
 		if err != nil {
 			return false, err
 		}
-		if session != nil && !e.cwdFilter.allows(session.Cwd) {
-			return false, nil
+		for _, id := range ids {
+			session, err := e.db.GetSession(ctx, id)
+			if err != nil {
+				return false, err
+			}
+			if session != nil && !e.cwdFilter.allows(session.Cwd) {
+				return false, nil
+			}
 		}
 	}
 	return true, nil
@@ -7874,7 +8278,15 @@ type processResult struct {
 	mtime       int64
 	err         error
 	incremental *incrementalUpdate
-	cacheSkip   bool
+	// providerStatHash stages the per-component freshness digest that
+	// applyProviderFilePathPolicies computed but did not yet write. The
+	// collector persists it after the matching session row commits
+	// successfully, so a downstream write failure (or a CWD-filter veto)
+	// never marks an absent or stale session as fresh. nil when the
+	// source is not a multi-file hasher agent or its parse produced no
+	// kept results.
+	providerStatHash *pendingProviderStatHash
+	cacheSkip        bool
 	// cacheAfterWrite records a successful, complete rowless container parse
 	// after its member writes commit. Unlike ordinary provider results, these
 	// containers have no physical-path session row that can make the next full
@@ -8159,6 +8571,32 @@ func (e *Engine) processProviderFile(
 		source.ProjectHint = file.Project
 	}
 
+	// Capture the per-component stat digest from the same pre-parse
+	// snapshot that gates freshness, BEFORE fingerprinting or parsing
+	// reads the source. Persisting a digest computed after the parse
+	// would race a concurrent companion rewrite: the stored digest would
+	// describe the new file state while the session row holds the old
+	// parse payload, so every later warm sync would short-circuit on the
+	// new digest and the stale row would never be refreshed. This single
+	// snapshot feeds the warm-match comparison in
+	// providerSourceFreshBeforeFingerprint, the confirmed-unchanged-skip
+	// stamp, and the write-path staging, so all three always agree.
+	var preParseStatHash *pendingProviderStatHash
+	if hasher, ok := e.providerStatHashers[file.Agent]; ok {
+		if physicalPath := providerDiscoveredPath(source); physicalPath != "" {
+			targetKey := physicalPath
+			if e.pathRewriter != nil {
+				targetKey = e.pathRewriter(physicalPath)
+			}
+			preParseStatHash = &pendingProviderStatHash{
+				agent:        file.Agent,
+				physicalPath: physicalPath,
+				targetKey:    targetKey,
+				digest:       hasher.ComputeMultiFileStatHash(physicalPath),
+			}
+		}
+	}
+
 	verifiedCapture, verifiedMtime, verifiedFresh, verifiedStateOK :=
 		e.verifiedProviderSourceState(provider, source, file)
 	if verifiedStateOK && verifiedFresh {
@@ -8199,7 +8637,9 @@ func (e *Engine) processProviderFile(
 	} else if forceReplace {
 		sourceForceReplace = true
 	}
-	if freshMtime, fresh := e.providerSourceFreshBeforeFingerprint(source, file); fresh {
+	if freshMtime, fresh := e.providerSourceFreshBeforeFingerprint(
+		ctx, source, file, preParseStatHash,
+	); fresh {
 		return processResult{
 			skip:  true,
 			mtime: freshMtime,
@@ -8385,7 +8825,7 @@ func (e *Engine) processProviderFile(
 	// earlier freshness checks; this is the generic fallback for the rest.
 	if !incForceReplace && !e.forceParse && !file.ForceParse &&
 		e.providerSourceUnchangedInDB(
-			source, fingerprint, providerSemantics,
+			ctx, source, fingerprint, providerSemantics, preParseStatHash,
 		) {
 		return processResult{
 			skip:      true,
@@ -8541,6 +8981,7 @@ func (e *Engine) processProviderFile(
 		suppressPresenceSweep: !outcome.ResultSetComplete,
 		providerFailureCount:  providerFailureCount,
 		retentionLease:        lease,
+		providerStatHash:      preParseStatHash,
 	}
 	if file.Agent == parser.AgentOmnigent && cacheSkip && cleanCache &&
 		!e.forceParse && !file.ForceParse &&
@@ -8575,7 +9016,7 @@ func (e *Engine) processProviderFile(
 			})
 		}
 	}
-	e.applyProviderFilePathPolicies(provider, file.Agent, &res)
+	e.applyProviderFilePathPolicies(ctx, provider, file.Agent, file.Path, &res)
 	if storageStateOK {
 		e.stageOpenCodeStorageTrust(
 			&res, file.Path, storageState, storageSnap,
@@ -8786,8 +9227,10 @@ func (e *Engine) providerSourceMissingSessionOwnershipsForCompleteResult(
 //     current parse no longer emits is added to the exclusion list so the
 //     superseded row is deleted.
 func (e *Engine) applyProviderFilePathPolicies(
+	ctx context.Context,
 	provider parser.Provider,
 	agent parser.AgentType,
+	filePath string,
 	res *processResult,
 ) {
 	if provider.Capabilities().Source.MultiSessionSource == parser.CapabilitySupported {
@@ -8826,18 +9269,74 @@ func (e *Engine) applyProviderFilePathPolicies(
 		currentID := result.Session.ID
 		currentPrefixedID := e.idPrefix + result.Session.ID
 
-		existingIDs, err := e.db.ListSessionIDsByFilePath(lookupPath, string(agent))
-		if err != nil {
-			log.Printf("list session IDs by file path: %v", err)
-			kept = append(kept, result)
-			continue
+		// Freebuff shares the Codebuff provider. Query both agent types
+		// so stale rows and resurrection guards work for both.
+		agentsToQuery := []string{string(agent)}
+		if agent == parser.AgentCodebuff {
+			agentsToQuery = append(agentsToQuery, string(parser.AgentFreebuff))
+		}
+		var existingIDs []string
+		primaryErr := make(map[string]error, len(agentsToQuery))
+		for _, agentStr := range agentsToQuery {
+			ids, err := e.db.ListSessionIDsByFilePath(lookupPath, agentStr)
+			if err != nil {
+				primaryErr[agentStr] = err
+				continue
+			}
+			existingIDs = append(existingIDs, ids...)
+		}
+		// One-shot retry: any agent that errored on the first call gets
+		// one more chance. Successful retries absorb their IDs into
+		// existingIDs and clear the per-agent error so a transient
+		// primary-agent failure does not propagate as a full-failure.
+		if len(primaryErr) > 0 {
+			for agentStr := range primaryErr {
+				ids, retryErr := e.db.ListSessionIDsByFilePath(lookupPath, agentStr)
+				if retryErr != nil {
+					continue
+				}
+				existingIDs = append(existingIDs, ids...)
+				delete(primaryErr, agentStr)
+			}
+		}
+		// Bail when any agent's identity lookup remains unsuccessful
+		// after retry. Continuing with partial lifecycle information
+		// can recreate a trashed identity or leave both Codebuff and
+		// Freebuff classifications active for the same file.
+		if len(primaryErr) > 0 {
+			var failedAgents []string
+			var failedErrs []error
+			for _, agentStr := range agentsToQuery {
+				if err, ok := primaryErr[agentStr]; ok {
+					failedAgents = append(failedAgents, agentStr)
+					failedErrs = append(failedErrs, err)
+				}
+			}
+			sort.Strings(failedAgents)
+			res.err = fmt.Errorf(
+				"list session IDs by file path %q for agents %v: %w",
+				lookupPath, failedAgents, errors.Join(failedErrs...),
+			)
+			res.noCacheSkip = true
+			kept = kept[:0]
+			res.results = kept
+			// Per-event work must drop the digest write too: an error
+			// path must not stamp a row that suppresses real drift on the
+			// next warm sync.
+			return
 		}
 
 		// Resurrection guard. The path's identity is removed when a trashed row
 		// shares it, or when any alternate identity for the path (the
 		// provider's excluded fallback IDs or a stale stored ID) is trashed or
 		// permanently excluded. In that case the new row must not be written.
-		suppress := e.db.HasTrashedSessionByFilePath(lookupPath, string(agent))
+		suppress := false
+		for _, agentStr := range agentsToQuery {
+			if e.db.HasTrashedSessionByFilePath(lookupPath, agentStr) {
+				suppress = true
+				break
+			}
+		}
 		if !suppress {
 			for id := range excluded {
 				if id == currentID || id == currentPrefixedID {
@@ -8880,6 +9379,57 @@ func (e *Engine) applyProviderFilePathPolicies(
 		kept = append(kept, result)
 	}
 	res.results = kept
+	if len(kept) > 0 && filePath != "" {
+		// Per-event work gates the digest stage by what actually got kept
+		// (an empty kept must not stamp a row that would suppress real
+		// drift on the next warm sync). The digest itself is the pre-parse
+		// snapshot processProviderFile captured before fingerprinting or
+		// parsing (preParseStatHash), so it cannot describe a file state
+		// the parse never read; the fallback below recomputes from the
+		// physical on-disk chat path only for paths that bypassed
+		// processProviderFile's capture. The cache key uses the
+		// pathRewriter's "host:/remote/path" form so remote-synced
+		// sources keep hashing a real local file but read back under
+		// the canonical logical key.
+		//
+		// The digest is persisted only after the matching source's
+		// sessions-table write commits successfully. The per-row persist
+		// gate in flushPending and the single-session writeSessionFull
+		// loop is what guarantees provider_freshness only sees digests
+		// whose matching session row actually committed; a CWD-filter
+		// veto, a failed upsert, or a parser-skipped session all bypass
+		// the persist call and keep the side-table clean.
+		// Fallback staging for results that bypassed processProviderFile's
+		// pre-parse capture (res.providerStatHash == nil). Today only
+		// Codebuff/Freebuff register a MultiFileStatHasher and their
+		// provider-authoritative path always captures, so this recomputes
+		// post-parse only for hypothetical non-processProviderFile
+		// producers; it is not the hot path.
+		if res.providerStatHash == nil {
+			if hasher, ok := e.providerStatHashers[agent]; ok {
+				targetKey := filePath
+				if e.pathRewriter != nil {
+					targetKey = e.pathRewriter(filePath)
+				}
+				if targetKey != "" {
+					res.providerStatHash = &pendingProviderStatHash{
+						agent:        agent,
+						physicalPath: filePath,
+						targetKey:    targetKey,
+						digest:       hasher.ComputeMultiFileStatHash(filePath),
+					}
+				}
+			}
+		}
+		// Test observability: this counter lets tests distinguish a
+		// regression that drops just the staging block from one that
+		// drops the entire freshness gate. See stagedProviderStatHashes
+		// on Engine and the per-row suppress test in
+		// codebuff_integration_test.go.
+		if res.providerStatHash != nil {
+			e.stagedProviderStatHashes.Add(1)
+		}
+	}
 }
 
 // deleteParserExcludedSessions deletes rows the current parser deliberately
@@ -9439,9 +9989,11 @@ func (e *Engine) shouldSkipFile(
 // an empty key, or a non-fingerprint identity (no size, e.g. a tombstone)
 // never matches and therefore reparses.
 func (e *Engine) providerSourceUnchangedInDB(
+	ctx context.Context,
 	source parser.SourceRef,
 	fingerprint parser.SourceFingerprint,
 	semantics parser.ProviderSyncSemantics,
+	preParseStatHash *pendingProviderStatHash,
 ) bool {
 	if fingerprint.MTimeNS == 0 && fingerprint.Size == 0 {
 		return false
@@ -9478,7 +10030,47 @@ func (e *Engine) providerSourceUnchangedInDB(
 		parser.NeedsProjectReparse(project) {
 		return false
 	}
-	return e.db.GetDataVersionByPath(lookupPath) >= db.CurrentDataVersion()
+	// Only a source confirmed unchanged against an existing current session
+	// row may earn a provider_freshness side-table stamp. This is the
+	// DB-confirmed skip site the cold-start branch of
+	// providerSourceFreshBeforeFingerprint closes its loop through: a
+	// content-unchanged source with no stored digest flows fingerprint →
+	// this skip → stamp, without ever persisting a digest before an outcome
+	// the engine can trust.
+	fresh := e.db.GetDataVersionByPath(lookupPath) >= db.CurrentDataVersion()
+	if fresh {
+		e.stampProviderStatHashForConfirmedSource(ctx, preParseStatHash)
+	}
+	return fresh
+}
+
+// stampProviderStatHashForConfirmedSource persists the pre-parse
+// per-component stat digest for a source whose provider.Fingerprint was
+// just verified against an existing current session row (the
+// providerSourceUnchangedInDB skip). This is the only pre-write moment a
+// digest may safely be written: a transient failure between an eager stamp
+// and the fingerprint/parse/write that follows would leave a matching
+// digest that permanently suppresses every later retry. The digest is the
+// pre-parse snapshot captured in processProviderFile, so it describes
+// exactly the file state the fingerprint verified, and the DB key uses the
+// pathRewriter's logical key, mirroring the write path. Providers without
+// a MultiFileStatHasher carry no digest and are skipped here; their
+// freshness is owned by the engine's existing stat and skip-cache paths.
+func (e *Engine) stampProviderStatHashForConfirmedSource(
+	ctx context.Context,
+	statHash *pendingProviderStatHash,
+) {
+	if statHash == nil || statHash.digest == 0 {
+		return
+	}
+	if err := e.db.UpsertProviderStatHash(
+		ctx, statHash.agent, statHash.targetKey, statHash.digest,
+	); err != nil {
+		log.Printf(
+			"provider_freshness write for %s/%s: %v",
+			statHash.agent, statHash.targetKey, err,
+		)
+	}
 }
 
 func (e *Engine) providerFingerprintHashMatchesDB(
@@ -9707,9 +10299,45 @@ func (e *Engine) providerIncrementalContentChanged(
 	return curHash != storedHash, true
 }
 
+// providerStatFreshnessMtime derives the cache mtime key from the same
+// rule the provider's cold-write fingerprint uses. Codebuff/Freebuff
+// delegate to parser.CodebuffCompanionMtime, which is the single
+// source of truth for the max(chat, run-state, chat-meta) derivation;
+// other MultiFileStatHasher agents fall through to chat-only since
+// they have no sibling companions to fold in.
+func providerStatFreshnessMtime(
+	agent parser.AgentType,
+	lookupPath string,
+	chatInfo os.FileInfo,
+) int64 {
+	if agent != parser.AgentCodebuff && agent != parser.AgentFreebuff {
+		return chatInfo.ModTime().UnixNano()
+	}
+	return parser.CodebuffCompanionMtime(lookupPath, chatInfo)
+}
+
+// providerFreshDigestSourceCurrentInDB reports whether the stored session
+// row for a digest-matched source is still current: the row exists, its
+// data version is current, and it does not need a project reparse. A
+// matching provider_freshness digest proves only that the file stat is
+// unchanged; these checks are what allow the digest short-circuit to skip
+// safely, mirroring the tail guards of providerSourceUnchangedInDB.
+func (e *Engine) providerFreshDigestSourceCurrentInDB(lookupPath string) bool {
+	if _, _, ok := e.db.GetFileInfoByPath(lookupPath); !ok {
+		return false
+	}
+	if project, ok := e.db.GetProjectByPath(lookupPath); ok &&
+		parser.NeedsProjectReparse(project) {
+		return false
+	}
+	return e.db.GetDataVersionByPath(lookupPath) >= db.CurrentDataVersion()
+}
+
 func (e *Engine) providerSourceFreshBeforeFingerprint(
+	ctx context.Context,
 	source parser.SourceRef,
 	file parser.DiscoveredFile,
+	preParseStatHash *pendingProviderStatHash,
 ) (int64, bool) {
 	if e.forceParse || file.ForceParse {
 		return 0, false
@@ -9726,6 +10354,107 @@ func (e *Engine) providerSourceFreshBeforeFingerprint(
 	if err != nil {
 		info, err = os.Stat(path)
 		if err != nil {
+			return 0, false
+		}
+	}
+	// Per-component digest pre-check for multi-file providers
+	// (Codebuff/Freebuff). When the provider implements
+	// MultiFileStatHasher and the side-table holds a digest that
+	// matches the current stat snapshot, the source is fresh and we
+	// short-circuit provider.Fingerprint. The hash is computed from
+	// the physical on-disk chat path while the cache lookup uses the
+	// pathRewriter's logical key, mirroring the write path; without
+	// that split a remote-synced source whose stored file_path is
+	// "host:/remote/path" would hash zero-stat tuples for every
+	// companion and miss real content drift on the materialized
+	// download. A stored digest that does not match the current
+	// stat snapshot forces provider.Fingerprint instead of falling
+	// through to the size/mtime composite below, because that
+	// composite can miss same-size sibling rewrites whose mtime
+	// stays below the existing max (or offsetting size deltas that
+	// cancel out in sum-of-sizes). The side-table is populated
+	// only after an outcome the engine can trust: a successful
+	// write's flushPending, a single-session writeSessionFull
+	// commit, or the DB-confirmed unchanged skip in processFile
+	// (stampProviderStatHashForConfirmedSource, which runs only
+	// after the current fingerprint was verified against an
+	// existing current session row). Nothing here ever persists
+	// the digest before fingerprinting, parsing, or session
+	// writing succeeds — a transient failure must not leave a
+	// matching digest that suppresses every later retry.
+	if preParseStatHash != nil {
+		stored, hasStored, hashErr :=
+			e.db.GetProviderStatHash(ctx, file.Agent, lookupPath)
+		switch {
+		case hashErr != nil:
+			// A read error must be handled before !hasStored: the DB
+			// layer reports failures as (0, false, err), so a naive
+			// !hasStored-first ordering would swallow the error into
+			// the cold-start arm and could persist a digest that never
+			// should have been written. On read error force a real
+			// re-verification rather than falling through to the lossy
+			// size/mtime composite: a persistent read error that
+			// started this turn should not silently skip a stale
+			// source indefinitely.
+			log.Printf(
+				"provider_freshness read for %s/%s: %v",
+				file.Agent, lookupPath, hashErr)
+			return 0, false
+		case !hasStored:
+			// Cold-start (no side-table row yet) or post-tombstone
+			// (provider_freshness was cleared): force a real
+			// fingerprint so a content-unchanged source still flows
+			// through provider.Fingerprint → engine skip → no write →
+			// no flushPending → no recordProviderStatHash => the
+			// side-table row would never get re-populated on its own
+			// and !hasStored would persist forever. Closing that loop
+			// must NOT use a synchronous pre-parse digest write (the
+			// old cold-stamp): a transient failure after the stamp
+			// would leave a matching digest that suppresses every
+			// later retry. Instead the loop is closed at the
+			// DB-confirmed unchanged skip in processFile, which runs
+			// after provider.Fingerprint verified the current source
+			// against an existing current session row — the only
+			// pre-write moment the digest may safely be persisted.
+			// A genuinely new or changed source flows through a
+			// successful write whose flushPending (or writeSessionFull)
+			// persists the digest; CWD-filtered sources stay absent
+			// because their session write never commits
+			// (TestSyncCodebuffCwdFilteredSourceDoesNotPersistStatHash).
+			// The fingerprint call still runs so size/mtime/data-
+			// version freshness checks proceed normally; the digest
+			// just lives somewhere gated by a confirmed outcome.
+			return 0, false
+		case stored == preParseStatHash.digest:
+			// Cold writes stamp fingerprint.MTimeNS as the max of
+			// chat + sibling companions (see codebuffFingerprintSource);
+			// the skip cache key/decision must align with that stamp
+			// so a cold→warm cycle does not drift. Only Codebuff/Freebuff
+			// have sibling companions today; other agents implementing
+			// MultiFileStatHasher fall through to chat-only via the
+			// helper.
+			//
+			// A matching digest proves only that the file stat is
+			// unchanged; it cannot prove the stored session is still
+			// current. Without row-existence, data-version, and
+			// project-reparse checks an unchanged Codebuff source would
+			// bypass parser migrations and project repairs indefinitely,
+			// because this short-circuit never reaches fingerprinting or
+			// parsing. Defer to the fingerprint path whenever the stored
+			// row is missing, stale, or needs project reclassification.
+			if !e.providerFreshDigestSourceCurrentInDB(lookupPath) {
+				return 0, false
+			}
+			return providerStatFreshnessMtime(file.Agent, lookupPath, info), true
+		default:
+			// Stored digest disagrees with current component stats.
+			// Forcing provider.Fingerprint instead of falling through
+			// to the size/mtime composite is the point of the per
+			// component digest: a same-size companion rewrite whose
+			// mtime stays below the existing max, an offsetting pair
+			// of size changes that cancel out in sum-of-sizes, or a
+			// missing companion that another leg replaces must not
+			// short-circuit on the legacy composite.
 			return 0, false
 		}
 	}
@@ -9780,6 +10509,40 @@ func (e *Engine) providerSourceFreshBeforeFingerprint(
 		// append still changes the composite and falls through to the
 		// full fingerprint.
 		size, mtime := kiloLegacyEffectiveStat(path, info)
+		effectiveInfo := fakeSnapshotInfo{
+			fSize:  size,
+			fMtime: mtime,
+		}
+		if e.shouldSkipByPath(path, effectiveInfo) {
+			return mtime, true
+		}
+	case parser.AgentCodebuff:
+		// Codebuff's fingerprint is composite (chat-messages.json
+		// plus run-state.json and chat-meta.json). The stat-only
+		// composite below matches the stored Size/Mtime the fingerprint
+		// stamps, so unchanged sessions skip without reading transcript
+		// bytes, and a sibling-only change still changes the composite
+		// and falls through to the full fingerprint.
+		//
+		// Note: the per-component digest above (Issue 1) handles the
+		// warm path once provider_freshness has at least one row. This
+		// case remains the cold-start fallback for the very first
+		// warm sync after the column is introduced, when no digest
+		// exists yet and the legacy size/mtime composite must still
+		// short-circuit unchanged sources so the digest can be
+		// stamped after the cold parse.
+		dir := filepath.Dir(path)
+		size := info.Size()
+		mtime := info.ModTime().UnixNano()
+		for _, name := range []string{"run-state.json", "chat-meta.json"} {
+			companion := filepath.Join(dir, name)
+			if ci, err := os.Stat(companion); err == nil {
+				size += ci.Size()
+				if ts := ci.ModTime().UnixNano(); ts > mtime {
+					mtime = ts
+				}
+			}
+		}
 		effectiveInfo := fakeSnapshotInfo{
 			fSize:  size,
 			fMtime: mtime,
@@ -10953,6 +11716,13 @@ type pendingWrite struct {
 	// baselineEligible is set by collectAndBatch only when the complete source
 	// outcome is safe to make deletion-eligible after this write succeeds.
 	baselineEligible bool
+	// providerStatHash is set on the first allowed ParseResult of a
+	// source whose processResult staged a per-component freshness
+	// digest. The flush path persists it after the matching session
+	// row commits successfully, so a downstream write failure or a
+	// CWD-filter veto never marks an absent or stale session as
+	// fresh. nil when the source is not a multi-file hasher agent.
+	providerStatHash *pendingProviderStatHash
 	// storageTrustPath/State/Snap promote the session's OpenCode
 	// storage-gate trust after its batch is confirmed fully written.
 	// Empty for everything else.
@@ -13994,6 +14764,55 @@ func (e *Engine) SourceMtime(sessionID string) int64 {
 		_, mtime := roocodeEffectiveStat(path, info)
 		return mtime
 	}
+	if def.Type == parser.AgentCodebuff {
+		// Freshness spans chat-messages.json plus run-state.json and
+		// chat-meta.json. Reducing three files to a single max mtime is
+		// lossy: a same-size companion-file rewrite whose mtime stays
+		// below the existing max, or offsetting size changes that keep
+		// the sum unchanged, would both leave SourceMtime stable and
+		// stale metadata survive. Hash each component's (size, mtime,
+		// ctime) triple plus directory metadata so any per-file change
+		// in size, mtime, or ctime is detected by the watcher. The
+		// triple matches the format used by ComputeMultiFileStatHash;
+		// ctime is the reliable change signal a pure (size, mtime)
+		// tuple lacks — a same-size rewrite with preserved mtime still
+		// bumps ctime on Unix and change-time on Windows.
+		dir := filepath.Dir(path)
+		h := fnv.New64a()
+		h.Write([]byte{0xCB})
+		var buf [24]byte
+		writeTuple := func(size, mtime, ctime int64) {
+			binary.LittleEndian.PutUint64(buf[:8], uint64(size))
+			binary.LittleEndian.PutUint64(buf[8:16], uint64(mtime))
+			binary.LittleEndian.PutUint64(buf[16:24], uint64(ctime))
+			_, _ = h.Write(buf[:])
+		}
+		// Primary file.
+		ci, err := os.Stat(path)
+		if err != nil {
+			return 0
+		}
+		ctime, _ := fileChangeTime(path, ci)
+		writeTuple(ci.Size(), ci.ModTime().UnixNano(), ctime)
+		// Companion files (run-state.json, chat-meta.json).
+		for _, name := range parser.CodebuffCompanionFilenames {
+			companion := filepath.Join(dir, name)
+			if ci, err := os.Stat(companion); err == nil {
+				ctime, _ := fileChangeTime(companion, ci)
+				writeTuple(ci.Size(), ci.ModTime().UnixNano(), ctime)
+			} else {
+				writeTuple(0, 0, 0)
+			}
+		}
+		// Directory metadata so create/rename/delete is folded in.
+		if di, err := os.Stat(dir); err == nil {
+			ctime, _ := fileChangeTime(dir, di)
+			writeTuple(0, di.ModTime().UnixNano(), ctime)
+		} else {
+			writeTuple(0, 0, 0)
+		}
+		return int64(h.Sum64())
+	}
 	if def.Type == parser.AgentKiloLegacy {
 		// Freshness spans task_metadata.json (the stored path) plus
 		// its siblings ui_messages.json and api_conversation_history.json.
@@ -14481,6 +15300,7 @@ func (e *Engine) processAndWriteSessionFile(
 		return false, nil
 	}
 
+	written := 0
 	for i, pr := range res.results {
 		write := pendingWrite{
 			sess:         pr.Session,
@@ -14507,6 +15327,12 @@ func (e *Engine) processAndWriteSessionFile(
 		// sibling write fails, so discover and queue children after every
 		// attempt rather than waiting for the entire result set to finish.
 		queueErr := queueWrittenChildren([]string{resultIDs[i]})
+		if writeErr == nil {
+			// A nil writeSessionFull is the single-session analog of
+			// outcome.written[i]=true in flushPending; only counted
+			// successes advance the persisted-digest gate below.
+			written++
+		}
 		if writeErr != nil &&
 			!isIntentionalSessionSkip(writeErr) &&
 			!errors.Is(writeErr, errSessionPreserved) {
@@ -14527,6 +15353,18 @@ func (e *Engine) processAndWriteSessionFile(
 		if errors.Is(writeErr, errSessionPreserved) {
 			preserved = true
 		}
+	}
+	// Persist staged digest only when at least one session row
+	// actually committed. Mirrors the per-row gate in flushPending:
+	// a session-trashed, parser-excluded, or otherwise skipped
+	// batch must NOT stamp provider_freshness with a digest whose
+	// matching session row was not actually persisted. Without this
+	// the single-session sync path would leave provider_freshness
+	// empty for Codebuff/Freebuff forever, leaving the digest gate
+	// un-armed on the next warm pass and a stale session row
+	// unrepaired by the per-component digest.
+	if written > 0 && res.providerStatHash != nil {
+		e.recordProviderStatHash(ctx, *res.providerStatHash)
 	}
 	if err := e.db.LinkSubagentSessionsForSessions(resultIDs); err != nil {
 		return false, fmt.Errorf("link changed subagent sessions: %w", err)

--- a/internal/sync/parsediff.go
+++ b/internal/sync/parsediff.go
@@ -392,6 +392,17 @@ func sortAndLimitParseDiffFiles(
 // reliability (parseDiffSourceReliableForRaced) and skip-cache/data-version
 // freshness are unaffected.
 func parseDiffDiscoveryMtime(f parser.DiscoveredFile) (int64, bool) {
+	// Codebuff/Freebuff session mtime is a composite of the primary
+	// chat-messages.json mtime plus any companion file (run-state.json,
+	// chat-meta.json) and directory mtime. The provider's DiscoveryMTimeNS
+	// stamps only the primary file's mtime, so a companion-only change
+	// would leave the ordering value stale and could drop a recently
+	// rewritten session from a --limit sample. Fall through to
+	// discoveredFileMtime for these agents so the composite freshness
+	// is used for ordering.
+	if f.Agent == parser.AgentCodebuff || f.Agent == parser.AgentFreebuff {
+		return 0, false
+	}
 	if f.ProviderSource == nil || f.ProviderSource.DiscoveryMTimeNS == 0 {
 		return 0, false
 	}
@@ -529,7 +540,18 @@ func (e *Engine) parseDiffSourceReliableForRaced(
 	// non-virtual DB path rather than trusting a shared store's composite mtime.
 	def, ok := parser.AgentByType(agent)
 	if !ok {
-		return false
+		// Freebuff shares the Codebuff provider and on-disk layout
+		// but is not a standalone entry in the parser Registry.
+		// Map it to the Codebuff definition so the raced guard
+		// applies to Freebuff sessions: their source is the same
+		// literal chat-messages.json file, and the composite
+		// companion mtime is the same per-session race signal.
+		if agent == parser.AgentFreebuff {
+			def, ok = parser.AgentByType(parser.AgentCodebuff)
+		}
+		if !ok {
+			return false
+		}
 	}
 	return def.FileBased && e.parseDiffAgentDiscoverable(def)
 }
@@ -574,6 +596,15 @@ func parseDiffLiveMtime(
 			return 0, err
 		}
 		return copilotEffectiveMtime(path, info), nil
+	case parser.AgentCodebuff, parser.AgentFreebuff:
+		// Codebuff and Freebuff share the same on-disk layout with
+		// companion files (run-state.json, chat-meta.json) that can
+		// change independently of chat-messages.json. Use the composite
+		// companion freshness so a companion-only rewrite is detected
+		// as a race rather than reported as drift.
+		return discoveredFileMtime(parser.DiscoveredFile{
+			Path: path, Agent: agent,
+		})
 	}
 	return discoveredFileMtime(parser.DiscoveredFile{
 		Path: path, Agent: agent,

--- a/internal/sync/parsediff_compare_test.go
+++ b/internal/sync/parsediff_compare_test.go
@@ -2296,6 +2296,164 @@ func TestParseDiffDBBackedLimitOrdersByDiscoveryMtime(t *testing.T) {
 		"the older session must be the one cut by --limit")
 }
 
+// TestParseDiffCodebuffCompanionOnlyChangeAdvancesOrderingMtime verifies
+// that a companion-only change (e.g. run-state.json touched while
+// chat-messages.json is untouched) advances the parse-diff ordering mtime.
+// The --limit sampler must not drop a recently rewritten session when the
+// only on-disk change is to a companion file. Verified: fails against the
+// pre-fix discoveredFileMtime (which only stat'd chat-messages.json) —
+// kept the older session instead of the companion-bumped one.
+func TestParseDiffCodebuffCompanionOnlyChangeAdvancesOrderingMtime(t *testing.T) {
+	// Two Codebuff sessions with identical chat-messages.json mtimes.
+	// Session A (older): chat-messages.json and run-state.json share
+	// the same base mtime. Session B (newer): chat-messages.json has
+	// the same base mtime, but run-state.json was bumped by one hour.
+	// A correct composite freshness must advance Session B's ordering
+	// value past Session A's, so --limit keeps B and cuts A.
+
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+
+	// Create minimal Codebuff session directories with companion files.
+	for _, dir := range []string{dirA, dirB} {
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, "chat-messages.json"),
+			[]byte(`[{"id":"u-1","variant":"user","content":"hello","timestamp":"03:04 PM"}]`),
+			0o644,
+		))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, "run-state.json"),
+			[]byte(`{"sessionState":{"mainAgentState":{"agentType":"base2-free-deepseek"}}}`),
+			0o644,
+		))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, "chat-meta.json"),
+			[]byte(`{"messageCount":1,"firstPrompt":"hello","messagesSize":50}`),
+			0o644,
+		))
+	}
+
+	baseTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	// Chtimes updates ctime to the current wall-clock time on all
+	// platforms, and codebuffCompositeMtime uses max(mtime,ctime).
+	// Use a future mtime so the bumped companion's mtime dominates
+	// its own ctime rather than being buried by it.
+	newerTime := time.Now().Add(time.Hour)
+
+	// Pin both chat-messages.json files to the same mtime.
+	chatA := filepath.Join(dirA, "chat-messages.json")
+	chatB := filepath.Join(dirB, "chat-messages.json")
+	require.NoError(t, os.Chtimes(chatA, baseTime, baseTime))
+	require.NoError(t, os.Chtimes(chatB, baseTime, baseTime))
+
+	// Pin both chat-meta.json files to base time.
+	metaA := filepath.Join(dirA, "chat-meta.json")
+	metaB := filepath.Join(dirB, "chat-meta.json")
+	require.NoError(t, os.Chtimes(metaA, baseTime, baseTime))
+	require.NoError(t, os.Chtimes(metaB, baseTime, baseTime))
+
+	// Session A: run-state.json at base time (no companion change).
+	runStateA := filepath.Join(dirA, "run-state.json")
+	require.NoError(t, os.Chtimes(runStateA, baseTime, baseTime))
+
+	// Session B: run-state.json bumped (companion-only change).
+	runStateB := filepath.Join(dirB, "run-state.json")
+	require.NoError(t, os.Chtimes(runStateB, newerTime, newerTime))
+
+	kept, cutPaths, limited := sortAndLimitParseDiffFiles(
+		[]parser.DiscoveredFile{
+			{Path: chatA, Agent: parser.AgentCodebuff},
+			{Path: chatB, Agent: parser.AgentCodebuff},
+		},
+		1,
+	)
+
+	require.True(t, limited)
+	require.Len(t, kept, 1)
+	assert.Equal(t, chatB, kept[0].Path,
+		"newer run-state.json must advance the composite freshness mtime "+
+			"even though chat-messages.json mtimes are identical; a zero here "+
+			"means parseDiffDiscoveryMtime or discoveredFileMtime dropped "+
+			"the companion stat and ordered by primary mtime alone")
+	assert.Len(t, cutPaths, 1)
+	assert.True(t, cutPaths[chatA],
+		"the session with older run-state.json must be the one cut by --limit")
+}
+
+func TestParseDiffFreebuffCompanionOnlyChangeAdvancesOrderingMtime(t *testing.T) {
+	// Freebuff variant of the Codebuff companion-only test. Freebuff
+	// shares the Codebuff provider and routes through codebuffCompositeMtime,
+	// so companion-only changes must advance the ordering mtime the same way.
+
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+
+	// Create minimal session directories with companion files.
+	for _, dir := range []string{dirA, dirB} {
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, "chat-messages.json"),
+			[]byte(`[{"id":"u-1","variant":"user","content":"hello","timestamp":"03:04 PM"}]`),
+			0o644,
+		))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, "run-state.json"),
+			[]byte(`{"sessionState":{"mainAgentState":{"agentType":"base2-free-deepseek"}}}`),
+			0o644,
+		))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, "chat-meta.json"),
+			[]byte(`{"messageCount":1,"firstPrompt":"hello","messagesSize":50}`),
+			0o644,
+		))
+	}
+
+	baseTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	// Chtimes updates ctime to the current wall-clock time on all
+	// platforms, and codebuffCompositeMtime uses max(mtime,ctime).
+	// Use a future mtime so the bumped companion's mtime dominates
+	// its own ctime rather than being buried by it.
+	newerTime := time.Now().Add(time.Hour)
+
+	// Pin both chat-messages.json files to the same mtime.
+	chatA := filepath.Join(dirA, "chat-messages.json")
+	chatB := filepath.Join(dirB, "chat-messages.json")
+	require.NoError(t, os.Chtimes(chatA, baseTime, baseTime))
+	require.NoError(t, os.Chtimes(chatB, baseTime, baseTime))
+
+	// Pin both chat-meta.json files to base time.
+	metaA := filepath.Join(dirA, "chat-meta.json")
+	metaB := filepath.Join(dirB, "chat-meta.json")
+	require.NoError(t, os.Chtimes(metaA, baseTime, baseTime))
+	require.NoError(t, os.Chtimes(metaB, baseTime, baseTime))
+
+	// Session A: run-state.json at base time (no companion change).
+	runStateA := filepath.Join(dirA, "run-state.json")
+	require.NoError(t, os.Chtimes(runStateA, baseTime, baseTime))
+
+	// Session B: run-state.json bumped (companion-only change).
+	runStateB := filepath.Join(dirB, "run-state.json")
+	require.NoError(t, os.Chtimes(runStateB, newerTime, newerTime))
+
+	kept, cutPaths, limited := sortAndLimitParseDiffFiles(
+		[]parser.DiscoveredFile{
+			{Path: chatA, Agent: parser.AgentFreebuff},
+			{Path: chatB, Agent: parser.AgentFreebuff},
+		},
+		1,
+	)
+
+	require.True(t, limited)
+	require.Len(t, kept, 1)
+	assert.Equal(t, chatB, kept[0].Path,
+		"Freebuff: newer run-state.json must advance the composite freshness "+
+			"even though chat-messages.json mtimes are identical; a zero here "+
+			"means discoveredFileMtime did not route AgentFreebuff through "+
+			"codebuffCompositeMtime")
+	assert.Len(t, cutPaths, 1)
+	assert.True(t, cutPaths[chatA],
+		"the session with older run-state.json must be the one cut by --limit")
+}
+
 func TestParseDiffReportHasFailures(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/sync/provider_effects.go
+++ b/internal/sync/provider_effects.go
@@ -20,12 +20,18 @@ func validateProviderOutcome(
 	for _, result := range outcome.Results {
 		session := result.Result.Session
 		if session.Agent != def.Type {
-			return fmt.Errorf(
-				"%s: provider result session agent mismatch for %q: got %s",
-				def.Type,
-				session.ID,
-				session.Agent,
-			)
+			// The Codebuff provider may emit Freebuff sessions based on
+			// the agentType field in run-state.json. Both agents share
+			// the same on-disk layout and are discovered by one provider.
+			if def.Type != parser.AgentCodebuff ||
+				session.Agent != parser.AgentFreebuff {
+				return fmt.Errorf(
+					"%s: provider result session agent mismatch for %q: got %s",
+					def.Type,
+					session.ID,
+					session.Agent,
+				)
+			}
 		}
 		if err := validateProviderParseResultSessionIDs(def, result.Result); err != nil {
 			return err
@@ -102,6 +108,12 @@ func validateProviderSessionID(def parser.AgentDef, sessionID, field string) err
 		return nil
 	}
 	if strings.HasPrefix(sessionID, def.IDPrefix) {
+		return nil
+	}
+	// The Codebuff provider may emit Freebuff sessions whose IDs use
+	// the "freebuff:" prefix rather than the provider's "codebuff:" prefix.
+	if def.Type == parser.AgentCodebuff &&
+		strings.HasPrefix(sessionID, string(parser.AgentFreebuff)+":") {
 		return nil
 	}
 	return fmt.Errorf(

--- a/internal/sync/provider_effects_test.go
+++ b/internal/sync/provider_effects_test.go
@@ -1,0 +1,91 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.kenn.io/agentsview/internal/parser"
+)
+
+func TestValidateProviderOutcome_FreebuffException(t *testing.T) {
+	// The Codebuff provider may emit Freebuff sessions based on the
+	// agentType field in run-state.json. Both agents share the same
+	// on-disk layout and are discovered by one provider.
+	def := parser.AgentDef{
+		Type:      parser.AgentCodebuff,
+		IDPrefix:  "codebuff:",
+		FileBased: true,
+	}
+	source := parser.SourceRef{
+		Provider: parser.AgentCodebuff,
+		Key:      "test-source",
+	}
+	fingerprint := parser.SourceFingerprint{Key: "test-source"}
+
+	outcome := parser.ParseOutcome{
+		Results: []parser.ParseResultOutcome{
+			{
+				Result: parser.ParseResult{
+					Session: parser.ParsedSession{
+						ID:    "freebuff:2026-07-15T20-01-32.065Z",
+						Agent: parser.AgentFreebuff,
+					},
+				},
+			},
+		},
+	}
+
+	err := validateProviderOutcome(def, source, fingerprint, outcome)
+	assert.NoError(t, err, "Codebuff provider should accept Freebuff sessions")
+}
+
+func TestValidateProviderOutcome_RejectsWrongAgent(t *testing.T) {
+	// Non-Freebuff agents from the Codebuff provider should be rejected.
+	def := parser.AgentDef{
+		Type:      parser.AgentCodebuff,
+		IDPrefix:  "codebuff:",
+		FileBased: true,
+	}
+	source := parser.SourceRef{
+		Provider: parser.AgentCodebuff,
+		Key:      "test-source",
+	}
+	fingerprint := parser.SourceFingerprint{Key: "test-source"}
+
+	outcome := parser.ParseOutcome{
+		Results: []parser.ParseResultOutcome{
+			{
+				Result: parser.ParseResult{
+					Session: parser.ParsedSession{
+						ID:    "codebuff:2026-07-15T20-01-32.065Z",
+						Agent: parser.AgentGemini,
+					},
+				},
+			},
+		},
+	}
+
+	err := validateProviderOutcome(def, source, fingerprint, outcome)
+	assert.Error(t, err, "Codebuff provider should reject non-Codebuff/Freebuff agents")
+	assert.Contains(t, err.Error(), "agent mismatch")
+}
+
+func TestValidateProviderSessionID_FreebuffPrefix(t *testing.T) {
+	def := parser.AgentDef{
+		Type:     parser.AgentCodebuff,
+		IDPrefix: "codebuff:",
+	}
+
+	// Freebuff prefix should be accepted.
+	err := validateProviderSessionID(def, "freebuff:2026-07-15T20-01-32.065Z", "session id")
+	assert.NoError(t, err, "Codebuff provider should accept freebuff: prefixed IDs")
+
+	// Codebuff prefix should also be accepted (normal case).
+	err = validateProviderSessionID(def, "codebuff:2026-07-15T20-01-32.065Z", "session id")
+	assert.NoError(t, err, "Codebuff provider should accept codebuff: prefixed IDs")
+
+	// Gemini prefix should be rejected.
+	err = validateProviderSessionID(def, "gemini:sess-id", "session id")
+	assert.Error(t, err, "Codebuff provider should reject gemini: prefixed IDs")
+}

--- a/internal/sync/roocode_freshness_test.go
+++ b/internal/sync/roocode_freshness_test.go
@@ -70,7 +70,9 @@ func TestRooCodeFreshBeforeFingerprintUsesCompositeStat(t *testing.T) {
 		})
 	}
 
-	mtime, fresh := engine.providerSourceFreshBeforeFingerprint(source, file)
+	mtime, fresh := engine.providerSourceFreshBeforeFingerprint(
+		t.Context(), source, file, nil,
+	)
 	assert.True(t, fresh, "unchanged composite stat must skip the fingerprint")
 	assert.Equal(t, compositeMtime, mtime)
 
@@ -87,7 +89,9 @@ func TestRooCodeFreshBeforeFingerprintUsesCompositeStat(t *testing.T) {
 		[]byte(`[{"ts":2,"type":"say","say":"text","text":"hi"}]`), 0o644))
 	require.NoError(t, os.Chtimes(messagesPath, future, future))
 
-	_, fresh = engine.providerSourceFreshBeforeFingerprint(source, file)
+	_, fresh = engine.providerSourceFreshBeforeFingerprint(
+		t.Context(), source, file, nil,
+	)
 	assert.False(t, fresh,
 		"a sibling-only transcript change must fall through to the fingerprint")
 }

--- a/internal/sync/s3_source_test.go
+++ b/internal/sync/s3_source_test.go
@@ -1471,6 +1471,10 @@ func TestSyncRootsSinceScopedRemoteRootSyncsNewObject(t *testing.T) {
 	})
 	t.Cleanup(engine.Close)
 
+	// Reset after the engine-construction probe from buildProviderStatHashers
+	// which calls NewProvider with empty roots for the type assertion.
+	factory.roots = nil
+
 	stats := engine.SyncRootsSince(
 		context.Background(), []string{remoteRoot}, time.Time{}, nil,
 	)


### PR DESCRIPTION
Parses Codebuff and Freebuff sessions from `~/.config/manicode/projects/<project>/chats/<timestamp>/`. Both agents share the same on-disk layout; sessions are classified by the `agentType` field in `run-state.json`.

### Highlights

- Full transcript parsing: user/ai/error messages, tool calls with skill attribution, thinking blocks, subagent invocations
- Block types: text, tool, agent, mode-divider, plan, ask-user, image
- Credits tracking: extracts `creditsUsed` from `run-state.json` and maps to cost (1 credit = $0.01)
- Freebuff auto-classification: sessions with "free" in `agentType` appear as a separate filter

### Unique considerations

- Freebuff shares the Codebuff provider (single registration) to avoid double-discovery and skip-cache contention
- The `agentType` field is an agent template name (e.g. `base2-free-deepseek`), not the actual LLM model -- the real model is selected server-side
- `contextTokenCount` provides context window size but per-message token breakdown is not available in the on-disk format

### Limitations

- Mid-session model switches are invisible -- the on-disk format has no per-turn model field
- Freebuff has no credits (ad-supported); cost tracking only applies to Codebuff
- The `agent` field on `ChatMessage` is not populated in the persisted format, so per-turn agent attribution relies on subagent blocks only