### PR TITLE
fix(cli): expand leading tilde in DuckDB mirror paths

### DIFF
--- a/cmd/agentsview/duckdb.go
+++ b/cmd/agentsview/duckdb.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.kenn.io/agentsview/internal/config"
 	duckdbsync "go.kenn.io/agentsview/internal/duckdb"
+	"go.kenn.io/agentsview/internal/pathutil"
 	"go.kenn.io/agentsview/internal/server"
 )
 
@@ -515,7 +516,10 @@ func runDuckDBQuackServe(cfg DuckDBQuackServeConfig) {
 		fatal("duckdb quack serve: %v", err)
 	}
 	if cfg.Path != "" {
-		duckCfg.Path = cfg.Path
+		duckCfg.Path, err = pathutil.ExpandHome(cfg.Path)
+		if err != nil {
+			fatal("duckdb quack serve: expanding --path: %v", err)
+		}
 	}
 	if cfg.AllowInsecure {
 		duckCfg.AllowInsecure = true

--- a/cmd/agentsview/import.go
+++ b/cmd/agentsview/import.go
@@ -11,6 +11,7 @@ import (
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
 	"go.kenn.io/agentsview/internal/importer"
+	"go.kenn.io/agentsview/internal/pathutil"
 )
 
 type ImportConfig struct {
@@ -19,6 +20,12 @@ type ImportConfig struct {
 }
 
 func runImport(cfg ImportConfig) {
+	expandedPath, err := pathutil.ExpandHome(cfg.Path)
+	if err != nil {
+		log.Fatalf("expanding import path: %v", err)
+	}
+	cfg.Path = expandedPath
+
 	appCfg, err := config.LoadMinimal()
 	if err != nil {
 		log.Fatalf("loading config: %v", err)

--- a/cmd/agentsview/recall.go
+++ b/cmd/agentsview/recall.go
@@ -15,6 +15,7 @@ import (
 
 	"go.kenn.io/agentsview/internal/config"
 	"go.kenn.io/agentsview/internal/db"
+	"go.kenn.io/agentsview/internal/pathutil"
 	corerecall "go.kenn.io/agentsview/internal/recall"
 	"go.kenn.io/agentsview/internal/service"
 )
@@ -912,7 +913,11 @@ func newRecallImportCommand() *cobra.Command {
 					return err
 				}
 			}
-			f, err := os.Open(args[0])
+			path, err := pathutil.ExpandHome(args[0])
+			if err != nil {
+				return fmt.Errorf("expanding recall import path: %w", err)
+			}
+			f, err := os.Open(path)
 			if err != nil {
 				return fmt.Errorf("opening recall import file: %w", err)
 			}
@@ -1050,7 +1055,7 @@ func addRecallFilterFlags(cmd *cobra.Command, f *service.RecallFilter) {
 	flags := cmd.Flags()
 	flags.StringVar(&f.Query, "query", "", "Filter by query text")
 	flags.StringVar(&f.Project, "project", "", "Filter by project")
-	flags.StringVar(&f.CWD, "cwd", "", "Filter by cwd")
+	flags.Var(&homePathValue{value: &f.CWD}, "cwd", "Filter by cwd")
 	flags.StringVar(&f.GitBranch, "git-branch", "", "Filter by git branch")
 	flags.StringVar(&f.Agent, "agent", "", "Filter by agent")
 	flags.StringVar(&f.Type, "type", "", "Filter by recall type")
@@ -1100,6 +1105,28 @@ func addRecallFilterFlags(cmd *cobra.Command, f *service.RecallFilter) {
 	)
 	flags.IntVar(&f.Limit, "limit", 0, "Maximum entries to return")
 }
+
+type homePathValue struct {
+	value *string
+}
+
+func (v *homePathValue) Set(path string) error {
+	expanded, err := pathutil.ExpandHome(path)
+	if err != nil {
+		return err
+	}
+	*v.value = expanded
+	return nil
+}
+
+func (v *homePathValue) String() string {
+	if v == nil || v.value == nil {
+		return ""
+	}
+	return *v.value
+}
+
+func (*homePathValue) Type() string { return "path" }
 
 func addRecallEntryCurrentCWDFlag(cmd *cobra.Command, currentCWD *bool) {
 	cmd.Flags().BoolVar(
@@ -1238,7 +1265,7 @@ func addRecallQueryFlags(cmd *cobra.Command, req *service.RecallQuery) {
 		"Retrieval mode: lexical, vector, or hybrid",
 	)
 	flags.StringVar(&req.Project, "project", "", "Filter by project")
-	flags.StringVar(&req.CWD, "cwd", "", "Filter by cwd")
+	flags.Var(&homePathValue{value: &req.CWD}, "cwd", "Filter by cwd")
 	flags.StringVar(&req.GitBranch, "git-branch", "", "Filter by git branch")
 	flags.StringVar(&req.Agent, "agent", "", "Filter by agent")
 	flags.StringVar(&req.Type, "type", "", "Filter by recall type")

--- a/cmd/agentsview/recall_test.go
+++ b/cmd/agentsview/recall_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -21,6 +22,18 @@ import (
 	corerecall "go.kenn.io/agentsview/internal/recall"
 	"go.kenn.io/agentsview/internal/service"
 )
+
+func TestRecallCWDFlagExpandsHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	var filter service.RecallFilter
+	cmd := &cobra.Command{Use: "test"}
+	addRecallFilterFlags(cmd, &filter)
+
+	require.NoError(t, cmd.Flags().Parse([]string{"--cwd", "~/work"}))
+	assert.Equal(t, filepath.Join(home, "work"), filter.CWD)
+}
 
 func TestPrintRecallEntryReviewLineDefaultsReviewStateToUnreviewedAuto(
 	t *testing.T,

--- a/cmd/agentsview/session.go
+++ b/cmd/agentsview/session.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"go.kenn.io/agentsview/internal/config"
+	"go.kenn.io/agentsview/internal/pathutil"
 	"go.kenn.io/agentsview/internal/service"
 	"go.kenn.io/agentsview/internal/timeutil"
 )
@@ -219,6 +220,10 @@ func explicitServerToken(cmd *cobra.Command) (string, error) {
 	}
 	path, err := cmd.Flags().GetString("server-token-file")
 	if err == nil && strings.TrimSpace(path) != "" {
+		path, err = pathutil.ExpandHome(path)
+		if err != nil {
+			return "", fmt.Errorf("expanding --server-token-file: %w", err)
+		}
 		b, err := os.ReadFile(path)
 		if err != nil {
 			return "", fmt.Errorf("reading --server-token-file: %w", err)

--- a/cmd/agentsview/session_test.go
+++ b/cmd/agentsview/session_test.go
@@ -1518,6 +1518,31 @@ func TestSessionUsage_ServerTokenSendsBearer(t *testing.T) {
 	require.NotNil(t, out)
 }
 
+func TestSessionUsage_ServerTokenFileExpandsHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	tokenFile := filepath.Join(home, "remote-token")
+	require.NoError(t, os.WriteFile(
+		tokenFile, []byte("remote-secret\n"), 0o600,
+	))
+
+	ts, _ := newRemoteUsageServer(t, remoteUsageSpec{
+		canonicalID:   "remote-session",
+		bearer:        "remote-secret",
+		serverRunning: true,
+	})
+
+	cmd := sessionUsageCommand(t,
+		"session", "usage", "remote-session",
+		"--server", ts.URL,
+		"--server-token-file", "~/remote-token")
+
+	out, _, err := sessionUsageDataForCommand(cmd, "remote-session")
+	require.NoError(t, err)
+	require.NotNil(t, out)
+}
+
 func TestSessionUsage_ServerHTTPClientHasTimeout(t *testing.T) {
 	oldClient := sessionUsageHTTPClient
 	sessionUsageHTTPClient = &http.Client{Timeout: 20 * time.Millisecond}

--- a/cmd/agentsview/sync_profile.go
+++ b/cmd/agentsview/sync_profile.go
@@ -9,6 +9,8 @@ import (
 	"runtime/pprof"
 	"runtime/trace"
 	"slices"
+
+	"go.kenn.io/agentsview/internal/pathutil"
 )
 
 // startSyncProfile starts whichever of the hidden --cpuprofile,
@@ -19,6 +21,9 @@ import (
 // profiling typo never aborts a real sync.
 func startSyncProfile(cfg SyncConfig) func() {
 	var stoppers []func()
+	cfg.CPUProfile = expandSyncProfilePath("cpuprofile", cfg.CPUProfile)
+	cfg.MemProfile = expandSyncProfilePath("memprofile", cfg.MemProfile)
+	cfg.Trace = expandSyncProfilePath("trace", cfg.Trace)
 
 	if cfg.CPUProfile != "" {
 		f, err := os.Create(cfg.CPUProfile)
@@ -80,4 +85,13 @@ func startSyncProfile(cfg SyncConfig) func() {
 			stop()
 		}
 	}
+}
+
+func expandSyncProfilePath(name, path string) string {
+	expanded, err := pathutil.ExpandHome(path)
+	if err != nil {
+		log.Printf("%s: expand path: %v", name, err)
+		return ""
+	}
+	return expanded
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2347,6 +2347,10 @@ func (c *Config) ResolveDuckDB() (DuckDBConfig, error) {
 		if err != nil {
 			return duck, fmt.Errorf("expanding path: %w", err)
 		}
+		expanded, err = expandLeadingTilde(expanded)
+		if err != nil {
+			return duck, fmt.Errorf("expanding path: %w", err)
+		}
 		duck.Path = expanded
 	}
 	if duck.URL != "" {
@@ -2374,6 +2378,23 @@ func (c *Config) ResolveDuckDB() (DuckDBConfig, error) {
 		duck.MachineName = h
 	}
 	return duck, nil
+}
+
+func expandLeadingTilde(path string) (string, error) {
+	if path == "" || path[0] != '~' {
+		return path, nil
+	}
+	if len(path) > 1 && path[1] != '/' && path[1] != '\\' {
+		return path, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("determining home directory: %w", err)
+	}
+	if path == "~" {
+		return home, nil
+	}
+	return filepath.Join(home, filepath.FromSlash(path[2:])), nil
 }
 
 var (

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gofrs/flock"
 	"github.com/spf13/pflag"
 	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/pathutil"
 )
 
 // TerminalConfig holds terminal launch preferences.
@@ -843,6 +844,9 @@ func loadPGServeBase() (Config, error) {
 		return cfg, err
 	}
 	cfg.loadEnv()
+	if err := expandDataDir(&cfg); err != nil {
+		return cfg, err
+	}
 	if err := cfg.loadFile(); err != nil {
 		return cfg, fmt.Errorf("loading config file: %w", err)
 	}
@@ -875,6 +879,9 @@ func LoadMinimal() (Config, error) {
 		return cfg, err
 	}
 	cfg.loadEnv()
+	if err := expandDataDir(&cfg); err != nil {
+		return cfg, err
+	}
 
 	if err := cfg.loadFile(); err != nil {
 		return cfg, fmt.Errorf("loading config file: %w", err)
@@ -898,6 +905,9 @@ func LoadReadOnly() (Config, error) {
 		return cfg, err
 	}
 	cfg.loadEnv()
+	if err := expandDataDir(&cfg); err != nil {
+		return cfg, err
+	}
 
 	if err := cfg.loadFileReadOnly(); err != nil {
 		return cfg, fmt.Errorf("loading config file: %w", err)
@@ -1700,6 +1710,9 @@ func splitFlagList(value string) []string {
 
 func finalize(cfg *Config) error {
 	var err error
+	if err := expandLocalPaths(cfg); err != nil {
+		return err
+	}
 	if strings.TrimSpace(cfg.LocalMachineName) == "" {
 		return fmt.Errorf("identify local sync machine: hostname is empty")
 	}
@@ -2082,6 +2095,9 @@ func ResolveDataDir() (string, error) {
 	if v := dataDirFromEnv(); v != "" {
 		cfg.DataDir = v
 	}
+	if err := expandDataDir(&cfg); err != nil {
+		return "", err
+	}
 	return cfg.DataDir, nil
 }
 
@@ -2347,7 +2363,7 @@ func (c *Config) ResolveDuckDB() (DuckDBConfig, error) {
 		if err != nil {
 			return duck, fmt.Errorf("expanding path: %w", err)
 		}
-		expanded, err = expandLeadingTilde(expanded)
+		expanded, err = pathutil.ExpandHome(expanded)
 		if err != nil {
 			return duck, fmt.Errorf("expanding path: %w", err)
 		}
@@ -2378,23 +2394,6 @@ func (c *Config) ResolveDuckDB() (DuckDBConfig, error) {
 		duck.MachineName = h
 	}
 	return duck, nil
-}
-
-func expandLeadingTilde(path string) (string, error) {
-	if path == "" || path[0] != '~' {
-		return path, nil
-	}
-	if len(path) > 1 && path[1] != '/' && path[1] != '\\' {
-		return path, nil
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("determining home directory: %w", err)
-	}
-	if path == "~" {
-		return home, nil
-	}
-	return filepath.Join(home, filepath.FromSlash(path[2:])), nil
 }
 
 var (

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2469,6 +2469,13 @@ func expandBracedEnv(s string) (string, error) {
 
 // SaveTerminalConfig persists terminal settings to the config file.
 func (c *Config) SaveTerminalConfig(tc TerminalConfig) error {
+	live := tc
+	expanded, err := pathutil.ExpandHome(live.CustomBin)
+	if err != nil {
+		return fmt.Errorf("expanding terminal custom binary: %w", err)
+	}
+	live.CustomBin = expanded
+
 	return c.withConfigLock(func() error {
 		existing, err := c.readConfigMap()
 		if err != nil {
@@ -2479,7 +2486,7 @@ func (c *Config) SaveTerminalConfig(tc TerminalConfig) error {
 		if err := c.writeConfigMap(existing); err != nil {
 			return err
 		}
-		c.Terminal = tc
+		c.Terminal = live
 		return nil
 	})
 }

--- a/internal/config/config_duckdb_tilde_test.go
+++ b/internal/config/config_duckdb_tilde_test.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveDuckDB_ExpandsLeadingTildePath(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	cfg := Config{
+		DuckDB: DuckDBConfig{
+			Path: "~/mirror.duckdb",
+		},
+	}
+
+	resolved, err := cfg.ResolveDuckDB()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, "mirror.duckdb"), resolved.Path)
+}
+
+func TestResolveDuckDB_DoesNotExpandMidStringTilde(t *testing.T) {
+	cfg := Config{
+		DuckDB: DuckDBConfig{
+			Path: "path/with~marker.duckdb",
+		},
+	}
+
+	resolved, err := cfg.ResolveDuckDB()
+	require.NoError(t, err)
+	assert.Equal(t, "path/with~marker.duckdb", resolved.Path)
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -932,6 +932,16 @@ func TestResolveDataDir_DefaultAndEnvOverride(t *testing.T) {
 	assert.Equal(t, custom, dir)
 }
 
+func TestResolveDataDir_ExpandsHome(t *testing.T) {
+	home := t.TempDir()
+	setTestHome(t, home)
+	t.Setenv("AGENTSVIEW_DATA_DIR", "~/agentsview-data")
+
+	dir, err := ResolveDataDir()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, "agentsview-data"), dir)
+}
+
 // TestDataDir_LegacyEnvFallback verifies that the legacy AGENT_VIEWER_DATA_DIR
 // env var still takes effect when the canonical AGENTSVIEW_DATA_DIR is unset,
 // and that the canonical name wins when both are set.
@@ -1837,6 +1847,49 @@ func TestLoadFile_SyncIncludeCwdPrefixesDefaultsEmpty(t *testing.T) {
 	cfg := f.LoadMinimal(t)
 
 	assert.Empty(t, cfg.SyncIncludeCwdPrefixes)
+}
+
+func TestLoadMinimal_ExpandsUserSuppliedLocalPaths(t *testing.T) {
+	home := t.TempDir()
+	setTestHome(t, home)
+	f := newConfigFixture(t)
+	f.WriteConfigText(t, `sync_include_cwd_prefixes = ["~/work"]
+codex_sessions_dirs = ["~/codex-sessions"]
+
+[duckdb]
+path = "~/sessions.duckdb"
+
+[vector]
+db_path = "~/vectors.db"
+
+[recall.extract.prompts]
+dir = "~/recall-prompts"
+
+[terminal]
+mode = "custom"
+custom_bin = "~/bin/terminal"
+
+[agent.codex]
+binary = "~/bin/codex"
+sandbox = "~/bin/sandbox"
+`)
+
+	cfg := f.LoadMinimal(t)
+
+	assert.Equal(t, []string{filepath.Join(home, "work")},
+		cfg.SyncIncludeCwdPrefixes)
+	assert.Equal(t, []string{filepath.Join(home, "codex-sessions")},
+		cfg.ResolveDirs(parser.AgentCodex))
+	assert.Equal(t, filepath.Join(home, "sessions.duckdb"), cfg.DuckDB.Path)
+	assert.Equal(t, filepath.Join(home, "vectors.db"), cfg.Vector.DBPath)
+	assert.Equal(t, filepath.Join(home, "recall-prompts"),
+		cfg.Recall.Extract.Prompts.Dir)
+	assert.Equal(t, filepath.Join(home, "bin", "terminal"),
+		cfg.Terminal.CustomBin)
+	assert.Equal(t, filepath.Join(home, "bin", "codex"),
+		cfg.Agent["codex"].Binary)
+	assert.Equal(t, filepath.Join(home, "bin", "sandbox"),
+		cfg.Agent["codex"].Sandbox)
 }
 
 func TestIsDefaultAgentsviewDBPath(t *testing.T) {

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"fmt"
+
+	"go.kenn.io/agentsview/internal/pathutil"
+)
+
+func expandDataDir(cfg *Config) error {
+	expanded, err := pathutil.ExpandHome(cfg.DataDir)
+	if err != nil {
+		return fmt.Errorf("expanding data directory: %w", err)
+	}
+	cfg.DataDir = expanded
+	return nil
+}
+
+func expandLocalPaths(cfg *Config) error {
+	expand := func(name string, value *string) error {
+		expanded, err := pathutil.ExpandHome(*value)
+		if err != nil {
+			return fmt.Errorf("expanding %s: %w", name, err)
+		}
+		*value = expanded
+		return nil
+	}
+	expandSlice := func(name string, values []string) error {
+		for i := range values {
+			if err := expand(name, &values[i]); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if err := expand("data directory", &cfg.DataDir); err != nil {
+		return err
+	}
+	fields := []struct {
+		name  string
+		value *string
+	}{
+		{"terminal custom binary", &cfg.Terminal.CustomBin},
+		{"proxy binary", &cfg.Proxy.Bin},
+		{"proxy TLS certificate", &cfg.Proxy.TLSCert},
+		{"proxy TLS key", &cfg.Proxy.TLSKey},
+		{"DuckDB path", &cfg.DuckDB.Path},
+		{"vector database path", &cfg.Vector.DBPath},
+		{"recall prompt directory", &cfg.Recall.Extract.Prompts.Dir},
+	}
+	for _, field := range fields {
+		if err := expand(field.name, field.value); err != nil {
+			return err
+		}
+	}
+	if err := expandSlice("sync cwd prefix", cfg.SyncIncludeCwdPrefixes); err != nil {
+		return err
+	}
+	for agent, dirs := range cfg.AgentDirs {
+		if err := expandSlice(fmt.Sprintf("%s session directory", agent), dirs); err != nil {
+			return err
+		}
+		cfg.AgentDirs[agent] = dirs
+	}
+	for name, agent := range cfg.Agent {
+		if err := expand(fmt.Sprintf("agent %s binary", name), &agent.Binary); err != nil {
+			return err
+		}
+		if err := expand(fmt.Sprintf("agent %s sandbox", name), &agent.Sandbox); err != nil {
+			return err
+		}
+		cfg.Agent[name] = agent
+	}
+	return nil
+}

--- a/internal/pathutil/home.go
+++ b/internal/pathutil/home.go
@@ -1,0 +1,28 @@
+// Package pathutil provides shared normalization for user-supplied local paths.
+package pathutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ExpandHome replaces a leading home shorthand ("~" or "~/") with the
+// current user's home directory. Named-user shorthands and tildes elsewhere
+// in the path are left unchanged.
+func ExpandHome(path string) (string, error) {
+	if path == "" || path[0] != '~' {
+		return path, nil
+	}
+	if len(path) > 1 && !os.IsPathSeparator(path[1]) {
+		return path, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("determining home directory: %w", err)
+	}
+	if path == "~" {
+		return home, nil
+	}
+	return filepath.Join(home, path[2:]), nil
+}

--- a/internal/pathutil/home_test.go
+++ b/internal/pathutil/home_test.go
@@ -1,0 +1,35 @@
+package pathutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpandHome(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "home", path: "~", want: home},
+		{name: "child", path: "~/nested/file", want: filepath.Join(home, "nested", "file")},
+		{name: "relative", path: "relative/path", want: "relative/path"},
+		{name: "mid-string tilde", path: "relative/~marker", want: "relative/~marker"},
+		{name: "named user", path: "~someone/file", want: "~someone/file"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ExpandHome(tt.path)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/server/huma_routes_config.go
+++ b/internal/server/huma_routes_config.go
@@ -146,6 +146,7 @@ func (s *Server) humaSetTerminalConfig(
 	}
 	s.mu.Lock()
 	err := s.cfg.SaveTerminalConfig(tc)
+	tc = s.cfg.Terminal
 	s.mu.Unlock()
 	if err != nil {
 		return nil, internalError("save terminal config", err)

--- a/internal/server/resume_handler_test.go
+++ b/internal/server/resume_handler_test.go
@@ -1090,3 +1090,43 @@ func TestGetTerminalConfig(t *testing.T) {
 		assertStatus(t, w, http.StatusBadRequest)
 	})
 }
+
+func TestSetTerminalConfigExpandsHomeBeforeImmediateResume(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test fixture uses a POSIX executable script")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	binDir := filepath.Join(home, "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(binDir, "test-terminal"),
+		[]byte("#!/bin/sh\nexit 0\n"),
+		0o755,
+	))
+
+	te := setup(t)
+	projectDir := t.TempDir()
+	te.seedSession(t, "live-terminal-config", projectDir, 1, func(s *db.Session) {
+		s.Agent = "claude"
+	})
+
+	w := te.post(t,
+		"/api/v1/config/terminal",
+		`{"mode":"custom","custom_bin":"~/bin/test-terminal"}`,
+	)
+	assertStatus(t, w, http.StatusOK)
+
+	w = te.post(t, "/api/v1/sessions/live-terminal-config/resume", `{}`)
+	assertStatus(t, w, http.StatusOK)
+	var resp struct {
+		Launched bool   `json:"launched"`
+		Terminal string `json:"terminal"`
+		Error    string `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.True(t, resp.Launched)
+	assert.Equal(t, "test-terminal", resp.Terminal)
+	assert.Empty(t, resp.Error)
+}


### PR DESCRIPTION
DuckDB config resolution currently leaves a leading `~` literal in `[duckdb].path`, so daemon-backed pushes can canonicalize the server mirror path against the daemon working directory instead of the user's home directory.

This expands leading-home shorthand during DuckDB config resolution, alongside the existing defaulting and env expansion, so the daemon and in-process callers resolve the same mirror path from the same config value. `${HOME}` expansion, default-path fallback, and non-leading tildes keep their current behavior. The change stays in `internal/config` with focused resolution regression coverage.

The config snippet and daemon-vs-in-process repro came from @halms's issue report.

Closes #1264
