### PR TITLE
Route trusted Linux builds to managed runners

### DIFF
--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -1,7 +1,8 @@
 name: Bench Gate
 
-# Fork PRs use GitHub-hosted runners. Same-repository PRs call the
-# main-branch workflow, whose Linux jobs can use the managed public fleet.
+# The PR dispatcher always calls the main-pinned workflow. That workflow
+# independently routes same-repository Linux jobs to the managed public fleet
+# and fork jobs to GitHub-hosted runners.
 on:
   pull_request:
     # Docs/frontend-only PRs cannot change the gated Go paths. If
@@ -14,25 +15,10 @@ on:
       - "Makefile"
       - ".github/workflows/bench.yml"
       - ".github/workflows/bench-pr.yml"
-  pull_request_target:
-    # Docs/frontend-only PRs cannot change the gated Go paths. If
-    # this check is ever made required on branch protection, pair it
-    # with a no-op sibling workflow on the inverse paths.
-    paths:
-      - "**.go"
-      - "go.mod"
-      - "go.sum"
-      - "Makefile"
-      - ".github/workflows/bench.yml"
-      - ".github/workflows/bench-pr.yml"
-
 permissions: read-all
 
 jobs:
   run:
-    if: >-
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) ||
-      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository)
     uses: kenn-io/agentsview/.github/workflows/bench.yml@main
     with:
       checkout_ref: refs/pull/${{ github.event.pull_request.number }}/merge

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -1,0 +1,38 @@
+name: Bench Gate
+
+# Fork PRs use GitHub-hosted runners. Same-repository PRs call the
+# main-branch workflow, whose Linux jobs can use the managed public fleet.
+on:
+  pull_request:
+    # Docs/frontend-only PRs cannot change the gated Go paths. If
+    # this check is ever made required on branch protection, pair it
+    # with a no-op sibling workflow on the inverse paths.
+    paths:
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+      - "Makefile"
+      - ".github/workflows/bench.yml"
+      - ".github/workflows/bench-pr.yml"
+  pull_request_target:
+    # Docs/frontend-only PRs cannot change the gated Go paths. If
+    # this check is ever made required on branch protection, pair it
+    # with a no-op sibling workflow on the inverse paths.
+    paths:
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+      - "Makefile"
+      - ".github/workflows/bench.yml"
+      - ".github/workflows/bench-pr.yml"
+
+permissions: read-all
+
+jobs:
+  run:
+    if: >-
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository)
+    uses: kenn-io/agentsview/.github/workflows/bench.yml@main
+    with:
+      checkout_ref: refs/pull/${{ github.event.pull_request.number }}/merge

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -45,7 +45,7 @@ permissions:
 jobs:
   bench-gate:
     name: Benchmark Gate
