### PR TITLE
feat(remotesync): prune forbidden roots nested inside allowed archive roots

### DIFF
--- a/internal/remotesync/archive.go
+++ b/internal/remotesync/archive.go
@@ -22,6 +22,9 @@ func WriteArchive(w io.Writer, targets TargetSet) error {
 	}
 	writtenHermesState := make(map[string]struct{})
 	writePath := func(path string, optional bool) error {
+		if pathWithinForbiddenRoots(targets.ForbiddenRoots, path) {
+			return nil
+		}
 		clean := filepath.Clean(path)
 		if stateDB, ok := hermesSQLite[clean]; ok {
 			if _, written := writtenHermesState[stateDB]; written {
@@ -33,9 +36,12 @@ func WriteArchive(w io.Writer, targets TargetSet) error {
 		if optional {
 			return writeOptionalArchiveFile(tw, path)
 		}
-		return writeArchivePath(tw, path)
+		return writeArchivePath(tw, path, targets.ForbiddenRoots)
 	}
 	for agent, dirs := range targets.Dirs {
+		if parser.RemoteSyncExcludedAgent(agent) {
+			continue
+		}
 		if _, fileScoped := targets.Files[agent]; fileScoped {
 			continue
 		}
@@ -46,8 +52,11 @@ func WriteArchive(w io.Writer, targets TargetSet) error {
 		}
 	}
 	for agent, files := range targets.Files {
+		if parser.RemoteSyncExcludedAgent(agent) {
+			continue
+		}
 		if agent == parser.AgentWindsurf {
-			if err := writeWindsurfArchiveFiles(tw, files); err != nil {
+			if err := writeWindsurfArchiveFiles(tw, files, targets.ForbiddenRoots); err != nil {
 				return err
 			}
 			continue
@@ -99,9 +108,14 @@ func writeHermesStateDBSnapshot(tw *tar.Writer, stateDB string) error {
 
 var writeHermesSnapshotFile = writeSQLiteSnapshot
 
-func writeWindsurfArchiveFiles(tw *tar.Writer, files []string) error {
+func writeWindsurfArchiveFiles(
+	tw *tar.Writer, files []string, forbiddenRoots []string,
+) error {
 	seen := make(map[string]struct{}, len(files))
 	for _, path := range files {
+		if pathWithinForbiddenRoots(forbiddenRoots, path) {
+			continue
+		}
 		if _, ok := seen[path]; ok {
 			continue
 		}
@@ -187,7 +201,12 @@ func writeOptionalArchiveFile(tw *tar.Writer, path string) error {
 	return writeArchiveFile(tw, path, info)
 }
 
-func writeArchivePath(tw *tar.Writer, root string) error {
+func writeArchivePath(
+	tw *tar.Writer, root string, forbiddenRoots []string,
+) error {
+	if pathWithinForbiddenRoots(forbiddenRoots, root) {
+		return nil
+	}
 	info, err := os.Lstat(root)
 	if err != nil {
 		return fmt.Errorf("stat archive path %q: %w", root, err)
@@ -204,6 +223,12 @@ func writeArchivePath(tw *tar.Writer, root string) error {
 				return nil
 			}
 			return err
+		}
+		if pathWithinForbiddenRoots(forbiddenRoots, path) {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
 		}
 		info, err := entry.Info()
 		if err != nil {
@@ -344,7 +369,9 @@ func WriteArchiveFiles(w io.Writer, allowed TargetSet, files []string) error {
 	}
 	writtenHermesState := make(map[string]struct{})
 	for _, path := range files {
-		local, ok := resolveDeltaFilePath(allowedRoots, path)
+		local, ok := resolveDeltaFilePath(
+			allowedRoots, allowed.ForbiddenRoots, path,
+		)
 		if !ok {
 			continue
 		}
@@ -386,18 +413,27 @@ func WriteArchiveFiles(w io.Writer, allowed TargetSet, files []string) error {
 // root returns filepath.Join(root, rel) where rel passed
 // filepath.IsLocal, so the path used for filesystem access is always
 // derived from a trusted base rather than the request string.
-func resolveDeltaFilePath(allowedRoots []string, path string) (string, bool) {
+func resolveDeltaFilePath(
+	allowedRoots []string, forbiddenRoots []string, path string,
+) (string, bool) {
 	clean := filepath.Clean(path)
 	for _, root := range allowedRoots {
 		root = filepath.Clean(root)
 		if clean == root {
+			if pathWithinForbiddenRoots(forbiddenRoots, root) {
+				return "", false
+			}
 			return root, true
 		}
 		rel, err := filepath.Rel(root, clean)
 		if err != nil || !filepath.IsLocal(rel) {
 			continue
 		}
-		return filepath.Join(root, rel), true
+		local := filepath.Join(root, rel)
+		if pathWithinForbiddenRoots(forbiddenRoots, local) {
+			return "", false
+		}
+		return local, true
 	}
 	return "", false
 }

--- a/internal/remotesync/archive.go
+++ b/internal/remotesync/archive.go
@@ -14,6 +14,7 @@ import (
 
 func WriteArchive(w io.Writer, targets TargetSet) error {
 	tw := tar.NewWriter(w)
+	forbidden := newForbiddenRootMatcher(targets.ForbiddenRoots)
 	hermesSQLite := make(map[string]string)
 	for _, stateDB := range hermesStateDBTargets(targets) {
 		for _, path := range hermesSQLitePaths(stateDB) {
@@ -22,7 +23,7 @@ func WriteArchive(w io.Writer, targets TargetSet) error {
 	}
 	writtenHermesState := make(map[string]struct{})
 	writePath := func(path string, optional bool) error {
-		if pathWithinForbiddenRoots(targets.ForbiddenRoots, path) {
+		if forbidden.within(path) {
 			return nil
 		}
 		clean := filepath.Clean(path)
@@ -36,7 +37,7 @@ func WriteArchive(w io.Writer, targets TargetSet) error {
 		if optional {
 			return writeOptionalArchiveFile(tw, path)
 		}
-		return writeArchivePath(tw, path, targets.ForbiddenRoots)
+		return writeArchivePath(tw, path, forbidden)
 	}
 	for agent, dirs := range targets.Dirs {
 		if parser.RemoteSyncExcludedAgent(agent) {
@@ -56,7 +57,7 @@ func WriteArchive(w io.Writer, targets TargetSet) error {
 			continue
 		}
 		if agent == parser.AgentWindsurf {
-			if err := writeWindsurfArchiveFiles(tw, files, targets.ForbiddenRoots); err != nil {
+			if err := writeWindsurfArchiveFiles(tw, files, forbidden); err != nil {
 				return err
 			}
 			continue
@@ -109,11 +110,11 @@ func writeHermesStateDBSnapshot(tw *tar.Writer, stateDB string) error {
 var writeHermesSnapshotFile = writeSQLiteSnapshot
 
 func writeWindsurfArchiveFiles(
-	tw *tar.Writer, files []string, forbiddenRoots []string,
+	tw *tar.Writer, files []string, forbidden forbiddenRootMatcher,
 ) error {
 	seen := make(map[string]struct{}, len(files))
 	for _, path := range files {
-		if pathWithinForbiddenRoots(forbiddenRoots, path) {
+		if forbidden.within(path) {
 			continue
 		}
 		if _, ok := seen[path]; ok {
@@ -202,9 +203,9 @@ func writeOptionalArchiveFile(tw *tar.Writer, path string) error {
 }
 
 func writeArchivePath(
-	tw *tar.Writer, root string, forbiddenRoots []string,
+	tw *tar.Writer, root string, forbidden forbiddenRootMatcher,
 ) error {
-	if pathWithinForbiddenRoots(forbiddenRoots, root) {
+	if forbidden.within(root) {
 		return nil
 	}
 	info, err := os.Lstat(root)
@@ -224,7 +225,7 @@ func writeArchivePath(
 			}
 			return err
 		}
-		if pathWithinForbiddenRoots(forbiddenRoots, path) {
+		if forbidden.within(path) {
 			if entry.IsDir() {
 				return filepath.SkipDir
 			}
@@ -362,6 +363,7 @@ func writeArchiveHeader(
 // validate.
 func WriteArchiveFiles(w io.Writer, allowed TargetSet, files []string) error {
 	tw := tar.NewWriter(w)
+	forbidden := newForbiddenRootMatcher(allowed.ForbiddenRoots)
 	allowedRoots := allowed.DeltaAllowedRoots()
 	hermesStateDBs := make(map[string]struct{})
 	for _, stateDB := range hermesStateDBTargets(allowed) {
@@ -369,9 +371,7 @@ func WriteArchiveFiles(w io.Writer, allowed TargetSet, files []string) error {
 	}
 	writtenHermesState := make(map[string]struct{})
 	for _, path := range files {
-		local, ok := resolveDeltaFilePath(
-			allowedRoots, allowed.ForbiddenRoots, path,
-		)
+		local, ok := resolveDeltaFilePath(allowedRoots, forbidden, path)
 		if !ok {
 			continue
 		}
@@ -414,26 +414,20 @@ func WriteArchiveFiles(w io.Writer, allowed TargetSet, files []string) error {
 // filepath.IsLocal, so the path used for filesystem access is always
 // derived from a trusted base rather than the request string.
 func resolveDeltaFilePath(
-	allowedRoots []string, forbiddenRoots []string, path string,
+	allowedRoots []string, forbidden forbiddenRootMatcher, path string,
 ) (string, bool) {
 	clean := filepath.Clean(path)
 	for _, root := range allowedRoots {
 		root = filepath.Clean(root)
 		if clean == root {
-			if pathWithinForbiddenRoots(forbiddenRoots, root) {
-				return "", false
-			}
-			return root, true
+			return root, !forbidden.within(root)
 		}
 		rel, err := filepath.Rel(root, clean)
 		if err != nil || !filepath.IsLocal(rel) {
 			continue
 		}
 		local := filepath.Join(root, rel)
-		if pathWithinForbiddenRoots(forbiddenRoots, local) {
-			return "", false
-		}
-		return local, true
+		return local, !forbidden.within(local)
 	}
 	return "", false
 }

--- a/internal/remotesync/archive_test.go
+++ b/internal/remotesync/archive_test.go
@@ -658,7 +658,7 @@ func TestResolveDeltaFilePath(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, ok := resolveDeltaFilePath(
-				fromSlashAll(tt.roots), nil, filepath.FromSlash(tt.path))
+				fromSlashAll(tt.roots), forbiddenRootMatcher{}, filepath.FromSlash(tt.path))
 			require.Equal(t, tt.ok, ok)
 			assert.Equal(t, filepath.FromSlash(tt.want), got)
 		})

--- a/internal/remotesync/archive_test.go
+++ b/internal/remotesync/archive_test.go
@@ -240,6 +240,101 @@ func TestHermesArchivesSnapshotWALCommitBeforeCheckpoint(t *testing.T) {
 	}
 }
 
+func TestWriteArchiveExcludesRemoteSyncExcludedAgentState(t *testing.T) {
+	root := t.TempDir()
+	chatDB := filepath.Join(root, "chat.db")
+	require.NoError(t, os.WriteFile(chatDB, []byte("authentication state"), 0o600))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "credentials.json"), []byte("secret"), 0o600,
+	))
+
+	targets := TargetSet{
+		Dirs: map[parser.AgentType][]string{
+			parser.AgentTrae: {root},
+		},
+		Files: map[parser.AgentType][]string{
+			parser.AgentTrae: {chatDB},
+		},
+	}
+	for _, tt := range []struct {
+		name  string
+		write func(io.Writer) error
+	}{
+		{
+			name: "full",
+			write: func(w io.Writer) error {
+				return WriteArchive(w, targets)
+			},
+		},
+		{
+			name: "delta",
+			write: func(w io.Writer) error {
+				return WriteArchiveFiles(w, targets, []string{chatDB})
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var archive bytes.Buffer
+			require.NoError(t, tt.write(&archive))
+			_, err := tar.NewReader(&archive).Next()
+			assert.ErrorIs(t, err, io.EOF,
+				"a remote-sync-excluded agent's state must never enter a remote archive")
+		})
+	}
+}
+
+func TestWriteArchivePrunesForbiddenRootNestedInAllowedRoot(t *testing.T) {
+	root := t.TempDir()
+	allowed := filepath.Join(root, "sessions")
+	forbidden := filepath.Join(allowed, ".forbidden-provider")
+	keep := filepath.Join(allowed, "session.jsonl")
+	secret := filepath.Join(forbidden, "chat.db")
+	require.NoError(t, os.MkdirAll(forbidden, 0o755))
+	require.NoError(t, os.WriteFile(keep, []byte("session"), 0o644))
+	require.NoError(t, os.WriteFile(secret, []byte("authentication state"), 0o600))
+
+	targets := TargetSet{
+		Dirs:           map[parser.AgentType][]string{parser.AgentClaude: {allowed}},
+		ForbiddenRoots: []string{forbidden},
+	}
+	for _, tt := range []struct {
+		name  string
+		write func(io.Writer) error
+	}{
+		{
+			name: "full archive",
+			write: func(w io.Writer) error {
+				return WriteArchive(w, targets)
+			},
+		},
+		{
+			name: "delta archive",
+			write: func(w io.Writer) error {
+				return WriteArchiveFiles(w, targets, []string{keep, secret})
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var archive bytes.Buffer
+			require.NoError(t, tt.write(&archive))
+
+			var names []string
+			tr := tar.NewReader(&archive)
+			for {
+				hdr, err := tr.Next()
+				if errors.Is(err, io.EOF) {
+					break
+				}
+				require.NoError(t, err)
+				names = append(names, hdr.Name)
+			}
+			assert.Contains(t, names, archiveNameForTest(t, keep))
+			assert.NotContains(t, names, archiveNameForTest(t, secret),
+				"a forbidden nested root must not enter the transfer artifact")
+		})
+	}
+}
+
 func TestWriteArchivePropagatesAdvertisedHermesSnapshotFailure(t *testing.T) {
 	stateDB := filepath.Join(t.TempDir(), "profile", "state.db")
 	require.NoError(t, os.MkdirAll(filepath.Dir(stateDB), 0o755))
@@ -563,7 +658,7 @@ func TestResolveDeltaFilePath(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, ok := resolveDeltaFilePath(
-				fromSlashAll(tt.roots), filepath.FromSlash(tt.path))
+				fromSlashAll(tt.roots), nil, filepath.FromSlash(tt.path))
 			require.Equal(t, tt.ok, ok)
 			assert.Equal(t, filepath.FromSlash(tt.want), got)
 		})

--- a/internal/remotesync/manifest.go
+++ b/internal/remotesync/manifest.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+
+	"go.kenn.io/agentsview/internal/parser"
 )
 
 // ManifestEntry describes one regular file available for remote sync.
@@ -56,6 +58,9 @@ func BuildManifest(targets TargetSet) (Manifest, error) {
 		})
 	}
 	addLstat := func(path string) error {
+		if pathWithinForbiddenRoots(targets.ForbiddenRoots, path) {
+			return nil
+		}
 		info, err := os.Lstat(path)
 		if err != nil {
 			if os.IsNotExist(err) {
@@ -69,6 +74,9 @@ func BuildManifest(targets TargetSet) (Manifest, error) {
 		return nil
 	}
 	for agent, dirs := range targets.Dirs {
+		if parser.RemoteSyncExcludedAgent(agent) {
+			continue
+		}
 		if _, fileScoped := targets.Files[agent]; fileScoped {
 			continue
 		}
@@ -76,12 +84,15 @@ func BuildManifest(targets TargetSet) (Manifest, error) {
 			if _, ok := hermesSQLite[filepath.Clean(root)]; ok {
 				continue
 			}
-			if err := manifestWalk(root, add); err != nil {
+			if err := manifestWalk(root, targets.ForbiddenRoots, add); err != nil {
 				return Manifest{}, err
 			}
 		}
 	}
-	for _, files := range targets.Files {
+	for agent, files := range targets.Files {
+		if parser.RemoteSyncExcludedAgent(agent) {
+			continue
+		}
 		for _, path := range files {
 			if _, ok := hermesSQLite[filepath.Clean(path)]; ok {
 				continue
@@ -100,6 +111,9 @@ func BuildManifest(targets TargetSet) (Manifest, error) {
 		}
 	}
 	for _, stateDB := range hermesStateDBs {
+		if pathWithinForbiddenRoots(targets.ForbiddenRoots, stateDB) {
+			continue
+		}
 		size, modTime, exists := hermesSQLiteSnapshotIdentity(stateDB)
 		if exists {
 			m.Files = append(m.Files, ManifestEntry{
@@ -113,7 +127,12 @@ func BuildManifest(targets TargetSet) (Manifest, error) {
 	return m, nil
 }
 
-func manifestWalk(root string, add func(string, os.FileInfo)) error {
+func manifestWalk(
+	root string, forbiddenRoots []string, add func(string, os.FileInfo),
+) error {
+	if pathWithinForbiddenRoots(forbiddenRoots, root) {
+		return nil
+	}
 	info, err := os.Lstat(root)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -136,6 +155,12 @@ func manifestWalk(root string, add func(string, os.FileInfo)) error {
 				return nil
 			}
 			return err
+		}
+		if pathWithinForbiddenRoots(forbiddenRoots, path) {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
 		}
 		info, err := entry.Info()
 		if err != nil {

--- a/internal/remotesync/manifest.go
+++ b/internal/remotesync/manifest.go
@@ -43,6 +43,7 @@ func BuildManifest(targets TargetSet) (Manifest, error) {
 			"manifest not supported for sanitized file-scoped agents")
 	}
 	m := Manifest{Files: []ManifestEntry{}}
+	forbidden := newForbiddenRootMatcher(targets.ForbiddenRoots)
 	hermesStateDBs := hermesStateDBTargets(targets)
 	hermesSQLite := make(map[string]struct{}, len(hermesStateDBs)*4)
 	for _, stateDB := range hermesStateDBs {
@@ -58,7 +59,7 @@ func BuildManifest(targets TargetSet) (Manifest, error) {
 		})
 	}
 	addLstat := func(path string) error {
-		if pathWithinForbiddenRoots(targets.ForbiddenRoots, path) {
+		if forbidden.within(path) {
 			return nil
 		}
 		info, err := os.Lstat(path)
@@ -84,7 +85,7 @@ func BuildManifest(targets TargetSet) (Manifest, error) {
 			if _, ok := hermesSQLite[filepath.Clean(root)]; ok {
 				continue
 			}
-			if err := manifestWalk(root, targets.ForbiddenRoots, add); err != nil {
+			if err := manifestWalk(root, forbidden, add); err != nil {
 				return Manifest{}, err
 			}
 		}
@@ -111,7 +112,7 @@ func BuildManifest(targets TargetSet) (Manifest, error) {
 		}
 	}
 	for _, stateDB := range hermesStateDBs {
-		if pathWithinForbiddenRoots(targets.ForbiddenRoots, stateDB) {
+		if forbidden.within(stateDB) {
 			continue
 		}
 		size, modTime, exists := hermesSQLiteSnapshotIdentity(stateDB)
@@ -128,9 +129,9 @@ func BuildManifest(targets TargetSet) (Manifest, error) {
 }
 
 func manifestWalk(
-	root string, forbiddenRoots []string, add func(string, os.FileInfo),
+	root string, forbidden forbiddenRootMatcher, add func(string, os.FileInfo),
 ) error {
-	if pathWithinForbiddenRoots(forbiddenRoots, root) {
+	if forbidden.within(root) {
 		return nil
 	}
 	info, err := os.Lstat(root)
@@ -156,7 +157,7 @@ func manifestWalk(
 			}
 			return err
 		}
-		if pathWithinForbiddenRoots(forbiddenRoots, path) {
+		if forbidden.within(path) {
 			if entry.IsDir() {
 				return filepath.SkipDir
 			}

--- a/internal/remotesync/manifest_test.go
+++ b/internal/remotesync/manifest_test.go
@@ -57,6 +57,28 @@ func TestBuildManifestToleratesMissingRootsAndExtraFiles(t *testing.T) {
 	assert.Empty(t, m.Files)
 }
 
+func TestBuildManifestPrunesForbiddenRootNestedInAllowedRoot(t *testing.T) {
+	root := t.TempDir()
+	allowed := filepath.Join(root, "sessions")
+	forbidden := filepath.Join(allowed, ".forbidden-provider")
+	keep := filepath.Join(allowed, "session.jsonl")
+	secret := filepath.Join(forbidden, "chat.db")
+	require.NoError(t, os.MkdirAll(forbidden, 0o755))
+	require.NoError(t, os.WriteFile(keep, []byte("session"), 0o644))
+	require.NoError(t, os.WriteFile(secret, []byte("authentication state"), 0o600))
+
+	manifest, err := BuildManifest(TargetSet{
+		Dirs:           map[parser.AgentType][]string{parser.AgentClaude: {allowed}},
+		ForbiddenRoots: []string{forbidden},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, manifest.Files, 1)
+	assert.Equal(t, keep, manifest.Files[0].Path)
+	assert.NotEqual(t, secret, manifest.Files[0].Path,
+		"the manifest must never advertise a file under a forbidden root")
+}
+
 func TestBuildManifestRejectsFileScopedAgents(t *testing.T) {
 	_, err := BuildManifest(TargetSet{
 		Dirs: map[parser.AgentType][]string{parser.AgentWindsurf: {"/srv/Windsurf/User"}},

--- a/internal/remotesync/paths.go
+++ b/internal/remotesync/paths.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	pathpkg "path"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strings"
 )
@@ -133,11 +134,47 @@ func validateTargetSetPaths(targets TargetSet) error {
 }
 
 // pathWithinForbiddenRoots reports whether path is a forbidden root or lies
-// beneath one, treating path and roots as local OS filepaths. It is a thin
-// wrapper over PathWithinForbiddenRoots for this package's many same-package
-// callers, all of which operate on local filesystem paths.
+// beneath one, treating path and roots as local OS filepaths. Both sides are
+// first canonicalized into the same local comparison domain (see
+// localComparablePath), so a forbidden root configured with a relative
+// spelling still guards its children when compared against an absolute
+// target, and spelling-variant aliases of one directory on a
+// case-insensitive filesystem compare equal. It wraps
+// PathWithinForbiddenRoots for this package's many same-package callers,
+// all of which operate on local filesystem paths.
 func pathWithinForbiddenRoots(roots []string, path string) bool {
-	return PathWithinForbiddenRoots(roots, path, filepath.Separator)
+	comparable := make([]string, 0, len(roots))
+	for _, root := range roots {
+		// filepath.Abs("") would resolve to the working directory,
+		// silently turning a blank root into a cwd-wide exclusion.
+		if root == "" {
+			continue
+		}
+		comparable = append(comparable, localComparablePath(root))
+	}
+	return PathWithinForbiddenRoots(
+		comparable, localComparablePath(path), filepath.Separator,
+	)
+}
+
+// localComparablePath canonicalizes a local OS path for forbidden-root
+// comparison: resolved to absolute against the process working directory
+// (so "." and other relative override spellings anchor to the same place as
+// their absolute aliases) and case-folded on Windows and macOS, whose
+// default filesystems are case-insensitive. Folding on a case-sensitive
+// APFS/NTFS variant can only over-prune — it never widens what leaves the
+// machine. Symlink aliases are intentionally not resolved here: the archive
+// and manifest walkers never traverse symlinks, so a symlinked spelling of
+// a forbidden root cannot smuggle its contents into an archive.
+func localComparablePath(p string) string {
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		abs = filepath.Clean(p)
+	}
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		abs = strings.ToLower(abs)
+	}
+	return abs
 }
 
 // PathWithinForbiddenRoots reports whether path is a forbidden root or lies

--- a/internal/remotesync/paths.go
+++ b/internal/remotesync/paths.go
@@ -149,6 +149,16 @@ func pathWithinForbiddenRoots(roots []string, path string) bool {
 // boundary so sibling names such as .forbidden-provider-backup do not get
 // conflated with a protected directory (root "/a/b" must not match path
 // "/a/bc").
+//
+// Unlike filepath.Clean/filepath.Rel on Windows, normalization here is not
+// volume-aware: it does not preserve a leading UNC "\\host\share" marker or
+// refuse to compare paths on different drives. Correctness for volume-scoped
+// paths therefore depends on root and path having passed through the same
+// cleanPathWithSeparator call with the same sep, which cancels out any
+// shared lossy transform (both current call sites satisfy this — see
+// cleanPathWithSeparator). This function does not independently reject a
+// root and path that name different volumes; do not call it with root and
+// path drawn from different normalization domains.
 func PathWithinForbiddenRoots(roots []string, path string, sep byte) bool {
 	path = cleanPathWithSeparator(path, sep)
 	sepStr := string(sep)
@@ -175,6 +185,15 @@ func PathWithinForbiddenRoots(roots []string, path string, sep byte) bool {
 // implements this for '/'; for any other separator, p is translated to '/',
 // cleaned, and translated back so the same normalization rules apply
 // regardless of which OS is running the check.
+//
+// This is lossy for Windows volume markers: path.Clean collapses a leading
+// "//" (translated from a UNC "\\host\share" prefix) down to a single
+// separator, whereas real filepath.Clean on Windows preserves it, and this
+// function has no equivalent of filepath.Rel's refusal to relate paths on
+// different drives (e.g. "C:\x" vs "D:\x"). PathWithinForbiddenRoots relies
+// on root and path always passing through this same lossy transform so the
+// collapse cancels out in the comparison; it does not restore true
+// volume-name awareness.
 func cleanPathWithSeparator(p string, sep byte) string {
 	if sep == '/' {
 		return pathpkg.Clean(p)

--- a/internal/remotesync/paths.go
+++ b/internal/remotesync/paths.go
@@ -124,7 +124,33 @@ func validateTargetSetPaths(targets TargetSet) error {
 			return fmt.Errorf("target file %q: %w", file, err)
 		}
 	}
+	for _, root := range targets.ForbiddenRoots {
+		if _, err := safeRemotePathArchiveName(root); err != nil {
+			return fmt.Errorf("forbidden root %q: %w", root, err)
+		}
+	}
 	return nil
+}
+
+// pathWithinForbiddenRoots reports whether path is a forbidden root or lies
+// beneath one. Roots are normalized when targets are resolved, and this check
+// deliberately uses filepath.Rel instead of a string prefix so sibling names
+// such as .forbidden-provider-backup do not get conflated with the protected
+// directory.
+func pathWithinForbiddenRoots(roots []string, path string) bool {
+	path = filepath.Clean(path)
+	for _, root := range roots {
+		root = filepath.Clean(root)
+		if path == root {
+			return true
+		}
+		rel, err := filepath.Rel(root, path)
+		if err == nil && rel != ".." &&
+			!strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return true
+		}
+	}
+	return false
 }
 
 func tempPathToRemotePath(

--- a/internal/remotesync/paths.go
+++ b/internal/remotesync/paths.go
@@ -133,24 +133,56 @@ func validateTargetSetPaths(targets TargetSet) error {
 }
 
 // pathWithinForbiddenRoots reports whether path is a forbidden root or lies
-// beneath one. Roots are normalized when targets are resolved, and this check
-// deliberately uses filepath.Rel instead of a string prefix so sibling names
-// such as .forbidden-provider-backup do not get conflated with the protected
-// directory.
+// beneath one, treating path and roots as local OS filepaths. It is a thin
+// wrapper over PathWithinForbiddenRoots for this package's many same-package
+// callers, all of which operate on local filesystem paths.
 func pathWithinForbiddenRoots(roots []string, path string) bool {
-	path = filepath.Clean(path)
+	return PathWithinForbiddenRoots(roots, path, filepath.Separator)
+}
+
+// PathWithinForbiddenRoots reports whether path is a forbidden root or lies
+// beneath one. sep is the path separator of the caller's domain: '/' for
+// remote POSIX paths (see internal/ssh, which builds paths for the resolve
+// script and tar filter), or filepath.Separator for local OS paths. Roots
+// and path are normalized (dot segments resolved, redundant separators
+// collapsed) before comparison, and matching requires a full path-component
+// boundary so sibling names such as .forbidden-provider-backup do not get
+// conflated with a protected directory (root "/a/b" must not match path
+// "/a/bc").
+func PathWithinForbiddenRoots(roots []string, path string, sep byte) bool {
+	path = cleanPathWithSeparator(path, sep)
+	sepStr := string(sep)
 	for _, root := range roots {
-		root = filepath.Clean(root)
+		root = cleanPathWithSeparator(root, sep)
 		if path == root {
 			return true
 		}
-		rel, err := filepath.Rel(root, path)
-		if err == nil && rel != ".." &&
-			!strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		if root == sepStr {
+			if strings.HasPrefix(path, sepStr) {
+				return true
+			}
+			continue
+		}
+		if strings.HasPrefix(path, root+sepStr) {
 			return true
 		}
 	}
 	return false
+}
+
+// cleanPathWithSeparator normalizes p (resolving "." and ".." components and
+// collapsing redundant separators) using sep as the path separator. path.Clean
+// implements this for '/'; for any other separator, p is translated to '/',
+// cleaned, and translated back so the same normalization rules apply
+// regardless of which OS is running the check.
+func cleanPathWithSeparator(p string, sep byte) string {
+	if sep == '/' {
+		return pathpkg.Clean(p)
+	}
+	sepStr := string(sep)
+	slashed := strings.ReplaceAll(p, sepStr, "/")
+	cleaned := pathpkg.Clean(slashed)
+	return strings.ReplaceAll(cleaned, "/", sepStr)
 }
 
 func tempPathToRemotePath(

--- a/internal/remotesync/paths.go
+++ b/internal/remotesync/paths.go
@@ -159,22 +159,48 @@ func pathWithinForbiddenRoots(roots []string, path string) bool {
 
 // localComparablePath canonicalizes a local OS path for forbidden-root
 // comparison: resolved to absolute against the process working directory
-// (so "." and other relative override spellings anchor to the same place as
-// their absolute aliases) and case-folded on Windows and macOS, whose
+// (so "." and other relative override spellings anchor to the same place
+// as their absolute aliases), symlink-resolved (so a root reached through
+// a symlinked ancestor compares by its physical location — the walkers
+// skip symlink entries, but they do follow symlinked ancestors of the
+// roots they are handed), and case-folded on Windows and macOS, whose
 // default filesystems are case-insensitive. Folding on a case-sensitive
 // APFS/NTFS variant can only over-prune — it never widens what leaves the
-// machine. Symlink aliases are intentionally not resolved here: the archive
-// and manifest walkers never traverse symlinks, so a symlinked spelling of
-// a forbidden root cannot smuggle its contents into an archive.
+// machine.
 func localComparablePath(p string) string {
 	abs, err := filepath.Abs(p)
 	if err != nil {
 		abs = filepath.Clean(p)
 	}
+	abs = resolveSymlinksBestEffort(abs)
 	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
 		abs = strings.ToLower(abs)
 	}
 	return abs
+}
+
+// resolveSymlinksBestEffort resolves symlinks in p, falling back to
+// resolving the longest existing ancestor and keeping the missing tail
+// literal (forbidden roots may name directories that do not exist yet;
+// their eventual contents still deserve the boundary). A path that cannot
+// be resolved at all is returned unchanged — comparisons then degrade to
+// the lexical behavior rather than failing open by returning nothing.
+func resolveSymlinksBestEffort(p string) string {
+	if resolved, err := filepath.EvalSymlinks(p); err == nil {
+		return resolved
+	}
+	dir, tail := filepath.Dir(p), filepath.Base(p)
+	for {
+		if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+			return filepath.Join(resolved, tail)
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return p
+		}
+		tail = filepath.Join(filepath.Base(dir), tail)
+		dir = parent
+	}
 }
 
 // PathWithinForbiddenRoots reports whether path is a forbidden root or lies

--- a/internal/remotesync/paths.go
+++ b/internal/remotesync/paths.go
@@ -143,7 +143,20 @@ func validateTargetSetPaths(targets TargetSet) error {
 // PathWithinForbiddenRoots for this package's many same-package callers,
 // all of which operate on local filesystem paths.
 func pathWithinForbiddenRoots(roots []string, path string) bool {
-	comparable := make([]string, 0, len(roots))
+	return newForbiddenRootMatcher(roots).within(path)
+}
+
+// forbiddenRootMatcher holds a forbidden-root set with spellings already
+// canonicalized into the local comparison domain. Archive and manifest
+// walks construct one per operation so each entry canonicalizes only the
+// candidate path instead of re-resolving every root for every entry; the
+// zero matcher matches nothing and does no work at all.
+type forbiddenRootMatcher struct {
+	comparable []string
+}
+
+func newForbiddenRootMatcher(roots []string) forbiddenRootMatcher {
+	var comparable []string
 	for _, root := range roots {
 		// filepath.Abs("") would resolve to the working directory,
 		// silently turning a blank root into a cwd-wide exclusion.
@@ -152,8 +165,21 @@ func pathWithinForbiddenRoots(roots []string, path string) bool {
 		}
 		comparable = append(comparable, localComparablePath(root))
 	}
+	return forbiddenRootMatcher{comparable: comparable}
+}
+
+// within reports whether path is a forbidden root or lies beneath one.
+// Canonicalizing the candidate touches the filesystem (Abs plus symlink
+// resolution), so callers must pass only trusted paths or client paths
+// already validated against an allowed root — never a raw request string,
+// which on Windows could name a UNC share and force an outbound
+// connection just by being stat'ed.
+func (m forbiddenRootMatcher) within(path string) bool {
+	if len(m.comparable) == 0 {
+		return false
+	}
 	return PathWithinForbiddenRoots(
-		comparable, localComparablePath(path), filepath.Separator,
+		m.comparable, localComparablePath(path), filepath.Separator,
 	)
 }
 
@@ -185,13 +211,17 @@ func localComparablePath(p string) string {
 // their eventual contents still deserve the boundary). A path that cannot
 // be resolved at all is returned unchanged — comparisons then degrade to
 // the lexical behavior rather than failing open by returning nothing.
+// evalSymlinksFn is swapped by tests that assert which paths reach
+// filesystem-touching canonicalization.
+var evalSymlinksFn = filepath.EvalSymlinks
+
 func resolveSymlinksBestEffort(p string) string {
-	if resolved, err := filepath.EvalSymlinks(p); err == nil {
+	if resolved, err := evalSymlinksFn(p); err == nil {
 		return resolved
 	}
 	dir, tail := filepath.Dir(p), filepath.Base(p)
 	for {
-		if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		if resolved, err := evalSymlinksFn(dir); err == nil {
 			return filepath.Join(resolved, tail)
 		}
 		parent := filepath.Dir(dir)

--- a/internal/remotesync/paths_test.go
+++ b/internal/remotesync/paths_test.go
@@ -85,6 +85,53 @@ func toBackslash(roots []string) []string {
 	return out
 }
 
+// TestPathWithinForbiddenRootsWindowsStyleFixtures uses literal
+// backslash/UNC/drive-letter strings (not derived from forbiddenRootCases via
+// ReplaceAll) to document PathWithinForbiddenRoots' actual behavior on
+// Windows-shaped paths, including the volume-awareness gap called out on
+// PathWithinForbiddenRoots and cleanPathWithSeparator: normalization here is
+// not volume-aware the way real filepath.Clean/filepath.Rel are on Windows.
+// The UNC and drive-letter cases below happen to resolve correctly because
+// root and path pass through the same lossy transform (the leading "\\" of a
+// UNC path collapses to a single separator for both, and a differing drive
+// letter is still rejected because it's literally a different leading
+// string, not because this function understands volumes) — this is the
+// "collapse cancels out" property the doc comments describe, not general
+// volume awareness.
+func TestPathWithinForbiddenRootsWindowsStyleFixtures(t *testing.T) {
+	tests := []forbiddenRootCase{
+		{
+			"unc_root_matches_child",
+			[]string{`\\server\share\Secret`}, `\\server\share\Secret\file.txt`, true,
+		},
+		{
+			"unc_root_matches_itself",
+			[]string{`\\server\share\Secret`}, `\\server\share\Secret`, true,
+		},
+		{
+			"unc_prefix_not_boundary",
+			[]string{`\\server\share\Secret`}, `\\server\share\Secret2\file.txt`, false,
+		},
+		{
+			"drive_letter_root_matches_child",
+			[]string{`C:\Users\foo\Secret`}, `C:\Users\foo\Secret\file.txt`, true,
+		},
+		{
+			"drive_letter_mismatch_different_volume_rejected",
+			[]string{`C:\Users\foo\Secret`}, `D:\Users\foo\Secret\file.txt`, false,
+		},
+		{
+			"drive_letter_relative_traversal_resolves_to_sibling",
+			[]string{`C:\a\b`}, `C:\a\b\..\c`, false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, PathWithinForbiddenRoots(tc.roots, tc.path, '\\'))
+		})
+	}
+}
+
 // TestPathWithinForbiddenRootsLocalWrapper confirms the unexported
 // pathWithinForbiddenRoots wrapper used by this package's other files
 // (archive.go, manifest.go, resolve.go, types.go) matches the exported

--- a/internal/remotesync/paths_test.go
+++ b/internal/remotesync/paths_test.go
@@ -1,6 +1,7 @@
 package remotesync
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -182,6 +183,38 @@ func TestPathWithinForbiddenRootsLocalWrapperCanonicalizesRelativeSpellings(
 	assert.False(t, pathWithinForbiddenRoots(
 		[]string{"sessions"}, filepath.Join(base, "sessions2"),
 	), "canonicalization must preserve component-boundary matching")
+}
+
+// TestPathWithinForbiddenRootsLocalWrapperResolvesSymlinkAliases pins the
+// symlink half of alias handling: a path reached through a symlinked
+// ancestor must compare by its physical location, in both directions —
+// alias-spelled path against physical forbidden root, and alias-spelled
+// forbidden root against physical path.
+func TestPathWithinForbiddenRootsLocalWrapperResolvesSymlinkAliases(
+	t *testing.T,
+) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test fixture uses POSIX symlinks")
+	}
+	base, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+	forbidden := filepath.Join(base, "trae")
+	require.NoError(t, os.MkdirAll(filepath.Join(forbidden, "sub"), 0o755))
+	alias := filepath.Join(base, "alias")
+	require.NoError(t, os.Symlink(forbidden, alias))
+
+	assert.True(t, pathWithinForbiddenRoots(
+		[]string{forbidden}, filepath.Join(alias, "sub", "chat.db"),
+	), "alias-spelled path must resolve into the physical forbidden root")
+	assert.True(t, pathWithinForbiddenRoots(
+		[]string{alias}, filepath.Join(forbidden, "sub", "chat.db"),
+	), "alias-spelled forbidden root must guard its physical children")
+	assert.True(t, pathWithinForbiddenRoots(
+		[]string{forbidden}, filepath.Join(alias, "sub", "missing", "x"),
+	), "missing tails resolve through their longest existing ancestor")
+	assert.False(t, pathWithinForbiddenRoots(
+		[]string{forbidden}, filepath.Join(base, "other"),
+	), "unrelated siblings stay outside the boundary")
 }
 
 // TestPathWithinForbiddenRootsLocalWrapperCaseFolding asserts the local

--- a/internal/remotesync/paths_test.go
+++ b/internal/remotesync/paths_test.go
@@ -1,0 +1,98 @@
+package remotesync
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// forbiddenRootCase is the shared edge-case table used to characterize the
+// pre-unification divergence between the two forbidden-root predicates and
+// to drive the unified replacement, PathWithinForbiddenRoots.
+type forbiddenRootCase struct {
+	name  string
+	roots []string
+	path  string
+	want  bool
+}
+
+// forbiddenRootCases covers the edge cases called out in the task brief:
+// root "/", root == path, trailing-slash roots, prefix-but-not-boundary
+// (/a/bc vs root /a/b), and relative traversal (..). Cases are written with
+// '/' separators and translated to '\' by the backslash-separator test
+// below, so both the local (OS filepath) and remote (POSIX) call sites are
+// exercised against the same table.
+var forbiddenRootCases = []forbiddenRootCase{
+	{"root_slash_matches_deep_path", []string{"/"}, "/etc/passwd", true},
+	{"root_slash_matches_itself", []string{"/"}, "/", true},
+	{"root_slash_does_not_match_relative_path", []string{"/"}, "relative/x", false},
+	{"root_equal_path", []string{"/a/b"}, "/a/b", true},
+	{"root_child_matches", []string{"/a/b"}, "/a/b/c", true},
+	{"trailing_slash_root_matches_child", []string{"/a/b/"}, "/a/b/c", true},
+	{"trailing_slash_root_matches_itself", []string{"/a/b/"}, "/a/b", true},
+	{"prefix_not_boundary_bc", []string{"/a/b"}, "/a/bc", false},
+	{"prefix_not_boundary_more", []string{"/a/b"}, "/a/bmore", false},
+	{"relative_traversal_escapes_root", []string{"/a/b"}, "/a/b/../../etc", false},
+	{"relative_traversal_stays_under_root", []string{"/a"}, "/a/b/../../a/c", true},
+	{"relative_traversal_resolves_to_sibling", []string{"/a/b"}, "/a/b/../c", false},
+	{"relative_root_and_path_match", []string{"secret"}, "secret/x", true},
+	{"relative_path_against_absolute_root", []string{"/a/b"}, "relative/x", false},
+	{"empty_root_never_matches", []string{""}, "/a/b", false},
+	{"second_root_in_list_matches", []string{"/x", "/a/b"}, "/a/b/c", true},
+	{"no_roots_never_matches", nil, "/a/b", false},
+	{"path_is_bare_dotdot", []string{"/a/b"}, "..", false},
+}
+
+// TestPathWithinForbiddenRootsSlashSeparator exercises PathWithinForbiddenRoots
+// with '/', the separator internal/ssh uses for remote POSIX paths, and the
+// separator internal/remotesync's local wrapper also uses on non-Windows
+// hosts (filepath.Separator == '/').
+func TestPathWithinForbiddenRootsSlashSeparator(t *testing.T) {
+	for _, tc := range forbiddenRootCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, PathWithinForbiddenRoots(tc.roots, tc.path, '/'))
+		})
+	}
+}
+
+// TestPathWithinForbiddenRootsBackslashSeparator exercises the same table
+// through the Windows-style separator ('\'). Neither pre-unification donor
+// implementation could be exercised against this separator on a non-Windows
+// runner: the old internal/remotesync predicate depended on
+// filepath.Separator, which is only '\' on an actual Windows GOOS build, and
+// the old internal/ssh predicate was hardcoded to '/'. Because the unified
+// predicate takes sep as an explicit parameter, local-filepath behavior is
+// now testable on any host OS.
+func TestPathWithinForbiddenRootsBackslashSeparator(t *testing.T) {
+	for _, tc := range forbiddenRootCases {
+		t.Run(tc.name, func(t *testing.T) {
+			roots := toBackslash(tc.roots)
+			path := strings.ReplaceAll(tc.path, "/", `\`)
+			assert.Equal(t, tc.want, PathWithinForbiddenRoots(roots, path, '\\'))
+		})
+	}
+}
+
+func toBackslash(roots []string) []string {
+	if roots == nil {
+		return nil
+	}
+	out := make([]string, len(roots))
+	for i, r := range roots {
+		out[i] = strings.ReplaceAll(r, "/", `\`)
+	}
+	return out
+}
+
+// TestPathWithinForbiddenRootsLocalWrapper confirms the unexported
+// pathWithinForbiddenRoots wrapper used by this package's other files
+// (archive.go, manifest.go, resolve.go, types.go) matches the exported
+// predicate for local OS paths.
+func TestPathWithinForbiddenRootsLocalWrapper(t *testing.T) {
+	for _, tc := range forbiddenRootCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, pathWithinForbiddenRoots(tc.roots, tc.path))
+		})
+	}
+}

--- a/internal/remotesync/paths_test.go
+++ b/internal/remotesync/paths_test.go
@@ -1,10 +1,13 @@
 package remotesync
 
 import (
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // forbiddenRootCase is the shared edge-case table used to characterize the
@@ -135,11 +138,63 @@ func TestPathWithinForbiddenRootsWindowsStyleFixtures(t *testing.T) {
 // TestPathWithinForbiddenRootsLocalWrapper confirms the unexported
 // pathWithinForbiddenRoots wrapper used by this package's other files
 // (archive.go, manifest.go, resolve.go, types.go) matches the exported
-// predicate for local OS paths.
+// predicate for local OS paths, except where its canonicalization
+// deliberately strengthens matching: a relative path is anchored to the
+// working directory before comparison, so root "/" now guards it too.
 func TestPathWithinForbiddenRootsLocalWrapper(t *testing.T) {
+	localWants := map[string]bool{
+		// filepath.Abs anchors "relative/x" under cwd, which lies
+		// beneath root "/" — the wrapper intentionally diverges from
+		// the pure lexical predicate here.
+		"root_slash_does_not_match_relative_path": true,
+	}
 	for _, tc := range forbiddenRootCases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, pathWithinForbiddenRoots(tc.roots, tc.path))
+			want := tc.want
+			if localWant, ok := localWants[tc.name]; ok {
+				want = localWant
+			}
+			assert.Equal(t, want, pathWithinForbiddenRoots(tc.roots, tc.path))
 		})
+	}
+}
+
+// TestPathWithinForbiddenRootsLocalWrapperCanonicalizesRelativeSpellings
+// pins the fix for filesystem-equivalent alias spellings: a forbidden root
+// configured relatively must still guard its absolute alias's children,
+// and vice versa, and a root of "." must guard relative children.
+func TestPathWithinForbiddenRootsLocalWrapperCanonicalizesRelativeSpellings(
+	t *testing.T,
+) {
+	base, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+	t.Chdir(base)
+	absRoot := filepath.Join(base, "sessions")
+
+	assert.True(t, pathWithinForbiddenRoots(
+		[]string{"sessions"}, filepath.Join(absRoot, "chat.db"),
+	), "relative root spelling must guard absolute children")
+	assert.True(t, pathWithinForbiddenRoots(
+		[]string{absRoot}, filepath.Join("sessions", "chat.db"),
+	), "absolute root must guard relatively spelled children")
+	assert.True(t, pathWithinForbiddenRoots([]string{"."}, "sessions"),
+		"root \".\" must guard relative children of the working directory")
+	assert.False(t, pathWithinForbiddenRoots(
+		[]string{"sessions"}, filepath.Join(base, "sessions2"),
+	), "canonicalization must preserve component-boundary matching")
+}
+
+// TestPathWithinForbiddenRootsLocalWrapperCaseFolding asserts the local
+// wrapper compares case-insensitively exactly on hosts whose default
+// filesystems are case-insensitive (Windows, macOS) and case-sensitively
+// everywhere else.
+func TestPathWithinForbiddenRootsLocalWrapperCaseFolding(t *testing.T) {
+	got := pathWithinForbiddenRoots([]string{"/a/Secret"}, "/a/sECRET/file")
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		assert.True(t, got,
+			"case-variant alias of a forbidden root must match on a case-insensitive host")
+	} else {
+		assert.False(t, got,
+			"case-sensitive hosts must not conflate case-variant paths")
 	}
 }

--- a/internal/remotesync/paths_test.go
+++ b/internal/remotesync/paths_test.go
@@ -231,3 +231,56 @@ func TestPathWithinForbiddenRootsLocalWrapperCaseFolding(t *testing.T) {
 			"case-sensitive hosts must not conflate case-variant paths")
 	}
 }
+
+// TestSelectAllowedFilesNeverCanonicalizesUnmatchedClientPaths pins the
+// validate-before-canonicalize order: forbidden-root comparison resolves
+// symlinks (filesystem access), so a client-supplied delta path that
+// matches no allowed root must be rejected without ever being touched —
+// on Windows, stat'ing a raw \\attacker\share path would force an
+// outbound SMB connection.
+func TestSelectAllowedFilesNeverCanonicalizesUnmatchedClientPaths(
+	t *testing.T,
+) {
+	base, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+	forbiddenRoot := filepath.Join(base, "trae")
+	require.NoError(t, os.MkdirAll(forbiddenRoot, 0o755))
+	allowed := TargetSet{ForbiddenRoots: []string{forbiddenRoot}}
+
+	var touched []string
+	orig := evalSymlinksFn
+	evalSymlinksFn = func(p string) (string, error) {
+		if strings.Contains(p, "attacker") {
+			touched = append(touched, p)
+		}
+		return orig(p)
+	}
+	t.Cleanup(func() { evalSymlinksFn = orig })
+
+	for _, attacker := range []string{
+		`\\attacker\share\x`,
+		"/attacker/evil",
+	} {
+		_, ok := SelectAllowedFiles(allowed, []string{attacker})
+		assert.False(t, ok, "unmatched path %q must be rejected", attacker)
+	}
+	assert.Empty(t, touched,
+		"client paths matching no allowed root must never reach filesystem canonicalization")
+}
+
+// TestForbiddenRootMatcherEmptyDoesNoWork asserts the common
+// no-forbidden-roots case short-circuits before any canonicalization.
+func TestForbiddenRootMatcherEmptyDoesNoWork(t *testing.T) {
+	calls := 0
+	orig := evalSymlinksFn
+	evalSymlinksFn = func(p string) (string, error) {
+		calls++
+		return orig(p)
+	}
+	t.Cleanup(func() { evalSymlinksFn = orig })
+
+	m := newForbiddenRootMatcher(nil)
+	assert.False(t, m.within("/any/path"))
+	assert.Zero(t, calls,
+		"an empty matcher must not canonicalize candidate paths")
+}

--- a/internal/remotesync/resolve.go
+++ b/internal/remotesync/resolve.go
@@ -111,12 +111,13 @@ func filterForbiddenTargets(t TargetSet) TargetSet {
 	if len(t.ForbiddenRoots) == 0 {
 		return t
 	}
+	forbidden := newForbiddenRootMatcher(t.ForbiddenRoots)
 	fileScoped := make(map[parser.AgentType]bool, len(t.Files))
 	for agent := range t.Files {
 		fileScoped[agent] = true
 	}
 	for agent, dirs := range t.Dirs {
-		kept := withoutForbidden(dirs, t.ForbiddenRoots)
+		kept := withoutForbidden(dirs, forbidden)
 		if len(kept) == 0 {
 			delete(t.Dirs, agent)
 			continue
@@ -124,7 +125,7 @@ func filterForbiddenTargets(t TargetSet) TargetSet {
 		t.Dirs[agent] = kept
 	}
 	for agent, files := range t.Files {
-		kept := withoutForbidden(files, t.ForbiddenRoots)
+		kept := withoutForbidden(files, forbidden)
 		if len(kept) == 0 {
 			delete(t.Files, agent)
 			continue
@@ -142,14 +143,14 @@ func filterForbiddenTargets(t TargetSet) TargetSet {
 			delete(t.Files, agent)
 		}
 	}
-	t.ExtraFiles = withoutForbidden(t.ExtraFiles, t.ForbiddenRoots)
+	t.ExtraFiles = withoutForbidden(t.ExtraFiles, forbidden)
 	return t
 }
 
-func withoutForbidden(paths, forbiddenRoots []string) []string {
+func withoutForbidden(paths []string, forbidden forbiddenRootMatcher) []string {
 	var kept []string
 	for _, path := range paths {
-		if !pathWithinForbiddenRoots(forbiddenRoots, path) {
+		if !forbidden.within(path) {
 			kept = append(kept, path)
 		}
 	}
@@ -486,6 +487,7 @@ func SelectAllowedTargets(allowed TargetSet, requested TargetSet) (TargetSet, bo
 		Dirs:           make(map[parser.AgentType][]string),
 		ForbiddenRoots: append([]string(nil), allowed.ForbiddenRoots...),
 	}
+	forbidden := newForbiddenRootMatcher(selected.ForbiddenRoots)
 	for agent, dirs := range requested.Dirs {
 		allowedDirs := allowed.Dirs[agent]
 		if _, fileScoped := allowed.Files[agent]; fileScoped {
@@ -499,7 +501,7 @@ func SelectAllowedTargets(allowed TargetSet, requested TargetSet) (TargetSet, bo
 			if !ok {
 				return TargetSet{}, false
 			}
-			if pathWithinForbiddenRoots(selected.ForbiddenRoots, selectedDir) {
+			if forbidden.within(selectedDir) {
 				return TargetSet{}, false
 			}
 			selected.Dirs[agent] = append(selected.Dirs[agent], selectedDir)
@@ -528,7 +530,7 @@ func SelectAllowedTargets(allowed TargetSet, requested TargetSet) (TargetSet, bo
 			if selected.Files == nil {
 				selected.Files = make(map[parser.AgentType][]string)
 			}
-			if pathWithinForbiddenRoots(selected.ForbiddenRoots, selectedFile) {
+			if forbidden.within(selectedFile) {
 				return TargetSet{}, false
 			}
 			selected.Files[agent] = append(selected.Files[agent], selectedFile)
@@ -539,7 +541,7 @@ func SelectAllowedTargets(allowed TargetSet, requested TargetSet) (TargetSet, bo
 		if !ok {
 			return TargetSet{}, false
 		}
-		if pathWithinForbiddenRoots(selected.ForbiddenRoots, selectedFile) {
+		if forbidden.within(selectedFile) {
 			return TargetSet{}, false
 		}
 		selected.ExtraFiles = append(selected.ExtraFiles, selectedFile)
@@ -670,9 +672,10 @@ func isAiderUnsafeRoot(dir string) bool {
 // comparisons additionally require matching path dialects and reject
 // symlinked ancestors that would escape the allowed root.
 func SelectAllowedFiles(allowed TargetSet, files []string) ([]string, bool) {
+	forbidden := newForbiddenRootMatcher(allowed.ForbiddenRoots)
 	selected := make([]string, 0, len(files))
 	for _, file := range files {
-		canonical, ok := selectAllowedFile(allowed, file)
+		canonical, ok := selectAllowedFile(allowed, forbidden, file)
 		if !ok {
 			return nil, false
 		}
@@ -681,12 +684,18 @@ func SelectAllowedFiles(allowed TargetSet, files []string) ([]string, bool) {
 	return selected, true
 }
 
-func selectAllowedFile(allowed TargetSet, file string) (string, bool) {
-	if pathWithinForbiddenRoots(allowed.ForbiddenRoots, file) {
-		return "", false
-	}
+// selectAllowedFile validates the request string against the allowed sets
+// first and checks forbidden roots only on a match. The forbidden check
+// canonicalizes its argument with filesystem access, which must never run
+// on an unmatched client-supplied path: on Windows a raw request naming
+// \\attacker\share would otherwise force an outbound SMB connection.
+// Every accept path below is either a server-derived string or anchored
+// under a trusted allowed root before the matcher sees it.
+func selectAllowedFile(
+	allowed TargetSet, forbidden forbiddenRootMatcher, file string,
+) (string, bool) {
 	if canonical, ok := selectAllowedString(allowed.ExtraFiles, file); ok {
-		return canonical, true
+		return canonical, !forbidden.within(canonical)
 	}
 	for agent, files := range allowed.Files {
 		if !verbatimFileScopedAgent(agent) {
@@ -700,10 +709,10 @@ func selectAllowedFile(allowed TargetSet, file string) (string, bool) {
 		// skips it because its delta roots come from the same fresh
 		// resolution.
 		if canonical, ok := selectAllowedString(files, file); ok {
-			return canonical, true
+			return canonical, !forbidden.within(canonical)
 		}
 		if verbatimSessionFileUnderAllowedRoot(allowed, agent, file) {
-			return file, true
+			return file, !forbidden.within(file)
 		}
 	}
 	if !isAbsRemotePath(file) {
@@ -740,8 +749,10 @@ func selectAllowedFile(allowed TargetSet, file string) (string, bool) {
 				// Exact root matches are allowed: file roots (Aider
 				// history files) must stream, and a directory root
 				// yields nothing because WriteArchiveFiles skips
-				// non-regular entries.
-				return file, true
+				// non-regular entries. The file is anchored under the
+				// trusted dir at this point, so the forbidden check may
+				// canonicalize it.
+				return file, !forbidden.within(file)
 			}
 		}
 	}

--- a/internal/remotesync/resolve.go
+++ b/internal/remotesync/resolve.go
@@ -93,9 +93,67 @@ func ResolveTargets(cfg config.Config) TargetSet {
 			}
 		}
 	}
-	return TargetSet{
+	return filterForbiddenTargets(TargetSet{
 		Dirs: dirs, Files: files, ExtraFiles: extra, ForbiddenRoots: forbiddenRoots,
+	})
+}
+
+// filterForbiddenTargets drops resolved targets that lie inside a forbidden
+// root before they are advertised. Overlapping directory overrides can nest
+// an allowed agent's root beneath an excluded agent's root; advertising the
+// nested target would make every honest client echo it back and fail the
+// whole request in SelectAllowedTargets (fail closed, HTTP 403) instead of
+// syncing the remaining targets. The per-item forbidden checks in
+// SelectAllowedTargets stay as defense-in-depth against stale or
+// hand-crafted requests. Registry order does not matter here: the filter
+// runs after every excluded agent has contributed its roots.
+func filterForbiddenTargets(t TargetSet) TargetSet {
+	if len(t.ForbiddenRoots) == 0 {
+		return t
 	}
+	fileScoped := make(map[parser.AgentType]bool, len(t.Files))
+	for agent := range t.Files {
+		fileScoped[agent] = true
+	}
+	for agent, dirs := range t.Dirs {
+		kept := withoutForbidden(dirs, t.ForbiddenRoots)
+		if len(kept) == 0 {
+			delete(t.Dirs, agent)
+			continue
+		}
+		t.Dirs[agent] = kept
+	}
+	for agent, files := range t.Files {
+		kept := withoutForbidden(files, t.ForbiddenRoots)
+		if len(kept) == 0 {
+			delete(t.Files, agent)
+			continue
+		}
+		t.Files[agent] = kept
+	}
+	// A file-scoped agent's root is only safe to advertise alongside its
+	// curated file list; if filtering removed either half, drop both so the
+	// agent cannot degrade to a raw directory target.
+	for agent := range fileScoped {
+		_, hasDirs := t.Dirs[agent]
+		_, hasFiles := t.Files[agent]
+		if hasDirs != hasFiles {
+			delete(t.Dirs, agent)
+			delete(t.Files, agent)
+		}
+	}
+	t.ExtraFiles = withoutForbidden(t.ExtraFiles, t.ForbiddenRoots)
+	return t
+}
+
+func withoutForbidden(paths, forbiddenRoots []string) []string {
+	var kept []string
+	for _, path := range paths {
+		if !pathWithinForbiddenRoots(forbiddenRoots, path) {
+			kept = append(kept, path)
+		}
+	}
+	return kept
 }
 
 func appendUniqueForbiddenRoot(roots []string, root string) []string {

--- a/internal/remotesync/resolve.go
+++ b/internal/remotesync/resolve.go
@@ -16,11 +16,19 @@ func ResolveTargets(cfg config.Config) TargetSet {
 	dirs := make(map[parser.AgentType][]string)
 	files := make(map[parser.AgentType][]string)
 	var extra []string
+	var forbiddenRoots []string
 	for _, def := range parser.Registry {
+		resolvedDirs := cfg.ResolveDirs(def.Type)
+		if def.RemoteSyncExcluded {
+			for _, dir := range resolvedDirs {
+				forbiddenRoots = appendUniqueForbiddenRoot(forbiddenRoots, dir)
+			}
+			continue
+		}
 		if !resolveAgentHasOnDiskSource(def) {
 			continue
 		}
-		for _, dir := range cfg.ResolveDirs(def.Type) {
+		for _, dir := range resolvedDirs {
 			if def.Type == parser.AgentHermes {
 				hermesDirs, hermesFiles := resolveHermesTargets(dir)
 				if len(hermesDirs) > 0 {
@@ -85,7 +93,20 @@ func ResolveTargets(cfg config.Config) TargetSet {
 			}
 		}
 	}
-	return TargetSet{Dirs: dirs, Files: files, ExtraFiles: extra}
+	return TargetSet{
+		Dirs: dirs, Files: files, ExtraFiles: extra, ForbiddenRoots: forbiddenRoots,
+	}
+}
+
+func appendUniqueForbiddenRoot(roots []string, root string) []string {
+	if root == "" {
+		return roots
+	}
+	root = filepath.Clean(root)
+	if slices.Contains(roots, root) {
+		return roots
+	}
+	return append(roots, root)
 }
 
 func resolveHermesTargets(root string) ([]string, []string) {
@@ -404,7 +425,8 @@ func TargetSetAllowed(allowed TargetSet, requested TargetSet) bool {
 
 func SelectAllowedTargets(allowed TargetSet, requested TargetSet) (TargetSet, bool) {
 	selected := TargetSet{
-		Dirs: make(map[parser.AgentType][]string),
+		Dirs:           make(map[parser.AgentType][]string),
+		ForbiddenRoots: append([]string(nil), allowed.ForbiddenRoots...),
 	}
 	for agent, dirs := range requested.Dirs {
 		allowedDirs := allowed.Dirs[agent]
@@ -417,6 +439,9 @@ func SelectAllowedTargets(allowed TargetSet, requested TargetSet) (TargetSet, bo
 		for _, dir := range dirs {
 			selectedDir, ok := selectAllowedString(allowedDirs, dir)
 			if !ok {
+				return TargetSet{}, false
+			}
+			if pathWithinForbiddenRoots(selected.ForbiddenRoots, selectedDir) {
 				return TargetSet{}, false
 			}
 			selected.Dirs[agent] = append(selected.Dirs[agent], selectedDir)
@@ -445,12 +470,18 @@ func SelectAllowedTargets(allowed TargetSet, requested TargetSet) (TargetSet, bo
 			if selected.Files == nil {
 				selected.Files = make(map[parser.AgentType][]string)
 			}
+			if pathWithinForbiddenRoots(selected.ForbiddenRoots, selectedFile) {
+				return TargetSet{}, false
+			}
 			selected.Files[agent] = append(selected.Files[agent], selectedFile)
 		}
 	}
 	for _, file := range requested.ExtraFiles {
 		selectedFile, ok := selectAllowedString(allowed.ExtraFiles, file)
 		if !ok {
+			return TargetSet{}, false
+		}
+		if pathWithinForbiddenRoots(selected.ForbiddenRoots, selectedFile) {
 			return TargetSet{}, false
 		}
 		selected.ExtraFiles = append(selected.ExtraFiles, selectedFile)
@@ -593,6 +624,9 @@ func SelectAllowedFiles(allowed TargetSet, files []string) ([]string, bool) {
 }
 
 func selectAllowedFile(allowed TargetSet, file string) (string, bool) {
+	if pathWithinForbiddenRoots(allowed.ForbiddenRoots, file) {
+		return "", false
+	}
 	if canonical, ok := selectAllowedString(allowed.ExtraFiles, file); ok {
 		return canonical, true
 	}

--- a/internal/remotesync/resolve_test.go
+++ b/internal/remotesync/resolve_test.go
@@ -83,6 +83,33 @@ func TestResolveTargetsFiltersAndIncludesSpecialFiles(t *testing.T) {
 	assert.Contains(t, targets.ExtraFiles, codexIndex)
 }
 
+func TestResolveTargetsExcludesRemoteSyncExcludedAgentState(t *testing.T) {
+	root := t.TempDir()
+	chatDB := filepath.Join(root, "chat.db")
+	for _, path := range []string{
+		chatDB,
+		chatDB + "-wal",
+		chatDB + "-shm",
+		chatDB + "-journal",
+	} {
+		require.NoError(t, os.WriteFile(path, []byte("sqlite"), 0o644))
+	}
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "credentials.json"), []byte("secret"), 0o600,
+	))
+
+	targets := remotesync.ResolveTargets(config.Config{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentTrae: {root},
+		},
+	})
+
+	assert.NotContains(t, targets.Dirs, parser.AgentTrae)
+	assert.NotContains(t, targets.Files, parser.AgentTrae)
+	assert.Equal(t, []string{filepath.Clean(root)}, targets.ForbiddenRoots,
+		"excluded-provider roots must remain as transfer boundaries")
+}
+
 func TestResolveTargetsExcludesTraeProfile(t *testing.T) {
 	root := t.TempDir()
 	traeRoot := filepath.Join(root, "TRAE", "User")
@@ -283,6 +310,32 @@ func TestSelectAllowedTargetsReturnsResolvedValues(t *testing.T) {
 		"/srv/Windsurf/User/workspaceStorage/a/state.vscdb",
 	}, selected.Files[parser.AgentWindsurf])
 	assert.Equal(t, []string{"/srv/.codex/session_index.jsonl"}, selected.ExtraFiles)
+}
+
+func TestSelectAllowedTargetsRetainsForbiddenRootsAndRejectsForbiddenDelta(t *testing.T) {
+	root := t.TempDir()
+	allowedRoot := filepath.Join(root, "sessions")
+	forbiddenRoot := filepath.Join(allowedRoot, ".forbidden-provider")
+	secret := filepath.Join(forbiddenRoot, "chat.db")
+	keep := filepath.Join(allowedRoot, "session.jsonl")
+	require.NoError(t, os.MkdirAll(forbiddenRoot, 0o755))
+	require.NoError(t, os.WriteFile(keep, []byte("session"), 0o644))
+	require.NoError(t, os.WriteFile(secret, []byte("authentication state"), 0o600))
+
+	allowed := remotesync.TargetSet{
+		Dirs:           map[parser.AgentType][]string{parser.AgentClaude: {allowedRoot}},
+		ForbiddenRoots: []string{forbiddenRoot},
+	}
+	selected, ok := remotesync.SelectAllowedTargets(allowed, remotesync.TargetSet{
+		Dirs: map[parser.AgentType][]string{parser.AgentClaude: {allowedRoot}},
+	})
+
+	require.True(t, ok)
+	assert.Equal(t, []string{forbiddenRoot}, selected.ForbiddenRoots,
+		"archive and manifest writers need the server-resolved boundary")
+	_, ok = remotesync.SelectAllowedFiles(allowed, []string{secret})
+	assert.False(t, ok,
+		"the delta request must reject a forbidden file even under an allowed root")
 }
 
 func TestSelectAllowedTargetsRejectsFileScopedDirOnlyRequest(t *testing.T) {

--- a/internal/remotesync/resolve_test.go
+++ b/internal/remotesync/resolve_test.go
@@ -446,7 +446,11 @@ func TestResolveTargetsMatchesSSHResolverForRepresentativeHome(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("SSH resolver parity test compares Unix shell path dialects")
 	}
-	home := t.TempDir()
+	// The resolve script emits physical paths, so the parity fixture must
+	// live at a physical spelling (macOS t.TempDir() sits under the /var
+	// symlink).
+	home, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
 	claudeDir := filepath.Join(home, ".claude", "projects")
 	codexDir := filepath.Join(home, ".codex", "sessions")
 	devinDir := filepath.Join(home, ".local", "share", "devin")
@@ -476,7 +480,7 @@ func TestResolveTargetsMatchesSSHResolverForRepresentativeHome(t *testing.T) {
 	cmd.Env = []string{"HOME=" + home, "AIDER_DIR=" + aiderRoot, "DEVIN_DIR=" + devinDir}
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "ssh resolver output: %s", out)
-	sshDirs, sshFiles, sshExtra := ssh.ParseResolvedTargetsWithFilesForTest(string(out))
+	sshDirs, sshFiles, sshExtra, _ := ssh.ParseResolvedTargetsWithFilesForTest(string(out))
 
 	goTargets := remotesync.ResolveTargets(config.Config{
 		AgentDirs: map[parser.AgentType][]string{

--- a/internal/remotesync/resolve_test.go
+++ b/internal/remotesync/resolve_test.go
@@ -125,6 +125,69 @@ func TestResolveTargetsExcludesTraeProfile(t *testing.T) {
 	assert.Equal(t, []string{claudeRoot}, targets.Dirs[parser.AgentClaude])
 }
 
+// TestResolveTargetsOmitsAllowedTargetsInsideForbiddenRoots pins the fix
+// for overlapping directory overrides: an allowed agent's root nested
+// inside an excluded agent's root must be omitted from the advertised
+// TargetSet — not advertised and then rejected — so an honest client
+// echoing the advertised set syncs the remaining targets instead of
+// failing the whole request with 403.
+func TestResolveTargetsOmitsAllowedTargetsInsideForbiddenRoots(t *testing.T) {
+	base := t.TempDir()
+	traeRoot := filepath.Join(base, "trae")
+	nestedClaude := filepath.Join(traeRoot, "claude")
+	outsideClaude := filepath.Join(base, "claude")
+	require.NoError(t, os.MkdirAll(nestedClaude, 0o755))
+	require.NoError(t, os.MkdirAll(outsideClaude, 0o755))
+
+	targets := remotesync.ResolveTargets(config.Config{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentTrae:   {traeRoot},
+			parser.AgentClaude: {nestedClaude, outsideClaude},
+		},
+	})
+
+	assert.Equal(t, []string{outsideClaude}, targets.Dirs[parser.AgentClaude],
+		"nested root must be dropped from the advertised set, siblings kept")
+	assert.Equal(t, []string{traeRoot}, targets.ForbiddenRoots)
+
+	selected, ok := remotesync.SelectAllowedTargets(targets, targets)
+	require.True(t, ok,
+		"a client echoing the advertised set must not be rejected")
+	assert.Equal(t, []string{outsideClaude}, selected.Dirs[parser.AgentClaude])
+}
+
+// TestResolveTargetsDropsFileScopedAgentWhenSessionFilesForbidden guards
+// the file-scoped pairing invariant: when a forbidden root swallows a
+// file-scoped agent's curated session files but not its advertised root,
+// both halves must be dropped — otherwise the agent would degrade to a
+// raw directory target and expose settings and caches its file scoping
+// exists to keep unreachable.
+func TestResolveTargetsDropsFileScopedAgentWhenSessionFilesForbidden(
+	t *testing.T,
+) {
+	base := t.TempDir()
+	rooRoot := filepath.Join(base, "globalStorage", "rooveterinaryinc.roo-cline")
+	tasksDir := filepath.Join(rooRoot, "tasks")
+	taskDir := filepath.Join(tasksDir, "task-1")
+	require.NoError(t, os.MkdirAll(taskDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(taskDir, "history_item.json"),
+		[]byte(`{"id":"task-1","ts":1,"task":"t"}`), 0o644,
+	))
+
+	targets := remotesync.ResolveTargets(config.Config{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentTrae:    {tasksDir},
+			parser.AgentRooCode: {rooRoot},
+		},
+	})
+
+	assert.Equal(t, []string{tasksDir}, targets.ForbiddenRoots)
+	assert.NotContains(t, targets.Dirs, parser.AgentRooCode,
+		"file-scoped root must not survive as a raw directory target")
+	assert.NotContains(t, targets.Files, parser.AgentRooCode)
+}
+
 // TestResolveTargetsPoolsideNarrowsToTrajectories ensures the HTTP
 // remote-sync resolver narrows Poolside's application-data root to
 // only the trajectories/ subdirectory, preventing unrelated config,

--- a/internal/remotesync/types.go
+++ b/internal/remotesync/types.go
@@ -104,6 +104,7 @@ func (t TargetSet) SplitFileScoped() (dirScoped, fileScoped TargetSet) {
 // never delta-streamed. WriteArchiveFiles uses these roots while
 // retaining the TargetSet's agent ownership information.
 func (t TargetSet) DeltaAllowedRoots() []string {
+	forbidden := newForbiddenRootMatcher(t.ForbiddenRoots)
 	roots := make([]string, 0, len(t.Dirs)+len(t.Files)+len(t.ExtraFiles))
 	for agent, dirs := range t.Dirs {
 		if parser.RemoteSyncExcludedAgent(agent) {
@@ -113,7 +114,7 @@ func (t TargetSet) DeltaAllowedRoots() []string {
 			continue
 		}
 		for _, dir := range dirs {
-			if !pathWithinForbiddenRoots(t.ForbiddenRoots, dir) {
+			if !forbidden.within(dir) {
 				roots = append(roots, dir)
 			}
 		}
@@ -124,14 +125,14 @@ func (t TargetSet) DeltaAllowedRoots() []string {
 		}
 		if verbatimFileScopedAgent(agent) {
 			for _, file := range files {
-				if !pathWithinForbiddenRoots(t.ForbiddenRoots, file) {
+				if !forbidden.within(file) {
 					roots = append(roots, file)
 				}
 			}
 		}
 	}
 	for _, file := range t.ExtraFiles {
-		if !pathWithinForbiddenRoots(t.ForbiddenRoots, file) {
+		if !forbidden.within(file) {
 			roots = append(roots, file)
 		}
 	}

--- a/internal/remotesync/types.go
+++ b/internal/remotesync/types.go
@@ -18,9 +18,10 @@ type SyncStats struct {
 }
 
 type TargetSet struct {
-	Dirs       map[parser.AgentType][]string `json:"dirs"`
-	Files      map[parser.AgentType][]string `json:"files,omitempty"`
-	ExtraFiles []string                      `json:"extra_files,omitempty"`
+	Dirs           map[parser.AgentType][]string `json:"dirs"`
+	Files          map[parser.AgentType][]string `json:"files,omitempty"`
+	ExtraFiles     []string                      `json:"extra_files,omitempty"`
+	ForbiddenRoots []string                      `json:"forbidden_roots,omitempty"`
 }
 
 // HasFileScopedAgents reports whether any agent exports a curated
@@ -65,6 +66,8 @@ func (t TargetSet) IsEmpty() bool {
 // syncs incrementally via the mirror delta; the sanitized half is
 // fetched as a separate small full archive every sync.
 func (t TargetSet) SplitFileScoped() (dirScoped, fileScoped TargetSet) {
+	dirScoped.ForbiddenRoots = append([]string(nil), t.ForbiddenRoots...)
+	fileScoped.ForbiddenRoots = append([]string(nil), t.ForbiddenRoots...)
 	for agent, dirs := range t.Dirs {
 		if _, ok := t.Files[agent]; ok && !verbatimFileScopedAgent(agent) {
 			if fileScoped.Dirs == nil {
@@ -103,17 +106,35 @@ func (t TargetSet) SplitFileScoped() (dirScoped, fileScoped TargetSet) {
 func (t TargetSet) DeltaAllowedRoots() []string {
 	roots := make([]string, 0, len(t.Dirs)+len(t.Files)+len(t.ExtraFiles))
 	for agent, dirs := range t.Dirs {
+		if parser.RemoteSyncExcludedAgent(agent) {
+			continue
+		}
 		if _, fileScoped := t.Files[agent]; fileScoped {
 			continue
 		}
-		roots = append(roots, dirs...)
-	}
-	for agent, files := range t.Files {
-		if verbatimFileScopedAgent(agent) {
-			roots = append(roots, files...)
+		for _, dir := range dirs {
+			if !pathWithinForbiddenRoots(t.ForbiddenRoots, dir) {
+				roots = append(roots, dir)
+			}
 		}
 	}
-	roots = append(roots, t.ExtraFiles...)
+	for agent, files := range t.Files {
+		if parser.RemoteSyncExcludedAgent(agent) {
+			continue
+		}
+		if verbatimFileScopedAgent(agent) {
+			for _, file := range files {
+				if !pathWithinForbiddenRoots(t.ForbiddenRoots, file) {
+					roots = append(roots, file)
+				}
+			}
+		}
+	}
+	for _, file := range t.ExtraFiles {
+		if !pathWithinForbiddenRoots(t.ForbiddenRoots, file) {
+			roots = append(roots, file)
+		}
+	}
 	return roots
 }
 
@@ -138,6 +159,9 @@ func (r ArchiveRequest) MarshalJSON() ([]byte, error) {
 	if len(r.ExtraFiles) > 0 {
 		out["extra_files"] = r.ExtraFiles
 	}
+	if len(r.ForbiddenRoots) > 0 {
+		out["forbidden_roots"] = r.ForbiddenRoots
+	}
 	if r.DeltaFiles != nil {
 		out["delta_files"] = r.DeltaFiles
 	}
@@ -146,17 +170,19 @@ func (r ArchiveRequest) MarshalJSON() ([]byte, error) {
 
 func (r *ArchiveRequest) UnmarshalJSON(data []byte) error {
 	var raw struct {
-		Dirs       map[parser.AgentType][]string `json:"dirs"`
-		Files      json.RawMessage               `json:"files"`
-		ExtraFiles []string                      `json:"extra_files"`
-		DeltaFiles []string                      `json:"delta_files"`
+		Dirs           map[parser.AgentType][]string `json:"dirs"`
+		Files          json.RawMessage               `json:"files"`
+		ExtraFiles     []string                      `json:"extra_files"`
+		ForbiddenRoots []string                      `json:"forbidden_roots"`
+		DeltaFiles     []string                      `json:"delta_files"`
 	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
 	r.TargetSet = TargetSet{
-		Dirs:       raw.Dirs,
-		ExtraFiles: raw.ExtraFiles,
+		Dirs:           raw.Dirs,
+		ExtraFiles:     raw.ExtraFiles,
+		ForbiddenRoots: raw.ForbiddenRoots,
 	}
 	r.DeltaFiles = raw.DeltaFiles
 	if len(raw.Files) == 0 {

--- a/internal/ssh/resolve.go
+++ b/internal/ssh/resolve.go
@@ -389,22 +389,16 @@ func resolveAgentHasOnDiskSource(def parser.AgentDef) bool {
 	}
 }
 
-// parseResolvedTargets parses script output into deduplicated agent root paths,
-// agent-scoped files, and extra files (records tagged with resolveFilePrefix).
-// Generated resolver output is
+// parseResolvedTargets parses script output into deduplicated agent root
+// paths, agent-scoped files, extra files (records tagged with
+// resolveFilePrefix), and forbidden roots (records tagged with
+// resolveForbiddenRootPrefix). Generated resolver output is
 // NUL-delimited so remote paths containing newlines cannot inject extra
 // records; newline-delimited input is accepted only for older tests and
 // defensive compatibility. Most agent targets are directories; Aider
 // targets are individual .aider.chat.history.md files. Skips empty
 // records, empty values, and values containing record separators.
 func parseResolvedTargets(
-	output string,
-) (map[parser.AgentType][]string, map[parser.AgentType][]string, []string) {
-	dirs, files, extraFiles, _ := parseResolvedTargetsWithForbidden(output)
-	return dirs, files, extraFiles
-}
-
-func parseResolvedTargetsWithForbidden(
 	output string,
 ) (map[parser.AgentType][]string, map[parser.AgentType][]string, []string, []string) {
 	dirs := make(map[parser.AgentType][]string)
@@ -483,7 +477,7 @@ func parseResolvedTargetsWithForbidden(
 func parseResolvedDirs(
 	output string,
 ) (map[parser.AgentType][]string, []string) {
-	dirs, _, extraFiles := parseResolvedTargets(output)
+	dirs, _, extraFiles, _ := parseResolvedTargets(output)
 	return dirs, extraFiles
 }
 
@@ -493,10 +487,14 @@ func ParseResolvedTargetsForTest(output string) (map[parser.AgentType][]string, 
 	return parseResolvedDirs(output)
 }
 
+// ParseResolvedTargetsWithFilesForTest exposes SSH resolver output parsing
+// to internal/remotesync parity tests, discarding forbidden roots that
+// those tests don't assert on.
 func ParseResolvedTargetsWithFilesForTest(
 	output string,
 ) (map[parser.AgentType][]string, map[parser.AgentType][]string, []string) {
-	return parseResolvedTargets(output)
+	dirs, files, extraFiles, _ := parseResolvedTargets(output)
+	return dirs, files, extraFiles
 }
 
 func resolveOutputRecords(output string) []string {
@@ -522,6 +520,6 @@ func resolveDirs(
 	if err != nil {
 		return nil, nil, nil, nil, fmt.Errorf("resolve dirs: %w", err)
 	}
-	dirs, files, extraFiles, forbiddenRoots := parseResolvedTargetsWithForbidden(string(out))
+	dirs, files, extraFiles, forbiddenRoots := parseResolvedTargets(string(out))
 	return dirs, files, extraFiles, forbiddenRoots, nil
 }

--- a/internal/ssh/resolve.go
+++ b/internal/ssh/resolve.go
@@ -45,7 +45,8 @@ func buildAiderResolveSnippet(envVar string) string {
 			"[ \"$av_aider_files\" -ge %d ] && return; "+
 			"[ \"$av_aider_dirs\" -ge %d ] && return; "+
 			"elif [ -f \"$av_entry\" ] && [ \"$av_base\" = '%s' ]; then "+
-			"printf '%%s\\000' \"%s:$av_entry\"; "+
+			"av_aider_phys=$(av_phys_file \"$av_entry\") || continue; "+
+			"printf '%%s\\000' \"%s:$av_aider_phys\"; "+
 			"av_aider_files=$((av_aider_files + 1)); "+
 			"[ \"$av_aider_files\" -ge %d ] && return; "+
 			"fi; "+
@@ -79,24 +80,35 @@ func buildAiderResolveSnippet(envVar string) string {
 // provider facade. For each agent with an EnvVar, the script checks the env var
 // first and falls back to the default dir. Dirs (and files) that don't exist on
 // the remote are skipped.
+// resolveScriptPhysHelpers defines the script's path-canonicalization
+// helpers. av_phys_dir prints a directory's physical path (symlinked
+// ancestors resolved); av_phys_file does the same for a file path by
+// physically resolving its dirname — including a bare filename (parent
+// ".") and a root-level "/file" (parent "/"). Every emitter canonicalizes
+// through them so forbidden-root comparisons and tar exclusions on the Go
+// side compare one spelling per location: a target aliased into an
+// excluded provider's tree via a symlink resolves to the same prefix as
+// the forbidden root itself. av_phys_file is a pure path transform —
+// existence checks stay with the emitters — so parents must exist but the
+// file itself need not.
+const resolveScriptPhysHelpers = "av_phys_dir() { " +
+	"CDPATH= cd -P -- \"$1\" 2>/dev/null && pwd; " +
+	"}\n" +
+	"av_phys_file() { " +
+	"av_phys_parent=$(av_phys_dir \"$(dirname -- \"$1\")\") || return 1; " +
+	"av_phys_base=$(basename -- \"$1\"); " +
+	"case \"$av_phys_parent\" in " +
+	"/) printf '%s' \"/$av_phys_base\";; " +
+	"*) printf '%s' \"$av_phys_parent/$av_phys_base\";; esac; " +
+	"}\n"
+
 func buildResolveScript() string {
 	var b strings.Builder
 	b.WriteString(
-		// av_phys_dir prints a directory's physical path (symlinked
-		// ancestors resolved). Every emitter canonicalizes through it so
-		// forbidden-root comparisons and tar exclusions on the Go side
-		// compare one spelling per location — a target aliased into an
-		// excluded provider's tree via a symlink resolves to the same
-		// prefix as the forbidden root itself. av_phys_file does the same
-		// for a file by resolving its parent directory.
-		"av_phys_dir() { CDPATH= cd -P -- \"$1\" 2>/dev/null && pwd; }\n" +
-			"av_phys_file() { " +
-			"[ -f \"$1\" ] || return 1; " +
-			"av_phys_parent=$(av_phys_dir \"${1%/*}\") || return 1; " +
-			"printf '%s' \"$av_phys_parent/${1##*/}\"; " +
-			"}\n" +
+		resolveScriptPhysHelpers +
 			"av_emit_agent_file() { " +
 			"agent=\"$1\"; " +
+			"[ -f \"$2\" ] || return 0; " +
 			"file=$(av_phys_file \"$2\") || return 0; " +
 			"printf '%s\\000' \"" + resolveAgentFilePrefix + ":$agent:$file\"; " +
 			"}\n" +
@@ -211,6 +223,7 @@ func buildResolveScript() string {
 			"[ -d \"$target\" ] && printf '%s\\000' \"$agent:$target\"; " +
 			"}\n" +
 			"av_emit_extra_file() { " +
+			"[ -f \"$1\" ] || return 0; " +
 			"file=$(av_phys_file \"$1\") || return 0; " +
 			"printf '%s\\000' \"" + resolveFilePrefix + ":$file\"; " +
 			"}\n" +

--- a/internal/ssh/resolve.go
+++ b/internal/ssh/resolve.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path"
 	"strings"
+	"unicode/utf8"
 
 	"go.kenn.io/agentsview/internal/parser"
 )
@@ -84,13 +85,17 @@ func buildAiderResolveSnippet(envVar string) string {
 // helpers. av_phys_dir prints a directory's physical path (symlinked
 // ancestors resolved); av_phys_file does the same for a file path by
 // physically resolving its dirname — including a bare filename (parent
-// ".") and a root-level "/file" (parent "/"). Every emitter canonicalizes
-// through them so forbidden-root comparisons and tar exclusions on the Go
-// side compare one spelling per location: a target aliased into an
-// excluded provider's tree via a symlink resolves to the same prefix as
-// the forbidden root itself. av_phys_file is a pure path transform —
-// existence checks stay with the emitters — so parents must exist but the
-// file itself need not.
+// ".") and a root-level "/file" (parent "/"). av_phys_missing handles a
+// path that need not exist at all: it physically resolves the longest
+// existing ancestor and rejoins the missing tail literally, so a missing
+// forbidden root under a symlinked (or relative) prefix still lands on
+// the same spelling canonicalized targets use. Every emitter
+// canonicalizes through them so forbidden-root comparisons and tar
+// exclusions on the Go side compare one spelling per location: a target
+// aliased into an excluded provider's tree via a symlink resolves to the
+// same prefix as the forbidden root itself. av_phys_file is a pure path
+// transform — existence checks stay with the emitters — so parents must
+// exist but the file itself need not.
 //
 // Physical paths containing CR or LF are refused (return 1) rather than
 // emitted: command substitution strips trailing newlines from pwd output,
@@ -117,6 +122,23 @@ const resolveScriptPhysHelpers = "av_nl='\n'\n" +
 	"case \"$av_phys_parent\" in " +
 	"/) printf '%s' \"/$av_phys_base\";; " +
 	"*) printf '%s' \"$av_phys_parent/$av_phys_base\";; esac; " +
+	"}\n" +
+	"av_phys_missing() { " +
+	"case \"$1\" in *\"$av_nl\"*|*\"$av_cr\"*) return 1;; esac; " +
+	"av_pm_path=\"$1\"; av_pm_tail=\"\"; " +
+	"while [ ! -d \"$av_pm_path\" ]; do " +
+	"av_pm_base=$(basename -- \"$av_pm_path\"); " +
+	"if [ -n \"$av_pm_tail\" ]; then av_pm_tail=\"$av_pm_base/$av_pm_tail\"; " +
+	"else av_pm_tail=\"$av_pm_base\"; fi; " +
+	"av_pm_parent=$(dirname -- \"$av_pm_path\"); " +
+	"[ \"$av_pm_parent\" = \"$av_pm_path\" ] && return 1; " +
+	"av_pm_path=\"$av_pm_parent\"; " +
+	"done; " +
+	"av_pm_phys=$(av_phys_dir \"$av_pm_path\") || return 1; " +
+	"if [ -z \"$av_pm_tail\" ]; then printf '%s' \"$av_pm_phys\"; return 0; fi; " +
+	"case \"$av_pm_phys\" in " +
+	"/) printf '%s' \"/$av_pm_tail\";; " +
+	"*) printf '%s' \"$av_pm_phys/$av_pm_tail\";; esac; " +
 	"}\n"
 
 func buildResolveScript() string {
@@ -142,6 +164,7 @@ func buildResolveScript() string {
 			"av_windsurf_db=\"$av_windsurf_ws/" + parser.WindsurfStateDBName + "\"; " +
 			"[ -f \"$av_windsurf_db\" ] || continue; " +
 			"if [ \"$av_windsurf_root_emitted\" -eq 0 ]; then " +
+			"target=$(av_phys_dir \"$target\") || return 0; " +
 			"printf '%s\\000' \"" + string(parser.AgentWindsurf) + ":$target\"; " +
 			"av_windsurf_root_emitted=1; " +
 			"fi; " +
@@ -167,6 +190,7 @@ func buildResolveScript() string {
 			"av_roo_history=\"$av_roo_task/history_item.json\"; " +
 			"[ -f \"$av_roo_history\" ] || continue; " +
 			"if [ \"$av_roocode_root_emitted\" -eq 0 ]; then " +
+			"target=$(av_phys_dir \"$target\") || return 0; " +
 			"printf '%s\\000' \"" + string(parser.AgentRooCode) + ":$target\"; " +
 			"av_roocode_root_emitted=1; " +
 			"fi; " +
@@ -192,6 +216,7 @@ func buildResolveScript() string {
 			"av_kl_metadata=\"$av_kl_task/task_metadata.json\"; " +
 			"[ -f \"$av_kl_metadata\" ] || continue; " +
 			"if [ \"$av_kilo_legacy_root_emitted\" -eq 0 ]; then " +
+			"target=$(av_phys_dir \"$target\") || return 0; " +
 			"printf '%s\\000' \"" + string(parser.AgentKiloLegacy) + ":$target\"; " +
 			"av_kilo_legacy_root_emitted=1; " +
 			"fi; " +
@@ -210,6 +235,7 @@ func buildResolveScript() string {
 			"case \"$target\" in */) target=\"${target%/}\";; esac; " +
 			"case \"${target##*/}\" in " +
 			"trajectories) [ -d \"$target\" ] && " +
+			"target=$(av_phys_dir \"$target\") && " +
 			"printf '%s\\000' \"" + string(parser.AgentPoolside) + ":$target\";; " +
 			"*) av_poolside_traj=\"$target/trajectories\"; " +
 			"[ -d \"$av_poolside_traj\" ] && " +
@@ -217,10 +243,14 @@ func buildResolveScript() string {
 			"printf '%s\\000' \"" + string(parser.AgentPoolside) + ":$av_poolside_traj\";; " +
 			"esac; " +
 			"}\n" +
+			// Provider-specific narrowing keys on the override's literal
+			// basename (a symlink named "trajectories" or
+			// "workspaceStorage" is meaningful as spelled), so
+			// canonicalization happens after narrowing, at each
+			// emitter's root-emission printf — never before dispatch.
 			"av_emit_target() { " +
 			"agent=\"$1\"; " +
 			"target=\"$2\"; " +
-			"if [ -d \"$target\" ]; then target=$(av_phys_dir \"$target\") || return 0; fi; " +
 			"if [ \"$agent\" = \"" + string(parser.AgentWindsurf) + "\" ]; then " +
 			"av_emit_windsurf_target \"$target\"; " +
 			"return; " +
@@ -237,7 +267,9 @@ func buildResolveScript() string {
 			"av_emit_poolside_target \"$target\"; " +
 			"return; " +
 			"fi; " +
-			"[ -d \"$target\" ] && printf '%s\\000' \"$agent:$target\"; " +
+			"[ -d \"$target\" ] || return 0; " +
+			"target=$(av_phys_dir \"$target\") || return 0; " +
+			"printf '%s\\000' \"$agent:$target\"; " +
 			"}\n" +
 			"av_emit_extra_file() { " +
 			"[ -f \"$1\" ] || return 0; " +
@@ -246,21 +278,21 @@ func buildResolveScript() string {
 			"}\n" +
 			// A forbidden root that exists is emitted by its physical
 			// spelling so it shares a prefix with canonicalized targets;
-			// a missing one keeps its literal spelling — it has no
-			// contents to protect yet, and the boundary still guards the
-			// literal path.
+			// a missing one resolves through its longest existing
+			// ancestor (av_phys_missing) so a root spelled via a
+			// symlinked or relative prefix still guards the physical
+			// subtree where its contents would appear.
 			// A forbidden root whose physical path cannot be represented
-			// (av_phys_dir refuses CR/LF spellings) aborts the whole
-			// resolve: skipping the record would silently drop the
-			// exclusion boundary, and emitting a newline path would let
-			// the record parser reject it later — aborting here fails
-			// closed at the source. Missing roots keep their literal
-			// spelling; a literal spelling containing a newline is
-			// rejected by the record parser, which also fails closed.
+			// (av_phys_dir and av_phys_missing refuse CR/LF spellings)
+			// aborts the whole resolve: skipping the record would
+			// silently drop the exclusion boundary, and emitting a
+			// newline path would let the record parser reject it later —
+			// aborting here fails closed at the source.
 			"av_emit_forbidden_root() { " +
 			"dir=\"$1\"; [ -n \"$dir\" ] || dir=\"$2\"; " +
 			"[ -n \"$dir\" ] || return 0; " +
-			"if [ -d \"$dir\" ]; then dir=$(av_phys_dir \"$dir\") || exit 1; fi; " +
+			"if [ -d \"$dir\" ]; then dir=$(av_phys_dir \"$dir\") || exit 1; " +
+			"else dir=$(av_phys_missing \"$dir\") || exit 1; fi; " +
 			"printf '%s\\000' \"" + resolveForbiddenRootPrefix + ":$dir\"; " +
 			"}\n" +
 			"av_has_hermes_transcript() { " +
@@ -582,8 +614,17 @@ func resolveOutputRecords(output string) []string {
 	return strings.Split(output, "\n")
 }
 
+// invalidResolvedPath rejects resolved-path spellings that downstream
+// exclusion machinery cannot represent faithfully: NUL/CR/LF collide
+// with the record and tar -T framings, and non-UTF-8 bytes are mangled
+// by both escapeTarExcludeGlob's rune iteration and the Python
+// snapshot's JSON marshaling, so a boundary spelled with them would
+// silently guard the wrong subtree. Target records are dropped per
+// path; forbidden-root records fail the whole sync.
 func invalidResolvedPath(value string) bool {
-	return value == "" || strings.ContainsAny(value, "\x00\r\n")
+	return value == "" ||
+		strings.ContainsAny(value, "\x00\r\n") ||
+		!utf8.ValidString(value)
 }
 
 // resolveDirs runs the resolve script on the remote host via SSH and

--- a/internal/ssh/resolve.go
+++ b/internal/ssh/resolve.go
@@ -82,10 +82,23 @@ func buildAiderResolveSnippet(envVar string) string {
 func buildResolveScript() string {
 	var b strings.Builder
 	b.WriteString(
-		"av_emit_agent_file() { " +
+		// av_phys_dir prints a directory's physical path (symlinked
+		// ancestors resolved). Every emitter canonicalizes through it so
+		// forbidden-root comparisons and tar exclusions on the Go side
+		// compare one spelling per location — a target aliased into an
+		// excluded provider's tree via a symlink resolves to the same
+		// prefix as the forbidden root itself. av_phys_file does the same
+		// for a file by resolving its parent directory.
+		"av_phys_dir() { CDPATH= cd -P -- \"$1\" 2>/dev/null && pwd; }\n" +
+			"av_phys_file() { " +
+			"[ -f \"$1\" ] || return 1; " +
+			"av_phys_parent=$(av_phys_dir \"${1%/*}\") || return 1; " +
+			"printf '%s' \"$av_phys_parent/${1##*/}\"; " +
+			"}\n" +
+			"av_emit_agent_file() { " +
 			"agent=\"$1\"; " +
-			"file=\"$2\"; " +
-			"[ -f \"$file\" ] && printf '%s\\000' \"" + resolveAgentFilePrefix + ":$agent:$file\"; " +
+			"file=$(av_phys_file \"$2\") || return 0; " +
+			"printf '%s\\000' \"" + resolveAgentFilePrefix + ":$agent:$file\"; " +
 			"}\n" +
 			"av_emit_windsurf_target() { " +
 			"target=\"$1\"; " +
@@ -171,12 +184,14 @@ func buildResolveScript() string {
 			"printf '%s\\000' \"" + string(parser.AgentPoolside) + ":$target\";; " +
 			"*) av_poolside_traj=\"$target/trajectories\"; " +
 			"[ -d \"$av_poolside_traj\" ] && " +
+			"av_poolside_traj=$(av_phys_dir \"$av_poolside_traj\") && " +
 			"printf '%s\\000' \"" + string(parser.AgentPoolside) + ":$av_poolside_traj\";; " +
 			"esac; " +
 			"}\n" +
 			"av_emit_target() { " +
 			"agent=\"$1\"; " +
 			"target=\"$2\"; " +
+			"if [ -d \"$target\" ]; then target=$(av_phys_dir \"$target\") || return 0; fi; " +
 			"if [ \"$agent\" = \"" + string(parser.AgentWindsurf) + "\" ]; then " +
 			"av_emit_windsurf_target \"$target\"; " +
 			"return; " +
@@ -196,12 +211,19 @@ func buildResolveScript() string {
 			"[ -d \"$target\" ] && printf '%s\\000' \"$agent:$target\"; " +
 			"}\n" +
 			"av_emit_extra_file() { " +
-			"file=\"$1\"; " +
-			"[ -f \"$file\" ] && printf '%s\\000' \"" + resolveFilePrefix + ":$file\"; " +
+			"file=$(av_phys_file \"$1\") || return 0; " +
+			"printf '%s\\000' \"" + resolveFilePrefix + ":$file\"; " +
 			"}\n" +
+			// A forbidden root that exists is emitted by its physical
+			// spelling so it shares a prefix with canonicalized targets;
+			// a missing one keeps its literal spelling — it has no
+			// contents to protect yet, and the boundary still guards the
+			// literal path.
 			"av_emit_forbidden_root() { " +
 			"dir=\"$1\"; [ -n \"$dir\" ] || dir=\"$2\"; " +
-			"[ -n \"$dir\" ] && printf '%s\\000' \"" + resolveForbiddenRootPrefix + ":$dir\"; " +
+			"[ -n \"$dir\" ] || return 0; " +
+			"if [ -d \"$dir\" ]; then dir=$(av_phys_dir \"$dir\") || return 0; fi; " +
+			"printf '%s\\000' \"" + resolveForbiddenRootPrefix + ":$dir\"; " +
 			"}\n" +
 			"av_has_hermes_transcript() { " +
 			"av_hermes_transcript_dir=\"$1\"; " +
@@ -228,7 +250,8 @@ func buildResolveScript() string {
 			"for av_hermes_file in \"$av_hermes_state\" \"$av_hermes_state-wal\" \"$av_hermes_state-shm\" \"$av_hermes_state-journal\"; do " +
 			"av_emit_extra_file \"$av_hermes_file\"; done; " +
 			"elif [ -f \"$av_hermes_state\" ]; then " +
-			"printf '%s\\000' \"" + string(parser.AgentHermes) + ":$av_hermes_state\"; " +
+			"av_hermes_state_phys=$(av_phys_file \"$av_hermes_state\") && " +
+			"printf '%s\\000' \"" + string(parser.AgentHermes) + ":$av_hermes_state_phys\"; " +
 			"for av_hermes_file in \"$av_hermes_state-wal\" \"$av_hermes_state-shm\" \"$av_hermes_state-journal\"; do " +
 			"av_emit_extra_file \"$av_hermes_file\"; done; " +
 			"elif [ \"$av_hermes_allow_flat\" -eq 1 ] && av_has_hermes_transcript \"$target\"; then " +
@@ -264,7 +287,7 @@ func buildResolveScript() string {
 			"}\n" +
 			"av_emit_codex_index() { " +
 			"idx=\"${dir%/*}/" + parser.CodexSessionIndexFilename + "\"; " +
-			"[ -f \"$idx\" ] && printf '%s\\000' \"" + resolveFilePrefix + ":$idx\"; " +
+			"av_emit_extra_file \"$idx\"; " +
 			"}\n",
 	)
 	for _, def := range parser.Registry {
@@ -395,12 +418,17 @@ func resolveAgentHasOnDiskSource(def parser.AgentDef) bool {
 // resolveForbiddenRootPrefix). Generated resolver output is
 // NUL-delimited so remote paths containing newlines cannot inject extra
 // records; newline-delimited input is accepted only for older tests and
-// defensive compatibility. Most agent targets are directories; Aider
+// defensive compatibility, and only that legacy mode trims whitespace —
+// NUL-delimited records are preserved exactly, so a path with leading or
+// trailing whitespace keeps the spelling every downstream comparison and
+// tar exclusion depends on. Most agent targets are directories; Aider
 // targets are individual .aider.chat.history.md files. Skips empty
-// records, empty values, and values containing record separators.
+// records, empty values, and values containing record separators — except
+// forbidden-root records, which fail the parse instead: silently dropping
+// an exclusion boundary would archive the excluded provider's state.
 func parseResolvedTargets(
 	output string,
-) (map[parser.AgentType][]string, map[parser.AgentType][]string, []string, []string) {
+) (map[parser.AgentType][]string, map[parser.AgentType][]string, []string, []string, error) {
 	dirs := make(map[parser.AgentType][]string)
 	files := make(map[parser.AgentType][]string)
 	var extraFiles []string
@@ -409,12 +437,30 @@ func parseResolvedTargets(
 	seenFile := make(map[string]struct{})
 	seenAgentFile := make(map[parser.AgentType]map[string]struct{})
 	seenForbiddenRoot := make(map[string]struct{})
+	nulDelimited := strings.Contains(output, resolveRecordSep)
 	for _, record := range resolveOutputRecords(output) {
-		record = strings.TrimSpace(record)
+		if !nulDelimited {
+			record = strings.TrimSpace(record)
+		}
 		if record == "" {
 			continue
 		}
 		key, value, ok := strings.Cut(record, ":")
+		if key == resolveForbiddenRootPrefix {
+			if !ok || invalidResolvedPath(value) {
+				return nil, nil, nil, nil, fmt.Errorf(
+					"resolve output: forbidden-root record %q is empty or "+
+						"unrepresentable; refusing to sync without its "+
+						"exclusion boundary", record)
+			}
+			cleaned := path.Clean(value)
+			if _, dup := seenForbiddenRoot[cleaned]; dup {
+				continue
+			}
+			seenForbiddenRoot[cleaned] = struct{}{}
+			forbiddenRoots = append(forbiddenRoots, cleaned)
+			continue
+		}
 		if !ok || invalidResolvedPath(value) {
 			continue
 		}
@@ -424,14 +470,6 @@ func parseResolvedTargets(
 			}
 			seenFile[value] = struct{}{}
 			extraFiles = append(extraFiles, value)
-			continue
-		}
-		if key == resolveForbiddenRootPrefix {
-			if _, dup := seenForbiddenRoot[value]; dup {
-				continue
-			}
-			seenForbiddenRoot[value] = struct{}{}
-			forbiddenRoots = append(forbiddenRoots, path.Clean(value))
 			continue
 		}
 		if key == resolveAgentFilePrefix {
@@ -471,19 +509,21 @@ func parseResolvedTargets(
 		seen[value] = struct{}{}
 		dirs[at] = append(dirs[at], value)
 	}
-	return dirs, files, extraFiles, forbiddenRoots
+	return dirs, files, extraFiles, forbiddenRoots, nil
 }
 
 func parseResolvedDirs(
 	output string,
-) (map[parser.AgentType][]string, []string) {
-	dirs, _, extraFiles, _ := parseResolvedTargets(output)
-	return dirs, extraFiles
+) (map[parser.AgentType][]string, []string, error) {
+	dirs, _, extraFiles, _, err := parseResolvedTargets(output)
+	return dirs, extraFiles, err
 }
 
 // ParseResolvedTargetsForTest exposes SSH resolver output parsing to
 // internal/remotesync parity tests.
-func ParseResolvedTargetsForTest(output string) (map[parser.AgentType][]string, []string) {
+func ParseResolvedTargetsForTest(
+	output string,
+) (map[parser.AgentType][]string, []string, error) {
 	return parseResolvedDirs(output)
 }
 
@@ -492,9 +532,9 @@ func ParseResolvedTargetsForTest(output string) (map[parser.AgentType][]string, 
 // those tests don't assert on.
 func ParseResolvedTargetsWithFilesForTest(
 	output string,
-) (map[parser.AgentType][]string, map[parser.AgentType][]string, []string) {
-	dirs, files, extraFiles, _ := parseResolvedTargets(output)
-	return dirs, files, extraFiles
+) (map[parser.AgentType][]string, map[parser.AgentType][]string, []string, error) {
+	dirs, files, extraFiles, _, err := parseResolvedTargets(output)
+	return dirs, files, extraFiles, err
 }
 
 func resolveOutputRecords(output string) []string {
@@ -520,6 +560,9 @@ func resolveDirs(
 	if err != nil {
 		return nil, nil, nil, nil, fmt.Errorf("resolve dirs: %w", err)
 	}
-	dirs, files, extraFiles, forbiddenRoots := parseResolvedTargets(string(out))
+	dirs, files, extraFiles, forbiddenRoots, err := parseResolvedTargets(string(out))
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("resolve dirs: %w", err)
+	}
 	return dirs, files, extraFiles, forbiddenRoots, nil
 }

--- a/internal/ssh/resolve.go
+++ b/internal/ssh/resolve.go
@@ -91,10 +91,27 @@ func buildAiderResolveSnippet(envVar string) string {
 // the forbidden root itself. av_phys_file is a pure path transform —
 // existence checks stay with the emitters — so parents must exist but the
 // file itself need not.
-const resolveScriptPhysHelpers = "av_phys_dir() { " +
-	"CDPATH= cd -P -- \"$1\" 2>/dev/null && pwd; " +
+//
+// Physical paths containing CR or LF are refused (return 1) rather than
+// emitted: command substitution strips trailing newlines from pwd output,
+// so a directory name ending in a newline would otherwise be emitted with
+// a clean-looking but WRONG spelling that downstream exclusion would
+// guard instead of the real subtree. The sentinel dance (pwd && printf x)
+// preserves the true spelling long enough to detect the newline. Such
+// paths are unrepresentable end to end anyway — tar -T input is
+// newline-delimited and the record parser rejects them — so refusal here
+// makes targets fail closed per path, and av_emit_forbidden_root turns
+// refusal into a whole-script abort.
+const resolveScriptPhysHelpers = "av_nl='\n'\n" +
+	"av_cr=$(printf '\\r')\n" +
+	"av_phys_dir() { " +
+	"av_phys_out=$(CDPATH= cd -P -- \"$1\" 2>/dev/null && pwd && printf x) || return 1; " +
+	"av_phys_out=${av_phys_out%??}; " +
+	"case \"$av_phys_out\" in *\"$av_nl\"*|*\"$av_cr\"*) return 1;; esac; " +
+	"printf '%s' \"$av_phys_out\"; " +
 	"}\n" +
 	"av_phys_file() { " +
+	"case \"$1\" in *\"$av_nl\"*|*\"$av_cr\"*) return 1;; esac; " +
 	"av_phys_parent=$(av_phys_dir \"$(dirname -- \"$1\")\") || return 1; " +
 	"av_phys_base=$(basename -- \"$1\"); " +
 	"case \"$av_phys_parent\" in " +
@@ -232,10 +249,18 @@ func buildResolveScript() string {
 			// a missing one keeps its literal spelling — it has no
 			// contents to protect yet, and the boundary still guards the
 			// literal path.
+			// A forbidden root whose physical path cannot be represented
+			// (av_phys_dir refuses CR/LF spellings) aborts the whole
+			// resolve: skipping the record would silently drop the
+			// exclusion boundary, and emitting a newline path would let
+			// the record parser reject it later — aborting here fails
+			// closed at the source. Missing roots keep their literal
+			// spelling; a literal spelling containing a newline is
+			// rejected by the record parser, which also fails closed.
 			"av_emit_forbidden_root() { " +
 			"dir=\"$1\"; [ -n \"$dir\" ] || dir=\"$2\"; " +
 			"[ -n \"$dir\" ] || return 0; " +
-			"if [ -d \"$dir\" ]; then dir=$(av_phys_dir \"$dir\") || return 0; fi; " +
+			"if [ -d \"$dir\" ]; then dir=$(av_phys_dir \"$dir\") || exit 1; fi; " +
 			"printf '%s\\000' \"" + resolveForbiddenRootPrefix + ":$dir\"; " +
 			"}\n" +
 			"av_has_hermes_transcript() { " +

--- a/internal/ssh/resolve.go
+++ b/internal/ssh/resolve.go
@@ -18,6 +18,10 @@ const resolveFilePrefix = "@file"
 // transfer without recursively archiving that agent's root directory.
 const resolveAgentFilePrefix = "@agentfile"
 
+// resolveForbiddenRootPrefix marks a root that must never be recursively
+// transferred, even when another allowed provider root overlaps it.
+const resolveForbiddenRootPrefix = "@forbidden"
+
 const resolveRecordSep = "\x00"
 
 func aiderSkipDirCasePattern() string {
@@ -195,6 +199,10 @@ func buildResolveScript() string {
 			"file=\"$1\"; " +
 			"[ -f \"$file\" ] && printf '%s\\000' \"" + resolveFilePrefix + ":$file\"; " +
 			"}\n" +
+			"av_emit_forbidden_root() { " +
+			"dir=\"$1\"; [ -n \"$dir\" ] || dir=\"$2\"; " +
+			"[ -n \"$dir\" ] && printf '%s\\000' \"" + resolveForbiddenRootPrefix + ":$dir\"; " +
+			"}\n" +
 			"av_has_hermes_transcript() { " +
 			"av_hermes_transcript_dir=\"$1\"; " +
 			"[ -d \"$av_hermes_transcript_dir\" ] || return 1; " +
@@ -260,6 +268,15 @@ func buildResolveScript() string {
 			"}\n",
 	)
 	for _, def := range parser.Registry {
+		if def.RemoteSyncExcluded {
+			for _, rel := range def.DefaultDirs {
+				fmt.Fprintf(&b,
+					"av_emit_forbidden_root \"%s\" \"$HOME/%s\"\n",
+					remoteEnvExpansion(def.EnvVar), rel,
+				)
+			}
+			continue
+		}
 		if !resolveAgentHasOnDiskSource(def) {
 			continue
 		}
@@ -383,12 +400,21 @@ func resolveAgentHasOnDiskSource(def parser.AgentDef) bool {
 func parseResolvedTargets(
 	output string,
 ) (map[parser.AgentType][]string, map[parser.AgentType][]string, []string) {
+	dirs, files, extraFiles, _ := parseResolvedTargetsWithForbidden(output)
+	return dirs, files, extraFiles
+}
+
+func parseResolvedTargetsWithForbidden(
+	output string,
+) (map[parser.AgentType][]string, map[parser.AgentType][]string, []string, []string) {
 	dirs := make(map[parser.AgentType][]string)
 	files := make(map[parser.AgentType][]string)
 	var extraFiles []string
+	var forbiddenRoots []string
 	seenDir := make(map[parser.AgentType]map[string]struct{})
 	seenFile := make(map[string]struct{})
 	seenAgentFile := make(map[parser.AgentType]map[string]struct{})
+	seenForbiddenRoot := make(map[string]struct{})
 	for _, record := range resolveOutputRecords(output) {
 		record = strings.TrimSpace(record)
 		if record == "" {
@@ -404,6 +430,14 @@ func parseResolvedTargets(
 			}
 			seenFile[value] = struct{}{}
 			extraFiles = append(extraFiles, value)
+			continue
+		}
+		if key == resolveForbiddenRootPrefix {
+			if _, dup := seenForbiddenRoot[value]; dup {
+				continue
+			}
+			seenForbiddenRoot[value] = struct{}{}
+			forbiddenRoots = append(forbiddenRoots, path.Clean(value))
 			continue
 		}
 		if key == resolveAgentFilePrefix {
@@ -443,7 +477,7 @@ func parseResolvedTargets(
 		seen[value] = struct{}{}
 		dirs[at] = append(dirs[at], value)
 	}
-	return dirs, files, extraFiles
+	return dirs, files, extraFiles, forbiddenRoots
 }
 
 func parseResolvedDirs(
@@ -482,12 +516,12 @@ func invalidResolvedPath(value string) bool {
 func resolveDirs(
 	ctx context.Context,
 	host, user string, port int, sshOpts []string,
-) (map[parser.AgentType][]string, map[parser.AgentType][]string, []string, error) {
+) (map[parser.AgentType][]string, map[parser.AgentType][]string, []string, []string, error) {
 	script := buildResolveScript()
 	out, err := runSSHScript(ctx, host, user, port, sshOpts, script)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("resolve dirs: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("resolve dirs: %w", err)
 	}
-	dirs, files, extraFiles := parseResolvedTargets(string(out))
-	return dirs, files, extraFiles, nil
+	dirs, files, extraFiles, forbiddenRoots := parseResolvedTargetsWithForbidden(string(out))
+	return dirs, files, extraFiles, forbiddenRoots, nil
 }

--- a/internal/ssh/resolve_test.go
+++ b/internal/ssh/resolve_test.go
@@ -920,3 +920,72 @@ func TestResolveScriptEmitsPhysicalPathsForSymlinkedRoots(t *testing.T) {
 		filepath.Join(physicalClaude, "projects"),
 		"targets must be emitted by physical spelling to share a namespace with forbidden roots")
 }
+
+// TestAvPhysFileEdgeCases exercises the script's file-canonicalization
+// helper directly (it is a pure path transform; existence checks live
+// with the emitters): a root-level "/file" keeps parent "/", a bare
+// filename resolves against the physical working directory, and a file
+// spelled through a symlinked parent resolves to its physical location.
+func TestAvPhysFileEdgeCases(t *testing.T) {
+	base := physTempDir(t)
+	physicalDir := filepath.Join(base, "real")
+	require.NoError(t, os.MkdirAll(physicalDir, 0o755))
+	alias := filepath.Join(base, "alias")
+	require.NoError(t, os.Symlink(physicalDir, alias))
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"root_level_file_keeps_root_parent", "/no-such-file", "/no-such-file"},
+		{"bare_filename_resolves_against_cwd", "bare.md",
+			filepath.Join(base, "bare.md")},
+		{"symlinked_parent_resolves_physically",
+			filepath.Join(alias, "history.md"),
+			filepath.Join(physicalDir, "history.md")},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			script := resolveScriptPhysHelpers +
+				"av_phys_file \"$AV_TEST_INPUT\"\n"
+			cmd := exec.Command("sh")
+			cmd.Stdin = strings.NewReader(script)
+			cmd.Dir = base
+			cmd.Env = []string{"AV_TEST_INPUT=" + tc.input}
+			out, err := cmd.CombinedOutput()
+			require.NoError(t, err, "helper failed: %s", out)
+			assert.Equal(t, tc.want, string(out))
+		})
+	}
+}
+
+// TestResolveScriptAiderSymlinkOverlapStaysForbidden is the regression
+// test for Aider results reached through a symlink into an excluded
+// provider's tree: the emitted history-file path must carry the physical
+// forbidden-root prefix so the transfer-side filter drops it.
+func TestResolveScriptAiderSymlinkOverlapStaysForbidden(t *testing.T) {
+	home := physTempDir(t)
+	physicalTrae := filepath.Join(home, "real-trae")
+	repoDir := filepath.Join(physicalTrae, "code", "repo")
+	require.NoError(t, os.MkdirAll(repoDir, 0o755))
+	history := filepath.Join(repoDir, parser.AiderHistoryFileName())
+	require.NoError(t, os.WriteFile(history, []byte("# aider"), 0o644))
+	aiderAlias := filepath.Join(home, "aider-alias")
+	require.NoError(t, os.Symlink(
+		filepath.Join(physicalTrae, "code"), aiderAlias))
+
+	out := runResolveScriptForTest(t,
+		"HOME="+home, "TRAE_DIR="+physicalTrae, "AIDER_DIR="+aiderAlias)
+	dirs, _, _, forbiddenRoots, err := parseResolvedTargets(string(out))
+	require.NoError(t, err)
+
+	require.Contains(t, forbiddenRoots, physicalTrae)
+	require.Len(t, dirs[parser.AgentAider], 1,
+		"the walk should still find the history file through the alias")
+	got := dirs[parser.AgentAider][0]
+	assert.Equal(t, history, got,
+		"aider results must be emitted by physical spelling")
+	assert.True(t, pathWithinForbiddenRoots(forbiddenRoots, got),
+		"physical spelling must fall inside the forbidden root so the transfer filter excludes it")
+}

--- a/internal/ssh/resolve_test.go
+++ b/internal/ssh/resolve_test.go
@@ -44,30 +44,30 @@ func resolveScriptMentionsAgent(script string, agent parser.AgentType) bool {
 }
 
 func TestResolveScriptExcludesDevinProviderRoot(t *testing.T) {
-	home := t.TempDir()
+	home := physTempDir(t)
 	devinRoot := filepath.Join(home, ".local", "share", "devin")
 	require.NoError(t, os.MkdirAll(devinRoot, 0o755))
 
 	out := runResolveScriptForTest(t, "HOME="+home, "DEVIN_DIR="+devinRoot)
 
-	dirs, _ := parseResolvedDirs(string(out))
+	dirs, _, _ := parseResolvedDirs(string(out))
 	assert.NotContains(t, dirs, parser.AgentDevin)
 }
 
 func TestResolveScriptExcludesTraeProfile(t *testing.T) {
-	home := t.TempDir()
+	home := physTempDir(t)
 	traeRoot := filepath.Join(home, "AppData", "Roaming", "TRAE", "User")
 	claudeRoot := filepath.Join(home, ".claude", "projects")
 	require.NoError(t, os.MkdirAll(traeRoot, 0o755))
 	require.NoError(t, os.MkdirAll(claudeRoot, 0o755))
 
 	out := runResolveScriptForTest(t, "HOME="+home, "TRAE_DIR="+traeRoot)
-	dirs, _ := parseResolvedDirs(string(out))
+	dirs, _, _ := parseResolvedDirs(string(out))
 	assert.NotContains(t, dirs, parser.AgentTrae)
 }
 
 func TestResolveScriptHonorsClaudeConfigDirRoot(t *testing.T) {
-	home := t.TempDir()
+	home := physTempDir(t)
 	root := filepath.Join(home, "claude personal")
 	projectsDir := filepath.Join(root, "projects")
 	require.NoError(t, os.MkdirAll(projectsDir, 0o755), "mkdir projects")
@@ -77,7 +77,7 @@ func TestResolveScriptHonorsClaudeConfigDirRoot(t *testing.T) {
 		"CLAUDE_CONFIG_DIR="+root,
 	)
 
-	dirs, _ := parseResolvedDirs(string(out))
+	dirs, _, _ := parseResolvedDirs(string(out))
 	assert.Contains(t, dirs[parser.AgentClaude], root+"/projects")
 	assert.NotContains(t, dirs[parser.AgentClaude], home+"/.claude/projects")
 }
@@ -86,7 +86,7 @@ func TestResolveScriptTreatsEnvValuesAsData(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("resolve script runs on POSIX remote hosts; local Windows filepaths and MSYS shell parsing are not representative")
 	}
-	home := t.TempDir()
+	home := physTempDir(t)
 	projectsDir := filepath.Join(home, "config root", "projects")
 	require.NoError(t, os.MkdirAll(projectsDir, 0o755), "mkdir projects")
 
@@ -97,7 +97,7 @@ func TestResolveScriptTreatsEnvValuesAsData(t *testing.T) {
 		"CLAUDE_PROJECTS_DIR="+projectsDir,
 	)
 
-	dirs, _ := parseResolvedDirs(string(out))
+	dirs, _, _ := parseResolvedDirs(string(out))
 	assert.Contains(t, dirs[parser.AgentClaude], projectsDir)
 }
 
@@ -106,7 +106,7 @@ func TestResolveScriptExitsZero(t *testing.T) {
 	// dirs exist. Verify by running it against an empty
 	// HOME so no default dirs are found.
 	out := runResolveScriptForTest(t, "HOME=/nonexistent")
-	dirs, files, extraFiles, forbiddenRoots :=
+	dirs, files, extraFiles, forbiddenRoots, _ :=
 		parseResolvedTargets(string(out))
 	assert.Empty(t, dirs)
 	assert.Empty(t, files)
@@ -120,7 +120,7 @@ func TestResolveScriptExitsZero(t *testing.T) {
 // titles get transferred and imported during remote SSH sync. Runs the real
 // script through sh against a temp HOME rather than mocking it.
 func TestResolveScriptIncludesCodexIndex(t *testing.T) {
-	home := t.TempDir()
+	home := physTempDir(t)
 	sessionsDir := filepath.Join(home, ".codex", "sessions")
 	require.NoError(t, os.MkdirAll(sessionsDir, 0o755), "mkdir sessions")
 	indexPath := filepath.Join(home, ".codex", "session_index.jsonl")
@@ -132,7 +132,7 @@ func TestResolveScriptIncludesCodexIndex(t *testing.T) {
 	// forward-slash paths that differ from native filepath.Join output.
 	// Match by POSIX suffix, which also guards against the parent
 	// expansion collapsing the index path to /session_index.jsonl.
-	dirs, extraFiles := parseResolvedDirs(string(out))
+	dirs, extraFiles, _ := parseResolvedDirs(string(out))
 	assert.Truef(t, hasSuffix(dirs[parser.AgentCodex], ".codex/sessions"),
 		"codex sessions dir should be resolved, got %v", dirs[parser.AgentCodex])
 	assert.Truef(t, hasSuffix(extraFiles, ".codex/session_index.jsonl"),
@@ -153,7 +153,7 @@ func hasSuffix(paths []string, suffix string) bool {
 // script discovers Hermes named-profile session dirs and database files, not
 // just the default profile.
 func TestResolveScriptIncludesHermesNamedProfiles(t *testing.T) {
-	home := t.TempDir()
+	home := physTempDir(t)
 	require.NoError(t, os.MkdirAll(filepath.Join(home, ".hermes", "sessions"), 0o755))
 	require.NoError(t, os.WriteFile(
 		filepath.Join(home, ".hermes", "state.db"), []byte("sqlite"), 0o644,
@@ -173,7 +173,7 @@ func TestResolveScriptIncludesHermesNamedProfiles(t *testing.T) {
 	}
 
 	out := runResolveScriptForTest(t, "HOME="+home)
-	dirs, extraFiles := parseResolvedDirs(string(out))
+	dirs, extraFiles, _ := parseResolvedDirs(string(out))
 
 	assert.Truef(t, hasSuffix(dirs[parser.AgentHermes], ".hermes/sessions"),
 		"default profile sessions dir should resolve, got %v", dirs[parser.AgentHermes])
@@ -190,7 +190,7 @@ func TestResolveScriptIncludesHermesNamedProfiles(t *testing.T) {
 }
 
 func TestResolveScriptExcludesRemoteSyncExcludedAgentState(t *testing.T) {
-	home := t.TempDir()
+	home := physTempDir(t)
 	root := filepath.Join(home, "AppData", "Roaming", "Trae", "User")
 	require.NoError(t, os.MkdirAll(root, 0o755))
 	for _, name := range []string{
@@ -207,37 +207,37 @@ func TestResolveScriptExcludesRemoteSyncExcludedAgentState(t *testing.T) {
 	))
 
 	out := runResolveScriptForTest(t, "HOME="+home, "TRAE_DIR="+root)
-	dirs, files, _, _ := parseResolvedTargets(string(out))
+	dirs, files, _, _, _ := parseResolvedTargets(string(out))
 
 	assert.NotContains(t, dirs, parser.AgentTrae)
 	assert.NotContains(t, files, parser.AgentTrae)
 }
 
 func TestResolveScriptCarriesTraeForbiddenRoot(t *testing.T) {
-	home := t.TempDir()
+	home := physTempDir(t)
 	root := filepath.Join(home, "AppData", "Roaming", "Trae", "User")
 	require.NoError(t, os.MkdirAll(root, 0o755))
 
 	out := runResolveScriptForTest(t, "HOME="+home, "TRAE_DIR="+root)
-	_, _, _, forbiddenRoots := parseResolvedTargets(string(out))
+	_, _, _, forbiddenRoots, _ := parseResolvedTargets(string(out))
 
 	assert.Contains(t, forbiddenRoots, root,
 		"the SSH resolver must preserve excluded roots as transfer boundaries")
 }
 
 func TestResolveScriptCarriesMissingExcludedRoot(t *testing.T) {
-	home := t.TempDir()
+	home := physTempDir(t)
 	root := filepath.Join(home, "AppData", "Roaming", "Trae", "User")
 
 	out := runResolveScriptForTest(t, "HOME="+home, "TRAE_DIR="+root)
-	_, _, _, forbiddenRoots := parseResolvedTargets(string(out))
+	_, _, _, forbiddenRoots, _ := parseResolvedTargets(string(out))
 
 	assert.Contains(t, forbiddenRoots, root,
 		"the exclusion boundary must survive creation after remote resolution")
 }
 
 func TestResolveScriptHermesOverrideReplacesNamedProfiles(t *testing.T) {
-	home := filepath.ToSlash(t.TempDir())
+	home := filepath.ToSlash(physTempDir(t))
 	profileSessions := path.Join(
 		home, ".hermes", "profiles", "research", "sessions",
 	)
@@ -253,14 +253,14 @@ func TestResolveScriptHermesOverrideReplacesNamedProfiles(t *testing.T) {
 		"HOME="+home,
 		"HERMES_SESSIONS_DIR="+customSessions,
 	)
-	dirs, extraFiles := parseResolvedDirs(string(out))
+	dirs, extraFiles, _ := parseResolvedDirs(string(out))
 
 	assert.Equal(t, []string{customSessions}, dirs[parser.AgentHermes])
 	assert.Equal(t, []string{path.Join(customRoot, "state.db")}, extraFiles)
 }
 
 func TestResolveScriptHermesProfilesContainerOverrideEnumeratesProfiles(t *testing.T) {
-	home := filepath.ToSlash(t.TempDir())
+	home := filepath.ToSlash(physTempDir(t))
 	profilesRoot := path.Join(home, ".hermes", "profiles")
 	researchRoot := path.Join(profilesRoot, "research")
 	researchSessions := path.Join(researchRoot, "sessions")
@@ -272,7 +272,7 @@ func TestResolveScriptHermesProfilesContainerOverrideEnumeratesProfiles(t *testi
 	require.NoError(t, os.WriteFile(researchStateDB, []byte("sqlite"), 0o644))
 	require.NoError(t, os.WriteFile(databaseOnlyStateDB, []byte("sqlite"), 0o644))
 
-	outsideRoot := filepath.ToSlash(path.Join(t.TempDir(), "outside-profile"))
+	outsideRoot := filepath.ToSlash(path.Join(physTempDir(t), "outside-profile"))
 	require.NoError(t, os.MkdirAll(path.Join(outsideRoot, "sessions"), 0o755))
 	require.NoError(t, os.Symlink(outsideRoot, path.Join(profilesRoot, "linked")))
 
@@ -280,7 +280,7 @@ func TestResolveScriptHermesProfilesContainerOverrideEnumeratesProfiles(t *testi
 		"HOME="+home,
 		"HERMES_SESSIONS_DIR="+profilesRoot,
 	)
-	dirs, extraFiles := parseResolvedDirs(string(out))
+	dirs, extraFiles, _ := parseResolvedDirs(string(out))
 
 	assert.ElementsMatch(t, []string{researchSessions, databaseOnlyStateDB},
 		dirs[parser.AgentHermes])
@@ -288,7 +288,7 @@ func TestResolveScriptHermesProfilesContainerOverrideEnumeratesProfiles(t *testi
 }
 
 func TestResolveScriptHermesTrailingSlashOverrideIncludesStateDB(t *testing.T) {
-	home := filepath.ToSlash(t.TempDir())
+	home := filepath.ToSlash(physTempDir(t))
 	customRoot := path.Join(home, "custom-hermes")
 	customSessions := path.Join(customRoot, "sessions")
 	require.NoError(t, os.MkdirAll(filepath.FromSlash(customSessions), 0o755))
@@ -299,14 +299,14 @@ func TestResolveScriptHermesTrailingSlashOverrideIncludesStateDB(t *testing.T) {
 		"HOME="+home,
 		"HERMES_SESSIONS_DIR="+customSessions+"/",
 	)
-	dirs, extraFiles := parseResolvedDirs(string(out))
+	dirs, extraFiles, _ := parseResolvedDirs(string(out))
 
 	assert.Equal(t, []string{customSessions}, dirs[parser.AgentHermes])
 	assert.Equal(t, []string{stateDB}, extraFiles)
 }
 
 func TestResolveScriptIncludesFlatCustomHermesRoot(t *testing.T) {
-	home := t.TempDir()
+	home := physTempDir(t)
 	customRoot := filepath.Join(home, "custom", "hermes-archive")
 	require.NoError(t, os.MkdirAll(customRoot, 0o755))
 	require.NoError(t, os.WriteFile(
@@ -317,21 +317,21 @@ func TestResolveScriptIncludesFlatCustomHermesRoot(t *testing.T) {
 		"HOME="+home,
 		"HERMES_SESSIONS_DIR="+customRoot,
 	)
-	dirs, extraFiles := parseResolvedDirs(string(out))
+	dirs, extraFiles, _ := parseResolvedDirs(string(out))
 
 	assert.Equal(t, []string{customRoot}, dirs[parser.AgentHermes])
 	assert.Empty(t, extraFiles)
 }
 
 func TestResolveScriptIncludesHermesDatabaseOnlyProfile(t *testing.T) {
-	home := filepath.ToSlash(t.TempDir())
+	home := filepath.ToSlash(physTempDir(t))
 	profileRoot := path.Join(home, ".hermes", "profiles", "database-only")
 	require.NoError(t, os.MkdirAll(profileRoot, 0o755))
 	stateDB := path.Join(profileRoot, "state.db")
 	require.NoError(t, os.WriteFile(stateDB, []byte("sqlite"), 0o644))
 
 	out := runResolveScriptForTest(t, "HOME="+home)
-	dirs, _ := parseResolvedDirs(string(out))
+	dirs, _, _ := parseResolvedDirs(string(out))
 
 	assert.Truef(t, hasSuffix(
 		dirs[parser.AgentHermes], ".hermes/profiles/database-only/state.db",
@@ -339,7 +339,7 @@ func TestResolveScriptIncludesHermesDatabaseOnlyProfile(t *testing.T) {
 }
 
 func TestResolveScriptSkipsSessionlessHermesProfileCredentials(t *testing.T) {
-	home := t.TempDir()
+	home := physTempDir(t)
 	profileRoot := filepath.Join(home, ".hermes", "profiles", "sessions")
 	require.NoError(t, os.MkdirAll(profileRoot, 0o755))
 	require.NoError(t, os.WriteFile(
@@ -353,7 +353,7 @@ func TestResolveScriptSkipsSessionlessHermesProfileCredentials(t *testing.T) {
 	))
 
 	out := runResolveScriptForTest(t, "HOME="+home)
-	dirs, extraFiles := parseResolvedDirs(string(out))
+	dirs, extraFiles, _ := parseResolvedDirs(string(out))
 
 	assert.NotContains(t, dirs[parser.AgentHermes], profileRoot)
 	assert.NotContains(t, extraFiles, filepath.Join(profileRoot, ".env"))
@@ -361,10 +361,10 @@ func TestResolveScriptSkipsSessionlessHermesProfileCredentials(t *testing.T) {
 }
 
 func TestResolveScriptSkipsSymlinkedHermesProfile(t *testing.T) {
-	home := t.TempDir()
+	home := physTempDir(t)
 	profilesRoot := filepath.Join(home, ".hermes", "profiles")
 	require.NoError(t, os.MkdirAll(profilesRoot, 0o755))
-	outsideRoot := filepath.Join(t.TempDir(), "outside-profile")
+	outsideRoot := filepath.Join(physTempDir(t), "outside-profile")
 	outsideSessions := filepath.Join(outsideRoot, "sessions")
 	require.NoError(t, os.MkdirAll(outsideSessions, 0o755))
 	require.NoError(t, os.WriteFile(
@@ -374,7 +374,7 @@ func TestResolveScriptSkipsSymlinkedHermesProfile(t *testing.T) {
 	require.NoError(t, os.Symlink(outsideRoot, profileLink))
 
 	out := runResolveScriptForTest(t, "HOME="+home)
-	dirs, extraFiles := parseResolvedDirs(string(out))
+	dirs, extraFiles, _ := parseResolvedDirs(string(out))
 
 	assert.NotContains(t, dirs[parser.AgentHermes], filepath.Join(profileLink, "sessions"))
 	assert.Empty(t, extraFiles)
@@ -384,11 +384,11 @@ func TestResolveScriptSkipsSymlinkedHermesProfile(t *testing.T) {
 // dir exists, the glob expands to nothing emittable (av_emit_target's [ -d ]
 // guard drops the non-existent path) — so only the default profile resolves.
 func TestResolveScriptSkipsMissingHermesProfiles(t *testing.T) {
-	home := t.TempDir()
+	home := physTempDir(t)
 	require.NoError(t, os.MkdirAll(filepath.Join(home, ".hermes", "sessions"), 0o755))
 
 	out := runResolveScriptForTest(t, "HOME="+home)
-	dirs, _ := parseResolvedDirs(string(out))
+	dirs, _, _ := parseResolvedDirs(string(out))
 
 	assert.Truef(t, hasSuffix(dirs[parser.AgentHermes], ".hermes/sessions"),
 		"default profile sessions dir should resolve, got %v", dirs[parser.AgentHermes])
@@ -401,14 +401,14 @@ func TestResolveScriptSkipsMissingHermesProfiles(t *testing.T) {
 // produces no extra-file entry, so the transfer's tar command never names a
 // nonexistent path (which would be a fatal, non-benign error).
 func TestResolveScriptSkipsMissingCodexIndex(t *testing.T) {
-	home := t.TempDir()
+	home := physTempDir(t)
 	require.NoError(t,
 		os.MkdirAll(filepath.Join(home, ".codex", "sessions"), 0o755),
 		"mkdir sessions")
 
 	out := runResolveScriptForTest(t, "HOME="+home)
 
-	_, extraFiles := parseResolvedDirs(string(out))
+	_, extraFiles, _ := parseResolvedDirs(string(out))
 	assert.Empty(t, extraFiles,
 		"no extra files when session_index.jsonl is absent")
 }
@@ -418,7 +418,7 @@ func TestResolveScriptSkipsMissingCodexIndex(t *testing.T) {
 // target, so Aider must stay opt-in even when a history file exists at home
 // root. Runs the real script through sh against a temp HOME.
 func TestResolveScriptSkipsAiderHomeDefault(t *testing.T) {
-	home := t.TempDir()
+	home := physTempDir(t)
 	require.NoError(t, os.WriteFile(
 		filepath.Join(home, ".aider.chat.history.md"),
 		[]byte("# aider chat started at 2024-01-01 00:00:00\n"),
@@ -427,7 +427,7 @@ func TestResolveScriptSkipsAiderHomeDefault(t *testing.T) {
 
 	out := runResolveScriptForTest(t, "HOME="+home)
 
-	dirs, _ := parseResolvedDirs(string(out))
+	dirs, _, _ := parseResolvedDirs(string(out))
 	assert.Empty(t, dirs[parser.AgentAider],
 		"aider bare-$HOME default must not be resolved for remote tar, got %v",
 		dirs[parser.AgentAider])
@@ -441,7 +441,7 @@ func TestResolveScriptSkipsAiderHomeDefault(t *testing.T) {
 // treats resolved entries as tar targets, so emitting the code root would
 // archive the entire repository instead of just .aider.chat.history.md files.
 func TestResolveScriptAiderScopedByEnvFindsHistoryFiles(t *testing.T) {
-	home := t.TempDir()
+	home := physTempDir(t)
 	codeRoot := filepath.Join(home, "code")
 	repoA := filepath.Join(codeRoot, "repo-a")
 	repoB := filepath.Join(codeRoot, "nested", "repo-b")
@@ -465,7 +465,7 @@ func TestResolveScriptAiderScopedByEnvFindsHistoryFiles(t *testing.T) {
 
 	out := runResolveScriptForTest(t, "HOME="+home, "AIDER_DIR="+codeRoot)
 
-	dirs, _ := parseResolvedDirs(string(out))
+	dirs, _, _ := parseResolvedDirs(string(out))
 	aiderTargets := slashPaths(dirs[parser.AgentAider])
 	assert.ElementsMatch(t, []string{filepath.ToSlash(historyA), filepath.ToSlash(historyB)}, aiderTargets,
 		"explicit AIDER_DIR must resolve only aider history files")
@@ -481,7 +481,7 @@ func TestResolveScriptAiderNewlinePathCannotInjectTarget(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Windows path APIs reject embedded newlines; this regression covers POSIX remote shell output")
 	}
-	home := t.TempDir()
+	home := physTempDir(t)
 	codeRoot := filepath.Join(home, "code")
 	injected := "/home/victim/" + parser.AiderHistoryFileName()
 	maliciousDir := filepath.Join(codeRoot, "repo\naider:", "home", "victim")
@@ -491,7 +491,7 @@ func TestResolveScriptAiderNewlinePathCannotInjectTarget(t *testing.T) {
 
 	out := runResolveScriptForTest(t, "HOME="+home, "AIDER_DIR="+codeRoot)
 
-	dirs, _ := parseResolvedDirs(string(out))
+	dirs, _, _ := parseResolvedDirs(string(out))
 	assert.NotContains(t, dirs[parser.AgentAider], injected,
 		"newline-bearing repository paths must not inject a second transfer target")
 	for _, target := range dirs[parser.AgentAider] {
@@ -512,12 +512,12 @@ func slashPaths(paths []string) []string {
 // to literal $HOME (the very thing the home-default skip prevents) is also
 // dropped, so an unscoped override cannot reintroduce a whole-home tar.
 func TestResolveScriptAiderRejectsHomeOverride(t *testing.T) {
-	home := t.TempDir()
+	home := physTempDir(t)
 
 	for _, override := range []string{home, home + "/"} {
 		out := runResolveScriptForTest(t, "HOME="+home, "AIDER_DIR="+override)
 
-		dirs, _ := parseResolvedDirs(string(out))
+		dirs, _, _ := parseResolvedDirs(string(out))
 		assert.Empty(t, dirs[parser.AgentAider],
 			"AIDER_DIR=%q (== $HOME) must not resolve to a whole-home tar, got %v",
 			override, dirs[parser.AgentAider])
@@ -525,7 +525,7 @@ func TestResolveScriptAiderRejectsHomeOverride(t *testing.T) {
 }
 
 func TestResolveScriptWindsurfTargetsOnlySessionFiles(t *testing.T) {
-	home := t.TempDir()
+	home := physTempDir(t)
 	userRoot := filepath.Join(home, "AppData", "Roaming", "Windsurf", "User")
 	workspaceRoot := filepath.Join(userRoot, "workspaceStorage")
 	workspaceDir := filepath.Join(workspaceRoot, "workspace-a")
@@ -590,7 +590,7 @@ func TestParseResolvedDirs(t *testing.T) {
 		"@file:/home/wes/.codex/session_index.jsonl\n" +
 		"\n"
 
-	dirs, extraFiles := parseResolvedDirs(input)
+	dirs, extraFiles, _ := parseResolvedDirs(input)
 
 	// codex has one valid dir and one empty (excluded) entry.
 	assert.Equal(t, []string{"/home/wes/.codex/sessions"}, dirs[parser.AgentCodex])
@@ -611,7 +611,7 @@ func TestParseResolvedDirsNULRecords(t *testing.T) {
 		"aider:/home/wes/code/repo/.aider.chat.history.md\x00" +
 		"@file:/home/wes/.codex/session_index.jsonl\x00"
 
-	dirs, extraFiles := parseResolvedDirs(input)
+	dirs, extraFiles, _ := parseResolvedDirs(input)
 
 	assert.Equal(t, []string{"/home/wes/.claude/projects"}, dirs[parser.AgentClaude])
 	assert.Equal(t,
@@ -628,7 +628,7 @@ func TestParseResolvedTargetsIncludesAgentFiles(t *testing.T) {
 		"@agentfile:windsurf:/home/wes/Windsurf/User/workspaceStorage/a/workspace.json\x00" +
 		"@file:/home/wes/.codex/session_index.jsonl\x00"
 
-	dirs, files, extraFiles, _ := parseResolvedTargets(input)
+	dirs, files, extraFiles, _, _ := parseResolvedTargets(input)
 
 	assert.Equal(t, []string{"/home/wes/Windsurf/User"}, dirs[parser.AgentWindsurf])
 	assert.Equal(t, []string{
@@ -640,7 +640,7 @@ func TestParseResolvedTargetsIncludesAgentFiles(t *testing.T) {
 }
 
 func TestResolveScriptRooCodeTargetsOnlySessionFiles(t *testing.T) {
-	home := t.TempDir()
+	home := physTempDir(t)
 	rooRoot := filepath.Join(home, ".config", "Code", "User",
 		"globalStorage", "rooveterinaryinc.roo-cline")
 	task1 := filepath.Join(rooRoot, "tasks", "task-1")
@@ -694,7 +694,7 @@ func TestResolveScriptRooCodeTargetsOnlySessionFiles(t *testing.T) {
 }
 
 func TestResolveScriptRooCodeSkipsRootWithoutSessions(t *testing.T) {
-	home := t.TempDir()
+	home := physTempDir(t)
 	rooRoot := filepath.Join(home, ".config", "Code", "User",
 		"globalStorage", "rooveterinaryinc.roo-cline")
 	settingsDir := filepath.Join(rooRoot, "settings")
@@ -715,7 +715,7 @@ func TestResolveScriptKiloLegacyRejectsSymlinkedTaskDir(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink semantics differ on Windows")
 	}
-	home := t.TempDir()
+	home := physTempDir(t)
 	klRoot := filepath.Join(home, ".config", "Code", "User",
 		"globalStorage", "kilocode.kilo-code")
 	tasksDir := filepath.Join(klRoot, "tasks")
@@ -734,7 +734,7 @@ func TestResolveScriptKiloLegacyRejectsSymlinkedTaskDir(t *testing.T) {
 	))
 
 	// Symlinked task directory pointing outside root.
-	outsideDir := filepath.Join(t.TempDir(), "escaped-task")
+	outsideDir := filepath.Join(physTempDir(t), "escaped-task")
 	require.NoError(t, os.MkdirAll(outsideDir, 0o755))
 	require.NoError(t, os.WriteFile(
 		filepath.Join(outsideDir, "task_metadata.json"),
@@ -762,7 +762,7 @@ func TestResolveScriptKiloLegacyRejectsSymlinkedTaskDir(t *testing.T) {
 // only the trajectories/ subdirectory, mirroring
 // remotesync.resolvePoolsideTarget.
 func TestResolveScriptPoolsideTargetsOnlyTrajectories(t *testing.T) {
-	home := t.TempDir()
+	home := physTempDir(t)
 	poolsideRoot := filepath.Join(home, ".local", "state", "poolside")
 	trajectoriesDir := filepath.Join(poolsideRoot, "trajectories")
 	settingsDir := filepath.Join(poolsideRoot, "settings")
@@ -795,7 +795,7 @@ func TestResolveScriptPoolsideTargetsOnlyTrajectories(t *testing.T) {
 // SSH resolver emits nothing when the trajectories/ subdirectory does
 // not exist.
 func TestResolveScriptPoolsideSkipsRootWithoutTrajectories(t *testing.T) {
-	home := t.TempDir()
+	home := physTempDir(t)
 	poolsideRoot := filepath.Join(home, ".local", "state", "poolside")
 	require.NoError(t, os.MkdirAll(poolsideRoot, 0o755))
 
@@ -814,7 +814,7 @@ func TestResolveScriptPoolsideTrajectoriesRoot(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("resolve script runs on POSIX remote hosts; local Windows filepaths and MSYS shell parsing are not representative")
 	}
-	home := t.TempDir()
+	home := physTempDir(t)
 	// Set POOLSIDE_DIR directly to a trajectories/ directory.
 	trajectoriesDir := filepath.Join(home, "poolside", "trajectories")
 	require.NoError(t, os.MkdirAll(trajectoriesDir, 0o755))
@@ -824,7 +824,7 @@ func TestResolveScriptPoolsideTrajectoriesRoot(t *testing.T) {
 
 	out := runResolveScriptForTest(t, "HOME="+home, "POOLSIDE_DIR="+trajectoriesDir)
 
-	dirs, _ := parseResolvedDirs(string(out))
+	dirs, _, _ := parseResolvedDirs(string(out))
 	assert.Equal(t, []string{trajectoriesDir}, dirs[parser.AgentPoolside],
 		"the environment override must produce one transfer target")
 
@@ -838,4 +838,85 @@ func TestResolveScriptPoolsideTrajectoriesRoot(t *testing.T) {
 		assert.NotContains(t, record, "poolside/poolside",
 			"must not double-nest trajectories")
 	}
+}
+
+// physTempDir returns t.TempDir() with symlinks resolved. The resolve
+// script emits physical paths (see av_phys_dir), so fixtures must compare
+// against physical spellings — on macOS t.TempDir() lives under /var,
+// which is a symlink to /private/var.
+func physTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+	return dir
+}
+
+func TestParseResolvedTargetsFailsClosedOnUnrepresentableForbiddenRoot(
+	t *testing.T,
+) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			"newline_inside_forbidden_value",
+			"claude:/home/u/.claude\x00@forbidden:/home/u/evil\ndir\x00",
+		},
+		{
+			"empty_forbidden_value",
+			"claude:/home/u/.claude\x00@forbidden:\x00",
+		},
+		{
+			"bare_forbidden_record",
+			"claude:/home/u/.claude\x00@forbidden\x00",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, _, _, err := parseResolvedTargets(tc.input)
+			require.Error(t, err,
+				"a forbidden record that cannot be represented must fail the sync, not drop the boundary")
+			assert.Contains(t, err.Error(), "forbidden")
+		})
+	}
+}
+
+func TestParseResolvedTargetsPreservesNULDelimitedSpellingsExactly(
+	t *testing.T,
+) {
+	input := "@forbidden:/home/u/trae dir \x00" +
+		"claude:/home/u/.claude \x00"
+
+	dirs, _, _, forbiddenRoots, err := parseResolvedTargets(input)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/home/u/trae dir "}, forbiddenRoots,
+		"NUL-delimited forbidden roots must keep trailing whitespace — trimming changes the excluded path")
+	assert.Equal(t, []string{"/home/u/.claude "}, dirs[parser.AgentClaude],
+		"NUL-delimited target spellings must be preserved exactly")
+}
+
+func TestResolveScriptEmitsPhysicalPathsForSymlinkedRoots(t *testing.T) {
+	home := physTempDir(t)
+	physicalTrae := filepath.Join(home, "real-trae")
+	physicalClaude := filepath.Join(home, "real-claude")
+	require.NoError(t, os.MkdirAll(physicalTrae, 0o755))
+	require.NoError(t, os.MkdirAll(
+		filepath.Join(physicalClaude, "projects"), 0o755))
+	traeAlias := filepath.Join(home, "trae-alias")
+	require.NoError(t, os.Symlink(physicalTrae, traeAlias))
+	// The default Claude root $HOME/.claude/projects is reached through a
+	// symlinked ancestor.
+	require.NoError(t, os.Symlink(
+		physicalClaude, filepath.Join(home, ".claude")))
+
+	out := runResolveScriptForTest(t, "HOME="+home, "TRAE_DIR="+traeAlias)
+	dirs, _, _, forbiddenRoots, err := parseResolvedTargets(string(out))
+	require.NoError(t, err)
+
+	assert.Contains(t, forbiddenRoots, physicalTrae,
+		"forbidden roots must be emitted by physical spelling so alias overlap cannot bypass them")
+	assert.NotContains(t, forbiddenRoots, traeAlias)
+	assert.Contains(t, dirs[parser.AgentClaude],
+		filepath.Join(physicalClaude, "projects"),
+		"targets must be emitted by physical spelling to share a namespace with forbidden roots")
 }

--- a/internal/ssh/resolve_test.go
+++ b/internal/ssh/resolve_test.go
@@ -67,6 +67,7 @@ func TestResolveScriptExcludesTraeProfile(t *testing.T) {
 }
 
 func TestResolveScriptHonorsClaudeConfigDirRoot(t *testing.T) {
+	skipScriptPathEqualityOnWindows(t)
 	home := physTempDir(t)
 	root := filepath.Join(home, "claude personal")
 	projectsDir := filepath.Join(root, "projects")
@@ -214,6 +215,7 @@ func TestResolveScriptExcludesRemoteSyncExcludedAgentState(t *testing.T) {
 }
 
 func TestResolveScriptCarriesTraeForbiddenRoot(t *testing.T) {
+	skipScriptPathEqualityOnWindows(t)
 	home := physTempDir(t)
 	root := filepath.Join(home, "AppData", "Roaming", "Trae", "User")
 	require.NoError(t, os.MkdirAll(root, 0o755))
@@ -237,6 +239,7 @@ func TestResolveScriptCarriesMissingExcludedRoot(t *testing.T) {
 }
 
 func TestResolveScriptHermesOverrideReplacesNamedProfiles(t *testing.T) {
+	skipScriptPathEqualityOnWindows(t)
 	home := filepath.ToSlash(physTempDir(t))
 	profileSessions := path.Join(
 		home, ".hermes", "profiles", "research", "sessions",
@@ -260,6 +263,7 @@ func TestResolveScriptHermesOverrideReplacesNamedProfiles(t *testing.T) {
 }
 
 func TestResolveScriptHermesProfilesContainerOverrideEnumeratesProfiles(t *testing.T) {
+	skipScriptPathEqualityOnWindows(t)
 	home := filepath.ToSlash(physTempDir(t))
 	profilesRoot := path.Join(home, ".hermes", "profiles")
 	researchRoot := path.Join(profilesRoot, "research")
@@ -288,6 +292,7 @@ func TestResolveScriptHermesProfilesContainerOverrideEnumeratesProfiles(t *testi
 }
 
 func TestResolveScriptHermesTrailingSlashOverrideIncludesStateDB(t *testing.T) {
+	skipScriptPathEqualityOnWindows(t)
 	home := filepath.ToSlash(physTempDir(t))
 	customRoot := path.Join(home, "custom-hermes")
 	customSessions := path.Join(customRoot, "sessions")
@@ -306,6 +311,7 @@ func TestResolveScriptHermesTrailingSlashOverrideIncludesStateDB(t *testing.T) {
 }
 
 func TestResolveScriptIncludesFlatCustomHermesRoot(t *testing.T) {
+	skipScriptPathEqualityOnWindows(t)
 	home := physTempDir(t)
 	customRoot := filepath.Join(home, "custom", "hermes-archive")
 	require.NoError(t, os.MkdirAll(customRoot, 0o755))
@@ -441,6 +447,7 @@ func TestResolveScriptSkipsAiderHomeDefault(t *testing.T) {
 // treats resolved entries as tar targets, so emitting the code root would
 // archive the entire repository instead of just .aider.chat.history.md files.
 func TestResolveScriptAiderScopedByEnvFindsHistoryFiles(t *testing.T) {
+	skipScriptPathEqualityOnWindows(t)
 	home := physTempDir(t)
 	codeRoot := filepath.Join(home, "code")
 	repoA := filepath.Join(codeRoot, "repo-a")
@@ -569,6 +576,19 @@ func hasRecordWithPathSuffix(records []string, prefix, suffix string) bool {
 		}
 	}
 	return false
+}
+
+// skipScriptPathEqualityOnWindows skips script-execution tests that
+// assert exact emitted path spellings or build POSIX symlink fixtures.
+// The resolve script targets POSIX remote hosts; on Windows CI it runs
+// under MSYS sh, whose pwd -P prints /c/... POSIX spellings for Windows
+// paths, so physical-path emission (av_phys_dir) rewrites fixtures into
+// a dialect no real deployment produces.
+func skipScriptPathEqualityOnWindows(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("resolve script targets POSIX remote hosts; MSYS pwd rewrites Windows paths into /c/... spellings")
+	}
 }
 
 func runResolveScriptForTest(t *testing.T, env ...string) []byte {
@@ -896,6 +916,7 @@ func TestParseResolvedTargetsPreservesNULDelimitedSpellingsExactly(
 }
 
 func TestResolveScriptEmitsPhysicalPathsForSymlinkedRoots(t *testing.T) {
+	skipScriptPathEqualityOnWindows(t)
 	home := physTempDir(t)
 	physicalTrae := filepath.Join(home, "real-trae")
 	physicalClaude := filepath.Join(home, "real-claude")
@@ -927,6 +948,7 @@ func TestResolveScriptEmitsPhysicalPathsForSymlinkedRoots(t *testing.T) {
 // filename resolves against the physical working directory, and a file
 // spelled through a symlinked parent resolves to its physical location.
 func TestAvPhysFileEdgeCases(t *testing.T) {
+	skipScriptPathEqualityOnWindows(t)
 	base := physTempDir(t)
 	physicalDir := filepath.Join(base, "real")
 	require.NoError(t, os.MkdirAll(physicalDir, 0o755))
@@ -965,6 +987,7 @@ func TestAvPhysFileEdgeCases(t *testing.T) {
 // provider's tree: the emitted history-file path must carry the physical
 // forbidden-root prefix so the transfer-side filter drops it.
 func TestResolveScriptAiderSymlinkOverlapStaysForbidden(t *testing.T) {
+	skipScriptPathEqualityOnWindows(t)
 	home := physTempDir(t)
 	physicalTrae := filepath.Join(home, "real-trae")
 	repoDir := filepath.Join(physicalTrae, "code", "repo")

--- a/internal/ssh/resolve_test.go
+++ b/internal/ssh/resolve_test.go
@@ -106,8 +106,13 @@ func TestResolveScriptExitsZero(t *testing.T) {
 	// dirs exist. Verify by running it against an empty
 	// HOME so no default dirs are found.
 	out := runResolveScriptForTest(t, "HOME=/nonexistent")
-	// No dirs should be found.
-	assert.Empty(t, strings.TrimSpace(string(out)))
+	dirs, files, extraFiles, forbiddenRoots :=
+		parseResolvedTargetsWithForbidden(string(out))
+	assert.Empty(t, dirs)
+	assert.Empty(t, files)
+	assert.Empty(t, extraFiles)
+	assert.True(t, hasSuffix(forbiddenRoots, ".config/Trae/User"),
+		"missing excluded roots remain protected if created after resolution")
 }
 
 // TestResolveScriptIncludesCodexIndex verifies the resolve script emits the
@@ -182,6 +187,53 @@ func TestResolveScriptIncludesHermesNamedProfiles(t *testing.T) {
 	assert.True(t, hasSuffix(extraFiles, ".hermes/profiles/orchestrator/state.db-journal"))
 	assert.True(t, hasSuffix(extraFiles, ".hermes/profiles/research/state.db"))
 	assert.True(t, hasSuffix(extraFiles, ".hermes/state.db"))
+}
+
+func TestResolveScriptExcludesRemoteSyncExcludedAgentState(t *testing.T) {
+	home := t.TempDir()
+	root := filepath.Join(home, "AppData", "Roaming", "Trae", "User")
+	require.NoError(t, os.MkdirAll(root, 0o755))
+	for _, name := range []string{
+		"chat.db",
+		"chat.db-wal",
+		"chat.db-shm",
+		"chat.db-journal",
+	} {
+		require.NoError(t,
+			os.WriteFile(filepath.Join(root, name), []byte("sqlite"), 0o644))
+	}
+	require.NoError(t, os.WriteFile(
+		filepath.Join(root, "credentials.json"), []byte("secret"), 0o600,
+	))
+
+	out := runResolveScriptForTest(t, "HOME="+home, "TRAE_DIR="+root)
+	dirs, files, _ := parseResolvedTargets(string(out))
+
+	assert.NotContains(t, dirs, parser.AgentTrae)
+	assert.NotContains(t, files, parser.AgentTrae)
+}
+
+func TestResolveScriptCarriesTraeForbiddenRoot(t *testing.T) {
+	home := t.TempDir()
+	root := filepath.Join(home, "AppData", "Roaming", "Trae", "User")
+	require.NoError(t, os.MkdirAll(root, 0o755))
+
+	out := runResolveScriptForTest(t, "HOME="+home, "TRAE_DIR="+root)
+	_, _, _, forbiddenRoots := parseResolvedTargetsWithForbidden(string(out))
+
+	assert.Contains(t, forbiddenRoots, root,
+		"the SSH resolver must preserve excluded roots as transfer boundaries")
+}
+
+func TestResolveScriptCarriesMissingExcludedRoot(t *testing.T) {
+	home := t.TempDir()
+	root := filepath.Join(home, "AppData", "Roaming", "Trae", "User")
+
+	out := runResolveScriptForTest(t, "HOME="+home, "TRAE_DIR="+root)
+	_, _, _, forbiddenRoots := parseResolvedTargetsWithForbidden(string(out))
+
+	assert.Contains(t, forbiddenRoots, root,
+		"the exclusion boundary must survive creation after remote resolution")
 }
 
 func TestResolveScriptHermesOverrideReplacesNamedProfiles(t *testing.T) {

--- a/internal/ssh/resolve_test.go
+++ b/internal/ssh/resolve_test.go
@@ -1012,3 +1012,45 @@ func TestResolveScriptAiderSymlinkOverlapStaysForbidden(t *testing.T) {
 	assert.True(t, pathWithinForbiddenRoots(forbiddenRoots, got),
 		"physical spelling must fall inside the forbidden root so the transfer filter excludes it")
 }
+
+// TestAvPhysHelpersRefuseNewlinePaths pins the fail-closed handling of
+// physical paths containing CR/LF: command substitution strips trailing
+// newlines from pwd output, so emitting such a path would produce a
+// clean-looking but wrong spelling that downstream exclusion would guard
+// instead of the real subtree. The helpers must refuse instead.
+func TestAvPhysHelpersRefuseNewlinePaths(t *testing.T) {
+	skipScriptPathEqualityOnWindows(t)
+	base := physTempDir(t)
+	newlineDir := filepath.Join(base, "bad\ndir")
+	require.NoError(t, os.MkdirAll(newlineDir, 0o755))
+
+	script := resolveScriptPhysHelpers +
+		"if av_phys_dir \"$AV_TEST_INPUT\"; then echo ACCEPTED; else echo REFUSED; fi\n" +
+		"if av_phys_file \"$AV_TEST_INPUT/file\"; then echo ACCEPTED; else echo REFUSED; fi\n"
+	cmd := exec.Command("sh")
+	cmd.Stdin = strings.NewReader(script)
+	cmd.Env = []string{"AV_TEST_INPUT=" + newlineDir}
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "helper harness failed: %s", out)
+	assert.Equal(t, "REFUSED\nREFUSED\n", string(out),
+		"newline-carrying physical paths must be refused, not emitted misspelled")
+}
+
+// TestResolveScriptAbortsOnUnrepresentableForbiddenRoot pins the
+// whole-script abort: when an excluded agent's root physically resolves
+// to a newline-carrying path, the resolve must fail (non-zero exit) so
+// the sync aborts, rather than emitting a mangled spelling that would
+// guard the wrong subtree.
+func TestResolveScriptAbortsOnUnrepresentableForbiddenRoot(t *testing.T) {
+	skipScriptPathEqualityOnWindows(t)
+	home := physTempDir(t)
+	traeRoot := filepath.Join(home, "trae\nroot")
+	require.NoError(t, os.MkdirAll(traeRoot, 0o755))
+
+	cmd := exec.Command("sh")
+	cmd.Stdin = strings.NewReader(buildResolveScript())
+	cmd.Env = []string{"HOME=" + home, "TRAE_DIR=" + traeRoot}
+	out, err := cmd.CombinedOutput()
+	require.Error(t, err,
+		"an unrepresentable forbidden root must abort the resolve, got output: %s", out)
+}

--- a/internal/ssh/resolve_test.go
+++ b/internal/ssh/resolve_test.go
@@ -228,6 +228,7 @@ func TestResolveScriptCarriesTraeForbiddenRoot(t *testing.T) {
 }
 
 func TestResolveScriptCarriesMissingExcludedRoot(t *testing.T) {
+	skipScriptPathEqualityOnWindows(t)
 	home := physTempDir(t)
 	root := filepath.Join(home, "AppData", "Roaming", "Trae", "User")
 
@@ -890,6 +891,10 @@ func TestParseResolvedTargetsFailsClosedOnUnrepresentableForbiddenRoot(
 			"bare_forbidden_record",
 			"claude:/home/u/.claude\x00@forbidden\x00",
 		},
+		{
+			"non_utf8_forbidden_value",
+			"claude:/home/u/.claude\x00@forbidden:/home/u/\xff\xfe\x00",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1026,13 +1031,14 @@ func TestAvPhysHelpersRefuseNewlinePaths(t *testing.T) {
 
 	script := resolveScriptPhysHelpers +
 		"if av_phys_dir \"$AV_TEST_INPUT\"; then echo ACCEPTED; else echo REFUSED; fi\n" +
-		"if av_phys_file \"$AV_TEST_INPUT/file\"; then echo ACCEPTED; else echo REFUSED; fi\n"
+		"if av_phys_file \"$AV_TEST_INPUT/file\"; then echo ACCEPTED; else echo REFUSED; fi\n" +
+		"if av_phys_missing \"$AV_TEST_INPUT/missing\"; then echo ACCEPTED; else echo REFUSED; fi\n"
 	cmd := exec.Command("sh")
 	cmd.Stdin = strings.NewReader(script)
 	cmd.Env = []string{"AV_TEST_INPUT=" + newlineDir}
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "helper harness failed: %s", out)
-	assert.Equal(t, "REFUSED\nREFUSED\n", string(out),
+	assert.Equal(t, "REFUSED\nREFUSED\nREFUSED\n", string(out),
 		"newline-carrying physical paths must be refused, not emitted misspelled")
 }
 
@@ -1053,4 +1059,141 @@ func TestResolveScriptAbortsOnUnrepresentableForbiddenRoot(t *testing.T) {
 	out, err := cmd.CombinedOutput()
 	require.Error(t, err,
 		"an unrepresentable forbidden root must abort the resolve, got output: %s", out)
+}
+
+// TestResolveScriptPoolsideSymlinkedTrajectoriesOverride pins the
+// canonicalize-after-narrowing ordering: a POOLSIDE_DIR override that is
+// a symlink NAMED trajectories must be recognized by its literal
+// basename (used as-is), then emitted by physical spelling.
+// Canonicalizing before dispatch would rename the override to its
+// physical basename and make the resolver look for a nested
+// trajectories/ that does not exist.
+func TestResolveScriptPoolsideSymlinkedTrajectoriesOverride(t *testing.T) {
+	skipScriptPathEqualityOnWindows(t)
+	home := physTempDir(t)
+	physicalDir := filepath.Join(home, "poolside-data")
+	require.NoError(t, os.MkdirAll(physicalDir, 0o755))
+	alias := filepath.Join(home, "trajectories")
+	require.NoError(t, os.Symlink(physicalDir, alias))
+
+	out := runResolveScriptForTest(t, "HOME="+home, "POOLSIDE_DIR="+alias)
+	dirs, _, _, _, err := parseResolvedTargets(string(out))
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{physicalDir}, dirs[parser.AgentPoolside],
+		"a symlink named trajectories must narrow by its literal basename and emit its physical path")
+}
+
+// TestResolveScriptWindsurfSymlinkedWorkspaceStorageOverride is the
+// workspaceStorage analog: the override's literal basename decides
+// whether workspaceStorage is appended, and only the emitted root is
+// canonicalized.
+func TestResolveScriptWindsurfSymlinkedWorkspaceStorageOverride(t *testing.T) {
+	skipScriptPathEqualityOnWindows(t)
+	home := physTempDir(t)
+	physicalDir := filepath.Join(home, "windsurf-data")
+	wsDir := filepath.Join(physicalDir, "ws1")
+	require.NoError(t, os.MkdirAll(wsDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(wsDir, parser.WindsurfStateDBName), []byte("db"), 0o644))
+	alias := filepath.Join(home, "workspaceStorage")
+	require.NoError(t, os.Symlink(physicalDir, alias))
+
+	out := runResolveScriptForTest(t, "HOME="+home, "WINDSURF_DIR="+alias)
+	dirs, files, _, _, err := parseResolvedTargets(string(out))
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{physicalDir}, dirs[parser.AgentWindsurf],
+		"a symlink named workspaceStorage must narrow by its literal basename and emit its physical path")
+	assert.Contains(t, files[parser.AgentWindsurf],
+		filepath.Join(wsDir, parser.WindsurfStateDBName),
+		"session files must carry the physical spelling")
+}
+
+// TestAvPhysMissingResolvesLongestExistingAncestor exercises the
+// missing-path canonicalization helper directly: the longest existing
+// ancestor resolves physically and the missing tail is rejoined
+// literally, so a forbidden root that does not exist yet still guards
+// the physical subtree where its contents would appear.
+func TestAvPhysMissingResolvesLongestExistingAncestor(t *testing.T) {
+	skipScriptPathEqualityOnWindows(t)
+	base := physTempDir(t)
+	physicalDir := filepath.Join(base, "real")
+	require.NoError(t, os.MkdirAll(physicalDir, 0o755))
+	alias := filepath.Join(base, "alias")
+	require.NoError(t, os.Symlink(physicalDir, alias))
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"existing_dir_resolves_physically", alias, physicalDir},
+		{"missing_leaf_under_existing_parent",
+			filepath.Join(base, "missing"), filepath.Join(base, "missing")},
+		{"missing_tail_under_symlinked_ancestor",
+			filepath.Join(alias, "missing", "leaf"),
+			filepath.Join(physicalDir, "missing", "leaf")},
+		{"relative_spelling_anchors_to_cwd", "missing-rel/leaf",
+			filepath.Join(base, "missing-rel", "leaf")},
+		{"fully_missing_absolute_path_keeps_spelling",
+			"/nonexistent-av-test/a/b", "/nonexistent-av-test/a/b"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			script := resolveScriptPhysHelpers +
+				"av_phys_missing \"$AV_TEST_INPUT\"\n"
+			cmd := exec.Command("sh")
+			cmd.Stdin = strings.NewReader(script)
+			cmd.Dir = base
+			cmd.Env = []string{"AV_TEST_INPUT=" + tc.input}
+			out, err := cmd.CombinedOutput()
+			require.NoError(t, err, "helper failed: %s", out)
+			assert.Equal(t, tc.want, string(out))
+		})
+	}
+}
+
+// TestResolveScriptMissingForbiddenRootResolvesSymlinkedAncestor pins
+// av_emit_forbidden_root's missing-root handling: a TRAE_DIR that does
+// not exist but is spelled through a symlinked ancestor must be emitted
+// under the physical subtree where its contents would appear, so the
+// boundary matches canonicalized targets if the root is created later.
+func TestResolveScriptMissingForbiddenRootResolvesSymlinkedAncestor(
+	t *testing.T,
+) {
+	skipScriptPathEqualityOnWindows(t)
+	home := physTempDir(t)
+	physicalDir := filepath.Join(home, "real-apps")
+	require.NoError(t, os.MkdirAll(physicalDir, 0o755))
+	alias := filepath.Join(home, "apps-alias")
+	require.NoError(t, os.Symlink(physicalDir, alias))
+	missingRoot := filepath.Join(alias, "Trae", "User")
+
+	out := runResolveScriptForTest(t, "HOME="+home, "TRAE_DIR="+missingRoot)
+	_, _, _, forbiddenRoots, err := parseResolvedTargets(string(out))
+	require.NoError(t, err)
+
+	assert.Contains(t, forbiddenRoots,
+		filepath.Join(physicalDir, "Trae", "User"),
+		"a missing forbidden root must resolve through its longest existing ancestor")
+	assert.NotContains(t, forbiddenRoots, missingRoot)
+}
+
+// TestParseResolvedTargetsDropsNonUTF8TargetRecords: non-UTF-8 spellings
+// are unrepresentable downstream (glob escaping iterates runes, the
+// Python snapshot filter round-trips JSON), so target records carrying
+// them are dropped rather than mangled. Forbidden records with non-UTF-8
+// bytes fail the sync instead, covered by the fail-closed test above.
+func TestParseResolvedTargetsDropsNonUTF8TargetRecords(t *testing.T) {
+	input := "claude:/home/u/\xff\x00codex:/home/u/.codex/sessions\x00"
+
+	dirs, _, _, _, err := parseResolvedTargets(input)
+	require.NoError(t, err)
+
+	assert.Empty(t, dirs[parser.AgentClaude],
+		"a non-UTF-8 target spelling must be dropped, not passed downstream")
+	assert.Equal(t, []string{"/home/u/.codex/sessions"},
+		dirs[parser.AgentCodex],
+		"valid records in the same output must survive")
 }

--- a/internal/ssh/resolve_test.go
+++ b/internal/ssh/resolve_test.go
@@ -107,7 +107,7 @@ func TestResolveScriptExitsZero(t *testing.T) {
 	// HOME so no default dirs are found.
 	out := runResolveScriptForTest(t, "HOME=/nonexistent")
 	dirs, files, extraFiles, forbiddenRoots :=
-		parseResolvedTargetsWithForbidden(string(out))
+		parseResolvedTargets(string(out))
 	assert.Empty(t, dirs)
 	assert.Empty(t, files)
 	assert.Empty(t, extraFiles)
@@ -207,7 +207,7 @@ func TestResolveScriptExcludesRemoteSyncExcludedAgentState(t *testing.T) {
 	))
 
 	out := runResolveScriptForTest(t, "HOME="+home, "TRAE_DIR="+root)
-	dirs, files, _ := parseResolvedTargets(string(out))
+	dirs, files, _, _ := parseResolvedTargets(string(out))
 
 	assert.NotContains(t, dirs, parser.AgentTrae)
 	assert.NotContains(t, files, parser.AgentTrae)
@@ -219,7 +219,7 @@ func TestResolveScriptCarriesTraeForbiddenRoot(t *testing.T) {
 	require.NoError(t, os.MkdirAll(root, 0o755))
 
 	out := runResolveScriptForTest(t, "HOME="+home, "TRAE_DIR="+root)
-	_, _, _, forbiddenRoots := parseResolvedTargetsWithForbidden(string(out))
+	_, _, _, forbiddenRoots := parseResolvedTargets(string(out))
 
 	assert.Contains(t, forbiddenRoots, root,
 		"the SSH resolver must preserve excluded roots as transfer boundaries")
@@ -230,7 +230,7 @@ func TestResolveScriptCarriesMissingExcludedRoot(t *testing.T) {
 	root := filepath.Join(home, "AppData", "Roaming", "Trae", "User")
 
 	out := runResolveScriptForTest(t, "HOME="+home, "TRAE_DIR="+root)
-	_, _, _, forbiddenRoots := parseResolvedTargetsWithForbidden(string(out))
+	_, _, _, forbiddenRoots := parseResolvedTargets(string(out))
 
 	assert.Contains(t, forbiddenRoots, root,
 		"the exclusion boundary must survive creation after remote resolution")
@@ -628,7 +628,7 @@ func TestParseResolvedTargetsIncludesAgentFiles(t *testing.T) {
 		"@agentfile:windsurf:/home/wes/Windsurf/User/workspaceStorage/a/workspace.json\x00" +
 		"@file:/home/wes/.codex/session_index.jsonl\x00"
 
-	dirs, files, extraFiles := parseResolvedTargets(input)
+	dirs, files, extraFiles, _ := parseResolvedTargets(input)
 
 	assert.Equal(t, []string{"/home/wes/Windsurf/User"}, dirs[parser.AgentWindsurf])
 	assert.Equal(t, []string{

--- a/internal/ssh/sync.go
+++ b/internal/ssh/sync.go
@@ -64,7 +64,7 @@ func (rs *RemoteSync) Run(
 		"Downloading session data from %s (%d agents)...\n",
 		rs.Host, len(dirs),
 	)
-	tmpDir, err := downloadAndExtractWithForbiddenRoots(
+	tmpDir, err := downloadAndExtract(
 		ctx, rs.Host, rs.User, rs.Port, rs.SSHOpts,
 		dirs, files, extraFiles, forbiddenRoots,
 	)

--- a/internal/ssh/sync.go
+++ b/internal/ssh/sync.go
@@ -42,7 +42,7 @@ func (rs *RemoteSync) Run(
 	fmt.Printf(
 		"Resolving agent directories on %s...\n", rs.Host,
 	)
-	dirs, files, extraFiles, err := resolveDirs(
+	dirs, files, extraFiles, forbiddenRoots, err := resolveDirs(
 		ctx, rs.Host, rs.User, rs.Port, rs.SSHOpts,
 	)
 	if err != nil {
@@ -64,8 +64,9 @@ func (rs *RemoteSync) Run(
 		"Downloading session data from %s (%d agents)...\n",
 		rs.Host, len(dirs),
 	)
-	tmpDir, err := downloadAndExtract(
-		ctx, rs.Host, rs.User, rs.Port, rs.SSHOpts, dirs, files, extraFiles,
+	tmpDir, err := downloadAndExtractWithForbiddenRoots(
+		ctx, rs.Host, rs.User, rs.Port, rs.SSHOpts,
+		dirs, files, extraFiles, forbiddenRoots,
 	)
 	if err != nil {
 		return stats, fmt.Errorf(
@@ -106,9 +107,10 @@ func (rs *RemoteSync) Run(
 		BlockedResultCategories: rs.BlockedResultCategories,
 		Progress:                progress,
 	}.ImportExtracted(ctx, remotesync.TargetSet{
-		Dirs:       dirs,
-		Files:      files,
-		ExtraFiles: extraFiles,
+		Dirs:           dirs,
+		Files:          files,
+		ExtraFiles:     extraFiles,
+		ForbiddenRoots: forbiddenRoots,
 	}, tmpDir)
 	if lastProgress.SessionsTotal > 0 {
 		elapsed := time.Since(t0).Truncate(time.Millisecond)

--- a/internal/ssh/sync.go
+++ b/internal/ssh/sync.go
@@ -107,10 +107,13 @@ func (rs *RemoteSync) Run(
 		BlockedResultCategories: rs.BlockedResultCategories,
 		Progress:                progress,
 	}.ImportExtracted(ctx, remotesync.TargetSet{
-		Dirs:           dirs,
-		Files:          files,
-		ExtraFiles:     extraFiles,
-		ForbiddenRoots: forbiddenRoots,
+		Dirs:       dirs,
+		Files:      files,
+		ExtraFiles: extraFiles,
+		// ForbiddenRoots is intentionally omitted: the tar script already
+		// pruned forbidden content before it reached tmpDir, and these
+		// values are remote POSIX paths, not paths in the local-path
+		// domain ImportExtracted operates in.
 	}, tmpDir)
 	if lastProgress.SessionsTotal > 0 {
 		elapsed := time.Since(t0).Truncate(time.Millisecond)

--- a/internal/ssh/transfer.go
+++ b/internal/ssh/transfer.go
@@ -224,7 +224,18 @@ paths = json.loads(%q)
 databases = json.loads(%q)
 forbidden = json.loads(%q)
 
+# Member names and forbidden roots are compared in one rootless form so
+# the match cannot depend on whether tarfile preserves the "./" arcname
+# spelling (current CPython does; both spellings normalize identically).
+def archive_name(name):
+    if name.startswith("./"):
+        name = name[2:]
+    return name.lstrip("/")
+
+forbidden = [root for root in (archive_name(f) for f in forbidden) if root]
+
 def is_forbidden(archive_path):
+    archive_path = archive_name(archive_path)
     for root in forbidden:
         if archive_path == root or archive_path.startswith(root.rstrip("/") + "/"):
             return True

--- a/internal/ssh/transfer.go
+++ b/internal/ssh/transfer.go
@@ -18,24 +18,16 @@ import (
 )
 
 // buildTarCommand generates the remote shell script for the given
-// agent directories, agent-scoped files, and extra files. Uses -C /
+// agent directories, agent-scoped files, and extra files, while
+// preserving excluded-provider roots as path boundaries. Uses -C /
 // so paths are relative to root, and feeds paths to tar over stdin
 // instead of expanding them as tar argv. The script itself is sent to
 // the remote shell over stdin, so a large file-scoped Windsurf export
-// does not consume ssh/exec argument space.
+// does not consume ssh/exec argument space. Agent ownership alone is
+// not sufficient: an allowed directory can contain a forbidden
+// provider's store, so every transfer input is screened independently
+// of its owner. Pass a nil forbiddenRoots when there are none.
 func buildTarCommand(
-	dirs map[parser.AgentType][]string,
-	files map[parser.AgentType][]string,
-	extraFiles []string,
-) string {
-	return buildTarCommandWithForbiddenRoots(dirs, files, extraFiles, nil)
-}
-
-// buildTarCommandWithForbiddenRoots creates an SSH archive command while
-// preserving excluded-provider roots as path boundaries. Agent ownership alone
-// is not sufficient: an allowed directory can contain a forbidden provider's
-// store, so every transfer input is screened independently of its owner.
-func buildTarCommandWithForbiddenRoots(
 	dirs map[parser.AgentType][]string,
 	files map[parser.AgentType][]string,
 	extraFiles []string,
@@ -306,20 +298,9 @@ func shellQuote(s string) string {
 }
 
 // downloadAndExtract tars remote agent dirs and extracts to a local
-// temp dir. Returns the temp dir path; caller must clean up.
+// temp dir. Returns the temp dir path; caller must clean up. Pass a
+// nil forbiddenRoots when there are none.
 func downloadAndExtract(
-	ctx context.Context,
-	host, user string, port int, sshOpts []string,
-	dirs map[parser.AgentType][]string,
-	files map[parser.AgentType][]string,
-	extraFiles []string,
-) (string, error) {
-	return downloadAndExtractWithForbiddenRoots(
-		ctx, host, user, port, sshOpts, dirs, files, extraFiles, nil,
-	)
-}
-
-func downloadAndExtractWithForbiddenRoots(
 	ctx context.Context,
 	host, user string, port int, sshOpts []string,
 	dirs map[parser.AgentType][]string,
@@ -327,7 +308,7 @@ func downloadAndExtractWithForbiddenRoots(
 	extraFiles []string,
 	forbiddenRoots []string,
 ) (string, error) {
-	tarCmd := buildTarCommandWithForbiddenRoots(
+	tarCmd := buildTarCommand(
 		dirs, files, extraFiles, forbiddenRoots,
 	)
 	stdout, cleanup, err := runSSHScriptStream(

--- a/internal/ssh/transfer.go
+++ b/internal/ssh/transfer.go
@@ -107,21 +107,13 @@ func filterForbiddenRoots(paths, forbiddenRoots []string) []string {
 	return filtered
 }
 
+// pathWithinForbiddenRoots reports whether remotePath is a forbidden root or
+// lies beneath one, treating remotePath and roots as remote POSIX paths. It
+// is a thin wrapper over remotesync.PathWithinForbiddenRoots, shared with
+// internal/remotesync's local-walk pruning so both call sites agree on
+// boundary matching (e.g. root "/a/b" must not match sibling path "/a/bc").
 func pathWithinForbiddenRoots(roots []string, remotePath string) bool {
-	remotePath = path.Clean(remotePath)
-	for _, root := range roots {
-		root = path.Clean(root)
-		if remotePath == root {
-			return true
-		}
-		if root == "/" && strings.HasPrefix(remotePath, "/") {
-			return true
-		}
-		if root != "/" && strings.HasPrefix(remotePath, root+"/") {
-			return true
-		}
-	}
-	return false
+	return remotesync.PathWithinForbiddenRoots(roots, remotePath, '/')
 }
 
 func buildPlainTarCommand(paths, forbiddenArchivePaths []string) string {

--- a/internal/ssh/transfer.go
+++ b/internal/ssh/transfer.go
@@ -122,9 +122,29 @@ func buildPlainTarCommand(paths, forbiddenArchivePaths []string) string {
 	b.WriteString("} | tar cf - -C /")
 	for _, forbiddenPath := range forbiddenArchivePaths {
 		b.WriteString(" --exclude=")
-		b.WriteString(shellQuote(forbiddenPath))
+		b.WriteString(shellQuote(escapeTarExcludeGlob(forbiddenPath)))
 	}
 	b.WriteString(" -T -\n")
+	return b.String()
+}
+
+// escapeTarExcludeGlob backslash-escapes tar --exclude glob metacharacters
+// (*, ?, [, and \ itself) in a literal path so the resulting pattern matches
+// only that exact path. tar --exclude patterns are globs under both GNU
+// tar's fnmatch and bsdtar's libarchive, so an unescaped forbidden-root path
+// containing a metacharacter (e.g. reached via an env-override path
+// containing "[") can silently fail to match itself, defeating the
+// exclusion. Both implementations honor a leading backslash to force a
+// literal match, so escaping here is safe on both.
+func escapeTarExcludeGlob(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch r {
+		case '*', '?', '[', '\\':
+			b.WriteByte('\\')
+		}
+		b.WriteRune(r)
+	}
 	return b.String()
 }
 

--- a/internal/ssh/transfer.go
+++ b/internal/ssh/transfer.go
@@ -28,7 +28,21 @@ func buildTarCommand(
 	files map[parser.AgentType][]string,
 	extraFiles []string,
 ) string {
+	return buildTarCommandWithForbiddenRoots(dirs, files, extraFiles, nil)
+}
+
+// buildTarCommandWithForbiddenRoots creates an SSH archive command while
+// preserving excluded-provider roots as path boundaries. Agent ownership alone
+// is not sufficient: an allowed directory can contain a forbidden provider's
+// store, so every transfer input is screened independently of its owner.
+func buildTarCommandWithForbiddenRoots(
+	dirs map[parser.AgentType][]string,
+	files map[parser.AgentType][]string,
+	extraFiles []string,
+	forbiddenRoots []string,
+) string {
 	hermesStateDBs := hermesSSHStateDBs(dirs, extraFiles)
+	hermesStateDBs = filterForbiddenRoots(hermesStateDBs, forbiddenRoots)
 	hermesSQLite := make(map[string]struct{}, len(hermesStateDBs)*4)
 	for _, stateDB := range hermesStateDBs {
 		for _, suffix := range []string{"", "-wal", "-shm", "-journal"} {
@@ -37,6 +51,9 @@ func buildTarCommand(
 	}
 	paths := make([]string, 0)
 	addPath := func(remotePath string) {
+		if pathWithinForbiddenRoots(forbiddenRoots, remotePath) {
+			return
+		}
 		if _, isHermesSQLite := hermesSQLite[path.Clean(remotePath)]; isHermesSQLite {
 			return
 		}
@@ -45,6 +62,9 @@ func buildTarCommand(
 		}
 	}
 	for agent, agentDirs := range dirs {
+		if parser.RemoteSyncExcludedAgent(agent) {
+			continue
+		}
 		if _, fileScoped := files[agent]; fileScoped {
 			continue
 		}
@@ -52,7 +72,10 @@ func buildTarCommand(
 			addPath(d)
 		}
 	}
-	for _, agentFiles := range files {
+	for agent, agentFiles := range files {
+		if parser.RemoteSyncExcludedAgent(agent) {
+			continue
+		}
 		for _, f := range agentFiles {
 			addPath(f)
 		}
@@ -60,13 +83,48 @@ func buildTarCommand(
 	for _, f := range extraFiles {
 		addPath(f)
 	}
-	if len(hermesStateDBs) > 0 {
-		return buildPythonSnapshotTarCommand(paths, hermesStateDBs)
+	forbiddenArchivePaths := make([]string, 0, len(forbiddenRoots))
+	for _, root := range forbiddenRoots {
+		if archivePath := tarListPath(root); archivePath != "" {
+			forbiddenArchivePaths = append(forbiddenArchivePaths, archivePath)
+		}
 	}
-	return buildPlainTarCommand(paths)
+	if len(hermesStateDBs) > 0 {
+		return buildPythonSnapshotTarCommand(
+			paths, hermesStateDBs, forbiddenArchivePaths,
+		)
+	}
+	return buildPlainTarCommand(paths, forbiddenArchivePaths)
 }
 
-func buildPlainTarCommand(paths []string) string {
+func filterForbiddenRoots(paths, forbiddenRoots []string) []string {
+	filtered := make([]string, 0, len(paths))
+	for _, remotePath := range paths {
+		if !pathWithinForbiddenRoots(forbiddenRoots, remotePath) {
+			filtered = append(filtered, remotePath)
+		}
+	}
+	return filtered
+}
+
+func pathWithinForbiddenRoots(roots []string, remotePath string) bool {
+	remotePath = path.Clean(remotePath)
+	for _, root := range roots {
+		root = path.Clean(root)
+		if remotePath == root {
+			return true
+		}
+		if root == "/" && strings.HasPrefix(remotePath, "/") {
+			return true
+		}
+		if root != "/" && strings.HasPrefix(remotePath, root+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+func buildPlainTarCommand(paths, forbiddenArchivePaths []string) string {
 	var b strings.Builder
 	b.WriteString("set -e\n")
 	b.WriteString("av_emit_tar_path() { [ -e \"/$1\" ] || return 0; printf '%s\\n' \"$1\"; }\n")
@@ -77,7 +135,12 @@ func buildPlainTarCommand(paths []string) string {
 		b.WriteString(shellQuote(archivePath))
 		b.WriteByte('\n')
 	}
-	b.WriteString("} | tar cf - -C / -T -\n")
+	b.WriteString("} | tar cf - -C /")
+	for _, forbiddenPath := range forbiddenArchivePaths {
+		b.WriteString(" --exclude=")
+		b.WriteString(shellQuote(forbiddenPath))
+	}
+	b.WriteString(" -T -\n")
 	return b.String()
 }
 
@@ -110,7 +173,9 @@ func hermesSSHStateDBs(
 	return stateDBs
 }
 
-func buildPythonSnapshotTarCommand(paths, stateDBs []string) string {
+func buildPythonSnapshotTarCommand(
+	paths, stateDBs, forbiddenArchivePaths []string,
+) string {
 	type sqliteArchivePath struct {
 		Source  string `json:"source"`
 		Archive string `json:"archive"`
@@ -127,7 +192,8 @@ func buildPythonSnapshotTarCommand(paths, stateDBs []string) string {
 	}
 	pathsJSON, _ := json.Marshal(paths)
 	databasesJSON, _ := json.Marshal(databases)
-	fallback := buildPlainTarCommand(paths)
+	forbiddenJSON, _ := json.Marshal(forbiddenArchivePaths)
+	fallback := buildPlainTarCommand(paths, forbiddenArchivePaths)
 	var fallbackWarnings strings.Builder
 	for _, database := range databases {
 		fallbackWarnings.WriteString("  printf '%s\\n' ")
@@ -152,6 +218,18 @@ import tempfile
 
 paths = json.loads(%q)
 databases = json.loads(%q)
+forbidden = json.loads(%q)
+
+def is_forbidden(archive_path):
+    for root in forbidden:
+        if archive_path == root or archive_path.startswith(root.rstrip("/") + "/"):
+            return True
+    return False
+
+def archive_filter(tarinfo):
+    if is_forbidden(tarinfo.name):
+        return None
+    return tarinfo
 
 def warn_skipped(source_path, reason):
     print("warning: skipped Hermes state.db snapshot: {}: {}".format(source_path, reason), file=sys.stderr)
@@ -162,7 +240,7 @@ with tarfile.open(fileobj=sys.stdout.buffer, mode="w|") as archive:
         if not os.path.lexists(source_path):
             continue
         try:
-            archive.add(source_path, arcname=archive_path, recursive=True)
+            archive.add(source_path, arcname=archive_path, recursive=True, filter=archive_filter)
         except FileNotFoundError:
             continue
     for item in databases:
@@ -212,7 +290,7 @@ with tarfile.open(fileobj=sys.stdout.buffer, mode="w|") as archive:
 PY
 else
 %s%sfi
-`, string(pathsJSON), string(databasesJSON), fallbackWarnings.String(), fallback)
+`, string(pathsJSON), string(databasesJSON), string(forbiddenJSON), fallbackWarnings.String(), fallback)
 }
 
 func tarListPath(path string) string {
@@ -244,7 +322,22 @@ func downloadAndExtract(
 	files map[parser.AgentType][]string,
 	extraFiles []string,
 ) (string, error) {
-	tarCmd := buildTarCommand(dirs, files, extraFiles)
+	return downloadAndExtractWithForbiddenRoots(
+		ctx, host, user, port, sshOpts, dirs, files, extraFiles, nil,
+	)
+}
+
+func downloadAndExtractWithForbiddenRoots(
+	ctx context.Context,
+	host, user string, port int, sshOpts []string,
+	dirs map[parser.AgentType][]string,
+	files map[parser.AgentType][]string,
+	extraFiles []string,
+	forbiddenRoots []string,
+) (string, error) {
+	tarCmd := buildTarCommandWithForbiddenRoots(
+		dirs, files, extraFiles, forbiddenRoots,
+	)
 	stdout, cleanup, err := runSSHScriptStream(
 		ctx, host, user, port, sshOpts, tarCmd,
 	)

--- a/internal/ssh/transfer_test.go
+++ b/internal/ssh/transfer_test.go
@@ -551,3 +551,60 @@ func TestRemappedDir(t *testing.T) {
 	want := filepath.Join("tmp", "sync-123", "home", "wes", ".claude")
 	assert.Equal(t, want, got)
 }
+
+// TestBuildTarCommandPythonBranchPrunesForbiddenRootNestedInAllowedRoot
+// exercises the Python snapshot archive path (taken whenever a Hermes
+// state.db is present) against a forbidden root nested inside an allowed
+// root: archive_filter must drop the forbidden subtree while the allowed
+// session file and the Hermes snapshot still stream. This pins the
+// member-name/forbidden-root spelling agreement inside the Python script
+// end to end, independent of how tarfile spells arcnames.
+func TestBuildTarCommandPythonBranchPrunesForbiddenRootNestedInAllowedRoot(
+	t *testing.T,
+) {
+	if runtime.GOOS == "windows" {
+		t.Skip("remote snapshot script uses POSIX paths; local Windows paths are not representative")
+	}
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 unavailable; the script would take the plain-tar fallback")
+	}
+	root := t.TempDir()
+	allowed := filepath.Join(root, "sessions")
+	forbidden := filepath.Join(allowed, ".forbidden-provider")
+	keep := filepath.Join(allowed, "session.jsonl")
+	secret := filepath.Join(forbidden, "chat.db")
+	require.NoError(t, os.MkdirAll(forbidden, 0o755))
+	require.NoError(t, os.WriteFile(keep, []byte("session"), 0o644))
+	require.NoError(t, os.WriteFile(secret, []byte("authentication state"), 0o600))
+	stateDB := filepath.Join(root, "hermes", "state.db")
+	require.NoError(t, os.MkdirAll(filepath.Dir(stateDB), 0o755))
+	writer, err := sql.Open("sqlite3", stateDB)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = writer.Close() })
+	_, err = writer.Exec(`CREATE TABLE sessions (id TEXT PRIMARY KEY)`)
+	require.NoError(t, err)
+
+	script := buildTarCommand(
+		map[parser.AgentType][]string{
+			parser.AgentClaude: {allowed},
+			parser.AgentHermes: {stateDB},
+		},
+		nil, nil, []string{forbidden},
+	)
+	require.Contains(t, script, "python3",
+		"a Hermes state.db must route through the Python snapshot branch")
+	cmd := exec.Command("sh")
+	cmd.Stdin = strings.NewReader(script)
+	archive, err := cmd.CombinedOutput()
+	require.NoError(t, err, "archive command output: %s", archive)
+
+	names := tarNames(t, archive)
+	assert.Contains(t, names, archivePathForTest(keep))
+	assert.Contains(t, names, archivePathForTest(stateDB))
+	assert.NotContains(t, names, archivePathForTest(secret),
+		"the Python archive filter must drop forbidden content nested in an allowed root")
+	for _, name := range names {
+		assert.NotContains(t, name, ".forbidden-provider",
+			"no spelling of the forbidden subtree may enter the archive")
+	}
+}

--- a/internal/ssh/transfer_test.go
+++ b/internal/ssh/transfer_test.go
@@ -244,6 +244,55 @@ func TestBuildTarCommandPrunesForbiddenRootNestedInAllowedRoot(t *testing.T) {
 		"SSH transfer inputs must not recurse into a forbidden nested root")
 }
 
+// TestBuildPlainTarCommandEscapesGlobMetacharactersInExcludePattern verifies
+// that a forbidden root containing tar glob metacharacters (here "[" and
+// "]") produces a backslash-escaped --exclude pattern, not a raw glob. tar
+// --exclude patterns are globs under both GNU tar's fnmatch and bsdtar's
+// libarchive, so an unescaped literal path containing "[...]" would be
+// parsed as a character class instead of matching itself.
+func TestBuildPlainTarCommandEscapesGlobMetacharactersInExcludePattern(t *testing.T) {
+	cmd := buildPlainTarCommand(
+		[]string{"./allowed/session.jsonl"},
+		[]string{"./allowed/[forbidden-provider]"},
+	)
+	assert.Contains(t, cmd, `--exclude='./allowed/\[forbidden-provider]'`,
+		"forbidden root glob metacharacters must be backslash-escaped in the tar --exclude pattern")
+}
+
+// TestBuildTarCommandPrunesBracketCharredForbiddenRootNestedInAllowedRoot is
+// the execution-level counterpart of the escaping test above: it proves a
+// real tar invocation still prunes a forbidden root whose name contains
+// glob metacharacters. On the plain-tar path with no Hermes state DBs,
+// --exclude is the only layer that prevents recursion into a forbidden root
+// nested inside an allowed directory.
+func TestBuildTarCommandPrunesBracketCharredForbiddenRootNestedInAllowedRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("remote archive script uses POSIX paths; local Windows paths are not representative")
+	}
+	root := t.TempDir()
+	allowed := filepath.Join(root, "sessions")
+	forbidden := filepath.Join(allowed, "[forbidden-provider]")
+	keep := filepath.Join(allowed, "session.jsonl")
+	secret := filepath.Join(forbidden, "chat.db")
+	require.NoError(t, os.MkdirAll(forbidden, 0o755))
+	require.NoError(t, os.WriteFile(keep, []byte("session"), 0o644))
+	require.NoError(t, os.WriteFile(secret, []byte("authentication state"), 0o600))
+
+	script := buildTarCommand(
+		map[parser.AgentType][]string{parser.AgentClaude: {allowed}},
+		nil, nil, []string{forbidden},
+	)
+	cmd := exec.Command("sh")
+	cmd.Stdin = strings.NewReader(script)
+	archive, err := cmd.CombinedOutput()
+
+	require.NoError(t, err, "archive command output: %s", archive)
+	names := tarNames(t, archive)
+	assert.Contains(t, names, archivePathForTest(keep))
+	assert.NotContains(t, names, archivePathForTest(secret),
+		"a forbidden root containing glob metacharacters must still be pruned by tar --exclude")
+}
+
 func TestBuildTarCommandRejectsSymlinkedHermesSQLitePaths(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("remote snapshot script uses POSIX symlinks and paths")

--- a/internal/ssh/transfer_test.go
+++ b/internal/ssh/transfer_test.go
@@ -24,7 +24,7 @@ func TestBuildTarCommand(t *testing.T) {
 		parser.AgentClaude: {"/home/wes/.claude/projects"},
 		parser.AgentCodex:  {"/home/wes/.codex/sessions"},
 	}
-	cmd := buildTarCommand(dirs, nil, []string{"/home/wes/.codex/session_index.jsonl"})
+	cmd := buildTarCommand(dirs, nil, []string{"/home/wes/.codex/session_index.jsonl"}, nil)
 
 	assert.Contains(t, cmd, "| tar cf - -C / -T -", "bad tar pipe: %s", cmd)
 	assert.NotContains(t, tarCommandLine(t, cmd), "home/wes/.claude/projects",
@@ -50,7 +50,7 @@ func TestBuildTarCommandSkipsFileScopedWindsurfDirs(t *testing.T) {
 		},
 	}
 
-	cmd := buildTarCommand(dirs, files, nil)
+	cmd := buildTarCommand(dirs, files, nil, nil)
 
 	assert.Contains(t, cmd, "'./home/wes/Windsurf/User/workspaceStorage/a/state.vscdb'")
 	assert.Contains(t, cmd, "'./home/wes/Windsurf/User/workspaceStorage/a/workspace.json'")
@@ -94,6 +94,7 @@ func TestBuildTarCommandStreamsPathListToTar(t *testing.T) {
 			parser.AgentWindsurf: {stateDB, workspaceJSON},
 		},
 		nil,
+		nil,
 	)
 	cmd := exec.Command("sh")
 	cmd.Stdin = strings.NewReader(script)
@@ -124,6 +125,7 @@ func TestBuildTarCommandSkipsMissingFileScopedPath(t *testing.T) {
 		map[parser.AgentType][]string{
 			parser.AgentWindsurf: {stateDB, missingWAL},
 		},
+		nil,
 		nil,
 	)
 	cmd := exec.Command("sh")
@@ -166,6 +168,7 @@ func TestBuildTarCommandSnapshotsHermesStateDBWithoutSidecars(t *testing.T) {
 		map[parser.AgentType][]string{parser.AgentHermes: {stateDB}},
 		nil,
 		[]string{wal, shm, stateDB + "-journal"},
+		nil,
 	)
 	cmd := exec.Command("sh")
 	cmd.Stdin = strings.NewReader(script)
@@ -203,6 +206,7 @@ func TestBuildTarCommandExcludesRemoteSyncExcludedAgentState(t *testing.T) {
 			parser.AgentTrae: {chatDB},
 		},
 		nil,
+		nil,
 	)
 	cmd := exec.Command("sh")
 	cmd.Stdin = strings.NewReader(script)
@@ -225,7 +229,7 @@ func TestBuildTarCommandPrunesForbiddenRootNestedInAllowedRoot(t *testing.T) {
 	require.NoError(t, os.WriteFile(keep, []byte("session"), 0o644))
 	require.NoError(t, os.WriteFile(secret, []byte("authentication state"), 0o600))
 
-	script := buildTarCommandWithForbiddenRoots(
+	script := buildTarCommand(
 		map[parser.AgentType][]string{parser.AgentClaude: {allowed}},
 		nil, nil, []string{forbidden},
 	)
@@ -254,7 +258,7 @@ func TestBuildTarCommandRejectsSymlinkedHermesSQLitePaths(t *testing.T) {
 
 		script := buildTarCommand(
 			map[parser.AgentType][]string{parser.AgentHermes: {stateDB}},
-			nil, nil,
+			nil, nil, nil,
 		)
 		cmd := exec.Command("sh")
 		cmd.Stdin = strings.NewReader(script)
@@ -278,7 +282,7 @@ func TestBuildTarCommandRejectsSymlinkedHermesSQLitePaths(t *testing.T) {
 
 		script := buildTarCommand(
 			map[parser.AgentType][]string{parser.AgentHermes: {stateDB}},
-			nil, []string{wal},
+			nil, []string{wal}, nil,
 		)
 		cmd := exec.Command("sh")
 		cmd.Stdin = strings.NewReader(script)
@@ -316,7 +320,7 @@ func TestBuildTarCommandSkipsFailedHermesSnapshotAndKeepsOtherData(t *testing.T)
 		map[parser.AgentType][]string{
 			parser.AgentHermes: {badSessions, goodSessions},
 		},
-		nil, []string{badStateDB, goodStateDB},
+		nil, []string{badStateDB, goodStateDB}, nil,
 	)
 	cmd := exec.Command("sh")
 	cmd.Stdin = strings.NewReader(script)
@@ -354,7 +358,7 @@ func TestBuildTarCommandWithoutPythonKeepsTranscriptsAndOtherAgents(t *testing.T
 			parser.AgentHermes: {hermesSessions},
 			parser.AgentClaude: {claudeDir},
 		},
-		nil, []string{hermesStateDB},
+		nil, []string{hermesStateDB}, nil,
 	)
 	tarPath, err := exec.LookPath("tar")
 	require.NoError(t, err)
@@ -402,7 +406,7 @@ func TestDownloadAndExtractReportsSuccessfulSSHStderr(t *testing.T) {
 	require.NoError(t, err)
 	os.Stderr = stderrWriter
 	extracted, syncErr := downloadAndExtract(
-		context.Background(), "remote", "", 0, nil, nil, nil, nil,
+		context.Background(), "remote", "", 0, nil, nil, nil, nil, nil,
 	)
 	closeErr := stderrWriter.Close()
 	os.Stderr = originalStderr
@@ -440,7 +444,7 @@ func TestBuildTarCommandSkipsLineDelimitedUnsafePath(t *testing.T) {
 	require.NoError(t, os.WriteFile(safeFile, []byte("{}\n"), 0o644))
 	require.NoError(t, os.WriteFile(unsafeFile, []byte("{}\n"), 0o644))
 
-	script := buildTarCommand(nil, nil, []string{safeFile, unsafeFile})
+	script := buildTarCommand(nil, nil, []string{safeFile, unsafeFile}, nil)
 	cmd := exec.Command("sh")
 	cmd.Stdin = strings.NewReader(script)
 	archive, err := cmd.Output()

--- a/internal/ssh/transfer_test.go
+++ b/internal/ssh/transfer_test.go
@@ -189,6 +189,57 @@ func TestBuildTarCommandSnapshotsHermesStateDBWithoutSidecars(t *testing.T) {
 	assert.Equal(t, "Committed in WAL", title)
 }
 
+func TestBuildTarCommandExcludesRemoteSyncExcludedAgentState(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("remote archive script uses POSIX paths; local Windows paths are not representative")
+	}
+	root := t.TempDir()
+	chatDB := filepath.Join(root, "chat.db")
+	require.NoError(t, os.WriteFile(chatDB, []byte("authentication state"), 0o600))
+
+	script := buildTarCommand(
+		map[parser.AgentType][]string{parser.AgentTrae: {root}},
+		map[parser.AgentType][]string{
+			parser.AgentTrae: {chatDB},
+		},
+		nil,
+	)
+	cmd := exec.Command("sh")
+	cmd.Stdin = strings.NewReader(script)
+	archive, err := cmd.CombinedOutput()
+	require.NoError(t, err, "archive command output: %s", archive)
+	assert.Empty(t, tarNames(t, archive),
+		"a remote-sync-excluded agent's state must never enter an SSH archive")
+}
+
+func TestBuildTarCommandPrunesForbiddenRootNestedInAllowedRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("remote archive script uses POSIX paths; local Windows paths are not representative")
+	}
+	root := t.TempDir()
+	allowed := filepath.Join(root, "sessions")
+	forbidden := filepath.Join(allowed, ".forbidden-provider")
+	keep := filepath.Join(allowed, "session.jsonl")
+	secret := filepath.Join(forbidden, "chat.db")
+	require.NoError(t, os.MkdirAll(forbidden, 0o755))
+	require.NoError(t, os.WriteFile(keep, []byte("session"), 0o644))
+	require.NoError(t, os.WriteFile(secret, []byte("authentication state"), 0o600))
+
+	script := buildTarCommandWithForbiddenRoots(
+		map[parser.AgentType][]string{parser.AgentClaude: {allowed}},
+		nil, nil, []string{forbidden},
+	)
+	cmd := exec.Command("sh")
+	cmd.Stdin = strings.NewReader(script)
+	archive, err := cmd.CombinedOutput()
+
+	require.NoError(t, err, "archive command output: %s", archive)
+	names := tarNames(t, archive)
+	assert.Contains(t, names, archivePathForTest(keep))
+	assert.NotContains(t, names, archivePathForTest(secret),
+		"SSH transfer inputs must not recurse into a forbidden nested root")
+}
+
 func TestBuildTarCommandRejectsSymlinkedHermesSQLitePaths(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("remote snapshot script uses POSIX symlinks and paths")


### PR DESCRIPTION
Builds on #1282, which added the `RemoteSyncExcluded` capability.

Remote sync already skips excluded agents (currently Trae), but an
excluded root nested inside another agent's allowed root — possible with
overlapping directory overrides — would still end up in archives and
tarballs.

Fix: `TargetSet` carries `ForbiddenRoots`, always re-derived server-side,
and every layer enforces them — target resolution omits nested targets,
request validation rejects them, the archive/manifest walkers prune them,
and the SSH path excludes them from the generated tar command.

All checks go through one predicate, `remotesync.PathWithinForbiddenRoots`.
Paths are canonicalized before comparison (absolute, symlinks resolved,
case-folded on Windows/macOS; the SSH script emits physical paths), so an
alias spelling of a forbidden root cannot slip past. Resolver output
parsing fails the sync rather than ever dropping an exclusion boundary.

Notes:

- With an env override (e.g. `TRAE_DIR`), the override is the protected
  root; default locations are not additionally protected — same as
  allowed-agent resolution.
- Tar exclude patterns are glob-escaped and covered by a test against
  real tar.

Where to look: `internal/remotesync/paths.go` (predicate +
canonicalization), `resolve.go` (advertised-set filtering),
`internal/ssh/resolve.go` (script + parsing), `internal/ssh/transfer.go`
(tar exclusion).
