### PR TITLE
refactor: drive sync and remote-sync policy from provider capabilities

### DIFF
--- a/internal/parser/aider_provider.go
+++ b/internal/parser/aider_provider.go
@@ -707,5 +707,8 @@ func aiderProviderCapabilities() Capabilities {
 			ToolResults:          CapabilitySupported,
 			PerMessageTokenUsage: CapabilitySupported,
 		},
+		Sync: ProviderSyncSemantics{
+			UnchangedResults: UnchangedResultMTimeAndHash,
+		},
 	}
 }

--- a/internal/parser/capabilities.go
+++ b/internal/parser/capabilities.go
@@ -21,6 +21,28 @@ const (
 type Capabilities struct {
 	Source  SourceCapabilities
 	Content ContentCapabilities
+	Sync    ProviderSyncSemantics
+}
+
+// UnchangedResultPolicy controls how the engine compares parsed members from a
+// shared source with their stored rows. The zero value keeps every result.
+type UnchangedResultPolicy uint8
+
+const (
+	UnchangedResultNone UnchangedResultPolicy = iota
+	UnchangedResultMTime
+	UnchangedResultMTimeAndHash
+)
+
+// ProviderSyncSemantics declares stable provider-wide cache and result
+// freshness policy. Its zero value opts out of every specialized behavior.
+type ProviderSyncSemantics struct {
+	FingerprintHashInCacheKey           bool
+	FingerprintHashRequiredForFreshness bool
+	// SkipCacheFreshWithoutStoredRow permits a matching skip-cache entry to
+	// remain fresh before this provider has persisted a row for the source.
+	SkipCacheFreshWithoutStoredRow bool
+	UnchangedResults               UnchangedResultPolicy
 }
 
 // SourceCapabilities declares optional source mechanics implemented by a

--- a/internal/parser/capabilities_sync_test.go
+++ b/internal/parser/capabilities_sync_test.go
@@ -1,0 +1,78 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestProviderSyncSemanticsDeclarations verifies that every registered
+// provider's declared Capabilities().Sync matches the engine's historical
+// per-agent sync behavior. Providers not listed in wantSync are expected to
+// carry the zero-value ProviderSyncSemantics.
+func TestProviderSyncSemanticsDeclarations(t *testing.T) {
+	wantSync := map[AgentType]ProviderSyncSemantics{
+		AgentClaude: {
+			FingerprintHashInCacheKey:           true,
+			FingerprintHashRequiredForFreshness: true,
+			SkipCacheFreshWithoutStoredRow:      true,
+		},
+		AgentCodex: {
+			FingerprintHashInCacheKey:           true,
+			FingerprintHashRequiredForFreshness: true,
+			SkipCacheFreshWithoutStoredRow:      true,
+		},
+		AgentDevin: {
+			FingerprintHashInCacheKey:           true,
+			FingerprintHashRequiredForFreshness: true,
+		},
+		AgentQoder: {
+			FingerprintHashInCacheKey:           true,
+			FingerprintHashRequiredForFreshness: true,
+		},
+		AgentWindsurf: {
+			FingerprintHashInCacheKey:           true,
+			FingerprintHashRequiredForFreshness: true,
+		},
+		AgentHermes: {
+			FingerprintHashRequiredForFreshness: true,
+		},
+		AgentGemini: {
+			FingerprintHashRequiredForFreshness: true,
+		},
+		AgentZed: {
+			UnchangedResults: UnchangedResultMTime,
+		},
+		AgentKiro: {
+			UnchangedResults: UnchangedResultMTime,
+		},
+		AgentTrae: {
+			UnchangedResults: UnchangedResultMTimeAndHash,
+		},
+		AgentAider: {
+			UnchangedResults: UnchangedResultMTimeAndHash,
+		},
+		AgentShelley: {
+			UnchangedResults: UnchangedResultMTimeAndHash,
+		},
+		AgentOpenCode: {
+			UnchangedResults: UnchangedResultMTimeAndHash,
+		},
+		AgentKilo: {
+			UnchangedResults: UnchangedResultMTimeAndHash,
+		},
+		AgentMiMoCode: {
+			UnchangedResults: UnchangedResultMTimeAndHash,
+		},
+		AgentIcodemate: {
+			UnchangedResults: UnchangedResultMTimeAndHash,
+		},
+	}
+
+	for _, factory := range ProviderFactories() {
+		agent := factory.Definition().Type
+		t.Run(string(agent), func(t *testing.T) {
+			assert.Equal(t, wantSync[agent], factory.Capabilities().Sync)
+		})
+	}
+}

--- a/internal/parser/claude_provider.go
+++ b/internal/parser/claude_provider.go
@@ -649,5 +649,10 @@ func claudeProviderCapabilities() Capabilities {
 			Model:                CapabilitySupported,
 			StopReason:           CapabilitySupported,
 		},
+		Sync: ProviderSyncSemantics{
+			FingerprintHashInCacheKey:           true,
+			FingerprintHashRequiredForFreshness: true,
+			SkipCacheFreshWithoutStoredRow:      true,
+		},
 	}
 }

--- a/internal/parser/codex_provider.go
+++ b/internal/parser/codex_provider.go
@@ -836,5 +836,10 @@ func codexProviderCapabilities() Capabilities {
 			TerminationStatus:    CapabilitySupported,
 			Model:                CapabilitySupported,
 		},
