### PR TITLE
Bind trusted runner routing to canonical PR revisions

### DIFF
--- a/.github/actions/build-desktop-artifact/action.yml
+++ b/.github/actions/build-desktop-artifact/action.yml
@@ -26,6 +26,8 @@ runs:
       with:
         node-version: "24"
 
+    - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4  # stable
+
     - name: Setup MinGW (Windows)
       if: runner.os == 'Windows'
       uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884  # v2

--- a/.github/actions/build-desktop-artifact/action.yml
+++ b/.github/actions/build-desktop-artifact/action.yml
@@ -75,7 +75,7 @@ runs:
         cd desktop
         export TAURI_ENV_TARGET_TRIPLE="$AGENTSVIEW_TARGET_TRIPLE"
         npm run prepare-sidecar
-        build_cmd=(npx tauri build --bundles "$BUNDLE")
+        build_cmd=(npx tauri build --verbose --bundles "$BUNDLE")
         if [ -n "$AGENTSVIEW_TARGET_TRIPLE" ]; then
           build_cmd+=(--target "$AGENTSVIEW_TARGET_TRIPLE")
         fi

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -21,4 +21,4 @@ jobs:
   run:
     uses: kenn-io/agentsview/.github/workflows/bench.yml@main
     with:
-      checkout_ref: refs/pull/${{ github.event.pull_request.number }}/merge
+      checkout_ref: ${{ github.sha }}

--- a/.github/workflows/bench-pr.yml
+++ b/.github/workflows/bench-pr.yml
@@ -20,5 +20,3 @@ permissions: read-all
 jobs:
   run:
     uses: kenn-io/agentsview/.github/workflows/bench.yml@main
