### PR TITLE
fix(signals): treat raw terminal API errors as errored outcomes

### DIFF
--- a/internal/db/sessions.go
+++ b/internal/db/sessions.go
@@ -182,7 +182,7 @@ func scanSessionRow(rs rowScanner) (Session, error) {
 	return s, err
 }
 
-const CurrentQualitySignalVersion = 2
+const CurrentQualitySignalVersion = 3
 
 // QualitySignals groups persisted deterministic quality-signal
 // columns for API callers while keeping the database representation

--- a/internal/signals/outcome.go
+++ b/internal/signals/outcome.go
@@ -42,6 +42,13 @@ func ClassifyOutcome(in OutcomeInput) OutcomeResult {
 		return OutcomeResult{"unknown", "low", false}
 	}
 
+	if in.EndedWithRole == "assistant" && hasTerminalAPIErrorText(in.LastAssistantText) {
+		if isRecent(in.LastActivity) {
+			return OutcomeResult{"unknown", "low", true}
+		}
+		return OutcomeResult{"errored", "medium", false}
+	}
+
 	if in.MessageCount == 2 && in.EndedWithRole == "assistant" {
 		return OutcomeResult{"completed", "medium", false}
 	}
@@ -92,4 +99,9 @@ func hasGiveUpPattern(text string) bool {
 		}
 	}
 	return false
+}
+
+func hasTerminalAPIErrorText(text string) bool {
+	lower := strings.ToLower(strings.TrimSpace(text))
+	return strings.HasPrefix(lower, "api error:")
 }

--- a/internal/signals/outcome_terminal_api_error_test.go
+++ b/internal/signals/outcome_terminal_api_error_test.go
@@ -1,0 +1,78 @@
+package signals
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClassifyOutcome_TerminalRawAPIError(t *testing.T) {
+	got := ClassifyOutcome(OutcomeInput{
+		MessageCount:      4,
+		EndedWithRole:     "assistant",
+		LastAssistantText: "API Error: Unable to connect to API (ConnectionRefused)",
+		LastActivity:      time.Now().Add(-time.Hour),
+	})
+
+	assert.Equal(t, OutcomeResult{
+		Outcome:    "errored",
+		Confidence: "medium",
+	}, got)
+}
+
+func TestClassifyOutcome_TerminalRawAPIErrorTwoMessageSession(t *testing.T) {
+	got := ClassifyOutcome(OutcomeInput{
+		MessageCount:      2,
+		EndedWithRole:     "assistant",
+		LastAssistantText: "API Error: Unable to connect to API (ConnectionRefused)",
+		LastActivity:      time.Now().Add(-time.Hour),
+	})
+
+	assert.Equal(t, OutcomeResult{
+		Outcome:    "errored",
+		Confidence: "medium",
+	}, got)
+}
+
+func TestClassifyOutcome_TerminalRawAPIErrorSingleMessageSession(t *testing.T) {
+	got := ClassifyOutcome(OutcomeInput{
+		MessageCount:      1,
+		EndedWithRole:     "assistant",
+		LastAssistantText: "API Error: Unable to connect to API (ConnectionRefused)",
+		LastActivity:      time.Now().Add(-time.Hour),
+	})
+
+	assert.Equal(t, OutcomeResult{
+		Outcome:    "errored",
+		Confidence: "medium",
+	}, got)
+}
+
+func TestClassifyOutcome_TerminalRawAPIErrorFalsePositive(t *testing.T) {
+	got := ClassifyOutcome(OutcomeInput{
+		MessageCount:      4,
+		EndedWithRole:     "assistant",
+		LastAssistantText: "The final line was `API Error: Unable to connect to API`, but the retry succeeded and here is the answer.",
+		LastActivity:      time.Now().Add(-time.Hour),
+	})
+
+	assert.Equal(t, OutcomeResult{
+		Outcome:    "completed",
+		Confidence: "medium",
+	}, got)
+}
+
+func TestClassifyOutcome_RecentTwoMessageAssistantSessionStillCompleted(t *testing.T) {
+	got := ClassifyOutcome(OutcomeInput{
+		MessageCount:      2,
+		EndedWithRole:     "assistant",
+		LastAssistantText: "Here is the answer.",
+		LastActivity:      time.Now(),
+	})
+
+	assert.Equal(t, OutcomeResult{
+		Outcome:    "completed",
+		Confidence: "medium",
+	}, got)
+}

--- a/internal/sync/recompute_memory_test.go
+++ b/internal/sync/recompute_memory_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -112,6 +113,42 @@ func TestRecomputeSignalsDoesNotReleaseHeapDirectly(t *testing.T) {
 	require.NoError(t, fx.engine.RecomputeSignals(ctx, id))
 
 	assert.Zero(t, calls)
+}
+
+func TestBackfillSignalsRecomputesVersion2TerminalAPIErrorSession(t *testing.T) {
+	fx := newEngineFixture(t)
+	ctx := context.Background()
+	const id = "api-stale"
+	endedAt := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339Nano)
+
+	require.NoError(t, fx.db.UpsertSession(db.Session{
+		ID: id, Project: "proj", Machine: "m", Agent: "claude",
+		MessageCount: 2, UserMessageCount: 1, EndedAt: &endedAt,
+	}))
+	require.NoError(t, fx.db.ReplaceSessionMessages(id, []db.Message{
+		{SessionID: id, Ordinal: 0, Role: "user", Content: "hello"},
+		{
+			SessionID: id, Ordinal: 1, Role: "assistant",
+			Content: "API Error: Unable to connect to API (ConnectionRefused)",
+		},
+	}))
+	require.NoError(t, fx.db.UpdateSessionSignals(id, db.SessionSignalUpdate{
+		Outcome:           "completed",
+		OutcomeConfidence: "medium",
+		QualitySignals: db.QualitySignals{
+			Version: 2,
+		},
+	}))
+
+	require.NoError(t,
+		fx.db.BackfillSignals(ctx, fx.engine.BackfillSignalComputer()))
+
+	sess, err := fx.db.GetSessionFull(ctx, id)
+	require.NoError(t, err)
+	require.NotNil(t, sess)
+	assert.Equal(t, db.CurrentQualitySignalVersion, sess.QualitySignalVersion)
+	assert.Equal(t, "errored", sess.Outcome)
+	assert.Equal(t, "medium", sess.OutcomeConfidence)
 }
 
 func TestRecomputeHeapReleaserSkipsSmallSessions(t *testing.T) {


### PR DESCRIPTION
Outcome classification currently marks a session completed when its final assistant message is a raw unrecovered API error, because the assistant-ended branch only lowers confidence for give-up prose.

This adds a dedicated terminal API-error discriminator before the generic assistant-completed branch and leaves the rest of the outcome ladder intact. User-ended sessions, repeated failure streaks, give-up phrases, and normal assistant answers keep their current classifications. The change stays in `internal/signals` with focused outcome regression coverage.

The terminal transcript entry and local corpus check came from @godilley's issue report.

Closes #1269
