### PR TITLE
fix(sync): bound OpenCode background work across watcher and polling modes

### DIFF
--- a/cmd/agentsview/archive_write_backend.go
+++ b/cmd/agentsview/archive_write_backend.go
@@ -104,6 +104,7 @@ func newArchivePushUnwatchedPoller(
 	ticker := time.NewTicker(unwatchedPollInterval)
 	return newUnwatchedPollCoordinatorWithTicks(
 		ctx, engine, ticker.C, ticker.Stop, func(work func()) { work() }, nil,
+		newProviderDegradedPollingResolver(),
 	)
 }
 
@@ -924,11 +925,10 @@ func (b *localArchiveWriteBackend) PGPushWatch(
 			},
 			OnPollingRequired: func(obligation syncpkg.PollingObligation) error {
 				return poller.AddObligation(pollingObligation{
-					Key:           obligation.Key,
-					Agent:         obligation.Agent,
-					Roots:         obligation.Roots,
-					Probe:         obligation.Probe,
-					DegradedProbe: obligation.DegradedProbe,
+					Key:   obligation.Key,
+					Agent: obligation.Agent,
+					Roots: obligation.Roots,
+					Probe: obligation.Probe,
 				})
 			},
 			OnPollingReleased: poller.RemoveObligation,

--- a/cmd/agentsview/archive_write_backend.go
+++ b/cmd/agentsview/archive_write_backend.go
@@ -925,6 +925,7 @@ func (b *localArchiveWriteBackend) PGPushWatch(
 			OnPollingRequired: func(obligation syncpkg.PollingObligation) error {
 				return poller.AddObligation(pollingObligation{
 					Key:           obligation.Key,
+					Agent:         obligation.Agent,
 					Roots:         obligation.Roots,
 					Probe:         obligation.Probe,
 					DegradedProbe: obligation.DegradedProbe,

--- a/cmd/agentsview/archive_write_backend.go
+++ b/cmd/agentsview/archive_write_backend.go
@@ -924,9 +924,10 @@ func (b *localArchiveWriteBackend) PGPushWatch(
 			},
 			OnPollingRequired: func(obligation syncpkg.PollingObligation) error {
 				return poller.AddObligation(pollingObligation{
-					Key:   obligation.Key,
-					Roots: obligation.Roots,
-					Probe: obligation.Probe,
+					Key:           obligation.Key,
+					Roots:         obligation.Roots,
+					Probe:         obligation.Probe,
+					DegradedProbe: obligation.DegradedProbe,
 				})
 			},
 			OnPollingReleased: poller.RemoveObligation,

--- a/cmd/agentsview/archive_write_backend_test.go
+++ b/cmd/agentsview/archive_write_backend_test.go
@@ -829,7 +829,6 @@ func TestLocalPGPushWatchPropagatesDegradedProbeToArchivePoller(t *testing.T) {
 		},
 		database: database,
 	}
-	probe := &staticDegradedPollProbe{}
 	poller := &recordingUnwatchedRootPoller{
 		added: make(chan pollingObligation, 1),
 	}
@@ -843,10 +842,10 @@ func TestLocalPGPushWatchPropagatesDegradedProbeToArchivePoller(t *testing.T) {
 			options syncpkg.WatcherOptions,
 		) (func(), func(), []string) {
 			require.NoError(t, options.OnPollingRequired(syncpkg.PollingObligation{
-				Key:           "watch-root|scope",
-				Roots:         []string{filepath.Join(dataDir, "scope")},
-				Probe:         filepath.Join(dataDir, "watch-root"),
-				DegradedProbe: probe,
+				Key:   "watch-root|scope",
+				Agent: parser.AgentOpenCode,
+				Roots: []string{filepath.Join(dataDir, "scope")},
+				Probe: filepath.Join(dataDir, "watch-root"),
 			}))
 			return func() {}, func() {}, nil
 		},
@@ -881,9 +880,9 @@ func TestLocalPGPushWatchPropagatesDegradedProbeToArchivePoller(t *testing.T) {
 	select {
 	case obligation := <-poller.added:
 		assert.Equal(t, "watch-root|scope", obligation.Key)
+		assert.Equal(t, parser.AgentOpenCode, obligation.Agent)
 		assert.Equal(t, []string{filepath.Join(dataDir, "scope")}, obligation.Roots)
 		assert.Equal(t, filepath.Join(dataDir, "watch-root"), obligation.Probe)
-		assert.Same(t, probe, obligation.DegradedProbe)
 	default:
 		t.Fatal("expected polling obligation to reach archive poller")
 	}
@@ -953,6 +952,7 @@ func TestLocalPGPushWatchGivesDeferredScopesAPollingOwner(t *testing.T) {
 				func(roots []string) {
 					owned <- append([]string(nil), roots...)
 				},
+				nil,
 			)
 		},
 	}

--- a/cmd/agentsview/archive_write_backend_test.go
+++ b/cmd/agentsview/archive_write_backend_test.go
@@ -806,6 +806,89 @@ func (noopPGTarget) PushWithOptions(
 }
 func (noopPGTarget) Close() error { return nil }
 
+type recordingUnwatchedRootPoller struct {
+	added chan pollingObligation
+}
+
+func (p *recordingUnwatchedRootPoller) AddObligation(obligation pollingObligation) error {
+	p.added <- obligation
+	return nil
+}
+
+func (*recordingUnwatchedRootPoller) RemoveObligation(string) error { return nil }
+func (*recordingUnwatchedRootPoller) Stop()                         {}
+
+func TestLocalPGPushWatchPropagatesDegradedProbeToArchivePoller(t *testing.T) {
+	dataDir := t.TempDir()
+	dbPath := filepath.Join(dataDir, "sessions.db")
+	database := dbtest.OpenTestDBAt(t, dbPath)
+	backend := &localArchiveWriteBackend{
+		appCfg: config.Config{
+			DataDir: dataDir,
+			DBPath:  dbPath,
+		},
+		database: database,
+	}
+	probe := &staticDegradedPollProbe{}
+	poller := &recordingUnwatchedRootPoller{
+		added: make(chan pollingObligation, 1),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	backend.watchHooks = &archivePushWatchHooks{
+		startWatcher: func(
+			_ config.Config,
+			_ *syncpkg.Engine,
+			_ syncpkg.WatchCallback,
+			options syncpkg.WatcherOptions,
+		) (func(), func(), []string) {
+			require.NoError(t, options.OnPollingRequired(syncpkg.PollingObligation{
+				Key:           "watch-root|scope",
+				Roots:         []string{filepath.Join(dataDir, "scope")},
+				Probe:         filepath.Join(dataDir, "watch-root"),
+				DegradedProbe: probe,
+			}))
+			return func() {}, func() {}, nil
+		},
+		newLoop: func(
+			_ string, _ time.Duration, _ time.Duration,
+			_ func(context.Context, pushReason) error,
+		) (*pushLoop, func()) {
+			return &pushLoop{}, func() {}
+		},
+		newPGPusher: func(*syncpkg.Engine) *pgPusher {
+			return &pgPusher{
+				localSync: func(context.Context) error { return nil },
+				connect:   func() (pgTarget, error) { return noopPGTarget{}, nil },
+			}
+		},
+		pgStartupSync: func(_ context.Context, _ *syncpkg.Engine, _ bool) (bool, error) {
+			cancel()
+			return false, context.Canceled
+		},
+		newUnwatchedPoller: func(
+			context.Context, unwatchedPollSyncer,
+		) unwatchedRootPoller {
+			return poller
+		},
+	}
+
+	require.NoError(t, backend.PGPushWatch(
+		ctx, pgTargetSelection{}, PGPushConfig{}, nil, nil,
+		time.Hour, time.Hour,
+	))
+
+	select {
+	case obligation := <-poller.added:
+		assert.Equal(t, "watch-root|scope", obligation.Key)
+		assert.Equal(t, []string{filepath.Join(dataDir, "scope")}, obligation.Roots)
+		assert.Equal(t, filepath.Join(dataDir, "watch-root"), obligation.Probe)
+		assert.Same(t, probe, obligation.DegradedProbe)
+	default:
+		t.Fatal("expected polling obligation to reach archive poller")
+	}
+}
+
 // The watcher's full recovery and rename promotion defer unavailable scopes
 // to their polling probes, and pg watch's interval push is a plain SyncAll
 // that never tombstones missed deletions. Local pg watch must therefore own

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -330,11 +330,10 @@ func runServe(cfg config.Config, opts serveOptions) {
 				},
 				OnPollingRequired: func(obligation sync.PollingObligation) error {
 					return unwatchedPoller.AddObligation(pollingObligation{
-						Key:           obligation.Key,
-						Agent:         obligation.Agent,
-						Roots:         obligation.Roots,
-						Probe:         obligation.Probe,
-						DegradedProbe: obligation.DegradedProbe,
+						Key:   obligation.Key,
+						Agent: obligation.Agent,
+						Roots: obligation.Roots,
+						Probe: obligation.Probe,
 					})
 				},
 				OnPollingReleased: unwatchedPoller.RemoveObligation,
@@ -1908,7 +1907,9 @@ func watchPollingObligations(
 			result = results[i]
 		}
 		if !result.MissingRootLifecycleOwned {
-			add(root.pollingObligations(root.path, root.path, root.pendingPollingDirs)...)
+			add(root.pollingObligations(
+				root.path, root.path, root.pendingPollingDirs, false,
+			)...)
 		}
 		for _, dir := range root.persistentPollingDirs {
 			cleanDir := filepath.Clean(dir)
@@ -1923,12 +1924,16 @@ func watchPollingObligations(
 			// after the obligations are installed leaves its configured dir
 			// pollable and the fallback poll reconciles it as an
 			// authoritative empty discovery.
-			add(root.pollingObligations(root.path, root.path, root.syncDirs())...)
+			add(root.pollingObligations(
+				root.path, root.path, root.syncDirs(), true,
+			)...)
 			continue
 		}
 		if result.Unwatched > 0 || result.BudgetExhausted ||
 			result.ResourceExhausted || result.Err != nil {
-			add(root.pollingObligations(root.path, root.path, root.syncDirs())...)
+			add(root.pollingObligations(
+				root.path, root.path, root.syncDirs(), true,
+			)...)
 		}
 	}
 	for _, dir := range unwatchedDirs {
@@ -1949,6 +1954,7 @@ func (r watchRoot) pollingObligations(
 	rootKey string,
 	probePath string,
 	dirs []string,
+	providerScoped bool,
 ) []sync.PollingObligation {
 	dirs = deduplicateStrings(dirs)
 	if len(dirs) == 0 {
@@ -1959,16 +1965,12 @@ func (r watchRoot) pollingObligations(
 		dirFilter[filepath.Clean(dir)] = struct{}{}
 	}
 	byKey := make(map[string][]string)
-	degraded := make(map[string]parser.DegradedPollingStateProbe)
+	obligationAgent := make(map[string]parser.AgentType)
 	for _, dir := range dirs {
 		cleanDir := filepath.Clean(dir)
 		key := rootKey
-		var (
-			probe      parser.DegradedPollingStateProbe
-			probeAgent parser.AgentType
-			probeOK    = true
-			seen       bool
-		)
+		var agent parser.AgentType
+		sameAgent := true
 		for _, scope := range r.scopes {
 			if filepath.Clean(scope.syncDir) != cleanDir {
 				continue
@@ -1976,24 +1978,23 @@ func (r watchRoot) pollingObligations(
 			if _, ok := dirFilter[filepath.Clean(scope.syncDir)]; !ok {
 				continue
 			}
-			seen = true
-			if scope.degradedProbe == nil {
-				probeOK = false
-				break
-			}
-			if probe == nil {
-				probe = scope.degradedProbe
-				probeAgent = scope.agent
-				continue
-			}
-			if scope.agent != probeAgent {
-				probeOK = false
-				break
+			if agent == "" {
+				agent = scope.agent
+			} else if scope.agent != agent {
+				sameAgent = false
 			}
 		}
-		if seen && probeOK && probe != nil {
+		if providerScoped && sameAgent && agent != "" {
 			key = rootKey + "|" + cleanDir
-			degraded[key] = probe
+		}
+		currentAgent := parser.AgentType("")
+		if sameAgent {
+			currentAgent = agent
+		}
+		if prior, ok := obligationAgent[key]; !ok {
+			obligationAgent[key] = currentAgent
+		} else if prior == "" || currentAgent == "" || prior != currentAgent {
+			obligationAgent[key] = ""
 		}
 		byKey[key] = appendUniqueString(byKey[key], cleanDir)
 	}
@@ -2007,10 +2008,10 @@ func (r watchRoot) pollingObligations(
 		roots := byKey[key]
 		slices.Sort(roots)
 		obligations = append(obligations, sync.PollingObligation{
-			Key:           key,
-			Roots:         roots,
-			Probe:         filepath.Clean(probePath),
-			DegradedProbe: degraded[key],
+			Key:   key,
+			Agent: obligationAgent[key],
+			Roots: roots,
+			Probe: filepath.Clean(probePath),
 		})
 	}
 	return obligations
@@ -2360,24 +2361,8 @@ func deduplicateStrings(values []string) []string {
 }
 
 type watchScope struct {
-	agent         parser.AgentType
-	syncDir       string
-	degradedProbe parser.DegradedPollingStateProbe
-}
-
-type lateBoundDegradedPollProbe struct {
-	provider parser.Provider
-	root     string
-}
-
-func (p lateBoundDegradedPollProbe) DegradedPollingState(
-	ctx context.Context,
-) (string, error) {
-	probe, err := parser.ResolveDegradedPollingProbe(ctx, p.provider, p.root)
-	if err != nil {
-		return "", err
-	}
-	return probe.DegradedPollingState(ctx)
+	agent   parser.AgentType
+	syncDir string
 }
 
 type watchRoot struct {
@@ -2393,9 +2378,8 @@ func (r watchRoot) registeredRoot() sync.WatchRoot {
 	scopes := make([]sync.WatchScope, 0, len(r.scopes))
 	for _, scope := range r.scopes {
 		scopes = append(scopes, sync.WatchScope{
-			Agent:         string(scope.agent),
-			SyncDir:       scope.syncDir,
-			DegradedProbe: scope.degradedProbe,
+			Agent:   string(scope.agent),
+			SyncDir: scope.syncDir,
 		})
 	}
 	return sync.WatchRoot{
@@ -2432,13 +2416,11 @@ func collectWatchRoots(cfg config.Config) (
 		path string,
 		recursive,
 		exists bool,
-		degradedProbe parser.DegradedPollingStateProbe,
 	) {
 		path = filepath.Clean(path)
 		scope := watchScope{
-			agent:         agent,
-			syncDir:       filepath.Clean(dir),
-			degradedProbe: degradedProbe,
+			agent:   agent,
+			syncDir: filepath.Clean(dir),
 		}
 		if idx, ok := rootIndexes[path]; ok {
 			roots[idx].recursive = roots[idx].recursive || recursive
@@ -2465,9 +2447,8 @@ func collectWatchRoots(cfg config.Config) (
 				root string,
 				recursive,
 				exists bool,
-				degradedProbe parser.DegradedPollingStateProbe,
 			) {
-				addRoot(def.Type, dir, root, recursive, exists, degradedProbe)
+				addRoot(def.Type, dir, root, recursive, exists)
 			}
 			_, hasProvider := parser.ProviderFactoryByType(def.Type)
 			if providerWatched, polling := collectProviderWatchRoots(def, d, addAgentRoot); providerWatched {
@@ -2537,7 +2518,6 @@ func collectProviderWatchRoots(
 		root string,
 		recursive,
 		exists bool,
-		degradedProbe parser.DegradedPollingStateProbe,
 	),
 ) (bool, providerPollingReasons) {
 	factory, ok := parser.ProviderFactoryByType(def.Type)
@@ -2568,30 +2548,9 @@ func collectProviderWatchRoots(
 			polling.symlinkRoots = append(polling.symlinkRoots, root)
 			continue
 		}
-		degradedProbe, probeErr := parser.ResolveDegradedPollingProbe(
-			context.Background(), provider, root,
-		)
-		if probeErr != nil {
-			if errors.Is(probeErr, parser.ErrUnsupportedProviderFeature) &&
-				def.Type == parser.AgentOpenCode {
-				degradedProbe = lateBoundDegradedPollProbe{
-					provider: provider,
-					root:     root,
-				}
-			} else if !errors.Is(probeErr, parser.ErrUnsupportedProviderFeature) {
-				log.Printf("%s provider degraded poll probe for %s: %v",
-					def.Type, root, probeErr)
-				degradedProbe = nil
-			}
-		} else if def.Type == parser.AgentOpenCode {
-			degradedProbe = lateBoundDegradedPollProbe{
-				provider: provider,
-				root:     root,
-			}
-		}
 		_, err := os.Stat(root)
 		exists := err == nil
-		addRoot(dir, root, providerRoot.Recursive, exists, degradedProbe)
+		addRoot(dir, root, providerRoot.Recursive, exists)
 		if exists {
 			continue
 		}
@@ -2661,14 +2620,13 @@ func collectLegacyWatchRoots(
 		root string,
 		recursive,
 		exists bool,
-		degradedProbe parser.DegradedPollingStateProbe,
 	),
 ) []string {
 	var unwatchedDirs []string
 	if def.ShallowWatchRootsFunc != nil {
 		for _, watchDir := range def.ShallowWatchRootsFunc(dir) {
 			if _, err := os.Stat(watchDir); err == nil {
-				addRoot(dir, watchDir, false, true, nil)
+				addRoot(dir, watchDir, false, true)
 			}
 		}
 	}
@@ -2679,7 +2637,7 @@ func collectLegacyWatchRoots(
 		}
 		for _, watchDir := range watchDirs {
 			if _, err := os.Stat(watchDir); err == nil {
-				addRoot(dir, watchDir, !def.ShallowWatch, true, nil)
+				addRoot(dir, watchDir, !def.ShallowWatch, true)
 				continue
 			}
 			unwatchedDirs = append(unwatchedDirs, dir)
@@ -2688,14 +2646,14 @@ func collectLegacyWatchRoots(
 	}
 	if len(def.WatchSubdirs) == 0 {
 		if _, err := os.Stat(dir); err == nil {
-			addRoot(dir, dir, !def.ShallowWatch, true, nil)
+			addRoot(dir, dir, !def.ShallowWatch, true)
 		}
 		return unwatchedDirs
 	}
 	for _, sub := range def.WatchSubdirs {
 		watchDir := filepath.Join(dir, sub)
 		if _, err := os.Stat(watchDir); err == nil {
-			addRoot(dir, watchDir, !def.ShallowWatch, true, nil)
+			addRoot(dir, watchDir, !def.ShallowWatch, true)
 		}
 	}
 	return unwatchedDirs

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -330,9 +330,10 @@ func runServe(cfg config.Config, opts serveOptions) {
 				},
 				OnPollingRequired: func(obligation sync.PollingObligation) error {
 					return unwatchedPoller.AddObligation(pollingObligation{
-						Key:   obligation.Key,
-						Roots: obligation.Roots,
-						Probe: obligation.Probe,
+						Key:           obligation.Key,
+						Roots:         obligation.Roots,
+						Probe:         obligation.Probe,
+						DegradedProbe: obligation.DegradedProbe,
 					})
 				},
 				OnPollingReleased: unwatchedPoller.RemoveObligation,
@@ -1887,15 +1888,24 @@ func watchPollingObligations(
 ) []sync.PollingObligation {
 	byKey := make(map[string][]string)
 	probes := make(map[string]string)
+	degraded := make(map[string]parser.DegradedPollingStateProbe)
 	represented := make(map[string]struct{})
 	// The probe is the physical path whose availability gates the
 	// obligation's reconciliation roots: the watch root's own path for
 	// root-keyed groups, the dir itself for persistent dirs.
-	add := func(key, probe string, roots ...string) {
+	add := func(
+		key,
+		probe string,
+		degradedProbe parser.DegradedPollingStateProbe,
+		roots ...string,
+	) {
 		if key == "" {
 			return
 		}
 		probes[key] = filepath.Clean(probe)
+		if degradedProbe != nil {
+			degraded[key] = degradedProbe
+		}
 		for _, root := range roots {
 			if root == "" {
 				continue
@@ -1911,10 +1921,10 @@ func watchPollingObligations(
 			result = results[i]
 		}
 		if !result.MissingRootLifecycleOwned {
-			add(root.path, root.path, root.pendingPollingDirs...)
+			add(root.path, root.path, root.degradedPollProbe, root.pendingPollingDirs...)
 		}
 		for _, dir := range root.persistentPollingDirs {
-			add("persistent:"+filepath.Clean(dir), dir, dir)
+			add("persistent:"+filepath.Clean(dir), dir, nil, dir)
 		}
 		if i >= len(results) {
 			// No registration result exists for this root: the watcher was
@@ -1923,25 +1933,25 @@ func watchPollingObligations(
 			// after the obligations are installed leaves its configured dir
 			// pollable and the fallback poll reconciles it as an
 			// authoritative empty discovery.
-			add(root.path, root.path, root.syncDirs()...)
+			add(root.path, root.path, root.degradedPollProbe, root.syncDirs()...)
 			continue
 		}
 		if result.Unwatched > 0 || result.BudgetExhausted ||
 			result.ResourceExhausted || result.Err != nil {
-			add(root.path, root.path, root.syncDirs()...)
+			add(root.path, root.path, root.degradedPollProbe, root.syncDirs()...)
 		}
 	}
 	for _, dir := range unwatchedDirs {
 		dir = filepath.Clean(dir)
 		if _, ok := represented[dir]; !ok {
-			add("persistent:"+dir, dir, dir)
+			add("persistent:"+dir, dir, nil, dir)
 		}
 	}
 	obligations := make([]sync.PollingObligation, 0, len(byKey))
 	for key, roots := range byKey {
 		slices.Sort(roots)
 		obligations = append(obligations, sync.PollingObligation{
-			Key: key, Roots: roots, Probe: probes[key],
+			Key: key, Roots: roots, Probe: probes[key], DegradedProbe: degraded[key],
 		})
 	}
 	slices.SortFunc(obligations, func(a, b sync.PollingObligation) int {
@@ -2300,6 +2310,7 @@ type watchRoot struct {
 	scopes                []watchScope
 	pendingPollingDirs    []string
 	persistentPollingDirs []string
+	degradedPollProbe     parser.DegradedPollingStateProbe
 }
 
 func (r watchRoot) registeredRoot() sync.WatchRoot {
@@ -2338,12 +2349,22 @@ func collectWatchRoots(cfg config.Config) (
 	rootIndexes := make(map[string]int)
 	persistentPollingDirs := make(map[string]struct{})
 	symlinkGatedDirs = make(map[string][]string)
-	addRoot := func(agent parser.AgentType, dir, path string, recursive, exists bool) {
+	addRoot := func(
+		agent parser.AgentType,
+		dir,
+		path string,
+		recursive,
+		exists bool,
+		degradedProbe parser.DegradedPollingStateProbe,
+	) {
 		path = filepath.Clean(path)
 		scope := watchScope{agent: agent, syncDir: dir}
 		if idx, ok := rootIndexes[path]; ok {
 			roots[idx].recursive = roots[idx].recursive || recursive
 			roots[idx].exists = roots[idx].exists || exists
+			if roots[idx].degradedPollProbe == nil {
+				roots[idx].degradedPollProbe = degradedProbe
+			}
 			if !slices.Contains(roots[idx].scopes, scope) {
 				roots[idx].scopes = append(roots[idx].scopes, scope)
 			}
@@ -2351,16 +2372,23 @@ func collectWatchRoots(cfg config.Config) (
 		}
 		rootIndexes[path] = len(roots)
 		roots = append(roots, watchRoot{
-			path:      path,
-			recursive: recursive,
-			exists:    exists,
-			scopes:    []watchScope{scope},
+			path:              path,
+			recursive:         recursive,
+			exists:            exists,
+			scopes:            []watchScope{scope},
+			degradedPollProbe: degradedProbe,
 		})
 	}
 	for _, def := range parser.Registry {
 		for _, d := range cfg.ResolveDirs(def.Type) {
-			addAgentRoot := func(dir, root string, recursive, exists bool) {
-				addRoot(def.Type, dir, root, recursive, exists)
+			addAgentRoot := func(
+				dir,
+				root string,
+				recursive,
+				exists bool,
+				degradedProbe parser.DegradedPollingStateProbe,
+			) {
+				addRoot(def.Type, dir, root, recursive, exists, degradedProbe)
 			}
 			_, hasProvider := parser.ProviderFactoryByType(def.Type)
 			if providerWatched, polling := collectProviderWatchRoots(def, d, addAgentRoot); providerWatched {
@@ -2425,7 +2453,13 @@ type providerPollingReasons struct {
 func collectProviderWatchRoots(
 	def parser.AgentDef,
 	dir string,
-	addRoot func(dir, root string, recursive, exists bool),
+	addRoot func(
+		dir,
+		root string,
+		recursive,
+		exists bool,
+		degradedProbe parser.DegradedPollingStateProbe,
+	),
 ) (bool, providerPollingReasons) {
 	factory, ok := parser.ProviderFactoryByType(def.Type)
 	if !ok {
@@ -2455,9 +2489,19 @@ func collectProviderWatchRoots(
 			polling.symlinkRoots = append(polling.symlinkRoots, root)
 			continue
 		}
+		degradedProbe, probeErr := parser.ResolveDegradedPollingProbe(
+			context.Background(), provider, root,
+		)
+		if probeErr != nil {
+			if !errors.Is(probeErr, parser.ErrUnsupportedProviderFeature) {
+				log.Printf("%s provider degraded poll probe for %s: %v",
+					def.Type, root, probeErr)
+			}
+			degradedProbe = nil
+		}
 		_, err := os.Stat(root)
 		exists := err == nil
-		addRoot(dir, root, providerRoot.Recursive, exists)
+		addRoot(dir, root, providerRoot.Recursive, exists, degradedProbe)
 		if exists {
 			continue
 		}
@@ -2522,13 +2566,19 @@ func pathCoveredByAnyWatchRootCreation(path string, roots []watchRoot) bool {
 func collectLegacyWatchRoots(
 	def parser.AgentDef,
 	dir string,
-	addRoot func(dir, root string, recursive, exists bool),
+	addRoot func(
+		dir,
+		root string,
+		recursive,
+		exists bool,
+		degradedProbe parser.DegradedPollingStateProbe,
+	),
 ) []string {
 	var unwatchedDirs []string
 	if def.ShallowWatchRootsFunc != nil {
 		for _, watchDir := range def.ShallowWatchRootsFunc(dir) {
 			if _, err := os.Stat(watchDir); err == nil {
-				addRoot(dir, watchDir, false, true)
+				addRoot(dir, watchDir, false, true, nil)
 			}
 		}
 	}
@@ -2539,7 +2589,7 @@ func collectLegacyWatchRoots(
 		}
 		for _, watchDir := range watchDirs {
 			if _, err := os.Stat(watchDir); err == nil {
-				addRoot(dir, watchDir, !def.ShallowWatch, true)
+				addRoot(dir, watchDir, !def.ShallowWatch, true, nil)
 				continue
 			}
 			unwatchedDirs = append(unwatchedDirs, dir)
@@ -2548,14 +2598,14 @@ func collectLegacyWatchRoots(
 	}
 	if len(def.WatchSubdirs) == 0 {
 		if _, err := os.Stat(dir); err == nil {
-			addRoot(dir, dir, !def.ShallowWatch, true)
+			addRoot(dir, dir, !def.ShallowWatch, true, nil)
 		}
 		return unwatchedDirs
 	}
 	for _, sub := range def.WatchSubdirs {
 		watchDir := filepath.Join(dir, sub)
 		if _, err := os.Stat(watchDir); err == nil {
-			addRoot(dir, watchDir, !def.ShallowWatch, true)
+			addRoot(dir, watchDir, !def.ShallowWatch, true, nil)
 		}
 	}
 	return unwatchedDirs

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -331,6 +331,7 @@ func runServe(cfg config.Config, opts serveOptions) {
 				OnPollingRequired: func(obligation sync.PollingObligation) error {
 					return unwatchedPoller.AddObligation(pollingObligation{
 						Key:           obligation.Key,
+						Agent:         obligation.Agent,
 						Roots:         obligation.Roots,
 						Probe:         obligation.Probe,
 						DegradedProbe: obligation.DegradedProbe,
@@ -2581,6 +2582,11 @@ func collectProviderWatchRoots(
 				log.Printf("%s provider degraded poll probe for %s: %v",
 					def.Type, root, probeErr)
 				degradedProbe = nil
+			}
+		} else if def.Type == parser.AgentOpenCode {
+			degradedProbe = lateBoundDegradedPollProbe{
+				provider: provider,
+				root:     root,
 			}
 		}
 		_, err := os.Stat(root)

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -1913,7 +1913,7 @@ func watchPollingObligations(
 		}
 		if !result.MissingRootLifecycleOwned {
 			add(root.pollingObligations(
-				root.path, root.path, root.pendingPollingDirs, false,
+				root.path, root.path, root.pendingPollingDirs,
 			)...)
 		}
 		for dir, scopes := range root.persistentPollingScopes {
@@ -1922,7 +1922,6 @@ func watchPollingObligations(
 				"persistent:"+cleanDir,
 				cleanDir,
 				scopes,
-				false,
 			)...)
 		}
 		if i >= len(results) {
@@ -1933,14 +1932,14 @@ func watchPollingObligations(
 			// pollable and the fallback poll reconciles it as an
 			// authoritative empty discovery.
 			add(root.pollingObligations(
-				root.path, root.path, root.syncDirs(), true,
+				unwatchedRootKey(root.path), root.path, root.syncDirs(),
 			)...)
 			continue
 		}
 		if result.Unwatched > 0 || result.BudgetExhausted ||
 			result.ResourceExhausted || result.Err != nil {
 			add(root.pollingObligations(
-				root.path, root.path, root.syncDirs(), true,
+				unwatchedRootKey(root.path), root.path, root.syncDirs(),
 			)...)
 		}
 	}
@@ -1958,7 +1957,6 @@ func watchPollingObligations(
 				"persistent:"+dir,
 				dir,
 				[]watchScope{{syncDir: dir}},
-				false,
 			)...)
 		}
 	}
@@ -1968,17 +1966,23 @@ func watchPollingObligations(
 	return obligations
 }
 
+// unwatchedRootKey names the obligation a root gets when its watcher was never
+// constructed or its registration failed. It is a distinct key rather than the
+// root's own so that this obligation and the root's pending obligation stay
+// separate without either having to be split per directory to tell them apart.
+func unwatchedRootKey(rootPath string) string {
+	return "unwatched:" + filepath.Clean(rootPath)
+}
+
 func (r watchRoot) pollingObligations(
 	rootKey string,
 	probePath string,
 	dirs []string,
-	alwaysSplitByDir bool,
 ) []sync.PollingObligation {
 	return pollingObligationsForScopes(
 		rootKey,
 		probePath,
 		r.scopesForDirs(dirs),
-		alwaysSplitByDir,
 	)
 }
 
@@ -1990,15 +1994,15 @@ func (r watchRoot) pollingObligations(
 // directory it never looked at, and a change in another grouped directory is
 // skipped for as long as the probe stays unchanged.
 //
-// alwaysSplitByDir additionally forces the split at one directory. It is not a
-// second policy: the registration-failure call sites reuse the root's own key,
-// so without the per-directory suffix their obligation would collide with the
-// pending obligation for the same root when both fire.
+// Callers do not choose this. The registration-failure sites used to force the
+// split at one directory so their obligation would not collide with the
+// pending obligation on the same root key; they carry their own key prefix
+// instead, which keeps them distinct without emitting a second obligation over
+// the same directory, agent, and probe.
 func pollingObligationsForScopes(
 	rootKey string,
 	probePath string,
 	scopes []watchScope,
-	alwaysSplitByDir bool,
 ) []sync.PollingObligation {
 	if len(scopes) == 0 {
 		return nil
@@ -2024,7 +2028,7 @@ func pollingObligationsForScopes(
 		dirs = append(dirs, dir)
 	}
 	slices.Sort(dirs)
-	splitByDir := alwaysSplitByDir || len(grouped) > 1
+	splitByDir := len(grouped) > 1
 	for _, cleanDir := range dirs {
 		key := rootKey
 		var agent parser.AgentType
@@ -2196,7 +2200,6 @@ func symlinkPollingObligations(
 			"symlink:"+filepath.Clean(symRoot),
 			filepath.Clean(symRoot),
 			scopes,
-			false,
 		)...)
 	}
 	slices.SortFunc(obligations, func(a, b sync.PollingObligation) int {

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -1916,10 +1916,13 @@ func watchPollingObligations(
 				root.path, root.path, root.pendingPollingDirs, false,
 			)...)
 		}
-		for _, dir := range root.persistentPollingDirs {
+		for dir, scopes := range root.persistentPollingScopes {
 			cleanDir := filepath.Clean(dir)
-			add(root.pollingObligations(
-				"persistent:"+cleanDir, cleanDir, []string{cleanDir}, false,
+			add(pollingObligationsForScopes(
+				"persistent:"+cleanDir,
+				cleanDir,
+				scopes,
+				false,
 			)...)
 		}
 		if i >= len(results) {
@@ -1951,9 +1954,12 @@ func watchPollingObligations(
 	for _, dir := range unwatchedDirs {
 		dir = filepath.Clean(dir)
 		if _, ok := represented[dir]; !ok {
-			add(sync.PollingObligation{
-				Key: "persistent:" + dir, Roots: []string{dir}, Probe: dir,
-			})
+			add(pollingObligationsForScopes(
+				"persistent:"+dir,
+				dir,
+				[]watchScope{{syncDir: dir}},
+				false,
+			)...)
 		}
 	}
 	slices.SortFunc(obligations, func(a, b sync.PollingObligation) int {
@@ -1968,28 +1974,49 @@ func (r watchRoot) pollingObligations(
 	dirs []string,
 	providerScoped bool,
 ) []sync.PollingObligation {
-	dirs = deduplicateStrings(dirs)
-	if len(dirs) == 0 {
+	return pollingObligationsForScopes(
+		rootKey,
+		probePath,
+		r.scopesForDirs(dirs),
+		providerScoped,
+	)
+}
+
+func pollingObligationsForScopes(
+	rootKey string,
+	probePath string,
+	scopes []watchScope,
+	providerScoped bool,
+) []sync.PollingObligation {
+	if len(scopes) == 0 {
 		return nil
 	}
-	dirFilter := make(map[string]struct{}, len(dirs))
-	for _, dir := range dirs {
-		dirFilter[filepath.Clean(dir)] = struct{}{}
+	grouped := make(map[string][]watchScope, len(scopes))
+	for _, scope := range scopes {
+		cleanDir := filepath.Clean(scope.syncDir)
+		if cleanDir == "" {
+			continue
+		}
+		grouped[cleanDir] = appendUniqueWatchScope(grouped[cleanDir], watchScope{
+			agent:   scope.agent,
+			syncDir: cleanDir,
+		})
+	}
+	if len(grouped) == 0 {
+		return nil
 	}
 	byKey := make(map[string][]string)
 	obligationAgent := make(map[string]parser.AgentType)
-	for _, dir := range dirs {
-		cleanDir := filepath.Clean(dir)
+	dirs := make([]string, 0, len(grouped))
+	for dir := range grouped {
+		dirs = append(dirs, dir)
+	}
+	slices.Sort(dirs)
+	for _, cleanDir := range dirs {
 		key := rootKey
 		var agent parser.AgentType
 		sameAgent := true
-		for _, scope := range r.scopes {
-			if filepath.Clean(scope.syncDir) != cleanDir {
-				continue
-			}
-			if _, ok := dirFilter[filepath.Clean(scope.syncDir)]; !ok {
-				continue
-			}
+		for _, scope := range grouped[cleanDir] {
 			if agent == "" {
 				agent = scope.agent
 			} else if scope.agent != agent {
@@ -2152,30 +2179,12 @@ func symlinkPollingObligations(
 ) []sync.PollingObligation {
 	obligations := make([]sync.PollingObligation, 0, len(symlinkGatedDirs))
 	for symRoot, scopes := range symlinkGatedDirs {
-		roots := make([]string, 0, len(scopes))
-		agent := parser.AgentType("")
-		sameAgent := true
-		for _, scope := range scopes {
-			if scope.syncDir != "" {
-				roots = appendUniqueString(roots, filepath.Clean(scope.syncDir))
-			}
-			if agent == "" {
-				agent = scope.agent
-			} else if scope.agent != agent {
-				sameAgent = false
-			}
-		}
-		currentAgent := parser.AgentType("")
-		if sameAgent {
-			currentAgent = agent
-		}
-		slices.Sort(roots)
-		obligations = append(obligations, sync.PollingObligation{
-			Key:   "symlink:" + filepath.Clean(symRoot),
-			Agent: currentAgent,
-			Roots: roots,
-			Probe: filepath.Clean(symRoot),
-		})
+		obligations = append(obligations, pollingObligationsForScopes(
+			"symlink:"+filepath.Clean(symRoot),
+			filepath.Clean(symRoot),
+			scopes,
+			false,
+		)...)
 	}
 	slices.SortFunc(obligations, func(a, b sync.PollingObligation) int {
 		return strings.Compare(a.Key, b.Key)
@@ -2190,7 +2199,7 @@ func accountRegisteredWatchRoots(
 ) []string {
 	persistent := make(map[string]bool)
 	for _, root := range roots {
-		for _, dir := range root.persistentPollingDirs {
+		for dir := range root.persistentPollingScopes {
 			persistent[dir] = true
 		}
 	}
@@ -2453,13 +2462,27 @@ type watchScope struct {
 	syncDir string
 }
 
+func appendUniqueWatchScope(scopes []watchScope, next watchScope) []watchScope {
+	next.syncDir = filepath.Clean(next.syncDir)
+	if next.syncDir == "" {
+		return scopes
+	}
+	if slices.ContainsFunc(scopes, func(existing watchScope) bool {
+		return existing.agent == next.agent &&
+			filepath.Clean(existing.syncDir) == next.syncDir
+	}) {
+		return scopes
+	}
+	return append(scopes, next)
+}
+
 type watchRoot struct {
-	path                  string
-	recursive             bool
-	exists                bool
-	scopes                []watchScope
-	pendingPollingDirs    []string
-	persistentPollingDirs []string
+	path                    string
+	recursive               bool
+	exists                  bool
+	scopes                  []watchScope
+	pendingPollingDirs      []string
+	persistentPollingScopes map[string][]watchScope
 }
 
 func (r watchRoot) registeredRoot() sync.WatchRoot {
@@ -2486,6 +2509,31 @@ func (r watchRoot) syncDirs() []string {
 	return dirs
 }
 
+func (r watchRoot) scopesForDirs(dirs []string) []watchScope {
+	if len(dirs) == 0 {
+		return nil
+	}
+	dirFilter := make(map[string]struct{}, len(dirs))
+	for _, dir := range dirs {
+		cleanDir := filepath.Clean(dir)
+		if cleanDir != "" {
+			dirFilter[cleanDir] = struct{}{}
+		}
+	}
+	scopes := make([]watchScope, 0, len(r.scopes))
+	for _, scope := range r.scopes {
+		cleanDir := filepath.Clean(scope.syncDir)
+		if _, ok := dirFilter[cleanDir]; !ok {
+			continue
+		}
+		scopes = appendUniqueWatchScope(scopes, watchScope{
+			agent:   scope.agent,
+			syncDir: cleanDir,
+		})
+	}
+	return scopes
+}
+
 // collectWatchRoots resolves the configured watch plan. symlinkGatedDirs maps
 // each recursive provider root skipped because it is a symlink to the exact
 // provider-owned configured dirs whose reconciliation scope its target
@@ -2497,7 +2545,7 @@ func collectWatchRoots(cfg config.Config) (
 	symlinkGatedDirs map[string][]watchScope,
 ) {
 	rootIndexes := make(map[string]int)
-	persistentPollingDirs := make(map[string]struct{})
+	persistentPollingScopes := make(map[string][]watchScope)
 	symlinkGatedDirs = make(map[string][]watchScope)
 	addRoot := func(
 		agent parser.AgentType,
@@ -2529,6 +2577,13 @@ func collectWatchRoots(cfg config.Config) (
 			scopes:    []watchScope{scope},
 		})
 	}
+	addPersistentPollingScope := func(scope watchScope) {
+		persistentPollingScopes[filepath.Clean(scope.syncDir)] = appendUniqueWatchScope(
+			persistentPollingScopes[filepath.Clean(scope.syncDir)],
+			scope,
+		)
+		unwatchedDirs = appendUniqueString(unwatchedDirs, filepath.Clean(scope.syncDir))
+	}
 	for _, def := range parser.Registry {
 		for _, d := range cfg.ResolveDirs(def.Type) {
 			addAgentRoot := func(
@@ -2542,18 +2597,16 @@ func collectWatchRoots(cfg config.Config) (
 			_, hasProvider := parser.ProviderFactoryByType(def.Type)
 			if providerWatched, polling := collectProviderWatchRoots(def, d, addAgentRoot); providerWatched {
 				if polling.persistent {
-					persistentPollingDirs[d] = struct{}{}
-					unwatchedDirs = appendUniqueString(unwatchedDirs, d)
+					addPersistentPollingScope(watchScope{
+						agent:   def.Type,
+						syncDir: d,
+					})
 				}
 				for _, symRoot := range polling.symlinkRoots {
-					scope := watchScope{agent: def.Type, syncDir: filepath.Clean(d)}
-					if !slices.ContainsFunc(symlinkGatedDirs[symRoot], func(existing watchScope) bool {
-						return existing.agent == scope.agent && existing.syncDir == scope.syncDir
-					}) {
-						symlinkGatedDirs[symRoot] = append(
-							symlinkGatedDirs[symRoot], scope,
-						)
-					}
+					symlinkGatedDirs[filepath.Clean(symRoot)] = appendUniqueWatchScope(
+						symlinkGatedDirs[filepath.Clean(symRoot)],
+						watchScope{agent: def.Type, syncDir: d},
+					)
 				}
 				for _, missing := range polling.missingRoots {
 					idx, ok := rootIndexes[filepath.Clean(missing)]
@@ -2569,24 +2622,34 @@ func collectWatchRoots(cfg config.Config) (
 			}
 			if !def.FileBased {
 				if hasProvider {
-					persistentPollingDirs[d] = struct{}{}
-					unwatchedDirs = appendUniqueString(unwatchedDirs, d)
+					addPersistentPollingScope(watchScope{
+						agent:   def.Type,
+						syncDir: d,
+					})
 				}
 				continue
 			}
 			fallbackUnwatched := collectLegacyWatchRoots(def, d, addAgentRoot)
 			for _, pollingDir := range fallbackUnwatched {
-				persistentPollingDirs[pollingDir] = struct{}{}
-				unwatchedDirs = appendUniqueString(unwatchedDirs, pollingDir)
+				addPersistentPollingScope(watchScope{
+					agent:   def.Type,
+					syncDir: pollingDir,
+				})
 			}
 		}
 	}
-	for dir := range persistentPollingDirs {
+	for dir, scopes := range persistentPollingScopes {
 		for i := range roots {
 			if slices.Contains(roots[i].syncDirs(), dir) {
-				roots[i].persistentPollingDirs = appendUniqueString(
-					roots[i].persistentPollingDirs, dir,
-				)
+				if roots[i].persistentPollingScopes == nil {
+					roots[i].persistentPollingScopes = make(map[string][]watchScope)
+				}
+				for _, scope := range scopes {
+					roots[i].persistentPollingScopes[dir] = appendUniqueWatchScope(
+						roots[i].persistentPollingScopes[dir],
+						scope,
+					)
+				}
 				break
 			}
 		}

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -2345,8 +2345,9 @@ func (r watchRoot) registeredRoot() sync.WatchRoot {
 	scopes := make([]sync.WatchScope, 0, len(r.scopes))
 	for _, scope := range r.scopes {
 		scopes = append(scopes, sync.WatchScope{
-			Agent:   string(scope.agent),
-			SyncDir: scope.syncDir,
+			Agent:         string(scope.agent),
+			SyncDir:       scope.syncDir,
+			DegradedProbe: r.degradedProbeForDir(scope.syncDir),
 		})
 	}
 	return sync.WatchRoot{

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -1995,18 +1995,22 @@ func (r watchRoot) pollingObligations(
 // nil results because no watcher registered any roots: no per-root
 // registration outcome exists, no missing-root lifecycle can be natively
 // owned, and every root therefore gates its sync scopes on its own path.
-// The probe gates are registered before the ungated coverage fallback: the
-// poll coordinator's ticker is already live, so a tick landing between two
-// synchronous registrations polls whatever is installed at that instant, and
-// a fallback installed first would reconcile a scope whose gate has not
-// landed yet. Returns the coverage callback's error so the caller can join
-// it with the construction failure.
+// When polling ownership is available, coverage degradation becomes
+// notification-only here: the poll owner already has every configured dir
+// through probe-gated or persistent obligations, so re-registering the same
+// dirs as an unprobed watcher-fallback would bypass unchanged degraded-probe
+// suppression on later ticks. The probe gates still register before the
+// notification callback runs, because the poll coordinator's ticker is
+// already live and a tick landing between two synchronous registrations polls
+// whatever is installed at that instant. Returns the coverage callback's
+// error so the caller can join it with the construction failure.
 func registerWatcherUnavailableObligations(
 	options sync.WatcherOptions,
 	roots []watchRoot,
 	unwatchedDirs []string,
 	symlinkGatedDirs map[string][]string,
 ) error {
+	coverageRoots := unwatchedDirs
 	if options.OnPollingRequired != nil {
 		obligations := watchPollingObligations(roots, nil, unwatchedDirs)
 		obligations = append(
@@ -2019,11 +2023,12 @@ func registerWatcherUnavailableObligations(
 				)
 			}
 		}
+		coverageRoots = nil
 	}
 	if options.OnCoverageDegraded == nil {
 		return nil
 	}
-	return options.OnCoverageDegraded(unwatchedDirs)
+	return options.OnCoverageDegraded(coverageRoots)
 }
 
 // symlinkPollingObligations gates persistent polling of dirs whose recursive

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -1886,33 +1886,19 @@ func watchPollingObligations(
 	results []sync.RecursiveWatchResult,
 	unwatchedDirs []string,
 ) []sync.PollingObligation {
-	byKey := make(map[string][]string)
-	probes := make(map[string]string)
-	degraded := make(map[string]parser.DegradedPollingStateProbe)
+	obligations := make([]sync.PollingObligation, 0, len(roots))
 	represented := make(map[string]struct{})
-	// The probe is the physical path whose availability gates the
-	// obligation's reconciliation roots: the watch root's own path for
-	// root-keyed groups, the dir itself for persistent dirs.
-	add := func(
-		key,
-		probe string,
-		degradedProbe parser.DegradedPollingStateProbe,
-		roots ...string,
-	) {
-		if key == "" {
-			return
-		}
-		probes[key] = filepath.Clean(probe)
-		if degradedProbe != nil {
-			degraded[key] = degradedProbe
-		}
-		for _, root := range roots {
-			if root == "" {
+	add := func(next ...sync.PollingObligation) {
+		for _, obligation := range next {
+			if obligation.Key == "" {
 				continue
 			}
-			root = filepath.Clean(root)
-			byKey[key] = appendUniqueString(byKey[key], root)
-			represented[root] = struct{}{}
+			for _, root := range obligation.Roots {
+				if root != "" {
+					represented[filepath.Clean(root)] = struct{}{}
+				}
+			}
+			obligations = append(obligations, obligation)
 		}
 	}
 	for i, root := range roots {
@@ -1921,10 +1907,13 @@ func watchPollingObligations(
 			result = results[i]
 		}
 		if !result.MissingRootLifecycleOwned {
-			add(root.path, root.path, root.degradedPollProbe, root.pendingPollingDirs...)
+			add(root.pollingObligations(root.path, root.path, root.pendingPollingDirs)...)
 		}
 		for _, dir := range root.persistentPollingDirs {
-			add("persistent:"+filepath.Clean(dir), dir, nil, dir)
+			cleanDir := filepath.Clean(dir)
+			add(sync.PollingObligation{
+				Key: "persistent:" + cleanDir, Roots: []string{cleanDir}, Probe: cleanDir,
+			})
 		}
 		if i >= len(results) {
 			// No registration result exists for this root: the watcher was
@@ -1933,30 +1922,64 @@ func watchPollingObligations(
 			// after the obligations are installed leaves its configured dir
 			// pollable and the fallback poll reconciles it as an
 			// authoritative empty discovery.
-			add(root.path, root.path, root.degradedPollProbe, root.syncDirs()...)
+			add(root.pollingObligations(root.path, root.path, root.syncDirs())...)
 			continue
 		}
 		if result.Unwatched > 0 || result.BudgetExhausted ||
 			result.ResourceExhausted || result.Err != nil {
-			add(root.path, root.path, root.degradedPollProbe, root.syncDirs()...)
+			add(root.pollingObligations(root.path, root.path, root.syncDirs())...)
 		}
 	}
 	for _, dir := range unwatchedDirs {
 		dir = filepath.Clean(dir)
 		if _, ok := represented[dir]; !ok {
-			add("persistent:"+dir, dir, nil, dir)
+			add(sync.PollingObligation{
+				Key: "persistent:" + dir, Roots: []string{dir}, Probe: dir,
+			})
 		}
-	}
-	obligations := make([]sync.PollingObligation, 0, len(byKey))
-	for key, roots := range byKey {
-		slices.Sort(roots)
-		obligations = append(obligations, sync.PollingObligation{
-			Key: key, Roots: roots, Probe: probes[key], DegradedProbe: degraded[key],
-		})
 	}
 	slices.SortFunc(obligations, func(a, b sync.PollingObligation) int {
 		return strings.Compare(a.Key, b.Key)
 	})
+	return obligations
+}
+
+func (r watchRoot) pollingObligations(
+	rootKey string,
+	probePath string,
+	dirs []string,
+) []sync.PollingObligation {
+	dirs = deduplicateStrings(dirs)
+	if len(dirs) == 0 {
+		return nil
+	}
+	byKey := make(map[string][]string)
+	degraded := make(map[string]parser.DegradedPollingStateProbe)
+	for _, dir := range dirs {
+		cleanDir := filepath.Clean(dir)
+		key := rootKey
+		if probe := r.degradedProbeForDir(cleanDir); probe != nil {
+			key = rootKey + "|" + cleanDir
+			degraded[key] = probe
+		}
+		byKey[key] = appendUniqueString(byKey[key], cleanDir)
+	}
+	keys := make([]string, 0, len(byKey))
+	for key := range byKey {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	obligations := make([]sync.PollingObligation, 0, len(keys))
+	for _, key := range keys {
+		roots := byKey[key]
+		slices.Sort(roots)
+		obligations = append(obligations, sync.PollingObligation{
+			Key:           key,
+			Roots:         roots,
+			Probe:         filepath.Clean(probePath),
+			DegradedProbe: degraded[key],
+		})
+	}
 	return obligations
 }
 
@@ -2310,7 +2333,7 @@ type watchRoot struct {
 	scopes                []watchScope
 	pendingPollingDirs    []string
 	persistentPollingDirs []string
-	degradedPollProbe     parser.DegradedPollingStateProbe
+	degradedPollProbes    map[string]parser.DegradedPollingStateProbe
 }
 
 func (r watchRoot) registeredRoot() sync.WatchRoot {
@@ -2335,6 +2358,13 @@ func (r watchRoot) syncDirs() []string {
 		dirs = appendUniqueString(dirs, scope.syncDir)
 	}
 	return dirs
+}
+
+func (r watchRoot) degradedProbeForDir(dir string) parser.DegradedPollingStateProbe {
+	if r.degradedPollProbes == nil {
+		return nil
+	}
+	return r.degradedPollProbes[filepath.Clean(dir)]
 }
 
 // collectWatchRoots resolves the configured watch plan. symlinkGatedDirs maps
@@ -2362,8 +2392,11 @@ func collectWatchRoots(cfg config.Config) (
 		if idx, ok := rootIndexes[path]; ok {
 			roots[idx].recursive = roots[idx].recursive || recursive
 			roots[idx].exists = roots[idx].exists || exists
-			if roots[idx].degradedPollProbe == nil {
-				roots[idx].degradedPollProbe = degradedProbe
+			if degradedProbe != nil {
+				if roots[idx].degradedPollProbes == nil {
+					roots[idx].degradedPollProbes = make(map[string]parser.DegradedPollingStateProbe)
+				}
+				roots[idx].degradedPollProbes[filepath.Clean(dir)] = degradedProbe
 			}
 			if !slices.Contains(roots[idx].scopes, scope) {
 				roots[idx].scopes = append(roots[idx].scopes, scope)
@@ -2371,12 +2404,16 @@ func collectWatchRoots(cfg config.Config) (
 			return
 		}
 		rootIndexes[path] = len(roots)
+		degradedPollProbes := make(map[string]parser.DegradedPollingStateProbe)
+		if degradedProbe != nil {
+			degradedPollProbes[filepath.Clean(dir)] = degradedProbe
+		}
 		roots = append(roots, watchRoot{
-			path:              path,
-			recursive:         recursive,
-			exists:            exists,
-			scopes:            []watchScope{scope},
-			degradedPollProbe: degradedProbe,
+			path:               path,
+			recursive:          recursive,
+			exists:             exists,
+			scopes:             []watchScope{scope},
+			degradedPollProbes: degradedPollProbes,
 		})
 	}
 	for _, def := range parser.Registry {

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -1953,12 +1953,44 @@ func (r watchRoot) pollingObligations(
 	if len(dirs) == 0 {
 		return nil
 	}
+	dirFilter := make(map[string]struct{}, len(dirs))
+	for _, dir := range dirs {
+		dirFilter[filepath.Clean(dir)] = struct{}{}
+	}
 	byKey := make(map[string][]string)
 	degraded := make(map[string]parser.DegradedPollingStateProbe)
 	for _, dir := range dirs {
 		cleanDir := filepath.Clean(dir)
 		key := rootKey
-		if probe := r.degradedProbeForDir(cleanDir); probe != nil {
+		var (
+			probe      parser.DegradedPollingStateProbe
+			probeAgent parser.AgentType
+			probeOK    = true
+			seen       bool
+		)
+		for _, scope := range r.scopes {
+			if filepath.Clean(scope.syncDir) != cleanDir {
+				continue
+			}
+			if _, ok := dirFilter[filepath.Clean(scope.syncDir)]; !ok {
+				continue
+			}
+			seen = true
+			if scope.degradedProbe == nil {
+				probeOK = false
+				break
+			}
+			if probe == nil {
+				probe = scope.degradedProbe
+				probeAgent = scope.agent
+				continue
+			}
+			if scope.agent != probeAgent {
+				probeOK = false
+				break
+			}
+		}
+		if seen && probeOK && probe != nil {
 			key = rootKey + "|" + cleanDir
 			degraded[key] = probe
 		}
@@ -2327,8 +2359,9 @@ func deduplicateStrings(values []string) []string {
 }
 
 type watchScope struct {
-	agent   parser.AgentType
-	syncDir string
+	agent         parser.AgentType
+	syncDir       string
+	degradedProbe parser.DegradedPollingStateProbe
 }
 
 type watchRoot struct {
@@ -2338,7 +2371,6 @@ type watchRoot struct {
 	scopes                []watchScope
 	pendingPollingDirs    []string
 	persistentPollingDirs []string
-	degradedPollProbes    map[string]parser.DegradedPollingStateProbe
 }
 
 func (r watchRoot) registeredRoot() sync.WatchRoot {
@@ -2347,7 +2379,7 @@ func (r watchRoot) registeredRoot() sync.WatchRoot {
 		scopes = append(scopes, sync.WatchScope{
 			Agent:         string(scope.agent),
 			SyncDir:       scope.syncDir,
-			DegradedProbe: r.degradedProbeForDir(scope.syncDir),
+			DegradedProbe: scope.degradedProbe,
 		})
 	}
 	return sync.WatchRoot{
@@ -2364,13 +2396,6 @@ func (r watchRoot) syncDirs() []string {
 		dirs = appendUniqueString(dirs, scope.syncDir)
 	}
 	return dirs
-}
-
-func (r watchRoot) degradedProbeForDir(dir string) parser.DegradedPollingStateProbe {
-	if r.degradedPollProbes == nil {
-		return nil
-	}
-	return r.degradedPollProbes[filepath.Clean(dir)]
 }
 
 // collectWatchRoots resolves the configured watch plan. symlinkGatedDirs maps
@@ -2394,32 +2419,27 @@ func collectWatchRoots(cfg config.Config) (
 		degradedProbe parser.DegradedPollingStateProbe,
 	) {
 		path = filepath.Clean(path)
-		scope := watchScope{agent: agent, syncDir: dir}
+		scope := watchScope{
+			agent:         agent,
+			syncDir:       filepath.Clean(dir),
+			degradedProbe: degradedProbe,
+		}
 		if idx, ok := rootIndexes[path]; ok {
 			roots[idx].recursive = roots[idx].recursive || recursive
 			roots[idx].exists = roots[idx].exists || exists
-			if degradedProbe != nil {
-				if roots[idx].degradedPollProbes == nil {
-					roots[idx].degradedPollProbes = make(map[string]parser.DegradedPollingStateProbe)
-				}
-				roots[idx].degradedPollProbes[filepath.Clean(dir)] = degradedProbe
-			}
-			if !slices.Contains(roots[idx].scopes, scope) {
+			if !slices.ContainsFunc(roots[idx].scopes, func(existing watchScope) bool {
+				return existing.agent == scope.agent && existing.syncDir == scope.syncDir
+			}) {
 				roots[idx].scopes = append(roots[idx].scopes, scope)
 			}
 			return
 		}
 		rootIndexes[path] = len(roots)
-		degradedPollProbes := make(map[string]parser.DegradedPollingStateProbe)
-		if degradedProbe != nil {
-			degradedPollProbes[filepath.Clean(dir)] = degradedProbe
-		}
 		roots = append(roots, watchRoot{
-			path:               path,
-			recursive:          recursive,
-			exists:             exists,
-			scopes:             []watchScope{scope},
-			degradedPollProbes: degradedPollProbes,
+			path:      path,
+			recursive: recursive,
+			exists:    exists,
+			scopes:    []watchScope{scope},
 		})
 	}
 	for _, def := range parser.Registry {

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -1913,7 +1913,7 @@ func watchPollingObligations(
 		}
 		if !result.MissingRootLifecycleOwned {
 			add(root.pollingObligations(
-				root.path, root.path, root.pendingPollingDirs,
+				pendingRootKey(root.path), root.path, root.pendingPollingDirs,
 			)...)
 		}
 		for dir, scopes := range root.persistentPollingScopes {
@@ -1964,6 +1964,16 @@ func watchPollingObligations(
 		return strings.Compare(a.Key, b.Key)
 	})
 	return obligations
+}
+
+// Obligation keys are namespaced by the reason that created them. Every key
+// carries a prefix, including the pending one: a bare path could otherwise be
+// produced twice, once as a pending root literally named "unwatched:X" and once
+// as the unwatched key for a root named "X", and the coordinator indexes
+// obligations by key, so the collision would drop one reason's probe gate and
+// degraded state.
+func pendingRootKey(rootPath string) string {
+	return "pending:" + filepath.Clean(rootPath)
 }
 
 // unwatchedRootKey names the obligation a root gets when its watcher was never

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -797,12 +797,14 @@ func probeWatchRecoveryScope(cfg config.Config) watchRecoveryScope {
 	// availability probe is the symlink target itself: os.Stat follows the
 	// link and fails while the target is gone, deferring the configured
 	// scope before an overlapping present path could expand into it.
-	for symRoot, dirs := range symlinkGatedDirs {
+	for symRoot, scopes := range symlinkGatedDirs {
 		if _, err := os.Stat(symRoot); err == nil {
 			continue
 		}
-		for _, dir := range dirs {
-			deferred[filepath.Clean(dir)] = struct{}{}
+		for _, scope := range scopes {
+			if scope.syncDir != "" {
+				deferred[filepath.Clean(scope.syncDir)] = struct{}{}
+			}
 		}
 	}
 	for _, r := range roots {
@@ -1848,7 +1850,9 @@ func startFileWatcher(
 		}
 	}
 	if options.OnPollingRequired != nil {
-		obligations := watchPollingObligations(roots, results, unwatchedDirs)
+		obligations := watchPollingObligations(
+			roots, results, unwatchedDirs, symlinkGatedDirs,
+		)
 		obligations = append(obligations, symlinkPollingObligations(symlinkGatedDirs)...)
 		for _, obligation := range obligations {
 			if err := options.OnPollingRequired(obligation); err != nil {
@@ -1885,6 +1889,7 @@ func watchPollingObligations(
 	roots []watchRoot,
 	results []sync.RecursiveWatchResult,
 	unwatchedDirs []string,
+	symlinkGatedDirs map[string][]watchScope,
 ) []sync.PollingObligation {
 	obligations := make([]sync.PollingObligation, 0, len(roots))
 	represented := make(map[string]struct{})
@@ -1913,9 +1918,9 @@ func watchPollingObligations(
 		}
 		for _, dir := range root.persistentPollingDirs {
 			cleanDir := filepath.Clean(dir)
-			add(sync.PollingObligation{
-				Key: "persistent:" + cleanDir, Roots: []string{cleanDir}, Probe: cleanDir,
-			})
+			add(root.pollingObligations(
+				"persistent:"+cleanDir, cleanDir, []string{cleanDir}, false,
+			)...)
 		}
 		if i >= len(results) {
 			// No registration result exists for this root: the watcher was
@@ -1934,6 +1939,13 @@ func watchPollingObligations(
 			add(root.pollingObligations(
 				root.path, root.path, root.syncDirs(), true,
 			)...)
+		}
+	}
+	for _, scopes := range symlinkGatedDirs {
+		for _, scope := range scopes {
+			if scope.syncDir != "" {
+				represented[filepath.Clean(scope.syncDir)] = struct{}{}
+			}
 		}
 	}
 	for _, dir := range unwatchedDirs {
@@ -2042,27 +2054,89 @@ func registerWatcherUnavailableObligations(
 	options sync.WatcherOptions,
 	roots []watchRoot,
 	unwatchedDirs []string,
-	symlinkGatedDirs map[string][]string,
+	symlinkGatedDirs map[string][]watchScope,
 ) error {
 	coverageRoots := unwatchedDirs
 	if options.OnPollingRequired != nil {
-		obligations := watchPollingObligations(roots, nil, unwatchedDirs)
+		obligations := watchPollingObligations(
+			roots, nil, unwatchedDirs, symlinkGatedDirs,
+		)
 		obligations = append(
 			obligations, symlinkPollingObligations(symlinkGatedDirs)...,
 		)
+		var registrationErr error
+		installed := make([]sync.PollingObligation, 0, len(obligations))
+		failed := make([]sync.PollingObligation, 0)
 		for _, obligation := range obligations {
 			if err := options.OnPollingRequired(obligation); err != nil {
 				log.Printf(
 					"register polling obligation %q: %v", obligation.Key, err,
 				)
+				registrationErr = errors.Join(registrationErr, err)
+				failed = append(failed, obligation)
+				continue
 			}
+			installed = append(installed, obligation)
 		}
-		coverageRoots = nil
+		if registrationErr == nil {
+			coverageRoots = nil
+		} else {
+			coverageRoots = filterWatcherUnavailableFallbackRoots(
+				coverageRoots, installed, failed,
+			)
+		}
+		if options.OnCoverageDegraded == nil {
+			return registrationErr
+		}
+		if len(coverageRoots) == 0 {
+			return registrationErr
+		}
+		return errors.Join(
+			registrationErr, options.OnCoverageDegraded(coverageRoots),
+		)
 	}
 	if options.OnCoverageDegraded == nil {
 		return nil
 	}
 	return options.OnCoverageDegraded(coverageRoots)
+}
+
+func filterWatcherUnavailableFallbackRoots(
+	coverageRoots []string,
+	installed []sync.PollingObligation,
+	failed []sync.PollingObligation,
+) []string {
+	owned := make(map[string]struct{})
+	blocked := make(map[string]struct{})
+	for _, obligation := range installed {
+		for _, root := range obligation.Roots {
+			if root != "" {
+				owned[filepath.Clean(root)] = struct{}{}
+			}
+		}
+	}
+	for _, obligation := range failed {
+		if obligation.Probe == "" {
+			continue
+		}
+		for _, root := range obligation.Roots {
+			if root != "" {
+				blocked[filepath.Clean(root)] = struct{}{}
+			}
+		}
+	}
+	filtered := make([]string, 0, len(coverageRoots))
+	for _, root := range coverageRoots {
+		cleanRoot := filepath.Clean(root)
+		if _, ok := owned[cleanRoot]; ok {
+			continue
+		}
+		if overlapsDeferredScope(cleanRoot, blocked) {
+			continue
+		}
+		filtered = appendUniqueString(filtered, cleanRoot)
+	}
+	return filtered
 }
 
 // symlinkPollingObligations gates persistent polling of dirs whose recursive
@@ -2074,17 +2148,31 @@ func registerWatcherUnavailableObligations(
 // referencing it has a missing probe, so this composes with the dir's own
 // persistent obligation.
 func symlinkPollingObligations(
-	symlinkGatedDirs map[string][]string,
+	symlinkGatedDirs map[string][]watchScope,
 ) []sync.PollingObligation {
 	obligations := make([]sync.PollingObligation, 0, len(symlinkGatedDirs))
-	for symRoot, dirs := range symlinkGatedDirs {
-		roots := make([]string, 0, len(dirs))
-		for _, dir := range dirs {
-			roots = appendUniqueString(roots, filepath.Clean(dir))
+	for symRoot, scopes := range symlinkGatedDirs {
+		roots := make([]string, 0, len(scopes))
+		agent := parser.AgentType("")
+		sameAgent := true
+		for _, scope := range scopes {
+			if scope.syncDir != "" {
+				roots = appendUniqueString(roots, filepath.Clean(scope.syncDir))
+			}
+			if agent == "" {
+				agent = scope.agent
+			} else if scope.agent != agent {
+				sameAgent = false
+			}
+		}
+		currentAgent := parser.AgentType("")
+		if sameAgent {
+			currentAgent = agent
 		}
 		slices.Sort(roots)
 		obligations = append(obligations, sync.PollingObligation{
 			Key:   "symlink:" + filepath.Clean(symRoot),
+			Agent: currentAgent,
 			Roots: roots,
 			Probe: filepath.Clean(symRoot),
 		})
@@ -2399,17 +2487,18 @@ func (r watchRoot) syncDirs() []string {
 }
 
 // collectWatchRoots resolves the configured watch plan. symlinkGatedDirs maps
-// each recursive provider root skipped because it is a symlink to the
-// configured dirs whose reconciliation scope its target availability gates;
-// those roots never join the watcher plan or the returned roots.
+// each recursive provider root skipped because it is a symlink to the exact
+// provider-owned configured dirs whose reconciliation scope its target
+// availability gates; those roots never join the watcher plan or the returned
+// roots.
 func collectWatchRoots(cfg config.Config) (
 	roots []watchRoot,
 	unwatchedDirs []string,
-	symlinkGatedDirs map[string][]string,
+	symlinkGatedDirs map[string][]watchScope,
 ) {
 	rootIndexes := make(map[string]int)
 	persistentPollingDirs := make(map[string]struct{})
-	symlinkGatedDirs = make(map[string][]string)
+	symlinkGatedDirs = make(map[string][]watchScope)
 	addRoot := func(
 		agent parser.AgentType,
 		dir,
@@ -2457,9 +2546,14 @@ func collectWatchRoots(cfg config.Config) (
 					unwatchedDirs = appendUniqueString(unwatchedDirs, d)
 				}
 				for _, symRoot := range polling.symlinkRoots {
-					symlinkGatedDirs[symRoot] = appendUniqueString(
-						symlinkGatedDirs[symRoot], d,
-					)
+					scope := watchScope{agent: def.Type, syncDir: filepath.Clean(d)}
+					if !slices.ContainsFunc(symlinkGatedDirs[symRoot], func(existing watchScope) bool {
+						return existing.agent == scope.agent && existing.syncDir == scope.syncDir
+					}) {
+						symlinkGatedDirs[symRoot] = append(
+							symlinkGatedDirs[symRoot], scope,
+						)
+					}
 				}
 				for _, missing := range polling.missingRoots {
 					idx, ok := rootIndexes[filepath.Clean(missing)]

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -1972,21 +1972,33 @@ func (r watchRoot) pollingObligations(
 	rootKey string,
 	probePath string,
 	dirs []string,
-	providerScoped bool,
+	alwaysSplitByDir bool,
 ) []sync.PollingObligation {
 	return pollingObligationsForScopes(
 		rootKey,
 		probePath,
 		r.scopesForDirs(dirs),
-		providerScoped,
+		alwaysSplitByDir,
 	)
 }
 
+// pollingObligationsForScopes splits a provider-owned directory into its own
+// obligation whenever the obligation would otherwise cover more than one, the
+// rule the runtime watcher fallback already applies in
+// internal/sync/watch_backend.go. One obligation carries one probe, so
+// grouping same-provider directories under it lets that probe answer for a
+// directory it never looked at, and a change in another grouped directory is
+// skipped for as long as the probe stays unchanged.
+//
+// alwaysSplitByDir additionally forces the split at one directory. It is not a
+// second policy: the registration-failure call sites reuse the root's own key,
+// so without the per-directory suffix their obligation would collide with the
+// pending obligation for the same root when both fire.
 func pollingObligationsForScopes(
 	rootKey string,
 	probePath string,
 	scopes []watchScope,
-	providerScoped bool,
+	alwaysSplitByDir bool,
 ) []sync.PollingObligation {
 	if len(scopes) == 0 {
 		return nil
@@ -2012,6 +2024,7 @@ func pollingObligationsForScopes(
 		dirs = append(dirs, dir)
 	}
 	slices.Sort(dirs)
+	splitByDir := alwaysSplitByDir || len(grouped) > 1
 	for _, cleanDir := range dirs {
 		key := rootKey
 		var agent parser.AgentType
@@ -2023,7 +2036,7 @@ func pollingObligationsForScopes(
 				sameAgent = false
 			}
 		}
-		if providerScoped && sameAgent && agent != "" {
+		if splitByDir && sameAgent && agent != "" {
 			key = rootKey + "|" + cleanDir
 		}
 		currentAgent := parser.AgentType("")

--- a/cmd/agentsview/main.go
+++ b/cmd/agentsview/main.go
@@ -2364,6 +2364,21 @@ type watchScope struct {
 	degradedProbe parser.DegradedPollingStateProbe
 }
 
+type lateBoundDegradedPollProbe struct {
+	provider parser.Provider
+	root     string
+}
+
+func (p lateBoundDegradedPollProbe) DegradedPollingState(
+	ctx context.Context,
+) (string, error) {
+	probe, err := parser.ResolveDegradedPollingProbe(ctx, p.provider, p.root)
+	if err != nil {
+		return "", err
+	}
+	return probe.DegradedPollingState(ctx)
+}
+
 type watchRoot struct {
 	path                  string
 	recursive             bool
@@ -2556,11 +2571,17 @@ func collectProviderWatchRoots(
 			context.Background(), provider, root,
 		)
 		if probeErr != nil {
-			if !errors.Is(probeErr, parser.ErrUnsupportedProviderFeature) {
+			if errors.Is(probeErr, parser.ErrUnsupportedProviderFeature) &&
+				def.Type == parser.AgentOpenCode {
+				degradedProbe = lateBoundDegradedPollProbe{
+					provider: provider,
+					root:     root,
+				}
+			} else if !errors.Is(probeErr, parser.ErrUnsupportedProviderFeature) {
 				log.Printf("%s provider degraded poll probe for %s: %v",
 					def.Type, root, probeErr)
+				degradedProbe = nil
 			}
-			degradedProbe = nil
 		}
 		_, err := os.Stat(root)
 		exists := err == nil

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -90,7 +90,7 @@ func TestPendingOpenCodeRootPreservesProviderOwnershipWhenItBecomesSQLite(t *tes
 	)
 	require.Len(t, got, 1)
 	assert.Equal(t, agentsync.PollingObligation{
-		Key:   root,
+		Key:   pendingRootKey(root),
 		Agent: parser.AgentOpenCode,
 		Roots: []string{root},
 		Probe: root,
@@ -1704,7 +1704,7 @@ func TestWatchPollingObligationsKeepPendingAndPersistentReasonsIndependent(t *te
 
 	assert.Equal(t, []agentsync.PollingObligation{
 		{
-			Key: pendingPath, Agent: parser.AgentDevin,
+			Key: pendingRootKey(pendingPath), Agent: parser.AgentDevin,
 			Roots: []string{shared}, Probe: pendingPath,
 		},
 		{
@@ -3732,13 +3732,13 @@ func TestWatchPollingObligationsSplitSameProviderPendingDirs(t *testing.T) {
 
 	assert.Equal(t, []agentsync.PollingObligation{
 		{
-			Key:   watchPath + "|" + filepath.Clean(firstDir),
+			Key:   pendingRootKey(watchPath) + "|" + filepath.Clean(firstDir),
 			Agent: parser.AgentOpenCode,
 			Roots: []string{firstDir},
 			Probe: watchPath,
 		},
 		{
-			Key:   watchPath + "|" + filepath.Clean(secondDir),
+			Key:   pendingRootKey(watchPath) + "|" + filepath.Clean(secondDir),
 			Agent: parser.AgentOpenCode,
 			Roots: []string{secondDir},
 			Probe: watchPath,
@@ -3808,7 +3808,7 @@ func TestWatchPollingObligationsKeepMixedProviderDirsGrouped(t *testing.T) {
 
 	require.Len(t, got, 1)
 	assert.Equal(t, agentsync.PollingObligation{
-		Key:   watchPath,
+		Key:   pendingRootKey(watchPath),
 		Roots: []string{mixedDir, otherMixedDir},
 		Probe: watchPath,
 	}, got[0], "mixed-provider dirs stay generic and keep sharing the root obligation")
@@ -3843,7 +3843,7 @@ func TestWatchPollingObligationsDoNotDuplicateUnwatchedAndPendingObligations(t *
 
 	require.Len(t, got, 2, "the pending and unwatched reasons are distinct obligations")
 	keys := []string{got[0].Key, got[1].Key}
-	assert.ElementsMatch(t, []string{watchPath, unwatchedRootKey(watchPath)}, keys,
+	assert.ElementsMatch(t, []string{pendingRootKey(watchPath), unwatchedRootKey(watchPath)}, keys,
 		"they are told apart by their own keys, not by a per-directory suffix")
 	for _, obligation := range got {
 		assert.Equal(t, []string{syncDir}, obligation.Roots)

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -33,12 +33,6 @@ import (
 	"go.kenn.io/agentsview/internal/testjsonl"
 )
 
-type staticDegradedPollProbe struct{}
-
-func (*staticDegradedPollProbe) DegradedPollingState(context.Context) (string, error) {
-	return "state", nil
-}
-
 func TestRuntimeWarningHelper(t *testing.T) {
 	logOutput := captureLogOutput(t)
 	var visible bytes.Buffer
@@ -54,16 +48,20 @@ func TestRuntimeWarningHelper(t *testing.T) {
 	assert.Contains(t, logOutput.String(), "could not write daemon runtime record")
 }
 
-func TestLateBoundDegradedPollProbeActivatesWhenOpenCodeRootBecomesSQLite(t *testing.T) {
+func TestProviderDegradedPollingResolverActivatesWhenOpenCodeRootBecomesSQLite(t *testing.T) {
 	root := t.TempDir()
-	provider, ok := parser.NewProvider(parser.AgentOpenCode, parser.ProviderConfig{
+	resolver := newProviderDegradedPollingResolver()
+	obligation := pollingObligation{
+		Key:   "opencode-root",
+		Agent: parser.AgentOpenCode,
 		Roots: []string{root},
-	})
-	require.True(t, ok)
-	probe := lateBoundDegradedPollProbe{provider: provider, root: root}
+		Probe: root,
+	}
 
-	_, err := probe.DegradedPollingState(t.Context())
-	require.ErrorIs(t, err, parser.ErrUnsupportedProviderFeature)
+	decision, err := resolver.ShouldReconcile(t.Context(), obligation)
+	require.NoError(t, err)
+	assert.True(t, decision.Poll)
+	assert.False(t, decision.Tracked)
 
 	db, err := sql.Open("sqlite3", filepath.Join(root, "opencode.db"))
 	require.NoError(t, err)
@@ -72,18 +70,66 @@ func TestLateBoundDegradedPollProbeActivatesWhenOpenCodeRootBecomesSQLite(t *tes
 	_, err = db.Exec(`CREATE TABLE probe_state (id INTEGER PRIMARY KEY)`)
 	require.NoError(t, err)
 
-	state, err := probe.DegradedPollingState(t.Context())
+	decision, err = resolver.ShouldReconcile(t.Context(), obligation)
 	require.NoError(t, err)
-	assert.NotEmpty(t, state)
+	assert.True(t, decision.Poll)
+	assert.True(t, decision.Tracked)
 }
 
-func TestLateBoundDegradedPollProbeFallsBackWhenOpenCodeRootBecomesHybrid(t *testing.T) {
-	root := t.TempDir()
-	provider, ok := parser.NewProvider(parser.AgentOpenCode, parser.ProviderConfig{
+func TestPendingOpenCodeRootPreservesProviderOwnershipWhenItBecomesSQLite(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "missing-opencode")
+	got := watchPollingObligations(
+		[]watchRoot{{
+			path:               root,
+			scopes:             []watchScope{{agent: parser.AgentOpenCode, syncDir: root}},
+			pendingPollingDirs: []string{root},
+		}},
+		[]agentsync.RecursiveWatchResult{{Watched: 1}},
+		[]string{root},
+	)
+	require.Len(t, got, 1)
+	assert.Equal(t, agentsync.PollingObligation{
+		Key:   root,
+		Agent: parser.AgentOpenCode,
 		Roots: []string{root},
-	})
-	require.True(t, ok)
-	probe := lateBoundDegradedPollProbe{provider: provider, root: root}
+		Probe: root,
+	}, got[0])
+
+	resolver := newProviderDegradedPollingResolver()
+	obligation := pollingObligation{
+		Key:   got[0].Key,
+		Agent: got[0].Agent,
+		Roots: got[0].Roots,
+		Probe: got[0].Probe,
+	}
+	decision, err := resolver.ShouldReconcile(t.Context(), obligation)
+	require.NoError(t, err)
+	assert.True(t, decision.Poll)
+	assert.False(t, decision.Tracked)
+
+	require.NoError(t, os.MkdirAll(root, 0o755))
+	db, err := sql.Open("sqlite3", filepath.Join(root, "opencode.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	require.NoError(t, db.Ping())
+	_, err = db.Exec(`CREATE TABLE probe_state (id INTEGER PRIMARY KEY)`)
+	require.NoError(t, err)
+
+	decision, err = resolver.ShouldReconcile(t.Context(), obligation)
+	require.NoError(t, err)
+	assert.True(t, decision.Poll)
+	assert.True(t, decision.Tracked)
+}
+
+func TestProviderDegradedPollingResolverFallsBackWhenOpenCodeRootBecomesHybrid(t *testing.T) {
+	root := t.TempDir()
+	resolver := newProviderDegradedPollingResolver()
+	obligation := pollingObligation{
+		Key:   "opencode-root",
+		Agent: parser.AgentOpenCode,
+		Roots: []string{root},
+		Probe: root,
+	}
 
 	db, err := sql.Open("sqlite3", filepath.Join(root, "opencode.db"))
 	require.NoError(t, err)
@@ -92,15 +138,18 @@ func TestLateBoundDegradedPollProbeFallsBackWhenOpenCodeRootBecomesHybrid(t *tes
 	_, err = db.Exec(`CREATE TABLE probe_state (id INTEGER PRIMARY KEY)`)
 	require.NoError(t, err)
 
-	state, err := probe.DegradedPollingState(t.Context())
+	decision, err := resolver.ShouldReconcile(t.Context(), obligation)
 	require.NoError(t, err)
-	assert.NotEmpty(t, state)
+	assert.True(t, decision.Poll)
+	assert.True(t, decision.Tracked)
 
 	require.NoError(t,
 		os.MkdirAll(filepath.Join(root, "storage", "session"), 0o755))
 
-	_, err = probe.DegradedPollingState(t.Context())
-	require.ErrorIs(t, err, parser.ErrUnsupportedProviderFeature)
+	decision, err = resolver.ShouldReconcile(t.Context(), obligation)
+	require.NoError(t, err)
+	assert.True(t, decision.Poll)
+	assert.False(t, decision.Tracked)
 }
 
 func TestServeRuntimeRecordWriteFailureWarnsVisibleAfterSlowStartup(t *testing.T) {
@@ -604,11 +653,11 @@ func TestPollUnwatchedRootsOnceUsesScopedAuthoritativeReconciliation(t *testing.
 	roots := []string{"/tmp/claude", "/tmp/codex"}
 
 	pollUnwatchedRootsOnce(t.Context(), fake, []pollingObligation{{
-		Key: "roots",
+		Key:   "roots",
 		Roots: roots,
 	}})
 	pollUnwatchedRootsOnce(t.Context(), fake, []pollingObligation{{
-		Key: "roots",
+		Key:   "roots",
 		Roots: roots,
 	}})
 
@@ -1647,7 +1696,10 @@ func TestWatchPollingObligationsKeepPendingAndPersistentReasonsIndependent(t *te
 	)
 
 	assert.Equal(t, []agentsync.PollingObligation{
-		{Key: pendingPath, Roots: []string{shared}, Probe: pendingPath},
+		{
+			Key: pendingPath, Agent: parser.AgentDevin,
+			Roots: []string{shared}, Probe: pendingPath,
+		},
 		{Key: "persistent:" + shared, Roots: []string{shared}, Probe: shared},
 	}, got)
 }
@@ -1655,11 +1707,10 @@ func TestWatchPollingObligationsKeepPendingAndPersistentReasonsIndependent(t *te
 func TestWatchPollingObligationsCoverRegistrationFailureByLogicalRoot(t *testing.T) {
 	syncDir := t.TempDir()
 	watchPath := filepath.Join(syncDir, "sessions")
-	probe := &staticDegradedPollProbe{}
 	roots := []watchRoot{{
 		path: watchPath, exists: true, recursive: true,
 		scopes: []watchScope{{
-			agent: parser.AgentClaude, syncDir: syncDir, degradedProbe: probe,
+			agent: parser.AgentClaude, syncDir: syncDir,
 		}},
 	}}
 
@@ -1671,9 +1722,9 @@ func TestWatchPollingObligationsCoverRegistrationFailureByLogicalRoot(t *testing
 
 	require.Len(t, got, 1)
 	assert.Equal(t, watchPath+"|"+filepath.Clean(syncDir), got[0].Key)
+	assert.Equal(t, parser.AgentClaude, got[0].Agent)
 	assert.Equal(t, []string{syncDir}, got[0].Roots)
 	assert.Equal(t, watchPath, got[0].Probe)
-	assert.Same(t, probe, got[0].DegradedProbe)
 }
 
 func TestWatchPollingObligationsKeepMergedRootProbesScopedToTheirDir(t *testing.T) {
@@ -1681,13 +1732,12 @@ func TestWatchPollingObligationsKeepMergedRootProbesScopedToTheirDir(t *testing.
 	openCodeDir := filepath.Join(base, "opencode")
 	unsupportedDir := filepath.Join(base, "kilo")
 	watchPath := filepath.Join(base, "shared")
-	probe := &staticDegradedPollProbe{}
 	roots := []watchRoot{{
 		path:      watchPath,
 		exists:    true,
 		recursive: true,
 		scopes: []watchScope{
-			{agent: parser.AgentOpenCode, syncDir: openCodeDir, degradedProbe: probe},
+			{agent: parser.AgentOpenCode, syncDir: openCodeDir},
 			{agent: parser.AgentKilo, syncDir: unsupportedDir},
 		},
 	}}
@@ -1701,16 +1751,16 @@ func TestWatchPollingObligationsKeepMergedRootProbesScopedToTheirDir(t *testing.
 	require.Len(t, got, 2)
 	assert.Equal(t, []agentsync.PollingObligation{
 		{
-			Key:           watchPath,
-			Roots:         []string{unsupportedDir},
-			Probe:         watchPath,
-			DegradedProbe: nil,
+			Key:   watchPath + "|" + filepath.Clean(unsupportedDir),
+			Agent: parser.AgentKilo,
+			Roots: []string{unsupportedDir},
+			Probe: watchPath,
 		},
 		{
-			Key:           watchPath + "|" + filepath.Clean(openCodeDir),
-			Roots:         []string{openCodeDir},
-			Probe:         watchPath,
-			DegradedProbe: probe,
+			Key:   watchPath + "|" + filepath.Clean(openCodeDir),
+			Agent: parser.AgentOpenCode,
+			Roots: []string{openCodeDir},
+			Probe: watchPath,
 		},
 	}, got)
 }
@@ -1718,13 +1768,12 @@ func TestWatchPollingObligationsKeepMergedRootProbesScopedToTheirDir(t *testing.
 func TestWatchPollingObligationsSharedDirWithUnsupportedScopeDisablesProbe(t *testing.T) {
 	sharedDir := t.TempDir()
 	watchPath := filepath.Join(sharedDir, "shared")
-	probe := &staticDegradedPollProbe{}
 	roots := []watchRoot{{
 		path:      watchPath,
 		exists:    true,
 		recursive: true,
 		scopes: []watchScope{
-			{agent: parser.AgentOpenCode, syncDir: sharedDir, degradedProbe: probe},
+			{agent: parser.AgentOpenCode, syncDir: sharedDir},
 			{agent: parser.AgentKilo, syncDir: sharedDir},
 		},
 	}}
@@ -1793,6 +1842,7 @@ func TestWatcherUnavailableFallbackDefersBrokenSymlinkScope(t *testing.T) {
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
 		t.Context(), syncer, make(chan time.Time), func() {},
 		func(run func()) { run() }, nil,
+		nil,
 	)
 	t.Cleanup(coordinator.Stop)
 	options := agentsync.WatcherOptions{
@@ -1853,6 +1903,7 @@ func TestWatcherUnavailableFallbackDefersMissingNestedRootScope(t *testing.T) {
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
 		t.Context(), syncer, make(chan time.Time), func() {},
 		func(run func()) { run() }, nil,
+		nil,
 	)
 	t.Cleanup(coordinator.Stop)
 	options := agentsync.WatcherOptions{
@@ -1912,6 +1963,7 @@ func TestWatcherUnavailableFallbackDefersNestedRootLostAfterRegistration(t *test
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
 		t.Context(), syncer, make(chan time.Time), func() {},
 		func(run func()) { run() }, nil,
+		nil,
 	)
 	t.Cleanup(coordinator.Stop)
 	options := agentsync.WatcherOptions{
@@ -1981,6 +2033,7 @@ func TestWatcherUnavailableObligationsGateBeforeFallback(t *testing.T) {
 			stepAvailable = append(stepAvailable,
 				availableUnwatchedPollRoots(coordinator.currentPollObligations()))
 		},
+		nil,
 	)
 	t.Cleanup(coordinator.Stop)
 	options := agentsync.WatcherOptions{
@@ -2020,14 +2073,17 @@ func TestWatcherUnavailableObligationsGateBeforeFallback(t *testing.T) {
 
 func TestWatcherUnavailableFallbackDoesNotBypassUnchangedDegradedProbe(t *testing.T) {
 	configured := requireExistingPollRoot(t, t.TempDir(), "opencode")
-	watchPath := filepath.Join(configured, "sessions")
-	require.NoError(t, os.MkdirAll(watchPath, 0o755))
-	probe := &sequenceDegradedPollProbe{states: []string{"stable", "stable"}}
+	db, err := sql.Open("sqlite3", filepath.Join(configured, "opencode.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	require.NoError(t, db.Ping())
+	_, err = db.Exec(`CREATE TABLE probe_state (id INTEGER PRIMARY KEY)`)
+	require.NoError(t, err)
 
 	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 2)}
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
 		t.Context(), syncer, make(chan time.Time), func() {},
-		func(run func()) { run() }, nil,
+		func(run func()) { run() }, nil, newProviderDegradedPollingResolver(),
 	)
 	t.Cleanup(coordinator.Stop)
 	options := agentsync.WatcherOptions{
@@ -2038,19 +2094,19 @@ func TestWatcherUnavailableFallbackDoesNotBypassUnchangedDegradedProbe(t *testin
 		},
 		OnPollingRequired: func(obligation agentsync.PollingObligation) error {
 			return coordinator.AddObligation(pollingObligation{
-				Key:           obligation.Key,
-				Roots:         obligation.Roots,
-				Probe:         obligation.Probe,
-				DegradedProbe: obligation.DegradedProbe,
+				Key:   obligation.Key,
+				Agent: obligation.Agent,
+				Roots: obligation.Roots,
+				Probe: obligation.Probe,
 			})
 		},
 	}
 	roots := []watchRoot{{
-		path:      watchPath,
+		path:      configured,
 		exists:    true,
 		recursive: true,
 		scopes: []watchScope{
-			{agent: parser.AgentOpenCode, syncDir: configured, degradedProbe: probe},
+			{agent: parser.AgentOpenCode, syncDir: configured},
 		},
 	}}
 

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -1796,7 +1796,7 @@ func TestWatchPollingObligationsCoverRegistrationFailureByLogicalRoot(t *testing
 	)
 
 	require.Len(t, got, 1)
-	assert.Equal(t, watchPath+"|"+filepath.Clean(syncDir), got[0].Key)
+	assert.Equal(t, unwatchedRootKey(watchPath), got[0].Key)
 	assert.Equal(t, parser.AgentClaude, got[0].Agent)
 	assert.Equal(t, []string{syncDir}, got[0].Roots)
 	assert.Equal(t, watchPath, got[0].Probe)
@@ -1827,13 +1827,13 @@ func TestWatchPollingObligationsKeepMergedRootProbesScopedToTheirDir(t *testing.
 	require.Len(t, got, 2)
 	assert.Equal(t, []agentsync.PollingObligation{
 		{
-			Key:   watchPath + "|" + filepath.Clean(unsupportedDir),
+			Key:   unwatchedRootKey(watchPath) + "|" + filepath.Clean(unsupportedDir),
 			Agent: parser.AgentKilo,
 			Roots: []string{unsupportedDir},
 			Probe: watchPath,
 		},
 		{
-			Key:   watchPath + "|" + filepath.Clean(openCodeDir),
+			Key:   unwatchedRootKey(watchPath) + "|" + filepath.Clean(openCodeDir),
 			Agent: parser.AgentOpenCode,
 			Roots: []string{openCodeDir},
 			Probe: watchPath,
@@ -1863,7 +1863,7 @@ func TestWatchPollingObligationsSharedDirWithUnsupportedScopeDisablesProbe(t *te
 
 	require.Len(t, got, 1)
 	assert.Equal(t, []agentsync.PollingObligation{{
-		Key:   watchPath,
+		Key:   unwatchedRootKey(watchPath),
 		Roots: []string{sharedDir},
 		Probe: watchPath,
 	}}, got)
@@ -3812,4 +3812,41 @@ func TestWatchPollingObligationsKeepMixedProviderDirsGrouped(t *testing.T) {
 		Roots: []string{mixedDir, otherMixedDir},
 		Probe: watchPath,
 	}, got[0], "mixed-provider dirs stay generic and keep sharing the root obligation")
+}
+
+// TestWatchPollingObligationsDoNotDuplicateUnwatchedAndPendingObligations
+// covers the pair a shared root key used to produce: when a root has pending
+// polling dirs and its registration also failed, both branches fire, and with
+// both keyed on the root the two obligations differed only by a per-directory
+// suffix while carrying the same agent, roots, and probe. The coordinator then
+// evaluated the same degraded probe twice per tick.
+func TestWatchPollingObligationsDoNotDuplicateUnwatchedAndPendingObligations(t *testing.T) {
+	base := t.TempDir()
+	syncDir := filepath.Join(base, "opencode")
+	watchPath := filepath.Join(base, "sessions")
+	roots := []watchRoot{{
+		path:      watchPath,
+		exists:    true,
+		recursive: true,
+		scopes: []watchScope{
+			{agent: parser.AgentOpenCode, syncDir: syncDir},
+		},
+		pendingPollingDirs: []string{syncDir},
+	}}
+
+	got := watchPollingObligations(
+		roots,
+		[]agentsync.RecursiveWatchResult{{Unwatched: 1, Err: errors.New("watch failed")}},
+		nil,
+		nil,
+	)
+
+	require.Len(t, got, 2, "the pending and unwatched reasons are distinct obligations")
+	keys := []string{got[0].Key, got[1].Key}
+	assert.ElementsMatch(t, []string{watchPath, unwatchedRootKey(watchPath)}, keys,
+		"they are told apart by their own keys, not by a per-directory suffix")
+	for _, obligation := range got {
+		assert.Equal(t, []string{syncDir}, obligation.Roots)
+		assert.Equal(t, watchPath, obligation.Probe)
+	}
 }

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -705,7 +705,7 @@ func TestCollectWatchRootsPreservesDirsSharingWatchRoot(t *testing.T) {
 	assert.False(t, sessions.exists)
 	assert.Equal(t, []watchScope{{agent: parser.AgentCodex, syncDir: sessionsDir}}, sessions.scopes)
 	assert.Equal(t, []string{sessionsDir}, sessions.pendingPollingDirs)
-	assert.Empty(t, sessions.persistentPollingDirs)
+	assert.Empty(t, sessions.persistentPollingScopes)
 
 	archived, ok := findCollectedWatchRoot(roots, archivedDir)
 	require.True(t, ok, "missing archive root remains in the logical plan")
@@ -713,7 +713,7 @@ func TestCollectWatchRootsPreservesDirsSharingWatchRoot(t *testing.T) {
 	assert.False(t, archived.exists)
 	assert.Equal(t, []watchScope{{agent: parser.AgentCodex, syncDir: archivedDir}}, archived.scopes)
 	assert.Equal(t, []string{archivedDir}, archived.pendingPollingDirs)
-	assert.Empty(t, archived.persistentPollingDirs)
+	assert.Empty(t, archived.persistentPollingScopes)
 }
 
 func TestCollectWatchRootsPollsRecursiveSymlinkProviderRoot(t *testing.T) {
@@ -1597,8 +1597,10 @@ func TestStartFileWatcherKeepsPollingForIndependentReasonAfterPendingCoverage(t 
 		},
 		{
 			path: root, exists: true,
-			scopes:                []watchScope{{agent: parser.AgentDevin, syncDir: root}},
-			persistentPollingDirs: []string{root},
+			scopes: []watchScope{{agent: parser.AgentDevin, syncDir: root}},
+			persistentPollingScopes: map[string][]watchScope{
+				root: {{agent: parser.AgentDevin, syncDir: root}},
+			},
 		},
 	}
 
@@ -1686,8 +1688,10 @@ func TestWatchPollingObligationsKeepPendingAndPersistentReasonsIndependent(t *te
 		},
 		{
 			path: filepath.Join(shared, "existing"), exists: true,
-			scopes:                []watchScope{{agent: parser.AgentDevin, syncDir: shared}},
-			persistentPollingDirs: []string{shared},
+			scopes: []watchScope{{agent: parser.AgentDevin, syncDir: shared}},
+			persistentPollingScopes: map[string][]watchScope{
+				shared: {{agent: parser.AgentDevin, syncDir: shared}},
+			},
 		},
 	}
 
@@ -1708,6 +1712,70 @@ func TestWatchPollingObligationsKeepPendingAndPersistentReasonsIndependent(t *te
 			Roots: []string{shared}, Probe: shared,
 		},
 	}, got)
+}
+
+func TestWatchPollingObligationsPreservePollOnlyOwnerOnSharedConfiguredDir(t *testing.T) {
+	shared := t.TempDir()
+	roots := []watchRoot{{
+		path: filepath.Join(shared, "watched"),
+		scopes: []watchScope{{
+			agent: parser.AgentClaude, syncDir: shared,
+		}},
+	}}
+
+	tests := []struct {
+		name   string
+		scopes []watchScope
+		agent  parser.AgentType
+	}{
+		{
+			name: "single complete owner stays provider scoped",
+			scopes: []watchScope{{
+				agent: parser.AgentOpenCode, syncDir: shared,
+			}},
+			agent: parser.AgentOpenCode,
+		},
+		{
+			name: "mixed owners stay generic",
+			scopes: []watchScope{
+				{agent: parser.AgentOpenCode, syncDir: shared},
+				{agent: parser.AgentClaude, syncDir: shared},
+			},
+			agent: "",
+		},
+		{
+			name: "incomplete owner metadata stays generic",
+			scopes: []watchScope{
+				{agent: parser.AgentOpenCode, syncDir: shared},
+				{agent: "", syncDir: shared},
+			},
+			agent: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			roots[0].persistentPollingScopes = map[string][]watchScope{
+				shared: tc.scopes,
+			}
+
+			got := watchPollingObligations(
+				roots,
+				[]agentsync.RecursiveWatchResult{{Watched: 1}},
+				[]string{shared},
+				nil,
+			)
+
+			require.Equal(t, []agentsync.PollingObligation{{
+				Key:   "persistent:" + shared,
+				Agent: tc.agent,
+				Roots: []string{shared},
+				Probe: shared,
+			}}, got)
+			assert.NotEqual(t, parser.AgentClaude, got[0].Agent,
+				"persistent ownership must come from the persistent reason, not the carrier watch root")
+		})
+	}
 }
 
 func TestWatchPollingObligationsCoverRegistrationFailureByLogicalRoot(t *testing.T) {

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -86,6 +86,7 @@ func TestPendingOpenCodeRootPreservesProviderOwnershipWhenItBecomesSQLite(t *tes
 		}},
 		[]agentsync.RecursiveWatchResult{{Watched: 1}},
 		[]string{root},
+		nil,
 	)
 	require.Len(t, got, 1)
 	assert.Equal(t, agentsync.PollingObligation{
@@ -1424,6 +1425,7 @@ func TestStartFileWatcherSuppressesPendingPollingWhenLifecycleIsOwned(t *testing
 			MissingRootLifecycleOwned: true,
 		}},
 		got,
+		nil,
 	), "owned missing roots must not schedule authoritative polling")
 }
 
@@ -1636,9 +1638,9 @@ func TestWatchPollingObligationsMissingRootLifecycleCardinality(t *testing.T) {
 				unwatched = append(unwatched, syncDir)
 			}
 
-			assert.Empty(t, watchPollingObligations(roots, owned, nil),
+			assert.Empty(t, watchPollingObligations(roots, owned, nil, nil),
 				"native lifecycle work must remain independent of configured archive cardinality")
-			assert.Len(t, watchPollingObligations(roots, portable, unwatched), rootCount,
+			assert.Len(t, watchPollingObligations(roots, portable, unwatched, nil), rootCount,
 				"portable backends retain one obligation per uncovered missing root")
 		})
 	}
@@ -1667,7 +1669,7 @@ func TestOpenCodeFormatMissingRootsUseNativeLifecycleWithoutPolling(t *testing.T
 			}
 			unwatched = accountRegisteredWatchRoots(unwatched, roots, results)
 
-			assert.Empty(t, watchPollingObligations(roots, results, unwatched),
+			assert.Empty(t, watchPollingObligations(roots, results, unwatched, nil),
 				"absent OpenCode-format providers must not add archive-scale polling")
 		})
 	}
@@ -1693,6 +1695,7 @@ func TestWatchPollingObligationsKeepPendingAndPersistentReasonsIndependent(t *te
 		roots,
 		[]agentsync.RecursiveWatchResult{{Watched: 1}, {Watched: 1}},
 		[]string{shared},
+		nil,
 	)
 
 	assert.Equal(t, []agentsync.PollingObligation{
@@ -1700,7 +1703,10 @@ func TestWatchPollingObligationsKeepPendingAndPersistentReasonsIndependent(t *te
 			Key: pendingPath, Agent: parser.AgentDevin,
 			Roots: []string{shared}, Probe: pendingPath,
 		},
-		{Key: "persistent:" + shared, Roots: []string{shared}, Probe: shared},
+		{
+			Key: "persistent:" + shared, Agent: parser.AgentDevin,
+			Roots: []string{shared}, Probe: shared,
+		},
 	}, got)
 }
 
@@ -1718,6 +1724,7 @@ func TestWatchPollingObligationsCoverRegistrationFailureByLogicalRoot(t *testing
 		roots,
 		[]agentsync.RecursiveWatchResult{{Unwatched: 1, Err: errors.New("watch failed")}},
 		[]string{syncDir},
+		nil,
 	)
 
 	require.Len(t, got, 1)
@@ -1746,6 +1753,7 @@ func TestWatchPollingObligationsKeepMergedRootProbesScopedToTheirDir(t *testing.
 		roots,
 		[]agentsync.RecursiveWatchResult{{Unwatched: 1, Err: errors.New("watch failed")}},
 		[]string{openCodeDir, unsupportedDir},
+		nil,
 	)
 
 	require.Len(t, got, 2)
@@ -1782,6 +1790,7 @@ func TestWatchPollingObligationsSharedDirWithUnsupportedScopeDisablesProbe(t *te
 		roots,
 		[]agentsync.RecursiveWatchResult{{Unwatched: 1, Err: errors.New("watch failed")}},
 		[]string{sharedDir},
+		nil,
 	)
 
 	require.Len(t, got, 1)
@@ -1804,11 +1813,12 @@ func TestSymlinkPollingObligationsGateDirsOnTargetAvailability(t *testing.T) {
 	symRoot := filepath.Join(parent, "sessions")
 	requireSymlinkOrSkip(t, target, symRoot)
 
-	obligations := symlinkPollingObligations(map[string][]string{
-		symRoot: {parent},
+	obligations := symlinkPollingObligations(map[string][]watchScope{
+		symRoot: {{agent: parser.AgentOpenCode, syncDir: parent}},
 	})
 	require.Equal(t, []agentsync.PollingObligation{{
-		Key: "symlink:" + symRoot, Roots: []string{parent}, Probe: symRoot,
+		Key: "symlink:" + symRoot, Agent: parser.AgentOpenCode,
+		Roots: []string{parent}, Probe: symRoot,
 	}}, obligations)
 
 	combined := []pollingObligation{
@@ -1821,6 +1831,22 @@ func TestSymlinkPollingObligationsGateDirsOnTargetAvailability(t *testing.T) {
 	require.NoError(t, os.RemoveAll(target))
 	assert.Empty(t, availableUnwatchedPollRoots(combined),
 		"a broken symlink target must defer the dir even though the dir itself exists")
+}
+
+func TestWatchPollingObligationsSkipGenericPersistentForSymlinkGatedDir(t *testing.T) {
+	parent := t.TempDir()
+	symRoot := filepath.Join(parent, "sessions")
+
+	got := watchPollingObligations(
+		nil,
+		nil,
+		[]string{parent},
+		map[string][]watchScope{symRoot: {{
+			agent: parser.AgentOpenCode, syncDir: parent,
+		}}},
+	)
+
+	assert.Empty(t, got)
 }
 
 // TestWatcherUnavailableFallbackDefersBrokenSymlinkScope guards the
@@ -1864,7 +1890,9 @@ func TestWatcherUnavailableFallbackDefersBrokenSymlinkScope(t *testing.T) {
 		options,
 		nil,
 		[]string{parent, other},
-		map[string][]string{symRoot: {parent}},
+		map[string][]watchScope{symRoot: {{
+			agent: parser.AgentOpenCode, syncDir: parent,
+		}}},
 	))
 
 	bothDirs := []string{parent, other}
@@ -2123,6 +2151,138 @@ func TestWatcherUnavailableFallbackDoesNotBypassUnchangedDegradedProbe(t *testin
 	assert.Never(t, func() bool { return len(syncer.snapshot()) > 1 },
 		200*time.Millisecond, 10*time.Millisecond,
 		"unchanged degraded-probe state must suppress the construction-failure fallback too")
+}
+
+func TestRegisterWatcherUnavailableObligationsRetainsCoverageOnScopedRegistrationError(t *testing.T) {
+	parent := requireExistingPollRoot(t, t.TempDir(), "opencode")
+	other := requireExistingPollRoot(t, t.TempDir(), "other")
+	var coverageRoots []string
+	options := agentsync.WatcherOptions{
+		OnCoverageDegraded: func(roots []string) error {
+			coverageRoots = append([]string(nil), roots...)
+			return nil
+		},
+		OnPollingRequired: func(obligation agentsync.PollingObligation) error {
+			return errors.New("register failed")
+		},
+	}
+	roots := []watchRoot{{
+		path:      parent,
+		exists:    true,
+		recursive: true,
+		scopes: []watchScope{{
+			agent: parser.AgentOpenCode, syncDir: parent,
+		}},
+	}}
+
+	err := registerWatcherUnavailableObligations(
+		options, roots, []string{parent, other}, nil,
+	)
+
+	require.ErrorContains(t, err, "register failed")
+	assert.Nil(t, coverageRoots)
+}
+
+func TestRegisterWatcherUnavailableObligationsDoesNotFallbackAcrossFailedSymlinkGate(t *testing.T) {
+	parent := t.TempDir()
+	target := filepath.Join(t.TempDir(), "sessions-target")
+	require.NoError(t, os.MkdirAll(target, 0o755))
+	symRoot := filepath.Join(parent, "sessions")
+	requireSymlinkOrSkip(t, target, symRoot)
+	other := requireExistingPollRoot(t, t.TempDir(), "other")
+
+	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 2)}
+	coordinator := newUnwatchedPollCoordinatorWithTicks(
+		t.Context(), syncer, make(chan time.Time), func() {},
+		func(run func()) { run() }, nil, nil,
+	)
+	t.Cleanup(coordinator.Stop)
+	options := agentsync.WatcherOptions{
+		OnCoverageDegraded: func(roots []string) error {
+			if len(roots) == 0 {
+				return nil
+			}
+			return coordinator.AddObligation(pollingObligation{
+				Key: "watcher-fallback", Roots: roots,
+			})
+		},
+		OnPollingRequired: func(obligation agentsync.PollingObligation) error {
+			if strings.HasPrefix(obligation.Key, "symlink:") {
+				return errors.New("register failed")
+			}
+			return coordinator.AddObligation(pollingObligation{
+				Key:   obligation.Key,
+				Agent: obligation.Agent,
+				Roots: obligation.Roots,
+				Probe: obligation.Probe,
+			})
+		},
+	}
+
+	require.ErrorContains(t, registerWatcherUnavailableObligations(
+		options,
+		nil,
+		[]string{parent, other},
+		map[string][]watchScope{symRoot: {{
+			agent: parser.AgentOpenCode, syncDir: parent,
+		}}},
+	), "register failed")
+
+	coordinator.requestPoll()
+	requirePollWithin(t, syncer.wake, time.Second)
+	assert.Equal(t, [][]string{{other}}, syncer.snapshot(),
+		"a failed symlink gate must not reintroduce the gated dir through generic fallback")
+}
+
+func TestRegisterWatcherUnavailableObligationsDoesNotDuplicateSuccessfulOwnedRootsAfterPartialFailure(t *testing.T) {
+	parent := requireExistingPollRoot(t, t.TempDir(), "opencode")
+	other := requireExistingPollRoot(t, t.TempDir(), "other")
+
+	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 2)}
+	coordinator := newUnwatchedPollCoordinatorWithTicks(
+		t.Context(), syncer, make(chan time.Time), func() {},
+		func(run func()) { run() }, nil, nil,
+	)
+	t.Cleanup(coordinator.Stop)
+	options := agentsync.WatcherOptions{
+		OnCoverageDegraded: func(roots []string) error {
+			if len(roots) == 0 {
+				return nil
+			}
+			return coordinator.AddObligation(pollingObligation{
+				Key: "watcher-fallback", Roots: roots,
+			})
+		},
+		OnPollingRequired: func(obligation agentsync.PollingObligation) error {
+			if obligation.Key == "persistent:"+other {
+				return errors.New("register failed")
+			}
+			return coordinator.AddObligation(pollingObligation{
+				Key:   obligation.Key,
+				Agent: obligation.Agent,
+				Roots: obligation.Roots,
+				Probe: obligation.Probe,
+			})
+		},
+	}
+	roots := []watchRoot{{
+		path:      parent,
+		exists:    true,
+		recursive: true,
+		scopes: []watchScope{{
+			agent: parser.AgentOpenCode, syncDir: parent,
+		}},
+	}}
+
+	require.ErrorContains(t, registerWatcherUnavailableObligations(
+		options, roots, []string{parent, other}, nil,
+	), "register failed")
+
+	coordinator.requestPoll()
+	requirePollWithin(t, syncer.wake, time.Second)
+	assert.Equal(t, [][]string{{parent}}, syncer.snapshot(),
+		"a partial failure must not add a generic fallback that duplicates the successful provider-owned root")
+	assert.Equal(t, []parser.AgentType{parser.AgentOpenCode}, syncer.agentSnapshot())
 }
 
 func findCollectedWatchRoot(roots []watchRoot, path string) (watchRoot, bool) {

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -3701,3 +3701,115 @@ func TestSyncWatchBatchDirectoryRenameDefersUnavailableProviderRoots(t *testing.
 	assert.NotNil(t, synced,
 		"the available root must still reconcile the rename authoritatively")
 }
+
+// TestWatchPollingObligationsSplitSameProviderPendingDirs covers the grouping
+// the runtime watcher fallback never had: a pending reason spanning two
+// directories owned by one provider produced a single obligation carrying one
+// probe, so that probe answered for whichever directory it matched first and a
+// change in the other was skipped for as long as the probe stayed unchanged.
+func TestWatchPollingObligationsSplitSameProviderPendingDirs(t *testing.T) {
+	base := t.TempDir()
+	firstDir := filepath.Join(base, "opencode-a")
+	secondDir := filepath.Join(base, "opencode-b")
+	watchPath := filepath.Join(base, "shared")
+	roots := []watchRoot{{
+		path:      watchPath,
+		exists:    true,
+		recursive: true,
+		scopes: []watchScope{
+			{agent: parser.AgentOpenCode, syncDir: firstDir},
+			{agent: parser.AgentOpenCode, syncDir: secondDir},
+		},
+		pendingPollingDirs: []string{firstDir, secondDir},
+	}}
+
+	got := watchPollingObligations(
+		roots,
+		[]agentsync.RecursiveWatchResult{{Watched: 1}},
+		nil,
+		nil,
+	)
+
+	assert.Equal(t, []agentsync.PollingObligation{
+		{
+			Key:   watchPath + "|" + filepath.Clean(firstDir),
+			Agent: parser.AgentOpenCode,
+			Roots: []string{firstDir},
+			Probe: watchPath,
+		},
+		{
+			Key:   watchPath + "|" + filepath.Clean(secondDir),
+			Agent: parser.AgentOpenCode,
+			Roots: []string{secondDir},
+			Probe: watchPath,
+		},
+	}, got, "one probe cannot answer for two provider-owned directories")
+}
+
+// TestSymlinkPollingObligationsSplitSameProviderDirs is the symlink-gated
+// analogue: the gate reports one symlink root, but the directories beneath it
+// are polled independently and must each carry their own obligation.
+func TestSymlinkPollingObligationsSplitSameProviderDirs(t *testing.T) {
+	base := t.TempDir()
+	symRoot := filepath.Join(base, "link-target")
+	firstDir := filepath.Join(base, "opencode-a")
+	secondDir := filepath.Join(base, "opencode-b")
+
+	got := symlinkPollingObligations(map[string][]watchScope{
+		symRoot: {
+			{agent: parser.AgentOpenCode, syncDir: firstDir},
+			{agent: parser.AgentOpenCode, syncDir: secondDir},
+		},
+	})
+
+	assert.Equal(t, []agentsync.PollingObligation{
+		{
+			Key:   "symlink:" + filepath.Clean(symRoot) + "|" + filepath.Clean(firstDir),
+			Agent: parser.AgentOpenCode,
+			Roots: []string{firstDir},
+			Probe: filepath.Clean(symRoot),
+		},
+		{
+			Key:   "symlink:" + filepath.Clean(symRoot) + "|" + filepath.Clean(secondDir),
+			Agent: parser.AgentOpenCode,
+			Roots: []string{secondDir},
+			Probe: filepath.Clean(symRoot),
+		},
+	}, got)
+}
+
+// TestWatchPollingObligationsKeepMixedProviderDirsGrouped pins the negative
+// space: only provider-owned directories split. A directory whose scopes carry
+// more than one agent stays generic and keeps sharing the root's obligation.
+func TestWatchPollingObligationsKeepMixedProviderDirsGrouped(t *testing.T) {
+	base := t.TempDir()
+	mixedDir := filepath.Join(base, "mixed")
+	otherMixedDir := filepath.Join(base, "mixed-two")
+	watchPath := filepath.Join(base, "shared")
+	roots := []watchRoot{{
+		path:      watchPath,
+		exists:    true,
+		recursive: true,
+		scopes: []watchScope{
+			{agent: parser.AgentOpenCode, syncDir: mixedDir},
+			{agent: parser.AgentKilo, syncDir: mixedDir},
+			{agent: parser.AgentOpenCode, syncDir: otherMixedDir},
+			{agent: parser.AgentKilo, syncDir: otherMixedDir},
+		},
+		pendingPollingDirs: []string{mixedDir, otherMixedDir},
+	}}
+
+	got := watchPollingObligations(
+		roots,
+		[]agentsync.RecursiveWatchResult{{Watched: 1}},
+		nil,
+		nil,
+	)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, agentsync.PollingObligation{
+		Key:   watchPath,
+		Roots: []string{mixedDir, otherMixedDir},
+		Probe: watchPath,
+	}, got[0], "mixed-provider dirs stay generic and keep sharing the root obligation")
+}

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -77,6 +77,32 @@ func TestLateBoundDegradedPollProbeActivatesWhenOpenCodeRootBecomesSQLite(t *tes
 	assert.NotEmpty(t, state)
 }
 
+func TestLateBoundDegradedPollProbeFallsBackWhenOpenCodeRootBecomesHybrid(t *testing.T) {
+	root := t.TempDir()
+	provider, ok := parser.NewProvider(parser.AgentOpenCode, parser.ProviderConfig{
+		Roots: []string{root},
+	})
+	require.True(t, ok)
+	probe := lateBoundDegradedPollProbe{provider: provider, root: root}
+
+	db, err := sql.Open("sqlite3", filepath.Join(root, "opencode.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	require.NoError(t, db.Ping())
+	_, err = db.Exec(`CREATE TABLE probe_state (id INTEGER PRIMARY KEY)`)
+	require.NoError(t, err)
+
+	state, err := probe.DegradedPollingState(t.Context())
+	require.NoError(t, err)
+	assert.NotEmpty(t, state)
+
+	require.NoError(t,
+		os.MkdirAll(filepath.Join(root, "storage", "session"), 0o755))
+
+	_, err = probe.DegradedPollingState(t.Context())
+	require.ErrorIs(t, err, parser.ErrUnsupportedProviderFeature)
+}
+
 func TestServeRuntimeRecordWriteFailureWarnsVisibleAfterSlowStartup(t *testing.T) {
 	out, err := runServeRuntimeWarningHelper(t, true, 1200*time.Millisecond)
 	require.NoError(t, err, string(out))
@@ -567,12 +593,24 @@ func (f *fakeUnwatchedPollSyncer) ReconcileWatchRoots(
 	return nil
 }
 
+func (f *fakeUnwatchedPollSyncer) ReconcileProviderRoots(
+	ctx context.Context, _ parser.AgentType, roots []string,
+) error {
+	return f.ReconcileWatchRoots(ctx, roots, false)
+}
+
 func TestPollUnwatchedRootsOnceUsesScopedAuthoritativeReconciliation(t *testing.T) {
 	fake := &fakeUnwatchedPollSyncer{}
 	roots := []string{"/tmp/claude", "/tmp/codex"}
 
-	pollUnwatchedRootsOnce(t.Context(), fake, roots)
-	pollUnwatchedRootsOnce(t.Context(), fake, roots)
+	pollUnwatchedRootsOnce(t.Context(), fake, []pollingObligation{{
+		Key: "roots",
+		Roots: roots,
+	}})
+	pollUnwatchedRootsOnce(t.Context(), fake, []pollingObligation{{
+		Key: "roots",
+		Roots: roots,
+	}})
 
 	require.Equal(t, 2, fake.calls)
 	assert.Equal(t, roots, fake.callRoots[0])

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -1933,6 +1933,60 @@ func TestWatcherUnavailableObligationsGateBeforeFallback(t *testing.T) {
 		"the completed registration keeps unaffected dirs pollable")
 }
 
+func TestWatcherUnavailableFallbackDoesNotBypassUnchangedDegradedProbe(t *testing.T) {
+	configured := requireExistingPollRoot(t, t.TempDir(), "opencode")
+	watchPath := filepath.Join(configured, "sessions")
+	require.NoError(t, os.MkdirAll(watchPath, 0o755))
+	probe := &sequenceDegradedPollProbe{states: []string{"stable", "stable"}}
+
+	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 2)}
+	coordinator := newUnwatchedPollCoordinatorWithTicks(
+		t.Context(), syncer, make(chan time.Time), func() {},
+		func(run func()) { run() }, nil,
+	)
+	t.Cleanup(coordinator.Stop)
+	options := agentsync.WatcherOptions{
+		OnCoverageDegraded: func(roots []string) error {
+			return coordinator.AddObligation(pollingObligation{
+				Key: "watcher-fallback", Roots: roots,
+			})
+		},
+		OnPollingRequired: func(obligation agentsync.PollingObligation) error {
+			return coordinator.AddObligation(pollingObligation{
+				Key:           obligation.Key,
+				Roots:         obligation.Roots,
+				Probe:         obligation.Probe,
+				DegradedProbe: obligation.DegradedProbe,
+			})
+		},
+	}
+	roots := []watchRoot{{
+		path:      watchPath,
+		exists:    true,
+		recursive: true,
+		scopes: []watchScope{
+			{agent: parser.AgentOpenCode, syncDir: configured},
+		},
+		degradedPollProbes: map[string]parser.DegradedPollingStateProbe{
+			filepath.Clean(configured): probe,
+		},
+	}}
+
+	require.NoError(t, registerWatcherUnavailableObligations(
+		options, roots, []string{configured}, nil,
+	))
+
+	coordinator.requestPoll()
+	requirePollWithin(t, syncer.wake, time.Second)
+	assert.Equal(t, [][]string{{configured}}, syncer.snapshot(),
+		"the first degraded poll must still reconcile the configured dir")
+
+	coordinator.requestPoll()
+	assert.Never(t, func() bool { return len(syncer.snapshot()) > 1 },
+		200*time.Millisecond, 10*time.Millisecond,
+		"unchanged degraded-probe state must suppress the construction-failure fallback too")
+}
+
 func findCollectedWatchRoot(roots []watchRoot, path string) (watchRoot, bool) {
 	path = filepath.Clean(path)
 	for _, root := range roots {

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -1597,8 +1597,10 @@ func TestWatchPollingObligationsCoverRegistrationFailureByLogicalRoot(t *testing
 	probe := &staticDegradedPollProbe{}
 	roots := []watchRoot{{
 		path: watchPath, exists: true, recursive: true,
-		scopes:            []watchScope{{agent: parser.AgentClaude, syncDir: syncDir}},
-		degradedPollProbe: probe,
+		scopes: []watchScope{{agent: parser.AgentClaude, syncDir: syncDir}},
+		degradedPollProbes: map[string]parser.DegradedPollingStateProbe{
+			filepath.Clean(syncDir): probe,
+		},
 	}}
 
 	got := watchPollingObligations(
@@ -1608,10 +1610,52 @@ func TestWatchPollingObligationsCoverRegistrationFailureByLogicalRoot(t *testing
 	)
 
 	require.Len(t, got, 1)
-	assert.Equal(t, watchPath, got[0].Key)
+	assert.Equal(t, watchPath+"|"+filepath.Clean(syncDir), got[0].Key)
 	assert.Equal(t, []string{syncDir}, got[0].Roots)
 	assert.Equal(t, watchPath, got[0].Probe)
 	assert.Same(t, probe, got[0].DegradedProbe)
+}
+
+func TestWatchPollingObligationsKeepMergedRootProbesScopedToTheirDir(t *testing.T) {
+	base := t.TempDir()
+	openCodeDir := filepath.Join(base, "opencode")
+	unsupportedDir := filepath.Join(base, "kilo")
+	watchPath := filepath.Join(base, "shared")
+	probe := &staticDegradedPollProbe{}
+	roots := []watchRoot{{
+		path:      watchPath,
+		exists:    true,
+		recursive: true,
+		scopes: []watchScope{
+			{agent: parser.AgentOpenCode, syncDir: openCodeDir},
+			{agent: parser.AgentKilo, syncDir: unsupportedDir},
+		},
+		degradedPollProbes: map[string]parser.DegradedPollingStateProbe{
+			filepath.Clean(openCodeDir): probe,
+		},
+	}}
+
+	got := watchPollingObligations(
+		roots,
+		[]agentsync.RecursiveWatchResult{{Unwatched: 1, Err: errors.New("watch failed")}},
+		[]string{openCodeDir, unsupportedDir},
+	)
+
+	require.Len(t, got, 2)
+	assert.Equal(t, []agentsync.PollingObligation{
+		{
+			Key:           watchPath,
+			Roots:         []string{unsupportedDir},
+			Probe:         watchPath,
+			DegradedProbe: nil,
+		},
+		{
+			Key:           watchPath + "|" + filepath.Clean(openCodeDir),
+			Roots:         []string{openCodeDir},
+			Probe:         watchPath,
+			DegradedProbe: probe,
+		},
+	}, got)
 }
 
 // A persistent polling obligation probes the configured dir, which can still

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -33,6 +33,12 @@ import (
 	"go.kenn.io/agentsview/internal/testjsonl"
 )
 
+type staticDegradedPollProbe struct{}
+
+func (*staticDegradedPollProbe) DegradedPollingState(context.Context) (string, error) {
+	return "state", nil
+}
+
 func TestRuntimeWarningHelper(t *testing.T) {
 	logOutput := captureLogOutput(t)
 	var visible bytes.Buffer
@@ -1588,9 +1594,11 @@ func TestWatchPollingObligationsKeepPendingAndPersistentReasonsIndependent(t *te
 func TestWatchPollingObligationsCoverRegistrationFailureByLogicalRoot(t *testing.T) {
 	syncDir := t.TempDir()
 	watchPath := filepath.Join(syncDir, "sessions")
+	probe := &staticDegradedPollProbe{}
 	roots := []watchRoot{{
 		path: watchPath, exists: true, recursive: true,
-		scopes: []watchScope{{agent: parser.AgentClaude, syncDir: syncDir}},
+		scopes:            []watchScope{{agent: parser.AgentClaude, syncDir: syncDir}},
+		degradedPollProbe: probe,
 	}}
 
 	got := watchPollingObligations(
@@ -1599,9 +1607,11 @@ func TestWatchPollingObligationsCoverRegistrationFailureByLogicalRoot(t *testing
 		[]string{syncDir},
 	)
 
-	assert.Equal(t, []agentsync.PollingObligation{{
-		Key: watchPath, Roots: []string{syncDir}, Probe: watchPath,
-	}}, got)
+	require.Len(t, got, 1)
+	assert.Equal(t, watchPath, got[0].Key)
+	assert.Equal(t, []string{syncDir}, got[0].Roots)
+	assert.Equal(t, watchPath, got[0].Probe)
+	assert.Same(t, probe, got[0].DegradedProbe)
 }
 
 // A persistent polling obligation probes the configured dir, which can still

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -54,6 +54,29 @@ func TestRuntimeWarningHelper(t *testing.T) {
 	assert.Contains(t, logOutput.String(), "could not write daemon runtime record")
 }
 
+func TestLateBoundDegradedPollProbeActivatesWhenOpenCodeRootBecomesSQLite(t *testing.T) {
+	root := t.TempDir()
+	provider, ok := parser.NewProvider(parser.AgentOpenCode, parser.ProviderConfig{
+		Roots: []string{root},
+	})
+	require.True(t, ok)
+	probe := lateBoundDegradedPollProbe{provider: provider, root: root}
+
+	_, err := probe.DegradedPollingState(t.Context())
+	require.ErrorIs(t, err, parser.ErrUnsupportedProviderFeature)
+
+	db, err := sql.Open("sqlite3", filepath.Join(root, "opencode.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	require.NoError(t, db.Ping())
+	_, err = db.Exec(`CREATE TABLE probe_state (id INTEGER PRIMARY KEY)`)
+	require.NoError(t, err)
+
+	state, err := probe.DegradedPollingState(t.Context())
+	require.NoError(t, err)
+	assert.NotEmpty(t, state)
+}
+
 func TestServeRuntimeRecordWriteFailureWarnsVisibleAfterSlowStartup(t *testing.T) {
 	out, err := runServeRuntimeWarningHelper(t, true, 1200*time.Millisecond)
 	require.NoError(t, err, string(out))

--- a/cmd/agentsview/main_test.go
+++ b/cmd/agentsview/main_test.go
@@ -1597,10 +1597,9 @@ func TestWatchPollingObligationsCoverRegistrationFailureByLogicalRoot(t *testing
 	probe := &staticDegradedPollProbe{}
 	roots := []watchRoot{{
 		path: watchPath, exists: true, recursive: true,
-		scopes: []watchScope{{agent: parser.AgentClaude, syncDir: syncDir}},
-		degradedPollProbes: map[string]parser.DegradedPollingStateProbe{
-			filepath.Clean(syncDir): probe,
-		},
+		scopes: []watchScope{{
+			agent: parser.AgentClaude, syncDir: syncDir, degradedProbe: probe,
+		}},
 	}}
 
 	got := watchPollingObligations(
@@ -1627,11 +1626,8 @@ func TestWatchPollingObligationsKeepMergedRootProbesScopedToTheirDir(t *testing.
 		exists:    true,
 		recursive: true,
 		scopes: []watchScope{
-			{agent: parser.AgentOpenCode, syncDir: openCodeDir},
+			{agent: parser.AgentOpenCode, syncDir: openCodeDir, degradedProbe: probe},
 			{agent: parser.AgentKilo, syncDir: unsupportedDir},
-		},
-		degradedPollProbes: map[string]parser.DegradedPollingStateProbe{
-			filepath.Clean(openCodeDir): probe,
 		},
 	}}
 
@@ -1656,6 +1652,34 @@ func TestWatchPollingObligationsKeepMergedRootProbesScopedToTheirDir(t *testing.
 			DegradedProbe: probe,
 		},
 	}, got)
+}
+
+func TestWatchPollingObligationsSharedDirWithUnsupportedScopeDisablesProbe(t *testing.T) {
+	sharedDir := t.TempDir()
+	watchPath := filepath.Join(sharedDir, "shared")
+	probe := &staticDegradedPollProbe{}
+	roots := []watchRoot{{
+		path:      watchPath,
+		exists:    true,
+		recursive: true,
+		scopes: []watchScope{
+			{agent: parser.AgentOpenCode, syncDir: sharedDir, degradedProbe: probe},
+			{agent: parser.AgentKilo, syncDir: sharedDir},
+		},
+	}}
+
+	got := watchPollingObligations(
+		roots,
+		[]agentsync.RecursiveWatchResult{{Unwatched: 1, Err: errors.New("watch failed")}},
+		[]string{sharedDir},
+	)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, []agentsync.PollingObligation{{
+		Key:   watchPath,
+		Roots: []string{sharedDir},
+		Probe: watchPath,
+	}}, got)
 }
 
 // A persistent polling obligation probes the configured dir, which can still
@@ -1965,10 +1989,7 @@ func TestWatcherUnavailableFallbackDoesNotBypassUnchangedDegradedProbe(t *testin
 		exists:    true,
 		recursive: true,
 		scopes: []watchScope{
-			{agent: parser.AgentOpenCode, syncDir: configured},
-		},
-		degradedPollProbes: map[string]parser.DegradedPollingStateProbe{
-			filepath.Clean(configured): probe,
+			{agent: parser.AgentOpenCode, syncDir: configured, degradedProbe: probe},
 		},
 	}}
 

--- a/cmd/agentsview/unwatched_poll.go
+++ b/cmd/agentsview/unwatched_poll.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"log"
-	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -41,10 +40,81 @@ type pollingObligation struct {
 	// the scope then would tombstone every session under the missing
 	// subtree. Empty means the Roots themselves are probed.
 	Probe string
-	// DegradedProbe carries an additive provider-owned freshness token for
-	// degraded polling. Equal consecutive states suppress authoritative
-	// reconciliation for this obligation's Roots on that tick.
-	DegradedProbe parser.DegradedPollingStateProbe
+}
+
+type degradedPollingDecision struct {
+	Poll    bool
+	Tracked bool
+}
+
+type degradedPollingResolver interface {
+	ShouldReconcile(context.Context, pollingObligation) (
+		degradedPollingDecision, error,
+	)
+	Forget(pollingObligation)
+}
+
+type providerDegradedPollingResolver struct {
+	mu     sync.Mutex
+	states map[string]string
+}
+
+func newProviderDegradedPollingResolver() *providerDegradedPollingResolver {
+	return &providerDegradedPollingResolver{
+		states: make(map[string]string),
+	}
+}
+
+func (r *providerDegradedPollingResolver) ShouldReconcile(
+	ctx context.Context,
+	obligation pollingObligation,
+) (degradedPollingDecision, error) {
+	if err := ctx.Err(); err != nil {
+		return degradedPollingDecision{}, err
+	}
+	if obligation.Agent == "" || obligation.Probe == "" || len(obligation.Roots) == 0 {
+		return degradedPollingDecision{Poll: true}, nil
+	}
+	provider, ok := parser.NewProvider(obligation.Agent, parser.ProviderConfig{
+		Roots: append([]string(nil), obligation.Roots...),
+	})
+	if !ok {
+		r.Forget(obligation)
+		return degradedPollingDecision{Poll: true}, nil
+	}
+	probe, err := parser.ResolveDegradedPollingProbe(ctx, provider, obligation.Probe)
+	if err != nil {
+		if ctx.Err() != nil {
+			return degradedPollingDecision{}, ctx.Err()
+		}
+		r.Forget(obligation)
+		return degradedPollingDecision{Poll: true}, nil
+	}
+	state, err := probe.DegradedPollingState(ctx)
+	if err != nil {
+		if ctx.Err() != nil {
+			return degradedPollingDecision{}, ctx.Err()
+		}
+		r.Forget(obligation)
+		return degradedPollingDecision{Poll: true}, nil
+	}
+	r.mu.Lock()
+	prior, ok := r.states[obligation.Key]
+	r.states[obligation.Key] = state
+	r.mu.Unlock()
+	if ok && prior == state {
+		return degradedPollingDecision{Tracked: true}, nil
+	}
+	return degradedPollingDecision{Poll: true, Tracked: true}, nil
+}
+
+func (r *providerDegradedPollingResolver) Forget(obligation pollingObligation) {
+	if obligation.Key == "" {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.states, obligation.Key)
 }
 
 type sharedUnwatchedPollCoordinator struct {
@@ -57,6 +127,7 @@ type sharedUnwatchedPollCoordinator struct {
 	doWork       func(func())
 	// onRootsOwned is a test observer invoked after installation and before ack.
 	onRootsOwned func([]string)
+	degradedPoll degradedPollingResolver
 	add          chan unwatchedPollAdd
 	// pollWake coalesces ticks and explicit wakes while the serialized worker runs.
 	pollWake chan struct{}
@@ -66,8 +137,6 @@ type sharedUnwatchedPollCoordinator struct {
 	// coordinator loop; each entry keeps its probe so availability is
 	// evaluated per obligation at poll time.
 	pollObligations []pollingObligation
-	pollStates      map[string]string
-	pollRevisions   map[string]uint64
 	stop            chan struct{}
 	done            chan struct{}
 	stopOnce        sync.Once
@@ -81,6 +150,7 @@ func newUnwatchedPollCoordinator(
 	ticker := time.NewTicker(unwatchedPollInterval)
 	return newUnwatchedPollCoordinatorWithTicks(
 		ctx, engine, ticker.C, ticker.Stop, idleTracker.Do, nil,
+		newProviderDegradedPollingResolver(),
 	)
 }
 
@@ -91,24 +161,24 @@ func newUnwatchedPollCoordinatorWithTicks(
 	stopTicker func(),
 	doWork func(func()),
 	onRootsOwned func([]string),
+	degradedPoll degradedPollingResolver,
 ) *sharedUnwatchedPollCoordinator {
 	workerCtx, workerCancel := context.WithCancel(ctx)
 	coordinator := &sharedUnwatchedPollCoordinator{
-		ctx:           ctx,
-		workerCtx:     workerCtx,
-		workerCancel:  workerCancel,
-		engine:        engine,
-		ticks:         ticks,
-		stopTicker:    stopTicker,
-		doWork:        doWork,
-		add:           make(chan unwatchedPollAdd),
-		pollWake:      make(chan struct{}, 1),
-		pollDone:      make(chan struct{}),
-		pollStates:    make(map[string]string),
-		pollRevisions: make(map[string]uint64),
-		stop:          make(chan struct{}),
-		done:          make(chan struct{}),
-		onRootsOwned:  onRootsOwned,
+		ctx:          ctx,
+		workerCtx:    workerCtx,
+		workerCancel: workerCancel,
+		engine:       engine,
+		ticks:        ticks,
+		stopTicker:   stopTicker,
+		doWork:       doWork,
+		onRootsOwned: onRootsOwned,
+		degradedPoll: degradedPoll,
+		add:          make(chan unwatchedPollAdd),
+		pollWake:     make(chan struct{}, 1),
+		pollDone:     make(chan struct{}),
+		stop:         make(chan struct{}),
+		done:         make(chan struct{}),
 	}
 	go coordinator.run()
 	return coordinator
@@ -132,10 +202,10 @@ func (c *sharedUnwatchedPollCoordinator) updateRoots(
 ) error {
 	request := unwatchedPollAdd{
 		obligation: pollingObligation{
-			Key:           obligation.Key,
-			Roots:         append([]string(nil), obligation.Roots...),
-			Probe:         obligation.Probe,
-			DegradedProbe: obligation.DegradedProbe,
+			Key:   obligation.Key,
+			Agent: obligation.Agent,
+			Roots: append([]string(nil), obligation.Roots...),
+			Probe: obligation.Probe,
 		},
 		remove: remove,
 		done:   make(chan struct{}),
@@ -178,9 +248,10 @@ func (c *sharedUnwatchedPollCoordinator) run() {
 			snapshot := sortedPollObligations(obligations)
 			c.pollMu.Lock()
 			c.pollObligations = snapshot
-			c.pollRevisions[request.obligation.Key]++
-			delete(c.pollStates, request.obligation.Key)
 			c.pollMu.Unlock()
+			if c.degradedPoll != nil {
+				c.degradedPoll.Forget(request.obligation)
+			}
 			if c.onRootsOwned != nil {
 				c.onRootsOwned(unwatchedPollObligationRoots(obligations))
 			}
@@ -232,22 +303,25 @@ func (c *sharedUnwatchedPollCoordinator) runPollWorker() {
 			if c.workerCtx.Err() != nil {
 				return
 			}
-			obligations, priorStates, priorRevisions := c.currentPollSnapshot()
-			selected, nextStates := c.preparePollRun(
-				c.workerCtx, obligations, priorStates,
-			)
+			obligations := c.currentPollSnapshot()
+			selected, tracked, err := c.preparePollRun(c.workerCtx, obligations)
+			if err != nil {
+				c.resetTracked(tracked)
+				return
+			}
 			if len(selected) == 0 {
 				continue
 			}
 			log.Printf("polling %d unwatched root(s)", len(unwatchedPollObligationSliceRoots(selected)))
 			c.doWork(func() {
 				if c.workerCtx.Err() != nil {
+					c.resetTracked(tracked)
 					return
 				}
 				if err := pollUnwatchedRootsOnce(c.workerCtx, c.engine, selected); err != nil {
+					c.resetTracked(tracked)
 					return
 				}
-				c.commitPollStates(nextStates, priorRevisions)
 			})
 		}
 	}
@@ -271,9 +345,12 @@ func (c *sharedUnwatchedPollCoordinator) runPollWorker() {
 // deferred scope as an authoritative empty discovery and tombstone its
 // sessions.
 func availableUnwatchedPollRoots(obligations []pollingObligation) []string {
-	selected, _ := availableUnwatchedPollObligationsWithState(
+	selected, _, err := availableUnwatchedPollObligations(
 		context.Background(), obligations, nil,
 	)
+	if err != nil {
+		return nil
+	}
 	return unwatchedPollObligationSliceRoots(selected)
 }
 
@@ -356,52 +433,39 @@ func pollUnwatchedRootsOnce(
 	return nil
 }
 
-func (c *sharedUnwatchedPollCoordinator) currentPollSnapshot() (
-	[]pollingObligation,
-	map[string]string,
-	map[string]uint64,
-) {
+func (c *sharedUnwatchedPollCoordinator) currentPollSnapshot() []pollingObligation {
 	c.pollMu.Lock()
 	defer c.pollMu.Unlock()
-	return append([]pollingObligation(nil), c.pollObligations...),
-		clonePollStates(c.pollStates),
-		clonePollRevisions(c.pollRevisions)
+	return append([]pollingObligation(nil), c.pollObligations...)
 }
 
 func (c *sharedUnwatchedPollCoordinator) preparePollRun(
 	ctx context.Context,
 	obligations []pollingObligation,
-	prior map[string]string,
-) ([]pollingObligation, map[string]string) {
-	return availableUnwatchedPollObligationsWithState(
-		ctx, obligations, prior,
+) ([]pollingObligation, []pollingObligation, error) {
+	return availableUnwatchedPollObligations(
+		ctx, obligations, c.degradedPoll,
 	)
 }
 
-func (c *sharedUnwatchedPollCoordinator) commitPollStates(
-	states map[string]string,
-	revisions map[string]uint64,
+func (c *sharedUnwatchedPollCoordinator) resetTracked(
+	obligations []pollingObligation,
 ) {
-	if len(states) == 0 {
+	if c.degradedPoll == nil || len(obligations) == 0 {
 		return
 	}
-	c.pollMu.Lock()
-	defer c.pollMu.Unlock()
-	for key, state := range states {
-		if revision, ok := revisions[key]; ok && c.pollRevisions[key] != revision {
-			continue
-		}
-		c.pollStates[key] = state
+	for _, obligation := range obligations {
+		c.degradedPoll.Forget(obligation)
 	}
 }
 
-func availableUnwatchedPollObligationsWithState(
+func availableUnwatchedPollObligations(
 	ctx context.Context,
 	obligations []pollingObligation,
-	prior map[string]string,
-) ([]pollingObligation, map[string]string) {
+	degradedPoll degradedPollingResolver,
+) ([]pollingObligation, []pollingObligation, error) {
 	blocked := make(map[string]struct{})
-	pendingStates := make(map[string]string)
+	trackedByKey := make(map[string]pollingObligation)
 	selected := make([]pollingObligation, 0, len(obligations))
 	for _, obligation := range obligations {
 		probeMissing := false
@@ -418,13 +482,16 @@ func availableUnwatchedPollObligationsWithState(
 			}
 			continue
 		}
-		if obligation.DegradedProbe != nil {
-			state, err := obligation.DegradedProbe.DegradedPollingState(ctx)
-			if err == nil {
-				if prior[obligation.Key] == state {
-					continue
-				}
-				pendingStates[obligation.Key] = state
+		if degradedPoll != nil && obligation.Agent != "" {
+			decision, err := degradedPoll.ShouldReconcile(ctx, obligation)
+			if err != nil {
+				return nil, nil, err
+			}
+			if !decision.Poll {
+				continue
+			}
+			if decision.Tracked {
+				trackedByKey[obligation.Key] = obligation
 			}
 		}
 		roots := make([]string, 0, len(obligation.Roots))
@@ -437,48 +504,48 @@ func availableUnwatchedPollObligationsWithState(
 			}
 		}
 		if len(roots) == 0 {
+			if tracked, ok := trackedByKey[obligation.Key]; ok && degradedPoll != nil {
+				degradedPoll.Forget(tracked)
+				delete(trackedByKey, obligation.Key)
+			}
 			continue
 		}
 		selected = append(selected, pollingObligation{
-			Key:           obligation.Key,
-			Agent:         obligation.Agent,
-			Roots:         roots,
-			Probe:         obligation.Probe,
-			DegradedProbe: obligation.DegradedProbe,
+			Key:   obligation.Key,
+			Agent: obligation.Agent,
+			Roots: roots,
+			Probe: obligation.Probe,
 		})
 	}
 	filtered := make([]pollingObligation, 0, len(selected))
 	for _, obligation := range selected {
-		deferred := false
+		roots := make([]string, 0, len(obligation.Roots))
 		for _, root := range obligation.Roots {
-			if overlapsDeferredScope(filepath.Clean(root), blocked) {
-				deferred = true
-				break
+			if !overlapsDeferredScope(filepath.Clean(root), blocked) {
+				roots = append(roots, root)
 			}
 		}
-		if deferred {
-			delete(pendingStates, obligation.Key)
+		if len(roots) == 0 {
+			if tracked, ok := trackedByKey[obligation.Key]; ok && degradedPoll != nil {
+				degradedPoll.Forget(tracked)
+				delete(trackedByKey, obligation.Key)
+			}
 			continue
 		}
+		if len(roots) != len(obligation.Roots) {
+			if tracked, ok := trackedByKey[obligation.Key]; ok && degradedPoll != nil {
+				degradedPoll.Forget(tracked)
+				delete(trackedByKey, obligation.Key)
+			}
+		}
+		obligation.Roots = roots
 		filtered = append(filtered, obligation)
 	}
-	return filtered, pendingStates
-}
-
-func clonePollStates(states map[string]string) map[string]string {
-	if len(states) == 0 {
-		return nil
+	tracked := make([]pollingObligation, 0, len(filtered))
+	for _, obligation := range filtered {
+		if trackedObligation, ok := trackedByKey[obligation.Key]; ok {
+			tracked = append(tracked, trackedObligation)
+		}
 	}
-	cloned := make(map[string]string, len(states))
-	maps.Copy(cloned, states)
-	return cloned
-}
-
-func clonePollRevisions(revisions map[string]uint64) map[string]uint64 {
-	if len(revisions) == 0 {
-		return nil
-	}
-	cloned := make(map[string]uint64, len(revisions))
-	maps.Copy(cloned, revisions)
-	return cloned
+	return filtered, tracked, nil
 }

--- a/cmd/agentsview/unwatched_poll.go
+++ b/cmd/agentsview/unwatched_poll.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"go.kenn.io/agentsview/internal/parser"
 	"go.kenn.io/agentsview/internal/server"
 )
 
@@ -37,6 +38,10 @@ type pollingObligation struct {
 	// the scope then would tombstone every session under the missing
 	// subtree. Empty means the Roots themselves are probed.
 	Probe string
+	// DegradedProbe carries an additive provider-owned freshness token for
+	// degraded polling. Equal consecutive states suppress authoritative
+	// reconciliation for this obligation's Roots on that tick.
+	DegradedProbe parser.DegradedPollingStateProbe
 }
 
 type sharedUnwatchedPollCoordinator struct {
@@ -58,6 +63,7 @@ type sharedUnwatchedPollCoordinator struct {
 	// coordinator loop; each entry keeps its probe so availability is
 	// evaluated per obligation at poll time.
 	pollObligations []pollingObligation
+	pollStates      map[string]string
 	stop            chan struct{}
 	done            chan struct{}
 	stopOnce        sync.Once
@@ -94,6 +100,7 @@ func newUnwatchedPollCoordinatorWithTicks(
 		add:          make(chan unwatchedPollAdd),
 		pollWake:     make(chan struct{}, 1),
 		pollDone:     make(chan struct{}),
+		pollStates:   make(map[string]string),
 		stop:         make(chan struct{}),
 		done:         make(chan struct{}),
 		onRootsOwned: onRootsOwned,
@@ -120,9 +127,10 @@ func (c *sharedUnwatchedPollCoordinator) updateRoots(
 ) error {
 	request := unwatchedPollAdd{
 		obligation: pollingObligation{
-			Key:   obligation.Key,
-			Roots: append([]string(nil), obligation.Roots...),
-			Probe: obligation.Probe,
+			Key:           obligation.Key,
+			Roots:         append([]string(nil), obligation.Roots...),
+			Probe:         obligation.Probe,
+			DegradedProbe: obligation.DegradedProbe,
 		},
 		remove: remove,
 		done:   make(chan struct{}),
@@ -163,6 +171,9 @@ func (c *sharedUnwatchedPollCoordinator) run() {
 				obligations[request.obligation.Key] = request.obligation
 			}
 			c.setPollObligations(obligations)
+			c.pollMu.Lock()
+			delete(c.pollStates, request.obligation.Key)
+			c.pollMu.Unlock()
 			if c.onRootsOwned != nil {
 				c.onRootsOwned(unwatchedPollObligationRoots(obligations))
 			}
@@ -216,7 +227,9 @@ func (c *sharedUnwatchedPollCoordinator) runPollWorker() {
 			if c.workerCtx.Err() != nil {
 				return
 			}
-			roots := availableUnwatchedPollRoots(c.currentPollObligations())
+			roots, nextStates := c.preparePollRun(
+				c.workerCtx, c.currentPollObligations(),
+			)
 			if len(roots) == 0 {
 				continue
 			}
@@ -225,7 +238,10 @@ func (c *sharedUnwatchedPollCoordinator) runPollWorker() {
 				if c.workerCtx.Err() != nil {
 					return
 				}
-				pollUnwatchedRootsOnce(c.workerCtx, c.engine, roots)
+				if err := pollUnwatchedRootsOnce(c.workerCtx, c.engine, roots); err != nil {
+					return
+				}
+				c.commitPollStates(nextStates)
 			})
 		}
 	}
@@ -302,11 +318,112 @@ func unwatchedPollRoots(owned map[string]struct{}) []string {
 
 func pollUnwatchedRootsOnce(
 	ctx context.Context, engine unwatchedPollSyncer, roots []string,
-) {
+) error {
 	if len(roots) == 0 {
-		return
+		return nil
 	}
 	if err := engine.ReconcileWatchRoots(ctx, roots, false); err != nil {
 		log.Printf("polling unwatched roots: %v", err)
+		return err
 	}
+	return nil
+}
+
+func (c *sharedUnwatchedPollCoordinator) currentPollStates() map[string]string {
+	c.pollMu.Lock()
+	defer c.pollMu.Unlock()
+	return clonePollStates(c.pollStates)
+}
+
+func (c *sharedUnwatchedPollCoordinator) preparePollRun(
+	ctx context.Context,
+	obligations []pollingObligation,
+) ([]string, map[string]string) {
+	return availableUnwatchedPollRootsWithState(
+		ctx, obligations, c.currentPollStates(),
+	)
+}
+
+func (c *sharedUnwatchedPollCoordinator) commitPollStates(states map[string]string) {
+	if len(states) == 0 {
+		return
+	}
+	c.pollMu.Lock()
+	defer c.pollMu.Unlock()
+	for key, state := range states {
+		c.pollStates[key] = state
+	}
+}
+
+func availableUnwatchedPollRootsWithState(
+	ctx context.Context,
+	obligations []pollingObligation,
+	prior map[string]string,
+) ([]string, map[string]string) {
+	candidates := make(map[string]struct{})
+	blocked := make(map[string]struct{})
+	candidateOwners := make(map[string][]string)
+	pendingStates := make(map[string]string)
+	for _, obligation := range obligations {
+		probeMissing := false
+		if obligation.Probe != "" {
+			if _, err := os.Stat(obligation.Probe); err != nil {
+				probeMissing = true
+			}
+		}
+		if probeMissing {
+			for _, root := range obligation.Roots {
+				if root != "" {
+					blocked[filepath.Clean(root)] = struct{}{}
+				}
+			}
+			continue
+		}
+		if obligation.DegradedProbe != nil {
+			state, err := obligation.DegradedProbe.DegradedPollingState(ctx)
+			if err == nil {
+				if prior[obligation.Key] == state {
+					continue
+				}
+				pendingStates[obligation.Key] = state
+			}
+		}
+		for _, root := range obligation.Roots {
+			if root == "" {
+				continue
+			}
+			if _, err := os.Stat(root); err == nil {
+				candidates[root] = struct{}{}
+				candidateOwners[root] = append(candidateOwners[root], obligation.Key)
+			}
+		}
+	}
+	for root := range candidates {
+		if overlapsDeferredScope(filepath.Clean(root), blocked) {
+			delete(candidates, root)
+		}
+	}
+	if len(pendingStates) == 0 {
+		return unwatchedPollRoots(candidates), nil
+	}
+	committed := make(map[string]string)
+	for root := range candidates {
+		for _, key := range candidateOwners[root] {
+			if state, ok := pendingStates[key]; ok {
+				committed[key] = state
+			}
+		}
+	}
+	return unwatchedPollRoots(candidates), committed
+}
+
+func clonePollStates(states map[string]string) map[string]string {
+	if len(states) == 0 {
+		return nil
+	}
+	cloned := make(map[string]string, len(states))
+	for key, value := range states {
+		cloned[key] = value
+	}
+	return cloned
 }

--- a/cmd/agentsview/unwatched_poll.go
+++ b/cmd/agentsview/unwatched_poll.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -415,9 +416,7 @@ func clonePollStates(states map[string]string) map[string]string {
 		return nil
 	}
 	cloned := make(map[string]string, len(states))
-	for key, value := range states {
-		cloned[key] = value
-	}
+	maps.Copy(cloned, states)
 	return cloned
 }
 
@@ -426,8 +425,6 @@ func clonePollRevisions(revisions map[string]uint64) map[string]uint64 {
 		return nil
 	}
 	cloned := make(map[string]uint64, len(revisions))
-	for key, revision := range revisions {
-		cloned[key] = revision
-	}
+	maps.Copy(cloned, revisions)
 	return cloned
 }

--- a/cmd/agentsview/unwatched_poll.go
+++ b/cmd/agentsview/unwatched_poll.go
@@ -343,7 +343,9 @@ func (c *sharedUnwatchedPollCoordinator) runPollWorker() {
 // expands each requested root to the configured dirs above and below it, so a
 // pollable ancestor or descendant of a blocked root would reconcile the
 // deferred scope as an authoritative empty discovery and tombstone its
-// sessions.
+// sessions. Provider-owned candidates only honor blockers from the same
+// provider plus unscoped blockers, because ReconcileProviderRoots cannot
+// expand into another provider's unavailable scope.
 func availableUnwatchedPollRoots(obligations []pollingObligation) []string {
 	selected, _, err := availableUnwatchedPollObligations(
 		context.Background(), obligations, nil,
@@ -409,10 +411,11 @@ func pollUnwatchedRootsOnce(
 			}
 		}
 	}
+	var pollErr error
 	if roots := unwatchedPollRoots(watchRoots); len(roots) > 0 {
 		if err := engine.ReconcileWatchRoots(ctx, roots, false); err != nil {
 			log.Printf("polling unwatched roots: %v", err)
-			return err
+			pollErr = errors.Join(pollErr, err)
 		}
 	}
 	agents := make([]parser.AgentType, 0, len(byAgent))
@@ -427,10 +430,10 @@ func pollUnwatchedRootsOnce(
 		}
 		if err := engine.ReconcileProviderRoots(ctx, agent, roots); err != nil {
 			log.Printf("polling unwatched %s roots: %v", agent, err)
-			return err
+			pollErr = errors.Join(pollErr, err)
 		}
 	}
-	return nil
+	return pollErr
 }
 
 func (c *sharedUnwatchedPollCoordinator) currentPollSnapshot() []pollingObligation {
@@ -464,7 +467,8 @@ func availableUnwatchedPollObligations(
 	obligations []pollingObligation,
 	degradedPoll degradedPollingResolver,
 ) ([]pollingObligation, []pollingObligation, error) {
-	blocked := make(map[string]struct{})
+	blockedGlobal := make(map[string]struct{})
+	blockedByAgent := make(map[parser.AgentType]map[string]struct{})
 	trackedByKey := make(map[string]pollingObligation)
 	selected := make([]pollingObligation, 0, len(obligations))
 	for _, obligation := range obligations {
@@ -475,9 +479,16 @@ func availableUnwatchedPollObligations(
 			}
 		}
 		if probeMissing {
+			target := blockedGlobal
+			if obligation.Agent != "" {
+				if blockedByAgent[obligation.Agent] == nil {
+					blockedByAgent[obligation.Agent] = make(map[string]struct{})
+				}
+				target = blockedByAgent[obligation.Agent]
+			}
 			for _, root := range obligation.Roots {
 				if root != "" {
-					blocked[filepath.Clean(root)] = struct{}{}
+					target[filepath.Clean(root)] = struct{}{}
 				}
 			}
 			continue
@@ -521,7 +532,9 @@ func availableUnwatchedPollObligations(
 	for _, obligation := range selected {
 		roots := make([]string, 0, len(obligation.Roots))
 		for _, root := range obligation.Roots {
-			if !overlapsDeferredScope(filepath.Clean(root), blocked) {
+			if !rootBlockedForObligation(
+				filepath.Clean(root), obligation.Agent, blockedGlobal, blockedByAgent,
+			) {
 				roots = append(roots, root)
 			}
 		}
@@ -548,4 +561,24 @@ func availableUnwatchedPollObligations(
 		}
 	}
 	return filtered, tracked, nil
+}
+
+func rootBlockedForObligation(
+	root string,
+	agent parser.AgentType,
+	blockedGlobal map[string]struct{},
+	blockedByAgent map[parser.AgentType]map[string]struct{},
+) bool {
+	if overlapsDeferredScope(root, blockedGlobal) {
+		return true
+	}
+	if agent == "" {
+		for _, blocked := range blockedByAgent {
+			if overlapsDeferredScope(root, blocked) {
+				return true
+			}
+		}
+		return false
+	}
+	return overlapsDeferredScope(root, blockedByAgent[agent])
 }

--- a/cmd/agentsview/unwatched_poll.go
+++ b/cmd/agentsview/unwatched_poll.go
@@ -306,7 +306,7 @@ func (c *sharedUnwatchedPollCoordinator) runPollWorker() {
 			obligations := c.currentPollSnapshot()
 			selected, tracked, err := c.preparePollRun(c.workerCtx, obligations)
 			if err != nil {
-				c.resetTracked(tracked)
+				c.resetTracked(tracked, tracked)
 				return
 			}
 			if len(selected) == 0 {
@@ -315,11 +315,12 @@ func (c *sharedUnwatchedPollCoordinator) runPollWorker() {
 			log.Printf("polling %d unwatched root(s)", len(unwatchedPollObligationSliceRoots(selected)))
 			c.doWork(func() {
 				if c.workerCtx.Err() != nil {
-					c.resetTracked(tracked)
+					c.resetTracked(tracked, tracked)
 					return
 				}
-				if err := pollUnwatchedRootsOnce(c.workerCtx, c.engine, selected); err != nil {
-					c.resetTracked(tracked)
+				failed, err := pollUnwatchedRootsOnce(c.workerCtx, c.engine, selected)
+				if err != nil {
+					c.resetTracked(tracked, failed)
 					return
 				}
 			})
@@ -391,12 +392,14 @@ func unwatchedPollRoots(owned map[string]struct{}) []string {
 
 func pollUnwatchedRootsOnce(
 	ctx context.Context, engine unwatchedPollSyncer, obligations []pollingObligation,
-) error {
+) ([]pollingObligation, error) {
 	if len(obligations) == 0 {
-		return nil
+		return nil, nil
 	}
 	watchRoots := make(map[string]struct{})
+	generic := make([]pollingObligation, 0)
 	byAgent := make(map[parser.AgentType]map[string]struct{})
+	byAgentObligations := make(map[parser.AgentType][]pollingObligation)
 	for _, obligation := range obligations {
 		target := watchRoots
 		if obligation.Agent != "" {
@@ -404,6 +407,11 @@ func pollUnwatchedRootsOnce(
 				byAgent[obligation.Agent] = make(map[string]struct{})
 			}
 			target = byAgent[obligation.Agent]
+			byAgentObligations[obligation.Agent] = append(
+				byAgentObligations[obligation.Agent], obligation,
+			)
+		} else {
+			generic = append(generic, obligation)
 		}
 		for _, root := range obligation.Roots {
 			if root != "" {
@@ -412,10 +420,12 @@ func pollUnwatchedRootsOnce(
 		}
 	}
 	var pollErr error
+	failed := make([]pollingObligation, 0)
 	if roots := unwatchedPollRoots(watchRoots); len(roots) > 0 {
 		if err := engine.ReconcileWatchRoots(ctx, roots, false); err != nil {
 			log.Printf("polling unwatched roots: %v", err)
 			pollErr = errors.Join(pollErr, err)
+			failed = append(failed, generic...)
 		}
 	}
 	agents := make([]parser.AgentType, 0, len(byAgent))
@@ -431,9 +441,10 @@ func pollUnwatchedRootsOnce(
 		if err := engine.ReconcileProviderRoots(ctx, agent, roots); err != nil {
 			log.Printf("polling unwatched %s roots: %v", agent, err)
 			pollErr = errors.Join(pollErr, err)
+			failed = append(failed, byAgentObligations[agent]...)
 		}
 	}
-	return pollErr
+	return failed, pollErr
 }
 
 func (c *sharedUnwatchedPollCoordinator) currentPollSnapshot() []pollingObligation {
@@ -452,13 +463,19 @@ func (c *sharedUnwatchedPollCoordinator) preparePollRun(
 }
 
 func (c *sharedUnwatchedPollCoordinator) resetTracked(
-	obligations []pollingObligation,
+	tracked, failed []pollingObligation,
 ) {
-	if c.degradedPoll == nil || len(obligations) == 0 {
+	if c.degradedPoll == nil || len(tracked) == 0 || len(failed) == 0 {
 		return
 	}
-	for _, obligation := range obligations {
-		c.degradedPoll.Forget(obligation)
+	failedByKey := make(map[string]struct{}, len(failed))
+	for _, obligation := range failed {
+		failedByKey[obligation.Key] = struct{}{}
+	}
+	for _, obligation := range tracked {
+		if _, ok := failedByKey[obligation.Key]; ok {
+			c.degradedPoll.Forget(obligation)
+		}
 	}
 }
 

--- a/cmd/agentsview/unwatched_poll.go
+++ b/cmd/agentsview/unwatched_poll.go
@@ -20,6 +20,7 @@ var errUnwatchedPollStopped = errors.New("unwatched poll coordinator stopped")
 
 type unwatchedPollSyncer interface {
 	ReconcileWatchRoots(context.Context, []string, bool) error
+	ReconcileProviderRoots(context.Context, parser.AgentType, []string) error
 }
 
 type unwatchedPollAdd struct {
@@ -30,6 +31,7 @@ type unwatchedPollAdd struct {
 
 type pollingObligation struct {
 	Key   string
+	Agent parser.AgentType
 	Roots []string
 	// Probe mirrors sync.PollingObligation.Probe: the physical watcher path
 	// whose availability gates this obligation's reconciliation Roots. When
@@ -173,8 +175,9 @@ func (c *sharedUnwatchedPollCoordinator) run() {
 			} else {
 				obligations[request.obligation.Key] = request.obligation
 			}
-			c.setPollObligations(obligations)
+			snapshot := sortedPollObligations(obligations)
 			c.pollMu.Lock()
+			c.pollObligations = snapshot
 			c.pollRevisions[request.obligation.Key]++
 			delete(c.pollStates, request.obligation.Key)
 			c.pollMu.Unlock()
@@ -188,9 +191,9 @@ func (c *sharedUnwatchedPollCoordinator) run() {
 	}
 }
 
-func (c *sharedUnwatchedPollCoordinator) setPollObligations(
+func sortedPollObligations(
 	obligations map[string]pollingObligation,
-) {
+) []pollingObligation {
 	snapshot := make([]pollingObligation, 0, len(obligations))
 	for _, obligation := range obligations {
 		snapshot = append(snapshot, obligation)
@@ -198,9 +201,7 @@ func (c *sharedUnwatchedPollCoordinator) setPollObligations(
 	slices.SortFunc(snapshot, func(a, b pollingObligation) int {
 		return strings.Compare(a.Key, b.Key)
 	})
-	c.pollMu.Lock()
-	c.pollObligations = snapshot
-	c.pollMu.Unlock()
+	return snapshot
 }
 
 func (c *sharedUnwatchedPollCoordinator) currentPollObligations() []pollingObligation {
@@ -232,18 +233,18 @@ func (c *sharedUnwatchedPollCoordinator) runPollWorker() {
 				return
 			}
 			obligations, priorStates, priorRevisions := c.currentPollSnapshot()
-			roots, nextStates := c.preparePollRun(
+			selected, nextStates := c.preparePollRun(
 				c.workerCtx, obligations, priorStates,
 			)
-			if len(roots) == 0 {
+			if len(selected) == 0 {
 				continue
 			}
-			log.Printf("polling %d unwatched root(s)", len(roots))
+			log.Printf("polling %d unwatched root(s)", len(unwatchedPollObligationSliceRoots(selected)))
 			c.doWork(func() {
 				if c.workerCtx.Err() != nil {
 					return
 				}
-				if err := pollUnwatchedRootsOnce(c.workerCtx, c.engine, roots); err != nil {
+				if err := pollUnwatchedRootsOnce(c.workerCtx, c.engine, selected); err != nil {
 					return
 				}
 				c.commitPollStates(nextStates, priorRevisions)
@@ -270,13 +271,25 @@ func (c *sharedUnwatchedPollCoordinator) runPollWorker() {
 // deferred scope as an authoritative empty discovery and tombstone its
 // sessions.
 func availableUnwatchedPollRoots(obligations []pollingObligation) []string {
-	roots, _ := availableUnwatchedPollRootsWithState(
+	selected, _ := availableUnwatchedPollObligationsWithState(
 		context.Background(), obligations, nil,
 	)
-	return roots
+	return unwatchedPollObligationSliceRoots(selected)
 }
 
 func unwatchedPollObligationRoots(obligations map[string]pollingObligation) []string {
+	owned := make(map[string]struct{})
+	for _, obligation := range obligations {
+		for _, root := range obligation.Roots {
+			if root != "" {
+				owned[root] = struct{}{}
+			}
+		}
+	}
+	return unwatchedPollRoots(owned)
+}
+
+func unwatchedPollObligationSliceRoots(obligations []pollingObligation) []string {
 	owned := make(map[string]struct{})
 	for _, obligation := range obligations {
 		for _, root := range obligation.Roots {
@@ -298,14 +311,47 @@ func unwatchedPollRoots(owned map[string]struct{}) []string {
 }
 
 func pollUnwatchedRootsOnce(
-	ctx context.Context, engine unwatchedPollSyncer, roots []string,
+	ctx context.Context, engine unwatchedPollSyncer, obligations []pollingObligation,
 ) error {
-	if len(roots) == 0 {
+	if len(obligations) == 0 {
 		return nil
 	}
-	if err := engine.ReconcileWatchRoots(ctx, roots, false); err != nil {
-		log.Printf("polling unwatched roots: %v", err)
-		return err
+	watchRoots := make(map[string]struct{})
+	byAgent := make(map[parser.AgentType]map[string]struct{})
+	for _, obligation := range obligations {
+		target := watchRoots
+		if obligation.Agent != "" {
+			if byAgent[obligation.Agent] == nil {
+				byAgent[obligation.Agent] = make(map[string]struct{})
+			}
+			target = byAgent[obligation.Agent]
+		}
+		for _, root := range obligation.Roots {
+			if root != "" {
+				target[root] = struct{}{}
+			}
+		}
+	}
+	if roots := unwatchedPollRoots(watchRoots); len(roots) > 0 {
+		if err := engine.ReconcileWatchRoots(ctx, roots, false); err != nil {
+			log.Printf("polling unwatched roots: %v", err)
+			return err
+		}
+	}
+	agents := make([]parser.AgentType, 0, len(byAgent))
+	for agent := range byAgent {
+		agents = append(agents, agent)
+	}
+	slices.Sort(agents)
+	for _, agent := range agents {
+		roots := unwatchedPollRoots(byAgent[agent])
+		if len(roots) == 0 {
+			continue
+		}
+		if err := engine.ReconcileProviderRoots(ctx, agent, roots); err != nil {
+			log.Printf("polling unwatched %s roots: %v", agent, err)
+			return err
+		}
 	}
 	return nil
 }
@@ -326,8 +372,8 @@ func (c *sharedUnwatchedPollCoordinator) preparePollRun(
 	ctx context.Context,
 	obligations []pollingObligation,
 	prior map[string]string,
-) ([]string, map[string]string) {
-	return availableUnwatchedPollRootsWithState(
+) ([]pollingObligation, map[string]string) {
+	return availableUnwatchedPollObligationsWithState(
 		ctx, obligations, prior,
 	)
 }
@@ -349,15 +395,14 @@ func (c *sharedUnwatchedPollCoordinator) commitPollStates(
 	}
 }
 
-func availableUnwatchedPollRootsWithState(
+func availableUnwatchedPollObligationsWithState(
 	ctx context.Context,
 	obligations []pollingObligation,
 	prior map[string]string,
-) ([]string, map[string]string) {
-	candidates := make(map[string]struct{})
+) ([]pollingObligation, map[string]string) {
 	blocked := make(map[string]struct{})
-	candidateOwners := make(map[string][]string)
 	pendingStates := make(map[string]string)
+	selected := make([]pollingObligation, 0, len(obligations))
 	for _, obligation := range obligations {
 		probeMissing := false
 		if obligation.Probe != "" {
@@ -382,33 +427,42 @@ func availableUnwatchedPollRootsWithState(
 				pendingStates[obligation.Key] = state
 			}
 		}
+		roots := make([]string, 0, len(obligation.Roots))
 		for _, root := range obligation.Roots {
 			if root == "" {
 				continue
 			}
 			if _, err := os.Stat(root); err == nil {
-				candidates[root] = struct{}{}
-				candidateOwners[root] = append(candidateOwners[root], obligation.Key)
+				roots = append(roots, root)
 			}
 		}
-	}
-	for root := range candidates {
-		if overlapsDeferredScope(filepath.Clean(root), blocked) {
-			delete(candidates, root)
+		if len(roots) == 0 {
+			continue
 		}
+		selected = append(selected, pollingObligation{
+			Key:           obligation.Key,
+			Agent:         obligation.Agent,
+			Roots:         roots,
+			Probe:         obligation.Probe,
+			DegradedProbe: obligation.DegradedProbe,
+		})
 	}
-	if len(pendingStates) == 0 {
-		return unwatchedPollRoots(candidates), nil
-	}
-	committed := make(map[string]string)
-	for root := range candidates {
-		for _, key := range candidateOwners[root] {
-			if state, ok := pendingStates[key]; ok {
-				committed[key] = state
+	filtered := make([]pollingObligation, 0, len(selected))
+	for _, obligation := range selected {
+		deferred := false
+		for _, root := range obligation.Roots {
+			if overlapsDeferredScope(filepath.Clean(root), blocked) {
+				deferred = true
+				break
 			}
 		}
+		if deferred {
+			delete(pendingStates, obligation.Key)
+			continue
+		}
+		filtered = append(filtered, obligation)
 	}
-	return unwatchedPollRoots(candidates), committed
+	return filtered, pendingStates
 }
 
 func clonePollStates(states map[string]string) map[string]string {

--- a/cmd/agentsview/unwatched_poll.go
+++ b/cmd/agentsview/unwatched_poll.go
@@ -265,34 +265,10 @@ func (c *sharedUnwatchedPollCoordinator) runPollWorker() {
 // deferred scope as an authoritative empty discovery and tombstone its
 // sessions.
 func availableUnwatchedPollRoots(obligations []pollingObligation) []string {
-	candidates := make(map[string]struct{})
-	blocked := make(map[string]struct{})
-	for _, obligation := range obligations {
-		probeMissing := false
-		if obligation.Probe != "" {
-			if _, err := os.Stat(obligation.Probe); err != nil {
-				probeMissing = true
-			}
-		}
-		for _, root := range obligation.Roots {
-			if root == "" {
-				continue
-			}
-			if probeMissing {
-				blocked[filepath.Clean(root)] = struct{}{}
-				continue
-			}
-			if _, err := os.Stat(root); err == nil {
-				candidates[root] = struct{}{}
-			}
-		}
-	}
-	for root := range candidates {
-		if overlapsDeferredScope(filepath.Clean(root), blocked) {
-			delete(candidates, root)
-		}
-	}
-	return unwatchedPollRoots(candidates)
+	roots, _ := availableUnwatchedPollRootsWithState(
+		context.Background(), obligations, nil,
+	)
+	return roots
 }
 
 func unwatchedPollObligationRoots(obligations map[string]pollingObligation) []string {

--- a/cmd/agentsview/unwatched_poll.go
+++ b/cmd/agentsview/unwatched_poll.go
@@ -64,6 +64,7 @@ type sharedUnwatchedPollCoordinator struct {
 	// evaluated per obligation at poll time.
 	pollObligations []pollingObligation
 	pollStates      map[string]string
+	pollRevisions   map[string]uint64
 	stop            chan struct{}
 	done            chan struct{}
 	stopOnce        sync.Once
@@ -90,20 +91,21 @@ func newUnwatchedPollCoordinatorWithTicks(
 ) *sharedUnwatchedPollCoordinator {
 	workerCtx, workerCancel := context.WithCancel(ctx)
 	coordinator := &sharedUnwatchedPollCoordinator{
-		ctx:          ctx,
-		workerCtx:    workerCtx,
-		workerCancel: workerCancel,
-		engine:       engine,
-		ticks:        ticks,
-		stopTicker:   stopTicker,
-		doWork:       doWork,
-		add:          make(chan unwatchedPollAdd),
-		pollWake:     make(chan struct{}, 1),
-		pollDone:     make(chan struct{}),
-		pollStates:   make(map[string]string),
-		stop:         make(chan struct{}),
-		done:         make(chan struct{}),
-		onRootsOwned: onRootsOwned,
+		ctx:           ctx,
+		workerCtx:     workerCtx,
+		workerCancel:  workerCancel,
+		engine:        engine,
+		ticks:         ticks,
+		stopTicker:    stopTicker,
+		doWork:        doWork,
+		add:           make(chan unwatchedPollAdd),
+		pollWake:      make(chan struct{}, 1),
+		pollDone:      make(chan struct{}),
+		pollStates:    make(map[string]string),
+		pollRevisions: make(map[string]uint64),
+		stop:          make(chan struct{}),
+		done:          make(chan struct{}),
+		onRootsOwned:  onRootsOwned,
 	}
 	go coordinator.run()
 	return coordinator
@@ -172,6 +174,7 @@ func (c *sharedUnwatchedPollCoordinator) run() {
 			}
 			c.setPollObligations(obligations)
 			c.pollMu.Lock()
+			c.pollRevisions[request.obligation.Key]++
 			delete(c.pollStates, request.obligation.Key)
 			c.pollMu.Unlock()
 			if c.onRootsOwned != nil {
@@ -227,8 +230,9 @@ func (c *sharedUnwatchedPollCoordinator) runPollWorker() {
 			if c.workerCtx.Err() != nil {
 				return
 			}
+			obligations, priorStates, priorRevisions := c.currentPollSnapshot()
 			roots, nextStates := c.preparePollRun(
-				c.workerCtx, c.currentPollObligations(),
+				c.workerCtx, obligations, priorStates,
 			)
 			if len(roots) == 0 {
 				continue
@@ -241,7 +245,7 @@ func (c *sharedUnwatchedPollCoordinator) runPollWorker() {
 				if err := pollUnwatchedRootsOnce(c.workerCtx, c.engine, roots); err != nil {
 					return
 				}
-				c.commitPollStates(nextStates)
+				c.commitPollStates(nextStates, priorRevisions)
 			})
 		}
 	}
@@ -305,28 +309,41 @@ func pollUnwatchedRootsOnce(
 	return nil
 }
 
-func (c *sharedUnwatchedPollCoordinator) currentPollStates() map[string]string {
+func (c *sharedUnwatchedPollCoordinator) currentPollSnapshot() (
+	[]pollingObligation,
+	map[string]string,
+	map[string]uint64,
+) {
 	c.pollMu.Lock()
 	defer c.pollMu.Unlock()
-	return clonePollStates(c.pollStates)
+	return append([]pollingObligation(nil), c.pollObligations...),
+		clonePollStates(c.pollStates),
+		clonePollRevisions(c.pollRevisions)
 }
 
 func (c *sharedUnwatchedPollCoordinator) preparePollRun(
 	ctx context.Context,
 	obligations []pollingObligation,
+	prior map[string]string,
 ) ([]string, map[string]string) {
 	return availableUnwatchedPollRootsWithState(
-		ctx, obligations, c.currentPollStates(),
+		ctx, obligations, prior,
 	)
 }
 
-func (c *sharedUnwatchedPollCoordinator) commitPollStates(states map[string]string) {
+func (c *sharedUnwatchedPollCoordinator) commitPollStates(
+	states map[string]string,
+	revisions map[string]uint64,
+) {
 	if len(states) == 0 {
 		return
 	}
 	c.pollMu.Lock()
 	defer c.pollMu.Unlock()
 	for key, state := range states {
+		if revision, ok := revisions[key]; ok && c.pollRevisions[key] != revision {
+			continue
+		}
 		c.pollStates[key] = state
 	}
 }
@@ -400,6 +417,17 @@ func clonePollStates(states map[string]string) map[string]string {
 	cloned := make(map[string]string, len(states))
 	for key, value := range states {
 		cloned[key] = value
+	}
+	return cloned
+}
+
+func clonePollRevisions(revisions map[string]uint64) map[string]uint64 {
+	if len(revisions) == 0 {
+		return nil
+	}
+	cloned := make(map[string]uint64, len(revisions))
+	for key, revision := range revisions {
+		cloned[key] = revision
 	}
 	return cloned
 }

--- a/cmd/agentsview/unwatched_poll_test.go
+++ b/cmd/agentsview/unwatched_poll_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -60,6 +61,14 @@ func (p *sequenceDegradedPollProbe) DegradedPollingState(
 		p.states = p.states[1:]
 	}
 	return state, nil
+}
+
+type errorDegradedPollProbe struct {
+	err error
+}
+
+func (p errorDegradedPollProbe) DegradedPollingState(context.Context) (string, error) {
+	return "", p.err
 }
 
 func (s *cancelBlockingUnwatchedPollSyncer) ReconcileWatchRoots(
@@ -224,6 +233,29 @@ func TestUnwatchedPollDegradedProbeSkipsUnchangedScope(t *testing.T) {
 	requirePollWithin(t, syncer.wake, time.Second)
 	assert.Equal(t, [][]string{{root}, {root}}, syncer.snapshot(),
 		"a changed degraded probe must re-run authoritative reconciliation")
+}
+
+func TestUnwatchedPollDegradedProbeErrorFallsBackToAuthoritativePoll(t *testing.T) {
+	ticks := make(chan time.Time, 3)
+	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 3)}
+	coordinator := newUnwatchedPollCoordinatorWithTicks(
+		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil,
+	)
+	t.Cleanup(coordinator.Stop)
+	root := requireExistingPollRoot(t, t.TempDir(), "opencode")
+	require.NoError(t, coordinator.AddObligation(pollingObligation{
+		Key:           "opencode-root",
+		Roots:         []string{root},
+		DegradedProbe: errorDegradedPollProbe{err: errors.New("probe failed")},
+	}))
+
+	ticks <- time.Now()
+	requirePollWithin(t, syncer.wake, time.Second)
+	ticks <- time.Now()
+	requirePollWithin(t, syncer.wake, time.Second)
+
+	assert.Equal(t, [][]string{{root}, {root}}, syncer.snapshot(),
+		"a degraded probe error must fall back to authoritative polling without caching state")
 }
 
 func TestUnwatchedPollSkipsAbsentObligatedRootUntilItReturns(t *testing.T) {

--- a/cmd/agentsview/unwatched_poll_test.go
+++ b/cmd/agentsview/unwatched_poll_test.go
@@ -42,6 +42,26 @@ type cancelBlockingUnwatchedPollSyncer struct {
 	calls    int
 }
 
+type sequenceDegradedPollProbe struct {
+	mu     sync.Mutex
+	states []string
+}
+
+func (p *sequenceDegradedPollProbe) DegradedPollingState(
+	context.Context,
+) (string, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.states) == 0 {
+		return "", nil
+	}
+	state := p.states[0]
+	if len(p.states) > 1 {
+		p.states = p.states[1:]
+	}
+	return state, nil
+}
+
 func (s *cancelBlockingUnwatchedPollSyncer) ReconcileWatchRoots(
 	ctx context.Context, _ []string, _ bool,
 ) error {
@@ -171,6 +191,39 @@ func TestUnwatchedPollTickUsesRootsAddedAfterStart(t *testing.T) {
 	assert.Equal(t, [][]string{{initial, runtime}}, syncer.snapshot())
 	assert.Equal(t, []bool{false}, syncer.full,
 		"unwatched polling must reconcile the owned scopes authoritatively")
+}
+
+func TestUnwatchedPollDegradedProbeSkipsUnchangedScope(t *testing.T) {
+	ticks := make(chan time.Time, 4)
+	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 4)}
+	coordinator := newUnwatchedPollCoordinatorWithTicks(
+		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil,
+	)
+	t.Cleanup(coordinator.Stop)
+	root := requireExistingPollRoot(t, t.TempDir(), "opencode")
+	probe := &sequenceDegradedPollProbe{
+		states: []string{"state-1", "state-1", "state-2"},
+	}
+	require.NoError(t, coordinator.AddObligation(pollingObligation{
+		Key:           "opencode-root",
+		Roots:         []string{root},
+		DegradedProbe: probe,
+	}))
+
+	ticks <- time.Now()
+	requirePollWithin(t, syncer.wake, time.Second)
+	assert.Equal(t, [][]string{{root}}, syncer.snapshot(),
+		"the first degraded poll must establish authoritative state")
+
+	ticks <- time.Now()
+	assert.Never(t, func() bool { return len(syncer.snapshot()) > 1 },
+		100*time.Millisecond, 10*time.Millisecond,
+		"an unchanged degraded probe must suppress the authoritative poll")
+
+	ticks <- time.Now()
+	requirePollWithin(t, syncer.wake, time.Second)
+	assert.Equal(t, [][]string{{root}, {root}}, syncer.snapshot(),
+		"a changed degraded probe must re-run authoritative reconciliation")
 }
 
 func TestUnwatchedPollSkipsAbsentObligatedRootUntilItReturns(t *testing.T) {

--- a/cmd/agentsview/unwatched_poll_test.go
+++ b/cmd/agentsview/unwatched_poll_test.go
@@ -23,6 +23,7 @@ type recordingUnwatchedPollSyncer struct {
 	mu           sync.Mutex
 	calls        [][]string
 	full         []bool
+	agents       []parser.AgentType
 	wake         chan struct{}
 	reconcileErr error
 }
@@ -83,6 +84,12 @@ func (s *cancelBlockingUnwatchedPollSyncer) ReconcileWatchRoots(
 	return ctx.Err()
 }
 
+func (s *cancelBlockingUnwatchedPollSyncer) ReconcileProviderRoots(
+	ctx context.Context, _ parser.AgentType, roots []string,
+) error {
+	return s.ReconcileWatchRoots(ctx, roots, false)
+}
+
 func (s *cancelBlockingUnwatchedPollSyncer) callCount() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -106,6 +113,12 @@ func (s *blockingUnwatchedPollSyncer) ReconcileWatchRoots(
 	return nil
 }
 
+func (s *blockingUnwatchedPollSyncer) ReconcileProviderRoots(
+	ctx context.Context, _ parser.AgentType, roots []string,
+) error {
+	return s.ReconcileWatchRoots(ctx, roots, false)
+}
+
 func (s *blockingUnwatchedPollSyncer) snapshot() ([][]string, int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -122,6 +135,22 @@ func (s *recordingUnwatchedPollSyncer) ReconcileWatchRoots(
 	s.mu.Lock()
 	s.calls = append(s.calls, append([]string(nil), roots...))
 	s.full = append(s.full, full)
+	s.agents = append(s.agents, "")
+	s.mu.Unlock()
+	select {
+	case s.wake <- struct{}{}:
+	default:
+	}
+	return s.reconcileErr
+}
+
+func (s *recordingUnwatchedPollSyncer) ReconcileProviderRoots(
+	_ context.Context, agent parser.AgentType, roots []string,
+) error {
+	s.mu.Lock()
+	s.calls = append(s.calls, append([]string(nil), roots...))
+	s.full = append(s.full, false)
+	s.agents = append(s.agents, agent)
 	s.mu.Unlock()
 	select {
 	case s.wake <- struct{}{}:
@@ -138,6 +167,12 @@ func (s *recordingUnwatchedPollSyncer) snapshot() [][]string {
 		result[i] = append([]string(nil), s.calls[i]...)
 	}
 	return result
+}
+
+func (s *recordingUnwatchedPollSyncer) agentSnapshot() []parser.AgentType {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]parser.AgentType(nil), s.agents...)
 }
 
 func TestUnwatchedPollConcurrentAddDeduplicatesUpdatedRootSet(t *testing.T) {
@@ -256,6 +291,38 @@ func TestUnwatchedPollDegradedProbeErrorFallsBackToAuthoritativePoll(t *testing.
 
 	assert.Equal(t, [][]string{{root}, {root}}, syncer.snapshot(),
 		"a degraded probe error must fall back to authoritative polling without caching state")
+}
+
+func TestUnwatchedPollUsesProviderScopedReconciliationForOwnedRoots(t *testing.T) {
+	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 2)}
+	parent := requireExistingPollRoot(t, t.TempDir(), "shared")
+	child := requireExistingPollRoot(t, parent, "opencode")
+	selected, states := availableUnwatchedPollObligationsWithState(
+		t.Context(),
+		[]pollingObligation{{
+		Key:           "opencode-root",
+		Agent:         parser.AgentOpenCode,
+		Roots:         []string{child},
+		DegradedProbe: &sequenceDegradedPollProbe{states: []string{"stable", "stable"}},
+		}, {
+			Key:   "codex-root",
+			Agent: parser.AgentCodex,
+			Roots: []string{parent},
+		}},
+		map[string]string{"opencode-root": "stable"},
+	)
+	require.Equal(t, map[string]string{}, states)
+	require.Equal(t, []pollingObligation{{
+		Key:   "codex-root",
+		Agent: parser.AgentCodex,
+		Roots: []string{parent},
+	}}, selected)
+
+	require.NoError(t, pollUnwatchedRootsOnce(t.Context(), syncer, selected))
+	requirePollWithin(t, syncer.wake, time.Second)
+	assert.Equal(t, [][]string{{parent}}, syncer.snapshot())
+	assert.Equal(t, []parser.AgentType{parser.AgentCodex}, syncer.agentSnapshot(),
+		"provider-owned polling must preserve agent scope instead of using generic root expansion")
 }
 
 func TestUnwatchedPollSkipsAbsentObligatedRootUntilItReturns(t *testing.T) {
@@ -521,7 +588,7 @@ func TestUnwatchedPollPreservesSessionsUnderBlockedOverlappingScope(t *testing.T
 			Probe: filepath.Join(nested, "missing-subtree")},
 	}
 	roots := availableUnwatchedPollRoots(obligations)
-	pollUnwatchedRootsOnce(t.Context(), engine, roots)
+	pollUnwatchedRootsOnce(t.Context(), engine, nil)
 
 	assert.Empty(t, roots,
 		"an ancestor overlapping a blocked scope must not stay pollable")

--- a/cmd/agentsview/unwatched_poll_test.go
+++ b/cmd/agentsview/unwatched_poll_test.go
@@ -666,6 +666,52 @@ func TestUnwatchedPollParentCancellationCancelsJoinsAndRejectsUpdates(
 	assert.Equal(t, 1, syncer.callCount())
 }
 
+func TestUnwatchedPollReplacementDoesNotRestoreStaleProbeState(t *testing.T) {
+	ticks := make(chan time.Time)
+	syncer := &blockingUnwatchedPollSyncer{
+		started: make(chan []string, 2),
+		release: make(chan struct{}),
+	}
+	coordinator := newUnwatchedPollCoordinatorWithTicks(
+		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil,
+	)
+	t.Cleanup(coordinator.Stop)
+	root := requireExistingPollRoot(t, t.TempDir(), "root")
+	require.NoError(t, coordinator.AddObligation(pollingObligation{
+		Key:           "root",
+		Roots:         []string{root},
+		DegradedProbe: &sequenceDegradedPollProbe{states: []string{"stable", "stable"}},
+	}))
+
+	coordinator.requestPoll()
+	select {
+	case got := <-syncer.started:
+		require.Equal(t, []string{root}, got)
+	case <-time.After(time.Second):
+		t.Fatal("initial poll did not start before replacement")
+	}
+
+	replaced := make(chan error, 1)
+	go func() {
+		replaced <- coordinator.AddObligation(pollingObligation{
+			Key:           "root",
+			Roots:         []string{root},
+			DegradedProbe: &sequenceDegradedPollProbe{states: []string{"stable", "stable"}},
+		})
+	}()
+
+	close(syncer.release)
+	require.NoError(t, requireReceivePollResult(t, replaced, time.Second))
+
+	coordinator.requestPoll()
+	select {
+	case got := <-syncer.started:
+		require.Equal(t, []string{root}, got)
+	case <-time.After(time.Second):
+		t.Fatal("replacement obligation did not trigger a fresh poll")
+	}
+}
+
 func TestUnwatchedPollRemoveRootsStopsReconciliationAfterNativeRecovery(t *testing.T) {
 	ticks := make(chan time.Time, 1)
 	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 2)}

--- a/cmd/agentsview/unwatched_poll_test.go
+++ b/cmd/agentsview/unwatched_poll_test.go
@@ -639,6 +639,56 @@ func TestAvailableUnwatchedPollObligationsKeepsDifferentAgentOverlapPollable(t *
 		"a missing probe for one provider must not block an overlapping root owned by another provider")
 }
 
+func TestUnwatchedPollKeepsUnchangedNestedProviderScopeSuppressed(t *testing.T) {
+	base := t.TempDir()
+	nested := requireExistingPollRoot(t, base, "nested")
+	resolver := &scriptedDegradedPollingResolver{
+		decisions: map[string][]degradedPollingDecision{
+			"opencode-parent": {{Poll: true, Tracked: true}},
+			"opencode-nested": {{Poll: false}},
+		},
+	}
+
+	selected, tracked, err := availableUnwatchedPollObligations(
+		t.Context(),
+		[]pollingObligation{
+			{
+				Key:   "opencode-parent",
+				Agent: parser.AgentOpenCode,
+				Roots: []string{base},
+				Probe: base,
+			},
+			{
+				Key:   "opencode-nested",
+				Agent: parser.AgentOpenCode,
+				Roots: []string{nested},
+				Probe: nested,
+			},
+		},
+		resolver,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []pollingObligation{{
+		Key:   "opencode-parent",
+		Agent: parser.AgentOpenCode,
+		Roots: []string{base},
+		Probe: base,
+	}}, selected)
+	require.Equal(t, []pollingObligation{{
+		Key:   "opencode-parent",
+		Agent: parser.AgentOpenCode,
+		Roots: []string{base},
+		Probe: base,
+	}}, tracked)
+
+	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 1)}
+	_, err = pollUnwatchedRootsOnce(t.Context(), syncer, selected)
+	require.NoError(t, err)
+	requirePollWithin(t, syncer.wake, time.Second)
+	assert.Equal(t, [][]string{{base}}, syncer.snapshot())
+	assert.Equal(t, []parser.AgentType{parser.AgentOpenCode}, syncer.agentSnapshot())
+}
+
 // TestAvailableUnwatchedPollRootsBlocksMixedRelativeAndAbsoluteScopes pins the
 // path-form parity between this gate and the engine: ReconcileWatchRoots
 // expands requested roots against configured dirs in absolute form

--- a/cmd/agentsview/unwatched_poll_test.go
+++ b/cmd/agentsview/unwatched_poll_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -44,32 +43,43 @@ type cancelBlockingUnwatchedPollSyncer struct {
 	calls    int
 }
 
-type sequenceDegradedPollProbe struct {
-	mu     sync.Mutex
-	states []string
+type scriptedDegradedPollingResolver struct {
+	mu        sync.Mutex
+	decisions map[string][]degradedPollingDecision
+	positions map[string]int
 }
 
-func (p *sequenceDegradedPollProbe) DegradedPollingState(
-	context.Context,
-) (string, error) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if len(p.states) == 0 {
-		return "", nil
+func (r *scriptedDegradedPollingResolver) ShouldReconcile(
+	ctx context.Context,
+	obligation pollingObligation,
+) (degradedPollingDecision, error) {
+	if err := ctx.Err(); err != nil {
+		return degradedPollingDecision{}, err
 	}
-	state := p.states[0]
-	if len(p.states) > 1 {
-		p.states = p.states[1:]
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.positions == nil {
+		r.positions = make(map[string]int)
 	}
-	return state, nil
+	decisions := r.decisions[obligation.Key]
+	if len(decisions) == 0 {
+		return degradedPollingDecision{Poll: true}, nil
+	}
+	idx := r.positions[obligation.Key]
+	if idx >= len(decisions) {
+		idx = len(decisions) - 1
+	}
+	decision := decisions[idx]
+	if idx < len(decisions)-1 {
+		r.positions[obligation.Key] = idx + 1
+	}
+	return decision, nil
 }
 
-type errorDegradedPollProbe struct {
-	err error
-}
-
-func (p errorDegradedPollProbe) DegradedPollingState(context.Context) (string, error) {
-	return "", p.err
+func (r *scriptedDegradedPollingResolver) Forget(obligation pollingObligation) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.positions, obligation.Key)
 }
 
 func (s *cancelBlockingUnwatchedPollSyncer) ReconcileWatchRoots(
@@ -179,7 +189,7 @@ func TestUnwatchedPollConcurrentAddDeduplicatesUpdatedRootSet(t *testing.T) {
 	ticks := make(chan time.Time)
 	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 4)}
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
-		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil,
+		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil, nil,
 	)
 	t.Cleanup(coordinator.Stop)
 	parent := t.TempDir()
@@ -216,7 +226,7 @@ func TestUnwatchedPollTickUsesRootsAddedAfterStart(t *testing.T) {
 	ticks := make(chan time.Time, 1)
 	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 2)}
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
-		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil,
+		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil, nil,
 	)
 	t.Cleanup(coordinator.Stop)
 	parent := t.TempDir()
@@ -240,18 +250,25 @@ func TestUnwatchedPollTickUsesRootsAddedAfterStart(t *testing.T) {
 func TestUnwatchedPollDegradedProbeSkipsUnchangedScope(t *testing.T) {
 	ticks := make(chan time.Time, 4)
 	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 4)}
+	resolver := &scriptedDegradedPollingResolver{
+		decisions: map[string][]degradedPollingDecision{
+			"opencode-root": {
+				{Poll: true, Tracked: true},
+				{Tracked: true},
+				{Poll: true, Tracked: true},
+			},
+		},
+	}
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
-		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil,
+		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil, resolver,
 	)
 	t.Cleanup(coordinator.Stop)
 	root := requireExistingPollRoot(t, t.TempDir(), "opencode")
-	probe := &sequenceDegradedPollProbe{
-		states: []string{"state-1", "state-1", "state-2"},
-	}
 	require.NoError(t, coordinator.AddObligation(pollingObligation{
-		Key:           "opencode-root",
-		Roots:         []string{root},
-		DegradedProbe: probe,
+		Key:   "opencode-root",
+		Agent: parser.AgentOpenCode,
+		Roots: []string{root},
+		Probe: root,
 	}))
 
 	ticks <- time.Now()
@@ -273,15 +290,21 @@ func TestUnwatchedPollDegradedProbeSkipsUnchangedScope(t *testing.T) {
 func TestUnwatchedPollDegradedProbeErrorFallsBackToAuthoritativePoll(t *testing.T) {
 	ticks := make(chan time.Time, 3)
 	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 3)}
+	resolver := &scriptedDegradedPollingResolver{
+		decisions: map[string][]degradedPollingDecision{
+			"opencode-root": {{Poll: true}, {Poll: true}},
+		},
+	}
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
-		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil,
+		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil, resolver,
 	)
 	t.Cleanup(coordinator.Stop)
 	root := requireExistingPollRoot(t, t.TempDir(), "opencode")
 	require.NoError(t, coordinator.AddObligation(pollingObligation{
-		Key:           "opencode-root",
-		Roots:         []string{root},
-		DegradedProbe: errorDegradedPollProbe{err: errors.New("probe failed")},
+		Key:   "opencode-root",
+		Agent: parser.AgentOpenCode,
+		Roots: []string{root},
+		Probe: root,
 	}))
 
 	ticks <- time.Now()
@@ -297,21 +320,26 @@ func TestUnwatchedPollUsesProviderScopedReconciliationForOwnedRoots(t *testing.T
 	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 2)}
 	parent := requireExistingPollRoot(t, t.TempDir(), "shared")
 	child := requireExistingPollRoot(t, parent, "opencode")
-	selected, states := availableUnwatchedPollObligationsWithState(
+	selected, tracked, err := availableUnwatchedPollObligations(
 		t.Context(),
 		[]pollingObligation{{
-		Key:           "opencode-root",
-		Agent:         parser.AgentOpenCode,
-		Roots:         []string{child},
-		DegradedProbe: &sequenceDegradedPollProbe{states: []string{"stable", "stable"}},
+			Key:   "opencode-root",
+			Agent: parser.AgentOpenCode,
+			Roots: []string{child},
+			Probe: child,
 		}, {
 			Key:   "codex-root",
 			Agent: parser.AgentCodex,
 			Roots: []string{parent},
 		}},
-		map[string]string{"opencode-root": "stable"},
+		&scriptedDegradedPollingResolver{
+			decisions: map[string][]degradedPollingDecision{
+				"opencode-root": {{Tracked: true}},
+			},
+		},
 	)
-	require.Equal(t, map[string]string{}, states)
+	require.NoError(t, err)
+	require.Empty(t, tracked)
 	require.Equal(t, []pollingObligation{{
 		Key:   "codex-root",
 		Agent: parser.AgentCodex,
@@ -336,7 +364,7 @@ func TestUnwatchedPollSkipsAbsentObligatedRootUntilItReturns(t *testing.T) {
 	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 3)}
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
 		t.Context(), syncer, make(chan time.Time), func() {},
-		func(run func()) { run() }, nil,
+		func(run func()) { run() }, nil, nil,
 	)
 	t.Cleanup(coordinator.Stop)
 	require.NoError(t, coordinator.AddObligation(pollingObligation{
@@ -374,7 +402,7 @@ func TestUnwatchedPollDefersScopesWhileProbePathMissing(t *testing.T) {
 	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 3)}
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
 		t.Context(), syncer, make(chan time.Time), func() {},
-		func(run func()) { run() }, nil,
+		func(run func()) { run() }, nil, nil,
 	)
 	t.Cleanup(coordinator.Stop)
 	require.NoError(t, coordinator.AddObligation(pollingObligation{
@@ -413,7 +441,7 @@ func TestUnwatchedPollDefersSharedScopeWhileAnyProbeMissing(t *testing.T) {
 	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 3)}
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
 		t.Context(), syncer, make(chan time.Time), func() {},
-		func(run func()) { run() }, nil,
+		func(run func()) { run() }, nil, nil,
 	)
 	t.Cleanup(coordinator.Stop)
 	require.NoError(t, coordinator.AddObligation(pollingObligation{
@@ -607,7 +635,7 @@ func TestUnwatchedPollObligationUpdatesRemainResponsiveDuringReconciliation(
 		release: make(chan struct{}),
 	}
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
-		context.Background(), syncer, ticks, func() {}, func(run func()) { run() }, nil,
+		context.Background(), syncer, ticks, func() {}, func(run func()) { run() }, nil, nil,
 	)
 	t.Cleanup(func() {
 		select {
@@ -661,7 +689,7 @@ func TestUnwatchedPollStopCancelsAndJoinsActiveReconciliation(t *testing.T) {
 	}
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
 		parentCtx, syncer, make(chan time.Time), func() {},
-		func(run func()) { run() }, nil,
+		func(run func()) { run() }, nil, nil,
 	)
 	t.Cleanup(func() {
 		cancelParent()
@@ -701,7 +729,7 @@ func TestUnwatchedPollParentCancellationCancelsJoinsAndRejectsUpdates(
 	}
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
 		parentCtx, syncer, make(chan time.Time), func() {},
-		func(run func()) { run() }, nil,
+		func(run func()) { run() }, nil, nil,
 	)
 	t.Cleanup(func() {
 		cancelParent()
@@ -739,15 +767,24 @@ func TestUnwatchedPollReplacementDoesNotRestoreStaleProbeState(t *testing.T) {
 		started: make(chan []string, 2),
 		release: make(chan struct{}),
 	}
+	resolver := &scriptedDegradedPollingResolver{
+		decisions: map[string][]degradedPollingDecision{
+			"root": {
+				{Poll: true, Tracked: true},
+				{Tracked: true},
+			},
+		},
+	}
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
-		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil,
+		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil, resolver,
 	)
 	t.Cleanup(coordinator.Stop)
 	root := requireExistingPollRoot(t, t.TempDir(), "root")
 	require.NoError(t, coordinator.AddObligation(pollingObligation{
-		Key:           "root",
-		Roots:         []string{root},
-		DegradedProbe: &sequenceDegradedPollProbe{states: []string{"stable", "stable"}},
+		Key:   "root",
+		Agent: parser.AgentOpenCode,
+		Roots: []string{root},
+		Probe: root,
 	}))
 
 	coordinator.requestPoll()
@@ -761,9 +798,10 @@ func TestUnwatchedPollReplacementDoesNotRestoreStaleProbeState(t *testing.T) {
 	replaced := make(chan error, 1)
 	go func() {
 		replaced <- coordinator.AddObligation(pollingObligation{
-			Key:           "root",
-			Roots:         []string{root},
-			DegradedProbe: &sequenceDegradedPollProbe{states: []string{"stable", "stable"}},
+			Key:   "root",
+			Agent: parser.AgentOpenCode,
+			Roots: []string{root},
+			Probe: root,
 		})
 	}()
 
@@ -783,7 +821,7 @@ func TestUnwatchedPollRemoveRootsStopsReconciliationAfterNativeRecovery(t *testi
 	ticks := make(chan time.Time, 1)
 	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 2)}
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
-		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil,
+		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil, nil,
 	)
 	t.Cleanup(coordinator.Stop)
 	parent := t.TempDir()
@@ -807,7 +845,7 @@ func TestUnwatchedPollRemovingOneOverlappingObligationKeepsSharedRoot(t *testing
 	ticks := make(chan time.Time)
 	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 2)}
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
-		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil,
+		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil, nil,
 	)
 	t.Cleanup(coordinator.Stop)
 	parent := t.TempDir()
@@ -832,7 +870,7 @@ func TestUnwatchedPollEmptyObligationNeverExpandsToFullReconciliation(t *testing
 	ticks := make(chan time.Time)
 	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 1)}
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
-		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil,
+		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil, nil,
 	)
 	t.Cleanup(coordinator.Stop)
 	require.NoError(t, coordinator.AddObligation(pollingObligation{Key: "empty"}))
@@ -847,7 +885,7 @@ func TestUnwatchedPollStopIsConcurrentAndRejectsLaterRoots(t *testing.T) {
 	ticks := make(chan time.Time)
 	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 1)}
 	coordinator := newUnwatchedPollCoordinatorWithTicks(
-		context.Background(), syncer, ticks, func() {}, func(run func()) { run() }, nil,
+		context.Background(), syncer, ticks, func() {}, func(run func()) { run() }, nil, nil,
 	)
 	require.NoError(t, coordinator.AddObligation(pollingObligation{
 		Key: "owned", Roots: []string{"/owned"},
@@ -879,6 +917,7 @@ func TestUnwatchedPollAddObligationRacingStopReturnsOwnershipOrStopped(t *testin
 			func(roots []string) {
 				ownedSnapshots <- append([]string(nil), roots...)
 			},
+			nil,
 		)
 		start := make(chan struct{})
 		addResult := make(chan error, 1)

--- a/cmd/agentsview/unwatched_poll_test.go
+++ b/cmd/agentsview/unwatched_poll_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -25,6 +26,7 @@ type recordingUnwatchedPollSyncer struct {
 	agents       []parser.AgentType
 	wake         chan struct{}
 	reconcileErr error
+	errs         []error
 }
 
 type blockingUnwatchedPollSyncer struct {
@@ -151,7 +153,7 @@ func (s *recordingUnwatchedPollSyncer) ReconcileWatchRoots(
 	case s.wake <- struct{}{}:
 	default:
 	}
-	return s.reconcileErr
+	return s.nextErr()
 }
 
 func (s *recordingUnwatchedPollSyncer) ReconcileProviderRoots(
@@ -165,6 +167,20 @@ func (s *recordingUnwatchedPollSyncer) ReconcileProviderRoots(
 	select {
 	case s.wake <- struct{}{}:
 	default:
+	}
+	return s.nextErr()
+}
+
+func (s *recordingUnwatchedPollSyncer) nextErr() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.errs) == 0 {
+		return s.reconcileErr
+	}
+	err := s.errs[0]
+	s.errs = s.errs[1:]
+	if err != nil {
+		return err
 	}
 	return s.reconcileErr
 }
@@ -353,6 +369,27 @@ func TestUnwatchedPollUsesProviderScopedReconciliationForOwnedRoots(t *testing.T
 		"provider-owned polling must preserve agent scope instead of using generic root expansion")
 }
 
+func TestUnwatchedPollContinuesAfterEarlierProviderFailure(t *testing.T) {
+	claudeRoot := requireExistingPollRoot(t, t.TempDir(), "claude")
+	openCodeRoot := requireExistingPollRoot(t, t.TempDir(), "opencode")
+	syncer := &recordingUnwatchedPollSyncer{
+		wake: make(chan struct{}, 2),
+		errs: []error{errors.New("claude failed"), nil},
+	}
+
+	err := pollUnwatchedRootsOnce(t.Context(), syncer, []pollingObligation{
+		{Key: "claude-root", Agent: parser.AgentClaude, Roots: []string{claudeRoot}},
+		{Key: "opencode-root", Agent: parser.AgentOpenCode, Roots: []string{openCodeRoot}},
+	})
+
+	require.ErrorContains(t, err, "claude failed")
+	assert.Equal(t, [][]string{{claudeRoot}, {openCodeRoot}}, syncer.snapshot())
+	assert.Equal(t,
+		[]parser.AgentType{parser.AgentClaude, parser.AgentOpenCode},
+		syncer.agentSnapshot(),
+		"a later provider-owned group must still poll after an earlier provider group fails")
+}
+
 func TestUnwatchedPollSkipsAbsentObligatedRootUntilItReturns(t *testing.T) {
 	parent := t.TempDir()
 	root := filepath.Join(parent, "provider")
@@ -517,6 +554,44 @@ func TestAvailableUnwatchedPollRootsDefersRootsOverlappingBlockedScopes(t *testi
 			assert.Equal(t, tc.want, availableUnwatchedPollRoots(tc.obligations))
 		})
 	}
+}
+
+func TestAvailableUnwatchedPollObligationsKeepsDifferentAgentOverlapPollable(t *testing.T) {
+	base := t.TempDir()
+	nested := requireExistingPollRoot(t, base, "nested")
+	selected, tracked, err := availableUnwatchedPollObligations(
+		t.Context(),
+		[]pollingObligation{
+			{
+				Key:   "opencode-root",
+				Agent: parser.AgentOpenCode,
+				Roots: []string{base},
+				Probe: base,
+			},
+			{
+				Key:   "claude-root",
+				Agent: parser.AgentClaude,
+				Roots: []string{nested},
+				Probe: filepath.Join(nested, "missing-probe"),
+			},
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Empty(t, tracked)
+	require.Equal(t, []pollingObligation{{
+		Key:   "opencode-root",
+		Agent: parser.AgentOpenCode,
+		Roots: []string{base},
+		Probe: base,
+	}}, selected)
+
+	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 1)}
+	require.NoError(t, pollUnwatchedRootsOnce(t.Context(), syncer, selected))
+	requirePollWithin(t, syncer.wake, time.Second)
+	assert.Equal(t, [][]string{{base}}, syncer.snapshot())
+	assert.Equal(t, []parser.AgentType{parser.AgentOpenCode}, syncer.agentSnapshot(),
+		"a missing probe for one provider must not block an overlapping root owned by another provider")
 }
 
 // TestAvailableUnwatchedPollRootsBlocksMixedRelativeAndAbsoluteScopes pins the

--- a/cmd/agentsview/unwatched_poll_test.go
+++ b/cmd/agentsview/unwatched_poll_test.go
@@ -362,7 +362,8 @@ func TestUnwatchedPollUsesProviderScopedReconciliationForOwnedRoots(t *testing.T
 		Roots: []string{parent},
 	}}, selected)
 
-	require.NoError(t, pollUnwatchedRootsOnce(t.Context(), syncer, selected))
+	_, err = pollUnwatchedRootsOnce(t.Context(), syncer, selected)
+	require.NoError(t, err)
 	requirePollWithin(t, syncer.wake, time.Second)
 	assert.Equal(t, [][]string{{parent}}, syncer.snapshot())
 	assert.Equal(t, []parser.AgentType{parser.AgentCodex}, syncer.agentSnapshot(),
@@ -377,7 +378,7 @@ func TestUnwatchedPollContinuesAfterEarlierProviderFailure(t *testing.T) {
 		errs: []error{errors.New("claude failed"), nil},
 	}
 
-	err := pollUnwatchedRootsOnce(t.Context(), syncer, []pollingObligation{
+	_, err := pollUnwatchedRootsOnce(t.Context(), syncer, []pollingObligation{
 		{Key: "claude-root", Agent: parser.AgentClaude, Roots: []string{claudeRoot}},
 		{Key: "opencode-root", Agent: parser.AgentOpenCode, Roots: []string{openCodeRoot}},
 	})
@@ -388,6 +389,49 @@ func TestUnwatchedPollContinuesAfterEarlierProviderFailure(t *testing.T) {
 		[]parser.AgentType{parser.AgentClaude, parser.AgentOpenCode},
 		syncer.agentSnapshot(),
 		"a later provider-owned group must still poll after an earlier provider group fails")
+}
+
+func TestUnwatchedPollPreservesTrackedStateForSuccessfulGroupsAfterPeerFailure(
+	t *testing.T,
+) {
+	ticks := make(chan time.Time)
+	claudeRoot := requireExistingPollRoot(t, t.TempDir(), "claude")
+	openCodeRoot := requireExistingPollRoot(t, t.TempDir(), "opencode")
+	syncer := &recordingUnwatchedPollSyncer{
+		wake: make(chan struct{}, 4),
+		errs: []error{errors.New("claude failed"), nil, nil},
+	}
+	resolver := &scriptedDegradedPollingResolver{
+		decisions: map[string][]degradedPollingDecision{
+			"claude-root":   {{Poll: true, Tracked: true}, {Poll: true, Tracked: true}},
+			"opencode-root": {{Poll: true, Tracked: true}, {Tracked: true}},
+		},
+	}
+	coordinator := newUnwatchedPollCoordinatorWithTicks(
+		t.Context(), syncer, ticks, func() {}, func(run func()) { run() }, nil, resolver,
+	)
+	t.Cleanup(coordinator.Stop)
+	for _, obligation := range []pollingObligation{{
+		Key: "claude-root", Agent: parser.AgentClaude, Roots: []string{claudeRoot}, Probe: claudeRoot,
+	}, {
+		Key: "opencode-root", Agent: parser.AgentOpenCode, Roots: []string{openCodeRoot}, Probe: openCodeRoot,
+	}} {
+		require.NoError(t, coordinator.AddObligation(obligation))
+	}
+
+	coordinator.requestPoll()
+	assert.Eventually(t, func() bool {
+		return len(syncer.snapshot()) == 2
+	}, time.Second, time.Millisecond)
+
+	coordinator.requestPoll()
+	assert.Eventually(t, func() bool {
+		return len(syncer.snapshot()) == 3
+	}, time.Second, time.Millisecond)
+	assert.Equal(t,
+		[][]string{{claudeRoot}, {openCodeRoot}, {claudeRoot}},
+		syncer.snapshot(),
+		"only the failed provider group must poll again after a peer group succeeds")
 }
 
 func TestUnwatchedPollSkipsAbsentObligatedRootUntilItReturns(t *testing.T) {
@@ -587,7 +631,8 @@ func TestAvailableUnwatchedPollObligationsKeepsDifferentAgentOverlapPollable(t *
 	}}, selected)
 
 	syncer := &recordingUnwatchedPollSyncer{wake: make(chan struct{}, 1)}
-	require.NoError(t, pollUnwatchedRootsOnce(t.Context(), syncer, selected))
+	_, err = pollUnwatchedRootsOnce(t.Context(), syncer, selected)
+	require.NoError(t, err)
 	requirePollWithin(t, syncer.wake, time.Second)
 	assert.Equal(t, [][]string{{base}}, syncer.snapshot())
 	assert.Equal(t, []parser.AgentType{parser.AgentOpenCode}, syncer.agentSnapshot(),

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -2260,6 +2261,10 @@ const storedSourcePathHintRootBatchSize = 100
 type StoredSourcePathHintScope struct {
 	Path                  string
 	IncludeVirtualMembers bool
+	// Excluded names descendant roots the caller reconciles under their own
+	// scope. Filtering them after a page is read lets a large excluded archive
+	// consume the page limit, so the exclusion belongs in the query.
+	Excluded []string
 }
 
 // WatchReconcileSourcePageSize bounds each watcher reconciliation ownership
@@ -2360,6 +2365,13 @@ func (db *DB) listActiveSessionSourceOwnershipScopeBatch(
 				AND b.file_path NOT LIKE ? ESCAPE '!'))`
 			args = append(args, root+"#", root+"$",
 				likeRoot+`#%/%`, likeRoot+`#%\%`)
+		}
+		var exclusionClause string
+		exclusionClause, args = storedSourcePathHintExclusionSQL(
+			"b.file_path", scope.Excluded, args,
+		)
+		if exclusionClause != "" {
+			rootClause = `(` + rootClause + exclusionClause + `)`
 		}
 		rootClauses = append(rootClauses, rootClause)
 	}
@@ -2753,18 +2765,37 @@ func (db *DB) ListStoredSourcePathHintsContext(
 func normalizeStoredSourcePathHintScopes(
 	scopes []StoredSourcePathHintScope,
 ) []StoredSourcePathHintScope {
-	byPath := make(map[string]bool, len(scopes))
+	type mergedScope struct {
+		includeVirtualMembers bool
+		excluded              []string
+	}
+	byPath := make(map[string]*mergedScope, len(scopes))
 	for _, scope := range scopes {
 		path := cleanStoredSourcePathHint(scope.Path)
 		if path == "" || path == "." {
 			continue
 		}
-		byPath[path] = byPath[path] || scope.IncludeVirtualMembers
+		excluded := normalizeExcludedHintRoots(path, scope.Excluded)
+		merged, ok := byPath[path]
+		if !ok {
+			byPath[path] = &mergedScope{
+				includeVirtualMembers: scope.IncludeVirtualMembers,
+				excluded:              excluded,
+			}
+			continue
+		}
+		merged.includeVirtualMembers = merged.includeVirtualMembers ||
+			scope.IncludeVirtualMembers
+		// Repeated declarations of one path union their rows, so a root only
+		// one of them excludes must stay visible.
+		merged.excluded = intersectHintRoots(merged.excluded, excluded)
 	}
 	out := make([]StoredSourcePathHintScope, 0, len(byPath))
-	for path, includeVirtualMembers := range byPath {
+	for path, merged := range byPath {
 		out = append(out, StoredSourcePathHintScope{
-			Path: path, IncludeVirtualMembers: includeVirtualMembers,
+			Path:                  path,
+			IncludeVirtualMembers: merged.includeVirtualMembers,
+			Excluded:              merged.excluded,
 		})
 	}
 	sort.Slice(out, func(i, j int) bool {
@@ -2773,26 +2804,89 @@ func normalizeStoredSourcePathHintScopes(
 	return out
 }
 
+// normalizeExcludedHintRoots keeps the strict descendants of root, the only
+// exclusions that can narrow a scope without emptying it, then deduplicates
+// and orders them so the rendered SQL is stable.
+func normalizeExcludedHintRoots(root string, excluded []string) []string {
+	if len(excluded) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(excluded))
+	for _, candidate := range excluded {
+		cleaned := cleanStoredSourcePathHint(candidate)
+		if cleaned == "" || cleaned == "." || cleaned == root {
+			continue
+		}
+		if !strings.HasPrefix(cleaned, root+string(filepath.Separator)) {
+			continue
+		}
+		if slices.Contains(out, cleaned) {
+			continue
+		}
+		out = append(out, cleaned)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func intersectHintRoots(left, right []string) []string {
+	if len(left) == 0 || len(right) == 0 {
+		return nil
+	}
+	out := make([]string, 0, min(len(left), len(right)))
+	for _, root := range left {
+		if slices.Contains(right, root) {
+			out = append(out, root)
+		}
+	}
+	return out
+}
+
+// storedSourcePathHintExclusionSQL renders the predicate that drops descendant
+// roots the caller reconciles separately. Both stored-source queries route
+// through it so an excluded archive is never read and then discarded.
+func storedSourcePathHintExclusionSQL(
+	column string, excluded []string, args []any,
+) (string, []any) {
+	if len(excluded) == 0 {
+		return "", args
+	}
+	var clause strings.Builder
+	for _, root := range excluded {
+		clause.WriteString(` AND ` + column + ` <> ? AND ` +
+			column + ` NOT LIKE ? ESCAPE '!'`)
+		args = append(args, root,
+			sqliteLikeEscape(root)+string(filepath.Separator)+"%")
+	}
+	return clause.String(), args
+}
+
 func storedSourcePathHintQuery(
 	agent string,
 	scopes []StoredSourcePathHintScope,
 ) (string, []any) {
 	selects := make([]string, 0, len(scopes)*3)
 	var args []any
-	appendSelect := func(predicate string, values ...any) {
-		selects = append(selects, `SELECT file_path
-			FROM sessions
-			WHERE agent = ?
-			  AND file_path IS NOT NULL
-			  AND deleted_at IS NULL
-			  AND `+predicate)
-		args = append(args, agent)
-		args = append(args, values...)
-	}
 	for _, scope := range scopes {
 		root := cleanStoredSourcePathHint(scope.Path)
 		if root == "" || root == "." {
 			continue
+		}
+		exclusion, _ := storedSourcePathHintExclusionSQL(
+			"file_path", scope.Excluded, nil,
+		)
+		appendSelect := func(predicate string, values ...any) {
+			selects = append(selects, `SELECT file_path
+			FROM sessions
+			WHERE agent = ?
+			  AND file_path IS NOT NULL
+			  AND deleted_at IS NULL
+			  AND `+predicate+exclusion)
+			args = append(args, agent)
+			args = append(args, values...)
+			_, args = storedSourcePathHintExclusionSQL(
+				"file_path", scope.Excluded, args,
+			)
 		}
 		descendantPrefix, descendantEnd := activeSessionSourceBounds(root)
 		appendSelect(`file_path = ?`, root)
@@ -2828,6 +2922,9 @@ func storedSourcePathHintInAnyRoot(
 func storedSourcePathHintInRoot(path string, scope StoredSourcePathHintScope) bool {
 	path = cleanStoredSourcePathHint(path)
 	root := cleanStoredSourcePathHint(scope.Path)
+	if storedSourcePathHintExcluded(path, scope.Excluded) {
+		return false
+	}
 	if path == root || strings.HasPrefix(path, root+string(filepath.Separator)) {
 		return true
 	}
@@ -2836,6 +2933,20 @@ func storedSourcePathHintInRoot(path string, scope StoredSourcePathHintScope) bo
 		scope.IncludeVirtualMembers &&
 		suffix != "" &&
 		!strings.ContainsAny(suffix, `/\`)
+}
+
+// storedSourcePathHintExcluded mirrors storedSourcePathHintExclusionSQL in Go
+// so the query and the post-read filter agree on scope membership. A virtual
+// member is covered by its container's prefix, so no member branch is needed.
+func storedSourcePathHintExcluded(path string, excluded []string) bool {
+	return slices.ContainsFunc(excluded, func(root string) bool {
+		cleaned := cleanStoredSourcePathHint(root)
+		if cleaned == "" || cleaned == "." {
+			return false
+		}
+		return path == cleaned ||
+			strings.HasPrefix(path, cleaned+string(filepath.Separator))
+	})
 }
 
 func sqliteLikeEscape(value string) string {

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -2826,42 +2826,68 @@ func normalizeStoredSourcePathHintScopes(
 // already absolute. Comparing both in absolute form is what stops a relative
 // configured path from reading as outside an exclusion that in fact contains
 // it, which would page the excluded archive on every pass.
-func hintContainmentPath(path string) string {
+//
+// The empty second return says the path could not be canonicalized. Callers
+// treat that as "cannot decide containment" and drop the exclusion rather than
+// fall back to a lexical compare, which is the mismatch this exists to remove.
+func hintContainmentPath(path string) (string, bool) {
 	cleaned := cleanStoredSourcePathHint(path)
 	if cleaned == "" || cleaned == "." {
-		return cleaned
+		return "", false
 	}
 	abs, err := filepath.Abs(cleaned)
 	if err != nil {
-		return cleaned
+		return "", false
 	}
-	return abs
+	return abs, true
+}
+
+// hintRootPrefix returns the prefix a descendant of root must start with. A
+// volume or share root such as `C:\` already ends in a separator, and appending
+// a second one yields a prefix nothing can match.
+func hintRootPrefix(root string) string {
+	if strings.HasSuffix(root, string(filepath.Separator)) {
+		return root
+	}
+	return root + string(filepath.Separator)
 }
 
 // normalizeExcludedHintRoots keeps the strict descendants of root, the only
 // exclusions that can narrow a scope without emptying it, then deduplicates
 // and orders them so the rendered SQL is stable.
+//
+// Each surviving exclusion is re-expressed in the scope's own representation.
+// The query binds it against `file_path`, and rows under a relatively expressed
+// scope carry relative paths, so an exclusion left in absolute form would match
+// nothing and the excluded archive would page anyway, filtered out only after
+// the read.
 func normalizeExcludedHintRoots(root string, excluded []string) []string {
 	if len(excluded) == 0 {
 		return nil
 	}
-	comparableRoot := hintContainmentPath(root)
+	cleanRoot := cleanStoredSourcePathHint(root)
+	comparableRoot, ok := hintContainmentPath(root)
+	if !ok {
+		return nil
+	}
 	out := make([]string, 0, len(excluded))
 	for _, candidate := range excluded {
-		cleaned := cleanStoredSourcePathHint(candidate)
-		comparable := hintContainmentPath(candidate)
-		if comparable == "" || comparable == "." || comparable == comparableRoot {
+		comparable, ok := hintContainmentPath(candidate)
+		if !ok || comparable == comparableRoot {
 			continue
 		}
-		if !strings.HasPrefix(
-			comparable, comparableRoot+string(filepath.Separator),
-		) {
+		if !strings.HasPrefix(comparable, hintRootPrefix(comparableRoot)) {
 			continue
 		}
-		if slices.Contains(out, cleaned) {
+		rel, err := filepath.Rel(comparableRoot, comparable)
+		if err != nil {
 			continue
 		}
-		out = append(out, cleaned)
+		stored := cleanStoredSourcePathHint(filepath.Join(cleanRoot, rel))
+		if slices.Contains(out, stored) {
+			continue
+		}
+		out = append(out, stored)
 	}
 	sort.Strings(out)
 	return out
@@ -2977,16 +3003,17 @@ func storedSourcePathHintInRoot(path string, scope StoredSourcePathHintScope) bo
 // so the query and the post-read filter agree on scope membership. A virtual
 // member is covered by its container's prefix, so no member branch is needed.
 func storedSourcePathHintExcluded(path string, excluded []string) bool {
-	comparablePath := hintContainmentPath(path)
+	comparablePath, pathOK := hintContainmentPath(path)
+	if !pathOK {
+		return false
+	}
 	return slices.ContainsFunc(excluded, func(root string) bool {
-		comparableRoot := hintContainmentPath(root)
-		if comparableRoot == "" || comparableRoot == "." {
+		comparableRoot, ok := hintContainmentPath(root)
+		if !ok {
 			return false
 		}
 		return comparablePath == comparableRoot ||
-			strings.HasPrefix(
-				comparablePath, comparableRoot+string(filepath.Separator),
-			)
+			strings.HasPrefix(comparablePath, hintRootPrefix(comparableRoot))
 	})
 }
 

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -2835,6 +2835,12 @@ func hintContainmentPath(path string) (string, bool) {
 	if cleaned == "" || cleaned == "." {
 		return "", false
 	}
+	if strings.ContainsRune(cleaned, 0) {
+		// No filesystem this repo targets accepts a NUL, and filepath.Abs only
+		// rejects it on some of them, so checking here keeps the undecidable
+		// branch from depending on which OS the caller is running.
+		return "", false
+	}
 	abs, err := filepath.Abs(cleaned)
 	if err != nil {
 		return "", false

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -2768,6 +2768,7 @@ func normalizeStoredSourcePathHintScopes(
 	type mergedScope struct {
 		includeVirtualMembers bool
 		excluded              []string
+		visible               bool
 	}
 	byPath := make(map[string]*mergedScope, len(scopes))
 	for _, scope := range scopes {
@@ -2775,13 +2776,25 @@ func normalizeStoredSourcePathHintScopes(
 		if path == "" || path == "." {
 			continue
 		}
-		excluded := normalizeExcludedHintRoots(path, scope.Excluded)
 		merged, ok := byPath[path]
 		if !ok {
-			byPath[path] = &mergedScope{
-				includeVirtualMembers: scope.IncludeVirtualMembers,
-				excluded:              excluded,
-			}
+			merged = &mergedScope{}
+			byPath[path] = merged
+		}
+		if storedSourcePathHintExcluded(path, scope.Excluded) {
+			// The scope itself lies at or under a root the caller reconciles
+			// separately, so it contributes no rows at all. A provider that
+			// resolves one requested root into leaf scopes (a container file,
+			// a sessions dir) hands back exactly this shape for the nested
+			// roots it was asked to leave alone; narrowing such a scope is
+			// impossible, so it is dropped instead.
+			continue
+		}
+		excluded := normalizeExcludedHintRoots(path, scope.Excluded)
+		if !merged.visible {
+			merged.visible = true
+			merged.includeVirtualMembers = scope.IncludeVirtualMembers
+			merged.excluded = excluded
 			continue
 		}
 		merged.includeVirtualMembers = merged.includeVirtualMembers ||
@@ -2792,6 +2805,9 @@ func normalizeStoredSourcePathHintScopes(
 	}
 	out := make([]StoredSourcePathHintScope, 0, len(byPath))
 	for path, merged := range byPath {
+		if !merged.visible {
+			continue
+		}
 		out = append(out, StoredSourcePathHintScope{
 			Path:                  path,
 			IncludeVirtualMembers: merged.includeVirtualMembers,

--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -2820,6 +2820,24 @@ func normalizeStoredSourcePathHintScopes(
 	return out
 }
 
+// hintContainmentPath canonicalizes a path for containment comparison only.
+// Scope paths keep the representation the caller stored, because the query has
+// to match `file_path` exactly as persisted, while exclusion roots arrive
+// already absolute. Comparing both in absolute form is what stops a relative
+// configured path from reading as outside an exclusion that in fact contains
+// it, which would page the excluded archive on every pass.
+func hintContainmentPath(path string) string {
+	cleaned := cleanStoredSourcePathHint(path)
+	if cleaned == "" || cleaned == "." {
+		return cleaned
+	}
+	abs, err := filepath.Abs(cleaned)
+	if err != nil {
+		return cleaned
+	}
+	return abs
+}
+
 // normalizeExcludedHintRoots keeps the strict descendants of root, the only
 // exclusions that can narrow a scope without emptying it, then deduplicates
 // and orders them so the rendered SQL is stable.
@@ -2827,13 +2845,17 @@ func normalizeExcludedHintRoots(root string, excluded []string) []string {
 	if len(excluded) == 0 {
 		return nil
 	}
+	comparableRoot := hintContainmentPath(root)
 	out := make([]string, 0, len(excluded))
 	for _, candidate := range excluded {
 		cleaned := cleanStoredSourcePathHint(candidate)
-		if cleaned == "" || cleaned == "." || cleaned == root {
+		comparable := hintContainmentPath(candidate)
+		if comparable == "" || comparable == "." || comparable == comparableRoot {
 			continue
 		}
-		if !strings.HasPrefix(cleaned, root+string(filepath.Separator)) {
+		if !strings.HasPrefix(
+			comparable, comparableRoot+string(filepath.Separator),
+		) {
 			continue
 		}
 		if slices.Contains(out, cleaned) {
@@ -2955,13 +2977,16 @@ func storedSourcePathHintInRoot(path string, scope StoredSourcePathHintScope) bo
 // so the query and the post-read filter agree on scope membership. A virtual
 // member is covered by its container's prefix, so no member branch is needed.
 func storedSourcePathHintExcluded(path string, excluded []string) bool {
+	comparablePath := hintContainmentPath(path)
 	return slices.ContainsFunc(excluded, func(root string) bool {
-		cleaned := cleanStoredSourcePathHint(root)
-		if cleaned == "" || cleaned == "." {
+		comparableRoot := hintContainmentPath(root)
+		if comparableRoot == "" || comparableRoot == "." {
 			return false
 		}
-		return path == cleaned ||
-			strings.HasPrefix(path, cleaned+string(filepath.Separator))
+		return comparablePath == comparableRoot ||
+			strings.HasPrefix(
+				comparablePath, comparableRoot+string(filepath.Separator),
+			)
 	})
 }
 

--- a/internal/db/source_path_hints_test.go
+++ b/internal/db/source_path_hints_test.go
@@ -1427,7 +1427,17 @@ func TestNormalizeExcludedHintRootsHandlesVolumeAndUnresolvableRoots(t *testing.
 
 	t.Run("an exclusion that cannot be canonicalized is dropped", func(t *testing.T) {
 		root := filepath.Join(t.TempDir(), "claude")
-		assert.Empty(t, normalizeExcludedHintRoots(root, []string{"", "."}),
-			"an undecidable exclusion must not fall back to a lexical compare")
+		// "" and "." return before canonicalization; the NUL reaches it and is
+		// the case that would stay green if the lexical fallback came back.
+		assert.Empty(t, normalizeExcludedHintRoots(root, []string{
+			"", ".", filepath.Join(root, "archive\x00"),
+		}), "an undecidable exclusion must not fall back to a lexical compare")
+	})
+
+	t.Run("an undecidable scope excludes nothing rather than everything", func(t *testing.T) {
+		root := filepath.Join(t.TempDir(), "claude")
+		assert.Empty(t, normalizeExcludedHintRoots("\x00", []string{root}),
+			"a scope that cannot be canonicalized cannot decide containment either")
+		assert.False(t, storedSourcePathHintExcluded("\x00", []string{root}))
 	})
 }

--- a/internal/db/source_path_hints_test.go
+++ b/internal/db/source_path_hints_test.go
@@ -1168,14 +1168,23 @@ func TestNormalizeStoredSourcePathHintScopesBoundsExclusions(t *testing.T) {
 	nested := filepath.Join(root, "archive")
 	sibling := filepath.Join(filepath.Dir(root), "codex")
 
-	t.Run("keeps only strict descendants", func(t *testing.T) {
+	t.Run("narrows by strict descendants only", func(t *testing.T) {
 		got := normalizeStoredSourcePathHintScopes([]StoredSourcePathHintScope{{
 			Path:     root,
-			Excluded: []string{nested, root, sibling, "", ".", nested},
+			Excluded: []string{nested, sibling, "", ".", nested},
 		}})
 		require.Len(t, got, 1)
 		assert.Equal(t, []string{nested}, got[0].Excluded,
-			"an exclusion at or outside the scope root would empty or not narrow it")
+			"an exclusion outside the scope root does not narrow it")
+	})
+
+	t.Run("an exclusion at the scope root drops the scope", func(t *testing.T) {
+		got := normalizeStoredSourcePathHintScopes([]StoredSourcePathHintScope{{
+			Path:     root,
+			Excluded: []string{root},
+		}})
+		assert.Empty(t, got,
+			"a scope entirely inside an exclusion contributes no rows")
 	})
 
 	t.Run("repeated declarations intersect", func(t *testing.T) {
@@ -1204,4 +1213,90 @@ func TestStoredSourcePathHintInRootHonorsExclusions(t *testing.T) {
 		filepath.Join(nested, "state.db")+"#member", scope),
 		"a virtual member is excluded with its container")
 	assert.True(t, storedSourcePathHintInRoot(root+"#member", scope))
+}
+
+// TestListActiveSessionSourceOwnershipScopesPageDropsScopesInsideExclusions
+// covers the shape a provider resolver hands back: one requested parent root
+// expands into leaf scopes (a container file, a sessions dir) for every
+// configured root beneath it, including the nested root the caller excluded.
+// Such a scope cannot be narrowed, only dropped, and the pre-fix code left it
+// paging the whole nested archive.
+func TestListActiveSessionSourceOwnershipScopesPageDropsScopesInsideExclusions(t *testing.T) {
+	d := testDB(t)
+	root := t.TempDir()
+	nested := filepath.Join(root, "nested")
+	parentSessions := filepath.Join(root, "sessions")
+	nestedSessions := filepath.Join(nested, "sessions")
+	nestedStateDB := filepath.Join(nested, "state.db")
+
+	seeds := []storedSourcePathSeed{{
+		id:    "parent-0000",
+		agent: "hermes",
+		path:  filepath.Join(parentSessions, "session-0000.jsonl"),
+	}}
+	for i := range WatchReconcileSourcePageSize + 4 {
+		seeds = append(seeds, storedSourcePathSeed{
+			id:    fmt.Sprintf("nested-file-%04d", i),
+			agent: "hermes",
+			path:  filepath.Join(nestedSessions, fmt.Sprintf("session-%04d.jsonl", i)),
+		}, storedSourcePathSeed{
+			id:    fmt.Sprintf("nested-member-%04d", i),
+			agent: "hermes",
+			path:  fmt.Sprintf("%s#member-%04d", nestedStateDB, i),
+		})
+	}
+	insertSessionsWithSourcePaths(t, d, seeds)
+	require.NoError(t, d.BaselineActiveSessionSourcePaths(
+		t.Context(), defaultMachine, sourcePathsFromSeeds(seeds),
+	))
+
+	resolved := []StoredSourcePathHintScope{
+		{Path: parentSessions},
+		{Path: nestedStateDB, IncludeVirtualMembers: true},
+		{Path: nestedSessions},
+	}
+	for i := range resolved {
+		resolved[i].Excluded = []string{nested}
+	}
+
+	page, err := d.ListActiveSessionSourceOwnershipScopesPage(
+		t.Context(), defaultMachine, "hermes", resolved, SessionSourceCursor{},
+	)
+	require.NoError(t, err)
+
+	got := make([]string, 0, len(page))
+	for _, ownership := range page {
+		got = append(got, ownership.ID)
+	}
+	assert.Equal(t, []string{"parent-0000"}, got,
+		"a resolved leaf scope inside an excluded root pages nothing, and does not displace the selected scope's rows")
+}
+
+func TestNormalizeStoredSourcePathHintScopesDropsScopesInsideExclusions(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "hermes")
+	nested := filepath.Join(root, "nested")
+
+	t.Run("scope at or under an exclusion is dropped", func(t *testing.T) {
+		got := normalizeStoredSourcePathHintScopes([]StoredSourcePathHintScope{
+			{Path: filepath.Join(root, "sessions"), Excluded: []string{nested}},
+			{Path: filepath.Join(nested, "state.db"), IncludeVirtualMembers: true, Excluded: []string{nested}},
+			{Path: nested, Excluded: []string{nested}},
+		})
+		require.Len(t, got, 1)
+		assert.Equal(t, filepath.Join(root, "sessions"), got[0].Path)
+		assert.Empty(t, got[0].Excluded,
+			"an exclusion disjoint from the surviving scope narrows nothing")
+	})
+
+	t.Run("another declaration keeps a dropped path visible", func(t *testing.T) {
+		leaf := filepath.Join(nested, "state.db")
+		got := normalizeStoredSourcePathHintScopes([]StoredSourcePathHintScope{
+			{Path: leaf, Excluded: []string{nested}},
+			{Path: leaf, IncludeVirtualMembers: true},
+		})
+		require.Len(t, got, 1)
+		assert.Equal(t, leaf, got[0].Path)
+		assert.True(t, got[0].IncludeVirtualMembers)
+		assert.Empty(t, got[0].Excluded)
+	})
 }

--- a/internal/db/source_path_hints_test.go
+++ b/internal/db/source_path_hints_test.go
@@ -1111,3 +1111,97 @@ func insertSessionsWithSourcePaths(
 	require.NoError(t, err, "insert source path sessions")
 	require.Equal(t, len(seeds), result.WrittenSessions, "WrittenSessions")
 }
+
+// TestListActiveSessionSourceOwnershipScopesPageExcludesNestedRootsInQuery
+// proves the exclusion is applied by the query rather than after the page is
+// read: the excluded archive is larger than one page, so a read-then-filter
+// exclusion returns an empty page while the selected scope's own rows wait
+// behind it.
+func TestListActiveSessionSourceOwnershipScopesPageExcludesNestedRootsInQuery(t *testing.T) {
+	d := testDB(t)
+	root := t.TempDir()
+	// "archive" sorts ahead of "session", so the nested rows are exactly the
+	// ones a page limit would hand back first.
+	nested := filepath.Join(root, "archive")
+	seeds := make([]storedSourcePathSeed, 0, WatchReconcileSourcePageSize+8)
+	for i := range WatchReconcileSourcePageSize + 4 {
+		seeds = append(seeds, storedSourcePathSeed{
+			id:    fmt.Sprintf("nested-%04d", i),
+			agent: "claude",
+			path:  filepath.Join(nested, fmt.Sprintf("nested-%04d.jsonl", i)),
+		})
+	}
+	selectedIDs := make([]string, 0, 4)
+	for i := range 4 {
+		id := fmt.Sprintf("parent-%04d", i)
+		selectedIDs = append(selectedIDs, id)
+		seeds = append(seeds, storedSourcePathSeed{
+			id:    id,
+			agent: "claude",
+			path:  filepath.Join(root, fmt.Sprintf("session-%04d.jsonl", i)),
+		})
+	}
+	insertSessionsWithSourcePaths(t, d, seeds)
+	require.NoError(t, d.BaselineActiveSessionSourcePaths(
+		t.Context(), defaultMachine, sourcePathsFromSeeds(seeds),
+	))
+
+	page, err := d.ListActiveSessionSourceOwnershipScopesPage(
+		t.Context(), defaultMachine, "claude",
+		[]StoredSourcePathHintScope{{Path: root, Excluded: []string{nested}}},
+		SessionSourceCursor{},
+	)
+	require.NoError(t, err)
+
+	got := make([]string, 0, len(page))
+	for _, ownership := range page {
+		got = append(got, ownership.ID)
+		assert.NotContains(t, ownership.FilePath, nested,
+			"an excluded nested root must not reach the caller")
+	}
+	assert.Equal(t, selectedIDs, got,
+		"the first page must carry the selected scope's rows, not the excluded archive's")
+}
+
+func TestNormalizeStoredSourcePathHintScopesBoundsExclusions(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "claude")
+	nested := filepath.Join(root, "archive")
+	sibling := filepath.Join(filepath.Dir(root), "codex")
+
+	t.Run("keeps only strict descendants", func(t *testing.T) {
+		got := normalizeStoredSourcePathHintScopes([]StoredSourcePathHintScope{{
+			Path:     root,
+			Excluded: []string{nested, root, sibling, "", ".", nested},
+		}})
+		require.Len(t, got, 1)
+		assert.Equal(t, []string{nested}, got[0].Excluded,
+			"an exclusion at or outside the scope root would empty or not narrow it")
+	})
+
+	t.Run("repeated declarations intersect", func(t *testing.T) {
+		got := normalizeStoredSourcePathHintScopes([]StoredSourcePathHintScope{
+			{Path: root, Excluded: []string{nested}},
+			{Path: root},
+		})
+		require.Len(t, got, 1)
+		assert.Empty(t, got[0].Excluded,
+			"declarations of one path union their rows, so a root only one excludes stays visible")
+	})
+}
+
+func TestStoredSourcePathHintInRootHonorsExclusions(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "claude")
+	nested := filepath.Join(root, "archive")
+	scope := StoredSourcePathHintScope{
+		Path: root, IncludeVirtualMembers: true, Excluded: []string{nested},
+	}
+
+	assert.True(t, storedSourcePathHintInRoot(
+		filepath.Join(root, "session.jsonl"), scope))
+	assert.False(t, storedSourcePathHintInRoot(
+		filepath.Join(nested, "session.jsonl"), scope))
+	assert.False(t, storedSourcePathHintInRoot(
+		filepath.Join(nested, "state.db")+"#member", scope),
+		"a virtual member is excluded with its container")
+	assert.True(t, storedSourcePathHintInRoot(root+"#member", scope))
+}

--- a/internal/db/source_path_hints_test.go
+++ b/internal/db/source_path_hints_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -1297,6 +1298,63 @@ func TestNormalizeStoredSourcePathHintScopesDropsScopesInsideExclusions(t *testi
 		require.Len(t, got, 1)
 		assert.Equal(t, leaf, got[0].Path)
 		assert.True(t, got[0].IncludeVirtualMembers)
+		assert.Empty(t, got[0].Excluded)
+	})
+}
+
+// TestStoredSourcePathHintExclusionsMatchAcrossPathRepresentations covers the
+// mismatch a lexical comparison creates: exclusion roots reach the query
+// already absolute, while a provider can hand back an ownership scope that
+// kept its relative configured path. Comparing the two as written leaves the
+// scope outside its own exclusion, so every pass pages the excluded archive
+// and discards it in the later safety filter.
+func TestStoredSourcePathHintExclusionsMatchAcrossPathRepresentations(t *testing.T) {
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	relativeRoot := filepath.Join("testdata", "hints-representation")
+	absoluteRoot := filepath.Join(wd, relativeRoot)
+	relativeNested := filepath.Join(relativeRoot, "nested")
+	absoluteNested := filepath.Join(absoluteRoot, "nested")
+
+	t.Run("relative scope inside an absolute exclusion is dropped", func(t *testing.T) {
+		got := normalizeStoredSourcePathHintScopes([]StoredSourcePathHintScope{
+			{Path: filepath.Join(relativeNested, "state.db"), Excluded: []string{absoluteNested}},
+		})
+		assert.Empty(t, got)
+	})
+
+	t.Run("absolute scope inside a relative exclusion is dropped", func(t *testing.T) {
+		got := normalizeStoredSourcePathHintScopes([]StoredSourcePathHintScope{
+			{Path: filepath.Join(absoluteNested, "state.db"), Excluded: []string{relativeNested}},
+		})
+		assert.Empty(t, got)
+	})
+
+	t.Run("relative scope keeps an absolute exclusion as a narrowing", func(t *testing.T) {
+		got := normalizeStoredSourcePathHintScopes([]StoredSourcePathHintScope{
+			{Path: relativeRoot, Excluded: []string{absoluteNested}},
+		})
+		require.Len(t, got, 1)
+		assert.Equal(t, relativeRoot, got[0].Path,
+			"the scope keeps the representation the query has to match")
+		assert.Equal(t, []string{absoluteNested}, got[0].Excluded,
+			"a nested exclusion still narrows a relatively expressed scope")
+	})
+
+	t.Run("absolute scope keeps a relative exclusion as a narrowing", func(t *testing.T) {
+		got := normalizeStoredSourcePathHintScopes([]StoredSourcePathHintScope{
+			{Path: absoluteRoot, Excluded: []string{relativeNested}},
+		})
+		require.Len(t, got, 1)
+		assert.Equal(t, absoluteRoot, got[0].Path)
+		assert.Equal(t, []string{relativeNested}, got[0].Excluded)
+	})
+
+	t.Run("a sibling outside the scope still narrows nothing", func(t *testing.T) {
+		got := normalizeStoredSourcePathHintScopes([]StoredSourcePathHintScope{
+			{Path: relativeRoot, Excluded: []string{filepath.Join(wd, "testdata", "other")}},
+		})
+		require.Len(t, got, 1)
 		assert.Empty(t, got[0].Excluded)
 	})
 }

--- a/internal/db/source_path_hints_test.go
+++ b/internal/db/source_path_hints_test.go
@@ -1330,24 +1330,24 @@ func TestStoredSourcePathHintExclusionsMatchAcrossPathRepresentations(t *testing
 		assert.Empty(t, got)
 	})
 
-	t.Run("relative scope keeps an absolute exclusion as a narrowing", func(t *testing.T) {
+	t.Run("an absolute exclusion is re-expressed for a relative scope", func(t *testing.T) {
 		got := normalizeStoredSourcePathHintScopes([]StoredSourcePathHintScope{
 			{Path: relativeRoot, Excluded: []string{absoluteNested}},
 		})
 		require.Len(t, got, 1)
 		assert.Equal(t, relativeRoot, got[0].Path,
 			"the scope keeps the representation the query has to match")
-		assert.Equal(t, []string{absoluteNested}, got[0].Excluded,
-			"a nested exclusion still narrows a relatively expressed scope")
+		assert.Equal(t, []string{relativeNested}, got[0].Excluded,
+			"the exclusion binds against file_path, so it has to use the scope's representation")
 	})
 
-	t.Run("absolute scope keeps a relative exclusion as a narrowing", func(t *testing.T) {
+	t.Run("a relative exclusion is re-expressed for an absolute scope", func(t *testing.T) {
 		got := normalizeStoredSourcePathHintScopes([]StoredSourcePathHintScope{
 			{Path: absoluteRoot, Excluded: []string{relativeNested}},
 		})
 		require.Len(t, got, 1)
 		assert.Equal(t, absoluteRoot, got[0].Path)
-		assert.Equal(t, []string{relativeNested}, got[0].Excluded)
+		assert.Equal(t, []string{absoluteNested}, got[0].Excluded)
 	})
 
 	t.Run("a sibling outside the scope still narrows nothing", func(t *testing.T) {
@@ -1356,5 +1356,78 @@ func TestStoredSourcePathHintExclusionsMatchAcrossPathRepresentations(t *testing
 		})
 		require.Len(t, got, 1)
 		assert.Empty(t, got[0].Excluded)
+	})
+}
+
+// TestListActiveSessionSourceOwnershipScopesPageExcludesRelativeScopeInQuery
+// exercises the exclusion through SQL rather than through normalization alone.
+// An exclusion left in the representation it arrived in binds against
+// `file_path` values that use the scope's representation, so it matches nothing
+// and the excluded archive pages anyway.
+func TestListActiveSessionSourceOwnershipScopesPageExcludesRelativeScopeInQuery(t *testing.T) {
+	d := testDB(t)
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	relativeRoot := filepath.Join("testdata", "relative-scope")
+	absoluteNested := filepath.Join(wd, relativeRoot, "archive")
+
+	seeds := make([]storedSourcePathSeed, 0, WatchReconcileSourcePageSize+8)
+	for i := range WatchReconcileSourcePageSize + 4 {
+		seeds = append(seeds, storedSourcePathSeed{
+			id:    fmt.Sprintf("nested-%04d", i),
+			agent: "claude",
+			path:  filepath.Join(relativeRoot, "archive", fmt.Sprintf("a-%04d.jsonl", i)),
+		})
+	}
+	selectedIDs := make([]string, 0, 3)
+	for i := range 3 {
+		id := fmt.Sprintf("selected-%04d", i)
+		selectedIDs = append(selectedIDs, id)
+		seeds = append(seeds, storedSourcePathSeed{
+			id:    id,
+			agent: "claude",
+			path:  filepath.Join(relativeRoot, fmt.Sprintf("session-%04d.jsonl", i)),
+		})
+	}
+	insertSessionsWithSourcePaths(t, d, seeds)
+	require.NoError(t, d.BaselineActiveSessionSourcePaths(
+		t.Context(), defaultMachine, sourcePathsFromSeeds(seeds),
+	))
+
+	page, err := d.ListActiveSessionSourceOwnershipScopesPage(
+		t.Context(), defaultMachine, "claude",
+		[]StoredSourcePathHintScope{{
+			Path: relativeRoot, Excluded: []string{absoluteNested},
+		}},
+		SessionSourceCursor{},
+	)
+	require.NoError(t, err)
+
+	got := make([]string, 0, len(page))
+	for _, ownership := range page {
+		got = append(got, ownership.ID)
+	}
+	assert.Equal(t, selectedIDs, got,
+		"an absolute exclusion must narrow a relatively expressed scope in the query, not after the read")
+}
+
+func TestNormalizeExcludedHintRootsHandlesVolumeAndUnresolvableRoots(t *testing.T) {
+	t.Run("a root ending in a separator still matches descendants", func(t *testing.T) {
+		root := filepath.VolumeName(os.Args[0])
+		if root == "" {
+			t.Skip("no volume name on this platform")
+		}
+		volumeRoot := root + string(filepath.Separator)
+		nested := filepath.Join(volumeRoot, "archive")
+
+		got := normalizeExcludedHintRoots(volumeRoot, []string{nested})
+		assert.Equal(t, []string{nested}, got,
+			"appending a second separator to a volume root yields a prefix nothing matches")
+	})
+
+	t.Run("an exclusion that cannot be canonicalized is dropped", func(t *testing.T) {
+		root := filepath.Join(t.TempDir(), "claude")
+		assert.Empty(t, normalizeExcludedHintRoots(root, []string{"", "."}),
+			"an undecidable exclusion must not fall back to a lexical compare")
 	})
 }

--- a/internal/parser/capabilities.go
+++ b/internal/parser/capabilities.go
@@ -30,6 +30,7 @@ type SourceCapabilities struct {
 	StreamingDiscovery   CapabilitySupport
 	WatchSources         CapabilitySupport
 	WatchRoots           CapabilitySupport
+	DegradedPollingProbe CapabilitySupport
 	ClassifyChangedPath  CapabilitySupport
 	StoredSourceHints    CapabilitySupport
 	FindSource           CapabilitySupport

--- a/internal/parser/opencode_provider.go
+++ b/internal/parser/opencode_provider.go
@@ -59,7 +59,7 @@ func (f openCodeFormatProviderFactory) Definition() AgentDef {
 }
 
 func (f openCodeFormatProviderFactory) Capabilities() Capabilities {
-	return openCodeFormatProviderCapabilities()
+	return openCodeFormatProviderCapabilities(f.spec.agent)
 }
 
 func (f openCodeFormatProviderFactory) NewProvider(cfg ProviderConfig) Provider {
@@ -67,7 +67,7 @@ func (f openCodeFormatProviderFactory) NewProvider(cfg ProviderConfig) Provider 
 	return &openCodeFormatProvider{
 		ProviderBase: ProviderBase{
 			Def:    cloneAgentDef(f.def),
-			Caps:   openCodeFormatProviderCapabilities(),
+			Caps:   openCodeFormatProviderCapabilities(f.spec.agent),
 			Config: cfg,
 		},
 		sources: newOpenCodeFormatSourceSet(cfg.Roots, f.spec),
@@ -89,6 +89,32 @@ func (p *openCodeFormatProvider) DiscoverEach(ctx context.Context, yield func(So
 
 func (p *openCodeFormatProvider) WatchPlan(ctx context.Context) (WatchPlan, error) {
 	return p.sources.WatchPlan(ctx)
+}
+
+func (p *openCodeFormatProvider) DegradedPollingProbe(
+	ctx context.Context,
+	watchRoot string,
+) (DegradedPollingStateProbe, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if p.Def.Type != AgentOpenCode {
+		return nil, p.unsupported(ProviderFeatureDegradedPollingProbe)
+	}
+	watchRoot = filepath.Clean(watchRoot)
+	for _, root := range p.sources.roots {
+		for _, candidate := range p.sources.spec.watchRoots(root) {
+			if filepath.Clean(candidate) != watchRoot {
+				continue
+			}
+			src := p.sources.spec.resolve(root)
+			if src.DBPath == "" || !IsRegularFile(src.DBPath) {
+				return nil, p.unsupported(ProviderFeatureDegradedPollingProbe)
+			}
+			return openCodeSQLiteDegradedPollProbe{dbPath: src.DBPath}, nil
+		}
+	}
+	return nil, p.unsupported(ProviderFeatureDegradedPollingProbe)
 }
 
 func (p *openCodeFormatProvider) SourcesForChangedPath(
@@ -982,6 +1008,35 @@ func sqliteWALHasFrames(path string) bool {
 	return info.Mode().IsRegular() && info.Size() > sqliteWALHeaderSize
 }
 
+type openCodeSQLiteDegradedPollProbe struct {
+	dbPath string
+}
+
+func (p openCodeSQLiteDegradedPollProbe) DegradedPollingState(
+	ctx context.Context,
+) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	state, ok := StatSQLiteContainerState(p.dbPath)
+	if !ok {
+		return "", fmt.Errorf("stat sqlite container state %s", p.dbPath)
+	}
+	return fmt.Sprintf(
+		"%d:%d:%d:%d:%d:%d:%d:%d:%d:%d",
+		state.DBSize,
+		state.DBMtimeSec,
+		state.DBChangeCounter,
+		state.DBInode,
+		state.DBDevice,
+		state.WALSize,
+		state.WALMtimeSec,
+		state.WALCkptSeq,
+		state.WALSalt1,
+		state.WALSalt2,
+	), nil
+}
+
 func (s openCodeFormatSourceSet) sourceForRawID(root, sessionID string) (SourceRef, bool) {
 	path := s.spec.find(root, sessionID)
 	if path == "" {
@@ -1101,22 +1156,26 @@ func findOpenCodeProviderStorageSessionIDByMessageID(
 	return ""
 }
 
-func openCodeFormatProviderCapabilities() Capabilities {
+func openCodeFormatProviderCapabilities(agent AgentType) Capabilities {
+	source := SourceCapabilities{
+		DiscoverSources:       CapabilitySupported,
+		StreamingDiscovery:    CapabilitySupported,
+		WatchSources:          CapabilitySupported,
+		ClassifyChangedPath:   CapabilitySupported,
+		FindSource:            CapabilitySupported,
+		CompositeFingerprint:  CapabilitySupported,
+		IncrementalAppend:     CapabilityNotApplicable,
+		MultiSessionSource:    CapabilityNotApplicable,
+		SharedContainerSource: CapabilitySupported,
+		PerSessionErrors:      CapabilityNotApplicable,
+		ExcludedSessions:      CapabilityNotApplicable,
+		ForceReplaceOnParse:   CapabilityNotApplicable,
+	}
+	if agent == AgentOpenCode {
+		source.DegradedPollingProbe = CapabilitySupported
+	}
 	return Capabilities{
-		Source: SourceCapabilities{
-			DiscoverSources:       CapabilitySupported,
-			StreamingDiscovery:    CapabilitySupported,
-			WatchSources:          CapabilitySupported,
-			ClassifyChangedPath:   CapabilitySupported,
-			FindSource:            CapabilitySupported,
-			CompositeFingerprint:  CapabilitySupported,
-			IncrementalAppend:     CapabilityNotApplicable,
-			MultiSessionSource:    CapabilityNotApplicable,
-			SharedContainerSource: CapabilitySupported,
-			PerSessionErrors:      CapabilityNotApplicable,
-			ExcludedSessions:      CapabilityNotApplicable,
-			ForceReplaceOnParse:   CapabilityNotApplicable,
-		},
+		Source: source,
 		Content: ContentCapabilities{
 			FirstMessage:         CapabilitySupported,
 			Cwd:                  CapabilitySupported,

--- a/internal/parser/opencode_provider.go
+++ b/internal/parser/opencode_provider.go
@@ -108,7 +108,9 @@ func (p *openCodeFormatProvider) DegradedPollingProbe(
 				continue
 			}
 			src := p.sources.spec.resolve(root)
-			if src.DBPath == "" || !IsRegularFile(src.DBPath) {
+			if src.Mode != OpenCodeSourceSQLite ||
+				src.DBPath == "" ||
+				!IsRegularFile(src.DBPath) {
 				return nil, p.unsupported(ProviderFeatureDegradedPollingProbe)
 			}
 			return openCodeSQLiteDegradedPollProbe{dbPath: src.DBPath}, nil

--- a/internal/parser/opencode_provider_test.go
+++ b/internal/parser/opencode_provider_test.go
@@ -526,6 +526,28 @@ func TestOpenCodeDegradedPollingProbeIsOpenCodeOnly(t *testing.T) {
 	}
 }
 
+func TestOpenCodeDegradedPollingProbeRejectsHybridStorageRoots(t *testing.T) {
+	root := t.TempDir()
+	_, seeder, db := newTestDBAt(t, filepath.Join(root, "opencode.db"))
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	seeder.AddProject("prj_1", "/workspace/app")
+	seeder.AddSession(
+		"ses_probe", "prj_1", "", "Probe", 1700000000000, 1700000010000,
+	)
+	require.NoError(t, os.MkdirAll(
+		filepath.Join(root, "storage", "session", "global"),
+		0o755,
+	))
+
+	provider, ok := NewProvider(AgentOpenCode, ProviderConfig{
+		Roots: []string{root},
+	})
+	require.True(t, ok)
+
+	_, err := ResolveDegradedPollingProbe(t.Context(), provider, root)
+	require.ErrorIs(t, err, ErrUnsupportedProviderFeature)
+}
+
 func TestOpenCodeProviderSQLiteSourceMethods(t *testing.T) {
 
 	fixture := openCodeSQLiteProviderReadFixture(t)

--- a/internal/parser/opencode_provider_test.go
+++ b/internal/parser/opencode_provider_test.go
@@ -479,6 +479,53 @@ func TestOpenCodeProviderStorageSourceMethods(t *testing.T) {
 	assert.Equal(t, "global", removed[0].ProjectHint)
 }
 
+func TestOpenCodeDegradedPollingProbeIsOpenCodeOnly(t *testing.T) {
+	root := t.TempDir()
+	_, seeder, db := newTestDBAt(t, filepath.Join(root, "opencode.db"))
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+	seeder.AddProject("prj_1", "/workspace/app")
+	seeder.AddSession(
+		"ses_probe", "prj_1", "", "Probe", 1700000000000, 1700000010000,
+	)
+
+	openCodeProvider, ok := NewProvider(AgentOpenCode, ProviderConfig{
+		Roots: []string{root},
+	})
+	require.True(t, ok)
+	assert.Equal(t,
+		CapabilitySupported,
+		openCodeProvider.Capabilities().Source.DegradedPollingProbe,
+	)
+	probe, err := ResolveDegradedPollingProbe(
+		t.Context(), openCodeProvider, root,
+	)
+	require.NoError(t, err)
+	state, err := probe.DegradedPollingState(t.Context())
+	require.NoError(t, err)
+	assert.NotEmpty(t, state)
+
+	for _, agent := range []AgentType{
+		AgentKilo,
+		AgentMiMoCode,
+		AgentIcodemate,
+	} {
+		t.Run(string(agent), func(t *testing.T) {
+			provider, ok := NewProvider(agent, ProviderConfig{
+				Roots: []string{t.TempDir()},
+			})
+			require.True(t, ok)
+			assert.Equal(t,
+				CapabilityUnsupported,
+				provider.Capabilities().Source.DegradedPollingProbe,
+			)
+			_, err := ResolveDegradedPollingProbe(
+				t.Context(), provider, t.TempDir(),
+			)
+			require.ErrorIs(t, err, ErrUnsupportedProviderFeature)
+		})
+	}
+}
+
 func TestOpenCodeProviderSQLiteSourceMethods(t *testing.T) {
 
 	fixture := openCodeSQLiteProviderReadFixture(t)

--- a/internal/parser/provider.go
+++ b/internal/parser/provider.go
@@ -7,9 +7,10 @@ import (
 )
 
 const (
-	ProviderFeatureFingerprint = "fingerprint"
-	ProviderFeatureParse       = "parse"
-	ProviderFeatureWatchRoots  = "watch roots"
+	ProviderFeatureFingerprint          = "fingerprint"
+	ProviderFeatureParse                = "parse"
+	ProviderFeatureWatchRoots           = "watch roots"
+	ProviderFeatureDegradedPollingProbe = "degraded polling probe"
 )
 
 // ErrUnsupportedProviderFeature identifies optional provider behavior that is
@@ -196,6 +197,13 @@ func (b ProviderBase) WatchPlan(context.Context) (WatchPlan, error) {
 	return WatchPlan{}, nil
 }
 
+func (b ProviderBase) DegradedPollingProbe(
+	context.Context,
+	string,
+) (DegradedPollingStateProbe, error) {
+	return nil, b.unsupported(ProviderFeatureDegradedPollingProbe)
+}
+
 func (b ProviderBase) SourcesForChangedPath(
 	context.Context,
 	ChangedPathRequest,
@@ -296,6 +304,23 @@ type WatchRootPlanner interface {
 	WatchRoots(context.Context) ([]WatchRoot, error)
 }
 
+// DegradedPollingStateProbe captures one provider-owned freshness token for a
+// degraded polling unit. Equal tokens mean the provider's bounded authoritative
+// reconciliation for that unit would be a no-op.
+type DegradedPollingStateProbe interface {
+	DegradedPollingState(context.Context) (string, error)
+}
+
+// DegradedPollingProbeProvider declares an additive provider-owned degraded
+// polling probe. Providers keep their existing degraded polling behavior until
+// they advertise and implement this capability.
+type DegradedPollingProbeProvider interface {
+	DegradedPollingProbe(
+		context.Context,
+		string,
+	) (DegradedPollingStateProbe, error)
+}
+
 // ResolveWatchRoots returns the bounded root-planning capability when a
 // provider advertises it. Providers that have not migrated yet retain their
 // WatchPlan behavior, but parser-only include/exclude globs are never carried
@@ -323,6 +348,27 @@ func ResolveWatchRoots(
 		return nil, err
 	}
 	return watchRootMetadata(plan.Roots), nil
+}
+
+func ResolveDegradedPollingProbe(
+	ctx context.Context,
+	provider Provider,
+	watchRoot string,
+) (DegradedPollingStateProbe, error) {
+	if provider.Capabilities().Source.DegradedPollingProbe != CapabilitySupported {
+		return nil, UnsupportedProviderFeatureError{
+			Provider: provider.Definition().Type,
+			Feature:  ProviderFeatureDegradedPollingProbe,
+		}
+	}
+	prober, ok := provider.(DegradedPollingProbeProvider)
+	if !ok {
+		return nil, UnsupportedProviderFeatureError{
+			Provider: provider.Definition().Type,
+			Feature:  ProviderFeatureDegradedPollingProbe,
+		}
+	}
+	return prober.DegradedPollingProbe(ctx, watchRoot)
 }
 
 func watchRootMetadata(roots []WatchRoot) []WatchRoot {

--- a/internal/parser/provider_capabilities_test.go
+++ b/internal/parser/provider_capabilities_test.go
@@ -14,6 +14,10 @@ func TestProviderCapabilitiesWatchRootsDefaultUnsupported(t *testing.T) {
 	assert.Equal(t, CapabilityUnsupported, (SourceCapabilities{}).WatchRoots)
 }
 
+func TestProviderCapabilitiesDegradedPollingProbeDefaultUnsupported(t *testing.T) {
+	assert.Equal(t, CapabilityUnsupported, (SourceCapabilities{}).DegradedPollingProbe)
+}
+
 func TestProviderCapabilitiesStreamingDiscoveryDefaultUnsupported(t *testing.T) {
 	assert.Equal(t, CapabilityUnsupported, (SourceCapabilities{}).StreamingDiscovery)
 }

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -1031,6 +1031,10 @@ func (e *Engine) classifyProviderChangedPath(
 			!changedPathWithinAnyRoot(path, watchRoots) {
 			continue
 		}
+		if agentType == parser.AgentOpenCode &&
+			e.unchangedOpenCodeSQLiteWatcherEvent(path) {
+			continue
+		}
 		for _, watchRoot := range watchRoots {
 			request := parser.ChangedPathRequest{
 				Path:      path,

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -3159,6 +3159,11 @@ func (e *Engine) reconcileWatchRootsStreamed(
 		scope = nil
 	} else if scope != nil {
 		scope.agent = agent
+		if agent != "" {
+			scope.exactRoots = matchedConfiguredRootsForSelections(
+				roots, e.agentDirs[agent],
+			)
+		}
 	}
 	preContainerStates := e.captureSQLiteContainerStates(nil)
 	providers, completedScopes, failedRoots, failures, discoveryErr, err := e.streamReconciliationCandidates(
@@ -3874,9 +3879,14 @@ func (e *Engine) tombstoneMissingWatchSourcesForAgentLocked(
 		var replacementIndex reconciliationSpoolStore
 		ownsReplacementIndex := false
 		allProviderRootsCovered := reconciliationCoversConfiguredRoots(roots, dirs)
-		if factory := e.providerFactories[agent]; factory != nil {
+		excludedDescendantRoots := unselectedDescendantConfiguredRoots(roots, dirs)
+		matchedConfiguredRoots := matchedConfiguredRootsForRequestedPaths(
+			roots, dirs,
+		)
+		if factory := e.providerFactories[agent]; factory != nil &&
+			len(matchedConfiguredRoots) > 0 {
 			provider = factory.NewProvider(parser.ProviderConfig{
-				Roots: e.agentDirs[agent], Machine: e.machine,
+				Roots: matchedConfiguredRoots, Machine: e.machine,
 				PathRewriter: e.pathRewriter,
 			})
 		}
@@ -3913,6 +3923,9 @@ func (e *Engine) tombstoneMissingWatchSourcesForAgentLocked(
 				missingByPath := make(map[string]bool, len(page))
 				for _, ownership := range page {
 					statPath := ownership.FilePath
+					if pathUnderAnyConfiguredRoot(statPath, excludedDescendantRoots) {
+						continue
+					}
 					persistentMemberContainerExists := false
 					missing, ok := missingByPath[statPath]
 					if !ok {
@@ -4160,6 +4173,108 @@ func reconciliationCoversConfiguredRoots(requested, configured []string) bool {
 	return true
 }
 
+func unselectedDescendantConfiguredRoots(
+	selected, configured []string,
+) []string {
+	cleanSelected := make([]string, 0, len(selected))
+	for _, root := range selected {
+		cleaned := cleanRootPath(root)
+		if cleaned == "" || slices.Contains(cleanSelected, cleaned) {
+			continue
+		}
+		cleanSelected = append(cleanSelected, cleaned)
+	}
+	excluded := make([]string, 0, len(configured))
+	for _, dir := range configured {
+		cleanedDir := cleanRootPath(dir)
+		if cleanedDir == "" || slices.Contains(cleanSelected, cleanedDir) {
+			continue
+		}
+		if !slices.ContainsFunc(cleanSelected, func(root string) bool {
+			return samePathOrDescendant(cleanedDir, root)
+		}) {
+			continue
+		}
+		excluded = append(excluded, cleanedDir)
+	}
+	return excluded
+}
+
+func matchedConfiguredRootsForSelections(
+	selected, configured []string,
+) []string {
+	cleanSelected := make(map[string]struct{}, len(selected))
+	for _, root := range selected {
+		cleaned := cleanRootPath(root)
+		if cleaned == "" {
+			continue
+		}
+		cleanSelected[cleaned] = struct{}{}
+	}
+	matched := make([]string, 0, len(configured))
+	seen := make(map[string]struct{}, len(configured))
+	for _, dir := range configured {
+		cleanedDir := cleanRootPath(dir)
+		if cleanedDir == "" {
+			continue
+		}
+		if _, ok := cleanSelected[cleanedDir]; !ok {
+			continue
+		}
+		if _, dup := seen[cleanedDir]; dup {
+			continue
+		}
+		seen[cleanedDir] = struct{}{}
+		matched = append(matched, dir)
+	}
+	return matched
+}
+
+func matchedConfiguredRootsForRequestedPaths(
+	requested, configured []string,
+) []string {
+	cleanRequested := make(map[string]struct{}, len(requested))
+	for _, root := range requested {
+		cleaned := cleanRootPath(validatedProviderSourceStatPath(root))
+		if cleaned == "" {
+			continue
+		}
+		cleanRequested[cleaned] = struct{}{}
+	}
+	matched := make([]string, 0, len(configured))
+	seen := make(map[string]struct{}, len(configured))
+	for _, dir := range configured {
+		cleanedDir := cleanRootPath(dir)
+		if cleanedDir == "" {
+			continue
+		}
+		matchedRequest := false
+		for requestedPath := range cleanRequested {
+			if samePathOrDescendant(requestedPath, cleanedDir) ||
+				samePathOrDescendant(cleanedDir, requestedPath) {
+				matchedRequest = true
+				break
+			}
+		}
+		if !matchedRequest {
+			continue
+		}
+		if _, dup := seen[cleanedDir]; dup {
+			continue
+		}
+		seen[cleanedDir] = struct{}{}
+		matched = append(matched, dir)
+	}
+	return matched
+}
+
+func pathUnderAnyConfiguredRoot(path string, roots []string) bool {
+	cleanedPath := cleanRootPath(path)
+	return slices.ContainsFunc(roots, func(root string) bool {
+		return samePathOrDescendant(cleanedPath, root)
+	})
+}
+
 func (e *Engine) buildReconciliationReplacementIndex(
 	ctx context.Context, provider parser.Provider, configuredRoots []string,
 ) (result reconciliationSpoolStore, retErr error) {
@@ -4229,39 +4344,9 @@ func (e *Engine) logicalRootsForWatchRoots(roots []string) []string {
 	return logical
 }
 
-// logicalRootsForAgentWatchRoots resolves the given roots against one agent's
-// configured dirs only. Unlike logicalRootsForWatchRoots it never crosses into
-// another provider's dirs, so an overlapping ancestor root cannot drag other
-// providers into a scoped reconciliation.
-func (e *Engine) logicalRootsForAgentWatchRoots(
-	agent parser.AgentType, roots []string,
-) []string {
-	dirs := e.agentDirs[agent]
-	var logical []string
-	for _, root := range roots {
-		cleanedRoot := cleanRootPath(root)
-		matched := false
-		for _, dir := range dirs {
-			cleanedDir := cleanRootPath(dir)
-			if !samePathOrDescendant(cleanedRoot, cleanedDir) &&
-				!samePathOrDescendant(cleanedDir, cleanedRoot) {
-				continue
-			}
-			if !slices.Contains(logical, cleanedDir) {
-				logical = append(logical, cleanedDir)
-			}
-			matched = true
-		}
-		if !matched && !slices.Contains(logical, cleanedRoot) {
-			logical = append(logical, cleanedRoot)
-		}
-	}
-	return logical
-}
-
-// agentReconciliationRoots restricts the requested roots to a single agent's
-// configured dirs and excludes remote object roots, mirroring
-// localReconciliationRoots but without the cross-provider expansion.
+// agentReconciliationRoots cleans, deduplicates, and remote-filters the exact
+// provider roots selected for one agent. Unlike localReconciliationRoots it
+// never expands a selected root to overlapping configured dirs.
 func (e *Engine) agentReconciliationRoots(
 	agent parser.AgentType, roots []string,
 ) ([]string, int) {
@@ -4272,9 +4357,13 @@ func (e *Engine) agentReconciliationRoots(
 			remote++
 			continue
 		}
-		local = append(local, root)
+		cleanedRoot := cleanRootPath(root)
+		if cleanedRoot == "" || slices.Contains(local, cleanedRoot) {
+			continue
+		}
+		local = append(local, cleanedRoot)
 	}
-	return e.logicalRootsForAgentWatchRoots(agent, local), remote
+	return local, remote
 }
 
 // localReconciliationRoots expands a full watcher recovery to every configured
@@ -4361,6 +4450,10 @@ func (e *Engine) SyncRootsSince(
 
 type rootSyncScope struct {
 	roots []string
+	// exactRoots maps agent-scoped selections back onto configured roots so
+	// relative/absolute equivalents remain in scope without re-expanding into
+	// overlapping sibling configured dirs.
+	exactRoots []string
 	// agent, when non-empty, restricts discovery to a single provider so a
 	// scoped reconciliation cannot drag other providers into the pass through
 	// ancestor/descendant root overlap. Zero value matches every agent.
@@ -4395,6 +4488,15 @@ func (s *rootSyncScope) includes(dir string) bool {
 		return false
 	}
 	cleaned := cleanRootPath(dir)
+	if s.agent != "" {
+		exactRoots := s.exactRoots
+		if len(exactRoots) == 0 {
+			exactRoots = s.roots
+		}
+		return slices.ContainsFunc(exactRoots, func(root string) bool {
+			return cleanRootPath(root) == cleaned
+		})
+	}
 	return slices.ContainsFunc(s.roots, func(root string) bool {
 		return samePathOrDescendant(cleaned, root)
 	})

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -3878,7 +3878,9 @@ func (e *Engine) tombstoneMissingWatchSourcesForAgentLocked(
 		var provider parser.Provider
 		var replacementIndex reconciliationSpoolStore
 		ownsReplacementIndex := false
-		allProviderRootsCovered := reconciliationCoversConfiguredRoots(roots, dirs)
+		allProviderRootsCovered := reconciliationCoversConfiguredRoots(
+			roots, dirs, agentFilter != "",
+		)
 		excludedDescendantRoots := unselectedDescendantConfiguredRoots(roots, dirs)
 		matchedConfiguredRoots := matchedConfiguredRootsForRequestedPaths(
 			roots, dirs,
@@ -3903,14 +3905,22 @@ func (e *Engine) tombstoneMissingWatchSourcesForAgentLocked(
 					ownershipScopes = resolved
 				}
 			}
+			// Exclusions ride the query so a large unselected nested archive
+			// never fills a page ahead of this scope's own rows. The read-side
+			// skip below still runs: a provider-resolved ownership scope need
+			// not be an ancestor of the excluded root, and normalization drops
+			// the exclusion in that case.
+			dbScopes := storedSourceDBHintScopes(ownershipScopes)
+			for i := range dbScopes {
+				dbScopes[i].Excluded = excludedDescendantRoots
+			}
 			var cursor db.SessionSourceCursor
 			for {
 				if err := ctx.Err(); err != nil {
 					return deleted, err
 				}
 				page, err := e.db.ListActiveSessionSourceOwnershipScopesPage(
-					ctx, e.machine, string(agent),
-					storedSourceDBHintScopes(ownershipScopes), cursor,
+					ctx, e.machine, string(agent), dbScopes, cursor,
 				)
 				if err != nil {
 					return deleted, fmt.Errorf(
@@ -4159,14 +4169,33 @@ func (e *Engine) tombstoneSessionSourceOwnership(
 	return true, nil
 }
 
-func reconciliationCoversConfiguredRoots(requested, configured []string) bool {
+// reconciliationScopeCoversConfiguredRoot reports whether a pass over the
+// requested roots reaches one configured root. rootSyncScope.includes admits
+// discovery through it and tombstone accounting asks it what the pass covered,
+// so the two cannot drift: an agent-scoped pass admits only exactly selected
+// configured dirs, leaving a nested configured root undiscovered when its
+// ancestor was selected, while a generic pass expands into descendants.
+func reconciliationScopeCoversConfiguredRoot(
+	requested []string, configured string, agentScoped bool,
+) bool {
+	cleanedConfigured := cleanRootPath(configured)
+	return slices.ContainsFunc(requested, func(requestedRoot string) bool {
+		cleanedRequested := cleanRootPath(requestedRoot)
+		if agentScoped {
+			return cleanedConfigured == cleanedRequested
+		}
+		return samePathOrDescendant(cleanedConfigured, cleanedRequested)
+	})
+}
+
+func reconciliationCoversConfiguredRoots(
+	requested, configured []string, agentScoped bool,
+) bool {
 	for _, configuredRoot := range configured {
 		if isRemoteReconciliationRoot(configuredRoot) ||
-			!slices.ContainsFunc(requested, func(requestedRoot string) bool {
-				return samePathOrDescendant(
-					cleanRootPath(configuredRoot), cleanRootPath(requestedRoot),
-				)
-			}) {
+			!reconciliationScopeCoversConfiguredRoot(
+				requested, configuredRoot, agentScoped,
+			) {
 			return false
 		}
 	}
@@ -4487,19 +4516,11 @@ func (s *rootSyncScope) includes(dir string) bool {
 	if dir == "" {
 		return false
 	}
-	cleaned := cleanRootPath(dir)
-	if s.agent != "" {
-		exactRoots := s.exactRoots
-		if len(exactRoots) == 0 {
-			exactRoots = s.roots
-		}
-		return slices.ContainsFunc(exactRoots, func(root string) bool {
-			return cleanRootPath(root) == cleaned
-		})
+	roots := s.roots
+	if s.agent != "" && len(s.exactRoots) > 0 {
+		roots = s.exactRoots
 	}
-	return slices.ContainsFunc(s.roots, func(root string) bool {
-		return samePathOrDescendant(cleaned, root)
-	})
+	return reconciliationScopeCoversConfiguredRoot(roots, dir, s.agent != "")
 }
 
 func (s *rootSyncScope) includesAny(dirs []string) bool {

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -1395,7 +1395,7 @@ func TestSyncEngineKiroSQLiteUpdatePaths(t *testing.T) {
 	assertSessionMessageCount(t, env.db, "kiro:full-sync-session", 2)
 
 	ks.updateSession(t, "physical-path-session", overlapPayload, 1779015620000)
-	env.engine.SyncPaths([]string{ks.path})
+	require.NoError(t, env.engine.SyncPathsContext(t.Context(), []string{ks.path}))
 
 	assertSessionMessageCount(t, env.db, "kiro:physical-path-session", 2)
 	assertMessageContent(t, env.db, "kiro:physical-path-session",
@@ -1404,9 +1404,9 @@ func TestSyncEngineKiroSQLiteUpdatePaths(t *testing.T) {
 	)
 
 	ks.updateSession(t, "virtual-path-session", overlapPayload, 1779015630000)
-	env.engine.SyncPaths([]string{
+	require.NoError(t, env.engine.SyncPathsContext(t.Context(), []string{
 		parser.KiroSQLiteVirtualPath(ks.path, "virtual-path-session"),
-	})
+	}))
 
 	assertSessionMessageCount(t, env.db, "kiro:virtual-path-session", 2)
 	assertMessageContent(t, env.db, "kiro:virtual-path-session",

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -7321,6 +7321,45 @@ func TestEngine_ClassifyPathsOpenCodeSQLiteWALFile(
 	assert.Equal(t, parser.AgentOpenCode, files[0].Agent)
 }
 
+func TestEngine_ClassifyPathsOpenCodeSQLiteWALSkipsTrustedNoOpEvent(
+	t *testing.T,
+) {
+	db := openTestDB(t)
+	opencodeDir := t.TempDir()
+	engine := NewEngine(db, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentOpenCode: {opencodeDir},
+		},
+		Machine: "local",
+	})
+
+	dbPath := filepath.Join(opencodeDir, "opencode.db")
+	seedOpenCodeSQLiteWALSession(t, dbPath, "ses_wal")
+	walPath := filepath.Join(opencodeDir, "opencode.db-wal")
+	state, ok := parser.StatSQLiteContainerState(dbPath)
+	require.True(t, ok, "container state must be readable")
+	engine.trustedSQLiteContainers = map[string]trustedSQLiteContainer{
+		dbPath: {state: state},
+	}
+
+	assert.Empty(t, requireClassifyPaths(t, engine, []string{walPath}),
+		"an unchanged trusted container must suppress watcher-side SQLite fanout")
+
+	conn, err := sql.Open("sqlite3", dbPath)
+	require.NoError(t, err, "reopen opencode db")
+	t.Cleanup(func() { _ = conn.Close() })
+	_, err = conn.Exec(
+		`INSERT INTO session (id, project_id, time_created, time_updated)
+		 VALUES ('ses_next', 'prj_1', 3, 4)`,
+	)
+	require.NoError(t, err, "append changed SQLite session")
+
+	files := requireClassifyPaths(t, engine, []string{walPath})
+	require.Len(t, files, 2)
+	assert.Equal(t, parser.AgentOpenCode, files[0].Agent)
+	assert.Equal(t, parser.AgentOpenCode, files[1].Agent)
+}
+
 // seedOpenCodeSQLiteWALSession creates a minimal OpenCode-shaped SQLite
 // database and keeps its writer open with the session commit held in the WAL.
 // This exercises the same uncheckpointed state produced by a live OpenCode

--- a/internal/sync/opencode_container_gate.go
+++ b/internal/sync/opencode_container_gate.go
@@ -156,6 +156,33 @@ func openCodeContainerPathForEvent(
 	return ""
 }
 
+func (e *Engine) unchangedOpenCodeSQLiteWatcherEvent(path string) bool {
+	e.containerMu.Lock()
+	hasTrusted := len(e.trustedSQLiteContainers) > 0
+	e.containerMu.Unlock()
+	if !hasTrusted {
+		return false
+	}
+	for _, dir := range e.agentDirs[parser.AgentOpenCode] {
+		if dir == "" || strings.HasPrefix(dir, "s3://") {
+			continue
+		}
+		dbPath := openCodeContainerPathForEvent(parser.AgentOpenCode, dir, path)
+		if dbPath == "" {
+			continue
+		}
+		current, ok := statSQLiteContainerState(dbPath)
+		if !ok {
+			return false
+		}
+		e.containerMu.Lock()
+		trusted, ok := e.trustedSQLiteContainers[dbPath]
+		e.containerMu.Unlock()
+		return ok && current == trusted.state
+	}
+	return false
+}
+
 // beginSQLiteContainerPass starts a pass's gate bookkeeping from the
 // discovered files and the pre-discovery container captures. files must be
 // the pre-filter discovery set: promotion requires seeing a completion for

--- a/internal/sync/reconcile_provider_roots_test.go
+++ b/internal/sync/reconcile_provider_roots_test.go
@@ -187,19 +187,12 @@ func TestReconcileProviderRootsDoesNotExpandAcrossSameProviderScopes(t *testing.
 	require.NoError(t, engine.ReconcileProviderRoots(
 		t.Context(), parser.AgentClaude, []string{parentDir}))
 
-	deleted, err := database.GetSessionFull(t.Context(), parentIDs[2])
-	require.NoError(t, err)
-	require.NotNil(t, deleted)
-	require.NotNil(t, deleted.DeletionCause)
-	assert.Equal(t, "source_missing", *deleted.DeletionCause)
-
-	for i, id := range parentIDs {
-		if i == 2 {
-			continue
-		}
+	for _, id := range parentIDs {
 		active, err := database.GetSession(t.Context(), id)
 		require.NoError(t, err)
-		assert.NotNil(t, active, "surviving parent sessions must remain active")
+		assert.NotNil(t, active,
+			"a pass that never discovered the nested configured root cannot tell "+
+				"a deleted source from one relocated into it")
 	}
 
 	for _, id := range nestedIDs {
@@ -214,4 +207,74 @@ func TestReconcileProviderRootsDoesNotExpandAcrossSameProviderScopes(t *testing.
 	assert.LessOrEqual(t, engine.LastReconciliationResult().Metrics.MaxRehydratedSources,
 		len(parentIDs),
 		"rehydration must stay bounded by the selected parent scope")
+
+	require.NoError(t, engine.ReconcileProviderRoots(
+		t.Context(), parser.AgentClaude, []string{parentDir, nestedDir}))
+
+	deleted, err := database.GetSessionFull(t.Context(), parentIDs[2])
+	require.NoError(t, err)
+	require.NotNil(t, deleted)
+	require.NotNil(t, deleted.DeletionCause)
+	assert.Equal(t, "source_missing", *deleted.DeletionCause,
+		"a pass selecting every configured root still tombstones the removed source")
+
+	for i, id := range parentIDs {
+		if i == 2 {
+			continue
+		}
+		active, err := database.GetSession(t.Context(), id)
+		require.NoError(t, err)
+		assert.NotNil(t, active, "surviving parent sessions must remain active")
+	}
+}
+
+// TestReconcileProviderRootsKeepsSessionMovedIntoUnselectedNestedScope covers
+// the move a partial pass cannot see: the source vanished from the selected
+// parent and reappeared under a configured nested root the pass excluded from
+// discovery, so its absence is not evidence of deletion.
+func TestReconcileProviderRootsKeepsSessionMovedIntoUnselectedNestedScope(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	base := t.TempDir()
+	parentDir := filepath.Join(base, "claude")
+	nestedDir := filepath.Join(parentDir, "nested")
+	require.NoError(t, os.MkdirAll(nestedDir, 0o755))
+
+	parentIDs := writeNamedClaudeCorpus(t, parentDir, "parent", 5)
+	nestedIDs := writeNamedClaudeCorpus(t, nestedDir, "nested", 3)
+
+	database := openTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {parentDir, nestedDir},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+
+	require.Equal(t, len(parentIDs)+len(nestedIDs),
+		engine.SyncAll(t.Context(), nil).Synced, "cold pass ingests every source")
+
+	movedID := parentIDs[2]
+	from := filepath.Join(parentDir, "project", movedID+".jsonl")
+	to := filepath.Join(nestedDir, "project", movedID+".jsonl")
+	require.NoError(t, os.MkdirAll(filepath.Dir(to), 0o755))
+	require.NoError(t, os.Rename(from, to))
+
+	require.NoError(t, engine.ReconcileProviderRoots(
+		t.Context(), parser.AgentClaude, []string{parentDir}))
+
+	moved, err := database.GetSession(t.Context(), movedID)
+	require.NoError(t, err)
+	assert.NotNil(t, moved,
+		"a session moved into an unselected nested configured root must survive a parent-scoped pass")
+
+	require.NoError(t, engine.ReconcileProviderRoots(
+		t.Context(), parser.AgentClaude, []string{parentDir, nestedDir}))
+
+	stillActive, err := database.GetSession(t.Context(), movedID)
+	require.NoError(t, err)
+	assert.NotNil(t, stillActive,
+		"a covering pass finds the relocated source and leaves the session active")
 }

--- a/internal/sync/reconcile_provider_roots_test.go
+++ b/internal/sync/reconcile_provider_roots_test.go
@@ -31,10 +31,14 @@ func writeAiderRepoSession(t *testing.T, root, repo, prompt string) (path, id st
 // writeClaudeCorpus writes n minimal Claude sessions under dir and returns
 // their derived session IDs.
 func writeClaudeCorpus(t *testing.T, dir string, n int) []string {
+	return writeNamedClaudeCorpus(t, dir, "claude", n)
+}
+
+func writeNamedClaudeCorpus(t *testing.T, dir, prefix string, n int) []string {
 	t.Helper()
 	ids := make([]string, 0, n)
 	for i := range n {
-		name := fmt.Sprintf("claude-%04d", i)
+		name := fmt.Sprintf("%s-%04d", prefix, i)
 		path := filepath.Join(dir, "project", name+".jsonl")
 		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
 		require.NoError(t, os.WriteFile(path, []byte(
@@ -149,4 +153,65 @@ func TestReconcileProviderRootsDoesNotExpandAcrossProviders(t *testing.T) {
 		"agent-scoped reconciliation must not stat other providers' sources")
 	assert.LessOrEqual(t, engine.LastReconciliationResult().Metrics.MaxRehydratedSources,
 		aiderCount, "rehydration must stay bounded by the scoped provider's corpus")
+}
+
+func TestReconcileProviderRootsDoesNotExpandAcrossSameProviderScopes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	base := t.TempDir()
+	parentDir := filepath.Join(base, "claude")
+	nestedDir := filepath.Join(parentDir, "nested")
+	require.NoError(t, os.MkdirAll(nestedDir, 0o755))
+
+	parentIDs := writeNamedClaudeCorpus(t, parentDir, "parent", 5)
+	nestedIDs := writeNamedClaudeCorpus(t, nestedDir, "nested", 100)
+	deletedPath := filepath.Join(parentDir, "project", "parent-0002.jsonl")
+
+	database := openTestDB(t)
+	engine := NewEngine(database, EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentClaude: {parentDir, nestedDir},
+		},
+		Machine: "local",
+	})
+	t.Cleanup(engine.Close)
+
+	require.Equal(t, len(parentIDs)+len(nestedIDs),
+		engine.SyncAll(t.Context(), nil).Synced, "cold pass ingests every source")
+	require.NoError(t, os.Remove(deletedPath))
+
+	rec := &lstatRecorder{}
+	engine.lstat = rec.stat
+
+	require.NoError(t, engine.ReconcileProviderRoots(
+		t.Context(), parser.AgentClaude, []string{parentDir}))
+
+	deleted, err := database.GetSessionFull(t.Context(), parentIDs[2])
+	require.NoError(t, err)
+	require.NotNil(t, deleted)
+	require.NotNil(t, deleted.DeletionCause)
+	assert.Equal(t, "source_missing", *deleted.DeletionCause)
+
+	for i, id := range parentIDs {
+		if i == 2 {
+			continue
+		}
+		active, err := database.GetSession(t.Context(), id)
+		require.NoError(t, err)
+		assert.NotNil(t, active, "surviving parent sessions must remain active")
+	}
+
+	for _, id := range nestedIDs {
+		active, err := database.GetSession(t.Context(), id)
+		require.NoError(t, err)
+		assert.NotNil(t, active,
+			"agent-scoped reconciliation must not enumerate or tombstone a nested configured scope")
+	}
+
+	assert.Zero(t, rec.countUnder(nestedDir),
+		"agent-scoped reconciliation must not stat a nested configured scope for the same provider")
+	assert.LessOrEqual(t, engine.LastReconciliationResult().Metrics.MaxRehydratedSources,
+		len(parentIDs),
+		"rehydration must stay bounded by the selected parent scope")
 }

--- a/internal/sync/watch_backend.go
+++ b/internal/sync/watch_backend.go
@@ -11,9 +11,8 @@ import (
 // by a logical watcher root. A physical root may cover multiple configured
 // directories or providers, so registration must preserve every exact scope.
 type WatchScope struct {
-	Agent         string
-	SyncDir       string
-	DegradedProbe parser.DegradedPollingStateProbe
+	Agent   string
+	SyncDir string
 }
 
 // WatchRoot is one desired logical watcher root. Exists describes startup
@@ -43,17 +42,12 @@ func pollingObligationsForScopes(
 		byDir[cleanDir] = append(byDir[cleanDir], scope)
 	}
 	byKey := make(map[string][]string)
-	degraded := make(map[string]parser.DegradedPollingStateProbe)
-	degradedAgent := make(map[string]parser.AgentType)
+	obligationAgent := make(map[string]parser.AgentType)
+	splitByDir := len(byDir) > 1
 	for cleanDir, dirScopes := range byDir {
 		obligationKey := key
-		var (
-			probe      parser.DegradedPollingStateProbe
-			probeAgent string
-			probeOK    = true
-			agent      parser.AgentType
-			sameAgent  = true
-		)
+		var agent parser.AgentType
+		sameAgent := true
 		for _, scope := range dirScopes {
 			scopeAgent := parser.AgentType(scope.Agent)
 			if agent == "" {
@@ -61,31 +55,20 @@ func pollingObligationsForScopes(
 			} else if scopeAgent != agent {
 				sameAgent = false
 			}
-			if scope.DegradedProbe == nil {
-				probeOK = false
-				break
-			}
-			if probe == nil {
-				probe = scope.DegradedProbe
-				probeAgent = scope.Agent
-				continue
-			}
-			if scope.Agent != probeAgent {
-				probeOK = false
-				break
-			}
 		}
-		if probeOK && probe != nil {
+		if splitByDir && sameAgent && agent != "" {
 			obligationKey = key + "|" + cleanDir
-			degraded[obligationKey] = probe
+		}
+		currentAgent := parser.AgentType("")
+		if sameAgent {
+			currentAgent = agent
+		}
+		if prior, ok := obligationAgent[obligationKey]; !ok {
+			obligationAgent[obligationKey] = currentAgent
+		} else if prior == "" || currentAgent == "" || prior != currentAgent {
+			obligationAgent[obligationKey] = ""
 		}
 		byKey[obligationKey] = appendUniqueScopeRoot(byKey[obligationKey], cleanDir)
-		if !sameAgent {
-			agent = ""
-		}
-		if agent != "" {
-			degradedAgent[obligationKey] = agent
-		}
 	}
 	keys := make([]string, 0, len(byKey))
 	for obligationKey := range byKey {
@@ -97,11 +80,10 @@ func pollingObligationsForScopes(
 		roots := byKey[obligationKey]
 		slices.Sort(roots)
 		obligations = append(obligations, PollingObligation{
-			Key:           obligationKey,
-			Agent:         degradedAgent[obligationKey],
-			Roots:         roots,
-			Probe:         filepath.Clean(probe),
-			DegradedProbe: degraded[obligationKey],
+			Key:   obligationKey,
+			Agent: obligationAgent[obligationKey],
+			Roots: roots,
+			Probe: filepath.Clean(probe),
 		})
 	}
 	return obligations

--- a/internal/sync/watch_backend.go
+++ b/internal/sync/watch_backend.go
@@ -92,10 +92,8 @@ func pollingObligationsForScopes(
 }
 
 func appendUniqueScopeRoot(roots []string, root string) []string {
-	for _, existing := range roots {
-		if existing == root {
-			return roots
-		}
+	if slices.Contains(roots, root) {
+		return roots
 	}
 	return append(roots, root)
 }

--- a/internal/sync/watch_backend.go
+++ b/internal/sync/watch_backend.go
@@ -44,14 +44,23 @@ func pollingObligationsForScopes(
 	}
 	byKey := make(map[string][]string)
 	degraded := make(map[string]parser.DegradedPollingStateProbe)
+	degradedAgent := make(map[string]parser.AgentType)
 	for cleanDir, dirScopes := range byDir {
 		obligationKey := key
 		var (
 			probe      parser.DegradedPollingStateProbe
 			probeAgent string
 			probeOK    = true
+			agent      parser.AgentType
+			sameAgent  = true
 		)
 		for _, scope := range dirScopes {
+			scopeAgent := parser.AgentType(scope.Agent)
+			if agent == "" {
+				agent = scopeAgent
+			} else if scopeAgent != agent {
+				sameAgent = false
+			}
 			if scope.DegradedProbe == nil {
 				probeOK = false
 				break
@@ -71,6 +80,12 @@ func pollingObligationsForScopes(
 			degraded[obligationKey] = probe
 		}
 		byKey[obligationKey] = appendUniqueScopeRoot(byKey[obligationKey], cleanDir)
+		if !sameAgent {
+			agent = ""
+		}
+		if agent != "" {
+			degradedAgent[obligationKey] = agent
+		}
 	}
 	keys := make([]string, 0, len(byKey))
 	for obligationKey := range byKey {
@@ -83,6 +98,7 @@ func pollingObligationsForScopes(
 		slices.Sort(roots)
 		obligations = append(obligations, PollingObligation{
 			Key:           obligationKey,
+			Agent:         degradedAgent[obligationKey],
 			Roots:         roots,
 			Probe:         filepath.Clean(probe),
 			DegradedProbe: degraded[obligationKey],

--- a/internal/sync/watch_backend.go
+++ b/internal/sync/watch_backend.go
@@ -34,17 +34,41 @@ func pollingObligationsForScopes(
 	if len(scopes) == 0 {
 		return nil
 	}
-	byKey := make(map[string][]string)
-	degraded := make(map[string]parser.DegradedPollingStateProbe)
+	byDir := make(map[string][]WatchScope)
 	for _, scope := range scopes {
 		if scope.SyncDir == "" {
 			continue
 		}
 		cleanDir := filepath.Clean(scope.SyncDir)
+		byDir[cleanDir] = append(byDir[cleanDir], scope)
+	}
+	byKey := make(map[string][]string)
+	degraded := make(map[string]parser.DegradedPollingStateProbe)
+	for cleanDir, dirScopes := range byDir {
 		obligationKey := key
-		if scope.DegradedProbe != nil {
+		var (
+			probe      parser.DegradedPollingStateProbe
+			probeAgent string
+			probeOK    = true
+		)
+		for _, scope := range dirScopes {
+			if scope.DegradedProbe == nil {
+				probeOK = false
+				break
+			}
+			if probe == nil {
+				probe = scope.DegradedProbe
+				probeAgent = scope.Agent
+				continue
+			}
+			if scope.Agent != probeAgent {
+				probeOK = false
+				break
+			}
+		}
+		if probeOK && probe != nil {
 			obligationKey = key + "|" + cleanDir
-			degraded[obligationKey] = scope.DegradedProbe
+			degraded[obligationKey] = probe
 		}
 		byKey[obligationKey] = appendUniqueScopeRoot(byKey[obligationKey], cleanDir)
 	}

--- a/internal/sync/watch_backend.go
+++ b/internal/sync/watch_backend.go
@@ -1,13 +1,19 @@
 package sync
 
-import "slices"
+import (
+	"path/filepath"
+	"slices"
+
+	"go.kenn.io/agentsview/internal/parser"
+)
 
 // WatchScope identifies one configured provider root whose changes are covered
 // by a logical watcher root. A physical root may cover multiple configured
 // directories or providers, so registration must preserve every exact scope.
 type WatchScope struct {
-	Agent   string
-	SyncDir string
+	Agent         string
+	SyncDir       string
+	DegradedProbe parser.DegradedPollingStateProbe
 }
 
 // WatchRoot is one desired logical watcher root. Exists describes startup
@@ -18,6 +24,56 @@ type WatchRoot struct {
 	Recursive bool
 	Exists    bool
 	Scopes    []WatchScope
+}
+
+func pollingObligationsForScopes(
+	key string,
+	probe string,
+	scopes []WatchScope,
+) []PollingObligation {
+	if len(scopes) == 0 {
+		return nil
+	}
+	byKey := make(map[string][]string)
+	degraded := make(map[string]parser.DegradedPollingStateProbe)
+	for _, scope := range scopes {
+		if scope.SyncDir == "" {
+			continue
+		}
+		cleanDir := filepath.Clean(scope.SyncDir)
+		obligationKey := key
+		if scope.DegradedProbe != nil {
+			obligationKey = key + "|" + cleanDir
+			degraded[obligationKey] = scope.DegradedProbe
+		}
+		byKey[obligationKey] = appendUniqueScopeRoot(byKey[obligationKey], cleanDir)
+	}
+	keys := make([]string, 0, len(byKey))
+	for obligationKey := range byKey {
+		keys = append(keys, obligationKey)
+	}
+	slices.Sort(keys)
+	obligations := make([]PollingObligation, 0, len(keys))
+	for _, obligationKey := range keys {
+		roots := byKey[obligationKey]
+		slices.Sort(roots)
+		obligations = append(obligations, PollingObligation{
+			Key:           obligationKey,
+			Roots:         roots,
+			Probe:         filepath.Clean(probe),
+			DegradedProbe: degraded[obligationKey],
+		})
+	}
+	return obligations
+}
+
+func appendUniqueScopeRoot(roots []string, root string) []string {
+	for _, existing := range roots {
+		if existing == root {
+			return roots
+		}
+	}
+	return append(roots, root)
 }
 
 // RegisterRoots passes the complete desired root plan to the watcher before

--- a/internal/sync/watch_backend_factory_darwin.go
+++ b/internal/sync/watch_backend_factory_darwin.go
@@ -48,8 +48,8 @@ const (
 // probe on the collapsed scope roots would let authoritative reconciliation
 // tombstone every session under the absent subtree.
 type darwinFallbackPollPlan struct {
-	path  string
-	roots []string
+	path   string
+	scopes []WatchScope
 }
 
 // darwinFallbackPollingObligationKey names the per-plan fallback obligation so
@@ -63,24 +63,36 @@ func darwinFallbackPollingObligationKey(path string) string {
 func appendFallbackPollPlan(
 	plans []darwinFallbackPollPlan, path string, scopes []WatchScope,
 ) []darwinFallbackPollPlan {
-	roots := appendWatchScopeRoots(nil, scopes)
-	if len(roots) == 0 {
+	if len(scopes) == 0 {
 		return plans
 	}
 	for i := range plans {
 		if plans[i].path == path {
-			merged := plans[i].roots
-			for _, root := range roots {
-				if !slices.Contains(merged, root) {
-					merged = append(merged, root)
+			merged := plans[i].scopes
+			for _, scope := range scopes {
+				duplicate := false
+				for _, existing := range merged {
+					if existing.SyncDir == scope.SyncDir &&
+						existing.DegradedProbe == scope.DegradedProbe {
+						duplicate = true
+						break
+					}
+				}
+				if !duplicate {
+					merged = append(merged, scope)
 				}
 			}
-			slices.Sort(merged)
-			plans[i].roots = merged
+			slices.SortFunc(merged, func(a, b WatchScope) int {
+				return strings.Compare(a.SyncDir, b.SyncDir)
+			})
+			plans[i].scopes = merged
 			return plans
 		}
 	}
-	plans = append(plans, darwinFallbackPollPlan{path: path, roots: roots})
+	plans = append(plans, darwinFallbackPollPlan{
+		path:   path,
+		scopes: append([]WatchScope(nil), scopes...),
+	})
 	slices.SortFunc(plans, func(a, b darwinFallbackPollPlan) int {
 		return strings.Compare(a.path, b.path)
 	})
@@ -1052,12 +1064,17 @@ func (b *darwinWatchBackend) requireRootPollingLocked(
 func (b *darwinWatchBackend) installRootPollingLocked(
 	state *darwinLogicalRoot,
 ) error {
-	roots := appendWatchScopeRoots(nil, state.plan.Scopes)
 	if b.onPollingRequired != nil {
-		return b.onPollingRequired(PollingObligation{
-			Key: state.plan.Path, Roots: roots, Probe: state.plan.Path,
-		})
+		for _, obligation := range pollingObligationsForScopes(
+			state.plan.Path, state.plan.Path, state.plan.Scopes,
+		) {
+			if err := b.onPollingRequired(obligation); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
+	roots := appendWatchScopeRoots(nil, state.plan.Scopes)
 	if b.onCoverageDegraded != nil {
 		return b.onCoverageDegraded(roots)
 	}
@@ -1250,12 +1267,14 @@ func (b *darwinWatchBackend) requireFallbackPolling(
 	b.mu.Unlock()
 	if required != nil {
 		for _, plan := range plans {
-			if err := required(PollingObligation{
-				Key:   darwinFallbackPollingObligationKey(plan.path),
-				Roots: plan.roots,
-				Probe: plan.path,
-			}); err != nil {
-				return err
+			for _, obligation := range pollingObligationsForScopes(
+				darwinFallbackPollingObligationKey(plan.path),
+				plan.path,
+				plan.scopes,
+			) {
+				if err := required(obligation); err != nil {
+					return err
+				}
 			}
 		}
 		b.mu.Lock()
@@ -1273,7 +1292,7 @@ func (b *darwinWatchBackend) requireFallbackPolling(
 		// absent.
 		var roots []string
 		for _, plan := range plans {
-			for _, root := range plan.roots {
+			for _, root := range appendWatchScopeRoots(nil, plan.scopes) {
 				if !slices.Contains(roots, root) {
 					roots = append(roots, root)
 				}

--- a/internal/sync/watch_backend_factory_darwin.go
+++ b/internal/sync/watch_backend_factory_darwin.go
@@ -960,7 +960,11 @@ func (b *darwinWatchBackend) processLifecycle(checkPending bool) {
 			b.rootTransitions.Inc()
 			state.open.Store(true)
 			b.resetRetryLocked(state)
-			releasedPolling = append(releasedPolling, state.plan.Path)
+			for _, obligation := range pollingObligationsForScopes(
+				state.plan.Path, state.plan.Path, state.plan.Scopes,
+			) {
+				releasedPolling = append(releasedPolling, obligation.Key)
+			}
 		}
 		if state.phase == darwinRootActivationCollecting {
 			if b.retryDueLocked(state, now) {
@@ -1515,13 +1519,18 @@ func (b *darwinWatchBackend) processNativeRecoveryHandoff() {
 
 	if pollingOwned && pollingKeyed && release != nil {
 		for _, plan := range releasePlans {
-			key := darwinFallbackPollingObligationKey(plan.path)
-			if err := release(key); err != nil {
-				b.mu.Lock()
-				b.reportErrorLocked(fmt.Errorf("release fallback polling: %w", err))
-				b.scheduleFallbackRetryLocked(time.Now())
-				b.mu.Unlock()
-				return
+			for _, obligation := range pollingObligationsForScopes(
+				darwinFallbackPollingObligationKey(plan.path),
+				plan.path,
+				plan.scopes,
+			) {
+				if err := release(obligation.Key); err != nil {
+					b.mu.Lock()
+					b.reportErrorLocked(fmt.Errorf("release fallback polling: %w", err))
+					b.scheduleFallbackRetryLocked(time.Now())
+					b.mu.Unlock()
+					return
+				}
 			}
 		}
 	}

--- a/internal/sync/watch_backend_factory_darwin.go
+++ b/internal/sync/watch_backend_factory_darwin.go
@@ -72,8 +72,8 @@ func appendFallbackPollPlan(
 			for _, scope := range scopes {
 				duplicate := false
 				for _, existing := range merged {
-					if existing.SyncDir == scope.SyncDir &&
-						existing.DegradedProbe == scope.DegradedProbe {
+					if existing.Agent == scope.Agent &&
+						existing.SyncDir == scope.SyncDir {
 						duplicate = true
 						break
 					}

--- a/internal/sync/watch_backend_fsnotify.go
+++ b/internal/sync/watch_backend_fsnotify.go
@@ -30,7 +30,7 @@ type fsnotifyBackend struct {
 	watchOwners       map[string]map[string]struct{}
 	watchBudgetCost   map[string]int
 	runtimeBudget     int
-	rootScopes        map[string][]string
+	rootScopes        map[string][]WatchScope
 	degradedRoots     map[string]struct{}
 	onPollingRequired func(PollingObligation) error
 	lifecycleMu       sync.Mutex
@@ -67,7 +67,7 @@ func newFSNotifyBackend(excludes []string) (*fsnotifyBackend, error) {
 		excludes:        normalizeExcludePatterns(excludes),
 		watchOwners:     make(map[string]map[string]struct{}),
 		watchBudgetCost: make(map[string]int),
-		rootScopes:      make(map[string][]string),
+		rootScopes:      make(map[string][]WatchScope),
 		degradedRoots:   make(map[string]struct{}),
 		stop:            make(chan struct{}),
 		done:            make(chan struct{}),
@@ -134,16 +134,10 @@ func (b *fsnotifyBackend) AddRecursive(root string, budget int) RecursiveWatchRe
 func (b *fsnotifyBackend) setWatchRootPlan(roots []WatchRoot) {
 	b.watchMu.Lock()
 	defer b.watchMu.Unlock()
-	b.rootScopes = make(map[string][]string, len(roots))
+	b.rootScopes = make(map[string][]WatchScope, len(roots))
 	for _, root := range roots {
 		path := filepath.Clean(root.Path)
-		for _, scope := range root.Scopes {
-			if scope.SyncDir != "" {
-				b.rootScopes[path] = append(b.rootScopes[path], scope.SyncDir)
-			}
-		}
-		slices.Sort(b.rootScopes[path])
-		b.rootScopes[path] = slices.Compact(b.rootScopes[path])
+		b.rootScopes[path] = append([]WatchScope(nil), root.Scopes...)
 	}
 }
 
@@ -493,10 +487,10 @@ func (b *fsnotifyBackend) requireRuntimePolling(roots []string) {
 			continue
 		}
 		required := b.onPollingRequired
-		scopes := append([]string(nil), b.rootScopes[root]...)
+		scopes := append([]WatchScope(nil), b.rootScopes[root]...)
 		b.watchMu.Unlock()
 		if len(scopes) == 0 {
-			scopes = []string{root}
+			scopes = []WatchScope{{SyncDir: root}}
 		}
 		if required == nil {
 			b.reportError(fmt.Errorf(
@@ -504,17 +498,20 @@ func (b *fsnotifyBackend) requireRuntimePolling(roots []string) {
 			))
 			continue
 		}
-		if err := required(PollingObligation{
-			Key: "fsnotify-runtime:" + root, Roots: scopes, Probe: root,
-		}); err != nil {
-			b.reportError(fmt.Errorf(
-				"transfer fsnotify coverage for %s to polling: %w", root, err,
-			))
-			continue
+		for _, obligation := range pollingObligationsForScopes(
+			"fsnotify-runtime:"+root, root, scopes,
+		) {
+			if err := required(obligation); err != nil {
+				b.reportError(fmt.Errorf(
+					"transfer fsnotify coverage for %s to polling: %w", root, err,
+				))
+				goto nextRoot
+			}
 		}
 		b.watchMu.Lock()
 		b.degradedRoots[root] = struct{}{}
 		b.watchMu.Unlock()
+	nextRoot:
 	}
 }
 

--- a/internal/sync/watch_backend_fsnotify_test.go
+++ b/internal/sync/watch_backend_fsnotify_test.go
@@ -18,6 +18,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type testDegradedProbe struct{}
+
+func (testDegradedProbe) DegradedPollingState(context.Context) (string, error) {
+	return "stable", nil
+}
+
 func testFSNotifyBackend(t *testing.T) *fsnotifyBackend {
 	t.Helper()
 	backend, err := newFSNotifyBackend(nil)
@@ -291,6 +297,52 @@ func TestFSNotifyBackendRootLossTransfersExactScopeToPolling(t *testing.T) {
 	assert.Equal(t, "fsnotify-runtime:"+root, obligation.Key)
 	assert.Equal(t, []string{syncDir}, obligation.Roots)
 	assert.Empty(t, backend.watcher.WatchList())
+}
+
+func TestFSNotifyBackendRootLossPreservesDegradedProbePerScope(t *testing.T) {
+	backend := testFSNotifyBackend(t)
+	root := t.TempDir()
+	openCodeDir := filepath.Join(root, "opencode")
+	unsupportedDir := filepath.Join(root, "kilo")
+	polling := make(chan PollingObligation, 2)
+	watcher, err := newWatcherWithBackendOptions(
+		0, 0, func(context.Context, WatchBatch) error { return nil },
+		backend, 8, 1_000,
+		WatcherOptions{OnPollingRequired: func(obligation PollingObligation) error {
+			polling <- obligation
+			return nil
+		}},
+	)
+	require.NoError(t, err)
+	results := watcher.RegisterRoots([]WatchRoot{{
+		Path: root, Recursive: true, Exists: true,
+		Scopes: []WatchScope{
+			{Agent: "opencode", SyncDir: openCodeDir, DegradedProbe: testDegradedProbe{}},
+			{Agent: "kilo", SyncDir: unsupportedDir},
+		},
+	}}, 2)
+	require.Len(t, results, 1)
+	require.Equal(t, 1, results[0].Watched)
+
+	_, relevant := backend.translateEvent(fsnotify.Event{
+		Name: root, Op: fsnotify.Remove,
+	})
+	require.True(t, relevant)
+	first := requireReceiveWithin(t, polling, time.Second)
+	second := requireReceiveWithin(t, polling, time.Second)
+	obligations := map[string]PollingObligation{
+		first.Key:  first,
+		second.Key: second,
+	}
+	require.Contains(t, obligations, "fsnotify-runtime:"+root)
+	require.Contains(t, obligations, "fsnotify-runtime:"+root+"|"+openCodeDir)
+	assert.Equal(t, []string{unsupportedDir},
+		obligations["fsnotify-runtime:"+root].Roots)
+	assert.Nil(t, obligations["fsnotify-runtime:"+root].DegradedProbe)
+	assert.Equal(t, []string{openCodeDir},
+		obligations["fsnotify-runtime:"+root+"|"+openCodeDir].Roots)
+	assert.NotNil(t,
+		obligations["fsnotify-runtime:"+root+"|"+openCodeDir].DegradedProbe)
 }
 
 func waitForBackendEvent(

--- a/internal/sync/watch_backend_fsnotify_test.go
+++ b/internal/sync/watch_backend_fsnotify_test.go
@@ -16,13 +16,9 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/parser"
 )
-
-type testDegradedProbe struct{}
-
-func (testDegradedProbe) DegradedPollingState(context.Context) (string, error) {
-	return "stable", nil
-}
 
 func testFSNotifyBackend(t *testing.T) *fsnotifyBackend {
 	t.Helper()
@@ -295,6 +291,7 @@ func TestFSNotifyBackendRootLossTransfersExactScopeToPolling(t *testing.T) {
 	assert.Equal(t, backendItemDirectory, event.ItemType)
 	obligation := requireReceiveWithin(t, polling, time.Second)
 	assert.Equal(t, "fsnotify-runtime:"+root, obligation.Key)
+	assert.Equal(t, parser.AgentClaude, obligation.Agent)
 	assert.Equal(t, []string{syncDir}, obligation.Roots)
 	assert.Empty(t, backend.watcher.WatchList())
 }
@@ -317,7 +314,7 @@ func TestFSNotifyBackendRootLossPreservesDegradedProbePerScope(t *testing.T) {
 	results := watcher.RegisterRoots([]WatchRoot{{
 		Path: root, Recursive: true, Exists: true,
 		Scopes: []WatchScope{
-			{Agent: "opencode", SyncDir: openCodeDir, DegradedProbe: testDegradedProbe{}},
+			{Agent: "opencode", SyncDir: openCodeDir},
 			{Agent: "kilo", SyncDir: unsupportedDir},
 		},
 	}}, 2)
@@ -334,15 +331,16 @@ func TestFSNotifyBackendRootLossPreservesDegradedProbePerScope(t *testing.T) {
 		first.Key:  first,
 		second.Key: second,
 	}
-	require.Contains(t, obligations, "fsnotify-runtime:"+root)
 	require.Contains(t, obligations, "fsnotify-runtime:"+root+"|"+openCodeDir)
-	assert.Equal(t, []string{unsupportedDir},
-		obligations["fsnotify-runtime:"+root].Roots)
-	assert.Nil(t, obligations["fsnotify-runtime:"+root].DegradedProbe)
+	require.Contains(t, obligations, "fsnotify-runtime:"+root+"|"+unsupportedDir)
 	assert.Equal(t, []string{openCodeDir},
 		obligations["fsnotify-runtime:"+root+"|"+openCodeDir].Roots)
-	assert.NotNil(t,
-		obligations["fsnotify-runtime:"+root+"|"+openCodeDir].DegradedProbe)
+	assert.Equal(t, parser.AgentOpenCode,
+		obligations["fsnotify-runtime:"+root+"|"+openCodeDir].Agent)
+	assert.Equal(t, []string{unsupportedDir},
+		obligations["fsnotify-runtime:"+root+"|"+unsupportedDir].Roots)
+	assert.Equal(t, parser.AgentKilo,
+		obligations["fsnotify-runtime:"+root+"|"+unsupportedDir].Agent)
 }
 
 func waitForBackendEvent(
@@ -437,12 +435,14 @@ func TestFSNotifyBackendRuntimeDegradationPreservesOverlappingRootScopes(t *test
 	assert.False(t, excluded)
 	first := requireReceiveWithin(t, polling, time.Second)
 	second := requireReceiveWithin(t, polling, time.Second)
-	obligations := map[string][]string{
-		first.Key:  first.Roots,
-		second.Key: second.Roots,
+	obligations := map[string]PollingObligation{
+		first.Key:  first,
+		second.Key: second,
 	}
-	assert.Equal(t, []string{parentScope}, obligations["fsnotify-runtime:"+parent])
-	assert.Equal(t, []string{nestedScope}, obligations["fsnotify-runtime:"+nested])
+	assert.Equal(t, []string{parentScope}, obligations["fsnotify-runtime:"+parent].Roots)
+	assert.Equal(t, parser.AgentClaude, obligations["fsnotify-runtime:"+parent].Agent)
+	assert.Equal(t, []string{nestedScope}, obligations["fsnotify-runtime:"+nested].Roots)
+	assert.Equal(t, parser.AgentCursor, obligations["fsnotify-runtime:"+nested].Agent)
 }
 
 func TestFSNotifyBackendRuntimeCreateRecursivelyWatchesMovedSubtree(t *testing.T) {

--- a/internal/sync/watch_backend_test.go
+++ b/internal/sync/watch_backend_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.kenn.io/agentsview/internal/parser"
 )
 
 func TestPollingObligationsForScopesDisableProbeForSharedDirMixedProviders(t *testing.T) {
@@ -14,7 +15,7 @@ func TestPollingObligationsForScopesDisableProbeForSharedDirMixedProviders(t *te
 		"watch-root",
 		dir,
 		[]WatchScope{
-			{Agent: "opencode", SyncDir: dir, DegradedProbe: testDegradedProbe{}},
+			{Agent: "opencode", SyncDir: dir},
 			{Agent: "kilo", SyncDir: dir},
 		},
 	)
@@ -22,6 +23,24 @@ func TestPollingObligationsForScopesDisableProbeForSharedDirMixedProviders(t *te
 	require.Len(t, got, 1)
 	assert.Equal(t, PollingObligation{
 		Key:   "watch-root",
+		Roots: []string{dir},
+		Probe: dir,
+	}, got[0])
+}
+
+func TestPollingObligationsForScopesPreserveAgentForSingleScope(t *testing.T) {
+	dir := t.TempDir()
+
+	got := pollingObligationsForScopes(
+		"watch-root",
+		dir,
+		[]WatchScope{{Agent: string(parser.AgentOpenCode), SyncDir: dir}},
+	)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, PollingObligation{
+		Key:   "watch-root",
+		Agent: parser.AgentOpenCode,
 		Roots: []string{dir},
 		Probe: dir,
 	}, got[0])

--- a/internal/sync/watch_backend_test.go
+++ b/internal/sync/watch_backend_test.go
@@ -1,0 +1,28 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPollingObligationsForScopesDisableProbeForSharedDirMixedProviders(t *testing.T) {
+	dir := t.TempDir()
+
+	got := pollingObligationsForScopes(
+		"watch-root",
+		dir,
+		[]WatchScope{
+			{Agent: "opencode", SyncDir: dir, DegradedProbe: testDegradedProbe{}},
+			{Agent: "kilo", SyncDir: dir},
+		},
+	)
+
+	require.Len(t, got, 1)
+	assert.Equal(t, PollingObligation{
+		Key:   "watch-root",
+		Roots: []string{dir},
+		Probe: dir,
+	}, got[0])
+}

--- a/internal/sync/watcher.go
+++ b/internal/sync/watcher.go
@@ -82,6 +82,11 @@ type PollingObligation struct {
 	// subtree holds every session, tombstoning all of them. Empty means the
 	// Roots themselves are the physical paths to probe.
 	Probe string
+	// Agent preserves provider ownership for obligations that belong to one
+	// provider, so degraded polling can reconcile them without cross-provider
+	// expansion. Empty means the obligation spans mixed providers and must use
+	// generic root reconciliation.
+	Agent parser.AgentType
 	// DegradedProbe is an additive provider-owned freshness probe for degraded
 	// polling. Equal consecutive states suppress authoritative reconciliation
 	// for this obligation's Roots on that tick.

--- a/internal/sync/watcher.go
+++ b/internal/sync/watcher.go
@@ -13,6 +13,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"go.kenn.io/agentsview/internal/parser"
 )
 
 type RecursiveWatchResult struct {
@@ -80,6 +82,10 @@ type PollingObligation struct {
 	// subtree holds every session, tombstoning all of them. Empty means the
 	// Roots themselves are the physical paths to probe.
 	Probe string
+	// DegradedProbe is an additive provider-owned freshness probe for degraded
+	// polling. Equal consecutive states suppress authoritative reconciliation
+	// for this obligation's Roots on that tick.
+	DegradedProbe parser.DegradedPollingStateProbe
 }
 
 // WatcherOptions configures runtime ownership handoffs that are not needed by

--- a/internal/sync/watcher.go
+++ b/internal/sync/watcher.go
@@ -87,10 +87,6 @@ type PollingObligation struct {
 	// expansion. Empty means the obligation spans mixed providers and must use
 	// generic root reconciliation.
 	Agent parser.AgentType
-	// DegradedProbe is an additive provider-owned freshness probe for degraded
-	// polling. Equal consecutive states suppress authoritative reconciliation
-	// for this obligation's Roots on that tick.
-	DegradedProbe parser.DegradedPollingStateProbe
 }
 
 // WatcherOptions configures runtime ownership handoffs that are not needed by

--- a/internal/sync/watcher_darwin_test.go
+++ b/internal/sync/watcher_darwin_test.go
@@ -1571,6 +1571,54 @@ func TestDarwinWatcherFallbackKeepsPollingUntilNativeRetrySucceeds(t *testing.T)
 	assert.Equal(t, int32(3), attempts.Load())
 }
 
+func TestDarwinWatcherFallbackPreservesDegradedProbePerScope(t *testing.T) {
+	root := t.TempDir()
+	backend, err := newDarwinWatchBackend(nil, 20*time.Millisecond)
+	require.NoError(t, err)
+	polling := make(chan PollingObligation, 2)
+	watcher, err := newWatcherWithBackendOptions(
+		0, 0, func(context.Context, WatchBatch) error { return nil }, backend,
+		defaultWatchBatchMaxEntries, defaultWatchBatchMaxPathBytes,
+		WatcherOptions{
+			OnPollingRequired: func(obligation PollingObligation) error {
+				polling <- obligation
+				return nil
+			},
+		},
+	)
+	require.NoError(t, err)
+	t.Cleanup(watcher.Stop)
+	openCodeDir := filepath.Join(root, "opencode")
+	unsupportedDir := filepath.Join(root, "kilo")
+	results := watcher.RegisterRoots([]WatchRoot{{
+		Path: root, Recursive: true, Exists: true,
+		Scopes: []WatchScope{
+			{Agent: "opencode", SyncDir: openCodeDir, DegradedProbe: testDegradedProbe{}},
+			{Agent: "kilo", SyncDir: unsupportedDir},
+		},
+	}}, 10)
+	require.Equal(t, []RecursiveWatchResult{{Watched: 1}}, results)
+	require.NoError(t, watcher.Start())
+
+	backend.requestFallback(darwinFallbackNativeDrop)
+	first := requireReceiveWithin(t, polling, time.Second)
+	second := requireReceiveWithin(t, polling, time.Second)
+	obligations := map[string]PollingObligation{
+		first.Key:  first,
+		second.Key: second,
+	}
+	require.Contains(t, obligations, darwinFallbackPollingObligationKey(root))
+	require.Contains(t,
+		obligations, darwinFallbackPollingObligationKey(root)+"|"+openCodeDir)
+	assert.Equal(t, []string{unsupportedDir},
+		obligations[darwinFallbackPollingObligationKey(root)].Roots)
+	assert.Nil(t, obligations[darwinFallbackPollingObligationKey(root)].DegradedProbe)
+	assert.Equal(t, []string{openCodeDir},
+		obligations[darwinFallbackPollingObligationKey(root)+"|"+openCodeDir].Roots)
+	assert.NotNil(t,
+		obligations[darwinFallbackPollingObligationKey(root)+"|"+openCodeDir].DegradedProbe)
+}
+
 // TestDarwinWatcherStopDuringRecoveryReleaseDoesNotPanic stops the watcher
 // while the recovery handoff is inside its polling-release callback, which
 // runs with the backend mutex released. The lifecycle goroutine reports the

--- a/internal/sync/watcher_darwin_test.go
+++ b/internal/sync/watcher_darwin_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"go.kenn.io/agentsview/internal/fsevents"
+	"go.kenn.io/agentsview/internal/parser"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/internal/sync/watcher_darwin_test.go
+++ b/internal/sync/watcher_darwin_test.go
@@ -1593,7 +1593,7 @@ func TestDarwinWatcherFallbackPreservesDegradedProbePerScope(t *testing.T) {
 	results := watcher.RegisterRoots([]WatchRoot{{
 		Path: root, Recursive: true, Exists: true,
 		Scopes: []WatchScope{
-			{Agent: "opencode", SyncDir: openCodeDir, DegradedProbe: testDegradedProbe{}},
+			{Agent: "opencode", SyncDir: openCodeDir},
 			{Agent: "kilo", SyncDir: unsupportedDir},
 		},
 	}}, 10)
@@ -1607,16 +1607,18 @@ func TestDarwinWatcherFallbackPreservesDegradedProbePerScope(t *testing.T) {
 		first.Key:  first,
 		second.Key: second,
 	}
-	require.Contains(t, obligations, darwinFallbackPollingObligationKey(root))
 	require.Contains(t,
 		obligations, darwinFallbackPollingObligationKey(root)+"|"+openCodeDir)
-	assert.Equal(t, []string{unsupportedDir},
-		obligations[darwinFallbackPollingObligationKey(root)].Roots)
-	assert.Nil(t, obligations[darwinFallbackPollingObligationKey(root)].DegradedProbe)
+	require.Contains(t,
+		obligations, darwinFallbackPollingObligationKey(root)+"|"+unsupportedDir)
 	assert.Equal(t, []string{openCodeDir},
 		obligations[darwinFallbackPollingObligationKey(root)+"|"+openCodeDir].Roots)
-	assert.NotNil(t,
-		obligations[darwinFallbackPollingObligationKey(root)+"|"+openCodeDir].DegradedProbe)
+	assert.Equal(t, parser.AgentOpenCode,
+		obligations[darwinFallbackPollingObligationKey(root)+"|"+openCodeDir].Agent)
+	assert.Equal(t, []string{unsupportedDir},
+		obligations[darwinFallbackPollingObligationKey(root)+"|"+unsupportedDir].Roots)
+	assert.Equal(t, parser.AgentKilo,
+		obligations[darwinFallbackPollingObligationKey(root)+"|"+unsupportedDir].Agent)
 }
 
 // TestDarwinWatcherStopDuringRecoveryReleaseDoesNotPanic stops the watcher


### PR DESCRIPTION
Degraded polling now retains provider-owned watch scopes end to end. Persistent polling reasons carry their originating watch scopes, so a shared configured dir keeps a single complete owner when one exists and falls back to generic only for mixed or incomplete ownership. Provider-scoped polling reconciles only the exact selected configured roots, which keeps an unchanged nested OpenCode scope suppressed while a changed parent scope still syncs through the existing provider path.

One predicate now answers whether a pass reaches a configured root, and both discovery admission and tombstone accounting call it. A provider-scoped pass therefore reports only the roots it actually selected as covered, so a session relocated into a configured nested root the pass did not select is not read as deleted; that tombstone waits for a pass covering every configured root. Descendant scopes a pass excludes are excluded by the ownership query rather than after its rows are paged, so a small selected scope no longer does work proportional to a large unselected nested archive.

Each provider-owned directory carries its own polling obligation once a reason covers more than one, matching what the runtime watcher fallback already did. One obligation carries one probe, so a probe no longer answers for a directory it never observed. Obligation keys are namespaced by the reason that created them, which keeps two reasons on the same root distinct without either having to be split per directory to tell them apart.

The group-scoped acknowledgement reset from the prior rebuild stays intact, and every eligible polling group still runs in deterministic order. The bounded journal change feed remains deferred to a follow-up for issue #1208.

Part of #1208
