### PR TITLE
fix(vector): classify whitespace-only embedding rejections as permanent

### DIFF
--- a/internal/vector/encoder.go
+++ b/internal/vector/encoder.go
@@ -133,6 +133,9 @@ func hasDocumentSpecificEmbeddingError(body string) bool {
 	if strings.Contains(body, "content") && strings.Contains(body, "policy") {
 		return true
 	}
+	if describesEmptyEmbeddingInput(body) {
+		return true
+	}
 	overLimit := strings.Contains(body, "too long") ||
 		strings.Contains(body, "too large") ||
 		strings.Contains(body, "too many") ||
@@ -148,6 +151,15 @@ func hasDocumentSpecificEmbeddingError(body string) bool {
 		strings.Contains(body, "context") ||
 		strings.Contains(body, "input") ||
 		strings.Contains(body, "text")
+}
+
+func describesEmptyEmbeddingInput(body string) bool {
+	hasWhitespaceRejection := strings.Contains(body, "whitespace-only") ||
+		strings.Contains(body, "whitespace only")
+	if !hasWhitespaceRejection || !strings.Contains(body, "empty") {
+		return false
+	}
+	return strings.Contains(body, "embedding input")
 }
 
 // embeddingsRequestBody is the OpenAI-compatible embeddings request.

--- a/internal/vector/encoder_test.go
+++ b/internal/vector/encoder_test.go
@@ -786,6 +786,7 @@ func TestHTTPStatusErrorPermanentClassification(t *testing.T) {
 		{http.StatusBadRequest, "maximum context length is 8192 tokens", true},
 		{http.StatusRequestEntityTooLarge, "input too large", true},
 		{http.StatusUnprocessableEntity, "content policy violation", true},
+		{http.StatusBadRequest, "Invalid embedding input: Input strings must not be empty or whitespace-only", true},
 		{http.StatusBadRequest, "", false},
 		{http.StatusBadRequest, "no route", false},
 		{http.StatusBadRequest, "invalid token", false},

--- a/internal/vector/whitespace_embedding_rejection_test.go
+++ b/internal/vector/whitespace_embedding_rejection_test.go
@@ -1,0 +1,53 @@
+package vector
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWhitespaceOnlyEmbeddingInputIsPermanent(t *testing.T) {
+	err := &HTTPStatusError{
+		Status: http.StatusBadRequest,
+		Body:   `{"error":{"message":"Invalid embedding input: Input strings must not be empty or whitespace-only","type":"embedding_error"}}`,
+	}
+
+	assert.True(t, err.Permanent())
+}
+
+func TestSchemaValidationEmptyInputIsNotPermanent(t *testing.T) {
+	err := &HTTPStatusError{
+		Status: http.StatusBadRequest,
+		Body:   `{"error":{"message":"schema violation: input must be a non-empty string","type":"invalid_request_error"}}`,
+	}
+
+	assert.False(t, err.Permanent())
+}
+
+func TestWhitespaceOnlyModelValidationIsNotPermanent(t *testing.T) {
+	err := &HTTPStatusError{
+		Status: http.StatusBadRequest,
+		Body:   `{"error":{"message":"model must not be a whitespace-only string","type":"invalid_request_error"}}`,
+	}
+
+	assert.False(t, err.Permanent())
+}
+
+func TestWhitespaceOnlySchemaValidationIsNotPermanent(t *testing.T) {
+	err := &HTTPStatusError{
+		Status: http.StatusBadRequest,
+		Body:   `{"error":{"message":"schema validation: input string must not be empty or whitespace-only","type":"invalid_request_error"}}`,
+	}
+
+	assert.False(t, err.Permanent())
+}
+
+func TestWhitespaceOnlyEmbeddingErrorTypeIsNotPermanentWithoutInputContext(t *testing.T) {
+	err := &HTTPStatusError{
+		Status: http.StatusBadRequest,
+		Body:   `{"error":{"message":"model must not be empty or whitespace-only","type":"embedding_error"}}`,
+	}
+
+	assert.False(t, err.Permanent())
+}


### PR DESCRIPTION
Vector builds currently abort when the embeddings endpoint rejects one document as empty or whitespace-only, even though the same surface already skip-stamps other document-specific permanent rejections.

This extends the existing `hasDocumentSpecificEmbeddingError` classifier so whitespace-only input rejections route through the shipped permanent-error path instead of creating a second special case in the build loop. Token-window overflow and content-policy rejections keep skipping, while auth, routing, model, media-type, rate-limit, and server failures still abort the build. The change stays in `internal/vector` with focused classifier regression coverage.

The fatal error body and build symptom came from @jesserobbins's issue report.

Closes #1272