+		Sync: ProviderSyncSemantics{
+			FingerprintHashInCacheKey:           true,
+			FingerprintHashRequiredForFreshness: true,
+			SkipCacheFreshWithoutStoredRow:      true,
+		},
 	}
 }

--- a/internal/parser/devin_provider.go
+++ b/internal/parser/devin_provider.go
@@ -642,5 +642,9 @@ func devinProviderCapabilities() Capabilities {
 			PerMessageTokenUsage: CapabilitySupported,
 			Model:                CapabilitySupported,
 		},
+		Sync: ProviderSyncSemantics{
+			FingerprintHashInCacheKey:           true,
+			FingerprintHashRequiredForFreshness: true,
+		},
 	}
 }

--- a/internal/parser/gemini_provider.go
+++ b/internal/parser/gemini_provider.go
@@ -649,5 +649,8 @@ func geminiProviderCapabilities() Capabilities {
 			PerMessageTokenUsage: CapabilitySupported,
 			Model:                CapabilitySupported,
 		},
+		Sync: ProviderSyncSemantics{
+			FingerprintHashRequiredForFreshness: true,
+		},
 	}
 }

--- a/internal/parser/hermes_provider.go
+++ b/internal/parser/hermes_provider.go
@@ -1592,5 +1592,8 @@ func hermesProviderCapabilities() Capabilities {
 			AggregateUsageEvents: CapabilitySupported,
 			Model:                CapabilitySupported,
 		},
+		Sync: ProviderSyncSemantics{
+			FingerprintHashRequiredForFreshness: true,
+		},
 	}
 }

--- a/internal/parser/kiro_provider.go
+++ b/internal/parser/kiro_provider.go
@@ -787,5 +787,8 @@ func kiroProviderCapabilities() Capabilities {
 			ToolCalls:    CapabilitySupported,
 			ToolResults:  CapabilitySupported,
 		},
+		Sync: ProviderSyncSemantics{
+			UnchangedResults: UnchangedResultMTime,
+		},
 	}
 }

--- a/internal/parser/opencode_provider.go
+++ b/internal/parser/opencode_provider.go
@@ -736,8 +736,8 @@ func (s openCodeFormatSourceSet) Fingerprint(
 		return SourceFingerprint{}, fmt.Errorf("stat %s: source is a directory", path)
 	}
 	fingerprint.Size = info.Size()
-	// No content hash: no engine freshness gate consumes it for this
-	// family (see providerFingerprintHashRequiredForFreshness), and the
+	// No content hash: this family declares FingerprintHashRequiredForFreshness
+	// false, so no engine freshness gate consumes it, and the
 	// authoritative storage fingerprint is computed by Parse and compared
 	// post-parse by dropUnchangedSharedSQLiteResults. Computing it here
 	// re-read and re-hashed every message and part file of the session on

--- a/internal/parser/opencode_provider.go
+++ b/internal/parser/opencode_provider.go
@@ -1126,5 +1126,8 @@ func openCodeFormatProviderCapabilities() Capabilities {
 			PerMessageTokenUsage: CapabilitySupported,
 			Model:                CapabilitySupported,
 		},
+		Sync: ProviderSyncSemantics{
+			UnchangedResults: UnchangedResultMTimeAndHash,
+		},
 	}
 }

--- a/internal/parser/qoder_provider.go
+++ b/internal/parser/qoder_provider.go
@@ -154,5 +154,9 @@ func qoderProviderCapabilities() Capabilities {
 			MalformedLineCount:   CapabilitySupported,
 			Model:                CapabilitySupported,
 		},
+		Sync: ProviderSyncSemantics{
+			FingerprintHashInCacheKey:           true,
+			FingerprintHashRequiredForFreshness: true,
+		},
 	}
 }

--- a/internal/parser/shelley_provider.go
+++ b/internal/parser/shelley_provider.go
@@ -303,5 +303,8 @@ func shelleyProviderCapabilities() Capabilities {
 			PerMessageTokenUsage: CapabilitySupported,
 			Model:                CapabilitySupported,
 		},
+		Sync: ProviderSyncSemantics{
+			UnchangedResults: UnchangedResultMTimeAndHash,
+		},
 	}
 }