-    runs-on: ${{ (github.event_name == 'pull_request_target' || github.ref == 'refs/heads/main') && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
+    runs-on: ${{ (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -28,17 +28,13 @@ name: Bench Gate
 # produced still gate) rather than silently disabling the whole gate.
 
 on:
-  pull_request:
-    # Docs/frontend-only PRs cannot change the gated Go paths. If
-    # this check is ever made required on branch protection, pair it
-    # with a no-op sibling workflow on the inverse paths.
-    paths:
-      - "**.go"
-      - "go.mod"
-      - "go.sum"
-      - "Makefile"
-      - ".github/workflows/bench.yml"
-
+  workflow_call:
+    inputs:
+      checkout_ref:
+        description: Git ref to check out
+        required: false
+        type: string
+        default: ""
 concurrency:
   group: bench-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
@@ -49,10 +45,11 @@ permissions:
 jobs:
   bench-gate:
     name: Benchmark Gate
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request_target' || github.ref == 'refs/heads/main') && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          ref: ${{ inputs.checkout_ref || github.sha }}
           persist-credentials: false
           fetch-depth: 0
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,20 +1,15 @@
 name: CI
 
-# Fork PRs use GitHub-hosted runners. Same-repository PRs call the
-# main-branch workflow, whose Linux jobs can use the managed public fleet.
+# The PR dispatcher always calls the main-pinned workflow. That workflow
+# independently routes same-repository Linux jobs to the managed public fleet
+# and fork jobs to GitHub-hosted runners.
 on:
   pull_request:
-
-  pull_request_target:
-
 
 permissions: read-all
 
 jobs:
   run:
-    if: >-
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) ||
-      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository)
     uses: kenn-io/agentsview/.github/workflows/ci.yml@main
     with:
       checkout_ref: refs/pull/${{ github.event.pull_request.number }}/merge

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,0 +1,20 @@
+name: CI
+
+# Fork PRs use GitHub-hosted runners. Same-repository PRs call the
+# main-branch workflow, whose Linux jobs can use the managed public fleet.
+on:
+  pull_request:
+
+  pull_request_target:
+
+
+permissions: read-all
+
+jobs:
+  run:
+    if: >-
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository)
+    uses: kenn-io/agentsview/.github/workflows/ci.yml@main
+    with:
+      checkout_ref: refs/pull/${{ github.event.pull_request.number }}/merge

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,19 @@
 name: CI
 
 on:
+  workflow_call:
+    inputs:
+      checkout_ref:
+        description: Git ref to check out
+        required: false
+        type: string
+        default: ""
   push:
     branches: [main]
   # Run on every pull request regardless of base branch so stacked PRs that
   # target another feature branch (not just main) still get the full test,
   # lint, and e2e suite. The expensive desktop/tauri bundle builds are gated
   # to main separately in desktop-artifacts.yml.
-  pull_request:
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
@@ -18,10 +23,11 @@ permissions:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request_target' || github.ref == 'refs/heads/main') && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          ref: ${{ inputs.checkout_ref || github.sha }}
           persist-credentials: false
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
@@ -37,10 +43,11 @@ jobs:
         run: make lint-ci
 
   frontend:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request_target' || github.ref == 'refs/heads/main') && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          ref: ${{ inputs.checkout_ref || github.sha }}
           persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -67,10 +74,11 @@ jobs:
         working-directory: frontend
 
   frontend-node-25:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request_target' || github.ref == 'refs/heads/main') && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          ref: ${{ inputs.checkout_ref || github.sha }}
           persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -86,10 +94,11 @@ jobs:
         working-directory: frontend
 
   docs:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request_target' || github.ref == 'refs/heads/main') && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          ref: ${{ inputs.checkout_ref || github.sha }}
           persist-credentials: false
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
@@ -108,10 +117,11 @@ jobs:
         run: make docs-check
 
   scripts:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request_target' || github.ref == 'refs/heads/main') && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          ref: ${{ inputs.checkout_ref || github.sha }}
           persist-credentials: false
 
       - name: Run shell script tests
@@ -124,7 +134,7 @@ jobs:
 
   test:
     name: Go Test (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ contains(fromJSON('["ubuntu-latest","ubuntu-24.04","ubuntu-22.04"]'), matrix.os) && (github.event_name == 'pull_request_target' || github.ref == 'refs/heads/main') && 'kenn-linux-x64-public' || matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -132,6 +142,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          ref: ${{ inputs.checkout_ref || github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -185,6 +196,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          ref: ${{ inputs.checkout_ref || github.sha }}
           persist-credentials: false
 
       - name: Prepare placeholder sidecar resource
@@ -215,10 +227,11 @@ jobs:
         run: cargo test --locked --manifest-path desktop/src-tauri/Cargo.toml --lib install_downloaded_update
 
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request_target' || github.ref == 'refs/heads/main') && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          ref: ${{ inputs.checkout_ref || github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -246,7 +259,7 @@ jobs:
         run: echo "::warning::Codecov upload failed"
 
   integration:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request_target' || github.ref == 'refs/heads/main') && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     services:
       postgres:
         image: pgvector/pgvector:pg18
@@ -264,6 +277,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          ref: ${{ inputs.checkout_ref || github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -312,10 +326,11 @@ jobs:
           TEST_SSH_KEY: ${{ github.workspace }}/testdata/ssh/test_key
 
   e2e:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request_target' || github.ref == 'refs/heads/main') && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          ref: ${{ inputs.checkout_ref || github.sha }}
           fetch-depth: 0
           persist-credentials: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: ${{ (github.event_name == 'pull_request_target' || github.ref == 'refs/heads/main') && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
+    runs-on: ${{ (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
@@ -43,7 +43,7 @@ jobs:
         run: make lint-ci
 
   frontend:
-    runs-on: ${{ (github.event_name == 'pull_request_target' || github.ref == 'refs/heads/main') && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
+    runs-on: ${{ (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
@@ -74,7 +74,7 @@ jobs:
         working-directory: frontend
 
   frontend-node-25:
-    runs-on: ${{ (github.event_name == 'pull_request_target' || github.ref == 'refs/heads/main') && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
+    runs-on: ${{ (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
@@ -94,7 +94,7 @@ jobs:
         working-directory: frontend
 
   docs:
-    runs-on: ${{ (github.event_name == 'pull_request_target' || github.ref == 'refs/heads/main') && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
+    runs-on: ${{ (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
@@ -117,7 +117,7 @@ jobs:
         run: make docs-check
 
   scripts:
-    runs-on: ${{ (github.event_name == 'pull_request_target' || github.ref == 'refs/heads/main') && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
+    runs-on: ${{ (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
@@ -134,7 +134,7 @@ jobs:
 
   test:
     name: Go Test (${{ matrix.os }})
-    runs-on: ${{ contains(fromJSON('["ubuntu-latest","ubuntu-24.04","ubuntu-22.04"]'), matrix.os) && (github.event_name == 'pull_request_target' || github.ref == 'refs/heads/main') && 'kenn-linux-x64-public' || matrix.os }}
+    runs-on: ${{ contains(fromJSON('["ubuntu-latest","ubuntu-24.04","ubuntu-22.04"]'), matrix.os) && (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -227,7 +227,7 @@ jobs:
         run: cargo test --locked --manifest-path desktop/src-tauri/Cargo.toml --lib install_downloaded_update
 
   coverage:
-    runs-on: ${{ (github.event_name == 'pull_request_target' || github.ref == 'refs/heads/main') && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
+    runs-on: ${{ (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
@@ -259,7 +259,7 @@ jobs:
         run: echo "::warning::Codecov upload failed"
 
   integration:
-    runs-on: ${{ (github.event_name == 'pull_request_target' || github.ref == 'refs/heads/main') && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
+    runs-on: ${{ (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     services:
       postgres:
         image: pgvector/pgvector:pg18
@@ -326,7 +326,7 @@ jobs:
           TEST_SSH_KEY: ${{ github.workspace }}/testdata/ssh/test_key
 
   e2e:
-    runs-on: ${{ (github.event_name == 'pull_request_target' || github.ref == 'refs/heads/main') && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
+    runs-on: ${{ (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:

--- a/.github/workflows/desktop-artifacts-pr.yml
+++ b/.github/workflows/desktop-artifacts-pr.yml
@@ -1,7 +1,8 @@
 name: Desktop Artifacts
 
-# Fork PRs use GitHub-hosted runners. Same-repository PRs call the
-# main-branch workflow, whose Linux jobs can use the managed public fleet.
+# The PR dispatcher always calls the main-pinned workflow. That workflow
+# independently routes same-repository Linux jobs to the managed public fleet
+# and fork jobs to GitHub-hosted runners.
 on:
   pull_request:
     branches: [main]
@@ -13,24 +14,10 @@ on:
       - '.github/workflows/desktop-artifacts.yml'
       - '.github/actions/build-desktop-artifact/**'
       - '.github/workflows/desktop-artifacts-pr.yml'
-  pull_request_target:
-    branches: [main]
-    paths:
-      - 'desktop/**'
-      - 'frontend/**'
-      - 'go.mod'
-      - 'go.sum'
-      - '.github/workflows/desktop-artifacts.yml'
-      - '.github/actions/build-desktop-artifact/**'
-      - '.github/workflows/desktop-artifacts-pr.yml'
-
 permissions: read-all
 
 jobs:
   run:
-    if: >-
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) ||
-      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository)
     uses: kenn-io/agentsview/.github/workflows/desktop-artifacts.yml@main
     with:
       checkout_ref: refs/pull/${{ github.event.pull_request.number }}/merge

--- a/.github/workflows/desktop-artifacts-pr.yml
+++ b/.github/workflows/desktop-artifacts-pr.yml
@@ -1,0 +1,36 @@
+name: Desktop Artifacts
+
+# Fork PRs use GitHub-hosted runners. Same-repository PRs call the
+# main-branch workflow, whose Linux jobs can use the managed public fleet.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'desktop/**'
+      - 'frontend/**'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/desktop-artifacts.yml'
+      - '.github/actions/build-desktop-artifact/**'
+      - '.github/workflows/desktop-artifacts-pr.yml'
+  pull_request_target:
+    branches: [main]
+    paths:
+      - 'desktop/**'
+      - 'frontend/**'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/desktop-artifacts.yml'
+      - '.github/actions/build-desktop-artifact/**'
+      - '.github/workflows/desktop-artifacts-pr.yml'
+
+permissions: read-all
+
+jobs:
+  run:
+    if: >-
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository)
+    uses: kenn-io/agentsview/.github/workflows/desktop-artifacts.yml@main
+    with:
+      checkout_ref: refs/pull/${{ github.event.pull_request.number }}/merge

--- a/.github/workflows/desktop-artifacts.yml
+++ b/.github/workflows/desktop-artifacts.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   build:
     name: Desktop Build (${{ matrix.name }})
-    runs-on: ${{ contains(fromJSON('["ubuntu-latest","ubuntu-24.04","ubuntu-22.04"]'), matrix.os) && (github.event_name == 'pull_request_target' || github.ref == 'refs/heads/main') && 'kenn-linux-x64-public' || matrix.os }}
+    runs-on: ${{ contains(fromJSON('["ubuntu-latest","ubuntu-24.04","ubuntu-22.04"]'), matrix.os) && (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || matrix.os }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/desktop-artifacts.yml
+++ b/.github/workflows/desktop-artifacts.yml
@@ -1,8 +1,15 @@
 name: Desktop Artifacts
 
 on:
-  # Keep this workflow GitHub-hosted so pull requests cannot select a
-  # persistent runner. macOS builds live in desktop-macos-main.yml.
+  workflow_call:
+    inputs:
+      checkout_ref:
+        description: Git ref to check out
+        required: false
+        type: string
+        default: ""
+  # Linux builds use the managed public fleet for main and same-repository PRs.
+  # macOS builds live in desktop-macos-main.yml.
   push:
     branches: [main]
     paths:
@@ -12,16 +19,6 @@ on:
       - 'go.sum'
       - '.github/workflows/desktop-artifacts.yml'
       - '.github/actions/build-desktop-artifact/**'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'desktop/**'
-      - 'frontend/**'
-      - 'go.mod'
-      - 'go.sum'
-      - '.github/workflows/desktop-artifacts.yml'
-      - '.github/actions/build-desktop-artifact/**'
-
 permissions:
   contents: read
 
@@ -32,7 +29,7 @@ concurrency:
 jobs:
   build:
     name: Desktop Build (${{ matrix.name }})
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ contains(fromJSON('["ubuntu-latest","ubuntu-24.04","ubuntu-22.04"]'), matrix.os) && (github.event_name == 'pull_request_target' || github.ref == 'refs/heads/main') && 'kenn-linux-x64-public' || matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -58,6 +55,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          ref: ${{ inputs.checkout_ref || github.sha }}
           persist-credentials: false
 
       - uses: ./.github/actions/build-desktop-artifact

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.ref == 'refs/heads/main' && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:


### PR DESCRIPTION
Same-repository pull-request branches are controlled by repository collaborators and should use organization-managed Linux capacity. Fork pull requests remain arbitrary code—even when the author is an organization member—and must continue to use GitHub-hosted runners.

Each PR now triggers only `pull_request`, so required checks are associated with the current PR revision. The dispatcher calls a main-pinned reusable workflow, and that immutable workflow independently requires both the head and base repositories to equal `github.repository` before selecting the managed public fleet. The caller supplies no runner or trust input.

The organization runner policy restricts access to the exact main-branch reusable workflows. Main pushes use the managed Linux fleet; Windows, macOS, ARM Linux, tags, and fork PRs retain their hosted runners.