### PR TITLE
[codex] Cap persisted Claude tool-result reads

### DIFF
--- a/internal/parser/claude.go
+++ b/internal/parser/claude.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -30,9 +31,10 @@ var (
 )
 
 const (
-	initialScanBufSize = 64 * 1024        // 64KB
-	maxLineSize        = 64 * 1024 * 1024 // 64MB
-	forkThreshold      = 3
+	initialScanBufSize         = 64 * 1024        // 64KB
+	maxLineSize                = 64 * 1024 * 1024 // 64MB
+	maxPersistedToolResultSize = 16 * 1024 * 1024 // 16MB
+	forkThreshold              = 3
 )
 
 // dagEntry holds metadata for a single JSONL entry participating
@@ -1944,9 +1946,18 @@ func readClaudePersistedToolResult(
 		if !pathWithinDir(cleanResult, dir) {
 			continue
 		}
-		b, err := os.ReadFile(cleanResult)
+		f, err := os.Open(cleanResult)
 		if err != nil {
 			return "", false
+		}
+		b, readErr := io.ReadAll(io.LimitReader(f, maxPersistedToolResultSize+1))
+		closeErr := f.Close()
+		if readErr != nil || closeErr != nil {
+			return "", false
+		}
+		if len(b) > maxPersistedToolResultSize {
+			b = b[:maxPersistedToolResultSize]
+			b = append(b, "\n\n[agentsview: persisted tool result truncated at 16 MiB]"...)
 		}
 		return string(b), true
 	}

--- a/internal/parser/claude_parser_test.go
+++ b/internal/parser/claude_parser_test.go
@@ -1431,6 +1431,33 @@ func TestParseClaudeSession_ResolvesPersistedToolResultOutput(
 	assert.Equal(t, fullOutput, DecodeContent(got.ContentRaw))
 }
 
+func TestReadClaudePersistedToolResultTruncatesOversizedFile(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	sessionDir := filepath.Join(dir, "project", "parent-session")
+	resultPath := filepath.Join(sessionDir, "tool-results", "oversized.txt")
+	require.NoError(t, os.MkdirAll(filepath.Dir(resultPath), 0o755))
+	require.NoError(t, os.WriteFile(resultPath, []byte("prefix"), 0o644))
+	require.NoError(t, os.Truncate(resultPath, maxPersistedToolResultSize+1))
+
+	sessionPath := filepath.Join(dir, "project", "parent-session.jsonl")
+	got, ok := readClaudePersistedToolResult(sessionPath, resultPath)
+	require.True(t, ok)
+	assert.True(t, strings.HasPrefix(got, "prefix"))
+	assert.Equal(
+		t,
+		maxPersistedToolResultSize+len("\n\n[agentsview: persisted tool result truncated at 16 MiB]"),
+		len(got),
+	)
+	assert.True(t, strings.HasSuffix(
+		got,
+		"[agentsview: persisted tool result truncated at 16 MiB]",
+	))
+}
+
 func TestParseClaudeSession_PersistedToolResultDoesNotOverwriteSiblings(
 	t *testing.T,
 ) {


### PR DESCRIPTION
Closes #1292.

Claude Code can persist oversized tool output in a sidecar under a session's `tool-results` directory. AgentsView previously loaded that sidecar with `os.ReadFile` and embedded the complete value into the reconstructed message. A multi-gigabyte sidecar therefore produced several multi-gigabyte allocations during parsing and JSON marshaling, eventually exceeded SQLite's value-size limit, left startup sync incomplete, and could trigger an operating-system SIGKILL during retry.

This change reads persisted tool-result sidecars through a 16 MiB limit. Larger results retain their bounded prefix and gain an explicit truncation marker, keeping the archive searchable and the truncation visible without allowing one sidecar to exhaust process memory.

The regression test uses a sparse oversized sidecar and verifies both the cap and marker. I also validated the change against the original failure shape: the affected session synced in under a second with roughly 202 MiB maximum RSS instead of reaching roughly 26 GiB, and a full archive resync completed successfully.

Validation: `go test ./internal/parser -count=1`.