-    with:
-      checkout_ref: ${{ github.sha }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -29,12 +29,6 @@ name: Bench Gate
 
 on:
   workflow_call:
-    inputs:
-      checkout_ref:
-        description: Git ref to check out
-        required: false
-        type: string
-        default: ""
 concurrency:
   group: bench-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
@@ -49,7 +43,6 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          ref: ${{ inputs.checkout_ref || github.sha }}
           persist-credentials: false
           fetch-depth: 0
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -45,7 +45,7 @@ permissions:
 jobs:
   bench-gate:
     name: Benchmark Gate
-    runs-on: ${{ (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'kenn-io/agentsview' && (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -12,4 +12,4 @@ jobs:
   run:
     uses: kenn-io/agentsview/.github/workflows/ci.yml@main
     with:
-      checkout_ref: refs/pull/${{ github.event.pull_request.number }}/merge
+      checkout_ref: ${{ github.sha }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -11,5 +11,3 @@ permissions: read-all
 jobs:
   run:
     uses: kenn-io/agentsview/.github/workflows/ci.yml@main
-    with:
-      checkout_ref: ${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: ${{ (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'kenn-io/agentsview' && (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
@@ -43,7 +43,7 @@ jobs:
         run: make lint-ci
 
   frontend:
-    runs-on: ${{ (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'kenn-io/agentsview' && (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
@@ -74,7 +74,7 @@ jobs:
         working-directory: frontend
 
   frontend-node-25:
-    runs-on: ${{ (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'kenn-io/agentsview' && (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
@@ -94,7 +94,7 @@ jobs:
         working-directory: frontend
 
   docs:
-    runs-on: ${{ (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'kenn-io/agentsview' && (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
@@ -117,7 +117,7 @@ jobs:
         run: make docs-check
 
   scripts:
-    runs-on: ${{ (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'kenn-io/agentsview' && (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
@@ -134,7 +134,7 @@ jobs:
 
   test:
     name: Go Test (${{ matrix.os }})
-    runs-on: ${{ contains(fromJSON('["ubuntu-latest","ubuntu-24.04","ubuntu-22.04"]'), matrix.os) && (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || matrix.os }}
+    runs-on: ${{ contains(fromJSON('["ubuntu-latest","ubuntu-24.04","ubuntu-22.04"]'), matrix.os) && github.repository == 'kenn-io/agentsview' && (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -227,7 +227,7 @@ jobs:
         run: cargo test --locked --manifest-path desktop/src-tauri/Cargo.toml --lib install_downloaded_update
 
   coverage:
-    runs-on: ${{ (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'kenn-io/agentsview' && (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
@@ -259,7 +259,7 @@ jobs:
         run: echo "::warning::Codecov upload failed"
 
   integration:
-    runs-on: ${{ (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'kenn-io/agentsview' && (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     services:
       postgres:
         image: pgvector/pgvector:pg18
@@ -326,7 +326,7 @@ jobs:
           TEST_SSH_KEY: ${{ github.workspace }}/testdata/ssh/test_key
 
   e2e:
-    runs-on: ${{ (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'kenn-io/agentsview' && (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,6 @@ name: CI
 
 on:
   workflow_call:
-    inputs:
-      checkout_ref:
-        description: Git ref to check out
-        required: false
-        type: string
-        default: ""
   push:
     branches: [main]
   # Run on every pull request regardless of base branch so stacked PRs that
@@ -27,7 +21,6 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          ref: ${{ inputs.checkout_ref || github.sha }}
           persist-credentials: false
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
@@ -47,7 +40,6 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          ref: ${{ inputs.checkout_ref || github.sha }}
           persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -78,7 +70,6 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          ref: ${{ inputs.checkout_ref || github.sha }}
           persist-credentials: false
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
@@ -98,7 +89,6 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          ref: ${{ inputs.checkout_ref || github.sha }}
           persist-credentials: false
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
@@ -121,7 +111,6 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          ref: ${{ inputs.checkout_ref || github.sha }}
           persist-credentials: false
 
       - name: Run shell script tests
@@ -142,7 +131,6 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          ref: ${{ inputs.checkout_ref || github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -196,7 +184,6 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          ref: ${{ inputs.checkout_ref || github.sha }}
           persist-credentials: false
 
       - name: Prepare placeholder sidecar resource
@@ -231,7 +218,6 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          ref: ${{ inputs.checkout_ref || github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -277,7 +263,6 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          ref: ${{ inputs.checkout_ref || github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -330,7 +315,6 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          ref: ${{ inputs.checkout_ref || github.sha }}
           fetch-depth: 0
           persist-credentials: false
 

--- a/.github/workflows/desktop-artifacts-pr.yml
+++ b/.github/workflows/desktop-artifacts-pr.yml
@@ -19,5 +19,3 @@ permissions: read-all
 jobs:
   run:
     uses: kenn-io/agentsview/.github/workflows/desktop-artifacts.yml@main
-    with:
-      checkout_ref: ${{ github.sha }}

--- a/.github/workflows/desktop-artifacts-pr.yml
+++ b/.github/workflows/desktop-artifacts-pr.yml
@@ -20,4 +20,4 @@ jobs:
   run:
     uses: kenn-io/agentsview/.github/workflows/desktop-artifacts.yml@main
     with:
-      checkout_ref: refs/pull/${{ github.event.pull_request.number }}/merge
+      checkout_ref: ${{ github.sha }}

--- a/.github/workflows/desktop-artifacts.yml
+++ b/.github/workflows/desktop-artifacts.yml
@@ -2,12 +2,6 @@ name: Desktop Artifacts
 
 on:
   workflow_call:
-    inputs:
-      checkout_ref:
-        description: Git ref to check out
-        required: false
-        type: string
-        default: ""
   # Linux builds use the managed public fleet for main and same-repository PRs.
   # macOS builds live in desktop-macos-main.yml.
   push:
@@ -55,7 +49,6 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          ref: ${{ inputs.checkout_ref || github.sha }}
           persist-credentials: false
 
       - uses: ./.github/actions/build-desktop-artifact

--- a/.github/workflows/desktop-artifacts.yml
+++ b/.github/workflows/desktop-artifacts.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   build:
     name: Desktop Build (${{ matrix.name }})
-    runs-on: ${{ contains(fromJSON('["ubuntu-latest","ubuntu-24.04","ubuntu-22.04"]'), matrix.os) && (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || matrix.os }}
+    runs-on: ${{ contains(fromJSON('["ubuntu-latest","ubuntu-24.04","ubuntu-22.04"]'), matrix.os) && github.repository == 'kenn-io/agentsview' && (github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.base.repo.full_name == github.repository)) && 'kenn-linux-x64-public' || matrix.os }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: ${{ github.ref == 'refs/heads/main' && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
+    runs-on: ${{ github.repository == 'kenn-io/agentsview' && github.ref == 'refs/heads/main' && 'kenn-linux-x64-public' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -5,6 +5,7 @@ const isCI = process.env.CI === "true";
 export default defineConfig({
   testDir: "e2e",
   timeout: isCI ? 45_000 : 20_000,
+  workers: isCI ? 8 : undefined,
   retries: 0,
   use: {
     baseURL: "http://127.0.0.1:8090",

--- a/internal/sync/change_time_test.go
+++ b/internal/sync/change_time_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,14 +21,22 @@ func TestFileChangeTimeDetectsSameStatRewrite(t *testing.T) {
 	beforeChange, ok := fileChangeTime(path, beforeInfo)
 	require.True(t, ok, "native change time unavailable")
 
-	require.NoError(t, os.WriteFile(path, []byte("after!"), 0o600))
-	require.NoError(t, os.Chtimes(
-		path, beforeInfo.ModTime(), beforeInfo.ModTime(),
-	))
-	afterInfo, err := os.Stat(path)
-	require.NoError(t, err)
-	afterChange, ok := fileChangeTime(path, afterInfo)
-	require.True(t, ok, "native change time unavailable after rewrite")
+	var afterInfo os.FileInfo
+	afterChange := beforeChange
+	deadline := time.Now().Add(2 * time.Second)
+	for afterChange == beforeChange && time.Now().Before(deadline) {
+		require.NoError(t, os.WriteFile(path, []byte("after!"), 0o600))
+		require.NoError(t, os.Chtimes(
+			path, beforeInfo.ModTime(), beforeInfo.ModTime(),
+		))
+		afterInfo, err = os.Stat(path)
+		require.NoError(t, err)
+		afterChange, ok = fileChangeTime(path, afterInfo)
+		require.True(t, ok, "native change time unavailable after rewrite")
+		if afterChange == beforeChange {
+			time.Sleep(time.Millisecond)
+		}
+	}
 
 	require.Equal(t, beforeInfo.Size(), afterInfo.Size(),
 		"fixture must preserve size")


### PR DESCRIPTION
Trusted Linux jobs should select the managed runner only when the workflow is executing in the canonical repository. Fork-local events must remain on GitHub-hosted labels even when their branch and repository identities match each other.

The PR dispatchers call main-pinned reusable workflows without runner, trust, or checkout inputs. Those workflows independently derive trust from the canonical head and base repository identities, while checkout uses the immutable SHA GitHub associated with the caller event.

The managed image is intentionally lean, so the desktop composite explicitly installs a commit-pinned stable Rust toolchain instead of relying on hosted-image defaults. Playwright CI is bounded to eight workers because the host exposes more logical CPUs than each runner pod requests.

The coverage fixture now waits for the filesystem to expose a new change-time tick before asserting same-size rewrite detection, avoiding false failures on fast overlay filesystems without weakening the signature assertion.