### PR TITLE
fix(copilot): use exact tool execution timestamps

### DIFF
--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -162,8 +162,12 @@ Grok section and remove the explicit registry exception in the coverage test.
   including reindex behavior, but not the event or database schema. The
   [configuration-directory reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-config-dir-reference)
   further identifies `events.jsonl` and workspace artifacts. No
-  producer-side serializer is public. For independent legacy CLI and sibling
-  Copilot-store observations, clone
+  producer-side serializer is public. Reverified 2026-07-28 against the
+  sanitized session shape reported in
+  [#1288](https://github.com/kenn-io/agentsview/issues/1288): `events.jsonl`
+  emits matching `tool.execution_start` and `tool.execution_complete` records
+  keyed by `toolCallId`, whose timestamps provide the exact execution interval.
+  For independent legacy CLI and sibling Copilot-store observations, clone
   `https://github.com/getagentseal/codeburn.git` at
   `3472885629c41725b40c19c0780ecce148b067bf` and inspect its
   [Copilot format notes](https://github.com/getagentseal/codeburn/blob/3472885629c41725b40c19c0780ecce148b067bf/docs/providers/copilot.md)

--- a/docs/internal/session-format-sources.md
+++ b/docs/internal/session-format-sources.md
@@ -167,6 +167,9 @@ Grok section and remove the explicit registry exception in the coverage test.
   [#1288](https://github.com/kenn-io/agentsview/issues/1288): `events.jsonl`
   emits matching `tool.execution_start` and `tool.execution_complete` records
   keyed by `toolCallId`, whose timestamps provide the exact execution interval.
+  Reverified 2026-07-28 against current local session artifacts that completion
+  records can include a boolean `success`; explicit `false` marks a failed
+  terminal execution, while older records may omit the field.
   For independent legacy CLI and sibling Copilot-store observations, clone
   `https://github.com/getagentseal/codeburn.git` at
   `3472885629c41725b40c19c0780ecce148b067bf` and inspect its

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -333,7 +333,10 @@ const projectIdentityRemoteScrubCompletedKey = "project_identity_remote_scrub_v1
 // (74: Claude Code IDE context reparse. Standalone ide_opened_file and
 // ide_selection wrappers are promoted to system metadata so existing
 // VS Code sessions no longer use them as titles or user turns.)
-const dataVersion = 74
+// (75: GitHub Copilot CLI tool execution events now provide exact tool
+// durations. Existing Copilot sessions need re-parsing to populate those
+// events and replace idle-gap timing with execution intervals.)
+const dataVersion = 75
 
 const tokenCoverageRepairStatsKey = "token_coverage_repair_v1"
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -1008,9 +1008,9 @@ func TestMigration_ToolResultEventsTable(t *testing.T) {
 		"expected tool_result_events table after reopen")
 }
 
-func TestCurrentDataVersionClaudeIDEContext(t *testing.T) {
-	assert.Equal(t, 74, CurrentDataVersion(),
-		"Claude IDE context parsing requires a data version bump")
+func TestCurrentDataVersionCopilotExactToolTiming(t *testing.T) {
+	assert.Equal(t, 75, CurrentDataVersion(),
+		"Copilot exact tool timing requires a data version bump")
 }
 
 func TestInsertMessages_PreservesToolResultEvents(t *testing.T) {

--- a/internal/db/timing.go
+++ b/internal/db/timing.go
@@ -174,12 +174,12 @@ func (db *DB) queryCallRows(
 		    call_index,
 		    MIN(CASE WHEN status = 'started' THEN timestamp END)
 		      AS started_at,
-		    MAX(CASE WHEN status = 'completed' THEN timestamp END)
-		      AS completed_at
+		    MAX(CASE WHEN status IN ('completed', 'errored')
+		      THEN timestamp END) AS terminal_at
 		  FROM tool_result_events
 		  WHERE session_id = ?
 		    AND source = 'copilot-cli'
-		    AND status IN ('started', 'completed')
+		    AND status IN ('started', 'completed', 'errored')
 		  GROUP BY session_id, tool_call_message_ordinal, call_index
 		)
 		SELECT
@@ -191,14 +191,14 @@ func (db *DB) queryCallRows(
 		  tc.subagent_session_id,
 		  tc.input_json,
 		  ce.started_at,
-		  ce.completed_at,
+		  ce.terminal_at,
 		  CASE
 		    WHEN ce.started_at IS NOT NULL
-		         AND ce.completed_at IS NOT NULL
-		         AND julianday(ce.completed_at) >= julianday(ce.started_at) THEN
+		         AND ce.terminal_at IS NOT NULL
+		         AND julianday(ce.terminal_at) >= julianday(ce.started_at) THEN
 		      CAST(
 		        ROUND(
-		          (julianday(ce.completed_at) - julianday(ce.started_at))
+		          (julianday(ce.terminal_at) - julianday(ce.started_at))
 		          * 86400000
 		        ) AS INTEGER
 		      )

--- a/internal/db/timing.go
+++ b/internal/db/timing.go
@@ -74,6 +74,8 @@ type CallRow struct {
 	SubagentSessionID *string
 	InputJSON         string
 	DurationMs        *int64
+	ExactStartedAt    *string
+	ExactEndedAt      *string
 }
 
 // GetSessionTiming computes the per-session timing summary. Returns
@@ -165,6 +167,23 @@ func (db *DB) queryCallRows(
 ) ([]CallRow, error) {
 	now := time.Now().UTC().Format(time.RFC3339)
 	rows, err := db.getReader().QueryContext(ctx, `
+		WITH copilot_events AS (
+		  SELECT
+		    session_id,
+		    tool_call_message_ordinal,
+		    call_index,
+		    MIN(CASE
+		      WHEN source = 'copilot-cli' AND status = 'started'
+		      THEN timestamp
+		    END) AS started_at,
+		    MAX(CASE
+		      WHEN source = 'copilot-cli' AND status = 'completed'
+		      THEN timestamp
+		    END) AS completed_at
+		  FROM tool_result_events
+		  WHERE session_id = ?
+		  GROUP BY session_id, tool_call_message_ordinal, call_index
+		)
 		SELECT
 		  tc.message_id,
 		  tc.tool_use_id,
@@ -173,7 +192,18 @@ func (db *DB) queryCallRows(
 		  tc.skill_name,
 		  tc.subagent_session_id,
 		  tc.input_json,
+		  ce.started_at,
+		  ce.completed_at,
 		  CASE
+		    WHEN ce.started_at IS NOT NULL
+		         AND ce.completed_at IS NOT NULL
+		         AND julianday(ce.completed_at) >= julianday(ce.started_at) THEN
+		      CAST(
+		        ROUND(
+		          (julianday(ce.completed_at) - julianday(ce.started_at))
+		          * 86400000
+		        ) AS INTEGER
+		      )
 		    WHEN tc.subagent_session_id IS NOT NULL
 		         AND s_sub.started_at IS NOT NULL THEN
 		      CAST(
@@ -185,11 +215,16 @@ func (db *DB) queryCallRows(
 		    ELSE NULL
 		  END AS subagent_duration_ms
 		FROM tool_calls tc
+		LEFT JOIN messages m ON m.id = tc.message_id
+		LEFT JOIN copilot_events ce
+		  ON ce.session_id = tc.session_id
+		  AND ce.tool_call_message_ordinal = m.ordinal
+		  AND ce.call_index = tc.call_index
 		LEFT JOIN sessions s_sub
 		  ON s_sub.id = tc.subagent_session_id
 		WHERE tc.session_id = ?
 		ORDER BY tc.message_id, tc.id
-	`, now, sessionID)
+	`, sessionID, now, sessionID)
 	if err != nil {
 		return nil, err
 	}
@@ -200,10 +235,11 @@ func (db *DB) queryCallRows(
 		var r CallRow
 		var toolUseID, inputJSON sql.NullString
 		var skill, sub sql.NullString
+		var exactStart, exactEnd sql.NullString
 		var subDur sql.NullInt64
 		if err := rows.Scan(
 			&r.MessageID, &toolUseID, &r.ToolName, &r.Category,
-			&skill, &sub, &inputJSON, &subDur,
+			&skill, &sub, &inputJSON, &exactStart, &exactEnd, &subDur,
 		); err != nil {
 			return nil, err
 		}
@@ -224,6 +260,14 @@ func (db *DB) queryCallRows(
 		if subDur.Valid {
 			v := subDur.Int64
 			r.DurationMs = &v
+		}
+		if exactStart.Valid {
+			v := exactStart.String
+			r.ExactStartedAt = &v
+		}
+		if exactEnd.Valid {
+			v := exactEnd.String
+			r.ExactEndedAt = &v
 		}
 		out = append(out, r)
 	}
@@ -261,6 +305,7 @@ func AssembleTiming(
 
 	// Group calls by message id.
 	callsByMsg := map[int64][]CallTiming{}
+	callRowsByMsg := map[int64][]CallRow{}
 	for _, r := range calls {
 		c := CallTiming{
 			ToolUseID:         r.ToolUseID,
@@ -272,6 +317,7 @@ func AssembleTiming(
 			InputPreview:      makeInputPreview(r.Category, r.ToolName, r.InputJSON),
 		}
 		callsByMsg[r.MessageID] = append(callsByMsg[r.MessageID], c)
+		callRowsByMsg[r.MessageID] = append(callRowsByMsg[r.MessageID], r)
 	}
 
 	categoryTotals := map[string]*CategoryTotal{}
@@ -285,6 +331,9 @@ func AssembleTiming(
 		turnCalls := callsByMsg[t.MessageID]
 		if turnCalls == nil {
 			turnCalls = []CallTiming{}
+		}
+		if exact := exactTurnDuration(callRowsByMsg[t.MessageID]); exact != nil {
+			t.DurationMs = exact
 		}
 
 		for i := range turnCalls {
@@ -345,6 +394,34 @@ func AssembleTiming(
 	})
 
 	return out
+}
+
+func exactTurnDuration(calls []CallRow) *int64 {
+	if len(calls) == 0 {
+		return nil
+	}
+	var earliest, latest time.Time
+	for _, call := range calls {
+		if call.ExactStartedAt == nil || call.ExactEndedAt == nil {
+			return nil
+		}
+		started, err := time.Parse(time.RFC3339, *call.ExactStartedAt)
+		if err != nil {
+			return nil
+		}
+		ended, err := time.Parse(time.RFC3339, *call.ExactEndedAt)
+		if err != nil || ended.Before(started) {
+			return nil
+		}
+		if earliest.IsZero() || started.Before(earliest) {
+			earliest = started
+		}
+		if latest.IsZero() || ended.After(latest) {
+			latest = ended
+		}
+	}
+	duration := latest.Sub(earliest).Milliseconds()
+	return &duration
 }
 
 // turnAttribution is the result of attributeTurnGo. RemainderMs is the

--- a/internal/db/timing.go
+++ b/internal/db/timing.go
@@ -172,16 +172,14 @@ func (db *DB) queryCallRows(
 		    session_id,
 		    tool_call_message_ordinal,
 		    call_index,
-		    MIN(CASE
-		      WHEN source = 'copilot-cli' AND status = 'started'
-		      THEN timestamp
-		    END) AS started_at,
-		    MAX(CASE
-		      WHEN source = 'copilot-cli' AND status = 'completed'
-		      THEN timestamp
-		    END) AS completed_at
+		    MIN(CASE WHEN status = 'started' THEN timestamp END)
+		      AS started_at,
+		    MAX(CASE WHEN status = 'completed' THEN timestamp END)
+		      AS completed_at
 		  FROM tool_result_events
 		  WHERE session_id = ?
+		    AND source = 'copilot-cli'
+		    AND status IN ('started', 'completed')
 		  GROUP BY session_id, tool_call_message_ordinal, call_index
 		)
 		SELECT

--- a/internal/db/timing_test.go
+++ b/internal/db/timing_test.go
@@ -323,7 +323,7 @@ func TestGetSessionTiming_CopilotParallelExactEvents(t *testing.T) {
 	timingInsertToolResultEvent(t, d, sessionID, 1, 1,
 		"call-b", "started", "2026-07-28T10:00:02Z")
 	timingInsertToolResultEvent(t, d, sessionID, 1, 1,
-		"call-b", "completed", "2026-07-28T10:00:06Z")
+		"call-b", "errored", "2026-07-28T10:00:06Z")
 	timingInsertMessage(t, d, sessionID, 2, "user",
 		"next", "2026-07-28T10:01:00Z", false)
 

--- a/internal/db/timing_test.go
+++ b/internal/db/timing_test.go
@@ -596,7 +596,7 @@ func timingInsertToolCallAtIndex(
 }
 
 func timingInt64Ptr(v int64) *int64 {
-	return &v
+	return new(v)
 }
 
 func timingInsertToolResultEvent(

--- a/internal/db/timing_test.go
+++ b/internal/db/timing_test.go
@@ -220,6 +220,213 @@ func TestActiveGapCapConstantsAgree(t *testing.T) {
 	)
 }
 
+func TestExactTurnDuration(t *testing.T) {
+	exact := func(started, ended string) CallRow {
+		return CallRow{
+			ExactStartedAt: &started,
+			ExactEndedAt:   &ended,
+		}
+	}
+	startOnly := func(started string) CallRow {
+		return CallRow{ExactStartedAt: &started}
+	}
+	endOnly := func(ended string) CallRow {
+		return CallRow{ExactEndedAt: &ended}
+	}
+
+	tests := []struct {
+		name  string
+		calls []CallRow
+		want  *int64
+	}{
+		{
+			name: "single exact interval",
+			calls: []CallRow{exact(
+				"2026-07-28T10:00:00.125Z",
+				"2026-07-28T10:00:03.850Z",
+			)},
+			want: timingInt64Ptr(3_725),
+		},
+		{
+			name:  "completion without start",
+			calls: []CallRow{endOnly("2026-07-28T10:00:03Z")},
+		},
+		{
+			name:  "start without completion",
+			calls: []CallRow{startOnly("2026-07-28T10:00:00Z")},
+		},
+		{
+			name: "completion before start",
+			calls: []CallRow{exact(
+				"2026-07-28T10:00:03Z",
+				"2026-07-28T10:00:02Z",
+			)},
+		},
+		{
+			name: "invalid timestamp",
+			calls: []CallRow{exact(
+				"not-a-timestamp",
+				"2026-07-28T10:00:02Z",
+			)},
+		},
+		{
+			name: "parallel interval spans earliest start to latest completion",
+			calls: []CallRow{
+				exact(
+					"2026-07-28T10:00:01Z",
+					"2026-07-28T10:00:04Z",
+				),
+				exact(
+					"2026-07-28T10:00:02Z",
+					"2026-07-28T10:00:06Z",
+				),
+			},
+			want: timingInt64Ptr(5_000),
+		},
+		{
+			name: "one incomplete parallel call keeps fallback",
+			calls: []CallRow{
+				exact(
+					"2026-07-28T10:00:01Z",
+					"2026-07-28T10:00:04Z",
+				),
+				startOnly("2026-07-28T10:00:02Z"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, exactTurnDuration(tt.calls))
+		})
+	}
+}
+
+func TestGetSessionTiming_CopilotParallelExactEvents(t *testing.T) {
+	d := testDB(t)
+	const sessionID = "copilot-parallel-exact"
+	timingInsertSession(t, d, sessionID,
+		"2026-07-28T10:00:00Z", "2026-07-28T10:01:00Z")
+	timingInsertMessage(t, d, sessionID, 0, "user",
+		"run checks", "2026-07-28T10:00:00Z", false)
+	timingInsertMessage(t, d, sessionID, 1, "assistant",
+		"running checks", "2026-07-28T10:00:00Z", true)
+	messageID := timingMsgID(t, d, sessionID, 1)
+	timingInsertToolCallAtIndex(t, d, sessionID, messageID, 0,
+		"call-a", "first", "Other", "")
+	timingInsertToolCallAtIndex(t, d, sessionID, messageID, 1,
+		"call-b", "second", "Other", "")
+	timingInsertToolResultEvent(t, d, sessionID, 1, 0,
+		"call-a", "started", "2026-07-28T10:00:01Z")
+	timingInsertToolResultEvent(t, d, sessionID, 1, 0,
+		"call-a", "completed", "2026-07-28T10:00:04Z")
+	timingInsertToolResultEvent(t, d, sessionID, 1, 1,
+		"call-b", "started", "2026-07-28T10:00:02Z")
+	timingInsertToolResultEvent(t, d, sessionID, 1, 1,
+		"call-b", "completed", "2026-07-28T10:00:06Z")
+	timingInsertMessage(t, d, sessionID, 2, "user",
+		"next", "2026-07-28T10:01:00Z", false)
+
+	got, err := d.GetSessionTiming(context.Background(), sessionID)
+	require.NoError(t, err)
+	require.Len(t, got.Turns, 1)
+	assert.Equal(t, timingInt64Ptr(5_000), got.Turns[0].DurationMs)
+	require.Len(t, got.Turns[0].Calls, 2)
+	assert.Equal(t, timingInt64Ptr(3_000), got.Turns[0].Calls[0].DurationMs)
+	assert.Equal(t, timingInt64Ptr(4_000), got.Turns[0].Calls[1].DurationMs)
+	assert.True(t, got.Turns[0].Calls[0].IsParallel)
+	assert.True(t, got.Turns[0].Calls[1].IsParallel)
+	assert.Equal(t, int64(5_000), got.ToolDurationMs)
+	require.NotNil(t, got.SlowestCall)
+	assert.Equal(t, "call-b", got.SlowestCall.ToolUseID)
+}
+
+func TestGetSessionTiming_CopilotInvalidExactEventsFallBack(t *testing.T) {
+	type timingEvent struct {
+		source    string
+		status    string
+		timestamp string
+	}
+	tests := []struct {
+		name   string
+		id     string
+		events []timingEvent
+	}{
+		{
+			name: "completion without start",
+			id:   "completion-only",
+			events: []timingEvent{
+				{"copilot-cli", "completed", "2026-07-28T10:00:04Z"},
+			},
+		},
+		{
+			name: "start without completion",
+			id:   "start-only",
+			events: []timingEvent{
+				{"copilot-cli", "started", "2026-07-28T10:00:01Z"},
+			},
+		},
+		{
+			name: "completion before start",
+			id:   "reversed",
+			events: []timingEvent{
+				{"copilot-cli", "started", "2026-07-28T10:00:04Z"},
+				{"copilot-cli", "completed", "2026-07-28T10:00:03Z"},
+			},
+		},
+		{
+			name: "other source",
+			id:   "other-source",
+			events: []timingEvent{
+				{"other", "started", "2026-07-28T10:00:01Z"},
+				{"other", "completed", "2026-07-28T10:00:04Z"},
+			},
+		},
+		{
+			name: "other statuses",
+			id:   "other-status",
+			events: []timingEvent{
+				{"copilot-cli", "queued", "2026-07-28T10:00:01Z"},
+				{"copilot-cli", "finished", "2026-07-28T10:00:04Z"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := testDB(t)
+			sessionID := "copilot-fallback-" + tt.id
+			timingInsertSession(t, d, sessionID,
+				"2026-07-28T10:00:00Z", "2026-07-28T10:00:12Z")
+			timingInsertMessage(t, d, sessionID, 0, "user",
+				"run", "2026-07-28T10:00:00Z", false)
+			timingInsertMessage(t, d, sessionID, 1, "assistant",
+				"running", "2026-07-28T10:00:02Z", true)
+			messageID := timingMsgID(t, d, sessionID, 1)
+			timingInsertToolCall(t, d, sessionID, messageID,
+				"call", "check", "Other", "")
+			for _, event := range tt.events {
+				timingInsertToolResultEventWithSource(
+					t, d, sessionID, 1, 0, "call",
+					event.source, event.status, event.timestamp,
+				)
+			}
+			timingInsertMessage(t, d, sessionID, 2, "user",
+				"next", "2026-07-28T10:00:12Z", false)
+
+			got, err := d.GetSessionTiming(context.Background(), sessionID)
+			require.NoError(t, err)
+			require.Len(t, got.Turns, 1)
+			assert.Equal(t, timingInt64Ptr(10_000), got.Turns[0].DurationMs)
+			require.Len(t, got.Turns[0].Calls, 1)
+			assert.Equal(t,
+				timingInt64Ptr(10_000),
+				got.Turns[0].Calls[0].DurationMs,
+			)
+		})
+	}
+}
+
 func TestMakeInputPreview(t *testing.T) {
 	cases := []struct {
 		name      string
@@ -363,6 +570,18 @@ func timingInsertToolCall(
 	toolUseID, toolName, category, subagentSessionID string,
 ) {
 	t.Helper()
+	timingInsertToolCallAtIndex(
+		t, d, sessionID, messageID, 0,
+		toolUseID, toolName, category, subagentSessionID,
+	)
+}
+
+func timingInsertToolCallAtIndex(
+	t *testing.T, d *DB,
+	sessionID string, messageID int64, callIndex int,
+	toolUseID, toolName, category, subagentSessionID string,
+) {
+	t.Helper()
 	var sub any = nil
 	if subagentSessionID != "" {
 		sub = subagentSessionID
@@ -371,9 +590,13 @@ func timingInsertToolCall(
 		INSERT INTO tool_calls
 			(session_id, message_id, tool_use_id, tool_name,
 			 category, input_json, subagent_session_id, call_index)
-		VALUES (?, ?, ?, ?, ?, '{}', ?, 0)
-	`, sessionID, messageID, toolUseID, toolName, category, sub)
+		VALUES (?, ?, ?, ?, ?, '{}', ?, ?)
+	`, sessionID, messageID, toolUseID, toolName, category, sub, callIndex)
 	require.NoError(t, err, "timingInsertToolCall %s/%d", sessionID, messageID)
+}
+
+func timingInt64Ptr(v int64) *int64 {
+	return &v
 }
 
 func timingInsertToolResultEvent(
@@ -382,15 +605,27 @@ func timingInsertToolResultEvent(
 	toolUseID, status, timestamp string,
 ) {
 	t.Helper()
+	timingInsertToolResultEventWithSource(
+		t, d, sessionID, messageOrdinal, callIndex,
+		toolUseID, "copilot-cli", status, timestamp,
+	)
+}
+
+func timingInsertToolResultEventWithSource(
+	t *testing.T, d *DB,
+	sessionID string, messageOrdinal, callIndex int,
+	toolUseID, source, status, timestamp string,
+) {
+	t.Helper()
 	_, err := d.getWriter().ExecContext(context.Background(), `
 		INSERT INTO tool_result_events
 			(session_id, tool_call_message_ordinal, call_index,
 			 tool_use_id, source, status, content, content_length,
 			 timestamp, event_index)
-		VALUES (?, ?, ?, ?, 'copilot-cli', ?, '', 0, ?,
+		VALUES (?, ?, ?, ?, ?, ?, '', 0, ?,
 		        CASE WHEN ? = 'started' THEN 0 ELSE 1 END)
-	`, sessionID, messageOrdinal, callIndex, toolUseID, status,
-		timestamp, status)
+	`, sessionID, messageOrdinal, callIndex, toolUseID, source,
+		status, timestamp, status)
 	require.NoError(t, err,
 		"timingInsertToolResultEvent %s/%d", sessionID, messageOrdinal)
 }

--- a/internal/db/timing_test.go
+++ b/internal/db/timing_test.go
@@ -25,6 +25,22 @@ func TestGetSessionTiming_ReadOnlyFixture(t *testing.T) {
 	timingInsertMessage(t, d, "solo", 2, "user",
 		"ok", "2026-04-26T10:00:30Z", false)
 
+	timingInsertSession(t, d, "copilot-exact",
+		"2026-07-24T11:56:20Z", "2026-07-25T00:34:49.483Z")
+	timingInsertMessage(t, d, "copilot-exact", 0, "user",
+		"finish", "2026-07-24T11:56:20Z", false)
+	timingInsertMessage(t, d, "copilot-exact", 1, "assistant",
+		"task_complete", "2026-07-24T11:56:24.189Z", true)
+	copilotMessageID := timingMsgID(t, d, "copilot-exact", 1)
+	timingInsertToolCall(t, d, "copilot-exact", copilotMessageID,
+		"call_example", "task_complete", "Other", "")
+	timingInsertToolResultEvent(t, d, "copilot-exact", 1, 0,
+		"call_example", "started", "2026-07-24T11:56:24.198Z")
+	timingInsertToolResultEvent(t, d, "copilot-exact", 1, 0,
+		"call_example", "completed", "2026-07-24T11:56:27.923Z")
+	timingInsertMessage(t, d, "copilot-exact", 2, "user",
+		"next request", "2026-07-25T00:34:49.483Z", false)
+
 	timingInsertSession(t, d, "fallback",
 		"2026-04-26T10:00:00Z", "2026-04-26T10:00:30Z")
 	timingInsertMessage(t, d, "fallback", 0, "user",
@@ -110,6 +126,17 @@ func TestGetSessionTiming_ReadOnlyFixture(t *testing.T) {
 		assert.Equal(t, int64(29_000), *got.Turns[0].DurationMs, "turn duration")
 		require.NotNil(t, got.Turns[0].Calls[0].DurationMs, "call duration")
 		assert.Equal(t, int64(29_000), *got.Turns[0].Calls[0].DurationMs, "call duration")
+	})
+
+	t.Run("copilot exact tool events exclude idle gap", func(t *testing.T) {
+		got, err := d.GetSessionTiming(ctx, "copilot-exact")
+		require.NoError(t, err, "GetSessionTiming")
+		require.Len(t, got.Turns, 1)
+		require.Len(t, got.Turns[0].Calls, 1)
+		require.NotNil(t, got.Turns[0].DurationMs, "turn duration")
+		assert.Equal(t, int64(3_725), *got.Turns[0].DurationMs)
+		require.NotNil(t, got.Turns[0].Calls[0].DurationMs, "call duration")
+		assert.Equal(t, int64(3_725), *got.Turns[0].Calls[0].DurationMs)
 	})
 
 	t.Run("last message falls back to session end", func(t *testing.T) {
@@ -343,8 +370,27 @@ func timingInsertToolCall(
 	_, err := d.getWriter().ExecContext(context.Background(), `
 		INSERT INTO tool_calls
 			(session_id, message_id, tool_use_id, tool_name,
-			 category, input_json, subagent_session_id)
-		VALUES (?, ?, ?, ?, ?, '{}', ?)
+			 category, input_json, subagent_session_id, call_index)
+		VALUES (?, ?, ?, ?, ?, '{}', ?, 0)
 	`, sessionID, messageID, toolUseID, toolName, category, sub)
 	require.NoError(t, err, "timingInsertToolCall %s/%d", sessionID, messageID)
+}
+
+func timingInsertToolResultEvent(
+	t *testing.T, d *DB,
+	sessionID string, messageOrdinal, callIndex int,
+	toolUseID, status, timestamp string,
+) {
+	t.Helper()
+	_, err := d.getWriter().ExecContext(context.Background(), `
+		INSERT INTO tool_result_events
+			(session_id, tool_call_message_ordinal, call_index,
+			 tool_use_id, source, status, content, content_length,
+			 timestamp, event_index)
+		VALUES (?, ?, ?, ?, 'copilot-cli', ?, '', 0, ?,
+		        CASE WHEN ? = 'started' THEN 0 ELSE 1 END)
+	`, sessionID, messageOrdinal, callIndex, toolUseID, status,
+		timestamp, status)
+	require.NoError(t, err,
+		"timingInsertToolResultEvent %s/%d", sessionID, messageOrdinal)
 }

--- a/internal/duckdb/messages.go
+++ b/internal/duckdb/messages.go
@@ -528,18 +528,18 @@ func (s *Store) queryCallRows(
 		    call_index,
 		    MIN(CASE WHEN status = 'started' THEN timestamp END)
 		      AS started_at,
-		    MAX(CASE WHEN status = 'completed' THEN timestamp END)
-		      AS completed_at
+		    MAX(CASE WHEN status IN ('completed', 'errored')
+		      THEN timestamp END) AS terminal_at
 		  FROM tool_result_events
 		  WHERE session_id = ?
 		    AND source = 'copilot-cli'
-		    AND status IN ('started', 'completed')
+		    AND status IN ('started', 'completed', 'errored')
 		  GROUP BY tool_call_message_ordinal, call_index
 		)
 		SELECT tc.message_id, COALESCE(tc.tool_use_id, ''),
 			tc.tool_name, tc.category, tc.skill_name,
 			tc.subagent_session_id, COALESCE(tc.input_json, ''),
-			ce.started_at, ce.completed_at,
+			ce.started_at, ce.terminal_at,
 			s_sub.started_at, s_sub.ended_at
 		FROM tool_calls tc
 		LEFT JOIN messages m ON m.id = tc.message_id

--- a/internal/duckdb/messages.go
+++ b/internal/duckdb/messages.go
@@ -522,15 +522,34 @@ func (s *Store) queryCallRows(
 	ctx context.Context, sessionID string,
 ) ([]db.CallRow, error) {
 	rows, err := s.queryContext(ctx, `
+		WITH copilot_events AS (
+		  SELECT
+		    tool_call_message_ordinal,
+		    call_index,
+		    MIN(CASE WHEN status = 'started' THEN timestamp END)
+		      AS started_at,
+		    MAX(CASE WHEN status = 'completed' THEN timestamp END)
+		      AS completed_at
+		  FROM tool_result_events
+		  WHERE session_id = ?
+		    AND source = 'copilot-cli'
+		    AND status IN ('started', 'completed')
+		  GROUP BY tool_call_message_ordinal, call_index
+		)
 		SELECT tc.message_id, COALESCE(tc.tool_use_id, ''),
 			tc.tool_name, tc.category, tc.skill_name,
 			tc.subagent_session_id, COALESCE(tc.input_json, ''),
+			ce.started_at, ce.completed_at,
 			s_sub.started_at, s_sub.ended_at
 		FROM tool_calls tc
+		LEFT JOIN messages m ON m.id = tc.message_id
+		LEFT JOIN copilot_events ce
+		  ON m.ordinal = ce.tool_call_message_ordinal
+		  AND tc.call_index = ce.call_index
 		LEFT JOIN sessions s_sub ON s_sub.id = tc.subagent_session_id
 		WHERE tc.session_id = ?
 		ORDER BY tc.message_id, tc.call_index`,
-		sessionID,
+		sessionID, sessionID,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("querying duckdb timing calls: %w", err)
@@ -541,13 +560,19 @@ func (s *Store) queryCallRows(
 	now := time.Now().UTC().Format(time.RFC3339)
 	for rows.Next() {
 		var r db.CallRow
+		var toolUseID, inputJSON sql.NullString
 		var skill, sub sql.NullString
-		var startedAt, endedAt any
+		var exactStartedAt, exactEndedAt any
+		var subStartedAt, subEndedAt any
 		if err := rows.Scan(
-			&r.MessageID, &r.ToolUseID, &r.ToolName, &r.Category,
-			&skill, &sub, &r.InputJSON, &startedAt, &endedAt,
+			&r.MessageID, &toolUseID, &r.ToolName, &r.Category,
+			&skill, &sub, &inputJSON, &exactStartedAt, &exactEndedAt,
+			&subStartedAt, &subEndedAt,
 		); err != nil {
 			return nil, fmt.Errorf("scanning duckdb timing call: %w", err)
+		}
+		if toolUseID.Valid {
+			r.ToolUseID = toolUseID.String
 		}
 		if skill.Valid {
 			value := skill.String
@@ -556,7 +581,25 @@ func (s *Store) queryCallRows(
 		if sub.Valid {
 			value := sub.String
 			r.SubagentSessionID = &value
-			if dur, ok := timingMillis(formatDBTime(startedAt), firstNonEmpty(formatDBTime(endedAt), now)); ok {
+		}
+		if inputJSON.Valid {
+			r.InputJSON = inputJSON.String
+		}
+		exactStart := formatDBTime(exactStartedAt)
+		exactEnd := formatDBTime(exactEndedAt)
+		if exactStart != "" {
+			r.ExactStartedAt = &exactStart
+		}
+		if exactEnd != "" {
+			r.ExactEndedAt = &exactEnd
+		}
+		if dur, ok := timingMillis(exactStart, exactEnd); ok {
+			r.DurationMs = &dur
+		} else if sub.Valid {
+			if dur, ok := timingMillis(
+				formatDBTime(subStartedAt),
+				firstNonEmpty(formatDBTime(subEndedAt), now),
+			); ok {
 				r.DurationMs = &dur
 			}
 		}

--- a/internal/duckdb/store_test.go
+++ b/internal/duckdb/store_test.go
@@ -1608,6 +1608,18 @@ func TestGetSessionTimingUsesCopilotEventsForExactDuration(t *testing.T) {
 			},
 		},
 	}
+	failedCall := call
+	failedCall.CallIndex = 1
+	failedCall.ToolName = "shell"
+	failedCall.Category = "Bash"
+	failedCall.ToolUseID = "call_failed"
+	failedCall.ResultEvents = append(
+		[]db.ToolResultEvent(nil), call.ResultEvents...,
+	)
+	for i := range failedCall.ResultEvents {
+		failedCall.ResultEvents[i].ToolUseID = failedCall.ToolUseID
+	}
+	failedCall.ResultEvents[1].Status = "errored"
 
 	sess := syncSession(
 		sessionID, "alpha", "copilot timing", sessionStartedAt, 3,
@@ -1620,7 +1632,7 @@ func TestGetSessionTimingUsesCopilotEventsForExactDuration(t *testing.T) {
 			syncMessage(sessionID, 0, "user", "finish the task",
 				sessionStartedAt),
 			syncMessage(sessionID, 1, "assistant", "task_complete",
-				"2026-07-24T11:56:24.189Z", call),
+				"2026-07-24T11:56:24.189Z", call, failedCall),
 			syncMessage(sessionID, 2, "user", "next request",
 				nextUserAt),
 		},
@@ -1640,7 +1652,7 @@ func TestGetSessionTimingUsesCopilotEventsForExactDuration(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	require.Len(t, got.Turns, 1)
-	require.Len(t, got.Turns[0].Calls, 1)
+	require.Len(t, got.Turns[0].Calls, 2)
 	require.NotNil(t, got.Turns[0].DurationMs,
 		"turn duration must not be the idle-gap; copilot events must provide exact timing")
 	assert.Equal(t, int64(3_725), *got.Turns[0].DurationMs,
@@ -1650,6 +1662,10 @@ func TestGetSessionTimingUsesCopilotEventsForExactDuration(t *testing.T) {
 		"call duration must not be nil")
 	assert.Equal(t, int64(3_725), *got.Turns[0].Calls[0].DurationMs,
 		"call duration should be copilot event span (3725ms)")
+	require.NotNil(t, got.Turns[0].Calls[1].DurationMs,
+		"errored call duration must not be nil")
+	assert.Equal(t, int64(3_725), *got.Turns[0].Calls[1].DurationMs,
+		"errored call should use the same terminal event timing")
 }
 
 func TestGetAllMessagesDoesNotTruncateAtDefaultLimit(t *testing.T) {

--- a/internal/duckdb/store_test.go
+++ b/internal/duckdb/store_test.go
@@ -1575,6 +1575,83 @@ func TestGetSessionTimingPopulatesSharedTimingPayload(t *testing.T) {
 	assert.Equal(t, int64(120000), *timing.Turns[0].Calls[0].DurationMs)
 }
 
+func TestGetSessionTimingUsesCopilotEventsForExactDuration(t *testing.T) {
+	ctx := context.Background()
+	local := newLocalDB(t)
+
+	sessionID := "duck-copilot-timing"
+	sessionStartedAt := "2026-07-24T11:56:20.000Z"
+	startedAt := "2026-07-24T11:56:24.198Z"
+	completedAt := "2026-07-24T11:56:27.923Z"
+	nextUserAt := "2026-07-25T00:34:49.483Z"
+
+	call := db.ToolCall{
+		CallIndex: 0,
+		ToolName:  "task_complete",
+		Category:  "Other",
+		ToolUseID: "call_example",
+		InputJSON: `{"task":"finish"}`,
+		ResultEvents: []db.ToolResultEvent{
+			{
+				ToolUseID:  "call_example",
+				Source:     "copilot-cli",
+				Status:     "started",
+				Timestamp:  startedAt,
+				EventIndex: 0,
+			},
+			{
+				ToolUseID:  "call_example",
+				Source:     "copilot-cli",
+				Status:     "completed",
+				Timestamp:  completedAt,
+				EventIndex: 1,
+			},
+		},
+	}
+
+	sess := syncSession(
+		sessionID, "alpha", "copilot timing", sessionStartedAt, 3,
+	)
+	sess.Agent = "copilot"
+	sess.EndedAt = &nextUserAt
+	_, err := local.WriteSessionBatchAtomic([]db.SessionBatchWrite{{
+		Session: sess,
+		Messages: []db.Message{
+			syncMessage(sessionID, 0, "user", "finish the task",
+				sessionStartedAt),
+			syncMessage(sessionID, 1, "assistant", "task_complete",
+				"2026-07-24T11:56:24.189Z", call),
+			syncMessage(sessionID, 2, "user", "next request",
+				nextUserAt),
+		},
+		DataVersion:     1,
+		ReplaceMessages: true,
+	}})
+	require.NoError(t, err)
+
+	syncer := newInMemoryTestSync(t, local, SyncOptions{})
+	require.NoError(t, createSchema(ctx, syncer.DB()))
+	_, err = syncer.pushEverything(ctx, nil)
+	require.NoError(t, err)
+
+	store := NewStoreFromDB(syncer.DB())
+
+	got, err := store.GetSessionTiming(ctx, sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Len(t, got.Turns, 1)
+	require.Len(t, got.Turns[0].Calls, 1)
+	require.NotNil(t, got.Turns[0].DurationMs,
+		"turn duration must not be the idle-gap; copilot events must provide exact timing")
+	assert.Equal(t, int64(3_725), *got.Turns[0].DurationMs,
+		"turn duration should be copilot event span (3725ms), not idle gap")
+	assert.Equal(t, int64(3_725), got.ToolDurationMs)
+	require.NotNil(t, got.Turns[0].Calls[0].DurationMs,
+		"call duration must not be nil")
+	assert.Equal(t, int64(3_725), *got.Turns[0].Calls[0].DurationMs,
+		"call duration should be copilot event span (3725ms)")
+}
+
 func TestGetAllMessagesDoesNotTruncateAtDefaultLimit(t *testing.T) {
 	ctx := context.Background()
 	local := newLocalDB(t)

--- a/internal/parser/copilot.go
+++ b/internal/parser/copilot.go
@@ -236,7 +236,12 @@ func (b *copilotSessionBuilder) handleToolComplete(
 	if toolCallID == "" {
 		return
 	}
-	b.appendToolEvent(toolCallID, ts, "completed")
+	status := "completed"
+	success := data.Get("success")
+	if success.Exists() && success.Type == gjson.False {
+		status = "errored"
+	}
+	b.appendToolEvent(toolCallID, ts, status)
 
 	r := data.Get("result")
 	content := r.Str

--- a/internal/parser/copilot.go
+++ b/internal/parser/copilot.go
@@ -19,11 +19,13 @@ const (
 	copilotEventSessionStart    = "session.start"
 	copilotEventUserMessage     = "user.message"
 	copilotEventAssistantMsg    = "assistant.message"
+	copilotEventToolStart       = "tool.execution_start"
 	copilotEventToolComplete    = "tool.execution_complete"
 	copilotEventAssistantReason = "assistant.reasoning"
 	copilotEventModelChange     = "session.model_change"
 	copilotEventSessionShutdown = "session.shutdown"
 	copilotReportedCostSource   = "copilot-reported"
+	copilotToolEventSource      = "copilot-cli"
 )
 
 var copilotUsageBasedPricingStartedAt = time.Date(
@@ -69,6 +71,8 @@ func (b *copilotSessionBuilder) processLine(line string) {
 		b.handleUserMessage(data, ts)
 	case copilotEventAssistantMsg:
 		b.handleAssistantMessage(data, ts)
+	case copilotEventToolStart:
+		b.handleToolEvent(data, ts, "started")
 	case copilotEventToolComplete:
 		b.handleToolComplete(data, ts)
 	case copilotEventAssistantReason:
@@ -214,6 +218,7 @@ func (b *copilotSessionBuilder) handleToolComplete(
 	if toolCallID == "" {
 		return
 	}
+	b.appendToolEvent(toolCallID, ts, "completed")
 
 	r := data.Get("result")
 	content := r.Str
@@ -234,6 +239,39 @@ func (b *copilotSessionBuilder) handleToolComplete(
 		}},
 	})
 	b.ordinal++
+}
+
+func (b *copilotSessionBuilder) handleToolEvent(
+	data gjson.Result, ts time.Time, status string,
+) {
+	toolCallID := data.Get("toolCallId").Str
+	if toolCallID == "" {
+		return
+	}
+	b.appendToolEvent(toolCallID, ts, status)
+}
+
+func (b *copilotSessionBuilder) appendToolEvent(
+	toolCallID string, ts time.Time, status string,
+) {
+	for i := len(b.messages) - 1; i >= 0; i-- {
+		for j := range b.messages[i].ToolCalls {
+			call := &b.messages[i].ToolCalls[j]
+			if call.ToolUseID != toolCallID {
+				continue
+			}
+			call.ResultEvents = append(
+				call.ResultEvents,
+				ParsedToolResultEvent{
+					ToolUseID: toolCallID,
+					Source:    copilotToolEventSource,
+					Status:    status,
+					Timestamp: ts,
+				},
+			)
+			return
+		}
+	}
 }
 
 func (b *copilotSessionBuilder) handleAssistantReasoning() {

--- a/internal/parser/copilot.go
+++ b/internal/parser/copilot.go
@@ -32,11 +32,17 @@ var copilotUsageBasedPricingStartedAt = time.Date(
 	2026, time.June, 1, 0, 0, 0, 0, time.UTC,
 )
 
+type copilotToolCallRef struct {
+	messageIndex int
+	callIndex    int
+}
+
 // copilotSessionBuilder accumulates state while scanning a
 // Copilot JSONL session file line by line.
 type copilotSessionBuilder struct {
 	messages     []ParsedMessage
 	usageEvents  []ParsedUsageEvent
+	toolCallRefs map[string]copilotToolCallRef
 	firstMessage string
 	startedAt    time.Time
 	endedAt      time.Time
@@ -48,7 +54,8 @@ type copilotSessionBuilder struct {
 
 func newCopilotSessionBuilder() *copilotSessionBuilder {
 	return &copilotSessionBuilder{
-		project: "unknown",
+		project:      "unknown",
+		toolCallRefs: make(map[string]copilotToolCallRef),
 	}
 }
 
@@ -208,6 +215,17 @@ func (b *copilotSessionBuilder) handleAssistantMessage(
 		OutputTokens:    outputTokens,
 		HasOutputTokens: hasOutputTokens,
 	})
+	messageIndex := len(b.messages) - 1
+	for callIndex := range b.messages[messageIndex].ToolCalls {
+		toolCallID := b.messages[messageIndex].ToolCalls[callIndex].ToolUseID
+		if toolCallID == "" {
+			continue
+		}
+		b.toolCallRefs[toolCallID] = copilotToolCallRef{
+			messageIndex: messageIndex,
+			callIndex:    callIndex,
+		}
+	}
 	b.ordinal++
 }
 
@@ -254,24 +272,21 @@ func (b *copilotSessionBuilder) handleToolEvent(
 func (b *copilotSessionBuilder) appendToolEvent(
 	toolCallID string, ts time.Time, status string,
 ) {
-	for i := len(b.messages) - 1; i >= 0; i-- {
-		for j := range b.messages[i].ToolCalls {
-			call := &b.messages[i].ToolCalls[j]
-			if call.ToolUseID != toolCallID {
-				continue
-			}
-			call.ResultEvents = append(
-				call.ResultEvents,
-				ParsedToolResultEvent{
-					ToolUseID: toolCallID,
-					Source:    copilotToolEventSource,
-					Status:    status,
-					Timestamp: ts,
-				},
-			)
-			return
-		}
+	ref, ok := b.toolCallRefs[toolCallID]
+	if !ok || ref.messageIndex < 0 || ref.messageIndex >= len(b.messages) {
+		return
 	}
+	if ref.callIndex < 0 ||
+		ref.callIndex >= len(b.messages[ref.messageIndex].ToolCalls) {
+		return
+	}
+	call := &b.messages[ref.messageIndex].ToolCalls[ref.callIndex]
+	call.ResultEvents = append(call.ResultEvents, ParsedToolResultEvent{
+		ToolUseID: toolCallID,
+		Source:    copilotToolEventSource,
+		Status:    status,
+		Timestamp: ts,
+	})
 }
 
 func (b *copilotSessionBuilder) handleAssistantReasoning() {

--- a/internal/parser/copilot_provider.go
+++ b/internal/parser/copilot_provider.go
@@ -519,6 +519,7 @@ func copilotProviderCapabilities() Capabilities {
 			Thinking:             CapabilitySupported,
 			ToolCalls:            CapabilitySupported,
 			ToolResults:          CapabilitySupported,
+			ToolResultEvents:     CapabilitySupported,
 			PerMessageTokenUsage: CapabilitySupported,
 			AggregateUsageEvents: CapabilitySupported,
 			Model:                CapabilitySupported,

--- a/internal/parser/copilot_test.go
+++ b/internal/parser/copilot_test.go
@@ -98,6 +98,13 @@ func assertEqual[T comparable](t *testing.T, want, got T, name string) {
 	assert.Equal(t, want, got, name)
 }
 
+func TestCopilotProviderCapabilities(t *testing.T) {
+	caps := copilotProviderCapabilities()
+	assert.Equal(t, CapabilitySupported, caps.Content.ToolCalls)
+	assert.Equal(t, CapabilitySupported, caps.Content.ToolResults)
+	assert.Equal(t, CapabilitySupported, caps.Content.ToolResultEvents)
+}
+
 func TestParseCopilotSession_Basic(t *testing.T) {
 	path := writeCopilotJSONL(t,
 		`{"type":"session.start","data":{"sessionId":"abc-123","context":{"cwd":"/home/alice/code/myproject","branch":"main"}},"timestamp":"2025-01-15T10:00:00Z"}`,
@@ -192,6 +199,26 @@ func TestParseCopilotSession_ToolResultTypes(t *testing.T) {
 			assertEqual(t, tt.expectedLen, trMsg.ToolResults[0].ContentLength, "tool result ContentLength")
 		})
 	}
+}
+
+func TestParseCopilotSession_ToolEventsUseLatestMatchingCall(t *testing.T) {
+	path := writeCopilotJSONL(t,
+		`{"type":"session.start","data":{"sessionId":"reused-call-id"},"timestamp":"2026-07-28T10:00:00Z"}`,
+		`{"type":"user.message","data":{"content":"Run both checks"},"timestamp":"2026-07-28T10:00:01Z"}`,
+		`{"type":"assistant.message","data":{"toolRequests":[{"toolCallId":"shared","name":"first","arguments":"{}"}]},"timestamp":"2026-07-28T10:00:02Z"}`,
+		`{"type":"assistant.message","data":{"toolRequests":[{"toolCallId":"shared","name":"second","arguments":"{}"}]},"timestamp":"2026-07-28T10:00:03Z"}`,
+		`{"type":"tool.execution_start","data":{"toolCallId":"unknown"},"timestamp":"2026-07-28T10:00:03.500Z"}`,
+		`{"type":"tool.execution_start","data":{"toolCallId":"shared"},"timestamp":"2026-07-28T10:00:04Z"}`,
+		`{"type":"tool.execution_complete","data":{"toolCallId":"shared","result":"done"},"timestamp":"2026-07-28T10:00:05Z"}`,
+	)
+
+	_, msgs := parseAndValidateHelper(t, path, "m", 4)
+	require.Len(t, msgs[1].ToolCalls, 1)
+	assert.Empty(t, msgs[1].ToolCalls[0].ResultEvents)
+	require.Len(t, msgs[2].ToolCalls, 1)
+	require.Len(t, msgs[2].ToolCalls[0].ResultEvents, 2)
+	assert.Equal(t, "started", msgs[2].ToolCalls[0].ResultEvents[0].Status)
+	assert.Equal(t, "completed", msgs[2].ToolCalls[0].ResultEvents[1].Status)
 }
 
 func TestParseCopilotSession_Reasoning(t *testing.T) {

--- a/internal/parser/copilot_test.go
+++ b/internal/parser/copilot_test.go
@@ -171,6 +171,35 @@ func TestParseCopilotSession_ToolCalls(t *testing.T) {
 	assertEqual(t, wantTS, trMsg.Timestamp, "tool result timestamp")
 }
 
+func TestParseCopilotSession_ToolCompleteStatus(t *testing.T) {
+	tests := []struct {
+		name        string
+		successJSON string
+		wantStatus  string
+	}{
+		{name: "success", successJSON: `,"success":true`, wantStatus: "completed"},
+		{name: "failure", successJSON: `,"success":false`, wantStatus: "errored"},
+		{name: "missing success", wantStatus: "completed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeCopilotJSONL(t,
+				`{"type":"session.start","data":{"sessionId":"tool-status"},"timestamp":"2025-01-15T10:00:00Z"}`,
+				`{"type":"user.message","data":{"content":"Run the tool"},"timestamp":"2025-01-15T10:00:01Z"}`,
+				`{"type":"assistant.message","data":{"toolRequests":[{"toolCallId":"tc-1","name":"shell","arguments":"{}"}]},"timestamp":"2025-01-15T10:00:02Z"}`,
+				`{"type":"tool.execution_complete","data":{"toolCallId":"tc-1"`+tt.successJSON+`},"timestamp":"2025-01-15T10:00:03Z"}`,
+			)
+
+			_, msgs := parseAndValidateHelper(t, path, "m", 3)
+			require.Len(t, msgs[1].ToolCalls, 1)
+			require.Len(t, msgs[1].ToolCalls[0].ResultEvents, 1)
+			assert.Equal(t, tt.wantStatus,
+				msgs[1].ToolCalls[0].ResultEvents[0].Status)
+		})
+	}
+}
+
 func TestParseCopilotSession_ToolResultTypes(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/parser/copilot_test.go
+++ b/internal/parser/copilot_test.go
@@ -124,6 +124,7 @@ func TestParseCopilotSession_ToolCalls(t *testing.T) {
 		`{"type":"session.start","data":{"sessionId":"tool-test"},"timestamp":"2025-01-15T10:00:00Z"}`,
 		`{"type":"user.message","data":{"content":"Read the config file"},"timestamp":"2025-01-15T10:00:01Z"}`,
 		`{"type":"assistant.message","data":{"content":"","toolRequests":[{"toolCallId":"tc-1","name":"view","arguments":"{\"path\":\"config.json\"}"}]},"timestamp":"2025-01-15T10:00:02Z"}`,
+		`{"type":"tool.execution_start","data":{"toolCallId":"tc-1"},"timestamp":"2025-01-15T10:00:02.125Z"}`,
 		`{"type":"tool.execution_complete","data":{"toolCallId":"tc-1","success":true,"result":"{\"key\":\"value\"}"},"timestamp":"2025-01-15T10:00:03Z"}`,
 		`{"type":"assistant.message","data":{"content":"The config file contains a key-value pair."},"timestamp":"2025-01-15T10:00:04Z"}`,
 	)
@@ -139,6 +140,19 @@ func TestParseCopilotSession_ToolCalls(t *testing.T) {
 		ToolUseID: "tc-1",
 		InputJSON: `{"path":"config.json"}`,
 	}})
+	require.Len(t, tcMsg.ToolCalls[0].ResultEvents, 2)
+	assert.Equal(t, ParsedToolResultEvent{
+		ToolUseID: "tc-1",
+		Source:    "copilot-cli",
+		Status:    "started",
+		Timestamp: parseTimestamp("2025-01-15T10:00:02.125Z"),
+	}, tcMsg.ToolCalls[0].ResultEvents[0])
+	assert.Equal(t, ParsedToolResultEvent{
+		ToolUseID: "tc-1",
+		Source:    "copilot-cli",
+		Status:    "completed",
+		Timestamp: parseTimestamp("2025-01-15T10:00:03Z"),
+	}, tcMsg.ToolCalls[0].ResultEvents[1])
 
 	// Check tool result message.
 	trMsg := msgs[2]

--- a/internal/postgres/session_timing.go
+++ b/internal/postgres/session_timing.go
@@ -102,6 +102,21 @@ func (s *Store) queryCallRows(
 ) ([]db.CallRow, error) {
 	now := time.Now().UTC()
 	rows, err := s.pg.QueryContext(ctx, `
+		WITH copilot_events AS (
+		  SELECT
+		    session_id,
+		    tool_call_message_ordinal,
+		    call_index,
+		    MIN(timestamp) FILTER (
+		      WHERE source = 'copilot-cli' AND status = 'started'
+		    ) AS started_at,
+		    MAX(timestamp) FILTER (
+		      WHERE source = 'copilot-cli' AND status = 'completed'
+		    ) AS completed_at
+		  FROM tool_result_events
+		  WHERE session_id = $1
+		  GROUP BY session_id, tool_call_message_ordinal, call_index
+		)
 		SELECT
 		  tc.message_ordinal,
 		  tc.tool_use_id,
@@ -110,20 +125,32 @@ func (s *Store) queryCallRows(
 		  tc.skill_name,
 		  tc.subagent_session_id,
 		  tc.input_json,
+		  ce.started_at,
+		  ce.completed_at,
 		  CASE
+		    WHEN ce.started_at IS NOT NULL
+		         AND ce.completed_at IS NOT NULL
+		         AND ce.completed_at >= ce.started_at THEN
+		      (round(EXTRACT(EPOCH FROM (
+		        ce.completed_at - ce.started_at
+		      )) * 1000))::bigint
 		    WHEN tc.subagent_session_id IS NOT NULL
 		         AND s_sub.started_at IS NOT NULL THEN
 		      (round(EXTRACT(EPOCH FROM (
-		        COALESCE(s_sub.ended_at, $1::timestamptz) - s_sub.started_at
+		        COALESCE(s_sub.ended_at, $2::timestamptz) - s_sub.started_at
 		      )) * 1000))::bigint
 		    ELSE NULL
 		  END AS subagent_duration_ms
 		FROM tool_calls tc
+		LEFT JOIN copilot_events ce
+		  ON ce.session_id = tc.session_id
+		  AND ce.tool_call_message_ordinal = tc.message_ordinal
+		  AND ce.call_index = tc.call_index
 		LEFT JOIN sessions s_sub
 		  ON s_sub.id = tc.subagent_session_id
-		WHERE tc.session_id = $2
+		WHERE tc.session_id = $1
 		ORDER BY tc.message_ordinal, tc.id
-	`, now, sessionID)
+	`, sessionID, now)
 	if err != nil {
 		return nil, fmt.Errorf("querying timing calls: %w", err)
 	}
@@ -134,10 +161,11 @@ func (s *Store) queryCallRows(
 		var msgOrdinal int
 		var toolUseID, inputJSON, skill, sub sql.NullString
 		var toolName, category string
+		var exactStart, exactEnd *time.Time
 		var subDur sql.NullInt64
 		if err := rows.Scan(
 			&msgOrdinal, &toolUseID, &toolName, &category,
-			&skill, &sub, &inputJSON, &subDur,
+			&skill, &sub, &inputJSON, &exactStart, &exactEnd, &subDur,
 		); err != nil {
 			return nil, fmt.Errorf("scanning timing call: %w", err)
 		}
@@ -163,6 +191,14 @@ func (s *Store) queryCallRows(
 		if subDur.Valid {
 			v := subDur.Int64
 			r.DurationMs = &v
+		}
+		if exactStart != nil {
+			v := FormatISO8601(*exactStart)
+			r.ExactStartedAt = &v
+		}
+		if exactEnd != nil {
+			v := FormatISO8601(*exactEnd)
+			r.ExactEndedAt = &v
 		}
 		out = append(out, r)
 	}

--- a/internal/postgres/session_timing.go
+++ b/internal/postgres/session_timing.go
@@ -108,13 +108,15 @@ func (s *Store) queryCallRows(
 		    tool_call_message_ordinal,
 		    call_index,
 		    MIN(timestamp) FILTER (
-		      WHERE source = 'copilot-cli' AND status = 'started'
+		      WHERE status = 'started'
 		    ) AS started_at,
 		    MAX(timestamp) FILTER (
-		      WHERE source = 'copilot-cli' AND status = 'completed'
+		      WHERE status = 'completed'
 		    ) AS completed_at
 		  FROM tool_result_events
 		  WHERE session_id = $1
+		    AND source = 'copilot-cli'
+		    AND status IN ('started', 'completed')
 		  GROUP BY session_id, tool_call_message_ordinal, call_index
 		)
 		SELECT

--- a/internal/postgres/session_timing.go
+++ b/internal/postgres/session_timing.go
@@ -111,12 +111,12 @@ func (s *Store) queryCallRows(
 		      WHERE status = 'started'
 		    ) AS started_at,
 		    MAX(timestamp) FILTER (
-		      WHERE status = 'completed'
-		    ) AS completed_at
+		      WHERE status IN ('completed', 'errored')
+		    ) AS terminal_at
 		  FROM tool_result_events
 		  WHERE session_id = $1
 		    AND source = 'copilot-cli'
-		    AND status IN ('started', 'completed')
+		    AND status IN ('started', 'completed', 'errored')
 		  GROUP BY session_id, tool_call_message_ordinal, call_index
 		)
 		SELECT
@@ -128,13 +128,13 @@ func (s *Store) queryCallRows(
 		  tc.subagent_session_id,
 		  tc.input_json,
 		  ce.started_at,
-		  ce.completed_at,
+		  ce.terminal_at,
 		  CASE
 		    WHEN ce.started_at IS NOT NULL
-		         AND ce.completed_at IS NOT NULL
-		         AND ce.completed_at >= ce.started_at THEN
+		         AND ce.terminal_at IS NOT NULL
+		         AND ce.terminal_at >= ce.started_at THEN
 		      (round(EXTRACT(EPOCH FROM (
-		        ce.completed_at - ce.started_at
+		        ce.terminal_at - ce.started_at
 		      )) * 1000))::bigint
 		    WHEN tc.subagent_session_id IS NOT NULL
 		         AND s_sub.started_at IS NOT NULL THEN

--- a/internal/postgres/session_timing_pgtest_test.go
+++ b/internal/postgres/session_timing_pgtest_test.go
@@ -112,10 +112,16 @@ func TestPGGetSessionTiming_CopilotExactToolEventsExcludeIdleGap(t *testing.T) {
 		"task_complete", "2026-07-24T11:56:24.189Z", true)
 	timingInsertToolCallPG(t, pg, "timing-copilot-exact", 1, 0,
 		"call_example", "task_complete", "Other", "")
+	timingInsertToolCallPG(t, pg, "timing-copilot-exact", 1, 1,
+		"call_failed", "shell", "Bash", "")
 	timingInsertToolResultEventPG(t, pg, "timing-copilot-exact", 1, 0,
 		"call_example", "started", "2026-07-24T11:56:24.198Z")
 	timingInsertToolResultEventPG(t, pg, "timing-copilot-exact", 1, 0,
 		"call_example", "completed", "2026-07-24T11:56:27.923Z")
+	timingInsertToolResultEventPG(t, pg, "timing-copilot-exact", 1, 1,
+		"call_failed", "started", "2026-07-24T11:56:24.198Z")
+	timingInsertToolResultEventPG(t, pg, "timing-copilot-exact", 1, 1,
+		"call_failed", "errored", "2026-07-24T11:56:27.923Z")
 	timingInsertMessagePG(t, pg, "timing-copilot-exact", 2, "user",
 		"next request", "2026-07-25T00:34:49.483Z", false)
 
@@ -128,11 +134,13 @@ func TestPGGetSessionTiming_CopilotExactToolEventsExcludeIdleGap(t *testing.T) {
 	)
 	require.NoError(t, err, "GetSessionTiming")
 	require.Len(t, got.Turns, 1)
-	require.Len(t, got.Turns[0].Calls, 1)
+	require.Len(t, got.Turns[0].Calls, 2)
 	require.NotNil(t, got.Turns[0].DurationMs)
 	assert.Equal(t, int64(3_725), *got.Turns[0].DurationMs)
 	require.NotNil(t, got.Turns[0].Calls[0].DurationMs)
 	assert.Equal(t, int64(3_725), *got.Turns[0].Calls[0].DurationMs)
+	require.NotNil(t, got.Turns[0].Calls[1].DurationMs)
+	assert.Equal(t, int64(3_725), *got.Turns[0].Calls[1].DurationMs)
 }
 
 func TestPGGetSessionTiming_Solo(t *testing.T) {

--- a/internal/postgres/session_timing_pgtest_test.go
+++ b/internal/postgres/session_timing_pgtest_test.go
@@ -76,6 +76,65 @@ func timingInsertToolCallPG(
 	require.NoError(t, err, "insert tool_call %s/%d", sessionID, msgOrdinal)
 }
 
+func timingInsertToolResultEventPG(
+	t *testing.T, pg *sql.DB, sessionID string,
+	msgOrdinal, callIndex int,
+	toolUseID, status, timestamp string,
+) {
+	t.Helper()
+	_, err := pg.Exec(`
+		INSERT INTO tool_result_events
+			(session_id, tool_call_message_ordinal, call_index,
+			 tool_use_id, source, status, content, content_length,
+			 timestamp, event_index)
+		VALUES ($1, $2, $3, $4, 'copilot-cli', $5, '', 0,
+		        $6::timestamptz,
+		        CASE WHEN $5 = 'started' THEN 0 ELSE 1 END)
+	`, sessionID, msgOrdinal, callIndex, toolUseID, status, timestamp)
+	require.NoError(t, err,
+		"insert tool_result_event %s/%d", sessionID, msgOrdinal)
+}
+
+func TestPGGetSessionTiming_CopilotExactToolEventsExcludeIdleGap(t *testing.T) {
+	pgURL := testPGURL(t)
+	ensureStoreSchema(t, pgURL)
+
+	pg, err := Open(pgURL, testSchema, true)
+	require.NoError(t, err, "Open")
+	defer pg.Close()
+
+	timingResetSession(t, pg, "timing-copilot-exact")
+	timingInsertSessionPG(t, pg, "timing-copilot-exact",
+		"2026-07-24T11:56:20Z", "2026-07-25T00:34:49.483Z")
+	timingInsertMessagePG(t, pg, "timing-copilot-exact", 0, "user",
+		"finish", "2026-07-24T11:56:20Z", false)
+	timingInsertMessagePG(t, pg, "timing-copilot-exact", 1, "assistant",
+		"task_complete", "2026-07-24T11:56:24.189Z", true)
+	timingInsertToolCallPG(t, pg, "timing-copilot-exact", 1, 0,
+		"call_example", "task_complete", "Other", "")
+	timingInsertToolResultEventPG(t, pg, "timing-copilot-exact", 1, 0,
+		"call_example", "started", "2026-07-24T11:56:24.198Z")
+	timingInsertToolResultEventPG(t, pg, "timing-copilot-exact", 1, 0,
+		"call_example", "completed", "2026-07-24T11:56:27.923Z")
+	timingInsertMessagePG(t, pg, "timing-copilot-exact", 2, "user",
+		"next request", "2026-07-25T00:34:49.483Z", false)
+
+	store, err := NewStore(pgURL, testSchema, true)
+	require.NoError(t, err, "NewStore")
+	defer store.Close()
+
+	got, err := store.GetSessionTiming(
+		context.Background(), "timing-copilot-exact",
+	)
+	require.NoError(t, err, "GetSessionTiming")
+	require.Len(t, got.Turns, 1)
+	require.Len(t, got.Turns[0].Calls, 1)
+	require.NotNil(t, got.Turns[0].DurationMs)
+	assert.Equal(t, int64(3_725), *got.Turns[0].DurationMs)
+	require.NotNil(t, got.Turns[0].Calls[0].DurationMs)
+	assert.Equal(t, int64(3_725), *got.Turns[0].Calls[0].DurationMs)
+}
+
 func TestPGGetSessionTiming_Solo(t *testing.T) {
 	pgURL := testPGURL(t)
 	ensureStoreSchema(t, pgURL)

--- a/internal/sync/copilot_archive_test.go
+++ b/internal/sync/copilot_archive_test.go
@@ -1,0 +1,101 @@
+package sync_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.kenn.io/agentsview/internal/dbtest"
+	"go.kenn.io/agentsview/internal/parser"
+	"go.kenn.io/agentsview/internal/sync"
+)
+
+func writeCopilotSyncFixture(
+	t *testing.T, root, sessionID string, lines []string, mtime time.Time,
+) string {
+	t.Helper()
+
+	sessionDir := filepath.Join(root, "session-state", sessionID)
+	require.NoError(t, os.MkdirAll(sessionDir, 0o755))
+	eventsPath := filepath.Join(sessionDir, "events.jsonl")
+	require.NoError(t, os.WriteFile(
+		eventsPath,
+		[]byte(strings.Join(lines, "\n")+"\n"),
+		0o644,
+	))
+	require.NoError(t, os.Chtimes(eventsPath, mtime, mtime))
+	return eventsPath
+}
+
+// Copilot appends execution events after the assistant tool-call message.
+// A later full parse must replace the stored message so those retroactively
+// paired events update the existing tool call rather than only adding the
+// newly emitted tool-result ordinal.
+func TestSyncCopilotLateExecutionEventsUpdateStoredToolCall(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	root := t.TempDir()
+	testDB := dbtest.OpenTestDB(t)
+	engine := sync.NewEngine(testDB, sync.EngineConfig{
+		AgentDirs: map[parser.AgentType][]string{
+			parser.AgentCopilot: {root},
+		},
+		Machine: "local",
+	})
+
+	base := time.Date(2026, time.July, 24, 11, 56, 0, 0, time.UTC)
+	sessionID := "late-tool-events"
+	lines := []string{
+		`{"type":"session.start","data":{"sessionId":"late-tool-events"},"timestamp":"2026-07-24T11:56:20.000Z"}`,
+		`{"type":"user.message","data":{"content":"Finish the task"},"timestamp":"2026-07-24T11:56:21.000Z"}`,
+		`{"type":"assistant.message","data":{"toolRequests":[{"toolCallId":"call_example","name":"task_complete","arguments":"{}"}]},"timestamp":"2026-07-24T11:56:24.189Z"}`,
+	}
+	eventsPath := writeCopilotSyncFixture(
+		t, root, sessionID, lines, base,
+	)
+
+	stats := engine.SyncAll(context.Background(), nil)
+	require.Equal(t, 1, stats.Synced)
+
+	storedID := "copilot:" + sessionID
+	msgs, err := testDB.GetAllMessages(context.Background(), storedID)
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+	require.Len(t, msgs[1].ToolCalls, 1)
+	assert.Empty(t, msgs[1].ToolCalls[0].ResultEvents)
+
+	lines = append(lines,
+		`{"type":"tool.execution_start","data":{"toolCallId":"call_example"},"timestamp":"2026-07-24T11:56:24.198Z"}`,
+		`{"type":"tool.execution_complete","data":{"toolCallId":"call_example","success":true,"result":"done"},"timestamp":"2026-07-24T11:56:27.923Z"}`,
+	)
+	require.NoError(t, os.WriteFile(
+		eventsPath,
+		[]byte(strings.Join(lines, "\n")+"\n"),
+		0o644,
+	))
+	later := base.Add(time.Minute)
+	require.NoError(t, os.Chtimes(eventsPath, later, later))
+
+	stats = engine.SyncAll(context.Background(), nil)
+	require.Equal(t, 1, stats.Synced)
+
+	msgs, err = testDB.GetAllMessages(context.Background(), storedID)
+	require.NoError(t, err)
+	require.Len(t, msgs, 2,
+		"the paired result carrier must not become an extra stored message")
+	require.Len(t, msgs[1].ToolCalls, 1)
+	events := msgs[1].ToolCalls[0].ResultEvents
+	require.Len(t, events, 2)
+	assert.Equal(t, "started", events[0].Status)
+	assert.Equal(t, "2026-07-24T11:56:24.198Z", events[0].Timestamp)
+	assert.Equal(t, "completed", events[1].Status)
+	assert.Equal(t, "2026-07-24T11:56:27.923Z", events[1].Timestamp)
+}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -12770,12 +12770,18 @@ func pairToolResultEventSummaries(
 				continue
 			}
 			summary := summarizeToolResultEvents(tc.ResultEvents)
-			tc.ResultContentLength = len(summary)
 			if blocked[tc.Category] {
+				if summary != "" {
+					tc.ResultContentLength = len(summary)
+				}
 				tc.ResultContent = ""
 				tc.ResultEvents = nil
 				continue
 			}
+			if summary == "" {
+				continue
+			}
+			tc.ResultContentLength = len(summary)
 			tc.ResultContent = summary
 		}
 	}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -12773,9 +12773,9 @@ func pairToolResultEventSummaries(
 			if blocked[tc.Category] {
 				if summary != "" {
 					tc.ResultContentLength = len(summary)
+					tc.ResultEvents = nil
 				}
 				tc.ResultContent = ""
-				tc.ResultEvents = nil
 				continue
 			}
 			if summary == "" {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -10923,6 +10923,10 @@ func shouldReplaceFullParseMessages(
 		revivingSourceMissing ||
 		pw.sess.Agent == parser.AgentCowork ||
 		isOpenCodeFormatStorageAgent(pw.sess.Agent) ||
+		// Copilot pairs later execution events back to an earlier
+		// assistant tool call. Appending only new ordinals would leave
+		// the stored call without its exact timing metadata.
+		pw.sess.Agent == parser.AgentCopilot ||
 		pw.sess.Agent == parser.AgentVSCopilot ||
 		pw.sess.Agent == parser.AgentAntigravity ||
 		pw.sess.Agent == parser.AgentAntigravityCLI ||

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -3608,6 +3608,52 @@ func TestPairToolResultEventSummaries(t *testing.T) {
 			}},
 		},
 		{
+			name: "blocked category preserves timestamp-only events",
+			msgs: []db.Message{{
+				ToolCalls: []db.ToolCall{{
+					ToolUseID: "call_view",
+					ToolName:  "view",
+					Category:  "Read",
+					ResultEvents: []db.ToolResultEvent{
+						{
+							ToolUseID: "call_view",
+							Source:    "copilot-cli",
+							Status:    "started",
+							Timestamp: "2026-07-24T11:56:24.198Z",
+						},
+						{
+							ToolUseID: "call_view",
+							Source:    "copilot-cli",
+							Status:    "completed",
+							Timestamp: "2026-07-24T11:56:27.923Z",
+						},
+					},
+				}},
+			}},
+			blocked: map[string]bool{"Read": true},
+			want: []db.Message{{
+				ToolCalls: []db.ToolCall{{
+					ToolUseID: "call_view",
+					ToolName:  "view",
+					Category:  "Read",
+					ResultEvents: []db.ToolResultEvent{
+						{
+							ToolUseID: "call_view",
+							Source:    "copilot-cli",
+							Status:    "started",
+							Timestamp: "2026-07-24T11:56:24.198Z",
+						},
+						{
+							ToolUseID: "call_view",
+							Source:    "copilot-cli",
+							Status:    "completed",
+							Timestamp: "2026-07-24T11:56:27.923Z",
+						},
+					},
+				}},
+			}},
+		},
+		{
 			name: "single event becomes summary",
 			msgs: []db.Message{{
 				ToolCalls: []db.ToolCall{{

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -3561,6 +3561,53 @@ func TestPairToolResultEventSummaries(t *testing.T) {
 		want    []db.Message
 	}{
 		{
+			name: "timestamp-only events preserve paired result length",
+			msgs: []db.Message{{
+				ToolCalls: []db.ToolCall{{
+					ToolUseID:           "call_example",
+					ToolName:            "task_complete",
+					Category:            "Other",
+					ResultContentLength: 8,
+					ResultEvents: []db.ToolResultEvent{
+						{
+							ToolUseID: "call_example",
+							Source:    "copilot-cli",
+							Status:    "started",
+							Timestamp: "2026-07-24T11:56:24.198Z",
+						},
+						{
+							ToolUseID: "call_example",
+							Source:    "copilot-cli",
+							Status:    "completed",
+							Timestamp: "2026-07-24T11:56:27.923Z",
+						},
+					},
+				}},
+			}},
+			want: []db.Message{{
+				ToolCalls: []db.ToolCall{{
+					ToolUseID:           "call_example",
+					ToolName:            "task_complete",
+					Category:            "Other",
+					ResultContentLength: 8,
+					ResultEvents: []db.ToolResultEvent{
+						{
+							ToolUseID: "call_example",
+							Source:    "copilot-cli",
+							Status:    "started",
+							Timestamp: "2026-07-24T11:56:24.198Z",
+						},
+						{
+							ToolUseID: "call_example",
+							Source:    "copilot-cli",
+							Status:    "completed",
+							Timestamp: "2026-07-24T11:56:27.923Z",
+						},
+					},
+				}},
+			}},
+		},
+		{
 			name: "single event becomes summary",
 			msgs: []db.Message{{
 				ToolCalls: []db.ToolCall{{


### PR DESCRIPTION
## Summary

- parse Copilot CLI `tool.execution_start` and `tool.execution_complete` events and attach them to the matching tool call
- preserve explicit Copilot tool failures from `success: false` and treat both successful and failed terminal events as exact timing endpoints
- use those event timestamps for per-call and per-turn timing in SQLite, PostgreSQL, and DuckDB/Quack
- fall back to the existing message-gap calculation when exact events are missing, incomplete, or invalid
- replace Copilot messages on later full parses so newly appended execution events update existing tool calls
- reparse existing Copilot sessions by bumping the data version
- preserve existing tool result content when timestamp-only events are present

## Behavior

Copilot tool calls previously inherited the interval between the assistant message and the next user message. For resumed sessions, this could attribute hours of idle time to a tool that completed in seconds.

When matching execution events are available, AgentsView now uses the actual execution interval. Parallel calls use the earliest valid start and latest valid terminal event, while each call retains its individual duration. Explicit `success: false` completion events remain failures for tool health signals without losing their exact end timestamp. Later syncs also replace previously stored Copilot messages so execution events appended after the initial tool call are persisted.

## Validation

- added parser coverage for successful, failed, and legacy completion events, plus unknown and reused IDs
- added SQLite coverage for exact, incomplete, invalid, parallel, and errored terminal intervals
- added PostgreSQL and DuckDB/Quack parity coverage for successful and errored terminal events
- added a two-sync regression where execution events arrive after the tool-call message
- added regression coverage for timestamp-only result events
- manually reproduced the issue and verified that idle time is no longer attributed to the completed tool call
- ran `go test -tags fts5 ./internal/parser ./internal/db ./internal/duckdb ./internal/sync`, `go test -tags fts5 ./internal/postgres`, the focused PostgreSQL `pgtest`, `go fmt ./...`, and `go vet ./...`

Fixes #1288