--- a/internal/parser/trae_provider.go
+++ b/internal/parser/trae_provider.go
@@ -681,5 +681,8 @@ func traeProviderCapabilities() Capabilities {
 	caps.Content.ToolCalls = CapabilityUnsupported
 	caps.Content.ToolResults = CapabilityUnsupported
 	caps.Content.Thinking = CapabilityUnsupported
+	caps.Sync = ProviderSyncSemantics{
+		UnchangedResults: UnchangedResultMTimeAndHash,
+	}
 	return caps
 }

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -88,6 +88,13 @@ type AgentDef struct {
 	// scheduling inputs default to unsupported.
 	PeriodicReconcile bool
 
+	// RemoteSyncExcluded keeps every path under the agent's roots out of
+	// remote sync artifacts: resolve scripts, manifests, archives, delta
+	// roots, and tar commands. Set for stores that co-locate transcripts
+	// with secrets or state that cannot be copied safely; each artifact
+	// seam checks it so exclusion fails closed.
+	RemoteSyncExcluded bool
+
 	// WatchRootsFunc resolves the directories to watch for live
 	// updates under a configured root, for agents whose watch
 	// targets depend on the on-disk layout rather than a static
@@ -375,6 +382,10 @@ var Registry = []AgentDef{
 		WatchSubdirs: []string{"workspaceStorage", "globalStorage"},
 		FileBased:    true,
 		Usage:        UsageCapabilities{NoPerMessageTokenData: true},
+		// Trae's modern layout stores sessions as encrypted state that a
+		// remote machine cannot read; shipping it would copy opaque
+		// encrypted blobs.
+		RemoteSyncExcluded: true,
 	},
 	{
 		Type:        AgentVSCopilot,
@@ -835,6 +846,13 @@ func AgentByType(t AgentType) (AgentDef, bool) {
 		}
 	}
 	return AgentDef{}, false
+}
+
+// RemoteSyncExcludedAgent reports whether the agent's raw source tree must
+// stay out of every remote sync artifact. Unknown agents are not excluded.
+func RemoteSyncExcludedAgent(agent AgentType) bool {
+	def, ok := AgentByType(agent)
+	return ok && def.RemoteSyncExcluded
 }
 
 // AgentNameLacksPerMessageTokenData reports whether the named agent

--- a/internal/parser/types_test.go
+++ b/internal/parser/types_test.go
@@ -678,6 +678,24 @@ func TestPeriodicReconcileCapability(t *testing.T) {
 	assert.False(t, optedIn[AgentGemini])
 }
 
+func TestRemoteSyncExcludedCapability(t *testing.T) {
+	excluded := map[AgentType]bool{}
+	for _, def := range Registry {
+		excluded[def.Type] = def.RemoteSyncExcluded
+	}
+	// Trae's modern layout stores sessions as encrypted state that a remote
+	// machine cannot read, so it opts out of every remote sync artifact.
+	assert.True(t, excluded[AgentTrae])
+	assert.False(t, excluded[AgentClaude])
+	assert.False(t, excluded[AgentCodex])
+}
+
+func TestRemoteSyncExcludedAgent(t *testing.T) {
+	assert.True(t, RemoteSyncExcludedAgent(AgentTrae))
+	assert.False(t, RemoteSyncExcludedAgent(AgentClaude))
+	assert.False(t, RemoteSyncExcludedAgent(AgentType("unknown-agent")))
+}
+
 func TestAgentByPrefixCowork(t *testing.T) {
 	def, ok := AgentByPrefix("cowork:c0000000-0000-4000-8000-000000000001")
 	require.True(t, ok, "cowork-prefixed ID should resolve")

--- a/internal/parser/windsurf_provider.go
+++ b/internal/parser/windsurf_provider.go
@@ -1350,5 +1350,9 @@ func windsurfProviderCapabilities() Capabilities {
 			AggregateUsageEvents: CapabilitySupported,
 			Model:                CapabilitySupported,
 		},
+		Sync: ProviderSyncSemantics{
+			FingerprintHashInCacheKey:           true,
+			FingerprintHashRequiredForFreshness: true,
+		},
 	}
 }

--- a/internal/parser/zed_provider.go
+++ b/internal/parser/zed_provider.go
@@ -315,5 +315,8 @@ func zedProviderCapabilities() Capabilities {
 			AggregateUsageEvents: CapabilitySupported,
 			Model:                CapabilitySupported,
 		},
+		Sync: ProviderSyncSemantics{
+			UnchangedResults: UnchangedResultMTime,
+		},
 	}
 }

