### PR TITLE
fix(test): filter recall evidence log capture to recall lines

### DIFF
--- a/internal/db/recall_evidence_window_test.go
+++ b/internal/db/recall_evidence_window_test.go
@@ -1189,9 +1189,27 @@ func requireRecallEntry(t *testing.T, d *DB, id string) *RecallEntry {
 	return entry
 }
 
-func captureRecallEvidenceLog(t *testing.T) *bytes.Buffer {
+// recallEvidenceLogBuffer keeps only "recall: " prefixed lines written to the
+// global logger while installed, discarding unrelated lines — e.g. the
+// "db: <Op> ..." slow-op diagnostics gated on slowOpThreshold — so a
+// coincidentally slow operation (coverage instrumentation, a loaded CI
+// runner) cannot pollute the exact-equality assertions on revocation lines.
+// The stdlib log package with flags and prefix cleared issues exactly one
+// Write call per formatted line, so matching the prefix per Write is exact.
+type recallEvidenceLogBuffer struct {
+	bytes.Buffer
+}
+
+func (b *recallEvidenceLogBuffer) Write(p []byte) (int, error) {
+	if bytes.HasPrefix(p, []byte("recall: ")) {
+		return b.Buffer.Write(p)
+	}
+	return len(p), nil
+}
+
+func captureRecallEvidenceLog(t *testing.T) *recallEvidenceLogBuffer {
 	t.Helper()
-	var output bytes.Buffer
+	var output recallEvidenceLogBuffer
 	previousWriter := log.Writer()
 	previousFlags := log.Flags()
 	previousPrefix := log.Prefix()
@@ -1204,4 +1222,17 @@ func captureRecallEvidenceLog(t *testing.T) *bytes.Buffer {
 		log.SetPrefix(previousPrefix)
 	})
 	return &output
+}
+
+func TestRecallEvidenceLogCaptureIgnoresUnrelatedLines(t *testing.T) {
+	logs := captureRecallEvidenceLog(t)
+
+	log.Printf("db: ReplaceSessionMessages s1 (3 msgs): 180ms")
+	log.Printf("recall: revoked provenance for entry-1: missing digest")
+
+	assert.Equal(
+		t,
+		"recall: revoked provenance for entry-1: missing digest",
+		strings.TrimSpace(logs.String()),
+	)
 }


### PR DESCRIPTION
The seven recall-evidence tests in `internal/db/recall_evidence_window_test.go` capture the global `log` output via `captureRecallEvidenceLog` and assert on the whole buffer — mostly exact-equality against a single expected `recall: revoked provenance ...` line, plus two empty-buffer checks on rollback paths. That is stricter than the tests' intent: any unrelated line written to the global logger inside the capture window fails them.

One such line exists in practice: `ReplaceSessionMessages` logs a `db: ReplaceSessionMessages ...` diagnostic when the call exceeds `slowOpThreshold` (100ms). Under the coverage job's instrumentation the call crossed the threshold and the diagnostic landed in the captured buffer, failing `TestRecallEvidenceReconciliationLogsStableReason/missing_digest` on an unrelated PR (run 30135996204).

This change filters at the capture point instead of loosening assertions: `captureRecallEvidenceLog` now returns a writer that retains only `recall: `-prefixed lines (the only prefix the revocation flush emits) and discards everything else. Since the writer embeds `bytes.Buffer`, all seven call sites — `String()`, `Reset()`, the `assert.Empty` checks — are unchanged, and the exact-equality assertions keep their full strength for recall lines specifically. A small regression test replays the pollution scenario directly.

The slow-op diagnostics themselves are intentional production instrumentation and are untouched. Other log-capture helpers in the repo (`cmd/agentsview`, `internal/config`, `internal/parser`, `internal/duckdb`) already use substring/count-based assertions and are not affected by this failure mode, so they are deliberately left alone.

Reviewers should look at the `recallEvidenceLogBuffer.Write` prefix check: it relies on the stdlib `log` package issuing one `Write` per formatted line, which holds because the helper clears flags and prefix while installed.