--- a/internal/remotesync/resolve.go
+++ b/internal/remotesync/resolve.go
@@ -180,7 +180,7 @@ func hermesStateFiles(stateDB string, includeDB bool) []string {
 }
 
 func resolveAgentHasOnDiskSource(def parser.AgentDef) bool {
-	if def.Type == parser.AgentTrae {
+	if def.RemoteSyncExcluded {
 		return false
 	}
 	if !def.FileBased {

--- a/internal/ssh/resolve.go
+++ b/internal/ssh/resolve.go
@@ -357,7 +357,7 @@ func remoteDefaultRootTail(rel string) string {
 // resolveAgentHasOnDiskSource reports whether a file-backed agent has local
 // sources the resolve script should probe via the provider facade.
 func resolveAgentHasOnDiskSource(def parser.AgentDef) bool {
-	if def.Type == parser.AgentTrae {
+	if def.RemoteSyncExcluded {
 		return false
 	}
 	if !def.FileBased {

--- a/internal/ssh/resolve_test.go
+++ b/internal/ssh/resolve_test.go
@@ -25,10 +25,8 @@ func TestBuildResolveScript(t *testing.T) {
 	for _, def := range parser.Registry {
 		want := def.FileBased &&
 			parser.ProviderMigrationModes()[def.Type] ==
-				parser.ProviderMigrationProviderAuthoritative
-		if def.Type == parser.AgentTrae {
-			want = false
-		}
+				parser.ProviderMigrationProviderAuthoritative &&
+			!def.RemoteSyncExcluded
 		if want {
 			assert.True(t, resolveScriptMentionsAgent(script, def.Type),
 				"file-backed provider-authoritative agent %s missing from script", def.Type)

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -6853,6 +6853,7 @@ func (e *Engine) processProviderFile(
 			),
 		}, true
 	}
+	providerSemantics := provider.Capabilities().Sync
 
 	// SyncSingleSession resolves a single session by ID and carries the
 	// caller-preferred project (typically the DB-preserved value, so a
@@ -6927,7 +6928,7 @@ func (e *Engine) processProviderFile(
 		}
 		return processResult{err: err}, true
 	}
-	cacheKey := providerProcessCacheKey(file, source, fingerprint)
+	cacheKey := providerProcessCacheKey(file, source, fingerprint, providerSemantics)
 	cacheSkip := e.shouldCacheSkip(file)
 	if cacheSkip && !e.forceParse && !file.ForceParse {
 		e.skipMu.RLock()
@@ -6938,7 +6939,9 @@ func (e *Engine) processProviderFile(
 			// self-healing (e.g. a parser data-version bump or generated
 			// roborev CI worktree project): clear the entry and fall through
 			// to a full reparse, mirroring the legacy process arm.
-			if !e.providerSkipCacheEntryFreshInDB(file, source, fingerprint) {
+			if !e.providerSkipCacheEntryFreshInDB(
+				file, source, fingerprint, providerSemantics,
+			) {
 				e.clearSkip(cacheKey)
 			} else if e.pathNeedsCachedSkipBypass(file.Path) {
 				e.clearSkip(cacheKey)
@@ -6951,7 +6954,9 @@ func (e *Engine) processProviderFile(
 				e.clearSkip(cacheKey)
 			} else {
 				if verifiedStateOK &&
-					e.shouldSkipProviderSourceByDB(file, fingerprint) {
+					e.shouldSkipProviderSourceByDB(
+						file, fingerprint, providerSemantics,
+					) {
 					e.promoteVerifiedSource(verifiedCapture)
 				}
 				return processResult{
@@ -6963,7 +6968,9 @@ func (e *Engine) processProviderFile(
 			}
 		}
 	}
-	if cacheSkip && e.shouldSkipProviderSource(file, source, fingerprint) {
+	if cacheSkip && e.shouldSkipProviderSource(
+		file, source, fingerprint, providerSemantics,
+	) {
 		return processResult{
 			skip:      true,
 			mtime:     fingerprint.MTimeNS,
@@ -6996,7 +7003,9 @@ func (e *Engine) processProviderFile(
 	// a shared index mtime bump that did not change this session's title must
 	// not trigger a reparse.
 	if !incForceReplace && !e.forceParse && !file.ForceParse &&
-		e.shouldSkipProviderSourceByDB(file, fingerprint) {
+		e.shouldSkipProviderSourceByDB(
+			file, fingerprint, providerSemantics,
+		) {
 		if verifiedStateOK {
 			e.promoteVerifiedSource(verifiedCapture)
 		}
@@ -7020,7 +7029,7 @@ func (e *Engine) processProviderFile(
 	// reparses, matching the prior behavior. Claude and Cowork have their own
 	// earlier freshness checks; this is the generic fallback for the rest.
 	if !incForceReplace && !e.forceParse && !file.ForceParse &&
-		e.providerSourceUnchangedInDB(source, fingerprint) {
+		e.providerSourceUnchangedInDB(source, fingerprint, providerSemantics) {
 		return processResult{
 			skip:      true,
 			mtime:     fingerprint.MTimeNS,
@@ -7129,7 +7138,9 @@ func (e *Engine) processProviderFile(
 	parsedResults := parseOutcomeResults(outcome.Results)
 	parsedCount := len(parsedResults)
 	res := processResult{
-		results:               e.dropUnchangedSharedSQLiteResults(file, parsedResults),
+		results: e.dropUnchangedSharedSQLiteResults(
+			file, parsedResults, providerSemantics.UnchangedResults,
+		),
 		excludedSessionIDs:    append([]string(nil), outcome.ExcludedSessionIDs...),
 		mtime:                 fingerprint.MTimeNS,
 		cacheSkip:             cacheSkip,
@@ -7184,41 +7195,32 @@ func (e *Engine) processProviderFile(
 // fingerprint stored in file_hash already match, using the path rewriter so
 // remote stored paths resolve. Force-parse runs (parse-diff, single-session
 // resync) keep every result so they always re-emit.
+//
+// The comparison policy is declared per provider on Capabilities().Sync.
+// UnchangedResultNone opts a provider out entirely: every session is its own
+// source and has no shared-container siblings to drop (e.g. Claude, Codex).
+// UnchangedResultMTime compares only file_mtime: Zed and Kiro fan one
+// container DB out to a session per row with no per-row content hash, so
+// mtime plus data version matches their legacy container sync. Without Kiro
+// declaring it, every Kiro row would be reparsed and rewritten on every full
+// sync. UnchangedResultMTimeAndHash also compares file_hash: Shelley's and
+// Trae's per-session results share one container fingerprint hash, which
+// catches same-mtime rewrites; Aider's runs in a history file share the
+// file's content hash, so a same-mtime append/truncate is caught; and
+// OpenCode-family providers (OpenCode, Kilo, MiMoCode, Icodemate) use the
+// opencode storage fingerprint to catch same-mtime content changes.
 func (e *Engine) dropUnchangedSharedSQLiteResults(
 	file parser.DiscoveredFile,
 	results []parser.ParseResult,
+	policy parser.UnchangedResultPolicy,
 ) []parser.ParseResult {
 	if e.forceParse || file.ForceParse || len(results) == 0 {
 		return results
 	}
-	compareHash := false
-	switch file.Agent {
-	case parser.AgentShelley:
-		compareHash = true
-	case parser.AgentTrae:
-		// Trae fans one shared SQLite store out into virtual per-session paths.
-		// Every session shares the container fingerprint hash, which catches
-		// same-mtime rewrites while still letting unchanged sessions drop after
-		// the provider re-parses the container.
-		compareHash = true
-	case parser.AgentAider:
-		// Every aider run in a history file shares the file's content hash, so
-		// a same-mtime append/truncate is caught by the hash compare.
-		compareHash = true
-	case parser.AgentOpenCode, parser.AgentKilo, parser.AgentMiMoCode, parser.AgentIcodemate:
-		// OpenCode-family providers fan one shared container out to per-session
-		// results. The per-session mtime is the session's own updated time, and
-		// the hash compare uses the opencode storage fingerprint to catch
-		// same-mtime content changes.
-		compareHash = true
-	case parser.AgentZed, parser.AgentKiro:
-		// Zed and Kiro fan one container DB out to a session per row and have no
-		// per-row content hash, so unchanged rows are detected by mtime plus
-		// data version, matching their legacy container sync. Without Kiro here
-		// every Kiro row is reparsed and rewritten on every full sync.
-	default:
+	if policy == parser.UnchangedResultNone {
 		return results
 	}
+	compareHash := policy == parser.UnchangedResultMTimeAndHash
 
 	kept := results[:0]
 	for _, r := range results {
@@ -7482,78 +7484,60 @@ func providerProcessCacheKey(
 	file parser.DiscoveredFile,
 	source parser.SourceRef,
 	fingerprint parser.SourceFingerprint,
+	semantics parser.ProviderSyncSemantics,
 ) string {
-	agent := file.Agent
-	if agent == "" {
-		agent = source.Provider
+	key := plannedSkipKey(source, fingerprint)
+	if key == "" {
+		key = file.Path
 	}
-	key := ""
-	if key := plannedSkipKey(source, fingerprint); key != "" {
-		return providerProcessCacheKeyWithHash(key, agent, fingerprint)
-	}
-	key = file.Path
-	return providerProcessCacheKeyWithHash(key, agent, fingerprint)
+	return providerProcessCacheKeyWithHash(key, fingerprint, semantics)
 }
 
+// providerProcessCacheKeyWithHash appends the fingerprint hash to the skip
+// cache key when the provider declares FingerprintHashInCacheKey. Hermes
+// deliberately declares it false: its skip keys must stay plain paths so the
+// remote import's exact-file mapping (a profile's state.db in ExtraFiles) can
+// translate the persisted entry back to the remote path. Same-mtime content
+// changes are still caught by FingerprintHashRequiredForFreshness, which
+// compares the fingerprint hash against the stored row.
 func providerProcessCacheKeyWithHash(
 	key string,
-	agent parser.AgentType,
 	fingerprint parser.SourceFingerprint,
+	semantics parser.ProviderSyncSemantics,
 ) string {
 	if key == "" {
 		return ""
 	}
-	if fingerprint.Hash == "" || !providerFingerprintHashInCacheKey(agent) {
+	if fingerprint.Hash == "" || !semantics.FingerprintHashInCacheKey {
 		return key
 	}
 	return key + "?source_hash=" + fingerprint.Hash
 }
 
-// Hermes is deliberately absent: its skip keys must stay plain paths so the
-// remote import's exact-file mapping (a profile's state.db in ExtraFiles) can
-// translate the persisted entry back to the remote path. Same-mtime content
-// changes are still caught by providerFingerprintHashRequiredForFreshness,
-// which compares the fingerprint hash against the stored row.
-func providerFingerprintHashInCacheKey(agent parser.AgentType) bool {
-	switch agent {
-	case parser.AgentClaude, parser.AgentCodex, parser.AgentDevin,
-		parser.AgentQoder, parser.AgentWindsurf:
-		return true
-	default:
-		return false
-	}
-}
-
-// providerFingerprintHashRequiredForFreshness also protects stored rows. Hash
-// cache keys protect rowless parser exclusions and failures; cacheSkip removes
-// older hash siblings so hot append-only files retain only one content version.
-func providerFingerprintHashRequiredForFreshness(agent parser.AgentType) bool {
-	switch agent {
-	case parser.AgentClaude, parser.AgentCodex, parser.AgentDevin, parser.AgentHermes,
-		parser.AgentQoder, parser.AgentWindsurf, parser.AgentGemini:
-		return true
-	default:
-		return false
-	}
-}
-
+// providerSkipCacheEntryFreshInDB reports whether a cached skip entry remains
+// valid against the current DB state. FingerprintHashRequiredForFreshness
+// also protects stored rows: hash cache keys (FingerprintHashInCacheKey)
+// protect rowless parser exclusions and failures, while cacheSkip removes
+// older hash siblings so hot append-only files retain only one content
+// version.
 func (e *Engine) providerSkipCacheEntryFreshInDB(
 	file parser.DiscoveredFile,
 	source parser.SourceRef,
 	fingerprint parser.SourceFingerprint,
+	semantics parser.ProviderSyncSemantics,
 ) bool {
 	agent := file.Agent
 	if agent == "" {
 		agent = source.Provider
 	}
-	if fingerprint.Hash == "" || !providerFingerprintHashRequiredForFreshness(agent) {
+	if fingerprint.Hash == "" || !semantics.FingerprintHashRequiredForFreshness {
 		return true
 	}
 	lookupPath := providerSkipLookupPath(file, source, fingerprint)
 	if e.pathRewriter != nil {
 		lookupPath = e.pathRewriter(lookupPath)
 	}
-	if agent == parser.AgentClaude || agent == parser.AgentCodex {
+	if semantics.SkipCacheFreshWithoutStoredRow {
 		storedIDs, err := e.db.ListSessionIDsByFilePath(
 			lookupPath, string(agent),
 		)
@@ -7566,7 +7550,9 @@ func (e *Engine) providerSkipCacheEntryFreshInDB(
 			return true
 		}
 	}
-	return e.providerFingerprintHashMatchesDB(agent, lookupPath, fingerprint)
+	return e.providerFingerprintHashMatchesDB(
+		lookupPath, fingerprint, semantics.FingerprintHashRequiredForFreshness,
+	)
 }
 
 func processFileUsesProvider(agent parser.AgentType) bool {
@@ -7582,6 +7568,7 @@ func (e *Engine) shouldSkipProviderSource(
 	file parser.DiscoveredFile,
 	source parser.SourceRef,
 	fingerprint parser.SourceFingerprint,
+	semantics parser.ProviderSyncSemantics,
 ) bool {
 	agent := file.Agent
 	if agent == "" {
@@ -7607,7 +7594,9 @@ func (e *Engine) shouldSkipProviderSource(
 	if storedMtime != fingerprint.MTimeNS {
 		return false
 	}
-	if !e.providerFingerprintHashMatchesDB(agent, lookupPath, fingerprint) {
+	if !e.providerFingerprintHashMatchesDB(
+		lookupPath, fingerprint, semantics.FingerprintHashRequiredForFreshness,
+	) {
 		return false
 	}
 	return e.db.GetDataVersionByPath(lookupPath) >= db.CurrentDataVersion()
@@ -7964,6 +7953,7 @@ func (e *Engine) shouldSkipFile(
 func (e *Engine) providerSourceUnchangedInDB(
 	source parser.SourceRef,
 	fingerprint parser.SourceFingerprint,
+	semantics parser.ProviderSyncSemantics,
 ) bool {
 	if fingerprint.MTimeNS == 0 && fingerprint.Size == 0 {
 		return false
@@ -7985,7 +7975,9 @@ func (e *Engine) providerSourceUnchangedInDB(
 		) {
 			return false
 		}
-	} else if !e.providerFingerprintHashMatchesDB(source.Provider, lookupPath, fingerprint) {
+	} else if !e.providerFingerprintHashMatchesDB(
+		lookupPath, fingerprint, semantics.FingerprintHashRequiredForFreshness,
+	) {
 		return false
 	}
 	// A stale stored project (e.g. a generated roborev CI worktree name)
@@ -8000,11 +7992,11 @@ func (e *Engine) providerSourceUnchangedInDB(
 }
 
 func (e *Engine) providerFingerprintHashMatchesDB(
-	agent parser.AgentType,
 	lookupPath string,
 	fingerprint parser.SourceFingerprint,
+	required bool,
 ) bool {
-	if fingerprint.Hash == "" || !providerFingerprintHashRequiredForFreshness(agent) {
+	if fingerprint.Hash == "" || !required {
 		return true
 	}
 	storedHash, ok := e.db.GetFileHashByPath(lookupPath)
@@ -8264,8 +8256,9 @@ func (e *Engine) providerSourceFreshBeforeFingerprint(
 	// the session file's size and mtime would skip a session whose project
 	// metadata changed while the transcript did not, leaving a stale project
 	// on scheduled syncs. Gemini relies on the post-fingerprint DB hash check
-	// instead (providerFingerprintHashRequiredForFreshness), which catches a
-	// resolved-project change even when size and mtime are unchanged.
+	// instead (declared via FingerprintHashRequiredForFreshness), which
+	// catches a resolved-project change even when size and mtime are
+	// unchanged.
 	case parser.AgentCopilot:
 		mtime := copilotEffectiveMtime(path, info)
 		effectiveInfo := fakeSnapshotInfo{
@@ -8786,12 +8779,14 @@ func (e *Engine) tryIncrementalJSONL(
 // advanced but this session's name did not" semantics. Other providers keep
 // their existing in-memory skip-cache behavior unchanged.
 func (e *Engine) shouldSkipProviderSourceByDB(
-	file parser.DiscoveredFile, fingerprint parser.SourceFingerprint,
+	file parser.DiscoveredFile,
+	fingerprint parser.SourceFingerprint,
+	semantics parser.ProviderSyncSemantics,
 ) bool {
 	if file.Agent != parser.AgentCodex {
 		return false
 	}
-	return e.shouldSkipCodexFingerprint(file.Path, fingerprint)
+	return e.shouldSkipCodexFingerprint(file.Path, fingerprint, semantics)
 }
 
 // shouldSkipCodexFingerprint reproduces the legacy shouldSkipCodex decision in
@@ -8803,7 +8798,9 @@ func (e *Engine) shouldSkipProviderSourceByDB(
 //     (the raw transcript mtime is still at or below the stored mtime) skips
 //     unless this session's stored title differs from the current index title.
 func (e *Engine) shouldSkipCodexFingerprint(
-	path string, fingerprint parser.SourceFingerprint,
+	path string,
+	fingerprint parser.SourceFingerprint,
+	semantics parser.ProviderSyncSemantics,
 ) bool {
 	lookupPath := path
 	if e.pathRewriter != nil {
@@ -8814,7 +8811,7 @@ func (e *Engine) shouldSkipCodexFingerprint(
 		return false
 	}
 	if !e.providerFingerprintHashMatchesDB(
-		parser.AgentCodex, lookupPath, fingerprint,
+		lookupPath, fingerprint, semantics.FingerprintHashRequiredForFreshness,
 	) {
 		return false
 	}

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -2463,7 +2463,9 @@ func TestReconcileWatchRootsRevivesByteIdenticalSourceWithWarmSkipCache(
 	storedHash, ok := fx.db.GetFileHashByPath(path)
 	require.True(t, ok)
 	cacheKey := providerProcessCacheKeyWithHash(
-		path, parser.AgentClaude, parser.SourceFingerprint{Hash: storedHash},
+		path,
+		parser.SourceFingerprint{Hash: storedHash},
+		parser.ProviderSyncSemantics{FingerprintHashInCacheKey: true},
 	)
 	fx.engine.cacheSkip(cacheKey, originalInfo.ModTime().UnixNano())
 	assert.Equal(t, 1, fx.engine.persistSkipCache(),
@@ -5130,7 +5132,7 @@ func TestShouldSkipCodexReparsesStaleProject(t *testing.T) {
 	assert.False(t, e.shouldSkipCodexFingerprint(path, parser.SourceFingerprint{
 		Size:    info.Size(),
 		MTimeNS: info.ModTime().UnixNano(),
-	}), "stale generated roborev CI projects must be reparsed")
+	}, parser.ProviderSyncSemantics{}), "stale generated roborev CI projects must be reparsed")
 }
 
 func TestProcessFileSkipCacheReparsesStaleCodexProject(t *testing.T) {
@@ -5342,7 +5344,9 @@ func cacheCodexProviderFingerprint(
 	require.True(t, found)
 	fingerprint, err := provider.Fingerprint(context.Background(), source)
 	require.NoError(t, err)
-	key := providerProcessCacheKey(file, source, fingerprint)
+	key := providerProcessCacheKey(
+		file, source, fingerprint, provider.Capabilities().Sync,
+	)
 	require.NotEmpty(t, key)
 	return key, fingerprint.MTimeNS
 }
@@ -5803,12 +5807,13 @@ func TestProviderProcessCacheKeyCodexIncludesContentHash(t *testing.T) {
 		FingerprintKey: path,
 	}
 
+	semantics := parser.ProviderSyncSemantics{FingerprintHashInCacheKey: true}
 	first := providerProcessCacheKey(file, source, parser.SourceFingerprint{
 		Key: path, Hash: "first-content-hash",
-	})
+	}, semantics)
 	second := providerProcessCacheKey(file, source, parser.SourceFingerprint{
 		Key: path, Hash: "second-content-hash",
-	})
+	}, semantics)
 
 	assert.Equal(t, path+"?source_hash=first-content-hash", first)
 	assert.Equal(t, path+"?source_hash=second-content-hash", second)

--- a/internal/sync/hermes_archive_test.go
+++ b/internal/sync/hermes_archive_test.go
@@ -229,7 +229,7 @@ func TestProcessFileHermesArchiveSkipCacheUsesAggregateMtime(t *testing.T) {
 	require.Zero(t, failed)
 	engine.InjectSkipCache(map[string]int64{
 		providerProcessCacheKeyWithHash(
-			stateDB, parser.AgentHermes, fingerprint,
+			stateDB, fingerprint, provider.Capabilities().Sync,
 		): wantMtime,
 	})
 

--- a/internal/sync/provider_process_test.go
+++ b/internal/sync/provider_process_test.go
@@ -604,6 +604,11 @@ func TestProcessFileClaudeCachedSourceWithoutStoredSessionSkipsParse(t *testing.
 	)
 	provider.Def.Type = parser.AgentClaude
 	provider.Def.IDPrefix = "claude:"
+	provider.Caps.Sync = parser.ProviderSyncSemantics{
+		FingerprintHashInCacheKey:           true,
+		FingerprintHashRequiredForFreshness: true,
+		SkipCacheFreshWithoutStoredRow:      true,
+	}
 	engine := NewEngine(openTestDB(t), EngineConfig{
 		AgentDirs: map[parser.AgentType][]string{
 			parser.AgentClaude: {root},
@@ -616,7 +621,7 @@ func TestProcessFileClaudeCachedSourceWithoutStoredSessionSkipsParse(t *testing.
 	})
 	engine.cacheSkip(providerProcessCacheKey(
 		parser.DiscoveredFile{Path: sourcePath, Agent: parser.AgentClaude},
-		source, fingerprint,
+		source, fingerprint, provider.Capabilities().Sync,
 	), fingerprint.MTimeNS)
 
 	res := engine.processFile(context.Background(), parser.DiscoveredFile{
@@ -656,6 +661,11 @@ func TestProcessFileRowlessCachedSourceChangedHashReparses(t *testing.T) {
 			)
 			provider.Def.Type = agent
 			provider.Def.IDPrefix = string(agent) + ":"
+			provider.Caps.Sync = parser.ProviderSyncSemantics{
+				FingerprintHashInCacheKey:           true,
+				FingerprintHashRequiredForFreshness: true,
+				SkipCacheFreshWithoutStoredRow:      true,
+			}
 			engine := NewEngine(openTestDB(t), EngineConfig{
 				AgentDirs: map[parser.AgentType][]string{agent: {root}},
 				Machine:   "devbox",
@@ -670,7 +680,7 @@ func TestProcessFileRowlessCachedSourceChangedHashReparses(t *testing.T) {
 			oldFingerprint.Hash = "old-ignored-content"
 			oldKey := providerProcessCacheKey(
 				parser.DiscoveredFile{Path: sourcePath, Agent: agent},
-				source, oldFingerprint,
+				source, oldFingerprint, provider.Capabilities().Sync,
 			)
 			engine.cacheSkip(oldKey, fingerprint.MTimeNS)
 
@@ -736,6 +746,11 @@ func TestProcessFileClaudeCachedStoredSessionChangedHashReparses(t *testing.T) {
 	)
 	provider.Def.Type = parser.AgentClaude
 	provider.Def.IDPrefix = "claude:"
+	provider.Caps.Sync = parser.ProviderSyncSemantics{
+		FingerprintHashInCacheKey:           true,
+		FingerprintHashRequiredForFreshness: true,
+		SkipCacheFreshWithoutStoredRow:      true,
+	}
 	engine := NewEngine(openTestDB(t), EngineConfig{
 		AgentDirs: map[parser.AgentType][]string{
 			parser.AgentClaude: {root},

--- a/internal/sync/verified_source_gate_integration_test.go
+++ b/internal/sync/verified_source_gate_integration_test.go
@@ -337,10 +337,16 @@ func TestVerifiedSourceGateLegacyClaudeRowMustEstablishFingerprint(t *testing.T)
 				Type: parser.AgentClaude, DisplayName: "Claude",
 				IDPrefix: "claude:", FileBased: true,
 			},
-			Caps: parser.Capabilities{Source: parser.SourceCapabilities{
-				IncrementalAppend: parser.CapabilitySupported,
-				VerifiedLocalStat: parser.CapabilitySupported,
-			}},
+			Caps: parser.Capabilities{
+				Source: parser.SourceCapabilities{
+					IncrementalAppend: parser.CapabilitySupported,
+					VerifiedLocalStat: parser.CapabilitySupported,
+				},
+				Sync: parser.ProviderSyncSemantics{
+					FingerprintHashInCacheKey:           true,
+					FingerprintHashRequiredForFreshness: true,
+				},
+			},
 		},
 		root:    root,
 		sources: make(map[string]parser.SourceRef),

--- a/internal/sync/windsurf_integration_test.go
+++ b/internal/sync/windsurf_integration_test.go
@@ -384,8 +384,10 @@ func TestProcessFileWindsurfSameMtimeHashChangeReparses(t *testing.T) {
 				engine.cacheSkip(
 					providerProcessCacheKeyWithHash(
 						virtualPath,
-						parser.AgentWindsurf,
 						parser.SourceFingerprint{Hash: initialHash},
+						parser.ProviderSyncSemantics{
+							FingerprintHashInCacheKey: true,
+						},
 					),
 					initialMtime,
 				)


### PR DESCRIPTION
Replaces four hard-coded agent switches in the sync engine and two hard-coded
Trae checks in remote sync with declarative provider capabilities.

`parser.Capabilities` gains a `Sync ProviderSyncSemantics` block declaring
per-provider cache and freshness policy: whether the fingerprint hash joins
the skip-cache key, whether freshness requires a stored-row hash match,
whether a skip-cache entry can be fresh before a stored row exists, and how
unchanged results from shared SQLite containers are dropped
(mtime vs mtime+hash). The engine reads these declarations instead of
switching on agent type; the deleted switch rationales move to the
declaration and consumption-site comments. `parser.AgentDef` gains
`RemoteSyncExcluded`, replacing the `def.Type == parser.AgentTrae` checks in
`internal/remotesync/resolve.go` and `internal/ssh/resolve.go`.

There is no behavior change: declarations reproduce the previous switch
memberships exactly, and a registry-wide parity test
(`TestProviderSyncSemanticsDeclarations`) asserts every registered agent's
declared semantics, including zero values for undeclared agents. One
removed code path — the `agent == ""` fallback in the cache-key helper — is
dead-code elimination: provider resolution by `file.Agent` precedes it and
fails first.

Why now: a pending Omnigent provider PR adds more consumers of both
capabilities; landing the refactor separately keeps that PR reviewable.

Reviewers should look at: `internal/parser/capabilities.go` (the new
types), `internal/sync/engine.go` (the four consumption sites), and
`internal/parser/capabilities_sync_test.go` (the parity table).
